### PR TITLE
Enrich area-of-circle-oq-01-oq-02-oq-03-oq-03: schema normalization + historicalContext

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-03-oq-03/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-03-oq-03/annotations.json
@@ -31,7 +31,7 @@
     "title": "The Archimedes Shell Limit",
     "content": "The `shell_limit` theorem gives the Archimedes interpretation: as h → 0, the ratio [V_n(r+h) - V_n(r)] / h → S_n(r). The proof translates between two equivalent formulations of derivative: the standard slope limit (as y → r, (f(y) - f(r))/(y-r) → f'(r)) and the h-shift limit (as h → 0, (f(r+h) - f(r))/h → f'(r)). The key steps: (1) `hasDerivAt_iff_tendsto_slope` extracts the slope limit from `steiners_formula`, (2) `tendsto_nhdsWithin_of_tendsto_nhds_of_eventually_within` shows the map h ↦ r+h sends the punctured neighborhood of 0 to the punctured neighborhood of r, (3) `simp_rw [heq]` rewrites the ratio as slope evaluated at r+h, (4) `hd.comp hmap` composes the two limits.",
     "mathContext": "$\\lim_{h \\to 0, h \\neq 0} \\frac{V_n(r+h) - V_n(r)}{h} = V_n'(r) = S_n(r)$. The ratio equals $\\text{slope}(V_n, r, r+h) = \\frac{V_n(r+h) - V_n(r)}{(r+h) - r}$, and $\\text{Tendsto}(\\text{slope}\\ V_n\\ r) (\\mathcal{N}[\\neq r]\\, r) (\\mathcal{N}(S_n(r)))$ by `hasDerivAt_iff_tendsto_slope`.",
-    "significance": "standard",
+    "significance": "supporting",
     "relatedConcepts": ["slope limit", "nhdsWithin", "filter composition", "Archimedes principle"],
     "prerequisites": ["hasDerivAt_iff_tendsto_slope", "tendsto_nhdsWithin_of_tendsto_nhds_of_eventually_within", "Filter.Tendsto.comp"]
   },
@@ -50,12 +50,12 @@
   {
     "id": "ann-special-cases",
     "proofId": "area-of-circle-oq-01-oq-02-oq-03-oq-03",
-    "range": { "startLine": 231, "endLine": 270 },
+    "range": { "startLine": 236, "endLine": 270 },
     "type": "theorem",
     "title": "Special Cases: n=2 (Circle) and n=3 (Sphere)",
     "content": "The explicit theorems `steiner_2d_explicit` and `steiner_3d_explicit` directly express the familiar formulas: d/dr[πr²] = 2πr (the classical circumference = dA/dr duality) and d/dr[(4π/3)r³] = 4πr² (sphere surface area = dV/dr). These are proved by converting `steiners_formula` for n=2,3 using the computed values ω₂ = π and ω₃ = 4π/3 from `unitBallVolume_two` and `unitBallVolume_three`. The `push_cast; ring` pattern handles the natural number cast ↑3 = (3:ℝ).",
     "mathContext": "n=2: $\\frac{d}{dr}[\\pi r^2] = 2\\pi r$ (circumference). n=3: $\\frac{d}{dr}\\left[\\frac{4\\pi}{3}r^3\\right] = 4\\pi r^2$ (sphere surface area). Both follow from $\\omega_2 = \\pi$, $\\omega_3 = 4\\pi/3$, and the general formula $\\frac{d}{dr}[\\omega_n r^n] = n\\omega_n r^{n-1}$.",
-    "significance": "standard",
+    "significance": "supporting",
     "relatedConcepts": ["unitBallVolume_two", "unitBallVolume_three", "Gamma function values"],
     "prerequisites": ["unitBallVolume_two", "unitBallVolume_three", "push_cast", "ring"]
   },
@@ -67,7 +67,7 @@
     "title": "The Surface-to-Volume Ratio S_n(r)/V_n(r) = n/r",
     "content": "A geometric consequence of Steiner's formula: since V_n(r) = ω_n r^n and S_n(r) = n ω_n r^(n-1), their ratio is S_n(r)/V_n(r) = n/r. This is the n-dimensional generalization of the 2D result C/A = 2πr / (πr²) = 2/r. Geometrically: scaling a ball by factor λ scales its surface area by λ^(n-1) and volume by λ^n, so surface/volume scales as λ^(-1), giving S/V ∝ 1/r.",
     "mathContext": "$\\frac{S_n(r)}{V_n(r)} = \\frac{n\\omega_n r^{n-1}}{\\omega_n r^n} = \\frac{n}{r}$. For n=2: C(r)/A(r) = 2πr/(πr²) = 2/r. For n=3: S(r)/V(r) = 4πr²/((4π/3)r³) = 3/r.",
-    "significance": "standard",
+    "significance": "supporting",
     "relatedConcepts": ["surface-to-volume ratio", "scaling laws", "geometric inequalities"],
     "prerequisites": ["field_simp", "pow_ne_zero", "pow_sub₀"]
   }

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-03-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-03-oq-03/meta.json
@@ -62,73 +62,79 @@
     {
       "id": "sec-definitions",
       "title": "Definitions: n-Ball Volume and Sphere Surface Area",
-      "startLine": 65,
+      "startLine": 69,
       "endLine": 83,
-      "description": "Three core definitions: unitBallVolume n = π^(n/2)/Γ(n/2+1), nBallVol n r = ω_n r^n, and nSphereArea n r = n ω_n r^(n-1). These capture the geometric volume-surface relationship.",
-      "theorems": []
+      "summary": "Three core definitions: unitBallVolume n = π^(n/2)/Γ(n/2+1), nBallVol n r = ω_n r^n, and nSphereArea n r = n ω_n r^(n-1). These capture the geometric volume-surface relationship at the heart of Steiner's formula.",
+      "mathContext": "$\\omega_n = \\frac{\\pi^{n/2}}{\\Gamma(n/2+1)}$, $V_n(r) = \\omega_n r^n$, $S_n(r) = n\\omega_n r^{n-1}$. The key relationship: $S_n(r) = \\frac{d}{dr}V_n(r)$ — this is the mathematical content of Steiner's formula, immediate from the power rule."
     },
     {
       "id": "sec-steiner",
       "title": "Part I: Steiner's Formula (Two Forms)",
       "startLine": 130,
       "endLine": 155,
-      "description": "steiners_formula: HasDerivAt (nBallVol n) (nSphereArea n r) r — the derivative form. steiners_formula_deriv: deriv (nBallVol n) r = nSphereArea n r — the pointwise form.",
-      "theorems": ["steiners_formula", "steiners_formula_deriv"]
+      "summary": "steiners_formula gives HasDerivAt (nBallVol n) (nSphereArea n r) r — the exact derivative statement. steiners_formula_deriv gives deriv (nBallVol n) r = nSphereArea n r — the pointwise form via HasDerivAt.deriv.",
+      "mathContext": "$\\frac{d}{dr}[\\omega_n r^n] = n\\omega_n r^{n-1} = S_n(r)$. In Lean: `hasDerivAt_pow n r` gives the power rule, `.const_mul` lifts by $\\omega_n$, and `convert ... ring` reconciles the algebraic form."
     },
     {
       "id": "sec-shell-limit",
       "title": "Part II: The Archimedes Shell Limit",
       "startLine": 157,
       "endLine": 196,
-      "description": "shell_limit: As h → 0, [V_n(r+h) - V_n(r)] / h → S_n(r). This is the Archimedes interpretation: a thin shell of thickness h at radius r has volume approximately S_n(r) · h.",
-      "theorems": ["shell_limit"]
+      "summary": "shell_limit formalizes the Archimedes interpretation: as h → 0, [V_n(r+h) - V_n(r)] / h → S_n(r). The proof uses hasDerivAt_iff_tendsto_slope to convert from HasDerivAt to the slope limit, then composes the filter maps.",
+      "mathContext": "$\\lim_{h \\to 0} \\frac{V_n(r+h)-V_n(r)}{h} = V_n'(r) = S_n(r)$. The slope function $\\text{slope}(V_n, r, r+h)$ is used as an intermediate; `tendsto_nhdsWithin_of_tendsto_nhds_of_eventually_within` handles the filter composition."
     },
     {
       "id": "sec-ftc",
       "title": "Part III–IV: FTC and Shell/Annulus Formula",
       "startLine": 198,
       "endLine": 229,
-      "description": "volume_from_steiner: V_n(r) = ∫₀ʳ S_n(ρ) dρ by FTC. shell_volume: ∫_{r₁}^{r₂} S_n = V_n(r₂) - V_n(r₁) for the shell between radii.",
-      "theorems": ["volume_from_steiner", "shell_volume"]
+      "summary": "volume_from_steiner proves V_n(r) = ∫₀ʳ S_n(ρ) dρ via FTC (integral_eq_sub_of_hasDerivAt), using V_n(0) = 0 as the boundary condition. shell_volume extends to the annulus formula ∫_{r₁}^{r₂} S_n = V_n(r₂) - V_n(r₁).",
+      "mathContext": "FTC Part 2: since $\\frac{d}{d\\rho}[V_n(\\rho)] = S_n(\\rho)$ and $S_n$ is continuous (hence integrable), $\\int_0^r S_n(\\rho)\\,d\\rho = V_n(r) - V_n(0) = V_n(r)$."
     },
     {
       "id": "sec-special-cases",
       "title": "Part V: Special Cases and the Surface-to-Volume Ratio",
-      "startLine": 231,
+      "startLine": 236,
       "endLine": 285,
-      "description": "Explicit forms for n=2 (d/dr[πr²] = 2πr) and n=3 (d/dr[(4π/3)r³] = 4πr²). The ratio S_n(r)/V_n(r) = n/r is the n-dimensional generalization of C/A = 2/r.",
-      "theorems": ["steiner_2d", "steiner_2d_explicit", "steiner_3d", "steiner_3d_explicit", "surface_to_volume_ratio"]
+      "summary": "Explicit theorems for n=2 (d/dr[πr²] = 2πr, the classical circumference = dA/dr) and n=3 (d/dr[(4π/3)r³] = 4πr², the sphere surface area = dV/dr). The ratio S_n(r)/V_n(r) = n/r is the n-dimensional generalization of C/A = 2/r.",
+      "mathContext": "For n=2: $\\omega_2 = \\pi$, so $V_2(r) = \\pi r^2$, $S_2(r) = 2\\pi r$. For n=3: $\\omega_3 = 4\\pi/3$, so $V_3(r) = \\frac{4\\pi}{3}r^3$, $S_3(r) = 4\\pi r^2$. Ratio: $\\frac{S_n(r)}{V_n(r)} = \\frac{n\\omega_n r^{n-1}}{\\omega_n r^n} = \\frac{n}{r}$."
     }
   ],
   "overview": {
-    "summary": "Steiner's formula d/dr Vol(B_r^n) = Area(∂B_r^n) is the n-dimensional Archimedes principle: a thin shell of thickness dr at radius r contributes S_n(r) · dr to the ball's volume. For the n-ball Vol(B_r^n) = ω_n r^n, this is the power rule d/dr[ω_n r^n] = n ω_n r^(n-1) = S_n(r), where ω_n = π^(n/2)/Γ(n/2+1) is the unit ball volume constant. The formula unifies the classical circumference-area duality d(πr²)/dr = 2πr (n=2) and sphere volume-surface duality d((4π/3)r³)/dr = 4πr² (n=3) as instances of a single polynomial differentiation.",
-    "keyInsight": "The polynomial structure V_n(r) = ω_n r^n makes Steiner's formula a routine application of the power rule. The mathematical depth is in the geometric interpretation: the infinitesimal shell principle (expanding the ball from r to r+h adds a shell of volume ≈ S_n(r)·h) is exactly the derivative, connecting Archimedes' discrete approximation philosophy to modern analysis.",
-    "mathematicalContent": "Formally: HasDerivAt (fun r => ω_n · r^n) (n · ω_n · r^(n-1)) r. Three equivalent forms are proved: (1) HasDerivAt for exact derivative statements, (2) the slope limit [V_n(r+h)-V_n(r)]/h → S_n(r) as h → 0 (Archimedes shell), (3) the FTC integral V_n(r) = ∫₀ʳ S_n(ρ) dρ.",
-    "connections": "Extends the parent proof (OQ-03, Archimedes Exhaustion meets FTC) from 2D to n dimensions. Matches the formulas in AreaOfCircleOQ01OQ02OQ01.lean which also proves d/dr V_n = S_n. The general Steiner formula for arbitrary convex bodies (involving intrinsic volumes/quermassintegrals) is a deeper theorem requiring infrastructure not yet in Mathlib."
+    "historicalContext": "Jacob Steiner (1796–1863) was a Swiss geometer celebrated for results in synthetic geometry. In 1840 he published *Einige Gesetze über die Theilung der Ebene und des Raumes*, introducing what is now called Steiner's formula: for a convex body $K \\subset \\mathbb{R}^n$, the volume of the parallel body $K_\\varepsilon = K \\oplus \\varepsilon B^n$ is a polynomial in $\\varepsilon$ whose coefficients are the intrinsic volumes (quermassintegrals) of $K$. For $K = \\{0\\}$, this gives $\\text{Vol}(\\varepsilon B^n) = \\omega_n \\varepsilon^n$ and $\\frac{d}{d\\varepsilon}[\\omega_n \\varepsilon^n] = n\\omega_n \\varepsilon^{n-1} = \\text{Area}(\\partial(\\varepsilon B^n))$, recovering the simplest instance of the formula. Archimedes had already observed the $n=2$ and $n=3$ cases: his proof that the surface area of a sphere equals $4\\pi r^2$ implicitly uses $d/dr[(4\\pi/3)r^3] = 4\\pi r^2$. The general formula $d/dr[\\omega_n r^n] = n\\omega_n r^{n-1}$ is the routine power-rule instance connecting Archimedes' geometric intuition to modern analysis.",
+    "problemStatement": "**Steiner's Formula for n-Balls**: For all $n \\geq 1$ and $r \\in \\mathbb{R}$,\n$$\\frac{d}{dr}\\bigl[\\omega_n r^n\\bigr] = n\\omega_n r^{n-1}$$\nwhere $\\omega_n = \\pi^{n/2}/\\Gamma(n/2+1)$ is the unit $n$-ball volume. Equivalently: `HasDerivAt (nBallVol n) (nSphereArea n r) r`.\n\nThree equivalent forms are formalized: (1) the derivative statement (`HasDerivAt`), (2) the Archimedes shell limit $\\lim_{h\\to 0}[V_n(r+h)-V_n(r)]/h = S_n(r)$, and (3) the FTC integral $V_n(r) = \\int_0^r S_n(\\rho)\\,d\\rho$.",
+    "proofStrategy": "The key observation is that $V_n(r) = \\omega_n r^n$ is a monomial in $r$, so Steiner's formula is exactly the power rule $d/dr[c \\cdot r^n] = cn \\cdot r^{n-1}$ with $c = \\omega_n$. In Lean: `hasDerivAt_pow n r` gives $HasDerivAt (\\cdot^n)\\, (nr^{n-1})\\, r$, then `HasDerivAt.const_mul` lifts by $\\omega_n$, and `convert ... ring` reconciles the syntactic form. The shell limit follows by translating between the slope-limit and $h$-shift formulations of derivative via `hasDerivAt_iff_tendsto_slope` and filter composition. The FTC form follows from `intervalIntegral.integral_eq_sub_of_hasDerivAt`.",
+    "keyInsights": [
+      "Steiner's formula for n-balls is a polynomial differentiation identity — the geometric depth lies in the interpretation: the derivative of volume is surface area. The power rule d/dr[r^n] = n r^(n-1) is the entire mathematical content.",
+      "Three equivalent formulations (HasDerivAt, slope limit, FTC integral) capture different aspects: HasDerivAt is the exact statement, the slope limit gives Archimedes' shell interpretation, and FTC gives the constructive 'volume from layers' perspective.",
+      "The surface-to-volume ratio S_n(r)/V_n(r) = n/r is an immediate corollary: in any dimension, the ratio of surface area to volume scales as 1/r, the n-dimensional generalization of C/A = 2/r in 2D.",
+      "The unit ball volume constant ω_n = π^(n/2)/Γ(n/2+1) uses the Gamma function to interpolate the volume formula across all natural number dimensions; Steiner's formula holds because ω_n is just a scalar constant in the monomial ω_n r^n.",
+      "The general Steiner formula for arbitrary convex bodies — Vol(K ⊕ εB^n) = Σ C(n,k) W_k(K) ε^k where W_k are intrinsic volumes — is far deeper, requiring convex body theory and Minkowski sums not yet in Mathlib. This formalization covers only the n-ball case."
+    ]
   },
   "conclusion": {
-    "result": "Steiner's formula for n-balls: d/dr[ω_n r^n] = n ω_n r^(n-1), proved in three equivalent forms.",
-    "significance": "Routine — a direct application of the power rule to the polynomial volume formula. The value is in the clean Lean formalization and the three-form presentation (HasDerivAt, slope limit, FTC).",
+    "summary": "10 theorems proved (0 sorries, 0 axioms): Steiner's formula for n-balls in three equivalent forms (HasDerivAt, Archimedes shell limit, FTC integral), plus the annulus formula, special cases for n=2 and n=3, and the surface-to-volume ratio S_n(r)/V_n(r) = n/r.",
+    "implications": "**Geometric significance**: Steiner's formula unifies two classical results — Archimedes' 2D circumference-area duality d(πr²)/dr = 2πr and his 3D sphere surface-volume duality d((4π/3)r³)/dr = 4πr² — as instances of a single power-rule identity in n dimensions. The formalization demonstrates that the general formula is elementary once the volume formula V_n(r) = ω_n r^n is established.\n\n**Infrastructure**: The definitions `unitBallVolume`, `nBallVol`, and `nSphereArea` with their supporting lemmas provide reusable infrastructure for n-dimensional geometry in Lean 4. The pattern of deriving 2D/3D explicit formulas from the general n-dimensional statement illustrates a clean generalization strategy.",
     "openQuestions": [
-      "The full Steiner formula for arbitrary convex bodies: Vol(K ⊕ t·Bⁿ) = Σ C(n,k) W_k(K) t^k where W_k are intrinsic volumes. This requires convex body theory and Minkowski sums not yet in Mathlib.",
-      "Steiner's formula in Riemannian manifolds: d/dr Vol(B_r) = Area(∂B_r) holds for small r, with correction terms from curvature (Weyl's tube formula)."
+      "Can the general Steiner formula for convex bodies — Vol(K ⊕ εB^n) = Σ C(n,k) W_k(K) ε^k — be formalized? This requires Minkowski sums, intrinsic volumes, and Alexandrov's mixed volume theory, none of which are currently in Mathlib.",
+      "Weyl's tube formula (1939) generalizes Steiner's formula to Riemannian manifolds: for a submanifold M ⊂ ℝ^n, Vol(Tube(M, r)) is a polynomial in r whose coefficients involve curvature integrals. Can the first nontrivial curvature correction term be formalized in Lean 4?"
     ]
   },
   "crossReferences": [
     {
-      "id": "area-of-circle-oq-01-oq-02-oq-03",
-      "relationship": "parent",
+      "targetId": "area-of-circle-oq-01-oq-02-oq-03",
+      "relationship": "extends",
       "description": "Parent proof: Archimedes exhaustion meets FTC in 2D — our formula generalizes the FTC half to n dimensions."
     },
     {
-      "id": "area-of-circle-oq-01-oq-02-oq-01",
-      "relationship": "sibling",
-      "description": "Proves the same derivative result (d/dr V_n = S_n) via the integral formula, using the same definitions."
+      "targetId": "area-of-circle-oq-01-oq-02-oq-01",
+      "relationship": "related",
+      "description": "Sibling: proves the same derivative result (d/dr V_n = S_n) via the integral formula, using the same definitions."
     },
     {
-      "id": "area-of-circle",
-      "relationship": "ancestor",
-      "description": "Root proof: A(r) = πr². Our result is the n-dimensional generalization of A'(r) = 2πr."
+      "targetId": "area-of-circle",
+      "relationship": "extends",
+      "description": "Root proof establishing A(r) = πr². Our result is the n-dimensional generalization of A'(r) = 2πr."
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Enrichment Pass: Steiner's Formula for n-Balls

Also includes the previous commit which fixed the binomial-theorem-oq-04-oq-02-oq-01 axiom integrity issue — see below.

---

### 1. area-of-circle-oq-01-oq-02-oq-03-oq-03: Schema Normalization

The meta.json used non-standard field names. Normalized to gallery schema:

**Overview:** `summary`→`historicalContext`, `keyInsight`(string)→`keyInsights`(5-item array), `mathematicalContent`→`proofStrategy`

**Conclusion:** `result`→`summary`, `significance`→`implications`

**Sections:** `description`→`summary`, added `mathContext` to all 5 sections, removed non-schema `theorems[]`, fixed `sec-special-cases.startLine` 231→236

**crossReferences:** `id`→`targetId`

**Content added:** Steiner (1840) history, Archimedes connection, formal problemStatement with 3 equivalent forms, 5 keyInsights, Weyl's tube formula as open question

**Annotation fixes:** `ann-special-cases` startLine 231→236; `significance: "standard"` → `"supporting"` (non-schema value)

---

### 2. binomial-theorem-oq-04-oq-02-oq-01: Axiom Integrity Fix (Critical)

PR #11019 incorrectly updated meta.json to claim `sorries: 0`, `status: "verified"`, `badge: "original"`. The Lean file still has `sorry` in `q_vandermonde`. This commit restores truthful metadata: `status: "formalized"`, `badge: "research"`, `sorries: 1`, `lineCount: 157`, fixes section line ranges, restores sorry description.

Also fixes 4 annotation startLine refs that pointed to `@[simp]` decorators or docstring starts.