### PR TITLE
Fix: correct sorry count and status for binomial-theorem-oq-04-oq-02-oq-01 (#gallery-integrity)

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-04-oq-02-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-04-oq-02-oq-01/meta.json
@@ -2,13 +2,13 @@
   "id": "binomial-theorem-oq-04-oq-02-oq-01",
   "title": "q-Vandermonde Identity: Gaussian Binomial Coefficients",
   "slug": "binomial-theorem-oq-04-oq-02-oq-01",
-  "sorries": 0,
+  "sorries": 1,
   "description": "Formalization of Gaussian binomial coefficients [n choose k]_q via the q-Pascal recurrence, and the q-Vandermonde identity: [m+n choose r]_q = Σ_k [m choose k]_q · [n choose r-k]_q · q^(k·(n+k-r)).",
   "meta": {
     "author": "Formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Gaussian_binomial_coefficient",
     "date": "2026",
-    "status": "verified",
+    "status": "formalized",
     "tags": [
       "combinatorics",
       "algebra",
@@ -17,8 +17,8 @@
       "research"
     ],
     "proofRepoPath": "Proofs/BinomialTheoremOQ04OQ02OQ01.lean",
-    "badge": "original",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "Nat.choose_succ_succ",
@@ -37,7 +37,7 @@
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
     "lineCount": 218,
-    "assumptions": "0 sorries, 0 axioms. The q-Vandermonde inductive step is fully proved via q-Pascal expansion, Finset.sum_congr, sum_add_distrib, and sum_range_succ reindexing.",
+    "assumptions": "1 sorry: q_vandermonde (main identity). The vandermonde_from_q corollary depends on q_vandermonde. All supporting lemmas (gaussBinom_eq_zero_of_lt, gaussBinom_self, gaussBinom_one) are fully proved.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -108,7 +108,7 @@
     }
   ],
   "conclusion": {
-    "summary": "8 theorems proved (0 sorries, 0 axioms). The Gaussian binomial infrastructure is original to this gallery: definition, vanishing, self-choice, and classical limit are all fully proved. The q-Vandermonde identity is fully proved by induction with complete Finset.sum reindexing. Classical Vandermonde follows as a corollary at q=1.",
+    "summary": "6 theorems proved (1 sorry remaining). The Gaussian binomial infrastructure is original to this gallery: definition, vanishing, self-choice, and classical limit are all fully proved. The q-Vandermonde identity (q_vandermonde) and its classical corollary (vandermonde_from_q) remain to be proved — q_vandermonde has a sorry.",
     "implications": "**Theoretical Significance**: Gaussian binomials [n choose k]_q are ubiquitous in combinatorics and representation theory. This formalization provides a foundation for q-analogs of other binomial identities: the q-binomial theorem, the q-Chu-Vandermonde identity, and generating functions for set-valued tableaux.\n\n**Practical**: The gaussBinom definition can serve as infrastructure for formalizing quantum group representations, counting formulas in algebraic combinatorics, and the theory of basic hypergeometric series in Lean 4.",
     "openQuestions": [
       "Can gaussBinom_self be derived from gaussBinom_eq_zero_of_lt using the q-Pascal rule, providing an alternative to the current direct induction?",
@@ -145,7 +145,7 @@
     "theoremCount": 8,
     "definitionCount": 1,
     "path": "Proofs/BinomialTheoremOQ04OQ02OQ01.lean",
-    "sorries": 0
+    "sorries": 1
   },
   "references": [
     {


### PR DESCRIPTION
## Summary

- Gallery integrity fix: `meta.json` for `binomial-theorem-oq-04-oq-02-oq-01` incorrectly claimed the q-Vandermonde identity was fully proved
- The Lean source (`BinomialTheoremOQ04OQ02OQ01.lean` line 133) has a `sorry` on the main theorem `q_vandermonde`; `vandermonde_from_q` (its corollary) inherits this sorry
- Corrected 7 fields: `sorries` 0→1 (root and `meta` and `leanFile`), `meta.status` `verified`→`formalized`, `meta.badge` `original`→`wip`, `meta.assumptions` and `conclusion.summary` updated to accurately describe the state

## Fields changed

| Field | Before | After |
|---|---|---|
| `sorries` (root) | 0 | 1 |
| `meta.status` | `"verified"` | `"formalized"` |
| `meta.badge` | `"original"` | `"wip"` |
| `meta.sorries` | 0 | 1 |
| `meta.assumptions` | "0 sorries, 0 axioms..." | "1 sorry: q_vandermonde (main identity)..." |
| `leanFile.sorries` | 0 | 1 |
| `conclusion.summary` | "8 theorems proved (0 sorries, 0 axioms)..." | "6 theorems proved (1 sorry remaining)..." |

## No Lean source changes

The Lean file is not modified — only the metadata is corrected to match reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)