### PR TITLE
Fix: stale lineCount in 3 gallery proofs (erdos-817, basel-oq, cayley-hamilton)

### DIFF
--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02/meta.json
@@ -21,7 +21,7 @@
     "sorries": 0,
     "dateAdded": "2026-04-12",
     "axiomCount": 5,
-    "lineCount": 763,
+    "lineCount": 791,
     "assumptions": "5 axioms: aperyB_recurrence (WZ recurrence), denominator_control (lcm^3*a_n is integer), lcm_hanson_bound (3^n Hanson bound), apery_linearForm_decay (geometric decay), apery_linearForm_nonzero (L_n != 0 for n>=1). Removed unused nair_lcm_bound. Main theorem apery_theorem PROVED from these 5 axioms.",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -163,7 +163,7 @@
       "Nat"
     ],
     "namespace": "AperyZetaThree",
-    "lineCount": 763,
+    "lineCount": 791,
     "axiomCount": 5,
     "theoremCount": 22,
     "definitionCount": 4,

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-01/meta.json
@@ -19,7 +19,7 @@
     "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 200,
+    "lineCount": 206,
     "assumptions": "No axioms. 1 sorry: vec_minpoly_exists — existence and minimality of the vector minimal polynomial requires extracting a PID ideal generator via Mathlib's IsPrincipalIdealRing API (not yet bridged). 8 of 9 theorems fully proved.",
     "mathlib_version": "4.26.0"
   },
@@ -47,7 +47,7 @@
       "Mathlib.RingTheory.Polynomial.Basic"
     ],
     "namespace": "MinpolyVec",
-    "lineCount": 200,
+    "lineCount": 206,
     "axiomCount": 0,
     "theoremCount": 9,
     "definitionCount": 3,

--- a/src/data/proofs/erdos-817/meta.json
+++ b/src/data/proofs/erdos-817/meta.json
@@ -202,12 +202,12 @@
       "Nat"
     ],
     "namespace": "Erdos817",
-    "lineCount": 368,
+    "lineCount": 557,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 8,
     "path": "Proofs/Erdos817Problem.lean",
-    "sorries": 2
+    "sorries": 0
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Stale `lineCount` in 3 gallery proof meta.json files after Lean source files were expanded by prior research/enrichment commits.

## Evidence

| Proof | Field | Before | After |
|-------|-------|--------|-------|
| erdos-817 | `leanFile.lineCount` | 368 | 557 |
| erdos-817 | `leanFile.sorries` | 2 | 0 |
| basel-problem-oq-01-oq-01-oq-02 | `meta.lineCount` | 763 | 791 |
| basel-problem-oq-01-oq-01-oq-02 | `leanFile.lineCount` | 763 | 791 |
| cayley-hamilton-minpoly-oq-03-oq-01 | `meta.lineCount` | 200 | 206 |
| cayley-hamilton-minpoly-oq-03-oq-01 | `leanFile.lineCount` | 200 | 206 |

All values verified against `wc -l` and `grep -c "sorry"` on the actual Lean source files.

---
Automated fix by lean-mechanic agent.