### PR TITLE
Enrichment: taylor-theorem-oq-02 — mathContext, preamble section

### DIFF
--- a/src/data/proofs/taylor-theorem-oq-02/annotations.json
+++ b/src/data/proofs/taylor-theorem-oq-02/annotations.json
@@ -6,6 +6,7 @@
     "type": "insight",
     "title": "The FPS-to-Taylor Bridge",
     "content": "The core challenge is connecting two different representations of the same function:\n\n- **Mathlib's FPS representation**: `HasSum (fun n => p n (fun _ => y)) (f (x₀+y))` where p n is a degree-n continuous multilinear map ℝⁿ → ℝ\n- **Classical Taylor form**: `HasSum (fun n => iteratedDeriv n f x₀ / n! * y^n) (f (x₀+y))` where each term is a scalar\n\nThe bridge has two steps:\n1. **Multilinearity**: `m(y,...,y) = y^n · m(1,...,1)` (extracting the `y^n` factor)\n2. **Permutation symmetry**: `iteratedFDeriv = Σ_{σ} p n (v ∘ σ)` for constant v becomes `iteratedFDeriv = n! · p n (1,...,1)` (identifying the `1/n!` denominator)\n\nThe factor `n!` appears naturally: the permutation group Perm(Fin n) has exactly n! elements, and each permutation of a constant vector gives the same value.",
+    "mathContext": "The bridge lemma `fps_eval_eq_taylor_term` states: $p_n(y,\\ldots,y) = \\frac{\\partial^n f}{\\partial x^n}(x_0) \\cdot \\frac{y^n}{n!}$. It is assembled from `multilinear_eval_const` (giving $y^n$) and `fps_coeff_eq_taylor_coeff` (giving $\\partial^n f / n!$): together $p_n(y,\\ldots,y) = y^n \\cdot p_n(1,\\ldots,1) = y^n \\cdot \\frac{\\partial^n f}{\\partial x^n}(x_0)}{n!}$.",
     "significance": "key",
     "relatedConcepts": ["HasFPowerSeriesAt", "iteratedFDeriv", "FormalMultilinearSeries", "Perm"],
     "prerequisites": ["taylor-theorem", "HasFPowerSeriesAt"]
@@ -17,7 +18,8 @@
     "type": "technique",
     "title": "Fintype.card_perm = n! — The Permutation Count",
     "content": "The proof uses `Fintype.card_perm` to rewrite `|Perm (Fin n)| = n!`. This is the key step that introduces the `n!` denominator in the Taylor series.\n\nThe proof chain:\n```\nFinset.sum_const  →  nsmul_eq_mul  →  Fintype.card_perm\n```\n\nSpecifically:\n- `Finset.sum_const`: sum of constant c over S = |S| • c\n- `Finset.card_univ`: |Finset.univ| = Fintype.card\n- `Fintype.card_perm`: Fintype.card (Perm (Fin n)) = n!\n- `nsmul_eq_mul`: converts ℕ-scalar multiplication to ring multiplication\n\nThis is a clean and general argument — it does not need any special properties of the particular function f.",
-    "significance": "technical",
+    "mathContext": "The Mathlib lemma `HasFPowerSeriesOnBall.iteratedFDeriv_eq_sum_of_completeSpace` gives $\\partial^n_F f(x_0)(v) = \\sum_{\\sigma \\in \\operatorname{Perm}(\\operatorname{Fin}\\, n)} p_n(v \\circ \\sigma)$. For constant $v = (1,\\ldots,1)$ every $\\sigma$ gives the same value: $\\sum_{\\sigma} p_n(1,\\ldots,1) = |\\operatorname{Perm}(\\operatorname{Fin}\\, n)| \\cdot p_n(1,\\ldots,1) = n! \\cdot p_n(1,\\ldots,1)$. Rearranging: $p_n(1,\\ldots,1) = \\partial^n f(x_0) / n!$.",
+    "significance": "supporting",
     "relatedConcepts": ["Fintype.card_perm", "nsmul_eq_mul", "Finset.sum_const", "permutation group"],
     "prerequisites": ["HasFPowerSeriesOnBall.iteratedFDeriv_eq_sum_of_completeSpace"]
   },
@@ -28,6 +30,7 @@
     "type": "insight",
     "title": "Why Smoothness Fails: The Cauchy Example",
     "content": "The module docstring highlights the sharp boundary between smooth and analytic functions:\n\n**Cauchy's example**: f(x) = exp(-1/x²) for x ≠ 0, f(0) = 0.\n\nThis function is C^∞ at 0 — every derivative exists and equals 0 at x=0. So the Taylor series at 0 is identically 0. But f(x) ≠ 0 for x ≠ 0, so the Taylor series **fails** to converge to f anywhere except at the expansion point.\n\nThe Taylor remainder Rₙ(x) = f(x) - 0 = f(x) **does not converge to 0** — it stays at f(x) forever!\n\nThis example shows that the O(hⁿ) bound from Taylor's theorem (gallery: taylor-theorem) does NOT imply Rₙ → 0. Something more is needed — namely, **analyticity** (convergence of the power series).",
+    "mathContext": "The Cauchy function $f(x) = e^{-1/x^2}$ (with $f(0)=0$) satisfies $f^{(n)}(0) = 0$ for all $n \\in \\mathbb{N}$, so its Taylor series at 0 is $\\sum_{n} 0 \\cdot x^n = 0$. But $f(x) > 0$ for $x \\neq 0$, so $R_n(x) = f(x) - 0 = f(x) \\not\\to 0$ for fixed $x \\neq 0$. This shows $C^\\infty$ is strictly weaker than analytic ($\\mathrm{AnalyticAt}$) — the latter is equivalent to $\\mathrm{HasFPowerSeriesAt}$.",
     "significance": "key",
     "relatedConcepts": ["smooth functions", "analytic functions", "Cauchy example", "exp(-1/x²)"],
     "prerequisites": ["taylor-theorem", "HasFPowerSeriesAt"]
@@ -35,21 +38,23 @@
   {
     "id": "ann-has-sum-congr",
     "proofId": "taylor-theorem-oq-02",
-    "range": { "startLine": 135, "endLine": 139 },
+    "range": { "startLine": 128, "endLine": 132 },
     "type": "technique",
     "title": "HasSum.congr — One-Line Main Theorem",
     "content": "With the bridge lemma in hand, the main convergence theorem `taylor_hasSum_of_hasFPS` reduces to a single line:\n\n```lean\n(h.hasSum hy).congr fun n => (fps_eval_eq_taylor_term h n y).symm\n```\n\nThis is the standard Mathlib pattern:\n1. Start with `h.hasSum hy : HasSum (fun n => p n (fun _ => y)) (f (x₀+y))`\n2. Apply `.congr` with the bridge lemma (reversed) to rewrite each term\n3. Get `HasSum (fun n => iteratedDeriv n f x₀ / n! * y^n) (f (x₀+y))`\n\nThe elegance: once you have the right bridge lemma, the proof is trivial.",
-    "significance": "technical",
+    "mathContext": "`HasSum.congr` states: if `HasSum f s` and `∀ n, f n = g n`, then `HasSum g s`. Here $f_n = p_n(y,\\ldots,y)$ and $g_n = \\frac{\\partial^n f}{\\partial x^n}(x_0)/n! \\cdot y^n$; the bridge lemma `fps_eval_eq_taylor_term` gives $f_n = g_n$ for all $n$. So `h.hasSum hy` applied with `.congr` immediately yields the Taylor `HasSum`.",
+    "significance": "supporting",
     "relatedConcepts": ["HasSum.congr", "HasFPowerSeriesAt.hasSum", "fps_eval_eq_taylor_term"],
     "prerequisites": ["HasSum"]
   },
   {
     "id": "ann-convergence-theorems",
     "proofId": "taylor-theorem-oq-02",
-    "range": { "startLine": 140, "endLine": 174 },
+    "range": { "startLine": 134, "endLine": 168 },
     "type": "insight",
     "title": "Four Equivalent Convergence Statements for Analytic Functions",
     "content": "The file derives four equivalent formulations of Taylor convergence from a single `HasSum` foundation:\n\n**1. HasSum form** (`taylor_hasSum_of_hasFPS`, line 131):\n```\nHasSum (fun n => ∂ⁿf(x₀)/n! · yⁿ) (f(x₀+y))\n```\nStrongest statement: the series converges absolutely in the summability sense.\n\n**2. Tendsto form** (`taylor_tendsto_of_hasFPS`, line 140):\n```\nFilter.Tendsto (∑_{k<n} ...) atTop (nhds (f(x₀+y)))\n```\nDerived by `.tendsto_sum_nat` — partial sums approach f in the filter topology.\n\n**3. Remainder form** (`taylor_remainder_tendsto_zero`, line 150):\n```\nFilter.Tendsto (f(x₀+y) - ∑_{k<n} ...) atTop (nhds 0)\n```\nThe remainder Rₙ → 0. Proved via `tendsto_const_nhds.sub`.\n\n**4. Tsum form** (`taylor_tsum_eq`, line 163):\n```\n∑' n, ∂ⁿf(x₀)/n! · yⁿ = f(x₀+y)\n```\nThe infinite series SUM equals f. Follows from `HasSum.tsum_eq`.\n\nAll four are mathematically equivalent but serve different proof contexts: HasSum for algebra, Tendsto for analysis, Remainder for remainder estimates, Tsum for direct equalities.",
+    "mathContext": "The four forms follow by standard Mathlib conversions from `HasSum s a`: (1) `HasSum` itself; (2) `.tendsto_sum_nat : Filter.Tendsto (fun n => ∑_{k<n} f k) atTop (nhds a)`; (3) `tendsto_const_nhds.sub htend` converting partial sums convergence to $a - S_n \\to 0$; (4) `.tsum_eq : ∑' n, f n = a`. All are logically equivalent given $a$ is in the appropriate topology.",
     "significance": "key",
     "relatedConcepts": ["HasSum", "Filter.Tendsto", "tsum", "taylor_hasSum_of_hasFPS"],
     "prerequisites": ["HasFPowerSeriesAt"]
@@ -57,10 +62,11 @@
   {
     "id": "ann-analyticAt-version",
     "proofId": "taylor-theorem-oq-02",
-    "range": { "startLine": 176, "endLine": 200 },
+    "range": { "startLine": 170, "endLine": 194 },
     "type": "insight",
     "title": "AnalyticAt vs HasFPowerSeriesAt: Two Levels of the API",
     "content": "The file distinguishes two levels of the analyticity API:\n\n**`HasFPowerSeriesAt f p x₀`** (lower level):\n- States that a *specific* power series `p` represents `f` near `x₀`\n- Gives explicit access to `p.radius` and the series coefficients\n- Theorems: `taylor_hasSum_of_hasFPS`, `taylor_tsum_eq`\n\n**`AnalyticAt ℝ f x₀`** (higher level):\n- States that *some* power series represents `f` near `x₀`\n- Existential — hides the specific `p`\n- Theorems: `analyticAt_taylor_convergence`, `analyticAt_tsum_eq`\n\nThe key bridge: `AnalyticAt` is defined as `∃ p r, HasFPowerSeriesOnBall f p x₀ r`. So `obtain ⟨p, r, hr⟩ := hf` gives the explicit series. The radius satisfies `0 < p.radius` because `p.radius ≥ r > 0`.\n\nFor practical use: if you know `f` is analytic, use `analyticAt_taylor_convergence` which gives you the radius without needing to exhibit `p`. If you have a concrete `p` (e.g., for exp), use the `HasFPowerSeriesAt` theorems directly.",
+    "mathContext": "`AnalyticAt ℝ f x₀` unfolds as $\\exists p\\, r,\\, \\mathrm{HasFPowerSeriesOnBall}\\, f\\, p\\, x_0\\, r$. The proof of `analyticAt_taylor_convergence` uses `obtain ⟨p, r, hr⟩ := hf` and then `lt_of_lt_of_le hr.r_pos hr.le_radius` to get $0 < r \\le p.\\mathrm{radius}$, so $p.\\mathrm{radius} > 0$. The `HasFPowerSeriesAt` version follows with `⟨r, hr⟩`.",
     "significance": "key",
     "relatedConcepts": ["AnalyticAt", "HasFPowerSeriesAt", "HasFPowerSeriesOnBall", "FormalMultilinearSeries"],
     "prerequisites": ["HasFPowerSeriesAt"]
@@ -68,10 +74,11 @@
   {
     "id": "ann-vs-oq-03",
     "proofId": "taylor-theorem-oq-02",
-    "range": { "startLine": 40, "endLine": 50 },
+    "range": { "startLine": 38, "endLine": 50 },
     "type": "insight",
     "title": "Structural vs Ad Hoc: Comparison with OQ-03",
     "content": "This proof (OQ-02) and the companion (OQ-03) both prove Taylor convergence, but with different scope and method:\n\n**OQ-03** (taylor-theorem-oq-03): Proves Taylor convergence for exp(x) specifically.\n- Uses explicit derivative bounds: `iteratedDeriv n exp x₀ = exp x₀` by induction\n- Uses summability of `‖x‖^n/n!` to bound the error\n- Constructive, gives explicit error bounds (|e - S_n(1)| ≤ 3/n!)\n\n**OQ-02** (this file): Proves Taylor convergence for ALL analytic functions.\n- Uses the structural definition: analytic ≡ HasFPowerSeriesAt\n- No explicit derivative computation needed\n- No error bounds, but covers the full generality\n\nThe relationship: OQ-02's result explains WHY exp's Taylor series converges (exp is analytic). OQ-03's result gives HOW FAST it converges (explicit bound). Both perspectives are valuable.",
+    "mathContext": "The two proofs address different aspects: OQ-03 proves $|e - \\sum_{k<n} 1/k!| \\le 3/n!$ using $\\partial^k \\exp(x_0) = \\exp(x_0)$ and $\\sum_{k \\ge n} \\|x_0\\|^k/k! \\to 0$. OQ-02 proves $R_n(y) \\to 0$ for all $f$ with $\\mathrm{HasFPowerSeriesAt}\\,f\\,p\\,x_0$ and $y \\in B(0, p.\\mathrm{radius})$. OQ-02 applies to exp as a special case (exp has a global power series), but gives no rate.",
     "significance": "supporting",
     "relatedConcepts": ["HasFPowerSeriesAt", "AnalyticAt", "exp convergence", "taylor-theorem-oq-03"],
     "prerequisites": ["taylor-theorem-oq-03"]

--- a/src/data/proofs/taylor-theorem-oq-02/meta.json
+++ b/src/data/proofs/taylor-theorem-oq-02/meta.json
@@ -76,6 +76,14 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Preamble: OQ-02 Setup and Proof Architecture",
+      "startLine": 1,
+      "endLine": 55,
+      "summary": "Module docstring defining OQ-02 (does Taylor remainder vanish for analytic f?), the two-representation challenge (FPS vs Taylor series), and how the three-lemma bridge resolves it. Establishes contrast with smooth/C∞ case via Cauchy's exp(-1/x²) counterexample.",
+      "mathContext": "OQ-02 asks: if $f$ has `HasFPowerSeriesAt f p x_0`, does $\\sum_{k<n} \\frac{\\partial^k f}{\\partial x^k}(x_0)/k! \\cdot y^k \\to f(x_0 + y)$? The preamble frames this as a bridge: Mathlib gives `HasSum (p_n(y,\\ldots,y))` but the gallery expects `HasSum (\\partial^n f/n! \\cdot y^n)`. The two are equal term-by-term via multilinearity + the permutation-sum formula."
+    },
+    {
       "id": "multilinearity",
       "title": "Section 1: Multilinearity in 1D",
       "startLine": 57,


### PR DESCRIPTION
## Summary
- Added `mathContext` LaTeX fields to all 7 annotations in `taylor-theorem-oq-02` (0 → 10 quality pts)
- Fixed non-standard `significance: "technical"` → `"supporting"` in 2 annotations
- Added preamble section (lines 1–55) covering OQ-02 setup and proof architecture (4 → 5 sections)

## Files
- `src/data/proofs/taylor-theorem-oq-02/annotations.json`
- `src/data/proofs/taylor-theorem-oq-02/meta.json`

🤖 Generated by enricher-2