### PR TITLE
chore: lower SpernerMathlib4 maxHeartbeats 1600000→400000

### DIFF
--- a/proofs/Proofs/SpernerMathlib4.lean
+++ b/proofs/Proofs/SpernerMathlib4.lean
@@ -48,7 +48,7 @@ total doors ≡ panchromatic cells (mod 2).
 Sperner, combinatorics, parity, triangulation, door-counting
 -/
 
-set_option maxHeartbeats 1600000
+set_option maxHeartbeats 400000
 
 open Finset
 


### PR DESCRIPTION
## Summary

- PR #11123 replaced the expensive `strongInduction` proof of `even_card_of_fpf_invol` with a 13-line `sum_involution` proof and verified `maxHeartbeats 400000` compiles — but never lowered the limit
- This PR applies the 75% reduction: `set_option maxHeartbeats 1600000` → `set_option maxHeartbeats 400000`

## Test plan

- [x] `./proofs/scripts/docker-build.sh Proofs.SpernerMathlib4` — ✅ succeeded with `maxHeartbeats 400000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)