### PR TITLE
Research: erdos-1083-oq-02 — quadratic bounds and factored SV structure (16→23 theorems)

### DIFF
--- a/proofs/Proofs/Erdos1083OQ02.lean
+++ b/proofs/Proofs/Erdos1083OQ02.lean
@@ -184,6 +184,77 @@ theorem relative_gap_decreasing (d₁ d₂ : ℕ) (h : d₁ ≤ d₂) (hd1 : d�
   linarith
 
 /-
+## Quadratic Bounds on the Gap
+
+The absolute gap 2/(d(d+2)) satisfies tight bounds:
+  1/d² < 2/(d(d+2)) < 2/d²
+Together these show the gap is exactly of order 1/d².
+-/
+
+/-- The gap strictly exceeds 1/d² for d ≥ 3.
+    Proof: 2/(d(d+2)) > 1/d² ⟺ 2d² > d(d+2) ⟺ d² > 2d ⟺ d > 2. -/
+theorem gap_exceeds_reciprocal_sq (d : ℕ) (hd : d ≥ 3) :
+    1 / (↑d : ℝ) ^ 2 < 2 / ((↑d : ℝ) * (↑d + 2)) := by
+  have hd_pos : (0 : ℝ) < (d : ℝ) := Nat.cast_pos.mpr (by omega)
+  have hd2_pos : (0 : ℝ) < (↑d : ℝ) + 2 := by linarith
+  have hd3 : (3 : ℝ) ≤ (d : ℝ) := by exact_mod_cast hd
+  rw [div_lt_div_iff (pow_pos hd_pos 2) (mul_pos hd_pos hd2_pos)]
+  have hmul : (0 : ℝ) < (↑d : ℝ) * ((↑d : ℝ) - 2) := mul_pos hd_pos (by linarith)
+  nlinarith [hmul]
+
+/-- The gap is strictly below 2/d² for d ≥ 1.
+    Proof: 2/(d(d+2)) < 2/d² ⟺ d² < d(d+2) ⟺ 0 < 2d. -/
+theorem gap_below_twice_reciprocal_sq (d : ℕ) (hd : d ≥ 1) :
+    2 / ((↑d : ℝ) * (↑d + 2)) < 2 / (↑d : ℝ) ^ 2 := by
+  have hd_pos : (0 : ℝ) < (d : ℝ) := Nat.cast_pos.mpr (by omega)
+  have hd2_pos : (0 : ℝ) < (↑d : ℝ) + 2 := by linarith
+  rw [div_lt_div_iff (mul_pos hd_pos hd2_pos) (pow_pos hd_pos 2)]
+  nlinarith
+
+/-- The absolute gap 2/(d(d+2)) is strictly decreasing in d.
+    Proof: (d+1)(d+3) > d(d+2) since 2d+3 > 0. -/
+theorem gap_strictly_decreasing (d : ℕ) (hd : d ≥ 4) :
+    2 / ((↑d + 1 : ℝ) * (↑d + 3)) < 2 / ((↑d : ℝ) * (↑d + 2)) := by
+  have hd_pos : (0 : ℝ) < (d : ℝ) := Nat.cast_pos.mpr (by omega)
+  have hd2_pos : (0 : ℝ) < (↑d : ℝ) + 2 := by linarith
+  have hd1_pos : (0 : ℝ) < (↑d : ℝ) + 1 := by linarith
+  have hd3_pos : (0 : ℝ) < (↑d : ℝ) + 3 := by linarith
+  rw [div_lt_div_iff (mul_pos hd1_pos hd3_pos) (mul_pos hd_pos hd2_pos)]
+  nlinarith
+
+/-
+## Factored Structure of the SV Exponent
+-/
+
+/-- The SV exponent factors as (d+1)/(d+2) · (2/d).
+    This reveals that SV achieves fraction (d+1)/(d+2) of the conjectured
+    exponent, with the factor approaching 1 as d → ∞. -/
+theorem sv_fraction_of_conjecture (d : ℕ) (hd : d ≥ 4) :
+    2 * (↑d + 1) / (↑d * (↑d + 2)) = (↑d + 1) / (↑d + 2) * (2 / ↑d) := by
+  have hd_pos : (0 : ℝ) < (d : ℝ) := Nat.cast_pos.mpr (by omega)
+  have hd_ne : (d : ℝ) ≠ 0 := hd_pos.ne'
+  have hd2_pos : (0 : ℝ) < (↑d : ℝ) + 2 := by linarith
+  have hd2_ne : (↑d : ℝ) + 2 ≠ 0 := hd2_pos.ne'
+  field_simp
+  ring
+
+/-- The fraction (d+1)/(d+2) is strictly increasing in d.
+    Proof: (d+1)(d+3) < (d+2)² ⟺ d²+4d+3 < d²+4d+4 ⟺ 3 < 4. -/
+theorem sv_fraction_increasing (d : ℕ) :
+    (↑d + 1) / (↑d + 2 : ℝ) < (↑d + 2) / (↑d + 3) := by
+  have hd_nn : (0 : ℝ) ≤ (d : ℝ) := by exact_mod_cast Nat.zero_le d
+  have hd2_pos : (0 : ℝ) < (↑d : ℝ) + 2 := by linarith
+  have hd3_pos : (0 : ℝ) < (↑d : ℝ) + 3 := by linarith
+  rw [div_lt_div_iff hd2_pos hd3_pos]
+  nlinarith
+
+/-- The SV fraction at d=4: (4+1)/(4+2) = 5/6. -/
+theorem sv_fraction_d4 : (4 + 1 : ℝ) / (4 + 2) = 5 / 6 := by norm_num
+
+/-- The SV fraction at d=10: (10+1)/(10+2) = 11/12. -/
+theorem sv_fraction_d10 : (10 + 1 : ℝ) / (10 + 2) = 11 / 12 := by norm_num
+
+/-
 ## Impact of Hypothetical Improvements
 -/
 
@@ -216,20 +287,23 @@ axiom erdos_1083_conjecture (d : ℕ) (hd : d ≥ 3) :
 
 State of Erdős #1083 OQ-02:
 - Erdős (1946): exponent 1/d
-- Solymosi-Vu (2008): exponent 2(d+1)/(d(d+2))
+- Solymosi-Vu (2008): exponent 2(d+1)/(d(d+2)) = (d+1)/(d+2) · (2/d)
 - Conjecture: exponent 2/d - o(1)
-- Absolute gap: 2/(d(d+2)) = O(1/d²)
+- Absolute gap: 2/(d(d+2)), with tight bounds 1/d² < gap < 2/d²
+- Gap is strictly decreasing in d (monotone convergence to 0)
 - Progress fraction: d/(d+2) of the [Erdős → conjecture] gap
 - Relative gap: 1/(d+2) of the conjectured exponent
 
 Axiom count: 5 (f, erdos_lower, grid_upper, solymosi_vu, conjecture)
 Sorry count: 0
-Proved: 12 theorems (gap analysis, progress analysis, near-optimality)
+Proved: 23 theorems (gap analysis, progress fractions, near-optimality,
+         quadratic bounds, factored structure)
 
-Key insight: SV covers d/(d+2) of the exponent gap. This fraction
-approaches 1 as d→∞, meaning SV is nearly optimal in high dimensions.
-Yet for each fixed d, the gap 2/(d(d+2)) persists and no technique
-currently eliminates it.
+Key insights:
+1. SV = (d+1)/(d+2) · conjecture: the structural obstruction is the
+   factor 1 - 1/(d+2) = d/(d+2), approaching 1 as d → ∞.
+2. 1/d² < gap < 2/d²: the gap is exactly order 1/d², not smaller.
+3. For each fixed d, the gap persists; no technique currently eliminates it.
 -/
 
 end Erdos1083OQ02

--- a/research/problems/erdos-1083-oq-02/knowledge.md
+++ b/research/problems/erdos-1083-oq-02/knowledge.md
@@ -96,3 +96,33 @@
 ### Files Modified
 - `proofs/Proofs/Erdos1083OQ02.lean` (208→274 lines, 13→19 theorems)
 - `src/data/proofs/erdos-1083-oq-02/meta.json` (lineCount, theoremCount, contributions)
+
+## Session 2026-04-14 (Session 4) - Quadratic Bounds and Factored Structure (researcher-8)
+
+**Mode**: REVISIT
+**Outcome**: progress — 7 new theorems, theorem count 16→23
+
+### What I Did
+- Cross-referenced knowledge.md session 2 claims against current file: found theorems
+  `gap_exceeds_reciprocal_sq`, `gap_below_twice_reciprocal_sq`, `gap_strictly_decreasing`,
+  `sv_fraction_of_conjecture`, `sv_fraction_increasing` were in knowledge but not in file
+- Added these theorems plus concrete instances `sv_fraction_d4`, `sv_fraction_d10`
+- Added two new sections: "Quadratic Bounds on the Gap" and "Factored Structure of SV"
+- Updated Summary comment and meta.json (lineCount 235→309, theoremCount 12→23)
+
+### Key Findings
+- Tight quadratic bounds: 1/d² < 2/(d(d+2)) < 2/d² — the gap is precisely order 1/d²
+- Factored form: SV exponent = (d+1)/(d+2) × (2/d) — the fraction approaches 1 as d→∞
+- Absolute gap is strictly decreasing: each successive d has a strictly smaller gap
+- All proofs are algebraic (div_lt_div_iff + nlinarith), no sorries added
+
+### Files Modified
+- `proofs/Proofs/Erdos1083OQ02.lean` (235→309 lines, 16→23 theorems)
+- `src/data/proofs/erdos-1083-oq-02/meta.json` (lineCount, theoremCount, originalContributions)
+
+### Status
+- **Axiom count**: 5 (unchanged)
+- **Sorry count**: 0
+- **Theorems proved**: 23 (added 7 structural/quadratic/factored theorems)
+- **Assessment**: Gallery formalization COMPLETE for known theory. The actual gap
+  reduction for any fixed d ≥ 3 remains a deep open problem with no known approach.

--- a/src/data/research/problems/erdos-1083-oq-02.json
+++ b/src/data/research/problems/erdos-1083-oq-02.json
@@ -39,7 +39,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 19 theorems (was 13). Added progress fraction analysis: SV covers d/(d+2) of Erdős→conjecture gap. Gallery formalization complete for known theory.",
+    "progressSummary": "PROGRESS: 23 theorems (was 16). Added tight quadratic bounds and factored structure. Gallery formalization COMPLETE.",
     "builtItems": [
       "Created Erdos1083OQ02.lean with SV bound formalization",
       "Proved sv_improves_erdos and sv_below_conjecture (exact exponent comparison)",
@@ -56,7 +56,12 @@
       "sv_covers_d_over_d_plus_2_of_total_gap: SV closes d/(d+2) of full Erdős→conjecture gap [Erdos1083OQ02.lean:204]",
       "sv_remaining_gap_fraction: remaining open fraction = 2/(d+2) [Erdos1083OQ02.lean:222]",
       "sv_progress_fraction_d4: d=4 progress = 2/3",
-      "sv_progress_fraction_d10: d=10 progress = 5/6"
+      "sv_progress_fraction_d10: d=10 progress = 5/6",
+      "gap_exceeds_reciprocal_sq: 1/d² < 2/(d(d+2)) for d≥3 [Erdos1083OQ02.lean:196]",
+      "gap_below_twice_reciprocal_sq: 2/(d(d+2)) < 2/d² for d≥1 [Erdos1083OQ02.lean:207]",
+      "gap_strictly_decreasing: 2/((d+1)(d+3)) < 2/(d(d+2)) for d≥4 [Erdos1083OQ02.lean:216]",
+      "sv_fraction_of_conjecture: SV = (d+1)/(d+2) × (2/d) [Erdos1083OQ02.lean:232]",
+      "sv_fraction_increasing: (d+1)/(d+2) strictly increases in d [Erdos1083OQ02.lean:243]"
     ],
     "insights": [
       "SV exponent 2(d+1)/(d(d+2)) is strictly between 1/d and 2/d for d≥4",
@@ -68,7 +73,9 @@
       "For d=4: SV covers 2/3 of gap; for d=10: 5/6; approaches 1 as d→∞",
       "For all d≥2: SV covers at least half the gap (monotone in d)",
       "Progress fraction theorem: SV closes exactly d/(d+2) of the full Erdős→conjecture gap. This is equivalent to sv_fraction_of_conjecture but viewed from a different angle (Erdős baseline vs conjecture)",
-      "The remaining open fraction is 2/(d+2): for d=4 this is 1/3, for d=10 it is 1/6, decreasing to 0"
+      "The remaining open fraction is 2/(d+2): for d=4 this is 1/3, for d=10 it is 1/6, decreasing to 0",
+      "Gap tight bounds: 1/d² < 2/(d(d+2)) < 2/d² — gap is exactly order 1/d²",
+      "Absolute gap is strictly decreasing: each additional dimension shrinks the gap"
     ],
     "mathlibGaps": [
       "No formalization of incidence geometry in ℝ^d",


### PR DESCRIPTION
## Summary

Adds 7 structural theorems to `Erdos1083OQ02.lean` completing the gap characterization for Erdős distinct distances problem #1083-OQ-02.

**Quadratic Bounds on the Gap** (new section):
- `gap_exceeds_reciprocal_sq`: 1/d² < 2/(d(d+2)) for d ≥ 3
- `gap_below_twice_reciprocal_sq`: 2/(d(d+2)) < 2/d² for d ≥ 1  
- `gap_strictly_decreasing`: absolute gap 2/((d+1)(d+3)) < 2/(d(d+2)) for d ≥ 4

**Factored Structure of SV Exponent** (new section):
- `sv_fraction_of_conjecture`: SV exponent = (d+1)/(d+2) × (2/d)
- `sv_fraction_increasing`: (d+1)/(d+2) strictly increases with d
- `sv_fraction_d4` = 5/6, `sv_fraction_d10` = 11/12

These theorems complete the structural characterization: the gap is exactly order 1/d² (not smaller), decreases monotonically with d, and the SV bound factors cleanly as (d+1)/(d+2) times the conjectured exponent.

**Stats**: 0 sorries added, 5 axioms unchanged, 16→23 theorems, 235→309 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)