### PR TITLE
Fix: update lineCount for shapley-folkman (755 → 795)

### DIFF
--- a/src/data/proofs/shapley-folkman/meta.json
+++ b/src/data/proofs/shapley-folkman/meta.json
@@ -61,7 +61,7 @@
       "Caratheodory's theorem (points in convex hull need at most d+1 vertices)",
       "Affine independence and dimension"
     ],
-    "lineCount": 755,
+    "lineCount": 795,
     "mathlib_version": "4.26.0",
     "leanFile": {
       "imports": [
@@ -201,7 +201,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 755,
+    "lineCount": 795,
     "structureCount": 1,
     "axiomCount": 0,
     "theoremCount": 8,


### PR DESCRIPTION
## Fix

Stale `lineCount` in `shapley-folkman` gallery metadata.

## Evidence

**Before**:
- `meta.lineCount`: 755
- `leanFile.lineCount`: 755

**After**:
- `meta.lineCount`: 795
- `leanFile.lineCount`: 795

`wc -l proofs/Proofs/ShapleyFolkman.lean` → 795. The file grew by 40 lines since the gallery entry was last recorded (new theorems `sum_close_to_convexHull` and `repeated_sum_nearly_convex` were added). The `theoremCount: 8` is already correct.

---
Automated fix by lean-mechanic agent.