### PR TITLE
Research: erdos-1050 — prove 3 sorries (7→4)

### DIFF
--- a/proofs/Proofs/Erdos1050Problem.lean
+++ b/proofs/Proofs/Erdos1050Problem.lean
@@ -233,7 +233,15 @@ theorem transcendence_implies_irrationality :
     ∀ q : ℕ, q ≥ 2 → ∀ r : ℚ, r ≠ 0 →
       (∀ n : ℕ, n ≥ 1 → (r : ℝ) ≠ -((q : ℝ)^n)) →
       Irrational (T q r) := by
-  sorry
+  intro h q hq r hr hpole
+  have htrans := h q hq r hr hpole
+  -- Transcendental ℚ x → Irrational x: if x = (p:ℝ) for p:ℚ, then x is algebraic
+  intro hmem
+  apply htrans
+  simp only [Set.mem_range] at hmem
+  obtain ⟨p, hp⟩ := hmem
+  rw [← hp]
+  exact isAlgebraic_algebraMap p
 
 /-- The transcendence conjecture status: OPEN. -/
 theorem transcendence_conjecture_status :
@@ -252,14 +260,20 @@ noncomputable def S_1049 (t : ℝ) : ℝ :=
 
 /-- T(q, -1) = S_1049(q) for integer q. -/
 theorem T_eq_S_1049 (q : ℕ) (hq : q ≥ 2) : T q (-1) = S_1049 q := by
-  sorry
+  simp only [T, S_1049]
+  apply tsum_congr
+  intro n
+  split_ifs with h
+  · rfl
+  · push_cast; ring
 
 /-- The problems are related through shifting the constant. -/
 theorem problems_related (q : ℕ) (hq : q ≥ 2) (r : ℚ) (hr : r ≠ 0) :
     -- T(q, r) and S_1049(q) are both irrational for appropriate parameters
     Irrational (T q (-1)) ∧
     (∀ n : ℕ, n ≥ 1 → (r : ℝ) ≠ -((q : ℝ)^n)) → Irrational (T q r) := by
-  sorry
+  intro ⟨_, hpole⟩
+  exact borwein_irrationality q r hq hr hpole
 
 /-!
 ## Part VIII: Approximation and Numerical Values

--- a/src/data/proofs/erdos-1050/meta.json
+++ b/src/data/proofs/erdos-1050/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 7,
+    "sorries": 4,
     "erdosNumber": 1050,
     "erdosUrl": "https://erdosproblems.com/1050",
     "erdosProblemStatus": "solved",
@@ -63,7 +63,7 @@
       "erdos-257"
     ],
     "axiomCount": 2,
-    "lineCount": 357,
+    "lineCount": 371,
     "assumptions": "2 axioms: borwein_irrationality (Borwein's 1991 Padé approximation result for T(q,r)), S_approx (numerical bounds 0.286 < S < 0.288)."
   },
   "overview": {
@@ -229,7 +229,7 @@
       "Real"
     ],
     "namespace": "Erdos1050",
-    "lineCount": 357,
+    "lineCount": 371,
     "axiomCount": 2,
     "theoremCount": 26,
     "definitionCount": 9,
@@ -251,7 +251,7 @@
       }
     ],
     "path": "Proofs/Erdos1050Problem.lean",
-    "sorries": 7
+    "sorries": 4
   },
   "references": [
     {
@@ -270,5 +270,5 @@
       "type": "book"
     }
   ],
-  "sorries": 7
+  "sorries": 4
 }


### PR DESCRIPTION
## Summary

- Proved `transcendence_implies_irrationality`: `GeneralTranscendenceConjecture → Irrational (T q r)` via `isAlgebraic_algebraMap` (rational numbers are algebraic, so transcendental implies irrational)
- Proved `T_eq_S_1049`: `T q (-1) = S_1049 q` by `tsum_congr` + `push_cast; ring` (denominators q^n + (-1) = q^n - 1)
- Proved `problems_related`: simplifies to `borwein_irrationality` directly; the first conjunct `Irrational (T q (-1))` is redundant

Remaining 4 sorries: `T_summable`, `S_summable` (convergence via geometric comparison), `S_first_terms`, `partial_sums_converge` — these require more infrastructure.

## Test plan
- [ ] Verify Lean build compiles `Proofs.Erdos1050Problem`
- [ ] Check sorries reduced from 7 → 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)