### PR TITLE
Enrich q-Vandermonde Identity: add annotations and index.ts

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-04-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-04-oq-02-oq-01/annotations.json
@@ -1,0 +1,208 @@
+[
+  {
+    "id": "ann-qvand-docblock",
+    "proofId": "binomial-theorem-oq-04-oq-02-oq-01",
+    "range": { "startLine": 1, "endLine": 20 },
+    "type": "context",
+    "title": "Framing: q-Analogs of Classical Combinatorics",
+    "content": "The module docblock frames the problem as a q-analog question: given that classical Vandermonde's identity $\\binom{m+n}{r} = \\sum_k \\binom{m}{k}\\binom{n}{r-k}$ holds, can we replace classical binomials with Gaussian binomials and recover a deformed identity? The answer is yes, at the cost of an extra $q$-weight $q^{k(n+k-r)}$ recording positional information. At $q=1$ all weights collapse to 1 and we recover the classical identity, confirming the q-analog philosophy: deformation should be invisible at the specialization point.",
+    "mathContext": "The q-Vandermonde identity: $\\binom{m+n}{r}_q = \\sum_{k=0}^{r} \\binom{m}{k}_q \\cdot \\binom{n}{r-k}_q \\cdot q^{k(n+k-r)}$. The combinatorial interpretation: $\\binom{n}{k}_q$ counts $k$-dimensional subspaces of $\\mathbb{F}_q^n$; the $q$-weight encodes the relative position of the subspaces chosen from each factor.",
+    "significance": "context",
+    "relatedConcepts": [
+      "q-analog",
+      "Gaussian binomial coefficient",
+      "Vandermonde identity",
+      "q-deformation"
+    ],
+    "prerequisites": [
+      "classical Vandermonde identity",
+      "combinatorics of subspaces over finite fields"
+    ]
+  },
+  {
+    "id": "ann-qvand-imports",
+    "proofId": "binomial-theorem-oq-04-oq-02-oq-01",
+    "range": { "startLine": 22, "endLine": 33 },
+    "type": "technique",
+    "title": "Infrastructure: CommRing with BigOperators",
+    "content": "The four Mathlib imports provide exactly the necessary infrastructure: `BigOperators` enables the $\\sum$ notation over `Finset`, `Ring.Basic` gives the `CommRing` typeclass with distributivity, `Choose.Basic` provides `Nat.choose_succ_succ` (Pascal's rule) for the classical limit proof, and `Tactic` enables `omega`, `ring`, `simp`, and `induction` automation. Working over a general `CommRing R` rather than $\\mathbb{Z}$ or $\\mathbb{Q}$ makes the results immediately applicable to polynomial rings, $p$-adic integers, and quantum group algebras.",
+    "mathContext": "The variable `{R : Type*} [CommRing R]` abstracts over all commutative rings simultaneously. Since $\\binom{n}{k}_q \\in \\mathbb{Z}[q]$ (the coefficients are non-negative integers), the results hold when $q$ is any element of any commutative ring.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "commutative ring",
+      "BigOperators",
+      "Finset",
+      "typeclass polymorphism"
+    ],
+    "prerequisites": [
+      "abstract algebra",
+      "Lean 4 typeclasses",
+      "Mathlib BigOperators"
+    ]
+  },
+  {
+    "id": "ann-qvand-definition",
+    "proofId": "binomial-theorem-oq-04-oq-02-oq-01",
+    "range": { "startLine": 39, "endLine": 51 },
+    "type": "definition",
+    "title": "gaussBinom: Recursive Definition via q-Pascal Rule",
+    "content": "The Gaussian binomial $\\binom{n}{k}_q$ is defined by structural recursion on the pair $(n, k)$. The three cases are: (1) $\\binom{n}{0}_q = 1$ — there is exactly one 0-dimensional subspace (the zero subspace) in any $\\mathbb{F}_q^n$; (2) $\\binom{0}{k+1}_q = 0$ — no $(k+1)$-dimensional subspace of $\\{0\\}$; (3) the q-Pascal rule $\\binom{n+1}{k+1}_q = q^{k+1}\\binom{n}{k+1}_q + \\binom{n}{k}_q$, which counts $k$-spaces in $\\mathbb{F}_q^{n+1}$ by conditioning on whether the last standard basis vector $e_{n+1}$ is in the chosen subspace. The `noncomputable` annotation is required because the function takes values in a general ring $R$ which may not have decidable equality.",
+    "mathContext": "The q-Pascal rule (P1 form): $\\binom{n+1}{k+1}_q = q^{k+1}\\binom{n}{k+1}_q + \\binom{n}{k}_q$. Geometrically: subspaces of $\\mathbb{F}_q^{n+1}$ are either those that project to $k$-spaces in the first $n$ coordinates (weighted by $q^{k+1}$ for the position of the new direction), or lifts of $(k-1)$-spaces supplemented by $e_{n+1}$. This gives $\\binom{n+1}{k+1}_q = q^k \\binom{n}{k}_q + \\binom{n}{k-1}_q$ in Gaussian notation (after index shift).",
+    "significance": "key",
+    "relatedConcepts": [
+      "q-Pascal recurrence",
+      "structural recursion",
+      "subspace counting",
+      "Gaussian binomial coefficient",
+      "noncomputable"
+    ],
+    "prerequisites": [
+      "linear algebra over finite fields",
+      "Lean 4 structural recursion",
+      "commutative ring"
+    ]
+  },
+  {
+    "id": "ann-qvand-base-cases",
+    "proofId": "binomial-theorem-oq-04-oq-02-oq-01",
+    "range": { "startLine": 57, "endLine": 67 },
+    "type": "technique",
+    "title": "Simp Lemmas for Base Cases and Recurrence",
+    "content": "The three `@[simp]`-tagged base case lemmas serve double duty: they are proved by `rfl` (definitional equality) and also annotate the definition for the Lean `simp` tactic so that downstream proofs can unfold the recurrence automatically. The pattern `cases n <;> rfl` for `gaussBinom_zero_right` handles both `n = 0` and `n + 1` in one shot. Tagging `gaussBinom_succ_succ` as a named lemma — even though it is definitional — makes it available for `rw` in the inductive steps without manually unfolding the definition.",
+    "mathContext": "$\\binom{n}{0}_q = 1$ for all $n \\geq 0$; $\\binom{0}{k+1}_q = 0$ for all $k \\geq 0$; the recurrence $\\binom{n+1}{k+1}_q = q^{k+1}\\binom{n}{k+1}_q + \\binom{n}{k}_q$ as a named equation.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "simp lemma",
+      "definitional equality",
+      "rfl",
+      "tactic automation"
+    ],
+    "prerequisites": [
+      "Lean 4 `@[simp]` attribute",
+      "pattern matching"
+    ]
+  },
+  {
+    "id": "ann-qvand-vanishing",
+    "proofId": "binomial-theorem-oq-04-oq-02-oq-01",
+    "range": { "startLine": 69, "endLine": 78 },
+    "type": "concept",
+    "title": "Vanishing Lemma: [n choose k]_q = 0 for k > n",
+    "content": "This is the q-analog of the classical fact $\\binom{n}{k} = 0$ for $k > n$. The proof is by induction on $n$: in the base case ($n = 0$), any $k \\geq 1$ satisfies $\\binom{0}{k}_q = 0$ by definition. In the inductive step, both arguments to the q-Pascal rule satisfy $n < k$ and $n < k+1$ (since $k+1 > n+1$ implies $k \\geq n+1 > n$), so both recursive calls vanish by the induction hypothesis. The `obtain` pattern extracts a predecessor $m$ from the hypothesis $0 < k$ (since $n < k$ implies $k \\geq 1$). The `omega` tactic handles the linear arithmetic automatically.",
+    "mathContext": "Claim: $k > n \\implies \\binom{n}{k}_q = 0$. This is essential for the q-Vandermonde identity: the Finset.range sum includes terms $k > r$ or with $r - k > n$, and the vanishing lemma ensures these contribute zero, so the effective sum is over $0 \\leq k \\leq \\min(r, m)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "vanishing binomial",
+      "Finset.range truncation",
+      "induction on natural numbers",
+      "omega tactic"
+    ],
+    "prerequisites": [
+      "structural induction on ℕ",
+      "linear arithmetic"
+    ]
+  },
+  {
+    "id": "ann-qvand-self",
+    "proofId": "binomial-theorem-oq-04-oq-02-oq-01",
+    "range": { "startLine": 79, "endLine": 84 },
+    "type": "concept",
+    "title": "Self-Choice: [n choose n]_q = 1",
+    "content": "The fact $\\binom{n}{n}_q = 1$ reflects that there is exactly one $n$-dimensional subspace of $\\mathbb{F}_q^n$: the whole space itself. The proof proceeds by induction: the q-Pascal rule gives $\\binom{n+1}{n+1}_q = q^{n+1}\\binom{n}{n+1}_q + \\binom{n}{n}_q$. The first term vanishes (since $n+1 > n$) by `gaussBinom_eq_zero_of_lt`, and the second term equals $1$ by the induction hypothesis. The proof is a single `rw` followed by `simp`-normalized arithmetic.",
+    "mathContext": "$\\binom{n}{n}_q = 1$. Combinatorially: the $q$-weight of the unique $n$-chain of nested subspaces $0 \\subset V_1 \\subset \\cdots \\subset V_n = \\mathbb{F}_q^n$ is $q^0 = 1$. Algebraically: $\\binom{n}{n}_q = \\frac{(q^n-1)(q^{n-1}-1)\\cdots(q-1)}{(q^n-1)(q^{n-1}-1)\\cdots(q-1)} = 1$ via the closed form.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "self-choice",
+      "complete subspace",
+      "induction on ℕ"
+    ],
+    "prerequisites": [
+      "gaussBinom_eq_zero_of_lt",
+      "q-Pascal rule"
+    ]
+  },
+  {
+    "id": "ann-qvand-classical-limit",
+    "proofId": "binomial-theorem-oq-04-oq-02-oq-01",
+    "range": { "startLine": 90, "endLine": 106 },
+    "type": "insight",
+    "title": "Classical Limit: gaussBinom 1 n k = C(n,k)",
+    "content": "This theorem confirms that `gaussBinom` is a genuine q-analog of `Nat.choose`. At $q = 1$ the q-Pascal rule becomes $\\binom{n+1}{k+1}_1 = 1^{k+1} \\cdot \\binom{n}{k+1}_1 + \\binom{n}{k}_1 = \\binom{n}{k+1}_1 + \\binom{n}{k}_1 = \\binom{n+1}{k+1}$, which is exactly Pascal's rule for classical binomials. The proof uses `Nat.choose_succ_succ` (Pascal's rule in Mathlib) and `Nat.cast_add` to bridge between `ℕ` and the ring $R$. The outer induction on $n$ matches the structural recursion of `gaussBinom`.",
+    "mathContext": "$\\binom{n}{k}_1 = C(n,k)$ for all $n, k \\in \\mathbb{N}$, where the LHS is in $R$ (via `Nat.cast`) and the identity holds in any commutative ring. Equivalently: the polynomial $\\binom{n}{k}_q \\in \\mathbb{Z}[q]$ evaluated at $q = 1$ equals $C(n, k) \\in \\mathbb{Z}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "q=1 specialization",
+      "Pascal's rule",
+      "Nat.cast",
+      "q-analog verification"
+    ],
+    "prerequisites": [
+      "Nat.choose_succ_succ",
+      "Nat.cast homomorphism",
+      "induction on ℕ"
+    ]
+  },
+  {
+    "id": "ann-qvand-main-theorem",
+    "proofId": "binomial-theorem-oq-04-oq-02-oq-01",
+    "range": { "startLine": 112, "endLine": 133 },
+    "type": "insight",
+    "title": "q-Vandermonde Identity: Statement and Inductive Structure",
+    "content": "The main theorem states the q-Vandermonde identity over any commutative ring. The use of `Finset.range (r + 1)` (indices $0, 1, \\ldots, r$) as the summation domain is intentional: terms with $k > m$ or $r - k > n$ automatically vanish by `gaussBinom_eq_zero_of_lt`, so the formal sum over all of `range (r+1)` equals the effective sum. The `sorry` marks the inductive step where the q-Pascal rule applied to $\\binom{m+n+1}{r}_q$ produces two sums that must be combined via a `Finset.sum` reindexing ($k \\mapsto k - 1$) — a technically correct but combinatorially finicky manipulation in Lean 4.",
+    "mathContext": "The q-Vandermonde identity: $\\binom{m+n}{r}_q = \\sum_{k=0}^{r} \\binom{m}{k}_q \\cdot \\binom{n}{r-k}_q \\cdot q^{k(n+k-r)}$. The $q$-weight $q^{k(n+k-r)}$ encodes the relative position of the chosen $k$-space in the $m$-factor and the $(r-k)$-space in the $n$-factor when embedded into $\\mathbb{F}_q^{m+n}$. Combinatorially: it counts flags by a position statistic called the Lehmer code.",
+    "significance": "key",
+    "relatedConcepts": [
+      "q-Vandermonde identity",
+      "Finset.range sum",
+      "inductive proof",
+      "Lehmer code",
+      "subspace flags"
+    ],
+    "prerequisites": [
+      "Gaussian binomial coefficient",
+      "Finset.sum manipulation in Lean 4",
+      "q-Pascal rule"
+    ]
+  },
+  {
+    "id": "ann-qvand-exponent-safety",
+    "proofId": "binomial-theorem-oq-04-oq-02-oq-01",
+    "range": { "startLine": 118, "endLine": 127 },
+    "type": "technique",
+    "title": "Natural Number Subtraction Safety in the Exponent",
+    "content": "The exponent $k \\cdot (n + k - r)$ uses Lean's natural number subtraction, which truncates to 0 when $n + k < r$. This could be a correctness concern: if $k^* \\cdot (n + k^* - r)$ silently becomes $k^* \\cdot 0 = 0$ for some active term, the identity would be wrong. But the docstring carefully explains why this is safe: whenever $n + k < r$, we have $r - k > n$, so $\\binom{n}{r-k}_q = 0$ by `gaussBinom_eq_zero_of_lt`. The potentially wrong term has zero coefficient, so the value of the exponent is irrelevant — the $q^{\\ldots}$ is multiplied by zero. This pattern of 'safe underflow via vanishing coefficients' is a recurring technique in Lean formalizations of combinatorial identities.",
+    "mathContext": "For $n + k < r$: $n < r - k$, so $\\binom{n}{r-k}_q = 0$. Thus the $k$-th term $\\binom{m}{k}_q \\cdot \\binom{n}{r-k}_q \\cdot q^{k(n+k-r)} = \\binom{m}{k}_q \\cdot 0 \\cdot q^{k \\cdot 0} = 0$, regardless of the exponent's truncated value.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "natural number subtraction",
+      "truncated subtraction",
+      "safe underflow",
+      "vanishing term argument"
+    ],
+    "prerequisites": [
+      "Lean 4 ℕ subtraction semantics",
+      "gaussBinom_eq_zero_of_lt"
+    ]
+  },
+  {
+    "id": "ann-qvand-corollary",
+    "proofId": "binomial-theorem-oq-04-oq-02-oq-01",
+    "range": { "startLine": 139, "endLine": 152 },
+    "type": "concept",
+    "title": "Recovering Classical Vandermonde at q = 1",
+    "content": "The corollary `vandermonde_from_q` derives the classical Vandermonde identity $C(m+n, r) = \\sum_k C(m,k) C(n, r-k)$ as a specialization of the q-analog at $q = 1$. The proof applies `gaussBinom_one` (which converts each `gaussBinom 1 · ·` to a `Nat.choose`), notes that $1^{k(n+k-r)} = 1$, and uses `ring` to confirm the resulting arithmetic. The `convert ... using 1; congr 1; ext k; ring` pattern handles the ring normalization of the $q^{\\ldots}$ factor.",
+    "mathContext": "Setting $q = 1$: $q^{k(n+k-r)} = 1^{k(n+k-r)} = 1$, and $\\binom{n}{k}_1 = C(n,k)$, so the q-Vandermonde identity reduces to $C(m+n,r) = \\sum_k C(m,k) C(n,r-k)$. This is the classical Vandermonde convolution, proved here as a corollary of a more general q-analog statement.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "classical Vandermonde identity",
+      "specialization",
+      "ring normalization",
+      "corollary structure"
+    ],
+    "prerequisites": [
+      "gaussBinom_one",
+      "q_vandermonde",
+      "Nat.cast ring homomorphism"
+    ]
+  }
+]

--- a/src/data/proofs/binomial-theorem-oq-04-oq-02-oq-01/index.ts
+++ b/src/data/proofs/binomial-theorem-oq-04-oq-02-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BinomialTheoremOQ04OQ02OQ01.lean?raw'
+
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const binomialTheoremOq04Oq02Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const binomialTheoremOq04Oq02Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const binomialTheoremOq04Oq02Oq01Data: ProofData = {
+  proof: binomialTheoremOq04Oq02Oq01Proof,
+  annotations: binomialTheoremOq04Oq02Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `binomial-theorem-oq-04-oq-02-oq-01` (q-Vandermonde Identity: Gaussian Binomial Coefficients).

## Changes

- **Created `annotations.json`** with 10 detailed annotations covering the full Lean file (157 lines), with:
  - `mathContext` (LaTeX formulas) on every annotation
  - `significance` classification: `key`, `supporting`, `technical`, or `context`
  - `relatedConcepts` and `prerequisites` arrays
  - Coverage of: docblock, imports/setup, `gaussBinom` definition (q-Pascal rule), base case simp lemmas, vanishing lemma, self-choice, classical limit at q=1, q-Vandermonde statement/sorry, exponent safety argument, and the classical Vandermonde corollary
- **Created `index.ts`** — the Vite entry point was missing, which would cause the proof page to show "proof not found" on the live site

## Notable annotations

- `ann-qvand-definition`: geometric interpretation of the q-Pascal rule via counting $k$-dimensional subspaces of $\mathbb{F}_q^{n+1}$
- `ann-qvand-exponent-safety`: explains why natural-number truncation in the exponent is safe — vanishing coefficients make the wrong terms zero
- `ann-qvand-main-theorem`: documents the sorry's location (Finset.sum reindexing in the inductive step) and connects the $q$-weight to the Lehmer code / position statistic