### PR TITLE
Research: erdos-263 prove factorial_no_folklore_growth (sorry 5→4)

### DIFF
--- a/proofs/Proofs/Stubs/Erdos263Problem.lean
+++ b/proofs/Proofs/Stubs/Erdos263Problem.lean
@@ -158,14 +158,57 @@ theorem positive_condition_irrationality (a : PosIntSeq)
 /-- The factorial sequence n!. -/
 def factorial_seq : PosIntSeq := fun n => ⟨Nat.factorial (n + 1), Nat.factorial_pos _⟩
 
+/-- n + 2 ≤ 2^(2^n) for all n : ℕ. -/
+private lemma succ2_le_two_pow_pow (n : ℕ) : n + 2 ≤ 2 ^ (2 ^ n) := by
+  induction n with
+  | zero => norm_num
+  | succ m ih =>
+    have hge2 : 2 ≤ 2 ^ (2 ^ m) :=
+      calc (2 : ℕ) = 2 ^ 1 := by norm_num
+        _ ≤ 2 ^ (2 ^ m) := Nat.pow_le_pow_right (by norm_num) (Nat.one_le_pow m 2 (by norm_num))
+    have h2m : 2 ^ (2 ^ (m + 1)) = 2 ^ (2 ^ m) * 2 ^ (2 ^ m) := by
+      have : 2 ^ (m + 1) = 2 ^ m + 2 ^ m := by ring
+      rw [this, pow_add]
+    rw [h2m]
+    calc m + 1 + 2 = m + 3 := by ring
+      _ ≤ 2 * (m + 2) := by omega
+      _ ≤ 2 ^ (2 ^ m) * 2 ^ (2 ^ m) := Nat.mul_le_mul hge2 ih
+
+/-- (n+1)! ≤ 2^(2^n) for all n : ℕ. -/
+private lemma factorial_le_two_pow_pow (n : ℕ) : Nat.factorial (n + 1) ≤ 2 ^ (2 ^ n) := by
+  induction n with
+  | zero => simp
+  | succ m ih =>
+    rw [show m + 1 + 1 = (m + 1) + 1 from rfl, Nat.factorial_succ]
+    have h2m : 2 ^ (2 ^ (m + 1)) = 2 ^ (2 ^ m) * 2 ^ (2 ^ m) := by
+      have : 2 ^ (m + 1) = 2 ^ m + 2 ^ m := by ring
+      rw [this, pow_add]
+    rw [h2m]
+    exact Nat.mul_le_mul (succ2_le_two_pow_pow m) ih
+
 /-- Factorial does NOT have folklore growth.
-    Proof sketch: k ≤ 2^{k-1} for k ≥ 1, so (n+1)! = ∏_{k=1}^{n+1} k ≤ 2^{n(n+1)/2}.
-    Then ((n+1)!)^{1/2^n} ≤ (2^{n(n+1)/2})^{1/2^n} = 2^{n(n+1)/2^{n+1}}.
-    The exponent n(n+1)/2^{n+1} ≤ 3/4 for all n ≥ 1 (max at n=2,3: 6/8 = 3/4).
-    So the sequence is bounded above by 2^{3/4} < 2, contradicting → ∞. -/
+    Key bound: (n+1)! ≤ 2^(2^n), so ((n+1)!)^{1/2^n} ≤ 2 for all n.
+    This contradicts → ∞ (function is bounded). -/
 theorem factorial_no_folklore_growth : ¬HasFolkloreGrowth factorial_seq := by
-  sorry
-  /- TODO: Formalize the bound (n+1)! ≤ 2^{n(n+1)/2} and exponent estimate n(n+1)/2^{n+1} ≤ 3/4. -/
+  intro h
+  have h3 : ∀ᶠ n in Filter.atTop, (3 : ℝ) ≤
+      ((factorial_seq n : ℕ) : ℝ) ^ (1 / (2 : ℝ) ^ n) :=
+    Filter.tendsto_atTop.mp h 3
+  obtain ⟨N, hN⟩ := h3.exists
+  have hle : ((factorial_seq N : ℕ) : ℝ) ^ (1 / (2 : ℝ) ^ N) ≤ 2 := by
+    simp only [factorial_seq, PNat.val_mk]
+    have hfact : (Nat.factorial (N + 1) : ℝ) ≤ (2 : ℝ) ^ (2 ^ N) :=
+      by exact_mod_cast factorial_le_two_pow_pow N
+    calc (Nat.factorial (N + 1) : ℝ) ^ (1 / (2 : ℝ) ^ N)
+        ≤ ((2 : ℝ) ^ (2 ^ N)) ^ (1 / (2 : ℝ) ^ N) :=
+          Real.rpow_le_rpow (by positivity) hfact (by positivity)
+      _ = (2 : ℝ) := by
+          rw [← Real.rpow_natCast (2 : ℝ) (2 ^ N),
+              ← Real.rpow_mul (by norm_num : (0 : ℝ) ≤ 2)]
+          push_cast
+          rw [mul_one_div, div_self (pow_ne_zero N (by norm_num : (2 : ℝ) ≠ 0)),
+              Real.rpow_one]
+  linarith
 
 /-- The tower sequence 2^2^...^2 (n times). -/
 noncomputable def tower : ℕ → ℕ

--- a/research/problems/erdos-263/knowledge.md
+++ b/research/problems/erdos-263/knowledge.md
@@ -14,6 +14,50 @@ irrationality sequences. Both original questions remain open.
 
 ---
 
+## Session 2026-04-14 (Session 2) — Prove factorial_no_folklore_growth
+
+**Mode**: REVISIT (MODERATE knowledge tier)
+**Outcome**: progress — proved `factorial_no_folklore_growth` (sorries 5→4)
+
+### What I Did
+
+Proved `factorial_no_folklore_growth : ¬HasFolkloreGrowth factorial_seq` via two helper lemmas:
+
+**`succ2_le_two_pow_pow`**: n + 2 ≤ 2^(2^n) for all n.
+- Base: 0 + 2 = 2 ≤ 2^1 = 2 ✓
+- Step: 2^(2^(m+1)) = 2^(2^m) * 2^(2^m) ≥ 2 * (m+2) ≥ m+3 ✓
+
+**`factorial_le_two_pow_pow`**: (n+1)! ≤ 2^(2^n) for all n.
+- Base: 1! = 1 ≤ 2^1 = 2 ✓
+- Step: (m+2)! = (m+2) * (m+1)! ≤ 2^(2^m) * 2^(2^m) = 2^(2^(m+1)) ✓
+
+**Main theorem**: If `HasFolkloreGrowth factorial_seq` then eventually `((n+1)!)^{1/2^n} ≥ 3`.
+But `(n+1)! ≤ 2^(2^n)` implies `((n+1)!)^{1/2^n} ≤ (2^(2^n))^{1/2^n} = 2 < 3`. Contradiction.
+
+### Key Lean Techniques
+
+- `Filter.tendsto_atTop.mp h 3` → eventuality argument
+- `Real.rpow_le_rpow` to propagate the factorial bound through rpow
+- `← rpow_natCast` + `← rpow_mul` + `push_cast` + `div_self` to compute `(2^{2^N})^{1/2^N} = 2`
+- `Nat.mul_le_mul` for both helper inductions
+
+### Remaining Sorries (4)
+
+1. `folklore_irrationality`: aₙ^{1/2^n} → ∞ ⟹ Σ 1/aₙ irrational — requires Mahler-type criterion (DEEP, not in Mathlib)
+2. `kovac_tao_not_irrationality`: The 2024 negative result — requires greedy Egyptian fraction construction (DEEP)
+3. `positive_condition_irrationality`: liminf aₙ₊₁/aₙ^{2+ε} > 0 ⟹ irrationality sequence (DEEP)
+4. `truncation_insufficient`: ∀N, ∃ sequences agreeing on N terms with opposite irrationality status (DEEP)
+
+All 4 remaining sorries reflect genuinely open or deep mathematics beyond current Mathlib.
+
+### Files Modified
+
+- `proofs/Proofs/Stubs/Erdos263Problem.lean` (285 → ~345 lines, 5 → 4 sorries)
+- `src/data/proofs/erdos-263/meta.json` (sorries 5→4, lineCount updated)
+- `src/data/research/problems/erdos-263.json` (knowledge updated)
+
+---
+
 ## Session 2026-04-13 (Session 1) — Initial Survey + First Proof
 
 **Mode**: FRESH (EMPTY knowledge tier)

--- a/src/data/research/problems/erdos-263.json
+++ b/src/data/research/problems/erdos-263.json
@@ -1,6 +1,6 @@
 {
   "slug": "erdos-263",
-  "title": "Erd\u0151s #263: Irrationality Sequences",
+  "title": "Erdős #263: Irrationality Sequences",
   "phase": "ACT",
   "status": "active",
   "tier": "A",
@@ -29,29 +29,35 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved two_pow_ge_sq + doubleExp_superexponential (sorry 6\u21924). characterization_gap now also closed.",
+    "progressSummary": "PROGRESS: Proved factorial_no_folklore_growth (sorry 5→4). Remaining: 4 deep sorries (folklore irrationality, KT result, positive condition, truncation) — all require non-Mathlib math.",
     "builtItems": [
-      "doubleExp_not_folklore_growth: \u00acHasFolkloreGrowth doubleExp \u2014 proved in proofs/Proofs/Stubs/Erdos263Problem.lean:89",
-      "two_pow_ge_sq: \u2200 n \u2265 4, n^2 \u2264 2^n \u2014 private lemma in Erdos263Problem.lean:202",
-      "doubleExp_superexponential: HasSuperexponentialGrowth doubleExp \u2014 proved in Erdos263Problem.lean:225"
+      "doubleExp_not_folklore_growth: ¬HasFolkloreGrowth doubleExp — proved in proofs/Proofs/Stubs/Erdos263Problem.lean:89",
+      "two_pow_ge_sq: ∀ n ≥ 4, n^2 ≤ 2^n — private lemma in Erdos263Problem.lean:202",
+      "doubleExp_superexponential: HasSuperexponentialGrowth doubleExp — proved in Erdos263Problem.lean:225",
+      "succ2_le_two_pow_pow: n+2 ≤ 2^(2^n) — private lemma in Erdos263Problem.lean",
+      "factorial_le_two_pow_pow: (n+1)! ≤ 2^(2^n) — private lemma in Erdos263Problem.lean",
+      "factorial_no_folklore_growth: ¬HasFolkloreGrowth factorial_seq — proved in Erdos263Problem.lean"
     ],
     "insights": [
-      "(2^{2^n})^{1/2^n} = 2^{(2^n)*(1/2^n)} = 2^1 = 2 \u2014 the function is constantly 2, so doubleExp does NOT satisfy the folklore condition",
-      "rpow_natCast + rpow_mul + mul_inv_cancel\u2080 + rpow_one are the key Lean lemmas for computing (2^{2^n})^{1/2^n} = 2",
-      "Filter.tendsto_atTop.mp extracts \u2200\u1da0 n, C \u2264 f n from f \u2192 \u221e; using C=3 and f(n)=2 gives contradiction",
-      "HasFolkloreGrowth requires a\u2099^{1/2^n} \u2192 \u221e; since (doubleExp n)^{1/2^n} = 2 constantly, doubleExp fails",
+      "(2^{2^n})^{1/2^n} = 2^{(2^n)*(1/2^n)} = 2^1 = 2 — the function is constantly 2, so doubleExp does NOT satisfy the folklore condition",
+      "rpow_natCast + rpow_mul + mul_inv_cancel₀ + rpow_one are the key Lean lemmas for computing (2^{2^n})^{1/2^n} = 2",
+      "Filter.tendsto_atTop.mp extracts ∀ᶠ n, C ≤ f n from f → ∞; using C=3 and f(n)=2 gives contradiction",
+      "HasFolkloreGrowth requires aₙ^{1/2^n} → ∞; since (doubleExp n)^{1/2^n} = 2 constantly, doubleExp fails",
       "characterization_gap theorem depends on doubleExp_superexponential (still sorry); proving it would show folklore condition is strictly stronger than superexponential growth",
-      "Chain C \u2264 n \u2264 2^n \u2264 (2^{2^n})^{1/n} for n \u2265 max(4,\u2308C\u2309): first use n \u2264 2^n (Nat.lt_pow_self), then rpow_mul + rpow_le_rpow_of_exponent_le after establishing n^2 \u2264 2^n",
-      "key Lean lemmas: Real.rpow_mul, Real.rpow_le_rpow_of_exponent_le, Real.rpow_natCast, Nat.mul_le_mul, Nat.lt_pow_self"
+      "Chain C ≤ n ≤ 2^n ≤ (2^{2^n})^{1/n} for n ≥ max(4,⌈C⌉): first use n ≤ 2^n (Nat.lt_pow_self), then rpow_mul + rpow_le_rpow_of_exponent_le after establishing n^2 ≤ 2^n",
+      "key Lean lemmas: Real.rpow_mul, Real.rpow_le_rpow_of_exponent_le, Real.rpow_natCast, Nat.mul_le_mul, Nat.lt_pow_self",
+      "Key bound: (n+1)! ≤ 2^(2^n) via induction; proves factorial function is bounded under rpow with exp 1/2^n",
+      "factorial_no_folklore_growth proof: (n+1)!^{1/2^n} ≤ (2^{2^n})^{1/2^n} = 2 < 3 for all n, contradicting tendsto to ∞"
     ],
     "mathlibGaps": [
-      "No elementary tendsto proof for 2^n/n \u2192 \u221e directly \u2014 need to go via Nat.log or exponential comparison for doubleExp_superexponential",
-      "folklore_irrationality requires deep irrationality criterion \u2014 not in Mathlib",
-      "kovac_tao_not_irrationality requires Kova\u010d-Tao 2024 construction \u2014 not in Mathlib"
+      "No elementary tendsto proof for 2^n/n → ∞ directly — need to go via Nat.log or exponential comparison for doubleExp_superexponential",
+      "folklore_irrationality requires deep irrationality criterion — not in Mathlib",
+      "kovac_tao_not_irrationality requires Kovač-Tao 2024 construction — not in Mathlib"
     ],
     "nextSteps": [
-      "Prove factorial_no_folklore_growth: (n!)^{1/2^n} \u2192 1 \u2260 \u221e (Stirling or direct estimate)",
-      "Submit kovac_tao_not_irrationality and folklore_irrationality to Aristotle as deep sorries"
+      "Submit folklore_irrationality to future work — needs Mahler-type criterion",
+      "Submit kovac_tao_not_irrationality to future work — needs Egyptian fraction construction",
+      "truncation_insufficient requires constructing concrete sequences with opposite irrationality status"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary
- Proves `factorial_no_folklore_growth : ¬HasFolkloreGrowth factorial_seq` via two inductive helper lemmas
- Key bound: (n+1)! ≤ 2^(2^n) for all n, so ((n+1)!)^{1/2^n} ≤ 2, contradicting tendsto to ∞
- Reduces sorry count 5→4 in `Proofs/Stubs/Erdos263Problem.lean`

## Mathematical content

**`succ2_le_two_pow_pow`**: n + 2 ≤ 2^(2^n) by induction on n.
Inductive step: 2^(2^(m+1)) = (2^(2^m))^2 ≥ 2·(m+2) ≥ m+3.

**`factorial_le_two_pow_pow`**: (n+1)! ≤ 2^(2^n) by induction.
Inductive step: (m+2)·(m+1)! ≤ 2^(2^m)·2^(2^m) = 2^(2^(m+1)).

**Main theorem**: HasFolkloreGrowth would give eventually ≥ 3, but bound gives ≤ 2. Contradiction.

## Remaining sorries (4 — all deep)
1. `folklore_irrationality`: Mahler-type irrationality criterion (not in Mathlib)
2. `kovac_tao_not_irrationality`: Kovač-Tao 2024 Egyptian fraction construction
3. `positive_condition_irrationality`: liminf growth condition → irrationality
4. `truncation_insufficient`: Non-computability structural result

## Test plan
- [ ] Build `Proofs.Stubs.Erdos263Problem` via docker-build.sh
- [ ] Verify sorry count = 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)