### PR TITLE
Audit: fix area-of-circle-oq-02-oq-01 badge (verified→mathlib)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-02-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-02-oq-01/meta.json
@@ -26,7 +26,14 @@
       "vol_3ball_scaling: Vol(B³(r)) = (4π/3)r³ with verified scaling law",
       "Negative example: parent axiom is false at n=0, r=0 (0≠1 contradiction)"
     ],
-    "assumptions": "0 axiom(s) and 0 sorry(s). Fully verified for n ≥ 1."
+    "assumptions": "0 axiom(s) and 0 sorry(s). Fully verified for n ≥ 1.",
+    "mathlibDependencies": [
+      {
+        "theorem": "EuclideanSpace.volume_ball",
+        "description": "Volume of n-ball in Euclidean space — core result providing the n-ball volume formula",
+        "module": "Mathlib.MeasureTheory.Measure.Lebesgue.VolumeOfBalls"
+      }
+    ]
   },
   "overview": {
     "historicalContext": "The n-ball scaling law Vol(Bⁿ(r)) = rⁿ·Vol(Bⁿ(1)) is a classical consequence of the homogeneity of Lebesgue measure: under the dilation x ↦ rx, the n-dimensional Lebesgue measure scales as rⁿ (a change-of-variables formula). The general formula Vol(Bⁿ(1)) = π^(n/2)/Γ(n/2+1) was computed by Liouville in the 19th century via Gaussian integral techniques and the reflection formula for the Gamma function.\n\nIn Lean's Mathlib library, the result `EuclideanSpace.volume_ball` formalizes the n-ball volume using the form `√π^n/Γ(n/2+1)` rather than `π^(n/2)/Γ(n/2+1)`. These are mathematically equal (since √π = π^(1/2)), but their formal representations differ: `√π^n` is a natural power of a square root, while `π^(n/2)` is a real power of π. The bridge lemma (√π)^n = π^(n/2) — a simple 4-line proof using Lean's `rpow` laws — is the only technical content of this file.\n\nThe parent entry (area-of-circle-oq-02) had axiomatized the scaling law rather than proved it, because the Mathlib API for n-ball volumes was not yet surfaced in the gallery's proof infrastructure. This entry closes that gap, reducing the parent's axiom count from 1 to 0 for all practical applications (n ≥ 1).",


### PR DESCRIPTION
## Summary

Gallery integrity fix — the proof obtains its main result via `EuclideanSpace.volume_ball` from Mathlib, making it Tier B (bridge formalization). Badge corrected from `verified` to `mathlib` and Mathlib dependency documented. Discovered during gallery integrity audit.

## Changes

- `badge`: `verified` → `mathlib` (the badge was already corrected in a prior enrichment commit; this PR documents the Mathlib dependency)
- Added `mathlibDependencies` array listing `EuclideanSpace.volume_ball` from `Mathlib.MeasureTheory.Measure.Lebesgue.VolumeOfBalls`
- `lineCount` is already correct at 163 (updated in prior enrichment commit)

## Verification

`grep "EuclideanSpace.volume_ball" proofs/Proofs/AreaOfCircleOQ02OQ01.lean` confirms the proof uses this Mathlib theorem directly as its core result (`rw [EuclideanSpace.volume_ball, ...]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)