### PR TITLE
Fix: remove broken index.ts for godel-second-incompleteness-oq02

### DIFF
--- a/src/data/proofs/godel-second-incompleteness-oq02/index.ts
+++ b/src/data/proofs/godel-second-incompleteness-oq02/index.ts
@@ -1,8 +1,0 @@
-import type { ProofEntry } from "@/types";
-import meta from "./meta.json";
-
-const proof: ProofEntry = {
-  ...meta,
-};
-
-export default proof;


### PR DESCRIPTION
## Summary
- Remove `src/data/proofs/godel-second-incompleteness-oq02/index.ts` which imported from non-existent `@/types` module
- This file was causing build failures (`TS2307: Cannot find module '@/types'`)
- Other proof directories work fine without `index.ts` — the build system handles them

## Test plan
- [x] `pnpm build` succeeds after removal