### PR TITLE
Enrich cayley-hamilton-minpoly-oq-03-oq-01: sections, conclusion, fix sorry annotation

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-01/annotations.json
@@ -48,15 +48,27 @@
     "prerequisites": ["charpoly degree = n", "minpoly divides charpoly", "aeval_mulVec_eq_krylov_sum"]
   },
   {
-    "id": "ann-minpoly-vec-existence-sorry",
+    "id": "ann-minpoly-vec-existence",
     "proofId": "cayley-hamilton-minpoly-oq-03-oq-01",
     "range": { "startLine": 162, "endLine": 180 },
+    "type": "theorem",
+    "title": "vec_minpoly_exists: Setup and Minimum-Degree Extraction",
+    "content": "The main theorem (lines 169-249+) begins by finding the minimum-degree nonzero annihilating polynomial via degree_lt_wf.min — Lean's built-in well-founded recursion on polynomial degree. The set Ann = {p ≠ 0 | p(M)·v = 0} is nonempty (witnessed by μ_M), so degree_lt_wf.min Ann extracts the minimum-degree element q₀. Minimality is encoded as: for any p ∈ Ann, p.degree is not strictly less than q₀.degree. The next step makes q₀ monic via unit scaling: μ = (q₀.leadingCoeff)⁻¹ • q₀, using monic_of_isUnit_leadingCoeff_inv_smul. This avoids Mathlib's abstract PID machinery entirely.",
+    "mathContext": "Well-founded recursion: $\\deg: K[X] \\setminus \\{0\\} \\to \\mathbb{N}$ has no infinite descending chains, so any nonempty set of polynomials has a minimum-degree element. Here $\\text{Ann} = \\{p \\neq 0 \\mid p(M)v = 0\\}$ is nonempty (contains $\\mu_M$), so $\\exists q_0 \\in \\text{Ann}$ with $\\deg(q_0)$ minimal. Making it monic: $\\mu = c^{-1} q_0$ where $c = \\text{lc}(q_0) \\neq 0$ — scaling by a unit preserves degree and annihilation.",
+    "significance": "key",
+    "relatedConcepts": ["degree_lt_wf", "monic_of_isUnit_leadingCoeff_inv_smul", "well-founded recursion", "minimum-degree polynomial"],
+    "prerequisites": ["Polynomial.degree_lt_wf in Mathlib", "IsUnit.mk0 (nonzero leadingCoeff is a unit in a field)", "Polynomial.natDegree_smul_of_smul_regular"]
+  },
+  {
+    "id": "ann-minpoly-vec-divisibility-proof",
+    "proofId": "cayley-hamilton-minpoly-oq-03-oq-01",
+    "range": { "startLine": 181, "endLine": 267 },
     "type": "technique",
-    "title": "vec_minpoly_exists: The One Remaining Sorry",
-    "content": "The main theorem vec_minpoly_exists (lines 172-178) asserts: there exists a monic μ with μ.natDegree ≤ n, μ(M)·v = 0, μ | μ_M, and μ | q for every q with q(M)·v = 0. This is exactly the PID generator of the ideal I_v = vecAnnSet M v. The sorry (line 178) remains because extracting the generator requires Mathlib's IsPrincipalIdealRing API: one needs to convert the Set K[X]-valued vecAnnSet into an Ideal K[X], apply the PID principal ideal theorem via Ideal.IsPrincipal.generator, and extract the monic generator via Ideal.span_singleton. The proof summary (lines 182-206) estimates ~100 lines using Submodule.IsPrincipal and Ideal.span_singleton.",
-    "mathContext": "$K[X]$ is a PID. The ideal $I_v = \\langle \\mu_{M,v} \\rangle$ has a unique monic generator $\\mu_{M,v}$. In Lean: the gap is converting `vecAnnSet` (a `Set K[X]`) to an `Ideal K[X]` via `Ideal.mk` using the three ideal axioms already proved, then applying `IsPrincipalIdealRing.principal` and extracting the generator with `Ideal.IsPrincipal.generator`.",
-    "significance": "supporting",
-    "relatedConcepts": ["IsPrincipalIdealRing", "Ideal.IsPrincipal.generator", "Ideal.span_singleton", "Submodule.IsPrincipal"],
-    "prerequisites": ["K[X] is a PID via Polynomial.instIsPrincipalIdealRing", "Ideal.mk from membership axioms", "Ideal.IsPrincipal theorem in Mathlib"]
+    "title": "vec_minpoly_exists: Divisibility via Euclidean Contradiction + Degree Chain",
+    "content": "Steps 3-4 of the main proof. Divisibility (μ | q for any annihilating q): by contradiction, assume r = q mod μ ≠ 0. The Euclidean identity q = (q mod μ) + μ·(q div μ) gives r(M)·v = q(M)·v - μ(M)·(q div μ)(M)·v = 0 - 0 = 0 (using annihilation of both q and μ). But deg(r) < deg(μ), contradicting minimality of deg(μ). Therefore μ | q. Degree bound (μ.natDegree ≤ n): q₀.degree ≤ μ_M.degree (since μ_M ∈ Ann), and μ_M.natDegree ≤ charpoly.natDegree = n via the divisibility chain. The closing summary comment (lines 250-267) reviews all 9 theorems.",
+    "mathContext": "Minimality implies divisibility: if $\\mu \\nmid q$ then $r = q \\bmod \\mu \\neq 0$ and $\\deg(r) < \\deg(\\mu)$. But $r(M)v = q(M)v - \\mu(M)(q\\div\\mu)(M)v = 0$, so $r \\in \\text{Ann}$, contradicting minimality. Degree chain: $\\deg(\\mu) \\leq \\deg(\\mu_M) \\leq \\deg(\\chi_M) = n$.",
+    "significance": "key",
+    "relatedConcepts": ["modByMonic_add_div", "degree_modByMonic_lt", "Euclidean division argument", "natDegree_charpoly"],
+    "prerequisites": ["Polynomial.modByMonic_eq_zero_iff_dvd", "vecAnnSet_mul_mem (ideal closure for annihilation)", "Matrix.charpoly_natDegree_eq_dim"]
   }
 ]

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-01/meta.json
@@ -30,7 +30,8 @@
     "keyInsights": [
       "The annihilator ideal I_v of v under M is always nonzero: it contains μ_M, since μ_M(M) = 0 as a matrix implies μ_M(M)·v = 0·v = 0 for every vector v",
       "The divisibility μ_{M,v} | μ_M holds by definition: μ_M ∈ I_v = ⟨μ_{M,v}⟩. This means the Krylov iteration for any v terminates in at most deg(μ_M) ≤ n steps",
-      "The annihilator set is not merely a subgroup but an ideal: if p(M)·v = 0, then (q·p)(M)·v = q(M)·0 = 0 for any polynomial q"
+      "The annihilator set is not merely a subgroup but an ideal: if p(M)·v = 0, then (q·p)(M)·v = q(M)·0 = 0 for any polynomial q",
+      "The proof of vec_minpoly_exists uses degree_lt_wf (well-founded recursion on polynomial degree) to extract the minimum-degree annihilating polynomial — rather than invoking Mathlib's abstract PID machinery, it directly implements the Euclidean division + minimality contradiction argument, making the construction explicit and computational."
     ],
     "prerequisites": [
       "Cayley-Hamilton theorem and minimal polynomial theory",
@@ -54,7 +55,52 @@
     "path": "Proofs/CayleyHamiltonMinpolyOQ03OQ01.lean",
     "sorries": 0
   },
+  "sections": [
+    {
+      "id": "part-i-krylov-expansion",
+      "title": "Part I: Krylov Infrastructure — Polynomial Evaluation as Krylov Sum",
+      "startLine": 1,
+      "endLine": 78,
+      "summary": "Module header, imports, and namespace setup, followed by: krylovVec definition (M^k · v), sum_mulVec helper (mulVec distributes over finite matrix sums), and the central lemma aeval_mulVec_eq_krylov_sum (polynomial evaluation at M applied to v equals a linear combination of Krylov vectors with polynomial coefficients)."
+    },
+    {
+      "id": "part-ii-annihilator-ideal",
+      "title": "Part II: The Vector Annihilator Set as an Ideal of K[X]",
+      "startLine": 79,
+      "endLine": 110,
+      "summary": "vecAnnSet definition and three ideal axioms: zero membership (trivial), closure under addition (map_add + add_mulVec), and closure under multiplication (map_mul + mul_mulVec — the ideal axiom distinguishing it from a subgroup). The annihilator set is the key algebraic object whose monic generator is μ_{M,v}."
+    },
+    {
+      "id": "part-iii-inclusion",
+      "title": "Part III: μ_M Annihilates Every Vector",
+      "startLine": 111,
+      "endLine": 126,
+      "summary": "minpoly_mem_vecAnnSet (μ_M(M)·v = 0·v = 0 via minpoly.aeval) and vecAnnSet_ne_bot (the annihilator ideal is nonzero, witnessed by μ_M itself). These establish that vecAnnSet has a generator, guaranteeing existence of μ_{M,v}."
+    },
+    {
+      "id": "part-iv-degree-bound",
+      "title": "Part IV: Degree Bound and Krylov Zero Combination",
+      "startLine": 127,
+      "endLine": 157,
+      "summary": "vec_ann_poly_of_deg_le_dim (there exists an annihilating polynomial of degree ≤ n, witnessed by μ_M via the divisibility chain minpoly | charpoly) and krylov_zero_combo_at_minpoly (the Krylov vectors at μ_M satisfy a zero linear combination — the Lean certificate for Krylov termination in ≤ n steps)."
+    },
+    {
+      "id": "part-v-existence",
+      "title": "Part V: vec_minpoly_exists — Full Existence, Monic Form, Divisibility",
+      "startLine": 158,
+      "endLine": 267,
+      "summary": "The main theorem vec_minpoly_exists proves existence of a monic μ with degree ≤ n, μ(M)·v = 0, μ | μ_M, and universal minimality (μ | q for every annihilating q). The proof uses degree_lt_wf to find the minimum-degree element, monic_of_isUnit_leadingCoeff_inv_smul for the monic form, and a Euclidean division + minimality contradiction for the divisibility. The closing summary comment reviews all 9 theorems."
+    }
+  ],
   "sorries": 0,
+  "conclusion": {
+    "summary": "Nine theorems fully formalize the generalized (vector) minimal polynomial μ_{M,v}: the monic polynomial of smallest degree annihilating vector v under matrix M. The capstone theorem vec_minpoly_exists establishes all four key properties simultaneously — existence, degree ≤ n, divisibility of μ_M, and universal minimality — using well-founded recursion on polynomial degree rather than abstract PID machinery.",
+    "implications": "This formalization provides the algebraic foundation for Wiedemann's sparse matrix algorithm: since μ_{M,v} | μ_M, the Krylov sequence (v, Mv, M²v, ...) always terminates in ≤ deg(μ_M) ≤ n steps for any starting vector v, justifying single-vector Krylov methods over finite fields. The theorem krylov_zero_combo_at_minpoly gives the explicit zero linear combination of Krylov vectors, bridging algebraic minimality (μ_M(M) = 0) with the computational property (Krylov sequence is linearly dependent within n+1 vectors). The construction also avoids Mathlib's IsPrincipalIdealRing API, implementing PID generator extraction directly via Euclidean division and degree minimality.",
+    "openQuestions": [
+      "Can the vector minimal polynomial μ_{M,v} be contributed to Mathlib as a standalone definition (analogous to Polynomial.minpoly), with these 9 theorems forming its API surface?",
+      "Does Wiedemann's sparse linear system algorithm (Mx = b over GF(q)) admit a full Lean 4 formalization using vec_minpoly_exists and aeval_mulVec_eq_krylov_sum as core primitives?"
+    ]
+  },
   "crossReferences": [
     {
       "targetId": "cayley-hamilton-minpoly-oq-03",


### PR DESCRIPTION
## Summary
- Added 5 structured sections matching PART I-V structure of the 267-line Lean file
- Added conclusion with summary, implications (Wiedemann algorithm connection, PID-free proof), and 2 open questions (Mathlib contribution, Wiedemann formalization)
- Added 4th keyInsight about degree_lt_wf and computational PID generator extraction
- Fixed incorrect annotation: rewrote `ann-minpoly-vec-existence-sorry` to remove false claim about a remaining sorry (0 sorries confirmed); now describes the complete 4-step degree_lt_wf + monic extraction proof (lines 162-180)
- Added 6th annotation covering the Euclidean divisibility contradiction + degree chain (lines 181-267)

## Enrichment targets
- **Proof**: cayley-hamilton-minpoly-oq-03-oq-01 (Krylov Method for the Generalized Vector Minimal Polynomial)
- **Annotations**: 6 (up from 4, one corrected for accuracy)
- **Sections**: 5 sections added
- **Accuracy fix**: stale sorry annotation removed — file is fully proved with 0 sorries

🤖 Generated with [Claude Code](https://claude.com/claude-code)