### PR TITLE
Enrich Multinomial Covariance: annotations, historicalContext, keyInsights

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-03/annotations.json
@@ -7,27 +7,33 @@
     "title": "multinomialProb and Normalization",
     "content": "Redefines multinomialProb locally (definitionally equal to BinomialTheoremOQ02OQ01OQ02.multinomialProb) and proves the normalization ∑ P(k) = 1 by delegation. The local redefinition avoids namespace issues while keeping proofs readable. multinomialProb_eq establishes the definitional equality enabling simp_rw rewrites between namespaces.",
     "mathContext": "$\\text{multinomialProb}(s, p, n, k) = \\binom{n}{k_1, \\ldots} \\prod_{i \\in s} p_i^{k_i}$. Normalization: $\\sum_{k \\in \\text{piAntidiag}(s,n)} P(k) = 1$ when $\\sum_{i \\in s} p_i = 1$.",
-    "significance": "supporting"
+    "significance": "supporting",
+    "relatedConcepts": ["multinomial coefficient", "probability mass function", "Finset.piAntidiag", "namespace aliasing in Lean 4"],
+    "prerequisites": ["multinomial distribution basics", "Lean 4 namespace system", "Mathlib Finset.piAntidiag", "BinomialTheoremOQ02OQ01OQ02.multinomialProb"]
   },
   {
     "id": "ann-mean-fiber-grouping",
     "proofId": "binomial-theorem-oq-02-oq-01-oq-03",
     "range": { "startLine": 70, "endLine": 132 },
-    "type": "theorem",
+    "type": "technique",
     "title": "Mean E[Xᵢ] = n·pᵢ via Fiber Grouping",
     "content": "multinomial_mean proves ∑_k k(i₀)·P(k) = n·p(i₀) in three steps. (1) sum_fiberwise_of_maps_to groups the double sum: ∑_k f(k) = ∑_j ∑_{k:k(i₀)=j} f(k). The mapping k ↦ k(i₀) hits range(n+1) since k(i₀) ≤ ∑_s k(l) = n. (2) On each fiber, step1 replaces k(i₀) : ℝ with j : ℝ (using exact_mod_cast via the filter membership proof), then step2 factors out j and applies multinomial_marginal_pmf to get the binomial PMF. (3) The resulting sum ∑_j j·binomPMF(n,p,j) = n·p is handled by binomial_mean_all.",
     "mathContext": "Fiber grouping: $\\sum_{k} k(i_0) \\cdot P(k) = \\sum_{j=0}^{n} j \\cdot \\underbrace{\\sum_{k: k(i_0)=j} P(k)}_{= \\binom{n}{j} p_{i_0}^j (1-p_{i_0})^{n-j}} = \\sum_{j=0}^{n} j \\cdot \\text{binomPMF}(n, p_{i_0}, j) = n p_{i_0}$.",
-    "significance": "key"
+    "significance": "key",
+    "relatedConcepts": ["law of total expectation", "marginal distribution of multinomial", "binomial distribution as marginal", "Finset.sum_fiberwise_of_maps_to"],
+    "prerequisites": ["Finset.sum_fiberwise_of_maps_to", "marginal PMF of multinomial (BinomialTheoremOQ02OQ01OQ02)", "binomial mean formula (BinomialTheoremOQ03)", "exact_mod_cast tactic"]
   },
   {
     "id": "ann-cross-moment-sorry",
     "proofId": "binomial-theorem-oq-02-oq-01-oq-03",
     "range": { "startLine": 134, "endLine": 166 },
-    "type": "theorem",
+    "type": "insight",
     "title": "Cross-Moment Sorry: E[XᵢXⱼ] = n(n-1)pᵢpⱼ",
-    "content": "multinomial_cross_moment is stated with a detailed proof sketch in the docstring. The proof uses the joint MGF identity (from multinomial_mgf_real with g(l) = 1+a for l=i, 1+b for l=j, 1 otherwise): ∑_k P(k)·(1+a)^{k(i)}·(1+b)^{k(j)} = (1+pᵢa+pⱼb)^n. Differentiating w.r.t. a at 0 (HasDerivAt.sum) gives ∑_k P(k)·k(i)·(1+b)^{k(j)} = n·pᵢ·(1+pⱼb)^{n-1}. Differentiating w.r.t. b at 0 gives E[XᵢXⱼ] = n(n-1)pᵢpⱼ.",
-    "mathContext": "Joint MGF: $\\sum_k P(k) (1+a)^{k(i)} (1+b)^{k(j)} = (1 + p_i a + p_j b)^n$. Cross-moment: $E[X_i X_j] = \\frac{\\partial^2}{\\partial a \\partial b}\\Big|_{a=b=0} (1+p_i a + p_j b)^n = n(n-1) p_i p_j$.",
-    "significance": "key"
+    "content": "multinomial_cross_moment is stated with a detailed proof sketch in the docstring. The proof uses the joint MGF identity (from multinomial_mgf_real with g(l) = 1+a for l=i, 1+b for l=j, 1 otherwise): ∑_k P(k)·(1+a)^{k(i)}·(1+b)^{k(j)} = (1+pᵢa+pⱼb)^n. Differentiating w.r.t. a at 0 (HasDerivAt.sum) gives ∑_k P(k)·k(i)·(1+b)^{k(j)} = n·pᵢ·(1+pⱼb)^{n-1}. Differentiating w.r.t. b at 0 gives E[XᵢXⱼ] = n(n-1)pᵢpⱼ. The quantity n(n-1) is a factorial moment: it counts ordered pairs of distinct trials, both from category i and j respectively.",
+    "mathContext": "Joint MGF: $\\sum_k P(k) (1+a)^{k(i)} (1+b)^{k(j)} = (1 + p_i a + p_j b)^n$. Cross-moment via mixed partial: $E[X_i X_j] = \\frac{\\partial^2}{\\partial a \\partial b}\\Big|_{a=b=0} (1+p_i a + p_j b)^n = n(n-1) p_i p_j$.",
+    "significance": "key",
+    "relatedConcepts": ["moment generating function", "joint MGF of multinomial", "factorial moments", "mixed partial derivatives", "HasDerivAt in Mathlib"],
+    "prerequisites": ["multinomial MGF theorem (BinomialTheoremOQ02OQ01)", "HasDerivAt and chain rule in Mathlib", "factorial moments of discrete distributions", "differentiation under expectation"]
   },
   {
     "id": "ann-covariance-main",
@@ -35,8 +41,10 @@
     "range": { "startLine": 168, "endLine": 202 },
     "type": "theorem",
     "title": "Main Theorem: Multinomial Covariance",
-    "content": "multinomial_covariance reduces the covariance formula to the cross-moment and mean. The proof: (1) rewrites the raw multinomial coefficient form as multinomialProb, (2) expands (k(i)·k(j) - n·p(i)·n·p(j))·P via sub_mul and sum_sub_distrib, splitting into two sums, (3) the second sum (constant × normalization) is evaluated by multinomialProb_sum_one, (4) the first sum is the cross-moment, (5) closes by ring arithmetic. The key computation is n(n-1)pᵢpⱼ - n²pᵢpⱼ = -npᵢpⱼ.",
+    "content": "multinomial_covariance reduces the covariance formula to the cross-moment and mean. The proof: (1) rewrites the raw multinomial coefficient form as multinomialProb, (2) expands (k(i)·k(j) - n·p(i)·n·p(j))·P via sub_mul and sum_sub_distrib, splitting into two sums, (3) the second sum (constant × normalization) is evaluated by multinomialProb_sum_one, (4) the first sum is the cross-moment, (5) closes by ring arithmetic. The key computation is n(n-1)pᵢpⱼ - n²pᵢpⱼ = -npᵢpⱼ. This algebraic reduction is complete and sorry-free; only the cross-moment lemma carries a sorry.",
     "mathContext": "$\\text{Cov}(X_i, X_j) = E[X_i X_j] - E[X_i] E[X_j] = n(n-1)p_ip_j - n^2 p_i p_j = -n p_i p_j$.",
-    "significance": "key"
+    "significance": "key",
+    "relatedConcepts": ["covariance definition", "bilinearity of covariance", "competition constraint in multinomial", "ring arithmetic in Lean 4"],
+    "prerequisites": ["definition of covariance as E[XY] - E[X]E[Y]", "multinomial_mean", "multinomial_cross_moment", "multinomialProb_sum_one", "Finset.sum_sub_distrib"]
   }
 ]

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-03/meta.json
@@ -26,7 +26,7 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "The covariance structure of the multinomial distribution is a classical result in probability theory. For $(X_1, \\ldots, X_k) \\sim \\text{Multinomial}(n, p_1, \\ldots, p_k)$, the negative covariance $\\text{Cov}(X_i, X_j) = -np_ip_j$ for $i \\neq j$ reflects the fundamental constraint that the counts must sum to $n$: if more trials yield outcome $i$, fewer must yield outcome $j$. This negative correlation is routinely used in the analysis of goodness-of-fit tests, confidence intervals for proportions, and the derivation of the chi-squared distribution.",
+    "historicalContext": "The multinomial distribution traces to Jacob Bernoulli's *Ars Conjectandi* (1713) and was studied extensively by Abraham de Moivre and later Laplace as a natural generalization of the binomial. Its covariance structure became central with Karl Pearson's landmark 1900 paper introducing the chi-squared goodness-of-fit test: the asymptotic distribution of $\\chi^2 = \\sum_i (O_i - E_i)^2/E_i$ depends on the multinomial covariance matrix $\\Sigma = n(\\text{diag}(p) - pp^T)$, whose off-diagonal entries are precisely $-np_ip_j$. R.A. Fisher refined this theory in the 1920s while developing maximum likelihood estimation and contingency table analysis. For $(X_1, \\ldots, X_k) \\sim \\text{Multinomial}(n, p_1, \\ldots, p_k)$, the negative covariance $\\text{Cov}(X_i, X_j) = -np_ip_j$ for $i \\neq j$ reflects the fundamental constraint $\\sum X_l = n$: if more trials yield outcome $i$, fewer must yield outcome $j$. The Lean formalization machine-checks the fiber-grouping argument used to compute $E[X_i] = np_i$ — a technique that reduces the multinomial mean to the binomial mean via the marginal PMF.",
     "problemStatement": "For $(X_1, \\ldots, X_k) \\sim \\text{Multinomial}(n, p_1, \\ldots, p_k)$ with $\\sum p_i = 1$, prove that $\\text{Cov}(X_i, X_j) = -np_ip_j$ for distinct $i \\neq j$.",
     "text": "Proves the multinomial covariance formula $\\text{Cov}(X_i, X_j) = -np_ip_j$ in two steps: (1) the mean $E[X_i] = np_i$ is fully proved via fiber grouping, and (2) the cross-moment $E[X_iX_j] = n(n-1)p_ip_j$ is the key sorry. Given these, the covariance follows by ring arithmetic: $E[X_iX_j] - E[X_i]E[X_j] = n(n-1)p_ip_j - n^2p_ip_j = -np_ip_j$.",
     "proofStrategy": "The mean proof uses the `sum_fiberwise_of_maps_to` lemma to group the multinomial sum by the value of $k(i_0) = j$, reducing each fiber to a scalar multiple of the marginal PMF $P(X_{i_0}=j) = \\binom{n}{j}p_{i_0}^j(1-p_{i_0})^{n-j}$ (from BinomialTheoremOQ02OQ01OQ02), then recognizing the resulting sum as the binomial mean $\\sum_j j \\cdot \\text{binomPMF}(n,p,j) = np$ (from BinomialTheoremOQ03). The covariance then follows by linearity and ring arithmetic from the cross-moment and the mean.",
@@ -35,7 +35,8 @@
       "The covariance formula is -npᵢpⱼ because E[XᵢXⱼ] = n(n-1)pᵢpⱼ while E[Xᵢ]·E[Xⱼ] = n²pᵢpⱼ, so Cov = -npᵢpⱼ",
       "The cross-moment E[XᵢXⱼ] = n(n-1)pᵢpⱼ can be proved by differentiating the joint MGF (∑ P(k)·(1+a)^{k(i)}·(1+b)^{k(j)} = (1+pᵢa+pⱼb)^n) twice using HasDerivAt",
       "The negative correlation arises from the hard constraint ∑ Xₗ = n: winning observations in category i must come at the expense of other categories",
-      "multinomial_covariance is fully proved in terms of multinomial_cross_moment — the algebraic reduction is complete"
+      "multinomial_covariance is fully proved in terms of multinomial_cross_moment — the algebraic reduction is complete",
+      "The covariance matrix $\\Sigma = n(\\text{diag}(p) - pp^T)$ is necessarily singular (rank $k-1$) because $\\sum_i X_i = n$ forces all variation into the constraint hyperplane; this singularity is why the chi-squared statistic has $k-1$ degrees of freedom rather than $k$"
     ]
   },
   "sections": [
@@ -72,8 +73,9 @@
     "summary": "The mean theorem `multinomial_mean` is fully proved (0 sorries) via fiber grouping and the marginal PMF. The covariance theorem `multinomial_covariance` is proved modulo the cross-moment sorry. The algebraic reduction Cov = E[XᵢXⱼ] - E[Xᵢ]E[Xⱼ] = n(n-1)pᵢpⱼ - n²pᵢpⱼ = -npᵢpⱼ is fully formalized.",
     "implications": "The negative covariance -npᵢpⱼ is foundational in multivariate statistics: it determines the covariance matrix of the multinomial distribution (diagonal Var(Xᵢ) = npᵢ(1-pᵢ), off-diagonal Cov(Xᵢ,Xⱼ) = -npᵢpⱼ), which is used in the asymptotic chi-squared distribution of goodness-of-fit statistics, the delta method for functions of multinomial proportions, and the analysis of categorical data in contingency tables.",
     "openQuestions": [
-      "Prove multinomial_cross_moment: E[XᵢXⱼ] = n(n-1)pᵢpⱼ using the joint MGF differentiation approach sketched in the proof comment (HasDerivAt applied twice to ∑ P(k)·(1+a)^{k(i)}·(1+b)^{k(j)} = (1+pᵢa+pⱼb)^n)",
-      "Formalize the full multinomial covariance matrix: the matrix with entries Cov(Xᵢ,Xⱼ) is n·(diag(p) - p·pᵀ), and prove it is positive semi-definite on the constraint hyperplane ∑ xᵢ = 0"
+      "Prove multinomial_cross_moment: E[XᵢXⱼ] = n(n-1)pᵢpⱼ using the joint MGF differentiation approach sketched in the proof (HasDerivAt applied twice to ∑ P(k)·(1+a)^{k(i)}·(1+b)^{k(j)} = (1+pᵢa+pⱼb)^n); the key obstacle is commuting HasDerivAt.sum with the finite sum over piAntidiag",
+      "Formalize the full multinomial covariance matrix $\\Sigma_{ij} = n(\\delta_{ij}p_i - p_ip_j)$ as a Mathlib matrix, prove it is positive semi-definite on the hyperplane $\\{x : \\sum x_i = 0\\}$ (equivalently, that $\\Sigma$ has eigenvalues $np_i$ with eigenvectors orthogonal to $(1,\\ldots,1)$), and connect to the chi-squared asymptotic theory",
+      "Prove the multinomial CLT: $n^{-1/2}(X_1 - np_1, \\ldots, X_k - np_k) \\xrightarrow{d} \\mathcal{N}(0, \\Sigma)$ as $n \\to \\infty$, using the formalized covariance matrix as input to a multivariate characteristic function argument"
     ]
   },
   "leanFile": {


### PR DESCRIPTION
Enrichment pass for binomial-theorem-oq-02-oq-01-oq-03.

## Quality improvements

- **annotations.json**: Added `relatedConcepts` and `prerequisites` to all 4 annotations covering the full proof
- **meta.json historicalContext**: Expanded with real mathematical history — Bernoulli's *Ars Conjectandi* (1713), Pearson's 1900 chi-squared paper, Fisher's contingency table work — and the significance of the covariance matrix for chi-squared asymptotics
- **meta.json keyInsights**: Added 6th insight about the covariance matrix $\Sigma = n(\text{diag}(p) - pp^T)$ being necessarily singular (rank $k-1$) and why this gives $k-1$ degrees of freedom in chi-squared tests
- **meta.json openQuestions**: Expanded from 2 to 3 questions, each more mathematically precise: cross-moment proof via HasDerivAt, full covariance matrix PSD formalization, and multinomial CLT

## Axiom integrity

No axiom integrity issues. The `axiomCount: 0` correctly reflects no `axiom` declarations and no assumption-carrying structure fields. The one sorry is `multinomial_cross_moment` which is properly noted in `assumptions`.