### PR TITLE
Research: Erdős #263 session 1 — prove doubleExp_not_folklore_growth

### DIFF
--- a/proofs/Proofs/Stubs/Erdos263Problem.lean
+++ b/proofs/Proofs/Stubs/Erdos263Problem.lean
@@ -87,7 +87,27 @@ theorem folklore_irrationality (a : PosIntSeq)
     The irrationality of Σ 1/2^{2^n} follows instead from the Sylvester-type
     condition a_{n+1} ≈ a_n² (see doubleExp_sylvester_growth). -/
 theorem doubleExp_not_folklore_growth : ¬HasFolkloreGrowth doubleExp := by
-  sorry
+  intro h
+  -- Key computation: (2^{2^n})^{1/2^n} = 2^((2^n) * (1/2^n)) = 2^1 = 2
+  have hconst : ∀ n : ℕ, ((doubleExp n : ℕ) : ℝ) ^ (1 / (2 : ℝ) ^ n) = 2 := fun n => by
+    simp only [doubleExp, PNat.val_mk]
+    push_cast
+    -- Goal: ((2:ℝ)^(2^n:ℕ))^(1/2^n) = 2  [inner ^ is npow, outer ^ is rpow]
+    rw [← Real.rpow_natCast (2 : ℝ) (2 ^ n),
+        ← Real.rpow_mul (by norm_num : (0 : ℝ) ≤ 2)]
+    -- Goal: (2:ℝ)^(((2^n:ℕ):ℝ) * (1/2^n)) = 2
+    push_cast
+    -- Goal: (2:ℝ)^((2:ℝ)^n * (1/(2:ℝ)^n)) = 2
+    rw [one_div, mul_inv_cancel₀ (pow_ne_zero _ (by norm_num : (2 : ℝ) ≠ 0))]
+    exact Real.rpow_one 2
+  -- The function is constantly 2, so it cannot tend to ∞
+  have h2 : Filter.Tendsto (fun _ : ℕ => (2 : ℝ)) Filter.atTop Filter.atTop :=
+    h.congr (Filter.eventually_of_forall hconst)
+  -- Contradiction: constant 2 doesn't tend to ∞ (since 3 > 2)
+  have h3 : ∀ᶠ _ : ℕ in Filter.atTop, (3 : ℝ) ≤ 2 :=
+    Filter.tendsto_atTop.mp h2 3
+  obtain ⟨_, h4⟩ := h3.exists
+  norm_num at h4
 
 /-- For double exponential, a_{n+1} = a_n²: the sequence satisfies a_{n+1} = a_n².
     This implies irrationality of Σ 1/a_n by the Sylvester argument

--- a/research/problems/erdos-263/knowledge.md
+++ b/research/problems/erdos-263/knowledge.md
@@ -1,0 +1,66 @@
+# Knowledge Base: Erdős #263 - Irrationality Sequences
+
+## Problem Summary
+
+**Erdős #263**: A sequence (aₙ) of positive integers is an *irrationality sequence* if for every
+sequence (bₙ) with bₙ/aₙ → 1, the sum Σ 1/bₙ is irrational.
+
+**Questions**:
+1. Is aₙ = 2^{2^n} an irrationality sequence?
+2. Must every irrationality sequence satisfy aₙ^{1/n} → ∞?
+
+**Status**: OPEN. Kovač-Tao (2024) established that sequences with aₙ₊₁/aₙ² → 0 are NOT
+irrationality sequences. Both original questions remain open.
+
+---
+
+## Session 2026-04-13 (Session 1) — Initial Survey + First Proof
+
+**Mode**: FRESH (EMPTY knowledge tier)
+**Outcome**: progress — proved doubleExp_not_folklore_growth
+
+### What I Found
+
+The stub file `proofs/Proofs/Stubs/Erdos263Problem.lean` already existed (265 lines, 7 sorries, 0 axioms)
+with the full mathematical framework:
+- `IsIrrationalitySequence`: definition (Part II)
+- `doubleExp`: 2^{2^n} sequence (Part II)
+- `HasFolkloreGrowth`, `HasSuperexponentialGrowth`: growth conditions (Parts III-IV)
+- `HasKovacTaoCondition`: the 2024 negative result condition (Part V)
+- 2 proved theorems: `doubleExp_square_growth` (a_{n+1}=a_n²), `doubleExp_strictly_increasing`
+- 1 proved theorem: `doubleExp_convergent` (Σ 1/2^{2^n} converges by geometric comparison)
+
+### What I Proved
+
+**`doubleExp_not_folklore_growth`**: ¬HasFolkloreGrowth doubleExp
+
+Key insight: `(2^{2^n})^{1/2^n} = 2^{(2^n)*(1/2^n)} = 2^1 = 2` — the function is constantly 2,
+which cannot tend to ∞.
+
+Proof technique: `rpow_natCast` + `rpow_mul` to compute the exponent, then `Filter.tendsto_atTop`
+to extract the contradiction (constant 2 can't be ≥ 3 eventually).
+
+Also: `characterization_gap` depends on this theorem (proves ∃ a with superexponential but not
+folklore growth — witnessing with doubleExp). Since `doubleExp_superexponential` still has sorry,
+`characterization_gap` still has sorry.
+
+### Files Modified
+
+- `proofs/Proofs/Stubs/Erdos263Problem.lean` (265 → 285 lines, 7 → 6 sorries)
+- `src/data/proofs/erdos-263/meta.json` (sorries 7→6, lineCount 265→285)
+- `src/data/research/problems/erdos-263.json`
+
+### Remaining Sorries (6)
+
+1. `folklore_irrationality`: aₙ^{1/2^n} → ∞ ⟹ Σ 1/aₙ irrational (deep)
+2. `kovac_tao_not_irrationality`: The 2024 negative result (deep, non-trivial)
+3. `positive_condition_irrationality`: liminf aₙ₊₁/aₙ^{2+ε} > 0 ⟹ irrationality sequence (deep)
+4. `factorial_no_folklore_growth`: ¬HasFolkloreGrowth factorial_seq (routine)
+5. `doubleExp_superexponential`: HasSuperexponentialGrowth doubleExp (routine analysis)
+6. `truncation_insufficient`: Any finite truncation loses irrationality info (structural)
+
+### Next Steps
+
+1. Prove `doubleExp_superexponential`: (2^{2^n})^{1/n} = 2^{2^n/n} → ∞ since 2^n/n → ∞
+2. Prove `factorial_no_folklore_growth`: (n!)^{1/2^n} → 1 ≠ ∞ (Stirling or direct estimate)
+3. Submit remaining deep sorries to Aristotle (folklore, KT condition, positive condition)

--- a/src/data/proofs/erdos-263/meta.json
+++ b/src/data/proofs/erdos-263/meta.json
@@ -17,13 +17,13 @@
       "analysis"
     ],
     "badge": "wip",
-    "sorries": 7,
+    "sorries": 6,
     "erdosNumber": 263,
     "erdosUrl": "https://erdosproblems.com/263",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "lineCount": 265,
-    "assumptions": "No axioms. 7 sorry(s) remain in the formalization.",
+    "lineCount": 285,
+    "assumptions": "No axioms. 6 sorry(s) remain: folklore_irrationality, kovac_tao_not_irrationality, positive_condition_irrationality, factorial_no_folklore_growth, doubleExp_superexponential, truncation_insufficient.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/research/problems/erdos-263.json
+++ b/src/data/research/problems/erdos-263.json
@@ -1,0 +1,74 @@
+{
+  "slug": "erdos-263",
+  "title": "Erdős #263: Irrationality Sequences",
+  "phase": "ACT",
+  "status": "active",
+  "tier": "A",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "WIP: 7 sorries, 0 axioms.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "NEW",
+    "since": "2026-04-13T22:43:37.492Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "PROGRESS: Proved doubleExp_not_folklore_growth (sorry 7→6). Next: prove doubleExp_superexponential and factorial_no_folklore_growth.",
+    "builtItems": [
+      "doubleExp_not_folklore_growth: ¬HasFolkloreGrowth doubleExp — proved in proofs/Proofs/Stubs/Erdos263Problem.lean:89"
+    ],
+    "insights": [
+      "(2^{2^n})^{1/2^n} = 2^{(2^n)*(1/2^n)} = 2^1 = 2 — the function is constantly 2, so doubleExp does NOT satisfy the folklore condition",
+      "rpow_natCast + rpow_mul + mul_inv_cancel₀ + rpow_one are the key Lean lemmas for computing (2^{2^n})^{1/2^n} = 2",
+      "Filter.tendsto_atTop.mp extracts ∀ᶠ n, C ≤ f n from f → ∞; using C=3 and f(n)=2 gives contradiction",
+      "HasFolkloreGrowth requires aₙ^{1/2^n} → ∞; since (doubleExp n)^{1/2^n} = 2 constantly, doubleExp fails",
+      "characterization_gap theorem depends on doubleExp_superexponential (still sorry); proving it would show folklore condition is strictly stronger than superexponential growth"
+    ],
+    "mathlibGaps": [
+      "No elementary tendsto proof for 2^n/n → ∞ directly — need to go via Nat.log or exponential comparison for doubleExp_superexponential",
+      "folklore_irrationality requires deep irrationality criterion — not in Mathlib",
+      "kovac_tao_not_irrationality requires Kovač-Tao 2024 construction — not in Mathlib"
+    ],
+    "nextSteps": [
+      "Prove doubleExp_superexponential: (2^{2^n})^{1/n} = 2^{2^n/n} → ∞ since 2^n/n → ∞",
+      "Prove factorial_no_folklore_growth: (n!)^{1/2^n} → 1 ≠ ∞ (Stirling or direct estimate)",
+      "Submit kovac_tao_not_irrationality and folklore_irrationality to Aristotle as deep sorries"
+    ]
+  },
+  "tags": [
+    "erdos-problems",
+    "number-theory",
+    "irrationality",
+    "seeker-selected"
+  ],
+  "relatedProofs": [
+    "erdos-2",
+    "erdos-26",
+    "erdos-263"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-04-13T22:43:37.492Z",
+  "lastUpdate": "2026-04-13",
+  "significance": 7,
+  "tractability": 5
+}


### PR DESCRIPTION
## Summary

- Proved `doubleExp_not_folklore_growth : ¬HasFolkloreGrowth doubleExp` in `Erdos263Problem.lean`
- Reduces sorry count 7→6
- Created initial `knowledge.md` and `erdos-263.json` for problem tracking

## Math

The key insight: `(2^{2^n})^{1/2^n} = 2^{(2^n)·(1/2^n)} = 2^1 = 2` — the
folklore growth function is constantly 2, not tending to ∞.

Proof uses `Real.rpow_natCast` + `Real.rpow_mul` + `mul_inv_cancel₀` + `Real.rpow_one`
to compute the constant, then `Filter.tendsto_atTop.mp` to extract the contradiction
(constant 2 cannot satisfy `∀ᶠ n, 3 ≤ 2`).

## Remaining sorries (6)

1. `folklore_irrationality` — deep, needs irrationality criterion
2. `kovac_tao_not_irrationality` — Kovač-Tao 2024, deep
3. `positive_condition_irrationality` — deep
4. `factorial_no_folklore_growth` — routine (next target)
5. `doubleExp_superexponential` — routine analysis (next target)
6. `truncation_insufficient` — structural

🤖 Generated with [Claude Code](https://claude.ai/claude-code)