### PR TITLE
Audit: fix sorry count mismatches in 4 gallery proofs

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -14,10 +14,10 @@
       "measure-theory"
     ],
     "badge": "formalized",
-    "sorries": 4,
+    "sorries": 3,
     "axiomCount": 0,
     "lineCount": 460,
-    "assumptions": "4 remaining sorries: (1) truncated_rn_deriv_lq_bound — Hölder extremizer for truncations, (2) rn_deriv_memLq — Fatou from truncation bounds, (3) indicator case type-matching in Lp.induction, (4) riesz_lp_surjective_from_rn — signed measure construction. Proved: integrationCLM linear map + continuity bound, integrationCLM_apply, lintegral_mul_le_of_memLp, integrable_mul_of_memLp, truncated_rn_deriv_memLq, Lp.induction addition + closedness cases.",
+    "assumptions": "3 remaining sorries: (1) truncated_rn_deriv_lq_bound — Hölder extremizer for truncations, (2) rn_deriv_memLq — Fatou from truncation bounds, (3) riesz_lp_surjective_from_rn — signed measure construction. Proved: integrationCLM linear map + continuity bound, integrationCLM_apply, lintegral_mul_le_of_memLp, integrable_mul_of_memLp, truncated_rn_deriv_memLq, Lp.induction addition + closedness cases.",
     "dateAdded": "2026-04-13"
   },
   "overview": {
@@ -128,6 +128,6 @@
       }
     ],
     "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-    "sorries": 4
+    "sorries": 3
   }
 }

--- a/src/data/proofs/erdos-109-oq-01/meta.json
+++ b/src/data/proofs/erdos-109-oq-01/meta.json
@@ -17,10 +17,10 @@
       "ip-sets"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 3,
     "dateAdded": "2026-04-12",
     "axiomCount": 4,
-    "assumptions": "4 axioms: (1) upperDensity_shift — shift invariance of upper density (standard, needs careful Filter.limsup manipulation); (2) hindman_theorem — Hindman 1974 finite coloring gives monochromatic IP set; (3) posUpperDensity_piecewiseSyndetic — positive density implies piecewise syndetic (classical, pigeonhole); (4) posUpperDensity_ipStar — positive density implies IP* (Furstenberg-Katznelson IP Szemerédi 1985).",
+    "assumptions": "1 formal axiom + 3 sorry'd theorems (counted as 4 total assumptions): (1) hindman_theorem — formal axiom; Hindman 1974 finite coloring gives monochromatic IP set; (2) upperDensity_shift — sorry; shift invariance of upper density (needs Filter.limsup manipulation); (3) posUpperDensity_piecewiseSyndetic — sorry; positive density implies piecewise syndetic (classical, pigeonhole); (4) posUpperDensity_ipStar — sorry; positive density implies IP* (Furstenberg-Katznelson IP Szemerédi 1985).",
     "lineCount": 413,
     "theoremCount": 7,
     "definitionCount": 10,
@@ -101,7 +101,7 @@
     "theoremCount": 7,
     "definitionCount": 10,
     "path": "Proofs/Erdos109OQ01.lean",
-    "sorries": 0
+    "sorries": 3
   },
   "crossReferences": [
     {
@@ -110,5 +110,5 @@
       "description": "Explores gap conditions for the sumset conjecture proved by MRR (2019)"
     }
   ],
-  "sorries": 0
+  "sorries": 3
 }

--- a/src/data/proofs/erdos-817/meta.json
+++ b/src/data/proofs/erdos-817/meta.json
@@ -17,7 +17,7 @@
       "extremal-combinatorics"
     ],
     "badge": "wip",
-    "sorries": 4,
+    "sorries": 2,
     "erdosNumber": 817,
     "erdosUrl": "https://erdosproblems.com/817",
     "erdosProblemStatus": "open",
@@ -59,7 +59,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 232,
-    "assumptions": "2 axiom(s) and 4 sorry(s). See the Lean source for details."
+    "assumptions": "0 formal axioms; 2 sorry(s) (g_ge_n bound and g3_le_exp exponential bound). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "This problem combines two fundamental concepts in additive combinatorics: subset sums and arithmetic progression avoidance. The subset sum set ⟨A⟩ of a finite set A is the collection of all possible sums formed by selecting subsets of A. This structure appears throughout number theory and combinatorics.\n\nErdős and Sárközy studied the function g_k(n): the minimal N such that {1,...,N} contains some n-element set A whose subset sums avoid non-trivial k-term arithmetic progressions. They proved that g₃(n) ≫ 3ⁿ/n^{O(1)}, establishing exponential growth up to polynomial factors.\n\nThe main conjecture asks whether the polynomial factor is necessary: is g₃(n) truly ≫ 3ⁿ? This remains open and connects to deep questions about the structure of subset sum sets and Szemerédi-type theorems.",
@@ -207,7 +207,7 @@
     "theoremCount": 11,
     "definitionCount": 8,
     "path": "Proofs/Erdos817Problem.lean",
-    "sorries": 4
+    "sorries": 2
   },
   "crossReferences": [
     {

--- a/src/data/proofs/pascals-hexagon/meta.json
+++ b/src/data/proofs/pascals-hexagon/meta.json
@@ -19,7 +19,7 @@
       "classic"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "Mathlib.LinearAlgebra.CrossProduct",
@@ -46,7 +46,7 @@
     ],
     "dateAdded": "2025-12-29",
     "leanFile": {
-      "lineCount": 767,
+      "lineCount": 1165,
       "structures": 1,
       "axioms": 1,
       "theorems": 26,
@@ -54,8 +54,8 @@
       "instances": 0
     },
     "axiomCount": 1,
-    "lineCount": 767,
-    "assumptions": "1 axiom (conic_implies_pascal_constraint). 0 sorries — all theorems proved.",
+    "lineCount": 1165,
+    "assumptions": "1 axiom (conic_implies_pascal_constraint). 1 sorry in proof_sketch_conic_implies_pascal (pending Sylvester's law for the standard conic reduction).",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -225,12 +225,12 @@
       "Matrix"
     ],
     "namespace": null,
-    "lineCount": 767,
+    "lineCount": 1165,
     "axiomCount": 1,
     "theoremCount": 21,
     "definitionCount": 24,
     "path": "Proofs/PascalsHexagon.lean",
-    "sorries": 0
+    "sorries": 1
   },
   "references": [
     {


### PR DESCRIPTION
## Summary

Gallery integrity audit — sorry count fields were outdated in 4 proofs:

- **pascals-hexagon**: `sorries: 0→1` — `proof_sketch_conic_implies_pascal` has 1 sorry (Sylvester's law pending); lineCount synced `767→1165`
- **erdos-817**: `sorries: 4→2` — only `g_ge_n` and `g3_le_exp` remain; assumptions text updated
- **cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01**: `sorries: 4→3` — one sorry was resolved (indicator case in Lp.induction); assumptions text updated
- **erdos-109-oq-01**: `sorries: 0→3` — clarified: 1 formal axiom + 3 sorry'd theorems; all 4 counted in axiomCount=4

All statuses (`axiomatized`, `formalized`) and badges remain correct — only the `sorries` count fields and associated `assumptions` text were outdated.

## Audit Trail

All 4 proofs marked `issues-fixed` in `audit-tracker.json` (committed separately).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)