### PR TITLE
Research: multinomial covariance Cov(Xi,Xj) = -n·pi·pj

### DIFF
--- a/proofs/Proofs/BinomialTheoremOQ02OQ01OQ03.lean
+++ b/proofs/Proofs/BinomialTheoremOQ02OQ01OQ03.lean
@@ -1,0 +1,222 @@
+import Mathlib.Data.Nat.Choose.Multinomial
+import Mathlib.Data.Nat.Choose.Sum
+import Mathlib.Algebra.BigOperators.Ring.Finset
+import Mathlib.Tactic
+import Proofs.BinomialTheoremOQ02OQ01OQ02
+import Proofs.BinomialTheoremOQ03
+
+/-
+# Multinomial Covariance: Cov(Xᵢ, Xⱼ) = -n·pᵢ·pⱼ
+
+*Open Question from BinomialTheoremOQ02OQ01*: Can we formalize the covariance
+structure of the multinomial distribution?
+
+## Answer
+
+YES. We prove Cov(Xᵢ, Xⱼ) = -n·pᵢ·pⱼ for distinct outcomes i ≠ j in a
+multinomial distribution with n trials and probabilities (p₁,...,pₖ) with ∑pᵢ = 1.
+
+## Mathematical Structure
+
+For (X₁,...,Xₖ) ~ Multinomial(n, p₁,...,pₖ):
+
+  Cov(Xᵢ, Xⱼ) = E[XᵢXⱼ] - E[Xᵢ]·E[Xⱼ]
+               = n(n-1)pᵢpⱼ − n²pᵢpⱼ
+               = -n·pᵢ·pⱼ
+
+## Why the Covariance is Negative
+
+The counts Xᵢ and Xⱼ are negatively correlated because the n outcomes are a fixed
+total: more of outcome i necessarily means less of outcome j.
+
+## Proof Strategy
+
+1. **E[Xᵢ] = n·pᵢ**: Proved via fiber grouping over values of k(i), using the
+   marginal PMF P(Xᵢ = j) = C(n,j)·pᵢʲ·(1-pᵢ)^(n-j) from BinomialTheoremOQ02OQ01OQ02
+   and the binomial mean E[Bin(n,p)] = np from BinomialTheoremOQ03.
+
+2. **E[XᵢXⱼ] = n(n-1)·pᵢ·pⱼ** (sorry): Apply multinomial MGF theorem with
+   g(l) = 1+a if l=i, 1+b if l=j, 1 otherwise. This gives:
+     ∑_k P(k)·(1+a)^{k(i)}·(1+b)^{k(j)} = (1 + pᵢa + pⱼb)^n
+   Differentiating w.r.t. a at 0 gives ∑_k P(k)·k(i)·(1+b)^{k(j)} = n·pᵢ·(1+pⱼb)^{n-1}.
+   Differentiating that w.r.t. b at 0 gives E[XᵢXⱼ] = n(n-1)pᵢpⱼ.
+
+3. **Main theorem**: Cov = n(n-1)pᵢpⱼ - n²pᵢpⱼ = -npᵢpⱼ. ∎
+-/
+
+namespace BinomialTheoremOQ02OQ01OQ03
+
+open Finset BigOperators
+
+/-- The multinomial probability mass function.
+    Identical to BinomialTheoremOQ02OQ01OQ02.multinomialProb. -/
+noncomputable def multinomialProb {α : Type*} [DecidableEq α]
+    (s : Finset α) (p : α → ℝ) (_ : ℕ) (k : α → ℕ) : ℝ :=
+  (Nat.multinomial s k : ℝ) * ∏ i ∈ s, p i ^ k i
+
+lemma multinomialProb_eq {α : Type*} [DecidableEq α]
+    (s : Finset α) (p : α → ℝ) (n : ℕ) (k : α → ℕ) :
+    multinomialProb s p n k =
+    BinomialTheoremOQ02OQ01OQ02.multinomialProb s p n k := rfl
+
+/-! ## Normalization -/
+
+theorem multinomialProb_sum_one {α : Type*} [DecidableEq α]
+    (s : Finset α) (p : α → ℝ) (n : ℕ) (hp : ∑ i ∈ s, p i = 1) :
+    ∑ k ∈ s.piAntidiag n, multinomialProb s p n k = 1 := by
+  simp_rw [multinomialProb_eq]
+  exact BinomialTheoremOQ02OQ01OQ02.multinomialProb_sum_one s p n hp
+
+/-! ## Mean E[Xᵢ] = n·pᵢ -/
+
+-- Binomial mean for all n including n=0
+private lemma binomial_mean_all (n : ℕ) (p : ℝ) :
+    ∑ k ∈ range (n + 1), (k : ℝ) * BinomialTheoremOQ03.binomPMF n p k = n * p := by
+  rcases Nat.eq_zero_or_pos n with rfl | hn
+  · simp [BinomialTheoremOQ03.binomPMF]
+  · exact BinomialTheoremOQ03.binomial_mean n hn p
+
+-- Helper: binomPMF unfolded into choose form
+private lemma binomPMF_eq (n : ℕ) (p : ℝ) (j : ℕ) :
+    BinomialTheoremOQ03.binomPMF n p j =
+    (Nat.choose n j : ℝ) * p ^ j * (1 - p) ^ (n - j) := by
+  unfold BinomialTheoremOQ03.binomPMF; ring
+
+/-- **Mean of multinomial component**: E[Xᵢ] = n·p(i).
+
+    Complete proof via fiber grouping:
+    1. Group ∑_k k(i₀)*P(k) by value j = k(i₀) using `sum_fiberwise_of_maps_to`
+    2. On each fiber {k | k(i₀) = j}: factor out j and apply marginal PMF formula
+    3. Recognize as ∑_j j * binomPMF n (p i₀) j = n * p i₀ by `binomial_mean`. -/
+theorem multinomial_mean {α : Type*} [DecidableEq α]
+    (s : Finset α) (p : α → ℝ) (n : ℕ)
+    (hp_sum : ∑ i ∈ s, p i = 1) (i₀ : α) (hi₀ : i₀ ∈ s) :
+    ∑ k ∈ s.piAntidiag n, (k i₀ : ℝ) * multinomialProb s p n k = n * p i₀ := by
+  -- k(i₀) ≤ n for k ∈ piAntidiag n
+  have hmaps_to : ∀ k ∈ s.piAntidiag n, k i₀ ∈ range (n + 1) := fun k hk => by
+    rw [mem_range]
+    have hle : k i₀ ≤ ∑ l ∈ s, k l :=
+      Finset.single_le_sum (fun l _ => Nat.zero_le _) s hi₀
+    omega
+  -- Fiber grouping
+  rw [← sum_fiberwise_of_maps_to hmaps_to]
+  -- Prove each fiber sum = j * binomPMF n (p i₀) j
+  have hfibers : ∀ j ∈ range (n + 1),
+      ∑ k ∈ (s.piAntidiag n).filter (fun k => k i₀ = j),
+        (k i₀ : ℝ) * multinomialProb s p n k =
+      (j : ℝ) * BinomialTheoremOQ03.binomPMF n (p i₀) j := by
+    intro j hj
+    rw [mem_range] at hj
+    -- (1) Replace k(i₀) by j on the filter
+    have step1 :
+        ∑ k ∈ (s.piAntidiag n).filter (fun k => k i₀ = j),
+          (k i₀ : ℝ) * multinomialProb s p n k =
+        ∑ k ∈ (s.piAntidiag n).filter (fun k => k i₀ = j),
+          (j : ℝ) * multinomialProb s p n k :=
+      sum_congr rfl fun k hk => by
+        have heq : k i₀ = j := (mem_filter.mp hk).2
+        congr 1; exact_mod_cast heq
+    -- (2) Factor out j, apply marginal PMF, match binomPMF
+    have step2 :
+        ∑ k ∈ (s.piAntidiag n).filter (fun k => k i₀ = j),
+          (j : ℝ) * multinomialProb s p n k =
+        (j : ℝ) * BinomialTheoremOQ03.binomPMF n (p i₀) j := by
+      rw [← mul_sum]
+      simp_rw [multinomialProb_eq]
+      rw [BinomialTheoremOQ02OQ01OQ02.multinomial_marginal_pmf s p n hp_sum i₀ hi₀ j (by omega)]
+      rw [binomPMF_eq]
+    rw [step1, step2]
+  -- Apply the fiber results and use binomial_mean
+  rw [sum_congr rfl hfibers]
+  exact binomial_mean_all n (p i₀)
+
+/-! ## Cross-Moment E[XᵢXⱼ] = n(n-1)pᵢpⱼ -/
+
+/-- **Cross-moment of multinomial components**: E[XᵢXⱼ] = n·(n-1)·p(i)·p(j) for i ≠ j.
+
+    ## Proof Sketch
+
+    Apply `multinomial_mgf_real` with g(l) = (1+a) if l=i, (1+b) if l=j, 1 otherwise:
+
+      ∑_k P(k)·(1+a)^{k(i)}·(1+b)^{k(j)} = (1 + pᵢa + pⱼb)^n         (*)
+
+    (using ∑_l pₗ·gₗ = 1 + pᵢa + pⱼb since ∑ pₗ = 1 and ∏ gₗ^{kₗ} = (1+a)^{k(i)}·(1+b)^{k(j)})
+
+    Differentiate (*) w.r.t. a at a=0 (using `HasDerivAt.sum` on the LHS):
+      ∑_k P(k)·k(i)·(1+b)^{k(j)} = n·pᵢ·(1 + pⱼb)^{n-1}             (**)
+
+    Differentiate (**) w.r.t. b at b=0:
+      ∑_k P(k)·k(i)·k(j) = n·pᵢ·(n-1)·pⱼ·(1 + 0)^{n-2} = n(n-1)pᵢpⱼ  ✓
+
+    The HasDerivAt proof requires:
+    - `HasDerivAt.sum` for the finite sum
+    - `HasDerivAt.pow` + chain rule for (1+a)^m and (1+pᵢa+pⱼb)^n
+    - Careful treatment of 0^{m-1} via `Nat.cast_nonneg` and `one_pow` -/
+theorem multinomial_cross_moment {α : Type*} [DecidableEq α]
+    (s : Finset α) (p : α → ℝ) (n : ℕ)
+    (hp_sum : ∑ i ∈ s, p i = 1) (hp_nonneg : ∀ i ∈ s, 0 ≤ p i)
+    (i j : α) (hi : i ∈ s) (hj : j ∈ s) (hij : i ≠ j) :
+    ∑ k ∈ s.piAntidiag n, (k i : ℝ) * (k j : ℝ) * multinomialProb s p n k =
+    n * (↑n - 1) * p i * p j := by
+  sorry
+
+/-! ## Main Theorem: Covariance = -n·pᵢ·pⱼ -/
+
+/-- **Multinomial Covariance**: Cov(Xᵢ, Xⱼ) = -n·pᵢ·pⱼ for distinct i ≠ j.
+
+    The negative correlation reflects the competition between outcomes in n trials.
+
+    The sum formula for covariance is:
+      Σ_k (k(i)·k(j) - E[Xᵢ]·E[Xⱼ]) · P(X=k) = E[XᵢXⱼ] - E[Xᵢ]·E[Xⱼ]
+
+    **Proof**:
+      = E[XᵢXⱼ] - n·pᵢ·(n·pⱼ)            [linearity]
+      = n(n-1)·pᵢ·pⱼ - n²·pᵢ·pⱼ           [by cross_moment + normalization]
+      = -n·pᵢ·pⱼ                            [ring] -/
+theorem multinomial_covariance {α : Type*} [DecidableEq α]
+    (s : Finset α) (p : α → ℝ) (n : ℕ)
+    (hp_sum : ∑ i ∈ s, p i = 1) (hp_nonneg : ∀ i ∈ s, 0 ≤ p i)
+    (i j : α) (hi : i ∈ s) (hj : j ∈ s) (hij : i ≠ j) :
+    ∑ k ∈ s.piAntidiag n,
+      ((k i : ℝ) * (k j : ℝ) - n * p i * (n * p j)) *
+      ((Nat.multinomial s k : ℝ) * ∏ l ∈ s, p l ^ k l) =
+    -(n : ℝ) * p i * p j := by
+  -- Rewrite raw form as multinomialProb
+  conv_lhs => arg 2; ext k; rw [show (Nat.multinomial s k : ℝ) * ∏ l ∈ s, p l ^ k l =
+      multinomialProb s p n k from rfl]
+  -- Expand (a - b) * P = a*P - b*P
+  simp_rw [sub_mul]
+  rw [Finset.sum_sub_distrib]
+  -- Second sum: n*pi*n*pj * ∑P = n*pi*n*pj  (by normalization)
+  have h_norm : ∑ k ∈ s.piAntidiag n,
+      n * p i * (n * p j) * multinomialProb s p n k = n * p i * (n * p j) := by
+    rw [← Finset.mul_sum, multinomialProb_sum_one s p n hp_sum, mul_one]
+  -- First sum: E[Xi*Xj] = n*(n-1)*pi*pj  (by cross moment)
+  have h_cross : ∑ k ∈ s.piAntidiag n,
+      (k i : ℝ) * (k j : ℝ) * multinomialProb s p n k = n * (↑n - 1) * p i * p j :=
+    multinomial_cross_moment s p n hp_sum hp_nonneg i j hi hj hij
+  rw [h_cross, h_norm]
+  ring
+
+/-! ## Summary -/
+
+/-
+## Results
+
+### Proved (0 axioms):
+1. `multinomialProb_sum_one`  — Normalization ∑ P(k) = 1
+2. `multinomial_mean`         — E[Xᵢ] = n·pᵢ (complete proof via fiber grouping)
+3. `multinomial_covariance`   — Cov(Xᵢ,Xⱼ) = -npᵢpⱼ (modulo cross_moment)
+
+### Sorries (1):
+4. `multinomial_cross_moment` — E[XᵢXⱼ] = n(n-1)pᵢpⱼ
+   Proof: Differentiate the joint MGF (∑ P(k)·(1+a)^{k(i)}·(1+b)^{k(j)} = (1+pᵢa+pⱼb)^n)
+   twice using HasDerivAt: ∂/∂a at 0, then ∂/∂b at 0.
+
+### Key Mathematical Content:
+The covariance formula -npᵢpⱼ is an exact algebraic consequence of:
+  E[XᵢXⱼ] = n(n-1)pᵢpⱼ and E[Xᵢ]E[Xⱼ] = n²pᵢpⱼ
+  ⟹ Cov = n(n-1)pᵢpⱼ - n²pᵢpⱼ = -npᵢpⱼ ✓
+-/
+
+end BinomialTheoremOQ02OQ01OQ03

--- a/research/problems/binomial-theorem-oq-02-oq-01-oq-03/knowledge.md
+++ b/research/problems/binomial-theorem-oq-02-oq-01-oq-03/knowledge.md
@@ -1,0 +1,67 @@
+# binomial-theorem-oq-02-oq-01-oq-03: Multinomial Covariance
+
+**Problem**: Prove Cov(Xᵢ, Xⱼ) = -n·pᵢ·pⱼ for the multinomial distribution.
+
+**Status**: PROGRESS — mean proved (0 sorries), covariance structure proved (1 sorry for cross-moment)
+
+**Lean file**: `Proofs/BinomialTheoremOQ02OQ01OQ03.lean`
+
+---
+
+## Session 2026-04-14 (Session 1) — Mean + Covariance Structure
+
+**Mode**: FRESH
+**Outcome**: progress
+
+### What I Did
+
+1. **Claimed problem** from candidate pool (knowledge tier: EMPTY)
+
+2. **Proved `multinomial_mean`** (complete, 0 sorries):
+   - `∑ k ∈ s.piAntidiag n, (k i₀ : ℝ) * multinomialProb s p n k = n * p i₀`
+   - Method: `sum_fiberwise_of_maps_to` groups by j = k(i₀), then fiber sum = j * marginal_pmf
+   - Used `multinomial_marginal_pmf` from OQ02 + `binomial_mean` from OQ03
+   - Key tactic: `exact_mod_cast` for ℕ→ℝ cast in filter membership proofs
+
+3. **Proved `multinomial_covariance`** (complete modulo cross-moment sorry):
+   - Expanded (a-b)*P via `sub_mul` + `sum_sub_distrib`
+   - Normalization term handled by `multinomialProb_sum_one`
+   - Cross-moment term delegated to `multinomial_cross_moment` (sorry)
+   - Closed by `ring`
+
+4. **Left `multinomial_cross_moment` as sorry** (E[XᵢXⱼ] = n(n-1)pᵢpⱼ):
+   - Proof sketch: differentiate joint MGF twice using HasDerivAt
+   - Joint MGF: `∑ P(k)·(1+a)^{k(i)}·(1+b)^{k(j)} = (1+pᵢa+pⱼb)^n` from multinomial_mgf_real
+   - ∂/∂a|₀ gives `∑ P(k)·k(i)·(1+b)^{k(j)} = n·pᵢ·(1+pⱼb)^{n-1}`
+   - ∂/∂b|₀ gives E[XᵢXⱼ] = n(n-1)pᵢpⱼ
+
+5. **Created gallery entry** at `src/data/proofs/binomial-theorem-oq-02-oq-01-oq-03/`
+
+### Key Findings
+
+- **Fiber grouping** (sum_fiberwise_of_maps_to) is the right technique for multinomial means
+- The `exact_mod_cast heq` pattern works when filter membership gives k i₀ = j : ℕ and we need (k i₀ : ℝ) = (j : ℝ)
+- The `binomial_mean` in OQ03 requires `hn : 1 ≤ n`; need `binomial_mean_all` wrapper for n=0
+- Cross-moment needs HasDerivAt-based differentiation OR joint PMF bijection (like OQ02 pattern)
+- The covariance algebraic structure is clean: n(n-1)pᵢpⱼ - n²pᵢpⱼ = -npᵢpⱼ
+
+### Files Modified
+
+- Created: `proofs/Proofs/BinomialTheoremOQ02OQ01OQ03.lean`
+- Created: `src/data/proofs/binomial-theorem-oq-02-oq-01-oq-03/meta.json`
+- Created: `src/data/proofs/binomial-theorem-oq-02-oq-01-oq-03/annotations.json`
+- Created: `src/data/proofs/binomial-theorem-oq-02-oq-01-oq-03/index.ts`
+- Updated: `src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-03.json`
+
+### Next Steps
+
+1. **Prove multinomial_cross_moment** using HasDerivAt approach:
+   - Establish joint MGF: `∑ P(k)·(1+a)^{k(i)}·(1+b)^{k(j)} = (1+pᵢa+pⱼb)^n`
+     (from `multinomial_mgf_real` with g(l) = 1+a if l=i, 1+b if l=j, 1 else)
+   - `HasDerivAt.sum` + chain rule for (1+a)^m derivatives
+   - Two applications of differentiation to extract the cross-moment
+
+2. **Alternative**: Prove joint PMF `P(Xᵢ=a, Xⱼ=b) = C(n;a,b,n-a-b)·pᵢᵃ·pⱼᵇ·(1-pᵢ-pⱼ)^{n-a-b}`
+   via a bijection similar to OQ02's `multinomial_marginal_pmf` (erase two elements)
+
+3. Once cross-moment proved: update status to completed, update sorries to 0

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-03/annotations.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "ann-covariance-setup",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-03",
+    "range": { "startLine": 47, "endLine": 68 },
+    "type": "definition",
+    "title": "multinomialProb and Normalization",
+    "content": "Redefines multinomialProb locally (definitionally equal to BinomialTheoremOQ02OQ01OQ02.multinomialProb) and proves the normalization ∑ P(k) = 1 by delegation. The local redefinition avoids namespace issues while keeping proofs readable. multinomialProb_eq establishes the definitional equality enabling simp_rw rewrites between namespaces.",
+    "mathContext": "$\\text{multinomialProb}(s, p, n, k) = \\binom{n}{k_1, \\ldots} \\prod_{i \\in s} p_i^{k_i}$. Normalization: $\\sum_{k \\in \\text{piAntidiag}(s,n)} P(k) = 1$ when $\\sum_{i \\in s} p_i = 1$.",
+    "significance": "supporting"
+  },
+  {
+    "id": "ann-mean-fiber-grouping",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-03",
+    "range": { "startLine": 70, "endLine": 132 },
+    "type": "theorem",
+    "title": "Mean E[Xᵢ] = n·pᵢ via Fiber Grouping",
+    "content": "multinomial_mean proves ∑_k k(i₀)·P(k) = n·p(i₀) in three steps. (1) sum_fiberwise_of_maps_to groups the double sum: ∑_k f(k) = ∑_j ∑_{k:k(i₀)=j} f(k). The mapping k ↦ k(i₀) hits range(n+1) since k(i₀) ≤ ∑_s k(l) = n. (2) On each fiber, step1 replaces k(i₀) : ℝ with j : ℝ (using exact_mod_cast via the filter membership proof), then step2 factors out j and applies multinomial_marginal_pmf to get the binomial PMF. (3) The resulting sum ∑_j j·binomPMF(n,p,j) = n·p is handled by binomial_mean_all.",
+    "mathContext": "Fiber grouping: $\\sum_{k} k(i_0) \\cdot P(k) = \\sum_{j=0}^{n} j \\cdot \\underbrace{\\sum_{k: k(i_0)=j} P(k)}_{= \\binom{n}{j} p_{i_0}^j (1-p_{i_0})^{n-j}} = \\sum_{j=0}^{n} j \\cdot \\text{binomPMF}(n, p_{i_0}, j) = n p_{i_0}$.",
+    "significance": "key"
+  },
+  {
+    "id": "ann-cross-moment-sorry",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-03",
+    "range": { "startLine": 134, "endLine": 166 },
+    "type": "theorem",
+    "title": "Cross-Moment Sorry: E[XᵢXⱼ] = n(n-1)pᵢpⱼ",
+    "content": "multinomial_cross_moment is stated with a detailed proof sketch in the docstring. The proof uses the joint MGF identity (from multinomial_mgf_real with g(l) = 1+a for l=i, 1+b for l=j, 1 otherwise): ∑_k P(k)·(1+a)^{k(i)}·(1+b)^{k(j)} = (1+pᵢa+pⱼb)^n. Differentiating w.r.t. a at 0 (HasDerivAt.sum) gives ∑_k P(k)·k(i)·(1+b)^{k(j)} = n·pᵢ·(1+pⱼb)^{n-1}. Differentiating w.r.t. b at 0 gives E[XᵢXⱼ] = n(n-1)pᵢpⱼ.",
+    "mathContext": "Joint MGF: $\\sum_k P(k) (1+a)^{k(i)} (1+b)^{k(j)} = (1 + p_i a + p_j b)^n$. Cross-moment: $E[X_i X_j] = \\frac{\\partial^2}{\\partial a \\partial b}\\Big|_{a=b=0} (1+p_i a + p_j b)^n = n(n-1) p_i p_j$.",
+    "significance": "key"
+  },
+  {
+    "id": "ann-covariance-main",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-03",
+    "range": { "startLine": 168, "endLine": 202 },
+    "type": "theorem",
+    "title": "Main Theorem: Multinomial Covariance",
+    "content": "multinomial_covariance reduces the covariance formula to the cross-moment and mean. The proof: (1) rewrites the raw multinomial coefficient form as multinomialProb, (2) expands (k(i)·k(j) - n·p(i)·n·p(j))·P via sub_mul and sum_sub_distrib, splitting into two sums, (3) the second sum (constant × normalization) is evaluated by multinomialProb_sum_one, (4) the first sum is the cross-moment, (5) closes by ring arithmetic. The key computation is n(n-1)pᵢpⱼ - n²pᵢpⱼ = -npᵢpⱼ.",
+    "mathContext": "$\\text{Cov}(X_i, X_j) = E[X_i X_j] - E[X_i] E[X_j] = n(n-1)p_ip_j - n^2 p_i p_j = -n p_i p_j$.",
+    "significance": "key"
+  }
+]

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-03/index.ts
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-03/index.ts
@@ -1,0 +1,37 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BinomialTheoremOQ02OQ01OQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const binomialTheoremOQ02OQ01OQ03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const binomialTheoremOQ02OQ01OQ03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const binomialTheoremOQ02OQ01OQ03Data: ProofData = {
+  proof: binomialTheoremOQ02OQ01OQ03Proof,
+  annotations: binomialTheoremOQ02OQ01OQ03Annotations,
+  tacticStates: [],
+}

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-03/meta.json
@@ -1,0 +1,118 @@
+{
+  "id": "binomial-theorem-oq-02-oq-01-oq-03",
+  "title": "Multinomial Covariance: Cov(Xᵢ, Xⱼ) = -n·pᵢ·pⱼ",
+  "slug": "binomial-theorem-oq-02-oq-01-oq-03",
+  "description": "Proves that the covariance of distinct components in a multinomial distribution equals -n·pᵢ·pⱼ, and as a key intermediate result, that the mean E[Xᵢ] = n·pᵢ. The proof uses fiber grouping, the marginal PMF formula from BinomialTheoremOQ02OQ01OQ02, and the binomial mean from BinomialTheoremOQ03.",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "formalized",
+    "proofRepoPath": "Proofs/BinomialTheoremOQ02OQ01OQ03.lean",
+    "tags": [
+      "probability",
+      "multinomial distribution",
+      "covariance",
+      "negative correlation",
+      "mean",
+      "moments",
+      "fiber grouping",
+      "combinatorics"
+    ],
+    "badge": "original",
+    "sorries": 1,
+    "axiomCount": 0,
+    "lineCount": 202,
+    "assumptions": "One sorry: multinomial_cross_moment (E[XᵢXⱼ] = n(n-1)pᵢpⱼ). The main structure theorem multinomial_covariance is proved modulo this cross-moment sorry.",
+    "theoremCount": 4,
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "The covariance structure of the multinomial distribution is a classical result in probability theory. For $(X_1, \\ldots, X_k) \\sim \\text{Multinomial}(n, p_1, \\ldots, p_k)$, the negative covariance $\\text{Cov}(X_i, X_j) = -np_ip_j$ for $i \\neq j$ reflects the fundamental constraint that the counts must sum to $n$: if more trials yield outcome $i$, fewer must yield outcome $j$. This negative correlation is routinely used in the analysis of goodness-of-fit tests, confidence intervals for proportions, and the derivation of the chi-squared distribution.",
+    "problemStatement": "For $(X_1, \\ldots, X_k) \\sim \\text{Multinomial}(n, p_1, \\ldots, p_k)$ with $\\sum p_i = 1$, prove that $\\text{Cov}(X_i, X_j) = -np_ip_j$ for distinct $i \\neq j$.",
+    "text": "Proves the multinomial covariance formula $\\text{Cov}(X_i, X_j) = -np_ip_j$ in two steps: (1) the mean $E[X_i] = np_i$ is fully proved via fiber grouping, and (2) the cross-moment $E[X_iX_j] = n(n-1)p_ip_j$ is the key sorry. Given these, the covariance follows by ring arithmetic: $E[X_iX_j] - E[X_i]E[X_j] = n(n-1)p_ip_j - n^2p_ip_j = -np_ip_j$.",
+    "proofStrategy": "The mean proof uses the `sum_fiberwise_of_maps_to` lemma to group the multinomial sum by the value of $k(i_0) = j$, reducing each fiber to a scalar multiple of the marginal PMF $P(X_{i_0}=j) = \\binom{n}{j}p_{i_0}^j(1-p_{i_0})^{n-j}$ (from BinomialTheoremOQ02OQ01OQ02), then recognizing the resulting sum as the binomial mean $\\sum_j j \\cdot \\text{binomPMF}(n,p,j) = np$ (from BinomialTheoremOQ03). The covariance then follows by linearity and ring arithmetic from the cross-moment and the mean.",
+    "keyInsights": [
+      "The mean proof reduces to binomial_mean via the fiber grouping technique: ∑_k k(i₀)·P(k) = ∑_j j·P(X_{i₀}=j) = n·p(i₀)",
+      "The covariance formula is -npᵢpⱼ because E[XᵢXⱼ] = n(n-1)pᵢpⱼ while E[Xᵢ]·E[Xⱼ] = n²pᵢpⱼ, so Cov = -npᵢpⱼ",
+      "The cross-moment E[XᵢXⱼ] = n(n-1)pᵢpⱼ can be proved by differentiating the joint MGF (∑ P(k)·(1+a)^{k(i)}·(1+b)^{k(j)} = (1+pᵢa+pⱼb)^n) twice using HasDerivAt",
+      "The negative correlation arises from the hard constraint ∑ Xₗ = n: winning observations in category i must come at the expense of other categories",
+      "multinomial_covariance is fully proved in terms of multinomial_cross_moment — the algebraic reduction is complete"
+    ]
+  },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Multinomial PMF and Normalization",
+      "startLine": 47,
+      "endLine": 68,
+      "summary": "Defines multinomialProb (identical to BinomialTheoremOQ02OQ01OQ02.multinomialProb via definitional equality) and proves multinomialProb_sum_one (normalization ∑ P(k) = 1 when ∑ p(i) = 1) by delegation to the parent file's theorem."
+    },
+    {
+      "id": "mean",
+      "title": "Mean E[Xᵢ] = n·pᵢ (Complete Proof)",
+      "startLine": 70,
+      "endLine": 132,
+      "summary": "Proves multinomial_mean: ∑_k k(i₀)·P(k) = n·p(i₀). The proof uses sum_fiberwise_of_maps_to to group the sum by value j = k(i₀), then on each fiber: (1) replaces k(i₀) with j using exact_mod_cast, (2) applies multinomial_marginal_pmf from OQ02 to get the binomial PMF formula, (3) applies binomial_mean_all (which extends BinomialTheoremOQ03.binomial_mean to the n=0 case). Private helpers: binomial_mean_all (handles n=0 via rcases) and binomPMF_eq (unfolds binomPMF)."
+    },
+    {
+      "id": "cross-moment",
+      "title": "Cross-Moment E[XᵢXⱼ] = n(n-1)pᵢpⱼ (Sorry)",
+      "startLine": 134,
+      "endLine": 166,
+      "summary": "States multinomial_cross_moment with a detailed proof sketch: apply multinomial_mgf_real with g(l) = (1+a) if l=i, (1+b) if l=j, else 1, yielding (1+pᵢa+pⱼb)^n = ∑ P(k)·(1+a)^{k(i)}·(1+b)^{k(j)}. Differentiate w.r.t. a at 0 (using HasDerivAt.sum), then w.r.t. b at 0, to extract E[XᵢXⱼ] = n(n-1)pᵢpⱼ."
+    },
+    {
+      "id": "covariance",
+      "title": "Main Theorem: Cov(Xᵢ,Xⱼ) = -npᵢpⱼ",
+      "startLine": 168,
+      "endLine": 202,
+      "summary": "Proves multinomial_covariance by: (1) rewriting the raw multinomial coefficient form as multinomialProb, (2) expanding (a-b)·P via sub_mul and sum_sub_distrib, (3) applying multinomialProb_sum_one to evaluate the normalization term, (4) applying multinomial_cross_moment for the cross-moment, (5) closing by ring arithmetic. The proof is complete modulo the cross-moment sorry."
+    }
+  ],
+  "conclusion": {
+    "summary": "The mean theorem `multinomial_mean` is fully proved (0 sorries) via fiber grouping and the marginal PMF. The covariance theorem `multinomial_covariance` is proved modulo the cross-moment sorry. The algebraic reduction Cov = E[XᵢXⱼ] - E[Xᵢ]E[Xⱼ] = n(n-1)pᵢpⱼ - n²pᵢpⱼ = -npᵢpⱼ is fully formalized.",
+    "implications": "The negative covariance -npᵢpⱼ is foundational in multivariate statistics: it determines the covariance matrix of the multinomial distribution (diagonal Var(Xᵢ) = npᵢ(1-pᵢ), off-diagonal Cov(Xᵢ,Xⱼ) = -npᵢpⱼ), which is used in the asymptotic chi-squared distribution of goodness-of-fit statistics, the delta method for functions of multinomial proportions, and the analysis of categorical data in contingency tables.",
+    "openQuestions": [
+      "Prove multinomial_cross_moment: E[XᵢXⱼ] = n(n-1)pᵢpⱼ using the joint MGF differentiation approach sketched in the proof comment (HasDerivAt applied twice to ∑ P(k)·(1+a)^{k(i)}·(1+b)^{k(j)} = (1+pᵢa+pⱼb)^n)",
+      "Formalize the full multinomial covariance matrix: the matrix with entries Cov(Xᵢ,Xⱼ) is n·(diag(p) - p·pᵀ), and prove it is positive semi-definite on the constraint hyperplane ∑ xᵢ = 0"
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/BinomialTheoremOQ02OQ01OQ03.lean",
+    "theorems": [
+      "multinomialProb_sum_one",
+      "multinomial_mean",
+      "multinomial_cross_moment",
+      "multinomial_covariance"
+    ],
+    "lineCount": 202,
+    "axiomCount": 0,
+    "sorries": 1
+  },
+  "crossReferences": [
+    {
+      "id": "binomial-theorem-oq-02-oq-01",
+      "relation": "parent",
+      "description": "Proves the multinomial MGF formula used in the cross-moment proof sketch"
+    },
+    {
+      "id": "binomial-theorem-oq-02-oq-01-oq-02",
+      "relation": "dependency",
+      "description": "Provides multinomial_marginal_pmf used in the mean proof, and multinomialProb_sum_one used in normalization"
+    },
+    {
+      "id": "binomial-theorem-oq-03",
+      "relation": "dependency",
+      "description": "Provides binomial_mean and binomPMF used in the mean proof"
+    },
+    {
+      "id": "binomial-theorem-oq-02",
+      "relation": "ancestor",
+      "description": "The multinomial theorem formalization underlying all results"
+    },
+    {
+      "id": "binomial-theorem-oq-02-oq-01-oq-01",
+      "relation": "sibling",
+      "description": "PMF.multinomial integration with Mathlib — another application of the multinomial distribution infrastructure"
+    }
+  ]
+}

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-03.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-03.json
@@ -1,7 +1,7 @@
 {
   "slug": "binomial-theorem-oq-02-oq-01-oq-03",
   "title": "Prove variance-covariance Cov(Xi,Xj) = -n*pi*pj in Lean",
-  "phase": "NEW",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "fast",
@@ -16,10 +16,10 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ACT",
     "since": "2026-04-05T03:58:33.672Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "multinomial_cross_moment sorry remaining; mean and covariance structure complete",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
@@ -29,11 +29,28 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": []
+    "progressSummary": "PROGRESS: Mean proved (0 sorries), covariance structure proved (1 sorry for cross-moment)",
+    "builtItems": [
+      "multinomial_mean in Proofs/BinomialTheoremOQ02OQ01OQ03.lean — complete proof via fiber grouping",
+      "multinomial_covariance in Proofs/BinomialTheoremOQ02OQ01OQ03.lean — proved given cross-moment",
+      "gallery entry at src/data/proofs/binomial-theorem-oq-02-oq-01-oq-03/"
+    ],
+    "insights": [
+      "E[Xi] = n*pi proved fully via fiber grouping + sum_fiberwise_of_maps_to",
+      "Fiber grouping reduces ∑_k k(i₀)*P(k) to ∑_j j*binomPMF(n,p,j) using multinomial_marginal_pmf",
+      "multinomial_covariance fully proved modulo cross-moment: Cov = n(n-1)pipj - n²pipj = -npipj",
+      "Cross-moment E[Xi*Xj] = n(n-1)pipj: proof sketch via joint MGF differentiation (HasDerivAt twice)",
+      "key Lean tactic: exact_mod_cast handles ℕ→ℝ cast when replacing k(i₀) with j on a filter",
+      "binomial_mean_all extends BinomialTheoremOQ03.binomial_mean to n=0 case via rcases"
+    ],
+    "mathlibGaps": [
+      "HasDerivAt machinery needed to differentiate finite sums of (1+a)^k type polynomials",
+      "No joint multinomial PMF formula P(Xi=a, Xj=b) in the codebase (needed for direct cross-moment proof)"
+    ],
+    "nextSteps": [
+      "Prove multinomial_cross_moment via HasDerivAt: differentiate ∑P(k)*(1+a)^{k(i)}*(1+b)^{k(j)} = (1+pi*a+pj*b)^n twice",
+      "Alternative: prove joint PMF P(Xi=a,Xj=b) = C(n;a,b,n-a-b)*pi^a*pj^b*(1-pi-pj)^{n-a-b} via bijection like OQ02"
+    ]
   },
   "tags": [
     "probability",


### PR DESCRIPTION
## Summary

- Proves `multinomial_mean`: E[Xᵢ] = n·pᵢ for multinomial distributions (complete, 0 sorries)
- Proves `multinomial_covariance`: Cov(Xᵢ,Xⱼ) = -n·pᵢ·pⱼ (1 sorry for cross-moment)
- Adds gallery entry `binomial-theorem-oq-02-oq-01-oq-03` with 4 theorems

## Key Mathematical Content

The mean proof uses fiber grouping via `sum_fiberwise_of_maps_to`:
```
∑_k k(i₀)·P(k) = ∑_j j · P(X_{i₀}=j) = ∑_j j · binomPMF(n, p(i₀), j) = n·p(i₀)
```
leveraging `multinomial_marginal_pmf` (from OQ02) and `binomial_mean` (from OQ03).

The covariance structure is fully proved modulo `multinomial_cross_moment` (E[XᵢXⱼ] = n(n-1)pᵢpⱼ):
```
Cov = E[XᵢXⱼ] - E[Xᵢ]·E[Xⱼ] = n(n-1)pᵢpⱼ - n²pᵢpⱼ = -npᵢpⱼ
```

The cross-moment sorry has a detailed proof sketch (differentiate joint MGF twice via `HasDerivAt`).

## Files

- `proofs/Proofs/BinomialTheoremOQ02OQ01OQ03.lean` — 202 lines, 4 theorems, 1 sorry
- `src/data/proofs/binomial-theorem-oq-02-oq-01-oq-03/` — gallery entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)