### PR TITLE
Audit: fix sorry count — cantor-easton-oq-03 (2 sorries → 0)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12612,9 +12612,9 @@
       "issues": []
     },
     "cantor-diagonalization-oq-01-oq-01-oq-02-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-14T21:51:41Z",
-      "result": "clean",
+      "auditCount": 2,
+      "lastAudited": "2026-04-21T10:54:04Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "cauchy-schwarz-integral-oq-01-oq-03": {

--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-02-oq-03/meta.json
@@ -2,7 +2,7 @@
   "id": "cantor-diagonalization-oq-01-oq-01-oq-02-oq-03",
   "title": "Easton's Theorem: The Full Spectrum of the Generalized Continuum Function",
   "slug": "cantor-diagonalization-oq-01-oq-01-oq-02-oq-03",
-  "description": "Formalizes the necessary conditions for Easton's spectrum: (E1) 2^{ℵ_α} ≥ ℵ_{α+1} (Cantor lower bound), (E2) monotonicity of the continuum function, and (E3) König's cofinality constraint cf(2^{ℵ_α}) > ℵ_α for all regular cardinals. The consistency direction (any function satisfying E1-E3 is realizable via class forcing) is sorry'd as it requires Easton product forcing.",
+  "description": "Formalizes the necessary conditions for Easton's spectrum: (E1) 2^{ℵ_α} ≥ ℵ_{α+1} (Cantor lower bound), (E2) monotonicity of the continuum function, and (E3) König's cofinality constraint cf(2^{ℵ_α}) > ℵ_α for all regular cardinals. The consistency direction (any function satisfying E1-E3 is realizable via class forcing) is stated as a True placeholder, as it requires Easton product forcing not yet formalized in Mathlib.",
   "meta": {
     "author": "researcher-6",
     "sourceUrl": "https://en.wikipedia.org/wiki/Easton%27s_theorem",
@@ -17,10 +17,10 @@
       "koenig-theorem"
     ],
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 0,
     "axiomCount": 0,
     "lineCount": 179,
-    "assumptions": "No axioms. 2 sorries: (1) easton_iff_characterization — the consistency direction of Easton's theorem, requiring class (Easton product) forcing, which is not formalized in Mathlib; (2) cofinality computation for ℵ_{α+ω} in easton_excludes_limit_alephs. 5 theorems fully proved.",
+    "assumptions": "No axioms, no sorries. Mathematical content present but unproved via 3 True-stub theorems: easton_consistency, easton_full_characterization, and easton_iff_characterization all prove True as placeholders for the forcing-based consistency direction. The cofinality exclusion theorem (easton_excludes_limit_alephs) is now fully proved. 4 theorems fully proved (easton_lower_bound, easton_monotone, easton_konig_general, easton_konig_aleph, easton_excludes_limit_alephs, continuum_satisfies_easton).",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -96,9 +96,9 @@
     "theoremCount": 7,
     "definitionCount": 1,
     "path": "Proofs/CantorDiagonalizationOQ01OQ01OQ02OQ03.lean",
-    "sorries": 2
+    "sorries": 0
   },
-  "sorries": 2,
+  "sorries": 0,
   "crossReferences": [
     {
       "targetId": "cantor-diagonalization-oq-01-oq-01-oq-02",


### PR DESCRIPTION
## Summary

- `cantor-diagonalization-oq-01-oq-01-oq-02-oq-03` (Easton's Theorem): meta.json claimed `sorries: 2` but the Lean file has **0 sorry keywords**
- The two previously-sorry'd items were resolved: one became True stubs (forcing direction), one fully proved (cofinality exclusion `easton_excludes_limit_alephs`)
- Updated `sorries` field from 2→0 in `meta.sorries`, `leanFile.sorries`, and top-level `sorries`
- Updated `assumptions` text to accurately describe the 3 True stubs (not sorries) and note that cofinality theorem is now complete
- Updated description to say "stated as a True placeholder" rather than "sorry'd"
- Audit tracker updated: `issues-fixed`

## Evidence

**meta.json claimed**: `"sorries": 2` with assumptions listing 2 specific sorries  
**Lean file shows**: `grep -c "sorry" file.lean` → 1 (only in a comment); no actual `sorry` tactic calls

## Severity

HIGH (sorry count mismatch) — fixed directly

---
Discovered during gallery integrity audit.