### PR TITLE
Audit: fix lineCount for godel-second-incompleteness-oq02 (205→258)

### DIFF
--- a/src/data/proofs/godel-second-incompleteness-oq02/meta.json
+++ b/src/data/proofs/godel-second-incompleteness-oq02/meta.json
@@ -44,7 +44,7 @@
       "Provability logic and the modal system GL",
       "Löb's theorem and its relationship to Second Incompleteness"
     ],
-    "lineCount": 205,
+    "lineCount": 258,
     "proofRepoPath": "Proofs/GodelSecondIncompletenessOQ02.lean",
     "mathlib_version": "4.26.0",
     "relatedProofs": [


### PR DESCRIPTION
## Summary

- Fixes `lineCount` metadata mismatch in `godel-second-incompleteness-oq02/meta.json`
- File has 258 lines; meta.json incorrectly claimed 205

## Audit Findings

All mathematical claims verified correct:
- ✅ 0 sorries
- ✅ 1 axiom in this file (`con_implies_G`) + 5 imported from `GodelFirstIncompletenessOQ01` = 6 total
- ✅ Status `axiomatized`, badge `axiom` — correct
- ❌ `lineCount: 205` → should be `258` (file was extended after meta.json was written)

The extra lines (206-258) include two corollary theorems, an informal Löb's theorem discussion, an axiom-count note, and `#check` statements — all legitimate content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)