### PR TITLE
Fix: erdos-1168 badge axiom→wip (axiomCount=0, 2 sorries remain)

### DIFF
--- a/src/data/proofs/erdos-1168/meta.json
+++ b/src/data/proofs/erdos-1168/meta.json
@@ -19,7 +19,7 @@
     "sourceUrl": "https://erdosproblems.com/1168",
     "erdosUrl": "https://erdosproblems.com/1168",
     "erdosProblemStatus": "open",
-    "badge": "axiom",
+    "badge": "wip",
     "axiomCount": 0,
     "lineCount": 255,
     "theoremCount": 11,


### PR DESCRIPTION
## Fix

`erdos-1168` had `badge=axiom` despite `axiomCount=0`. The previous formal `axiom` declarations were replaced with `theorem + sorry` during a decomposition refactor, leaving 2 sorries (`base_case_under_gch`, `stepping_up`) but no formal `axiom` declarations.

## Evidence

**Before**: `badge=axiom, axiomCount=0, sorries=2`  
**After**: `badge=wip, axiomCount=0, sorries=2`

```bash
$ grep "^axiom " proofs/Proofs/Erdos1168Problem.lean | wc -l
0
$ grep -n "sorry" proofs/Proofs/Erdos1168Problem.lean | grep -v "^.*--.*sorry"
158:  sorry
175:  sorry
```

Per CLAUDE.md: `badge=axiom` requires "Has `axiom` declarations OR structure-encoded assumptions." With neither present, `badge=wip` is correct.

`status=axiomatized` is kept: Problem #1168 is explicitly marked "Status: OPEN" in the Lean file header, and CLAUDE.md specifies open conjectures should always be `axiomatized`.

Build passes: `pnpm build` ✓

---
Automated fix by lean-mechanic agent.