### PR TITLE
Research: bertrands-postulate-oq-03-oq-04 Aristotle sorries (2→0)

### DIFF
--- a/proofs/Proofs/BertrandsPostulateOQ03OQ04Aristotle.lean
+++ b/proofs/Proofs/BertrandsPostulateOQ03OQ04Aristotle.lean
@@ -9,9 +9,8 @@
   - Clean theorem statements with no definition sorries
   - No axiom declarations
 
-  Status: 2 sorries in long_interval_density_from_pnt:
-  (1) pnt_1c_logx_tendsto: Combining pnt_1c and log_ratio via Filter.Tendsto.mul + congr
-  (2) long_interval_density_from_pnt': Algebraic combination of step 1 and PNT via Tendsto.sub
+  Status: 0 sorries — all proofs complete.
+  Proofs mirror BertrandsPostulateOQ03OQ04OQ03.lean (pnt_at_scaled_point, pnt_density_long_interval).
 -/
 import Mathlib.NumberTheory.PrimeCounting
 import Mathlib.Analysis.SpecificLimits.Basic
@@ -63,7 +62,24 @@ lemma log_ratio_tendsto_one (c : ℝ) (hc : c > 0) :
 lemma pnt_1c_logx_tendsto (c : ℝ) (hc : c > 0) :
     Tendsto (fun x : ℝ =>
       (primePi ((1 + c) * x) : ℝ) * Real.log x / ((1 + c) * x)) atTop (𝓝 1) := by
-  sorry
+  have h1c_pos : (0 : ℝ) < 1 + c := by linarith
+  -- PNT at (1+c)x via composition with scaling x ↦ (1+c)x
+  have pnt_1c : Tendsto (fun x : ℝ =>
+      (primePi ((1 + c) * x) : ℝ) * Real.log ((1 + c) * x) / ((1 + c) * x)) atTop (𝓝 1) :=
+    primeNumberTheorem.comp (Filter.Tendsto.const_mul_atTop h1c_pos tendsto_id)
+  -- log(x)/log((1+c)x) → 1
+  have hlog_ratio := log_ratio_tendsto_one c hc
+  -- Product: [π·log(y)/y] · [log(x)/log(y)] → 1·1 = 1, then log(y) cancels
+  have hmul := pnt_1c.mul hlog_ratio
+  rw [mul_one] at hmul
+  refine hmul.congr' ?_
+  filter_upwards [eventually_gt_atTop (1 : ℝ)] with x hx
+  have hx_pos : (0 : ℝ) < x := by linarith
+  have h1cx_pos : (0 : ℝ) < (1 + c) * x := mul_pos h1c_pos hx_pos
+  have hlog1cx_ne : Real.log ((1 + c) * x) ≠ 0 :=
+    ne_of_gt (Real.log_pos (by nlinarith))
+  field_simp
+  ring
 
 /-- Aristotle target: Density asymptotic for intervals of length cx from PNT.
 
@@ -76,7 +92,32 @@ lemma long_interval_density_from_pnt' (c : ℝ) (hc : c > 0) :
     Tendsto (fun x : ℝ =>
       ((primePi ((1 + c) * x) : ℝ) - (primePi x : ℝ)) * Real.log x / (c * x))
       atTop (𝓝 1) := by
-  sorry
+  have h1c_pos : (0 : ℝ) < 1 + c := by linarith
+  have hc_ne : c ≠ 0 := ne_of_gt hc
+  -- π((1+c)x)·log(x)/((1+c)x) → 1
+  have pnt_1c_logx := pnt_1c_logx_tendsto c hc
+  -- π(x)·log(x)/x → 1 (PNT)
+  have pnt_x := primeNumberTheorem
+  -- Scale pnt_1c_logx by (1+c)/c
+  have h1 : Tendsto (fun x : ℝ =>
+      (1 + c) / c * ((primePi ((1 + c) * x) : ℝ) * Real.log x / ((1 + c) * x)))
+      atTop (𝓝 ((1 + c) / c * 1)) :=
+    pnt_1c_logx.const_mul ((1 + c) / c)
+  -- Scale pnt_x by 1/c
+  have h2 : Tendsto (fun x : ℝ =>
+      1 / c * ((primePi x : ℝ) * Real.log x / x))
+      atTop (𝓝 (1 / c * 1)) :=
+    pnt_x.const_mul (1 / c)
+  -- Subtract: (1+c)/c·1 - 1/c·1 = 1
+  have h3 := h1.sub h2
+  rw [show (1 + c) / c * 1 - 1 / c * 1 = (1 : ℝ) by field_simp; ring] at h3
+  refine h3.congr' ?_
+  filter_upwards [eventually_gt_atTop (0 : ℝ)] with x hx
+  have hx_ne : x ≠ 0 := ne_of_gt hx
+  have hcx_ne : c * x ≠ 0 := mul_ne_zero hc_ne hx_ne
+  have h1cx_ne : (1 + c) * x ≠ 0 := mul_ne_zero (ne_of_gt h1c_pos) hx_ne
+  field_simp
+  ring
 
 end
 

--- a/research/problems/bertrands-postulate-oq-03-oq-04/knowledge.md
+++ b/research/problems/bertrands-postulate-oq-03-oq-04/knowledge.md
@@ -1,0 +1,43 @@
+# bertrands-postulate-oq-03-oq-04 — Knowledge Base
+
+## Problem Statement
+
+PNT-based asymptotic for prime gaps in short intervals.
+
+For a "short" interval [x, x+h], how many primes does it contain?
+The PNT prediction: π(x+h) - π(x) ~ h/ln(x) when h is not too small.
+
+## Status
+
+- **Gallery status**: axiomatized (1 axiom: shortIntervalPNT_rh_conditional)
+- **Lean files**: BertrandsPostulateOQ03OQ04.lean (0 sorries, 1 axiom)
+- **Aristotle companion**: BertrandsPostulateOQ03OQ04Aristotle.lean (0 sorries after fix)
+
+## Sessions
+
+### Session 2026-04-22 (Session 1) - Aristotle Sorry Resolution
+
+**Mode**: REVISIT
+**Outcome**: completed
+
+#### What I Did
+- Read the 4 Lean files for this problem family
+- Found 2 sorries in BertrandsPostulateOQ03OQ04Aristotle.lean
+  - `pnt_1c_logx_tendsto`: needed filter product proof
+  - `long_interval_density_from_pnt'`: needed Tendsto.sub algebraic decomposition
+- Confirmed both proofs were already written (identically) in BertrandsPostulateOQ03OQ04OQ03.lean
+  as `pnt_at_scaled_point` and `pnt_density_long_interval`
+- Copied the proofs into the Aristotle file (2→0 sorries)
+
+#### Key Findings
+- `pnt_1c_logx_tendsto` = `pnt_at_scaled_point` in OQ03 (identical theorem/proof)
+- `long_interval_density_from_pnt'` = `pnt_density_long_interval` in OQ03 (identical)
+- The main file (OQ04) and OQ03 file have 0 sorries and were already clean
+- Research problem metadata had stale sorryCount: 1 for OQ03 (actual: 0)
+
+#### Files Modified
+- proofs/Proofs/BertrandsPostulateOQ03OQ04Aristotle.lean (2→0 sorries)
+- src/data/research/problems/bertrands-postulate-oq-03-oq-04.json (updated knowledge)
+
+#### Next Steps
+None — all sorries resolved. Problem correctly axiomatized.

--- a/src/data/research/problems/bertrands-postulate-oq-03-oq-04.json
+++ b/src/data/research/problems/bertrands-postulate-oq-03-oq-04.json
@@ -29,23 +29,23 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Created BertrandsPostulateOQ03OQ04.lean (323 lines). Builds with 2 sorries + 1 axiom. Proves ShortIntervalPNT density implies PrimeGapConjecture existence; log ratio lemma proved; RH-conditional density axiomatized.",
+    "progressSummary": "COMPLETE: All sorries resolved. 0 sorries across all files. 1 axiom (shortIntervalPNT_rh_conditional) correctly represents open conjecture.",
     "builtItems": [
       "BertrandsPostulateOQ03OQ04.lean: ShortIntervalPNT def + 7 proved/partial theorems",
-      "Gallery entry: src/data/proofs/bertrands-postulate-oq-03-oq-04/meta.json"
+      "Gallery entry: src/data/proofs/bertrands-postulate-oq-03-oq-04/meta.json",
+      "BertrandsPostulateOQ03OQ04Aristotle.lean: proved pnt_1c_logx_tendsto and long_interval_density_from_pnt (2→0 sorries)"
     ],
     "insights": [
       "ShortIntervalPNT (density ~ h/ln x) is strictly stronger than PrimeGapConjecture (existence only)",
       "primeCounting_lt_implies_prime_exists: counting jump → prime in gap, proved via Finset.card_le_card",
       "log(x)/log((1+c)x) → 1 proved via 1/(1 + log(1+c)/log(x)) decomposition",
       "Under RH: von Koch bound gives density for h = x^(1/2+ε) — axiomatized",
-      "Filter limit algebra for combining PNT limits is the hard part — 2 sorries remain"
+      "Filter limit algebra for combining PNT limits is the hard part — 2 sorries remain",
+      "pnt_1c_logx_tendsto proved via filter product of PNT.comp(scaling) * log_ratio_tendsto_one",
+      "long_interval_density_from_pnt proved via (1+c)/c * pnt_1c_logx - 1/c * pnt via Tendsto.sub"
     ],
     "mathlibGaps": [],
-    "nextSteps": [
-      "Prove long_interval_density_from_pnt: need pnt_1c.mul hlog_ratio filter algebra",
-      "Submit sorries to Aristotle for automated search"
-    ]
+    "nextSteps": []
   },
   "tags": [
     "seeker-selected"
@@ -106,7 +106,7 @@
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BertrandsPostulateOQ03OQ04Aristotle.lean"
     },


### PR DESCRIPTION
## Summary

- Prove both sorries in `BertrandsPostulateOQ03OQ04Aristotle.lean` (2→0 sorries)
- Add `research/problems/bertrands-postulate-oq-03-oq-04/knowledge.md` documenting the session

## Mathematical Content

The Aristotle companion file for `bertrands-postulate-oq-03-oq-04` had 2 open sorries for filter algebra lemmas that are central to the PNT density result:

1. **`pnt_1c_logx_tendsto`**: π((1+c)x)·log(x)/((1+c)x) → 1

   Proof: Compose PNT (π(x)·log(x)/x → 1) with the scaling x ↦ (1+c)x, then multiply by log_ratio_tendsto_one (log(x)/log((1+c)x) → 1). The logs cancel algebraically via `field_simp; ring`.

2. **`long_interval_density_from_pnt'`**: (π((1+c)x) − π(x))·log(x)/(cx) → 1

   Proof: Algebraic decomposition as (1+c)/c × [step 1] − 1/c × [PNT], both tending to 1 via `Tendsto.const_mul` and `Tendsto.sub`.

These proofs are identical to `pnt_at_scaled_point` and `pnt_density_long_interval` in `BertrandsPostulateOQ03OQ04OQ03.lean`, which were already proved. The Aristotle file was a duplicate target that just needed the same proofs filled in.

## File Status After This PR

| File | Sorries | Axioms |
|------|---------|--------|
| `BertrandsPostulateOQ03OQ04.lean` | 0 | 1 |
| `BertrandsPostulateOQ03OQ04Aristotle.lean` | **0** (was 2) | 0 |
| `BertrandsPostulateOQ03OQ04OQ03.lean` | 0 | 0 |

The 1 remaining axiom (`shortIntervalPNT_rh_conditional`) correctly represents the RH-conditional result — density holds for h ≥ x^(1/2+ε) assuming Riemann Hypothesis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)