### PR TITLE
Fix: stale metadata in 3 gallery proofs (batch 12)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-02-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-02-oq-01/meta.json
@@ -18,7 +18,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 130,
+    "lineCount": 163,
     "originalContributions": [
       "sqrt_pi_pow_eq: (√π)^n = π^(n/2) — bridge between Mathlib and unitBallVolume forms",
       "nball_volume_scaling_theorem: Vol(Bⁿ(r)) = rⁿ·Vol(Bⁿ(1)) for n ≥ 1, provable from Mathlib",
@@ -96,9 +96,11 @@
     }
   ],
   "leanFile": {
-    "imports": ["Proofs.AreaOfCircleOQ02"],
+    "imports": [
+      "Proofs.AreaOfCircleOQ02"
+    ],
     "namespace": "AreaOfCircleOQ02OQ01",
-    "lineCount": 130,
+    "lineCount": 163,
     "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 0,

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -14,10 +14,10 @@
       "measure-theory"
     ],
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 4,
     "axiomCount": 0,
-    "lineCount": 647,
-    "assumptions": "2 remaining sorries: (1) truncated_rn_deriv_lq_bound — Hölder extremizer uniform bound for truncations, set-function bound hypothesis may be insufficient (needs direct functional bound); (2) riesz_lp_surjective_from_rn — signed measure construction + full assembly. Proved: integrationCLM, integrationCLM_apply, lintegral_mul_le_of_memLp, integrable_mul_of_memLp, truncated_rn_deriv_memLq (sub-goal 5a), integral_representation (all 3 Lp.induction cases), rn_deriv_memLq MCT step (lintegral_iSup + monotonicity + abs_clamp + sup_min sub-lemmas).",
+    "lineCount": 819,
+    "assumptions": "4 remaining sorries: (1) indicator_eLpNorm_zero — eLpNorm of indicator on null set is zero; (2) lintegral_mul_le_of_memLp — Hölder-type lintegral bound for Lp membership; (3) integrationCLM_apply — integration CLM evaluates as expected integral; (4) integral_representation — integral representation extends from indicators to all of Lp. See Lean source for details.",
     "dateAdded": "2026-04-13"
   },
   "overview": {
@@ -106,7 +106,7 @@
     "imports": [
       "Mathlib"
     ],
-    "lineCount": 647,
+    "lineCount": 819,
     "axiomCount": 0,
     "theoremCount": 15,
     "definitionCount": 2,
@@ -133,6 +133,6 @@
       }
     ],
     "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-    "sorries": 2
+    "sorries": 4
   }
 }

--- a/src/data/proofs/erdos-35/meta.json
+++ b/src/data/proofs/erdos-35/meta.json
@@ -23,7 +23,7 @@
     "erdosNumber": 35,
     "erdosUrl": "https://erdosproblems.com/35",
     "erdosProblemStatus": "solved",
-    "axiomCount": 0,
+    "axiomCount": 2,
     "lineCount": 373,
     "prerequisites": [
       "Schnirelmann density and its properties",
@@ -180,5 +180,5 @@
       "note": "Standard reference for Schnirelmann density theory and additive bases"
     }
   ],
-  "sorries": 2
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Correct stale `sorries`, `lineCount`, and `axiomCount` fields in 3 gallery proofs where metadata drifted from the actual Lean source files.

## Evidence

**cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01**
- `meta.sorries`: 2 → 4 (actual sorries at L103, L427, L496, L522)
- `meta.lineCount` + `leanFile.lineCount`: 647 → 819 (file grew after research PR expanded it)
- `assumptions` text updated to name all 4 sorry theorems accurately

**area-of-circle-oq-02-oq-01**
- `meta.lineCount` + `leanFile.lineCount`: 130 → 163 (file expanded by research PR #10902)
- Sorry count and axiom count are correct (0 each); only line count was stale

**erdos-35**
- Top-level `sorries`: 2 → 0 (all sorry tactics have been eliminated; `meta.sorries` and `leanFile.sorries` were already 0)
- `meta.axiomCount`: 0 → 2 (two `axiom` declarations exist; `leanFile.axiomCount` was already 2)

---
Automated fix by lean-mechanic agent.