### PR TITLE
Fix: poincare-conjecture meta sync — axiomCount 33→32, sorryCount 1→0

### DIFF
--- a/research/problems/poincare-conjecture-incomplete-01/knowledge.md
+++ b/research/problems/poincare-conjecture-incomplete-01/knowledge.md
@@ -2,9 +2,7 @@
 
 ## Problem Summary
 
-The Poincaré Conjecture proof file (`PoincareConjecture.lean`, ~17,600 lines) had 1 sorry at
-line 2965 in `rp3_locallyEuclidean`. This theorem proves RP³ is locally Euclidean via gnomonic
-projection. A complete proof existed in commented-out code (lines 2966-3073).
+**COMPLETED.** The Poincaré Conjecture proof file (`PoincareConjecture.lean`, 17,675 lines) originally had 1 sorry at line 2965 in `rp3_locallyEuclidean`. That sorry was axiomatized in Session 1, then researcher-3 (2026-04-13) proved it as a theorem by fixing the Mathlib 4.26.0 API calls. The file now has 0 sorries, 32 axioms (down from 33).
 
 ## Session 2026-04-13 (Session 1) — Axiomatize rp3_locallyEuclidean
 
@@ -26,6 +24,22 @@ projection. A complete proof existed in commented-out code (lines 2966-3073).
 - All 33 axioms are mathematically justified: 32 deep 3-manifold topology results + 1 RP³ lemma
 
 ### Next Steps
-- Try uncommenting the proof with fix: `Subtype.ext heq` instead of `Subtype.ext (Subtype.ext ...)`
-- Check if `Equiv.ofBijective_apply_symm_apply` is directly available in current Mathlib4
-- If fixed, axiom count goes back to 32 and `rp3_locallyEuclidean` becomes a theorem again
+- [DONE] Fixed: axiomCount 33→32, sorryCount 1→0, lineCount 17668→17675 in meta.json
+
+## Session 2026-04-13 (Session 2) — Metadata sync (researcher-8)
+
+**Mode**: REVISIT
+**Outcome**: metadata fix — axiomCount 33→32, sorryCount 1→0, lineCount synced
+
+### What I Did
+- Verified current main branch: `rp3_locallyEuclidean` is a proved theorem (0 sorries), not an axiom
+- Researcher-3 had already fixed the API issues on 2026-04-13 (Quotient.exact, Equiv.ofBijective)
+- Fixed stale `meta.json` fields: axiomCount 33→32, sorryCount 1→0, lineCount 17668→17675
+
+### Key Findings
+- File has 32 `axiom` declarations (not 33); rp3_locallyEuclidean is a theorem
+- The `meta.axiomCount: 33` was stale from Session 1's axiomatization approach
+- Researcher-3's proof used: `Subtype.coe_inj.mp` for g_inj, corrected argument order for antipodal disjointness, and `e.apply_symm_apply` for continuous_toFun
+
+### Files Modified
+- `src/data/proofs/poincare-conjecture/meta.json`: axiomCount 33→32, sorryCount 1→0, lineCount 17668→17675

--- a/src/data/proofs/poincare-conjecture/meta.json
+++ b/src/data/proofs/poincare-conjecture/meta.json
@@ -16,8 +16,8 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 33,
-    "assumptions": "33 axioms. All are deep results in 3-manifold topology (Ricci flow, geometrization, surgery theory) and RP³ topology (rp3_locallyEuclidean: gnomonic projection homeomorphism, commented-out proof needs Lean 4.26.0 API fixes for Quotient.exact and Equiv.ofBijective). Standard Lean axioms: Classical, propext, funext.",
+    "axiomCount": 32,
+    "assumptions": "32 axioms. All are deep results in 3-manifold topology (Ricci flow, geometrization, surgery theory). `rp3_locallyEuclidean` (RP³ is locally Euclidean via gnomonic projection on hemispheres) is now a proved theorem, not an axiom. Standard Lean axioms: Classical, propext, funext.",
     "mathlibDependencies": [
       {
         "theorem": "SimplyConnectedSpace",
@@ -75,12 +75,12 @@
       "590 theorems proved, 137 structures defined, 218 definitions, 82 parts across 11574 lines"
     ],
     "leanFile": {
-      "lineCount": 17668,
+      "lineCount": 17675,
       "theoremCount": 897,
       "lemmaCount": 0,
       "defCount": 365,
       "axiomCount": 32,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "structureCount": 183,
       "instanceCount": 21,
       "parts": 100,
@@ -88,7 +88,7 @@
     },
     "dateAdded": "2025-12-29",
     "millenniumProblem": "poincare",
-    "lineCount": 17668,
+    "lineCount": 17675,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -336,7 +336,7 @@
       "ThurstonGeometry"
     ],
     "namespace": "PoincareConjecture",
-    "lineCount": 17668,
+    "lineCount": 17675,
     "axiomCount": 32,
     "theoremCount": 941,
     "definitionCount": 369,

--- a/src/data/research/problems/poincare-conjecture-incomplete-01.json
+++ b/src/data/research/problems/poincare-conjecture-incomplete-01.json
@@ -20,7 +20,10 @@
     "since": "2026-04-13T00:00:00.000Z",
     "iteration": 1,
     "focus": "Survey complete: 32 deep axioms (all legitimate), 1 technical sorry",
-    "blockers": ["Docker unavailable for build verification", "Quotient.exact API change in Mathlib 4.26.0"],
+    "blockers": [
+      "Docker unavailable for build verification",
+      "Quotient.exact API change in Mathlib 4.26.0"
+    ],
     "nextAction": "Fix rp3_locallyEuclidean sorry by adapting Quotient.exact and Equiv.ofBijective usage",
     "attemptCounts": {
       "total": 1,
@@ -29,8 +32,10 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SURVEY: All 32 axioms are deep results in 3-manifold topology (unprovable from Mathlib). The 1 sorry at line 2965 has a complete proof commented out (lines 2966-3072) needing Quotient.exact and Equiv.ofBijective API updates.",
-    "builtItems": [],
+    "progressSummary": "COMPLETE: rp3_locallyEuclidean proved by researcher-3 (2026-04-13). 0 sorries, 32 axioms. Metadata synced.",
+    "builtItems": [
+      "Fixed meta.json: axiomCount 33→32, sorryCount 1→0, lineCount 17668→17675"
+    ],
     "insights": [
       "All 32 axioms: Perelman finite extinction, Smale high-dim Poincare (n>=5), Freedman dim-4, sphere simply connected, ConnectedSum (def axiom), Poincare homology sphere, Whitehead manifold, Waldhausen genus-0, Dehn surgery, Property P, JSJ decomposition, etc.",
       "The sorry in rp3_locallyEuclidean builds ℝ³ ≃ₜ q(H_p) via gnomonic projection on hemispheres",
@@ -43,10 +48,7 @@
       "No ConnectedSum definition for topological spaces",
       "No JSJ decomposition infrastructure"
     ],
-    "nextSteps": [
-      "Fix rp3_locallyEuclidean by adapting Quotient.exact in g_inj and g_surj",
-      "Check Equiv.ofBijective_apply_symm_apply in current Mathlib"
-    ]
+    "nextSteps": []
   },
   "tags": [
     "topology",


### PR DESCRIPTION
## Summary

- `meta.axiomCount`: 33 → 32 (rp3_locallyEuclidean is a proved theorem, not an axiom)
- `meta.leanFile.sorryCount`: 1 → 0 (Lean file has 0 sorries)
- `lineCount`: 17668 → 17675 (synced with actual file)
- `assumptions` field: removed stale mention of rp3_locallyEuclidean as an axiom

## Background

In Session 1 (2026-04-13), the sorry in `rp3_locallyEuclidean` was axiomatized (axiomCount 32→33).
Researcher-3 subsequently proved it as a theorem by fixing Mathlib 4.26.0 API calls
(`Subtype.coe_inj.mp`, corrected antipodal disjointness argument, `e.apply_symm_apply`),
but the meta.json axiomCount was left at 33 instead of reverting to 32.

Marks research problem `poincare-conjecture-incomplete-01` as completed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)