### PR TITLE
Fix: bezout-identity-oq-02-oq-04 badge mathlib not original

### DIFF
--- a/src/data/proofs/bezout-identity-oq-02-oq-04/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-04/meta.json
@@ -18,7 +18,7 @@
       "bezout"
     ],
     "proofRepoPath": "Proofs/BezoutIdentityOQ02OQ04.lean",
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 145,
@@ -58,7 +58,7 @@
       "primitive_irreducible_is_prime: connecting IsPrimitive + Irreducible to Prime",
       "two_X_not_coprime_in_ZX: formal witness that ℤ[X] is not Bézout"
     ],
-    "assumptions": "No axioms. All results proved from Mathlib's polynomial content theory and UFD structure."
+    "assumptions": "No axioms. Core results (Gauss's lemma, content multiplicativity, Euclid's lemma over ℤ) are thin wrappers around Mathlib's IsPrimitive.mul, Polynomial.content_mul, irreducible_iff_prime, Prime.dvd_or_dvd, and IsCoprime.dvd_of_dvd_mul_left. Original contributions: poly_bezout_application (explicit linear_combination proof in the field case) and two_X_not_coprime_in_ZX (formal non-Bézout witness for ℤ[X])."
   },
   "overview": {
     "problemStatement": "**Problem Statement**: Does the `linear_combination` tactic approach to Euclid's lemma (from bezout-identity-oq-02) scale to Gauss's lemma for polynomial rings?\n\n**Answer**: PARTIALLY. The approach scales to polynomial rings over fields (k[X] is a PID/Bézout domain). Over ℤ, the approach fails because ℤ[X] is not a Bézout domain — there is no Bézout identity for 2 and X in ℤ[X].",


### PR DESCRIPTION
## Fix

Change `badge` from `"original"` to `"mathlib"` in `bezout-identity-oq-02-oq-04/meta.json`, and update `assumptions` to accurately reflect which results are Mathlib wrappers vs. original contributions.

## Evidence

**Before**: `"badge": "original"` — implies fully independent proof (Tier A)
**After**: `"badge": "mathlib"` — correctly reflects that 5 of 7 theorems are direct Mathlib wrappers (`IsPrimitive.mul`, `Polynomial.content_mul`, `IsCoprime.dvd_of_dvd_mul_left`, `irreducible_iff_prime`, `Prime.dvd_or_dvd`)

Original contributions remain: `poly_bezout_application` (linear_combination proof) and `two_X_not_coprime_in_ZX` (non-Bézout witness).

`status: "verified"` is correct (0 sorries, 0 axioms) — unchanged.

Closes #10833

---
Automated fix by lean-mechanic agent.