### PR TITLE
Fix annotation alignment in tractatus-ontology

### DIFF
--- a/src/data/proofs/tractatus-ontology/annotations.json
+++ b/src/data/proofs/tractatus-ontology/annotations.json
@@ -186,7 +186,7 @@
   {
     "id": "ann-tractatus-thm6",
     "proofId": "tractatus-ontology",
-    "range": { "startLine": 440, "endLine": 452 },
+    "range": { "startLine": 441, "endLine": 452 },
     "type": "theorem",
     "title": "Double Negation (Classical Logic)",
     "content": "Double negation elimination: $\\neg\\neg p \\leftrightarrow p$ in every world. This uses `not_not` from Mathlib, which depends on `Classical.em`. The Tractatus assumes classical logic; an intuitionist would reject this equivalence, accepting only the left-to-right direction ($p \\to \\neg\\neg p$).",
@@ -324,7 +324,7 @@
   {
     "id": "ann-tractatus-ladder",
     "proofId": "tractatus-ontology",
-    "range": { "startLine": 1153, "endLine": 1175 },
+    "range": { "startLine": 1150, "endLine": 1172 },
     "type": "insight",
     "title": "The Ladder (TLP 6.54)",
     "content": "TLP 6.54: 'My propositions serve as elucidations in the following way: anyone who understands me eventually recognizes them as nonsensical, when he has used them — as steps — to climb beyond them. He must, so to speak, throw away the ladder after he has climbed up it.'\n\nEverything above is the ladder. The view from the top — that logical form is shared between language and reality rather than represented by either — is precisely what Lean, or any formal system, shows through its structure rather than states as a theorem. The residue left over after formalization is the most Wittgensteinian part.\n\n**[Interpretive choice]** The Tractatus is self-consciously paradoxical: it uses meaningful propositions to argue that certain things cannot be meaningfully said. Any formalization must pick a side — either the ladder is meaningful (in which case the self-undermining thesis fails) or it is not (in which case the formalization formalizes nothing). We take the first option: the formal skeleton is mathematically meaningful, and the philosophical claim about its limitations is carried by the annotations, not the code.",
@@ -334,7 +334,7 @@
   {
     "id": "ann-tractatus-proposition-seven",
     "proofId": "tractatus-ontology",
-    "range": { "startLine": 1177, "endLine": 1183 },
+    "range": { "startLine": 1174, "endLine": 1227 },
     "type": "theorem",
     "title": "Proposition 7 (TLP 7)",
     "content": "TLP 7: *Wovon man nicht sprechen kann, darueber muss man schweigen.* — 'Whereof one cannot speak, thereof one must be silent.'\n\nThe theorem `proposition_seven` proves that any proposition expressing a world-independent truth must be either a tautology or a contradiction. The object language can formally match any world-independent truth P — a tautology matches True, a contradiction matches False — but this matching is trivial. The proposition does not 'say' P in any meaningful sense.\n\nThe `axiom silence : True` enacts Wittgenstein's silence as a formal gesture — a deliberately axiomatic declaration that marks the boundary of formalization. It is trivially true but axiomatic by design, not by necessity.",


### PR DESCRIPTION
## Summary

- Fix three misaligned annotation ranges in `src/data/proofs/tractatus-ontology/annotations.json` that pointed to empty lines or mid-comment text instead of their intended code landmarks in the 1229-line `TractatusOntology.lean` file.
- **ann-tractatus-thm6**: 440-452 -> 441-452 (was starting at a blank line instead of the Theorem 6 comment)
- **ann-tractatus-ladder**: 1153-1175 -> 1150-1172 (was starting mid-comment and ending at the wrong block; now covers the full TLP 6.54 block comment)
- **ann-tractatus-proposition-seven**: 1177-1183 -> 1174-1227 (was starting mid-docstring; now covers the proposition_seven docstring, theorem, related expressibility theorems, and axiom silence)
- meta.json lineCount already correct at 1229 -- no change needed.

## Test plan

- [ ] Verify JSON is valid (confirmed via `python3 -m json.tool`)
- [ ] Confirm each corrected range starts at the intended landmark line by cross-referencing with `TractatusOntology.lean`
- [ ] Gallery build passes (`pnpm build`)

Generated with [Claude Code](https://claude.com/claude-code)