### PR TITLE
Enrich cayley-hamilton-reduction-oq-01-oq-02: sections, conclusion, fix annotations

### DIFF
--- a/src/data/proofs/cayley-hamilton-reduction-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/cayley-hamilton-reduction-oq-01-oq-02/annotations.json
@@ -10,7 +10,7 @@
     "title": "Efficient Minimal Polynomial Reduction: The Open Question",
     "content": "The header frames the question: can the minimal polynomial reduction — evaluating p(M) as (p mod minpoly(M))(M) — be made efficient for sparse matrices? The answer is yes via three mechanisms: (1) nilpotent M with M^k = 0 → use X^k as modulus directly, bypassing minpoly computation; (2) upper triangular M → minpoly divides the diagonal product ∏(X - M_i_i), which is O(n) to compute; (3) general → the standard reduction holds for any matrix. The nilpotent case is the key efficiency gain: the polynomial evaluation truncates at degree k with just division by X^k (coefficient truncation).",
     "mathContext": "For nilpotent $M$ ($M^k = 0$): $\\text{minpoly}(M) \\mid X^k$, so any polynomial in $M$ reduces to a polynomial of degree $< k$. The reduction $p(M) = (p \\bmod X^k)(M)$ requires no computation of $\\text{minpoly}(M)$ — just truncate $p$'s coefficients at degree $k$. Compare to general sparse matrices where computing $\\text{minpoly}$ requires $O(n^2)$–$O(n^3)$ operations.",
-    "significance": "main",
+    "significance": "key",
     "relatedConcepts": [
       "minimal polynomial",
       "nilpotent matrix",
@@ -34,7 +34,7 @@
     "title": "Nilpotent Minpoly Divides X^k",
     "content": "The key divisibility: if M^k = 0, then minpoly K M divides X^k. Proof: apply minpoly.dvd, which requires showing aeval M (X^k) = 0. Since aeval M (X^k) = M^k (polynomial evaluation of X^k at M gives M^k) and M^k = 0 by hypothesis, the annihilation holds.",
     "mathContext": "$\\text{minpoly}(M) \\mid X^k$ iff $X^k \\in I_M := \\{p : p(M) = 0\\}$ and $\\text{minpoly}(M)$ generates $I_M$. The annihilation $M^k = 0$ gives $X^k \\in I_M$, hence divisibility.",
-    "significance": "main",
+    "significance": "key",
     "relatedConcepts": [
       "minpoly.dvd",
       "nilpotent matrix",
@@ -57,7 +57,7 @@
     "title": "Nilpotent Polynomial Reduction (Key Efficiency Theorem)",
     "content": "For nilpotent M (M^k = 0), polynomial evaluation at M depends only on the polynomial modulo X^k. The proof uses Euclidean division: p = (p mod X^k) + X^k * (p div X^k). Applying aeval M: aeval M p = aeval M (p mod X^k) + aeval M (X^k) * aeval M (p div X^k). Since aeval M (X^k) = M^k = 0, the second term vanishes. The efficiency: p mod X^k is degree truncation — drop all terms of degree ≥ k. This is O(deg p) work with no matrix operations needed.",
     "mathContext": "The Euclidean identity $p = (p \\bmod X^k) + X^k \\cdot (p \\div X^k)$ gives $p(M) = (p \\bmod X^k)(M) + M^k \\cdot (p \\div X^k)(M) = (p \\bmod X^k)(M)$ since $M^k = 0$. The modulus $X^k$ is trivially known (just the nilpotency index), requiring no eigenvalue computation.",
-    "significance": "main",
+    "significance": "key",
     "relatedConcepts": [
       "modByMonic",
       "Euclidean division",
@@ -71,11 +71,35 @@
     ]
   },
   {
+    "id": "ann-ch-red-oq01-oq02-03b-degree-bound",
+    "proofId": "cayley-hamilton-reduction-oq-01-oq-02",
+    "range": { "startLine": 57, "endLine": 67 },
+    "type": "theorem",
+    "title": "Nilpotent Minpoly Degree Bound: deg(minpoly) ≤ k",
+    "content": "Given that minpoly K M | X^k, the degree bound follows by Polynomial.natDegree_le_of_dvd combined with natDegree_X_pow k = k. The key point: when k is small (e.g., k = 2 for a 100×100 strictly upper triangular block matrix), this gives a degree bound of 2 rather than 100, enabling much shorter Krylov iterations.",
+    "mathContext": "$\\text{minpoly}(M) \\mid X^k \\Rightarrow \\deg(\\text{minpoly}(M)) \\leq \\deg(X^k) = k$. Combined with $k \\leq n$ (nilpotency index ≤ matrix dimension for $n\\times n$ matrices), we get $\\deg(\\text{minpoly}(M)) \\leq k \\leq n$. For strictly upper triangular $n\\times n$ matrices, $k = n$ (the matrix satisfies $M^n = 0$ but $M^{n-1} \\neq 0$).",
+    "significance": "supporting",
+    "relatedConcepts": ["natDegree_le_of_dvd", "natDegree_X_pow", "nilpotency index", "Krylov termination"],
+    "prerequisites": ["nilpotent_minpoly_dvd_pow", "Polynomial.natDegree_le_of_dvd"]
+  },
+  {
+    "id": "ann-ch-red-oq01-oq02-03c-power-vanish",
+    "proofId": "cayley-hamilton-reduction-oq-01-oq-02",
+    "range": { "startLine": 93, "endLine": 111 },
+    "type": "theorem",
+    "title": "Power Vanishing and Reduction Equivalence",
+    "content": "Two supporting results. `nilpotent_power_eq_zero` (lines 96-100): if M^k = 0, then M^j = 0 for all j ≥ k. This is the Krylov termination certificate: the Krylov sequence {v, Mv, ..., M^{k-1}v} generates the same subspace as {v, Mv, ..., M^{j}v} for all j ≥ k, since M^k v = 0. The proof uses Nat.exists_eq_add_of_le + pow_add.\n\n`nilpotent_reduction_equiv` (lines 104-111): for nilpotent M, reducing mod X^k gives the same result as reducing mod minpoly K M. This confirms that either modulus can be used equivalently in practice, with X^k being the computationally cheaper choice.",
+    "mathContext": "$M^j = M^{j-k} \\cdot M^k = 0$ for $j \\geq k$. The Krylov sequence $v, Mv, \\ldots, M^{k-1}v$ is a complete basis for the Krylov subspace $\\mathcal{K}_k(M,v) = \\text{span}\\{v, Mv, \\ldots, M^{k-1}v\\}$, since all higher powers vanish. The equivalence $(p \\bmod X^k)(M) = (p \\bmod \\mu_M)(M)$ holds because $\\mu_M \\mid X^k$ implies the two reduction residues agree in evaluation at $M$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Krylov subspace termination", "Nat.exists_eq_add_of_le", "nilpotent_reduction_equiv", "modular equivalence"],
+    "prerequisites": ["nilpotent_poly_reduction", "modByMonic_add_div", "minpoly.aeval"]
+  },
+  {
     "id": "ann-ch-red-oq01-oq02-04-upper-tri",
     "proofId": "cayley-hamilton-reduction-oq-01-oq-02",
     "range": {
-      "startLine": 116,
-      "endLine": 145
+      "startLine": 117,
+      "endLine": 143
     },
     "type": "theorem",
     "title": "Upper Triangular Minpoly Divides Diagonal Product",
@@ -93,5 +117,29 @@
       "Matrix.aeval_self_charpoly",
       "Polynomial.natDegree_le_of_dvd"
     ]
+  },
+  {
+    "id": "ann-ch-red-oq01-oq02-05-general",
+    "proofId": "cayley-hamilton-reduction-oq-01-oq-02",
+    "range": { "startLine": 145, "endLine": 172 },
+    "type": "theorem",
+    "title": "General Minimal Polynomial Reduction and Degree Truncation",
+    "content": "`minpoly_poly_reduction` (lines 153-158): the general reduction theorem — for any matrix M and polynomial p, aeval M p = aeval M (p %ₘ minpoly K M). This is the same pattern as the nilpotent case but applies universally. The proof is clean: Euclidean division + aeval M (minpoly K M) = 0 (from Mathlib's minpoly.aeval).\n\n`nilpotent_reduction_degree_lt` (lines 163-171): the reduced polynomial p %ₘ X^k has natDegree < k. This confirms that the nilpotent reduction really does compress the polynomial: any polynomial of degree ≥ k in a nilpotent matrix reduces to one of degree < k.",
+    "mathContext": "The general reduction: $p(M) = (p \\bmod \\mu_M)(M)$ holds for any $M$ because $p = (p \\bmod \\mu_M) + \\mu_M \\cdot q$ gives $p(M) = (p \\bmod \\mu_M)(M) + \\mu_M(M) \\cdot q(M) = (p \\bmod \\mu_M)(M) + 0$. The degree bound: $\\deg(p \\bmod X^k) < k$ by the division algorithm.",
+    "significance": "supporting",
+    "relatedConcepts": ["modByMonic_add_div", "minpoly.aeval", "degree_modByMonic_lt", "general Cayley-Hamilton reduction"],
+    "prerequisites": ["Polynomial.modByMonic_add_div", "minpoly.aeval K M", "Polynomial.natDegree_lt_natDegree"]
+  },
+  {
+    "id": "ann-ch-red-oq01-oq02-06-summary",
+    "proofId": "cayley-hamilton-reduction-oq-01-oq-02",
+    "range": { "startLine": 175, "endLine": 210 },
+    "type": "context",
+    "title": "Summary: Three Efficiency Mechanisms and Algorithmic Impact",
+    "content": "The closing documentation summarizes the three efficiency mechanisms. Note: the summary header says '8 theorems' but the bullet list includes 9 (nilpotent_reduction_equiv is listed but not counted). The meta.json correctly records theoremCount: 9.\n\nFor sparse matrices (banded, block triangular, nearly nilpotent), the minimal polynomial often has degree much smaller than n. Nilpotent matrices — arising in upper Hessenberg decompositions, shift matrices, graph adjacency matrices — benefit most: the reduction becomes pure coefficient truncation with no matrix multiplications.",
+    "mathContext": "Computational complexity: General minpoly computation via Krylov: $O(n^2)$ matrix-vector products. Nilpotent case via $X^k$: $O(k)$ coefficient reads, 0 matrix multiplications for the modulus. Upper triangular: $O(n)$ scalar reads (diagonal). For sparse matrices where $k \\ll n$ (e.g., $k = O(\\log n)$), the savings can be dramatic.",
+    "significance": "context",
+    "relatedConcepts": ["computational complexity", "sparse matrix algorithms", "nilpotency index", "Wiedemann algorithm"],
+    "prerequisites": ["the three reduction mechanisms", "polynomial arithmetic complexity"]
   }
 ]

--- a/src/data/proofs/cayley-hamilton-reduction-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-reduction-oq-01-oq-02/meta.json
@@ -34,13 +34,68 @@
     "keyInsights": [
       "For nilpotent M (M^k = 0), X^k can serve as the reduction modulus directly, since minpoly K M | X^k. This avoids computing minpoly altogether — the reduction is just polynomial degree truncation.",
       "The nilpotency index k gives a tight degree bound: deg(minpoly) ≤ k ≤ n. For sparse structured matrices with small k, this is much better than the general bound n.",
-      "For upper triangular matrices, minpoly K M divides ∏ᵢ(X - M i i), which is computed in O(n) time by reading the diagonal — matching the efficiency of OQ-01's charpoly approach."
+      "For upper triangular matrices, minpoly K M divides ∏ᵢ(X - M i i), which is computed in O(n) time by reading the diagonal — matching the efficiency of OQ-01's charpoly approach.",
+      "nilpotent_reduction_equiv establishes that the two moduli (X^k and minpoly K M) are interchangeable in practice: both give the same polynomial evaluation at M, so the cheaper X^k can always be substituted without loss of correctness.",
+      "nilpotent_power_eq_zero proves Krylov termination directly: M^j = 0 for all j ≥ k. This means the Krylov sequence {v, Mv, ..., M^{k-1}v} is a complete invariant of the linear map restricted to its range — no new information is generated after k steps."
     ],
     "prerequisites": [
       "Minimal polynomial theory: minpoly.dvd, minpoly.monic, minpoly.aeval",
       "Euclidean division of polynomials: modByMonic_add_div",
       "CayleyHamiltonReductionOQ01.lean: efficient charpoly reduction for sparse matrices",
       "Matrix.charpoly_of_upperTriangular: diagonal product formula"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Header and Imports",
+      "startLine": 1,
+      "endLine": 39,
+      "summary": "Module docstring answers the efficiency question for sparse matrices: yes, with three mechanisms (nilpotent X^k bypass, upper triangular diagonal product, general reduction). Imports Mathlib for charpoly, minpoly, block matrices, polynomial division, and nilpotency. Namespace MinpolyReductionOQ02."
+    },
+    {
+      "id": "nilpotent-minpoly-theory",
+      "title": "Part I: Nilpotent Matrix Minimal Polynomial Theory",
+      "startLine": 41,
+      "endLine": 67,
+      "summary": "nilpotent_minpoly_dvd_pow: if M^k = 0 then minpoly K M | X^k (via minpoly.dvd + aeval_X + map_pow). nilpotent_minpoly_natDegree_le: degree bound deg(minpoly) ≤ k from natDegree_le_of_dvd + natDegree_X_pow. These establish that the nilpotency index k is a tight degree certificate requiring no minpoly computation."
+    },
+    {
+      "id": "nilpotent-reduction",
+      "title": "Part II: Efficient Polynomial Reduction via Nilpotency Index",
+      "startLine": 69,
+      "endLine": 111,
+      "summary": "nilpotent_poly_reduction: aeval M p = aeval M (p %ₘ X^k) — the key efficiency theorem. nilpotent_power_eq_zero: M^j = 0 for all j ≥ k (Krylov termination certificate). nilpotent_reduction_equiv: X^k and minpoly K M are interchangeable reduction moduli. Proves the nilpotent bypass is both correct and complete."
+    },
+    {
+      "id": "upper-triangular",
+      "title": "Part III: Upper Triangular Minpoly Bound",
+      "startLine": 113,
+      "endLine": 143,
+      "summary": "upper_tri_minpoly_dvd_prod: minpoly K M | ∏ᵢ(X - M i i) for block-triangular M (using charpoly_of_upperTriangular + minpoly.dvd). upper_tri_minpoly_natDegree_le: degree ≤ n. Reduces minpoly computation to reading the diagonal — O(n) vs O(n³) for general charpoly."
+    },
+    {
+      "id": "general-reduction",
+      "title": "Part IV: General Efficient Reduction",
+      "startLine": 145,
+      "endLine": 172,
+      "summary": "minpoly_poly_reduction: the foundational reduction theorem aeval M p = aeval M (p %ₘ minpoly K M), valid for any matrix M. nilpotent_reduction_degree_lt: confirms that p %ₘ X^k has natDegree < k (the reduction genuinely compresses the polynomial). These theorems complete the efficiency framework."
+    },
+    {
+      "id": "summary",
+      "title": "Proof Summary and Algorithmic Impact",
+      "startLine": 175,
+      "endLine": 210,
+      "summary": "Documentation block listing all 9 proved theorems under the three mechanisms. Emphasizes the nilpotent case as the most dramatic efficiency gain: polynomial evaluation in nilpotent matrices is pure coefficient truncation — no matrix multiplications for the modulus, O(deg p) total work. For strictly upper triangular n×n matrices, the nilpotency index k = n, recovering the general bound with an explicit formula for the modulus."
+    }
+  ],
+  "conclusion": {
+    "summary": "This formalization proves that minimal polynomial reduction for sparse matrices admits three efficient special cases, all proved with 0 sorries and 0 axioms. The nilpotent case (M^k = 0) is the most significant: X^k serves as an explicit, trivially-computed reduction modulus, bypassing any computation of minpoly K M. The 9 theorems collectively justify using structure-specific reduction moduli in Krylov subspace algorithms.",
+    "implications": "The efficiency results formalized here underpin the theoretical foundations of several numerical algorithms:\n\n**Nilpotent matrices** arise in Schur decompositions, Jordan form computations, and graph theory (adjacency matrices of DAGs). When M^k = 0 for small k, Krylov methods terminate in ≤ k steps rather than ≤ n, giving O(k) matrix-vector products instead of O(n).\n\n**Block triangular matrices** arise from graph-structured problems (lower triangular systems from topological orderings, block LU factorizations). The upper triangular bound means minpoly can be determined from the diagonal without computing eigenvalues.\n\n**General reduction** (minpoly_poly_reduction) enables the Cayley-Hamilton framework for polynomial matrix expressions: any function of M that is a polynomial in M can be computed modulo minpoly K M without loss. This is fundamental to matrix function algorithms (matrix exponential, resolvent computation).",
+    "openQuestions": [
+      "Cayley-Hamilton via nilpotency: can the general Cayley-Hamilton theorem (charpoly(M)(M) = 0) be proved for any matrix by reducing to the nilpotent case via the Jordan decomposition, without appealing to the abstract algebraic proof? This would give an algorithmic proof with explicit complexity bounds.",
+      "Block nilpotent matrices: for block upper triangular M with nilpotent diagonal blocks, the minimal polynomial is X^k where k is the maximum nilpotency index of the blocks. Can this be formalized cleanly in Lean using Matrix.Block infrastructure?",
+      "Sparse polynomial evaluation: the formalization proves correctness of the X^k bypass but does not address the complexity of evaluating (p %ₘ X^k)(M). For a sparse M, computing Σᵢ<k pᵢ · Mⁱ v requires k matrix-vector products. Can Horner's method be formalized to show this is optimal?"
     ]
   },
   "leanFile": {


### PR DESCRIPTION
## Enrichment pass for cayley-hamilton-reduction-oq-01-oq-02

**Quality improvements:**

- **Fixed annotation `significance` values**: all were "main" (non-standard) → corrected to "key"

- **Added 6 `sections`** covering all 210 lines:
  - Preamble: header/imports/namespace
  - Part I: nilpotent minpoly theory (dvd + degree bound)
  - Part II: efficient reduction via nilpotency index (3 theorems)
  - Part III: upper triangular minpoly bound (2 theorems)
  - Part IV: general efficient reduction (2 theorems)
  - Summary: documentation block and algorithmic context

- **Added `conclusion`**:
  - Summary of 9 proved theorems (0 sorries, 0 axioms)
  - Implications: nilpotent Krylov termination, block triangular algorithms, matrix function computation
  - 3 open questions: Cayley-Hamilton via nilpotency, block nilpotent matrices, sparse evaluation complexity

- **Extended `keyInsights`** from 3 to 5:
  - Added: nilpotent_reduction_equiv shows X^k and minpoly are interchangeable moduli
  - Added: nilpotent_power_eq_zero proves Krylov termination certificate

- **Added 4 annotations** for uncovered code sections:
  - `ann-ch-red-oq01-oq02-03b-degree-bound`: nilpotent degree bound (lines 57-67)
  - `ann-ch-red-oq01-oq02-03c-power-vanish`: power vanishing + reduction equivalence (lines 93-111)
  - `ann-ch-red-oq01-oq02-05-general`: general reduction + degree truncation (lines 145-172)
  - `ann-ch-red-oq01-oq02-06-summary`: algorithmic context and complexity (lines 175-210)

Build verified: `pnpm build` passes.