### PR TITLE
chore: sync research listings and data

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -14984,7 +14984,7 @@
     {
       "slug": "area-of-circle-oq-03-oq-03-oq-01",
       "id": "area-of-circle-oq-03-oq-03-oq-01",
-      "title": "Ellipse area \u03c0\u00b7a\u00b7b via Mathlib measure-theoretic change of variables",
+      "title": "Ellipse area π·a·b via Mathlib measure-theoretic change of variables",
       "status": "active",
       "tier": "B",
       "significance": 6,
@@ -15046,7 +15046,7 @@
       "started": "2026-04-05T22:23:02.409Z",
       "status": "active",
       "lastUpdate": "2026-04-05T22:26:32Z",
-      "notes": "Seeker selected: Fourier transform of Gaussian \u2014 removes gaussian_fourier_identity axiom from CLT proof"
+      "notes": "Seeker selected: Fourier transform of Gaussian — removes gaussian_fourier_identity axiom from CLT proof"
     },
     {
       "slug": "four-color-theorem-oq-02-oq-03",
@@ -16375,11 +16375,12 @@
     },
     {
       "slug": "erdos-840",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-04-13T22:43:37.492Z",
-      "status": "active",
-      "lastUpdate": "2026-04-13T22:43:37.492Z"
+      "status": "graduated",
+      "lastUpdate": "2026-04-21T17:34:57.408Z",
+      "completed": "2026-04-21T17:34:57.407Z"
     },
     {
       "slug": "erdos-678",
@@ -16867,11 +16868,12 @@
     },
     {
       "slug": "lovasz-local-lemma-oq-02-incomplete-01",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-04-21T15:44:50.655Z",
-      "status": "active",
-      "lastUpdate": "2026-04-21T15:44:50.678Z"
+      "status": "graduated",
+      "lastUpdate": "2026-04-21T17:34:57.464Z",
+      "completed": "2026-04-21T17:34:57.464Z"
     },
     {
       "slug": "feuerbachs-theorem-oq-02-incomplete-01",
@@ -16883,11 +16885,12 @@
     },
     {
       "slug": "cantor-diagonalization-oq-02-oq-03-oq-02-incomplete-01",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "fast",
       "started": "2026-04-21T15:44:50.655Z",
-      "status": "active",
-      "lastUpdate": "2026-04-21T15:44:50.678Z"
+      "status": "graduated",
+      "lastUpdate": "2026-04-21T17:34:57.463Z",
+      "completed": "2026-04-21T17:34:57.462Z"
     },
     {
       "slug": "schauder-fixed-point-oq-03-oq-01-incomplete-01",


### PR DESCRIPTION
## Summary
- Sync research-listings.json with actual iteration counts (66 added, 776 updated)
- Update enrichment tracker and research problem metadata
- Auto-generated by deployer agent

## Test plan
- [x] Build passed (`pnpm build`)
- [x] Deployed successfully to Cloudflare

🤖 Generated with [Claude Code](https://claude.com/claude-code)