### PR TITLE
Research: Riesz Lp surjectivity via RN — main theorem 0-sorry, rnDeriv_integrable proved

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean
@@ -662,17 +662,8 @@ private theorem signedMeasureOfFunctional_ac [IsFiniteMeasure μ]
 private theorem rnDeriv_integrable_of_finite [IsFiniteMeasure μ]
     (ν : SignedMeasure α)
     (hac : ν.AbsolutelyContinuous μ.toENNRealVectorMeasure) :
-    Integrable (ν.rnDeriv μ) μ := by
-  -- Proof outline (sorry pending API name confirmation):
-  -- SignedMeasure.rnDeriv μ = posPart.rnDeriv μ - negPart.rnDeriv μ (by definition)
-  -- JordanDecomposition always has IsFiniteMeasure on both parts (field constraint)
-  -- Measure.integrable_rnDeriv [IsFiniteMeasure ν] [SigmaFinite μ] gives L1 for each part
-  -- So: simp only [SignedMeasure.rnDeriv]; apply Integrable.sub;
-  --     · haveI : IsFiniteMeasure ν.toJordanDecomposition.posPart := inferInstance
-  --       exact Measure.integrable_rnDeriv _ μ
-  --     · haveI : IsFiniteMeasure ν.toJordanDecomposition.negPart := inferInstance
-  --       exact Measure.integrable_rnDeriv _ μ
-  sorry
+    Integrable (ν.rnDeriv μ) μ :=
+  SignedMeasure.integrable_rnDeriv ν μ
 
 /-- **RN derivative reconstructs ν on sets**: ν E = ∫_E (ν.rnDeriv μ) dμ.
     Proof: rn_reconstruction gives μ.withDensityᵥ (ν.rnDeriv μ) = ν;


### PR DESCRIPTION
## Summary

- **Main theorem `riesz_lp_surjective_from_rn`**: assembled with 0 sorries; all 5 proof steps connected
- **`rnDeriv_integrable_of_finite`**: proved via `SignedMeasure.integrable_rnDeriv` (1-liner)
- **`signedMeasureOfFunctional`**: complete SignedMeasure structure (all fields proved, 0 sorries)
- **`signedMeasureOfFunctional_ac`**: absolute continuity proved (0 sorries)
- Phase advanced: OBSERVE → ACT

## Remaining focused sorries (2 hard)

1. **`indicator_lp_hasSum`** (~80 lines): Lp partial sums of disjoint indicators → indicator of union. Uses `indicator_biUnion` + `tendsto_measure_iInter_atTop`.
2. **`holder_extremizer_lq_bound`** (~60 lines): ‖clamp(g,-n,n)‖_q ≤ ‖φ‖ via extremizer h=sign(gₙ)|gₙ|^{q-1}. Needs `∫ h·g = φ(h)` for bounded h (simple function density argument).

Note: `truncated_rn_deriv_lq_bound` at line 209 is intentionally kept as a FALSE sorry for reference.

## Test plan

- [ ] Verify file compiles through `docker-build.sh` (requires Docker daemon)
- [ ] Confirm sorry count matches: 3 sorries total (1 FALSE reference + 2 hard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)