### PR TITLE
Fix: erdos-27 lineCount 242→318 and stale sorry count in assumptions

### DIFF
--- a/src/data/proofs/erdos-27/meta.json
+++ b/src/data/proofs/erdos-27/meta.json
@@ -60,14 +60,14 @@
       "bbmst_bound connection to perfect coverings"
     ],
     "axiomCount": 0,
-    "lineCount": 242,
+    "lineCount": 318,
     "prerequisites": [
       "Covering systems and congruence classes",
       "Natural density of integer sequences",
       "Chinese Remainder Theorem",
       "Modular arithmetic"
     ],
-    "assumptions": "No axioms. 12 sorry(s) remain in the formalization."
+    "assumptions": "No axioms. 9 sorry(s) remain in the formalization."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #27: Almost Covering Systems**\n\nThis $\\$100$ Erdős prize problem sits at the heart of the theory of covering systems — one of Erdős's most sustained research interests.\n\n**Background: Covering Systems**\nA covering system is a finite collection of congruence classes $a_i \\pmod{n_i}$ with distinct moduli $n_1 < \\ldots < n_k$ such that every integer belongs to at least one class. Erdős initiated the systematic study of these objects in 1950 and posed dozens of problems about them over the next five decades.\n\n**The Almost-Covering Question:**\nErdős asked a natural relaxation: instead of covering *every* integer, what if we only need to cover all but a small fraction? An $\\varepsilon$-almost covering leaves at most density $\\varepsilon$ of integers uncovered. The specific question was whether a fixed constant $C > 1$ suffices to achieve $\\varepsilon$-almost covering with all moduli in the bounded range $[N, CN]$, for *all* $\\varepsilon > 0$ and $N \\geq 1$.\n\n**The FFKPY Disproof:**\nFilaseta, Ford, Konyagin, Pomerance, and Yu resolved this negatively. Their key insight: for moduli in $[N, CN]$ with fixed $C$, the total 'coverage capacity' is $\\sum_{n=N}^{CN} 1/n \\approx \\ln C$, which is bounded. Using a critical exponent $\\alpha(N) = \\frac{\\log\\log\\log N}{4\\log\\log N}$, they showed that for $C \\leq N^{\\alpha(N)}$ (which includes all constants), the uncovered density is bounded below by approximately $1/(2C)$. No fixed $C$ can make this arbitrarily small.\n\n**What Does Work:**\nIf $C$ is allowed to grow with $N$ (e.g., $C(N) = N^{1/\\log\\log N}$), then $\\varepsilon$-almost coverings exist for any fixed $\\varepsilon$. The boundary between success and failure lies at the growth rate of the critical exponent.\n\n**Connection to Perfect Coverings:**\nThe related question for perfect coverings (covering *every* integer) was resolved by Hough (2015): covering systems cannot have all moduli exceeding some absolute bound. Bloom, Briggs, Maynard, Smith, and Tao (2024) improved the bound to $616{,}000$.",
@@ -189,7 +189,7 @@
       "Filter"
     ],
     "namespace": "Erdos27",
-    "lineCount": 242,
+    "lineCount": 318,
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 16,


### PR DESCRIPTION
## Fix

Corrects stale metadata in `erdos-27/meta.json`. The stub file grew from 242 to 318 lines when sorries were reduced from 12 to 9 (inline proofs added), but `meta.json` was not updated. Also fixes the `assumptions` field which still claimed 12 sorries.

## Evidence

**Before**: `meta.lineCount: 242`, `leanFile.lineCount: 242`, `assumptions: "12 sorry(s) remain"`
**After**: `meta.lineCount: 318`, `leanFile.lineCount: 318`, `assumptions: "9 sorry(s) remain"`

```
$ git show HEAD:proofs/Proofs/Stubs/Erdos27Problem.lean | wc -l
318
$ git show HEAD:proofs/Proofs/Stubs/Erdos27Problem.lean | grep -n sorry
128:  sorry
225:  sorry
231:  sorry
235:  sorry
242:  sorry
251:  sorry
260:  sorry
268:  sorry
277:  sorry
```

9 actual sorry tactics (matches `meta.sorries: 9`). lineCount was stale from initial commit at 242 lines.

---
Automated fix by lean-mechanic agent.