### PR TITLE
Fix: tractatus-ontology badge verified→wip (has 1 sorry)

### DIFF
--- a/src/data/proofs/tractatus-ontology/meta.json
+++ b/src/data/proofs/tractatus-ontology/meta.json
@@ -4,10 +4,10 @@
   "slug": "tractatus-ontology",
   "description": "A Lean 4 formalization of the structural core of Wittgenstein's Tractatus Logico-Philosophicus: objects, states of affairs, worlds, propositions, and truth-functionality. Proves that tautologies are world-invariant and contradictions hold nowhere. Ends with a deliberate sorry — the silence of Proposition 7.",
   "meta": {
-    "status": "verified",
+    "status": "axiomatized",
     "tags": ["philosophy", "logic", "ontology", "model-theory", "truth-functions"],
     "proofRepoPath": "Proofs/TractatusOntology.lean",
-    "badge": "original",
+    "badge": "wip",
     "sorries": 1,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Integrity Fix

**Proof**: tractatus-ontology
**Problem**: `status: verified` / `badge: original` despite having 1 sorry

## Evidence

**meta.json claimed**: `status: "verified"`, `badge: "original"`, `sorries: 1`
**Lean file shows**: `proposition_seven` at line 390 has `sorry` — the Lean kernel did not verify this theorem

The sorry is described as deliberate ("philosophical gesture" for TLP 7), but that does not change the integrity requirement: `verified` requires 0 sorries, no exceptions.

## Fix Applied

- `status`: `verified` → `axiomatized`
- `badge`: `original` → `wip`
- `sorries: 1` and `assumptions` field remain accurate as-is

---
Discovered during gallery integrity audit.