### PR TITLE
Audit: tracker update 2026-04-14 (round 2)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -309,10 +309,10 @@
       "result": "clean"
     },
     "ballot-problem-oq-01-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
-      "result": "clean"
+      "lastAudited": "2026-04-14T18:30:04Z",
+      "result": "issues-fixed"
     },
     "ballot-problem-oq-01-oq-04": {
       "auditCount": 2,
@@ -12588,6 +12588,12 @@
       "issues": []
     },
     "law-of-sines-oq-06": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-14T18:00:25Z",
+      "result": "issues-found",
+      "issues": []
+    },
+    "law-of-cosines-oq-06": {
       "auditCount": 1,
       "lastAudited": "2026-04-14T18:00:25Z",
       "result": "issues-found",


### PR DESCRIPTION
## Audit Tracker Update

Updates tracker entries for two proofs audited on 2026-04-14:

| Proof | Result | Notes |
|-------|--------|-------|
| law-of-cosines-oq-06 | ⚠️ issues-found | Law of Sines proof in cosines namespace (filed #10737) |
| ballot-problem-oq-01-oq-02 | ✅ issues-fixed | Badge verified→mathlib corrected in #10761 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)