### PR TITLE
Audit: bezout-identity-oq-04-oq-02 — correct badge original→mathlib

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12836,6 +12836,12 @@
       "lastAudited": "2026-04-21T16:05:40Z",
       "result": "fixed",
       "issues": []
+    },
+    "bezout-identity-oq-04-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-21T17:27:38Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {

--- a/src/data/proofs/bezout-identity-oq-04-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-04-oq-02/meta.json
@@ -17,7 +17,7 @@
       "bezout",
       "generalization"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "mathlibDependencies": [


### PR DESCRIPTION
## Audit Finding

**Proof**: bezout-identity-oq-04-oq-02 (Bézout's Identity in Euclidean Domains)
**Issue**: badge is "original" but the core result relies on Mathlib's EuclideanDomain.gcd_eq_gcd_ab — Tier B classification requires badge "mathlib".

## Evidence

The key backward direction:
```lean
theorem gcd_achievable_ED (a b : R) :
    ∃ x y : R, a * x + b * y = gcd a b :=
  ⟨gcdA a b, gcdB a b, (gcd_eq_gcd_ab a b).symm⟩
```
This directly wraps Mathlib's gcd_eq_gcd_ab for its existence witness.

## Fix

- badge: "original" → "mathlib"

Status remains "verified" (0 sorries, 0 axioms confirmed in Lean source).
The theorem statements (linear_combination_iff_gcd_dvd, gcd_complete_characterization_ED) are new, but the core proof is a Mathlib bridge.

## Note

The description and text already honestly credit Mathlib. Only the badge field needs updating.

---
Discovered during gallery integrity audit.