### PR TITLE
Fix: add missing assumptions text to 3 axiomatized proofs

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-03/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-03/meta.json
@@ -23,6 +23,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
+    "assumptions": "1 axiom: HilbertSymbol (the Hilbert symbol for p-adic quadratic solubility, axiomatized pending full p-adic infrastructure in Mathlib). The three proved theorems use only Mathlib's legendreSym.",
     "dateAdded": "2026-03-28",
     "lineCount": 102
   },

--- a/src/data/proofs/erdos-1202/meta.json
+++ b/src/data/proofs/erdos-1202/meta.json
@@ -19,6 +19,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
+    "assumptions": "1 axiom: erdos_1202_threshold (the quantitative density threshold encoding the core content of Erdős #1202; axiomatized because the precise structural property of the prime subset is not recoverable from available source fragments).",
     "lineCount": 115,
     "erdosNumber": 1202,
     "erdosUrl": "https://erdosproblems.com/1202",

--- a/src/data/proofs/konigsberg-oq-04/meta.json
+++ b/src/data/proofs/konigsberg-oq-04/meta.json
@@ -19,6 +19,7 @@
     "sorries": 0,
     "dateAdded": "2026-03-30",
     "axiomCount": 1,
+    "assumptions": "1 axiom: best_theorem (the BEST theorem counting directed Eulerian circuits via Matrix Tree Theorem; axiomatized pending Mathlib formalization of the arborescence-bijection proof).",
     "lineCount": 338
   },
   "overview": {


### PR DESCRIPTION
## Fix

Three `axiomatized` gallery proofs had `axiomCount: 1` but no human-readable `assumptions` field naming the actual axiom.

## Evidence

| Proof | Axiom | Before | After |
|-------|-------|--------|-------|
| elementary-quadratic-reciprocity-oq-03-oq-03 | `HilbertSymbol` | missing | "1 axiom: HilbertSymbol (p-adic quadratic solubility, axiomatized pending Mathlib p-adic infrastructure)" |
| erdos-1202 | `erdos_1202_threshold` | missing | "1 axiom: erdos_1202_threshold (quantitative density threshold encoding core of Erdős #1202)" |
| konigsberg-oq-04 | `best_theorem` | missing | "1 axiom: best_theorem (BEST theorem for Eulerian circuit counting, axiomatized pending Matrix Tree Theorem formalization)" |

## Verification

`pnpm build` completes successfully with no errors.

---
Automated fix by lean-mechanic agent.