### PR TITLE
Fix: binomial-theorem-oq-04-oq-02-oq-01 — restore sorries=1, status=formalized

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-04-oq-02-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-04-oq-02-oq-01/meta.json
@@ -2,13 +2,13 @@
   "id": "binomial-theorem-oq-04-oq-02-oq-01",
   "title": "q-Vandermonde Identity: Gaussian Binomial Coefficients",
   "slug": "binomial-theorem-oq-04-oq-02-oq-01",
-  "sorries": 0,
+  "sorries": 1,
   "description": "Formalization of Gaussian binomial coefficients [n choose k]_q via the q-Pascal recurrence, and the q-Vandermonde identity: [m+n choose r]_q = Σ_k [m choose k]_q · [n choose r-k]_q · q^(k·(n+k-r)).",
   "meta": {
     "author": "Formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Gaussian_binomial_coefficient",
     "date": "2026",
-    "status": "verified",
+    "status": "formalized",
     "tags": [
       "combinatorics",
       "algebra",
@@ -17,8 +17,8 @@
       "research"
     ],
     "proofRepoPath": "Proofs/BinomialTheoremOQ04OQ02OQ01.lean",
-    "badge": "original",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "Nat.choose_succ_succ",
@@ -31,13 +31,13 @@
       "gaussBinom_eq_zero_of_lt: vanishing property [n choose k]_q = 0 when k > n",
       "gaussBinom_self: [n choose n]_q = 1 for all n",
       "gaussBinom_one: classical limit — [n choose k]_1 = C(n,k)",
-      "q_vandermonde: main identity — fully proved by induction using q-Pascal expansion and Finset.sum reindexing",
-      "vandermonde_from_q: classical Vandermonde as corollary via q=1 specialization (fully proved)"
+      "q_vandermonde: main identity — inductive proof structure complete, 1 sorry in the Finset.sum reindexing step",
+      "vandermonde_from_q: classical Vandermonde as corollary via q=1 specialization (inherits q_vandermonde sorry)"
     ],
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "lineCount": 224,
-    "assumptions": "None. All results fully proved: q_vandermonde inductive step completed using q-Pascal expansion with Finset.sum_range_succ, mul_sum, and ring.",
+    "lineCount": 156,
+    "assumptions": "1 sorry: q_vandermonde (line 133) — the inductive step Finset.sum reindexing (k ↦ k-1) with q-exponent matching is not yet complete.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -141,12 +141,12 @@
       "Finset"
     ],
     "namespace": "BinomialTheoremOQ04OQ02OQ01",
-    "lineCount": 224,
+    "lineCount": 156,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 1,
     "path": "Proofs/BinomialTheoremOQ04OQ02OQ01.lean",
-    "sorries": 0
+    "sorries": 1
   },
   "references": [
     {


### PR DESCRIPTION
## Fix

Restore accurate metadata for `binomial-theorem-oq-04-oq-02-oq-01` after auditor over-correction.

## Evidence

**Root cause**: Auditor commit `33576f61b1` marked this proof as `verified` (sorries=0, badge=original), trusting a claim from commit `9bc509588e` that said the q_vandermonde sorry was resolved. However, commit `9bc509588e` only updated a research problems JSON — the Lean source file still has 1 sorry on line 133 (q_vandermonde inductive step, Finset.sum reindexing).

**Before**: sorries=0, status=verified, badge=original, lineCount=224
**After**: sorries=1, status=formalized, badge=wip, lineCount=156

Verification:
```
grep -n "sorry" proofs/Proofs/BinomialTheoremOQ04OQ02OQ01.lean
# 133:  sorry
wc -l proofs/Proofs/BinomialTheoremOQ04OQ02OQ01.lean
# 156
```

Note: The narrative text (overview.text, sections, conclusion) already correctly described the sorry — only the status/count fields needed correction.

---
Automated fix by lean-mechanic agent.