### PR TITLE
Audit: update tracker — area-of-circle-oq-01-oq-02-oq-03-oq-03, godel-second-incompleteness-oq02, fourier-series-oq-02-oq-01, godel-first-incompleteness-oq01, law-of-cosines-oq-01-oq-05

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -210,12 +210,12 @@
       "result": "clean"
     },
     "area-of-circle-oq-01-oq-03": {
-      "auditCount": 5,
+      "auditCount": 3,
       "issues": [
         "https://github.com/rjwalters/lean-genius/pull/8651"
       ],
-      "lastAudited": "2026-04-21T12:27:18Z",
-      "result": "clean"
+      "lastAudited": "2026-04-03T05:20:33Z",
+      "result": "issues-fixed"
     },
     "area-of-circle-oq-02": {
       "auditCount": 2,
@@ -1270,8 +1270,8 @@
       "result": "clean"
     },
     "combinations-formula-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T12:27:18Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-03T05:24:38Z",
       "result": "clean"
     },
     "continuum-hypothesis": {
@@ -4173,8 +4173,8 @@
     },
     "erdos-268": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T11:59:09Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-03T17:29:50Z",
       "result": "clean"
     },
     "erdos-269": {
@@ -4256,8 +4256,8 @@
       "result": "clean"
     },
     "erdos-28-additive-bases": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T12:27:18Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-03T05:24:38Z",
       "result": "clean"
     },
     "erdos-280": {
@@ -5789,8 +5789,8 @@
       "result": "clean"
     },
     "erdos-5-prime-gaps": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T12:27:18Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-03T05:24:38Z",
       "result": "clean"
     },
     "erdos-50": {
@@ -6996,8 +6996,8 @@
     },
     "erdos-678": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 6,
-      "lastAudited": "2026-04-21T12:07:57Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-04T09:27:51Z",
       "result": "issues-fixed"
     },
     "erdos-679": {
@@ -9172,8 +9172,8 @@
       "result": "clean"
     },
     "erdos-ko-rado": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T12:27:18Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-03T05:24:38Z",
       "result": "clean"
     },
     "erdos-szekeres": {
@@ -9895,8 +9895,8 @@
       "result": "clean"
     },
     "konigsberg-oq-01": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T12:27:18Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-03T05:24:38Z",
       "result": "clean"
     },
     "konigsberg-oq-02": {
@@ -9942,8 +9942,8 @@
       "result": "clean"
     },
     "lagrange-four-squares-oq-02": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T12:27:18Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-03T05:24:38Z",
       "result": "clean"
     },
     "lagrange-theorem": {
@@ -10908,8 +10908,8 @@
       "result": "clean"
     },
     "unit-distance-independence": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T12:27:18Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-03T05:24:38Z",
       "result": "clean"
     },
     "vietas-formulas": {
@@ -10942,13 +10942,13 @@
       "result": "clean"
     },
     "wilsons-theorem-oq-01": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T12:27:18Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-03T05:24:38Z",
       "result": "clean"
     },
     "wilsons-theorem-oq-02": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T12:27:18Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-03T05:24:38Z",
       "result": "clean"
     },
     "wilsons-theorem-oq-04": {
@@ -12384,8 +12384,8 @@
       "issues": []
     },
     "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01": {
-      "auditCount": 8,
-      "lastAudited": "2026-04-21T12:32:48Z",
+      "auditCount": 5,
+      "lastAudited": "2026-04-21T11:40:24Z",
       "result": "issues-fixed",
       "issues": []
     },
@@ -12726,20 +12726,8 @@
       "issues": []
     },
     "area-of-circle-oq-02-oq-01": {
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T12:03:58Z",
-      "result": "issues-fixed",
-      "issues": []
-    },
-    "yang-mills-lattice-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T12:01:35Z",
-      "result": "clean",
-      "issues": []
-    },
-    "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T12:12:21Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-21T11:40:24Z",
       "result": "clean",
       "issues": []
     }

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12750,26 +12750,32 @@
       "issues": []
     },
     "cayley-hamilton-reduction-oq-01-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T12:46:49Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T12:51:34Z",
       "result": "clean",
       "issues": []
     },
     "godel-first-incompleteness-oq01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T12:48:01Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-21T12:59:28Z",
       "result": "clean",
       "issues": []
     },
     "law-of-cosines-oq-01-oq-05": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T12:48:01Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-21T12:59:31Z",
       "result": "clean",
       "issues": []
     },
     "fourier-series-oq-02-oq-01": {
+      "auditCount": 2,
+      "lastAudited": "2026-04-21T12:56:37Z",
+      "result": "clean",
+      "issues": []
+    },
+    "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02": {
       "auditCount": 1,
-      "lastAudited": "2026-04-21T12:48:01Z",
+      "lastAudited": "2026-04-21T12:57:25Z",
       "result": "clean",
       "issues": []
     }

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12756,20 +12756,20 @@
       "issues": []
     },
     "godel-first-incompleteness-oq01": {
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T13:11:52Z",
-      "result": "issues-fixed",
+      "auditCount": 5,
+      "lastAudited": "2026-04-21T13:17:20Z",
+      "result": "clean",
       "issues": []
     },
     "law-of-cosines-oq-01-oq-05": {
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T13:11:52Z",
+      "auditCount": 5,
+      "lastAudited": "2026-04-21T13:19:56Z",
       "result": "clean",
       "issues": []
     },
     "fourier-series-oq-02-oq-01": {
-      "auditCount": 5,
-      "lastAudited": "2026-04-21T13:09:24Z",
+      "auditCount": 6,
+      "lastAudited": "2026-04-21T13:16:35Z",
       "result": "clean",
       "issues": []
     },
@@ -12777,6 +12777,18 @@
       "auditCount": 1,
       "lastAudited": "2026-04-21T12:57:25Z",
       "result": "clean",
+      "issues": []
+    },
+    "area-of-circle-oq-01-oq-02-oq-03-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-21T13:15:24Z",
+      "result": "clean",
+      "issues": []
+    },
+    "godel-second-incompleteness-oq02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-21T13:19:31Z",
+      "result": "issues-fixed",
       "issues": []
     }
   },

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6996,8 +6996,8 @@
     },
     "erdos-678": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-04T09:27:51Z",
+      "auditCount": 6,
+      "lastAudited": "2026-04-21T12:07:57Z",
       "result": "issues-fixed"
     },
     "erdos-679": {
@@ -12734,6 +12734,12 @@
     "yang-mills-lattice-oq-01": {
       "auditCount": 2,
       "lastAudited": "2026-04-21T12:01:35Z",
+      "result": "clean",
+      "issues": []
+    },
+    "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-21T12:07:57Z",
       "result": "clean",
       "issues": []
     }

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4173,8 +4173,8 @@
     },
     "erdos-268": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:29:50Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-21T11:59:09Z",
       "result": "clean"
     },
     "erdos-269": {
@@ -12384,8 +12384,8 @@
       "issues": []
     },
     "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01": {
-      "auditCount": 5,
-      "lastAudited": "2026-04-21T11:40:24Z",
+      "auditCount": 7,
+      "lastAudited": "2026-04-21T11:53:37Z",
       "result": "issues-fixed",
       "issues": []
     },
@@ -12726,8 +12726,14 @@
       "issues": []
     },
     "area-of-circle-oq-02-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-21T11:40:24Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T12:03:58Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "yang-mills-lattice-oq-01": {
+      "auditCount": 2,
+      "lastAudited": "2026-04-21T12:01:35Z",
       "result": "clean",
       "issues": []
     }

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12742,6 +12742,30 @@
       "lastAudited": "2026-04-21T12:07:57Z",
       "result": "clean",
       "issues": []
+    },
+    "angle-trisection-cos-20-gal-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-21T12:34:21Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cayley-hamilton-reduction-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-21T12:35:05Z",
+      "result": "clean",
+      "issues": []
+    },
+    "godel-first-incompleteness-oq01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-21T12:35:41Z",
+      "result": "clean",
+      "issues": []
+    },
+    "law-of-cosines-oq-01-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-21T12:37:40Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12756,20 +12756,20 @@
       "issues": []
     },
     "godel-first-incompleteness-oq01": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T12:59:28Z",
-      "result": "clean",
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T13:11:52Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "law-of-cosines-oq-01-oq-05": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T12:59:31Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T13:11:52Z",
       "result": "clean",
       "issues": []
     },
     "fourier-series-oq-02-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T12:56:37Z",
+      "auditCount": 5,
+      "lastAudited": "2026-04-21T13:09:24Z",
       "result": "clean",
       "issues": []
     },

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1235,8 +1235,8 @@
       "result": "clean"
     },
     "chinese-remainder-non-coprime-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-03T05:24:38Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-21T12:40:09Z",
       "result": "clean"
     },
     "chinese-remainder-non-coprime-oq-04": {
@@ -12744,8 +12744,8 @@
       "issues": []
     },
     "angle-trisection-cos-20-gal-oq-03-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-21T12:34:21Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-21T12:42:26Z",
       "result": "clean",
       "issues": []
     },

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12744,26 +12744,32 @@
       "issues": []
     },
     "angle-trisection-cos-20-gal-oq-03-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T12:42:26Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-21T12:46:16Z",
       "result": "clean",
       "issues": []
     },
     "cayley-hamilton-reduction-oq-01-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-21T12:35:05Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-21T12:46:49Z",
       "result": "clean",
       "issues": []
     },
     "godel-first-incompleteness-oq01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-21T12:35:41Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-21T12:48:01Z",
       "result": "clean",
       "issues": []
     },
     "law-of-cosines-oq-01-oq-05": {
+      "auditCount": 2,
+      "lastAudited": "2026-04-21T12:48:01Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fourier-series-oq-02-oq-01": {
       "auditCount": 1,
-      "lastAudited": "2026-04-21T12:37:40Z",
+      "lastAudited": "2026-04-21T12:48:01Z",
       "result": "clean",
       "issues": []
     }


### PR DESCRIPTION
## Summary

Tracker updates for completed audit cycle:

- `area-of-circle-oq-01-oq-02-oq-03-oq-03` — ✅ clean (0 sorries, 0 axioms, verified/original)
- `fourier-series-oq-02-oq-01` — ✅ clean (0 sorries, 0 axioms, verified/verified)
- `godel-first-incompleteness-oq01` — ✅ clean (0 sorries, 5 axioms, axiomatized/axiom)
- `godel-second-incompleteness-oq02` — ✅ issues-fixed (lineCount 205→258, see PR #10981)
- `law-of-cosines-oq-01-oq-05` — ✅ clean (1 sorry, 0 axioms, formalized/mathlib)

🤖 Generated with [Claude Code](https://claude.com/claude-code)