### PR TITLE
Fix: add missing summary field to ptolemys-theorem-oq-01-oq-01 sections

### DIFF
--- a/src/data/proofs/ptolemys-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01-oq-01/meta.json
@@ -1,0 +1,135 @@
+{
+  "id": "ptolemys-theorem-oq-01-oq-01",
+  "title": "Ptolemy's Theorem Converse: Equality Characterizes Cyclic Order",
+  "slug": "ptolemys-theorem-oq-01-oq-01",
+  "description": "Proves the converse of Ptolemy's theorem for unit-circle points: if the equality ‖z₁-z₃‖·‖z₂-z₄‖ = ‖z₁-z₂‖·‖z₃-z₄‖ + ‖z₂-z₃‖·‖z₁-z₄‖ holds for four distinct points on the unit circle, then they appear in counterclockwise or clockwise cyclic order. Combined with the forward direction from PtolemysTheoremOQ01, this gives the complete biconditional: Ptolemy equality ↔ CCW or CW order. The proof uses the equality case of the triangle inequality in the strictly convex space ℂ (via SameRay) to extract a positive proportionality constant, then axiomatizes the angular case analysis identifying positive sine-product ratios with cyclic orderings.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Ptolemy%27s_theorem",
+    "date": "2026-04-21",
+    "status": "axiomatized",
+    "tags": [
+      "geometry",
+      "complex-analysis",
+      "ptolemy",
+      "cyclic-quadrilateral",
+      "converse",
+      "intermediate"
+    ],
+    "proofRepoPath": "Proofs/PtolemysTheoremOQ01OQ01.lean",
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 1,
+    "assumptions": "One axiom: `positive_ratio_implies_cyclic_order` — the angular case analysis showing that a positive product of half-angle sines forces CCW or CW order. This follows from the exp factorization in PtolemysTheoremOQ01 and a finite sign analysis of the three interlacing patterns of four angles.",
+    "mathlibDependencies": [
+      {
+        "theorem": "sameRay_iff_norm_add",
+        "description": "In a strictly convex space, SameRay ℝ x y ↔ ‖x + y‖ = ‖x‖ + ‖y‖ (equality case of triangle inequality)",
+        "module": "Mathlib.Analysis.InnerProductSpace.Convex"
+      },
+      {
+        "theorem": "ptolemy_equality_implies_proportional",
+        "description": "Ptolemy equality + nonzero factors → ∃ t>0, t•(z₁-z₂)(z₃-z₄) = (z₂-z₃)(z₁-z₄)",
+        "module": "Proofs.PtolemysComplexProofOQ01"
+      },
+      {
+        "theorem": "ptolemy_equality_for_unit_circle_ccw",
+        "description": "CCW order on unit circle → Ptolemy equality (forward direction)",
+        "module": "Proofs.PtolemysTheoremOQ01"
+      },
+      {
+        "theorem": "norm_sub_rev",
+        "description": "‖a - b‖ = ‖b - a‖, used to convert CW order conclusion to standard form",
+        "module": "Mathlib.Topology.Algebra.Order.LiminfLimsup"
+      }
+    ],
+    "originalContributions": [
+      "ptolemy_equality_implies_ccw_or_cw: Main converse theorem — Ptolemy equality for unit-circle points implies CCW or CW order",
+      "ptolemy_equality_iff_ccw_or_cw: Full biconditional characterization of cyclic quadrilaterals via Ptolemy equality",
+      "IsCWOrder: Definition of clockwise cyclic order as the reverse of CCW order",
+      "FourDistinct: Structure capturing all six pairwise distinctness conditions for four complex points",
+      "ptolemy_of_cw: Ptolemy equality for CW order via relabeling and norm symmetry"
+    ],
+    "lineCount": 250,
+    "theoremCount": 6,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "Ptolemy's theorem (c. 150 AD) states that for a cyclic quadrilateral ABCD in convex position, AC·BD = AB·CD + BC·DA. The question of whether equality alone characterizes concyclic order — the *converse* — was implicit in Ptolemy's work but requires careful proof. In modern terms, it follows from the cross-ratio characterization: for four points on a circle, the cross-ratio R = (z₂-z₃)(z₁-z₄)/((z₁-z₂)(z₃-z₄)) is always real, and R > 0 precisely when the points are in CCW or CW order. This file provides the Lean 4 formalization of the converse direction, completing the full biconditional characterization.",
+    "problemStatement": "**Open Question from PtolemysTheoremOQ01**: The parent proof showed CCW order → Ptolemy equality. Does the converse hold? If four distinct unit-circle points satisfy ‖z₁-z₃‖·‖z₂-z₄‖ = ‖z₁-z₂‖·‖z₃-z₄‖ + ‖z₂-z₃‖·‖z₁-z₄‖, must they be in CCW or CW order?",
+    "text": "The converse of Ptolemy's theorem follows from the strict convexity of the complex plane as a normed space. The Ptolemy equality ‖a+b‖ = ‖a‖ + ‖b‖ (after algebraic rewriting) is exactly the equality case of the triangle inequality, which in a strictly convex space forces a and b to lie on the same ray (SameRay). Since both products are nonzero (four distinct points), this gives a positive proportionality constant. The angular step — identifying positive cross-ratio with cyclic order — uses the exp factorization exp(iα)-exp(iβ) = 2i·sin((α-β)/2)·exp(i(α+β)/2).",
+    "proofStrategy": "**Step 1** (Algebra → Positive proportionality): The Ptolemy equality\n  ‖z₁-z₃‖·‖z₂-z₄‖ = ‖z₁-z₂‖·‖z₃-z₄‖ + ‖z₂-z₃‖·‖z₁-z₄‖\nreduces via the identity (z₁-z₂)(z₃-z₄) + (z₂-z₃)(z₁-z₄) = (z₁-z₃)(z₂-z₄) to the equality case ‖a+b‖ = ‖a‖ + ‖b‖. In the strictly convex space ℂ, this forces SameRay ℝ a b, which (since both are nonzero) gives ∃ t > 0, t•a = b.\n\n**Step 2** (Geometry → Cyclic order): Write zⱼ = exp(iθⱼ). The positive proportionality reduces (after canceling the common exponential phase E₁₂₃₄ and the (2i)² factors) to t·sin((θ₁-θ₂)/2)·sin((θ₃-θ₄)/2) = sin((θ₂-θ₃)/2)·sin((θ₁-θ₄)/2). With t > 0, both sine products have the same sign. Among the three possible interlacing patterns of four distinct angles, only CCW and CW order give equal-sign products.",
+    "keyInsights": [
+      "The algebraic identity (z₁-z₂)(z₃-z₄) + (z₂-z₃)(z₁-z₄) = (z₁-z₃)(z₂-z₄) converts Ptolemy equality to a triangle inequality equality case.",
+      "Strict convexity of ℂ (as a real inner product space) is the key that converts triangle equality to SameRay, hence to positive proportionality.",
+      "The exponential phase factors E₁₂·E₃₄ = E₂₃·E₁₄ cancel exactly in the ratio, leaving a purely real sine-product ratio.",
+      "Three cyclic interlacing patterns exist for four angles; only CCW and CW give equal-sign sine products (the axiom encodes this finite case analysis).",
+      "CW order is handled elegantly by relabeling: IsCCWOrder z₁ z₄ z₃ z₂, then using ‖a-b‖ = ‖b-a‖ and multiplication commutativity."
+    ],
+    "prerequisites": [
+      "Ptolemy equality for CCW order (PtolemysTheoremOQ01)",
+      "SameRay characterization of triangle equality (PtolemysComplexProofOQ01)",
+      "exp difference factorization (PtolemysTheoremOQ01)",
+      "Strict convexity of ℂ as a real inner product space"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-setup",
+      "title": "Definitions: IsCWOrder and FourDistinct",
+      "startLine": 1,
+      "endLine": 60,
+      "summary": "Defines clockwise cyclic order (as CCW order with reversed labels) and a bundled distinctness predicate for four complex points.",
+      "description": "Defines clockwise cyclic order (as CCW order with reversed labels) and a bundled distinctness predicate for four complex points."
+    },
+    {
+      "id": "sec-positivity",
+      "title": "Ptolemy Equality → Positive Proportionality",
+      "startLine": 61,
+      "endLine": 90,
+      "summary": "Combines ptolemy_equality_implies_proportional with distinctness to get positive proportionality via strict convexity.",
+      "description": "Combines ptolemy_equality_implies_proportional with distinctness to get ∃ t>0, t•(z₁-z₂)(z₃-z₄) = (z₂-z₃)(z₁-z₄). This is the algebraic core using strict convexity of ℂ."
+    },
+    {
+      "id": "sec-axiom",
+      "title": "Angular Case Analysis (Axiom)",
+      "startLine": 91,
+      "endLine": 155,
+      "summary": "Axiomatizes the trigonometric step: positive proportionality implies CCW or CW order.",
+      "description": "Axiomatizes the trigonometric step: positive proportionality for unit-circle points → CCW or CW order. Documents the complete proof sketch via exp factorization and sign analysis."
+    },
+    {
+      "id": "sec-main",
+      "title": "Main Theorem: Ptolemy Converse",
+      "startLine": 156,
+      "endLine": 190,
+      "summary": "The main result: Ptolemy equality implies CCW or CW order via two-step composition.",
+      "description": "The main result: ptolemy_equality_implies_ccw_or_cw. Combines ptolemy_eq_implies_pos_prop and positive_ratio_implies_cyclic_order in a two-line proof."
+    },
+    {
+      "id": "sec-biconditional",
+      "title": "Full Biconditional Characterization",
+      "startLine": 191,
+      "endLine": 250,
+      "summary": "Proves the complete biconditional: Ptolemy equality iff CCW or CW order.",
+      "description": "Proves the complete ↔ via ptolemy_equality_iff_ccw_or_cw. The CW direction requires relabeling (z₁,z₄,z₃,z₂) and converting via norm symmetry and product commutativity."
+    }
+  ],
+  "crossReferences": [
+    {
+      "id": "ptolemys-theorem-oq-01",
+      "relationship": "parent",
+      "description": "Proves the forward direction (CCW → equality) and all angular infrastructure (exp_diff_factor, ptolemy_ratio_pos_of_ccw, IsCCWOrder)"
+    },
+    {
+      "id": "ptolemys-complex-proof-oq-01",
+      "relationship": "dependency",
+      "description": "Provides ptolemy_equality_implies_proportional (the equality-case-of-triangle-inequality argument)"
+    },
+    {
+      "id": "ptolemys-theorem",
+      "relationship": "ancestor",
+      "description": "The original Ptolemy theorem formalization using complex numbers"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add missing `summary` field to all 5 sections in `ptolemys-theorem-oq-01-oq-01/meta.json`
- The `ProofSection` TypeScript type requires `summary` but this proof only had `description`
- This was causing build failures (`pnpm build` TS2352 error)

## Test plan
- [x] Verify `pnpm build` passes after this fix