### PR TITLE
Research: Law of Sines (law-of-cosines-oq-06) — 0 axioms, 0 sorries

### DIFF
--- a/research/aristotle-jobs.json
+++ b/research/aristotle-jobs.json
@@ -3307,9 +3307,10 @@
       "file": "proofs/Proofs/ArithmeticSeriesOQ02OQ03.lean",
       "problem_id": "arithmeticseriesoq02oq03",
       "submitted": "unknown",
-      "status": "completed",
-      "outcome": "No improvement (recovered from server)",
-      "notes": "Recovered from server at 2026-04-13T07:17:15Z. No sorry reduction."
+      "status": "integrated",
+      "outcome": "Already had 0 sorries",
+      "notes": "Recovered from server at 2026-04-13T07:17:15Z. No sorry reduction.",
+      "theorems_proved": 0
     }
   ]
 }

--- a/src/data/proofs/law-of-cosines-oq-06/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-06/meta.json
@@ -1,0 +1,93 @@
+{
+  "id": "law-of-cosines-oq-06",
+  "title": "Law of Sines via InnerProductGeometry.angle",
+  "slug": "law-of-cosines-oq-06",
+  "description": "Proves the Law of Sines for planar triangles in Euclidean 2-space using cross products and the sin-angle identity. All axioms eliminated: 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LawOfSinesOQ06.lean",
+    "tags": [
+      "geometry",
+      "trigonometry",
+      "law-of-sines",
+      "inner-product-space",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 309,
+    "assumptions": "No axioms or sorries. All results proved from Mathlib primitives.",
+    "dateAdded": "2026-04-13",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "Sin-cross identity: sin(angle u v)·‖u‖·‖v‖ = |cross2D u v| proved from 2D Lagrange identity",
+      "Three equivalent area formulas connecting side-angle products to cross product area",
+      "Law of Sines derived purely from area equality without coordinates"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The Law of Sines is one of the fundamental results of Euclidean trigonometry, relating the sides of a triangle to the sines of the opposite angles. It was known to Ptolemy (c. 150 CE) in the context of the inscribed angle theorem, and was stated explicitly by Abu Nasr ibn Iraq (c. 1000 CE) and later by François Viète (1579). The area-based proof used here — equating three area formulas (1/2)ab sin(C) — is one of the clearest elementary approaches. The key mathematical content is that for a non-degenerate planar triangle, the cross product captures the signed area, and the sin-angle identity connects it to the inner product angle. In Lean 4, the proof must handle the analytic subtleties of InnerProductGeometry.angle (defined via arccos) and the non-triviality of sin being positive for triangle angles.",
+    "problemStatement": "In a triangle with vertices $A, B, C \\in \\mathbb{R}^2$, sides $a = |BC|$, $b = |AC|$, $c = |AB|$, and angles $\\alpha, \\beta, \\gamma$ opposite those sides (defined via InnerProductGeometry.angle), prove the **Law of Sines**: $\\frac{a}{\\sin\\alpha} = \\frac{b}{\\sin\\beta} = \\frac{c}{\\sin\\gamma}$.",
+    "text": "Equates three area formulas via the sin-angle identity and cross product, then cancels common side lengths.",
+    "proofStrategy": "1. **2D Lagrange Identity** (by ring): ‖u‖²‖v‖² = ⟨u,v⟩² + (cross2D u v)². 2. **Sin-Cross Identity** (proved): sin(angle u v)·‖u‖·‖v‖ = |cross2D u v|, using sin_arccos and sqrt algebraic manipulation. 3. **Area formulas**: Area = (1/2)|cross2D(B-A, C-A)| = (1/2)cb·sin(α) = (1/2)ca·sin(β) = (1/2)ba·sin(γ). 4. **Law of Sines**: equating area_from_A = area_from_B gives cb·sin(α) = ca·sin(β), cancel c to get b·sin(α) = a·sin(β), i.e., a/sin(α) = b/sin(β).",
+    "keyInsights": [
+      "The sin-cross identity sin(angle u v)·‖u‖·‖v‖ = |cross2D u v| is the heart of the proof. It is proved via: (1) InnerProductGeometry.angle = arccos(⟨u,v⟩/‖u‖‖v‖), (2) Real.sin_arccos gives sin = sqrt(1-x²), (3) sqrt(1-(⟨u,v⟩/N)²)·N = sqrt((1-c²)·N²) = sqrt(cross²) = |cross| by the Lagrange identity, (4) Real.sqrt_sq_eq_abs closes the goal.",
+      "The 2D Lagrange identity ‖u‖²‖v‖² = ⟨u,v⟩² + (cross2D u v)² is the algebraic engine. In Fin 2 coordinates it expands to (u₀²+u₁²)(v₀²+v₁²) = (u₀v₀+u₁v₁)² + (u₀v₁-u₁v₀)², which ring closes in one tactic.",
+      "Cross product sign relations (cross_β = -cross_α, cross_γ = cross_α) follow from ring in coordinates and are critical for making the area formula work at vertices B and C where the side vectors are different.",
+      "Sin positivity (sin(α) > 0) is derived from the sin-cross identity plus cross ≠ 0 (non-degeneracy). For β and γ, it follows from area_from_B/C > 0 combined with positive side lengths.",
+      "The final cancellation uses mul_left_cancel₀ after rewriting the equality as c·(b·sin(α)) = c·(a·sin(β)) from the area equations. This avoids the messiness of dividing and handles the case cleanly."
+    ],
+    "prerequisites": [
+      "EuclideanSpace ℝ (Fin 2) and PiLp inner product space",
+      "InnerProductGeometry.angle defined as arccos(⟨u,v⟩/‖u‖‖v‖)",
+      "Real.sin_arccos: sin(arccos x) = sqrt(1-x²) for x ∈ [-1,1]",
+      "Real.sqrt_mul and Real.sqrt_sq_eq_abs",
+      "Lean 4 tactics: ring, linarith, nlinarith, norm_pos_iff, mul_left_cancel₀"
+    ]
+  },
+  "sections": [
+    {
+      "id": "cross-product",
+      "title": "2D Cross Product and Lagrange Identity",
+      "startLine": 31,
+      "endLine": 55,
+      "summary": "Defines cross2D and proves the 2D Lagrange identity ‖u‖²‖v‖² = ⟨u,v⟩² + (cross2D u v)² by ring.",
+      "mathContext": "$\\|u\\|^2 \\|v\\|^2 = \\langle u, v \\rangle^2 + (u_0 v_1 - u_1 v_0)^2$. In Fin 2 coordinates, this is $(u_0^2 + u_1^2)(v_0^2 + v_1^2) = (u_0 v_0 + u_1 v_1)^2 + (u_0 v_1 - u_1 v_0)^2$, a standard algebraic identity proved by \\texttt{ring}."
+    },
+    {
+      "id": "sin-cross-identity",
+      "title": "Sin-Angle / Cross Product Identity",
+      "startLine": 58,
+      "endLine": 105,
+      "summary": "Proves sin(angle u v)·(‖u‖·‖v‖) = |cross2D u v| for nonzero vectors, using sin_arccos and the Lagrange identity.",
+      "mathContext": "The proof chain: $\\sin(\\arccos(c)) = \\sqrt{1-c^2}$, then $\\sqrt{1-c^2} \\cdot N = \\sqrt{(1-c^2) N^2}$ (using $N \\geq 0$), then $(1-c^2)N^2 = N^2 - \\langle u,v \\rangle^2 = (\\text{cross})^2$ by Lagrange, then $\\sqrt{(\\text{cross})^2} = |\\text{cross}|$."
+    },
+    {
+      "id": "triangle-setup",
+      "title": "Triangle Structure and Basic Lemmas",
+      "startLine": 108,
+      "endLine": 163,
+      "summary": "Defines Triangle with non-degeneracy condition (cross2D(B-A, C-A) ≠ 0), side lengths a/b/c, angles α/β/γ, and area.",
+      "mathContext": "Non-degeneracy encodes that the triangle has positive area. It implies all three difference vectors are nonzero (needed for angle and sin-cross identity), and gives area_pos directly from abs_pos."
+    },
+    {
+      "id": "area-formulas",
+      "title": "Three Area Formulas",
+      "startLine": 194,
+      "endLine": 248,
+      "summary": "Proves Area = cb·sin(α)/2 = ca·sin(β)/2 = ba·sin(γ)/2 at each vertex using sin_angle_mul_norms.",
+      "mathContext": "At vertex A: the cross product of (B-A) and (C-A) captures the signed area. The sin-cross identity gives $\\sin(\\alpha) \\cdot \\|B-A\\| \\cdot \\|C-A\\| = |\\text{cross}|$. At B and C, cross product sign relations ensure the absolute values agree with the area formula."
+    },
+    {
+      "id": "law-of-sines",
+      "title": "Law of Sines",
+      "startLine": 271,
+      "endLine": 305,
+      "summary": "Derives a/sin(α) = b/sin(β) and a/sin(α) = c/sin(γ) from the area equalities.",
+      "mathContext": "From $cb\\sin(\\alpha)/2 = ca\\sin(\\beta)/2$: cancel $c/2$ to get $b\\sin(\\alpha) = a\\sin(\\beta)$. Rearrange: $a/\\sin(\\alpha) = b/\\sin(\\beta)$. The Lean proof uses \\texttt{div\\_eq\\_div\\_iff} with the sin-positivity lemmas, then \\texttt{mul\\_left\\_cancel₀} after algebraic manipulation."
+    }
+  ]
+}

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-04.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-04.json
@@ -19,9 +19,9 @@
     "phase": "OBSERVE",
     "since": "2026-04-03T05:50:19-07:00",
     "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "focus": "Surveyed \u2014 low value, parent fully verified",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "Skip \u2014 no mathematical progress possible",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,9 +29,14 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
+    "progressSummary": "SURVEYED: Low-significance pedagogical question. Parent BinomialTheoremOQ02 is fully verified (0 sorries, 0 axioms). This OQ asks for alternative proof technique (direct induction vs Mathlib delegation). No mathematical value in pursuing.",
     "builtItems": [],
-    "insights": [],
+    "insights": [
+      "Parent proof delegates multinomial theorem to Mathlib Finset.sum_pow_eq_sum_piAntidiag",
+      "OQ asks for from-scratch induction proof \u2014 pedagogical only, no new math",
+      "All 16 related Lean files are fully verified with 0 sorries and 0 axioms",
+      "Significance: 4/10 \u2014 not worth researcher time"
+    ],
     "mathlibGaps": [],
     "nextSteps": [],
     "markdown": "# Knowledge Base: binomial-theorem-oq-02-oq-04\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"

--- a/src/data/research/problems/erdos-109-oq-01.json
+++ b/src/data/research/problems/erdos-109-oq-01.json
@@ -18,13 +18,13 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-04-12T00:00:00.000Z",
-    "iteration": 2,
-    "focus": "Added 8 new proved results; 3 density sorries remain (deep ergodic theory)",
+    "iteration": 3,
+    "focus": "Fixed definition bug, decomposed density constraint into provable helpers",
     "blockers": [
       "posUpperDensity_piecewiseSyndetic requires ergodic theory / limsup API",
-      "posUpperDensity_ipStar requires IP Szemerédi theorem"
+      "posUpperDensity_ipStar requires IP Szemer\u00e9di theorem"
     ],
-    "nextAction": "Attempt sumset_density_constraint via limsup shift invariance",
+    "nextAction": "Prove upperDensity_mono from Mathlib Filter.limsup_le_limsup API",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -32,7 +32,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 10 sorries eliminated total (syndetic_infinite, ip_set_sumset_structure, ip_set_nonempty, ip_set_infinite, thick_infinite, hindman_two_color, sumset_subset_iff, syndetic_nonempty, thick_nonempty, syndetic_infinite in Aristotle). 3 sorries remain (all density/ergodic).",
+    "progressSummary": "PROGRESS: Fixed IsPiecewiseSyndetic definition bug. Proved sumset_density_constraint structurally (modulo 2 standard helpers). Sorry count 3\u21924 (net +1 from decomposition), but main theorem now has complete proof structure. 4 sorries remain: PS definition, shift invariance, monotonicity, IP*.",
     "builtItems": [
       "Created Proofs/Erdos109OQ01.lean (355 lines, 10 theorems, 7 defs, 3 sorries, 1 axiom)",
       "Defined syndetic, thick, piecewise syndetic gap conditions",
@@ -42,30 +42,35 @@
       "Added IsIPStar definition (IP* sets)",
       "Replaced false posUpperDensity_contains_IP with correct posUpperDensity_ipStar",
       "Proved ip_set_nonempty: x(0) in S via singleton FS",
-      "Proved ip_set_infinite: x(k) ≥ k+1 by induction, so S is unbounded",
-      "Proved thick_infinite: thickness g=n gives m+n ∈ S with m+n ≥ n",
-      "Proved hindman_two_color: 2-coloring → one cell is IP (via hindman_theorem)",
-      "Proved sumset_subset_iff: (B+C)⊆A ↔ ∀b∈B,∀c∈C,b+c∈A",
+      "Proved ip_set_infinite: x(k) \u2265 k+1 by induction, so S is unbounded",
+      "Proved thick_infinite: thickness g=n gives m+n \u2208 S with m+n \u2265 n",
+      "Proved hindman_two_color: 2-coloring \u2192 one cell is IP (via hindman_theorem)",
+      "Proved sumset_subset_iff: (B+C)\u2286A \u2194 \u2200b\u2208B,\u2200c\u2208C,b+c\u2208A",
       "Proved Aristotle: syndetic_nonempty, thick_nonempty, syndetic_infinite",
-      "Added detailed proof sketch for upperDensity_shift (bijection argument + O(k/N) bound)",
-      "Added proof attempt for upperDensity_mono via Filter.limsup_le_limsup with IsBounded/IsCobounded conditions"
+      "Fixed IsPiecewiseSyndetic definition (corrected mathematical bug)",
+      "Added upperDensity_shift lemma (sorry - standard real analysis)",
+      "Added upperDensity_mono lemma (sorry - standard real analysis)",
+      "Proved sumset_density_constraint from helpers (no sorry in main theorem)"
     ],
     "insights": [
       "Gap-controlled version proved by MRR (2019)",
-      "Syndetic B likely too strong — open question",
+      "Syndetic B likely too strong \u2014 open question",
       "IP sets provide bridge between density and sumset structure",
-      "Proof requires ergodic theory — beyond current Lean formalization",
-      "Positive upper density does NOT imply containing an IP set (counterexample: {n : n mod 3 ≠ 0})",
+      "Proof requires ergodic theory \u2014 beyond current Lean formalization",
+      "Positive upper density does NOT imply containing an IP set (counterexample: {n : n mod 3 \u2260 0})",
       "Correct relationship is IP* (intersects every IP set), not containment",
       "IP set sumset structure proved via odd/even index splitting of generating sequence",
-      "ip_set_infinite proof: strict monotonicity gives x(k) ≥ k+1 by induction; Set.infinite_of_not_bddAbove then closes it",
-      "thick_infinite: IsThick g=n gives run [m, m+n] ⊆ S; element m+n ≥ n provides unboundedness",
-      "hindman_two_color: use Fin 2 coloring (0 if n∈A else 1), then fin_cases on returned cell index",
-      "sumset_density_constraint (sorry): needs limsup shift invariance — injection c↦b₀+c gives |C∩Icc 1 N|≤|A∩Icc 1 (N+b₀)|, then limsup manipulation required",
-      "sumset_density_constraint approach: (N-b₀)/N → 1 allows asymptotic comparison, but Lean limsup API makes this complex",
-      "upperDensity_mono proof attempt: Filter.limsup_le_limsup needs IsBoundedUnder (C-ratio ≤ 1) and IsCoboundedUnder (A-ratio ≥ 0) — both hold but exact API needs verification",
-      "upperDensity_shift approach: {n|n+k∈A}∩[1,N] bijects with A∩[k+1,N+k], so density differs from A∩[1,N] by at most k/N → 0; requires limsup squeeze theorem",
-      "upperDensity_mono and upperDensity_shift are HARD sorries suitable for Aristotle — they use known Filter.limsup API but need careful boundedness arguments"
+      "ip_set_infinite proof: strict monotonicity gives x(k) \u2265 k+1 by induction; Set.infinite_of_not_bddAbove then closes it",
+      "thick_infinite: IsThick g=n gives run [m, m+n] \u2286 S; element m+n \u2265 n provides unboundedness",
+      "hindman_two_color: use Fin 2 coloring (0 if n\u2208A else 1), then fin_cases on returned cell index",
+      "sumset_density_constraint (sorry): needs limsup shift invariance \u2014 injection c\u21a6b\u2080+c gives |C\u2229Icc 1 N|\u2264|A\u2229Icc 1 (N+b\u2080)|, then limsup manipulation required",
+      "sumset_density_constraint approach: (N-b\u2080)/N \u2192 1 allows asymptotic comparison, but Lean limsup API makes this complex",
+      "upperDensity_mono proof: Filter.limsup_le_limsup needs IsBoundedUnder (C-ratio \u2264 1) and IsCoboundedUnder (A-ratio \u2265 0) \u2014 both hold but exact API needs verification",
+      "upperDensity_shift approach: {n|n+k\u2208A}\u2229[1,N] bijects with A\u2229[k+1,N+k], so density differs from A\u2229[1,N] by at most k/N \u2192 0; requires limsup squeeze theorem",
+      "upperDensity_mono and upperDensity_shift are HARD sorries suitable for Aristotle \u2014 they use known Filter.limsup API but need careful boundedness arguments",
+      "IsPiecewiseSyndetic definition was INCORRECT: old def \u2203 T syndetic, IsThick(S\u2229T) too strong; even 2N fails since no subset of 2N contains consecutive naturals. Fixed to standard: \u2203 T U, IsSyndetic T \u2227 IsThick U \u2227 T\u2229U \u2286 S",
+      "sumset_density_constraint decomposed into 2 standard helpers: (1) upperDensity_shift: density invariant under translation by constant, (2) upperDensity_mono: subsets have \u2264 density. Main theorem proved from these via C \u2286 {n | n+b\u2080 \u2208 A}",
+      "Key proof idea for sumset_density_constraint: pick b\u2080 \u2208 B (from syndeticity), then C maps into A via c \u21a6 c+b\u2080, giving C \u2286 preimage of A under (+b\u2080). Density preserved by shift invariance"
     ],
     "mathlibGaps": [],
     "nextSteps": [],


### PR DESCRIPTION
## Summary

- **Problem**: law-of-cosines-oq-06 — Formalize the Law of Sines for planar triangles using `InnerProductGeometry.angle` and `EuclideanSpace ℝ (Fin 2)`
- **Outcome**: Complete proof, 0 axioms, 0 sorries
- **File**: `proofs/Proofs/LawOfSinesOQ06.lean` (309 lines)

## Mathematical Content

The proof uses three components:

1. **2D Lagrange Identity** (`lagrange_2d`): `‖u‖²‖v‖² = ⟨u,v⟩² + (cross2D u v)²` — proved by `ring` in Fin 2 coordinates

2. **Sin-Cross Identity** (`sin_angle_mul_norms`): `sin(angle u v)·‖u‖·‖v‖ = |cross2D u v|` — proved via `sin_arccos`, Lagrange identity, and `sqrt_sq_eq_abs`

3. **Area Equality**: Three area formulas `Area = cb·sin(α)/2 = ca·sin(β)/2 = ba·sin(γ)/2` are equated to derive `a/sin(α) = b/sin(β) = c/sin(γ)`

## Gallery Entry

Added `src/data/proofs/law-of-cosines-oq-06/meta.json` with full mathematical context, proof strategy, key insights, and section annotations.

## Other Changes

- Resolved merge conflict in `erdos-109-oq-01.json` (iteration 3: fixed `IsPiecewiseSyndetic` definition bug, decomposed `sumset_density_constraint`; 4 sorries remain in the ergodic/limsup layer)
- Marked `binomial-theorem-oq-02-oq-04` as surveyed/low-value (parent fully verified)
- Updated Aristotle job status for `ArithmeticSeriesOQ02OQ03`

🤖 Generated with [Claude Code](https://claude.com/claude-code)