### PR TITLE
Fix: stale leanFile.lineCount for 4 gallery proofs

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -23,7 +23,7 @@
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
     "assumptions": "Three open sorries: (1) hook_length_formula (requires SYT↔NI bijection + det factorization), (2) ni_count_eq_syt_count (Fomin/Viennot/RSK correspondence), (3) lgv_det_factors_as_hook_quotient (det factorization identity). StandardYoungTableau.ext is now fully proved (funext).",
-    "lineCount": 225,
+    "lineCount": 676,
     "theoremCount": 12,
     "definitionCount": 5,
     "originalContributions": [
@@ -79,7 +79,7 @@
       "LGV"
     ],
     "namespace": "HookLengthFormula",
-    "lineCount": 225,
+    "lineCount": 676,
     "axiomCount": 0,
     "sorries": 3,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",

--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
@@ -24,7 +24,7 @@
     "axiomCount": 1,
     "assumptions": "1 axiom: poisson_approx_birthday3 (Chen-Stein method: P(no triple) → exp(-C(n,3)/d²) as d → ∞). All other theorems fully proved including choose3_mul_six (Pascal induction, 0 sorries).",
     "dateAdded": "2026-04-04",
-    "lineCount": 418,
+    "lineCount": 463,
     "theoremCount": 19,
     "definitionCount": 3,
     "originalContributions": [
@@ -143,7 +143,7 @@
       "Real"
     ],
     "namespace": "BirthdayThreshold3",
-    "lineCount": 418,
+    "lineCount": 463,
     "axiomCount": 1,
     "sorries": 0,
     "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",

--- a/src/data/proofs/cantor-diagonalization-oq-02-oq-03-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-02-oq-03-oq-02/meta.json
@@ -23,7 +23,7 @@
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
     "assumptions": "diagInter_isUnbounded (the diagonal intersection of clubs is unbounded). This is expressed as a sorry (1 sorry total) rather than an axiom declaration. The proof sketch is given in full in the sorry docstring. The closed part of the diagonal intersection is fully proved.",
-    "lineCount": 314,
+    "lineCount": 380,
     "theoremCount": 9,
     "definitionCount": 5,
     "originalContributions": [
@@ -64,7 +64,7 @@
   },
   "leanFile": {
     "namespace": "FodorLemma",
-    "lineCount": 314,
+    "lineCount": 380,
     "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-840/meta.json
+++ b/src/data/proofs/erdos-840/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/840",
     "erdosProblemStatus": "open",
     "axiomCount": 8,
-    "lineCount": 221,
+    "lineCount": 237,
     "assumptions": "8 axioms (theorem sorries) and 2 definition sorries. Axioms: (1) sidon_sumset_card — classical Sidon cardinality |A+A|=C(|A|+1,2); (2) erdos_freud_lower_bound — Erdős-Freud (1991) lower bound f(N)≥(2/√3+o(1))√N; (3) construction_is_quasi_sidon — Erdős-Freud construction is quasi-Sidon; (4) erdos_freud_upper_bound — Erdős-Freud (1991) upper bound f(N)≤(2+o(1))√N; (5) pikhurko_upper_bound — Pikhurko (2006) improved bound f(N)≤(c_P+o(1))√N; (6) sidon_set_upper_bound — classical Sidon bound |A|≤√N+O(N^{1/4}); (7) sidon_set_exists — Singer construction Sidon sets of size ~√N; (8) pikhurko_constant_approx — numerical bound c_P∈(1.86,1.87). Definition sorries: f(N) and fAlt(N,δ) (axiomatized definitions). Proven: lower_bound_constant_value, bounds_gap, cilleruelo_difference_set, open_problem_gap.",
     "mathlib_version": "4.26.0"
   },
@@ -101,7 +101,7 @@
     "imports": [],
     "opens": [],
     "namespace": null,
-    "lineCount": 221,
+    "lineCount": 237,
     "axiomCount": 8,
     "theoremCount": 9,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Updates stale `leanFile.lineCount` fields where Lean source files grew due to researcher PRs but `meta.json` was not updated.

## Evidence

| Proof | Before | After | Cause |
|-------|--------|-------|-------|
| `ballot-problem-oq-03-oq-01-oq-02` | 225 | 676 | Hook-length formula PRs #11096/#11110 |
| `cantor-diagonalization-oq-02-oq-03-oq-02` | 314 | 380 | Fodor's lemma PR #11082 |
| `birthday-problem-oq-03-oq-01-oq-02` | 418 | 463 | Research PR #11075 |
| `erdos-840` | 221 | 237 | Quasi-Sidon sorry elimination PR #11092 |

Verified: `sorries`, `status`, and `badge` fields are all correct and unchanged.

---
Automated fix by lean-mechanic agent.