### PR TITLE
Audit: update tracker — area-of-circle-oq-01-oq-03, wilsons-theorem-oq-01, wilsons-theorem-oq-02, unit-distance-independence, lagrange-four-squares-oq-02, konigsberg-oq-01

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -210,11 +210,11 @@
       "result": "clean"
     },
     "area-of-circle-oq-01-oq-03": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
         "https://github.com/rjwalters/lean-genius/pull/8651"
       ],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-21T12:20:41Z",
       "result": "issues-fixed"
     },
     "area-of-circle-oq-02": {
@@ -9895,8 +9895,8 @@
       "result": "clean"
     },
     "konigsberg-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-03T05:24:38Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-21T12:21:55Z",
       "result": "clean"
     },
     "konigsberg-oq-02": {
@@ -9942,8 +9942,8 @@
       "result": "clean"
     },
     "lagrange-four-squares-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-03T05:24:38Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-21T12:21:45Z",
       "result": "clean"
     },
     "lagrange-theorem": {
@@ -10908,8 +10908,8 @@
       "result": "clean"
     },
     "unit-distance-independence": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-03T05:24:38Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-21T12:21:35Z",
       "result": "clean"
     },
     "vietas-formulas": {
@@ -10942,13 +10942,13 @@
       "result": "clean"
     },
     "wilsons-theorem-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-03T05:24:38Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-21T12:21:24Z",
       "result": "clean"
     },
     "wilsons-theorem-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-03T05:24:38Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-21T12:21:11Z",
       "result": "clean"
     },
     "wilsons-theorem-oq-04": {


### PR DESCRIPTION
## Summary

Audit tracker updates from 2026-04-21 session:

- **area-of-circle-oq-01-oq-03**: issues-fixed (stale sorry-count text corrected via PR #10941, #10943)
- **wilsons-theorem-oq-01**: clean (verified/original, 0 sorries, 0 axioms)
- **wilsons-theorem-oq-02**: clean (verified/original, 0 sorries, 0 axioms)
- **unit-distance-independence**: clean (axiomatized/axiom, 2 axioms correctly declared)
- **lagrange-four-squares-oq-02**: clean (verified/original, 0 sorries, 0 axioms)
- **konigsberg-oq-01**: clean (verified/original, 0 sorries, 0 axioms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)