### PR TITLE
Research: erdos-1012-oq-03 — Cross condition helper + structured h_neighbors proof

### DIFF
--- a/proofs/Proofs/Erdos1012OQ03.lean
+++ b/proofs/Proofs/Erdos1012OQ03.lean
@@ -56,9 +56,12 @@ Survey + proof infrastructure. Rédei proved modulo 2 infrastructure lemmas.
 - [x] sc_tournament_has_cycle (cycle existence in SC tournament)
 - [x] tournament_cycle_extendable (longest-cycle extension)
 - [x] Directed threshold proof (0 sorries)
-- [ ] Ghouila-Houri proof (structured: 1 sorry in path surgery, main proved)
+- [ ] Ghouila-Houri proof (structured: 2 sorrys in no-cross sub-case, cross case proved)
   - [x] sc_degree_has_cycle (cycle existence in SC high-degree digraph)
-  - [ ] ghouila_houri_cycle_extendable (1 sorry: path surgery for k < n-1)
+  - [ ] ghouila_houri_cycle_extendable (2 sorrys: no-cross path surgery for k < n-1)
+    - [x] cross-condition case: handled via gh_cross_gives_longer_cycle
+    - [ ] no-cross case (out-neighbors): degree + SC path surgery
+    - [ ] no-cross case (in-neighbors): symmetric, same barrier
   - [x] grow_cycle_gh (well-founded recursion, proved)
   - [x] ghouila_houri (delegates to helpers, proved)
 -/
@@ -875,10 +878,50 @@ private theorem gh_cycle_extendable_small_k
       --   use SC to find a path from w into l_max and combine with the cycle to
       --   get a longer cycle, contradicting maximality. Needs vertex-disjoint path
       --   extraction (Menger's theorem / shortest SC path argument).
+      -- Helper: applying gh_cross_gives_longer_cycle gives a cycle longer than l_max,
+      -- contradicting h_max_bound.
+      have h_cross_contradiction :
+          ∀ (z₁ z₂ : V), z₁ ∉ l_max → z₂ ∉ l_max → D.arc z₁ z₂ →
+          ∀ (i : ℕ) (hi : i < k_max),
+          D.arc (l_max[i]'hi) z₁ →
+          D.arc z₂ (l_max[(i + 1) % k_max]'(Nat.mod_lt _ (by omega))) →
+          False := by
+        intro z₁ z₂ hz₁ hz₂ harc_12 i hi harc_iz₁ harc_z₂i
+        obtain ⟨l', hl', hlt'⟩ :=
+          gh_cross_gives_longer_cycle D l_max hnd_max (by omega) harcs_max
+            z₁ z₂ hz₁ hz₂ harc_12 i hi harc_iz₁ harc_z₂i
+        exact absurd (h_max_bound l' hl') (by omega)
       have h_neighbors : (∀ w : V, D.arc v w → w ∈ l_max) ∧
           (∀ w : V, D.arc w v → w ∈ l_max) := by
-        sorry -- Path surgery: cross case handled by gh_cross_gives_longer_cycle;
-              -- no-cross case needs SC path surgery (Menger's theorem or shortest-path argument)
+        constructor
+        · -- All out-neighbors of v are on l_max
+          intro w harc_vw
+          by_contra hw_off
+          -- Cross-condition: if ∃ i with arc(l_max[i], v) ∧ arc(w, l_max[(i+1)%k_max])
+          -- then gh_cross_gives_longer_cycle contradicts maximality of l_max.
+          by_cases h_cross : ∃ (i : ℕ) (hi : i < k_max),
+              D.arc (l_max[i]'hi) v ∧
+              D.arc w (l_max[(i + 1) % k_max]'(Nat.mod_lt _ (by omega)))
+          · obtain ⟨i, hi, harc_iv, harc_wl⟩ := h_cross
+            exact h_cross_contradiction v w hv hw_off harc_vw i hi harc_iv harc_wl
+          · -- No-cross case: ∀ i, arc(l_max[i], v) → ¬arc(w, l_max[(i+1)%k_max])
+            -- In this case the degree-counting argument gives contradiction for
+            -- k_max ≥ n-2 (odd n) via |A_v| + |B_w| ≤ k_max with
+            -- |A_v| ≥ (n+1)/2 - (n-k_max-1) and |B_w| ≥ (n+1)/2 - (n-k_max-1).
+            -- For k_max < n-2 or even n, SC path surgery is needed.
+            push_neg at h_cross
+            sorry -- No-cross: degree bound + SC path surgery for general case
+        · -- All in-neighbors of v are on l_max (symmetric argument)
+          intro w harc_wv
+          by_contra hw_off
+          -- Cross-condition check: z₁ = w, z₂ = v, arc(w, v)
+          by_cases h_cross : ∃ (i : ℕ) (hi : i < k_max),
+              D.arc (l_max[i]'hi) w ∧
+              D.arc v (l_max[(i + 1) % k_max]'(Nat.mod_lt _ (by omega)))
+          · obtain ⟨i, hi, harc_iw, harc_vl⟩ := h_cross
+            exact h_cross_contradiction w v hw_off hv harc_wv i hi harc_iw harc_vl
+          · push_neg at h_cross
+            sorry -- No-cross: degree bound + SC path surgery for general case
       obtain ⟨h_out_on, h_in_on⟩ := h_neighbors
       -- Step 5: Degree counting gives contradiction with non-insertability
       -- Since all neighbors of v are on l_max:
@@ -2061,7 +2104,7 @@ Decomposed via counting/probabilistic method:
 
 Remaining sorries: none (directed_hamiltonian_threshold is fully proved, 0 sorries)
 
-### Ghouila-Houri (1 sorry remains: path surgery in degree-counting argument)
+### Ghouila-Houri (2 sorrys remain: no-cross sub-case of path surgery)
 **Bug fixed**: `all_neighbors_on_longest_cycle` was a FALSE statement
 (counterexample: V={a,b,c,d,e}, arcs={a→b,b→c,c→a,a→d,d→e,e→a} is SC with longest
 cycle 3, but d has neighbor e off-cycle). The sorry was relocated into the correct
@@ -2074,30 +2117,35 @@ Proof structure (grow-cycle approach):
 2. `ghouila_houri_cycle_extendable` (PROVED modulo path surgery):
    - k = n-1: degree counting forces insertion (PROVED)
    - k < n-1, insertable: direct insertion (PROVED)
-   - k < n-1, non-insertable: longest-cycle + degree counting (1 sorry: path surgery)
+   - k < n-1, non-insertable, CROSS condition: gh_cross_gives_longer_cycle (PROVED)
+   - k < n-1, non-insertable, NO-CROSS (2 sorrys): path surgery for out/in directions
 3. `exists_longest_cycle` (PROVED): bounded induction gives max-length cycle
 4. `grow_cycle_gh` (proved): well-founded recursion using 2
 5. `ghouila_houri` (proved): delegates to 1 + 4
 
-**Remaining sorry**: "all neighbors of v on longest cycle" in GH context.
-Requires path surgery. Plan:
+**Remaining sorrys**: The no-cross case in `h_neighbors` (out-direction and in-direction).
 
-1. Cross condition (PROVED via `gh_cross_gives_longer_cycle`):
-   If ∃ i with arc(l_max[i], v) AND arc(w, l_max[(i+1)%k]), then
-   l_max.rotate(i+1) ++ [v, w] is a cycle of length k+2. Contradicts maximality.
+Structure of the no-cross sorrys:
+- Given: arc(v, w) (or arc(w, v)), v ∉ l_max, w ∉ l_max (off-cycle vertices).
+- Given: for all i with arc(l_max[i], v): ¬arc(w, l_max[(i+1)%k]) (no-cross condition).
+- Need: contradiction with maximality of l_max.
 
-2. No-cross case (OPEN, needs SC path surgery):
-   When shift(A_v) ∩ B_w = ∅ (no cross), need:
-   Use SC to find w → ... → l_max[j] and l_max[i] → ... → v → w paths.
-   Combine to build a cycle through all l_max vertices + v (+ detour through w).
-   Length > k_max → contradiction.
-   Tool: `gh_ni_all` (all off-cycle vertices non-insertable) + Menger's theorem.
+The degree bound argument (for n odd, k_max = n-2):
+  |A_v| + |B_w| ≤ k_max (from no-cross shift-disjointness).
+  |A_v| ≥ inDeg(v) - (n-k_max-1) ≥ (n+1)/2 - (n-k_max-1).
+  |B_w| ≥ outDeg(w) - (n-k_max-1) ≥ (n+1)/2 - (n-k_max-1).
+  Sum ≥ n+1 - 2(n-k_max-1) = 2k_max-n+3 > k_max when k_max ≥ n-2 and n odd.
+  → Contradiction for n odd and k_max = n-2.
+  For n even or k_max < n-2: needs deeper argument.
 
-3. Generalized non-insertability (PROVED via `gh_ni_all`):
-   Every vertex w ∉ l_max is non-insertable into l_max (same proof as h_ni for v).
+Alternative construction (promising for k_max = n-2 even n):
+  If ∃ q ∈ A_v with arc(w, l_max[(q+2)%k]):
+    Cycle v → w → l_max[(q+2)%k] → ... → l_max[q] has length k_max+1. Contradiction.
+  For k_max = n-2 even n, the equality analysis shows such q must exist.
+  For k_max < n-2: needs extension with more off-cycle vertices (iterative argument).
 
-**Note**: directed path rotation does NOT close directed paths into cycles
-(can't reverse path segments). The grow-cycle approach is correct for directed graphs.
+The general proof requires path surgery (Menger's theorem or rotation-extension).
+`h_ni_all` (all off-cycle non-insertable) is a key tool. `hsc` (SC) gives the needed paths.
 
 ### Rédei (DONE)
 Proved by induction via tournament insertion lemma.

--- a/proofs/Proofs/Erdos1012OQ03.lean
+++ b/proofs/Proofs/Erdos1012OQ03.lean
@@ -508,52 +508,104 @@ private lemma exists_longest_cycle (D : Digraph V)
         have := nodup_length_le_card l hl.1
         omega)
 
-/-! **Path surgery infrastructure**
+/-
+  Cross-condition cycle extension: if the longest cycle l_max has a "cross arc pair"
+  — a position i where arc(l_max[i], z₁) and arc(z₂, l_max[(i+1)%k]) — and there is
+  arc(z₁, z₂), then splicing in z₁, z₂ at position i gives a cycle of length k+2.
 
-The following lemma extracts a simple (Nodup) path from any walk in a digraph.
-This is the first piece of infrastructure needed for the path surgery in h_neighbors. -/
-
-/-- Any walk (possibly with repeated vertices) in a digraph contains a simple sub-walk
-    (Nodup path) between the same start and end vertices.
-
-    This is proved by well-founded induction on the walk length: if the walk has
-    a repeated vertex, we "short-circuit" by removing the loop, decreasing the length.
-
-    This is the key lemma needed for path surgery in the GH proof: SC gives us
-    *walks* between vertices; we need *simple paths*. -/
-private lemma sc_walk_to_simple_path (D : Digraph V) (walk : List V)
-    (hlen : 1 ≤ walk.length)
-    (harcs : ∀ i, (h : i + 1 < walk.length) → D.arc walk[i] walk[i+1]) :
-    ∃ path : List V, path.Nodup ∧
-      path.head? = walk.head? ∧ path.getLast? = walk.getLast? ∧
-      ∀ i, (h : i + 1 < path.length) → D.arc path[i] path[i+1] := by
-  -- Induction on walk length (well-founded: simplification strictly decreases length)
-  -- Case 1: walk.Nodup → walk itself is the simple path
-  -- Case 2: walk has repeated vertex at positions i < j → remove the loop [i+1..j-1],
-  --   get shorter walk' = walk[0..i] ++ walk[j..end], apply ih.
-  --   Arc at splice: walk[j-1] → walk[j] = walk[i], and walk[i] = walk[j] so
-  --   arc(walk'[i-1], walk'[i]) = arc(walk[j-1], walk[j]) is preserved.
-  --   walk' still has same head and last as walk, length strictly less.
-  sorry
-
-/-- In a strongly connected digraph, for any two distinct vertices u, v,
-    there exists a simple (Nodup) path from u to v.
-
-    Proof: SC gives a walk from u to v; sc_walk_to_simple_path simplifies it. -/
-private lemma sc_simple_path_exists (D : Digraph V) (hsc : D.IsStronglyConnected)
-    (u v : V) (huv : u ≠ v) :
-    ∃ path : List V, path.Nodup ∧ path.head? = some u ∧ path.getLast? = some v ∧
-      ∀ i, (h : i + 1 < path.length) → D.arc path[i] path[i+1] := by
-  obtain ⟨walk, hhead, hlast, harcs⟩ := hsc u v huv
-  -- walk.length ≥ 2 (u ≠ v means at least 2 distinct vertices)
-  have hlen : 2 ≤ walk.length := by
-    rcases walk with _ | ⟨a, _ | ⟨b, t⟩⟩
-    · simp [List.head?] at hhead
-    · simp only [List.head?, List.getLast?] at hhead hlast
-      exact absurd ((Option.some.inj hhead).symm.trans (Option.some.inj hlast)) huv
-    · simp [List.length_cons]
-  obtain ⟨path, hnd, hph, hpl, harcs_p⟩ := sc_walk_to_simple_path D walk (by omega) harcs
-  exact ⟨path, hnd, hph.trans hhead, hpl.trans hlast, harcs_p⟩
+  Construction: l_max.rotate(i+1) ++ [z₁, z₂]
+    = l_max[i+1], ..., l_max[k-1], l_max[0], ..., l_max[i], z₁, z₂
+  with wrap-around arc z₂ → l_max[(i+1)%k].
+-/
+private lemma gh_cross_gives_longer_cycle
+    (D : Digraph V)
+    (l_max : List V) (hnd : l_max.Nodup) (hlen2 : 2 ≤ l_max.length)
+    (harcs_max : ∀ (j : ℕ) (hj : j < l_max.length),
+        D.arc (l_max[j]'hj) (l_max[(j + 1) % l_max.length]'(Nat.mod_lt _ (by omega))))
+    (z₁ z₂ : V) (hz₁ : z₁ ∉ l_max) (hz₂ : z₂ ∉ l_max)
+    (harc_12 : D.arc z₁ z₂)
+    (i : ℕ) (hi : i < l_max.length)
+    (harc_iz₁ : D.arc (l_max[i]'hi) z₁)
+    (harc_z₂i : D.arc z₂ (l_max[(i + 1) % l_max.length]'(Nat.mod_lt _ (by omega)))) :
+    ∃ l' : List V, IsDirectedCycleList D l' ∧ l_max.length < l'.length := by
+  set k := l_max.length with hk_def
+  -- New cycle: rotate l_max by (i+1) positions, then append [z₁, z₂]
+  -- This gives: l_max[i+1], ..., l_max[k-1], l_max[0], ..., l_max[i], z₁, z₂
+  let r := (i + 1) % k
+  let nc := l_max.rotate (i + 1) ++ [z₁, z₂]
+  have hlen_nc : nc.length = k + 2 := by
+    simp [nc, List.length_append, List.length_rotate]
+  -- Nodup: rotation preserves nodup; z₁, z₂ not in l_max; z₁ ≠ z₂ from looplessness
+  have hz₁z₂ : z₁ ≠ z₂ := fun h => D.loopless z₁ (h ▸ harc_12)
+  have hnd_nc : nc.Nodup := by
+    apply List.Nodup.append
+    · exact List.nodup_rotate.mpr hnd
+    · simp [List.nodup_cons, hz₁z₂]
+    · intro x hx
+      rw [List.mem_rotate] at hx
+      simp only [List.mem_cons, List.mem_singleton, not_or]
+      exact ⟨fun h => hz₁ (h ▸ hx), fun h => hz₂ (h ▸ hx)⟩
+  -- Helper: getElem of nc at position j
+  have hget_lt : ∀ (j : ℕ) (hj : j < k),
+      nc[j]'(by simp [hlen_nc]; omega) = l_max[(j + i + 1) % k]'(Nat.mod_lt _ (by omega)) := by
+    intro j hj
+    simp only [nc]
+    rw [List.getElem_append_left (by simp [List.length_rotate]; omega),
+        List.getElem_rotate, show j + (i + 1) = j + i + 1 from by omega]
+  have hget_k : nc[k]'(by simp [hlen_nc]) = z₁ := by
+    simp only [nc]
+    rw [List.getElem_append_right (by simp [List.length_rotate])]
+    simp [List.length_rotate]
+  have hget_k1 : nc[k + 1]'(by simp [hlen_nc]) = z₂ := by
+    simp only [nc]
+    rw [List.getElem_append_right (by simp [List.length_rotate]; omega)]
+    simp [List.length_rotate]
+  -- Arc condition for nc
+  have harcs_nc : ∀ j (hj : j < nc.length),
+      D.arc (nc[j]'hj) (nc[(j + 1) % nc.length]'(Nat.mod_lt _ (by omega))) := by
+    intro j hj
+    rw [hlen_nc] at hj ⊢
+    have hjk2 : j < k + 2 := hj
+    -- 4 cases on j
+    rcases Nat.lt_or_ge j k with hj_lt | hj_ge
+    · -- Case j < k: arc within rotated cycle (or arc to z₁ when j = k-1)
+      rcases Nat.lt_or_ge j (k - 1) with hj_lt' | hj_ge'
+      · -- Sub-case j < k - 1: consecutive arc in rotated cycle
+        have hjnext : (j + 1) % (k + 2) = j + 1 := Nat.mod_eq_of_lt (by omega)
+        rw [hget_lt j (by omega), hjnext, hget_lt (j+1) (by omega)]
+        -- Need arc(l_max[(j+i+1)%k], l_max[(j+i+2)%k])
+        -- Use: (j+i+2)%k = ((j+i+1)%k + 1)%k via Nat.mod_add_mod
+        have h1 : (j + i + 2) % k = ((j + i + 1) % k + 1) % k := by
+          rw [show j + i + 2 = j + i + 1 + 1 from by omega, ← Nat.mod_add_mod]
+        rw [h1]
+        exact harcs_max _ _
+      · -- Sub-case j = k - 1: last rotated element → z₁
+        have hjk1 : j = k - 1 := by omega
+        have hjnext : (j + 1) % (k + 2) = k := by omega
+        -- Goal: D.arc (nc[j]) (nc[(j+1)%(k+2)])
+        have hidx : (j + i + 1) % k = i := by
+          rw [hjk1, show k - 1 + i + 1 = i + k from by omega,
+              Nat.add_mod_right, Nat.mod_eq_of_lt hi]
+        rw [hget_lt j (by omega)]
+        simp only [hjnext, hidx]
+        rw [hget_k]
+        exact harc_iz₁
+    · -- Case j ≥ k: j is k or k+1
+      rcases Nat.eq_or_gt_of_le hj_ge with rfl | hj_gt
+      · -- Case j = k: arc z₁ → z₂
+        have hjnext : (k + 1) % (k + 2) = k + 1 := Nat.mod_eq_of_lt (by omega)
+        simp only [hjnext, hget_k, hget_k1]
+        exact harc_12
+      · -- Case j = k + 1: wrap-around arc z₂ → l_max[(i+1)%k]
+        have hjk1 : j = k + 1 := by omega
+        have hjnext : (k + 1 + 1) % (k + 2) = 0 := by
+          rw [show k + 1 + 1 = k + 2 from by omega, Nat.mod_self]
+        simp only [hjk1, hjnext, hget_k1]
+        rw [hget_lt 0 (by omega)]
+        -- Need arc(z₂, l_max[(0+i+1)%k]) = arc(z₂, l_max[(i+1)%k])
+        simp only [Nat.zero_add]
+        exact harc_z₂i
+  exact ⟨nc, ⟨hnd_nc, by simp [hlen_nc]; omega, harcs_nc⟩, by simp [hlen_nc]; omega⟩
 
 /-! **Path surgery note**: The previous version had a standalone lemma
 `all_neighbors_on_longest_cycle` claiming that in ANY SC digraph, all neighbors of a
@@ -749,15 +801,84 @@ private theorem gh_cycle_extendable_small_k
                   · simp [show k_max - 1 + 1 = k_max from by omega, Nat.mod_self]
         -- This contradicts maximality of l_max
         exact absurd (h_max_bound _ h_cycle) (by simp [h_longer]; omega)
-      -- Step 4: All neighbors of v are on l_max
-      -- In the GH context (SC + degree ≥ ⌈n/2⌉), this follows from path surgery:
-      -- if w ∉ C* and arc(v,w), combine SC paths C*→v and w→C* with the cycle
-      -- segment to build a closed walk through all C* vertices + v. Extract a
-      -- simple cycle of length > k_max, contradicting maximality.
-      -- Requires careful handling of vertex-disjoint path extraction.
+      -- Step 3b: Generalized non-insertability — NO vertex off l_max is insertable.
+      -- (Same proof as h_ni above, works for any w ∉ l_max, not just v.)
+      have h_ni_all : ∀ (w : V) (hw : w ∉ l_max) (j : ℕ) (hj : j < k_max),
+          ¬(D.arc (l_max[j]'hj) w ∧
+            D.arc w (l_max[(j + 1) % k_max]'(Nat.mod_lt _ (by omega)))) := by
+        intro w hw j hj ⟨harc_jw, harc_wj⟩
+        have h_longer' : (l_max.insertIdx (j + 1) w).length = k_max + 1 :=
+          List.length_insertIdx (by omega)
+        have h_cycle' : IsDirectedCycleList D (l_max.insertIdx (j + 1) w) := by
+          refine ⟨List.Nodup.insertIdx hw hnd_max, by simp [h_longer']; omega, ?_⟩
+          intro p hp; simp only [h_longer'] at hp
+          have heli : ∀ m (hm : m < k_max + 1),
+              (l_max.insertIdx (j + 1) w)[m]'hm =
+                if m < j + 1 then l_max[m]'(by omega)
+                else if m = j + 1 then w
+                else l_max[m - 1]'(by omega) := fun m hm =>
+            insertIdx_getElem_eq l_max w (j+1) (by omega) m (by rwa [h_longer'])
+          rw [heli p hp]
+          set pnext := (p + 1) % (k_max + 1)
+          have hpnext_lt : pnext < k_max + 1 := Nat.mod_lt _ (by omega)
+          rw [heli pnext hpnext_lt]
+          by_cases hpi : p < j
+          · have hpnext : pnext = p + 1 := Nat.mod_eq_of_lt (by omega)
+            simp only [show p < j + 1 from by omega, show p + 1 < j + 1 from by omega,
+                       hpnext, ↓reduceIte]; exact harcs_max p (by omega)
+          · by_cases hpi2 : p = j
+            · subst hpi2
+              have hpnext : pnext = j + 1 := Nat.mod_eq_of_lt (by omega)
+              simp [hpnext]; exact harc_jw
+            · by_cases hpi3 : p = j + 1
+              · subst hpi3
+                have hpnext : pnext = if j + 2 < k_max + 1 then j + 2 else 0 := by
+                  simp only [pnext]; split_ifs with h
+                  · exact Nat.mod_eq_of_lt h
+                  · push_neg at h; rw [show j + 2 = k_max + 1 from by omega, Nat.mod_self]
+                simp only [show ¬(j + 1 < j + 1) from by omega,
+                           show j + 1 = j + 1 from rfl, if_false, if_true]
+                split_ifs at hpnext with h
+                · rw [hpnext]
+                  simp only [show ¬(j + 2 < j + 1) from by omega,
+                             show ¬(j + 2 = j + 1) from by omega,
+                             if_false, show j + 2 - 1 = j + 1 from by omega]
+                  convert harc_wj using 2; exact (Nat.mod_eq_of_lt (by omega)).symm
+                · have hjk : j + 1 = k_max := by omega
+                  rw [hpnext]; simp only [show (0 : ℕ) < j + 1 from by omega, ↓reduceIte]
+                  convert harc_wj using 2; simp [hjk, Nat.mod_self]
+              · have hpgt : j + 1 < p := by omega
+                by_cases hwrap : p + 1 < k_max + 1
+                · have hpnext : pnext = p + 1 := Nat.mod_eq_of_lt hwrap
+                  rw [hpnext]
+                  simp only [show ¬(p < j + 1) from by omega, show ¬(p = j + 1) from by omega,
+                             show ¬(p + 1 < j + 1) from by omega,
+                             show ¬(p + 1 = j + 1) from by omega,
+                             if_false]; exact harcs_max (p - 1) (by omega)
+                · have hpk : p = k_max := by omega
+                  have hpnext : pnext = 0 := by simp [pnext, hpk, Nat.mod_self]
+                  rw [hpnext, hpk]
+                  simp only [show ¬(k_max < j + 1) from by omega,
+                             show ¬(k_max = j + 1) from by omega,
+                             show (0 : ℕ) < j + 1 from by omega, if_false, ↓reduceIte]
+                  have : k_max - 1 < k_max := by omega
+                  convert harcs_max (k_max - 1) this using 2
+                  · simp; omega
+                  · simp [show k_max - 1 + 1 = k_max from by omega, Nat.mod_self]
+        exact absurd (h_max_bound _ h_cycle') (by simp [h_longer']; omega)
+      -- Step 4: All neighbors of v are on l_max.
+      --
+      -- The argument uses gh_cross_gives_longer_cycle for the "cross condition" case:
+      --   if w ∉ l_max, arc(v,w), and ∃ i with arc(l_max[i],v) ∧ arc(w,l_max[(i+1)%k]),
+      --   then the cycle l_max.rotate(i+1) ++ [v,w] has length k_max+2. Contradiction.
+      -- The "no-cross" case (shift(A_v) ∩ B_w = ∅) requires path surgery:
+      --   use SC to find a path from w into l_max and combine with the cycle to
+      --   get a longer cycle, contradicting maximality. Needs vertex-disjoint path
+      --   extraction (Menger's theorem / shortest SC path argument).
       have h_neighbors : (∀ w : V, D.arc v w → w ∈ l_max) ∧
           (∀ w : V, D.arc w v → w ∈ l_max) := by
-        sorry -- Path surgery: needs SC paths + degree conditions + longest cycle maximality
+        sorry -- Path surgery: cross case handled by gh_cross_gives_longer_cycle;
+              -- no-cross case needs SC path surgery (Menger's theorem or shortest-path argument)
       obtain ⟨h_out_on, h_in_on⟩ := h_neighbors
       -- Step 5: Degree counting gives contradiction with non-insertability
       -- Since all neighbors of v are on l_max:
@@ -1958,8 +2079,22 @@ Proof structure (grow-cycle approach):
 4. `grow_cycle_gh` (proved): well-founded recursion using 2
 5. `ghouila_houri` (proved): delegates to 1 + 4
 
-**Remaining sorry**: "all neighbors of v on longest cycle" in GH context. Requires:
-construct longer cycle from SC paths through off-cycle vertices + cycle segments.
+**Remaining sorry**: "all neighbors of v on longest cycle" in GH context.
+Requires path surgery. Plan:
+
+1. Cross condition (PROVED via `gh_cross_gives_longer_cycle`):
+   If ∃ i with arc(l_max[i], v) AND arc(w, l_max[(i+1)%k]), then
+   l_max.rotate(i+1) ++ [v, w] is a cycle of length k+2. Contradicts maximality.
+
+2. No-cross case (OPEN, needs SC path surgery):
+   When shift(A_v) ∩ B_w = ∅ (no cross), need:
+   Use SC to find w → ... → l_max[j] and l_max[i] → ... → v → w paths.
+   Combine to build a cycle through all l_max vertices + v (+ detour through w).
+   Length > k_max → contradiction.
+   Tool: `gh_ni_all` (all off-cycle vertices non-insertable) + Menger's theorem.
+
+3. Generalized non-insertability (PROVED via `gh_ni_all`):
+   Every vertex w ∉ l_max is non-insertable into l_max (same proof as h_ni for v).
 
 **Note**: directed path rotation does NOT close directed paths into cycles
 (can't reverse path segments). The grow-cycle approach is correct for directed graphs.

--- a/research/problems/erdos-1012-oq-03-incomplete-01/knowledge.md
+++ b/research/problems/erdos-1012-oq-03-incomplete-01/knowledge.md
@@ -5,6 +5,53 @@
 Prove `directed_hamiltonian_threshold` and `ghouila_houri` in `Proofs/Erdos1012OQ03.lean`.
 `directed_hamiltonian_threshold`: a strongly connected digraph with arcCount > (n-1)² has a Hamiltonian cycle.
 
+## Session 2026-04-13 (Session 6) — Cross-condition case formally proved in h_neighbors
+
+**Mode**: REVISIT
+**Outcome**: progress — cross-condition case now formally proved; 2 sorrys remain (symmetric no-cross sub-cases)
+
+### What I Did
+
+1. Added `h_cross_contradiction` helper lemma inside `gh_cycle_extendable_small_k` Case 2:
+   - Abstracts the pattern: z₁ ∉ l_max, z₂ ∉ l_max, arc(z₁,z₂), plus cross arcs → False
+   - Uses `gh_cross_gives_longer_cycle` + `h_max_bound` to derive contradiction
+   
+2. Replaced the single `h_neighbors` sorry with structured proof:
+   - **Cross case (out-direction)**: if ∃ i with arc(l_max[i],v) ∧ arc(w,l_max[(i+1)%k]): use h_cross_contradiction. PROVED.
+   - **No-cross (out-direction)**: sorry — degree + SC path surgery for general case
+   - **Cross case (in-direction)**: symmetric, z₁=w, z₂=v. PROVED.
+   - **No-cross (in-direction)**: sorry — symmetric to out-direction
+
+3. Updated file header checklist (1→2 sorrys, both for no-cross sub-case)
+
+4. Updated roadmap with degree bound analysis showing why no-cross is hard:
+   - Works for n odd, k_max = n-2 via direct degree counting
+   - Alternative construction: ∃ q ∈ A_v with arc(w, l_max[(q+2)%k]) → cycle of length k_max+1
+   - General case needs iterative path surgery or Menger's theorem
+
+### Key Mathematical Findings
+
+1. **The no-cross sorry is genuinely hard**: Direct degree counting |A_v| + |B_w| ≤ k_max combined with lower bounds only gives contradiction for n odd and k_max = n-2. For even n or k_max ≤ n-3, additional structure is needed.
+
+2. **Double-shift construction** (promising for k_max = n-2 even n): If ∃ q ∈ A_v with (q+2)%k ∈ B_w: build cycle v → w → l_max[(q+2)%k] → ... → l_max[q] of length k_max+1. In the equality case analysis for even n, such q always exists.
+
+3. **Sum argument barrier**: Summing non-insertability over all off-cycle vertices gives C→U + U→C ≤ k_max * |U|. With degree lower bounds this only contradicts k_max ≥ n-2 (odd n) or k_max ≥ n-1 (even n). For smaller k_max, no contradiction from this alone.
+
+4. **Key structural constraint**: shift(A_v) and B_w are disjoint subsets of Fin k_max (from no-cross). This is the "shift-disjointness" that makes the degree counting argument work when the off-cycle count is small.
+
+### Files Modified
+
+- `proofs/Proofs/Erdos1012OQ03.lean` (added h_cross_contradiction, structured h_neighbors proof ~879-921, updated header/roadmap)
+- `src/data/proofs/erdos-1012-oq-03/meta.json` (sorries 1→2, lineCount updated)
+
+### Next Steps
+
+- **Double-shift construction**: Formalize the case ∃ q ∈ A_v with arc(w, l_max[(q+2)%k]). If this holds: explicit longer cycle, contradiction. Remaining question: does this always hold?
+- **Equality case for even n, k_max = n-2**: Fully derive the structural constraints (A_v = A_w, B_v = B_w, arc(w,v)) and use double-shift construction to close the proof.
+- **General k_max**: Likely needs iterative argument: for k_max ≤ n-3, consider paths through multiple off-cycle vertices or Menger's theorem application.
+
+---
+
 ## Session 2026-04-13 (Session 5) — Cross condition helper + generalized non-insertability
 
 **Mode**: REVISIT

--- a/src/data/proofs/erdos-1012-oq-03/meta.json
+++ b/src/data/proofs/erdos-1012-oq-03/meta.json
@@ -2,9 +2,9 @@
   "id": "erdos-1012-oq-03",
   "title": "Directed Graph Hamiltonian Cycle Thresholds",
   "slug": "erdos-1012-oq-03",
-  "description": "Directed analogues of Hamiltonian cycle conditions: Ghouila-Houri, Moon-Moser, and Rédei theorems for digraphs and tournaments.",
+  "description": "Directed analogues of Hamiltonian cycle conditions: Ghouila-Houri, Moon-Moser, and R\u00e9dei theorems for digraphs and tournaments.",
   "meta": {
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1012OQ03.lean",
     "tags": [
       "graph-theory",
@@ -12,23 +12,23 @@
       "hamiltonian-cycles",
       "tournaments"
     ],
-    "badge": "axiom",
-    "sorries": 1,
-    "axiomCount": 1,
-    "lineCount": 1823,
-    "assumptions": "1 axiom: gh_longest_cycle_is_hamiltonian (path surgery step in Ghouila-Houri: given a longest directed cycle of length k < n in a strongly connected GH-degree digraph, SC routing constructs a longer cycle — standard result, technically involved). 1 sorry: sc_walk_to_simple_path (well-founded induction simplifying a walk to a simple path — infrastructure lemma for path surgery). Rédei, Moon-Moser, directed_hamiltonian_threshold fully proved.",
+    "badge": "wip",
+    "sorries": 2,
+    "axiomCount": 0,
+    "lineCount": 2159,
+    "assumptions": "2 sorrys: no-cross sub-case of path surgery in gh_cycle_extendable_small_k (cross-condition case now proved via gh_cross_gives_longer_cycle). Previous all_neighbors_on_longest_cycle was FALSE \u2014 fixed. Redei, Moon-Moser, directed_hamiltonian_threshold fully proved.",
     "dateAdded": "2026-03-30",
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Hamiltonian_path_problem#Directed_graphs",
-    "date": "Rédei 1934, Ghouila-Houri 1960, Moon-Moser 1963; formalized 2026"
+    "date": "R\u00e9dei 1934, Ghouila-Houri 1960, Moon-Moser 1963; formalized 2026"
   },
   "overview": {
-    "historicalContext": "The theory of directed Hamiltonian cycles developed in the 1930s–1970s as a directed counterpart to the celebrated undirected results of Dirac (1952) and others. Rédei (1934) proved that every tournament (complete directed graph) has a Hamiltonian path — a result with a clean inductive proof via vertex insertion. Moon and Moser (1963) strengthened this: strongly connected tournaments always have Hamiltonian cycles, not just paths. Ghouila-Houri (1960) gave the directed analogue of Dirac's theorem: a strongly connected digraph in which every vertex has both in-degree and out-degree $\\geq n/2$ has a Hamiltonian cycle. Meyniel (1973) gave a weaker sufficient condition (sum of degrees $\\geq 2n-1$ for non-adjacent pairs), matching the degree-sum form of Ore's undirected theorem. Erdős Problem 1012 (undirected) asks about long cycle thresholds; this OQ explores the directed analogues.",
-    "problemStatement": "For directed graphs: (1) What minimum degree condition on a strongly connected digraph guarantees a Hamiltonian cycle? (Ghouila-Houri, 1960: $\\delta^+(v) \\geq n/2$ and $\\delta^-(v) \\geq n/2$ for all $v$.) (2) Do all strongly connected tournaments have Hamiltonian cycles? (Moon-Moser, 1963: yes.) (3) Do all tournaments have Hamiltonian paths? (Rédei, 1934: yes.) (4) What arc-count threshold forces Hamiltonicity in a strongly connected digraph?",
-    "proofStrategy": "The file builds up from scratch: Digraph structure, degree definitions, Tournament and StronglyConnected predicates, Hamiltonian cycle/path definitions. Rédei's theorem is fully proved by induction: `tournament_path_insert` extends a Hamiltonian path by inserting a new vertex into an existing path (always possible in a tournament), and `tournament_full_path_list` builds the full path by induction; `list_path_to_hamiltonian` converts the list representation to the `Equiv`-based definition. Moon-Moser's theorem is now fully proved. Ghouila-Houri uses `gh_longest_cycle_is_hamiltonian` (axiom) for path surgery and `sc_walk_to_simple_path` (sorry: walk→simple-path helper). Arc threshold proved via probabilistic counting.",
+    "historicalContext": "The theory of directed Hamiltonian cycles developed in the 1930s\u20131970s as a directed counterpart to the celebrated undirected results of Dirac (1952) and others. R\u00e9dei (1934) proved that every tournament (complete directed graph) has a Hamiltonian path \u2014 a result with a clean inductive proof via vertex insertion. Moon and Moser (1963) strengthened this: strongly connected tournaments always have Hamiltonian cycles, not just paths. Ghouila-Houri (1960) gave the directed analogue of Dirac's theorem: a strongly connected digraph in which every vertex has both in-degree and out-degree $\\geq n/2$ has a Hamiltonian cycle. Meyniel (1973) gave a weaker sufficient condition (sum of degrees $\\geq 2n-1$ for non-adjacent pairs), matching the degree-sum form of Ore's undirected theorem. Erd\u0151s Problem 1012 (undirected) asks about long cycle thresholds; this OQ explores the directed analogues.",
+    "problemStatement": "For directed graphs: (1) What minimum degree condition on a strongly connected digraph guarantees a Hamiltonian cycle? (Ghouila-Houri, 1960: $\\delta^+(v) \\geq n/2$ and $\\delta^-(v) \\geq n/2$ for all $v$.) (2) Do all strongly connected tournaments have Hamiltonian cycles? (Moon-Moser, 1963: yes.) (3) Do all tournaments have Hamiltonian paths? (R\u00e9dei, 1934: yes.) (4) What arc-count threshold forces Hamiltonicity in a strongly connected digraph?",
+    "proofStrategy": "The file builds up from scratch: Digraph structure, degree definitions, Tournament and StronglyConnected predicates, Hamiltonian cycle/path definitions. R\u00e9dei's theorem is fully proved by induction: `tournament_path_insert` extends a Hamiltonian path by inserting a new vertex into an existing path (always possible in a tournament), and `tournament_full_path_list` builds the full path by induction; `list_path_to_hamiltonian` converts the list representation to the `Equiv`-based definition. Moon-Moser's theorem is now fully proved: `sc_tournament_has_cycle` (extract a simple cycle from a Hamiltonian path + SC walk), `tournament_cycle_non_insertable` (S\u207a/S\u207b partition argument), `tournament_cycle_extendable` (cycle extension using SC contradiction), and `grow_cycle_to_hamiltonian` (well-founded induction growing any cycle to Hamiltonian). Ghouila-Houri and the arc threshold remain as sorries.",
     "keyInsights": [
-      "Rédei's 1934 theorem (every tournament has a Hamiltonian path) has a beautiful constructive proof: start with a single vertex, and inductively insert each new vertex $v$ into the existing Hamiltonian path. Since $v$ beats some vertices and loses to others in the tournament, there always exists a position to insert $v$ maintaining the directed path property. This is formalized via `tournament_path_insert` — a pure induction argument.",
-      "The Moon-Moser theorem requires strong connectivity, unlike Rédei's path result. The proof strategy is a 'longest cycle' argument: take a longest directed cycle $C$ in the tournament; if $|C| < n$, take a vertex $v \\notin C$; partition $C$ into $S^+ = \\{\\text{successors of } v \\text{ in } C\\}$ and $S^- = \\{\\text{predecessors of } v \\text{ in } C\\}$; strong connectivity forces the cycle to be extendable, contradicting maximality.",
+      "R\u00e9dei's 1934 theorem (every tournament has a Hamiltonian path) has a beautiful constructive proof: start with a single vertex, and inductively insert each new vertex $v$ into the existing Hamiltonian path. Since $v$ beats some vertices and loses to others in the tournament, there always exists a position to insert $v$ maintaining the directed path property. This is formalized via `tournament_path_insert` \u2014 a pure induction argument.",
+      "The Moon-Moser theorem requires strong connectivity, unlike R\u00e9dei's path result. The proof strategy is a 'longest cycle' argument: take a longest directed cycle $C$ in the tournament; if $|C| < n$, take a vertex $v \\notin C$; partition $C$ into $S^+ = \\{\\text{successors of } v \\text{ in } C\\}$ and $S^- = \\{\\text{predecessors of } v \\text{ in } C\\}$; strong connectivity forces the cycle to be extendable, contradicting maximality.",
       "The key infrastructure lemma `tournament_path_insert` (lines 151-220) requires careful case analysis: given a Hamiltonian path $p_1 \\to p_2 \\to \\cdots \\to p_k$ and a new vertex $v$, either $v \\to p_1$ (insert at front), or $p_k \\to v$ (append at back), or there exists $i$ with $p_i \\to v \\to p_{i+1}$ (insert in middle). In a tournament, one of these must hold since for consecutive pairs, the direction is determined.",
       "The `HasHamiltonianCycle` definition uses `Equiv.Perm (Fin n)` to encode the cycle as a bijection on vertex indices, requiring arc $(\\sigma(i), \\sigma(i+1))$ for all $i$ (mod $n$). This is the cleanest algebraic encoding: the permutation gives the cyclic ordering, and all $n$ arcs must be present. The `HasHamiltonianPath` similarly uses a bijection on $\\{0, \\ldots, n-1\\}$.",
       "Ghouila-Houri's theorem is the directed Dirac: $\\delta^+(v), \\delta^-(v) \\geq n/2$ for all $v$ in a strongly connected $n$-vertex digraph implies Hamiltonicity. The proof follows the undirected argument but requires tracking both in- and out-degrees: take a longest directed path $P = v_0 \\to \\cdots \\to v_k$; the out-neighbors of $v_k$ and in-neighbors of $v_0$ form large sets in $P$, and by pigeonhole there exists a vertex $v_i$ where closing the path into a cycle is possible."
@@ -40,7 +40,7 @@
       "title": "Imports, Background, and Status",
       "startLine": 1,
       "endLine": 64,
-      "summary": "Imports Mathlib combinatorics and tactic modules. Module docstring covers key results (Ghouila-Houri, Moon-Moser, Rédei) and a checklist showing which components are proved vs. remaining sorries."
+      "summary": "Imports Mathlib combinatorics and tactic modules. Module docstring covers key results (Ghouila-Houri, Moon-Moser, R\u00e9dei) and a checklist showing which components are proved vs. remaining sorries."
     },
     {
       "id": "part-i-definitions",
@@ -58,7 +58,7 @@
     },
     {
       "id": "part-ii-redei-infrastructure",
-      "title": "Part II.C: List-Based Path Infrastructure (Rédei)",
+      "title": "Part II.C: List-Based Path Infrastructure (R\u00e9dei)",
       "startLine": 134,
       "endLine": 284,
       "summary": "Defines IsDirectedPathList (list-based directed path). Proves tournament_path_insert (insert new vertex into existing Hamiltonian path), tournament_full_path_list (build full Hamiltonian path by induction), and list_path_to_hamiltonian (convert list path to Equiv-based definition)."
@@ -68,29 +68,29 @@
       "title": "Part III: Ghouila-Houri Theorem",
       "startLine": 285,
       "endLine": 758,
-      "summary": "Fully proves ghouila_houri: strongly connected digraph with δ⁺(v), δ⁻(v) ≥ n/2 for all v has a Hamiltonian cycle. Includes sc_degree_has_cycle (greedy path + back-arc), ghouila_houri_cycle_extendable (cycle extension under GH conditions), and grow_cycle_gh (well-founded recursion)."
+      "summary": "Fully proves ghouila_houri: strongly connected digraph with \u03b4\u207a(v), \u03b4\u207b(v) \u2265 n/2 for all v has a Hamiltonian cycle. Includes sc_degree_has_cycle (greedy path + back-arc), ghouila_houri_cycle_extendable (cycle extension under GH conditions), and grow_cycle_gh (well-founded recursion)."
     },
     {
       "id": "part-iv-moon-moser",
       "title": "Part IV: Moon-Moser Theorem and Infrastructure",
       "startLine": 302,
       "endLine": 941,
-      "summary": "Extensive infrastructure: IsDirectedCycleList (list-based cycle definition), sc_tournament_has_cycle (fully proved: Hamiltonian path + SC walk gives initial cycle), tournament_cycle_non_insertable (S⁺/S⁻ partition dichotomy when no insertion point exists), tournament_cycle_extendable (fully proved: SC contradiction forces cycle extension), list_cycle_to_hamiltonian (cycle list → Equiv), grow_cycle_to_hamiltonian (well-founded induction growing any cycle to Hamiltonian), moon_moser theorem (FULLY PROVED: no sorries). Ends with Rédei's theorem: fully proved by induction."
+      "summary": "Extensive infrastructure: IsDirectedCycleList (list-based cycle definition), sc_tournament_has_cycle (fully proved: Hamiltonian path + SC walk gives initial cycle), tournament_cycle_non_insertable (S\u207a/S\u207b partition dichotomy when no insertion point exists), tournament_cycle_extendable (fully proved: SC contradiction forces cycle extension), list_cycle_to_hamiltonian (cycle list \u2192 Equiv), grow_cycle_to_hamiltonian (well-founded induction growing any cycle to Hamiltonian), moon_moser theorem (FULLY PROVED: no sorries). Ends with R\u00e9dei's theorem: fully proved by induction."
     },
     {
       "id": "part-v-threshold",
       "title": "Part V: Edge Threshold + Proof Roadmap",
       "startLine": 943,
       "endLine": 991,
-      "summary": "Defines arcCount. Proves directed_hamiltonian_threshold: (n-1)² < arcCount ∧ strongly connected → Hamiltonian cycle via probabilistic counting (hamiltonian_of_few_missing_arcs, perm_arc_bad_card_le). Closes with #check commands verifying all four main theorems."
+      "summary": "Defines arcCount. Proves directed_hamiltonian_threshold: (n-1)\u00b2 < arcCount \u2227 strongly connected \u2192 Hamiltonian cycle via probabilistic counting (hamiltonian_of_few_missing_arcs, perm_arc_bad_card_le). Closes with #check commands verifying all four main theorems."
     }
   ],
   "conclusion": {
-    "summary": "Rédei (Hamiltonian path in tournaments), Moon-Moser (Hamiltonian cycles in SC tournaments), and directed_hamiltonian_threshold are fully proved. Ghouila-Houri uses 1 axiom (gh_longest_cycle_is_hamiltonian: path surgery step) and 1 sorry (sc_walk_to_simple_path: walk→simple-path infrastructure). The 1823-line file is the most substantial directed Hamiltonicity formalization in this gallery.",
-    "implications": "Directed Hamiltonicity thresholds have applications beyond pure graph theory: tournament Hamiltonian paths correspond to linear extensions of partial orders, with applications to voting theory (ranking candidates) and scheduling. Rédei's theorem has a direct combinatorial interpretation: in any round-robin tournament, there exists a ranking of all players consistent with the match results (as a directed path). Moon-Moser's result shows that strongly connected tournaments (those where outcomes don't create a dominant clique) have circular Hamiltonian cycles — a stronger consistency property.",
+    "summary": "Redei (Hamiltonian path in tournaments), Moon-Moser (Hamiltonian cycles in SC tournaments), and directed_hamiltonian_threshold are fully proved. Ghouila-Houri has 2 sorrys (gh_cycle_extendable_small_k: no-cross sub-case of path surgery when k+1 < n). The cross-condition case is now proved via gh_cross_gives_longer_cycle.",
+    "implications": "Directed Hamiltonicity thresholds have applications beyond pure graph theory: tournament Hamiltonian paths correspond to linear extensions of partial orders, with applications to voting theory (ranking candidates) and scheduling. R\u00e9dei's theorem has a direct combinatorial interpretation: in any round-robin tournament, there exists a ranking of all players consistent with the match results (as a directed path). Moon-Moser's result shows that strongly connected tournaments (those where outcomes don't create a dominant clique) have circular Hamiltonian cycles \u2014 a stronger consistency property.",
     "openQuestions": [
       "Meyniel's condition (weaker than Ghouila-Houri: $\\delta^+(u) + \\delta^-(u) + \\delta^+(v) + \\delta^-(v) \\geq 2n-1$ for non-adjacent pairs) implies Hamiltonicity. Can this stronger result be formalized, or would it require substantially more tournament infrastructure?",
-      "The arc threshold $(n-1)^2$ in `directed_hamiltonian_threshold` — is this the tight bound? What is the densest non-Hamiltonian strongly connected tournament on $n$ vertices, and can a tight threshold be proved in Lean?"
+      "The arc threshold $(n-1)^2$ in `directed_hamiltonian_threshold` \u2014 is this the tight bound? What is the densest non-Hamiltonian strongly connected tournament on $n$ vertices, and can a tight threshold be proved in Lean?"
     ]
   },
   "crossReferences": [
@@ -121,12 +121,12 @@
       "Finset"
     ],
     "namespace": "Erdos1012OQ03",
-    "lineCount": 1823,
-    "axiomCount": 1,
-    "sorries": 1,
+    "lineCount": 2159,
+    "axiomCount": 0,
+    "sorries": 2,
     "path": "Proofs/Erdos1012OQ03.lean",
     "theoremCount": 9,
     "definitionCount": 9
   },
-  "sorries": 1
+  "sorries": 2
 }

--- a/src/data/research/problems/erdos-1012-oq-03-incomplete-01.json
+++ b/src/data/research/problems/erdos-1012-oq-03-incomplete-01.json
@@ -19,12 +19,9 @@
     "phase": "ACT",
     "since": "2026-03-30T16:34:54.972Z",
     "iteration": 5,
-    "focus": "2 sorries remain: sc_walk_to_simple_path (list induction, tractable for Aristotle) + h_neighbors (vertex-disjoint paths)",
-    "blockers": [
-      "sc_has_simple_path_avoiding lemma needed: Nodup SC path avoiding forbidden vertex set",
-      "off-cycle path segments c_j→v and w→c_p may share vertices without 'avoiding' infrastructure"
-    ],
-    "nextAction": "Prove sc_walk_to_simple_path via List.take/drop induction; then use in h_neighbors partial proof",
+    "focus": "1 sorry: no-cross path surgery in h_neighbors. Cross condition handled by gh_cross_gives_longer_cycle. No-cross requires SC path surgery via sc_has_simple_path_avoiding lemma (~150-200 lines).",
+    "blockers": ["sc_has_simple_path_avoiding lemma needed: Nodup SC path avoiding forbidden vertex set", "off-cycle path segments c_j→v and w→c_p may share vertices without 'avoiding' infrastructure"],
+    "nextAction": "Add sc_has_simple_path lemma (Nodup paths from SC) then sc_has_simple_path_avoiding, then build the h_neighbors proof",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -32,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Added sc_walk_to_simple_path + sc_simple_path_exists infrastructure. File now 1976 lines, 2 sorries (up from 1). sc_walk_to_simple_path sorry is easier (list induction); h_neighbors sorry still needs vertex-disjoint paths. Phase: ACT iteration 5.",
+    "progressSummary": "Added gh_cross_gives_longer_cycle (cross condition case) and h_ni_all (generalized non-insertability for all off-cycle vertices). 1 sorry remains for no-cross path surgery case.",
     "builtItems": [
       "Proved list_path_to_hamiltonian via Equiv.ofBijective in Erdos1012OQ03.lean:246-277",
       "Key insight: nodup list of full length gives bijection, arc condition transfers directly",
@@ -46,12 +43,12 @@
       "Proved hA_card counting: injection pos (indexOf) from {w | arc(w,v)} to A",
       "Proved hB_card counting: injection pos from {w | arc(v,w)} to B",
       "Infrastructure: h_l_eq (l.toFinset = univ\\{v}), hmem (w≠v → w∈l), h_indexOf_inj",
+      "gh_cross_gives_longer_cycle (~90 lines, Erdos1012OQ03.lean:520-606): cross condition cycle extension; if arc(l_max[i],z1) ∧ arc(z1,z2) ∧ arc(z2,l_max[(i+1)%k]) then l_max.rotate(i+1)++[z1,z2] is a cycle of length k+2",
+      "h_ni_all (~70 lines, Erdos1012OQ03.lean:~797-868): generalized non-insertability; ALL vertices w ∉ l_max are non-insertable (not just the specific v), proved by same insertion argument as h_ni + h_max_bound contradiction",
       "gh_cycle_extendable_small_k axiom: stated k<n-1 extension as axiom with complete proof sketch in docstring",
       "Proved insertable case of gh_cycle_extendable_small_k (~70 lines): by_cases on ∃ w ∉ l, insertable(w), full insertion proof with arc verification",
       "Deleted false all_neighbors_on_longest_cycle lemma",
-      "Inlined sorry in gh_cycle_extendable_small_k Case 2 with GH hypotheses",
-      "sc_walk_to_simple_path: extracts Nodup path from any walk (sorry for list induction impl, Erdos1012OQ03.lean:512-540)",
-      "sc_simple_path_exists: SC => simple paths exist between distinct vertices (no sorry, uses sc_walk_to_simple_path, :542-560)"
+      "Inlined sorry in gh_cycle_extendable_small_k Case 2 with GH hypotheses"
     ],
     "insights": [
       "list_path_to_hamiltonian: build equivalence from l.getElem, prove bijective via Nodup + full coverage",
@@ -73,17 +70,19 @@
       "The sorry at line 579 is Case 2 (non-insertable) of gh_cycle_extendable_small_k. Requires: (1) longest-cycle selection, (2) prove no off-cycle arcs via SC path surgery, (3) degree counting → contradiction. Estimated ~100+ lines.",
       "Infrastructure in place: Digraph, IsStronglyConnected, arc/outDegree/inDegree, IsDirectedCycleList, insertability proofs. Case 1 (insertable) is fully proved.",
       "CRITICAL: all_neighbors_on_longest_cycle is FALSE for general SC digraphs. Counterexample: V={a,b,c,d,e}, arcs={a→b,b→c,c→a,a→d,d→e,e→a}",
-      "sc_walk_to_simple_path is the key missing infrastructure: any walk in a digraph simplifies to a Nodup path with same endpoints (provable by induction on walk length + loop removal)",
-      "sc_simple_path_exists: SC digraphs have simple paths between any two distinct vertices (follows from sc_walk_to_simple_path)",
-      "h_neighbors proof structure: (1) get simple paths via sc_simple_path_exists, (2) build closed walk through entire cycle + v + w, (3) extract simple cycle of length > k_max — step 3 requires vertex-disjoint off-cycle paths",
-      "sc_walk_to_simple_path proof: if walk has repeated vertex at i<j, remove loop [i+1..j-1] via list splice; arc preserved at splice since walk[i]=walk[j]; length strictly decreases for well-founded induction"
+      "Nat.mod_add_mod is essential for variable-modulus arithmetic: (m%n+k)%n=(m+k)%n; omega handles only constant moduli and cannot prove (j+i+2)%k = ((j+i+1)%k+1)%k for variable k",
+      "List.getElem_rotate confirmed: (l.rotate n)[k] = l[(k+n)%l.length]; List.nodup_rotate.mpr hnd gives Nodup on rotated list",
+      "Cross condition handles one sub-case of h_neighbors (∃ i with arc(l[i],z1) ∧ arc(z1,z2) ∧ arc(z2,l[(i+1)%k])) but no-cross case requires genuine SC path surgery (Menger's theorem or shortest-path argument)",
+      "Digraph.loopless gives z1 ≠ z2 for free from arc(z1,z2) and ¬arc z1 z1; no extra inequality hypothesis needed in gh_cross_gives_longer_cycle"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove sc_walk_to_simple_path: well-founded induction on walk.length, loop removal via List.take++List.drop, arc preservation at splice via walk[i]=walk[j]",
-      "Once sc_walk_to_simple_path is proved, use sc_simple_path_exists in h_neighbors to get simple paths from cycle to v and from w to cycle",
-      "For h_neighbors: final obstacle is vertex-disjointness of the two off-cycle path segments (needs sc_simple_path_avoiding or Menger-type argument using GH degree condition)",
-      "sc_simple_path_avoiding (V-set-avoiding simple paths) may follow from high vertex-connectivity implied by GH degree condition (~50-80 more lines)"
+      "Path surgery requires ~150-200 lines of Lean infrastructure: sc_has_simple_path (Nodup SC paths), first/last C*-vertex extraction from a path, and nodup-concatenation of off-cycle path segments",
+      "Key obstacle: SC path from c_{k-1} to v and from w to c_0 may share off-cycle vertices, breaking the Nodup condition for the concatenated cycle",
+      "Correct construction: find LAST C*-vertex c_j on path(c_{k-1}→v) and FIRST C*-vertex c_p on path(w→c_0); use off-cycle sub-paths to build cycle c_p→(C*)→c_{j-1}→c_j→(off-cycle)→v→w→(off-cycle)→c_p",
+      "This cycle has length ≥ k_max + 2 IF off-cycle sub-paths don't share vertices (need vertex-disjoint off-cycle paths)",
+      "Global counting alternative: sum h_all_ni over all off-cycle vertices, get contradiction from GH out-degrees of on-cycle vertices. This works for n odd and k_max=2 but NOT in general.",
+      "Recommendation: add sc_has_simple_path_avoiding as a lemma (simple path avoiding a forbidden set) using well-founded induction on path simplification"
     ]
   },
   "tags": [
@@ -103,14 +102,14 @@
     "mathlib": []
   },
   "started": "2026-03-30T16:34:54.972Z",
-  "lastUpdate": "2026-03-30T16:34:54.972Z",
+  "lastUpdate": "2026-04-13T00:00:00.000Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [
     {
       "path": "Proofs/Erdos1012OQ03.lean",
       "filename": "Erdos1012OQ03.lean",
-      "lineCount": 1630,
+      "lineCount": 2104,
       "theoremCount": 20,
       "axiomCount": 1,
       "defCount": 10,

--- a/src/data/research/problems/erdos-1012-oq-03-incomplete-01.json
+++ b/src/data/research/problems/erdos-1012-oq-03-incomplete-01.json
@@ -19,9 +19,9 @@
     "phase": "ACT",
     "since": "2026-03-30T16:34:54.972Z",
     "iteration": 5,
-    "focus": "1 sorry: no-cross path surgery in h_neighbors. Cross condition handled by gh_cross_gives_longer_cycle. No-cross requires SC path surgery via sc_has_simple_path_avoiding lemma (~150-200 lines).",
-    "blockers": ["sc_has_simple_path_avoiding lemma needed: Nodup SC path avoiding forbidden vertex set", "off-cycle path segments c_j→v and w→c_p may share vertices without 'avoiding' infrastructure"],
-    "nextAction": "Add sc_has_simple_path lemma (Nodup paths from SC) then sc_has_simple_path_avoiding, then build the h_neighbors proof",
+    "focus": "2 sorrys: no-cross sub-cases of h_neighbors in gh_cycle_extendable_small_k. Cross-condition cases (both out and in directions) now formally proved. No-cross requires degree counting + double-shift construction.",
+    "blockers": ["No-cross degree counting only closes n odd k_max=n-2 case directly", "For even n k_max=n-2: double-shift construction needs q∈A_v with arc(w,l[(q+2)%k]) to always exist", "For k_max≤n-3: iterative path surgery or Menger's theorem infrastructure (~200 lines) needed"],
+    "nextAction": "Formalize double-shift construction: ∃ q∈A_v with (q+2)%k∈B_w → cycle v→w→l[(q+2)%k]→...→l[q] of length k_max+1. Then equality case analysis for even n.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Added gh_cross_gives_longer_cycle (cross condition case) and h_ni_all (generalized non-insertability for all off-cycle vertices). 1 sorry remains for no-cross path surgery case.",
+    "progressSummary": "Session 6: Cross-condition case of h_neighbors now formally proved via h_cross_contradiction helper. 2 symmetric sorrys remain for no-cross sub-cases (out and in direction). Direct degree counting only works for n odd k_max=n-2; double-shift construction promising for even n equality case.",
     "builtItems": [
       "Proved list_path_to_hamiltonian via Equiv.ofBijective in Erdos1012OQ03.lean:246-277",
       "Key insight: nodup list of full length gives bijection, arc condition transfers directly",
@@ -48,7 +48,9 @@
       "gh_cycle_extendable_small_k axiom: stated k<n-1 extension as axiom with complete proof sketch in docstring",
       "Proved insertable case of gh_cycle_extendable_small_k (~70 lines): by_cases on ∃ w ∉ l, insertable(w), full insertion proof with arc verification",
       "Deleted false all_neighbors_on_longest_cycle lemma",
-      "Inlined sorry in gh_cycle_extendable_small_k Case 2 with GH hypotheses"
+      "Inlined sorry in gh_cycle_extendable_small_k Case 2 with GH hypotheses",
+      "h_cross_contradiction helper (Session 6, ~15 lines): abstracts cross-condition pattern, eliminates code duplication between out and in directions",
+      "h_neighbors cross-condition case (Session 6): out-direction cross case and in-direction cross case now formally proved via h_cross_contradiction; only no-cross sub-cases remain as sorry"
     ],
     "insights": [
       "list_path_to_hamiltonian: build equivalence from l.getElem, prove bijective via Nodup + full coverage",
@@ -73,7 +75,12 @@
       "Nat.mod_add_mod is essential for variable-modulus arithmetic: (m%n+k)%n=(m+k)%n; omega handles only constant moduli and cannot prove (j+i+2)%k = ((j+i+1)%k+1)%k for variable k",
       "List.getElem_rotate confirmed: (l.rotate n)[k] = l[(k+n)%l.length]; List.nodup_rotate.mpr hnd gives Nodup on rotated list",
       "Cross condition handles one sub-case of h_neighbors (∃ i with arc(l[i],z1) ∧ arc(z1,z2) ∧ arc(z2,l[(i+1)%k])) but no-cross case requires genuine SC path surgery (Menger's theorem or shortest-path argument)",
-      "Digraph.loopless gives z1 ≠ z2 for free from arc(z1,z2) and ¬arc z1 z1; no extra inequality hypothesis needed in gh_cross_gives_longer_cycle"
+      "Digraph.loopless gives z1 ≠ z2 for free from arc(z1,z2) and ¬arc z1 z1; no extra inequality hypothesis needed in gh_cross_gives_longer_cycle",
+      "h_cross_contradiction pattern: ∀ z1 z2 ∉ l_max, arc(z1,z2), arc(l[i],z1), arc(z2,l[(i+1)%k]) → False; proved by gh_cross_gives_longer_cycle + h_max_bound. Reusable for both out and in direction.",
+      "No-cross degree counting barrier: |A_v| ≥ n/2 - (n-k_max-1), |B_w| ≥ n/2 - (n-k_max-1). Shift-disjointness shift(A_v)∩B_v=∅ gives |A_v|+|B_v|≤k_max, contradiction only for n odd k_max=n-2.",
+      "Double-shift construction for even n k_max=n-2: if ∃ q∈A_v with arc(w, l[(q+2)%k]) then cycle v→w→l[(q+2)%k]→...→l[q] has length k_max+1 > k_max. In equality case for even n such q always exists (A_v=A_w, B_v=B_w, arc(w,v) structural constraints).",
+      "Sum argument barrier: summing non-insertability over all off-cycle gives C→U + U→C ≤ k_max*|U|; with GH degree bounds this only contradicts k_max≥n-2 (odd n) or k_max≥n-1 (even n). For smaller k_max, no contradiction from degree counting alone.",
+      "The sorry in h_neighbors split 1→2 (out-direction no-cross + in-direction no-cross symmetric), but both sorrys are now more precisely scoped than the prior monolithic sorry"
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -82,7 +89,8 @@
       "Correct construction: find LAST C*-vertex c_j on path(c_{k-1}→v) and FIRST C*-vertex c_p on path(w→c_0); use off-cycle sub-paths to build cycle c_p→(C*)→c_{j-1}→c_j→(off-cycle)→v→w→(off-cycle)→c_p",
       "This cycle has length ≥ k_max + 2 IF off-cycle sub-paths don't share vertices (need vertex-disjoint off-cycle paths)",
       "Global counting alternative: sum h_all_ni over all off-cycle vertices, get contradiction from GH out-degrees of on-cycle vertices. This works for n odd and k_max=2 but NOT in general.",
-      "Recommendation: add sc_has_simple_path_avoiding as a lemma (simple path avoiding a forbidden set) using well-founded induction on path simplification"
+      "Recommendation: add sc_has_simple_path_avoiding as a lemma (simple path avoiding a forbidden set) using well-founded induction on path simplification",
+      "Next approach (Session 7): formalize double-shift construction for k_max=n-2 even n case; then handle k_max≤n-3 via Menger's theorem or iterative SC path surgery"
     ]
   },
   "tags": [
@@ -102,7 +110,7 @@
     "mathlib": []
   },
   "started": "2026-03-30T16:34:54.972Z",
-  "lastUpdate": "2026-04-13T00:00:00.000Z",
+  "lastUpdate": "2026-04-13T12:00:00.000Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [


### PR DESCRIPTION
## Summary

- Adds `h_cross_contradiction` helper in `gh_cycle_extendable_small_k` Case 2 that abstracts the cross-arc contradiction pattern (two off-cycle vertices with arc between them and cross arcs to/from `l_max`) into a reusable `False`-derivation
- Replaces monolithic `h_neighbors` sorry with a structured proof that formally handles the cross-condition sub-cases for both out-direction and in-direction; 2 symmetric no-cross sorrys remain
- Documents the mathematical barrier for the no-cross case: direct degree counting only closes n odd / k_max = n-2; double-shift construction is the next promising approach for the even-n equality case

## Mathematical Content

The `h_neighbors` proof now has this structure:
1. **Cross case (out-direction)**: if ∃ i with `arc(l_max[i],v) ∧ arc(w,l_max[(i+1)%k])` → use `h_cross_contradiction` → **PROVED**
2. **No-cross (out-direction)**: sorry — needs degree counting + double-shift construction  
3. **Cross case (in-direction)**: symmetric to (1) → **PROVED**
4. **No-cross (in-direction)**: sorry — symmetric to (2)

## Files Modified

- `proofs/Proofs/Erdos1012OQ03.lean` — added `h_cross_contradiction`, structured `h_neighbors` proof, updated header/roadmap
- `src/data/proofs/erdos-1012-oq-03/meta.json` — sorries: 1→2 (more precisely scoped), lineCount updated
- `research/problems/erdos-1012-oq-03-incomplete-01/knowledge.md` — Session 6 notes
- `src/data/research/problems/erdos-1012-oq-03-incomplete-01.json` — updated knowledge fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)