### PR TITLE
Enrich algebraic-numbers-countable-oq-02-oq-02: Cantor's 1874 Nested Interval Proof

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-02/annotations.json
@@ -1,28 +1,86 @@
-{
-  "annotations": [
-    {
-      "line": 60,
-      "type": "definition",
-      "content": "The nested interval construction: at each step, divide into thirds and choose middle or right to avoid f(n). The choice ensures a(n+1) > a(n) always.",
-      "category": "construction"
-    },
-    {
-      "line": 130,
-      "type": "proof-technique",
-      "content": "Exclusion property: case analysis on the if-then-else. In each case, f(n) is on the wrong side of the new interval boundary.",
-      "category": "case-analysis"
-    },
-    {
-      "line": 200,
-      "type": "proof-technique",
-      "content": "Limit point existence via sSup of bounded monotone sequence. Uses ConditionallyCompleteLinearOrder of ℝ.",
-      "category": "completeness"
-    },
-    {
-      "line": 230,
-      "type": "proof-technique",
-      "content": "Key step: f(n) ≠ x. From exclusion: f(n) ≤ a(n+1) < x (strict mono) or f(n) > b(n+1) ≥ x. Either way f(n) ≠ x.",
-      "category": "core-argument"
-    }
-  ]
-}
+[
+  {
+    "id": "ann-algcount-oq02-oq02-01",
+    "proofId": "algebraic-numbers-countable-oq-02-oq-02",
+    "range": { "startLine": 1, "endLine": 58 },
+    "type": "context",
+    "title": "Historical and Mathematical Context: Cantor's 1874 Nested Interval Argument",
+    "content": "This file formalizes Cantor's original 1874 proof of ℝ uncountability — a proof that precedes the famous diagonal argument by 17 years. In the 1874 paper 'Über eine Eigenschaft des Inbegriffes aller reellen algebraischen Zahlen', Cantor introduced the nested interval technique to show that no enumeration f : ℕ → ℝ can be surjective.\n\nThe key historical insight is that the nested interval argument is *constructive*: it explicitly exhibits a real number missing from any proposed enumeration. The diagonal argument (1891) shows the existence of such a number non-constructively via a diagonalization trick. Both proofs yield ¬ Countable ℝ, but the nested interval version provides an explicit witness — the supremum of the left endpoints.\n\nThe formalization uses Mathlib's `sSup` (conditional supremum from `ConditionallyCompleteLattice`) to define the limit point, and proves the full chain of 13 theorems establishing ℝ uncountability with 0 sorries and 0 axioms.",
+    "mathContext": "The key property that makes the proof work: $a_{n+1} > a_n$ always (strictly, not just $\\geq$). Without this, $f(n)$ could equal the limit point if $f(n)$ coincides with a boundary. With strict increase, $\\sup_n a_n > a_{n+1} > f(n)$ (in the left-exclusion case), giving $f(n) \\neq \\sup_n a_n$.",
+    "significance": "context",
+    "relatedConcepts": ["Cantor's diagonal argument", "nested intervals", "constructive mathematics", "sSup", "ConditionallyCompleteLattice"],
+    "prerequisites": ["countability theory", "completeness of ℝ", "Mathlib.Order.ConditionallyCompleteLattice.Basic"]
+  },
+  {
+    "id": "ann-algcount-oq02-oq02-02",
+    "proofId": "algebraic-numbers-countable-oq-02-oq-02",
+    "range": { "startLine": 60, "endLine": 80 },
+    "type": "definition",
+    "title": "The Thirds-Based Nested Interval Construction",
+    "content": "The `nested` function implements the interval construction by structural recursion on ℕ. At step 0, the interval is [0,1]. At step n+1, given [aₙ, bₙ] with d = bₙ - aₙ, three thresholds are computed: t₁ = aₙ + d/3 and t₂ = aₙ + 2d/3. The choice:\n- If f(n) < t₁ (f(n) in left third): take middle third [t₁, t₂]\n- If f(n) > t₂ (f(n) in right third): take middle third [t₁, t₂]\n- Otherwise (f(n) in middle third or at boundary): take right third [t₂, bₙ]\n\nIn all three cases, the new left endpoint aₙ₊₁ is either t₁ or t₂, both strictly greater than aₙ. This is the key design choice: using thirds (rather than halves) ensures the left endpoint *always* advances, even when f(n) is at the boundary between thirds.",
+    "mathContext": "The thirds division: $t_1 = a_n + \\frac{b_n - a_n}{3}$, $t_2 = a_n + \\frac{2(b_n - a_n)}{3}$. Possible new left endpoints: $t_1 > a_n$ or $t_2 > a_n$. In all cases $a_{n+1} \\geq t_1 = a_n + d/3 > a_n$ where $d = b_n - a_n > 0$.",
+    "significance": "key",
+    "relatedConcepts": ["noncomputable def", "structural recursion", "thirds subdivision", "if-then-else branch"],
+    "prerequisites": ["basic real arithmetic", "ℕ recursion in Lean 4"]
+  },
+  {
+    "id": "ann-algcount-oq02-oq02-03",
+    "proofId": "algebraic-numbers-countable-oq-02-oq-02",
+    "range": { "startLine": 93, "endLine": 162 },
+    "type": "technique",
+    "title": "Core Properties: Strict Monotonicity via Uniform Case Analysis",
+    "content": "The four key properties (width_pos, a_strict_mono, b_mono, exclusion) are all proved by the same pattern: induction on n, then a three-way case split on the if-then-else branches of the construction. The proof structure for each theorem is:\n1. Unfold the recursive definition with `simp only [a, b, nested]`\n2. Set local variables for aₙ, bₙ, d\n3. Use `have hd : d > 0 := width_pos f n` (bootstrap from width_pos)\n4. Case split with `by_cases h1 : f n < aₙ + d/3`, then `by_cases h2 : f n > aₙ + 2d/3`\n5. In each branch, `simp [h1, h2]` simplifies the if-then-else, then `linarith` closes with arithmetic\n\nThe `a_strictMono` and `b_antitone` global versions then follow from `strictMono_nat_of_lt_succ` and `antitone_nat_of_succ_le`, converting pointwise successor inequalities to global monotonicity.",
+    "mathContext": "Strict monotonicity: $a_{n+1} \\in \\{a_n + d/3,\\, a_n + 2d/3\\} \\subset (a_n, b_n)$, so $a_{n+1} > a_n$ since $d > 0$. This implies $\\text{StrictMono}(a_f)$ via `strictMono_nat_of_lt_succ`. Antitone: $b_{n+1} \\leq b_n$ in all branches.",
+    "significance": "supporting",
+    "relatedConcepts": ["StrictMono", "Antitone", "strictMono_nat_of_lt_succ", "antitone_nat_of_succ_le", "by_cases", "linarith"],
+    "prerequisites": ["width_pos (bootstrap lemma)", "Lean 4 case analysis tactics", "Mathlib monotonicity lemmas"]
+  },
+  {
+    "id": "ann-algcount-oq02-oq02-04",
+    "proofId": "algebraic-numbers-countable-oq-02-oq-02",
+    "range": { "startLine": 140, "endLine": 154 },
+    "type": "insight",
+    "title": "Exclusion Property: Why ≤ (Not <) Is the Right Bound",
+    "content": "The exclusion theorem states: for each n, either f(n) ≤ a(n+1) or f(n) > b(n+1). The left-side bound is ≤ (not <). This is deliberate: when f(n) is in the middle third or at t₂, we take the right third [t₂, bₙ], and in this case f(n) ≤ t₂ = a(n+1) exactly. If we required f(n) < a(n+1), this boundary case would fail.\n\nThe weak ≤ bound is sufficient because the main theorem then uses *strict* monotonicity of (aₙ): even though f(n) ≤ a(n+1), the limit point x = sSup(aₙ) satisfies x > a(n+1) (from limit_gt_a with index n+1). So f(n) ≤ a(n+1) < x. The ≤ in exclusion combines with strict > in limit_gt_a to give f(n) < x, hence f(n) ≠ x.",
+    "mathContext": "Exclusion: $f(n) \\leq a_{n+1}$ or $f(n) > b_{n+1}$. Limit: $x = \\sup_k a_k > a_{n+1}$ (since $a_{n+2} > a_{n+1}$ and $a_{n+2} \\leq x$). Combined: $f(n) \\leq a_{n+1} < x$ or $f(n) > b_{n+1} \\geq x$. Either way $f(n) \\neq x$.",
+    "significance": "key",
+    "relatedConcepts": ["exclusion boundary case", "weak vs strict inequality", "limit_gt_a", "linarith combination"],
+    "prerequisites": ["a_strict_mono", "width_pos", "real arithmetic"]
+  },
+  {
+    "id": "ann-algcount-oq02-oq02-05",
+    "proofId": "algebraic-numbers-countable-oq-02-oq-02",
+    "range": { "startLine": 183, "endLine": 213 },
+    "type": "concept",
+    "title": "Limit Point via sSup: Using Completeness of ℝ",
+    "content": "The limit point is defined as `limitPoint f := sSup (Set.range (a f))` — the supremum of all left endpoints. This uses ℝ's structure as a `ConditionallyCompleteLinearOrder`: `sSup` exists and is finite provided the set is nonempty and bounded above.\n\nThe two key properties proved here:\n- `limit_gt_a`: limitPoint > a(n) for all n. Proof: a(n+1) ≤ limitPoint (from `le_csSup`) and a(n+1) > a(n) (from strict monotonicity). Combined by linarith.\n- `limit_le_b`: limitPoint ≤ b(n) for all n. Proof: every a(m) ≤ b(n) (from `a_le_b_all`), so b(n) is an upper bound; `csSup_le` then gives sSup ≤ b(n).\n\nThe lemma `a_le_b_all` is the key auxiliary: it shows any left endpoint is ≤ any right endpoint, even for different indices m,n. This requires considering cases m ≤ n (use monotonicity of a) and m > n (use antitone of b).",
+    "mathContext": "For the limit point $x = \\sup\\{a_n : n \\in \\mathbb{N}\\}$: (1) $x > a_n$ for all $n$: since $a_{n+1} > a_n$ and $a_{n+1} \\leq x$ (by `le_csSup`). (2) $x \\leq b_n$ for all $n$: since $\\{a_m\\}$ is bounded above by $b_n$ (from $a_m \\leq b_m \\leq b_n$ for $m \\geq n$ or $a_m \\leq b_m$ and using antitone $b$), and `csSup_le` gives $x \\leq b_n$.",
+    "significance": "key",
+    "relatedConcepts": ["sSup", "ConditionallyCompleteLinearOrder", "le_csSup", "csSup_le", "BddAbove"],
+    "prerequisites": ["Mathlib.Order.ConditionallyCompleteLattice.Basic", "a_strictMono", "b_antitone", "a_le_b_all"]
+  },
+  {
+    "id": "ann-algcount-oq02-oq02-06",
+    "proofId": "algebraic-numbers-countable-oq-02-oq-02",
+    "range": { "startLine": 219, "endLine": 256 },
+    "type": "concept",
+    "title": "Main Theorems: From Limit Point to ℝ Uncountability",
+    "content": "The climax of the proof is `limitPoint_not_in_range`: for any f : ℕ → ℝ, the limit point differs from every f(n). The proof is a `cases` split on the exclusion property:\n- Left case (f(n) ≤ a(n+1)): `limit_gt_a f (n+1)` gives x > a(n+1) ≥ f(n), so f(n) < x, contradicting heq.\n- Right case (f(n) > b(n+1)): `limit_le_b f (n+1)` gives x ≤ b(n+1) < f(n), so x < f(n), contradicting heq.\n\nFrom this, `exists_real_not_in_range` follows directly (provide limitPoint f as the witness), `no_surjection_nat_to_real` negates any claimed surjection, and `reals_uncountable_nested` applies `Countable.exists_surjective_nat` to reduce countability to surjectivity.",
+    "mathContext": "The contradiction in each case: Left: $f(n) \\leq a_{n+1} < x$ (by `limit_gt_a f (n+1)` and $a_{n+1} < x$) gives $f(n) < x$, but $f(n) = x$ by hypothesis — contradiction. Right: $f(n) > b_{n+1} \\geq x$ (by `limit_le_b f (n+1)`) gives $f(n) > x$ — contradiction. Hence $f(n) \\neq x$ for any $n$, so $x \\notin \\operatorname{range}(f)$.",
+    "significance": "key",
+    "relatedConcepts": ["limitPoint_not_in_range", "exists_real_not_in_range", "reals_uncountable_nested", "Countable.exists_surjective_nat"],
+    "prerequisites": ["limit_gt_a", "limit_le_b", "exclusion", "Countable API in Mathlib"]
+  },
+  {
+    "id": "ann-algcount-oq02-oq02-07",
+    "proofId": "algebraic-numbers-countable-oq-02-oq-02",
+    "range": { "startLine": 258, "endLine": 285 },
+    "type": "context",
+    "title": "Summary: 13 Theorems, 0 Sorries, 0 Axioms",
+    "content": "The closing summary documents the complete proof chain: 13 theorems proved with 0 sorries and 0 axioms. The proof is fully machine-verified, relying only on Mathlib's completeness of ℝ (the `ConditionallyCompleteLattice` structure and associated lemmas `le_csSup`, `csSup_le`).\n\nThe closing comment emphasizes the critical design choice: the *strictly* increasing left endpoints. This is the key innovation over a naive bisection approach. With bisection, if f(n) equals the midpoint, the left endpoint could stay constant, and the limit point could equal f(n). The thirds construction eliminates this by always advancing the left endpoint by at least d/3 > 0.",
+    "mathContext": "Compared to a naive bisection: if f(n) = (a_n + b_n)/2 and we take the right half $[(a_n+b_n)/2, b_n]$, then $a_{n+1} = (a_n+b_n)/2 = f(n)$. If $x = f(n)$, the exclusion gives $f(n) \\leq a_{n+1} = f(n) = x$, which is not a contradiction. The thirds construction avoids this: $a_{n+1} \\geq a_n + d/3 > a_n$, so $x > a_{n+1} \\geq f(n)$ (in the left case) gives a strict contradiction.",
+    "significance": "context",
+    "relatedConcepts": ["proof completeness", "axiom-free verification", "thirds vs bisection", "historical significance"],
+    "prerequisites": ["all prior theorems in the file"]
+  }
+]

--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-02/index.ts
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-02/index.ts
@@ -1,2 +1,36 @@
-import meta from './meta.json';
-export default meta;
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AlgebraicNumbersCountableOQ02OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const algebraicNumbersCountableOq02Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const algebraicNumbersCountableOq02Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const algebraicNumbersCountableOq02Oq02Data: ProofData = {
+  proof: algebraicNumbersCountableOq02Oq02Proof,
+  annotations: algebraicNumbersCountableOq02Oq02Annotations,
+}

--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-02/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-02/meta.json
@@ -72,14 +72,16 @@
     "assumptions": "0 axioms. Relies only on Mathlib's completeness of ℝ (conditional supremum) and basic real arithmetic."
   },
   "overview": {
-    "historicalContext": "In 1874, Cantor published his first proof that ℝ is uncountable, using a nested interval argument. This predates the more famous diagonal argument by 17 years (1891). The nested interval proof is more constructive: given any list of reals, it explicitly constructs a real not on the list. This formalization captures the original 1874 argument in Lean 4.",
+    "historicalContext": "In 1874, Georg Cantor published 'Über eine Eigenschaft des Inbegriffes aller reellen algebraischen Zahlen' (Journal für die reine und angewandte Mathematik, 77, pp. 258-262), introducing his first proof that the real numbers are uncountable. This predates the more famous diagonal argument (1891) by 17 years.\n\nThe nested interval proof is remarkable for its constructive character: given any proposed enumeration f : ℕ → ℝ, it explicitly constructs an interval-based witness — a real number guaranteed not to appear in the list. Cantor's original paper was primarily about algebraic numbers being countable; the uncountability of ℝ was a corollary demonstrating the existence of transcendental numbers.\n\nThis Lean 4 formalization uses a thirds-based subdivision (rather than the halves that might seem natural), a key technical choice that ensures left endpoints strictly increase at every step. Cantor's original argument had this monotonicity property implicitly; making it explicit and proved is the main contribution of this formalization over a naive bisection approach.",
     "problemStatement": "Formalize Cantor's 1874 nested interval construction proving that ℝ is uncountable, as an alternative to the cardinality-based proof in OQ-02.",
     "text": "A 285-line formalization of Cantor's original 1874 proof. The construction divides each interval into thirds and selects a subinterval avoiding f(n), ensuring left endpoints strictly increase. The supremum of left endpoints is then shown to differ from every f(n) by case analysis on the exclusion property.",
     "proofStrategy": "Thirds-based interval subdivision with strict left-endpoint increase. The key insight: by always advancing the left endpoint (by at least d/3), the supremum x satisfies x > aₙ for all n. Combined with the exclusion property (f(n) ≤ aₙ₊₁ or f(n) > bₙ₊₁), this gives f(n) < x or f(n) > x, hence f(n) ≠ x.",
     "keyInsights": [
-      "**Strict monotonicity is essential**: A bisection construction where aₙ sometimes stays constant allows f(n) to equal the limit point. The thirds construction guarantees aₙ₊₁ > aₙ always.",
-      "**Boundary exclusion vs interior exclusion**: Excluding f(n) from the open interior (aₙ₊₁, bₙ₊₁) is insufficient — f(n) could equal an endpoint. Strict monotonicity of (aₙ) ensures the limit point is in the interior of ALL intervals.",
-      "**Completeness of ℝ**: The proof uses sSup (conditional supremum) from ℝ's conditionally complete lattice structure, not compactness or topology."
+      "**Strict monotonicity is essential**: A bisection construction where aₙ sometimes stays constant allows f(n) to equal the limit point. The thirds construction guarantees aₙ₊₁ > aₙ always — the left endpoint advances by at least d/3 > 0 regardless of where f(n) falls.",
+      "**Weak exclusion + strict monotonicity = strict separation**: The exclusion property gives f(n) ≤ a(n+1) (weak ≤, not <), but limit_gt_a gives x > a(n+1) (strict). The combination f(n) ≤ a(n+1) < x yields f(n) < x — a strict inequality from weak hypotheses.",
+      "**Completeness of ℝ via sSup**: The proof uses sSup (conditional supremum) from ℝ's conditionally complete lattice structure. This is the *only* use of completeness — the rest is constructive real arithmetic.",
+      "**Cross-index monotonicity (a_le_b_all)**: The crucial auxiliary that any left endpoint a(m) ≤ any right endpoint b(n), even for different indices. Without this, the bound limit_le_b fails. The proof splits into m ≤ n (use strictMono a) and m > n (use antitone b) cases.",
+      "**Constructive witness**: Unlike the diagonal argument, the nested interval proof provides an explicit real number not in the range of f — the supremum sSup(range(a f)). This constructive character makes the argument well-suited for potential extraction of computational content."
     ],
     "prerequisites": [
       "Completeness of ℝ as a conditionally complete lattice",
@@ -116,21 +118,21 @@
       "id": "main-results",
       "title": "Main Theorems",
       "summary": "Proves the limit point is not in range(f), no surjection ℕ → ℝ exists, and ℝ is uncountable.",
-      "startLine": 222,
-      "endLine": 265,
+      "startLine": 215,
+      "endLine": 285,
       "mathContext": "$f(n) \\neq x$ for all $n$: from exclusion, $f(n) \\leq a_{n+1} < x$ or $f(n) > b_{n+1} \\geq x$."
     }
   ],
   "crossReferences": [
     {
-      "targetId": "algebraic-numbers-countable-oq-02",
+      "id": "algebraic-numbers-countable-oq-02",
       "relationship": "parent",
-      "description": "The parent proof uses cardinality (ℵ₀ < 𝔠) to prove ℝ uncountable. This file provides an alternative constructive proof."
+      "description": "The parent proof uses cardinality (ℵ₀ < 𝔠) to prove ℝ uncountable. This file provides an alternative constructive nested interval proof of the same result."
     },
     {
-      "targetId": "algebraic-numbers-countable",
+      "id": "algebraic-numbers-countable",
       "relationship": "ancestor",
-      "description": "Proves algebraic numbers are countable. Combined with ℝ uncountable, this gives transcendental numbers uncountable."
+      "description": "Proves algebraic numbers are countable. Combined with ℝ uncountable (proved here), this establishes that transcendental numbers are uncountable."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
Enrichment pass for `algebraic-numbers-countable-oq-02-oq-02` (Cantor's 1874 Nested Interval Proof of ℝ Uncountability).

## Quality improvements

- **Fixed `index.ts`** — was broken (only `export default meta`, missing Lean source import and proof/annotation exports)
- **Rewrote `annotations.json`** — was in non-standard format (missing id/proofId/range/mathContext/significance etc.); replaced with 7 properly structured annotations
- **Expanded `historicalContext`** to 3-paragraph narrative with 1874 paper context, constructive character vs diagonal argument, and thirds vs bisection design choice
- **Added 5 keyInsights** (was 3): strict monotonicity, weak exclusion + strict limit combination, sSup completeness, cross-index monotonicity (a_le_b_all), constructive witness
- **Fixed crossReferences format** (targetId → id per schema)
- **Fixed last section endLine** (265→285, covers closing summary)