### PR TITLE
Centralize Erdos pipeline max problem number (1200 -> 1250)

### DIFF
--- a/scripts/erdos/cache.ts
+++ b/scripts/erdos/cache.ts
@@ -5,6 +5,7 @@
 import * as fs from 'fs'
 import * as path from 'path'
 import type { CacheEntry, CacheManifest } from './types'
+import { MAX_PROBLEM_NUMBER } from './types'
 
 const CACHE_DIR = '.erdos-cache'
 const MANIFEST_FILE = 'manifest.json'
@@ -337,7 +338,7 @@ export function getCachedProblemNumbers(config: CacheConfig = defaultConfig): nu
  */
 export function getNextUncachedBatch(
   batchSize: number,
-  maxProblem = 1200,
+  maxProblem = MAX_PROBLEM_NUMBER,
   config: CacheConfig = defaultConfig
 ): number[] {
   const cached = new Set(getCachedProblemNumbers(config))
@@ -355,7 +356,7 @@ export function getNextUncachedBatch(
 /**
  * Get progress summary
  */
-export function getProgressSummary(maxProblem = 1200, config: CacheConfig = defaultConfig): {
+export function getProgressSummary(maxProblem = MAX_PROBLEM_NUMBER, config: CacheConfig = defaultConfig): {
   cached: number
   remaining: number
   total: number

--- a/scripts/erdos/index.ts
+++ b/scripts/erdos/index.ts
@@ -24,6 +24,7 @@
  */
 
 import type { CliOptions, PipelineStats, TransformedProblem } from './types'
+import { MAX_PROBLEM_NUMBER } from './types'
 import { getCacheStats, ensureCacheDir, getProgressSummary, getNextUncachedBatch, getSlowConfig, getVerySlowConfig } from './cache'
 import { scrapeRange, scrapeProblems, getScrapeStats } from './scrape'
 import { transformProblems, getTransformStats } from './transform'
@@ -253,9 +254,9 @@ async function runPipeline(options: CliOptions): Promise<PipelineStats> {
     console.log(`Step 1: Scraping problems ${range.start}-${range.end}...`)
     scraped = await scrapeRange(range.start, range.end, config, !options.refresh, undefined, options.playwright)
   } else {
-    // Default: scrape all (1-1200)
-    console.log('Step 1: Scraping all problems 1-1200...')
-    scraped = await scrapeRange(1, 1200, config, !options.refresh, undefined, options.playwright)
+    // Default: scrape all (1-MAX_PROBLEM_NUMBER)
+    console.log(`Step 1: Scraping all problems 1-${MAX_PROBLEM_NUMBER}...`)
+    scraped = await scrapeRange(1, MAX_PROBLEM_NUMBER, config, !options.refresh, undefined, options.playwright)
   }
   stats.totalScraped = scraped.length
 

--- a/scripts/erdos/scrape.ts
+++ b/scripts/erdos/scrape.ts
@@ -10,6 +10,7 @@
  */
 
 import type { ScrapedProblem, ScrapedStatus } from './types'
+import { MAX_PROBLEM_NUMBER } from './types'
 import {
   getCachedHtml,
   getCachedLatex,
@@ -522,7 +523,7 @@ export async function scrapeRange(
 }
 
 /**
- * Scrape all known problems (1-1200 to cover gaps)
+ * Scrape all known problems (1-MAX_PROBLEM_NUMBER to cover gaps)
  */
 export async function scrapeAll(
   config?: CacheConfig,
@@ -530,7 +531,7 @@ export async function scrapeAll(
   onProgress?: (current: number, total: number, problem: ScrapedProblem | null) => void,
   usePlaywright = false
 ): Promise<ScrapedProblem[]> {
-  return scrapeRange(1, 1200, config, useCache, onProgress, usePlaywright)
+  return scrapeRange(1, MAX_PROBLEM_NUMBER, config, useCache, onProgress, usePlaywright)
 }
 
 /**

--- a/scripts/erdos/types.ts
+++ b/scripts/erdos/types.ts
@@ -6,6 +6,15 @@
 export type { ErdosProblemStatus, ProofMeta, ProofBadge } from '../../src/types/proof'
 
 /**
+ * Maximum problem number on erdosproblems.com.
+ *
+ * The site currently lists 1,217 problems. We use 1250 to leave headroom
+ * so newly added problems are picked up without another code change.
+ * Bump this constant when the site grows past the current ceiling.
+ */
+export const MAX_PROBLEM_NUMBER = 1250
+
+/**
  * Problem status as scraped from erdosproblems.com
  */
 export type ScrapedStatus = 'OPEN' | 'SOLVED' | 'PARTIALLY_SOLVED'
@@ -14,7 +23,7 @@ export type ScrapedStatus = 'OPEN' | 'SOLVED' | 'PARTIALLY_SOLVED'
  * Raw problem data scraped from erdosproblems.com
  */
 export interface ScrapedProblem {
-  /** Problem number (1-1135+) */
+  /** Problem number (1-1217+) */
   number: number
   /** Problem title extracted from page */
   title: string


### PR DESCRIPTION
## Summary

- Introduces `MAX_PROBLEM_NUMBER = 1250` in `scripts/erdos/types.ts` as the single source of truth for the scraping ceiling
- Replaces all six hardcoded `1200` references across `cache.ts`, `scrape.ts`, and `index.ts`
- Provides headroom above the site's current 1,217 problems so new additions are picked up automatically

Closes #10870

## Acceptance Criteria Verification

| Criterion | Status |
|-----------|--------|
| Shared constant in types.ts | Done (`MAX_PROBLEM_NUMBER = 1250`) |
| cache.ts `getNextUncachedBatch` default updated | Done |
| cache.ts `getProgressSummary` default updated | Done |
| scrape.ts `scrapeAll` range updated | Done |
| index.ts default scrape path updated | Done |
| generate-gallery.ts checked for limits | Confirmed clean -- no hardcoded caps |
| No remaining hardcoded 1200 in erdos scripts | Confirmed via grep |
| Type check passes | `pnpm tsc --noEmit` clean |

## Test plan

- [ ] `pnpm tsc --noEmit` passes (verified)
- [ ] `grep -r 1200 scripts/erdos/*.ts` returns no matches (verified)
- [ ] Running `--status` shows total = 1250 instead of 1200
- [ ] Running `--batch 5` targets problems beyond 1200 when lower numbers are cached

🤖 Generated with [Claude Code](https://claude.com/claude-code)