### PR TITLE
Enrich erdos-1107-oq-02: fix crossRef schema, add missing section + header

### DIFF
--- a/src/data/proofs/erdos-1107-oq-02/annotations.json
+++ b/src/data/proofs/erdos-1107-oq-02/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-erdos1107-oq02-header",
+    "proofId": "erdos-1107-oq-02",
+    "range": { "startLine": 1, "endLine": 28 },
+    "type": "context",
+    "title": "Effectivizing Heath-Brown: From Existence to Exact Threshold",
+    "content": "Erdős Problem #1107 OQ-02 asks for the effective version of Heath-Brown's theorem: not just that a threshold N exists, but what N is. The file header explains the strategy: computational exhaustion to 1000 (via `native_decide`) identifies exactly which integers fail, confirming N=120 and the six exceptions {7, 15, 23, 87, 111, 119}.\n\nImports: `Nat.Prime.Defs` and `Nat.Factorization.Basic` provide `Nat.primeFactors` for the squareful definition. The `open Nat` makes `primeFactors` and `primeFactorsList` available without prefix.",
+    "mathContext": "Heath-Brown's 1988 theorem (from his paper in *Séminaire de Théorie des Nombres, Paris 1986–87*) uses ternary quadratic forms to show every large $n$ is a sum of three squareful numbers. The original proof gives no explicit threshold. This formalization provides the threshold $N = 120$ and proves it is sharp.",
+    "significance": "context",
+    "relatedConcepts": ["Heath-Brown theorem", "ternary quadratic forms", "effective theorems", "squareful numbers", "Nat.primeFactors"],
+    "prerequisites": ["Nat.primeFactors", "squareful (2-powerful) numbers", "ternary quadratic forms (conceptual)"]
+  },
+  {
     "id": "ann-squareful-def",
     "proofId": "erdos-1107-oq-02",
     "range": { "startLine": 30, "endLine": 57 },

--- a/src/data/proofs/erdos-1107-oq-02/meta.json
+++ b/src/data/proofs/erdos-1107-oq-02/meta.json
@@ -76,12 +76,20 @@
       "mathContext": "Nine range checks, each covering 100 consecutive integers, verified by native_decide."
     },
     {
+      "id": "basic-properties",
+      "title": "Basic Properties and Threshold Decomposition",
+      "startLine": 98,
+      "endLine": 121,
+      "summary": "Establishes that 0, 1, 4, 8, 9, 27, 108 are squareful, and that 120 = 4+8+108 is the first representable value above the exceptions. Threshold tightness: 119 fails, 120 succeeds.",
+      "mathContext": "Key decomposition: $120 = 4 + 8 + 108 = 2^2 + 2^3 + 2^2 \\cdot 3^3$, proving the threshold is achieved. Tightness via `threshold_tight = not_sum3_119`."
+    },
+    {
       "id": "main-result",
-      "title": "Main Result",
-      "startLine": 110,
-      "endLine": 130,
-      "summary": "The effective threshold theorem and tightness.",
-      "mathContext": "The main axiom states every n ≥ 120 is representable. Tightness: 119 is not."
+      "title": "Main Result: Effective Heath-Brown",
+      "startLine": 122,
+      "endLine": 156,
+      "summary": "The main axiom squareful_sum_threshold encodes Heath-Brown's theorem for n ≥ 120. Summary section documents the three-part result.",
+      "mathContext": "axiom `squareful_sum_threshold`: $\\forall n \\geq 120$, $n$ is a sum of 3 squareful numbers. Encodes the infinite part (beyond computational verification) via the Heath-Brown ternary quadratic forms argument."
     }
   ],
   "conclusion": {
@@ -94,9 +102,9 @@
   },
   "crossReferences": [
     {
-      "proofId": "erdos-1107",
+      "targetId": "erdos-1107",
       "relationship": "parent",
-      "description": "Parent problem: general r-powerful sum conjecture"
+      "description": "Parent problem: general r-powerful sum conjecture for all r ≥ 2"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
Enrichment pass for **Effective Squareful Sum Threshold** (erdos-1107-oq-02).

## Quality improvements

- **Fixed schema bug**: `crossReferences[0].proofId` → `targetId` (the field name per gallery schema was wrong)
- **Added missing section** `basic-properties` (lines 98–121) to meta.json: the Lean file has a "## Basic Properties" section but meta.json had no corresponding section — jumping from verification (line 96) to main-result at wrong line 110
- **Fixed `main-result` section** `startLine` from 110 → 122 (actual Lean content start)
- **Added header annotation** (lines 1–28): context about Heath-Brown's effectivization strategy and the import choices