### PR TITLE
Fix: lineCount metadata for 20 gallery proofs

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
@@ -56,7 +56,7 @@
     ],
     "dateAdded": "2026-02-24",
     "axiomCount": 0,
-    "lineCount": 1938,
+    "lineCount": 1937,
     "assumptions": "0 sorries. The IBP formula fourierCoeffOn_deriv_periodic is now proved via import from AreaOfCircleOQ01OQ02OQ02.lean.",
     "mathlib_version": "4.26.0"
   },
@@ -267,7 +267,7 @@
       "Topology"
     ],
     "namespace": "IsoperimetricOQ",
-    "lineCount": 1938,
+    "lineCount": 1937,
     "axiomCount": 0,
     "theoremCount": 68,
     "definitionCount": 12,

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified. 2 lemmas (sum_zero_left, sum_succ_left) + 1 theorem (multiset_vandermonde), all with 0 sorries. The r=0 base case is handled inline within multiset_vandermonde rather than as a named lemma.",
     "mathlib_version": "4.26.0",
-    "lineCount": 119,
+    "lineCount": 118,
     "theoremCount": 3,
     "definitionCount": 0
   },

--- a/src/data/proofs/bezout-identity-oq-04-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-04-oq-02/meta.json
@@ -43,7 +43,7 @@
       "Key insight: the correct algebraic level is EuclideanDomain, not UFD — ℤ[X] is a UFD where gcd(2,X)=1 but 1 ∉ {2f+Xg}"
     ],
     "dateAdded": "2026-04-21",
-    "lineCount": 139,
+    "lineCount": 138,
     "prerequisites": [
       "Bézout's identity for ℤ (parent proof)",
       "Euclidean domain structure (Mathlib)",

--- a/src/data/proofs/binomial-theorem-oq-04-oq-02-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-04-oq-02-oq-01/meta.json
@@ -36,7 +36,7 @@
     ],
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "lineCount": 156,
+    "lineCount": 224,
     "assumptions": "1 sorry: q_vandermonde (line 133) — the inductive step Finset.sum reindexing (k ↦ k-1) with q-exponent matching is not yet complete.",
     "mathlib_version": "4.26.0"
   },
@@ -141,7 +141,7 @@
       "Finset"
     ],
     "namespace": "BinomialTheoremOQ04OQ02OQ01",
-    "lineCount": 156,
+    "lineCount": 224,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 1,

--- a/src/data/proofs/binomial-theorem-oq-04-oq-02-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-04-oq-02-oq-01/meta.json
@@ -2,13 +2,13 @@
   "id": "binomial-theorem-oq-04-oq-02-oq-01",
   "title": "q-Vandermonde Identity: Gaussian Binomial Coefficients",
   "slug": "binomial-theorem-oq-04-oq-02-oq-01",
-  "sorries": 1,
+  "sorries": 0,
   "description": "Formalization of Gaussian binomial coefficients [n choose k]_q via the q-Pascal recurrence, and the q-Vandermonde identity: [m+n choose r]_q = Σ_k [m choose k]_q · [n choose r-k]_q · q^(k·(n+k-r)).",
   "meta": {
     "author": "Formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Gaussian_binomial_coefficient",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "tags": [
       "combinatorics",
       "algebra",
@@ -17,8 +17,8 @@
       "research"
     ],
     "proofRepoPath": "Proofs/BinomialTheoremOQ04OQ02OQ01.lean",
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "original",
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Nat.choose_succ_succ",
@@ -31,19 +31,19 @@
       "gaussBinom_eq_zero_of_lt: vanishing property [n choose k]_q = 0 when k > n",
       "gaussBinom_self: [n choose n]_q = 1 for all n",
       "gaussBinom_one: classical limit — [n choose k]_1 = C(n,k)",
-      "q_vandermonde: main identity — inductive proof structure complete, 1 sorry in the Finset.sum reindexing step",
-      "vandermonde_from_q: classical Vandermonde as corollary via q=1 specialization (inherits q_vandermonde sorry)"
+      "q_vandermonde: main identity — fully proved by induction using q-Pascal expansion and Finset.sum reindexing",
+      "vandermonde_from_q: classical Vandermonde as corollary via q=1 specialization (fully proved)"
     ],
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
     "lineCount": 224,
-    "assumptions": "1 sorry: q_vandermonde (line 133) — the inductive step Finset.sum reindexing (k ↦ k-1) with q-exponent matching is not yet complete.",
+    "assumptions": "None. All results fully proved: q_vandermonde inductive step completed using q-Pascal expansion with Finset.sum_range_succ, mul_sum, and ring.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
     "historicalContext": "Gaussian binomial coefficients $\\binom{n}{k}_q$ (also called q-binomial coefficients) arise naturally in the theory of finite fields: $\\binom{n}{k}_q$ counts the number of $k$-dimensional subspaces of $\\mathbb{F}_q^n$. They were studied by Gauss in his work on cyclotomic polynomials and appear throughout the theory of quantum groups, basic hypergeometric series, and combinatorics of set partitions. The q-Vandermonde identity $\\binom{m+n}{r}_q = \\sum_k \\binom{m}{k}_q \\binom{n}{r-k}_q q^{k(n-r+k)}$ is the natural q-analog of the classical Vandermonde convolution, with the additional $q$-weight $q^{k(n-r+k)}$ recording how subspaces are positioned. At $q = 1$, all weights become 1 and the identity reduces to classical Vandermonde.",
     "problemStatement": "**q-Vandermonde Identity**: For all natural numbers $m$, $n$, $r$ and a commutative ring element $q$:\n$$\\binom{m+n}{r}_q = \\sum_{k=0}^{r} \\binom{m}{k}_q \\cdot \\binom{n}{r-k}_q \\cdot q^{k(n+k-r)}$$\n\nwhere the Gaussian binomial $\\binom{n}{k}_q$ is defined by the q-Pascal recurrence\n$\\binom{n+1}{k+1}_q = q^{k+1} \\binom{n}{k+1}_q + \\binom{n}{k}_q$.",
-    "text": "Formalization of Gaussian binomial coefficients and the q-Vandermonde identity over a commutative ring. Mathlib 4 has no gaussBinom — this file builds the theory from scratch. The definition and basic properties are fully proved; the main q-Vandermonde identity has 1 sorry pending completion of the inductive step.",
+    "text": "Formalization of Gaussian binomial coefficients and the q-Vandermonde identity over a commutative ring. Mathlib 4 has no gaussBinom — this file builds the theory from scratch. The definition and basic properties are fully proved; the main q-Vandermonde identity is fully proved.",
     "proofStrategy": "The Gaussian binomial $\\binom{n}{k}_q$ is defined by structural recursion on the pair $(n, k)$: base cases $\\binom{n}{0}_q = 1$ and $\\binom{0}{k+1}_q = 0$, with the q-Pascal rule $\\binom{n+1}{k+1}_q = q^{k+1}\\binom{n}{k+1}_q + \\binom{n}{k}_q$ for the recursive step. Basic properties (vanishing for $k > n$, classical limit at $q = 1$) are proved by induction. The q-Vandermonde identity is to be proved by induction on $n$: the base case $n = 0$ reduces to the observation that $\\binom{0}{j}_q = 0$ for $j > 0$, collapsing the sum to the single $k = r$ term. The inductive step requires applying the q-Pascal rule to $\\binom{m+n+1}{r}_q$ and using the induction hypothesis on both $r$ and $r-1$, with Finset.sum reindexing via sum_congr, sum_add_distrib, mul_sum, sum_range_succ, and ring.",
     "keyInsights": [
       "The q-Pascal rule has two forms: P1 (our definition) splits on position and increments the numerator-denominator by 1 together; P2 (the symmetric form) has the q-weight on the other term. Both are equivalent via the q-symmetry [n choose k]_q = [n choose n-k]_q.",
@@ -146,7 +146,7 @@
     "theoremCount": 8,
     "definitionCount": 1,
     "path": "Proofs/BinomialTheoremOQ04OQ02OQ01.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-02/meta.json
@@ -36,6 +36,7 @@
         "module": "Mathlib.SetTheory.Cardinal.Basic"
       }
     ],
+    "lineCount": 255,
     "assumptions": []
   },
   "parent": "cantor-diagonalization-oq-01-oq-01",

--- a/src/data/proofs/cantor-diagonalization-oq-04-oq-03/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-04-oq-03/meta.json
@@ -32,6 +32,7 @@
         "module": "Mathlib.Order.CompleteLattice"
       }
     ],
+    "lineCount": 283,
     "assumptions": []
   },
   "parent": "cantor-diagonalization-oq-04",

--- a/src/data/proofs/cauchy-schwarz-integral/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral/meta.json
@@ -43,7 +43,7 @@
     ],
     "dateAdded": "2026-02-11",
     "axiomCount": 0,
-    "lineCount": 118,
+    "lineCount": 117,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0"
   },
@@ -187,7 +187,7 @@
       "MeasureTheory"
     ],
     "namespace": "BunyakovskySchwarz",
-    "lineCount": 118,
+    "lineCount": 117,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 0,

--- a/src/data/proofs/erdos-1028/meta.json
+++ b/src/data/proofs/erdos-1028/meta.json
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "solved",
     "relatedProblems": [],
     "axiomCount": 2,
-    "lineCount": 311,
+    "lineCount": 310,
     "assumptions": "6 axioms: erdos_upper, erdos_spencer_lower, random_upper, large_discrepancy_exists, H_two, H_three. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
@@ -238,7 +238,7 @@
       "Finset"
     ],
     "namespace": "Erdos1028",
-    "lineCount": 311,
+    "lineCount": 310,
     "axiomCount": 2,
     "theoremCount": 8,
     "definitionCount": 10,

--- a/src/data/proofs/erdos-1034/meta.json
+++ b/src/data/proofs/erdos-1034/meta.json
@@ -26,7 +26,7 @@
       "erdos-1033"
     ],
     "axiomCount": 1,
-    "lineCount": 779,
+    "lineCount": 778,
     "assumptions": "3 axiom(s) and 3 sorries. See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
@@ -273,7 +273,7 @@
       "Finset"
     ],
     "namespace": "Erdos1034",
-    "lineCount": 779,
+    "lineCount": 778,
     "axiomCount": 1,
     "theoremCount": 17,
     "definitionCount": 22,

--- a/src/data/proofs/erdos-1206/meta.json
+++ b/src/data/proofs/erdos-1206/meta.json
@@ -12,6 +12,7 @@
     "tags": [
       "erdos"
     ],
+    "lineCount": 23,
     "badge": "wip",
     "sorries": 1,
     "erdosNumber": 1206,

--- a/src/data/proofs/erdos-1211/meta.json
+++ b/src/data/proofs/erdos-1211/meta.json
@@ -16,6 +16,7 @@
       "density",
       "subset-sums"
     ],
+    "lineCount": 23,
     "badge": "wip",
     "sorries": 1,
     "erdosNumber": 1211,

--- a/src/data/proofs/erdos-1212/meta.json
+++ b/src/data/proofs/erdos-1212/meta.json
@@ -17,6 +17,7 @@
       "prime-numbers",
       "lattice-graphs"
     ],
+    "lineCount": 23,
     "badge": "wip",
     "sorries": 1,
     "erdosNumber": 1212,

--- a/src/data/proofs/erdos-1213/meta.json
+++ b/src/data/proofs/erdos-1213/meta.json
@@ -16,6 +16,7 @@
       "sequences",
       "pigeonhole"
     ],
+    "lineCount": 23,
     "badge": "wip",
     "sorries": 1,
     "erdosNumber": 1213,

--- a/src/data/proofs/erdos-1215/meta.json
+++ b/src/data/proofs/erdos-1215/meta.json
@@ -16,6 +16,7 @@
       "topology",
       "unit-circle"
     ],
+    "lineCount": 23,
     "badge": "wip",
     "sorries": 1,
     "erdosNumber": 1215,

--- a/src/data/proofs/erdos-1216/meta.json
+++ b/src/data/proofs/erdos-1216/meta.json
@@ -16,6 +16,7 @@
       "tournament-theory",
       "combinatorics"
     ],
+    "lineCount": 23,
     "badge": "wip",
     "sorries": 1,
     "erdosNumber": 1216,

--- a/src/data/proofs/erdos-1217/meta.json
+++ b/src/data/proofs/erdos-1217/meta.json
@@ -16,6 +16,7 @@
       "density-theory",
       "sequences"
     ],
+    "lineCount": 23,
     "badge": "wip",
     "sorries": 1,
     "erdosNumber": 1217,

--- a/src/data/proofs/fourier-series-oq-02-oq-01/meta.json
+++ b/src/data/proofs/fourier-series-oq-02-oq-01/meta.json
@@ -42,7 +42,7 @@
       "Key insight: ĉ_n → 0 requires only L²-membership; quantitative bounds are not needed"
     ],
     "dateAdded": "2026-04-21",
-    "lineCount": 75,
+    "lineCount": 83,
     "prerequisites": [
       "FourierSeries.lean: fourierCoeff_tendsto_zero for L² functions",
       "Mathlib HolderWith: holder_continuous, MemLp for continuous functions on compact spaces",

--- a/src/data/proofs/hilbert-20-oq-01-oq-03/meta.json
+++ b/src/data/proofs/hilbert-20-oq-01-oq-03/meta.json
@@ -38,6 +38,7 @@
       "Dencker sufficiency theorem assembled from weight->estimate->solvability chain",
       "Adjoint preserves principal type property"
     ],
+    "lineCount": 325,
     "assumptions": [
       "HasAPrioriEstimate: Sobolev a priori estimates (needs Sobolev spaces)",
       "IsLocallySolvable: local solvability (needs distribution theory)",

--- a/src/data/proofs/lhopital-oq-01/meta.json
+++ b/src/data/proofs/lhopital-oq-01/meta.json
@@ -52,7 +52,7 @@
       "lhopital_failure: combined statement of the counterexample"
     ],
     "dateAdded": "2026-04-21",
-    "lineCount": 169,
+    "lineCount": 142,
     "assumptions": "0 sorries, 0 axioms. Fully machine-verified.",
     "mathlib_version": "4.26.0"
   },
@@ -139,7 +139,7 @@
     "imports": ["Mathlib"],
     "opens": ["Real", "Filter", "Topology"],
     "namespace": "LHopitalFailure",
-    "lineCount": 169,
+    "lineCount": 142,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 0,

--- a/src/data/proofs/szemeredi-hypergraph-core-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/szemeredi-hypergraph-core-oq-01-incomplete-01/meta.json
@@ -39,7 +39,7 @@
     ],
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "lineCount": 240,
+    "lineCount": 244,
     "assumptions": "1 sorry (naive_implies_gowers). All definitions and 12 out of 13 theorems fully machine-verified.",
     "mathlib_version": "4.26.0"
   },
@@ -130,7 +130,7 @@
     ],
     "opens": ["Classical"],
     "namespace": "Szemeredi.Hypergraph",
-    "lineCount": 240,
+    "lineCount": 244,
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 5,


### PR DESCRIPTION
## Fix

Two categories of metadata corrections:

### 1. lineCount fixes (20 proofs)

Corrects `lineCount` fields where `meta.json` no longer matched the actual Lean source file (verified with `wc -l` against committed files).

| Proof | Before | After | Reason |
|-------|--------|-------|--------|
| hilbert-20-oq-01-oq-03 | null | 325 | Field was never set |
| cantor-diagonalization-oq-04-oq-03 | null | 283 | Field was never set |
| cantor-diagonalization-oq-01-oq-01-oq-02 | null | 255 | Field was never set |
| erdos-1206/1211/1212/1213/1215/1216/1217 | null | 23 | Stubs, field never set |
| binomial-theorem-oq-04-oq-02-oq-01 | 156 | 224 | File grew with q-Vandermonde content |
| fourier-series-oq-02-oq-01 | 75 | 83 | File grew with enrichment |
| szemeredi-hypergraph-core-oq-01-incomplete-01 | 240 | 244 | File grew |
| lhopital-oq-01 | 169 | 142 | File reduced by enricher PR #11057 |
| area-of-circle-oq-01-oq-03 | 1938 | 1937 | Off-by-one |
| arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02 | 119 | 118 | Off-by-one |
| bezout-identity-oq-04-oq-02 | 139 | 138 | Off-by-one |
| cauchy-schwarz-integral | 118 | 117 | Off-by-one |
| erdos-1028 | 311 | 310 | Off-by-one |
| erdos-1034 | 779 | 778 | Off-by-one |

### 2. binomial-theorem-oq-04-oq-02-oq-01 sorry/status fix

PR #11067 incorrectly "restored" sorries=1, claiming a sorry still existed on line 133 of the q-Vandermonde proof. But PR #11061 had already completed the induction (0 sorries, 224 lines). The Lean file at origin/main confirms: `grep -c sorry proofs/Proofs/BinomialTheoremOQ04OQ02OQ01.lean = 0`.

**Before**: `sorries: 1, status: formalized, badge: wip, lineCount: 156`
**After**: `sorries: 0, status: verified, badge: original, lineCount: 224`

---
Replaces #11076 (which had the same lineCount fixes but also contained incorrect binomial-theorem changes that conflicted with #11067).

Automated fix by lean-mechanic agent.