### PR TITLE
Audit tracker: 230+ proofs re-audited (bulk assumptions text corrections)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1949,9 +1949,9 @@
       "result": "issues-fixed"
     },
     "erdos-102": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T10:17:33Z",
+      "lastAudited": "2026-04-21T18:53:44Z",
       "result": "issues-fixed"
     },
     "erdos-1020": {
@@ -2009,16 +2009,16 @@
       "result": "clean"
     },
     "erdos-1028": {
-      "auditCount": 3,
-      "issues": [],
-      "lastAudited": "2026-04-03T21:51:32Z",
-      "result": "clean"
-    },
-    "erdos-1029": {
       "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-03T21:51:32Z",
-      "result": "clean"
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
+    },
+    "erdos-1029": {
+      "auditCount": 5,
+      "issues": [],
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-103": {
       "auditCount": 4,
@@ -2039,16 +2039,16 @@
       "result": "clean"
     },
     "erdos-1031": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-04-03T21:54:44Z",
-      "result": "clean"
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-1032": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-03T21:54:44Z",
-      "result": "clean"
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-1033": {
       "auditCount": 4,
@@ -2058,8 +2058,8 @@
     },
     "erdos-1034": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 5,
-      "lastAudited": "2026-04-03T21:54:44Z",
+      "auditCount": 6,
+      "lastAudited": "2026-04-21T18:53:44Z",
       "result": "issues-fixed"
     },
     "erdos-1035": {
@@ -2123,10 +2123,10 @@
       "result": "clean"
     },
     "erdos-1044": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-03T21:54:44Z",
-      "result": "clean"
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-1045": {
       "auditCount": 3,
@@ -2135,10 +2135,10 @@
       "result": "clean"
     },
     "erdos-1046": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-03T21:54:45Z",
-      "result": "clean"
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-1047": {
       "auditCount": 3,
@@ -2219,16 +2219,16 @@
       "result": "issues-fixed"
     },
     "erdos-1057": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-03T21:54:45Z",
-      "result": "clean"
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-1058": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-03T21:54:45Z",
-      "result": "clean"
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-1059": {
       "auditCount": 3,
@@ -2315,10 +2315,10 @@
       "result": "clean"
     },
     "erdos-1067": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-03T21:57:29Z",
-      "result": "clean"
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-1068": {
       "auditCount": 3,
@@ -2369,10 +2369,10 @@
       "result": "issues-fixed"
     },
     "erdos-1075": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-03T21:57:30Z",
-      "result": "clean"
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-1076": {
       "auditCount": 3,
@@ -2388,14 +2388,14 @@
     },
     "erdos-1078": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-21T18:53:44Z",
       "result": "issues-fixed"
     },
     "erdos-1079": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-21T18:53:44Z",
       "result": "issues-fixed"
     },
     "erdos-108": {
@@ -2418,15 +2418,15 @@
     },
     "erdos-1082": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:57:30Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-1083": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:57:30Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-1084": {
       "agentId": "auditor-cycle-20-batch",
@@ -2454,21 +2454,21 @@
     },
     "erdos-1087": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-03T21:57:30Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-1088": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:57:30Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-1089": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:57:30Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-109": {
       "agentId": "auditor-cycle-20-batch",
@@ -2520,9 +2520,9 @@
     },
     "erdos-1096": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:57:30Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-1097": {
       "agentId": "auditor-cycle-20-batch",
@@ -2586,20 +2586,20 @@
     },
     "erdos-1102": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-21T18:53:44Z",
       "result": "issues-fixed"
     },
     "erdos-1103": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-21T18:53:44Z",
       "result": "issues-fixed"
     },
     "erdos-1104": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-21T18:53:44Z",
       "result": "issues-fixed"
     },
     "erdos-1105": {
@@ -2652,8 +2652,8 @@
     },
     "erdos-1112": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-21T18:53:44Z",
       "result": "issues-fixed"
     },
     "erdos-1113": {
@@ -2664,8 +2664,8 @@
     },
     "erdos-1114": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-21T18:53:44Z",
       "result": "issues-fixed"
     },
     "erdos-1115": {
@@ -2711,21 +2711,21 @@
       "result": "issues-fixed"
     },
     "erdos-1120": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T10:17:33Z",
+      "lastAudited": "2026-04-21T18:53:44Z",
       "result": "issues-fixed"
     },
     "erdos-1121": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T10:17:33Z",
+      "lastAudited": "2026-04-21T18:53:44Z",
       "result": "issues-fixed"
     },
     "erdos-1122": {
-      "auditCount": 2,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-03T10:17:33Z",
+      "lastAudited": "2026-04-21T18:53:44Z",
       "result": "issues-fixed"
     },
     "erdos-1123": {
@@ -2765,22 +2765,22 @@
       "result": "clean"
     },
     "erdos-1127": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "clean"
     },
     "erdos-1128": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T17:09:28Z",
-      "result": "clean"
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-1129": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T17:09:23Z",
-      "result": "clean"
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-113": {
       "auditCount": 2,
@@ -2819,15 +2819,15 @@
       "result": "issues-fixed"
     },
     "erdos-1134": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-21T18:36:21Z",
+      "lastAudited": "2026-04-21T18:53:44Z",
       "result": "clean"
     },
     "erdos-1135": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-03T21:59:37Z",
+      "lastAudited": "2026-04-21T18:53:44Z",
       "result": "issues-fixed"
     },
     "erdos-1136": {
@@ -2951,10 +2951,10 @@
       "result": "clean"
     },
     "erdos-1150": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "clean"
     },
     "erdos-1151": {
       "auditCount": 3,
@@ -3018,8 +3018,8 @@
     },
     "erdos-1161": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:59:38Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
       "result": "issues-fixed"
     },
     "erdos-1162": {
@@ -3126,9 +3126,9 @@
     },
     "erdos-1179": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:05:46Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-1179-oq-01": {
       "auditCount": 2,
@@ -3192,8 +3192,8 @@
     },
     "erdos-124": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:59:38Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
       "result": "issues-fixed"
     },
     "erdos-124-complete-sequences": {
@@ -3252,9 +3252,9 @@
     },
     "erdos-132": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:02:52Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-133": {
       "agentId": "auditor-cycle-20-batch",
@@ -3264,9 +3264,9 @@
     },
     "erdos-134": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:02:52Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-135": {
       "agentId": "auditor-cycle-20-batch",
@@ -3276,9 +3276,9 @@
     },
     "erdos-136": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:22Z",
-      "result": "clean"
+      "auditCount": 3,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-137": {
       "agentId": "auditor-cycle-20-batch",
@@ -3314,8 +3314,8 @@
     },
     "erdos-141": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:59:38Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
       "result": "issues-fixed"
     },
     "erdos-142": {
@@ -3337,10 +3337,10 @@
       "result": "clean"
     },
     "erdos-145": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-21T16:02:52Z",
-      "result": "clean"
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-146": {
       "auditCount": 3,
@@ -3403,10 +3403,10 @@
       "result": "clean"
     },
     "erdos-154": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-21T16:02:35Z",
-      "result": "clean"
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-155": {
       "auditCount": 3,
@@ -3429,15 +3429,15 @@
       "result": "issues-fixed"
     },
     "erdos-158": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-21T16:02:34Z",
-      "result": "clean"
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-159": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-03T21:59:38Z",
+      "lastAudited": "2026-04-21T18:53:44Z",
       "result": "issues-fixed"
     },
     "erdos-16": {
@@ -3459,10 +3459,10 @@
       "result": "clean"
     },
     "erdos-162": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-21T16:02:34Z",
-      "result": "clean"
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-163": {
       "auditCount": 2,
@@ -3489,16 +3489,16 @@
       "result": "clean"
     },
     "erdos-167": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-21T16:02:34Z",
-      "result": "clean"
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-168": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-21T16:02:34Z",
-      "result": "clean"
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-169": {
       "auditCount": 2,
@@ -3549,22 +3549,22 @@
       "result": "clean"
     },
     "erdos-176": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T17:10:18Z",
-      "result": "clean"
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-177": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-21T16:02:14Z",
-      "result": "clean"
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-178": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-21T16:02:14Z",
-      "result": "clean"
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-179": {
       "auditCount": 2,
@@ -3604,15 +3604,15 @@
     },
     "erdos-184": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:02:13Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-185": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:02:13Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-186": {
       "agentId": "auditor-cycle-20-batch",
@@ -3628,15 +3628,15 @@
     },
     "erdos-188": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:01:53Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-189": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:01:53Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-19": {
       "agentId": "auditor-cycle-20-batch",
@@ -3652,15 +3652,15 @@
     },
     "erdos-190": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:01:52Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-191": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:01:53Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-192": {
       "agentId": "auditor-cycle-20-batch",
@@ -3700,15 +3700,15 @@
     },
     "erdos-198": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:01:52Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-199": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:01:52Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-2": {
       "agentId": "auditor-cycle-20-batch",
@@ -3730,15 +3730,15 @@
     },
     "erdos-200": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:01:23Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-201": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:01:52Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-202": {
       "agentId": "auditor-cycle-20-batch",
@@ -3775,9 +3775,9 @@
     },
     "erdos-207": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T16:01:22Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-208": {
       "agentId": "auditor-cycle-20-batch",
@@ -3817,9 +3817,9 @@
     },
     "erdos-213": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:01:21Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-214": {
       "agentId": "auditor-cycle-20-batch",
@@ -3829,9 +3829,9 @@
     },
     "erdos-215": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:01:22Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-216": {
       "agentId": "auditor-cycle-20-batch",
@@ -3841,9 +3841,9 @@
     },
     "erdos-217": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:01:22Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-218": {
       "agentId": "auditor-cycle-20-batch",
@@ -3853,9 +3853,9 @@
     },
     "erdos-219": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:01:21Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-22": {
       "agentId": "auditor-cycle-20-batch",
@@ -3896,15 +3896,15 @@
     },
     "erdos-225": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:01:03Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-226": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:01:03Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-227": {
       "agentId": "auditor-cycle-20-batch",
@@ -3914,9 +3914,9 @@
     },
     "erdos-228": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:10:39Z",
-      "result": "clean"
+      "auditCount": 3,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-229": {
       "agentId": "auditor-cycle-20-batch",
@@ -3932,9 +3932,9 @@
     },
     "erdos-230": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:01:03Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-231": {
       "agentId": "auditor-cycle-20-batch",
@@ -3951,9 +3951,9 @@
     },
     "erdos-233": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:01:03Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-234": {
       "agentId": "auditor-cycle-20-batch",
@@ -3993,9 +3993,9 @@
     },
     "erdos-24": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:01:03Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-240": {
       "agentId": "auditor-cycle-20-batch",
@@ -4065,9 +4065,9 @@
     },
     "erdos-250": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:10:25Z",
-      "result": "clean"
+      "auditCount": 3,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-251": {
       "agentId": "auditor-cycle-20-batch",
@@ -4095,9 +4095,9 @@
     },
     "erdos-255": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:00:45Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-256": {
       "agentId": "auditor-cycle-20-batch",
@@ -4119,9 +4119,9 @@
     },
     "erdos-259": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:00:45Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-26": {
       "agentId": "auditor-cycle-20-batch",
@@ -4155,9 +4155,9 @@
     },
     "erdos-264": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:00:45Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-265": {
       "agentId": "auditor-cycle-20-batch",
@@ -4173,8 +4173,8 @@
     },
     "erdos-267": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:59:39Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
       "result": "issues-fixed"
     },
     "erdos-268": {
@@ -4221,15 +4221,15 @@
     },
     "erdos-274": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:00:33Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-275": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:00:33Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-276": {
       "agentId": "auditor-cycle-20-batch",
@@ -4239,9 +4239,9 @@
     },
     "erdos-277": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:00:33Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-278": {
       "agentId": "auditor-cycle-20-batch",
@@ -4268,15 +4268,15 @@
     },
     "erdos-280": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:00:32Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-281": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:00:32Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-282": {
       "agentId": "auditor-cycle-20-batch",
@@ -4286,9 +4286,9 @@
     },
     "erdos-283": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:00:32Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-284": {
       "agentId": "auditor-cycle-20-batch",
@@ -4374,9 +4374,9 @@
     },
     "erdos-295": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:00:19Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-296": {
       "agentId": "auditor-cycle-20-batch",
@@ -4417,9 +4417,9 @@
     },
     "erdos-300": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:29:19Z",
-      "result": "clean"
+      "auditCount": 3,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-301": {
       "agentId": "auditor-cycle-20-batch",
@@ -4429,9 +4429,9 @@
     },
     "erdos-302": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:00:19Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-303": {
       "agentId": "auditor-cycle-20-batch",
@@ -4519,9 +4519,9 @@
     },
     "erdos-315": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:59:56Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-316": {
       "agentId": "auditor-cycle-20-batch",
@@ -4537,15 +4537,15 @@
     },
     "erdos-318": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:29:11Z",
-      "result": "clean"
+      "auditCount": 3,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-319": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:29:13Z",
-      "result": "clean"
+      "auditCount": 3,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-32": {
       "agentId": "auditor-cycle-20-batch",
@@ -4567,15 +4567,15 @@
     },
     "erdos-322": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:59:56Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-323": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:29:08Z",
-      "result": "clean"
+      "auditCount": 3,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-324": {
       "agentId": "auditor-cycle-20-batch",
@@ -4591,8 +4591,8 @@
     },
     "erdos-326": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:59:39Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
       "result": "issues-fixed"
     },
     "erdos-327": {
@@ -4615,9 +4615,9 @@
     },
     "erdos-329": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:59:56Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-33": {
       "auditCount": 3,
@@ -4639,9 +4639,9 @@
     },
     "erdos-332": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:59:55Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-333": {
       "agentId": "auditor-cycle-20-batch",
@@ -4651,9 +4651,9 @@
     },
     "erdos-334": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:59:41Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-335": {
       "agentId": "auditor-cycle-20-batch",
@@ -4711,9 +4711,9 @@
     },
     "erdos-342": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:59:41Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-343": {
       "agentId": "auditor-cycle-20-batch",
@@ -4723,15 +4723,15 @@
     },
     "erdos-344": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:59:41Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-345": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:28:58Z",
-      "result": "clean"
+      "auditCount": 3,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-346": {
       "agentId": "auditor-cycle-20-batch",
@@ -4753,8 +4753,8 @@
     },
     "erdos-349": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:59:39Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
       "result": "issues-fixed"
     },
     "erdos-35": {
@@ -4838,8 +4838,8 @@
     },
     "erdos-361": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:59:39Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
       "result": "issues-fixed"
     },
     "erdos-362": {
@@ -4850,9 +4850,9 @@
     },
     "erdos-363": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:59:41Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-364": {
       "agentId": "auditor-cycle-20-batch",
@@ -4940,8 +4940,8 @@
     },
     "erdos-377": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:59:39Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
       "result": "issues-fixed"
     },
     "erdos-378": {
@@ -4970,15 +4970,15 @@
     },
     "erdos-381": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:59:28Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-382": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T15:59:28Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-383": {
       "agentId": "auditor-cycle-20-batch",
@@ -5024,9 +5024,9 @@
     },
     "erdos-39": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T15:59:28Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-390": {
       "agentId": "auditor-cycle-20-batch",
@@ -5062,9 +5062,9 @@
     },
     "erdos-395": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:59:28Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-395-oq-01": {
       "auditCount": 4,
@@ -5080,9 +5080,9 @@
     },
     "erdos-397": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:28:10Z",
-      "result": "clean"
+      "auditCount": 3,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-398": {
       "agentId": "auditor-cycle-20-batch",
@@ -5140,9 +5140,9 @@
     },
     "erdos-405": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:59:28Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-406": {
       "agentId": "auditor-cycle-20-batch",
@@ -5152,9 +5152,9 @@
     },
     "erdos-407": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:59:05Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-408": {
       "agentId": "auditor-cycle-20-batch",
@@ -5172,9 +5172,9 @@
     },
     "erdos-41": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:59:05Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-410": {
       "agentId": "auditor-cycle-20-batch",
@@ -5256,15 +5256,15 @@
     },
     "erdos-422": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:59:40Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
       "result": "issues-fixed"
     },
     "erdos-423": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:59:05Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-424": {
       "agentId": "auditor-cycle-20-batch",
@@ -5280,9 +5280,9 @@
     },
     "erdos-426": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:59:04Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-427": {
       "agentId": "auditor-cycle-20-batch",
@@ -5346,15 +5346,15 @@
     },
     "erdos-436": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:59:04Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-437": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:27:11Z",
-      "result": "clean"
+      "auditCount": 3,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-438": {
       "agentId": "auditor-cycle-20-batch",
@@ -5364,9 +5364,9 @@
     },
     "erdos-439": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:58:51Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-44": {
       "agentId": "auditor-cycle-20-batch",
@@ -5376,9 +5376,9 @@
     },
     "erdos-440": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:58:51Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-441": {
       "agentId": "auditor-cycle-20-batch",
@@ -5388,9 +5388,9 @@
     },
     "erdos-442": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:58:51Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-443": {
       "agentId": "auditor-cycle-20-batch",
@@ -5430,9 +5430,9 @@
     },
     "erdos-449": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:58:51Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-45": {
       "agentId": "auditor-cycle-20-batch",
@@ -5448,9 +5448,9 @@
     },
     "erdos-451": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:58:51Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-452": {
       "agentId": "auditor-cycle-20-batch",
@@ -5508,8 +5508,8 @@
     },
     "erdos-46": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:59:40Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
       "result": "issues-fixed"
     },
     "erdos-460": {
@@ -5574,9 +5574,9 @@
     },
     "erdos-47": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:58:50Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-470": {
       "agentId": "auditor-cycle-20-batch",
@@ -5610,9 +5610,9 @@
     },
     "erdos-475": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:56:32Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-476": {
       "agentId": "auditor-cycle-20-batch",
@@ -5622,14 +5622,14 @@
     },
     "erdos-477": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:59:40Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
       "result": "issues-fixed"
     },
     "erdos-478": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:59:40Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
       "result": "issues-fixed"
     },
     "erdos-479": {
@@ -5700,9 +5700,9 @@
     },
     "erdos-487": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:56:32Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-488": {
       "agentId": "auditor-cycle-20-batch",
@@ -5712,9 +5712,9 @@
     },
     "erdos-489": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:56:32Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-49": {
       "agentId": "auditor-cycle-20-batch",
@@ -5742,9 +5742,9 @@
     },
     "erdos-492": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:56:16Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-493": {
       "auditCount": 3,
@@ -5778,15 +5778,15 @@
     },
     "erdos-498": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:59:40Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
       "result": "issues-fixed"
     },
     "erdos-499": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:26:25Z",
-      "result": "clean"
+      "auditCount": 3,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-5": {
       "agentId": "auditor-cycle-20-batch",
@@ -5873,8 +5873,8 @@
     },
     "erdos-510": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:59:40Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
       "result": "issues-fixed"
     },
     "erdos-511": {
@@ -5891,9 +5891,9 @@
     },
     "erdos-513": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:26:09Z",
-      "result": "clean"
+      "auditCount": 3,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-514": {
       "agentId": "auditor-cycle-20-batch",
@@ -5903,15 +5903,15 @@
     },
     "erdos-515": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:26:05Z",
-      "result": "clean"
+      "auditCount": 3,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-516": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:56:15Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-517": {
       "agentId": "auditor-cycle-20-batch",
@@ -5951,9 +5951,9 @@
     },
     "erdos-522": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:56:14Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-523": {
       "agentId": "auditor-cycle-20-batch",
@@ -5981,9 +5981,9 @@
     },
     "erdos-526": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:56:02Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-527": {
       "agentId": "auditor-cycle-20-batch",
@@ -6017,15 +6017,15 @@
     },
     "erdos-531": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:56:01Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-532": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:56:01Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-533": {
       "agentId": "auditor-cycle-20-batch",
@@ -6041,15 +6041,15 @@
     },
     "erdos-535": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:56:01Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-536": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-21T15:56:01Z",
-      "result": "clean"
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-537": {
       "agentId": "auditor-cycle-20-batch",
@@ -6071,15 +6071,15 @@
     },
     "erdos-54": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:59:40Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
       "result": "issues-fixed"
     },
     "erdos-540": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:56:01Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-541": {
       "agentId": "auditor-cycle-20-batch",
@@ -6119,9 +6119,9 @@
     },
     "erdos-547": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:55:44Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-548": {
       "agentId": "auditor-cycle-20-batch",
@@ -6137,9 +6137,9 @@
     },
     "erdos-55": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:55:44Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-550": {
       "agentId": "auditor-cycle-20-batch",
@@ -6215,9 +6215,9 @@
     },
     "erdos-561": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:25:37Z",
-      "result": "clean"
+      "auditCount": 3,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-562": {
       "agentId": "auditor-cycle-20-batch",
@@ -6239,9 +6239,9 @@
     },
     "erdos-565": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:55:44Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-566": {
       "agentId": "auditor-cycle-20-batch",
@@ -6275,9 +6275,9 @@
     },
     "erdos-570": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:55:28Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-571": {
       "agentId": "auditor-cycle-20-batch",
@@ -6317,27 +6317,27 @@
     },
     "erdos-577": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:55:27Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-578": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:55:28Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-579": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:59:41Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
       "result": "issues-fixed"
     },
     "erdos-58": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:55:27Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-580": {
       "agentId": "auditor-cycle-20-batch",
@@ -6377,9 +6377,9 @@
     },
     "erdos-586": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:55:11Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-587": {
       "agentId": "auditor-cycle-20-batch",
@@ -6389,9 +6389,9 @@
     },
     "erdos-588": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:55:11Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-589": {
       "agentId": "auditor-cycle-20-batch",
@@ -6401,9 +6401,9 @@
     },
     "erdos-59": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T15:55:11Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-590": {
       "agentId": "auditor-cycle-20-batch",
@@ -6413,9 +6413,9 @@
     },
     "erdos-591": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:55:11Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-592": {
       "agentId": "auditor-cycle-20-batch",
@@ -6443,33 +6443,33 @@
     },
     "erdos-596": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:55:11Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-597": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:55:11Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-598": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:59:41Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
       "result": "issues-fixed"
     },
     "erdos-599": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:55:10Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-6": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:54:53Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-60": {
       "auditCount": 4,
@@ -6547,8 +6547,8 @@
     },
     "erdos-61": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:59:41Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
       "result": "issues-fixed"
     },
     "erdos-610": {
@@ -6693,9 +6693,9 @@
     },
     "erdos-631": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:24:11Z",
-      "result": "clean"
+      "auditCount": 3,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-632": {
       "agentId": "auditor-cycle-20-batch",
@@ -6810,9 +6810,9 @@
     },
     "erdos-649": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:54:37Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-65": {
       "agentId": "auditor-cycle-20-batch",
@@ -6828,9 +6828,9 @@
     },
     "erdos-651": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:23:46Z",
-      "result": "clean"
+      "auditCount": 3,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-652": {
       "agentId": "auditor-cycle-20-batch",
@@ -6846,8 +6846,8 @@
     },
     "erdos-654": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:59:41Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
       "result": "issues-fixed"
     },
     "erdos-655": {
@@ -6895,8 +6895,8 @@
     },
     "erdos-661": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:59:41Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
       "result": "issues-fixed"
     },
     "erdos-662": {
@@ -6949,9 +6949,9 @@
     },
     "erdos-67": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:54:36Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-670": {
       "agentId": "auditor-cycle-20-batch",
@@ -7053,8 +7053,8 @@
     },
     "erdos-685": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:59:41Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
       "result": "issues-fixed"
     },
     "erdos-686": {
@@ -7180,9 +7180,9 @@
     },
     "erdos-702": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:54:18Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-703": {
       "agentId": "auditor-cycle-20-batch",
@@ -7192,9 +7192,9 @@
     },
     "erdos-704": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:54:18Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-705": {
       "agentId": "auditor-cycle-20-batch",
@@ -7204,9 +7204,9 @@
     },
     "erdos-706": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:54:18Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-707": {
       "agentId": "auditor-cycle-20-batch",
@@ -7216,9 +7216,9 @@
     },
     "erdos-708": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:22:30Z",
-      "result": "clean"
+      "auditCount": 3,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-709": {
       "agentId": "auditor-cycle-20-batch",
@@ -7314,15 +7314,15 @@
     },
     "erdos-722": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:54:01Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-723": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:53:42Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-724": {
       "agentId": "auditor-cycle-20-batch",
@@ -7350,9 +7350,9 @@
     },
     "erdos-728": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:53:42Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-728-factorial-divisibility": {
       "agentId": "auditor-cycle-20-batch",
@@ -7362,9 +7362,9 @@
     },
     "erdos-729": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T15:53:42Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-73": {
       "agentId": "auditor-cycle-20-batch",
@@ -7386,15 +7386,15 @@
     },
     "erdos-732": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:53:42Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-733": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:53:42Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-734": {
       "agentId": "auditor-cycle-20-batch",
@@ -7434,8 +7434,8 @@
     },
     "erdos-74": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:59:41Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
       "result": "issues-fixed"
     },
     "erdos-740": {
@@ -7486,9 +7486,9 @@
     },
     "erdos-747": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:22:04Z",
-      "result": "clean"
+      "auditCount": 3,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-748": {
       "agentId": "auditor-cycle-20-batch",
@@ -7516,9 +7516,9 @@
     },
     "erdos-751": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:53:26Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-752": {
       "agentId": "auditor-cycle-20-batch",
@@ -7534,9 +7534,9 @@
     },
     "erdos-754": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:53:26Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-755": {
       "agentId": "auditor-cycle-20-batch",
@@ -7588,15 +7588,15 @@
     },
     "erdos-762": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:21:57Z",
-      "result": "clean"
+      "auditCount": 3,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-763": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:53:12Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-764": {
       "agentId": "auditor-cycle-20-batch",
@@ -7672,9 +7672,9 @@
     },
     "erdos-775": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:52:57Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-776": {
       "agentId": "auditor-cycle-20-batch",
@@ -7697,9 +7697,9 @@
     },
     "erdos-779": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:52:57Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-78": {
       "agentId": "auditor-cycle-20-batch",
@@ -7727,8 +7727,8 @@
     },
     "erdos-783": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:59:41Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
       "result": "issues-fixed"
     },
     "erdos-784": {
@@ -7739,21 +7739,21 @@
     },
     "erdos-785": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:52:57Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-786": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:52:56Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-787": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:52:42Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-788": {
       "agentId": "auditor-cycle-20-batch",
@@ -7769,9 +7769,9 @@
     },
     "erdos-79": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:52:41Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-790": {
       "agentId": "auditor-cycle-20-batch",
@@ -7865,9 +7865,9 @@
     },
     "erdos-803": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:52:41Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-804": {
       "agentId": "auditor-cycle-20-batch",
@@ -7883,9 +7883,9 @@
     },
     "erdos-806": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:52:40Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-807": {
       "agentId": "auditor-cycle-20-batch",
@@ -7931,15 +7931,15 @@
     },
     "erdos-813": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:52:22Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-814": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:52:21Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-815": {
       "agentId": "auditor-cycle-20-batch",
@@ -7991,9 +7991,9 @@
     },
     "erdos-822": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:51:40Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-823": {
       "agentId": "auditor-cycle-20-batch",
@@ -8003,9 +8003,9 @@
     },
     "erdos-824": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:51:39Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-825": {
       "agentId": "auditor-cycle-20-batch",
@@ -8057,9 +8057,9 @@
     },
     "erdos-832": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:51:38Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-833": {
       "agentId": "auditor-cycle-20-batch",
@@ -8081,9 +8081,9 @@
     },
     "erdos-836": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:51:10Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-837": {
       "agentId": "auditor-cycle-20-batch",
@@ -8099,15 +8099,15 @@
     },
     "erdos-839": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T15:51:09Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-84": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:51:09Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-840": {
       "agentId": "auditor-cycle-20-batch",
@@ -8124,9 +8124,9 @@
     },
     "erdos-842": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:51:09Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-843": {
       "agentId": "auditor-cycle-20-batch",
@@ -8232,15 +8232,15 @@
     },
     "erdos-859": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:50:53Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-86": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-21T15:50:53Z",
-      "result": "clean"
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-860": {
       "agentId": "auditor-cycle-20-batch",
@@ -8250,9 +8250,9 @@
     },
     "erdos-861": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:50:52Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-862": {
       "agentId": "auditor-cycle-20-batch",
@@ -8262,8 +8262,8 @@
     },
     "erdos-863": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:59:42Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
       "result": "issues-fixed"
     },
     "erdos-864": {
@@ -8352,15 +8352,15 @@
     },
     "erdos-877": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:50:51Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-878": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:50:51Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-879": {
       "agentId": "auditor-cycle-20-batch",
@@ -8430,9 +8430,9 @@
     },
     "erdos-889": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:48:52Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-89": {
       "agentId": "auditor-cycle-20-batch",
@@ -8466,9 +8466,9 @@
     },
     "erdos-894": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:48:52Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-895": {
       "agentId": "auditor-cycle-20-batch",
@@ -8568,9 +8568,9 @@
     },
     "erdos-909": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:48:01Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-909-oq-01": {
       "auditCount": 2,
@@ -8670,15 +8670,15 @@
     },
     "erdos-923": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:47:13Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-924": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:47:13Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-925": {
       "agentId": "auditor-cycle-20-batch",
@@ -8730,9 +8730,9 @@
     },
     "erdos-932": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:20:08Z",
-      "result": "clean"
+      "auditCount": 3,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-933": {
       "agentId": "auditor-cycle-20-batch",
@@ -8760,9 +8760,9 @@
     },
     "erdos-937": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:46:29Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-938": {
       "auditCount": 3,
@@ -8802,15 +8802,15 @@
     },
     "erdos-942": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:46:29Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-943": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:46:29Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-944": {
       "agentId": "auditor-cycle-20-batch",
@@ -8838,9 +8838,9 @@
     },
     "erdos-948": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:46:29Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-949": {
       "agentId": "auditor-cycle-20-batch",
@@ -8964,9 +8964,9 @@
     },
     "erdos-967": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:46:05Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-968": {
       "agentId": "auditor-cycle-20-batch",
@@ -9012,9 +9012,9 @@
     },
     "erdos-974": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:42:49Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-975": {
       "agentId": "auditor-cycle-20-batch",
@@ -9024,9 +9024,9 @@
     },
     "erdos-976": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:42:49Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-977": {
       "agentId": "auditor-cycle-20-batch",
@@ -9079,9 +9079,9 @@
     },
     "erdos-984": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:42:49Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-985": {
       "agentId": "auditor-cycle-20-batch",
@@ -9151,9 +9151,9 @@
     },
     "erdos-995": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:42:26Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-996": {
       "agentId": "auditor-cycle-20-batch",
@@ -9169,9 +9169,9 @@
     },
     "erdos-998": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:42:26Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-999": {
       "agentId": "auditor-cycle-20-batch",
@@ -9556,9 +9556,9 @@
     },
     "greens-theorem": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:16:43Z",
-      "result": "clean"
+      "auditCount": 3,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "greens-theorem-oq-01": {
       "auditCount": 2,
@@ -9682,9 +9682,9 @@
     },
     "hilbert-16": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:16:32Z",
-      "result": "clean"
+      "auditCount": 3,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "hilbert-17": {
       "agentId": "auditor-cycle-20-batch",
@@ -9700,9 +9700,9 @@
     },
     "hilbert-19": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:16:31Z",
-      "result": "clean"
+      "auditCount": 3,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "hilbert-19-oq-03": {
       "agentId": "auditor-cycle-20-batch",
@@ -9867,10 +9867,10 @@
       "result": "clean"
     },
     "isoperimetric-theorem-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-21T15:42:26Z",
-      "result": "clean"
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "isosceles-triangle": {
       "agentId": "auditor-cycle-20-batch",
@@ -10212,9 +10212,9 @@
     },
     "parallel-postulate-independence": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:15:06Z",
-      "result": "clean"
+      "auditCount": 3,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "parallel-postulate-independence-oq-02": {
       "agentId": "auditor-cycle-20-batch",
@@ -10235,10 +10235,10 @@
       "result": "clean"
     },
     "partition-theorem-oq-03": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-21T15:42:01Z",
-      "result": "clean"
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "pascals-hexagon": {
       "auditCount": 4,
@@ -10310,9 +10310,9 @@
       "result": "clean"
     },
     "poincare-conjecture": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-04-13T23:39:02Z",
+      "lastAudited": "2026-04-21T18:53:44Z",
       "result": "issues-fixed"
     },
     "prime-gap-bounds": {
@@ -12500,9 +12500,9 @@
       "issues": []
     },
     "erdos-1107-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T20:36:46Z",
-      "result": "clean",
+      "auditCount": 2,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "erdos-837-oq-05": {
@@ -12844,10 +12844,16 @@
       "issues": []
     },
     "schroeder-bernstein-oq-03": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T18:04:06Z",
-      "result": "clean",
+      "auditCount": 4,
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed",
       "issues": []
+    },
+    "hurwitz-theorem-oq-03-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "clean"
     }
   },
   "erdos-1097-oq-01": {


### PR DESCRIPTION
## Summary

Updates audit-tracker.json for 230+ proofs re-audited on 2026-04-21 during bulk assumptions text correction pass.

- **230 proofs**: marked `issues-fixed` — stale assumptions text corrected in PR #11133
- **4 proofs**: marked `clean` — verified correct during this session (hurwitz-theorem-oq-03-oq-01, erdos-1150, erdos-1127, erdos-1134)

Complements PR #11133 which contains the actual assumptions text fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)