### PR TITLE
Enrich chebyshev-pnt-bridge-oq-01-oq-02 + area-of-circle-oq-05-oq-02: annotations

### DIFF
--- a/src/data/proofs/area-of-circle-oq-05-oq-02/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-02/annotations.json
@@ -21,6 +21,27 @@
     ]
   },
   {
+    "id": "ann-oq02-imports",
+    "proofId": "area-of-circle-oq-05-oq-02",
+    "range": { "startLine": 30, "endLine": 41 },
+    "type": "technical",
+    "title": "Imports: Gaussian, Spectral Theorem, Fubini, and Parent Proof",
+    "content": "Seven imports assemble the required Mathlib infrastructure. Gaussian.GaussianIntegral provides Real.integral_gaussian (the base ∫ exp(-x²) = √π). Analysis.Matrix.Spectrum brings IsHermitian.eigenvectorUnitary and spectral_theorem. Analysis.Matrix.PosDef provides the PosDef class with eigenvalues_pos. MeasureTheory.Integral.Pi provides integral_fintype_prod_volume_eq_prod (Fubini for ℝⁿ product spaces). Lebesgue.Basic brings map_linearMap_volume_pi_eq_smul_volume_pi (the change-of-variables lemma). LinearAlgebra.Determinant adds det_eq_prod_eigenvalues. Finally, Proofs.AreaOfCircleOQ05 imports the parent scaled_gaussian result, demonstrating the gallery's modular proof reuse.",
+    "mathContext": "Import chain: parent $\\int_{\\mathbb{R}} e^{-bx^2}\\,dx = \\sqrt{\\pi/b}$ (AreaOfCircleOQ05) $\\to$ Fubini $\\to$ diagonal case $\\to$ spectral theorem $\\to$ general case.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "Mathlib.Analysis.Matrix.Spectrum",
+      "MeasureTheory.Integral.Pi",
+      "Mathlib.Analysis.Matrix.PosDef",
+      "integral_fintype_prod_volume_eq_prod"
+    ],
+    "prerequisites": [
+      "Mathlib library structure",
+      "Lean 4 import system",
+      "Gaussian integral (AreaOfCircleOQ05)"
+    ]
+  },
+  {
     "id": "ann-oq02-prod-sqrt",
     "proofId": "area-of-circle-oq-05-oq-02",
     "range": { "startLine": 48, "endLine": 63 },
@@ -37,6 +58,27 @@
     "prerequisites": [
       "Lean 4 induction on ℕ",
       "Real.sqrt properties (positivity, multiplicativity)"
+    ]
+  },
+  {
+    "id": "ann-oq02-diagonal-stmt",
+    "proofId": "area-of-circle-oq-05-oq-02",
+    "range": { "startLine": 65, "endLine": 75 },
+    "type": "concept",
+    "title": "diagonal_gaussian Statement: The Fully Proved Core",
+    "content": "The theorem `diagonal_gaussian` is the heart of the formalization and is proved with 0 sorries. It states: for any n and positive weights b : Fin n → ℝ, the integral of exp(-∑ bᵢxᵢ²) over ℝⁿ equals √(πⁿ/∏bᵢ). The hypothesis `hb : ∀ i, 0 < b i` ensures each weight is positive, needed both for the scalar Gaussian (which requires b > 0) and for the product in the denominator to be well-defined. This generalizes immediately from the diagonal case to the general positive-definite case via the spectral theorem.",
+    "mathContext": "$$\\int_{\\mathbb{R}^n} e^{-\\sum_{i} b_i x_i^2}\\,dx = \\sqrt{\\frac{\\pi^n}{\\prod_i b_i}}, \\quad b_i > 0$$",
+    "significance": "key",
+    "relatedConcepts": [
+      "multivariate Gaussian distribution",
+      "Fubini's theorem",
+      "diagonal positive-definite matrix",
+      "scalar Gaussian integral"
+    ],
+    "prerequisites": [
+      "Real.exp: exponential function",
+      "MeasureTheory.integral over Fin n → ℝ",
+      "scaled_gaussian from AreaOfCircleOQ05"
     ]
   },
   {
@@ -58,6 +100,27 @@
       "prod_sqrt_eq_sqrt_prod",
       "scaled_gaussian from AreaOfCircleOQ05",
       "MeasureTheory.Integral.Pi"
+    ]
+  },
+  {
+    "id": "ann-oq02-spectral-outline",
+    "proofId": "area-of-circle-oq-05-oq-02",
+    "range": { "startLine": 97, "endLine": 114 },
+    "type": "insight",
+    "title": "Spectral Decomposition Proof Outline and the Remaining Gap",
+    "content": "The docstring for `multivariate_gaussian_integral` describes a 5-step proof plan: (1) spectral theorem — A = U * diag(λ) * U* for eigenvector unitary U; (2) quadratic form rewrite xᵀAx = ∑ᵢ λᵢ(Uᵀx)ᵢ²; (3) orthogonal change of variables y = Uᵀx (measure-preserving since |det U| = 1); (4) apply diagonal_gaussian with b = eigenvalues; (5) use det A = ∏ λᵢ. Steps 1, 2, 4, 5 are mathematically clear and Mathlib has all the pieces. The single sorry lives entirely in step 3: connecting the orthogonal linear map to a MeasurableEquiv and invoking map_linearMap_volume_pi_eq_smul_volume_pi with the determinant condition.",
+    "mathContext": "Spectral theorem: $A = U^\\top \\mathrm{diag}(\\lambda_1,\\ldots,\\lambda_n) U$. Change of variables: $y = U^\\top x \\Rightarrow \\int_{{\\mathbb{R}^n}} f(x)\\,dx = \\int_{{\\mathbb{R}^n}} f(Uy)\\,dy$ (since $|\\det U| = 1$). Then $\\det A = \\prod_i \\lambda_i$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "spectral theorem for symmetric matrices",
+      "MeasurableEquiv from linear map",
+      "measure-preserving transformations",
+      "determinant and eigenvalues"
+    ],
+    "prerequisites": [
+      "IsHermitian.eigenvectorUnitary",
+      "Matrix.PosDef.eigenvalues_pos",
+      "map_linearMap_volume_pi_eq_smul_volume_pi"
     ]
   },
   {


### PR DESCRIPTION
Two enrichment passes in this PR.

## chebyshev-pnt-bridge-oq-01-oq-02

- **Annotations**: 0 → 7, covering all code sections with LaTeX `mathContext` fields
  - Context annotation (lines 1-32): historical significance of Chebyshev's 1852 proof
  - Technical annotation (lines 34-40): Mathlib import explanation
  - Concept annotation (lines 42-51): theorem statement with LaTeX
  - Key annotations for all 4 calc steps (factorization identity, prime filter, Legendre bound, counting)
- **historicalContext**: expanded from ~300 to ~650 chars with Chebyshev 1852 explicit constants, Legendre's formula, connection to Hadamard–de la Vallée Poussin 1896
- **keyInsights**: 4 → 6 entries
- **sections**: 1 → 7 entries covering full 79-line file
- **lineCount** corrected: 65 → 79

## area-of-circle-oq-05-oq-02

This entry already had good meta.json and 4 initial annotations. Added 3 annotations for uncovered sections:

- **ann-oq02-imports** (lines 30-41): Explains each Mathlib import and its mathematical role
- **ann-oq02-diagonal-stmt** (lines 65-75): Key annotation for the `diagonal_gaussian` theorem statement
- **ann-oq02-spectral-outline** (lines 97-114): Explains the 5-step spectral proof plan and identifies the sorry location precisely

Total annotations: 4 → 7.

---

Note: `pnpm build` fails due to a pre-existing issue in `erdos-476-oq-05/index.ts` referencing `Erdos476OQ05Problem.lean` which does not exist. This is unrelated to changes in this PR.