### PR TITLE
Enrich Power Mean Limits: add annotations.json and deepen keyInsights

### DIFF
--- a/src/data/proofs/erdos-105-oq-02/annotations.json
+++ b/src/data/proofs/erdos-105-oq-02/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-erdos105oq02-header",
+    "proofId": "erdos-105-oq-02",
+    "range": { "startLine": 1, "endLine": 38 },
+    "type": "context",
+    "title": "Problem Setup: The Threshold Function for Rich Lines",
+    "content": "Erdős Problem #105 concerns lines through point sets in the plane that avoid specified obstacle points. Given n non-collinear points A, the threshold function f(n) is the maximum obstacle count that still guarantees a rich unblocked line. This file answers OQ-02 (Is f(n) = Θ(n)?) affirmatively by combining Beck/Szemerédi-Trotter 1983 (lower bound) and Xichuan 2024 (upper bound). The import of Erdos105Problem.lean brings in the definitions of thresholdFunction and openProblem_exact_threshold, so this file focuses entirely on the asymptotic analysis.",
+    "mathContext": "A line $\\ell$ is *rich* if $|\\ell \\cap A| \\geq 2$. $f(n) = \\max\\{k : \\forall A, B$ with $|A| = n$ non-collinear, $|B| \\leq k \\Rightarrow \\exists$ rich $\\ell$ avoiding $B\\}$. **OQ-02**: $f(n) = \\Theta(n)$?",
+    "significance": "key",
+    "relatedConcepts": ["threshold function", "rich lines", "obstacle set", "Erdős-Purdy conjecture", "incidence geometry"],
+    "prerequisites": ["Erdos105Problem.lean", "point-line incidence geometry", "combinatorial geometry"]
+  },
+  {
     "id": "ann-asymptotic-defs",
     "proofId": "erdos-105-oq-02",
     "range": { "startLine": 40, "endLine": 58 },

--- a/src/data/proofs/erdos-105-oq-02/meta.json
+++ b/src/data/proofs/erdos-105-oq-02/meta.json
@@ -44,7 +44,8 @@
       "The Θ(n) question resolves to showing both bounds hold simultaneously: Beck-SzTr gives the lower bound cn ≤ f(n), and Xichuan's n-3 blocking construction gives the upper bound f(n) ≤ n-4 ≤ n for n ≥ 4.",
       "The optimal constant c* = sup{c > 0 : cn ≤ f(n) for all n} is well-defined because the set of valid c is nonempty (from Beck-SzTr) and bounded above by 1 (from the upper bound with n=2: c·2 ≤ f(2) ≤ 2 forces c ≤ 1).",
       "The asymptotic definitions for ℕ → ℕ functions require working with ℝ-valued bounds (not ℕ-valued) since the constant c in 'cn ≤ f(n)' may be irrational.",
-      "The gap theorem f(n) ≤ n-4 for n ≥ 4 shows the interval [f(n), n] always has length at least 4 — a structural consequence of Xichuan's explicit counterexample."
+      "The gap theorem f(n) ≤ n-4 for n ≥ 4 shows the interval [f(n), n] always has length at least 4 — a structural consequence of Xichuan's explicit counterexample.",
+      "The custom BigO/BigOmega/BigTheta definitions (rather than Mathlib's filter-based Asymptotics) are deliberate: the discrete ℕ → ℕ setting needs explicit constant witnesses that are easier to extract from the elementary existential form than from the filter-theoretic formulation."
     ],
     "prerequisites": [
       "Erdős Problem #105 formalization (Erdos105Problem.lean)",


### PR DESCRIPTION
Enrichment pass for two gallery entries.

## Entry 1: amgm-inequality-oq-03-oq-03-oq-01 (Power Mean Limits)

- **Created `annotations.json`** with 11 annotations covering all major proof sections (0 → 11)
- Each annotation has mathContext, significance, relatedConcepts, prerequisites
- Added 5th keyInsight about filter composition via `tendsto_neg_atBot_atTop`

## Entry 2: erdos-105-oq-02 (Threshold Function f(n) = Θ(n))

- **Added header annotation** (lines 1–38): problem setup and file structure
- **Added 5th keyInsight**: explains why custom BigO/BigTheta is used over Mathlib Asymptotics
- Annotations: 7 → 8, KeyInsights: 4 → 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)