### PR TITLE
Enrich gallery: fix index.ts patterns and annotation types (batch)

### DIFF
--- a/research/problems/borsuk-ulam-oq-04-oq-03/knowledge.md
+++ b/research/problems/borsuk-ulam-oq-04-oq-03/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: borsuk-ulam-oq-04-oq-03
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/borsuk-ulam-oq-04-oq-03/literature/README.md
+++ b/research/problems/borsuk-ulam-oq-04-oq-03/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for borsuk-ulam-oq-04-oq-03
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/borsuk-ulam-oq-04-oq-03/problem.md
+++ b/research/problems/borsuk-ulam-oq-04-oq-03/problem.md
@@ -1,0 +1,140 @@
+# Problem: ∞-Topos Section Problem via Synthetic HoTT
+
+**Slug**: borsuk-ulam-oq-04-oq-03
+**Created**: 2026-04-21
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+Can the ∞-topos section problem — the non-existence of sections of the universal $\mathbb{Z}/2$-bundle over $B\mathbb{Z}/2$ — be formalized in Lean using a synthetic homotopy type theory approach?
+
+Concretely: prove in Lean/Mathlib that there is no continuous (or homotopy-coherent) section
+$$
+s : B\mathbb{Z}/2 \to E\mathbb{Z}/2
+$$
+of the principal $\mathbb{Z}/2$-bundle $E\mathbb{Z}/2 \to B\mathbb{Z}/2$, where $E\mathbb{Z}/2 \simeq *$ (the universal cover is contractible).
+
+Equivalently: prove that the fibration $S^0 \to * \to B\mathbb{Z}/2$ has no section, which is the abstract form of the covering space obstruction used in the Borsuk-Ulam proof.
+
+### Plain Language
+
+The Borsuk-Ulam theorem relies on a covering space argument: odd maps $S^n \to S^n$ have odd degree, which comes from the fact that the double cover $S^n \to \mathbb{R}P^n$ has no section. In higher categorical language, this says: the universal $\mathbb{Z}/2$-bundle (which classifies double covers) has a contractible total space — so any section would be a splitting, implying the base $B\mathbb{Z}/2 = \mathbb{R}P^\infty$ is also contractible. But $\pi_1(B\mathbb{Z}/2) = \mathbb{Z}/2 \neq 0$, contradiction.
+
+The goal is to formalize this non-existence result in Lean, either:
+- Using Lean 4 + Mathlib's existing topological tools (covering spaces, fundamental groups)
+- Using a synthetic/HoTT approach (univalence, higher inductive types)
+- Or using the existing `CoveringType` abstraction from `borsuk-ulam-oq-04`
+
+### Why This Matters
+
+1. **Completes the Borsuk-Ulam axiom**: The main sorry in `borsuk-ulam` is `no_continuous_odd_nonzero_on_sphere`. This problem attacks the underlying covering space obstruction in its most abstract form.
+2. **Bridges HoTT and classical topology**: Formalizing this in Lean would demonstrate that synthetic homotopy type theory can recover classical obstructions.
+3. **Foundation for higher results**: The ∞-topos version generalizes to $\mathbb{Z}/p$-bundles and equivariant homotopy theory (Hill-Hopkins-Ravenel norms).
+4. **Gallery coherence**: The `CoveringType` abstraction in `borsuk-ulam-oq-04` was specifically designed to support this generalization.
+
+## Known Results
+
+### What's Already Proven (in gallery)
+
+- `borsuk-ulam`: Borsuk-Ulam theorem (with axiom `no_continuous_odd_nonzero_on_sphere`)
+- `borsuk-ulam-oq-04`: Higher Categorical Analogues of the Covering Space Argument — `CoveringType` abstraction formalized, descent proved without sorries
+- `borsuk-ulam-oq-03-oq-04`: Related (active claim — likely ∞-groupoid structure)
+- `borsuk-ulam-oq-02-oq-01-oq-01`, `oq-04`: Various Borsuk-Ulam extensions
+
+### What's Still Open
+
+- Full proof that $\pi_1(\mathbb{R}P^n) \cong \mathbb{Z}/2\mathbb{Z}$ in Mathlib
+- Lifting criterion for covering spaces (needed for classical approach)
+- Synthetic proof that $B\mathbb{Z}/2$ has non-trivial $\pi_1$ (HoTT approach)
+- Non-existence of sections over $B\mathbb{Z}/2$
+
+### Our Goal
+
+Formalize in Lean (using Mathlib or synthetic HoTT) that the universal $\mathbb{Z}/2$-bundle over $B\mathbb{Z}/2$ admits no section. The proof strategy should either:
+1. Use `CoveringType` from `borsuk-ulam-oq-04` as foundation, or
+2. Directly use `EvenCovering` or `OddDegree` infrastructure if available in Mathlib
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `borsuk-ulam` | Parent theorem, has `no_continuous_odd_nonzero_on_sphere` axiom | Covering space argument |
+| `borsuk-ulam-oq-04` | Defines `CoveringType`, proves descent algebraically | Higher categorical descent |
+| `borsuk-ulam-oq-02-oq-01-oq-04` | Covers $\pi_1$ aspects | Fundamental group |
+| `borsuk-ulam-oq-03-oq-04` | Potentially related ∞-groupoid work | Higher homotopy groups |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **`CoveringType` approach**: Extend the `CoveringType` structure from `borsuk-ulam-oq-04` to show that a section of the universal bundle would imply a retraction of the total space onto the base, contradicting contractibility of $E\mathbb{Z}/2$.
+   - Why it might work: `CoveringType` already captures the essential categorical structure; the no-section result follows abstractly.
+   - Risk: The contractibility of $E\mathbb{Z}/2$ may require additional Mathlib lemmas.
+
+2. **Fundamental group approach**: Prove $\pi_1(B\mathbb{Z}/2) = \mathbb{Z}/2$ using Lean 4 / Mathlib, then show a section would force $\pi_1$ to be trivial (via retraction).
+   - Why it might work: The long exact sequence of a fibration gives the obstruction directly.
+   - Risk: Mathlib's $\pi_1$ infrastructure may be incomplete for this.
+
+3. **Synthetic HoTT approach**: In Lean 4 with HoTT-style reasoning, $B\mathbb{Z}/2$ is the delooping of $\mathbb{Z}/2$; a section of the universal bundle would be a splitting of the defining fiber sequence.
+   - Why it might work: Clean, avoids point-set topology.
+   - Risk: Lean 4 is not a native HoTT prover; would need careful encoding.
+
+### Key Difficulties
+
+- $E\mathbb{Z}/2 = S^\infty$ is not directly in Mathlib
+- The classifying space $B\mathbb{Z}/2 = \mathbb{R}P^\infty$ requires colimit constructions
+- The long exact sequence of a fibration may need custom infrastructure
+
+### What Would a Proof Need?
+
+- `CoveringType.noSection` (to be proved): if total space is contractible, no section exists
+- Or: `Pi1_BZ2 : π₁(BZ2) ≅ ZMod 2` (fundamental group computation)
+- Or: a `sorry`-carrying formalization that identifies exactly where Mathlib support is lacking
+
+## Tractability Assessment
+
+**Difficulty**: Medium–High
+
+**Justification**:
+- The algebraic/categorical argument is clean and well-understood
+- Mathlib's covering space and fundamental group API is partially in place
+- The `CoveringType` abstraction from `borsuk-ulam-oq-04` provides a direct entry point
+- Risk: may need `axiom`-carrying formalization if $\pi_1(B\mathbb{Z}/2)$ is not yet in Mathlib
+
+**Estimated Effort**:
+- Exploration: 1–2 days (survey Mathlib + `CoveringType` API)
+- If tractable via `CoveringType`: 3–5 days
+- If requires new $\pi_1$ infrastructure: weeks (likely `axiomatized` result)
+
+## References
+
+### Papers
+- Lurie, *Higher Topos Theory* (2009) — ∞-topos framework, classifying spaces
+- Shulman, *All (∞,1)-toposes have strict univalent universes* — synthetic approach
+- Buchholtz, van Doorn, Rijke, *Higher Groups in HoTT* — $B\mathbb{Z}/2$ in HoTT
+
+### Mathlib
+- `Mathlib.AlgebraicTopology.FundamentalGroupoid` — fundamental groupoid
+- `Mathlib.Topology.CoveringSpace` — covering spaces
+- `Mathlib.Topology.Homotopy.Basic` — homotopy infrastructure
+
+## Metadata
+
+```yaml
+tags:
+  - topology
+  - homotopy-theory
+  - hott
+  - covering-spaces
+  - borsuk-ulam
+related_proofs:
+  - borsuk-ulam
+  - borsuk-ulam-oq-04
+  - borsuk-ulam-oq-02-oq-01-oq-04
+difficulty: medium-high
+source: gallery-gap
+created: 2026-04-21
+```

--- a/research/problems/borsuk-ulam-oq-04-oq-03/state.md
+++ b/research/problems/borsuk-ulam-oq-04-oq-03/state.md
@@ -1,0 +1,25 @@
+# Research State: borsuk-ulam-oq-04-oq-03
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-04-21T18:43:08+02:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/registry.json
+++ b/research/registry.json
@@ -16523,11 +16523,11 @@
     },
     {
       "slug": "borsuk-ulam-oq-04-oq-03",
-      "phase": "NEW",
+      "phase": "OBSERVE",
       "path": "full",
       "started": "2026-04-14T17:49:44.227Z",
       "status": "active",
-      "lastUpdate": "2026-04-14T17:49:44.227Z"
+      "lastUpdate": "2026-04-21T18:43:08+02:00"
     },
     {
       "slug": "bounded-prime-gaps-oq-03-oq-03",
@@ -16576,11 +16576,12 @@
     },
     {
       "slug": "central-limit-theorem-oq-03-oq-02",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-04-14T17:49:44.228Z",
-      "status": "active",
-      "lastUpdate": "2026-04-21T12:34:15.786Z"
+      "status": "graduated",
+      "lastUpdate": "2026-04-21T16:43:02.237Z",
+      "completed": "2026-04-21T16:43:02.236Z"
     },
     {
       "slug": "chinese-remainder-constructive-oq-04-oq-03-oq-01",
@@ -16857,11 +16858,12 @@
     },
     {
       "slug": "ramseys-theorem-oq-02",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-04-21T15:44:50.655Z",
-      "status": "active",
-      "lastUpdate": "2026-04-21T15:44:50.677Z"
+      "status": "graduated",
+      "lastUpdate": "2026-04-21T16:43:02.238Z",
+      "completed": "2026-04-21T16:43:02.238Z"
     },
     {
       "slug": "lovasz-local-lemma-oq-02-incomplete-01",

--- a/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01-oq-01/meta.json
@@ -59,11 +59,20 @@
       "summary": "Proves `extWeightedPowerMean_monotone`: for all r ≤ t (no sign restriction), M_r ≤ M_t. Four-case proof via `rcases eq_or_ne r 0` and `rcases eq_or_ne t 0`: (r=t=0) both sides equal GM, trivial; (r=0, t≠0) t > 0 from arithmetic, delegates to `geom_mean_le_power_mean_pos`; (r≠0, t=0) r < 0 from arithmetic, delegates to `power_mean_le_geom_mean_neg`; (r≠0, t≠0) delegates to `power_mean_monotone_all` from the parent."
     },
     {
-      "id": "corollaries",
-      "title": "Corollaries: HM-GM-AM Chain and Monotone Family",
+      "id": "corollary-hm-gm-am",
+      "title": "Corollary: HM ≤ GM ≤ AM Chain",
       "startLine": 105,
+      "endLine": 129,
+      "summary": "Proves `hm_le_gm_le_am`: both HM ≤ GM and GM ≤ AM from the unified monotonicity theorem by instantiating at r = -1, 0 and r = 0, 1 respectively. Uses `norm_num` to prove -1 ≤ 0 ≤ 1, then rewrites via `extWeightedPowerMean_zero` and `extWeightedPowerMean_of_ne_zero` to recover standard mean expressions.",
+      "mathContext": "The classical chain $\\mathrm{HM} \\le \\mathrm{GM} \\le \\mathrm{AM}$ becomes a two-line proof: apply `extWeightedPowerMean_monotone` at $(-1, 0)$ for HM ≤ GM (using `M_{-1} = $ HM and `M_0 = $ GM), then at $(0, 1)$ for GM ≤ AM (using `M_1 = $ AM). The simp lemmas `extWeightedPowerMean_zero` and `extWeightedPowerMean_of_ne_zero` handle the boundary cases $r = 0$ vs $r \\ne 0$."
+    },
+    {
+      "id": "corollary-monotone",
+      "title": "Corollary: Monotone Function in Mathlib's Order Library",
+      "startLine": 130,
       "endLine": 138,
-      "summary": "Two corollaries: `hm_le_gm_le_am` derives HM ≤ GM ≤ AM by instantiating unified monotonicity at r = -1, 0, 1 using `norm_num` to prove -1 ≤ 0 ≤ 1, then rewrites via `extWeightedPowerMean_zero` and `extWeightedPowerMean_of_ne_zero` to recover the standard mean expressions. `extWeightedPowerMean_monotone_fun` wraps the pointwise inequality into Mathlib's `Monotone` typeclass, enabling use with `mono` tactic and `Monotone.comp`."
+      "summary": "Proves `extWeightedPowerMean_monotone_fun`: the map r ↦ extWeightedPowerMean(s, w, z)(r) is `Monotone` in Mathlib's sense. One-line proof wrapping `extWeightedPowerMean_monotone`. Enables use with the `mono` tactic and `Monotone.comp` for chaining monotone functions.",
+      "mathContext": "Mathlib's `Monotone f` is `∀ a ≤ b, f a ≤ f b`. Here $f = \\lambda r, M_r(z, w)$ for fixed $(z, w)$. The wrapper `fun _ _ hrt => extWeightedPowerMean_monotone ... hrt` converts the pointwise statement into the `Monotone` typeclass. This enables the power mean family to participate in Lean's monotonicity framework (e.g., `Monotone.comp_antitone`, `OrderIso`, composition lemmas)."
     }
   ],
   "overview": {

--- a/src/data/proofs/amgm-inequality-oq-03-oq-04/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-04/annotations.json
@@ -10,7 +10,7 @@
     "title": "Overview: Rényi Entropy and Power Means Are the Same",
     "content": "The header explains the central insight: the weighted power mean M_r(p,p) (with a probability distribution serving as both weights and values) is increasing in r if and only if Rényi entropy H_α(p) is decreasing in α. These are not separate facts — they are the same statement in different notation, connected by the identity H_α(p) = −log(M_{α−1}(p,p)).\n\nThe mathematical proof of the identity is laid out explicitly: M_{α-1}(p,p) = (Σ pᵢ·pᵢ^(α-1))^(1/(α-1)) = (Σ pᵢ^α)^(1/(α-1)), so log(M_{α-1}) = (1/(α-1))·log(Σ pᵢ^α), and negating gives H_α = −log(M_{α-1}).",
     "mathContext": "$H_\\alpha(p) = \\frac{1}{1-\\alpha}\\log\\sum_i p_i^\\alpha$; $M_r(p,p) = \\left(\\sum_i p_i \\cdot p_i^r\\right)^{1/r}$; identity: $H_\\alpha(p) = -\\log M_{\\alpha-1}(p,p)$",
-    "significance": "main",
+    "significance": "key",
     "relatedConcepts": [
       "Rényi entropy",
       "power means",
@@ -55,7 +55,7 @@
     "title": "Key Algebraic Identity: Σ pᵢ·pᵢ^(α-1) = Σ pᵢ^α",
     "content": "The private lemma `mul_rpow_pred` proves x·x^(α-1) = x^α for x > 0 by rewriting x = x^1 and applying `Real.rpow_add` to get x^1 · x^(α-1) = x^(1+(α-1)) = x^α.\n\nThe theorem `renyi_sum_eq_powerMean_sum` lifts this pointwise identity to Finset sums via `Finset.sum_congr`. This is the algebraic bridge between the selfPowerMean sum (Σ pᵢ·pᵢ^(α-1)) and the renyiEntropy sum (Σ pᵢ^α).",
     "mathContext": "$x \\cdot x^{\\alpha-1} = x^{1+(\\alpha-1)} = x^\\alpha$ by `Real.rpow_add` (valid for $x > 0$). This requires positivity — the identity fails for $x = 0$ when $\\alpha - 1 < 0$.",
-    "significance": "main",
+    "significance": "key",
     "relatedConcepts": [
       "rpow_add",
       "Finset.sum_congr"
@@ -76,7 +76,7 @@
     "title": "Main Identity: H_α(p) = −log(M_{α−1}(p,p))",
     "content": "The proof of `renyi_eq_neg_log_powerMean` has three steps:\n\n1. Replace Σ pᵢ·pᵢ^(α-1) with Σ pᵢ^α using `renyi_sum_eq_powerMean_sum`.\n2. Apply `Real.log_rpow` to get log((Σ pᵢ^α)^(1/(α-1))) = (1/(α-1))·log(Σ pᵢ^α). This requires positivity of the sum, which we get from `renyi_sum_pos`.\n3. Simplify the arithmetic: (1/(1-α))·L = −(1/(α-1))·L, which `field_simp` + `ring` handles.\n\nThe result is that unfolding definitions and applying these three steps closes the goal.",
     "mathContext": "$\\log M_{\\alpha-1}(p,p) = \\log\\left((\\sum p_i^\\alpha)^{1/(\\alpha-1)}\\right) = \\frac{1}{\\alpha-1}\\log\\sum p_i^\\alpha = -\\frac{1}{1-\\alpha}\\log\\sum p_i^\\alpha = -H_\\alpha(p)$",
-    "significance": "main",
+    "significance": "key",
     "relatedConcepts": [
       "Real.log_rpow",
       "field_simp",
@@ -98,7 +98,7 @@
     "title": "Biconditional Equivalence of Monotonicity",
     "content": "Three theorems establish the biconditional:\n\n`renyi_decreasing_of_powerMean_increasing` (M→H): Assume M_r ≤ M_s for r ≤ s. For α ≤ β, apply M_{α-1} ≤ M_{β-1}, take logs (log is monotone), negate (neg_le_neg). Combined with the identity, H_β ≤ H_α.\n\n`powerMean_increasing_of_renyi_decreasing` (H→M): Assume H_α ≤ H_β for α ≤ β. Set α = r+1, β = t+1. The hypothesis gives H_{t+1} ≤ H_{r+1}, i.e., −log(M_t) ≤ −log(M_r). Flip to log(M_r) ≤ log(M_t). Use exp/log round-trip (exp_log, exp_le_exp) to conclude M_r ≤ M_t.\n\n`renyi_monotone_iff_powerMean_monotone`: The biconditional packages both directions.",
     "mathContext": "The exp/log round-trip: $M_r = \\exp(\\log M_r) \\leq \\exp(\\log M_t) = M_t$ since exp is monotone. This uses `Real.exp_log` (requiring positivity) and `Real.exp_le_exp`.",
-    "significance": "main",
+    "significance": "key",
     "relatedConcepts": [
       "neg_le_neg",
       "Real.log_le_log",

--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-01/meta.json
@@ -46,7 +46,8 @@
       "The `CyclicCubicData` structure is the key original contribution of this file: it bundles an irreducibility proof, a degree fact, and a Galois order divisibility fact into a single type, allowing parameterized theorems to be stated and proved uniformly for p ∈ {3, 7} without case-splitting at every call site.",
       "All hard mathematical content — Eisenstein criterion, Gauss's lemma, Galois group cardinality — lives in the parent proofs. This file contributes only the parameterized abstraction layer and the `ring`-verified identity `eisensteinCubic(p).comp(2X + C shift) = trisectionPoly(p)`, confirming the two polynomial families are related by a uniform linear substitution.",
       "The Galois group bound follows automatically: irreducible polynomials of prime degree over ℚ have the prime dividing |Gal| (Polynomial.Gal.prime_degree_dvd_card). For degree 3, this gives 3 | |Gal| in both cases, delegated to the parent results.",
-      "The Wantzel connection: an angle θ is constructible iff $\\cos θ$ is constructible, which requires its minimal polynomial to have degree a power of 2. Since both $\\cos(20°)$ and $\\cos(π/7)$ have irreducible degree-3 minimal polynomials (this file's core result), neither is constructible — 60° cannot be trisected and π/7 radians cannot be trisected."
+      "The Wantzel connection: an angle θ is constructible iff $\\cos θ$ is constructible, which requires its minimal polynomial to have degree a power of 2. Since both $\\cos(20°)$ and $\\cos(π/7)$ have irreducible degree-3 minimal polynomials (this file's core result), neither is constructible — 60° cannot be trisected and π/7 radians cannot be trisected.",
+      "The Eisenstein-shift pattern (X ↦ 2X + shift) generalizes to the full family of angles 2π/p for primes p ≡ 1 (mod 3): the minimal polynomial of $\\cos(2\\pi/p)$ has degree $(p-1)/2$ and is related by a linear substitution to an Eisenstein polynomial at $p$. This file's unification at p ∈ {3, 7} is the degree-3 base case of a general family, suggesting that `CyclicCubicData` instances extend to $\\cos(2\\pi/p)$ for all $p \\equiv 1 \\pmod{3}$."
     ],
     "prerequisites": [
       "angle-trisection-cos-20-gal: Galois group of 8X³−6X−1 (cos(20°) case)",
@@ -62,7 +63,8 @@
       "title": "Module Documentation: Unified Galois Group Problem",
       "startLine": 1,
       "endLine": 44,
-      "summary": "Module docstring framing the unification question: can the cos(20°) and cos(π/7) Galois group results be unified into a single theorem parameterized by Eisenstein prime p? The answer is YES. A table records the two cases (p=3: 8X³−6X−1, p=7: 8X³−4X²−4X+1) and their shared algebraic pattern. Lists the four main unified theorems and imports from the parent files AngleTrisectionCos20Gal and AngleTrisectionCos20GalOQ01."
+      "summary": "Module docstring framing the unification question: can the cos(20°) and cos(π/7) Galois group results be unified into a single theorem parameterized by Eisenstein prime p? The answer is YES. A table records the two cases (p=3: 8X³−6X−1, p=7: 8X³−4X²−4X+1) and their shared algebraic pattern. Lists the four main unified theorems and imports from the parent files AngleTrisectionCos20Gal and AngleTrisectionCos20GalOQ01.",
+      "mathContext": "Both minimal polynomials arise from Eisenstein cubics via the substitution $X \\mapsto 2X + \\text{shift}$: $r_3(2X+1) = 8X^3-6X-1$ and $r_7(2X+2) = 8X^3-4X^2-4X+1$, where $r_p(X) = X^3 - pX^2 + p(p-1)/2 \\cdot X - (p-1)(p-2)/6$ is Eisenstein at $p$. The imports `Proofs.AngleTrisectionCos20Gal` and `Proofs.AngleTrisectionCos20GalOQ01` provide the concrete Galois computations; this file adds only the parameterized abstraction layer."
     },
     {
       "id": "parameterized-defs",

--- a/src/data/proofs/chebyshev-pnt-bridge/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge/meta.json
@@ -66,12 +66,20 @@
       "mathContext": "Key imports: `Mathlib.NumberTheory.Primorial` (primorial(n) = ∏_{p≤n} p, with the bound primorial(n) ≤ 4^n), `Mathlib.Data.Nat.Choose.Central` (central binomial C(2n,n)), `Mathlib.Data.Nat.Choose.Factorization` (p-adic valuations of C(2n,n)), `Mathlib.NumberTheory.PrimeCounting` (π(x) = primeCounting x)."
     },
     {
-      "id": "sec-bridge-upper",
-      "title": "Upper Bound via Primorial",
+      "id": "sec-bridge-upper-defs",
+      "title": "Part I: Definitions and Primorial Divisibility",
       "startLine": 33,
+      "endLine": 89,
+      "summary": "Defines numPrimesAbove (count of primes in (m,n]) and prodPrimesAbove (product of primes in (m,n]). Proves numPrimesAbove_eq (relates to primeCounting), prime_in_range_dvd_primorial (each prime p in (m,n] divides primorial(n)), and prodPrimesAbove_dvd_primorial (the product of all such primes divides primorial(n) via Finset.prod_primes_dvd).",
+      "mathContext": "$\\prod_{p \text{ prime}, m < p \\leq n} p \\mid n\\#$ where \\# = \text{primorial}(n)$. Each prime $ in the range divides \\#$ since it appears as one of the factors."
+    },
+    {
+      "id": "sec-bridge-upper-bound",
+      "title": "Part I: Main Upper Bound via Primorial",
+      "startLine": 90,
       "endLine": 140,
-      "summary": "Defines numPrimesAbove and prodPrimesAbove for counting/multiplying primes in intervals. Proves the product of primes in (√n, n] divides primorial(n). Main result: (√n)^{π(n)-π(√n)} ≤ 4^n.",
-      "mathContext": "The key chain: primes p ∈ (√n, n] satisfy p > √n, so ∏_{p ∈ (√n,n]} p ≥ (√n)^{π(n)-π(√n)}. This product divides primorial(n) ≤ 4^n (Mathlib's `Nat.primorial_le_pow`). The helper `numPrimesAbove m n` counts primes in (m,n] as `primeCounting n - primeCounting m`."
+      "summary": "Proves pow_sqrt_primeCounting_le: (√n)^{π(n)-π(√n)} ≤ 4^n. Primes in (√n, n] each exceed √n, so their product ≥ (√n)^k where k = π(n)-π(√n). Since this product divides n# ≤ 4^n, the bound follows. Then upper_bound_from_primorial concludes π(n) ≤ 2·n·log 4 / log n + √n, the key upper bound.",
+      "mathContext": "$\\pi(n) - \\pi(\\sqrt{n}) \\leq \frac{n \\log 4}{\\log \\sqrt{n}} = \frac{2n\\log 4}{\\log n}$, so $\\pi(n) \\leq \frac{2n\\log 4}{\\log n} + \\sqrt{n} \\sim \frac{2\\log 4 \\cdot n}{\\log n}$ as  \to \\infty$."
     },
     {
       "id": "sec-bridge-factorization",

--- a/src/data/proofs/erdos-100-oq-02-oq-02/meta.json
+++ b/src/data/proofs/erdos-100-oq-02-oq-02/meta.json
@@ -58,12 +58,20 @@
       "summary": "Documents the open question (Is Kanold's bound provable from Guth-Katz?) and its affirmative answer. Imports Erdos100Problem which provides the Guth-Katz axiom, diam_ge_n_over_log_n bridge theorem, and integer distance set definitions."
     },
     {
-      "id": "key-lemma",
-      "title": "Key Lemma: log n ≤ 4·n^{1/4}",
+      "id": "key-lemma-docs",
+      "title": "Key Lemma: Documentation and Theorem Statement",
       "startLine": 24,
+      "endLine": 43,
+      "summary": "Module comment documenting the two-step log bound strategy, Lean docstring for log_le_four_rpow_quarter, theorem statement, and the two positivity/monotonicity prerequisites: hn_pos (n > 0 as a real) and hq_ge1 (n^{1/4} ≥ 1). These are needed for all subsequent log and rpow lemmas.",
+      "mathContext": "The theorem $\\log n \\le 4 \\cdot n^{1/4}$ for $n \\ge 1$ is proved by factoring through the fourth root: $\\log n = 4\\log(n^{1/4})$ and $\\log(n^{1/4}) \\le n^{1/4}$. Prerequisites: `one_le_rpow` gives $n^{1/4} \\ge 1$ since $n \\ge 1$ and $1/4 \\ge 0$; `Nat.cast_pos.mpr` casts $n \\ge 1$ to $(n : \\mathbb{R}) > 0$."
+    },
+    {
+      "id": "key-lemma-proof",
+      "title": "Key Lemma: Log Power Rule and Elementary Bound",
+      "startLine": 44,
       "endLine": 51,
-      "summary": "Proves log_le_four_rpow_quarter: for n ≥ 1, log n ≤ 4·n^{1/4}. Uses the decomposition log n = 4·log(n^{1/4}) via Real.log_rpow, and log(n^{1/4}) ≤ n^{1/4} from the elementary bound log x ≤ x - 1 (Real.log_le_sub_one_of_pos).",
-      "mathContext": "The bound log x ≤ x - 1 holds for all x > 0 and is tight at x = 1. Applied to x = n^{1/4} ≥ 1, it gives log(n^{1/4}) ≤ n^{1/4} - 1 ≤ n^{1/4}. Since log n = 4·log(n^{1/4}) by the logarithm power rule, we get log n ≤ 4·n^{1/4}. This bound is not tight (n^{1/4} grows much faster than log n) but suffices for the asymptotic comparison."
+      "summary": "Proves hlog_eq (log(n^{1/4}) = (1/4)·log n via Real.log_rpow) and hlog_le (log(n^{1/4}) ≤ n^{1/4} via log x ≤ x−1). Closes with linarith combining log n = 4·log(n^{1/4}) ≤ 4·n^{1/4}.",
+      "mathContext": "The elementary bound $\\log x \\le x - 1$ holds for all $x > 0$ (from concavity of $\\log$, with equality at $x = 1$). Applied to $x = n^{1/4} \\ge 1$: $\\log(n^{1/4}) \\le n^{1/4} - 1 \\le n^{1/4}$. Combined with `log_rpow`: $\\log n = 4 \\log(n^{1/4}) \\le 4 n^{1/4}$. The `linarith` call closes the goal from these two have-bounds."
     },
     {
       "id": "main-theorem-setup",

--- a/src/data/proofs/erdos-1205/annotations.json
+++ b/src/data/proofs/erdos-1205/annotations.json
@@ -107,7 +107,7 @@
     "title": "Main Theorem: erdos_1205 (F(x) = Θ(log x))",
     "content": "The main theorem `erdos_1205` bundles both bounds into a single conjunction: the lower bound ∃ c > 0 and the upper bound ∃ C > 0, establishing F(x) = Θ(log x). The proof is a one-line pair introduction: `⟨fx_lower_bound, fx_upper_bound⟩`.\n\nThis confirms that the optimal multi-coverage grows logarithmically — neither faster (bounded by the average) nor slower (the probabilistic method guarantees at least Ω(log x)). The `#check` lines confirm `harmonicSum`, `coverageCount`, and `erdos_1205` are well-typed and accessible.",
     "mathContext": "Statement: $(\\exists c > 0, \\forall x \\ge 2, \\exists a, \\forall m \\le x: C_a(m) \\ge c\\ln x) \\wedge (\\exists C > 0, \\forall x \\ge 2, \\forall a, \\exists m \\le x: C_a(m) \\le C\\ln x)$. The conjunction of `fx_lower_bound` and `fx_upper_bound` gives $F(x) = \\Theta(\\log x)$.",
-    "significance": "critical",
+    "significance": "key",
     "relatedConcepts": [
       "Real.log in Mathlib",
       "Finset quantifiers",

--- a/src/data/proofs/erdos-1205/meta.json
+++ b/src/data/proofs/erdos-1205/meta.json
@@ -69,28 +69,48 @@
       "title": "Problem Header: F(x) = Θ(log x)",
       "startLine": 1,
       "endLine": 17,
-      "summary": "Documents the problem and its answer F(x) = Θ(log x), sketching the upper bound (averaging) and lower bound (probabilistic method)."
+      "summary": "Module docstring documenting Problem #1205, its answer F(x) = Θ(log x), and the two main tools: averaging (upper bound) and probabilistic method (lower bound).",
+      "mathContext": "Let $F(x) = \\max_a \\min_{m \\le x} C_a(m)$, where $C_a(m) = |\\{n \\le x : m \\equiv a_n \\pmod{n}\\}|$. The answer $F(x) = \\Theta(\\log x)$ follows because $\\sum_{n \\le x} 1/n \\sim \\ln x$: the harmonic series controls both the average coverage (upper bound) and achievable minimum coverage (lower bound by probabilistic existence)."
     },
     {
       "id": "coverage-def",
       "title": "Definitions: CoveringAssignment and coverageCount",
       "startLine": 19,
       "endLine": 42,
-      "summary": "Defines CoveringAssignment (map from moduli to residues), coverageCount (number of moduli n ≤ x covering m), and harmonicSum (∑ 1/n, the theoretical maximum)."
+      "summary": "Defines CoveringAssignment (Fin x → Fin n.succ, mapping each modulus to a residue class) and coverageCount (counts moduli n ≤ x covering m, via Finset.filter). Also contains the F(x) docstring explaining the maximum guaranteed multi-coverage concept.",
+      "mathContext": "`CoveringAssignment x` is the dependent product $\\prod_{n < x} (\\mathbb{Z}/n\\mathbb{Z})$, using `Fin n.val.succ` to represent $\\{0,\\ldots,n-1\\}$. The `coverageCount x m a` function counts the cardinality of $\\{n \\le x : m \\equiv a(n) \\pmod{n}\\}$ via `Finset.univ.filter`."
     },
     {
-      "id": "axioms",
-      "title": "Known Bounds (Axiomatized)",
+      "id": "harmonic-sum",
+      "title": "Harmonic Sum: Theoretical Maximum Coverage",
       "startLine": 44,
+      "endLine": 46,
+      "summary": "Defines harmonicSum(x) = ∑_{n<x} 1/(n+1) as a noncomputable real-valued function. This is the theoretical maximum average coverage per integer under any covering assignment.",
+      "mathContext": "The harmonic sum $H(x) = \\sum_{n=1}^{x} 1/n \\sim \\ln x + \\gamma$ (Euler–Mascheroni constant $\\gamma \\approx 0.5772$). For any covering assignment $a$, the expected coverage of a random $m$ equals $\\sum_{n \\le x} \\Pr[m \\equiv a_n \\pmod{n}] = \\sum_{n \\le x} 1/n = H(x)$, bounding $F(x) \\le H(x) \\approx \\ln x$."
+    },
+    {
+      "id": "axiom-upper",
+      "title": "Upper Bound Axiom: F(x) ≤ C·ln(x)",
+      "startLine": 47,
+      "endLine": 61,
+      "summary": "Axiomatizes fx_upper_bound: there exists C > 0 such that for all x ≥ 2 and all covering assignments, some m ≤ x has coverage ≤ C·log(x). The proof sketch invokes the averaging argument: total coverage ∑_m C_a(m) = ∑_n ⌊x/n⌋ ≈ x·ln(x), so the minimum cannot exceed the average ≈ ln(x).",
+      "mathContext": "For any assignment $a$: $\\sum_{m=1}^{x} C_a(m) = \\sum_{n=1}^{x} |\\{m \\le x : n \\mid m - a_n\\}| = \\sum_{n=1}^{x} \\lfloor x/n \\rfloor \\approx x \\ln x$. Dividing by $x$: the average coverage per $m$ is $\\approx \\ln x$. Hence $\\min_m C_a(m) \\le \\text{avg} \\le C \\ln x$."
+    },
+    {
+      "id": "axiom-lower",
+      "title": "Lower Bound Axiom: F(x) ≥ c·ln(x)",
+      "startLine": 62,
       "endLine": 70,
-      "summary": "Axiomatizes fx_upper_bound (averaging: F(x) ≤ C·ln(x)) and fx_lower_bound (probabilistic method: F(x) ≥ c·ln(x)), each with proof sketches."
+      "summary": "Axiomatizes fx_lower_bound: there exists c > 0 such that for all x ≥ 2, some covering assignment achieves coverage ≥ c·log(x) for every m ≤ x. The proof sketch uses the probabilistic method: random assignment gives E[C(m)] = H(x) ≈ ln(x), and Chernoff/LLL concentration ensures the minimum is also Ω(ln x).",
+      "mathContext": "Random assignment (each $a_n$ uniform on $\\{0,\\ldots,n-1\\}$): $E[C(m)] = \\sum_{n \\le x} 1/n = H(x) \\approx \\ln x$. The Lovász Local Lemma or Chernoff bound shows $\\Pr[\\min_m C(m) < c\\ln x] < 1$, proving existence of a good assignment. This requires concentration inequalities for sums of independent Bernoulli variables — not yet in Mathlib."
     },
     {
       "id": "main-theorem",
       "title": "Main Theorem: erdos_1205",
       "startLine": 72,
       "endLine": 87,
-      "summary": "Derives the Θ(log x) result as a conjunction of the two axioms. The full statement bundles both bounds into one theorem."
+      "summary": "The main theorem erdos_1205 packages both bounds as a conjunction: (∃ c > 0, eventually F(x) ≥ c·log x) ∧ (∃ C > 0, eventually F(x) ≤ C·log x). The proof is just ⟨fx_lower_bound, fx_upper_bound⟩, delegating to the two axioms.",
+      "mathContext": "The theorem statement encodes $F(x) = \\Theta(\\log x)$ as a conjunction of existential bounds. The `#check` statements at the end confirm the types of `erdos_1205`, `harmonicSum`, and `coverageCount`, serving as a type-correctness sanity check."
     }
   ],
   "conclusion": {
@@ -102,5 +122,17 @@
       "How does $F(x)$ behave when restricted to prime moduli $n$ (i.e., $n \\le x$ and $n$ prime)?"
     ]
   },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1",
+      "relationship": "related",
+      "description": "Erdős's covering system problem (Problem #1): does a finite covering system of distinct moduli exist? This multi-covering problem extends the question to maximizing simultaneous coverage."
+    },
+    {
+      "targetId": "bertrands-postulate-oq-03-oq-04-oq-03",
+      "relationship": "related",
+      "description": "Both entries use the harmonic series ∑ 1/n ≈ ln(x) as a key asymptotic; this entry uses it to bound F(x) while the PNT density entry uses it to control interval prime counts."
+    }
+  ],
   "sorries": 0
 }

--- a/src/data/proofs/erdos-1213/meta.json
+++ b/src/data/proofs/erdos-1213/meta.json
@@ -36,25 +36,44 @@
   },
   "sections": [
     {
-      "id": "header-comment",
-      "title": "Problem Statement and Background",
+      "id": "problem-header",
+      "title": "Problem Identification and Status",
       "startLine": 1,
+      "endLine": 7,
+      "summary": "Module comment header identifying Erdős Problem #1213, its source (erdosproblems.com/1213), and its status as SOLVED (existence of f(a,K) confirmed by Hegyvári 1986, though the optimal growth rate in K remains open).",
+      "mathContext": "The problem concerns sequences $a_1 < a_2 < \\cdots < a_n$ with $a_1 = a \\ge 1$ and bounded gaps $a_{i+1} - a_i \\le K$. These are discrete analogs of Lipschitz functions on $\\{1, \\ldots, n\\}$. The 'solved' status means the existence of $f(a,K)$ is established, but the optimal $f(a,K) \\ll a \\cdot e^{O(K)}$ bound from Hegyvári (1986) is not believed tight."
+    },
+    {
+      "id": "problem-statement",
+      "title": "Mathematical Statement: Equal-Sum Interval Pairs",
+      "startLine": 8,
       "endLine": 14,
-      "summary": "Lean block comment documenting Erdős Problem #1213: the existence of f(a,K) guaranteeing two equal-sum intervals in bounded-gap sequences. Records Hegyvári's 1986 result f(a,K) ≪ a·e^{O(K)} and the open question of whether the exponential in K is optimal."
+      "summary": "Documents the full problem: for n > f(a,K) with a₁=a, gaps ≤ K, there exist two distinct index-intervals I and J with ∑_{i∈I} aᵢ = ∑_{j∈J} aⱼ. Records Hegyvári's explicit bound f(a,K) ≪ a·e^{O(K)} and the open question of improving the exponential.",
+      "mathContext": "The equal-sum condition $\\sum_{i \\in I} a_i = \\sum_{j \\in J} a_j$ for disjoint index intervals $I = [l_1, r_1]$ and $J = [l_2, r_2]$ can be rephrased as: the function $S(l,r) = \\sum_{i=l}^{r} a_i$ is not injective on pairs $(l,r)$ with $l \\le r \\le n$. There are $\\binom{n}{2}$ such pairs; the range of $S$ lies in $[a, n \\cdot (a + Kn)]$. By pigeonhole, if $\\binom{n}{2} > n(a + Kn)$, a collision is guaranteed — giving a bound of order $\\sqrt{aKn}$, looser than Hegyvári's."
     },
     {
       "id": "imports",
       "title": "Mathlib Import",
       "startLine": 16,
       "endLine": 16,
-      "summary": "Imports the full Mathlib library, giving access to `StrictMono`, `Finset.Ico`, `Finset.sum`, and `Finset.exists_ne_map_eq_of_card_lt_of_maps_to` (the finitary pigeonhole lemma)—the key tools needed for a full formalization."
+      "summary": "Imports the full Mathlib library, giving access to `StrictMono`, `Finset.Ico`, `Finset.sum`, and `Finset.exists_ne_map_eq_of_card_lt_of_maps_to` (the finitary pigeonhole lemma) — the key tools for a full formalization.",
+      "mathContext": "Key Mathlib lemmas for the eventual proof: `Finset.exists_ne_map_eq_of_card_lt_of_maps_to` (if f maps a finite set of size > |T| into T, some two map to the same value); `Finset.sum_Ico` (sum over a contiguous range); `StrictMono` (the sequence monotonicity condition); `Nat.lt_of_sub_eq_succ` (for bounded gap conditions)."
     },
     {
       "id": "placeholder-theorem",
-      "title": "Placeholder: Equal Interval Sums Theorem",
+      "title": "Placeholder Theorem: erdos_1213",
       "startLine": 18,
+      "endLine": 20,
+      "summary": "Placeholder `erdos_1213 : True := by sorry`. The actual theorem type should be: ∀ a K : ℕ, ∃ N : ℕ, ∀ f : ℕ → ℕ, StrictMono f → f 0 = a → (∀ i, f (i+1) - f i ≤ K) → N < n → ∃ l₁ r₁ l₂ r₂, (l₁,r₁) ≠ (l₂,r₂) ∧ ∑ i ∈ Ico l₁ r₁, f i = ∑ j ∈ Ico l₂ r₂, f j.",
+      "mathContext": "The formalization challenge: (1) encoding bounded gaps as $\\forall i, f(i+1) - f(i) \\le K$ in `ℕ` (where subtraction is saturating — requires casting to `ℤ` or using `f(i) + K ≥ f(i+1)`); (2) the pigeonhole step needs a bound on the range of `Finset.Ico`-sums, requiring careful `Nat.cast` management; (3) the 'two distinct intervals' condition needs a careful definition of interval equality."
+    },
+    {
+      "id": "check-statement",
+      "title": "Type Check: Theorem Accessibility",
+      "startLine": 22,
       "endLine": 23,
-      "summary": "Placeholder `erdos_1213 : True := by sorry` for the eventual formalization. A Lean proof would define the bounded-gap sequence condition, formalize interval sums over `Finset.Ico`, and prove the equal-interval-sum guarantee for n > f(a,K) via the pigeonhole principle."
+      "summary": "`#check erdos_1213` confirms the theorem is well-typed and accessible in the current namespace. Along with the sorry marker comment, it serves as a tracing point for future proof development.",
+      "mathContext": "The `#check` command in Lean 4 elaborates the term and prints its type without executing it. For a `sorry`-carrying theorem, the type is inferred from the stated return type (`True`). When the formalization is complete, replacing `True` with the actual statement will be validated here."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-1215/meta.json
+++ b/src/data/proofs/erdos-1215/meta.json
@@ -36,11 +36,28 @@
   },
   "sections": [
     {
+      "id": "module-header",
+      "title": "Module Header: Problem Statement and Mac Lane's Resolution",
+      "startLine": 1,
+      "endLine": 14,
+      "summary": "Module comment documenting Erdős Problem #1215, its source (erdosproblems.com/1215), and the negative resolution by Mac Lane (1953): for any simply-connected compact A ⊂ {|z| < 1}, there exists a polynomial P with P(0)=1, all roots on the unit circle, and |P(z)| > 2 on A. Choosing A as a labyrinth block forces arbitrarily long paths.",
+      "mathContext": "The sublevel set $\\{z : |P(z)| < 1\\}$ for $P$ with all roots on the unit circle is a polynomial lemniscate region. Its boundary $\\{|P(z)| = 1\\}$ is a lemniscate curve, which by the theory of algebraic curves can have up to $\\deg(P) - 1$ connected components. Mac Lane's key tool: density of polynomials with unit-circle roots in uniform norm on compact subsets of $\\{|z| < 1\\}$."
+    },
+    {
+      "id": "imports",
+      "title": "Imports",
+      "startLine": 16,
+      "endLine": 17,
+      "summary": "`import Mathlib` — full Mathlib import. The actual formalization would need `Mathlib.Analysis.Complex.Basic` (Complex.abs), `Mathlib.RingTheory.Polynomial.Basic` (Polynomial ℂ), and path topology results not yet in Mathlib.",
+      "mathContext": "Current Mathlib gaps for this formalization: (1) `Path` type for continuous curves in ℂ; (2) path length for curves in $\\mathbb{C}$; (3) polynomial approximation theory on compact sets; (4) lemniscate topology results. These are active areas of Mathlib development."
+    },
+    {
       "id": "placeholder-theorem",
       "title": "Placeholder: Polynomial Lemniscate Path Theorem",
       "startLine": 18,
       "endLine": 23,
-      "summary": "Placeholder `erdos_1215 : True := by sorry`. A Lean formalization would require complex analysis infrastructure: `Polynomial ℂ`, `Complex.abs`, path topology in ℂ, and results on polynomial lemniscates—most of which require significant new Mathlib development."
+      "summary": "Placeholder `erdos_1215 : True := by sorry`. The actual statement would be: there is NO constant C such that for all P with P(0)=1 and unit-circle roots, a path in {|P(z)| < 1} from 0 to ∂{|P|=1} exists with length ≤ C·deg(P). Proven by Mac Lane (1953) via labyrinth polynomial constructions.",
+      "mathContext": "The formal statement requires: `Polynomial ℂ` (polynomials over $\\mathbb{C}$), `Complex.abs` (the modulus), `ContinuousOn` or `Path` (continuous curves), and a notion of arc length $\\int_\\gamma |\\gamma'(t)|\\,dt$. The negation `¬∃ C, ...` would be proved by providing for each $C$ an explicit labyrinth polynomial $P_C$ constructed via Walsh-type approximation from roots on the unit circle."
     }
   ],
   "conclusion": {
@@ -52,5 +69,17 @@
       "Can Lean 4's `Complex.abs` and `Polynomial.eval` infrastructure support even a simple statement of this theorem, or are results about path lengths in level sets too far from current Mathlib?"
     ]
   },
+  "crossReferences": [
+    {
+      "targetId": "angle-trisection-cos-20-gal-oq-03-oq-01",
+      "relationship": "related",
+      "description": "Both involve polynomials with roots on the unit circle: Galois group computations for cyclotomic-type polynomials connect to lemniscate topology of polynomials with unit-circle roots."
+    },
+    {
+      "targetId": "cantor-diagonalization-oq-01-oq-01-oq-02-oq-03",
+      "relationship": "related",
+      "description": "Both represent formalization stubs pending major Mathlib infrastructure: Easton's class forcing and Mac Lane's polynomial lemniscate theory share the challenge of encoding analytic/metamathematical content in Lean 4."
+    }
+  ],
   "sorries": 1
 }

--- a/src/data/proofs/erdos-1216/meta.json
+++ b/src/data/proofs/erdos-1216/meta.json
@@ -36,11 +36,56 @@
   },
   "sections": [
     {
+      "id": "problem-header",
+      "title": "Problem Header: Directed Ramsey Numbers",
+      "startLine": 1,
+      "endLine": 7,
+      "summary": "Module comment header identifying Erdős Problem #1216, source URL, and status (SOLVED — Erdős's question of whether f(n) = ⌊log₂ n⌋+1 answered NO by Reid-Parker 1970).",
+      "mathContext": "A tournament $T$ on $n$ vertices is a complete directed graph: for every pair $\\{u,v\\}$, exactly one of $u \\to v$ or $v \\to u$ holds. The function $f(n) = \\min_{|T|=n} \\max\\{k : T \\supseteq T_k^\\mathrm{trans}\\}$ measures the guaranteed transitive subtournament size. The directed Ramsey number $R_{\\rm dir}(k) = \\min\\{n : f(n) \\ge k\\}$ is the inverse function."
+    },
+    {
+      "id": "problem-statement",
+      "title": "Mathematical Statement: f(n) vs ⌊log₂ n⌋+1",
+      "startLine": 8,
+      "endLine": 14,
+      "summary": "Documents the full problem: is f(n) = ⌊log₂ n⌋+1? Records Stearns's greedy lower bound (f(n) ≥ ⌊log₂ n⌋+1) and that the directed Ramsey number is the inverse of f(n). The question was answered NO for large n.",
+      "mathContext": "Stearns's greedy proof: start with any vertex $v_1$; its out-neighborhood $N^+(v_1)$ has size $\\ge \\lceil(n-1)/2\\rceil$. Pick $v_2 \\in N^+(v_1)$; the out-neighborhood of $v_2$ within $N^+(v_1)$ has size $\\ge \\lfloor(|N^+(v_1)|-1)/2\\rfloor \\ge (n-3)/4$. After $k$ steps, the remaining set has size $\\ge n/2^k - C$, giving a transitive chain $v_1 \\to v_2 \\to \\cdots \\to v_k$ of length $k = \\lfloor \\log_2 n\\rfloor + 1$."
+    },
+    {
+      "id": "imports",
+      "title": "Mathlib Import",
+      "startLine": 16,
+      "endLine": 16,
+      "summary": "Full Mathlib import providing `SimpleGraph`, `Finset`, `Nat.log`, and tournament infrastructure for the eventual formalization.",
+      "mathContext": "Key Mathlib tools for formalization: `SimpleGraph.Tournament` (tournament predicate on `SimpleGraph V`); `SimpleGraph.neighborFinset` (out-neighborhood as `Finset V`); `Finset.exists_max_image` (greedy maximum selection); `Nat.log` (for the ⌊log₂ n⌋ bound). The greedy induction would use `Finset.card_pos` to ensure the neighborhood is nonempty at each step."
+    },
+    {
       "id": "placeholder-theorem",
-      "title": "Placeholder: Transitive Subtournament Theorem",
+      "title": "Placeholder Theorem: erdos_1216",
       "startLine": 18,
+      "endLine": 20,
+      "summary": "Placeholder `erdos_1216 : True := by sorry`. The Stearns lower bound would be: ∀ n : ℕ, ∀ T : SimpleGraph (Fin n), T.IsTournament → ∃ S : Finset (Fin n), S.card ≥ Nat.log 2 n + 1 ∧ T.IsTransitiveOn S.",
+      "mathContext": "The Lean formalization of 'transitive subtournament on $S$': $\\forall u \\in S, \\forall v \\in S, \\forall w \\in S$, $T.Adj u v \\to T.Adj v w \\to T.Adj u w$. The greedy step requires showing that the out-neighborhood of any vertex in a tournament has size $\\ge (n-1)/2$, formalized as `SimpleGraph.Tournament.exists_large_outNeighborhood`."
+    },
+    {
+      "id": "check-statement",
+      "title": "Type Check",
+      "startLine": 22,
       "endLine": 23,
-      "summary": "Placeholder `erdos_1216 : True := by sorry`. A Lean formalization would use Mathlib's `SimpleGraph` and tournament types, defining transitive subtournaments and proving the Stearns greedy lower bound f(n) ≥ ⌊log₂ n⌋ + 1."
+      "summary": "`#check erdos_1216` verifies the theorem is well-typed. The sorry marker comment documents that this is a placeholder for future formalization.",
+      "mathContext": "The current placeholder type `True` is a sentinel: any proof of `True` is trivial (`trivial`), but using `sorry` marks it for tracking. When the actual formalization is complete, the type will be replaced with the Stearns bound and the proof by the greedy algorithm."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "ramseys-theorem",
+      "relationship": "related",
+      "description": "The directed Ramsey number R_dir(k) is the tournament analogue of the undirected Ramsey number R(k,k). Both measure how large a structure must be to guarantee a specified ordered substructure."
+    },
+    {
+      "targetId": "erdos-1213",
+      "relationship": "related",
+      "description": "Both #1213 and #1216 are Ramsey-type threshold problems: #1213 asks for the threshold n > f(a,K) guaranteeing equal-sum intervals, #1216 for the threshold guaranteeing a transitive subtournament. Both have known existence bounds with unknown optimal growth rates."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/gcd-algorithm-oq-04/meta.json
+++ b/src/data/proofs/gcd-algorithm-oq-04/meta.json
@@ -58,7 +58,8 @@
       "title": "Module Overview: Two GCD Hierarchies",
       "startLine": 1,
       "endLine": 53,
-      "summary": "Module docstring explaining the two GCD hierarchies (EuclideanDomain vs GCDMonoid), the critical structural fact that EuclideanDomain.gcdMonoid is a def not an instance, and the coherence question. Lists key Mathlib facts. Imports Mathlib and opens EuclideanDomain namespace."
+      "summary": "Module docstring explaining the two GCD hierarchies (EuclideanDomain vs GCDMonoid), the critical structural fact that EuclideanDomain.gcdMonoid is a def not an instance, and the coherence question. Lists key Mathlib facts. Imports Mathlib and opens EuclideanDomain namespace.",
+      "mathContext": "Two Mathlib GCD hierarchies for ℤ: (1) `EuclideanDomain` computes `gcd a b` via the Euclidean algorithm recursively (terminating because the Euclidean valuation decreases); (2) `GCDMonoid` axiomatizes `gcd a b` as a least common divisor satisfying `gcd_dvd_left`, `gcd_dvd_right`, and `dvd_gcd`. The key fact: `EuclideanDomain.gcdMonoid` is a `def`, not a `[instance]` — Lean's typeclass system can only use it after explicit activation via `letI := EuclideanDomain.gcdMonoid`. The module explores when the two GCDs agree (definitionally, via `rfl`) and when they only associate (for ℤ, where GCDMonoid normalizes to non-negative)."
     },
     {
       "id": "euclidean-gcd-axioms",


### PR DESCRIPTION
## Enrichment pass — two proofs

### 1. gcd-algorithm-oq-04: EuclideanDomain GCD vs GCDMonoid Coherence

- **Fix index.ts**: Upgraded from legacy format to proper TypeScript with raw Lean source import so proof source displays on gallery page
- **Deepen historicalContext**: 265 → ~900 chars with real mathematical history (Euclid's *Elements*, Euclidean domain abstraction, GCD monoid theory, deliberate def-vs-instance design)
- **Add third openQuestion**: About automatic GCDMonoid derivation without explicit letI
- **Expand implications**: Added PID connection and how the def-vs-instance pattern recurs in Mathlib

### 2. erdos-1216: Largest Transitive Subtournament (Directed Ramsey Numbers)

- **Add 3 sections**: Preamble (problem description), imports, placeholder theorem — improving from 1 → 3 sections with mathContext for the formal f(n) definition
- **Add crossReferences**: Links to ramseys-theorem and erdos-1 gallery entries

### Axiom integrity
Both entries verified: no axiom or sorry discrepancies introduced.