### PR TITLE
Research: Ptolemy converse — equality implies CCW or CW order

### DIFF
--- a/proofs/Proofs/Erdos817Problem.lean
+++ b/proofs/Proofs/Erdos817Problem.lean
@@ -163,8 +163,18 @@ This is a partial result toward the main conjecture. -/
 
 /-- The trivial lower bound: g_k(n) ≥ n since we need n distinct elements. -/
 theorem g_ge_n (k n : ℕ) (hk : k ≥ 3) (hn : n ≥ 1) : g k n ≥ n := by
-  -- Any A ⊆ {1,...,N} with |A| = n requires N ≥ n
-  sorry
+  unfold g
+  apply Nat.le_sInf
+  · -- ValidNs k n is nonempty: need to exhibit an N and AP-free set A ⊆ Icc 1 N with |A| = n.
+    -- The set A = {k^0, k^1, ..., k^{n-1}} works (its subset sums are base-k {0,1}-digit
+    -- numbers, which avoid k-APs), but formalizing the AP-freeness requires a carry argument.
+    sorry
+  · -- Every N ∈ ValidNs k n satisfies N ≥ n
+    intro N ⟨A, hA_sub, hA_card, _⟩
+    have hcard : A.card ≤ N := by
+      calc A.card ≤ (Finset.Icc 1 N).card := Finset.card_le_card hA_sub
+        _ = N := by simp [Nat.card_Icc]
+    omega
 
 /-- An upper bound: g_3(n) ≤ 3^n (trivially, using {1, 3, 9, ..., 3^(n-1)}). -/
 theorem g3_le_exp (n : ℕ) (hn : n ≥ 1) : g 3 n ≤ 3^n := by
@@ -179,16 +189,111 @@ theorem g3_le_exp (n : ℕ) (hn : n ≥ 1) : g 3 n ≤ 3^n := by
 
 /-- For n = 1: g_3(1) = 1 since A = {1} has subset sums {0, 1}, which is 3-AP-free. -/
 theorem g3_one : g 3 1 = 1 := by
-  -- The set {1} has subset sums {0, 1}
-  -- No 3-term AP can fit in {0, 1}
-  sorry
+  -- Step 1: subsetSums {1} = {0, 1} as Finsets (decidable computation)
+  have hss_finset : subsetSums ({1} : Finset ℕ) = {0, 1} := by decide
+  -- Step 2: hence (subsetSums {1} : Set ℕ) = {0, 1}
+  have hss : (subsetSums ({1} : Finset ℕ) : Set ℕ) = {0, 1} := by
+    rw [hss_finset]; simp [Finset.coe_insert, Finset.coe_singleton]
+  -- Step 3: {0, 1} ⊆ ℕ is 3-AP-free (at most 2 elements, no 3-AP fits)
+  have hfree : IsAPFreeOfLength 3 ({0, 1} : Set ℕ) := by
+    intro a d hd
+    by_cases ha2 : 2 ≤ a
+    · exact ⟨0, by omega, by simp only [zero_mul, add_zero, Set.mem_insert_iff,
+                                         Set.mem_singleton_iff]; omega⟩
+    · push_neg at ha2
+      interval_cases a
+      · exact ⟨2, by omega, by simp only [Set.mem_insert_iff, Set.mem_singleton_iff]; omega⟩
+      · exact ⟨1, by omega, by simp only [Set.mem_insert_iff, Set.mem_singleton_iff]; omega⟩
+  -- Step 4: 1 ∈ ValidNs 3 1 (A = {1} ⊆ Icc 1 1, |A| = 1, AP-free sums)
+  have h1valid : (1 : ℕ) ∈ ValidNs 3 1 := by
+    refine ⟨{1}, ?_, by simp, ?_⟩
+    · simp [Finset.mem_Icc]
+    · rwa [hss]
+  -- Step 5: g 3 1 = 1
+  apply Nat.le_antisymm
+  · exact Nat.sInf_le h1valid
+  · apply Nat.le_sInf ⟨1, h1valid⟩
+    intro N ⟨A, hA_sub, hA_card, _⟩
+    have : A.card ≤ N := by
+      calc A.card ≤ (Finset.Icc 1 N).card := Finset.card_le_card hA_sub
+        _ = N := by simp [Nat.card_Icc]
+    omega
 
-/-- For n = 2: g_3(2) = 2 since A = {1, 2} has subset sums {0, 1, 2, 3}, which
-    contains the 3-AP (0, 1, 2) if d = 1. But A = {1, 3} has sums {0, 1, 3, 4},
-    which is 3-AP-free. -/
-theorem g3_two : g 3 2 = 2 := by
-  -- Need to show 2 is the minimum N
-  sorry
+/-- For n = 2: g_3(2) = 3.
+    Note: the previous claim g_3(2) = 2 was incorrect. The only 2-element subset of {1,2}
+    is {1,2} itself, whose sums {0,1,2,3} contain the 3-AP (0,1,2). So N=2 fails.
+    For N=3: A = {1,3} has sums {0,1,3,4}, which is 3-AP-free (verified below). -/
+theorem g3_two : g 3 2 = 3 := by
+  -- Step 1: subsetSums {1,3} = {0,1,3,4} (decidable computation)
+  have hss13 : subsetSums ({1, 3} : Finset ℕ) = {0, 1, 3, 4} := by decide
+  -- Step 2: (subsetSums {1,3} : Set ℕ) = {0,1,3,4}
+  have hss13_set : (subsetSums ({1, 3} : Finset ℕ) : Set ℕ) = {0, 1, 3, 4} := by
+    rw [hss13]; simp [Finset.coe_insert, Finset.coe_singleton]
+  -- Step 3: {0,1,3,4} is 3-AP-free
+  have hfree13 : IsAPFreeOfLength 3 ({0, 1, 3, 4} : Set ℕ) := by
+    intro a d hd
+    -- If a ≥ 5, then a ∉ {0,1,3,4} (use i=0)
+    rcases le_or_lt 5 a with ha5 | ha5
+    · exact ⟨0, by omega, by simp only [zero_mul, add_zero, Set.mem_insert_iff,
+                                          Set.mem_singleton_iff]; omega⟩
+    -- If d ≥ 5, then a+d ≥ 5 ∉ {0,1,3,4} (use i=1)
+    rcases le_or_lt 5 d with hd5 | hd5
+    · exact ⟨1, by omega, by simp only [one_mul, Set.mem_insert_iff,
+                                          Set.mem_singleton_iff]; omega⟩
+    -- Otherwise a ∈ {0,1,2,3,4}, d ∈ {1,2,3,4}: 20 concrete cases
+    · interval_cases a <;> interval_cases d <;>
+        first
+        | exact ⟨0, by omega, by simp only [zero_mul, add_zero, Set.mem_insert_iff,
+                                              Set.mem_singleton_iff]; omega⟩
+        | exact ⟨1, by omega, by simp only [one_mul, Set.mem_insert_iff,
+                                              Set.mem_singleton_iff]; omega⟩
+        | exact ⟨2, by omega, by simp only [Set.mem_insert_iff,
+                                              Set.mem_singleton_iff]; omega⟩
+  -- Step 4: {1,3} ⊆ Icc 1 3, |{1,3}| = 2, AP-free — so 3 ∈ ValidNs 3 2
+  have h3valid : (3 : ℕ) ∈ ValidNs 3 2 := by
+    refine ⟨{1, 3}, ?_, by decide, ?_⟩
+    · intro x hx; simp only [Finset.mem_insert, Finset.mem_singleton] at hx
+      simp only [Finset.mem_Icc]; rcases hx with rfl | rfl <;> omega
+    · rwa [hss13_set]
+  -- Step 5: N=2 fails — the only 2-element subset of Icc 1 2 is {1,2}, sums contain a 3-AP
+  have hfail2 : (2 : ℕ) ∉ ValidNs 3 2 := by
+    intro ⟨A, hA_sub, hA_card, hA_free⟩
+    -- Icc 1 2 = {1, 2} and |A| = 2, so A = {1, 2}
+    have hIcc : Finset.Icc 1 2 = {1, 2} := by decide
+    rw [hIcc] at hA_sub
+    have hA_eq : A = {1, 2} := by
+      apply Finset.eq_of_subset_of_card_le hA_sub
+      simp [hA_card]
+    subst hA_eq
+    -- subsetSums {1,2} contains 3-AP: 0, 1, 2 with d=1
+    have hss12 : subsetSums ({1, 2} : Finset ℕ) = {0, 1, 2, 3} := by decide
+    have hss12_set : (subsetSums ({1, 2} : Finset ℕ) : Set ℕ) = {0, 1, 2, 3} := by
+      rw [hss12]; simp [Finset.coe_insert, Finset.coe_singleton]
+    rw [hss12_set] at hA_free
+    obtain ⟨i, hi, hi_mem⟩ := hA_free 0 1 (by omega)
+    simp only [zero_add, one_mul, Set.mem_insert_iff, Set.mem_singleton_iff] at hi_mem
+    interval_cases i <;> simp_all <;> omega
+  -- Step 6: g 3 2 = 3
+  apply Nat.le_antisymm
+  · -- g 3 2 ≤ 3
+    exact Nat.sInf_le h3valid
+  · -- g 3 2 ≥ 3: all N ∈ ValidNs 3 2 satisfy N ≥ 3
+    apply Nat.le_sInf ⟨3, h3valid⟩
+    intro N hN
+    -- If N ≤ 2, then N ∉ ValidNs 3 2
+    by_contra hlt
+    push_neg at hlt
+    interval_cases N
+    · -- N = 0: Icc 1 0 = ∅, no 2-element subset
+      obtain ⟨A, hA_sub, hA_card, _⟩ := hN
+      have : A.card ≤ (Finset.Icc 1 0).card := Finset.card_le_card hA_sub
+      simp at this; omega
+    · -- N = 1: Icc 1 1 = {1}, only 1-element subsets
+      obtain ⟨A, hA_sub, hA_card, _⟩ := hN
+      have : A.card ≤ (Finset.Icc 1 1).card := Finset.card_le_card hA_sub
+      simp at this; omega
+    · -- N = 2: only valid set is {1,2}, which fails
+      exact hfail2 hN
 
 /-
 ## Heuristic Analysis

--- a/proofs/Proofs/PtolemysTheoremOQ01Incomplete01.lean
+++ b/proofs/Proofs/PtolemysTheoremOQ01Incomplete01.lean
@@ -1,0 +1,465 @@
+/-!
+# Completing the Ptolemy Concyclicity Characterization (OQ-01 Incomplete-01)
+
+## What This File Proves
+
+This file completes the concyclicity characterization of Ptolemy's theorem by providing
+the **converse direction**: for four distinct unit-circle points, if Ptolemy's equality
+holds, then the points must be in CCW or CW order.
+
+Combined with `ptolemy_equality_for_unit_circle_ccw` (from PtolemysTheoremOQ01.lean),
+this gives the **full biconditional** for unit-circle points:
+
+  **Ptolemy equality** ↔ **CCW order** (or its reverse, CW order)
+
+## Historical Context: Completing the Sorry
+
+PtolemysTheoremOQ01.lean was initially marked "sorry" for `ptolemy_ratio_pos_of_ccw`:
+
+  > "R > 0 [requires ptolemy_ratio_pos_of_ccw, currently sorry]"
+
+The sorry was resolved without the inscribed angle theorem, using the **exponential
+difference factorization**:
+
+  exp(iα) - exp(iβ) = 2I·sin((α-β)/2)·exp(i(α+β)/2)
+
+For CCW order θ₁<θ₂<θ₃<θ₄<θ₁+2π, all four half-angle sines are negative,
+giving R = (−)(−)/((−)(−)) > 0.
+
+## The Converse Direction (New)
+
+The completed OQ01 file proves (4) → (3) → (2) → (1):
+  4. CCW order → 3. Ratio R > 0 → 2. SameRay → 1. Ptolemy equality
+
+This file proves (1) → (4): Ptolemy equality → CCW or CW order.
+This closes the equivalence chain:
+  Ptolemy equality ↔ SameRay ↔ Ratio R > 0 ↔ CCW or CW order
+
+## Proof Strategy for the Converse
+
+Given Ptolemy equality for distinct unit-circle points:
+1. Apply `ptolemy_equality_implies_proportional`: ∃ t > 0, (z₂-z₃)(z₁-z₄) = t·(z₁-z₂)(z₃-z₄)
+2. Write zₖ = exp(i·arg(zₖ)), substitute the exp_diff_factor formula
+3. Derive: t = sin((θ₂-θ₃)/2)·sin((θ₁-θ₄)/2) / (sin((θ₁-θ₂)/2)·sin((θ₃-θ₄)/2))
+4. Since t > 0, both products have the same sign
+5. Sign analysis: the only sign patterns consistent with unit-circle distinctness
+   are all-negative (→ CCW: θ₁<θ₂<θ₃<θ₄) or all-positive (→ CW: θ₁>θ₂>θ₃>θ₄)
+   or two specific mixed patterns (which reduce to cyclic rotations of CCW/CW)
+
+## Status
+
+- Main theorem `ptolemy_equality_implies_ccw_or_cw`: stated, key steps sorry'd
+- Sorries: (1) t = sine ratio algebraic derivation (HARD, for Aristotle)
+           (2) sign case analysis for mixed-sign cases (HARD, for Aristotle)
+-/
+
+import Proofs.PtolemysTheoremOQ01
+import Proofs.PtolemysComplexProofOQ01
+import Proofs.PtolemysComplexProof
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
+import Mathlib.Tactic
+
+open Complex Real
+
+namespace PtolemysTheoremOQ01Incomplete01
+
+/-! ## Section I: Angle Extraction for Unit-Circle Points -/
+
+/-- Every unit-circle point equals exp(i·arg(z)). -/
+private lemma unit_circle_eq_exp_arg (z : ℂ) (hz : ‖z‖ = 1) :
+    z = Complex.exp (↑(Complex.arg z) * Complex.I) := by
+  have habs : Complex.abs z = 1 := by rwa [Complex.norm_eq_abs] at hz
+  conv_lhs => rw [← Complex.abs_mul_exp_arg_mul_I z, habs]
+  simp
+
+/-- For distinct unit-circle points, their args are distinct. -/
+private lemma arg_ne_of_ne {z w : ℂ} (hz : ‖z‖ = 1) (hw : ‖w‖ = 1) (hne : z ≠ w) :
+    Complex.arg z ≠ Complex.arg w := by
+  intro h
+  apply hne
+  rw [unit_circle_eq_exp_arg z hz, unit_circle_eq_exp_arg w hw, h]
+
+/-! ## Section II: Half-Angle Sine Sign Lemmas -/
+
+/-- For args in (-π, π] with distinct values, sin((θ-φ)/2) is nonzero. -/
+private lemma sin_half_ne_zero_of_ne {θ φ : ℝ}
+    (hθ : Complex.arg (Complex.exp (↑θ * Complex.I)) = θ ∨ True)
+    (hne : θ ≠ φ)
+    (hbnd : (θ - φ) ∈ Set.Ioo (-(2 * Real.pi)) (2 * Real.pi)) :
+    Real.sin ((θ - φ) / 2) ≠ 0 := by
+  rw [Real.sin_ne_zero_iff]
+  intro ⟨n, hn⟩
+  have hpi : 0 < Real.pi := Real.pi_pos
+  have : (θ - φ) / 2 ∈ Set.Ioo (-Real.pi) Real.pi := by
+    constructor <;> [linarith [hbnd.1]; linarith [hbnd.2]]
+  have hn0 : n = 0 := by
+    have hlo : -Real.pi < ↑n * Real.pi := by rw [hn]; linarith [this.1]
+    have hhi : ↑n * Real.pi < Real.pi := by rw [hn]; linarith [this.2]
+    have : (-1 : ℤ) < n := by
+      apply Int.cast_lt (R := ℝ) |>.mp; push_cast; linarith
+    have : n < (1 : ℤ) := by
+      apply Int.cast_lt (R := ℝ) |>.mp; push_cast; linarith
+    omega
+  simp [hn0] at hn; linarith
+
+/-- For args θ, φ ∈ (-π, π] with θ ≠ φ:
+    sin((θ-φ)/2) > 0 iff θ > φ,  sin((θ-φ)/2) < 0 iff θ < φ. -/
+private lemma sin_half_sign_iff {θ φ : ℝ}
+    (hbnd : (θ - φ) ∈ Set.Ioo (-(2 * Real.pi)) (2 * Real.pi)) (hne : θ ≠ φ) :
+    (0 < Real.sin ((θ - φ) / 2) ↔ φ < θ) ∧
+    (Real.sin ((θ - φ) / 2) < 0 ↔ θ < φ) := by
+  have hpi : 0 < Real.pi := Real.pi_pos
+  have hrange : (θ - φ) / 2 ∈ Set.Ioo (-Real.pi) Real.pi := by
+    constructor <;> [linarith [hbnd.1]; linarith [hbnd.2]]
+  have hne2 : θ - φ ≠ 0 := sub_ne_zero.mpr hne
+  constructor
+  · constructor
+    · intro h
+      by_contra h'
+      push_neg at h'
+      have : Real.sin ((θ - φ) / 2) ≤ 0 := by
+        apply Real.sin_nonpos_of_nonneg_of_nonpos
+        · linarith [hrange.1]
+        · linarith
+      linarith
+    · intro h
+      apply Real.sin_pos_of_pos_of_lt_pi
+      · linarith
+      · linarith [hrange.2]
+  · constructor
+    · intro h
+      by_contra h'
+      push_neg at h'
+      have : Real.sin ((θ - φ) / 2) ≥ 0 := by
+        rcases lt_or_eq_of_le h' with hlt | heq
+        · apply Real.sin_nonneg_of_nonneg_of_le_pi
+          · linarith
+          · linarith [hrange.2]
+        · rw [← heq]; simp
+      linarith
+    · intro h
+      have : Real.sin ((θ - φ) / 2) < 0 := by
+        apply Real.sin_neg_of_neg_of_neg_pi_lt
+        · linarith
+        · linarith [hrange.1]
+      exact this
+
+/-! ## Section III: The Sine Ratio Identity -/
+
+/-- The key algebraic identity: the ratio t from Ptolemy equality equals the sine ratio.
+For unit-circle points zₖ = exp(iθₖ), if (z₂-z₃)(z₁-z₄) = t·(z₁-z₂)(z₃-z₄) then:
+  t = sin((θ₂-θ₃)/2)·sin((θ₁-θ₄)/2) / (sin((θ₁-θ₂)/2)·sin((θ₃-θ₄)/2)) -/
+private lemma t_eq_sine_ratio {θ₁ θ₂ θ₃ θ₄ : ℝ} {t : ℝ}
+    (ht_pos : 0 < t)
+    (ht_eq : (Complex.exp (↑θ₂ * Complex.I) - Complex.exp (↑θ₃ * Complex.I)) *
+             (Complex.exp (↑θ₁ * Complex.I) - Complex.exp (↑θ₄ * Complex.I)) =
+             (t : ℂ) *
+             ((Complex.exp (↑θ₁ * Complex.I) - Complex.exp (↑θ₂ * Complex.I)) *
+              (Complex.exp (↑θ₃ * Complex.I) - Complex.exp (↑θ₄ * Complex.I))))
+    (hs₁₂_ne : Real.sin ((θ₁ - θ₂) / 2) ≠ 0)
+    (hs₃₄_ne : Real.sin ((θ₃ - θ₄) / 2) ≠ 0) :
+    t = Real.sin ((θ₂ - θ₃) / 2) * Real.sin ((θ₁ - θ₄) / 2) /
+        (Real.sin ((θ₁ - θ₂) / 2) * Real.sin ((θ₃ - θ₄) / 2)) := by
+  -- Half-angle factorization: exp(ia)-exp(ib) = 2I·sin((a-b)/2)·exp(i(a+b)/2)
+  have hha : ∀ a b : ℝ, Complex.exp (↑a * Complex.I) - Complex.exp (↑b * Complex.I) =
+      2 * Complex.I * ↑(Real.sin ((a - b) / 2)) *
+      Complex.exp (↑((a + b) / 2) * Complex.I) := by
+    intro a b
+    have h1 : Complex.exp (↑a * Complex.I) =
+        Complex.exp (↑((a + b) / 2) * Complex.I) * Complex.exp (↑((a - b) / 2) * Complex.I) := by
+      rw [← Complex.exp_add]; congr 1; push_cast; ring
+    have h2 : Complex.exp (↑b * Complex.I) =
+        Complex.exp (↑((a + b) / 2) * Complex.I) * Complex.exp (-(↑((a - b) / 2) * Complex.I)) := by
+      rw [← Complex.exp_add]; congr 1; push_cast; ring
+    rw [h1, h2, ← mul_sub]
+    have h2isin : Complex.exp (↑((a - b) / 2) * Complex.I) -
+                  Complex.exp (-(↑((a - b) / 2) * Complex.I)) =
+                  2 * Complex.I * ↑(Real.sin ((a - b) / 2)) := by
+      rw [show -(↑((a - b) / 2) : ℂ) * Complex.I = ↑(-((a - b) / 2)) * Complex.I from by push_cast; ring]
+      simp only [Complex.exp_mul_I, Real.cos_neg, Real.sin_neg]
+      push_cast; ring
+    rw [h2isin]; ring
+  -- Phase cancellation: E₂₃·E₁₄ = E₁₂·E₃₄
+  have hE : Complex.exp (↑((θ₂ + θ₃) / 2) * Complex.I) *
+            Complex.exp (↑((θ₁ + θ₄) / 2) * Complex.I) =
+            Complex.exp (↑((θ₁ + θ₂) / 2) * Complex.I) *
+            Complex.exp (↑((θ₃ + θ₄) / 2) * Complex.I) := by
+    rw [← Complex.exp_add, ← Complex.exp_add]; congr 1; push_cast; ring
+  -- Rewrite ht_eq using hha
+  rw [hha θ₂ θ₃, hha θ₁ θ₄, hha θ₁ θ₂, hha θ₃ θ₄] at ht_eq
+  -- Both sides: (2I)²·s·E where s and E are the sine product and phase
+  -- LHS = -4·s₂₃·s₁₄·E₂₃E₁₄, RHS = t·(-4)·s₁₂·s₃₄·E₁₂E₃₄
+  -- After canceling -4 and E: s₂₃·s₁₄ = t·s₁₂·s₃₄
+  have hE_ne : Complex.exp (↑((θ₁ + θ₂) / 2) * Complex.I) *
+               Complex.exp (↑((θ₃ + θ₄) / 2) * Complex.I) ≠ 0 :=
+    mul_ne_zero (Complex.exp_ne_zero _) (Complex.exp_ne_zero _)
+  have hs₁₂_ne' : (↑(Real.sin ((θ₁ - θ₂) / 2)) : ℂ) ≠ 0 := by exact_mod_cast hs₁₂_ne
+  have hs₃₄_ne' : (↑(Real.sin ((θ₃ - θ₄) / 2)) : ℂ) ≠ 0 := by exact_mod_cast hs₃₄_ne
+  -- After factoring out -4 and E, the complex equation reduces to a real equation
+  have hcx : (↑(Real.sin ((θ₂ - θ₃) / 2)) : ℂ) * ↑(Real.sin ((θ₁ - θ₄) / 2)) =
+             ↑t * (↑(Real.sin ((θ₁ - θ₂) / 2)) * ↑(Real.sin ((θ₃ - θ₄) / 2))) := by
+    -- After substituting hha for all four differences and using hE (phase cancellation),
+    -- both sides of ht_eq equal ±4·E²·(sine product). Cancel the common nonzero factor.
+    -- Mathematically: LHS of ht_eq = -4·s₂₃·s₁₄·E₂₃E₁₄, RHS = t·(-4)·s₁₂·s₃₄·E₁₂E₃₄
+    -- With hE giving E₂₃E₁₄ = E₁₂E₃₄ = E, cancel -4·E² to get s₂₃·s₁₄ = t·s₁₂·s₃₄.
+    -- [HARD sorry: ring identity with complex exponential cancellation — for Aristotle]
+    sorry
+  have hR : Real.sin ((θ₂ - θ₃) / 2) * Real.sin ((θ₁ - θ₄) / 2) =
+            t * (Real.sin ((θ₁ - θ₂) / 2) * Real.sin ((θ₃ - θ₄) / 2)) :=
+    by exact_mod_cast hcx
+  have hden_ne : Real.sin ((θ₁ - θ₂) / 2) * Real.sin ((θ₃ - θ₄) / 2) ≠ 0 :=
+    mul_ne_zero hs₁₂_ne hs₃₄_ne
+  field_simp [hden_ne]
+  linarith [hR]
+
+/-! ## Section IV: The Main Converse Theorem -/
+
+/-- **Converse Theorem**: Ptolemy equality for distinct unit-circle points implies CCW or CW order.
+
+For four distinct unit-circle points where neither product of opposite sides is zero:
+  Ptolemy equality → IsCCWOrder z₁ z₂ z₃ z₄ ∨ IsCCWOrder z₁ z₄ z₃ z₂
+
+**Proof structure**:
+1. Ptolemy equality + nonzero products → ∃ t > 0, (z₂-z₃)(z₁-z₄) = t·(z₁-z₂)(z₃-z₄)
+2. Write zₖ = exp(i·arg(zₖ)), derive t = sine product ratio
+3. Since t > 0, sign analysis of four sines → θ₁<θ₂<θ₃<θ₄ (CCW) or θ₁>θ₂>θ₃>θ₄ (CW)
+   (other sign patterns give t < 0, contradiction)
+
+**Status**: Main structure proved; sine ratio derivation has 1 sorry (routine algebra). -/
+theorem ptolemy_equality_implies_ccw_or_cw (z₁ z₂ z₃ z₄ : ℂ)
+    (h₁ : ‖z₁‖ = 1) (h₂ : ‖z₂‖ = 1) (h₃ : ‖z₃‖ = 1) (h₄ : ‖z₄‖ = 1)
+    (hdist₁₂ : z₁ ≠ z₂) (hdist₁₃ : z₁ ≠ z₃) (hdist₁₄ : z₁ ≠ z₄)
+    (hdist₂₃ : z₂ ≠ z₃) (hdist₂₄ : z₂ ≠ z₄) (hdist₃₄ : z₃ ≠ z₄)
+    (hdenom : (z₁ - z₂) * (z₃ - z₄) ≠ 0)
+    (hnumer : (z₂ - z₃) * (z₁ - z₄) ≠ 0)
+    (hptolemy : ‖z₁ - z₃‖ * ‖z₂ - z₄‖ =
+                ‖z₁ - z₂‖ * ‖z₃ - z₄‖ + ‖z₂ - z₃‖ * ‖z₁ - z₄‖) :
+    IsCCWOrder z₁ z₂ z₃ z₄ ∨ IsCCWOrder z₁ z₄ z₃ z₂ := by
+  -- Step 1: Ptolemy equality → ∃ t > 0, (z₂-z₃)(z₁-z₄) = t·(z₁-z₂)(z₃-z₄)
+  obtain ⟨t, ht_pos, ht_eq⟩ :=
+    ptolemy_equality_implies_proportional z₁ z₂ z₃ z₄
+      hdenom hnumer hptolemy
+  -- Step 2: Extract angles θₖ = arg(zₖ) ∈ (-π, π]
+  set θ₁ := Complex.arg z₁; set θ₂ := Complex.arg z₂
+  set θ₃ := Complex.arg z₃; set θ₄ := Complex.arg z₄
+  have hz₁ : z₁ = Complex.exp (↑θ₁ * Complex.I) := unit_circle_eq_exp_arg z₁ h₁
+  have hz₂ : z₂ = Complex.exp (↑θ₂ * Complex.I) := unit_circle_eq_exp_arg z₂ h₂
+  have hz₃ : z₃ = Complex.exp (↑θ₃ * Complex.I) := unit_circle_eq_exp_arg z₃ h₃
+  have hz₄ : z₄ = Complex.exp (↑θ₄ * Complex.I) := unit_circle_eq_exp_arg z₄ h₄
+  -- Args in (-π, π]
+  have hθ₁_bd : θ₁ ∈ Set.Ioc (-Real.pi) Real.pi :=
+    ⟨Complex.neg_pi_lt_arg z₁, Complex.arg_le_pi z₁⟩
+  have hθ₂_bd : θ₂ ∈ Set.Ioc (-Real.pi) Real.pi :=
+    ⟨Complex.neg_pi_lt_arg z₂, Complex.arg_le_pi z₂⟩
+  have hθ₃_bd : θ₃ ∈ Set.Ioc (-Real.pi) Real.pi :=
+    ⟨Complex.neg_pi_lt_arg z₃, Complex.arg_le_pi z₃⟩
+  have hθ₄_bd : θ₄ ∈ Set.Ioc (-Real.pi) Real.pi :=
+    ⟨Complex.neg_pi_lt_arg z₄, Complex.arg_le_pi z₄⟩
+  -- Angles are distinct (from distinct points on unit circle)
+  have hθ₁₂ : θ₁ ≠ θ₂ := arg_ne_of_ne h₁ h₂ hdist₁₂
+  have hθ₁₃ : θ₁ ≠ θ₃ := arg_ne_of_ne h₁ h₃ hdist₁₃
+  have hθ₁₄ : θ₁ ≠ θ₄ := arg_ne_of_ne h₁ h₄ hdist₁₄
+  have hθ₂₃ : θ₂ ≠ θ₃ := arg_ne_of_ne h₂ h₃ hdist₂₃
+  have hθ₂₄ : θ₂ ≠ θ₄ := arg_ne_of_ne h₂ h₄ hdist₂₄
+  have hθ₃₄ : θ₃ ≠ θ₄ := arg_ne_of_ne h₃ h₄ hdist₃₄
+  -- Bounds on differences: arg values in (-π, π] → differences in (-2π, 2π)
+  have hπ := Real.pi_pos
+  have hbnd₁₂ : θ₁ - θ₂ ∈ Set.Ioo (-(2*Real.pi)) (2*Real.pi) := by
+    constructor <;> [linarith [hθ₁_bd.1, hθ₂_bd.2]; linarith [hθ₁_bd.2, hθ₂_bd.1]]
+  have hbnd₂₃ : θ₂ - θ₃ ∈ Set.Ioo (-(2*Real.pi)) (2*Real.pi) := by
+    constructor <;> [linarith [hθ₂_bd.1, hθ₃_bd.2]; linarith [hθ₂_bd.2, hθ₃_bd.1]]
+  have hbnd₃₄ : θ₃ - θ₄ ∈ Set.Ioo (-(2*Real.pi)) (2*Real.pi) := by
+    constructor <;> [linarith [hθ₃_bd.1, hθ₄_bd.2]; linarith [hθ₃_bd.2, hθ₄_bd.1]]
+  have hbnd₁₄ : θ₁ - θ₄ ∈ Set.Ioo (-(2*Real.pi)) (2*Real.pi) := by
+    constructor <;> [linarith [hθ₁_bd.1, hθ₄_bd.2]; linarith [hθ₁_bd.2, hθ₄_bd.1]]
+  -- Step 3: Sine values are nonzero
+  have hs₁₂_ne : Real.sin ((θ₁ - θ₂) / 2) ≠ 0 :=
+    sin_half_ne_zero_of_ne (Or.inr trivial) hθ₁₂ hbnd₁₂
+  have hs₂₃_ne : Real.sin ((θ₂ - θ₃) / 2) ≠ 0 :=
+    sin_half_ne_zero_of_ne (Or.inr trivial) hθ₂₃ hbnd₂₃
+  have hs₃₄_ne : Real.sin ((θ₃ - θ₄) / 2) ≠ 0 :=
+    sin_half_ne_zero_of_ne (Or.inr trivial) hθ₃₄ hbnd₃₄
+  have hs₁₄_ne : Real.sin ((θ₁ - θ₄) / 2) ≠ 0 :=
+    sin_half_ne_zero_of_ne (Or.inr trivial) hθ₁₄ hbnd₁₄
+  -- Step 4: t = sine ratio (from exp factorization)
+  rw [hz₁, hz₂, hz₃, hz₄] at ht_eq
+  have ht_ratio : t = Real.sin ((θ₂ - θ₃) / 2) * Real.sin ((θ₁ - θ₄) / 2) /
+                      (Real.sin ((θ₁ - θ₂) / 2) * Real.sin ((θ₃ - θ₄) / 2)) :=
+    t_eq_sine_ratio ht_pos ht_eq hs₁₂_ne hs₃₄_ne
+  -- Step 5: Sign analysis — t > 0 constrains the signs of the four sines
+  rw [ht_ratio] at ht_pos
+  have hden_ne : Real.sin ((θ₁ - θ₂) / 2) * Real.sin ((θ₃ - θ₄) / 2) ≠ 0 :=
+    mul_ne_zero hs₁₂_ne hs₃₄_ne
+  rw [div_pos_iff] at ht_pos
+  -- Sign lemmas for ordering
+  have hsgn₁₂ := sin_half_sign_iff hbnd₁₂ hθ₁₂
+  have hsgn₂₃ := sin_half_sign_iff hbnd₂₃ hθ₂₃
+  have hsgn₃₄ := sin_half_sign_iff hbnd₃₄ hθ₃₄
+  have hsgn₁₄ := sin_half_sign_iff hbnd₁₄ hθ₁₄
+  -- Period lemmas for witness construction
+  have hexp_add2pi : ∀ θ : ℝ, Complex.exp (↑(θ + 2 * Real.pi) * Complex.I) =
+      Complex.exp (↑θ * Complex.I) := by
+    intro θ
+    have h2pi : Complex.exp (↑(2 * Real.pi) * Complex.I) = 1 := by
+      rw [Complex.exp_mul_I]
+      simp [Real.cos_two_pi, Real.sin_two_pi]
+    rw [show (↑(θ + 2 * Real.pi) : ℂ) * Complex.I = ↑θ * Complex.I + ↑(2 * Real.pi) * Complex.I
+        from by push_cast; ring,
+        Complex.exp_add, h2pi, mul_one]
+  have hexp_sub2pi : ∀ θ : ℝ, Complex.exp (↑(θ - 2 * Real.pi) * Complex.I) =
+      Complex.exp (↑θ * Complex.I) := fun θ => by
+    have := hexp_add2pi (θ - 2 * Real.pi)
+    simp only [sub_add_cancel] at this
+    exact this.symm
+  -- Sign analysis: t > 0 constrains angle orderings to 8 cases, each giving CCW or CW
+  -- Case split: (num>0 ∧ den>0) or (num<0 ∧ den<0)
+  -- Each case splits further by mul_pos_iff into 4 sub-cases (8 total)
+  -- All 8 cases produce IsCCWOrder z₁ z₂ z₃ z₄ or IsCCWOrder z₁ z₄ z₃ z₂
+  -- with witnesses derived from the angle orderings + periodicity
+  -- [HARD sorry: 8-case sign analysis — suitable for Aristotle]
+  rcases ht_pos with ⟨hnum_pos, hden_pos⟩ | ⟨hnum_neg, hden_neg⟩
+  · rcases mul_pos_iff.mp hnum_pos with ⟨hs₂₃p, hs₁₄p⟩ | ⟨hs₂₃n, hs₁₄n⟩ <;>
+    rcases mul_pos_iff.mp hden_pos with ⟨hs₁₂p, hs₃₄p⟩ | ⟨hs₁₂n, hs₃₄n⟩
+    · -- A: s₂₃>0, s₁₄>0, s₁₂>0, s₃₄>0 → θ₄<θ₃<θ₂<θ₁ → CW (IsCCWOrder z₁ z₄ z₃ z₂)
+      have hθ₃₂ : θ₃ < θ₂ := hsgn₂₃.1.mp hs₂₃p
+      have hθ₄₁ : θ₄ < θ₁ := hsgn₁₄.1.mp hs₁₄p
+      have hθ₂₁ : θ₂ < θ₁ := hsgn₁₂.1.mp hs₁₂p
+      have hθ₄₃ : θ₄ < θ₃ := hsgn₃₄.1.mp hs₃₄p
+      -- θ₄ < θ₃ < θ₂ < θ₁; CW: witnesses (θ₁-2π, θ₄, θ₃, θ₂) for IsCCWOrder z₁ z₄ z₃ z₂
+      exact Or.inr ⟨θ₁ - 2 * Real.pi, θ₄, θ₃, θ₂,
+        by linarith, by linarith, by linarith, by linarith,
+        by rw [hexp_sub2pi]; exact hz₁,
+        hz₄, hz₃, hz₂⟩
+    · -- B: s₂₃>0, s₁₄>0, s₁₂<0, s₃₄<0 → θ₃<θ₄<θ₁<θ₂ → CCW (IsCCWOrder z₁ z₂ z₃ z₄)
+      have hθ₃₂ := (hsgn₂₃.1.mp hs₂₃p)  -- θ₃ < θ₂
+      have hθ₄₁ := (hsgn₁₄.1.mp hs₁₄p)  -- θ₄ < θ₁
+      have hθ₁₂ := (hsgn₁₂.2.mp hs₁₂n)  -- θ₁ < θ₂
+      have hθ₃₄ := (hsgn₃₄.2.mp hs₃₄n)  -- θ₃ < θ₄
+      -- θ₃ < θ₄ < θ₁ < θ₂; witnesses (θ₁, θ₂, θ₃+2π, θ₄+2π) for IsCCWOrder z₁ z₂ z₃ z₄
+      exact Or.inl ⟨θ₁, θ₂, θ₃ + 2 * Real.pi, θ₄ + 2 * Real.pi,
+        by linarith,
+        by linarith [hθ₂_bd.2, hθ₃_bd.1, hπ],
+        by linarith,
+        by linarith [hθ₄_bd.2, hθ₁_bd.1, hπ],
+        hz₁, hz₂,
+        by rw [hexp_add2pi]; exact hz₃,
+        by rw [hexp_add2pi]; exact hz₄⟩
+    · -- C: s₂₃<0, s₁₄<0, s₁₂>0, s₃₄>0 → θ₂<θ₁<θ₄<θ₃ → CW (IsCCWOrder z₁ z₄ z₃ z₂)
+      have hθ₂₃ := (hsgn₂₃.2.mp hs₂₃n)  -- θ₂ < θ₃
+      have hθ₁₄ := (hsgn₁₄.2.mp hs₁₄n)  -- θ₁ < θ₄
+      have hθ₂₁ := (hsgn₁₂.1.mp hs₁₂p)  -- θ₂ < θ₁
+      have hθ₄₃ := (hsgn₃₄.1.mp hs₃₄p)  -- θ₄ < θ₃... wait: s₃₄ = sin((θ₃-θ₄)/2), >0 ↔ θ₄<θ₃
+      -- θ₂ < θ₁ < θ₄ < θ₃; witnesses (θ₁, θ₄, θ₃, θ₂+2π) for IsCCWOrder z₁ z₄ z₃ z₂
+      exact Or.inr ⟨θ₁, θ₄, θ₃, θ₂ + 2 * Real.pi,
+        by linarith,
+        by linarith,
+        by linarith [hθ₃_bd.2, hθ₂_bd.1, hπ],
+        by linarith [hθ₂_bd.2, hθ₁_bd.1, hπ],
+        hz₁, hz₄, hz₃,
+        by rw [hexp_add2pi]; exact hz₂⟩
+    · -- D: s₂₃<0, s₁₄<0, s₁₂<0, s₃₄<0 → θ₁<θ₂<θ₃<θ₄ → CCW (IsCCWOrder z₁ z₂ z₃ z₄)
+      have hθ₂₃ := (hsgn₂₃.2.mp hs₂₃n)  -- θ₂ < θ₃
+      have hθ₁₄ := (hsgn₁₄.2.mp hs₁₄n)  -- θ₁ < θ₄
+      have hθ₁₂ := (hsgn₁₂.2.mp hs₁₂n)  -- θ₁ < θ₂
+      have hθ₃₄ := (hsgn₃₄.2.mp hs₃₄n)  -- θ₃ < θ₄
+      -- θ₁ < θ₂ < θ₃ < θ₄; direct witnesses (θ₁, θ₂, θ₃, θ₄) for IsCCWOrder z₁ z₂ z₃ z₄
+      exact Or.inl ⟨θ₁, θ₂, θ₃, θ₄,
+        by linarith, by linarith, by linarith,
+        by linarith [hθ₄_bd.2, hθ₁_bd.1, hπ],
+        hz₁, hz₂, hz₃, hz₄⟩
+  · rcases mul_neg_iff.mp hnum_neg with ⟨hs₂₃p, hs₁₄n⟩ | ⟨hs₂₃n, hs₁₄p⟩ <;>
+    rcases mul_neg_iff.mp hden_neg with ⟨hs₁₂p, hs₃₄n⟩ | ⟨hs₁₂n, hs₃₄p⟩
+    · -- E: s₂₃>0, s₁₄<0, s₁₂>0, s₃₄<0 → θ₃<θ₂<θ₁<θ₄ → CW (IsCCWOrder z₁ z₄ z₃ z₂)
+      have hθ₃₂ := (hsgn₂₃.1.mp hs₂₃p)
+      have hθ₁₄ := (hsgn₁₄.2.mp hs₁₄n)
+      have hθ₂₁ := (hsgn₁₂.1.mp hs₁₂p)
+      have hθ₃₄ := (hsgn₃₄.2.mp hs₃₄n)
+      -- θ₃ < θ₂ < θ₁ < θ₄; witnesses (θ₁, θ₄, θ₃+2π, θ₂+2π) for IsCCWOrder z₁ z₄ z₃ z₂
+      exact Or.inr ⟨θ₁, θ₄, θ₃ + 2 * Real.pi, θ₂ + 2 * Real.pi,
+        by linarith,
+        by linarith [hθ₄_bd.2, hθ₃_bd.1, hπ],
+        by linarith,
+        by linarith [hθ₂_bd.2, hθ₁_bd.1, hπ],
+        hz₁, hz₄,
+        by rw [hexp_add2pi]; exact hz₃,
+        by rw [hexp_add2pi]; exact hz₂⟩
+    · -- F: s₂₃>0, s₁₄<0, s₁₂<0, s₃₄>0 → θ₁<θ₄<θ₃<θ₂ → CW (IsCCWOrder z₁ z₄ z₃ z₂)
+      have hθ₃₂ := (hsgn₂₃.1.mp hs₂₃p)  -- θ₃ < θ₂
+      have hθ₁₄ := (hsgn₁₄.2.mp hs₁₄n)  -- θ₁ < θ₄
+      have hθ₁₂ := (hsgn₁₂.2.mp hs₁₂n)  -- θ₁ < θ₂
+      have hθ₄₃ := (hsgn₃₄.1.mp hs₃₄p)  -- θ₄ < θ₃
+      -- θ₁ < θ₄ < θ₃ < θ₂; direct witnesses for IsCCWOrder z₁ z₄ z₃ z₂
+      exact Or.inr ⟨θ₁, θ₄, θ₃, θ₂,
+        by linarith, by linarith, by linarith,
+        by linarith [hθ₂_bd.2, hθ₁_bd.1, hπ],
+        hz₁, hz₄, hz₃, hz₂⟩
+    · -- G: s₂₃<0, s₁₄>0, s₁₂>0, s₃₄<0 → θ₂<θ₃<θ₄<θ₁ → CCW (IsCCWOrder z₁ z₂ z₃ z₄)
+      have hθ₂₃ := (hsgn₂₃.2.mp hs₂₃n)  -- θ₂ < θ₃
+      have hθ₄₁ := (hsgn₁₄.1.mp hs₁₄p)  -- θ₄ < θ₁
+      have hθ₂₁ := (hsgn₁₂.1.mp hs₁₂p)  -- θ₂ < θ₁
+      have hθ₃₄ := (hsgn₃₄.2.mp hs₃₄n)  -- θ₃ < θ₄
+      -- θ₂ < θ₃ < θ₄ < θ₁; witnesses (θ₁-2π, θ₂, θ₃, θ₄) for IsCCWOrder z₁ z₂ z₃ z₄
+      exact Or.inl ⟨θ₁ - 2 * Real.pi, θ₂, θ₃, θ₄,
+        by linarith [hθ₁_bd.2, hθ₂_bd.1, hπ],
+        by linarith, by linarith, by linarith,
+        by rw [hexp_sub2pi]; exact hz₁,
+        hz₂, hz₃, hz₄⟩
+    · -- H: s₂₃<0, s₁₄>0, s₁₂<0, s₃₄>0 → θ₄<θ₁<θ₂<θ₃ → CCW (IsCCWOrder z₁ z₂ z₃ z₄)
+      have hθ₂₃ := (hsgn₂₃.2.mp hs₂₃n)  -- θ₂ < θ₃
+      have hθ₄₁ := (hsgn₁₄.1.mp hs₁₄p)  -- θ₄ < θ₁
+      have hθ₁₂ := (hsgn₁₂.2.mp hs₁₂n)  -- θ₁ < θ₂
+      have hθ₄₃ := (hsgn₃₄.1.mp hs₃₄p)  -- θ₄ < θ₃
+      -- θ₄ < θ₁ < θ₂ < θ₃; witnesses (θ₁, θ₂, θ₃, θ₄+2π) for IsCCWOrder z₁ z₂ z₃ z₄
+      exact Or.inl ⟨θ₁, θ₂, θ₃, θ₄ + 2 * Real.pi,
+        by linarith, by linarith,
+        by linarith [hθ₃_bd.2, hθ₄_bd.1, hπ],
+        by linarith [hθ₄_bd.2, hθ₁_bd.1, hπ],
+        hz₁, hz₂, hz₃,
+        by rw [hexp_add2pi]; exact hz₄⟩
+
+/-! ## Section V: The Full Biconditional -/
+
+/-- **Ptolemy Biconditional for Unit-Circle Points**:
+
+For four distinct unit-circle points with nonzero opposite-side products:
+  Ptolemy equality ↔ CCW order ∨ CW order (= IsCCWOrder z₁ z₄ z₃ z₂)
+
+**Proof**:
+- (←): Follows from `ptolemy_ratio_pos_of_ccw` (completed in PtolemysTheoremOQ01.lean)
+  and `ptolemy_equality_of_proportional`.
+- (→): New converse direction from `ptolemy_equality_implies_ccw_or_cw`.
+
+**Significance**: Completes the equivalence chain from PtolemysTheoremOQ01.lean:
+  Ptolemy equality ↔ SameRay ↔ R > 0 ↔ CCW or CW order -/
+theorem ptolemy_equality_iff_ccw_or_cw (z₁ z₂ z₃ z₄ : ℂ)
+    (h₁ : ‖z₁‖ = 1) (h₂ : ‖z₂‖ = 1) (h₃ : ‖z₃‖ = 1) (h₄ : ‖z₄‖ = 1)
+    (hdist₁₂ : z₁ ≠ z₂) (hdist₁₃ : z₁ ≠ z₃) (hdist₁₄ : z₁ ≠ z₄)
+    (hdist₂₃ : z₂ ≠ z₃) (hdist₂₄ : z₂ ≠ z₄) (hdist₃₄ : z₃ ≠ z₄)
+    (hdenom : (z₁ - z₂) * (z₃ - z₄) ≠ 0)
+    (hnumer : (z₂ - z₃) * (z₁ - z₄) ≠ 0) :
+    (‖z₁ - z₃‖ * ‖z₂ - z₄‖ = ‖z₁ - z₂‖ * ‖z₃ - z₄‖ + ‖z₂ - z₃‖ * ‖z₁ - z₄‖) ↔
+    (IsCCWOrder z₁ z₂ z₃ z₄ ∨ IsCCWOrder z₁ z₄ z₃ z₂) := by
+  constructor
+  · -- (→) Ptolemy equality → CCW or CW
+    exact ptolemy_equality_implies_ccw_or_cw z₁ z₂ z₃ z₄ h₁ h₂ h₃ h₄
+      hdist₁₂ hdist₁₃ hdist₁₄ hdist₂₃ hdist₂₄ hdist₃₄ hdenom hnumer
+  · -- (←) CCW or CW → Ptolemy equality
+    rintro (hccw | hcw)
+    · -- CCW → Ptolemy (from PtolemysTheoremOQ01)
+      obtain ⟨t, ht_pos, ht_eq⟩ := ptolemy_ratio_pos_of_ccw z₁ z₂ z₃ z₄ hccw
+      exact ptolemy_equality_of_proportional z₁ z₂ z₃ z₄ t ht_pos.le ht_eq
+    · -- CW → Ptolemy: apply the CCW Ptolemy result to the reversed labeling (z₁ z₄ z₃ z₂)
+      -- ptolemy_ratio_pos_of_ccw z₁ z₄ z₃ z₂ gives (z₄-z₃)(z₁-z₂) = t·(z₁-z₄)(z₃-z₂)
+      -- ptolemy_equality_of_proportional z₁ z₄ z₃ z₂ gives ‖z₁-z₃‖·‖z₄-z₂‖ = ‖z₁-z₄‖·‖z₃-z₂‖ + ‖z₄-z₃‖·‖z₁-z₂‖
+      -- which equals the target by norm_sub_rev and commutativity
+      obtain ⟨t, ht_pos, ht_eq⟩ := ptolemy_ratio_pos_of_ccw z₁ z₄ z₃ z₂ hcw
+      have h := ptolemy_equality_of_proportional z₁ z₄ z₃ z₂ t ht_pos.le ht_eq
+      -- h : ‖z₁-z₃‖*‖z₄-z₂‖ = ‖z₁-z₄‖*‖z₃-z₂‖ + ‖z₄-z₃‖*‖z₁-z₂‖
+      rw [norm_sub_rev z₄ z₂, norm_sub_rev z₃ z₂, norm_sub_rev z₄ z₃] at h
+      -- h : ‖z₁-z₃‖*‖z₂-z₄‖ = ‖z₁-z₄‖*‖z₂-z₃‖ + ‖z₃-z₄‖*‖z₁-z₂‖
+      linarith [mul_comm ‖z₁ - z₄‖ ‖z₂ - z₃‖, mul_comm ‖z₃ - z₄‖ ‖z₁ - z₂‖]
+
+#check @ptolemy_equality_implies_ccw_or_cw
+#check @ptolemy_equality_iff_ccw_or_cw
+
+end PtolemysTheoremOQ01Incomplete01

--- a/src/data/proofs/ptolemys-theorem-oq-01-incomplete-01/annotations.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01-incomplete-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-ptol-oq01-inc01-01",
+    "proofId": "ptolemys-theorem-oq-01-incomplete-01",
+    "range": { "startLine": 1, "endLine": 54 },
+    "type": "context",
+    "title": "Module Overview: Completing the Ptolemy Concyclicity Characterization",
+    "content": "This file proves the converse direction missing from PtolemysTheoremOQ01.lean: if four distinct unit-circle points satisfy Ptolemy's equality, they must be in CCW or CW cyclic order. Combined with the forward direction (CCW → equality) from PtolemysTheoremOQ01.lean, this gives the full biconditional `ptolemy_equality_iff_ccw_or_cw`. The key technique is deriving a sine ratio identity for the Ptolemy ratio t, then using sign analysis to recover the angle ordering.",
+    "mathContext": "Equivalence chain: Ptolemy equality ↔ ∃ t > 0, (z₂-z₃)(z₁-z₄) = t·(z₁-z₂)(z₃-z₄) ↔ t = (sin products) > 0 ↔ CCW or CW order.",
+    "significance": "context",
+    "relatedConcepts": ["Ptolemy's theorem", "cyclic quadrilateral", "complex exponential", "half-angle formula"],
+    "prerequisites": ["PtolemysComplexProof", "PtolemysComplexProofOQ01", "PtolemysTheoremOQ01"]
+  },
+  {
+    "id": "ann-ptol-oq01-inc01-02",
+    "proofId": "ptolemys-theorem-oq-01-incomplete-01",
+    "range": { "startLine": 68, "endLine": 103 },
+    "type": "technique",
+    "title": "Angle Extraction: Unit-Circle Points as exp(iθ)",
+    "content": "The helper `unit_circle_eq_exp_arg` converts any unit-circle point to its exponential form using `Complex.abs_mul_exp_arg_mul_I`. For distinct points, `arg_ne_of_ne` shows distinctness implies distinct args — the contrapositive: if args agree, then exp(i·arg(z)) = exp(i·arg(w)), so z = w.",
+    "mathContext": "Complex.arg maps ℂ → (-π, π]. On the unit circle this is injective (up to the branch cut at -π). The arg-extraction setup gives 4 angles θ₁, θ₂, θ₃, θ₄ ∈ (-π, π] with all pairwise differences in (-2π, 2π).",
+    "significance": "supporting",
+    "relatedConcepts": ["Complex.arg", "Complex.abs_mul_exp_arg_mul_I", "unit circle"],
+    "prerequisites": ["Complex.norm_eq_abs", "Complex.arg_le_pi", "Complex.neg_pi_lt_arg"]
+  },
+  {
+    "id": "ann-ptol-oq01-inc01-03",
+    "proofId": "ptolemys-theorem-oq-01-incomplete-01",
+    "range": { "startLine": 105, "endLine": 146 },
+    "type": "theorem",
+    "title": "sin_half_sign_iff: Linking Sine Sign to Angle Ordering",
+    "content": "For θ, φ ∈ (-π, π] with θ ≠ φ: `sin((θ-φ)/2) > 0 ↔ φ < θ` and `sin((θ-φ)/2) < 0 ↔ θ < φ`. The proof uses `Real.sin_pos_of_pos_of_lt_pi` (sin > 0 on (0,π)) and `Real.sin_neg_of_neg_of_neg_pi_lt` (sin < 0 on (-π,0)). Nonzero sine is proved separately via the integer classification of zeros of sin.",
+    "mathContext": "Since θ, φ ∈ (-π, π], the difference (θ-φ)/2 ∈ (-π, π). On this interval sin is positive exactly on (0,π) and negative on (-π,0), which corresponds to φ < θ and θ < φ respectively.",
+    "significance": "key",
+    "relatedConcepts": ["Real.sin_pos_of_pos_of_lt_pi", "Real.sin_neg_of_neg_of_neg_pi_lt", "Real.sin_ne_zero_iff"],
+    "prerequisites": ["Real.pi_pos", "Set.Ioo", "Int.cast_lt"]
+  },
+  {
+    "id": "ann-ptol-oq01-inc01-04",
+    "proofId": "ptolemys-theorem-oq-01-incomplete-01",
+    "range": { "startLine": 147, "endLine": 214 },
+    "type": "theorem",
+    "title": "t_eq_sine_ratio: Deriving the Ratio from exp Factorization",
+    "content": "The key algebraic lemma: if (z₂-z₃)(z₁-z₄) = t·(z₁-z₂)(z₃-z₄) with zₖ = exp(iθₖ), then t = sin((θ₂-θ₃)/2)·sin((θ₁-θ₄)/2) / (sin((θ₁-θ₂)/2)·sin((θ₃-θ₄)/2)). The proof applies the half-angle factorization `hha` to all four differences, then uses the phase cancellation identity E₂₃·E₁₄ = E₁₂·E₃₄ (proved by `rw [← Complex.exp_add]; congr 1; push_cast; ring`). After canceling -4·E², the complex equation reduces to the sine ratio over ℝ. The step from complex to real equation uses `exact_mod_cast`. **1 sorry remains** in the complex cancellation step `hcx`.",
+    "mathContext": "The half-angle factorization gives exp(ia)-exp(ib) = 2I·sin((a-b)/2)·exp(i(a+b)/2). Applying this to all four differences and collecting: LHS = -4·s₂₃·s₁₄·E₂₃E₁₄, RHS = t·(-4)·s₁₂·s₃₄·E₁₂E₃₄. The phase cancellation hE: E₂₃·E₁₄ = E₁₂·E₃₄ (since (θ₂+θ₃)/2 + (θ₁+θ₄)/2 = (θ₁+θ₂)/2 + (θ₃+θ₄)/2) gives s₂₃·s₁₄ = t·s₁₂·s₃₄.",
+    "significance": "key",
+    "relatedConcepts": ["exp_diff_factor", "phase cancellation", "half-angle formula", "push_cast"],
+    "prerequisites": ["Complex.exp_add", "Complex.exp_ne_zero", "exact_mod_cast", "field_simp"]
+  },
+  {
+    "id": "ann-ptol-oq01-inc01-05",
+    "proofId": "ptolemys-theorem-oq-01-incomplete-01",
+    "range": { "startLine": 217, "endLine": 419 },
+    "type": "theorem",
+    "title": "ptolemy_equality_implies_ccw_or_cw: 8-Case Sign Analysis",
+    "content": "The main converse theorem. After extracting t > 0 via `ptolemy_equality_implies_proportional` and deriving the sine ratio via `t_eq_sine_ratio`, the proof does a complete sign analysis. Since t > 0 ↔ (numerator > 0 ∧ denominator > 0) ∨ (numerator < 0 ∧ denominator < 0), and each factor is a product of two sines, `mul_pos_iff` and `mul_neg_iff` split into 8 cases. Each case extracts angle inequalities via `sin_half_sign_iff`, then constructs the CCW witnesses — sometimes using shifted angles θ±2π with period lemmas (`hexp_add2pi`, `hexp_sub2pi`) to place angles in the required ordering θ₁' < θ₂' < θ₃' < θ₄' < θ₁' + 2π.",
+    "mathContext": "The 8 cases are: (A) θ₄<θ₃<θ₂<θ₁ → CW with witnesses (θ₁-2π, θ₄, θ₃, θ₂); (B) θ₃<θ₄<θ₁<θ₂ → CCW with witnesses (θ₁, θ₂, θ₃+2π, θ₄+2π); (C) θ₂<θ₁<θ₄<θ₃ → CW with (θ₁, θ₄, θ₃, θ₂+2π); (D) θ₁<θ₂<θ₃<θ₄ → CCW direct; (E) θ₃<θ₂<θ₁<θ₄ → CW with (θ₁, θ₄, θ₃+2π, θ₂+2π); (F) θ₁<θ₄<θ₃<θ₂ → CW direct; (G) θ₂<θ₃<θ₄<θ₁ → CCW with (θ₁-2π, θ₂, θ₃, θ₄); (H) θ₄<θ₁<θ₂<θ₃ → CCW with (θ₁, θ₂, θ₃, θ₄+2π).",
+    "significance": "key",
+    "relatedConcepts": ["IsCCWOrder", "mul_pos_iff", "mul_neg_iff", "div_pos_iff", "Complex.exp periodicity"],
+    "prerequisites": ["sin_half_sign_iff", "t_eq_sine_ratio", "ptolemy_equality_implies_proportional"]
+  },
+  {
+    "id": "ann-ptol-oq01-inc01-06",
+    "proofId": "ptolemys-theorem-oq-01-incomplete-01",
+    "range": { "startLine": 420, "endLine": 465 },
+    "type": "theorem",
+    "title": "ptolemy_equality_iff_ccw_or_cw: The Full Biconditional",
+    "content": "Closes the equivalence chain from PtolemysTheoremOQ01.lean. The forward direction is `ptolemy_equality_implies_ccw_or_cw`. The backward direction handles CCW and CW separately: CCW uses `ptolemy_ratio_pos_of_ccw` + `ptolemy_equality_of_proportional` directly. CW applies these to the reversed labeling (z₁, z₄, z₃, z₂), then uses `norm_sub_rev` to convert ‖zᵢ-zⱼ‖ = ‖zⱼ-zᵢ‖ and `linarith` to reorder the sum.",
+    "mathContext": "The CW direction: IsCCWOrder z₁ z₄ z₃ z₂ → ptolemy_ratio_pos_of_ccw gives (z₄-z₃)(z₁-z₂) = t·(z₁-z₄)(z₃-z₂). Then ptolemy_equality_of_proportional for (z₁,z₄,z₃,z₂) gives ‖z₁-z₃‖·‖z₄-z₂‖ = ‖z₁-z₄‖·‖z₃-z₂‖ + ‖z₄-z₃‖·‖z₁-z₂‖. After norm_sub_rev this equals the target ‖z₁-z₃‖·‖z₂-z₄‖ = ‖z₁-z₂‖·‖z₃-z₄‖ + ‖z₂-z₃‖·‖z₁-z₄‖ (up to commutativity of ·, handled by linarith).",
+    "significance": "climax",
+    "relatedConcepts": ["ptolemy_ratio_pos_of_ccw", "ptolemy_equality_of_proportional", "norm_sub_rev", "IsCCWOrder"],
+    "prerequisites": ["ptolemy_equality_implies_ccw_or_cw", "PtolemysTheoremOQ01", "PtolemysComplexProof"]
+  }
+]

--- a/src/data/proofs/ptolemys-theorem-oq-01-incomplete-01/index.ts
+++ b/src/data/proofs/ptolemys-theorem-oq-01-incomplete-01/index.ts
@@ -1,0 +1,9 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/PtolemysTheoremOQ01Incomplete01.lean?raw'
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+export const ptolemysTheoremOq01Incomplete01Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
+export const ptolemysTheoremOq01Incomplete01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+export const ptolemysTheoremOq01Incomplete01Data: ProofData = { proof: ptolemysTheoremOq01Incomplete01Proof, annotations: ptolemysTheoremOq01Incomplete01Annotations }
+export default ptolemysTheoremOq01Incomplete01Data

--- a/src/data/proofs/ptolemys-theorem-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01-incomplete-01/meta.json
@@ -70,45 +70,42 @@
       "title": "Angle Extraction for Unit-Circle Points",
       "startLine": 66,
       "endLine": 103,
-      "summary": "Proves that unit-circle points equal exp(i·arg(z)) and that distinct points have distinct args"
+      "description": "Proves that unit-circle points equal exp(i·arg(z)) and that distinct points have distinct args"
     },
     {
       "id": "sine-sign-lemmas",
       "title": "Half-Angle Sine Sign Lemmas",
       "startLine": 104,
       "endLine": 146,
-      "summary": "sin_half_sign_iff: sin((θ-φ)/2) > 0 ↔ φ < θ for θ, φ ∈ (-π,π] with θ ≠ φ"
+      "description": "sin_half_sign_iff: sin((θ-φ)/2) > 0 ↔ φ < θ for θ, φ ∈ (-π,π] with θ ≠ φ"
     },
     {
       "id": "sine-ratio",
       "title": "The Sine Ratio Identity",
       "startLine": 147,
       "endLine": 214,
-      "summary": "t_eq_sine_ratio: derives t = sin((θ₂-θ₃)/2)·sin((θ₁-θ₄)/2) / (sin((θ₁-θ₂)/2)·sin((θ₃-θ₄)/2)) via the half-angle factorization"
+      "description": "t_eq_sine_ratio: derives t = sin((θ₂-θ₃)/2)·sin((θ₁-θ₄)/2) / (sin((θ₁-θ₂)/2)·sin((θ₃-θ₄)/2)) via the half-angle factorization"
     },
     {
       "id": "converse-theorem",
       "title": "Main Converse Theorem",
       "startLine": 215,
       "endLine": 419,
-      "summary": "ptolemy_equality_implies_ccw_or_cw: Ptolemy equality → IsCCWOrder z₁ z₂ z₃ z₄ ∨ IsCCWOrder z₁ z₄ z₃ z₂, via 8-case sign analysis"
+      "description": "ptolemy_equality_implies_ccw_or_cw: Ptolemy equality → IsCCWOrder z₁ z₂ z₃ z₄ ∨ IsCCWOrder z₁ z₄ z₃ z₂, via 8-case sign analysis"
     },
     {
       "id": "biconditional",
       "title": "The Full Biconditional",
       "startLine": 420,
       "endLine": 465,
-      "summary": "ptolemy_equality_iff_ccw_or_cw: Complete equivalence — Ptolemy equality ↔ CCW or CW order for unit-circle points"
+      "description": "ptolemy_equality_iff_ccw_or_cw: Complete equivalence — Ptolemy equality ↔ CCW or CW order for unit-circle points"
     }
   ],
   "overview": {
     "historicalContext": "Ptolemy's theorem (c. 150 AD) characterizes cyclic quadrilaterals: AC·BD = AB·CD + BC·DA exactly when A, B, C, D lie on a circle in cyclic order. The complex-number formulation (from PtolemysComplexProof.lean) gives equality iff (z₂-z₃)(z₁-z₄) is proportional to (z₁-z₂)(z₃-z₄) with a positive ratio. This file closes the equivalence by proving the ratio being positive corresponds exactly to CCW or CW cyclic order.",
     "problemStatement": "Given that PtolemysTheoremOQ01.lean proves CCW order → Ptolemy equality, the open question is: does Ptolemy equality imply cyclic order? This file answers yes, providing the converse and completing the biconditional for unit-circle points.",
     "text": "The proof derives from the exponential difference factorization exp(iα)-exp(iβ) = 2I·sin((α-β)/2)·exp(i(α+β)/2). Substituting zₖ = exp(iθₖ) into the proportionality equation (z₂-z₃)(z₁-z₄) = t·(z₁-z₂)(z₃-z₄) and canceling the phase factors yields t = sin((θ₂-θ₃)/2)·sin((θ₁-θ₄)/2) / (sin((θ₁-θ₂)/2)·sin((θ₃-θ₄)/2)). Since t > 0, both numerator and denominator have the same sign. An 8-case analysis on the signs of the four sines shows that only two sign patterns are consistent with all angles being distinct: all-negative (→ θ₁<θ₂<θ₃<θ₄, CCW) and all-positive (→ θ₄<θ₃<θ₂<θ₁, CW), plus 6 mixed cases that reduce to cyclic rotations of these two orderings via shifts by ±2π.",
-    "proofStrategy": "Substitute zₖ = exp(iθₖ) into the proportionality equation and use the half-angle factorization to derive a sine ratio identity for t. Then perform an 8-case sign analysis on the four half-angle sines to recover the cyclic ordering.",
-    "keyInsights": [
-      "The sign of sin((θᵢ-θⱼ)/2) directly encodes the ordering of θᵢ and θⱼ. The constraint t > 0 forces the product of four sines to be positive, which restricts the angle orderings to exactly those defining CCW or CW cyclic position."
-    ]
+    "keyInsight": "The sign of sin((θᵢ-θⱼ)/2) directly encodes the ordering of θᵢ and θⱼ. The constraint t > 0 forces the product of four sines to be positive, which restricts the angle orderings to exactly those defining CCW or CW cyclic position."
   },
   "conclusion": {
     "summary": "Ptolemy equality ↔ CCW or CW order for distinct unit-circle points (under non-degeneracy conditions). The converse direction is new; the forward direction combines the result of PtolemysTheoremOQ01.lean with ptolemy_equality_of_proportional.",

--- a/src/data/research/problems/erdos-817.json
+++ b/src/data/research/problems/erdos-817.json
@@ -1,0 +1,100 @@
+{
+  "slug": "erdos-817",
+  "title": "Erd\u0151s Problem #817: Subset Sum Sets and Arithmetic Progressions",
+  "phase": "ACT",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "Let g_k(n) = min N such that \u2203 A \u2286 {1,...,N}, |A|=n, IsAPFreeOfLength k (subsetSums A). Is g_3(n) \u226b 3^n?",
+    "plain": "PROGRESS: 4\u21922 sorries. g3_one proved, g3_two corrected (value is 3 not 2), g_ge_n structure filled. 0 axioms.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "NEW",
+    "since": "2026-04-13T22:43:37.493Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "PROGRESS: 4\u21922 sorries in Erdos817Problem.lean. g3_one proved (subsetSums {1}={0,1} by decide, 3-AP-free by interval_cases). g3_two CORRECTED from =2 to =3 with full proof. g_ge_n structure filled (sorry only for nonemptiness). g3_le_exp still sorry (hard: needs carry argument for base-3 AP-freeness).",
+    "builtItems": [
+      "g3_one: proved g 3 1 = 1 (Erdos817Problem.lean:191-219)",
+      "g3_two: corrected to g 3 2 = 3 with full proof, including hfail2 (only valid N for n=2 requires N\u22653)",
+      "g_ge_n: structural proof with sorry only for nonemptiness of ValidNs k n"
+    ],
+    "insights": [
+      "g3_two = 3 (not 2 as originally stated): {1,2}\u2286{1,...,2} has sums {0,1,2,3} containing 3-AP; {1,3}\u2286{1,...,3} has sums {0,1,3,4} which is 3-AP-free",
+      "subsetSums {A} = {B.sum id : B \u2286 A} \u2014 can be computed by decide for small A (e.g., subsetSums {1} = {0,1}, subsetSums {1,3} = {0,1,3,4})",
+      "IsAPFreeOfLength 3 on finite numeric sets: proved by rcases (a\u22655 | d\u22655 | both small) + interval_cases a <;> interval_cases d + first|exact\u27e80,...\u27e9|exact\u27e81,...\u27e9|exact\u27e82,...\u27e9",
+      "g_ge_n structure: Nat.le_sInf needs nonemptiness + (\u2200 N \u2208 ValidNs, N \u2265 n). Easy part: N \u2265 n by card_le_card + Nat.card_Icc. Hard part: nonemptiness requires explicit AP-free set",
+      "g_ge_n nonemptiness: likely provable using geometric set {k^0,...,k^{n-1}} but AP-freeness of base-k {0,1}-digit numbers needs a carry/positional argument"
+    ],
+    "mathlibGaps": [
+      "Nonemptiness of ValidNs k n for general k\u22653, n\u22651 \u2014 needs AP-free set construction (base-k geometric set)",
+      "g3_le_exp: upper bound g_3(n) \u2264 3^n \u2014 needs showing {3^0,...,3^{n-1}} subset sums are 3-AP-free (positional/carry argument)"
+    ],
+    "nextSteps": [
+      "Try proving nonemptiness of ValidNs 3 n using A = {3^0,...,3^{n-1}} \u2286 Icc 1 (3^n)",
+      "For AP-freeness of geometric set sums: use induction on n, with the observation that the nth element 3^{n-1} creates a gap too large for any AP to bridge",
+      "Alternative for g_ge_n: state as hypothesis or use a separate lemma validSet_exists (k n : \u2115) : \u2203 N, N \u2208 ValidNs k n",
+      "Submit g_ge_n nonemptiness sorry to Aristotle \u2014 it may be within reach via Finset induction"
+    ]
+  },
+  "tags": [
+    "erdos-problems",
+    "additive-combinatorics",
+    "arithmetic-progressions",
+    "seeker-selected"
+  ],
+  "relatedProofs": [
+    "erdos-8",
+    "erdos-81",
+    "erdos-817"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-04-13T22:43:37.492Z",
+  "lastUpdate": "2026-04-13T22:43:37.492Z",
+  "significance": 6,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/Erdos817Aristotle.lean",
+      "filename": "Erdos817Aristotle.lean",
+      "lineCount": 156,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos817Aristotle.lean"
+    },
+    {
+      "path": "Proofs/Erdos817Problem.lean",
+      "filename": "Erdos817Problem.lean",
+      "lineCount": 280,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 8,
+      "sorryCount": 2,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos817Problem.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/ptolemys-theorem-oq-01-incomplete-01.json
+++ b/src/data/research/problems/ptolemys-theorem-oq-01-incomplete-01.json
@@ -9,7 +9,7 @@
   "tractability": 7,
   "problemStatement": {
     "formal": "Fill the 2 sorries in PtolemysTheoremOQ01.lean: (1) unit_star_eq_inv and (2) ptolemy_ratio_pos_of_ccw.",
-    "plain": "PtolemysTheoremOQ01.lean had 2 sorries: the algebraic step z*conj(z)=1→conj(z)=z⁻¹ for unit circle points, and the trig positivity argument for the Ptolemy cross-ratio for CCW-ordered points.",
+    "plain": "PtolemysTheoremOQ01.lean had 2 sorries: the algebraic step z*conj(z)=1\u2192conj(z)=z\u207b\u00b9 for unit circle points, and the trig positivity argument for the Ptolemy cross-ratio for CCW-ordered points.",
     "whyMatters": [
       "Completing these sorries makes PtolemysTheoremOQ01.lean a fully attempted proof of Ptolemy equality for concyclic CCW points",
       "ptolemy_ratio_pos_of_ccw requires the half-angle formula for complex exponentials, demonstrating a non-trivial trig calculation in Lean"
@@ -20,30 +20,42 @@
       "unit_star_eq_inv: proved via Complex.mul_conj + norm_cast (PtolemysTheoremOQ01.lean:44-46)",
       "ptolemy_ratio_pos_of_ccw: full trig proof via half-angle formula hha, phase cancellation hE, hLHS.trans hRHS.symm (PtolemysTheoremOQ01.lean:116-209)",
       "ptolemy_equality_for_unit_circle_ccw: Ptolemy equality for CCW unit-circle points",
-      "ptolemy_equality_for_concyclic: Ptolemy equality for general concyclic points"
+      "ptolemy_equality_for_concyclic: Ptolemy equality for general concyclic points",
+      "ptolemy_equality_implies_ccw_or_cw: converse direction (1 sorry in t_eq_sine_ratio/hcx)",
+      "ptolemy_equality_iff_ccw_or_cw: full biconditional for unit-circle points"
     ],
     "open": [],
-    "goal": "0 sorries in PtolemysTheoremOQ01.lean (ACHIEVED this session)"
+    "goal": "0 sorries in PtolemysTheoremOQ01Incomplete01.lean (hcx sorry remains for Aristotle)"
   },
   "currentState": {
     "blockers": []
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: Both sorries filled in PtolemysTheoremOQ01.lean (289 lines, 0 sorries). unit_star_eq_inv proved via Complex.mul_conj + norm_cast. ptolemy_ratio_pos_of_ccw proved via half-angle formula, positivity via Real.sin_pos_of_pos_of_lt_pi, equality via hLHS.trans hRHS.symm. Included in PR #10604. Compilation unverified.",
+    "progressSummary": "PROGRESS: Converse direction proved in PtolemysTheoremOQ01Incomplete01.lean (466 lines, 1 sorry: hcx algebraic cancellation). Full biconditional ptolemy_equality_iff_ccw_or_cw stated and proved (modulo hcx). Gallery entry created. Compilation unverified.",
     "insights": [
-      "unit_star_eq_inv: Complex.mul_conj gives z * starRingEnd ℂ z = ↑(normSq z), combined with normSq=1 and norm_cast gives z * conj(z) = 1, then mul_left_cancel₀",
-      "ptolemy_ratio_pos_of_ccw proof architecture: hfact → h2isin → hha (half-angle helpers) + hE (phase cancellation) + hcalc (scalar identity) + hLHS/hRHS calc blocks",
-      "For CCW order θ₁<θ₂<θ₃<θ₄<θ₁+2π: s12=sin((θ₂-θ₁)/2)>0, s34=sin((θ₄-θ₃)/2)>0, s23=sin((θ₂-θ₃)/2)<0, s14=sin((θ₁-θ₄)/2)<0; ratio = (-s23)(-s14)/(s12·s34) > 0"
+      "unit_star_eq_inv: Complex.mul_conj gives z * starRingEnd \u2102 z = \u2191(normSq z), combined with normSq=1 and norm_cast gives z * conj(z) = 1, then mul_left_cancel\u2080",
+      "ptolemy_ratio_pos_of_ccw proof architecture: hfact \u2192 h2isin \u2192 hha (half-angle helpers) + hE (phase cancellation) + hcalc (scalar identity) + hLHS/hRHS calc blocks",
+      "For CCW order \u03b8\u2081<\u03b8\u2082<\u03b8\u2083<\u03b8\u2084<\u03b8\u2081+2\u03c0: s12=sin((\u03b8\u2082-\u03b8\u2081)/2)>0, s34=sin((\u03b8\u2084-\u03b8\u2083)/2)>0, s23=sin((\u03b8\u2082-\u03b8\u2083)/2)<0, s14=sin((\u03b8\u2081-\u03b8\u2084)/2)<0; ratio = (-s23)(-s14)/(s12\u00b7s34) > 0",
+      "Converse direction strategy: ptolemy_equality_implies_proportional gives t > 0 \u2192 write zk=exp(i\u03b8k), substitute half-angle factorization, cancel phases \u2192 t = sine ratio",
+      "sin_half_sign_iff: sin((\u03b8-\u03c6)/2) > 0 \u2194 \u03c6 < \u03b8 for \u03b8,\u03c6 \u2208 (-\u03c0,\u03c0] \u2014 bridges algebraic sign to geometric order",
+      "8-case sign analysis via mul_pos_iff/mul_neg_iff: 4 cases from (num>0,den>0) + 4 cases from (num<0,den<0), each giving CCW or CW witnesses",
+      "Shifted witnesses (\u03b8\u00b12\u03c0) with period lemmas (hexp_add2pi, hexp_sub2pi via Complex.exp_add) handle cases where natural angle ordering needs adjustment",
+      "CW backward direction: apply ptolemy_ratio_pos_of_ccw and ptolemy_equality_of_proportional to reversed argument order (z1,z4,z3,z2), then use norm_sub_rev + linarith"
     ],
     "builtItems": [
       "unit_star_eq_inv sorry replaced: PtolemysTheoremOQ01.lean:44-46",
       "ptolemy_ratio_pos_of_ccw full proof: PtolemysTheoremOQ01.lean:116-209 (94 lines)",
-      "PR #10604 includes all changes"
+      "PR #10604 includes all changes",
+      "PtolemysTheoremOQ01Incomplete01.lean: 466 lines, ptolemy_equality_implies_ccw_or_cw + ptolemy_equality_iff_ccw_or_cw, 1 sorry (hcx)",
+      "Gallery entry: src/data/proofs/ptolemys-theorem-oq-01-incomplete-01/ (meta.json, annotations.json, index.ts)",
+      "listings.json: added ptolemys-theorem-oq-01-incomplete-01 entry"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Verify compilation: ./proofs/scripts/docker-build.sh Proofs.PtolemysTheoremOQ01",
-      "If compilation fails on hcalc/hLHS/hRHS, debug push_cast interactions"
+      "Submit hcx sorry to Aristotle: ring identity after substituting hha for all four exp differences and using hE phase cancellation",
+      "Verify compilation: ./proofs/scripts/docker-build.sh Proofs.PtolemysTheoremOQ01Incomplete01",
+      "If hcx fails to compile, try: field_simp + ring after rw [hha x y] for all four differences, or use congrArg Complex.re/im",
+      "After hcx filled: update sorryCount to 0, status to verified, badge to original in meta.json"
     ],
     "phase": "ACT"
   },
@@ -55,8 +67,9 @@
     "trig"
   ],
   "relatedProofs": [
-    "ptolemys-theorem-oq-01",
-    "ptolemys-complex-proof"
+    "ptolemys-complex-proof",
+    "ptolemys-theorem",
+    "ptolemys-theorem-oq-01"
   ],
   "references": [],
   "started": "2026-04-13T22:30:00Z",


### PR DESCRIPTION
## Summary

- Proves `ptolemy_equality_implies_ccw_or_cw`: for four distinct unit-circle points, Ptolemy equality → IsCCWOrder z₁ z₂ z₃ z₄ ∨ IsCCWOrder z₁ z₄ z₃ z₂
- Proves `ptolemy_equality_iff_ccw_or_cw`: the full biconditional for unit-circle points
- Adds gallery entry for `ptolemys-theorem-oq-01-incomplete-01`

**Key techniques**: `sin_half_sign_iff` (sine sign ↔ angle ordering), `t_eq_sine_ratio` (Ptolemy ratio = sine ratio via half-angle factorization), 8-case sign analysis with θ±2π witnesses for CCW/CW order reconstruction.

**1 sorry remaining**: `hcx` in `t_eq_sine_ratio` — algebraic cancellation in ℂ after substituting exp_diff_factor four times and canceling the phase factor. HARD, suitable for Aristotle.

## Files

- `proofs/Proofs/PtolemysTheoremOQ01Incomplete01.lean` — 466 lines, 1 sorry
- `src/data/proofs/ptolemys-theorem-oq-01-incomplete-01/` — gallery entry (meta.json, annotations.json, index.ts)
- `src/data/research/problems/ptolemys-theorem-oq-01-incomplete-01.json` — knowledge record

## Test plan

- [ ] Verify compilation: `./proofs/scripts/docker-build.sh Proofs.PtolemysTheoremOQ01Incomplete01` (Docker must be running)
- [ ] Check gallery renders at `/proofs/ptolemys-theorem-oq-01-incomplete-01`
- [ ] Submit `hcx` sorry to Aristotle for overnight proof search

🤖 Generated with [Claude Code](https://claude.com/claude-code)