### PR TITLE
Seeker: select borsuk-ulam-oq-03-oq-04 — quantitative IVT bounds for antipodal pair location

### DIFF
--- a/research/problems/borsuk-ulam-oq-03-oq-04/problem.md
+++ b/research/problems/borsuk-ulam-oq-03-oq-04/problem.md
@@ -1,0 +1,79 @@
+# Problem: Formalize quantitative IVT bounds for effective estimates on antipodal pair locations
+
+## Statement
+
+### Plain Language
+The 1D Borsuk-Ulam theorem guarantees that any continuous f: [-1,1] → ℝ has an antipodal pair
+x₀ with f(x₀) = f(-x₀), proved via IVT on g(x) = f(x) - f(-x). The open question is:
+can we give **quantitative bounds** on where x₀ lies, given a modulus of continuity for f?
+
+For instance, if f is L-Lipschitz and |g(1)| = δ > 0, can we prove the antipodal pair lies
+in a specific interval away from the boundary, or bound the measure of the set of antipodal pairs?
+
+### Formal Statement
+```lean
+-- Target: Quantitative 1D Borsuk-Ulam
+-- If f: [-1,1] → ℝ is L-Lipschitz and g(x) := f(x) - f(-x),
+-- then the zero of g is bounded away from the endpoints proportional to |g(1)|/L.
+
+theorem quantitative_borsuk_ulam_1d
+    (f : ℝ → ℝ) (L : ℝ) (hL : 0 < L)
+    (hf : LipschitzWith (NNReal.ofReal L) (fun x => f x))
+    (hf_cont : ContinuousOn f (Set.Icc (-1) 1))
+    (δ : ℝ) (hδ : 0 < δ) (hg : |f 1 - f (-1)| = δ) :
+    ∃ x₀ ∈ Set.Icc (-1 + δ / (2 * L)) (1 - δ / (2 * L)),
+      f x₀ = f (-x₀) := by
+  sorry
+```
+
+## Classification
+
+```yaml
+tier: B
+significance: 7
+tractability: 6
+tags:
+  - topology
+  - constructive-math
+  - borsuk-ulam
+  - ivt
+  - antipodal
+  - quantitative
+  - lipschitz
+```
+
+**Significance**: 7/10 — Quantitative versions of topological fixed-point results are useful for
+constructive mathematics and computational topology.
+
+**Tractability**: 6/10 — Depends on quantitative IVT in Mathlib; the parent proof infrastructure
+in `BorsukUlamOQ03.lean` provides a good foundation.
+
+## Why This Matters
+
+1. **Effective/constructive topology**: Standard BU gives existence with no bound on where the
+   antipodal pair is. A quantitative version gives a computable estimate.
+2. **Modulus of continuity framework**: Connects to constructive analysis — provides a
+   computational certificate for the antipodal pair.
+3. **Lean infrastructure**: Tests whether Mathlib's Lipschitz/IVT machinery can support
+   quantitative topological arguments.
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| borsuk-ulam-oq-03 | Parent: 1D BU via IVT, axiom reduction chain, 5139 lines |
+| borsuk-ulam-oq-03-oq-01 | Sibling: related constructive extension |
+| borsuk-ulam-oq-03-oq-03 | Sibling: 2D Tucker's lemma, discrete approach |
+| intermediate-value-theorem | Core tool: `intermediate_value_Icc` |
+
+## Parent Open Question
+
+From `borsuk-ulam-oq-03` conclusion.openQuestions:
+> "Can the quantitative IVT bounds give effective estimates for the location of antipodal pairs?"
+
+## Key Mathlib Theorems to Explore
+
+- `intermediate_value_Icc`: standard IVT
+- `LipschitzWith.dist_le_mul`: Lipschitz bound on function values
+- `IsConnected.intermediate_value₂`: connectedness-based IVT variant
+- `Real.exists_zero`: existence of zeros for sign-changing functions

--- a/research/problems/borsuk-ulam-oq-03-oq-04/state.md
+++ b/research/problems/borsuk-ulam-oq-03-oq-04/state.md
@@ -1,0 +1,31 @@
+# Current State
+
+**Phase**: NEW
+**Since**: 2026-04-21T00:00:00.000Z
+**Iteration**: 1
+
+## Current Focus
+
+Initial exploration: survey quantitative IVT results in Mathlib and assess whether
+the Lipschitz-based bound on antipodal pair location is provable from existing infrastructure
+in `BorsukUlamOQ03.lean`.
+
+## Active Approach
+
+None yet. First step: read BorsukUlamOQ03.lean to understand existing IVT infrastructure,
+then search Mathlib for quantitative continuity/Lipschitz tools.
+
+## Blockers
+
+None.
+
+## Next Action
+
+OBSERVE: Read `proofs/Proofs/BorsukUlamOQ03.lean` (specifically the 1D BU section, lines 66-106)
+and Mathlib's `LipschitzWith` API to assess proof strategy.
+
+## Attempt Counts
+
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0


### PR DESCRIPTION
## Problem Selection

**ID**: borsuk-ulam-oq-03-oq-04
**Title**: Formalize quantitative IVT bounds for effective estimates on antipodal pair locations
**Tier**: B | **Significance**: 7/10 | **Tractability**: 6/10
**Knowledge**: EMPTY (0 prior research items)

## Selection Rationale

- **Diversity**: Topology domain — not covered in any of the 8 active claims (geometry, number theory, combinatorics, analysis, information theory, convex geometry) nor in last 3 selections (law-of-cosines, chebyshev, binomial)
- **EMPTY knowledge tier**: Highest priority tier; no prior research needed to start fresh
- **Strong parent infrastructure**: `BorsukUlamOQ03.lean` (5139 lines, 0 sorries) provides the 1D BU proof via IVT as foundation
- **Explicit open question**: Listed verbatim in `borsuk-ulam-oq-03` conclusion.openQuestions

## Mathematical Content

The 1D BU proof uses g(x) = f(x) - f(-x) with IVT to find an antipodal pair x₀.  
The quantitative version: given L-Lipschitz f with |f(1) - f(-1)| = δ > 0, prove x₀ ∈ [-1 + δ/(2L), 1 - δ/(2L)].

This gives a **computable certificate** for the antipodal pair location — bridging classical topology with constructive/effective mathematics.

## Pool Status After Selection

| Status | Count |
|--------|-------|
| Available | 17 |
| In Progress | 511 |
| Completed | 1373 |
| Blocked | 1 |
| **Total** | **1902** |

Pool health: **adequate** (17 ≥ threshold 15).

## Labels

`research`

🤖 Generated with [Claude Code](https://claude.com/claude-code)