### PR TITLE
enrichment: four-color-theorem, godel-incompleteness, ramanujan-sum-fallacy

### DIFF
--- a/src/data/proofs/four-color-theorem/annotations.json
+++ b/src/data/proofs/four-color-theorem/annotations.json
@@ -9,12 +9,14 @@
     "type": "concept",
     "title": "The Theorem That Took 124 Years",
     "content": "The Four Color Theorem has a remarkable history. Posed in 1852, it resisted proof for over a century, defeating many brilliant mathematicians. Its eventual 1976 proof required something unprecedented: a computer checking thousands of cases no human could verify.\n\nThe theorem states that any map can be colored with at most four colors such that no two adjacent regions share a color. While easy to state and seemingly simple, the proof revealed deep connections between graph theory, combinatorics, and computation.\n\nThis formalization presents the conceptual structure. The complete proof (Appel-Haken 1976, Gonthier 2005) requires computer verification of 1,936 configurations.",
+    "mathContext": "$\\chi(G) \\leq 4$ for all planar graphs $G$, where $\\chi(G) = \\min\\{k : G \\text{ is } k\\text{-colorable}\\}$. First major theorem with essential computer assistance: Appel-Haken (1976) verified 1,936 reducible configurations; Robertson et al. (1997) reduced to 633. Formalized by Gonthier in Coq (2005), reducing trust to the Coq kernel.",
     "significance": "key",
     "relatedConcepts": [
       "graph theory",
       "computer-assisted proof",
       "planar graphs"
-    ]
+    ],
+    "prerequisites": ["graph theory basics", "map-graph duality", "chromatic number"]
   },
   {
     "id": "ann-graph-structure",
@@ -26,12 +28,14 @@
     "type": "definition",
     "title": "Graphs and Their Structure",
     "content": "We model maps as graphs where vertices represent regions and edges connect adjacent regions. This transforms the map coloring problem into a graph coloring problem.\n\nA graph $G = (V, E)$ consists of:\n- A set $V$ of vertices (the regions)\n- A set $E$ of edges (adjacency relations)\n- Edges are symmetric: if region A borders B, then B borders A\n\nThis abstraction lets us apply graph-theoretic tools to a geometric problem.",
+    "mathContext": "$G = (V, E)$ with $E \\subseteq \\binom{V}{2}$ (simple undirected graph). The dual of a planar map: countries $\\mapsto$ vertices, shared borders $\\mapsto$ edges. A planar map is 4-colorable iff its dual graph satisfies $\\chi \\leq 4$. The dual is always planar, so the map and graph versions are equivalent.",
     "significance": "key",
     "relatedConcepts": [
       "vertex",
       "edge",
       "adjacency"
-    ]
+    ],
+    "prerequisites": ["set theory", "equivalence relations", "map-graph duality"]
   },
   {
     "id": "ann-coloring",
@@ -43,13 +47,14 @@
     "type": "definition",
     "title": "Graph Coloring",
     "content": "A **proper k-coloring** assigns one of k colors to each vertex such that adjacent vertices receive different colors. The **chromatic number** $\\chi(G)$ is the minimum k for which a proper k-coloring exists.\n\nThe Four Color Theorem states: $\\chi(G) \\leq 4$ for all planar graphs G.\n\nNote that we need $k \\geq 4$ for some graphs (like the complete graph $K_4$, where every vertex connects to every other). The theorem says 4 always suffices for planar graphs.",
-    "mathContext": "$\\chi(G) = \\min\\{k : G \\text{ is } k\\text{-colorable}\\}$",
+    "mathContext": "$\\chi(G) = \\min\\{k : G \\text{ is } k\\text{-colorable}\\}$. A proper $k$-coloring is $c: V \\to \\{1,\\ldots,k\\}$ with $c(u) \\neq c(v)$ for all $\\{u,v\\} \\in E$. The complete graph $K_4$ requires $\\chi(K_4) = 4$; $K_4$ is planar, so the bound 4 is tight. The theorem asserts $\\chi(G) \\leq 4$ for ALL planar $G$.",
     "significance": "key",
     "relatedConcepts": [
       "chromatic number",
       "proper coloring",
       "k-colorable"
-    ]
+    ],
+    "prerequisites": ["graph definition", "function coloring", "chromatic number"]
   },
   {
     "id": "ann-planar",
@@ -61,12 +66,14 @@
     "type": "definition",
     "title": "Planar Graphs",
     "content": "A graph is **planar** if it can be drawn in the plane with no edge crossings. Equivalently, it can be embedded on a sphere.\n\nNot all graphs are planar! The complete graph $K_5$ (5 vertices, all connected) and the complete bipartite graph $K_{3,3}$ are the 'forbidden minors'—every non-planar graph contains one of these as a substructure.\n\nPlanarity is essential to the theorem. Non-planar graphs can require arbitrarily many colors.",
+    "mathContext": "A graph $G$ is planar iff it contains no subdivision of $K_5$ or $K_{3,3}$ as a subgraph (Kuratowski 1930). Equivalently: no $K_5$ or $K_{3,3}$ as a topological minor (Wagner 1937). For planar $G$ with $|V| \\geq 3$: $|E| \\leq 3|V| - 6$ (from Euler's formula + $|F| \\geq |E|/3$ since every face has $\\geq 3$ boundary edges). The complete graph $K_5$ violates this: $|E|=10 > 3 \\cdot 5 - 6 = 9$.",
     "significance": "key",
     "relatedConcepts": [
       "planar embedding",
       "Kuratowski's theorem",
       "forbidden minors"
-    ]
+    ],
+    "prerequisites": ["graph embeddings", "Euler's formula", "Kuratowski's theorem"]
   },
   {
     "id": "ann-euler",
@@ -78,7 +85,7 @@
     "type": "theorem",
     "title": "Euler's Formula: The Fundamental Constraint",
     "content": "For any connected planar graph embedded in the plane:\n\n$$V - E + F = 2$$\n\nwhere V = vertices, E = edges, F = faces (including the unbounded outer face).\n\nThis remarkable formula constrains planar graph structure. Combined with the handshaking lemma (sum of degrees = 2E), it implies every planar graph has a vertex of degree at most 5.\n\nThis 'low-degree vertex' existence is the entry point for inductive proofs of coloring theorems.",
-    "mathContext": "$V - E + F = 2$ for connected planar graphs",
+    "mathContext": "$V - E + F = 2$ for connected planar graphs. Since each face is bounded by $\\geq 3$ edges and each edge bounds $\\leq 2$ faces: $3F \\leq 2E$, so $F \\leq 2E/3$. Substituting: $V - E + 2E/3 \\geq 2$, giving $E \\leq 3V - 6$. The handshaking lemma $\\sum_v \\deg(v) = 2E \\leq 6V - 12$ gives average degree $< 6$, so some vertex has $\\deg \\leq 5$.",
     "significance": "key",
     "prerequisites": [
       "ann-planar"
@@ -99,7 +106,7 @@
     "type": "theorem",
     "title": "Every Planar Graph Has a Low-Degree Vertex",
     "content": "Every planar graph with at least one vertex has a vertex of degree at most 5.\n\n**Proof sketch:** By Euler's formula and handshaking, the average degree in a planar graph is less than 6. Therefore, some vertex must have degree at most 5.\n\nThis result is crucial: it guarantees we can always find a 'removable' vertex for inductive arguments. It's why the Five Color Theorem is easy (6 colors would be trivial, 5 requires one trick, 4 requires computer assistance).",
-    "mathContext": "$\\forall G$ planar, $\\exists v \\in V(G)$ with $\\deg(v) \\leq 5$",
+    "mathContext": "$\\forall G$ planar, $\\exists v \\in V(G)$ with $\\deg(v) \\leq 5$. Proof: $\\sum_v \\deg(v) = 2|E| \\leq 6|V| - 12 < 6|V|$, so average degree $< 6$, so minimum degree $\\leq 5$. The bound 5 is tight: the icosahedron graph has minimum degree exactly 5. For 4-coloring, the key cases are $\\deg(v) \\leq 4$ (easy) and $\\deg(v) = 5$ (requires Kempe chains).",
     "significance": "key",
     "prerequisites": [
       "ann-euler"
@@ -119,7 +126,7 @@
     "type": "theorem",
     "title": "The Five Color Theorem",
     "content": "Every planar graph is 5-colorable. This is much easier than Four Color!\n\n**Proof by induction:**\n1. Find a vertex v of degree ≤ 5\n2. Remove v to get smaller graph G'\n3. By induction, G' is 5-colorable\n4. Restore v: it has ≤ 5 neighbors using ≤ 5 colors\n5. If all 5 colors appear among neighbors, use Kempe chains to free one\n6. Color v with the freed color\n\nThe key insight: with 5 colors and ≤ 5 neighbors, we can always make room. With 4 colors, this argument fails—hence the difficulty of the Four Color Theorem.",
-    "mathContext": "$\\chi(G) \\leq 5$ for all planar graphs G",
+    "mathContext": "$\\chi(G) \\leq 5$ for all planar $G$. The Heawood 1890 proof: if $\\deg(v) = 5$ and neighbors use all 5 colors, pick non-adjacent neighbors $u_1$ (color 1) and $u_3$ (color 3). If they're in the same Kempe $(1,3)$-chain, try $(2,4)$-chain swap on neighbor $u_2$. At least one of these swaps frees a color for $v$. With 4 colors and $\\deg(v) = 5$: two non-adjacent neighbors might share the same Kempe chain, blocking both swaps simultaneously — this is the gap Kempe's 1879 proof failed to handle.",
     "significance": "key",
     "prerequisites": [
       "ann-low-degree"
@@ -139,12 +146,14 @@
     "type": "concept",
     "title": "Kempe Chains: The Color-Swapping Trick",
     "content": "A **Kempe chain** for colors a and b starting at vertex v is the maximal connected subgraph of vertices colored a or b containing v.\n\nThe crucial property: swapping colors a ↔ b on a Kempe chain produces another valid coloring! Adjacent vertices still have different colors because:\n- Vertices outside the chain keep their colors\n- Inside the chain, neighbors alternate between a and b\n\nKempe invented this for his 1879 'proof' of Four Colors. His argument was flawed, but the technique is correct and essential. The flaw was in handling cases where multiple Kempe chains interact.",
+    "mathContext": "The Kempe $(a,b)$-chain at $v$: the connected component of $v$ in $G[\\{u \\in V : c(u) \\in \\{a,b\\}\\}]$. Swapping $a \\leftrightarrow b$ on this chain produces a valid coloring: for edge $\\{u,w\\}$ with both in the chain, $c(u) \\neq c(w)$ since they are $a$ and $b$ in some order; for one endpoint inside and one outside, the outside keeps its color $\\notin \\{a,b\\}$, still different. Kempe's error: two chains can become connected after a swap, making a second swap invalid.",
     "significance": "key",
     "relatedConcepts": [
       "color swapping",
       "connected component",
       "Kempe's fallacy"
-    ]
+    ],
+    "prerequisites": ["proper coloring", "connected components in subgraphs", "graph-induced subgraph"]
   },
   {
     "id": "ann-kempe-swap",
@@ -156,7 +165,8 @@
     "type": "theorem",
     "title": "Kempe Chain Swapping Preserves Validity",
     "content": "If we have a proper coloring and swap colors along a Kempe chain, the result is still a proper coloring.\n\n**Why it works:**\n- Any edge with both endpoints in the chain: before, one was color a, one was b; after, they're swapped but still different\n- Any edge with one endpoint in, one out: the outside endpoint keeps its original color (not a or b), so still different from the inside endpoint\n- Any edge with both endpoints outside: unchanged\n\nThis lets us 'free up' a color at a specific vertex by pushing conflicting colors elsewhere.",
-    "mathContext": "Swapping on Kempe chain preserves $\\forall(u,v) \\in E: c(u) \\neq c(v)$",
+    "mathContext": "Swapping on Kempe chain preserves $\\forall(u,v) \\in E: c(u) \\neq c(v)$. Formal verification: partition edges into 3 types — both in chain (colors swap, remain $a \\neq b$), one inside/one outside (outside color $\\notin \\{a,b\\}$, still different), both outside (unchanged). Case analysis closes the proof. In Lean: follows by `simp` on the structural characterization of the Kempe component.",
+    "mathContext": "Formally: let $K$ = Kempe $(a,b)$-chain, $c': V \\to \\{1,2,3,4\\}$ with $c'(v) = \\overline{c(v)}^{a \\leftrightarrow b}$ if $v \\in K$, else $c'(v) = c(v)$. Claim: $c'$ is a proper coloring. For $\\{u,w\\} \\in E$: if both $u,w \\in K$ then $c'(u) \\neq c'(w)$ (both swapped, were $a,b$); if $u \\in K, w \\notin K$ then $c(w) \\notin \\{a,b\\}$ (else $w$ would be in $K$), so $c'(w) = c(w) \\neq c(u) \\in \\{a,b\\}$.",
     "significance": "key",
     "prerequisites": [
       "ann-kempe-chains"
@@ -176,12 +186,14 @@
     "type": "concept",
     "title": "Reducibility: Configurations That Can't Block Coloring",
     "content": "A configuration C is **reducible** if it cannot appear in a minimal counterexample to Four Color. That is: if a planar graph G contains C, then G is 4-colorable (or G can be simplified to a smaller graph that's 4-colorable).\n\nProving reducibility requires showing that any 4-coloring of the graph minus the configuration can be extended to include it. This involves analyzing all possible colorings of the boundary and showing Kempe chains can always make room.\n\nFor many configurations, this case analysis is astronomically complex—too many cases for human verification. This is where computers become essential.",
+    "mathContext": "Configuration $C$ is reducible if: for any planar graph $G \\supseteq C$, a 4-coloring of $G \\setminus \\text{int}(C)$ extends to a 4-coloring of $G$. The boundary $\\partial C$ has $k \\leq 14$ vertices (for the Appel-Haken set), giving at most $4^{14} \\approx 2.7 \\times 10^8$ boundary colorings to check. Computer reduces via Kempe recoloring: for each boundary coloring, determine if the interior can be consistently 4-colored. Appel-Haken: all 1,936 configurations are reducible.",
     "significance": "key",
     "relatedConcepts": [
       "minimal counterexample",
       "configuration",
       "extendability"
-    ]
+    ],
+    "prerequisites": ["minimal counterexample method", "Kempe chain recoloring", "boundary coloring extension"]
   },
   {
     "id": "ann-computer-verification",
@@ -193,12 +205,14 @@
     "type": "concept",
     "title": "Computer-Assisted Proof",
     "content": "The Appel-Haken proof (1976) required:\n- 1,200 hours of computer time\n- Verification of 1,936 configurations\n- 400+ pages of hand-written supporting proofs\n\nInitial reception was skeptical. How can we trust a proof no human can check? What if there's a bug in the program?\n\nGeorges Gonthier's 2005 Coq formalization addressed these concerns by reducing trust to a small, verified proof-checking kernel. The proof certificate is machine-checkable, and the checker itself is tiny enough to be human-verified.\n\nThis paradigm shift—from 'trust the program' to 'trust the proof checker'—has become foundational in formal methods.",
+    "mathContext": "The unavoidable set $\\mathcal{R}$: every planar graph must contain at least one member. For each $C \\in \\mathcal{R}$ (boundary size $|\\partial C| \\leq 14$): enumerate all $4^{|\\partial C|}$ boundary colorings, verify each is extendable (or reducible by Kempe). Appel-Haken: $|\\mathcal{R}| = 1{,}936$. Robertson et al. (1997): $|\\mathcal{R}| = 633$ with improved discharging. Gonthier (2005): the Coq proof kernel is $\\approx 10{,}000$ lines of OCaml — small enough for human audit, unlike the application code.",
     "significance": "key",
     "relatedConcepts": [
       "Coq",
       "formal verification",
       "proof assistant"
-    ]
+    ],
+    "prerequisites": ["unavoidable set", "reducible configurations", "discharging method", "Coq proof assistant"]
   },
   {
     "id": "ann-gonthier",
@@ -210,11 +224,13 @@
     "type": "insight",
     "title": "Gonthier's Coq Formalization",
     "content": "In 2005, Georges Gonthier completed a full formalization of the Four Color Theorem in Coq. This was a landmark achievement:\n\n- **Complete verification:** Every step machine-checked, including all 1,936 configurations\n- **Independent verification:** The Coq proof is a certificate anyone can verify using the proof checker\n- **Trust reduction:** We no longer trust Appel-Haken's program; we trust Coq's small kernel\n\nThe formalization took several person-years but provided certainty that the theorem is correct. It demonstrated that even massive computational proofs can be made rigorous through formal methods.",
+    "mathContext": "Gonthier built on Robertson et al.'s 633-configuration set using SSReflect (a Coq extension for boolean reflection). The proof term inhabits the type `four_color_theorem : ∀ G : planarGraph, 4_colorable G` in CIC (Calculus of Inductive Constructions). Trust hierarchy: theorem $\\leftarrow$ Coq kernel ($\\approx 10^4$ lines OCaml) $\\leftarrow$ CIC type theory (consistency relative to large cardinals). This is a foundational improvement over trusting $\\approx 10^6$ lines of Fortran/C in the Appel-Haken check.",
     "significance": "key",
     "relatedConcepts": [
       "Coq proof assistant",
       "SSReflect",
       "proof certificate"
-    ]
+    ],
+    "prerequisites": ["Coq proof assistant", "SSReflect tactics", "type theory (CIC)", "boolean reflection"]
   }
 ]

--- a/src/data/proofs/godel-incompleteness/annotations.json
+++ b/src/data/proofs/godel-incompleteness/annotations.json
@@ -9,12 +9,14 @@
     "type": "concept",
     "title": "The Theorem That Changed Everything",
     "content": "Gödel's 1931 paper is one of the most important in the history of mathematics and logic. It proved that Hilbert's dream of a complete, consistent formal foundation for mathematics was impossible.\n\nThe theorem states that any formal system $F$ capable of expressing basic arithmetic must be **incomplete**: there exist true statements that $F$ cannot prove. This isn't a flaw in our axioms—it's a fundamental limitation of formal reasoning itself.\n\nThis formalization presents the key conceptual components. A complete proof would require thousands of lines defining syntax, proof systems, and primitive recursive functions.",
+    "mathContext": "Gödel's First Incompleteness Theorem: For any consistent formal system $F$ extending PA, $\\exists \\phi$ such that $F \\not\\vdash \\phi$ and $F \\not\\vdash \\neg\\phi$. Second Incompleteness: $F \\not\\vdash \\text{Con}(F)$ for consistent $F$. Together these terminate Hilbert's program — no consistent axiomatizable extension of arithmetic is both complete and proves its own consistency.",
     "significance": "key",
     "relatedConcepts": [
       "Hilbert's Program",
       "formal systems",
       "metamathematics"
-    ]
+    ],
+    "prerequisites": ["formal logic", "Peano Arithmetic", "proof theory"]
   },
   {
     "id": "ann-formula-type",
@@ -26,12 +28,14 @@
     "type": "definition",
     "title": "The Formula Type",
     "content": "We axiomatize `Formula` as an abstract type representing well-formed formulas in our formal system. In a full formalization, this would be an inductive type defining the syntax of first-order arithmetic:\n\n- Variables: $x, y, z, \\ldots$\n- Constants: $0, 1, 2, \\ldots$\n- Functions: $+, \\times, S$ (successor)\n- Relations: $=, <$\n- Logical connectives: $\\land, \\lor, \\neg, \\rightarrow$\n- Quantifiers: $\\forall, \\exists$\n\nEvery formula in Peano Arithmetic can be built from these primitives.",
+    "mathContext": "Terms: $t ::= 0 \\mid x \\mid S(t) \\mid t + t \\mid t \\cdot t$. Formulas: $\\phi ::= (t_1 = t_2) \\mid \\neg\\phi \\mid (\\phi \\land \\psi) \\mid \\exists x.\\phi$. The set $\\text{Fml}$ of all formulas is countably infinite, so a Gödel numbering (injective function $\\text{Fml} \\to \\mathbb{N}$) exists. In Lean, this would be `inductive Formula : Type` with constructors for each case.",
     "significance": "key",
     "relatedConcepts": [
       "formal syntax",
       "first-order logic",
       "Peano Arithmetic"
-    ]
+    ],
+    "prerequisites": ["first-order logic syntax", "inductive data types in Lean", "formal language theory"]
   },
   {
     "id": "ann-provability",
@@ -49,7 +53,8 @@
       "proof",
       "derivation",
       "syntactic consequence"
-    ]
+    ],
+    "prerequisites": ["Hilbert-style deduction systems", "inference rules", "syntactic vs. semantic truth"]
   },
   {
     "id": "ann-godel-numbering",
@@ -67,7 +72,8 @@
       "encoding",
       "arithmetization",
       "metamathematics"
-    ]
+    ],
+    "prerequisites": ["natural number arithmetic", "injective functions", "first-order formulas"]
   },
   {
     "id": "ann-encoding-injective",
@@ -79,6 +85,7 @@
     "type": "insight",
     "title": "Injectivity of Encoding",
     "content": "The Gödel numbering must be **injective**: different formulas get different numbers. This ensures we can uniquely identify formulas by their codes.\n\nGödel used prime factorization for his encoding. For instance, a sequence of symbols $(a_1, a_2, \\ldots, a_n)$ might be encoded as $2^{a_1} \\cdot 3^{a_2} \\cdot 5^{a_3} \\cdots p_n^{a_n}$ where $p_i$ is the $i$th prime. The fundamental theorem of arithmetic guarantees unique decoding.",
+    "mathContext": "Prime encoding: $\\langle a_1, \\ldots, a_n\\rangle \\mapsto \\prod_{i=1}^n p_i^{a_i}$ where $p_i$ is the $i$th prime. Injectivity follows from the Fundamental Theorem of Arithmetic (unique prime factorization): if $\\prod p_i^{a_i} = \\prod p_i^{b_i}$, then $a_i = b_i$ for all $i$. In Lean: `theorem encode_injective : Function.Injective encode`.",
     "significance": "supporting",
     "prerequisites": [
       "ann-godel-numbering"
@@ -139,14 +146,15 @@
     "type": "theorem",
     "title": "The Diagonal Lemma (Fixed Point Theorem)",
     "content": "This is the formal engine of self-reference. For any property $P(x)$ expressible in the system, there exists a sentence $\\gamma$ such that:\n\n$\\gamma \\iff P(\\ulcorner\\gamma\\urcorner)$\n\nIn other words, $\\gamma$ says \"I have property $P$.\" The sentence refers to itself—not by name, but by describing its own Gödel number!\n\nThe construction uses the substitution function and diagonalization, similar to Cantor's proof that the reals are uncountable. It's the formalization of the Liar's Paradox mechanism.",
-    "mathContext": "$\\forall P. \\exists\\gamma. \\gamma \\iff P(\\ulcorner\\gamma\\urcorner)$",
+    "mathContext": "$\\forall P. \\exists\\gamma. \\vdash \\gamma \\leftrightarrow P(\\ulcorner\\gamma\\urcorner)$. Construction: let $\\text{diag}(n)$ be the Gödel number of $\\phi(\\ulcorner\\phi\\urcorner)$ where $\\phi$ is the formula with number $n$. Then $\\gamma = \\phi(\\ulcorner\\phi\\urcorner)$ where $\\phi(x) \\equiv P(\\text{diag}(x))$. Analogous to Cantor's diagonal: the $n$th formula applied to its own number.",
     "significance": "key",
     "relatedConcepts": [
       "self-reference",
       "fixed point",
       "Liar's Paradox",
       "diagonalization"
-    ]
+    ],
+    "prerequisites": ["substitution function", "Gödel numbering", "diagonal argument (Cantor)"]
   },
   {
     "id": "ann-not-prov",
@@ -220,12 +228,14 @@
     "type": "concept",
     "title": "Death of Hilbert's Program",
     "content": "David Hilbert had proposed that:\n1. All mathematics could be formalized in a complete, consistent system\n2. The consistency of this system could be proved by \"finitary\" means\n\nGödel's First Incompleteness Theorem killed (1): no complete system exists. His Second Incompleteness Theorem killed (2): no consistent system can prove its own consistency.\n\nThis was a shock to the mathematical community. The dream of absolute certainty in mathematics was over.",
+    "mathContext": "Hilbert's program (1920s): formalize all of mathematics and prove $\\text{Con}(\\text{PA})$ by finitary means. Gödel 1st theorem: $\\text{Con}(F) \\implies \\neg\\text{Complete}(F)$ for any $F$ extending PA. Gödel 2nd theorem: $\\text{Con}(F) \\implies F \\not\\vdash \\text{Con}(F)$. Together: no system can be simultaneously consistent, complete, and self-verifying — Hilbert's trifecta is impossible.",
     "significance": "key",
     "relatedConcepts": [
       "Hilbert",
       "formalism",
       "finitism"
-    ]
+    ],
+    "prerequisites": ["Hilbert's formalism program (1920s)", "Gödel's Second Incompleteness Theorem", "finitary proof theory"]
   },
   {
     "id": "ann-limits",
@@ -237,12 +247,14 @@
     "type": "insight",
     "title": "The Inexhaustibility of Mathematics",
     "content": "Gödel's theorem reveals something profound: mathematical truth is inexhaustible. No matter how many axioms we add, there will always be truths beyond our reach.\n\nWe can always add $G$ as a new axiom—then the system proves what it couldn't before. But immediately, a new Gödel sentence $G'$ emerges that the expanded system cannot prove. It's turtles all the way down.",
+    "mathContext": "The inexhaustibility tower: $F_0 = \\text{PA}$, $F_{\\alpha+1} = F_\\alpha + \\text{Con}(F_\\alpha)$, $F_\\lambda = \\bigcup_{\\alpha < \\lambda} F_\\alpha$ at limits. Each $F_\\alpha$ is strictly stronger than $F_{\\beta}$ for $\\alpha > \\beta$. Ordinal analysis (Gentzen): $|\\text{PA}| = \\varepsilon_0$, the first epsilon number. Adding all true $\\Pi^0_1$ sentences gives all of true arithmetic — but this set is not recursively enumerable.",
     "significance": "key",
     "relatedConcepts": [
       "axiom extension",
       "ordinal analysis",
       "transfinite hierarchy"
-    ]
+    ],
+    "prerequisites": ["Gödel sentence construction", "ordinal numbers", "proof-theoretic ordinals"]
   },
   {
     "id": "ann-mechanism-debate",
@@ -254,11 +266,13 @@
     "type": "concept",
     "title": "Mind vs. Machine",
     "content": "Some philosophers (notably Roger Penrose and J.R. Lucas) have argued that Gödel's theorem shows human minds are not machines—we can \"see\" that $G$ is true even though no formal system can prove it.\n\nThis interpretation is controversial. Critics argue that humans are also subject to limitations, and our \"seeing\" the truth of $G$ depends on assumptions (like consistency) that we cannot verify.\n\nThe debate continues: does mathematical intuition transcend computation, or are we also bounded by our own version of incompleteness?",
+    "mathContext": "The Lucas-Penrose argument: human minds can verify $\\text{Con}(F)$ and hence prove $G_F$, which $F$ cannot prove, so minds $\\not\\subseteq F$. Refutation (Putnam, Boolos): if the human's reasoning is formalized as system $H$, then $H \\not\\vdash G_H$; the human's 'seeing' $G_F$ is true presupposes belief in $\\text{Con}(F)$, which $F$ does not provide. Neither humans nor machines escape the incompleteness tower — both must appeal to stronger systems.",
     "significance": "supporting",
     "relatedConcepts": [
       "mechanism",
       "Lucas-Penrose argument",
       "philosophy of mind"
-    ]
+    ],
+    "prerequisites": ["Turing machines and computability", "Gödel's First Incompleteness Theorem", "philosophy of mathematics"]
   }
 ]

--- a/src/data/proofs/ramanujan-sum-fallacy/annotations.json
+++ b/src/data/proofs/ramanujan-sum-fallacy/annotations.json
@@ -9,8 +9,14 @@
     "type": "concept",
     "title": "The Famous Fallacy",
     "content": "The claim $1+2+3+4+\\cdots = -\\frac{1}{12}$ went viral through a Numberphile video. While the value $-\\frac{1}{12}$ does appear in the Riemann zeta function ($\\zeta(-1) = -\\frac{1}{12}$), the 'elementary proof' using series manipulation is mathematically invalid.",
-    "mathContext": "In standard analysis, this series diverges to infinity. The -1/12 comes from **analytic continuation**, not from adding up the terms.",
+    "mathContext": "In standard analysis, $\\sum_{n=1}^{\\infty} n$ diverges to $+\\infty$. The value $-\\frac{1}{12}$ arises from **analytic continuation**: $\\zeta(s) = \\sum_{n=1}^{\\infty} n^{-s}$ converges for $\\text{Re}(s) > 1$, and the unique meromorphic extension to $\\mathbb{C}$ gives $\\zeta(-1) = -\\frac{1}{12}$. This is a *different mathematical operation* from ordinary summation.",
     "significance": "key",
+    "prerequisites": [
+      "infinite series",
+      "divergent series",
+      "Riemann zeta function",
+      "analytic continuation"
+    ],
     "relatedConcepts": [
       "divergent series",
       "zeta function",
@@ -27,8 +33,14 @@
     "type": "definition",
     "title": "How Mathlib Handles Infinite Sums",
     "content": "Mathlib's `tsum` (topological sum) function is the standard way to express infinite sums in Lean. Crucially, `tsum f` only equals the expected limit if the sum **converges**. For divergent series, `tsum` returns **0** by convention.",
-    "mathContext": "This design choice prevents false conclusions: you can't do arithmetic with 'infinite' values because they're just represented as 0. All the useful lemmas about series require a `Summable` proof.",
+    "mathContext": "Formally: `tsum f = if h : Summable f then (h.choose : α) else 0`. This junk-value convention means all lemmas that do useful things — `tsum_add`, `tsum_eq_zero_add`, `tsum_geometric_two` — carry a `Summable f` hypothesis. Without it, `tsum f = 0` and you can only prove $0 = 0$.",
     "significance": "key",
+    "prerequisites": [
+      "real analysis",
+      "infinite series",
+      "Lean 4 type system",
+      "Mathlib tsum API"
+    ],
     "relatedConcepts": [
       "tsum",
       "Summable",
@@ -45,7 +57,13 @@
     "type": "definition",
     "title": "Defining the Natural Number Series",
     "content": "We define `naturals n = n + 1` to get the sequence $1, 2, 3, 4, \\ldots$ (offset by 1 because $\\mathbb{N}$ starts at 0 in Lean).",
+    "mathContext": "The function `naturals : ℕ → ℝ` defined by `naturals n = ↑(n + 1)` gives the series $\\sum_{n=0}^{\\infty} (n+1) = 1 + 2 + 3 + \\cdots$. The cast `↑` coerces `ℕ` to `ℝ`. This offset-by-one indexing is standard in Lean/Mathlib: `Finset.range n = {0, 1, ..., n-1}`, so `∑ k in Finset.range n, naturals k = \\frac{n(n+1)}{2}`.",
     "significance": "supporting",
+    "prerequisites": [
+      "natural numbers",
+      "Lean 4 type coercions",
+      "Mathlib tsum API"
+    ],
     "relatedConcepts": [
       "natural numbers",
       "sequences"
@@ -61,8 +79,14 @@
     "type": "theorem",
     "title": "The False Claim Would Require Convergence",
     "content": "This theorem shows that IF we could prove $\\sum n = -\\frac{1}{12}$, THEN the series would need to be `Summable`. But the series diverges, so this implication is vacuously true - we can never satisfy the hypothesis.",
-    "mathContext": "The `sorry` here is permanent - this line of reasoning is blocked. Lean forces us to acknowledge that the hypothesis is impossible.",
+    "mathContext": "The argument uses the contrapositive of `tsum_eq_zero_of_not_summable`: if `¬ Summable f`, then `tsum f = 0`. So `tsum naturals = -1/12` would force `tsum naturals ≠ 0`, hence `Summable naturals` — but we prove `¬ Summable naturals` by showing partial sums are unbounded. The `sorry` marks the exact point where the informal argument breaks the formal rules.",
     "significance": "key",
+    "prerequisites": [
+      "real analysis",
+      "divergent series",
+      "Lean 4 type system",
+      "Mathlib tsum API"
+    ],
     "relatedConcepts": [
       "vacuous truth",
       "impossible hypothesis"
@@ -78,8 +102,14 @@
     "type": "definition",
     "title": "The Grandi Series",
     "content": "The **Grandi series** $1-1+1-1+\\cdots$ has partial sums that alternate forever between 0 and 1. It does not converge in any standard sense.",
-    "mathContext": "The Numberphile video claims this equals $\\frac{1}{2}$ by averaging 0 and 1. This is actually the **Cesaro mean**, not the limit. They're different mathematical concepts!",
+    "mathContext": "Defined as `grandi n = (-1)^n`. The partial sums are $S_n = \\frac{1-(-1)^{n+1}}{2}$, oscillating between 0 and 1. The **Cesàro mean** is $\\lim_{N\\to\\infty}\\frac{1}{N}\\sum_{n=0}^{N-1} S_n = \\frac{1}{2}$, which the Numberphile video conflates with the series limit. In Mathlib: `¬ Summable grandi` because the partial sums do not converge.",
     "significance": "key",
+    "prerequisites": [
+      "real analysis",
+      "partial sums",
+      "Cesaro summability",
+      "infinite series"
+    ],
     "relatedConcepts": [
       "partial sums",
       "Cesaro mean",
@@ -96,8 +126,13 @@
     "type": "theorem",
     "title": "FALLACY: Cannot Prove Grandi = 1/2",
     "content": "Here we attempt to prove the Numberphile claim that $1-1+1-1+\\cdots = \\frac{1}{2}$. **This is impossible** - the `sorry` can never be filled in. Since the series isn't summable, `tsum grandi = 0` by definition, and $0 \\neq \\frac{1}{2}$.",
-    "mathContext": "The red X (❌) in the comments indicates Lean rejects this. This is the first fallacy in the Numberphile argument.",
+    "mathContext": "Formally: `tsum_eq_zero_of_not_summable : ¬ Summable f → tsum f = 0`. Since `¬ Summable grandi`, we get `tsum grandi = 0`. The goal `tsum grandi = 1/2` reduces to `(0 : ℝ) = 1/2`, which `norm_num` immediately refutes. Any `sorry`-free proof here would yield `False`.",
     "significance": "key",
+    "prerequisites": [
+      "Grandi series",
+      "Mathlib tsum API",
+      "Lean 4 norm_num"
+    ],
     "relatedConcepts": [
       "tsum convention",
       "proof failure"
@@ -113,8 +148,14 @@
     "type": "concept",
     "title": "The Shift-and-Add Trick",
     "content": "The Numberphile proof adds $S_2$ to a shifted copy of itself:\n$$2S_2 = (1-2+3-4+\\cdots) + (0+1-2+3+\\cdots)$$\nThis term-by-term addition is ONLY valid for convergent series!",
-    "mathContext": "The **Riemann series theorem** proves that rearranging a conditionally convergent series can give any real number as a 'sum'. For divergent series, such manipulations are completely meaningless.",
+    "mathContext": "The **Riemann series theorem** (Riemann, 1853) states that any conditionally convergent series can be rearranged to converge to any value in $\\mathbb{R} \\cup \\{\\pm\\infty\\}$. For *divergent* series, term-by-term operations are completely undefined. The shift operation in Mathlib is `tsum_eq_zero_add : Summable f → tsum f = f 0 + tsum (f ∘ Nat.succ)`, which requires a summability witness.",
     "significance": "key",
+    "prerequisites": [
+      "infinite series",
+      "Riemann rearrangement theorem",
+      "conditional convergence",
+      "absolute convergence"
+    ],
     "relatedConcepts": [
       "Riemann series theorem",
       "rearrangement",
@@ -131,7 +172,14 @@
     "type": "lemma",
     "title": "Alternating Naturals Don't Converge Either",
     "content": "The series $1-2+3-4+5-6+\\cdots$ also diverges. Its partial sums grow without bound in absolute value: $1, -1, 2, -2, 3, -3, \\ldots$",
+    "mathContext": "Define `alternatingNaturals n = (-1)^n * (n + 1)`. The partial sums satisfy $|S_{2k}| = k+1$ and $|S_{2k+1}| = k+1$ — both grow without bound. `¬ Summable alternatingNaturals` follows from the necessary condition: if `Summable f`, then `Filter.Tendsto f atTop (nhds 0)`. But `|alternatingNaturals n| = n+1 → ∞`, so it cannot tend to 0.",
     "significance": "key",
+    "prerequisites": [
+      "real analysis",
+      "necessary condition for convergence",
+      "alternating series",
+      "Mathlib Summable API"
+    ],
     "relatedConcepts": [
       "divergence",
       "partial sums"
@@ -147,8 +195,13 @@
     "type": "theorem",
     "title": "Shifting Requires Convergence Proof",
     "content": "Mathlib's lemmas for manipulating series (like `tsum_eq_zero_add`) all require a `Summable` hypothesis. This is the **type-level gatekeeper** that prevents invalid reasoning.",
-    "mathContext": "Notice `hf : Summable f` in the theorem statement. Without this proof, Lean won't let you use the lemma.",
+    "mathContext": "The relevant Mathlib lemma: `theorem tsum_eq_zero_add {f : ℕ → α} (hf : Summable f) : ∑' n, f n = f 0 + ∑' n, f (n + 1)`. Without `hf`, both sides equal 0 by `tsum_eq_zero_of_not_summable`, making the equation trivially `0 = 0 + 0`. The `Summable` term is a **proof witness** — it cannot be faked; you must construct it from first principles.",
     "significance": "key",
+    "prerequisites": [
+      "Lean 4 dependent types",
+      "Mathlib tsum API",
+      "typeclass constraints"
+    ],
     "relatedConcepts": [
       "typeclass constraints",
       "proof obligations"
@@ -164,7 +217,13 @@
     "type": "theorem",
     "title": "FALLACY: Shift-Add Blocked by Type System",
     "content": "When we try to apply the shift-and-add manipulation to our divergent series, **Lean blocks us**. We would need `Summable alternatingNaturals`, but we proved this is false!",
+    "mathContext": "The attempted proof calls `tsum_eq_zero_add h` where `h : Summable alternatingNaturals`. But `alternatingNaturals_not_summable : ¬ Summable alternatingNaturals` makes it impossible to construct such `h` without `sorry`. Lean's elaborator rejects the proof: there is no term of type `Summable alternatingNaturals` to supply. The `sorry` here is a permanent red flag — it marks the exact location where the informal argument breaks the formal rules.",
     "significance": "key",
+    "prerequisites": [
+      "Lean 4 type checking",
+      "Mathlib tsum API",
+      "proof by contradiction"
+    ],
     "relatedConcepts": [
       "type checking",
       "blocked proof"
@@ -180,8 +239,13 @@
     "type": "lemma",
     "title": "Partial Sums Grow Without Bound",
     "content": "The sum $1+2+\\cdots+n = \\frac{n(n+1)}{2}$, which grows without bound as $n \\to \\infty$. This is the formal statement that the series diverges.",
-    "mathContext": "For any $M$, we can find $N$ large enough that the partial sum exceeds $M$. This is the definition of divergence to infinity.",
+    "mathContext": "The triangular number formula $T_n = \\frac{n(n+1)}{2}$ gives `∑ k in Finset.range n, (k+1) = n*(n+1)/2`. For any bound $M$, choosing $n > 2M$ gives $T_n > M$. Formally: `∀ M : ℝ, ∃ N : ℕ, ∀ n ≥ N, M < ∑ k in Finset.range n, naturals k`. This implies `¬ Summable naturals` since summable sequences must have terms tending to 0, but `naturals n = n+1 → ∞`.",
     "significance": "key",
+    "prerequisites": [
+      "real analysis",
+      "triangular numbers",
+      "Gauss summation formula"
+    ],
     "relatedConcepts": [
       "divergence to infinity",
       "triangle numbers"
@@ -197,8 +261,13 @@
     "type": "theorem",
     "title": "MAIN RESULT: The Sum Does NOT Equal -1/12",
     "content": "Here's the key theorem: $\\sum_{n=1}^{\\infty} n \\neq -\\frac{1}{12}$. The proof is almost trivial once we know the series doesn't converge:\n1. `naturals` is not summable\n2. Therefore `tsum naturals = 0` (by Mathlib convention)\n3. $0 \\neq -\\frac{1}{12}$ (by `norm_num`)",
-    "mathContext": "This is what Lean can actually PROVE, as opposed to the fallacious claim. The type system has protected us from error.",
+    "mathContext": "Proof sketch: `have h0 : tsum naturals = 0 := tsum_eq_zero_of_not_summable naturals_not_summable; have h1 : (0 : ℝ) ≠ -1/12 := by norm_num; rw [h0]; exact h1`. The three-step argument reflects the mathematical reality: **standard summation assigns no value to this series** — not $-1/12$, not $+\\infty$, just the junk value 0.",
     "significance": "key",
+    "prerequisites": [
+      "real analysis",
+      "Mathlib tsum API",
+      "Lean 4 norm_num"
+    ],
     "relatedConcepts": [
       "tsum_eq_zero_of_not_summable",
       "norm_num"
@@ -214,8 +283,14 @@
     "type": "concept",
     "title": "What -1/12 Actually Means",
     "content": "The value $-\\frac{1}{12}$ is real - it comes from the **Riemann zeta function** $\\zeta(s) = \\sum n^{-s}$ analytically continued to $s = -1$. But this is a DIFFERENT mathematical operation than ordinary summation.",
-    "mathContext": "In Lean, we would model zeta regularization with a completely different function type. The type system enforces the distinction automatically - you can't confuse `tsum` with `zeta_regularized`.",
+    "mathContext": "The Riemann zeta function $\\zeta(s) = \\sum_{n=1}^{\\infty} n^{-s}$ converges for $\\text{Re}(s) > 1$ and extends uniquely to a meromorphic function on $\\mathbb{C} \\setminus \\{1\\}$. At $s = -1$: $\\zeta(-1) = -\\frac{1}{12}$. In Lean, this would be a *different function type*: `riemannZeta : ℂ → ℂ` vs `tsum : (ℕ → ℝ) → ℝ`. The Lean type system makes the distinction **syntactically enforced** — you cannot accidentally confuse ordinary summation with zeta regularization.",
     "significance": "key",
+    "prerequisites": [
+      "complex analysis",
+      "Riemann zeta function",
+      "analytic continuation",
+      "meromorphic functions"
+    ],
     "relatedConcepts": [
       "Riemann zeta function",
       "analytic continuation",
@@ -232,7 +307,13 @@
     "type": "theorem",
     "title": "Step 2 Fails: Cannot Shift Divergent Series",
     "content": "The second step uses the shift-and-add manipulation. **BLOCKED**: This requires `Summable` which we cannot prove for divergent series.",
+    "mathContext": "Step 2 of the Numberphile argument claims $2S_2 = \\frac{1}{4}$ by shifting and adding. In Lean: `tsum alternatingNaturals + tsum (fun n => alternatingNaturals (n+1)) = 1/4`. By `tsum_eq_zero_of_not_summable`, both `tsum`s equal 0, giving `0 + 0 = 0 ≠ 1/4`. The shift lemma `tsum_eq_zero_add` is unavailable since `¬ Summable alternatingNaturals`. Step 2 thus fails in two independent ways: the computed value is wrong, and the manipulation is illegal.",
     "significance": "key",
+    "prerequisites": [
+      "alternating series",
+      "Mathlib tsum API",
+      "Lean 4 type checking"
+    ],
     "relatedConcepts": [
       "second fallacy",
       "manipulation blocked"
@@ -248,8 +329,13 @@
     "type": "theorem",
     "title": "Step 3 'Works' But Is Useless",
     "content": "Interestingly, the equation $S - S_2 = 4S$ **does typecheck** - but it's trivially true because both sides equal 0! This shows how Mathlib's convention prevents false conclusions: we can prove $0 - 0 = 4 \\cdot 0$, but this tells us nothing about $-\\frac{1}{12}$.",
-    "mathContext": "The `sorry`-free proof here uses `tsum_eq_zero_of_not_summable` twice, reducing everything to $0 = 0$.",
+    "mathContext": "The algebraic step $S - S_2 = 4S$ typechecks as: `tsum naturals - tsum alternatingNaturals = 4 * tsum naturals`. Since both `tsum` values are 0 by `tsum_eq_zero_of_not_summable`, this becomes `0 - 0 = 4 * 0`, i.e., `0 = 0` — provable by `ring`. The Numberphile argument uses this *form* to conclude $S = -\\frac{1}{12}$, but Lean sees only `0 = 0`: no information about the actual series value is transmitted.",
     "significance": "key",
+    "prerequisites": [
+      "Mathlib tsum API",
+      "Lean 4 ring tactic",
+      "algebraic manipulation"
+    ],
     "relatedConcepts": [
       "vacuous truth",
       "zero convention"
@@ -265,7 +351,14 @@
     "type": "concept",
     "title": "Conclusion: Type Systems Enforce Rigor",
     "content": "Lean's type system and Mathlib's design choices enforce mathematical rigor automatically:\n\n1. **Summable typeclass**: Acts as proof obligation before series manipulation\n2. **tsum = 0 convention**: Prevents arithmetic on divergent 'values'\n3. **Distinct types**: Regularization would be a different function entirely\n\nThe -1/12 result is useful in physics, but it requires different mathematical machinery that Lean would model with appropriate types.",
+    "mathContext": "The `Summable` typeclass is a **proof-carrying data** pattern: before calling `tsum_add (h1 : Summable f) (h2 : Summable g)`, you must supply witnesses `h1` and `h2` — real mathematical proofs that cannot be fabricated. Lean's kernel verifies proof correctness definitionally, making it impossible to accidentally apply series lemmas to divergent series. This is the fundamental difference between informal mathematics (where errors propagate undetected) and formal verification (where each step is machine-checked).",
     "significance": "key",
+    "prerequisites": [
+      "Lean 4 type system",
+      "Mathlib Summable typeclass",
+      "formal verification",
+      "proof-carrying data"
+    ],
     "relatedConcepts": [
       "formal verification",
       "type safety",

--- a/src/data/proofs/ramanujan-sum-fallacy/annotations.source.json
+++ b/src/data/proofs/ramanujan-sum-fallacy/annotations.source.json
@@ -8,8 +8,14 @@
     "type": "concept",
     "title": "The Famous Fallacy",
     "content": "The claim $1+2+3+4+\\cdots = -\\frac{1}{12}$ went viral through a Numberphile video. While the value $-\\frac{1}{12}$ does appear in the Riemann zeta function ($\\zeta(-1) = -\\frac{1}{12}$), the 'elementary proof' using series manipulation is mathematically invalid.",
-    "mathContext": "In standard analysis, this series diverges to infinity. The -1/12 comes from **analytic continuation**, not from adding up the terms.",
+    "mathContext": "In standard analysis, $\\sum_{n=1}^{\\infty} n$ diverges to $+\\infty$. The value $-\\frac{1}{12}$ arises from **analytic continuation**: $\\zeta(s) = \\sum_{n=1}^{\\infty} n^{-s}$ converges for $\\text{Re}(s) > 1$, and the unique meromorphic extension to $\\mathbb{C}$ gives $\\zeta(-1) = -\\frac{1}{12}$. This is a *different mathematical operation* from ordinary summation.",
     "significance": "key",
+    "prerequisites": [
+      "infinite series",
+      "divergent series",
+      "Riemann zeta function",
+      "analytic continuation"
+    ],
     "relatedConcepts": [
       "divergent series",
       "zeta function",
@@ -26,8 +32,14 @@
     "type": "definition",
     "title": "How Mathlib Handles Infinite Sums",
     "content": "Mathlib's `tsum` (topological sum) function is the standard way to express infinite sums in Lean. Crucially, `tsum f` only equals the expected limit if the sum **converges**. For divergent series, `tsum` returns **0** by convention.",
-    "mathContext": "This design choice prevents false conclusions: you can't do arithmetic with 'infinite' values because they're just represented as 0. All the useful lemmas about series require a `Summable` proof.",
+    "mathContext": "Formally: `tsum f = if h : Summable f then (h.choose : α) else 0`. This junk-value convention means all lemmas that do useful things — `tsum_add`, `tsum_eq_zero_add`, `tsum_geometric_two` — carry a `Summable f` hypothesis. Without it, `tsum f = 0` and you can only prove $0 = 0$.",
     "significance": "key",
+    "prerequisites": [
+      "real analysis",
+      "infinite series",
+      "Lean 4 type system",
+      "Mathlib tsum API"
+    ],
     "relatedConcepts": [
       "tsum",
       "Summable",
@@ -44,7 +56,13 @@
     "type": "definition",
     "title": "Defining the Natural Number Series",
     "content": "We define `naturals n = n + 1` to get the sequence $1, 2, 3, 4, \\ldots$ (offset by 1 because $\\mathbb{N}$ starts at 0 in Lean).",
+    "mathContext": "The function `naturals : ℕ → ℝ` defined by `naturals n = ↑(n + 1)` gives the series $\\sum_{n=0}^{\\infty} (n+1) = 1 + 2 + 3 + \\cdots$. The cast `↑` coerces `ℕ` to `ℝ`. This offset-by-one indexing is standard in Lean/Mathlib: `Finset.range n = {0, 1, ..., n-1}`, so `∑ k in Finset.range n, naturals k = \\frac{n(n+1)}{2}`.",
     "significance": "supporting",
+    "prerequisites": [
+      "natural numbers",
+      "Lean 4 type coercions",
+      "Mathlib tsum API"
+    ],
     "relatedConcepts": [
       "natural numbers",
       "sequences"
@@ -60,8 +78,14 @@
     "type": "theorem",
     "title": "The False Claim Would Require Convergence",
     "content": "This theorem shows that IF we could prove $\\sum n = -\\frac{1}{12}$, THEN the series would need to be `Summable`. But the series diverges, so this implication is vacuously true - we can never satisfy the hypothesis.",
-    "mathContext": "The `sorry` here is permanent - this line of reasoning is blocked. Lean forces us to acknowledge that the hypothesis is impossible.",
+    "mathContext": "The argument uses the contrapositive of `tsum_eq_zero_of_not_summable`: if `¬ Summable f`, then `tsum f = 0`. So `tsum naturals = -1/12` would force `tsum naturals ≠ 0`, hence `Summable naturals` — but we prove `¬ Summable naturals` by showing partial sums are unbounded. The `sorry` marks the exact point where the informal argument breaks the formal rules.",
     "significance": "key",
+    "prerequisites": [
+      "real analysis",
+      "divergent series",
+      "Lean 4 type system",
+      "Mathlib tsum API"
+    ],
     "relatedConcepts": [
       "vacuous truth",
       "impossible hypothesis"
@@ -77,8 +101,14 @@
     "type": "definition",
     "title": "The Grandi Series",
     "content": "The **Grandi series** $1-1+1-1+\\cdots$ has partial sums that alternate forever between 0 and 1. It does not converge in any standard sense.",
-    "mathContext": "The Numberphile video claims this equals $\\frac{1}{2}$ by averaging 0 and 1. This is actually the **Cesaro mean**, not the limit. They're different mathematical concepts!",
+    "mathContext": "Defined as `grandi n = (-1)^n`. The partial sums are $S_n = \\frac{1-(-1)^{n+1}}{2}$, oscillating between 0 and 1. The **Cesàro mean** is $\\lim_{N\\to\\infty}\\frac{1}{N}\\sum_{n=0}^{N-1} S_n = \\frac{1}{2}$, which the Numberphile video conflates with the series limit. In Mathlib: `¬ Summable grandi` because the partial sums do not converge.",
     "significance": "key",
+    "prerequisites": [
+      "real analysis",
+      "partial sums",
+      "Cesaro summability",
+      "infinite series"
+    ],
     "relatedConcepts": [
       "partial sums",
       "Cesaro mean",
@@ -96,8 +126,13 @@
     "type": "theorem",
     "title": "FALLACY: Cannot Prove Grandi = 1/2",
     "content": "Here we attempt to prove the Numberphile claim that $1-1+1-1+\\cdots = \\frac{1}{2}$. **This is impossible** - the `sorry` can never be filled in. Since the series isn't summable, `tsum grandi = 0` by definition, and $0 \\neq \\frac{1}{2}$.",
-    "mathContext": "The red X (❌) in the comments indicates Lean rejects this. This is the first fallacy in the Numberphile argument.",
+    "mathContext": "Formally: `tsum_eq_zero_of_not_summable : ¬ Summable f → tsum f = 0`. Since `¬ Summable grandi`, we get `tsum grandi = 0`. The goal `tsum grandi = 1/2` reduces to `(0 : ℝ) = 1/2`, which `norm_num` immediately refutes. Any `sorry`-free proof here would yield `False`.",
     "significance": "key",
+    "prerequisites": [
+      "Grandi series",
+      "Mathlib tsum API",
+      "Lean 4 norm_num"
+    ],
     "relatedConcepts": [
       "tsum convention",
       "proof failure"
@@ -113,8 +148,14 @@
     "type": "concept",
     "title": "The Shift-and-Add Trick",
     "content": "The Numberphile proof adds $S_2$ to a shifted copy of itself:\n$$2S_2 = (1-2+3-4+\\cdots) + (0+1-2+3+\\cdots)$$\nThis term-by-term addition is ONLY valid for convergent series!",
-    "mathContext": "The **Riemann series theorem** proves that rearranging a conditionally convergent series can give any real number as a 'sum'. For divergent series, such manipulations are completely meaningless.",
+    "mathContext": "The **Riemann series theorem** (Riemann, 1853) states that any conditionally convergent series can be rearranged to converge to any value in $\\mathbb{R} \\cup \\{\\pm\\infty\\}$. For *divergent* series, term-by-term operations are completely undefined. The shift operation in Mathlib is `tsum_eq_zero_add : Summable f → tsum f = f 0 + tsum (f ∘ Nat.succ)`, which requires a summability witness.",
     "significance": "key",
+    "prerequisites": [
+      "infinite series",
+      "Riemann rearrangement theorem",
+      "conditional convergence",
+      "absolute convergence"
+    ],
     "relatedConcepts": [
       "Riemann series theorem",
       "rearrangement",
@@ -132,7 +173,14 @@
     "type": "lemma",
     "title": "Alternating Naturals Don't Converge Either",
     "content": "The series $1-2+3-4+5-6+\\cdots$ also diverges. Its partial sums grow without bound in absolute value: $1, -1, 2, -2, 3, -3, \\ldots$",
+    "mathContext": "Define `alternatingNaturals n = (-1)^n * (n + 1)`. The partial sums satisfy $|S_{2k}| = k+1$ and $|S_{2k+1}| = k+1$ — both grow without bound. `¬ Summable alternatingNaturals` follows from the necessary condition: if `Summable f`, then `Filter.Tendsto f atTop (nhds 0)`. But `|alternatingNaturals n| = n+1 → ∞`, so it cannot tend to 0.",
     "significance": "key",
+    "prerequisites": [
+      "real analysis",
+      "necessary condition for convergence",
+      "alternating series",
+      "Mathlib Summable API"
+    ],
     "relatedConcepts": [
       "divergence",
       "partial sums"
@@ -149,8 +197,13 @@
     "type": "theorem",
     "title": "Shifting Requires Convergence Proof",
     "content": "Mathlib's lemmas for manipulating series (like `tsum_eq_zero_add`) all require a `Summable` hypothesis. This is the **type-level gatekeeper** that prevents invalid reasoning.",
-    "mathContext": "Notice `hf : Summable f` in the theorem statement. Without this proof, Lean won't let you use the lemma.",
+    "mathContext": "The relevant Mathlib lemma: `theorem tsum_eq_zero_add {f : ℕ → α} (hf : Summable f) : ∑' n, f n = f 0 + ∑' n, f (n + 1)`. Without `hf`, both sides equal 0 by `tsum_eq_zero_of_not_summable`, making the equation trivially `0 = 0 + 0`. The `Summable` term is a **proof witness** — it cannot be faked; you must construct it from first principles.",
     "significance": "key",
+    "prerequisites": [
+      "Lean 4 dependent types",
+      "Mathlib tsum API",
+      "typeclass constraints"
+    ],
     "relatedConcepts": [
       "typeclass constraints",
       "proof obligations"
@@ -166,7 +219,13 @@
     "type": "theorem",
     "title": "FALLACY: Shift-Add Blocked by Type System",
     "content": "When we try to apply the shift-and-add manipulation to our divergent series, **Lean blocks us**. We would need `Summable alternatingNaturals`, but we proved this is false!",
+    "mathContext": "The attempted proof calls `tsum_eq_zero_add h` where `h : Summable alternatingNaturals`. But `alternatingNaturals_not_summable : ¬ Summable alternatingNaturals` makes it impossible to construct such `h` without `sorry`. Lean's elaborator rejects the proof: there is no term of type `Summable alternatingNaturals` to supply. The `sorry` here is a permanent red flag — it marks the exact location where the informal argument breaks the formal rules.",
     "significance": "key",
+    "prerequisites": [
+      "Lean 4 type checking",
+      "Mathlib tsum API",
+      "proof by contradiction"
+    ],
     "relatedConcepts": [
       "type checking",
       "blocked proof"
@@ -183,8 +242,13 @@
     "type": "lemma",
     "title": "Partial Sums Grow Without Bound",
     "content": "The sum $1+2+\\cdots+n = \\frac{n(n+1)}{2}$, which grows without bound as $n \\to \\infty$. This is the formal statement that the series diverges.",
-    "mathContext": "For any $M$, we can find $N$ large enough that the partial sum exceeds $M$. This is the definition of divergence to infinity.",
+    "mathContext": "The triangular number formula $T_n = \\frac{n(n+1)}{2}$ gives `∑ k in Finset.range n, (k+1) = n*(n+1)/2`. For any bound $M$, choosing $n > 2M$ gives $T_n > M$. Formally: `∀ M : ℝ, ∃ N : ℕ, ∀ n ≥ N, M < ∑ k in Finset.range n, naturals k`. This implies `¬ Summable naturals` since summable sequences must have terms tending to 0, but `naturals n = n+1 → ∞`.",
     "significance": "key",
+    "prerequisites": [
+      "real analysis",
+      "triangular numbers",
+      "Gauss summation formula"
+    ],
     "relatedConcepts": [
       "divergence to infinity",
       "triangle numbers"
@@ -201,8 +265,13 @@
     "type": "theorem",
     "title": "MAIN RESULT: The Sum Does NOT Equal -1/12",
     "content": "Here's the key theorem: $\\sum_{n=1}^{\\infty} n \\neq -\\frac{1}{12}$. The proof is almost trivial once we know the series doesn't converge:\n1. `naturals` is not summable\n2. Therefore `tsum naturals = 0` (by Mathlib convention)\n3. $0 \\neq -\\frac{1}{12}$ (by `norm_num`)",
-    "mathContext": "This is what Lean can actually PROVE, as opposed to the fallacious claim. The type system has protected us from error.",
+    "mathContext": "Proof sketch: `have h0 : tsum naturals = 0 := tsum_eq_zero_of_not_summable naturals_not_summable; have h1 : (0 : ℝ) ≠ -1/12 := by norm_num; rw [h0]; exact h1`. The three-step argument reflects the mathematical reality: **standard summation assigns no value to this series** — not $-1/12$, not $+\\infty$, just the junk value 0.",
     "significance": "key",
+    "prerequisites": [
+      "real analysis",
+      "Mathlib tsum API",
+      "Lean 4 norm_num"
+    ],
     "relatedConcepts": [
       "tsum_eq_zero_of_not_summable",
       "norm_num"
@@ -219,8 +288,14 @@
     "type": "concept",
     "title": "What -1/12 Actually Means",
     "content": "The value $-\\frac{1}{12}$ is real - it comes from the **Riemann zeta function** $\\zeta(s) = \\sum n^{-s}$ analytically continued to $s = -1$. But this is a DIFFERENT mathematical operation than ordinary summation.",
-    "mathContext": "In Lean, we would model zeta regularization with a completely different function type. The type system enforces the distinction automatically - you can't confuse `tsum` with `zeta_regularized`.",
+    "mathContext": "The Riemann zeta function $\\zeta(s) = \\sum_{n=1}^{\\infty} n^{-s}$ converges for $\\text{Re}(s) > 1$ and extends uniquely to a meromorphic function on $\\mathbb{C} \\setminus \\{1\\}$. At $s = -1$: $\\zeta(-1) = -\\frac{1}{12}$. In Lean, this would be a *different function type*: `riemannZeta : ℂ → ℂ` vs `tsum : (ℕ → ℝ) → ℝ`. The Lean type system makes the distinction **syntactically enforced** — you cannot accidentally confuse ordinary summation with zeta regularization.",
     "significance": "key",
+    "prerequisites": [
+      "complex analysis",
+      "Riemann zeta function",
+      "analytic continuation",
+      "meromorphic functions"
+    ],
     "relatedConcepts": [
       "Riemann zeta function",
       "analytic continuation",
@@ -237,7 +312,13 @@
     "type": "theorem",
     "title": "Step 2 Fails: Cannot Shift Divergent Series",
     "content": "The second step uses the shift-and-add manipulation. **BLOCKED**: This requires `Summable` which we cannot prove for divergent series.",
+    "mathContext": "Step 2 of the Numberphile argument claims $2S_2 = \\frac{1}{4}$ by shifting and adding. In Lean: `tsum alternatingNaturals + tsum (fun n => alternatingNaturals (n+1)) = 1/4`. By `tsum_eq_zero_of_not_summable`, both `tsum`s equal 0, giving `0 + 0 = 0 ≠ 1/4`. The shift lemma `tsum_eq_zero_add` is unavailable since `¬ Summable alternatingNaturals`. Step 2 thus fails in two independent ways: the computed value is wrong, and the manipulation is illegal.",
     "significance": "key",
+    "prerequisites": [
+      "alternating series",
+      "Mathlib tsum API",
+      "Lean 4 type checking"
+    ],
     "relatedConcepts": [
       "second fallacy",
       "manipulation blocked"
@@ -254,8 +335,13 @@
     "type": "theorem",
     "title": "Step 3 'Works' But Is Useless",
     "content": "Interestingly, the equation $S - S_2 = 4S$ **does typecheck** - but it's trivially true because both sides equal 0! This shows how Mathlib's convention prevents false conclusions: we can prove $0 - 0 = 4 \\cdot 0$, but this tells us nothing about $-\\frac{1}{12}$.",
-    "mathContext": "The `sorry`-free proof here uses `tsum_eq_zero_of_not_summable` twice, reducing everything to $0 = 0$.",
+    "mathContext": "The algebraic step $S - S_2 = 4S$ typechecks as: `tsum naturals - tsum alternatingNaturals = 4 * tsum naturals`. Since both `tsum` values are 0 by `tsum_eq_zero_of_not_summable`, this becomes `0 - 0 = 4 * 0`, i.e., `0 = 0` — provable by `ring`. The Numberphile argument uses this *form* to conclude $S = -\\frac{1}{12}$, but Lean sees only `0 = 0`: no information about the actual series value is transmitted.",
     "significance": "key",
+    "prerequisites": [
+      "Mathlib tsum API",
+      "Lean 4 ring tactic",
+      "algebraic manipulation"
+    ],
     "relatedConcepts": [
       "vacuous truth",
       "zero convention"
@@ -272,7 +358,14 @@
     "type": "concept",
     "title": "Conclusion: Type Systems Enforce Rigor",
     "content": "Lean's type system and Mathlib's design choices enforce mathematical rigor automatically:\n\n1. **Summable typeclass**: Acts as proof obligation before series manipulation\n2. **tsum = 0 convention**: Prevents arithmetic on divergent 'values'\n3. **Distinct types**: Regularization would be a different function entirely\n\nThe -1/12 result is useful in physics, but it requires different mathematical machinery that Lean would model with appropriate types.",
+    "mathContext": "The `Summable` typeclass is a **proof-carrying data** pattern: before calling `tsum_add (h1 : Summable f) (h2 : Summable g)`, you must supply witnesses `h1` and `h2` — real mathematical proofs that cannot be fabricated. Lean's kernel verifies proof correctness definitionally, making it impossible to accidentally apply series lemmas to divergent series. This is the fundamental difference between informal mathematics (where errors propagate undetected) and formal verification (where each step is machine-checked).",
     "significance": "key",
+    "prerequisites": [
+      "Lean 4 type system",
+      "Mathlib Summable typeclass",
+      "formal verification",
+      "proof-carrying data"
+    ],
     "relatedConcepts": [
       "formal verification",
       "type safety",


### PR DESCRIPTION
## Summary

Enriched three proof gallery entries with deeper mathematical context:

- **four-color-theorem**: Added mathContext to 7 annotations (Euler's formula planarity bound, Kempe chain component definition, reducibility configuration count $4^{14}$, Gonthier's CIC trust hierarchy); added prerequisites to 8 annotations
- **godel-incompleteness**: Added mathContext to 6 annotations (full first-order grammar, inexhaustibility tower $F_{\alpha+1} = F_\alpha + \text{Con}(F_\alpha)$, Lucas-Penrose debate with Putnam-Boolos refutation); added prerequisites to 8 annotations
- **ramanujan-sum-fallacy**: Added mathContext to all 5 missing annotations (tsum junk-value definition, alternating series divergence, shift-blocked proof, step 2 dual failure); added prerequisites to all 16 annotations

## Mathematical quality

All enrichments add substantive formal content: Mathlib lemma signatures, formal statement schemas, precise quantitative details, and type-level explanations of how Lean enforces mathematical rigor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)