### PR TITLE
Enrich fourier-series-oq-02-oq-01: sections, conclusion, fix annotation quality

### DIFF
--- a/src/data/proofs/fourier-series-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/fourier-series-oq-02-oq-01/annotations.json
@@ -10,7 +10,7 @@
     "title": "The L² Route for Riemann-Lebesgue",
     "content": "The header frames the question: can Riemann-Lebesgue for Hölder functions be proved via the L² Parseval route rather than explicit decay bounds? The answer is yes. The chain Hölder → continuous → MemLp 2 → Lp element → fourierCoeff_tendsto_zero gives ĉ_n → 0 in fewer steps than the direct approach, at the cost of losing the quantitative decay rate O(1/|n|^α).",
     "mathContext": "For $f$ Hölder on $\\text{AddCircle}\\,T$ (compact): $f$ is continuous, hence bounded. On the probability space $(\\text{AddCircle}\\,T, \\text{haar})$, bounded measurable functions are in $L^\\infty \\subseteq L^2$. By Parseval, $\\sum_n |\\hat{c}_n(f)|^2 < \\infty$, so $\\hat{c}_n(f) \\to 0$.",
-    "significance": "main",
+    "significance": "key",
     "relatedConcepts": [
       "Riemann-Lebesgue lemma",
       "Hölder continuity",
@@ -34,7 +34,7 @@
     "title": "Hölder → Continuous → MemLp 2 (Compact Bridge)",
     "content": "The key infrastructure step: Hölder f is continuous (holder_continuous), continuous functions on the compact AddCircle T are bounded (by their sup norm, attained on a compact set), and bounded measurable functions on a probability space are in L². The Lean proof uses memLp_const + mono' + IsCompact.bddAbove. This is the bridge from regularity (Hölder) to the Hilbert space theory (L²).",
     "mathContext": "For compact $X$ with probability measure $\\mu$: if $f : X \\to \\mathbb{C}$ is continuous, then $\\|f\\|_\\infty = \\sup_x \\|f(x)\\| < \\infty$ (attained, since $X$ compact). Then $\\|f(x)\\|^2 \\leq \\|f\\|_\\infty^2$ everywhere, so $\\int \\|f\\|^2 \\, d\\mu \\leq \\|f\\|_\\infty^2 \\cdot \\mu(X) = \\|f\\|_\\infty^2 < \\infty$.",
-    "significance": "main",
+    "significance": "key",
     "relatedConcepts": [
       "MemLp",
       "memLp_const",
@@ -74,23 +74,39 @@
     "id": "ann-fs-oq02-oq01-04-main-theorem",
     "proofId": "fourier-series-oq-02-oq-01",
     "range": {
-      "startLine": 47,
-      "endLine": 83
+      "startLine": 45,
+      "endLine": 79
     },
     "type": "theorem",
     "title": "riemannLebesgue_of_holder_via_L2 (Main Theorem)",
-    "content": "The main theorem: for α-Hölder f on AddCircle T with α > 0, the Fourier coefficients ĉ_n(f) tend to 0 as |n| → ∞. The proof uses the four-step L² chain. The final step applies fourierCoeff_tendsto_zero (from FourierSeries.lean) to f_Lp, then transfers the conclusion from f_Lp to f using hfc_eq (funext of coefficient equality). The sibling theorem riemannLebesgue_routes_agree records that both proof routes reach the same conclusion.",
-    "mathContext": "The L² route is morally: $f \\in \\text{Hölder} \\implies f \\in L^2 \\implies \\sum_n |\\hat{c}_n(f)|^2 < \\infty \\implies \\hat{c}_n(f) \\to 0$. Compare to OQ-02's direct route: $f \\in \\text{Hölder}(\\alpha) \\implies |\\hat{c}_n(f)| \\leq (C/2)(T/2|n|)^\\alpha \\to 0$.",
-    "significance": "main",
+    "content": "The main theorem: for α-Hölder f on AddCircle T with α > 0, the Fourier coefficients ĉ_n(f) tend to 0 as |n| → ∞. The proof uses the four-step L² chain. The final step applies fourierCoeff_tendsto_zero (from FourierSeries.lean) to f_Lp, then transfers the conclusion from f_Lp to f using hfc_eq (funext of coefficient equality).\n\nNote: `set_option maxHeartbeats 400000` is needed because Lean's type-class inference for the chain MemLp → Lp → L² Hilbert space is elaboration-heavy. The proof itself is only ~25 lines but triggers deep instance search through MeasureTheory.Lp.",
+    "mathContext": "The L² route is: $f \\in \\text{Hölder}(\\alpha) \\Rightarrow f \\in L^2 \\Rightarrow \\sum_n |\\hat{c}_n(f)|^2 < \\infty \\Rightarrow \\hat{c}_n(f) \\to 0$. Compare to OQ-02's direct route: $f \\in \\text{Hölder}(\\alpha) \\Rightarrow |\\hat{c}_n(f)| \\leq \\frac{C}{2}\\left(\\frac{T}{2|n|}\\right)^\\alpha \\to 0$. The L² route is shorter but non-quantitative: it gives existence of the limit (= 0) without the rate.",
+    "significance": "key",
     "relatedConcepts": [
       "fourierCoeff_tendsto_zero",
       "Riemann-Lebesgue lemma",
-      "L² Parseval"
+      "L² Parseval",
+      "maxHeartbeats elaboration"
     ],
     "prerequisites": [
       "FourierSeries.fourierCoeff_tendsto_zero",
       "FourierDecayInfra.holder_continuous",
       "MeasureTheory.MemLp.toLp"
     ]
+  },
+  {
+    "id": "ann-fs-oq02-oq01-05-consistency",
+    "proofId": "fourier-series-oq-02-oq-01",
+    "range": {
+      "startLine": 81,
+      "endLine": 92
+    },
+    "type": "insight",
+    "title": "riemannLebesgue_routes_agree: Proof by Iff.rfl",
+    "content": "The consistency check theorem is proved by `Iff.rfl`. This is because both sides of the biconditional are identical: the statement asserts that `Tendsto ... ↔ Tendsto ...` where both sides are the same proposition. The theorem's purpose is not mathematical content but pedagogical documentation — it records that the two proof routes (direct Hölder bound in OQ-02, L² Parseval in this file) establish the same result, so neither is logically stronger.\n\nThe `Iff.rfl` proof demonstrates a pattern in formal mathematics: a mathematically obvious statement (two proofs of the same fact give the same fact) can sometimes be formalized almost for free by definitional equality.",
+    "mathContext": "Both routes prove: $\\forall n \\in \\mathbb{Z},\\ \\hat{c}_n(f) \\xrightarrow{|n|\\to\\infty} 0$. The biconditional $P \\leftrightarrow P$ is always true (by `Iff.rfl`). The content is not in the proof but in the comparison: the direct route gives the quantitative bound $|\\hat{c}_n| \\leq C \\cdot n^{-\\alpha}$ while the L² route gives only $\\hat{c}_n \\to 0$ with no rate.",
+    "significance": "context",
+    "relatedConcepts": ["Iff.rfl", "proof comparison", "quantitative vs qualitative decay", "pedagogical formalization"],
+    "prerequisites": ["Lean 4 Iff.rfl", "the two proof routes"]
   }
 ]

--- a/src/data/proofs/fourier-series-oq-02-oq-01/meta.json
+++ b/src/data/proofs/fourier-series-oq-02-oq-01/meta.json
@@ -33,13 +33,47 @@
     "keyInsights": [
       "The compact space AddCircle T (as a quotient of ℝ/Tℤ) makes every continuous function bounded, hence in L∞ ⊆ L² (on the probability measure haarAddCircle). This bridge from continuity to L² membership uses memLp_const + mono'.",
       "The Fourier coefficient transfer hfc_eq uses integral_congr_ae: since ⇑f_Lp =ᵐ f, their integrals ∫ fourier(-n)·_ ∂haarAddCircle agree, so ĉ_n(f_Lp) = ĉ_n(f).",
-      "The L² route (via Parseval) is shorter than the direct Hölder bound but less informative: it gives ĉ_n → 0 without the quantitative rate O(1/|n|^α). OQ-02 provides the rate; this proof provides the cleaner existence proof."
+      "The L² route (via Parseval) is shorter than the direct Hölder bound but less informative: it gives ĉ_n → 0 without the quantitative rate O(1/|n|^α). OQ-02 provides the rate; this proof provides the cleaner existence proof.",
+      "The set_option maxHeartbeats 400000 is necessary because the type-class resolution for the chain MeasureTheory.MemLp → Lp → L² Hilbert basis is elaboration-intensive. This is a common issue with Mathlib's measure-theory hierarchy where instance chains can be long.",
+      "The consistency check riemannLebesgue_routes_agree is proved by Iff.rfl — both sides are definitionally identical. This is a formal documentation pattern: stating the equivalence makes explicit that both proof routes (direct Hölder and L² Parseval) achieve the same mathematical conclusion."
     ],
     "prerequisites": [
       "FourierSeries.lean: fourierCoeff_tendsto_zero (L² Parseval-based Riemann-Lebesgue)",
       "FourierSeriesOQ02.lean: riemannLebesgue_of_holder (direct bound proof, for comparison)",
       "FourierSeriesOQ02Incomplete01.lean: IsHolderOnCircle, holder_continuous",
       "Mathlib: MeasureTheory.MemLp, memLp_const, IsCompact.bddAbove"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Header, Imports, and Setup",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "Module docstring explains the question (can RL for Hölder be proved via L²?) and the 5-step answer. Imports Mathlib's Fourier/AddCircle, InnerProductSpace, L2Space, and the project's FourierSeries.lean (fourierCoeff_tendsto_zero) and FourierSeriesOQ02.lean (direct bound proof). set_option maxHeartbeats 400000 for elaboration budget. Opens MeasureTheory, Complex, Topology, Filter, AddCircle."
+    },
+    {
+      "id": "main-theorem",
+      "title": "Main Theorem: riemannLebesgue_of_holder_via_L2",
+      "startLine": 45,
+      "endLine": 79,
+      "summary": "Proves ĉ_n(f) → 0 for α-Hölder f via the L² route. Four steps: (1) holder_continuous → Continuous f; (2) compact AddCircle + memLp_const + mono' + bddAbove → MemLp 2; (3) MemLp.toLp lifts f to f_Lp ∈ L²; (4) integral_congr_ae transfers Fourier coefficients, then fourierCoeff_tendsto_zero (Parseval-based RL) gives the conclusion."
+    },
+    {
+      "id": "consistency-check",
+      "title": "Consistency Check: riemannLebesgue_routes_agree",
+      "startLine": 81,
+      "endLine": 92,
+      "summary": "Documents that the L² route and the direct Hölder bound route (from OQ-02) reach the same conclusion. Proved by Iff.rfl (both sides are identical propositions). The theorem is pedagogical — it formally records that the two proof strategies for RL are equivalent in their conclusion, even though OQ-02's direct approach additionally provides the quantitative rate O(1/|n|^α)."
+    }
+  ],
+  "conclusion": {
+    "summary": "This 90-line formalization answers a natural question about Fourier analysis: the Riemann-Lebesgue lemma for Hölder continuous functions can be proved via the L² Parseval route (fourierCoeff_tendsto_zero from Mathlib's Hilbert basis theorem) in addition to the direct Hölder decay bound approach of OQ-02. All theorems are proved with 0 sorries and 0 axioms.",
+    "implications": "The L² route demonstrates a fundamental principle of harmonic analysis: regularity conditions (Hölder continuity) imply membership in Lᵖ spaces, which in turn give decay of Fourier coefficients via Parseval-type theorems. The compact additive circle AddCircle T is the natural domain because compactness converts continuity into boundedness, bridging from pointwise regularity to global Lᵖ membership.\n\nThis proof also illustrates the trade-off between qualitative and quantitative results: the L² Parseval route is shorter and more abstract, but only establishes ĉ_n → 0 without a rate. The OQ-02 direct approach provides the quantitative bound |ĉ_n| = O(n^{-α}), which is essential for applications like estimating the error in truncated Fourier series approximations.\n\nFrom the Lean formalization perspective, the proof demonstrates a common Mathlib infrastructure pattern: lift a function to a suitable Lᵖ class, apply the abstract Lᵖ theorem, then transfer the conclusion back via almost-everywhere equality.",
+    "openQuestions": [
+      "Can this L² route be generalized to functions in the Sobolev space H^s (s > 1/2), which are also in L² via the Sobolev embedding theorem? H^s functions have Fourier coefficients satisfying Σ n^{2s} |ĉ_n|² < ∞, giving a sharper ĉ_n = O(n^{-s}) decay.",
+      "The consistency check theorem riemannLebesgue_routes_agree is proved by Iff.rfl — a trivial proof. Is there a meaningful non-trivial relationship between the two routes, such as a formal derivation of one from the other (rather than independence)?",
+      "Quantitative L² bounds: Parseval gives Σ|ĉ_n|² < ∞ but not a rate. For f ∈ H^s ⊂ L², the stronger Parseval identity Σ n^{2s} |ĉ_n|² = ‖f‖_{H^s}² gives n^s|ĉ_n| → 0 — a sharper conclusion. Can this Sobolev-Fourier rate be formalized in Lean 4?"
     ]
   },
   "leanFile": {


### PR DESCRIPTION
## Summary
- Added 3 structured sections (preamble, main theorem, consistency check) to meta.json
- Added conclusion with summary, implications, and 3 open questions about Sobolev extensions
- Fixed all `significance: "main"` → `"key"` annotation values (schema compliance)
- Added 5th annotation `ann-fs-oq02-oq01-05-consistency` explaining the Iff.rfl consistency check theorem
- Extended keyInsights from 3 to 5 with `set_option maxHeartbeats` rationale and Iff.rfl documentation pattern

## Enrichment targets
- **Proof**: fourier-series-oq-02-oq-01 (Riemann-Lebesgue for Hölder Functions via L²)
- **Annotations**: 5 (up from 4)
- **Sections**: 3 sections added
- **Quality improvements**: significance values corrected, mathContext present on all annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)