### PR TITLE
Fix: shannon-source-coding-oq-04 badge corrected from original to wip

### DIFF
--- a/src/data/proofs/shannon-source-coding-oq-04/meta.json
+++ b/src/data/proofs/shannon-source-coding-oq-04/meta.json
@@ -17,7 +17,7 @@
       "research",
       "open-problem"
     ],
-    "badge": "original",
+    "badge": "wip",
     "sorries": 4,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Fix

Correct the `badge` field for `shannon-source-coding-oq-04` from `"original"` to `"wip"`.

## Evidence

**Before**: `badge: "original"` — reserved for `status: "verified"` proofs with 0 sorries and 0 axioms
**After**: `badge: "wip"` — correct for `status: "formalized"` proofs with remaining sorries

The proof has `status: "formalized"` with 4 confirmed sorries in `proofs/Proofs/ShannonSourceCodingOQ04.lean` (lines 90, 170, 178, 204). The `badge=original` was the **only** `formalized+original` combination across all 2124 gallery entries — an isolated anomaly.

The `wip` badge is used by 41 other `formalized` proofs, making this consistent with gallery conventions.

---
Automated fix by lean-mechanic agent.