### PR TITLE
Enrich Simplicial Numbers/f-vectors: fix sorry claim, add annotation, deepen meta

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-03/annotations.json
@@ -63,6 +63,18 @@
     ]
   },
   {
+    "id": "ann-simplicial-reformulation",
+    "proofId": "arithmetic-series-oq-02-oq-03",
+    "range": { "startLine": 88, "endLine": 94 },
+    "type": "theorem",
+    "title": "Inverse Direction: Simplicial Numbers as Face Enumerators",
+    "content": "The dual reformulation `simplicial_eq_faceCount`: $S_m(n) = f_{m-1}(\\Delta^{n+m-1})$ for $m \\geq 1$. This re-reads the main identity from the simplicial-number side: every simplicial number $S_m(n) = \\binom{n+m}{m}$ counts the $(m-1)$-faces of a simplex of appropriate dimension. The proof is `congr 1 <;> omega`, reducing to the arithmetic identity $(n+m-1+1) = n+m$ and $(m-1+1) = m$, which `omega` handles.",
+    "mathContext": "$S_m(n) = \\binom{n+m}{m} = \\binom{(n+m-1)+1}{(m-1)+1} = f_{m-1}(\\Delta^{n+m-1})$. The index shift $m \\mapsto m-1$ is the boundary between the two conventions.",
+    "significance": "supporting",
+    "relatedConcepts": ["simplicial numbers", "faceCount", "index arithmetic", "omega tactic"],
+    "prerequisites": ["faceCount_eq_simplicial", "simplicial definition", "omega"]
+  },
+  {
     "id": "ann-total-faces",
     "proofId": "arithmetic-series-oq-02-oq-03",
     "range": { "startLine": 98, "endLine": 108 },
@@ -86,28 +98,28 @@
   {
     "id": "ann-euler-char",
     "proofId": "arithmetic-series-oq-02-oq-03",
-    "range": { "startLine": 113, "endLine": 117 },
+    "range": { "startLine": 113, "endLine": 129 },
     "type": "theorem",
-    "title": "Euler Characteristic of the Simplex",
-    "content": "States $\\chi(\\Delta^k) = \\sum_{j=0}^k (-1)^j f_j = 1$ -- the Euler characteristic of a simplex is 1, reflecting its contractibility. Currently `sorry`: the proof requires reindexing an alternating sum over integers and applying $\\sum_{i=0}^n (-1)^i \\binom{n}{i} = 0$ for $n \\geq 1$.",
-    "mathContext": "$\\chi(\\Delta^k) = \\sum_{j=0}^k (-1)^j \\binom{k+1}{j+1} = -\\sum_{i=1}^{k+1} (-1)^i \\binom{k+1}{i} = -(0 - 1) = 1$, using $\\sum_{i=0}^{k+1} (-1)^i \\binom{k+1}{i} = 0$.",
+    "title": "Euler Characteristic of the Simplex (Fully Proved)",
+    "content": "Proves $\\chi(\\Delta^k) = \\sum_{j=0}^k (-1)^j f_j = 1$ — the Euler characteristic of a simplex equals 1, reflecting its contractibility. The key is Mathlib's `Int.alternating_sum_range_choose_of_ne` which gives $\\sum_{i=0}^n (-1)^i \\binom{n}{i} = 0$ for $n \\geq 1$. The proof: apply this to $n = k+1$, split off the $i=0$ term (contributing $+1$), show the remaining shifted sum equals the negation of the target using `Finset.sum_neg_distrib` and `pow_succ` to rewrite $(-1)^{x+1} = -(-1)^x$.",
+    "mathContext": "$\\chi(\\Delta^k) = \\sum_{j=0}^k (-1)^j \\binom{k+1}{j+1} = -\\sum_{i=1}^{k+1} (-1)^i \\binom{k+1}{i} = -(0 - 1) = 1$, using $\\sum_{i=0}^{k+1} (-1)^i \\binom{k+1}{i} = 0$ (alternating binomial sum identity).",
     "significance": "key",
     "prerequisites": [
-      "alternating binomial sum",
-      "Euler-Poincaré formula",
-      "integer arithmetic in Lean 4"
+      "Int.alternating_sum_range_choose_of_ne",
+      "Finset.sum_range_succ'",
+      "Finset.sum_neg_distrib"
     ],
     "relatedConcepts": [
       "Euler characteristic",
-      "alternating sum",
+      "alternating binomial sum",
       "contractibility",
-      "Euler-Poincaré formula"
+      "Int.alternating_sum_range_choose_of_ne"
     ]
   },
   {
     "id": "ann-concrete-examples",
     "proofId": "arithmetic-series-oq-02-oq-03",
-    "range": { "startLine": 121, "endLine": 137 },
+    "range": { "startLine": 132, "endLine": 148 },
     "type": "technique",
     "title": "Concrete Face Counts: Point to Tetrahedron",
     "content": "Verifies face counts for the first four simplices: $\\Delta^0$ (1 vertex), $\\Delta^1$ (2 vertices, 1 edge), $\\Delta^2$ (3 vertices, 3 edges, 1 triangle), $\\Delta^3$ (4 vertices, 6 edges, 4 triangles, 1 tetrahedron). Uses `simp` for simple cases and `native_decide` for computed values like $\\binom{4}{2} = 6$.",
@@ -127,7 +139,7 @@
   {
     "id": "ann-figurate-connections",
     "proofId": "arithmetic-series-oq-02-oq-03",
-    "range": { "startLine": 139, "endLine": 151 },
+    "range": { "startLine": 150, "endLine": 162 },
     "type": "insight",
     "title": "Figurate Numbers as Face Enumerators",
     "content": "Two elegant connections: (1) Triangular numbers count edges: $S_2(n) = \\binom{n+2}{2} = f_1(\\Delta^{n+1})$. The $n$-th triangular number is the number of edges of the $(n+1)$-simplex. (2) Tetrahedral numbers count triangular faces: $S_3(n) = \\binom{n+3}{3} = f_2(\\Delta^{n+2})$. Both proved by `simp [simplicial, faceCount]; ring_nf`.",

--- a/src/data/proofs/arithmetic-series-oq-02-oq-03/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-03/meta.json
@@ -22,14 +22,15 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "The connection between simplicial numbers and face counts of simplices is classical. The f-vector (f₀, f₁, ..., f_k) of a simplicial complex records the number of faces in each dimension. For the standard k-simplex Δ^k (the convex hull of k+1 vertices), each j-face is a (j+1)-element subset of the vertex set, giving f_j = C(k+1, j+1). The simplicial numbers S_m(n) = C(n+m, m), introduced as higher-dimensional analogues of triangular numbers, are precisely these face counts under appropriate reindexing.",
+    "historicalContext": "The connection between simplicial numbers and face counts of simplices is classical. The f-vector (f₀, f₁, ..., f_k) of a simplicial complex records the number of faces in each dimension. For the standard k-simplex Δ^k (the convex hull of k+1 vertices), each j-face is a (j+1)-element subset of the vertex set, giving f_j = C(k+1, j+1). The simplicial numbers S_m(n) = C(n+m, m), introduced as higher-dimensional analogues of triangular numbers, are precisely these face counts under appropriate reindexing. Euler's polyhedral formula V - E + F = 2 (1750) is the prototype: for a tetrahedron (Δ^3), f₀ - f₁ + f₂ = 4 - 6 + 4 = 2, but the boundary ∂Δ^3 is a sphere (χ = 2), while the solid Δ^3 has χ = 1. The full theory of f-vectors and h-vectors of simplicial polytopes was developed by Dehn (1905), Sommerville (1927), and McMullen's g-theorem (1970, proved 1980 by Billera-Lee and Stanley independently).",
     "problemStatement": "Can the simplicial numbers be connected to the face numbers of simplicial complexes (f-vectors) in algebraic topology?",
     "text": "Yes. The face count f_j(Δ^k) = C(k+1, j+1) equals the simplicial number S_{j+1}(k-j). The total face count is 2^(k+1) - 1, and the Euler characteristic is 1.",
     "proofStrategy": "Direct computation: faceCount k j = C(k+1, j+1) and simplicial (j+1) (k-j) = C((k-j)+(j+1), j+1) = C(k+1, j+1). The total faces sum uses Nat.sum_range_choose (binomial theorem) with the i=0 term removed.",
     "keyInsights": [
       "The face count f_j(Δ^k) = C(k+1, j+1) equals simplicial (j+1) (k-j), connecting combinatorial geometry to number sequences",
       "Triangular numbers count edges of simplices: S_2(n) = f_1(Δ^{n+1}). Tetrahedral numbers count triangular faces: S_3(n) = f_2(Δ^{n+2})",
-      "The total face count 2^(k+1) - 1 follows from the binomial theorem ∑ C(n,i) = 2^n with the empty face removed"
+      "The total face count 2^(k+1) - 1 follows from the binomial theorem ∑ C(n,i) = 2^n with the empty face removed",
+      "The Euler characteristic χ(Δ^k) = 1 is proved purely algebraically from the alternating binomial sum identity ∑(-1)^i C(n,i) = 0, formalized in Lean via Int.alternating_sum_range_choose_of_ne — no homotopy or homology needed"
     ],
     "prerequisites": [
       "Binomial coefficients (Nat.choose)",
@@ -50,28 +51,32 @@
       "title": "Standard Simplex and f-Vector",
       "startLine": 30,
       "endLine": 60,
-      "summary": "Defines the f-vector (face count by dimension) and proves the standard simplex Δ^k has C(k+1,j+1) faces of dimension j."
+      "summary": "Defines the f-vector (face count by dimension) and proves the standard simplex Δ^k has C(k+1,j+1) faces of dimension j.",
+      "mathContext": "$f_j(\\Delta^k) = \\binom{k+1}{j+1}$: choosing $j+1$ vertices from $k+1$ determines each $j$-dimensional face. Special cases: $f_0 = k+1$ vertices, $f_k = 1$ (the whole simplex), $f_1 = \\frac{k(k+1)}{2}$ edges."
     },
     {
       "id": "simplicial-connection",
       "title": "Simplicial Numbers as Face Counts",
       "startLine": 62,
-      "endLine": 100,
-      "summary": "Establishes C(k+1,j+1) = S_{j+1}(k-j), connecting simplicial number sequences to the f-vector of the standard simplex."
+      "endLine": 95,
+      "summary": "Establishes C(k+1,j+1) = S_{j+1}(k-j), connecting simplicial number sequences to the f-vector of the standard simplex.",
+      "mathContext": "$S_{j+1}(k-j) = \\binom{(k-j)+(j+1)}{j+1} = \\binom{k+1}{j+1} = f_j(\\Delta^k)$. The arithmetic identity $(k-j)+(j+1) = k+1$ reduces this to a pure `omega` computation."
     },
     {
       "id": "euler-relation",
       "title": "Euler Characteristic and f-Vector Sum",
-      "startLine": 102,
+      "startLine": 97,
       "endLine": 130,
-      "summary": "Proves the Euler characteristic of Δ^k equals 1, and the alternating f-vector sum gives χ = 1."
+      "summary": "Proves the total face count is 2^(k+1)-1 and the Euler characteristic of Δ^k equals 1.",
+      "mathContext": "Total faces: $\\sum_{j=0}^k \\binom{k+1}{j+1} = 2^{k+1} - 1$ (binomial theorem minus empty set). Euler characteristic: $\\sum_{j=0}^k (-1)^j \\binom{k+1}{j+1} = 1$ (alternating sum identity applied to $n=k+1$)."
     },
     {
       "id": "verifications",
-      "title": "Concrete Verifications",
+      "title": "Concrete Verifications and Figurate Connections",
       "startLine": 132,
       "endLine": 163,
-      "summary": "Verifies f-vectors for specific simplices (triangle: {3,3,1}, tetrahedron: {4,6,4,1}) via native_decide."
+      "summary": "Verifies f-vectors for Δ^0 through Δ^3 via native_decide; proves triangular and tetrahedral numbers count edges and triangular faces respectively.",
+      "mathContext": "f-vectors form rows of Pascal's triangle: $\\Delta^3: (4,6,4,1)$. Figurate number identities: $S_2(n) = f_1(\\Delta^{n+1})$ (triangular), $S_3(n) = f_2(\\Delta^{n+2})$ (tetrahedral). Proved by `simp [simplicial, faceCount]; ring_nf`."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for arithmetic-series-oq-02-oq-03 (fully verified, 0 axioms).

## Quality improvements

**Annotation fixes** (correcting incorrect content + range errors):
- `ann-euler-char`: content incorrectly claimed theorem was 'sorry' — it's fully proved via `Int.alternating_sum_range_choose_of_ne`. Extended range to cover the full proof (113-129)
- `ann-concrete-examples`: corrected range 121-137 → 132-148 (was overlapping euler_characteristic theorem)
- `ann-figurate-connections`: corrected range 139-151 → 150-162 (theorems are at 150-162)

**New annotation:**
- `ann-simplicial-reformulation` (lines 88-94): covers `simplicial_eq_faceCount` — the dual direction theorem showing every simplicial number (n)$ counts 569Xlfaces of $\Delta^{n+m-1}$

**Meta.json improvements:**
- Added 4th `keyInsight`: Euler characteristic algebraic proof via alternating binomial sum
- Deepened `historicalContext`: added Euler's polyhedral formula (1750), Dehn-Sommerville relations, McMullen's g-theorem (1970/1980)
- Added `mathContext` to all 4 section entries