### PR TITLE
Research: shapley-folkman Case A proof + gcd-algorithm-oq-04 gallery entry

### DIFF
--- a/proofs/Proofs/ShapleyFolkman.lean
+++ b/proofs/Proofs/ShapleyFolkman.lean
@@ -537,14 +537,54 @@ theorem reduce_excess_by_one [FiniteDimensional ℝ E]
   --   At l_min: b-weight = 0 exactly.
   --
   -- For c'_l > 0: ε₀ from neg_indices only, so a-weight sv_l - ε₀·c'_l may be < 0!
-  -- To avoid this, we need the joint ε. We accept a sorry here for the general case.
+  -- We case-split: Case A (ε₀ ≤ sv(emb l)/c'(l) for all pos l) is fully proved.
+  -- Case B (some pos-index gives smaller ratio) requires joint ε and WF on Carathéodory count.
   --
   -- Claim: new_point i ∈ convexHull ℝ (S i) for all i ∈ t.
   have new_mem_convexHull : ∀ i ∈ t, new_point i ∈ convexHull ℝ (S i) := by
-    sorry -- Requires: (1) for i ∉ range(emb): same as D.point i; (2) for i = emb l with c'_l < 0:
-          -- convex combination with non-negative weights bounded by ε₀ def;
-          -- (3) for i = emb l with c'_l > 0: need joint ε (or positive-index ratio bound).
-          -- Full proof requires choosing ε = min(ε₀, min of pos ratios) and case analysis.
+    -- Case A: ε₀ satisfies all pos-index constraints.
+    -- Case B: some pos l has sv(emb l)/c'(l) < ε₀; needs joint ε (sorry).
+    by_cases hCaseA : ∀ l ∈ pos_indices, ε₀ ≤ sv (emb l) / c' l
+    · intro i hi
+      by_cases h : ∃ l : Fin (d + 1), emb l = i
+      · obtain ⟨l, rfl⟩ := h
+        rw [new_point_emb l]
+        obtain ⟨hav_mem, hbv_mem, hsv_pos, hsv_lt1, hpoint_eq⟩ :=
+          hrepr (emb l) (hemb_mem l)
+        -- Rewrite as convex combination: (sv - ε₀c')•av + (1-sv+ε₀c')•bv
+        have hrw : D.point (emb l) + ε₀ • (c' l • δ l) =
+            (sv (emb l) - ε₀ * c' l) • av (emb l) +
+            (1 - sv (emb l) + ε₀ * c' l) • bv (emb l) := by
+          rw [hpoint_eq]; simp only [δ, smul_sub, smul_smul, add_smul, sub_smul]; ring
+        rw [hrw]
+        have hsum : (sv (emb l) - ε₀ * c' l) + (1 - sv (emb l) + ε₀ * c' l) = 1 := by ring
+        rcases lt_trichotomy (c' l) 0 with hneg | hzero | hpos
+        · -- c'_l < 0: neg-index bound gives b-coeff ≥ 0; a-coeff ≥ 0 since sv + ε₀(-c') > 0
+          have ha_pos : 0 ≤ sv (emb l) - ε₀ * c' l :=
+            by nlinarith [le_of_lt hsv_pos, le_of_lt hε₀_pos, neg_pos.mpr hneg]
+          have hb_pos : 0 ≤ 1 - sv (emb l) + ε₀ * c' l := by
+            have hle := hε₀_le_neg l (Finset.mem_filter.mpr ⟨Finset.mem_univ _, hneg⟩)
+            rw [div_le_iff (neg_pos.mpr hneg)] at hle; nlinarith
+          exact convex_convexHull ℝ (S (emb l))
+            (subset_convexHull ℝ _ hav_mem) hbv_mem ha_pos hb_pos hsum
+        · -- c'_l = 0: expression equals D.point (emb l)
+          have heq : (sv (emb l) - ε₀ * c' l) • av (emb l) +
+              (1 - sv (emb l) + ε₀ * c' l) • bv (emb l) = D.point (emb l) := by
+            rw [hzero, mul_zero, sub_zero, add_zero, hpoint_eq]
+          rw [heq]; exact D.mem_convexHull (emb l) (Finset.mem_of_mem_filter _ (hemb_mem l))
+        · -- c'_l > 0: hCaseA gives ε₀ ≤ sv/c', so a-coeff ≥ 0; b-coeff > 0 since 1-sv > 0
+          have ha_pos : 0 ≤ sv (emb l) - ε₀ * c' l := by
+            have hle := hCaseA l (Finset.mem_filter.mpr ⟨Finset.mem_univ _, hpos⟩)
+            rw [le_div_iff hpos] at hle; linarith
+          have hb_pos : 0 ≤ 1 - sv (emb l) + ε₀ * c' l :=
+            by nlinarith [le_of_lt hε₀_pos, le_of_lt hpos, hsv_lt1]
+          exact convex_convexHull ℝ (S (emb l))
+            (subset_convexHull ℝ _ hav_mem) hbv_mem ha_pos hb_pos hsum
+      · rw [new_point_not_emb i (not_exists.mp h)]
+        exact D.mem_convexHull i hi
+    · -- Case B: some l ∈ pos_indices has sv(emb l)/c'(l) < ε₀.
+      -- Correct approach: joint ε = min(ε₀, min over pos_indices) + WF on Carathéodory count.
+      sorry -- Case B: requires joint ε; full proof by WF induction on Carathéodory vertex count.
   -- Step 6k: new_point is zero outside t.
   have new_zero : ∀ i, i ∉ t → new_point i = 0 := by
     intro i hi

--- a/research/problems/shapley-folkman/knowledge.md
+++ b/research/problems/shapley-folkman/knowledge.md
@@ -224,3 +224,37 @@ The proof proceeds as:
 1. Fix `new_mem_convexHull`: compute joint ε = min over both neg and pos coefficient bounds
 2. Handle Case B separately with WF induction on Carathéodory vertex count
 3. Alternative: submit new_mem_convexHull sorry to Aristotle as HARD sorry
+
+---
+
+## Session 2026-04-21 (Session 6) — Case A of new_mem_convexHull Proved
+
+**Mode**: REVISIT
+**Outcome**: progress — Case A of `new_mem_convexHull` fully proved; Case B still sorry
+
+### What I Did
+- Replaced `new_mem_convexHull` sorry (lines 543-547) with ~50-line case-split proof
+- Introduced `by_cases hCaseA : ∀ l ∈ pos_indices, ε₀ ≤ sv (emb l) / c' l`
+- In Case A (when ε₀ satisfies pos-index bounds too): proved all three sub-cases:
+  - c'_l < 0: a-coeff ≥ 0 via nlinarith; b-coeff ≥ 0 via `hε₀_le_neg` bound; then `convex_convexHull`
+  - c'_l = 0: perturbed point equals `D.point (emb l)` which is already in conv(S)
+  - c'_l > 0: a-coeff ≥ 0 via `hCaseA` hypothesis + `le_div_iff`; b-coeff ≥ 0 via nlinarith + `hsv_lt1`
+- For non-emb indices: `new_point_not_emb` gives same as `D.point i ∈ conv(S i)` via `D.mem_convexHull`
+- Case B: sorry with documented reason: "requires joint ε; full proof by WF induction on Carathéodory vertex count"
+
+### Key Findings
+- Case A proof works cleanly when ε₀ (from neg_indices only) also satisfies all pos_indices bounds
+- `convex_convexHull ℝ (S (emb l))` directly proves convex combinations stay in convexHull
+- The three-way c'_l trichotomy (`lt_trichotomy`) is the right decomposition
+- For c'_l = 0: `hzero` simplifies to exact `D.point` membership — no perturbation
+- Case B architectural insight: pos-index minimizer means new point goes to bv ∈ conv(S) not S;
+  excess count doesn't decrease without WF on Carathéodory vertex count (Starr 1969 full proof)
+
+### Files Modified
+- `proofs/Proofs/ShapleyFolkman.lean`: replaced `new_mem_convexHull` sorry with 50-line case-split
+
+### Next Steps
+1. Prove Case B: define joint ε = min(ε₀, min over pos_indices sv(emb l)/c'(l)), then show
+   WF descent: either Case A kicks in (excess decreases), or pos-index minimizer gives new_point
+   ∈ conv(S) with strictly fewer Carathéodory vertices (Starr 1969)
+2. Submit remaining Case B sorry to Aristotle as HARD sorry

--- a/src/data/proofs/gcd-algorithm-oq-04/annotations.json
+++ b/src/data/proofs/gcd-algorithm-oq-04/annotations.json
@@ -1,0 +1,51 @@
+[
+  {
+    "id": "ann-gcd-oq04-overview",
+    "title": "EuclideanDomain GCD vs GCDMonoid: Two Hierarchies for One Concept",
+    "type": "overview",
+    "startLine": 1,
+    "endLine": 48,
+    "mathContext": "In Lean 4/Mathlib, GCDs arise from two distinct typeclass hierarchies. `EuclideanDomain` provides `EuclideanDomain.gcd` via the Euclidean algorithm — it is computable, algorithmic, and may return negative values. `GCDMonoid` provides `GCDMonoid.gcd` with algebraic normalization guarantees — it returns a canonical representative. The critical structural fact: `EuclideanDomain.gcdMonoid` is intentionally a `def` (not an `instance`) to prevent diamond conflicts in the typeclass system. This means the two GCDs are not automatically related by typeclass resolution — coherence must be proved explicitly.",
+    "significance": "This distinction is a practical source of confusion for Lean 4 users: when computing gcd(6, -9) in ℤ, GCDMonoid.gcd returns 3 (normalized, positive) while EuclideanDomain.gcd may return -3 (raw algorithm output). They are associated but not equal. The proof explains exactly when and why the two GCDs agree, preventing subtle proof errors when mixing the two hierarchies."
+  },
+  {
+    "id": "ann-gcd-axioms",
+    "title": "Part I: GCDMonoid Divisibility Axioms",
+    "type": "theorem",
+    "startLine": 54,
+    "endLine": 89,
+    "mathContext": "Five theorems prove that `EuclideanDomain.gcd` satisfies the GCDMonoid axioms without needing any GCDMonoid instance: (1) `euclidean_gcd_dvd_left`: gcd(a,b) ∣ a; (2) `euclidean_gcd_dvd_right`: gcd(a,b) ∣ b; (3) `euclidean_dvd_gcd`: if d ∣ a and d ∣ b then d ∣ gcd(a,b) (universal property); (4) `euclidean_dvd_gcd_iff`: d ∣ gcd(a,b) ↔ d ∣ a ∧ d ∣ b; (5) `euclidean_gcd_satisfies_gcdMonoid_axioms`: all three GCDMonoid axioms simultaneously. All proofs are direct applications of the corresponding `EuclideanDomain` API (gcd_dvd_left, gcd_dvd_right, dvd_gcd) — the Euclidean algorithm is designed precisely to satisfy these axioms.",
+    "significance": "The GCDMonoid axioms characterize the GCD abstractly: it divides both inputs, and any common divisor divides it. Proving that EuclideanDomain.gcd satisfies these axioms is the algebraic core of the coherence result. The proof is clean because Mathlib's EuclideanDomain API already exposes these divisibility facts — the theorems here are essentially just restatements in GCDMonoid language.",
+    "relatedConcepts": ["EuclideanDomain.gcd_dvd_left", "EuclideanDomain.dvd_gcd", "GCDMonoid axioms", "universal property of GCD"]
+  },
+  {
+    "id": "ann-gcdmonoid-coherence",
+    "title": "Part II: Definitional Coherence via letI",
+    "type": "theorem",
+    "startLine": 91,
+    "endLine": 115,
+    "mathContext": "The key coherence theorem: when `EuclideanDomain.gcdMonoid R` is activated via `letI`, the two GCDs are definitionally equal. The proof of `euclidean_gcd_eq_gcdMonoid_gcd_via_def` is simply `rfl` — no computation needed. This works because `EuclideanDomain.gcdMonoid` defines `GCDMonoid.gcd := EuclideanDomain.gcd` by construction: it creates a `GCDMonoid R` structure where the `gcd` field is literally set to `EuclideanDomain.gcd`. The `gcdMonoid_via_def_dvd_gcd_iff` theorem then derives the universal property of `GCDMonoid.gcd` by rewriting to `EuclideanDomain.gcd` and applying `euclidean_dvd_gcd_iff`.",
+    "significance": "The `letI` pattern is essential here and explains a common Lean 4 pitfall. Without `letI := EuclideanDomain.gcdMonoid R`, typeclass synthesis for `GCDMonoid R` will fail or use a different instance. The `letI` annotation locally injects the def as an instance, scoped to the remainder of the proof or do-block. This is definitional coherence: not merely provably equal, but equal by definition — `rfl` suffices.",
+    "relatedConcepts": ["letI", "definitional equality", "rfl", "EuclideanDomain.gcdMonoid", "typeclass diamonds"]
+  },
+  {
+    "id": "ann-integer-normalization",
+    "title": "Part III: Integer Normalization — Association, Not Equality",
+    "type": "theorem",
+    "startLine": 117,
+    "endLine": 151,
+    "mathContext": "For ℤ, Lean uses a special `GCDMonoid ℤ` instance (not from `EuclideanDomain.gcdMonoid`) that normalizes to non-negative values: `GCDMonoid.gcd a b = ↑(Int.gcd a b)`. But `EuclideanDomain.gcd` in ℤ follows the raw algorithm and can give negative results. The bridge: `Int.natAbs_euclideanDomain_gcd a b : (EuclideanDomain.gcd a b).natAbs = Int.gcd a b`. Since two integers are associated iff they have the same `natAbs` (`Int.associated_iff_natAbs`), we get `Associated (EuclideanDomain.gcd a b) (GCDMonoid.gcd a b)`. Four concrete examples (verified by `native_decide`) illustrate that `Int.gcd` and `GCDMonoid.gcd` agree but differ from `EuclideanDomain.gcd`.",
+    "significance": "Association is the correct notion of 'same up to unit' for commutative rings: a and b are associated iff a = u * b for some unit u. For ℤ, units are ±1, so association means same absolute value. This is the precise sense in which `EuclideanDomain.gcd` and `GCDMonoid.gcd` agree for ℤ: they compute the same mathematical GCD, but one normalizes to positive while the other may be negative. The theorem int_euclidean_gcd_associated_gcdMonoid is the correct, non-trivial statement of coherence for ℤ.",
+    "relatedConcepts": ["Associated", "Int.natAbs", "Int.gcd", "Int.associated_iff_natAbs", "Int.natAbs_euclideanDomain_gcd", "normalization"]
+  },
+  {
+    "id": "ann-type-hierarchy",
+    "title": "Part IV: Type Hierarchy — UFD and Bézout from GCDMonoid",
+    "type": "overview",
+    "startLine": 153,
+    "endLine": 184,
+    "mathContext": "Under `letI := EuclideanDomain.gcdMonoid R`, Lean's typeclass system derives `UniqueFactorizationMonoid R` and `IsBezout R` via `inferInstance`. This demonstrates the downstream algebraic consequences: every Euclidean domain is a UFD (unique factorization monoid) and a Bézout domain (every finitely generated ideal is principal, equivalently, every pair of elements has a GCD that is a linear combination). The type hierarchy is: EuclideanDomain → (via gcdMonoid) → GCDMonoid → UFD and IsBezout.",
+    "significance": "This section shows that the `EuclideanDomain.gcdMonoid` def is not just a technical coherence tool — it is the mechanism by which Lean proves the classical theorem 'every Euclidean domain is a UFD and a Bézout domain.' The `letI` activation is the missing link: once GCDMonoid is activated, the typeclass search finds the paths EuclideanDomain → GCDMonoid → UFD and EuclideanDomain → GCDMonoid → IsBezout automatically.",
+    "relatedConcepts": ["UniqueFactorizationMonoid", "IsBezout", "EuclideanDomain", "algebraic hierarchy", "inferInstance"]
+  }
+]

--- a/src/data/proofs/gcd-algorithm-oq-04/index.ts
+++ b/src/data/proofs/gcd-algorithm-oq-04/index.ts
@@ -1,0 +1,4 @@
+import meta from "./meta.json";
+import annotations from "./annotations.json";
+
+export { meta, annotations };

--- a/src/data/proofs/gcd-algorithm-oq-04/meta.json
+++ b/src/data/proofs/gcd-algorithm-oq-04/meta.json
@@ -1,0 +1,155 @@
+{
+  "id": "gcd-algorithm-oq-04",
+  "title": "EuclideanDomain GCD vs GCDMonoid: Coherence and Normalization",
+  "slug": "gcd-algorithm-oq-04",
+  "description": "Proves that the GCD from `EuclideanDomain` (Euclidean algorithm) and from `GCDMonoid` (normalization-based) are coherent in Lean 4/Mathlib. The key structural fact: `EuclideanDomain.gcdMonoid` is a `def` (not an `instance`) — it must be activated with `letI`. Under this activation, both GCDs are definitionally equal. For concrete types like ℤ, the two GCDs are merely associated (not equal), since GCDMonoid.gcd normalizes to a non-negative value while EuclideanDomain.gcd may be negative.",
+  "meta": {
+    "author": "Lean Genius (formalized in Lean 4)",
+    "date": "2026-04-21",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GcdAlgorithmOQ04.lean",
+    "tags": [
+      "algebra",
+      "gcd",
+      "euclidean-domain",
+      "gcd-monoid",
+      "typeclass-coherence",
+      "type-theory",
+      "open-question"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "0 axioms, 0 sorries. All results fully machine-verified.",
+    "lineCount": 186,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "dateAdded": "2026-04-21",
+    "originalContributions": [
+      "euclidean_gcd_satisfies_gcdMonoid_axioms: explicit proof that EuclideanDomain.gcd satisfies all 3 GCDMonoid axioms",
+      "euclidean_gcd_eq_gcdMonoid_gcd_via_def: definitional equality (rfl) when using EuclideanDomain.gcdMonoid",
+      "gcdMonoid_via_def_dvd_gcd_iff: universal property of GCDMonoid.gcd under the activated def",
+      "int_euclidean_gcd_associated_gcdMonoid: EuclideanDomain.gcd is associated to GCDMonoid.gcd for ℤ",
+      "Four-part structure: GCDMonoid axioms, GCDMonoid instance, Integer normalization, Type hierarchy"
+    ],
+    "mathlib_version": "4.26.0",
+    "prerequisites": [
+      "EuclideanDomain typeclass and Euclidean GCD algorithm",
+      "GCDMonoid typeclass with normalization",
+      "Associated elements and units in commutative rings",
+      "letI for activating non-instance defs"
+    ]
+  },
+  "overview": {
+    "historicalContext": "In Lean 4/Mathlib, GCDs arise from two separate typeclass hierarchies: `EuclideanDomain` (algorithmic, via the Euclidean algorithm) and `GCDMonoid` (algebraic, with normalization). The coherence question — do they agree? — is non-trivial because `EuclideanDomain.gcdMonoid` is intentionally a `def`, not an `instance`, to avoid diamond conflicts. This proof clarifies the exact relationship: definitional equality when `gcdMonoid` is activated, and mere association for concrete types like ℤ.",
+    "keyIdeas": [
+      "EuclideanDomain.gcdMonoid is a def, not an instance — requires explicit letI activation",
+      "Under letI := EuclideanDomain.gcdMonoid R, GCDMonoid.gcd = EuclideanDomain.gcd by rfl",
+      "For ℤ, GCDMonoid.gcd = ↑(Int.gcd) (always ≥ 0); EuclideanDomain.gcd can be negative",
+      "Association bridges: Int.natAbs_euclideanDomain_gcd + Int.associated_iff_natAbs"
+    ],
+    "proofTechnique": "Four-part structure: (I) prove EuclideanDomain.gcd satisfies GCDMonoid axioms via dvd_gcd and gcd_dvd_left/right; (II) activate EuclideanDomain.gcdMonoid with letI, establish definitional equality by rfl; (III) for ℤ, use Int.natAbs_euclideanDomain_gcd and Int.associated_iff_natAbs to prove association; (IV) show the type hierarchy consequences (UFD, Bézout)."
+  },
+  "sections": [
+    {
+      "id": "euclidean-gcd-axioms",
+      "title": "Part I: GCDMonoid Divisibility Axioms",
+      "startLine": 54,
+      "endLine": 89,
+      "summary": "Proves that EuclideanDomain.gcd satisfies all three GCDMonoid axioms without needing a GCDMonoid instance.",
+      "mathContext": "Five theorems: gcd ∣ a, gcd ∣ b, universal property d ∣ a ∧ d ∣ b → d ∣ gcd, biconditional form, and all three axioms together. All proofs are direct applications of EuclideanDomain.gcd_dvd_left, gcd_dvd_right, dvd_gcd."
+    },
+    {
+      "id": "gcdmonoid-instance",
+      "title": "Part II: GCDMonoid Instance from EuclideanDomain",
+      "startLine": 91,
+      "endLine": 115,
+      "summary": "Establishes coherence: when EuclideanDomain.gcdMonoid is activated via letI, the two GCDs are definitionally equal.",
+      "mathContext": "euclidean_gcd_eq_gcdMonoid_gcd_via_def: EuclideanDomain.gcd a b = GCDMonoid.gcd a b by rfl under letI. This works because EuclideanDomain.gcdMonoid defines gcd := EuclideanDomain.gcd."
+    },
+    {
+      "id": "integer-normalization",
+      "title": "Part III: Integer Normalization",
+      "startLine": 117,
+      "endLine": 151,
+      "summary": "For ℤ, EuclideanDomain.gcd and GCDMonoid.gcd are associated (not equal). Verified via Int.natAbs.",
+      "mathContext": "GCDMonoid.gcd for ℤ uses Int.gcd (always ≥ 0). EuclideanDomain.gcd can be negative. Key: (EuclideanDomain.gcd a b).natAbs = Int.gcd a b (Mathlib lemma Int.natAbs_euclideanDomain_gcd). From this, Associated (EuclideanDomain.gcd a b) (GCDMonoid.gcd a b) via Int.associated_iff_natAbs."
+    },
+    {
+      "id": "type-hierarchy",
+      "title": "Part IV: Type Hierarchy",
+      "startLine": 153,
+      "endLine": 184,
+      "summary": "Shows that EuclideanDomain.gcdMonoid enables UniqueFactorizationMonoid and IsBezout as downstream instances.",
+      "mathContext": "Under letI := EuclideanDomain.gcdMonoid R, inferInstance derives both UniqueFactorizationMonoid R and IsBezout R, demonstrating the full algebraic hierarchy consequence."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "gcd-algorithm",
+      "relationship": "extends",
+      "description": "Parent proof: Euclidean algorithm for natural numbers"
+    },
+    {
+      "targetId": "gcd-algorithm-oq-02",
+      "relationship": "related",
+      "description": "Binary GCD (Stein's algorithm) — an alternative algorithm also proved correct"
+    },
+    {
+      "targetId": "binary-gcd",
+      "relationship": "related",
+      "description": "Binary GCD — computable GCD algorithm"
+    }
+  ],
+  "conclusion": {
+    "summary": "EuclideanDomain.gcd and GCDMonoid.gcd are coherent in Lean 4/Mathlib: definitionally equal when EuclideanDomain.gcdMonoid is activated, and merely associated for concrete types like ℤ. The distinction arises from normalization: GCDMonoid normalizes to a canonical representative, while EuclideanDomain.gcd follows the raw algorithm output.",
+    "implications": "This formalization resolves a practical confusion when working with GCDs in Lean 4: why does `GCDMonoid.gcd` and `EuclideanDomain.gcd` sometimes give different results for the same inputs? The answer is normalization. The proof shows that the structural relationship is clean: definitional equality under the explicit gcdMonoid def, with a clear association theorem for concrete types.",
+    "openQuestions": [
+      "Can the normalization map be characterized for polynomial rings over fields?",
+      "Is there a single typeclass that captures both the algorithmic and normalized GCD uniformly?"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Mathlib Community",
+      "title": "Mathlib4: EuclideanDomain",
+      "note": "EuclideanDomain.gcdMonoid definition and Int.natAbs_euclideanDomain_gcd"
+    },
+    {
+      "authors": "Mathlib Community",
+      "title": "Mathlib4: GCDMonoid",
+      "note": "GCDMonoid typeclass with normalization axioms"
+    }
+  ],
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": ["EuclideanDomain"],
+    "namespace": "GcdAlgorithmOQ04",
+    "lineCount": 186,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "path": "Proofs/GcdAlgorithmOQ04.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "euclidean_gcd_satisfies_gcdMonoid_axioms",
+      "type": "core",
+      "description": "EuclideanDomain.gcd satisfies all three GCDMonoid axioms simultaneously",
+      "leanType": "∀ [EuclideanDomain R] [DecidableEq R] (a b : R), EuclideanDomain.gcd a b ∣ a ∧ EuclideanDomain.gcd a b ∣ b ∧ (∀ d : R, d ∣ a → d ∣ b → d ∣ EuclideanDomain.gcd a b)"
+    },
+    {
+      "name": "euclidean_gcd_eq_gcdMonoid_gcd_via_def",
+      "type": "core",
+      "description": "Under EuclideanDomain.gcdMonoid, both GCDs are definitionally equal",
+      "leanType": "∀ [EuclideanDomain R] [DecidableEq R] (a b : R), letI : GCDMonoid R := EuclideanDomain.gcdMonoid R; EuclideanDomain.gcd a b = GCDMonoid.gcd a b"
+    },
+    {
+      "name": "int_euclidean_gcd_associated_gcdMonoid",
+      "type": "core",
+      "description": "For ℤ, EuclideanDomain.gcd and GCDMonoid.gcd are associated",
+      "leanType": "∀ (a b : ℤ), Associated (EuclideanDomain.gcd a b) (GCDMonoid.gcd a b)"
+    }
+  ]
+}

--- a/src/data/research/problems/gcd-algorithm-oq-04.json
+++ b/src/data/research/problems/gcd-algorithm-oq-04.json
@@ -1,8 +1,8 @@
 {
   "slug": "gcd-algorithm-oq-04",
   "title": "Unifying EuclideanDomain GCD with GCDMonoid Normalization",
-  "phase": "NEW",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "fast",
   "problemStatement": {

--- a/src/data/research/problems/shapley-folkman.json
+++ b/src/data/research/problems/shapley-folkman.json
@@ -6,7 +6,7 @@
   "tier": "A",
   "path": "full",
   "knowledge": {
-    "progressSummary": "PROGRESS: 1 sorry remaining in reduce_excess_by_one (new_mem_convexHull). Proof architecture complete: ε perturbation constructed, hemb_inj proved (List.get on nodup list), hD_subset proved (trivial via hemb_mem), hnew_point_av proved (av ∈ S). Only new_mem_convexHull remains — needs joint ε from both neg and pos coefficient indices.",
+    "progressSummary": "PROGRESS: Case A of new_mem_convexHull proved. Case B (pos-index minimizer) still sorry — requires joint ε and WF induction on Carathéodory rank per Starr 1969",
     "insights": [
       "reduce_excess_by_one is the mathematical core — requires: (1) linear dependence of d+1 direction vectors via finrank, (2) perturbation ε construction from boundary distances, (3) verification that new points remain in convex hulls",
       "sum_close_to_convexHull needs convexHull(∑ Sᵢ) = ∑ convexHull(Sᵢ) from Mathlib (check Mathlib.Analysis.Convex.Combination for sum identity)",
@@ -20,7 +20,8 @@
       "The 1-dimensional kernel argument shows c\\u2019 cannot always be chosen to force Case A — both Case A and Case B simultaneously failing is possible when (1-sv0)(1-sv1) > sv0*sv1",
       "hD_subset is trivially true: D.excessIndices subset holds because emb maps INTO D.excessIndices (by hemb_mem), so all perturbed excess indices were already excess",
       "hemb_inj proved using List.nodup_iff_injective_get on D.excessIndices.val.toList (nodup by Finset.nodup_val)",
-      "ε₀ from neg_indices only is insufficient for new_mem_convexHull: need joint min over neg AND pos coefficient bounds for pos-coeff perturbed points to stay in conv(S)"
+      "ε₀ from neg_indices only is insufficient for new_mem_convexHull: need joint min over neg AND pos coefficient bounds for pos-coeff perturbed points to stay in conv(S)",
+      "Case A of new_mem_convexHull proved: when ε₀ satisfies all pos-index bounds, three-way c-trichotomy (neg/zero/pos) covers all cases via convex_convexHull ℝ (S i)"
     ],
     "builtItems": [
       "binary_repr_of_mem_convexHull_not_mem private lemma (ShapleyFolkman.lean:220)",
@@ -31,13 +32,13 @@
       "hemb_inj: injectivity of embedding (List.nodup_iff_injective_get)",
       "hD_subset: D.excessIndices subset proof (trivial via hemb_mem)",
       "hnew_point_av: new_point(emb l_min) = av(emb l_min) ∈ S (algebraic proof)",
-      "ε₀ perturbation construction with neg-coefficient minimum"
+      "ε₀ perturbation construction with neg-coefficient minimum",
+      "Case A proof of new_mem_convexHull via by_cases hCaseA + c-trichotomy (ShapleyFolkman.lean ~50 lines at lines 543-590)"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove new_mem_convexHull: compute joint ε = min(ε_neg, ε_pos) over both neg and pos coefficient indices to keep all weights in [0,1]",
-      "Handle Case B in excess decrease proof: when joint minimizer is from pos_indices, need WF on Caratheodory vertex count",
-      "Submit new_mem_convexHull to Aristotle as HARD sorry"
+      "Prove Case B of new_mem_convexHull: joint ε = min(ε₀, pos-index bounds); WF on Carathéodory vertex count (Starr 1969)",
+      "Submit Case B sorry to Aristotle as HARD sorry"
     ],
     "phase": "ACT"
   },


### PR DESCRIPTION
## Summary

- **shapley-folkman**: Prove Case A of `new_mem_convexHull` in `reduce_excess_by_one`. Uses `by_cases hCaseA` + three-way trichotomy on coefficient sign to show convex hull membership is preserved under perturbation. Case B (pos-index minimizer) still has a sorry requiring Starr 1969 WF descent on Carathéodory rank.
- **gcd-algorithm-oq-04**: New gallery entry for "EuclideanDomain GCD vs GCDMonoid: Coherence and Normalization" — a proof that already existed on main (`GcdAlgorithmOQ04.lean`, 0 sorries, 0 axioms, 10 theorems). Added `meta.json`, `annotations.json`, `index.ts`.

## Mathematical Content

The Shapley-Folkman progress proves that when the perturbation step parameter ε₀ satisfies both negative-coefficient and positive-coefficient ratio bounds (Case A), every perturbed point remains in its respective convex hull. The three cases follow `lt_trichotomy` on c'_l and close via `convex_convexHull ℝ (S i)`.

## Test plan
- [ ] `pnpm build` passes (gallery entry renders)
- [ ] Docker build of `Proofs.ShapleyFolkman` (verify existing sorries compile)
- [ ] Docker build of `Proofs.GcdAlgorithmOQ04` (verify 0 sorries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)