### PR TITLE
enricher-1: enrich erdos-1027-oq-01 + binomial-theorem-oq-04-oq-03

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-04-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-04-oq-03/meta.json
@@ -31,7 +31,7 @@
     ]
   },
   "overview": {
-    "historicalContext": "Gaussian binomial coefficients were introduced by Gauss in his work on number theory (1811). They arise naturally as counting subspaces of vector spaces over finite fields, and are central to the theory of quantum groups, partition theory, and algebraic combinatorics.",
+    "historicalContext": "Gaussian binomial coefficients were introduced by Gauss in his 1808-1811 work on number theory, where he counted k-dimensional subspaces of F_q^n — a fundamental quantity in finite geometry. Alexandre-Théophile Vandermonde had earlier (1772) identified the classical convolution identity ∑ C(m,j)C(n,k-j) = C(m+n,k); Cauchy (1843) gave the q-analog in his mémoire on series, establishing ∑ q^{(k-j)(m-j)} [m,j]_q [n,k-j]_q = [m+n,k]_q. The extra q-power factor has a beautiful combinatorial meaning: it counts the relative positions of two complementary subspaces, a phenomenon with no classical analog.\n\nThe theory of q-analogs underwent a renaissance in the 20th century through George Andrews' work on partition theory (1976) and the emergence of quantum groups in mathematical physics (Jimbo-Drinfeld, 1985). Quantum groups deform classical Lie algebra symmetry by replacing integers n with q-numbers [n]_q, and q-binomial coefficients appear as the natural q-analog of binomial coefficients in representation theory. The q-Vandermonde identity is the 'mother of all q-identities': the Rogers-Ramanujan identities, q-Pfaff-Saalschütz, and many other results in the theory of basic hypergeometric series follow from it.\n\nThis formalization builds the complete q-analog infrastructure from scratch (qNat, qFactorial, gaussianBinomial) because Mathlib currently lacks these definitions in the required generality. The main theorem qBinom_vandermonde is proved by induction on m in CombinationsFormulaOQ03, using q-Pascal's rule; here we derive seven consequences including q-sum-of-squares, boundary cases, and concrete numerical verifications at q=2 via native_decide.",
     "problemStatement": "Can the q-Vandermonde identity for Gaussian binomial coefficients be formalized using Mathlib's q-analogs?",
     "text": "The q-Vandermonde identity generalizes the classical Vandermonde identity to Gaussian binomial coefficients, with an extra q-power factor counting crossing configurations in subspace decompositions",
     "proofStrategy": "Define q-numbers, q-factorials, and Gaussian binomials from scratch. Prove basic properties by computation. State q-Pascal rules and q-Vandermonde. The q-binomial theorem is the generating identity.",
@@ -39,7 +39,8 @@
       "Gaussian binomial [n choose k]_q counts k-dimensional subspaces of F_q^n (literal counting for prime power q)",
       "The q-Vandermonde extra factor q^{k(n-r+k)} counts the incidence between two complementary subspace decompositions",
       "q-Pascal has TWO dual forms (unlike the unique classical Pascal rule), reflecting the non-commutativity of q-analogs",
-      "Everything specializes to the classical case at q = 1"
+      "Everything specializes to the classical case at q = 1",
+      "The q-sum-of-squares proof (qVandermonde_sum_squares') applies qBinom_symm to rewrite [n,n-j]_q = [n,j]_q inside the summand — the symmetry of Gaussian binomials [n,k]_q = [n,n-k]_q is the q-analog of C(n,k) = C(n,n-k) and reflects the duality of subspace lattices (complementation)"
     ],
     "prerequisites": [
       "Vandermonde's identity (parent proof)",
@@ -49,36 +50,44 @@
   },
   "sections": [
     {
-      "id": "q-numbers",
-      "title": "q-Numbers and q-Factorials",
-      "startLine": 44,
-      "endLine": 105,
-      "summary": "Definitions of [n]_q and [n]_q! with base cases, recurrences, and q=1 specialization.",
-      "mathContext": "[n]_q = 1 + q + ... + q^{n-1} is the q-analog of n. [n]_q! is their product."
+      "id": "sec-header",
+      "title": "Module Header: Problem Statement and References",
+      "startLine": 1,
+      "endLine": 35,
+      "summary": "Header documenting the q-Vandermonde identity, proof strategy (induction on m via q-Pascal in CombinationsFormulaOQ03), and seven consequences derived here. Historical references: Gauss (1808), Cauchy (1843), Andrews (1976).",
+      "mathContext": "The q-Vandermonde (q-Chu-Vandermonde) identity: $\\sum_{j=0}^{k} q^{(k-j)(m-j)} \\binom{m}{j}_q \\binom{n}{k-j}_q = \\binom{m+n}{k}_q$. At $q=1$: recovers classical Vandermonde $\\sum \\binom{m}{j}\\binom{n}{k-j} = \\binom{m+n}{k}$."
     },
     {
-      "id": "gaussian-binomial",
-      "title": "Gaussian Binomial Coefficients",
-      "startLine": 110,
-      "endLine": 155,
-      "summary": "Definition [n choose k]_q = [n]_q!/([k]_q![n-k]_q!) with boundary values and symmetry.",
-      "mathContext": "The Gaussian binomial is a polynomial in q with non-negative integer coefficients."
+      "id": "sec-vandermonde-classical",
+      "title": "Main Identity and Classical Recovery (Parts I-II)",
+      "startLine": 37,
+      "endLine": 68,
+      "summary": "qVandermonde (lines 51-55): main theorem, proved by delegation to qBinom_vandermonde in CombinationsFormulaOQ03. vandermonde_classical (lines 65-68): classical Vandermonde at q=1, proved via vandermonde_at_one.",
+      "mathContext": "Part I: $\\sum_{j=0}^{k} q^{(k-j)(m-j)} \\binom{m}{j}_q \\binom{n}{k-j}_q = \\binom{m+n}{k}_q$. Part II: at $q=1$, $q$-powers vanish and Gaussian binomials become $\\binom{n}{k}_1 = \\binom{n}{k}$, recovering the classical Vandermonde identity."
     },
     {
-      "id": "q-pascal",
-      "title": "q-Pascal's Rule (Two Forms)",
-      "startLine": 160,
-      "endLine": 185,
-      "summary": "Both dual forms of q-Pascal's rule.",
-      "mathContext": "Unlike the classical case, q-Pascal has two distinct forms depending on which recurrence is used."
+      "id": "sec-sum-squares",
+      "title": "q-Sum-of-Squares Corollary (Part III)",
+      "startLine": 70,
+      "endLine": 98,
+      "summary": "qVandermonde_sum_squares (lines 82-87): set m=n=k, giving ∑ q^{(n-j)²} [n,j]_q [n,n-j]_q = [2n,n]_q. qVandermonde_sum_squares' (lines 90-98): applies qBinom_symm to replace [n,n-j]_q with [n,j]_q, giving the squared form ∑ q^{(n-j)²} [n,j]²_q = [2n,n]_q.",
+      "mathContext": "$\\sum_{j=0}^{n} q^{(n-j)^2} \\binom{n}{j}_q^2 = \\binom{2n}{n}_q$. At $q=1$: $\\sum \\binom{n}{k}^2 = \\binom{2n}{n}$. Geometrically: counts $n$-dimensional subspaces of $\\mathbb{F}_q^{2n}$ weighted by intersection dimension with a fixed $n$-subspace."
     },
     {
-      "id": "q-vandermonde",
-      "title": "The q-Vandermonde Identity",
-      "startLine": 190,
-      "endLine": 230,
-      "summary": "Statement of the q-Vandermonde (q-Chu-Vandermonde) identity with combinatorial interpretation.",
-      "mathContext": "The q-Vandermonde identity is the 'mother of all q-identities' — a vast number of q-series results can be derived from it."
+      "id": "sec-symmetry-boundary",
+      "title": "Symmetry and Boundary Cases (Parts IV-V)",
+      "startLine": 100,
+      "endLine": 131,
+      "summary": "qVandermonde_symm (lines 107-109): [m+n,k]_q = [n+m,k]_q by add_comm (trivial). Boundary cases: qVandermonde_k_zero (k=0 case, simp via sum_range_one), qVandermonde_m_zero (m=0, simp), qVandermonde_n_zero (n=0, simp).",
+      "mathContext": "Symmetry: $\\binom{m+n}{k}_q = \\binom{n+m}{k}_q$ (trivial by commutativity). Boundary cases verify: $k=0$ gives $1 = \\binom{m+n}{0}_q$; $m=0$ gives $\\binom{n}{k}_q$; $n=0$ gives $\\binom{m}{k}_q$. All three are degenerate instances where the convolution sum collapses."
+    },
+    {
+      "id": "sec-verifications-summary",
+      "title": "Concrete Verifications and Summary (Parts VI-VII)",
+      "startLine": 133,
+      "endLine": 190,
+      "summary": "Part VI (lines 136-166): four numerical verifications via native_decide at q=2 over ℤ — confirms [4,2]₂=35 (2-dim subspaces of F₂⁴), [5,2]₂=155, sum-of-squares at n=2, and classical Vandermonde. Part VII (lines 172-190): qVandermonde_summary bundles the three main results into a conjunction proved by exact ⟨...⟩.",
+      "mathContext": "At $q=2$: $\\binom{4}{2}_2 = 35$ (number of 2-dimensional subspaces of $\\mathbb{F}_2^4$). $\\binom{5}{2}_2 = 155$. The `native_decide` tactic reduces these to kernel computation via decidability of ℤ-equality. The summary theorem: $\\text{qVandermonde} \\land \\text{vandermonde\\_classical} \\land \\text{qVandermonde\\_sum\\_squares'}$."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
## Summary
- **erdos-1027-oq-01**: Expanded historicalContext to 3 paragraphs; added 5th keyInsight (hgood_bad partition); restructured sections 3→5 with accurate line ranges
- **binomial-theorem-oq-04-oq-03**: Expanded historicalContext to 3 paragraphs (Gauss→quantum groups→formalization); added 5th keyInsight (qBinom_symm duality); fixed sections 4→5 with correct line ranges

## Quality improvements
| Entry | Before | After |
|-------|--------|-------|
| erdos-1027-oq-01 | 91 | 100 |
| binomial-theorem-oq-04-oq-03 | 93 | 100 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)