### PR TITLE
Tractatus: final polish -- strengthen framing, clean redundancy

### DIFF
--- a/proofs/Proofs/TractatusOntology.lean
+++ b/proofs/Proofs/TractatusOntology.lean
@@ -1195,7 +1195,8 @@ theorem nontrivial_expressibility_requires_world_dependence
   · obtain ⟨w₁, _, h₁, _⟩ := hnt
     exact (hcontra w₁) h₁
 
-/-- A nontrivial proposition cannot express any world-independent
+/-- **Corollary of `nontrivial_expressibility_requires_world_dependence`.**
+    A nontrivial proposition cannot express any world-independent
     property.  If `p` varies across worlds, there is no `P : Prop`
     such that `expresses p P`.  This is the typed form of the
     saying/showing boundary: genuine content cannot be pinned to a

--- a/src/data/proofs/tractatus-ontology/annotations.json
+++ b/src/data/proofs/tractatus-ontology/annotations.json
@@ -322,6 +322,17 @@
     "relatedConcepts": ["model theory", "invariance", "independence", "expressibility", "formal limits", "compositionality", "saying vs showing", "TLP 2.061", "TLP 5", "TLP 7"]
   },
   {
+    "id": "ann-tractatus-main-theorem",
+    "proofId": "tractatus-ontology",
+    "range": { "startLine": 1071, "endLine": 1112 },
+    "type": "theorem",
+    "title": "Central Result: Expressibility Requires World-Dependence",
+    "content": "Any attempt to represent world-independent content in a truth-functional language collapses to triviality; therefore, meaningful propositions must correspond to variation across possible worlds.\n\nThe argument proceeds in two steps. First, `world_constant_taut_or_contra` shows that any proposition with the same truth value in all worlds is either a tautology or a contradiction. Second, `saying_showing_triviality` applies this to the `expresses` relation: if a proposition tracks a fixed meta-level property P in every world, its truth value is world-constant, so it collapses to a tautology (when P is true) or a contradiction (when P is false). The downstream theorems `nontrivial_expressibility_requires_world_dependence` and `nontrivial_cannot_express_world_independent` derive that nontrivial propositions -- those that are true in some worlds and false in others -- cannot express any world-independent content at all.",
+    "mathContext": "The key lemma `world_constant_taut_or_contra` uses `Classical.em` (via `by_cases`) to split on whether the proposition holds in a reference world. The `saying_showing_triviality` theorem reduces the `expresses` hypothesis to the world-constant case via transitivity of biconditionals. Together they establish a provable boundary on the expressive power of the object language: the only world-independent facts it can represent are the trivially true and the trivially false.",
+    "significance": "critical",
+    "relatedConcepts": ["TLP 7", "TLP 4.46", "expressibility", "world-dependence", "tautology", "contradiction", "saying vs showing", "formal limits"]
+  },
+  {
     "id": "ann-tractatus-ladder",
     "proofId": "tractatus-ontology",
     "range": { "startLine": 1150, "endLine": 1172 },
@@ -334,7 +345,7 @@
   {
     "id": "ann-tractatus-proposition-seven",
     "proofId": "tractatus-ontology",
-    "range": { "startLine": 1174, "endLine": 1227 },
+    "range": { "startLine": 1174, "endLine": 1228 },
     "type": "theorem",
     "title": "Proposition 7 (TLP 7)",
     "content": "TLP 7: *Wovon man nicht sprechen kann, darueber muss man schweigen.* — 'Whereof one cannot speak, thereof one must be silent.'\n\nThe theorem `proposition_seven` proves that any proposition expressing a world-independent truth must be either a tautology or a contradiction. The object language can formally match any world-independent truth P — a tautology matches True, a contradiction matches False — but this matching is trivial. The proposition does not 'say' P in any meaningful sense.\n\nThe `axiom silence : True` enacts Wittgenstein's silence as a formal gesture — a deliberately axiomatic declaration that marks the boundary of formalization. It is trivially true but axiomatic by design, not by necessity.",

--- a/src/data/proofs/tractatus-ontology/meta.json
+++ b/src/data/proofs/tractatus-ontology/meta.json
@@ -2,7 +2,7 @@
   "id": "tractatus-ontology",
   "title": "Wittgenstein's Tractarian Ontology",
   "slug": "tractatus-ontology",
-  "description": "A Lean 4 formalization of the structural core of Wittgenstein's Tractatus Logico-Philosophicus: objects, states of affairs, worlds, propositions, truth-functionality, and first-order quantifiers. Proves compositionality for both propositional and first-order languages. Extends to HOAS-encoded quantifiers with duality and distribution theorems. Ends with a deliberate axiom — the silence of Proposition 7.",
+  "description": "This work reconstructs the Tractatus as a parameterized model-theoretic system and proves that its central philosophical claims correspond to explicit semantic constraints and provable limits of expressibility.",
   "meta": {
     "status": "axiomatized",
     "tags": ["philosophy", "logic", "ontology", "model-theory", "truth-functions"],
@@ -40,12 +40,12 @@
     ],
     "dateAdded": "04/14/26",
     "axiomCount": 1,
-    "lineCount": 1229,
+    "lineCount": 1230,
     "assumptions": "One deliberate axiom: `silence : True` (TLP 7) — a trivially true but axiomatic declaration that enacts Wittgenstein's silence as a formal gesture. All theorems are fully proved with 0 sorries. Uses classical logic (Classical.em) throughout. The companion file TractatusQuantifiers.lean has no sorries or axioms."
   },
   "overview": {
     "historicalContext": "The Tractatus Logico-Philosophicus (1921) is Wittgenstein's only book-length philosophical work published in his lifetime. It presents a logical atomist ontology: the world consists of facts (obtaining states of affairs), propositions picture possible states of affairs, and all meaningful propositions are truth-functions of elementary propositions. The work culminates in proposition 6.54 — the famous ladder that must be thrown away — and the closing injunction: 'Whereof one cannot speak, thereof one must be silent.'",
-    "problemStatement": "Can the structural core of the Tractatus — its ontology of objects, states of affairs, worlds, truth-functional propositions, and quantifiers — be faithfully formalized in a modern proof assistant? What is captured by formalization, and what necessarily escapes?",
+    "problemStatement": "This work reconstructs the Tractatus as a parameterized model-theoretic system and proves that its central philosophical claims correspond to explicit semantic constraints and provable limits of expressibility.",
     "proofStrategy": "We define types for objects (opaque), states of affairs (abstract), and worlds (predicates on states of affairs). Propositions form an inductive type with elementary, negation, and conjunction constructors. All other connectives are derived. A recursive evaluation function maps propositions to truth values relative to worlds. We then extend to first-order propositions (FOProp) using higher-order abstract syntax (HOAS) for quantifier binding, and prove compositionality, duality, and distribution theorems for the extended language.",
     "keyInsights": [
       "The world-as-predicate encoding makes elementary independence trivially true — the assignment IS the world; this is the free model, and constrained models break independence",
@@ -170,7 +170,7 @@
       "id": "limits",
       "title": "The Limits of Formalization (TLP 6.54, 7)",
       "startLine": 1071,
-      "endLine": 1229,
+      "endLine": 1230,
       "summary": "World-constant triviality lemma, saying/showing triviality theorem, contingent propositions theorem, nontrivial predicate theorems, proposition seven, nontrivial expressibility theorems, the ladder of TLP 6.54, and the axiom of silence."
     }
   ],
@@ -227,7 +227,7 @@
     "imports": ["Mathlib.Tactic"],
     "opens": [],
     "namespace": "Tractatus",
-    "lineCount": 1229,
+    "lineCount": 1230,
     "axiomCount": 1,
     "theoremCount": 37,
     "definitionCount": 29,


### PR DESCRIPTION
## Summary

- **meta.json**: Updated `description` and `overview.problemStatement` with the stronger framing: "This work reconstructs the Tractatus as a parameterized model-theoretic system and proves that its central philosophical claims correspond to explicit semantic constraints and provable limits of expressibility."
- **TractatusOntology.lean**: Marked `nontrivial_cannot_express_world_independent` as a corollary of `nontrivial_expressibility_requires_world_dependence` in its docstring.
- **annotations.json**: Added `ann-tractatus-main-theorem` annotation at the start of the limits section (lines 1071-1112) summarizing the central result: "Any attempt to represent world-independent content in a truth-functional language collapses to triviality; therefore, meaningful propositions must correspond to variation across possible worlds."
- Updated `lineCount` (1229 -> 1230) and section/annotation endLine values to account for the added docstring line.
- Verified all 36 annotation ranges against the 1230-line file -- all are correctly aligned.

## Test plan

- [x] `pnpm build` passes
- [x] JSON files validated (meta.json, annotations.json)
- [x] All 36 annotation ranges verified within bounds of 1230-line Lean file
- [x] No changes to Lean proof code (only docstring addition)

Closes #10866

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>