### PR TITLE
Seeker: initialize erdos-476 and fair-games-theorem-oq-02-oq-01 workspaces

### DIFF
--- a/research/problems/erdos-476/knowledge.md
+++ b/research/problems/erdos-476/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: erdos-476
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/erdos-476/literature/README.md
+++ b/research/problems/erdos-476/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for erdos-476
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/erdos-476/problem.md
+++ b/research/problems/erdos-476/problem.md
@@ -1,0 +1,147 @@
+# Problem: Prove the Erdős-Heilbronn Conjecture (replace axiom)
+
+**Slug**: erdos-476
+**Created**: 2026-04-22T09:05:08+02:00
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+For a prime $p$ and a subset $A \subseteq \mathbb{Z}/p\mathbb{Z}$ with $|A| \geq 2$, define the restricted sumset:
+$$A \mathbin{\hat{+}} A = \{a + b : a, b \in A,\ a \neq b\}$$
+
+Prove:
+$$|A \mathbin{\hat{+}} A| \geq \min(2|A| - 3,\ p)$$
+
+### Plain Language
+
+The Erdős-Heilbronn Conjecture (1964), proved by da Silva and Hamidoune in 1994, says
+that if you take a set of $n$ distinct elements from $\mathbb{Z}/p\mathbb{Z}$ and add them
+in pairs (excluding $a + a$), you get at least $\min(2n-3, p)$ distinct values.
+
+The current gallery proof uses `axiom erdos_heilbronn_bound` as a placeholder.
+This problem asks: **replace the axiom with an actual Lean proof**.
+
+### Why This Matters
+
+This is one of the foundational results of additive combinatorics. The proof technique
+(originally exterior algebra; alternatively the polynomial method) has been highly
+influential. Removing the axiom would make this one of the first complete formalizations
+of the da Silva-Hamidoune theorem in Lean 4.
+
+## Known Results
+
+### What's Already Proven in the Gallery
+
+- `erdos-476` (current): `erdos_heilbronn_bound` stated as axiom; all surrounding infrastructure complete:
+  - `restrictedSumset` definition
+  - `AP_restrictedSumset`: arithmetic progressions achieve exactly $2n-3$ elements
+  - `AP_achieves_bound`: tightness of the bound
+  - `bound_comparison`: restricted vs unrestricted sumset relationship
+  - `card_two_case`: $|A| = 2$ base case verified
+  - `card_three_lower_bound`: $|A| = 3$ lower bound
+  - `erdos_476_summary`: main theorem (depends on axiom)
+
+### Key Axiom to Remove
+
+```lean
+-- proofs/Proofs/Erdos476Problem.lean, line 111
+axiom erdos_heilbronn_bound (A : Finset (ZMod p)) (h : 2 ≤ A.card) :
+    (restrictedSumset p A).card ≥ min (2 * A.card - 3) p
+```
+
+### Our Goal
+
+Prove `erdos_heilbronn_bound` as a theorem, eliminating the axiom. This makes
+`erdos_476_summary` and all downstream results fully verified.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `erdos-476-oq-05` | Cauchy-Davenport extremal sets | Vosper's theorem, AP characterization |
+| `erdos-476-oq-05-incomplete-01` | Vosper's theorem (incomplete) | Polynomial method |
+| `cauchy-davenport` (if exists) | Unrestricted sumsets | Additive combinatorics |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Polynomial method (Alon-Nathanson-Ruzsa 1995)**: Use the Combinatorial Nullstellensatz.
+   Consider the polynomial $f(x, y) = \prod_{i=0}^{n-3}(x + y - c_i)$ for $c_i \notin A \hat{+} A$.
+   If $|A \hat{+} A| < 2n-3$, then $f$ vanishes on all $(a, b)$ with $a \neq b$, contradicting
+   the Nullstellensatz coefficient condition.
+   - Why it might work: Mathlib has `MvPolynomial` and finite field theory; Nullstellensatz is tractable
+   - Risk: Combinatorial Nullstellensatz for multivariate case needs careful setup
+
+2. **Exterior algebra (da Silva-Hamidoune 1994)**: Use Grassmann derivatives. The $k$-th
+   Grassmann derivative of $\prod_{a \in A}(x - a)$ encodes information about the restricted sumset.
+   - Why it might work: The original proof; conceptually clean
+   - Risk: Exterior algebra in Lean 4 / Mathlib may require more infrastructure
+
+3. **Induction on |A|**: Base cases $|A| = 2, 3$ are already done. Inductive step via
+   a Freiman-type argument.
+   - Why it might work: Avoids heavy algebra
+   - Risk: The inductive structure is not straightforward; standard proofs do not use simple induction
+
+### Key Difficulties
+
+- The polynomial method proof requires `Finset.sum` manipulation over $\mathbb{Z}/p\mathbb{Z}$
+- Need a Lean statement of Combinatorial Nullstellensatz or can use a direct coefficient argument
+- The exterior algebra approach requires multilinear algebra infrastructure
+
+### What Would a Proof Need?
+
+- Combinatorial Nullstellensatz: coefficient of $\prod x_i^{t_i}$ in $f$ is nonzero if $f$ does not vanish on product sets. Check if Mathlib has `Polynomial.combinatorialNullstellensatz` or similar.
+- Finset cardinality bounds over `ZMod p`
+- Polynomial evaluation at structured finite sets
+
+## Tractability Assessment
+
+**Difficulty**: Challenging
+
+**Justification**:
+- The mathematics is completely known (proved in 1994)
+- The polynomial method proof is shorter and more direct than the exterior algebra proof
+- Mathlib has `ZMod`, `Finset`, `MvPolynomial`, and `FiniteField` infrastructure
+- Main risk: Combinatorial Nullstellensatz may not be in Mathlib and would need to be proven first
+
+**Estimated Effort**:
+- Exploration: 2-3 days (survey Mathlib's polynomial/Nullstellensatz landscape)
+- If Nullstellensatz available: 1-2 weeks
+- If Nullstellensatz needs building: 3-6 weeks
+
+## References
+
+### Papers
+- da Silva, Hamidoune (1994) — *Cyclic spaces for Grassmann derivatives and additive theory*, Bull. London Math. Soc.
+- Alon, Nathanson, Ruzsa (1995) — *The polynomial method and restricted sums of congruence classes*, J. Number Theory
+- Alon (1999) — *Combinatorial Nullstellensatz*, Combinatorics, Probability and Computing
+
+### Mathlib
+- `Mathlib.FieldTheory.Finite.Basic` — `ZMod` finite fields
+- `Mathlib.RingTheory.MvPolynomial.Basic` — multivariate polynomials
+- `Mathlib.Data.Finset.Card` — cardinality lemmas
+- `Mathlib.Algebra.GeomSum` — geometric sum lemmas useful for AP calculations
+
+## Metadata
+
+```yaml
+tags:
+  - additive-combinatorics
+  - finite-fields
+  - polynomial-method
+  - nullstellensatz
+  - erdos-problems
+related_proofs:
+  - erdos-476-oq-05
+  - erdos-476-oq-05-incomplete-01
+difficulty: challenging
+source: gallery-gap
+created: 2026-04-22T09:05:08+02:00
+```
+
+**Significance**: 8/10
+**Tractability**: 6/10

--- a/research/problems/erdos-476/state.md
+++ b/research/problems/erdos-476/state.md
@@ -1,0 +1,25 @@
+# Research State: erdos-476
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-04-22T09:08:40+02:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/fair-games-theorem-oq-02-oq-01/knowledge.md
+++ b/research/problems/fair-games-theorem-oq-02-oq-01/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: fair-games-theorem-oq-02-oq-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/fair-games-theorem-oq-02-oq-01/literature/README.md
+++ b/research/problems/fair-games-theorem-oq-02-oq-01/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for fair-games-theorem-oq-02-oq-01
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/fair-games-theorem-oq-02-oq-01/problem.md
+++ b/research/problems/fair-games-theorem-oq-02-oq-01/problem.md
@@ -1,0 +1,142 @@
+# Problem: Optional Stopping Theorem (Doob) Formalization via Mathlib
+
+**Slug**: fair-games-theorem-oq-02-oq-01
+**Created**: 2026-04-22T09:05:08+02:00
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+Construct a simple symmetric random walk $(S_n)_{n \geq 0}$ with $S_0 = k$ as a Lean 4
+`MeasureTheory.Martingale` and apply Doob's Optional Stopping Theorem to prove:
+
+$$E[S_\tau] = k$$
+
+where $\tau = \inf\{n : S_n \in \{0, N\}\}$ is the first hitting time of $\{0, N\}$.
+
+### Plain Language
+
+The fair-games-theorem gallery proof establishes the Optional Stopping Theorem (OST)
+abstractly. This problem asks: **can we instantiate it with a concrete example?**
+
+Specifically:
+1. Build a simple symmetric random walk $S_n = k + X_1 + \cdots + X_n$ where each $X_i \in \{+1, -1\}$ with equal probability, as a `MeasureTheory.Martingale` against a suitable filtration.
+2. Define the stopping time $\tau$ (hitting time of $\{0, N\}$) as a `MeasureTheory.IsStoppingTime`.
+3. Apply `MeasureTheory.Martingale.stoppedValue_eq_expected` (or equivalent Mathlib lemma) to derive $E[S_\tau] = S_0 = k$.
+4. Use this to recover the classical ruin probability $P(S_\tau = 0) = 1 - k/N$.
+
+### Why This Matters
+
+The abstract OST proof in the gallery is elegant but self-referential: it never instantiates
+a concrete random process. This problem builds the bridge from abstract martingale theory
+to classical probability examples. It is prerequisite infrastructure for:
+- `fair-games-theorem-oq-02-oq-03`: Variance of ruin time (needs $E[M_\tau]$ for quartic martingale)
+- `fair-games-theorem-oq-02-oq-04`: Biased Gambler's Ruin (needs $E[r^{S_\tau}]$ for geometric martingale)
+
+## Known Results
+
+### What's Already Proven
+
+- `fair-games-theorem`: OST for bounded stopping times — `MeasureTheory.Martingale.stoppedValue_eq_expected` exists in Mathlib (0 sorries, 1 axiom for submartingale converse direction)
+- `fair-games-theorem-oq-02`: $E[\tau] = k(N-k)$ and $P(\text{ruin}) = 1 - k/N$ (verified, 0 sorries)
+- Mathlib has `MeasureTheory.Martingale`, `IsStoppingTime`, and `stoppedValue` for discrete-time processes
+
+### What's Still Open
+
+- No concrete simple random walk example in the gallery as a Lean `Martingale`
+- Linking `ProbabilityTheory.iIndepFun` Bernoulli increments to the `Martingale` typeclass
+
+### Our Goal
+
+Produce a verified Lean 4 theorem of the form:
+
+```lean
+theorem simple_rw_expected_stopped_value
+    (k N : ℕ) (hk : 0 < k) (hkN : k < N)
+    (P : MeasureTheory.Measure (ℕ → Bool)) [IsProbabilityMeasure P] :
+    -- random walk S_n with S_0 = k, steps ±1
+    -- τ = hitting time of {0, N}
+    E[S τ] = k
+```
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `fair-games-theorem` | OST infrastructure | Submartingale sandwich, `stoppedValue_eq_expected` |
+| `fair-games-theorem-oq-02` | Expected ruin time | Classical RW martingale $S_n$, $S_n^2 - n$ |
+| `fair-games-theorem-oq-02-oq-03` | Variance (downstream) | Quartic martingale |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Bernoulli product space**: Construct $\Omega = \{+1, -1\}^\mathbb{N}$ with product measure, define $X_i(\omega) = \omega_i$, and set $S_n = k + \sum_{i=0}^{n-1} X_i$.
+   - Why it might work: Mathlib has `ProbabilityTheory.iIndepFun` for product measures
+   - Risk: Connecting `iIndepFun` structure to `Martingale` typeclass requires careful filtration setup
+
+2. **Abstract martingale stance**: Define $S_n$ axiomatically as satisfying the martingale property without constructing the probability space explicitly.
+   - Why it might work: Simpler to state; uses `Martingale` typeclass directly
+   - Risk: Less foundationally satisfying; may not transfer to downstream applications
+
+### Key Difficulties
+
+- Building the canonical filtration $(\mathcal{F}_n)$ from the increments in Lean
+- Proving the Markov/martingale property under the product measure
+- `IsStoppingTime` verification for hitting times in Lean
+
+### What Would a Proof Need?
+
+- A product probability space for Bernoulli$(\frac{1}{2})$ increments
+- `Filtration` defined by $\mathcal{F}_n = \sigma(X_0, \ldots, X_{n-1})$
+- The martingale property: `E[S_{n+1} | ℱ_n] = S_n`
+- Boundedness of `τ ∧ N` for applying Mathlib's bounded-stopping-time OST
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- Mathlib has all required ingredients (`Martingale`, `IsStoppingTime`, `stoppedValue`, product measures)
+- The construction is standard probability theory
+- Main challenge is ergonomics: connecting Mathlib's abstract framework to a concrete product space
+- Similar constructions exist in Mathlib for random walks in other contexts
+
+**Estimated Effort**:
+- Exploration: 1-2 days (survey Mathlib random walk / product space infrastructure)
+- If tractable: 3-7 days (construction + martingale property + OST application)
+- If hard: 2-4 weeks (if filtration/product space interface is rough)
+
+## References
+
+### Papers
+- Doob, J.L. (1953) — *Stochastic Processes*, Chapter VII: Optional stopping theorem
+
+### Mathlib
+- `Mathlib.Probability.Martingale.OptionalStopping` — `stoppedValue_eq_expected`, bounded OST
+- `Mathlib.Probability.Process.HittingTime` — `IsStoppingTime` for hitting times
+- `Mathlib.Probability.Independence.Basic` — `iIndepFun` for product spaces
+- `Mathlib.MeasureTheory.Measure.MeasureSpace` — product measures
+
+## Metadata
+
+```yaml
+tags:
+  - probability
+  - martingale
+  - optional-stopping
+  - random-walk
+  - gambler-ruin
+related_proofs:
+  - fair-games-theorem
+  - fair-games-theorem-oq-02
+  - fair-games-theorem-oq-02-oq-03
+difficulty: medium
+source: gallery-gap
+created: 2026-04-22T09:05:08+02:00
+```
+
+**Significance**: 8/10
+**Tractability**: 6/10

--- a/research/problems/fair-games-theorem-oq-02-oq-01/state.md
+++ b/research/problems/fair-games-theorem-oq-02-oq-01/state.md
@@ -1,0 +1,25 @@
+# Research State: fair-games-theorem-oq-02-oq-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-04-22T09:08:39+02:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/registry.json
+++ b/research/registry.json
@@ -15785,11 +15785,11 @@
     },
     {
       "slug": "fair-games-theorem-oq-02-oq-01",
-      "phase": "COMPLETED",
+      "phase": "OBSERVE",
       "path": "full",
       "started": "2026-04-13T00:54:20.757Z",
       "status": "graduated",
-      "lastUpdate": "2026-04-13T04:46:46.310Z",
+      "lastUpdate": "2026-04-22T09:08:39+02:00",
       "completed": "2026-04-13T04:46:46.309Z"
     },
     {
@@ -16427,11 +16427,11 @@
     },
     {
       "slug": "erdos-476",
-      "phase": "COMPLETED",
+      "phase": "OBSERVE",
       "path": "full",
       "started": "2026-04-13T22:43:37.493Z",
       "status": "graduated",
-      "lastUpdate": "2026-04-14T21:25:05.895Z",
+      "lastUpdate": "2026-04-22T09:08:40+02:00",
       "completed": "2026-04-14T21:25:05.895Z"
     },
     {


### PR DESCRIPTION
## Summary

- Initializes research workspace for **erdos-476**: Prove the Erdős-Heilbronn Conjecture by replacing `axiom erdos_heilbronn_bound` with an actual Lean proof (polynomial method approach)
- Initializes research workspace for **fair-games-theorem-oq-02-oq-01**: Construct a simple random walk as a Mathlib `Martingale` and apply Doob's Optional Stopping Theorem to compute concrete stopping expectations

Both workspaces include detailed `problem.md` files with formal statements, known results, proof approaches, key difficulties, and tractability assessments.

## Pool Status

- Available: 83 (threshold: 15) — pool healthy
- In-progress: 1,253+
- Selected this run: 2 Tier-A problems (significance 8, tractability 6)

## Labels

`research`

🤖 Generated with [Claude Code](https://claude.com/claude-code)