### PR TITLE
Fix: sync theoremCount 21→22 for tractatus-ontology (PR #10771 follow-up)

### DIFF
--- a/proofs/Proofs/TractatusOntology.lean
+++ b/proofs/Proofs/TractatusOntology.lean
@@ -364,7 +364,172 @@ theorem nand_expresses_conj (p q : Proposition S) (w : World S) :
   simp [Proposition.nand, Proposition.eval, not_not]
 
 -- ═══════════════════════════════════════════════════════════════
--- SECTION 9: The Limits of Formalization (TLP 6.54, 7)
+-- SECTION 10: Logical Consequence and Inference (TLP 5.1–5.14)
+-- ═══════════════════════════════════════════════════════════════
+
+/-
+TLP 5.11: "If the truth-grounds which are common to a number of
+           propositions are all also truth-grounds of some one
+           proposition, we say that the truth of this proposition
+           follows from the truth of those propositions."
+TLP 5.12: "In particular the truth of a proposition p follows from
+           that of a proposition q, if all the truth-grounds of q
+           are truth-grounds of p."
+TLP 5.14: "If a proposition follows from another, then the latter
+           says more than the former, and the former less than the
+           latter."
+
+We define semantic entailment as truth-preservation across all
+worlds — the proposition-level lifting of the world-level modus
+ponens already proved as Theorem 12.
+-/
+
+-- ---------------------------------------------------------------
+-- Definition: Semantic entailment (TLP 5.11, 5.12)
+-- ---------------------------------------------------------------
+
+/-- `Entails p q` holds when every world making `p` true also makes
+    `q` true. This is semantic (model-theoretic) consequence: we
+    quantify over worlds, not derivations. -/
+def Entails (p q : Proposition S) : Prop :=
+  ∀ w : World S, p.eval w → q.eval w
+
+-- ---------------------------------------------------------------
+-- Definition: Multi-premise entailment (TLP 5.11 generalized)
+-- ---------------------------------------------------------------
+
+/-- `EntailsAll premises conclusion` holds when any world making
+    every premise true also makes the conclusion true. -/
+def EntailsAll (premises : List (Proposition S)) (conclusion : Proposition S) : Prop :=
+  ∀ w : World S, (∀ p ∈ premises, p.eval w) → conclusion.eval w
+
+-- ---------------------------------------------------------------
+-- Definition: "Says more" (TLP 5.14)
+-- ---------------------------------------------------------------
+
+/-- `SaysMore p q` holds when `p` entails `q` but `q` does not
+    entail `p`. Following TLP 5.14, `p` "says more" — it narrows
+    the space of possible worlds further than `q` does. -/
+def SaysMore (p q : Proposition S) : Prop :=
+  Entails p q ∧ ¬ Entails q p
+
+-- ---------------------------------------------------------------
+-- Theorem 14: Entailment is reflexive (preorder structure)
+-- ---------------------------------------------------------------
+
+/-
+Every proposition entails itself — the identity inference.
+-/
+
+theorem entails_refl (p : Proposition S) : Entails p p :=
+  fun _ hp => hp
+
+-- ---------------------------------------------------------------
+-- Theorem 15: Entailment is transitive (preorder structure)
+-- ---------------------------------------------------------------
+
+/-
+If p entails q and q entails r, then p entails r — chaining
+inferences. Together with reflexivity, this makes Entails a
+preorder on propositions.
+
+Note: we do NOT declare a PartialOrder instance. Propositions
+that are logically equivalent (mutual entailment) need not be
+syntactically equal, so antisymmetry fails. The equivalence
+classes under mutual entailment form the Lindenbaum-Tarski
+algebra.
+-/
+
+theorem entails_trans (p q r : Proposition S)
+    (hpq : Entails p q) (hqr : Entails q r) : Entails p r :=
+  fun w hp => hqr w (hpq w hp)
+
+-- ---------------------------------------------------------------
+-- Preorder instance
+-- ---------------------------------------------------------------
+
+/-
+We equip `Proposition S` with a `Preorder` via `Entails`. This
+integrates with Mathlib's order-theory hierarchy, giving access to
+`le_refl` and `le_trans`.
+-/
+
+instance : Preorder (Proposition S) where
+  le := Entails
+  le_refl := entails_refl
+  le_trans := entails_trans
+
+-- ---------------------------------------------------------------
+-- Theorem 16: A tautology follows from anything (TLP 5.142)
+-- ---------------------------------------------------------------
+
+/-
+TLP 5.142: "A tautology follows from all propositions: it says
+nothing." Since a tautology holds in every world, it is entailed
+by any premise whatsoever.
+-/
+
+theorem tautology_follows_from_anything (p : Proposition S)
+    (h : IsTautology p) : ∀ q : Proposition S, Entails q p :=
+  fun _ w _ => h w
+
+-- ---------------------------------------------------------------
+-- Theorem 17: A contradiction entails everything (TLP 5.14 dual)
+-- ---------------------------------------------------------------
+
+/-
+From a contradiction, anything follows — ex falso quodlibet. A
+contradiction holds in no world, so the universal quantification
+in `Entails` is vacuously satisfied.
+-/
+
+theorem contradiction_entails_everything (p : Proposition S)
+    (h : IsContradiction p) : ∀ q : Proposition S, Entails p q :=
+  fun _ w hp => absurd hp (h w)
+
+-- ---------------------------------------------------------------
+-- Theorem 18: Deduction theorem (TLP 5.132)
+-- ---------------------------------------------------------------
+
+/-
+TLP 5.132: "If p follows from q, I can conclude from q to p;
+            infer p from q."
+
+The deduction theorem bridges semantic entailment and tautological
+implication: p entails q if and only if p → q is a tautology.
+This connects the "follows from" relation (semantic) with the
+structure of implications (syntactic/truth-functional).
+-/
+
+theorem deduction_theorem (p q : Proposition S) :
+    Entails p q ↔ IsTautology (Proposition.impl p q) := by
+  constructor
+  · intro h w
+    rw [impl_semantics]
+    exact h w
+  · intro h w hp
+    have := h w
+    rw [impl_semantics] at this
+    exact this hp
+
+-- ---------------------------------------------------------------
+-- Theorem 19: Modus ponens as entailment
+-- ---------------------------------------------------------------
+
+/-
+Modus ponens lifted to the entailment level: the conjunction of
+p and (p → q) entails q. This is the proposition-level version
+of the world-level Theorem 12.
+-/
+
+theorem modus_ponens_entails (p q : Proposition S) :
+    Entails (Proposition.conj p (Proposition.impl p q)) q := by
+  intro w ⟨hp, himp⟩
+  rw [impl_semantics] at himp
+  exact himp hp
+
+-- ═══════════════════════════════════════════════════════════════
+-- SECTION 11: The Limits of Formalization (TLP 6.54, 7)
 -- ═══════════════════════════════════════════════════════════════
 
 /-

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -309,10 +309,10 @@
       "result": "clean"
     },
     "ballot-problem-oq-01-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
-      "result": "clean"
+      "lastAudited": "2026-04-14T18:30:04Z",
+      "result": "issues-fixed"
     },
     "ballot-problem-oq-01-oq-04": {
       "auditCount": 2,
@@ -12588,6 +12588,12 @@
       "issues": []
     },
     "law-of-sines-oq-06": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-14T18:00:25Z",
+      "result": "issues-found",
+      "issues": []
+    },
+    "law-of-cosines-oq-06": {
       "auditCount": 1,
       "lastAudited": "2026-04-14T18:00:25Z",
       "result": "issues-found",

--- a/src/data/proofs/tractatus-ontology/annotations.json
+++ b/src/data/proofs/tractatus-ontology/annotations.json
@@ -226,9 +226,64 @@
     "relatedConcepts": ["TLP 5.5", "Sheffer stroke", "NAND", "functional completeness", "Henry Sheffer"]
   },
   {
+    "id": "ann-tractatus-entails",
+    "proofId": "tractatus-ontology",
+    "range": { "startLine": 391, "endLine": 414 },
+    "type": "definition",
+    "title": "Semantic Entailment and 'Says More' (TLP 5.11, 5.12, 5.14)",
+    "content": "TLP 5.11: 'If the truth-grounds which are common to a number of propositions are all also truth-grounds of some one proposition, we say that the truth of this proposition follows from the truth of those propositions.' TLP 5.12: 'In particular the truth of a proposition p follows from that of a proposition q, if all the truth-grounds of q are truth-grounds of p.'\n\nWe define three related concepts:\n- `Entails p q` -- semantic entailment: every world making $p$ true also makes $q$ true\n- `EntailsAll premises conclusion` -- multi-premise entailment generalizing TLP 5.11\n- `SaysMore p q` -- strict entailment (TLP 5.14): $p$ entails $q$ but not conversely, meaning $p$ narrows the space of possible worlds more than $q$ does\n\nThe definition of `Entails` uses universal quantification over worlds rather than set inclusion on truth-grounds, but these are equivalent (see TLP 5.122 on sense inclusion).",
+    "mathContext": "`Entails p q` is defined as `\\forall w, p.\\text{eval}(w) \\to q.\\text{eval}(w)`. This is the standard model-theoretic notion of semantic consequence. `SaysMore p q` is `Entails p q \\land \\neg Entails q p` -- a strict partial order fragment corresponding to information-theoretic strength: a proposition that 'says more' excludes more possible worlds.",
+    "significance": "critical",
+    "relatedConcepts": ["TLP 5.11", "TLP 5.12", "TLP 5.14", "semantic consequence", "model theory", "information content", "truth-grounds"]
+  },
+  {
+    "id": "ann-tractatus-preorder",
+    "proofId": "tractatus-ontology",
+    "range": { "startLine": 424, "endLine": 460 },
+    "type": "theorem",
+    "title": "Entailment as Preorder (TLP 5.12)",
+    "content": "Entailment is reflexive (every proposition entails itself) and transitive (entailment chains compose). Together these make `Entails` a preorder on propositions, which we register as a `Preorder` instance integrating with Mathlib's order theory.\n\nCrucially, we do NOT declare a `PartialOrder` instance. Antisymmetry would require that mutual entailment implies syntactic equality ($\\text{Entails}(p, q) \\land \\text{Entails}(q, p) \\to p = q$), which fails: logically equivalent propositions like $p$ and $\\neg\\neg p$ mutually entail each other but are distinct terms of type `Proposition S`. The equivalence classes under mutual entailment form the Lindenbaum-Tarski algebra -- the quotient where antisymmetry does hold.",
+    "mathContext": "A preorder is a reflexive, transitive relation. The Lean `Preorder` typeclass extends `LE` and `LT`, defining $p \\le q$ as `Entails p q` and $p < q$ as `Entails p q \\land \\neg Entails q p` (which is exactly `SaysMore`). Quotienting by mutual entailment would yield a Boolean algebra (the Lindenbaum-Tarski algebra), but we leave this for future work.",
+    "significance": "key",
+    "relatedConcepts": ["preorder", "partial order", "antisymmetry", "Lindenbaum-Tarski algebra", "logical equivalence"]
+  },
+  {
+    "id": "ann-tractatus-extremals",
+    "proofId": "tractatus-ontology",
+    "range": { "startLine": 462, "endLine": 488 },
+    "type": "theorem",
+    "title": "Tautology and Contradiction as Extremals (TLP 5.142)",
+    "content": "TLP 5.142: 'A tautology follows from all propositions: it says nothing.' The dual: a contradiction entails everything (ex falso quodlibet).\n\nThese theorems reveal that tautologies and contradictions are the extremal elements of the entailment preorder:\n- A tautology is a *top* element: every proposition $q$ satisfies $q \\le \\text{taut}$\n- A contradiction is a *bottom* element: every proposition $q$ satisfies $\\text{contra} \\le q$\n\nFor Wittgenstein, this is not a mere technical fact but the reason tautologies 'say nothing' (TLP 4.461): they impose no constraint on which world is actual.",
+    "mathContext": "The proof of `tautology_follows_from_anything` is one line: since a tautology $p$ holds in every world, the antecedent of `Entails q p` is irrelevant. The proof of `contradiction_entails_everything` uses `absurd` to derive anything from a contradiction: if $p$ holds in $w$ but $p$ is a contradiction, we have a proof of `False`.",
+    "significance": "key",
+    "relatedConcepts": ["TLP 5.142", "TLP 4.461", "top element", "bottom element", "ex falso quodlibet", "logical triviality"]
+  },
+  {
+    "id": "ann-tractatus-deduction",
+    "proofId": "tractatus-ontology",
+    "range": { "startLine": 504, "endLine": 513 },
+    "type": "theorem",
+    "title": "The Deduction Theorem (TLP 5.132)",
+    "content": "TLP 5.132: 'If p follows from q, I can conclude from q to p; infer p from q.'\n\nThe deduction theorem is the bridge between semantic and syntactic consequence: $p$ entails $q$ if and only if $p \\to q$ is a tautology. Forward: if every world making $p$ true also makes $q$ true, then $p \\to q$ holds in every world. Backward: if $p \\to q$ is a tautology and $p$ holds in some world $w$, then $q$ holds in $w$ by modus ponens.\n\nThis is philosophically significant because it connects the *relation* of entailment (a metalinguistic concept, quantifying over worlds) with a *single proposition* ($p \\to q$) in the object language. The Tractatus perceives this connection 'from the structure of the propositions' (TLP 5.13) -- another instance of showing rather than saying.",
+    "mathContext": "The proof uses `impl_semantics` (already proved as Theorem 10) to convert between the syntactic implication `Proposition.impl p q` and the semantic arrow `p.eval w \\to q.eval w`. The biconditional is proved by constructing both directions explicitly. This theorem connects Hilbert-style deduction (tautological implication) with semantic consequence (model-theoretic entailment) -- the completeness direction for this simple propositional framework.",
+    "significance": "critical",
+    "relatedConcepts": ["TLP 5.13", "TLP 5.131", "TLP 5.132", "deduction theorem", "completeness", "semantic consequence", "syntactic consequence", "saying vs showing"]
+  },
+  {
+    "id": "ann-tractatus-mp-entails",
+    "proofId": "tractatus-ontology",
+    "range": { "startLine": 525, "endLine": 529 },
+    "type": "theorem",
+    "title": "Modus Ponens as Entailment",
+    "content": "Modus ponens lifted from the world level (Theorem 12) to the proposition level: the conjunction $p \\land (p \\to q)$ entails $q$. This completes the circle: Theorem 12 showed truth-preservation within a single world; this theorem packages it as a relation between propositions across all worlds.\n\nTogether with the deduction theorem, this shows that our object language has enough internal structure to express its own inference rules -- the kind of self-referential capacity that makes the Tractatus's saying/showing distinction philosophically tense.",
+    "mathContext": "The proof destructs the conjunction hypothesis into `hp : p.eval w` and `himp : (Proposition.impl p q).eval w`, applies `impl_semantics` to convert the latter to a function, and applies it. This is the entailment-level analogue of the world-level modus ponens.",
+    "significance": "key",
+    "relatedConcepts": ["modus ponens", "entailment", "inference rules", "saying vs showing"]
+  },
+  {
     "id": "ann-tractatus-ladder",
     "proofId": "tractatus-ontology",
-    "range": { "startLine": 370, "endLine": 384 },
+    "range": { "startLine": 535, "endLine": 548 },
     "type": "insight",
     "title": "The Ladder (TLP 6.54)",
     "content": "TLP 6.54: 'My propositions serve as elucidations in the following way: anyone who understands me eventually recognizes them as nonsensical, when he has used them — as steps — to climb beyond them. He must, so to speak, throw away the ladder after he has climbed up it.'\n\nEverything above is the ladder. The view from the top — that logical form is shared between language and reality rather than represented by either — is precisely what Lean, or any formal system, shows through its structure rather than states as a theorem. The residue left over after formalization is the most Wittgensteinian part.\n\n**[Interpretive choice]** The Tractatus is self-consciously paradoxical: it uses meaningful propositions to argue that certain things cannot be meaningfully said. Any formalization must pick a side — either the ladder is meaningful (in which case the self-undermining thesis fails) or it is not (in which case the formalization formalizes nothing). We take the first option: the formal skeleton is mathematically meaningful, and the philosophical claim about its limitations is carried by the annotations, not the code.",
@@ -238,7 +293,7 @@
   {
     "id": "ann-tractatus-proposition-seven",
     "proofId": "tractatus-ontology",
-    "range": { "startLine": 386, "endLine": 393 },
+    "range": { "startLine": 550, "endLine": 558 },
     "type": "theorem",
     "title": "Proposition 7 (TLP 7)",
     "content": "TLP 7: *Wovon man nicht sprechen kann, darüber muss man schweigen.* — 'Whereof one cannot speak, thereof one must be silent.'\n\nThe theorem states: there exist truths about this formal system that no proposition within it can express. Specifically, meta-properties like 'p is a tautology' — which quantify over all worlds — have no equivalent object-language proposition whose world-by-world truth value matches them.\n\nThis is provable. We could fill the sorry. But the sorry *is* the silence. It marks the boundary where the formalization stops speaking — not because it must, but because the Tractatus demands it. Every other theorem in this file closes its proof; this one remains open.\n\nThe sorry also has a technical function: it makes this the one claim in the file that Lean cannot verify, mirroring Wittgenstein's proposition 7 as the one claim in the Tractatus that cannot be a picture of reality (since it is about the limits of picturing itself).",

--- a/src/data/proofs/tractatus-ontology/meta.json
+++ b/src/data/proofs/tractatus-ontology/meta.json
@@ -2,7 +2,7 @@
   "id": "tractatus-ontology",
   "title": "Wittgenstein's Tractarian Ontology",
   "slug": "tractatus-ontology",
-  "description": "A Lean 4 formalization of the structural core of Wittgenstein's Tractatus Logico-Philosophicus: objects, states of affairs, worlds, propositions, and truth-functionality. Proves that tautologies are world-invariant and contradictions hold nowhere. Ends with a deliberate sorry — the silence of Proposition 7.",
+  "description": "A Lean 4 formalization of the structural core of Wittgenstein's Tractatus Logico-Philosophicus: objects, states of affairs, worlds, propositions, truth-functionality, and logical consequence. Defines semantic entailment, proves the deduction theorem, and establishes a preorder on propositions. Ends with a deliberate sorry — the silence of Proposition 7.",
   "meta": {
     "status": "axiomatized",
     "tags": ["philosophy", "logic", "ontology", "model-theory", "truth-functions"],
@@ -31,22 +31,24 @@
       "Truth-functional compositionality theorem via structural induction",
       "Elementary independence theorem witnessing the Sachverhalt/world correspondence",
       "NAND functional completeness formalizing TLP 5.5",
+      "Semantic entailment (Entails) with Preorder instance and deduction theorem (TLP 5.1-5.14)",
       "Philosophical annotations bridging formal verification and Wittgensteinian philosophy"
     ],
     "dateAdded": "04/14/26",
     "axiomCount": 0,
-    "lineCount": 394,
+    "lineCount": 559,
     "assumptions": "One deliberate sorry: proposition_seven (TLP 7) — states that inexpressible truths exist but leaves the proof open as a philosophical gesture. All other theorems are fully verified. Uses classical logic (Classical.em) throughout."
   },
   "overview": {
     "historicalContext": "The Tractatus Logico-Philosophicus (1921) is Wittgenstein's only book-length philosophical work published in his lifetime. It presents a logical atomist ontology: the world consists of facts (obtaining states of affairs), propositions picture possible states of affairs, and all meaningful propositions are truth-functions of elementary propositions. The work culminates in proposition 6.54 — the famous ladder that must be thrown away — and the closing injunction: 'Whereof one cannot speak, thereof one must be silent.'",
     "problemStatement": "Can the structural core of the Tractatus — its ontology of objects, states of affairs, worlds, and truth-functional propositions — be faithfully formalized in a modern proof assistant? What is captured by formalization, and what necessarily escapes?",
-    "proofStrategy": "We define types for objects (opaque), states of affairs (abstract), and worlds (predicates on states of affairs). Propositions form an inductive type with elementary, negation, and conjunction constructors. All other connectives are derived. A recursive evaluation function maps propositions to truth values relative to worlds. We then prove key structural theorems: compositionality, independence, tautology/contradiction characterization, and connective semantics.",
+    "proofStrategy": "We define types for objects (opaque), states of affairs (abstract), and worlds (predicates on states of affairs). Propositions form an inductive type with elementary, negation, and conjunction constructors. All other connectives are derived. A recursive evaluation function maps propositions to truth values relative to worlds. We then prove key structural theorems: compositionality, independence, tautology/contradiction characterization, connective semantics, and logical consequence via semantic entailment.",
     "keyInsights": [
       "The world-as-predicate encoding makes elementary independence trivially true — the assignment IS the world",
       "Truth-functional compositionality follows by structural induction on the proposition type",
       "The formalization necessarily works at the metalevel — we prove theorems ABOUT propositions in Lean, which is precisely the kind of thing Wittgenstein says can only be shown, not said",
-      "Classical logic (excluded middle) is used throughout, matching Wittgenstein's bivalent semantics"
+      "Classical logic (excluded middle) is used throughout, matching Wittgenstein's bivalent semantics",
+      "Entailment forms a preorder (not partial order) on propositions — mutual entailment gives logical equivalence, not syntactic equality"
     ],
     "prerequisites": [
       "Basic propositional logic",
@@ -119,16 +121,23 @@
       "summary": "Thirteen theorems establishing compositionality, independence, bivalence, connective semantics, and functional completeness."
     },
     {
+      "id": "logical-consequence",
+      "title": "Logical Consequence and Inference (TLP 5.1-5.14)",
+      "startLine": 366,
+      "endLine": 529,
+      "summary": "Semantic entailment, multi-premise entailment, and 'says more' definitions. Six theorems: reflexivity, transitivity, Preorder instance, tautology/contradiction extremals, deduction theorem, and modus ponens as entailment."
+    },
+    {
       "id": "limits",
       "title": "The Limits of Formalization (TLP 6.54, 7)",
-      "startLine": 366,
-      "endLine": 389,
+      "startLine": 531,
+      "endLine": 559,
       "summary": "Closing philosophical reflection on what escapes formalization — the ladder and the silence."
     }
   ],
   "conclusion": {
-    "summary": "We have formalized the ontological skeleton of the Tractatus: objects, states of affairs, worlds, and truth-functional propositions. Thirteen theorems are fully proved; the fourteenth — that inexpressible truths exist — is stated and deliberately left as sorry. The silence of Proposition 7 is enacted, not just cited.",
-    "implications": "This demonstrates that the formal core of the Tractatus — often dismissed as merely philosophical rather than mathematical — admits precise statement and machine-verified proof. The exercise also reveals where formalization reaches its limits: the saying/showing distinction, the nature of logical form, and the self-undermining character of 6.54 all resist capture in any formal system.",
+    "summary": "We have formalized the ontological skeleton and logical consequence theory of the Tractatus: objects, states of affairs, worlds, truth-functional propositions, semantic entailment, and the deduction theorem. Nineteen theorems are fully proved; the twentieth — that inexpressible truths exist — is stated and deliberately left as sorry. The silence of Proposition 7 is enacted, not just cited.",
+    "implications": "This demonstrates that the formal core of the Tractatus — often dismissed as merely philosophical rather than mathematical — admits precise statement and machine-verified proof. The entailment section (TLP 5.1-5.14) shows that logical consequence, the preorder structure on propositions, and the deduction theorem all arise naturally from the Tractarian framework. The exercise also reveals where formalization reaches its limits: the saying/showing distinction, the nature of logical form, and the self-undermining character of 6.54 all resist capture in any formal system.",
     "openQuestions": [
       "Could dependent types better capture TLP 2.0141 — that an object's form IS its combinatorial possibility?",
       "Is there a formalization that captures the saying/showing distinction without collapsing it?",
@@ -162,10 +171,10 @@
     "imports": ["Mathlib.Tactic"],
     "opens": [],
     "namespace": "Tractatus",
-    "lineCount": 394,
+    "lineCount": 559,
     "axiomCount": 0,
-    "theoremCount": 15,
-    "definitionCount": 8,
+    "theoremCount": 21,
+    "definitionCount": 11,
     "path": "Proofs/TractatusOntology.lean",
     "sorries": 1
   },
@@ -193,6 +202,18 @@
       "type": "core",
       "description": "p ∨ ¬p is a tautology — paradigmatic logical truth (TLP 4.46)",
       "leanType": "IsTautology (Proposition.disj p (Proposition.neg p))"
+    },
+    {
+      "name": "entails_refl",
+      "type": "core",
+      "description": "Entailment is reflexive — every proposition entails itself (TLP 5.12)",
+      "leanType": "Entails p p"
+    },
+    {
+      "name": "deduction_theorem",
+      "type": "core",
+      "description": "p entails q iff p → q is a tautology — bridges semantic and syntactic consequence (TLP 5.132)",
+      "leanType": "Entails p q ↔ IsTautology (Proposition.impl p q)"
     }
   ]
 }

--- a/src/data/proofs/tractatus-ontology/meta.json
+++ b/src/data/proofs/tractatus-ontology/meta.json
@@ -136,7 +136,7 @@
     }
   ],
   "conclusion": {
-    "summary": "We have formalized the ontological skeleton and logical consequence theory of the Tractatus: objects, states of affairs, worlds, truth-functional propositions, semantic entailment, and the deduction theorem. Nineteen theorems are fully proved; the twentieth — that inexpressible truths exist — is stated and deliberately left as sorry. The silence of Proposition 7 is enacted, not just cited.",
+    "summary": "We have formalized the ontological skeleton and logical consequence theory of the Tractatus: objects, states of affairs, worlds, truth-functional propositions, semantic entailment, and the deduction theorem. Twenty-one theorems are fully proved; the twenty-second — that inexpressible truths exist — is stated and deliberately left as sorry. The silence of Proposition 7 is enacted, not just cited.",
     "implications": "This demonstrates that the formal core of the Tractatus — often dismissed as merely philosophical rather than mathematical — admits precise statement and machine-verified proof. The entailment section (TLP 5.1-5.14) shows that logical consequence, the preorder structure on propositions, and the deduction theorem all arise naturally from the Tractarian framework. The exercise also reveals where formalization reaches its limits: the saying/showing distinction, the nature of logical form, and the self-undermining character of 6.54 all resist capture in any formal system.",
     "openQuestions": [
       "Could dependent types better capture TLP 2.0141 — that an object's form IS its combinatorial possibility?",
@@ -173,7 +173,7 @@
     "namespace": "Tractatus",
     "lineCount": 559,
     "axiomCount": 0,
-    "theoremCount": 21,
+    "theoremCount": 22,
     "definitionCount": 11,
     "path": "Proofs/TractatusOntology.lean",
     "sorries": 1


### PR DESCRIPTION
## Fix

Corrects the theorem count mismatch in `tractatus-ontology` meta.json identified in the judge review of #10771.

## Evidence

**Before**: `theoremCount: 21`, "Nineteen theorems are fully proved; the twentieth..."
**After**: `theoremCount: 22`, "Twenty-one theorems are fully proved; the twenty-second..."

The Lean file (`proofs/Proofs/TractatusOntology.lean`) at this branch contains exactly 22 `theorem` declarations:
- 15 in the core Theorems section (lines ~154-364)
- 6 in the Logical Consequence section (lines ~366-529): entails_refl, entails_trans, tautology_follows_from_anything, contradiction_entails_everything, deduction_theorem, modus_ponens_entails
- 1 in the Limits section (`proposition_seven`, line ~555)

Two fields corrected:
1. `leanFile.theoremCount`: 21 → 22
2. `conclusion.summary`: "Nineteen...twentieth" → "Twenty-one...twenty-second"

Addresses judge review note: "The only actionable item is fixing `theoremCount` from 21 to 22 in meta.json."

---
Automated fix by lean-mechanic agent.