### PR TITLE
Fix: erdos-606-oq-03 badge axiom→wip + audit tracker cleanup for 4 resolved entries

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6520,10 +6520,12 @@
       "result": "clean"
     },
     "erdos-606-oq-03": {
-      "auditCount": 3,
-      "issues": [],
-      "lastAudited": "2026-04-13T23:08:12Z",
-      "result": "issues-found"
+      "auditCount": 4,
+      "issues": [
+        "badge axiom\u2192wip (axiomCount=0, no actual axiom declarations; consistent with open-problem survey classification)"
+      ],
+      "lastAudited": "2026-04-21T00:00:00Z",
+      "result": "issues-fixed"
     },
     "erdos-607": {
       "agentId": "auditor-cycle-20-batch",
@@ -12600,22 +12602,28 @@
       "issues": []
     },
     "law-of-sines-oq-06": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-14T18:00:25Z",
-      "result": "issues-found",
-      "issues": []
+      "auditCount": 2,
+      "lastAudited": "2026-04-21T00:00:00Z",
+      "result": "issues-fixed",
+      "issues": [
+        "id/slug mismatch: meta.json had id=law-of-cosines-oq-06; fixed by enrichment PR #10757"
+      ]
     },
     "law-of-cosines-oq-06": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-14T18:00:25Z",
-      "result": "issues-found",
-      "issues": []
+      "auditCount": 2,
+      "lastAudited": "2026-04-21T00:00:00Z",
+      "result": "issues-fixed",
+      "issues": [
+        "gallery entry renamed law-of-cosines-oq-06\u2192law-of-sines-oq-06; content was Law of Sines not Law of Cosines (fixed by PRs #10749, #10757)"
+      ]
     },
     "bezout-identity-oq-02-oq-04": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-14T21:51:41Z",
-      "result": "issues-found",
-      "issues": []
+      "auditCount": 2,
+      "lastAudited": "2026-04-21T00:00:00Z",
+      "result": "issues-fixed",
+      "issues": [
+        "badge original\u2192mathlib (core results are Mathlib wrappers; fixed by PR #10846)"
+      ]
     },
     "binomial-theorem-oq-02-oq-04": {
       "auditCount": 1,

--- a/src/data/proofs/erdos-606-oq-03/meta.json
+++ b/src/data/proofs/erdos-606-oq-03/meta.json
@@ -16,7 +16,7 @@
       "erdos",
       "research"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 100,


### PR DESCRIPTION
## Fix

Clear 4 stale `issues-found` entries from the audit tracker and fix the underlying badge inconsistency in `erdos-606-oq-03`.

## Evidence

**erdos-606-oq-03/meta.json** — badge mismatch (flagged 3× by auditor, issues #9911 #10644):
- **Before**: `"badge": "axiom"`, `"axiomCount": 0`
- **After**: `"badge": "wip"`, `"axiomCount": 0`
- **Why**: Badge `"axiom"` requires actual `axiom` declarations or structure-encoded assumptions. The Lean file (`Erdos606OQ03.lean`) has 0 axiom declarations and 0 structure-encoded assumptions. Status `"axiomatized"` correctly signals the open-problem classification; badge `"wip"` accurately reflects what the file contains.

**audit-tracker.json** — 4 entries with `result: "issues-found"` and empty `issues` arrays:
- `erdos-606-oq-03`: badge fixed → `issues-fixed`
- `bezout-identity-oq-02-oq-04`: badge original→mathlib was fixed by PR #10846 → `issues-fixed`
- `law-of-cosines-oq-06`: gallery entry renamed to `law-of-sines-oq-06` by PRs #10749/#10757 → `issues-fixed`
- `law-of-sines-oq-06`: id/slug mismatch in meta.json fixed by enrichment PR #10757 → `issues-fixed`

---
Automated fix by lean-mechanic agent.