### PR TITLE
Enrich hurwitz-theorem-oq-03-oq-01: add 5 annotations + fix section boundaries

### DIFF
--- a/src/data/proofs/hurwitz-theorem-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/hurwitz-theorem-oq-03-oq-01/annotations.json
@@ -1,1 +1,62 @@
-[]
+[
+  {
+    "id": "ann-hurwitz-oq03oq01-header",
+    "proofId": "hurwitz-theorem-oq-03-oq-01",
+    "range": { "startLine": 1, "endLine": 46 },
+    "type": "context",
+    "title": "Two-Case Strategy: Gelfand-Mazur for Fields, Clifford for Division Rings",
+    "content": "The module docstring (lines 6-42) cleanly separates the two cases of Hurwitz's only-if direction:\n\n**Commutative case** (lines 14-16): Any normed ℝ-field is ≅ ℝ (dim 1) or ℂ (dim 2) by Gelfand-Mazur — both in {1,2,4,8}. Fully proved.\n\n**Non-commutative case** (lines 18-25): Classical proof uses Clifford algebras and Radon-Hurwitz numbers. Unit imaginary elements of A generate Clifford relations on ℝ^(n-1), and the periodicity of Cl(n-1) representations forces n ∈ {1,2,4,8}. Currently a sorry.\n\n**Relation to parent** (lines 27-36): `HurwitzTheorem.lean` contains `axiom hurwitz_only_if (n : ℕ) ... (nsi : NSquareIdentity n) : n ∈ admissibleDimensions`. The bridge from `NormedDivisionRing` to `NSquareIdentity` requires choosing an orthonormal basis and transporting multiplication through coordinates — the key missing infrastructure.",
+    "mathContext": "The two formulations: (1) Gelfand-Mazur: `F` normed ℝ-field → `F ≃ₐ[ℝ] ℝ ∨ F ≃ₐ[ℝ] ℂ` → finrank ∈ {1,2}; (2) Clifford reduction: `NormedDivisionRing A` dim n → n-1 anticommuting unit vectors → Cl(n-1) module dim n → Radon-Hurwitz numbers force n ∈ {1,2,4,8}. These are equivalent but use different Mathlib infrastructure.",
+    "significance": "context",
+    "relatedConcepts": ["Gelfand-Mazur theorem", "Clifford algebras", "Radon-Hurwitz numbers", "NSquareIdentity", "NormedDivisionRing"],
+    "prerequisites": ["Hurwitz theorem (1898)", "Gelfand-Mazur (Mathlib 2025)", "Bott periodicity", "Clifford algebra representations"]
+  },
+  {
+    "id": "ann-admissible-def",
+    "proofId": "hurwitz-theorem-oq-03-oq-01",
+    "range": { "startLine": 48, "endLine": 51 },
+    "type": "definition",
+    "title": "admissibleDimensions: The Four Magic Dimensions",
+    "content": "Defines `admissibleDimensions : Set ℕ := {1, 2, 4, 8}` — the four dimensions allowed by Hurwitz's theorem. This is a `Set ℕ` (not `Finset ℕ`) for ease of use in membership statements. Membership uses `Set.mem_insert_iff` in the proofs.\n\nThe four numbers arise from a deep coincidence in algebra and topology:\n- **1**: ℝ (real numbers)\n- **2**: ℂ (complex numbers)\n- **4**: ℍ (quaternions, Hamilton 1843)\n- **8**: 𝕆 (octonions, Cayley-Graves 1843-1845)\n\nThe pattern {1, 2, 4, 8} = {2^0, 2^1, 2^2, 2^3} reflects the Cayley-Dickson construction: each algebra is obtained by doubling the previous. The process stops at dim 8 because octonions are non-associative and the next doubling (sedenions, dim 16) loses the division property.",
+    "mathContext": "`admissibleDimensions = {1, 2, 4, 8}` corresponds to the Cayley-Dickson tower: $\\mathbb{R} \\to \\mathbb{C} \\to \\mathbb{H} \\to \\mathbb{O}$. Hurwitz's theorem says these are the ONLY finite-dimensional real normed division algebras.",
+    "significance": "key",
+    "relatedConcepts": ["Cayley-Dickson construction", "division algebras", "Set.mem_insert_iff"],
+    "prerequisites": ["Set ℕ membership", "Lean set literals"]
+  },
+  {
+    "id": "ann-gelfand-mazur-consequence",
+    "proofId": "hurwitz-theorem-oq-03-oq-01",
+    "range": { "startLine": 55, "endLine": 68 },
+    "type": "technique",
+    "title": "Gelfand-Mazur Consequence: finrank ∈ {1, 2} for Normed Fields",
+    "content": "`finrank_normed_field_eq_one_or_two` uses `NormedAlgebra.Real.nonempty_algEquiv_or F` — the Gelfand-Mazur theorem as formalized in Mathlib 2025 by Stoll — which gives `F ≃ₐ[ℝ] ℝ ∨ F ≃ₐ[ℝ] ℂ`. The proof unpacks each case:\n\n**Case F ≅ ℝ** (lines 61-64): Get `e : F ≃ₐ[ℝ] ℝ`. Then `e.toLinearEquiv.finrank_eq` gives `finrank ℝ F = finrank ℝ ℝ`, and `CommSemiring.finrank_self ℝ` gives `finrank ℝ ℝ = 1`.\n\n**Case F ≅ ℂ** (lines 65-68): Get `e : F ≃ₐ[ℝ] ℂ`. Then `e.toLinearEquiv.finrank_eq.trans Complex.finrank_real_complex` gives `finrank ℝ F = 2`.\n\nThis proof is a clean two-line chain in each case, with no arithmetic or estimation — the dimension is determined exactly by the isomorphism type.",
+    "mathContext": "Gelfand-Mazur theorem: any normed ℝ-field is isomorphic (as normed ℝ-algebra) to ℝ or ℂ. This implies `finrank ℝ F ∈ {1, 2}`. The key Mathlib lemmas: `NormedAlgebra.Real.nonempty_algEquiv_or`, `LinearEquiv.finrank_eq`, `CommSemiring.finrank_self`, `Complex.finrank_real_complex`.",
+    "significance": "key",
+    "relatedConcepts": ["Gelfand-Mazur theorem", "AlgEquiv", "finrank_eq", "Complex.finrank_real_complex"],
+    "prerequisites": ["NormedAlgebra.Real.nonempty_algEquiv_or", "LinearEquiv.finrank_eq", "Mathlib.Analysis.Normed.Algebra.GelfandMazur"]
+  },
+  {
+    "id": "ann-field-case-corollary",
+    "proofId": "hurwitz-theorem-oq-03-oq-01",
+    "range": { "startLine": 70, "endLine": 79 },
+    "type": "insight",
+    "title": "Hurwitz Field Case: No Finite-Dimensionality Assumption Needed",
+    "content": "`hurwitz_field_case` proves that `finrank ℝ F ∈ admissibleDimensions` for any `NormedField F` with `NormedAlgebra ℝ F`. The proof is a direct two-case reduction:\n1. If finrank = 1: `rw [h]; simp [admissibleDimensions, Set.mem_insert_iff]` — membership of 1 in {1,2,4,8}\n2. If finrank = 2: same tactic — membership of 2 in {1,2,4,8}\n\n**Key insight**: The theorem does NOT require `[Module.Finite ℝ F]` as a hypothesis. The Gelfand-Mazur theorem implies finite-dimensionality automatically — if F is an infinite-dimensional normed ℝ-field, it cannot be isomorphic to ℝ or ℂ, which are both finite-dimensional. So the hypothesis `[NormedField F]` alone suffices.\n\nThis contrasts with `hurwitz_only_if_ring` (the non-commutative case) which requires `[Module.Finite ℝ A]` explicitly.",
+    "mathContext": "`hurwitz_field_case`: `NormedField F, NormedAlgebra ℝ F ⊢ finrank ℝ F ∈ {1,2,4,8}`. No finite-dimensionality assumption: Gelfand-Mazur implies F ≅ ℝ or F ≅ ℂ, which are both finite-dimensional, so `finrank ℝ F = 1 or 2 ∈ {1,2,4,8}`.",
+    "significance": "key",
+    "relatedConcepts": ["NormedField", "Module.Finite", "admissibleDimensions", "Gelfand-Mazur implicit finite-dimensionality"],
+    "prerequisites": ["finrank_normed_field_eq_one_or_two", "Set.mem_insert_iff", "simp"]
+  },
+  {
+    "id": "ann-noncommutative-sorry",
+    "proofId": "hurwitz-theorem-oq-03-oq-01",
+    "range": { "startLine": 81, "endLine": 115 },
+    "type": "insight",
+    "title": "The Non-Commutative Sorry: Two Paths to Quaternion-Octonion Restriction",
+    "content": "`hurwitz_only_if_ring` extends to all `NormedDivisionRing A` (associative) with `[Module.Finite ℝ A]`. The sorry (line 115) represents the non-commutative hard case. The inline proof sketch (lines 103-114) outlines the resolution:\n\n**Path 1: NSquareIdentity reduction** (lines 106-112): Choose an orthonormal basis {e₁,...,eₙ} of A as ℝ-vector space. Define multiplication in coordinates via mul a b := basis coordinates of (Σ aᵢeᵢ)·(Σ bᵢeᵢ). The norm-multiplicativity ‖xy‖ = ‖x‖·‖y‖ then gives normSq a × normSq b = normSq(mul a b) — exactly `NSquareIdentity n`. Apply `HurwitzTheorem.hurwitz_only_if` (an axiom in the parent file).\n\n**Path 2: Clifford algebras** (lines 89-92): The (n-1) imaginary unit elements of A satisfy eᵢeⱼ + eⱼeᵢ = -2δᵢⱼ (Clifford relations on ℝ^(n-1)), giving a real n-dim representation of Cl(n-1). The Radon-Hurwitz constraint forces n ∈ {1,2,4,8}.\n\n**Frobenius' theorem note** (lines 97-99): For ASSOCIATIVE real division algebras, only ℝ, ℂ, ℍ (dims 1,2,4) are possible. The octonions (dim 8) need non-associativity beyond `NormedDivisionRing`. So the sorry, once resolved, actually gives a stronger result: `finrank ℝ A ∈ {1, 2, 4}` for associative A, and the `8` entry is vacuously included.",
+    "mathContext": "The sorry covers: `NormedDivisionRing A, NormedAlgebra ℝ A, Module.Finite ℝ A ⊢ finrank ℝ A ∈ {1,2,4,8}`. Classical result (Frobenius 1877 for associative, Hurwitz 1898 for norm-multiplicative): only ℝ (dim 1), ℂ (dim 2), ℍ (dim 4), 𝕆 (dim 8) exist. The `NSquareIdentity` bridge: if A is normed division ring of dim n, then n×n matrix multiplication on ℝⁿ satisfies the n-square identity.",
+    "significance": "key",
+    "relatedConcepts": ["NormedDivisionRing", "NSquareIdentity", "Clifford algebras", "Radon-Hurwitz numbers", "Frobenius theorem"],
+    "prerequisites": ["HurwitzTheorem.hurwitz_only_if", "Module.Finite", "orthonormal basis", "Clifford relations"]
+  }
+]

--- a/src/data/proofs/hurwitz-theorem-oq-03-oq-01/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-03-oq-01/meta.json
@@ -22,7 +22,7 @@
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
     "assumptions": "1 sorry: hurwitz_only_if_ring (non-commutative case) — requires Clifford algebra representation theory or NSquareIdentity reduction from HurwitzTheorem.lean. The commutative subcase (hurwitz_field_case) is axiom-free.",
-    "lineCount": 115,
+    "lineCount": 117,
     "theoremCount": 3,
     "definitionCount": 1,
     "originalContributions": [
@@ -82,25 +82,33 @@
       "summary": "Imports Gelfand-Mazur, complex finrank, and normed field infrastructure. Docstring explains the field vs. non-commutative split and the planned NSquareIdentity reduction."
     },
     {
+      "id": "admissible-def",
+      "title": "Admissible Dimensions Definition",
+      "startLine": 48,
+      "endLine": 51,
+      "summary": "Defines admissibleDimensions := {1, 2, 4, 8} as a Set ℕ — the four dimensions permitted by Hurwitz's theorem.",
+      "mathContext": "The four values correspond to ℝ (dim 1), ℂ (dim 2), ℍ (dim 4), 𝕆 (dim 8) via the Cayley-Dickson construction."
+    },
+    {
       "id": "field-case",
       "title": "Commutative Case: Proved via Gelfand-Mazur",
-      "startLine": 47,
-      "endLine": 87,
-      "summary": "finrank_normed_field_eq_one_or_two and hurwitz_field_case: normed fields over ℝ have finrank 1 or 2. Both proved, 0 sorries.",
-      "mathContext": "Uses NormedAlgebra.Real.nonempty_algEquiv_or (Gelfand-Mazur) and LinearEquiv.finrank_eq."
+      "startLine": 53,
+      "endLine": 79,
+      "summary": "finrank_normed_field_eq_one_or_two and hurwitz_field_case: normed fields over ℝ have finrank 1 or 2, both in {1,2,4,8}. Both proved with 0 sorries. No finite-dimensionality assumption needed — Gelfand-Mazur implies it.",
+      "mathContext": "Uses NormedAlgebra.Real.nonempty_algEquiv_or (Gelfand-Mazur): F ≅ ℝ or F ≅ ℂ. Then LinearEquiv.finrank_eq + CommSemiring.finrank_self / Complex.finrank_real_complex give finrank = 1 or 2."
     },
     {
       "id": "general-case",
       "title": "General Division Ring Case (1 sorry)",
-      "startLine": 88,
+      "startLine": 81,
       "endLine": 115,
-      "summary": "hurwitz_only_if_ring: the non-commutative case with a documented sorry. Proof sketch explains the NSquareIdentity reduction path.",
-      "mathContext": "The sorry will be resolved once the orthonormal basis transport is formalized, connecting to HurwitzTheorem.hurwitz_only_if."
+      "summary": "hurwitz_only_if_ring: the non-commutative case with a documented sorry and full proof sketch. Two resolution paths: (1) NSquareIdentity reduction via orthonormal basis transport, (2) direct Clifford algebra + Radon-Hurwitz argument.",
+      "mathContext": "The sorry covers NormedDivisionRing A, NormedAlgebra ℝ A, Module.Finite ℝ A. By Frobenius, the associative case only admits dims 1, 2, 4 — the '8' entry is vacuous for NormedDivisionRing."
     }
   ],
   "leanFile": {
     "namespace": "HurwitzOnlyIf",
-    "lineCount": 113,
+    "lineCount": 117,
     "axiomCount": 0,
     "theoremCount": 3,
     "definitionCount": 1,


### PR DESCRIPTION
## Enrichment: hurwitz-theorem-oq-03-oq-01

This Hurwitz only-if direction proof had an empty annotations.json (quality 38/100). This PR adds complete annotation coverage and fixes section boundary issues.

### Annotations Added (5 new)

- **ann-hurwitz-oq03oq01-header**: Two-case strategy (Gelfand-Mazur for fields, Clifford for division rings), and the relation to the parent `HurwitzTheorem.lean` `NSquareIdentity` axiom
- **ann-admissible-def**: `admissibleDimensions = {1,2,4,8}` — the four Cayley-Dickson doubles, with `Set.mem_insert_iff` usage  
- **ann-gelfand-mazur-consequence**: `finrank_normed_field_eq_one_or_two` — case analysis F≅ℝ vs F≅ℂ via `NormedAlgebra.Real.nonempty_algEquiv_or`, `finrank_eq` chain
- **ann-field-case-corollary**: Key insight: `hurwitz_field_case` needs no `Module.Finite` hypothesis — Gelfand-Mazur implies finite-dimensionality automatically
- **ann-noncommutative-sorry**: Two paths to resolve the sorry (NSquareIdentity reduction vs direct Clifford algebra), plus Frobenius theorem note (associative case only gives dims 1,2,4)

### Section Fixes

- Added missing `admissible-def` section (lines 48-51) 
- Fixed `field-case` section: startLine 47→53, endLine 87→79 (was overlapping general-case by pointing into its docstring)
- Fixed `general-case` section: startLine 88→81 (was skipping the `/-! ### The General (Division Ring) Case -/` header)
- Fixed `lineCount`: 115→117 in both `meta` and `leanFile` fields

🤖 Enricher-1