### PR TITLE
Fix: add missing top-level sorries field to 15 gallery proofs

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01/meta.json
@@ -153,5 +153,6 @@
       "type": "core",
       "description": "Uniform fibers preserve uniformOn probability (3 sorries for API)"
     }
-  ]
+  ],
+  "sorries": 3
 }

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-03/meta.json
@@ -114,5 +114,6 @@
       "relation": "sibling",
       "description": "PMF.multinomial integration with Mathlib — another application of the multinomial distribution infrastructure"
     }
-  ]
+  ],
+  "sorries": 1
 }

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -134,5 +134,6 @@
     ],
     "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
     "sorries": 3
-  }
+  },
+  "sorries": 3
 }

--- a/src/data/proofs/erdos-1196/meta.json
+++ b/src/data/proofs/erdos-1196/meta.json
@@ -207,5 +207,6 @@
     "definitionCount": 5,
     "path": "Proofs/Erdos1196Problem.lean",
     "sorries": 1
-  }
+  },
+  "sorries": 1
 }

--- a/src/data/proofs/erdos-1206/meta.json
+++ b/src/data/proofs/erdos-1206/meta.json
@@ -72,5 +72,6 @@
       "Is {n⁵ : n ≥ 1} itself a Sidon set (equivalently: does a⁵ + b⁵ = c⁵ + d⁵ have no solutions with {a,b} ≠ {c,d})?",
       "Does the extremal conjecture g_k(A) ≥ g_k({1,...,N}) hold for k ≥ 3?"
     ]
-  }
+  },
+  "sorries": 1
 }

--- a/src/data/proofs/erdos-1208/meta.json
+++ b/src/data/proofs/erdos-1208/meta.json
@@ -119,5 +119,6 @@
       "Does the unit distance problem bound $O(n^{4/3})$ in the plane imply a tight lower bound of $F_2(n) \\geq n^{1/3}$, or can sharper incidence bounds improve this?",
       "Can the `EuclideanSpace ℝ (Fin d)` formalization in Mathlib support a Lean proof of the greedy lower bound $F_d(n) \\geq \\Omega(n^{2/(d+1)})$, at least for small fixed $d$?"
     ]
-  }
+  },
+  "sorries": 1
 }

--- a/src/data/proofs/erdos-1211/meta.json
+++ b/src/data/proofs/erdos-1211/meta.json
@@ -76,5 +76,6 @@
       "Is there a connection between this problem and Kneser's theorem or the Cauchy–Davenport theorem on sum set density in abelian groups?",
       "Can Mathlib's `Filter.limsup` infrastructure be used to formalize logarithmic density, and are there existing Mathlib lemmas about Euler products $\\prod_{a \\in A}(1 + a^{-s})$ that could support this formalization?"
     ]
-  }
+  },
+  "sorries": 1
 }

--- a/src/data/proofs/erdos-1212/meta.json
+++ b/src/data/proofs/erdos-1212/meta.json
@@ -60,5 +60,6 @@
       "What is the minimum 'complexity' of such a path—can one find a path $(x_n, y_n)$ where both $x_n, y_n$ grow at most linearly? Is there a path where both coordinates are always composite (stronger than at-least-one)?",
       "Is there a clean characterization of the connected components of the subgraph $G[\\min > 1]$ (coprime pairs with both coordinates $> 1$)? Is this subgraph connected, and does connectivity depend on the prime distribution?"
     ]
-  }
+  },
+  "sorries": 1
 }

--- a/src/data/proofs/erdos-1213/meta.json
+++ b/src/data/proofs/erdos-1213/meta.json
@@ -51,5 +51,6 @@
       "Is the dependence on $a$ in $f(a,K)$ necessary? Can the threshold be made uniform in $a$ (i.e., depend only on $K$) with a different formulation?",
       "Can the Hegyvári proof be formalized in Lean 4 using `Finset.card` pigeonhole (`Finset.exists_ne_map_eq_of_card_lt_of_maps_to`) applied to the set of interval sums?"
     ]
-  }
+  },
+  "sorries": 1
 }

--- a/src/data/proofs/erdos-1215/meta.json
+++ b/src/data/proofs/erdos-1215/meta.json
@@ -51,5 +51,6 @@
       "For the restricted class of cyclotomic polynomials (with roots at roots of unity), is there a polynomial path-length bound? Mac Lane's labyrinth construction may require non-cyclotomic unit-circle roots.",
       "Can Lean 4's `Complex.abs` and `Polynomial.eval` infrastructure support even a simple statement of this theorem, or are results about path lengths in level sets too far from current Mathlib?"
     ]
-  }
+  },
+  "sorries": 1
 }

--- a/src/data/proofs/erdos-1216/meta.json
+++ b/src/data/proofs/erdos-1216/meta.json
@@ -51,5 +51,6 @@
       "Can the Stearns greedy argument be formalized in Lean 4 using `SimpleGraph.Tournament` and a finset-based induction on the greedy neighborhood halving?",
       "Is there a tournament-theoretic version of the probabilistic method that gives a sharp upper bound on $f(n)$, improving on the Erdős-Moser $2\\log_2 n$ bound?"
     ]
-  }
+  },
+  "sorries": 1
 }

--- a/src/data/proofs/erdos-1217/meta.json
+++ b/src/data/proofs/erdos-1217/meta.json
@@ -58,5 +58,6 @@
       "Can `Filter.limsup` in Mathlib 4 be used to define the upper log-log density of a sequence, and can Mertens' second theorem (∑_{p ≤ x} 1/p ~ log log x) be formalized from the current prime number theorem infrastructure in Mathlib?",
       "Is the 'log-log density' studied in the current Mathlib number theory library, or would formalizing Problem #1217 require developing this density theory from scratch?"
     ]
-  }
+  },
+  "sorries": 1
 }

--- a/src/data/proofs/law-of-cosines-oq-01-oq-05/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-01-oq-05/meta.json
@@ -159,5 +159,6 @@
     "definitionCount": 2,
     "path": "Proofs/LawOfCosinesOQ05.lean",
     "sorries": 1
-  }
+  },
+  "sorries": 1
 }

--- a/src/data/proofs/lovasz-local-lemma-oq-02/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-02/meta.json
@@ -115,8 +115,13 @@
     ]
   },
   "leanFile": {
-    "imports": ["Mathlib", "Proofs.LovaszLocalLemma"],
-    "opens": ["ProbMethod.LovaszLocal"],
+    "imports": [
+      "Mathlib",
+      "Proofs.LovaszLocalLemma"
+    ],
+    "opens": [
+      "ProbMethod.LovaszLocal"
+    ],
     "namespace": "ProbMethod.LovaszLocal.OQ02",
     "lineCount": 186,
     "axiomCount": 0,
@@ -190,5 +195,6 @@
       "description": "Exact biconditional: ∃ x ∈ [0,1] with p ≤ x*(1-x)^d ↔ p ≤ T(d)",
       "leanType": "(d : ℕ) → 0 < d → (p : ℚ) → 0 ≤ p → (∃ x : ℚ, 0 ≤ x ∧ x ≤ 1 ∧ p ≤ x * (1-x)^d) ↔ p ≤ lllThreshold d"
     }
-  ]
+  ],
+  "sorries": 2
 }

--- a/src/data/proofs/pascals-hexagon/meta.json
+++ b/src/data/proofs/pascals-hexagon/meta.json
@@ -248,5 +248,6 @@
       "description": "If a hexagon is inscribed in a conic, the three intersection points of opposite sides are collinear",
       "leanType": "inscribed_in_conic hexagon -> collinear (opposite_intersections hexagon)"
     }
-  ]
+  ],
+  "sorries": 1
 }


### PR DESCRIPTION
## Fix

15 gallery `meta.json` files had non-zero sorry counts in `meta.sorries` and `leanFile.sorries` but were missing the top-level `sorries` field entirely. The top-level field is the authoritative sorries count used by the gallery display and integrity checks.

## Evidence

**Before**: Top-level `sorries` field absent (reads as `null`/`undefined`), while `meta.sorries` had the correct non-zero value.

**After**: Top-level `sorries` field added, matching `meta.sorries` in all 15 cases.

**Affected proofs:**
| Proof | Sorries |
|-------|---------|
| ballot-problem-oq-01-oq-02-oq-01 | 3 |
| binomial-theorem-oq-02-oq-01-oq-03 | 1 |
| cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01 | 3 |
| erdos-1196 | 1 |
| erdos-1206 | 1 |
| erdos-1208 | 1 |
| erdos-1211 | 1 |
| erdos-1212 | 1 |
| erdos-1213 | 1 |
| erdos-1215 | 1 |
| erdos-1216 | 1 |
| erdos-1217 | 1 |
| law-of-cosines-oq-01-oq-05 | 1 |
| lovasz-local-lemma-oq-02 | 2 |
| pascals-hexagon | 1 |

---
Automated fix by lean-mechanic agent.