### PR TITLE
Seeker: select binomial-theorem-oq-04-oq-02-oq-01 — q-Vandermonde identity for Gaussian binomial coefficients

### DIFF
--- a/research/problems/binomial-theorem-oq-04-oq-02-oq-01/knowledge.md
+++ b/research/problems/binomial-theorem-oq-04-oq-02-oq-01/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: binomial-theorem-oq-04-oq-02-oq-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/binomial-theorem-oq-04-oq-02-oq-01/literature/README.md
+++ b/research/problems/binomial-theorem-oq-04-oq-02-oq-01/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for binomial-theorem-oq-04-oq-02-oq-01
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/binomial-theorem-oq-04-oq-02-oq-01/problem.md
+++ b/research/problems/binomial-theorem-oq-04-oq-02-oq-01/problem.md
@@ -1,0 +1,149 @@
+# Problem: q-Vandermonde Identity for Gaussian Binomial Coefficients
+
+**Slug**: binomial-theorem-oq-04-oq-02-oq-01
+**Created**: 2026-04-21T06:01:53-07:00
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+The q-Vandermonde (Gauss-Vandermonde) identity states:
+
+$$
+\binom{m+n}{r}_q = \sum_{k=0}^{r} q^{k(m-r+k)} \binom{m}{r-k}_q \binom{n}{k}_q
+$$
+
+where $\binom{n}{k}_q = \frac{(q;q)_n}{(q;q)_k (q;q)_{n-k}}$ are the Gaussian binomial coefficients (q-binomial coefficients).
+
+Equivalently, in the form without the $q^{k(m-r+k)}$ twist:
+
+$$
+\binom{m+n}{r}_q = \sum_{k=0}^{r} q^{(r-k)(n-k)} \binom{m}{k}_q \binom{n}{r-k}_q
+$$
+
+As a Lean theorem:
+
+```lean
+theorem q_vandermonde (q : ℝ) (hq : q ≠ 1) (m n r : ℕ) :
+    gaussBinom q (m + n) r = ∑ k ∈ Finset.range (r + 1),
+      q ^ (k * (m - r + k)) * gaussBinom q m (r - k) * gaussBinom q n k := by
+  sorry
+```
+
+### Plain Language
+
+The classical Vandermonde identity $\binom{m+n}{r} = \sum_k \binom{m}{k}\binom{n}{r-k}$
+counts ways to choose $r$ items from $m+n$ by splitting across two groups. The
+q-Vandermonde identity is its q-analog: it replaces binomial coefficients with
+Gaussian binomial coefficients (which count subspaces of vector spaces over $\mathbb{F}_q$)
+and introduces a $q$-weight factor that tracks the relative position of chosen subspaces.
+
+At $q=1$, the Gaussian binomials reduce to ordinary binomials and the identity
+recovers the classical Vandermonde identity.
+
+### Why This Matters
+
+- Gaussian binomial coefficients count $k$-dimensional subspaces of $\mathbb{F}_q^n$
+- The q-Vandermonde identity is foundational for q-series theory and quantum groups
+- It appears in representation theory, combinatorics of partitions, and physics (integrable systems)
+- Fills a gap in Mathlib's q-analog theory adjacent to the existing binomial theorem formalization
+
+## Known Results
+
+### What's Already Proven
+
+- Classical Vandermonde identity `Nat.add_choose_eq` — in Mathlib
+- Gaussian binomial coefficients `Nat.gaussBinom` — in Mathlib (GaussianBinomial.lean)
+- Basic recurrence for Gaussian binomials — in Mathlib
+- `GaussianBinomial.lean` contains `gaussBinom_add_succ_right` and related lemmas
+
+### What's Still Open
+
+- The q-Vandermonde convolution identity itself is not yet in Mathlib
+- The generating function interpretation over $\mathbb{F}_q^n$ vector spaces
+
+### Our Goal
+
+Prove the q-Vandermonde identity for Gaussian binomial coefficients in Lean/Mathlib,
+connecting it to the existing `Nat.gaussBinom` infrastructure.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `binomial-theorem` | Parent proof; classical Vandermonde already handled | Binomial coefficients, Finset.sum |
+| `arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02` | Multiset Vandermonde — parallel combinatorial identity | Finset convolutions |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Induction on r (Pascal recurrence)**
+   - The Gaussian binomial satisfies $\binom{n}{k}_q = \binom{n-1}{k-1}_q + q^k \binom{n-1}{k}_q$
+   - Use this recurrence to prove the q-Vandermonde by induction on $r$, matching the
+     classical Vandermonde proof structure
+   - Why it might work: direct parallel to classical proof; recurrence is in Mathlib
+   - Risk: bookkeeping of q-powers is intricate
+
+2. **Generating function / polynomial identity**
+   - The identity follows from $(1+qx)(1+q^2x)\cdots(1+q^m x)(1+qx)\cdots(1+q^n x)$
+     expansion as polynomials in $q$
+   - Risk: requires formalizing polynomial manipulations over q
+
+3. **Direct combinatorial bijection**
+   - Interpret both sides as counting subspaces of $\mathbb{F}_q^{m+n}$
+   - Risk: requires finite field infrastructure in Mathlib
+
+### Key Difficulties
+
+- Correct handling of $q$-power exponents in the twisted sum
+- The `gaussBinom` API in Mathlib may not have all needed lemmas
+- Edge cases when $q = 0$ or $q = 1$ (limit to classical case)
+
+### What Would a Proof Need?
+
+- Pascal recurrence: `gaussBinom_succ_succ` or equivalent
+- Finset sum manipulation: shifting index, splitting sums
+- Algebraic identity: factoring out q-powers
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- The classical Vandermonde proof is well-understood and parallelizes to q-setting
+- Mathlib already has `Nat.gaussBinom` with recurrences
+- The main challenge is tracking q-exponent arithmetic, which is mechanical
+- Similar algebraic identities have been successfully formalized in Lean
+
+**Estimated Effort**:
+- Exploration (OBSERVE/ORIENT): 1-2 days
+- Proof attempt (DECIDE/ACT): 2-5 days
+
+## References
+
+### Papers
+- Gasper & Rahman, "Basic Hypergeometric Series" (2nd ed., 2004) — definitive reference
+- Andrews, "The Theory of Partitions" — Chapter 3 covers q-Vandermonde
+
+### Mathlib
+- `Mathlib.RingTheory.GaussianBinomial` — `gaussBinom` definition and recurrences
+- `Mathlib.Data.Nat.Choose.Vandermonde` — classical Vandermonde identity
+
+## Metadata
+
+```yaml
+tags:
+  - combinatorics
+  - q-analogs
+  - gaussian-binomials
+  - vandermonde
+  - q-series
+related_proofs:
+  - binomial-theorem
+difficulty: medium
+source: gallery-gap
+created: 2026-04-21T06:01:53-07:00
+```

--- a/research/problems/binomial-theorem-oq-04-oq-02-oq-01/state.md
+++ b/research/problems/binomial-theorem-oq-04-oq-02-oq-01/state.md
@@ -1,0 +1,25 @@
+# Research State: binomial-theorem-oq-04-oq-02-oq-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-04-21T06:01:53-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/registry.json
+++ b/research/registry.json
@@ -16504,7 +16504,7 @@
       "path": "full",
       "started": "2026-04-14T17:49:44.227Z",
       "status": "active",
-      "lastUpdate": "2026-04-14T17:49:44.261Z"
+      "lastUpdate": "2026-04-21T06:01:53-07:00"
     },
     {
       "slug": "birthday-problem-oq-03-oq-01-oq-02-oq-01",


### PR DESCRIPTION
## Selection Report

**Date**: 2026-04-21
**Mode**: SELECT
**Pool Status**: 18 available, 513 in-progress, 1370 completed

## Selected Problem

- **ID**: `binomial-theorem-oq-04-oq-02-oq-01`
- **Name**: q-Vandermonde identity for Gaussian binomial coefficients
- **Tier**: B
- **Significance**: 7/10
- **Tractability**: 6/10
- **Knowledge Score**: 0 (EMPTY)
- **Status**: available

## Selection Rationale

1. **EMPTY knowledge tier** (highest priority) — no prior research files exist; needs exploration immediately
2. **Combinatorics domain** — diversifies from recent geometry (law-of-cosines), analysis (fourier-series), and number theory (chebyshev) selections
3. **Classical tractable result** — q-Vandermonde is a well-known identity with clear formalization path via Mathlib's existing `Nat.gaussBinom` infrastructure

## Rejection Summary

- **Candidates considered**: 20 available
- **Rejected (active claim)**: `erdos-268`
- **Rejected (lower composite)**: A-tier candidates (`sperner-ndim-oq-05` score 58, `szemeredi-hypergraph-core` score 59) ranked below due to tractability 5 vs 6
- **Rejected (domain overlap)**: `bounded-prime-gaps-oq-03-oq-03` (number theory, recently covered)
- **Confidence**: medium (5 EMPTY candidates tied at composite 67)

## Pool Health

- Pool depth: adequate (18 available > 15 threshold)
- No replenishment needed this cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)