### PR TITLE
Audit: fix erdos-678 sorry count (7→4)

### DIFF
--- a/src/data/proofs/erdos-678/meta.json
+++ b/src/data/proofs/erdos-678/meta.json
@@ -17,7 +17,7 @@
       "computational"
     ],
     "badge": "wip",
-    "sorries": 7,
+    "sorries": 4,
     "erdosNumber": 678,
     "erdosUrl": "https://erdosproblems.com/678",
     "erdosProblemStatus": "solved",
@@ -65,7 +65,7 @@
       "Native decision procedures in Lean 4"
     ],
     "lineCount": 187,
-    "assumptions": "0 axiom(s) and 7 sorry(s). See the Lean source for details.",
+    "assumptions": "0 axiom(s) and 4 sorry(s). See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -170,8 +170,8 @@
     "axiomCount": 0,
     "theoremCount": 16,
     "definitionCount": 0,
-    "sorries": 7,
+    "sorries": 4,
     "path": "Proofs/Erdos678Problem.lean"
   },
-  "sorries": 7
+  "sorries": 4
 }


### PR DESCRIPTION
Gallery integrity fix — 3 sorries were filled in but metadata not updated. Correcting count from 7 to 4. Discovered during gallery integrity audit.