### PR TITLE
Fix: poincare-conjecture axiomCount corrected (33, not 32)

### DIFF
--- a/src/data/proofs/poincare-conjecture/meta.json
+++ b/src/data/proofs/poincare-conjecture/meta.json
@@ -16,8 +16,8 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 32,
-    "assumptions": "32 axioms. All are deep results in 3-manifold topology (Ricci flow, geometrization, surgery theory). `rp3_locallyEuclidean` (RP³ is locally Euclidean via gnomonic projection on hemispheres) is now a proved theorem, not an axiom. Standard Lean axioms: Classical, propext, funext.",
+    "axiomCount": 33,
+    "assumptions": "33 axioms. All are deep results in 3-manifold topology (Ricci flow, geometrization, surgery theory). `rp3_locallyEuclidean` (RP³ is locally Euclidean via gnomonic projection on hemispheres) is now a proved theorem, not an axiom. Standard Lean axioms: Classical, propext, funext.",
     "mathlibDependencies": [
       {
         "theorem": "SimplyConnectedSpace",
@@ -75,11 +75,11 @@
       "590 theorems proved, 137 structures defined, 218 definitions, 82 parts across 11574 lines"
     ],
     "leanFile": {
-      "lineCount": 17675,
+      "lineCount": 17670,
       "theoremCount": 897,
       "lemmaCount": 0,
       "defCount": 365,
-      "axiomCount": 32,
+      "axiomCount": 33,
       "sorryCount": 0,
       "structureCount": 183,
       "instanceCount": 21,
@@ -88,7 +88,7 @@
     },
     "dateAdded": "2025-12-29",
     "millenniumProblem": "poincare",
-    "lineCount": 17675,
+    "lineCount": 17670,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -336,8 +336,8 @@
       "ThurstonGeometry"
     ],
     "namespace": "PoincareConjecture",
-    "lineCount": 17675,
-    "axiomCount": 32,
+    "lineCount": 17670,
+    "axiomCount": 33,
     "theoremCount": 941,
     "definitionCount": 369,
     "path": "Proofs/PoincareConjecture.lean",


### PR DESCRIPTION
## Summary

- `axiomCount` was set to 32 in all three locations (`meta`, `meta.leanFile`, `leanFile`), but `grep -c "^axiom " proofs/Proofs/PoincareConjecture.lean` returns **33**
- `lineCount` was set to 17675 in all three locations, but `wc -l proofs/Proofs/PoincareConjecture.lean` returns **17670**
- Updated all occurrences of both values to match the actual Lean source file

## Changes

Single file edited: `src/data/proofs/poincare-conjecture/meta.json`
- `meta.axiomCount`: 32 → 33
- `meta.assumptions` string: "32 axioms" → "33 axioms"
- `meta.leanFile.axiomCount`: 32 → 33
- `meta.leanFile.lineCount`: 17675 → 17670
- `meta.lineCount`: 17675 → 17670
- `leanFile.axiomCount`: 32 → 33
- `leanFile.lineCount`: 17675 → 17670

## Test plan

- [ ] Verify `grep -c "^axiom " proofs/Proofs/PoincareConjecture.lean` returns 33
- [ ] Verify `wc -l proofs/Proofs/PoincareConjecture.lean` returns 17670
- [ ] Confirm no other gallery files reference the old counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)