### PR TITLE
Research: erdos-817 — g3_le_exp explicit witness, base-3 AP-free proof outline

### DIFF
--- a/proofs/Proofs/Erdos817Problem.lean
+++ b/proofs/Proofs/Erdos817Problem.lean
@@ -176,12 +176,43 @@ theorem g_ge_n (k n : ℕ) (hk : k ≥ 3) (hn : n ≥ 1) : g k n ≥ n := by
         _ = N := by simp [Nat.card_Icc]
     omega
 
-/-- An upper bound: g_3(n) ≤ 3^n (trivially, using {1, 3, 9, ..., 3^(n-1)}). -/
+/-- 3^i is strictly increasing (needed for injectivity). -/
+private lemma pow3_strictMono : StrictMono (fun i : ℕ => (3 : ℕ)^i) :=
+  fun _ _ h => Nat.pow_lt_pow_right (by norm_num) h
+
+/-- An upper bound: g_3(n) ≤ 3^n, using A = {1, 3, 9, ..., 3^(n-1)}.
+
+    Mathematical key: the subset sums of A = {3^0, ..., 3^{n-1}} are the base-3
+    numbers with digits in {0,1}. No 3 of them form an arithmetic progression.
+
+    Proof of AP-freeness: if a, a+d, a+2d are base-3 {0,1}-numbers with d > 0,
+    then a + (a+2d) = 2(a+d). Comparing base-3 digits position-by-position:
+    at position i the contribution is [i∈S] + [i∈U] = 2[i∈T] (no carry since ≤2 < 3),
+    hence [i∈S] = [i∈T] = [i∈U] for all i, giving S = T, so d = 0. ↯ -/
 theorem g3_le_exp (n : ℕ) (hn : n ≥ 1) : g 3 n ≤ 3^n := by
-  -- The set {1, 3, 9, ..., 3^(n-1)} works
-  -- Its subset sums are all numbers in base 3 with digits 0 or 1
-  -- This is a Sidon-like set avoiding 3-APs
-  sorry
+  -- Witness: A = {1, 3, 9, ..., 3^(n-1)}
+  let A := (Finset.range n).image (fun i => (3 : ℕ)^i)
+  have hA_sub : A ⊆ Finset.Icc 1 (3^n) := by
+    intro x hx
+    simp only [A, Finset.mem_image, Finset.mem_range] at hx
+    obtain ⟨i, hi, rfl⟩ := hx
+    exact Finset.mem_Icc.mpr ⟨Nat.one_le_pow i 3 (by norm_num),
+      Nat.pow_le_pow_right (by norm_num) (by omega)⟩
+  have hA_card : A.card = n := by
+    simp only [A, Finset.card_image_of_injective _ pow3_strictMono.injective,
+               Finset.card_range]
+  -- AP-freeness of subsetSums A: the base-3 digit uniqueness argument.
+  -- Elements of subsetSums A are ∑_{j∈J} 3^j for J ⊆ range n.
+  -- If a + (a+2d) = 2(a+d) with all three in subsetSums A, digit comparison gives d = 0.
+  have hA_free : IsAPFreeOfLength 3 (subsetSums A : Set ℕ) := by
+    sorry
+    /- Proof outline (for future formalization):
+       Let S, T, U ⊆ range n give a = f(S), a+d = f(T), a+2d = f(U) via f(J) = ∑_{j∈J} 3^j.
+       From a + (a+2d) = 2(a+d): f(S) + f(U) = 2*f(T).
+       At each position i: [i∈S] + [i∈U] = 2*[i∈T] (no carry: LHS ≤ 2 < 3).
+       So [i∈S] = [i∈T] = [i∈U] for all i, giving S = U = T.
+       Thus d = f(T) - f(S) = 0. Contradiction with d > 0. -/
+  exact Nat.sInf_le ⟨A, hA_sub, hA_card, hA_free⟩
 
 /-
 ## Examples for Small Cases

--- a/src/data/research/problems/erdos-817.json
+++ b/src/data/research/problems/erdos-817.json
@@ -1,13 +1,13 @@
 {
   "slug": "erdos-817",
-  "title": "Erd\u0151s Problem #817: Subset Sum Sets and Arithmetic Progressions",
+  "title": "Erdős Problem #817: Subset Sum Sets and Arithmetic Progressions",
   "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
   "problemStatement": {
-    "formal": "Let g_k(n) = min N such that \u2203 A \u2286 {1,...,N}, |A|=n, IsAPFreeOfLength k (subsetSums A). Is g_3(n) \u226b 3^n?",
-    "plain": "PROGRESS: 4\u21922 sorries. g3_one proved, g3_two corrected (value is 3 not 2), g_ge_n structure filled. 0 axioms.",
+    "formal": "Let g_k(n) = min N such that ∃ A ⊆ {1,...,N}, |A|=n, IsAPFreeOfLength k (subsetSums A). Is g_3(n) ≫ 3^n?",
+    "plain": "PROGRESS: 4→2 sorries. g3_one proved, g3_two corrected (value is 3 not 2), g_ge_n structure filled. 0 axioms.",
     "whyMatters": []
   },
   "knownResults": {
@@ -29,28 +29,30 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 4\u21922 sorries in Erdos817Problem.lean. g3_one proved (subsetSums {1}={0,1} by decide, 3-AP-free by interval_cases). g3_two CORRECTED from =2 to =3 with full proof. g_ge_n structure filled (sorry only for nonemptiness). g3_le_exp still sorry (hard: needs carry argument for base-3 AP-freeness).",
+    "progressSummary": "PROGRESS: 2 sorries remaining in Erdos817Problem.lean (session 2). g3_le_exp: explicit witness A={3^0,...,3^{n-1}} provided with A⊆Icc 1 (3^n) and |A|=n proved; sorry only for AP-freeness. g_ge_n: sorry for nonemptiness only. Base-3 digit no-carry proof strategy documented.",
     "builtItems": [
-      "g3_one: proved g 3 1 = 1 (Erdos817Problem.lean:191-219)",
-      "g3_two: corrected to g 3 2 = 3 with full proof, including hfail2 (only valid N for n=2 requires N\u22653)",
-      "g_ge_n: structural proof with sorry only for nonemptiness of ValidNs k n"
+      "g3_one: proved g 3 1 = 1 (Erdos817Problem.lean:222-250)",
+      "g3_two: corrected to g 3 2 = 3 with full proof, including hfail2",
+      "g_ge_n: structural proof with sorry only for nonemptiness of ValidNs k n",
+      "g3_le_exp: witness A=(range n).image (3^.) provided; hA_sub and hA_card proved; pow3_strictMono helper; AP-free sorry with complete proof outline"
     ],
     "insights": [
-      "g3_two = 3 (not 2 as originally stated): {1,2}\u2286{1,...,2} has sums {0,1,2,3} containing 3-AP; {1,3}\u2286{1,...,3} has sums {0,1,3,4} which is 3-AP-free",
-      "subsetSums {A} = {B.sum id : B \u2286 A} \u2014 can be computed by decide for small A (e.g., subsetSums {1} = {0,1}, subsetSums {1,3} = {0,1,3,4})",
-      "IsAPFreeOfLength 3 on finite numeric sets: proved by rcases (a\u22655 | d\u22655 | both small) + interval_cases a <;> interval_cases d + first|exact\u27e80,...\u27e9|exact\u27e81,...\u27e9|exact\u27e82,...\u27e9",
-      "g_ge_n structure: Nat.le_sInf needs nonemptiness + (\u2200 N \u2208 ValidNs, N \u2265 n). Easy part: N \u2265 n by card_le_card + Nat.card_Icc. Hard part: nonemptiness requires explicit AP-free set",
-      "g_ge_n nonemptiness: likely provable using geometric set {k^0,...,k^{n-1}} but AP-freeness of base-k {0,1}-digit numbers needs a carry/positional argument"
+      "g3_two = 3 (not 2 as originally stated): {1,2} has sums {0,1,2,3} containing 3-AP; {1,3} has sums {0,1,3,4} which is 3-AP-free",
+      "subsetSums: can be computed by decide for small A",
+      "IsAPFreeOfLength 3 on finite sets: proved by interval_cases a <;> interval_cases d pattern",
+      "g_ge_n structure: Nat.le_sInf needs nonemptiness + (forall N in ValidNs, N >= n)",
+      "KEY INSIGHT for AP-freeness of {3^0,...,3^{n-1}} sums: if a, a+d, a+2d all have base-3 {0,1}-digits, then a+(a+2d)=2(a+d). At each position i: [i in S]+[i in U]=2[i in T] (NO carry since <=2<3). Therefore [i in S]=[i in T]=[i in U] for all i, giving S=T, so d=0.",
+      "Witness bounds: 3^i>=1 (Nat.one_le_pow), 3^i<=3^n for i<n (Nat.pow_le_pow_right), |image of 3^. on range n| = n (Finset.card_image_of_injective + StrictMono.injective)"
     ],
     "mathlibGaps": [
-      "Nonemptiness of ValidNs k n for general k\u22653, n\u22651 \u2014 needs AP-free set construction (base-k geometric set)",
-      "g3_le_exp: upper bound g_3(n) \u2264 3^n \u2014 needs showing {3^0,...,3^{n-1}} subset sums are 3-AP-free (positional/carry argument)"
+      "AP-freeness of subsetSums({3^0,...,3^{n-1}}): needs digit uniqueness for base-3 addition of {0,1}-digit numbers",
+      "Nonemptiness of ValidNs k n: follows from g3_le_exp once AP-freeness is proved"
     ],
     "nextSteps": [
-      "Try proving nonemptiness of ValidNs 3 n using A = {3^0,...,3^{n-1}} \u2286 Icc 1 (3^n)",
-      "For AP-freeness of geometric set sums: use induction on n, with the observation that the nth element 3^{n-1} creates a gap too large for any AP to bridge",
-      "Alternative for g_ge_n: state as hypothesis or use a separate lemma validSet_exists (k n : \u2115) : \u2203 N, N \u2208 ValidNs k n",
-      "Submit g_ge_n nonemptiness sorry to Aristotle \u2014 it may be within reach via Finset induction"
+      "Prove AP-freeness of subsetSums({3^0,...,3^{n-1}}) using digit no-carry argument",
+      "Key subgoal: if sum_{i in S} 3^i + sum_{i in U} 3^i = 2*sum_{i in T} 3^i with S,T,U subsets of range n, then S=T=U",
+      "Submit hA_free sorry to Aristotle with proof outline as hint",
+      "Once g3_le_exp proved, derive g_ge_n nonemptiness from k=3 case"
     ]
   },
   "tags": [
@@ -88,7 +90,7 @@
     {
       "path": "Proofs/Erdos817Problem.lean",
       "filename": "Erdos817Problem.lean",
-      "lineCount": 280,
+      "lineCount": 368,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 8,


### PR DESCRIPTION
## Summary

Session 2 progress on Erdős #817 (subset sum sets and arithmetic progressions):

- **g3_le_exp**: Provide explicit witness `A = {1,3,...,3^{n-1}}` with two steps fully proved:
  - `hA_sub`: `A ⊆ Icc 1 (3^n)` — via `Nat.one_le_pow` + `Nat.pow_le_pow_right`
  - `hA_card`: `|A| = n` — via `Finset.card_image_of_injective` + `pow3_strictMono`
  - `pow3_strictMono`: `StrictMono (fun i => 3^i)` fully proved (no sorry)
  - `hA_free`: 1 sorry with complete mathematical proof outline

- **Mathematical insight documented**: The base-3 digit no-carry argument shows AP-freeness:
  > If a, a+d, a+2d are all base-3 {0,1}-digit numbers, then `a+(a+2d) = 2(a+d)`.
  > At position i: `[i∈S]+[i∈U] = 2[i∈T]` (no carry since sum ≤ 2 < 3).
  > So `[i∈S]=[i∈T]=[i∈U]` for all i → S=T → d=0. Contradiction with d>0.

## Prior work (already in main)
- `g3_one`: proved `g 3 1 = 1`
- `g3_two`: corrected from `= 2` to `= 3` with full proof

## Remaining sorries (2)
1. `g_ge_n` nonemptiness of `ValidNs k n` (needs AP-free construction)  
2. `hA_free` AP-freeness of `subsetSums {1,3,...,3^{n-1}}` (digit uniqueness formalization)

## Test plan
- [ ] Docker build: `./proofs/scripts/docker-build.sh Proofs.Erdos817Problem`
- [ ] Verify sorry count = 2 (unchanged from session 1)
- [ ] Verify new helper `pow3_strictMono` compiles (no sorry)
- [ ] Verify `hA_sub` and `hA_card` proofs compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)