### PR TITLE
Research: divisibility-rules-oq-02 — mark completed (0 sorries, 0 axioms)

### DIFF
--- a/research/problems/divisibility-rules-oq-02/knowledge.md
+++ b/research/problems/divisibility-rules-oq-02/knowledge.md
@@ -1,21 +1,29 @@
 # Knowledge Base: divisibility-rules-oq-02
 
-Insights accumulated during research on this problem.
+**Problem**: Divisibility by 7 and 13 via alternating 3-digit block sums  
+**Status**: COMPLETED (0 sorries, 0 axioms)  
+**Lean file**: `proofs/Proofs/DivisibilityRulesOQ02.lean` (143 lines)
 
 ---
 
-## Problem Understanding
+## Session 2026-04-21 (Session 1) - Proof Already Complete
 
-[Initial observations about the problem will be recorded here]
+**Mode**: FRESH  
+**Outcome**: completed
 
----
+### What I Did
 
-## Insights
+Found that `DivisibilityRulesOQ02.lean` is fully verified with 0 sorries and 0 axioms.
+Updated knowledge tracking to reflect completion.
 
-[Insights from research attempts will be accumulated here]
+### Key Findings
 
----
+- The proof formalizes the general theorem `dvd_iff_dvd_altDigitSum`: for any d > 0 and base b with `b % d = d - 1` (i.e., b ≡ -1 mod d), we have `d | n ↔ d | altDigitSum b n`.
+- Instantiated for d=7 (b=1000), d=13 (b=1000), d=11 (b=10), d=101 (b=100).
+- Key fact `1000 % 7 = 6` proved by `native_decide`; all instances follow by one-line delegation.
+- The shared 3-digit rule for 7 and 13 arises from `7 × 11 × 13 = 1001 = 1000 + 1`.
 
-## Dead Ends
+### Potential Follow-Ups
 
-[Approaches known not to work will be documented here]
+1. **For which primes p does 10^k ≡ -1 (mod p) hold for some k?** The answer is: primes p where the multiplicative order of 10 mod p is even, equivalently where -1 is a power of 10 mod p. Characterize by Legendre symbols or splitting in cyclotomic fields.
+2. **Base-agnostic generalization**: Can we prove a Lean theorem parameterized over the base B, showing divisibility-by-d tests from B^k ≡ ±1 (mod d) for any B? This would subsume base-10, base-2, base-16 rules simultaneously.

--- a/src/data/research/problems/divisibility-rules-oq-02.json
+++ b/src/data/research/problems/divisibility-rules-oq-02.json
@@ -1,8 +1,8 @@
 {
   "slug": "divisibility-rules-oq-02",
   "title": "[Problem Title]",
-  "phase": "OBSERVE",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "fast",
   "problemStatement": {
@@ -16,7 +16,7 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "COMPLETED",
     "since": "2026-04-05T23:12:43-07:00",
     "iteration": 1,
     "focus": "Initial problem understanding. Read problem.md and gather context.",
@@ -29,9 +29,21 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETE: Fully verified (0 sorries, 0 axioms). General alternating block divisibility rule proved and instantiated for 7, 13, 11, 101.",
+    "builtItems": [
+      "DivisibilityRulesOQ02.lean:54 — dvd_iff_dvd_altDigitSum (general rule)",
+      "DivisibilityRulesOQ02.lean:36 — seven_modEq_altDigitSum_1000",
+      "DivisibilityRulesOQ02.lean:73 — seven_dvd_iff_altDigitSum",
+      "DivisibilityRulesOQ02.lean:84 — thirteen_dvd_iff_altDigitSum",
+      "DivisibilityRulesOQ02.lean:118 — eleven_dvd_iff_altDigitSum",
+      "DivisibilityRulesOQ02.lean:123 — hundredone_dvd_iff_altDigitSum"
+    ],
+    "insights": [
+      "General theorem dvd_iff_dvd_altDigitSum: for b ≡ -1 (mod d), d | n ↔ d | altDigitSum b n",
+      "1000 ≡ -1 (mod 7) and (mod 13) because 7 × 11 × 13 = 1001 = 1000 + 1",
+      "All classical alternating-sum divisibility rules are one-line instances of a single algebraic theorem",
+      "Key congruences proved by native_decide; divisibility equivalences follow from modEq linearity"
+    ],
     "mathlibGaps": [],
     "nextSteps": [],
     "markdown": "# Knowledge Base: divisibility-rules-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"


### PR DESCRIPTION
## Summary

- Marks `divisibility-rules-oq-02` as completed in the research pool and knowledge files
- Proof `DivisibilityRulesOQ02.lean` was already fully verified (0 sorries, 0 axioms); tracking files were stale
- Documents key results and insights in `knowledge.md`

## What was already proved

| Theorem | Statement |
|---------|-----------|
| `dvd_iff_dvd_altDigitSum` | General rule: b ≡ -1 (mod d) ⟹ d \| n ↔ d \| altDigitSum b n |
| `seven_dvd_iff_altDigitSum` | 7 \| n ↔ 7 \| alternating sum of 3-digit blocks |
| `thirteen_dvd_iff_altDigitSum` | 13 \| n ↔ 13 \| alternating sum of 3-digit blocks |
| `eleven_dvd_iff_altDigitSum` | Classical div-by-11 as instance of general rule |
| `hundredone_dvd_iff_altDigitSum` | 2-digit block rule for 101 |

The shared 3-digit rule for 7 and 13 follows from 7 × 11 × 13 = 1001 = 1000 + 1.

## Files Modified

- `research/problems/divisibility-rules-oq-02/knowledge.md` — populated with findings
- `src/data/research/problems/divisibility-rules-oq-02.json` — status → completed, knowledge populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)