### PR TITLE
Enrich brouwer-fixed-point-oq-04-oq-02: 5 annotations + sections + cross-refs

### DIFF
--- a/src/data/proofs/brouwer-fixed-point-oq-04-oq-02/annotations.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-04-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-nash-brouwer-header",
+    "proofId": "brouwer-fixed-point-oq-04-oq-02",
+    "range": { "startLine": 1, "endLine": 50 },
+    "type": "context",
+    "title": "Nash's Original Brouwer Argument vs. Kakutani Approach",
+    "content": "This file formalizes Nash's 1950 proof of equilibrium existence — the original argument from his 2-page PNAS paper, which used Brouwer's fixed point theorem directly. This distinguishes it from `BrouwerFixedPointOQ04OQ01.lean` (Kakutani-based proof via best-response correspondences).\n\n**The key innovation**: Nash replaced the set-valued best-response correspondence with a single-valued continuous map. Instead of tracking which pure strategies are optimal (the best-response correspondence, requiring upper hemicontinuity theory), Nash's map tracks *how much better* each pure strategy is and shifts weight proportionally. This avoids Berge's maximum theorem entirely.\n\n**Reduction from OQ-01**: The OQ-01 (Kakutani) approach required 2 axioms: `kakutani_product_simplex` and `berge_maximum_theorem`. This file eliminates `berge_maximum_theorem` — polynomial continuity is elementary — reducing to 1 axiom (`brouwer_product_simplex`) plus 1 sorry (multilinear reindexing).",
+    "mathContext": "Nash (1950): for each player $i$ and pure strategy $k$, define the *excess payoff* $e_{ik}(\\sigma) = \\max(0, EU_i(e_k, \\sigma_{-i}) - EU_i(\\sigma_i, \\sigma_{-i}))$. The Nash map: $\\phi_{ik}(\\sigma) = (\\sigma_i(k) + e_{ik}(\\sigma)) / (1 + \\sum_l e_{il}(\\sigma))$. Any fixed point satisfies: $e_{ik}(\\sigma) = \\sigma_i(k) \\cdot C_i$ for all $i,k$, where $C_i \\geq 0$. If $C_i > 0$, all positive-weight strategies are best responses — i.e., $\\sigma$ is a Nash equilibrium. If $C_i = 0$, no deviation is profitable, also a Nash equilibrium.",
+    "significance": "context",
+    "relatedConcepts": ["Nash equilibrium", "Brouwer fixed point theorem", "mixed strategies", "deviation map", "BrouwerFixedPointOQ04OQ01"],
+    "prerequisites": ["Brouwer FPT", "product simplex", "multilinear extension", "BrouwerFixedPointOQ04"]
+  },
+  {
+    "id": "ann-multilinear-game",
+    "proofId": "brouwer-fixed-point-oq-04-oq-02",
+    "range": { "startLine": 51, "endLine": 100 },
+    "type": "definition",
+    "title": "MultilinearGame Structure: Pure Payoffs and Mixed Extension",
+    "content": "The `MultilinearGame` structure captures a finite N-player game with:\n- `N : ℕ` — number of players\n- `strategies i : ℕ` — number of pure strategies for player i\n- `payoff i : (∀ j, Fin (strategies j)) → ℝ` — pure strategy payoff for player i\n\nThe *mixed utility* `mixedUtility G i σ` for player i under strategy profile σ (one mixed strategy per player) is the multilinear extension:\n$$EU_i(\\sigma) = \\sum_{s : \\prod_j [\\text{strategies}_j]} \\prod_j \\sigma_j(s_j) \\cdot \\text{payoff}_i(s)$$\n\nThis is a polynomial in all mixed strategy components, making it jointly continuous without any additional hypotheses.",
+    "mathContext": "For a finite game with $m_i$ strategies for player $i$, mixed strategies are probability vectors $\\sigma_i \\in \\Delta_{m_i-1}$. The mixed extension $EU_i : \\prod_i \\Delta_{m_i-1} \\to \\mathbb{R}$ is a multi-linear polynomial (degree $N$) in $\\sum_i m_i$ variables. Continuity follows from the polynomial structure — no compactness or convexity arguments needed.",
+    "significance": "key",
+    "relatedConcepts": ["multilinear extension", "expected utility", "finite games", "mixed strategies", "Finset.sum"],
+    "prerequisites": ["Finset.prod", "Finset.univ", "Fin N"]
+  },
+  {
+    "id": "ann-nash-map-construction",
+    "proofId": "brouwer-fixed-point-oq-04-oq-02",
+    "range": { "startLine": 141, "endLine": 200 },
+    "type": "technique",
+    "title": "Nash's Deviation Map: Well-Definedness and Self-Mapping",
+    "content": "The Nash deviation map has two components:\n\n**Excess payoff** (well-defined): `excess G i k σ = max 0 (EU_i(eₖ, σ₋ᵢ) - EU_i(σᵢ, σ₋ᵢ))` — how much player i gains by switching to pure strategy k. Always ≥ 0 by definition.\n\n**Normalized map** (self-maps the simplex): `nashMap G i k σ = (σᵢ(k) + excess G i k σ) / (1 + Σₗ excess G i l σ)`. The denominator is `1 + total_excess ≥ 1 > 0`, so division is well-defined. The map sends the product simplex to itself:\n- Each component ≥ 0: numerator = σᵢ(k) + excess ≥ 0 + 0 = 0\n- Components sum to 1: `Σₖ nashMap G i k σ = (Σₖ σᵢ(k) + Σₖ excess) / (1 + Σₖ excess) = (1 + Cᵢ)/(1 + Cᵢ) = 1`\n\nThe simplex-preservation is the key structural lemma, proved by algebraic manipulation.",
+    "mathContext": "Self-mapping: $\\sum_k \\phi_{ik}(\\sigma) = \\frac{\\sum_k (\\sigma_i(k) + e_{ik})}{1 + \\sum_k e_{ik}} = \\frac{1 + C_i}{1 + C_i} = 1$ where $C_i = \\sum_k e_{ik} \\geq 0$. Non-negativity: $\\phi_{ik}(\\sigma) \\geq 0$ since $\\sigma_i(k) \\geq 0$ and $e_{ik} \\geq 0$. Together: $\\phi_i(\\sigma) \\in \\Delta_{m_i-1}$.",
+    "significance": "key",
+    "relatedConcepts": ["product simplex", "probability simplex", "self-map", "excess payoff", "normalization"],
+    "prerequisites": ["Finset.sum_div", "mixedUtility_linear_in_i", "ProductSimplex"]
+  },
+  {
+    "id": "ann-fixed-point-is-nash",
+    "proofId": "brouwer-fixed-point-oq-04-oq-02",
+    "range": { "startLine": 201, "endLine": 260 },
+    "type": "insight",
+    "title": "The Key Algebraic Argument: Fixed Points Are Nash Equilibria",
+    "content": "The proof that any fixed point σ* of Nash's map is a Nash equilibrium is a beautiful piece of algebra:\n\n**Setup**: If φ(σ*) = σ*, then for each player i and strategy k:\n`σ*ᵢ(k) = (σ*ᵢ(k) + eᵢₖ) / (1 + Cᵢ)`\n\nwhere Cᵢ = Σₗ eᵢₗ ≥ 0 is the total excess for player i.\n\n**Rearranging**: σ*ᵢ(k) · (1 + Cᵢ) = σ*ᵢ(k) + eᵢₖ, so **eᵢₖ = σ*ᵢ(k) · Cᵢ** for all i, k.\n\n**Equilibrium proof**: Sum over k: Cᵢ = Σₖ eᵢₖ = Σₖ σ*ᵢ(k) · Cᵢ = Cᵢ · 1 = Cᵢ. This is consistent. Now if Cᵢ > 0: for each k with σ*ᵢ(k) > 0, we have eᵢₖ = σ*ᵢ(k)·Cᵢ > 0, meaning EU_i(eₖ, σ*) > EU_i(σ*). But then EU_i(σ*ᵢ, σ*) = Σₖ σ*ᵢ(k)·EU_i(eₖ, σ*) > EU_i(σ*ᵢ, σ*) — contradiction! So **Cᵢ = 0** for all i, meaning no player can improve by deviating.",
+    "mathContext": "At fixed point: $e_{ik} = \\sigma^*_i(k) \\cdot C_i$. If $C_i > 0$: $EU_i(\\sigma^*_i, \\sigma^*_{-i}) = \\sum_k \\sigma^*_i(k) \\cdot EU_i(e_k, \\sigma^*_{-i}) = \\sum_k \\sigma^*_i(k) \\cdot [EU_i(\\sigma^*_i, \\sigma^*_{-i}) + e_{ik}/\\sigma^*_i(k) + \\ldots]$. The contradiction forces $C_i = 0$, i.e., $e_{ik} = 0$ for all $k$.",
+    "significance": "key",
+    "relatedConcepts": ["fixed point algebra", "Nash equilibrium", "excess payoff", "contradiction"],
+    "prerequisites": ["fixed_point_is_nash", "Finset.sum_congr", "max_eq_zero_iff"]
+  },
+  {
+    "id": "ann-multilinear-reindexing-sorry",
+    "proofId": "brouwer-fixed-point-oq-04-oq-02",
+    "range": { "startLine": 101, "endLine": 140 },
+    "type": "insight",
+    "title": "The One Sorry: Multilinear Factoring by One Player's Strategy",
+    "content": "`mixedUtility_linear_in_i` (the 1 sorry) states that `EU_i(eₖ, σ₋ᵢ) = Σ_{s₋ᵢ} ∏_{j≠i} σ_j(s_j) · payoff(k, s₋ᵢ)`. This is the linearity of expected utility in one player's strategy, obtained by separating player i's strategy from the others in the multilinear sum.\n\n**Proof sketch**: The full sum is `Σ_{s} ∏_j σ_j(s_j) · payoff(s)`. For player i's strategy = eₖ (pure strategy k), only terms with s_i = k survive. Separating: `Σ_{s₋ᵢ} ∏_{j≠i} σ_j(s_j) · payoff(k, s₋ᵢ)`. This requires reindexing a `Finset.sum` over `(Fin m₁) × ... × (Fin mₙ)` by factoring out the i-th coordinate.\n\n**Formalization barrier**: In Lean, `Finset.univ` for a product type doesn't automatically provide this factoring. The needed lemma is essentially `Finset.sum_product'` applied to separate the sum over all strategy profiles into `Σ_{k : Fin m_i} × Σ_{s₋ᵢ}`. This is routine mathematics but requires careful Finset bookkeeping.",
+    "mathContext": "$EU_i(\\sigma) = \\sum_{s \\in \\prod_j S_j} \\prod_j \\sigma_j(s_j) \\cdot u_i(s) = \\sum_k \\sigma_i(k) \\cdot \\left(\\sum_{s_{-i}} \\prod_{j \\neq i} \\sigma_j(s_j) \\cdot u_i(k, s_{-i})\\right)$. The factoring uses `Finset.sum_product'` or `Finset.sum_comm` to separate the sum over player $i$'s strategies from the rest.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.sum_product'", "multilinear factoring", "sorry", "Finset.univ for product types"],
+    "prerequisites": ["Finset.sum_comm", "Finset.prod_univ_eq_prod_range", "Fin.prod_univ_succ"]
+  }
+]

--- a/src/data/proofs/brouwer-fixed-point-oq-04-oq-02/index.ts
+++ b/src/data/proofs/brouwer-fixed-point-oq-04-oq-02/index.ts
@@ -1,0 +1,9 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BrouwerFixedPointOQ04OQ02.lean?raw'
+const meta = metaJson as unknown as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+export const brouwerOq04Oq02Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections || [], source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
+export const brouwerOq04Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+export const brouwerOq04Oq02Data: ProofData = { proof: brouwerOq04Oq02Proof, annotations: brouwerOq04Oq02Annotations, tacticStates: [] }
+export default brouwerOq04Oq02Data

--- a/src/data/proofs/brouwer-fixed-point-oq-04-oq-02/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-04-oq-02/meta.json
@@ -1,0 +1,146 @@
+{
+  "id": "brouwer-fixed-point-oq-04-oq-02",
+  "title": "Nash Equilibrium Existence via Nash's Brouwer Argument",
+  "slug": "brouwer-fixed-point-oq-04-oq-02",
+  "meta": {
+    "author": "researcher-2",
+    "date": "2026-04-21",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/BrouwerFixedPointOQ04OQ02.lean",
+    "tags": [
+      "topology",
+      "game-theory",
+      "economics",
+      "fixed-point-theory",
+      "convex-analysis"
+    ],
+    "badge": "axiom",
+    "sorries": 1,
+    "axioms": 1,
+    "dateAdded": "2026-04-21",
+    "dateUpdated": "2026-04-21",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "MultilinearGame structure with explicit pure strategy payoffs and multilinear utility extension",
+      "Proof that mixedUtility is jointly continuous (polynomial in all strategy profiles)",
+      "Nash's deviation map: excess and normalized deviation map with proved well-definedness",
+      "Proved nashMap maps ProductSimplex to itself (components are valid probability distributions)",
+      "Proved nashMap is continuous (finite composition of continuous operations)",
+      "Proved fixed_point_is_nash: any fixed point of Nash's map is a Nash equilibrium",
+      "Reduced Nash existence from 2 axioms (OQ-01) to 1 axiom + 1 sorry"
+    ],
+    "historicalContext": "John Nash's 1950 proof of equilibrium existence in his landmark 2-page paper used Brouwer's fixed point theorem directly — not Kakutani's generalization, which Nash also used in his 1951 Annals paper. The original argument defines a deviation map on the product simplex: each player shifts weight toward pure strategies that give higher expected utility, then normalizes. Continuous self-maps of compact convex sets have fixed points by Brouwer, and at any fixed point the deviation vanishes — meaning no player can unilaterally improve. This formalization implements this original argument for multilinear games.",
+    "problemStatement": "For a finite N-player game where expected utility is the multilinear extension of pure strategy payoffs (the standard definition for matrix games), does there exist a Nash equilibrium in mixed strategies? Nash (1950) proved yes, using Brouwer FPT applied to an explicit single-valued continuous self-map of the product simplex.",
+    "proofStrategy": "Define Nash's deviation map: for each player i and pure strategy k, compute the excess payoff from deviating to pure strategy k; shift weight toward strategies with positive excess, then normalize. This map is continuous (polynomial in strategy profiles) and maps the product simplex to itself. Brouwer FPT gives a fixed point, and the algebra of the fixed-point equation shows all excesses are zero — i.e., no player can improve by deviating.",
+    "assumptions": "1 axiom: brouwer_product_simplex (Brouwer FPT for the product simplex — the topological embedding of ∏ᵢ Δᵢ into ℝⁿ for appropriate n). 1 sorry: mixedUtility_linear_in_i (multilinear factoring: reindexing a finite sum over all pure strategy profiles by one player's strategy value).",
+    "axiomCount": 1,
+    "lineCount": 280,
+    "theoremCount": 15,
+    "definitionCount": 8
+  },
+  "overview": {
+    "historicalContext": "Nash's original 1950 proof of equilibrium existence occupies only a paragraph in his 2-page PNAS paper. The key idea: define a continuous map on the product of mixed strategy simplices whose fixed points are Nash equilibria. Each player shifts weight toward pure strategies that offer improvement over their current mixed strategy. The normalization ensures the result is a valid mixed strategy. Brouwer's fixed point theorem guarantees a fixed point, and the algebra of the fixed-point equation implies all players are in equilibrium. Nash later gave a Kakutani-based proof in his 1951 Annals paper, but the Brouwer version is more direct and avoids upper hemicontinuity.",
+    "problemStatement": "For a finite N-player game with multilinear expected utility, prove that a Nash equilibrium in mixed strategies exists.",
+    "proofStrategy": "Define the excess payoff `excess_i(k, σ) = max(0, EU_i(eₖ, σ) − EU_i(σᵢ, σ))`, and the normalized Nash map `φᵢ(k, σ) = (σᵢ(k) + excess_i(k, σ)) / (1 + Σₗ excess_i(l, σ))`. Prove: (1) φ maps the product simplex to itself; (2) φ is continuous; (3) by Brouwer FPT, φ has a fixed point; (4) any fixed point is a Nash equilibrium.",
+    "keyInsights": [
+      "Nash's map avoids UHC: the key innovation is replacing the set-valued best-response correspondence with a single-valued continuous map. No Berge's theorem needed.",
+      "Fixed point algebra: at a fixed point, each excess equals σᵢ(k) times the total excess Cᵢ. If Cᵢ > 0, all positive-weight pure strategies have positive excess, making the expected utility strictly larger than itself — contradiction.",
+      "Continuity from polynomials: the multilinear extension of payoffs is a polynomial in all strategy components, hence automatically continuous.",
+      "Product simplex is compact convex: the product of the mixed strategy simplices is compact (Tychonoff) and convex, satisfying Brouwer's hypotheses."
+    ],
+    "prerequisites": [
+      "Brouwer Fixed Point Theorem",
+      "Multilinear algebra (finite sums and products)",
+      "Probability simplices and mixed strategies",
+      "Continuity of polynomial maps"
+    ],
+    "text": "Nash equilibrium existence for multilinear games via Nash's original Brouwer argument."
+  },
+  "conclusion": {
+    "summary": "Formalizes Nash's original 1950 proof of equilibrium existence via Brouwer FPT. Main contributions: MultilinearGame structure, joint continuity of mixedUtility, Nash's deviation map, and the algebraic proof that fixed points are Nash equilibria. 1 sorry (multilinear reindexing), 1 axiom (product simplex Brouwer). Reduces OQ-01's 2 axioms to 1 by eliminating the need for Berge's maximum theorem.",
+    "implications": "Demonstrates that Nash equilibrium existence follows from the topological minimum (Brouwer FPT), without requiring the more subtle upper hemicontinuity theory of set-valued maps. The key obstacle (Berge's theorem) is replaced by elementary polynomial continuity.",
+    "openQuestions": [
+      "Can mixedUtility_linear_in_i be proved formally by Finset sum reindexing?",
+      "Can brouwer_product_simplex be derived from kakutani_fixed_point_axiom via the Fin.append embedding?",
+      "Does the Nash map approach extend to games with infinite strategy sets (e.g., compact metric spaces)?"
+    ]
+  },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Imports, Namespace, and MultilinearGame Structure",
+      "startLine": 1,
+      "endLine": 100,
+      "summary": "Imports topology and convex analysis. Defines MultilinearGame (pure payoffs + multilinear extension), mixedUtility (joint continuity from polynomial structure), and ProductSimplex.",
+      "mathContext": "MultilinearGame: N players, strategies i : ℕ, payoff i : (∀ j, Fin (strategies j)) → ℝ. mixedUtility is a polynomial of degree N in Σᵢ strategies i variables, hence jointly continuous."
+    },
+    {
+      "id": "multilinear-linearity",
+      "title": "Multilinear Factoring and Continuity (1 sorry)",
+      "startLine": 101,
+      "endLine": 140,
+      "summary": "mixedUtility_linear_in_i: EU_i(eₖ, σ₋ᵢ) = Σ_{s₋ᵢ} ∏_{j≠i} σ_j(s_j) · payoff(k, s₋ᵢ). The 1 sorry: separating a Finset.sum over product types by factoring out one player's coordinate.",
+      "mathContext": "EU_i(eₖ) = Σ_{s₋ᵢ} ∏_{j≠i} σ_j(s_j) · u_i(k, s₋ᵢ). Requires Finset.sum_product' to factor the sum over ∏_j Fin(mⱼ) by the i-th coordinate."
+    },
+    {
+      "id": "nash-map",
+      "title": "Nash Deviation Map: Well-Definedness and Self-Mapping",
+      "startLine": 141,
+      "endLine": 200,
+      "summary": "Defines excess payoff (max 0, deviation gain) and normalized Nash map. Proves: denominator > 0 (well-defined division), nashMap components are non-negative, components sum to 1 (self-maps the simplex), nashMap is continuous.",
+      "mathContext": "excess G i k σ = max 0 (EU_i(eₖ, σ₋ᵢ) − EU_i(σᵢ, σ₋ᵢ)). nashMap G i k σ = (σᵢ(k) + excess) / (1 + Σₗ excess). Denominator ≥ 1 > 0. Σₖ nashMap = (1 + Cᵢ)/(1 + Cᵢ) = 1."
+    },
+    {
+      "id": "fixed-point-and-nash",
+      "title": "Fixed Point Is Nash + Main Existence Theorem",
+      "startLine": 201,
+      "endLine": 280,
+      "summary": "fixed_point_is_nash: algebraic proof that any fixed point σ* of Nash's map is a Nash equilibrium (Cᵢ = 0 for all i). nash_existence: apply brouwer_product_simplex axiom to nashMap, then fixed_point_is_nash.",
+      "mathContext": "At fixed point: eᵢₖ = σ*ᵢ(k)·Cᵢ for all i,k. If Cᵢ > 0: EU_i(σ*ᵢ, σ*₋ᵢ) > EU_i(σ*ᵢ, σ*₋ᵢ) — contradiction. So Cᵢ = 0, meaning σ* is a Nash equilibrium."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "brouwer-fixed-point-oq-04-oq-01",
+      "relationship": "related",
+      "description": "Alternative Nash existence proof via Kakutani FPT + Berge's maximum theorem (set-valued best-response correspondence). This file reduces axiom count from 2 to 1 by using Nash's original single-valued Brouwer argument."
+    },
+    {
+      "targetId": "brouwer-fixed-point-oq-04",
+      "relationship": "depends-on",
+      "description": "Provides the brouwer_product_simplex axiom (Brouwer FPT for product simplex) and the kakutani_fixed_point_axiom used in OQ-01."
+    }
+  ],
+  "references": [
+    {
+      "authors": "John F. Nash",
+      "title": "Equilibrium Points in N-Person Games",
+      "year": "1950",
+      "venue": "Proceedings of the National Academy of Sciences",
+      "note": "Original 2-page proof using Brouwer FPT directly"
+    },
+    {
+      "authors": "John F. Nash",
+      "title": "Non-Cooperative Games",
+      "year": "1951",
+      "venue": "Annals of Mathematics",
+      "note": "Kakutani-based proof in the extended version"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Topology.Basic",
+      "Mathlib.Topology.Compactness.Compact",
+      "Mathlib.Analysis.InnerProductSpace.PiL2",
+      "Mathlib.Analysis.Convex.Basic",
+      "Mathlib.Algebra.BigOperators.Group.Finset",
+      "Proofs.BrouwerFixedPointOQ04"
+    ],
+    "namespace": "NashBrouwer",
+    "lineCount": 280,
+    "axiomCount": 1,
+    "sorries": 1,
+    "path": "Proofs/BrouwerFixedPointOQ04OQ02.lean"
+  },
+  "sorries": 1
+}


### PR DESCRIPTION
## Enrichment: brouwer-fixed-point-oq-04-oq-02

Nash equilibrium existence via Nash's original 1950 Brouwer argument. Entry had quality 33/100 with no annotations, no sections, no cross-references.

### Annotations Added (5)

- **ann-nash-brouwer-header**: Brouwer vs Kakutani contrast — explains how this reduces OQ-01's 2 axioms to 1 by replacing Berge's theorem with polynomial continuity
- **ann-multilinear-game**: `MultilinearGame` structure — pure payoffs, multilinear extension, joint continuity from polynomial structure
- **ann-nash-map-construction**: Excess payoff + normalized Nash map — well-definedness (denominator ≥ 1), simplex self-map algebra (Σₖ = (1+Cᵢ)/(1+Cᵢ) = 1)
- **ann-fixed-point-is-nash**: The key algebraic argument — at fixed point `eᵢₖ = σ*ᵢ(k)·Cᵢ`, and if Cᵢ > 0 we get EU_i > EU_i — contradiction, so Cᵢ = 0 (Nash equilibrium)
- **ann-multilinear-reindexing-sorry**: The 1 sorry explained — `mixedUtility_linear_in_i` needs `Finset.sum_product'` to factor the multi-player sum by one player's coordinate

### Structure Added

- 4 sections: setup (1-100), multilinear-linearity (101-140), nash-map (141-200), fixed-point-and-nash (201-280)
- 2 cross-references: parent `brouwer-fixed-point-oq-04` (axiom source) + sibling `brouwer-fixed-point-oq-04-oq-01` (Kakutani approach comparison)

🤖 Enricher-1