### PR TITLE
Research: Add Fischler-Sprang-Zudilin 2019 axiom to basel-problem-oq-02

### DIFF
--- a/proofs/Proofs/BaselProblemOQ02.lean
+++ b/proofs/Proofs/BaselProblemOQ02.lean
@@ -236,6 +236,23 @@ axiom zudilin_theorem :
   Irrational (zetaValue 5) ∨ Irrational (zetaValue 7) ∨
   Irrational (zetaValue 9) ∨ Irrational (zetaValue 11)
 
+/-- **Fischler–Sprang–Zudilin (2019)**: A quantitative strengthening of Rivoal's theorem.
+    Among the odd zeta values ζ(3), ζ(5), ..., ζ(2s+1), for any ε ∈ (0,1) and all
+    sufficiently large s, at least (1−ε)·log(s)/(1+log 2) of them are irrational.
+
+    Formally: for each ε ∈ (0,1) there is a threshold s₀ such that for all s ≥ s₀,
+    there exists a finite set S ⊆ {1,...,s} with |S| ≥ (1−ε)·log(s)/(1+log 2)
+    and ζ(2k+1) irrational for every k ∈ S.
+
+    This dramatically strengthens Rivoal's qualitative "infinitely many" to a
+    logarithmic lower bound — the current state of the art on odd zeta irrationality.
+    Reference: Compositio Mathematica 155(5), pp. 938–952, 2019. Not yet in Mathlib. -/
+axiom fischler_sprang_zudilin_2019 (ε : ℝ) (hε : 0 < ε) (hε1 : ε < 1) :
+    ∃ s₀ : ℕ, ∀ s : ℕ, s₀ ≤ s →
+      ∃ (S : Finset ℕ),
+        (1 - ε) * Real.log s / (1 + Real.log 2) ≤ (S.card : ℝ) ∧
+        ∀ k ∈ S, k ≤ s ∧ 1 ≤ k ∧ Irrational (zetaValue (2 * k + 1))
+
 -- ============================================================================
 -- ## Part 9: The Irrationality Landscape
 -- ============================================================================

--- a/src/data/proofs/basel-problem-oq-02/meta.json
+++ b/src/data/proofs/basel-problem-oq-02/meta.json
@@ -4,7 +4,7 @@
   "slug": "basel-problem-oq-02",
   "description": "Formalizes the open question: are all odd zeta values ζ(2k+1) transcendental? Proves even zeta transcendence (ζ(2), ζ(4)) from Lindemann axiom, axiomatizes Apéry's theorem (ζ(3) irrational), and establishes structural implications: transcendence conjecture ⟹ irrationality conjecture ⟹ known results.",
   "meta": {
-    "author": "Open (Lindemann 1882, Apéry 1978, Rivoal 2000, Zudilin 2001)",
+    "author": "Open (Lindemann 1882, Apéry 1978, Rivoal 2000, Zudilin 2001, Fischler–Sprang–Zudilin 2019)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Riemann_zeta_function",
     "date": "2000",
     "status": "axiomatized",
@@ -51,9 +51,9 @@
       "Proved conjecture_implies_all_known: transcendence conjecture recovers all known results (sorry-free)"
     ],
     "dateAdded": "2026-03-24",
-    "axiomCount": 4,
-    "lineCount": 331,
-    "assumptions": "4 axiom(s): Lindemann (π transcendental), Apéry (ζ(3) irrational), Rivoal (infinitely many odd ζ irrational), Zudilin (one of ζ(5,7,9,11) irrational). Even-zeta transcendence (ζ(2), ζ(4)) fully proved from Lindemann axiom. Structural implications proved sorry-free. 0 sorries.",
+    "axiomCount": 5,
+    "lineCount": 348,
+    "assumptions": "5 axiom(s): Lindemann (π transcendental), Apéry (ζ(3) irrational), Rivoal (infinitely many odd ζ irrational), Zudilin (one of ζ(5,7,9,11) irrational), Fischler-Sprang-Zudilin 2019 (quantitative: ≥(1-ε)·log(s)/(1+log 2) irrational odd ζ values among first s). Even-zeta transcendence (ζ(2), ζ(4)) fully proved from Lindemann axiom. Structural implications proved sorry-free. 0 sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -243,8 +243,8 @@
       "Polynomial"
     ],
     "namespace": "BaselProblemOQ02",
-    "lineCount": 331,
-    "axiomCount": 4,
+    "lineCount": 348,
+    "axiomCount": 5,
     "theoremCount": 20,
     "definitionCount": 6,
     "path": "Proofs/BaselProblemOQ02.lean",

--- a/src/data/research/problems/basel-problem-oq-02.json
+++ b/src/data/research/problems/basel-problem-oq-02.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: Restored Rivoal/Zudilin axioms and structural implications lost in refactoring. File now has 4 axioms, 20 theorems, 0 sorries.",
+    "progressSummary": "COMPLETE: 5 axioms (Lindemann, Apery, Rivoal, Zudilin, FSZ-2019), 20 theorems, 0 sorries. Added Fischler-Sprang-Zudilin 2019 quantitative axiom completing state-of-the-art coverage.",
     "builtItems": [
       "Created proofs/Proofs/BaselProblemOQ02.lean (109 lines)",
       "Proved zetaValue_two and zetaValue_four from Mathlib",
@@ -54,7 +54,8 @@
       "Restored axiom zudilin_theorem (4-way disjunction: one of ζ(5,7,9,11) irrational)",
       "Restored conjecture_implies_rivoal (sorry-free proof)",
       "Restored conjecture_implies_zudilin (sorry-free proof)",
-      "Restored conjecture_implies_all_known (sorry-free summary theorem)"
+      "Restored conjecture_implies_all_known (sorry-free summary theorem)",
+      "Added axiom fischler_sprang_zudilin_2019: quantitative Rivoal bound in Lean (BaselProblemOQ02.lean:238-258)"
     ],
     "insights": [
       "Stark even/odd divide: ζ(2k) = rational × π^(2k) (fully understood since Euler 1734), but ζ(2k+1) has no closed form",
@@ -69,7 +70,8 @@
       "IsAlgebraic.mul + isAlgebraic_algebraMap gives clean transcendence proofs without explicit polynomial construction",
       "Polynomial.natDegree_comp enables comp_ne_zero_of_pos_natDegree via case analysis on constant vs positive-degree polynomials",
       "algebraMap ℚ ℝ is definitionally Rat.cast; push_cast handles the conversion cleanly",
-      "Rivoal/Zudilin axioms and structural implications were lost in refactoring commit 39fb3769a8, restored from 1499a0b513"
+      "Rivoal/Zudilin axioms and structural implications were lost in refactoring commit 39fb3769a8, restored from 1499a0b513",
+      "Fischler-Sprang-Zudilin 2019 (Compositio Math) gives quantitative Rivoal: ≥(1-ε)log(s)/(1+log2) of ζ(3),...,ζ(2s+1) are irrational; axiomatized as fischler_sprang_zudilin_2019 in Lean file"
     ],
     "mathlibGaps": [],
     "nextSteps": []


### PR DESCRIPTION
## Summary

- Adds `fischler_sprang_zudilin_2019` as the 5th axiom in `BaselProblemOQ02.lean`
- This is the Compositio Mathematica 2019 result: at least (1−ε)·log(s)/(1+log 2) of ζ(3),...,ζ(2s+1) are irrational — the quantitative strengthening of Rivoal's theorem and the current state-of-the-art on odd zeta irrationality
- The paper was already in the `references` section of meta.json but not axiomatized in Lean
- Updates `axiomCount` from 4 to 5, `lineCount` from 331 to 348, `assumptions` field
- **0 sorries** (no regression from current 0-sorry state)

## Files Changed

- `proofs/Proofs/BaselProblemOQ02.lean`: +17 lines (FSZ axiom with full docstring)
- `src/data/proofs/basel-problem-oq-02/meta.json`: axiomCount 4→5, lineCount 331→348, assumptions updated
- `src/data/research/problems/basel-problem-oq-02.json`: knowledge updated (insight + builtItem)

## Axiom Integrity Check

All 5 axioms correctly counted: Lindemann (π transcendental), Apéry (ζ(3) irrational), Rivoal (infinitely many odd ζ irrational), Zudilin (one of ζ(5,7,9,11) irrational), Fischler-Sprang-Zudilin 2019 (quantitative Rivoal bound). No structure-encoded assumptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)