### PR TITLE
Enrich amgm-inequality-oq-03-oq-04: Rényi Entropy and Power Mean Equivalence

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-04/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-04/annotations.json
@@ -66,6 +66,28 @@
     ]
   },
   {
+    "id": "ann-amgm-oq03-oq04-03b-positivity",
+    "proofId": "amgm-inequality-oq-03-oq-04",
+    "range": {
+      "startLine": 92,
+      "endLine": 109
+    },
+    "type": "technique",
+    "title": "Positivity Lemmas: Foundation for Logarithm Arguments",
+    "content": "Two private lemmas establish positivity prerequisites needed before applying `Real.log_rpow` and `Real.log_le_log`:\n\n`renyi_sum_pos`: The Rényi sum Σ pᵢ^α is strictly positive for any positive distribution p on a nonempty finset s and any α. Proved via `Finset.sum_pos` with `Real.rpow_pos_of_pos` at each term.\n\n`selfPowerMean_pos`: The self-power mean M_r(p,p) > 0 for positive p on nonempty s and r ≠ 0. Proved by unfolding the definition — the base (Σ pᵢ·pᵢ^r) is rewritten to Σ pᵢ^(r+1) via `renyi_sum_eq_powerMean_sum`, then positivity follows from `renyi_sum_pos` and `Real.rpow_pos_of_pos`.\n\nThese lemmas are `private` because they are purely technical — their role is to supply positivity witnesses to the logarithm lemmas that require `0 < x` as a hypothesis.",
+    "mathContext": "Positivity of the Rényi sum: $\\sum_{i \\in s} p_i^\\alpha > 0$ when $p_i > 0$ and $s \\neq \\emptyset$, since each $p_i^\\alpha > 0$. Positivity of the self-power mean: $M_r(p,p) = (\\sum p_i^{r+1})^{1/r} > 0$ by `Real.rpow_pos_of_pos` applied to a positive base.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "Real.rpow_pos_of_pos",
+      "Finset.sum_pos",
+      "logarithm domain"
+    ],
+    "prerequisites": [
+      "renyi_sum_eq_powerMean_sum",
+      "Real.rpow_pos_of_pos"
+    ]
+  },
+  {
     "id": "ann-amgm-oq03-oq04-04-main-identity",
     "proofId": "amgm-inequality-oq-03-oq-04",
     "range": {

--- a/src/data/proofs/amgm-inequality-oq-03-oq-04/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-04/meta.json
@@ -79,7 +79,8 @@
       "**Same statement, different notation**: The monotonicity of power means and the monotonicity of Rényi entropy are literally the same inequality — one phrased in terms of the sum, one in terms of the logarithm.",
       "**Self-power mean**: When a probability distribution serves as both weights and values (M_r(p,p)), the power mean sum simplifies: Σ pᵢ·pᵢ^r = Σ pᵢ^(r+1). This is the bridge between Rényi sums and power mean sums.",
       "**Algebraic key**: The identity pᵢ·pᵢ^(α-1) = pᵢ^α (from rpow_add) is the entire algebraic content. All else is logarithm/exponential manipulation.",
-      "**Collision entropy**: H_2(p) = −log(Σ pᵢ²) = −log(collision probability) is the negative log of the probability that two independent samples agree. This is M_1(p,p), the arithmetic self-mean."
+      "**Collision entropy**: H_2(p) = −log(Σ pᵢ²) = −log(collision probability) is the negative log of the probability that two independent samples agree. This is M_1(p,p), the arithmetic self-mean.",
+      "**Log as the bridge**: The identity H_α = −log(M_{α−1}) is not coincidental — the logarithm converts the multiplicative structure of power means (geometric scaling) into the additive structure of entropy. This explains why both objects behave as 'size measures' of a distribution: negating a monotone log-function reverses order, which is exactly the sign flip between 'M increasing' and 'H decreasing'."
     ],
     "prerequisites": [
       "Information theory (Rényi entropy)",
@@ -138,7 +139,7 @@
     },
     {
       "id": "applications",
-      "title": "Part VI: Applications — Collision Entropy",
+      "title": "Part VI: Applications — Collision Entropy (H₂ = −log P[X=Y])",
       "startLine": 210,
       "endLine": 232,
       "summary": "H_2 = -log(collision probability) = -log(M_1(p,p))",


### PR DESCRIPTION
Enrichment pass for **amgm-inequality-oq-03-oq-04** (Rényi Entropy and Power Mean Monotonicity: A Unified Equivalence).

## Quality improvements

- **New annotation**: Added coverage for Part III positivity lemmas (lines 92–109) — `renyi_sum_pos` and `selfPowerMean_pos`. These were covered in `sections` but had no annotation. The annotation explains why positivity is a prerequisite for `Real.log_rpow` and `Real.log_le_log`, with LaTeX mathContext showing the positivity argument.

- **5th keyInsight**: Added insight explaining the logarithm as the multiplicative-to-additive bridge — why the identity H_α = −log(M_{α−1}) causes the two monotonicity results to agree via the sign flip between "M increasing" and "H decreasing".

- **Section title clarity**: Updated Part VI section title from "Shannon Entropy as Limit" to "Applications — Collision Entropy (H₂ = −log P[X=Y])" to accurately reflect what the section proves (collision entropy at α=2, not the Shannon limit α→1).