### PR TITLE
Fix: LebesgueMeasureOQ03OQ01 — correct 3 ENNReal API names

### DIFF
--- a/proofs/Proofs/LebesgueMeasureOQ03OQ01.lean
+++ b/proofs/Proofs/LebesgueMeasureOQ03OQ01.lean
@@ -44,7 +44,7 @@ open MeasureTheory Set Metric Real LebesgueMeasureOQ03
 lemma ennreal_const_le_finite_imp_zero (c M : ℝ≥0∞) (hM : M < ⊤)
     (hbdd : ∀ N : ℕ, ↑N * c ≤ M) : c = 0 := by
   by_contra hc
-  have hpos : 0 < c := ENNReal.pos_of_ne_zero hc
+  have hpos : 0 < c := pos_iff_ne_zero.mpr hc
   -- Case c = ⊤: 1 * ⊤ = ⊤ ≤ M < ⊤, contradiction
   rcases eq_or_ne c ⊤ with rfl | hctop
   · simpa using (hbdd 1).trans_lt hM
@@ -56,11 +56,9 @@ lemma ennreal_const_le_finite_imp_zero (c M : ℝ≥0∞) (hM : M < ⊤)
   -- M / c < N implies M < N * c
   -- Proof: M = (M/c) * c < N * c (multiply both sides by c > 0)
   have hkey : M < ↑N * c := by
-    have hdmc : M / c * c = M := ENNReal.div_mul_cancel₀ hpos.ne' hctop
+    have hdmc : M / c * c = M := ENNReal.div_mul_cancel hpos.ne' hctop
     calc M = M / c * c := hdmc.symm
-      _ < ↑N * c := by
-          apply ENNReal.mul_lt_mul_right' hN
-          exact hpos.ne'
+      _ < ↑N * c := ENNReal.mul_lt_mul_left hpos.ne' hctop hN
   exact absurd (hbdd N) (not_le.mpr hkey)
 
 -- ============================================================


### PR DESCRIPTION
## Summary

Fixes 3 incorrect ENNReal lemma names in `ennreal_const_le_finite_imp_zero` (the Archimedean property lemma) in `proofs/Proofs/LebesgueMeasureOQ03OQ01.lean`.

The proof strategy is correct; only the API calls were wrong:

1. `ENNReal.pos_of_ne_zero` (nonexistent) → `pos_iff_ne_zero.mpr`
2. `ENNReal.div_mul_cancel₀` (nonexistent) → `ENNReal.div_mul_cancel` (takes `a ≠ 0` and `a ≠ ∞` args)
3. `apply ENNReal.mul_lt_mul_right' hN; exact hpos.ne'` (wrong arg order — `hN : M/c < ↑N` doesn't match first param `h0 : a ≠ 0`) → `ENNReal.mul_lt_mul_left hpos.ne' hctop hN`

The rest of the file (`measure_biUnion_finset`, `ENNReal.exists_nat_gt`, `ENNReal.div_lt_top`, orthonormal disjointness proofs) is verified against Mathlib source and is correct.

## Test plan

- [ ] Docker build `Proofs.LebesgueMeasureOQ03OQ01` compiles without errors
- [ ] All 8 lemmas/theorems prove without sorries (0 sorries claimed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)