### PR TITLE
Enrich bertrands-postulate-oq-03-oq-04-oq-03: add PNT filter algebra annotations

### DIFF
--- a/src/data/proofs/bertrands-postulate-oq-03-oq-04-oq-03/annotations.json
+++ b/src/data/proofs/bertrands-postulate-oq-03-oq-04-oq-03/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-header-structure",
+    "proofId": "bertrands-postulate-oq-03-oq-04-oq-03",
+    "range": { "startLine": 10, "endLine": 53 },
+    "type": "context",
+    "title": "Modularization of Filter Algebra Steps",
+    "content": "The file header explicitly frames the open question: can the inline filter algebra steps from OQ-04's `long_interval_density_from_pnt` be extracted as standalone, sorry-free lemmas? The two steps are named: (1) PNT rescaling — expressing π((1+c)x) with log(x) instead of log((1+c)x); (2) interval density — combining two PNT estimates to get the gap count. The key algebraic identity underlying step (2) is displayed in ASCII art: interval density = (1+c)/c × PNT_at_(1+c)x - 1/c × PNT_at_x.",
+    "mathContext": "$\\frac{\\pi((1+c)x) - \\pi(x)}{cx} = \\frac{1+c}{c} \\cdot \\frac{\\pi((1+c)x)}{(1+c)x} - \\frac{1}{c} \\cdot \\frac{\\pi(x)}{x}$",
+    "significance": "context",
+    "relatedConcepts": ["PNT density", "modular proof design", "filter algebra", "open question"],
+    "prerequisites": ["Prime Number Theorem", "Filter.Tendsto in Lean 4", "prime counting function π(x)"]
+  },
+  {
+    "id": "ann-log-ratio",
+    "proofId": "bertrands-postulate-oq-03-oq-04-oq-03",
+    "range": { "startLine": 60, "endLine": 90 },
+    "type": "technique",
+    "title": "Log Ratio Lemma: Change of Logarithm",
+    "content": "The private lemma `log_ratio_tendsto_one` proves that log(x)/log((1+c)x) → 1. The proof strategy uses `filter_upwards` to work for large x (where log x > 0), rewrites the ratio as 1/(1 + log(1+c)/log(x)), and then uses `tendsto_const_nhds.div_atTop Real.tendsto_log_atTop` to show the denominator log(1+c)/log(x) → 0. This lemma is the technical bridge allowing PNT's natural statement at (1+c)x (using log((1+c)x)) to be converted to use log(x) instead.",
+    "mathContext": "$\\frac{\\log x}{\\log((1+c)x)} = \\frac{1}{1 + \\frac{\\log(1+c)}{\\log x}} \\to \\frac{1}{1+0} = 1$ since $\\log x \\to \\infty$",
+    "significance": "supporting",
+    "relatedConcepts": ["log arithmetic", "tendsto_const_nhds.div_atTop", "filter_upwards", "change of logarithm"],
+    "prerequisites": ["Real.log properties", "Filter.Tendsto", "real analysis limits"]
+  },
+  {
+    "id": "ann-pnt-rescaling",
+    "proofId": "bertrands-postulate-oq-03-oq-04-oq-03",
+    "range": { "startLine": 96, "endLine": 130 },
+    "type": "technique",
+    "title": "PNT Rescaling via Filter Composition",
+    "content": "The theorem `pnt_at_scaled_point` uses `primeNumberTheorem.comp` with the scaling map `x ↦ (1+c)·x` to obtain PNT at the scaled point. The composition `Filter.Tendsto.comp (Filter.Tendsto.const_mul_atTop h1c_pos tendsto_id)` shifts the evaluation point from x to (1+c)x. Then `pnt_1c.mul hlog_ratio` multiplies the two limits (both → 1), and `hmul.congr'` with `field_simp; ring` cleans up the algebraic equality. The `filter_upwards` guard ensures log((1+c)x) ≠ 0 so the algebraic manipulation is valid.",
+    "mathContext": "$\\pi((1+c)x) \\cdot \\frac{\\log((1+c)x)}{(1+c)x} \\to 1$ (PNT at $(1+c)x$), and $\\frac{\\log x}{\\log((1+c)x)} \\to 1$; multiplying gives $\\pi((1+c)x) \\cdot \\frac{\\log x}{(1+c)x} \\to 1$",
+    "significance": "key",
+    "relatedConcepts": ["Filter.Tendsto.comp", "Filter.Tendsto.mul", "tendsto_congr'", "PNT composition"],
+    "prerequisites": ["Prime Number Theorem statement", "Filter composition in Lean 4", "log_ratio_tendsto_one"]
+  },
+  {
+    "id": "ann-congr-technique",
+    "proofId": "bertrands-postulate-oq-03-oq-04-oq-03",
+    "range": { "startLine": 120, "endLine": 131 },
+    "type": "technique",
+    "title": "Filter.tendsto_congr' for Function Equality Cleanup",
+    "content": "A recurring pattern in this file: after combining filter limits, the resulting function expression doesn't syntactically match the goal. `Filter.tendsto_congr'` (or `Filter.Tendsto.congr'`) allows replacing a function with an eventually-equal one. The proof of eventual equality uses `filter_upwards` to work in a region where log ≠ 0, then `field_simp; ring` to prove the algebraic identity. This decomposes the proof into (1) limit combination and (2) algebraic rewriting, keeping each step clean.",
+    "mathContext": "If $f =_{\\text{a.e.}} g$ and $f \\to L$, then $g \\to L$; here $(\\text{product expression}) =_{x \\to \\infty} \\pi((1+c)x) \\cdot \\log(x) / ((1+c)x)$",
+    "significance": "technical",
+    "relatedConcepts": ["Filter.tendsto_congr'", "filter_upwards", "algebraic equality", "field_simp"],
+    "prerequisites": ["Filter.Tendsto congruence lemmas", "eventually-equal functions", "Lean field_simp tactic"]
+  },
+  {
+    "id": "ann-density-theorem",
+    "proofId": "bertrands-postulate-oq-03-oq-04-oq-03",
+    "range": { "startLine": 136, "endLine": 182 },
+    "type": "insight",
+    "title": "Interval Density via Linear Combination of PNT Estimates",
+    "content": "The main theorem `pnt_density_long_interval` implements the algebraic identity: scale pnt_at_scaled_point by (1+c)/c and subtract PNT scaled by 1/c. The key calculation is (1+c)/c × 1 - 1/c × 1 = 1 (done by `rw [show ...]` with `field_simp; ring`). The `congr'` step then verifies that (1+c)/c × [π((1+c)x)·logx/((1+c)x)] - 1/c × [π(x)·logx/x] equals the goal expression (π((1+c)x) - π(x))·logx/(cx) via `field_simp; ring`. This is a clean application of Mathlib's `Tendsto.const_mul` and `Tendsto.sub` combinators.",
+    "mathContext": "$\\frac{(\\pi((1+c)x) - \\pi(x)) \\log x}{cx} = \\frac{1+c}{c} \\cdot \\underbrace{\\frac{\\pi((1+c)x) \\log x}{(1+c)x}}_{\\to 1} - \\frac{1}{c} \\cdot \\underbrace{\\frac{\\pi(x) \\log x}{x}}_{\\to 1} \\to \\frac{1+c}{c} - \\frac{1}{c} = 1$",
+    "significance": "key",
+    "relatedConcepts": ["Tendsto.const_mul", "Tendsto.sub", "algebraic decomposition", "prime gap density"],
+    "prerequisites": ["pnt_at_scaled_point", "primeNumberTheorem", "filter limit arithmetic"]
+  },
+  {
+    "id": "ann-gap-summary",
+    "proofId": "bertrands-postulate-oq-03-oq-04-oq-03",
+    "range": { "startLine": 188, "endLine": 213 },
+    "type": "insight",
+    "title": "The Long/Short Interval Density Gap",
+    "content": "The theorem `pnt_density_gap_summary` is a structural summary packaging both what is proved and what is open. Part (1) uses `pnt_density_long_interval` to confirm the h = cx case is unconditionally proved. Part (2) references the conditional theorem from OQ-04: if `ShortIntervalPNT θ` holds (an open conjecture for θ < 1/2, RH-conditional for θ ∈ (1/2,1)), then primes exist in every interval (x, x + x^θ]. This explicit conjunction of proved and open parts is pedagogically important — it makes the boundary of current knowledge precise.",
+    "mathContext": "Proved: $\\pi((1+c)x) - \\pi(x) \\sim cx/\\log x$ for fixed $c > 0$. Open: for $h = x^\\theta$, $\\theta < 1$, density $\\sim x^\\theta/\\log x$ requires `ShortIntervalPNT θ` (unknown for $\\theta < 1/2$, RH-conditional for $\\theta \\in (1/2, 1)$).",
+    "significance": "key",
+    "relatedConcepts": ["ShortIntervalPNT", "short interval prime conjecture", "Riemann Hypothesis", "prime gap bounds"],
+    "prerequisites": ["BertrandsPostulateOQ03OQ04.ShortIntervalPNT", "pnt_density_long_interval", "open problems in analytic number theory"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `bertrands-postulate-oq-03-oq-04-oq-03` (PNT Density Asymptotic for Prime Gaps: Filter Algebra Proof). The entry had a detailed meta.json but was missing `annotations.json`, resulting in a quality score of 43.

## Quality Improvements

**Created `annotations.json`** (6 annotations covering all 4 proof sections):

- `ann-header-structure`: Modularization context — why the OQ-04 inline steps were extracted
- `ann-log-ratio`: The private `log_ratio_tendsto_one` lemma (log change-of-base technique)  
- `ann-pnt-rescaling`: `pnt_at_scaled_point` — PNT composition with scaling map via `Tendsto.comp`
- `ann-congr-technique`: The `Filter.tendsto_congr'` + `filter_upwards` + `field_simp; ring` pattern used throughout
- `ann-density-theorem`: `pnt_density_long_interval` — interval density via `(1+c)/c × PNT_at_(1+c)x - 1/c × PNT_at_x`
- `ann-gap-summary`: The `pnt_density_gap_summary` conjunction of proved (h=cx) vs open (h=x^θ) cases

Each annotation includes LaTeX `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`.

## Axiom Integrity Note

`axiomCount: 0` in the meta.json. The proof depends transitively on `Proofs.PrimeNumberTheorem` which carries 1 axiom for the PNT itself. The `assumptions` field correctly documents this dependency. The `axiomCount: 0` refers to direct axioms in this file only (consistent with how the parent PNT entry reports it).