### PR TITLE
Fix: stale lineCount in 8 gallery proofs (batch)

### DIFF
--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02/meta.json
@@ -21,7 +21,7 @@
     "sorries": 0,
     "dateAdded": "2026-04-12",
     "axiomCount": 5,
-    "lineCount": 664,
+    "lineCount": 763,
     "assumptions": "5 axioms: aperyB_recurrence (WZ recurrence), denominator_control (lcm^3*a_n is integer), lcm_hanson_bound (3^n Hanson bound), apery_linearForm_decay (geometric decay), apery_linearForm_nonzero (L_n != 0 for n>=1). Removed unused nair_lcm_bound. Main theorem apery_theorem PROVED from these 5 axioms.",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -163,7 +163,7 @@
       "Nat"
     ],
     "namespace": "AperyZetaThree",
-    "lineCount": 664,
+    "lineCount": 763,
     "axiomCount": 5,
     "theoremCount": 22,
     "definitionCount": 4,

--- a/src/data/proofs/bezout-identity-oq-02-oq-04/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-04/meta.json
@@ -21,7 +21,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 145,
+    "lineCount": 170,
     "mathlibDependencies": [
       {
         "theorem": "IsPrimitive.mul",

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -16,7 +16,7 @@
     "badge": "wip",
     "sorries": 3,
     "axiomCount": 0,
-    "lineCount": 829,
+    "lineCount": 524,
     "assumptions": "3 remaining sorries: (1) truncated_rn_deriv_lq_bound — Hölder extremizer uniform bound for truncations (sub-goal 5b); (2) rn_deriv_memLq MCT step — lintegral_iSup monotone convergence + pointwise monotonicity; (3) riesz_lp_surjective_from_rn — signed measure construction + full assembly. Proved: integrationCLM, integrationCLM_apply, lintegral_mul_le_of_memLp, integrable_mul_of_memLp, truncated_rn_deriv_memLq (sub-goal 5a), integral_representation (all 3 Lp.induction cases), holder_test_sign_property, memLq_of_uniform_truncation_bound (MCT lemma for clean architecture).",
     "dateAdded": "2026-04-13"
   },
@@ -106,7 +106,7 @@
     "imports": [
       "Mathlib"
     ],
-    "lineCount": 829,
+    "lineCount": 524,
     "axiomCount": 0,
     "theoremCount": 15,
     "definitionCount": 2,

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-03/meta.json
@@ -59,7 +59,7 @@
       "holder_real_from_normedField_lintegral: Real Hölder as a special case of the NormedField version"
     ],
     "dateAdded": "2026-04-14",
-    "lineCount": 170,
+    "lineCount": 209,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0"
   },
@@ -161,7 +161,7 @@
     "imports": ["Mathlib"],
     "opens": ["MeasureTheory", "ENNReal", "NNReal", "Real", "InnerProductSpace"],
     "namespace": "HolderNormedField",
-    "lineCount": 170,
+    "lineCount": 209,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 0,

--- a/src/data/proofs/erdos-181-oq-01/meta.json
+++ b/src/data/proofs/erdos-181-oq-01/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 2,
-    "lineCount": 185,
+    "lineCount": 170,
     "theoremCount": 10,
     "assumptions": "The main Burr-Erdős conjecture R_sym(Q_n) ≤ C·2^n and the Tikhomirov (2022) bound R_sym(Q_n) ≤ C·2^{(2-c)n} are stated as axioms. All other results (R_sym(Q_1) = 2, lower bound structure) are fully machine-verified.",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/erdos-35/meta.json
+++ b/src/data/proofs/erdos-35/meta.json
@@ -24,7 +24,7 @@
     "erdosUrl": "https://erdosproblems.com/35",
     "erdosProblemStatus": "solved",
     "axiomCount": 0,
-    "lineCount": 255,
+    "lineCount": 336,
     "prerequisites": [
       "Schnirelmann density and its properties",
       "Additive bases and Waring's problem",
@@ -140,7 +140,7 @@
       "Set"
     ],
     "namespace": "Erdos35",
-    "lineCount": 255,
+    "lineCount": 336,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 9,

--- a/src/data/proofs/erdos-476/meta.json
+++ b/src/data/proofs/erdos-476/meta.json
@@ -54,7 +54,7 @@
       "combinatorial_nullstellensatz axiom: polynomial method"
     ],
     "axiomCount": 2,
-    "lineCount": 291,
+    "lineCount": 384,
     "assumptions": "2 axioms: erdos_heilbronn_bound, AP_restrictedSumset. 0 sorries."
   },
   "overview": {
@@ -179,7 +179,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos476",
-    "lineCount": 291,
+    "lineCount": 384,
     "axiomCount": 2,
     "theoremCount": 9,
     "definitionCount": 4,

--- a/src/data/proofs/tractatus-ontology/meta.json
+++ b/src/data/proofs/tractatus-ontology/meta.json
@@ -39,7 +39,7 @@
     ],
     "dateAdded": "04/14/26",
     "axiomCount": 1,
-    "lineCount": 658,
+    "lineCount": 842,
     "assumptions": "One deliberate axiom: `silence : True` (TLP 7) — a trivially true but axiomatic declaration that enacts Wittgenstein's silence as a formal gesture. All theorems are fully proved with 0 sorries. Uses classical logic (Classical.em) throughout. The companion file TractatusQuantifiers.lean has no sorries or axioms."
   },
   "overview": {
@@ -205,7 +205,7 @@
     "imports": ["Mathlib.Tactic"],
     "opens": [],
     "namespace": "Tractatus",
-    "lineCount": 658,
+    "lineCount": 842,
     "axiomCount": 1,
     "theoremCount": 24,
     "definitionCount": 14,


### PR DESCRIPTION
## Fix

8 gallery `meta.json` files had stale `lineCount` values after research PRs modified their Lean sources but didn't update the metadata.

## Evidence

| Proof | Before | After | Cause |
|-------|--------|-------|-------|
| `cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01` | 829 | 524 | Architecture rewrite (#10802) |
| `tractatus-ontology` | 658 | 842 | Tractatus PRs (#10821, #10822) |
| `basel-problem-oq-01-oq-01-oq-02` | 664 | 763 | Apéry growth bound (#10519) |
| `erdos-476` | 291 | 384 | AP_restrictedSumset (#10824) |
| `erdos-35` | 255 | 336 | power_bound proof (#10782) |
| `cauchy-schwarz-integral-oq-01-oq-03` | 170 | 209 | Complex Hölder (#10806) |
| `bezout-identity-oq-02-oq-04` | 145 | 170 | Initial research |
| `erdos-181-oq-01` | 185 | 170 | Symmetric Ramsey (#10825) |

## Validation

- `pnpm build` passes (✓ built in 18.54s)
- All lineCount values verified against actual Lean file line counts

---
Automated fix by lean-mechanic agent.