### PR TITLE
Fix: badge axiom→wip for erdos-456 and erdos-1051

### DIFF
--- a/src/data/proofs/erdos-1051/meta.json
+++ b/src/data/proofs/erdos-1051/meta.json
@@ -15,7 +15,7 @@
       "series",
       "transcendence-theory"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 0,
     "erdosNumber": 1051,
     "erdosUrl": "https://erdosproblems.com/1051",

--- a/src/data/proofs/erdos-456/meta.json
+++ b/src/data/proofs/erdos-456/meta.json
@@ -18,7 +18,7 @@
       "natural-density",
       "open-problem"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 0,
     "erdosNumber": 456,
     "erdosUrl": "https://erdosproblems.com/456",


### PR DESCRIPTION
## Fix

Two gallery entries have `badge: "axiom"` but `axiomCount: 0` — an integrity violation.

## Evidence

### erdos-456
- **Before**: `badge: "axiom"`, `axiomCount: 0`, `sorries: 0`
- **After**: `badge: "wip"`, `axiomCount: 0`, `sorries: 0`
- **Why**: All 12 original axioms were eliminated and proved from Mathlib. The Lean file header states: "Final: 0 axioms, 0 sorries. All infrastructure fully verified." The badge was never updated after the axiom reduction. Open conjectures are `Prop` definitions, not `axiom` declarations.

### erdos-1051
- **Before**: `badge: "axiom"`, `axiomCount: 0`, `sorries: 0`
- **After**: `badge: "wip"`, `axiomCount: 0`, `sorries: 0`
- **Why**: Open problem formalization with no axiom declarations. Main conjecture `ErdosProblem1051` is a `Prop` definition, not an `axiom`.

## Rationale

Per gallery definitions: `badge: "axiom"` requires actual `axiom` declarations OR structure-encoded assumptions. With `axiomCount: 0` and `sorries: 0`, the correct badge is `"wip"` for open-problem formalizations. This is consistent with 176 other proofs using `wip + axiomatized` for the same pattern.

---
Automated fix by lean-mechanic agent.