### PR TITLE
Fix: erdos-748 sorry count 4→1 in meta.json

### DIFF
--- a/src/data/proofs/erdos-748/meta.json
+++ b/src/data/proofs/erdos-748/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 1,
     "erdosNumber": 748,
     "erdosUrl": "https://erdosproblems.com/748",
     "erdosProblemStatus": "solved",
@@ -60,7 +60,7 @@
     ],
     "axiomCount": 3,
     "lineCount": 279,
-    "assumptions": "3 axiom(s) and 4 sorries. See the Lean source for details."
+    "assumptions": "3 axiom(s) and 1 sorry. See the Lean source for details."
   },
   "overview": {
     "historicalContext": "Peter Cameron and Paul Erdős conjectured that the number $f(n)$ of sum-free subsets of $\\{1, \\ldots, n\\}$ satisfies $f(n) = 2^{(1+o(1))n/2}$, meaning the trivial lower bound from the upper half construction is essentially tight. The lower bound $f(n) \\ge 2^{\\lfloor n/2 \\rfloor}$ is elementary: any subset of $\\{\\lceil n/2 \\rceil, \\ldots, n\\}$ is sum-free since all pairwise sums exceed $n$. The conjecture was resolved independently by Ben Green (2004, Bull. London Math. Soc.) and Alexander Sapozhenko (2003, Dokl. Akad. Nauk). Green's proof introduced a proto-container argument: he showed that sum-free subsets are 'almost contained' in structured templates — either subsets of the upper half or subsets of odd numbers — and bounded the template count. This structural insight anticipated the Balogh-Morris-Samotij / Saxton-Thomason hypergraph container method (2015), one of the most powerful tools in modern combinatorics. More precisely, $f(n) \\sim c_n \\cdot 2^{n/2}$ where $c_n$ depends on the parity of $n$, reflecting the two dominant sum-free families (upper half for even $n$, odd numbers for odd $n$). The problem connects to Schur numbers in Ramsey theory and to the broader program of counting combinatorial structures avoiding prescribed patterns.",
@@ -182,7 +182,7 @@
     "theoremCount": 11,
     "definitionCount": 5,
     "path": "Proofs/Erdos748Problem.lean",
-    "sorries": 4
+    "sorries": 1
   },
   "crossReferences": [
     {
@@ -201,5 +201,5 @@
       "description": "Related Erdős problem sharing themes: additive-combinatorics, combinatorics, solved"
     }
   ],
-  "sorries": 4
+  "sorries": 1
 }


### PR DESCRIPTION
## Summary

- meta.json for `erdos-748` claimed `sorries: 4` but the Lean source (`Erdos748Problem.lean`) has exactly **1 sorry** (line 170)
- Updated all three `sorries` fields (meta, leanFile, top-level) from 4 → 1
- Updated `assumptions` text from "3 axiom(s) and 4 sorries" → "3 axiom(s) and 1 sorry"

## Evidence

**meta.json claimed**: `"sorries": 4`
**Lean file actual**: `grep -c "sorry" proofs/Proofs/Erdos748Problem.lean` → 1 (line 170: `sorry -- Full proof requires careful asymptotic analysis`)

## Test plan
- [ ] Verify `grep -c "sorry" proofs/Proofs/Erdos748Problem.lean` returns 1
- [ ] Verify gallery build passes: `pnpm build`

Discovered during gallery integrity audit (loom-auditor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)