### PR TITLE
Fix: badge corrections for 2 gallery proofs

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-03/meta.json
@@ -17,7 +17,7 @@
       "fiber grouping",
       "combinatorics"
     ],
-    "badge": "original",
+    "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
     "lineCount": 223,

--- a/src/data/proofs/erdos-817/meta.json
+++ b/src/data/proofs/erdos-817/meta.json
@@ -16,7 +16,7 @@
       "subset-sums",
       "extremal-combinatorics"
     ],
-    "badge": "research",
+    "badge": "wip",
     "sorries": 0,
     "erdosNumber": 817,
     "erdosUrl": "https://erdosproblems.com/817",


### PR DESCRIPTION
## Fix

Corrected invalid/inconsistent badge values in two gallery proofs.

## Evidence

**binomial-theorem-oq-02-oq-01-oq-03**:
- **Before**: `badge: "original"` (implies fully verified, 0 assumptions)
- **After**: `badge: "wip"` (1 sorry remains for `multinomial_cross_moment`)
- The `original` badge is reserved for fully machine-checked proofs with no sorries or axioms. This proof has `sorries: 1` so `wip` is correct.

**erdos-817**:
- **Before**: `badge: "research"` (not a valid badge value)
- **After**: `badge: "wip"` (open Erdős problem, main conjecture not proved)
- Valid badge values are: `original`, `verified`, `axiom`, `mathlib`, `wip`, `infrastructure`, `from-axioms`. The value `research` is not in this set.

---
Automated fix by lean-mechanic agent.