### PR TITLE
Audit: update tracker — 8 proofs (fourier-series, angle-trisection, area-of-circle, arithmetic-series, cayley-hamilton, godel-first/second, law-of-cosines)

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified. 3 lemmas (sum_zero_left, sum_zero_right, sum_succ_left) + 1 theorem (multiset_vandermonde), all with 0 sorries.",
     "mathlib_version": "4.26.0",
-    "lineCount": 122,
+    "lineCount": 118,
     "theoremCount": 4,
     "definitionCount": 0
   },

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -144,7 +144,7 @@
     "angle-trisection-oq-02-oq-04-oq-01": {
       "auditCount": 4,
       "issues": [
-        "sorry 7\u21923"
+        "sorry 7→3"
       ],
       "lastAudited": "2026-04-13T03:29:17Z",
       "result": "issues-fixed"
@@ -255,7 +255,7 @@
     "area-of-circle-oq-05": {
       "auditCount": 2,
       "issues": [
-        "sorries 1\u21920, status formalized\u2192verified, badge wip\u2192mathlib (sorry was completed)"
+        "sorries 1→0, status formalized→verified, badge wip→mathlib (sorry was completed)"
       ],
       "lastAudited": "2026-04-03T09:33:04Z",
       "result": "issues-fixed"
@@ -545,10 +545,10 @@
     "binomial-theorem-oq-04-oq-03": {
       "auditCount": 3,
       "issues": [
-        "sorry 6\u21920",
-        "axiomCount 1\u21920",
-        "status axiomatized\u2192verified",
-        "badge axiom\u2192original"
+        "sorry 6→0",
+        "axiomCount 1→0",
+        "status axiomatized→verified",
+        "badge axiom→original"
       ],
       "lastAudited": "2026-04-13T03:29:17Z",
       "result": "issues-fixed"
@@ -795,8 +795,8 @@
     "cantor-diagonalization-oq-01-oq-01-oq-02": {
       "auditCount": 3,
       "issues": [
-        "sorry 1\u21920",
-        "status formalized\u2192verified"
+        "sorry 1→0",
+        "status formalized→verified"
       ],
       "lastAudited": "2026-04-13T03:29:17Z",
       "result": "issues-fixed"
@@ -1462,7 +1462,7 @@
     "descartes-rule-of-signs-oq-02": {
       "auditCount": 4,
       "issues": [
-        "PR #6448: sorries 2\u21920, lineCount 552\u2192698"
+        "PR #6448: sorries 2→0, lineCount 552→698"
       ],
       "lastAudited": "2026-04-03T22:10:54Z",
       "result": "clean"
@@ -5159,7 +5159,7 @@
     "erdos-409": {
       "auditCount": 4,
       "issues": [
-        "status axiomatized\u2192verified, badge wip\u2192original (0 sorries, 0 axioms confirmed)"
+        "status axiomatized→verified, badge wip→original (0 sorries, 0 axioms confirmed)"
       ],
       "lastAudited": "2026-04-13T03:03:24Z",
       "result": "issues-fixed"
@@ -6773,7 +6773,7 @@
       "lastAudited": "2026-04-13T03:29:17Z",
       "result": "issues-fixed",
       "issues": [
-        "sorry 18\u219216"
+        "sorry 18→16"
       ]
     },
     "erdos-645": {
@@ -7281,7 +7281,7 @@
     "erdos-719": {
       "auditCount": 4,
       "issues": [
-        "PR #6447: sorries 2\u21921, lineCount 175\u2192196"
+        "PR #6447: sorries 2→1, lineCount 175→196"
       ],
       "lastAudited": "2026-04-03T17:35:38Z",
       "result": "clean"
@@ -7469,7 +7469,7 @@
     "erdos-746": {
       "auditCount": 6,
       "issues": [
-        "PR #6440: sorry count 3\u21924",
+        "PR #6440: sorry count 3→4",
         "Issue #6441: 9 vacuous True stubs",
         "https://github.com/rjwalters/lean-genius/pull/8651"
       ],
@@ -9329,7 +9329,7 @@
     "feuerbachs-theorem-oq-02": {
       "auditCount": 3,
       "issues": [
-        "axiomCount 5\u21923"
+        "axiomCount 5→3"
       ],
       "lastAudited": "2026-04-13T03:29:17Z",
       "result": "issues-fixed"
@@ -11916,7 +11916,7 @@
       "lastAudited": "2026-04-05T12:44:33Z",
       "result": "issues-fixed",
       "issues": [
-        "lineCount 98\u2192112, theoremCount 7\u21928 (enricher used stale counts)"
+        "lineCount 98→112, theoremCount 7→8 (enricher used stale counts)"
       ]
     },
     "arithmetic-series-oq-02-oq-04-oq-01-oq-03": {
@@ -12308,7 +12308,7 @@
       "lastAudited": "2026-04-13T22:38:12Z",
       "result": "issues-fixed",
       "issues": [
-        "sorry 4\u21923"
+        "sorry 4→3"
       ]
     },
     "chebyshev-pnt-bridge-oq-01": {
@@ -12316,9 +12316,9 @@
       "lastAudited": "2026-04-13T03:29:17Z",
       "result": "issues-fixed",
       "issues": [
-        "sorry 4\u21925",
-        "status axiomatized\u2192formalized",
-        "badge axiom\u2192wip"
+        "sorry 4→5",
+        "status axiomatized→formalized",
+        "badge axiom→wip"
       ]
     },
     "divisibility-by-3-oq-03-oq-02": {
@@ -12326,9 +12326,9 @@
       "lastAudited": "2026-04-13T03:29:17Z",
       "result": "issues-fixed",
       "issues": [
-        "sorry 1\u21920",
-        "status axiomatized\u2192verified",
-        "badge axiom\u2192original"
+        "sorry 1→0",
+        "status axiomatized→verified",
+        "badge axiom→original"
       ]
     },
     "lebesgue-measure-oq-03-oq-01": {
@@ -12336,9 +12336,9 @@
       "lastAudited": "2026-04-13T03:29:17Z",
       "result": "issues-fixed",
       "issues": [
-        "sorry 1\u21920",
-        "status axiomatized\u2192verified",
-        "badge axiom\u2192original"
+        "sorry 1→0",
+        "status axiomatized→verified",
+        "badge axiom→original"
       ]
     },
     "area-of-circle-oq-02-oq-04": {
@@ -12774,10 +12774,12 @@
       "issues": []
     },
     "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-21T12:57:25Z",
-      "result": "clean",
-      "issues": []
+      "auditCount": 2,
+      "lastAudited": "2026-04-21T13:30:00Z",
+      "result": "issues-fixed",
+      "issues": [
+        "lineCount 122→118 (corrected to match actual Lean file)"
+      ]
     },
     "area-of-circle-oq-01-oq-02-oq-03-oq-03": {
       "auditCount": 1,


### PR DESCRIPTION
## Summary

Tracker updates for 8 gallery proofs audited on 2026-04-21, plus one meta.json fix.

**Audit results:**
- `fourier-series-oq-02-oq-01`: clean — 0 sorries, 0 axioms, no True stubs
- `angle-trisection-cos-20-gal-oq-03-oq-01`: clean — 0 sorries, 0 axioms, no True stubs
- `area-of-circle-oq-01-oq-02-oq-03-oq-03`: clean — 0 sorries, 0 axioms, no True stubs
- `arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02`: issues-fixed — lineCount corrected 122→118
- `cayley-hamilton-reduction-oq-01-oq-02`: clean — 0 sorries, 0 axioms, no True stubs
- `godel-first-incompleteness-oq01`: clean — 5 axioms, correctly axiomatized, matching meta
- `godel-second-incompleteness-oq02`: clean — 6 axioms, correctly axiomatized, matching meta
- `law-of-cosines-oq-01-oq-05`: clean — 1 sorry matching meta (formalized status correct)

**Fix:** `arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02/meta.json` lineCount corrected from 122 to 118 (actual `ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02.lean` has 118 lines per the research commit).

## Test plan

- [ ] Verify `audit-tracker.json` is valid JSON
- [ ] Verify `arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02/meta.json` has `lineCount: 118`
- [ ] Verify arithmetic-series tracker entry has `result: issues-fixed` with correct issues note

🤖 Generated with [Claude Code](https://claude.com/claude-code)