### PR TITLE
Enrich unit n-ball volume: 5 annotations, 5 keyInsights (93→~100)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01/annotations.json
@@ -46,5 +46,17 @@
     "significance": "main",
     "relatedConcepts": ["summable_pow_div_factorial", "Filter.Tendsto.comp", "squeeze theorem"],
     "prerequisites": ["omega_even_formula", "omega_le_two_even_half", "summable_pow_div_factorial"]
+  },
+  {
+    "id": "ann-aoc-oq01-oq02-oq01-oq01-oq01-05",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01",
+    "range": { "startLine": 134, "endLine": 160 },
+    "type": "theorem",
+    "title": "Corollaries: Subsequences and Eventually-Small Bound",
+    "content": "Three corollaries follow from `omega_tendsto_zero`:\n\n1. **omega_even_tendsto_zero**: ω_{2k} → 0. Proved by composing `omega_tendsto_zero` with the injection k ↦ 2k (which is `tendsto_atTop_atTop_of_monotone` with the obvious monotonicity).\n\n2. **omega_odd_tendsto_zero**: ω_{2k+1} → 0. Same pattern with k ↦ 2k+1.\n\n3. **omega_eventually_lt_one**: Eventually ω_n < 1. Extracted by unfolding `Metric.tendsto_atTop` at ε=1 to get an explicit N such that n ≥ N → |ω_n - 0| < 1, i.e., ω_n < 1 (since ω_n > 0).\n\nThese corollaries demonstrate how a single limit theorem (`omega_tendsto_zero`) can be specialized to both subsequences and uniform eventual bounds, all within Lean's filter framework.",
+    "mathContext": "In Lean's filter library: `Tendsto f atTop (nhds 0)` means for every ε-neighborhood of 0, all but finitely many values of f land in it. `Metric.tendsto_atTop` gives the ε-N version: `∀ ε > 0, ∃ N, ∀ n ≥ N, dist (f n) 0 < ε`. The `eventually_atTop` lemma converts this to the `∀ᶠ n in atTop, P n` notation.",
+    "significance": "supporting",
+    "relatedConcepts": ["Metric.tendsto_atTop", "eventually_atTop", "filter composition"],
+    "prerequisites": ["omega_tendsto_zero", "Tendsto", "Metric.tendsto_atTop"]
   }
 ]

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -72,7 +72,8 @@
       "**Even formula**: ω_{2k} = π^k/k! is exact, making these the terms of e^π. The convergence follows immediately from summability.",
       "**Odd bound**: The key inequality 4π/(2k+3) ≤ 4π/(2k+2) (from 2k+3 ≥ 2k+2) gives the induction step. No numerical computation needed.",
       "**Squeeze via n/2**: Bounding ω_n by 2·π^(n/2)/(n/2)! works for all n simultaneously, avoiding the need to combine two subsequence limits separately.",
-      "**Curse of dimensionality**: ω_n → 0 reflects the concentration of measure phenomenon. In high dimensions, almost all volume concentrates in a thin shell near the sphere boundary, and the ball becomes 'empty'."
+      "**Curse of dimensionality**: ω_n → 0 reflects the concentration of measure phenomenon. In high dimensions, almost all volume concentrates in a thin shell near the sphere boundary, and the ball becomes 'empty'.",
+      "**Lean filter composition pattern**: The main theorem uses a three-level composition of limits: first `summable_pow_div_factorial` gives π^k/k! → 0; then `tendsto_atTop_atTop_of_monotone` gives n/2 → ∞; then `Tendsto.comp` chains them to π^(n/2)/(n/2)! → 0. This is the standard Lean/Mathlib pattern for proving limits of composite sequences — more robust than direct ε-N arguments."
     ],
     "prerequisites": [
       "Ball volume recurrence (AreaOfCircleOQ01OQ02OQ01OQ01.lean)",


### PR DESCRIPTION
## Summary
- Adds 5th annotation for corollaries section (lines 134-160): `omega_eventually_lt_one`, even/odd subsequence limits, Lean filter composition pattern
- Adds 5th keyInsight: explains the three-level filter composition (`summable_pow_div_factorial` → `Tendsto.comp` → squeeze) as a reusable Mathlib proof pattern

## Entry
`area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01`: "Unit n-Ball Volumes Tend to Zero: ω_n → 0 as n → ∞"

🤖 enricher-2