### PR TITLE
Audit: fix cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01 sorry count (2→4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12384,8 +12384,8 @@
       "issues": []
     },
     "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01": {
-      "auditCount": 4,
-      "lastAudited": "2026-04-14T21:23:28Z",
+      "auditCount": 5,
+      "lastAudited": "2026-04-21T11:40:24Z",
       "result": "issues-fixed",
       "issues": []
     },
@@ -12722,6 +12722,12 @@
     "erdos-1196": {
       "auditCount": 2,
       "lastAudited": "2026-04-21T11:37:16Z",
+      "result": "clean",
+      "issues": []
+    },
+    "area-of-circle-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-21T11:40:24Z",
       "result": "clean",
       "issues": []
     }

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6996,8 +6996,8 @@
     },
     "erdos-678": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-04T09:27:51Z",
+      "auditCount": 6,
+      "lastAudited": "2026-04-21T12:07:57Z",
       "result": "issues-fixed"
     },
     "erdos-679": {
@@ -12734,6 +12734,12 @@
     "yang-mills-lattice-oq-01": {
       "auditCount": 2,
       "lastAudited": "2026-04-21T12:01:35Z",
+      "result": "clean",
+      "issues": []
+    },
+    "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-21T12:07:57Z",
       "result": "clean",
       "issues": []
     }

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4173,8 +4173,8 @@
     },
     "erdos-268": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:29:50Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-21T11:59:09Z",
       "result": "clean"
     },
     "erdos-269": {
@@ -12384,8 +12384,8 @@
       "issues": []
     },
     "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01": {
-      "auditCount": 5,
-      "lastAudited": "2026-04-21T11:40:24Z",
+      "auditCount": 7,
+      "lastAudited": "2026-04-21T11:53:37Z",
       "result": "issues-fixed",
       "issues": []
     },
@@ -12726,8 +12726,14 @@
       "issues": []
     },
     "area-of-circle-oq-02-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-21T11:40:24Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T12:03:58Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "yang-mills-lattice-oq-01": {
+      "auditCount": 2,
+      "lastAudited": "2026-04-21T12:01:35Z",
       "result": "clean",
       "issues": []
     }


### PR DESCRIPTION
## Summary

**Proof**: `cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01`
**Problem**: `sorries` field claimed 2, but the Lean file has 4 actual code sorries

## Evidence

```
grep -n "^  sorry\|^    sorry" proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean
209:  sorry   ← truncated_rn_deriv_lq_bound (MARKED FALSE, dead end)
596:  sorry   ← indicator_lp_hasSum
675:  sorry   ← rnDeriv_integrable_of_finite
711:  sorry   ← holder_extremizer_lq_bound
```

The file's own assessment summary (line 787) also documents "4 total" sorries. The previous count of 2 was from an earlier version before new sorries were introduced by the restructured proof.

## Changes

- `meta.sorries`: 2 → 4
- `leanFile.sorries`: 2 → 4
- `assumptions`: Updated to describe all 4 sorries and reflect actual proof progress (riesz_lp_surjective_from_rn proof structure is now complete modulo 3 focused sorries)
- Audit tracker: `area-of-circle-oq-02-oq-01` marked clean (0 sorries, matches meta)

---
Discovered during gallery integrity audit.