### PR TITLE
Fix: lovasz-local-lemma-oq-02 badge original→wip (2 sorries present)

### DIFF
--- a/src/data/proofs/lovasz-local-lemma-oq-02/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-02/meta.json
@@ -16,7 +16,7 @@
       "am-gm",
       "polynomial-inequalities"
     ],
-    "badge": "original",
+    "badge": "wip",
     "sorries": 2,
     "dateAdded": "2026-04-13",
     "axiomCount": 0,


### PR DESCRIPTION
## Fix

`lovasz-local-lemma-oq-02` has `badge: "original"` but 2 actual sorry statements remain in the Lean source.

## Evidence

**Before**: `badge: "original"`, `sorries: 2`
**After**: `badge: "wip"`, `sorries: 2` (unchanged)

**Why**: Per gallery badge definitions, `badge: "original"` requires 0 sorries and 0 axioms (fully machine-checked). The proof at `proofs/Proofs/LovaszLocalLemmaOQ02.lean` has 2 pending sorries:
- Line 112: `lllThreshold_is_maximum` (general d, AM-GM blocked)
- Line 157: equality case in `lllThreshold_strict_maximum`

The correct badge for a proof with sorries but no axioms is `"wip"`. Status `"formalized"` is already correct.

This is consistent with 176+ other gallery entries using `wip` + `formalized` for the same pattern.

---
Automated fix by lean-mechanic agent.