### PR TITLE
Audit: fix erdos-109-oq-01 — axiomCount 0→3, sorries 3→0, status→axiomatized

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12408,8 +12408,8 @@
       "issues": []
     },
     "erdos-109-oq-01": {
-      "auditCount": 7,
-      "lastAudited": "2026-04-14T22:22:03Z",
+      "auditCount": 8,
+      "lastAudited": "2026-04-21T11:03:29Z",
       "result": "issues-fixed",
       "issues": []
     },
@@ -12624,9 +12624,9 @@
       "issues": []
     },
     "cayley-hamilton-minpoly-oq-03-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-14T21:51:41Z",
-      "result": "clean",
+      "auditCount": 2,
+      "lastAudited": "2026-04-21T11:01:10Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "erdos-181-oq-01": {

--- a/src/data/proofs/erdos-109-oq-01/meta.json
+++ b/src/data/proofs/erdos-109-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius",
     "sourceUrl": "https://erdosproblems.com/109",
     "date": "2026-04-12",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos109OQ01.lean",
     "tags": [
       "additive-combinatorics",
@@ -16,11 +16,11 @@
       "hindman",
       "ip-sets"
     ],
-    "badge": "wip",
-    "sorries": 3,
+    "badge": "axiom",
+    "sorries": 0,
     "dateAdded": "2026-04-12",
-    "axiomCount": 0,
-    "assumptions": "No formal axiom declarations. 3 sorries: (1) posUpperDensity_piecewiseSyndetic — piecewise syndeticity from positive density (pigeonhole); (2) hindman_theorem positivity gap — ultrafilter non-principality argument for positive sequence elements; (3) posUpperDensity_ipStar — positive density implies IP* (Furstenberg-Katznelson IP Szemerédi 1985). hindman_theorem converted from axiom to theorem with partial Mathlib proof.",
+    "axiomCount": 3,
+    "assumptions": "3 axioms: (1) posUpperDensity_piecewiseSyndetic — piecewise syndeticity from positive density (pigeonhole argument not yet in Mathlib); (2) hindman_theorem — Hindman (1974) via idempotent ultrafilters; (3) posUpperDensity_ipStar — Furstenberg-Katznelson IP Szemerédi theorem (1985). Previously stated as sorries; converted to axiom declarations reflecting their status as deep results assumed without Lean proof.",
     "lineCount": 487,
     "theoremCount": 7,
     "definitionCount": 10,
@@ -97,11 +97,11 @@
   "leanFile": {
     "namespace": "Erdos109OQ01",
     "lineCount": 487,
-    "axiomCount": 0,
+    "axiomCount": 3,
     "theoremCount": 7,
     "definitionCount": 10,
     "path": "Proofs/Erdos109OQ01.lean",
-    "sorries": 3
+    "sorries": 0
   },
   "crossReferences": [
     {
@@ -110,5 +110,5 @@
       "description": "Explores gap conditions for the sumset conjecture proved by MRR (2019)"
     }
   ],
-  "sorries": 3
+  "sorries": 0
 }


### PR DESCRIPTION
## Summary

- **Proof**: erdos-109-oq-01 (Erdős Sumset Conjecture: Gap Conditions and IP Sets)
- **Issues**: Two integrity violations:
  1. `axiomCount: 0` but Lean file has **3 `axiom` declarations**: `posUpperDensity_piecewiseSyndetic`, `hindman_theorem`, `posUpperDensity_ipStar`
  2. `sorries: 3` but actual sorry count is **0** (previous sorries were converted to axiom declarations)

## Root Cause

The proof was refactored: 3 `sorry` keywords were replaced with `axiom` declarations, but meta.json was never updated. The `assumptions` text still says "No formal axiom declarations. 3 sorries..."

## Changes

- `axiomCount`: 0 → 3
- `leanFile.axiomCount`: 0 → 3
- `sorries` (all 3 fields): 3 → 0
- `status`: `"formalized"` → `"axiomatized"` (per policy: has axiom declarations)
- `badge`: `"wip"` → `"axiom"`
- `assumptions`: updated to accurately describe 3 axioms, 0 sorries

## Evidence

```
grep -n "^axiom" proofs/Proofs/Erdos109OQ01.lean
73:axiom posUpperDensity_piecewiseSyndetic
278:axiom hindman_theorem
299:axiom posUpperDensity_ipStar
```

---
Discovered during gallery integrity audit.