### PR TITLE
Enrich lhopital-oq-01: fix index.ts, full annotation coverage

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02/annotations.json
@@ -2,33 +2,38 @@
   {
     "id": "ann-mvandermonde-header",
     "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02",
-    "range": { "startLine": 1, "endLine": 31 },
+    "range": {
+      "startLine": 1,
+      "endLine": 32
+    },
     "type": "context",
     "title": "Multiset Vandermonde: Problem Setup and Strategy",
-    "content": "The module docstring frames the problem: prove the multiset Vandermonde identity mc(m+n,r) = Σ_{j=0}^{r} mc(m,j)·mc(n,r-j), where mc(n,k) = Nat.multichoose n k counts multisets of size k drawn from a set of n elements. The combinatorial reading: choosing a multiset of size r from a disjoint union of m+n types splits by how many items (j) come from the first m types, giving a product mc(m,j)·mc(n,r-j). The proof strategy is double induction on m and r using the Pascal-like recurrence mc(n+1)(k+1) = mc(n)(k+1) + mc(n+1)(k), the multiset analogue of Pascal's triangle identity.",
-    "mathContext": "The multiset coefficient $\\text{mc}(n,k) = \\binom{n+k-1}{k}$ counts multisets of size $k$ from $n$ types. The identity $\\text{mc}(m+n,r) = \\sum_{j=0}^r \\text{mc}(m,j)\\cdot\\text{mc}(n,r-j)$ follows from $(1/(1-x))^{m+n} = (1/(1-x))^m \\cdot (1/(1-x))^n$ by extracting the $[x^r]$ coefficient on each side. The Pascal-like recurrence $\\text{mc}(n+1)(k+1) = \\text{mc}(n)(k+1) + \\text{mc}(n+1)(k)$ plays the same structural role as $\\binom{n}{k} = \\binom{n-1}{k-1} + \\binom{n-1}{k}$ in the classical proof.",
+    "content": "The module docstring frames the problem: prove the multiset Vandermonde identity C^ms(m+n,r) = Σ_{j=0}^{r} C^ms(m,j)·C^ms(n,r-j), where C^ms(n,k) = Nat.multichoose n k counts multisets of size k from a set of n elements. The relation multichoose n k = C(n+k-1, k) connects multiset coefficients to standard binomials. The proof strategy is double induction on m and r, driven by the Pascal-like recurrence multichoose(n+1)(k+1) = multichoose n (k+1) + multichoose(n+1) k.",
+    "mathContext": "The multiset coefficient satisfies $\\binom{n+k-1}{k} = \\text{multichoose}(n,k)$, the number of ways to choose $k$ items from $n$ types with repetition. The identity $\\text{mc}(m+n,r) = \\sum_{j=0}^r \\text{mc}(m,j)\\cdot\\text{mc}(n,r-j)$ is the 'stars and bars' analogue of Vandermonde: choosing $r$ items with repetition from $m+n$ types splits by how many come from the first $m$ types. The Pascal-like recurrence $\\text{mc}(n+1)(k+1) = \\text{mc}(n)(k+1) + \\text{mc}(n+1)(k)$ plays the role of Pascal's triangle identity $\\binom{n}{k} = \\binom{n-1}{k-1} + \\binom{n-1}{k}$.",
     "significance": "context",
     "relatedConcepts": [
       "multiset coefficient",
-      "stars and bars",
       "Vandermonde identity",
-      "generating functions",
-      "Pascal recurrence"
+      "Pascal recurrence",
+      "stars and bars"
     ],
     "prerequisites": [
       "Nat.multichoose",
       "Nat.multichoose_succ_succ",
-      "classical Vandermonde identity"
+      "Mathlib.Data.Nat.Choose.Basic"
     ]
   },
   {
     "id": "ann-sum-zero-left",
     "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02",
-    "range": { "startLine": 37, "endLine": 47 },
+    "range": {
+      "startLine": 38,
+      "endLine": 47
+    },
     "type": "technique",
     "title": "Base Case m = 0: Only j = 0 Term Survives",
-    "content": "When m = 0, every multiset coefficient mc(0, j) = 0 for j ≥ 1 (there are no multisets of size ≥ 1 from an empty set). So the Vandermonde sum Σ_{j=0}^{r} mc(0,j)·mc(n,r-j) collapses to just the j = 0 term: mc(0,0)·mc(n,r) = 1·mc(n,r) = mc(n,r). The proof proceeds by induction on r: the zero case is dispatched by `simp [multichoose_zero_right]`; the successor case uses `sum_range_succ'` to split off the j = 0 term (mc(n,r+1)) from the front of the sum, then `simp` with `multichoose_zero_succ` (= 0) kills all remaining terms.",
-    "mathContext": "$\\text{mc}(0, 0) = 1$ (one empty multiset) and $\\text{mc}(0, j+1) = 0$ for all $j$ (no nonempty multisets from the empty set). Thus $\\sum_{j=0}^r \\text{mc}(0,j)\\cdot\\text{mc}(n,r-j) = 1\\cdot\\text{mc}(n,r) + \\sum_{j=1}^r 0 = \\text{mc}(n,r)$. In Lean, `Finset.sum_range_succ'` splits a sum over `range(r+1)` into `f(0) + Σ_{j < r} f(j+1)`, enabling the j=0 extraction.",
+    "content": "When m = 0, multichoose 0 j = 0 for all j ≥ 1 (only multichoose 0 0 = 1). So the sum Σ_{j≤r} multichoose(0,j)·multichoose(n,r-j) collapses to just the j = 0 term: 1·multichoose n r = multichoose n r. Proved by induction on r: the zero case uses multichoose_zero_right; the successor case uses sum_range_succ' to split off the j = 0 term, then simp dispatches the rest with multichoose_zero_succ (= 0) and multichoose_zero_right (= 1).",
+    "mathContext": "$\\text{mc}(0, 0) = 1$ and $\\text{mc}(0, j+1) = 0$ for all $j$. Thus $\\sum_{j=0}^r \\text{mc}(0,j)\\cdot\\text{mc}(n,r-j) = \\text{mc}(0,0)\\cdot\\text{mc}(n,r) + \\sum_{j=1}^r 0 = \\text{mc}(n,r)$. The Lean proof uses `sum_range_succ'` to split off the $j=0$ term from the sum over `range(r+1)`, placing it at the front. Then `multichoose_zero_succ` kills all remaining terms.",
     "significance": "supporting",
     "relatedConcepts": [
       "Nat.multichoose_zero_right",
@@ -42,92 +47,75 @@
     ]
   },
   {
-    "id": "ann-sum-succ-left-docstring",
+    "id": "ann-sum-zero-right",
     "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02",
-    "range": { "startLine": 52, "endLine": 63 },
+    "range": {
+      "startLine": 89,
+      "endLine": 103
+    },
     "type": "insight",
-    "title": "sum_succ_left: The Algebraic Engine of the Inductive Step",
-    "content": "This lemma captures the key algebraic identity that allows the m-th inductive case to imply the (m+1)-th: the Vandermonde sum for m+1 items over range(r+2) equals the sum for m items over range(r+2) plus the sum for m+1 items over range(r+1). In other words, increasing m by 1 decomposes the new sum into the old sum (with m) plus a shorter sum. This mirrors how Pascal's identity decomposes C(m+1, j) = C(m, j) + C(m, j-1), turning the passage from m to m+1 into a sum of two known quantities. The lemma's statement uses range(r+2) for the first two sums and range(r+1) for the third — the index shift is built into the formulation.",
-    "mathContext": "The identity: $\\sum_{j=0}^{r+1} \\text{mc}(m+1,j)\\cdot\\text{mc}(n,r+1-j) = \\sum_{j=0}^{r+1} \\text{mc}(m,j)\\cdot\\text{mc}(n,r+1-j) + \\sum_{j=0}^{r} \\text{mc}(m+1,j)\\cdot\\text{mc}(n,r-j)$. The proof strategy: extract $j=0$ terms from both range($r+2$) sums (they both equal $\\text{mc}(n,r+1)$ and cancel), apply $\\text{mc}(m+1)(j+1) = \\text{mc}(m)(j+1) + \\text{mc}(m+1)(j)$ to the shifted inner sums, then `sum_add_distrib` separates them into two sums.",
-    "significance": "key",
-    "relatedConcepts": [
-      "Pascal recurrence",
-      "algebraic decomposition",
-      "inductive step lemma",
-      "Finset.sum_add_distrib"
-    ],
-    "prerequisites": [
-      "Nat.multichoose_succ_succ",
-      "Finset.sum_range_succ'",
-      "Finset.sum_add_distrib"
-    ]
-  },
-  {
-    "id": "ann-sum-succ-left-proof",
-    "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02",
-    "range": { "startLine": 64, "endLine": 77 },
-    "type": "technique",
-    "title": "sum_succ_left Proof: Index Shifting and Sum Splitting",
-    "content": "The proof proceeds mechanically in 5 steps: (1) apply `sum_range_succ'` twice to split both range(r+2) sums — the j=0 terms (mc(m+1,0)·mc(n,r+1) and mc(m,0)·mc(n,r+1)) both equal mc(n,r+1) and combine via `one_mul`; (2) handle the index shift — the inner sums have r+1-(j+1) which simplifies to r-j by `omega`, applied via `simp_rw [hsub]`; (3) expand the Pascal recurrence mc(m+1)(j+1) = mc(m)(j+1) + mc(m+1)(j) using `simp_rw [Nat.multichoose_succ_succ, add_mul]`, distributing the product through the sum; (4) separate the two halves using `sum_add_distrib`; (5) close with `ring` to handle the commutative rearrangement.",
-    "mathContext": "Key tactic: `simp_rw [Nat.succ_sub_succ_eq_sub]` (simplified here as `omega`) aligns the subtraction index $r+1-(j+1) = r-j$. This is necessary because Lean's natural number subtraction is truncated, and the rewrite must happen under the sum binder. The final `ring` step handles: $a + (b + c) = a + b + c$ and any remaining associativity/commutativity.",
-    "significance": "technical",
-    "relatedConcepts": [
-      "simp_rw",
-      "Nat.multichoose_succ_succ",
-      "Finset.sum_range_succ'",
-      "Finset.sum_add_distrib",
-      "natural number subtraction",
-      "ring tactic"
-    ],
-    "prerequisites": [
-      "Lean 4 simp_rw tactic",
-      "Finset.sum_range_succ'",
-      "add_mul distributivity"
-    ]
-  },
-  {
-    "id": "ann-multiset-vandermonde-statement",
-    "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02",
-    "range": { "startLine": 83, "endLine": 91 },
-    "type": "concept",
-    "title": "Multiset Vandermonde Identity: Statement",
-    "content": "The main theorem states that multichoose(m+n, r) = Σ_{j=0}^{r} multichoose(m,j)·multichoose(n,r-j) for all natural numbers m, n, r. The combinatorial reading: any multiset of size r drawn from m+n types can be uniquely decomposed by choosing j items from the first m types and r-j items from the remaining n types. Summing over all valid j gives the total count. The Finset.range(r+1) sum ranges j over 0, 1, ..., r; terms where j > m or r-j > n automatically vanish because multichoose_eq_zero_of_lt = 0 in those cases (more precisely, multichoose(0)(k+1) = 0 handles the boundary).",
-    "mathContext": "$\\text{mc}(m+n, r) = \\sum_{j=0}^r \\text{mc}(m,j)\\cdot\\text{mc}(n,r-j)$, where $\\text{mc}(n,k) = \\binom{n+k-1}{k}$. Generating function proof: $\\sum_r \\text{mc}(m+n,r) x^r = (1-x)^{-(m+n)} = (1-x)^{-m}\\cdot(1-x)^{-n} = \\left(\\sum_j \\text{mc}(m,j)x^j\\right)\\left(\\sum_k \\text{mc}(n,k)x^k\\right)$; coefficient of $x^r$ on the right is exactly $\\sum_j \\text{mc}(m,j)\\cdot\\text{mc}(n,r-j)$.",
-    "significance": "key",
-    "relatedConcepts": [
-      "multiset coefficient",
-      "Vandermonde identity",
-      "convolution",
-      "generating functions",
-      "stars and bars"
-    ],
-    "prerequisites": [
-      "Nat.multichoose",
-      "Finset.range sum",
-      "combinatorics of multisets"
-    ]
-  },
-  {
-    "id": "ann-multiset-vandermonde-proof",
-    "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02",
-    "range": { "startLine": 92, "endLine": 117 },
-    "type": "insight",
-    "title": "Double Induction: Assembling the Proof from Lemmas",
-    "content": "The proof uses nested induction: outer on m (generalizing r via `induction m generalizing r`), inner on r. The four cases are: (1) m=0: `sum_zero_left` gives the result directly; (2) m=succ, r=0: `simp [multichoose_zero_right]` closes the goal since both sides equal 1; (3) m=succ, r=succ (the key case): the arithmetic identity `hsum : m+1+n = (m+n)+1` enables rewriting the LHS as mc(m+n)(r+1) + mc(m+n+1)(r) via `multichoose_succ_succ`, then the outer IH gives the sum for mc(m+n)(r+1) and the inner IH gives the sum for mc(m+n+1)(r), and finally `sum_succ_left` (applied in reverse via `← sum_succ_left`) combines them into the RHS sum for mc(m+1+n)(r+1).",
-    "mathContext": "The key inductive step in closed form: $\\text{mc}(m+1+n, r+1) = \\text{mc}(m+n, r+1) + \\text{mc}((m+n)+1, r)$ by the Pascal recurrence. By outer IH: $\\text{mc}(m+n, r+1) = \\sum_{j} \\text{mc}(m,j)\\cdot\\text{mc}(n,r+1-j)$. By inner IH: $\\text{mc}(m+1+n, r) = \\sum_{j} \\text{mc}(m+1,j)\\cdot\\text{mc}(n,r-j)$. Adding and applying `sum_succ_left` in reverse: sum = $\\sum_{j} \\text{mc}(m+1,j)\\cdot\\text{mc}(n,r+1-j)$.",
+    "title": "Double Induction: Inline Base Cases for r = 0 and m = 0",
+    "content": "The main theorem uses double induction — outer on m (with r generalized), inner on r. The m = 0 base case (line 94-97) delegates to sum_zero_left. The m = succ, r = 0 base case (lines 100-103) is handled inline: multichoose(m+1+n, 0) = 1 = multichoose(m+1, 0)·multichoose(n, 0) since multichoose _ 0 = 1 for any first argument, so `simp [Nat.multichoose_zero_right]` closes the goal immediately. This avoids a separate lemma for the r=0 base; the one-liner `simp` subsumes what would otherwise require a standalone proof.",
+    "mathContext": "At $r = 0$: $\\text{mc}(m+1+n, 0) = 1$ and the sum $\\sum_{j=0}^{0} \\text{mc}(m+1, j)\\cdot\\text{mc}(n, 0-j) = \\text{mc}(m+1, 0)\\cdot\\text{mc}(n, 0) = 1\\cdot 1 = 1$. Since `Nat.multichoose_zero_right : ∀ n, multichoose n 0 = 1`, both sides reduce to 1 in one simp step. The outer induction `induction m generalizing r` gives the IH a universally-quantified `r`, enabling the inner induction to use the outer IH at a different value of $r$.",
     "significance": "key",
     "relatedConcepts": [
       "double induction",
-      "Nat.multichoose_succ_succ",
+      "Nat.multichoose_zero_right",
       "induction generalizing",
-      "sum_succ_left",
+      "base case"
+    ],
+    "prerequisites": [
+      "Nat.multichoose_zero_right",
       "sum_zero_left"
+    ]
+  },
+  {
+    "id": "ann-sum-succ-left",
+    "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02",
+    "range": {
+      "startLine": 60,
+      "endLine": 77
+    },
+    "type": "technique",
+    "title": "Sum Decomposition Lemma: The Engine of Double Induction",
+    "content": "The crucial algebraic identity: Σ_{j≤r+1} mc(m+1,j)·mc(n,r+1-j) = Σ_{j≤r+1} mc(m,j)·mc(n,r+1-j) + Σ_{j≤r} mc(m+1,j)·mc(n,r-j). The proof applies sum_range_succ' to both sides to extract the j=0 terms (both equal mc(n,r+1)), leaving inner sums over range(r+1) with indices shifted. The key step: simp_rw [Nat.multichoose_succ_succ, add_mul] expands mc(m+1)(j+1) = mc(m)(j+1) + mc(m+1)(j) and distributes through the product. sum_add_distrib separates the two sum components, and ring closes the goal. The index shift r+1-(j+1) = r-j (via Nat.succ_sub_succ_eq_sub) allows the two sums to align.",
+    "mathContext": "The Pascal-like recurrence $\\text{mc}(m+1)(j+1) = \\text{mc}(m)(j+1) + \\text{mc}(m+1)(j)$ gives: $\\sum_{j=0}^{r+1} \\text{mc}(m+1,j)\\cdot\\text{mc}(n,r+1-j) = \\sum_{j=0}^{r+1}[\\text{mc}(m,j+1)+\\text{mc}(m+1,j)]\\cdot\\text{mc}(n,r-j)$ (after index shift $j\\to j+1$ for $j\\geq 1$). Distributing and splitting into two sums gives the identity. This is the multiset analogue of the standard Pascal-Vandermonde step $C(m+1,j) = C(m,j) + C(m,j-1)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.multichoose_succ_succ",
+      "Finset.sum_range_succ'",
+      "Finset.sum_add_distrib",
+      "Pascal recurrence"
+    ],
+    "prerequisites": [
+      "Nat.multichoose_succ_succ",
+      "Nat.succ_sub_succ_eq_sub",
+      "Finset.sum_range_succ'",
+      "Finset.sum_add_distrib"
+    ]
+  },
+  {
+    "id": "ann-multiset-vandermonde",
+    "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02",
+    "range": {
+      "startLine": 89,
+      "endLine": 116
+    },
+    "type": "insight",
+    "title": "Multiset Vandermonde Identity (Main Theorem)",
+    "content": "The main theorem: multichoose(m+n,r) = Σ_{j=0}^{r} multichoose(m,j)·multichoose(n,r-j) for all natural numbers m, n, r. Proved by double induction — outer on m, inner on r. The zero-m case uses sum_zero_left. The successor-m, zero-r case is discharged inline with simp. The successor-m, successor-r case is the key step: rw [hsum, Nat.multichoose_succ_succ] splits mc(m+1+n)(r+1) = mc(m+n)(r+1) + mc(m+n+1)(r). Both parts are handled by the outer IH (ih_m at r+1) and inner IH (ih_r), then sum_succ_left reassembles them.",
+    "mathContext": "Double induction structure: $P(0,r)$ holds by `sum_zero_left`; $P(m+1,0)$ holds by simp (both sides are 1); $P(m+1,r+1)$ follows from $P(m,r+1)$ and $P(m+1,r)$ via `sum_succ_left`. In closed form: $\\text{mc}(m+1+n, r+1) = \\text{mc}(m+n, r+1) + \\text{mc}(m+n+1, r) = \\sum_j \\text{mc}(m,j)\\cdot\\text{mc}(n,r+1-j) + \\sum_j \\text{mc}(m+1,j)\\cdot\\text{mc}(n,r-j) = \\sum_j \\text{mc}(m+1,j)\\cdot\\text{mc}(n,r+1-j)$ (by `sum_succ_left`). This mirrors the proof of classical Vandermonde by induction on $m$ using Pascal's identity.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.multichoose_succ_succ",
+      "double induction",
+      "Vandermonde identity",
+      "multiset coefficient"
     ],
     "prerequisites": [
       "sum_zero_left",
       "sum_succ_left",
-      "Nat.multichoose_succ_succ",
-      "Lean 4 nested induction"
+      "Nat.multichoose_succ_succ"
     ]
   }
 ]

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02/meta.json
@@ -20,10 +20,10 @@
     "sorries": 0,
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified. 3 lemmas (sum_zero_left, sum_zero_right, sum_succ_left) + 1 theorem (multiset_vandermonde), all with 0 sorries.",
+    "assumptions": "None. Fully machine-verified. 2 lemmas (sum_zero_left, sum_succ_left) + 1 theorem (multiset_vandermonde), all with 0 sorries. The r=0 base case is handled inline within multiset_vandermonde rather than as a named lemma.",
     "mathlib_version": "4.26.0",
-    "lineCount": 118,
-    "theoremCount": 4,
+    "lineCount": 119,
+    "theoremCount": 3,
     "definitionCount": 0
   },
   "overview": {
@@ -50,28 +50,32 @@
       "title": "Module Docstring and Imports",
       "startLine": 1,
       "endLine": 32,
-      "summary": "Module docstring explains the multiset Vandermonde identity and its combinatorial interpretation (choosing multisets from a disjoint union). States the proof strategy (double induction via Pascal-like recurrence). Imports Mathlib.Data.Nat.Choose.Basic and Mathlib.Algebra.BigOperators.Group.Finset.Basic; opens Finset, BigOperators, and namespace MultisetVandermonde."
+      "summary": "Module docstring explains the multiset Vandermonde identity and its combinatorial interpretation (choosing multisets from a disjoint union). States the proof strategy (double induction via Pascal-like recurrence). Imports Mathlib; opens Finset, BigOperators, and namespace MultisetVandermonde.",
+      "mathContext": "The multiset coefficient $\\text{mc}(n,k) = \\binom{n+k-1}{k}$ counts size-$k$ multisets from an $n$-element set. The target identity $\\text{mc}(m+n,r) = \\sum_{j=0}^r \\text{mc}(m,j)\\cdot\\text{mc}(n,r-j)$ follows from the generating function identity $(1-x)^{-m}\\cdot(1-x)^{-n} = (1-x)^{-(m+n)}$ by comparing coefficients of $x^r$."
     },
     {
       "id": "base-cases",
-      "title": "Base Case Lemmas (m = 0 and r = 0)",
+      "title": "Base Case Lemma: m = 0",
       "startLine": 36,
-      "endLine": 53,
-      "summary": "Two base case lemmas. sum_zero_left (lines 39-48): when m = 0, multichoose(0,j) = 0 for j ≥ 1, so the sum collapses to the j = 0 term multichoose(n,r). Proved by induction on r using sum_range_succ' to extract the j = 0 term. sum_zero_right (lines 50-53): when r = 0, both sides are 1. Proved by simp with multichoose_zero_right."
+      "endLine": 47,
+      "summary": "sum_zero_left (lines 38-46): when m = 0, multichoose(0,j) = 0 for j ≥ 1, so the convolution sum collapses to the j = 0 term multichoose(n,r). Proved by induction on r using sum_range_succ' to extract the j = 0 term, then simp with multichoose_zero_succ and multichoose_zero_right. The r = 0 base case for m > 0 is handled inline in the main theorem.",
+      "mathContext": "$\\text{mc}(0, 0) = 1$ and $\\text{mc}(0, j+1) = 0$ for all $j \\geq 0$. Thus $\\sum_{j=0}^r \\text{mc}(0,j)\\cdot\\text{mc}(n,r-j) = 1\\cdot\\text{mc}(n,r) + 0 = \\text{mc}(n,r) = \\text{mc}(0+n,r)$. The Lean proof peels the $j=0$ term via `Finset.sum_range_succ'` and kills all other terms by `Nat.multichoose_zero_succ`."
     },
     {
       "id": "sum-decomposition",
       "title": "Key Sum Decomposition Lemma",
-      "startLine": 58,
-      "endLine": 79,
-      "summary": "sum_succ_left (lines 62-79): Σ_{j≤r+1} mc(m+1,j)·mc(n,r+1-j) = Σ_{j≤r+1} mc(m,j)·mc(n,r+1-j) + Σ_{j≤r} mc(m+1,j)·mc(n,r-j). Proof: extract j=0 terms via sum_range_succ', apply succ_sub_succ_eq_sub to align indices, expand mc(m+1)(j+1) = mc(m)(j+1) + mc(m+1)(j) via multichoose_succ_succ, distribute via add_mul + sum_add_distrib, close with ring."
+      "startLine": 48,
+      "endLine": 77,
+      "summary": "sum_succ_left (lines 60-77): Σ_{j≤r+1} mc(m+1,j)·mc(n,r+1-j) = Σ_{j≤r+1} mc(m,j)·mc(n,r+1-j) + Σ_{j≤r} mc(m+1,j)·mc(n,r-j). Proof: extract j=0 terms via sum_range_succ', apply succ_sub_succ_eq_sub to align indices, expand mc(m+1)(j+1) = mc(m)(j+1) + mc(m+1)(j) via multichoose_succ_succ, distribute via add_mul + sum_add_distrib, close with ring.",
+      "mathContext": "The Pascal-like recurrence $\\text{mc}(m+1)(j+1) = \\text{mc}(m)(j+1) + \\text{mc}(m+1)(j)$ drives the splitting. After peeling the $j=0$ terms from both sides (each equals $\\text{mc}(n,r+1)$, which cancels), the inner sums align under the index shift $r+1-(j+1) = r-j$. Expanding and separating via $\\Sigma$ linearity gives the two-sum identity. The closing `ring` handles the $j=0$ boundary arithmetic."
     },
     {
       "id": "main-theorem",
       "title": "Multiset Vandermonde Identity",
-      "startLine": 85,
-      "endLine": 121,
-      "summary": "multiset_vandermonde (lines 91-121): the main theorem proved by double induction. Outer induction on m uses sum_zero_left for m = 0. Inner induction on r handles m = succ, r = 0 by sum_zero_right. The key inductive step (m = succ, r = succ): rw with multichoose_succ_succ to split mc(m+1+n)(r+1) = mc(m+n)(r+1) + mc(m+n+1)(r), apply both induction hypotheses (ih_m and ih_r), then use sum_succ_left to reassemble. Final congr 1 and simp [Nat.add_sub_cancel] close the goal."
+      "startLine": 83,
+      "endLine": 116,
+      "summary": "multiset_vandermonde (lines 89-116): the main theorem proved by double induction. Outer induction on m (with r generalized) uses sum_zero_left for m = 0. Inner induction on r handles m = succ, r = 0 inline (simp). The key inductive step (m = succ, r = succ): rw with multichoose_succ_succ splits mc(m+1+n)(r+1) = mc(m+n)(r+1) + mc(m+n+1)(r), apply both induction hypotheses (ih_m at r+1 and ih_r), then use sum_succ_left in reverse to reassemble.",
+      "mathContext": "The double induction mirrors the Pascal-triangle proof of classical Vandermonde: $P(0,r)$ holds by `sum_zero_left`; $P(m+1,0)$ holds since both sides are 1; $P(m+1,r+1)$ from $P(m,r+1)$ and $P(m+1,r)$ via `sum_succ_left`. In formulas: $\\text{mc}(m+1+n,r+1) = \\text{mc}(m+n,r+1) + \\text{mc}(m+1+n,r) = \\sum_j\\text{mc}(m,j)\\text{mc}(n,r+1-j) + \\sum_j\\text{mc}(m+1,j)\\text{mc}(n,r-j) = \\sum_j\\text{mc}(m+1,j)\\text{mc}(n,r+1-j)$."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/annotations.json
@@ -1,86 +1,154 @@
 [
   {
-    "id": "ann-hook-lgv-header",
+    "id": "ann-hook-context",
     "proofId": "ballot-problem-oq-03-oq-01-oq-02",
-    "range": { "startLine": 1, "endLine": 61 },
+    "range": { "startLine": 1, "endLine": 36 },
     "type": "context",
-    "title": "Hook-Length Formula via LGV: Setup and Strategy",
-    "content": "The file extends the n×n LGV infrastructure (BallotProblemOQ03OQ02) toward the Frame-Robinson-Thrall (1954) hook-length formula. The strategy requires two deep steps: (1) bijection SYT(λ) ↔ NI-path tuples using the Greene-Viennot-Fomin correspondence, and (2) the algebraic identity det[C(m+σⱼ+j-i,m)] = n!/hookProd(λ). The LGV encoding uses sources(k)=k and targets(k)=σ(k)+k where σ is the weakly-increasing reversal of the partition rows. The namespace opens YoungDiagram, Finset, and LGV.",
-    "mathContext": "Hook-length formula: $f^\\lambda = \\frac{n!}{\\prod_{u \\in \\lambda} h(u)}$ where $h(i,j) = \\text{arm}(i,j) + \\text{leg}(i,j) + 1$. LGV encoding: for partition rows $(\\rho_0 \\geq \\cdots \\geq \\rho_{r-1})$, set $\\sigma_k = \\rho_{r-1-k}$ (weakly increasing), sources $= k$, targets $= \\sigma_k + k$. The bijection SYT$(\\lambda) \\leftrightarrow$ NI-paths is the Robinson-Schensted-Knuth correspondence.",
-    "significance": "key",
-    "relatedConcepts": ["Frame-Robinson-Thrall 1954", "LGV lemma", "hook-length formula", "Standard Young Tableaux", "RSK correspondence"],
-    "prerequisites": ["lgv_lemma_rxr from BallotProblemOQ03OQ02", "YoungDiagram API", "LGVConfig structure"]
+    "title": "Hook-Length Formula: Historical Context and LGV Strategy",
+    "content": "The hook-length formula (Frame-Robinson-Thrall 1954) counts Standard Young Tableaux: f^λ = n!/∏h(u), where h(u) = arm(u) + leg(u) + 1 is the hook length at cell u of shape λ. This is one of the most celebrated formulas in algebraic combinatorics — it connects SYT enumeration, representation theory (f^λ = dim Specht module S^λ), and lattice path counting via LGV. The file extends the n×n LGV infrastructure from BallotProblemOQ03OQ02 toward a full formalization: hook infrastructure is built and verified numerically for 8 shapes, while the two deep steps (SYT↔NI bijection and det factorization) remain as named sorries.",
+    "mathContext": "For a Young diagram $\\lambda$ with $n = |\\lambda|$ cells, the **hook-length formula** states $f^\\lambda = \\frac{n!}{\\prod_{u \\in \\lambda} h(u)}$, where $h(u) = \\text{arm}(u) + \\text{leg}(u) + 1$. The **LGV proof strategy**: (1) SYT($\\lambda$) bijects with non-intersecting lattice path tuples via the Fomin/RSK correspondence; (2) the LGV determinant $\\det\\left[\\binom{m+\\sigma_j+j-i}{m}\\right]$ factors as $n!/\\text{hookProd}(\\lambda)$. Together with the LGV lemma, these give $|\\text{SYT}(\\lambda)| = n!/\\text{hookProd}(\\lambda)$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Frame-Robinson-Thrall formula",
+      "Standard Young Tableaux",
+      "LGV lemma",
+      "Specht modules",
+      "RSK correspondence"
+    ],
+    "prerequisites": [
+      "lgv_lemma_rxr from BallotProblemOQ03OQ02",
+      "YoungDiagram (Mathlib)",
+      "Frame-Robinson-Thrall 1954"
+    ]
   },
   {
-    "id": "ann-hook-infrastructure",
+    "id": "ann-hook-length-def",
     "proofId": "ballot-problem-oq-03-oq-01-oq-02",
-    "range": { "startLine": 63, "endLine": 110 },
+    "range": { "startLine": 47, "endLine": 71 },
     "type": "definition",
-    "title": "Hook Length Infrastructure: armLen, legLen, hookLength",
-    "content": "Three definitions build the hook length: `armLen μ i j = μ.rowLen i - j - 1` counts cells strictly right of (i,j) in row i; `legLen μ i j = μ.colLen j - i - 1` counts cells strictly below (i,j) in column j; `hookLength μ i j = armLen + legLen + 1`. Key lemmas: `hookLength_pos` proves positivity (arm+leg+1 ≥ 1 unconditionally by omega); `hookLength_add_eq` gives h(i,j) + i + j + 1 = rowLen(i) + colLen(j) for (i,j) ∈ μ, avoiding natural number subtraction issues; `hookLength_corner` gives h(0,0) + 1 = rowLen(0) + colLen(0).",
-    "mathContext": "$h(i,j) = (\\mu.\\text{rowLen}\\,i - j - 1) + (\\mu.\\text{colLen}\\,j - i - 1) + 1$. Positivity: $\\text{arm} + \\text{leg} + 1 \\geq 1$ always. Key identity: $h(i,j) + i + j + 1 = \\mu.\\text{rowLen}\\,i + \\mu.\\text{colLen}\\,j$ for $(i,j) \\in \\mu$. This form avoids $\\mathbb{N}$-subtraction since all terms are natural numbers.",
+    "title": "hookLength: arm + leg + 1, Always Positive",
+    "content": "Three layered definitions: armLen μ i j = rowLen(i) - j - 1 (cells to the right), legLen μ i j = colLen(j) - i - 1 (cells below), hookLength μ i j = armLen + legLen + 1. The unconditional positivity lemma hookLength_pos uses omega directly (arm + leg + 1 ≥ 1 always). The characterization lemma hookLength_add_eq: for (i,j) ∈ μ, hookLength + i + j + 1 = rowLen(i) + colLen(j) — this avoids ℕ subtraction issues by converting the hook formula to an additive identity. The membership hypotheses give j < rowLen(i) and i < colLen(j), which reenergize the subtraction terms.",
+    "mathContext": "In a Young diagram $\\mu$: $\\text{arm}(i,j) = \\text{rowLen}(i) - j - 1$ and $\\text{leg}(i,j) = \\text{colLen}(j) - i - 1$, so $h(i,j) = \\text{arm} + \\text{leg} + 1$. **Key identity**: $h(i,j) + i + j + 1 = \\text{rowLen}(i) + \\text{colLen}(j)$ for $(i,j) \\in \\mu$. This is proved by `omega` using the membership conditions $j < \\text{rowLen}(i)$ and $i < \\text{colLen}(j)$, which prevent truncated-subtraction degeneracy. The hook-length formula uses this identity: $\\prod_{(i,j)\\in\\mu} h(i,j) = \\text{hookProd}(\\mu)$.",
     "significance": "key",
-    "relatedConcepts": ["YoungDiagram.rowLen", "YoungDiagram.colLen", "mem_iff_lt_rowLen", "mem_iff_lt_colLen", "omega tactic"],
-    "prerequisites": ["YoungDiagram from Mathlib", "Nat.sub in Lean 4", "YoungDiagram.mem_iff_lt_rowLen"]
+    "relatedConcepts": [
+      "YoungDiagram.rowLen",
+      "YoungDiagram.colLen",
+      "arm length",
+      "leg length",
+      "natural number subtraction"
+    ],
+    "prerequisites": [
+      "YoungDiagram.mem_iff_lt_rowLen",
+      "YoungDiagram.mem_iff_lt_colLen",
+      "omega tactic"
+    ]
   },
   {
-    "id": "ann-hook-product",
+    "id": "ann-hook-prod-def",
     "proofId": "ballot-problem-oq-03-oq-01-oq-02",
-    "range": { "startLine": 112, "endLine": 130 },
+    "range": { "startLine": 79, "endLine": 92 },
     "type": "definition",
-    "title": "Hook Product: ∏_{(i,j)∈μ} h(i,j)",
-    "content": "`hookProd μ = ∏ c ∈ μ.cells, hookLength μ c.1 c.2` is the product of all hook lengths over all cells. Proved positive by `hookProd_pos` (using `Finset.prod_pos` with `hookLength_pos` at each cell). The empty diagram case: `hookProd_empty : hookProd ⊥ = 1` by `YoungDiagram.cells_bot + Finset.prod_empty`. The hook product is the denominator in the Frame-Robinson-Thrall formula f^λ = n!/hookProd(λ).",
-    "mathContext": "$\\text{hookProd}(\\mu) = \\prod_{(i,j) \\in \\mu} h(i,j)$. Positivity: each $h(i,j) \\geq 1$, so the product is $\\geq 1$. Empty case: $\\mu = \\bot$ has no cells, so $\\text{hookProd}(\\bot) = \\prod_{\\emptyset} = 1$. For example, $\\text{hookProd}(3,2,1) = 5 \\times 3 \\times 1 \\times 3 \\times 1 \\times 1 = 45$.",
+    "title": "hookProd: Product of Hook Lengths over All Cells",
+    "content": "hookProd μ = ∏ c ∈ μ.cells, hookLength μ c.1 c.2 — the product of all hook lengths over all cells. Two basic properties: hookProd_pos (always > 0, via Finset.prod_pos + hookLength_pos) and hookProd_empty (= 1 for the empty diagram, via cells_bot + prod_empty). The hook-length formula states card(SYT μ) × hookProd μ = μ.card! Numerically: for (2,1): hookProd = 3×1×1 = 3, 3!/3 = 2 SYTs; for (3,2,1): hookProd = 5×3×1×3×1×1 = 45, 6!/45 = 16 SYTs.",
+    "mathContext": "$\\text{hookProd}(\\mu) = \\prod_{(i,j) \\in \\mu} h(i,j)$. Positivity: each factor $h(i,j) \\geq 1 > 0$, so `Finset.prod_pos` with `hookLength_pos` gives $\\text{hookProd}(\\mu) > 0$. Empty diagram: $\\mu = \\bot$ has `cells_bot = \\emptyset$`, giving the empty product = 1. The hook-length formula can be written as $\\text{card(SYT}(\\mu)) = \\frac{|\\mu|!}{\\text{hookProd}(\\mu)}$, where $\\text{hookProd}(\\mu)$ always divides $|\\mu|!$ (a non-obvious divisibility result).",
     "significance": "key",
-    "relatedConcepts": ["Finset.prod", "Finset.prod_pos", "YoungDiagram.cells_bot", "Finset.prod_empty"],
-    "prerequisites": ["hookLength_pos", "YoungDiagram.cells in Mathlib", "Finset.prod_pos"]
+    "relatedConcepts": [
+      "hookLength",
+      "YoungDiagram.cells",
+      "Finset.prod_pos",
+      "hook-length formula"
+    ],
+    "prerequisites": [
+      "hookLength_pos",
+      "YoungDiagram.cells_bot",
+      "Finset.prod_pos",
+      "Finset.prod_empty"
+    ]
   },
   {
     "id": "ann-syt-structure",
     "proofId": "ballot-problem-oq-03-oq-01-oq-02",
-    "range": { "startLine": 132, "endLine": 165 },
+    "range": { "startLine": 101, "endLine": 120 },
     "type": "definition",
-    "title": "StandardYoungTableau: Bijective Strict Filling",
-    "content": "`StandardYoungTableau μ` is a structure with fields: `entry : ℕ × ℕ → ℕ` (value 0 outside μ), `entry_zero` (outside-cells = 0), `entry_range` (values in {1,...,μ.card}), `entry_injOn` (injective on μ), `row_strict` (strict left-to-right increase), `col_strict` (strict top-to-bottom increase). The `ext` theorem (sorry) requires proof irrelevance for the Prop-valued fields. The key distinction from Mathlib's `SemistandardYoungTableau` is that SYT requires strict row increase (not weak), which forces entries to be a permutation of {1,...,n}.",
-    "mathContext": "SYT conditions: $T : \\mu \\to \\{1,\\ldots,|\\mu|\\}$ bijective with $T(i,j_1) < T(i,j_2)$ when $j_1 < j_2$ and $T(i_1,j) < T(i_2,j)$ when $i_1 < i_2$. Count: $f^\\lambda = |\\text{SYT}(\\lambda)|$. For shape $(2,1)$: $f^{(2,1)} = 2$.",
+    "title": "StandardYoungTableau: Strict Row/Column Increases, Not in Mathlib",
+    "content": "Defines StandardYoungTableau μ as a structure with 6 fields: entry (cell → ℕ), entry_zero (cells outside μ map to 0), entry_range (cells inside μ have entries in {1,...,|μ|}), entry_injOn (injectivity on μ), row_strict (entries strictly increase left-to-right), col_strict (entries strictly increase top-to-bottom). Mathlib has SemistandardYoungTableau (weakly increasing rows) but NOT SYT. The ext lemma (proved by cases + funext) gives proof irrelevance: two SYTs are equal iff their entry functions agree everywhere.",
+    "mathContext": "An SYT of shape $\\mu$ is a bijection $T: \\mu \\to \\{1,\\ldots,|\\mu|\\}$ with $T(i,j_1) < T(i,j_2)$ for $j_1 < j_2$ (row-strict) and $T(i_1,j) < T(i_2,j)$ for $i_1 < i_2$ (column-strict). Extending $T$ to all of $\\mathbb{N}^2$ via `entry_zero` (outside cells = 0) makes the domain a total Lean function. The `Fintype` instance for `StandardYoungTableau μ` (needed for `Fintype.card`) remains open — it would require showing SYT biject with a `Fin` type via the column-reading order.",
     "significance": "key",
-    "relatedConcepts": ["SemistandardYoungTableau in Mathlib", "RSK correspondence", "Fintype instance", "proof irrelevance"],
-    "prerequisites": ["YoungDiagram from Mathlib", "Lean 4 structure", "bijective filling", "strict monotonicity"]
+    "relatedConcepts": [
+      "SemistandardYoungTableau (Mathlib)",
+      "YoungDiagram",
+      "Fintype.card",
+      "RSK correspondence"
+    ],
+    "prerequisites": [
+      "YoungDiagram",
+      "Fintype",
+      "funext"
+    ]
   },
   {
     "id": "ann-lgv-config",
     "proofId": "ballot-problem-oq-03-oq-01-oq-02",
-    "range": { "startLine": 167, "endLine": 221 },
-    "type": "technique",
-    "title": "LGV Configuration: Partition Encoding for NI-Path Counting",
-    "content": "`youngLGVConfig r σ hσ m hm` encodes the partition with weakly-increasing row lengths σ as an LGV configuration: sources(k) = k, targets(k) = σ(k)+k. Targets are strictly monotone because σ monotone + i < j implies σ(i)+i < σ(j)+j (via omega). The `youngLGVConfig_wellFormed` lemma proves the LGV well-formedness condition (any source ≤ any target) under the hypothesis σ⟨0⟩ ≥ r-1. The sigma convention: rows are REVERSED so σ is weakly INCREASING (matching LGV target monotonicity).",
-    "mathContext": "Configuration: $\\text{sources}(k) = k$, $\\text{targets}(k) = \\sigma(k) + k$ for $\\sigma$ weakly increasing. Target monotonicity: $i < j \\Rightarrow \\sigma(i) + i < \\sigma(j) + j$. Well-formedness: $\\text{sources}(i) = i \\leq r-1 \\leq \\sigma(0) \\leq \\sigma(j)+j = \\text{targets}(j)$.",
-    "significance": "key",
-    "relatedConcepts": ["LGVConfig", "lgv_lemma_rxr", "Monotone in Lean 4", "Fin.mk_le_mk"],
-    "prerequisites": ["LGVConfig from BallotProblemOQ03OQ02", "Monotone typeclass", "Fin ordering in Lean 4"]
+    "range": { "startLine": 130, "endLine": 153 },
+    "type": "definition",
+    "title": "youngLGVConfig: LGV Encoding for Partitions via Reversed Row Lengths",
+    "content": "youngLGVConfig r σ hσ m hm builds the LGV configuration for a partition with weakly increasing row lengths σ : Fin r → ℕ (reversed from standard partition order). Sources: k ↦ k (identity, strictly monotone). Targets: k ↦ σ(k) + k (strictly monotone since σ monotone + position increments). The wellFormed condition (max source ≤ min target) requires σ(0) ≥ r-1: the smallest row must be long enough to dominate all sources. targets_strictMono is proved by omega after establishing σ(a) ≤ σ(b) (from monotonicity) and a < b (given).",
+    "mathContext": "For partition $(\\lambda_1 \\geq \\cdots \\geq \\lambda_r)$, reverse to get $\\sigma = (\\lambda_r \\leq \\cdots \\leq \\lambda_1)$. LGV sources $a_k = k$, targets $b_k = \\sigma_k + k$. Strictly monotone: $\\sigma_a \\leq \\sigma_b$ and $a < b$ imply $\\sigma_a + a < \\sigma_b + b$. **wellFormed** requires $\\max\\{a_k\\} = r-1 \\leq \\min\\{b_k\\} = \\sigma_0 + 0$, i.e., $\\sigma_0 \\geq r-1$ (smallest row length $\\geq$ number of rows minus 1). This ensures paths have valid start/end positions.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "LGVConfig",
+      "niTupleCount",
+      "Fomin growth diagrams",
+      "RSK correspondence"
+    ],
+    "prerequisites": [
+      "LGVConfig from BallotProblemOQ03OQ02",
+      "Monotone",
+      "Fin.zero_le"
+    ]
   },
   {
-    "id": "ann-main-theorem-sorry",
+    "id": "ann-main-theorem-sorries",
     "proofId": "ballot-problem-oq-03-oq-01-oq-02",
-    "range": { "startLine": 236, "endLine": 291 },
+    "range": { "startLine": 164, "endLine": 191 },
     "type": "insight",
-    "title": "Hook-Length Formula: Two Hard Sorries and Proof Structure",
-    "content": "The main theorem `hook_length_formula` depends on two sorry components: (1) `ni_count_eq_syt_count` — the SYT↔NI bijection via the Fomin/Viennot correspondence (~200 lines); (2) `lgv_det_factors_as_hook_quotient` — the identity det[C(m+σⱼ+j-i,m)]×hookProd = n! (~200 lines of determinant algebra). Together they imply hook_length_formula via `lgv_lemma_rxr`. The 2-row rectangular case `hook_length_formula_2row_rect` is fully proved (delegates to `LGVCorollaries.hook_length_formula_two_row`), providing a validated partial result.",
-    "mathContext": "Sorry chain: SYT$(\\mu) \\cong$ NI-paths (Fomin bijection) + $\\det[M] \\cdot \\text{hookProd} = n!$ (Frame-Robinson-Thrall) $\\Rightarrow$ $|\\text{SYT}(\\mu)| \\cdot \\text{hookProd}(\\mu) = n!$. Proved: $C_m \\cdot ((m+1)! \\cdot m!) = (2m)!$ (2-row Catalan formula).",
+    "title": "Three Open Sorries: Bijection, Det Factorization, Full Formula",
+    "content": "The proof requires three sorry steps: (1) hook_length_formula: card(SYT μ) × hookProd μ = μ.card! — the main result, combining (2) and (3) with lgv_lemma_rxr. (2) ni_count_eq_syt_count: card(SYT μ) = niTupleCount(youngLGVConfig) — the Fomin growth diagram bijection between SYT and non-intersecting lattice path tuples (~200 lines). (3) lgv_det_factors_as_hook_quotient: det[C(m+σⱼ+j-i,m)] = μ.card!/hookProd μ — a Vandermonde-type algebraic identity (~200 lines). The 2-row formula (hook_length_formula_2row_rect) IS proved, connecting to BallotProblemOQ03OQ03.",
+    "mathContext": "Full proof chain: $|\\text{SYT}(\\mu)| \\overset{(2)}{=} \\text{niTupleCount} \\overset{\\text{LGV}}{=} |\\det[C(m+\\sigma_j+j-i,m)]| \\overset{(3)}{=} \\frac{n!}{\\text{hookProd}(\\mu)}$. The **Fomin correspondence** (step 2) is the RSK bijection restricted to standard tableaux, realized via growth diagrams. The **Frame-Robinson-Thrall identity** (step 3) expresses the LGV determinant as a product of binomial coefficients that telescopes to the hook quotient. Both require ~200 lines of Lean infrastructure not yet formalized.",
     "significance": "key",
-    "relatedConcepts": ["Frame-Robinson-Thrall 1954", "Fomin growth diagrams", "Vandermonde identity", "niTupleCount"],
-    "prerequisites": ["lgv_lemma_rxr from BallotProblemOQ03OQ02", "niTupleCount definition", "Fintype.card for StandardYoungTableau"]
+    "relatedConcepts": [
+      "hook_length_formula_2row_rect",
+      "lgv_lemma_rxr",
+      "RSK correspondence",
+      "Frame-Robinson-Thrall identity",
+      "Vandermonde determinant"
+    ],
+    "prerequisites": [
+      "lgv_lemma_rxr",
+      "ni_count_eq_syt_count (sorry)",
+      "lgv_det_factors_as_hook_quotient (sorry)"
+    ]
   },
   {
     "id": "ann-numerical-verification",
     "proofId": "ballot-problem-oq-03-oq-01-oq-02",
-    "range": { "startLine": 293, "endLine": 354 },
+    "range": { "startLine": 199, "endLine": 223 },
     "type": "technique",
-    "title": "Numerical Verification via norm_num for 8 Specific Shapes",
-    "content": "The hook-length formula is verified for 8 specific Young diagram shapes using `norm_num` on factorial arithmetic: (2,1)→2, (2,2)→2, (3,1)→3, (3,2)→5, (3,2,1)→16, (4,3,2,1)→1440, (3,3)→5 (Catalan C₃), (4,4)→14 (Catalan C₄). Each verification is an `example` that directly checks `n!.factorial / hookProd = f^λ`. The Catalan connection: for shape (m,m), f^(m,m) = Cₘ = C(2m,m)/(m+1). The (4,4) hookProd = 5×4×3×2×4×3×2×1 = 2880, and 8!/2880 = 14 = C₄.",
-    "mathContext": "Hook-length table: $f^{(2,1)} = 3!/3 = 2$, $f^{(3,2,1)} = 6!/45 = 16$, $f^{(4,4)} = 8!/2880 = 14 = C_4$. Catalan numbers: $f^{(m,m)} = \\frac{(2m)!}{(m+1)! \\cdot m!} = C_m$.",
+    "title": "Numerical Verification via norm_num for 8 Shapes",
+    "content": "Eight concrete examples verify the hook-length formula numerically for specific shapes: (2,1)→2, (2,2)→2, (3,1)→3, (3,2)→5, (3,2,1)→16, (4,3,2,1)→1440, (3,3)→5 (Catalan C₃), (4,4)→14 (Catalan C₄). All proved by norm_num after computing hookProd explicitly. The Catalan cases connect to the ballot problem: f^{(n,n)} = C_n since SYT of rectangular 2-row shape (n,n) biject with Dyck paths (non-crossing matchings). The norm_num proofs validate the hook computations without needing the full bijection proof.",
+    "mathContext": "**Catalan connection**: $f^{(n,n)} = C_n = \\frac{1}{n+1}\\binom{2n}{n}$. For $(3,3)$: hookProd $= 4\\cdot 3\\cdot 2\\cdot 3\\cdot 2\\cdot 1 = 144$, $f = 6!/144 = 5 = C_3$. For $(4,4)$: hookProd $= 5\\cdot 4\\cdot 3\\cdot 2\\cdot 4\\cdot 3\\cdot 2\\cdot 1 = 2880$, $f = 8!/2880 = 14 = C_4$. These connect to `hook_length_formula_2row_rect` (proved via `LGVCorollaries.hook_length_formula_two_row`): $C_m \\cdot (m+1)!\\cdot m! = (2m)!$.",
     "significance": "supporting",
-    "relatedConcepts": ["norm_num tactic", "Catalan numbers", "factorial computation", "hook product table"],
-    "prerequisites": ["Nat.factorial in Lean 4", "norm_num for ℕ arithmetic"]
+    "relatedConcepts": [
+      "Catalan numbers",
+      "norm_num tactic",
+      "hook product",
+      "staircase partition",
+      "Dyck paths"
+    ],
+    "prerequisites": [
+      "hookProd computation",
+      "Nat.factorial",
+      "norm_num"
+    ]
   }
 ]

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -18,12 +18,12 @@
       "determinants",
       "representation-theory"
     ],
-    "badge": "verified",
-    "sorries": 4,
+    "badge": "research",
+    "sorries": 3,
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "assumptions": "Four open sorries: (1) StandardYoungTableau.ext (proof irrelevance via funext), (2) hook_length_formula (requires SYT↔NI bijection), (3) ni_count_eq_syt_count (Fomin/Viennot correspondence), (4) lgv_det_factors_as_hook_quotient (det factorization identity).",
-    "lineCount": 220,
+    "assumptions": "Three open sorries: (1) hook_length_formula (requires SYT↔NI bijection + det factorization), (2) ni_count_eq_syt_count (Fomin growth diagram bijection, ~200 lines), (3) lgv_det_factors_as_hook_quotient (Frame-Robinson-Thrall det identity, ~200 lines). StandardYoungTableau.ext is fully proved. The 2-row formula (hook_length_formula_2row_rect) is proved via BallotProblemOQ03OQ03.",
+    "lineCount": 225,
     "theoremCount": 12,
     "definitionCount": 5,
     "originalContributions": [
@@ -79,33 +79,33 @@
       "LGV"
     ],
     "namespace": "HookLengthFormula",
-    "lineCount": 220,
+    "lineCount": 225,
     "axiomCount": 0,
-    "sorries": 4,
+    "sorries": 3,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",
     "theoremCount": 12,
     "definitionCount": 5
   },
   "crossReferences": [
     {
-      "id": "ballot-problem-oq-03-oq-01",
-      "title": "LGV Lemma 2×2",
-      "relationship": "foundational"
+      "targetId": "ballot-problem-oq-03-oq-01",
+      "relationship": "foundational",
+      "description": "LGV Lemma 2×2 — the 2×2 determinantal path counting formula that forms the base case of the LGV infrastructure used here"
     },
     {
-      "id": "ballot-problem-oq-03-oq-02",
-      "title": "LGV Lemma n×n",
-      "relationship": "foundational"
+      "targetId": "ballot-problem-oq-03-oq-02",
+      "relationship": "foundational",
+      "description": "LGV Lemma n×n — the general n×n LGV determinant formula (lgv_lemma_rxr) that is the main tool for proving the hook-length formula"
     },
     {
-      "id": "ballot-problem-oq-03-oq-01-oq-01",
-      "title": "General n×n LGV (restatement)",
-      "relationship": "sibling"
+      "targetId": "ballot-problem-oq-03-oq-01-oq-01",
+      "relationship": "sibling",
+      "description": "General n×n LGV restatement — parallel formulation of the LGV lemma for comparison"
     },
     {
-      "id": "ballot-problem-oq-03-oq-03",
-      "title": "2-row hook-length formula",
-      "relationship": "extends"
+      "targetId": "ballot-problem-oq-03-oq-03",
+      "relationship": "extends",
+      "description": "2-row hook-length formula (LGVCorollaries.hook_length_formula_two_row) — proves the special case C_m·(m+1)!·m! = (2m)!, which hook_length_formula_2row_rect reuses directly"
     }
   ],
   "sections": [
@@ -158,5 +158,5 @@
       "mathContext": "Verified: (2,1)→2, (2,2)→2, (3,1)→3, (3,2)→5, (3,2,1)→16, (4,3,2,1)→1440, (3,3)→5 (C₃), (4,4)→14 (C₄)."
     }
   ],
-  "sorries": 4
+  "sorries": 3
 }

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/annotations.json
@@ -1,0 +1,107 @@
+[
+  {
+    "id": "ann-multinomial-context",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-01",
+    "range": { "startLine": 7, "endLine": 30 },
+    "type": "context",
+    "title": "Multinomial PMF in Mathlib: Strategy and Dependencies",
+    "content": "The open question asks whether the multinomial distribution can be integrated into Mathlib's PMF framework. The answer is yes: the construction proceeds in four steps — (1) define the support type (Composition), (2) construct the PMF value function in ENNReal, (3) prove normalization from the multinomial theorem, and (4) derive properties (marginals, moments). The key insight is that the multinomial theorem IS the normalization proof. The file depends on BinomialTheoremOQ02OQ01 (multinomialProb, multinomialProb_sum_eq_one) and Mathlib's PMF type which requires a function α → ℝ≥0∞ plus a tsum = 1 normalization proof.",
+    "mathContext": "Mathlib's `PMF α` is a structure: $f : \\alpha \\to \\mathbb{R}_{\\geq 0}^\\infty$ with $\\sum_{a : \\alpha} f(a) = 1$. The multinomial PMF assigns $f(k) = \\binom{n}{k_1, \\ldots, k_r} \\prod_{i} p_i^{k_i}$ to each composition $k = (k_1, \\ldots, k_r)$ with $\\sum k_i = n$. **Normalization**: the multinomial theorem gives $(\\sum_i p_i)^n = \\sum_{\\sum k_i = n} \\binom{n}{k} \\prod p_i^{k_i} = 1$ when $\\sum p_i = 1$. This makes the multinomial theorem the normalization proof directly.",
+    "significance": "context",
+    "relatedConcepts": [
+      "PMF (Mathlib)",
+      "multinomial distribution",
+      "ENNReal",
+      "multinomial theorem",
+      "BinomialTheoremOQ02OQ01"
+    ],
+    "prerequisites": [
+      "Mathlib PMF framework",
+      "ENNReal arithmetic",
+      "Nat.multinomial (Mathlib)"
+    ]
+  },
+  {
+    "id": "ann-composition-type",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-01",
+    "range": { "startLine": 41, "endLine": 53 },
+    "type": "definition",
+    "title": "Composition: The Support Type of the Multinomial Distribution",
+    "content": "Defines Composition α s n as a structure with three fields: counts : α → ℕ (the outcome counts), sum_eq (the counts sum to n), and counts_outside (counts outside the alphabet s are 0). This serves as the support type — every point in the multinomial distribution is one element of this type. The Fintype instance is open (sorry): the finiteness follows because each counts(i) ≤ n and there are finitely many indices in s, making the space finite by a counting argument via piAntidiag.",
+    "mathContext": "The support of the multinomial$(n, p_1, \\ldots, p_r)$ distribution is $\\{(k_1, \\ldots, k_r) : k_i \\geq 0, \\sum k_i = n\\} = \\text{piAntidiag}(s, n)$ as a Finset. The `Composition` structure wraps this finset as a `Fintype` suitable for Lean's `PMF α` which requires a `Fintype` or `Countable` index type. The finiteness: each $k_i \\leq n$, so the support is contained in $\\{0,\\ldots,n\\}^{|s|}$, which is finite.",
+    "significance": "key",
+    "relatedConcepts": [
+      "piAntidiag (Mathlib)",
+      "Fintype",
+      "PMF support",
+      "composition (combinatorics)"
+    ],
+    "prerequisites": [
+      "Finset.piAntidiag",
+      "Fintype",
+      "DecidableEq"
+    ]
+  },
+  {
+    "id": "ann-pmf-normalization",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-01",
+    "range": { "startLine": 63, "endLine": 99 },
+    "type": "insight",
+    "title": "Multinomial Theorem = PMF Normalization",
+    "content": "The deepest insight of this file: the multinomial theorem IS the PMF normalization proof. multinomialPMFVal s p n k = multinomial(s,k.counts) · ∏ p(i)^k.counts(i) and the sum over all compositions equals (∑ p(i))^n = 1 (when ∑ p(i) = 1). The normalization theorem multinomialPMF_sum_eq_one states this in ENNReal (sorry: requires lifting Finset.sum_pow_eq_sum_piAntidiag to ENNReal). multinomialPMF is then a trivial constructor: ⟨multinomialPMFVal, normalization_proof⟩.",
+    "mathContext": "$\\sum_{k : \\text{Composition}(s,n)} \\binom{n}{k_1,\\ldots,k_r} \\prod_{i\\in s} p_i^{k_i} = \\left(\\sum_{i\\in s} p_i\\right)^n = 1^n = 1$. In Lean: `Finset.sum_pow_eq_sum_piAntidiag` expresses the multinomial theorem as a Finset sum over `piAntidiag s n`. Lifting from `ℝ` to `ℝ≥0∞` requires careful handling of the coercion $\\mathbb{N} \\to \\mathbb{R}_{\\geq 0}^\\infty$ and the ENNReal version of the product-sum interchange.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.sum_pow_eq_sum_piAntidiag",
+      "ENNReal coercions",
+      "PMF.mk",
+      "multinomial theorem"
+    ],
+    "prerequisites": [
+      "Nat.multinomial",
+      "Finset.sum_pow_eq_sum_piAntidiag",
+      "ENNReal.coe_nat"
+    ]
+  },
+  {
+    "id": "ann-marginal-binomial",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-01",
+    "range": { "startLine": 133, "endLine": 141 },
+    "type": "insight",
+    "title": "Marginal Distributions are Binomial (open sorry)",
+    "content": "The marginal theorem multinomial_marginal_binomial states: fixing the i-th component to m and summing over all remaining compositions, the sum equals C(n,m) · p(i)^m · (1-p(i))^(n-m). This is the binomial PMF formula. Proof strategy: fix k(i) = m, sum over piAntidiag(s\\{i}, n-m) for the remaining components, and apply the (k-1)-dimensional multinomial theorem to recognize (1-p(i))^(n-m) = (∑_{j≠i} p(j))^(n-m). The sorry captures ~100 lines of Finset manipulation.",
+    "mathContext": "$P(X_i = m) = \\sum_{k: k_i = m} P(X = k) = \\binom{n}{m} p_i^m \\sum_{k': \\sum k'_j = n-m} \\binom{n-m}{k'} \\prod_{j\\neq i} p_j^{k'_j} = \\binom{n}{m} p_i^m (1-p_i)^{n-m}$. The inner sum equals $(1-p_i)^{n-m}$ by the $(k-1)$-dimensional multinomial theorem applied to $\\{p_j : j \\neq i\\}$, which sum to $1 - p_i$. This proves $X_i \\sim \\text{Binomial}(n, p_i)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "binomial distribution",
+      "marginal distribution",
+      "piAntidiag",
+      "multinomial theorem"
+    ],
+    "prerequisites": [
+      "Finset.piAntidiag",
+      "Nat.choose",
+      "multinomial theorem"
+    ]
+  },
+  {
+    "id": "ann-moments-covariance",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-01",
+    "range": { "startLine": 148, "endLine": 168 },
+    "type": "insight",
+    "title": "Mean npᵢ and Negative Covariance -npᵢpⱼ (both open)",
+    "content": "Two moment results, both sorry: multinomial_mean (E[Xᵢ] = n·pᵢ) and multinomial_covariance (Cov(Xᵢ,Xⱼ) = -n·pᵢ·pⱼ for i≠j). The mean follows by differentiating the multinomial theorem generating function. The covariance uses E[XᵢXⱼ] = n(n-1)pᵢpⱼ (from fixing two coordinates and summing over remaining n-2 draws), giving Cov = n(n-1)pᵢpⱼ - (npᵢ)(npⱼ) = -npᵢpⱼ. The negative covariance reflects the constraint ∑ Xᵢ = n: more of one outcome necessarily means less of another.",
+    "mathContext": "$E[X_i] = \\sum_{k} k_i \\cdot P(X=k) = n p_i$ (differentiating $(\\sum p_j)^n$ w.r.t. $p_i$). $\\text{Cov}(X_i, X_j) = E[X_i X_j] - E[X_i]E[X_j] = n(n-1)p_i p_j - n^2 p_i p_j = -n p_i p_j < 0$. The negative covariance is characteristic of constrained counts: all $X_i$ sum to the fixed $n$, so any fluctuation above the mean in $X_i$ forces below-mean fluctuations in $\\sum_{j \\neq i} X_j$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "generating function",
+      "negative covariance",
+      "moment computation",
+      "sum constraint"
+    ],
+    "prerequisites": [
+      "multinomial_marginal_binomial",
+      "Finset.sum manipulation"
+    ]
+  }
+]

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/index.ts
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/index.ts
@@ -1,0 +1,8 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean?raw'
+const meta = metaJson as unknown as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+export const binomialTheoremOQ02OQ01OQ01Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections ?? [], source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
+export const binomialTheoremOQ02OQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+export const binomialTheoremOQ02OQ01OQ01Data: ProofData = { proof: binomialTheoremOQ02OQ01OQ01Proof, annotations: binomialTheoremOQ02OQ01OQ01Annotations, tacticStates: [] }

--- a/src/data/proofs/enrichment-tracker.json
+++ b/src/data/proofs/enrichment-tracker.json
@@ -1258,5 +1258,11 @@
     "quality": 93,
     "lastEnriched": "2026-04-21",
     "status": "enriched"
+  },
+  "ballot-problem-oq-03-oq-01-oq-02": {
+    "passes": 1,
+    "quality": 85,
+    "lastEnriched": "2026-04-21",
+    "status": "enriched"
   }
 }

--- a/src/data/proofs/enrichment-tracker.json
+++ b/src/data/proofs/enrichment-tracker.json
@@ -1264,5 +1264,11 @@
     "quality": 85,
     "lastEnriched": "2026-04-21",
     "status": "enriched"
+  },
+  "binomial-theorem-oq-02-oq-01-oq-01": {
+    "passes": 1,
+    "quality": 80,
+    "lastEnriched": "2026-04-21",
+    "status": "enriched"
   }
 }

--- a/src/data/proofs/enrichment-tracker.json
+++ b/src/data/proofs/enrichment-tracker.json
@@ -1246,5 +1246,11 @@
     "quality": 90,
     "lastEnriched": "2026-04-02",
     "status": "enriched"
+  },
+  "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02": {
+    "passes": 1,
+    "quality": 88,
+    "lastEnriched": "2026-04-21",
+    "status": "enriched"
   }
 }

--- a/src/data/proofs/enrichment-tracker.json
+++ b/src/data/proofs/enrichment-tracker.json
@@ -1252,5 +1252,11 @@
     "quality": 88,
     "lastEnriched": "2026-04-21",
     "status": "enriched"
+  },
+  "szemeredi-hypergraph-core-oq-01-incomplete-01": {
+    "passes": 1,
+    "quality": 93,
+    "lastEnriched": "2026-04-21",
+    "status": "enriched"
   }
 }

--- a/src/data/proofs/lhopital-oq-01/annotations.json
+++ b/src/data/proofs/lhopital-oq-01/annotations.json
@@ -1,31 +1,74 @@
 [
   {
     "id": "ann-overview",
+    "proofId": "lhopital-oq-01",
+    "range": { "startLine": 1, "endLine": 30 },
+    "type": "concept",
     "title": "One-Directional Nature of L'Hôpital's Rule",
-    "type": "overview",
-    "startLine": 1,
-    "endLine": 30,
-    "mathContext": "L'Hôpital's rule says: f'/g' → L implies f/g → L (under suitable conditions). The rule does NOT say: f/g → L implies f'/g' → L. This entry provides the canonical machine-verified counterexample showing the converse fails.",
-    "significance": "Many students try to 'run L'Hôpital backwards' — this proof conclusively shows that approach fails. The example f = x + sin x, g = x is deceptively simple: the ratio f/g is asymptotically trivial, but f'/g' oscillates wildly."
+    "content": "L'Hôpital's rule is a **one-directional tool**: the implication runs only from derivatives to ratios, never the reverse.\n\nThe rule states: if $f'/g' \\to L$ (under suitable conditions) then $f/g \\to L$. A common student error is to \"run L'Hôpital backwards\" — to conclude that if $f/g \\to L$ then $f'/g' \\to L$. This file provides a clean machine-verified counterexample that closes this gap.\n\nThe counterexample is beautifully simple: $f(x) = x + \\sin x$, $g(x) = x$. The ratio $f/g = 1 + \\sin(x)/x \\to 1$ (trivially), while $f'/g' = 1 + \\cos x$ oscillates between 0 and 2 indefinitely.",
+    "mathContext": "L'Hôpital (forward): $\\frac{f'}{g'} \\to L \\Rightarrow \\frac{f}{g} \\to L$. Converse fails: $\\frac{f}{g} \\to L \\not\\Rightarrow \\frac{f'}{g'} \\to L$. Counterexample: $f = x + \\sin x$, $g = x$ gives $\\frac{f}{g} \\to 1$ but $\\frac{f'}{g'} = 1 + \\cos x$ diverges.",
+    "significance": "key",
+    "relatedConcepts": ["L'Hôpital's rule", "counterexample", "oscillating limits", "one-directional implications"],
+    "prerequisites": ["L'Hôpital's rule (lhopital.lean)", "real analysis: limits at infinity"]
+  },
+  {
+    "id": "ann-derivatives",
+    "proofId": "lhopital-oq-01",
+    "range": { "startLine": 36, "endLine": 49 },
+    "type": "technique",
+    "title": "Computing Derivatives via HasDerivAt Composition",
+    "content": "The three derivative lemmas set up the ratio $f'/g'$ that will be shown to have no limit.\n\n`f_hasDerivAt` uses `.add` to combine `hasDerivAt_id` (derivative of $x$ is 1) with `Real.hasDerivAt_sin` (derivative of $\\sin x$ is $\\cos x$). The result is that $(x + \\sin x)' = 1 + \\cos x$.\n\n`g_hasDerivAt` is simply `hasDerivAt_id` applied to $g(x) = x$, giving $g'(x) = 1$.\n\n`deriv_ratio_eq` then reduces $(1 + \\cos x)/1$ to $1 + \\cos x$ via `div_one` — a trivial algebraic step that clarifies what function we are studying.",
+    "mathContext": "$f(x) = x + \\sin x \\Rightarrow f'(x) = 1 + \\cos x$ (by sum rule). $g(x) = x \\Rightarrow g'(x) = 1$. Hence $\\frac{f'(x)}{g'(x)} = \\frac{1 + \\cos x}{1} = 1 + \\cos x$.",
+    "significance": "supporting",
+    "relatedConcepts": ["HasDerivAt", "hasDerivAt_id", "Real.hasDerivAt_sin", "sum rule for derivatives"],
+    "prerequisites": ["Mathlib HasDerivAt API", "trigonometric differentiation"]
   },
   {
     "id": "ann-squeeze",
-    "title": "sin(x)/x → 0: Squeeze via x⁻¹",
+    "proofId": "lhopital-oq-01",
+    "range": { "startLine": 54, "endLine": 78 },
     "type": "technique",
-    "startLine": 53,
-    "endLine": 72,
-    "mathContext": "Key bound: |sin(x)/x| = |sin x|/x ≤ 1/x = x⁻¹ (for x > 0). The bound uses |sin x| ≤ 1 (from Real.sin_le_one and Real.neg_one_le_sin), division monotonicity via gcongr, and tendsto_inv_atTop_zero for the right side.",
-    "significance": "The proof avoids all trigonometric computation — it only needs the basic bound |sin x| ≤ 1. This is cleaner than approaches using L'Hôpital's rule itself to compute the limit.",
-    "relatedConcepts": ["tendsto_inv_atTop_zero", "gcongr", "Filter.Metric.tendsto_atTop"]
+    "title": "sin(x)/x → 0: Squeeze via x⁻¹",
+    "content": "This is a clean ε-δ proof of $\\sin(x)/x \\to 0$ that avoids all trigonometric computation beyond the basic bound $|\\sin x| \\leq 1$.\n\n**Strategy**: Use `Metric.tendsto_atTop` to unfold both `hinv` (the known $x^{-1} \\to 0$) and the goal, then show $|\\sin x / x| < \\varepsilon$ by the chain:\n$$|\\sin x / x| = |\\sin x|/x \\leq 1/x = x^{-1} < \\varepsilon.$$\n\nThe bound $|\\sin x| \\leq 1$ comes from `Real.sin_le_one` and `Real.neg_one_le_sin`, combined via `abs_le`. The monotone inequality $|\\sin x|/x \\leq 1/x$ is discharged by `gcongr`.\n\n**Pedagogically**: This proves `sin(x)/x → 0` at infinity without L'Hôpital — a useful self-contained result.",
+    "mathContext": "$|\\sin x / x| = |\\sin x|/x \\leq 1/x = x^{-1} \\xrightarrow{x\\to\\infty} 0$. Squeeze: $0 \\leq |\\sin x/x| \\leq x^{-1} \\to 0$ forces $\\sin x/x \\to 0$.",
+    "significance": "key",
+    "relatedConcepts": ["tendsto_inv_atTop_zero", "gcongr", "Metric.tendsto_atTop", "squeeze theorem"],
+    "prerequisites": ["epsilon-delta limits", "absolute value inequalities", "Mathlib filter API"]
+  },
+  {
+    "id": "ann-ratio-limit",
+    "proofId": "lhopital-oq-01",
+    "range": { "startLine": 79, "endLine": 92 },
+    "type": "insight",
+    "title": "f/g → 1 via Algebraic Rearrangement + sin(x)/x → 0",
+    "content": "Having established $\\sin(x)/x \\to 0$, the limit $f/g \\to 1$ follows by writing $(x + \\sin x)/x = 1 + \\sin x/x$.\n\nThe equality holds for $x \\neq 0$; the proof uses `filter_upwards [eventually_ge_atTop 1]` to restrict to $x \\geq 1$ where $x \\neq 0$ certainly holds. Then `field_simp` performs the algebraic manipulation.\n\nThe limit $1 + \\sin x/x \\to 1 + 0 = 1$ follows from `Tendsto.add` (adding a constant tendency to `sin_div_tendsto_zero`), and `Tendsto.congr'` transfers the result to the original formulation $(x + \\sin x)/x$.\n\nThis is a textbook illustration of **limit arithmetic**: reducing a ratio limit to a sum of known limits.",
+    "mathContext": "$\\frac{x + \\sin x}{x} = 1 + \\frac{\\sin x}{x} \\xrightarrow{x\\to\\infty} 1 + 0 = 1$. Equality holds for $x \\geq 1 \\neq 0$; result transferred via `Tendsto.congr'`.",
+    "significance": "key",
+    "relatedConcepts": ["Tendsto.congr'", "filter_upwards", "limit arithmetic", "eventually_ge_atTop"],
+    "prerequisites": ["filter convergence in Mathlib", "sin_div_tendsto_zero (previous lemma)"]
   },
   {
     "id": "ann-oscillation",
-    "title": "cos(x) Oscillation: Two-Subsequence Argument",
+    "proofId": "lhopital-oq-01",
+    "range": { "startLine": 97, "endLine": 154 },
     "type": "technique",
-    "startLine": 93,
-    "endLine": 156,
-    "mathContext": "To show 1 + cos(x) has no limit: (1) along x = 2πn → ∞, we have 1 + cos(2πn) = 1 + 1 = 2; (2) along x = π + 2πn → ∞, we have 1 + cos(π + 2πn) = 1 + (-1) = 0. By tendsto_nhds_unique, any limit L must equal both 2 and 0, which is impossible. The proof uses Real.cos_int_mul_two_pi and Real.cos_add_pi.",
-    "significance": "The two-subsequence argument is the standard technique for proving limits don't exist. The key Lean API is: Tendsto.comp (to extract subsequences), simp_rw (to evaluate the constant values), and tendsto_nhds_unique (to extract the limit value).",
-    "relatedConcepts": ["Real.cos_int_mul_two_pi", "Real.cos_add_pi", "tendsto_nhds_unique", "Filter.Tendsto.comp"]
+    "title": "Two-Subsequence Argument: 1 + cos(x) Has No Limit",
+    "content": "This section proves the core of the counterexample: $1 + \\cos x$ has no limit as $x \\to \\infty$.\n\n**Setup**: Four helper lemmas prepare the subsequences:\n- `cos_two_pi_nat`: $\\cos(2\\pi n) = 1$ for all $n : \\mathbb{N}$ (via `Real.cos_int_mul_two_pi` after casting $\\mathbb{N} \\to \\mathbb{Z}$)\n- `cos_pi_add_two_pi_nat`: $\\cos(\\pi + 2\\pi n) = -1$ (via `Real.cos_add_pi` then `cos_two_pi_nat`)\n- `two_pi_nat_atTop`: $2\\pi n \\to \\infty$ (via tendsto_natCast with scaling by $2\\pi > 0$)\n- `pi_add_two_pi_nat_atTop`: $\\pi + 2\\pi n \\to \\infty$ (adding constant $\\pi$ to the previous)\n\n**The contradiction**: Assume $L$ exists with $1 + \\cos x \\to L$. Then:\n1. Along $x = 2\\pi n$: `hL.comp two_pi_nat_atTop` gives a subsequence tending to $L$, but `simp_rw [hval2]` rewrites all values to $2$, so `tendsto_nhds_unique` forces $L = 2$.\n2. Along $x = \\pi + 2\\pi n$: similarly forces $L = 0$.\n3. `linarith` closes with $2 = 0$, a contradiction.\n\nThis is the canonical technique for proving oscillating divergence in Lean.",
+    "mathContext": "$1 + \\cos(2\\pi n) = 2$ and $1 + \\cos(\\pi + 2\\pi n) = 0$. If $L = \\lim_{x\\to\\infty}(1+\\cos x)$ existed, subsequence limits would force $L = 2$ and $L = 0$ simultaneously — impossible.",
+    "significance": "key",
+    "relatedConcepts": ["tendsto_nhds_unique", "Filter.Tendsto.comp", "Real.cos_int_mul_two_pi", "Real.cos_add_pi", "oscillating sequences"],
+    "prerequisites": ["filter subsequences (Tendsto.comp)", "trigonometric periodicity", "uniqueness of limits"]
+  },
+  {
+    "id": "ann-failure",
+    "proofId": "lhopital-oq-01",
+    "range": { "startLine": 159, "endLine": 169 },
+    "type": "insight",
+    "title": "The Failure Theorem: Conjoining Both Results",
+    "content": "The final theorem `lhopital_failure` packages both results into a single conjunction:\n- **Left conjunct**: $(x + \\sin x)/x \\to 1$ — the ratio of the original functions converges.\n- **Right conjunct**: $\\neg\\exists L,\\; (1 + \\cos x)/1 \\to L$ — the ratio of derivatives has no limit.\n\nThe proof is a one-liner: `⟨f_div_g_tendsto_one, by simp only [div_one]; exact deriv_ratio_no_limit⟩`. The `div_one` simp is needed to match the statement in `deriv_ratio_no_limit` (which uses $1 + \\cos x$ without the $/1$).\n\nThis theorem is the machine-verified witness that the converse of L'Hôpital's rule is false — it simultaneously exhibits a convergent ratio and a non-convergent derivative ratio for the same pair of functions.",
+    "mathContext": "$\\text{lhopital\\_failure}: \\left(\\lim_{x\\to\\infty}\\frac{x+\\sin x}{x} = 1\\right) \\wedge \\left(\\nexists L,\\; \\lim_{x\\to\\infty}\\frac{1+\\cos x}{1} = L\\right)$.",
+    "significance": "key",
+    "relatedConcepts": ["conjunction in Lean", "div_one", "f_div_g_tendsto_one", "deriv_ratio_no_limit"],
+    "prerequisites": ["Lean conjunction introduction ⟨·, ·⟩", "previous lemmas in this file"]
   }
 ]

--- a/src/data/proofs/lhopital-oq-01/index.ts
+++ b/src/data/proofs/lhopital-oq-01/index.ts
@@ -1,4 +1,36 @@
-import meta from "./meta.json";
-import annotations from "./annotations.json";
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/LHopitalOQ01.lean?raw'
 
-export { meta, annotations };
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const lhopitalOq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const lhopitalOq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const lhopitalOq01Data: ProofData = {
+  proof: lhopitalOq01Proof,
+  annotations: lhopitalOq01Annotations,
+}

--- a/src/data/proofs/lhopital-oq-01/meta.json
+++ b/src/data/proofs/lhopital-oq-01/meta.json
@@ -57,7 +57,7 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "L'Hôpital's rule (1696, actually due to Bernoulli) states: if f'/g' → L then f/g → L under appropriate conditions. A natural converse question is whether the limit of f/g implies anything about f'/g'. The answer is emphatically NO. The standard counterexample — f(x) = x + sin(x), g(x) = x — appears in many analysis textbooks (Rudin §5.13, Apostol, etc.) and is pedagogically important because it shows that L'Hôpital's rule is strictly one-directional.",
+    "historicalContext": "L'Hôpital's rule was published in 1696 in the first calculus textbook, *Analyse des Infiniment Petits*, but the rule was actually communicated by Johann Bernoulli to L'Hôpital in a 1694 letter under a paid correspondence agreement — a fact Bernoulli only revealed after L'Hôpital's death in 1704. The rule states: if $f'/g' \\to L$ then $f/g \\to L$ under appropriate conditions (both functions vanish at the limit point, $g' \\neq 0$ nearby). A natural pedagogical question arose: is the converse true? Does knowing that $f/g$ has a limit tell us anything about $f'/g'$? The answer, as established by the counterexample $f(x) = x + \\sin x$, $g(x) = x$, is an emphatic NO. This example appears in Rudin's *Principles of Mathematical Analysis* §5.13 and is standard in graduate real analysis courses precisely because it corrects a common student misconception.",
     "problemStatement": "Show that L'Hôpital's rule has no converse: there exists f, g differentiable on (0, ∞) such that $\\lim_{x \\to \\infty} \\frac{f(x)}{g(x)}$ exists but $\\lim_{x \\to \\infty} \\frac{f'(x)}{g'(x)}$ does not exist.",
     "text": "Formalizes the canonical L'Hôpital counterexample: f(x) = x + sin(x), g(x) = x. The limit f/g = (x + sin x)/x → 1 is proved via the squeeze theorem (|sin x/x| ≤ 1/x → 0). The non-existence of the limit of f'/g' = 1 + cos(x) is proved via the two-subsequence argument: along 2πn the value is 2, along π + 2πn the value is 0, so no single limit exists.",
     "proofStrategy": "The limit sin(x)/x → 0 is proved via the squeeze: using tendsto_inv_atTop_zero, we get x⁻¹ < ε eventually, and |sin x/x| ≤ x⁻¹ by gcongr + |sin x| ≤ 1. For the non-convergence: cos(2πn) = 1 via Real.cos_int_mul_two_pi (after casting ℕ → ℤ), and cos(π + 2πn) = -1 via Real.cos_add_pi. Both subsequences 2πn and π + 2πn tend to ∞, so by tendsto_nhds_unique any hypothetical limit must be both 2 and 0.",
@@ -65,7 +65,8 @@
       "L'Hôpital's rule is strictly one-directional: f'/g' → L implies f/g → L, but NOT conversely.",
       "sin(x)/x → 0 follows cleanly from |sin x| ≤ 1 and x⁻¹ → 0 (no L'Hôpital needed).",
       "Non-convergence via two subsequences: 2πn → ∞ with value 2, and π + 2πn → ∞ with value 0. Any limit would be both 2 and 0 — contradiction.",
-      "tendsto_nhds_unique provides the clean contradiction: unique limits of the same sequence at two different subsequences."
+      "tendsto_nhds_unique provides the clean contradiction: unique limits of the same sequence at two different subsequences.",
+      "The example f = x + sin x, g = x is deliberately asymptotically well-behaved (f/g → 1) while hiding wild oscillation in the derivatives — illustrating that smooth ratio behavior does not constrain derivative behavior."
     ],
     "prerequisites": [
       "L'Hôpital's rule (LHopital.lean)",
@@ -111,7 +112,8 @@
     "summary": "Fully verified (0 sorries, 0 axioms): 11 theorems proving that L'Hôpital's rule cannot be reversed. The counterexample f(x) = x + sin(x), g(x) = x demonstrates that the existence of lim f/g gives no information about lim f'/g'.",
     "implications": "**Pedagogical**: This counterexample is essential for students learning L'Hôpital's rule — it prevents the common error of 'running L'Hôpital's rule backwards.' The proof illustrates the squeeze theorem for sin(x)/x and the subsequence argument for oscillating limits.\n\n**Extension of LHopital.lean**: The parent proof establishes L'Hôpital's rule; this extension proves the boundary of the theorem's applicability.",
     "openQuestions": [
-      "Can the converse hold for monotone quotients? (e.g., if f/g is monotone and L'Hôpital applies, does lim f/g = lim f'/g'?)"
+      "Can the converse hold for monotone quotients? (e.g., if f/g is monotone and L'Hôpital applies, does lim f/g = lim f'/g'?)",
+      "Can one characterize the class of function pairs (f, g) for which the converse of L'Hôpital does hold — i.e., lim f/g = L implies lim f'/g' = L? (A sufficient condition: g'/g → 0 implies f'/g' → L whenever f/g → L, but the exact boundary is open.)"
     ]
   },
   "crossReferences": [

--- a/src/data/proofs/szemeredi-hypergraph-core-oq-01-incomplete-01/annotations.json
+++ b/src/data/proofs/szemeredi-hypergraph-core-oq-01-incomplete-01/annotations.json
@@ -1,41 +1,46 @@
 [
   {
     "id": "ann-gowers-overview",
+    "proofId": "szemeredi-hypergraph-core-oq-01-incomplete-01",
+    "range": { "startLine": 1, "endLine": 42 },
+    "type": "context",
     "title": "Stratified SimplicialComplex: Design Rationale",
-    "type": "overview",
-    "startLine": 1,
-    "endLine": 42,
-    "mathContext": "Two designs for simplicial complexes exist in this codebase: (1) flat — a single Finset of all faces with downward closure (SzemerediHypergraphCoreOQ01.lean); (2) stratified — a function skeleton : Fin dim → Finset (Finset V) giving faces at each dimension level (this file). For Gowers regularity, the stratified design is superior because topCliques is defined by conditioning on the top-level skeleton, which maps directly to the `skeleton (dim-1)` field rather than filtering the whole face set.",
-    "significance": "The design choice affects what can be expressed naturally. Gowers regularity conditions on 'the (k-1)-complex underlying H' — a level-specific notion. The Fin-indexed skeleton makes this conditioning definitional rather than definitional-after-filter."
+    "content": "Two designs for simplicial complexes exist in this codebase: (1) flat — a single Finset of all faces with downward closure (SzemerediHypergraphCoreOQ01.lean); (2) stratified — a function skeleton : Fin dim → Finset (Finset V) giving faces at each dimension level (this file). For Gowers regularity, the stratified design is superior because topCliques is defined by conditioning on the top-level skeleton, which maps directly to the `skeleton (dim-1)` field rather than filtering the whole face set.",
+    "mathContext": "Two designs for simplicial complexes exist in this codebase: (1) flat — a single Finset of all faces with downward closure (SzemerediHypergraphCoreOQ01.lean); (2) stratified — a function skeleton : Fin dim → Finset (Finset V) giving faces at each dimension level (this file). For Gowers regularity, the stratified design is superior because topCliques is defined by conditioning on the top-level skeleton, which maps directly to the `skeleton (dim-1)` field rather than filtering the whole face set. The design choice affects what can be expressed naturally: Gowers regularity conditions on 'the (k-1)-complex underlying H' — a level-specific notion. The Fin-indexed skeleton makes this conditioning definitional rather than definitional-after-filter.",
+    "significance": "context",
+    "relatedConcepts": ["stratified simplicial complex", "flat simplicial complex", "Fin dim indexing", "topCliques"]
   },
   {
     "id": "ann-top-cliques",
-    "title": "topCliques: the Key Linking Construction",
+    "proofId": "szemeredi-hypergraph-core-oq-01-incomplete-01",
+    "range": { "startLine": 85, "endLine": 117 },
     "type": "definition",
-    "startLine": 85,
-    "endLine": 117,
-    "mathContext": "topCliques hdim C = { T ∈ pow(V) | |T| = dim+1 ∧ ∀ F ⊆ T with |F| = dim, F ∈ C.skeleton(dim-1) }. For a k-graph H with C : SimplicialComplex V (k-1), topCliques(C) = k-subsets of V all of whose (k-1)-subsets are in C's top level. This is the 'support' of the complex relative to H: the k-cliques that C endorses as potential H-edges. topCliques_completeComplex proves topCliques(complete) = all k-subsets.",
-    "significance": "topCliques bridges the simplicial complex (a combinatorial object) and the hypergraph density (an analytic object). It answers: which potential k-edges does the complex C 'see'? Density relative to C measures what fraction of these endorsed k-sets are actual H-edges.",
+    "title": "topCliques: the Key Linking Construction",
+    "content": "topCliques hdim C = { T ∈ pow(V) | |T| = dim+1 ∧ ∀ F ⊆ T with |F| = dim, F ∈ C.skeleton(dim-1) }. For a k-graph H with C : SimplicialComplex V (k-1), topCliques(C) = k-subsets of V all of whose (k-1)-subsets are in C's top level. This is the 'support' of the complex relative to H: the k-cliques that C endorses as potential H-edges. topCliques_completeComplex proves topCliques(complete) = all k-subsets.",
+    "mathContext": "$\\text{topCliques}(\\mathcal{C}) = \\{T \\subseteq V : |T| = \\dim+1 \\text{ and } \\forall F \\subsetneq T \\text{ with } |F| = \\dim,\\ F \\in \\mathcal{C}.\\text{skeleton}(\\dim-1)\\}$. For a $k$-graph $H$ with $\\mathcal{C} : \\text{SimplicialComplex}(V, k-1)$, topCliques bridges the simplicial complex (combinatorial object) and the hypergraph density (analytic object). Density relative to $\\mathcal{C}$ measures what fraction of endorsed $k$-sets are actual $H$-edges.",
+    "significance": "key",
     "relatedConcepts": ["SimplicialComplex", "relativeKDensity", "Gowers regularity", "topCliques_mono"]
   },
   {
     "id": "ann-relative-density",
-    "title": "relativeKDensity: Density Conditioning on Complex",
+    "proofId": "szemeredi-hypergraph-core-oq-01-incomplete-01",
+    "range": { "startLine": 123, "endLine": 157 },
     "type": "definition",
-    "startLine": 123,
-    "endLine": 157,
-    "mathContext": "relativeKDensity hk H C = |H.edges ∩ topCliques(C)| / |topCliques(C)|, returning 0 when empty. The intersection H.edges ∩ topCliques(C) selects H-edges that are 'endorsed' by C. The theorem relativeKDensity_completeComplex shows that when C is the complete complex (all j-subsets as faces), topCliques(C) = all k-subsets of V, so the relative density equals the global density |H.edges| / C(|V|, k). Proof: H.edges ⊆ all-k-subsets by H.uniform, so H.edges ∩ D = H.edges by Finset.inter_eq_left.",
-    "significance": "This is the core definition enabling Gowers regularity. By conditioning on sub-complexes C', we can ask: does H have roughly the same density when we look only at topCliques endorsed by C'? This is conceptually richer than naive density over vertex sub-parts, as the complex captures which lower-dimensional structures 'support' the k-edges.",
-    "relatedConcepts": ["topCliques", "globalDensity", "IsGowersRegular", "H.uniform"]
+    "title": "relativeKDensity: Density Conditioning on Complex",
+    "content": "relativeKDensity hk H C = |H.edges ∩ topCliques(C)| / |topCliques(C)|, returning 0 when empty. The intersection H.edges ∩ topCliques(C) selects H-edges that are 'endorsed' by C. The theorem relativeKDensity_completeComplex shows that when C is the complete complex (all j-subsets as faces), topCliques(C) = all k-subsets of V, so the relative density equals the global density |H.edges| / C(|V|, k). Proof: H.edges ⊆ all-k-subsets by H.uniform, so H.edges ∩ D = H.edges by Finset.inter_eq_left.",
+    "mathContext": "$d(H \\mid \\mathcal{C}) = |H.\\text{edges} \\cap \\text{topCliques}(\\mathcal{C})| / |\\text{topCliques}(\\mathcal{C})|$. This is the core definition enabling Gowers regularity. By conditioning on sub-complexes $\\mathcal{C}' \\subseteq \\mathcal{C}$, we measure whether $H$ has roughly the same density among topCliques endorsed by $\\mathcal{C}'$ as among all topCliques of $\\mathcal{C}$. Key property: $d(H \\mid \\mathcal{C}_{\\text{complete}}) = |H.\\text{edges}| / \\binom{|V|}{k}$ (global density), proved via `Finset.inter_eq_left.mpr` since $H.\\text{edges} \\subseteq \\text{all-}k\\text{-subsets}$ by $H.\\text{uniform}$.",
+    "significance": "key",
+    "relatedConcepts": ["topCliques", "globalDensity", "IsGowersRegular", "Finset.inter_eq_left"]
   },
   {
     "id": "ann-gowers-regularity",
-    "title": "IsGowersRegular: Stability Under Dense Sub-Complexes",
+    "proofId": "szemeredi-hypergraph-core-oq-01-incomplete-01",
+    "range": { "startLine": 163, "endLine": 186 },
     "type": "definition",
-    "startLine": 163,
-    "endLine": 186,
-    "mathContext": "IsGowersRegular hk H ε δ C says: for all sub-complexes C' ⊆ C with |topCliques(C')| ≥ δ·|topCliques(C)|, we have |d(H | C') - d(H | C)| ≤ ε. The δ condition ensures C' is 'dense' — it endorses at least a δ fraction of C's topCliques. Monotonicity: (ε,δ)-regular → (ε',δ)-regular for ε' ≥ ε (larger tolerance easier); (ε,δ)-regular → (ε,δ')-regular for δ' ≥ δ (larger density threshold means fewer qualifying C', so easier to satisfy).",
-    "significance": "This is the exact notion introduced by Gowers (2007). For graphs (k=2), it reduces to the classical bipartite ε-regularity of Szemerédi. The key difference from naive regularity: Gowers conditions on the complex structure (topological sub-complexes) rather than vertex sub-sets. This richer condition is what makes the hypergraph counting lemma work.",
+    "title": "IsGowersRegular: Stability Under Dense Sub-Complexes",
+    "content": "IsGowersRegular hk H ε δ C says: for all sub-complexes C' ⊆ C with |topCliques(C')| ≥ δ·|topCliques(C)|, we have |d(H | C') - d(H | C)| ≤ ε. The δ condition ensures C' is 'dense' — it endorses at least a δ fraction of C's topCliques. Monotonicity: (ε,δ)-regular → (ε',δ)-regular for ε' ≥ ε (larger tolerance easier); (ε,δ)-regular → (ε,δ')-regular for δ' ≥ δ (larger density threshold means fewer qualifying C', so easier to satisfy).",
+    "mathContext": "Gowers $(\\varepsilon, \\delta)$-regularity: $\\forall \\mathcal{C}' \\subseteq \\mathcal{C}$ with $|\\text{topCliques}(\\mathcal{C}')| \\geq \\delta\\cdot|\\text{topCliques}(\\mathcal{C})|$, $|d(H \\mid \\mathcal{C}') - d(H \\mid \\mathcal{C})| \\leq \\varepsilon$. For graphs ($k=2$) this reduces to classical bipartite $\\varepsilon$-regularity of Szemerédi. The key difference from naive regularity: conditions are on the complex structure (topological sub-complexes) rather than vertex sub-sets. This richer condition is what enables the hypergraph counting lemma (Nagle-Rödl-Schacht 2006).",
+    "significance": "key",
     "relatedConcepts": ["topCliques_mono", "IsSubComplex", "relativeKDensity", "naive_implies_gowers"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for lhopital-oq-01 (L'Hôpital's Rule: Failure of the Converse).

## Changes

**index.ts** — Fixed from bare re-export to proper typed TypeScript template with `lhopitalOq01Proof`, `lhopitalOq01Annotations`, and `lhopitalOq01Data` exports. Without this, the proof page shows "proof not found" on the live site.

**annotations.json** — Rewrote from 3 informal annotations to 6 well-structured annotations:
- Added `proofId`, `range` objects, and `content` fields (previously missing)
- Full section coverage: §1 Derivatives (previously uncovered), §2 Squeeze/limit, §3 Two-subsequence oscillation argument, §4 Failure conjunction
- All annotations have `mathContext`, `significance`, `relatedConcepts`, `prerequisites`

**meta.json** — Three enrichments:
- 5th `keyInsight`: the asymptotic simplicity of f/g hiding wild derivative oscillation
- Expanded `historicalContext` with the Bernoulli/L'Hôpital priority dispute and 1694 letter
- 2nd `openQuestion`: characterizing when the converse of L'Hôpital does hold