### PR TITLE
Enrich 4 gallery entries: Menelaus, Squareful, Combinatorial Nullstellensatz

### DIFF
--- a/src/data/proofs/factor-remainder-nullstellensatz-oq-02/annotations.json
+++ b/src/data/proofs/factor-remainder-nullstellensatz-oq-02/annotations.json
@@ -62,7 +62,7 @@
   {
     "id": "ann-cnull-uniform",
     "proofId": "factor-remainder-nullstellensatz-oq-02",
-    "range": { "startLine": 162, "endLine": 178 },
+    "range": { "startLine": 169, "endLine": 178 },
     "type": "technique",
     "title": "Uniform Grid Specialization (Proved from Axiom)",
     "content": "Specializes the Nullstellensatz to the case where all sets $S_i$ are the same set $S \\subseteq F$: if $f \\in F[x_1, \\ldots, x_n]$ has total degree $\\sum t_i$ with nonzero leading monomial coefficient and $|S| > t_i$ for all $i$, then $f$ does not vanish on $S^n$. Proved by setting all $S_i = S$ in the main axiom.",

--- a/src/data/proofs/factor-remainder-nullstellensatz-oq-02/meta.json
+++ b/src/data/proofs/factor-remainder-nullstellensatz-oq-02/meta.json
@@ -87,16 +87,16 @@
     {
       "id": "single-variable",
       "title": "Single-Variable Non-Vanishing (Proved)",
-      "startLine": 1,
-      "endLine": 72,
+      "startLine": 47,
+      "endLine": 78,
       "summary": "Proves the base case: a nonzero polynomial of degree $d$ over a field cannot vanish on more than $d$ points. Uses `Polynomial.card_roots_le_degree` from Mathlib.",
       "mathContext": "If $f \\in F[x]$ is nonzero and $|S| > \\deg(f)$, then $\\exists\\, s \\in S$ with $f(s) \\neq 0$."
     },
     {
       "id": "grid-nonvanishing",
       "title": "Grid Non-Vanishing (Axiomatized)",
-      "startLine": 73,
-      "endLine": 100,
+      "startLine": 80,
+      "endLine": 109,
       "summary": "States the grid non-vanishing lemma: a nonzero multivariate polynomial with $\\deg_{x_i}(f) < |S_i|$ for each $i$ cannot vanish on $S_1 \\times \\cdots \\times S_n$.",
       "mathContext": "Provable by induction on the number of variables, using the single-variable case at each step."
     },
@@ -163,14 +163,18 @@
   },
   "references": [
     {
-      "key": "Al99",
-      "citation": "Alon, N. (1999). Combinatorial Nullstellensatz. Combin. Probab. Comput. 8(1-2), 7-29.",
-      "type": "paper"
+      "authors": "Alon, Noga",
+      "title": "Combinatorial Nullstellensatz",
+      "year": "1999",
+      "venue": "Combinatorics, Probability and Computing, 8(1-2), 7-29",
+      "note": "The original paper introducing the Combinatorial Nullstellensatz and demonstrating applications to Cauchy-Davenport, graph colorings, permanent bounds, and additive combinatorics."
     },
     {
-      "key": "AT92",
-      "citation": "Alon, N. & Tarsi, M. (1992). Colorings and orientations of graphs. Combinatorica 12, 125-134.",
-      "type": "paper"
+      "authors": "Alon, Noga; Tarsi, Michael",
+      "title": "Colorings and orientations of graphs",
+      "year": "1992",
+      "venue": "Combinatorica, 12, 125-134",
+      "note": "Introduced the Alon-Tarsi polynomial technique for list colorings; precursor to the Combinatorial Nullstellensatz framework."
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
Enrichment passes for multiple entries in a single branch:

## cevas-theorem-non-euclidean-oq-02 (Hyperbolic Menelaus)
- Added ann-euclidean-menelaus annotation (lines 157-166)
- Added mathContext to all 5 sections; fixed section boundary errors
- Added references: Papadopoulos, Ungar 2000, Ceva 1678

## erdos-1107-oq-02 (Effective Squareful Sum Threshold)
- Fixed crossReferences schema: proofId → targetId
- Added references: Heath-Brown 1988 paper
- Split main-result section + added basic-properties section

## factor-remainder-nullstellensatz-oq-02 (Combinatorial Nullstellensatz)
- Normalized references format: key/citation → authors/title/year/venue/note
- Fixed section startLines: single-variable 1→47, grid-nonvanishing 73→80
- Fixed annotation range: ann-cnull-uniform 162→169

## basel-problem-oq-01-oq-01-oq-02 (Apéry ζ(3)) — in earlier commit on this branch
- Added 5 new annotations covering previously unannotated sections
- Fixed mainTheorems description (apery_theorem is proved, not sorry)
- Updated openQuestions to reflect actual 4 remaining axiom proofs