### PR TITLE
Audit: fix area-of-circle-oq-02-oq-01 badge (verified→mathlib)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-02-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-02-oq-01/meta.json
@@ -15,7 +15,7 @@
       "euclidean-space"
     ],
     "proofRepoPath": "Proofs/AreaOfCircleOQ02OQ01.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 130,


### PR DESCRIPTION
## Integrity Fix

**Proof**: area-of-circle-oq-02-oq-01
**Problem**: Badge was `verified` but the main theorem uses Mathlib's `EuclideanSpace.volume_ball` as the core result.

## Evidence

The proof description itself states: "Proves that Vol(Bⁿ(r)) = rⁿ · Vol(Bⁿ(1)) for n ≥ 1 using Mathlib's EuclideanSpace.volume_ball"

The main theorem `nball_volume_scaling_theorem` applies `EuclideanSpace.volume_ball` directly. This is a Tier B (Mathlib bridge) proof.

## Fix

Changed `badge: "verified"` → `badge: "mathlib"`. The `status: "verified"` field correctly remains unchanged (0 sorries, 0 axioms — fully machine-checked, just derived from Mathlib).

---
Discovered during gallery integrity audit.