### PR TITLE
Seeker: select 4 problems for pool replenishment — analysis, geometry, game theory

### DIFF
--- a/research/problems/angle-trisection-oq-04-oq-03/knowledge.md
+++ b/research/problems/angle-trisection-oq-04-oq-03/knowledge.md
@@ -1,0 +1,39 @@
+# Knowledge: angle-trisection-oq-04-oq-03
+
+## Key Facts
+
+### Pierpont Primes
+- A prime p is Pierpont if p - 1 = 2^u · 3^v for some u, v ≥ 0
+- Small Pierpont primes: 2, 3, 5, 7, 13, 17, 19, 37, 73, 97, 109, 163, 193, 257, 433, ...
+- Note: 2 = 2^1·3^0+1, 3 = 2^1·3^1/3 (hmm: 3-1=2=2^1·3^0 ✓), 5-1=4=2^2 ✓, 7-1=6=2·3 ✓
+- All Fermat primes (5, 17, 257, 65537) are also Pierpont primes
+
+### Pierpont Criterion (1895)
+- Regular n-gon constructible by compass + angle trisector (neusis) iff
+  n = 2^a · 3^b · p₁ · ... · pₘ where pᵢ are distinct Pierpont primes > 3
+- Galois theory: constructible iff [Q(ζₙ) : Q] divides some 2^s · 3^t
+- [Q(ζₙ) : Q] = φ(n) = Euler totient of n
+- So criterion: φ(n) = 2^a · 3^b
+
+### Comparison with Gauss-Wantzel
+- Gauss-Wantzel: compass constructible iff φ(n) = 2^k (only powers of 2)
+- Pierpont: neusis constructible iff φ(n) = 2^a · 3^b (allows factors of 3)
+- Key: angle trisection allows cube roots → field extensions of degree 3
+
+### Constructible n-gons (Pierpont, not Gauss-Wantzel)
+- n=7: φ(7)=6=2·3 ✓ (Pierpont prime 7)
+- n=9: φ(9)=6=2·3 ✓ (=3²)
+- n=13: φ(13)=12=4·3 ✓ (Pierpont prime 13)
+- n=14: φ(14)=6=2·3 ✓
+- n=18: φ(18)=6=2·3 ✓
+- n=19: φ(19)=18=2·3² ✓
+
+## Open Questions
+- How is `IsNeusisConstructible` defined in `AngleTrisectionOQ04.lean`?
+- Is there existing Mathlib support for φ(n) = 2^a · 3^b characterization?
+- Does the parent proof have a `constructible ↔ field degree` lemma?
+
+## References
+- Pierpont, J. (1895): "On an unresolved problem of Euclidean geometry"
+- Parent proof: `proofs/Proofs/AngleTrisectionOQ04.lean`
+- `Mathlib.NumberTheory.ArithmeticFunction` — Euler totient

--- a/research/problems/angle-trisection-oq-04-oq-03/literature/README.md
+++ b/research/problems/angle-trisection-oq-04-oq-03/literature/README.md
@@ -1,0 +1,28 @@
+# Literature: angle-trisection-oq-04-oq-03
+
+## Key References
+
+### Primary
+- **AngleTrisectionOQ04.lean** (`proofs/Proofs/AngleTrisectionOQ04.lean`)
+  — Parent proof with neusis constructibility framework
+
+### Constructibility Theory
+- Pierpont, J. (1895): "On an unresolved problem of Euclidean geometry"
+  — Original paper proving the Pierpont prime criterion for neusis construction
+- Conway & Guy: "The Book of Numbers" (1996)
+  — Accessible treatment of Fermat and Pierpont primes, constructibility
+
+### Galois Theory
+- Cox, D.A. (2012): "Galois Theory" (2nd ed., Wiley)
+  — Chapter 10: geometric constructions and Galois theory
+- Stewart, I.: "Galois Theory" (4th ed., CRC Press)
+  — Classical treatment connecting constructibility to field extensions
+
+### Number Theory
+- OEIS A005109: Pierpont primes (primes p with p-1 = 2^a * 3^b)
+
+### Lean 4 / Mathlib
+- `Mathlib.FieldTheory.Galois` — Galois theory in Lean 4
+- `Mathlib.NumberTheory.ArithmeticFunction` — Euler totient φ(n)
+- `Mathlib.RingTheory.RootsOfUnity.Basic` — roots of unity ζₙ
+- `Mathlib.FieldTheory.SplittingField.Construction` — splitting fields

--- a/research/problems/angle-trisection-oq-04-oq-03/problem.md
+++ b/research/problems/angle-trisection-oq-04-oq-03/problem.md
@@ -1,0 +1,121 @@
+# Problem: Pierpont Prime Criterion for Neusis-Constructible n-gons
+
+**Slug**: angle-trisection-oq-04-oq-03
+**Created**: 2026-04-21
+**Status**: Active
+**Source**: gallery-extension
+
+## Problem Statement
+
+### Plain Language
+
+The gallery proof `AngleTrisectionOQ04.lean` establishes the tool hierarchy
+(compass < compass+neusis < compass+origami) and characterizes what is constructible
+with each tool. This open question asks:
+
+**Can the Pierpont prime criterion for neusis-constructible regular n-gons be
+formalized in Lean 4?**
+
+The Gauss-Wantzel theorem characterizes compass-and-straightedge constructible n-gons
+via Fermat primes: a regular n-gon is constructible iff n = 2^k · p₁ · ... · pₘ where
+each pᵢ is a Fermat prime (prime of the form 2^(2^j) + 1).
+
+The analog for neusis construction uses **Pierpont primes**: primes of the form
+2^u · 3^v + 1. A regular n-gon is neusis-constructible iff n = 2^a · 3^b · p₁ · ... · pₘ
+where each pᵢ is a Pierpont prime > 3.
+
+### Formal Statement
+
+```lean
+-- A prime p is a Pierpont prime if p - 1 = 2^u * 3^v for some u, v ≥ 0
+def IsPierpontPrime (p : ℕ) : Prop :=
+  Nat.Prime p ∧ ∃ u v : ℕ, p - 1 = 2 ^ u * 3 ^ v
+
+-- A number n has the Pierpont factorization form
+def HasPierpontForm (n : ℕ) : Prop :=
+  ∃ a b : ℕ, ∃ ps : List ℕ,
+    (∀ p ∈ ps, IsPierpontPrime p ∧ p > 3) ∧
+    n = 2 ^ a * 3 ^ b * ps.prod
+
+theorem pierpont_criterion (n : ℕ) (hn : 3 ≤ n) :
+    IsNeusisConstructible (regularPolygon n) ↔ HasPierpontForm n := by
+  sorry
+```
+
+### Why This Matters
+
+- Direct extension of Gauss-Wantzel theorem (compass → neusis)
+- Connects Galois theory (field extensions of degree 2^a · 3^b) to constructibility
+- Pierpont primes: 2, 3, 5, 7, 13, 17, 19, 37, 73, 97, 109, 163, 193, 257...
+- The neusis-constructible n-gons include all Fermat prime cases plus 7-gon, 9-gon, 13-gon...
+
+## Known Results
+
+### From Parent Proof (`AngleTrisectionOQ04.lean`)
+
+The gallery establishes:
+- Tool hierarchy: compass-only ⊂ compass+neusis ⊂ compass+origami
+- `trisection_by_neusis`: angle trisection is possible with neusis
+- `impossible_with_compass_only`: angle trisection impossible with compass alone
+- `neusis_constructs_cube_root`: neusis can extract cube roots
+- Framework for neusis-constructible sets
+
+### Mathematical Facts
+
+1. **Pierpont (1895)**: Regular n-gon is constructible by ruler and compass with angle
+   trisection (= neusis) iff n = 2^a · 3^b · p₁ · ... · pₘ with pᵢ Pierpont primes > 3
+2. **Galois theory**: Neusis corresponds to field extensions of degree dividing 2^a · 3^b
+   (not just powers of 2)
+3. **Examples**: n=7 (Pierpont prime 7 = 2·3+1), n=9 (=3²), n=13, n=19...
+4. **Non-examples**: n=11 (11-1=10=2·5, not 2^u·3^v form), n=23...
+
+### Lean 4 / Mathlib Status
+- `Nat.Prime`: primality in Mathlib
+- `IsFermatPrime`: possibly in Mathlib — check `Mathlib.NumberTheory.FermatPsp`
+- Galois theory: `Mathlib.FieldTheory.Galois` — verify degree calculation
+- Constructibility: may need to extend parent proof's framework
+
+## Suggested Approach
+
+### Phase 1: OBSERVE
+1. Read `AngleTrisectionOQ04.lean` to understand `IsNeusisConstructible` definition
+2. Check what "constructible" means formally in the parent proof
+3. Search Mathlib for Fermat prime or Pierpont prime definitions
+4. Assess: does the parent proof have enough infrastructure for the criterion?
+
+### Phase 2: ORIENT
+1. What does `IsNeusisConstructible` type look like in parent?
+2. How does Galois theory connect to constructibility in the parent framework?
+3. Is the Gauss-Wantzel theorem itself formalized? (If so, extension is cleaner)
+
+### Phase 3: DECIDE
+1. If Gauss-Wantzel is formalized: prove Pierpont as the "≡ mod 2 vs mod 6" analog
+2. If not: may need to build field degree characterization from scratch
+3. Simplest: prove `IsPierpontPrime` definition and the small cases (n=7, 9)
+
+### Phase 4: ACT
+
+```lean
+def IsPierpontPrime (p : ℕ) : Prop :=
+  Nat.Prime p ∧ ∃ u v : ℕ, p - 1 = 2 ^ u * 3 ^ v
+
+-- Verify small Pierpont primes
+example : IsPierpontPrime 2 := ⟨Nat.prime_two, 1, 0, by norm_num⟩
+example : IsPierpontPrime 3 := ⟨Nat.prime_three, 1, 1, by norm_num⟩
+example : IsPierpontPrime 5 := ⟨by norm_num, 2, 0, by norm_num⟩
+example : IsPierpontPrime 7 := ⟨by norm_num, 1, 1, by norm_num⟩
+example : IsPierpontPrime 13 := ⟨by norm_num, 2, 1, by norm_num⟩
+```
+
+## Related Gallery Proofs
+
+- `angle-trisection-oq-04`: Parent — tool hierarchy and neusis constructibility
+- `angle-trisection`: Grandparent — compass impossibility
+- `gauss-wantzel`: Related — Fermat prime criterion for compass construction
+
+## Quality Assessment
+
+- **Tractability**: 6/10 — well-defined criterion, needs Galois theory infrastructure
+- **Significance**: 7/10 — natural extension of Gauss-Wantzel, Pierpont's original result
+- **Domain**: Geometry / constructibility / Galois theory / number theory
+- **Risk**: Medium — depends on parent proof's constructibility framework

--- a/research/problems/angle-trisection-oq-04-oq-03/state.md
+++ b/research/problems/angle-trisection-oq-04-oq-03/state.md
@@ -1,0 +1,32 @@
+# Research State: angle-trisection-oq-04-oq-03
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-04-21
+**Iteration**: 1
+**Selected by Seeker**: 2026-04-21
+
+## Current Focus
+Understand the `IsNeusisConstructible` definition in `AngleTrisectionOQ04.lean` and
+assess whether the Galois-theoretic framework exists to state the Pierpont criterion.
+Key question: is `IsNeusisConstructible` defined via field extensions or via geometric
+construction steps?
+
+## Active Approach
+1. Read `AngleTrisectionOQ04.lean` to understand the constructibility framework
+2. Search Mathlib for `IsFermatPrime` and related number theory
+3. Check if Gauss-Wantzel theorem is in Mathlib
+4. Determine: can Pierpont primes be defined and the criterion stated?
+
+## Next Steps
+1. Read `proofs/Proofs/AngleTrisectionOQ04.lean` fully
+2. Check `Mathlib.NumberTheory.FermatPsp` or similar
+3. Search for `constructible` in Mathlib — geometric or algebraic?
+4. Assess: prove definition + small examples vs full criterion
+
+## Blockers
+- None yet (OBSERVE phase)
+
+## History
+- 2026-04-21: Problem selected by Seeker (pool replenishment, tier B)

--- a/research/problems/area-of-circle-oq-05-oq-02/knowledge.md
+++ b/research/problems/area-of-circle-oq-05-oq-02/knowledge.md
@@ -1,0 +1,44 @@
+# Knowledge: area-of-circle-oq-05-oq-02
+
+## Key Facts
+
+### Mathematical Setup
+- Positive-definite real symmetric A: all eigenvalues λᵢ > 0
+- ∫_{ℝⁿ} e^{-xᵀAx} dx = √(πⁿ/det A)
+- Proof chain: spectral decomposition → change of variables → Fubini → scalar integral
+
+### Scalar Case (from parent)
+- ∫_{ℝ} e^{-ax²} dx = √(π/a) for a > 0
+- This is the building block for the multivariate case via Fubini
+
+### Spectral Theorem (to verify in Mathlib)
+- `Matrix.IsHermitian`: real symmetric matrices have real eigenvalues
+- `Matrix.IsHermitian.eigenvectorMatrix`: Q such that Q^T A Q = D (diagonal)
+- `Matrix.IsHermitian.spectral_theorem`: A = Q D Q^T (spectral decomposition)
+- Need: Q is orthogonal (Q^T Q = I)
+
+### Change of Variables
+- y = Qx, |det Q| = 1 (orthogonal matrix)
+- `MeasureTheory.MeasurePreserving` for orthogonal transformations?
+- `MeasureTheory.integral_comp_mul_right`: f(Ax) substitution
+
+### Fubini
+- `MeasureTheory.integral_prod`: for product measures
+- For `Fin n → ℝ`, the product measure decomposes as ∏ᵢ (Lebesgue on ℝ)
+- `MeasureTheory.Measure.pi`: product measure on `Fin n → ℝ`
+
+### Determinant
+- `Matrix.det_diagonal`: det(diag(λ₁,...,λₙ)) = ∏ λᵢ
+- `Matrix.PosDef.det_pos`: det A > 0 for positive-definite A
+- `Real.sqrt_mul`: √(πⁿ/det A) = ∏ᵢ √(π/λᵢ) via eigenvalues
+
+## Open Questions
+- Does Mathlib have spectral theorem in a form usable for change-of-variables?
+- Is there a `MeasurePreserving` lemma for orthogonal linear maps?
+- How is `Fin n → ℝ` measure handled — `EuclideanSpace` or `Fin n → ℝ`?
+
+## References
+- Parent proof: `proofs/Proofs/AreaOfCircleOQ05.lean`
+- `Mathlib.LinearAlgebra.Matrix.PosDef`
+- `Mathlib.MeasureTheory.Integral.Bochner`
+- `Mathlib.MeasureTheory.Measure.Haar.Basic`

--- a/research/problems/area-of-circle-oq-05-oq-02/literature/README.md
+++ b/research/problems/area-of-circle-oq-05-oq-02/literature/README.md
@@ -1,0 +1,24 @@
+# Literature: area-of-circle-oq-05-oq-02
+
+## Key References
+
+### Primary
+- **AreaOfCircleOQ05.lean** (`proofs/Proofs/AreaOfCircleOQ05.lean`)
+  — Parent proof with scalar Gaussian integral
+
+### Analysis / Probability
+- Folland, G.B. (1999): "Real Analysis: Modern Techniques and Their Applications"
+  — Chapter on integration in Rⁿ, Gaussian integrals
+- Evans & Gariepy: "Measure Theory and Fine Properties of Functions"
+  — Change of variables theorem in measure theory
+
+### Linear Algebra
+- Horn & Johnson: "Matrix Analysis" (2013, Cambridge)
+  — Spectral theorem for real symmetric matrices, positive-definite matrices
+
+### Lean 4 / Mathlib
+- `Mathlib.LinearAlgebra.Matrix.PosDef` — positive-definite matrices
+- `Mathlib.LinearAlgebra.Matrix.Hermitian` — real symmetric / Hermitian eigenvalues
+- `Mathlib.MeasureTheory.Measure.Haar.Basic` — Haar measure on Rⁿ
+- `Mathlib.MeasureTheory.Integral.Bochner` — Bochner integral
+- `Mathlib.MeasureTheory.Measure.MeasureSpace` — product measures

--- a/research/problems/area-of-circle-oq-05-oq-02/problem.md
+++ b/research/problems/area-of-circle-oq-05-oq-02/problem.md
@@ -1,0 +1,109 @@
+# Problem: Multivariate Gaussian Integral via Matrix Diagonalization
+
+**Slug**: area-of-circle-oq-05-oq-02
+**Created**: 2026-04-21
+**Status**: Active
+**Source**: gallery-extension
+
+## Problem Statement
+
+### Plain Language
+
+The gallery proof `AreaOfCircleOQ05.lean` establishes the scalar Gaussian integral
+∫_{ℝ} e^{-x²} dx = √π. This open question asks:
+
+**Can the multivariate Gaussian integral be formalized in Lean 4?**
+
+Specifically: for a positive-definite real symmetric matrix A of size n×n,
+
+    ∫_{ℝⁿ} exp(-xᵀAx) dx = √(πⁿ / det(A))
+
+### Formal Statement
+
+```lean
+theorem multivariate_gaussian_integral (n : ℕ) (A : Matrix (Fin n) (Fin n) ℝ)
+    (hA : A.PosDef) :
+    ∫ x : Fin n → ℝ, Real.exp (-(Matrix.dotProduct x (A.mulVec x))) =
+      Real.sqrt (Real.pi ^ n / A.det) := by
+  -- Diagonalize A = QᵀDQ via spectral theorem
+  -- Apply change of variables y = Q x
+  -- Use Fubini: ∫ e^{-λ₁y₁²} ... e^{-λₙyₙ²} = ∏ √(π/λᵢ)
+  -- Combine: ∏ √(π/λᵢ) = √(πⁿ/∏λᵢ) = √(πⁿ/det A)
+  sorry
+```
+
+### Why This Matters
+
+- Natural generalization of the scalar Gaussian in `AreaOfCircleOQ05.lean`
+- Used in probability theory (multivariate normal distribution), statistics, quantum mechanics
+- Requires spectral theorem + Fubini + measure theory on ℝⁿ — substantial Mathlib coverage
+- Tractability 7/10: all the ingredients likely exist in Mathlib
+
+## Known Results
+
+### From Parent Proof (`AreaOfCircleOQ05.lean`)
+- `gaussian_integral_eq_sqrt_pi`: ∫_{ℝ} e^{-x²} dx = √π (proved)
+- Scalar case: ∫ e^{-ax²} dx = √(π/a) for a > 0 (derivable from scaling)
+
+### Mathematical Facts
+
+1. **Spectral theorem**: Symmetric positive-definite A = QᵀDQ where Q orthogonal,
+   D = diag(λ₁, ..., λₙ) with all λᵢ > 0
+2. **Change of variables**: y = Qx, Jacobian = |det Q| = 1 (Q orthogonal)
+3. **Fubini**: ∫_{ℝⁿ} e^{-yᵀDy} dy = ∫_{ℝⁿ} ∏ᵢ e^{-λᵢyᵢ²} dy = ∏ᵢ ∫_{ℝ} e^{-λᵢyᵢ²} dyᵢ
+4. **Scalar integral**: ∫ e^{-λy²} dy = √(π/λ)
+5. **Product**: ∏ᵢ √(π/λᵢ) = √(πⁿ / ∏λᵢ) = √(πⁿ / det A)
+
+### Lean 4 / Mathlib Status
+- `Matrix.PosDef`: positive-definite matrices — in Mathlib
+- `Matrix.IsSymm`: symmetric matrices — in Mathlib
+- Spectral theorem for real symmetric matrices: `Matrix.IsSymm.eigenvectorMatrix` — verify in Mathlib
+- `MeasureTheory.integral_comp_mul_right`: change of variables in integrals — check
+- `MeasureTheory.Fubini`: product integrals — in Mathlib
+- `Matrix.det_diagonal`: determinant of diagonal matrix — in Mathlib
+
+## Suggested Approach
+
+### Phase 1: OBSERVE
+1. Read `AreaOfCircleOQ05.lean` to understand the scalar integral formalization
+2. Check `Mathlib.LinearAlgebra.Matrix.PosDef` for spectral theorem access
+3. Search for `Matrix.IsHermitian.eigenvectorMatrix` or similar
+4. Check `MeasureTheory.volume_comp_linearMap` for orthogonal change of variables
+
+### Phase 2: ORIENT
+1. Can the spectral theorem in Mathlib give us Q and D explicitly?
+2. Is there an `OrthogonalGroup` action on measures?
+3. Does `MeasureTheory.Fubini` work cleanly for ℝⁿ as `Fin n → ℝ`?
+
+### Phase 3: DECIDE
+1. If spectral theorem path works: full proof via Q, D, Fubini
+2. Simpler: prove only for diagonal A first, then generalize
+3. Alternative: induction on n using Fubini to peel off one variable at a time
+
+### Phase 4: ACT
+
+```lean
+-- Step 1: Diagonal case
+theorem multivariate_gaussian_diagonal (n : ℕ) (λ : Fin n → ℝ) (hλ : ∀ i, 0 < λ i) :
+    ∫ x : Fin n → ℝ, Real.exp (-∑ i, λ i * x i ^ 2) =
+      Real.sqrt (Real.pi ^ n / ∏ i, λ i) := by
+  rw [show (-∑ i, λ i * x i ^ 2) = ...]
+  rw [Real.exp_sum]
+  rw [integral_fintype_prod]
+  simp [gaussian_integral_eq_sqrt_pi]
+
+-- Step 2: General case via spectral theorem
+```
+
+## Related Gallery Proofs
+
+- `area-of-circle-oq-05`: Parent — scalar Gaussian integral
+- `erdos-1151-oq-04`: Related — uses similar analysis/measure theory infrastructure
+- `central-limit-theorem`: Uses multivariate Gaussian in its statement
+
+## Quality Assessment
+
+- **Tractability**: 7/10 — clear mathematical path, good Mathlib coverage
+- **Significance**: 7/10 — fundamental result in probability theory
+- **Domain**: Analysis / probability / linear algebra
+- **Risk**: Low-medium — spectral theorem availability is the main uncertainty

--- a/research/problems/area-of-circle-oq-05-oq-02/state.md
+++ b/research/problems/area-of-circle-oq-05-oq-02/state.md
@@ -1,0 +1,32 @@
+# Research State: area-of-circle-oq-05-oq-02
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-04-21
+**Iteration**: 1
+**Selected by Seeker**: 2026-04-21
+
+## Current Focus
+Understand the scalar Gaussian integral formalization in `AreaOfCircleOQ05.lean`,
+then assess Mathlib's spectral theorem for real symmetric matrices.
+Key question: does Mathlib provide `Matrix.IsHermitian.eigenvectorMatrix` with enough
+API to use in a change-of-variables argument?
+
+## Active Approach
+1. Read `AreaOfCircleOQ05.lean` to understand how the scalar case is proved
+2. Search Mathlib for `Matrix.PosDef`, spectral theorem, orthogonal change of variables
+3. Check Fubini for product measures on `Fin n → ℝ`
+4. Determine: prove diagonal case first, then generalize via spectral theorem
+
+## Next Steps
+1. Read `proofs/Proofs/AreaOfCircleOQ05.lean` fully
+2. Check `Mathlib.LinearAlgebra.Matrix.PosDef` and `Matrix.IsHermitian`
+3. Search for `volume_comp_linearMap` in Mathlib (change of variables for linear maps)
+4. Assess: is `MeasureTheory.integral_comp_mul_right` sufficient?
+
+## Blockers
+- None yet (OBSERVE phase)
+
+## History
+- 2026-04-21: Problem selected by Seeker (pool replenishment, tier B)

--- a/research/problems/brouwer-fixed-point-oq-04-oq-02/knowledge.md
+++ b/research/problems/brouwer-fixed-point-oq-04-oq-02/knowledge.md
@@ -1,0 +1,33 @@
+# Knowledge: brouwer-fixed-point-oq-04-oq-02
+
+## Key Facts
+
+### Nash Equilibrium Setup
+- n-player game: each player i has finite strategy set Sᵢ
+- Mixed strategy: probability distribution σᵢ ∈ Δ(Sᵢ) (probability simplex)
+- Expected payoff: Uᵢ(σ) = Σ_{s ∈ ∏ Sⱼ} σ₁(s₁)·...·σₙ(sₙ)·uᵢ(s)
+- Nash equilibrium: σ* s.t. Uᵢ(σᵢ*, σ₋ᵢ*) ≥ Uᵢ(τᵢ, σ₋ᵢ*) for all i, τᵢ
+
+### Best Response Correspondence
+- BRᵢ(σ₋ᵢ) = argmax_{τᵢ ∈ Δ(Sᵢ)} Uᵢ(τᵢ, σ₋ᵢ)
+- Nonempty: Extreme value theorem (Δ(Sᵢ) compact, Uᵢ continuous)
+- Convex: Uᵢ is linear in σᵢ, so argmax is convex (if not unique, it's a face of the simplex)
+- UHC: Berge's maximum theorem (payoff continuous, domain compact-valued)
+
+### Kakutani Application
+- Domain: Δ = ∏ᵢ Δ(Sᵢ) — compact, convex (product of compact convex sets)
+- Correspondence: BR(σ) = ∏ᵢ BRᵢ(σ₋ᵢ) — UHC, nonempty, convex values
+- Fixed point: σ* ∈ BR(σ*) ⟺ Nash equilibrium
+
+### Mathlib Status (to verify)
+- `ProbabilityMassFunction`: Available — discrete distributions over `α : Type`
+- `stdSimplex` or `Simplex`: convex analysis tools
+- Extreme value theorem: `IsCompact.exists_isMaxOn`
+- Berge's maximum theorem: likely NOT in Mathlib
+- Game theory: likely very limited in Mathlib
+
+## References
+- Nash, J.F. (1950): "Equilibrium Points in n-Person Games"
+- Nash, J.F. (1951): "Non-Cooperative Games"
+- Kakutani, S. (1941): "A Generalization of Brouwer's Fixed Point Theorem"
+- Parent proof: `proofs/Proofs/BrouwerFixedPointOQ04.lean`

--- a/research/problems/brouwer-fixed-point-oq-04-oq-02/literature/README.md
+++ b/research/problems/brouwer-fixed-point-oq-04-oq-02/literature/README.md
@@ -1,0 +1,23 @@
+# Literature: brouwer-fixed-point-oq-04-oq-02
+
+## Key References
+
+### Primary
+- **BrouwerFixedPointOQ04.lean** (`proofs/Proofs/BrouwerFixedPointOQ04.lean`)
+  — Parent proof with Kakutani axiom and Nash equilibrium framework
+
+### Game Theory
+- Nash, J.F. (1950): "Equilibrium Points in n-Person Games", PNAS 36(1)
+  — Original paper proving Nash equilibrium existence
+- Nash, J.F. (1951): "Non-Cooperative Games", Annals of Mathematics 54(2)
+  — Complete treatment with mixed strategy equilibrium
+
+### Fixed Point Theory
+- Kakutani, S. (1941): "A Generalization of Brouwer's Fixed Point Theorem"
+  — Original paper proving Kakutani FPT
+- Berge, C. (1963): Topological Spaces — Berge's maximum theorem
+
+### Lean 4 / Mathlib
+- `Mathlib.Probability.ProbabilityMassFunction.Basic` — discrete probability
+- `Mathlib.Topology.Algebra.Module.Convex` — convex analysis
+- `Mathlib.Topology.Compactness.Compact` — compactness results

--- a/research/problems/brouwer-fixed-point-oq-04-oq-02/problem.md
+++ b/research/problems/brouwer-fixed-point-oq-04-oq-02/problem.md
@@ -1,0 +1,136 @@
+# Problem: Nash Equilibrium Existence via Kakutani Fixed Point
+
+**Slug**: brouwer-fixed-point-oq-04-oq-02
+**Created**: 2026-04-21
+**Status**: Active
+**Source**: gallery-extension
+
+## Problem Statement
+
+### Plain Language
+
+The gallery proof `BrouwerFixedPointOQ04.lean` formalizes the Kakutani Fixed Point
+Theorem using an axiom `kakutani_fixed_point_axiom`. This open question asks:
+
+**Can the Nash equilibrium existence theorem (Nash 1950) be fully formalized in
+Lean 4 using the Kakutani axiom, by defining best-response correspondences and
+proving their upper hemicontinuity (UHC)?**
+
+Nash's theorem: In any finite n-player game where each player has a finite
+strategy set, there exists a Nash equilibrium in mixed strategies.
+
+### Formal Question
+
+```lean
+-- Finite n-player game: strategy sets S₁,...,Sₙ (finite)
+-- Mixed strategy: probability distribution over Sᵢ
+-- Payoff function: Δ(S₁) × ... × Δ(Sₙ) → ℝ (continuous bilinear extension)
+-- Best response: BRᵢ(σ₋ᵢ) = argmax over σᵢ of expected payoff
+
+-- Nash equilibrium: σ* s.t. σᵢ* ∈ BRᵢ(σ*₋ᵢ) for all i
+theorem nash_equilibrium_exists (n : ℕ) (game : FiniteGame n) :
+    ∃ σ : MixedStrategyProfile n game, IsNashEquilibrium game σ := by
+  -- Apply Kakutani to best-response correspondence on mixed strategy simplex
+  apply kakutani_implies_nash
+  · show IsCompactConvex (MixedStrategyProfile n game)
+  · show IsUHC (bestResponseCorrespondence game)
+  · show ∀ σ, Nonempty (bestResponseCorrespondence game σ)
+  · show ∀ σ, Convex (bestResponseCorrespondence game σ)
+```
+
+### Why This Matters
+
+- One of the most significant applications of fixed-point theory in science
+- Nash's work (1950) earned the Nobel Prize in Economics (1994)
+- Completes the application theory established in `BrouwerFixedPointOQ04.lean`
+- Demonstrates Lean 4's capability for formalization in economics/game theory
+- High significance: connects topology, probability, and economics in one proof
+
+## Known Results
+
+### From Parent Proof (`BrouwerFixedPointOQ04.lean`)
+
+The gallery establishes:
+- `kakutani_fixed_point_axiom`: Kakutani FPT (axiomatized)
+- `single_valued_reduction`: Kakutani for singletons = Brouwer (PROVED)
+- `kakutani_1d_ivt`: 1D Kakutani via IVT (PROVED)
+- Correspondence definitions: `Correspondence`, upper hemicontinuity
+- Framework for Nash equilibrium existence (structured)
+
+The `kakutani_fixed_point_axiom` states:
+```lean
+axiom kakutani_fixed_point_axiom {n : ℕ} (S : Set (Fin n → ℝ))
+    (hS_compact : IsCompact S) (hS_convex : Convex S) (hS_nonempty : S.Nonempty)
+    (F : (Fin n → ℝ) → Set (Fin n → ℝ))
+    (hF_uhc : IsUpperHemicontinuous F S)
+    (hF_nonempty : ∀ x ∈ S, (F x).Nonempty)
+    (hF_convex : ∀ x ∈ S, Convex (F x))
+    (hF_image : ∀ x ∈ S, F x ⊆ S) :
+    ∃ x ∈ S, x ∈ F x
+```
+
+### Mathematical Facts
+
+- Mixed strategy simplex Δ(Sᵢ) is compact and convex
+- Product Δ = ∏ᵢ Δ(Sᵢ) is compact and convex (Tychonoff)
+- Best response BRᵢ(σ₋ᵢ) = argmax of expected payoff: closed (upper hemi-continuous)
+- Best response BRᵢ(σ₋ᵢ) is nonempty (extreme value theorem) and convex (linearity of expectation)
+- Joint best response BR(σ) = ∏ᵢ BRᵢ(σ₋ᵢ) is UHC, nonempty, convex
+- Fixed point of BR = Nash equilibrium
+
+### Lean 4 / Mathlib Considerations
+
+- `MvPolynomial` or `Finsupp`: for multilinear payoff extension
+- `Mathlib.Topology.Algebra.Module.Convex`: convex sets and Carathéodory
+- `Mathlib.Topology.Algebra.Order`: extreme value theorem
+- `Mathlib.Probability.ProbabilityMassFunction`: probability distributions on finite types
+- `ProbabilityMassFunction.support`: mixed strategies with Finsupp
+
+## Suggested Approach
+
+### Phase 1: OBSERVE
+1. Read `BrouwerFixedPointOQ04.lean` fully — understand the Kakutani axiom format
+2. Check if there's already any Nash equilibrium formalization in Mathlib
+3. Look for `MixedStrategy` or `ProbabilityMassFunction` on finite types
+4. Check extreme value theorem for compactness of argmax
+
+### Phase 2: ORIENT
+1. Define `FiniteGame`: strategy sets as `Fin n → Fin k` or `Fintype`
+2. Define `MixedStrategy i`: probability distribution over `S i`
+3. Show best-response is UHC: requires compactness + extreme value theorem
+4. Identify which Mathlib lemmas handle the convexity of argmax
+
+### Phase 3: DECIDE
+1. If definitions work out: formalize full Nash equilibrium theorem
+2. If best-response UHC is hard: state it as a lemma and focus on the Kakutani application
+3. Simplify: 2-player zero-sum game first (classic Nash for matrix games)
+
+### Phase 4: ACT
+```lean
+structure FiniteGame (n : ℕ) where
+  strategyCount : Fin n → ℕ
+  payoff : ∀ i, (∀ j, Fin (strategyCount j)) → ℝ
+
+def MixedStrategyProfile (n : ℕ) (g : FiniteGame n) : Type :=
+  ∀ i : Fin n, ProbabilityMassFunction (Fin (g.strategyCount i))
+
+theorem nash_equilibrium_exists (n : ℕ) (g : FiniteGame n) :
+    ∃ σ : MixedStrategyProfile n g, IsNashEquilibrium g σ := by
+  apply kakutani_fixed_point_axiom
+  -- 1. Mixed strategy simplex is compact convex
+  -- 2. Best response is UHC with nonempty convex values
+  ...
+```
+
+## Related Gallery Proofs
+
+- `brouwer-fixed-point-oq-04`: Parent — Kakutani FPT formalization
+- `brouwer-fixed-point`: Brouwer's Fixed Point Theorem (ultimate parent)
+- `schauder-fixed-point`: Schauder FPT (related: infinite-dimensional analog)
+
+## Quality Assessment
+
+- **Tractability**: 5/10 — clear path, but best-response UHC needs care
+- **Significance**: 8/10 — Nobel Prize-level application, high prestige
+- **Domain**: Topology / game theory / economics
+- **Risk**: Medium-high — mixed strategy formalization requires probability infrastructure

--- a/research/problems/brouwer-fixed-point-oq-04-oq-02/state.md
+++ b/research/problems/brouwer-fixed-point-oq-04-oq-02/state.md
@@ -1,0 +1,30 @@
+# Research State: brouwer-fixed-point-oq-04-oq-02
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-04-21
+**Iteration**: 1
+**Selected by Seeker**: 2026-04-21
+
+## Current Focus
+Understand the Kakutani axiom in `BrouwerFixedPointOQ04.lean` and assess what
+Mathlib has for mixed strategies and probability mass functions over finite types.
+Key question: does Mathlib have `ProbabilityMassFunction.toMeasure` and related
+tools sufficient for Nash equilibrium?
+
+## Active Approach
+Read BrouwerFixedPointOQ04.lean, then search Mathlib for:
+- `ProbabilityMassFunction` (discrete probability over Fintype)
+- `Simplex` or `stdSimplex` in convex analysis
+- `IsUpperHemicontinuous` as defined in the parent proof
+- Extreme value theorem for argmax over compact sets
+
+## Next Steps
+1. Read `proofs/Proofs/BrouwerFixedPointOQ04.lean` fully
+2. Check `Mathlib.Probability.ProbabilityMassFunction.Basic`
+3. Search for Nash equilibrium or game theory in Mathlib
+4. Assess: 2-player game first or general n-player game?
+
+## History
+- 2026-04-21: Problem selected by Seeker (pool replenishment)

--- a/research/problems/erdos-1151-oq-04/knowledge.md
+++ b/research/problems/erdos-1151-oq-04/knowledge.md
@@ -1,0 +1,35 @@
+# Knowledge: erdos-1151-oq-04
+
+## Key Facts
+
+### The Lebesgue Function
+- Λₙ(x) = Σₖ |ℓₖⁿ(x)| where ℓₖⁿ are Lagrange basis polynomials at Chebyshev nodes
+- Measures worst-case amplification of interpolation errors
+- For Chebyshev nodes: Λₙ(x) ≈ (2/π)·log(n) + O(1) for most x ∈ [-1, 1]
+- For rational cosine arguments: Λₙ(cos(πp/q)) grows at least logarithmically
+
+### The Erdős (1941) Result
+- For odd p, q with q > 1: Chebyshev interpolation of the zero function diverges at cos(πp/q)?
+- Wait: need to re-read — Erdős result likely concerns a specific non-zero function
+- The axiom `erdos_1941_divergence` takes `fun _ => 0` — this seems suspicious
+- **Key question**: Does the axiom statement make mathematical sense as written?
+
+### Chebyshev Nodes
+- Standard: xₖⁿ = cos((2k-1)π/(2n)) for k = 1, ..., n
+- Lie in (-1, 1)
+- `chebyshevNode_mem_Icc` in parent: nodes lie in [-1, 1]
+
+### Mathlib Resources (to verify)
+- `Mathlib.Analysis.Polynomial.Chebyshev`: Chebyshev polynomials T_n
+- Lagrange interpolation: likely not formalized for arbitrary nodes
+- Trigonometric sums: `Mathlib.Analysis.SpecialFunctions.Trigonometric`
+
+## Open Questions
+- Is `chebyshevInterpSeq (fun _ => 0) x n` always 0? If so, how can it → +∞?
+- What is the actual Lean definition of `chebyshevInterpSeq`?
+- Does Mathlib have Lagrange interpolation at Chebyshev nodes?
+
+## References
+- Erdős, P. (1941): "On the convergence of trigonometric series"
+- Natanson, I.P.: "Constructive Function Theory" Vol. III
+- Parent proof: `proofs/Proofs/Erdos1151Problem.lean`

--- a/research/problems/erdos-1151-oq-04/literature/README.md
+++ b/research/problems/erdos-1151-oq-04/literature/README.md
@@ -1,0 +1,24 @@
+# Literature: erdos-1151-oq-04
+
+## Key References
+
+### Primary
+- **Erdos1151Problem.lean** (`proofs/Proofs/Erdos1151Problem.lean`)
+  — Parent proof with `erdos_1941_divergence` axiom
+
+### Classical Analysis
+- Erdős, P. (1941): "On the convergence of trigonometric series"
+  — Original divergence result for rational cosine points
+- Natanson, I.P.: "Constructive Function Theory" Vol. III
+  — Comprehensive treatment of Chebyshev interpolation and Lebesgue function
+- Brutman, L. (1997): "Lebesgue Functions for Polynomial Interpolation — A Survey"
+  — Survey of Lebesgue function bounds for various node systems
+
+### Chebyshev Nodes
+- Mason & Handscomb: "Chebyshev Polynomials" (2003, CRC Press)
+  — Standard reference for Chebyshev polynomial and interpolation theory
+
+### Lean 4 / Mathlib
+- `Mathlib.Analysis.Polynomial.Chebyshev` — Chebyshev polynomial T_n, U_n
+- `Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic` — trigonometric functions
+- `Mathlib.Topology.Algebra.Order` — filter tendsto, atTop

--- a/research/problems/erdos-1151-oq-04/problem.md
+++ b/research/problems/erdos-1151-oq-04/problem.md
@@ -1,0 +1,116 @@
+# Problem: Prove erdos_1941_divergence via Lebesgue Function Growth
+
+**Slug**: erdos-1151-oq-04
+**Created**: 2026-04-21
+**Status**: Active
+**Source**: gallery-extension
+
+## Problem Statement
+
+### Plain Language
+
+The gallery proof `Erdos1151Problem.lean` formalizes Erdős problem #1151 using an axiom
+`erdos_1941_divergence`. This open question asks:
+
+**Can the axiom `erdos_1941_divergence` be proved in Lean 4 by formalizing the Lebesgue
+function growth rate Λₙ(cos(πp/q)) → ∞ for rational cosine points with odd p, q?**
+
+The Erdős (1941) result states that for any odd integers p, q with 1 < q, the Chebyshev
+interpolation sequence at x = cos(πp/q) diverges to +∞.
+
+### Formal Axiom to Prove
+
+```lean
+axiom erdos_1941_divergence (p q : ℕ) (hp : Odd p) (hq : Odd q) (hq1 : 1 < q)
+    (x : ℝ) (hx : x = Real.cos (↑p * Real.pi / ↑q)) :
+    Filter.Tendsto (fun n => chebyshevInterpSeq (fun _ => 0) x n)
+      Filter.atTop Filter.atTop
+```
+
+### Why This Matters
+
+- Eliminates an axiom from `Erdos1151Problem.lean`, moving from axiomatized to verified
+- Connects classical approximation theory (Chebyshev nodes, Lebesgue function) to Lean 4
+- Demonstrates how divergence growth rate estimates can be formalized in Mathlib
+- The result (Erdős 1941) is a cornerstone of interpolation theory
+
+## Known Results
+
+### From Parent Proof (`Erdos1151Problem.lean`)
+
+- `chebyshevNode_mem_Icc`: Chebyshev nodes lie in [-1, 1]
+- `chebyshevNodes_injective`: nodes are distinct
+- `limitPointSet_isClosed`: limit point sets are closed
+- `chebyshevInterpSeq`: the interpolation sequence is defined
+- `erdos_1941_divergence`: **this is the axiom we want to prove**
+
+### Mathematical Facts
+
+1. **Lebesgue function**: Λₙ(x) = Σₖ |ℓₖⁿ(x)| where ℓₖⁿ are the Lagrange basis polynomials
+   at Chebyshev nodes
+2. **Growth bound**: Λₙ(cos(πp/q)) ≥ C·log(n) for rational cosines with odd p, q
+3. **Divergence**: Since Λₙ(x) → ∞, by the Banach-Steinhaus theorem (or direct construction
+   of bump functions), the interpolation sequence diverges at x
+
+### Key Identity
+
+For Chebyshev nodes xₖ = cos((2k-1)π/(2n)), the Lebesgue function satisfies:
+
+    Λₙ(cos(πp/q)) = (1/n) |Σₖ cot((2k-1-2pn/q)π/(2n))|
+
+This trigonometric product grows logarithmically for rational arguments.
+
+## Suggested Approach
+
+### Phase 1: OBSERVE
+1. Read `Erdos1151Problem.lean` fully — understand `chebyshevInterpSeq` definition
+2. Check `Mathlib.Analysis.Polynomial.Chebyshev` for Chebyshev polynomial theory
+3. Search for `Lebesgue function` or `lagrangeBasis` in Mathlib
+4. Read Chebyshev node definitions: are they the standard (2k-1)π/(2n) nodes?
+
+### Phase 2: ORIENT
+1. Determine if Lebesgue function is defined or can be constructed from Mathlib pieces
+2. Find trigonometric sum bounds: cotangent sum estimates
+3. Assess: prove full Λₙ → ∞ or prove divergence more directly?
+
+### Phase 3: DECIDE
+1. If Lebesgue function approach: prove Λₙ ≥ C·log(n) then apply to get divergence
+2. If direct: construct bump function f_n with |f_n| ≤ 1, |Iₙ(f_n, x)| → ∞
+3. Fallback: state Λₙ growth as a sorry-lemma, prove the implication
+
+### Phase 4: ACT
+
+```lean
+-- Key lemma to prove
+lemma lebesgue_function_growth (p q : ℕ) (hp : Odd p) (hq : Odd q) (hq1 : 1 < q) :
+    Filter.Tendsto (fun n => lebesgueFunction n (Real.cos (↑p * Real.pi / ↑q)))
+      Filter.atTop Filter.atTop := by
+  -- Use cotangent sum identity + partial fraction estimates
+  sorry
+
+-- Then derive erdos_1941_divergence from Lebesgue function growth
+theorem erdos_1941_divergence_proof (p q : ℕ) (hp : Odd p) (hq : Odd q) (hq1 : 1 < q)
+    (x : ℝ) (hx : x = Real.cos (↑p * Real.pi / ↑q)) :
+    Filter.Tendsto (fun n => chebyshevInterpSeq (fun _ => 0) x n)
+      Filter.atTop Filter.atTop := by
+  -- chebyshevInterpSeq (fun _ => 0) = 0, so this is 0 → ∞?
+  -- Wait: need to check if the zero function gives divergence
+  -- Re-read the parent proof more carefully
+  sorry
+```
+
+**Note**: Need to verify whether `chebyshevInterpSeq (fun _ => 0)` is identically zero
+(in which case the statement seems contradictory) or represents something else.
+
+## Related Gallery Proofs
+
+- `erdos-1151`: Parent — Erdős problem #1151 (direct parent)
+- `chebyshev-pnt-bridge`: Chebyshev polynomial theory in gallery
+- `fourier-series`: Related: Fourier interpolation and divergence
+
+## Quality Assessment
+
+- **Tractability**: 4/10 — Lebesgue function bounds require careful analysis
+- **Significance**: 7/10 — Eliminates axiom from gallery, important result
+- **Domain**: Analysis / approximation theory
+- **Risk**: High — cotangent sum estimates may need substantial Mathlib infrastructure

--- a/research/problems/erdos-1151-oq-04/state.md
+++ b/research/problems/erdos-1151-oq-04/state.md
@@ -1,0 +1,32 @@
+# Research State: erdos-1151-oq-04
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-04-21
+**Iteration**: 1
+**Selected by Seeker**: 2026-04-21
+
+## Current Focus
+Read `Erdos1151Problem.lean` to understand the `chebyshevInterpSeq` definition and the
+exact statement of `erdos_1941_divergence`. Key question: is `chebyshevInterpSeq (fun _ => 0) x n`
+identically zero (making the statement trivially false) or does the sequence represent
+something more subtle?
+
+## Active Approach
+1. Read the parent Lean file to understand definitions
+2. Check Mathlib for Chebyshev polynomial and interpolation theory
+3. Search for Lebesgue function or Lagrange basis in Mathlib
+4. Determine if the divergence follows from Lebesgue function growth
+
+## Next Steps
+1. Read `proofs/Proofs/Erdos1151Problem.lean` fully
+2. Check `Mathlib.Analysis.Polynomial.Chebyshev` existence
+3. Search for trigonometric product formula for Lebesgue function
+4. Clarify the meaning of `chebyshevInterpSeq (fun _ => 0)` — is the zero function special?
+
+## Blockers
+- None yet (OBSERVE phase)
+
+## History
+- 2026-04-21: Problem selected by Seeker (pool replenishment, tier B)

--- a/src/data/research/problems/angle-trisection-oq-04-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-04-oq-03.json
@@ -1,0 +1,99 @@
+{
+  "slug": "angle-trisection-oq-04-oq-03",
+  "title": "Pierpont Prime Criterion for Neusis-Constructible Regular n-gons",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "theorem pierpont_criterion (n : ℕ) (hn : 3 ≤ n) : IsNeusisConstructible (regularPolygon n) ↔ HasPierpontForm n",
+    "plain": "Can the Pierpont prime criterion be formalized in Lean 4? A regular n-gon is constructible by compass+neusis iff n = 2^a · 3^b · p₁·...·pₘ where each pᵢ is a Pierpont prime (prime p with p-1 = 2^u · 3^v).",
+    "whyMatters": [
+      "Extends Gauss-Wantzel theorem from compass to neusis construction",
+      "Connects Galois theory (degree 2^a·3^b extensions) to constructibility geometry",
+      "Pierpont (1895) result: neusis-constructible n-gons include 7-gon, 9-gon, 13-gon"
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "trisection_by_neusis: angle trisection is possible with neusis (parent)",
+      "impossible_with_compass_only: angle trisection impossible with compass alone (parent)",
+      "neusis_constructs_cube_root: neusis can extract cube roots (parent)"
+    ],
+    "open": [
+      "IsPierpontPrime definition and examples",
+      "HasPierpontForm characterization via φ(n) = 2^a · 3^b",
+      "Full pierpont_criterion theorem"
+    ],
+    "goal": "Formalize Pierpont prime criterion as analog of Gauss-Wantzel for neusis"
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-04-21",
+    "iteration": 1,
+    "focus": "Read AngleTrisectionOQ04.lean to understand IsNeusisConstructible definition",
+    "blockers": [],
+    "nextAction": "Read proofs/Proofs/AngleTrisectionOQ04.lean, check Galois theory infrastructure",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "Problem selected by Seeker. Parent establishes tool hierarchy and neusis constructibility. Pierpont criterion: φ(n) must divide 2^a·3^b.",
+    "builtItems": [],
+    "insights": [
+      "Pierpont prime: p with p-1 = 2^u · 3^v; examples: 2,3,5,7,13,17,19,37,73...",
+      "Gauss-Wantzel: φ(n)=2^k needed; Pierpont: φ(n)=2^a·3^b sufficient",
+      "Key new n-gons: 7 (φ=6=2·3), 9 (φ=6), 13 (φ=12=4·3), 14, 18, 19...",
+      "Galois theory: neusis corresponds to degree-3 (cube root) extensions over compass"
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Read AngleTrisectionOQ04.lean fully",
+      "Check Mathlib for IsFermatPrime or related",
+      "Assess constructibility framework — geometric vs algebraic"
+    ]
+  },
+  "tags": [
+    "geometry",
+    "constructibility",
+    "galois-theory",
+    "number-theory",
+    "pierpont-primes"
+  ],
+  "relatedProofs": [
+    "angle-trisection",
+    "angle-trisection-oq-04",
+    "gauss-wantzel"
+  ],
+  "references": {
+    "papers": [
+      "Pierpont, J. (1895): On an unresolved problem of Euclidean geometry"
+    ],
+    "urls": [],
+    "mathlib": [
+      "Mathlib.FieldTheory.Galois",
+      "Mathlib.NumberTheory.ArithmeticFunction",
+      "Mathlib.RingTheory.RootsOfUnity.Basic"
+    ]
+  },
+  "started": "2026-04-21T19:30:00.000Z",
+  "lastUpdate": "2026-04-21T19:30:00.000Z",
+  "significance": 7,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/AngleTrisectionOQ04.lean",
+      "filename": "AngleTrisectionOQ04.lean",
+      "lineCount": 0,
+      "theoremCount": 0,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ04.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/area-of-circle-oq-05-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-02.json
@@ -1,0 +1,96 @@
+{
+  "slug": "area-of-circle-oq-05-oq-02",
+  "title": "Multivariate Gaussian Integral via Matrix Diagonalization",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "theorem multivariate_gaussian_integral (n : ℕ) (A : Matrix (Fin n) (Fin n) ℝ) (hA : A.PosDef) : ∫ x : Fin n → ℝ, Real.exp (-(Matrix.dotProduct x (A.mulVec x))) = Real.sqrt (Real.pi ^ n / A.det)",
+    "plain": "For a positive-definite real symmetric matrix A of size n×n, prove ∫_{ℝⁿ} exp(-xᵀAx) dx = √(πⁿ/det(A)) by diagonalizing A via the spectral theorem.",
+    "whyMatters": [
+      "Natural generalization of the scalar Gaussian integral in AreaOfCircleOQ05.lean",
+      "Used in multivariate normal distributions, statistics, and quantum mechanics",
+      "Requires spectral theorem + Fubini + measure theory — demonstrates Mathlib coverage"
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "gaussian_integral_eq_sqrt_pi: ∫_{ℝ} e^{-x²} dx = √π (parent proof)",
+      "Matrix.PosDef: positive-definite matrices in Mathlib",
+      "MeasureTheory.integral_prod: Fubini for product measures"
+    ],
+    "open": [
+      "Spectral theorem change of variables for orthogonal Q",
+      "Multivariate Gaussian integral formula"
+    ],
+    "goal": "Prove multivariate Gaussian integral via spectral decomposition + Fubini"
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-04-21",
+    "iteration": 1,
+    "focus": "Read AreaOfCircleOQ05.lean and assess Mathlib spectral theorem API",
+    "blockers": [],
+    "nextAction": "Read proofs/Proofs/AreaOfCircleOQ05.lean, search Matrix.IsHermitian spectral theorem",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "Problem selected by Seeker. Parent has scalar Gaussian. Key approach: diagonalize A = Q^T D Q, use Fubini and scalar case per eigenvalue.",
+    "builtItems": [],
+    "insights": [
+      "Spectral theorem: symmetric positive-definite A = Q^T D Q, Q orthogonal",
+      "Change of variables y = Qx has Jacobian 1 (orthogonal Q)",
+      "Fubini separates: ∫ e^{-Σ λᵢyᵢ²} = ∏ ∫ e^{-λᵢyᵢ²} = ∏ √(π/λᵢ)",
+      "Product of √(π/λᵢ) = √(πⁿ/det A) via det A = ∏ λᵢ"
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Read AreaOfCircleOQ05.lean fully",
+      "Check Matrix.IsHermitian.eigenvectorMatrix in Mathlib",
+      "Search MeasureTheory for orthogonal change of variables"
+    ]
+  },
+  "tags": [
+    "analysis",
+    "probability",
+    "gaussian-integral",
+    "spectral-theorem",
+    "measure-theory"
+  ],
+  "relatedProofs": [
+    "area-of-circle",
+    "area-of-circle-oq-05",
+    "central-limit-theorem"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": [
+      "Mathlib.LinearAlgebra.Matrix.PosDef",
+      "Mathlib.MeasureTheory.Integral.Bochner",
+      "Mathlib.MeasureTheory.Measure.Haar.Basic"
+    ]
+  },
+  "started": "2026-04-21T19:30:00.000Z",
+  "lastUpdate": "2026-04-21T19:30:00.000Z",
+  "significance": 7,
+  "tractability": 7,
+  "leanFiles": [
+    {
+      "path": "Proofs/AreaOfCircleOQ05.lean",
+      "filename": "AreaOfCircleOQ05.lean",
+      "lineCount": 0,
+      "theoremCount": 0,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ05.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/brouwer-fixed-point-oq-04-oq-02.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-04-oq-02.json
@@ -1,0 +1,105 @@
+{
+  "slug": "brouwer-fixed-point-oq-04-oq-02",
+  "title": "Nash Equilibrium Existence via Kakutani Fixed Point Theorem",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "A",
+  "path": "full",
+  "problemStatement": {
+    "formal": "theorem nash_equilibrium_exists (n : ℕ) (game : FiniteGame n) : ∃ σ : MixedStrategyProfile n game, IsNashEquilibrium game σ",
+    "plain": "Can Nash equilibrium existence (Nash 1950) be formalized in Lean 4 using the Kakutani fixed point axiom from BrouwerFixedPointOQ04.lean, by defining best-response correspondences and proving their upper hemicontinuity?",
+    "whyMatters": [
+      "Nobel Prize-level application (Nash 1994 Nobel in Economics)",
+      "Completes the application theory in BrouwerFixedPointOQ04.lean",
+      "Connects topology, probability, and economics in one formalization"
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "kakutani_fixed_point_axiom: Kakutani FPT axiomatized in parent",
+      "single_valued_reduction: Kakutani for singletons = Brouwer (parent, proved)",
+      "kakutani_1d_ivt: 1D Kakutani via IVT (parent, proved)",
+      "IsUpperHemicontinuous: defined in parent proof"
+    ],
+    "open": [
+      "FiniteGame structure definition",
+      "MixedStrategyProfile as ProbabilityMassFunction product",
+      "Best response UHC via Berge's maximum theorem",
+      "nash_equilibrium_exists via Kakutani application"
+    ],
+    "goal": "Prove Nash equilibrium existence using Kakutani axiom + best-response UHC"
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-04-21",
+    "iteration": 1,
+    "focus": "Read BrouwerFixedPointOQ04.lean, assess Mathlib probability mass function and simplex",
+    "blockers": [],
+    "nextAction": "Read proofs/Proofs/BrouwerFixedPointOQ04.lean, check ProbabilityMassFunction in Mathlib",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "Problem selected by Seeker. Parent has Kakutani axiom. Nash proof needs: mixed strategy simplex (compact+convex) + best-response UHC (Berge's theorem).",
+    "builtItems": [],
+    "insights": [
+      "Mixed strategy simplex Δ(Sᵢ) is compact and convex; product Δ = ∏ Δ(Sᵢ) also compact+convex",
+      "Best response BRᵢ(σ₋ᵢ) = argmax of linear payoff: nonempty (EVT), convex (linearity), UHC (Berge)",
+      "Berge's maximum theorem: UHC of argmax when payoff continuous, domain compact-valued",
+      "Kakutani fixed point of joint best response BR(σ) = ∏ BRᵢ(σ₋ᵢ) is Nash equilibrium"
+    ],
+    "mathlibGaps": [
+      "Berge's maximum theorem likely not in Mathlib — may need to prove separately"
+    ],
+    "nextSteps": [
+      "Read BrouwerFixedPointOQ04.lean fully",
+      "Check Mathlib.Probability.ProbabilityMassFunction.Basic",
+      "Search for game theory or Nash equilibrium in Mathlib"
+    ]
+  },
+  "tags": [
+    "topology",
+    "game-theory",
+    "economics",
+    "fixed-point",
+    "nash-equilibrium"
+  ],
+  "relatedProofs": [
+    "brouwer-fixed-point",
+    "brouwer-fixed-point-oq-04",
+    "schauder-fixed-point"
+  ],
+  "references": {
+    "papers": [
+      "Nash, J.F. (1950): Equilibrium Points in n-Person Games",
+      "Nash, J.F. (1951): Non-Cooperative Games",
+      "Kakutani, S. (1941): A Generalization of Brouwer's Fixed Point Theorem"
+    ],
+    "urls": [],
+    "mathlib": [
+      "Mathlib.Probability.ProbabilityMassFunction.Basic",
+      "Mathlib.Topology.Algebra.Module.Convex",
+      "Mathlib.Topology.Compactness.Compact"
+    ]
+  },
+  "started": "2026-04-21T19:30:00.000Z",
+  "lastUpdate": "2026-04-21T19:30:00.000Z",
+  "significance": 8,
+  "tractability": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/BrouwerFixedPointOQ04.lean",
+      "filename": "BrouwerFixedPointOQ04.lean",
+      "lineCount": 0,
+      "theoremCount": 0,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ04.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/erdos-1151-oq-04.json
+++ b/src/data/research/problems/erdos-1151-oq-04.json
@@ -1,0 +1,94 @@
+{
+  "slug": "erdos-1151-oq-04",
+  "title": "Prove erdos_1941_divergence via Lebesgue Function Growth at Chebyshev Nodes",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "axiom erdos_1941_divergence (p q : ℕ) (hp : Odd p) (hq : Odd q) (hq1 : 1 < q) (x : ℝ) (hx : x = Real.cos (↑p * Real.pi / ↑q)) : Filter.Tendsto (fun n => chebyshevInterpSeq (fun _ => 0) x n) Filter.atTop Filter.atTop",
+    "plain": "Can the axiom erdos_1941_divergence be proved in Lean 4 by formalizing the Lebesgue function growth rate Λₙ(cos(πp/q)) → ∞ for rational cosine points with odd p, q?",
+    "whyMatters": [
+      "Eliminates an axiom from Erdos1151Problem.lean, moving from axiomatized to verified",
+      "Connects classical approximation theory (Chebyshev nodes, Lebesgue function) to Lean 4",
+      "Demonstrates how divergence growth rate estimates can be formalized in Mathlib"
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "chebyshevNode_mem_Icc: Chebyshev nodes lie in [-1, 1]",
+      "chebyshevNodes_injective: nodes are distinct",
+      "limitPointSet_isClosed: limit point sets are closed"
+    ],
+    "open": [
+      "Lebesgue function growth: Λₙ(cos(πp/q)) → ∞ as n → ∞",
+      "erdos_1941_divergence: divergence of Chebyshev interpolation at rational cosines"
+    ],
+    "goal": "Prove erdos_1941_divergence to eliminate the axiom from the gallery"
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-04-21",
+    "iteration": 1,
+    "focus": "Read Erdos1151Problem.lean, assess Mathlib for Chebyshev polynomial theory",
+    "blockers": [],
+    "nextAction": "Read proofs/Proofs/Erdos1151Problem.lean, search Mathlib for ChebyshevPolynomial",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "Problem selected by Seeker. Parent uses erdos_1941_divergence as an axiom. Key fact: Lebesgue function Λₙ(cos(πp/q)) → ∞ for odd p, q.",
+    "builtItems": [],
+    "insights": [
+      "Lebesgue function Λₙ(x) = Σₖ |ℓₖ(x)| measures worst-case interpolation amplification",
+      "Growth rate for rational cosines: Λₙ(cos(πp/q)) ≥ C·log(n)",
+      "Divergence of interpolation sequence follows from Λₙ → ∞ via bump function"
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Read Erdos1151Problem.lean fully",
+      "Check Mathlib.Analysis.Polynomial.Chebyshev existence",
+      "Search for trigonometric product formula for Lebesgue function"
+    ]
+  },
+  "tags": [
+    "analysis",
+    "approximation-theory",
+    "chebyshev",
+    "lebesgue-function",
+    "erdos-problems"
+  ],
+  "relatedProofs": [
+    "chebyshev-pnt-bridge",
+    "erdos-1",
+    "erdos-11",
+    "erdos-115",
+    "erdos-1151",
+    "fourier-series"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-04-21T19:30:00.000Z",
+  "lastUpdate": "2026-04-21T19:30:00.000Z",
+  "significance": 7,
+  "tractability": 4,
+  "leanFiles": [
+    {
+      "path": "Proofs/Erdos1151Problem.lean",
+      "filename": "Erdos1151Problem.lean",
+      "lineCount": 185,
+      "theoremCount": 5,
+      "axiomCount": 2,
+      "defCount": 8,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1151Problem.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Pool replenishment: 4 new research problems selected and initialized for the researcher pipeline. Pool goes from 37 → 40 available (well above the 15-problem threshold).

### Problems Selected

| Problem | Tier | Sig | Tract | Domain |
|---------|------|-----|-------|--------|
| `erdos-1151-oq-04` | B | 7 | 4 | Analysis / approximation theory |
| `area-of-circle-oq-05-oq-02` | B | 7 | 7 | Analysis / probability |
| `angle-trisection-oq-04-oq-03` | B | 7 | 6 | Geometry / Galois theory |
| `brouwer-fixed-point-oq-04-oq-02` | A | 8 | 5 | Topology / game theory |

### Problem Details

**erdos-1151-oq-04**: Prove `erdos_1941_divergence` axiom in `Erdos1151Problem.lean` by formalizing the Lebesgue function growth rate Λₙ(cos(πp/q)) → ∞ for rational cosine arguments with odd p, q.

**area-of-circle-oq-05-oq-02**: Multivariate Gaussian integral ∫_{ℝⁿ} e^{-xᵀAx} dx = √(πⁿ/det A) via spectral decomposition + Fubini. Natural extension of the scalar Gaussian in `AreaOfCircleOQ05.lean`.

**angle-trisection-oq-04-oq-03**: Pierpont prime criterion for neusis-constructible n-gons — the analog of Gauss-Wantzel for compass+neusis. A regular n-gon is neusis-constructible iff φ(n) = 2^a · 3^b.

**brouwer-fixed-point-oq-04-oq-02**: Nash equilibrium existence theorem via Kakutani fixed point — Nobel Prize-level application of topology. Uses `kakutani_fixed_point_axiom` from `BrouwerFixedPointOQ04.lean`.

### Domain Diversity

Previous selections (on main): number theory (chebyshev-pnt-bridge), algorithms (binary-gcd), algebra (hurwitz-theorem). New selections cover different domains: analysis, geometry, topology/economics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)