### PR TITLE
Enrich cantor-diagonalization-oq-01-oq-01-oq-02-oq-03: fix factual errors + add header

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-02-oq-03/annotations.json
@@ -88,10 +88,10 @@
   {
     "id": "ann-easton-consistency-sorry",
     "proofId": "cantor-diagonalization-oq-01-oq-01-oq-02-oq-03",
-    "range": { "startLine": 92, "endLine": 132 },
+    "range": { "startLine": 92, "endLine": 138 },
     "type": "context",
-    "title": "The Deep Direction: Easton Forcing (Sorry)",
-    "content": "This section contains the sorry'd deep direction of Easton's theorem: any Easton function is REALIZABLE as the continuum function in some forcing extension of ZFC. `easton_consistency` is formalized as a trivial placeholder (concludes `True`), while `easton_iff_characterization` has the sorry. The comment explains why: class forcing — specifically Easton product forcing that adds $F(\\alpha) - \\aleph_\\alpha$ many Cohen subsets to each regular $\\aleph_\\alpha$ simultaneously — is not formalized in Mathlib. This is a fundamental limitation: Easton's theorem is a metamathematical statement about ZFC models, not a theorem within ZFC.",
+    "title": "The Deep Direction: Easton Forcing (Acknowledged Limitation)",
+    "content": "This section contains the deep direction of Easton's theorem: any Easton function is REALIZABLE as the continuum function in some forcing extension of ZFC. Three theorems appear here: `easton_consistency`, `easton_full_characterization`, and `easton_iff_characterization`. All three conclude `True` rather than the actual forcing statement — an honest acknowledgment that class forcing (Easton product forcing) is not in Mathlib, not a sorry gap. The file has 0 sorries and 0 axioms; the mathematical limitation is deliberate and documented. The comment explains why: class forcing — specifically Easton product forcing that adds $F(\\alpha) - \\aleph_\\alpha$ many Cohen subsets to each regular $\\aleph_\\alpha$ simultaneously — is not formalized in Mathlib. This is a fundamental limitation: Easton's theorem is a metamathematical statement about ZFC models, not a theorem within ZFC.",
     "mathContext": "Easton product forcing: for each regular cardinal $\\kappa$, add $F(\\kappa)$-many Cohen subsets to $\\kappa$ via a product of Cohen forcings $\\prod_{\\kappa \\text{ regular}} \\mathrm{Add}(\\kappa, F(\\kappa))$ with Easton support. This forces $2^\\kappa = F(\\kappa)$ for all regular $\\kappa$ while preserving all cardinals. The proof that GCH violations don't 'interfere' between different regular cardinals is the hard part, requiring the Easton lemma about products with varying chain conditions.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -111,22 +111,51 @@
   {
     "id": "ann-easton-excluded",
     "proofId": "cantor-diagonalization-oq-01-oq-01-oq-02-oq-03",
-    "range": { "startLine": 138, "endLine": 151 },
+    "range": { "startLine": 143, "endLine": 170 },
     "type": "insight",
-    "title": "König Excludes ℵ_{α+ω}: A Concrete Application",
-    "content": "A concrete example of König's constraint in action: $2^{\\aleph_\\alpha} \\neq \\aleph_{\\alpha+\\omega}$, because $\\aleph_{\\alpha+\\omega}$ is a limit cardinal with cofinality $\\omega \\leq \\aleph_\\alpha$, violating E3. The proof derives a contradiction: if $2^{\\aleph_\\alpha} = \\aleph_{\\alpha+\\omega}$, then König's theorem gives $\\aleph_\\alpha < \\mathrm{cf}(\\aleph_{\\alpha+\\omega})$, but $\\mathrm{cf}(\\aleph_{\\alpha+\\omega}) = \\omega \\leq \\aleph_\\alpha$. The second sorry is the cofinality computation $\\mathrm{cf}(\\aleph_{\\alpha+\\omega}) = \\omega$.",
-    "mathContext": "$\\mathrm{cf}(\\aleph_{\\alpha+\\omega}) = \\omega$ because $\\aleph_{\\alpha+\\omega} = \\sup_{n < \\omega} \\aleph_{\\alpha+n}$ is a countably cofinal limit. By König: $\\aleph_\\alpha < \\mathrm{cf}(2^{\\aleph_\\alpha})$, but if $2^{\\aleph_\\alpha} = \\aleph_{\\alpha+\\omega}$ then $\\mathrm{cf}(2^{\\aleph_\\alpha}) = \\omega \\leq \\aleph_\\alpha$ (for $\\alpha \\geq 1$) — contradiction. For $\\alpha = 0$: $2^{\\aleph_0} \\neq \\aleph_\\omega$ is the classic Easton application.",
-    "significance": "supporting",
+    "title": "König Excludes ℵ_{α+ω}: A Fully Proved Concrete Application",
+    "content": "A fully proved concrete example of König's constraint: $2^{\\aleph_\\alpha} \\neq \\aleph_{\\alpha+\\omega}$, because $\\aleph_{\\alpha+\\omega}$ has cofinality $\\omega \\leq \\aleph_\\alpha$, violating E3.\n\nThe Lean proof (lines 151–170) derives a contradiction from the assumption $2^{\\aleph_\\alpha} = \\aleph_{\\alpha+\\omega}$:\n1. König gives $\\aleph_\\alpha < (\\aleph_{\\alpha+\\omega}).\\mathrm{ord.cof}$\n2. A cofinality chain computes $(\\aleph_{\\alpha+\\omega}).\\mathrm{ord.cof} = \\aleph_0 \\leq \\aleph_\\alpha$:\n   - `rw [ord_aleph]` converts aleph ord to omega_\n   - `cof_omega (isSuccLimit_add α isSuccLimit_omega0)` uses that $\\alpha+\\omega$ is a limit ordinal\n   - `cof_add α ω omega0_ne_zero` reduces to $\\mathrm{cof}(\\omega)$\n   - `cof_omega0` gives $\\mathrm{cof}(\\omega) = \\aleph_0$\n3. This contradicts $\\aleph_\\alpha < \\aleph_0 \\leq \\aleph_\\alpha$.\n\nThis theorem is fully proved with 0 sorries — the cofinality computation uses four Mathlib lemmas chained together.",
+    "mathContext": "$\\mathrm{cf}(\\aleph_{\\alpha+\\omega}) = \\omega$ because $\\aleph_{\\alpha+\\omega} = \\sup_{n < \\omega} \\aleph_{\\alpha+n}$ is a countably cofinal limit. By König: $\\aleph_\\alpha < \\mathrm{cf}(2^{\\aleph_\\alpha})$, but if $2^{\\aleph_\\alpha} = \\aleph_{\\alpha+\\omega}$ then $\\mathrm{cf}(2^{\\aleph_\\alpha}) = \\omega \\leq \\aleph_\\alpha$ — contradiction. For $\\alpha = 0$: $2^{\\aleph_0} \\neq \\aleph_\\omega$ is the classic application. Key chain: `ord_aleph → cof_omega (isSuccLimit) → cof_add → cof_omega0`.",
+    "significance": "key",
     "relatedConcepts": [
       "König's theorem",
       "cofinality of limit alephs",
       "singular cardinals",
-      "excluded values"
+      "excluded values",
+      "ord_aleph",
+      "cof_omega",
+      "cof_add"
     ],
     "prerequisites": [
       "easton_konig_aleph",
-      "cofinality computation",
-      "limit cardinals"
+      "ord_aleph",
+      "cof_omega",
+      "cof_add",
+      "cof_omega0",
+      "isSuccLimit_add"
+    ]
+  },
+  {
+    "id": "ann-easton-header",
+    "proofId": "cantor-diagonalization-oq-01-oq-01-oq-02-oq-03",
+    "range": { "startLine": 1, "endLine": 34 },
+    "type": "context",
+    "title": "Easton's Theorem: What This File Proves",
+    "content": "This file formalizes the necessary conditions for Easton's theorem — the complete characterization of which functions can serve as the generalized continuum function $\\alpha \\mapsto 2^{\\aleph_\\alpha}$ on regular cardinals.\n\nThe three necessary conditions (E1)–(E3) are what ZFC can prove without forcing. Easton's 1970 result is that these are also sufficient — any function satisfying them is realizable via class forcing. The sufficiency direction requires forcing infrastructure not in Mathlib, so it is stated with conclusion True.\n\nImports: three Mathlib cardinal modules provide the key lemmas — `Cardinal.Basic` for the aleph function and Cantor's theorem, `Cardinal.Ordinal` for the ord/aleph correspondence, and `Cardinal.Cofinality` for König's theorem (`lt_cof_power`) and the cofinality computation machinery.",
+    "mathContext": "Easton's spectrum: a function $F: \\mathrm{Ord} \\to \\mathrm{Card}$ is an **Easton function** iff (E1) $F(\\alpha) \\geq \\aleph_{\\alpha+1}$, (E2) $F$ is monotone, (E3) $\\mathrm{cf}(F(\\alpha)) > \\aleph_\\alpha$ for regular $\\aleph_\\alpha$. Easton proved these characterize exactly the functions realizable as $2^{\\aleph_\\alpha}$ in some ZFC model.",
+    "significance": "context",
+    "relatedConcepts": [
+      "generalized continuum hypothesis",
+      "Easton's theorem",
+      "class forcing",
+      "König's theorem",
+      "regular cardinals"
+    ],
+    "prerequisites": [
+      "cardinal arithmetic",
+      "aleph function",
+      "cofinality",
+      "set-theoretic forcing (conceptual)"
     ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for **Easton's Theorem: The Full Spectrum of the Generalized Continuum Function** (cantor-diagonalization-oq-01-oq-01-oq-02-oq-03).

## Quality improvements

- **Fixed factual error in `ann-easton-excluded`**: previous annotation stated "The second sorry is the cofinality computation cf(ℵ_{α+ω}) = ω" — but the Lean file fully proves this computation via a four-lemma chain (`ord_aleph → cof_omega → cof_add → cof_omega0`). Removed the incorrect sorry reference, expanded content to document the full proof steps, expanded range from 138–151 to 143–170.
- **Fixed misleading title in `ann-easton-consistency-sorry`**: title said "Sorry" but the file has 0 sorries — the forcing boundary theorems use `trivial` (conclusion `True`) as an honest acknowledgment, not a sorry. Renamed to "Acknowledged Limitation" and updated content accordingly. Expanded range to 92–138 to cover all three forcing-boundary theorems.
- **Added `ann-easton-header`** (lines 1–34): context annotation explaining what the file proves, why the sufficiency direction concludes True rather than the real mathematical content, and which Mathlib modules provide the key lemmas.