### PR TITLE
Audit: erdos-1175 — correct assumptions text (6→2 axioms)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3102,8 +3102,8 @@
     },
     "erdos-1175": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-21T18:13:35Z",
       "result": "issues-fixed"
     },
     "erdos-1176": {

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3114,9 +3114,9 @@
     },
     "erdos-1177": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-21T18:05:59Z",
+      "result": "clean"
     },
     "erdos-1178": {
       "auditCount": 2,
@@ -3126,9 +3126,9 @@
     },
     "erdos-1179": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:05:46Z",
+      "result": "clean"
     },
     "erdos-1179-oq-01": {
       "auditCount": 2,
@@ -3143,10 +3143,10 @@
       "result": "clean"
     },
     "erdos-1181": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-21T18:05:18Z",
+      "result": "clean"
     },
     "erdos-1183": {
       "auditCount": 2,
@@ -3168,9 +3168,9 @@
     },
     "erdos-120": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-21T18:04:26Z",
+      "result": "clean"
     },
     "erdos-121": {
       "agentId": "auditor-cycle-20-batch",
@@ -12844,9 +12844,9 @@
       "issues": []
     },
     "schroeder-bernstein-oq-03": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T17:57:48Z",
-      "result": "issues-found",
+      "auditCount": 3,
+      "lastAudited": "2026-04-21T18:04:06Z",
+      "result": "clean",
       "issues": []
     }
   },

--- a/src/data/proofs/erdos-1175/meta.json
+++ b/src/data/proofs/erdos-1175/meta.json
@@ -22,7 +22,7 @@
     "erdosProblemStatus": "open",
     "axiomCount": 2,
     "lineCount": 186,
-    "assumptions": "6 axioms: cardinalChromaticNumber, chromaticNumber_le_iff, shelah_consistency, and 3 more. See Lean source for complete statements.",
+    "assumptions": "2 axioms: cardinalChromaticNumber (axiomatized cardinal chromatic number to avoid universe/decidability issues), shelah_consistency (Shelah's ZFC-consistency result: ∃ G with χ(G) = ℵ₁ whose triangle-free subgraphs all have countable chromatic number). See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-1177/meta.json
+++ b/src/data/proofs/erdos-1177/meta.json
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "open",
     "axiomCount": 5,
     "lineCount": 206,
-    "assumptions": "7 axioms. See Lean source for complete statements.",
+    "assumptions": "5 axioms. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Audit Finding

**Proof**: erdos-1175 (Triangle-Free Subgraphs with Large Chromatic Number)
**Severity**: LOW

## Problem

The `assumptions` field claimed "6 axioms: cardinalChromaticNumber, chromaticNumber_le_iff, shelah_consistency, and 3 more" but the Lean source contains only **2** `axiom` declarations:

1. `cardinalChromaticNumber` — axiomatized cardinal chromatic number function
2. `shelah_consistency` — Shelah's ZFC-consistency result

`chromaticNumber_le_iff` appears only as a comment placeholder; it was never declared as an axiom. There are no "3 more."

## Evidence

```bash
$ git show HEAD:proofs/Proofs/Erdos1175Problem.lean | grep "^axiom "
axiom cardinalChromaticNumber {V : Type*} (G : SimpleGraph V) : Cardinal
axiom shelah_consistency : ...
```

The `axiomCount: 2` metadata fields were already correct. Only the prose `assumptions` text was wrong.

## Fix

Updated `assumptions` to accurately describe the 2 actual axioms.

---
Discovered during gallery integrity audit.