### PR TITLE
Tractatus: reorder sections and elevate main results

### DIFF
--- a/proofs/Proofs/TractatusOntology.lean
+++ b/proofs/Proofs/TractatusOntology.lean
@@ -118,7 +118,7 @@ it does not.
 def World := Sachverhalt → Prop
 
 -- ═══════════════════════════════════════════════════════════════
--- TLP 2.061-2.062: Independence Structure
+-- SECTION 4: TLP 2.061-2.062: Independence Structure
 -- ═══════════════════════════════════════════════════════════════
 
 /-
@@ -144,7 +144,7 @@ instance : IndependentWorlds S :=
   ⟨fun a => ⟨a, fun _ => Iff.rfl⟩⟩
 
 -- ═══════════════════════════════════════════════════════════════
--- TLP 4.2-4.463: Propositions and Logical Space
+-- SECTION 5: TLP 4.2-4.463: Propositions and Logical Space
 -- ═══════════════════════════════════════════════════════════════
 
 /-
@@ -161,7 +161,7 @@ inductive Proposition (S : Type) where
   | conj       : Proposition S → Proposition S → Proposition S
 
 -- ═══════════════════════════════════════════════════════════════
--- SECTION 5: TLP 5: Truth-Functionality (Formalized)
+-- SECTION 6: TLP 5: Truth-Functionality (Formalized)
 -- ═══════════════════════════════════════════════════════════════
 
 /-
@@ -189,7 +189,7 @@ def nand (p q : Proposition S) : Proposition S :=
 end Proposition
 
 -- ═══════════════════════════════════════════════════════════════
--- SECTION 6: TLP 5.1-5.14: Semantic Evaluation
+-- SECTION 7: TLP 5.1-5.14: Semantic Evaluation
 -- ═══════════════════════════════════════════════════════════════
 
 /-
@@ -227,7 +227,7 @@ theorem Proposition.evalBool_correct (p : Proposition S) (w : S → Bool) :
   | conj q r ihq ihr => simp [evalBool, eval, Bool.and_eq_true, ihq, ihr]
 
 -- ═══════════════════════════════════════════════════════════════
--- SECTION 7: TLP 5.502: Tautology and Contradiction
+-- SECTION 8: TLP 5.502: Tautology and Contradiction
 -- ═══════════════════════════════════════════════════════════════
 
 /-
@@ -251,7 +251,7 @@ def Nontrivial (p : Proposition S) : Prop :=
   ∃ w₁ w₂ : World S, p.eval w₁ ∧ ¬ p.eval w₂
 
 -- ═══════════════════════════════════════════════════════════════
--- SECTION 7b: General World Models
+-- SECTION 9: General World Models
 -- ═══════════════════════════════════════════════════════════════
 
 /-
@@ -311,6 +311,11 @@ def IsTautologyM (p : Proposition S) : Prop :=
 def IsContradictionM (p : Proposition S) : Prop :=
   ∀ w : M.W, ¬ (evalM M p w)
 
+-- [MAIN RESULT] --------------------------------------------------
+-- truth_functional_compositionality_gen (model-independent)
+-- Compositionality holds in any world model, not just the free one.
+-- ----------------------------------------------------------------
+
 /-- Compositionality generalizes to any world model: two worlds
     that agree on every state of affairs agree on every compound
     proposition.  The proof is structurally identical to
@@ -336,7 +341,7 @@ theorem evalM_free_eq_eval (p : Proposition S) (w : S → Prop) :
   | conj q r ihq ihr => simp only [evalM, Proposition.eval, ihq, ihr]
 
 -- ═══════════════════════════════════════════════════════════════
--- SECTION 8: Theorems
+-- SECTION 10: Main Theorems
 -- ═══════════════════════════════════════════════════════════════
 
 -- ---------------------------------------------------------------
@@ -398,6 +403,11 @@ on every compound proposition. The truth-value of a complex
 proposition is entirely determined by the truth-values of its
 elementary constituents.
 -/
+
+-- [MAIN RESULT] --------------------------------------------------
+-- truth_functional_compositionality (TLP 5)
+-- Worlds agreeing on elementaries agree on all compounds.
+-- ----------------------------------------------------------------
 
 theorem truth_functional_compositionality (p : Proposition S)
     (w₁ w₂ : World S)
@@ -548,14 +558,23 @@ theorem nand_expresses_conj (p q : Proposition S) (w : World S) :
   simp [Proposition.nand, Proposition.eval, not_not]
 
 -- ═══════════════════════════════════════════════════════════════
--- TLP 2.061 Contrast: Constrained World Model
+-- SECTION 11: Constrained World Models
 -- ═══════════════════════════════════════════════════════════════
 
 /-
-To show that `IndependentWorlds` is not vacuous, we exhibit a
-model where independence fails. Consider two states of affairs,
-`a` and `b`, where `b` is constrained to co-occur with `a`.
-No world in this model can have `a` obtain while `b` does not.
+To show that `IndependentWorlds` is not vacuous, we exhibit
+models where independence fails. Two examples demonstrate the
+point: an abstract constrained model and a concrete weather model.
+-/
+
+-- ---------------------------------------------------------------
+-- 11a: Abstract constrained model (TLP 2.061 contrast)
+-- ---------------------------------------------------------------
+
+/-
+Consider two states of affairs, `a` and `b`, where `b` is
+constrained to co-occur with `a`. No world in this model can
+have `a` obtain while `b` does not.
 -/
 
 /-- A constrained world: `b` must obtain whenever `a` does. -/
@@ -566,6 +585,11 @@ def ConstrainedWorld (S : Type) (a b : S) :=
 def ConstrainedWorld.toWorld {S : Type} {a b : S}
     (cw : ConstrainedWorld S a b) : World S :=
   cw.val
+
+-- [MAIN RESULT] --------------------------------------------------
+-- constrained_independence_fails (TLP 2.061 contrast)
+-- Independence is a modeling choice, not a logical law.
+-- ----------------------------------------------------------------
 
 /-- `IndependentWorlds` fails for the constrained model when `a ≠ b`.
     The assignment `{a ↦ True, b ↦ False}` has no constrained realizer. -/
@@ -579,8 +603,52 @@ theorem constrained_independence_fails (a b : S) (hab : a ≠ b) :
   have hb : w b := hw ha
   exact hab ((hmatch b).mp hb)
 
+-- ---------------------------------------------------------------
+-- 11b: Weather model — concrete constrained example
+-- ---------------------------------------------------------------
+
+/-
+The free model treats every truth-value assignment as a possible
+world. But in many domains, structural constraints rule out certain
+assignments. Here we model a simple physical constraint: rain
+implies clouds.
+
+A `WeatherFacts` type has three states of affairs: rain, clouds,
+and snow. The `weatherModel` restricts worlds to those satisfying
+the constraint `rain → clouds`. This is a physical dependency,
+not a logical one — the Tractarian object language cannot express
+it, but the model theory can enforce it.
+
+The key consequence: `elementary_independence` (Theorem 5) holds
+for `freeModel` but *fails* for `weatherModel`. In the free model,
+any assignment is realizable; in the weather model, the assignment
+{rain, not-clouds} is forbidden by the constraint.
+-/
+
+inductive WeatherFacts where
+  | rain
+  | clouds
+  | snow
+  deriving DecidableEq, Repr
+
+/-- A constrained world model: rain implies clouds.
+    Not every truth-value assignment is a valid world. -/
+def weatherModel : WorldModel WeatherFacts where
+  W        := { w : WeatherFacts → Prop // w .rain → w .clouds }
+  holds    := fun w s => w.val s
+  nonempty := ⟨⟨fun _ => False, fun h => h.elim⟩⟩
+
+/-- In the weather model, independence fails: there is no world
+    where rain holds but clouds does not. The constraint
+    `rain → clouds` prevents such a world from existing. -/
+theorem weather_independence_fails :
+    ¬ ∃ w : (weatherModel).W,
+        weatherModel.holds w .rain ∧ ¬ weatherModel.holds w .clouds := by
+  intro ⟨w, hrain, hclouds⟩
+  exact hclouds (w.property hrain)
+
 -- ═══════════════════════════════════════════════════════════════
--- Concrete Examples (TwoFacts Instantiation)
+-- SECTION 12: Concrete Examples (TwoFacts Instantiation)
 -- ═══════════════════════════════════════════════════════════════
 
 /-
@@ -630,272 +698,7 @@ def rainyWorldBool : TwoFacts → Bool
 #eval (Proposition.neg itSnows).evalBool rainyWorldBool            -- true
 
 -- ═══════════════════════════════════════════════════════════════
--- SECTION 9b: Constrained World Model — Weather Example
--- ═══════════════════════════════════════════════════════════════
-
-/-
-The free model treats every truth-value assignment as a possible
-world. But in many domains, structural constraints rule out certain
-assignments. Here we model a simple physical constraint: rain
-implies clouds.
-
-A `WeatherFacts` type has three states of affairs: rain, clouds,
-and snow. The `weatherModel` restricts worlds to those satisfying
-the constraint `rain → clouds`. This is a physical dependency,
-not a logical one — the Tractarian object language cannot express
-it, but the model theory can enforce it.
-
-The key consequence: `elementary_independence` (Theorem 5) holds
-for `freeModel` but *fails* for `weatherModel`. In the free model,
-any assignment is realizable; in the weather model, the assignment
-{rain, not-clouds} is forbidden by the constraint.
--/
-
-inductive WeatherFacts where
-  | rain
-  | clouds
-  | snow
-  deriving DecidableEq, Repr
-
-/-- A constrained world model: rain implies clouds.
-    Not every truth-value assignment is a valid world. -/
-def weatherModel : WorldModel WeatherFacts where
-  W        := { w : WeatherFacts → Prop // w .rain → w .clouds }
-  holds    := fun w s => w.val s
-  nonempty := ⟨⟨fun _ => False, fun h => h.elim⟩⟩
-
-/-- In the weather model, independence fails: there is no world
-    where rain holds but clouds does not. The constraint
-    `rain → clouds` prevents such a world from existing. -/
-theorem weather_independence_fails :
-    ¬ ∃ w : (weatherModel).W,
-        weatherModel.holds w .rain ∧ ¬ weatherModel.holds w .clouds := by
-  intro ⟨w, hrain, hclouds⟩
-  exact hclouds (w.property hrain)
-
--- ═══════════════════════════════════════════════════════════════
--- The expresses relation (TLP 4.12, 4.1212)
--- ═══════════════════════════════════════════════════════════════
-
-/-
-`expresses p P` captures what it means for an object-language
-proposition to "say" a meta-language truth P. The proposition
-p expresses P when p's truth value tracks P in every possible
-world -- they are always equal.
-
-This makes the object/meta distinction visible in types:
-  - `p : Proposition S`       -- object language
-  - `P : Prop`                -- meta language
-  - `expresses p P : Prop`    -- the bridge claim
-
-TLP 4.12: Propositions can represent the whole of reality, but
-they cannot represent what they must have in common with reality
-in order to be able to represent it.
--/
-
-def expresses (p : Proposition S) (P : Prop) : Prop :=
-  ∀ w : World S, p.eval w ↔ P
-
--- ═══════════════════════════════════════════════════════════════
--- Analytical Decomposition: Invariance vs Dependence
--- ═══════════════════════════════════════════════════════════════
-
-/-
-The formalization reveals a three-way classification of all results.
-The Tractatus is not a set of truths about the world — it is a
-specification of a semantic architecture. Each theorem below falls
-into exactly one class:
-
-CORE INVARIANTS (hold in every WorldModel, no extra assumptions):
-  truth_functional_compositionality_gen
-    — compositionality is structural; it follows from the inductive
-      definition of Proposition alone, independent of which worlds exist
-  elem_prop_bivalence
-    — excluded middle on world-predicate applications; requires
-      Classical.em but no world-model constraints
-  double_negation, de_morgan_disj
-    — classical tautologies at the meta-level; world-invariant
-
-MODEL ASSUMPTIONS (hold only in IndependentWorlds / freeModel;
-may fail in constrained models):
-  elementary_independence
-    — realizable := fun a => ⟨a, fun _ => Iff.rfl⟩ exploits
-      World S = S → Prop; this IS a design choice, not a theorem
-  weather_independence_fails / constrained_independence_fails
-    — both witness that independence is NOT a logical law but
-      a property of the model
-
-FORMAL LIMITS (provable boundaries of the system):
-  saying_showing_triviality / proposition_seven
-    — world-independent content collapses to tautology or contradiction
-  nontrivial_expressibility_requires_world_dependence
-    — non-trivial saying requires genuine world-dependence; proved
-  structEq_ne_semEq (via the divergence theorem)
-    — formalization captures truth conditions but not logical form
-
-The three classes are mutually exclusive and jointly exhaustive
-across all 25 theorems in this file.
--/
--- ═══════════════════════════════════════════════════════════════
--- SECTION 10: The Limits of Formalization (TLP 6.54, 7)
--- ═══════════════════════════════════════════════════════════════
-
--- ---------------------------------------------------------------
--- Lemma: World-constant propositions are trivial (TLP 4.46)
--- ---------------------------------------------------------------
-
-/-- A proposition whose truth value is the same in all worlds
-    must be a tautology or a contradiction. -/
-lemma world_constant_taut_or_contra (q : Proposition S) [Nonempty S]
-    (h : ∀ w₁ w₂ : World S, q.eval w₁ ↔ q.eval w₂) :
-    IsTautology q ∨ IsContradiction q := by
-  obtain ⟨s₀⟩ : Nonempty S := inferInstance
-  set w₀ : World S := fun _ => True with hw₀
-  by_cases hq : q.eval w₀
-  · left
-    intro w
-    exact (h w₀ w).mp hq
-  · right
-    intro w hqw
-    exact hq ((h w w₀).mp hqw)
-
--- ---------------------------------------------------------------
--- Theorem: World-independent facts collapse to triviality
---          (TLP 4.12, 4.1212)
--- ---------------------------------------------------------------
-
-/-- Any proposition expressing a world-independent property
-    must be a tautology or a contradiction.
-
-    The hypothesis `expresses q P` states that `q`'s truth value
-    tracks the meta-level proposition `P` in every world.  Since
-    `expresses` unfolds to `∀ w, q.eval w ↔ P`, this is
-    definitionally compatible with all prior callers. -/
-theorem saying_showing_triviality (q : Proposition S) (P : Prop) [Nonempty S]
-    (h : expresses q P) :
-    IsTautology q ∨ IsContradiction q := by
-  apply world_constant_taut_or_contra
-  intro w₁ w₂
-  exact (h w₁).trans (h w₂).symm
-
-/-- A non-trivial proposition must have different truth values
-    in some pair of worlds. -/
-theorem contingent_propositions_vary (q : Proposition S) [Nonempty S]
-    (h_not_taut : ¬ IsTautology q)
-    (h_not_contra : ¬ IsContradiction q) :
-    ∃ w₁ w₂ : World S, q.eval w₁ ∧ ¬ q.eval w₂ := by
-  push_neg at h_not_contra
-  obtain ⟨w₁, hw₁⟩ := h_not_contra
-  unfold IsTautology at h_not_taut
-  push_neg at h_not_taut
-  obtain ⟨w₂, hw₂⟩ := h_not_taut
-  exact ⟨w₁, w₂, hw₁, hw₂⟩
-
--- ---------------------------------------------------------------
--- Nontrivial: connecting predicate (TLP 4.46, 4.462)
--- ---------------------------------------------------------------
-
-/-- A proposition that is neither a tautology nor a contradiction
-    is nontrivial: it varies across worlds. Direct corollary of
-    `contingent_propositions_vary`. -/
-theorem nontrivial_of_not_taut_not_contra (q : Proposition S) [Nonempty S]
-    (h_not_taut : ¬ IsTautology q)
-    (h_not_contra : ¬ IsContradiction q) :
-    Nontrivial q :=
-  contingent_propositions_vary q h_not_taut h_not_contra
-
-/-- `Nontrivial` is equivalent to being neither a tautology nor
-    a contradiction. The forward direction unpacks the witnesses;
-    the backward direction delegates to `contingent_propositions_vary`. -/
-theorem nontrivial_iff_not_taut_not_contra (q : Proposition S) [Nonempty S] :
-    Nontrivial q ↔ ¬ IsTautology q ∧ ¬ IsContradiction q := by
-  constructor
-  · rintro ⟨w₁, w₂, h₁, h₂⟩
-    exact ⟨fun ht => h₂ (ht w₂), fun hc => (hc w₁) h₁⟩
-  · rintro ⟨hnt, hnc⟩
-    exact contingent_propositions_vary q hnt hnc
-
-/-
-TLP 6.54: "My propositions serve as elucidations in the following
-           way: anyone who understands me eventually recognizes
-           them as nonsensical, when he has used them — as steps —
-           to climb beyond them. He must, so to speak, throw away
-           the ladder after he has climbed up it."
-
-Everything above is the ladder. The view from the top — that
-logical form is shared between language and reality rather than
-represented by either — is precisely what Lean, or any formal
-system, shows through its structure rather than states as a
-theorem. The saying/showing distinction cannot be formalized
-without collapsing it.
-
-TLP 7: "Wovon man nicht sprechen kann, darueber muss man schweigen."
-
-The object language can formally match any world-independent
-truth P — a tautology matches True, a contradiction matches
-False. But this matching is trivial: the same tautology would
-match ANY true P, and the same contradiction would match ANY
-false P. The proposition does not "say" P in any meaningful
-sense; it merely shares its truth value by accident of logic.
--/
-
-/-- Proposition 7: expressing a world-independent truth in the
-    object language necessarily produces a trivial proposition.
-    This is the formal content of TLP 7 -- what cannot be said
-    (non-trivially) in the object language can only be shown
-    by the structure of the metalanguage. -/
-theorem proposition_seven (q : Proposition S) (P : Prop) [Nonempty S]
-    (h : expresses q P) :
-    IsTautology q ∨ IsContradiction q :=
-  saying_showing_triviality q P h
-
-/-- A proposition nontrivially expresses content P only if P varies
-    with the world -- i.e., P cannot be world-independent.
-    Contrapositive of `saying_showing_triviality`. -/
-theorem nontrivial_expressibility_requires_world_dependence
-    (q : Proposition S) (P : Prop) [Nonempty S]
-    (hnt : Nontrivial q)
-    (h : expresses q P) :
-    False := by
-  rcases saying_showing_triviality q P h with htaut | hcontra
-  · obtain ⟨_, w₂, _, h₂⟩ := hnt
-    exact h₂ (htaut w₂)
-  · obtain ⟨w₁, _, h₁, _⟩ := hnt
-    exact (hcontra w₁) h₁
-
-/-- A nontrivial proposition cannot express any world-independent
-    property.  If `p` varies across worlds, there is no `P : Prop`
-    such that `expresses p P`.  This is the typed form of the
-    saying/showing boundary: genuine content cannot be pinned to a
-    single meta-proposition. -/
-theorem nontrivial_cannot_express_world_independent
-    (p : Proposition S) (P : Prop) [Nonempty S]
-    (hnt : Nontrivial p) :
-    ¬ expresses p P := by
-  intro h
-  exact nontrivial_expressibility_requires_world_dependence p P hnt h
-
-/-- TLP 7: *Wovon man nicht sprechen kann, darüber muss man schweigen.*
-
-    This axiom no longer stands alone as a bare gesture.  The
-    `expresses` relation (TLP 4.12) makes the object/meta boundary
-    a type-level concept, and the theorems above prove that:
-
-      - `expresses p P` -- typed bridge between object and meta language.
-      - `saying_showing_triviality` -- any expression of world-independent
-        content collapses to a tautology or contradiction.
-      - `nontrivial_cannot_express_world_independent` -- nontrivial
-        propositions cannot express any `P : Prop`.
-      - `proposition_seven` -- TLP 7 restated via `expresses`.
-
-    Silence marks where the chain ends: the ladder's top rung.  It is
-    not the result of a missing proof obligation but a structural
-    feature -- the saying/showing distinction cannot be captured
-    within the same formalism that draws it. -/
-axiom silence : True
-
--- ═══════════════════════════════════════════════════════════════
--- SECTION 11: Structural vs Semantic Equivalence (TLP 4.0141)
+-- SECTION 13: Structural vs Semantic Equivalence (TLP 4.0141)
 -- ═══════════════════════════════════════════════════════════════
 
 /-
@@ -1185,6 +988,12 @@ Each inclusion is strict: atom-swapped elementaries witness
 structEq ⊊ formEq, and double negation witnesses formEq ⊊ semEq.
 -/
 
+-- [MAIN RESULT] --------------------------------------------------
+-- structEq_ne_semEq (TLP 4.0141)
+-- Structural and semantic equivalence diverge: truth conditions
+-- cannot capture logical form.
+-- ----------------------------------------------------------------
+
 theorem structEq_ne_semEq [Nonempty S] :
     ∃ (p q : Proposition S),
       Proposition.semEq p q ∧ ¬ Proposition.structEq p q := by
@@ -1195,5 +1004,226 @@ theorem structEq_ne_semEq [Nonempty S] :
     simp [Proposition.eval, not_not]
   · -- structural non-equivalence: syntactic trees differ
     simp [Proposition.structEq]
+
+-- ═══════════════════════════════════════════════════════════════
+-- The expresses relation (TLP 4.12, 4.1212)
+-- ═══════════════════════════════════════════════════════════════
+
+/-
+`expresses p P` captures what it means for an object-language
+proposition to "say" a meta-language truth P. The proposition
+p expresses P when p's truth value tracks P in every possible
+world -- they are always equal.
+
+This makes the object/meta distinction visible in types:
+  - `p : Proposition S`       -- object language
+  - `P : Prop`                -- meta language
+  - `expresses p P : Prop`    -- the bridge claim
+
+TLP 4.12: Propositions can represent the whole of reality, but
+they cannot represent what they must have in common with reality
+in order to be able to represent it.
+-/
+
+def expresses (p : Proposition S) (P : Prop) : Prop :=
+  ∀ w : World S, p.eval w ↔ P
+
+-- ═══════════════════════════════════════════════════════════════
+-- Analytical Decomposition: Invariance vs Dependence
+-- ═══════════════════════════════════════════════════════════════
+
+/-
+The formalization reveals a three-way classification of all results.
+The Tractatus is not a set of truths about the world — it is a
+specification of a semantic architecture. Each theorem below falls
+into exactly one class:
+
+CORE INVARIANTS (hold in every WorldModel, no extra assumptions):
+  truth_functional_compositionality_gen
+    — compositionality is structural; it follows from the inductive
+      definition of Proposition alone, independent of which worlds exist
+  elem_prop_bivalence
+    — excluded middle on world-predicate applications; requires
+      Classical.em but no world-model constraints
+  double_negation, de_morgan_disj
+    — classical tautologies at the meta-level; world-invariant
+
+MODEL ASSUMPTIONS (hold only in IndependentWorlds / freeModel;
+may fail in constrained models):
+  elementary_independence
+    — realizable := fun a => ⟨a, fun _ => Iff.rfl⟩ exploits
+      World S = S → Prop; this IS a design choice, not a theorem
+  weather_independence_fails / constrained_independence_fails
+    — both witness that independence is NOT a logical law but
+      a property of the model
+
+FORMAL LIMITS (provable boundaries of the system):
+  saying_showing_triviality / proposition_seven
+    — world-independent content collapses to tautology or contradiction
+  nontrivial_expressibility_requires_world_dependence
+    — non-trivial saying requires genuine world-dependence; proved
+  structEq_ne_semEq (via the divergence theorem)
+    — formalization captures truth conditions but not logical form
+
+The three classes are mutually exclusive and jointly exhaustive
+across all 25 theorems in this file.
+-/
+-- ═══════════════════════════════════════════════════════════════
+-- SECTION 14: The Limits of Formalization (TLP 6.54, 7)
+-- ═══════════════════════════════════════════════════════════════
+
+-- ---------------------------------------------------------------
+-- Lemma: World-constant propositions are trivial (TLP 4.46)
+-- ---------------------------------------------------------------
+
+/-- A proposition whose truth value is the same in all worlds
+    must be a tautology or a contradiction. -/
+lemma world_constant_taut_or_contra (q : Proposition S) [Nonempty S]
+    (h : ∀ w₁ w₂ : World S, q.eval w₁ ↔ q.eval w₂) :
+    IsTautology q ∨ IsContradiction q := by
+  obtain ⟨s₀⟩ : Nonempty S := inferInstance
+  set w₀ : World S := fun _ => True with hw₀
+  by_cases hq : q.eval w₀
+  · left
+    intro w
+    exact (h w₀ w).mp hq
+  · right
+    intro w hqw
+    exact hq ((h w w₀).mp hqw)
+
+-- ---------------------------------------------------------------
+-- Theorem: World-independent facts collapse to triviality
+--          (TLP 4.12, 4.1212)
+-- ---------------------------------------------------------------
+
+/-- Any proposition expressing a world-independent property
+    must be a tautology or a contradiction.
+
+    The hypothesis `expresses q P` states that `q`'s truth value
+    tracks the meta-level proposition `P` in every world.  Since
+    `expresses` unfolds to `∀ w, q.eval w ↔ P`, this is
+    definitionally compatible with all prior callers. -/
+theorem saying_showing_triviality (q : Proposition S) (P : Prop) [Nonempty S]
+    (h : expresses q P) :
+    IsTautology q ∨ IsContradiction q := by
+  apply world_constant_taut_or_contra
+  intro w₁ w₂
+  exact (h w₁).trans (h w₂).symm
+
+/-- A non-trivial proposition must have different truth values
+    in some pair of worlds. -/
+theorem contingent_propositions_vary (q : Proposition S) [Nonempty S]
+    (h_not_taut : ¬ IsTautology q)
+    (h_not_contra : ¬ IsContradiction q) :
+    ∃ w₁ w₂ : World S, q.eval w₁ ∧ ¬ q.eval w₂ := by
+  push_neg at h_not_contra
+  obtain ⟨w₁, hw₁⟩ := h_not_contra
+  unfold IsTautology at h_not_taut
+  push_neg at h_not_taut
+  obtain ⟨w₂, hw₂⟩ := h_not_taut
+  exact ⟨w₁, w₂, hw₁, hw₂⟩
+
+-- ---------------------------------------------------------------
+-- Nontrivial: connecting predicate (TLP 4.46, 4.462)
+-- ---------------------------------------------------------------
+
+/-- A proposition that is neither a tautology nor a contradiction
+    is nontrivial: it varies across worlds. Direct corollary of
+    `contingent_propositions_vary`. -/
+theorem nontrivial_of_not_taut_not_contra (q : Proposition S) [Nonempty S]
+    (h_not_taut : ¬ IsTautology q)
+    (h_not_contra : ¬ IsContradiction q) :
+    Nontrivial q :=
+  contingent_propositions_vary q h_not_taut h_not_contra
+
+/-- `Nontrivial` is equivalent to being neither a tautology nor
+    a contradiction. The forward direction unpacks the witnesses;
+    the backward direction delegates to `contingent_propositions_vary`. -/
+theorem nontrivial_iff_not_taut_not_contra (q : Proposition S) [Nonempty S] :
+    Nontrivial q ↔ ¬ IsTautology q ∧ ¬ IsContradiction q := by
+  constructor
+  · rintro ⟨w₁, w₂, h₁, h₂⟩
+    exact ⟨fun ht => h₂ (ht w₂), fun hc => (hc w₁) h₁⟩
+  · rintro ⟨hnt, hnc⟩
+    exact contingent_propositions_vary q hnt hnc
+
+/-
+TLP 6.54: "My propositions serve as elucidations in the following
+           way: anyone who understands me eventually recognizes
+           them as nonsensical, when he has used them — as steps —
+           to climb beyond them. He must, so to speak, throw away
+           the ladder after he has climbed up it."
+
+Everything above is the ladder. The view from the top — that
+logical form is shared between language and reality rather than
+represented by either — is precisely what Lean, or any formal
+system, shows through its structure rather than states as a
+theorem. The saying/showing distinction cannot be formalized
+without collapsing it.
+
+TLP 7: "Wovon man nicht sprechen kann, darueber muss man schweigen."
+
+The object language can formally match any world-independent
+truth P — a tautology matches True, a contradiction matches
+False. But this matching is trivial: the same tautology would
+match ANY true P, and the same contradiction would match ANY
+false P. The proposition does not "say" P in any meaningful
+sense; it merely shares its truth value by accident of logic.
+-/
+
+/-- Proposition 7: expressing a world-independent truth in the
+    object language necessarily produces a trivial proposition.
+    This is the formal content of TLP 7 -- what cannot be said
+    (non-trivially) in the object language can only be shown
+    by the structure of the metalanguage. -/
+theorem proposition_seven (q : Proposition S) (P : Prop) [Nonempty S]
+    (h : expresses q P) :
+    IsTautology q ∨ IsContradiction q :=
+  saying_showing_triviality q P h
+
+/-- A proposition nontrivially expresses content P only if P varies
+    with the world -- i.e., P cannot be world-independent.
+    Contrapositive of `saying_showing_triviality`. -/
+theorem nontrivial_expressibility_requires_world_dependence
+    (q : Proposition S) (P : Prop) [Nonempty S]
+    (hnt : Nontrivial q)
+    (h : expresses q P) :
+    False := by
+  rcases saying_showing_triviality q P h with htaut | hcontra
+  · obtain ⟨_, w₂, _, h₂⟩ := hnt
+    exact h₂ (htaut w₂)
+  · obtain ⟨w₁, _, h₁, _⟩ := hnt
+    exact (hcontra w₁) h₁
+
+/-- A nontrivial proposition cannot express any world-independent
+    property.  If `p` varies across worlds, there is no `P : Prop`
+    such that `expresses p P`.  This is the typed form of the
+    saying/showing boundary: genuine content cannot be pinned to a
+    single meta-proposition. -/
+theorem nontrivial_cannot_express_world_independent
+    (p : Proposition S) (P : Prop) [Nonempty S]
+    (hnt : Nontrivial p) :
+    ¬ expresses p P := by
+  intro h
+  exact nontrivial_expressibility_requires_world_dependence p P hnt h
+
+/-- TLP 7: *Wovon man nicht sprechen kann, darüber muss man schweigen.*
+
+    This axiom no longer stands alone as a bare gesture.  The
+    `expresses` relation (TLP 4.12) makes the object/meta boundary
+    a type-level concept, and the theorems above prove that:
+
+      - `expresses p P` -- typed bridge between object and meta language.
+      - `saying_showing_triviality` -- any expression of world-independent
+        content collapses to a tautology or contradiction.
+      - `nontrivial_cannot_express_world_independent` -- nontrivial
+        propositions cannot express any `P : Prop`.
+      - `proposition_seven` -- TLP 7 restated via `expresses`.
+
+    Silence marks where the chain ends: the ladder's top rung.  It is
+    not the result of a missing proof obligation but a structural
+    feature -- the saying/showing distinction cannot be captured
+    within the same formalism that draws it. -/
+axiom silence : True
 
 end Tractatus

--- a/src/data/proofs/tractatus-ontology/annotations.json
+++ b/src/data/proofs/tractatus-ontology/annotations.json
@@ -100,7 +100,7 @@
   {
     "id": "ann-tractatus-taut-contra",
     "proofId": "tractatus-ontology",
-    "range": { "startLine": 229, "endLine": 245 },
+    "range": { "startLine": 229, "endLine": 252 },
     "type": "definition",
     "title": "Tautology and Contradiction (TLP 4.46, 6.1)",
     "content": "TLP 4.46: 'Among the possible groups of truth-conditions there are two extreme cases.' TLP 6.1: 'The propositions of logic are tautologies.'\n\n`IsTautology p` means $p$ evaluates to true in *every* world. `IsContradiction p` means $p$ evaluates to false in *every* world. These are the two extreme cases of TLP 4.46 — a tautology says nothing about which world is actual (it holds in all of them), while a contradiction rules out every possibility.",
@@ -111,7 +111,7 @@
   {
     "id": "ann-tractatus-worldmodel",
     "proofId": "tractatus-ontology",
-    "range": { "startLine": 247, "endLine": 334 },
+    "range": { "startLine": 253, "endLine": 341 },
     "type": "definition",
     "title": "General World Models: Beyond the Boolean Cube",
     "content": "The original `World S = S -> Prop` treats every truth-value assignment as a possible world. This is the 'free model' -- the full Boolean cube. The `WorldModel` structure generalizes this by packaging an arbitrary type of worlds, a `holds` relation, and a nonemptiness witness.\n\nThe free model is recovered as `freeModel S`, and the compatibility lemma `evalM_free_eq_eval` proves that evaluating via the general `evalM` over `freeModel` gives the same result as the original `Proposition.eval`. All existing theorems remain untouched.\n\nThe philosophical motivation: the Tractatus assumes that states of affairs are logically independent (TLP 2.061). This is baked into the free model. But in many applications -- physics, epistemic logic, constrained databases -- structural constraints rule out certain assignments. The `WorldModel` abstraction makes the independence assumption explicit and optional, enabling constrained models where some assignments are forbidden.\n\nThe generalized compositionality theorem `truth_functional_compositionality_gen` shows that truth-functionality holds in any world model, not just the free model. This is a model-independent structural property of propositional logic.",
@@ -120,9 +120,19 @@
     "relatedConcepts": ["model theory", "possible worlds", "Boolean cube", "constrained models", "TLP 2.061", "independence", "truth-functionality"]
   },
   {
+    "id": "ann-main-result-compositionality-gen",
+    "proofId": "tractatus-ontology",
+    "range": { "startLine": 314, "endLine": 331 },
+    "type": "theorem",
+    "title": "[Main Result] Compositionality is Model-Independent",
+    "content": "truth_functional_compositionality_gen proves that compositionality -- the property that two worlds agreeing on all elementary states of affairs agree on every compound proposition -- holds in any world model, not just the free model. This is a purely structural consequence of the inductive definition of Proposition: it requires no assumptions about which worlds exist or how they are constrained. The proof is structurally identical to truth_functional_compositionality but operates over an arbitrary WorldModel parameter M.",
+    "significance": "critical",
+    "relatedConcepts": ["TLP 5", "WorldModel", "truth-functionality", "compositionality", "model-independence"]
+  },
+  {
     "id": "ann-tractatus-thm1",
     "proofId": "tractatus-ontology",
-    "range": { "startLine": 340, "endLine": 354 },
+    "range": { "startLine": 347, "endLine": 361 },
     "type": "theorem",
     "title": "Tautologies Are World-Invariant (TLP 6.1)",
     "content": "TLP 6.1: 'The propositions of logic are tautologies.' This theorem states that a proposition holds in every world if and only if it is a tautology. The proof is `rfl` — it holds by definition. This is not a deficiency; it reflects that the *definition* of tautology captures exactly what 'proposition of logic' means in the Tractarian framework.",
@@ -133,7 +143,7 @@
   {
     "id": "ann-tractatus-thm2",
     "proofId": "tractatus-ontology",
-    "range": { "startLine": 357, "endLine": 367 },
+    "range": { "startLine": 363, "endLine": 374 },
     "type": "theorem",
     "title": "Contradictions Hold Nowhere (TLP 4.46)",
     "content": "If a proposition is a contradiction, it is false in every world. The proof is immediate from the definition — again, this reflects that the formalization has correctly captured the Tractarian concept.",
@@ -143,7 +153,7 @@
   {
     "id": "ann-tractatus-thm3",
     "proofId": "tractatus-ontology",
-    "range": { "startLine": 369, "endLine": 384 },
+    "range": { "startLine": 376, "endLine": 391 },
     "type": "theorem",
     "title": "Elementary Proposition Bivalence (TLP 4.023)",
     "content": "TLP 4.023: 'The proposition determines reality to this extent, that one only needs to say \"Yes\" or \"No\" to it.' For any state of affairs $s$ and world $w$, either $s$ obtains in $w$ or it does not: $w(s) \\lor \\neg w(s)$.\n\nThe proof invokes `Classical.em` — the law of excluded middle. This is a *classical* axiom in Lean's foundation; it is not provable constructively. Wittgenstein assumes bivalence throughout the Tractatus, so classical logic is the appropriate foundation here.",
@@ -154,7 +164,7 @@
   {
     "id": "ann-tractatus-thm4",
     "proofId": "tractatus-ontology",
-    "range": { "startLine": 386, "endLine": 407 },
+    "range": { "startLine": 393, "endLine": 420 },
     "type": "theorem",
     "title": "Truth-Functional Compositionality (TLP 5)",
     "content": "TLP 5: 'The proposition is a truth-function of elementary propositions.' This is the central theorem of the formalization. It states: if two worlds agree on every elementary proposition, they agree on every compound proposition.\n\nThe proof proceeds by structural induction on the proposition:\n- **Base case** (`elementary`): direct from the hypothesis that the worlds agree on elementaries\n- **Negation** (`neg`): if $p$ has the same truth value in both worlds, so does $\\neg p$\n- **Conjunction** (`conj`): if $p$ and $q$ each have the same truth values, so does $p \\land q$\n\nThis is the formal content of 'truth-functionality': compound truth values are determined entirely by elementary truth values.",
@@ -165,7 +175,7 @@
   {
     "id": "ann-tractatus-thm5",
     "proofId": "tractatus-ontology",
-    "range": { "startLine": 409, "endLine": 427 },
+    "range": { "startLine": 422, "endLine": 438 },
     "type": "theorem",
     "title": "Logical Independence (TLP 2.061, 2.062)",
     "content": "TLP 2.061: 'Atomic facts are independent of one another.' TLP 2.062: 'From the existence or non-existence of one atomic fact it is impossible to infer the existence or non-existence of another.'\n\nGiven *any* truth-value assignment to states of affairs, there exists a world realizing it. The proof is beautifully trivial: in our encoding, a truth-value assignment `S -> Prop` literally *is* a `World S`. The witness is the assignment itself.\n\n**[Interpretive choice]** This triviality is both a strength and a limitation. It means independence is *built into the encoding* rather than *proved from it*. A richer encoding — where states of affairs had internal structure involving shared objects — would make independence a substantive theorem requiring proof. Our encoding achieves independence 'for free' by design, which is faithful to the Tractatus's treatment of it as foundational rather than derived.",
@@ -176,7 +186,7 @@
   {
     "id": "ann-tractatus-thm6",
     "proofId": "tractatus-ontology",
-    "range": { "startLine": 429, "endLine": 440 },
+    "range": { "startLine": 440, "endLine": 452 },
     "type": "theorem",
     "title": "Double Negation (Classical Logic)",
     "content": "Double negation elimination: $\\neg\\neg p \\leftrightarrow p$ in every world. This uses `not_not` from Mathlib, which depends on `Classical.em`. The Tractatus assumes classical logic; an intuitionist would reject this equivalence, accepting only the left-to-right direction ($p \\to \\neg\\neg p$).",
@@ -186,7 +196,7 @@
   {
     "id": "ann-tractatus-thm7",
     "proofId": "tractatus-ontology",
-    "range": { "startLine": 442, "endLine": 458 },
+    "range": { "startLine": 454, "endLine": 471 },
     "type": "theorem",
     "title": "De Morgan's Laws (TLP 5.101)",
     "content": "De Morgan's laws verify that our definitions of derived connectives produce the expected semantics. The first law: $(p \\lor q)$ — defined as $\\neg(\\neg p \\land \\neg q)$ — evaluates to $p.\\text{eval}(w) \\lor q.\\text{eval}(w)$. The second: $\\neg(p \\land q)$ evaluates to $\\neg p.\\text{eval}(w) \\lor \\neg q.\\text{eval}(w)$.\n\nThese confirm that the $\\{\\neg, \\land\\}$ basis generates the full propositional calculus as Wittgenstein claims in TLP 5.101.",
@@ -197,7 +207,7 @@
   {
     "id": "ann-tractatus-thm8",
     "proofId": "tractatus-ontology",
-    "range": { "startLine": 460, "endLine": 473 },
+    "range": { "startLine": 473, "endLine": 486 },
     "type": "theorem",
     "title": "Excluded Middle as Tautology (TLP 4.46)",
     "content": "$p \\lor \\neg p$ is a tautology — it holds in every world. This is the paradigmatic example of TLP 6.1: a 'proposition of logic' that is true regardless of which states of affairs obtain. For Wittgenstein, this does not say something *about* the world; it shows something about the structure of logical space.",
@@ -208,7 +218,7 @@
   {
     "id": "ann-tractatus-thm9",
     "proofId": "tractatus-ontology",
-    "range": { "startLine": 475, "endLine": 487 },
+    "range": { "startLine": 488, "endLine": 499 },
     "type": "theorem",
     "title": "p and not-p Is a Contradiction",
     "content": "$p \\land \\neg p$ holds in no world — the paradigmatic contradiction. The proof is immediate: `simp [Proposition.eval]` decomposes the conjunction into $p.\\text{eval}(w)$ and $\\neg p.\\text{eval}(w)$, which are directly contradictory.",
@@ -218,7 +228,7 @@
   {
     "id": "ann-tractatus-thm10-11",
     "proofId": "tractatus-ontology",
-    "range": { "startLine": 488, "endLine": 509 },
+    "range": { "startLine": 501, "endLine": 522 },
     "type": "theorem",
     "title": "Implication and Biconditional Semantics",
     "content": "These theorems verify that the derived connectives have their standard semantics:\n- $(p \\to q).\\text{eval}(w) \\leftrightarrow (p.\\text{eval}(w) \\to q.\\text{eval}(w))$\n- $(p \\leftrightarrow q).\\text{eval}(w) \\leftrightarrow (p.\\text{eval}(w) \\leftrightarrow q.\\text{eval}(w))$\n\nThe `tauto` tactic handles the classical propositional reasoning after `simp` normalizes the definitions.",
@@ -228,7 +238,7 @@
   {
     "id": "ann-tractatus-thm12",
     "proofId": "tractatus-ontology",
-    "range": { "startLine": 511, "endLine": 526 },
+    "range": { "startLine": 524, "endLine": 538 },
     "type": "theorem",
     "title": "Modus Ponens (Metalogical, TLP 4.121)",
     "content": "If $p \\to q$ is true in a world and $p$ is true in that world, then $q$ is true in that world. This is a meta-theorem: it is proved in Lean (the metalanguage) *about* propositions in our object language.\n\nThis is precisely the kind of thing Wittgenstein says can be *shown* by the symbolism but not *said* within it (TLP 4.121: 'What can be shown cannot be said'). The formal system shows that modus ponens preserves truth — it does not contain a proposition asserting this fact. Our Lean theorem *says* what the Tractarian framework can only *show*.",
@@ -239,7 +249,7 @@
   {
     "id": "ann-tractatus-thm13",
     "proofId": "tractatus-ontology",
-    "range": { "startLine": 528, "endLine": 546 },
+    "range": { "startLine": 540, "endLine": 558 },
     "type": "theorem",
     "title": "NAND Functional Completeness (TLP 5.5)",
     "content": "TLP 5.5 anticipates the Sheffer stroke: all truth-functions can be derived from a single binary operation. We show:\n- $\\text{nand}(p, p)$ is equivalent to $\\neg p$ (NAND with itself gives negation)\n- $\\neg\\text{nand}(p, q)$ is equivalent to $p \\land q$ (negated NAND gives conjunction)\n\nSince $\\{\\neg, \\land\\}$ is functionally complete, and both are expressible via NAND, NAND alone suffices for all truth-functions. Wittgenstein's insight (shared with Sheffer, 1913) is that the apparent multiplicity of logical connectives conceals a deeper unity.",
@@ -248,20 +258,19 @@
     "relatedConcepts": ["TLP 5.5", "Sheffer stroke", "NAND", "functional completeness", "Henry Sheffer"]
   },
   {
-    "id": "ann-tractatus-concrete-examples",
+    "id": "ann-main-result-constrained",
     "proofId": "tractatus-ontology",
-    "range": { "startLine": 580, "endLine": 628 },
-    "type": "concept",
-    "title": "Concrete Examples: From Abstract to Computable",
-    "content": "The Tractarian machinery above is parametric in an abstract type `S` of states of affairs. Here we instantiate `S` with a concrete two-element type (`TwoFacts`: rain and snow) to make the formalization interactive.\n\nTwo kinds of evaluation are demonstrated:\n- **Prop-valued** (`eval`): the `example` proofs confirm that `itRains` holds in `rainyWorld` and `itSnows` does not. These are type-checked but not executable.\n- **Bool-valued** (`evalBool`): the `#eval` calls compute truth values at elaboration time, printing `true` or `false` in the Lean infoview. This makes the formalization tangible — readers can modify the world and see results immediately.\n\nThe `TwoFacts` type derives `DecidableEq`, `Repr`, and `Fintype`, making it suitable for both decidable evaluation and (in principle) exhaustive truth-table enumeration.",
-    "mathContext": "The `Fintype` instance certifies that `TwoFacts` has finitely many inhabitants. Combined with `DecidableEq`, this would allow enumerating all $2^2 = 4$ possible worlds and computing a complete truth table. The `Repr` instance enables `#eval` to print the type's constructors.",
-    "significance": "key",
-    "relatedConcepts": ["decidability", "Fintype", "truth tables", "computational semantics", "Bool vs Prop"]
+    "range": { "startLine": 589, "endLine": 605 },
+    "type": "theorem",
+    "title": "[Main Result] Independence is a Modeling Choice",
+    "content": "constrained_independence_fails proves that IndependentWorlds fails for the constrained model when the two distinguished states of affairs are distinct. The assignment {a -> True, b -> False} has no constrained realizer, because the constraint b-must-obtain-when-a-does prevents such an assignment from being a world. This demonstrates that independence is not a logical law but a property of the chosen world model. The Tractatus builds independence into its ontology (TLP 2.061); our formalization makes this assumption explicit and shows precisely where it breaks.",
+    "significance": "critical",
+    "relatedConcepts": ["TLP 2.061", "constrained worlds", "IndependentWorlds", "independence failure", "modeling choice"]
   },
   {
     "id": "ann-tractatus-weathermodel",
     "proofId": "tractatus-ontology",
-    "range": { "startLine": 630, "endLine": 675 },
+    "range": { "startLine": 607, "endLine": 648 },
     "type": "theorem",
     "title": "Constrained Models: Weather Example and Independence Failure",
     "content": "The `weatherModel` is a concrete constrained model with three states of affairs (rain, clouds, snow) and one structural constraint: rain implies clouds. A world is a subtype `{ w : WeatherFacts -> Prop // w .rain -> w .clouds }` -- only truth-value assignments satisfying the constraint count as possible worlds.\n\nThe key theorem `weather_independence_fails` proves that in this model, there is no world where rain holds but clouds does not. This is a direct failure of elementary independence (Theorem 5): in the free model, the assignment {rain := True, clouds := False, snow := anything} is a valid world, but in the weather model it violates the constraint.\n\nThis demonstrates the philosophical point: independence is a property of the *model*, not of propositional logic itself. The Tractatus builds independence into its ontology (TLP 2.061); our formalization makes this assumption explicit and shows what happens when it is relaxed.",
@@ -270,9 +279,41 @@
     "relatedConcepts": ["TLP 2.061", "independence failure", "constrained models", "subtype", "physical constraints", "model theory"]
   },
   {
+    "id": "ann-tractatus-concrete-examples",
+    "proofId": "tractatus-ontology",
+    "range": { "startLine": 650, "endLine": 698 },
+    "type": "concept",
+    "title": "Concrete Examples: From Abstract to Computable",
+    "content": "The Tractarian machinery above is parametric in an abstract type `S` of states of affairs. Here we instantiate `S` with a concrete two-element type (`TwoFacts`: rain and snow) to make the formalization interactive.\n\nTwo kinds of evaluation are demonstrated:\n- **Prop-valued** (`eval`): the `example` proofs confirm that `itRains` holds in `rainyWorld` and `itSnows` does not. These are type-checked but not executable.\n- **Bool-valued** (`evalBool`): the `#eval` calls compute truth values at elaboration time, printing `true` or `false` in the Lean infoview. This makes the formalization tangible — readers can modify the world and see results immediately.\n\nThe `TwoFacts` type derives `DecidableEq`, `Repr`, and `Fintype`, making it suitable for both decidable evaluation and (in principle) exhaustive truth-table enumeration.",
+    "mathContext": "The `Fintype` instance certifies that `TwoFacts` has finitely many inhabitants. Combined with `DecidableEq`, this would allow enumerating all $2^2 = 4$ possible worlds and computing a complete truth table. The `Repr` instance enables `#eval` to print the type's constructors.",
+    "significance": "key",
+    "relatedConcepts": ["decidability", "Fintype", "truth tables", "computational semantics", "Bool vs Prop"]
+  },
+  {
+    "id": "ann-tractatus-formeq",
+    "proofId": "tractatus-ontology",
+    "range": { "startLine": 700, "endLine": 963 },
+    "type": "concept",
+    "title": "Logical-Form Equivalence: formEq (TLP 4.0141, 4.014)",
+    "content": "TLP 4.0141 describes a 'general rule' connecting different representations of the same logical form -- the score, the symphony, the gramophone groove. We formalize this as formEq: two propositions share their logical form iff one is obtained from the other by a bijective renaming (Equiv.Perm) of atoms.\n\nThis relation sits strictly between structEq (identical syntax tree, identical atoms) and semEq (identical truth values in all worlds). The rename functor maps atom-renaming functions over proposition trees, preserving all connective structure. Using Equiv.Perm for the renaming gives formEq the structure of a group action, making symmetry and transitivity immediate.\n\nThe key subtlety: formEq does NOT imply semEq. Elementary propositions about rain and snow have the same logical form (both are elementary) but different truth values in rainyWorld. The correct intermediate notion is truth-table isomorphism: there exists a world-relabeling making the propositions agree everywhere. This is strictly weaker than semEq (which requires agreement without any relabeling).",
+    "mathContext": "The hierarchy structEq < formEq < semEq captures three distinct senses of 'sameness' for propositions. structEq is syntactic identity up to definitional equality. formEq is syntactic identity up to atom permutation -- the formal correlate of shared logical form. semEq is semantic identity -- shared truth conditions. Both inclusions are strict: atom-swapped elementaries witness structEq < formEq, and double negation witnesses formEq < semEq.",
+    "significance": "critical",
+    "relatedConcepts": ["TLP 4.0141", "TLP 4.014", "logical form", "permutation group", "renaming", "truth-table isomorphism", "syntactic equivalence", "semantic equivalence"]
+  },
+  {
+    "id": "ann-main-result-structeq",
+    "proofId": "tractatus-ontology",
+    "range": { "startLine": 991, "endLine": 1006 },
+    "type": "theorem",
+    "title": "[Main Result] Structural and Semantic Equivalence Diverge",
+    "content": "structEq_ne_semEq proves that structural and semantic equivalence are genuinely different relations: there exist propositions that are semantically equivalent (same truth value in every possible world) but not structurally equivalent (different syntactic trees). The witness is neg(neg(elementary s)) vs elementary s: double negation gives semantic equivalence, but the syntactic trees have different shapes. This makes explicit what the formalization captures (truth conditions) and what it cannot (logical form). With the introduction of formEq, this is now contextualized within the three-level hierarchy structEq < formEq < semEq.",
+    "significance": "critical",
+    "relatedConcepts": ["TLP 4.0141", "logical form", "limits of formalization", "structEq", "semEq", "formEq"]
+  },
+  {
     "id": "ann-tractatus-classification",
     "proofId": "tractatus-ontology",
-    "range": { "startLine": 676, "endLine": 715 },
+    "range": { "startLine": 1031, "endLine": 1070 },
     "type": "insight",
     "title": "Analytical Decomposition: Invariance vs Dependence vs Limits",
     "content": "The formalization's 25 theorems divide sharply into three classes, and the division is philosophically decisive.\n\n**Core invariants** hold in every WorldModel with no assumptions beyond classical logic: compositionality (`truth_functional_compositionality_gen`), bivalence (`elem_prop_bivalence`), double negation, De Morgan laws. These are properties of the *proposition grammar itself* — they would hold in any model-theoretic semantics for this language.\n\n**Model assumptions** hold in the free model (where `World S = S -> Prop`) but can fail in constrained models: `elementary_independence` is the canonical example. It is not a theorem of propositional logic — it is a choice about which functions count as worlds. The `weatherModel` and `ConstrainedWorld` demonstrate that relaxing this choice breaks independence while preserving all core invariants.\n\n**Formal limits** are provable *boundaries* of the system: `saying_showing_triviality` and `nontrivial_expressibility_requires_world_dependence` prove exactly what the object language can and cannot express. `structEq_ne_semEq` (the structural vs semantic divergence) proves that truth-conditional equivalence is strictly weaker than syntactic identity.\n\nThe Tractatus is not a set of truths about the world — it is a specification of a semantic architecture. This classification makes that architecture explicit: what is logical structure, what is ontological assumption, and what is provable boundary.",
@@ -283,7 +324,7 @@
   {
     "id": "ann-tractatus-ladder",
     "proofId": "tractatus-ontology",
-    "range": { "startLine": 769, "endLine": 791 },
+    "range": { "startLine": 1153, "endLine": 1175 },
     "type": "insight",
     "title": "The Ladder (TLP 6.54)",
     "content": "TLP 6.54: 'My propositions serve as elucidations in the following way: anyone who understands me eventually recognizes them as nonsensical, when he has used them — as steps — to climb beyond them. He must, so to speak, throw away the ladder after he has climbed up it.'\n\nEverything above is the ladder. The view from the top — that logical form is shared between language and reality rather than represented by either — is precisely what Lean, or any formal system, shows through its structure rather than states as a theorem. The residue left over after formalization is the most Wittgensteinian part.\n\n**[Interpretive choice]** The Tractatus is self-consciously paradoxical: it uses meaningful propositions to argue that certain things cannot be meaningfully said. Any formalization must pick a side — either the ladder is meaningful (in which case the self-undermining thesis fails) or it is not (in which case the formalization formalizes nothing). We take the first option: the formal skeleton is mathematically meaningful, and the philosophical claim about its limitations is carried by the annotations, not the code.",
@@ -293,10 +334,10 @@
   {
     "id": "ann-tractatus-proposition-seven",
     "proofId": "tractatus-ontology",
-    "range": { "startLine": 793, "endLine": 809 },
+    "range": { "startLine": 1177, "endLine": 1183 },
     "type": "theorem",
     "title": "Proposition 7 (TLP 7)",
-    "content": "TLP 7: *Wovon man nicht sprechen kann, darueber muss man schweigen.* — 'Whereof one cannot speak, thereof one must be silent.'\n\nThe theorem `proposition_seven` proves that any proposition expressing a world-independent truth must be either a tautology or a contradiction. The object language can formally match any world-independent truth P — a tautology matches True, a contradiction matches False — but this matching is trivial. The proposition does not 'say' P in any meaningful sense.\n\nThe `axiom silence : True` (line 768) enacts Wittgenstein's silence as a formal gesture — a deliberately axiomatic declaration that marks the boundary of formalization. It is trivially true but axiomatic by design, not by necessity.",
+    "content": "TLP 7: *Wovon man nicht sprechen kann, darueber muss man schweigen.* — 'Whereof one cannot speak, thereof one must be silent.'\n\nThe theorem `proposition_seven` proves that any proposition expressing a world-independent truth must be either a tautology or a contradiction. The object language can formally match any world-independent truth P — a tautology matches True, a contradiction matches False — but this matching is trivial. The proposition does not 'say' P in any meaningful sense.\n\nThe `axiom silence : True` enacts Wittgenstein's silence as a formal gesture — a deliberately axiomatic declaration that marks the boundary of formalization. It is trivially true but axiomatic by design, not by necessity.",
     "mathContext": "The type of `proposition_seven` is `forall (q : Proposition S) (P : Prop), [Nonempty S] -> (forall w : World S, q.eval w <-> P) -> IsTautology q or IsContradiction q`. This says: if a proposition's truth value is the same constant P in every world, then the proposition must be a tautology (if P is true) or a contradiction (if P is false). No proposition can non-trivially express a metalogical property.",
     "significance": "critical",
     "relatedConcepts": ["TLP 7", "axiom silence", "Tarski undefinability", "saying vs showing", "metalanguage", "object language", "silence"]
@@ -332,16 +373,5 @@
     "content": "TLP 5.52 claims quantifiers are N-operator applications: the universal quantifier over f(x) is N applied to all values {f(a), f(b), f(c), ...}. For finite domains this works — the universal quantifier is a finite conjunction, and the N-operator handles finite lists.\n\nFor infinite domains, Wittgenstein's claim is philosophically problematic. The N-operator is a finitary syntactic construction: it takes a finite list of propositions and produces their joint denial. Applying it to infinitely many values requires an infinitary extension that the Tractatus does not provide.\n\nGeach (1981) argues this is a fundamental gap: the Tractatus cannot express genuinely infinite quantification within its truth-functional framework. Soames (1983) strengthens the point, showing that the claim in TLP 5 — that all propositions are truth-functions of elementary propositions — fails for infinite-domain quantification.\n\nOur formalization sidesteps this problem by defining `FOProp.eval` directly using Lean's `forall` and `exists`, which handle infinite domains natively. The philosophical question — whether Wittgenstein's finitary framework can be extended to the infinite case — remains open.",
     "significance": "critical",
     "relatedConcepts": ["TLP 5.52", "N-operator", "infinitary logic", "Geach", "Soames", "truth-functions", "finite vs infinite domains"]
-  },
-  {
-    "id": "ann-tractatus-formeq",
-    "proofId": "tractatus-ontology",
-    "range": { "startLine": 853, "endLine": 1074 },
-    "type": "concept",
-    "title": "Logical-Form Equivalence: formEq (TLP 4.0141, 4.014)",
-    "content": "TLP 4.0141 describes a 'general rule' connecting different representations of the same logical form -- the score, the symphony, the gramophone groove. We formalize this as formEq: two propositions share their logical form iff one is obtained from the other by a bijective renaming (Equiv.Perm) of atoms.\n\nThis relation sits strictly between structEq (identical syntax tree, identical atoms) and semEq (identical truth values in all worlds). The rename functor maps atom-renaming functions over proposition trees, preserving all connective structure. Using Equiv.Perm for the renaming gives formEq the structure of a group action, making symmetry and transitivity immediate.\n\nThe key subtlety: formEq does NOT imply semEq. Elementary propositions about rain and snow have the same logical form (both are elementary) but different truth values in rainyWorld. The correct intermediate notion is truth-table isomorphism: there exists a world-relabeling making the propositions agree everywhere. This is strictly weaker than semEq (which requires agreement without any relabeling).",
-    "mathContext": "The hierarchy structEq < formEq < semEq captures three distinct senses of 'sameness' for propositions. structEq is syntactic identity up to definitional equality. formEq is syntactic identity up to atom permutation -- the formal correlate of shared logical form. semEq is semantic identity -- shared truth conditions. Both inclusions are strict: atom-swapped elementaries witness structEq < formEq, and double negation witnesses formEq < semEq.",
-    "significance": "critical",
-    "relatedConcepts": ["TLP 4.0141", "TLP 4.014", "logical form", "permutation group", "renaming", "truth-table isomorphism", "syntactic equivalence", "semantic equivalence"]
   }
 ]

--- a/src/data/proofs/tractatus-ontology/meta.json
+++ b/src/data/proofs/tractatus-ontology/meta.json
@@ -40,7 +40,7 @@
     ],
     "dateAdded": "04/14/26",
     "axiomCount": 1,
-    "lineCount": 1119,
+    "lineCount": 1229,
     "assumptions": "One deliberate axiom: `silence : True` (TLP 7) — a trivially true but axiomatic declaration that enacts Wittgenstein's silence as a formal gesture. All theorems are fully proved with 0 sorries. Uses classical logic (Classical.em) throughout. The companion file TractatusQuantifiers.lean has no sorries or axioms."
   },
   "overview": {
@@ -86,8 +86,15 @@
       "id": "worlds",
       "title": "Worlds (TLP 1, 1.1, 2.04)",
       "startLine": 104,
+      "endLine": 118,
+      "summary": "Worlds as predicates determining which states of affairs obtain."
+    },
+    {
+      "id": "independence",
+      "title": "Independence Structure (TLP 2.061-2.062)",
+      "startLine": 120,
       "endLine": 144,
-      "summary": "Worlds as predicates determining which states of affairs obtain. Includes IndependentWorlds typeclass and its default instance."
+      "summary": "IndependentWorlds typeclass and its default instance for the free Boolean cube."
     },
     {
       "id": "propositions",
@@ -114,64 +121,57 @@
       "id": "tautology-contradiction",
       "title": "Tautology and Contradiction (TLP 4.46, 6.1)",
       "startLine": 229,
-      "endLine": 245,
-      "summary": "Definitions of tautology (true in all worlds) and contradiction (false in all worlds)."
+      "endLine": 252,
+      "summary": "Definitions of tautology (true in all worlds), contradiction (false in all worlds), and nontrivial propositions."
     },
     {
       "id": "general-world-models",
       "title": "General World Models",
-      "startLine": 247,
-      "endLine": 334,
-      "summary": "WorldModel structure parameterizing semantics over arbitrary world collections. Includes freeModel (the unconstrained model recovering original semantics), evalM, IsTautologyM, IsContradictionM, generalized compositionality, and a compatibility lemma proving evalM over freeModel equals the original eval."
+      "startLine": 253,
+      "endLine": 341,
+      "summary": "WorldModel structure parameterizing semantics over arbitrary world collections. Includes freeModel, evalM, IsTautologyM, IsContradictionM, generalized compositionality (main result), and a compatibility lemma proving evalM over freeModel equals the original eval."
     },
     {
-      "id": "theorems",
-      "title": "Theorems",
-      "startLine": 335,
-      "endLine": 578,
-      "summary": "Core theorems establishing compositionality, independence, bivalence, connective semantics, functional completeness, and constrained independence failure."
+      "id": "main-theorems",
+      "title": "Main Theorems",
+      "startLine": 343,
+      "endLine": 558,
+      "summary": "Core theorems 1-13: compositionality (main result), independence, bivalence, connective semantics, and NAND functional completeness."
+    },
+    {
+      "id": "constrained-models",
+      "title": "Constrained World Models",
+      "startLine": 560,
+      "endLine": 648,
+      "summary": "Abstract constrained model (ConstrainedWorld with constrained_independence_fails, main result) and concrete weather model (WeatherFacts with weather_independence_fails). Both demonstrate that independence is a modeling choice, not a logical law."
     },
     {
       "id": "concrete-examples",
       "title": "Concrete Examples",
-      "startLine": 580,
-      "endLine": 628,
+      "startLine": 650,
+      "endLine": 698,
       "summary": "TwoFacts instantiation with rain/snow, Prop-valued and Bool-valued evaluation examples."
-    },
-    {
-      "id": "constrained-model",
-      "title": "Constrained World Model -- Weather Example",
-      "startLine": 630,
-      "endLine": 675,
-      "summary": "WeatherFacts type with rain/clouds/snow and a weatherModel enforcing rain implies clouds. Proves that elementary independence fails in constrained models."
-    },
-    {
-      "id": "limits",
-      "title": "The Limits of Formalization (TLP 6.54, 7)",
-      "startLine": 677,
-      "endLine": 768,
-      "summary": "World-constant triviality lemma, saying/showing triviality theorem, contingent propositions theorem, proposition seven, and the axiom of silence."
     },
     {
       "id": "structural-vs-semantic",
       "title": "Structural vs Semantic Equivalence (TLP 4.0141)",
-      "startLine": 834,
-      "endLine": 851,
-      "summary": "Defines structural (syntactic) and semantic (truth-conditional) equivalence for propositions."
+      "startLine": 700,
+      "endLine": 1007,
+      "summary": "Defines structural (structEq), semantic (semEq), and logical-form (formEq via Equiv.Perm) equivalence. Proves formEq is an equivalence relation, establishes strict hierarchy structEq < formEq < semEq, and proves the divergence theorem structEq_ne_semEq (main result)."
     },
     {
-      "id": "logical-form-equivalence",
-      "title": "Logical-Form Equivalence: formEq (TLP 4.0141, 4.014)",
-      "startLine": 853,
-      "endLine": 1074,
-      "summary": "Introduces atom renaming (rename functor with id/comp lemmas), logical-form equivalence (formEq via Equiv.Perm), proves formEq is an equivalence relation, establishes the strict hierarchy structEq < formEq < semEq with truth-table isomorphism as the bridge to semEq, and provides concrete strictness witnesses using TwoFacts."
+      "id": "expresses-and-classification",
+      "title": "The expresses Relation and Analytical Decomposition",
+      "startLine": 1008,
+      "endLine": 1070,
+      "summary": "The expresses relation (TLP 4.12) bridging object and meta language, and a three-way classification of all results: core invariants, model assumptions, and formal limits."
     },
     {
-      "id": "equivalence-divergence",
-      "title": "Structural and Semantic Equivalence Diverge (TLP 4.0141)",
-      "startLine": 1076,
-      "endLine": 1119,
-      "summary": "Proves structEq and semEq diverge (neg-neg-elementary vs elementary), now contextualized within the three-level hierarchy structEq < formEq < semEq."
+      "id": "limits",
+      "title": "The Limits of Formalization (TLP 6.54, 7)",
+      "startLine": 1071,
+      "endLine": 1229,
+      "summary": "World-constant triviality lemma, saying/showing triviality theorem, contingent propositions theorem, nontrivial predicate theorems, proposition seven, nontrivial expressibility theorems, the ladder of TLP 6.54, and the axiom of silence."
     }
   ],
   "conclusion": {
@@ -227,7 +227,7 @@
     "imports": ["Mathlib.Tactic"],
     "opens": [],
     "namespace": "Tractatus",
-    "lineCount": 1119,
+    "lineCount": 1229,
     "axiomCount": 1,
     "theoremCount": 37,
     "definitionCount": 29,
@@ -291,6 +291,7 @@
     {
       "name": "truth_functional_compositionality_gen",
       "type": "core",
+      "mainResult": true,
       "description": "Compositionality generalized to arbitrary world models (not just the free model)",
       "leanType": "∀ (M : WorldModel S) (p : Proposition S) (w₁ w₂ : M.W), (∀ s, M.holds w₁ s ↔ M.holds w₂ s) → (evalM M p w₁ ↔ evalM M p w₂)"
     },
@@ -329,6 +330,20 @@
       "type": "core",
       "description": "Strict separation: double-negated elementary is semEq but not formEq to elementary",
       "leanType": "(neg (neg (elementary s))).semEq (elementary s) ∧ ¬ (neg (neg (elementary s))).formEq (elementary s)"
+    },
+    {
+      "name": "constrained_independence_fails",
+      "type": "core",
+      "mainResult": true,
+      "description": "Independence fails in constrained models — it is a modeling choice, not a logical law (TLP 2.061 contrast)",
+      "leanType": "¬ ∀ assignment : S → Prop, ∃ cw : ConstrainedWorld S a b, ∀ s, cw.val s ↔ assignment s"
+    },
+    {
+      "name": "structEq_ne_semEq",
+      "type": "core",
+      "mainResult": true,
+      "description": "Structural and semantic equivalence diverge: truth conditions cannot capture logical form (TLP 4.0141)",
+      "leanType": "∃ (p q : Proposition S), Proposition.semEq p q ∧ ¬ Proposition.structEq p q"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Reorganize TractatusOntology.lean (1199 -> 1229 lines) for clearer narrative flow: renumber all sections 1-14, consolidate constrained world models (ConstrainedWorld + WeatherFacts) into one section, move structural vs semantic equivalence before the limits of formalization so `structEq_ne_semEq` precedes `silence`
- Add `[MAIN RESULT]` comment markers on four key theorems: `truth_functional_compositionality_gen`, `truth_functional_compositionality`, `constrained_independence_fails`, `structEq_ne_semEq`
- Update meta.json sections, lineCount, and mainTheorems with `mainResult: true` flags; update all annotation line ranges in annotations.json with three new `"significance": "critical"` entries for the main results

No theorem statements or proofs changed -- pure comment/ordering refactor.

## Acceptance Criteria Verification

| Criterion | Status |
|-----------|--------|
| WorldModel/GeneralSemantics as Section 9 (before theorems) | Verified (lines 253-341) |
| truth_functional_compositionality_gen adjacent to compositionality | Verified (Section 9 -> Section 10) |
| structEq/semEq/structEq_ne_semEq before silence/Limits | Verified (Section 13 before Section 14) |
| Constrained models consolidated (ConstrainedWorld + WeatherFacts) | Verified (Section 11, lines 560-648) |
| Concrete Examples after constrained models | Verified (Section 12, lines 650-698) |
| [MAIN RESULT] markers on four theorems | Verified (lines 314, 407, 589, 991) |
| annotations.json critical entries for main results | Verified (3 new entries) |
| meta.json sections updated | Verified (16 sections with correct ranges) |
| meta.json mainTheorems with mainResult: true | Verified (3 entries) |
| meta.json lineCount updated | Verified (1229) |
| pnpm build passes | Verified |
| No merge conflict markers | Verified (grep returns 0) |

## Test plan

- [x] `pnpm build` passes with no TypeScript/data errors
- [x] `grep -c "<<<<<<\|>>>>>>>" proofs/Proofs/TractatusOntology.lean` returns 0
- [x] All section IDs in meta.json match proofId references in annotations.json
- [x] Four `[MAIN RESULT]` markers present in Lean file
- [x] Three `mainResult: true` flags in meta.json mainTheorems
- [x] Three `significance: "critical"` annotations for main results in annotations.json

Closes #10836

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>