### PR TITLE
Enrich gcd-algorithm-oq-04: fix annotation schema and overview fields

### DIFF
--- a/src/data/proofs/gcd-algorithm-oq-04/annotations.json
+++ b/src/data/proofs/gcd-algorithm-oq-04/annotations.json
@@ -1,51 +1,62 @@
 [
   {
-    "id": "ann-gcd-oq04-overview",
-    "title": "EuclideanDomain GCD vs GCDMonoid: Two Hierarchies for One Concept",
-    "type": "overview",
-    "startLine": 1,
-    "endLine": 48,
-    "mathContext": "In Lean 4/Mathlib, GCDs arise from two distinct typeclass hierarchies. `EuclideanDomain` provides `EuclideanDomain.gcd` via the Euclidean algorithm — it is computable, algorithmic, and may return negative values. `GCDMonoid` provides `GCDMonoid.gcd` with algebraic normalization guarantees — it returns a canonical representative. The critical structural fact: `EuclideanDomain.gcdMonoid` is intentionally a `def` (not an `instance`) to prevent diamond conflicts in the typeclass system. This means the two GCDs are not automatically related by typeclass resolution — coherence must be proved explicitly.",
-    "significance": "This distinction is a practical source of confusion for Lean 4 users: when computing gcd(6, -9) in ℤ, GCDMonoid.gcd returns 3 (normalized, positive) while EuclideanDomain.gcd may return -3 (raw algorithm output). They are associated but not equal. The proof explains exactly when and why the two GCDs agree, preventing subtle proof errors when mixing the two hierarchies."
+    "id": "ann-gcd-oq04-preamble",
+    "proofId": "gcd-algorithm-oq-04",
+    "range": { "startLine": 1, "endLine": 53 },
+    "type": "context",
+    "title": "Two GCD Hierarchies in Lean 4: EuclideanDomain vs GCDMonoid",
+    "content": "The module docstring frames the coherence problem. Lean 4/Mathlib provides GCDs via two typeclass hierarchies: EuclideanDomain (algorithmic, computable) and GCDMonoid (algebraic, normalized). The critical structural fact stated here: EuclideanDomain.gcdMonoid is a def (not an instance), preventing diamond conflicts. For concrete types like ℤ, Lean uses a separate GCDMonoid instance that normalizes to non-negative values, distinct from the raw EuclideanDomain.gcd output. Key Mathlib facts listed: EuclideanDomain.gcdMonoid, Int.natAbs_euclideanDomain_gcd, Int.coe_gcd, Int.associated_iff_natAbs.",
+    "mathContext": "Two GCD sources: $\\text{EuclideanDomain.gcd}$ (Euclidean algorithm, may be negative for $\\mathbb{Z}$) and $\\text{GCDMonoid.gcd}$ (normalized, always non-negative for $\\mathbb{Z}$). Coherence: $\\text{letI} := \\text{EuclideanDomain.gcdMonoid} R \\Rightarrow \\text{GCDMonoid.gcd} = \\text{EuclideanDomain.gcd}$ by $\\text{rfl}$. For $\\mathbb{Z}$: $|\\text{EuclideanDomain.gcd}(a,b)| = \\text{Int.gcd}(a,b) = \\text{GCDMonoid.gcd}(a,b)$.",
+    "significance": "context",
+    "relatedConcepts": ["EuclideanDomain", "GCDMonoid", "typeclass diamonds", "letI", "normalization in commutative rings"],
+    "prerequisites": ["Lean 4 typeclass system", "EuclideanDomain typeclass", "GCDMonoid typeclass", "Mathlib import"]
   },
   {
     "id": "ann-gcd-axioms",
-    "title": "Part I: GCDMonoid Divisibility Axioms",
+    "proofId": "gcd-algorithm-oq-04",
+    "range": { "startLine": 54, "endLine": 89 },
     "type": "theorem",
-    "startLine": 54,
-    "endLine": 89,
-    "mathContext": "Five theorems prove that `EuclideanDomain.gcd` satisfies the GCDMonoid axioms without needing any GCDMonoid instance: (1) `euclidean_gcd_dvd_left`: gcd(a,b) ∣ a; (2) `euclidean_gcd_dvd_right`: gcd(a,b) ∣ b; (3) `euclidean_dvd_gcd`: if d ∣ a and d ∣ b then d ∣ gcd(a,b) (universal property); (4) `euclidean_dvd_gcd_iff`: d ∣ gcd(a,b) ↔ d ∣ a ∧ d ∣ b; (5) `euclidean_gcd_satisfies_gcdMonoid_axioms`: all three GCDMonoid axioms simultaneously. All proofs are direct applications of the corresponding `EuclideanDomain` API (gcd_dvd_left, gcd_dvd_right, dvd_gcd) — the Euclidean algorithm is designed precisely to satisfy these axioms.",
-    "significance": "The GCDMonoid axioms characterize the GCD abstractly: it divides both inputs, and any common divisor divides it. Proving that EuclideanDomain.gcd satisfies these axioms is the algebraic core of the coherence result. The proof is clean because Mathlib's EuclideanDomain API already exposes these divisibility facts — the theorems here are essentially just restatements in GCDMonoid language.",
-    "relatedConcepts": ["EuclideanDomain.gcd_dvd_left", "EuclideanDomain.dvd_gcd", "GCDMonoid axioms", "universal property of GCD"]
+    "title": "Part I: GCDMonoid Divisibility Axioms for EuclideanDomain.gcd",
+    "content": "Five theorems prove that EuclideanDomain.gcd satisfies the GCDMonoid axioms without needing a GCDMonoid instance: euclidean_gcd_dvd_left (gcd ∣ a), euclidean_gcd_dvd_right (gcd ∣ b), euclidean_dvd_gcd (universal property: d ∣ a ∧ d ∣ b → d ∣ gcd), euclidean_dvd_gcd_iff (biconditional form), and euclidean_gcd_satisfies_gcdMonoid_axioms (all three simultaneously). Each proof is a direct application of the corresponding EuclideanDomain API — the Euclidean algorithm is built to satisfy these axioms by construction.",
+    "mathContext": "GCDMonoid axioms: (1) $\\gcd(a,b) \\mid a$; (2) $\\gcd(a,b) \\mid b$; (3) $\\forall d: d \\mid a \\wedge d \\mid b \\Rightarrow d \\mid \\gcd(a,b)$. The universal property characterizes $\\gcd(a,b)$ uniquely up to association. Lean API used: `EuclideanDomain.gcd_dvd_left`, `gcd_dvd_right`, `dvd_gcd`.",
+    "significance": "key",
+    "relatedConcepts": ["EuclideanDomain.gcd_dvd_left", "EuclideanDomain.dvd_gcd", "GCDMonoid axioms", "universal property of GCD", "divisibility in commutative rings"],
+    "prerequisites": ["EuclideanDomain typeclass", "dvd relation in Lean 4", "GCDMonoid axioms"]
   },
   {
     "id": "ann-gcdmonoid-coherence",
-    "title": "Part II: Definitional Coherence via letI",
+    "proofId": "gcd-algorithm-oq-04",
+    "range": { "startLine": 91, "endLine": 115 },
     "type": "theorem",
-    "startLine": 91,
-    "endLine": 115,
-    "mathContext": "The key coherence theorem: when `EuclideanDomain.gcdMonoid R` is activated via `letI`, the two GCDs are definitionally equal. The proof of `euclidean_gcd_eq_gcdMonoid_gcd_via_def` is simply `rfl` — no computation needed. This works because `EuclideanDomain.gcdMonoid` defines `GCDMonoid.gcd := EuclideanDomain.gcd` by construction: it creates a `GCDMonoid R` structure where the `gcd` field is literally set to `EuclideanDomain.gcd`. The `gcdMonoid_via_def_dvd_gcd_iff` theorem then derives the universal property of `GCDMonoid.gcd` by rewriting to `EuclideanDomain.gcd` and applying `euclidean_dvd_gcd_iff`.",
-    "significance": "The `letI` pattern is essential here and explains a common Lean 4 pitfall. Without `letI := EuclideanDomain.gcdMonoid R`, typeclass synthesis for `GCDMonoid R` will fail or use a different instance. The `letI` annotation locally injects the def as an instance, scoped to the remainder of the proof or do-block. This is definitional coherence: not merely provably equal, but equal by definition — `rfl` suffices.",
-    "relatedConcepts": ["letI", "definitional equality", "rfl", "EuclideanDomain.gcdMonoid", "typeclass diamonds"]
+    "title": "Part II: Definitional Coherence via letI",
+    "content": "The key coherence theorem euclidean_gcd_eq_gcdMonoid_gcd_via_def proves that under letI := EuclideanDomain.gcdMonoid R, both GCDs are definitionally equal — the proof is simply rfl. This works because EuclideanDomain.gcdMonoid defines GCDMonoid.gcd := EuclideanDomain.gcd by construction. The companion theorem gcdMonoid_via_def_dvd_gcd_iff derives the universal property of GCDMonoid.gcd under the activated def by rewriting to EuclideanDomain.gcd and applying euclidean_dvd_gcd_iff. The letI annotation is essential: without it, typeclass synthesis would fail or find a different GCDMonoid instance.",
+    "mathContext": "Under $\\texttt{letI} : \\text{GCDMonoid}\\, R := \\text{EuclideanDomain.gcdMonoid}\\, R$: $\\text{EuclideanDomain.gcd}\\, a\\, b = \\text{GCDMonoid.gcd}\\, a\\, b$ by $\\text{rfl}$ (definitional equality). This follows because EuclideanDomain.gcdMonoid constructs a record `\\{\\text{gcd} := \\text{EuclideanDomain.gcd}, \\ldots\\}$, so the field access is definitionally transparent.",
+    "significance": "key",
+    "relatedConcepts": ["letI", "definitional equality", "rfl in Lean 4", "EuclideanDomain.gcdMonoid", "typeclass diamonds", "GCDMonoid instance"],
+    "prerequisites": ["letI syntax in Lean 4", "definitional equality vs propositional equality", "EuclideanDomain.gcdMonoid"]
   },
   {
     "id": "ann-integer-normalization",
-    "title": "Part III: Integer Normalization — Association, Not Equality",
+    "proofId": "gcd-algorithm-oq-04",
+    "range": { "startLine": 117, "endLine": 151 },
     "type": "theorem",
-    "startLine": 117,
-    "endLine": 151,
-    "mathContext": "For ℤ, Lean uses a special `GCDMonoid ℤ` instance (not from `EuclideanDomain.gcdMonoid`) that normalizes to non-negative values: `GCDMonoid.gcd a b = ↑(Int.gcd a b)`. But `EuclideanDomain.gcd` in ℤ follows the raw algorithm and can give negative results. The bridge: `Int.natAbs_euclideanDomain_gcd a b : (EuclideanDomain.gcd a b).natAbs = Int.gcd a b`. Since two integers are associated iff they have the same `natAbs` (`Int.associated_iff_natAbs`), we get `Associated (EuclideanDomain.gcd a b) (GCDMonoid.gcd a b)`. Four concrete examples (verified by `native_decide`) illustrate that `Int.gcd` and `GCDMonoid.gcd` agree but differ from `EuclideanDomain.gcd`.",
-    "significance": "Association is the correct notion of 'same up to unit' for commutative rings: a and b are associated iff a = u * b for some unit u. For ℤ, units are ±1, so association means same absolute value. This is the precise sense in which `EuclideanDomain.gcd` and `GCDMonoid.gcd` agree for ℤ: they compute the same mathematical GCD, but one normalizes to positive while the other may be negative. The theorem int_euclidean_gcd_associated_gcdMonoid is the correct, non-trivial statement of coherence for ℤ.",
-    "relatedConcepts": ["Associated", "Int.natAbs", "Int.gcd", "Int.associated_iff_natAbs", "Int.natAbs_euclideanDomain_gcd", "normalization"]
+    "title": "Part III: Integer Normalization — Association, Not Equality",
+    "content": "For ℤ, the installed GCDMonoid instance uses Int.gcd (always ≥ 0), not EuclideanDomain.gcdMonoid. So GCDMonoid.gcd a b = ↑(Int.gcd a b) ≠ EuclideanDomain.gcd a b in general (the latter can be negative). The bridge theorem int_euclidean_gcd_natAbs uses the Mathlib lemma Int.natAbs_euclideanDomain_gcd. Then int_euclidean_gcd_associated_gcdMonoid uses Int.associated_iff_natAbs (integers are associated iff same natAbs) to conclude Association. Four native_decide examples verify the concrete values gcd(6,-3)=3 and gcd(12,8)=4.",
+    "mathContext": "For $\\mathbb{Z}$: $|\\text{EuclideanDomain.gcd}(a,b)| = \\text{Int.gcd}(a,b) = \\text{GCDMonoid.gcd}(a,b)$. Two integers $x, y \\in \\mathbb{Z}$ are associated iff $\\exists$ unit $u$ (i.e., $u = \\pm 1$) with $x = uy$, equivalently $|x| = |y|$. Mathlib key: `Int.associated_iff_natAbs : Associated a b ↔ a.natAbs = b.natAbs`.",
+    "significance": "key",
+    "relatedConcepts": ["Associated", "Int.natAbs", "Int.gcd", "Int.associated_iff_natAbs", "Int.natAbs_euclideanDomain_gcd", "normalization in ℤ"],
+    "prerequisites": ["Associated elements in commutative rings", "units in ℤ are ±1", "Int.natAbs", "Int.gcd", "native_decide tactic"]
   },
   {
     "id": "ann-type-hierarchy",
-    "title": "Part IV: Type Hierarchy — UFD and Bézout from GCDMonoid",
-    "type": "overview",
-    "startLine": 153,
-    "endLine": 184,
-    "mathContext": "Under `letI := EuclideanDomain.gcdMonoid R`, Lean's typeclass system derives `UniqueFactorizationMonoid R` and `IsBezout R` via `inferInstance`. This demonstrates the downstream algebraic consequences: every Euclidean domain is a UFD (unique factorization monoid) and a Bézout domain (every finitely generated ideal is principal, equivalently, every pair of elements has a GCD that is a linear combination). The type hierarchy is: EuclideanDomain → (via gcdMonoid) → GCDMonoid → UFD and IsBezout.",
-    "significance": "This section shows that the `EuclideanDomain.gcdMonoid` def is not just a technical coherence tool — it is the mechanism by which Lean proves the classical theorem 'every Euclidean domain is a UFD and a Bézout domain.' The `letI` activation is the missing link: once GCDMonoid is activated, the typeclass search finds the paths EuclideanDomain → GCDMonoid → UFD and EuclideanDomain → GCDMonoid → IsBezout automatically.",
-    "relatedConcepts": ["UniqueFactorizationMonoid", "IsBezout", "EuclideanDomain", "algebraic hierarchy", "inferInstance"]
+    "proofId": "gcd-algorithm-oq-04",
+    "range": { "startLine": 153, "endLine": 186 },
+    "type": "insight",
+    "title": "Part IV: Algebraic Hierarchy — EuclideanDomain → UFD and Bézout",
+    "content": "The final section shows downstream algebraic consequences. Under letI := EuclideanDomain.gcdMonoid R, Lean's inferInstance derives both UniqueFactorizationMonoid R and IsBezout R. The type hierarchy is: EuclideanDomain → (via gcdMonoid def) → GCDMonoid → UFD and IsBezout. This demonstrates that EuclideanDomain.gcdMonoid is not just a technical coherence tool — it is the mechanism by which Lean proves the classical theorem 'every Euclidean domain is a UFD and a Bézout domain.'",
+    "mathContext": "Instance chain: EuclideanDomain $R$ → (letI gcdMonoid) → GCDMonoid $R$ → UniqueFactorizationMonoid $R$ and IsBezout $R$. The Bézout property states: for all $a, b \\in R$, there exist $u, v$ with $ua + vb = \\gcd(a,b)$. The UFD property: every element factors uniquely into irreducibles. Both follow from GCDMonoid in Mathlib's algebraic hierarchy.",
+    "significance": "supporting",
+    "relatedConcepts": ["UniqueFactorizationMonoid", "IsBezout", "algebraic hierarchy in Mathlib", "inferInstance", "Bézout's identity"],
+    "prerequisites": ["GCDMonoid typeclass", "UniqueFactorizationMonoid", "IsBezout typeclass", "Lean 4 typeclass inference"]
   }
 ]

--- a/src/data/proofs/gcd-algorithm-oq-04/meta.json
+++ b/src/data/proofs/gcd-algorithm-oq-04/meta.json
@@ -42,15 +42,24 @@
   },
   "overview": {
     "historicalContext": "In Lean 4/Mathlib, GCDs arise from two separate typeclass hierarchies: `EuclideanDomain` (algorithmic, via the Euclidean algorithm) and `GCDMonoid` (algebraic, with normalization). The coherence question — do they agree? — is non-trivial because `EuclideanDomain.gcdMonoid` is intentionally a `def`, not an `instance`, to avoid diamond conflicts. This proof clarifies the exact relationship: definitional equality when `gcdMonoid` is activated, and mere association for concrete types like ℤ.",
-    "keyIdeas": [
-      "EuclideanDomain.gcdMonoid is a def, not an instance — requires explicit letI activation",
-      "Under letI := EuclideanDomain.gcdMonoid R, GCDMonoid.gcd = EuclideanDomain.gcd by rfl",
-      "For ℤ, GCDMonoid.gcd = ↑(Int.gcd) (always ≥ 0); EuclideanDomain.gcd can be negative",
-      "Association bridges: Int.natAbs_euclideanDomain_gcd + Int.associated_iff_natAbs"
+    "problemStatement": "For a type R with [EuclideanDomain R] [DecidableEq R], prove that EuclideanDomain.gcd and GCDMonoid.gcd are coherent: (1) when EuclideanDomain.gcdMonoid is activated via letI, they are definitionally equal; (2) for ℤ (where a different GCDMonoid instance is installed), they are merely associated.",
+    "keyInsights": [
+      "EuclideanDomain.gcdMonoid is a def, not an instance — requires explicit letI activation to avoid diamond conflicts in the typeclass system",
+      "Under letI := EuclideanDomain.gcdMonoid R, GCDMonoid.gcd = EuclideanDomain.gcd by rfl (definitional equality, not just propositional)",
+      "For ℤ, GCDMonoid.gcd = ↑(Int.gcd) (always ≥ 0); EuclideanDomain.gcd can be negative — they are associated but not equal",
+      "Association bridges the gap: Int.natAbs_euclideanDomain_gcd + Int.associated_iff_natAbs establish that both GCDs represent the same mathematical GCD up to sign",
+      "The algebraic hierarchy EuclideanDomain → GCDMonoid → UFD + IsBezout shows why the gcdMonoid def is mathematically important, not just a technical artifact"
     ],
-    "proofTechnique": "Four-part structure: (I) prove EuclideanDomain.gcd satisfies GCDMonoid axioms via dvd_gcd and gcd_dvd_left/right; (II) activate EuclideanDomain.gcdMonoid with letI, establish definitional equality by rfl; (III) for ℤ, use Int.natAbs_euclideanDomain_gcd and Int.associated_iff_natAbs to prove association; (IV) show the type hierarchy consequences (UFD, Bézout)."
+    "proofStrategy": "Four-part structure: (I) prove EuclideanDomain.gcd satisfies GCDMonoid axioms via dvd_gcd and gcd_dvd_left/right; (II) activate EuclideanDomain.gcdMonoid with letI, establish definitional equality by rfl; (III) for ℤ, use Int.natAbs_euclideanDomain_gcd and Int.associated_iff_natAbs to prove association; (IV) show the type hierarchy consequences (UFD, Bézout)."
   },
   "sections": [
+    {
+      "id": "preamble",
+      "title": "Module Overview: Two GCD Hierarchies",
+      "startLine": 1,
+      "endLine": 53,
+      "summary": "Module docstring explaining the two GCD hierarchies (EuclideanDomain vs GCDMonoid), the critical structural fact that EuclideanDomain.gcdMonoid is a def not an instance, and the coherence question. Lists key Mathlib facts. Imports Mathlib and opens EuclideanDomain namespace."
+    },
     {
       "id": "euclidean-gcd-axioms",
       "title": "Part I: GCDMonoid Divisibility Axioms",


### PR DESCRIPTION
Enrichment pass for gcd-algorithm-oq-04 (EuclideanDomain GCD vs GCDMonoid: Coherence and Normalization).

## Changes

**Annotation schema fixes (all 4 annotations):**
- Added missing `proofId` field
- Changed flat `startLine/endLine` to nested `range: {startLine, endLine}` (correct schema)
- Added `content` field (was using `significance` field as content)
- Added `prerequisites` to all annotations
- Fixed type names: `overview` → `context` or `insight` as appropriate

**New annotation:**
- Added preamble annotation (lines 1-53) covering module docstring and structural overview

**meta.json fixes:**
- Renamed `overview.keyIdeas` → `overview.keyInsights` (standard field name)
- Renamed `overview.proofTechnique` → `overview.proofStrategy` (standard field name)
- Added `overview.problemStatement` (was missing)
- Added 5th keyInsight about algebraic hierarchy

**New section:**
- Added preamble section (lines 1-53) to sections array

**Axiom integrity:** No changes. 0 axioms, 0 sorries, status: verified — all correct.