### PR TITLE
Enrich: law-of-cosines-oq-06 (annotations+conclusion) and kummer-theorem-oq-01-oq-01 (mathContext)

### DIFF
--- a/src/data/proofs/kummer-theorem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/kummer-theorem-oq-01-oq-01/annotations.json
@@ -6,6 +6,7 @@
     "type": "insight",
     "title": "Nat.factorization_choose' IS the Carries Formula — Already in Mathlib 4.26.0",
     "content": "The theorem `Nat.factorization_choose'` in `Mathlib.Data.Nat.Choose.Factorization` is:\n\n```lean\ntheorem Nat.factorization_choose' {p n k b : ℕ} (hp : p.Prime) (hnb : log p (n + k) < b) :\n    (choose (n + k) k).factorization p = #{i ∈ Ico 1 b | p ^ i ≤ k % p ^ i + n % p ^ i}\n```\n\nThe set `{i ∈ Ico 1 b | p^i ≤ k mod p^i + n mod p^i}` counts the positions where a carry occurs when adding `k` and `n` in base `p`. A carry at position `i` occurs precisely when `k mod p^i + n mod p^i ≥ p^i` — the sum of the lower `i` digits overflows.\n\nThe parent proof `KummerTheoremOQ01.lean` (line 105–108) states:\n> \"Full formalization requires base-p carry counting (not yet in Mathlib)\"\n\nThis was **wrong** as of Mathlib 4.26.0. The carry counting formalism exists as `Nat.factorization_choose'`.",
+    "mathContext": "$v_p\\binom{n+k}{k} = \\#\\{i \\in [1,b) : p^i \\le k \\bmod p^i + n \\bmod p^i\\}$ — the number of carries when adding $k$ and $n$ in base $p$. The bound $b$ need only satisfy $b > \\log_p(n+k)$.",
     "significance": "key",
     "relatedConcepts": ["Nat.factorization_choose'", "carries", "p-adic valuation", "Kummer's theorem"],
     "prerequisites": ["kummer-theorem"]
@@ -17,6 +18,7 @@
     "type": "insight",
     "title": "Three-Step Derivation: Distribution → Bridge → Kummer",
     "content": "The multinomial Kummer theorem follows a clean three-step derivation:\n\n**Step 1 — Distribution** (`factorization_list_prod`):\n```\nv_p(l.prod) = ∑ v_p(x) for x in l    [Nat.factorization_mul by induction]\n```\n\n**Step 2 — Bridge** (`multinomial_factorization_is_sum_of_binomial_factorizations`):\n```\nv_p(multinomial ks) \n  = v_p(∏ C(acc+k, k))              [multinomial_eq_prod_choose from OQ-01]\n  = ∑ v_p(C(acc+k, k))              [Step 1]\n```\n\n**Step 3 — Kummer** (`multinomial_kummer`):\n```\nv_p(C(acc+k, k)) = #{carries when adding k and acc}   [Nat.factorization_choose']\n```\n\nCombining: `v_p(multinomial ks) = ∑_{steps} #{carries at step} = total carries`.\n\nEach step is a one-or-two line Lean proof.",
+    "mathContext": "$v_p(\\text{mult}(ks)) = v_p\\!\\left(\\prod_{(acc,k)} \\binom{acc+k}{k}\\right) = \\sum_{(acc,k)} v_p\\binom{acc+k}{k} = \\sum_{(acc,k)} \\#\\{\\text{carries at step}\\}$, where the product runs over the \\texttt{scanl} pairs.",
     "significance": "key",
     "relatedConcepts": ["factorization_list_prod", "multinomial_eq_prod_choose", "Nat.factorization_choose'"],
     "prerequisites": ["kummer-theorem-oq-01"]
@@ -62,6 +64,7 @@
     "type": "technique",
     "title": "Inductive Proof that v_p Distributes Over List Products",
     "content": "`factorization_list_prod` proves `l.prod.factorization p = (l.map (·.factorization p)).sum` by induction:\n\n```lean\n| nil => simp\n| cons n rest ih =>\n    rw [Nat.factorization_mul hn hrest, Finsupp.add_apply]\n    congr 1\n    exact ih ...\n```\n\n`Nat.factorization_mul hn hrest : (n * rest.prod).factorization = n.factorization + rest.prod.factorization`\n\n`Finsupp.add_apply : (f + g) p = f p + g p`\n\nThen `congr 1` reduces to proving `rest.prod.factorization p = (rest.map ...).sum`, which is the inductive hypothesis.\n\nNote: `rest.prod ≠ 0` follows from `List.prod_ne_zero` applied to all elements satisfying the nonzero hypothesis.",
+    "mathContext": "$v_p\\!\\left(\\prod_{i=1}^{n} a_i\\right) = \\sum_{i=1}^{n} v_p(a_i)$ for $a_i \\ne 0$, proved by induction using $v_p(mn) = v_p(m) + v_p(n)$ (\\texttt{Nat.factorization\\_mul}).",
     "significance": "technique",
     "relatedConcepts": ["Nat.factorization_mul", "Finsupp.add_apply", "List.prod_ne_zero"],
     "prerequisites": ["Nat.factorization_mul", "Finsupp.add_apply", "List.prod_ne_zero"]

--- a/src/data/proofs/law-of-cosines-oq-06/annotations.json
+++ b/src/data/proofs/law-of-cosines-oq-06/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-lagrange-identity",
+    "proofId": "law-of-cosines-oq-06",
+    "range": { "startLine": 31, "endLine": 62 },
+    "type": "technique",
+    "title": "2D Lagrange Identity: Algebraic Engine for Sin-Cross Identity",
+    "content": "The 2D Lagrange identity `‖u‖²‖v‖² = ⟨u,v⟩² + (cross2D u v)²` is the algebraic foundation of the proof. In Fin 2 coordinates, it expands to:\n\n$(u_0^2 + u_1^2)(v_0^2 + v_1^2) = (u_0 v_0 + u_1 v_1)^2 + (u_0 v_1 - u_1 v_0)^2$\n\nThis is a pure polynomial identity proved by `ring`. The `cross2D` function `u 0 * v 1 - u 1 * v 0` is the 2D analog of the 3D cross product, capturing the signed area of the parallelogram spanned by `u` and `v`.\n\nThe cross product satisfies: `cross2D u u = 0` (anti-reflexivity) and `cross2D u v = -cross2D v u` (antisymmetry), both proved by `ring`. These follow directly from the definition without using the Lagrange identity.\n\nThe Lagrange identity has an elegant interpretation: $‖u × v‖^2 = ‖u‖^2 ‖v‖^2 - ⟨u,v⟩^2 = ‖u‖^2 ‖v‖^2 (1 - \\cos^2\\theta) = ‖u‖^2 ‖v‖^2 \\sin^2\\theta$, which is why it implies the sin-cross identity.",
+    "mathContext": "$\\|u\\|^2 \\|v\\|^2 = \\langle u, v \\rangle^2 + (\\text{cross}_{2D}(u,v))^2$. Rearranged: $(\\text{cross}_{2D}(u,v))^2 = \\|u\\|^2 \\|v\\|^2 - \\langle u, v \\rangle^2 = \\|u\\|^2 \\|v\\|^2 \\sin^2(\\angle(u,v))$.",
+    "significance": "key",
+    "relatedConcepts": ["Cauchy-Schwarz inequality", "cross product", "Gram determinant", "ring tactic"],
+    "prerequisites": ["EuclideanSpace ℝ (Fin 2)", "inner product definition", "norm squared formula"]
+  },
+  {
+    "id": "ann-sin-cross-identity",
+    "proofId": "law-of-cosines-oq-06",
+    "range": { "startLine": 63, "endLine": 103 },
+    "type": "insight",
+    "title": "Sin-Cross Identity: Connecting Angle to Area via arccos",
+    "content": "The key lemma `sin_angle_mul_norms` proves that for nonzero vectors `u, v ∈ ℝ²`:\n\n`sin(angle u v) · (‖u‖ · ‖v‖) = |cross2D u v|`\n\nThe proof is a 5-step algebraic chain:\n1. Unfold `angle = arccos(⟨u,v⟩/(‖u‖·‖v‖))` and apply `Real.sin_arccos`: `sin(arccos x) = sqrt(1 - x²)`\n2. Show `0 ≤ 1 - (⟨u,v⟩/N)²` using Cauchy-Schwarz derived from the Lagrange identity\n3. Establish the key algebraic identity: `(1 - (⟨u,v⟩/N)²) · N² = (cross2D u v)²` by `field_simp` + `nlinarith [lagrange_2d]`\n4. Multiply through: `sqrt(1-c²) · N = sqrt((1-c²)·N²) = sqrt(cross²)` using `Real.sqrt_mul` and `Real.sqrt_sq`\n5. Apply `Real.sqrt_sq_eq_abs` to conclude `sqrt(cross²) = |cross|`\n\nThe difficulty is that `InnerProductGeometry.angle` is defined via `arccos`, not directly as an angle. The proof must navigate the analytic machinery of `Real.sin_arccos` and square root manipulations.",
+    "mathContext": "$\\sin(\\arccos(c)) = \\sqrt{1-c^2}$, so $\\sin(\\angle(u,v)) \\cdot \\|u\\| \\|v\\| = \\sqrt{1 - \\left(\\frac{\\langle u,v \\rangle}{\\|u\\|\\|v\\|}\\right)^2} \\cdot \\|u\\|\\|v\\| = \\sqrt{\\|u\\|^2\\|v\\|^2 - \\langle u,v\\rangle^2} = |\\text{cross}_{2D}(u,v)|$.",
+    "significance": "key",
+    "relatedConcepts": ["InnerProductGeometry.angle", "Real.sin_arccos", "Real.sqrt_mul", "Real.sqrt_sq_eq_abs", "Cauchy-Schwarz"],
+    "prerequisites": ["lagrange_2d", "arccos definition", "sqrt monotonicity", "field_simp tactic"]
+  },
+  {
+    "id": "ann-triangle-structure",
+    "proofId": "law-of-cosines-oq-06",
+    "range": { "startLine": 104, "endLine": 163 },
+    "type": "definition",
+    "title": "Triangle Structure: Non-Degeneracy via Cross Product",
+    "content": "The `Triangle` structure encodes a planar triangle with a built-in non-degeneracy condition:\n\n```lean\nstructure Triangle where\n  A B C : Vec2\n  hNonDeg : cross2D (B - A) (C - A) ≠ 0\n```\n\nThis is equivalent to `Area > 0` (the triangle is non-degenerate). The condition implies:\n- All three edge vectors are nonzero: `B - A ≠ 0`, `C - A ≠ 0`, `C - B ≠ 0`\n- All side lengths are positive: `a, b, c > 0`\n- `area_pos`: Area > 0 follows immediately from `abs_pos.mpr t.hNonDeg`\n\nThe cross product sign relations are proved by `ring` in coordinates:\n- `cross_β`: `cross2D (A-B) (C-B) = -cross2D (B-A) (C-A)` — the cross products at vertices A and B differ by sign\n- `cross_γ`: `cross2D (A-C) (B-C) = cross2D (B-A) (C-A)` — vertex C gives the same sign\n\nThese sign relations are critical for the area formula to work at all three vertices without case analysis.",
+    "mathContext": "The non-degeneracy condition $\\text{cross}_{2D}(B-A, C-A) \\ne 0$ is equivalent to $A, B, C$ not being collinear. It encodes that $\\det\\begin{pmatrix}B_x - A_x & C_x - A_x \\\\ B_y - A_y & C_y - A_y\\end{pmatrix} \\ne 0$, i.e., the triangle has nonzero area.",
+    "significance": "supporting",
+    "relatedConcepts": ["structure types in Lean 4", "non-degeneracy", "signed area", "det ≠ 0"],
+    "prerequisites": ["cross2D definition", "Vec2 = EuclideanSpace ℝ (Fin 2)", "norm_pos_iff"]
+  },
+  {
+    "id": "ann-area-formulas",
+    "proofId": "law-of-cosines-oq-06",
+    "range": { "startLine": 164, "endLine": 248 },
+    "type": "technique",
+    "title": "Three Area Formulas and Sin Positivity",
+    "content": "The area formulas express the triangle area three ways, one at each vertex:\n\n- `area_from_A`: Area = c·b·sin(α)/2 (vertex A, sides `c = |AB|`, `b = |AC|`, angle α = ∠BAC)\n- `area_from_B`: Area = c·a·sin(β)/2 (vertex B, sides `c = |AB|`, `a = |BC|`, angle β = ∠ABC)\n- `area_from_C`: Area = b·a·sin(γ)/2 (vertex C, sides `b = |AC|`, `a = |BC|`, angle γ = ∠ACB)\n\nEach proof applies `sin_angle_mul_norms` to get `sin(∠)·product_of_sides = |cross|`, then uses `linarith` to match the area definition `Area = |cross|/2`.\n\nFor vertices B and C, the side vectors are reversed (e.g., `A-B` rather than `B-A`), so `norm_sub_rev` establishes `‖A-B‖ = ‖B-A‖`, and the cross sign lemmas handle `|cross2D(A-B,C-B)| = |cross2D(B-A,C-A)|`.\n\nSin positivity (`sinA_pos`, `sinB_pos`, `sinC_pos`) follows: from `sin_angle_mul_norms` and `cross ≠ 0`, we get `sin(α)·(product > 0) > 0`, so `sin(α) > 0`. This is required by `div_eq_div_iff` in the law of sines proof.",
+    "mathContext": "Area $= \\frac{1}{2}|\\text{cross}_{2D}(B-A, C-A)| = \\frac{1}{2}c \\cdot b \\cdot \\sin(\\alpha) = \\frac{1}{2}c \\cdot a \\cdot \\sin(\\beta) = \\frac{1}{2}b \\cdot a \\cdot \\sin(\\gamma)$. Each equality uses $\\sin(\\angle(u,v))\\|u\\|\\|v\\| = |\\text{cross}_{2D}(u,v)|$.",
+    "significance": "key",
+    "relatedConcepts": ["area formula", "sin positivity", "norm_sub_rev", "linarith", "abs_pos"],
+    "prerequisites": ["sin_angle_mul_norms", "cross_β", "cross_γ", "area_pos"]
+  },
+  {
+    "id": "ann-law-of-sines-final",
+    "proofId": "law-of-cosines-oq-06",
+    "range": { "startLine": 249, "endLine": 305 },
+    "type": "insight",
+    "title": "Law of Sines: Cancellation via mul_left_cancel₀",
+    "content": "The final proof of `law_of_sines_ab` derives `a/sin(α) = b/sin(β)` from the area equality:\n\n```lean\nrw [div_eq_div_iff t.sinA_pos.ne' t.sinB_pos.ne']\n-- goal: t.a * sin(β) = t.b * sin(α)\nhave h1 := t.area_from_A  -- Area = c·b·sin(α)/2\nhave h2 := t.area_from_B  -- Area = c·a·sin(β)/2\nhave heq : t.c * t.b * sin(α) = t.c * t.a * sin(β) := by linarith\nhave key : t.b * sin(α) = t.a * sin(β) := mul_left_cancel₀ t.c_pos.ne' ...\n```\n\nThe key steps:\n1. `div_eq_div_iff`: reduces `a/sinα = b/sinβ` to `a·sinβ = b·sinα`\n2. Area equality from `area_from_A = area_from_B` gives `c·b·sinα = c·a·sinβ`\n3. Factor as `c·(b·sinα) = c·(a·sinβ)` using `ring` lemmas\n4. `mul_left_cancel₀` cancels `c ≠ 0`\n\n`law_of_sines_ac` is analogous, cancelling `b` instead. The full `law_of_sines` combines both via `And.intro`.\n\nThe use of `mul_left_cancel₀` (rather than division) avoids division-by-zero concerns and produces cleaner Lean proofs.",
+    "mathContext": "$c \\cdot b \\cdot \\sin\\alpha = c \\cdot a \\cdot \\sin\\beta \\implies b \\cdot \\sin\\alpha = a \\cdot \\sin\\beta \\implies \\frac{a}{\\sin\\alpha} = \\frac{b}{\\sin\\beta}$. The final step uses `div_eq_div_iff` to cross-multiply.",
+    "significance": "key",
+    "relatedConcepts": ["div_eq_div_iff", "mul_left_cancel₀", "area equality", "sin positivity"],
+    "prerequisites": ["area_from_A", "area_from_B", "sinA_pos", "sinB_pos", "c_pos"]
+  }
+]


### PR DESCRIPTION
## Enrichment pass — 2 entries

### 1. law-of-cosines-oq-06 (quality 30 → 100)
- Added `annotations.json` with 5 annotations covering all proof sections
- Added `conclusion` to `meta.json` (summary, implications, 3 open questions)

### 2. kummer-theorem-oq-01-oq-01 (quality 93 → 100)
- Added `mathContext` LaTeX formulas to 3 annotations missing it:
  - Carries formula for `Nat.factorization_choose'`
  - Three-step multinomial derivation chain
  - v_p distribution over products via `Nat.factorization_mul`