### PR TITLE
Audit: fix erdos-73 sorry count (1→0) — all sorries proved

### DIFF
--- a/src/data/proofs/erdos-73/meta.json
+++ b/src/data/proofs/erdos-73/meta.json
@@ -17,7 +17,7 @@
       "structural-graph-theory"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 73,
     "erdosUrl": "https://erdosproblems.com/73",
     "erdosProblemStatus": "solved",
@@ -74,7 +74,7 @@
     ],
     "axiomCount": 3,
     "lineCount": 226,
-    "assumptions": "3 axioms: reed_bound, reed_theorem, reed_bound_zero. 1 sorry: trivial_case (strict condition ⇒ bipartite via odd cycle argument). Previously 4 sorries; bipartite_deficiency_zero, strict_implies_bipartite, and K3_violates_strict are now fully proved."
+    "assumptions": "3 axioms: reed_bound, reed_theorem, reed_bound_zero. 0 sorries. All 4 previously sorry'd theorems (trivial_case, bipartite_deficiency_zero, strict_implies_bipartite, K3_violates_strict) are now fully proved."
   },
   "overview": {
     "historicalContext": "**Origins: Independence and Bipartiteness**\n\nThe connection between independence number and bipartiteness is classical: a graph $G$ is bipartite if and only if $\\alpha(G[S]) \\ge |S|/2$ for every induced subgraph $G[S]$. This follows from the odd cycle characterization — an odd cycle $C_{2m+1}$ has $\\alpha = m < (2m+1)/2$, so any non-bipartite graph violates the condition.\n\n**Erdős's Question**\n\nErdős asked a natural structural question: if we relax the condition to $\\alpha(G[S]) \\ge (|S| - k)/2$ for some fixed $k \\ge 0$, must $G$ still be 'close to bipartite'? Specifically, can $G$ be made bipartite by removing at most $f(k)$ vertices, where $f(k)$ depends only on $k$ and not on $|V(G)|$? The power of this question lies in the quantifier structure — a fixed finite bound controlling an arbitrarily large graph.\n\n**Reed's Solution (1999)**\n\nBruce Reed proved the affirmative answer in his paper 'Mangoes and Blueberries' (Combinatorica 1999). The proof uses the Erdős-Pósa theorem for odd cycles: the $k$-independence condition bounds the number of vertex-disjoint odd cycles in $G$, and bounded packing implies a bounded transversal (a set of vertices hitting all odd cycles). Reed's bound is $f(k) \\le 2^k$, but the optimal growth rate remains unknown.\n\n**Significance**\n\nThe result is a prototype for structural graph theory results showing that 'approximate' satisfaction of a property (bipartiteness) forces 'approximate' structure (few exceptional vertices). This paradigm appears throughout the Graph Minors Project of Robertson and Seymour.",
@@ -182,8 +182,7 @@
     "openQuestions": [
       "What is the optimal growth rate of $f(k)$? Is $f(k) = O(k)$ or $f(k) = O(\\text{poly}(k))$?",
       "Can the Erdős-Pósa constant for odd cycles be improved to give better bounds?",
-      "Is there a polynomial-time algorithm to find the minimum odd cycle transversal for graphs satisfying the $k$-independence condition?",
-      "Complete the 1 remaining sorry: trivial_case (strict condition ⇒ bipartite via odd cycle argument)"
+      "Is there a polynomial-time algorithm to find the minimum odd cycle transversal for graphs satisfying the $k$-independence condition?"
     ]
   },
   "leanFile": {
@@ -205,7 +204,7 @@
     "theoremCount": 9,
     "definitionCount": 10,
     "path": "Proofs/Erdos73Problem.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "references": [
     {
@@ -246,5 +245,5 @@
       "description": "thematic"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Summary

- **erdos-73**: `sorries` field was showing 1 (from a prior partial fix), but the Lean file `Proofs/Erdos73Problem.lean` now has 0 actual sorries. All 4 previously sorry'd theorems are fully proved: `trivial_case`, `bipartite_deficiency_zero`, `strict_implies_bipartite`, and `K3_violates_strict`. Updated all three `sorries` fields (meta, leanFile, top-level) to 0. Also updated `assumptions` text and removed stale open question about completing the sorry.

## Verification

- `grep -c "sorry" proofs/Proofs/Erdos73Problem.lean` → 0 (confirmed no sorries)
- Previously `sorries: 4` in meta.json; PR #10897 partially updated to `sorries: 1` but the Lean file already had 0

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)