### PR TITLE
Fix: erdos-840 — correct sorries 0→10, axiomCount 9→8, lineCount 227→221

### DIFF
--- a/src/data/proofs/erdos-840/meta.json
+++ b/src/data/proofs/erdos-840/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-840",
-  "title": "Erd\u0151s Problem #840: Quasi-Sidon Subsets",
+  "title": "Erdős Problem #840: Quasi-Sidon Subsets",
   "slug": "erdos-840",
-  "description": "How large can a quasi-Sidon subset of {1,...,N} be? A set A is quasi-Sidon if |A+A| = (1+o(1))\u00b7C(|A|,2). Bounds: (2/\u221a3)\u221aN \u2264 f(N) \u2264 1.86\u221aN.",
+  "description": "How large can a quasi-Sidon subset of {1,...,N} be? A set A is quasi-Sidon if |A+A| = (1+o(1))·C(|A|,2). Bounds: (2/√3)√N ≤ f(N) ≤ 1.86√N.",
   "meta": {
-    "author": "Erd\u0151s and Freud",
+    "author": "Erdős and Freud",
     "sourceUrl": "https://erdosproblems.com/840",
     "date": "1991",
     "status": "axiomatized",
@@ -17,29 +17,29 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 10,
     "erdosNumber": 840,
     "erdosUrl": "https://erdosproblems.com/840",
     "erdosProblemStatus": "open",
-    "axiomCount": 9,
-    "lineCount": 227,
-    "assumptions": "9 axioms: (1) sidon_sumset_card \u2014 classical Sidon cardinality |A+A|=C(|A|+1,2); (2) erdos_freud_lower_bound \u2014 Erd\u0151s-Freud (1991) lower bound f(N)\u2265(2/\u221a3+o(1))\u221aN; (3) construction_is_quasi_sidon \u2014 Erd\u0151s-Freud construction is quasi-Sidon; (4) erdos_freud_upper_bound \u2014 Erd\u0151s-Freud (1991) upper bound f(N)\u2264(2+o(1))\u221aN; (5) pikhurko_upper_bound \u2014 Pikhurko (2006) improved bound f(N)\u2264(c_P+o(1))\u221aN; (6) sidon_set_upper_bound \u2014 classical Sidon bound |A|\u2264\u221aN+O(N^{1/4}); (7) sidon_set_exists \u2014 Singer construction Sidon sets of size ~\u221aN; (8) pikhurko_constant_approx \u2014 numerical bound c_P\u2208(1.86,1.87); (9) bounds_gap \u2014 gap c_P-2/\u221a3<0.72. Proven: lower_bound_constant_value, cilleruelo_difference_set, open_problem_gap.",
+    "axiomCount": 8,
+    "lineCount": 221,
+    "assumptions": "8 axioms (theorem sorries) and 2 definition sorries. Axioms: (1) sidon_sumset_card — classical Sidon cardinality |A+A|=C(|A|+1,2); (2) erdos_freud_lower_bound — Erdős-Freud (1991) lower bound f(N)≥(2/√3+o(1))√N; (3) construction_is_quasi_sidon — Erdős-Freud construction is quasi-Sidon; (4) erdos_freud_upper_bound — Erdős-Freud (1991) upper bound f(N)≤(2+o(1))√N; (5) pikhurko_upper_bound — Pikhurko (2006) improved bound f(N)≤(c_P+o(1))√N; (6) sidon_set_upper_bound — classical Sidon bound |A|≤√N+O(N^{1/4}); (7) sidon_set_exists — Singer construction Sidon sets of size ~√N; (8) pikhurko_constant_approx — numerical bound c_P∈(1.86,1.87). Definition sorries: f(N) and fAlt(N,δ) (axiomatized definitions). Proven: lower_bound_constant_value, bounds_gap, cilleruelo_difference_set, open_problem_gap.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "Sidon sets (also called $B_2$ sequences) were introduced by Simon Sidon in a 1932 letter to Erd\u0151s, asking for the maximum size of a subset of $\\{1, \\ldots, N\\}$ with all pairwise sums distinct. Erd\u0151s and Tur\u00e1n (1941) proved the upper bound $|A| \\leq \\sqrt{N} + O(N^{1/4})$, while constructions by Singer (1938, using difference sets from projective planes) and Bose\u2013Chowla (1962) achieved $|A| \\sim \\sqrt{N}$. The quasi-Sidon relaxation, introduced by Erd\u0151s and Freud in 1991, allows a vanishing fraction of sum collisions: $|A + A| = (1 + o(1)) \\binom{|A|}{2}$. This permits larger sets \u2014 the question is how much larger. Erd\u0151s and Freud proved $(2/\\sqrt{3})\\sqrt{N} \\leq f(N) \\leq 2\\sqrt{N}$ using a reflection construction and pigeonhole arguments. Pikhurko (2006) improved the upper bound to $\\approx 1.863\\sqrt{N}$ via a connection to edge-magic graph labelings and thin additive bases. Cilleruelo (2010) resolved the analogous problem for difference sets ($A - A$ instead of $A + A$), showing the answer is simply $\\sim \\sqrt{N}$ with constant 1. The sum version remains open, with the true constant lying in the interval $[2/\\sqrt{3}, 1.863] \\approx [1.155, 1.863]$.",
+    "historicalContext": "Sidon sets (also called $B_2$ sequences) were introduced by Simon Sidon in a 1932 letter to Erdős, asking for the maximum size of a subset of $\\{1, \\ldots, N\\}$ with all pairwise sums distinct. Erdős and Turán (1941) proved the upper bound $|A| \\leq \\sqrt{N} + O(N^{1/4})$, while constructions by Singer (1938, using difference sets from projective planes) and Bose–Chowla (1962) achieved $|A| \\sim \\sqrt{N}$. The quasi-Sidon relaxation, introduced by Erdős and Freud in 1991, allows a vanishing fraction of sum collisions: $|A + A| = (1 + o(1)) \\binom{|A|}{2}$. This permits larger sets — the question is how much larger. Erdős and Freud proved $(2/\\sqrt{3})\\sqrt{N} \\leq f(N) \\leq 2\\sqrt{N}$ using a reflection construction and pigeonhole arguments. Pikhurko (2006) improved the upper bound to $\\approx 1.863\\sqrt{N}$ via a connection to edge-magic graph labelings and thin additive bases. Cilleruelo (2010) resolved the analogous problem for difference sets ($A - A$ instead of $A + A$), showing the answer is simply $\\sim \\sqrt{N}$ with constant 1. The sum version remains open, with the true constant lying in the interval $[2/\\sqrt{3}, 1.863] \\approx [1.155, 1.863]$.",
     "problemStatement": "Let $f(N)$ be the maximum size of a quasi-Sidon subset $A \\subseteq \\{1, \\ldots, N\\}$, where $A$ is quasi-Sidon if $|A + A| = (1 + o(1)) \\binom{|A|}{2}$. What is the asymptotic constant $c$ such that $f(N) \\sim c\\sqrt{N}$? Known bounds: $(2/\\sqrt{3})\\sqrt{N} \\leq f(N) \\leq 1.863\\sqrt{N}$.",
-    "text": "How large can a quasi-Sidon subset of {1,...,N} be? A set A is quasi-Sidon if |A+A| = (1+o(1))\u00b7C(|A|,2). Bounds: (2/\u221a3)\u221aN \u2264 f(N) \u2264 1.86\u221aN.",
-    "proofStrategy": "The formalization defines Sidon sets (all pairwise sums distinct), sumsets $A + A$, and the quasi-Sidon condition via little-$o$ notation. The function $f(N)$ is axiomatized as the maximum quasi-Sidon subset size. The Erd\u0151s\u2013Freud lower bound construction (Sidon set $B \\subseteq [1, N/3]$ union reflection $\\{N - b : b \\in B\\}$) and Pikhurko's upper bound are axiomatized. Related results on difference sets (Cilleruelo) and classical Sidon bounds are also included.",
+    "text": "How large can a quasi-Sidon subset of {1,...,N} be? A set A is quasi-Sidon if |A+A| = (1+o(1))·C(|A|,2). Bounds: (2/√3)√N ≤ f(N) ≤ 1.86√N.",
+    "proofStrategy": "The formalization defines Sidon sets (all pairwise sums distinct), sumsets $A + A$, and the quasi-Sidon condition via little-$o$ notation. The function $f(N)$ is axiomatized as the maximum quasi-Sidon subset size. The Erdős–Freud lower bound construction (Sidon set $B \\subseteq [1, N/3]$ union reflection $\\{N - b : b \\in B\\}$) and Pikhurko's upper bound are axiomatized. Related results on difference sets (Cilleruelo) and classical Sidon bounds are also included.",
     "keyInsights": [
       "**Quasi-Sidon relaxation**: A Sidon set has $|A+A| = \\binom{|A|}{2} + |A|$ exactly; quasi-Sidon only requires $(1 + o(1))\\binom{|A|}{2}$. This tiny relaxation allows sets $\\sim 15\\%$ larger than Sidon sets.",
       "**Reflection construction**: Take a Sidon set $B \\subseteq [1, N/3]$ of size $\\sim \\sqrt{N/3}$ and form $A = B \\cup \\{N - b : b \\in B\\}$. Cross-sums $b_1 + (N - b_2) \\approx N$ cluster near $N$, avoiding most collisions with $b_1 + b_2$ or $(N-b_1) + (N-b_2)$.",
       "**Pikhurko's constant involves $\\pi$**: The upper bound constant $c_P = (1/4 + 1/(\\pi + 2)^2)^{-1/2} \\approx 1.863$ arises from optimizing over trigonometric sums in the analysis of edge-magic graph labelings.",
       "**Difference vs. sum asymmetry**: For $A - A$, Cilleruelo showed $f_{\\text{diff}}(N) \\sim \\sqrt{N}$ (constant 1). The sum version is harder because $A + A$ is 'smaller' than $A - A$ for structured sets ($|A+A| \\leq |A-A|$ by Ruzsa's inequality for sets with additive structure).",
-      "**Connection to Ruzsa\u2013Szemer\u00e9di**: Quasi-Sidon sets relate to $(6,3)$-free graphs and the Ruzsa\u2013Szemer\u00e9di removal lemma. Few repeated sums in $A + A$ mean the 'sum graph' on $A$ has few triangles."
+      "**Connection to Ruzsa–Szemerédi**: Quasi-Sidon sets relate to $(6,3)$-free graphs and the Ruzsa–Szemerédi removal lemma. Few repeated sums in $A + A$ mean the 'sum graph' on $A$ has few triangles."
     ],
     "prerequisites": [
-      "Additive combinatorics: sumsets $A + A$, Sidon ($B_2$) sets, and the Pl\u00fcnnecke-Ruzsa inequality relating $|A+A|$ to additive structure",
+      "Additive combinatorics: sumsets $A + A$, Sidon ($B_2$) sets, and the Plünnecke-Ruzsa inequality relating $|A+A|$ to additive structure",
       "Asymptotic analysis: little-$o$ notation, $\\Theta(\\sqrt{N})$ growth rates, and the distinction between exact and asymptotic extremal bounds",
       "Combinatorial number theory: binomial coefficients $\\binom{|A|}{2}$ as representation counts, pigeonhole arguments on sum collisions, and constructive lower bounds via Singer difference sets",
       "Extremal graph theory: connections to $(6,3)$-free graphs, the Ruzsa-Szemer\\'{e}di removal lemma, and edge-magic graph labelings (Pikhurko's upper bound)"
@@ -48,52 +48,52 @@
   "sections": [
     {
       "id": "sidon-quasi-sidon-defs",
-      "title": "\u00a71: Sidon Sets and the Quasi-Sidon Condition",
+      "title": "§1: Sidon Sets and the Quasi-Sidon Condition",
       "startLine": 42,
       "endLine": 95,
-      "summary": "Defines intervalFinset N = {1,...,N}, sumset A+A, IsSidon (all pairwise sums distinct), IsLittleO for asymptotic notation, and IsQuasiSidon with error o(|A+A|). Defines f(N) as max quasi-Sidon subset size and fAlt(N,\u03b4) as the \u03b4-approximate version. Proves sidon_sumset_card: Sidon sets have |A+A| = \u0398(|A|\u00b2).",
-      "mathContext": "$A \\subseteq \\{1,\\ldots,N\\}$ is Sidon (Sidon 1932, also B\u2082) if all pairwise sums $a_i + a_j$ ($i \\leq j$) are distinct. Equivalently, $|A+A| = \\binom{|A|}{2} + |A|$. The quasi-Sidon relaxation asks that $|A+A| \\geq \\binom{|A|}{2} + |A| - o(|A+A|)$ \u2014 allowing an asymptotically negligible number of collisions."
+      "summary": "Defines intervalFinset N = {1,...,N}, sumset A+A, IsSidon (all pairwise sums distinct), IsLittleO for asymptotic notation, and IsQuasiSidon with error o(|A+A|). Defines f(N) as max quasi-Sidon subset size and fAlt(N,δ) as the δ-approximate version. Proves sidon_sumset_card: Sidon sets have |A+A| = Θ(|A|²).",
+      "mathContext": "$A \\subseteq \\{1,\\ldots,N\\}$ is Sidon (Sidon 1932, also B₂) if all pairwise sums $a_i + a_j$ ($i \\leq j$) are distinct. Equivalently, $|A+A| = \\binom{|A|}{2} + |A|$. The quasi-Sidon relaxation asks that $|A+A| \\geq \\binom{|A|}{2} + |A| - o(|A+A|)$ — allowing an asymptotically negligible number of collisions."
     },
     {
       "id": "known-bounds",
-      "title": "\u00a72: Known Bounds \u2014 Erd\u0151s-Freud and Pikhurko",
+      "title": "§2: Known Bounds — Erdős-Freud and Pikhurko",
       "startLine": 96,
       "endLine": 152,
-      "summary": "Axiomatizes erdos_freud_lower_bound: f(N) \u2265 (2/\u221a3)N^(1/2) - o(N^(1/2)). Proves lower_bound_constant_value (2/\u221a3 = 2\u221a3/3). Defines lowerBoundConstruction and proves it is quasi-Sidon. Axiomatizes erdos_freud_upper_bound: f(N) \u2264 N^(1/2) + o(N^(1/2)) and pikhurko_upper_bound with sharper constant.",
-      "mathContext": "For classical Sidon sets: $|A| \\leq \\sqrt{N} + O(N^{1/4})$ (Singer 1938). Erd\u0151s and Freud (1991) proved quasi-Sidon sets can exceed this: $f(N) \\geq (2/\\sqrt{3})\\sqrt{N} - o(\\sqrt{N}) \\approx 1.155\\sqrt{N}$, strictly beating the Sidon bound. The upper bound $f(N) \\leq \\sqrt{N} + o(\\sqrt{N})$... wait, that would mean the lower bound exceeds the upper. The open question is whether $f(N)/\\sqrt{N} \\to c$ for some $c \\in (1, 2/\\sqrt{3}]$."
+      "summary": "Axiomatizes erdos_freud_lower_bound: f(N) ≥ (2/√3)N^(1/2) - o(N^(1/2)). Proves lower_bound_constant_value (2/√3 = 2√3/3). Defines lowerBoundConstruction and proves it is quasi-Sidon. Axiomatizes erdos_freud_upper_bound: f(N) ≤ N^(1/2) + o(N^(1/2)) and pikhurko_upper_bound with sharper constant.",
+      "mathContext": "For classical Sidon sets: $|A| \\leq \\sqrt{N} + O(N^{1/4})$ (Singer 1938). Erdős and Freud (1991) proved quasi-Sidon sets can exceed this: $f(N) \\geq (2/\\sqrt{3})\\sqrt{N} - o(\\sqrt{N}) \\approx 1.155\\sqrt{N}$, strictly beating the Sidon bound. The upper bound $f(N) \\leq \\sqrt{N} + o(\\sqrt{N})$... wait, that would mean the lower bound exceeds the upper. The open question is whether $f(N)/\\sqrt{N} \\to c$ for some $c \\in (1, 2/\\sqrt{3}]$."
     },
     {
       "id": "erdos-840-question",
-      "title": "\u00a73: The Main Question and Optimal Constant",
+      "title": "§3: The Main Question and Optimal Constant",
       "startLine": 154,
       "endLine": 165,
-      "summary": "States erdos_840_question: does f(N) ~ c\u00b7N^(1/2) for some constant c, and if so what is c? The formalization captures the open conjecture that the Erd\u0151s-Freud lower bound (2/\u221a3) is asymptotically optimal.",
-      "mathContext": "The central open question: is $\\lim_{N\\to\\infty} f(N)/\\sqrt{N}$ equal to $2/\\sqrt{3}$? The Erd\u0151s-Freud construction achieves this ratio, and they conjecture it is optimal. Pikhurko's improvement gives a sharper upper bound approaching $2/\\sqrt{3}$ from above, narrowing the gap. The question is equivalent to asking whether the quasi-Sidon condition allows only a bounded improvement over Sidon sets."
+      "summary": "States erdos_840_question: does f(N) ~ c·N^(1/2) for some constant c, and if so what is c? The formalization captures the open conjecture that the Erdős-Freud lower bound (2/√3) is asymptotically optimal.",
+      "mathContext": "The central open question: is $\\lim_{N\\to\\infty} f(N)/\\sqrt{N}$ equal to $2/\\sqrt{3}$? The Erdős-Freud construction achieves this ratio, and they conjecture it is optimal. Pikhurko's improvement gives a sharper upper bound approaching $2/\\sqrt{3}$ from above, narrowing the gap. The question is equivalent to asking whether the quasi-Sidon condition allows only a bounded improvement over Sidon sets."
     },
     {
       "id": "difference-set-theory",
-      "title": "\u00a74: Difference Sets and Cilleruelo's Theorem",
+      "title": "§4: Difference Sets and Cilleruelo's Theorem",
       "startLine": 163,
       "endLine": 200,
-      "summary": "Defines diffset A-A for integer Sidon sets. Axiomatizes cilleruelo_difference_set: Sidon sets over \u2124 have |A-A| = |A|\u00b2 - |A| + 1. Proves sidon_set_upper_bound: Sidon subsets of {1,...,N} have size \u2264 \u221aN + O(N^(1/4)). Proves sidon_set_exists: Sidon sets achieving \u2248 \u221aN exist.",
+      "summary": "Defines diffset A-A for integer Sidon sets. Axiomatizes cilleruelo_difference_set: Sidon sets over ℤ have |A-A| = |A|² - |A| + 1. Proves sidon_set_upper_bound: Sidon subsets of {1,...,N} have size ≤ √N + O(N^(1/4)). Proves sidon_set_exists: Sidon sets achieving ≈ √N exist.",
       "mathContext": "For Sidon sets $A \\subseteq \\mathbb{Z}$: the difference set $A - A$ has exactly $|A|^2 - |A| + 1$ elements (all differences are distinct except $0$). This difference-set characterization, due to Cilleruelo, provides an alternative route to Sidon set bounds via additive combinatorics and connects to perfect difference sets in finite projective planes."
     },
     {
       "id": "bounds-gap",
-      "title": "\u00a75: The Gap Between Sidon and Quasi-Sidon Bounds",
+      "title": "§5: The Gap Between Sidon and Quasi-Sidon Bounds",
       "startLine": 207,
       "endLine": 229,
-      "summary": "Proves bounds_gap: the Erd\u0151s-Freud lower bound (2/\u221a3) strictly exceeds the classical Sidon upper bound (1), making the quasi-Sidon problem genuinely distinct. Axiomatizes open_problem_gap: the exact value of lim f(N)/\u221aN is unknown. Summarizes the current state of the problem.",
-      "mathContext": "Since $2/\\sqrt{3} \\approx 1.155 > 1$, quasi-Sidon sets are provably larger than any Sidon set by a constant factor. The gap between the lower bound $2/\\sqrt{3}$ and the upper bound (approaching $2/\\sqrt{3}$ from above) is the frontier of the problem. Closing this gap would resolve Erd\u0151s Problem #840 and determine whether the Erd\u0151s-Freud construction is optimal."
+      "summary": "Proves bounds_gap: the Erdős-Freud lower bound (2/√3) strictly exceeds the classical Sidon upper bound (1), making the quasi-Sidon problem genuinely distinct. Axiomatizes open_problem_gap: the exact value of lim f(N)/√N is unknown. Summarizes the current state of the problem.",
+      "mathContext": "Since $2/\\sqrt{3} \\approx 1.155 > 1$, quasi-Sidon sets are provably larger than any Sidon set by a constant factor. The gap between the lower bound $2/\\sqrt{3}$ and the upper bound (approaching $2/\\sqrt{3}$ from above) is the frontier of the problem. Closing this gap would resolve Erdős Problem #840 and determine whether the Erdős-Freud construction is optimal."
     }
   ],
   "conclusion": {
-    "summary": "Erd\u0151s Problem #840 formalizes the quasi-Sidon problem: determine the maximum size of a subset of {1,...,N} with asymptotically optimal sumset size. The formalization axiomatizes the Erd\u0151s\u2013Freud bounds, Pikhurko's improvement, and related results on difference sets and classical Sidon bounds.",
-    "implications": "**Theoretical Significance**: Resolution would quantify exactly how much the quasi-Sidon relaxation buys over classical Sidon sets.\n\nThe connection to edge-magic graphs (Pikhurko), Ruzsa\u2013Szemer\u00e9di theory, and additive energy makes this a nexus problem in additive combinatorics. Closing the 38% gap between bounds would likely require new structural understanding of sets with few sum collisions.",
+    "summary": "Erdős Problem #840 formalizes the quasi-Sidon problem: determine the maximum size of a subset of {1,...,N} with asymptotically optimal sumset size. The formalization axiomatizes the Erdős–Freud bounds, Pikhurko's improvement, and related results on difference sets and classical Sidon bounds.",
+    "implications": "**Theoretical Significance**: Resolution would quantify exactly how much the quasi-Sidon relaxation buys over classical Sidon sets.\n\nThe connection to edge-magic graphs (Pikhurko), Ruzsa–Szemerédi theory, and additive energy makes this a nexus problem in additive combinatorics. Closing the 38% gap between bounds would likely require new structural understanding of sets with few sum collisions.",
     "openQuestions": [
       "What is the exact asymptotic constant $c$ such that $f(N) \\sim c\\sqrt{N}$? Is it $2/\\sqrt{3}$ or closer to $1.863$?",
       "Can the reflection construction ($B \\cup \\{N - b\\}$) be improved by using three or more shifted copies of a Sidon set?",
-      "Is there a connection between the quasi-Sidon constant and the Ruzsa\u2013Szemer\u00e9di density threshold?",
+      "Is there a connection between the quasi-Sidon constant and the Ruzsa–Szemerédi density threshold?",
       "For the difference-set version, Cilleruelo showed the constant is 1. Why is the sum version fundamentally harder?"
     ]
   },
@@ -101,29 +101,29 @@
     "imports": [],
     "opens": [],
     "namespace": null,
-    "lineCount": 227,
-    "axiomCount": 9,
+    "lineCount": 221,
+    "axiomCount": 8,
     "theoremCount": 9,
     "definitionCount": 0,
-    "sorries": 0,
+    "sorries": 10,
     "path": "Proofs/Erdos840Problem.lean"
   },
   "crossReferences": [
     {
       "targetId": "erdos-14",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: additive-combinatorics, sidon-sets, sumsets"
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, sidon-sets, sumsets"
     },
     {
       "targetId": "erdos-152",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: additive-combinatorics, sidon-sets, sumsets"
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, sidon-sets, sumsets"
     },
     {
       "targetId": "erdos-153",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: additive-combinatorics, sidon-sets, sumsets"
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, sidon-sets, sumsets"
     }
   ],
-  "sorries": 0
+  "sorries": 10
 }


### PR DESCRIPTION
## Fix

Correct three metadata fields in `src/data/proofs/erdos-840/meta.json`.

## Evidence

**sorries: 0 → 10**

The Lean file `Proofs/Erdos840Problem.lean` has 10 sorry tokens: 8 theorem sorries (open conjectures axiomatized) and 2 definition sorries (`f(N)` and `fAlt(N,δ)` on lines 85, 88). The `axiomCount` was tracking these as axioms but `sorries` was incorrectly left at 0.

```bash
grep -o '\bsorry\b' proofs/Proofs/Erdos840Problem.lean | wc -l
# 10
```

**axiomCount: 9 → 8**

`bounds_gap` was listed as an axiom in `assumptions` but is fully proved by Aristotle (via `rw + norm_num + nlinarith`). The correct count of axiom-equivalent sorried theorems is 8.

**lineCount: 227 → 221**

```bash
wc -l proofs/Proofs/Erdos840Problem.lean
# 221
```

## Assumptions field

Updated to: move `bounds_gap` from axiom list to proven list; clarify the 2 definition sorries; accurate axiom count (8 not 9).

---
Automated fix by lean-mechanic agent.