### PR TITLE
Fix: sync sorry count 5→4 for erdos-263 (factorial_no_folklore_growth proved)

### DIFF
--- a/src/data/proofs/erdos-263/meta.json
+++ b/src/data/proofs/erdos-263/meta.json
@@ -17,13 +17,13 @@
       "analysis"
     ],
     "badge": "wip",
-    "sorries": 5,
+    "sorries": 4,
     "erdosNumber": 263,
     "erdosUrl": "https://erdosproblems.com/263",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "lineCount": 342,
-    "assumptions": "No axioms. 5 sorry(s) remain: folklore_irrationality, kovac_tao_not_irrationality, positive_condition_irrationality, factorial_no_folklore_growth, truncation_insufficient.",
+    "lineCount": 385,
+    "assumptions": "No axioms. 4 sorry(s) remain: folklore_irrationality, kovac_tao_not_irrationality, positive_condition_irrationality, truncation_insufficient. Proved: factorial_no_folklore_growth (2026-04-14 via factorial_le_two_pow_pow bound).",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -159,12 +159,12 @@
       "Real"
     ],
     "namespace": "Erdos263",
-    "lineCount": 342,
+    "lineCount": 385,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 19,
     "path": "Proofs/Stubs/Erdos263Problem.lean",
-    "sorries": 5
+    "sorries": 4
   },
   "crossReferences": [
     {
@@ -226,5 +226,5 @@
       "note": "Growth lower bounds for irrationality sequences, connected to Problem #262"
     }
   ],
-  "sorries": 5
+  "sorries": 4
 }


### PR DESCRIPTION
## Fix

`meta.json` claimed `sorries: 5` but the Lean file has 4 actual sorries.

## Evidence

**Root cause**: Commit 93a1d4c3e4 (#10766) proved `factorial_no_folklore_growth` via a `factorial_le_two_pow_pow` bound (reducing from 5 to 4 sorries) but did not update `meta.json`.

**Before**:
- `meta.sorries: 5`
- `meta.lineCount: 342`
- `assumptions` listed `factorial_no_folklore_growth` as an open sorry

**After**:
- `meta.sorries: 4`
- `meta.lineCount: 385` (actual file length after adding 43 lines for helper lemmas)
- `assumptions` correctly lists 4 remaining sorries and notes `factorial_no_folklore_growth` was proved

**4 remaining sorries**: `folklore_irrationality`, `kovac_tao_not_irrationality`, `positive_condition_irrationality`, `truncation_insufficient`

---
Automated fix by lean-mechanic agent.