### PR TITLE
research: Erdos117OQ01, PtolemysTheoremOQ01Incomplete01, Erdos1018OQ04Incomplete01 sorries

### DIFF
--- a/proofs/Proofs/Erdos1018OQ04Incomplete01.lean
+++ b/proofs/Proofs/Erdos1018OQ04Incomplete01.lean
@@ -82,25 +82,41 @@ theorem embeddable_mono {r : ℕ} {H : Erdos1018OQ04.Hypergraph V r}
     have := congr_fun h ⟨i.val, Nat.lt_of_lt_of_le i.isLt hdd⟩
     simp [Fin.val_mk, Nat.lt_of_lt_of_le i.isLt hdd] at this
     exact this
-  · -- Separation condition preserved using the linear zero-padding map ι : ℝ^d →ₗ[ℝ] ℝ^{d'}
+  · -- Separation condition preserved: the extended map is ι ∘ φ where
+    -- ι : (Fin d → ℝ) → (Fin d' → ℝ) is the zero-padding linear injection.
+    -- Linear maps preserve convex hulls (LinearMap.image_convexHull) and
+    -- injective functions reflect intersections (Set.image_inter).
     intro e₁ he₁ e₂ he₂ hne
-    -- Define the linear zero-padding map
-    let ι : (Fin d → ℝ) →ₗ[ℝ] (Fin d' → ℝ) :=
-      { toFun := fun x i => if h : i.val < d then x ⟨i.val, h⟩ else 0
-        map_add' := fun x y => by ext i; simp [Pi.add_apply]; split_ifs <;> ring
-        map_smul' := fun r x => by ext i; simp [Pi.smul_apply]; split_ifs <;> ring }
-    have hι_inj : Function.Injective ι := fun x y h => by
+    -- The zero-padding function (as a plain function, proved to be linear below)
+    let ι : (Fin d → ℝ) → (Fin d' → ℝ) := fun x i => if h : i.val < d then x ⟨i.val, h⟩ else 0
+    -- ι is a linear map
+    have hι_lin : IsLinearMap ℝ ι := ⟨
+      fun a b => funext fun i => by simp only [ι, Pi.add_apply]; split_ifs <;> simp,
+      fun r a => funext fun i => by simp only [ι, Pi.smul_apply]; split_ifs <;> simp [smul_zero]
+    ⟩
+    -- ι is injective (the d' coordinates include the original d coordinates)
+    have hι_inj : Function.Injective ι := by
+      intro a b h
       ext ⟨i, hi⟩
       have := congr_fun h ⟨i, Nat.lt_of_lt_of_le hi hdd⟩
-      simp only [ι, Nat.lt_of_lt_of_le hi hdd, dite_true] at this
+      simp only [ι, dif_pos hi] at this
       exact this
-    -- The padded map is definitionally ι ∘ φ
-    have hpad : (fun v i => if h : i.val < d then φ v ⟨i.val, h⟩ else 0) = ι ∘ φ := rfl
-    -- Rewrite convex hulls: convexHull(ι∘φ '' e) = ι '' convexHull(φ '' e)
-    simp_rw [hpad, Set.image_comp, ← LinearMap.image_convexHull]
-    -- Now: ι''A ∩ ι''B = ι''(A∩B) ⊆ ι''C where A∩B ⊆ C [by hsep]
+    -- The image of the extended function equals ι applied to the original image
+    have himage : ∀ e : Finset V,
+        Set.image (fun v i => if h : i.val < d then φ v ⟨i.val, h⟩ else 0) (↑e : Set V) =
+        ι '' (φ '' ↑e) := fun e => by
+      ext y
+      constructor
+      · rintro ⟨v, hv, rfl⟩
+        exact ⟨φ v, ⟨v, hv, rfl⟩, rfl⟩
+      · rintro ⟨_, ⟨v, hv, rfl⟩, rfl⟩
+        exact ⟨v, hv, rfl⟩
+    rw [himage e₁, himage e₂, himage (e₁ ∩ e₂)]
+    -- Rewrite convex hulls: convexHull(ι '' S) = ι '' convexHull(S) for linear ι
+    rw [← hι_lin.image_convexHull, ← hι_lin.image_convexHull, ← hι_lin.image_convexHull]
+    -- Merge intersection: ι '' A ∩ ι '' B = ι '' (A ∩ B) for injective ι
     rw [← Set.image_inter hι_inj]
-    exact Set.image_subset _ (hsep e₁ he₁ e₂ he₂ hne)
+    exact Set.image_subset ι (hsep e₁ he₁ e₂ he₂ hne)
 
 /-! ## Part III: K₃ (Triangle) is Planar -/
 
@@ -197,7 +213,7 @@ theorem dense_graph_not_planar (ε : ℝ) (hε : ε > 0) :
   intro n hn
   have hn1 : n ≥ N := Nat.le_of_max_le_left hn
   have hn2 : n ≥ 1 := Nat.le_of_max_le_right hn
-  have hn_pos : (0 : ℝ) < n := by exact_mod_cast (show 0 < n from Nat.lt_of_lt_of_le Nat.zero_lt_one hn2)
+  have hn_pos : (0 : ℝ) < n := Nat.cast_pos.mpr (by omega)
   have hge : (n : ℝ) ^ ε ≥ 4 := hN n hn1
   calc (n : ℝ) ^ (1 + ε) = n * (n : ℝ) ^ ε := by
         rw [Real.rpow_add hn_pos, Real.rpow_one]

--- a/proofs/Proofs/Erdos117OQ01.lean
+++ b/proofs/Proofs/Erdos117OQ01.lean
@@ -214,15 +214,44 @@ def AsymptoticallyMultiplicative : Prop :=
 theorem submultiplicative_implies_convergence
     (hsub : ∀ m n : ℕ, h (m + n) ≤ h m * h n) :
     growthRateConverges := by
-  -- Fekete's subadditive lemma outline:
-  -- Step 1: a(n) = log(h n) is subadditive: a(m+n) ≤ a(m) + a(n)
-  --   because log(h(m+n)) ≤ log(h m * h n) = log(h m) + log(h n).
-  -- Step 2: a(n) ≥ 0 (since h n ≥ 1 → log h n ≥ 0, by h_pos).
-  -- Step 3: By Fekete's lemma, a(n)/n = growthRate n converges to inf{a(n)/n : n ≥ 1}.
-  -- The key lemma needed: ∀ subadditive a with a(n) ≥ 0, Tendsto (a(n)/n) atTop (nhds L)
-  --   where L = sInf {a(n)/n | n ≥ 1}. This is classical analysis.
-  -- [HARD sorry: Fekete's subadditive lemma — check if Mathlib4 has it]
-  sorry
+  -- Use Mathlib4's Subadditive.tendsto_lim (Fekete's lemma) via Mathlib.Analysis.Subadditive
+  let f : ℕ → ℝ := fun n => Real.log (h n : ℝ)
+  -- Step 0: All h n > 0 (including h 0, derived from submultiplicativity + h_pos)
+  have h_all_pos : ∀ n : ℕ, (0 : ℝ) < h n := by
+    intro n
+    rcases Nat.eq_zero_or_pos n with rfl | hn
+    · -- h 0 > 0: if h 0 = 0 then h(0+1) ≤ 0·h 1 = 0, contradicting h 1 ≥ 1
+      have hineq := hsub 0 1
+      simp only [zero_add] at hineq
+      by_contra hc
+      push_neg at hc
+      have h0_eq : h 0 = 0 := Nat.le_zero.mp (by exact_mod_cast hc)
+      rw [h0_eq, zero_mul] at hineq
+      linarith [h_pos 1 le_rfl]
+    · exact_mod_cast Nat.lt_of_lt_of_le Nat.zero_lt_one (h_pos n hn)
+  -- Step 1: f = log h is subadditive (Fekete condition)
+  have hf_sub : Subadditive f := fun m n => by
+    show Real.log (h (m + n) : ℝ) ≤ Real.log (h m : ℝ) + Real.log (h n : ℝ)
+    rw [← Real.log_mul (ne_of_gt (h_all_pos m)) (ne_of_gt (h_all_pos n))]
+    exact Real.log_le_log (h_all_pos (m + n)) (by exact_mod_cast hsub m n)
+  -- Step 2: f n / n is bounded below by 0 (h n ≥ 1 → log(h n) ≥ 0)
+  have hbdd : BddBelow (Set.range fun n : ℕ => f n / n) := by
+    refine ⟨0, ?_⟩
+    rintro x ⟨n, rfl⟩
+    rcases Nat.eq_zero_or_pos n with rfl | hpos
+    · simp  -- f 0 / 0 = log(h 0) / 0 = 0 in Lean (div by zero = 0)
+    · have hn_pos : (0 : ℝ) < n := Nat.cast_pos.mpr hpos
+      have hhn : (1 : ℝ) ≤ h n := by exact_mod_cast h_pos n hpos
+      exact div_nonneg (Real.log_nonneg hhn) hn_pos.le
+  -- Step 3: Apply Fekete's lemma (Mathlib: Subadditive.tendsto_lim)
+  -- Conclusion: growthRate n = f n / n for n ≥ 1, so both converge to same limit
+  refine ⟨hf_sub.lim, ?_⟩
+  apply (hf_sub.tendsto_lim hbdd).congr'
+  apply Filter.eventually_atTop.mpr
+  exact ⟨1, fun n hn => by
+    -- f n / n = Real.log (h n) / n = growthRate n (for n ≥ 1, n ≠ 0)
+    unfold growthRate
+    rw [if_neg (show n ≠ 0 from by omega)]⟩
 
 /-- The trivial case: h(1) = 1, so the growth rate starts at 0 -/
 theorem growthRate_1 (h1 : h 1 = 1) : growthRate 1 = 0 := by

--- a/proofs/Proofs/PtolemysTheoremOQ01Incomplete01.lean
+++ b/proofs/Proofs/PtolemysTheoremOQ01Incomplete01.lean
@@ -199,25 +199,35 @@ private lemma t_eq_sine_ratio {θ₁ θ₂ θ₃ θ₄ : ℝ} {t : ℝ}
   -- After factoring out -4 and E, the complex equation reduces to a real equation
   have hcx : (↑(Real.sin ((θ₂ - θ₃) / 2)) : ℂ) * ↑(Real.sin ((θ₁ - θ₄) / 2)) =
              ↑t * (↑(Real.sin ((θ₁ - θ₂) / 2)) * ↑(Real.sin ((θ₃ - θ₄) / 2))) := by
-    -- After rw[hha...], ht_eq says (2I·s₂₃·E₂₃)·(2I·s₁₄·E₁₄) = t·(2I·s₁₂·E₁₂)·(2I·s₃₄·E₃₄).
-    -- Cancel the common factor (2I)²·(E₁₂·E₃₄) using hE (E₂₃E₁₄ = E₁₂E₃₄).
-    have hI2_ne : (2 * Complex.I) ^ 2 ≠ 0 := by
-      rw [show (2 * Complex.I) ^ 2 = 2 ^ 2 * Complex.I ^ 2 from by ring, Complex.I_sq]
-      norm_num
-    have h_ne : (2 * Complex.I) ^ 2 * (Complex.exp (↑((θ₁ + θ₂) / 2) * Complex.I) *
-        Complex.exp (↑((θ₃ + θ₄) / 2) * Complex.I)) ≠ 0 :=
-      mul_ne_zero hI2_ne hE_ne
-    apply mul_left_cancel₀ h_ne
-    -- (2I)²·E₁₂E₃₄·s₂₃s₁₄ = (2I·s₂₃·E₂₃)·(2I·s₁₄·E₁₄) via ← hE + ring
-    have key : (2 * Complex.I) ^ 2 * (Complex.exp (↑((θ₁ + θ₂) / 2) * Complex.I) *
-        Complex.exp (↑((θ₃ + θ₄) / 2) * Complex.I)) *
-        (↑(Real.sin ((θ₂ - θ₃) / 2)) * ↑(Real.sin ((θ₁ - θ₄) / 2))) =
-        (2 * Complex.I * ↑(Real.sin ((θ₂ - θ₃) / 2)) *
-         Complex.exp (↑((θ₂ + θ₃) / 2) * Complex.I)) *
-        (2 * Complex.I * ↑(Real.sin ((θ₁ - θ₄) / 2)) *
-         Complex.exp (↑((θ₁ + θ₄) / 2) * Complex.I)) := by
-      rw [← hE]; ring
-    rw [key, ht_eq]; ring
+    -- Strategy: factor (2I)² · E₂₃E₁₄ from both sides.
+    -- LHS side: ↑s₂₃ · ↑s₁₄ · (2I)² · E₂₃E₁₄ = (2I·↑s₂₃·E₂₃) · (2I·↑s₁₄·E₁₄) [ring]
+    --   = ht_eq LHS (after hha substitution already done at line 189)
+    --   = ht_eq RHS = t · (2I·↑s₁₂·E₁₂) · (2I·↑s₃₄·E₃₄)
+    --   = ↑t · ↑s₁₂ · ↑s₃₄ · (2I)² · E₁₂E₃₄ [ring]
+    --   = ↑t · ↑s₁₂ · ↑s₃₄ · (2I)² · E₂₃E₁₄ [hE: E₂₃E₁₄ = E₁₂E₃₄, so ← hE]
+    -- Then cancel (2I)² · E₂₃E₁₄ ≠ 0.
+    have hI2_ne : (2 : ℂ) * Complex.I ≠ 0 := mul_ne_zero (by norm_num) Complex.I_ne_zero
+    have hfactor_ne : (2 * Complex.I) ^ 2 * (Complex.exp (↑((θ₂ + θ₃) / 2) * Complex.I) *
+        Complex.exp (↑((θ₁ + θ₄) / 2) * Complex.I)) ≠ 0 :=
+      mul_ne_zero (pow_ne_zero _ hI2_ne) (mul_ne_zero (Complex.exp_ne_zero _) (Complex.exp_ne_zero _))
+    exact mul_right_cancel₀ hfactor_ne (by
+      calc (↑(Real.sin ((θ₂ - θ₃) / 2)) : ℂ) * ↑(Real.sin ((θ₁ - θ₄) / 2)) *
+            ((2 * Complex.I) ^ 2 * (Complex.exp (↑((θ₂ + θ₃) / 2) * Complex.I) *
+              Complex.exp (↑((θ₁ + θ₄) / 2) * Complex.I)))
+           = (2 * Complex.I * ↑(Real.sin ((θ₂ - θ₃) / 2)) *
+                Complex.exp (↑((θ₂ + θ₃) / 2) * Complex.I)) *
+             (2 * Complex.I * ↑(Real.sin ((θ₁ - θ₄) / 2)) *
+                Complex.exp (↑((θ₁ + θ₄) / 2) * Complex.I)) := by ring
+         _ = ↑t * ((2 * Complex.I * ↑(Real.sin ((θ₁ - θ₂) / 2)) *
+                       Complex.exp (↑((θ₁ + θ₂) / 2) * Complex.I)) *
+                   (2 * Complex.I * ↑(Real.sin ((θ₃ - θ₄) / 2)) *
+                       Complex.exp (↑((θ₃ + θ₄) / 2) * Complex.I))) := ht_eq
+         _ = ↑t * (↑(Real.sin ((θ₁ - θ₂) / 2)) * ↑(Real.sin ((θ₃ - θ₄) / 2))) *
+             ((2 * Complex.I) ^ 2 * (Complex.exp (↑((θ₁ + θ₂) / 2) * Complex.I) *
+               Complex.exp (↑((θ₃ + θ₄) / 2) * Complex.I))) := by ring
+         _ = ↑t * (↑(Real.sin ((θ₁ - θ₂) / 2)) * ↑(Real.sin ((θ₃ - θ₄) / 2))) *
+             ((2 * Complex.I) ^ 2 * (Complex.exp (↑((θ₂ + θ₃) / 2) * Complex.I) *
+               Complex.exp (↑((θ₁ + θ₄) / 2) * Complex.I))) := by rw [← hE])
   have hR : Real.sin ((θ₂ - θ₃) / 2) * Real.sin ((θ₁ - θ₄) / 2) =
             t * (Real.sin ((θ₁ - θ₂) / 2) * Real.sin ((θ₃ - θ₄) / 2)) :=
     by exact_mod_cast hcx


### PR DESCRIPTION
## Summary

- **Erdos117OQ01**: Proved `limInf_ge_log_c1` (liminf ≥ log c₁ using Filter.liminf_le_liminf) and `submultiplicative_implies_convergence` (Fekete's lemma via Mathlib4 `Subadditive.tendsto_lim`); `limInf_le_limSup` and `growthRate_lower_bound`/`upper_bound` also proved; `base_implies_behavior` left as sorry (statement potentially false for large ε)
- **PtolemysTheoremOQ01Incomplete01**: Filled `hcx` sorry (ring identity after half-angle substitution) via `mul_right_cancel₀` with 4-step calc proof; 0 sorries remain
- **Erdos1018OQ04Incomplete01**: Proved `embeddable_mono` and fixed `dense_graph_not_planar`
- **Erdos1050Problem**: Proved `T_summable` and `S_first_terms`; 0 sorries remain

## Test plan
- [ ] Docker build passes for `Proofs.Erdos117OQ01` (1 sorry remains: `base_implies_behavior`)
- [ ] Docker build passes for `Proofs.PtolemysTheoremOQ01Incomplete01` (0 sorries)
- [ ] Docker build passes for `Proofs.Erdos1018OQ04Incomplete01`
- [ ] Docker build passes for `Proofs.Erdos1050Problem`

🤖 Generated with [Claude Code](https://claude.com/claude-code)