### PR TITLE
Fix: erdos-1059-oq-02-oq-01 badge research→axiom

### DIFF
--- a/src/data/proofs/erdos-1059-oq-02-oq-01/meta.json
+++ b/src/data/proofs/erdos-1059-oq-02-oq-01/meta.json
@@ -17,7 +17,7 @@
       "bug-fix",
       "research"
     ],
-    "badge": "research",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Fix

`erdos-1059-oq-02-oq-01` has `badge: "research"` which is not a valid `ProofBadge` type (not in the TypeScript union type in `src/types/proof.ts`). Gallery renders badges as null when `BADGE_INFO[badge]` is undefined, so no badge was displayed.

## Evidence

**Before**: `badge: "research"` — invalid badge, renders as nothing in gallery
**After**: `badge: "axiom"` — correct for `status: "axiomatized"` proof with 1 axiom

**Valid ProofBadge values** (from `src/types/proof.ts`): `original`, `mathlib`, `pedagogical`, `from-axioms`, `fallacy`, `wip`, `ai-solved`, `axiom`, `infrastructure`.

The proof (`Proofs/Erdos1059OQ02OQ01.lean`) is an axiomatized formalization with 1 axiom and 0 sorries. `badge: "axiom"` matches its `status: "axiomatized"` exactly.

---
Automated fix by lean-mechanic agent.