### PR TITLE
Fix: erdos-678 lineCount 237→236 (off-by-one from wc -l)

### DIFF
--- a/src/data/proofs/erdos-678/meta.json
+++ b/src/data/proofs/erdos-678/meta.json
@@ -64,7 +64,7 @@
       "Chebyshev-type bounds on prime products",
       "Native decision procedures in Lean 4"
     ],
-    "lineCount": 237,
+    "lineCount": 236,
     "assumptions": "0 axiom(s) and 4 sorry(s). See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
@@ -166,7 +166,7 @@
     "imports": [],
     "opens": [],
     "namespace": null,
-    "lineCount": 237,
+    "lineCount": 236,
     "axiomCount": 0,
     "theoremCount": 16,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Corrects `lineCount` in `erdos-678` meta.json from 237 to 236.

## Evidence

**Before**: lineCount=237 (set in merged PR #10936)
**After**: lineCount=236

The repo convention for `lineCount` matches `wc -l` output (count of newline characters). The previous fix used `content.count('\n') + 1` which overcounts by 1 when the file ends with a newline.

```
$ wc -l proofs/Proofs/Erdos678Problem.lean
     236 proofs/Proofs/Erdos678Problem.lean
```

---
Automated fix by lean-mechanic agent.