### PR TITLE
Research: erdos-263 — connection_262_proved + doubleExp_sum_irrational sketch

### DIFF
--- a/proofs/Proofs/LawOfCosinesOQ05.lean
+++ b/proofs/Proofs/LawOfCosinesOQ05.lean
@@ -1,4 +1,6 @@
 import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Bounds
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Series
 import Mathlib.Analysis.SpecialFunctions.ExpDeriv
 import Mathlib.Analysis.SpecialFunctions.Sqrt
 import Mathlib.Tactic
@@ -333,13 +335,339 @@ For small K: cs_K(r) ≈ 1 - K·r²/2 + O(K²), sn_K(r) ≈ r + O(K).
 The unified formula at order K gives: c² = a² + b² - 2ab·cos(C).
 -/
 
-/-- The unified formula recovers the Euclidean law in the K → 0 limit. -/
+/-- Helper: exp(t) - 1 ≤ t * exp(t) for all t ∈ ℝ. -/
+private lemma exp_sub_one_le_mul_exp (t : ℝ) : Real.exp t - 1 ≤ t * Real.exp t := by
+  have h1 : 1 - Real.exp (-t) ≤ t := by linarith [Real.add_one_le_exp (-t)]
+  have h2 : Real.exp t * (1 - Real.exp (-t)) = Real.exp t - 1 := by
+    rw [mul_sub, mul_one, ← Real.exp_add]; simp
+  linarith [mul_le_mul_of_nonneg_left h1 (Real.exp_nonneg t)]
+
+/-- Helper: cosh(x) - 1 ≤ (x²/2) * exp(x²/2). -/
+private lemma cosh_sub_one_le (x : ℝ) : Real.cosh x - 1 ≤ x ^ 2 / 2 * Real.exp (x ^ 2 / 2) := by
+  have h1 : Real.cosh x ≤ Real.exp (x ^ 2 / 2) := Real.cosh_le_exp_half_sq x
+  have h2 : Real.exp (x ^ 2 / 2) - 1 ≤ x ^ 2 / 2 * Real.exp (x ^ 2 / 2) :=
+    exp_sub_one_le_mul_exp (x ^ 2 / 2)
+  linarith
+
+/-- cosh(x) ≥ 1 for all x. -/
+private lemma one_le_cosh (x : ℝ) : 1 ≤ Real.cosh x := by
+  have h : (1 : ℝ) ≤ Real.cosh x ^ 2 := by
+    nlinarith [Real.cosh_sq_sub_sinh_sq x, sq_nonneg (Real.sinh x)]
+  have hnn : (0 : ℝ) ≤ Real.cosh x := (Real.cosh_pos x).le
+  have hmono := Real.sqrt_le_sqrt h
+  rwa [Real.sqrt_one, Real.sqrt_sq hnn] at hmono
+
+/-- Bound: cosh(u·x) - 1 ≤ -K · (x²/2 · exp(x²/2)), for 0 < -K ≤ 1, u² = -K. -/
+private lemma cosh_K_bound {K u : ℝ} (hK : 0 < -K) (hK1 : -K ≤ 1) (hu2 : u ^ 2 = -K) (x : ℝ) :
+    Real.cosh (u * x) - 1 ≤ -K * (x ^ 2 / 2 * Real.exp (x ^ 2 / 2)) := by
+  have h1 := cosh_sub_one_le (u * x)
+  rw [mul_pow, hu2] at h1
+  have hfactor : (0 : ℝ) ≤ -K * x ^ 2 / 2 :=
+    div_nonneg (mul_nonneg (le_of_lt hK) (sq_nonneg x)) (by norm_num)
+  have hexp_mono : Real.exp (-K * x ^ 2 / 2) ≤ Real.exp (x ^ 2 / 2) :=
+    Real.exp_le_exp.mpr (by nlinarith [sq_nonneg x])
+  linarith [mul_le_mul_of_nonneg_left hexp_mono hfactor,
+            show -K * x ^ 2 / 2 * Real.exp (x ^ 2 / 2) =
+                 -K * (x ^ 2 / 2 * Real.exp (x ^ 2 / 2)) from by ring]
+
+/-- Bound: cosh(2·u·x) - 1 ≤ -K · 2 · (x² · exp(2x²)), for 0 < -K ≤ 1, u² = -K. -/
+private lemma cosh_double_K_bound {K u : ℝ} (hK : 0 < -K) (hK1 : -K ≤ 1) (hu2 : u ^ 2 = -K)
+    (x : ℝ) :
+    Real.cosh (2 * (u * x)) - 1 ≤ -K * 2 * (x ^ 2 * Real.exp (2 * x ^ 2)) := by
+  have h1 := cosh_sub_one_le (2 * (u * x))
+  rw [show (2 * (u * x)) ^ 2 = 4 * (u ^ 2 * x ^ 2) from by ring, hu2] at h1
+  have hfactor : (0 : ℝ) ≤ 4 * (-K * x ^ 2) / 2 :=
+    div_nonneg (mul_nonneg (by norm_num) (mul_nonneg (le_of_lt hK) (sq_nonneg x))) (by norm_num)
+  have hexp_mono : Real.exp (4 * (-K * x ^ 2) / 2) ≤ Real.exp (2 * x ^ 2) :=
+    Real.exp_le_exp.mpr (by nlinarith [sq_nonneg x])
+  linarith [mul_le_mul_of_nonneg_left hexp_mono hfactor,
+            show 4 * (-K * x ^ 2) / 2 * Real.exp (2 * x ^ 2) =
+                 -K * 2 * (x ^ 2 * Real.exp (2 * x ^ 2)) from by ring]
+
+set_option maxHeartbeats 4000000 in
+/-- The unified formula recovers the Euclidean law in the K → 0 limit.
+    Proof: for K > 0, |expr| ≤ K·M using |sin x| ≤ |x| and 1 - cos x ≤ x²/2;
+    for K < 0, |expr| ≤ |K|·M using cosh x - 1 ≤ x²/2·exp(x²/2) and double-angle identity;
+    for K = 0, expression is exactly 0. -/
 theorem euclidean_limit_holds (a b c cosC : ℝ)
     (heuclidean : c ^ 2 = a ^ 2 + b ^ 2 - 2 * a * b * cosC) :
     ∀ ε > 0, ∃ δ > 0, ∀ K : ℝ, |K| < δ →
       |curvatureCos K c - (curvatureCos K a * curvatureCos K b +
         K * curvatureSin K a * curvatureSin K b * cosC)| < ε := by
-  sorry  -- Requires Taylor expansion; K → 0 limit verified analytically above
+  intro ε hε
+  -- Bound constant for K > 0: |expr| ≤ K * M_pos
+  -- Bound constant for K < 0: |expr| ≤ κ * M_neg (where κ = -K)
+  -- We use M = max(M_pos, M_neg) + 1 as a unified bound for all |K| ≤ 1.
+  --
+  -- M_pos comes from: 1 - cos x ≤ x²/2 and |sin x| ≤ |x|
+  -- M_neg comes from: cosh x - 1 ≤ x²/2·exp(x²/2) and sinh² = (cosh(2x)-1)/2
+  let M_pos := (c ^ 2 + a ^ 2 + b ^ 2) / 2 + |a| * |b| * |cosC| + 1
+  let M_neg := c ^ 2 / 2 * Real.exp (c ^ 2 / 2) +
+               a ^ 2 / 2 * Real.exp (a ^ 2 / 2) +
+               (Real.exp (a ^ 2 / 2) + 1) * (b ^ 2 / 2 * Real.exp (b ^ 2 / 2)) +
+               (a ^ 2 * Real.exp (2 * a ^ 2) + b ^ 2 * Real.exp (2 * b ^ 2)) / 2 * |cosC| + 1
+  have hM_pos_pos : 0 < M_pos := by positivity
+  have hM_neg_pos : 0 < M_neg := by positivity
+  let M := M_pos + M_neg
+  have hM_pos : 0 < M := by positivity
+  refine ⟨min 1 (ε / M), lt_min one_pos (div_pos hε hM_pos), fun K hK => ?_⟩
+  have hK1 : |K| ≤ 1 := le_of_lt (hK.trans_le (min_le_left _ _))
+  have hKM : |K| * M < ε := by
+    have := hK.trans_le (min_le_right _ _)
+    calc |K| * M < ε / M * M := by
+          apply mul_lt_mul_of_pos_right this hM_pos
+        _ = ε := div_mul_cancel₀ ε (ne_of_gt hM_pos)
+  rcases lt_trichotomy K 0 with hneg | hzero | hpos
+  · -- K < 0 case: use cosh/sinh bounds
+    have hκ : 0 < -K := neg_pos.mpr hneg
+    have hκ1 : -K ≤ 1 := by linarith [(abs_le.mp hK1).1]
+    -- Unfold piecewise definitions
+    simp only [curvatureCos, curvatureSin,
+               show ¬K > 0 from not_lt.mpr (le_of_lt hneg), if_false, hneg, if_true]
+    -- Simplify K * sinh_a/sqrt * sinh_b/sqrt = -sinh_a * sinh_b (by K_mul_div_sqrt_sq_neg)
+    have hsimp_neg : K * (Real.sinh (Real.sqrt (-K) * a) / Real.sqrt (-K)) *
+                     (Real.sinh (Real.sqrt (-K) * b) / Real.sqrt (-K)) * cosC =
+                     -(Real.sinh (Real.sqrt (-K) * a) * Real.sinh (Real.sqrt (-K) * b) * cosC) := by
+      have h := K_mul_div_sqrt_sq_neg K (Real.sinh (Real.sqrt (-K) * a))
+                                        (Real.sinh (Real.sqrt (-K) * b)) hneg
+      linear_combination cosC * h
+    rw [hsimp_neg]
+    -- Expression = cosh(√κ·c) - cosh(√κ·a)·cosh(√κ·b) + sinh(√κ·a)·sinh(√κ·b)·cosC
+    set u := Real.sqrt (-K)  -- u = √κ
+    have hu2 : u ^ 2 = -K := Real.sq_sqrt (le_of_lt hκ)
+    have hu_nn : 0 ≤ u := Real.sqrt_nonneg _
+    -- Bound |cosh(u·c) - 1|
+    have hcosh_c := cosh_K_bound hκ hκ1 hu2 c
+    -- Bound |1 - cosh(u·a)·cosh(u·b)|
+    have hcosh_a := cosh_K_bound hκ hκ1 hu2 a
+    have hcosh_b := cosh_K_bound hκ hκ1 hu2 b
+    have hcosh_a_le : Real.cosh (u * a) ≤ Real.exp (a ^ 2 / 2) + 1 := by
+      have h1 := Real.cosh_le_exp_half_sq (u * a)
+      rw [mul_pow, hu2] at h1
+      have h2 : Real.exp (-K * a ^ 2 / 2) ≤ Real.exp (a ^ 2 / 2) :=
+        Real.exp_le_exp.mpr (by nlinarith [sq_nonneg a])
+      linarith [Real.exp_nonneg (a ^ 2 / 2)]
+    -- Bound |sinh(u·a)·sinh(u·b)| via AM-GM + double angle
+    have hsinh_sq_a : 2 * Real.sinh (u * a) ^ 2 = Real.cosh (2 * (u * a)) - 1 := by
+      linarith [Real.cosh_two_mul (u * a), Real.cosh_sq_sub_sinh_sq (u * a)]
+    have hsinh_sq_b : 2 * Real.sinh (u * b) ^ 2 = Real.cosh (2 * (u * b)) - 1 := by
+      linarith [Real.cosh_two_mul (u * b), Real.cosh_sq_sub_sinh_sq (u * b)]
+    have hcosh_2a := cosh_double_K_bound hκ hκ1 hu2 a
+    have hcosh_2b := cosh_double_K_bound hκ hκ1 hu2 b
+    -- |sinh_a * sinh_b| ≤ (sinh_a² + sinh_b²) / 2 by AM-GM
+    have hsinh_amgm : Real.sinh (u * a) * Real.sinh (u * b) ≤
+        (Real.sinh (u * a) ^ 2 + Real.sinh (u * b) ^ 2) / 2 := by
+      nlinarith [sq_nonneg (Real.sinh (u * a) - Real.sinh (u * b))]
+    have hsinh_amgm_neg : -(Real.sinh (u * a) * Real.sinh (u * b)) ≤
+        (Real.sinh (u * a) ^ 2 + Real.sinh (u * b) ^ 2) / 2 := by
+      nlinarith [sq_nonneg (Real.sinh (u * a) + Real.sinh (u * b))]
+    have hsinh_prod_bound : |Real.sinh (u * a) * Real.sinh (u * b)| ≤
+        (Real.sinh (u * a) ^ 2 + Real.sinh (u * b) ^ 2) / 2 := by
+      rw [abs_le]
+      constructor
+      · linarith
+      · exact hsinh_amgm
+    -- Combine: |sinh_a * sinh_b| ≤ -K * (a²·exp(2a²) + b²·exp(2b²))/2
+    have hsinh_final : |Real.sinh (u * a) * Real.sinh (u * b)| ≤
+        -K * ((a ^ 2 * Real.exp (2 * a ^ 2) + b ^ 2 * Real.exp (2 * b ^ 2)) / 2) := by
+      calc |Real.sinh (u * a) * Real.sinh (u * b)|
+          ≤ (Real.sinh (u * a) ^ 2 + Real.sinh (u * b) ^ 2) / 2 := hsinh_prod_bound
+        _ = (2 * Real.sinh (u * a) ^ 2 + 2 * Real.sinh (u * b) ^ 2) / 4 := by ring
+        _ = ((Real.cosh (2 * (u * a)) - 1) + (Real.cosh (2 * (u * b)) - 1)) / 4 := by
+            rw [hsinh_sq_a, hsinh_sq_b]
+        _ ≤ (-K * 2 * (a ^ 2 * Real.exp (2 * a ^ 2)) +
+              -K * 2 * (b ^ 2 * Real.exp (2 * b ^ 2))) / 4 := by
+            apply div_le_div_of_nonneg_right _ (by norm_num)
+            linarith
+        _ = -K * ((a ^ 2 * Real.exp (2 * a ^ 2) + b ^ 2 * Real.exp (2 * b ^ 2)) / 2) := by ring
+    -- Now assemble the bound on the full expression
+    have hone_cosh : 1 ≤ Real.cosh (u * a) := one_le_cosh _
+    have hone_cosh' : 1 ≤ Real.cosh (u * b) := one_le_cosh _
+    -- |cosh(u·c) - cosh(u·a)·cosh(u·b) + sinh(u·a)·sinh(u·b)·cosC|
+    -- ≤ |cosh(u·c) - 1| + |1 - cosh(u·a)·cosh(u·b)| + |sinh(u·a)·sinh(u·b)·cosC|
+    have hineq : |Real.cosh (u * c) - Real.cosh (u * a) * Real.cosh (u * b) +
+                  Real.sinh (u * a) * Real.sinh (u * b) * cosC|
+                 ≤ (Real.cosh (u * c) - 1) + (Real.cosh (u * a) - 1) +
+                   Real.cosh (u * a) * (Real.cosh (u * b) - 1) +
+                   |Real.sinh (u * a) * Real.sinh (u * b)| * |cosC| := by
+      have hcc := one_le_cosh (u * c)
+      have hca := one_le_cosh (u * a)
+      have hcb := one_le_cosh (u * b)
+      have h_abs : |Real.sinh (u * a) * Real.sinh (u * b) * cosC| =
+                   |Real.sinh (u * a) * Real.sinh (u * b)| * |cosC| := by
+        rw [abs_mul]
+      rw [show Real.cosh (u * c) - Real.cosh (u * a) * Real.cosh (u * b) +
+          Real.sinh (u * a) * Real.sinh (u * b) * cosC =
+          (Real.cosh (u * c) - 1) + (-(Real.cosh (u * a) * Real.cosh (u * b) - 1)) +
+          Real.sinh (u * a) * Real.sinh (u * b) * cosC by ring]
+      calc |(Real.cosh (u * c) - 1) + -(Real.cosh (u * a) * Real.cosh (u * b) - 1) +
+              Real.sinh (u * a) * Real.sinh (u * b) * cosC|
+          ≤ |Real.cosh (u * c) - 1| + |Real.cosh (u * a) * Real.cosh (u * b) - 1| +
+            |Real.sinh (u * a) * Real.sinh (u * b) * cosC| := by
+              -- Decompose: P = cosh_c - 1 ≥ 0, Q = cosh_ab - 1 ≥ 0, R = sinh*cosC
+              have hP : (0 : ℝ) ≤ Real.cosh (u * c) - 1 := by linarith
+              have hQ : (0 : ℝ) ≤ Real.cosh (u * a) * Real.cosh (u * b) - 1 := by nlinarith
+              have h_c : |Real.cosh (u * c) - 1| = Real.cosh (u * c) - 1 :=
+                abs_of_nonneg hP
+              have h_ab : |Real.cosh (u * a) * Real.cosh (u * b) - 1| =
+                          Real.cosh (u * a) * Real.cosh (u * b) - 1 := abs_of_nonneg hQ
+              have hRp : Real.sinh (u * a) * Real.sinh (u * b) * cosC ≤
+                         |Real.sinh (u * a) * Real.sinh (u * b) * cosC| := le_abs_self _
+              have hRn : -|Real.sinh (u * a) * Real.sinh (u * b) * cosC| ≤
+                         Real.sinh (u * a) * Real.sinh (u * b) * cosC := by
+                have h := le_abs_self (-(Real.sinh (u * a) * Real.sinh (u * b) * cosC))
+                rw [abs_neg] at h; linarith
+              rw [abs_le]
+              constructor
+              · linarith [h_c, h_ab, hRn]
+              · linarith [h_c, h_ab, hRp]
+        _ ≤ (Real.cosh (u * c) - 1) + (Real.cosh (u * a) * Real.cosh (u * b) - 1) +
+              |Real.sinh (u * a) * Real.sinh (u * b)| * |cosC| := by
+            have h_c : |Real.cosh (u * c) - 1| = Real.cosh (u * c) - 1 :=
+              abs_of_nonneg (by linarith)
+            have h_ab : |Real.cosh (u * a) * Real.cosh (u * b) - 1| =
+                        Real.cosh (u * a) * Real.cosh (u * b) - 1 :=
+              abs_of_nonneg (by nlinarith)
+            rw [h_c, h_ab, h_abs]
+        _ = (Real.cosh (u * c) - 1) + (Real.cosh (u * a) - 1) +
+              Real.cosh (u * a) * (Real.cosh (u * b) - 1) +
+              |Real.sinh (u * a) * Real.sinh (u * b)| * |cosC| := by ring
+    calc |Real.cosh (u * c) - (Real.cosh (u * a) * Real.cosh (u * b) +
+              -(Real.sinh (u * a) * Real.sinh (u * b) * cosC))|
+        = |Real.cosh (u * c) - Real.cosh (u * a) * Real.cosh (u * b) +
+              Real.sinh (u * a) * Real.sinh (u * b) * cosC| := by ring_nf
+      _ ≤ (Real.cosh (u * c) - 1) + (Real.cosh (u * a) - 1) +
+            Real.cosh (u * a) * (Real.cosh (u * b) - 1) +
+            |Real.sinh (u * a) * Real.sinh (u * b)| * |cosC| := hineq
+      _ ≤ -K * (c ^ 2 / 2 * Real.exp (c ^ 2 / 2)) +
+            -K * (a ^ 2 / 2 * Real.exp (a ^ 2 / 2)) +
+            (Real.exp (a ^ 2 / 2) + 1) * (-K * (b ^ 2 / 2 * Real.exp (b ^ 2 / 2))) +
+            (-K * ((a ^ 2 * Real.exp (2 * a ^ 2) + b ^ 2 * Real.exp (2 * b ^ 2)) / 2)) * |cosC| := by
+          apply add_le_add
+          · apply add_le_add
+            · apply add_le_add
+              · exact hcosh_c
+              · exact hcosh_a
+            · have hca_bd : Real.cosh (u * a) ≤ Real.exp (a ^ 2 / 2) + 1 := hcosh_a_le
+              nlinarith [Real.exp_nonneg (a ^ 2 / 2)]
+          · apply mul_le_mul_of_nonneg_right hsinh_final (abs_nonneg cosC)
+      _ ≤ -K * M_neg := by
+          -- Previous step = -K * (M_neg - 1), and -K ≥ 0 so -K * M_neg ≥ -K * (M_neg - 1)
+          have hrw : -K * (c ^ 2 / 2 * Real.exp (c ^ 2 / 2) +
+                          a ^ 2 / 2 * Real.exp (a ^ 2 / 2) +
+                          (Real.exp (a ^ 2 / 2) + 1) * (b ^ 2 / 2 * Real.exp (b ^ 2 / 2)) +
+                          (a ^ 2 * Real.exp (2 * a ^ 2) + b ^ 2 * Real.exp (2 * b ^ 2)) / 2 *
+                          |cosC| + 1) =
+                     -K * (c ^ 2 / 2 * Real.exp (c ^ 2 / 2)) +
+                     -K * (a ^ 2 / 2 * Real.exp (a ^ 2 / 2)) +
+                     (Real.exp (a ^ 2 / 2) + 1) * (-K * (b ^ 2 / 2 * Real.exp (b ^ 2 / 2))) +
+                     (-K * ((a ^ 2 * Real.exp (2 * a ^ 2) + b ^ 2 * Real.exp (2 * b ^ 2)) / 2)) *
+                     |cosC| + (-K) * 1 := by ring
+          simp only [M_neg]
+          linarith [hκ.le]
+      _ ≤ |K| * M := by
+          rw [abs_of_neg hneg]
+          simp only [M]
+          linarith [mul_pos hκ hM_pos_pos]
+      _ < ε := hKM
+  · -- K = 0 case: expression is exactly 0 < ε
+    subst hzero
+    simp [curvatureCos_zero, curvatureSin_zero, hε]
+  · -- K > 0 case: use cos/sin Taylor bounds
+    have hs : 0 < Real.sqrt K := Real.sqrt_pos.mpr hpos
+    have hs' : Real.sqrt K ≠ 0 := hs.ne'
+    simp only [curvatureCos, curvatureSin, hpos, if_true,
+               show ¬K < 0 from not_lt.mpr (le_of_lt hpos), if_false]
+    -- Simplify K * (sin(√K·a)/√K) * (sin(√K·b)/√K) = sin(√K·a) * sin(√K·b)
+    have hsimp : K * (Real.sin (Real.sqrt K * a) / Real.sqrt K) *
+                 (Real.sin (Real.sqrt K * b) / Real.sqrt K) * cosC =
+                 Real.sin (Real.sqrt K * a) * Real.sin (Real.sqrt K * b) * cosC := by
+      have h := K_mul_div_sqrt_sq_pos K (Real.sin (Real.sqrt K * a))
+                                        (Real.sin (Real.sqrt K * b)) hpos
+      linear_combination cosC * h
+    rw [hsimp]
+    set u := Real.sqrt K
+    have hu2 : u ^ 2 = K := Real.sq_sqrt (le_of_lt hpos)
+    have hu_nn : 0 ≤ u := hs.le
+    -- Bound 1 - cos(u·x) ≤ K·x²/2 via Taylor: 1 - (u·x)²/2 ≤ cos(u·x), then rw u²=K
+    have hcos_c : 1 - Real.cos (u * c) ≤ K * c ^ 2 / 2 := by
+      have h1 : 1 - (u * c) ^ 2 / 2 ≤ Real.cos (u * c) := Real.one_sub_sq_div_two_le_cos
+      rw [mul_pow, hu2] at h1; linarith
+    have hcos_a : 1 - Real.cos (u * a) ≤ K * a ^ 2 / 2 := by
+      have h1 : 1 - (u * a) ^ 2 / 2 ≤ Real.cos (u * a) := Real.one_sub_sq_div_two_le_cos
+      rw [mul_pow, hu2] at h1; linarith
+    have hcos_b : 1 - Real.cos (u * b) ≤ K * b ^ 2 / 2 := by
+      have h1 : 1 - (u * b) ^ 2 / 2 ≤ Real.cos (u * b) := Real.one_sub_sq_div_two_le_cos
+      rw [mul_pow, hu2] at h1; linarith
+    -- Bound |sin(u·a)·sin(u·b)| ≤ K·|a|·|b| via |sin x| ≤ |x| and u²=K
+    have hsin_prod : |Real.sin (u * a) * Real.sin (u * b)| ≤ K * (|a| * |b|) := by
+      have hsa : |Real.sin (u * a)| ≤ u * |a| := by
+        calc |Real.sin (u * a)| ≤ |u * a| := Real.abs_sin_le_abs
+          _ = u * |a| := by rw [abs_mul, abs_of_nonneg hu_nn]
+      have hsb : |Real.sin (u * b)| ≤ u * |b| := by
+        calc |Real.sin (u * b)| ≤ |u * b| := Real.abs_sin_le_abs
+          _ = u * |b| := by rw [abs_mul, abs_of_nonneg hu_nn]
+      calc |Real.sin (u * a) * Real.sin (u * b)|
+          = |Real.sin (u * a)| * |Real.sin (u * b)| := abs_mul _ _
+        _ ≤ (u * |a|) * (u * |b|) := mul_le_mul hsa hsb (abs_nonneg _) (by positivity)
+        _ = u ^ 2 * (|a| * |b|) := by ring
+        _ = K * (|a| * |b|) := by rw [hu2]
+    -- Auxiliary facts for triangle inequality
+    have hcc : Real.cos (u * c) - 1 ≤ 0 := by linarith [Real.cos_le_one (u * c)]
+    have hcprod : 0 ≤ 1 - Real.cos (u * a) * Real.cos (u * b) := by
+      nlinarith [Real.cos_le_one (u * a), Real.cos_le_one (u * b),
+                 Real.neg_one_le_cos (u * a), Real.neg_one_le_cos (u * b)]
+    -- Triangle inequality: |P + Q + R| ≤ (1-cos_c) + (1-cos_a*cos_b) + |sin_a*sin_b|*|cosC|
+    -- where P = cos_c-1 (≤0), Q = 1-cos_a*cos_b (≥0), R = -(sin_a*sin_b*cosC)
+    have htri : |Real.cos (u * c) - (Real.cos (u * a) * Real.cos (u * b) +
+                    Real.sin (u * a) * Real.sin (u * b) * cosC)|
+              ≤ (1 - Real.cos (u * c)) + (1 - Real.cos (u * a) * Real.cos (u * b)) +
+                |Real.sin (u * a) * Real.sin (u * b)| * |cosC| := by
+      -- Bound ±(sin_a*sin_b*cosC) by |sin_a*sin_b|*|cosC|
+      have hsin_le : -(Real.sin (u * a) * Real.sin (u * b) * cosC) ≤
+                     |Real.sin (u * a) * Real.sin (u * b)| * |cosC| := by
+        have h := le_abs_self (-(Real.sin (u * a) * Real.sin (u * b) * cosC))
+        rw [abs_neg, abs_mul] at h; exact h
+      have hsin_ge : -(|Real.sin (u * a) * Real.sin (u * b)| * |cosC|) ≤
+                     -(Real.sin (u * a) * Real.sin (u * b) * cosC) := by
+        have h := le_abs_self (Real.sin (u * a) * Real.sin (u * b) * cosC)
+        rw [abs_mul] at h; linarith
+      rw [show Real.cos (u * c) - (Real.cos (u * a) * Real.cos (u * b) +
+               Real.sin (u * a) * Real.sin (u * b) * cosC) =
+               (Real.cos (u * c) - 1) + (1 - Real.cos (u * a) * Real.cos (u * b)) +
+               (-(Real.sin (u * a) * Real.sin (u * b) * cosC)) from by ring,
+          abs_le]
+      constructor
+      · linarith [hcprod]
+      · linarith [hcc, hcprod]
+    -- Bound 1-cos_a*cos_b ≤ (1-cos_a) + (1-cos_b) and sin product by K*(|a|*|b|)*|cosC|
+    have hexpand : 1 - Real.cos (u * a) * Real.cos (u * b) ≤
+                   (1 - Real.cos (u * a)) + 1 * (1 - Real.cos (u * b)) := by
+      nlinarith [Real.cos_le_one (u * a), Real.cos_le_one (u * b)]
+    have hsin_cosC : |Real.sin (u * a) * Real.sin (u * b)| * |cosC| ≤
+                     K * (|a| * |b|) * |cosC| :=
+      mul_le_mul_of_nonneg_right hsin_prod (abs_nonneg cosC)
+    -- Pre-compute 1-cos_a*cos_b ≤ K*a²/2 + K*b²/2 to simplify final linarith
+    have hcab : 1 - Real.cos (u * a) * Real.cos (u * b) ≤ K * a ^ 2 / 2 + K * b ^ 2 / 2 := by
+      linarith [hexpand, hcos_a, hcos_b]
+    -- Assemble: |expr| ≤ K*c²/2 + K*a²/2 + K*b²/2 + K*(|a|*|b|)*|cosC| ≤ K*M_pos ≤ |K|*M
+    calc |Real.cos (u * c) - (Real.cos (u * a) * Real.cos (u * b) +
+              Real.sin (u * a) * Real.sin (u * b) * cosC)|
+        ≤ K * c ^ 2 / 2 + K * a ^ 2 / 2 + K * b ^ 2 / 2 +
+            K * (|a| * |b|) * |cosC| := by
+          linarith [htri, hcab, hsin_cosC, hcos_c]
+      _ ≤ K * M_pos := by
+          have heq : K * c ^ 2 / 2 + K * a ^ 2 / 2 + K * b ^ 2 / 2 + K * (|a| * |b|) * |cosC| =
+                     K * ((c ^ 2 + a ^ 2 + b ^ 2) / 2 + |a| * |b| * |cosC|) := by ring
+          rw [heq]
+          apply mul_le_mul_of_nonneg_left _ (le_of_lt hpos)
+          simp only [M_pos]; linarith
+      _ ≤ |K| * M := by
+          rw [abs_of_pos hpos]
+          have hMge : K * M_pos ≤ K * (M_pos + M_neg) :=
+            mul_le_mul_of_nonneg_left (le_add_of_nonneg_right (le_of_lt hM_neg_pos)) (le_of_lt hpos)
+          simp only [M]; linarith
+      _ < ε := hKM
 
 /-!
 ## Summary

--- a/proofs/Proofs/Stubs/Erdos263Problem.lean
+++ b/proofs/Proofs/Stubs/Erdos263Problem.lean
@@ -411,6 +411,49 @@ theorem truncation_insufficient (N : ℕ) :
       IsIrrationalitySequence a ∧ ¬IsIrrationalitySequence b := by
   sorry
 
+/- ## Part XI: Connection Theorems -/
+
+/-- Every irrationality sequence has an irrational reciprocal sum.
+    Proof: take b n = (a n : ℕ) as ℤ — the identity perturbation.
+    Since b n / a n = 1 → 1, `IsIrrationalitySequence a` gives the result. -/
+theorem connection_262_proved : connection_262 := by
+  intro a ha
+  have hirr := ha (fun n => ((a n : ℕ) : ℤ))
+    (show IsPerturbation a (fun n => ((a n : ℕ) : ℤ)) from by
+      unfold IsPerturbation
+      have hratio : ∀ n, (((a n : ℕ) : ℤ) : ℝ) / ((a n : ℕ+) : ℝ) = 1 := fun n => by
+        have hpos : (0 : ℝ) < ((a n : ℕ+) : ℝ) := by exact_mod_cast (a n).pos
+        have heq : (((a n : ℕ) : ℤ) : ℝ) = ((a n : ℕ+) : ℝ) := by norm_cast
+        rw [heq, div_self hpos.ne']
+      simp_rw [hratio]; exact tendsto_const_nhds)
+    (fun n => by exact_mod_cast (a n).pos)
+  simpa only [reciprocalSum, Int.cast_natCast] using hirr
+
+/-- The sum Σ_{n=0}^∞ 1/2^{2^n} is irrational.
+
+    Necessary condition for ErdosQuestion1: if this sum were rational, the
+    identity perturbation b = a would witness that doubleExp is NOT an
+    irrationality sequence.
+
+    Note: `doubleExp_not_folklore_growth` shows folklore_irrationality does NOT
+    apply here. The proof uses a direct integer-gap argument instead.
+
+    PROOF OUTLINE (integer-gap argument, for Aristotle):
+    Suppose S = m/n (rational, n > 0). Let D_N = 2^{2^N}.
+
+    Split at N: D_N · S = A_N + R_N  where
+      A_N = Σ_{k<N} 2^{2^N - 2^k} ∈ ℕ  (since 2^N ≥ 2^k for k < N)
+      R_N = D_N · Σ_{k≥N} 1/2^{2^k} = 1 + ε_N
+
+    Bound: ε_N = Σ_{k>N} 1/2^{2^k - 2^N} < 1/(2^{2^N} - 1) < 2/2^{2^N}
+
+    For N with 2^{2^N} > 2n:  n · ε_N < 1.
+    Then: m · D_N = n · A_N + n + n · ε_N  where n · ε_N ∈ (0, 1).
+    But m · D_N - n · A_N - n ∈ ℤ and n · ε_N ∈ (0,1). Contradiction. -/
+theorem doubleExp_sum_irrational :
+    Irrational (∑' n, (1 : ℝ) / (doubleExp n : ℕ)) := by
+  sorry
+
 end Erdos263
 
 /-
@@ -453,12 +496,16 @@ end Erdos263
   - `characterization_gap`: Superexponential ≠ folklore growth (doubleExp as witness)
   - `factorial_no_folklore_growth`: (n!)^{1/2^n} ≤ 2 (bounded, cannot → ∞)
   - `factorial_has_kovac_tao_condition`: (n+2)!/((n+1)!)² → 0 (satisfies KT condition)
+  - `connection_262_proved`: Every irrationality sequence has irrational reciprocal sum
 
-  **Key sorries** (4 remaining, all deep — require non-Mathlib mathematics):
+  **Key sorries** (5 remaining):
+  Deep (require non-Mathlib mathematics):
   - `folklore_irrationality`: a_n^{1/2^n} → ∞ ⟹ Σ 1/a_n irrational (Mahler-type)
   - `kovac_tao_not_irrationality`: The Kovač-Tao 2024 negative result (Egyptian fractions)
   - `positive_condition_irrationality`: liminf a_{n+1}/a_n^{2+ε} > 0 ⟹ irrationality seq
   - `truncation_insufficient`: ∀N, irrationality status requires infinite information
+  Hard (known proof, needs tsum formalization — Aristotle candidate):
+  - `doubleExp_sum_irrational`: Σ 1/2^{2^n} is irrational (integer-gap argument)
 
   **Position of key sequences relative to KT threshold**:
   - doubleExp (2^{2^n}): ratio = 1 exactly (AT boundary, KT does NOT exclude it)

--- a/research/problems/erdos-263/knowledge.md
+++ b/research/problems/erdos-263/knowledge.md
@@ -14,6 +14,45 @@ irrationality sequences. Both original questions remain open.
 
 ---
 
+## Session 2026-04-21 (Session 6) — New Theorems: connection_262 + doubleExp_sum_irrational
+
+**Mode**: REVISIT (RICH knowledge tier)
+**Outcome**: progress — proved `connection_262_proved` (no sorry); added `doubleExp_sum_irrational` (HARD sorry with complete integer-gap proof sketch, Aristotle candidate)
+
+### What I Did
+
+Added two new theorems in Part XI:
+
+**`connection_262_proved`**: Proves `connection_262 : ∀ a, IsIrrationalitySequence a → Irrational (Σ 1/aₙ)`.
+- Proof: take the identity perturbation `b n = (a n : ℕ) : ℤ`. Since `b n / a n = 1 → 1`, the irrationality sequence property directly gives the result.
+- This closes a gap: `connection_262` was defined as a Prop but never proved.
+- The theorem confirms the relationship: `IsIrrationalitySequence a → Irrational (Σ 1/a_n)` (but NOT the converse — see `connection_264`).
+
+**`doubleExp_sum_irrational`**: States `Irrational (Σ 1/2^{2^n})` with HARD sorry.
+- This is NECESSARY for ErdosQuestion1: if the sum were rational, the identity perturbation would immediately prevent doubleExp from being an irrationality sequence.
+- Note: `folklore_irrationality` does NOT apply since `doubleExp_not_folklore_growth` shows doubleExp lacks folklore growth.
+- Complete proof outline (integer-gap argument):
+  - Assume S = m/n. Let D_N = 2^{2^N}.
+  - D_N · S = A_N + 1 + ε_N where A_N ∈ ℕ, ε_N ∈ (0, 2/D_N)
+  - For 2^{2^N} > 2n: n · ε_N < 1, giving n · D_N · S = n·A_N + n + (non-integer). Contradiction with m·D_N ∈ ℤ.
+- Submitted to Aristotle as HARD sorry (tsum formalization needed)
+
+### Mathematical Insight
+
+The irrationality of Σ 1/2^{2^n} is related to the fact that 2^{2^n} is a "Sylvester-type" sequence (aₙ₊₁ = aₙ²). The integer-gap proof works because the product of all terms up to N exactly cancels out, leaving a fractional remainder in (0,1).
+
+### Files Modified
+- `proofs/Proofs/Stubs/Erdos263Problem.lean` (468 → 515 lines, sorries 4 → 5, theorems 16 → 18)
+- `src/data/proofs/erdos-263/meta.json` (lineCount, theoremCount, sorries updated)
+- `src/data/research/problems/erdos-263.json` (knowledge updated)
+
+### Next Steps
+- `doubleExp_sum_irrational` is an Aristotle candidate (HARD sorry with complete proof sketch)
+- All other 4 sorries remain DEEP (require non-Mathlib mathematics)
+- This problem is blocked on the deep sorries; future progress requires Mathlib analytic number theory contributions
+
+---
+
 ## Session 2026-04-21 (Session 5) — Dependency Analysis
 
 **Mode**: REVISIT

--- a/research/problems/law-of-cosines-oq-01-oq-05/knowledge.md
+++ b/research/problems/law-of-cosines-oq-01-oq-05/knowledge.md
@@ -19,3 +19,32 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+## Session 2026-04-21 - PROOF COMPLETED
+
+**Mode**: REVISIT (continuing euclidean_limit_holds sorry)
+**Outcome**: completed
+
+### What I Did
+- Eliminated the sole remaining `sorry` in `euclidean_limit_holds`
+- K<0 case: replaced `abs_add` (not available after `set u := Real.sqrt (-K)`) with manual `abs_le.mpr` decomposition using `le_abs_self` + `abs_neg`; used `one_le_cosh` private lemma (via `Real.cosh_sq_sub_sinh_sq` + `Real.cosh_pos`)
+- K>0 case: used `Real.one_sub_sq_div_two_le_cos` (implicit argument, no `_` needed), `Real.abs_sin_le_abs` (same), rewrote product bounds via `mul_le_mul_of_nonneg_left`
+- M_neg definition corrected to `(Real.exp (a^2/2) + 1)*(b^2/2*exp(b^2/2))` factor
+- Replaced `nlinarith` assembly steps with explicit `ring`-equation + `linarith` for budget efficiency
+- Introduced `hcab` intermediate lemma to reduce final `linarith` hint count
+- Increased `maxHeartbeats` from 800000 to 4000000 to accommodate the complex `isDefEq` check in the K>0 `calc` block
+
+### Key Findings
+- `abs_add` is not usable as a hint in `linarith` or as a term after `set u := ...` — use `abs_le.mpr` with `le_abs_self` and `abs_neg` instead
+- `Real.one_sub_sq_div_two_le_cos` and `Real.abs_sin_le_abs` take no explicit arguments (implicit x)
+- `Real.cosh_nonneg` doesn't exist; use `(Real.cosh_pos x).le`
+- Lean 4's `rw` closes `X ≤ X` goals automatically; adding `exact le_refl _` causes "No goals" error
+- Heartbeat budget is consumed cumulatively; `isDefEq` checks in large `calc` blocks can exhaust 800000 budget
+
+### Files Modified
+- `proofs/Proofs/LawOfCosinesOQ05.lean` (0 sorries, 1 axiom: `heuclidean` hypothesis)
+- `src/data/research/problems/law-of-cosines-oq-01-oq-05.json` (status → completed)
+
+### Next Steps
+- None: proof is complete
+- Potential follow-up: generalize to Riemannian manifolds or non-constant curvature

--- a/src/data/proofs/erdos-263/meta.json
+++ b/src/data/proofs/erdos-263/meta.json
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "open",
     "axiomCount": 0,
     "lineCount": 468,
-    "assumptions": "No axioms. 4 sorry(s) remain: folklore_irrationality (Mahler-type criterion needed), kovac_tao_not_irrationality (Egyptian fraction construction needed), positive_condition_irrationality (liminf analysis beyond Mathlib), truncation_insufficient (requires exhibiting a known irrationality sequence). Proved: doubleExp_not_folklore_growth (ratio=2, constant), doubleExp_square_growth (a_{n+1}=a_n²), doubleExp_strictly_increasing, doubleExp_convergent, doubleExp_superexponential (2026-04-14), doubleExp_not_kovac_tao (ratio=1 at KT boundary, 2026-04-14), factorial_no_folklore_growth (via factorial_le_two_pow_pow bound, 2026-04-14), factorial_has_kovac_tao_condition (ratio→0, 2026-04-14), characterization_gap (superexponential⊋folklore, 2026-04-14).",
+    "assumptions": "No axioms. 5 sorry(s) remain: folklore_irrationality (Mahler-type criterion needed), kovac_tao_not_irrationality (Egyptian fraction construction needed), positive_condition_irrationality (liminf analysis beyond Mathlib), truncation_insufficient (requires exhibiting a known irrationality sequence), doubleExp_sum_irrational (HARD — integer-gap proof outlined, Aristotle candidate). Proved: doubleExp_not_folklore_growth (ratio=2, constant), doubleExp_square_growth (a_{n+1}=a_n²), doubleExp_strictly_increasing, doubleExp_convergent, doubleExp_superexponential (2026-04-14), doubleExp_not_kovac_tao (ratio=1 at KT boundary, 2026-04-14), factorial_no_folklore_growth (via factorial_le_two_pow_pow bound, 2026-04-14), factorial_has_kovac_tao_condition (ratio→0, 2026-04-14), characterization_gap (superexponential⊋folklore, 2026-04-14), connection_262_proved (identity perturbation, 2026-04-21).",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -159,12 +159,12 @@
       "Real"
     ],
     "namespace": "Erdos263",
-    "lineCount": 468,
+    "lineCount": 515,
     "axiomCount": 0,
-    "theoremCount": 16,
+    "theoremCount": 18,
     "definitionCount": 19,
     "path": "Proofs/Stubs/Erdos263Problem.lean",
-    "sorries": 4
+    "sorries": 5
   },
   "crossReferences": [
     {
@@ -226,5 +226,5 @@
       "note": "Growth lower bounds for irrationality sequences, connected to Problem #262"
     }
   ],
-  "sorries": 4
+  "sorries": 5
 }

--- a/src/data/research/problems/erdos-263.json
+++ b/src/data/research/problems/erdos-263.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (session 3): proved doubleExp_not_kovac_tao (ratio=1 exactly at KT boundary) and factorial_has_kovac_tao_condition (ratio→0, below KT boundary). 11 theorems proved, 4 deep sorries remain.",
+    "progressSummary": "PROGRESS (session 6): proved connection_262_proved (identity perturbation), added doubleExp_sum_irrational sorry (integer-gap proof, Aristotle candidate). 12 theorems proved, 5 sorries remain (4 deep + 1 hard).",
     "builtItems": [
       "doubleExp_not_folklore_growth: ¬HasFolkloreGrowth doubleExp — proved in proofs/Proofs/Stubs/Erdos263Problem.lean:89",
       "two_pow_ge_sq: ∀ n ≥ 4, n^2 ≤ 2^n — private lemma in Erdos263Problem.lean:202",
@@ -38,7 +38,9 @@
       "factorial_le_two_pow_pow: (n+1)! ≤ 2^(2^n) — private lemma in Erdos263Problem.lean",
       "factorial_no_folklore_growth: ¬HasFolkloreGrowth factorial_seq — proved in Erdos263Problem.lean",
       "doubleExp_not_kovac_tao: doubleExp ratio a_{n+1}/a_n^2 = 1 (AT KT boundary, not excluded) — Erdos263Problem.lean",
-      "factorial_has_kovac_tao_condition: factorial ratio (n+2)!/((n+1)!)^2 = (n+2)/(n+1)! → 0 (BELOW KT boundary) — Erdos263Problem.lean"
+      "factorial_has_kovac_tao_condition: factorial ratio (n+2)!/((n+1)!)^2 = (n+2)/(n+1)! → 0 (BELOW KT boundary) — Erdos263Problem.lean",
+      "connection_262_proved: ∀ a, IsIrrationalitySequence a → Irrational (Σ 1/aₙ) — proved via identity perturbation (2026-04-21)",
+      "doubleExp_sum_irrational: Irrational (Σ 1/2^{2^n}) — HARD sorry with integer-gap proof sketch (2026-04-21)"
     ],
     "insights": [
       "(2^{2^n})^{1/2^n} = 2^{(2^n)*(1/2^n)} = 2^1 = 2 — the function is constantly 2, so doubleExp does NOT satisfy the folklore condition",
@@ -52,7 +54,9 @@
       "factorial_no_folklore_growth proof: (n+1)!^{1/2^n} ≤ (2^{2^n})^{1/2^n} = 2 < 3 for all n, contradicting tendsto to ∞",
       "doubleExp sits EXACTLY at KT boundary: a_{n+1}/a_n^2 = 1 for all n (from doubleExp_square_growth), so KT does NOT exclude it — this is why KT theorem does not answer Q1",
       "factorial sits BELOW KT boundary: (n+2)!/((n+1)!)^2 = (n+2)/(n+1)! → 0, so if KT is proved, factorial is NOT an irrationality sequence",
-      "KT position table: doubleExp → ratio=1 (boundary, open), factorial → ratio→0 (below boundary, KT excludes), towerFun → ratio→∞ (above boundary)"
+      "KT position table: doubleExp → ratio=1 (boundary, open), factorial → ratio→0 (below boundary, KT excludes), towerFun → ratio→∞ (above boundary)",
+      "connection_262 says IsIrrationalitySequence a → Irrational (Σ 1/aₙ) — proved via identity perturbation b=a; the converse is FALSE (connection_264)",
+      "Σ 1/2^{2^n} is irrational by integer-gap: for D_N=2^{2^N} > 2n, D_N · (tail after N) = 1 + ε where n·ε ∈ (0,1) but must be integer if sum = m/n. Contradiction."
     ],
     "mathlibGaps": [
       "No elementary tendsto proof for 2^n/n → ∞ directly — need to go via Nat.log or exponential comparison for doubleExp_superexponential",


### PR DESCRIPTION
## Summary

- **`connection_262_proved`** (no sorry): Proves `connection_262 : ∀ a, IsIrrationalitySequence a → Irrational (Σ 1/aₙ)`. Proof uses the identity perturbation `b n = (a n : ℕ) : ℤ`, for which `b n / a n = 1 → 1`, so `IsIrrationalitySequence a` directly gives the result.

- **`doubleExp_sum_irrational`** (HARD sorry, Aristotle candidate): States that `Irrational (Σ 1/2^{2^n})`. This is a necessary condition for ErdosQuestion1. The `folklore_irrationality` theorem does NOT apply (since `doubleExp_not_folklore_growth` shows doubleExp lacks folklore growth), so a direct integer-gap argument is needed: for `D_N = 2^{2^N} > 2n`, the tail `D_N · Σ_{k≥N} 1/2^{2^k} = 1 + ε` where `n · ε ∈ (0,1)`, giving a non-integer where an integer is required.

## Files Changed
- `proofs/Proofs/Stubs/Erdos263Problem.lean`: 468 → 515 lines, sorries 4 → 5, theorems 16 → 18
- `src/data/proofs/erdos-263/meta.json`: updated counts
- `src/data/research/problems/erdos-263.json`: knowledge updated
- `research/problems/erdos-263/knowledge.md`: session 6 added

## Labels
research