### PR TITLE
Seeker: select law-of-cosines-oq-01-oq-05 — close euclidean_limit_holds sorry

### DIFF
--- a/research/problems/fourier-series-oq-02-oq-01/knowledge.md
+++ b/research/problems/fourier-series-oq-02-oq-01/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: fourier-series-oq-02-oq-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/fourier-series-oq-02-oq-01/literature/README.md
+++ b/research/problems/fourier-series-oq-02-oq-01/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for fourier-series-oq-02-oq-01
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/fourier-series-oq-02-oq-01/problem.md
+++ b/research/problems/fourier-series-oq-02-oq-01/problem.md
@@ -1,0 +1,154 @@
+# Problem: Alternative Mathlib proof of riemannLebesgue_of_holder
+
+**Slug**: fourier-series-oq-02-oq-01
+**Created**: 2026-04-21
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+Given the existing `riemannLebesgue_of_holder` theorem in `FourierHolderDecay`:
+
+```lean
+theorem riemannLebesgue_of_holder (C : ℝ≥0) (α : ℝ≥0)
+    (f : AddCircle T → ℂ) (hf : IsHolderOnCircle C α f) (hα : 0 < α) :
+    Tendsto (fun n : ℤ => fourierCoeff f n) cofinite (𝓝 0)
+```
+
+Can this be proved more cleanly via the Mathlib chain:
+
+$$\text{Hölder} \Rightarrow \text{Continuous} \Rightarrow L^1 \Rightarrow \text{Riemann-Lebesgue (Mathlib)}$$
+
+rather than via the current quantitative decay bound?
+
+### Plain Language
+
+The current proof of `riemannLebesgue_of_holder` goes through a quantitative Fourier
+coefficient decay estimate (`fourierCoeff_holder_decay`): it shows |ĉₙ| ≤ C/|n|^α, then
+derives that the set of frequencies where |ĉₙ| ≥ ε is finite.
+
+Mathlib has `Mathlib.Analysis.Fourier.RiemannLebesgueLemma` which provides the
+Riemann-Lebesgue theorem for L¹ functions. The question is whether we can give a
+*shorter*, more principled proof by:
+
+1. Showing every α-Hölder function (α > 0) is continuous
+2. Continuous functions on a compact space (AddCircle T) are bounded, hence integrable (L¹)
+3. Applying Mathlib's R-L lemma directly
+
+This would produce a cleaner derivation that doesn't depend on the intermediate
+quantitative bounds.
+
+### Why This Matters
+
+- Demonstrates how to connect the gallery's custom Hölder API to Mathlib's mainstream analysis
+- Would reduce the complexity of `FourierSeriesOQ02.lean` (currently 486 lines with 1 axiom)
+- Shows the gallery's quantitative estimates can be complemented by qualitative Mathlib paths
+- Models good Lean formalization practice: reuse Mathlib rather than reproving
+
+## Known Results
+
+### What's Already Proven
+
+- `riemannLebesgue_of_holder` — proved in `FourierSeriesOQ02.lean` via quantitative decay
+- `fourierCoeff_holder_decay` — decay estimate: |ĉₙ| ≤ (C/2)·(T/(2|n|))^α for n≠0
+- `IsHolderOnCircle` → continuous is standard (Hölder with α > 0 implies uniform continuity)
+- Mathlib: `Mathlib.Analysis.Fourier.RiemannLebesgueLemma` exists
+- Mathlib: `Mathlib.Topology.MetricSpace.Holder` has `HolderWith.uniformContinuous`
+
+### What's Still Open
+
+- Whether Mathlib's R-L for AddCircle gives exactly `Tendsto ... cofinite (𝓝 0)`
+- The exact Mathlib theorem name needed (may use `VanishingAtInfinity` vs `cofinite` filter)
+- Whether gallery `fourierCoeff` matches Mathlib's `AddCircle.fourierCoeff` or needs bridging
+
+### Our Goal
+
+Provide an alternative proof of `riemannLebesgue_of_holder` using:
+```lean
+theorem riemannLebesgue_of_holder_v2 ...  := by
+  have hcont : Continuous f := holder_continuous ...
+  have hL1 : Integrable f := hcont.integrable_of_compact_closure ...
+  exact mathlib_RL_for_L1 hL1
+```
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `fourier-series-oq-02` | Parent proof; contains existing Lean proof | Quantitative decay, cofinite filter |
+| `fourier-series-oq-04` | Fourier series, Dirichlet kernel | AddCircle Fourier theory |
+| `fourier-series-oq-03` | Dirichlet conditions (BV functions) | R-L for BV, integration by parts |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Direct Mathlib Bridge** (preferred):
+   - Look up Mathlib's AddCircle Fourier coefficient R-L theorem name
+   - Show `IsHolderOnCircle → ContinuousOn` via `HolderWith.continuous`
+   - Show compact + continuous → L¹
+   - Apply Mathlib R-L
+   - Risk: Mathlib R-L may use a different filter or different normalization
+
+2. **Upgrade existing proof**:
+   - Keep current proof structure but replace explicit decay computation
+     with `tendsto_of_tendsto_of_tendsto` applied to the bound tending to 0
+   - Less clean but likely to compile quickly
+
+### Key Difficulties
+
+- Matching the `cofinite` filter to whatever filter Mathlib's R-L uses
+  (may be `atTop` on `ℕ` vs cofinite on `ℤ`)
+- The gallery uses custom `fourierCoeff` — need to check it matches Mathlib's API
+- `IsHolderOnCircle` is gallery-local; need to extract `ContinuousOn` via `HolderWith`
+
+### What Would a Proof Need?
+
+- Key lemma 1: `IsHolderOnCircle C α f → Continuous f` (from `HolderWith.uniformContinuous`)
+- Key lemma 2: Mathlib R-L: `Integrable f → Tendsto (fourierCoeff f) cofinite (𝓝 0)` on AddCircle
+- Key lemma 3: `Continuous f → Integrable f` on compact `AddCircle T`
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- Mathematical path is completely clear (Hölder → continuous → integrable → R-L)
+- The challenge is finding right Mathlib lemma names and handling API mismatches
+- `Mathlib.Analysis.Fourier.RiemannLebesgueLemma` exists and covers this case
+- Similar Mathlib bridging work has succeeded in other gallery proofs
+
+**Estimated Effort**:
+- Exploration (finding Mathlib lemma names): 1-2 hours
+- Proof assembly: 2-4 hours
+
+## References
+
+### Papers
+- Zygmund, *Trigonometric Series*, Chapter 2 — standard reference for Fourier decay
+
+### Mathlib
+- `Mathlib.Analysis.Fourier.RiemannLebesgueLemma` — R-L for L¹ (the main tool needed)
+- `Mathlib.Topology.MetricSpace.Holder` — HolderWith, continuity implications
+- `Mathlib.Analysis.Fourier.AddCircle` — AddCircle Fourier coefficients
+- `Mathlib.MeasureTheory.Function.L2Space` — integrability on compact spaces
+
+## Metadata
+
+```yaml
+tags:
+  - harmonic-analysis
+  - fourier-series
+  - mathlib
+  - riemann-lebesgue
+  - holder-continuity
+  - integrability
+related_proofs:
+  - fourier-series-oq-02
+  - fourier-series-oq-03
+difficulty: medium
+source: gallery-gap
+created: 2026-04-21
+```

--- a/research/problems/fourier-series-oq-02-oq-01/state.md
+++ b/research/problems/fourier-series-oq-02-oq-01/state.md
@@ -1,0 +1,25 @@
+# Research State: fourier-series-oq-02-oq-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-04-21T05:11:03-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/law-of-cosines-oq-01-oq-05/state.md
+++ b/research/problems/law-of-cosines-oq-01-oq-05/state.md
@@ -3,11 +3,13 @@
 ## Current State
 **Phase**: OBSERVE
 **Path**: full
-**Since**: 2026-04-21T04:24:59-07:00
+**Since**: 2026-04-21T11:24:59-07:00
 **Iteration**: 1
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Follow-up research: close the remaining sorry `euclidean_limit_holds` in proofs/Proofs/LawOfCosinesOQ05.lean.
+
+The K→0 Euclidean limit requires proving that cs_K(c) → 1 - K·c²/2 and sn_K(r) → r as K→0, so that the unified law reduces to the Euclidean law of cosines c²=a²+b²-2ab·cos(C). This needs Taylor expansion analysis via Mathlib's `Real.cos_sq` / `HasDerivAt` machinery.
 
 ## Active Approach
 None yet.
@@ -20,6 +22,11 @@ None yet.
 ## Blockers
 None.
 
+## Context
+Gallery entry exists at src/data/proofs/law-of-cosines-oq-01-oq-05/.
+Proof file: proofs/Proofs/LawOfCosinesOQ05.lean (365 lines, 0 axioms, 1 sorry).
+All other theorems proved: unified Pythagorean identity, K=±1 recovery theorems, algebraic equivalences.
+
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+Read the existing proof file (proofs/Proofs/LawOfCosinesOQ05.lean) to understand the current sorry context.
+Explore Mathlib's Taylor expansion lemmas for cos(√K·r) at K=0.

--- a/research/registry.json
+++ b/research/registry.json
@@ -16688,6 +16688,13 @@
       "status": "graduated",
       "lastUpdate": "2026-04-21T12:01:09.950Z",
       "completed": "2026-04-21T12:01:09.950Z"
+    },
+    {
+      "slug": "fourier-series-oq-02-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-21T05:11:03-07:00",
+      "status": "active"
     }
   ],
   "config": {


### PR DESCRIPTION
## Problem Selection Report

**Date**: 2026-04-21
**Pool Status**: 15 available (at threshold), 511 in-progress, 1375 completed

## Selected Problem

- **ID**: `law-of-cosines-oq-01-oq-05`
- **Name**: Unified Curvature-Parametrized Law of Cosines (follow-up)
- **Tier**: B | **Significance**: 6/10 | **Tractability**: 7/10
- **Composite Score**: 76 (EMPTY knowledge tier + tractability 7 + sig 6)

## Selection Rationale

Follow-up pass to close the one remaining sorry in the unified law of cosines formalization:

- Proof exists at `proofs/Proofs/LawOfCosinesOQ05.lean` (365 lines, 0 axioms, 1 sorry)
- All other theorems proved: unified Pythagorean identity, K=±1 recovery, algebraic equivalences
- **Open**: `euclidean_limit_holds` — the K→0 limit requires Taylor expansion of `cos(√K·r)` and `sin(√K·r)/√K` at K=0 to recover the Euclidean law c²=a²+b²-2ab·cos(C)
- Gallery entry already at `src/data/proofs/law-of-cosines-oq-01-oq-05/`

## Suggested First Steps

1. Read `proofs/Proofs/LawOfCosinesOQ05.lean` ~lines 314–365 to find the sorry context
2. Search Mathlib for Taylor expansion lemmas: `Real.cos_sq`, `HasDerivAt`, `Filter.Tendsto`
3. Prove `cs_K(r) → 1 - K·r²/2` and `sn_K(r) → r` as K→0, then derive the Euclidean law

## Pool Health

14 → 15 available (re-opened `law-of-cosines-oq-01-oq-05` for follow-up; 2 problems have active claims).

🤖 Generated with [Claude Code](https://claude.com/claude-code)