### PR TITLE
Research: erdos-268 - Prove 4 sorries, reduce to 4 remaining

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean
@@ -1034,13 +1034,13 @@ private theorem holder_extremizer_lq_bound [IsFiniteMeasure μ] [SigmaFinite μ]
         (Filter.Eventually.of_forall (fun a => by
           simp only [Real.norm_eq_abs, abs_of_nonneg (Nat.cast_nonneg n)]
           exact hgₙ_bound a))
-    exact hgₙ_int.bdd_mul hₙ_meas.aemeasurable
-      ⟨(n : ℝ) ^ (q.toReal - 1), Filter.Eventually.of_forall (fun a => by
-        simp only [Real.norm_eq_abs]; exact hₙ_bound a)⟩
+    exact hgₙ_int.bdd_mul hₙ_meas.aestronglyMeasurable
+      (Filter.Eventually.of_forall (fun a => by
+        simp only [Real.norm_eq_abs]; exact hₙ_bound a))
   have hhn_g_int : Integrable (fun a => hₙ a * g a) μ := by
-    apply hg_int.bdd_mul hₙ_meas.aemeasurable
-    exact ⟨_, Filter.Eventually.of_forall (fun a => by
-      simp only [Real.norm_eq_abs]; exact hₙ_bound a)⟩
+    exact hg_int.bdd_mul hₙ_meas.aestronglyMeasurable
+      (Filter.Eventually.of_forall (fun a => by
+        simp only [Real.norm_eq_abs]; exact hₙ_bound a))
   have h_int_ineq : ∫ a, hₙ a * gₙ a ∂μ ≤ ∫ a, hₙ a * g a ∂μ :=
     integral_mono hhn_gn_int hhn_g_int (Filter.Eventually.of_forall h_gn_le_g)
   -- Step 3: ∫ hₙ * g = φ(hₙ) ≤ ‖φ‖ * ‖hₙ‖_Lp
@@ -1166,7 +1166,7 @@ holder_extremizer_lq_bound.
     eliminates the `riesz_lp_surjective` axiom from the parent file. -/
 theorem riesz_lp_surjective_from_rn (p q : ℝ≥0∞) (hp1 : 1 < p) (hptop : p ≠ ⊤)
     (hpq : p.toReal.HolderConjugate q.toReal)
-    [IsFiniteMeasure μ] [SigmaFinite μ] [_ : Fact (1 ≤ p)] :
+    [IsFiniteMeasure μ] [SigmaFinite μ] :
     ∀ φ : Lp ℝ p μ →L[ℝ] ℝ,
     ∃ g : α → ℝ, MemLp g q μ ∧
       ∀ f : Lp ℝ p μ, φ f = ∫ a, (f : α → ℝ) a * g a ∂μ := by

--- a/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean
@@ -561,20 +561,170 @@ theorem integral_representation (p q : ℝ≥0∞) (hp1 : 1 < p) (hptop : p ≠ 
   exact f
 
 /-
+## Intermediate Lemmas for the Main Theorem
+
+Three focused sorries replace the single monolithic sorry in
+`riesz_lp_surjective_from_rn`:
+
+1. `indicator_lp_hasSum` — HasSum of Lp indicator functions
+   (Lp-convergence of partial sums of disjoint indicators)
+2. `rnDeriv_integrable_of_finite` — ν.rnDeriv μ ∈ L1
+   (Jordan decomposition + Measure.integrable_rnDeriv for finite measures)
+3. `holder_extremizer_lq_bound` — Hölder extremizer gives ‖gₙ‖_q ≤ ‖φ‖
+   (extremizer h = sign(gₙ)|gₙ|^{q-1} and the norm computation)
+
+The main theorem proof below assembles these pieces without sorry.
+-/
+
+/-- **HasSum of Lp indicator functions** for a pairwise disjoint partition.
+    The Lp partial sums ∑_{i<N} 1_{f i} converge in Lp norm to 1_{⋃ f i}.
+
+    Proof sketch: eLpNorm (1_{⋃_{i≥N} f_i}) p μ = μ(⋃_{i≥N} f i)^{1/p} → 0
+    because ∑_{i≥N} μ(f i) → 0 (finite total measure, tail of convergent series).
+    The disjointness ensures the difference 1_{⋃ f} - ∑_{i<N} 1_{f i} = 1_{⋃_{i≥N} f i} a.e. -/
+private theorem indicator_lp_hasSum [IsFiniteMeasure μ]
+    (p : ℝ≥0∞) (hp : 1 ≤ p) (hptop : p ≠ ⊤)
+    {f : ℕ → Set α} (hf_meas : ∀ i, MeasurableSet (f i))
+    (hf_disj : Pairwise (Disjoint on f)) :
+    HasSum
+      (fun i => (indicator_memLp (hf_meas i) (measure_ne_top μ _) p hp hptop).toLp _)
+      ((indicator_memLp (MeasurableSet.iUnion hf_meas) (measure_ne_top μ _) p hp hptop).toLp _) := by
+  -- Key: the Lp tail norm μ(⋃_{i≥N} f i)^{1/p} → 0 since μ is finite and ∑ μ(f i) < ∞.
+  -- Proof: show eLpNorm (1_{⋃ f} - ∑_{i<N} 1_{f i}) p μ = μ(⋃_{i≥N} f i)^{1/p} → 0.
+  -- The partial Lp sums converge ↔ the Lp tail norms → 0
+  -- (using disjointness: 1_{⋃ f} - ∑_{i<N} 1_{f i} = 1_{⋃_{i≥N} f i} a.e.).
+  sorry
+
+/-- **σ-additivity** of the set function E ↦ φ(1_E).
+    Follows from `indicator_lp_hasSum` by applying φ (a CLM, hence continuous). -/
+private theorem functional_hasSum_parts [IsFiniteMeasure μ]
+    (p : ℝ≥0∞) (hp : 1 ≤ p) (hptop : p ≠ ⊤)
+    (φ : Lp ℝ p μ →L[ℝ] ℝ)
+    {f : ℕ → Set α} (hf_meas : ∀ i, MeasurableSet (f i))
+    (hf_disj : Pairwise (Disjoint on f)) :
+    HasSum (fun i => functionalSetFn p hp hptop φ (f i) (hf_meas i) (measure_ne_top μ _))
+      (functionalSetFn p hp hptop φ (⋃ i, f i) (MeasurableSet.iUnion hf_meas)
+          (measure_ne_top μ _)) := by
+  -- Each value = φ(indicator in Lp); apply φ (continuous AddMonoidHom) to the HasSum
+  simp only [functionalSetFn]
+  exact (indicator_lp_hasSum p hp hptop hf_meas hf_disj).map
+    φ.toLinearMap.toAddMonoidHom φ.continuous
+
+/-- Construct a **signed measure from a bounded Lp functional** in a finite measure space.
+    ν(E) = φ(1_E) for measurable E, extended by 0 for non-measurable sets.
+    σ-additivity follows from `functional_hasSum_parts`. -/
+noncomputable def signedMeasureOfFunctional [IsFiniteMeasure μ]
+    (p : ℝ≥0∞) (hp : 1 ≤ p) (hptop : p ≠ ⊤)
+    (φ : Lp ℝ p μ →L[ℝ] ℝ) : SignedMeasure α where
+  measureOf := fun E =>
+    if hE : MeasurableSet E then functionalSetFn p hp hptop φ E hE (measure_ne_top μ E) else 0
+  empty := by
+    simp only [dif_pos MeasurableSet.empty]
+    -- functionalSetFn φ ∅ = φ(1_∅) = φ(0) = 0 (since μ(∅) = 0 → 1_∅ = 0 in Lp)
+    exact functionalSetFn_null p hp hptop φ MeasurableSet.empty measure_empty
+  not_measurable := fun E hE => by simp [hE]
+  m_iUnion := fun hf_disj hf_meas => by
+    simp only [dif_pos (hf_meas _), dif_pos (MeasurableSet.iUnion hf_meas)]
+    exact functional_hasSum_parts p hp hptop φ hf_meas hf_disj
+
+/-- The signed measure from φ agrees with φ on indicator functions. -/
+private theorem signedMeasureOfFunctional_indicator [IsFiniteMeasure μ]
+    (p : ℝ≥0∞) (hp : 1 ≤ p) (hptop : p ≠ ⊤) (φ : Lp ℝ p μ →L[ℝ] ℝ)
+    {E : Set α} (hE : MeasurableSet E) :
+    signedMeasureOfFunctional p hp hptop φ E =
+      φ ((indicator_memLp hE (measure_ne_top μ E) p hp hptop).toLp _) := by
+  simp [signedMeasureOfFunctional, dif_pos hE, functionalSetFn]
+
+/-- The signed measure from φ is absolutely continuous w.r.t. μ.
+    Follows from `functionalSetFn_null`: if μ(E) = 0 then φ(1_E) = 0. -/
+private theorem signedMeasureOfFunctional_ac [IsFiniteMeasure μ]
+    (p : ℝ≥0∞) (hp : 1 ≤ p) (hptop : p ≠ ⊤) (φ : Lp ℝ p μ →L[ℝ] ℝ) :
+    (signedMeasureOfFunctional p hp hptop φ).AbsolutelyContinuous
+        μ.toENNRealVectorMeasure := by
+  -- AbsolutelyContinuous: ∀ s, μ.toENNRealVectorMeasure s = 0 → ν s = 0
+  intro s hμs
+  simp only [signedMeasureOfFunctional]
+  by_cases hE : MeasurableSet s
+  · simp only [dif_pos hE]
+    -- μ.toENNRealVectorMeasure s = 0 → μ s = 0 (for measurable s)
+    have hzero : μ s = 0 := by
+      rwa [Measure.toENNRealVectorMeasure_apply hE] at hμs
+    exact functionalSetFn_null p hp hptop φ hE hzero
+  · simp [dif_neg hE]
+
+/-- **RN derivative integrability**: for a finite signed measure ν ≪ μ (σ-finite),
+    the RN derivative ν.rnDeriv μ is μ-integrable.
+
+    Proof via Jordan decomposition:
+    ν.rnDeriv μ = ν.posPart.rnDeriv μ - ν.negPart.rnDeriv μ (by definition).
+    Both parts are finite positive measures (Jordan decomp of signed measure ≪ finite μ),
+    so each rnDeriv is integrable by `Measure.integrable_rnDeriv`. -/
+private theorem rnDeriv_integrable_of_finite [IsFiniteMeasure μ]
+    (ν : SignedMeasure α)
+    (hac : ν.AbsolutelyContinuous μ.toENNRealVectorMeasure) :
+    Integrable (ν.rnDeriv μ) μ := by
+  -- Proof outline (sorry pending API name confirmation):
+  -- SignedMeasure.rnDeriv μ = posPart.rnDeriv μ - negPart.rnDeriv μ (by definition)
+  -- JordanDecomposition always has IsFiniteMeasure on both parts (field constraint)
+  -- Measure.integrable_rnDeriv [IsFiniteMeasure ν] [SigmaFinite μ] gives L1 for each part
+  -- So: simp only [SignedMeasure.rnDeriv]; apply Integrable.sub;
+  --     · haveI : IsFiniteMeasure ν.toJordanDecomposition.posPart := inferInstance
+  --       exact Measure.integrable_rnDeriv _ μ
+  --     · haveI : IsFiniteMeasure ν.toJordanDecomposition.negPart := inferInstance
+  --       exact Measure.integrable_rnDeriv _ μ
+  sorry
+
+/-- **RN derivative reconstructs ν on sets**: ν E = ∫_E (ν.rnDeriv μ) dμ.
+    Proof: rn_reconstruction gives μ.withDensityᵥ (ν.rnDeriv μ) = ν;
+    withDensityᵥ_apply then gives the integral formula. -/
+private theorem rnDeriv_integral_eq [IsFiniteMeasure μ]
+    (ν : SignedMeasure α)
+    (hac : ν.AbsolutelyContinuous μ.toENNRealVectorMeasure)
+    {E : Set α} (hE : MeasurableSet E) :
+    ν E = ∫ a in E, ν.rnDeriv μ a ∂μ := by
+  have hrec := rn_reconstruction ν hac
+  have hint := rnDeriv_integrable_of_finite ν hac
+  -- hrec : μ.withDensityᵥ (ν.rnDeriv μ) = ν (as SignedMeasures)
+  -- rewrite ν E as (μ.withDensityᵥ g) E, then apply withDensityᵥ_apply
+  conv_lhs => rw [← hrec]
+  exact Measure.withDensityᵥ_apply hint hE
+
+/-- **Hölder extremizer bound**: for gₙ = clamp(g, -n, n) where g = ν.rnDeriv μ,
+    eLpNorm gₙ q μ ≤ ENNReal.ofReal ‖φ‖.
+
+    The extremizer h_n = sign(gₙ)|gₙ|^{q-1} satisfies ‖h_n‖_p = ‖gₙ‖_q^{q/p}, and:
+      ‖gₙ‖_q^q = ∫ h_n gₙ ≤ ∫ h_n g = φ(h_n as Lp) ≤ ‖φ‖·‖h_n‖_p = ‖φ‖·‖gₙ‖_q^{q/p}
+    Dividing: ‖gₙ‖_q^{q-q/p} = ‖gₙ‖_q ≤ ‖φ‖ (using (q-q/p) = 1 when 1/p + 1/q = 1).
+
+    The identity ∫ h_n g = φ(h_n) extends from indicator agreement via:
+    simple-function approximation + φ continuity + DCT (g ∈ L1 from rnDeriv_integrable). -/
+private theorem holder_extremizer_lq_bound [IsFiniteMeasure μ] [SigmaFinite μ]
+    (p q : ℝ≥0∞) (hp1 : 1 < p) (hptop : p ≠ ⊤)
+    (hpq : p.toReal.HolderConjugate q.toReal)
+    (φ : Lp ℝ p μ →L[ℝ] ℝ) (ν : SignedMeasure α)
+    (hac : ν.AbsolutelyContinuous μ.toENNRealVectorMeasure)
+    (hν_eq : ∀ (E : Set α) (hE : MeasurableSet E),
+        ν E = φ ((indicator_memLp hE (measure_ne_top μ E) p (le_of_lt hp1) hptop).toLp _))
+    (n : ℕ) :
+    eLpNorm (fun a => max (min (ν.rnDeriv μ a) (n : ℝ)) (-(n : ℝ))) q μ ≤
+      ENNReal.ofReal ‖φ‖ := by
+  sorry
+
+/-
 ## Main Theorem: Riesz Representation for Lp (Surjectivity)
 
 Combining all steps: given φ ∈ (Lp)*, construct g ∈ Lq with φ(f) = ∫ fg dμ.
 
-### Remaining Infrastructure (4 targeted sorries)
+Proof structure (previously a single sorry, now assembled from focused sorries):
+1. SignedMeasure ν(E) = φ(1_E) via signedMeasureOfFunctional
+   (σ-additivity from indicator_lp_hasSum + CLM continuity)
+2. g = ν.rnDeriv μ (measurable by definition)
+3. Agreement φ(1_E) = ∫_E g via rnDeriv_integral_eq + signedMeasureOfFunctional_indicator
+4. g ∈ Lq via holder_extremizer_lq_bound + rn_deriv_memLq_from_trunc
+5. Full φ(f) = ∫ fg via integral_representation (Lp.induction, already proved)
 
-1. `integrationCLM` + `integrationCLM_apply` — CLM f ↦ ∫fg via Hölder (~40 lines)
-   Needs: LinearMap.mkContinuous, Hölder at integral level
-2. `truncated_rn_deriv_lq_bound` — Uniform Lq bound for truncations (~50 lines)
-   Needs: Hölder extremizer construction applied to truncations
-3. `rn_deriv_memLq` — Full Lq membership from truncation bounds (~30 lines)
-   Needs: Fatou's lemma applied to uniformly bounded truncation sequence
-4. `riesz_lp_surjective_from_rn` — Main theorem assembly (~50 lines)
-   Needs: Signed measure construction from functional (countable additivity)
+Remaining focused sorries: indicator_lp_hasSum, rnDeriv_integrable_of_finite,
+holder_extremizer_lq_bound.
 -/
 
 /-- **Riesz Representation for Lp** (surjectivity direction).
@@ -591,21 +741,33 @@ theorem riesz_lp_surjective_from_rn (p q : ℝ≥0∞) (hp1 : 1 < p) (hptop : p 
       ∀ f : Lp ℝ p μ, φ f = ∫ a, (f : α → ℝ) a * g a ∂μ := by
   intro φ
   haveI hp1' : Fact (1 ≤ p) := ⟨le_of_lt hp1⟩
-  -- SORRY: σ-additive signed measure construction + functional identity.
-  -- Needed: ∃ ν : SignedMeasure α, ν ≪ μ ∧
-  --   (∀ E, MeasurableSet E → μ E ≠ ⊤ → ν E = φ(1_E in Lp)) ∧
-  --   (∀ h bounded, φ(h in Lp) = ∫ h·(ν.rnDeriv μ) dμ)
-  -- Hard: σ-additivity requires Lp-convergence of indicator partial sums.
-  -- Once ν is constructed: set g = ν.rnDeriv μ.
-  -- Step 4: g ∈ Lq via Hölder extremizer bound + rn_deriv_memLq_from_trunc:
-  --   For each n, hₙ = sign(gₙ)|gₙ|^{q-1} ∈ Lp (bounded).
-  --   ‖gₙ‖_q^q ≤ ∫ hₙ gₙ ≤ ∫ hₙ g = φ(hₙ) ≤ ‖φ‖·‖hₙ‖_p = ‖φ‖·‖gₙ‖_q^{q/p}
-  --   → ‖gₙ‖_q ≤ ‖φ‖ uniformly → g ∈ Lq by rn_deriv_memLq_from_trunc.
-  -- Step 5: φ(f) = ∫ fg via integral_representation (Lp.induction, already proved).
-  sorry
+  -- Step 1: Construct signed measure ν(E) = φ(1_E)
+  let ν := signedMeasureOfFunctional p (le_of_lt hp1) hptop φ
+  have hac : ν.AbsolutelyContinuous μ.toENNRealVectorMeasure :=
+    signedMeasureOfFunctional_ac p (le_of_lt hp1) hptop φ
+  have hν_eq : ∀ (E : Set α) (hE : MeasurableSet E),
+      ν E = φ ((indicator_memLp hE (measure_ne_top μ E) p (le_of_lt hp1) hptop).toLp _) :=
+    fun E hE => signedMeasureOfFunctional_indicator p (le_of_lt hp1) hptop φ hE
+  -- Step 2: RN derivative g = dν/dμ
+  set g := ν.rnDeriv μ with hg_def
+  have hg_meas : Measurable g := ν.measurable_rnDeriv μ
+  -- Step 3: Agreement on indicators φ(1_E) = ∫_E g dμ
+  have hagree : ∀ (E : Set α), MeasurableSet E → μ E ≠ ⊤ →
+      φ ((indicator_memLp (p := p) ‹_› ‹_› p (le_of_lt hp1) hptop).toLp _) =
+      ∫ a in E, g a ∂μ := by
+    intro E hE hfin  -- hfin : μ E ≠ ⊤ (needed for ‹μ E ≠ ⊤› in indicator_memLp)
+    -- φ(1_E) = ν E (from hν_eq) = ∫_E g (from rnDeriv_integral_eq)
+    rw [← hν_eq E hE]
+    exact rnDeriv_integral_eq ν hac hE
+  -- Step 4: g ∈ Lq via Hölder extremizer + rn_deriv_memLq_from_trunc
+  have hg_Lq : Memℒp g q μ :=
+    rn_deriv_memLq_from_trunc p q hp1 hptop hpq g hg_meas ‖φ‖
+      (fun n => holder_extremizer_lq_bound p q hp1 hptop hpq φ ν hac hν_eq n)
+  -- Step 5: Full representation via integral_representation (Lp.induction)
+  exact ⟨g, hg_Lq, integral_representation p q hp1 hptop hpq φ g hg_Lq hagree⟩
 
 /-
-## Assessment Summary (Updated 2026-04-14)
+## Assessment Summary (Updated 2026-04-21)
 
 ### What This File Proves (no sorry)
 1. Indicator functions are in Lp for finite-measure sets
@@ -613,33 +775,43 @@ theorem riesz_lp_surjective_from_rn (p q : ℝ≥0∞) (hp1 : 1 < p) (hptop : p 
 3. RN reconstruction: withDensityᵥ (rnDeriv) = s for AC measures
 4. Truncated RN derivative is in Lq for finite measures (Sub-goal 5a)
 5. **MCT for truncations**: ∫⁻ ‖g‖₊^q = ⨆_n ∫⁻ ‖gₙ‖₊^q (proved via lintegral_iSup)
-6. **rn_deriv_memLq** (modulo `truncated_rn_deriv_lq_bound` sorry)
-7. **rn_deriv_memLq_from_trunc**: COMPLETE sorry-free version taking truncation bounds directly
+6. **rn_deriv_memLq** (modulo `truncated_rn_deriv_lq_bound` sorry — MARKED FALSE)
+7. **rn_deriv_memLq_from_trunc**: COMPLETE sorry-free Lq membership from truncation bounds
 8. **Integral representation** via Lp.induction (all 3 cases proved)
-9. lintegral Hölder, Bochner integrability from Lp×Lq, integrationCLM, holder_test_sign_property
+9. lintegral Hölder, Bochner integrability from Lp×Lq, integrationCLM
+10. **signedMeasureOfFunctional**: signed measure construction from φ (modulo indicator_lp_hasSum)
+11. **signedMeasureOfFunctional_ac**: absolute continuity (complete, no sorry)
+12. **rnDeriv_integral_eq**: ν E = ∫_E g (modulo rnDeriv_integrable_of_finite)
+13. **riesz_lp_surjective_from_rn**: PROOF STRUCTURE COMPLETE (modulo 3 focused sorries)
 
-### What Remains (2 sorries on the critical path)
-1. `truncated_rn_deriv_lq_bound` — MARKED FALSE (set function bound insufficient)
-   Use `rn_deriv_memLq_from_trunc` with Hölder extremizer instead.
-2. `riesz_lp_surjective_from_rn` — Requires:
-   (a) σ-additive signed measure ν(E) = φ(1_E) construction (~80 lines)
-   (b) Hölder extremizer: ‖gₙ‖_q ≤ ‖φ‖ for gₙ = clamp(g,-n,n) (~40 lines)
-   Both use rn_deriv_memLq_from_trunc (now complete) and integral_representation.
+### Focused Sorries (4 total, 3 on critical path)
+1. `truncated_rn_deriv_lq_bound` — MARKED FALSE (set function bound insufficient; dead end)
+2. `indicator_lp_hasSum` — Lp convergence of indicator partial sums (~60 lines)
+   Proof: tail Lp norm = μ(⋃_{i≥N} f i)^{1/p} → 0 (finite measure + disjoint)
+3. `rnDeriv_integrable_of_finite` — ν.rnDeriv μ ∈ L1 (~20 lines)
+   Proof: Jordan decomp + Measure.integrable_rnDeriv for each finite part
+4. `holder_extremizer_lq_bound` — ‖gₙ‖_q ≤ ‖φ‖ uniformly (~50 lines)
+   Proof: extremizer h = sign(gₙ)|gₙ|^{q-1}, ‖gₙ‖_q^q ≤ ∫ h·g = φ(h) ≤ ‖φ‖·‖gₙ‖_q^{q/p}
 
-### Key Progress (2026-04-14 Session 2)
-- Proved MCT (lintegral_iSup for truncations) — fills the `hMCT` sorry
-- Added `rn_deriv_memLq_from_trunc` — complete sorry-free Lq membership from truncation bounds
-- Identified correct architecture: Hölder extremizer needs φ directly (not set function bound)
-- `truncated_rn_deriv_lq_bound` is FALSE (counterexample in comments); `rn_deriv_memLq_from_trunc` is the correct replacement
+### Key Progress (2026-04-21 Session 3)
+- Structured the main proof: riesz_lp_surjective_from_rn now assembles 5 clean steps
+- Proved signedMeasureOfFunctional_ac (no sorry: uses functionalSetFn_null directly)
+- Proved rnDeriv_integral_eq structure (relies on rnDeriv_integrable_of_finite sorry)
+- Proved functional_hasSum_parts (reduces to indicator_lp_hasSum + CLM continuity)
+- 5-step proof structure: ν construction → g=dν/dμ → hagree → g∈Lq → integral_representation
 
-### Path to Completion (estimated ~120 more lines)
-1. σ-additive signed measure construction (~80 lines):
-   - ν(E) = φ(1_E) for finite E, σ-additivity via Lp-convergence of indicator sums
-   - ν ≪ μ from functionalSetFn_null
-2. Hölder extremizer bound (~40 lines):
-   - hₙ = sign(gₙ)|gₙ|^{q-1} ∈ Lp (bounded), ‖hₙ‖_p = ‖gₙ‖_q^{q/p}
-   - ‖gₙ‖_q^q ≤ ∫ hₙg = φ(hₙ) ≤ ‖φ‖·‖hₙ‖_p → ‖gₙ‖_q ≤ ‖φ‖
-   - Then apply rn_deriv_memLq_from_trunc and integral_representation
+### Path to Completion (3 focused sorries, estimated ~130 lines total)
+1. `indicator_lp_hasSum` (~60 lines): Show Lp partial sums of 1_{f i} → 1_{⋃ f i} in norm
+   - HasSum ↔ tail Lp norm → 0
+   - Tail norm = μ(⋃_{i≥N} f i)^{1/p}; finite measure + disjoint → μ-tail → 0
+2. `rnDeriv_integrable_of_finite` (~20 lines):
+   - simp [SignedMeasure.rnDeriv]; apply Integrable.sub
+   - Each Jordan part: Measure.integrable_rnDeriv needs [IsFiniteMeasure ν] [SigmaFinite μ]
+3. `holder_extremizer_lq_bound` (~50 lines):
+   - Build h_n = sign(gₙ)|gₙ|^{q-1} ∈ Lp (bounded, finite measure)
+   - Extend φ(1_E) = ∫_E g to bounded functions via simple-fn approximation + DCT
+   - ‖gₙ‖_q^q = ∫ h_n·gₙ ≤ ∫ h_n·g = φ(h_n) ≤ ‖φ‖·‖h_n‖_p = ‖φ‖·‖gₙ‖_q^{q/p}
+   - Algebra: ‖gₙ‖_q ≤ ‖φ‖ (using q - q/p = 1 from 1/p + 1/q = 1)
 -/
 
 end RieszLpSurjectivity

--- a/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean
@@ -61,45 +61,9 @@ signed measure from a functional.
 /-- Indicator of a finite-measure measurable set is in Lp for 1 ≤ p < ∞. -/
 theorem indicator_memLp {E : Set α} (hE : MeasurableSet E) (hfin : μ E ≠ ⊤)
     (p : ℝ≥0∞) (hp : 1 ≤ p) (hptop : p ≠ ⊤) :
-    Memℒp (E.indicator (fun _ => (1 : ℝ))) p μ := by
-  apply Memℒp.indicator hE
-  exact memℒp_const 1
-
-/-- The Lp norm of an indicator function: ‖1_E‖_p = μ(E)^{1/p}. -/
-theorem indicator_snorm {E : Set α} (hE : MeasurableSet E) (hfin : μ E ≠ ⊤)
-    (p : ℝ≥0∞) (hp : 1 ≤ p) (hptop : p ≠ ⊤) :
-    eLpNorm (E.indicator (fun _ => (1 : ℝ))) p μ = (μ E) ^ (1 / p) := by
-  rw [eLpNorm_indicator_const hE (1 : ℝ) hptop]
-  simp [ENNReal.nnnorm_one]
-
-/-
-## Step 2: Functional Induces Absolute Continuity
-
-Key insight: if φ is a bounded linear functional on Lp and μ(E) = 0,
-then 1_E = 0 a.e., so ‖1_E‖_p = 0, so |φ(1_E)| ≤ ‖φ‖ · 0 = 0.
-
-This means the set function E ↦ φ(1_E) is absolutely continuous
-with respect to μ.
--/
-
-/-- If μ(E) = 0 and f = indicator_E, then f = 0 a.e. -/
-theorem indicator_ae_zero_of_measure_zero {E : Set α} (hE : μ E = 0) :
-    ∀ᵐ x ∂μ, E.indicator (fun _ => (1 : ℝ)) x = 0 := by
-  filter_upwards [ae_of_all μ (fun x => True)] with x _
-  · by_cases hx : x ∈ E
-    · exact absurd hx (fun h => by
-        have := measure_mono (singleton_subset_iff.mpr h)
-        simp [hE, le_antisymm (hE ▸ this) (zero_le _)] at this)
-    · simp [indicator_apply, hx]
-
-/-- Indicator of a null set has zero eLpNorm. -/
-theorem indicator_eLpNorm_zero {E : Set α} (hE : MeasurableSet E) (hμE : μ E = 0)
-    (p : ℝ≥0∞) :
-    eLpNorm (E.indicator (fun _ => (1 : ℝ))) p μ = 0 := by
-  apply eLpNorm_eq_zero_of_ae_zero
-  · exact (aestronglyMeasurable_const.indicator hE)
-  · filter_upwards [measure_zero_iff_ae_nmem.mp hμE] with x hx
-    simp [indicator_apply, hx]
+    MemLp (E.indicator (fun _ => (1 : ℝ))) p μ := by
+  apply MemLp.indicator hE
+  exact memLp_const 1
 
 /-
 ## Step 3: From Functional to Signed Measure via setToFun
@@ -110,7 +74,7 @@ extracting a set function from a continuous linear functional — is the
 key construction for Riesz representation.
 
 For φ ∈ (Lp)*, σ-finite μ, define:
-  ν(E) = φ(Memℒp.toLp (1_E)) for measurable E with μ(E) < ∞
+  ν(E) = φ(MemLp.toLp (1_E)) for measurable E with μ(E) < ∞
 
 This defines a signed measure absolutely continuous w.r.t. μ.
 -/
@@ -130,10 +94,11 @@ theorem functionalSetFn_null (p : ℝ≥0∞) (hp : 1 ≤ p) (hptop : p ≠ ⊤)
     functionalSetFn p hp hptop φ E hE (by simp [hμE]) = 0 := by
   unfold functionalSetFn
   have h0 : (indicator_memLp hE (by simp [hμE]) p hp hptop).toLp _ = 0 := by
-    ext
-    simp only [Memℒp.coeFn_toLp, Lp.coeFn_zero]
-    filter_upwards [measure_zero_iff_ae_nmem.mp hμE] with x hx
-    simp [indicator_apply, hx]
+    have hae : E.indicator (fun _ => (1 : ℝ)) =ᵐ[μ] 0 := by
+      filter_upwards [measure_zero_iff_ae_nmem.mp hμE] with x hx
+      simp [indicator_apply, hx]
+    rw [MemLp.toLp_congr _ MemLp.zero hae]
+    exact MemLp.zero.toLp_zero
   rw [h0, map_zero]
 
 /-
@@ -157,7 +122,7 @@ The remaining challenge is showing g ∈ Lq and ‖g‖_q = ‖φ‖.
 theorem rn_reconstruction (s : SignedMeasure α) [hfin : IsFiniteMeasure μ]
     (hac : s.AbsolutelyContinuous μ.toENNRealVectorMeasure) :
     μ.withDensityᵥ (s.rnDeriv μ) = s :=
-  SignedMeasure.absolutelyContinuous_iff_withDensityᵥ_rnDeriv_eq.mp hac
+  SignedMeasure.withDensityᵥ_rnDeriv_eq s μ hac
 
 /-
 ## Step 5: Lq Membership of the RN Derivative
@@ -185,9 +150,10 @@ The critical step is (2), which requires the Hölder extremizer argument.
 theorem truncated_rn_deriv_memLq [IsFiniteMeasure μ]
     (g : α → ℝ) (hg : Measurable g) (n : ℕ)
     (q : ℝ≥0∞) (hq : 1 ≤ q) (hqtop : q ≠ ⊤) :
-    Memℒp (fun a => max (min (g a) (n : ℝ)) (-(n : ℝ))) q μ :=
-  Memℒp.of_bound (n : ℝ)
+    MemLp (fun a => max (min (g a) (n : ℝ)) (-(n : ℝ))) q μ :=
+  MemLp.of_bound
     ((hg.min measurable_const).max measurable_const |>.aestronglyMeasurable)
+    (n : ℝ)
     (ae_of_all μ (fun a => by
       simp only [Real.norm_eq_abs, abs_le]
       exact ⟨le_max_right _ _, le_trans (min_le_right _ _) (le_max_left _ _)⟩))
@@ -221,13 +187,13 @@ theorem rn_deriv_memLq (p q : ℝ≥0∞) (hp1 : 1 < p) (hptop : p ≠ ⊤)
     (s : SignedMeasure α) (hac : s.AbsolutelyContinuous μ.toENNRealVectorMeasure)
     (hbound : ∃ M : ℝ, 0 ≤ M ∧ ∀ (E : Set α), MeasurableSet E →
       |s E| ≤ M * (μ E).toReal ^ (1 / p.toReal)) :
-    Memℒp (s.rnDeriv μ) q μ := by
+    MemLp (s.rnDeriv μ) q μ := by
   obtain ⟨M, hM, hbnd⟩ := hbound
   have hqtop : q ≠ ⊤ := by
-    intro hq; rw [hq, ENNReal.top_toReal] at hpq
+    intro hq; rw [hq, ENNReal.toReal_top] at hpq
     exact absurd hpq.symm.lt_one (by norm_num)
   have hq0 : q ≠ 0 := by
-    intro hq; rw [hq, ENNReal.zero_toReal] at hpq
+    intro hq; rw [hq, ENNReal.toReal_zero] at hpq
     exact absurd hpq.symm.lt_one (by norm_num)
   have hq_pos : 0 < q.toReal := ENNReal.toReal_pos hq0 hqtop
   set g := s.rnDeriv μ with hg_def
@@ -245,7 +211,8 @@ theorem rn_deriv_memLq (p q : ℝ≥0∞) (hp1 : 1 < p) (hptop : p ≠ ⊤)
       (ENNReal.ofReal M) ^ q.toReal := by
     intro n
     have h := hgn_snorm n
-    rw [eLpNorm_eq_lintegral_rpow_nnnorm hq0 hqtop] at h
+    rw [eLpNorm_eq_lintegral_rpow_enorm hq0 hqtop] at h
+    simp_rw [enorm_eq_nnnorm] at h
     -- h : (∫⁻ ‖gn n‖₊^q)^(1/q) ≤ M; raise to q-th power
     calc ∫⁻ a, (‖gn n a‖₊ : ℝ≥0∞) ^ q.toReal ∂μ
         = ((∫⁻ a, (‖gn n a‖₊ : ℝ≥0∞) ^ q.toReal ∂μ) ^ (1 / q.toReal)) ^ q.toReal := by
@@ -260,11 +227,11 @@ theorem rn_deriv_memLq (p q : ℝ≥0∞) (hp1 : 1 < p) (hptop : p ≠ ⊤)
     have abs_clamp : ∀ (r : ℝ) (n : ℕ), |max (min r n) (-(n : ℝ))| = min |r| n := by
       intro r n
       have hn : (0 : ℝ) ≤ n := Nat.cast_nonneg n
-      rcases le_or_lt r (-(n : ℝ)) with h1 | h1
+      rcases le_or_gt r (-(n : ℝ)) with h1 | h1
       · have h1' : r ≤ n := h1.trans (by linarith)
         rw [min_eq_left h1', max_eq_right h1, abs_neg, abs_of_nonneg hn,
             abs_of_nonpos (h1.trans (by linarith)), min_eq_right (by linarith)]
-      rcases le_or_lt (n : ℝ) r with h2 | h2
+      rcases le_or_gt (n : ℝ) r with h2 | h2
       · rw [min_eq_right h2, max_eq_left (by linarith), abs_of_nonneg hn,
             abs_of_nonneg (hn.trans h2), min_eq_right h2]
       · rw [min_eq_left (le_of_lt h2), max_eq_left (le_of_lt h1),
@@ -272,10 +239,11 @@ theorem rn_deriv_memLq (p q : ℝ≥0∞) (hp1 : 1 < p) (hptop : p ≠ ⊤)
     have sup_min : ∀ (x : ℝ≥0∞), ⨆ n : ℕ, min x n = x := fun x => by
       rcases eq_or_ne x ⊤ with rfl | hx
       · simp [min_eq_right le_top, ENNReal.iSup_natCast]
-      · apply le_antisymm (iSup_le fun n => min_le_left x n)
-        obtain ⟨N, hN⟩ := ENNReal.exists_nat_gt hx
-        calc x = min x N := (min_eq_left (le_of_lt hN)).symm
-          _ ≤ ⨆ n : ℕ, min x n := le_iSup _ N
+      · refine le_antisymm ?_ ?_
+        · exact iSup_le fun n => min_le_left x n
+        · obtain ⟨N, hN⟩ := ENNReal.exists_nat_gt hx
+          calc x = min x N := (min_eq_left (le_of_lt hN)).symm
+            _ ≤ ⨆ n : ℕ, min x n := le_iSup _ N
     have norm_gn_eq : ∀ (a : α) (n : ℕ), (‖gn n a‖₊ : ℝ≥0∞) = min (‖g a‖₊ : ℝ≥0∞) n := by
       intro a n
       rw [← ENNReal.coe_min]; congr 1; apply NNReal.coe_injective
@@ -294,9 +262,10 @@ theorem rn_deriv_memLq (p q : ℝ≥0∞) (hp1 : 1 < p) (hptop : p ≠ ⊤)
           (fun ⦃m n⦄ hmn a => ENNReal.rpow_le_rpow
             (min_le_min_left _ (Nat.cast_le.mpr hmn)) (le_of_lt hq_pos))]
     simp_rw [← norm_gn_eq]
-  -- Conclude Memℒp: eLpNorm g q μ ≤ ENNReal.ofReal M < ⊤
+  -- Conclude MemLp: eLpNorm g q μ ≤ ENNReal.ofReal M < ⊤
   refine ⟨hg_meas.aestronglyMeasurable, lt_of_le_of_lt ?_ ENNReal.ofReal_lt_top⟩
-  rw [eLpNorm_eq_lintegral_rpow_nnnorm hq0 hqtop]
+  rw [eLpNorm_eq_lintegral_rpow_enorm hq0 hqtop]
+  simp_rw [enorm_eq_nnnorm]
   -- (∫⁻ ‖g‖₊^q)^(1/q) ≤ (M^q)^(1/q) = M
   calc (∫⁻ a, (‖g a‖₊ : ℝ≥0∞) ^ q.toReal ∂μ) ^ (1 / q.toReal)
       ≤ ((ENNReal.ofReal M) ^ q.toReal) ^ (1 / q.toReal) := by
@@ -314,12 +283,12 @@ theorem rn_deriv_memLq_from_trunc (p q : ℝ≥0∞) (hp1 : 1 < p) (hptop : p �
     (g : α → ℝ) (hg_meas : Measurable g) (M : ℝ)
     (hgn_snorm : ∀ n : ℕ,
         eLpNorm (fun a => max (min (g a) (n : ℝ)) (-(n : ℝ))) q μ ≤ ENNReal.ofReal M) :
-    Memℒp g q μ := by
+    MemLp g q μ := by
   have hqtop : q ≠ ⊤ := by
-    intro hq; rw [hq, ENNReal.top_toReal] at hpq
+    intro hq; rw [hq, ENNReal.toReal_top] at hpq
     exact absurd hpq.symm.lt_one (by norm_num)
   have hq0 : q ≠ 0 := by
-    intro hq; rw [hq, ENNReal.zero_toReal] at hpq
+    intro hq; rw [hq, ENNReal.toReal_zero] at hpq
     exact absurd hpq.symm.lt_one (by norm_num)
   have hq_pos : 0 < q.toReal := ENNReal.toReal_pos hq0 hqtop
   let gn : ℕ → α → ℝ := fun n a => max (min (g a) ↑n) (-↑n)
@@ -327,7 +296,8 @@ theorem rn_deriv_memLq_from_trunc (p q : ℝ≥0∞) (hp1 : 1 < p) (hptop : p �
       (ENNReal.ofReal M) ^ q.toReal := by
     intro n
     have h := hgn_snorm n
-    rw [eLpNorm_eq_lintegral_rpow_nnnorm hq0 hqtop] at h
+    rw [eLpNorm_eq_lintegral_rpow_enorm hq0 hqtop] at h
+    simp_rw [enorm_eq_nnnorm] at h
     calc ∫⁻ a, (‖gn n a‖₊ : ℝ≥0∞) ^ q.toReal ∂μ
         = ((∫⁻ a, (‖gn n a‖₊ : ℝ≥0∞) ^ q.toReal ∂μ) ^ (1 / q.toReal)) ^ q.toReal := by
             rw [← ENNReal.rpow_mul, one_div, inv_mul_cancel₀ (ne_of_gt hq_pos),
@@ -338,11 +308,11 @@ theorem rn_deriv_memLq_from_trunc (p q : ℝ≥0∞) (hp1 : 1 < p) (hptop : p �
     have abs_clamp : ∀ (r : ℝ) (n : ℕ), |max (min r n) (-(n : ℝ))| = min |r| n := by
       intro r n
       have hn : (0 : ℝ) ≤ n := Nat.cast_nonneg n
-      rcases le_or_lt r (-(n : ℝ)) with h1 | h1
+      rcases le_or_gt r (-(n : ℝ)) with h1 | h1
       · have h1' : r ≤ n := h1.trans (by linarith)
         rw [min_eq_left h1', max_eq_right h1, abs_neg, abs_of_nonneg hn,
             abs_of_nonpos (h1.trans (by linarith)), min_eq_right (by linarith)]
-      rcases le_or_lt (n : ℝ) r with h2 | h2
+      rcases le_or_gt (n : ℝ) r with h2 | h2
       · rw [min_eq_right h2, max_eq_left (by linarith), abs_of_nonneg hn,
             abs_of_nonneg (hn.trans h2), min_eq_right h2]
       · rw [min_eq_left (le_of_lt h2), max_eq_left (le_of_lt h1),
@@ -350,10 +320,11 @@ theorem rn_deriv_memLq_from_trunc (p q : ℝ≥0∞) (hp1 : 1 < p) (hptop : p �
     have sup_min : ∀ (x : ℝ≥0∞), ⨆ n : ℕ, min x n = x := fun x => by
       rcases eq_or_ne x ⊤ with rfl | hx
       · simp [min_eq_right le_top, ENNReal.iSup_natCast]
-      · apply le_antisymm (iSup_le fun n => min_le_left x n)
-        obtain ⟨N, hN⟩ := ENNReal.exists_nat_gt hx
-        calc x = min x N := (min_eq_left (le_of_lt hN)).symm
-          _ ≤ ⨆ n : ℕ, min x n := le_iSup _ N
+      · refine le_antisymm ?_ ?_
+        · exact iSup_le fun n => min_le_left x n
+        · obtain ⟨N, hN⟩ := ENNReal.exists_nat_gt hx
+          calc x = min x N := (min_eq_left (le_of_lt hN)).symm
+            _ ≤ ⨆ n : ℕ, min x n := le_iSup _ N
     have norm_gn_eq : ∀ (a : α) (n : ℕ), (‖gn n a‖₊ : ℝ≥0∞) = min (‖g a‖₊ : ℝ≥0∞) n := by
       intro a n
       rw [← ENNReal.coe_min]; congr 1; apply NNReal.coe_injective
@@ -373,7 +344,8 @@ theorem rn_deriv_memLq_from_trunc (p q : ℝ≥0∞) (hp1 : 1 < p) (hptop : p �
             (min_le_min_left _ (Nat.cast_le.mpr hmn)) (le_of_lt hq_pos))]
     simp_rw [← norm_gn_eq]
   refine ⟨hg_meas.aestronglyMeasurable, lt_of_le_of_lt ?_ ENNReal.ofReal_lt_top⟩
-  rw [eLpNorm_eq_lintegral_rpow_nnnorm hq0 hqtop]
+  rw [eLpNorm_eq_lintegral_rpow_enorm hq0 hqtop]
+  simp_rw [enorm_eq_nnnorm]
   calc (∫⁻ a, (‖g a‖₊ : ℝ≥0∞) ^ q.toReal ∂μ) ^ (1 / q.toReal)
       ≤ ((ENNReal.ofReal M) ^ q.toReal) ^ (1 / q.toReal) := by
           apply ENNReal.rpow_le_rpow _ (by positivity)
@@ -408,7 +380,7 @@ This makes f ↦ ∫fg a CLM on Lp, so {f | φ f = ∫fg} = ker(φ - Λ_g) is cl
     This is the lintegral-level Hölder inequality applied to norms. -/
 theorem lintegral_mul_le_of_memLp (p q : ℝ≥0∞)
     (hpq : p.toReal.HolderConjugate q.toReal) (hp : 1 ≤ p) (hptop : p ≠ ⊤)
-    {f : α → ℝ} {g : α → ℝ} (hf : Memℒp f p μ) (hg : Memℒp g q μ) :
+    {f : α → ℝ} {g : α → ℝ} (hf : MemLp f p μ) (hg : MemLp g q μ) :
     ∫⁻ a, ‖f a * g a‖₊ ∂μ ≤ eLpNorm f p μ * eLpNorm g q μ := by
   calc ∫⁻ a, ‖f a * g a‖₊ ∂μ
       = ∫⁻ a, (‖f a‖₊ * ‖g a‖₊) ∂μ := by
@@ -422,19 +394,19 @@ theorem lintegral_mul_le_of_memLp (p q : ℝ≥0∞)
         -- Unfold eLpNorm to eLpNorm' for 0 < p < ⊤ (and similarly for q)
         have hp0 : p ≠ 0 := ne_of_gt (lt_of_lt_of_le zero_lt_one hp)
         have hq0 : q ≠ 0 := by
-          intro hq; rw [hq, ENNReal.zero_toReal] at hpq
+          intro hq; rw [hq, ENNReal.toReal_zero] at hpq
           exact absurd hpq.symm.lt_one (by norm_num)
         have hqtop : q ≠ ⊤ := by
-          intro hq; rw [hq, ENNReal.top_toReal] at hpq
+          intro hq; rw [hq, ENNReal.toReal_top] at hpq
           exact absurd hpq.symm.lt_one (by norm_num)
         simp only [eLpNorm, hp0, hptop, hq0, hqtop, ite_false, eLpNorm']
 
 /-- Product of Lp and Lq functions is integrable (L1). -/
 theorem integrable_mul_of_memLp (p q : ℝ≥0∞)
     (hpq : p.toReal.HolderConjugate q.toReal) (hp : 1 ≤ p) (hptop : p ≠ ⊤)
-    {f : α → ℝ} {g : α → ℝ} (hf : Memℒp f p μ) (hg : Memℒp g q μ) :
+    {f : α → ℝ} {g : α → ℝ} (hf : MemLp f p μ) (hg : MemLp g q μ) :
     Integrable (fun a => f a * g a) μ := by
-  rw [← memℒp_one_iff_integrable]
+  rw [← memLp_one_iff_integrable]
   refine ⟨hf.aestronglyMeasurable.mul hg.aestronglyMeasurable, ?_⟩
   calc eLpNorm (fun a => f a * g a) 1 μ
       = ∫⁻ a, ‖f a * g a‖₊ ∂μ := by simp [eLpNorm, eLpNorm']
@@ -454,15 +426,15 @@ noncomputable def integrationCLM (p q : ℝ≥0∞) (hp : 1 ≤ p) (hptop : p �
     [Fact (1 ≤ p)]
     (hpq : p.toReal.HolderConjugate q.toReal)
     [IsFiniteMeasure μ] [SigmaFinite μ]
-    (g : α → ℝ) (hg : Memℒp g q μ) :
+    (g : α → ℝ) (hg : MemLp g q μ) :
     Lp ℝ p μ →L[ℝ] ℝ := by
   refine LinearMap.mkContinuous ?_ (eLpNorm g q μ).toReal ?_
   · -- Linear map: f ↦ ∫ (↑f) * g ∂μ
     exact {
       toFun := fun f => ∫ a, (f : α → ℝ) a * g a ∂μ
       map_add' := fun f₁ f₂ => by
-        have h1 := integrable_mul_of_memLp p q hpq hp hptop (Lp.memℒp f₁) hg
-        have h2 := integrable_mul_of_memLp p q hpq hp hptop (Lp.memℒp f₂) hg
+        have h1 := integrable_mul_of_memLp p q hpq hp hptop (Lp.memLp f₁) hg
+        have h2 := integrable_mul_of_memLp p q hpq hp hptop (Lp.memLp f₂) hg
         simp only [Lp.coeFn_add, Pi.add_apply, add_mul]
         exact integral_add h1 h2
       map_smul' := fun c f => by
@@ -473,14 +445,14 @@ noncomputable def integrationCLM (p q : ℝ≥0∞) (hp : 1 ≤ p) (hptop : p �
   · -- Bound: ‖∫ fg‖ ≤ ‖g‖_Lq * ‖f‖_Lp
     intro f
     -- Chain: ‖∫ fg‖ ≤ ∫ ‖fg‖ ≤ (∫⁻ ‖fg‖₊).toReal ≤ (eLpNorm f p * eLpNorm g q).toReal
-    have hint := integrable_mul_of_memLp p q hpq hp hptop (Lp.memℒp f) hg
+    have hint := integrable_mul_of_memLp p q hpq hp hptop (Lp.memLp f) hg
     calc ‖∫ a, (f : α → ℝ) a * g a ∂μ‖
         ≤ ∫ a, ‖(f : α → ℝ) a * g a‖ ∂μ := norm_integral_le_integral_norm _
       _ ≤ (eLpNorm (f : α → ℝ) p μ * eLpNorm g q μ).toReal := by
           rw [← integral_norm_eq_lintegral_nnnorm hint.aestronglyMeasurable]
           · apply ENNReal.toReal_mono
-            · exact ENNReal.mul_ne_top (Lp.memℒp f).eLpNorm_lt_top.ne hg.eLpNorm_lt_top.ne
-            · exact lintegral_mul_le_of_memLp p q hpq hp hptop (Lp.memℒp f) hg
+            · exact ENNReal.mul_ne_top (Lp.memLp f).eLpNorm_lt_top.ne hg.eLpNorm_lt_top.ne
+            · exact lintegral_mul_le_of_memLp p q hpq hp hptop (Lp.memLp f) hg
       _ = (eLpNorm g q μ).toReal * ‖f‖ := by
           rw [ENNReal.toReal_mul, mul_comm]
           -- ‖f‖ in Lp is (eLpNorm (↑f) p μ).toReal by definition
@@ -491,7 +463,7 @@ theorem integrationCLM_apply (p q : ℝ≥0∞) (hp : 1 ≤ p) (hptop : p ≠ �
     [Fact (1 ≤ p)]
     (hpq : p.toReal.HolderConjugate q.toReal)
     [IsFiniteMeasure μ] [SigmaFinite μ]
-    (g : α → ℝ) (hg : Memℒp g q μ) (f : Lp ℝ p μ) :
+    (g : α → ℝ) (hg : MemLp g q μ) (f : Lp ℝ p μ) :
     integrationCLM p q hp hptop hpq g hg f = ∫ a, (f : α → ℝ) a * g a ∂μ := by
   simp [integrationCLM, LinearMap.mkContinuous_apply]
 
@@ -506,7 +478,7 @@ theorem integrationCLM_apply (p q : ℝ≥0∞) (hp : 1 ≤ p) (hptop : p ≠ �
 theorem integral_representation (p q : ℝ≥0∞) (hp1 : 1 < p) (hptop : p ≠ ⊤)
     (hpq : p.toReal.HolderConjugate q.toReal)
     [IsFiniteMeasure μ] [SigmaFinite μ]
-    (φ : Lp ℝ p μ →L[ℝ] ℝ) (g : α → ℝ) (hg : Memℒp g q μ)
+    (φ : Lp ℝ p μ →L[ℝ] ℝ) (g : α → ℝ) (hg : MemLp g q μ)
     (hagree : ∀ (E : Set α), MeasurableSet E → μ E ≠ ⊤ →
       φ ((indicator_memLp (p := p) ‹_› ‹_› p (le_of_lt hp1) hptop).toLp _) =
       ∫ a in E, g a ∂μ) :
@@ -577,11 +549,10 @@ The main theorem proof below assembles these pieces without sorry.
 -/
 
 /-- **HasSum of Lp indicator functions** for a pairwise disjoint partition.
-    The Lp partial sums ∑_{i<N} 1_{f i} converge in Lp norm to 1_{⋃ f i}.
+    The Lp partial sums ∑_{i∈F} 1_{f i} (over finite F) converge in Lp norm to 1_{⋃ f i}.
 
-    Proof sketch: eLpNorm (1_{⋃_{i≥N} f_i}) p μ = μ(⋃_{i≥N} f i)^{1/p} → 0
-    because ∑_{i≥N} μ(f i) → 0 (finite total measure, tail of convergent series).
-    The disjointness ensures the difference 1_{⋃ f} - ∑_{i<N} 1_{f i} = 1_{⋃_{i≥N} f i} a.e. -/
+    Proof: Use tendsto_indicatorConstLp_set with the measure of the symmetric difference
+    (⋃_{i∈F} f i) ∆ (⋃ f i) = ⋃_{i∉F} f i → 0, which follows from tail measure → 0. -/
 private theorem indicator_lp_hasSum [IsFiniteMeasure μ]
     (p : ℝ≥0∞) (hp : 1 ≤ p) (hptop : p ≠ ⊤)
     {f : ℕ → Set α} (hf_meas : ∀ i, MeasurableSet (f i))
@@ -589,11 +560,80 @@ private theorem indicator_lp_hasSum [IsFiniteMeasure μ]
     HasSum
       (fun i => (indicator_memLp (hf_meas i) (measure_ne_top μ _) p hp hptop).toLp _)
       ((indicator_memLp (MeasurableSet.iUnion hf_meas) (measure_ne_top μ _) p hp hptop).toLp _) := by
-  -- Key: the Lp tail norm μ(⋃_{i≥N} f i)^{1/p} → 0 since μ is finite and ∑ μ(f i) < ∞.
-  -- Proof: show eLpNorm (1_{⋃ f} - ∑_{i<N} 1_{f i}) p μ = μ(⋃_{i≥N} f i)^{1/p} → 0.
-  -- The partial Lp sums converge ↔ the Lp tail norms → 0
-  -- (using disjointness: 1_{⋃ f} - ∑_{i<N} 1_{f i} = 1_{⋃_{i≥N} f i} a.e.).
-  sorry
+  haveI hp1' : Fact (1 ≤ p) := ⟨hp⟩
+  -- Step 1: Convert .toLp _ to indicatorConstLp (same function a.e.)
+  have hconv : ∀ (E : Set α) (hE : MeasurableSet E),
+      (indicator_memLp hE (measure_ne_top μ E) p hp hptop).toLp _ =
+      indicatorConstLp p hE (measure_ne_top μ E) (1 : ℝ) := fun E hE =>
+    MemLp.toLp_congr (indicator_memLp hE _ p hp hptop)
+      (memLp_indicator_const p hE 1 (Or.inr (measure_ne_top μ E)))
+      (ae_eq_refl _)
+  simp_rw [hconv]
+  -- Step 2: Partial sums = indicatorConstLp of partial union
+  have hF_sum : ∀ F : Finset ℕ,
+      ∑ i ∈ F, indicatorConstLp p (hf_meas i) (measure_ne_top μ _) (1 : ℝ) =
+      indicatorConstLp p (F.measurableSet_biUnion hf_meas) (measure_ne_top μ _) (1 : ℝ) := by
+    intro F
+    induction F using Finset.induction_on with
+    | empty => simp [indicatorConstLp_empty]
+    | insert ha ih =>
+      rename_i a F' ha ih
+      rw [Finset.sum_insert ha, ih,
+          ← indicatorConstLp_disjoint_union (hf_meas a) (F'.measurableSet_biUnion hf_meas)
+              (measure_ne_top μ _) (measure_ne_top μ _)
+              (Set.disjoint_iUnion₂_right.mpr (fun i hi => hf_disj (fun h => ha (h ▸ hi))))]
+      -- The two indicatorConstLp calls represent the same indicator function a.e.
+      apply Lp.ext_iff.mpr
+      filter_upwards [indicatorConstLp_coeFn (hs := (hf_meas a).union (F'.measurableSet_biUnion hf_meas))
+                        (hμs := by finiteness) (c := (1:ℝ)),
+                      indicatorConstLp_coeFn (hs := (insert a F').measurableSet_biUnion hf_meas)
+                        (hμs := measure_ne_top μ _) (c := (1:ℝ))] with x hx1 hx2
+      rw [hx1, hx2, set_biUnion_insert]
+  -- Step 3: Tail sets ⋃_{i≥N} f i are antitone with empty intersection → measure → 0
+  let tail : ℕ → Set α := fun N => ⋃ i, if N ≤ i then f i else ∅
+  have htail_anti : Antitone tail := fun m n hmn x => by
+    simp only [tail, Set.mem_iUnion, Set.mem_ite_empty_right]
+    exact fun ⟨i, hi, hx⟩ => ⟨i, hmn.trans hi, hx⟩
+  have htail_iInter : ⋂ N, tail N = ∅ := by
+    ext x
+    simp only [tail, Set.mem_iInter, Set.mem_iUnion, Set.mem_ite_empty_right,
+               Set.mem_empty_iff_false, iff_false, not_forall, not_exists]
+    push_neg
+    intro h
+    by_contra habs
+    push_neg at habs
+    obtain ⟨k₀, hxk₀⟩ : ∃ k, x ∈ f k := by obtain ⟨k, _, hxk⟩ := h 0; exact ⟨k, hxk⟩
+    use k₀ + 1
+    intro k hk hxk
+    exact absurd (Set.mem_inter hxk₀ hxk) ((hf_disj (by omega)).inter_eq ▸ Set.not_mem_empty x)
+  have htail_tendsto : Tendsto (fun N => μ (tail N)) atTop (𝓝 0) := by
+    have hconv' := tendsto_measure_iInter_atTop (s := tail)
+      (hs := fun N => (MeasurableSet.iUnion fun i =>
+        (by split_ifs <;> [exact hf_meas i; exact MeasurableSet.empty])).nullMeasurableSet)
+      (hm := htail_anti) ⟨0, measure_ne_top μ _⟩
+    rw [htail_iInter, measure_empty] at hconv'; exact hconv'
+  -- Step 4: Symmetric difference (⋃_{i∈F} f i) ∆ (⋃ f i) ⊆ tail N when F ⊇ range N
+  have hΔ_bound : ∀ (N : ℕ) (F : Finset ℕ), Finset.range N ⊆ F →
+      (⋃ i ∈ F, f i) ∆ (⋃ i, f i) ⊆ tail N := by
+    intro N F hF x hx
+    rcases Set.mem_symmDiff.mp hx with ⟨⟨i, _, hxi⟩, habs⟩ | ⟨⟨i, hxi⟩, hnotF⟩
+    · exact absurd (Set.mem_iUnion.mpr ⟨i, hxi⟩) habs
+    · simp only [Set.mem_biUnion, not_exists, not_and] at hnotF
+      have hi_notF : i ∉ F := fun hi => hnotF i hi hxi
+      have hi_ge : N ≤ i := Nat.le_of_not_lt (fun h => hi_notF (hF (Finset.mem_range.mpr h)))
+      simp only [tail, Set.mem_iUnion, Set.mem_ite_empty_right]
+      exact ⟨i, hi_ge, hxi⟩
+  -- Step 5: Symmetric difference measure → 0 as F → atTop
+  have hΔ_tendsto : Tendsto (fun F : Finset ℕ => μ ((⋃ i ∈ F, f i) ∆ (⋃ i, f i))) atTop (𝓝 0) := by
+    rw [ENNReal.tendsto_atTop_zero]
+    intro ε hε
+    obtain ⟨N₀, hN₀⟩ := ENNReal.tendsto_atTop_zero.mp htail_tendsto ε hε
+    exact ⟨Finset.range N₀, fun F hF =>
+      (measure_mono (hΔ_bound N₀ F hF)).trans (hN₀ N₀ le_rfl)⟩
+  -- Step 6: Apply tendsto_indicatorConstLp_set
+  rw [HasSum]
+  simp_rw [hF_sum]
+  exact tendsto_indicatorConstLp_set hptop hΔ_tendsto
 
 /-- **σ-additivity** of the set function E ↦ φ(1_E).
     Follows from `indicator_lp_hasSum` by applying φ (a CLM, hence continuous). -/
@@ -633,7 +673,7 @@ private theorem signedMeasureOfFunctional_indicator [IsFiniteMeasure μ]
     {E : Set α} (hE : MeasurableSet E) :
     signedMeasureOfFunctional p hp hptop φ E =
       φ ((indicator_memLp hE (measure_ne_top μ E) p hp hptop).toLp _) := by
-  simp [signedMeasureOfFunctional, dif_pos hE, functionalSetFn]
+  simp [signedMeasureOfFunctional]
 
 /-- The signed measure from φ is absolutely continuous w.r.t. μ.
     Follows from `functionalSetFn_null`: if μ(E) = 0 then φ(1_E) = 0. -/
@@ -641,16 +681,12 @@ private theorem signedMeasureOfFunctional_ac [IsFiniteMeasure μ]
     (p : ℝ≥0∞) (hp : 1 ≤ p) (hptop : p ≠ ⊤) (φ : Lp ℝ p μ →L[ℝ] ℝ) :
     (signedMeasureOfFunctional p hp hptop φ).AbsolutelyContinuous
         μ.toENNRealVectorMeasure := by
-  -- AbsolutelyContinuous: ∀ s, μ.toENNRealVectorMeasure s = 0 → ν s = 0
   intro s hμs
-  simp only [signedMeasureOfFunctional]
   by_cases hE : MeasurableSet s
-  · simp only [dif_pos hE]
-    -- μ.toENNRealVectorMeasure s = 0 → μ s = 0 (for measurable s)
-    have hzero : μ s = 0 := by
-      rwa [Measure.toENNRealVectorMeasure_apply hE] at hμs
-    exact functionalSetFn_null p hp hptop φ hE hzero
-  · simp [dif_neg hE]
+  · rw [signedMeasureOfFunctional_indicator p hp hptop φ hE]
+    apply functionalSetFn_null p hp hptop φ hE
+    rwa [Measure.toENNRealVectorMeasure_apply hE] at hμs
+  · exact (signedMeasureOfFunctional p hp hptop φ).not_measurable hE
 
 /-- **RN derivative integrability**: for a finite signed measure ν ≪ μ (σ-finite),
     the RN derivative ν.rnDeriv μ is μ-integrable.
@@ -678,7 +714,7 @@ private theorem rnDeriv_integral_eq [IsFiniteMeasure μ]
   -- hrec : μ.withDensityᵥ (ν.rnDeriv μ) = ν (as SignedMeasures)
   -- rewrite ν E as (μ.withDensityᵥ g) E, then apply withDensityᵥ_apply
   conv_lhs => rw [← hrec]
-  exact Measure.withDensityᵥ_apply hint hE
+  exact withDensityᵥ_apply hint hE
 
 /-- **Hölder extremizer bound**: for gₙ = clamp(g, -n, n) where g = ν.rnDeriv μ,
     eLpNorm gₙ q μ ≤ ENNReal.ofReal ‖φ‖.
@@ -692,6 +728,7 @@ private theorem rnDeriv_integral_eq [IsFiniteMeasure μ]
 private theorem holder_extremizer_lq_bound [IsFiniteMeasure μ] [SigmaFinite μ]
     (p q : ℝ≥0∞) (hp1 : 1 < p) (hptop : p ≠ ⊤)
     (hpq : p.toReal.HolderConjugate q.toReal)
+    [hpFact : Fact (1 ≤ p)]
     (φ : Lp ℝ p μ →L[ℝ] ℝ) (ν : SignedMeasure α)
     (hac : ν.AbsolutelyContinuous μ.toENNRealVectorMeasure)
     (hν_eq : ∀ (E : Set α) (hE : MeasurableSet E),
@@ -726,9 +763,9 @@ holder_extremizer_lq_bound.
     eliminates the `riesz_lp_surjective` axiom from the parent file. -/
 theorem riesz_lp_surjective_from_rn (p q : ℝ≥0∞) (hp1 : 1 < p) (hptop : p ≠ ⊤)
     (hpq : p.toReal.HolderConjugate q.toReal)
-    [IsFiniteMeasure μ] [SigmaFinite μ] :
+    [IsFiniteMeasure μ] [SigmaFinite μ] [_ : Fact (1 ≤ p)] :
     ∀ φ : Lp ℝ p μ →L[ℝ] ℝ,
-    ∃ g : α → ℝ, Memℒp g q μ ∧
+    ∃ g : α → ℝ, MemLp g q μ ∧
       ∀ f : Lp ℝ p μ, φ f = ∫ a, (f : α → ℝ) a * g a ∂μ := by
   intro φ
   haveI hp1' : Fact (1 ≤ p) := ⟨le_of_lt hp1⟩
@@ -751,7 +788,7 @@ theorem riesz_lp_surjective_from_rn (p q : ℝ≥0∞) (hp1 : 1 < p) (hptop : p 
     rw [← hν_eq E hE]
     exact rnDeriv_integral_eq ν hac hE
   -- Step 4: g ∈ Lq via Hölder extremizer + rn_deriv_memLq_from_trunc
-  have hg_Lq : Memℒp g q μ :=
+  have hg_Lq : MemLp g q μ :=
     rn_deriv_memLq_from_trunc p q hp1 hptop hpq g hg_meas ‖φ‖
       (fun n => holder_extremizer_lq_bound p q hp1 hptop hpq φ ν hac hν_eq n)
   -- Step 5: Full representation via integral_representation (Lp.induction)

--- a/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean
@@ -725,6 +725,86 @@ private theorem rnDeriv_integral_eq [IsFiniteMeasure μ]
 
     The identity ∫ h_n g = φ(h_n) extends from indicator agreement via:
     simple-function approximation + φ continuity + DCT (g ∈ L1 from rnDeriv_integrable). -/
+/-
+## Helper: Extending φ to bounded functions via simple-function approximation
+
+For bounded measurable h, φ(h) = ∫ h * g via:
+1. For simple functions: φ(s) = ∫ s*g by linearity + indicator formula
+2. approxOn convergence in Lp + DCT extends to all bounded h
+
+This avoids circularity: uses g ∈ L1 (not g ∈ Lq).
+-/
+private theorem φ_simple_eq_integral [IsFiniteMeasure μ]
+    (p : ℝ≥0∞) (hp1 : 1 < p) (hptop : p ≠ ⊤)
+    [Fact (1 ≤ p)]
+    (φ : Lp ℝ p μ →L[ℝ] ℝ) (g : α → ℝ)
+    (hφ_ind : ∀ (E : Set α) (hE : MeasurableSet E),
+        φ ((indicator_memLp hE (measure_ne_top μ E) p (le_of_lt hp1) hptop).toLp _) =
+        ∫ a in E, g a ∂μ)
+    (hg_int : Integrable g μ)
+    (s : α →ₛ ℝ) (hs : MemLp (s : α → ℝ) p μ) :
+    φ (hs.toLp s) = ∫ a, (s : α → ℝ) a * g a ∂μ := by
+  induction s using SimpleFunc.induction with
+  | const c E hE =>
+    -- s = c * 1_E as a simple function
+    -- Connect MemLp.toLp of piecewise to indicatorConstLp
+    have hμE : μ E ≠ ⊤ := measure_ne_top μ E
+    -- The piecewise simple function c * 1_E equals c * (indicator function in Lp)
+    have heq_Lp : hs.toLp s =
+        c • (indicator_memLp hE hμE p (le_of_lt hp1) hptop).toLp _ := by
+      rw [Lp.ext_iff]
+      filter_upwards [hs.coeFn_toLp,
+        Lp.coeFn_smul c ((indicator_memLp hE hμE p (le_of_lt hp1) hptop).toLp _),
+        (indicator_memLp hE hμE p (le_of_lt hp1) hptop).coeFn_toLp] with x hxs hxsmul hxind
+      simp only [SimpleFunc.piecewise_const_coeFn, SimpleFunc.coe_piecewise, SimpleFunc.coe_const,
+        SimpleFunc.const_zero, Pi.piecewise_apply, Set.piecewise_apply] at hxs
+      rw [hxs, hxsmul, hxind]
+      simp [Set.indicator_apply, smul_eq_mul]
+      split_ifs <;> ring
+    rw [heq_Lp, map_smul, smul_eq_mul, hφ_ind E hE]
+    rw [← integral_indicator hE]
+    congr 1
+    filter_upwards [(indicator_memLp hE hμE p (le_of_lt hp1) hptop).coeFn_toLp] with x hx
+    simp only [hx, Set.indicator_apply]; split_ifs <;> ring
+  | add f₁ f₂ hdisj hf₁ hf₂ =>
+    -- s = f₁ + f₂ with disjoint supports
+    -- Need MemLp for f₁ and f₂ individually (from MemLp of sum + disjoint support)
+    have hf₁_Lp : MemLp (f₁ : α → ℝ) p μ := by
+      apply hs.mono f₁.aestronglyMeasurable
+      filter_upwards with x
+      simp only [SimpleFunc.coe_add, Pi.add_apply]
+      -- On disjoint supports: ‖f₁ x‖ ≤ ‖f₁ x + f₂ x‖
+      by_cases hx : x ∈ Function.support (f₁ : α → ℝ)
+      · have hf2x : (f₂ : α → ℝ) x = 0 :=
+          Function.nmem_support.mp (Set.disjoint_left.mp hdisj hx)
+        simp [hf2x]
+      · simp [Function.nmem_support.mp hx]
+    have hf₂_Lp : MemLp (f₂ : α → ℝ) p μ := by
+      apply hs.mono f₂.aestronglyMeasurable
+      filter_upwards with x
+      simp only [SimpleFunc.coe_add, Pi.add_apply]
+      by_cases hx : x ∈ Function.support (f₂ : α → ℝ)
+      · have hf1x : (f₁ : α → ℝ) x = 0 :=
+          Function.nmem_support.mp (Set.disjoint_right.mp hdisj hx)
+        simp [hf1x]
+      · simp [Function.nmem_support.mp hx]
+    have hadd : hs.toLp s = hf₁_Lp.toLp f₁ + hf₂_Lp.toLp f₂ := by
+      rw [Lp.ext_iff]
+      filter_upwards [hs.coeFn_toLp, hf₁_Lp.coeFn_toLp, hf₂_Lp.coeFn_toLp,
+        Lp.coeFn_add (hf₁_Lp.toLp f₁) (hf₂_Lp.toLp f₂)] with x hx h₁ h₂ hadd_lp
+      rw [hx, hadd_lp, h₁, h₂]; simp [SimpleFunc.coe_add, Pi.add_apply]
+    -- Product integrability: bounded × L1 is L1
+    have hf₁g_int : Integrable (fun a => (f₁ : α → ℝ) a * g a) μ := by
+      obtain ⟨C, hC⟩ := f₁.exists_forall_norm_le
+      exact hg_int.bdd_mul f₁.aestronglyMeasurable.aemeasurable
+        ⟨C, Filter.Eventually.of_forall hC⟩
+    have hf₂g_int : Integrable (fun a => (f₂ : α → ℝ) a * g a) μ := by
+      obtain ⟨C, hC⟩ := f₂.exists_forall_norm_le
+      exact hg_int.bdd_mul f₂.aestronglyMeasurable.aemeasurable
+        ⟨C, Filter.Eventually.of_forall hC⟩
+    rw [hadd, map_add, hf₁ hf₁_Lp, hf₂ hf₂_Lp, ← integral_add hf₁g_int hf₂g_int]
+    congr 1; ext a; simp [SimpleFunc.coe_add, Pi.add_apply]; ring
+
 private theorem holder_extremizer_lq_bound [IsFiniteMeasure μ] [SigmaFinite μ]
     (p q : ℝ≥0∞) (hp1 : 1 < p) (hptop : p ≠ ⊤)
     (hpq : p.toReal.HolderConjugate q.toReal)
@@ -736,7 +816,330 @@ private theorem holder_extremizer_lq_bound [IsFiniteMeasure μ] [SigmaFinite μ]
     (n : ℕ) :
     eLpNorm (fun a => max (min (ν.rnDeriv μ a) (n : ℝ)) (-(n : ℝ))) q μ ≤
       ENNReal.ofReal ‖φ‖ := by
-  sorry
+  set g := ν.rnDeriv μ with hg_def
+  set gₙ := fun a => max (min (g a) (n : ℝ)) (-(n : ℝ)) with hgₙ_def
+  have hg_meas : Measurable g := ν.measurable_rnDeriv μ
+  have hp0 : p ≠ 0 := ne_of_gt (lt_trans zero_lt_one hp1)
+  have hq0 : q ≠ 0 := by intro h; simp [h, ENNReal.toReal_zero] at hpq
+  have hqtop : q ≠ ⊤ := by intro h; simp [h, ENNReal.toReal_top] at hpq
+  have hq_pos : 0 < q.toReal := ENNReal.toReal_pos hq0 hqtop
+  have hp_pos : 0 < p.toReal := ENNReal.toReal_pos hp0 hptop
+  -- g ∈ L1 and ν(E) = ∫_E g
+  have hg_int : Integrable g μ := rnDeriv_integrable_of_finite ν hac
+  have hφ_ind : ∀ (E : Set α) (hE : MeasurableSet E),
+      φ ((indicator_memLp hE (measure_ne_top μ E) p (le_of_lt hp1) hptop).toLp _) =
+      ∫ a in E, g a ∂μ := by
+    intro E hE; rw [← hν_eq E hE]; exact rnDeriv_integral_eq ν hac hE
+  -- Extremizer: hₙ = sign(gₙ) * |gₙ|^{q-1}
+  set hₙ := fun a => Real.sign (gₙ a) * |gₙ a| ^ (q.toReal - 1) with hₙ_def
+  -- hₙ is bounded by n^{q-1}
+  have hgₙ_bound : ∀ a, |gₙ a| ≤ n := by
+    intro a; simp [gₙ, abs_le]
+    constructor
+    · linarith [le_max_right (min (g a) (n : ℝ)) (-(n : ℝ))]
+    · linarith [min_le_right (g a) (n : ℝ), le_max_left (min (g a) (n : ℝ)) (-(n : ℝ))]
+  have hₙ_bound : ∀ a, |hₙ a| ≤ (n : ℝ) ^ (q.toReal - 1) := by
+    intro a
+    simp only [hₙ_def, abs_mul]
+    have hsign : |Real.sign (gₙ a)| ≤ 1 := by
+      rcases lt_trichotomy (gₙ a) 0 with h | h | h
+      · simp [Real.sign_of_neg h]
+      · simp [h, Real.sign_zero]
+      · simp [Real.sign_of_pos h]
+    have hq_sub_pos : 0 ≤ q.toReal - 1 := by linarith [hpq.one_le_left]
+    have hrpow_nn : 0 ≤ |gₙ a| ^ (q.toReal - 1) :=
+      Real.rpow_nonneg (abs_nonneg _) _
+    have hrpow_abs : ||gₙ a| ^ (q.toReal - 1)| = |gₙ a| ^ (q.toReal - 1) :=
+      abs_of_nonneg hrpow_nn
+    by_cases hgn0 : gₙ a = 0
+    · simp [hgn0, Real.sign_zero]
+    · calc |Real.sign (gₙ a)| * ||gₙ a| ^ (q.toReal - 1)|
+          ≤ 1 * |gₙ a| ^ (q.toReal - 1) := by
+              rw [hrpow_abs]
+              exact mul_le_mul_of_nonneg_right hsign hrpow_nn
+        _ = |gₙ a| ^ (q.toReal - 1) := one_mul _
+        _ ≤ (n : ℝ) ^ (q.toReal - 1) :=
+              Real.rpow_le_rpow (abs_nonneg _) (hgₙ_bound a) hq_sub_pos
+  -- hₙ ∈ Lp (bounded + finite measure)
+  have hₙ_meas : Measurable hₙ := by
+    have hgₙ_meas : Measurable gₙ := (hg_meas.min measurable_const).max measurable_const
+    have hsign_meas : Measurable (Real.sign : ℝ → ℝ) := by
+      have h : (Real.sign : ℝ → ℝ) = fun r => if r < 0 then -1 else if 0 < r then 1 else 0 :=
+        funext fun r => by simp [Real.sign]
+      rw [h]
+      exact Measurable.ite (measurableSet_lt measurable_id measurable_zero) measurable_const
+        (Measurable.ite (measurableSet_lt measurable_zero measurable_id) measurable_const
+          measurable_const)
+    have hrpow_meas : Measurable (fun x : ℝ => |x| ^ (q.toReal - 1)) :=
+      (continuous_rpow_const (by linarith [hpq.symm.lt])).measurable.comp
+        continuous_abs.measurable
+    show Measurable (fun a => Real.sign (gₙ a) * |gₙ a| ^ (q.toReal - 1))
+    exact (hsign_meas.comp hgₙ_meas).mul (hrpow_meas.comp hgₙ_meas)
+  have hₙ_Lp : MemLp hₙ p μ :=
+    MemLp.of_bound hₙ_meas.aestronglyMeasurable ((n : ℝ) ^ (q.toReal - 1))
+      (Filter.Eventually.of_forall (fun a => by
+        simp only [Real.norm_eq_abs]; exact hₙ_bound a))
+  -- KEY: φ(hₙ) = ∫ hₙ * g via approxOn approximation + DCT
+  have hφ_hn : φ (hₙ_Lp.toLp hₙ) = ∫ a, hₙ a * g a ∂μ := by
+    -- Approximate hₙ by simple functions sₖ = approxOn hₙ
+    set sₖ : ℕ → α →ₛ ℝ :=
+      fun k => SimpleFunc.approxOn hₙ hₙ_meas (Set.range hₙ ∪ {0}) 0 (by simp) k
+    have hsk_Lp : ∀ k, MemLp (sₖ k : α → ℝ) p μ :=
+      fun k => memLp_approxOn_range hₙ_meas hₙ_Lp k
+    -- sₖ → hₙ in Lp
+    have hconv_Lp : Filter.Tendsto
+        (fun k => eLpNorm ((sₖ k : α → ℝ) - hₙ) p μ) atTop (𝓝 0) :=
+      tendsto_approxOn_range_Lp_eLpNorm hptop hₙ_meas hₙ_Lp.2.ne
+    -- Convert to norm convergence: ‖sₖ as Lp - hₙ as Lp‖ → 0
+    have hconv_norm : Filter.Tendsto
+        (fun k => ‖(hsk_Lp k).toLp (sₖ k) - hₙ_Lp.toLp hₙ‖) atTop (𝓝 0) := by
+      have : ∀ k, ‖(hsk_Lp k).toLp (sₖ k) - hₙ_Lp.toLp hₙ‖ =
+          (eLpNorm ((sₖ k : α → ℝ) - hₙ) p μ).toReal := by
+        intro k
+        rw [← Lp.norm_sub_eq_eLpNorm]
+        congr 1
+        rw [Lp.ext_iff]
+        filter_upwards [(hsk_Lp k).coeFn_toLp, hₙ_Lp.coeFn_toLp,
+          Lp.coeFn_sub ((hsk_Lp k).toLp _) (hₙ_Lp.toLp hₙ)] with x h₁ h₂ hsub
+        rw [hsub, h₁, h₂]; rfl
+      simp_rw [this]
+      rw [show (0 : ℝ) = (0 : ℝ≥0∞).toReal from by simp]
+      exact ENNReal.Tendsto.toReal hconv_Lp (by simp)
+    -- φ(sₖ) converges to φ(hₙ)
+    have hconv_φ : Filter.Tendsto
+        (fun k => φ ((hsk_Lp k).toLp (sₖ k))) atTop (𝓝 (φ (hₙ_Lp.toLp hₙ))) := by
+      apply φ.continuous.continuousAt.tendsto
+      rw [Metric.tendsto_atTop] at hconv_norm ⊢
+      intro ε hε
+      obtain ⟨N, hN⟩ := hconv_norm ε hε
+      exact ⟨N, fun k hk => by rw [dist_comm]; exact hN k hk⟩
+    -- Simple function formula: φ(sₖ) = ∫ sₖ * g
+    have hsk_φ : ∀ k, φ ((hsk_Lp k).toLp (sₖ k)) = ∫ a, (sₖ k : α → ℝ) a * g a ∂μ :=
+      fun k => φ_simple_eq_integral p hp1 hptop φ g hφ_ind hg_int (sₖ k) (hsk_Lp k)
+    -- ∫ sₖ * g → ∫ hₙ * g (DCT: |sₖ * g| ≤ 2*(n^{q-1})*|g| ∈ L1)
+    have hint_conv : Filter.Tendsto
+        (fun k => ∫ a, (sₖ k : α → ℝ) a * g a ∂μ) atTop (𝓝 (∫ a, hₙ a * g a ∂μ)) := by
+      apply tendsto_integral_of_dominated_convergence
+          (fun a => 2 * (n : ℝ) ^ (q.toReal - 1) * ‖g a‖)
+      · intro k; exact (sₖ k).aestronglyMeasurable.mul hg_meas.aestronglyMeasurable
+      · exact hg_int.norm.const_mul _
+      · intro k; filter_upwards with a
+        calc ‖(sₖ k : α → ℝ) a * g a‖ ≤ ‖(sₖ k : α → ℝ) a‖ * ‖g a‖ := norm_mul_le _ _
+          _ ≤ 2 * (n : ℝ) ^ (q.toReal - 1) * ‖g a‖ := by
+              apply mul_le_mul_of_nonneg_right _ (norm_nonneg _)
+              have hsk_bound := SimpleFunc.norm_approxOn_zero_le hₙ_meas (by simp) a k
+              simp only [sub_zero] at hsk_bound
+              exact hsk_bound.trans (by
+                simp only [Real.norm_eq_abs]
+                have := hₙ_bound a
+                linarith [abs_nonneg (hₙ a)])
+      · filter_upwards with a
+        exact ((tendsto_approxOn hₙ_meas (by simp) (by simp) a).mul tendsto_const_nhds)
+    -- Combine: φ(hₙ) = lim φ(sₖ) = lim ∫ sₖ*g = ∫ hₙ*g
+    exact tendsto_nhds_unique
+      (hconv_φ.congr' (eventually_of_forall hsk_φ))
+      hint_conv
+  -- Now prove the main bound: ‖gₙ‖_q ≤ ‖φ‖
+  -- Step 1: ‖gₙ‖_q^q = ∫ hₙ * gₙ (extremizer property)
+  have h_norm_q_eq : eLpNorm gₙ q μ ^ q.toReal =
+      ENNReal.ofReal (∫ a, hₙ a * gₙ a ∂μ) := by
+    -- Pointwise: sign(gₙ)|gₙ|^{q-1} * gₙ = |gₙ|^q
+    have hpoint : ∀ a, hₙ a * gₙ a = |gₙ a| ^ q.toReal := by
+      intro a
+      simp only [hₙ_def]
+      rcases eq_or_ne (gₙ a) 0 with h0 | h0
+      · simp [h0, Real.sign_zero, abs_zero, Real.zero_rpow (ne_of_gt hq_pos)]
+      · have h_abs_pos : 0 < |gₙ a| := abs_pos.mpr h0
+        have hsign_abs : Real.sign (gₙ a) * gₙ a = |gₙ a| := by
+          rcases lt_trichotomy (gₙ a) 0 with h | h | h
+          · rw [Real.sign_of_neg h, abs_of_neg h]; ring
+          · exact absurd h h0
+          · rw [Real.sign_of_pos h, abs_of_pos h]; ring
+        calc Real.sign (gₙ a) * |gₙ a| ^ (q.toReal - 1) * gₙ a
+            = |gₙ a| ^ (q.toReal - 1) * (Real.sign (gₙ a) * gₙ a) := by ring
+          _ = |gₙ a| ^ (q.toReal - 1) * |gₙ a| := by rw [hsign_abs]
+          _ = |gₙ a| ^ (q.toReal - 1) * |gₙ a| ^ (1 : ℝ) := by rw [Real.rpow_one]
+          _ = |gₙ a| ^ (q.toReal - 1 + 1) := (Real.rpow_add h_abs_pos _ _).symm
+          _ = |gₙ a| ^ q.toReal := by congr 1; ring
+    -- Measurability and integrability of |gₙ|^q
+    have hgₙ_meas₂ : Measurable gₙ := (hg_meas.min measurable_const).max measurable_const
+    have hmeas_abs : Measurable (fun a => |gₙ a| ^ q.toReal) :=
+      (continuous_rpow_const (le_of_lt hq_pos)).measurable.comp
+        (continuous_abs.measurable.comp hgₙ_meas₂)
+    have h_abs_int : Integrable (fun a => |gₙ a| ^ q.toReal) μ :=
+      (integrable_const ((n : ℝ) ^ q.toReal)).mono' hmeas_abs.aestronglyMeasurable
+        (Filter.Eventually.of_forall (fun a => by
+          simp only [Real.norm_eq_abs, abs_of_nonneg (Real.rpow_nonneg (abs_nonneg _) _)]
+          exact Real.rpow_le_rpow (abs_nonneg _) (hgₙ_bound a) (le_of_lt hq_pos)))
+    have h_abs_nn : 0 ≤ᵐ[μ] (fun a => |gₙ a| ^ q.toReal) :=
+      Filter.Eventually.of_forall (fun a => Real.rpow_nonneg (abs_nonneg _) _)
+    -- Chain: eLpNorm^q = ∫⁻ ‖gₙ‖ₑ^q = ∫⁻ ofReal(|gₙ|^q) = ofReal(∫ |gₙ|^q) = ofReal(∫ hₙ*gₙ)
+    rw [eLpNorm_eq_eLpNorm' hq0 hqtop, ← lintegral_rpow_enorm_eq_rpow_eLpNorm' hq_pos]
+    have hstep : ∫⁻ a, ‖gₙ a‖ₑ ^ q.toReal ∂μ =
+        ENNReal.ofReal (∫ a, |gₙ a| ^ q.toReal ∂μ) := by
+      have h1 : ∫⁻ a, ‖gₙ a‖ₑ ^ q.toReal ∂μ =
+          ∫⁻ a, ENNReal.ofReal (|gₙ a| ^ q.toReal) ∂μ :=
+        lintegral_congr (fun a => by
+          rw [enorm_eq_ofReal_abs, ofReal_rpow_of_nonneg (abs_nonneg _) (le_of_lt hq_pos)])
+      rw [h1]
+      exact (ofReal_integral_eq_lintegral_ofReal h_abs_int h_abs_nn).symm
+    rw [hstep]
+    congr 1
+    exact integral_congr_ae (Filter.Eventually.of_forall fun a => (hpoint a).symm)
+  -- Step 2: ∫ hₙ * gₙ ≤ ∫ hₙ * g (since hₙ * gₙ ≤ hₙ * g a.e.)
+  -- hₙ(a) * gₙ(a) ≤ hₙ(a) * g(a) because:
+  --   hₙ = sign(gₙ) * |gₙ|^{q-1} and gₙ = clamp(g, -n, n)
+  --   so hₙ(a) * (g(a) - gₙ(a)) ≥ 0 for all a (sign of difference agrees with sign of gₙ)
+  have h_gn_le_g : ∀ a, hₙ a * gₙ a ≤ hₙ a * g a := by
+    intro a
+    -- Equivalent to: 0 ≤ hₙ a * (g a - gₙ a)
+    suffices h : 0 ≤ hₙ a * (g a - gₙ a) by linarith [h]
+    simp only [hₙ_def, hgₙ_def]
+    -- Case analysis on where g a falls relative to [-n, n]
+    rcases le_or_gt (n : ℝ) (g a) with hg_hi | hg_lo
+    · -- g a ≥ n: gₙ a = n, hₙ a = n^{q-1} ≥ 0, g a - n ≥ 0
+      have hgₙ_eq : max (min (g a) (n : ℝ)) (-(n : ℝ)) = n := by
+        rw [min_eq_right hg_hi, max_eq_left (by linarith [Nat.cast_nonneg n])]
+      simp only [hgₙ_eq, abs_of_nonneg (Nat.cast_nonneg n)]
+      apply mul_nonneg
+      · apply mul_nonneg
+        · rcases Nat.eq_zero_or_pos n with rfl | hn
+          · simp [Real.sign_zero]
+          · rw [Real.sign_of_pos (Nat.cast_pos.mpr hn)]; norm_num
+        · exact Real.rpow_nonneg (Nat.cast_nonneg n) _
+      · linarith
+    · rcases le_or_gt (g a) (-(n : ℝ)) with hg_neg | hg_mid
+      · -- g a ≤ -n: gₙ a = -n, hₙ a = -n^{q-1} ≤ 0, g a - (-n) ≤ 0
+        have hgₙ_eq : max (min (g a) (n : ℝ)) (-(n : ℝ)) = -(n : ℝ) := by
+          rw [min_eq_left (le_of_lt hg_lo), max_eq_right hg_neg]
+        simp only [hgₙ_eq, abs_neg, abs_of_nonneg (Nat.cast_nonneg n)]
+        rcases Nat.eq_zero_or_pos n with rfl | hn_pos
+        · simp [Real.sign_zero]
+        · have hn_cast_pos : (0 : ℝ) < (n : ℝ) := Nat.cast_pos.mpr hn_pos
+          rw [Real.sign_of_neg (by linarith)]
+          have h_rpow_nn : 0 ≤ (n : ℝ) ^ (q.toReal - 1) :=
+            Real.rpow_nonneg (le_of_lt hn_cast_pos) _
+          rw [show -1 * (n : ℝ) ^ (q.toReal - 1) * (g a - -(n : ℝ)) =
+              (n : ℝ) ^ (q.toReal - 1) * (-(g a + (n : ℝ))) from by ring]
+          exact mul_nonneg h_rpow_nn (by linarith)
+      · -- -n < g a < n: gₙ a = g a, g a - gₙ a = 0
+        have hgₙ_eq : max (min (g a) (n : ℝ)) (-(n : ℝ)) = g a := by
+          rw [min_eq_left (le_of_lt hg_lo), max_eq_left (le_of_lt hg_neg)]
+        simp [hgₙ_eq]
+  -- Product integrability for the integral_mono
+  have hhn_gn_int : Integrable (fun a => hₙ a * gₙ a) μ := by
+    have hgₙ_meas : Measurable gₙ := (hg_meas.min measurable_const).max measurable_const
+    have hgₙ_int : Integrable gₙ μ :=
+      (integrable_const (n : ℝ)).mono hgₙ_meas.aestronglyMeasurable
+        (Filter.Eventually.of_forall (fun a => by
+          simp only [Real.norm_eq_abs, abs_of_nonneg (Nat.cast_nonneg n)]
+          exact hgₙ_bound a))
+    exact hgₙ_int.bdd_mul hₙ_meas.aemeasurable
+      ⟨(n : ℝ) ^ (q.toReal - 1), Filter.Eventually.of_forall (fun a => by
+        simp only [Real.norm_eq_abs]; exact hₙ_bound a)⟩
+  have hhn_g_int : Integrable (fun a => hₙ a * g a) μ := by
+    apply hg_int.bdd_mul hₙ_meas.aemeasurable
+    exact ⟨_, Filter.Eventually.of_forall (fun a => by
+      simp only [Real.norm_eq_abs]; exact hₙ_bound a)⟩
+  have h_int_ineq : ∫ a, hₙ a * gₙ a ∂μ ≤ ∫ a, hₙ a * g a ∂μ :=
+    integral_mono hhn_gn_int hhn_g_int (Filter.Eventually.of_forall h_gn_le_g)
+  -- Step 3: ∫ hₙ * g = φ(hₙ) ≤ ‖φ‖ * ‖hₙ‖_Lp
+  have h_φ_bound : ∫ a, hₙ a * g a ∂μ ≤ ‖φ‖ * ‖hₙ_Lp.toLp hₙ‖ := by
+    rw [← hφ_hn]
+    exact le_trans (Real.le_abs_self _) (φ.le_opNorm _)
+  -- Step 4: ‖hₙ‖_Lp = ‖gₙ‖_q^{q/p}
+  have h_hn_norm : ‖hₙ_Lp.toLp hₙ‖ = (eLpNorm gₙ q μ).toReal ^ (q.toReal / p.toReal) := by
+    -- Pointwise: ‖hₙ‖ₑ^p = ‖gₙ‖ₑ^q  via (q-1)*p = q from HolderConjugate
+    have hpnt : ∀ a, ‖hₙ a‖ₑ ^ p.toReal = ‖gₙ a‖ₑ ^ q.toReal := by
+      intro a
+      rw [enorm_eq_ofReal_abs, enorm_eq_ofReal_abs,
+          ofReal_rpow_of_nonneg (abs_nonneg _) (le_of_lt hp_pos),
+          ofReal_rpow_of_nonneg (abs_nonneg _) (le_of_lt hq_pos)]
+      congr 1
+      -- Prove |hₙ a|^p = |gₙ a|^q
+      rcases eq_or_ne (gₙ a) 0 with h0 | h0
+      · simp only [h0, hₙ_def, Real.sign_zero, abs_zero, zero_mul,
+                   Real.zero_rpow (ne_of_gt hp_pos), Real.zero_rpow (ne_of_gt hq_pos)]
+      · have h_sign_abs : |Real.sign (gₙ a)| = 1 := by
+          rcases lt_trichotomy (gₙ a) 0 with h | h | h
+          · simp [Real.sign_of_neg h]
+          · exact absurd h h0
+          · simp [Real.sign_of_pos h]
+        have h_hn_abs : |hₙ a| = |gₙ a| ^ (q.toReal - 1) := by
+          simp only [hₙ_def, abs_mul, abs_of_nonneg (Real.rpow_nonneg (abs_nonneg _) _)]
+          rw [h_sign_abs, one_mul]
+        rw [h_hn_abs, ← Real.rpow_mul (abs_nonneg _)]
+        congr 1
+        exact hpq.symm.sub_one_mul_conj
+    -- eLpNorm hₙ p μ ^ p = eLpNorm gₙ q μ ^ q
+    have h_elp_eq : eLpNorm hₙ p μ ^ p.toReal = eLpNorm gₙ q μ ^ q.toReal := by
+      rw [eLpNorm_eq_eLpNorm' hp0 hptop, ← lintegral_rpow_enorm_eq_rpow_eLpNorm' hp_pos,
+          eLpNorm_eq_eLpNorm' hq0 hqtop, ← lintegral_rpow_enorm_eq_rpow_eLpNorm' hq_pos]
+      exact lintegral_congr hpnt
+    -- Extract eLpNorm hₙ p μ = eLpNorm gₙ q μ ^ (q/p)
+    have h_hn_elp : eLpNorm hₙ p μ = eLpNorm gₙ q μ ^ (q.toReal / p.toReal) := by
+      have hp_ne : p.toReal ≠ 0 := ne_of_gt hp_pos
+      have h_lhs := congr_arg (· ^ (p.toReal⁻¹ : ℝ)) h_elp_eq
+      simp only [← ENNReal.rpow_mul] at h_lhs
+      rwa [mul_inv_cancel₀ hp_ne, ENNReal.rpow_one,
+           show q.toReal * p.toReal⁻¹ = q.toReal / p.toReal from (div_eq_mul_inv _ _).symm]
+          at h_lhs
+    rw [Lp.norm_def, eLpNorm_congr_ae hₙ_Lp.coeFn_toLp, h_hn_elp, ← ENNReal.toReal_rpow]
+  -- Step 5: Assemble: ‖gₙ‖_q^q ≤ ‖φ‖ * ‖gₙ‖_q^{q/p}  → ‖gₙ‖_q ≤ ‖φ‖
+  -- Case split on ‖gₙ‖_q = 0
+  rcases ENNReal.eq_or_lt_of_le (zero_le (eLpNorm gₙ q μ)) with h0 | hpos
+  · rw [← h0]; exact zero_le _
+  · -- hpos : 0 < eLpNorm gₙ q μ
+    -- gₙ is in Lq (bounded, finite measure), so eLpNorm gₙ q μ ≠ ⊤
+    have hgₙ_memLq : MemLp gₙ q μ :=
+      MemLp.of_bound
+        ((hg_meas.min measurable_const).max measurable_const).aestronglyMeasurable
+        (n : ℝ)
+        (Filter.Eventually.of_forall (fun a => by
+          simp only [Real.norm_eq_abs]; exact hgₙ_bound a))
+    have hgₙ_ne_top : eLpNorm gₙ q μ ≠ ⊤ := hgₙ_memLq.2.ne
+    -- S > 0 where S = ‖gₙ‖_q
+    have hS_pos : 0 < (eLpNorm gₙ q μ).toReal := ENNReal.toReal_pos hpos.ne' hgₙ_ne_top
+    -- ‖hₙ‖_p = S^(q-1)  (since q/p = q-1 by HolderConjugate)
+    have h_hn_norm' : ‖hₙ_Lp.toLp hₙ‖ = (eLpNorm gₙ q μ).toReal ^ (q.toReal - 1) := by
+      rw [h_hn_norm, hpq.symm.div_conj_eq_sub_one]
+    -- ∫ hₙ * gₙ ≥ 0 (since hₙ a * gₙ a = sign * |.|^{q-1} * · ≥ 0)
+    have h_int_nn : 0 ≤ ∫ a, hₙ a * gₙ a ∂μ :=
+      integral_nonneg (fun a => by
+        simp only [hₙ_def]
+        have hsign : Real.sign (gₙ a) * gₙ a = |gₙ a| := by
+          rcases lt_trichotomy (gₙ a) 0 with h | h | h
+          · rw [Real.sign_of_neg h, abs_of_neg h]; ring
+          · simp [h, Real.sign_zero]
+          · rw [Real.sign_of_pos h, abs_of_pos h]; ring
+        rw [show Real.sign (gₙ a) * |gₙ a| ^ (q.toReal - 1) * gₙ a =
+              |gₙ a| ^ (q.toReal - 1) * (Real.sign (gₙ a) * gₙ a) from by ring,
+            hsign]
+        exact mul_nonneg (Real.rpow_nonneg (abs_nonneg _) _) (abs_nonneg _))
+    -- S^q = ∫ hₙ * gₙ (in ℝ)
+    have h_S_eq_int : (eLpNorm gₙ q μ).toReal ^ q.toReal = ∫ a, hₙ a * gₙ a ∂μ := by
+      have h := congr_arg ENNReal.toReal h_norm_q_eq
+      rw [← ENNReal.toReal_rpow, ENNReal.toReal_ofReal h_int_nn] at h
+      exact h
+    -- Chain: S^q ≤ ‖φ‖ * S^(q-1)
+    have h_real_ineq : (eLpNorm gₙ q μ).toReal ^ q.toReal ≤
+        ‖φ‖ * (eLpNorm gₙ q μ).toReal ^ (q.toReal - 1) := by
+      rw [h_S_eq_int, ← h_hn_norm']
+      exact le_trans h_int_ineq h_φ_bound
+    -- S^q = S * S^(q-1)  (using q = 1 + (q-1) and S > 0)
+    have h_S_expand : (eLpNorm gₙ q μ).toReal ^ q.toReal =
+        (eLpNorm gₙ q μ).toReal * (eLpNorm gₙ q μ).toReal ^ (q.toReal - 1) := by
+      rw [show q.toReal = 1 + (q.toReal - 1) from by ring, Real.rpow_add hS_pos, Real.rpow_one]
+    -- S^(q-1) > 0, so cancel to get S ≤ ‖φ‖
+    have h_Sq_pos : 0 < (eLpNorm gₙ q μ).toReal ^ (q.toReal - 1) :=
+      Real.rpow_pos_of_pos hS_pos _
+    have h_S_le : (eLpNorm gₙ q μ).toReal ≤ ‖φ‖ := by
+      rw [h_S_expand] at h_real_ineq
+      exact (mul_le_mul_right h_Sq_pos).mp h_real_ineq
+    -- Convert S ≤ ‖φ‖ back to ENNReal
+    calc eLpNorm gₙ q μ
+        = ENNReal.ofReal (eLpNorm gₙ q μ).toReal := (ENNReal.ofReal_toReal hgₙ_ne_top).symm
+      _ ≤ ENNReal.ofReal ‖φ‖ := ENNReal.ofReal_le_ofReal h_S_le
 
 /-
 ## Main Theorem: Riesz Representation for Lp (Surjectivity)

--- a/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean
@@ -662,17 +662,8 @@ private theorem signedMeasureOfFunctional_ac [IsFiniteMeasure μ]
 private theorem rnDeriv_integrable_of_finite [IsFiniteMeasure μ]
     (ν : SignedMeasure α)
     (hac : ν.AbsolutelyContinuous μ.toENNRealVectorMeasure) :
-    Integrable (ν.rnDeriv μ) μ := by
-  -- Proof outline (sorry pending API name confirmation):
-  -- SignedMeasure.rnDeriv μ = posPart.rnDeriv μ - negPart.rnDeriv μ (by definition)
-  -- JordanDecomposition always has IsFiniteMeasure on both parts (field constraint)
-  -- Measure.integrable_rnDeriv [IsFiniteMeasure ν] [SigmaFinite μ] gives L1 for each part
-  -- So: simp only [SignedMeasure.rnDeriv]; apply Integrable.sub;
-  --     · haveI : IsFiniteMeasure ν.toJordanDecomposition.posPart := inferInstance
-  --       exact Measure.integrable_rnDeriv _ μ
-  --     · haveI : IsFiniteMeasure ν.toJordanDecomposition.negPart := inferInstance
-  --       exact Measure.integrable_rnDeriv _ μ
-  sorry
+    Integrable (ν.rnDeriv μ) μ :=
+  SignedMeasure.integrable_rnDeriv ν μ
 
 /-- **RN derivative reconstructs ν on sets**: ν E = ∫_E (ν.rnDeriv μ) dμ.
     Proof: rn_reconstruction gives μ.withDensityᵥ (ν.rnDeriv μ) = ν;

--- a/proofs/Proofs/Erdos268Problem.lean
+++ b/proofs/Proofs/Erdos268Problem.lean
@@ -58,8 +58,43 @@ theorem finite_has_convergent (A : Set ℕ) (hA : A.Finite) :
 /-- If A has convergent sum, so does any shifted version. -/
 theorem shifted_summable (A : Set ℕ) (k : ℕ)
     (h : HasConvergentHarmonicSubseries A) :
-    Summable (fun n : A => (1 : ℝ) / (n + k)) := by
-  sorry
+    Summable (fun n : A => (1 : ℝ) / (↑↑n + ↑k)) := by
+  unfold HasConvergentHarmonicSubseries at h
+  rcases Nat.eq_zero_or_pos k with rfl | hk
+  · simpa using h
+  · -- k ≥ 1.
+    -- Bound: 1/(n+k) ≤ 1/n + (if n=0 then 1/k else 0) for all n.
+    -- For n=0: 1/(0+k) = 1/k ≤ 0 + 1/k ✓
+    -- For n≥1: 1/(n+k) ≤ 1/n ≤ 1/n + 0 ✓
+    -- The indicator (if n=0 then 1/k else 0) has finite support, so is summable.
+    have hind : Summable (fun n : A => if n.val = 0 then (1 : ℝ) / k else 0) := by
+      by_cases h0 : (0 : ℕ) ∈ A
+      · -- nonzero only at the unique element ⟨0, h0⟩
+        have heq : (fun n : A => if n.val = 0 then (1 : ℝ) / k else 0) =
+            fun n => if n = (⟨0, h0⟩ : A) then (1 : ℝ) / k else 0 := by
+          ext ⟨n, _⟩; simp [Subtype.ext_iff]
+        rw [heq]
+        exact (hasSum_ite_eq (⟨0, h0⟩ : A) ((1 : ℝ) / k)).summable
+      · -- identically zero since 0 ∉ A
+        convert summable_zero using 1
+        ext ⟨n, hn⟩
+        simp [show n ≠ 0 from fun heq => h0 (heq ▸ hn)]
+    apply Summable.of_nonneg_of_le
+      (fun n => div_nonneg one_nonneg (by positivity))
+      (fun ⟨n, _⟩ => ?_)
+      (h.add hind)
+    -- Goal: 1/(n+k) ≤ 1/n + (if n=0 then 1/k else 0)
+    show (1 : ℝ) / (↑n + ↑k) ≤ (1 : ℝ) / ↑n + if n = 0 then (1 : ℝ) / ↑k else 0
+    rcases Nat.eq_zero_or_pos n with rfl | hn_pos
+    · -- n = 0: 1/(0+k) = 1/k ≤ 0 + 1/k
+      simp [Nat.cast_zero, zero_add]
+    · -- n ≥ 1: 1/(n+k) ≤ 1/n
+      have hn : (n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr (Nat.pos_iff_ne_zero.mp hn_pos)
+      simp [show n ≠ 0 from Nat.pos_iff_ne_zero.mp hn_pos]
+      have hn_pos' : (0 : ℝ) < n := Nat.cast_pos.mpr hn_pos
+      have hnk_pos : (0 : ℝ) < n + k := by exact_mod_cast Nat.add_pos_left hn_pos k
+      rw [div_le_div_iff hnk_pos hn_pos']
+      linarith [show (0 : ℝ) ≤ k from Nat.cast_nonneg k]
 
 /- ## Part II: The Point Set X -/
 
@@ -160,14 +195,28 @@ def AhmesSeries (A : Set ℕ) : ℝ := harmonicSubseriesSum A
 /-- X is non-empty (take any convergent subseries). -/
 theorem harmonicPointSet_nonempty (d : ℕ) :
     (harmonicPointSet d).Nonempty := by
-  sorry
+  -- Use powers of 2: infinite set with convergent harmonic sum
+  refine ⟨harmonicPoint d powersOf2Set, powersOf2Set, ?_, powers_convergent, rfl⟩
+  -- powersOf2Set is infinite: k ↦ 2^k is injective
+  have hrange : powersOf2Set = Set.range (fun k : ℕ => 2 ^ k) := by
+    ext n; simp [powersOf2Set, Set.mem_range]
+  rw [hrange]
+  exact Set.infinite_range_of_injective
+    (fun m n h => Nat.pow_right_injective (by norm_num) h)
 
 /-- X is path-connected. -/
 theorem harmonicPointSet_path_connected (d : ℕ) :
     IsPathConnected (harmonicPointSet d) := by
   sorry
 
-/-- X is dense in some region. -/
+/-- X is dense in some region.
+    NOTE: The statement uses `Dense` which means closure = Set.univ (globally dense).
+    The proof attempt sets U = interior (harmonicPointSet d), giving
+    Dense (interior (harmonicPointSet d)), which is not generally true.
+    A correct formulation would use relative density (dense in U), e.g.,
+    ∀ y ∈ U, y ∈ closure (harmonicPointSet d ∩ U), which is trivially true
+    since interior ⊆ harmonicPointSet d.
+    TODO: Fix the theorem statement. -/
 theorem harmonicPointSet_dense_somewhere (d : ℕ) :
     ∃ U : Set (Fin d → ℝ), IsOpen U ∧ U.Nonempty ∧
       Dense (harmonicPointSet d ∩ U) := by
@@ -186,14 +235,23 @@ theorem harmonicPointSet_dense_somewhere (d : ℕ) :
 
 /- ## Part VIII: Coordinate Properties -/
 
-/-- Each coordinate is a decreasing function of the shift. -/
+/-- Each coordinate is a decreasing function of the shift.
+    NOTE: This theorem is FALSE as stated when 0 ∈ A and i = 0.
+    Counterexample: A = {0} ∪ {2^k}, i=0, j=1.
+    Then shiftedHarmonicSum A 0 = Σ 1/2^k ≈ 2 (since 1/0 = 0)
+    but shiftedHarmonicSum A 1 = 1 + Σ 1/(2^k+1) > 2 (the n=0 term gives 1/(0+1)=1).
+    A correct version requires 0 ∉ A as an additional hypothesis.
+    TODO: Fix the theorem statement before attempting to prove it. -/
 theorem coordinate_decreasing (A : Set ℕ) (hA : A.Infinite)
     (hconv : HasConvergentHarmonicSubseries A)
     (i j : ℕ) (hij : i < j) :
     shiftedHarmonicSum A j < shiftedHarmonicSum A i := by
   sorry
 
-/-- The first coordinate is always the largest. -/
+/-- The first coordinate is always the largest.
+    NOTE: This theorem is FALSE as stated when 0 ∈ A (same issue as coordinate_decreasing).
+    It depends on coordinate_decreasing, which is also false as stated.
+    A correct version requires 0 ∉ A as an additional hypothesis. -/
 theorem first_coordinate_largest (d : ℕ) (hd : d ≥ 2) (A : Set ℕ)
     (hA : A.Infinite) (hconv : HasConvergentHarmonicSubseries A) :
     ∀ i : Fin d, (harmonicPoint d A) 0 ≥ (harmonicPoint d A) i := by
@@ -230,7 +288,29 @@ theorem projection_preserves (d₁ d₂ : ℕ) (h : d₁ ≤ d₂) :
 def squaresSet : Set ℕ := {n | ∃ k : ℕ, k ≥ 1 ∧ n = k ^ 2}
 
 theorem squares_convergent : HasConvergentHarmonicSubseries squaresSet := by
-  sorry
+  unfold HasConvergentHarmonicSubseries squaresSet
+  -- Bijection ℕ → squaresSet given by k ↦ (k+1)^2 (since squaresSet requires k ≥ 1)
+  let e : ℕ → squaresSet := fun k => ⟨(k + 1) ^ 2, k + 1, by omega, rfl⟩
+  have he_inj : Function.Injective e := by
+    intro a b h
+    simp only [e, Subtype.mk.injEq] at h
+    omega
+  have he_surj : Function.Surjective e := by
+    rintro ⟨n, k, hk, rfl⟩
+    exact ⟨k - 1, by simp only [e, Subtype.mk.injEq]; omega⟩
+  rw [← (Equiv.ofBijective e ⟨he_inj, he_surj⟩).summable_iff]
+  simp only [Equiv.ofBijective_apply, e]
+  -- Reindexed: 1/((k+1)^2 : ℝ). Dominated by p-series ∑ 1/n² (p=2>1).
+  have hpseries : Summable (fun n : ℕ => ((n : ℝ) ^ (2 : ℝ))⁻¹) :=
+    Real.summable_nat_rpow_inv.mpr (by norm_num : (1 : ℝ) < 2)
+  apply Summable.of_nonneg_of_le (fun k => by positivity)
+    (fun k => ?_) (hpseries.comp_injective (fun a b h => by omega : Function.Injective Nat.succ))
+  -- Goal: 1/((k+1)^2 : ℝ) ≤ ((k+1 : ℝ)^(2:ℝ))⁻¹
+  show (1 : ℝ) / ((k + 1) ^ 2 : ℕ) ≤ (((k + 1 : ℕ) : ℝ) ^ (2 : ℝ))⁻¹
+  rw [one_div, Nat.cast_pow]
+  push_cast
+  congr 1
+  rw [rpow_natCast]
 
 /-- The harmonic point for the squares set. -/
 noncomputable def squaresPoint (d : ℕ) : Fin d → ℝ :=
@@ -240,7 +320,21 @@ noncomputable def squaresPoint (d : ℕ) : Fin d → ℝ :=
 def powersOf2Set : Set ℕ := {n | ∃ k : ℕ, n = 2 ^ k}
 
 theorem powers_convergent : HasConvergentHarmonicSubseries powersOf2Set := by
-  sorry
+  unfold HasConvergentHarmonicSubseries
+  -- Bijection ℕ → powersOf2Set given by k ↦ 2^k
+  let e : ℕ → powersOf2Set := fun k => ⟨2 ^ k, k, rfl⟩
+  have he_inj : Function.Injective e := fun m n h => by
+    simp only [e, Subtype.mk.injEq] at h
+    exact Nat.pow_right_injective (by norm_num) h
+  have he_surj : Function.Surjective e := by
+    rintro ⟨n, k, hk⟩
+    exact ⟨k, Subtype.ext hk.symm⟩
+  rw [← (Equiv.ofBijective e ⟨he_inj, he_surj⟩).summable_iff]
+  simp only [Equiv.ofBijective_apply, e]
+  have heq : (fun k : ℕ => (1 : ℝ) / ↑(2 ^ k)) = (fun k : ℕ => (1 / 2 : ℝ) ^ k) := by
+    ext k; push_cast; ring
+  rw [heq]
+  exact summable_geometric_of_lt_one (by norm_num) (by norm_num)
 
 /-- The harmonic point for powers of 2.
     Σ 1/2^k = 1, so first coordinate is 1. -/

--- a/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/knowledge.md
+++ b/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/knowledge.md
@@ -2,9 +2,55 @@
 
 **Problem**: Can Mathlib's RN machinery (SignedMeasure.rnDeriv) prove that every φ ∈ (Lp)* is represented by integration against some g ∈ Lq?
 
-**Status**: PROGRESS — hMCT re-proved (3→2 sorries); 2 hard sorries remain
+**Status**: PROGRESS — main theorem riesz_lp_surjective_from_rn has 0 sorries; 3 focused helper sorries remain
 
 **Lean file**: `Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean`
+
+---
+
+## Session 2026-04-21 (Session 4) — Main theorem assembled, 3 focused helpers remain
+
+**Mode**: REVISIT
+**Outcome**: progress
+
+### What I Did
+
+1. **Built `signedMeasureOfFunctional`** (0 sorries): proper `SignedMeasure` structure with all fields:
+   - `measureOf E = if MeasurableSet E then φ(1_E) else 0`
+   - `empty`: via `functionalSetFn_null` (μ(∅)=0 → indicator = 0 in Lp)
+   - `not_measurable`: `simp [dif_neg hE]`
+   - `m_iUnion`: via `functional_hasSum_parts` + `HasSum.map` (CLM continuity)
+
+2. **Proved `signedMeasureOfFunctional_ac`** (0 sorries):
+   - `μ(E) = 0 → φ(1_E) = 0` via `functionalSetFn_null`
+
+3. **Proved `rnDeriv_integral_eq`** (depends on 1 sorry):
+   - `∫_E g dμ = ν(E)` via `withDensityᵥ_apply` + `rn_reconstruction`
+
+4. **Assembled `riesz_lp_surjective_from_rn`** (0 sorries in main theorem):
+   - Step 1: construct `ν = signedMeasureOfFunctional`
+   - Step 2: get `g = ν.rnDeriv μ`
+   - Step 3: `hagree`: `φ(1_E) = ∫_E g dμ` (via `rnDeriv_integral_eq`)
+   - Step 4: `g ∈ Lq` via `rn_deriv_memLq_from_trunc` + `holder_extremizer_lq_bound`
+   - Step 5: `integral_representation` closes the goal
+
+### Key Findings
+
+- `HasSum.map` is the key: CLM continuity converts indicator Lp convergence → functional value convergence
+- `signedMeasureOfFunctional_ac` proved without sorry: `μ(E)=0` → `indicator_{E} = 0` in Lp → `φ(0) = 0`
+- The proof architecture correctly bypasses the FALSE `truncated_rn_deriv_lq_bound` by using `holder_extremizer_lq_bound` (new, correct)
+- `rnDeriv_integrable_of_finite` sketch: Jordan decomp → `Integrable.sub` with `Measure.integrable_rnDeriv` twice
+
+### Files Modified
+
+- `proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean` (647→819 lines, 2→4 sorries but main theorem 0-sorry)
+- `src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json` (phase OBSERVE→ACT)
+
+### Remaining Sorries (3 focused helpers, ~130 lines total)
+
+1. **`indicator_lp_hasSum`** (~60 lines): Lp partial sums 1_{f i} → 1_{⋃ f i} in norm; use `tendsto_measure_iUnion_atTop`
+2. **`rnDeriv_integrable_of_finite`** (~20 lines): Jordan decomp + `Integrable.sub` + `Measure.integrable_rnDeriv`
+3. **`holder_extremizer_lq_bound`** (~50 lines): build h_n = sign(gₙ)|gₙ|^{q-1} ∈ Lp, then norm computation
 
 ---
 

--- a/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/knowledge.md
+++ b/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/knowledge.md
@@ -8,6 +8,54 @@
 
 ---
 
+## Session 2026-04-21 (Session 5) — Eliminate all 3 sorries in holder_extremizer_lq_bound
+
+**Mode**: REVISIT
+**Outcome**: progress
+
+### What I Did
+
+1. **Proved `h_norm_q_eq`** (eLpNorm gₙ^q = ofReal(∫ hₙ*gₙ)):
+   - Pointwise: `sign(gₙ)|gₙ|^{q-1} * gₙ = |gₙ|^q` via sign algebra + `Real.rpow_add`
+   - Chain: `eLpNorm_eq_eLpNorm'`, `← lintegral_rpow_enorm_eq_rpow_eLpNorm'`, `lintegral_congr` with `enorm_eq_ofReal_abs + ofReal_rpow_of_nonneg`, then `← ofReal_integral_eq_lintegral_ofReal`
+   - Needed: measurability, integrability, nonnegativity a.e. of `|gₙ|^q`
+
+2. **Proved `h_hn_norm`** (‖hₙ‖_p = S^(q/p)):
+   - Pointwise: `|hₙ|^p = |gₙ|^q` via `(q-1)*p = q` (`hpq.symm.sub_one_mul_conj`)
+   - Equal lintegrals → `eLpNorm hₙ p μ ^ p = eLpNorm gₙ q μ ^ q`
+   - Take (1/p)-th power via `congr_arg (· ^ p⁻¹)` + `ENNReal.rpow_mul + mul_inv_cancel₀`
+   - Assembly: `Lp.norm_def + eLpNorm_congr_ae + ENNReal.toReal_rpow`
+
+3. **Final ENNReal assembly** (eLpNorm gₙ q μ ≤ ofReal ‖φ‖):
+   - `q/p = q-1` via `hpq.symm.div_conj_eq_sub_one`
+   - Write `S^q = S * S^(q-1)` via `Real.rpow_add + Real.rpow_one`
+   - Cancel `S^(q-1) > 0` via `mul_le_mul_right`
+   - Convert to ENNReal via `ENNReal.ofReal_toReal + ENNReal.ofReal_le_ofReal`
+
+4. **Fixed syntax error** in `riesz_lp_surjective_from_rn`:
+   - Removed `[_ : Fact (1 ≤ p)]` (Lean 4 doesn't support `[_ : T]` in theorem signatures)
+   - `haveI hp1' : Fact (1 ≤ p) := ⟨le_of_lt hp1⟩` inside body provides the instance
+
+### Key Findings
+
+- `hpq.symm.sub_one_mul_conj : (q-1)*p = q` (via `HolderConjugate.symm` on `p.HolderConjugate q`)
+- `hpq.symm.div_conj_eq_sub_one : q/p = q-1` (key for reducing `S^(q/p)` to `S^(q-1)`)
+- `ENNReal.toReal_rpow : (x^z).toReal = x.toReal^z` (forward direction to unwrap)
+- `ofReal_integral_eq_lintegral_ofReal` direction: `ofReal(∫f) = ∫⁻ ofReal f`; use `.symm`
+- `lintegral_rpow_enorm_eq_rpow_eLpNorm'` with `←` to convert `(eLpNorm')^p → ∫⁻ ‖f‖ₑ^p`
+
+### Files Modified
+
+- `proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean` (+~180 lines, 3 sorries eliminated in `holder_extremizer_lq_bound`)
+
+### Remaining Sorries (2 total)
+
+1. **`indicator_lp_hasSum`** (line ~570): Lp partial sums 1_{⋃ Eₙ} convergence
+2. **`rnDeriv_integrable_of_finite`** (line ~175): Jordan decomp → Integrable.sub
+3. **`truncated_rn_deriv_lq_bound`** (line ~175): MARKED FALSE, kept as documented dead end
+
+---
+
 ## Session 2026-04-21 (Session 4) — Main theorem assembled, 3 focused helpers remain
 
 **Mode**: REVISIT

--- a/research/problems/erdos-268-oq-01/knowledge.md
+++ b/research/problems/erdos-268-oq-01/knowledge.md
@@ -1,21 +1,63 @@
 # Knowledge Base: erdos-268-oq-01
 
-Insights accumulated during research on this problem.
+## Problem Summary
+
+Erdős #268: Prove that the set X_d of harmonic subseries points has nonempty interior in ℝ^d.
+The main result (nonempty interior) is axiomatized as `erdos_268_solved`. The question is whether
+path-connectedness and other topological properties can be proved.
+
+## Current Status (2026-04-21, Session 3)
+
+**Sorry count**: 4 (reduced from 8 this session)
+
+**Proved this session**:
+- `shifted_summable`: If A has convergent harmonic sum, so does any shifted version 1/(n+k).
+  Proof: split on n=0 (single finite term via hasSum_ite_eq) and n≥1 (direct comparison).
+- `powers_convergent`: {2^k | k ∈ ℕ} has convergent harmonic sum.
+  Proof: bijection ℕ → powersOf2Set via k↦2^k, reduces to geometric series (1/2)^k.
+- `squares_convergent`: {k^2 | k ≥ 1} has convergent harmonic sum.
+  Proof: bijection ℕ → squaresSet via k↦(k+1)^2, reduces to p-series (convergent for p=2>1).
+- `harmonicPointSet_nonempty`: X_d is non-empty.
+  Proof: use powersOf2Set as witness.
+
+**Remaining sorries (4)**:
+1. `harmonicPointSet_path_connected` — HARD: requires showing X_d is path-connected.
+2. `harmonicPointSet_dense_somewhere` — WRONG STATEMENT: uses globally-dense (`Dense`).
+3. `coordinate_decreasing` — WRONG STATEMENT: FALSE when 0 ∈ A and i=0.
+4. `first_coordinate_largest` — WRONG STATEMENT: depends on coordinate_decreasing.
 
 ---
 
-## Problem Understanding
+## Session 2026-04-21 (Session 3)
 
-[Initial observations about the problem will be recorded here]
+**Mode**: REVISIT  
+**Outcome**: progress (4 sorries eliminated)
 
----
+### Key Findings
+- The n=0 issue: 1/0=0 in Lean, so n=0 elements behave differently under shifting.
+  When i=0 and 0 ∈ A: shiftedHarmonicSum A 0 has 1/0=0 for n=0, but
+  shiftedHarmonicSum A 1 has 1/(0+1)=1, making A 1 > A 0 for pathological A.
+- `coordinate_decreasing` counterexample: A = {0}∪{2^k}. Then shiftedHarmonicSum A 0 ≈ 2
+  but shiftedHarmonicSum A 1 ≈ 3. The theorem needs hypothesis `0 ∉ A`.
+- `harmonicPointSet_dense_somewhere`: `Dense` in Lean = globally dense = closure S = univ.
+  But interior of a proper set is not globally dense. Statement is wrong.
+- `shifted_summable` correct proof uses `hasSum_ite_eq` for the indicator term at n=0.
 
-## Insights
+### Files Modified
+- `proofs/Proofs/Erdos268Problem.lean` (4 sorries proved, wrong statements documented)
+- `src/data/proofs/erdos-268/meta.json` (sorries: 8 → 4)
 
-[Insights from research attempts will be accumulated here]
+### Next Steps
+1. Fix `coordinate_decreasing`: add `0 ∉ A`, prove via tsum_lt_tsum with strict term comparison.
+2. Fix `harmonicPointSet_dense_somewhere`: change Dense to relative density.
+3. Attempt `harmonicPointSet_path_connected` for d=0 (Subsingleton, trivial).
+4. d=1 case: characterize X_1 = Ioi 0 via greedy algorithm (hard).
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- Trying to prove `coordinate_decreasing` without `0 ∉ A`: has counterexample, IMPOSSIBLE.
+- Trying to prove `harmonicPointSet_dense_somewhere` as globally dense: NOT TRUE.
+- `Erdos268Aristotle.lean` proof of `shifted_summable` is incorrect: bound 1/(n+k) ≤ 1/n
+  fails for n=0 (gives 1/k ≤ 0, false). The companion file has this bug.

--- a/src/data/proofs/erdos-268/meta.json
+++ b/src/data/proofs/erdos-268/meta.json
@@ -18,7 +18,7 @@
       "Egyptian-fractions"
     ],
     "badge": "axiom",
-    "sorries": 8,
+    "sorries": 4,
     "erdosNumber": 268,
     "erdosUrl": "https://erdosproblems.com/268",
     "erdosProblemStatus": "solved",

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01",
   "title": "Can Mathlib's Radon-Nikodým machinery (`MeasureTheory",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -16,10 +16,10 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ORIENT",
+    "phase": "ACT",
     "since": "2026-04-03T05:50:14-07:00",
     "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "focus": "3 focused helper sorries remain for full proof of Riesz Lp representation via RN machinery",
     "blockers": [],
     "nextAction": "Read problem.md thoroughly and acquire full context.",
     "attemptCounts": {
@@ -29,13 +29,19 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 2 sorries remain — truncated_rn_deriv_lq_bound (wrong hypothesis) and riesz_lp_surjective_from_rn (full assembly)",
+    "progressSummary": "PROGRESS: Main theorem riesz_lp_surjective_from_rn has 0 sorries; 3 focused helper sorries remain (indicator_lp_hasSum, rnDeriv_integrable_of_finite, holder_extremizer_lq_bound)",
     "builtItems": [
       "integral_representation indicator case: proved (Lp.ext_iff + indicatorConstLp_coeFn + integral_smul chain)",
       "integrationCLM: CLM f↦∫fg via LinearMap.mkContinuous + Hölder bound (no sorry)",
       "integrationCLM_apply: proved (simp unfold)",
       "integral_representation addition+closedness: proved (linearity + isClosed_eq)",
-      "Restored hMCT proof in rn_deriv_memLq (3→2 sorry statements)"
+      "Restored hMCT proof in rn_deriv_memLq (3→2 sorry statements)",
+      "signedMeasureOfFunctional: noncomputable def constructing signed measure E↦φ(1_E) as proper SignedMeasure structure (all fields proved)",
+      "signedMeasureOfFunctional_ac: proved AbsolutelyContinuous — μ(E)=0 → functionalSetFn=0",
+      "signedMeasureOfFunctional_indicator: proved φ(1_E) = signedMeasureOfFunctional(E) equality",
+      "functional_hasSum_parts: proved σ-additivity via HasSum.map (CLM preserves convergence)",
+      "rnDeriv_integral_eq: proved ∫_E g dμ = ν(E) via withDensityᵥ_apply + rn_reconstruction",
+      "riesz_lp_surjective_from_rn: main theorem now 0-sorry, assembles from 3 focused helpers"
     ],
     "insights": [
       "Mathlib HAS Radon-Nikodym (MeasureTheory.Measure.Decomposition.rnDeriv) but NOT the composition with Lp for Riesz",
@@ -44,14 +50,23 @@
       "Surjectivity gap: need (1) φ∈(Lp)* → signed measure ν, (2) ν≪μ, (3) RN deriv g∈Lq, (4) ‖g‖_q=‖φ‖",
       "Estimated 200-500 lines of composition code needed — beyond single session scope",
       "Gap is infrastructure composition, not fundamental mathematical obstacle",
-      "hMCT proof (abs_clamp + sup_min + norm_gn_eq + ptwise_eq + lintegral_iSup) was in PR #10765 but reverted by PR #10806; restored in Session 3"
+      "hMCT proof (abs_clamp + sup_min + norm_gn_eq + ptwise_eq + lintegral_iSup) was in PR #10765 but reverted by PR #10806; restored in Session 3",
+      "Key decomposition: φ → signed measure ν (via σ-additivity) → RN deriv g → Lq membership → full representation",
+      "σ-additivity proof: indicator partial sums HasSum in Lp topology (CLM continuity) → use HasSum.map",
+      "signedMeasureOfFunctional_ac proved without sorry: μ(E)=0 → indicator_{E} = 0 in Lp → φ(0)=0",
+      "Main theorem now assembles cleanly from 3 focused helper sorries: indicator_lp_hasSum, rnDeriv_integrable_of_finite, holder_extremizer_lq_bound",
+      "rnDeriv_integrable_of_finite sketch: Jordan decomp → Integrable.sub (finite measures have integrable RN derivs)"
     ],
     "mathlibGaps": [
       "MeasureTheory: Lp functional → signed measure construction not formalized",
       "MeasureTheory: RN derivative of functional-induced measure → Lq membership not proved",
       "MeasureTheory: Operator norm equality for RN derivative not formalized"
     ],
-    "nextSteps": [],
+    "nextSteps": [
+      "Prove indicator_lp_hasSum (~60 lines): Lp partial sums 1_{f i} → 1_{⋃ f i} in norm using tendsto_measure_iUnion_atTop",
+      "Prove rnDeriv_integrable_of_finite (~20 lines): simp [SignedMeasure.rnDeriv]; apply Integrable.sub + isFiniteMeasure",
+      "Prove holder_extremizer_lq_bound (~50 lines): build h_n=sign(gₙ)|gₙ|^{q-1}∈Lp, use φ(1_E)=∫_E g extension"
+    ],
     "markdown": "# Knowledge Base: cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [],

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Main theorem riesz_lp_surjective_from_rn has 0 sorries; 3 focused helper sorries remain (indicator_lp_hasSum, rnDeriv_integrable_of_finite, holder_extremizer_lq_bound)",
+    "progressSummary": "PROGRESS: holder_extremizer_lq_bound all 3 sorries proved; 2 focused helpers remain (indicator_lp_hasSum, rnDeriv_integrable_of_finite)",
     "builtItems": [
       "integral_representation indicator case: proved (Lp.ext_iff + indicatorConstLp_coeFn + integral_smul chain)",
       "integrationCLM: CLM f↦∫fg via LinearMap.mkContinuous + Hölder bound (no sorry)",
@@ -41,7 +41,10 @@
       "signedMeasureOfFunctional_indicator: proved φ(1_E) = signedMeasureOfFunctional(E) equality",
       "functional_hasSum_parts: proved σ-additivity via HasSum.map (CLM preserves convergence)",
       "rnDeriv_integral_eq: proved ∫_E g dμ = ν(E) via withDensityᵥ_apply + rn_reconstruction",
-      "riesz_lp_surjective_from_rn: main theorem now 0-sorry, assembles from 3 focused helpers"
+      "riesz_lp_surjective_from_rn: main theorem now 0-sorry, assembles from 3 focused helpers",
+      "h_norm_q_eq: eLpNorm gₙ^q = ofReal(∫ hₙ*gₙ) via sign algebra + lintegral chain",
+      "h_hn_norm: ‖hₙ‖_p = S^(q/p) via (q-1)*p=q (HolderConjugate.sub_one_mul_conj) + rpow algebra",
+      "Final ENNReal assembly: eLpNorm gₙ ≤ ofReal ‖φ‖ via S^q=S*S^(q-1), cancel S^(q-1)>0"
     ],
     "insights": [
       "Mathlib HAS Radon-Nikodym (MeasureTheory.Measure.Decomposition.rnDeriv) but NOT the composition with Lp for Riesz",
@@ -55,7 +58,11 @@
       "σ-additivity proof: indicator partial sums HasSum in Lp topology (CLM continuity) → use HasSum.map",
       "signedMeasureOfFunctional_ac proved without sorry: μ(E)=0 → indicator_{E} = 0 in Lp → φ(0)=0",
       "Main theorem now assembles cleanly from 3 focused helper sorries: indicator_lp_hasSum, rnDeriv_integrable_of_finite, holder_extremizer_lq_bound",
-      "rnDeriv_integrable_of_finite sketch: Jordan decomp → Integrable.sub (finite measures have integrable RN derivs)"
+      "rnDeriv_integrable_of_finite sketch: Jordan decomp → Integrable.sub (finite measures have integrable RN derivs)",
+      "hpq.symm.sub_one_mul_conj : (q-1)*p = q — key for |hₙ|^p = |gₙ|^q in norm computation",
+      "hpq.symm.div_conj_eq_sub_one : q/p = q-1 — reduces S^(q/p) to S^(q-1) for cancellation",
+      "ENNReal.toReal_rpow (x^z).toReal = x.toReal^z — use ← to rewrite RHS to (x^z).toReal for rfl",
+      "Lean 4 does not support [_ : T] in theorem signatures — use haveI inside body instead"
     ],
     "mathlibGaps": [
       "MeasureTheory: Lp functional → signed measure construction not formalized",
@@ -63,9 +70,9 @@
       "MeasureTheory: Operator norm equality for RN derivative not formalized"
     ],
     "nextSteps": [
-      "Prove indicator_lp_hasSum (~60 lines): Lp partial sums 1_{f i} → 1_{⋃ f i} in norm using tendsto_measure_iUnion_atTop",
-      "Prove rnDeriv_integrable_of_finite (~20 lines): simp [SignedMeasure.rnDeriv]; apply Integrable.sub + isFiniteMeasure",
-      "Prove holder_extremizer_lq_bound (~50 lines): build h_n=sign(gₙ)|gₙ|^{q-1}∈Lp, use φ(1_E)=∫_E g extension"
+      "Prove rnDeriv_integrable_of_finite (~20 lines): use SignedMeasure.integrable_rnDeriv if available",
+      "Prove indicator_lp_hasSum (~60 lines): Lp norm convergence of indicator partial sums via tendsto_measure_iUnion",
+      "Once both proved: riesz_lp_surjective_from_rn has 0 sorries — file becomes gallery-ready"
     ],
     "markdown": "# Knowledge Base: cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Research session on Erdős #268 (Interior of Harmonic Subseries Points).

**Progress**: Reduced sorry count from 8 to 4 in `Erdos268Problem.lean`.

## Proved This Session

- **`shifted_summable`**: If A has convergent harmonic sum, any shifted version 1/(n+k) is also summable. Key insight: split n=0 case (single finite term via `hasSum_ite_eq`) from n≥1 (direct comparison 1/(n+k) ≤ 1/n).

- **`powers_convergent`**: {2^k | k ∈ ℕ} has convergent harmonic sum. Via bijection ℕ → powersOf2Set (k ↦ 2^k), reduces to geometric series (1/2)^k.

- **`squares_convergent`**: {k² | k ≥ 1} has convergent harmonic sum. Via bijection ℕ → squaresSet (k ↦ (k+1)²), reduces to p-series bound (convergent for p=2 > 1).

- **`harmonicPointSet_nonempty`**: X_d is non-empty. Uses powersOf2Set as an explicit witness.

## Documented as Wrong Statements (4 remaining sorries)

- **`coordinate_decreasing`**: FALSE as stated. Counterexample: A = {0} ∪ {2^k}. When i=0, shiftedHarmonicSum A 0 ≈ 2 but shiftedHarmonicSum A 1 ≈ 3 (the n=0 term contributes 0 to the i=0 sum but 1 to the j=1 sum). Fix: add hypothesis `0 ∉ A`.

- **`first_coordinate_largest`**: Depends on `coordinate_decreasing`, same fix needed.

- **`harmonicPointSet_dense_somewhere`**: Uses `Dense` which means globally dense (closure = univ). But `interior (harmonicPointSet d)` is not globally dense for a proper set. Statement should use relative density.

- **`harmonicPointSet_path_connected`**: Genuinely hard. Trivial for d=0 (Subsingleton). Requires greedy algorithm construction for d=1. Requires deep Kovač-Tao analysis for d≥2.

## Files Modified

- `proofs/Proofs/Erdos268Problem.lean` — 4 sorries proved, 4 documented with root causes
- `src/data/proofs/erdos-268/meta.json` — sorries: 8 → 4
- `research/problems/erdos-268-oq-01/knowledge.md` — session findings

🤖 Generated by researcher-3