### PR TITLE
Research: ballot-problem — prove hook formula for single-row diagrams

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean
@@ -274,7 +274,202 @@ theorem hook_length_formula_from_chain (μ : YoungDiagram)
   exact_mod_cast key
 
 -- ============================================================
--- PART VI: Numerical Verification
+-- PART VI: Hook-Length Formula for Single-Row Diagrams (Direct)
+-- ============================================================
+
+/-
+  For the single-row Young diagram with n cells, we prove the hook-length formula
+  **directly** (without LGV):
+  - hookLength(0,j) = n - j, so hookProd = n × (n-1) × ... × 1 = n!
+  - The unique SYT is entry(0,j) = j+1 (strictly increasing identity filling)
+  - Hence 1 × n! = n! ✓
+
+  This serves as a concrete verified instance of hook_length_formula.
+-/
+
+/-- The Young diagram with a single row of length n. Cells: {(0,j) | j < n}. -/
+def oneRowYD (n : ℕ) : YoungDiagram :=
+  YoungDiagram.ofRowLens [n] (by simp [List.SortedGE])
+
+/-- Membership in oneRowYD: (i,j) ∈ oneRowYD n ↔ i = 0 ∧ j < n -/
+lemma mem_oneRowYD {n i j : ℕ} : (i, j) ∈ oneRowYD n ↔ i = 0 ∧ j < n := by
+  simp only [oneRowYD, YoungDiagram.mem_ofRowLens, List.length_singleton]
+  constructor
+  · rintro ⟨hi, hj⟩
+    have hi0 : i = 0 := by omega
+    subst hi0
+    exact ⟨rfl, by simpa [List.getElem_cons_zero] using hj⟩
+  · rintro ⟨rfl, hj⟩
+    exact ⟨by omega, by simpa [List.getElem_cons_zero] using hj⟩
+
+/-- Card of oneRowYD n is n. -/
+lemma oneRowYD_card (n : ℕ) : (oneRowYD n).card = n := by
+  have hcells : (oneRowYD n).cells = (Finset.range n).image (Prod.mk 0) := by
+    ext ⟨i, j⟩
+    simp [YoungDiagram.mem_cells, mem_oneRowYD, Finset.mem_image, Finset.mem_range]
+    constructor
+    · rintro ⟨rfl, hj⟩; exact ⟨j, hj, rfl, rfl⟩
+    · rintro ⟨k, hk, rfl, rfl⟩; exact ⟨rfl, hk⟩
+  unfold YoungDiagram.card
+  rw [hcells, Finset.card_image_of_injective _ (fun a b h => (Prod.mk.inj h).2),
+    Finset.card_range]
+
+/-- Row length of row 0 in oneRowYD n is n. -/
+lemma rowLen_oneRowYD_zero (n : ℕ) : (oneRowYD n).rowLen 0 = n := by
+  apply Nat.le_antisymm
+  · -- rowLen 0 ≤ n: (0, n) ∉ oneRowYD n, so n ≥ rowLen 0
+    rw [← not_lt, ← YoungDiagram.mem_iff_lt_rowLen]
+    simp [mem_oneRowYD]
+  · -- n ≤ rowLen 0: (0, n-1) ∈ oneRowYD n gives n-1 < rowLen 0
+    cases n with
+    | zero => simp
+    | succ n =>
+      have := YoungDiagram.mem_iff_lt_rowLen.mp (mem_oneRowYD.mpr ⟨rfl, n.lt_succ_self⟩)
+      omega
+
+/-- Column length of column j in oneRowYD n is 1 when j < n. -/
+lemma colLen_oneRowYD {n j : ℕ} (hj : j < n) : (oneRowYD n).colLen j = 1 := by
+  apply Nat.le_antisymm
+  · -- colLen j ≤ 1: (1, j) ∉ oneRowYD n
+    rw [← not_lt, ← YoungDiagram.mem_iff_lt_colLen]
+    simp [mem_oneRowYD]
+  · -- 1 ≤ colLen j: (0, j) ∈ oneRowYD n gives 0 < colLen j
+    have h0 : 0 < (oneRowYD n).colLen j :=
+      YoungDiagram.mem_iff_lt_colLen.mp (mem_oneRowYD.mpr ⟨rfl, hj⟩)
+    omega
+
+/-- Hook length at cell (0, j) in oneRowYD n is n - j. -/
+lemma hookLength_oneRowYD {n j : ℕ} (hj : j < n) :
+    hookLength (oneRowYD n) 0 j = n - j := by
+  have hcell : (0, j) ∈ oneRowYD n := mem_oneRowYD.mpr ⟨rfl, hj⟩
+  have heq := hookLength_add_eq (oneRowYD n) hcell
+  rw [rowLen_oneRowYD_zero, colLen_oneRowYD hj] at heq
+  omega
+
+/-- Hook product of oneRowYD n equals n!.
+    Proof: hookLength(0,j) = n-j, so hookProd = ∏ₙ(n-j) = n.descFactorial n = n! -/
+theorem hookProd_oneRowYD (n : ℕ) : hookProd (oneRowYD n) = n.factorial := by
+  have hcells : (oneRowYD n).cells = (Finset.range n).image (Prod.mk 0) := by
+    ext ⟨i, j⟩
+    simp [YoungDiagram.mem_cells, mem_oneRowYD, Finset.mem_image, Finset.mem_range]
+    constructor
+    · rintro ⟨rfl, hj⟩; exact ⟨j, hj, rfl, rfl⟩
+    · rintro ⟨k, hk, rfl, rfl⟩; exact ⟨rfl, hk⟩
+  unfold hookProd
+  rw [hcells, Finset.prod_image (fun a _ b _ h => (Prod.mk.inj h).2)]
+  -- Goal: ∏ j ∈ range n, hookLength (oneRowYD n) (Prod.mk 0 j).1 (Prod.mk 0 j).2 = n!
+  -- (Prod.mk 0 j).1 = 0 and (Prod.mk 0 j).2 = j definitionally:
+  show ∏ j ∈ Finset.range n, hookLength (oneRowYD n) 0 j = n.factorial
+  -- Rewrite hookLength(0,j) = n-j, then use descFactorial identity
+  rw [Finset.prod_congr rfl (fun j hj => hookLength_oneRowYD (Finset.mem_range.mp hj)),
+      ← Nat.descFactorial_eq_prod_range]
+  exact Nat.descFactorial_self n
+
+-- ========================
+-- Unique SYT for single row
+-- ========================
+
+/-- The identity filling for oneRowYD n: cell (0,j) gets entry j+1. -/
+private def oneRowSYT (n : ℕ) : StandardYoungTableau (oneRowYD n) where
+  entry := fun c => if c.1 = 0 ∧ c.2 < n then c.2 + 1 else 0
+  entry_zero := fun ⟨i, j⟩ hc => if_neg (mt mem_oneRowYD.mpr hc)
+  entry_range := by
+    intro ⟨i, j⟩ hc
+    rw [mem_oneRowYD] at hc
+    show 1 ≤ (if i = 0 ∧ j < n then j + 1 else 0) ∧
+         (if i = 0 ∧ j < n then j + 1 else 0) ≤ (oneRowYD n).card
+    rw [if_pos hc, oneRowYD_card]
+    omega
+  entry_injOn := by
+    intro ⟨i₁, j₁⟩ hc₁ ⟨i₂, j₂⟩ hc₂ h
+    rw [mem_oneRowYD] at hc₁ hc₂
+    show (i₁, j₁) = (i₂, j₂)
+    simp only [if_pos hc₁, if_pos hc₂] at h
+    exact Prod.mk.inj_iff.mpr ⟨hc₁.1.trans hc₂.1.symm, by omega⟩
+  row_strict := by
+    intro i j₁ j₂ hc₁ hc₂ hjlt
+    rw [mem_oneRowYD] at hc₁ hc₂
+    show (if i = 0 ∧ j₁ < n then j₁ + 1 else 0) < (if i = 0 ∧ j₂ < n then j₂ + 1 else 0)
+    rw [if_pos hc₁, if_pos hc₂]
+    omega
+  col_strict := by
+    intro i₁ i₂ j hc₁ hc₂ hilt
+    rw [mem_oneRowYD] at hc₁ hc₂
+    -- hc₁.1 : i₁ = 0, hc₂.1 : i₂ = 0, but hilt : i₁ < i₂, so 0 < 0 → False
+    omega
+
+/-- Helper: entries of any SYT of a single-row diagram satisfy entry(0,j) = j+1. -/
+private lemma entry_oneRow_eq (n : ℕ) (T : StandardYoungTableau (oneRowYD n))
+    (j : ℕ) (hj : j < n) : T.entry (0, j) = j + 1 := by
+  have hcell : (0, j) ∈ oneRowYD n := mem_oneRowYD.mpr ⟨rfl, hj⟩
+  -- Lower bound: j+1 ≤ T.entry(0,j) by induction on j using row_strict
+  -- (Generalize over all k < n to get a proper IH)
+  have hlb : j + 1 ≤ T.entry (0, j) := by
+    suffices h : ∀ k < n, k + 1 ≤ T.entry (0, k) from h j hj
+    intro k
+    induction k with
+    | zero => intro hk0; exact (T.entry_range (0, 0) (mem_oneRowYD.mpr ⟨rfl, hk0⟩)).1
+    | succ k ih =>
+      intro hk
+      have hk' : k < n := by omega
+      have hstep := T.row_strict 0 k (k + 1)
+        (mem_oneRowYD.mpr ⟨rfl, hk'⟩) (mem_oneRowYD.mpr ⟨rfl, hk⟩) k.lt_succ_self
+      linarith [ih hk']
+  -- Upper bound: T.entry(0,j) ≤ j+1 using strict chain from j to n-1
+  have hub : T.entry (0, j) ≤ j + 1 := by
+    -- Key: T.entry(0,j) + k ≤ T.entry(0,j+k) for all k ≤ n-1-j
+    have hchain : ∀ k, k ≤ n - 1 - j → T.entry (0, j) + k ≤ T.entry (0, j + k) := by
+      intro k
+      induction k with
+      | zero => intro _; simp
+      | succ k ih =>
+        intro hk
+        have hk' : k ≤ n - 1 - j := by omega
+        have hjk : j + k < n := by omega
+        have hjk1 : j + k + 1 < n := by omega
+        have hstep := T.row_strict 0 (j + k) (j + k + 1)
+          (mem_oneRowYD.mpr ⟨rfl, hjk⟩) (mem_oneRowYD.mpr ⟨rfl, hjk1⟩) (by omega)
+        linarith [ih hk']
+    rcases Nat.eq_zero_or_pos n with hn | hn
+    · omega
+    · have hk := hchain (n - 1 - j) le_rfl
+      have hidx : j + (n - 1 - j) = n - 1 := by omega
+      rw [hidx] at hk
+      have hub_last : T.entry (0, n - 1) ≤ (oneRowYD n).card :=
+        (T.entry_range (0, n - 1) (mem_oneRowYD.mpr ⟨rfl, by omega⟩)).2
+      rw [oneRowYD_card] at hub_last
+      omega
+  omega
+
+/-- Every SYT of oneRowYD n equals oneRowSYT n. -/
+private lemma oneRowSYT_unique (n : ℕ) (T : StandardYoungTableau (oneRowYD n)) :
+    T = oneRowSYT n := by
+  apply StandardYoungTableau.ext
+  intro ⟨i, j⟩
+  by_cases h : (i, j) ∈ oneRowYD n
+  · -- In the diagram: T.entry(0,j) = j+1 = (oneRowSYT n).entry(0,j)
+    rw [mem_oneRowYD] at h
+    subst h.1
+    rw [entry_oneRow_eq n T j h.2]
+    -- (oneRowSYT n).entry (0,j) = if 0=0 ∧ j<n then j+1 else 0 = j+1
+    show j + 1 = if (0 : ℕ) = 0 ∧ j < n then j + 1 else 0
+    exact (if_pos ⟨rfl, h.2⟩).symm
+  · -- Not in diagram: both entries are 0
+    rw [T.entry_zero _ h]
+    show (0 : ℕ) = if i = 0 ∧ j < n then j + 1 else 0
+    exact (if_neg (mt mem_oneRowYD.mpr h)).symm
+
+/-- **Hook-length formula for single-row Young diagrams.**
+    card(SYT(oneRowYD n)) × hookProd(oneRowYD n) = n!
+    Proved directly: unique SYT with entry(0,j)=j+1, hookProd = n! -/
+theorem hook_length_formula_one_row (n : ℕ) :
+    Fintype.card (StandardYoungTableau (oneRowYD n)) * hookProd (oneRowYD n) = n.factorial := by
+  have hcard : Fintype.card (StandardYoungTableau (oneRowYD n)) = 1 :=
+    Fintype.card_eq_one_iff.mpr ⟨oneRowSYT n, oneRowSYT_unique n⟩
+  rw [hcard, one_mul, hookProd_oneRowYD]
+
+-- ============================================================
+-- PART VII: Numerical Verification
 -- ============================================================
 -- Verify the hook-length formula for specific shapes via norm_num.
 -- hookProd computation: ∏ hook lengths over all cells.

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/knowledge.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/knowledge.md
@@ -110,7 +110,67 @@ BallotProblemOQ03OQ01OQ02.lean
 
 ---
 
+## Session 2026-04-21 (Session 2) - Single-Row Hook Formula Proved Directly
+
+**Mode**: REVISIT
+**Outcome**: PROGRESS — `hook_length_formula_one_row` proved (~190 lines, 0 sorries)
+
+### What I Did
+
+1. Assessed PART V LGV chain: `ni_count_eq_syt_count` and `lgv_det_factors_as_hook_quotient`
+   are missing because `μ` is disconnected from the `(r, σ, m)` parameters — the LGV lemma
+   uses a specific `youngLGVConfig` but μ is arbitrary. This makes the chain mathematically incoherent.
+2. Strategic pivot: instead of continuing the LGV path (two HARD sorries), proved the
+   hook-length formula for single-row Young diagrams directly without LGV.
+3. Added PART VI (~190 lines) to `BallotProblemOQ03OQ01OQ02.lean`:
+   - `oneRowYD n`: `YoungDiagram.ofRowLens [n] (...)` — single-row shape
+   - `mem_oneRowYD`: `(i,j) ∈ oneRowYD n ↔ i = 0 ∧ j < n`
+   - `oneRowYD_card`: card = n (via Finset.card_image_of_injective)
+   - `rowLen_oneRowYD_zero`: rowLen 0 = n
+   - `colLen_oneRowYD`: colLen j = 1 for j < n
+   - `hookLength_oneRowYD`: hookLength(0,j) = n - j (uses `hookLength_add_eq`)
+   - `hookProd_oneRowYD`: hookProd = n! (via `descFactorial_eq_prod_range` + `descFactorial_self`)
+   - `oneRowSYT n`: the unique SYT with `entry(0,j) = j+1`
+   - `entry_oneRow_eq`: any SYT has `entry(0,j) = j+1` (double induction: lower by IH on j, upper by chain)
+   - `oneRowSYT_unique`: all SYTs of oneRowYD n equal oneRowSYT n
+   - `hook_length_formula_one_row`: `card(SYT(oneRowYD n)) × hookProd(oneRowYD n) = n!` (0 sorries!)
+
+### Key Findings
+
+**Direct path avoids LGV entirely**: For single-row μ, we don't need LGV/RSK/Vandermonde.
+The proof is elementary and fully verified.
+
+**Uniqueness proof technique**: Double induction — lower bound by induction on j using `row_strict`
+(each next entry is strictly larger), upper bound by chain argument (entries form a chain bounded
+by `entry_range` at the last cell). Together these pin each entry exactly.
+
+**Key lemmas used**:
+- `hookLength_add_eq (μ : YoungDiagram) : (i,j) ∈ μ → hookLength μ i j + 1 = rowLen i - j + colLen j`
+- `Nat.descFactorial_eq_prod_range : n.descFactorial k = ∏ i ∈ range k, (n - i)`
+- `Nat.descFactorial_self n : n.descFactorial n = n!`
+- `YoungDiagram.mem_iff_lt_rowLen`, `YoungDiagram.mem_iff_lt_colLen`
+
+**Error patterns resolved**:
+- `List.getElem_cons_zero` needed to simplify `[n][0] = n` in `mem_oneRowYD`
+- `if_neg (mt mem_oneRowYD.mpr hc)` for `entry_zero` — cleaner than push_neg
+- `if_pos hc` after `rw [mem_oneRowYD] at hc` for in-diagram cases
+- `suffices h : ∀ k < n, ...` to get proper IH for lower bound induction
+
+### Files Modified
+
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean` (315 → ~505 lines, PART VI added, 0 sorries)
+
+### Next Steps
+
+1. **Prove single-column case**: `hook_length_formula_one_col` similarly (column-symmetric)
+2. **Two-row hook formula**: May be achievable via direct bijection (RSK for 2-row shapes is explicit)
+3. **Consider Aristotle** for `ni_count_eq_syt_count` sub-lemmas if tackling LGV chain
+4. **Generalize**: Hook formula for rectangular shapes (direct counting argument)
+
+---
+
 ## Dead Ends
 
 - `lgv_det_factors_as_hook_quotient` with `=` and integer division `/` (reformulated to `*`)
 - `deriving Fintype` on StandardYoungTableau (impossible: infinite function field `entry : ℕ × ℕ → ℕ`)
+- LGV chain `ni_count_eq_syt_count` + `lgv_det_factors_as_hook_quotient`: μ disconnected from (r,σ,m)

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
@@ -44,12 +44,16 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: instFintypeSYT proved (critical infrastructure). hook_length_formula_bot proved (base case). hook_length_formula_from_chain proves main theorem FROM the two sorry lemmas, demonstrating logical chain is complete. Two deep sorry lemmas remain: RSK bijection and Vandermonde det identity.",
+    "progressSummary": "PROGRESS: hook_length_formula_one_row proved (0 sorries); LGV chain has 2 hard sorries",
     "builtItems": [
       "instFintypeSYT: Fintype instance for StandardYoungTableau (BallotProblemOQ03OQ01OQ02.lean, Part IIIb)",
       "emptyTableau: unique SYT of shape bot (BallotProblemOQ03OQ01OQ02.lean, Part IIIc)",
       "hook_length_formula_bot: proved theorem for empty diagram (BallotProblemOQ03OQ01OQ02.lean:hook_length_formula_bot)",
-      "hook_length_formula_from_chain: proved conditional theorem from two sorry lemmas (BallotProblemOQ03OQ01OQ02.lean:hook_length_formula_from_chain)"
+      "hook_length_formula_from_chain: proved conditional theorem from two sorry lemmas (BallotProblemOQ03OQ01OQ02.lean:hook_length_formula_from_chain)",
+      "oneRowYD, mem_oneRowYD, oneRowYD_card, rowLen_oneRowYD_zero, colLen_oneRowYD (PART VI infrastructure)",
+      "hookLength_oneRowYD, hookProd_oneRowYD — hook computations for single-row shape",
+      "oneRowSYT, entry_oneRow_eq, oneRowSYT_unique — SYT uniqueness machinery",
+      "hook_length_formula_one_row — verified instance of hook formula, 0 sorries"
     ],
     "insights": [
       "lgv_lemma_rxr in BallotProblemOQ03OQ02.lean is the key building block (Gessel-Viennot involution proof)",
@@ -59,7 +63,13 @@
       "hook_length_formula_bot: proved for empty diagram (base case, 1*1=0!=1)",
       "hook_length_formula_from_chain: proves main theorem FROM ni_count_eq_syt_count AND lgv_det_factors_as_hook_quotient — logical chain complete",
       "lgv_det_factors_as_hook_quotient reformulated as det*hookProd=n! (avoids integer division, cleaner than det=n!/hookProd)",
-      "Two sorry lemmas remain: RSK bijection (ni_count_eq_syt_count, ~200 lines) and Vandermonde-type det identity (lgv_det_factors_as_hook_quotient, ~200 lines)"
+      "Two sorry lemmas remain: RSK bijection (ni_count_eq_syt_count, ~200 lines) and Vandermonde-type det identity (lgv_det_factors_as_hook_quotient, ~200 lines)",
+      "Single-row hook formula proved directly without LGV: unique SYT entry(0,j)=j+1, hookProd=n!",
+      "oneRowYD n = YoungDiagram.ofRowLens [n] — ofRowLens is the right Mathlib constructor",
+      "hookLength_add_eq: hookLength μ i j + 1 = rowLen i - j + colLen j — key computation lemma",
+      "Nat.descFactorial_self n proves hookProd = n! via descFactorial_eq_prod_range",
+      "SYT uniqueness: lower bound by IH on row_strict, upper bound by chain to last cell",
+      "if_neg (mt mem_oneRowYD.mpr hc) is the clean pattern for entry_zero proofs"
     ],
     "mathlibGaps": [
       "hookLength may not be defined in Mathlib.Combinatorics.YoungDiagram — check arm/leg availability",


### PR DESCRIPTION
## Summary

- Proves `hook_length_formula_one_row` for single-row Young diagrams (0 sorries)
- Adds `oneRowYD n = YoungDiagram.ofRowLens [n] ...` and full membership/cardinality/hook infrastructure
- Proves `hookProd (oneRowYD n) = n!` via `descFactorial_eq_prod_range` + `descFactorial_self`
- Proves SYT uniqueness: `entry_oneRow_eq` (double induction) + `oneRowSYT_unique`
- Avoids blocked LGV chain (RSK + Vandermonde sorries remain open)

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.BallotProblemOQ03OQ01OQ02` — verify 0 sorry compile
- [ ] Confirm PART VI theorems appear under `HookLengthFormula` namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)