### PR TITLE
Seeker: select erdos-27 — Almost Covering Systems (FFKPY disproof, 12 sorries)

### DIFF
--- a/research/problems/erdos-27/knowledge.md
+++ b/research/problems/erdos-27/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: erdos-27
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/erdos-27/literature/README.md
+++ b/research/problems/erdos-27/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for erdos-27
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/erdos-27/problem.md
+++ b/research/problems/erdos-27/problem.md
@@ -1,0 +1,132 @@
+# Problem: Erdős #27 — Almost Covering Systems
+
+**Slug**: erdos-27
+**Created**: 2026-04-21
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+An **ε-almost covering system** is a finite set of congruences $a_i \pmod{n_i}$ with distinct moduli $n_1 < \cdots < n_k$ such that the density of integers satisfying none of the congruences is at most $\varepsilon$.
+
+**Erdős #27**: Does there exist $C > 1$ such that for every $\varepsilon > 0$ and $N \geq 1$, there is an $\varepsilon$-almost covering system with all moduli in $[N, CN]$?
+
+**Answer: NO** — disproved by Filaseta-Ford-Konyagin-Pomerance-Yu (FFKPY). Specifically, for $C \leq N^{\alpha(N)}$ where $\alpha(N) = \frac{\log\log\log N}{4\log\log N}$, the uncovered density is at least $(1 - o(1)) \cdot \prod(1 - 1/n_i)$, which cannot be made arbitrarily small.
+
+### Plain Language
+
+Can we cover almost all integers using congruences whose moduli are all close together (within a constant factor $C$)? The answer is no: for any fixed $C$, if moduli are restricted to $[N, CN]$, the "coverage" cannot approach 100%.
+
+### Why This Matters
+
+- Covers the theory of dense covering systems and their limitations
+- Connects to sieve theory (Brun, Selberg), density of arithmetic progressions
+- The disproof by FFKPY uses the multiplicative structure of intervals and logarithmic density arguments
+- The Lean formalization provides a machine-checked account of this negative result
+
+## Known Results
+
+### What's Already Proven (in Lean)
+
+- `Erdos27Problem.lean` (Proofs/Stubs/): Basic definitions — `Congruence`, `CongruenceSystem`, `uncoveredDensity`, `BoundedModuliSystem`, `AlmostCovering`
+- Aristotle companion `Erdos27Aristotle.lean` with 5 routine lemma targets for automation
+- Gallery entry at `src/data/proofs/erdos-27/` with 12 sorries remaining
+
+### What's Still Open in the Lean File
+
+- 12 sorries in `Erdos27Problem.lean` covering:
+  - Density calculation lemmas
+  - Product convergence bounds
+  - The core FFKPY lower bound argument
+  - Final impossibility theorem
+
+### Our Goal
+
+Eliminate or reduce the 12 sorries in `Erdos27Problem.lean`. Priority:
+1. **Aristotle targets**: 5 routine lemmas (structural/algebraic) — submit to Aristotle
+2. **Density lemmas**: Measure-theoretic density calculations
+3. **Product bounds**: $\prod(1 - 1/n)$ convergence/divergence estimates
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `erdos-27` (gallery) | Parent proof with 12 sorries | Congruence systems, density |
+| `bertrands-postulate` | Prime distribution bounds | Elementary number theory |
+| `chebyshev-bounds` | Log density estimates | Analytic number theory |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Aristotle-first**: Submit the 5 Aristotle companion lemmas for automated proof search. These are routine structural lemmas that Aristotle can handle.
+   - Why it might work: Already identified as Aristotle targets
+   - Risk: Some may require non-trivial algebraic manipulation
+
+2. **Mathlib density tools**: Use `MeasureTheory.Measure.addHaar` and `Nat.density` for uncovered density calculations.
+   - Why it might work: Mathlib has strong measure theory support
+   - Risk: Natural density is non-trivial to formalize; may need Banach density or asymptotic density
+
+3. **Product convergence**: For $\prod(1 - 1/n_i)$ with moduli in $[N, CN]$, use Mathlib's `Finprod` and logarithm estimates.
+   - Why it might work: Standard analytic estimates exist in Mathlib
+   - Risk: The FFKPY argument requires careful logarithmic bookkeeping
+
+### Key Difficulties
+
+- `uncoveredDensity` requires formalization of natural density (or asymptotic density) — Mathlib may not have a ready-made definition
+- The FFKPY lower bound uses multiplicative function estimates — requires `ArithmeticFunction` from Mathlib
+- 12 sorries may have interdependencies making partial progress harder
+
+### What Would a Proof Need?
+
+- Key lemma 1: `uncoveredDensity_prod_formula`: $d(\overline{S}) = \prod_i (1 - 1/n_i)$ for pairwise coprime moduli
+- Key lemma 2: `log_sum_bounded`: $\sum_{n \in [N, CN]} 1/n$ is bounded — $O(\log C)$
+- Key lemma 3: `almost_covering_impossible`: The core impossibility using the product bound
+- Technical: Natural density definition compatible with Mathlib's Filter/Measure infrastructure
+
+## Tractability Assessment
+
+**Difficulty**: Medium-High
+
+**Justification**:
+- The problem is SOLVED mathematically — no open conjecture to worry about
+- The Lean code structure exists with clear sorry targets
+- But the density formalization is non-trivial
+- Aristotle can handle 5/12 sorries if they are structural
+- Core FFKPY sorries (4-5) require analytic number theory machinery
+
+**Priority**: Check Aristotle companion first, then tackle density lemmas.
+
+## References
+
+### Papers
+- Filaseta, Ford, Konyagin, Pomerance, Yu (2007) — *Sieving by large integers* — core FFKPY result
+- Erdős (1950) — original problem statement
+
+### Mathlib
+- `Mathlib.Analysis.Asymptotics.Asymptotics` — asymptotic notation
+- `Mathlib.Analysis.SpecialFunctions.Log.Basic` — logarithm estimates
+- `Mathlib.Data.Int.ModEq` — congruences
+- `Mathlib.MeasureTheory.Measure.Haar.Basic` — Haar measure (density)
+
+## Metadata
+
+```yaml
+tags:
+  - number-theory
+  - covering-systems
+  - density
+  - erdos-problems
+related_proofs:
+  - erdos-27
+  - bertrands-postulate
+  - chebyshev-bounds
+difficulty: medium-high
+source: gallery-gap
+created: 2026-04-21
+```
+
+**Significance**: 7/10
+**Tractability**: 5/10

--- a/research/problems/erdos-27/state.md
+++ b/research/problems/erdos-27/state.md
@@ -1,0 +1,25 @@
+# Research State: erdos-27
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-04-21T07:22:44-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/registry.json
+++ b/research/registry.json
@@ -16356,11 +16356,11 @@
     },
     {
       "slug": "erdos-27",
-      "phase": "NEW",
+      "phase": "OBSERVE",
       "path": "full",
       "started": "2026-04-13T22:43:37.491Z",
       "status": "active",
-      "lastUpdate": "2026-04-13T22:43:37.491Z"
+      "lastUpdate": "2026-04-21T07:22:44-07:00"
     },
     {
       "slug": "erdos-35",

--- a/src/data/research/problems/erdos-27.json
+++ b/src/data/research/problems/erdos-27.json
@@ -1,0 +1,106 @@
+{
+  "slug": "erdos-27",
+  "title": "Erdős #27: Almost Covering Systems",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "Does there exist C > 1 s.t. ∀ ε > 0, N ≥ 1, ∃ ε-almost covering system with all moduli in [N, CN]? Answer: NO (FFKPY). For C ≤ N^{α(N)}, α(N) = logloglog N / 4loglog N, uncovered density ≥ (1-o(1))·∏(1-1/nᵢ).",
+    "plain": "Can we cover almost all integers using congruences whose moduli are all close together (within factor C)? No: for any fixed C, the coverage cannot approach 100% when moduli are restricted to [N, CN].",
+    "whyMatters": [
+      "Covers the theory of dense covering systems and their limitations — disproved by FFKPY",
+      "Connects to sieve theory (Brun, Selberg) and natural density of arithmetic progressions",
+      "12 sorries in existing Lean file represent the FFKPY disproof, including 5 Aristotle-ready targets"
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Erdos27Problem.lean: basic definitions — Congruence, CongruenceSystem, uncoveredDensity, BoundedModuliSystem, AlmostCovering (Proofs/Stubs/Erdos27Problem.lean)",
+      "Erdos27Aristotle.lean: 5 routine lemma targets for Aristotle automation",
+      "Gallery entry at src/data/proofs/erdos-27/ (formalized status, 12 sorries remaining)"
+    ],
+    "open": [
+      "12 sorries in Erdos27Problem.lean: density lemmas, product convergence bounds, core FFKPY lower bound",
+      "uncoveredDensity formalization (natural density vs measure-theoretic density)",
+      "∏(1-1/nᵢ) product bound for moduli in [N, CN]"
+    ],
+    "goal": "Eliminate or reduce 12 sorries. Priority: (1) submit 5 Aristotle targets; (2) density lemmas using Mathlib MeasureTheory; (3) product convergence estimates via logarithmic bounds."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-04-21T07:22:44-07:00",
+    "iteration": 1,
+    "focus": "Read Erdos27Problem.lean to identify exact sorry locations and their mathematical content.",
+    "blockers": [],
+    "nextAction": "Read Proofs/Stubs/Erdos27Problem.lean and Proofs/Stubs/Erdos27Aristotle.lean to map sorry targets.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Read Erdos27Problem.lean to map 12 sorry locations",
+      "Check which 5 are Aristotle-ready targets",
+      "Survey Mathlib for natural density and ArithmeticFunction support"
+    ],
+    "markdown": "# Knowledge Base: erdos-27\n\nInsights accumulated during research on Erdős #27: Almost Covering Systems.\n\n---\n\n## Problem Understanding\n\nProblem SOLVED (NO) by FFKPY. Lean formalization has 12 sorries in Erdos27Problem.lean.\nAristo companion (Erdos27Aristotle.lean) has 5 routine targets.\n\n---\n\n## Insights\n\n[To be filled during OBSERVE/ORIENT phases]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "number-theory",
+    "covering-systems",
+    "density",
+    "erdos-problems",
+    "sorry-reduction"
+  ],
+  "relatedProofs": [
+    "erdos-27",
+    "bertrands-postulate",
+    "chebyshev-bounds"
+  ],
+  "references": {
+    "papers": [
+      "Filaseta-Ford-Konyagin-Pomerance-Yu (2007) — Sieving by large integers — core FFKPY result"
+    ],
+    "urls": [
+      "https://erdosproblems.com/27"
+    ],
+    "mathlib": [
+      "Mathlib.Data.Int.ModEq — congruences",
+      "Mathlib.Analysis.Asymptotics.Asymptotics — asymptotic bounds",
+      "Mathlib.Analysis.SpecialFunctions.Log.Basic — logarithm estimates"
+    ]
+  },
+  "started": "2026-04-21T07:22:44-07:00",
+  "lastUpdate": "2026-04-21T07:22:44-07:00",
+  "leanFiles": [
+    {
+      "path": "Proofs/Stubs/Erdos27Problem.lean",
+      "filename": "Erdos27Problem.lean",
+      "lineCount": null,
+      "theoremCount": null,
+      "axiomCount": 0,
+      "defCount": null,
+      "sorryCount": 12,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Stubs/Erdos27Problem.lean"
+    },
+    {
+      "path": "Proofs/Stubs/Erdos27Aristotle.lean",
+      "filename": "Erdos27Aristotle.lean",
+      "lineCount": null,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 5,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Stubs/Erdos27Aristotle.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Problem Selection: Erdős #27

**Selected**: \`erdos-27\` — Almost Covering Systems  
**Tier**: B | **Significance**: 7/10 | **Tractability**: 5/10 | **Knowledge**: EMPTY  
**Domain**: Number theory (good diversity from recent probability/combinatorics)

## Problem Summary

Does there exist C > 1 such that ε-almost covering systems exist with moduli in [N, CN] for all ε, N? **Answer: NO** (Filaseta-Ford-Konyagin-Pomerance-Yu 2007).

The Lean formalization (Erdos27Problem.lean) has 12 sorries to resolve, plus an Aristotle companion with 5 routine lemma targets for automation.

## Rationale

- **Concrete work**: 12 sorries in existing Lean file — clear improvement path
- **Known answer**: FFKPY disproof gives the researcher a target without conjecture uncertainty
- **Aristotle-ready**: 5 companion lemmas ready for automated proof search
- **Domain diversity**: Number theory, vs recent selections in probability/combinatorics/topology
- **Quality gate**: Rejected borsuk-ulam-oq-04-oq-03 (infinity-topos section problem) as too abstract

## Pool Status After Selection

| Status | Count |
|--------|-------|
| Available | 58 |
| In Progress | 1254 |
| Completed | 591 |
| Graduated | 3 |
| Blocked | 2 |

Pool replenished from 12 → 58 available by correcting 6 incorrectly classified DB entries.

## Files Added

- \`src/data/research/problems/erdos-27.json\` — selection record
- \`research/problems/erdos-27/problem.md\` — full problem statement with FFKPY context
- \`research/problems/erdos-27/state.md\` — initial OBSERVE phase state
- \`research/problems/erdos-27/knowledge.md\` — empty knowledge base

🤖 Generated with [Claude Code](https://claude.com/claude-code)