### PR TITLE
Enrich arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02: full annotation schema, sections, conclusion

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02/annotations.json
@@ -1,0 +1,119 @@
+[
+  {
+    "id": "ann-mvandermonde-header",
+    "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 32
+    },
+    "type": "context",
+    "title": "Multiset Vandermonde: Problem Setup and Strategy",
+    "content": "The module docstring frames the problem: prove the multiset Vandermonde identity C^ms(m+n,r) = Σ_{j=0}^{r} C^ms(m,j)·C^ms(n,r-j), where C^ms(n,k) = Nat.multichoose n k counts multisets of size k from a set of n elements. The relation multichoose n k = C(n+k-1, k) connects multiset coefficients to standard binomials. The proof strategy is double induction on m and r, driven by the Pascal-like recurrence multichoose(n+1)(k+1) = multichoose n (k+1) + multichoose(n+1) k.",
+    "mathContext": "The multiset coefficient satisfies $\\binom{n+k-1}{k} = \\text{multichoose}(n,k)$, the number of ways to choose $k$ items from $n$ types with repetition. The identity $\\text{mc}(m+n,r) = \\sum_{j=0}^r \\text{mc}(m,j)\\cdot\\text{mc}(n,r-j)$ is the 'stars and bars' analogue of Vandermonde: choosing $r$ items with repetition from $m+n$ types splits by how many come from the first $m$ types. The Pascal-like recurrence $\\text{mc}(n+1)(k+1) = \\text{mc}(n)(k+1) + \\text{mc}(n+1)(k)$ plays the role of Pascal's triangle identity $\\binom{n}{k} = \\binom{n-1}{k-1} + \\binom{n-1}{k}$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "multiset coefficient",
+      "Vandermonde identity",
+      "Pascal recurrence",
+      "stars and bars"
+    ],
+    "prerequisites": [
+      "Nat.multichoose",
+      "Nat.multichoose_succ_succ",
+      "Mathlib.Data.Nat.Choose.Basic"
+    ]
+  },
+  {
+    "id": "ann-sum-zero-left",
+    "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02",
+    "range": {
+      "startLine": 39,
+      "endLine": 48
+    },
+    "type": "theorem",
+    "title": "Base Case m = 0: Only j = 0 Term Survives",
+    "content": "When m = 0, multichoose 0 j = 0 for all j ≥ 1 (only multichoose 0 0 = 1). So the sum Σ_{j≤r} multichoose(0,j)·multichoose(n,r-j) collapses to just the j = 0 term: 1·multichoose n r = multichoose n r. Proved by induction on r: the zero case uses multichoose_zero_right; the successor case uses sum_range_succ' to split off the j = 0 term, then simp dispatches the rest with multichoose_zero_succ (= 0) and multichoose_zero_right (= 1).",
+    "mathContext": "$\\text{mc}(0, 0) = 1$ and $\\text{mc}(0, j+1) = 0$ for all $j$. Thus $\\sum_{j=0}^r \\text{mc}(0,j)\\cdot\\text{mc}(n,r-j) = \\text{mc}(0,0)\\cdot\\text{mc}(n,r) + \\sum_{j=1}^r 0 = \\text{mc}(n,r)$. The Lean proof uses `sum_range_succ'` to split off the $j=0$ term from the sum over `range(r+1)`, placing it at the front.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.multichoose_zero_right",
+      "Nat.multichoose_zero_succ",
+      "Finset.sum_range_succ'"
+    ],
+    "prerequisites": [
+      "Nat.multichoose_zero_right",
+      "Nat.multichoose_zero_succ",
+      "Finset.sum_range_succ'"
+    ]
+  },
+  {
+    "id": "ann-sum-zero-right",
+    "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02",
+    "range": {
+      "startLine": 50,
+      "endLine": 53
+    },
+    "type": "theorem",
+    "title": "Base Case r = 0: Both Sides Equal 1",
+    "content": "When r = 0, the sum has only the j = 0 term (range 1 = {0}): multichoose(m,0)·multichoose(n,0) = 1·1 = 1. The RHS is multichoose(m+n,0) = 1. Both sides are 1 by multichoose_zero_right, so simp dispatches the goal immediately. This base case completes the (m, r=0) branch of the double induction.",
+    "mathContext": "$\\sum_{j=0}^0 \\text{mc}(m,j)\\cdot\\text{mc}(n,0-j) = \\text{mc}(m,0)\\cdot\\text{mc}(n,0) = 1\\cdot 1 = 1 = \\text{mc}(m+n,0)$. The sum over `range 1` in Lean contains only the $j=0$ term, making this a trivial one-step simplification.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.multichoose_zero_right",
+      "base-case"
+    ],
+    "prerequisites": [
+      "Nat.multichoose_zero_right"
+    ]
+  },
+  {
+    "id": "ann-sum-succ-left",
+    "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02",
+    "range": {
+      "startLine": 62,
+      "endLine": 79
+    },
+    "type": "theorem",
+    "title": "Sum Decomposition Lemma: The Engine of Double Induction",
+    "content": "The crucial algebraic identity: Σ_{j≤r+1} mc(m+1,j)·mc(n,r+1-j) = Σ_{j≤r+1} mc(m,j)·mc(n,r+1-j) + Σ_{j≤r} mc(m+1,j)·mc(n,r-j). The proof applies sum_range_succ' to both sides to extract the j=0 terms (both equal mc(n,r+1)), leaving inner sums over range(r+1) with indices shifted. The key step: simp_rw [Nat.multichoose_succ_succ, add_mul] expands mc(m+1)(j+1) = mc(m)(j+1) + mc(m+1)(j) and distributes through the product. sum_add_distrib separates the two sum components, and ring closes the goal. The index shift r+1-(j+1) = r-j (via Nat.succ_sub_succ_eq_sub) allows the two sums to align.",
+    "mathContext": "The Pascal-like recurrence $\\text{mc}(m+1)(j+1) = \\text{mc}(m)(j+1) + \\text{mc}(m+1)(j)$ gives: $\\sum_{j=0}^{r+1} \\text{mc}(m+1,j)\\cdot\\text{mc}(n,r+1-j) = \\sum_{j=0}^{r+1}[\\text{mc}(m,j+1)+\\text{mc}(m+1,j)]\\cdot\\text{mc}(n,r-j)$ (after index shift $j\\to j+1$ for $j\\geq 1$). Distributing and splitting into two sums gives the identity. This is the multiset analogue of the standard Pascal-Vandermonde step $C(m+1,j) = C(m,j) + C(m,j-1)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.multichoose_succ_succ",
+      "Finset.sum_range_succ'",
+      "Finset.sum_add_distrib",
+      "Pascal recurrence"
+    ],
+    "prerequisites": [
+      "Nat.multichoose_succ_succ",
+      "Nat.succ_sub_succ_eq_sub",
+      "Finset.sum_range_succ'",
+      "Finset.sum_add_distrib"
+    ]
+  },
+  {
+    "id": "ann-multiset-vandermonde",
+    "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02",
+    "range": {
+      "startLine": 91,
+      "endLine": 121
+    },
+    "type": "theorem",
+    "title": "Multiset Vandermonde Identity (Main Theorem)",
+    "content": "The main theorem: multichoose(m+n,r) = Σ_{j=0}^{r} multichoose(m,j)·multichoose(n,r-j) for all natural numbers m, n, r. Proved by double induction — outer on m, inner on r. The zero-m case uses sum_zero_left. The successor-m, zero-r case uses sum_zero_right. The successor-m, successor-r case is the key step: rw [hsum, Nat.multichoose_succ_succ] splits mc(m+1+n)(r+1) = mc(m+n)(r+1) + mc(m+n+1)(r). Both parts are handled by the outer IH (ih_m at r+1) and inner IH (ih_r), then sum_succ_left reassembles them. The final congr 1 and simp [Nat.add_sub_cancel] close the bookkeeping.",
+    "mathContext": "Double induction structure: $P(0,r)$ holds by `sum_zero_left`; $P(m+1,0)$ holds by `sum_zero_right`; $P(m+1,r+1)$ follows from $P(m,r+1)$ and $P(m+1,r)$ via `sum_succ_left`. In closed form: $\\text{mc}(m+1+n, r+1) = \\text{mc}(m+n, r+1) + \\text{mc}(m+n+1, r) = \\sum_j \\text{mc}(m,j)\\cdot\\text{mc}(n,r+1-j) + \\sum_j \\text{mc}(m+1,j)\\cdot\\text{mc}(n,r-j) = \\sum_j \\text{mc}(m+1,j)\\cdot\\text{mc}(n,r+1-j)$ (by `sum_succ_left`). This mirrors the proof of classical Vandermonde by induction on $m$ using Pascal's identity.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.multichoose_succ_succ",
+      "double induction",
+      "Vandermonde identity",
+      "multiset coefficient"
+    ],
+    "prerequisites": [
+      "sum_zero_left",
+      "sum_zero_right",
+      "sum_succ_left",
+      "Nat.multichoose_succ_succ"
+    ]
+  }
+]

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02/meta.json
@@ -1,0 +1,114 @@
+{
+  "id": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02",
+  "title": "Multiset Vandermonde Identity",
+  "slug": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02",
+  "description": "Proves the multiset Vandermonde identity: multichoose(m+n, r) = Σ_{j=0}^{r} multichoose(m,j) · multichoose(n,r-j). Derived by double induction on m and r using the Pascal-like recurrence for multiset coefficients. 3 lemmas, 1 theorem, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Vandermonde%27s_identity#Multiset_version",
+    "date": "2026-04-21",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02.lean",
+    "tags": [
+      "combinatorics",
+      "multiset",
+      "vandermonde",
+      "multichoose",
+      "double-induction"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-04-21",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified. 3 lemmas (sum_zero_left, sum_zero_right, sum_succ_left) + 1 theorem (multiset_vandermonde), all with 0 sorries.",
+    "mathlib_version": "4.26.0",
+    "lineCount": 122,
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The classical Vandermonde convolution C(m+n,r) = Σ C(m,j)·C(n,r-j) was known to Vandermonde (1772) and counts ways to choose r elements from two disjoint sets of sizes m and n. Its multiset analogue — replacing binomial coefficients with multiset coefficients (stars-and-bars counts) — appears in enumerative combinatorics as the generating-function identity 1/(1-x)^m · 1/(1-x)^n = 1/(1-x)^{m+n}, where the coefficient of x^r on each side gives multichoose(m+n,r) = Σ multichoose(m,j)·multichoose(n,r-j). This identity also appears in representation theory (weight multiplicities in tensor products) and in the study of negative binomial distributions.",
+    "problemStatement": "Prove the multiset Vandermonde identity: for all natural numbers m, n, r, multichoose(m+n, r) = Σ_{j=0}^{r} multichoose(m, j) · multichoose(n, r-j), where multichoose(n,k) = Nat.multichoose n k counts multisets of size k drawn from a set of n elements.",
+    "proofStrategy": "Double induction on m and r. The outer induction is on m; for each m, the inner induction is on r. Three auxiliary lemmas prepare the inductive step: (1) sum_zero_left: the m=0 base case (only j=0 survives); (2) sum_zero_right: the r=0 base case (both sides are 1); (3) sum_succ_left: the key algebraic identity that splits Σ mc(m+1,j)·mc(n,r+1-j) into two sums handled by the two induction hypotheses. The key recurrence driving everything is Nat.multichoose_succ_succ: mc(n+1)(k+1) = mc(n)(k+1) + mc(n+1)(k).",
+    "keyInsights": [
+      "The proof is structurally identical to the classical Vandermonde proof via Pascal's triangle: the Pascal-like recurrence mc(n+1)(k+1) = mc(n)(k+1) + mc(n+1)(k) plays the same role as C(n,k) = C(n-1,k-1) + C(n-1,k), making the multiset proof a direct analogue.",
+      "The sum_succ_left lemma is the algebraic engine: it expresses the passage from the m-sum to the (m+1)-sum as the sum of two known quantities. Without this lemma, the inductive step would require duplicating the algebraic manipulation inside the main proof.",
+      "The index shift r+1-(j+1) = r-j (via Nat.succ_sub_succ_eq_sub) is essential for term alignment in the sum decomposition. Natural number subtraction in Lean/Lean 4 is truncated (not negative), so this simp_rw step must be applied to both sides before distributing.",
+      "The generating function interpretation makes the identity obvious: [x^r](1/(1-x))^{m+n} = [x^r]((1/(1-x))^m · (1/(1-x))^n) = Σ_j [x^j](1/(1-x))^m · [x^{r-j}](1/(1-x))^n. The formal proof via double induction is the combinatorial translation of this power series argument."
+    ],
+    "prerequisites": [
+      "Nat.multichoose_succ_succ: Pascal-like recurrence for multiset coefficients",
+      "Nat.multichoose_zero_right: multichoose n 0 = 1",
+      "Nat.multichoose_zero_succ: multichoose 0 (k+1) = 0",
+      "Finset.sum_range_succ': sum splitting for index shift",
+      "Finset.sum_add_distrib: linearity of finite sums"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Module Docstring and Imports",
+      "startLine": 1,
+      "endLine": 32,
+      "summary": "Module docstring explains the multiset Vandermonde identity and its combinatorial interpretation (choosing multisets from a disjoint union). States the proof strategy (double induction via Pascal-like recurrence). Imports Mathlib.Data.Nat.Choose.Basic and Mathlib.Algebra.BigOperators.Group.Finset.Basic; opens Finset, BigOperators, and namespace MultisetVandermonde."
+    },
+    {
+      "id": "base-cases",
+      "title": "Base Case Lemmas (m = 0 and r = 0)",
+      "startLine": 36,
+      "endLine": 53,
+      "summary": "Two base case lemmas. sum_zero_left (lines 39-48): when m = 0, multichoose(0,j) = 0 for j ≥ 1, so the sum collapses to the j = 0 term multichoose(n,r). Proved by induction on r using sum_range_succ' to extract the j = 0 term. sum_zero_right (lines 50-53): when r = 0, both sides are 1. Proved by simp with multichoose_zero_right."
+    },
+    {
+      "id": "sum-decomposition",
+      "title": "Key Sum Decomposition Lemma",
+      "startLine": 58,
+      "endLine": 79,
+      "summary": "sum_succ_left (lines 62-79): Σ_{j≤r+1} mc(m+1,j)·mc(n,r+1-j) = Σ_{j≤r+1} mc(m,j)·mc(n,r+1-j) + Σ_{j≤r} mc(m+1,j)·mc(n,r-j). Proof: extract j=0 terms via sum_range_succ', apply succ_sub_succ_eq_sub to align indices, expand mc(m+1)(j+1) = mc(m)(j+1) + mc(m+1)(j) via multichoose_succ_succ, distribute via add_mul + sum_add_distrib, close with ring."
+    },
+    {
+      "id": "main-theorem",
+      "title": "Multiset Vandermonde Identity",
+      "startLine": 85,
+      "endLine": 121,
+      "summary": "multiset_vandermonde (lines 91-121): the main theorem proved by double induction. Outer induction on m uses sum_zero_left for m = 0. Inner induction on r handles m = succ, r = 0 by sum_zero_right. The key inductive step (m = succ, r = succ): rw with multichoose_succ_succ to split mc(m+1+n)(r+1) = mc(m+n)(r+1) + mc(m+n+1)(r), apply both induction hypotheses (ih_m and ih_r), then use sum_succ_left to reassemble. Final congr 1 and simp [Nat.add_sub_cancel] close the goal."
+    }
+  ],
+  "conclusion": {
+    "summary": "This 122-line formalization proves the multiset Vandermonde identity for all natural numbers m, n, r with 0 axioms and 0 sorries. The proof is constructive: the three auxiliary lemmas (sum_zero_left, sum_zero_right, sum_succ_left) explicitly decompose the inductive structure, and the main theorem assembles them via double induction guided by the Pascal-like recurrence Nat.multichoose_succ_succ.",
+    "implications": "The multiset Vandermonde identity complements the classical Vandermonde convolution (proved elsewhere in the gallery) and connects to the generating function identity (1/(1-x))^{m+n} = (1/(1-x))^m · (1/(1-x))^n. The coefficient extraction [x^r] on both sides gives the multiset identity combinatorially. Applications: (1) computing convolutions of negative-binomial distributions; (2) weight multiplicities in representation theory of GL(n) via Weyl's character formula; (3) combinatorial proofs for power series manipulation in formal algebra.\n\nThe double induction structure is characteristic of proofs about two-variable combinatorial identities: one variable provides the outer induction, the other provides the inner induction, and a key algebraic lemma (here sum_succ_left) encapsulates the inductive step's combinatorial content. This pattern also appears in proofs of the Chu–Vandermonde identity and Zhu–Vandermonde extensions.",
+    "openQuestions": [
+      "Can the multiset Vandermonde identity be proved via the generating function argument formalized in Lean 4? The formal power series ring over ℕ would give a one-line proof: (1/(1-X))^{m+n} = (1/(1-X))^m · (1/(1-X))^n, with coefficient extraction via Polynomial.coeff. This approach is available in Mathlib via PowerSeries.",
+      "The identity multichoose(m+n,r) = C(m+n+r-1,r) and the standard Vandermonde C(m+n,r) = Σ C(m,j)C(n,r-j) together imply the multiset identity. Can a purely algebraic derivation (not by induction) be formalized in Lean using the relation multichoose n k = C(n+k-1,k)?",
+      "Generalization: the q-analog of multichoose is the Gaussian binomial coefficient [n+k-1 choose k]_q. Does the q-Vandermonde identity [m+n choose r]_q = Σ q^{j(r-j)} [m choose j]_q [n choose r-j]_q extend to the multiset q-analog, and can it be formalized?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03",
+      "relationship": "extends",
+      "description": "OQ-03 proves the Vandermonde identity in descFactorial form using falling factorials. OQ-03-OQ-02 extends this to the multiset coefficient setting via the relation multichoose(n,k) = C(n+k-1,k)."
+    },
+    {
+      "targetId": "binomial-theorem-oq-03",
+      "relationship": "uses",
+      "description": "The standard Vandermonde convolution C(m+n,r) = Σ C(m,j)C(n,r-j) is the classical version of this identity; the multiset Vandermonde is its 'stars and bars' analogue."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Vandermonde, Alexandre-Théophile",
+      "title": "Mémoire sur des irrationnelles de différents ordres",
+      "year": "1772",
+      "venue": "Mémoires de l'Académie Royale des Sciences",
+      "note": "Original source for the classical Vandermonde convolution; the multiset version follows from generating function generalization"
+    },
+    {
+      "authors": "Stanley, Richard P.",
+      "title": "Enumerative Combinatorics, Vol. 1",
+      "year": "1997",
+      "venue": "Cambridge University Press",
+      "note": "Chapter 1: multiset coefficients, generating functions, and Vandermonde-type convolutions"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Rewrote all 3 existing annotations to the full schema (added proofId, range with line numbers, title, content, mathContext in LaTeX, significance, relatedConcepts, prerequisites)
- Added 5th header/context annotation for the module docstring (lines 1-32) explaining the problem and proof strategy
- Fixed sections format: replaced non-standard `description`+`theorems` fields with `startLine`, `endLine`, `summary`; added preamble section
- Expanded overview with historicalContext (Vandermonde 1772, generating function interpretation), problemStatement, proofStrategy, 4 keyInsights
- Added full conclusion with summary, implications (generating functions, representation theory, negative-binomial), and 3 open questions (formal power series proof, algebraic derivation, q-Vandermonde)
- Fixed crossReferences: changed `id` to `targetId`, updated relationship labels
- Added references section (Vandermonde 1772, Stanley Enumerative Combinatorics)

## Proof
**arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02** — Multiset Vandermonde Identity: `multichoose(m+n,r) = Σ multichoose(m,j)·multichoose(n,r-j)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)