### PR TITLE
Enrichment: euler-totient-oq-02-oq-01 — mathContext for product formula annotations

### DIFF
--- a/src/data/proofs/euler-totient-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/euler-totient-oq-02-oq-01/annotations.json
@@ -6,6 +6,7 @@
     "type": "insight",
     "title": "Three Equivalent Forms of the Product Formula",
     "content": "Mathlib provides three equivalent formulations of the Euler product formula, each suited to different contexts:\n\n**Factorization form** (integer, `n.factorization.prod`):\n```\nφ(n) = n.factorization.prod (fun p k => p^(k-1) * (p-1))\n```\nBest for: algebraic manipulations, connecting to multiplicativity.\n\n**Rational form** (over ℚ, using `primeFactors`):\n```\n(φ(n) : ℚ) = n * ∏ p ∈ n.primeFactors, (1 - (p : ℚ)⁻¹)\n```\nBest for: density arguments, analytic number theory.\n\n**Division form** (integer, using radical):\n```\nφ(n) = (n / ∏ p ∈ n.primeFactors, p) * ∏ p ∈ n.primeFactors, (p-1)\n```\nBest for: pure integer arithmetic, avoiding coercions.\n\nAll three are in Mathlib as `Nat.totient_eq_prod_factorization`, `Nat.totient_eq_mul_prod_factors`, and `Nat.totient_eq_div_primeFactors_mul` respectively.",
+    "mathContext": "The three forms express the same identity differently: (1) $\\varphi(n) = \\prod_{p^k \\parallel n} p^{k-1}(p-1)$ as a `Finsupp.prod`; (2) $(\\varphi(n) : \\mathbb{Q}) = n \\cdot \\prod_{p \\in n.\\text{primeFactors}} (1 - p^{-1})$ over $\\mathbb{Q}$; (3) $\\varphi(n) = (n / \\prod_{p|n} p) \\cdot \\prod_{p|n}(p-1)$ as integers. All three come from the same mathematical content: the Mathlib lemmas `Nat.totient_eq_prod_factorization`, `Nat.totient_eq_mul_prod_factors`, `Nat.totient_eq_div_primeFactors_mul`.",
     "significance": "key",
     "relatedConcepts": ["Finsupp.prod", "primeFactors", "factorization", "radical"],
     "prerequisites": ["euler-totient-oq-02"]
@@ -17,7 +18,8 @@
     "type": "insight",
     "title": "The Product Formula Is Not Independent — It Follows from Multiplicativity + FTA",
     "content": "The theorem `totient_from_multiplicativity` makes explicit the logical dependency:\n\n```\nφ(n)\n  = φ(∏_{p|n} p^{v_p(n)})         [FTA: n = ∏ p^{v_p(n)}]\n  = ∏_{p|n} φ(p^{v_p(n)})         [multiplicativity]\n  = ∏_{p|n} p^{v_p(n)-1}(p-1)    [prime power formula]\n```\n\nThe Lean proof uses `Finsupp.prod_congr` to replace `(fun p k => p^(k-1)*(p-1))` with `(fun p k => Nat.totient (p^k))` in the Finsupp product, requiring:\n- Each `p` in `n.factorization.support` is prime: `Nat.prime_of_mem_primeFactors` after `Nat.support_factorization`\n- Each exponent is positive: `Nat.pos_of_ne_zero (Finsupp.mem_support_iff.mp hp)`\n- The prime power formula: `Nat.totient_prime_pow hprime hkpos`\n\nThis means the product formula is completely determined by three independently provable facts — it has no additional mathematical content beyond their combination.",
-    "significance": "highlight",
+    "mathContext": "Three-step derivation: (1) `Nat.factorization_prod_pow_eq_self` gives $n = \\prod_{p | n} p^{v_p(n)}$; (2) multiplicativity of $\\varphi$ (proved in the parent `euler-totient-oq-02`) gives $\\varphi(\\prod p^{k_p}) = \\prod \\varphi(p^{k_p})$ for pairwise-coprime factors; (3) `Nat.totient_prime_pow` gives $\\varphi(p^k) = p^{k-1}(p-1)$ for $p$ prime, $k \\ge 1$. `Finsupp.prod_congr` applies (3) to each factor of the Finsupp product from (1).",
+    "significance": "key",
     "relatedConcepts": ["Finsupp.prod_congr", "Nat.totient_prime_pow", "Nat.support_factorization"],
     "prerequisites": ["euler-totient-oq-02", "Nat.factorization_prod_pow_eq_self"]
   },
@@ -28,6 +30,7 @@
     "type": "insight",
     "title": "Totient Density Depends Only on the Radical",
     "content": "The theorem `totient_density_same_support` captures a striking fact:\n\n> If `m.primeFactors = n.primeFactors`, then `φ(m)/m = φ(n)/n`.\n\nIn other words, **the totient density is determined by the set of primes dividing n**, not by their exponents. This means:\n- `φ(2)/2 = φ(4)/4 = φ(8)/8 = φ(16)/16 = ... = 1/2`\n- `φ(6)/6 = φ(12)/12 = φ(18)/18 = φ(36)/36 = ... = 1/3`\n- `φ(30)/30 = φ(60)/60 = φ(90)/90 = ... = 4/15`\n\nThe proof is immediate from `totient_density`: both sides equal `∏ p ∈ primeFactors, (1 - 1/p)`, which is the same when `primeFactors` are equal.\n\nThe number-theoretic interpretation: the radical `rad(n) = ∏ p` (product of distinct primes) determines the long-run density of integers coprime to n. Increasing exponents in the factorization just scales n proportionally without changing the fraction of coprimes.",
+    "mathContext": "`totient_density_same_support`: if $m.\\text{primeFactors} = n.\\text{primeFactors}$, then $\\varphi(m)/m = \\varphi(n)/n$ (as rationals). Proof: $\\varphi(m)/m = \\prod_{p \\in m.\\text{primeFactors}} (1-1/p) = \\prod_{p \\in n.\\text{primeFactors}} (1-1/p) = \\varphi(n)/n$ by rewriting with the hypothesis. The `primeFactors` condition is equivalent to $\\text{rad}(m) = \\text{rad}(n)$.",
     "significance": "key",
     "relatedConcepts": ["primeFactors", "radical", "totient density", "squarefree"],
     "prerequisites": []
@@ -39,7 +42,8 @@
     "type": "technique",
     "title": "Finsupp.prod_congr: Changing the Function in a Finsupp Product",
     "content": "When you have a Finsupp product and want to replace the function argument, use `Finsupp.prod_congr`:\n\n```lean\napply Finsupp.prod_congr\nintro p hp\n-- hp : p ∈ f.support\n-- goal: g p (f p) = h p (f p)\n```\n\nThis reduces a goal `f.prod g = f.prod h` to showing `g x (f x) = h x (f x)` for each `x ∈ f.support`.\n\nFor the factorization specifically, membership in `n.factorization.support` gives:\n1. Primality: `Nat.prime_of_mem_primeFactors (Nat.support_factorization n ▸ hp)`\n2. Positive exponent: `Nat.pos_of_ne_zero (Finsupp.mem_support_iff.mp hp)`\n\nNote: `Nat.support_factorization` is a `@[simp]` lemma: `n.factorization.support = n.primeFactors`.",
-    "significance": "technique",
+    "mathContext": "`Finsupp.prod_congr`: if $\\forall x \\in f.\\text{support},\\, g\\,x\\,(f\\,x) = h\\,x\\,(f\\,x)$, then $f.\\text{prod}\\,g = f.\\text{prod}\\,h$. Here $f = n.\\text{factorization}$, $g = \\lambda p\\, k.\\, p^{k-1}(p-1)$, $h = \\lambda p\\, k.\\, \\varphi(p^k)$. For each $p \\in n.\\text{factorization.support}$, `Nat.totient_prime_pow` gives $\\varphi(p^k) = p^{k-1}(p-1)$ once we know $p$ is prime and $k > 0$.",
+    "significance": "supporting",
     "relatedConcepts": ["Finsupp.prod_congr", "Nat.support_factorization", "Finsupp.mem_support_iff"],
     "prerequisites": []
   },
@@ -50,7 +54,8 @@
     "type": "technique",
     "title": "Deriving the Density Form from the Rational Form",
     "content": "The density `φ(n)/n = ∏(1-1/p)` follows from the rational formula `(φ(n) : ℚ) = n * ∏(1-1/p)` by a one-step algebraic manipulation:\n\n```lean\ntheorem totient_density (n : ℕ) (hn : n ≠ 0) :\n    (Nat.totient n : ℚ) / n = ∏ p ∈ n.primeFactors, (1 - (p : ℚ)⁻¹) := by\n  have hn' : (n : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr hn\n  rw [totient_rational_formula, mul_div_assoc, div_self hn', mul_one]\n```\n\nThe key steps:\n- `mul_div_assoc`: `n * ∏(...) / n = n * (∏(...) / n)` — but actually this splits the division\n- `div_self hn'`: `n / n = 1`\n- `mul_one`: `1 * ∏(...) = ∏(...)`\n\nThis pattern (divide a rational product by a non-zero cast) is common when working with density formulas in number theory.",
-    "significance": "technique",
+    "mathContext": "Starting from $\\varphi(n) = n \\cdot \\prod_{p|n}(1-1/p)$ (rational form), dividing both sides by $n \\neq 0$: $\\varphi(n)/n = \\prod_{p|n}(1-1/p)$. In Lean: `mul_div_assoc` + `div_self` + `mul_one`. The `Nat.cast_ne_zero.mpr hn` converts the hypothesis `n ≠ 0 : ℕ` to `(n : ℚ) ≠ 0` for the `div_self` step.",
+    "significance": "supporting",
     "relatedConcepts": ["mul_div_assoc", "div_self", "Nat.cast_ne_zero"],
     "prerequisites": []
   }


### PR DESCRIPTION
## Summary
- Added `mathContext` LaTeX fields to all 5 annotations in `euler-totient-oq-02-oq-01`
- Fixed significance: `"highlight"` → `"key"` in derivation annotation
- Annotations cover: three product formula forms (factorization/rational/division), FTA+multiplicativity derivation chain, totient density = radical invariant, `Finsupp.prod_congr` technique, density/rational form conversion

## Files
- `src/data/proofs/euler-totient-oq-02-oq-01/annotations.json`

🤖 Generated by enricher-2