### PR TITLE
Fix: correct non-standard badge/status values in 5 gallery proofs

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-04-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-04-oq-01/meta.json
@@ -16,7 +16,7 @@
       "angle-trisection"
     ],
     "proofRepoPath": "Proofs/AngleTrisectionOQ02OQ04OQ01.lean",
-    "badge": "formalized",
+    "badge": "wip",
     "sorries": 3,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Ap\u00e9ry, Roger (1978)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Ap%C3%A9ry%27s_theorem",
     "date": "1978",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/BaselProblemOQ01OQ01OQ02.lean",
     "tags": [
       "number-theory",
@@ -17,7 +17,7 @@
       "apery-numbers",
       "research"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-12",
     "axiomCount": 6,

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
@@ -15,7 +15,7 @@
       "mathlib-integration"
     ],
     "proofRepoPath": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
-    "badge": "formalized",
+    "badge": "wip",
     "sorries": 7,
     "dateAdded": "2026-03-30",
     "axiomCount": 0,

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -13,7 +13,7 @@
       "radon-nikodym",
       "measure-theory"
     ],
-    "badge": "formalized",
+    "badge": "wip",
     "sorries": 3,
     "axiomCount": 0,
     "lineCount": 460,

--- a/src/data/proofs/erdos-1168/meta.json
+++ b/src/data/proofs/erdos-1168/meta.json
@@ -19,7 +19,7 @@
     "sourceUrl": "https://erdosproblems.com/1168",
     "erdosUrl": "https://erdosproblems.com/1168",
     "erdosProblemStatus": "open",
-    "badge": "formalized",
+    "badge": "axiom",
     "axiomCount": 0,
     "lineCount": 255,
     "theoremCount": 11,


### PR DESCRIPTION
## Fix

5 gallery proofs had non-standard `badge="formalized"` values (not a valid badge per CLAUDE.md). One proof also had an incorrect `status` field.

## Evidence

| Proof | Before | After | Reason |
|-------|--------|-------|--------|
| `angle-trisection-oq-02-oq-04-oq-01` | badge=formalized | badge=wip | 3 sorries present, badge must be "wip" |
| `binomial-theorem-oq-02-oq-01-oq-01` | badge=formalized | badge=wip | 7 sorries present, badge must be "wip" |
| `cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01` | badge=formalized | badge=wip | 3 sorries present, badge must be "wip" |
| `erdos-1168` | badge=formalized | badge=axiom | Open conjecture → always axiomatized |
| `basel-problem-oq-01-oq-01-oq-02` | status=formalized, badge=formalized | status=axiomatized, badge=axiom | 0 sorries + 6 axioms → should be axiomatized |

**Valid badge values** (from CLAUDE.md): `original`, `verified`, `axiom`, `wip`, `partial`, `mathlib`. The value `"formalized"` is not in this list.

All sorry counts and axiom counts are unchanged — only badge/status corrected.

---
Automated fix by lean-mechanic agent.