### PR TITLE
Research: erdos-476 + erdos-1083 + basel — multi-proof improvements

### DIFF
--- a/proofs/Proofs/BaselProblemOQ01OQ01OQ02.lean
+++ b/proofs/Proofs/BaselProblemOQ01OQ01OQ02.lean
@@ -661,4 +661,103 @@ theorem apery_theorem : Irrational (zetaValue 3) := by
   · exact apery_linearForm_nonzero
   · exact denominator_control
 
+-- ============================================================================
+-- Part XIV: Additional Divisibility Infrastructure (proved without axioms)
+-- ============================================================================
+
+/-- lcmUpTo is monotone for divisibility: if m ≤ n then lcmUpTo m ∣ lcmUpTo n.
+    Proof: any element k ∈ range m is also in range n (since k < m ≤ n),
+    so (k+1) divides the larger lcm. -/
+theorem lcmUpTo_dvd_of_le {m n : ℕ} (h : m ≤ n) : lcmUpTo m ∣ lcmUpTo n := by
+  unfold lcmUpTo
+  apply Finset.lcm_dvd
+  intro a ha
+  apply Finset.dvd_lcm
+  exact Finset.mem_range.mpr ((Finset.mem_range.mp ha).trans_le h)
+
+/-- lcm(1,...,3) = 6. -/
+theorem lcmUpTo_three : lcmUpTo 3 = 6 := by native_decide
+
+/-- lcm(1,...,4) = 12. -/
+theorem lcmUpTo_four : lcmUpTo 4 = 12 := by native_decide
+
+/-- **Factorial Denominator Control**: (n!)³ · aₙ ∈ ℤ for all n.
+
+    Proved by 2-step induction on the Apéry recurrence:
+    - n=0: (0!)³ · 0 = 0 ∈ ℤ
+    - n=1: (1!)³ · 6 = 6 ∈ ℤ
+    - n+2: from the recurrence
+        (n+2)³ · a_{n+2} = c_{n+1} · a_{n+1} - (n+1)³ · a_n
+      and the factorial identity (n+2)!/  (n+2) = (n+1)!, we get:
+        ((n+2)!)³ · a_{n+2} = ((n+1)!)³ · (c_{n+1} · a_{n+1} - (n+1)³ · a_n)
+                             = c_{n+1} · m₁ - (n+1)³ · ((n+1)!)³ · a_n
+      Since ((n+1)!) = (n+1) · n!:
+        (n+1)³ · ((n+1)!)³ · a_n = (n+1)⁶ · (n!)³ · a_n = (n+1)⁶ · m₀ ∈ ℤ
+      So ((n+2)!)³ · a_{n+2} = c_{n+1} · m₁ - (n+1)⁶ · m₀ ∈ ℤ. □
+
+    Note: This is weaker than denominator_control (which uses lcmUpTo, not n!),
+    but is completely proved from first principles. Since lcmUpTo n ≤ n!, the
+    denominator of aₙ divides n!³ but may not divide lcmUpTo(n)³. -/
+theorem denominator_control_factorial : ∀ n : ℕ,
+    ∃ m : ℤ, ((n.factorial : ℚ)) ^ 3 * aperyA n = ↑m
+  | 0 => ⟨0, by simp [aperyA]⟩
+  | 1 => ⟨6, by norm_num [aperyA]⟩
+  | (n + 2) => by
+    obtain ⟨m₀, hm₀⟩ := denominator_control_factorial n
+    obtain ⟨m₁, hm₁⟩ := denominator_control_factorial (n + 1)
+    -- Target: ((n+2)!)³ · a_{n+2} = ↑(c_{n+1} · m₁ - (n+1)⁶ · m₀)
+    use aperyRecCoeff (n + 1) * m₁ - (n + 1 : ℤ) ^ 6 * m₀
+    -- Factorial identities: (n+2)! = (n+2)·(n+1)! and (n+1)! = (n+1)·n!
+    have hfact1 : ((n + 2).factorial : ℚ) = (↑(n + 2) : ℚ) * ((n + 1).factorial : ℚ) :=
+      by exact_mod_cast Nat.factorial_succ (n + 1)
+    have hfact2 : ((n + 1).factorial : ℚ) = (↑(n + 1) : ℚ) * ((n : ℕ).factorial : ℚ) :=
+      by exact_mod_cast Nat.factorial_succ n
+    -- The recurrence: (n+2)³ · a_{n+2} = c_{n+1} · a_{n+1} - (n+1)³ · a_n
+    have hrec : (↑(n + 2) : ℚ) ^ 3 * aperyA (n + 2) =
+        (aperyRecCoeff (n + 1) : ℚ) * aperyA (n + 1) - (↑(n + 1) : ℚ) ^ 3 * aperyA n := by
+      have hdef : aperyA (n + 2) =
+          ((aperyRecCoeff (n + 1) : ℚ) * aperyA (n + 1) - (↑(n + 1) : ℚ) ^ 3 * aperyA n) /
+          (↑(n + 2) : ℚ) ^ 3 := by
+        simp only [aperyA, aperyRecCoeff]
+        push_cast
+        ring
+      rw [hdef]
+      have hn2 : (↑(n + 2) : ℚ) ^ 3 ≠ 0 := by positivity
+      field_simp [hn2]
+    -- Second term: (n+1)³ · ((n+1)!)³ · a_n = (n+1)⁶ · m₀
+    have hterm2 : (↑(n + 1) : ℚ) ^ 3 * ((n + 1).factorial : ℚ) ^ 3 * aperyA n =
+                  (↑(n + 1) : ℚ) ^ 6 * ↑m₀ := by
+      rw [hfact2]
+      have : ((↑(n + 1) : ℚ) * ((n : ℕ).factorial : ℚ)) ^ 3 =
+             (↑(n + 1) : ℚ) ^ 3 * ((n : ℕ).factorial : ℚ) ^ 3 := by ring
+      rw [this]
+      have : (↑(n + 1) : ℚ) ^ 3 * ((↑(n + 1) : ℚ) ^ 3 * ((n : ℕ).factorial : ℚ) ^ 3) *
+             aperyA n = (↑(n + 1) : ℚ) ^ 6 * (((n : ℕ).factorial : ℚ) ^ 3 * aperyA n) := by ring
+      rw [this, hm₀]
+      push_cast; ring
+    -- Main calculation
+    have hmain : ((n + 2).factorial : ℚ) ^ 3 * aperyA (n + 2) =
+        (aperyRecCoeff (n + 1) : ℚ) * ↑m₁ - (↑(n + 1) : ℚ) ^ 6 * ↑m₀ := by
+      -- Step 1: Factor out (n+2)^3 from factorial
+      have hfact_eq : ((n + 2).factorial : ℚ) ^ 3 =
+                      ((n + 1).factorial : ℚ) ^ 3 * (↑(n + 2) : ℚ) ^ 3 := by
+        rw [hfact1]; ring
+      -- Step 2: Reduce to (n+1)!^3 · ((n+2)^3 · a_{n+2})
+      have hkey : ((n + 2).factorial : ℚ) ^ 3 * aperyA (n + 2) =
+          ((n + 1).factorial : ℚ) ^ 3 *
+          ((aperyRecCoeff (n + 1) : ℚ) * aperyA (n + 1) - (↑(n + 1) : ℚ) ^ 3 * aperyA n) := by
+        rw [hfact_eq, mul_assoc]
+        congr 1
+        exact hrec
+      -- Step 3: Distribute and substitute IH
+      rw [hkey, mul_sub,
+          show ((n + 1).factorial : ℚ) ^ 3 * ((aperyRecCoeff (n + 1) : ℚ) * aperyA (n + 1)) =
+               (aperyRecCoeff (n + 1) : ℚ) * (((n + 1).factorial : ℚ) ^ 3 * aperyA (n + 1)) by ring,
+          hm₁,
+          show ((n + 1).factorial : ℚ) ^ 3 * ((↑(n + 1) : ℚ) ^ 3 * aperyA n) =
+               (↑(n + 1) : ℚ) ^ 3 * ((n + 1).factorial : ℚ) ^ 3 * aperyA n by ring,
+          hterm2]
+    rw [hmain]
+    push_cast; ring
+
 end AperyZetaThree

--- a/proofs/Proofs/Erdos1083OQ02.lean
+++ b/proofs/Proofs/Erdos1083OQ02.lean
@@ -255,6 +255,29 @@ theorem sv_fraction_d4 : (4 + 1 : ℝ) / (4 + 2) = 5 / 6 := by norm_num
 theorem sv_fraction_d10 : (10 + 1 : ℝ) / (10 + 2) = 11 / 12 := by norm_num
 
 /-
+## Threshold Dimension Bounds
+-/
+
+/-- For d ≥ 6, SV covers at least 3/4 of the exponent gap.
+    Proof: d/(d+2) ≥ 3/4 ↔ 4d ≥ 3(d+2) ↔ d ≥ 6. -/
+theorem sv_covers_three_quarters (d : ℕ) (hd : d ≥ 6) :
+    (d : ℝ) / (↑d + 2) ≥ 3 / 4 := by
+  have hd_cast : (6 : ℝ) ≤ (d : ℝ) := by exact_mod_cast hd
+  have hd2_pos : (0 : ℝ) < (↑d : ℝ) + 2 := by linarith
+  rw [ge_iff_le, div_le_div_iff (by norm_num : (0 : ℝ) < 4) hd2_pos]
+  linarith
+
+/-- For d ≥ 22, SV covers at least 11/12 of the exponent gap.
+    Proof: d/(d+2) ≥ 11/12 ↔ 12d ≥ 11(d+2) ↔ d ≥ 22. -/
+theorem sv_covers_eleven_twelfths (d : ℕ) (hd : d ≥ 22) :
+    (d : ℝ) / (↑d + 2) ≥ 11 / 12 := by
+  have hd_cast : (22 : ℝ) ≤ (d : ℝ) := by exact_mod_cast hd
+  have hd2_pos : (0 : ℝ) < (↑d : ℝ) + 2 := by linarith
+  rw [ge_iff_le, div_le_div_iff (by norm_num : (0 : ℝ) < 12) hd2_pos]
+  linarith
+
+
+/-
 ## Impact of Hypothetical Improvements
 -/
 

--- a/proofs/Proofs/Erdos476Problem.lean
+++ b/proofs/Proofs/Erdos476Problem.lean
@@ -225,7 +225,7 @@ Erdős conjectured a generalization to sums of r distinct elements.
 The set of sums a₁ + a₂ + ... + aᵣ where all aᵢ are distinct.
 -/
 def restrictedSumsetR (A : Finset (ZMod p)) (r : ℕ) : Finset (ZMod p) :=
-  sorry  -- Sum over r-element subsets of A
+  (A.powersetCard r).image (fun s => s.sum id)
 
 /--
 **Erdős's Generalized Conjecture:**
@@ -243,7 +243,21 @@ If A = {a, b} with a ≠ b, then A +̂ A = {a + b}.
 -/
 theorem card_two_case (A : Finset (ZMod p)) (h : A.card = 2) :
     (restrictedSumset p A).card = 1 := by
-  sorry -- Technical: extract the two elements
+  obtain ⟨a, b, hab, rfl⟩ := Finset.card_eq_two.mp h
+  have heq : restrictedSumset p {a, b} = {a + b} := by
+    ext x
+    simp only [restrictedSumset, Finset.mem_image, Finset.mem_filter, Finset.mem_product,
+      Finset.mem_insert, Finset.mem_singleton]
+    constructor
+    · rintro ⟨⟨c, d⟩, ⟨⟨hc, hd⟩, hne⟩, rfl⟩
+      rcases hc with rfl | rfl <;> rcases hd with rfl | rfl
+      · exact absurd rfl hne
+      · rfl
+      · exact add_comm b a
+      · exact absurd rfl hne
+    · rintro rfl
+      exact ⟨(a, b), ⟨⟨Or.inl rfl, Or.inr rfl⟩, hab⟩, rfl⟩
+  simp [heq]
 
 /--
 For |A| = 3, the restricted sumset has at least 3 elements.
@@ -284,8 +298,25 @@ theorem erdos_476_summary (A : Finset (ZMod p)) (h : 2 ≤ A.card) :
   · exact erdos_476 p A h
   · intro a d hd hsmall
     use arithmeticProgression p a d A.card
+    have hp2 : 2 ≤ p := Nat.Prime.two_le Fact.out
+    have hle : A.card ≤ p := by omega
+    have hAP_card : (arithmeticProgression p a d A.card).card = A.card := by
+      unfold arithmeticProgression
+      have hinj : Set.InjOn (fun i => a + i • d) ↑(Finset.range A.card) := by
+        intro i hi j hj hij
+        simp only [Finset.mem_coe, Finset.mem_range] at hi hj
+        have h0 : (i : ℕ) • d = (j : ℕ) • d := add_left_cancel hij
+        simp only [nsmul_eq_mul] at h0
+        have heq : (i : ZMod p) = (j : ZMod p) := mul_right_cancel₀ hd h0
+        have hval := congr_arg ZMod.val heq
+        rw [ZMod.val_natCast, ZMod.val_natCast,
+            Nat.mod_eq_of_lt (hi.trans_le hle),
+            Nat.mod_eq_of_lt (hj.trans_le hle)] at hval
+        exact hval
+      rw [Finset.card_image_of_injOn hinj, Finset.card_range]
     constructor
-    · sorry -- AP has correct cardinality
-    · sorry -- AP achieves exact bound
+    · exact hAP_card
+    · rw [hAP_card]
+      exact AP_restrictedSumset p a d A.card hd (by omega) hsmall
 
 end Erdos476

--- a/src/data/research/problems/erdos-1083-oq-02.json
+++ b/src/data/research/problems/erdos-1083-oq-02.json
@@ -39,7 +39,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 23 theorems (was 16). Added tight quadratic bounds and factored structure. Gallery formalization COMPLETE.",
+    "progressSummary": "PROGRESS: 25 theorems (was 23). Added threshold dimension bounds for 3/4 and 11/12 gap coverage. Formalization fully complete. Mathematical gap reduction OPEN.",
     "builtItems": [
       "Created Erdos1083OQ02.lean with SV bound formalization",
       "Proved sv_improves_erdos and sv_below_conjecture (exact exponent comparison)",
@@ -61,7 +61,9 @@
       "gap_below_twice_reciprocal_sq: 2/(d(d+2)) < 2/d² for d≥1 [Erdos1083OQ02.lean:207]",
       "gap_strictly_decreasing: 2/((d+1)(d+3)) < 2/(d(d+2)) for d≥4 [Erdos1083OQ02.lean:216]",
       "sv_fraction_of_conjecture: SV = (d+1)/(d+2) × (2/d) [Erdos1083OQ02.lean:232]",
-      "sv_fraction_increasing: (d+1)/(d+2) strictly increases in d [Erdos1083OQ02.lean:243]"
+      "sv_fraction_increasing: (d+1)/(d+2) strictly increases in d [Erdos1083OQ02.lean:243]",
+      "sv_covers_three_quarters: d/(d+2)≥3/4 for d≥6 [Erdos1083OQ02.lean:258]",
+      "sv_covers_eleven_twelfths: d/(d+2)≥11/12 for d≥22 [Erdos1083OQ02.lean:268]"
     ],
     "insights": [
       "SV exponent 2(d+1)/(d(d+2)) is strictly between 1/d and 2/d for d≥4",
@@ -75,7 +77,9 @@
       "Progress fraction theorem: SV closes exactly d/(d+2) of the full Erdős→conjecture gap. This is equivalent to sv_fraction_of_conjecture but viewed from a different angle (Erdős baseline vs conjecture)",
       "The remaining open fraction is 2/(d+2): for d=4 this is 1/3, for d=10 it is 1/6, decreasing to 0",
       "Gap tight bounds: 1/d² < 2/(d(d+2)) < 2/d² — gap is exactly order 1/d²",
-      "Absolute gap is strictly decreasing: each additional dimension shrinks the gap"
+      "Absolute gap is strictly decreasing: each additional dimension shrinks the gap",
+      "General threshold pattern: d/(d+2)≥(k-1)/k ↔ d≥2(k-1); covers 3/4 for d≥6, 11/12 for d≥22",
+      "Formalization is complete: 25 theorems, 0 sorries, 5 axioms — gap reduction itself is genuinely open"
     ],
     "mathlibGaps": [
       "No formalization of incidence geometry in ℝ^d",


### PR DESCRIPTION
## Summary

Multiple research problem improvements across three proof files:

### Erdős #476 (Erdős-Heilbronn Conjecture) — 4 sorries → 0
- **`restrictedSumsetR`**: Replace `sorry` with `(A.powersetCard r).image (fun s => s.sum id)`
- **`card_two_case`**: Prove `|{a,b} +̂ {a,b}| = 1` via singleton equality + `rcases`
- **AP cardinality**: `(a + {0,...,n-1}·d).card = n` via `ZMod.val_natCast` injectivity
- **`erdos_476_summary`**: Both sorries closed using `AP_restrictedSumset` axiom

### Erdős #1083 OQ-02 (Distinct Distances) — 2 new theorems added
- `sv_covers_three_quarters`: d/(d+2) ≥ 3/4 for d ≥ 6 (via Solymosi-Vu exponent)
- `sv_covers_eleven_twelfths`: d/(d+2) ≥ 11/12 for d ≥ 22

### Basel Problem OQ-01 OQ-01 OQ-02 (Apéry's ζ(3) irrationality) — 3 new lemmas
- `lcmUpTo_dvd_of_le`: monotonicity of lcm via `Finset.lcm_dvd`
- `lcmUpTo_three = 6`, `lcmUpTo_four = 12`: computed via `native_decide`
- `denominator_control_factorial`: proves n!³·aₙ ∈ ℤ by 2-step induction

## Test plan
- [ ] `./proofs/scripts/docker-build.sh Proofs.Erdos476Problem` (0 sorries)
- [ ] `./proofs/scripts/docker-build.sh Proofs.Erdos1083OQ02` (0 sorries)
- [ ] `./proofs/scripts/docker-build.sh Proofs.BaselProblemOQ01OQ01OQ02`

🤖 Generated with [Claude Code](https://claude.com/claude-code)