### PR TITLE
Fix: add missing monic_poly_ratio_tendsto axiom in SumOfKthPowersOQ04

### DIFF
--- a/proofs/Proofs/SumOfKthPowersOQ04.lean
+++ b/proofs/Proofs/SumOfKthPowersOQ04.lean
@@ -70,6 +70,10 @@ noncomputable def powerSumRatio (k n : ℕ) : ℚ :=
     Proof strategy: decompose p = X^d + q where deg(q) < d, then
     p(n)/n^d = 1 + q(n)/n^d. Each term of q(n)/n^d has the form c/n^m
     for m ≥ 1, which → 0 by inv_tendsto_atTop. -/
+axiom monic_poly_ratio_tendsto (p : Polynomial ℚ) (d : ℕ)
+    (hd_deg : p.natDegree = d) (hlc : p.leadingCoeff = 1) (hd : 0 < d) :
+    Filter.Tendsto (fun n : ℕ => p.eval (↑n : ℚ) / (↑n : ℚ) ^ d)
+      Filter.atTop (nhds 1)
 
 /- **Main theorem**: The ratio ∑_{i=0}^{n-1} i^k / n^{k+1} → 1/(k+1) as n → ∞.
 


### PR DESCRIPTION
## Summary

- `proofs/Proofs/SumOfKthPowersOQ04.lean` called `monic_poly_ratio_tendsto` inside the proof of `powerSumRatio_tendsto` (line 131), but the identifier was never declared anywhere in the codebase
- The file's doc comment and `meta.json` (`axiomCount: 1`, status `axiomatized`) correctly described the axiom, but the actual `axiom` declaration was missing — only the doc comment existed as an orphan
- Without this declaration, the file would fail to compile in Lean 4 with an unknown identifier error

## Fix

Added the `axiom` declaration for `monic_poly_ratio_tendsto` immediately after its orphaned doc comment (before the main theorem comment block), with the signature derived from how it is called in the proof:

```lean
axiom monic_poly_ratio_tendsto (p : Polynomial ℚ) (d : ℕ)
    (hd_deg : p.natDegree = d) (hlc : p.leadingCoeff = 1) (hd : 0 < d) :
    Filter.Tendsto (fun n : ℕ => p.eval (↑n : ℚ) / (↑n : ℚ) ^ d)
      Filter.atTop (nhds 1)
```

No changes to `meta.json` were needed — it already correctly records `axiomCount: 1`.

## Test plan

- [x] Axiom declaration added with correct signature matching the call site at line 131
- [x] Doc comment now properly attached to the axiom declaration
- [x] `meta.json` axiomCount remains 1 (correct)
- [ ] `./proofs/scripts/docker-build.sh Proofs.SumOfKthPowersOQ04` — verify Lean accepts the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)