### PR TITLE
Fix: sync sorry counts for erdos-263, erdos-375, erdos-1050

### DIFF
--- a/src/data/proofs/erdos-1050/meta.json
+++ b/src/data/proofs/erdos-1050/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 7,
+    "sorries": 2,
     "erdosNumber": 1050,
     "erdosUrl": "https://erdosproblems.com/1050",
     "erdosProblemStatus": "solved",
@@ -64,7 +64,7 @@
     ],
     "axiomCount": 2,
     "lineCount": 357,
-    "assumptions": "2 axioms: borwein_irrationality (Borwein's 1991 Padé approximation result for T(q,r)), S_approx (numerical bounds 0.286 < S < 0.288)."
+    "assumptions": "2 axioms: borwein_irrationality (Borwein's 1991 Padé approximation result for T(q,r)), S_approx (numerical bounds 0.286 < S < 0.288). 2 sorries: T_summable (convergence of T(q,r)), S_first_terms (initial partial sum identity)."
   },
   "overview": {
     "historicalContext": "**From Lambert Series to Borwein's Theorem**\n\nThe study of series with exponential denominators began with Johann Heinrich Lambert's 1748 investigation of ∑ q^n/(1-q^n) — the Lambert series — which he connected to the divisor function τ(n). Euler recognized the identity ∑ 1/(q^n - 1) = ∑ τ(n)/q^n, linking these series to multiplicative number theory.\n\nIn 1948, Erdős published a foundational paper in the Journal of the Indian Mathematical Society proving that ∑ 1/(2^n - 1) is irrational. His method exploited the divisor function identity: if the sum were rational p/q, then ∑ τ(n)/2^n = p/q, and the arithmetic properties of τ (specifically, that τ(n) is often large — on average log n) would produce contradictions modulo carefully chosen primes. This result established the Erdős-Borwein constant E ≈ 1.60669 as one of the first explicitly-defined irrationals in this family.\n\nErdős conjectured much more: that ∑ 1/(2^n + t) should be transcendental for every integer t ≠ 0. Problem #1050 asks specifically about the case t = -3, i.e., whether ∑ 1/(2^n - 3) is irrational.\n\n**Peter Borwein (1991)** proved the definitive irrationality result in Math. Proc. Cambridge Philos. Soc.: for any integer q ≥ 2 and rational r ≠ 0 (with r ≠ -q^n for any n), the series ∑ 1/(q^n + r) is irrational. His proof used Padé approximation to the q-logarithm function log_q(1+x) = ∑ (-x)^n/(q^n - 1), constructing rational approximants whose quality exceeds the Dirichlet threshold. This completely solved Problem #1050 and subsumed Erdős's 1948 result as a special case.\n\nThe stronger transcendence conjecture remains OPEN. Even for the Erdős-Borwein constant ∑ 1/(2^n - 1), transcendence has not been established. The methods of Mahler (1929) and Nishioka (1996) for q-series transcendence do not directly apply to these Lambert-type series, and fundamentally new techniques appear to be needed.",
@@ -251,7 +251,7 @@
       }
     ],
     "path": "Proofs/Erdos1050Problem.lean",
-    "sorries": 7
+    "sorries": 2
   },
   "references": [
     {
@@ -270,5 +270,5 @@
       "type": "book"
     }
   ],
-  "sorries": 7
+  "sorries": 2
 }

--- a/src/data/proofs/erdos-263/meta.json
+++ b/src/data/proofs/erdos-263/meta.json
@@ -17,13 +17,13 @@
       "analysis"
     ],
     "badge": "wip",
-    "sorries": 6,
+    "sorries": 5,
     "erdosNumber": 263,
     "erdosUrl": "https://erdosproblems.com/263",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
     "lineCount": 285,
-    "assumptions": "No axioms. 6 sorry(s) remain: folklore_irrationality, kovac_tao_not_irrationality, positive_condition_irrationality, factorial_no_folklore_growth, doubleExp_superexponential, truncation_insufficient.",
+    "assumptions": "No axioms. 5 sorry(s) remain: folklore_irrationality, kovac_tao_not_irrationality, positive_condition_irrationality, factorial_no_folklore_growth, truncation_insufficient.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -164,7 +164,7 @@
     "theoremCount": 11,
     "definitionCount": 19,
     "path": "Proofs/Stubs/Erdos263Problem.lean",
-    "sorries": 6
+    "sorries": 5
   },
   "crossReferences": [
     {
@@ -226,5 +226,5 @@
       "note": "Growth lower bounds for irrationality sequences, connected to Problem #262"
     }
   ],
-  "sorries": 6
+  "sorries": 5
 }

--- a/src/data/proofs/erdos-375/meta.json
+++ b/src/data/proofs/erdos-375/meta.json
@@ -18,7 +18,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 1,
     "erdosNumber": 375,
     "erdosUrl": "https://erdosproblems.com/375",
     "erdosProblemStatus": "open",
@@ -60,7 +60,7 @@
     ],
     "axiomCount": 1,
     "lineCount": 353,
-    "assumptions": "1 axiom (ramachandra_shorey_tijdeman, 1975 partial result). 5 sorries (grimm_difficulty implies Legendres conjecture, and 4 supporting lemmas)."
+    "assumptions": "1 axiom (ramachandra_shorey_tijdeman, 1975 partial result). 1 sorry (grimm_difficulty: reduction to Legendre's conjecture)."
   },
   "overview": {
     "historicalContext": "**Erdos Problem #375: Grimm's Conjecture**\n\nThis conjecture was originally posed by C.A. Grimm in 1969 in the American Mathematical Monthly. It connects prime factorization with combinatorial matching theory.\n\n**The Core Question:**\nGiven any interval of k consecutive composite numbers (a 'prime gap'), can we always assign a distinct prime divisor to each composite?\n\n**Historical Progress:**\n- 1969: Grimm poses conjecture, proves k << log n / log log n\n- 1970s: Erdos-Selfridge extend to k <= (1+o(1)) log n\n- 1975: Ramachandra-Shorey-Tijdeman prove k << (log n / log log n)^3\n\n**Significance:**\nThis is listed as problem B32 in Guy's Unsolved Problems in Number Theory. It remains one of the most intriguing open problems connecting prime gaps to matching theory.",
@@ -184,7 +184,7 @@
     "theoremCount": 7,
     "definitionCount": 9,
     "path": "Proofs/Erdos375Problem.lean",
-    "sorries": 5
+    "sorries": 1
   },
   "crossReferences": [
     {
@@ -203,5 +203,5 @@
       "description": "Related Erdős problem sharing themes: composite-numbers, number-theory, open"
     }
   ],
-  "sorries": 5
+  "sorries": 1
 }


### PR DESCRIPTION
## Summary

Three `meta.json` sorry counts lagged behind Lean source after researcher fixes:

| Proof | meta claimed | Lean actual | Notes |
|-------|-------------|-------------|-------|
| `erdos-263` | 6 | 5 | `doubleExp_superexponential` was proved |
| `erdos-375` | 5 | 1 | 4 supporting lemmas proved; `grimm_difficulty` remains |
| `erdos-1050` | 7 | 2 | 5 sorries resolved; `T_summable` + `S_first_terms` remain |

Also updated `assumptions` text to reflect current sorry lists.

## Evidence

```bash
grep -n "^\s*sorry\b" proofs/Proofs/Stubs/Erdos263Problem.lean  # 5 results
grep -n "^\s*sorry\b" proofs/Proofs/Erdos375Problem.lean         # 1 result (line 351)
grep -n "^\s*sorry\b" proofs/Proofs/Erdos1050Problem.lean        # 2 results (lines 60, 129)
```

## Test plan
- [ ] `pnpm build` passes
- [ ] Sorry counts match Lean source

Discovered during gallery integrity audit (loom-auditor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)