### PR TITLE
Tractatus: rename sections to TLP numbers, add Design Decisions

### DIFF
--- a/proofs/Proofs/TractatusOntology.lean
+++ b/proofs/Proofs/TractatusOntology.lean
@@ -17,10 +17,60 @@ escapes — the saying/showing distinction, the ladder of 6.54 —
 is discussed in the gallery annotations.
 -/
 
+-- ═══════════════════════════════════════════════════════════════
+-- DESIGN DECISIONS
+-- ═══════════════════════════════════════════════════════════════
+
+/-
+The following modeling choices are deliberate and load-bearing.
+They represent a Tarskian reconstruction of Tractarian structure,
+not an exegesis of Wittgenstein's intent.
+
+1. WORLDS AS TOTAL PREDICATES (`S → Prop`)
+   Worlds are functions from states of affairs to Prop — unconstrained,
+   classical, and extensional. There is no requirement that worlds be
+   "complete" in any metaphysical sense; any assignment of truth values
+   to Sachverhalte constitutes a world. This gives elementary independence
+   for free (see `elementary_independence`), at the cost of not encoding
+   TLP 2.0141 (an object's form constrains its combinatorial possibilities).
+
+2. INDEPENDENCE BAKED INTO THE MODEL
+   Because `World S = S → Prop`, any truth-value assignment is a world.
+   Independence is not a theorem derived from structure — it is definitional.
+   A richer encoding (e.g. Sachverhalt as a dependent type over TractObject)
+   would make independence substantive and provable.
+
+3. CLASSICAL LOGIC ASSUMED THROUGHOUT (`Classical.em`)
+   Every theorem that turns on bivalence or double-negation elimination
+   invokes `Classical.em`. This matches Wittgenstein's bivalent semantics.
+   Constructivists should note that `elem_prop_bivalence`, `double_negation`,
+   and `excluded_middle_tautology` are all non-constructive.
+
+4. HOAS FOR QUANTIFIERS (TractatusQuantifiers.lean)
+   First-order binding (`∀ x, P(x)`) is encoded via higher-order abstract
+   syntax: `forall_ : (D → FOProp S D) → FOProp S D`. This leverages Lean's
+   metalanguage for variable binding rather than implementing substitution
+   explicitly. The tradeoff: HOAS ties the formalization to Lean's metatheory
+   more tightly than de Bruijn indices would, but dramatically reduces proof
+   overhead.
+
+5. ABSTRACT TYPES — NO STRUCTURE ON `TractObject`/`Sachverhalt`
+   Both `TractObject` and `Sachverhalt` are bare `variable (... : Type)`.
+   Lean knows nothing about their inhabitants. This captures Wittgenstein's
+   insistence on simplicity (TLP 2.02) and avoids committing to a structural
+   account of combination that the Tractatus leaves open.
+
+6. THE SILENCE IS AXIOMATIC, NOT SORRY
+   `axiom silence : True` (TLP 7) is a deliberate axiom, not a missing proof.
+   The `sorry` in the earlier `proposition_seven` statement was intentional
+   (the point was the gap), but the file's definitive statement is `axiom silence`.
+   This marks a boundary of formalization-by-design, not a proof obligation.
+-/
+
 namespace Tractatus
 
 -- ═══════════════════════════════════════════════════════════════
--- SECTION 1: Objects (TLP 2.02)
+-- SECTION 1: TLP 1-2.06: Objects and States of Affairs
 -- ═══════════════════════════════════════════════════════════════
 
 /-
@@ -35,7 +85,7 @@ type exists.
 variable (TractObject : Type)
 
 -- ═══════════════════════════════════════════════════════════════
--- SECTION 2: States of Affairs (TLP 2.01)
+-- SECTION 2: TLP 2.01-2.062: States of Affairs (Sachverhalte)
 -- ═══════════════════════════════════════════════════════════════
 
 /-
@@ -52,7 +102,7 @@ independence while remaining agnostic about combinatorial form.
 variable (Sachverhalt : Type)
 
 -- ═══════════════════════════════════════════════════════════════
--- SECTION 3: Worlds (TLP 1, 1.1, 2.04)
+-- SECTION 3: TLP 2.1-2.174: Worlds as Predicates
 -- ═══════════════════════════════════════════════════════════════
 
 /-
@@ -68,7 +118,7 @@ it does not.
 def World := Sachverhalt → Prop
 
 -- ═══════════════════════════════════════════════════════════════
--- SECTION 4: Propositions (TLP 4.21, 5, 5.101)
+-- SECTION 4: TLP 4.2-4.463: Propositions and Logical Space
 -- ═══════════════════════════════════════════════════════════════
 
 /-
@@ -85,7 +135,7 @@ inductive Proposition (S : Type) where
   | conj       : Proposition S → Proposition S → Proposition S
 
 -- ═══════════════════════════════════════════════════════════════
--- SECTION 5: Derived Connectives (TLP 5.101)
+-- SECTION 5: TLP 5: Truth-Functionality (Formalized)
 -- ═══════════════════════════════════════════════════════════════
 
 /-
@@ -113,7 +163,7 @@ def nand (p q : Proposition S) : Proposition S :=
 end Proposition
 
 -- ═══════════════════════════════════════════════════════════════
--- SECTION 6: Semantic Evaluation (TLP 2.21, 4.06)
+-- SECTION 6: TLP 5.1-5.14: Semantic Evaluation
 -- ═══════════════════════════════════════════════════════════════
 
 /-
@@ -151,7 +201,7 @@ theorem Proposition.evalBool_correct (p : Proposition S) (w : S → Bool) :
   | conj q r ihq ihr => simp [evalBool, eval, Bool.and_eq_true, ihq, ihr]
 
 -- ═══════════════════════════════════════════════════════════════
--- SECTION 7: Tautology and Contradiction (TLP 4.46, 6.1)
+-- SECTION 7: TLP 5.502: Tautology and Contradiction
 -- ═══════════════════════════════════════════════════════════════
 
 /-
@@ -169,7 +219,7 @@ def IsContradiction (p : Proposition S) : Prop :=
   ∀ w : World S, ¬ (p.eval w)
 
 -- ═══════════════════════════════════════════════════════════════
--- SECTION 8: Theorems
+-- SECTION 8: TLP 6.1: Core Theorems
 -- ═══════════════════════════════════════════════════════════════
 
 -- ---------------------------------------------------------------
@@ -381,7 +431,7 @@ theorem nand_expresses_conj (p q : Proposition S) (w : World S) :
   simp [Proposition.nand, Proposition.eval, not_not]
 
 -- ═══════════════════════════════════════════════════════════════
--- SECTION 9: Concrete Examples
+-- SECTION 9: Concrete Examples (TwoFacts Instantiation)
 -- ═══════════════════════════════════════════════════════════════
 
 /-
@@ -431,7 +481,7 @@ def rainyWorldBool : TwoFacts → Bool
 #eval (Proposition.neg itSnows).evalBool rainyWorldBool            -- true
 
 -- ═══════════════════════════════════════════════════════════════
--- SECTION 10: The Limits of Formalization (TLP 6.54, 7)
+-- SECTION 10: TLP 6.54-7: Limits of Formalization
 -- ═══════════════════════════════════════════════════════════════
 
 -- ---------------------------------------------------------------
@@ -479,10 +529,6 @@ theorem contingent_propositions_vary (q : Proposition S) [Nonempty S]
   push_neg at h_not_taut
   obtain ⟨w₂, hw₂⟩ := h_not_taut
   exact ⟨w₁, w₂, hw₁, hw₂⟩
-
--- ═══════════════════════════════════════════════════════════════
--- SECTION: The Limits of Formalization (TLP 6.54, 7)
--- ═══════════════════════════════════════════════════════════════
 
 /-
 TLP 6.54: "My propositions serve as elucidations in the following

--- a/proofs/Proofs/TractatusQuantifiers.lean
+++ b/proofs/Proofs/TractatusQuantifiers.lean
@@ -25,7 +25,7 @@ depends on the N-operator formalization (#10723).
 namespace Tractatus
 
 -- ═══════════════════════════════════════════════════════════════
--- SECTION 1: First-Order Propositions (TLP 5.52)
+-- SECTION 1: TLP 5.52: First-Order Propositions (FOProp)
 -- ═══════════════════════════════════════════════════════════════
 
 /-
@@ -54,7 +54,7 @@ inductive FOProp (S : Type) (D : Type) : Type where
   | exists_  : (D → FOProp S D) → FOProp S D
 
 -- ═══════════════════════════════════════════════════════════════
--- SECTION 2: Evaluation (TLP 5.52, extended)
+-- SECTION 2: TLP 5.52: Evaluation (Extended to First-Order)
 -- ═══════════════════════════════════════════════════════════════
 
 /-
@@ -78,7 +78,7 @@ def FOProp.eval (p : FOProp S D) (w : World S) : Prop :=
   | .exists_ f   => ∃ d : D, (f d).eval w
 
 -- ═══════════════════════════════════════════════════════════════
--- SECTION 3: Derived Connectives (first-order level)
+-- SECTION 3: TLP 5.1: Derived Connectives (First-Order Level)
 -- ═══════════════════════════════════════════════════════════════
 
 /-
@@ -97,7 +97,7 @@ def implFO (p q : FOProp S D) : FOProp S D :=
 end FOProp
 
 -- ═══════════════════════════════════════════════════════════════
--- SECTION 4: Theorems
+-- SECTION 4: TLP 5.1-5.14: Core Theorems (First-Order)
 -- ═══════════════════════════════════════════════════════════════
 
 -- ---------------------------------------------------------------
@@ -262,7 +262,7 @@ theorem fo_bivalence (p : FOProp S D) (w : World S) :
   Classical.em (p.eval w)
 
 -- ═══════════════════════════════════════════════════════════════
--- SECTION 5: Philosophical Limits — Infinite Domains (TLP 5.52)
+-- SECTION 5: TLP 5.502/6.54: Philosophical Limits — Infinite Domains
 -- ═══════════════════════════════════════════════════════════════
 
 /-

--- a/src/data/proofs/tractatus-ontology/annotations.json
+++ b/src/data/proofs/tractatus-ontology/annotations.json
@@ -1,5 +1,16 @@
 [
   {
+    "id": "ann-tractatus-what-this-is-not",
+    "proofId": "tractatus-ontology",
+    "range": { "startLine": 1, "endLine": 18 },
+    "type": "concept",
+    "title": "What This Is Not",
+    "content": "This formalization is a Tarskian reconstruction of the Tractatus's formal skeleton -- not a complete account of Wittgenstein's philosophy. Four boundaries matter:\n\n**1. Not a full account of meaning or use.** The Tractatus ties meaning to picturing and use to nothing (the later Wittgenstein did that). This formalization captures only the truth-conditional core: how propositions evaluate relative to worlds. The richer theory of meaning -- what makes a proposition a *picture*, how objects 'hang together' -- is not formalized.\n\n**2. Not capturing saying/showing (except via `axiom silence`).** TLP 4.121: 'What can be shown cannot be said.' The saying/showing distinction is the nerve of the Tractatus and it cannot be formalized without collapsing it. The `axiom silence` and the `proposition_seven` theorems gesture at this limit, but the gesture is in the metalanguage, not the object language.\n\n**3. Not Wittgenstein's later philosophy.** The Tractatus belongs to early Wittgenstein -- logical atomism, picture theory, bivalent truth conditions. The *Philosophical Investigations* (1953) repudiate nearly all of it. This formalization has nothing to say about language games, family resemblance, rule-following, or forms of life.\n\n**4. A Tarskian reconstruction, not an exegesis.** We use standard model theory: types for domains, predicates for truth, recursive evaluation for semantics. Wittgenstein did not have Tarski's apparatus, and he would likely have rejected the metalinguistic standpoint it requires. The formalization is faithful to the *structure* of the Tractarian ontology, not to its philosophical self-understanding.",
+    "mathContext": "The formal core -- objects as types, worlds as predicates, propositions as inductive trees, evaluation as structural recursion -- is standard model theory from the 1930s forward. Wittgenstein's contribution was the philosophical interpretation layered onto this structure, particularly the saying/showing distinction and the self-undermining 6.54. The formalization captures the former and can only gesture at the latter.",
+    "significance": "critical",
+    "relatedConcepts": ["logical atomism", "picture theory", "saying vs showing", "Tarski semantics", "Wittgenstein's later philosophy", "language games"]
+  },
+  {
     "id": "ann-tractatus-opening",
     "proofId": "tractatus-ontology",
     "range": { "startLine": 1, "endLine": 18 },

--- a/src/data/proofs/tractatus-ontology/meta.json
+++ b/src/data/proofs/tractatus-ontology/meta.json
@@ -38,7 +38,7 @@
     ],
     "dateAdded": "04/14/26",
     "axiomCount": 1,
-    "lineCount": 528,
+    "lineCount": 575,
     "assumptions": "One deliberate axiom: `silence : True` (TLP 7) — a trivially true but axiomatic declaration that enacts Wittgenstein's silence as a formal gesture. All theorems are fully proved with 0 sorries. Uses classical logic (Classical.em) throughout. The companion file TractatusQuantifiers.lean has no sorries or axioms."
   },
   "overview": {
@@ -61,73 +61,80 @@
   "sections": [
     {
       "id": "preamble",
-      "title": "Preamble",
+      "title": "Preamble and Design Decisions",
       "startLine": 1,
-      "endLine": 20,
-      "summary": "Module imports and documentation header introducing the formalization scope."
+      "endLine": 70,
+      "summary": "Module imports, documentation header, and Design Decisions block documenting six load-bearing modeling choices (worlds as predicates, independence by construction, classical logic, HOAS quantifiers, abstract types, axiomatic silence)."
     },
     {
       "id": "objects",
-      "title": "Objects (TLP 2.02)",
-      "startLine": 22,
-      "endLine": 35,
+      "title": "TLP 1-2.06: Objects and States of Affairs",
+      "startLine": 72,
+      "endLine": 86,
       "summary": "Objects as an abstract variable type — simple, structureless entities."
     },
     {
       "id": "states-of-affairs",
-      "title": "States of Affairs (TLP 2.01)",
-      "startLine": 37,
-      "endLine": 52,
+      "title": "TLP 2.01-2.062: States of Affairs (Sachverhalte)",
+      "startLine": 87,
+      "endLine": 103,
       "summary": "States of affairs (Sachverhalte) as an abstract type of possible combinations."
     },
     {
       "id": "worlds",
-      "title": "Worlds (TLP 1, 1.1, 2.04)",
-      "startLine": 54,
-      "endLine": 68,
+      "title": "TLP 2.1-2.174: Worlds as Predicates",
+      "startLine": 104,
+      "endLine": 119,
       "summary": "Worlds as predicates determining which states of affairs obtain."
     },
     {
       "id": "propositions",
-      "title": "Propositions (TLP 4.21, 5)",
-      "startLine": 70,
-      "endLine": 85,
+      "title": "TLP 4.2-4.463: Propositions and Logical Space",
+      "startLine": 120,
+      "endLine": 136,
       "summary": "Inductive type for propositions: elementary, negation, conjunction."
     },
     {
       "id": "derived-connectives",
-      "title": "Derived Connectives (TLP 5.101)",
-      "startLine": 87,
-      "endLine": 113,
+      "title": "TLP 5: Truth-Functionality (Formalized)",
+      "startLine": 137,
+      "endLine": 164,
       "summary": "Disjunction, implication, biconditional, and NAND defined from negation and conjunction."
     },
     {
       "id": "evaluation",
-      "title": "Semantic Evaluation (TLP 2.21, 4.06)",
-      "startLine": 115,
-      "endLine": 134,
-      "summary": "Recursive truth-value evaluation of propositions relative to worlds."
+      "title": "TLP 5.1-5.14: Semantic Evaluation",
+      "startLine": 165,
+      "endLine": 202,
+      "summary": "Recursive truth-value evaluation of propositions relative to worlds, including Bool-valued evaluator and correctness bridge."
     },
     {
       "id": "tautology-contradiction",
-      "title": "Tautology and Contradiction (TLP 4.46, 6.1)",
-      "startLine": 136,
-      "endLine": 152,
+      "title": "TLP 5.502: Tautology and Contradiction",
+      "startLine": 203,
+      "endLine": 220,
       "summary": "Definitions of tautology (true in all worlds) and contradiction (false in all worlds)."
     },
     {
       "id": "theorems",
-      "title": "Theorems",
-      "startLine": 154,
-      "endLine": 364,
+      "title": "TLP 6.1: Core Theorems",
+      "startLine": 221,
+      "endLine": 432,
       "summary": "Fifteen theorems establishing compositionality, independence, bivalence, connective semantics, and functional completeness."
     },
     {
+      "id": "concrete-examples",
+      "title": "Concrete Examples (TwoFacts Instantiation)",
+      "startLine": 433,
+      "endLine": 482,
+      "summary": "Instantiates the abstract Sachverhalt type with a two-element concrete type (rain and snow), demonstrating both Prop-valued and Bool-valued evaluation with #eval."
+    },
+    {
       "id": "limits",
-      "title": "The Limits of Formalization (TLP 6.54, 7)",
-      "startLine": 366,
-      "endLine": 389,
-      "summary": "Closing philosophical reflection on what escapes formalization — the ladder and the silence."
+      "title": "TLP 6.54-7: Limits of Formalization",
+      "startLine": 483,
+      "endLine": 575,
+      "summary": "Closing philosophical reflection on what escapes formalization — the ladder, the silence, and the formal content of TLP 7."
     }
   ],
   "conclusion": {
@@ -182,7 +189,7 @@
     "imports": ["Mathlib.Tactic"],
     "opens": [],
     "namespace": "Tractatus",
-    "lineCount": 528,
+    "lineCount": 575,
     "axiomCount": 1,
     "theoremCount": 21,
     "definitionCount": 8,


### PR DESCRIPTION
## Summary

- Rename all 10 SECTION banners in `TractatusOntology.lean` and all 5 in `TractatusQuantifiers.lean` to use Tractatus proposition numbers (e.g. "TLP 1-2.06: Objects and States of Affairs")
- Add Design Decisions comment block after the module docstring, documenting six load-bearing modeling choices
- Add "What This Is Not" annotation to `annotations.json` as the first entry
- Remove duplicate unlabeled SECTION banner (formerly at line 484)
- Add missing `concrete-examples` section entry in `meta.json` and update all section titles and line numbers

Closes #10815

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| 10 SECTION banners renamed in TractatusOntology.lean | Done | grep shows 10 numbered banners with TLP numbers |
| 5 SECTION banners renamed in TractatusQuantifiers.lean | Done | grep shows 5 renamed banners |
| Design Decisions block added after docstring | Done | Lines 19-67, 6 numbered decisions |
| "What This Is Not" annotation added | Done | First entry in annotations.json, id: ann-tractatus-what-this-is-not |
| Duplicate SECTION banner removed | Done | Only one SECTION 10 banner, no unnumbered duplicates |
| concrete-examples section added to meta.json | Done | New entry with id "concrete-examples" |
| All meta.json section titles updated | Done | All 9 existing titles + 1 new match Lean file banners |
| Line numbers updated in meta.json | Done | All startLine/endLine adjusted for +45 line shift |
| JSON files valid | Done | jq validation passes for both files |
| pnpm build succeeds | Done | Gallery builds without errors |
| No Lean code logic changed | Done | Only comments, banners, and JSON metadata |

## Test plan

- [x] `jq . annotations.json` validates successfully
- [x] `jq . meta.json` validates successfully
- [x] `pnpm build` succeeds (gallery renders without errors)
- [x] `grep -n SECTION TractatusOntology.lean` shows exactly 10 numbered entries, no duplicates
- [x] `grep -n SECTION TractatusQuantifiers.lean` shows exactly 5 renamed entries
- [x] No Lean code logic changes (only comments and banner strings)

Generated with [Claude Code](https://claude.com/claude-code)