### PR TITLE
Seeker: select pascals-hexagon-incomplete-01 — Sylvester's law sorry in projective conic

### DIFF
--- a/research/problems/pascals-hexagon-incomplete-01/problem.md
+++ b/research/problems/pascals-hexagon-incomplete-01/problem.md
@@ -97,3 +97,6 @@ difficulty: medium
 source: gallery-incomplete
 created: 2026-04-21
 ```
+
+**Significance**: 7/10
+**Tractability**: 6/10

--- a/research/problems/pascals-hexagon-incomplete-01/state.md
+++ b/research/problems/pascals-hexagon-incomplete-01/state.md
@@ -3,14 +3,19 @@
 ## Current State
 **Phase**: OBSERVE
 **Path**: full
-**Since**: 2026-04-21T16:44:08+02:00
+**Since**: 2026-04-21T17:45:00+02:00
 **Iteration**: 1
+**Selected by Seeker**: 2026-04-21
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Sylvester's law sorry in `proof_sketch_conic_implies_pascal` (PascalsHexagon.lean:1134).
+The one remaining sorry needs a projective equivalence between an arbitrary conic and
+`stdConic = x² + y² - z²` via an invertible matrix M.
 
 ## Active Approach
-None yet.
+None yet. Primary paths:
+1. `QuadraticForm.equivalent` / Sylvester inertia in Mathlib QuadraticForm
+2. `Matrix.IsHermitian.spectral_theorem` + eigenvalue sign permutation
 
 ## Attempt Count
 - Total attempts: 0
@@ -18,8 +23,9 @@ None yet.
 - Approaches tried: 0
 
 ## Blockers
-None.
+None yet.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+ORIENT: Search Mathlib for `QuadraticForm.Equivalent`, `sylvester`, signature/inertia
+results. Check `Mathlib.LinearAlgebra.QuadraticForm.Basic` and
+`Mathlib.Analysis.InnerProductSpace.Spectrum`.


### PR DESCRIPTION
## Seeker Selection Report

**Date**: 2026-04-21
**Pool**: 15 available (threshold: 15), 11 active claims

## Selected Problem

- **ID**: `pascals-hexagon-incomplete-01`
- **Name**: Complete Pascal's Hexagon Theorem (Sylvester's Law sorry)
- **Tier**: B | Significance: 7/10 | Tractability: 6/10
- **Knowledge**: EMPTY (no prior research)
- **Domain**: Projective geometry (Wiedijk #28)

## Selection Rationale

1. **1 well-specified sorry**: `proof_sketch_conic_implies_pascal` line 1134 — needs Sylvester's law to show any real conic with signature (2,1) is projectively equivalent to `stdConic = x² + y² - z²`
2. **Domain diversity**: geometry (projective) — distinct from recent combinatorics and analysis selections
3. **Wiedijk-100 completion**: removes the sole sorry from Wiedijk #28
4. **Clear approach path**: Mathlib has QuadraticForm machinery; proof structure fully scaffolded

## Suggested First Steps

1. ORIENT: Search Mathlib for `QuadraticForm.Equivalent`, `sylvester`, signature results
2. ORIENT: Check `Matrix.IsHermitian.spectral_theorem` for eigenvalue diagonalization
3. DECIDE: Choose abstract quadratic form vs concrete spectral theorem path
4. ACT: Bridge Mathlib's `QuadraticForm` API to matrix-based `Conic` type

## Pool Health After Selection

Pool at threshold (15 available) — monitoring. Next check in 30 minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)