### PR TITLE
Audit: correct assumptions text for erdos-1165 (8→5 axioms)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3029,9 +3029,9 @@
       "result": "clean"
     },
     "erdos-1165": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T10:17:33Z",
+      "lastAudited": "2026-04-21T18:23:16Z",
       "result": "issues-fixed"
     },
     "erdos-1166": {
@@ -3102,9 +3102,9 @@
     },
     "erdos-1175": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T18:13:35Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:21:08Z",
+      "result": "clean"
     },
     "erdos-1176": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-1165/meta.json
+++ b/src/data/proofs/erdos-1165/meta.json
@@ -21,7 +21,7 @@
     "erdosProblemStatus": "solved",
     "axiomCount": 5,
     "lineCount": 183,
-    "assumptions": "8 axioms: VisitCount and FavouriteSites (random walk infrastructure), prob_favourite_count_io with bounds (probability events), toth_favourite_sites_geq_4 (Tóth 2001), hao_li_okada_zheng_three_favourite_sites (Hao et al. 2024), bass_griffin_1d_unique (background). All theorems fully proved from axioms (0 sorries).",
+    "assumptions": "5 axioms: VisitCount and FavouriteSites (random walk infrastructure), prob_favourite_count_io (probability of i.o. event), toth_favourite_sites_geq_4 (Tóth 2001), hao_li_okada_zheng_three_favourite_sites (Hao et al. 2024). All theorems fully proved from axioms (0 sorries).",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Summary

- **erdos-1165**: assumptions narrative text said "8 axioms" but Lean source has exactly 5 axiom declarations. Removed references to non-existent `bass_griffin_1d_unique` axiom (Bass-Griffin result is a comment block, not an axiom) and the "with bounds" probability axioms (no such axioms exist). The `axiomCount` fields were already correct at 5.

## Evidence

```
grep -n "^axiom " proofs/Proofs/Erdos1165Problem.lean
55: axiom VisitCount
73: axiom FavouriteSites
88: axiom prob_favourite_count_io
108: axiom toth_favourite_sites_geq_4
121: axiom hao_li_okada_zheng_three_favourite_sites
```

## Test plan

- [x] Verified 5 axioms by direct grep of Lean source
- [x] Confirmed 0 sorries
- [x] Audit tracker updated to issues-fixed