### PR TITLE
Fix: ptolemys-theorem-oq-01-incomplete-01 meta.json type errors

### DIFF
--- a/src/data/proofs/ptolemys-theorem-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01-incomplete-01/meta.json
@@ -109,8 +109,12 @@
   "overview": {
     "historicalContext": "Ptolemy's theorem (c. 150 AD) characterizes cyclic quadrilaterals: AC·BD = AB·CD + BC·DA exactly when A, B, C, D lie on a circle in cyclic order. The complex-number formulation (from PtolemysComplexProof.lean) gives equality iff (z₂-z₃)(z₁-z₄) is proportional to (z₁-z₂)(z₃-z₄) with a positive ratio. This file closes the equivalence by proving the ratio being positive corresponds exactly to CCW or CW cyclic order.",
     "problemStatement": "Given that PtolemysTheoremOQ01.lean proves CCW order → Ptolemy equality, the open question is: does Ptolemy equality imply cyclic order? This file answers yes, providing the converse and completing the biconditional for unit-circle points.",
-    "text": "The proof derives from the exponential difference factorization exp(iα)-exp(iβ) = 2I·sin((α-β)/2)·exp(i(α+β)/2). Substituting zₖ = exp(iθₖ) into the proportionality equation (z₂-z₃)(z₁-z₄) = t·(z₁-z₂)(z₃-z₄) and canceling the phase factors yields t = sin((θ₂-θ₃)/2)·sin((θ₁-θ₄)/2) / (sin((θ₁-θ₂)/2)·sin((θ₃-θ₄)/2)). Since t > 0, both numerator and denominator have the same sign. An 8-case analysis on the signs of the four sines shows that only two sign patterns are consistent with all angles being distinct: all-negative (→ θ₁<θ₂<θ₃<θ₄, CCW) and all-positive (→ θ₄<θ₃<θ₂<θ₁, CW), plus 6 mixed cases that reduce to cyclic rotations of these two orderings via shifts by ±2π.",
-    "keyInsight": "The sign of sin((θᵢ-θⱼ)/2) directly encodes the ordering of θᵢ and θⱼ. The constraint t > 0 forces the product of four sines to be positive, which restricts the angle orderings to exactly those defining CCW or CW cyclic position."
+    "proofStrategy": "The proof derives from the exponential difference factorization exp(iα)-exp(iβ) = 2I·sin((α-β)/2)·exp(i(α+β)/2). Substituting zₖ = exp(iθₖ) into the proportionality equation and canceling phase factors yields a sine ratio. Since t > 0, an 8-case sign analysis shows only two sign patterns are consistent with distinct angles.",
+    "keyInsights": [
+      "The sign of sin((θᵢ-θⱼ)/2) directly encodes the ordering of θᵢ and θⱼ",
+      "The constraint t > 0 forces the product of four sines to be positive, restricting angle orderings to exactly CCW or CW cyclic position",
+      "Only 2 of 8 sign patterns for the four half-angle sines are compatible with all angles being distinct"
+    ]
   },
   "conclusion": {
     "summary": "Ptolemy equality ↔ CCW or CW order for distinct unit-circle points (under non-degeneracy conditions). The converse direction is new; the forward direction combines the result of PtolemysTheoremOQ01.lean with ptolemy_equality_of_proportional.",
@@ -118,10 +122,7 @@
       "Can the non-degeneracy hypotheses (hdenom ≠ 0, hnumer ≠ 0) be relaxed or shown to follow from distinctness?",
       "Can the sorry in t_eq_sine_ratio (the sine ratio identity) be filled by field_simp/ring after ring_nf applied to the ht_eq equation with substituted hha factorizations?"
     ],
-    "implications": [
-      "Completes the formal Lean 4 proof that Ptolemy's equality characterizes cyclic quadrilaterals",
-      "Demonstrates that half-angle sine sign analysis is a viable substitute for inscribed angle theorem arguments in formal proofs"
-    ]
+    "implications": "Completes the formal Lean 4 proof that Ptolemy's equality characterizes cyclic quadrilaterals. Demonstrates that half-angle sine sign analysis is a viable substitute for inscribed angle theorem arguments in formal proofs."
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Summary
- Fix overview fields: `text` -> `proofStrategy`, `keyInsight` (string) -> `keyInsights` (array)
- Fix conclusion: `implications` array -> string

These mismatches cause TypeScript build failures.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>