### PR TITLE
Enrich schroeder-bernstein-oq-03: full enrichment — Myhill's Isomorphism Theorem

### DIFF
--- a/src/data/proofs/schroeder-bernstein-oq-03/annotations.json
+++ b/src/data/proofs/schroeder-bernstein-oq-03/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-myhill-docstring",
+    "proofId": "schroeder-bernstein-oq-03",
+    "range": { "startLine": 1, "endLine": 62 },
+    "type": "context",
+    "title": "Myhill's Isomorphism Theorem: Computable Analogue of Schröder-Bernstein",
+    "content": "The module docstring presents Myhill's 1955 theorem as the computable version of Cantor-Schröder-Bernstein: classical CBS gives any bijection from two injections; Myhill's theorem gives a computable bijection from two computable injections. The key distinction is between many-one reducibility (≤ₘ, function need not be injective) and one-one reducibility (≤₁, function must be injective). The back-and-forth construction classifies each n by its backward orbit type (A: chain exits range(g), B: chain exits range(f), C: infinite). References to Myhill (1955, creative sets), Rogers (1967, §7.4), and Soare (2016, Chapter 3) establish the classical literature context.",
+    "mathContext": "One-one reducibility: $p \\leq_1 q$ iff $\\exists$ computable injective $f$ with $\\forall n, p(n) \\leftrightarrow q(f(n))$. One-one equivalence: $p \\equiv_1 q$ iff $p \\leq_1 q$ and $q \\leq_1 p$. Myhill: $p \\equiv_1 q \\iff \\exists$ computable permutation $e : \\mathbb{N} \\simeq \\mathbb{N}$ with $\\forall n, p(n) \\leftrightarrow q(e(n))$. Back-and-forth: orbit $n \\leftarrow g^{-1}(n) \\leftarrow f^{-1}(g^{-1}(n)) \\leftarrow \\cdots$ determines which injection to use for $\\sigma(n)$.",
+    "significance": "context",
+    "relatedConcepts": ["one-one reducibility", "many-one reducibility", "creative sets", "back-and-forth argument", "Cantor-Schröder-Bernstein"],
+    "prerequisites": ["computability theory basics", "partial recursive functions", "Lean 4 computability typeclasses"]
+  },
+  {
+    "id": "ann-myhill-corresponds",
+    "proofId": "schroeder-bernstein-oq-03",
+    "range": { "startLine": 64, "endLine": 70 },
+    "type": "definition",
+    "title": "Corresponds: Predicate Mapping Under a Permutation",
+    "content": "The Corresponds predicate abstracts the notion that a permutation e maps predicate p to predicate q: every n satisfying p maps to an element e(n) satisfying q, and vice versa. This is equivalent to saying e is a 'computable isomorphism' between the characteristic functions p and q. The definition separates the set-theoretic correspondence from the computability requirement (the latter is carried by e.Computable in theorem hypotheses).",
+    "mathContext": "$\\text{Corresponds}(p, e, q) \\equiv \\forall n,\\, p(n) \\leftrightarrow q(e(n))$. Equivalently: $e[A] = B$ where $A = p^{-1}(\\text{True})$ and $B = q^{-1}(\\text{True})$ are the corresponding subsets of $\\mathbb{N}$. The definition works for any equivalence $e : \\mathbb{N} \\simeq \\mathbb{N}$, not just computable ones.",
+    "significance": "supporting",
+    "relatedConcepts": ["computable isomorphism", "characteristic function", "predicate correspondence"],
+    "prerequisites": ["Lean 4 definitional equality", "Equiv type", "propositional iff"]
+  },
+  {
+    "id": "ann-myhill-easy",
+    "proofId": "schroeder-bernstein-oq-03",
+    "range": { "startLine": 73, "endLine": 94 },
+    "type": "theorem",
+    "title": "Easy Direction: Computable Bijection Implies One-One Equivalence",
+    "content": "The easy direction is fully proved. Given a computable bijection e with Corresponds p e q, construct: (1) e witnesses p ≤₁ q — e is computable (he.1), injective (e.injective), and maps p to q (hpq). (2) e.symm witnesses q ≤₁ p — e.symm is computable (he.2), injective, and the iff q n ↔ p (e.symm n) follows by applying hpq at e.symm(n) and using e(e.symm(n)) = n. The simp/Equiv.apply_symm_apply lemma handles the cancellation. The variant one_one_equiv_of_computable_perm takes explicit Computable hypotheses rather than e.Computable.",
+    "mathContext": "Proof of $q(n) \\leftrightarrow p(e^{-1}(n))$: by hypothesis, $p(e^{-1}(n)) \\leftrightarrow q(e(e^{-1}(n))) = q(n)$. So the iff holds by symmetry. This uses the key identity $e \\circ e^{-1} = \\text{id}$, i.e., $e(e^{-1}(n)) = n$ for all $n$.",
+    "significance": "key",
+    "relatedConcepts": ["Equiv.apply_symm_apply", "OneOneEquiv", "OneOneReducible", "Computable.symm"],
+    "prerequisites": ["Equiv.Computable typeclass", "OneOneEquiv in Mathlib", "computable injections"]
+  },
+  {
+    "id": "ann-myhill-partial-inverse",
+    "proofId": "schroeder-bernstein-oq-03",
+    "range": { "startLine": 97, "endLine": 134 },
+    "type": "technique",
+    "title": "Partial Inverse via Nat.rfind — Infrastructure for the Hard Direction",
+    "content": "The partial inverse partialInverse(g)(m) = Nat.rfind(n ↦ decide(g(n) = m)) searches for a preimage of m under g using unbounded search. Three key lemmas are stated (with sorry): (1) partialInverse_partrec: if g is computable, the partial inverse is Partrec. (2) partialInverse_spec: if n ∈ partialInverse(g)(m), then g(n) = m. (3) partialInverse_dom: elements in range(g) have a defined partial inverse. The forward orbit fwdOrbit(f,g,n,k) = (g∘f)^k(n) is defined by recursion. isGFree(g)(n) captures that n ∉ range(g), the condition for Type A orbit classification.",
+    "mathContext": "Partial inverse: $g^{-1}(m) := \\mu n[g(n) = m]$ (least $n$ with $g(n) = m$ if one exists, undefined otherwise). By `Nat.rfind_mem`: $n \\in \\text{Nat.rfind}(P) \\iff P(n) = \\text{true} \\wedge \\forall m < n, P(m) = \\text{false}$. `Partrec.rfind` states: if $P : \\mathbb{N} \\to \\mathbb{N}$ is partial recursive, then $\\mu n[P(n) = 0]$ is partial recursive. Applied here: $(m, n) \\mapsto \\text{decide}(g(n) = m)$ is computable (as $g$ is computable), so $g^{-1}$ is `Partrec`.",
+    "significance": "key",
+    "relatedConcepts": ["Partrec.rfind", "Nat.rfind", "partial recursive functions", "Partrec typeclass", "computable partial functions"],
+    "prerequisites": ["Partrec vs Computable in Lean 4", "Nat.rfind unbounded search", "partial functions in type theory"]
+  },
+  {
+    "id": "ann-myhill-main-theorem",
+    "proofId": "schroeder-bernstein-oq-03",
+    "range": { "startLine": 136, "endLine": 183 },
+    "type": "theorem",
+    "title": "Myhill's Isomorphism Theorem — Full Statement with Hard Direction (sorry'd)",
+    "content": "The main theorem myhill_isomorphism states the full biconditional. The easy direction (←) immediately applies myhill_easy. The hard direction (→) is sorry'd with a detailed comment explaining the back-and-forth construction: at stage 2k, ensure k ∈ dom(σ); at stage 2k+1, ensure k ∈ range(σ). The priority argument uses: (a) each stage terminates by injectivity of f and g; (b) domain/range exhaustion covers all of ℕ; (c) the membership condition p(n) ↔ q(σ(n)) is preserved; (d) computability from partialInverse_partrec. The sorry covers approximately 200 lines of Partrec-based formalization.",
+    "mathContext": "Hard direction strategy: define $\\sigma$ via stage-by-stage extension. At each stage, either extend $\\sigma$'s domain (using $f$) or ensure an element is in $\\sigma$'s range (using $g^{-1}$). Orbit classification: for $n$, let $n_0 = n$, $n_1 = g^{-1}(n_0)$, $n_2 = f^{-1}(n_1)$, $n_3 = g^{-1}(n_2), \\ldots$ If the chain terminates because $n_k \\notin \\text{range}(g)$ (Type A) or $n_k \\notin \\text{range}(f)$ (Type B), or runs forever (Type C): use $\\sigma(n) = f(n)$ for Type A and C, $\\sigma(n) = g^{-1}(n)$ for Type B.",
+    "significance": "key",
+    "relatedConcepts": ["back-and-forth construction", "priority argument", "Friedberg-Muchnik", "orbit classification", "computable bijection"],
+    "prerequisites": ["partial recursive functions", "back-and-forth method", "injectivity arguments", "partialInverse_partrec"]
+  },
+  {
+    "id": "ann-myhill-equivalence-relation",
+    "proofId": "schroeder-bernstein-oq-03",
+    "range": { "startLine": 186, "endLine": 234 },
+    "type": "insight",
+    "title": "Computable Isomorphism is an Equivalence Relation",
+    "content": "Six theorems establish the equivalence-relation structure. myhill_self: use the identity permutation (Equiv.refl ℕ, trivially computable, trivially maps p to p). myhill_symm: if e witnesses p ≃_c q, then e.symm witnesses q ≃_c p (using the same Computable pair with .symm). myhill_trans: if e₁ witnesses p ≃_c q and e₂ witnesses q ≃_c r, then e₁.trans e₂ witnesses p ≃_c r (using Computable.trans, and (hpq n).trans (hqr (e₁ n)) for the correspondence). computable_iso_is_equivalence packages these into the Mathlib Equivalence structure.",
+    "mathContext": "Reflexivity: $e = \\text{id}$, $p(n) \\leftrightarrow p(\\text{id}(n)) = p(n)$ by `Iff.rfl`. Symmetry: $p(n) \\leftrightarrow q(e(n)) \\Rightarrow q(m) \\leftrightarrow p(e^{-1}(m))$ by substituting $n = e^{-1}(m)$. Transitivity: $p(n) \\leftrightarrow q(e_1(n)) \\leftrightarrow r(e_2(e_1(n))) = r((e_1 \\circ e_2)(n))$ using `Iff.trans`. Composition of computable functions is computable: `he₁.trans he₂`.",
+    "significance": "supporting",
+    "relatedConcepts": ["Equivalence in Lean 4", "Equiv.refl", "Equiv.trans", "Computable.trans", "one-one degrees"],
+    "prerequisites": ["Equivalence typeclass in Lean 4", "Equiv.Computable", "Iff.rfl and Iff.trans"]
+  },
+  {
+    "id": "ann-myhill-special-cases",
+    "proofId": "schroeder-bernstein-oq-03",
+    "range": { "startLine": 238, "endLine": 257 },
+    "type": "insight",
+    "title": "Fixed Points: ∅ and ℕ Are the Extreme One-One Degree Classes",
+    "content": "The empty predicate (⊥) and universal predicate (⊤) are fixed points of computable isomorphism: any computable permutation maps ∅ to ∅ and ℕ to ℕ. Proof for ∅: if e maps ⊥ to p (meaning False ↔ p(e(n)) for all n), then for any m, surjectivity gives m = e(k) for some k, so p(m) = p(e(k)) ↔ False is False. Proof for ⊤: dual argument. These are the minimum and maximum in the one-one degree hierarchy, and they cannot be computably isomorphic to any other predicate.",
+    "mathContext": "Surjectivity of $e : \\mathbb{N} \\simeq \\mathbb{N}$: $\\forall m, \\exists k, e(k) = m$ (used as `e.surjective`). For the empty case: $\\text{False} \\leftrightarrow p(e(k))$ means $p(e(k)) = \\text{False}$; with $e(k) = m$ arbitrary, $p(m) = \\text{False}$. The one-one degrees form a partially ordered set (under $\\leq_1$) with $[\\emptyset]_1$ as minimum and $[\\mathbb{N}]_1$ as maximum.",
+    "significance": "supporting",
+    "relatedConcepts": ["Equiv.surjective", "one-one degrees", "creative sets", "simple sets", "completeness in reducibility"],
+    "prerequisites": ["Equiv surjectivity", "one-one degree hierarchy", "Post's problem context"]
+  }
+]

--- a/src/data/proofs/schroeder-bernstein-oq-03/index.ts
+++ b/src/data/proofs/schroeder-bernstein-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/SchroederBernsteinOQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const schroederBernsteinOQ03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const schroederBernsteinOQ03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const schroederBernsteinOQ03Data: ProofData = {
+  proof: schroederBernsteinOQ03Proof,
+  annotations: schroederBernsteinOQ03Annotations,
+}

--- a/src/data/proofs/schroeder-bernstein-oq-03/meta.json
+++ b/src/data/proofs/schroeder-bernstein-oq-03/meta.json
@@ -16,8 +16,9 @@
       "set-theory",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "original",
     "sorries": 4,
+    "axiomCount": 0,
     "mathlibDependencies": [
       {
         "theorem": "OneOneReducible",
@@ -51,8 +52,129 @@
       "Hard direction of Myhill's theorem: construct computable bijection from computable injections via back-and-forth priority argument (~200 lines of Partrec-based formalization)"
     ]
   },
+  "overview": {
+    "historicalContext": "John Myhill (1923–1987) published his isomorphism theorem in 1955 as part of developing the theory of creative sets and degrees of unsolvability. The theorem arose from the study of one-one reducibility ($\\leq_1$), a refinement of many-one reducibility where the reduction function must be injective. Myhill's key insight was that $p \\equiv_1 q$ — equivalence under mutual one-one reducibility — is precisely captured by the existence of a computable permutation mapping $p$ to $q$. This is the effective analogue of the classical Cantor-Schröder-Bernstein theorem: just as two classical injections yield a classical bijection, two computable injections yield a computable bijection. The back-and-forth proof technique Myhill used is a simplified version of what would become the priority method — the same back-and-forth orbit analysis Friedberg and Muchnik would generalize in 1956 to solve Post's problem (the existence of incomparable Turing degrees). Rogers' *Theory of Recursive Functions and Effective Computability* (MIT Press, 1967, §7.4, Theorem VII) gave the classical treatment, and Soare's *Turing Computability* (Springer, 2016, Chapter 3) is the modern reference. Formalizing this theorem in Lean 4 requires Mathlib's `Partrec` and `Computable` typeclasses, which were introduced to handle the boundary between total and partial recursive functions.",
+    "problemStatement": "For predicates $p, q : \\mathbb{N} \\to \\text{Prop}$, define one-one reducibility $p \\leq_1 q$ if there exists a computable injective $f : \\mathbb{N} \\to \\mathbb{N}$ such that $\\forall n,\\, p(n) \\leftrightarrow q(f(n))$. Define one-one equivalence $p \\equiv_1 q$ if $p \\leq_1 q$ and $q \\leq_1 p$. **Myhill's theorem**: $p \\equiv_1 q$ if and only if there exists a computable permutation $e : \\mathbb{N} \\simeq \\mathbb{N}$ (with both $e$ and $e^{-1}$ computable) such that $\\forall n,\\, p(n) \\leftrightarrow q(e(n))$.",
+    "proofStrategy": "Two directions. **Easy direction** ($\\Leftarrow$, fully proved): Given computable bijection $e$, use $e$ to witness $p \\leq_1 q$ (injective, computable, maps $p$ to $q$) and $e^{-1}$ to witness $q \\leq_1 p$. This requires only that $e^{-1}$ is also computable, which holds by hypothesis. **Hard direction** ($\\Rightarrow$, sorry'd): Given computable injections $f: p \\leq_1 q$ and $g: q \\leq_1 p$, classify each $n \\in \\mathbb{N}$ by its backward orbit under alternating $g^{-1}, f^{-1}$: Type A (chain terminates outside $\\text{range}(g)$) uses $\\sigma(n) := f(n)$; Type B (terminates outside $\\text{range}(f)$) uses $g^{-1}(n)$; Type C (infinite orbit) uses $f(n)$. This constructs a total computable bijection. Computability uses `Partrec.rfind` for partial inverses. The formalization provides all infrastructure (partial inverse, orbit definition, `isGFree` predicate) for the hard direction.",
+    "keyInsights": [
+      "Myhill's theorem is the computability-theoretic analogue of Cantor-Schröder-Bernstein: two computable injections yield a computable bijection — lifting a classical set-theoretic fact into the effective (algorithmic) realm",
+      "One-one reducibility ($\\leq_1$) is strictly finer than many-one reducibility ($\\leq_m$): $f$ must be injective. Myhill's theorem characterizes the $\\equiv_1$ equivalence classes as exactly the computable isomorphism classes — a deep structural result about the fine structure of degrees",
+      "The partial inverse $g^{-1}(m) = \\mu n[g(n) = m]$ (computable via `Nat.rfind`) is the key technical tool: it lets the back-and-forth construction 'step backward' along $g$, and its partial recursiveness (not total computability) is precisely why the construction requires `Partrec` rather than `Computable`",
+      "The back-and-forth orbit classification (Type A/B/C) is a finite-priority precursor to the Friedberg-Muchnik priority method (1956). Understanding Myhill's construction is the natural stepping-stone to formalizing infinite-injury priority arguments",
+      "Lean 4's `Equiv.Computable` captures exactly the right notion: a computable permutation requires both $e$ and $e^{-1}$ to be computable — this is non-trivial since a computable bijection can have a non-computable inverse in general (though not for permutations of $\\mathbb{N}$ with decidable range)",
+      "The corollaries (reflexivity via identity, symmetry via inverse, transitivity via composition) show that computable isomorphism is a genuine equivalence relation on predicates — paving the way for quotient structures over the one-one degrees"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-docstring",
+      "title": "Imports and Module Overview",
+      "startLine": 1,
+      "endLine": 62,
+      "summary": "Imports Mathlib computability modules. Module docstring explains the theorem statement, the easy vs hard directions, the orbit classification for the back-and-forth argument (Type A/B/C), and references to Myhill (1955), Rogers (1967), and Soare (2016).",
+      "mathContext": "The theorem: $p \\equiv_1 q \\iff \\exists$ computable permutation $e$ with $\\forall n, p(n) \\leftrightarrow q(e(n))$. One-one equivalence: $p \\equiv_1 q$ means $\\exists$ computable injective $f$ with $p \\leftrightarrow q \\circ f$ AND $\\exists$ computable injective $g$ with $q \\leftrightarrow p \\circ g$."
+    },
+    {
+      "id": "setup",
+      "title": "Section 1: Setup — Corresponds Predicate",
+      "startLine": 64,
+      "endLine": 70,
+      "summary": "Defines the Corresponds predicate: p Corresponds e q means ∀ n, p n ↔ q (e n). This captures that a permutation e maps p to q setwise.",
+      "mathContext": "Corresponds $(p, e, q) \\equiv \\forall n, p(n) \\leftrightarrow q(e(n))$. Abstracting this as a named predicate simplifies theorem statements and allows rewriting. It expresses that $e$ is a 'computable isomorphism' between the characteristic functions $p$ and $q$."
+    },
+    {
+      "id": "easy-direction",
+      "title": "Section 2: Easy Direction (Computable Bijection → OneOneEquiv)",
+      "startLine": 73,
+      "endLine": 94,
+      "summary": "Proves the easy direction: a computable bijection e with Corresponds p e q implies OneOneEquiv p q. Uses e for p ≤₁ q and e.symm for q ≤₁ p. Also proves a variant with explicit Computable hypotheses.",
+      "mathContext": "Given $e : \\mathbb{N} \\simeq \\mathbb{N}$ with $e.\\text{Computable}$ (both $e$ and $e^{-1}$ computable) and $\\forall n, p(n) \\leftrightarrow q(e(n))$: use $(e, \\text{injective}, \\text{computable})$ to witness $p \\leq_1 q$; use $(e^{-1}, \\text{injective}, \\text{computable})$ and the identity $q(m) \\leftrightarrow p(e^{-1}(m))$ (from $e(e^{-1}(m)) = m$) to witness $q \\leq_1 p$."
+    },
+    {
+      "id": "partial-inverse",
+      "title": "Section 3: Infrastructure — Partial Inverses and Orbits",
+      "startLine": 97,
+      "endLine": 134,
+      "summary": "Defines the partial inverse g⁻¹(m) = Nat.rfind(n ↦ g(n) = m) and states three key lemmas: partial inverse is Partrec (sorry'd), recovers the input under injection (sorry'd), and is defined on elements in range(g) (sorry'd). Also defines the forward orbit (g∘f)^k(n) and the isGFree predicate for orbit classification.",
+      "mathContext": "$g^{-1}(m) := \\mu n[g(n) = m]$ (partial recursive unbounded search). By `Partrec.rfind`, since $(m, n) \\mapsto \\text{decide}(g(n) = m)$ is computable (as $g$ is computable), $g^{-1}$ is partial recursive. For injective $g$: $n \\in g^{-1}(m) \\Rightarrow g(n) = m$. Forward orbit: $\\text{fwdOrbit}(f, g, n, k) = (g \\circ f)^k(n)$. isGFree: $n$ is not in $\\text{range}(g)$."
+    },
+    {
+      "id": "myhill-main",
+      "title": "Section 4–5: Myhill's Isomorphism Theorem",
+      "startLine": 136,
+      "endLine": 183,
+      "summary": "States and partially proves Myhill's theorem. The easy direction (←) follows immediately from myhill_easy. The hard direction (→) has a sorry covering the back-and-forth priority construction: classify orbits, define σ using f or g⁻¹ according to orbit type, prove σ is total, bijective, computable, and maps p to q.",
+      "mathContext": "Hard direction plan: given $f: p \\leq_1 q$ and $g: q \\leq_1 p$, for each $n$ trace backward: $n \\leftarrow g^{-1}(n) \\leftarrow f^{-1}(g^{-1}(n)) \\leftarrow \\cdots$. Type A (terminates not in range($g$)): $\\sigma(n) := f(n)$. Type B (terminates not in range($f$)): $\\sigma(n) := g^{-1}(n)$. Type C (infinite): $\\sigma(n) := f(n)$. Each stage terminates by injectivity; the construction is computable by `partialInverse_partrec`."
+    },
+    {
+      "id": "corollaries",
+      "title": "Sections 6–7: Corollaries — Equivalence Relation",
+      "startLine": 186,
+      "endLine": 234,
+      "summary": "Proves that computable isomorphism is an equivalence relation: reflexivity (identity permutation), symmetry (inverse permutation), transitivity (composition). Also exposes the two directions of Myhill's theorem as standalone lemmas and packages all three properties as an Equivalence instance.",
+      "mathContext": "Reflexivity: $p \\simeq_c p$ via $\\text{id} : \\mathbb{N} \\simeq \\mathbb{N}$ (identity is computable, trivially $p(n) \\leftrightarrow p(n)$). Symmetry: if $p \\simeq_c q$ via $e$, then $q \\simeq_c p$ via $e^{-1}$ (computable by hypothesis; $q(n) \\leftrightarrow p(e^{-1}(n))$ by applying $e^{-1}$ to the correspondence). Transitivity: if $p \\simeq_c q$ via $e_1$ and $q \\simeq_c r$ via $e_2$, then $p \\simeq_c r$ via $e_1 \\circ e_2$."
+    },
+    {
+      "id": "special-cases",
+      "title": "Section 8: Key Special Cases",
+      "startLine": 238,
+      "endLine": 257,
+      "summary": "Proves that ∅ and ℕ (the empty and universal predicates) are fixed points of computable isomorphism: any computable permutation maps ∅ to ∅ and ℕ to ℕ. These are the extreme cases in the one-one degree hierarchy.",
+      "mathContext": "For the empty predicate $p = \\bot$: if $e$ maps $\\bot$ to $q$ (meaning $\\bot(n) \\leftrightarrow q(e(n))$), then $q(m) = \\bot$ for all $m$ (surjectivity of $e$). Dually for $p = \\top$. These facts follow from surjectivity of $e$ as a bijection."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "schroeder-bernstein",
+      "relationship": "extends",
+      "description": "Parent proof: classical Cantor-Schröder-Bernstein theorem — Myhill's theorem is its computable analogue"
+    },
+    {
+      "targetId": "schroeder-bernstein-oq-02",
+      "relationship": "related",
+      "description": "Knaster-Tarski proof of CBS — an alternative classical proof approach to the parent theorem"
+    },
+    {
+      "targetId": "schroeder-bernstein-oq-04",
+      "relationship": "related",
+      "description": "Constructive CBS for finite types — another effective analogue in a different setting"
+    }
+  ],
+  "conclusion": {
+    "summary": "This formalization proves the easy direction of Myhill's 1955 Isomorphism Theorem and the full equivalence-relation structure of computable isomorphism. The hard direction — constructing a computable bijection from two computable injections via the back-and-forth priority argument — has 4 sorries covering the partial inverse computability proof and the main construction. All infrastructure (partial inverses via `Nat.rfind`, forward orbits, `isGFree` predicate) is in place for completing the hard direction.",
+    "implications": "Myhill's theorem is a cornerstone of classical recursion theory: it shows that the one-one degrees have a finer structure than many-one degrees, and that 'computable isomorphism' is the right equivalence relation on decidable sets. Formalizing it in Lean 4 validates that Mathlib's computability library (`Partrec`, `Computable`, `OneOneReducible`) is expressive enough for serious recursion theory. The equivalence-relation proof has immediate applications: it enables quotient constructions over the one-one degrees, and the computable isomorphism type forms the basis for studying creative sets, simple sets, and other index-set hierarchies in effective mathematics.",
+    "openQuestions": [
+      "Can the hard direction be completed by formalizing the back-and-forth priority construction in Lean 4, using `Partrec` throughout and avoiding the oracle-computation machinery of Turing reducibility?",
+      "Does Myhill's theorem generalize to computable metric spaces or effective Polish spaces, where 'computable bijection' has a topological meaning (computable homeomorphism)?",
+      "Is there a connection between Myhill isomorphism and the Borel isomorphism theorem (any two uncountable standard Borel spaces are Borel isomorphic), via the analogy between computable functions and Borel maps?"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Myhill, J.",
+      "title": "Creative sets",
+      "year": 1955,
+      "journal": "Zeitschrift für mathematische Logik und Grundlagen der Mathematik",
+      "volume": "1",
+      "pages": "97–108",
+      "note": "Original paper introducing Myhill's isomorphism theorem"
+    },
+    {
+      "authors": "Rogers, H.",
+      "title": "Theory of Recursive Functions and Effective Computability",
+      "year": 1967,
+      "publisher": "MIT Press",
+      "note": "Chapter 7, §7.4, Theorem VII — classical treatment"
+    },
+    {
+      "authors": "Soare, R.",
+      "title": "Turing Computability: Theory and Applications",
+      "year": 2016,
+      "publisher": "Springer",
+      "note": "Chapter 3 — modern treatment"
+    }
+  ],
   "sorries": 4,
-  "axiomCount": 0,
   "parentId": "schroeder-bernstein",
   "openQuestionId": "oq-03",
   "theorems": [


### PR DESCRIPTION
Full enrichment for schroeder-bernstein-oq-03 (Myhill's Isomorphism Theorem, 1955). This entry was at quality 0 with only a stub meta.json.

## What was added

### index.ts (new)
The proof was unreachable on the live site — index.ts was missing. Created with correct SchroederBernsteinOQ03.lean import and camelCase exports.

### annotations.json (new)
7 annotations covering all 8 Lean sections:
- Docstring context: one-one reducibility definition, back-and-forth orbit types
- Corresponds definition: set-theoretic meaning
- Easy direction: proof walkthrough with e(e⁻¹(n)) = n cancellation
- Partial inverse (hard-direction infrastructure): Nat.rfind as μn[g(n) = m], Partrec.rfind application
- Main theorem: orbit classification (Type A/B/C) with LaTeX
- Equivalence relation: reflexivity/symmetry/transitivity with Iff proofs
- Special cases: surjectivity argument for ∅ and ℕ as fixed points

### meta.json (major expansion)
- historicalContext: Myhill (1955), connection to priority method, Friedberg-Muchnik (1956), Rogers and Soare references
- problemStatement: formal LaTeX definition of ≤₁ and the permutation characterization
- proofStrategy: easy and hard directions, orbit classification
- 6 keyInsights: CBS analogy, degree fine structure, partial inverse as key tool, priority method connection, Equiv.Computable semantics, equivalence relation structure
- sections: all 8 Lean sections with mathContext
- conclusion: summary, implications, 3 open questions
- crossReferences: parent (schroeder-bernstein), siblings (oq-02, oq-04)
- references: full bibliographic details for Myhill 1955, Rogers 1967, Soare 2016

## Badge integrity fix

Changed badge: "verified" → badge: "original". The stub had status: "formalized" (4 sorries) with badge: "verified" — contradictory per axiom integrity policy. Badge "verified" implies 0 sorries. Correct badge for original formalization with sorries is "original".