### PR TITLE
Audit fix: sorry count mismatches in 2 proofs

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-01/meta.json
@@ -2,12 +2,12 @@
   "id": "arithmetic-series-oq-02-oq-02-oq-03-oq-01",
   "title": "Pólya Enumeration via Cyclic Group Actions",
   "slug": "arithmetic-series-oq-02-oq-02-oq-03-oq-01",
-  "description": "Formalizes Burnside's lemma and Pólya's enumeration theorem for cyclic groups acting on bead necklaces. Proves 6 binary necklaces of length 4 via Burnside, verifies the Pólya formula n·|Necklaces(n,2)| = Σ_{d|n} φ(d)·2^{n/d} for n=2,3,4,6, and explicitly computes necklace counts for n=1–6. Key insight: using ZMod n → Fin k colorings gives a clean axiom-free group action via ZMod subtraction. 1 sorry for the general Pólya theorem.",
+  "description": "Formalizes Burnside's lemma and Pólya's enumeration theorem for cyclic groups acting on bead necklaces. Proves 6 binary necklaces of length 4 via Burnside, verifies the Pólya formula n·|Necklaces(n,2)| = Σ_{d|n} φ(d)·2^{n/d} for n=2,3,4,6, and explicitly computes necklace counts for n=1–6. Key insight: using ZMod n → Fin k colorings gives a clean axiom-free group action via ZMod subtraction. General Pólya theorem now fully proved (0 sorries).",
   "meta": {
     "author": "G. Pólya (1937); formalized here",
     "sourceUrl": "https://en.wikipedia.org/wiki/P%C3%B3lya_enumeration_theorem",
     "date": "1937",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean",
     "dateAdded": "2026-04-04",
     "tags": [
@@ -21,12 +21,12 @@
       "zmod",
       "research"
     ],
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "verified",
+    "sorries": 0,
     "axiomCount": 0,
     "theoremCount": 23,
     "defCount": 4,
-    "lineCount": 365,
+    "lineCount": 507,
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
       {
@@ -131,10 +131,10 @@
     },
     {
       "id": "general-statement",
-      "title": "§5: General Pólya Theorem (1 sorry)",
+      "title": "§5: General Pólya Theorem (proved)",
       "startLine": 281,
       "endLine": 324,
-      "summary": "States polya_enumeration_theorem_CN: n · necklaceCount n k = Σ_{d|n} φ(d) · k^{n/d}. The proof outline is given (Burnside + cycle structure + totient grouping) but requires the cycle structure theorem |Fix(r)| = k^{gcd(r.val,n)}, left as 1 sorry.",
+      "summary": "Proves polya_enumeration_theorem_CN: n · necklaceCount n k = Σ_{d|n} φ(d) · k^{n/d}. The proof uses Burnside + cycle structure + totient grouping. Fully proved (0 sorries).",
       "mathContext": "$n \\cdot |\\text{Necklaces}(n,k)| = \\sum_{d|n} \\varphi(d) \\cdot k^{n/d}$. Proof gap: need $|\\text{Fix}(r)| = k^{\\gcd(r,n)}$ for all $r \\in \\mathbb{Z}/n\\mathbb{Z}$.",
       "theorems": [
         "polya_enumeration_theorem_CN"
@@ -153,7 +153,7 @@
     }
   ],
   "conclusion": {
-    "summary": "365-line formalization proving 23 theorems (1 sorry) from 0 axioms. Burnside's lemma is used to count necklaces; the Pólya divisor-sum formula is verified for small n. The general Pólya theorem remains as 1 sorry pending the cycle structure theorem.",
+    "summary": "Fully verified formalization proving 23 theorems (0 sorries) from 0 axioms. Burnside's lemma is used to count necklaces; the Pólya divisor-sum formula is verified for small n and proved in general via Burnside + cycle structure + totient grouping.",
     "implications": "Pólya's enumeration theorem is the foundational tool for counting combinatorial objects up to symmetry. The formalization demonstrates that Burnside's lemma from Mathlib is powerful enough to count necklaces concretely, and that ZMod-indexed colorings provide a particularly clean Lean 4 approach. The cycle structure theorem (each rotation by r has gcd(r,n) orbits on n positions) is the key missing ingredient for the general theorem — it connects the abstract Burnside sum to the totient-weighted divisor sum. The sequence [2,3,4,6,8,14] (binary necklaces for n=1–6) appears in OEIS A000029 and has applications in chemistry (molecular isomers), music theory (necklace rhythms), and coding theory (cyclic codes).",
     "openQuestions": [
       "Prove the cycle structure theorem: for rotation by r in ZMod n acting on ZMod n → Fin k, the number of fixed-point colorings is k^{gcd(r.val, n)}. This would close the 1 sorry and complete the general Pólya theorem.",
@@ -174,5 +174,5 @@
       "description": "Grandparent: 2D Hockey Stick Identity in the arithmetic series hierarchy"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11806,10 +11806,14 @@
       "issues": []
     },
     "arithmetic-series-oq-02-oq-02-oq-03-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-05T12:31:16Z",
-      "result": "clean",
-      "issues": []
+      "auditCount": 2,
+      "lastAudited": "2026-04-22T12:00:00Z",
+      "result": "issues-fixed",
+      "issues": [
+        "sorries 1->0 (general Polya theorem now fully proved)",
+        "status formalized->verified, badge wip->verified",
+        "lineCount 365->507"
+      ]
     },
     "basel-problem-oq-01-oq-03": {
       "auditCount": 1,
@@ -12832,9 +12836,9 @@
       "issues": []
     },
     "ballot-problem-oq-03-oq-01-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-21T16:05:40Z",
-      "result": "fixed",
+      "auditCount": 2,
+      "lastAudited": "2026-04-22T12:00:00Z",
+      "result": "clean",
       "issues": []
     },
     "bezout-identity-oq-04-oq-02": {
@@ -12882,10 +12886,14 @@
       "issues": []
     },
     "erdos-476-oq-05": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T20:00:58Z",
-      "result": "clean",
-      "issues": []
+      "auditCount": 3,
+      "lastAudited": "2026-04-22T12:00:00Z",
+      "result": "issues-fixed",
+      "issues": [
+        "sorries 3->1 (ap_of_near_periodic and vosper_base now fully proved)",
+        "lineCount 194->306",
+        "theoremCount 7->8"
+      ]
     },
     "ptolemys-theorem-oq-01-oq-01": {
       "auditCount": 1,

--- a/src/data/proofs/erdos-476-oq-05/meta.json
+++ b/src/data/proofs/erdos-476-oq-05/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-476-oq-05",
   "title": "Erdős #476 OQ5: Vosper's Theorem — Equality Case of Cauchy-Davenport",
   "slug": "erdos-476-oq-05",
-  "description": "Vosper's theorem (1956): if |A+B| = |A|+|B|-1 in Z/pZ with |A|,|B|≥2 and |A+B|<p, then A and B are arithmetic progressions with the same common difference d. Infrastructure proved: IsArithmeticProgression definition, singleton/pair AP lemmas, translation invariance. Full Vosper requires sorry pending the inductive step.",
+  "description": "Vosper's theorem (1956): if |A+B| = |A|+|B|-1 in Z/pZ with |A|,|B|≥2 and |A+B|<p, then A and B are arithmetic progressions with the same common difference d. Infrastructure fully proved: IsArithmeticProgression definition, singleton/pair AP lemmas, translation invariance, ap_of_near_periodic (backward-shift induction), and vosper_base (|A|=2 case). Full Vosper induction (1 sorry) remains open.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-21",
@@ -18,12 +18,12 @@
       "zmod"
     ],
     "badge": "wip",
-    "sorries": 3,
+    "sorries": 1,
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "assumptions": "3 sorries: (1) ap_of_near_periodic — key sublemma: if |B\\(B+d)|=1 and |B|<p then B is an AP (requires backward-shift induction on |B|); (2) vosper_base — the |A|=2 base case using sublemma; (3) vosper — full Vosper by induction on |A|. Infrastructure (IsArithmeticProgression, isAP_singleton, isAP_pair, isAP_shift, shift_card_eq) all proved with 0 sorries.",
-    "lineCount": 194,
-    "theoremCount": 7,
+    "assumptions": "1 sorry: vosper — full Vosper theorem by induction on |A|. Both ap_of_near_periodic (backward-shift induction) and vosper_base (|A|=2 case) are now fully proved. Infrastructure (IsArithmeticProgression, isAP_singleton, isAP_pair, isAP_shift, shift_card_eq) all proved with 0 sorries.",
+    "lineCount": 306,
+    "theoremCount": 8,
     "definitionCount": 1,
     "originalContributions": [
       "IsArithmeticProgression: AP definition for Finset (ZMod p) with starting point a and difference d",
@@ -31,8 +31,8 @@
       "isAP_pair: {a,b} is an AP with difference b-a (proved, 0 sorries)",
       "isAP_shift: translation preserves AP structure (proved, 0 sorries)",
       "shift_card_eq: |B.image (·+d)| = |B| via add_right_injective (proved, 0 sorries)",
-      "ap_of_near_periodic: B is AP if |B\\(B+d)|=1 (1 sorry — backward-shift induction)",
-      "vosper_base: Vosper for |A|=2 (1 sorry — uses ap_of_near_periodic)",
+      "ap_of_near_periodic: B is AP if |B\\(B+d)|=1 (proved — backward-shift induction)",
+      "vosper_base: Vosper for |A|=2 (proved — uses ap_of_near_periodic)",
       "vosper: full Vosper theorem (1 sorry — induction on |A|)"
     ]
   },
@@ -56,7 +56,7 @@
     ]
   },
   "conclusion": {
-    "summary": "Infrastructure for Vosper's theorem fully established: IsArithmeticProgression defined, basic AP lemmas proved (singleton, pair, shift, cardinality). Three sorries remain: the key near-periodicity sublemma, the base case, and the full induction. The mathematical structure is clear and the proof strategy is sound.",
+    "summary": "Infrastructure for Vosper's theorem fully established and mostly proved: IsArithmeticProgression defined, basic AP lemmas proved (singleton, pair, shift, cardinality), ap_of_near_periodic proved (backward-shift induction), vosper_base proved (|A|=2 case). One sorry remains: the full Vosper induction on |A|.",
     "implications": "Once ap_of_near_periodic is formalized (the backward-shift induction), the full Vosper theorem follows from standard induction. Vosper's theorem would then complement ZMod.cauchy_davenport in Mathlib, completing the picture of additive structure in Z/pZ.",
     "openQuestions": [
       "Formalize ap_of_near_periodic: B is an AP if |B \\ (B+d)| = 1 (needs backward-shift induction on |B|)",
@@ -104,24 +104,24 @@
       "title": "Key Sublemma: Near-Periodicity Forces AP",
       "startLine": 106,
       "endLine": 127,
-      "summary": "ap_of_near_periodic: |B \\ (B+d)| = 1 ∧ d≠0 ∧ |B|<p → B is AP with difference d. Sorry: backward-shift induction on |B| requires well-founded recursion."
+      "summary": "ap_of_near_periodic: |B \\ (B+d)| = 1 ∧ d≠0 ∧ |B|<p → B is AP with difference d. Fully proved via backward-shift induction on |B| using well-founded recursion."
     },
     {
       "id": "vosper-theorem",
       "title": "Vosper's Theorem: Base Case and Full Induction",
       "startLine": 128,
       "endLine": 165,
-      "summary": "vosper_base (|A|=2, inclusion-exclusion → ap_of_near_periodic, 1 sorry), vosper (strong induction on |A|, 1 sorry). Both contain complete proof outlines in comments."
+      "summary": "vosper_base (|A|=2, inclusion-exclusion → ap_of_near_periodic, fully proved), vosper (strong induction on |A|, 1 sorry). vosper_base now proved; only the full induction remains open."
     }
   ],
   "leanFile": {
     "namespace": "Erdos476OQ05",
-    "lineCount": 194,
+    "lineCount": 306,
     "axiomCount": 0,
-    "theoremCount": 7,
+    "theoremCount": 8,
     "definitionCount": 1,
     "path": "Proofs/Erdos476OQ05Problem.lean",
-    "sorries": 3
+    "sorries": 1
   },
-  "sorries": 3
+  "sorries": 1
 }


### PR DESCRIPTION
## Summary

- **arithmetic-series-oq-02-oq-02-oq-03-oq-01**: sorry count 1 -> 0. The general Polya enumeration theorem (`polya_enumeration_theorem_CN`) is now fully proved. Status upgraded from `formalized` to `verified`, badge from `wip` to `verified`. Line count updated 365 -> 507.
- **erdos-476-oq-05**: sorry count 3 -> 1. Both `ap_of_near_periodic` (backward-shift induction) and `vosper_base` (|A|=2 case) are now fully proved. Only the full `vosper` theorem (strong induction on |A|) remains as 1 sorry. Line count updated 194 -> 306, theorem count 7 -> 8.
- **ballot-problem-oq-03-oq-01-oq-02**: verified correct at 3 sorries (meta.json already matched Lean source). No changes needed.
- Audit tracker updated for all three entries.

## Verification method

Parsed each Lean source file with nested block comment and line comment stripping, then counted `\bsorry\b` tokens in non-comment code only.