### PR TITLE
Enrich erdos-1083-oq-02: 2 missing section annotations + Solymosi-Vu/Guth-Katz references

### DIFF
--- a/src/data/proofs/erdos-1083-oq-02/annotations.json
+++ b/src/data/proofs/erdos-1083-oq-02/annotations.json
@@ -58,5 +58,29 @@
     "significance": "context",
     "relatedConcepts": ["Guth-Katz theorem", "incidence geometry", "sum-product theory", "Polynomial Ham Sandwich theorem"],
     "prerequisites": ["distinct distances problem", "Guth-Katz 2015", "polynomial method"]
+  },
+  {
+    "id": "ann-sv-coverage-analysis",
+    "proofId": "erdos-1083-oq-02",
+    "range": { "startLine": 131, "endLine": 262 },
+    "type": "technique",
+    "title": "SV Coverage Analysis: Gap Bounds, Monotonicity, and Threshold Dimensions",
+    "content": "This section proves structural results about the SV exponent gap. `gap_below_twice_reciprocal_sq` (lines 137-144): 2/(d(d+2)) < 2/d², combined with the lower bound 1/d² < gap gives 1/d² < gap < 2/d². `gap_strictly_decreasing` (148-162): the gap is strictly decreasing in d, proved by (d+1)(d+3) - d(d+2) = 2d+3 > 0 via `nlinarith`. `sv_fraction_increasing`: (d+1)/(d+2) is strictly increasing in d. Progress analysis: SV closes d/(d+2) of the full Erdős→conjecture gap (= 1/d); SV improvement over Erdős is exactly 1/(d+2), proved by `field_simp; ring`. Threshold theorems: `sv_covers_three_quarters` (d≥6 gives ≥75% gap coverage), `sv_covers_eleven_twelfths` (d≥22 gives ≥11/12).",
+    "mathContext": "Progress fraction: SV exponent $-$ Erdős exponent $= 2(d+1)/(d(d+2)) - 1/d = 1/(d+2)$. Fraction of gap closed: $(1/(d+2)) \\div (1/d) = d/(d+2)$. Sandwich on gap: $1/d^2 < 2/(d(d+2)) < 2/d^2$ (since $d(d+2) = d^2 + 2d \\in (d^2, 2d^2)$). Thresholds: $d \\geq 6 \\Rightarrow d/(d+2) \\geq 3/4$; $d \\geq 22 \\Rightarrow d/(d+2) \\geq 11/12$.",
+    "significance": "supporting",
+    "relatedConcepts": ["gap sandwich bounds", "monotone exponent functions", "threshold dimension", "coverage fraction d/(d+2)", "field_simp ring tactic"],
+    "prerequisites": ["gap_formula result", "div_lt_div_iff", "nlinarith with polynomial hints", "linarith"]
+  },
+  {
+    "id": "ann-guth-katz-contrast",
+    "proofId": "erdos-1083-oq-02",
+    "range": { "startLine": 264, "endLine": 372 },
+    "type": "insight",
+    "title": "Guth-Katz (d=2) vs Solymosi-Vu (d≥4): Why d=2 Was Solved But d≥3 Remains Open",
+    "content": "The final section axiomatizes the Erdős conjecture (∀ε>0, f_d(n) ≥ c·n^{2/d-ε}) and the Guth-Katz (2015) theorem for d=2 (f_2(n) ≥ c·n^{1-ε}). `gk_implies_erdos_conjecture_d2` proves GK implies the d=2 Erdős conjecture — GK exponent 1-ε = 2/2-ε matches the conjecture. `gk_exceeds_sv_d2` proves GK exponent (1-ε) exceeds SV formula 3/4 at d=2, confirming GK is strictly stronger. Dimensional evaluations: `sv_exponent_d2 = 3/4` (SV at d=2: gap 1/4, the largest gap in the sequence), `sv_exponent_d3 = 8/15` (gap 2/15 at d=3). The d=2 success via Guth-Katz used the polynomial method (Polynomial Ham Sandwich + incidence geometry for lines in ℝ²), which does not generalize to d≥3 without new ideas.",
+    "mathContext": "GK theorem: $f_2(n) \\geq c \\cdot n/\\log n$ (exponent $1-o(1) = 2/2 - o(1)$). SV at $d=2$: $2(3)/(2 \\cdot 4) = 3/4$, gap $= 1/4$ (largest). SV at $d=3$: $2(4)/(3 \\cdot 5) = 8/15$, gap $= 2/15$. The polynomial method partitions $\\mathbb{R}^2$ via a degree-$D$ polynomial to bound point-line incidences — a 2D technique that has resisted 3D generalization. Borsuk-Ulam / ham sandwich results underlie the partition step.",
+    "significance": "key",
+    "relatedConcepts": ["Guth-Katz 2015 polynomial method", "polynomial ham sandwich theorem", "incidence geometry d=2 vs d≥3", "Szemerédi-Trotter theorem"],
+    "prerequisites": ["Guth-Katz theorem statement", "polynomial method in combinatorics", "SV exponent formula at d=2,3"]
   }
 ]

--- a/src/data/proofs/erdos-1083-oq-02/meta.json
+++ b/src/data/proofs/erdos-1083-oq-02/meta.json
@@ -114,11 +114,39 @@
     ],
     "implications": "Quantifies the precise gap between the best known incidence geometry bound (Solymosi-Vu) and the conjectured optimal exponent 2/d for distinct distances in ℝ^d. The exact formula 2/(d(d+2)) provides a concrete target: any improvement to the SV bound must gain at least this much in the exponent. The formalization cleanly separates the provable algebraic analysis from the axiomatized geometric content."
   },
+  "references": [
+    {
+      "authors": "Solymosi, József; Vu, Van H.",
+      "title": "Near optimal bounds for the Erdős distinct distances problem in high dimensions",
+      "year": "2008",
+      "venue": "Combinatorica 28(1), 113–125",
+      "note": "Proves f_d(n) ≥ c·n^{2(d+1)/(d(d+2))} for d ≥ 3 using incidence geometry and sum-product estimates; the axiomatized theorem solymosi_vu encodes this bound"
+    },
+    {
+      "authors": "Guth, Larry; Katz, Nets Hawk",
+      "title": "On the Erdős distinct distances problem in the plane",
+      "year": "2015",
+      "venue": "Annals of Mathematics 181(1), 155–190",
+      "note": "Proves f_2(n) ≥ cn/log n for the plane, essentially resolving the d=2 Erdős conjecture via the polynomial method (polynomial partitioning + ham sandwich theorem); axiomatized as guth_katz"
+    },
+    {
+      "authors": "Erdős, Paul",
+      "title": "On sets of distances of n points",
+      "year": "1946",
+      "venue": "American Mathematical Monthly 53(5), 248–250",
+      "note": "Original paper posing the distinct distances problem; proves the lower bound f_d(n) ≥ c·n^{1/d} via a simple pigeonhole/volume argument; conjectures the true bound is Θ(n^{2/d})"
+    }
+  ],
   "crossReferences": [
     {
       "targetId": "erdos-1083",
       "relationship": "parent",
       "description": "Parent problem: distinct distances in higher dimensions — the main Erdős Problem #1083"
+    },
+    {
+      "targetId": "borsuk-ulam",
+      "relationship": "related",
+      "description": "The Borsuk-Ulam and Polynomial Ham Sandwich theorems underlie the Guth-Katz polynomial method — the technique that resolved d=2 but has not generalized to d≥3"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Enrichment: erdos-1083-oq-02

**Distinct Distances Gap Analysis: Solymosi-Vu Bound** — quality 98, pass 1

Lines 131-372 (coverage-analysis and guth-katz-comparison sections) had no annotations.

### Changes

**annotations.json**
- Added `ann-sv-coverage-analysis` (lines 131–262): covers the unannotated coverage analysis section — gap sandwich bounds (1/d² < 2/(d(d+2)) < 2/d²), gap monotonicity (`gap_strictly_decreasing` via (d+1)(d+3)-d(d+2) = 2d+3 with `nlinarith`), SV fraction increasing, SV improvement = 1/(d+2) via `field_simp; ring`, and threshold theorems (d≥6 → ≥75% gap coverage, d≥22 → ≥11/12)
- Added `ann-guth-katz-contrast` (lines 264–372): covers the unannotated GK contrast section — Guth-Katz 2015 axiom, `gk_implies_erdos_conjecture_d2` proof, `gk_exceeds_sv_d2` result, dimensional evaluations (d=2 gap 1/4 largest, d=3 gap 2/15), and explanation of why polynomial method doesn't generalize to d≥3

**meta.json**
- Added `references` array: Solymosi-Vu 2008, Guth-Katz 2015, Erdős 1946 original paper
- Added `borsuk-ulam` cross-reference: ham sandwich theorem underlies the GK polynomial method

🤖 Generated with [Claude Code](https://claude.ai/claude-code)