### PR TITLE
Fix: stale lineCount in 9 gallery proofs (larger discrepancies)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -55,7 +55,7 @@
       "Key insight for odd bound: 4π/(2k+3) ≤ 4π/(2k+2) (larger denominator → smaller fraction)"
     ],
     "dateAdded": "2026-04-21",
-    "lineCount": 160,
+    "lineCount": 163,
     "prerequisites": [
       "Recurrence for ball volumes (parent proof)",
       "Convergence of exp series (Mathlib)",

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-01/meta.json
@@ -19,7 +19,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 267,
+    "lineCount": 265,
     "assumptions": "No axioms, no sorries. All 9 theorems fully proved. Key technique: degree_lt_wf minimality + Euclidean division (modByMonic) to establish existence and divisibility of vector minimal polynomial.",
     "mathlib_version": "4.26.0"
   },
@@ -47,7 +47,7 @@
       "Mathlib.RingTheory.Polynomial.Basic"
     ],
     "namespace": "MinpolyVec",
-    "lineCount": 267,
+    "lineCount": 265,
     "axiomCount": 0,
     "theoremCount": 9,
     "definitionCount": 3,

--- a/src/data/proofs/erdos-1083-oq-02/meta.json
+++ b/src/data/proofs/erdos-1083-oq-02/meta.json
@@ -34,7 +34,7 @@
       "Contrast between d=2 (GK resolves gap) and d≥4 (SV gap 2/(d(d+2)) remains entirely open)"
     ],
     "axiomCount": 6,
-    "lineCount": 347,
+    "lineCount": 372,
     "assumptions": "6 axioms: f (extremal function), erdos_lower/grid_upper (Erdős 1946), solymosi_vu (2008 bound), erdos_1083_conjecture (the open conjecture), guth_katz (Guth-Katz 2015 for d=2).",
     "theoremCount": 28
   },

--- a/src/data/proofs/erdos-1202/meta.json
+++ b/src/data/proofs/erdos-1202/meta.json
@@ -19,7 +19,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 97,
+    "lineCount": 115,
     "erdosNumber": 1202,
     "erdosUrl": "https://erdosproblems.com/1202",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-375/meta.json
+++ b/src/data/proofs/erdos-375/meta.json
@@ -59,7 +59,7 @@
       "Hall's marriage theorem formulation"
     ],
     "axiomCount": 2,
-    "lineCount": 361,
+    "lineCount": 357,
     "assumptions": "2 axioms: (1) ramachandra_shorey_tijdeman \u2014 Ramachandra-Shorey-Tijdeman (1975) partial result for k << (log n / log log n)^3; (2) grimm_difficulty \u2014 the known mathematical implication Grimm conjecture \u2192 Legendre conjecture (via prime gap bounds p_{n+1}-p_n \u226a p_n^{1/2-\u03b5}), requiring analytic number theory not yet in Mathlib."
   },
   "overview": {
@@ -179,7 +179,7 @@
       "Finset"
     ],
     "namespace": "Erdos375",
-    "lineCount": 361,
+    "lineCount": 357,
     "axiomCount": 2,
     "theoremCount": 7,
     "definitionCount": 9,

--- a/src/data/proofs/erdos-748/meta.json
+++ b/src/data/proofs/erdos-748/meta.json
@@ -59,7 +59,7 @@
       "erdos_748_summary: combining all results"
     ],
     "axiomCount": 3,
-    "lineCount": 330,
+    "lineCount": 325,
     "assumptions": "3 axiom(s): trivial_lower_bound, green_upper_bound, precise_asymptotic. See the Lean source for details."
   },
   "overview": {
@@ -177,7 +177,7 @@
       "Finset"
     ],
     "namespace": "Erdos748",
-    "lineCount": 330,
+    "lineCount": 325,
     "axiomCount": 3,
     "theoremCount": 11,
     "definitionCount": 5,

--- a/src/data/proofs/fourier-series-oq-02-oq-01/meta.json
+++ b/src/data/proofs/fourier-series-oq-02-oq-01/meta.json
@@ -22,7 +22,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 90,
+    "lineCount": 92,
     "assumptions": "No axioms, no sorries. Imports FourierSeries.lean (fourierCoeff_tendsto_zero via Parseval) and FourierSeriesOQ02.lean (IsHolderOnCircle, holder_continuous). The L² route uses MemLp.toLp and integral_congr_ae.",
     "mathlib_version": "4.26.0"
   },
@@ -52,7 +52,7 @@
       "Proofs.FourierSeriesOQ02"
     ],
     "namespace": "FourierHolderL2RL",
-    "lineCount": 90,
+    "lineCount": 92,
     "axiomCount": 0,
     "theoremCount": 2,
     "definitionCount": 0,

--- a/src/data/proofs/godel-first-incompleteness-oq01/meta.json
+++ b/src/data/proofs/godel-first-incompleteness-oq01/meta.json
@@ -45,7 +45,7 @@
       "ω-consistency vs plain consistency",
       "Axiomatic provability logic"
     ],
-    "lineCount": 214,
+    "lineCount": 271,
     "proofRepoPath": "Proofs/GodelFirstIncompletenessOQ01.lean",
     "mathlib_version": "4.26.0",
     "relatedProofs": [

--- a/src/data/proofs/yang-mills-lattice-oq-01/meta.json
+++ b/src/data/proofs/yang-mills-lattice-oq-01/meta.json
@@ -22,7 +22,7 @@
     "sorries": 0,
     "axiomCount": 2,
     "assumptions": "2 axioms: (1) os_reconstruction — the GNS construction from reflection-positive lattice OS data producing a WightmanQFT; this is mathematically proven (Osterwalder-Schrader 1973, Osterwalder-Seiler 1978) but requires functional analysis (Bochner's theorem, GNS construction) beyond current Mathlib. (2) os_mass_gap_transfer — that exponential decay of Schwinger functions implies a spectral gap in the reconstructed Hilbert space via the Kallen-Lehmann representation; similarly proven but requires the full OS machinery. The 2D results (Migdal formula, string tension, SU(2) computation) are fully proved with 0 axioms.",
-    "lineCount": 492,
+    "lineCount": 500,
     "mathlibDependencies": [
       {
         "theorem": "Real.log_neg",
@@ -148,7 +148,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 492,
+    "lineCount": 500,
     "structureCount": 7,
     "axiomCount": 2,
     "theoremCount": 22,


### PR DESCRIPTION
## Summary

9 proofs where `lineCount` was noticeably stale (not off-by-1, but larger gaps because the Lean source grew or shrank after the metadata was written).

| Proof | Old | New |
|-------|-----|-----|
| area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01 | 160 | 163 |
| cayley-hamilton-minpoly-oq-03-oq-01 | 267 | 265 |
| erdos-1083-oq-02 | 347 | 372 |
| erdos-1202 | 97 | 115 |
| erdos-375 | 361 | 357 |
| erdos-748 | 330 | 325 |
| fourier-series-oq-02-oq-01 | 90 | 92 |
| godel-first-incompleteness-oq01 | 214 | 271 |
| yang-mills-lattice-oq-01 | 492 | 500 |

All values verified with `wc -l` against current Lean source. No sorry count changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)