### PR TITLE
chore: sync research listings and data

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -16264,11 +16264,11 @@
     },
     {
       "slug": "szemeredi-hypergraph-core-oq-01-incomplete-01",
-      "phase": "NEW",
+      "phase": "OBSERVE",
       "path": "full",
       "started": "2026-04-13T22:43:37.319Z",
       "status": "active",
-      "lastUpdate": "2026-04-13T22:43:37.319Z"
+      "lastUpdate": "2026-04-21T14:18:44.788Z"
     },
     {
       "slug": "taylor-sincos-convergence-oq-02-incomplete-01",
@@ -16512,11 +16512,11 @@
     },
     {
       "slug": "birthday-problem-oq-03-oq-01-oq-02-oq-01",
-      "phase": "NEW",
+      "phase": "OBSERVE",
       "path": "full",
       "started": "2026-04-14T17:49:44.227Z",
       "status": "active",
-      "lastUpdate": "2026-04-14T17:49:44.227Z"
+      "lastUpdate": "2026-04-21T14:18:44.788Z"
     },
     {
       "slug": "borsuk-ulam-oq-04-oq-03",
@@ -16706,19 +16706,19 @@
     },
     {
       "slug": "ballot-problem-oq-03-oq-01-oq-02",
-      "phase": "NEW",
+      "phase": "OBSERVE",
       "path": "full",
       "started": "2026-04-21T13:15:44.124Z",
       "status": "active",
-      "lastUpdate": "2026-04-21T13:15:44.124Z"
+      "lastUpdate": "2026-04-21T14:18:44.789Z"
     },
     {
       "slug": "angle-trisection-cos-20-gal-oq-01-oq-01",
-      "phase": "NEW",
+      "phase": "OBSERVE",
       "path": "full",
       "started": "2026-04-21T13:15:44.253Z",
       "status": "active",
-      "lastUpdate": "2026-04-21T13:15:44.253Z"
+      "lastUpdate": "2026-04-21T14:18:44.789Z"
     },
     {
       "slug": "area-of-circle-oq-01-oq-02-oq-03-oq-03",
@@ -16731,19 +16731,86 @@
     },
     {
       "slug": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "fast",
       "started": "2026-04-21T13:15:44.253Z",
-      "status": "active",
-      "lastUpdate": "2026-04-21T13:15:44.278Z"
+      "status": "graduated",
+      "lastUpdate": "2026-04-21T14:18:44.764Z",
+      "completed": "2026-04-21T14:18:44.764Z"
     },
     {
       "slug": "borsuk-ulam-oq-03-oq-04",
-      "phase": "NEW",
+      "phase": "OBSERVE",
       "path": "full",
       "started": "2026-04-21T13:15:44.253Z",
       "status": "active",
-      "lastUpdate": "2026-04-21T13:15:44.253Z"
+      "lastUpdate": "2026-04-21T14:18:44.789Z"
+    },
+    {
+      "slug": "dirichlets-theorem-oq-02-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-21T14:18:44.612Z",
+      "status": "active",
+      "lastUpdate": "2026-04-21T14:18:44.612Z"
+    },
+    {
+      "slug": "erdos-100-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-21T14:18:44.644Z",
+      "status": "active",
+      "lastUpdate": "2026-04-21T14:18:44.644Z"
+    },
+    {
+      "slug": "law-of-sines-oq-06",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-21T14:18:44.702Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-21T14:18:44.702Z",
+      "completed": "2026-04-21T14:18:44.702Z"
+    },
+    {
+      "slug": "shannon-channel-coding-oq-04-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-21T14:18:44.704Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-21T14:18:44.704Z",
+      "completed": "2026-04-21T14:18:44.704Z"
+    },
+    {
+      "slug": "divisibility-rules-oq-01-oq-01",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-21T14:18:44.765Z",
+      "status": "active",
+      "lastUpdate": "2026-04-21T14:18:44.765Z"
+    },
+    {
+      "slug": "erdos-848-oq-01",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-21T14:18:44.766Z",
+      "status": "active",
+      "lastUpdate": "2026-04-21T14:18:44.766Z"
+    },
+    {
+      "slug": "divisibility-by-three-oq-01",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-21T14:18:44.771Z",
+      "status": "active",
+      "lastUpdate": "2026-04-21T14:18:44.771Z"
+    },
+    {
+      "slug": "divisibility-by-three-oq-02",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-21T14:18:44.771Z",
+      "status": "active",
+      "lastUpdate": "2026-04-21T14:18:44.771Z"
     }
   ],
   "config": {


### PR DESCRIPTION
## Summary
- Sync research-listings.json: 63 new, 773 updated listings (4248 total iterations)
- Add new research problem files (angle-trisection, binomial-theorem, bounded-prime-gaps, erdos variants)
- Update iteration counts for arithmetic-series and gcd-algorithm families
- Update audit tracker and daemon state

Automated sync by deployer agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)