### PR TITLE
Fix: hilbert-15 true-stub correction + audit tracker batch (2026-04-13)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9367,10 +9367,10 @@
       "result": "clean"
     },
     "fourier-series-oq-02": {
-      "auditCount": 4,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-13T21:36:34Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-03T22:13:08Z",
+      "result": "clean"
     },
     "fourier-series-oq-02-oq-03": {
       "auditCount": 4,
@@ -12384,9 +12384,9 @@
       "issues": []
     },
     "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-13T21:08:13Z",
-      "result": "issues-fixed",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T16:10:16Z",
+      "result": "clean",
       "issues": []
     },
     "chinese-remainder-non-coprime-oq-03-oq-02": {
@@ -12512,30 +12512,6 @@
     "erdos-1027-oq-03": {
       "auditCount": 2,
       "lastAudited": "2026-04-13T20:42:50Z",
-      "result": "clean",
-      "issues": []
-    },
-    "chebyshev-pnt-bridge-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T20:54:05Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-105-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T20:54:05Z",
-      "result": "clean",
-      "issues": []
-    },
-    "ptolemys-theorem-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T21:05:49Z",
-      "result": "issues-fixed",
-      "issues": []
-    },
-    "amgm-inequality-oq-03-oq-03-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T21:34:28Z",
       "result": "clean",
       "issues": []
     }

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -333,9 +333,9 @@
       "result": "clean"
     },
     "ballot-problem-oq-03-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-13T23:05:00Z",
       "result": "clean"
     },
     "ballot-problem-oq-03-oq-02": {
@@ -554,10 +554,10 @@
       "result": "issues-fixed"
     },
     "birch-swinnerton-dyer": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-04-05T16:13:12Z",
-      "result": "issues-found"
+      "lastAudited": "2026-04-13T23:07:49Z",
+      "result": "clean"
     },
     "birthday-problem": {
       "auditCount": 2,
@@ -769,9 +769,9 @@
       "result": "clean"
     },
     "burnside-counting": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-13T23:04:08Z",
       "result": "clean"
     },
     "cantor-diagonalization": {
@@ -958,9 +958,9 @@
       "result": "clean"
     },
     "cauchy-schwarz-oq-01-oq-04": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-13T23:03:48Z",
       "result": "clean"
     },
     "cauchy-schwarz-oq-03": {
@@ -1474,10 +1474,10 @@
       "result": "clean"
     },
     "descartes-rule-of-signs-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
-      "result": "clean"
+      "lastAudited": "2026-04-13T23:03:06Z",
+      "result": "issues-fixed"
     },
     "descartes-rule-of-signs-oq-04": {
       "auditCount": 2,
@@ -1859,10 +1859,10 @@
       "issues": []
     },
     "erdos-1012-oq-03": {
-      "auditCount": 13,
+      "auditCount": 14,
       "issues": [],
-      "lastAudited": "2026-04-13T03:03:24Z",
-      "result": "clean"
+      "lastAudited": "2026-04-13T22:03:07Z",
+      "result": "issues-fixed"
     },
     "erdos-1013": {
       "agentId": "auditor-cycle-20-batch",
@@ -6514,9 +6514,9 @@
       "result": "clean"
     },
     "erdos-606-oq-03": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-05T17:40:29Z",
+      "lastAudited": "2026-04-13T23:08:12Z",
       "result": "issues-found"
     },
     "erdos-607": {
@@ -9367,10 +9367,10 @@
       "result": "clean"
     },
     "fourier-series-oq-02": {
-      "auditCount": 3,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-03T22:13:08Z",
-      "result": "clean"
+      "lastAudited": "2026-04-13T22:00:17Z",
+      "result": "issues-fixed"
     },
     "fourier-series-oq-02-oq-03": {
       "auditCount": 4,
@@ -10620,10 +10620,10 @@
       "result": "clean"
     },
     "shapley-folkman": {
-      "auditCount": 3,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-05T16:08:43Z",
-      "result": "clean"
+      "lastAudited": "2026-04-13T22:58:15Z",
+      "result": "issues-fixed"
     },
     "solution-of-cubic": {
       "auditCount": 3,
@@ -10931,9 +10931,9 @@
       "result": "clean"
     },
     "weak-goldbach": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-05T16:13:12Z",
-      "result": "issues-found"
+      "auditCount": 3,
+      "lastAudited": "2026-04-13T23:07:50Z",
+      "result": "clean"
     },
     "wilsons-theorem": {
       "auditCount": 2,
@@ -12096,9 +12096,9 @@
       "issues": []
     },
     "erdos-606-oq-03-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-12T22:39:44Z",
-      "result": "clean",
+      "auditCount": 2,
+      "lastAudited": "2026-04-13T22:33:29Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "factor-remainder-nullstellensatz-oq-02": {
@@ -12304,8 +12304,8 @@
       "issues": []
     },
     "basel-problem-oq-01-oq-01-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T03:29:17Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-13T22:38:12Z",
       "result": "issues-fixed",
       "issues": [
         "sorry 4\u21923"
@@ -12384,9 +12384,9 @@
       "issues": []
     },
     "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T16:10:16Z",
-      "result": "clean",
+      "auditCount": 2,
+      "lastAudited": "2026-04-13T21:08:13Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "chinese-remainder-non-coprime-oq-03-oq-02": {
@@ -12408,9 +12408,9 @@
       "issues": []
     },
     "erdos-109-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T16:10:17Z",
-      "result": "clean",
+      "auditCount": 4,
+      "lastAudited": "2026-04-13T22:38:12Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "erdos-1129-oq-02": {
@@ -12512,6 +12512,60 @@
     "erdos-1027-oq-03": {
       "auditCount": 2,
       "lastAudited": "2026-04-13T20:42:50Z",
+      "result": "clean",
+      "issues": []
+    },
+    "chebyshev-pnt-bridge-oq-02": {
+      "auditCount": 2,
+      "lastAudited": "2026-04-13T22:05:22Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-105-oq-02": {
+      "auditCount": 2,
+      "lastAudited": "2026-04-13T22:05:53Z",
+      "result": "clean",
+      "issues": []
+    },
+    "ptolemys-theorem-oq-01": {
+      "auditCount": 2,
+      "lastAudited": "2026-04-13T22:05:53Z",
+      "result": "clean",
+      "issues": []
+    },
+    "amgm-inequality-oq-03-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T21:34:28Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1027-oq-01": {
+      "auditCount": 2,
+      "lastAudited": "2026-04-13T22:34:36Z",
+      "result": "clean",
+      "issues": []
+    },
+    "angle-trisection-cos-20-gal-oq-03": {
+      "auditCount": 2,
+      "lastAudited": "2026-04-13T22:34:36Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lovasz-local-lemma-oq-02": {
+      "auditCount": 2,
+      "lastAudited": "2026-04-13T22:34:36Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cube-root-3-irrational-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T22:34:36Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-130-wip-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T22:34:36Z",
       "result": "clean",
       "issues": []
     }


### PR DESCRIPTION
## Summary

- Corrects overclaimed status in hilbert-15-oq-02 (True-stub theorems claimed as verified)
- Audit tracker updates from 2026-04-13 gallery integrity run

## Audit Results (2026-04-13)

| Proof | Result | Action |
|-------|--------|--------|
| shapley-folkman | issues-fixed | Sorry count 1→3, lineCount 490→629 (PR #10634) |
| descartes-rule-of-signs-oq-03 | issues-fixed | Badge original→mathlib (PR #10638) |
| cauchy-schwarz-oq-01-oq-04 | clean | — |
| burnside-counting | clean | — |
| ballot-problem-oq-03-oq-01 | clean | — |
| birch-swinnerton-dyer | clean | Sorry was in comment, not tactic |
| weak-goldbach | clean | — |
| erdos-606-oq-03 | issues-found | Issue #10644 filed (badge mismatch + trivial theorem type) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)