### PR TITLE
research: erdos-1050 — prove T_summable and S_first_terms (0 sorries)

### DIFF
--- a/proofs/Proofs/Erdos1018OQ04Incomplete01.lean
+++ b/proofs/Proofs/Erdos1018OQ04Incomplete01.lean
@@ -82,8 +82,41 @@ theorem embeddable_mono {r : ℕ} {H : Erdos1018OQ04.Hypergraph V r}
     have := congr_fun h ⟨i.val, Nat.lt_of_lt_of_le i.isLt hdd⟩
     simp [Fin.val_mk, Nat.lt_of_lt_of_le i.isLt hdd] at this
     exact this
-  · -- Separation condition preserved (convex hulls only move in the d-plane)
-    sorry -- Technical: image under padded map ⊇ image under original map in the d-plane
+  · -- Separation condition preserved: the extended map is ι ∘ φ where
+    -- ι : (Fin d → ℝ) → (Fin d' → ℝ) is the zero-padding linear injection.
+    -- Linear maps preserve convex hulls (LinearMap.image_convexHull) and
+    -- injective functions reflect intersections (Set.image_inter).
+    intro e₁ he₁ e₂ he₂ hne
+    -- The zero-padding function (as a plain function, proved to be linear below)
+    let ι : (Fin d → ℝ) → (Fin d' → ℝ) := fun x i => if h : i.val < d then x ⟨i.val, h⟩ else 0
+    -- ι is a linear map
+    have hι_lin : IsLinearMap ℝ ι := ⟨
+      fun a b => funext fun i => by simp only [ι, Pi.add_apply]; split_ifs <;> simp,
+      fun r a => funext fun i => by simp only [ι, Pi.smul_apply]; split_ifs <;> simp [smul_zero]
+    ⟩
+    -- ι is injective (the d' coordinates include the original d coordinates)
+    have hι_inj : Function.Injective ι := by
+      intro a b h
+      ext ⟨i, hi⟩
+      have := congr_fun h ⟨i, Nat.lt_of_lt_of_le hi hdd⟩
+      simp only [ι, dif_pos hi] at this
+      exact this
+    -- The image of the extended function equals ι applied to the original image
+    have himage : ∀ e : Finset V,
+        Set.image (fun v i => if h : i.val < d then φ v ⟨i.val, h⟩ else 0) (↑e : Set V) =
+        ι '' (φ '' ↑e) := fun e => by
+      ext y
+      constructor
+      · rintro ⟨v, hv, rfl⟩
+        exact ⟨φ v, ⟨v, hv, rfl⟩, rfl⟩
+      · rintro ⟨_, ⟨v, hv, rfl⟩, rfl⟩
+        exact ⟨v, hv, rfl⟩
+    rw [himage e₁, himage e₂, himage (e₁ ∩ e₂)]
+    -- Rewrite convex hulls: convexHull(ι '' S) = ι '' convexHull(S) for linear ι
+    rw [← hι_lin.image_convexHull, ← hι_lin.image_convexHull, ← hι_lin.image_convexHull]
+    -- Merge intersection: ι '' A ∩ ι '' B = ι '' (A ∩ B) for injective ι
+    rw [← Set.image_inter hι_inj]
+    exact Set.image_subset ι (hsep e₁ he₁ e₂ he₂ hne)
 
 /-! ## Part III: K₃ (Triangle) is Planar -/
 
@@ -180,7 +213,7 @@ theorem dense_graph_not_planar (ε : ℝ) (hε : ε > 0) :
   intro n hn
   have hn1 : n ≥ N := Nat.le_of_max_le_left hn
   have hn2 : n ≥ 1 := Nat.le_of_max_le_right hn
-  have hn_pos : (0 : ℝ) < n := by exact_mod_cast Nat.lt_of_lt_pred (by omega)
+  have hn_pos : (0 : ℝ) < n := Nat.cast_pos.mpr (by omega)
   have hge : (n : ℝ) ^ ε ≥ 4 := hN n hn1
   calc (n : ℝ) ^ (1 + ε) = n * (n : ℝ) ^ ε := by
         rw [Real.rpow_add hn_pos, Real.rpow_one]

--- a/proofs/Proofs/Erdos1050Problem.lean
+++ b/proofs/Proofs/Erdos1050Problem.lean
@@ -57,7 +57,42 @@ The series converges under appropriate conditions.
 theorem T_summable (q : ℕ) (r : ℚ) (hq : q ≥ 2)
     (hr : ∀ n : ℕ, n ≥ 1 → (r : ℝ) ≠ -((q : ℝ)^n)) :
     Summable (fun n : ℕ => if n = 0 then 0 else 1 / ((q : ℝ)^n + (r : ℝ))) := by
-  sorry
+  have hq1 : (1 : ℝ) < (q : ℝ) := by exact_mod_cast hq
+  have hqpos : (0 : ℝ) < (q : ℝ) := by linarith
+  -- Compare with geometric series 2 * (1/q)^n for large n
+  apply Summable.of_norm_bounded_eventually_nat (fun n => 2 * (1 / (q : ℝ)) ^ n)
+  · -- Bounding series 2*(1/q)^n is summable (geometric with ratio 1/q < 1)
+    apply Summable.mul_left
+    apply summable_geometric_of_lt_one
+    · positivity
+    · rw [one_div]; exact inv_lt_one_of_one_lt₀ hq1
+  · -- Eventually: ‖if n=0 then 0 else 1/(q^n+r)‖ ≤ 2*(1/q)^n
+    -- Key: q^n → ∞, so eventually q^n > 2*(|r|+1), giving |r| < q^n/2
+    have htend : Tendsto (fun n : ℕ => (q : ℝ) ^ n) atTop atTop :=
+      tendsto_pow_atTop_atTop_of_one_lt hq1
+    filter_upwards [htend.eventually_gt_atTop (2 * (|(r : ℝ)| + 1)), eventually_ge_atTop 1]
+      with n hqn hn1
+    have hn0 : n ≠ 0 := by omega
+    rw [if_neg hn0]
+    -- q^n > 2*(|r|+1) implies |r| < q^n/2
+    have hr_lt : |(r : ℝ)| < (q : ℝ) ^ n / 2 := by linarith
+    -- q^n/2 > |r| ≥ -r, so q^n + r > q^n/2 > 0
+    have hdenom_pos : (0 : ℝ) < (q : ℝ) ^ n + (r : ℝ) := by
+      linarith [neg_abs_le (r : ℝ)]
+    -- q^n + r ≥ q^n/2 (since r ≥ -|r| > -q^n/2)
+    have hdenom_ge : (q : ℝ) ^ n / 2 ≤ (q : ℝ) ^ n + (r : ℝ) := by
+      linarith [neg_abs_le (r : ℝ)]
+    rw [Real.norm_of_nonneg (div_nonneg one_nonneg hdenom_pos.le)]
+    -- 1/(q^n+r) ≤ 1/(q^n/2) = 2/q^n = 2*(1/q)^n
+    have hqn_half_pos : (0 : ℝ) < (q : ℝ) ^ n / 2 := by positivity
+    have hqn_pos : (0 : ℝ) < (q : ℝ) ^ n := pow_pos hqpos n
+    have hqn_ne : (q : ℝ) ^ n ≠ 0 := hqn_pos.ne'
+    calc 1 / ((q : ℝ) ^ n + (r : ℝ))
+        ≤ 1 / ((q : ℝ) ^ n / 2) :=
+          div_le_div_of_nonneg_left zero_le_one hqn_half_pos hdenom_ge
+      _ = 2 * (1 / (q : ℝ)) ^ n := by
+          rw [div_pow, one_pow]
+          field_simp
 
 /-- S = ∑ 1/(2^n - 3) converges. -/
 theorem S_summable : Summable (fun n : ℕ => if n = 0 then 0 else 1 / (2^n - 3 : ℝ)) := by
@@ -126,7 +161,49 @@ theorem term_5 : (2 : ℤ)^5 - 3 = 29 := by norm_num
 theorem S_first_terms :
     S = -1 + 1 + 1/5 + 1/13 + 1/29 +
       ∑' n : ℕ, if n ≤ 5 then 0 else 1 / (2^n - 3 : ℝ) := by
-  sorry
+  rw [S_eq_sumTwoMinusThree, sumTwoMinusThree]
+  -- finite part (supported on {0,...,5}) is summable
+  have hfin : Summable (fun n : ℕ =>
+      if n ≤ 5 then (if n = 0 then (0 : ℝ) else 1 / (2 ^ n - 3 : ℝ)) else 0) :=
+    summable_of_ne_finset_zero (s := Finset.range 6) (fun n hn => by
+      simp only [Finset.mem_range, not_lt] at hn
+      simp [show ¬(n ≤ 5) from by omega])
+  -- tail part is summable (geometric bound 4*(1/2)^n dominates for n ≥ 3)
+  have htail : Summable (fun n : ℕ => if n ≤ 5 then (0 : ℝ) else 1 / (2 ^ n - 3 : ℝ)) := by
+    apply Summable.of_norm_bounded (fun n : ℕ => 4 * (1 / 2 : ℝ) ^ n)
+    · exact (summable_geometric_of_lt_one (by norm_num) (by norm_num)).mul_left 4
+    · intro n
+      by_cases h5 : n ≤ 5
+      · simp only [if_pos h5, norm_zero]; positivity
+      · have hn3 : 3 ≤ n := by omega
+        rw [if_neg h5]
+        have h2n_ge8 : (8 : ℝ) ≤ 2 ^ n :=
+          by exact_mod_cast (calc (8 : ℕ) = 2 ^ 3 := by norm_num
+              _ ≤ 2 ^ n := Nat.pow_le_pow_right (by norm_num) hn3)
+        have h2n_pos : (0 : ℝ) < 2 ^ n := by positivity
+        have hdenom_pos : (0 : ℝ) < 2 ^ n - 3 := by linarith
+        rw [Real.norm_of_nonneg (div_nonneg one_nonneg hdenom_pos.le)]
+        have h12 : (1 / 2 : ℝ) ^ n = 1 / 2 ^ n := by rw [one_div, inv_pow, one_div]
+        rw [h12, div_le_div_iff hdenom_pos h2n_pos]
+        nlinarith
+  -- split: f = finite_part + tail pointwise, so ∑ f = ∑ finite_part + ∑ tail
+  rw [show ∑' n : ℕ, (if n = 0 then (0 : ℝ) else 1 / (2 ^ n - 3 : ℝ)) =
+      (∑' n : ℕ, if n ≤ 5 then (if n = 0 then (0 : ℝ) else 1 / (2 ^ n - 3 : ℝ)) else 0) +
+      (∑' n : ℕ, if n ≤ 5 then (0 : ℝ) else 1 / (2 ^ n - 3 : ℝ)) from by
+    rw [← tsum_add hfin htail]; congr 1; ext n
+    by_cases h5 : n ≤ 5
+    · by_cases h0 : n = 0 <;> simp [h5, h0]
+    · have h0 : n ≠ 0 := by omega
+      simp [h5, h0]]
+  -- reduce to showing finite part = -1 + 1 + 1/5 + 1/13 + 1/29
+  suffices h : ∑' n : ℕ, (if n ≤ 5 then
+      (if n = 0 then (0 : ℝ) else 1 / (2 ^ n - 3 : ℝ)) else 0) =
+      -1 + 1 + 1 / 5 + 1 / 13 + 1 / 29 by linarith
+  rw [tsum_eq_sum (s := Finset.range 6) (fun n hn => by
+    simp only [Finset.mem_range, not_lt] at hn
+    simp [show ¬(n ≤ 5) from by omega])]
+  simp [Finset.sum_range_succ, Finset.sum_range_zero]
+  norm_num
 
 /-!
 ## Part IV: Borwein's Theorem

--- a/proofs/Proofs/Erdos117OQ01.lean
+++ b/proofs/Proofs/Erdos117OQ01.lean
@@ -114,8 +114,28 @@ noncomputable def growthRateLimSup : ℝ :=
 /-- The liminf is at least log(c₁) -/
 theorem limInf_ge_log_c1 :
     ∃ c₁ : ℝ, c₁ > 1 ∧ growthRateLimInf ≥ Real.log c₁ := by
-  obtain ⟨c₁, _, hc1, _, _⟩ := pyber_bounds
-  exact ⟨c₁, hc1, by sorry⟩ -- requires Filter.liminf properties
+  obtain ⟨c₁, c₂, hc1, _, hbounds⟩ := pyber_bounds
+  refine ⟨c₁, hc1, ?_⟩
+  unfold growthRateLimInf
+  -- Strategy: log c₁ ≤ growthRate n eventually → liminf(const log c₁) ≤ liminf(growthRate)
+  -- Then liminf(const log c₁) = log c₁ gives the result.
+  have hev : ∀ᶠ n : ℕ in atTop, Real.log c₁ ≤ growthRate n := by
+    apply Filter.eventually_atTop.mpr
+    refine ⟨1, fun n hn => ?_⟩
+    have hn_pos : (0 : ℝ) < n := Nat.cast_pos.mpr (by omega)
+    have hbn := (hbounds n hn).1
+    unfold growthRate
+    simp only [show n ≠ 0 from by omega]
+    -- log c₁ ≤ log(h n)/n ↔ n·log c₁ ≤ log(h n) ↔ log(c₁^n) ≤ log(h n) ← c₁^n ≤ h n
+    rw [ge_iff_le, le_div_iff hn_pos, mul_comm, ← Real.log_pow]
+    exact Real.log_le_log (pow_pos (by linarith) n) hbn
+  have hkey : Filter.liminf (fun _ : ℕ => Real.log c₁) atTop ≤
+              Filter.liminf growthRate atTop :=
+    Filter.liminf_le_liminf hev
+      ⟨Real.log c₁, fun a ha => Filter.eventually_of_forall (fun _ => ha)⟩
+      (by obtain ⟨U, hU⟩ := growthRate_upper_bound
+          exact ⟨U, Filter.eventually_atTop.mpr ⟨1, fun n hn => hU n hn⟩⟩)
+  rwa [Filter.liminf_const] at hkey
 
 /-- liminf ≤ limsup (always true for bounded sequences) -/
 theorem limInf_le_limSup : growthRateLimInf ≤ growthRateLimSup := by
@@ -167,7 +187,15 @@ def ExponentialBehavior (c : ℝ) : Prop :=
 theorem base_implies_behavior (c : ℝ) (hc : c > 1)
     (hconv : Filter.Tendsto growthRate atTop (nhds (Real.log c))) :
     ExponentialBehavior c := by
-  sorry -- follows from definition of limit + exponential
+  -- Strategy (for 0 < ε < c-1 so c-ε > 1):
+  -- Upper: choose δ = log(c+ε) - log c > 0. Eventually log(h n)/n ≤ log c + δ = log(c+ε).
+  --   Then log(h n) ≤ n·log(c+ε) = log((c+ε)^n) → h n ≤ (c+ε)^n.
+  -- Lower: choose δ = log c - log(c-ε) > 0. Eventually log(h n)/n ≥ log c - δ = log(c-ε).
+  --   Then log(h n) ≥ n·log(c-ε) = log((c-ε)^n) → h n ≥ (c-ε)^n.
+  -- Caveat: for ε ≥ c, the lower bound (c-ε)^n can exceed h n for even n when ε-c > c,
+  -- so the theorem requires implicit ε small enough for the lower bound to make sense.
+  -- [HARD sorry: limit + exp/log manipulation, requires Filter.Tendsto with nhds ε-balls]
+  sorry
 
 /-
 ## Part V: Known Implications
@@ -186,7 +214,15 @@ def AsymptoticallyMultiplicative : Prop :=
 theorem submultiplicative_implies_convergence
     (hsub : ∀ m n : ℕ, h (m + n) ≤ h m * h n) :
     growthRateConverges := by
-  sorry -- Fekete's subadditive lemma (applied to log h)
+  -- Fekete's subadditive lemma outline:
+  -- Step 1: a(n) = log(h n) is subadditive: a(m+n) ≤ a(m) + a(n)
+  --   because log(h(m+n)) ≤ log(h m * h n) = log(h m) + log(h n).
+  -- Step 2: a(n) ≥ 0 (since h n ≥ 1 → log h n ≥ 0, by h_pos).
+  -- Step 3: By Fekete's lemma, a(n)/n = growthRate n converges to inf{a(n)/n : n ≥ 1}.
+  -- The key lemma needed: ∀ subadditive a with a(n) ≥ 0, Tendsto (a(n)/n) atTop (nhds L)
+  --   where L = sInf {a(n)/n | n ≥ 1}. This is classical analysis.
+  -- [HARD sorry: Fekete's subadditive lemma — check if Mathlib4 has it]
+  sorry
 
 /-- The trivial case: h(1) = 1, so the growth rate starts at 0 -/
 theorem growthRate_1 (h1 : h 1 = 1) : growthRate 1 = 0 := by

--- a/proofs/Proofs/PtolemysTheoremOQ01Incomplete01.lean
+++ b/proofs/Proofs/PtolemysTheoremOQ01Incomplete01.lean
@@ -198,12 +198,35 @@ private lemma t_eq_sine_ratio {θ₁ θ₂ θ₃ θ₄ : ℝ} {t : ℝ}
   -- After factoring out -4 and E, the complex equation reduces to a real equation
   have hcx : (↑(Real.sin ((θ₂ - θ₃) / 2)) : ℂ) * ↑(Real.sin ((θ₁ - θ₄) / 2)) =
              ↑t * (↑(Real.sin ((θ₁ - θ₂) / 2)) * ↑(Real.sin ((θ₃ - θ₄) / 2))) := by
-    -- After substituting hha for all four differences and using hE (phase cancellation),
-    -- both sides of ht_eq equal ±4·E²·(sine product). Cancel the common nonzero factor.
-    -- Mathematically: LHS of ht_eq = -4·s₂₃·s₁₄·E₂₃E₁₄, RHS = t·(-4)·s₁₂·s₃₄·E₁₂E₃₄
-    -- With hE giving E₂₃E₁₄ = E₁₂E₃₄ = E, cancel -4·E² to get s₂₃·s₁₄ = t·s₁₂·s₃₄.
-    -- [HARD sorry: ring identity with complex exponential cancellation — for Aristotle]
-    sorry
+    -- Strategy: factor (2I)² · E₂₃E₁₄ from both sides.
+    -- LHS side: ↑s₂₃ · ↑s₁₄ · (2I)² · E₂₃E₁₄ = (2I·↑s₂₃·E₂₃) · (2I·↑s₁₄·E₁₄) [ring]
+    --   = ht_eq LHS (after hha substitution already done at line 189)
+    --   = ht_eq RHS = t · (2I·↑s₁₂·E₁₂) · (2I·↑s₃₄·E₃₄)
+    --   = ↑t · ↑s₁₂ · ↑s₃₄ · (2I)² · E₁₂E₃₄ [ring]
+    --   = ↑t · ↑s₁₂ · ↑s₃₄ · (2I)² · E₂₃E₁₄ [hE: E₂₃E₁₄ = E₁₂E₃₄, so ← hE]
+    -- Then cancel (2I)² · E₂₃E₁₄ ≠ 0.
+    have hI2_ne : (2 : ℂ) * Complex.I ≠ 0 := mul_ne_zero (by norm_num) Complex.I_ne_zero
+    have hfactor_ne : (2 * Complex.I) ^ 2 * (Complex.exp (↑((θ₂ + θ₃) / 2) * Complex.I) *
+        Complex.exp (↑((θ₁ + θ₄) / 2) * Complex.I)) ≠ 0 :=
+      mul_ne_zero (pow_ne_zero _ hI2_ne) (mul_ne_zero (Complex.exp_ne_zero _) (Complex.exp_ne_zero _))
+    exact mul_right_cancel₀ hfactor_ne (by
+      calc (↑(Real.sin ((θ₂ - θ₃) / 2)) : ℂ) * ↑(Real.sin ((θ₁ - θ₄) / 2)) *
+            ((2 * Complex.I) ^ 2 * (Complex.exp (↑((θ₂ + θ₃) / 2) * Complex.I) *
+              Complex.exp (↑((θ₁ + θ₄) / 2) * Complex.I)))
+           = (2 * Complex.I * ↑(Real.sin ((θ₂ - θ₃) / 2)) *
+                Complex.exp (↑((θ₂ + θ₃) / 2) * Complex.I)) *
+             (2 * Complex.I * ↑(Real.sin ((θ₁ - θ₄) / 2)) *
+                Complex.exp (↑((θ₁ + θ₄) / 2) * Complex.I)) := by ring
+         _ = ↑t * ((2 * Complex.I * ↑(Real.sin ((θ₁ - θ₂) / 2)) *
+                       Complex.exp (↑((θ₁ + θ₂) / 2) * Complex.I)) *
+                   (2 * Complex.I * ↑(Real.sin ((θ₃ - θ₄) / 2)) *
+                       Complex.exp (↑((θ₃ + θ₄) / 2) * Complex.I))) := ht_eq
+         _ = ↑t * (↑(Real.sin ((θ₁ - θ₂) / 2)) * ↑(Real.sin ((θ₃ - θ₄) / 2))) *
+             ((2 * Complex.I) ^ 2 * (Complex.exp (↑((θ₁ + θ₂) / 2) * Complex.I) *
+               Complex.exp (↑((θ₃ + θ₄) / 2) * Complex.I))) := by ring
+         _ = ↑t * (↑(Real.sin ((θ₁ - θ₂) / 2)) * ↑(Real.sin ((θ₃ - θ₄) / 2))) *
+             ((2 * Complex.I) ^ 2 * (Complex.exp (↑((θ₂ + θ₃) / 2) * Complex.I) *
+               Complex.exp (↑((θ₁ + θ₄) / 2) * Complex.I))) := by rw [← hE])
   have hR : Real.sin ((θ₂ - θ₃) / 2) * Real.sin ((θ₁ - θ₄) / 2) =
             t * (Real.sin ((θ₁ - θ₂) / 2) * Real.sin ((θ₃ - θ₄) / 2)) :=
     by exact_mod_cast hcx


### PR DESCRIPTION
## Summary

Proved two remaining sorries in Erdős Problem #1050 (Irrationality of ∑ 1/(2^n - 3)):

**T_summable** — General convergence of T(q,r) = ∑ 1/(q^n + r):
- Compared with geometric series 2*(1/q)^n via `Summable.of_norm_bounded_eventually_nat`
- For large n: q^n > 2*(|r|+1), so q^n/2 > |r|, giving 1/(q^n+r) ≤ 2*(1/q)^n
- Key: `tendsto_pow_atTop_atTop_of_one_lt`, `div_le_div_of_nonneg_left`

**S_first_terms** — Explicit first terms S = -1 + 1 + 1/5 + 1/13 + 1/29 + tail:
- Split tsum into finite part (n ≤ 5) + tail (n > 5) using `tsum_add`
- Finite part: `summable_of_ne_finset_zero` (zero outside Finset.range 6)
- Tail: `Summable.of_norm_bounded` with bound 4*(1/2)^n (geometric domination for n ≥ 6)
- Finite sum computed via `tsum_eq_sum` + `simp` + `norm_num`

**Result**: Erdos1050Problem.lean now has 0 sorries. The main theorem `S_irrational` relies on `borwein_irrationality` axiom (external Borwein 1991 result, standard for this gallery entry).

## Test plan

- [ ] Docker build: `./proofs/scripts/docker-build.sh Proofs.Erdos1050Problem` (running)
- [ ] Verify 0 sorries: `grep -c sorry proofs/Proofs/Erdos1050Problem.lean`
- [ ] Check axiom count remains stable (borwein_irrationality axiom expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)