### PR TITLE
Enrich PNT Density + Multinomial Covariance (two enrichment passes)

### DIFF
--- a/src/data/proofs/divisibility-rules-oq-02/annotations.json
+++ b/src/data/proofs/divisibility-rules-oq-02/annotations.json
@@ -1,0 +1,85 @@
+[
+  {
+    "id": "ann-key-congruence",
+    "proofId": "divisibility-rules-oq-02",
+    "range": { "startLine": 36, "endLine": 52 },
+    "type": "theorem",
+    "title": "The Key Congruence: 1000 ≡ -1 (mod 7)",
+    "content": "The proof is a `native_decide` computation: 1000 % 7 = 6 = 7 - 1. This single arithmetic fact unlocks the entire 3-digit block rule. Writing n = a₀ + a₁·1000 + a₂·1000² + ... and substituting 1000^k ≡ (-1)^k (mod 7) immediately gives n ≡ a₀ - a₁ + a₂ - ... (mod 7). The Lean proof `seven_modEq_altDigitSum_1000` then delegates to `modEq_alternating_digits_sum` from the parent file — a 1-line proof once the congruence is established.",
+    "mathContext": "$1000 \\equiv -1 \\pmod{7}$, so $1000^k \\equiv (-1)^k \\pmod{7}$. For $n = \\sum_{i} a_i \\cdot 1000^i$ (3-digit blocks): $n \\equiv \\sum_i (-1)^i a_i \\pmod{7}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "modular arithmetic (ℤ/dℤ)",
+      "alternating sum of blocks",
+      "native_decide for decidable propositions",
+      "modEq_alternating_digits_sum"
+    ],
+    "prerequisites": [
+      "1000 = 142 × 7 + 6",
+      "Int.ModEq definition",
+      "DivisibilityRules.altDigitSum"
+    ]
+  },
+  {
+    "id": "ann-general-rule",
+    "proofId": "divisibility-rules-oq-02",
+    "range": { "startLine": 54, "endLine": 77 },
+    "type": "theorem",
+    "title": "General Alternating Block Rule: b ≡ -1 (mod d) → alternating sum test",
+    "content": "dvd_iff_dvd_altDigitSum is the unifying theorem: for any d > 0 and base b with b % d = d - 1 (i.e., b ≡ -1 mod d), we have d | n ↔ d | altDigitSum b n. The proof uses modEq_alternating_digits_sum to get (n : ℤ) ≡ altDigitSum b n [ZMOD d], then uses the transitivity of ModEq: if d | n then (taking the congruence mod d) d | altDigitSum b n, and vice versa. The direction proofs use `dvd_add` on `hmod.dvd` (or `hmod.symm.dvd`) combined with cancellation.",
+    "mathContext": "If $b \\equiv -1 \\pmod{d}$, then $n \\equiv \\text{altDigitSum}_b(n) \\pmod{d}$, so $d \\mid n \\iff d \\mid \\text{altDigitSum}_b(n)$. Instances: $(d,b) \\in \\{(7,1000), (13,1000), (11,10), (101,100)\\}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Int.ModEq (ZMOD notation)",
+      "dvd_add for divisibility under addition",
+      "DivisibilityRules.modEq_alternating_digits_sum",
+      "alternating block sums in different bases"
+    ],
+    "prerequisites": [
+      "DivisibilityRules.modEq_alternating_digits_sum",
+      "Int.ModEq.dvd",
+      "sub_add_cancel for ℤ"
+    ]
+  },
+  {
+    "id": "ann-seven-thirteen-shared",
+    "proofId": "divisibility-rules-oq-02",
+    "range": { "startLine": 79, "endLine": 95 },
+    "type": "definition",
+    "title": "7 and 13 Share a Rule: Both Divide 1001",
+    "content": "Both seven_dvd_iff_altDigitSum and thirteen_dvd_iff_altDigitSum follow from the same `dvd_iff_dvd_altDigitSum` with (d=7, b=1000) and (d=13, b=1000) respectively. The mathematical reason they share the rule: 7 × 11 × 13 = 1001 = 1000 + 1, so 1000 ≡ -1 (mod 7) and 1000 ≡ -1 (mod 13) simultaneously. This is also why 7 | 1001 and 13 | 1001 — the 'off-by-one' property of 1000 relative to both 7 and 13 arises from their product being exactly 1001.",
+    "mathContext": "$7 \\times 11 \\times 13 = 1001 = 1000 + 1$, so $1000 \\equiv -1$ simultaneously modulo $7$, $11$, and $13$. Hence all three give 3-digit block alternating sum rules (though $11$ is simpler via single-digit alternating sums since $10 \\equiv -1 \\pmod{11}$ also holds).",
+    "significance": "key",
+    "relatedConcepts": [
+      "factorization of 1001 = 7 × 11 × 13",
+      "simultaneous congruences (CRT)",
+      "shared divisibility rules from common factors"
+    ],
+    "prerequisites": [
+      "1001 = 7 × 11 × 13",
+      "1000 % 7 = 6",
+      "1000 % 13 = 12"
+    ]
+  },
+  {
+    "id": "ann-eleven-101-examples",
+    "proofId": "divisibility-rules-oq-02",
+    "range": { "startLine": 114, "endLine": 124 },
+    "type": "theorem",
+    "title": "Div-by-11 and Div-by-101: Classical Rule as Instance",
+    "content": "eleven_dvd_iff_altDigitSum (d=11, b=10) recovers the classical alternating digit sum rule for 11, since 10 ≡ -1 (mod 11). hundredone_dvd_iff_altDigitSum (d=101, b=100) is the 2-digit block variant: 100 ≡ -1 (mod 101). Both are 1-line proofs via `dvd_iff_dvd_altDigitSum` with `native_decide` establishing the base congruences. The unification under one algebraic framework is the structural insight: all these classical 'mental arithmetic tricks' are instances of a single modular arithmetic principle.",
+    "mathContext": "Instances of the general rule: $10 \\equiv -1 \\pmod{11}$ gives alternating digit sums; $100 \\equiv -1 \\pmod{101}$ gives alternating 2-digit blocks. The classical test '11 divides 1001' follows: $1001 = 91 \\cdot 11$, alt-digit-sum = $1 - 0 + 0 - 1 = 0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "classical divisibility-by-11 test",
+      "alternating digit sum",
+      "101 and 2-digit blocks",
+      "unification of classical rules"
+    ],
+    "prerequisites": [
+      "10 % 11 = 10 (= 11 - 1)",
+      "100 % 101 = 100 (= 101 - 1)",
+      "DivisibilityRules.altDigitSum base 10 vs base 100"
+    ]
+  }
+]

--- a/src/data/proofs/divisibility-rules-oq-02/index.ts
+++ b/src/data/proofs/divisibility-rules-oq-02/index.ts
@@ -1,0 +1,31 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as unknown as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+
+const leanSource = () => import('../../../../proofs/Proofs/DivisibilityRulesOQ02.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences
+}
+
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const proofData: ProofData = { proof, annotations }
+
+export async function getProofSource(): Promise<string> {
+  const m = await leanSource()
+  return m.default
+}
+
+export default proofData

--- a/src/data/proofs/divisibility-rules-oq-02/meta.json
+++ b/src/data/proofs/divisibility-rules-oq-02/meta.json
@@ -28,13 +28,73 @@
     "assumptions": "0 axiom(s) and 0 sorry(s). Fully verified."
   },
   "overview": {
-    "text": "Since 1000 ≡ -1 (mod 7) and 1000 ≡ -1 (mod 13), divisibility by 7 or 13 can be tested by computing the alternating sum of 3-digit blocks.",
+    "historicalContext": "Divisibility rules are among the oldest results in number theory — rules for 2, 3, 5, 9 appear in medieval European and Indian mathematics. The rule for 11 (alternating digit sum) was known by the 13th century. The rule for 7 is less elementary: since no power of 10 has a simple period mod 7, a digit-by-digit test is not straightforward. The 3-digit block alternating sum rule for 7 follows from the observation that 1000 ≡ -1 (mod 7), a fact equivalent to 1001 = 7 × 143 = 7 × 11 × 13. This shared factorization means the same 3-digit block rule works for both 7 and 13 simultaneously. The general algebraic framework — b ≡ -1 (mod d) implies alternating b-ary block sums test divisibility by d — unifies all such rules.",
+    "problemStatement": "Prove that a natural number n is divisible by 7 (resp. 13) if and only if the alternating sum of its 3-digit blocks is divisible by 7 (resp. 13). More generally, for any d and base b with b ≡ -1 (mod d), prove d | n ↔ d | altDigitSum(b, n).",
+    "proofStrategy": "The key is the congruence identity: for b ≡ -1 (mod d), every number n satisfies n ≡ altDigitSum(b, n) (mod d). This follows from the base-b expansion n = ∑ aᵢ·bⁱ and the substitution bⁱ ≡ (-1)ⁱ (mod d). Once this congruence is established (delegated to `modEq_alternating_digits_sum` from the parent DivisibilityRules file), the divisibility equivalence follows immediately: d | n iff d | (n - altDigitSum) + altDigitSum iff d | altDigitSum.",
+    "text": "Since 1000 ≡ -1 (mod 7) and 1000 ≡ -1 (mod 13), divisibility by 7 or 13 can be tested by computing the alternating sum of 3-digit blocks. The Lean formalization proves the general rule `dvd_iff_dvd_altDigitSum` for any base b ≡ -1 (mod d), then instantiates it for d ∈ {7, 13, 11, 101}.",
     "keyInsights": [
-      "1000 ≡ -1 (mod 7): enables 3-digit block alternating sum for divisibility by 7",
-      "1000 ≡ -1 (mod 13): same block structure works for divisibility by 13",
-      "General principle: when b ≡ -1 (mod d), alternating block sums in base b test divisibility by d"
+      "1000 ≡ -1 (mod 7): enables 3-digit block alternating sum for divisibility by 7 — verified in one step by `native_decide`",
+      "1000 ≡ -1 (mod 13): same block structure works for divisibility by 13, since 7 × 11 × 13 = 1001 = 1000 + 1",
+      "General principle: when b ≡ -1 (mod d), alternating block sums in base b test divisibility by d — proved as `dvd_iff_dvd_altDigitSum`",
+      "The reason 7 and 13 share the 3-digit rule is that both divide 1001: their product with 11 is 1001 = 1000 + 1, so 1000 ≡ -1 simultaneously mod 7, 11, and 13",
+      "All classical divisibility rules of this type (div-by-11 via alternating digits, div-by-7/13 via 3-digit blocks, div-by-101 via 2-digit blocks) are instances of one algebraic theorem — the Lean proof unifies them as a single 1-line delegation per case"
     ]
   },
+  "sections": [
+    {
+      "id": "key-congruence-seven",
+      "title": "Foundation: 1000 ≡ -1 (mod 7)",
+      "startLine": 36,
+      "endLine": 52,
+      "summary": "Proves thousand_mod_seven (1000 % 7 = 6) by native_decide, then uses modEq_alternating_digits_sum to prove seven_modEq_altDigitSum_1000: n ≡ altDigitSum 1000 n (mod 7).",
+      "mathContext": "$1000 \\equiv -1 \\pmod 7$ (verified numerically). The parent lemma then gives $n \\equiv \\text{altDigitSum}_{1000}(n) \\pmod 7$."
+    },
+    {
+      "id": "general-rule",
+      "title": "General Alternating Block Divisibility Rule",
+      "startLine": 54,
+      "endLine": 77,
+      "summary": "dvd_iff_dvd_altDigitSum: the key theorem unifying all instances. For any d > 0 and b with b % d = d - 1, proves d | n ↔ d | altDigitSum b n. seven_dvd_iff_altDigitSum is the direct instance.",
+      "mathContext": "If $b \\equiv -1 \\pmod d$, then $d \\mid n \\iff d \\mid \\text{altDigitSum}_b(n)$. The proof uses $n \\equiv \\text{altDigitSum}_b(n) \\pmod d$ and linearity of divisibility."
+    },
+    {
+      "id": "divisibility-thirteen",
+      "title": "Divisibility by 13: Same Block Structure",
+      "startLine": 79,
+      "endLine": 95,
+      "summary": "thousand_mod_thirteen (1000 % 13 = 12) by native_decide, leading to thirteen_dvd_iff_altDigitSum: same 3-digit block rule works for 13 since 1000 ≡ -1 (mod 13).",
+      "mathContext": "$1000 \\equiv -1 \\pmod{13}$ (since $1001 = 7 \\times 11 \\times 13$). The shared rule for 7 and 13 arises from their common factor in $1001$."
+    },
+    {
+      "id": "further-instances",
+      "title": "Further Instances: 11, 101, and Concrete Examples",
+      "startLine": 100,
+      "endLine": 124,
+      "summary": "Concrete examples via native_decide (7 | 1001, 7 | 2002, ¬7 | 1234567). Then eleven_dvd_iff_altDigitSum (classical alt-digit rule) and hundredone_dvd_iff_altDigitSum (2-digit blocks for 101) as 1-line instances of the general theorem.",
+      "mathContext": "All instances use the same `dvd_iff_dvd_altDigitSum` with: $(11, 10)$ for single-digit alternating sums, $(101, 100)$ for 2-digit blocks."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully verified (0 sorries, 0 axioms) formalization of alternating block divisibility rules. The central theorem `dvd_iff_dvd_altDigitSum` unifies four classical rules under one algebraic roof, with each instance proved in one line.",
+    "implications": "The shared 3-digit block rule for 7 and 13 is not a coincidence — it follows from 7 × 11 × 13 = 1001. This algebraic view reveals that 'divisibility tricks' are not independent facts but instances of a single modular arithmetic principle. The Lean proof makes this structure explicit and machine-verified.",
+    "openQuestions": [
+      "Is there a divisibility rule for any prime p using blocks of length k, where 10^k ≡ ±1 (mod p)? For which primes does such a k exist?",
+      "Can the DivisibilityRules parent file be generalized to arbitrary number bases beyond base 10, giving divisibility rules in binary, hexadecimal, etc.?",
+      "Is the alternating sum rule the most efficient divisibility test for 7 in terms of number of digit operations, or are there faster single-pass algorithms?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "divisibility-rules",
+      "relationship": "extends",
+      "description": "The parent DivisibilityRules file provides altDigitSum, modEq_alternating_digits_sum, and dvd_iff_dvd_digits_sum (for OQ-01). OQ-02 builds on these to prove the 7/13/11/101 instances."
+    },
+    {
+      "targetId": "divisibility-rules-oq-01",
+      "relationship": "sibling",
+      "description": "OQ-01 proves the digit-sum rules (9 | n ↔ 9 | digitSum(n)) from a different congruence structure (10 ≡ 1 mod 9). OQ-02 proves the alternating-sum rules (b ≡ -1 mod d) in contrast."
+    }
+  ],
   "leanFile": {
     "imports": [
       "Proofs.DivisibilityRules"


### PR DESCRIPTION
Two enrichment passes on `feature/enricher-2`.

---

## 1. bertrands-postulate-oq-03-oq-04-oq-03 (quality 43 → annotations missing)

**5 new annotations** covering all proof sections:
- Module context: filter algebra structure and why it fails for short intervals
- `log_ratio_tendsto_one`: log(x)/log((1+c)x) → 1 via `Real.log_mul` and `div_atTop`
- `pnt_at_scaled_point`: PNT filter composition + log ratio multiplication
- `pnt_density_long_interval`: linear combination of two PNT estimates via `const_mul` + `sub`
- `pnt_density_gap_summary`: proved vs open prime gap density

Created `index.ts` for gallery registration.

---

## 2. binomial-theorem-oq-02-oq-01-oq-03 (quality 83)

Added `relatedConcepts` and `prerequisites` to all 4 annotations (missing in all):
- Covers multinomial PMF normalization, fiber grouping, MGF differentiation, covariance formula