### PR TITLE
Fix: amgm-inequality-oq-02-oq-03 axiomCount 2→1

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03/meta.json
@@ -25,9 +25,9 @@
       "Eliminates maclaurin_step axiom from AmgmInequalityOQ02.lean"
     ],
     "dateAdded": "2026-03-30",
-    "axiomCount": 2,
+    "axiomCount": 1,
     "lineCount": 226,
-    "assumptions": "2 axioms inherited from AmgmInequalityOQ02.lean: newton_log_concavity (Newton's inequalities for log-concavity), maclaurin_step (Maclaurin's inequality step). 0 own axioms. 0 sorries.",
+    "assumptions": "1 axiom: newton_log_concavity (Newton's log-concavity of elementary symmetric polynomials, inherited from AmgmInequalityOQ02.lean). The maclaurin_step axiom is eliminated by this file — proved here as maclaurin_step_proved. 0 sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Fix

Corrected `axiomCount` from 2 to 1 for `amgm-inequality-oq-02-oq-03`.

## Evidence

**Before**: `axiomCount: 2`, assumptions claimed both `newton_log_concavity` and `maclaurin_step` were inherited.

**After**: `axiomCount: 1`, assumptions correctly state only `newton_log_concavity` remains.

**Rationale**: `AmgmInequalityOQ02OQ03.lean` is specifically designed to *eliminate* the `maclaurin_step` axiom by proving it from `newton_log_concavity`. The file declares 0 axioms itself and never calls `maclaurin_step` anywhere in its proof code (the only reference is a docstring comment). The main theorem `maclaurin_step_proved` depends solely on `newton_log_concavity` (1 axiom).

The internal metadata (sections summary line 86, keyInsights, conclusion) already correctly described `newton_log_concavity` as the *only remaining* dependency — the `axiomCount` and `assumptions` fields were the only inconsistencies.

---
Automated fix by lean-mechanic agent.