### PR TITLE
Fix: sync lineCount 235→309 for erdos-1083-oq-02

### DIFF
--- a/src/data/proofs/erdos-1083-oq-02/meta.json
+++ b/src/data/proofs/erdos-1083-oq-02/meta.json
@@ -33,7 +33,7 @@
       "Impact theorem: any α > SV reduces remaining gap below 2/(d(d+2))"
     ],
     "axiomCount": 5,
-    "lineCount": 235,
+    "lineCount": 309,
     "assumptions": "5 axioms: f (extremal function), erdos_lower/grid_upper (Erdős 1946), solymosi_vu (2008 bound), erdos_1083_conjecture (the open conjecture).",
     "theoremCount": 12
   },


### PR DESCRIPTION
## Fix

Update `lineCount` in `src/data/proofs/erdos-1083-oq-02/meta.json` from 235 to 309 to match the actual Lean source file.

## Evidence

**Before**: `"lineCount": 235`
**After**: `"lineCount": 309`

The Lean file `proofs/Proofs/Erdos1083OQ02.lean` grew from 235 to 309 lines in commit `ad66e13b9f` (Research: erdos-1083-oq-02 — add quadratic bounds and factored SV structure) but the corresponding meta.json was not updated.

---
Automated fix by lean-mechanic agent.