### PR TITLE
Research: Multivariate Gaussian integral — diagonal case proved (area-of-circle-oq-05-oq-02)

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ05OQ02.lean
+++ b/proofs/Proofs/AreaOfCircleOQ05OQ02.lean
@@ -1,0 +1,138 @@
+/-
+Area of Circle OQ-05-OQ-02: Multivariate Gaussian Integral via Matrix Diagonalization
+
+Proves the multivariate Gaussian integral formula:
+
+    ∫ x : Fin n → ℝ, exp(-xᵀAx) = √(πⁿ / det A)
+
+for any positive-definite real symmetric matrix A.
+
+## Proof Strategy
+
+1. **Diagonal case** (`diagonal_gaussian`): When A = diag(b₁,...,bₙ),
+   exp(-∑ bᵢxᵢ²) = ∏ exp(-bᵢxᵢ²). Apply Fubini to factor the integral
+   over ℝⁿ into a product of scalar Gaussian integrals ∫ exp(-bᵢxᵢ²) = √(π/bᵢ).
+   Then ∏ √(π/bᵢ) = √(πⁿ/∏bᵢ) by induction.
+
+2. **General case** (`multivariate_gaussian_integral`): Diagonalize A = UᵀDU via
+   the spectral theorem (U orthogonal, D = diag(λ₁,...,λₙ), λᵢ > 0).
+   The orthogonal change of variables y = Uᵀx preserves Lebesgue measure
+   (|det Uᵀ| = 1). Then xᵀAx = yᵀDy = ∑ λᵢyᵢ², and det A = ∏ λᵢ.
+
+## Status
+- `prod_sqrt_eq_sqrt_prod` : proved (induction on n)
+- `diagonal_gaussian` : proved (Fubini + scalar Gaussian)
+- `multivariate_gaussian_integral` : 1 sorry (spectral change of variables)
+
+Parent: AreaOfCircleOQ05.lean
+-/
+
+import Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral
+import Mathlib.Analysis.Matrix.Spectrum
+import Mathlib.Analysis.Matrix.PosDef
+import Mathlib.MeasureTheory.Integral.Pi
+import Mathlib.MeasureTheory.Measure.Lebesgue.Basic
+import Mathlib.LinearAlgebra.Determinant
+import Proofs.AreaOfCircleOQ05
+
+namespace MultivariateGaussian
+
+open MeasureTheory Real Matrix Finset
+
+/-! ## Part 1: Product of Square Roots -/
+
+/-- Helper: the product of square roots equals the square root of the product,
+    when all factors are nonneg.
+
+    `∏ i, √(f i) = √(∏ i, f i)` -/
+private lemma prod_sqrt_eq_sqrt_prod :
+    ∀ (n : ℕ) (f : Fin n → ℝ), (∀ i, 0 ≤ f i) →
+    ∏ i, Real.sqrt (f i) = Real.sqrt (∏ i, f i) := by
+  intro n
+  induction n with
+  | zero => intro f _; simp
+  | succ n ih =>
+    intro f hf
+    -- Split product at last element: ∏ Fin(n+1) = (∏ Fin n over castSucc) * last
+    rw [Fin.prod_univ_castSucc (fun i => Real.sqrt (f i)),
+        Fin.prod_univ_castSucc f]
+    -- Apply IH to the prefix: ∏ √(f castSucc) = √(∏ f castSucc)
+    rw [ih (fun i => f (Fin.castSucc i)) (fun i => hf (Fin.castSucc i))]
+    -- Combine: √a * √b = √(a * b) using sqrt_mul with a ≥ 0
+    rw [← Real.sqrt_mul
+          (Finset.prod_nonneg (fun i _ => hf (Fin.castSucc i)))]
+
+/-! ## Part 2: The Diagonal Gaussian Integral -/
+
+/-- **Diagonal Gaussian Integral**: For positive weights b : Fin n → ℝ,
+    the integral of exp(-∑ bᵢxᵢ²) over ℝⁿ equals √(πⁿ / ∏ bᵢ).
+
+    Proof: factor exp(-∑ bᵢxᵢ²) = ∏ exp(-bᵢxᵢ²) via Real.exp_sum,
+    apply Fubini (integral_fintype_prod_volume_eq_prod), evaluate each
+    scalar Gaussian, then simplify the product of square roots. -/
+theorem diagonal_gaussian {n : ℕ} (b : Fin n → ℝ) (hb : ∀ i, 0 < b i) :
+    ∫ x : Fin n → ℝ, Real.exp (-∑ i, b i * x i ^ 2) =
+    Real.sqrt (Real.pi ^ n / ∏ i, b i) := by
+  -- Step 1: Rewrite exp(-∑ bᵢxᵢ²) = ∏ i, exp(-bᵢxᵢ²) using exp_sum
+  -- Strategy (following GaussianFourierTransform.lean):
+  --   simp_rw [← Finset.sum_neg_distrib] : -(∑ f) → ∑ (-f) under integral
+  --   simp_rw [Real.exp_sum]             : exp(∑ f) → ∏ exp(f) under integral
+  simp_rw [← Finset.sum_neg_distrib, Real.exp_sum]
+  -- Step 2: Apply Fubini — product integral over Fin n → ℝ factors as product of integrals
+  rw [integral_fintype_prod_volume_eq_prod (fun i xi => Real.exp (-(b i * xi ^ 2)))]
+  -- Step 3: Apply scalar Gaussian to each factor: ∫ exp(-bᵢxᵢ²) = √(π/bᵢ)
+  have key : ∀ i : Fin n, ∫ xi : ℝ, Real.exp (-(b i * xi ^ 2)) = Real.sqrt (π / b i) :=
+    fun i => GaussianIntegralCircle.scaled_gaussian (b i) (hb i)
+  simp_rw [key]
+  -- Step 4: Simplify ∏ √(π/bᵢ) = √(πⁿ/∏bᵢ)
+  -- First: ∏ √(π/bᵢ) = √(∏(π/bᵢ)) by prod_sqrt lemma
+  rw [prod_sqrt_eq_sqrt_prod n (fun i => π / b i)
+        (fun i => div_nonneg pi_nonneg (hb i).le)]
+  -- Then: ∏(π/bᵢ) = (∏ π)/(∏ bᵢ) = πⁿ/∏bᵢ
+  congr 1
+  rw [Finset.prod_div_distrib, Finset.prod_const, Finset.card_univ, Fintype.card_fin]
+
+/-! ## Part 3: The Multivariate Gaussian Integral -/
+
+/-- **Multivariate Gaussian Integral**: For a positive-definite real symmetric
+    matrix A of size n×n,
+
+        ∫ x : Fin n → ℝ, exp(-xᵀAx) = √(πⁿ / det A)
+
+    **Proof outline** (1 sorry remaining):
+    1. Spectral theorem: A = U * diag(λ) * Uᵀ where U is unitary (orthogonal for ℝ)
+       and all eigenvalues λᵢ > 0 (since A is positive-definite).
+    2. Quadratic form: xᵀAx = (Uᵀx)ᵀ diag(λ) (Uᵀx) = ∑ᵢ λᵢ (Uᵀx)ᵢ².
+    3. Change of variables y = Uᵀx: since U is orthogonal, |det Uᵀ| = 1,
+       so the map y ↦ Ux is measure-preserving on (Fin n → ℝ, volume).
+    4. Apply diagonal_gaussian with b = eigenvalues.
+    5. det A = ∏ λᵢ by IsHermitian.det_eq_prod_eigenvalues.
+
+    **Remaining sorry**: The measure-preserving change of variables
+    `∫ x, f(Uᵀx) = ∫ y, f(y)` requires constructing the MeasurableEquiv
+    from the orthogonal map and proving measure preservation via
+    `map_linearMap_volume_pi_eq_smul_volume_pi` with |det Uᵀ| = 1. -/
+theorem multivariate_gaussian_integral {n : ℕ} (A : Matrix (Fin n) (Fin n) ℝ)
+    (hA : A.PosDef) :
+    ∫ x : Fin n → ℝ, Real.exp (-(dotProduct x (A.mulVec x))) =
+    Real.sqrt (Real.pi ^ n / A.det) := by
+  -- Let hAsymm := hA.isHermitian (over ℝ: IsHermitian = IsSymm)
+  -- Let U = hAsymm.eigenvectorUnitary : Matrix (Fin n) (Fin n) ℝ
+  -- Let λ = hAsymm.eigenvalues : Fin n → ℝ, with all λᵢ > 0
+  -- Spectral theorem: A = conjStarAlgAut ℝ _ U (diagonal (RCLike.ofReal ∘ λ))
+  -- Key steps:
+  --   (a) Rewrite xᵀAx = ∑ᵢ λᵢ ((U*ᵥx)ᵢ)² (quadratic form in eigenbasis)
+  --   (b) Change variables: ∫ x, f(Uᵀ *ᵥ x) = ∫ y, f y (measure-preserving)
+  --   (c) Apply diagonal_gaussian with b = eigenvalues
+  --   (d) Use det A = ∏ eigenvalues
+  --
+  -- SORRY: spectral decomposition + orthogonal change of variables
+  -- Needed:
+  --   · hAsymm.spectral_theorem (A = U * diag(λ) * U*)
+  --   · Matrix.PosDef.eigenvalues_pos (all λᵢ > 0)
+  --   · Matrix.IsHermitian.det_eq_prod_eigenvalues (det A = ∏ λᵢ, cast to ℝ)
+  --   · map_linearMap_volume_pi_eq_smul_volume_pi with |det U| = 1
+  --   · MeasurePreserving.integral_comp' to rewrite the integral
+  sorry
+
+end MultivariateGaussian

--- a/research/problems/area-of-circle-oq-05-oq-02/knowledge.md
+++ b/research/problems/area-of-circle-oq-05-oq-02/knowledge.md
@@ -1,0 +1,81 @@
+# Knowledge: area-of-circle-oq-05-oq-02
+
+## Key Facts
+
+### Mathematical Setup
+- Positive-definite real symmetric A: all eigenvalues λᵢ > 0
+- ∫_{ℝⁿ} e^{-xᵀAx} dx = √(πⁿ/det A)
+- Proof chain: spectral decomposition → change of variables → Fubini → scalar integral
+
+### Scalar Case (from parent AreaOfCircleOQ05.lean)
+- `scaled_gaussian (a : ℝ) (ha : 0 < a) : ∫ x : ℝ, rexp (-(a * x ^ 2)) = √(π / a)`
+- This is the building block for the multivariate case via Fubini
+
+### Mathlib APIs Confirmed (Session 2026-04-21)
+
+**Spectral theorem:**
+- `Matrix.IsHermitian.spectral_theorem`:
+  `A = conjStarAlgAut 𝕜 _ eigenvectorUnitary (diagonal (RCLike.ofReal ∘ eigenvalues))`
+- `Matrix.IsHermitian.eigenvectorUnitary : Matrix n n 𝕜` (unitary matrix, star = transpose for ℝ)
+- `Matrix.IsHermitian.eigenvalues : n → ℝ`
+- `Matrix.PosDef.eigenvalues_pos : A.PosDef → ∀ i, 0 < hA.1.eigenvalues i`
+- `Matrix.IsHermitian.det_eq_prod_eigenvalues : det A = ∏ i, (eigenvalues i : 𝕜)`
+
+**Fubini for products:**
+- `integral_fintype_prod_volume_eq_prod (f : (i : ι) → E i → 𝕜) :
+    ∫ x : (i : ι) → E i, ∏ i, f i (x i) = ∏ i, ∫ x, f i x`
+- In `Mathlib.MeasureTheory.Integral.Pi`
+
+**exp factoring:**
+- `Real.exp_sum (s : Finset α) (f : α → ℝ) :
+    Real.exp (∑ x ∈ s, f x) = ∏ x ∈ s, Real.exp (f x)`
+- `← Finset.sum_neg_distrib` rewrites `-(∑ f) → ∑ (-f)` under simp_rw
+
+**Change of variables (to complete):**
+- `map_linearMap_volume_pi_eq_smul_volume_pi (hf : LinearMap.det f ≠ 0) :
+    Measure.map f volume = ENNReal.ofReal (abs (LinearMap.det f)⁻¹) • volume`
+- For orthogonal map (|det| = 1): `Measure.map f volume = volume`
+- `MeasurePreserving.integral_comp' (h : MeasurePreserving f μ ν) (g : β → G) :
+    ∫ x, g (f x) ∂μ = ∫ y, g y ∂ν`
+
+---
+
+## Session 2026-04-21 (Session 1) - Diagonal Case Proved
+
+**Mode**: FRESH
+**Outcome**: progress — diagonal_gaussian proved (0 sorries), main theorem 1 sorry
+
+### What I Did
+
+1. Surveyed Mathlib APIs: spectral theorem, Fubini for ℝⁿ, exp_sum, measure change-of-variables
+2. Confirmed `integral_fintype_prod_volume_eq_prod` in `Mathlib.MeasureTheory.Integral.Pi`
+3. Confirmed `Fin.prod_univ_castSucc` in `Mathlib.Algebra.BigOperators.Fin`
+4. Wrote `proofs/Proofs/AreaOfCircleOQ05OQ02.lean` (139 lines)
+5. Proved `prod_sqrt_eq_sqrt_prod` by induction (0 sorries)
+6. Proved `diagonal_gaussian` completely via exp_sum + Fubini + scaled_gaussian (0 sorries)
+7. Stated `multivariate_gaussian_integral` with 1 sorry (spectral change-of-variables)
+8. Created gallery entry `src/data/proofs/area-of-circle-oq-05-oq-02/`
+
+### Key Findings
+
+**diagonal_gaussian proof is clean**: Uses `← Finset.sum_neg_distrib` (from GaussianFourierTransform usage) + `Real.exp_sum` to factor exp(-∑) = ∏ exp(-), then Fubini via `integral_fintype_prod_volume_eq_prod`, then `scaled_gaussian` from parent, then `prod_sqrt_eq_sqrt_prod` + `prod_div_distrib` + `prod_const`.
+
+**Main sorry analysis**: The spectral decomposition step requires:
+- Rewriting `dotProduct x (A.mulVec x)` using spectral_theorem
+- Showing the change of variables y = (eigenvectorUnitary)ᵀ *ᵥ x is measure-preserving
+- This needs `map_linearMap_volume_pi_eq_smul_volume_pi` with |det (eigenvectorUnitary)ᵀ| = 1
+- The det = ±1 for unitary matrices; for real symmetric PosDef, det(eigenvectorUnitary) ∈ {±1}
+
+**Key challenge**: Constructing a `MeasurableEquiv` from the linear map `(eigenvectorUnitary)ᵀ *ᵥ·` to use `MeasurePreserving.integral_comp'`. The linear map IS measurable and is a bijection, so this should be possible via `LinearEquiv.measurePreserving` or `ContinuousLinearEquiv.measurePreserving`.
+
+### Files Modified
+- `proofs/Proofs/AreaOfCircleOQ05OQ02.lean` (created, 139 lines, 1 sorry)
+- `src/data/proofs/area-of-circle-oq-05-oq-02/` (gallery entry created)
+- `src/data/proofs/listings.json` (entry added)
+- `src/data/research/problems/area-of-circle-oq-05-oq-02.json` (updated knowledge)
+
+### Next Steps
+1. Find `ContinuousLinearEquiv.measurePreserving` or `LinearEquiv.measurePreserving` to build the MeasurableEquiv
+2. Show `Matrix.IsHermitian.eigenvectorUnitary` is a ContinuousLinearEquiv when restricted to ℝ
+3. Prove det = ±1 for eigenvectorUnitary — use `Matrix.unitaryGroup.det_apply` or similar
+4. Complete the quadratic form rewriting: xᵀAx = ∑ λᵢ (Uᵀx)ᵢ² via spectral_theorem

--- a/research/problems/area-of-circle-oq-05-oq-02/state.md
+++ b/research/problems/area-of-circle-oq-05-oq-02/state.md
@@ -1,0 +1,32 @@
+# Research State: area-of-circle-oq-05-oq-02
+
+## Current State
+**Phase**: ACT
+**Path**: full
+**Since**: 2026-04-21T20:59:46+02:00
+**Iteration**: 1
+**Selected by Seeker**: 2026-04-21
+
+## Current Focus
+Understand the scalar Gaussian integral formalization in `AreaOfCircleOQ05.lean`,
+then assess Mathlib's spectral theorem for real symmetric matrices.
+Key question: does Mathlib provide `Matrix.IsHermitian.eigenvectorMatrix` with enough
+API to use in a change-of-variables argument?
+
+## Active Approach
+1. Read `AreaOfCircleOQ05.lean` to understand how the scalar case is proved
+2. Search Mathlib for `Matrix.PosDef`, spectral theorem, orthogonal change of variables
+3. Check Fubini for product measures on `Fin n → ℝ`
+4. Determine: prove diagonal case first, then generalize via spectral theorem
+
+## Next Steps
+1. Read `proofs/Proofs/AreaOfCircleOQ05.lean` fully
+2. Check `Mathlib.LinearAlgebra.Matrix.PosDef` and `Matrix.IsHermitian`
+3. Search for `volume_comp_linearMap` in Mathlib (change of variables for linear maps)
+4. Assess: is `MeasureTheory.integral_comp_mul_right` sufficient?
+
+## Blockers
+- None yet (OBSERVE phase)
+
+## History
+- 2026-04-21: Problem selected by Seeker (pool replenishment, tier B)

--- a/src/data/proofs/area-of-circle-oq-05-oq-02/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-02/annotations.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": "ann-oq02-overview",
+    "proofId": "area-of-circle-oq-05-oq-02",
+    "range": { "startLine": 1, "endLine": 28 },
+    "type": "overview",
+    "content": "The multivariate Gaussian integral ∫ exp(-xᵀAx) = √(πⁿ/det A) for positive-definite A. The proof factors through: (1) a diagonal case proved by Fubini + scalar Gaussian, (2) a general case by spectral theorem (1 sorry for the orthogonal change-of-variables step)."
+  },
+  {
+    "id": "ann-oq02-prod-sqrt",
+    "proofId": "area-of-circle-oq-05-oq-02",
+    "range": { "startLine": 48, "endLine": 63 },
+    "type": "key-lemma",
+    "content": "Helper lemma `prod_sqrt_eq_sqrt_prod`: ∏ √(fᵢ) = √(∏ fᵢ) for nonneg fᵢ. Proved by induction using Fin.prod_univ_castSucc to split off the last element, IH for the prefix, and Real.sqrt_mul to combine. Not in Mathlib but easily derivable."
+  },
+  {
+    "id": "ann-oq02-diagonal",
+    "proofId": "area-of-circle-oq-05-oq-02",
+    "range": { "startLine": 73, "endLine": 93 },
+    "type": "key-theorem",
+    "content": "diagonal_gaussian is the key intermediate result. It's proved completely (0 sorries) using: (1) Real.exp_sum to factor exp(-∑) = ∏ exp(-), (2) integral_fintype_prod_volume_eq_prod (Fubini), (3) scaled_gaussian from AreaOfCircleOQ05 for each factor, (4) prod_sqrt_eq_sqrt_prod + prod_div_distrib + prod_const for the final simplification."
+  },
+  {
+    "id": "ann-oq02-main",
+    "proofId": "area-of-circle-oq-05-oq-02",
+    "range": { "startLine": 115, "endLine": 138 },
+    "type": "sorry-annotation",
+    "content": "The main theorem has 1 sorry: the spectral change-of-variables step. The proof needs: (a) hA.1.spectral_theorem (A = U * diag(λ) * Uᵀ), (b) PosDef.eigenvalues_pos (λᵢ > 0), (c) the orthogonal change y = Uᵀx is measure-preserving (|det Uᵀ| = 1 via map_linearMap_volume_pi_eq_smul_volume_pi), (d) IsHermitian.det_eq_prod_eigenvalues (det A = ∏ λᵢ)."
+  }
+]

--- a/src/data/proofs/area-of-circle-oq-05-oq-02/index.ts
+++ b/src/data/proofs/area-of-circle-oq-05-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AreaOfCircleOQ05OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const areaOfCircleOq05Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const areaOfCircleOq05Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const areaOfCircleOq05Oq02Data: ProofData = {
+  proof: areaOfCircleOq05Oq02Proof,
+  annotations: areaOfCircleOq05Oq02Annotations,
+}

--- a/src/data/proofs/area-of-circle-oq-05-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-02/meta.json
@@ -1,0 +1,97 @@
+{
+  "id": "area-of-circle-oq-05-oq-02",
+  "title": "Multivariate Gaussian Integral via Matrix Diagonalization",
+  "slug": "area-of-circle-oq-05-oq-02",
+  "description": "Proves the multivariate Gaussian integral ∫ exp(-xᵀAx) = √(πⁿ/det A) for positive-definite A. The diagonal case is proved completely via Fubini and the scalar Gaussian. The general case reduces to the diagonal case by the spectral theorem (1 sorry for the orthogonal change of variables).",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Gaussian_integral#n-dimensional_and_functional_generalization",
+    "date": "Classical result, formalized 2026",
+    "status": "formalized",
+    "tags": [
+      "analysis",
+      "integration",
+      "multivariate-gaussian",
+      "matrix-theory",
+      "spectral-theorem",
+      "measure-theory",
+      "open-question",
+      "probability-theory"
+    ],
+    "proofRepoPath": "Proofs/AreaOfCircleOQ05OQ02.lean",
+    "badge": "wip",
+    "sorries": 1,
+    "axiomCount": 0,
+    "assumptions": "1 sorry in multivariate_gaussian_integral: the orthogonal change-of-variables step requires constructing a MeasurableEquiv from the eigenvector unitary and applying map_linearMap_volume_pi_eq_smul_volume_pi with |det U| = 1. All other theorems (prod_sqrt_eq_sqrt_prod, diagonal_gaussian) are proved with 0 sorries.",
+    "originalContributions": [
+      "prod_sqrt_eq_sqrt_prod: proved by induction that ∏ √(fᵢ) = √(∏ fᵢ) for nonneg fᵢ using Fin.prod_univ_castSucc and Real.sqrt_mul",
+      "diagonal_gaussian: complete proof that ∫ exp(-∑ bᵢxᵢ²) = √(πⁿ/∏bᵢ) using Real.exp_sum + integral_fintype_prod_volume_eq_prod (Fubini) + scaled_gaussian from parent",
+      "multivariate_gaussian_integral: statement + proof sketch identifying spectral theorem path: eigenvectorUnitary, diagonal_gaussian, det_eq_prod_eigenvalues",
+      "Documents the change-of-variables infrastructure needed: map_linearMap_volume_pi_eq_smul_volume_pi with |det Uᵀ| = 1"
+    ],
+    "dateAdded": "2026-04-21",
+    "lineCount": 139,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "The multivariate Gaussian integral ∫_{ℝⁿ} exp(-xᵀAx) dx = √(πⁿ/det A) for positive-definite A is a cornerstone of probability theory (multivariate normal distribution), statistics, quantum mechanics (path integrals), and algebraic geometry (Siegel modular forms). It generalizes the classical Poisson-Laplace formula ∫_{ℝ} exp(-x²) = √π and appears throughout mathematical physics.",
+    "problemStatement": "**Open Question (OQ-02 from OQ-05)**: Can the multivariate Gaussian integral be formalized in Lean 4?\n\n**Answer**: YES (partially). The diagonal case is proved completely. The general case reduces to diagonal via spectral theorem with 1 remaining sorry for the orthogonal change-of-variables measure theory.",
+    "text": "A 139-line formalization with two key theorems: (1) `diagonal_gaussian` (proved completely): for positive weights b : Fin n → ℝ, ∫_{ℝⁿ} exp(-∑ bᵢxᵢ²) = √(πⁿ/∏bᵢ) via exp_sum + Fubini + scalar Gaussian. (2) `multivariate_gaussian_integral` (1 sorry): reduces to diagonal case via spectral theorem. The helper `prod_sqrt_eq_sqrt_prod` is proved by induction.",
+    "proofStrategy": "**Part 1** (prod_sqrt_eq_sqrt_prod): Induction on n. Base case: ∏_{Fin 0} = 1 = √1. Inductive step: split using Fin.prod_univ_castSucc, apply IH to prefix, then combine √a * √b = √(a*b) via Real.sqrt_mul.\n\n**Part 2** (diagonal_gaussian): (i) Rewrite exp(-∑ bᵢxᵢ²) = ∏ exp(-bᵢxᵢ²) via ← Finset.sum_neg_distrib then Real.exp_sum. (ii) Apply integral_fintype_prod_volume_eq_prod (Fubini for product spaces). (iii) Each factor ∫ exp(-bᵢxᵢ²) = √(π/bᵢ) by scaled_gaussian from AreaOfCircleOQ05. (iv) Simplify ∏ √(π/bᵢ) = √(πⁿ/∏bᵢ) via prod_sqrt_eq_sqrt_prod + prod_div_distrib + prod_const.\n\n**Part 3** (multivariate_gaussian_integral, sorry): (i) Spectral theorem: A = U * diag(λ) * Uᵀ (eigenvectorUnitary). (ii) Quadratic form: xᵀAx = ∑ λᵢ(Uᵀx)ᵢ². (iii) Orthogonal change of variables y = Uᵀx (measure-preserving). (iv) Apply diagonal_gaussian. (v) det A = ∏ λᵢ by det_eq_prod_eigenvalues.",
+    "keyInsights": [
+      "**Fubini as the Core Tool**: integral_fintype_prod_volume_eq_prod from MeasureTheory.Integral.Pi factors ∫_{ℝⁿ} ∏ f(xᵢ) as ∏ ∫_{ℝ} f(xᵢ), making the multivariate integral reduce to a product of scalar integrals. This is the key mathematical step.",
+      "**exp_sum as the Bridge**: Real.exp_sum converts exp(-∑ bᵢxᵢ²) to ∏ exp(-bᵢxᵢ²), enabling the Fubini factorization. Combined with ← Finset.sum_neg_distrib (-(∑f) → ∑(-f)), this makes the rewrite clean.",
+      "**Reuse via Import Chain**: scaled_gaussian from AreaOfCircleOQ05 is imported directly, demonstrating that the Lean Genius gallery builds on itself. Each open question generates child proofs that reuse parent infrastructure.",
+      "**prod_sqrt by Induction**: The helper ∏ √(fᵢ) = √(∏ fᵢ) is not in Mathlib but is easy to prove by induction, combining Fin.prod_univ_castSucc with Real.sqrt_mul.",
+      "**Spectral Gap**: The main sorry requires constructing a MeasurableEquiv from the eigenvector unitary and invoking map_linearMap_volume_pi_eq_smul_volume_pi. The key mathematical fact is |det Uᵀ| = 1 (orthogonal matrices preserve Lebesgue measure)."
+    ],
+    "prerequisites": [
+      "Gaussian integral (AreaOfCircleOQ05.lean): scaled_gaussian for the 1D case",
+      "Matrix spectral theorem (Mathlib.Analysis.Matrix.Spectrum): eigenvectorUnitary, eigenvalues, spectral_theorem",
+      "Fubini for product spaces (Mathlib.MeasureTheory.Integral.Pi): integral_fintype_prod_volume_eq_prod",
+      "Measure change-of-variables (Mathlib.MeasureTheory.Measure.Lebesgue.Basic): map_linearMap_volume_pi_eq_smul_volume_pi",
+      "Positive-definite matrices (Mathlib.Analysis.Matrix.PosDef): PosDef, eigenvalues_pos"
+    ]
+  },
+  "crossReferences": [
+    {
+      "id": "xref-oq05-parent",
+      "targetId": "area-of-circle-oq-05",
+      "targetTitle": "The Gaussian Integral and the Area of a Circle",
+      "relationship": "parent",
+      "description": "Parent proof establishing the scalar Gaussian integral ∫ e^{-x²} = √π via Mathlib's integral_gaussian"
+    },
+    {
+      "id": "xref-oq05-oq01",
+      "targetId": "area-of-circle-oq-05-oq-01",
+      "targetTitle": "Polar-Coordinate Proof of the Gaussian Integral",
+      "relationship": "sibling",
+      "description": "Sibling open question about the polar coordinate proof of the same scalar Gaussian"
+    }
+  ],
+  "sections": [
+    {
+      "id": "sec-helper",
+      "title": "Product of Square Roots",
+      "startLine": 42,
+      "endLine": 64,
+      "description": "Helper lemma: ∏ √(fᵢ) = √(∏ fᵢ) by induction on n"
+    },
+    {
+      "id": "sec-diagonal",
+      "title": "Diagonal Gaussian Integral",
+      "startLine": 65,
+      "endLine": 94,
+      "description": "Diagonal case: ∫ exp(-∑ bᵢxᵢ²) = √(πⁿ/∏bᵢ) — proved with 0 sorries"
+    },
+    {
+      "id": "sec-main",
+      "title": "Multivariate Gaussian Integral",
+      "startLine": 95,
+      "endLine": 139,
+      "description": "Main theorem: ∫ exp(-xᵀAx) = √(πⁿ/det A) for positive-definite A — 1 sorry"
+    }
+  ]
+}

--- a/src/data/research/problems/area-of-circle-oq-05-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-02.json
@@ -1,0 +1,107 @@
+{
+  "slug": "area-of-circle-oq-05-oq-02",
+  "title": "Multivariate Gaussian Integral via Matrix Diagonalization",
+  "phase": "ACT",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "theorem multivariate_gaussian_integral (n : \u2115) (A : Matrix (Fin n) (Fin n) \u211d) (hA : A.PosDef) : \u222b x : Fin n \u2192 \u211d, Real.exp (-(Matrix.dotProduct x (A.mulVec x))) = Real.sqrt (Real.pi ^ n / A.det)",
+    "plain": "For a positive-definite real symmetric matrix A of size n\u00d7n, prove \u222b_{\u211d\u207f} exp(-x\u1d40Ax) dx = \u221a(\u03c0\u207f/det(A)) by diagonalizing A via the spectral theorem.",
+    "whyMatters": [
+      "Natural generalization of the scalar Gaussian integral in AreaOfCircleOQ05.lean",
+      "Used in multivariate normal distributions, statistics, and quantum mechanics",
+      "Requires spectral theorem + Fubini + measure theory \u2014 demonstrates Mathlib coverage"
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "gaussian_integral_eq_sqrt_pi: \u222b_{\u211d} e^{-x\u00b2} dx = \u221a\u03c0 (parent proof)",
+      "Matrix.PosDef: positive-definite matrices in Mathlib",
+      "MeasureTheory.integral_prod: Fubini for product measures"
+    ],
+    "open": [
+      "Spectral theorem change of variables for orthogonal Q",
+      "Multivariate Gaussian integral formula"
+    ],
+    "goal": "Prove multivariate Gaussian integral via spectral decomposition + Fubini"
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-04-21",
+    "iteration": 1,
+    "focus": "Read AreaOfCircleOQ05.lean and assess Mathlib spectral theorem API",
+    "blockers": [],
+    "nextAction": "Read proofs/Proofs/AreaOfCircleOQ05.lean, search Matrix.IsHermitian spectral theorem",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "PROGRESS: diagonal_gaussian proved (0 sorries), main theorem 1 sorry for orthogonal change-of-variables. Gallery entry created.",
+    "builtItems": [
+      "prod_sqrt_eq_sqrt_prod (private lemma, AreaOfCircleOQ05OQ02.lean:48-63): \u220f \u221af\u1d62 = \u221a(\u220f f\u1d62), proved by induction, 0 sorries",
+      "diagonal_gaussian (theorem, AreaOfCircleOQ05OQ02.lean:73-93): diagonal multivariate Gaussian, 0 sorries",
+      "multivariate_gaussian_integral (theorem, AreaOfCircleOQ05OQ02.lean:115-136): main theorem, 1 sorry"
+    ],
+    "insights": [
+      "Spectral theorem: symmetric positive-definite A = Q^T D Q, Q orthogonal",
+      "Change of variables y = Qx has Jacobian 1 (orthogonal Q)",
+      "Fubini separates: \u222b e^{-\u03a3 \u03bb\u1d62y\u1d62\u00b2} = \u220f \u222b e^{-\u03bb\u1d62y\u1d62\u00b2} = \u220f \u221a(\u03c0/\u03bb\u1d62)",
+      "Product of \u221a(\u03c0/\u03bb\u1d62) = \u221a(\u03c0\u207f/det A) via det A = \u220f \u03bb\u1d62",
+      "diagonal_gaussian proved with 0 sorries: exp(-sum b\u1d62x\u1d62\u00b2) = \u220f exp(-b\u1d62x\u1d62\u00b2) via exp_sum, then Fubini (integral_fintype_prod_volume_eq_prod), then scaled_gaussian for each factor",
+      "prod_sqrt_eq_sqrt_prod proved by induction: \u220f \u221a(f\u1d62) = \u221a(\u220f f\u1d62) using Fin.prod_univ_castSucc + Real.sqrt_mul",
+      "Main sorry: spectral change-of-variables step needs eigenvectorUnitary MeasurableEquiv + map_linearMap_volume_pi_eq_smul_volume_pi with |det U\u1d40|=1",
+      "Key Mathlib chain: \u2190 Finset.sum_neg_distrib + Real.exp_sum rewrites exp(-\u2211) = \u220f exp(-) under integral binder"
+    ],
+    "mathlibGaps": [
+      "MeasurableEquiv from eigenvectorUnitary (orthogonal matrix) not directly available",
+      "Need to prove |det eigenvectorUnitary| = 1 for real symmetric PosDef matrix"
+    ],
+    "nextSteps": [
+      "Prove measure-preserving step: toLin' (eigenvectorUnitary)\u1d40 preserves volume using map_linearMap_volume_pi_eq_smul_volume_pi + Matrix.det_unitaryGroup",
+      "Connect quadratic form x\u1d40Ax to eigenbasis sum using spectral_theorem + dotProduct_mulVec",
+      "Use IsHermitian.det_eq_prod_eigenvalues to close det A = \u220f \u03bb\u1d62"
+    ]
+  },
+  "tags": [
+    "analysis",
+    "probability",
+    "gaussian-integral",
+    "spectral-theorem",
+    "measure-theory"
+  ],
+  "relatedProofs": [
+    "area-of-circle",
+    "area-of-circle-oq-05",
+    "central-limit-theorem"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": [
+      "Mathlib.LinearAlgebra.Matrix.PosDef",
+      "Mathlib.MeasureTheory.Integral.Bochner",
+      "Mathlib.MeasureTheory.Measure.Haar.Basic"
+    ]
+  },
+  "started": "2026-04-21T19:30:00.000Z",
+  "lastUpdate": "2026-04-21T19:30:00.000Z",
+  "significance": 7,
+  "tractability": 7,
+  "leanFiles": [
+    {
+      "path": "Proofs/AreaOfCircleOQ05.lean",
+      "filename": "AreaOfCircleOQ05.lean",
+      "lineCount": 0,
+      "theoremCount": 0,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ05.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Proves the diagonal multivariate Gaussian: `∫ exp(-∑ bᵢxᵢ²) = √(πⁿ/∏bᵢ)` with **0 sorries**
- Adds helper `prod_sqrt_eq_sqrt_prod`: `∏ √(fᵢ) = √(∏ fᵢ)` by induction (**0 sorries**)
- States the general case `multivariate_gaussian_integral`: `∫ exp(-xᵀAx) = √(πⁿ/det A)` for PosDef A (**1 sorry** for orthogonal CoV step)
- Creates gallery entry `area-of-circle-oq-05-oq-02` with full metadata

## Proof approach

`diagonal_gaussian` uses:
1. `Real.exp_sum` + `← Finset.sum_neg_distrib` to factor `exp(-∑ bᵢxᵢ²) = ∏ exp(-bᵢxᵢ²)`
2. `integral_fintype_prod_volume_eq_prod` (Fubini for ℝⁿ)
3. `scaled_gaussian` from parent `AreaOfCircleOQ05.lean`
4. `prod_sqrt_eq_sqrt_prod` + `prod_div_distrib` + `prod_const` for final simplification

## Remaining sorry

`multivariate_gaussian_integral`: needs orthogonal change-of-variables via `map_linearMap_volume_pi_eq_smul_volume_pi` with `|det (eigenvectorUnitary)ᵀ| = 1`, plus spectral decomposition rewriting `dotProduct x (A.mulVec x) = ∑ λᵢ (Uᵀx)ᵢ²`.

## Test plan
- [x] File builds via `docker-build.sh Proofs.AreaOfCircleOQ05OQ02` (1 expected sorry warning, 0 errors)
- [x] Gallery entry metadata validates
- [x] All claimed proofs have 0 sorries (`prod_sqrt_eq_sqrt_prod`, `diagonal_gaussian`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)