### PR TITLE
Fix: add missing lineCount to schroeder-bernstein-oq-03 meta.json

### DIFF
--- a/src/data/proofs/schroeder-bernstein-oq-03/meta.json
+++ b/src/data/proofs/schroeder-bernstein-oq-03/meta.json
@@ -19,6 +19,7 @@
     "badge": "wip",
     "sorries": 4,
     "axiomCount": 0,
+    "lineCount": 257,
     "mathlibDependencies": [
       {
         "theorem": "OneOneReducible",


### PR DESCRIPTION
## Fix

Added missing `lineCount` field to `schroeder-bernstein-oq-03/meta.json`.

## Evidence

**Before**: `lineCount` key absent (evaluated as `null`/0) in `meta.json`
**After**: `lineCount: 257` matching actual line count of `proofs/Proofs/SchroederBernsteinOQ03.lean`

## Validation

`pnpm build` completes successfully with no errors.

---
Automated fix by lean-mechanic agent.