### PR TITLE
Fix: brouwer-fixed-point-oq-04-oq-04 sorries 1→0 (proved in PR #10674)

### DIFF
--- a/src/data/proofs/brouwer-fixed-point-oq-04-oq-04/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-04-oq-04/meta.json
@@ -17,7 +17,7 @@
       "game-theory"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "axioms": 1,
     "dateAdded": "2026-04-12",
     "dateUpdated": "2026-04-12",
@@ -25,7 +25,7 @@
     "lineCount": 368,
     "theoremCount": 12,
     "defCount": 2,
-    "assumptions": "1 axiom (scarf_approx_fixed_point — Scarf's n-dimensional algorithm via Sperner's lemma, with full proof sketch). 0 sorry (LSC/USC limit arguments in approx_fp_limit_1d via all_goals sorry, standard analysis).",
+    "assumptions": "1 axiom (scarf_approx_fixed_point — Scarf's n-dimensional algorithm via Sperner's lemma, with full proof sketch). 0 sorries.",
     "originalContributions": [
       "IsApproxFixedPoint: ε-approximate fixed point definition",
       "discrete_ivt_real: Discrete IVT for ℝ (PROVED by induction)",
@@ -143,7 +143,7 @@
     "axiomCount": 1,
     "theoremCount": 12,
     "definitionCount": 2,
-    "sorries": 1
+    "sorries": 0
   },
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

`brouwer-fixed-point-oq-04-oq-04` has `sorries: 1` in meta.json, but the Lean source has 0 actual sorry statements.

## Evidence

**Before**: `sorries: 1`, `assumptions: "...0 sorry (LSC/USC limit arguments in approx_fp_limit_1d via all_goals sorry...)"`
**After**: `sorries: 0`, `assumptions: "1 axiom (...). 0 sorries."`

**Verified**: `grep -in 'sorry' proofs/Proofs/BrouwerFixedPointOQ04OQ04.lean` returns only the doc comment at line 400 ("Sorry count: 2" — stale comment from before the proof). Zero actual sorry tactics remain.

**Root cause**: PR #10674 resolved the sorries but meta.json was not updated.

The 1 axiom (`scarf_approx_fixed_point`) remains. Badge `"axiom"` and status `"axiomatized"` are still correct.

---
Automated fix by lean-mechanic agent.