### PR TITLE
Fix: sync lineCount in 7 gallery proof meta.json files

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-03-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-03-oq-01/meta.json
@@ -20,7 +20,7 @@
     "sorries": 0,
     "dateAdded": "2026-04-13",
     "axiomCount": 0,
-    "lineCount": 273,
+    "lineCount": 272,
     "assumptions": "None. 0 sorries, 0 axioms. Complete formalization using Mathlib's Filter.Tendsto, Real.rpow, and Finset.sup'/inf'."
   },
   "overview": {
@@ -106,7 +106,7 @@
     "imports": ["Mathlib"],
     "opens": ["Filter", "Real", "Finset"],
     "namespace": "AmgmPowerMeanLimits",
-    "lineCount": 273,
+    "lineCount": 272,
     "axiomCount": 0,
     "sorries": 0,
     "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",

--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02/meta.json
@@ -21,7 +21,7 @@
     "sorries": 0,
     "dateAdded": "2026-04-12",
     "axiomCount": 5,
-    "lineCount": 665,
+    "lineCount": 664,
     "assumptions": "5 axioms: aperyB_recurrence (WZ recurrence), denominator_control (lcm^3*a_n is integer), lcm_hanson_bound (3^n Hanson bound), apery_linearForm_decay (geometric decay), apery_linearForm_nonzero (L_n != 0 for n>=1). Removed unused nair_lcm_bound. Main theorem apery_theorem PROVED from these 5 axioms.",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -139,7 +139,7 @@
       "Nat"
     ],
     "namespace": "AperyZetaThree",
-    "lineCount": 665,
+    "lineCount": 664,
     "axiomCount": 5,
     "theoremCount": 22,
     "definitionCount": 4,

--- a/src/data/proofs/erdos-1027/meta.json
+++ b/src/data/proofs/erdos-1027/meta.json
@@ -25,7 +25,7 @@
       901
     ],
     "axiomCount": 1,
-    "lineCount": 355,
+    "lineCount": 353,
     "assumptions": "1 axiom: erdos_1027_solution (Koishi Chan's affirmative answer). 0 sorries remain. — card_constOn_le proved via injection into complement functions.",
     "mathlib_version": "4.29.0"
   },
@@ -187,7 +187,7 @@
       "Finset"
     ],
     "namespace": "Erdos1027",
-    "lineCount": 355,
+    "lineCount": 353,
     "axiomCount": 1,
     "theoremCount": 10,
     "definitionCount": 14,

--- a/src/data/proofs/erdos-606-oq-03/meta.json
+++ b/src/data/proofs/erdos-606-oq-03/meta.json
@@ -19,7 +19,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 101,
+    "lineCount": 100,
     "assumptions": "Open question formalization: the achievable hyperplane counts problem remains open for all d ≥ 2. The 3 stated theorems (choose_nonneg, line_count_range, hyperplane_extremes) are trivially true or simple combinatorial facts proved via Mathlib. Sylvester-Gallai, Green-Tao, and Motzkin are referenced in comments only — not declared as Lean axioms (axiomCount=0). Classified axiomatized as an open-problem survey file.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
@@ -100,7 +100,7 @@
       "Mathlib"
     ],
     "namespace": "Erdos606OQ03",
-    "lineCount": 101,
+    "lineCount": 100,
     "axiomCount": 0,
     "theoremCount": 3,
     "definitionCount": 0,

--- a/src/data/proofs/lebesgue-measure-oq-03-oq-01/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-03-oq-01/meta.json
@@ -17,7 +17,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 284,
+    "lineCount": 282,
     "assumptions": "0 axioms, 0 sorries. Fully machine-checked.",
     "dateAdded": "2026-04-12",
     "mathlib_version": "4.26.0",
@@ -117,7 +117,7 @@
       "Mathlib"
     ],
     "namespace": "LebesgueMeasureOQ03OQ01",
-    "lineCount": 284,
+    "lineCount": 282,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 0,

--- a/src/data/proofs/ptolemys-theorem-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01-incomplete-01/meta.json
@@ -59,7 +59,7 @@
     ],
     "dateAdded": "2026-04-13",
     "axiomCount": 0,
-    "lineCount": 466,
+    "lineCount": 465,
     "assumptions": "1 sorry: the sine ratio identity (hcx) — algebraic cancellation in ℂ after applying exp_diff_factor four times. HARD, suitable for Aristotle.",
     "theoremCount": 7,
     "definitionCount": 0

--- a/src/data/proofs/taylor-sincos-convergence-oq-02/meta.json
+++ b/src/data/proofs/taylor-sincos-convergence-oq-02/meta.json
@@ -29,7 +29,7 @@
       "Period-4 derivative lemmas for iteratedDeriv of sin and cos at 0"
     ],
     "dateAdded": "2026-04-05",
-    "lineCount": 273,
+    "lineCount": 274,
     "theoremCount": 16,
     "definitionCount": 0,
     "mathlib_version": "4.26.0"
@@ -78,7 +78,7 @@
       "Proofs.EulerIdentityOQ01OQ01"
     ],
     "namespace": "TaylorSinCosConvergenceOQ02",
-    "lineCount": 273,
+    "lineCount": 274,
     "axiomCount": 0,
     "theoremCount": 16,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Sync `lineCount` in 7 gallery proof `meta.json` files where small discrepancies (±1 or ±2 lines) accumulated from minor post-commit file edits.

## Evidence

| Proof | Before | After |
|-------|--------|-------|
| amgm-inequality-oq-03-oq-03-oq-01 | 273 | 272 |
| basel-problem-oq-01-oq-01-oq-02 | 665 | 664 |
| erdos-1027 | 355 | 353 |
| erdos-606-oq-03 | 101 | 100 |
| lebesgue-measure-oq-03-oq-01 | 284 | 282 |
| ptolemys-theorem-oq-01-incomplete-01 | 466 | 465 |
| taylor-sincos-convergence-oq-02 | 273 | 274 |

All sorries, axioms, status, and badge fields are correct — only lineCount was out of sync.

---
Automated fix by lean-mechanic agent.