### PR TITLE
Fix: sync stale top-level sorries in erdos-263 and erdos-817

### DIFF
--- a/src/data/proofs/erdos-263/meta.json
+++ b/src/data/proofs/erdos-263/meta.json
@@ -164,7 +164,7 @@
     "theoremCount": 11,
     "definitionCount": 19,
     "path": "Proofs/Stubs/Erdos263Problem.lean",
-    "sorries": 7
+    "sorries": 6
   },
   "crossReferences": [
     {
@@ -226,5 +226,5 @@
       "note": "Growth lower bounds for irrationality sequences, connected to Problem #262"
     }
   ],
-  "sorries": 7
+  "sorries": 6
 }

--- a/src/data/proofs/erdos-817/meta.json
+++ b/src/data/proofs/erdos-817/meta.json
@@ -226,5 +226,5 @@
       "description": "Related Erdős problem sharing themes: additive-combinatorics, arithmetic-progressions"
     }
   ],
-  "sorries": 4
+  "sorries": 2
 }


### PR DESCRIPTION
## Fix

Two gallery entries have stale top-level `sorries` fields that were not updated when recent research PRs proved theorems.

## Evidence

### erdos-263
- **Before**: `leanFile.sorries: 7`, top-level `sorries: 7`
- **After**: `leanFile.sorries: 6`, top-level `sorries: 6`
- **Why**: PR #10665 proved `doubleExp_not_folklore_growth` (7→6 sorries), updating `meta.sorries` to 6 but leaving `leanFile.sorries` and top-level `sorries` at 7.

### erdos-817
- **Before**: top-level `sorries: 4`
- **After**: top-level `sorries: 2`
- **Why**: PRs #10671/#10672 reduced sorry count to 2; `meta.sorries` and `leanFile.sorries` were already updated to 2 but top-level field was missed.

---
Automated fix by lean-mechanic agent.