### PR TITLE
Enrich chebyshev-pnt-bridge-oq-01-oq-02 + hurwitz-theorem-oq-03-oq-01

### DIFF
--- a/src/data/proofs/chebyshev-pnt-bridge-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-01-oq-02/annotations.json
@@ -1,1 +1,120 @@
-[]
+[
+  {
+    "id": "ann-cheb-oq02-01-context",
+    "proofId": "chebyshev-pnt-bridge-oq-01-oq-02",
+    "range": {
+      "startLine": 38,
+      "endLine": 49
+    },
+    "type": "context",
+    "title": "Two Proof Paths for the Chebyshev Bound",
+    "content": "The file header documents the key difference between this proof and the original in ChebyshevPNTBridge.lean. Both prove C(2n,n) ≤ (2n)^π(2n), but via different Mathlib entry points:\n\n**Original**: Uses `Nat.factorization_prod_pow_eq_self hcb_ne`, which requires a nonzero hypothesis `hcb_ne : centralBinom n ≠ 0`. Proceeds over `Finsupp.support` (only prime indices), needing `hprime_of_mem` and `hsub` helper lemmas.\n\n**This proof**: Uses `Nat.prod_pow_factorization_centralBinom n`, which works over the full `Finset.range (2*n+1)` — no nonzero hypothesis needed. Non-prime indices p contribute p^0 = 1 (since `.factorization p = 0` for non-prime p), and `prod_filter_of_ne` handles the collapse to primes cleanly.\n\nThe result is 4 clean calc steps vs 6 steps with helper lemmas — a meaningful simplification demonstrating the advantage of using the more specialized Mathlib lemma.",
+    "mathContext": "`Nat.prod_pow_factorization_centralBinom n : centralBinom n = ∏ p ∈ Finset.range (2*n+1), p ^ (centralBinom n).factorization p`. Contrast with `Nat.factorization_prod_pow_eq_self : n ≠ 0 → n = ∏ p ∈ n.factorization.support, p ^ n.factorization p`, which works over `Finsupp.support` and requires `n ≠ 0`.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.prod_pow_factorization_centralBinom",
+      "Nat.factorization_prod_pow_eq_self",
+      "Finsupp.support vs Finset.range",
+      "proof engineering"
+    ],
+    "prerequisites": [
+      "Nat.centralBinom: C(2n,n) in Mathlib.Data.Nat.Choose.Central",
+      "Nat.Factorization API"
+    ]
+  },
+  {
+    "id": "ann-cheb-oq02-02-step1",
+    "proofId": "chebyshev-pnt-bridge-oq-01-oq-02",
+    "range": {
+      "startLine": 50,
+      "endLine": 56
+    },
+    "type": "technique",
+    "title": "Step 1: Factorization Identity for centralBinom",
+    "content": "The first calc step applies `Nat.prod_pow_factorization_centralBinom n` in reverse (`.symm`) to write C(2n,n) as a product over all integers p in `Finset.range (2*n+1)`:\n\n```\ncentralBinom n = ∏ p ∈ range (2*n+1), p^((centralBinom n).factorization p)\n```\n\nThis is the Lean 4 expression of the fundamental theorem of arithmetic for centralBinom: every natural number equals the product of its prime power factors. The crucial advantage over `factorization_prod_pow_eq_self` is that the product runs over a full range rather than `Finsupp.support`, so no `centralBinom n ≠ 0` hypothesis is needed (Mathlib handles this internally). Non-prime indices will be collapsed in Step 2.",
+    "mathContext": "`Nat.prod_pow_factorization_centralBinom : ∀ (n : ℕ), ∏ p ∈ Finset.range (2*n+1), p ^ (Nat.centralBinom n).factorization p = Nat.centralBinom n`. The `.symm` reversal gives equality in the ≥-direction needed for the calc chain. For non-prime p, `(centralBinom n).factorization p = 0` so `p^0 = 1` — these terms are present in the product but contribute nothing.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.prod_pow_factorization_centralBinom",
+      "Fundamental theorem of arithmetic",
+      "Finset.range product",
+      "Nat.Finsupp.factorization"
+    ],
+    "prerequisites": [
+      "Nat.centralBinom",
+      "Nat.Factorization.prod_pow_factorization_centralBinom"
+    ]
+  },
+  {
+    "id": "ann-cheb-oq02-03-step2",
+    "proofId": "chebyshev-pnt-bridge-oq-01-oq-02",
+    "range": {
+      "startLine": 50,
+      "endLine": 64
+    },
+    "type": "technique",
+    "title": "Step 2: Non-Prime Vanishing via prod_filter_of_ne",
+    "content": "Step 2 collapses the product over `Finset.range (2*n+1)` to only the prime indices:\n\n```\n∏ p ∈ range(2n+1), p^(factorization p) = ∏ p ∈ (range(2n+1)).filter Nat.Prime, p^(factorization p)\n```\n\nThe proof applies `(prod_filter_of_ne _).symm`, which requires showing that non-prime terms equal 1. For a non-prime p, `by_contra h_nonprome` + `simp [Nat.factorization_eq_zero_of_not_prime _ h_nonprome]` establishes that `p^(factorization p) = p^0 = 1`, so the hypothesis `hp : p^(factorization p) ≠ 1` leads to contradiction.\n\nThis step is where working over `Finset.range` (rather than `Finsupp.support`) pays off: the product naturally includes all integers in [0, 2n], and the prime filter handles the pruning cleanly.",
+    "mathContext": "`Finset.prod_filter_of_ne : (∀ x ∈ s, f x = 1 → p x) → ∏ x ∈ s.filter p, f x = ∏ x ∈ s, f x`. Here f(p) = p^(factorization p), and the condition is: if p is not prime then f(p) = p^0 = 1. `Nat.factorization_eq_zero_of_not_prime : ¬ p.Prime → n.factorization p = 0`.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.prod_filter_of_ne",
+      "Nat.factorization_eq_zero_of_not_prime",
+      "prime filter",
+      "product over primes"
+    ],
+    "prerequisites": [
+      "Finset.prod_filter_of_ne",
+      "Nat.factorization_eq_zero_of_not_prime",
+      "Step 1 calc equality"
+    ]
+  },
+  {
+    "id": "ann-cheb-oq02-04-step3",
+    "proofId": "chebyshev-pnt-bridge-oq-01-oq-02",
+    "range": {
+      "startLine": 50,
+      "endLine": 71
+    },
+    "type": "lemma",
+    "title": "Step 3: Legendre's Formula Bounds Each Prime Power",
+    "content": "Step 3 bounds each prime power factor by 2n:\n\n```\n∏ p ∈ primes ≤ 2n, p^(v_p(C(2n,n))) ≤ ∏ p ∈ primes ≤ 2n, (2n)\n```\n\nThe proof uses `Finset.prod_le_prod` with two arguments: (1) each factor is nonneg (`Nat.zero_le`), (2) for each prime p in the filter, `p^(centralBinom n).factorization p ≤ 2n`.\n\nThe bound comes from `Nat.pow_factorization_choose_le`, which embodies Legendre's formula: v_p(C(2n,n)) ≤ log(2n)/log(p), so p^(v_p(C(2n,n))) ≤ p^(log(2n)/log(p)) = 2n. The rewrite `centralBinom_eq_two_mul_choose` converts centralBinom to the standard binomial coefficient form expected by `pow_factorization_choose_le`.",
+    "mathContext": "`Nat.pow_factorization_choose_le : ∀ {n : ℕ} (p : ℕ), 1 ≤ n → p ^ (Nat.choose (2*n) n).factorization p ≤ 2*n`. Legendre (1808): $v_p(\\binom{m}{k}) = \\frac{s_p(k) + s_p(m-k) - s_p(m)}{p-1}$ where $s_p(n)$ is the sum of base-p digits; equivalently, $v_p(\\binom{2n}{n}) \\le \\lfloor\\log_p(2n)\\rfloor$, giving $p^{v_p} \\le 2n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.pow_factorization_choose_le",
+      "Legendre's formula",
+      "Finset.prod_le_prod",
+      "centralBinom_eq_two_mul_choose"
+    ],
+    "prerequisites": [
+      "Nat.pow_factorization_choose_le",
+      "Legendre's formula for p-adic valuation",
+      "Finset.prod_le_prod"
+    ]
+  },
+  {
+    "id": "ann-cheb-oq02-05-step4",
+    "proofId": "chebyshev-pnt-bridge-oq-01-oq-02",
+    "range": {
+      "startLine": 50,
+      "endLine": 79
+    },
+    "type": "insight",
+    "title": "Step 4: Cardinality Equals primeCounting via count_eq_card_filter_range",
+    "content": "The final calc step converts the product of π(2n) copies of (2n) into the explicit power form:\n\n```\n∏ _p ∈ primes-filter, (2n) = (2n)^|primes-filter| = (2n)^primeCounting(2n)\n```\n\n`Finset.prod_const` handles the first equality: a product of k identical terms c equals c^k. The second equality — `|{p ∈ range(2n+1) | p.Prime}| = primeCounting(2n)` — uses `Nat.count_eq_card_filter_range`, which is the definitional unfolding of `primeCounting` (= `primeCounting'`) as counting primes in a range.\n\nThis step reveals the architecture of the Chebyshev bound: it reduces to counting primes (π) via Legendre bounds, with no analytic input whatsoever — a purely algebraic-combinatorial argument.",
+    "mathContext": "`Finset.prod_const : ∏ _x ∈ s, c = c ^ s.card`. `Nat.count_eq_card_filter_range : Nat.count p n = (Finset.range n).filter p |>.card`. `Nat.primeCounting = Nat.count Nat.Prime`. The `congr 1` + `unfold` + `exact` sequence closes the goal by unfolding `primeCounting` to `primeCounting'` to `Nat.count Nat.Prime`, then applying `count_eq_card_filter_range`.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Finset.prod_const",
+      "Nat.count_eq_card_filter_range",
+      "Nat.primeCounting",
+      "Nat.primeCounting'"
+    ],
+    "prerequisites": [
+      "Finset.prod_const",
+      "Nat.primeCounting definition",
+      "Nat.count_eq_card_filter_range"
+    ]
+  }
+]

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-01-oq-02/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-01-oq-02/meta.json
@@ -51,7 +51,7 @@
     ]
   },
   "overview": {
-    "historicalContext": "The Chebyshev prime bound C(2n,n) ≤ (2n)^π(2n) is central to the 1852 proof that π(n) ~ n/log(n). The original Lean proof in ChebyshevPNTBridge.lean uses Nat.factorization_prod_pow_eq_self to reconstruct the central binomial from its prime factorization. This entry answers the open question: can Mathlib's specialized lemma Nat.prod_pow_factorization_centralBinom provide a cleaner proof path?",
+    "historicalContext": "The Chebyshev prime bound C(2n,n) ≤ (2n)^π(2n) is central to Chebyshev's 1852 proof that π(x) lies between 0.92x/log(x) and 1.11x/log(x). The key ingredient is Legendre's formula (1808): v_p(n!) = Σ_{k≥1} ⌊n/p^k⌋, which implies v_p(C(2n,n)) ≤ log(2n)/log(p) and hence p^(v_p) ≤ 2n. Mathlib's `Nat.pow_factorization_choose_le` encodes this bound. The original Lean proof in ChebyshevPNTBridge.lean uses `factorization_prod_pow_eq_self` (requiring centralBinom ≠ 0) and reconstructs over `Finsupp.support`. This entry answers the open question: can Mathlib's specialized `prod_pow_factorization_centralBinom` lemma provide a cleaner proof path? The answer is yes — 4 calc steps vs 6, with no nonzero hypothesis.",
     "problemStatement": "Is there a cleaner proof of C(2n,n) ≤ (2n)^π(2n) using Nat.factorization_prod_pow_eq_self or Nat.prod_pow_factorization_centralBinom from Mathlib?",
     "text": "The answer is yes. The key difference from the original proof is that Nat.prod_pow_factorization_centralBinom directly gives C(2n,n) as a product over Finset.range(2n+1) without requiring hcb_ne : centralBinom n ≠ 0. Non-prime indices p contribute p^0 = 1 (since (centralBinom n).factorization p = 0 for non-prime p), collapsing the product to a sum over primes ≤ 2n via prod_filter_of_ne. Each prime term is then bounded by 2n via Legendre's formula (pow_factorization_choose_le), giving at most π(2n) terms each ≤ 2n.",
     "proofStrategy": "4-step calc chain: (1) apply prod_pow_factorization_centralBinom; (2) use prod_filter_of_ne with factorization_eq_zero_of_not_prime to collapse to prime filter; (3) bound each p^{v_p} ≤ 2n via pow_factorization_choose_le; (4) prod_const + primeCounting card equality.",
@@ -90,12 +90,36 @@
   ],
   "sections": [
     {
-      "id": "alternative-proof",
-      "title": "Alternative Proof via prod_pow_factorization_centralBinom",
-      "startLine": 40,
-      "endLine": 65,
-      "summary": "centralBinom_le_pow_primeCounting_via_factorization: 4-step calc proof using Mathlib's specialized centralBinom factorization lemma.",
-      "mathContext": "Step 1: prod_pow_factorization_centralBinom. Step 2: prod_filter_of_ne + factorization_eq_zero_of_not_prime. Step 3: pow_factorization_choose_le. Step 4: prod_const + primeCounting."
+      "id": "preamble",
+      "title": "Imports, Namespace, and Proof Comparison Header",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "Module header explains the two-proof comparison: the original uses factorization_prod_pow_eq_self (requires hcb_ne) over Finsupp.support; this proof uses prod_pow_factorization_centralBinom (no hypothesis) over Finset.range. Imports: Data.Nat.Choose.Factorization, NumberTheory.PrimeCounting, Tactic.",
+      "mathContext": "The module opens `Nat Finset` to bring `centralBinom`, `primeCounting`, `range`, `filter`, and `prod_*` lemmas into scope without qualification."
+    },
+    {
+      "id": "step1-factorization",
+      "title": "Step 1: Factorization Identity for centralBinom",
+      "startLine": 50,
+      "endLine": 56,
+      "summary": "theorem centralBinom_le_pow_primeCounting_via_factorization (n hn). Step 1 of calc: applies prod_pow_factorization_centralBinom.symm to write centralBinom n as ∏ p ∈ range(2n+1), p^(factorization p). No nonzero hypothesis needed.",
+      "mathContext": "`Nat.prod_pow_factorization_centralBinom n : ∏ p ∈ range(2n+1), p^(centralBinom n).factorization p = centralBinom n`. The `.symm` gives the right-to-left rewrite needed as the first calc step."
+    },
+    {
+      "id": "step2-prime-filter",
+      "title": "Steps 2–3: Prime Filter Collapse and Legendre Bound",
+      "startLine": 57,
+      "endLine": 71,
+      "summary": "Step 2 uses prod_filter_of_ne to collapse the range product to primes only (non-prime p have factorization p = 0, so p^0 = 1). Step 3 applies prod_le_prod + pow_factorization_choose_le (Legendre) to bound each p^(v_p) ≤ 2n.",
+      "mathContext": "Step 2: `Finset.prod_filter_of_ne` + `Nat.factorization_eq_zero_of_not_prime`. Step 3: `Finset.prod_le_prod` + `Nat.pow_factorization_choose_le` + `centralBinom_eq_two_mul_choose`. Legendre bound: $p^{v_p(\\binom{2n}{n})} \\le 2n$ for all primes $p$."
+    },
+    {
+      "id": "step4-cardinality",
+      "title": "Step 4: prod_const and primeCounting Cardinality",
+      "startLine": 72,
+      "endLine": 79,
+      "summary": "Step 4 converts ∏_{p prime ≤ 2n} (2n) into (2n)^|{primes ≤ 2n}| = (2n)^primeCounting(2n) using prod_const and count_eq_card_filter_range. End of namespace.",
+      "mathContext": "`Finset.prod_const : ∏ _x ∈ s, c = c^s.card`. `Nat.count_eq_card_filter_range Nat.Prime (2n+1) : Nat.count Nat.Prime (2n+1) = (range(2n+1)).filter Nat.Prime |>.card`. `primeCounting = primeCounting' = count Nat.Prime`."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Summary

Two proof gallery enrichments:

### chebyshev-pnt-bridge-oq-01-oq-02 (quality 32 → ~96)
- Added 5 annotations (was empty): proof comparison context, 4 calc-step annotations with mathContext
- Expanded `historicalContext` to 660+ chars: Legendre's formula (1808), Chebyshev's 1852 bounds
- Expanded sections from 1 to 4: preamble, step 1 (factorization identity), steps 2–3 (prime filter + Legendre), step 4 (cardinality = primeCounting)

### hurwitz-theorem-oq-03-oq-01 (quality 95 → 97)
- Expanded `historicalContext` (+188 chars): added Frobenius (1877) classification of associative case (ℝ, ℂ, ℍ only)
- Added 5th section `gelfand-mazur-lemma` (lines 55–68): documents `finrank_normed_field_eq_one_or_two` with explicit Mathlib lemma reference
- Added gallery data files and Lean source `HurwitzOnlyIf.lean` (117 lines, 1 sorry for non-commutative case)