### PR TITLE
Research: prove multinomial Cov(Xi,Xj) = -n·pi·pj (0 sorries)

### DIFF
--- a/proofs/Proofs/BinomialTheoremOQ02OQ01OQ03.lean
+++ b/proofs/Proofs/BinomialTheoremOQ02OQ01OQ03.lean
@@ -1,6 +1,9 @@
 import Mathlib.Data.Nat.Choose.Multinomial
 import Mathlib.Data.Nat.Choose.Sum
 import Mathlib.Algebra.BigOperators.Ring.Finset
+import Mathlib.Analysis.Calculus.Deriv.Add
+import Mathlib.Analysis.Calculus.Deriv.Mul
+import Mathlib.Analysis.Calculus.Deriv.Pow
 import Mathlib.Tactic
 import Proofs.BinomialTheoremOQ02OQ01OQ02
 import Proofs.BinomialTheoremOQ03
@@ -35,7 +38,7 @@ total: more of outcome i necessarily means less of outcome j.
    marginal PMF P(Xᵢ = j) = C(n,j)·pᵢʲ·(1-pᵢ)^(n-j) from BinomialTheoremOQ02OQ01OQ02
    and the binomial mean E[Bin(n,p)] = np from BinomialTheoremOQ03.
 
-2. **E[XᵢXⱼ] = n(n-1)·pᵢ·pⱼ** (sorry): Apply multinomial MGF theorem with
+2. **E[XᵢXⱼ] = n(n-1)·pᵢ·pⱼ**: Apply multinomial MGF theorem with
    g(l) = 1+a if l=i, 1+b if l=j, 1 otherwise. This gives:
      ∑_k P(k)·(1+a)^{k(i)}·(1+b)^{k(j)} = (1 + pᵢa + pⱼb)^n
    Differentiating w.r.t. a at 0 gives ∑_k P(k)·k(i)·(1+b)^{k(j)} = n·pᵢ·(1+pⱼb)^{n-1}.
@@ -96,7 +99,8 @@ theorem multinomial_mean {α : Type*} [DecidableEq α]
   have hmaps_to : ∀ k ∈ s.piAntidiag n, k i₀ ∈ range (n + 1) := fun k hk => by
     rw [mem_range]
     have hle : k i₀ ≤ ∑ l ∈ s, k l :=
-      Finset.single_le_sum (fun l _ => Nat.zero_le _) s hi₀
+      Finset.single_le_sum (fun l _ => Nat.zero_le _) hi₀
+    have hsum : ∑ l ∈ s, k l = n := (Finset.mem_piAntidiag.mp hk).1
     omega
   -- Fiber grouping
   rw [← sum_fiberwise_of_maps_to hmaps_to]
@@ -134,31 +138,197 @@ theorem multinomial_mean {α : Type*} [DecidableEq α]
 
 /-- **Cross-moment of multinomial components**: E[XᵢXⱼ] = n·(n-1)·p(i)·p(j) for i ≠ j.
 
-    ## Proof Sketch
+    Proof via bivariate MGF differentiation:
 
-    Apply `multinomial_mgf_real` with g(l) = (1+a) if l=i, (1+b) if l=j, 1 otherwise:
+    Step 1: Prove ∀ a b, ∑_k P(k)·(1+a)^{k(i)}·(1+b)^{k(j)} = (1+pᵢa+pⱼb)^n  [MGF]
 
-      ∑_k P(k)·(1+a)^{k(i)}·(1+b)^{k(j)} = (1 + pᵢa + pⱼb)^n         (*)
+    Step 2: Differentiate w.r.t. a at 0 (HasDerivAt.sum + chain rule):
+      ∑_k P(k)·k(i)·(1+b)^{k(j)} = n·pᵢ·(1+pⱼb)^{n-1}
 
-    (using ∑_l pₗ·gₗ = 1 + pᵢa + pⱼb since ∑ pₗ = 1 and ∏ gₗ^{kₗ} = (1+a)^{k(i)}·(1+b)^{k(j)})
-
-    Differentiate (*) w.r.t. a at a=0 (using `HasDerivAt.sum` on the LHS):
-      ∑_k P(k)·k(i)·(1+b)^{k(j)} = n·pᵢ·(1 + pⱼb)^{n-1}             (**)
-
-    Differentiate (**) w.r.t. b at b=0:
-      ∑_k P(k)·k(i)·k(j) = n·pᵢ·(n-1)·pⱼ·(1 + 0)^{n-2} = n(n-1)pᵢpⱼ  ✓
-
-    The HasDerivAt proof requires:
-    - `HasDerivAt.sum` for the finite sum
-    - `HasDerivAt.pow` + chain rule for (1+a)^m and (1+pᵢa+pⱼb)^n
-    - Careful treatment of 0^{m-1} via `Nat.cast_nonneg` and `one_pow` -/
+    Step 3: Differentiate w.r.t. b at 0:
+      ∑_k P(k)·k(i)·k(j) = n·pᵢ·(n-1)·pⱼ = n(n-1)pᵢpⱼ  ✓  -/
 theorem multinomial_cross_moment {α : Type*} [DecidableEq α]
     (s : Finset α) (p : α → ℝ) (n : ℕ)
     (hp_sum : ∑ i ∈ s, p i = 1) (hp_nonneg : ∀ i ∈ s, 0 ≤ p i)
     (i j : α) (hi : i ∈ s) (hj : j ∈ s) (hij : i ≠ j) :
     ∑ k ∈ s.piAntidiag n, (k i : ℝ) * (k j : ℝ) * multinomialProb s p n k =
     n * (↑n - 1) * p i * p j := by
-  sorry
+  -- Helper: (1+a)^m has derivative m at a=0
+  have deriv_add_pow : ∀ (m : ℕ),
+      HasDerivAt (fun a : ℝ => (1 + a) ^ m) (↑m) 0 := fun m => by
+    have h := (hasDerivAt_pow m (1 + (0 : ℝ))).comp 0
+                ((hasDerivAt_id (0 : ℝ)).const_add 1)
+    simp only [Function.comp, add_zero, one_pow, mul_one] at h
+    exact h
+  -- Bivariate MGF: ∑_k P(k)*(1+a)^{ki}*(1+b)^{kj} = (1+pi*a+pj*b)^n
+  have hmgf : ∀ (a b : ℝ),
+      ∑ k ∈ s.piAntidiag n,
+        multinomialProb s p n k * (1 + a) ^ k i * (1 + b) ^ k j =
+      (1 + p i * a + p j * b) ^ n := by
+    intro a b
+    -- Product formula: ∏_l g_l^{k_l} = (1+a)^{ki} * (1+b)^{kj}
+    have hprod : ∀ k : α → ℕ,
+        ∏ l ∈ s, (if l = i then 1 + a else if l = j then 1 + b else (1 : ℝ)) ^ k l =
+        (1 + a) ^ k i * (1 + b) ^ k j := fun k => by
+      rw [← Finset.mul_prod_erase s _ hi,
+          ← Finset.mul_prod_erase (s.erase i) _
+              (Finset.mem_erase.mpr ⟨hij.symm, hj⟩)]
+      have hgi : (if i = i then 1 + a else if i = j then 1 + b else (1 : ℝ)) ^ k i =
+                 (1 + a) ^ k i := by simp
+      have hgj : (if j = i then 1 + a else if j = j then 1 + b else (1 : ℝ)) ^ k j =
+                 (1 + b) ^ k j := by simp [hij.symm]
+      have hrest : ∏ x ∈ (s.erase i).erase j,
+          (if x = i then 1 + a else if x = j then 1 + b else (1 : ℝ)) ^ k x = 1 := by
+        apply Finset.prod_eq_one; intro l hl
+        have hli : l ≠ i := (Finset.mem_erase.mp (Finset.mem_erase.mp hl).2).1
+        have hlj : l ≠ j := (Finset.mem_erase.mp hl).1
+        simp [hli, hlj]
+      rw [hgi, hgj, hrest]; ring
+    -- Sum formula: ∑_l p_l * g_l = 1 + pi*a + pj*b
+    have hsum_g : ∑ l ∈ s,
+        p l * (if l = i then 1 + a else if l = j then 1 + b else (1 : ℝ)) =
+        1 + p i * a + p j * b := by
+      rw [← Finset.add_sum_erase s _ hi,
+          ← Finset.add_sum_erase (s.erase i) _
+              (Finset.mem_erase.mpr ⟨hij.symm, hj⟩)]
+      have hgi : p i * (if i = i then 1 + a else if i = j then 1 + b else (1 : ℝ)) =
+                 p i * (1 + a) := by simp
+      have hgj : p j * (if j = i then 1 + a else if j = j then 1 + b else (1 : ℝ)) =
+                 p j * (1 + b) := by simp [hij.symm]
+      have hrest : ∑ l ∈ (s.erase i).erase j,
+          p l * (if l = i then 1 + a else if l = j then 1 + b else (1 : ℝ)) =
+          ∑ l ∈ (s.erase i).erase j, p l := by
+        apply Finset.sum_congr rfl; intro l hl
+        have hli := (Finset.mem_erase.mp (Finset.mem_erase.mp hl).2).1
+        have hlj := (Finset.mem_erase.mp hl).1
+        simp [hli, hlj]
+      have hprest : ∑ l ∈ (s.erase i).erase j, p l = 1 - p i - p j := by
+        have h1 := (Finset.add_sum_erase s p hi).symm
+        have h2 := (Finset.add_sum_erase (s.erase i) p
+              (Finset.mem_erase.mpr ⟨hij.symm, hj⟩)).symm
+        linarith [hp_sum]
+      rw [hgi, hgj, hrest, hprest]; ring
+    -- Convert to BinomialTheoremOQ02OQ01OQ02 form and apply MGF theorem
+    have h_eq_sum : ∑ k ∈ s.piAntidiag n,
+        multinomialProb s p n k * (1 + a) ^ k i * (1 + b) ^ k j =
+      ∑ k ∈ s.piAntidiag n,
+        BinomialTheoremOQ02OQ01OQ02.multinomialProb s p n k *
+        ∏ l ∈ s, (if l = i then 1 + a else if l = j then 1 + b else (1 : ℝ)) ^ k l := by
+      apply Finset.sum_congr rfl; intro k _
+      rw [multinomialProb_eq, hprod k]; ring
+    rw [h_eq_sum, ← BinomialTheoremOQ02OQ01OQ02.multinomial_mgf_real, hsum_g]
+  -- Step 1: Differentiate w.r.t. a at 0
+  -- Result: ∑_k P(k)*ki*(1+b)^{kj} = n*pi*(1+pj*b)^(n-1)
+  have hstep1 : ∀ b : ℝ,
+      ∑ k ∈ s.piAntidiag n,
+        multinomialProb s p n k * (k i : ℝ) * (1 + b) ^ k j =
+      n * p i * (1 + p j * b) ^ (n - 1) := fun b => by
+    -- LHS: derivative of a-parameterized sum at a=0
+    have hd_lhs : HasDerivAt
+        (fun a => ∑ k ∈ s.piAntidiag n,
+          multinomialProb s p n k * (1 + a) ^ k i * (1 + b) ^ k j)
+        (∑ k ∈ s.piAntidiag n,
+          multinomialProb s p n k * (k i : ℝ) * (1 + b) ^ k j)
+        0 := by
+      have key : ∀ k ∈ s.piAntidiag n,
+          HasDerivAt (fun a => multinomialProb s p n k * (1 + a) ^ k i * (1 + b) ^ k j)
+            (multinomialProb s p n k * (k i : ℝ) * (1 + b) ^ k j) 0 := fun k _ => by
+        have hd1 := deriv_add_pow (k i)
+        have hd2 := (hd1.const_mul (multinomialProb s p n k)).mul_const ((1 + b) ^ k j)
+        convert hd2 using 1
+      have h := HasDerivAt.sum key
+      have feq : (∑ k ∈ s.piAntidiag n, fun a =>
+            multinomialProb s p n k * (1 + a) ^ k i * (1 + b) ^ k j) =
+          (fun a => ∑ k ∈ s.piAntidiag n,
+            multinomialProb s p n k * (1 + a) ^ k i * (1 + b) ^ k j) :=
+        funext fun a => Finset.sum_apply _ _ _
+      rw [feq] at h; exact h
+    -- RHS: derivative of (1+pi*a+pj*b)^n at a=0
+    have hd_rhs : HasDerivAt
+        (fun a => (1 + p i * a + p j * b : ℝ) ^ n)
+        (n * p i * (1 + p j * b) ^ (n - 1))
+        0 := by
+      have hinner : HasDerivAt (fun a : ℝ => 1 + p i * a + p j * b) (p i) 0 := by
+        have h1 : HasDerivAt (fun a : ℝ => p i * a) (p i * 1) 0 :=
+          (hasDerivAt_id (0 : ℝ)).const_mul (p i)
+        have h2 : HasDerivAt (fun a : ℝ => p i * a + p j * b) (p i * 1) 0 :=
+          h1.add_const _
+        have h3 : HasDerivAt (fun a : ℝ => 1 + (p i * a + p j * b)) (p i * 1) 0 :=
+          h2.const_add 1
+        simp only [mul_one] at h3
+        convert h3 using 1; funext a; ring
+      have houter : HasDerivAt (fun x : ℝ => x ^ n) (↑n * (1 + p i * 0 + p j * b) ^ (n - 1))
+          (1 + p i * 0 + p j * b) :=
+        hasDerivAt_pow n _
+      -- comp before simp so base points match syntactically
+      have hcomp := houter.comp 0 hinner
+      simp only [mul_zero, add_zero, Function.comp] at hcomp
+      convert hcomp using 1; ring
+    have hfg : (fun a => ∑ k ∈ s.piAntidiag n,
+          multinomialProb s p n k * (1 + a) ^ k i * (1 + b) ^ k j) =
+              fun a => (1 + p i * a + p j * b : ℝ) ^ n :=
+      funext (fun a => hmgf a b)
+    rw [hfg] at hd_lhs
+    linarith [hd_lhs.unique hd_rhs]
+  -- Step 2: Differentiate w.r.t. b at 0
+  -- Result: ∑_k P(k)*ki*kj = n*(n-1:ℕ)*pi*pj
+  have hstep2 : ∑ k ∈ s.piAntidiag n,
+      multinomialProb s p n k * (k i : ℝ) * (k j : ℝ) =
+      n * ↑(n - 1) * p i * p j := by
+    have hd_lhs : HasDerivAt
+        (fun b => ∑ k ∈ s.piAntidiag n,
+          multinomialProb s p n k * (k i : ℝ) * (1 + b) ^ k j)
+        (∑ k ∈ s.piAntidiag n,
+          multinomialProb s p n k * (k i : ℝ) * (k j : ℝ))
+        0 := by
+      have key : ∀ k ∈ s.piAntidiag n,
+          HasDerivAt (fun b => multinomialProb s p n k * (k i : ℝ) * (1 + b) ^ k j)
+            (multinomialProb s p n k * (k i : ℝ) * (k j : ℝ)) 0 := fun k _ => by
+        have hd1 := deriv_add_pow (k j)
+        have hd2 := hd1.const_mul (multinomialProb s p n k * (k i : ℝ))
+        convert hd2 using 1 <;> ring
+      have h := HasDerivAt.sum key
+      have feq : (∑ k ∈ s.piAntidiag n, fun b =>
+            multinomialProb s p n k * (k i : ℝ) * (1 + b) ^ k j) =
+          (fun b => ∑ k ∈ s.piAntidiag n,
+            multinomialProb s p n k * (k i : ℝ) * (1 + b) ^ k j) :=
+        funext fun b => Finset.sum_apply _ _ _
+      rw [feq] at h; exact h
+    have hd_rhs : HasDerivAt
+        (fun b => (n : ℝ) * p i * (1 + p j * b) ^ (n - 1))
+        (n * ↑(n - 1) * p i * p j)
+        0 := by
+      have hinner : HasDerivAt (fun b : ℝ => 1 + p j * b) (p j) 0 := by
+        have h1 : HasDerivAt (fun b : ℝ => p j * b) (p j * 1) 0 :=
+          (hasDerivAt_id (0 : ℝ)).const_mul (p j)
+        have h2 := h1.const_add (1 : ℝ)
+        simp only [mul_one] at h2
+        exact h2
+      have houter : HasDerivAt (fun x : ℝ => x ^ (n - 1))
+          (↑(n - 1) * (1 + p j * 0) ^ ((n - 1) - 1)) (1 + p j * 0) :=
+        hasDerivAt_pow (n - 1) _
+      -- comp before simp so base points match syntactically
+      have hcomp := houter.comp 0 hinner
+      simp only [mul_zero, add_zero, one_pow, mul_one] at hcomp
+      -- hcomp : HasDerivAt (fun b => (1+pj*b)^(n-1)) (↑(n-1) * pj) 0
+      have hscaled := hcomp.const_mul ((n : ℝ) * p i)
+      -- hscaled : HasDerivAt (fun b => n*pi*(1+pj*b)^(n-1)) (n*pi*(↑(n-1)*pj)) 0
+      convert hscaled using 1; ring
+    have hfg : (fun b => ∑ k ∈ s.piAntidiag n,
+          multinomialProb s p n k * (k i : ℝ) * (1 + b) ^ k j) =
+              fun b => (n : ℝ) * p i * (1 + p j * b) ^ (n - 1) :=
+      funext hstep1
+    rw [hfg] at hd_lhs
+    linarith [hd_lhs.unique hd_rhs]
+  -- Reorder multiplication and cast n-1 to match goal
+  rw [show ∑ k ∈ s.piAntidiag n, (k i : ℝ) * (k j : ℝ) * multinomialProb s p n k =
+          ∑ k ∈ s.piAntidiag n, multinomialProb s p n k * (k i : ℝ) * (k j : ℝ) from
+    Finset.sum_congr rfl (fun k _ => by ring)]
+  rw [hstep2]
+  -- (n-1:ℕ):ℝ = (n:ℝ)-1 when n≥1; both sides 0 when n=0
+  rcases Nat.eq_zero_or_pos n with rfl | hn
+  · simp
+  · rw [Nat.cast_pred hn]
 
 /-! ## Main Theorem: Covariance = -n·pᵢ·pⱼ -/
 
@@ -203,20 +373,20 @@ theorem multinomial_covariance {α : Type*} [DecidableEq α]
 /-
 ## Results
 
-### Proved (0 axioms):
-1. `multinomialProb_sum_one`  — Normalization ∑ P(k) = 1
-2. `multinomial_mean`         — E[Xᵢ] = n·pᵢ (complete proof via fiber grouping)
-3. `multinomial_covariance`   — Cov(Xᵢ,Xⱼ) = -npᵢpⱼ (modulo cross_moment)
-
-### Sorries (1):
-4. `multinomial_cross_moment` — E[XᵢXⱼ] = n(n-1)pᵢpⱼ
-   Proof: Differentiate the joint MGF (∑ P(k)·(1+a)^{k(i)}·(1+b)^{k(j)} = (1+pᵢa+pⱼb)^n)
-   twice using HasDerivAt: ∂/∂a at 0, then ∂/∂b at 0.
+### Proved (0 axioms, 0 sorries):
+1. `multinomialProb_sum_one`   — Normalization ∑ P(k) = 1
+2. `multinomial_mean`          — E[Xᵢ] = n·pᵢ (complete proof via fiber grouping)
+3. `multinomial_cross_moment`  — E[XᵢXⱼ] = n(n-1)pᵢpⱼ (via bivariate MGF differentiation)
+4. `multinomial_covariance`    — Cov(Xᵢ,Xⱼ) = -npᵢpⱼ
 
 ### Key Mathematical Content:
 The covariance formula -npᵢpⱼ is an exact algebraic consequence of:
   E[XᵢXⱼ] = n(n-1)pᵢpⱼ and E[Xᵢ]E[Xⱼ] = n²pᵢpⱼ
   ⟹ Cov = n(n-1)pᵢpⱼ - n²pᵢpⱼ = -npᵢpⱼ ✓
+
+The cross-moment proof uses differentiation of the bivariate MGF:
+  (∑_l pₗ·gₗ)^n = ∑_k P(k)·∏_l gₗ^{kₗ}   [multinomial_mgf_real]
+with gₗ = (1+a) for l=i, (1+b) for l=j, 1 otherwise.
 -/
 
 end BinomialTheoremOQ02OQ01OQ03

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-03.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-03.json
@@ -1,8 +1,8 @@
 {
   "slug": "binomial-theorem-oq-02-oq-01-oq-03",
   "title": "Prove variance-covariance Cov(Xi,Xj) = -n*pi*pj in Lean",
-  "phase": "ACT",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "fast",
   "problemStatement": {
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ACT",
-    "since": "2026-04-05T03:58:33.672Z",
-    "iteration": 1,
-    "focus": "multinomial_cross_moment sorry remaining; mean and covariance structure complete",
+    "phase": "COMPLETED",
+    "since": "2026-04-21T00:00:00.000Z",
+    "iteration": 2,
+    "focus": "COMPLETE: all theorems proved, 0 sorries",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Done.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,28 +29,26 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Mean proved (0 sorries), covariance structure proved (1 sorry for cross-moment)",
+    "progressSummary": "COMPLETE: All theorems proved, 0 sorries, 0 axioms",
     "builtItems": [
       "multinomial_mean in Proofs/BinomialTheoremOQ02OQ01OQ03.lean — complete proof via fiber grouping",
-      "multinomial_covariance in Proofs/BinomialTheoremOQ02OQ01OQ03.lean — proved given cross-moment",
+      "multinomial_cross_moment in Proofs/BinomialTheoremOQ02OQ01OQ03.lean — E[XiXj]=n(n-1)pipj via bivariate MGF + HasDerivAt twice",
+      "multinomial_covariance in Proofs/BinomialTheoremOQ02OQ01OQ03.lean — Cov(Xi,Xj)=-n*pi*pj, fully proved, 0 sorries",
       "gallery entry at src/data/proofs/binomial-theorem-oq-02-oq-01-oq-03/"
     ],
     "insights": [
       "E[Xi] = n*pi proved fully via fiber grouping + sum_fiberwise_of_maps_to",
       "Fiber grouping reduces ∑_k k(i₀)*P(k) to ∑_j j*binomPMF(n,p,j) using multinomial_marginal_pmf",
-      "multinomial_covariance fully proved modulo cross-moment: Cov = n(n-1)pipj - n²pipj = -npipj",
-      "Cross-moment E[Xi*Xj] = n(n-1)pipj: proof sketch via joint MGF differentiation (HasDerivAt twice)",
+      "multinomial_cross_moment proved via bivariate MGF: differentiate ∑P(k)*(1+a)^{k(i)}*(1+b)^{k(j)} = (1+pi*a+pj*b)^n w.r.t. a then b at 0",
+      "HasDerivAt.sum needs explicit funext bridge: (∑ k, fun a => f k a) ≠ (fun a => ∑ k, f k a) definitionally in Lean 4 unification; use funext + Finset.sum_apply",
+      "HasDerivAt.comp requires base points to match syntactically before simp — do comp first, simp after",
+      "Finset.piAntidiag membership in current Mathlib4: sum is .1 (first conjunct), not .2",
+      "Finset.single_le_sum API: takes (hf) (hi : i ∈ s), no explicit s argument",
       "key Lean tactic: exact_mod_cast handles ℕ→ℝ cast when replacing k(i₀) with j on a filter",
       "binomial_mean_all extends BinomialTheoremOQ03.binomial_mean to n=0 case via rcases"
     ],
-    "mathlibGaps": [
-      "HasDerivAt machinery needed to differentiate finite sums of (1+a)^k type polynomials",
-      "No joint multinomial PMF formula P(Xi=a, Xj=b) in the codebase (needed for direct cross-moment proof)"
-    ],
-    "nextSteps": [
-      "Prove multinomial_cross_moment via HasDerivAt: differentiate ∑P(k)*(1+a)^{k(i)}*(1+b)^{k(j)} = (1+pi*a+pj*b)^n twice",
-      "Alternative: prove joint PMF P(Xi=a,Xj=b) = C(n;a,b,n-a-b)*pi^a*pj^b*(1-pi-pj)^{n-a-b} via bijection like OQ02"
-    ]
+    "mathlibGaps": [],
+    "nextSteps": []
   },
   "tags": [
     "probability",
@@ -188,11 +186,11 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ03.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ03.lean",
-      "lineCount": 223,
+      "lineCount": 392,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ01OQ03.lean"
     },


### PR DESCRIPTION
## Summary

- Proves `multinomial_cross_moment`: E[XᵢXⱼ] = n·(n-1)·pᵢ·pⱼ via bivariate MGF differentiation
- Eliminates the sole `sorry` in `BinomialTheoremOQ02OQ01OQ03.lean`
- `multinomial_covariance: Cov(Xᵢ,Xⱼ) = -n·pᵢ·pⱼ` now fully proved: **0 sorries, 0 axioms**

## Proof Technique

Differentiates the joint MGF identity twice using `HasDerivAt`:

```
∑_k P(k)·(1+a)^{k(i)}·(1+b)^{k(j)} = (1 + pᵢ·a + pⱼ·b)^n
```

- Step 1: ∂/∂a at a=0 → `∑_k P(k)·k(i)·(1+b)^{k(j)} = n·pᵢ·(1+pⱼ·b)^{n-1}`
- Step 2: ∂/∂b at b=0 → `E[XᵢXⱼ] = n·(n-1)·pᵢ·pⱼ`

## Key Lean 4 Lessons

- `HasDerivAt.sum` requires `funext + Finset.sum_apply` to bridge `(∑ k, fun a => f k a)` vs `(fun a => ∑ k, f k a)`
- `HasDerivAt.comp` requires `.comp` before `simp` — base points must match syntactically
- `Finset.piAntidiag` membership in current Mathlib4: sum conjunct is `.1`
- `Finset.single_le_sum` API takes `(hf) (hi)`, no explicit `s` argument

🤖 Generated with [Claude Code](https://claude.com/claude-code)