### PR TITLE
Fix: brouwer-fixed-point-oq-04-oq-04 sorry count 1→0

### DIFF
--- a/src/data/proofs/brouwer-fixed-point-oq-04-oq-04/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-04-oq-04/meta.json
@@ -17,7 +17,7 @@
       "game-theory"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "axioms": 1,
     "dateAdded": "2026-04-12",
     "dateUpdated": "2026-04-12",
@@ -143,7 +143,7 @@
     "axiomCount": 1,
     "theoremCount": 12,
     "definitionCount": 2,
-    "sorries": 1
+    "sorries": 0
   },
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Summary

- meta.json for `brouwer-fixed-point-oq-04-oq-04` claimed `sorries: 1` but `BrouwerFixedPointOQ04OQ04.lean` has **0 sorries**
- The `assumptions` text already correctly noted "0 sorry" but the numeric field was stale
- Updated all three `sorries` fields from 1 → 0

## Evidence

**meta.json claimed**: `"sorries": 1`
**Lean file actual**: `grep -c "sorry" proofs/Proofs/BrouwerFixedPointOQ04OQ04.lean` → 0
**assumptions text**: already said "0 sorry (LSC/USC limit arguments...)"

Status (`axiomatized`) and badge (`axiom`) remain correct — the file still has 1 axiom (`scarf_approx_fixed_point`).

## Test plan
- [ ] Verify `grep -c "sorry" proofs/Proofs/BrouwerFixedPointOQ04OQ04.lean` returns 0
- [ ] Verify gallery build passes: `pnpm build`

Discovered during gallery integrity audit (loom-auditor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)