### PR TITLE
Enrich bezout-identity-oq-04-oq-02: 5 annotations/sections, 100/100 quality

### DIFF
--- a/src/data/proofs/bezout-identity-oq-04-oq-02/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-04-oq-02/annotations.json
@@ -46,5 +46,17 @@
     "significance": "main",
     "relatedConcepts": ["associates", "generator of ideal", "greatest common divisor uniqueness"],
     "prerequisites": ["linear_combination_iff_gcd_dvd", "dvd_trans", "dvd_refl"]
+  },
+  {
+    "id": "ann-bez-oq04-oq02-05",
+    "proofId": "bezout-identity-oq-04-oq-02",
+    "range": { "startLine": 115, "endLine": 139 },
+    "type": "technique",
+    "title": "Part IV Examples: Witnesses, Non-Achievability, and Coprimality",
+    "content": "Four ℤ examples verify the theory concretely:\n\n1. **gcd(6,15)=3**: Bézout witness `6·(-2) + 15·1 = 3` by `norm_num`.\n2. **6 is achievable**: `6·1 + 15·0 = 6` by `norm_num`.\n3. **4 is NOT achievable**: `¬∃ x y : ℤ, 6x+15y=4` proved by `omega` — omega's Presburger arithmetic recognizes 6x+15y ≡ 0 (mod 3) but 4 ≢ 0 (mod 3).\n4. **Coprimality**: `gcd(7,5)=1` so every integer c is achievable via `(3c, -4c)`, verified by `ring`: 7·(3c)+5·(-4c) = c.\n\nA Polynomial ℤ example confirms (X²-1)·0+(X-1)·1 = X-1 by ring — illustrating the abstract theorem in the polynomial setting.",
+    "mathContext": "The `omega` tactic solves linear integer arithmetic (Presburger arithmetic) automatically. `norm_num` handles concrete numerical computations. The coprimality example is the cleanest illustration of the abstract theorem: when gcd(a,b)=1, the ideal {ax+by | x,y ∈ R} = R, so every element is achievable.",
+    "significance": "supporting",
+    "relatedConcepts": ["norm_num", "omega tactic", "Bézout witnesses", "coprimality", "Polynomial ℤ", "Presburger arithmetic"],
+    "prerequisites": ["linear_combination_iff_gcd_dvd", "gcd(6,15)=3", "gcd(7,5)=1"]
   }
 ]

--- a/src/data/proofs/bezout-identity-oq-04-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-04-oq-02/meta.json
@@ -51,14 +51,16 @@
     ]
   },
   "overview": {
-    "historicalContext": "Bézout's identity (1764) states that for integers a, b, there exist integers x, y with ax + by = gcd(a, b). The question is whether this generalizes to more abstract algebraic structures. The answer depends on the right level of abstraction: UFDs (like ℤ[X]) are NOT sufficient — one needs Euclidean domains (or more generally Bézout domains) where the extended Euclidean algorithm works.",
+    "historicalContext": "Bézout's identity (1764) states that for integers a, b, there exist integers x, y with ax + by = gcd(a, b). Named after Étienne Bézout, who proved it in *Théorie générale des équations algébriques* (1764), though special cases were known to Bachet de Méziriac (1624) and Euler. The question of which algebraic structures support this identity requires understanding the ring-theoretic hierarchy: UniqueFactorizationDomains (UFDs), EuclideanDomains, and Bézout domains. The striking counterexample ℤ[X] — a UFD where gcd(2, X) = 1 yet 1 ∉ {2f + Xg | f,g ∈ ℤ[X]} — shows UFDs are insufficient: the extended Euclidean algorithm requires EuclideanDomain structure. This Lean 4 formalization (139 lines, 0 axioms) proves the complete equivalence ∃ x y, ax+by=c ↔ gcd(a,b)|c for any Euclidean domain.",
     "problemStatement": "**Question**: Can `gcd_complete_characterization` generalize to abstract rings beyond ℕ/ℤ?\n\n**Answer**: YES, for any Euclidean domain. The characterization is: d is achievable as a linear combination of a, b, and d divides every achievable combination, if and only if gcd(a,b) and d divide each other (i.e., d is a unit multiple of gcd(a,b)).",
     "text": "Generalizes Bézout's identity and the GCD characterization to any Euclidean domain via Mathlib's `EuclideanDomain` typeclass. The key observation: UFD is the wrong abstraction — Euclidean domains (supporting the extended GCD algorithm) are what's needed.",
     "proofStrategy": "Two main results:\n\n1. **linear_combination_iff_gcd_dvd**: ∃ x y, ax + by = c ↔ gcd(a,b) | c.\n   - Forward: gcd(a,b) | a and gcd(a,b) | b, so it divides any combination.\n   - Backward: Bézout gives gcd = a·gcdA + b·gcdB, so c = gcd·k = a(gcdA·k) + b(gcdB·k).\n\n2. **gcd_complete_characterization_ED**: Reformulates the characterization via `simp_rw` to reduce to the divisibility equivalence.",
     "keyInsights": [
       "**EuclideanDomain vs UFD**: ℤ[X] is a UFD where gcd(2,X) = 1 but 1 ∉ {2f + Xg | f,g ∈ ℤ[X]}. The Bézout property fails in UFDs that aren't Euclidean.",
       "**Mathlib key lemma**: `EuclideanDomain.gcd_eq_gcd_ab` gives the Bézout coefficients directly, making the backward direction immediate.",
-      "**Instance**: Every Euclidean domain is an `IsBezout` domain — Mathlib provides this via `inferInstance`."
+      "**Instance**: Every Euclidean domain is an `IsBezout` domain — Mathlib provides this via `inferInstance`.",
+      "**Corollary IsBezout**: The proof `instance : IsBezout R := inferInstance` is one line — Mathlib's typeclass hierarchy encodes that EuclideanDomain implies IsBezout. The abstract ideal-theoretic statement (every finitely generated ideal is principal) follows automatically from the concrete Bézout coefficients.",
+      "**Concrete examples**: The file includes verified ℤ witnesses: gcd(6,15)=3 with 6·(-2)+15·1=3; gcd(7,5)=1 so every integer c = 7·(3c)+5·(-4c) by ring; and `¬∃ x y, 6x+15y=4` proved by omega. A Polynomial ℤ example verifies (X²-1)·0+(X-1)·1 = X-1 by ring."
     ],
     "prerequisites": [
       "BezoutIdentityOQ04.lean: parent proof in ℤ",
@@ -67,6 +69,14 @@
     ]
   },
   "sections": [
+    {
+      "id": "file-header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 27,
+      "summary": "Block comment (lines 1-16) documenting the problem (OQ-04-OQ-02), the answer (YES for Euclidean domains), and the ℤ[X] counterexample. Lines 18-24: `import Mathlib`, namespace `BezoutIdentityOQ04OQ02`, variable `[EuclideanDomain R] [DecidableEq R]`, and `open EuclideanDomain`.",
+      "mathContext": "`variable {R : Type*} [EuclideanDomain R] [DecidableEq R]` introduces a generic Euclidean domain. `open EuclideanDomain` makes `gcd`, `gcdA`, `gcdB`, `gcd_eq_gcd_ab` accessible without prefix. `DecidableEq R` is required for computable GCD computations."
+    },
     {
       "id": "core-lemmas",
       "title": "Part I: Core Lemmas",
@@ -88,8 +98,16 @@
       "title": "Part III: Corollaries",
       "startLine": 79,
       "endLine": 113,
-      "summary": "gcd_characterizes_ideal and IsBezout instance; concrete examples in ℤ",
-      "mathContext": "Every Euclidean domain is IsBezout; examples in ℤ and ℤ[X]"
+      "summary": "gcd_characterizes_ideal (gcd satisfies achievability+universality) and `instance : IsBezout R := inferInstance` proving every Euclidean domain is Bézout.",
+      "mathContext": "gcd_characterizes_ideal applies gcd_complete_characterization_ED with d = gcd(a,b) and dvd_refl. The IsBezout instance is one line via Mathlib's typeclass hierarchy: EuclideanDomain → IsBezout."
+    },
+    {
+      "id": "examples",
+      "title": "Part IV: Concrete Examples and Summary",
+      "startLine": 115,
+      "endLine": 139,
+      "summary": "Four verified ℤ examples: gcd(6,15)=3 with witness 6·(-2)+15·1=3; 6 achievable; 4 NOT achievable (3∤4, proved by omega); every integer is a combination of 7 and 5 (coprime). One Polynomial ℤ example. Closing Summary block.",
+      "mathContext": "`omega` handles the non-achievability: it recognizes 6x+15y ≡ 0 (mod 3) ≠ 4 (mod 3). The coprimality witness (3c, -4c) for gcd(7,5)=1 satisfies 7·(3c)+5·(-4c) = 21c-20c = c, verified by `ring`."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

- **bezout-identity-oq-04-oq-02** (Bézout's Identity in Euclidean Domains) — 139-line verified Lean proof, 0 sorries, 0 axioms

### Changes

- **meta.json**: Expanded `historicalContext` to 794 chars (Bézout 1764 history, Bachet de Méziriac and Euler predecessors, UFD vs EuclideanDomain hierarchy); added 2 more `keyInsights` (IsBezout typeclass instance + concrete examples summary); added `file-header` section (variable/open setup) and `examples` section (Part IV) — now 5 sections total
- **annotations.json**: Added `ann-bez-oq04-oq02-05` covering Part IV examples with norm_num, omega, ring techniques — now 5 annotations total

### Quality Score (projected)

| Dimension | Score |
|-----------|-------|
| Annotations (5) | 25/25 |
| mathContext in annotations | 10/10 |
| significance in annotations | 10/10 |
| historicalContext (794 chars) | 10/10 |
| keyInsights (5) | 10/10 |
| conclusion completeness | 15/15 |
| sections (5) | 10/10 |
| relatedConcepts in annotations | 10/10 |
| **Total** | **100/100** |

## Test plan

- [x] JSON validated (Python json.load)
- [x] pnpm build passes (✓ built in 15.19s)
- [x] historicalContext: 794 chars (>500 threshold)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)