### PR TITLE
Add gallery entries for Erdos #1156 and #1182

### DIFF
--- a/src/data/proofs/erdos-1156/annotations.json
+++ b/src/data/proofs/erdos-1156/annotations.json
@@ -1,0 +1,100 @@
+[
+  {
+    "id": "ann-e1156-header",
+    "proofId": "erdos-1156",
+    "range": {
+      "startLine": 1,
+      "endLine": 47
+    },
+    "type": "concept",
+    "title": "Problem Overview: Chromatic Number Concentration",
+    "content": "**Erdos Problem #1156: Chromatic Number Concentration in Random Graphs**\n\nLet G(n, 1/2) be the Erdos-Renyi random graph on n vertices where each edge appears independently with probability 1/2.\n\n**Q1 (Constant concentration):** Does there exist a constant C such that chi(G) is a.s. concentrated within at most C values?\n\n**Q2 (Anti-concentration):** For any slowly growing omega(n) -> infinity, does there exist f(n) such that Pr[|chi(G) - f(n)| < omega(n)] < 1/2?\n\n**Known results:**\n- Bollobas (1988): chi ~ n/(2 log_2 n)\n- Shamir-Spencer (1987): O(n^{1/2}) concentration\n- Alon-Krivelevich (1997): O(n^{1/2}/log n) concentration\n- Heckel (2021): Two-value concentration for at least half of all n",
+    "mathContext": "The chromatic number chi(G) is the minimum number of colors needed for a proper vertex coloring. For G(n,1/2), chi ~ n/(2 log_2 n) a.s.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Chromatic number",
+      "Erdos-Renyi random graph",
+      "Concentration of measure",
+      "Graph coloring"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-e1156-chromatic",
+    "proofId": "erdos-1156",
+    "range": {
+      "startLine": 55,
+      "endLine": 65
+    },
+    "type": "definition",
+    "title": "Chromatic Number Definition",
+    "content": "**IsKColorable' and chromaticNumber'**\n\nA graph G on vertex type V is k-colorable if there exists a proper coloring f : V -> Fin k such that adjacent vertices receive different colors.\n\nThe chromatic number chi(G) is the infimum of the set of k for which G is k-colorable. Returns 0 if no finite coloring exists.\n\nThese are self-contained definitions (not imported from Mathlib) to avoid dependency issues.",
+    "mathContext": "chi(G) = inf{k : G is k-colorable}. A k-coloring is proper iff f(v) != f(w) whenever v ~ w.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Proper coloring",
+      "Chromatic number",
+      "Graph homomorphism to K_k"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-e1156-random-graph",
+    "proofId": "erdos-1156",
+    "range": {
+      "startLine": 67,
+      "endLine": 79
+    },
+    "type": "concept",
+    "title": "Axiomatized Random Graph Model",
+    "content": "**erdosRenyi and chromaticNumberRV axioms**\n\nThe Erdos-Renyi random graph G(n, 1/2) is axiomatized as a type `erdosRenyi n`, representing a probability distribution over simple graphs on n labeled vertices. The chromatic number of a random graph instance is given by `chromaticNumberRV n : erdosRenyi n -> Nat`.\n\nThese are axioms because a full formalization would require MeasureTheory.Measure on SimpleGraph (Fin n), which is not yet available in Mathlib.",
+    "mathContext": "G(n, 1/2) is a probability space over graphs on {1, ..., n} with P(edge {i,j}) = 1/2 independently.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Erdos-Renyi model",
+      "Probability space",
+      "Random variable",
+      "Measure theory"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-e1156-basic-facts",
+    "proofId": "erdos-1156",
+    "range": {
+      "startLine": 81,
+      "endLine": 96
+    },
+    "type": "technique",
+    "title": "Basic Coloring Theorems",
+    "content": "**isKColorable_card:** Every graph on n vertices is n-colorable. The proof uses the identity coloring f = id : Fin n -> Fin n, which is trivially proper since distinct vertices get distinct colors.\n\n**isKColorable_zero_iff:** A graph G is 0-colorable if and only if G has no edges. In one direction, a coloring f : V -> Fin 0 is impossible for any vertex (Fin 0 is empty), unless V is also empty. In the other direction, the empty function witnesses 0-colorability of an edgeless graph.",
+    "mathContext": "For n-vertex graphs: chi(G) <= n (trivially). chi(G) = 0 iff G has no edges and no vertices.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Identity coloring",
+      "Edgeless graph",
+      "Upper bound on chromatic number"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-e1156-q1",
+    "proofId": "erdos-1156",
+    "range": {
+      "startLine": 98,
+      "endLine": 114
+    },
+    "type": "concept",
+    "title": "The Main Open Conjecture (Q1)",
+    "content": "**erdos_1156_q1_conjecture:**\n\nThe central open question: there exists a constant C such that for all n, there exists m(n) with chi(G(n,1/2)) concentrated within C of m(n) almost surely.\n\nFormally: for all G in the support of G(n,1/2), |chromaticNumberRV(G) - m| <= C.\n\nThis is axiomatized because the answer is unknown. The best partial result is Heckel (2021): for at least half of all n, concentration holds with C = 1 (two consecutive values).",
+    "mathContext": "Conjecture: There exists C in N such that for all n, there exists m(n) with Pr[|chi(G(n,1/2)) - m(n)| > C] -> 0 as n -> infinity.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Concentration inequality",
+      "Heckel two-value theorem",
+      "Shamir-Spencer bound",
+      "Alon-Krivelevich bound"
+    ],
+    "prerequisites": []
+  }
+]

--- a/src/data/proofs/erdos-1156/index.ts
+++ b/src/data/proofs/erdos-1156/index.ts
@@ -1,0 +1,38 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos1156Problem.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos1156Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos1156Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos1156Data: ProofData = {
+  proof: erdos1156Proof,
+  annotations: erdos1156Annotations,
+}
+
+export default erdos1156Data

--- a/src/data/proofs/erdos-1156/meta.json
+++ b/src/data/proofs/erdos-1156/meta.json
@@ -1,0 +1,149 @@
+{
+  "id": "erdos-1156",
+  "title": "Erdos Problem #1156: Chromatic Number Concentration in Random Graphs",
+  "slug": "erdos-1156",
+  "description": "Does the chromatic number of the random graph G(n, 1/2) concentrate on a bounded number of values? Heckel (2021) showed concentration on two consecutive values for at least half of all n, but the general case remains open.",
+  "meta": {
+    "author": "Erdos",
+    "sourceUrl": "https://erdosproblems.com/1156",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos1156Problem.lean",
+    "tags": [
+      "erdos",
+      "graph-theory",
+      "random-graphs",
+      "chromatic-number",
+      "concentration-inequalities",
+      "open"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "erdosNumber": 1156,
+    "erdosUrl": "https://erdosproblems.com/1156",
+    "erdosProblemStatus": "open",
+    "dateAdded": "2026-04-22",
+    "mathlibDependencies": [
+      {
+        "theorem": "SimpleGraph",
+        "description": "Simple graph type and adjacency",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Basic"
+      },
+      {
+        "theorem": "Filter.Basic",
+        "description": "Filter infrastructure for asymptotic statements",
+        "module": "Mathlib.Order.Filter.Basic"
+      }
+    ],
+    "originalContributions": [
+      "IsKColorable' predicate: proper k-coloring via Fin k",
+      "chromaticNumber' definition: minimum colors for proper vertex coloring",
+      "erdosRenyi axiom: random graph model G(n, 1/2)",
+      "chromaticNumberRV axiom: chromatic number as random variable",
+      "erdos_1156_q1_conjecture axiom: constant concentration conjecture",
+      "erdos_1156_q2_conjecture theorem: anti-concentration (trivially proved placeholder)",
+      "isKColorable_card theorem: n-colorability of n-vertex graphs",
+      "isKColorable_zero_iff theorem: 0-colorable iff edgeless"
+    ],
+    "axiomCount": 3,
+    "lineCount": 124,
+    "assumptions": "3 axioms: erdosRenyi (random graph model), chromaticNumberRV (measurability), erdos_1156_q1_conjecture (open conjecture). 0 sorries."
+  },
+  "overview": {
+    "historicalContext": "**Erdos Problem #1156**\n\nThis problem asks about the concentration of the chromatic number of the Erdos-Renyi random graph G(n, 1/2). The chromatic number chi(G) is the minimum number of colors needed for a proper vertex coloring.\n\n**Historical Background:**\n- Bollobas (1988): chi(G(n,1/2)) ~ n/(2 log_2 n) almost surely\n- Shamir-Spencer (1987): chi concentrated in O(n^{1/2}) values\n- Alon-Krivelevich (1997): chi concentrated in O(n^{1/2}/log n) values\n- Heckel (2021): For at least half of all n, chi(G(n,1/2)) is concentrated on two consecutive values\n\n**Status:** OPEN. The gap between the best upper bound O(n^{1/2}/log n) and the conjectured O(1) is substantial.",
+    "problemStatement": "**Question 1 (Constant concentration):**\nDoes there exist a constant C such that chi(G(n, 1/2)) is almost surely concentrated within at most C values?\n\n**Question 2 (Anti-concentration):**\nFor any slowly growing omega(n) -> infinity, does there exist f(n) such that Pr[|chi(G) - f(n)| < omega(n)] < 1/2 for all sufficiently large n?\n\nQuestion 1 remains the central open problem. Question 2 is stated as a placeholder (the measure-theoretic formalization would require MeasureTheory).",
+    "text": "Does there exist a constant C such that the chromatic number of G(n, 1/2) is almost surely concentrated within at most C values?",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Chromatic Number:** Self-contained definition via IsKColorable' and chromaticNumber' (minimum k for proper k-coloring)\n\n2. **Random Graph Model:** Axiomatized via erdosRenyi type and chromaticNumberRV (no MeasureTheory infrastructure in Mathlib for graph probability spaces)\n\n3. **Question 1:** Axiomatized as erdos_1156_q1_conjecture -- existence of constant C bounding concentration width\n\n4. **Question 2:** Proved trivially (placeholder body is True) -- proper formalization needs measure theory\n\n5. **Basic Facts:** Proved isKColorable_card (every n-vertex graph is n-colorable) and isKColorable_zero_iff (0-colorable iff edgeless)",
+    "keyInsights": [
+      "**Bollobas Asymptotic:** chi(G(n,1/2)) ~ n/(2 log_2 n) a.s. -- the chromatic number grows, but slowly relative to n",
+      "**Concentration Gap:** Best known upper bound is O(n^{1/2}/log n) values, but the conjecture is O(1) -- a polynomial gap",
+      "**Heckel's Breakthrough:** For at least half of all n, chi concentrates on just TWO consecutive values",
+      "**Infrastructure Gap:** Full formalization requires random graph probability spaces not yet in Mathlib",
+      "**Two Questions:** Q1 asks for constant concentration (open), Q2 asks about anti-concentration (weaker, also open in full generality)"
+    ],
+    "prerequisites": [
+      "Graph theory (chromatic number, graph coloring)",
+      "Probability theory (random graphs, concentration inequalities)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "chromatic-number",
+      "title": "Chromatic Number Definition",
+      "summary": "Self-contained definitions of k-colorability and chromatic number",
+      "startLine": 55,
+      "endLine": 65,
+      "mathContext": "IsKColorable' and chromaticNumber' definitions using Fin k colorings"
+    },
+    {
+      "id": "random-graph-model",
+      "title": "Random Graph Model (Axiomatized)",
+      "summary": "Axioms for the Erdos-Renyi random graph G(n, 1/2) and measurability of chromatic number",
+      "startLine": 67,
+      "endLine": 79,
+      "mathContext": "erdosRenyi type axiom and chromaticNumberRV axiom"
+    },
+    {
+      "id": "basic-facts",
+      "title": "Basic Coloring Facts",
+      "summary": "Proved: every n-vertex graph is n-colorable; 0-colorable iff edgeless",
+      "startLine": 81,
+      "endLine": 96,
+      "mathContext": "isKColorable_card and isKColorable_zero_iff theorems"
+    },
+    {
+      "id": "q1-conjecture",
+      "title": "Question 1: Constant Concentration (Open)",
+      "summary": "The main open conjecture: chi(G(n,1/2)) concentrates within O(1) values",
+      "startLine": 98,
+      "endLine": 114,
+      "mathContext": "erdos_1156_q1_conjecture axiom: existence of constant C for concentration"
+    },
+    {
+      "id": "q2-placeholder",
+      "title": "Question 2: Anti-Concentration (Placeholder)",
+      "summary": "Trivially proved placeholder for the anti-concentration question",
+      "startLine": 116,
+      "endLine": 124,
+      "mathContext": "erdos_1156_q2_conjecture theorem (body is True, proved trivially)"
+    }
+  ],
+  "conclusion": {
+    "summary": "Erdos Problem #1156 asks whether the chromatic number of G(n, 1/2) concentrates on a bounded number of values. Despite major progress (Shamir-Spencer, Alon-Krivelevich, Heckel), the conjecture remains open. The formalization axiomatizes the random graph model and states both the constant concentration conjecture (Q1) and the anti-concentration question (Q2).",
+    "implications": "**Significance in Random Graph Theory**\n\n1. **Central Open Problem:** One of the most important questions about random graph colorings\n\n2. **Concentration Phenomena:** Connects to broader themes of concentration of measure in probability\n\n3. **Heckel's Result:** The 2021 breakthrough showing two-value concentration for half of n suggests the conjecture may be true\n\n4. **Infrastructure Gap:** Full formalization awaits development of random graph probability spaces in Mathlib",
+    "openQuestions": [
+      "Does chi(G(n,1/2)) concentrate on O(1) values for ALL n (not just half)?",
+      "What is the optimal concentration width -- is it exactly 2?",
+      "Can the Alon-Krivelevich O(n^{1/2}/log n) bound be improved substantially?",
+      "Does the concentration behavior change for G(n, p) with p != 1/2?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Tactic",
+      "Mathlib.Combinatorics.SimpleGraph.Basic",
+      "Mathlib.Order.Filter.Basic"
+    ],
+    "opens": [
+      "SimpleGraph"
+    ],
+    "namespace": "",
+    "lineCount": 124,
+    "axiomCount": 3,
+    "theoremCount": 3,
+    "definitionCount": 2,
+    "path": "Proofs/Erdos1156Problem.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-2",
+      "relationship": "related",
+      "description": "Erdos #2 also concerns random graph properties and probabilistic combinatorics"
+    },
+    {
+      "targetId": "erdos-39",
+      "relationship": "related",
+      "description": "Erdos #39 involves chromatic number bounds in graph theory"
+    }
+  ]
+}

--- a/src/data/proofs/erdos-1182/annotations.json
+++ b/src/data/proofs/erdos-1182/annotations.json
@@ -1,0 +1,102 @@
+[
+  {
+    "id": "ann-e1182-header",
+    "proofId": "erdos-1182",
+    "range": {
+      "startLine": 1,
+      "endLine": 29
+    },
+    "type": "concept",
+    "title": "Problem Overview: Ramsey-Theoretic Edge Thresholds",
+    "content": "**Erdos Problem #1182: Ramsey-Theoretic Edge Thresholds**\n\nLet f(n) = max edges in a connected n-vertex graph G with R(K_3, G) = 2n - 1.\nLet F(n) = max edges such that EVERY connected n-vertex graph with <= F(n) edges satisfies R(K_3, G) = 2n - 1.\n\n**Known bounds:**\n- F(n) >= n - 1 (Chvatal: trees satisfy R(K_3, T) = 2n - 1)\n- (17n + 1)/15 <= F(n) <= (27/4 + o(1)) * n * (log n)^2\n- sqrt(log n) * n^{3/2} << f(n) << n^{5/3} * (log n)^{2/3}\n\n**Computed small values:**\n  n:    2  3  4  5   6\n  F(n): 1  2  5  7   8\n  f(n): 1  2  5  8  12",
+    "mathContext": "R(K_3, G) is the minimum r such that any 2-coloring of K_r contains a red triangle or a blue copy of G.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Ramsey numbers",
+      "Extremal graph theory",
+      "Graph coloring",
+      "Tree Ramsey numbers"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-e1182-ramsey-def",
+    "proofId": "erdos-1182",
+    "range": {
+      "startLine": 40,
+      "endLine": 46
+    },
+    "type": "definition",
+    "title": "Ramsey Number Definition",
+    "content": "**ramseyNumber(s, t):**\n\nThe classical Ramsey number R(s, t) defined as the infimum of all r >= 1 such that every 2-coloring of the edges of K_r contains either a red clique of size s or a blue clique of size t.\n\nThe definition uses sInf over a set of natural numbers, with the r >= 1 condition ensuring non-degeneracy.",
+    "mathContext": "R(s,t) = min{r >= 1 : every 2-coloring of K_r has a red K_s or blue K_t}. R(3,3) = 6 is the classic example.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Ramsey theorem",
+      "Complete graph",
+      "Edge coloring",
+      "Clique"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-e1182-thresholds",
+    "proofId": "erdos-1182",
+    "range": {
+      "startLine": 77,
+      "endLine": 97
+    },
+    "type": "definition",
+    "title": "Threshold Functions f(n) and F(n)",
+    "content": "**f_threshold(n)** = sSup{e : exists G with edgeCount(G) = e and R(K_3, G) = 2n - 1}\n\nThis is the maximum number of edges achievable by any connected n-vertex graph with the tree-like Ramsey bound.\n\n**bigF_threshold(n)** = sSup{e <= n(n-1)/2 : for all connected G with edgeCount(G) <= e, R(K_3, G) = 2n - 1}\n\nThis is the maximum threshold guaranteeing the Ramsey bound for ALL connected graphs below it. The explicit edge-count bound e <= n(n-1)/2 ensures the set is bounded above for the sSup to be well-behaved on natural numbers.",
+    "mathContext": "f(n) measures the extremal edge count; F(n) measures the universal guarantee threshold. Always F(n) <= f(n).",
+    "significance": "key",
+    "relatedConcepts": [
+      "Extremal function",
+      "sSup on natural numbers",
+      "Bounded above condition",
+      "Universal vs existential thresholds"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-e1182-chvatal",
+    "proofId": "erdos-1182",
+    "range": {
+      "startLine": 99,
+      "endLine": 111
+    },
+    "type": "concept",
+    "title": "Chvatal's Tree Ramsey Theorem",
+    "content": "**chvatal_tree_ramsey (axiom):**\n\nFor any tree T on n >= 2 vertices, R(K_3, T) = 2n - 1 (Chvatal 1977).\n\nThis is the foundational result: trees achieve the smallest possible Ramsey number among connected graphs. Trees have exactly n - 1 edges, so they sit at the bottom of the edge-count hierarchy.\n\n**connected_min_edges (axiom):** A connected graph on n >= 1 vertices has at least n - 1 edges.\n\nCombined with Chvatal's theorem, this gives F(n) >= n - 1: any connected graph with at most n - 1 edges must be a tree, so it satisfies R(K_3, G) = 2n - 1.",
+    "mathContext": "Chvatal (1977): R(K_3, T_n) = 2n - 1 for trees. This is tight: R(K_3, K_n) grows as Theta(n^2/log n).",
+    "significance": "key",
+    "relatedConcepts": [
+      "Tree Ramsey number",
+      "Chvatal 1977",
+      "Connected graph",
+      "Minimum spanning tree"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-e1182-proved",
+    "proofId": "erdos-1182",
+    "range": {
+      "startLine": 157,
+      "endLine": 230
+    },
+    "type": "technique",
+    "title": "Proved Bounds and Small Cases",
+    "content": "**bigF_lower_bound_tree:** F(n) >= n - 1 for n >= 2.\n\nProof: n - 1 satisfies the defining condition of bigF_threshold. If G is connected with edgeCount(G) <= n - 1, then connected_min_edges gives edgeCount(G) >= n - 1, so edgeCount(G) = n - 1 exactly. Then G is a tree and chvatal_tree_ramsey applies.\n\n**f_val_2:** f(2) = 1. K_2 has 1 edge, R(K_3, K_2) = 3 = 2*2 - 1, and no graph on 2 vertices can have more than 1 edge.\n\n**bigF_val_2:** F(2) = 1. The only connected graph on 2 vertices is K_2 (1 edge), and it satisfies R(K_3, K_2) = 3.",
+    "mathContext": "The proofs use sSup/sInf properties (le_csSup, csSup_le) with explicit boundedness witnesses.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Lattice supremum",
+      "BddAbove witness",
+      "Small Ramsey numbers",
+      "Complete graph K_2"
+    ],
+    "prerequisites": []
+  }
+]

--- a/src/data/proofs/erdos-1182/index.ts
+++ b/src/data/proofs/erdos-1182/index.ts
@@ -1,0 +1,38 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos1182Problem.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos1182Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos1182Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos1182Data: ProofData = {
+  proof: erdos1182Proof,
+  annotations: erdos1182Annotations,
+}
+
+export default erdos1182Data

--- a/src/data/proofs/erdos-1182/meta.json
+++ b/src/data/proofs/erdos-1182/meta.json
@@ -1,0 +1,165 @@
+{
+  "id": "erdos-1182",
+  "title": "Erdos Problem #1182: Ramsey-Theoretic Edge Thresholds",
+  "slug": "erdos-1182",
+  "description": "Estimate the maximum edges f(n) and threshold F(n) for connected n-vertex graphs G satisfying R(K_3, G) = 2n - 1. In particular, does F(n)/n tend to infinity?",
+  "meta": {
+    "author": "Burr, Erdos, Faudree, Rousseau, Schelp (1980)",
+    "sourceUrl": "https://erdosproblems.com/1182",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos1182Problem.lean",
+    "tags": [
+      "erdos",
+      "graph-theory",
+      "ramsey-theory",
+      "extremal-combinatorics",
+      "open"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "erdosNumber": 1182,
+    "erdosUrl": "https://erdosproblems.com/1182",
+    "erdosProblemStatus": "open",
+    "dateAdded": "2026-04-22",
+    "mathlibDependencies": [
+      {
+        "theorem": "Mathlib",
+        "description": "Full Mathlib import for Finset, SimpleGraph, classical logic, and Relation.ReflTransGen",
+        "module": "Mathlib"
+      }
+    ],
+    "originalContributions": [
+      "ramseyNumber definition: Nat-valued Ramsey number R(s, t) via sInf",
+      "Graph structure: simple graph on Fin n with adj, symm, irrefl",
+      "edgeCount definition: number of unordered adjacent pairs",
+      "Graph.Connected definition: reachability via ReflTransGen",
+      "graphRamseyK3 definition: R(K_3, G) for a specific graph G",
+      "f_threshold definition: max edges with R(K_3, G) = 2n - 1",
+      "bigF_threshold definition: max edges guaranteeing R(K_3, G) = 2n - 1 for all connected graphs",
+      "erdos_1182_conjecture definition: does F(n)/n -> infinity?",
+      "chvatal_tree_ramsey axiom: R(K_3, T) = 2n - 1 for trees (Chvatal 1977)",
+      "connected_min_edges axiom: connected graph has >= n - 1 edges",
+      "bigF_lower_linear axiom: F(n) >= (17n + 1)/15 (BEFRS 1980)",
+      "bigF_lower_bound_tree theorem: F(n) >= n - 1 (proved)",
+      "f_val_2 theorem: f(2) = 1 (proved)",
+      "bigF_val_2 theorem: F(2) = 1 (proved)",
+      "completeGraph2 definition with edge count and connectivity lemmas"
+    ],
+    "axiomCount": 3,
+    "lineCount": 277,
+    "assumptions": "3 axioms: chvatal_tree_ramsey (Chvatal 1977), connected_min_edges (standard), bigF_lower_linear (BEFRS 1980). 0 sorries."
+  },
+  "overview": {
+    "historicalContext": "**Erdos Problem #1182**\n\nThis problem was posed by Burr, Erdos, Faudree, Rousseau, and Schelp (BEFRS) in their 1980 paper on Ramsey-theoretic edge thresholds.\n\n**Historical Background:**\n- Chvatal (1977): For any tree T on n vertices, R(K_3, T) = 2n - 1\n- This means trees are 'Ramsey-minimal' for the triangle -- they achieve the smallest possible Ramsey number\n- BEFRS (1980) asked: how many more edges can a graph have while still achieving R(K_3, G) = 2n - 1?\n\n**Known bounds:**\n- F(n) >= n - 1 (trees, by Chvatal)\n- (17n + 1)/15 <= F(n) <= (27/4 + o(1)) * n * (log n)^2\n- sqrt(log n) * n^{3/2} << f(n) << n^{5/3} * (log n)^{2/3}\n\n**Status:** OPEN -- the central question F(n)/n -> infinity remains unresolved.",
+    "problemStatement": "**Problem Statement**\n\nLet f(n) = max edges in a connected n-vertex graph G with R(K_3, G) = 2n - 1.\nLet F(n) = max edges such that EVERY connected n-vertex graph G with <= F(n) edges satisfies R(K_3, G) = 2n - 1.\n\nEstimate f(n) and F(n). In particular, does F(n)/n -> infinity?\n\nThe function f(n) measures the maximum edge count compatible with the tree-like Ramsey bound, while F(n) measures the threshold below which ALL connected graphs achieve this bound.",
+    "text": "Estimate f(n) and F(n) for Ramsey-theoretic edge thresholds. Does F(n)/n -> infinity?",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Ramsey Numbers:** ramseyNumber(s,t) defined via sInf over 2-colorings of complete graphs\n\n2. **Graph Infrastructure:** Custom Graph structure on Fin n with edgeCount, connectivity, and the graph-specific graphRamseyK3\n\n3. **Threshold Functions:** f_threshold via sSup of edge counts achieving R(K_3,G) = 2n-1; bigF_threshold via sSup of edge counts guaranteeing this for all connected graphs\n\n4. **Axiomatized Results:** Chvatal's tree theorem, BEFRS linear lower bound, and connected_min_edges\n\n5. **Proved Results:** F(n) >= n-1 from Chvatal + connectivity; f(2) = 1 and F(2) = 1 via explicit K_2 construction\n\n6. **Small Cases:** Complete infrastructure for Graph 2 including completeGraph2, edge counting, and connectivity proofs",
+    "keyInsights": [
+      "**Chvatal's Theorem:** R(K_3, T) = 2n - 1 for any tree T on n vertices -- trees are Ramsey-optimal for triangles",
+      "**Two Threshold Functions:** f(n) (maximum achievable) and F(n) (universal guarantee) capture different extremal questions",
+      "**Connectivity Matters:** The definitions correctly restrict to connected graphs, following the original BEFRS formulation",
+      "**Proved Lower Bound:** F(n) >= n - 1 follows from Chvatal because connected graphs with <= n-1 edges are trees",
+      "**Small Cases Computed:** f(2) = F(2) = 1 proved via explicit K_2 construction and Ramsey computation",
+      "**Explicit sSup/sInf:** The formalization uses lattice-theoretic supremum/infimum, requiring careful boundedness arguments"
+    ],
+    "prerequisites": [
+      "Graph theory (Ramsey numbers, graph coloring, connectivity)",
+      "Combinatorics (extremal graph theory, edge counting)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "ramsey-numbers",
+      "title": "Ramsey Number Definition",
+      "summary": "ramseyNumber(s, t) via sInf over 2-colorings of complete graphs",
+      "startLine": 40,
+      "endLine": 46,
+      "mathContext": "R(s,t) = min r such that any 2-coloring of K_r has a red K_s or blue K_t"
+    },
+    {
+      "id": "graph-infrastructure",
+      "title": "Graph Infrastructure",
+      "summary": "Graph structure, edgeCount, connectivity, and graphRamseyK3 definitions",
+      "startLine": 48,
+      "endLine": 75,
+      "mathContext": "Custom Graph type on Fin n with adj/symm/irrefl, edge counting via filtered Finset, connectivity via ReflTransGen"
+    },
+    {
+      "id": "threshold-functions",
+      "title": "Threshold Functions f(n) and F(n)",
+      "summary": "f_threshold and bigF_threshold definitions via sSup",
+      "startLine": 77,
+      "endLine": 97,
+      "mathContext": "f(n) = sSup{edges | exists G with edgeCount = e and R(K_3,G) = 2n-1}; F(n) = sSup{e | all connected G with <= e edges satisfy R(K_3,G) = 2n-1}"
+    },
+    {
+      "id": "known-results",
+      "title": "Axiomatized Known Results",
+      "summary": "Chvatal's tree theorem, connected_min_edges, and BEFRS lower bound",
+      "startLine": 99,
+      "endLine": 111,
+      "mathContext": "Chvatal (1977), connected graph minimum edges, and BEFRS (1980) linear lower bound"
+    },
+    {
+      "id": "small-cases",
+      "title": "Small Case Infrastructure (K_2)",
+      "summary": "completeGraph2 construction with edge count and connectivity proofs",
+      "startLine": 113,
+      "endLine": 155,
+      "mathContext": "K_2 has exactly 1 edge, is connected, and serves as the base case for f(2) and F(2)"
+    },
+    {
+      "id": "proved-bounds",
+      "title": "Proved Bounds",
+      "summary": "F(n) >= n-1, f(2) = 1, F(2) = 1 -- all proved from axioms",
+      "startLine": 157,
+      "endLine": 230,
+      "mathContext": "bigF_lower_bound_tree from Chvatal + connectivity; f_val_2 and bigF_val_2 via K_2 construction"
+    },
+    {
+      "id": "open-question",
+      "title": "The Main Open Question",
+      "summary": "erdos_1182_conjecture: does F(n)/n -> infinity?",
+      "startLine": 232,
+      "endLine": 242,
+      "mathContext": "For all C, exists N_0 such that F(n) >= C*n for n >= N_0"
+    }
+  ],
+  "conclusion": {
+    "summary": "Erdos Problem #1182 investigates Ramsey-theoretic edge thresholds: how many edges can a connected graph have while still satisfying the tree-like Ramsey bound R(K_3, G) = 2n - 1? The formalization defines both threshold functions f(n) and F(n), axiomatizes key results (Chvatal 1977, BEFRS 1980), and proves F(n) >= n-1 along with the base cases f(2) = F(2) = 1.",
+    "implications": "**Significance in Ramsey Theory**\n\n1. **Ramsey Minimality:** Trees are the canonical graphs achieving R(K_3, G) = 2n - 1, and this problem asks how far this extends beyond trees\n\n2. **Two Extremal Questions:** f(n) and F(n) capture maximum achievable vs. universal guarantee -- a fundamental duality in extremal combinatorics\n\n3. **Gap in Bounds:** The substantial gap between known upper and lower bounds for both f(n) and F(n) indicates the difficulty of the problem\n\n4. **BEFRS Legacy:** Part of the influential 1980 program studying Ramsey numbers of sparse graphs",
+    "openQuestions": [
+      "Does F(n)/n -> infinity? This is the central open question.",
+      "What are the exact values of f(n) and F(n) for small n beyond n = 6?",
+      "Can the upper bound F(n) <= (27/4 + o(1)) * n * (log n)^2 be improved?",
+      "What is the correct order of growth for f(n) between n^{3/2} and n^{5/3}?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Classical"
+    ],
+    "namespace": "Erdos1182",
+    "lineCount": 277,
+    "axiomCount": 3,
+    "theoremCount": 6,
+    "definitionCount": 9,
+    "path": "Proofs/Erdos1182Problem.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-83",
+      "relationship": "related",
+      "description": "Erdos #83 also concerns Ramsey numbers for specific graph classes"
+    },
+    {
+      "targetId": "erdos-888",
+      "relationship": "related",
+      "description": "Erdos #888 involves extremal graph theory and edge-counting thresholds"
+    }
+  ]
+}

--- a/src/data/research/problems/erdos-1156.json
+++ b/src/data/research/problems/erdos-1156.json
@@ -1,8 +1,8 @@
 {
   "slug": "erdos-1156",
   "title": "Erdős #1156",
-  "phase": "OBSERVE",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "graduated",
   "tier": "A",
   "path": "full",
   "problemStatement": {
@@ -47,7 +47,8 @@
   "relatedProofs": [
     "erdos-1",
     "erdos-11",
-    "erdos-115"
+    "erdos-115",
+    "erdos-1156"
   ],
   "references": {
     "papers": [],

--- a/src/data/research/problems/erdos-1182.json
+++ b/src/data/research/problems/erdos-1182.json
@@ -1,8 +1,8 @@
 {
   "slug": "erdos-1182",
   "title": "Erdős #1182",
-  "phase": "OBSERVE",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "graduated",
   "tier": "A",
   "path": "full",
   "problemStatement": {
@@ -53,7 +53,8 @@
   "relatedProofs": [
     "erdos-1",
     "erdos-11",
-    "erdos-118"
+    "erdos-118",
+    "erdos-1182"
   ],
   "references": {
     "papers": [],


### PR DESCRIPTION
## Summary

- Create gallery directories for Erdos problems #1156 and #1182, which had orphaned Lean proof files with no corresponding gallery integration
- Each entry includes meta.json, annotations.json, and index.ts following existing gallery patterns
- Mark both research stubs as graduated (status: graduated, phase: COMPLETED)

**Erdos #1156 -- Chromatic Number Concentration in Random Graphs**
- 124 lines, 3 axioms (erdosRenyi model, chromaticNumberRV measurability, Q1 conjecture), 0 sorries
- Status: open problem. Axiomatizes the random graph model and both concentration questions
- 5 annotations covering chromatic number definitions, random graph model, basic facts, and the open conjecture

**Erdos #1182 -- Ramsey-Theoretic Edge Thresholds**
- 277 lines, 3 axioms (Chvatal tree theorem, connected_min_edges, BEFRS linear bound), 0 sorries
- Status: open problem. Defines threshold functions f(n) and F(n), proves F(n) >= n-1 and base cases f(2) = F(2) = 1
- 5 annotations covering Ramsey definitions, threshold functions, Chvatal's theorem, and proved bounds

## Test plan

- [x] `pnpm build` passes with new entries
- [x] Both entries appear in generated listings.json
- [x] Research stubs updated to graduated status
- [x] Axiom counts match Lean source (3 each, no structure-encoded assumptions)
- [x] Line counts match actual files (124 and 277)