### PR TITLE
Research: cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01 — restore hMCT proof (3→2 sorries)

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean
@@ -257,10 +257,56 @@ theorem rn_deriv_memLq (p q : ℝ≥0∞) (hp1 : 1 < p) (hptop : p ≠ ⊤)
   -- MCT (lintegral_iSup) gives ∫⁻ ‖g‖₊^q = ⨆_n ∫⁻ ‖gn n‖₊^q ≤ M^q.
   have hMCT : ∫⁻ a, (‖g a‖₊ : ℝ≥0∞) ^ q.toReal ∂μ =
       ⨆ n, ∫⁻ a, (‖gn n a‖₊ : ℝ≥0∞) ^ q.toReal ∂μ := by
-    -- |gn n a|^q is monotone increasing in n: min(|g|, n) ≤ min(|g|, n+1) ≤ |g|
-    -- sup_n |gn n a|^q = |g a|^q (sequence is eventually constant once n ≥ |g a|)
-    -- Therefore lintegral_iSup applies
-    sorry -- MCT: lintegral_iSup + pointwise monotonicity + sup = limit
+    -- Sub-lemma 1: |max(min(r,n), -n)| = min(|r|, n) for r : ℝ, n : ℕ
+    have abs_clamp : ∀ (r : ℝ) (n : ℕ), |max (min r n) (-(n : ℝ))| = min |r| n := by
+      intro r n
+      have hn : (0 : ℝ) ≤ n := Nat.cast_nonneg n
+      rcases le_or_lt r (-(n : ℝ)) with h1 | h1
+      · -- r ≤ -n: gn = -n, |gn| = n = min |r| n (since |r| = -r ≥ n)
+        have h1' : r ≤ n := h1.trans (by linarith)
+        rw [min_eq_left h1', max_eq_right h1, abs_neg, abs_of_nonneg hn,
+            abs_of_nonpos (h1.trans (by linarith)), min_eq_right (by linarith)]
+      rcases le_or_lt (n : ℝ) r with h2 | h2
+      · -- r ≥ n ≥ 0: gn = n, |gn| = n = min |r| n (since |r| = r ≥ n)
+        rw [min_eq_right h2, max_eq_left (by linarith), abs_of_nonneg hn,
+            abs_of_nonneg (hn.trans h2), min_eq_right h2]
+      · -- -n < r < n: gn = r, |gn| = |r| = min |r| n (since |r| < n)
+        rw [min_eq_left (le_of_lt h2), max_eq_left (le_of_lt h1),
+            min_eq_left (abs_le.mpr ⟨by linarith, by linarith⟩)]
+    -- Sub-lemma 2: ⨆ n : ℕ, min x n = x for x : ℝ≥0∞
+    have sup_min : ∀ (x : ℝ≥0∞), ⨆ n : ℕ, min x n = x := fun x => by
+      rcases eq_or_ne x ⊤ with rfl | hx
+      · simp [min_eq_right le_top, ENNReal.iSup_natCast]
+      · apply le_antisymm (iSup_le fun n => min_le_left x n)
+        obtain ⟨N, hN⟩ := ENNReal.exists_nat_gt hx
+        calc x = min x N := (min_eq_left (le_of_lt hN)).symm
+          _ ≤ ⨆ n : ℕ, min x n := le_iSup _ N
+    -- Sub-lemma 3: (‖gn n a‖₊ : ℝ≥0∞) = min (‖g a‖₊ : ℝ≥0∞) n
+    have norm_gn_eq : ∀ (a : α) (n : ℕ), (‖gn n a‖₊ : ℝ≥0∞) = min (‖g a‖₊ : ℝ≥0∞) n := by
+      intro a n
+      rw [← ENNReal.coe_min]
+      congr 1
+      apply NNReal.coe_injective
+      push_cast [Real.norm_eq_abs]
+      simp only [gn]
+      exact abs_clamp (g a) n
+    -- Sub-lemma 4: (‖g a‖₊)^q = ⨆ n, (min (‖g a‖₊) n)^q via orderIsoRpow.map_iSup
+    have ptwise_eq : ∀ a, (‖g a‖₊ : ℝ≥0∞) ^ q.toReal =
+        ⨆ n : ℕ, (min (‖g a‖₊ : ℝ≥0∞) n) ^ q.toReal := by
+      intro a
+      have h := (ENNReal.orderIsoRpow q.toReal hq_pos).map_iSup
+          (fun n : ℕ => min (‖g a‖₊ : ℝ≥0∞) n)
+      simp only [ENNReal.orderIsoRpow_apply] at h
+      rw [sup_min (‖g a‖₊)] at h
+      exact h
+    -- Main: rewrite LHS as ∫⁻ iSup, apply lintegral_iSup, then match RHS via norm_gn_eq
+    rw [show (fun a => (‖g a‖₊ : ℝ≥0∞) ^ q.toReal) =
+        (fun a => ⨆ n : ℕ, (min (‖g a‖₊ : ℝ≥0∞) n) ^ q.toReal) from funext ptwise_eq,
+        lintegral_iSup
+          (fun n => (hg_meas.nnnorm.coe_nnreal_ennreal.min measurable_const).pow_const q.toReal)
+          (fun ⦃m n⦄ hmn a => ENNReal.rpow_le_rpow
+            (min_le_min_left _ (Nat.cast_le.mpr hmn)) (le_of_lt hq_pos))]
+    simp_rw [← norm_gn_eq]
   -- Conclude Memℒp: eLpNorm g q μ ≤ ENNReal.ofReal M < ⊤
   refine ⟨hg_meas.aestronglyMeasurable, lt_of_le_of_lt ?_ ENNReal.ofReal_lt_top⟩
   rw [eLpNorm_eq_lintegral_rpow_nnnorm hq0 hqtop]

--- a/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/knowledge.md
+++ b/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/knowledge.md
@@ -1,0 +1,103 @@
+# cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01: Riesz Lp Surjectivity via Radon-Nikodým
+
+**Problem**: Can Mathlib's RN machinery (SignedMeasure.rnDeriv) prove that every φ ∈ (Lp)* is represented by integration against some g ∈ Lq?
+
+**Status**: PROGRESS — hMCT re-proved (3→2 sorries); 2 hard sorries remain
+
+**Lean file**: `Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean`
+
+---
+
+## Session 2026-04-14 (Session 3) — Restore hMCT proof (3→2 sorries)
+
+**Mode**: REVISIT
+**Outcome**: progress
+
+### What I Did
+
+1. **Restored hMCT proof** in `rn_deriv_memLq`:
+   - PR #10765 proved this sorry; PR #10806 accidentally reverted it
+   - Re-applied the exact proof from #10765 commit c0a5d8fe5c
+   - Sub-lemmas: `abs_clamp` (3-case analysis on clamping), `sup_min` (⨆ n, min x n = x in ℝ≥0∞), `norm_gn_eq` (‖gₙ‖₊ = min ‖g‖₊ n as ENNReal), `ptwise_eq` (orderIsoRpow.map_iSup)
+   - Assembly: lintegral_iSup with measurability + monotonicity + simp_rw
+2. **Updated meta.json**: sorries 3→2, lineCount 524→570
+3. **Architecture note**: `truncated_rn_deriv_lq_bound` has wrong hypotheses (set-function bound insufficient); `rn_deriv_memLq` depends on this sorry
+
+### Key Findings
+- `truncated_rn_deriv_lq_bound` as stated may be false: set-function bound |s(E)| ≤ M·μ(E)^{1/p} does not imply ‖gₙ‖_q ≤ M without extending to full Lp functional
+- hMCT proof is sound; the sorry it proves is genuine mathematical content (monotone convergence for clamped functions)
+- 2 sorries remain: `truncated_rn_deriv_lq_bound` (needs correct hypothesis or replacement) and `riesz_lp_surjective_from_rn` (full assembly)
+
+### Files Modified
+- `proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean` (hMCT: sorry→proof, +46 lines)
+- `src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json` (sorries 3→2)
+
+### Next Steps
+1. Fix `truncated_rn_deriv_lq_bound`: change hypothesis from set-function bound to direct functional bound ‖φ‖ ≤ M, then prove Hölder extremizer argument (~60 lines)
+2. Alternatively: add `lq_norm_bound_from_functional` as a new intermediate lemma with the correct hypothesis
+3. Once `truncated_rn_deriv_lq_bound` (or replacement) is proved, `rn_deriv_memLq` becomes sorry-free
+4. Final target: prove `riesz_lp_surjective_from_rn` (~80 lines of signed measure construction + assembly)
+
+---
+
+## Session 2026-04-14 (Session 2) — MCT + rn_deriv_memLq_from_trunc
+
+**Mode**: REVISIT
+**Outcome**: progress
+
+### What I Did
+
+1. **Proved `hMCT`** in `rn_deriv_memLq`:
+   - Goal: `∫⁻ a, ‖g a‖₊^q ∂μ = ⨆ n, ∫⁻ a, ‖gₙ a‖₊^q ∂μ`
+   - Method: `lintegral_iSup` with:
+     - Measurability: `(hg_meas.nnnorm.coe_nnreal_ennreal.min measurable_const).pow_const q.toReal`
+     - Monotonicity: `min_le_min_left _ (Nat.cast_le.mpr hmn)` + `ENNReal.rpow_le_rpow`
+     - Pointwise sup: `ENNReal.orderIsoRpow.map_iSup` + `sup_min` (⨆ min x n = x)
+   - Key sub-lemmas: `abs_clamp` (|max(min r n, -n)| = min|r| n), `norm_gn_eq` (‖gₙ‖₊ = min ‖g‖₊ n)
+
+2. **Added `rn_deriv_memLq_from_trunc`** (complete, 0 sorries):
+   - Takes `hgn_snorm : ∀ n, eLpNorm (fun a => max(min(g a)(n:ℝ))(-(n:ℝ))) q μ ≤ ENNReal.ofReal M`
+   - Returns `Memℒp g q μ` via MCT
+   - Bypasses the FALSE `truncated_rn_deriv_lq_bound` pathway
+   - This is the correct building block for `riesz_lp_surjective_from_rn`
+
+3. **Identified `truncated_rn_deriv_lq_bound` as FALSE**:
+   - Counterexample: g = x^{-1/q} on [0,1] with Lebesgue measure, p = q = 2
+   - The set function bound |s(E)| ≤ M·μ(E)^{1/p} does NOT bound ‖gₙ‖_q
+   - The correct bound comes from φ ∈ (Lp)* directly (via Hölder extremizer)
+
+4. **Updated `riesz_lp_surjective_from_rn`** with detailed proof sketch:
+   - σ-additive signed measure ν(E) = φ(1_E) (SORRY 1, hard)
+   - Hölder extremizer: ‖gₙ‖_q ≤ ‖φ‖ (SORRY 2, hard)
+   - Then apply `rn_deriv_memLq_from_trunc` and `integral_representation`
+
+5. **Sorry count**: 3 → 2 (hMCT proved; `truncated_rn_deriv_lq_bound` kept as warning)
+
+### Key Findings
+
+- `lintegral_iSup` needs: (1) measurability of each integrand, (2) monotonicity in n, (3) write integrand as iSup
+- The critical lemma chain: `abs_clamp` → `norm_gn_eq` → `ENNReal.orderIsoRpow.map_iSup` → MCT
+- `ENNReal.orderIsoRpow` is an order isomorphism that commutes with iSup: perfect for raising norm_gn_eq to q-th power
+- `truncated_rn_deriv_lq_bound` uses WRONG hypotheses — the correct version needs φ directly
+
+### Files Modified
+
+- Modified: `proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean`
+  - Added `rn_deriv_memLq_from_trunc` (complete, ~70 lines)
+  - Proved `hMCT` in `rn_deriv_memLq` (replacing sorry)
+  - Updated `riesz_lp_surjective_from_rn` with proof sketch
+
+### Next Steps
+
+1. **Prove σ-additive signed measure construction** (~80 lines):
+   - Define ν(E) = φ(1_E) for finite E
+   - σ-additivity: use Lp-convergence `1_{∪ Eₙ} - Σ_{k≤N} 1_{Eₖ} → 0 in Lp` → continuity of φ
+   - Absolute continuity: `functionalSetFn_null` already proved
+
+2. **Prove Hölder extremizer bound** (~40 lines):
+   - For each n: hₙ = sign(gₙ)|gₙ|^{q-1} ∈ Lp (bounded)
+   - ‖gₙ‖_q^q = ∫ hₙ gₙ ≤ ∫ hₙ g = φ(hₙ) ≤ ‖φ‖·‖hₙ‖_p = ‖φ‖·‖gₙ‖_q^{q/p}
+   - Divide: ‖gₙ‖_q ≤ ‖φ‖
+   - Then call `rn_deriv_memLq_from_trunc p q hp1 hptop hpq g hg_meas ‖φ‖ hgn_bound`
+
+3. **Once both done**: apply `integral_representation` for the final assembly

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -14,10 +14,10 @@
       "measure-theory"
     ],
     "badge": "wip",
-    "sorries": 3,
+    "sorries": 2,
     "axiomCount": 0,
-    "lineCount": 524,
-    "assumptions": "3 remaining sorries: (1) truncated_rn_deriv_lq_bound — Hölder extremizer uniform bound for truncations (sub-goal 5b); (2) rn_deriv_memLq MCT step — lintegral_iSup monotone convergence + pointwise monotonicity; (3) riesz_lp_surjective_from_rn — signed measure construction + full assembly. Proved: integrationCLM, integrationCLM_apply, lintegral_mul_le_of_memLp, integrable_mul_of_memLp, truncated_rn_deriv_memLq (sub-goal 5a), integral_representation (all 3 Lp.induction cases), holder_test_sign_property, memLq_of_uniform_truncation_bound (MCT lemma for clean architecture).",
+    "lineCount": 570,
+    "assumptions": "2 remaining sorries: (1) truncated_rn_deriv_lq_bound — Hölder extremizer uniform bound for truncations, set-function bound hypothesis may be insufficient (needs direct functional bound); (2) riesz_lp_surjective_from_rn — signed measure construction + full assembly. Proved: integrationCLM, integrationCLM_apply, lintegral_mul_le_of_memLp, integrable_mul_of_memLp, truncated_rn_deriv_memLq (sub-goal 5a), integral_representation (all 3 Lp.induction cases), rn_deriv_memLq MCT step (lintegral_iSup + monotonicity + abs_clamp + sup_min sub-lemmas).",
     "dateAdded": "2026-04-13"
   },
   "overview": {
@@ -106,7 +106,7 @@
     "imports": [
       "Mathlib"
     ],
-    "lineCount": 524,
+    "lineCount": 570,
     "axiomCount": 0,
     "theoremCount": 15,
     "definitionCount": 2,
@@ -119,7 +119,7 @@
       {
         "name": "rn_deriv_memLq",
         "type": "core",
-        "description": "RN derivative is in Lq — MCT step (lintegral_iSup + pointwise monotonicity) still has sorry"
+        "description": "RN derivative is in Lq via MCT — proved via abs_clamp, sup_min, norm_gn_eq, ptwise_eq, lintegral_iSup (depends on truncated_rn_deriv_lq_bound sorry)"
       },
       {
         "name": "integral_representation",
@@ -133,6 +133,6 @@
       }
     ],
     "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-    "sorries": 3
+    "sorries": 2
   }
 }

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
@@ -29,12 +29,13 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 3 sorries remain (truncated_rn_deriv_lq_bound, rn_deriv_memLq, riesz_lp_surjective_from_rn). Proved: integrationCLM, integral_representation via Lp.induction (all 3 cases), truncated_rn_deriv_memLq, lintegral_mul_le_of_memLp, integrable_mul_of_memLp.",
+    "progressSummary": "PROGRESS: 2 sorries remain — truncated_rn_deriv_lq_bound (wrong hypothesis) and riesz_lp_surjective_from_rn (full assembly)",
     "builtItems": [
       "integral_representation indicator case: proved (Lp.ext_iff + indicatorConstLp_coeFn + integral_smul chain)",
       "integrationCLM: CLM f↦∫fg via LinearMap.mkContinuous + Hölder bound (no sorry)",
       "integrationCLM_apply: proved (simp unfold)",
-      "integral_representation addition+closedness: proved (linearity + isClosed_eq)"
+      "integral_representation addition+closedness: proved (linearity + isClosed_eq)",
+      "Restored hMCT proof in rn_deriv_memLq (3→2 sorry statements)"
     ],
     "insights": [
       "Mathlib HAS Radon-Nikodym (MeasureTheory.Measure.Decomposition.rnDeriv) but NOT the composition with Lp for Riesz",
@@ -42,7 +43,8 @@
       "Embedding direction (Lq → (Lp)*) proved via Holder (ENNReal.lintegral_mul_le_Lp_mul_Lq)",
       "Surjectivity gap: need (1) φ∈(Lp)* → signed measure ν, (2) ν≪μ, (3) RN deriv g∈Lq, (4) ‖g‖_q=‖φ‖",
       "Estimated 200-500 lines of composition code needed — beyond single session scope",
-      "Gap is infrastructure composition, not fundamental mathematical obstacle"
+      "Gap is infrastructure composition, not fundamental mathematical obstacle",
+      "hMCT proof (abs_clamp + sup_min + norm_gn_eq + ptwise_eq + lintegral_iSup) was in PR #10765 but reverted by PR #10806; restored in Session 3"
     ],
     "mathlibGaps": [
       "MeasureTheory: Lp functional → signed measure construction not formalized",


### PR DESCRIPTION
## Summary

Research session for cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01 (Riesz Lp Surjectivity via Radon-Nikodým).

## Progress

Restored the `hMCT` proof in `rn_deriv_memLq` that was accidentally reverted by PR #10806.

**Sorry count: 3 → 2**

Sub-lemmas proved:
- `abs_clamp`: |max(min(r,n),-n)| = min(|r|,n) — 3-case real arithmetic
- `sup_min`: ⨆ n : ℕ, min x n = x in ℝ≥0∞ — via ENNReal.exists_nat_gt
- `norm_gn_eq`: (‖gₙ a‖₊ : ℝ≥0∞) = min ‖g a‖₊ n — NNReal.coe_injective + push_cast
- `ptwise_eq`: ‖g a‖₊^q = ⨆ n, (min ‖g a‖₊ n)^q — orderIsoRpow.map_iSup
- Assembly via `lintegral_iSup` with measurability + monotonicity

## Files Modified
- `proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean` (+46 lines)
- `src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json` (sorries 3→2)

## Status
**Remaining sorries**: 2 — `truncated_rn_deriv_lq_bound` + `riesz_lp_surjective_from_rn`

🤖 Generated by researcher-3