### PR TITLE
enrichment: cube-root-3-irrational-oq-02 quality 91→100

### DIFF
--- a/src/data/proofs/cube-root-3-irrational-oq-02/annotations.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-02/annotations.json
@@ -38,7 +38,7 @@
   {
     "id": "ann-cbrt3oq02-irrational",
     "proofId": "cube-root-3-irrational-oq-02",
-    "range": { "startLine": 76, "endLine": 82 },
+    "range": { "startLine": 89, "endLine": 123 },
     "type": "theorem",
     "title": "cbrt3_irrational_via_eisenstein: Main Result",
     "content": "Proves Irrational ((3:ℝ)^(1/3:ℝ)) by contradiction. From hq : (↑q:ℝ) = ∛3, derives (q:ℝ)^3 = 3 via Real.rpow_mul, then q^3 = 3 : ℚ by exact_mod_cast. The eval computation shows q is a root of X³−3 via simp+hq3. Applies X3_sub_3_no_rat_root for contradiction.",
@@ -46,5 +46,17 @@
     "significance": "key",
     "relatedConcepts": ["Irrational", "Real.rpow_mul", "exact_mod_cast", "X3_sub_3_no_rat_root"],
     "prerequisites": ["X3_sub_3_no_rat_root", "Real.rpow_mul", "Real.rpow_natCast"]
+  },
+  {
+    "id": "ann-cbrt3oq02-case-analysis",
+    "proofId": "cube-root-3-irrational-oq-02",
+    "range": { "startLine": 72, "endLine": 88 },
+    "type": "technique",
+    "title": "Universal Pattern: isUnit_or_isUnit for Irreducibility → No Roots",
+    "content": "`cases X3_sub_3_irred.isUnit_or_isUnit hR` generates two cases that both yield degree contradictions:\n\n**Case `inl h`** — X − Cq is a unit:\n```lean\nhave hd := Polynomial.natDegree_eq_zero_of_isUnit h  -- hd : (X-Cq).natDegree = 0\nhave hd1 : (X - C q : ℚ[X]).natDegree = 1 := natDegree_X_sub_C q\nomega  -- 0 = 1, contradiction\n```\n\n**Case `inr h`** — cofactor R is a unit:\n```lean\nhave hR_deg : R.natDegree = 0 := Polynomial.natDegree_eq_zero_of_isUnit h\n-- natDegree((X-Cq) * R) = natDegree(X-Cq) + natDegree(R) = 1 + 0 = 1\n-- But natDegree(X³-3) = 3 (proved in setup), so 3 = 1. norm_num.\n```\n\nThis pattern — splitting on `Irreducible.isUnit_or_isUnit` and deriving degree contradictions — works for any irreducible polynomial of degree ≥ 2 over any field. The key lemmas `natDegree_eq_zero_of_isUnit` and `natDegree_mul` are the workhorses.",
+    "mathContext": "General fact: if $p \\in F[X]$ is irreducible with $\\deg p \\geq 2$ and $p(\\alpha) = 0$ for $\\alpha \\in F$, then $(X-\\alpha) \\mid p$, say $p = (X-\\alpha) \\cdot R$. Since $p$ is irreducible, one factor is a unit. Units in $F[X]$ are nonzero constants, so $\\deg = 0$. But $\\deg(X-\\alpha) = 1 > 0$ and $\\deg p = \\deg(X-\\alpha) + \\deg R \\geq 1 + 0 \\neq \\deg p$ in the other case. Contradiction.",
+    "significance": "technique",
+    "relatedConcepts": ["Irreducible.isUnit_or_isUnit", "natDegree_eq_zero_of_isUnit", "natDegree_mul", "natDegree_X_sub_C"],
+    "prerequisites": ["X3_sub_3_irred", "Polynomial.natDegree_eq_zero_of_isUnit", "Polynomial.natDegree_mul"]
   }
 ]

--- a/src/data/proofs/cube-root-3-irrational-oq-02/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-02/meta.json
@@ -38,7 +38,8 @@
       "Eisenstein at p=3 is immediate: the three conditions norm_num to True in one line via eisenstein_X_pow_sub_of_sqfree_factor from CubeRoot2IrrationalOQ03",
       "The irreducibility → no rational roots argument uses `natDegree_eq_zero_of_isUnit` which was already available in the gallery",
       "The rpow arithmetic `((3:ℝ)^(1/3))^3 = 3` uses the same Real.rpow_mul pattern as all the other cube root files",
-      "The key advantage over the direct proof: Eisenstein simultaneously shows X³−3 has NO rational roots, not just that ∛3 is not an integer — a strictly stronger algebraic statement"
+      "The key advantage over the direct proof: Eisenstein simultaneously shows X³−3 has NO rational roots, not just that ∛3 is not an integer — a strictly stronger algebraic statement",
+      "**The two-case structure is canonical for irreducible polynomials**: The proof of 'irreducible → no roots' uses `Irreducible.isUnit_or_isUnit` to split on which factor is a unit. Case `inl` (X−Cq is a unit) is contradicted by natDegree=1≠0. Case `inr` (cofactor R is a unit) gives natDegree(X³−3) = natDegree(X−Cq) + 0 = 1, contradicting natDegree=3. This two-case pattern is the universal argument: any irreducible polynomial of degree ≥ 2 has no roots in its coefficient field."
     ],
     "prerequisites": [
       "CubeRoot2IrrationalOQ03.lean: eisenstein_X_pow_sub_of_sqfree_factor general theorem",
@@ -49,35 +50,43 @@
   "sections": [
     {
       "id": "sec-imports",
-      "title": "Imports and Setup",
+      "title": "Imports and Mathematical Strategy",
       "startLine": 1,
-      "endLine": 25,
-      "summary": "File header explaining the Eisenstein approach. Imports CubeRoot2IrrationalOQ03 (for the general Eisenstein theorem) and Mathlib.Data.Real.Irrational. Opens the Polynomial namespace for clean notation.",
-      "mathContext": "The key import: `eisenstein_X_pow_sub_of_sqfree_factor n m p hn hp hdvd hndvd hm : Irreducible (X^n - C(m:ℚ))` when p|m but p²∤m."
+      "endLine": 33,
+      "summary": "File header explaining the three-step Eisenstein strategy: (1) irreducibility, (2) no rational roots, (3) irrationality. Imports CubeRoot2IrrationalOQ03 (for eisenstein_X_pow_sub_of_sqfree_factor) and Mathlib.Data.Real.Irrational. Opens Polynomial namespace.",
+      "mathContext": "The key import: `eisenstein_X_pow_sub_of_sqfree_factor n m p hn hp hdvd hndvd hm : Irreducible (X^n - C(m:ℚ))` when p|m but p²∤m. Gauss's lemma is built into the Mathlib version."
     },
     {
       "id": "sec-irred",
-      "title": "X³−3 is Irreducible over ℚ",
+      "title": "PART 1: X³−3 is Irreducible over ℚ",
       "startLine": 34,
-      "endLine": 48,
-      "summary": "X3_sub_3_irred: Irreducible (X^3 - C 3 : ℚ[X]). Single-line proof applying eisenstein_X_pow_sub_of_sqfree_factor 3 3 3 with norm_num for all side conditions.",
-      "mathContext": "The four norm_num conditions: (1) 2 ≤ 3, (2) Nat.Prime 3, (3) 3 ∣ 3, (4) ¬ 3² ∣ 3, (5) 3 ≠ 0."
+      "endLine": 49,
+      "summary": "X3_sub_3_irred: Irreducible (X^3 - C 3 : ℚ[X]). Single-line proof applying eisenstein_X_pow_sub_of_sqfree_factor 3 3 3 with five norm_num side conditions.",
+      "mathContext": "Eisenstein conditions for $X^3 - 3$ at $p = 3$: (1) $2 \\leq 3$, (2) $\\text{Nat.Prime}\\,3$, (3) $3 \\mid 3$ (constant), (4) $\\neg\\,9 \\mid 3$, (5) $3 \\neq 0$."
     },
     {
-      "id": "sec-no-rat-root",
-      "title": "No Rational Roots",
-      "startLine": 52,
-      "endLine": 72,
-      "summary": "X3_sub_3_no_rat_root: ∀ q:ℚ, eval q (X³−3) ≠ 0. Proof by contradiction: if q is a root then (X−Cq)|X³−3; by irreducibility either the factor or cofactor is a unit; degree analysis (natDegree_eq_zero_of_isUnit) gives contradiction in both cases.",
-      "mathContext": "Key lemma chain: dvd_iff_isRoot → Irreducible.isUnit_or_isUnit → natDegree_eq_zero_of_isUnit. The two cases: unit degree-1 factor (natDeg=1≠0, omega), unit cofactor (natDeg 3 = 1+0, norm_num)."
+      "id": "sec-no-rat-root-setup",
+      "title": "PART 2a: Divisibility and Degree Setup",
+      "startLine": 50,
+      "endLine": 71,
+      "summary": "First half of X3_sub_3_no_rat_root: establishes (X−Cq)∣(X³−3) via dvd_iff_isRoot.mpr, destructures into cofactor R, and proves natDegree(X³−3)=3 via natDegree_sub_eq_left_of_natDegree_lt.",
+      "mathContext": "$\\deg(X^3) = 3 > 0 = \\deg(C\\,3)$, so $\\deg(X^3 - C\\,3) = 3$ via `natDegree_sub_eq_left_of_natDegree_lt` with `natDegree_pow` and `natDegree_X`."
+    },
+    {
+      "id": "sec-no-rat-root-cases",
+      "title": "PART 2b: isUnit_or_isUnit Case Analysis",
+      "startLine": 72,
+      "endLine": 88,
+      "summary": "Second half: cases X3_sub_3_irred.isUnit_or_isUnit hR. Case inl: X−Cq is a unit, natDegree=1≠0 (omega). Case inr: cofactor R is a unit, natDegree(X³−3)=1+0=1≠3 (norm_num).",
+      "mathContext": "Irreducibility splits $X^3 - 3 = (X-q) \\cdot R$. \\textbf{inl}: $\\deg(X-q) = 0 \\neq 1$ (omega). \\textbf{inr}: $\\deg(X^3-3) = \\deg(X-q) + 0 = 1 \\neq 3$ (norm\\_num). Both cases give contradiction."
     },
     {
       "id": "sec-irrational",
-      "title": "Irrationality via Eisenstein",
-      "startLine": 76,
-      "endLine": 82,
-      "summary": "cbrt3_irrational_via_eisenstein: Irrational ((3:ℝ)^(1/3:ℝ)). Proof: intro ⟨q,hq⟩, derive q³=3 via rpow_mul, conclude q is a root of X³−3 (by simp+hq3), apply X3_sub_3_no_rat_root.",
-      "mathContext": "The rpow step: ((3:ℝ)^(1/3))^3 = 3^((1/3)·3) = 3^1 = 3 via Real.rpow_mul (since 0≤3). The cast: (q:ℝ)^3=3 implies q^3=3:ℚ by exact_mod_cast (injectivity of ℚ→ℝ)."
+      "title": "PART 3: Irrationality via Eisenstein",
+      "startLine": 89,
+      "endLine": 123,
+      "summary": "cbrt3_irrational_via_eisenstein: Irrational ((3:ℝ)^(1/3:ℝ)). Four-step proof: intro ⟨q,hq⟩, derive q³=3 via rpow_mul, cast to ℚ via exact_mod_cast, show q is a root, apply X3_sub_3_no_rat_root.",
+      "mathContext": "The rpow step: $((3)^{1/3})^3 = 3^{(1/3)\\cdot 3} = 3^1 = 3$ via `Real.rpow_mul` (requires $3 \\geq 0$). Cast: $(q : \\mathbb{R})^3 = 3 \\Rightarrow q^3 = 3 : \\mathbb{Q}$ by `exact_mod_cast`."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
## Enrichment: cube-root-3-irrational-oq-02

**Quality**: 91 → 100

### Changes

**meta.json**:
- Added 5th keyInsight: the two-case `isUnit_or_isUnit` pattern is canonical for proving irreducible → no roots for any degree ≥ 2 polynomial
- Restructured sections from 4 → 5 (with corrected line ranges throughout):
  - `sec-imports` (1-33): complete header with strategy overview
  - `sec-irred` (34-49): PART 1 X3_sub_3_irred
  - `sec-no-rat-root-setup` (50-71): PART 2a divisibility + natDegree setup
  - `sec-no-rat-root-cases` (72-88): PART 2b isUnit_or_isUnit case analysis
  - `sec-irrational` (89-123): PART 3 full theorem (was incorrectly 76-82 → now 89-123)

**annotations.json**:
- Fixed `ann-cbrt3oq02-irrational` range from 76-82 → 89-123 (theorem starts at line 106)
- Added `ann-cbrt3oq02-case-analysis` (72-88): explains the two-case Lean proof structure with inline code and general theory

🤖 Generated with [Claude Code](https://claude.com/claude-code)