### PR TITLE
Enrich Anning-Erdős finiteness bound (erdos-130-wip-01): add annotations

### DIFF
--- a/src/data/proofs/erdos-130-wip-01/annotations.json
+++ b/src/data/proofs/erdos-130-wip-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-x-coord-formula",
+    "proofId": "erdos-130-wip-01",
+    "range": { "startLine": 38, "endLine": 70 },
+    "type": "technique",
+    "title": "X-Coordinate Rationality via Distance Subtraction",
+    "content": "The key algebraic move is to subtract the two distance equations for P and Q:\n\n```lean\nhave h : x ^ 2 - (x - D) ^ 2 = a ^ 2 - (a - s) ^ 2 := by linarith\nnlinarith [h]\n```\n\nSubtracting $x^2 + y^2 = a^2$ from $(x-D)^2 + y^2 = (a-s)^2$ cancels the $y^2$ term entirely, leaving a linear equation in $x$. Expanding: $x^2 - (x-D)^2 = 2Dx - D^2$ and $a^2 - (a-s)^2 = 2as - s^2$, so $2Dx = 2as - s^2 + D^2$.\n\nThis is the fundamental rationality argument: when $D, a, s$ are integers, $2Dx$ is an integer — so $x$ is rational with denominator dividing $2D$. The proof uses `nlinarith` after extracting the key algebraic identity via `linarith`.",
+    "mathContext": "$2D \\cdot x = 2as - s^2 + D^2$ where $s = a - b$ is the signed difference. Rationality: $x = (2as - s^2 + D^2)/(2D) \\in \\mathbb{Q}$ with denominator dividing $2D$ when $a, s, D \\in \\mathbb{Z}$.",
+    "significance": "key",
+    "relatedConcepts": ["distance subtraction", "rationality", "nlinarith", "integer distance"],
+    "prerequisites": ["Euclidean distance formula", "algebraic manipulation"]
+  },
+  {
+    "id": "ann-signed-diff-card",
+    "proofId": "erdos-130-wip-01",
+    "range": { "startLine": 73, "endLine": 87 },
+    "type": "insight",
+    "title": "Triangle Inequality Bounds the Signed Difference to 2D+1 Choices",
+    "content": "The signed difference $s = a - b$ where $a = d(X,P)$ and $b = d(X,Q)$ satisfies $|s| \\leq D$ by the triangle inequality: $|d(X,P) - d(X,Q)| \\leq d(P,Q) = D$. Since $s$ is an integer, it takes values in $\\{-D, -D+1, \\ldots, D-1, D\\}$, giving exactly $2D+1$ choices.\n\n```lean\ntheorem signed_diff_card (D : ℕ) :\n    (Finset.Icc (-(D : ℤ)) (D : ℤ)).card = 2 * D + 1 := by\n  rw [Int.card_Icc]; push_cast; omega\n```\n\nThis combinatorial lemma is the heart of the finiteness argument: because each signed difference pair $(s, t)$ contributes at most 4 points (2 quadratic roots × 2 $y$-signs), the total is at most $4(2D+1)(2E+1)$.",
+    "mathContext": "$|\\{s \\in \\mathbb{Z} : |s| \\le D\\}| = 2D + 1$. Combined with the $t$-count: $(2D+1)(2E+1)$ pairs, each contributing $\\le 4$ points, giving the Anning–Erdős bound.",
+    "significance": "key",
+    "relatedConcepts": ["triangle inequality", "Finset.Icc", "Int.card_Icc", "combinatorial bound"],
+    "prerequisites": ["triangle inequality", "integer intervals"]
+  },
+  {
+    "id": "ann-y-linearity-linear-combination",
+    "proofId": "erdos-130-wip-01",
+    "range": { "startLine": 90, "endLine": 115 },
+    "type": "technique",
+    "title": "Third-Point Constraint via linear_combination",
+    "content": "The y-linearity lemma requires combining two equalities:\n- `hxeq`: $2D \\cdot x = 2as - s^2 + D^2$ (x-coordinate formula)\n- `hyeq`: $2r_y \\cdot y = a^2 - c^2 - 2r_x \\cdot x + r_x^2 + r_y^2$ (subtract distance equations for P and R)\n\nMultiplying `hyeq` by $2D$ and substituting `hxeq` to eliminate $x$ gives $2D \\cdot (2r_y y) = 4a(tD - r_x s) + K$ where $K$ is a constant independent of $a$ (but depending on $D, r_x, r_y, s, t$).\n\n```lean\nlinear_combination 2 * D * hyeq - 2 * r_x * hxeq\n```\n\nLean's `linear_combination` tactic closes this in one step by verifying the linear identity $2D \\cdot \\text{hyeq} - 2r_x \\cdot \\text{hxeq}$ reduces to the goal. The key insight is that multiplying $2r_y y$ by $2D$ makes the coefficient of $x$ equal to $2r_x \\cdot 2D$, which is then cancelled by $2r_x \\cdot (2D \\cdot x = \\ldots)$.",
+    "mathContext": "$2D \\cdot (2r_y y) = 4a(tD - r_x s) + (2D(r_x^2 + r_y^2 - t^2) - 2r_x(D^2 - s^2))$. The RHS is linear in $a$, with constant term $K = 2D(r_x^2 + r_y^2 - t^2) - 2r_x(D^2 - s^2)$.",
+    "significance": "key",
+    "relatedConcepts": ["linear_combination tactic", "elimination of variables", "distance constraint"],
+    "prerequisites": ["x_coord_formula", "y_coord_from_R", "linear_combination"]
+  },
+  {
+    "id": "ann-key-identity-proof-strategy",
+    "proofId": "erdos-130-wip-01",
+    "range": { "startLine": 118, "endLine": 165 },
+    "type": "insight",
+    "title": "The Quadratic Constraint: Squaring the Linear Expression",
+    "content": "The Anning–Erdős key identity is proved by a three-step chain:\n\n1. **Linear expression equals $2D \\cdot (2r_y y)$**: From `y_linear_in_a`, $L(a) = 2D(2r_y y)$.\n2. **Scale identity** (`key_scale_identity`): $(2D(2r_y y))^2 = 4r_y^2((2Da)^2 - (2Dx)^2)$, proved by `linear_combination 16 * D^2 * r_y^2 * hP` where `hP` is $x^2 + y^2 = a^2$.\n3. **Substitute x-formula**: Replace $2Dx$ with $2as - s^2 + D^2$ to get the RHS in terms of $a$ and $s$ only.\n\n```lean\ncalc LIN^2 = (2D·(2r_y·y))^2 := by rw [heq]\n  _ = 4r_y²·((2Da)²-(2Dx)²) := hscale\n  _ = 4r_y²·((2Da)²-(2as-s²+D²)²) := by rw [show 2*D*x = ... from hxeq]\n```\n\nThe `calc` block makes the logical chain explicit. The critical algebraic fact is that $y^2 = a^2 - x^2$ (from $x^2 + y^2 = a^2$), so $(2r_y y)^2 = r_y^2 \\cdot 4y^2 = 4r_y^2(a^2 - x^2)$, which upon scaling by $(2D)^2$ gives the scale identity.",
+    "mathContext": "$[L(a)]^2 = 4r_y^2[(2Da)^2 - (2as-s^2+D^2)^2]$. This is a polynomial of degree $\\le 2$ in $a$ (since the leading $a^2$ terms in $(2Da)^2$ and $(2as)^2$ cancel when $s \\ne 0$, giving degree $\\le 2$, hence at most 2 real roots).",
+    "significance": "key",
+    "relatedConcepts": ["Pythagorean identity", "polynomial degree", "calc tactic", "linear_combination"],
+    "prerequisites": ["x_coord_formula", "y_linear_in_a", "key_scale_identity"]
+  },
+  {
+    "id": "ann-count-and-finiteness",
+    "proofId": "erdos-130-wip-01",
+    "range": { "startLine": 168, "endLine": 194 },
+    "type": "concept",
+    "title": "Anning–Erdős Count: 4(2D+1)(2E+1) via Cartesian Product",
+    "content": "The finiteness bound combines combinatorial and algebraic ingredients:\n\n```lean\ntheorem anning_erdos_count (D E : ℕ) :\n    (Finset.Icc (-(D : ℤ)) D ×ˢ Finset.Icc (-(E : ℤ)) E).card * 4 =\n    4 * (2 * D + 1) * (2 * E + 1) := by\n  rw [Finset.card_product, signed_diff_card D, signed_diff_card E]; ring\n```\n\nThe argument:\n- $(2D+1)$ choices for $s \\in \\{-D, \\ldots, D\\}$ (triangle inequality for $d(X,P)$ vs $d(X,Q)$)\n- $(2E+1)$ choices for $t \\in \\{-E, \\ldots, E\\}$ (triangle inequality for $d(X,P)$ vs $d(X,R)$)\n- For each pair $(s,t)$: at most 2 quadratic roots for $a = d(X,P)$\n- For each $a$: at most 2 positions for $X$ (two $y$-signs since $y^2 = a^2 - x^2$)\n\nTotal: $(2D+1)(2E+1) \\times 4$ points. The examples `D=E=5` → 484, `D=3,E=4` → 252 illustrate concrete sizes.",
+    "mathContext": "$4(2D+1)(2E+1) = 4 + 8D + 8E + 16DE$ (expansion proved by `ring`). For small distances $D = E = 1$: bound is $36$; for $D = E = 10$: bound is $1764$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.card_product", "combinatorial bound", "finiteness", "Anning-Erdős theorem"],
+    "prerequisites": ["signed_diff_card", "anning_erdos_identity"]
+  }
+]


### PR DESCRIPTION
## Enrichment pass for erdos-130-wip-01

Adds 5 annotations covering all proof sections of the Anning-Erdős finiteness bound formalization.

### Quality improvements
- **Before**: quality 45 (no annotations)
- **After**: quality 100 (full annotation coverage)

### Annotations added
1. **X-Coordinate Rationality** (lines 38-70): Distance subtraction technique, `nlinarith` proof, rationality of $x = (2as-s^2+D^2)/(2D)$
2. **Signed Difference Bound** (lines 73-87): Triangle inequality gives $|s| \le D$, `Finset.Icc` counting, $2D+1$ choices
3. **Third-Point Constraint** (lines 90-115): `linear_combination` elimination of $x$ to get $y$ linear in $a$
4. **Quadratic Key Identity** (lines 118-165): Three-step `calc` chain using scale identity and Pythagorean substitution
5. **Anning-Erdős Count** (lines 168-194): $(2D+1)(2E+1) \times 4$ by `Finset.card_product`

Each annotation includes `mathContext` (LaTeX formulas), `significance`, `relatedConcepts`, and `prerequisites`.