### PR TITLE
Enrich szemeredi-hypergraph-core-oq-01-incomplete-01: fix index.ts, full annotation coverage

### DIFF
--- a/src/data/proofs/szemeredi-hypergraph-core-oq-01-incomplete-01/annotations.json
+++ b/src/data/proofs/szemeredi-hypergraph-core-oq-01-incomplete-01/annotations.json
@@ -5,10 +5,23 @@
     "range": { "startLine": 1, "endLine": 42 },
     "type": "context",
     "title": "Stratified SimplicialComplex: Design Rationale",
-    "content": "Two designs for simplicial complexes exist in this codebase: (1) flat — a single Finset of all faces with downward closure (SzemerediHypergraphCoreOQ01.lean); (2) stratified — a function skeleton : Fin dim → Finset (Finset V) giving faces at each dimension level (this file). For Gowers regularity, the stratified design is superior because topCliques is defined by conditioning on the top-level skeleton, which maps directly to the `skeleton (dim-1)` field rather than filtering the whole face set.",
-    "mathContext": "Two designs for simplicial complexes exist in this codebase: (1) flat — a single Finset of all faces with downward closure (SzemerediHypergraphCoreOQ01.lean); (2) stratified — a function skeleton : Fin dim → Finset (Finset V) giving faces at each dimension level (this file). For Gowers regularity, the stratified design is superior because topCliques is defined by conditioning on the top-level skeleton, which maps directly to the `skeleton (dim-1)` field rather than filtering the whole face set. The design choice affects what can be expressed naturally: Gowers regularity conditions on 'the (k-1)-complex underlying H' — a level-specific notion. The Fin-indexed skeleton makes this conditioning definitional rather than definitional-after-filter.",
+    "content": "Two designs for simplicial complexes exist in this codebase: (1) flat — a single Finset of all faces with downward closure (SzemerediHypergraphCoreOQ01.lean); (2) stratified — a function skeleton : Fin dim → Finset (Finset V) giving faces at each dimension level (this file). For Gowers regularity, the stratified design is superior because topCliques is defined by conditioning on the top-level skeleton, which maps directly to the `skeleton (dim-1)` field rather than filtering the whole face set.\n\nThe design choice affects what can be expressed naturally: Gowers regularity conditions on 'the (k-1)-complex underlying H' — a level-specific notion. The Fin-indexed skeleton makes this conditioning definitional rather than definitional-after-filter. This file extends SzemerediHypergraphCore.lean (UHypergraph, kPartiteDensity, naive regularity) with the relative density infrastructure needed for the hypergraph counting lemma.",
+    "mathContext": "Two simplicial complex designs: (1) flat: $\\mathcal{F} \\subseteq 2^V$ with $\\forall e \\in \\mathcal{F}, f \\subsetneq e \\Rightarrow f \\in \\mathcal{F}$; (2) stratified: $\\text{skeleton} : \\text{Fin}(\\dim) \\to \\text{Finset}(\\text{Finset}\\,V)$ with $\\text{skeleton}(j)$ = $(j+1)$-faces. The stratified design makes $\\text{topCliques}$ a direct lookup: $T$ is a topClique iff every $(\\dim)$-subset of $T$ is in $\\text{skeleton}(\\dim-1)$.",
     "significance": "context",
-    "relatedConcepts": ["stratified simplicial complex", "flat simplicial complex", "Fin dim indexing", "topCliques"]
+    "relatedConcepts": ["stratified simplicial complex", "flat simplicial complex", "Fin dim indexing", "topCliques"],
+    "prerequisites": ["simplicial complexes (downward-closed face sets)", "Szemerédi's graph regularity lemma", "k-uniform hypergraphs (UHypergraph)"]
+  },
+  {
+    "id": "ann-simplicial-structure",
+    "proofId": "szemeredi-hypergraph-core-oq-01-incomplete-01",
+    "range": { "startLine": 44, "endLine": 82 },
+    "type": "definition",
+    "title": "SimplicialComplex: Stratified Face Structure",
+    "content": "The `SimplicialComplex V dim` structure has three fields:\n- `skeleton : Fin dim → Finset (Finset V)` — the faces at each dimension level, where `skeleton j` contains $(j.val + 1)$-element faces for $j : \\text{Fin}(\\dim)$\n- `uniform` — every face at level $j$ has cardinality exactly $j.val + 1$\n- `down_closed` — every $j$-face's sub-faces of size $j$ are $(j-1)$-faces\n\n`IsSubComplex C' C` is the pointwise subset relation: $C'.\\text{skeleton}(j) \\subseteq C.\\text{skeleton}(j)$ for all $j$. This is a partial order with `refl` and `trans` lemmas.\n\n`completeComplex V dim` fills every level with all $(j+1)$-subsets of $V$. It's the top element of the IsSubComplex order. The proof that `completeComplex` satisfies `down_closed` is elegant: a sub-face of a subset of $V$ is still a subset of $V$, and its cardinality is exactly right.",
+    "mathContext": "$\\text{SimplicialComplex}(V, \\dim)$: $\\text{skeleton}(j) \\subseteq \\binom{V}{j+1}$ with $f \\subsetneq e \\in \\text{skeleton}(j)$, $|f| = j \\Rightarrow f \\in \\text{skeleton}(j-1)$. $\\text{completeComplex}$: $\\text{skeleton}(j) = \\binom{V}{j+1}$ (all $(j+1)$-subsets). $C' \\subseteq C \\Leftrightarrow \\forall j,\\, \\text{skeleton}_{C'}(j) \\subseteq \\text{skeleton}_C(j)$.",
+    "significance": "key",
+    "relatedConcepts": ["SimplicialComplex", "IsSubComplex", "completeComplex", "Fin dim indexing", "downward closure"],
+    "prerequisites": ["abstract simplicial complexes", "Lean 4 structures and fields", "Finset.powerset", "Fin type in Lean"]
   },
   {
     "id": "ann-top-cliques",
@@ -16,10 +29,11 @@
     "range": { "startLine": 85, "endLine": 117 },
     "type": "definition",
     "title": "topCliques: the Key Linking Construction",
-    "content": "topCliques hdim C = { T ∈ pow(V) | |T| = dim+1 ∧ ∀ F ⊆ T with |F| = dim, F ∈ C.skeleton(dim-1) }. For a k-graph H with C : SimplicialComplex V (k-1), topCliques(C) = k-subsets of V all of whose (k-1)-subsets are in C's top level. This is the 'support' of the complex relative to H: the k-cliques that C endorses as potential H-edges. topCliques_completeComplex proves topCliques(complete) = all k-subsets.",
+    "content": "topCliques hdim C = { T ∈ pow(V) | |T| = dim+1 ∧ ∀ F ⊆ T with |F| = dim, F ∈ C.skeleton(dim-1) }. For a k-graph H with C : SimplicialComplex V (k-1), topCliques(C) = k-subsets of V all of whose (k-1)-subsets are in C's top level. This is the 'support' of the complex relative to H: the k-cliques that C endorses as potential H-edges. topCliques_completeComplex proves topCliques(complete) = all k-subsets.\n\nTwo key theorems are proved here:\n- `topCliques_completeComplex`: For the complete complex, every $(\\dim+1)$-subset qualifies (proof: sub-faces land in the complete skeleton by definition).\n- `topCliques_mono`: Sub-complex implies sub-topCliques (proof: if $T$ qualifies for $C'$ and $C' \\subseteq C$, then $T$ also qualifies for $C$).",
     "mathContext": "$\\text{topCliques}(\\mathcal{C}) = \\{T \\subseteq V : |T| = \\dim+1 \\text{ and } \\forall F \\subsetneq T \\text{ with } |F| = \\dim,\\ F \\in \\mathcal{C}.\\text{skeleton}(\\dim-1)\\}$. For a $k$-graph $H$ with $\\mathcal{C} : \\text{SimplicialComplex}(V, k-1)$, topCliques bridges the simplicial complex (combinatorial object) and the hypergraph density (analytic object). Density relative to $\\mathcal{C}$ measures what fraction of endorsed $k$-sets are actual $H$-edges.",
     "significance": "key",
-    "relatedConcepts": ["SimplicialComplex", "relativeKDensity", "Gowers regularity", "topCliques_mono"]
+    "relatedConcepts": ["SimplicialComplex", "relativeKDensity", "Gowers regularity", "topCliques_mono"],
+    "prerequisites": ["SimplicialComplex (previous section)", "Finset filtering in Lean", "powerset and subset combinatorics"]
   },
   {
     "id": "ann-relative-density",
@@ -27,10 +41,11 @@
     "range": { "startLine": 123, "endLine": 157 },
     "type": "definition",
     "title": "relativeKDensity: Density Conditioning on Complex",
-    "content": "relativeKDensity hk H C = |H.edges ∩ topCliques(C)| / |topCliques(C)|, returning 0 when empty. The intersection H.edges ∩ topCliques(C) selects H-edges that are 'endorsed' by C. The theorem relativeKDensity_completeComplex shows that when C is the complete complex (all j-subsets as faces), topCliques(C) = all k-subsets of V, so the relative density equals the global density |H.edges| / C(|V|, k). Proof: H.edges ⊆ all-k-subsets by H.uniform, so H.edges ∩ D = H.edges by Finset.inter_eq_left.",
+    "content": "relativeKDensity hk H C = |H.edges ∩ topCliques(C)| / |topCliques(C)|, returning 0 when empty. The intersection H.edges ∩ topCliques(C) selects H-edges that are 'endorsed' by C. The theorem relativeKDensity_completeComplex shows that when C is the complete complex (all j-subsets as faces), topCliques(C) = all k-subsets of V, so the relative density equals the global density |H.edges| / C(|V|, k). Proof: H.edges ⊆ all-k-subsets by H.uniform, so H.edges ∩ D = H.edges by Finset.inter_eq_left.\n\nThree basic properties are proved:\n- `nonneg`: density ≥ 0 (by `positivity` after handling the empty case)\n- `le_one`: density ≤ 1 (intersection ≤ denominator by `Finset.card_le_card (Finset.inter_subset_right)`)\n- `empty`: density of the empty hypergraph is 0",
     "mathContext": "$d(H \\mid \\mathcal{C}) = |H.\\text{edges} \\cap \\text{topCliques}(\\mathcal{C})| / |\\text{topCliques}(\\mathcal{C})|$. This is the core definition enabling Gowers regularity. By conditioning on sub-complexes $\\mathcal{C}' \\subseteq \\mathcal{C}$, we measure whether $H$ has roughly the same density among topCliques endorsed by $\\mathcal{C}'$ as among all topCliques of $\\mathcal{C}$. Key property: $d(H \\mid \\mathcal{C}_{\\text{complete}}) = |H.\\text{edges}| / \\binom{|V|}{k}$ (global density), proved via `Finset.inter_eq_left.mpr` since $H.\\text{edges} \\subseteq \\text{all-}k\\text{-subsets}$ by $H.\\text{uniform}$.",
     "significance": "key",
-    "relatedConcepts": ["topCliques", "globalDensity", "IsGowersRegular", "Finset.inter_eq_left"]
+    "relatedConcepts": ["topCliques", "globalDensity", "IsGowersRegular", "Finset.inter_eq_left"],
+    "prerequisites": ["topCliques (previous section)", "UHypergraph.uniform field", "rational arithmetic in Lean (ℚ)", "Finset intersection and cardinality"]
   },
   {
     "id": "ann-gowers-regularity",
@@ -38,9 +53,22 @@
     "range": { "startLine": 163, "endLine": 186 },
     "type": "definition",
     "title": "IsGowersRegular: Stability Under Dense Sub-Complexes",
-    "content": "IsGowersRegular hk H ε δ C says: for all sub-complexes C' ⊆ C with |topCliques(C')| ≥ δ·|topCliques(C)|, we have |d(H | C') - d(H | C)| ≤ ε. The δ condition ensures C' is 'dense' — it endorses at least a δ fraction of C's topCliques. Monotonicity: (ε,δ)-regular → (ε',δ)-regular for ε' ≥ ε (larger tolerance easier); (ε,δ)-regular → (ε,δ')-regular for δ' ≥ δ (larger density threshold means fewer qualifying C', so easier to satisfy).",
-    "mathContext": "Gowers $(\\varepsilon, \\delta)$-regularity: $\\forall \\mathcal{C}' \\subseteq \\mathcal{C}$ with $|\\text{topCliques}(\\mathcal{C}')| \\geq \\delta\\cdot|\\text{topCliques}(\\mathcal{C})|$, $|d(H \\mid \\mathcal{C}') - d(H \\mid \\mathcal{C})| \\leq \\varepsilon$. For graphs ($k=2$) this reduces to classical bipartite $\\varepsilon$-regularity of Szemerédi. The key difference from naive regularity: conditions are on the complex structure (topological sub-complexes) rather than vertex sub-sets. This richer condition is what enables the hypergraph counting lemma (Nagle-Rödl-Schacht 2006).",
+    "content": "IsGowersRegular hk H ε δ C says: for all sub-complexes C' ⊆ C with |topCliques(C')| ≥ δ·|topCliques(C)|, we have |d(H | C') - d(H | C)| ≤ ε. The δ condition ensures C' is 'dense' — it endorses at least a δ fraction of C's topCliques. Monotonicity: (ε,δ)-regular → (ε',δ)-regular for ε' ≥ ε (larger tolerance easier); (ε,δ)-regular → (ε,δ')-regular for δ' ≥ δ (larger density threshold means fewer qualifying C', so easier to satisfy).\n\nFor graphs ($k = 2$): A 2-graph $H$ on bipartition $(A, B)$ is classically $\\varepsilon$-regular if for all $A' \\subseteq A$, $B' \\subseteq B$ with $|A'| \\geq \\varepsilon|A|$, $|B'| \\geq \\varepsilon|B|$, the edge density between $A'$ and $B'$ is within $\\varepsilon$ of the density between $A$ and $B$. `IsGowersRegular` generalizes this to hypergraphs using the topClique structure instead of vertex bipartitions.",
+    "mathContext": "Gowers $(\\varepsilon, \\delta)$-regularity: $\\forall \\mathcal{C}' \\subseteq \\mathcal{C}$ with $|\\text{topCliques}(\\mathcal{C}')| \\geq \\delta\\cdot|\\text{topCliques}(\\mathcal{C})|$, $|d(H \\mid \\mathcal{C}') - d(H \\mid \\mathcal{C})| \\leq \\varepsilon$. For graphs ($k=2$) this reduces to classical bipartite $\\varepsilon$-regularity of Szemerédi. The key difference from naive regularity: conditions are on the complex structure (topological sub-complexes) rather than vertex sub-sets.",
     "significance": "key",
-    "relatedConcepts": ["topCliques_mono", "IsSubComplex", "relativeKDensity", "naive_implies_gowers"]
+    "relatedConcepts": ["topCliques_mono", "IsSubComplex", "relativeKDensity", "naive_implies_gowers"],
+    "prerequisites": ["relativeKDensity (previous section)", "IsSubComplex partial order", "Szemerédi's graph regularity (background)", "rational inequalities in Lean"]
+  },
+  {
+    "id": "ann-naive-implies-gowers",
+    "proofId": "szemeredi-hypergraph-core-oq-01-incomplete-01",
+    "range": { "startLine": 188, "endLine": 244 },
+    "type": "insight",
+    "title": "naive_implies_gowers: Open Sorry and relativeKDensity_completeComplex",
+    "content": "This section contains both the deepest completed result and the one remaining sorry.\n\n**globalDensity and relativeKDensity_completeComplex (proved)**: `globalDensity H` = fraction of all $k$-subsets that are $H$-edges. The theorem `relativeKDensity_completeComplex` shows these coincide when $\\mathcal{C}$ = completeComplex. Proof: the topCliques of the complete complex are exactly all $k$-subsets (by `topCliques_completeComplex`), and since every $H$-edge has cardinality $k$ (by `H.uniform`), $H.\\text{edges} \\subseteq \\text{all-}k\\text{-subsets}$. Then `Finset.inter_eq_left.mpr` gives the intersection is just $H.\\text{edges}$.\n\n**naive_implies_gowers (sorry)**: The sorry reflects a genuine mathematical difficulty. Naive regularity conditions on vertex sub-parts (transversals $V_1' \\times ... \\times V_k'$), while Gowers regularity conditions on sub-complexes (topological objects). Sub-complex topCliques are NOT generally expressible as transversals of vertex sub-parts, so the direction naive → Gowers requires a structural hypothesis on the sub-complex (e.g., it must arise from vertex sub-selections). The sorry is honest and well-documented: this reduction is hard and requires reformulation or additional assumptions.",
+    "mathContext": "$d(H \\mid \\mathcal{C}_{\\text{complete}}) = |H.\\text{edges}| / \\binom{|V|}{k}$ = globalDensity. Proof: $\\text{topCliques}(\\mathcal{C}_{\\text{complete}}) = \\binom{V}{k}$ (all $k$-subsets), $H.\\text{edges} \\subseteq \\binom{V}{k}$ (by $H.\\text{uniform}$), so $H.\\text{edges} \\cap \\binom{V}{k} = H.\\text{edges}$ (by `Finset.inter_eq_left`). Sorry: naive $\\varepsilon$-regularity is a vertex-partition condition; Gowers regularity is a sub-complex condition. The two are not directly comparable without structural assumptions on $\\mathcal{C}'$.",
+    "significance": "key",
+    "relatedConcepts": ["globalDensity", "relativeKDensity_completeComplex", "naive_implies_gowers", "Finset.inter_eq_left", "IsHypergraphRegular"],
+    "prerequisites": ["relativeKDensity (previous section)", "UHypergraph.uniform field", "IsHypergraphRegular from SzemerediHypergraphCore.lean", "topCliques_completeComplex theorem"]
   }
 ]

--- a/src/data/proofs/szemeredi-hypergraph-core-oq-01-incomplete-01/index.ts
+++ b/src/data/proofs/szemeredi-hypergraph-core-oq-01-incomplete-01/index.ts
@@ -1,4 +1,36 @@
-import meta from "./meta.json";
-import annotations from "./annotations.json";
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/SzemerediHypergraphGowers.lean?raw'
 
-export { meta, annotations };
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const szemerediHypergraphCoreOq01Incomplete01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const szemerediHypergraphCoreOq01Incomplete01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const szemerediHypergraphCoreOq01Incomplete01Data: ProofData = {
+  proof: szemerediHypergraphCoreOq01Incomplete01Proof,
+  annotations: szemerediHypergraphCoreOq01Incomplete01Annotations,
+}

--- a/src/data/proofs/szemeredi-hypergraph-core-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/szemeredi-hypergraph-core-oq-01-incomplete-01/meta.json
@@ -53,7 +53,8 @@
       "The `hk : 1 < k` constraint is essential: topCliques needs `0 < k - 1`, which fails for k = 1.",
       "relativeKDensity_completeComplex: H.edges ⊆ all-k-subsets follows from H.uniform (every edge has card k and lies in univ). The key Finset lemma is `Finset.inter_eq_left.mpr`.",
       "naive_implies_gowers is HARD: naive regularity (sub-vertex-parts) and Gowers regularity (sub-complexes) are orthogonal. Sub-complex topCliques are NOT generally transversals of vertex sub-parts.",
-      "Two SimplicialComplex designs coexist: flat (SzemerediHypergraphCoreOQ01.lean) and stratified (this file). The stratified version has explicit dimension indexing."
+      "Two SimplicialComplex designs coexist: flat (SzemerediHypergraphCoreOQ01.lean) and stratified (this file). The stratified version has explicit dimension indexing.",
+      "relativeKDensity_completeComplex is the key consistency check: relative density w.r.t. the complete complex must equal global density. The proof uses H.uniform (every H-edge has card k) to show H.edges ⊆ all-k-subsets, then Finset.inter_eq_left to collapse the intersection."
     ],
     "prerequisites": [
       "Graph regularity and Szemerédi's theorem",
@@ -93,6 +94,14 @@
       "startLine": 159,
       "endLine": 187,
       "mathContext": "Gowers $(\\varepsilon, \\delta)$-regularity: $|d(H \\mid \\mathcal{C}') - d(H \\mid \\mathcal{C})| \\leq \\varepsilon$ for all $\\mathcal{C}' \\subseteq \\mathcal{C}$ with $|\\text{topCliques}(\\mathcal{C}')| \\geq \\delta \\cdot |\\text{topCliques}(\\mathcal{C})|$. Monotonicity: relaxing $\\varepsilon$ (larger) or $\\delta$ (larger) preserves regularity."
+    },
+    {
+      "id": "naive-implies-gowers",
+      "title": "Naive → Gowers: relativeKDensity_completeComplex and Open Sorry",
+      "summary": "globalDensity definition + relativeKDensity_completeComplex (proved: relative density w.r.t. complete complex = global density, via Finset.inter_eq_left). naive_implies_gowers (sorry): the reduction from naive regularity (vertex sub-parts) to Gowers regularity (sub-complexes) is open — the two density notions are not directly comparable without structural assumptions on C'.",
+      "startLine": 188,
+      "endLine": 244,
+      "mathContext": "$d(H \\mid \\mathcal{C}_{\\text{complete}}) = \\text{globalDensity}(H) = |H.\\text{edges}| / \\binom{|V|}{k}$. Proof: $H.\\text{uniform}$ gives $H.\\text{edges} \\subseteq \\binom{V}{k}$, so $H.\\text{edges} \\cap \\text{topCliques}(\\mathcal{C}_{\\text{complete}}) = H.\\text{edges}$ by `Finset.inter_eq_left.mpr`. Sorry: naive regularity over vertex sub-parts $V_1' \\times \\cdots \\times V_k'$ is NOT directly comparable to Gowers regularity over sub-complex topCliques."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for szemeredi-hypergraph-core-oq-01-incomplete-01 (Gowers Hypergraph Regularity: Stratified Simplicial Complex).

## Changes

**index.ts** — Fixed from bare re-export to proper typed TypeScript template.

**annotations.json** — Expanded from 4 to 6 well-structured annotations:
- Added `prerequisites` field to all annotations (previously missing)
- New annotation: §I SimplicialComplex structure (lines 44-82) — covering the `SimplicialComplex` structure, `IsSubComplex` partial order, and `completeComplex` definition
- New annotation: §V naive_implies_gowers (lines 188-244) — covering the proved `relativeKDensity_completeComplex` theorem and the open `naive_implies_gowers` sorry with mathematical explanation of why it's hard

**meta.json** — Two enrichments:
- 6th `keyInsight`: relativeKDensity_completeComplex as consistency check (Finset.inter_eq_left proof technique)
- New `sections` entry for PART V (lines 188-244): globalDensity definition + naive_implies_gowers