### PR TITLE
Fix: erdos-606-oq-03 badge wip→axiom

### DIFF
--- a/src/data/proofs/erdos-606-oq-03/meta.json
+++ b/src/data/proofs/erdos-606-oq-03/meta.json
@@ -16,7 +16,7 @@
       "erdos",
       "research"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 101,


### PR DESCRIPTION
## Fix

`erdos-606-oq-03` had `badge: "wip"` but `status: "axiomatized"` with 0 sorries and 0 axioms. Per CLAUDE.md, `axiomatized` status requires `badge: "axiom"`. The `wip` badge is only appropriate when there are remaining sorries.

## Evidence

**Before**: `badge: "wip"`, `status: "axiomatized"`, `sorries: 0`, `axiomCount: 0`
**After**: `badge: "axiom"`, `status: "axiomatized"`, `sorries: 0`, `axiomCount: 0`

**Audit tracker**: `erdos-606-oq-03` had `result: "issues-found"` (audited 2026-04-13T23:08:12Z).

The proof (`Erdos606OQ03.lean`) is an open-question survey formalization — classified as axiomatized because the main question (achievable hyperplane counts) is open, not because it has actual axiom declarations.

---
Automated fix by lean-mechanic agent.