### PR TITLE
Fix: law-of-cosines-oq-01-oq-05 lineCount 365→693 (retry)

### DIFF
--- a/src/data/proofs/law-of-cosines-oq-01-oq-05/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-01-oq-05/meta.json
@@ -20,7 +20,7 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 365,
+    "lineCount": 693,
     "assumptions": "None. All results fully proved from Mathlib: euclidean_limit_holds completed with explicit K→0 Taylor expansion bounds.",
     "dateAdded": "2026-04-21",
     "mathlib_version": "4.26.0",
@@ -39,7 +39,7 @@
     "proofStrategy": "1. Piecewise definitions: curvatureCos and curvatureSin use if-then-else on the sign of K, reducing to cos/cosh and sin/sinh respectively. 2. Pythagorean identity: rcases lt_trichotomy K 0 splits into three cases; K<0 uses Real.cosh_sq_sub_sinh_sq; K>0 uses Real.sin_sq_add_cos_sq; K=0 is immediate. 3. Key algebra: K·(x/√K)·(y/√K)=x·y (K>0) and K·(x/√(-K))·(y/√(-K))=-(x·y) (K<0) proved by calc chains with field_simp. 4. Recovery theorems: simp_only unfolds the piecewise definitions at K=±1; linarith closes from the structure law field. 5. Algebraic equivalences: simp_only + linear_combination with the key algebra lemmas prove K>0 and K<0 equivalences in both directions.",
     "keyInsights": [
       "The unified Pythagorean identity cs_K(r)² + K·sn_K(r)² = 1 encodes simultaneously cos²+sin²=1 (K=1), cosh²-sinh²=1 (K=-1), and 1+0=1 (K=0). The factor K changes the sign from + to - when K=-1, giving the hyperbolic identity. This is the algebraic heart of the unification.",
-      "The K→0 limit is the most subtle case. For K>0: cs_K(r) = cos(√K·r) → 1 - K·r²/2 + O(K²), and sn_K(r) = sin(√K·r)/√K → r + O(K). Substituting into the unified formula and keeping leading-order terms gives 1-K·c²/2 ≈ (1-K·a²/2)(1-K·b²/2) + K·a·b·cos(C), which at order K gives c²=a²+b²-2ab·cos(C). This limit requires Taylor expansion analysis that is left as a sorry.",
+      "The K→0 limit is the most subtle case. For K>0: cs_K(r) = cos(√K·r) → 1 - K·r²/2 + O(K²), and sn_K(r) = sin(√K·r)/√K → r + O(K). Substituting into the unified formula and keeping leading-order terms gives 1-K·c²/2 ≈ (1-K·a²/2)(1-K·b²/2) + K·a·b·cos(C), which at order K gives c²=a²+b²-2ab·cos(C). Proved in euclidean_limit_holds via explicit exp and cosh/sinh Taylor expansion bounds.",
       "The algebraic equivalences for K≠0 show that the unified formula at curvature K is exactly the spherical law at sides √K·a, √K·b, √K·c (for K>0) or the hyperbolic law at sides √(-K)·a, √(-K)·b, √(-K)·c (for K<0). This is the geometric content: a sphere of radius R=1/√K has curvature K, so the law of cosines on that sphere is the unified formula.",
       "The piecewise definition of cs_K and sn_K in Lean requires careful use of field_simp and simp_only with explicit norm_num proofs of conditions like ¬(-1>0) and (-1<0). The calc chain approach for the key algebra lemmas (K·(x/√K)·(y/√K)=x·y) is cleaner than ring-based approaches because field_simp can close the first step outright.",
       "The structure UnifiedTriangle K axiomatizes a triangle in K-geometry via its law field. This is analogous to how LawOfCosinesOQ03 axiomatizes hyperbolic triangles. The recovery theorems show that any K=1 unified triangle satisfies the spherical law and vice versa — the structure captures exactly the right mathematical content."
@@ -94,7 +94,7 @@
     }
   ],
   "conclusion": {
-    "summary": "The Lean formalization successfully unifies the Euclidean, spherical, and hyperbolic laws of cosines through curvature-parametrized trigonometric functions cs_K and sn_K. The core mathematical content — the unified Pythagorean identity and the K=±1 recovery theorems — is fully formalized with 0 sorries. The K→0 Euclidean limit remains as a sorry requiring Taylor expansion analysis.",
+    "summary": "The Lean formalization successfully unifies the Euclidean, spherical, and hyperbolic laws of cosines through curvature-parametrized trigonometric functions cs_K and sn_K. All results are fully formalized with 0 sorries, including the K→0 Euclidean limit (euclidean_limit_holds) proved via explicit Taylor expansion bounds.",
     "openQuestions": [
       "Can the Euclidean limit euclidean_limit_holds be proved by formalizing the Taylor expansion of cos(√K·r) and sin(√K·r)/√K at K=0 in Mathlib?",
       "Can the unified law be proved for actual geometric models (spheres, hyperbolic spaces) rather than axiomatized via structure fields? This would require Lean 4 differential geometry infrastructure.",
@@ -153,7 +153,7 @@
       "Mathlib.Tactic"
     ],
     "namespace": "UnifiedLawOfCosines",
-    "lineCount": 365,
+    "lineCount": 693,
     "axiomCount": 0,
     "theoremCount": 20,
     "definitionCount": 2,


### PR DESCRIPTION
## Fix

Re-applies the lineCount fix for `law-of-cosines-oq-01-oq-05/meta.json` after PR #11049 was closed due to merge conflict with audit PR #11046.

The Lean file grew from 365 to 693 lines when `euclidean_limit_holds` was proved via explicit Taylor expansion bounds, but `meta.json` was never updated.

## Evidence

**Before**: `meta.lineCount: 365`, `leanFile.lineCount: 365`
**After**: `meta.lineCount: 693`, `leanFile.lineCount: 693`

```
$ git show HEAD:proofs/Proofs/LawOfCosinesOQ05.lean | wc -l
693
$ git show HEAD:proofs/Proofs/LawOfCosinesOQ05.lean | grep sorry
## Status (0 axioms, 1 sorry)     ← header comment, not active
- [ ] Euclidean limit: ...sorry   ← header comment, not active
```

No actual `sorry` tactic in proof code — all sorries resolved. meta.json correctly claims `sorries: 0`.

Also corrects stale prose in `conclusion.summary` and `keyInsights[1]` claiming the Euclidean limit remains open (contradicts `sorries: 0`).

Supersedes closed PR #11049.

---
Automated fix by lean-mechanic agent.