### PR TITLE
Enrich lebesgue-measure-oq-03-oq-01: add missing sections and annotations

### DIFF
--- a/src/data/proofs/lebesgue-measure-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/lebesgue-measure-oq-03-oq-01/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-lebesgue-oq03-oq01-header",
+    "proofId": "lebesgue-measure-oq-03-oq-01",
+    "range": { "startLine": 1, "endLine": 43 },
+    "type": "context",
+    "title": "Impossibility Proof Structure: Five Steps to Measure Zero",
+    "content": "The module docstring (lines 4-42) lays out the five-step impossibility argument with explicit numbers:\n1. $\\|e_n - e_m\\| = \\sqrt{2} > 2/3$ → balls $B(e_n, 1/3)$ pairwise disjoint\n2. $\\|e_n\\| = 1$ + triangle inequality → each ball contained in $B(0, 4/3)$\n3. Translation invariance → all balls have equal measure $\\mu(B(0, 1/3))$\n4. Countable additivity → $N \\cdot \\mu(B(0, 1/3)) \\leq \\mu(B(0, 4/3)) < \\infty$ for all $N$\n5. Archimedean property → $\\mu(B(0, 1/3)) = 0$\n\nThe two imports bring in `Mathlib` for measure theory and `Proofs.LebesgueMeasureOQ03` for helper lemmas (`orthonormal_dist`, `orthonormal_balls_disjoint`).",
+    "mathContext": "The argument is geometric + analytic: pack infinitely many equal-measure disjoint balls into a bounded region, then use the measure-theoretic Archimedean principle. The key numbers: radius $1/3 < \\sqrt{2}/2$ ensures disjointness; containment in $B(0, 4/3) = B(0, 1 + 1/3)$ follows from the unit norm of $e_n$.",
+    "significance": "context",
+    "relatedConcepts": ["impossibility theorems", "orthonormal packing", "Archimedean property", "translation-invariant measures"],
+    "prerequisites": ["Hilbert space", "orthonormal sequences", "Borel measures", "σ-finite measures"]
+  },
+  {
     "id": "ann-archimedean",
     "proofId": "lebesgue-measure-oq-03-oq-01",
     "range": { "startLine": 44, "endLine": 64 },
@@ -86,13 +98,25 @@
   {
     "id": "ann-main-theorem",
     "proofId": "lebesgue-measure-oq-03-oq-01",
-    "range": { "startLine": 189, "endLine": 203 },
+    "range": { "startLine": 176, "endLine": 213 },
     "type": "insight",
-    "title": "Main Impossibility Theorem",
-    "content": "Assembles all ingredients: given a translation-invariant measure $\\mu$ with $\\mu(B(0, 4/3)) < \\infty$ on a Hilbert space with orthonormal sequence, the balls $B(e_n, 1/3)$ are pairwise disjoint (orthonormality), contained in $B(0, 4/3)$ (triangle inequality), and have equal measure $\\mu(B(0, 1/3))$ (translation invariance). The counting lemma forces $\\mu(B(0, 1/3)) = 0$. Since any ball of radius $1/3$ can be translated to the origin, $\\mu(B(y, 1/3)) = 0$ for all $y$.",
-    "mathContext": "$\\mu(B(0, 1/3)) = 0$, hence $\\mu(B(y, 1/3)) = 0$ for all $y \\in H$",
+    "title": "Main Impossibility Theorem and Any-Center Corollary",
+    "content": "**Part V (lines 176-201)**: `no_invariant_locally_finite_ball` assembles all ingredients via `zero_measure_of_infinite_disjoint` — passing the orthonormal ball family, the bounding set, measurability, disjointness, containment, finiteness, and equal-measure witnesses. The result is $\\mu(B(0, 1/3)) = 0$.\n\n**Corollary (lines 203-213)**: `no_invariant_locally_finite_any_center` immediately extends to any center $y$ by rewriting $\\mu(B(y, 1/3)) = \\mu(B(0, 1/3))$ via `trans_inv_ball_eq` and applying the main theorem. The single-line proof `rw [...]; exact no_invariant_locally_finite_ball ...` shows how cleanly the results compose.",
+    "mathContext": "$\\mu(B(0, 1/3)) = 0$, hence $\\mu(B(y, 1/3)) = 0$ for all $y \\in H$ by translation invariance: $\\mu(B(y, r)) = \\mu(B(0, r))$ for all $y, r$.",
     "significance": "key",
-    "relatedConcepts": ["impossibility theorem", "translation invariance", "infinite-dimensional analysis"],
+    "relatedConcepts": ["impossibility theorem", "translation invariance", "infinite-dimensional analysis", "zero_measure_of_infinite_disjoint"],
     "prerequisites": ["zero_measure_of_infinite_disjoint", "ortho_balls_disjoint", "ortho_ball_subset", "trans_inv_ball_eq"]
+  },
+  {
+    "id": "ann-small-balls-parametric",
+    "proofId": "lebesgue-measure-oq-03-oq-01",
+    "range": { "startLine": 215, "endLine": 281 },
+    "type": "technique",
+    "title": "Generalization: Small Balls and Parametric Radius",
+    "content": "**Part VI (lines 219-230)**: `no_invariant_locally_finite_small_ball` extends to any $r \\leq 1/3$ by monotone containment: $B(y, r) \\subseteq B(y, 1/3)$, and $\\mu$ is monotone, so $\\mu(B(y,r)) \\leq \\mu(B(y, 1/3)) = 0$. Proved by a `calc` chain using `Metric.ball_subset_ball`.\n\n**Part VII (lines 243-281)**: `no_invariant_parametric` proves $\\mu(B(0, \\delta)) = 0$ for any $0 < \\delta < \\sqrt{2}/2$ — not just $\\delta = 1/3$. The proof re-runs the entire argument with the parametric radius: disjointness uses $2\\delta < \\sqrt{2}$ directly, containment uses $B(e_n, \\delta) \\subseteq B(0, 1+\\delta)$. This is the sharpest version: the condition $\\delta < \\sqrt{2}/2 \\approx 0.707$ is tight because the orthonormal separation is exactly $\\sqrt{2}$.",
+    "mathContext": "Part VI: $B(y, r) \\subseteq B(y, 1/3)$ for $r \\leq 1/3$ → $\\mu(B(y,r)) = 0$. Part VII: $0 < \\delta < \\sqrt{2}/2 \\implies \\mu(B(0, \\delta)) = 0$ — the critical threshold is $\\sqrt{2}/2$ since $\\|e_n - e_m\\| = \\sqrt{2}$ is the orthonormal separation.",
+    "significance": "supporting",
+    "relatedConcepts": ["Metric.ball_subset_ball", "measure_mono", "parametric impossibility", "orthonormal separation"],
+    "prerequisites": ["no_invariant_locally_finite_any_center", "zero_measure_of_infinite_disjoint", "Metric.ball_subset_ball"]
   }
 ]

--- a/src/data/proofs/lebesgue-measure-oq-03-oq-01/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-03-oq-01/meta.json
@@ -77,11 +77,27 @@
     },
     {
       "id": "counting",
-      "title": "§4: Counting Lemma and Impossibility",
+      "title": "§4: Counting Lemma and Infrastructure",
       "startLine": 99,
-      "endLine": 163,
-      "summary": "The key measure-theoretic argument: infinitely many equal-measure disjoint sets in a finite-measure set force measure 0. Combined with translation invariance to prove the main theorem.",
+      "endLine": 175,
+      "summary": "The key measure-theoretic lemmas: translation-invariant definition, equal ball measures, OrthoSeq structure, ball containment, and pairwise disjoint balls from orthonormal separation.",
       "mathContext": "If $\\mu(S) < \\infty$ and $s_n \\subseteq S$ are pairwise disjoint with $\\mu(s_n) = c$ for all $n$, then $c \\cdot \\aleph_0 = \\sum_n c \\leq \\mu(S) < \\infty$, so $c = 0$. Applied to $s_n = B(e_n, 1/3)$ and $S = B(0, 4/3)$."
+    },
+    {
+      "id": "main-theorem",
+      "title": "§5: Main Impossibility Theorem and Corollary",
+      "startLine": 176,
+      "endLine": 213,
+      "summary": "no_invariant_locally_finite_ball assembles all ingredients to prove μ(B(0, 1/3)) = 0. Corollary: μ(B(y, 1/3)) = 0 for any center y.",
+      "mathContext": "$\\mu(B(0, 1/3)) = 0$ follows from zero_measure_of_infinite_disjoint applied to the orthonormal ball family. Corollary: $\\mu(B(y, 1/3)) = \\mu(B(0, 1/3)) = 0$ for all $y \\in H$ by translation invariance."
+    },
+    {
+      "id": "small-balls-parametric",
+      "title": "§6–7: Small Balls and Parametric Extension",
+      "startLine": 215,
+      "endLine": 281,
+      "summary": "Extends impossibility: μ(B(y, r)) = 0 for any r ≤ 1/3 (monotone containment), and parametrically μ(B(0, δ)) = 0 for any 0 < δ < √2/2.",
+      "mathContext": "Part VI: $B(y, r) \\subseteq B(y, 1/3)$ for $r \\leq 1/3$, so $\\mu(B(y, r)) \\leq \\mu(B(y, 1/3)) = 0$. Part VII: any $\\delta$ with $2\\delta < \\sqrt{2}$ makes the orthonormal balls $B(e_n, \\delta)$ pairwise disjoint and contained in $B(0, 1+\\delta)$, with the same counting argument giving $\\mu(B(0,\\delta)) = 0$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for **No Translation-Invariant Measure in Infinite Dimensions** (lebesgue-measure-oq-03-oq-01).

## Quality improvements

- **Added 3 missing sections** to meta.json: the file has 282 lines but meta.json only covered through line 163 — leaving ~42% of the file without section coverage. Added `main-theorem` (lines 176–213), `small-balls-parametric` (lines 215–281), and extended `counting` to cover the full infrastructure (lines 99–175).
- **Added `ann-lebesgue-oq03-oq01-header`** (lines 1–43): covers the module docstring and its five-step proof outline. Explains the geometric intuition (pack infinitely many equal-measure disjoint balls into a bounded region) and what the two imports provide.
- **Added `ann-small-balls-parametric`** (lines 215–281): covers Part VI (small-ball monotone extension, `r ≤ 1/3`) and Part VII (parametric generalization, `0 < δ < √2/2`). Explains why `√2/2` is the sharp threshold and how Part VII re-runs the whole argument parametrically.
- **Expanded `ann-main-theorem`** range from 189–203 to 176–213 to include the Part V separator comment and the any-center corollary (`no_invariant_locally_finite_any_center`).