### PR TITLE
Fix: audit sorry count — riesz-lp OQ01 OQ01 OQ02 OQ01 claims 2 sorries, actually 3

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -14,10 +14,10 @@
       "measure-theory"
     ],
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 3,
     "axiomCount": 0,
     "lineCount": 829,
-    "assumptions": "2 remaining sorries: (1) σ-additive signed measure construction ν(E)=φ(1_E) — needs DCT in Lp + CLM continuity; (2) Hölder extremizer — hn=sign(gn)|gn|^{q-1} ∈ Lp, ‖gn‖_q≤‖φ‖ via sign property. Proved: integrationCLM, integrationCLM_apply, lintegral_mul_le_of_memLp, integrable_mul_of_memLp, truncated_rn_deriv_memLq, rn_deriv_memLq (MCT), integral_representation (all 3 Lp.induction cases), holder_test_sign_property, memLq_of_uniform_truncation_bound (NEW: MCT lemma for clean architecture).",
+    "assumptions": "3 remaining sorries: (1) truncated_rn_deriv_lq_bound — Hölder extremizer uniform bound for truncations (sub-goal 5b); (2) rn_deriv_memLq MCT step — lintegral_iSup monotone convergence + pointwise monotonicity; (3) riesz_lp_surjective_from_rn — signed measure construction + full assembly. Proved: integrationCLM, integrationCLM_apply, lintegral_mul_le_of_memLp, integrable_mul_of_memLp, truncated_rn_deriv_memLq (sub-goal 5a), integral_representation (all 3 Lp.induction cases), holder_test_sign_property, memLq_of_uniform_truncation_bound (MCT lemma for clean architecture).",
     "dateAdded": "2026-04-13"
   },
   "overview": {
@@ -118,8 +118,8 @@
       },
       {
         "name": "rn_deriv_memLq",
-        "type": "proved",
-        "description": "RN derivative is in Lq — proved via MCT (monotone convergence) on truncations (2026-04-14)"
+        "type": "core",
+        "description": "RN derivative is in Lq — MCT step (lintegral_iSup + pointwise monotonicity) still has sorry"
       },
       {
         "name": "integral_representation",
@@ -133,6 +133,6 @@
       }
     ],
     "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-    "sorries": 2
+    "sorries": 3
   }
 }


### PR DESCRIPTION
## Summary

- meta.json for `cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01` claimed 2 sorries but the Lean source file has 3
- The third sorry is in `rn_deriv_memLq` at line 263 (MCT step: lintegral_iSup + pointwise monotonicity), which was incorrectly listed as "Proved" in the assumptions text

## Changes

1. `meta.sorries`: 2 -> 3
2. `meta.assumptions`: Updated to list all 3 remaining sorries; removed `rn_deriv_memLq (MCT)` from the proved list
3. `leanFile.sorries`: 2 -> 3
4. `leanFile.mainTheorems`: changed `rn_deriv_memLq` type from `"proved"` to `"core"` since it still contains a sorry

## The 3 sorries

1. **Line 209** in `truncated_rn_deriv_lq_bound` -- Holder extremizer uniform bound for truncations (sub-goal 5b)
2. **Line 263** in `rn_deriv_memLq` -- MCT step: lintegral_iSup + pointwise monotonicity
3. **Line 488** in `riesz_lp_surjective_from_rn` -- signed measure construction + full assembly

## Test plan

- [x] JSON is valid (verified with python3 json.load)
- [x] sorry count in meta.json matches grep count in Lean source (3)
- [x] No other fields need updating (status, badge, axiomCount all correct)