### PR TITLE
Fix: stale lineCount in 12 gallery proofs

### DIFF
--- a/src/data/proofs/bertrands-postulate-oq-03-oq-04-oq-03/meta.json
+++ b/src/data/proofs/bertrands-postulate-oq-03-oq-04-oq-03/meta.json
@@ -61,7 +61,7 @@
     ],
     "dateAdded": "2026-04-14",
     "axiomCount": 0,
-    "lineCount": 185,
+    "lineCount": 214,
     "assumptions": "0 axioms, 0 sorries. The proof is fully verified from PrimeNumberTheorem (which carries 1 axiom for the PNT itself) and Mathlib's filter analysis library.",
     "mathlib_version": "4.26.0",
     "relatedProblems": [
@@ -175,7 +175,7 @@
       "PrimeNumberTheorem"
     ],
     "namespace": "BertrandsPostulateOQ03OQ04OQ03",
-    "lineCount": 185,
+    "lineCount": 214,
     "axiomCount": 0,
     "sorries": 0,
     "path": "Proofs/BertrandsPostulateOQ03OQ04OQ03.lean",

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-03/meta.json
@@ -20,7 +20,7 @@
     "badge": "original",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 202,
+    "lineCount": 223,
     "assumptions": "One sorry: multinomial_cross_moment (E[XᵢXⱼ] = n(n-1)pᵢpⱼ). The main structure theorem multinomial_covariance is proved modulo this cross-moment sorry.",
     "theoremCount": 4,
     "mathlib_version": "4.26.0"
@@ -84,7 +84,7 @@
       "multinomial_cross_moment",
       "multinomial_covariance"
     ],
-    "lineCount": 202,
+    "lineCount": 223,
     "axiomCount": 0,
     "sorries": 1
   },

--- a/src/data/proofs/binomial-theorem-oq-02-oq-04/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-04/meta.json
@@ -21,7 +21,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 200,
+    "lineCount": 208,
     "theoremCount": 6,
     "assumptions": "None. The proof is fully machine-checked with no sorry or axiom declarations beyond Mathlib's standard axioms.",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 4,
     "axiomCount": 1,
-    "lineCount": 246,
+    "lineCount": 280,
     "assumptions": "1 axiom: kostochka_pyber_r2 (the r=2 graph case of Kostochka-Pyber theorem, proven 1988). 4 sorries in this file (geometric edge-crossing verifications).",
     "dateAdded": "2026-04-03",
     "mathlib_version": "4.26.0"
@@ -127,7 +127,7 @@
       "Proofs.Erdos1018OQ04"
     ],
     "namespace": "Erdos1018OQ04Completion",
-    "lineCount": 246,
+    "lineCount": 280,
     "axiomCount": 1,
     "theoremCount": 11,
     "path": "Proofs/Erdos1018OQ04Incomplete01.lean",

--- a/src/data/proofs/erdos-1050/meta.json
+++ b/src/data/proofs/erdos-1050/meta.json
@@ -63,7 +63,7 @@
       "erdos-257"
     ],
     "axiomCount": 2,
-    "lineCount": 405,
+    "lineCount": 483,
     "assumptions": "2 axioms: borwein_irrationality (Borwein's 1991 Padé approximation result for T(q,r)), S_approx (numerical bounds 0.286 < S < 0.288). 0 sorries: T_summable (convergence of T(q,r)), S_first_terms (initial partial sum identity)."
   },
   "overview": {
@@ -229,7 +229,7 @@
       "Real"
     ],
     "namespace": "Erdos1050",
-    "lineCount": 405,
+    "lineCount": 483,
     "axiomCount": 2,
     "theoremCount": 26,
     "definitionCount": 9,

--- a/src/data/proofs/erdos-117-oq-01/meta.json
+++ b/src/data/proofs/erdos-117-oq-01/meta.json
@@ -25,7 +25,7 @@
     "erdosNumber": 117,
     "erdosUrl": "https://erdosproblems.com/117",
     "erdosProblemStatus": "open",
-    "lineCount": 204
+    "lineCount": 270
   },
   "overview": {
     "historicalContext": "**Pinning Down the Exponential Base**\n\nErdős introduced the abelian covering number h(n) as part of his investigation of commutativity in finite groups. A group G has the n-commuting property if among any n+2 elements, at least two commute — or equivalently, G cannot be partitioned into n+1 pairwise non-commuting pairs. The covering number h(n) asks: what is the minimum size of a cover by abelian subgroups that works for all groups with this property?\n\nThe first exponential lower bound was proved by Isaacs in earlier work. Pyber's landmark 1987 paper established both exponential bounds c₁ⁿ ≤ h(n) ≤ c₂ⁿ with explicit constants satisfying c₂ > c₁ > 1. This settled the 'polynomial vs exponential' question but opened a new one: do the bounds converge to a single exponential base? Knowing the precise base c would give h(n) = Θ(cⁿ) — a clean asymptotic characterization.\n\nThe connection to Fekete's lemma (1923) provides a natural structural approach. Fekete's theorem states that subadditive functions f (with f(m+n) ≤ f(m)+f(n)) satisfy lim f(n)/n = inf f(n)/n. If h is submultiplicative (h(m+n) ≤ h(m)·h(n)), then log h is subadditive and the limit exists. The question of submultiplicativity of h is thus a key open structural problem.",
@@ -132,7 +132,7 @@
       "Filter"
     ],
     "namespace": "Erdos117OQ01",
-    "lineCount": 204,
+    "lineCount": 270,
     "axiomCount": 3,
     "theoremCount": 8,
     "substantiveTheoremCount": 5,

--- a/src/data/proofs/ptolemys-theorem-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01-incomplete-01/meta.json
@@ -59,7 +59,7 @@
     ],
     "dateAdded": "2026-04-13",
     "axiomCount": 0,
-    "lineCount": 466,
+    "lineCount": 490,
     "assumptions": "None. Fully machine-checked: 0 sorries, 0 axioms. The hcx identity proved via mul_left_cancel₀ with factor (2I)²·E₁₂E₃₄, using hE (phase cancellation) and ring.",
     "theoremCount": 7,
     "definitionCount": 0

--- a/src/data/proofs/shapley-folkman/meta.json
+++ b/src/data/proofs/shapley-folkman/meta.json
@@ -61,7 +61,7 @@
       "Caratheodory's theorem (points in convex hull need at most d+1 vertices)",
       "Affine independence and dimension"
     ],
-    "lineCount": 469,
+    "lineCount": 756,
     "mathlib_version": "4.26.0",
     "leanFile": {
       "imports": [
@@ -201,7 +201,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 469,
+    "lineCount": 756,
     "structureCount": 1,
     "axiomCount": 0,
     "theoremCount": 8,


### PR DESCRIPTION
## Fix

Updates `lineCount` metadata to match current Lean file line counts for 12 proofs whose files were extended by researcher agents without updating meta.json.

## Evidence

**Before → After**: shapley-folkman 469→756, erdos-73 226→311, erdos-263 385→469, erdos-1050 405→483, erdos-117-oq-01 204→270, erdos-1018-oq-04-incomplete-01 246→280, bertrands-postulate-oq-03-oq-04-oq-03 185→214, ptolemys-theorem-oq-01-incomplete-01 466→490, binomial-theorem-oq-02-oq-01-oq-03 202→223, erdos-109-oq-01 487→474, binomial-theorem-oq-02-oq-04 200→208, cayley-hamilton-minpoly-oq-03-oq-01 200→207.

**Validation**: `pnpm build` passes.

---
Automated fix by lean-mechanic agent.