### PR TITLE
Enrich fourier-series-oq-02-oq-01: 58→100/100 quality

### DIFF
--- a/src/data/proofs/fourier-series-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/fourier-series-oq-02-oq-01/annotations.json
@@ -22,5 +22,41 @@
     "significance": "main",
     "relatedConcepts": ["MemLp.toLp", "coeFn_toLp", "hasSum_sq_fourierCoeff", "Parseval"],
     "prerequisites": ["compact spaces", "Haar measure", "Lp spaces", "Parseval's identity"]
+  },
+  {
+    "id": "ann-fourier-oq02-oq01-03",
+    "proofId": "fourier-series-oq-02-oq-01",
+    "range": { "startLine": 1, "endLine": 8 },
+    "type": "context",
+    "title": "Imports: Selective Mathlib Modules",
+    "content": "The file imports specific Mathlib modules rather than `import Mathlib`, keeping compilation faster. Key modules:\n\n- `Mathlib.Analysis.Fourier.AddCircle`: `fourierCoeff`, `haarAddCircle`, Parseval\n- `Mathlib.Analysis.InnerProductSpace.l2Space`: L² space structure\n- `Mathlib.MeasureTheory.Function.L2Space`: `MemLp`, `toLp`, `coeFn_toLp`\n- `Mathlib.Topology.MetricSpace.Holder`: `HolderWith`, continuity\n- `Proofs.FourierSeries`: the parent module providing `fourierCoeff_tendsto_zero`",
+    "mathContext": "The local import `Proofs.FourierSeries` is the parent Lean module in this project, providing `FourierSeries.fourierCoeff_tendsto_zero : ∀ (f : Lp ℂ 2 haarAddCircle), Tendsto (fourierCoeff ⇑f) cofinite (𝓝 0)`. This is the Parseval-based Riemann-Lebesgue lemma for L² functions that drives this proof.",
+    "significance": "supporting",
+    "relatedConcepts": ["Mathlib.Analysis.Fourier.AddCircle", "haarAddCircle", "FourierSeries.lean", "selective imports"],
+    "prerequisites": ["Lean 4 import system", "Mathlib project structure"]
+  },
+  {
+    "id": "ann-fourier-oq02-oq01-04",
+    "proofId": "fourier-series-oq-02-oq-01",
+    "range": { "startLine": 36, "endLine": 45 },
+    "type": "technique",
+    "title": "Namespace Setup: maxHeartbeats, noncomputable, Opens",
+    "content": "Three setup lines before the theorem:\n\n1. `set_option maxHeartbeats 400000` — Parseval's identity elaboration is expensive; the default heartbeat limit (200000) would time out.\n\n2. `noncomputable section` — `Lp ℂ 2 haarAddCircle` (the L² space) is defined via quotient construction and is not computable. All definitions in this section are implicitly noncomputable.\n\n3. `open MeasureTheory Complex Topology Filter AddCircle` + `open scoped ENNReal NNReal Real` — these opens make `MemLp`, `haarAddCircle`, `Tendsto`, `cofinite`, `𝓝`, and numeric notations accessible without prefixes.",
+    "mathContext": "The `Fact (0 < T)` instance in `variable {T : ℝ} [hT : Fact (0 < T)]` is how Mathlib requires the positive period: it's a typeclass `Fact P` wrapping the proposition `P`. The `[hT : Fact (0 < T)]` makes the proof `hT.out : 0 < T` available for `AddCircle T` constructions.",
+    "significance": "supporting",
+    "relatedConcepts": ["maxHeartbeats", "noncomputable section", "Fact typeclass", "AddCircle", "Filter.cofinite"],
+    "prerequisites": ["Lean 4 section system", "noncomputable types", "Mathlib typeclass Fact"]
+  },
+  {
+    "id": "ann-fourier-oq02-oq01-05",
+    "proofId": "fourier-series-oq-02-oq-01",
+    "range": { "startLine": 60, "endLine": 78 },
+    "type": "technique",
+    "title": "MemLp.mono' and rwa Transfer: Two Key Techniques",
+    "content": "**MemLp.mono' (lines 60-66)**: The pattern `(memLp_const sSup_val).mono' hf_cont.aestronglyMeasurable (Eventually.of_forall bound_proof)` proves `MemLp f 2 haarAddCircle` by:\n- `memLp_const sSup_val`: the constant function `x ↦ sSup ‖f·‖` is in L² (it's bounded and the measure is finite)\n- `.mono'`: if g ∈ Lp and ‖f(x)‖ ≤ ‖g(x)‖ a.e., then f ∈ Lp\n- The bound `‖f(x)‖ ≤ sSup ‖f·‖` follows from `le_csSup` + `isCompact_range hf_cont.norm`\n\n**rwa + funext transfer (lines 76-78)**: Converts `fourierCoeff_tendsto_zero f_Lp` (for the L² element) to a statement about f by `rwa [show (fun n => fourierCoeff ⇑f_Lp n) = (fun n => fourierCoeff f n) from funext hfc_eq]`.",
+    "mathContext": "`le_csSup` requires the set to be bounded above (`bddAbove`) — this follows from `IsCompact.bddAbove (isCompact_range hf_cont.norm)` (the image of a continuous function on a compact space is compact, hence bounded). `Eventually.of_forall` lifts a pointwise bound to a filter predicate.",
+    "significance": "key",
+    "relatedConcepts": ["MemLp.mono'", "memLp_const", "isCompact_range", "le_csSup", "rwa", "funext"],
+    "prerequisites": ["MemLp in Mathlib", "Filter.Eventually.of_forall", "IsCompact.bddAbove"]
   }
 ]

--- a/src/data/proofs/fourier-series-oq-02-oq-01/meta.json
+++ b/src/data/proofs/fourier-series-oq-02-oq-01/meta.json
@@ -50,14 +50,16 @@
     ]
   },
   "overview": {
-    "historicalContext": "The Riemann-Lebesgue lemma (Riemann 1867, Lebesgue 1903) states that the Fourier coefficients of an integrable function tend to zero. The standard proofs proceed via L¹ density arguments or direct computation. For Hölder functions, one can give a quantitative proof showing ‖ĉ_n‖ = O(1/|n|^α), but there is also a simpler qualitative route via L².",
+    "historicalContext": "The Riemann-Lebesgue lemma was first proved by Bernhard Riemann (1867) for piecewise continuous functions and extended by Henri Lebesgue (1903) to all L¹ functions. It states that for f ∈ L¹(ℝ) (or on any locally compact group), the Fourier transform f̂(ξ) → 0 as |ξ| → ∞. Three classical proofs exist: (1) the L¹ density argument (approximate f by step functions, whose Fourier transforms can be computed explicitly); (2) integration by parts for smooth f; (3) the L² route via Parseval's identity (‖ĉ_n‖² summable → coefficients tend to zero). For Hölder-continuous functions, a quantitative version gives ‖ĉ_n‖ = O(|n|^{-α}). This Lean 4 formalization shows that the qualitative result (ĉ_n → 0) follows from the L² route in ~15 lines, bypassing the ~90-line quantitative proof.",
     "problemStatement": "**Question**: Is there a shorter proof of `riemannLebesgue_of_holder` that avoids the explicit quantitative bound and uses Mathlib's L² Riemann-Lebesgue infrastructure instead?\n\n**Answer**: YES. The L² Parseval argument gives the same conclusion in ~15 lines vs ~90 lines.",
     "text": "Gives an alternative proof of the Riemann-Lebesgue lemma for Hölder functions using the L²/Parseval route: Continuous → MemLp 2 → Parseval summability → coefficient convergence.",
     "proofStrategy": "The key chain:\n1. **Hölder → Continuous**: `HolderWith.continuous (hf.continuous hα)` gives Continuous f.\n2. **Continuous → MemLp 2**: On the compact space `AddCircle T` with finite Haar measure, any continuous function is bounded, hence in L².\n3. **Lift to Lp**: `hf_memLp.toLp f` creates an L² representative `f_Lp`.\n4. **Coefficient equality**: `⇑f_Lp =ᵐ f` (a.e.) implies `fourierCoeff ⇑f_Lp = fourierCoeff f`.\n5. **Parseval → RL**: `fourierCoeff_tendsto_zero f_Lp` (from FourierSeries.lean) gives ĉ_n(f_Lp) → 0 via Parseval.",
     "keyInsights": [
       "**L² suffices for RL**: The Riemann-Lebesgue property follows from L²-membership alone — quantitative Hölder decay rates are not needed for the qualitative statement.",
       "**Compact → bounded → L²**: On a compact metric space with finite measure, continuous implies bounded, and bounded implies L² — the key step enabling the lift.",
-      "**Parseval as backbone**: `hasSum_sq_fourierCoeff` in Mathlib (Parseval's identity) directly gives summability of ‖ĉ_n‖², from which ĉ_n → 0 follows immediately."
+      "**Parseval as backbone**: `hasSum_sq_fourierCoeff` in Mathlib (Parseval's identity) directly gives summability of ‖ĉ_n‖², from which ĉ_n → 0 follows immediately.",
+      "**`rwa` + `funext` transfer**: The `rwa [show ... = ... from funext hfc_eq]` at lines 77-78 transfers the Tendsto statement from `⇑f_Lp` to `f` using function extensionality. The key lemma `hfc_eq : ∀ n, fourierCoeff (⇑f_Lp) n = fourierCoeff f n` is built by `integral_congr_ae` applied to `hf_memLp.coeFn_toLp`. This is the standard Lean 4 pattern for transferring results between a.e.-equal functions.",
+      "**`MemLp.mono'` pattern**: The MemLp proof at lines 60-66 uses `(memLp_const sSup(...)).mono'` to show f ∈ L². The `mono'` lemma says: if g ∈ Lp and f is measurable with ‖f(x)‖ ≤ ‖g(x)‖ a.e., then f ∈ Lp. Here g is the constant function sSup ‖f‖, which is in Lp by `memLp_const`, and ‖f(x)‖ ≤ sSup ‖f‖ because f is continuous on a compact space (so the sup is achieved and `le_csSup` applies)."
     ],
     "prerequisites": [
       "FourierSeriesOQ02.lean: parent proof with quantitative Hölder decay bounds",
@@ -66,12 +68,44 @@
   },
   "sections": [
     {
+      "id": "imports",
+      "title": "Imports and Dependencies",
+      "startLine": 1,
+      "endLine": 8,
+      "summary": "Lines 1-8: selective Mathlib imports for AddCircle Fourier theory, inner product spaces, L² spaces, Hölder topology, tactics, and the parent FourierSeries.lean module. The selective imports (not `import Mathlib`) keep compilation faster.",
+      "mathContext": "Key imports: `Mathlib.Analysis.Fourier.AddCircle` (fourierCoeff, haarAddCircle, Parseval); `Mathlib.MeasureTheory.Function.L2Space` (MemLp, toLp, coeFn_toLp); `Mathlib.Topology.MetricSpace.Holder` (HolderWith, HolderWith.continuous); `Proofs.FourierSeries` (fourierCoeff_tendsto_zero for L² functions)."
+    },
+    {
+      "id": "module-overview",
+      "title": "Module Overview: L² vs Quantitative Approach",
+      "startLine": 9,
+      "endLine": 34,
+      "summary": "Block comment documenting the open question (can RL for Hölder functions be proved via Parseval?), the affirmative answer, the 5-step proof chain (Hölder→Continuous→MemLp→lift→Parseval), and the significance (L² qualitative vs quantitative ~90 line proof).",
+      "mathContext": "The 5-step chain formalized: (1) `HolderWith.continuous`: Hölder(α>0) → Continuous; (2) compact AddCircle T + finite Haar measure → bounded → L²; (3) `MemLp.toLp` lifts f to Lp equivalence class; (4) `coeFn_toLp`: the lift agrees a.e. with f; (5) `fourierCoeff_tendsto_zero` (Parseval): Σ‖ĉ_n‖² < ∞ → ĉ_n → 0."
+    },
+    {
+      "id": "namespace-setup",
+      "title": "Namespace, Opens, and Variable",
+      "startLine": 36,
+      "endLine": 45,
+      "summary": "Lines 36-45: `set_option maxHeartbeats 400000` (needed for Parseval elaboration), `noncomputable section` (Lp spaces are noncomputable), `open` declarations for MeasureTheory, Complex, Topology, Filter, AddCircle, ENNReal, NNReal, Real, and `namespace FourierHolderL2RL`. Variable `{T : ℝ} [hT : Fact (0 < T)]`.",
+      "mathContext": "`Fact (0 < T)` is the Mathlib typeclass requiring the period T to be positive, needed by `AddCircle T` and `haarAddCircle`. The `noncomputable` annotation is necessary because L² spaces (Lp ℂ 2 haarAddCircle) involve subtraction of equivalence classes which is not computable."
+    },
+    {
       "id": "main-theorem",
       "title": "L² Riemann-Lebesgue for Hölder Functions",
-      "startLine": 49,
-      "endLine": 73,
-      "summary": "riemannLebesgue_of_holder_via_L2 via Parseval path",
-      "mathContext": "Hölder → Continuous → MemLp 2 → fourierCoeff_tendsto_zero"
+      "startLine": 46,
+      "endLine": 79,
+      "summary": "riemannLebesgue_of_holder_via_L2: 5-step proof. Step 1 (line 57): Hölder → Continuous via `hf.continuous hα`. Step 2 (lines 60-66): Continuous → MemLp via `memLp_const.mono'` + `le_csSup`. Step 3 (line 68): `set f_Lp := hf_memLp.toLp f`. Step 4 (lines 71-74): `hfc_eq` via `integral_congr_ae`. Step 5 (lines 76-78): `fourierCoeff_tendsto_zero` + `rwa`.",
+      "mathContext": "The theorem type: `(C : ℝ≥0) → (α : ℝ≥0) → (f : AddCircle T → ℂ) → HolderWith C α f → 0 < α → Tendsto (fun n : ℤ => fourierCoeff f n) cofinite (𝓝 0)`. The filter `cofinite` captures \"for all but finitely many n\" — `Tendsto f cofinite (𝓝 0)` means |n| → ∞ implies f(n) → 0."
+    },
+    {
+      "id": "verification",
+      "title": "Verification and Namespace Close",
+      "startLine": 80,
+      "endLine": 83,
+      "summary": "Line 81: `#check @riemannLebesgue_of_holder_via_L2` verifies the theorem signature. Line 83: `end FourierHolderL2RL` closes the namespace. The theorem is accessible outside as `FourierHolderL2RL.riemannLebesgue_of_holder_via_L2`.",
+      "mathContext": "The `@` in `#check @riemannLebesgue_of_holder_via_L2` shows all implicit arguments explicitly, verifying the full type signature including `{T : ℝ}` and `[hT : Fact (0 < T)]`. This is a standard Lean 4 idiom to check that the theorem's implicit arguments have been properly inferred."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

- **fourier-series-oq-02-oq-01** (Riemann-Lebesgue via L²: Alternative Proof for Hölder Functions) — 83-line verified Lean proof, 0 sorries, 0 axioms

### Changes

- **meta.json**: Expanded `historicalContext` from 347 to 781 chars (added Riemann 1867/Lebesgue 1903 history, three classical proof approaches); added 2 more `keyInsights` (rwa+funext transfer pattern, MemLp.mono' pattern); restructured 1 section into 5 sections (imports, module-overview, namespace-setup, main-theorem with full range, verification)
- **annotations.json**: Added 3 new annotations — selective imports context, maxHeartbeats/noncomputable/opens setup, MemLp.mono' + rwa transfer techniques — bringing total to 5 annotations

### Quality Score

| Dimension | Before | After |
|-----------|--------|-------|
| Annotations | 10/25 | 25/25 |
| mathContext | 6/10 | 10/10 |
| significance | 6/10 | 10/10 |
| historicalContext | 7/10 | 10/10 |
| keyInsights | 6/10 | 10/10 |
| conclusion | 15/15 | 15/15 |
| sections | 2/10 | 10/10 |
| relatedConcepts | 6/10 | 10/10 |
| **Total** | **58/100** | **100/100** |

## Test plan

- [x] JSON validated (Python json.load)
- [x] Computed quality: 100/100 verified
- [x] pnpm build passes (✓ built in 16.47s)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)