### PR TITLE
Fix: sync lineCount for 13 gallery proofs (actual file lengths)

### DIFF
--- a/src/data/proofs/birch-swinnerton-dyer/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer/meta.json
@@ -108,7 +108,7 @@
     "dateAdded": "2025-12-29",
     "millenniumProblem": "bsd",
     "proofRepoPath": "Proofs/BirchSwinnertonDyer.lean",
-    "lineCount": 7409,
+    "lineCount": 7432,
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/brouwer-fixed-point-oq-04-oq-04/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-04-oq-04/meta.json
@@ -22,7 +22,7 @@
     "dateAdded": "2026-04-12",
     "dateUpdated": "2026-04-12",
     "axiomCount": 1,
-    "lineCount": 368,
+    "lineCount": 405,
     "theoremCount": 12,
     "defCount": 2,
     "assumptions": "1 axiom (scarf_approx_fixed_point — Scarf's n-dimensional algorithm via Sperner's lemma, with full proof sketch). 0 sorries.",
@@ -139,7 +139,7 @@
       "Proofs.BrouwerFixedPointOQ04OQ03"
     ],
     "namespace": "KakutaniConstructive",
-    "lineCount": 368,
+    "lineCount": 405,
     "axiomCount": 1,
     "theoremCount": 12,
     "definitionCount": 2,

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -16,7 +16,7 @@
     "badge": "wip",
     "sorries": 3,
     "axiomCount": 0,
-    "lineCount": 460,
+    "lineCount": 524,
     "assumptions": "3 remaining sorries: (1) truncated_rn_deriv_lq_bound — Hölder extremizer for truncations, (2) rn_deriv_memLq — Fatou from truncation bounds, (3) riesz_lp_surjective_from_rn — signed measure construction. Proved: integrationCLM linear map + continuity bound, integrationCLM_apply, lintegral_mul_le_of_memLp, integrable_mul_of_memLp, truncated_rn_deriv_memLq, Lp.induction addition + closedness cases.",
     "dateAdded": "2026-04-13"
   },
@@ -106,7 +106,7 @@
     "imports": [
       "Mathlib"
     ],
-    "lineCount": 460,
+    "lineCount": 524,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 2,

--- a/src/data/proofs/erdos-1012-oq-03/meta.json
+++ b/src/data/proofs/erdos-1012-oq-03/meta.json
@@ -15,7 +15,7 @@
     "badge": "axiom",
     "sorries": 1,
     "axiomCount": 1,
-    "lineCount": 1879,
+    "lineCount": 1827,
     "assumptions": "1 axiom: gh_longest_cycle_is_hamiltonian (Ghouila-Houri path surgery: under GH degree conditions, the longest directed cycle in a SC digraph is Hamiltonian — standard result from Ghouila-Houri 1960, Diestel §10). 1 sorry. Rédei, Moon-Moser, directed_hamiltonian_threshold fully proved.",
     "dateAdded": "2026-03-30",
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
@@ -121,7 +121,7 @@
       "Finset"
     ],
     "namespace": "Erdos1012OQ03",
-    "lineCount": 1823,
+    "lineCount": 1827,
     "axiomCount": 1,
     "sorries": 1,
     "path": "Proofs/Erdos1012OQ03.lean",

--- a/src/data/proofs/erdos-1050/meta.json
+++ b/src/data/proofs/erdos-1050/meta.json
@@ -63,7 +63,7 @@
       "erdos-257"
     ],
     "axiomCount": 2,
-    "lineCount": 357,
+    "lineCount": 405,
     "assumptions": "2 axioms: borwein_irrationality (Borwein's 1991 Padé approximation result for T(q,r)), S_approx (numerical bounds 0.286 < S < 0.288). 2 sorries: T_summable (convergence of T(q,r)), S_first_terms (initial partial sum identity)."
   },
   "overview": {
@@ -229,7 +229,7 @@
       "Real"
     ],
     "namespace": "Erdos1050",
-    "lineCount": 357,
+    "lineCount": 405,
     "axiomCount": 2,
     "theoremCount": 26,
     "definitionCount": 9,

--- a/src/data/proofs/erdos-1083-oq-02/meta.json
+++ b/src/data/proofs/erdos-1083-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-1083-oq-02",
   "title": "Distinct Distances Gap Analysis: Solymosi-Vu Bound",
   "slug": "erdos-1083-oq-02",
-  "description": "Formalizes the Solymosi-Vu lower bound for distinct distances in \u211d^d and proves the gap from the conjectured exponent is exactly 2/(d(d+2)).",
+  "description": "Formalizes the Solymosi-Vu lower bound for distinct distances in ℝ^d and proves the gap from the conjectured exponent is exactly 2/(d(d+2)).",
   "meta": {
     "author": "Lean Genius",
     "sourceUrl": "https://erdosproblems.com/1083",
@@ -23,29 +23,29 @@
     "dateAdded": "2026-04-13",
     "originalContributions": [
       "Formal statement of Solymosi-Vu bound with exact exponent 2(d+1)/(d(d+2))",
-      "Proved SV exponent lies strictly between Erd\u0151s 1/d and conjectured 2/d",
+      "Proved SV exponent lies strictly between Erdős 1/d and conjectured 2/d",
       "Derived exact gap formula: 2/(d(d+2))",
       "Concrete gap computations for d=4 (1/12) and d=10 (1/60)",
-      "Progress fraction analysis: SV covers d/(d+2) of the [Erd\u0151s\u2192conjecture] gap",
+      "Progress fraction analysis: SV covers d/(d+2) of the [Erdős→conjecture] gap",
       "Relative gap formula: remaining fraction of conjectured exponent = 1/(d+2)",
-      "Near-optimality theorems: SV covers \u22651/2 for d\u22652, \u22655/6 for d\u226510",
+      "Near-optimality theorems: SV covers ≥1/2 for d≥2, ≥5/6 for d≥10",
       "Monotonicity: relative gap decreasing in d",
-      "Impact theorem: any \u03b1 > SV reduces remaining gap below 2/(d(d+2))"
+      "Impact theorem: any α > SV reduces remaining gap below 2/(d(d+2))"
     ],
     "axiomCount": 5,
-    "lineCount": 220,
-    "assumptions": "5 axioms: f (extremal function), erdos_lower/grid_upper (Erd\u0151s 1946), solymosi_vu (2008 bound), erdos_1083_conjecture (the open conjecture).",
+    "lineCount": 235,
+    "assumptions": "5 axioms: f (extremal function), erdos_lower/grid_upper (Erdős 1946), solymosi_vu (2008 bound), erdos_1083_conjecture (the open conjecture).",
     "theoremCount": 12
   },
   "overview": {
-    "historicalContext": "Erd\u0151s (1946) established the first bounds on the distinct distances function f_d(n) in \u211d^d: n^{1/d} \u226a f_d(n) \u226a n^{2/d}. The gap between the exponents 1/d and 2/d was enormous. Solymosi and Vu (2008) dramatically improved the lower bound to n^{2(d+1)/(d(d+2))} for d \u2265 4, bringing the exponent within O(1/d\u00b2) of the conjectured truth. The remaining gap of 2/(d(d+2)) in the exponent is the target of this open question.",
+    "historicalContext": "Erdős (1946) established the first bounds on the distinct distances function f_d(n) in ℝ^d: n^{1/d} ≪ f_d(n) ≪ n^{2/d}. The gap between the exponents 1/d and 2/d was enormous. Solymosi and Vu (2008) dramatically improved the lower bound to n^{2(d+1)/(d(d+2))} for d ≥ 4, bringing the exponent within O(1/d²) of the conjectured truth. The remaining gap of 2/(d(d+2)) in the exponent is the target of this open question.",
     "problemStatement": "Can the gap between the Solymosi-Vu lower bound exponent 2(d+1)/(d(d+2)) and the conjectured exponent 2/d be eliminated? The gap is exactly 2/(d(d+2)).",
     "text": "Formalize the Solymosi-Vu bound and analyze the exponent gap for distinct distances in higher dimensions.",
-    "proofStrategy": "We axiomatize the known bounds (Erd\u0151s 1946, Solymosi-Vu 2008) and prove algebraically that the SV exponent lies strictly between Erd\u0151s's 1/d and the conjectured 2/d. We derive the exact gap formula 2/(d(d+2)) and compute it for specific dimensions.",
+    "proofStrategy": "We axiomatize the known bounds (Erdős 1946, Solymosi-Vu 2008) and prove algebraically that the SV exponent lies strictly between Erdős's 1/d and the conjectured 2/d. We derive the exact gap formula 2/(d(d+2)) and compute it for specific dimensions.",
     "keyInsights": [
-      "The SV exponent 2(d+1)/(d(d+2)) is a rational function of d, lying strictly between 1/d (Erd\u0151s) and 2/d (conjecture).",
-      "The gap 2/(d(d+2)) is O(1/d\u00b2), so the SV bound is nearly optimal in high dimensions, but the polynomial gap persists for each fixed d.",
-      "For d=4 the gap is 1/12 \u2248 0.083; for d=10 it's 1/60 \u2248 0.017."
+      "The SV exponent 2(d+1)/(d(d+2)) is a rational function of d, lying strictly between 1/d (Erdős) and 2/d (conjecture).",
+      "The gap 2/(d(d+2)) is O(1/d²), so the SV bound is nearly optimal in high dimensions, but the polynomial gap persists for each fixed d.",
+      "For d=4 the gap is 1/12 ≈ 0.083; for d=10 it's 1/60 ≈ 0.017."
     ],
     "prerequisites": [
       "Combinatorial geometry (distinct distances)",
@@ -58,7 +58,7 @@
       "title": "The Distinct Distance Function",
       "startLine": 1,
       "endLine": 30,
-      "summary": "Axiomatizes f_d(n), the minimum distinct distances from n points in \u211d^d.",
+      "summary": "Axiomatizes f_d(n), the minimum distinct distances from n points in ℝ^d.",
       "mathContext": "f_d(n) is an extremal function over all point configurations."
     },
     {
@@ -66,7 +66,7 @@
       "title": "Known Bounds",
       "startLine": 32,
       "endLine": 56,
-      "summary": "States Erd\u0151s's original bounds, the grid upper bound, and the Solymosi-Vu improvement.",
+      "summary": "States Erdős's original bounds, the grid upper bound, and the Solymosi-Vu improvement.",
       "mathContext": "The known bounds bracket f_d(n) between n^{2(d+1)/(d(d+2))} and n^{2/d}."
     },
     {
@@ -82,12 +82,12 @@
       "title": "The Conjecture",
       "startLine": 102,
       "endLine": 115,
-      "summary": "States Erd\u0151s's conjecture that f_d(n) = n^{2/d - o(1)}.",
+      "summary": "States Erdős's conjecture that f_d(n) = n^{2/d - o(1)}.",
       "mathContext": "Eliminating the SV gap would prove the conjecture."
     }
   ],
   "conclusion": {
-    "summary": "We formalize the state of Erd\u0151s #1083, proving that the Solymosi-Vu bound leaves a gap of exactly 2/(d(d+2)) from the conjectured truth. No approach is known to eliminate this gap.",
+    "summary": "We formalize the state of Erdős #1083, proving that the Solymosi-Vu bound leaves a gap of exactly 2/(d(d+2)) from the conjectured truth. No approach is known to eliminate this gap.",
     "openQuestions": [
       "Can the SV exponent be improved for specific small d (e.g., d=3 or d=4)?"
     ],

--- a/src/data/proofs/erdos-109-oq-01/meta.json
+++ b/src/data/proofs/erdos-109-oq-01/meta.json
@@ -21,7 +21,7 @@
     "dateAdded": "2026-04-12",
     "axiomCount": 4,
     "assumptions": "1 formal axiom + 2 sorry'd theorems (counted as 4 total assumptions): (1) hindman_theorem — formal axiom; Hindman 1974 finite coloring gives monochromatic IP set; (2) upperDensity_shift — sorry; shift invariance of upper density (needs Filter.limsup manipulation); (3) posUpperDensity_piecewiseSyndetic — sorry; positive density implies piecewise syndetic (classical, pigeonhole); (4) posUpperDensity_ipStar — sorry; positive density implies IP* (Furstenberg-Katznelson IP Szemerédi 1985).",
-    "lineCount": 413,
+    "lineCount": 487,
     "theoremCount": 7,
     "definitionCount": 10,
     "originalContributions": [
@@ -96,7 +96,7 @@
   },
   "leanFile": {
     "namespace": "Erdos109OQ01",
-    "lineCount": 413,
+    "lineCount": 487,
     "axiomCount": 4,
     "theoremCount": 7,
     "definitionCount": 10,

--- a/src/data/proofs/erdos-130-wip-01/meta.json
+++ b/src/data/proofs/erdos-130-wip-01/meta.json
@@ -24,7 +24,7 @@
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
     "assumptions": "No axioms. All theorems proved from Mathlib using ring identities, linarith, nlinarith, and linear_combination. The main result is a formalization of the elementary algebraic argument underlying the Anning-Erdős theorem.",
-    "lineCount": 194,
+    "lineCount": 201,
     "relatedProblems": [
       {
         "id": "erdos-130",
@@ -116,7 +116,7 @@
     ],
     "opens": [],
     "namespace": "Erdos130.AnningErdos",
-    "lineCount": 194,
+    "lineCount": 201,
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 0,

--- a/src/data/proofs/erdos-263/meta.json
+++ b/src/data/proofs/erdos-263/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/263",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "lineCount": 285,
+    "lineCount": 342,
     "assumptions": "No axioms. 5 sorry(s) remain: folklore_irrationality, kovac_tao_not_irrationality, positive_condition_irrationality, factorial_no_folklore_growth, truncation_insufficient.",
     "mathlib_version": "4.26.0"
   },
@@ -159,7 +159,7 @@
       "Real"
     ],
     "namespace": "Erdos263",
-    "lineCount": 265,
+    "lineCount": 342,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 19,

--- a/src/data/proofs/erdos-35/meta.json
+++ b/src/data/proofs/erdos-35/meta.json
@@ -24,7 +24,7 @@
     "erdosUrl": "https://erdosproblems.com/35",
     "erdosProblemStatus": "solved",
     "axiomCount": 0,
-    "lineCount": 245,
+    "lineCount": 255,
     "prerequisites": [
       "Schnirelmann density and its properties",
       "Additive bases and Waring's problem",
@@ -140,7 +140,7 @@
       "Set"
     ],
     "namespace": "Erdos35",
-    "lineCount": 245,
+    "lineCount": 255,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 9,

--- a/src/data/proofs/erdos-606-oq-03-oq-03/meta.json
+++ b/src/data/proofs/erdos-606-oq-03-oq-03/meta.json
@@ -34,7 +34,7 @@
     ],
     "dateAdded": "2026-04-12",
     "axiomCount": 1,
-    "lineCount": 223,
+    "lineCount": 508,
     "prerequisites": [
       "Basic plane geometry",
       "Finset operations"
@@ -145,7 +145,7 @@
       "Finset"
     ],
     "namespace": "SylvesterGallai",
-    "lineCount": 223,
+    "lineCount": 508,
     "axiomCount": 1,
     "theoremCount": 3,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-817/meta.json
+++ b/src/data/proofs/erdos-817/meta.json
@@ -58,7 +58,7 @@
       "Connection to Szemerédi's theorem"
     ],
     "axiomCount": 0,
-    "lineCount": 232,
+    "lineCount": 368,
     "assumptions": "0 formal axioms; 2 sorry(s) (g_ge_n bound and g3_le_exp exponential bound). See the Lean source for details."
   },
   "overview": {
@@ -202,7 +202,7 @@
       "Nat"
     ],
     "namespace": "Erdos817",
-    "lineCount": 232,
+    "lineCount": 368,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 8,

--- a/src/data/proofs/shapley-folkman/meta.json
+++ b/src/data/proofs/shapley-folkman/meta.json
@@ -61,7 +61,7 @@
       "Caratheodory's theorem (points in convex hull need at most d+1 vertices)",
       "Affine independence and dimension"
     ],
-    "lineCount": 629,
+    "lineCount": 469,
     "mathlib_version": "4.26.0",
     "leanFile": {
       "imports": [
@@ -201,7 +201,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 629,
+    "lineCount": 469,
     "structureCount": 1,
     "axiomCount": 0,
     "theoremCount": 8,


### PR DESCRIPTION
## Fix

Syncs `lineCount` metadata for 13 gallery proofs where the Lean source files have grown (or shrunk) since the count was last recorded. Only `lineCount` changed — all `badge`, `status`, `sorries`, and `axiomCount` values were independently verified correct.

## Evidence

| Proof | Claimed | Actual | Delta |
|-------|---------|--------|-------|
| erdos-606-oq-03-oq-03 | 223 | 508 | +285 |
| erdos-817 | 232 | 368 | +136 |
| erdos-109-oq-01 | 413 | 487 | +74 |
| cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01 | 460 | 524 | +64 |
| erdos-263 | 285 | 342 | +57 |
| erdos-1050 | 357 | 405 | +48 |
| brouwer-fixed-point-oq-04-oq-04 | 368 | 405 | +37 |
| birch-swinnerton-dyer | 7409 | 7432 | +23 |
| erdos-1083-oq-02 | 220 | 235 | +15 |
| erdos-35 | 245 | 255 | +10 |
| erdos-130-wip-01 | 194 | 201 | +7 |
| erdos-1012-oq-03 | 1879 | 1827 | -52 |
| shapley-folkman | 629 | 469 | -160 |

Build passes: `pnpm build` ✓

---
Automated fix by lean-mechanic agent.