### PR TITLE
Enrich erdos-476-oq-05: add 5 annotations for Vosper's theorem

### DIFF
--- a/src/data/proofs/erdos-476-oq-05/annotations.json
+++ b/src/data/proofs/erdos-476-oq-05/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-vosper-context",
+    "proofId": "erdos-476-oq-05",
+    "range": { "startLine": 1, "endLine": 45 },
+    "type": "context",
+    "title": "Vosper's Theorem: Inverse Problem for Cauchy-Davenport",
+    "content": "The module header (lines 1-35) frames Vosper's 1956 result as the structural complement to Cauchy-Davenport: if Cauchy-Davenport tells you |A+B| ≥ |A|+|B|-1, Vosper tells you what A and B must look like when equality holds.\n\nFour-step proof strategy (lines 12-18):\n1. Define arithmetic progressions in ZMod p\n2. Key sublemma: |B\\(B+d)| = 1 → B is an AP (backward-shift iteration)\n3. Base case |A| = 2: inclusion-exclusion forces |B∩(B+d)| = |B|-1 → |B\\(B+d)| = 1 → B is AP\n4. General induction on |A|: remove one element, apply induction, show removed element extends the AP\n\nImports (lines 37-44) bring in `ZMod.cauchy_davenport` from Mathlib.Combinatorics.Additive.CauchyDavenport and `Finset.Pointwise` for the sumset operation A+B.",
+    "mathContext": "Cauchy-Davenport (1813/1935): $|A+B| \\geq \\min(p, |A|+|B|-1)$ for $A,B \\subseteq \\mathbb{Z}/p\\mathbb{Z}$ and $p$ prime. Vosper (1956): equality with $|A|, |B| \\geq 2$ and $|A+B| < p$ iff $\\exists d \\neq 0$ with $A$ and $B$ both APs with difference $d$. Together they give a complete characterization of sumset structure in $\\mathbb{Z}/p\\mathbb{Z}$.",
+    "significance": "context",
+    "relatedConcepts": ["Cauchy-Davenport theorem", "additive combinatorics", "inverse sumset problems", "ZMod.cauchy_davenport", "Finset.Pointwise"],
+    "prerequisites": ["Cauchy-Davenport theorem", "ZMod p as a field", "Finset sumsets in Lean"]
+  },
+  {
+    "id": "ann-is-ap-definition",
+    "proofId": "erdos-476-oq-05",
+    "range": { "startLine": 49, "endLine": 58 },
+    "type": "definition",
+    "title": "IsArithmeticProgression: Image of Range Definition",
+    "content": "`IsArithmeticProgression A a d : Prop` is defined as `A = (Finset.range A.card).image (fun i => a + (i : ZMod p) * d)`. This equational definition has several advantages:\n\n- No separate distinctness proof needed: the image-of-range formulation handles size automatically\n- The d=0 edge case: image collapses to {a} regardless of A.card. IsArithmeticProgression A a 0 holds iff A = {a}\n- Coercion: `(i : ZMod p)` uses the canonical ring homomorphism ℕ → ZMod p",
+    "mathContext": "`IsArithmeticProgression A a d` iff $A = \\{a, a+d, a+2d, \\ldots, a+(k-1)d\\}$ where $k = |A|$. In $\\mathbb{Z}/p\\mathbb{Z}$, elements are distinct iff $d \\neq 0$ and $k \\leq p$ (since the map $i \\mapsto a + id$ is injective mod $p$ when $d \\neq 0$, as $p$ is prime).",
+    "significance": "key",
+    "relatedConcepts": ["Finset.range", "Finset.image", "ZMod coercion", "arithmetic progression"],
+    "prerequisites": ["Finset.image in Lean 4", "ZMod coercion", "Finset.card"]
+  },
+  {
+    "id": "ann-ap-infrastructure",
+    "proofId": "erdos-476-oq-05",
+    "range": { "startLine": 60, "endLine": 100 },
+    "type": "technique",
+    "title": "AP Infrastructure: Four Proved Lemmas (0 sorries)",
+    "content": "Four lemmas establish the basic AP toolkit, all fully proved:\n\n**`isAP_singleton`** (lines 63-65): Every singleton is an AP. Proof: `simp` with `Finset.card_singleton` and `Finset.image_singleton`.\n\n**`isAP_pair`** (lines 68-80): `{a, b}` with `a ≠ b` is an AP with difference `b-a`. Proof uses `Finset.card_pair`, `ext` membership, then `interval_cases i` for i=0 (gives a + 0·(b-a) = a by `simp`) and i=1 (gives a + 1·(b-a) = b by `ring`).\n\n**`isAP_shift`** (lines 83-90): Translation by c preserves AP with same difference d. Proof: unfold definition, apply `shift_card_eq` for cardinality, use `Finset.image_image` to compose, then `congr 1; ext i; ring`.\n\n**`shift_card_eq`** (lines 93-100): |B.image (·+d)| = |B|. Via `Finset.card_image_of_injective`: injectivity from x+d = y+d → x = y via `congrArg (· + (-d))`.",
+    "mathContext": "Translation $(\\cdot + d) : \\mathbb{Z}/p\\mathbb{Z} \\to \\mathbb{Z}/p\\mathbb{Z}$ is a bijection (field automorphism when $d \\neq 0$). AP shift: $\\{a, a+d, \\ldots, a+(k-1)d\\} + c = \\{a+c, a+d+c, \\ldots\\}$, an AP with same difference $d$ and starting point $a+c$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.card_image_of_injective", "Finset.image_image", "interval_cases tactic", "ring tactic", "congrArg"],
+    "prerequisites": ["Finset.image in Lean", "group cancellation in ZMod p", "congrArg"]
+  },
+  {
+    "id": "ann-near-periodic-sorry",
+    "proofId": "erdos-476-oq-05",
+    "range": { "startLine": 102, "endLine": 128 },
+    "type": "insight",
+    "title": "The Key Sublemma: Near-Periodicity Forces AP Structure (1 sorry)",
+    "content": "`ap_of_near_periodic`: if `(B \\ (B.image (· + d))).card = 1` and d ≠ 0 and |B| < p, then B is an AP with difference d.\n\nThe mathematical argument (lines 109-114):\n1. Let {b₀} = B \\ (B+d). Then b₀ has no predecessor: b₀ - d ∉ B.\n2. Every other b ∈ B has b - d ∈ B (predecessor exists).\n3. Starting from any b, iterating backward (b, b-d, b-2d, ...) eventually reaches b₀, since d ≠ 0 and |B| < p means the sequence cycles with period p before revisiting.\n4. All elements b₀, b₀+d, ..., b₀+(|B|-1)d are distinct and cover B.\n\n**Formalization barrier (sorry)**: The backward iteration needs well-founded recursion on |B|, requiring `Finset.induction_on` with a measure showing each step strictly decreases. The key: the 'distance from b₀ in B' decreases at each step.",
+    "mathContext": "Near-periodicity: $|B \\setminus (B+d)| = 1$ means the shift removes exactly one element and (by `shift_card_eq`) adds exactly one element. The unique non-predecessor element $b_0$ forces $B = \\{b_0, b_0+d, \\ldots, b_0+(|B|-1)d\\}$. The distinctness follows from $d \\neq 0$ and $|B| \\leq p-1 < p$ (primes in $\\mathbb{Z}/p\\mathbb{Z}$ have order $p$).",
+    "significance": "key",
+    "relatedConcepts": ["backward-shift induction", "Finset.induction_on", "well-founded recursion", "near-periodicity", "ap_of_near_periodic"],
+    "prerequisites": ["Finset.card_sdiff", "shift_card_eq", "backward iteration in ZMod p"]
+  },
+  {
+    "id": "ann-vosper-base-and-theorem",
+    "proofId": "erdos-476-oq-05",
+    "range": { "startLine": 130, "endLine": 189 },
+    "type": "insight",
+    "title": "Vosper Base Case and Full Theorem: Inclusion-Exclusion + Induction",
+    "content": "**`vosper_base`** (lines 132-158): For |A| = 2 (A = {a, b}, d = b-a ≠ 0): A is an AP by `isAP_pair`. For B, the sumset inclusion-exclusion gives: `|A+B| = 2|B| - |B ∩ (B+d)|`. Since |A+B| = |B|+1: `|B ∩ (B+d)| = |B|-1`, hence `|B \\ (B+d)| = 1`. Apply `ap_of_near_periodic`. The proof extracts a, b from A using `Finset.card_eq_two` → `obtain ⟨a, b, hab, rfl⟩`. The sorry is at the Finset inclusion-exclusion computation.\n\n**`vosper`** (lines 160-189): Full induction on |A|. Base: |A| = 2 by `vosper_base`. Inductive step |A| ≥ 3: Remove element a to get A' = A \\ {a}. Cauchy-Davenport: |A'+B| ≥ |A'|+|B|-1 = |A|+|B|-2. Since A'+B ⊆ A+B: |A'+B| ≤ |A|+|B|-1. The equality |A'+B| = |A'|+|B|-1 implies AP structure for A' and B by induction. Then a extends A' by exactly d, completing A's AP structure. The inductive step is the 1 sorry.",
+    "mathContext": "Inclusion-exclusion: $|A+B| = |(a+B) \\cup ((a+d)+B)| = 2|B| - |(a+B) \\cap ((a+d)+B)| = 2|B| - |B \\cap (B+d)|$. Setting equal to $|B|+1$: $|B \\cap (B+d)| = |B|-1$, $|B \\setminus (B+d)| = 1$. Inductive step: $|A'+B| \\geq \\min(p, |A'|+|B|-1)$ from Cauchy-Davenport, but also $|A'+B| \\leq |A+B| - 1 = |A|+|B|-2 = |A'|+|B|-1$, giving equality.",
+    "significance": "key",
+    "relatedConcepts": ["inclusion-exclusion principle", "Finset.card_eq_two", "ZMod.cauchy_davenport", "strong induction", "vosper_base"],
+    "prerequisites": ["ap_of_near_periodic", "isAP_pair", "Finset inclusion-exclusion", "strong induction on Finset.card"]
+  }
+]

--- a/src/data/proofs/erdos-476-oq-05/index.ts
+++ b/src/data/proofs/erdos-476-oq-05/index.ts
@@ -1,0 +1,46 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+// Type assertion for JSON import
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+// Import the Lean source file
+const leanSource = () => import('../../../../proofs/Proofs/Erdos476OQ05Problem.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '', // Loaded dynamically
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const proofData: ProofData = {
+  proof,
+  annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/erdos-476-oq-05/meta.json
+++ b/src/data/proofs/erdos-476-oq-05/meta.json
@@ -1,0 +1,113 @@
+{
+  "id": "erdos-476-oq-05",
+  "title": "Erdős #476 OQ5: Vosper's Theorem — Equality Case of Cauchy-Davenport",
+  "slug": "erdos-476-oq-05",
+  "description": "Vosper's theorem (1956): if |A+B| = |A|+|B|-1 in Z/pZ with |A|,|B|≥2 and |A+B|<p, then A and B are arithmetic progressions with the same common difference d. Infrastructure proved: IsArithmeticProgression definition, singleton/pair AP lemmas, translation invariance. Full Vosper requires sorry pending the inductive step.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-04-21",
+    "status": "formalized",
+    "proofRepoPath": "Proofs/Erdos476OQ05Problem.lean",
+    "tags": [
+      "additive-combinatorics",
+      "erdos",
+      "number-theory",
+      "arithmetic-progressions",
+      "cauchy-davenport",
+      "vosper-theorem",
+      "zmod"
+    ],
+    "badge": "wip",
+    "sorries": 3,
+    "dateAdded": "2026-04-21",
+    "axiomCount": 0,
+    "assumptions": "3 sorries: (1) ap_of_near_periodic — key sublemma: if |B\\(B+d)|=1 and |B|<p then B is an AP (requires backward-shift induction on |B|); (2) vosper_base — the |A|=2 base case using sublemma; (3) vosper — full Vosper by induction on |A|. Infrastructure (IsArithmeticProgression, isAP_singleton, isAP_pair, isAP_shift, shift_card_eq) all proved with 0 sorries.",
+    "lineCount": 194,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "originalContributions": [
+      "IsArithmeticProgression: AP definition for Finset (ZMod p) with starting point a and difference d",
+      "isAP_singleton: every singleton is an AP (proved, 0 sorries)",
+      "isAP_pair: {a,b} is an AP with difference b-a (proved, 0 sorries)",
+      "isAP_shift: translation preserves AP structure (proved, 0 sorries)",
+      "shift_card_eq: |B.image (·+d)| = |B| via add_right_injective (proved, 0 sorries)",
+      "ap_of_near_periodic: B is AP if |B\\(B+d)|=1 (1 sorry — backward-shift induction)",
+      "vosper_base: Vosper for |A|=2 (1 sorry — uses ap_of_near_periodic)",
+      "vosper: full Vosper theorem (1 sorry — induction on |A|)"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Vosper's theorem (1956) is the inverse result for Cauchy-Davenport (1813/1935): it characterizes WHEN the minimum |A+B| = |A|+|B|-1 is achieved. The Cauchy-Davenport theorem gives |A+B| ≥ min(p, |A|+|B|-1) for A,B ⊆ Z/pZ; Vosper showed the equality case (for non-trivial parameters) forces both A and B to be arithmetic progressions with the same step size. This is a cornerstone of additive combinatorics: the structure theorem dual to the counting theorem.",
+    "problemStatement": "Let p be prime, A,B ⊆ Z/pZ with |A|,|B| ≥ 2 and |A+B| = |A|+|B|-1 < p. Prove that there exists d ≠ 0 in Z/pZ and starting points a, b such that A = {a, a+d, ..., a+(|A|-1)d} and B = {b, b+d, ..., b+(|B|-1)d}.",
+    "text": "The proof strategy uses the Cauchy-Davenport theorem from Mathlib (`ZMod.cauchy_davenport`) as a key tool. For 2-element A = {a, a+d}: the sumset decomposes as A+B = (a+B) ∪ (a+d+B), and equality |A+B| = |B|+1 forces |B ∩ (d+B)| = |B|-1, i.e., B and its d-shift differ in exactly one element. The key sublemma `ap_of_near_periodic` then shows this near-periodicity forces B to be an AP with difference d. The full induction on |A| removes elements one at a time, applying the base case, and then verifying that the removed element extends the AP structure.",
+    "proofStrategy": "Infrastructure: define IsArithmeticProgression A a d := A = (range |A|).image (fun i => a + i*d). Key sublemma: |B \\ (B+d)| = 1 ⟹ B is AP (backward-shift argument: every b ≠ b_max satisfies b-d ∈ B, forcing B to be exhausted by the sequence b_max, b_max+d, ...). Base case |A|=2 uses inclusion-exclusion to compute |B ∩ (d+B)| from |A+B|. Full Vosper: induction on |A|+|B| using Cauchy-Davenport to ensure the reduced problem also achieves equality.",
+    "keyInsights": [
+      "Mathlib has ZMod.cauchy_davenport (the counting theorem) — Vosper is the missing structural complement",
+      "IsArithmeticProgression as A = image of range(|A|) avoids size constraints in the definition",
+      "Key sublemma ap_of_near_periodic: |B \\ (B+d)| ≤ 1 ↔ B is an AP (for |B| < p and d ≠ 0 in Z/pZ)",
+      "Injectivity of (·+d) in ZMod p follows from add_right_injective via AddRightCancelMonoid instance",
+      "The |A|=2 case: |A+B| = 2|B| - |B ∩ (d+B)| = |B|+1 forces |B ∩ (d+B)| = |B|-1"
+    ],
+    "prerequisites": [
+      "ZMod.cauchy_davenport: Mathlib.Combinatorics.Additive.CauchyDavenport",
+      "Finset.card_image_of_injective for cardinality preservation",
+      "add_right_injective for the shift map",
+      "Finset.image_image for composing image maps"
+    ]
+  },
+  "conclusion": {
+    "summary": "Infrastructure for Vosper's theorem fully established: IsArithmeticProgression defined, basic AP lemmas proved (singleton, pair, shift, cardinality). Three sorries remain: the key near-periodicity sublemma, the base case, and the full induction. The mathematical structure is clear and the proof strategy is sound.",
+    "implications": "Once ap_of_near_periodic is formalized (the backward-shift induction), the full Vosper theorem follows from standard induction. Vosper's theorem would then complement ZMod.cauchy_davenport in Mathlib, completing the picture of additive structure in Z/pZ.",
+    "openQuestions": [
+      "Formalize ap_of_near_periodic: B is an AP if |B \\ (B+d)| = 1 (needs backward-shift induction on |B|)",
+      "Extend Vosper to the case |A|=1 or |B|=1 (trivial but needs separate statement)",
+      "Prove the full Vosper theorem with the inductive step on |A|",
+      "Generalize to other groups: Vosper has analogs in other settings (e.g., non-prime orders with different extremal sets)"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-476",
+      "relationship": "extends",
+      "description": "Parent: Erdős-Heilbronn (restricted sumsets A+̂A ≥ min(2|A|-3,p)); Vosper is the equality characterization for the ordinary sumset A+B ≥ min(|A|+|B|-1,p)"
+    },
+    {
+      "targetId": "erdos-1212",
+      "relationship": "related",
+      "description": "Erdős #1212 also uses arithmetic progressions as the key structural tool: Vosper characterizes APs as the extremal sets for Cauchy-Davenport equality in Z/pZ, while #1212 uses APs as the construction method for infinite composite-inclusive paths in the coprime lattice graph. Both problems show APs arising as the 'canonical' solution to combinatorial-number-theoretic extremal questions."
+    }
+  ],
+  "sections": [
+    {
+      "id": "imports-definition",
+      "title": "Imports and IsArithmeticProgression Definition",
+      "startLine": 1,
+      "endLine": 65,
+      "summary": "Imports CauchyDavenport and basic Finset machinery. Defines IsArithmeticProgression A a d as a finset image equation."
+    },
+    {
+      "id": "ap-infrastructure",
+      "title": "AP Infrastructure (4 lemmas proved)",
+      "startLine": 66,
+      "endLine": 120,
+      "summary": "isAP_singleton, isAP_pair, isAP_shift, shift_card_eq — all proved with 0 sorries. The pair lemma uses interval_cases for a 2-case analysis; shift uses Finset.image_image and ring."
+    },
+    {
+      "id": "vosper-theorem",
+      "title": "Vosper's Theorem (3 sorries)",
+      "startLine": 121,
+      "endLine": 185,
+      "summary": "ap_of_near_periodic (key sublemma, 1 sorry), vosper_base (|A|=2 case, 1 sorry), vosper (full theorem, 1 sorry). All have detailed proof outlines in comments."
+    }
+  ],
+  "leanFile": {
+    "namespace": "Erdos476OQ05",
+    "lineCount": 194,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "path": "Proofs/Erdos476OQ05Problem.lean",
+    "sorries": 3
+  },
+  "sorries": 3
+}


### PR DESCRIPTION
## Summary

- Adds `annotations.json` with 5 annotations covering Vosper's theorem (1956): equality characterization of Cauchy-Davenport in Z/pZ
- Fixes `lineCount` 185→194 (actual Lean file size)
- Adds cross-reference linking to `erdos-1212` (shared AP-as-construction theme)
- Annotations cover: proof strategy overview, `IsArithmeticProgression` definition, 4 proved infrastructure lemmas, key near-periodicity sublemma (1 sorry), and base+inductive Vosper cases (2 sorries)

## Proof: erdos-476-oq-05 (Vosper's Theorem)

Vosper (1956): if |A+B| = |A|+|B|-1 in Z/pZ with |A|,|B|≥2 and |A+B|<p, then A and B are arithmetic progressions with the same common difference d. This is the inverse/equality characterization for the Cauchy-Davenport theorem (which Mathlib already has as `ZMod.cauchy_davenport`).

Infrastructure proved (0 sorries): `IsArithmeticProgression` definition, `isAP_singleton`, `isAP_pair`, `isAP_shift`, `shift_card_eq`. Three sorries remain for the key sublemma and full theorem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)