### PR TITLE
Enrich cayley-hamilton-minpoly-oq-03-oq-01: preamble annotation, 5th keyInsight

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-01/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-minpoly-vec-preamble",
+    "proofId": "cayley-hamilton-minpoly-oq-03-oq-01",
+    "range": { "startLine": 1, "endLine": 43 },
+    "type": "context",
+    "title": "Krylov Method for Vector Minimal Polynomial: Problem Statement and Context",
+    "content": "The module docstring frames the question: can the Krylov method be formalized for vector-specific minimal polynomials μ_{M,v}, the unique monic polynomial of smallest degree annihilating v under M? This extends the parent entry (OQ-03, Krylov complexity for the matrix minimal polynomial μ_M) to individual vectors. The key properties of μ_{M,v} stated here: it annihilates v, divides μ_M, has degree ≤ n, and is characterized by the Krylov sequence {v, Mv, ..., M^d·v} becoming linearly dependent at exactly step d = deg(μ_{M,v}). The primary application context is Wiedemann's (1986) algorithm for solving sparse linear systems over finite fields, where single-vector Krylov sequences replace full Krylov subspaces. References: Wiedemann (1986), Horn & Johnson §3.3, and Mathlib's LinearAlgebra.Matrix.Charpoly.Minpoly.",
+    "mathContext": "Vector minimal polynomial: $\\mu_{M,v}$ = unique monic $p \\in K[X]$ of minimum degree with $p(M)v = 0$. Properties: (1) $\\mu_{M,v} \\mid \\mu_M$ (hence $\\deg \\mu_{M,v} \\leq n$); (2) $\\mu_{M,v} \\mid q$ for any $q$ with $q(M)v = 0$ (universally minimal); (3) The Krylov sequence $v, Mv, M^2v, \\ldots$ is linearly independent up to step $d = \\deg \\mu_{M,v} - 1$ and dependent at step $d$.",
+    "significance": "context",
+    "relatedConcepts": ["Wiedemann's algorithm", "Krylov subspace methods", "sparse linear systems", "vector annihilator", "Polynomial.minpoly"],
+    "prerequisites": ["Polynomial.minpoly in Mathlib", "Matrix.mulVec", "Krylov sequences", "Field typeclass"]
+  },
+  {
     "id": "ann-minpoly-vec-krylov",
     "proofId": "cayley-hamilton-minpoly-oq-03-oq-01",
     "range": { "startLine": 44, "endLine": 78 },

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-01/meta.json
@@ -31,7 +31,8 @@
       "The annihilator ideal I_v of v under M is always nonzero: it contains μ_M, since μ_M(M) = 0 as a matrix implies μ_M(M)·v = 0·v = 0 for every vector v",
       "The divisibility μ_{M,v} | μ_M holds by definition: μ_M ∈ I_v = ⟨μ_{M,v}⟩. This means the Krylov iteration for any v terminates in at most deg(μ_M) ≤ n steps",
       "The annihilator set is not merely a subgroup but an ideal: if p(M)·v = 0, then (q·p)(M)·v = q(M)·0 = 0 for any polynomial q",
-      "The proof of vec_minpoly_exists uses degree_lt_wf (well-founded recursion on polynomial degree) to extract the minimum-degree annihilating polynomial — rather than invoking Mathlib's abstract PID machinery, it directly implements the Euclidean division + minimality contradiction argument, making the construction explicit and computational."
+      "The proof of vec_minpoly_exists uses degree_lt_wf (well-founded recursion on polynomial degree) to extract the minimum-degree annihilating polynomial — rather than invoking Mathlib's abstract PID machinery, it directly implements the Euclidean division + minimality contradiction argument, making the construction explicit and computational.",
+      "The Krylov expansion lemma `aeval_mulVec_eq_krylov_sum` is the computational bridge: it rewrites polynomial evaluation $p(M)v = \\sum_k c_k M^k v$ as an explicit Krylov linear combination. This connects algebraic minimality (μ_{M,v}(M)v = 0) to the linear-algebraic Krylov termination condition (the Krylov sequence becomes linearly dependent at step deg(μ_{M,v})), unifying the algebraic and computational perspectives on the vector minimal polynomial."
     ],
     "prerequisites": [
       "Cayley-Hamilton theorem and minimal polynomial theory",


### PR DESCRIPTION
Targeted enrichment for cayley-hamilton-minpoly-oq-03-oq-01 (Krylov Method for Vector Minimal Polynomial). Entry was quality 98 with one coverage gap.

## Changes

### annotations.json
- ann-minpoly-vec-preamble (lines 1-43): context annotation for the module preamble. Explains the question (can Krylov method handle μ_{M,v}?), the three properties of vector minimal polynomials, Wiedemann's (1986) application context, and the Mathlib imports used.

### meta.json
- 5th keyInsight: The Krylov expansion lemma aeval_mulVec_eq_krylov_sum as the computational bridge — rewrites p(M)v as an explicit Krylov sum, unifying algebraic minimality with the computational Krylov termination condition.

## Axiom integrity
Status: verified, badge: original, axiomCount: 0, sorries: 0 — confirmed correct.