### PR TITLE
Enrich arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02: fix annotation schema errors, add mathContext

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02/annotations.json
@@ -27,13 +27,13 @@
     "id": "ann-sum-zero-left",
     "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02",
     "range": {
-      "startLine": 39,
-      "endLine": 48
+      "startLine": 38,
+      "endLine": 47
     },
-    "type": "theorem",
+    "type": "technique",
     "title": "Base Case m = 0: Only j = 0 Term Survives",
     "content": "When m = 0, multichoose 0 j = 0 for all j ≥ 1 (only multichoose 0 0 = 1). So the sum Σ_{j≤r} multichoose(0,j)·multichoose(n,r-j) collapses to just the j = 0 term: 1·multichoose n r = multichoose n r. Proved by induction on r: the zero case uses multichoose_zero_right; the successor case uses sum_range_succ' to split off the j = 0 term, then simp dispatches the rest with multichoose_zero_succ (= 0) and multichoose_zero_right (= 1).",
-    "mathContext": "$\\text{mc}(0, 0) = 1$ and $\\text{mc}(0, j+1) = 0$ for all $j$. Thus $\\sum_{j=0}^r \\text{mc}(0,j)\\cdot\\text{mc}(n,r-j) = \\text{mc}(0,0)\\cdot\\text{mc}(n,r) + \\sum_{j=1}^r 0 = \\text{mc}(n,r)$. The Lean proof uses `sum_range_succ'` to split off the $j=0$ term from the sum over `range(r+1)`, placing it at the front.",
+    "mathContext": "$\\text{mc}(0, 0) = 1$ and $\\text{mc}(0, j+1) = 0$ for all $j$. Thus $\\sum_{j=0}^r \\text{mc}(0,j)\\cdot\\text{mc}(n,r-j) = \\text{mc}(0,0)\\cdot\\text{mc}(n,r) + \\sum_{j=1}^r 0 = \\text{mc}(n,r)$. The Lean proof uses `sum_range_succ'` to split off the $j=0$ term from the sum over `range(r+1)`, placing it at the front. Then `multichoose_zero_succ` kills all remaining terms.",
     "significance": "supporting",
     "relatedConcepts": [
       "Nat.multichoose_zero_right",
@@ -50,42 +50,33 @@
     "id": "ann-sum-zero-right",
     "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02",
     "range": {
-      "startLine": 50,
-      "endLine": 53
+      "startLine": 89,
+      "endLine": 103
     },
-    "type": "theorem",
-    "title": "Base Case r = 0: Both Sides Equal 1",
-    "content": "When r = 0, the sum has only the j = 0 term (range 1 = {0}): multichoose(m,0)·multichoose(n,0) = 1·1 = 1. The RHS is multichoose(m+n,0) = 1. Both sides are 1 by multichoose_zero_right, so simp dispatches the goal immediately. This base case completes the (m, r=0) branch of the double induction.",
-    "mathContext": "$\\sum_{j=0}^0 \\text{mc}(m,j)\\cdot\\text{mc}(n,0-j) = \\text{mc}(m,0)\\cdot\\text{mc}(n,0) = 1\\cdot 1 = 1 = \\text{mc}(m+n,0)$. The sum over `range 1` in Lean contains only the $j=0$ term, making this a trivial one-step simplification.",
-    "significance": "supporting",
+    "type": "insight",
+    "title": "Double Induction: Inline Base Cases for r = 0 and m = 0",
+    "content": "The main theorem uses double induction — outer on m (with r generalized), inner on r. The m = 0 base case (line 94-97) delegates to sum_zero_left. The m = succ, r = 0 base case (lines 100-103) is handled inline: multichoose(m+1+n, 0) = 1 = multichoose(m+1, 0)·multichoose(n, 0) since multichoose _ 0 = 1 for any first argument, so `simp [Nat.multichoose_zero_right]` closes the goal immediately. This avoids a separate lemma for the r=0 base; the one-liner `simp` subsumes what would otherwise require a standalone proof.",
+    "mathContext": "At $r = 0$: $\\text{mc}(m+1+n, 0) = 1$ and the sum $\\sum_{j=0}^{0} \\text{mc}(m+1, j)\\cdot\\text{mc}(n, 0-j) = \\text{mc}(m+1, 0)\\cdot\\text{mc}(n, 0) = 1\\cdot 1 = 1$. Since `Nat.multichoose_zero_right : ∀ n, multichoose n 0 = 1`, both sides reduce to 1 in one simp step. The outer induction `induction m generalizing r` gives the IH a universally-quantified `r`, enabling the inner induction to use the outer IH at a different value of $r$.",
+    "significance": "key",
     "relatedConcepts": [
+      "double induction",
       "Nat.multichoose_zero_right",
-      "base-case"
+      "induction generalizing",
+      "base case"
     ],
     "prerequisites": [
-      "Nat.multichoose_zero_right"
+      "Nat.multichoose_zero_right",
+      "sum_zero_left"
     ]
-  },
-  {
-    "id": "ann-sum-zero-right",
-    "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02",
-    "range": { "startLine": 50, "endLine": 53 },
-    "type": "theorem",
-    "title": "Base Case r = 0: Both Sides Equal 1",
-    "content": "sum_zero_right: when r = 0, the convolution sum has only the j = 0 term. Both multichoose(m,0) and multichoose(n,0) equal 1 by Nat.multichoose_zero_right, so the sum equals 1. The RHS multichoose(m+n,0) is also 1. The entire proof is dispatched by simp with multichoose_zero_right. This base case closes the (m, r=0) branch of the double induction.",
-    "mathContext": "$\\sum_{j=0}^0 \\text{mc}(m,j)\\cdot\\text{mc}(n,0-j) = \\text{mc}(m,0)\\cdot\\text{mc}(n,0) = 1\\cdot 1 = 1 = \\text{mc}(m+n,0)$. In Lean, the sum `∑ j ∈ range(0+1)` has only the $j=0$ term, and both `Nat.multichoose_zero_right` calls dispatch the factors to 1.",
-    "significance": "supporting",
-    "relatedConcepts": ["Nat.multichoose_zero_right", "base case induction", "empty sum"],
-    "prerequisites": ["Nat.multichoose_zero_right", "Finset.sum_range_succ"]
   },
   {
     "id": "ann-sum-succ-left",
     "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02",
     "range": {
-      "startLine": 62,
-      "endLine": 79
+      "startLine": 60,
+      "endLine": 77
     },
-    "type": "theorem",
+    "type": "technique",
     "title": "Sum Decomposition Lemma: The Engine of Double Induction",
     "content": "The crucial algebraic identity: Σ_{j≤r+1} mc(m+1,j)·mc(n,r+1-j) = Σ_{j≤r+1} mc(m,j)·mc(n,r+1-j) + Σ_{j≤r} mc(m+1,j)·mc(n,r-j). The proof applies sum_range_succ' to both sides to extract the j=0 terms (both equal mc(n,r+1)), leaving inner sums over range(r+1) with indices shifted. The key step: simp_rw [Nat.multichoose_succ_succ, add_mul] expands mc(m+1)(j+1) = mc(m)(j+1) + mc(m+1)(j) and distributes through the product. sum_add_distrib separates the two sum components, and ring closes the goal. The index shift r+1-(j+1) = r-j (via Nat.succ_sub_succ_eq_sub) allows the two sums to align.",
     "mathContext": "The Pascal-like recurrence $\\text{mc}(m+1)(j+1) = \\text{mc}(m)(j+1) + \\text{mc}(m+1)(j)$ gives: $\\sum_{j=0}^{r+1} \\text{mc}(m+1,j)\\cdot\\text{mc}(n,r+1-j) = \\sum_{j=0}^{r+1}[\\text{mc}(m,j+1)+\\text{mc}(m+1,j)]\\cdot\\text{mc}(n,r-j)$ (after index shift $j\\to j+1$ for $j\\geq 1$). Distributing and splitting into two sums gives the identity. This is the multiset analogue of the standard Pascal-Vandermonde step $C(m+1,j) = C(m,j) + C(m,j-1)$.",
@@ -107,13 +98,13 @@
     "id": "ann-multiset-vandermonde",
     "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02",
     "range": {
-      "startLine": 91,
-      "endLine": 121
+      "startLine": 89,
+      "endLine": 116
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Multiset Vandermonde Identity (Main Theorem)",
-    "content": "The main theorem: multichoose(m+n,r) = Σ_{j=0}^{r} multichoose(m,j)·multichoose(n,r-j) for all natural numbers m, n, r. Proved by double induction — outer on m, inner on r. The zero-m case uses sum_zero_left. The successor-m, zero-r case uses sum_zero_right. The successor-m, successor-r case is the key step: rw [hsum, Nat.multichoose_succ_succ] splits mc(m+1+n)(r+1) = mc(m+n)(r+1) + mc(m+n+1)(r). Both parts are handled by the outer IH (ih_m at r+1) and inner IH (ih_r), then sum_succ_left reassembles them. The final congr 1 and simp [Nat.add_sub_cancel] close the bookkeeping.",
-    "mathContext": "Double induction structure: $P(0,r)$ holds by `sum_zero_left`; $P(m+1,0)$ holds by `sum_zero_right`; $P(m+1,r+1)$ follows from $P(m,r+1)$ and $P(m+1,r)$ via `sum_succ_left`. In closed form: $\\text{mc}(m+1+n, r+1) = \\text{mc}(m+n, r+1) + \\text{mc}(m+n+1, r) = \\sum_j \\text{mc}(m,j)\\cdot\\text{mc}(n,r+1-j) + \\sum_j \\text{mc}(m+1,j)\\cdot\\text{mc}(n,r-j) = \\sum_j \\text{mc}(m+1,j)\\cdot\\text{mc}(n,r+1-j)$ (by `sum_succ_left`). This mirrors the proof of classical Vandermonde by induction on $m$ using Pascal's identity.",
+    "content": "The main theorem: multichoose(m+n,r) = Σ_{j=0}^{r} multichoose(m,j)·multichoose(n,r-j) for all natural numbers m, n, r. Proved by double induction — outer on m, inner on r. The zero-m case uses sum_zero_left. The successor-m, zero-r case is discharged inline with simp. The successor-m, successor-r case is the key step: rw [hsum, Nat.multichoose_succ_succ] splits mc(m+1+n)(r+1) = mc(m+n)(r+1) + mc(m+n+1)(r). Both parts are handled by the outer IH (ih_m at r+1) and inner IH (ih_r), then sum_succ_left reassembles them.",
+    "mathContext": "Double induction structure: $P(0,r)$ holds by `sum_zero_left`; $P(m+1,0)$ holds by simp (both sides are 1); $P(m+1,r+1)$ follows from $P(m,r+1)$ and $P(m+1,r)$ via `sum_succ_left`. In closed form: $\\text{mc}(m+1+n, r+1) = \\text{mc}(m+n, r+1) + \\text{mc}(m+n+1, r) = \\sum_j \\text{mc}(m,j)\\cdot\\text{mc}(n,r+1-j) + \\sum_j \\text{mc}(m+1,j)\\cdot\\text{mc}(n,r-j) = \\sum_j \\text{mc}(m+1,j)\\cdot\\text{mc}(n,r+1-j)$ (by `sum_succ_left`). This mirrors the proof of classical Vandermonde by induction on $m$ using Pascal's identity.",
     "significance": "key",
     "relatedConcepts": [
       "Nat.multichoose_succ_succ",
@@ -123,7 +114,6 @@
     ],
     "prerequisites": [
       "sum_zero_left",
-      "sum_zero_right",
       "sum_succ_left",
       "Nat.multichoose_succ_succ"
     ]

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02/meta.json
@@ -20,10 +20,10 @@
     "sorries": 0,
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified. 3 lemmas (sum_zero_left, sum_zero_right, sum_succ_left) + 1 theorem (multiset_vandermonde), all with 0 sorries.",
+    "assumptions": "None. Fully machine-verified. 2 lemmas (sum_zero_left, sum_succ_left) + 1 theorem (multiset_vandermonde), all with 0 sorries. The r=0 base case is handled inline within multiset_vandermonde rather than as a named lemma.",
     "mathlib_version": "4.26.0",
-    "lineCount": 118,
-    "theoremCount": 4,
+    "lineCount": 119,
+    "theoremCount": 3,
     "definitionCount": 0
   },
   "overview": {
@@ -50,28 +50,32 @@
       "title": "Module Docstring and Imports",
       "startLine": 1,
       "endLine": 32,
-      "summary": "Module docstring explains the multiset Vandermonde identity and its combinatorial interpretation (choosing multisets from a disjoint union). States the proof strategy (double induction via Pascal-like recurrence). Imports Mathlib.Data.Nat.Choose.Basic and Mathlib.Algebra.BigOperators.Group.Finset.Basic; opens Finset, BigOperators, and namespace MultisetVandermonde."
+      "summary": "Module docstring explains the multiset Vandermonde identity and its combinatorial interpretation (choosing multisets from a disjoint union). States the proof strategy (double induction via Pascal-like recurrence). Imports Mathlib; opens Finset, BigOperators, and namespace MultisetVandermonde.",
+      "mathContext": "The multiset coefficient $\\text{mc}(n,k) = \\binom{n+k-1}{k}$ counts size-$k$ multisets from an $n$-element set. The target identity $\\text{mc}(m+n,r) = \\sum_{j=0}^r \\text{mc}(m,j)\\cdot\\text{mc}(n,r-j)$ follows from the generating function identity $(1-x)^{-m}\\cdot(1-x)^{-n} = (1-x)^{-(m+n)}$ by comparing coefficients of $x^r$."
     },
     {
       "id": "base-cases",
-      "title": "Base Case Lemmas (m = 0 and r = 0)",
+      "title": "Base Case Lemma: m = 0",
       "startLine": 36,
-      "endLine": 53,
-      "summary": "Two base case lemmas. sum_zero_left (lines 39-48): when m = 0, multichoose(0,j) = 0 for j ≥ 1, so the sum collapses to the j = 0 term multichoose(n,r). Proved by induction on r using sum_range_succ' to extract the j = 0 term. sum_zero_right (lines 50-53): when r = 0, both sides are 1. Proved by simp with multichoose_zero_right."
+      "endLine": 47,
+      "summary": "sum_zero_left (lines 38-46): when m = 0, multichoose(0,j) = 0 for j ≥ 1, so the convolution sum collapses to the j = 0 term multichoose(n,r). Proved by induction on r using sum_range_succ' to extract the j = 0 term, then simp with multichoose_zero_succ and multichoose_zero_right. The r = 0 base case for m > 0 is handled inline in the main theorem.",
+      "mathContext": "$\\text{mc}(0, 0) = 1$ and $\\text{mc}(0, j+1) = 0$ for all $j \\geq 0$. Thus $\\sum_{j=0}^r \\text{mc}(0,j)\\cdot\\text{mc}(n,r-j) = 1\\cdot\\text{mc}(n,r) + 0 = \\text{mc}(n,r) = \\text{mc}(0+n,r)$. The Lean proof peels the $j=0$ term via `Finset.sum_range_succ'` and kills all other terms by `Nat.multichoose_zero_succ`."
     },
     {
       "id": "sum-decomposition",
       "title": "Key Sum Decomposition Lemma",
-      "startLine": 58,
-      "endLine": 79,
-      "summary": "sum_succ_left (lines 62-79): Σ_{j≤r+1} mc(m+1,j)·mc(n,r+1-j) = Σ_{j≤r+1} mc(m,j)·mc(n,r+1-j) + Σ_{j≤r} mc(m+1,j)·mc(n,r-j). Proof: extract j=0 terms via sum_range_succ', apply succ_sub_succ_eq_sub to align indices, expand mc(m+1)(j+1) = mc(m)(j+1) + mc(m+1)(j) via multichoose_succ_succ, distribute via add_mul + sum_add_distrib, close with ring."
+      "startLine": 48,
+      "endLine": 77,
+      "summary": "sum_succ_left (lines 60-77): Σ_{j≤r+1} mc(m+1,j)·mc(n,r+1-j) = Σ_{j≤r+1} mc(m,j)·mc(n,r+1-j) + Σ_{j≤r} mc(m+1,j)·mc(n,r-j). Proof: extract j=0 terms via sum_range_succ', apply succ_sub_succ_eq_sub to align indices, expand mc(m+1)(j+1) = mc(m)(j+1) + mc(m+1)(j) via multichoose_succ_succ, distribute via add_mul + sum_add_distrib, close with ring.",
+      "mathContext": "The Pascal-like recurrence $\\text{mc}(m+1)(j+1) = \\text{mc}(m)(j+1) + \\text{mc}(m+1)(j)$ drives the splitting. After peeling the $j=0$ terms from both sides (each equals $\\text{mc}(n,r+1)$, which cancels), the inner sums align under the index shift $r+1-(j+1) = r-j$. Expanding and separating via $\\Sigma$ linearity gives the two-sum identity. The closing `ring` handles the $j=0$ boundary arithmetic."
     },
     {
       "id": "main-theorem",
       "title": "Multiset Vandermonde Identity",
-      "startLine": 85,
-      "endLine": 121,
-      "summary": "multiset_vandermonde (lines 91-121): the main theorem proved by double induction. Outer induction on m uses sum_zero_left for m = 0. Inner induction on r handles m = succ, r = 0 by sum_zero_right. The key inductive step (m = succ, r = succ): rw with multichoose_succ_succ to split mc(m+1+n)(r+1) = mc(m+n)(r+1) + mc(m+n+1)(r), apply both induction hypotheses (ih_m and ih_r), then use sum_succ_left to reassemble. Final congr 1 and simp [Nat.add_sub_cancel] close the goal."
+      "startLine": 83,
+      "endLine": 116,
+      "summary": "multiset_vandermonde (lines 89-116): the main theorem proved by double induction. Outer induction on m (with r generalized) uses sum_zero_left for m = 0. Inner induction on r handles m = succ, r = 0 inline (simp). The key inductive step (m = succ, r = succ): rw with multichoose_succ_succ splits mc(m+1+n)(r+1) = mc(m+n)(r+1) + mc(m+n+1)(r), apply both induction hypotheses (ih_m at r+1 and ih_r), then use sum_succ_left in reverse to reassemble.",
+      "mathContext": "The double induction mirrors the Pascal-triangle proof of classical Vandermonde: $P(0,r)$ holds by `sum_zero_left`; $P(m+1,0)$ holds since both sides are 1; $P(m+1,r+1)$ from $P(m,r+1)$ and $P(m+1,r)$ via `sum_succ_left`. In formulas: $\\text{mc}(m+1+n,r+1) = \\text{mc}(m+n,r+1) + \\text{mc}(m+1+n,r) = \\sum_j\\text{mc}(m,j)\\text{mc}(n,r+1-j) + \\sum_j\\text{mc}(m+1,j)\\text{mc}(n,r-j) = \\sum_j\\text{mc}(m+1,j)\\text{mc}(n,r+1-j)$."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/enrichment-tracker.json
+++ b/src/data/proofs/enrichment-tracker.json
@@ -1246,5 +1246,11 @@
     "quality": 90,
     "lastEnriched": "2026-04-02",
     "status": "enriched"
+  },
+  "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02": {
+    "passes": 1,
+    "quality": 88,
+    "lastEnriched": "2026-04-21",
+    "status": "enriched"
   }
 }


### PR DESCRIPTION
## Summary

Enrichment pass for **Multiset Vandermonde Identity** (`arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02`).

### Annotation fixes (all cause annotation build errors)

- **Removed duplicate `ann-sum-zero-right`** — identical ID appeared twice in annotations.json
- **Fixed annotation types**: changed `"theorem"` → valid types (`"technique"` or `"insight"`) for all 4 non-context annotations; `"theorem"` is not a valid annotation type (valid: `concept|definition|technique|insight|context`)
- **Fixed `ann-sum-zero-left` startLine** 39 → 38 (lemma declaration line)
- **Fixed `ann-sum-succ-left` startLine** 62 → 60 (lemma declaration line)
- **Fixed `ann-multiset-vandermonde` endLine** 121 → 116 (file has 119 lines; 121 is out of bounds)
- **Redirected `ann-sum-zero-right`** from startLine 50 (a `-- ===` section comment with no Lean construct) to line 89; updated content to describe the double induction base case structure

### Meta.json improvements

- Corrected `lineCount` 118 → 119 and `theoremCount` 4 → 3 (2 lemmas + 1 theorem)
- Removed false claim of `sum_zero_right` named lemma (the r=0 case is handled inline in `multiset_vandermonde`)
- Fixed main-theorem section `endLine` 121 → 116
- Added `mathContext` (LaTeX) to all 4 sections

## Test plan

- [ ] Annotation build: `npx tsx scripts/annotations/build.ts` passes with no errors for this entry after merge
- [ ] Gallery renders correctly with updated section boundaries and annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)