### PR TITLE
Enrich erdos-1208: 1 → 5 sections with mathContext (92→~100)

### DIFF
--- a/src/data/proofs/erdos-1208/meta.json
+++ b/src/data/proofs/erdos-1208/meta.json
@@ -71,11 +71,44 @@
   },
   "sections": [
     {
-      "id": "placeholder-theorem",
-      "title": "Placeholder: Distance-Sidon Subset Theorem",
-      "startLine": 18,
-      "endLine": 23,
-      "summary": "Placeholder `erdos_1208 : True := by sorry` for the eventual formalization of the F_d(n) estimate. Lean formalization would require Euclidean distance in ℝ^d (via EuclideanSpace or inner_product_geometry) and a definition of the distance-distinct property."
+      "id": "header",
+      "title": "Problem Header: F_d(n) Bounds and Known Results",
+      "startLine": 1,
+      "endLine": 22,
+      "summary": "Documents the problem (F_d(n) = max size of distance-Sidon subset), the known bounds (lower: Ω(n^{1/3}) via Spencer–Szemerédi–Trotter, upper: O(n^{1/2}) via integer grid), and the open gap between 1/3 and 1/2 for d=2.",
+      "mathContext": "A distance-Sidon set Q requires C(|Q|,2) distinct pairwise distances. Lower bound proof: SST unit distance bound → greedy extraction → Ω(n^{1/3}). Upper bound: grid {1,...,N}² has O(N²) distinct distances → Sidon subset size ≤ O(N) = O(n^{1/2})."
+    },
+    {
+      "id": "definition-sidon",
+      "title": "Definition: IsDistanceSidon and Trivial Cases",
+      "startLine": 24,
+      "endLine": 57,
+      "summary": "Defines IsDistanceSidon (all pairwise distances distinct in a Finset in a metric space), with trivial theorems: the empty set is distance-Sidon (vacuously), and every singleton is distance-Sidon.",
+      "mathContext": "`IsDistanceSidon Q` is defined as: ∀ a b c e ∈ Q, dist a b = dist c e → ({a,b} = {c,e} as unordered pairs). For `Finset α` with `MetricSpace α`. Note: excludes the degenerate case dist(a,a) = 0 to avoid pairs (a,a) vs (b,b); the full definition handles this via the pair-equality conclusion."
+    },
+    {
+      "id": "size-bound",
+      "title": "Size Bound: k(k-1)/2 Distinct Distances Required",
+      "startLine": 58,
+      "endLine": 78,
+      "summary": "States (with sorry) the key lemma: a distance-Sidon subset Q of size k uses at least k(k-1)/2 distinct distances. This is the combinatorial heart: C(k,2) pairs each need a unique distance.",
+      "mathContext": "The sorry reflects that proving `Q.card * (Q.card - 1) / 2 ≤ (Q ×ˢ Q).image (dist).card` requires counting theory for Finset images. The relevant Mathlib lemmas would be `Finset.card_image_le` and injectivity arguments; the full proof requires showing the image-of-pairs is injective under IsDistanceSidon."
+    },
+    {
+      "id": "axioms",
+      "title": "Axioms: Lower and Upper Bounds for F₂(n)",
+      "startLine": 79,
+      "endLine": 124,
+      "summary": "Axiomatizes the two key bounds for d=2: fd2_lower_bound (Spencer–Szemerédi–Trotter 1984: F₂(n) ≥ Ω(n^{1/3})) and fd2_upper_bound (grid construction: ∃ n-point sets where every distance-Sidon subset has size ≤ O(n^{1/2})).",
+      "mathContext": "fd2_lower_bound axiom: `∃ C > 0, ∀ n, ∀ P: Finset ℝ², |P|=n → ∃ Q⊆P, IsDistanceSidon Q ∧ C·n^{1/3} ≤ |Q|`. fd2_upper_bound: `∃ C > 0, ∀ n, ∃ P, |P|=n ∧ ∀ Q⊆P, IsDistanceSidon Q → |Q| ≤ C·n^{1/2}`. Both use EuclideanSpace ℝ (Fin 2) for the Euclidean plane."
+    },
+    {
+      "id": "main-theorem",
+      "title": "Main Theorem: F₂(n) ≥ Ω(n^{1/3})",
+      "startLine": 125,
+      "endLine": 137,
+      "summary": "Proves erdos_1208 as a one-line derivation from fd2_lower_bound: every n-point planar set contains a distance-Sidon subset of size ≥ Ω(n^{1/3}). The #check lines verify all key declarations.",
+      "mathContext": "`theorem erdos_1208 := fd2_lower_bound`: the main result is immediate from the axiom, confirming the lower bound direction F₂(n) ≥ Ω(n^{1/3}). The upper bound from fd2_upper_bound is stated separately, showing the open gap [1/3, 1/2]."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
Replaces the single outdated stub section (lines 18-23) with 5 sections properly covering the actual 137-line Lean file:
- `header` (1-22): Problem description, known bounds for F_d(n)
- `definition-sidon` (24-57): IsDistanceSidon definition + empty/singleton cases
- `size-bound` (58-78): k(k-1)/2 distinct distances lemma (the sorry explains what's needed)
- `axioms` (79-124): fd2_lower_bound (SST 1984) + fd2_upper_bound (grid construction)
- `main-theorem` (125-137): erdos_1208 := fd2_lower_bound + sanity checks

All sections include `mathContext` fields with the Lean types and proof ideas.

## Entry
`erdos-1208`: Distance-Sidon subsets in ℝ^d — F₂(n) ≥ Ω(n^{1/3}) with 2 axioms, 1 sorry.

🤖 enricher-2