### PR TITLE
Fix: correct off-by-1 lineCount in 52 gallery proofs (batch 6)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-04/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-04/meta.json
@@ -63,7 +63,7 @@
       "Key insight: H decreasing ↔ M increasing follows from negating both sides of log(M_{α-1}) ≤ log(M_{β-1})"
     ],
     "dateAdded": "2026-04-21",
-    "lineCount": 233,
+    "lineCount": 232,
     "prerequisites": [
       "Probability distributions and Rényi entropy (information theory)",
       "Power means and AM-GM inequality (analysis)",

--- a/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
@@ -56,7 +56,7 @@
     ],
     "dateAdded": "2026-02-24",
     "axiomCount": 0,
-    "lineCount": 1938,
+    "lineCount": 1937,
     "assumptions": "0 sorries. The IBP formula fourierCoeffOn_deriv_periodic is now proved via import from AreaOfCircleOQ01OQ02OQ02.lean.",
     "mathlib_version": "4.26.0"
   },
@@ -267,7 +267,7 @@
       "Topology"
     ],
     "namespace": "IsoperimetricOQ",
-    "lineCount": 1938,
+    "lineCount": 1937,
     "axiomCount": 0,
     "theoremCount": 68,
     "definitionCount": 12,

--- a/src/data/proofs/bertrands-postulate-oq-03-oq-04-oq-03/meta.json
+++ b/src/data/proofs/bertrands-postulate-oq-03-oq-04-oq-03/meta.json
@@ -61,7 +61,7 @@
     ],
     "dateAdded": "2026-04-14",
     "axiomCount": 0,
-    "lineCount": 214,
+    "lineCount": 213,
     "assumptions": "0 axioms, 0 sorries. The proof is fully verified from PrimeNumberTheorem (which carries 1 axiom for the PNT itself) and Mathlib's filter analysis library.",
     "mathlib_version": "4.26.0",
     "relatedProblems": [
@@ -175,7 +175,7 @@
       "PrimeNumberTheorem"
     ],
     "namespace": "BertrandsPostulateOQ03OQ04OQ03",
-    "lineCount": 214,
+    "lineCount": 213,
     "axiomCount": 0,
     "sorries": 0,
     "path": "Proofs/BertrandsPostulateOQ03OQ04OQ03.lean",

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-03/meta.json
@@ -20,7 +20,7 @@
     "badge": "original",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 223,
+    "lineCount": 222,
     "assumptions": "One sorry: multinomial_cross_moment (E[XᵢXⱼ] = n(n-1)pᵢpⱼ). The main structure theorem multinomial_covariance is proved modulo this cross-moment sorry.",
     "theoremCount": 4,
     "mathlib_version": "4.26.0"
@@ -84,7 +84,7 @@
       "multinomial_cross_moment",
       "multinomial_covariance"
     ],
-    "lineCount": 223,
+    "lineCount": 222,
     "axiomCount": 0,
     "sorries": 1
   },

--- a/src/data/proofs/binomial-theorem-oq-02-oq-04/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-04/meta.json
@@ -21,7 +21,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 208,
+    "lineCount": 207,
     "theoremCount": 6,
     "assumptions": "None. The proof is fully machine-checked with no sorry or axiom declarations beyond Mathlib's standard axioms.",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/cauchy-schwarz-integral/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral/meta.json
@@ -43,7 +43,7 @@
     ],
     "dateAdded": "2026-02-11",
     "axiomCount": 0,
-    "lineCount": 118,
+    "lineCount": 117,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0"
   },
@@ -187,7 +187,7 @@
       "MeasureTheory"
     ],
     "namespace": "BunyakovskySchwarz",
-    "lineCount": 118,
+    "lineCount": 117,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 0,

--- a/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 4,
     "axiomCount": 1,
-    "lineCount": 280,
+    "lineCount": 279,
     "assumptions": "1 axiom: kostochka_pyber_r2 (the r=2 graph case of Kostochka-Pyber theorem, proven 1988). 4 sorries in this file (geometric edge-crossing verifications).",
     "dateAdded": "2026-04-03",
     "mathlib_version": "4.26.0"
@@ -127,7 +127,7 @@
       "Proofs.Erdos1018OQ04"
     ],
     "namespace": "Erdos1018OQ04Completion",
-    "lineCount": 280,
+    "lineCount": 279,
     "axiomCount": 1,
     "theoremCount": 11,
     "path": "Proofs/Erdos1018OQ04Incomplete01.lean",

--- a/src/data/proofs/erdos-1028/meta.json
+++ b/src/data/proofs/erdos-1028/meta.json
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "solved",
     "relatedProblems": [],
     "axiomCount": 2,
-    "lineCount": 311,
+    "lineCount": 310,
     "assumptions": "6 axioms: erdos_upper, erdos_spencer_lower, random_upper, large_discrepancy_exists, H_two, H_three. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
@@ -238,7 +238,7 @@
       "Finset"
     ],
     "namespace": "Erdos1028",
-    "lineCount": 311,
+    "lineCount": 310,
     "axiomCount": 2,
     "theoremCount": 8,
     "definitionCount": 10,

--- a/src/data/proofs/erdos-1034/meta.json
+++ b/src/data/proofs/erdos-1034/meta.json
@@ -26,7 +26,7 @@
       "erdos-1033"
     ],
     "axiomCount": 1,
-    "lineCount": 779,
+    "lineCount": 778,
     "assumptions": "3 axiom(s) and 3 sorries. See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
@@ -273,7 +273,7 @@
       "Finset"
     ],
     "namespace": "Erdos1034",
-    "lineCount": 779,
+    "lineCount": 778,
     "axiomCount": 1,
     "theoremCount": 17,
     "definitionCount": 22,

--- a/src/data/proofs/erdos-1050/meta.json
+++ b/src/data/proofs/erdos-1050/meta.json
@@ -63,7 +63,7 @@
       "erdos-257"
     ],
     "axiomCount": 2,
-    "lineCount": 483,
+    "lineCount": 482,
     "assumptions": "2 axioms: borwein_irrationality (Borwein's 1991 Padé approximation result for T(q,r)), S_approx (numerical bounds 0.286 < S < 0.288). 0 sorries: T_summable (convergence of T(q,r)), S_first_terms (initial partial sum identity)."
   },
   "overview": {
@@ -229,7 +229,7 @@
       "Real"
     ],
     "namespace": "Erdos1050",
-    "lineCount": 483,
+    "lineCount": 482,
     "axiomCount": 2,
     "theoremCount": 26,
     "definitionCount": 9,

--- a/src/data/proofs/erdos-108/meta.json
+++ b/src/data/proofs/erdos-108/meta.json
@@ -46,7 +46,7 @@
       "Special case extraction for Rödl's r=4 theorem"
     ],
     "axiomCount": 1,
-    "lineCount": 142,
+    "lineCount": 141,
     "assumptions": "1 axiom: erdos_hajnal_rodl_theorem. See Lean source for the complete statement."
   },
   "overview": {
@@ -225,7 +225,7 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos108",
-    "lineCount": 142,
+    "lineCount": 141,
     "axiomCount": 1,
     "theoremCount": 2,
     "definitionCount": 0,

--- a/src/data/proofs/erdos-109/meta.json
+++ b/src/data/proofs/erdos-109/meta.json
@@ -49,7 +49,7 @@
       "Verified example for even numbers"
     ],
     "axiomCount": 1,
-    "lineCount": 438,
+    "lineCount": 437,
     "assumptions": "1 axiom: moreira_richter_robertson. See Lean source for the complete statement."
   },
   "overview": {
@@ -242,7 +242,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos109",
-    "lineCount": 438,
+    "lineCount": 437,
     "axiomCount": 1,
     "theoremCount": 13,
     "definitionCount": 9,

--- a/src/data/proofs/erdos-1161/meta.json
+++ b/src/data/proofs/erdos-1161/meta.json
@@ -54,7 +54,7 @@
       "Small cases: explicit counts for S_1, S_2, S_3"
     ],
     "axiomCount": 0,
-    "lineCount": 324,
+    "lineCount": 323,
     "assumptions": "2 axioms from Beker [Be25d]: beker_characterization (f_k(n) ≥ (n-1)! implies lcm divisibility) and beker_maximizer_achieves (minimal lcm-divisible k achieves (n-1)!). All other theorems are fully proved, including max_permCount_ge_sub_factorial which uses a direct n-cycle counting argument independent of Beker's results."
   },
   "overview": {
@@ -143,7 +143,7 @@
       "Nat"
     ],
     "namespace": null,
-    "lineCount": 324,
+    "lineCount": 323,
     "axiomCount": 0,
     "theoremCount": 15,
     "definitionCount": 3,

--- a/src/data/proofs/erdos-117-oq-01/meta.json
+++ b/src/data/proofs/erdos-117-oq-01/meta.json
@@ -25,7 +25,7 @@
     "erdosNumber": 117,
     "erdosUrl": "https://erdosproblems.com/117",
     "erdosProblemStatus": "open",
-    "lineCount": 270
+    "lineCount": 269
   },
   "overview": {
     "historicalContext": "**Pinning Down the Exponential Base**\n\nErdős introduced the abelian covering number h(n) as part of his investigation of commutativity in finite groups. A group G has the n-commuting property if among any n+2 elements, at least two commute — or equivalently, G cannot be partitioned into n+1 pairwise non-commuting pairs. The covering number h(n) asks: what is the minimum size of a cover by abelian subgroups that works for all groups with this property?\n\nThe first exponential lower bound was proved by Isaacs in earlier work. Pyber's landmark 1987 paper established both exponential bounds c₁ⁿ ≤ h(n) ≤ c₂ⁿ with explicit constants satisfying c₂ > c₁ > 1. This settled the 'polynomial vs exponential' question but opened a new one: do the bounds converge to a single exponential base? Knowing the precise base c would give h(n) = Θ(cⁿ) — a clean asymptotic characterization.\n\nThe connection to Fekete's lemma (1923) provides a natural structural approach. Fekete's theorem states that subadditive functions f (with f(m+n) ≤ f(m)+f(n)) satisfy lim f(n)/n = inf f(n)/n. If h is submultiplicative (h(m+n) ≤ h(m)·h(n)), then log h is subadditive and the limit exists. The question of submultiplicativity of h is thus a key open structural problem.",
@@ -132,7 +132,7 @@
       "Filter"
     ],
     "namespace": "Erdos117OQ01",
-    "lineCount": 270,
+    "lineCount": 269,
     "axiomCount": 3,
     "theoremCount": 8,
     "substantiveTheoremCount": 5,

--- a/src/data/proofs/erdos-123/meta.json
+++ b/src/data/proofs/erdos-123/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/123",
     "erdosProblemStatus": "open",
     "axiomCount": 3,
-    "lineCount": 318,
+    "lineCount": 317,
     "assumptions": "3 axiom(s): powers23_repr, erdos_123_conjecture, erdos_lewin_357. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
@@ -116,7 +116,7 @@
       "Pointwise"
     ],
     "namespace": "Erdos123",
-    "lineCount": 318,
+    "lineCount": 317,
     "axiomCount": 3,
     "theoremCount": 22,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-135/meta.json
+++ b/src/data/proofs/erdos-135/meta.json
@@ -22,7 +22,7 @@
     "erdosProblemStatus": "solved",
     "erdosPrizeValue": "$250",
     "axiomCount": 5,
-    "lineCount": 392,
+    "lineCount": 391,
     "assumptions": "5 axioms: erdos_135_false (the five-distance conjecture is false, Tao 2024), tao_counterexample (Tao's explicit randomized parabola counterexample), tao_avoids_parallelograms (parabola construction avoids parallelograms), randomized_parabola_works (full randomized construction works), guth_katz_lower_bound (any n points have ≥ cn/√(log n) distinct distances, Guth-Katz 2015). 6 sorries.",
     "mathlib_version": "4.26.0"
   },
@@ -137,7 +137,7 @@
       "Real"
     ],
     "namespace": "Erdos135",
-    "lineCount": 392,
+    "lineCount": 391,
     "axiomCount": 5,
     "theoremCount": 5,
     "definitionCount": 11,

--- a/src/data/proofs/erdos-139/meta.json
+++ b/src/data/proofs/erdos-139/meta.json
@@ -30,7 +30,7 @@
       "Szemerédi regularity lemma (for understanding the proof chain)",
       "Roth's theorem and the corners theorem (k=3 case)"
     ],
-    "lineCount": 261,
+    "lineCount": 260,
     "assumptions": "4 axioms: kelley_meka_bound (r₃(N) ≤ N·exp(−c(log N)^(1/12)), Kelley-Meka 2023), gowers_bound (r_k(N) ≤ N/(log log N)^c for k≥4, Gowers 2001), behrend_lower_bound (r₃(N) ≥ N·exp(−c√(log N)), Behrend 1946), szemeredi_theorem (sets with positive density contain k-APs for all k). 1 sorry: main density-to-zero proof.",
     "mathlib_version": "4.26.0"
   },
@@ -113,7 +113,7 @@
       "Topology"
     ],
     "namespace": "Erdos139",
-    "lineCount": 261,
+    "lineCount": 260,
     "axiomCount": 4,
     "theoremCount": 8,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-143/meta.json
+++ b/src/data/proofs/erdos-143/meta.json
@@ -46,7 +46,7 @@
       "Formalized the KLL 2025 partial resolution"
     ],
     "axiomCount": 3,
-    "lineCount": 120,
+    "lineCount": 119,
     "assumptions": "3 axiom(s): kll_theorem, well_separated_integers_primitive, erdos_1935_primitive. See Lean source for complete statements."
   },
   "overview": {
@@ -219,7 +219,7 @@
       "Topology"
     ],
     "namespace": "Erdos143",
-    "lineCount": 120,
+    "lineCount": 119,
     "axiomCount": 3,
     "theoremCount": 1,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-157/meta.json
+++ b/src/data/proofs/erdos-157/meta.json
@@ -59,7 +59,7 @@
       "Verified theorem: powers_of_two_sidon"
     ],
     "axiomCount": 3,
-    "lineCount": 536,
+    "lineCount": 535,
     "assumptions": "3 axioms: (1) pilatte_existence — the Pilatte 2023 existence result (infinite Sidon set that is an asymptotic basis of order 3); (2) sidon_counting_bound — counting bound for Sidon sets; (3) basis_counting_lower — lower bound for basis counting. 0 sorries (previously 1 sorry for pilatte_existence was axiomatized; sidon_counting_contradiction proved by Aristotle)."
   },
   "overview": {
@@ -159,7 +159,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos157",
-    "lineCount": 536,
+    "lineCount": 535,
     "axiomCount": 3,
     "theoremCount": 7,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-167/meta.json
+++ b/src/data/proofs/erdos-167/meta.json
@@ -28,7 +28,7 @@
       "extremal combinatorics",
       "linear programming relaxation"
     ],
-    "lineCount": 275,
+    "lineCount": 274,
     "assumptions": "5 axioms: haxell_kohayakawa, tuza_for_k4_free, IsPlanar, and 2 more. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
@@ -136,7 +136,7 @@
       "Set"
     ],
     "namespace": "Erdos167",
-    "lineCount": 275,
+    "lineCount": 274,
     "axiomCount": 1,
     "theoremCount": 4,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-168/meta.json
+++ b/src/data/proofs/erdos-168/meta.json
@@ -55,7 +55,7 @@
       "Formalized the irrationality question"
     ],
     "axiomCount": 2,
-    "lineCount": 181,
+    "lineCount": 180,
     "assumptions": "5 axioms: gsw_limit_exists, limit_positive, limit_less_than_one, and 2 more. See Lean source for complete statements."
   },
   "overview": {
@@ -141,7 +141,7 @@
       "Finset"
     ],
     "namespace": "Erdos168",
-    "lineCount": 181,
+    "lineCount": 180,
     "axiomCount": 2,
     "theoremCount": 4,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-171/meta.json
+++ b/src/data/proofs/erdos-171/meta.json
@@ -56,7 +56,7 @@
       "Aristotle-verified: no_4_clique (no tetrahedron in ℝ²)"
     ],
     "axiomCount": 2,
-    "lineCount": 303,
+    "lineCount": 302,
     "references": [
       {
         "title": "The chromatic number of the plane is at least 5",
@@ -197,7 +197,7 @@
       "Metric"
     ],
     "namespace": "Erdos171",
-    "lineCount": 303,
+    "lineCount": 302,
     "axiomCount": 2,
     "theoremCount": 16,
     "definitionCount": 4,

--- a/src/data/proofs/erdos-172/meta.json
+++ b/src/data/proofs/erdos-172/meta.json
@@ -46,7 +46,7 @@
       "Explicit connection between finite and infinite versions"
     ],
     "axiomCount": 3,
-    "lineCount": 145,
+    "lineCount": 144,
     "references": [
       {
         "title": "Monochromatic sums and products in ℕ",
@@ -155,7 +155,7 @@
       "Finset"
     ],
     "namespace": "Erdos172",
-    "lineCount": 145,
+    "lineCount": 144,
     "axiomCount": 3,
     "theoremCount": 4,
     "definitionCount": 6,

--- a/src/data/proofs/erdos-202/meta.json
+++ b/src/data/proofs/erdos-202/meta.json
@@ -53,7 +53,7 @@
       "Multiple theorems proved by Aristotle including f_mono, f_le_N, L_mono, L_subpolynomial"
     ],
     "axiomCount": 0,
-    "lineCount": 860,
+    "lineCount": 859,
     "assumptions": "3 sorry(s). No axioms."
   },
   "overview": {
@@ -175,7 +175,7 @@
       "Classical"
     ],
     "namespace": "Erdos202",
-    "lineCount": 860,
+    "lineCount": 859,
     "axiomCount": 0,
     "theoremCount": 40,
     "definitionCount": 19,

--- a/src/data/proofs/erdos-29/meta.json
+++ b/src/data/proofs/erdos-29/meta.json
@@ -22,7 +22,7 @@
     "erdosProblemStatus": "solved",
     "erdosPrizeValue": "$100",
     "axiomCount": 5,
-    "lineCount": 524,
+    "lineCount": 523,
     "assumptions": "5 axioms: JPSZ_set (explicit construction), JPSZ_is_basis, JPSZ_representation_bound, JPSZ_explicit, JPSZ_size_optimal. JPSZ_is_economical and JPSZ_density_zero fully proved as consequences (not independent axioms): economical follows from representation bound via exp(C√(log n) - ε·log n) → -∞, density zero follows from size optimal via squeeze with C·√(log N/N) → 0. 0 sorries.",
     "prerequisites": [
       "Additive bases and Waring's problem",
@@ -171,7 +171,7 @@
       "Filter"
     ],
     "namespace": "Erdos29",
-    "lineCount": 524,
+    "lineCount": 523,
     "axiomCount": 5,
     "theoremCount": 12,
     "definitionCount": 12,

--- a/src/data/proofs/erdos-299/meta.json
+++ b/src/data/proofs/erdos-299/meta.json
@@ -54,7 +54,7 @@
       "Proof that powers of 2 have unbounded gaps"
     ],
     "axiomCount": 1,
-    "lineCount": 387,
+    "lineCount": 386,
     "assumptions": "1 axiom (bloom_theorem: Bloom's 2021 result on positive density sets). 0 sorries."
   },
   "overview": {
@@ -170,7 +170,7 @@
       "Finset"
     ],
     "namespace": "Erdos299",
-    "lineCount": 387,
+    "lineCount": 386,
     "axiomCount": 1,
     "theoremCount": 10,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-303/meta.json
+++ b/src/data/proofs/erdos-303/meta.json
@@ -54,7 +54,7 @@
       "Connection to density version (Erdős #302)"
     ],
     "axiomCount": 2,
-    "lineCount": 259,
+    "lineCount": 258,
     "assumptions": "2 axioms: brownRodl_theorem, erdos303_true. See Lean source for complete statements."
   },
   "overview": {
@@ -144,7 +144,7 @@
       "Set"
     ],
     "namespace": "Erdos303",
-    "lineCount": 259,
+    "lineCount": 258,
     "axiomCount": 2,
     "theoremCount": 8,
     "definitionCount": 8,

--- a/src/data/proofs/erdos-355/meta.json
+++ b/src/data/proofs/erdos-355/meta.json
@@ -48,7 +48,7 @@
       "Fibonacci-like sequence example with ratio approximately φ"
     ],
     "axiomCount": 2,
-    "lineCount": 392,
+    "lineCount": 391,
     "assumptions": "2 axiom(s) and 0 sorry(s). See the Lean source for details."
   },
   "overview": {
@@ -147,7 +147,7 @@
       "Set"
     ],
     "namespace": "Erdos355",
-    "lineCount": 392,
+    "lineCount": 391,
     "axiomCount": 2,
     "theoremCount": 15,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-37/meta.json
+++ b/src/data/proofs/erdos-37/meta.json
@@ -80,7 +80,7 @@
       "Classical axioms: schnirelmann_theorem, mann_theorem"
     ],
     "axiomCount": 6,
-    "lineCount": 368,
+    "lineCount": 367,
     "prerequisites": [
       "Essential components in additive number theory",
       "Lacunary sequences and their properties",
@@ -225,7 +225,7 @@
       "Filter"
     ],
     "namespace": "Erdos37",
-    "lineCount": 368,
+    "lineCount": 367,
     "axiomCount": 6,
     "theoremCount": 6,
     "definitionCount": 10,

--- a/src/data/proofs/erdos-370/meta.json
+++ b/src/data/proofs/erdos-370/meta.json
@@ -64,12 +64,12 @@
       "erdos_370: injective-function encoding of infinitude (sorry'd)"
     ],
     "axiomCount": 2,
-    "lineCount": 285,
+    "lineCount": 284,
     "assumptions": "2 axioms (gpf_mul_le, dickman_density) and 2 sorries. gpf function and 7 properties now proved from Mathlib."
   },
   "leanFile": {
     "path": "Proofs/Erdos370Problem.lean",
-    "lineCount": 285,
+    "lineCount": 284,
     "namespace": "Erdos370",
     "imports": [
       "Mathlib"

--- a/src/data/proofs/erdos-402/meta.json
+++ b/src/data/proofs/erdos-402/meta.json
@@ -60,7 +60,7 @@
       "erdos_402_contains_one: conjecture proved when 1 ∈ A"
     ],
     "axiomCount": 0,
-    "lineCount": 694,
+    "lineCount": 693,
     "assumptions": "1 sorry: erdos_402_graham_conjecture (main conjecture, requires Balasubramanian-Soundararajan sieve argument). Quadruple case fully proved."
   },
   "overview": {
@@ -177,7 +177,7 @@
       "Finset"
     ],
     "namespace": "Erdos402",
-    "lineCount": 694,
+    "lineCount": 693,
     "axiomCount": 0,
     "theoremCount": 25,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-45/meta.json
+++ b/src/data/proofs/erdos-45/meta.json
@@ -40,7 +40,7 @@
       }
     ],
     "axiomCount": 3,
-    "lineCount": 142,
+    "lineCount": 141,
     "prerequisites": [
       "Egyptian fractions and unit fraction decompositions",
       "Ramsey theory and monochromatic structures",
@@ -133,7 +133,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos45",
-    "lineCount": 142,
+    "lineCount": 141,
     "axiomCount": 3,
     "theoremCount": 3,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-485/meta.json
+++ b/src/data/proofs/erdos-485/meta.json
@@ -23,7 +23,7 @@
     "erdosUrl": "https://erdosproblems.com/485",
     "erdosProblemStatus": "solved",
     "axiomCount": 1,
-    "lineCount": 226,
+    "lineCount": 225,
     "assumptions": "1 axiom: schinzel_zannier_improved (Schinzel-Zannier 2009: f(k) ≫ log k). This deep algebraic result is not yet in Mathlib.",
     "mathlib_version": "4.26.0"
   },
@@ -115,7 +115,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos485",
-    "lineCount": 226,
+    "lineCount": 225,
     "axiomCount": 1,
     "theoremCount": 3,
     "definitionCount": 6,

--- a/src/data/proofs/erdos-517/meta.json
+++ b/src/data/proofs/erdos-517/meta.json
@@ -51,7 +51,7 @@
       "Verified example showing exponential sequences have Fejér gaps"
     ],
     "dateAdded": "2025-12-22",
-    "lineCount": 176,
+    "lineCount": 175,
     "prerequisites": [
       "Complex analysis: entire functions, power series",
       "Lacunary (gap) series and Fabry/Fejér gap conditions",
@@ -145,7 +145,7 @@
       "Topology"
     ],
     "namespace": "Erdos517",
-    "lineCount": 176,
+    "lineCount": 175,
     "axiomCount": 1,
     "theoremCount": 3,
     "definitionCount": 3,

--- a/src/data/proofs/erdos-551/meta.json
+++ b/src/data/proofs/erdos-551/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/551",
     "erdosProblemStatus": "solved",
     "axiomCount": 0,
-    "lineCount": 604,
+    "lineCount": 603,
     "assumptions": "No axioms. 22 sorry(s) remain in the formalization.",
     "mathlib_version": "4.26.0"
   },
@@ -175,7 +175,7 @@
       "Finset"
     ],
     "namespace": "Erdos551",
-    "lineCount": 604,
+    "lineCount": 603,
     "axiomCount": 0,
     "theoremCount": 26,
     "definitionCount": 14,

--- a/src/data/proofs/erdos-60/meta.json
+++ b/src/data/proofs/erdos-60/meta.json
@@ -51,7 +51,7 @@
       "conjecture_implies_two_copies: Aristotle-proved implication"
     ],
     "axiomCount": 8,
-    "lineCount": 386,
+    "lineCount": 385,
     "prerequisites": [
       "Extremal graph theory (Turán-type problems)",
       "4-cycles (C₄) in graphs",
@@ -182,7 +182,7 @@
       "Finset"
     ],
     "namespace": "Erdos60",
-    "lineCount": 386,
+    "lineCount": 385,
     "axiomCount": 8,
     "theoremCount": 10,
     "definitionCount": 12,

--- a/src/data/proofs/erdos-604/meta.json
+++ b/src/data/proofs/erdos-604/meta.json
@@ -59,7 +59,7 @@
       "Crossing number inequality",
       "Number theory (sums of two squares, Landau's theorem)"
     ],
-    "lineCount": 224,
+    "lineCount": 223,
     "assumptions": "No axioms. 1 sorry remaining: integerLattice_pinnedDistances (deep constructive existence). maxPinnedDistances and pinnedDistance_le are now sorry-free.",
     "mathlib_version": "4.26.0"
   },
@@ -184,7 +184,7 @@
       "Set"
     ],
     "namespace": null,
-    "lineCount": 224,
+    "lineCount": 223,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 11,

--- a/src/data/proofs/erdos-624/meta.json
+++ b/src/data/proofs/erdos-624/meta.json
@@ -57,7 +57,7 @@
     ],
     "dateAdded": "2025-12-27",
     "axiomCount": 5,
-    "lineCount": 219,
+    "lineCount": 218,
     "assumptions": "5 axioms: erdos_hajnal_upper_bound, erdos_624_open, weaker_conjecture_open, and 2 more. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
@@ -172,7 +172,7 @@
       "Set"
     ],
     "namespace": "Erdos624",
-    "lineCount": 219,
+    "lineCount": 218,
     "axiomCount": 5,
     "theoremCount": 4,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-629/meta.json
+++ b/src/data/proofs/erdos-629/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/629",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "lineCount": 912,
+    "lineCount": 911,
     "assumptions": "7 sorry(s). No axioms.",
     "mathlib_version": "4.26.0"
   },
@@ -175,7 +175,7 @@
       "Finset"
     ],
     "namespace": "Erdos629",
-    "lineCount": 912,
+    "lineCount": 911,
     "axiomCount": 0,
     "theoremCount": 37,
     "definitionCount": 14,

--- a/src/data/proofs/erdos-643/meta.json
+++ b/src/data/proofs/erdos-643/meta.json
@@ -49,7 +49,7 @@
       "Statement of Erdős-Rado Sunflower Lemma connection"
     ],
     "axiomCount": 3,
-    "lineCount": 1403,
+    "lineCount": 1402,
     "assumptions": "3 axiom(s) and 4 sorry(s)."
   },
   "overview": {
@@ -186,7 +186,7 @@
       "Classical"
     ],
     "namespace": "Harmonic.GeneralizeProofs",
-    "lineCount": 1403,
+    "lineCount": 1402,
     "axiomCount": 3,
     "theoremCount": 45,
     "definitionCount": 15,

--- a/src/data/proofs/erdos-69/meta.json
+++ b/src/data/proofs/erdos-69/meta.json
@@ -45,7 +45,7 @@
       "Structure connecting Problem 69 to Problem 257"
     ],
     "axiomCount": 1,
-    "lineCount": 189,
+    "lineCount": 188,
     "prerequisites": [
       "Arithmetic functions (ω, d, Ω) and prime factorization",
       "Infinite series, absolute convergence, and summation interchange",
@@ -194,7 +194,7 @@
       "Finset"
     ],
     "namespace": "Erdos69",
-    "lineCount": 189,
+    "lineCount": 188,
     "axiomCount": 1,
     "theoremCount": 5,
     "definitionCount": 2,

--- a/src/data/proofs/erdos-795/meta.json
+++ b/src/data/proofs/erdos-795/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/795",
     "erdosProblemStatus": "solved",
     "axiomCount": 0,
-    "lineCount": 500,
+    "lineCount": 499,
     "assumptions": "15 sorry(s).",
     "mathlib_version": "4.26.0"
   },
@@ -167,7 +167,7 @@
     ],
     "opens": [],
     "namespace": "Erdos795",
-    "lineCount": 500,
+    "lineCount": 499,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-840/meta.json
+++ b/src/data/proofs/erdos-840/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/840",
     "erdosProblemStatus": "open",
     "axiomCount": 9,
-    "lineCount": 228,
+    "lineCount": 227,
     "assumptions": "9 axioms: (1) sidon_sumset_card \u2014 classical Sidon cardinality |A+A|=C(|A|+1,2); (2) erdos_freud_lower_bound \u2014 Erd\u0151s-Freud (1991) lower bound f(N)\u2265(2/\u221a3+o(1))\u221aN; (3) construction_is_quasi_sidon \u2014 Erd\u0151s-Freud construction is quasi-Sidon; (4) erdos_freud_upper_bound \u2014 Erd\u0151s-Freud (1991) upper bound f(N)\u2264(2+o(1))\u221aN; (5) pikhurko_upper_bound \u2014 Pikhurko (2006) improved bound f(N)\u2264(c_P+o(1))\u221aN; (6) sidon_set_upper_bound \u2014 classical Sidon bound |A|\u2264\u221aN+O(N^{1/4}); (7) sidon_set_exists \u2014 Singer construction Sidon sets of size ~\u221aN; (8) pikhurko_constant_approx \u2014 numerical bound c_P\u2208(1.86,1.87); (9) bounds_gap \u2014 gap c_P-2/\u221a3<0.72. Proven: lower_bound_constant_value, cilleruelo_difference_set, open_problem_gap.",
     "mathlib_version": "4.26.0"
   },
@@ -101,7 +101,7 @@
     "imports": [],
     "opens": [],
     "namespace": null,
-    "lineCount": 228,
+    "lineCount": 227,
     "axiomCount": 9,
     "theoremCount": 9,
     "definitionCount": 0,

--- a/src/data/proofs/erdos-866/meta.json
+++ b/src/data/proofs/erdos-866/meta.json
@@ -54,7 +54,7 @@
       "Four open problems formalized as Lean propositions"
     ],
     "axiomCount": 0,
-    "lineCount": 85,
+    "lineCount": 84,
     "assumptions": "0 axioms. 0 sorries. All results formalized without axioms."
   },
   "overview": {
@@ -158,7 +158,7 @@
       "Real"
     ],
     "namespace": "Erdos866",
-    "lineCount": 85,
+    "lineCount": 84,
     "axiomCount": 0,
     "theoremCount": 3,
     "definitionCount": 10,

--- a/src/data/proofs/erdos-94/meta.json
+++ b/src/data/proofs/erdos-94/meta.json
@@ -61,7 +61,7 @@
       "convex_distinct_distances/convex_max_multiplicity/convex_unit_distance: related bounds"
     ],
     "axiomCount": 0,
-    "lineCount": 433,
+    "lineCount": 432,
     "assumptions": "No axioms. 12 sorries(s) remain in the formalization.",
     "mathlib_version": "4.26.0"
   },
@@ -182,7 +182,7 @@
       "Real"
     ],
     "namespace": "Erdos94",
-    "lineCount": 433,
+    "lineCount": 432,
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 16,

--- a/src/data/proofs/erdos-941/meta.json
+++ b/src/data/proofs/erdos-941/meta.json
@@ -58,7 +58,7 @@
       "generalizedQuestion: Problem #1107 connection"
     ],
     "axiomCount": 4,
-    "lineCount": 324,
+    "lineCount": 323,
     "assumptions": "4 axiom(s) and 0 sorry(s)."
   },
   "overview": {
@@ -178,7 +178,7 @@
       "Nat"
     ],
     "namespace": "Erdos941",
-    "lineCount": 324,
+    "lineCount": 323,
     "axiomCount": 4,
     "theoremCount": 11,
     "definitionCount": 13,

--- a/src/data/proofs/navier-stokes-existence/meta.json
+++ b/src/data/proofs/navier-stokes-existence/meta.json
@@ -63,7 +63,7 @@
     ],
     "dateAdded": "2026-03-14",
     "relatedProblems": [],
-    "lineCount": 21111,
+    "lineCount": 21110,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -264,7 +264,7 @@
       "TwoDimensionalGlobal"
     ],
     "namespace": "NavierStokesRegularity",
-    "lineCount": 21111,
+    "lineCount": 21110,
     "axiomCount": 0,
     "theoremCount": 845,
     "definitionCount": 104,

--- a/src/data/proofs/navier-stokes-oq-01/meta.json
+++ b/src/data/proofs/navier-stokes-oq-01/meta.json
@@ -60,7 +60,7 @@
       "Theorem total_dissipation_bound: ∫₀ᵀ 2νP(t) dt ≤ E(0), total dissipation bounded by initial enstrophy"
     ],
     "dateAdded": "2026-02-26",
-    "lineCount": 21111,
+    "lineCount": 21110,
     "assumptions": "None. Formalized with 0 axioms and 0 sorries remain.",
     "relatedProblems": [
       {
@@ -181,7 +181,7 @@
       "TwoDimensionalGlobal"
     ],
     "namespace": "NavierStokesRegularity",
-    "lineCount": 21111,
+    "lineCount": 21110,
     "axiomCount": 0,
     "theoremCount": 845,
     "definitionCount": 104,

--- a/src/data/proofs/navier-stokes-oq-02/meta.json
+++ b/src/data/proofs/navier-stokes-oq-02/meta.json
@@ -59,7 +59,7 @@
       "Theorem continuous_dependence_2d: for any ε > 0, threshold δ = ε·exp(-C·E(0)·T) gives W(0) ≤ δ implies W(t) ≤ ε, establishing Hadamard well-posedness"
     ],
     "dateAdded": "2026-02-28",
-    "lineCount": 21111,
+    "lineCount": 21110,
     "assumptions": "None. Formalized with 0 axioms and 0 sorries remain.",
     "mathlib_version": "4.26.0"
   },
@@ -202,7 +202,7 @@
       "TwoDimensionalGlobal"
     ],
     "namespace": "NavierStokesRegularity",
-    "lineCount": 21111,
+    "lineCount": 21110,
     "axiomCount": 0,
     "theoremCount": 845,
     "definitionCount": 104,

--- a/src/data/proofs/navier-stokes/meta.json
+++ b/src/data/proofs/navier-stokes/meta.json
@@ -73,7 +73,7 @@
     "millenniumProblem": "navier-stokes",
     "proofRepoPath": "Proofs/NavierStokes.lean",
     "mathlib_version": "4.26.0",
-    "lineCount": 21111
+    "lineCount": 21110
   },
   "objection": {
     "verdict": "CONDITIONAL 3D + PROVEN 2D",
@@ -335,7 +335,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 21111,
+    "lineCount": 21110,
     "structureCount": 249,
     "axiomCount": 0,
     "theoremCount": 845,

--- a/src/data/proofs/ptolemys-theorem-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01-incomplete-01/meta.json
@@ -59,7 +59,7 @@
     ],
     "dateAdded": "2026-04-13",
     "axiomCount": 0,
-    "lineCount": 490,
+    "lineCount": 489,
     "assumptions": "None. Fully machine-checked: 0 sorries, 0 axioms. The hcx identity proved via mul_left_cancel₀ with factor (2I)²·E₁₂E₃₄, using hE (phase cancellation) and ring.",
     "theoremCount": 7,
     "definitionCount": 0

--- a/src/data/proofs/shapley-folkman/meta.json
+++ b/src/data/proofs/shapley-folkman/meta.json
@@ -61,7 +61,7 @@
       "Caratheodory's theorem (points in convex hull need at most d+1 vertices)",
       "Affine independence and dimension"
     ],
-    "lineCount": 756,
+    "lineCount": 755,
     "mathlib_version": "4.26.0",
     "leanFile": {
       "imports": [
@@ -201,7 +201,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 756,
+    "lineCount": 755,
     "structureCount": 1,
     "axiomCount": 0,
     "theoremCount": 8,


### PR DESCRIPTION
## Summary

Fixes a systematic off-by-one error in 52 gallery proof `meta.json` files where `lineCount` was stored as `actual + 1`. Root cause: prior scripts used `len(content.split('\n'))` (which yields N+1 for newline-terminated files) instead of `content.count('\n')` (which matches `wc -l`).

- 52 files changed
- All changes: `lineCount: N → N-1` (both `meta.lineCount` and `leanFile.lineCount` where present)
- No sorry count changes
- No logic/content changes

**Files fixed**: amgm-inequality-oq-03-oq-04, area-of-circle-oq-01-oq-03, bertrands-postulate-oq-03-oq-04-oq-03, binomial-theorem-oq-02-oq-01-oq-03, binomial-theorem-oq-02-oq-04, cauchy-schwarz-integral, erdos-1018-oq-04-incomplete-01, erdos-1028, erdos-1034, erdos-1050, erdos-108, erdos-109, erdos-1161, erdos-117-oq-01, erdos-123, erdos-135, erdos-139, erdos-143, erdos-157, erdos-167, erdos-168, erdos-171, erdos-172, erdos-202, erdos-29, erdos-299, erdos-303, erdos-355, erdos-37, erdos-370, erdos-402, erdos-45, erdos-485, erdos-517, erdos-551, erdos-60, erdos-604, erdos-624, erdos-629, erdos-643, erdos-69, erdos-795, erdos-840, erdos-866, erdos-94, erdos-941, navier-stokes, navier-stokes-existence, navier-stokes-oq-01, navier-stokes-oq-02, ptolemys-theorem-oq-01-incomplete-01, shapley-folkman.

🤖 Generated with [Claude Code](https://claude.com/claude-code)