### PR TITLE
Enrich erdos-1205 pass 2: 4 sections, 5 keyInsights, conclusion implications

### DIFF
--- a/src/data/proofs/erdos-1205/meta.json
+++ b/src/data/proofs/erdos-1205/meta.json
@@ -31,21 +31,47 @@
       "The maximum possible total coverage is $\\sum_{n \\le x} 1/n \\approx \\ln x$, since a_n (mod n) covers exactly $\\lfloor x/n \\rfloor$ of the integers $m \\le x$, and each m is covered by exactly those n dividing $m - a_n$.",
       "The probabilistic method: choose each $a_n$ uniformly at random from $\\{0, \\ldots, n-1\\}$. For fixed m, $E[\\text{coverage of m}] = \\sum_{n \\le x} 1/n \\approx \\ln x$. By concentration, there exists a choice achieving $F(x) \\ge c \\ln x$.",
       "The covering congruences problem (every integer is covered) requires $\\sum 1/n_i \\ge 1$. The multi-covering problem scales this: achieving F-fold coverage requires $\\sum 1/n \\ge F$, which with moduli $1, 2, \\ldots, x$ gives $\\sum_{n \\le x} 1/n = \\Theta(\\log x)$.",
-      "This is connected to the Erdős-Turán conjecture and sieve theory: the 'covering density' of an arithmetic progression $a_n \\pmod{n}$ in $\\{1, \\ldots, x\\}$ is approximately $1/n$."
+      "This is connected to the Erdős-Turán conjecture and sieve theory: the 'covering density' of an arithmetic progression $a_n \\pmod{n}$ in $\\{1, \\ldots, x\\}$ is approximately $1/n$.",
+      "**Upper bound via pigeonhole**: The upper bound $F(x) \\le C \\ln x$ follows because each m must satisfy at least F(x) of the x congruences, so $F(x) \\cdot x \\le \\sum_{n \\le x} \\lfloor x/n \\rfloor \\le x \\sum_{n \\le x} 1/n \\approx x \\ln x$, giving $F(x) \\le \\ln x$. This counting argument requires no probabilistic tools and shows the $\\Theta(\\log x)$ bound is tight."
     ]
   },
   "sections": [
     {
-      "id": "sec-placeholder",
-      "title": "Placeholder Theorem (Pending Formalization)",
+      "id": "source-header",
+      "title": "Problem Source and Status",
       "startLine": 1,
-      "endLine": 24,
-      "summary": "Entire file is a stub. The problem statement (F(x) = Θ(log x) for optimal multi-covering by congruence classes) appears in the header comment. The mathematical result is solved but the Lean 4 formalization is pending."
+      "endLine": 7,
+      "summary": "Doc-comment header: source URL (erdosproblems.com/1205) and status SOLVED. Establishes the reference anchor for this gallery entry.",
+      "mathContext": "Source: Erdős Problem #1205. Status: SOLVED — the answer F(x) = Θ(log x) is known."
+    },
+    {
+      "id": "problem-statement",
+      "title": "Problem Statement: Optimal Multi-Covering",
+      "startLine": 8,
+      "endLine": 14,
+      "summary": "Full statement: Let F(x) be maximal such that congruence classes a_n (mod n) for all n ≤ x can be chosen so every m ≤ x satisfies at least F(x) of the congruences. Estimate F(x). This is a max-min covering problem.",
+      "mathContext": "$F(x) = \\max_{\\{a_n\\}} \\min_{m \\le x} |\\{n \\le x : m \\equiv a_n \\pmod{n}\\}|$. Answer: $F(x) = \\Theta(\\log x)$."
+    },
+    {
+      "id": "imports",
+      "title": "Mathlib Import",
+      "startLine": 16,
+      "endLine": 16,
+      "summary": "Imports all of Mathlib. A full formalization would need Mathlib.NumberTheory.ArithmeticFunction (for ∑ 1/n), Mathlib.Data.Nat.GCD.Basic (for congruences), and Mathlib.Probability.Basic (for the probabilistic argument).",
+      "mathContext": "Relevant Mathlib modules: `Mathlib.Data.Int.ModCast`, `Mathlib.NumberTheory.ArithmeticFunction` (harmonic sum estimates), `Mathlib.Combinatorics.Probabilistic`."
+    },
+    {
+      "id": "placeholder-theorem",
+      "title": "Placeholder Theorem and Verification",
+      "startLine": 18,
+      "endLine": 23,
+      "summary": "Stub `theorem erdos_1205 : True := by sorry` with `#check` verification. Awaiting formalization of the covering system definition, harmonic sum bounds, and probabilistic existence argument.",
+      "mathContext": "The actual theorem to prove: `∃ C c : ℝ, ∀ x : ℕ, c * Real.log x ≤ F x ∧ F x ≤ C * Real.log x`. Requires: definition of F(x) as a Lean function, harmonic sum asymptotics from Mathlib."
     }
   ],
   "conclusion": {
     "summary": "Erdős Problem #1205 asks for the maximum number F(x) of congruences $a_n \\pmod{n}$ (for all $n \\le x$) that can simultaneously be satisfied by every $m \\le x$. The answer is $F(x) = \\Theta(\\log x)$, matching the harmonic sum $\\sum_{n \\le x} 1/n$.",
-    "implications": "",
+    "implications": "The $\\Theta(\\log x)$ answer for F(x) is part of a broader pattern in additive combinatorics: harmonic sums control covering densities. This result connects to the Erdős covering systems conjecture (Halberstam-Roth: every covering system has a modulus divisible by 2), the probabilistic method in combinatorics (Alon-Spencer), and sieve theory (Selberg sieve, Lovász Local Lemma). A Lean formalization would add a clean example of the probabilistic method in Mathlib's growing combinatorics library.",
     "openQuestions": [
       "What is the exact leading constant in $F(x) \\sim c \\cdot \\ln x$? Is $c = 1$?",
       "Can the probabilistic existence proof be made constructive (explicit construction of optimal $a_n$)?",


### PR DESCRIPTION
## Summary
- Expands `erdos-1205` (Maximum Multi-Covering by Congruence Classes) from quality 85 → ~95+
- `meta.json` sections: 1 → 4 with `mathContext` fields (source-header, problem-statement with F(x) formula, imports, placeholder-theorem with target Lean type)
- `meta.json` keyInsights: 4 → 5; added pigeonhole upper bound explanation
- `meta.json` conclusion.implications: was empty; now explains connections to covering systems conjecture, Lovász Local Lemma, and Mathlib combinatorics

## Context
Second pass for the solved Erdős #1205 problem. The entry had all 5 annotations already (25/25) but was missing granular section structure and the conclusion implications field.

🤖 enricher-2