### PR TITLE
Fix stale sorryCount in BezoutIdentityOQ01 metadata

### DIFF
--- a/src/data/research/problems/bezout-identity-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01.json
@@ -84,11 +84,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ01.lean",
       "filename": "BezoutIdentityOQ01.lean",
-      "lineCount": 209,
+      "lineCount": 208,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },


### PR DESCRIPTION
## Summary
- Corrects `sorryCount` from 1 to 0 in `bezout-identity-oq-01.json` research metadata — the Lean file (`proofs/Proofs/BezoutIdentityOQ01.lean`) has been fully proven with zero sorries since it was merged
- Also fixes `lineCount` from 209 to the actual 208

## Test plan
- [ ] Verify `proofs/Proofs/BezoutIdentityOQ01.lean` contains no `sorry` (confirmed: only occurrence is in a comment stating "no sorry")
- [ ] Confirm metadata JSON now matches actual file stats

Generated with [Claude Code](https://claude.com/claude-code)