### PR TITLE
Audit: schroeder-bernstein-oq-03 — correct badge original→wip

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -144,7 +144,7 @@
     "angle-trisection-oq-02-oq-04-oq-01": {
       "auditCount": 4,
       "issues": [
-        "sorry 7→3"
+        "sorry 7\u21923"
       ],
       "lastAudited": "2026-04-13T03:29:17Z",
       "result": "issues-fixed"
@@ -255,7 +255,7 @@
     "area-of-circle-oq-05": {
       "auditCount": 3,
       "issues": [
-        "sorries 1→0, status formalized→verified, badge wip→mathlib (sorry was completed)"
+        "sorries 1\u21920, status formalized\u2192verified, badge wip\u2192mathlib (sorry was completed)"
       ],
       "lastAudited": "2026-04-21T15:42:01Z",
       "result": "clean"
@@ -551,10 +551,10 @@
     "binomial-theorem-oq-04-oq-03": {
       "auditCount": 3,
       "issues": [
-        "sorry 6→0",
-        "axiomCount 1→0",
-        "status axiomatized→verified",
-        "badge axiom→original"
+        "sorry 6\u21920",
+        "axiomCount 1\u21920",
+        "status axiomatized\u2192verified",
+        "badge axiom\u2192original"
       ],
       "lastAudited": "2026-04-13T03:29:17Z",
       "result": "issues-fixed"
@@ -801,8 +801,8 @@
     "cantor-diagonalization-oq-01-oq-01-oq-02": {
       "auditCount": 3,
       "issues": [
-        "sorry 1→0",
-        "status formalized→verified"
+        "sorry 1\u21920",
+        "status formalized\u2192verified"
       ],
       "lastAudited": "2026-04-13T03:29:17Z",
       "result": "issues-fixed"
@@ -1468,7 +1468,7 @@
     "descartes-rule-of-signs-oq-02": {
       "auditCount": 4,
       "issues": [
-        "PR #6448: sorries 2→0, lineCount 552→698"
+        "PR #6448: sorries 2\u21920, lineCount 552\u2192698"
       ],
       "lastAudited": "2026-04-03T22:10:54Z",
       "result": "clean"
@@ -5165,7 +5165,7 @@
     "erdos-409": {
       "auditCount": 4,
       "issues": [
-        "status axiomatized→verified, badge wip→original (0 sorries, 0 axioms confirmed)"
+        "status axiomatized\u2192verified, badge wip\u2192original (0 sorries, 0 axioms confirmed)"
       ],
       "lastAudited": "2026-04-13T03:03:24Z",
       "result": "issues-fixed"
@@ -6522,7 +6522,7 @@
     "erdos-606-oq-03": {
       "auditCount": 4,
       "issues": [
-        "badge axiom→wip (axiomCount=0, no actual axiom declarations; consistent with open-problem survey classification)"
+        "badge axiom\u2192wip (axiomCount=0, no actual axiom declarations; consistent with open-problem survey classification)"
       ],
       "lastAudited": "2026-04-21T00:00:00Z",
       "result": "issues-fixed"
@@ -6781,7 +6781,7 @@
       "lastAudited": "2026-04-13T03:29:17Z",
       "result": "issues-fixed",
       "issues": [
-        "sorry 18→16"
+        "sorry 18\u219216"
       ]
     },
     "erdos-645": {
@@ -7289,7 +7289,7 @@
     "erdos-719": {
       "auditCount": 4,
       "issues": [
-        "PR #6447: sorries 2→1, lineCount 175→196"
+        "PR #6447: sorries 2\u21921, lineCount 175\u2192196"
       ],
       "lastAudited": "2026-04-03T17:35:38Z",
       "result": "clean"
@@ -7477,7 +7477,7 @@
     "erdos-746": {
       "auditCount": 6,
       "issues": [
-        "PR #6440: sorry count 3→4",
+        "PR #6440: sorry count 3\u21924",
         "Issue #6441: 9 vacuous True stubs",
         "https://github.com/rjwalters/lean-genius/pull/8651"
       ],
@@ -9337,7 +9337,7 @@
     "feuerbachs-theorem-oq-02": {
       "auditCount": 3,
       "issues": [
-        "axiomCount 5→3"
+        "axiomCount 5\u21923"
       ],
       "lastAudited": "2026-04-13T03:29:17Z",
       "result": "issues-fixed"
@@ -11930,7 +11930,7 @@
       "lastAudited": "2026-04-05T12:44:33Z",
       "result": "issues-fixed",
       "issues": [
-        "lineCount 98→112, theoremCount 7→8 (enricher used stale counts)"
+        "lineCount 98\u2192112, theoremCount 7\u21928 (enricher used stale counts)"
       ]
     },
     "arithmetic-series-oq-02-oq-04-oq-01-oq-03": {
@@ -12322,7 +12322,7 @@
       "lastAudited": "2026-04-13T22:38:12Z",
       "result": "issues-fixed",
       "issues": [
-        "sorry 4→3"
+        "sorry 4\u21923"
       ]
     },
     "chebyshev-pnt-bridge-oq-01": {
@@ -12330,9 +12330,9 @@
       "lastAudited": "2026-04-13T03:29:17Z",
       "result": "issues-fixed",
       "issues": [
-        "sorry 4→5",
-        "status axiomatized→formalized",
-        "badge axiom→wip"
+        "sorry 4\u21925",
+        "status axiomatized\u2192formalized",
+        "badge axiom\u2192wip"
       ]
     },
     "divisibility-by-3-oq-03-oq-02": {
@@ -12340,9 +12340,9 @@
       "lastAudited": "2026-04-13T03:29:17Z",
       "result": "issues-fixed",
       "issues": [
-        "sorry 1→0",
-        "status axiomatized→verified",
-        "badge axiom→original"
+        "sorry 1\u21920",
+        "status axiomatized\u2192verified",
+        "badge axiom\u2192original"
       ]
     },
     "lebesgue-measure-oq-03-oq-01": {
@@ -12350,9 +12350,9 @@
       "lastAudited": "2026-04-13T03:29:17Z",
       "result": "issues-fixed",
       "issues": [
-        "sorry 1→0",
-        "status axiomatized→verified",
-        "badge axiom→original"
+        "sorry 1\u21920",
+        "status axiomatized\u2192verified",
+        "badge axiom\u2192original"
       ]
     },
     "area-of-circle-oq-02-oq-04": {
@@ -12614,7 +12614,7 @@
       "lastAudited": "2026-04-21T00:00:00Z",
       "result": "issues-fixed",
       "issues": [
-        "gallery entry renamed law-of-cosines-oq-06→law-of-sines-oq-06; content was Law of Sines not Law of Cosines (fixed by PRs #10749, #10757)"
+        "gallery entry renamed law-of-cosines-oq-06\u2192law-of-sines-oq-06; content was Law of Sines not Law of Cosines (fixed by PRs #10749, #10757)"
       ]
     },
     "bezout-identity-oq-02-oq-04": {
@@ -12622,7 +12622,7 @@
       "lastAudited": "2026-04-21T00:00:00Z",
       "result": "issues-fixed",
       "issues": [
-        "badge original→mathlib (core results are Mathlib wrappers; fixed by PR #10846)"
+        "badge original\u2192mathlib (core results are Mathlib wrappers; fixed by PR #10846)"
       ]
     },
     "binomial-theorem-oq-02-oq-04": {
@@ -12798,7 +12798,7 @@
       "lastAudited": "2026-04-21T13:30:00Z",
       "result": "issues-fixed",
       "issues": [
-        "lineCount 122→118 (corrected to match actual Lean file)"
+        "lineCount 122\u2192118 (corrected to match actual Lean file)"
       ]
     },
     "area-of-circle-oq-01-oq-02-oq-03-oq-03": {
@@ -12840,6 +12840,12 @@
     "bezout-identity-oq-04-oq-02": {
       "auditCount": 1,
       "lastAudited": "2026-04-21T17:27:38Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "schroeder-bernstein-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-21T17:54:09Z",
       "result": "issues-fixed",
       "issues": []
     }
@@ -12902,21 +12908,21 @@
     "lastAudited": "2026-04-21T17:41:37Z",
     "result": "issues-fixed",
     "auditCount": 1,
-    "notes": "Lean file has 0 actual sorries (diagInter_isUnbounded fully proved in PR #11082); stale documentation in comments mentioned \"the one sorry\". Fixed: sorries 1→0, badge wip→original, status formalized→verified.",
+    "notes": "Lean file has 0 actual sorries (diagInter_isUnbounded fully proved in PR #11082); stale documentation in comments mentioned \"the one sorry\". Fixed: sorries 1\u21920, badge wip\u2192original, status formalized\u2192verified.",
     "detectedIssues": null
   },
   "erdos-840": {
     "lastAudited": "2026-04-21T17:41:37Z",
     "result": "issues-fixed",
     "auditCount": 1,
-    "notes": "All 10 sorries converted to explicit axioms in commit 01567512e4. Fixed: sorries 10→0, axiomCount 10→8 (actual axiom declarations).",
+    "notes": "All 10 sorries converted to explicit axioms in commit 01567512e4. Fixed: sorries 10\u21920, axiomCount 10\u21928 (actual axiom declarations).",
     "detectedIssues": null
   },
   "lovasz-local-lemma-oq-02": {
     "lastAudited": "2026-04-21T17:41:37Z",
     "result": "issues-fixed",
     "auditCount": 1,
-    "notes": "1 sorry in code (line 207), 1 mention of \"sorry\" in parenthetical doc comment. Fixed: sorries 2→1.",
+    "notes": "1 sorry in code (line 207), 1 mention of \"sorry\" in parenthetical doc comment. Fixed: sorries 2\u21921.",
     "detectedIssues": null
   }
 }

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3210,9 +3210,9 @@
     },
     "erdos-126": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-21T18:01:41Z",
+      "result": "clean"
     },
     "erdos-127": {
       "agentId": "auditor-cycle-20-batch",
@@ -12844,9 +12844,9 @@
       "issues": []
     },
     "schroeder-bernstein-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-21T17:54:09Z",
-      "result": "issues-fixed",
+      "auditCount": 2,
+      "lastAudited": "2026-04-21T17:57:48Z",
+      "result": "issues-found",
       "issues": []
     }
   },

--- a/src/data/proofs/schroeder-bernstein-oq-03/meta.json
+++ b/src/data/proofs/schroeder-bernstein-oq-03/meta.json
@@ -16,7 +16,7 @@
       "set-theory",
       "open-question"
     ],
-    "badge": "original",
+    "badge": "wip",
     "sorries": 4,
     "axiomCount": 0,
     "mathlibDependencies": [
@@ -42,7 +42,7 @@
       }
     ],
     "originalContributions": [
-      "Formalization of Myhill's Isomorphism Theorem using Lean's Computable typeclasses",
+      "Partial formalization of Myhill's Isomorphism Theorem: easy direction fully proved, hard direction sorry'd (4 sorries)",
       "Clean proof of the easy direction: computable bijection implies one-one equivalence",
       "Infrastructure for partial inverse via Nat.rfind (computable preimage search)",
       "Proof that computable isomorphism is an equivalence relation (reflexive, symmetric, transitive)",


### PR DESCRIPTION
## Integrity Issue Fixed

**Proof**: schroeder-bernstein-oq-03 (Myhill's Isomorphism Theorem)
**Problem**: `badge: "original"` requires 0 sorries (fully verified). This proof has 4 sorries.

## Evidence

**meta.json claimed**: `badge: "original"`, `sorries: 4`
**Lean file shows**: 4 actual `sorry` keywords at lines 112, 117, 122, 180 in `Proofs/SchroederBernsteinOQ03.lean`

The easy direction of Myhill's theorem is fully proved (computable bijection → one-one equivalence), along with the equivalence-relation corollaries. The hard direction (constructing a computable bijection from two computable injections via back-and-forth argument) has 4 sorries.

## Fix

1. `badge`: `"original"` → `"wip"` (correct badge for proof with sorries)
2. First `originalContributions` entry: clarified to "Partial formalization... easy direction fully proved, hard direction sorry'd"

## Risk Classification

- Sorry count > 0 but badge != "wip" → **HIGH** severity per audit policy

---
Discovered during gallery integrity audit.