### PR TITLE
Fix: audit sorry count mismatches (batch 3) — 3 proofs

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3059,10 +3059,10 @@
       "result": "issues-fixed"
     },
     "erdos-117-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-03T17:41:00Z",
-      "result": "clean"
+      "lastAudited": "2026-04-14T22:22:03Z",
+      "result": "issues-fixed"
     },
     "erdos-1170": {
       "agentId": "auditor-cycle-20-batch",
@@ -7360,9 +7360,9 @@
     },
     "erdos-73": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:22:10Z",
-      "result": "clean"
+      "auditCount": 3,
+      "lastAudited": "2026-04-14T22:21:55Z",
+      "result": "issues-fixed"
     },
     "erdos-730": {
       "agentId": "auditor-cycle-20-batch",
@@ -12384,8 +12384,8 @@
       "issues": []
     },
     "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-14T00:06:55Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-14T21:23:28Z",
       "result": "issues-fixed",
       "issues": []
     },
@@ -12408,8 +12408,8 @@
       "issues": []
     },
     "erdos-109-oq-01": {
-      "auditCount": 6,
-      "lastAudited": "2026-04-14T00:22:09Z",
+      "auditCount": 7,
+      "lastAudited": "2026-04-14T22:22:03Z",
       "result": "issues-fixed",
       "issues": []
     },
@@ -12596,6 +12596,30 @@
     "law-of-cosines-oq-06": {
       "auditCount": 1,
       "lastAudited": "2026-04-14T18:00:25Z",
+      "result": "issues-found",
+      "issues": []
+    },
+    "binomial-theorem-oq-02-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-14T21:26:29Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-schwarz-integral-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-14T21:26:29Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-181-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-14T21:26:29Z",
+      "result": "clean",
+      "issues": []
+    },
+    "bezout-identity-oq-02-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-14T21:26:42Z",
       "result": "issues-found",
       "issues": []
     }

--- a/src/data/proofs/erdos-109-oq-01/meta.json
+++ b/src/data/proofs/erdos-109-oq-01/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "erdos-109-oq-01",
-  "title": "Erdős Sumset Conjecture: Gap Conditions and IP Sets",
+  "title": "Erd\u0151s Sumset Conjecture: Gap Conditions and IP Sets",
   "slug": "erdos-109-oq-01",
-  "description": "Explores gap conditions in the Erdős sumset conjecture (B+C subset of A). Defines syndetic, thick, piecewise syndetic sets. States gap-controlled sumset decomposition, syndetic sumset question, and connection to IP sets and Hindman's theorem.",
+  "description": "Explores gap conditions in the Erd\u0151s sumset conjecture (B+C subset of A). Defines syndetic, thick, piecewise syndetic sets. States gap-controlled sumset decomposition, syndetic sumset question, and connection to IP sets and Hindman's theorem.",
   "meta": {
     "author": "Lean Genius",
     "sourceUrl": "https://erdosproblems.com/109",
@@ -17,10 +17,10 @@
       "ip-sets"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "dateAdded": "2026-04-12",
-    "axiomCount": 4,
-    "assumptions": "1 formal axiom + 2 sorry'd theorems (counted as 4 total assumptions): (1) hindman_theorem — formal axiom; Hindman 1974 finite coloring gives monochromatic IP set; (2) upperDensity_shift — sorry; shift invariance of upper density (needs Filter.limsup manipulation); (3) posUpperDensity_piecewiseSyndetic — sorry; positive density implies piecewise syndetic (classical, pigeonhole); (4) posUpperDensity_ipStar — sorry; positive density implies IP* (Furstenberg-Katznelson IP Szemerédi 1985).",
+    "axiomCount": 3,
+    "assumptions": "3 axiom declarations: hindman_theorem (Hindman 1974 finite coloring gives monochromatic IP set), posUpperDensity_piecewiseSyndetic (positive density implies piecewise syndetic), posUpperDensity_ipStar (positive density implies IP* via Furstenberg-Katznelson IP Szemer\u00e9di theorem 1985). 0 sorries.",
     "lineCount": 487,
     "theoremCount": 7,
     "definitionCount": 10,
@@ -37,12 +37,12 @@
     ]
   },
   "overview": {
-    "historicalContext": "The Erdős sumset conjecture (Problem #109) asked whether every set $A \\subseteq \\mathbb{N}$ with positive upper density contains a sumset $B + C$ with both $B$ and $C$ infinite. This was proved by Moreira, Richter, and Robertson in 2019 using ergodic-theoretic methods — specifically, the Furstenberg correspondence principle and measure-preserving dynamical systems. Their proof actually showed something stronger: $B$ can have arbitrarily prescribed gaps. This open question explores what further gap control is possible. The concept of syndetic sets (bounded gaps) goes back to Gottschalk and Hedlund's work on topological dynamics (1955), while Hindman's theorem on IP sets (1974) is one of the deepest results in Ramsey theory, originally proved by a massive combinatorial argument and later reproved by Furstenberg and Katznelson (1985) using ultrafilter methods. The interplay between density conditions, gap conditions, and partition regularity (IP/IP*) lies at the heart of modern additive combinatorics.",
-    "problemStatement": "Given $A \\subseteq \\mathbb{N}$ with positive upper density, can the infinite sets $B, C$ in the sumset decomposition $B + C \\subseteq A$ be chosen with specific gap conditions? In particular: (1) Can $B$ be chosen with gaps controlled by an arbitrary function $f$? (YES — Moreira-Richter-Robertson) (2) Can $B$ be chosen to be syndetic (bounded gaps)? (OPEN — likely false)",
-    "proofStrategy": "The formalization first defines the hierarchy of gap conditions — syndetic (bounded gaps), thick (arbitrarily long runs), and piecewise syndetic (their intersection) — then states two conjectures: the gap-controlled version (proved by MRR) and the syndetic version (open). The connection to Hindman's theorem is formalized by defining IP sets (all finite sums from an infinite sequence), axiomatizing Hindman's theorem, and proving that IP sets contain infinite sumsets $B + C$ by splitting the generating sequence into odd- and even-indexed subsequences.",
+    "historicalContext": "The Erd\u0151s sumset conjecture (Problem #109) asked whether every set $A \\subseteq \\mathbb{N}$ with positive upper density contains a sumset $B + C$ with both $B$ and $C$ infinite. This was proved by Moreira, Richter, and Robertson in 2019 using ergodic-theoretic methods \u2014 specifically, the Furstenberg correspondence principle and measure-preserving dynamical systems. Their proof actually showed something stronger: $B$ can have arbitrarily prescribed gaps. This open question explores what further gap control is possible. The concept of syndetic sets (bounded gaps) goes back to Gottschalk and Hedlund's work on topological dynamics (1955), while Hindman's theorem on IP sets (1974) is one of the deepest results in Ramsey theory, originally proved by a massive combinatorial argument and later reproved by Furstenberg and Katznelson (1985) using ultrafilter methods. The interplay between density conditions, gap conditions, and partition regularity (IP/IP*) lies at the heart of modern additive combinatorics.",
+    "problemStatement": "Given $A \\subseteq \\mathbb{N}$ with positive upper density, can the infinite sets $B, C$ in the sumset decomposition $B + C \\subseteq A$ be chosen with specific gap conditions? In particular: (1) Can $B$ be chosen with gaps controlled by an arbitrary function $f$? (YES \u2014 Moreira-Richter-Robertson) (2) Can $B$ be chosen to be syndetic (bounded gaps)? (OPEN \u2014 likely false)",
+    "proofStrategy": "The formalization first defines the hierarchy of gap conditions \u2014 syndetic (bounded gaps), thick (arbitrarily long runs), and piecewise syndetic (their intersection) \u2014 then states two conjectures: the gap-controlled version (proved by MRR) and the syndetic version (open). The connection to Hindman's theorem is formalized by defining IP sets (all finite sums from an infinite sequence), axiomatizing Hindman's theorem, and proving that IP sets contain infinite sumsets $B + C$ by splitting the generating sequence into odd- and even-indexed subsequences.",
     "keyInsights": [
-      "The odd/even index splitting of an IP set's generating sequence yields two disjoint sub-IP sets whose sumset lands back in the original — this is the constructive core of the ip_set_sumset_structure proof",
-      "Gap-controlled sumset decomposition (arbitrary gap function) is provably true (MRR 2019), but asking for syndetic $B$ (bounded gaps) is likely too strong — the gaps in $A$ itself constrain the gaps in $B$",
+      "The odd/even index splitting of an IP set's generating sequence yields two disjoint sub-IP sets whose sumset lands back in the original \u2014 this is the constructive core of the ip_set_sumset_structure proof",
+      "Gap-controlled sumset decomposition (arbitrary gap function) is provably true (MRR 2019), but asking for syndetic $B$ (bounded gaps) is likely too strong \u2014 the gaps in $A$ itself constrain the gaps in $B$",
       "Positive density does NOT imply containing an IP set: $\\{n : n \\not\\equiv 0 \\pmod{3}\\}$ has density $2/3$ but no IP subset, since any IP set must contain elements summing to a multiple of 3. The correct relationship is IP* (intersecting every IP set)",
       "The hierarchy syndetic $\\subset$ piecewise syndetic $\\subset$ positive density provides increasingly fine structural information, each with different implications for sumset decomposition",
       "Hindman's theorem (axiomatized here) is essential: it bridges finite colorings and infinite combinatorial structure, providing the IP sets that connect density to sumset structure"
@@ -61,14 +61,14 @@
       "title": "Gap Condition Definitions",
       "startLine": 42,
       "endLine": 78,
-      "summary": "Defines the gap condition hierarchy: IsSyndetic (bounded gaps), IsThick (arbitrarily long runs), IsPiecewiseSyndetic (contains intersection of syndetic and thick — corrected from original too-strong definition). Proves syndetic sets are infinite and states (with sorry) that positive density implies piecewise syndetic."
+      "summary": "Defines the gap condition hierarchy: IsSyndetic (bounded gaps), IsThick (arbitrarily long runs), IsPiecewiseSyndetic (contains intersection of syndetic and thick \u2014 corrected from original too-strong definition). Proves syndetic sets are infinite and states (with sorry) that positive density implies piecewise syndetic."
     },
     {
       "id": "sumset-gap-strengthening",
       "title": "Gap-Controlled Sumset Conjectures",
       "startLine": 80,
       "endLine": 115,
-      "summary": "States the gap-controlled sumset conjecture (proved by MRR: arbitrary gap function f) and the open syndetic sumset question (can B have bounded gaps?). Proves sumset_density_constraint (upperDensity C ≤ upperDensity A) via decomposition into shift invariance and monotonicity helper lemmas."
+      "summary": "States the gap-controlled sumset conjecture (proved by MRR: arbitrary gap function f) and the open syndetic sumset question (can B have bounded gaps?). Proves sumset_density_constraint (upperDensity C \u2264 upperDensity A) via decomposition into shift invariance and monotonicity helper lemmas."
     },
     {
       "id": "ip-sets-hindman",
@@ -86,22 +86,22 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization maps the landscape of gap-condition strengthenings of the Erdős sumset conjecture. The gap-controlled version (arbitrary gap function) is stated as proved by MRR, while the syndetic version remains open. The connection to IP sets via Hindman's theorem is formalized, with the key constructive result that IP sets contain infinite sumsets proved by odd/even index splitting. A mathematical correction removes the false claim that positive density implies IP membership, replacing it with the correct IP* relationship.",
-    "implications": "The interplay between density, gap conditions, and Hindman-type partition regularity reveals deep structural constraints on sets of positive density. The IP set connection suggests that proving the syndetic sumset question requires understanding how density interacts with the algebraic structure of $\\beta\\mathbb{N}$ (the Stone-Čech compactification), where IP sets correspond to idempotent ultrafilters. The sumset density constraint is now structurally proved via clean decomposition into shift invariance and monotonicity. The remaining sorries involve either standard real analysis (shift invariance, monotonicity of upper density) or deep ergodic theory (IP Szemerédi, density→PS).",
+    "summary": "This formalization maps the landscape of gap-condition strengthenings of the Erd\u0151s sumset conjecture. The gap-controlled version (arbitrary gap function) is stated as proved by MRR, while the syndetic version remains open. The connection to IP sets via Hindman's theorem is formalized, with the key constructive result that IP sets contain infinite sumsets proved by odd/even index splitting. A mathematical correction removes the false claim that positive density implies IP membership, replacing it with the correct IP* relationship.",
+    "implications": "The interplay between density, gap conditions, and Hindman-type partition regularity reveals deep structural constraints on sets of positive density. The IP set connection suggests that proving the syndetic sumset question requires understanding how density interacts with the algebraic structure of $\\beta\\mathbb{N}$ (the Stone-\u010cech compactification), where IP sets correspond to idempotent ultrafilters. The sumset density constraint is now structurally proved via clean decomposition into shift invariance and monotonicity. The remaining sorries involve either standard real analysis (shift invariance, monotonicity of upper density) or deep ergodic theory (IP Szemer\u00e9di, density\u2192PS).",
     "openQuestions": [
-      "Is the syndetic sumset question true or false? If A has positive density, can B + C ⊆ A always be found with B syndetic?",
-      "Can the density constraint (upperDensity C ≤ upperDensity A given B + C ⊆ A and B syndetic) be proved from Mathlib primitives without the full ergodic machinery?",
-      "Can posUpperDensity_ipStar (positive density implies IP*) be proved directly from Hindman's theorem, or does it require the full Furstenberg-Katznelson IP Szemerédi theorem?"
+      "Is the syndetic sumset question true or false? If A has positive density, can B + C \u2286 A always be found with B syndetic?",
+      "Can the density constraint (upperDensity C \u2264 upperDensity A given B + C \u2286 A and B syndetic) be proved from Mathlib primitives without the full ergodic machinery?",
+      "Can posUpperDensity_ipStar (positive density implies IP*) be proved directly from Hindman's theorem, or does it require the full Furstenberg-Katznelson IP Szemer\u00e9di theorem?"
     ]
   },
   "leanFile": {
     "namespace": "Erdos109OQ01",
     "lineCount": 487,
-    "axiomCount": 4,
+    "axiomCount": 3,
     "theoremCount": 7,
     "definitionCount": 10,
     "path": "Proofs/Erdos109OQ01.lean",
-    "sorries": 2
+    "sorries": 0
   },
   "crossReferences": [
     {
@@ -110,5 +110,5 @@
       "description": "Explores gap conditions for the sumset conjecture proved by MRR (2019)"
     }
   ],
-  "sorries": 2
+  "sorries": 0
 }

--- a/src/data/proofs/erdos-117-oq-01/meta.json
+++ b/src/data/proofs/erdos-117-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-117-oq-01",
   "title": "Exponential Growth Rate of the Abelian Covering Number",
   "slug": "erdos-117-oq-01",
-  "description": "Pyber (1987) proved c₁ⁿ ≤ h(n) ≤ c₂ⁿ for the abelian covering number. Does lim log(h(n))/n exist? If so, h(n) = Θ(cⁿ) for a single constant c. Formalizes the growth rate sequence, proves it is bounded (from Pyber), defines liminf/limsup, and states the convergence question. Connection to Fekete's lemma via submultiplicativity.",
+  "description": "Pyber (1987) proved c\u2081\u207f \u2264 h(n) \u2264 c\u2082\u207f for the abelian covering number. Does lim log(h(n))/n exist? If so, h(n) = \u0398(c\u207f) for a single constant c. Formalizes the growth rate sequence, proves it is bounded (from Pyber), defines liminf/limsup, and states the convergence question. Connection to Fekete's lemma via submultiplicativity.",
   "meta": {
     "author": "Pyber (1987); Isaacs",
     "sourceUrl": "https://erdosproblems.com/117",
@@ -19,30 +19,30 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 1,
     "axiomCount": 3,
-    "assumptions": "3 axiom declarations: h (abelian covering number function), h_pos (h(n) ≥ 1), pyber_bounds (exponential bounds). 2 sorries in analysis lemmas.",
+    "assumptions": "3 axiom declarations: h (abelian covering number function), h_pos (h(n) \u2265 1), pyber_bounds (exponential bounds). 1 sorry in analysis lemmas.",
     "erdosNumber": 117,
     "erdosUrl": "https://erdosproblems.com/117",
     "erdosProblemStatus": "open",
     "lineCount": 204
   },
   "overview": {
-    "historicalContext": "**Pinning Down the Exponential Base**\n\nErdős introduced the abelian covering number h(n) as part of his investigation of commutativity in finite groups. A group G has the n-commuting property if among any n+2 elements, at least two commute — or equivalently, G cannot be partitioned into n+1 pairwise non-commuting pairs. The covering number h(n) asks: what is the minimum size of a cover by abelian subgroups that works for all groups with this property?\n\nThe first exponential lower bound was proved by Isaacs in earlier work. Pyber's landmark 1987 paper established both exponential bounds c₁ⁿ ≤ h(n) ≤ c₂ⁿ with explicit constants satisfying c₂ > c₁ > 1. This settled the 'polynomial vs exponential' question but opened a new one: do the bounds converge to a single exponential base? Knowing the precise base c would give h(n) = Θ(cⁿ) — a clean asymptotic characterization.\n\nThe connection to Fekete's lemma (1923) provides a natural structural approach. Fekete's theorem states that subadditive functions f (with f(m+n) ≤ f(m)+f(n)) satisfy lim f(n)/n = inf f(n)/n. If h is submultiplicative (h(m+n) ≤ h(m)·h(n)), then log h is subadditive and the limit exists. The question of submultiplicativity of h is thus a key open structural problem.",
-    "problemStatement": "**Problem Statement**\n\nDoes lim_{n→∞} log(h(n))/n exist?\n\nIf yes, h(n) = Θ(cⁿ) for c = e^L where L is the limit.\n\n**Status**: OPEN",
+    "historicalContext": "**Pinning Down the Exponential Base**\n\nErd\u0151s introduced the abelian covering number h(n) as part of his investigation of commutativity in finite groups. A group G has the n-commuting property if among any n+2 elements, at least two commute \u2014 or equivalently, G cannot be partitioned into n+1 pairwise non-commuting pairs. The covering number h(n) asks: what is the minimum size of a cover by abelian subgroups that works for all groups with this property?\n\nThe first exponential lower bound was proved by Isaacs in earlier work. Pyber's landmark 1987 paper established both exponential bounds c\u2081\u207f \u2264 h(n) \u2264 c\u2082\u207f with explicit constants satisfying c\u2082 > c\u2081 > 1. This settled the 'polynomial vs exponential' question but opened a new one: do the bounds converge to a single exponential base? Knowing the precise base c would give h(n) = \u0398(c\u207f) \u2014 a clean asymptotic characterization.\n\nThe connection to Fekete's lemma (1923) provides a natural structural approach. Fekete's theorem states that subadditive functions f (with f(m+n) \u2264 f(m)+f(n)) satisfy lim f(n)/n = inf f(n)/n. If h is submultiplicative (h(m+n) \u2264 h(m)\u00b7h(n)), then log h is subadditive and the limit exists. The question of submultiplicativity of h is thus a key open structural problem.",
+    "problemStatement": "**Problem Statement**\n\nDoes lim_{n\u2192\u221e} log(h(n))/n exist?\n\nIf yes, h(n) = \u0398(c\u207f) for c = e^L where L is the limit.\n\n**Status**: OPEN",
     "text": "Formalizes the question of whether the abelian covering number h(n) has a well-defined exponential growth rate.",
-    "proofStrategy": "**Approach**\n\n1. Define growthRate(n) = log(h(n))/n\n2. Prove bounded from Pyber: log(c₁) ≤ growthRate(n) ≤ log(c₂)\n3. Define liminf/limsup\n4. State convergence as liminf = limsup\n5. Connect to Fekete's lemma via submultiplicativity",
+    "proofStrategy": "**Approach**\n\n1. Define growthRate(n) = log(h(n))/n\n2. Prove bounded from Pyber: log(c\u2081) \u2264 growthRate(n) \u2264 log(c\u2082)\n3. Define liminf/limsup\n4. State convergence as liminf = limsup\n5. Connect to Fekete's lemma via submultiplicativity",
     "keyInsights": [
-      "**Bounded growth rate from Pyber**: The bounds c₁ⁿ ≤ h(n) ≤ c₂ⁿ immediately give log(c₁) ≤ log(h(n))/n ≤ log(c₂) for all n ≥ 1. The growth rate sequence is bounded in [log c₁, log c₂], so liminf and limsup both exist. The open question is whether they coincide.",
-      "**Fekete's lemma as the path forward**: If h is submultiplicative (h(m+n) ≤ h(m)·h(n)), then log h is subadditive. Fekete's classical lemma (1923) then guarantees lim log(h(n))/n = inf log(h(n))/n exists. The submultiplicativity question is the key open structural problem.",
-      "**Filter API formalization**: The use of Filter.liminf, Filter.limsup, and Filter.Tendsto with atTop in Lean 4 reflects Mathlib's abstract but powerful filter-based approach to limits, avoiding cumbersome ε-N quantifier chains.",
-      "**Open problems as Lean Props**: The declaration 'def erdos117OQ01 : Prop := exponentialBaseExists' makes the open question a first-class Lean object. Other theorems can formally depend on this Prop, enabling 'assuming Erdős #117-OQ-01, then...' arguments to be machine-checked.",
+      "**Bounded growth rate from Pyber**: The bounds c\u2081\u207f \u2264 h(n) \u2264 c\u2082\u207f immediately give log(c\u2081) \u2264 log(h(n))/n \u2264 log(c\u2082) for all n \u2265 1. The growth rate sequence is bounded in [log c\u2081, log c\u2082], so liminf and limsup both exist. The open question is whether they coincide.",
+      "**Fekete's lemma as the path forward**: If h is submultiplicative (h(m+n) \u2264 h(m)\u00b7h(n)), then log h is subadditive. Fekete's classical lemma (1923) then guarantees lim log(h(n))/n = inf log(h(n))/n exists. The submultiplicativity question is the key open structural problem.",
+      "**Filter API formalization**: The use of Filter.liminf, Filter.limsup, and Filter.Tendsto with atTop in Lean 4 reflects Mathlib's abstract but powerful filter-based approach to limits, avoiding cumbersome \u03b5-N quantifier chains.",
+      "**Open problems as Lean Props**: The declaration 'def erdos117OQ01 : Prop := exponentialBaseExists' makes the open question a first-class Lean object. Other theorems can formally depend on this Prop, enabling 'assuming Erd\u0151s #117-OQ-01, then...' arguments to be machine-checked.",
       "**The gap between c_1 and c_2 encodes structural ignorance**: Pyber's constants satisfy c_1 < c_2, and narrowing this gap is equivalent to tightening the extremal bounds on how efficiently abelian subgroups can cover pairwise non-commuting elements. The exponential base, if it exists, would be a fundamental constant of finite group theory analogous to how Ramsey numbers have conjectured exponential growth rates."
     ],
     "prerequisites": [
       "Group theory: abelian subgroups, covering numbers",
       "Analysis: liminf, limsup, Fekete's lemma",
-      "Familiarity with Erdős Problem #117"
+      "Familiarity with Erd\u0151s Problem #117"
     ]
   },
   "sections": [
@@ -59,7 +59,7 @@
       "title": "Part I: Three Axioms Encoding Pyber's Theorem",
       "startLine": 28,
       "endLine": 48,
-      "summary": "Part I block comment (lines 29-34). Three axiom declarations: h : ℕ → ℕ (line 39), h_pos (line 42), pyber_bounds (lines 45-47). These 3 axioms drive axiomCount=3 and badge='axiom'.",
+      "summary": "Part I block comment (lines 29-34). Three axiom declarations: h : \u2115 \u2192 \u2115 (line 39), h_pos (line 42), pyber_bounds (lines 45-47). These 3 axioms drive axiomCount=3 and badge='axiom'.",
       "mathContext": "$h: \\mathbb{N} \\to \\mathbb{N}$ axiomatized (not constructible). `pyber_bounds`: $\\exists c_1, c_2 > 1,\\; c_1 < c_2 \\wedge \\forall n \\geq 1: c_1^n \\leq h(n) \\leq c_2^n$."
     },
     {
@@ -76,15 +76,15 @@
       "startLine": 99,
       "endLine": 132,
       "summary": "Part III block comment (lines 99-104). Definitions growthRateLimInf and growthRateLimSup using Filter.liminf/limsup with atTop (lines 107-112). Theorem limInf_ge_log_c1 (sorry'd, lines 115-118). Theorem limInf_le_limSup (proved, lines 121-131) using IsBoundedUnder witnesses from the bound theorems.",
-      "mathContext": "$\\text{LimInf} = \\inf\\{L : r(n) \\geq L \\text{ eventually}\\}$, $\\text{LimSup} = \\sup\\{L : r(n) \\leq L \\text{ eventually}\\}$. Both in $[\\log c_1, \\log c_2]$. `limInf_le_limSup` proof: supplies `IsBoundedUnder ≤ atTop growthRate` and `IsCoboundedUnder ≤ atTop growthRate` witnesses."
+      "mathContext": "$\\text{LimInf} = \\inf\\{L : r(n) \\geq L \\text{ eventually}\\}$, $\\text{LimSup} = \\sup\\{L : r(n) \\leq L \\text{ eventually}\\}$. Both in $[\\log c_1, \\log c_2]$. `limInf_le_limSup` proof: supplies `IsBoundedUnder \u2264 atTop growthRate` and `IsCoboundedUnder \u2264 atTop growthRate` witnesses."
     },
     {
       "id": "open-question",
-      "title": "Parts IV–V: Open Question Definitions and Implications",
+      "title": "Parts IV\u2013V: Open Question Definitions and Implications",
       "startLine": 133,
       "endLine": 204,
       "summary": "Part IV (lines 133-164): propositions growthRateConverges, limInfEqLimSup, exponentialBaseExists, theorem limit_determines_base (proved), ExponentialBehavior definition. Part V (lines 172-197): base_implies_behavior (sorry), AsymptoticallyMultiplicative, submultiplicative_implies_convergence (sorry, Fekete), growthRate_1, erdos117OQ01. Lines 199-202: #check statements. Line 204: end namespace.",
-      "mathContext": "Open: $\\exists c > 1,\\; \\lim r(n) = \\log c$ (i.e., $h(n) = \\Theta(c^n)$). The 3 sorries: `limInf_ge_log_c1` (liminf lower bound), `base_implies_behavior` (limit → exponential behavior), `submultiplicative_implies_convergence` (Fekete's lemma). The proved theorem `limit_determines_base` uses `Real.log_exp` to construct $c = e^L$ from the limit $L$."
+      "mathContext": "Open: $\\exists c > 1,\\; \\lim r(n) = \\log c$ (i.e., $h(n) = \\Theta(c^n)$). The 3 sorries: `limInf_ge_log_c1` (liminf lower bound), `base_implies_behavior` (limit \u2192 exponential behavior), `submultiplicative_implies_convergence` (Fekete's lemma). The proved theorem `limit_determines_base` uses `Real.log_exp` to construct $c = e^L$ from the limit $L$."
     }
   ],
   "conclusion": {
@@ -93,34 +93,34 @@
     "openQuestions": [
       "Does lim log(h(n))/n exist?",
       "Is h(n) submultiplicative? (Would give convergence via Fekete)",
-      "What are the best known values of c₁ and c₂?"
+      "What are the best known values of c\u2081 and c\u2082?"
     ]
   },
   "mainTheorems": [
     {
       "name": "growthRate_lower_bound",
       "type": "core",
-      "description": "Growth rate ≥ log(c₁) > 0 for all n ≥ 1",
-      "leanType": "∃ L > 0, ∀ n ≥ 1, growthRate n ≥ L"
+      "description": "Growth rate \u2265 log(c\u2081) > 0 for all n \u2265 1",
+      "leanType": "\u2203 L > 0, \u2200 n \u2265 1, growthRate n \u2265 L"
     },
     {
       "name": "growthRate_upper_bound",
       "type": "core",
-      "description": "Growth rate ≤ log(c₂) for all n ≥ 1",
-      "leanType": "∃ U, ∀ n ≥ 1, growthRate n ≤ U"
+      "description": "Growth rate \u2264 log(c\u2082) for all n \u2265 1",
+      "leanType": "\u2203 U, \u2200 n \u2265 1, growthRate n \u2264 U"
     },
     {
       "name": "submultiplicative_implies_convergence",
       "type": "supporting",
-      "description": "Submultiplicativity of h → convergence (Fekete's lemma)",
-      "leanType": "submultiplicative → growthRateConverges"
+      "description": "Submultiplicativity of h \u2192 convergence (Fekete's lemma)",
+      "leanType": "submultiplicative \u2192 growthRateConverges"
     }
   ],
   "crossReferences": [
     {
       "targetId": "erdos-117",
       "relationship": "extends",
-      "description": "Extends Erdős #117 by formalizing the exponential growth rate question"
+      "description": "Extends Erd\u0151s #117 by formalizing the exponential growth rate question"
     }
   ],
   "leanFile": {
@@ -139,7 +139,7 @@
     "sorryTheorems": 5,
     "definitionCount": 10,
     "path": "Proofs/Erdos117OQ01.lean",
-    "sorries": 2
+    "sorries": 1
   },
-  "sorries": 2
+  "sorries": 1
 }

--- a/src/data/proofs/erdos-73/meta.json
+++ b/src/data/proofs/erdos-73/meta.json
@@ -1,6 +1,6 @@
 {
   "id": "erdos-73",
-  "title": "Erdős Problem #73: Almost Bipartite Graphs",
+  "title": "Erd\u0151s Problem #73: Almost Bipartite Graphs",
   "slug": "erdos-73",
   "description": "If every subgraph of G has an independent set covering at least half its vertices (minus k), must G be 'almost bipartite' - the union of a bipartite graph and O(1) extra vertices? Reed's 'Mangoes and Blueberries' paper (1999) proves yes.",
   "meta": {
@@ -17,7 +17,7 @@
       "structural-graph-theory"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 1,
     "erdosNumber": 73,
     "erdosUrl": "https://erdosproblems.com/73",
     "erdosProblemStatus": "solved",
@@ -64,12 +64,12 @@
       {
         "id": "erdos-106",
         "relationship": "thematic",
-        "description": "Graph coloring and chromatic number — connected via $\\chi$-boundedness"
+        "description": "Graph coloring and chromatic number \u2014 connected via $\\chi$-boundedness"
       },
       {
         "id": "erdos-47",
         "relationship": "thematic",
-        "description": "Ramsey-type problems in graph theory — similar flavor of local-to-global structural results"
+        "description": "Ramsey-type problems in graph theory \u2014 similar flavor of local-to-global structural results"
       }
     ],
     "axiomCount": 3,
@@ -77,17 +77,17 @@
     "assumptions": "3 axioms: reed_bound, reed_theorem, reed_bound_zero. 0 sorries."
   },
   "overview": {
-    "historicalContext": "**Origins: Independence and Bipartiteness**\n\nThe connection between independence number and bipartiteness is classical: a graph $G$ is bipartite if and only if $\\alpha(G[S]) \\ge |S|/2$ for every induced subgraph $G[S]$. This follows from the odd cycle characterization — an odd cycle $C_{2m+1}$ has $\\alpha = m < (2m+1)/2$, so any non-bipartite graph violates the condition.\n\n**Erdős's Question**\n\nErdős asked a natural structural question: if we relax the condition to $\\alpha(G[S]) \\ge (|S| - k)/2$ for some fixed $k \\ge 0$, must $G$ still be 'close to bipartite'? Specifically, can $G$ be made bipartite by removing at most $f(k)$ vertices, where $f(k)$ depends only on $k$ and not on $|V(G)|$? The power of this question lies in the quantifier structure — a fixed finite bound controlling an arbitrarily large graph.\n\n**Reed's Solution (1999)**\n\nBruce Reed proved the affirmative answer in his paper 'Mangoes and Blueberries' (Combinatorica 1999). The proof uses the Erdős-Pósa theorem for odd cycles: the $k$-independence condition bounds the number of vertex-disjoint odd cycles in $G$, and bounded packing implies a bounded transversal (a set of vertices hitting all odd cycles). Reed's bound is $f(k) \\le 2^k$, but the optimal growth rate remains unknown.\n\n**Significance**\n\nThe result is a prototype for structural graph theory results showing that 'approximate' satisfaction of a property (bipartiteness) forces 'approximate' structure (few exceptional vertices). This paradigm appears throughout the Graph Minors Project of Robertson and Seymour.",
+    "historicalContext": "**Origins: Independence and Bipartiteness**\n\nThe connection between independence number and bipartiteness is classical: a graph $G$ is bipartite if and only if $\\alpha(G[S]) \\ge |S|/2$ for every induced subgraph $G[S]$. This follows from the odd cycle characterization \u2014 an odd cycle $C_{2m+1}$ has $\\alpha = m < (2m+1)/2$, so any non-bipartite graph violates the condition.\n\n**Erd\u0151s's Question**\n\nErd\u0151s asked a natural structural question: if we relax the condition to $\\alpha(G[S]) \\ge (|S| - k)/2$ for some fixed $k \\ge 0$, must $G$ still be 'close to bipartite'? Specifically, can $G$ be made bipartite by removing at most $f(k)$ vertices, where $f(k)$ depends only on $k$ and not on $|V(G)|$? The power of this question lies in the quantifier structure \u2014 a fixed finite bound controlling an arbitrarily large graph.\n\n**Reed's Solution (1999)**\n\nBruce Reed proved the affirmative answer in his paper 'Mangoes and Blueberries' (Combinatorica 1999). The proof uses the Erd\u0151s-P\u00f3sa theorem for odd cycles: the $k$-independence condition bounds the number of vertex-disjoint odd cycles in $G$, and bounded packing implies a bounded transversal (a set of vertices hitting all odd cycles). Reed's bound is $f(k) \\le 2^k$, but the optimal growth rate remains unknown.\n\n**Significance**\n\nThe result is a prototype for structural graph theory results showing that 'approximate' satisfaction of a property (bipartiteness) forces 'approximate' structure (few exceptional vertices). This paradigm appears throughout the Graph Minors Project of Robertson and Seymour.",
     "problemStatement": "**Problem Statement**\n\nLet $k \\ge 0$. Let $G$ be a graph such that every induced subgraph $H$ on $n$ vertices contains an independent set of size $\\ge (n-k)/2$. Must $G$ be the union of a bipartite graph and $O_k(1)$ many vertices?\n\n**Notation**: $O_k(1)$ means a constant depending only on $k$, not on the size of $G$.\n\n**Answer**: YES. Reed proved that such graphs can be decomposed into a bipartite graph plus at most $f(k) \\le 2^k$ additional vertices.",
     "text": "If every subgraph of G has an independent set covering at least half its vertices (minus k), must G be 'almost bipartite' - the union of a bipartite graph and O(1) extra vertices? Reed's 'Mangoes and Blueberries' paper (1999) proves yes.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Graph primitives**: Defines `IsIndependentSet`, `independenceNumber`, `IsBipartite` directly on `SimpleGraph V` with `Fintype V`\n2. **The condition**: `satisfiesIndependenceCondition G k` quantifies over all subsets $S$ of the finite vertex set\n3. **Almost-bipartite structure**: `isAlmostBipartite G bound` and `bipartiteDeficiency G` capture vertex-deletion distance to bipartiteness\n4. **Reed's theorem**: Axiomatized via `reed_bound : ℕ → ℕ` and `reed_theorem`, with `erdos_73_solved` proved by unpacking\n5. **Special cases**: The $k = 0$ base case and $K_3$ example provide concrete verification\n6. **Coloring connection**: Links to chromatic number via $\\chi(G) \\le f(k) + 2$",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Graph primitives**: Defines `IsIndependentSet`, `independenceNumber`, `IsBipartite` directly on `SimpleGraph V` with `Fintype V`\n2. **The condition**: `satisfiesIndependenceCondition G k` quantifies over all subsets $S$ of the finite vertex set\n3. **Almost-bipartite structure**: `isAlmostBipartite G bound` and `bipartiteDeficiency G` capture vertex-deletion distance to bipartiteness\n4. **Reed's theorem**: Axiomatized via `reed_bound : \u2115 \u2192 \u2115` and `reed_theorem`, with `erdos_73_solved` proved by unpacking\n5. **Special cases**: The $k = 0$ base case and $K_3$ example provide concrete verification\n6. **Coloring connection**: Links to chromatic number via $\\chi(G) \\le f(k) + 2$",
     "keyInsights": [
       "**Local-to-global**: The $k$-independence condition is a local property (holds for all subgraphs) that forces a global structure (bipartite plus bounded exceptions)",
       "**Odd cycles as obstructions**: The only obstruction to bipartiteness is odd cycles, and the $k$-independence condition limits how many vertex-disjoint odd cycles can exist",
-      "**Erdős-Pósa connection**: Reed's proof crucially uses the Erdős-Pósa theorem (1965) — bounded packing of odd cycles implies bounded transversal",
-      "**$\\chi$-boundedness**: The result implies $\\chi(G) \\le f(k) + 2$, placing this in the framework of Gyárfás's $\\chi$-bounded graph families",
-      "**Quantifier structure**: The bound $f(k)$ depends only on $k$, not on $|V(G)|$ — this uniformity is the deep content of the theorem",
-      "**Exponential gap**: Reed's bound $f(k) \\le 2^k$ is likely not optimal — whether polynomial bounds suffice is open"
+      "**Erd\u0151s-P\u00f3sa connection**: Reed's proof crucially uses the Erd\u0151s-P\u00f3sa theorem (1965) \u2014 bounded packing of odd cycles implies bounded transversal",
+      "**$\\chi$-boundedness**: The result implies $\\chi(G) \\le f(k) + 2$, placing this in the framework of Gy\u00e1rf\u00e1s's $\\chi$-bounded graph families",
+      "**Quantifier structure**: The bound $f(k)$ depends only on $k$, not on $|V(G)|$ \u2014 this uniformity is the deep content of the theorem",
+      "**Exponential gap**: Reed's bound $f(k) \\le 2^k$ is likely not optimal \u2014 whether polynomial bounds suffice is open"
     ],
     "prerequisites": [
       "Graph theory (vertices, edges, colorings)",
@@ -177,13 +177,13 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #73 asked whether graphs where every subgraph has large independent sets must be 'almost bipartite'. Reed's 1999 proof confirmed this: the $k$-independence condition forces bipartite deficiency at most $f(k) \\le 2^k$. The formalization captures the full chain from definitions through Reed's theorem to the chromatic number corollary.",
-    "implications": "**Theoretical Significance**: **Connections and Significance**\n\n1. **Structural graph theory**: Prototype for 'approximate property implies approximate structure' results, a theme in the Robertson-Seymour Graph Minors Project\n**2. Erdős-Pósa framework**: The proof relies on packing-transversal duality for odd cycles, connecting to a major theme in combinatorics\n3. **$\\chi$-boundedness**: The corollary $\\chi(G) \\le f(k) + 2$ places the result in Gyárfás's theory of $\\chi$-bounded graph classes\n4. **Algorithmic implications**: The bounded deficiency suggests FPT algorithms for recognizing $k$-independence graphs.",
+    "summary": "Erd\u0151s Problem #73 asked whether graphs where every subgraph has large independent sets must be 'almost bipartite'. Reed's 1999 proof confirmed this: the $k$-independence condition forces bipartite deficiency at most $f(k) \\le 2^k$. The formalization captures the full chain from definitions through Reed's theorem to the chromatic number corollary.",
+    "implications": "**Theoretical Significance**: **Connections and Significance**\n\n1. **Structural graph theory**: Prototype for 'approximate property implies approximate structure' results, a theme in the Robertson-Seymour Graph Minors Project\n**2. Erd\u0151s-P\u00f3sa framework**: The proof relies on packing-transversal duality for odd cycles, connecting to a major theme in combinatorics\n3. **$\\chi$-boundedness**: The corollary $\\chi(G) \\le f(k) + 2$ places the result in Gy\u00e1rf\u00e1s's theory of $\\chi$-bounded graph classes\n4. **Algorithmic implications**: The bounded deficiency suggests FPT algorithms for recognizing $k$-independence graphs.",
     "openQuestions": [
       "What is the optimal growth rate of $f(k)$? Is $f(k) = O(k)$ or $f(k) = O(\\text{poly}(k))$?",
-      "Can the Erdős-Pósa constant for odd cycles be improved to give better bounds?",
+      "Can the Erd\u0151s-P\u00f3sa constant for odd cycles be improved to give better bounds?",
       "Is there a polynomial-time algorithm to find the minimum odd cycle transversal for graphs satisfying the $k$-independence condition?",
-      "Complete the 5 remaining sorries: trivial_case, bipartite_deficiency_zero, strict_implies_bipartite, K3_violates_strict, K3_almost_bipartite"
+      "Complete the 1 remaining sorry: trivial_case"
     ]
   },
   "leanFile": {
@@ -205,27 +205,27 @@
     "theoremCount": 9,
     "definitionCount": 10,
     "path": "Proofs/Erdos73Problem.lean",
-    "sorries": 5
+    "sorries": 1
   },
   "references": [
     {
       "key": "Re1999",
-      "citation": "Reed, B. (1999). Mangoes and Blueberries. Combinatorica 19(2), 267–296.",
+      "citation": "Reed, B. (1999). Mangoes and Blueberries. Combinatorica 19(2), 267\u2013296.",
       "type": "paper"
     },
     {
       "key": "EP1965",
-      "citation": "Erdős, P. and Pósa, L. (1965). On independent circuits contained in a graph. Canadian Journal of Mathematics 17, 347–352.",
+      "citation": "Erd\u0151s, P. and P\u00f3sa, L. (1965). On independent circuits contained in a graph. Canadian Journal of Mathematics 17, 347\u2013352.",
       "type": "paper"
     },
     {
       "key": "Gy1987",
-      "citation": "Gyárfás, A. (1987). Problems from the world surrounding perfect graphs. Zastosowania Matematyki 19, 413–441.",
+      "citation": "Gy\u00e1rf\u00e1s, A. (1987). Problems from the world surrounding perfect graphs. Zastosowania Matematyki 19, 413\u2013441.",
       "type": "paper"
     },
     {
       "key": "ErdosProblems",
-      "citation": "Erdős Problems. Problem #73.",
+      "citation": "Erd\u0151s Problems. Problem #73.",
       "type": "website"
     }
   ],
@@ -246,5 +246,5 @@
       "description": "thematic"
     }
   ],
-  "sorries": 5
+  "sorries": 1
 }


### PR DESCRIPTION
## Summary

- **erdos-73**: `sorries` 5 → 1 (4 sorry'd theorems were proved or converted to axioms since the last audit; 1 sorry remains in `trivial_case`)
- **erdos-117-oq-01**: `sorries` 2 → 1 (1 analysis lemma was proved; 1 sorry remains in the limit/exp-log manipulation)
- **erdos-109-oq-01**: `sorries` 2 → 0, `axiomCount` 4 → 3 (previously sorry'd lemmas were converted to axioms or proved; `assumptions` text updated to reflect 3 formal axiom declarations with 0 sorries)

All fixes discovered via gallery integrity audit (`find-targets.ts --issues`).

## Test plan
- [ ] Verify `sorries` fields match `grep -c "^\s*sorry" proofs/Proofs/*.lean` for the affected files
- [ ] Confirm audit-tracker.json records these as `issues-fixed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)