### PR TITLE
Enrich bertrands-postulate-oq-03-oq-04-oq-03: fix section boundary errors

### DIFF
--- a/src/data/proofs/bertrands-postulate-oq-03-oq-04-oq-03/meta.json
+++ b/src/data/proofs/bertrands-postulate-oq-03-oq-04-oq-03/meta.json
@@ -115,17 +115,17 @@
       "id": "interval-density",
       "title": "Interval Density from PNT",
       "startLine": 128,
-      "endLine": 175,
-      "summary": "pnt_density_long_interval: (π((1+c)x) - π(x))·log(x)/(cx) → 1. The main density theorem.",
-      "mathContext": "Decompose as (1+c)/c × [pnt_at_scaled_point] - 1/c × [PNT]. Use const_mul and sub for the filter limit combination. Use filter_upwards + field_simp + ring for algebraic matching."
+      "endLine": 183,
+      "summary": "pnt_density_long_interval: (π((1+c)x) - π(x))·log(x)/(cx) → 1. The main density theorem, including the final algebraic cleanup via field_simp and ring.",
+      "mathContext": "Decompose as (1+c)/c × [pnt_at_scaled_point] - 1/c × [PNT]. Use const_mul and sub for the filter limit combination. Use filter_upwards + field_simp + ring for algebraic matching. The proof ends at line 182 with `ring`."
     },
     {
       "id": "gap-summary",
       "title": "Density Gap Summary",
-      "startLine": 177,
-      "endLine": 185,
-      "summary": "pnt_density_gap_summary: packages the proved long-interval result and the open short-interval implication.",
-      "mathContext": "Part (1) references pnt_density_long_interval. Part (2) references the public theorem shortIntervalPNT_implies_primeGapConjecture_eventually from OQ-04."
+      "startLine": 184,
+      "endLine": 212,
+      "summary": "pnt_density_gap_summary: packages the proved long-interval result and the open short-interval implication. Includes Part 4 section separator and end of namespace.",
+      "mathContext": "Part (1) references pnt_density_long_interval. Part (2) references the public theorem shortIntervalPNT_implies_primeGapConjecture_eventually from OQ-04. The theorem explicitly names what is proved vs what is open."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for **PNT Density Asymptotic for Prime Gaps: Filter Algebra Proof** (bertrands-postulate-oq-03-oq-04-oq-03).

## Quality improvements

- **Fixed `interval-density` section boundary**: `endLine` was 175, but the `pnt_density_long_interval` proof continues to line 182 with the `ring` tactic that closes the algebraic equality goal. The section was truncated 7 lines early, missing the `filter_upwards` guard and the final `field_simp; ring` cleanup.
- **Fixed `gap-summary` section boundary**: `startLine` was 177 (middle of the density theorem proof) and `endLine` was 185 (only covering 9 lines). Corrected to 184–212 — starting at the "PART 4: Connection to Open Problem" separator comment and ending at the actual file end (line 212 is `end BertrandsPostulateOQ03OQ04OQ03`).