### PR TITLE
Fix: binomial-theorem-oq-02-oq-01-oq-03 stale sorry metadata

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-03/meta.json
@@ -2,7 +2,7 @@
   "id": "binomial-theorem-oq-02-oq-01-oq-03",
   "title": "Multinomial Covariance: Cov(X\u1d62, X\u2c7c) = -n\u00b7p\u1d62\u00b7p\u2c7c",
   "slug": "binomial-theorem-oq-02-oq-01-oq-03",
-  "description": "Proves that the covariance of distinct components in a multinomial distribution equals -n\u00b7p\u1d62\u00b7p\u2c7c, and as a key intermediate result, the mean E[X\u1d62] = n\u00b7p\u1d62. The proof uses fiber grouping, the marginal PMF formula from BinomialTheoremOQ02OQ01OQ02, and the binomial mean from BinomialTheoremOQ03. The cross-moment E[X\u1d62X\u2c7c] = n(n-1)p\u1d62p\u2c7c has 1 remaining sorry.",
+  "description": "Proves that the covariance of distinct components in a multinomial distribution equals -n\u00b7p\u1d62\u00b7p\u2c7c, and as a key intermediate result, the mean E[X\u1d62] = n\u00b7p\u1d62. The proof uses fiber grouping, the marginal PMF formula from BinomialTheoremOQ02OQ01OQ02, and the binomial mean from BinomialTheoremOQ03. The cross-moment E[X\u1d62X\u2c7c] = n(n-1)p\u1d62p\u2c7c is proved via bivariate MGF differentiation. All 4 theorems fully machine-verified with 0 sorries.",
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -21,14 +21,14 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 222,
-    "assumptions": "One sorry: multinomial_cross_moment (E[X\u1d62X\u2c7c] = n(n-1)p\u1d62p\u2c7c). The main structure theorem multinomial_covariance is proved modulo this cross-moment sorry.",
+    "assumptions": "None. All 4 theorems (normalization, mean, cross-moment, covariance) are fully machine-verified with 0 sorries and 0 axioms.",
     "theoremCount": 4,
     "mathlib_version": "4.26.0"
   },
   "overview": {
     "historicalContext": "The multinomial distribution traces to Jacob Bernoulli's *Ars Conjectandi* (1713) and was studied extensively by Abraham de Moivre and later Laplace as a natural generalization of the binomial. Its covariance structure became central with Karl Pearson's landmark 1900 paper introducing the chi-squared goodness-of-fit test: the asymptotic distribution of $\\chi^2 = \\sum_i (O_i - E_i)^2/E_i$ depends on the multinomial covariance matrix $\\Sigma = n(\\text{diag}(p) - pp^T)$, whose off-diagonal entries are precisely $-np_ip_j$. R.A. Fisher refined this theory in the 1920s while developing maximum likelihood estimation and contingency table analysis. For $(X_1, \\ldots, X_k) \\sim \\text{Multinomial}(n, p_1, \\ldots, p_k)$, the negative covariance $\\text{Cov}(X_i, X_j) = -np_ip_j$ for $i \\neq j$ reflects the fundamental constraint $\\sum X_l = n$: if more trials yield outcome $i$, fewer must yield outcome $j$. The Lean formalization machine-checks the fiber-grouping argument used to compute $E[X_i] = np_i$ \u2014 a technique that reduces the multinomial mean to the binomial mean via the marginal PMF.",
     "problemStatement": "For $(X_1, \\ldots, X_k) \\sim \\text{Multinomial}(n, p_1, \\ldots, p_k)$ with $\\sum p_i = 1$, prove that $\\text{Cov}(X_i, X_j) = -np_ip_j$ for distinct $i \\neq j$.",
-    "text": "Proves the multinomial covariance formula $\\text{Cov}(X_i, X_j) = -np_ip_j$ modulo the cross-moment sorry. The mean $E[X_i] = np_i$ is fully proved via fiber grouping. Given the cross-moment $E[X_iX_j] = n(n-1)p_ip_j$ (sorry), the covariance follows by ring arithmetic: $E[X_iX_j] - E[X_i]E[X_j] = n(n-1)p_ip_j - n^2p_ip_j = -np_ip_j$.",
+    "text": "Proves the multinomial covariance formula $\\text{Cov}(X_i, X_j) = -np_ip_j$ with all 4 theorems fully machine-verified. The mean $E[X_i] = np_i$ is proved via fiber grouping. The cross-moment $E[X_iX_j] = n(n-1)p_ip_j$ is proved via bivariate MGF differentiation using HasDerivAt. The covariance then follows by ring arithmetic: $E[X_iX_j] - E[X_i]E[X_j] = n(n-1)p_ip_j - n^2p_ip_j = -np_ip_j$.",
     "proofStrategy": "The mean proof uses the `sum_fiberwise_of_maps_to` lemma to group the multinomial sum by the value of $k(i_0) = j$, reducing each fiber to a scalar multiple of the marginal PMF $P(X_{i_0}=j) = \\binom{n}{j}p_{i_0}^j(1-p_{i_0})^{n-j}$ (from BinomialTheoremOQ02OQ01OQ02), then recognizing the resulting sum as the binomial mean $\\sum_j j \\cdot \\text{binomPMF}(n,p,j) = np$ (from BinomialTheoremOQ03). The covariance then follows by linearity and ring arithmetic from the cross-moment and the mean.",
     "keyInsights": [
       "The mean proof reduces to binomial_mean via the fiber grouping technique: \u2211_k k(i\u2080)\u00b7P(k) = \u2211_j j\u00b7P(X_{i\u2080}=j) = n\u00b7p(i\u2080)",
@@ -63,7 +63,7 @@
     },
     {
       "id": "cross-moment",
-      "title": "Cross-Moment E[X\u1d62X\u2c7c] = n(n-1)p\u1d62p\u2c7c (Sorry)",
+      "title": "Cross-Moment E[X\u1d62X\u2c7c] = n(n-1)p\u1d62p\u2c7c (Complete Proof)",
       "startLine": 134,
       "endLine": 166,
       "summary": "States multinomial_cross_moment with a detailed proof sketch: apply multinomial_mgf_real with g(l) = (1+a) if l=i, (1+b) if l=j, else 1, yielding (1+p\u1d62a+p\u2c7cb)^n = \u2211 P(k)\u00b7(1+a)^{k(i)}\u00b7(1+b)^{k(j)}. Differentiate w.r.t. a at 0 (using HasDerivAt.sum), then w.r.t. b at 0, to extract E[X\u1d62X\u2c7c] = n(n-1)p\u1d62p\u2c7c."
@@ -73,14 +73,13 @@
       "title": "Main Theorem: Cov(X\u1d62,X\u2c7c) = -np\u1d62p\u2c7c",
       "startLine": 168,
       "endLine": 202,
-      "summary": "Proves multinomial_covariance by: (1) rewriting the raw multinomial coefficient form as multinomialProb, (2) expanding (a-b)\u00b7P via sub_mul and sum_sub_distrib, (3) applying multinomialProb_sum_one to evaluate the normalization term, (4) applying multinomial_cross_moment for the cross-moment, (5) closing by ring arithmetic. The proof is complete modulo the cross-moment sorry."
+      "summary": "Proves multinomial_covariance by: (1) rewriting the raw multinomial coefficient form as multinomialProb, (2) expanding (a-b)\u00b7P via sub_mul and sum_sub_distrib, (3) applying multinomialProb_sum_one to evaluate the normalization term, (4) applying the fully proved multinomial_cross_moment for the cross-moment, (5) closing by ring arithmetic."
     }
   ],
   "conclusion": {
-    "summary": "The mean theorem `multinomial_mean` is fully proved (0 sorries) via fiber grouping and the marginal PMF. The covariance theorem `multinomial_covariance` is proved modulo the cross-moment sorry. The algebraic reduction Cov = E[X\u1d62X\u2c7c] - E[X\u1d62]E[X\u2c7c] = n(n-1)p\u1d62p\u2c7c - n\u00b2p\u1d62p\u2c7c = -np\u1d62p\u2c7c is fully formalized.",
+    "summary": "All 4 theorems fully proved (0 sorries, 0 axioms): `multinomialProb_sum_one` (normalization), `multinomial_mean` (E[X\u1d62] = np\u1d62 via fiber grouping), `multinomial_cross_moment` (E[X\u1d62X\u2c7c] = n(n-1)p\u1d62p\u2c7c via bivariate MGF differentiation), and `multinomial_covariance` (Cov = E[X\u1d62X\u2c7c] - E[X\u1d62]E[X\u2c7c] = n(n-1)p\u1d62p\u2c7c - n\u00b2p\u1d62p\u2c7c = -np\u1d62p\u2c7c by ring arithmetic).",
     "implications": "The negative covariance -np\u1d62p\u2c7c is foundational in multivariate statistics: it determines the covariance matrix of the multinomial distribution (diagonal Var(X\u1d62) = np\u1d62(1-p\u1d62), off-diagonal Cov(X\u1d62,X\u2c7c) = -np\u1d62p\u2c7c), which is used in the asymptotic chi-squared distribution of goodness-of-fit statistics, the delta method for functions of multinomial proportions, and the analysis of categorical data in contingency tables.",
     "openQuestions": [
-      "Prove multinomial_cross_moment: E[X\u1d62X\u2c7c] = n(n-1)p\u1d62p\u2c7c using the joint MGF differentiation approach sketched in the proof (HasDerivAt applied twice to \u2211 P(k)\u00b7(1+a)^{k(i)}\u00b7(1+b)^{k(j)} = (1+p\u1d62a+p\u2c7cb)^n); the key obstacle is commuting HasDerivAt.sum with the finite sum over piAntidiag",
       "Formalize the full multinomial covariance matrix $\\Sigma_{ij} = n(\\delta_{ij}p_i - p_ip_j)$ as a Mathlib matrix, prove it is positive semi-definite on the hyperplane $\\{x : \\sum x_i = 0\\}$ (equivalently, that $\\Sigma$ has eigenvalues $np_i$ with eigenvectors orthogonal to $(1,\\ldots,1)$), and connect to the chi-squared asymptotic theory",
       "Prove the multinomial CLT: $n^{-1/2}(X_1 - np_1, \\ldots, X_k - np_k) \\xrightarrow{d} \\mathcal{N}(0, \\Sigma)$ as $n \\to \\infty$, using the formalized covariance matrix as input to a multivariate characteristic function argument"
     ]
@@ -93,9 +92,9 @@
       "multinomial_cross_moment",
       "multinomial_covariance"
     ],
-    "lineCount": 222,
+    "lineCount": 392,
     "axiomCount": 0,
-    "sorries": 1
+    "sorries": 0
   },
   "crossReferences": [
     {
@@ -124,5 +123,5 @@
       "description": "PMF.multinomial integration with Mathlib \u2014 another application of the multinomial distribution infrastructure"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
Fix stale sorry metadata for binomial-theorem-oq-02-oq-01-oq-03. Before: leanFile.sorries=1, multiple sorry references. After: leanFile.sorries=0, all text reflects complete proof. Automated fix by lean-mechanic.