### PR TITLE
Fix: Aristotle companion for Erdős #553 (5 routine targets)

### DIFF
--- a/proofs/Proofs/Stubs/Erdos553Aristotle.lean
+++ b/proofs/Proofs/Stubs/Erdos553Aristotle.lean
@@ -1,0 +1,70 @@
+/-
+  Aristotle targets for Erdős Problem #553
+  Routine supporting lemmas for automated proof search.
+  See Erdos553Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main results (Alon-Rödl, Shearer — depend on R functions with def-sorrys)
+  - Routine supporting facts: coloring symmetry, clique properties, Turán-type bounds
+  - No definition sorries
+  - No axioms
+-/
+import Mathlib
+
+namespace Erdos553Aristotle
+
+open Finset SimpleGraph
+
+/-- An edge coloring of K_n with k colors -/
+def EdgeColoring (n k : ℕ) := Fin n × Fin n → Fin k
+
+/-- A coloring is symmetric -/
+def EdgeColoring.IsSymmetric {n k : ℕ} (c : EdgeColoring n k) : Prop :=
+  ∀ i j : Fin n, c (i, j) = c (j, i)
+
+/-- A set of vertices forms a monochromatic clique in color col -/
+def IsMonochromaticClique {n k : ℕ} (c : EdgeColoring n k)
+    (S : Finset (Fin n)) (col : Fin k) : Prop :=
+  ∀ i ∈ S, ∀ j ∈ S, i ≠ j → c (i, j) = col
+
+/-- A monochromatic triangle in color col -/
+def HasMonochromaticTriangle {n k : ℕ} (c : EdgeColoring n k) (col : Fin k) : Prop :=
+  ∃ a b d : Fin n, a ≠ b ∧ b ≠ d ∧ a ≠ d ∧
+    c (a, b) = col ∧ c (b, d) = col ∧ c (a, d) = col
+
+/-- A monochromatic clique of size m in color col -/
+def HasMonochromaticClique {n k : ℕ} (c : EdgeColoring n k) (col : Fin k) (m : ℕ) : Prop :=
+  ∃ S : Finset (Fin n), S.card = m ∧ IsMonochromaticClique c S col
+
+-- Routine: The empty set forms a monochromatic clique of size 0.
+theorem has_mono_clique_zero {n k : ℕ} (c : EdgeColoring n k) (col : Fin k) :
+    HasMonochromaticClique c col 0 := by
+  sorry
+
+-- Routine: A monochromatic clique of size m+1 contains one of size m.
+theorem mono_clique_downward {n k : ℕ} (c : EdgeColoring n k) (col : Fin k) (m : ℕ)
+    (h : HasMonochromaticClique c col (m + 1)) :
+    HasMonochromaticClique c col m := by
+  sorry
+
+-- Routine: A monochromatic triangle is a monochromatic clique of size 3.
+theorem triangle_is_3_clique {n k : ℕ} (c : EdgeColoring n k) (col : Fin k)
+    (h : HasMonochromaticTriangle c col) :
+    HasMonochromaticClique c col 3 := by
+  sorry
+
+-- Routine: Symmetric coloring: c(i,j) = c(j,i) implies swapped edge has same color.
+theorem symmetric_swap {n k : ℕ} (c : EdgeColoring n k) (hc : c.IsSymmetric)
+    (i j : Fin n) (col : Fin k) (h : c (i, j) = col) : c (j, i) = col := by
+  sorry
+
+-- Routine: Monochromatic clique in a symmetric coloring is symmetric.
+-- If S is a mono clique in col, then for i,j ∈ S with i ≠ j, c(j,i) = col too.
+theorem mono_clique_symmetric {n k : ℕ} (c : EdgeColoring n k) (hc : c.IsSymmetric)
+    (S : Finset (Fin n)) (col : Fin k)
+    (h : IsMonochromaticClique c S col)
+    (i j : Fin n) (hi : i ∈ S) (hj : j ∈ S) (hij : i ≠ j) :
+    c (j, i) = col := by
+  sorry
+
+end Erdos553Aristotle


### PR DESCRIPTION
## Fix

Adds Aristotle companion file for `erdos-553`, which has 15 sorries (formalized status) and no existing Aristotle companion.

## Evidence

**Companion file**: `proofs/Proofs/Stubs/Erdos553Aristotle.lean`
- 5 lemma/theorem targets (all `theorem ... := by sorry`)
- No `def := sorry`, no `axiom`, no `True` stubs, no `/-!` docstrings
- Routine supporting lemmas suitable for Aristotle proof search

---
Automated fix by lean-mechanic agent.