### PR TITLE
Fix: stale lineCount in 3 gallery proofs (batch 4)

### DIFF
--- a/src/data/proofs/cayley-hamilton-reduction-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-reduction-oq-01-oq-02/meta.json
@@ -23,7 +23,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 185,
+    "lineCount": 210,
     "assumptions": "No axioms, no sorries. All 9 theorems fully proved. Key techniques: modByMonic_add_div for reduction; minpoly.dvd + Polynomial.natDegree_le_of_dvd for divisibility; Matrix.charpoly_of_upperTriangular for the triangular case.",
     "mathlib_version": "4.26.0"
   },
@@ -52,7 +52,7 @@
       "Mathlib.RingTheory.Nilpotent.Basic"
     ],
     "namespace": "MinpolyReductionOQ02",
-    "lineCount": 185,
+    "lineCount": 210,
     "axiomCount": 0,
     "theoremCount": 9,
     "definitionCount": 0,

--- a/src/data/proofs/erdos-817/meta.json
+++ b/src/data/proofs/erdos-817/meta.json
@@ -206,12 +206,12 @@
       "Nat"
     ],
     "namespace": "Erdos817",
-    "lineCount": 368,
+    "lineCount": 580,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 8,
     "path": "Proofs/Erdos817Problem.lean",
-    "sorries": 2
+    "sorries": 0
   },
   "crossReferences": [
     {
@@ -230,5 +230,5 @@
       "description": "Related Erdős problem sharing themes: additive-combinatorics, arithmetic-progressions"
     }
   ],
-  "sorries": 2
+  "sorries": 0
 }

--- a/src/data/proofs/law-of-cosines-oq-01-oq-05/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-01-oq-05/meta.json
@@ -20,7 +20,7 @@
     "badge": "mathlib",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 270,
+    "lineCount": 365,
     "assumptions": "One sorry: euclidean_limit_holds (K→0 limit requires Taylor expansion analysis). All other results proved from Mathlib.",
     "dateAdded": "2026-04-21",
     "mathlib_version": "4.26.0",
@@ -153,7 +153,7 @@
       "Mathlib.Tactic"
     ],
     "namespace": "UnifiedLawOfCosines",
-    "lineCount": 270,
+    "lineCount": 365,
     "axiomCount": 0,
     "theoremCount": 20,
     "definitionCount": 2,


### PR DESCRIPTION
## Fix

Corrects stale `lineCount` (and `sorries`) fields in 3 gallery entries where the Lean source files were expanded after the metadata was written.

## Evidence

**erdos-817** (`Proofs/Erdos817Problem.lean`):
- Before: leanFile.lineCount=368, leanFile.sorries=2, root sorries=2
- After: leanFile.lineCount=580, leanFile.sorries=0, root sorries=0
- Note: meta section was already correct (sorries=0, lineCount=580); leanFile section was stale

**law-of-cosines-oq-01-oq-05** (`Proofs/LawOfCosinesOQ05.lean`):
- Before: lineCount=270
- After: lineCount=365
- (sorries count=1 is correct)

**cayley-hamilton-reduction-oq-01-oq-02** (`Proofs/CayleyHamiltonReductionOQ01OQ02.lean`):
- Before: lineCount=185
- After: lineCount=210
- (sorries count=0 is correct)

```
$ wc -l proofs/Proofs/Erdos817Problem.lean
     580
$ wc -l proofs/Proofs/LawOfCosinesOQ05.lean
     365
$ wc -l proofs/Proofs/CayleyHamiltonReductionOQ01OQ02.lean
     210
```

---
Automated fix by lean-mechanic agent.