### PR TITLE
enrichment: tractatus-ontology, ramanujan-sum-fallacy, four-color-theorem, godel-incompleteness

### DIFF
--- a/src/data/proofs/four-color-theorem/annotations.json
+++ b/src/data/proofs/four-color-theorem/annotations.json
@@ -9,12 +9,14 @@
     "type": "concept",
     "title": "The Theorem That Took 124 Years",
     "content": "The Four Color Theorem has a remarkable history. Posed in 1852, it resisted proof for over a century, defeating many brilliant mathematicians. Its eventual 1976 proof required something unprecedented: a computer checking thousands of cases no human could verify.\n\nThe theorem states that any map can be colored with at most four colors such that no two adjacent regions share a color. While easy to state and seemingly simple, the proof revealed deep connections between graph theory, combinatorics, and computation.\n\nThis formalization presents the conceptual structure. The complete proof (Appel-Haken 1976, Gonthier 2005) requires computer verification of 1,936 configurations.",
+    "mathContext": "$\\chi(G) \\leq 4$ for all planar graphs $G$, where $\\chi(G) = \\min\\{k : G \\text{ is } k\\text{-colorable}\\}$. First major theorem with essential computer assistance: Appel-Haken (1976) verified 1,936 reducible configurations; Robertson et al. (1997) reduced to 633. Formalized by Gonthier in Coq (2005), reducing trust to the Coq kernel.",
     "significance": "key",
     "relatedConcepts": [
       "graph theory",
       "computer-assisted proof",
       "planar graphs"
-    ]
+    ],
+    "prerequisites": ["graph theory basics", "map-graph duality", "chromatic number"]
   },
   {
     "id": "ann-graph-structure",
@@ -26,12 +28,14 @@
     "type": "definition",
     "title": "Graphs and Their Structure",
     "content": "We model maps as graphs where vertices represent regions and edges connect adjacent regions. This transforms the map coloring problem into a graph coloring problem.\n\nA graph $G = (V, E)$ consists of:\n- A set $V$ of vertices (the regions)\n- A set $E$ of edges (adjacency relations)\n- Edges are symmetric: if region A borders B, then B borders A\n\nThis abstraction lets us apply graph-theoretic tools to a geometric problem.",
+    "mathContext": "$G = (V, E)$ with $E \\subseteq \\binom{V}{2}$ (simple undirected graph). The dual of a planar map: countries $\\mapsto$ vertices, shared borders $\\mapsto$ edges. A planar map is 4-colorable iff its dual graph satisfies $\\chi \\leq 4$. The dual is always planar, so the map and graph versions are equivalent.",
     "significance": "key",
     "relatedConcepts": [
       "vertex",
       "edge",
       "adjacency"
-    ]
+    ],
+    "prerequisites": ["set theory", "equivalence relations", "map-graph duality"]
   },
   {
     "id": "ann-coloring",
@@ -43,13 +47,14 @@
     "type": "definition",
     "title": "Graph Coloring",
     "content": "A **proper k-coloring** assigns one of k colors to each vertex such that adjacent vertices receive different colors. The **chromatic number** $\\chi(G)$ is the minimum k for which a proper k-coloring exists.\n\nThe Four Color Theorem states: $\\chi(G) \\leq 4$ for all planar graphs G.\n\nNote that we need $k \\geq 4$ for some graphs (like the complete graph $K_4$, where every vertex connects to every other). The theorem says 4 always suffices for planar graphs.",
-    "mathContext": "$\\chi(G) = \\min\\{k : G \\text{ is } k\\text{-colorable}\\}$",
+    "mathContext": "$\\chi(G) = \\min\\{k : G \\text{ is } k\\text{-colorable}\\}$. A proper $k$-coloring is $c: V \\to \\{1,\\ldots,k\\}$ with $c(u) \\neq c(v)$ for all $\\{u,v\\} \\in E$. The complete graph $K_4$ requires $\\chi(K_4) = 4$; $K_4$ is planar, so the bound 4 is tight. The theorem asserts $\\chi(G) \\leq 4$ for ALL planar $G$.",
     "significance": "key",
     "relatedConcepts": [
       "chromatic number",
       "proper coloring",
       "k-colorable"
-    ]
+    ],
+    "prerequisites": ["graph definition", "function coloring", "chromatic number"]
   },
   {
     "id": "ann-planar",
@@ -61,12 +66,14 @@
     "type": "definition",
     "title": "Planar Graphs",
     "content": "A graph is **planar** if it can be drawn in the plane with no edge crossings. Equivalently, it can be embedded on a sphere.\n\nNot all graphs are planar! The complete graph $K_5$ (5 vertices, all connected) and the complete bipartite graph $K_{3,3}$ are the 'forbidden minors'—every non-planar graph contains one of these as a substructure.\n\nPlanarity is essential to the theorem. Non-planar graphs can require arbitrarily many colors.",
+    "mathContext": "A graph $G$ is planar iff it contains no subdivision of $K_5$ or $K_{3,3}$ as a subgraph (Kuratowski 1930). Equivalently: no $K_5$ or $K_{3,3}$ as a topological minor (Wagner 1937). For planar $G$ with $|V| \\geq 3$: $|E| \\leq 3|V| - 6$ (from Euler's formula + $|F| \\geq |E|/3$ since every face has $\\geq 3$ boundary edges). The complete graph $K_5$ violates this: $|E|=10 > 3 \\cdot 5 - 6 = 9$.",
     "significance": "key",
     "relatedConcepts": [
       "planar embedding",
       "Kuratowski's theorem",
       "forbidden minors"
-    ]
+    ],
+    "prerequisites": ["graph embeddings", "Euler's formula", "Kuratowski's theorem"]
   },
   {
     "id": "ann-euler",
@@ -78,7 +85,7 @@
     "type": "theorem",
     "title": "Euler's Formula: The Fundamental Constraint",
     "content": "For any connected planar graph embedded in the plane:\n\n$$V - E + F = 2$$\n\nwhere V = vertices, E = edges, F = faces (including the unbounded outer face).\n\nThis remarkable formula constrains planar graph structure. Combined with the handshaking lemma (sum of degrees = 2E), it implies every planar graph has a vertex of degree at most 5.\n\nThis 'low-degree vertex' existence is the entry point for inductive proofs of coloring theorems.",
-    "mathContext": "$V - E + F = 2$ for connected planar graphs",
+    "mathContext": "$V - E + F = 2$ for connected planar graphs. Since each face is bounded by $\\geq 3$ edges and each edge bounds $\\leq 2$ faces: $3F \\leq 2E$, so $F \\leq 2E/3$. Substituting: $V - E + 2E/3 \\geq 2$, giving $E \\leq 3V - 6$. The handshaking lemma $\\sum_v \\deg(v) = 2E \\leq 6V - 12$ gives average degree $< 6$, so some vertex has $\\deg \\leq 5$.",
     "significance": "key",
     "prerequisites": [
       "ann-planar"
@@ -99,7 +106,7 @@
     "type": "theorem",
     "title": "Every Planar Graph Has a Low-Degree Vertex",
     "content": "Every planar graph with at least one vertex has a vertex of degree at most 5.\n\n**Proof sketch:** By Euler's formula and handshaking, the average degree in a planar graph is less than 6. Therefore, some vertex must have degree at most 5.\n\nThis result is crucial: it guarantees we can always find a 'removable' vertex for inductive arguments. It's why the Five Color Theorem is easy (6 colors would be trivial, 5 requires one trick, 4 requires computer assistance).",
-    "mathContext": "$\\forall G$ planar, $\\exists v \\in V(G)$ with $\\deg(v) \\leq 5$",
+    "mathContext": "$\\forall G$ planar, $\\exists v \\in V(G)$ with $\\deg(v) \\leq 5$. Proof: $\\sum_v \\deg(v) = 2|E| \\leq 6|V| - 12 < 6|V|$, so average degree $< 6$, so minimum degree $\\leq 5$. The bound 5 is tight: the icosahedron graph has minimum degree exactly 5. For 4-coloring, the key cases are $\\deg(v) \\leq 4$ (easy) and $\\deg(v) = 5$ (requires Kempe chains).",
     "significance": "key",
     "prerequisites": [
       "ann-euler"
@@ -119,7 +126,7 @@
     "type": "theorem",
     "title": "The Five Color Theorem",
     "content": "Every planar graph is 5-colorable. This is much easier than Four Color!\n\n**Proof by induction:**\n1. Find a vertex v of degree ≤ 5\n2. Remove v to get smaller graph G'\n3. By induction, G' is 5-colorable\n4. Restore v: it has ≤ 5 neighbors using ≤ 5 colors\n5. If all 5 colors appear among neighbors, use Kempe chains to free one\n6. Color v with the freed color\n\nThe key insight: with 5 colors and ≤ 5 neighbors, we can always make room. With 4 colors, this argument fails—hence the difficulty of the Four Color Theorem.",
-    "mathContext": "$\\chi(G) \\leq 5$ for all planar graphs G",
+    "mathContext": "$\\chi(G) \\leq 5$ for all planar $G$. The Heawood 1890 proof: if $\\deg(v) = 5$ and neighbors use all 5 colors, pick non-adjacent neighbors $u_1$ (color 1) and $u_3$ (color 3). If they're in the same Kempe $(1,3)$-chain, try $(2,4)$-chain swap on neighbor $u_2$. At least one of these swaps frees a color for $v$. With 4 colors and $\\deg(v) = 5$: two non-adjacent neighbors might share the same Kempe chain, blocking both swaps simultaneously — this is the gap Kempe's 1879 proof failed to handle.",
     "significance": "key",
     "prerequisites": [
       "ann-low-degree"
@@ -139,12 +146,14 @@
     "type": "concept",
     "title": "Kempe Chains: The Color-Swapping Trick",
     "content": "A **Kempe chain** for colors a and b starting at vertex v is the maximal connected subgraph of vertices colored a or b containing v.\n\nThe crucial property: swapping colors a ↔ b on a Kempe chain produces another valid coloring! Adjacent vertices still have different colors because:\n- Vertices outside the chain keep their colors\n- Inside the chain, neighbors alternate between a and b\n\nKempe invented this for his 1879 'proof' of Four Colors. His argument was flawed, but the technique is correct and essential. The flaw was in handling cases where multiple Kempe chains interact.",
+    "mathContext": "The Kempe $(a,b)$-chain at $v$: the connected component of $v$ in $G[\\{u \\in V : c(u) \\in \\{a,b\\}\\}]$. Swapping $a \\leftrightarrow b$ on this chain produces a valid coloring: for edge $\\{u,w\\}$ with both in the chain, $c(u) \\neq c(w)$ since they are $a$ and $b$ in some order; for one endpoint inside and one outside, the outside keeps its color $\\notin \\{a,b\\}$, still different. Kempe's error: two chains can become connected after a swap, making a second swap invalid.",
     "significance": "key",
     "relatedConcepts": [
       "color swapping",
       "connected component",
       "Kempe's fallacy"
-    ]
+    ],
+    "prerequisites": ["proper coloring", "connected components in subgraphs", "graph-induced subgraph"]
   },
   {
     "id": "ann-kempe-swap",
@@ -156,7 +165,8 @@
     "type": "theorem",
     "title": "Kempe Chain Swapping Preserves Validity",
     "content": "If we have a proper coloring and swap colors along a Kempe chain, the result is still a proper coloring.\n\n**Why it works:**\n- Any edge with both endpoints in the chain: before, one was color a, one was b; after, they're swapped but still different\n- Any edge with one endpoint in, one out: the outside endpoint keeps its original color (not a or b), so still different from the inside endpoint\n- Any edge with both endpoints outside: unchanged\n\nThis lets us 'free up' a color at a specific vertex by pushing conflicting colors elsewhere.",
-    "mathContext": "Swapping on Kempe chain preserves $\\forall(u,v) \\in E: c(u) \\neq c(v)$",
+    "mathContext": "Swapping on Kempe chain preserves $\\forall(u,v) \\in E: c(u) \\neq c(v)$. Formal verification: partition edges into 3 types — both in chain (colors swap, remain $a \\neq b$), one inside/one outside (outside color $\\notin \\{a,b\\}$, still different), both outside (unchanged). Case analysis closes the proof. In Lean: follows by `simp` on the structural characterization of the Kempe component.",
+    "mathContext": "Formally: let $K$ = Kempe $(a,b)$-chain, $c': V \\to \\{1,2,3,4\\}$ with $c'(v) = \\overline{c(v)}^{a \\leftrightarrow b}$ if $v \\in K$, else $c'(v) = c(v)$. Claim: $c'$ is a proper coloring. For $\\{u,w\\} \\in E$: if both $u,w \\in K$ then $c'(u) \\neq c'(w)$ (both swapped, were $a,b$); if $u \\in K, w \\notin K$ then $c(w) \\notin \\{a,b\\}$ (else $w$ would be in $K$), so $c'(w) = c(w) \\neq c(u) \\in \\{a,b\\}$.",
     "significance": "key",
     "prerequisites": [
       "ann-kempe-chains"
@@ -176,12 +186,14 @@
     "type": "concept",
     "title": "Reducibility: Configurations That Can't Block Coloring",
     "content": "A configuration C is **reducible** if it cannot appear in a minimal counterexample to Four Color. That is: if a planar graph G contains C, then G is 4-colorable (or G can be simplified to a smaller graph that's 4-colorable).\n\nProving reducibility requires showing that any 4-coloring of the graph minus the configuration can be extended to include it. This involves analyzing all possible colorings of the boundary and showing Kempe chains can always make room.\n\nFor many configurations, this case analysis is astronomically complex—too many cases for human verification. This is where computers become essential.",
+    "mathContext": "Configuration $C$ is reducible if: for any planar graph $G \\supseteq C$, a 4-coloring of $G \\setminus \\text{int}(C)$ extends to a 4-coloring of $G$. The boundary $\\partial C$ has $k \\leq 14$ vertices (for the Appel-Haken set), giving at most $4^{14} \\approx 2.7 \\times 10^8$ boundary colorings to check. Computer reduces via Kempe recoloring: for each boundary coloring, determine if the interior can be consistently 4-colored. Appel-Haken: all 1,936 configurations are reducible.",
     "significance": "key",
     "relatedConcepts": [
       "minimal counterexample",
       "configuration",
       "extendability"
-    ]
+    ],
+    "prerequisites": ["minimal counterexample method", "Kempe chain recoloring", "boundary coloring extension"]
   },
   {
     "id": "ann-computer-verification",
@@ -193,12 +205,14 @@
     "type": "concept",
     "title": "Computer-Assisted Proof",
     "content": "The Appel-Haken proof (1976) required:\n- 1,200 hours of computer time\n- Verification of 1,936 configurations\n- 400+ pages of hand-written supporting proofs\n\nInitial reception was skeptical. How can we trust a proof no human can check? What if there's a bug in the program?\n\nGeorges Gonthier's 2005 Coq formalization addressed these concerns by reducing trust to a small, verified proof-checking kernel. The proof certificate is machine-checkable, and the checker itself is tiny enough to be human-verified.\n\nThis paradigm shift—from 'trust the program' to 'trust the proof checker'—has become foundational in formal methods.",
+    "mathContext": "The unavoidable set $\\mathcal{R}$: every planar graph must contain at least one member. For each $C \\in \\mathcal{R}$ (boundary size $|\\partial C| \\leq 14$): enumerate all $4^{|\\partial C|}$ boundary colorings, verify each is extendable (or reducible by Kempe). Appel-Haken: $|\\mathcal{R}| = 1{,}936$. Robertson et al. (1997): $|\\mathcal{R}| = 633$ with improved discharging. Gonthier (2005): the Coq proof kernel is $\\approx 10{,}000$ lines of OCaml — small enough for human audit, unlike the application code.",
     "significance": "key",
     "relatedConcepts": [
       "Coq",
       "formal verification",
       "proof assistant"
-    ]
+    ],
+    "prerequisites": ["unavoidable set", "reducible configurations", "discharging method", "Coq proof assistant"]
   },
   {
     "id": "ann-gonthier",
@@ -210,11 +224,13 @@
     "type": "insight",
     "title": "Gonthier's Coq Formalization",
     "content": "In 2005, Georges Gonthier completed a full formalization of the Four Color Theorem in Coq. This was a landmark achievement:\n\n- **Complete verification:** Every step machine-checked, including all 1,936 configurations\n- **Independent verification:** The Coq proof is a certificate anyone can verify using the proof checker\n- **Trust reduction:** We no longer trust Appel-Haken's program; we trust Coq's small kernel\n\nThe formalization took several person-years but provided certainty that the theorem is correct. It demonstrated that even massive computational proofs can be made rigorous through formal methods.",
+    "mathContext": "Gonthier built on Robertson et al.'s 633-configuration set using SSReflect (a Coq extension for boolean reflection). The proof term inhabits the type `four_color_theorem : ∀ G : planarGraph, 4_colorable G` in CIC (Calculus of Inductive Constructions). Trust hierarchy: theorem $\\leftarrow$ Coq kernel ($\\approx 10^4$ lines OCaml) $\\leftarrow$ CIC type theory (consistency relative to large cardinals). This is a foundational improvement over trusting $\\approx 10^6$ lines of Fortran/C in the Appel-Haken check.",
     "significance": "key",
     "relatedConcepts": [
       "Coq proof assistant",
       "SSReflect",
       "proof certificate"
-    ]
+    ],
+    "prerequisites": ["Coq proof assistant", "SSReflect tactics", "type theory (CIC)", "boolean reflection"]
   }
 ]

--- a/src/data/proofs/godel-incompleteness/annotations.json
+++ b/src/data/proofs/godel-incompleteness/annotations.json
@@ -9,12 +9,14 @@
     "type": "concept",
     "title": "The Theorem That Changed Everything",
     "content": "Gödel's 1931 paper is one of the most important in the history of mathematics and logic. It proved that Hilbert's dream of a complete, consistent formal foundation for mathematics was impossible.\n\nThe theorem states that any formal system $F$ capable of expressing basic arithmetic must be **incomplete**: there exist true statements that $F$ cannot prove. This isn't a flaw in our axioms—it's a fundamental limitation of formal reasoning itself.\n\nThis formalization presents the key conceptual components. A complete proof would require thousands of lines defining syntax, proof systems, and primitive recursive functions.",
+    "mathContext": "Gödel's First Incompleteness Theorem: For any consistent formal system $F$ extending PA, $\\exists \\phi$ such that $F \\not\\vdash \\phi$ and $F \\not\\vdash \\neg\\phi$. Second Incompleteness: $F \\not\\vdash \\text{Con}(F)$ for consistent $F$. Together these terminate Hilbert's program — no consistent axiomatizable extension of arithmetic is both complete and proves its own consistency.",
     "significance": "key",
     "relatedConcepts": [
       "Hilbert's Program",
       "formal systems",
       "metamathematics"
-    ]
+    ],
+    "prerequisites": ["formal logic", "Peano Arithmetic", "proof theory"]
   },
   {
     "id": "ann-formula-type",
@@ -26,12 +28,14 @@
     "type": "definition",
     "title": "The Formula Type",
     "content": "We axiomatize `Formula` as an abstract type representing well-formed formulas in our formal system. In a full formalization, this would be an inductive type defining the syntax of first-order arithmetic:\n\n- Variables: $x, y, z, \\ldots$\n- Constants: $0, 1, 2, \\ldots$\n- Functions: $+, \\times, S$ (successor)\n- Relations: $=, <$\n- Logical connectives: $\\land, \\lor, \\neg, \\rightarrow$\n- Quantifiers: $\\forall, \\exists$\n\nEvery formula in Peano Arithmetic can be built from these primitives.",
+    "mathContext": "Terms: $t ::= 0 \\mid x \\mid S(t) \\mid t + t \\mid t \\cdot t$. Formulas: $\\phi ::= (t_1 = t_2) \\mid \\neg\\phi \\mid (\\phi \\land \\psi) \\mid \\exists x.\\phi$. The set $\\text{Fml}$ of all formulas is countably infinite, so a Gödel numbering (injective function $\\text{Fml} \\to \\mathbb{N}$) exists. In Lean, this would be `inductive Formula : Type` with constructors for each case.",
     "significance": "key",
     "relatedConcepts": [
       "formal syntax",
       "first-order logic",
       "Peano Arithmetic"
-    ]
+    ],
+    "prerequisites": ["first-order logic syntax", "inductive data types in Lean", "formal language theory"]
   },
   {
     "id": "ann-provability",
@@ -49,7 +53,8 @@
       "proof",
       "derivation",
       "syntactic consequence"
-    ]
+    ],
+    "prerequisites": ["Hilbert-style deduction systems", "inference rules", "syntactic vs. semantic truth"]
   },
   {
     "id": "ann-godel-numbering",
@@ -67,7 +72,8 @@
       "encoding",
       "arithmetization",
       "metamathematics"
-    ]
+    ],
+    "prerequisites": ["natural number arithmetic", "injective functions", "first-order formulas"]
   },
   {
     "id": "ann-encoding-injective",
@@ -79,6 +85,7 @@
     "type": "insight",
     "title": "Injectivity of Encoding",
     "content": "The Gödel numbering must be **injective**: different formulas get different numbers. This ensures we can uniquely identify formulas by their codes.\n\nGödel used prime factorization for his encoding. For instance, a sequence of symbols $(a_1, a_2, \\ldots, a_n)$ might be encoded as $2^{a_1} \\cdot 3^{a_2} \\cdot 5^{a_3} \\cdots p_n^{a_n}$ where $p_i$ is the $i$th prime. The fundamental theorem of arithmetic guarantees unique decoding.",
+    "mathContext": "Prime encoding: $\\langle a_1, \\ldots, a_n\\rangle \\mapsto \\prod_{i=1}^n p_i^{a_i}$ where $p_i$ is the $i$th prime. Injectivity follows from the Fundamental Theorem of Arithmetic (unique prime factorization): if $\\prod p_i^{a_i} = \\prod p_i^{b_i}$, then $a_i = b_i$ for all $i$. In Lean: `theorem encode_injective : Function.Injective encode`.",
     "significance": "supporting",
     "prerequisites": [
       "ann-godel-numbering"
@@ -139,14 +146,15 @@
     "type": "theorem",
     "title": "The Diagonal Lemma (Fixed Point Theorem)",
     "content": "This is the formal engine of self-reference. For any property $P(x)$ expressible in the system, there exists a sentence $\\gamma$ such that:\n\n$\\gamma \\iff P(\\ulcorner\\gamma\\urcorner)$\n\nIn other words, $\\gamma$ says \"I have property $P$.\" The sentence refers to itself—not by name, but by describing its own Gödel number!\n\nThe construction uses the substitution function and diagonalization, similar to Cantor's proof that the reals are uncountable. It's the formalization of the Liar's Paradox mechanism.",
-    "mathContext": "$\\forall P. \\exists\\gamma. \\gamma \\iff P(\\ulcorner\\gamma\\urcorner)$",
+    "mathContext": "$\\forall P. \\exists\\gamma. \\vdash \\gamma \\leftrightarrow P(\\ulcorner\\gamma\\urcorner)$. Construction: let $\\text{diag}(n)$ be the Gödel number of $\\phi(\\ulcorner\\phi\\urcorner)$ where $\\phi$ is the formula with number $n$. Then $\\gamma = \\phi(\\ulcorner\\phi\\urcorner)$ where $\\phi(x) \\equiv P(\\text{diag}(x))$. Analogous to Cantor's diagonal: the $n$th formula applied to its own number.",
     "significance": "key",
     "relatedConcepts": [
       "self-reference",
       "fixed point",
       "Liar's Paradox",
       "diagonalization"
-    ]
+    ],
+    "prerequisites": ["substitution function", "Gödel numbering", "diagonal argument (Cantor)"]
   },
   {
     "id": "ann-not-prov",
@@ -220,12 +228,14 @@
     "type": "concept",
     "title": "Death of Hilbert's Program",
     "content": "David Hilbert had proposed that:\n1. All mathematics could be formalized in a complete, consistent system\n2. The consistency of this system could be proved by \"finitary\" means\n\nGödel's First Incompleteness Theorem killed (1): no complete system exists. His Second Incompleteness Theorem killed (2): no consistent system can prove its own consistency.\n\nThis was a shock to the mathematical community. The dream of absolute certainty in mathematics was over.",
+    "mathContext": "Hilbert's program (1920s): formalize all of mathematics and prove $\\text{Con}(\\text{PA})$ by finitary means. Gödel 1st theorem: $\\text{Con}(F) \\implies \\neg\\text{Complete}(F)$ for any $F$ extending PA. Gödel 2nd theorem: $\\text{Con}(F) \\implies F \\not\\vdash \\text{Con}(F)$. Together: no system can be simultaneously consistent, complete, and self-verifying — Hilbert's trifecta is impossible.",
     "significance": "key",
     "relatedConcepts": [
       "Hilbert",
       "formalism",
       "finitism"
-    ]
+    ],
+    "prerequisites": ["Hilbert's formalism program (1920s)", "Gödel's Second Incompleteness Theorem", "finitary proof theory"]
   },
   {
     "id": "ann-limits",
@@ -237,12 +247,14 @@
     "type": "insight",
     "title": "The Inexhaustibility of Mathematics",
     "content": "Gödel's theorem reveals something profound: mathematical truth is inexhaustible. No matter how many axioms we add, there will always be truths beyond our reach.\n\nWe can always add $G$ as a new axiom—then the system proves what it couldn't before. But immediately, a new Gödel sentence $G'$ emerges that the expanded system cannot prove. It's turtles all the way down.",
+    "mathContext": "The inexhaustibility tower: $F_0 = \\text{PA}$, $F_{\\alpha+1} = F_\\alpha + \\text{Con}(F_\\alpha)$, $F_\\lambda = \\bigcup_{\\alpha < \\lambda} F_\\alpha$ at limits. Each $F_\\alpha$ is strictly stronger than $F_{\\beta}$ for $\\alpha > \\beta$. Ordinal analysis (Gentzen): $|\\text{PA}| = \\varepsilon_0$, the first epsilon number. Adding all true $\\Pi^0_1$ sentences gives all of true arithmetic — but this set is not recursively enumerable.",
     "significance": "key",
     "relatedConcepts": [
       "axiom extension",
       "ordinal analysis",
       "transfinite hierarchy"
-    ]
+    ],
+    "prerequisites": ["Gödel sentence construction", "ordinal numbers", "proof-theoretic ordinals"]
   },
   {
     "id": "ann-mechanism-debate",
@@ -254,11 +266,13 @@
     "type": "concept",
     "title": "Mind vs. Machine",
     "content": "Some philosophers (notably Roger Penrose and J.R. Lucas) have argued that Gödel's theorem shows human minds are not machines—we can \"see\" that $G$ is true even though no formal system can prove it.\n\nThis interpretation is controversial. Critics argue that humans are also subject to limitations, and our \"seeing\" the truth of $G$ depends on assumptions (like consistency) that we cannot verify.\n\nThe debate continues: does mathematical intuition transcend computation, or are we also bounded by our own version of incompleteness?",
+    "mathContext": "The Lucas-Penrose argument: human minds can verify $\\text{Con}(F)$ and hence prove $G_F$, which $F$ cannot prove, so minds $\\not\\subseteq F$. Refutation (Putnam, Boolos): if the human's reasoning is formalized as system $H$, then $H \\not\\vdash G_H$; the human's 'seeing' $G_F$ is true presupposes belief in $\\text{Con}(F)$, which $F$ does not provide. Neither humans nor machines escape the incompleteness tower — both must appeal to stronger systems.",
     "significance": "supporting",
     "relatedConcepts": [
       "mechanism",
       "Lucas-Penrose argument",
       "philosophy of mind"
-    ]
+    ],
+    "prerequisites": ["Turing machines and computability", "Gödel's First Incompleteness Theorem", "philosophy of mathematics"]
   }
 ]

--- a/src/data/proofs/ramanujan-sum-fallacy/annotations.json
+++ b/src/data/proofs/ramanujan-sum-fallacy/annotations.json
@@ -9,8 +9,14 @@
     "type": "concept",
     "title": "The Famous Fallacy",
     "content": "The claim $1+2+3+4+\\cdots = -\\frac{1}{12}$ went viral through a Numberphile video. While the value $-\\frac{1}{12}$ does appear in the Riemann zeta function ($\\zeta(-1) = -\\frac{1}{12}$), the 'elementary proof' using series manipulation is mathematically invalid.",
-    "mathContext": "In standard analysis, this series diverges to infinity. The -1/12 comes from **analytic continuation**, not from adding up the terms.",
+    "mathContext": "In standard analysis, $\\sum_{n=1}^{\\infty} n$ diverges to $+\\infty$. The value $-\\frac{1}{12}$ arises from **analytic continuation**: $\\zeta(s) = \\sum_{n=1}^{\\infty} n^{-s}$ converges for $\\text{Re}(s) > 1$, and the unique meromorphic extension to $\\mathbb{C}$ gives $\\zeta(-1) = -\\frac{1}{12}$. This is a *different mathematical operation* from ordinary summation.",
     "significance": "key",
+    "prerequisites": [
+      "infinite series",
+      "divergent series",
+      "Riemann zeta function",
+      "analytic continuation"
+    ],
     "relatedConcepts": [
       "divergent series",
       "zeta function",
@@ -27,8 +33,14 @@
     "type": "definition",
     "title": "How Mathlib Handles Infinite Sums",
     "content": "Mathlib's `tsum` (topological sum) function is the standard way to express infinite sums in Lean. Crucially, `tsum f` only equals the expected limit if the sum **converges**. For divergent series, `tsum` returns **0** by convention.",
-    "mathContext": "This design choice prevents false conclusions: you can't do arithmetic with 'infinite' values because they're just represented as 0. All the useful lemmas about series require a `Summable` proof.",
+    "mathContext": "Formally: `tsum f = if h : Summable f then (h.choose : α) else 0`. This junk-value convention means all lemmas that do useful things — `tsum_add`, `tsum_eq_zero_add`, `tsum_geometric_two` — carry a `Summable f` hypothesis. Without it, `tsum f = 0` and you can only prove $0 = 0$.",
     "significance": "key",
+    "prerequisites": [
+      "real analysis",
+      "infinite series",
+      "Lean 4 type system",
+      "Mathlib tsum API"
+    ],
     "relatedConcepts": [
       "tsum",
       "Summable",
@@ -45,7 +57,13 @@
     "type": "definition",
     "title": "Defining the Natural Number Series",
     "content": "We define `naturals n = n + 1` to get the sequence $1, 2, 3, 4, \\ldots$ (offset by 1 because $\\mathbb{N}$ starts at 0 in Lean).",
+    "mathContext": "The function `naturals : ℕ → ℝ` defined by `naturals n = ↑(n + 1)` gives the series $\\sum_{n=0}^{\\infty} (n+1) = 1 + 2 + 3 + \\cdots$. The cast `↑` coerces `ℕ` to `ℝ`. This offset-by-one indexing is standard in Lean/Mathlib: `Finset.range n = {0, 1, ..., n-1}`, so `∑ k in Finset.range n, naturals k = \\frac{n(n+1)}{2}`.",
     "significance": "supporting",
+    "prerequisites": [
+      "natural numbers",
+      "Lean 4 type coercions",
+      "Mathlib tsum API"
+    ],
     "relatedConcepts": [
       "natural numbers",
       "sequences"
@@ -61,8 +79,14 @@
     "type": "theorem",
     "title": "The False Claim Would Require Convergence",
     "content": "This theorem shows that IF we could prove $\\sum n = -\\frac{1}{12}$, THEN the series would need to be `Summable`. But the series diverges, so this implication is vacuously true - we can never satisfy the hypothesis.",
-    "mathContext": "The `sorry` here is permanent - this line of reasoning is blocked. Lean forces us to acknowledge that the hypothesis is impossible.",
+    "mathContext": "The argument uses the contrapositive of `tsum_eq_zero_of_not_summable`: if `¬ Summable f`, then `tsum f = 0`. So `tsum naturals = -1/12` would force `tsum naturals ≠ 0`, hence `Summable naturals` — but we prove `¬ Summable naturals` by showing partial sums are unbounded. The `sorry` marks the exact point where the informal argument breaks the formal rules.",
     "significance": "key",
+    "prerequisites": [
+      "real analysis",
+      "divergent series",
+      "Lean 4 type system",
+      "Mathlib tsum API"
+    ],
     "relatedConcepts": [
       "vacuous truth",
       "impossible hypothesis"
@@ -78,8 +102,14 @@
     "type": "definition",
     "title": "The Grandi Series",
     "content": "The **Grandi series** $1-1+1-1+\\cdots$ has partial sums that alternate forever between 0 and 1. It does not converge in any standard sense.",
-    "mathContext": "The Numberphile video claims this equals $\\frac{1}{2}$ by averaging 0 and 1. This is actually the **Cesaro mean**, not the limit. They're different mathematical concepts!",
+    "mathContext": "Defined as `grandi n = (-1)^n`. The partial sums are $S_n = \\frac{1-(-1)^{n+1}}{2}$, oscillating between 0 and 1. The **Cesàro mean** is $\\lim_{N\\to\\infty}\\frac{1}{N}\\sum_{n=0}^{N-1} S_n = \\frac{1}{2}$, which the Numberphile video conflates with the series limit. In Mathlib: `¬ Summable grandi` because the partial sums do not converge.",
     "significance": "key",
+    "prerequisites": [
+      "real analysis",
+      "partial sums",
+      "Cesaro summability",
+      "infinite series"
+    ],
     "relatedConcepts": [
       "partial sums",
       "Cesaro mean",
@@ -96,8 +126,13 @@
     "type": "theorem",
     "title": "FALLACY: Cannot Prove Grandi = 1/2",
     "content": "Here we attempt to prove the Numberphile claim that $1-1+1-1+\\cdots = \\frac{1}{2}$. **This is impossible** - the `sorry` can never be filled in. Since the series isn't summable, `tsum grandi = 0` by definition, and $0 \\neq \\frac{1}{2}$.",
-    "mathContext": "The red X (❌) in the comments indicates Lean rejects this. This is the first fallacy in the Numberphile argument.",
+    "mathContext": "Formally: `tsum_eq_zero_of_not_summable : ¬ Summable f → tsum f = 0`. Since `¬ Summable grandi`, we get `tsum grandi = 0`. The goal `tsum grandi = 1/2` reduces to `(0 : ℝ) = 1/2`, which `norm_num` immediately refutes. Any `sorry`-free proof here would yield `False`.",
     "significance": "key",
+    "prerequisites": [
+      "Grandi series",
+      "Mathlib tsum API",
+      "Lean 4 norm_num"
+    ],
     "relatedConcepts": [
       "tsum convention",
       "proof failure"
@@ -113,8 +148,14 @@
     "type": "concept",
     "title": "The Shift-and-Add Trick",
     "content": "The Numberphile proof adds $S_2$ to a shifted copy of itself:\n$$2S_2 = (1-2+3-4+\\cdots) + (0+1-2+3+\\cdots)$$\nThis term-by-term addition is ONLY valid for convergent series!",
-    "mathContext": "The **Riemann series theorem** proves that rearranging a conditionally convergent series can give any real number as a 'sum'. For divergent series, such manipulations are completely meaningless.",
+    "mathContext": "The **Riemann series theorem** (Riemann, 1853) states that any conditionally convergent series can be rearranged to converge to any value in $\\mathbb{R} \\cup \\{\\pm\\infty\\}$. For *divergent* series, term-by-term operations are completely undefined. The shift operation in Mathlib is `tsum_eq_zero_add : Summable f → tsum f = f 0 + tsum (f ∘ Nat.succ)`, which requires a summability witness.",
     "significance": "key",
+    "prerequisites": [
+      "infinite series",
+      "Riemann rearrangement theorem",
+      "conditional convergence",
+      "absolute convergence"
+    ],
     "relatedConcepts": [
       "Riemann series theorem",
       "rearrangement",
@@ -131,7 +172,14 @@
     "type": "lemma",
     "title": "Alternating Naturals Don't Converge Either",
     "content": "The series $1-2+3-4+5-6+\\cdots$ also diverges. Its partial sums grow without bound in absolute value: $1, -1, 2, -2, 3, -3, \\ldots$",
+    "mathContext": "Define `alternatingNaturals n = (-1)^n * (n + 1)`. The partial sums satisfy $|S_{2k}| = k+1$ and $|S_{2k+1}| = k+1$ — both grow without bound. `¬ Summable alternatingNaturals` follows from the necessary condition: if `Summable f`, then `Filter.Tendsto f atTop (nhds 0)`. But `|alternatingNaturals n| = n+1 → ∞`, so it cannot tend to 0.",
     "significance": "key",
+    "prerequisites": [
+      "real analysis",
+      "necessary condition for convergence",
+      "alternating series",
+      "Mathlib Summable API"
+    ],
     "relatedConcepts": [
       "divergence",
       "partial sums"
@@ -147,8 +195,13 @@
     "type": "theorem",
     "title": "Shifting Requires Convergence Proof",
     "content": "Mathlib's lemmas for manipulating series (like `tsum_eq_zero_add`) all require a `Summable` hypothesis. This is the **type-level gatekeeper** that prevents invalid reasoning.",
-    "mathContext": "Notice `hf : Summable f` in the theorem statement. Without this proof, Lean won't let you use the lemma.",
+    "mathContext": "The relevant Mathlib lemma: `theorem tsum_eq_zero_add {f : ℕ → α} (hf : Summable f) : ∑' n, f n = f 0 + ∑' n, f (n + 1)`. Without `hf`, both sides equal 0 by `tsum_eq_zero_of_not_summable`, making the equation trivially `0 = 0 + 0`. The `Summable` term is a **proof witness** — it cannot be faked; you must construct it from first principles.",
     "significance": "key",
+    "prerequisites": [
+      "Lean 4 dependent types",
+      "Mathlib tsum API",
+      "typeclass constraints"
+    ],
     "relatedConcepts": [
       "typeclass constraints",
       "proof obligations"
@@ -164,7 +217,13 @@
     "type": "theorem",
     "title": "FALLACY: Shift-Add Blocked by Type System",
     "content": "When we try to apply the shift-and-add manipulation to our divergent series, **Lean blocks us**. We would need `Summable alternatingNaturals`, but we proved this is false!",
+    "mathContext": "The attempted proof calls `tsum_eq_zero_add h` where `h : Summable alternatingNaturals`. But `alternatingNaturals_not_summable : ¬ Summable alternatingNaturals` makes it impossible to construct such `h` without `sorry`. Lean's elaborator rejects the proof: there is no term of type `Summable alternatingNaturals` to supply. The `sorry` here is a permanent red flag — it marks the exact location where the informal argument breaks the formal rules.",
     "significance": "key",
+    "prerequisites": [
+      "Lean 4 type checking",
+      "Mathlib tsum API",
+      "proof by contradiction"
+    ],
     "relatedConcepts": [
       "type checking",
       "blocked proof"
@@ -180,8 +239,13 @@
     "type": "lemma",
     "title": "Partial Sums Grow Without Bound",
     "content": "The sum $1+2+\\cdots+n = \\frac{n(n+1)}{2}$, which grows without bound as $n \\to \\infty$. This is the formal statement that the series diverges.",
-    "mathContext": "For any $M$, we can find $N$ large enough that the partial sum exceeds $M$. This is the definition of divergence to infinity.",
+    "mathContext": "The triangular number formula $T_n = \\frac{n(n+1)}{2}$ gives `∑ k in Finset.range n, (k+1) = n*(n+1)/2`. For any bound $M$, choosing $n > 2M$ gives $T_n > M$. Formally: `∀ M : ℝ, ∃ N : ℕ, ∀ n ≥ N, M < ∑ k in Finset.range n, naturals k`. This implies `¬ Summable naturals` since summable sequences must have terms tending to 0, but `naturals n = n+1 → ∞`.",
     "significance": "key",
+    "prerequisites": [
+      "real analysis",
+      "triangular numbers",
+      "Gauss summation formula"
+    ],
     "relatedConcepts": [
       "divergence to infinity",
       "triangle numbers"
@@ -197,8 +261,13 @@
     "type": "theorem",
     "title": "MAIN RESULT: The Sum Does NOT Equal -1/12",
     "content": "Here's the key theorem: $\\sum_{n=1}^{\\infty} n \\neq -\\frac{1}{12}$. The proof is almost trivial once we know the series doesn't converge:\n1. `naturals` is not summable\n2. Therefore `tsum naturals = 0` (by Mathlib convention)\n3. $0 \\neq -\\frac{1}{12}$ (by `norm_num`)",
-    "mathContext": "This is what Lean can actually PROVE, as opposed to the fallacious claim. The type system has protected us from error.",
+    "mathContext": "Proof sketch: `have h0 : tsum naturals = 0 := tsum_eq_zero_of_not_summable naturals_not_summable; have h1 : (0 : ℝ) ≠ -1/12 := by norm_num; rw [h0]; exact h1`. The three-step argument reflects the mathematical reality: **standard summation assigns no value to this series** — not $-1/12$, not $+\\infty$, just the junk value 0.",
     "significance": "key",
+    "prerequisites": [
+      "real analysis",
+      "Mathlib tsum API",
+      "Lean 4 norm_num"
+    ],
     "relatedConcepts": [
       "tsum_eq_zero_of_not_summable",
       "norm_num"
@@ -214,8 +283,14 @@
     "type": "concept",
     "title": "What -1/12 Actually Means",
     "content": "The value $-\\frac{1}{12}$ is real - it comes from the **Riemann zeta function** $\\zeta(s) = \\sum n^{-s}$ analytically continued to $s = -1$. But this is a DIFFERENT mathematical operation than ordinary summation.",
-    "mathContext": "In Lean, we would model zeta regularization with a completely different function type. The type system enforces the distinction automatically - you can't confuse `tsum` with `zeta_regularized`.",
+    "mathContext": "The Riemann zeta function $\\zeta(s) = \\sum_{n=1}^{\\infty} n^{-s}$ converges for $\\text{Re}(s) > 1$ and extends uniquely to a meromorphic function on $\\mathbb{C} \\setminus \\{1\\}$. At $s = -1$: $\\zeta(-1) = -\\frac{1}{12}$. In Lean, this would be a *different function type*: `riemannZeta : ℂ → ℂ` vs `tsum : (ℕ → ℝ) → ℝ`. The Lean type system makes the distinction **syntactically enforced** — you cannot accidentally confuse ordinary summation with zeta regularization.",
     "significance": "key",
+    "prerequisites": [
+      "complex analysis",
+      "Riemann zeta function",
+      "analytic continuation",
+      "meromorphic functions"
+    ],
     "relatedConcepts": [
       "Riemann zeta function",
       "analytic continuation",
@@ -232,7 +307,13 @@
     "type": "theorem",
     "title": "Step 2 Fails: Cannot Shift Divergent Series",
     "content": "The second step uses the shift-and-add manipulation. **BLOCKED**: This requires `Summable` which we cannot prove for divergent series.",
+    "mathContext": "Step 2 of the Numberphile argument claims $2S_2 = \\frac{1}{4}$ by shifting and adding. In Lean: `tsum alternatingNaturals + tsum (fun n => alternatingNaturals (n+1)) = 1/4`. By `tsum_eq_zero_of_not_summable`, both `tsum`s equal 0, giving `0 + 0 = 0 ≠ 1/4`. The shift lemma `tsum_eq_zero_add` is unavailable since `¬ Summable alternatingNaturals`. Step 2 thus fails in two independent ways: the computed value is wrong, and the manipulation is illegal.",
     "significance": "key",
+    "prerequisites": [
+      "alternating series",
+      "Mathlib tsum API",
+      "Lean 4 type checking"
+    ],
     "relatedConcepts": [
       "second fallacy",
       "manipulation blocked"
@@ -248,8 +329,13 @@
     "type": "theorem",
     "title": "Step 3 'Works' But Is Useless",
     "content": "Interestingly, the equation $S - S_2 = 4S$ **does typecheck** - but it's trivially true because both sides equal 0! This shows how Mathlib's convention prevents false conclusions: we can prove $0 - 0 = 4 \\cdot 0$, but this tells us nothing about $-\\frac{1}{12}$.",
-    "mathContext": "The `sorry`-free proof here uses `tsum_eq_zero_of_not_summable` twice, reducing everything to $0 = 0$.",
+    "mathContext": "The algebraic step $S - S_2 = 4S$ typechecks as: `tsum naturals - tsum alternatingNaturals = 4 * tsum naturals`. Since both `tsum` values are 0 by `tsum_eq_zero_of_not_summable`, this becomes `0 - 0 = 4 * 0`, i.e., `0 = 0` — provable by `ring`. The Numberphile argument uses this *form* to conclude $S = -\\frac{1}{12}$, but Lean sees only `0 = 0`: no information about the actual series value is transmitted.",
     "significance": "key",
+    "prerequisites": [
+      "Mathlib tsum API",
+      "Lean 4 ring tactic",
+      "algebraic manipulation"
+    ],
     "relatedConcepts": [
       "vacuous truth",
       "zero convention"
@@ -265,7 +351,14 @@
     "type": "concept",
     "title": "Conclusion: Type Systems Enforce Rigor",
     "content": "Lean's type system and Mathlib's design choices enforce mathematical rigor automatically:\n\n1. **Summable typeclass**: Acts as proof obligation before series manipulation\n2. **tsum = 0 convention**: Prevents arithmetic on divergent 'values'\n3. **Distinct types**: Regularization would be a different function entirely\n\nThe -1/12 result is useful in physics, but it requires different mathematical machinery that Lean would model with appropriate types.",
+    "mathContext": "The `Summable` typeclass is a **proof-carrying data** pattern: before calling `tsum_add (h1 : Summable f) (h2 : Summable g)`, you must supply witnesses `h1` and `h2` — real mathematical proofs that cannot be fabricated. Lean's kernel verifies proof correctness definitionally, making it impossible to accidentally apply series lemmas to divergent series. This is the fundamental difference between informal mathematics (where errors propagate undetected) and formal verification (where each step is machine-checked).",
     "significance": "key",
+    "prerequisites": [
+      "Lean 4 type system",
+      "Mathlib Summable typeclass",
+      "formal verification",
+      "proof-carrying data"
+    ],
     "relatedConcepts": [
       "formal verification",
       "type safety",

--- a/src/data/proofs/ramanujan-sum-fallacy/annotations.source.json
+++ b/src/data/proofs/ramanujan-sum-fallacy/annotations.source.json
@@ -8,8 +8,14 @@
     "type": "concept",
     "title": "The Famous Fallacy",
     "content": "The claim $1+2+3+4+\\cdots = -\\frac{1}{12}$ went viral through a Numberphile video. While the value $-\\frac{1}{12}$ does appear in the Riemann zeta function ($\\zeta(-1) = -\\frac{1}{12}$), the 'elementary proof' using series manipulation is mathematically invalid.",
-    "mathContext": "In standard analysis, this series diverges to infinity. The -1/12 comes from **analytic continuation**, not from adding up the terms.",
+    "mathContext": "In standard analysis, $\\sum_{n=1}^{\\infty} n$ diverges to $+\\infty$. The value $-\\frac{1}{12}$ arises from **analytic continuation**: $\\zeta(s) = \\sum_{n=1}^{\\infty} n^{-s}$ converges for $\\text{Re}(s) > 1$, and the unique meromorphic extension to $\\mathbb{C}$ gives $\\zeta(-1) = -\\frac{1}{12}$. This is a *different mathematical operation* from ordinary summation.",
     "significance": "key",
+    "prerequisites": [
+      "infinite series",
+      "divergent series",
+      "Riemann zeta function",
+      "analytic continuation"
+    ],
     "relatedConcepts": [
       "divergent series",
       "zeta function",
@@ -26,8 +32,14 @@
     "type": "definition",
     "title": "How Mathlib Handles Infinite Sums",
     "content": "Mathlib's `tsum` (topological sum) function is the standard way to express infinite sums in Lean. Crucially, `tsum f` only equals the expected limit if the sum **converges**. For divergent series, `tsum` returns **0** by convention.",
-    "mathContext": "This design choice prevents false conclusions: you can't do arithmetic with 'infinite' values because they're just represented as 0. All the useful lemmas about series require a `Summable` proof.",
+    "mathContext": "Formally: `tsum f = if h : Summable f then (h.choose : α) else 0`. This junk-value convention means all lemmas that do useful things — `tsum_add`, `tsum_eq_zero_add`, `tsum_geometric_two` — carry a `Summable f` hypothesis. Without it, `tsum f = 0` and you can only prove $0 = 0$.",
     "significance": "key",
+    "prerequisites": [
+      "real analysis",
+      "infinite series",
+      "Lean 4 type system",
+      "Mathlib tsum API"
+    ],
     "relatedConcepts": [
       "tsum",
       "Summable",
@@ -44,7 +56,13 @@
     "type": "definition",
     "title": "Defining the Natural Number Series",
     "content": "We define `naturals n = n + 1` to get the sequence $1, 2, 3, 4, \\ldots$ (offset by 1 because $\\mathbb{N}$ starts at 0 in Lean).",
+    "mathContext": "The function `naturals : ℕ → ℝ` defined by `naturals n = ↑(n + 1)` gives the series $\\sum_{n=0}^{\\infty} (n+1) = 1 + 2 + 3 + \\cdots$. The cast `↑` coerces `ℕ` to `ℝ`. This offset-by-one indexing is standard in Lean/Mathlib: `Finset.range n = {0, 1, ..., n-1}`, so `∑ k in Finset.range n, naturals k = \\frac{n(n+1)}{2}`.",
     "significance": "supporting",
+    "prerequisites": [
+      "natural numbers",
+      "Lean 4 type coercions",
+      "Mathlib tsum API"
+    ],
     "relatedConcepts": [
       "natural numbers",
       "sequences"
@@ -60,8 +78,14 @@
     "type": "theorem",
     "title": "The False Claim Would Require Convergence",
     "content": "This theorem shows that IF we could prove $\\sum n = -\\frac{1}{12}$, THEN the series would need to be `Summable`. But the series diverges, so this implication is vacuously true - we can never satisfy the hypothesis.",
-    "mathContext": "The `sorry` here is permanent - this line of reasoning is blocked. Lean forces us to acknowledge that the hypothesis is impossible.",
+    "mathContext": "The argument uses the contrapositive of `tsum_eq_zero_of_not_summable`: if `¬ Summable f`, then `tsum f = 0`. So `tsum naturals = -1/12` would force `tsum naturals ≠ 0`, hence `Summable naturals` — but we prove `¬ Summable naturals` by showing partial sums are unbounded. The `sorry` marks the exact point where the informal argument breaks the formal rules.",
     "significance": "key",
+    "prerequisites": [
+      "real analysis",
+      "divergent series",
+      "Lean 4 type system",
+      "Mathlib tsum API"
+    ],
     "relatedConcepts": [
       "vacuous truth",
       "impossible hypothesis"
@@ -77,8 +101,14 @@
     "type": "definition",
     "title": "The Grandi Series",
     "content": "The **Grandi series** $1-1+1-1+\\cdots$ has partial sums that alternate forever between 0 and 1. It does not converge in any standard sense.",
-    "mathContext": "The Numberphile video claims this equals $\\frac{1}{2}$ by averaging 0 and 1. This is actually the **Cesaro mean**, not the limit. They're different mathematical concepts!",
+    "mathContext": "Defined as `grandi n = (-1)^n`. The partial sums are $S_n = \\frac{1-(-1)^{n+1}}{2}$, oscillating between 0 and 1. The **Cesàro mean** is $\\lim_{N\\to\\infty}\\frac{1}{N}\\sum_{n=0}^{N-1} S_n = \\frac{1}{2}$, which the Numberphile video conflates with the series limit. In Mathlib: `¬ Summable grandi` because the partial sums do not converge.",
     "significance": "key",
+    "prerequisites": [
+      "real analysis",
+      "partial sums",
+      "Cesaro summability",
+      "infinite series"
+    ],
     "relatedConcepts": [
       "partial sums",
       "Cesaro mean",
@@ -96,8 +126,13 @@
     "type": "theorem",
     "title": "FALLACY: Cannot Prove Grandi = 1/2",
     "content": "Here we attempt to prove the Numberphile claim that $1-1+1-1+\\cdots = \\frac{1}{2}$. **This is impossible** - the `sorry` can never be filled in. Since the series isn't summable, `tsum grandi = 0` by definition, and $0 \\neq \\frac{1}{2}$.",
-    "mathContext": "The red X (❌) in the comments indicates Lean rejects this. This is the first fallacy in the Numberphile argument.",
+    "mathContext": "Formally: `tsum_eq_zero_of_not_summable : ¬ Summable f → tsum f = 0`. Since `¬ Summable grandi`, we get `tsum grandi = 0`. The goal `tsum grandi = 1/2` reduces to `(0 : ℝ) = 1/2`, which `norm_num` immediately refutes. Any `sorry`-free proof here would yield `False`.",
     "significance": "key",
+    "prerequisites": [
+      "Grandi series",
+      "Mathlib tsum API",
+      "Lean 4 norm_num"
+    ],
     "relatedConcepts": [
       "tsum convention",
       "proof failure"
@@ -113,8 +148,14 @@
     "type": "concept",
     "title": "The Shift-and-Add Trick",
     "content": "The Numberphile proof adds $S_2$ to a shifted copy of itself:\n$$2S_2 = (1-2+3-4+\\cdots) + (0+1-2+3+\\cdots)$$\nThis term-by-term addition is ONLY valid for convergent series!",
-    "mathContext": "The **Riemann series theorem** proves that rearranging a conditionally convergent series can give any real number as a 'sum'. For divergent series, such manipulations are completely meaningless.",
+    "mathContext": "The **Riemann series theorem** (Riemann, 1853) states that any conditionally convergent series can be rearranged to converge to any value in $\\mathbb{R} \\cup \\{\\pm\\infty\\}$. For *divergent* series, term-by-term operations are completely undefined. The shift operation in Mathlib is `tsum_eq_zero_add : Summable f → tsum f = f 0 + tsum (f ∘ Nat.succ)`, which requires a summability witness.",
     "significance": "key",
+    "prerequisites": [
+      "infinite series",
+      "Riemann rearrangement theorem",
+      "conditional convergence",
+      "absolute convergence"
+    ],
     "relatedConcepts": [
       "Riemann series theorem",
       "rearrangement",
@@ -132,7 +173,14 @@
     "type": "lemma",
     "title": "Alternating Naturals Don't Converge Either",
     "content": "The series $1-2+3-4+5-6+\\cdots$ also diverges. Its partial sums grow without bound in absolute value: $1, -1, 2, -2, 3, -3, \\ldots$",
+    "mathContext": "Define `alternatingNaturals n = (-1)^n * (n + 1)`. The partial sums satisfy $|S_{2k}| = k+1$ and $|S_{2k+1}| = k+1$ — both grow without bound. `¬ Summable alternatingNaturals` follows from the necessary condition: if `Summable f`, then `Filter.Tendsto f atTop (nhds 0)`. But `|alternatingNaturals n| = n+1 → ∞`, so it cannot tend to 0.",
     "significance": "key",
+    "prerequisites": [
+      "real analysis",
+      "necessary condition for convergence",
+      "alternating series",
+      "Mathlib Summable API"
+    ],
     "relatedConcepts": [
       "divergence",
       "partial sums"
@@ -149,8 +197,13 @@
     "type": "theorem",
     "title": "Shifting Requires Convergence Proof",
     "content": "Mathlib's lemmas for manipulating series (like `tsum_eq_zero_add`) all require a `Summable` hypothesis. This is the **type-level gatekeeper** that prevents invalid reasoning.",
-    "mathContext": "Notice `hf : Summable f` in the theorem statement. Without this proof, Lean won't let you use the lemma.",
+    "mathContext": "The relevant Mathlib lemma: `theorem tsum_eq_zero_add {f : ℕ → α} (hf : Summable f) : ∑' n, f n = f 0 + ∑' n, f (n + 1)`. Without `hf`, both sides equal 0 by `tsum_eq_zero_of_not_summable`, making the equation trivially `0 = 0 + 0`. The `Summable` term is a **proof witness** — it cannot be faked; you must construct it from first principles.",
     "significance": "key",
+    "prerequisites": [
+      "Lean 4 dependent types",
+      "Mathlib tsum API",
+      "typeclass constraints"
+    ],
     "relatedConcepts": [
       "typeclass constraints",
       "proof obligations"
@@ -166,7 +219,13 @@
     "type": "theorem",
     "title": "FALLACY: Shift-Add Blocked by Type System",
     "content": "When we try to apply the shift-and-add manipulation to our divergent series, **Lean blocks us**. We would need `Summable alternatingNaturals`, but we proved this is false!",
+    "mathContext": "The attempted proof calls `tsum_eq_zero_add h` where `h : Summable alternatingNaturals`. But `alternatingNaturals_not_summable : ¬ Summable alternatingNaturals` makes it impossible to construct such `h` without `sorry`. Lean's elaborator rejects the proof: there is no term of type `Summable alternatingNaturals` to supply. The `sorry` here is a permanent red flag — it marks the exact location where the informal argument breaks the formal rules.",
     "significance": "key",
+    "prerequisites": [
+      "Lean 4 type checking",
+      "Mathlib tsum API",
+      "proof by contradiction"
+    ],
     "relatedConcepts": [
       "type checking",
       "blocked proof"
@@ -183,8 +242,13 @@
     "type": "lemma",
     "title": "Partial Sums Grow Without Bound",
     "content": "The sum $1+2+\\cdots+n = \\frac{n(n+1)}{2}$, which grows without bound as $n \\to \\infty$. This is the formal statement that the series diverges.",
-    "mathContext": "For any $M$, we can find $N$ large enough that the partial sum exceeds $M$. This is the definition of divergence to infinity.",
+    "mathContext": "The triangular number formula $T_n = \\frac{n(n+1)}{2}$ gives `∑ k in Finset.range n, (k+1) = n*(n+1)/2`. For any bound $M$, choosing $n > 2M$ gives $T_n > M$. Formally: `∀ M : ℝ, ∃ N : ℕ, ∀ n ≥ N, M < ∑ k in Finset.range n, naturals k`. This implies `¬ Summable naturals` since summable sequences must have terms tending to 0, but `naturals n = n+1 → ∞`.",
     "significance": "key",
+    "prerequisites": [
+      "real analysis",
+      "triangular numbers",
+      "Gauss summation formula"
+    ],
     "relatedConcepts": [
       "divergence to infinity",
       "triangle numbers"
@@ -201,8 +265,13 @@
     "type": "theorem",
     "title": "MAIN RESULT: The Sum Does NOT Equal -1/12",
     "content": "Here's the key theorem: $\\sum_{n=1}^{\\infty} n \\neq -\\frac{1}{12}$. The proof is almost trivial once we know the series doesn't converge:\n1. `naturals` is not summable\n2. Therefore `tsum naturals = 0` (by Mathlib convention)\n3. $0 \\neq -\\frac{1}{12}$ (by `norm_num`)",
-    "mathContext": "This is what Lean can actually PROVE, as opposed to the fallacious claim. The type system has protected us from error.",
+    "mathContext": "Proof sketch: `have h0 : tsum naturals = 0 := tsum_eq_zero_of_not_summable naturals_not_summable; have h1 : (0 : ℝ) ≠ -1/12 := by norm_num; rw [h0]; exact h1`. The three-step argument reflects the mathematical reality: **standard summation assigns no value to this series** — not $-1/12$, not $+\\infty$, just the junk value 0.",
     "significance": "key",
+    "prerequisites": [
+      "real analysis",
+      "Mathlib tsum API",
+      "Lean 4 norm_num"
+    ],
     "relatedConcepts": [
       "tsum_eq_zero_of_not_summable",
       "norm_num"
@@ -219,8 +288,14 @@
     "type": "concept",
     "title": "What -1/12 Actually Means",
     "content": "The value $-\\frac{1}{12}$ is real - it comes from the **Riemann zeta function** $\\zeta(s) = \\sum n^{-s}$ analytically continued to $s = -1$. But this is a DIFFERENT mathematical operation than ordinary summation.",
-    "mathContext": "In Lean, we would model zeta regularization with a completely different function type. The type system enforces the distinction automatically - you can't confuse `tsum` with `zeta_regularized`.",
+    "mathContext": "The Riemann zeta function $\\zeta(s) = \\sum_{n=1}^{\\infty} n^{-s}$ converges for $\\text{Re}(s) > 1$ and extends uniquely to a meromorphic function on $\\mathbb{C} \\setminus \\{1\\}$. At $s = -1$: $\\zeta(-1) = -\\frac{1}{12}$. In Lean, this would be a *different function type*: `riemannZeta : ℂ → ℂ` vs `tsum : (ℕ → ℝ) → ℝ`. The Lean type system makes the distinction **syntactically enforced** — you cannot accidentally confuse ordinary summation with zeta regularization.",
     "significance": "key",
+    "prerequisites": [
+      "complex analysis",
+      "Riemann zeta function",
+      "analytic continuation",
+      "meromorphic functions"
+    ],
     "relatedConcepts": [
       "Riemann zeta function",
       "analytic continuation",
@@ -237,7 +312,13 @@
     "type": "theorem",
     "title": "Step 2 Fails: Cannot Shift Divergent Series",
     "content": "The second step uses the shift-and-add manipulation. **BLOCKED**: This requires `Summable` which we cannot prove for divergent series.",
+    "mathContext": "Step 2 of the Numberphile argument claims $2S_2 = \\frac{1}{4}$ by shifting and adding. In Lean: `tsum alternatingNaturals + tsum (fun n => alternatingNaturals (n+1)) = 1/4`. By `tsum_eq_zero_of_not_summable`, both `tsum`s equal 0, giving `0 + 0 = 0 ≠ 1/4`. The shift lemma `tsum_eq_zero_add` is unavailable since `¬ Summable alternatingNaturals`. Step 2 thus fails in two independent ways: the computed value is wrong, and the manipulation is illegal.",
     "significance": "key",
+    "prerequisites": [
+      "alternating series",
+      "Mathlib tsum API",
+      "Lean 4 type checking"
+    ],
     "relatedConcepts": [
       "second fallacy",
       "manipulation blocked"
@@ -254,8 +335,13 @@
     "type": "theorem",
     "title": "Step 3 'Works' But Is Useless",
     "content": "Interestingly, the equation $S - S_2 = 4S$ **does typecheck** - but it's trivially true because both sides equal 0! This shows how Mathlib's convention prevents false conclusions: we can prove $0 - 0 = 4 \\cdot 0$, but this tells us nothing about $-\\frac{1}{12}$.",
-    "mathContext": "The `sorry`-free proof here uses `tsum_eq_zero_of_not_summable` twice, reducing everything to $0 = 0$.",
+    "mathContext": "The algebraic step $S - S_2 = 4S$ typechecks as: `tsum naturals - tsum alternatingNaturals = 4 * tsum naturals`. Since both `tsum` values are 0 by `tsum_eq_zero_of_not_summable`, this becomes `0 - 0 = 4 * 0`, i.e., `0 = 0` — provable by `ring`. The Numberphile argument uses this *form* to conclude $S = -\\frac{1}{12}$, but Lean sees only `0 = 0`: no information about the actual series value is transmitted.",
     "significance": "key",
+    "prerequisites": [
+      "Mathlib tsum API",
+      "Lean 4 ring tactic",
+      "algebraic manipulation"
+    ],
     "relatedConcepts": [
       "vacuous truth",
       "zero convention"
@@ -272,7 +358,14 @@
     "type": "concept",
     "title": "Conclusion: Type Systems Enforce Rigor",
     "content": "Lean's type system and Mathlib's design choices enforce mathematical rigor automatically:\n\n1. **Summable typeclass**: Acts as proof obligation before series manipulation\n2. **tsum = 0 convention**: Prevents arithmetic on divergent 'values'\n3. **Distinct types**: Regularization would be a different function entirely\n\nThe -1/12 result is useful in physics, but it requires different mathematical machinery that Lean would model with appropriate types.",
+    "mathContext": "The `Summable` typeclass is a **proof-carrying data** pattern: before calling `tsum_add (h1 : Summable f) (h2 : Summable g)`, you must supply witnesses `h1` and `h2` — real mathematical proofs that cannot be fabricated. Lean's kernel verifies proof correctness definitionally, making it impossible to accidentally apply series lemmas to divergent series. This is the fundamental difference between informal mathematics (where errors propagate undetected) and formal verification (where each step is machine-checked).",
     "significance": "key",
+    "prerequisites": [
+      "Lean 4 type system",
+      "Mathlib Summable typeclass",
+      "formal verification",
+      "proof-carrying data"
+    ],
     "relatedConcepts": [
       "formal verification",
       "type safety",

--- a/src/data/proofs/tractatus-ontology/annotations.json
+++ b/src/data/proofs/tractatus-ontology/annotations.json
@@ -8,6 +8,12 @@
     "content": "The Tractatus Logico-Philosophicus opens: 'The world is everything that is the case.' What follows is an attempt to express the formal skeleton of that vision in Lean 4 — the ontology of objects, states of affairs, facts, and truth-functional propositions. We formalize the part that *can* be formalized, and annotate where the philosophy exceeds the formalism.",
     "mathContext": "The Tractatus contains a nearly axiomatic ontology buried in its numbered propositions (1, 1.1, 2.01, 2.02, etc.). We extract and formalize the structural core: types for objects and states of affairs, a model-theoretic notion of world, an inductive grammar for propositions, and a recursive evaluation function. The result is a miniature model theory built from scratch.",
     "significance": "key",
+    "prerequisites": [
+      "propositional logic",
+      "model theory",
+      "Lean 4 inductive types",
+      "Wittgenstein's Tractatus"
+    ],
     "relatedConcepts": ["logical atomism", "model theory", "formal ontology", "Tractatus Logico-Philosophicus"]
   },
   {
@@ -17,7 +23,13 @@
     "type": "concept",
     "title": "Mathlib Import",
     "content": "We import `Mathlib.Tactic` for proof automation (`simp`, `tauto`, etc.) and access to classical logic lemmas like `not_not` and `not_and_or`. The formalization is otherwise self-contained — no Mathlib theorems appear in the definitions, only in the proofs.",
+    "mathContext": "The key Mathlib contributions: `Classical.em : ∀ P : Prop, P ∨ ¬P` (law of excluded middle, an axiom of classical logic), `not_not : ¬¬P ↔ P` (double negation elimination), and `not_and_or : ¬(P ∧ Q) ↔ ¬P ∨ ¬Q` (De Morgan). Tactics `simp`, `tauto`, and `ring` are decision procedures for propositional reasoning and ring equations.",
     "significance": "supporting",
+    "prerequisites": [
+      "Lean 4 import system",
+      "Mathlib",
+      "classical logic"
+    ],
     "relatedConcepts": ["Mathlib", "tactic mode", "classical logic"]
   },
   {
@@ -29,6 +41,12 @@
     "content": "TLP 2.02: 'The object is simple.' We model Tractarian objects as a `variable` type parameter — Lean knows nothing about its inhabitants except that the type exists. This captures Wittgenstein's insistence that objects have no analyzable internal structure.\n\n**[Interpretive choice]** Using a bare type parameter captures *simplicity* (no structure) but not the Tractarian claim that an object's *form* determines which states of affairs it can enter (TLP 2.0141). A dependent-type encoding — where each object carries a type constraining its combinatorial possibilities — would better capture 2.0141 but at the cost of specifying structure Wittgenstein deliberately leaves open. We opt for the lighter encoding.",
     "mathContext": "In Lean, `variable (TractObject : Type)` introduces a universe-polymorphic type parameter. Any theorem or definition mentioning `TractObject` is implicitly universally quantified over all types — so our results hold regardless of what objects 'are.'",
     "significance": "key",
+    "prerequisites": [
+      "Lean 4 type parameters",
+      "universe polymorphism",
+      "TLP 2.02",
+      "logical atomism"
+    ],
     "relatedConcepts": ["TLP 2.02", "TLP 2.0141", "simple objects", "logical atomism", "dependent types"]
   },
   {
@@ -40,6 +58,12 @@
     "content": "TLP 2.01: 'An atomic fact is a combination of objects.' A state of affairs (*Sachverhalt*) is a possible way objects might combine. We model this as an abstract type parameter, just like objects.\n\n**[Interpretive choice]** We do *not* encode states of affairs as sets of objects or as predicates over objects. The Tractatus arguably intends something more structural — the *way* objects hang together, not merely *which* objects are involved (the 'form' of TLP 2.032). By keeping Sachverhalt abstract, we preserve this openness. The cost is that we cannot express *within* the formalization how objects compose into states of affairs.",
     "mathContext": "The choice to keep `Sachverhalt` abstract rather than defining it as `Set TractObject -> Prop` or `List TractObject` is deliberate. An extensional encoding would commit us to saying that states of affairs with the same objects are identical — which conflicts with 'aRb' and 'bRa' being distinct states of affairs involving the same objects.",
     "significance": "key",
+    "prerequisites": [
+      "Lean 4 type parameters",
+      "TLP 2.01",
+      "atomic facts",
+      "extensional vs intensional identity"
+    ],
     "relatedConcepts": ["TLP 2.01", "TLP 2.0141", "atomic facts", "combinatorial form", "structural identity"]
   },
   {
@@ -51,6 +75,12 @@
     "content": "TLP 1: 'The world is everything that is the case.' TLP 2.04: 'The totality of existing atomic facts is the world.' A world is a function `Sachverhalt -> Prop` — for each state of affairs, it says whether that state of affairs obtains.\n\nThis is the standard model-theoretic move: a 'world' or 'model' is a truth-value assignment to atomic propositions. What is distinctive about the Tractarian version is the ontological weight: for Wittgenstein, the world literally *is* the totality of facts, not something that *has* facts as properties.",
     "mathContext": "Defining `World` as `Sachverhalt -> Prop` means a world is a predicate on states of affairs. This is equivalent to a subset of `Sachverhalt` (via the correspondence `Set a = (a -> Prop)`). We use the predicate form because it integrates more naturally with Lean's type theory.",
     "significance": "key",
+    "prerequisites": [
+      "model theory",
+      "TLP 1",
+      "possible worlds semantics",
+      "Lean 4 function types"
+    ],
     "relatedConcepts": ["TLP 1", "TLP 1.1", "TLP 2.04", "possible worlds", "model theory", "Kripke semantics"]
   },
   {
@@ -62,6 +92,12 @@
     "content": "TLP 4.21: 'The simplest proposition, the elementary proposition, asserts the existence of an atomic fact.' TLP 5: 'The proposition is a truth-function of elementary propositions.'\n\nWe define propositions as an inductive type with three constructors: `elementary` (asserts a state of affairs), `neg` (negation), and `conj` (conjunction). Every proposition is a finite tree built from these constructors.\n\nTLP 5.101 tells us that all truth-functions arise from successive applications of negation and conjunction. The other connectives — disjunction, implication, biconditional — are defined, not primitive.",
     "mathContext": "The `inductive` keyword in Lean defines a freely generated type. `Proposition S` is parametric in a type `S` of states of affairs. The three constructors give us a complete basis for propositional logic: $\\{\\neg, \\land\\}$ is functionally complete (any Boolean function can be expressed using only negation and conjunction).",
     "significance": "critical",
+    "prerequisites": [
+      "propositional logic",
+      "Lean 4 inductive types",
+      "TLP 4.21",
+      "functional completeness"
+    ],
     "relatedConcepts": ["TLP 4.21", "TLP 5", "TLP 5.101", "functional completeness", "propositional calculus", "inductive types"]
   },
   {
@@ -73,6 +109,12 @@
     "content": "TLP 5.101: 'The truth-functions of every number of elementary propositions can be written in a schema.' We define:\n\n- **Disjunction** $p \\lor q$ as $\\neg(\\neg p \\land \\neg q)$\n- **Implication** $p \\to q$ as $\\neg(p \\land \\neg q)$\n- **Biconditional** $p \\leftrightarrow q$ as $(p \\to q) \\land (q \\to p)$\n- **NAND** $p \\mid q$ as $\\neg(p \\land q)$\n\nThe NAND gate (TLP 5.5) is historically significant: Wittgenstein recognized — independently of Sheffer (1913) — that a single binary operation suffices for all truth-functions.",
     "mathContext": "These definitions are not just convenient abbreviations. They demonstrate the Tractarian thesis that the expressive power of propositional logic reduces entirely to $\\{\\neg, \\land\\}$, and further to the single Sheffer stroke $\\{\\mid\\}$. The theorems below verify that these definitions produce the expected semantics.",
     "significance": "key",
+    "prerequisites": [
+      "propositional logic",
+      "TLP 5.101",
+      "Sheffer stroke",
+      "Boolean functions"
+    ],
     "relatedConcepts": ["TLP 5.101", "TLP 5.5", "Sheffer stroke", "NAND", "functional completeness", "De Morgan's laws"]
   },
   {
@@ -84,6 +126,12 @@
     "content": "TLP 2.21: 'The picture agrees with reality or not; it is right or wrong, true or false.' TLP 4.06: 'Propositions can be true or false only by being pictures of the reality.'\n\nThe `eval` function is the heart of the formalization. It recursively computes the truth value of a proposition relative to a world:\n- An elementary proposition $e(s)$ is true in world $w$ iff the state of affairs $s$ obtains in $w$\n- $\\neg p$ is true iff $p$ is false\n- $p \\land q$ is true iff both $p$ and $q$ are true\n\nThis is Wittgenstein's picture theory reduced to its formal core: a proposition 'pictures' reality by having the same truth conditions.",
     "mathContext": "The function is defined by structural recursion on the `Proposition` inductive type. Lean automatically verifies that the recursion terminates because each recursive call is on a structurally smaller argument. The return type `Prop` means evaluation lives in Lean's universe of propositions — we are using Lean's logic to model Wittgenstein's.",
     "significance": "critical",
+    "prerequisites": [
+      "Lean 4 structural recursion",
+      "TLP 2.21",
+      "picture theory",
+      "Tarski truth conditions"
+    ],
     "relatedConcepts": ["TLP 2.21", "TLP 4.06", "picture theory", "truth conditions", "Tarski semantics", "structural recursion"]
   },
   {
@@ -95,6 +143,12 @@
     "content": "`evalBool` is a computable counterpart to `eval`. Where `eval` returns a `Prop` (inhabiting Lean's logical universe, opaque to computation), `evalBool` returns a `Bool` (a concrete data type that `#eval` can print). The structure mirrors `eval` exactly: elementary propositions look up the world, negation flips, conjunction uses Boolean AND.\n\nThe bridge theorem `evalBool_correct` proves that the two evaluators agree: `evalBool w = true` if and only if `eval (fun s => w s = true)` holds. The proof is by structural induction on the proposition, matching the pattern of `truth_functional_compositionality`.",
     "mathContext": "The `Bool`/`Prop` distinction is fundamental in Lean 4. `Prop` is the universe of logical propositions — it supports classical reasoning and quantification but is computationally erased. `Bool` is a concrete inductive type with two constructors (`true`, `false`) that persists at runtime. `evalBool` lives in `Bool` and is therefore computable; `evalBool_correct` bridges back to `Prop`-land where the theorems live.",
     "significance": "key",
+    "prerequisites": [
+      "Lean 4 Bool vs Prop",
+      "decidability",
+      "structural recursion",
+      "bridge theorems"
+    ],
     "relatedConcepts": ["decidability", "Bool vs Prop", "structural recursion", "computational semantics"]
   },
   {
@@ -106,6 +160,12 @@
     "content": "TLP 4.46: 'Among the possible groups of truth-conditions there are two extreme cases.' TLP 6.1: 'The propositions of logic are tautologies.'\n\n`IsTautology p` means $p$ evaluates to true in *every* world. `IsContradiction p` means $p$ evaluates to false in *every* world. These are the two extreme cases of TLP 4.46 — a tautology says nothing about which world is actual (it holds in all of them), while a contradiction rules out every possibility.",
     "mathContext": "Both definitions use universal quantification over `World S`. A tautology is $\\forall w, \\text{eval}(p, w)$; a contradiction is $\\forall w, \\neg\\text{eval}(p, w)$. The key philosophical point: for Wittgenstein, tautologies are not 'truths about the world' — they are limit cases that show the structure of logical space without saying anything about it.",
     "significance": "key",
+    "prerequisites": [
+      "propositional logic",
+      "TLP 4.46",
+      "possible worlds",
+      "classical logic"
+    ],
     "relatedConcepts": ["TLP 4.46", "TLP 6.1", "tautology", "contradiction", "logical truth", "modal logic"]
   },
   {
@@ -117,6 +177,13 @@
     "content": "The original `World S = S -> Prop` treats every truth-value assignment as a possible world. This is the 'free model' -- the full Boolean cube. The `WorldModel` structure generalizes this by packaging an arbitrary type of worlds, a `holds` relation, and a nonemptiness witness.\n\nThe free model is recovered as `freeModel S`, and the compatibility lemma `evalM_free_eq_eval` proves that evaluating via the general `evalM` over `freeModel` gives the same result as the original `Proposition.eval`. All existing theorems remain untouched.\n\nThe philosophical motivation: the Tractatus assumes that states of affairs are logically independent (TLP 2.061). This is baked into the free model. But in many applications -- physics, epistemic logic, constrained databases -- structural constraints rule out certain assignments. The `WorldModel` abstraction makes the independence assumption explicit and optional, enabling constrained models where some assignments are forbidden.\n\nThe generalized compositionality theorem `truth_functional_compositionality_gen` shows that truth-functionality holds in any world model, not just the free model. This is a model-independent structural property of propositional logic.",
     "mathContext": "The `WorldModel` structure has three fields: `W : Type` (the type of worlds), `holds : W -> S -> Prop` (which states of affairs obtain in each world), and `nonempty : Nonempty W` (at least one world exists). The `evalM` function evaluates propositions relative to a world model, and `IsTautologyM`/`IsContradictionM` quantify over the model's worlds rather than over all functions `S -> Prop`.",
     "significance": "critical",
+    "prerequisites": [
+      "model theory",
+      "Lean 4 structures",
+      "TLP 2.061",
+      "Boolean cube",
+      "constrained models"
+    ],
     "relatedConcepts": ["model theory", "possible worlds", "Boolean cube", "constrained models", "TLP 2.061", "independence", "truth-functionality"]
   },
   {
@@ -126,7 +193,14 @@
     "type": "theorem",
     "title": "[Main Result] Compositionality is Model-Independent",
     "content": "truth_functional_compositionality_gen proves that compositionality -- the property that two worlds agreeing on all elementary states of affairs agree on every compound proposition -- holds in any world model, not just the free model. This is a purely structural consequence of the inductive definition of Proposition: it requires no assumptions about which worlds exist or how they are constrained. The proof is structurally identical to truth_functional_compositionality but operates over an arbitrary WorldModel parameter M.",
+    "mathContext": "Formally: `∀ (M : WorldModel S) (p : Proposition S) (w₁ w₂ : M.W), (∀ s, M.holds w₁ s ↔ M.holds w₂ s) → (evalM M p w₁ ↔ evalM M p w₂)`. The proof proceeds by structural induction on `p`. The base case uses the hypothesis directly; the inductive steps lift the biconditionals through `¬` and `∧` using `Iff.not` and `Iff.and`. No property of the model `M` beyond its definition is used.",
     "significance": "critical",
+    "prerequisites": [
+      "model theory",
+      "Lean 4 structural induction",
+      "WorldModel abstraction",
+      "TLP 5"
+    ],
     "relatedConcepts": ["TLP 5", "WorldModel", "truth-functionality", "compositionality", "model-independence"]
   },
   {
@@ -138,6 +212,11 @@
     "content": "TLP 6.1: 'The propositions of logic are tautologies.' This theorem states that a proposition holds in every world if and only if it is a tautology. The proof is `rfl` — it holds by definition. This is not a deficiency; it reflects that the *definition* of tautology captures exactly what 'proposition of logic' means in the Tractarian framework.",
     "mathContext": "The `rfl` tactic closes the goal because `IsTautology p` is definitionally equal to `forall w : World S, p.eval w`. In Lean's type theory, definitional equality means no proof is needed — the two expressions are *computationally identical*.",
     "significance": "key",
+    "prerequisites": [
+      "Lean 4 definitional equality",
+      "TLP 6.1",
+      "tautology definition"
+    ],
     "relatedConcepts": ["TLP 6.1", "definitional equality", "tautology", "world-invariance"]
   },
   {
@@ -147,7 +226,13 @@
     "type": "theorem",
     "title": "Contradictions Hold Nowhere (TLP 4.46)",
     "content": "If a proposition is a contradiction, it is false in every world. The proof is immediate from the definition — again, this reflects that the formalization has correctly captured the Tractarian concept.",
+    "mathContext": "Formally: `IsContradiction p → ∀ w : World S, ¬ p.eval w`. Since `IsContradiction p` is defined as `∀ w, ¬ p.eval w`, this is again a definitional unfolding. The `intro h w` tactic pattern suffices: `h : IsContradiction p` gives `h w : ¬ p.eval w` immediately. Analogously to the tautology case, the proof witnesses the adequacy of the definition.",
     "significance": "supporting",
+    "prerequisites": [
+      "Lean 4 definitional equality",
+      "TLP 4.46",
+      "contradiction definition"
+    ],
     "relatedConcepts": ["TLP 4.46", "contradiction"]
   },
   {
@@ -159,6 +244,12 @@
     "content": "TLP 4.023: 'The proposition determines reality to this extent, that one only needs to say \"Yes\" or \"No\" to it.' For any state of affairs $s$ and world $w$, either $s$ obtains in $w$ or it does not: $w(s) \\lor \\neg w(s)$.\n\nThe proof invokes `Classical.em` — the law of excluded middle. This is a *classical* axiom in Lean's foundation; it is not provable constructively. Wittgenstein assumes bivalence throughout the Tractatus, so classical logic is the appropriate foundation here.",
     "mathContext": "`Classical.em` provides $P \\lor \\neg P$ for any proposition $P$. In Lean 4, this is available from `import Mathlib.Tactic` (or directly from `Init.Classical`). Constructive type theories reject this axiom, leading to a different notion of truth. The Tractatus is firmly classical.",
     "significance": "key",
+    "prerequisites": [
+      "classical logic",
+      "TLP 4.023",
+      "law of excluded middle",
+      "constructivism"
+    ],
     "relatedConcepts": ["TLP 4.023", "bivalence", "excluded middle", "classical logic", "constructivism"]
   },
   {
@@ -170,6 +261,12 @@
     "content": "TLP 5: 'The proposition is a truth-function of elementary propositions.' This is the central theorem of the formalization. It states: if two worlds agree on every elementary proposition, they agree on every compound proposition.\n\nThe proof proceeds by structural induction on the proposition:\n- **Base case** (`elementary`): direct from the hypothesis that the worlds agree on elementaries\n- **Negation** (`neg`): if $p$ has the same truth value in both worlds, so does $\\neg p$\n- **Conjunction** (`conj`): if $p$ and $q$ each have the same truth values, so does $p \\land q$\n\nThis is the formal content of 'truth-functionality': compound truth values are determined entirely by elementary truth values.",
     "mathContext": "The `induction p with` tactic performs structural induction on the `Proposition` type. The `Iff.not` and `Iff.and` lemmas lift biconditionals through negation and conjunction. The `simp only [Proposition.eval]` step unfolds the recursive definition.",
     "significance": "critical",
+    "prerequisites": [
+      "Lean 4 structural induction",
+      "propositional logic",
+      "TLP 5",
+      "Frege's principle of compositionality"
+    ],
     "relatedConcepts": ["TLP 5", "truth-functionality", "compositionality", "structural induction", "Frege's principle"]
   },
   {
@@ -179,8 +276,14 @@
     "type": "theorem",
     "title": "Logical Independence (TLP 2.061, 2.062)",
     "content": "TLP 2.061: 'Atomic facts are independent of one another.' TLP 2.062: 'From the existence or non-existence of one atomic fact it is impossible to infer the existence or non-existence of another.'\n\nGiven *any* truth-value assignment to states of affairs, there exists a world realizing it. The proof is beautifully trivial: in our encoding, a truth-value assignment `S -> Prop` literally *is* a `World S`. The witness is the assignment itself.\n\n**[Interpretive choice]** This triviality is both a strength and a limitation. It means independence is *built into the encoding* rather than *proved from it*. A richer encoding — where states of affairs had internal structure involving shared objects — would make independence a substantive theorem requiring proof. Our encoding achieves independence 'for free' by design, which is faithful to the Tractatus's treatment of it as foundational rather than derived.",
-    "mathContext": "The proof `IndependentWorlds.realizable assignment` delegates to the `IndependentWorlds` typeclass instance, which constructs the existential witness directly. `Iff.rfl` shows that the world's valuation of each state of affairs is definitionally equal to the assignment's — because they are the same function.",
+    "mathContext": "The proof: `IndependentWorlds.realizable assignment` delegates to the `IndependentWorlds` typeclass instance. The witness is `⟨assignment, fun s => Iff.rfl⟩` — the assignment itself is the world, and the realization condition holds by reflexivity of `↔`. The triviality of this proof reveals that in the free model, independence is a *definitional* rather than *substantive* property.",
     "significance": "critical",
+    "prerequisites": [
+      "TLP 2.061",
+      "model theory",
+      "Lean 4 typeclasses",
+      "Boolean cube"
+    ],
     "relatedConcepts": ["TLP 2.061", "TLP 2.062", "logical independence", "atomic facts", "possible worlds"]
   },
   {
@@ -190,7 +293,14 @@
     "type": "theorem",
     "title": "Double Negation (Classical Logic)",
     "content": "Double negation elimination: $\\neg\\neg p \\leftrightarrow p$ in every world. This uses `not_not` from Mathlib, which depends on `Classical.em`. The Tractatus assumes classical logic; an intuitionist would reject this equivalence, accepting only the left-to-right direction ($p \\to \\neg\\neg p$).",
+    "mathContext": "Formally: `∀ (p : Proposition S) (w : World S), p.eval (Proposition.neg (Proposition.neg p)) w ↔ p.eval w`. The proof unfolds `Proposition.eval` on the double negation, then applies `not_not : ¬¬P ↔ P` (from `Mathlib.Tactic`, which imports `Classical.em`). Constructive alternatives would prove only the weaker `p.eval w → ¬¬ p.eval w`.",
     "significance": "supporting",
+    "prerequisites": [
+      "classical logic",
+      "double negation elimination",
+      "intuitionism",
+      "Mathlib not_not"
+    ],
     "relatedConcepts": ["double negation", "classical logic", "intuitionism"]
   },
   {
@@ -202,6 +312,12 @@
     "content": "De Morgan's laws verify that our definitions of derived connectives produce the expected semantics. The first law: $(p \\lor q)$ — defined as $\\neg(\\neg p \\land \\neg q)$ — evaluates to $p.\\text{eval}(w) \\lor q.\\text{eval}(w)$. The second: $\\neg(p \\land q)$ evaluates to $\\neg p.\\text{eval}(w) \\lor \\neg q.\\text{eval}(w)$.\n\nThese confirm that the $\\{\\neg, \\land\\}$ basis generates the full propositional calculus as Wittgenstein claims in TLP 5.101.",
     "mathContext": "The `simp` tactic with `not_and_or` and `not_not` rewrites the nested negations into the standard disjunctive form. These are classical equivalences — `not_and_or` states $\\neg(P \\land Q) \\leftrightarrow \\neg P \\lor \\neg Q$.",
     "significance": "key",
+    "prerequisites": [
+      "propositional logic",
+      "De Morgan's laws",
+      "TLP 5.101",
+      "functional completeness"
+    ],
     "relatedConcepts": ["TLP 5.101", "De Morgan's laws", "functional completeness", "connective definability"]
   },
   {
@@ -213,6 +329,12 @@
     "content": "$p \\lor \\neg p$ is a tautology — it holds in every world. This is the paradigmatic example of TLP 6.1: a 'proposition of logic' that is true regardless of which states of affairs obtain. For Wittgenstein, this does not say something *about* the world; it shows something about the structure of logical space.",
     "mathContext": "The proof first applies `simp` to reduce the disjunction (defined via double negation) to a standard form, then invokes `Classical.em` to supply the excluded middle instance.",
     "significance": "key",
+    "prerequisites": [
+      "classical logic",
+      "TLP 4.46",
+      "tautology",
+      "logical space"
+    ],
     "relatedConcepts": ["TLP 4.46", "TLP 6.1", "excluded middle", "tautology", "logical truth"]
   },
   {
@@ -222,7 +344,13 @@
     "type": "theorem",
     "title": "p and not-p Is a Contradiction",
     "content": "$p \\land \\neg p$ holds in no world — the paradigmatic contradiction. The proof is immediate: `simp [Proposition.eval]` decomposes the conjunction into $p.\\text{eval}(w)$ and $\\neg p.\\text{eval}(w)$, which are directly contradictory.",
+    "mathContext": "Formally: `IsContradiction (Proposition.conj p (Proposition.neg p))`. After unfolding `Proposition.eval`, the goal becomes `¬(p.eval w ∧ ¬ p.eval w)`, which is `not_and_not_self : ¬(P ∧ ¬P)` — a theorem provable constructively (no classical axiom needed). This is the non-contradiction law, the dual of excluded middle.",
     "significance": "supporting",
+    "prerequisites": [
+      "propositional logic",
+      "law of non-contradiction",
+      "TLP 4.46"
+    ],
     "relatedConcepts": ["TLP 4.46", "contradiction", "non-contradiction"]
   },
   {
@@ -232,7 +360,14 @@
     "type": "theorem",
     "title": "Implication and Biconditional Semantics",
     "content": "These theorems verify that the derived connectives have their standard semantics:\n- $(p \\to q).\\text{eval}(w) \\leftrightarrow (p.\\text{eval}(w) \\to q.\\text{eval}(w))$\n- $(p \\leftrightarrow q).\\text{eval}(w) \\leftrightarrow (p.\\text{eval}(w) \\leftrightarrow q.\\text{eval}(w))$\n\nThe `tauto` tactic handles the classical propositional reasoning after `simp` normalizes the definitions.",
+    "mathContext": "These are **semantic adequacy theorems**: they verify that the syntactic definitions of `→` and `↔` (both encoded via `¬` and `∧`) produce the right semantic behavior. Without them, we could only claim that the definitions typecheck — not that they mean what we intend. The `tauto` tactic is a complete decision procedure for classical propositional logic, so both proofs are fully automated.",
     "significance": "supporting",
+    "prerequisites": [
+      "propositional logic",
+      "material implication",
+      "biconditional",
+      "Lean 4 tauto tactic"
+    ],
     "relatedConcepts": ["material implication", "biconditional", "truth-functional semantics"]
   },
   {
@@ -244,6 +379,12 @@
     "content": "If $p \\to q$ is true in a world and $p$ is true in that world, then $q$ is true in that world. This is a meta-theorem: it is proved in Lean (the metalanguage) *about* propositions in our object language.\n\nThis is precisely the kind of thing Wittgenstein says can be *shown* by the symbolism but not *said* within it (TLP 4.121: 'What can be shown cannot be said'). The formal system shows that modus ponens preserves truth — it does not contain a proposition asserting this fact. Our Lean theorem *says* what the Tractarian framework can only *show*.",
     "mathContext": "The proof rewrites the implication hypothesis using `impl_semantics`, then applies it to the premise. This two-step pattern — semantic reduction, then function application — mirrors the informal reasoning.",
     "significance": "key",
+    "prerequisites": [
+      "propositional logic",
+      "metalanguage vs object language",
+      "TLP 4.121",
+      "modus ponens"
+    ],
     "relatedConcepts": ["TLP 4.121", "modus ponens", "saying vs showing", "metalanguage", "object language"]
   },
   {
@@ -255,6 +396,13 @@
     "content": "TLP 5.5 anticipates the Sheffer stroke: all truth-functions can be derived from a single binary operation. We show:\n- $\\text{nand}(p, p)$ is equivalent to $\\neg p$ (NAND with itself gives negation)\n- $\\neg\\text{nand}(p, q)$ is equivalent to $p \\land q$ (negated NAND gives conjunction)\n\nSince $\\{\\neg, \\land\\}$ is functionally complete, and both are expressible via NAND, NAND alone suffices for all truth-functions. Wittgenstein's insight (shared with Sheffer, 1913) is that the apparent multiplicity of logical connectives conceals a deeper unity.",
     "mathContext": "The first proof uses `tauto` after simplification — the equivalence $\\neg(p \\land p) \\leftrightarrow \\neg p$ follows from the idempotence of conjunction. The second uses `not_not` to eliminate the double negation.",
     "significance": "key",
+    "prerequisites": [
+      "propositional logic",
+      "TLP 5.5",
+      "Sheffer stroke",
+      "functional completeness",
+      "NAND gate"
+    ],
     "relatedConcepts": ["TLP 5.5", "Sheffer stroke", "NAND", "functional completeness", "Henry Sheffer"]
   },
   {
@@ -264,7 +412,14 @@
     "type": "theorem",
     "title": "[Main Result] Independence is a Modeling Choice",
     "content": "constrained_independence_fails proves that IndependentWorlds fails for the constrained model when the two distinguished states of affairs are distinct. The assignment {a -> True, b -> False} has no constrained realizer, because the constraint b-must-obtain-when-a-does prevents such an assignment from being a world. This demonstrates that independence is not a logical law but a property of the chosen world model. The Tractatus builds independence into its ontology (TLP 2.061); our formalization makes this assumption explicit and shows precisely where it breaks.",
+    "mathContext": "Formally: `¬ ∀ assignment : S → Prop, ∃ cw : ConstrainedWorld S a b, ∀ s, cw.val s ↔ assignment s`. The witness assignment is `fun s => s = a` (only `a` obtains). A constrained world requires `w a → w b`, so any world realizing this assignment must have `w b`, i.e., `b = a`. Since `a ≠ b` (hypothesis), no constrained world exists. The proof is by contradiction using `absurd`.",
     "significance": "critical",
+    "prerequisites": [
+      "TLP 2.061",
+      "constrained models",
+      "Lean 4 subtypes",
+      "model theory"
+    ],
     "relatedConcepts": ["TLP 2.061", "constrained worlds", "IndependentWorlds", "independence failure", "modeling choice"]
   },
   {
@@ -276,6 +431,12 @@
     "content": "The `weatherModel` is a concrete constrained model with three states of affairs (rain, clouds, snow) and one structural constraint: rain implies clouds. A world is a subtype `{ w : WeatherFacts -> Prop // w .rain -> w .clouds }` -- only truth-value assignments satisfying the constraint count as possible worlds.\n\nThe key theorem `weather_independence_fails` proves that in this model, there is no world where rain holds but clouds does not. This is a direct failure of elementary independence (Theorem 5): in the free model, the assignment {rain := True, clouds := False, snow := anything} is a valid world, but in the weather model it violates the constraint.\n\nThis demonstrates the philosophical point: independence is a property of the *model*, not of propositional logic itself. The Tractatus builds independence into its ontology (TLP 2.061); our formalization makes this assumption explicit and shows what happens when it is relaxed.",
     "mathContext": "The proof of `weather_independence_fails` is a clean contradiction: given a hypothetical world `w` with `w.val .rain` and `not w.val .clouds`, we apply `w.property` (the constraint `w.val .rain -> w.val .clouds`) to the first hypothesis, obtaining `w.val .clouds`, which contradicts the second hypothesis.",
     "significance": "key",
+    "prerequisites": [
+      "TLP 2.061",
+      "Lean 4 subtypes",
+      "constrained models",
+      "logical independence"
+    ],
     "relatedConcepts": ["TLP 2.061", "independence failure", "constrained models", "subtype", "physical constraints", "model theory"]
   },
   {
@@ -287,6 +448,12 @@
     "content": "The Tractarian machinery above is parametric in an abstract type `S` of states of affairs. Here we instantiate `S` with a concrete two-element type (`TwoFacts`: rain and snow) to make the formalization interactive.\n\nTwo kinds of evaluation are demonstrated:\n- **Prop-valued** (`eval`): the `example` proofs confirm that `itRains` holds in `rainyWorld` and `itSnows` does not. These are type-checked but not executable.\n- **Bool-valued** (`evalBool`): the `#eval` calls compute truth values at elaboration time, printing `true` or `false` in the Lean infoview. This makes the formalization tangible — readers can modify the world and see results immediately.\n\nThe `TwoFacts` type derives `DecidableEq`, `Repr`, and `Fintype`, making it suitable for both decidable evaluation and (in principle) exhaustive truth-table enumeration.",
     "mathContext": "The `Fintype` instance certifies that `TwoFacts` has finitely many inhabitants. Combined with `DecidableEq`, this would allow enumerating all $2^2 = 4$ possible worlds and computing a complete truth table. The `Repr` instance enables `#eval` to print the type's constructors.",
     "significance": "key",
+    "prerequisites": [
+      "Lean 4 derive mechanism",
+      "Fintype",
+      "decidability",
+      "truth tables"
+    ],
     "relatedConcepts": ["decidability", "Fintype", "truth tables", "computational semantics", "Bool vs Prop"]
   },
   {
@@ -298,7 +465,49 @@
     "content": "TLP 4.0141 describes a 'general rule' connecting different representations of the same logical form -- the score, the symphony, the gramophone groove. We formalize this as formEq: two propositions share their logical form iff one is obtained from the other by a bijective renaming (Equiv.Perm) of atoms.\n\nThis relation sits strictly between structEq (identical syntax tree, identical atoms) and semEq (identical truth values in all worlds). The rename functor maps atom-renaming functions over proposition trees, preserving all connective structure. Using Equiv.Perm for the renaming gives formEq the structure of a group action, making symmetry and transitivity immediate.\n\nThe key subtlety: formEq does NOT imply semEq. Elementary propositions about rain and snow have the same logical form (both are elementary) but different truth values in rainyWorld. The correct intermediate notion is truth-table isomorphism: there exists a world-relabeling making the propositions agree everywhere. This is strictly weaker than semEq (which requires agreement without any relabeling).",
     "mathContext": "The hierarchy structEq < formEq < semEq captures three distinct senses of 'sameness' for propositions. structEq is syntactic identity up to definitional equality. formEq is syntactic identity up to atom permutation -- the formal correlate of shared logical form. semEq is semantic identity -- shared truth conditions. Both inclusions are strict: atom-swapped elementaries witness structEq < formEq, and double negation witnesses formEq < semEq.",
     "significance": "critical",
+    "prerequisites": [
+      "TLP 4.0141",
+      "permutation groups",
+      "logical form",
+      "Lean 4 Equiv.Perm",
+      "semantic equivalence"
+    ],
     "relatedConcepts": ["TLP 4.0141", "TLP 4.014", "logical form", "permutation group", "renaming", "truth-table isomorphism", "syntactic equivalence", "semantic equivalence"]
+  },
+  {
+    "id": "ann-tractatus-compositionality-fo",
+    "proofId": "tractatus-ontology",
+    "range": { "startLine": 49, "endLine": 55 },
+    "type": "theorem",
+    "title": "First-Order Compositionality (TLP 5, extended) [Companion File]",
+    "content": "The compositionality theorem — if two worlds agree on all elementary states of affairs, they agree on every proposition — extends to the first-order language including quantifiers.\n\nThe proof by structural induction on `FOProp` handles five cases. The propositional cases (`lift`, `negFO`, `conjFO`) are routine. The quantifier cases are the interesting ones: for `forall_ f`, the induction hypothesis states that compositionality holds for `f d` for each `d : D`. We apply it pointwise to transfer the universal quantification from one world to the other.\n\nThis theorem validates Wittgenstein's thesis (TLP 5) in the extended setting: truth-values of first-order propositions are still determined entirely by elementary truth-values, even when quantifiers range over an external domain.",
+    "mathContext": "The key technical step is that Lean's recursor for HOAS inductives provides an induction hypothesis of the form `forall d, (f d).eval w1 <-> (f d).eval w2`, which is exactly what is needed. This is stronger than what a naive induction would provide — it quantifies over all domain elements, not just structurally smaller terms.",
+    "significance": "critical",
+    "prerequisites": [
+      "first-order logic",
+      "HOAS",
+      "Lean 4 structural induction",
+      "TLP 5"
+    ],
+    "relatedConcepts": ["TLP 5", "compositionality", "structural induction", "HOAS induction", "first-order truth-functionality"]
+  },
+  {
+    "id": "ann-tractatus-infinite-domains",
+    "proofId": "tractatus-ontology",
+    "range": { "startLine": 49, "endLine": 55 },
+    "type": "insight",
+    "title": "The Infinite Domain Problem (TLP 5.52, Geach 1981, Soames 1983) [Companion File]",
+    "content": "TLP 5.52 claims quantifiers are N-operator applications: the universal quantifier over f(x) is N applied to all values {f(a), f(b), f(c), ...}. For finite domains this works — the universal quantifier is a finite conjunction, and the N-operator handles finite lists.\n\nFor infinite domains, Wittgenstein's claim is philosophically problematic. The N-operator is a finitary syntactic construction: it takes a finite list of propositions and produces their joint denial. Applying it to infinitely many values requires an infinitary extension that the Tractatus does not provide.\n\nGeach (1981) argues this is a fundamental gap: the Tractatus cannot express genuinely infinite quantification within its truth-functional framework. Soames (1983) strengthens the point, showing that the claim in TLP 5 — that all propositions are truth-functions of elementary propositions — fails for infinite-domain quantification.\n\nOur formalization sidesteps this problem by defining `FOProp.eval` directly using Lean's `forall` and `exists`, which handle infinite domains natively. The philosophical question — whether Wittgenstein's finitary framework can be extended to the infinite case — remains open.",
+    "mathContext": "Lean's `∀ x : D, P x` and `∃ x : D, P x` work for any type `D`, including infinite types like `ℕ` or `ℝ`. The `FOProp.eval` function uses these natively: `(forall_ f).eval w := ∀ d : D, (f d).eval w`. This is an infinitary extension of the finitary N-operator — we adopt Lean's metatheoretic `∀` rather than constructing an object-level infinite conjunction. Geach's objection applies to the Tractarian N-operator, not to this HOAS encoding.",
+    "significance": "critical",
+    "prerequisites": [
+      "TLP 5.52",
+      "N-operator",
+      "infinitary logic",
+      "Geach (1981)",
+      "HOAS"
+    ],
+    "relatedConcepts": ["TLP 5.52", "N-operator", "infinitary logic", "Geach", "Soames", "truth-functions", "finite vs infinite domains"]
   },
   {
     "id": "ann-main-result-structeq",
@@ -307,7 +516,14 @@
     "type": "theorem",
     "title": "[Main Result] Structural and Semantic Equivalence Diverge",
     "content": "structEq_ne_semEq proves that structural and semantic equivalence are genuinely different relations: there exist propositions that are semantically equivalent (same truth value in every possible world) but not structurally equivalent (different syntactic trees). The witness is neg(neg(elementary s)) vs elementary s: double negation gives semantic equivalence, but the syntactic trees have different shapes. This makes explicit what the formalization captures (truth conditions) and what it cannot (logical form). With the introduction of formEq, this is now contextualized within the three-level hierarchy structEq < formEq < semEq.",
+    "mathContext": "Formally: `∃ (p q : Proposition S), Proposition.semEq p q ∧ ¬ Proposition.structEq p q`. The witness pair is `(neg (neg (elementary s)), elementary s)`. Semantic equivalence holds because double negation elimination is valid classically (`not_not`). Structural non-equivalence holds because the two syntax trees have different depth (2 vs 0 `neg` constructors) — Lean can confirm this by case analysis on the inductive type.",
     "significance": "critical",
+    "prerequisites": [
+      "TLP 4.0141",
+      "logical form",
+      "structural vs semantic equivalence",
+      "double negation"
+    ],
     "relatedConcepts": ["TLP 4.0141", "logical form", "limits of formalization", "structEq", "semEq", "formEq"]
   },
   {
@@ -319,6 +535,13 @@
     "content": "The formalization's 25 theorems divide sharply into three classes, and the division is philosophically decisive.\n\n**Core invariants** hold in every WorldModel with no assumptions beyond classical logic: compositionality (`truth_functional_compositionality_gen`), bivalence (`elem_prop_bivalence`), double negation, De Morgan laws. These are properties of the *proposition grammar itself* — they would hold in any model-theoretic semantics for this language.\n\n**Model assumptions** hold in the free model (where `World S = S -> Prop`) but can fail in constrained models: `elementary_independence` is the canonical example. It is not a theorem of propositional logic — it is a choice about which functions count as worlds. The `weatherModel` and `ConstrainedWorld` demonstrate that relaxing this choice breaks independence while preserving all core invariants.\n\n**Formal limits** are provable *boundaries* of the system: `saying_showing_triviality` and `nontrivial_expressibility_requires_world_dependence` prove exactly what the object language can and cannot express. `structEq_ne_semEq` (the structural vs semantic divergence) proves that truth-conditional equivalence is strictly weaker than syntactic identity.\n\nThe Tractatus is not a set of truths about the world — it is a specification of a semantic architecture. This classification makes that architecture explicit: what is logical structure, what is ontological assumption, and what is provable boundary.",
     "mathContext": "The three-way classification maps to standard model-theoretic vocabulary: core invariants correspond to valid sentences (true in all models), model assumptions correspond to sentences whose truth depends on which model is selected, and formal limits correspond to incompleteness results — proven boundaries on expressive power. The classification is verified by inspecting each theorem's proof: invariants use only structural induction and classical propositional lemmas; model assumptions invoke the `IndependentWorlds` typeclass or the `freeModel` instance; limits invoke the `saying_showing_triviality` family.",
     "significance": "critical",
+    "prerequisites": [
+      "model theory",
+      "Lean 4 typeclasses",
+      "TLP 2.061",
+      "TLP 5",
+      "TLP 7"
+    ],
     "relatedConcepts": ["model theory", "invariance", "independence", "expressibility", "formal limits", "compositionality", "saying vs showing", "TLP 2.061", "TLP 5", "TLP 7"]
   },
   {
@@ -330,6 +553,13 @@
     "content": "Any attempt to represent world-independent content in a truth-functional language collapses to triviality; therefore, meaningful propositions must correspond to variation across possible worlds.\n\nThe argument proceeds in two steps. First, `world_constant_taut_or_contra` shows that any proposition with the same truth value in all worlds is either a tautology or a contradiction. Second, `saying_showing_triviality` applies this to the `expresses` relation: if a proposition tracks a fixed meta-level property P in every world, its truth value is world-constant, so it collapses to a tautology (when P is true) or a contradiction (when P is false). The downstream theorems `nontrivial_expressibility_requires_world_dependence` and `nontrivial_cannot_express_world_independent` derive that nontrivial propositions -- those that are true in some worlds and false in others -- cannot express any world-independent content at all.",
     "mathContext": "The key lemma `world_constant_taut_or_contra` uses `Classical.em` (via `by_cases`) to split on whether the proposition holds in a reference world. The `saying_showing_triviality` theorem reduces the `expresses` hypothesis to the world-constant case via transitivity of biconditionals. Together they establish a provable boundary on the expressive power of the object language: the only world-independent facts it can represent are the trivially true and the trivially false.",
     "significance": "critical",
+    "prerequisites": [
+      "TLP 7",
+      "model theory",
+      "expressibility",
+      "classical logic",
+      "world-dependence"
+    ],
     "relatedConcepts": ["TLP 7", "TLP 4.46", "expressibility", "world-dependence", "tautology", "contradiction", "saying vs showing", "formal limits"]
   },
   {
@@ -339,7 +569,14 @@
     "type": "insight",
     "title": "The Ladder (TLP 6.54)",
     "content": "TLP 6.54: 'My propositions serve as elucidations in the following way: anyone who understands me eventually recognizes them as nonsensical, when he has used them — as steps — to climb beyond them. He must, so to speak, throw away the ladder after he has climbed up it.'\n\nEverything above is the ladder. The view from the top — that logical form is shared between language and reality rather than represented by either — is precisely what Lean, or any formal system, shows through its structure rather than states as a theorem. The residue left over after formalization is the most Wittgensteinian part.\n\n**[Interpretive choice]** The Tractatus is self-consciously paradoxical: it uses meaningful propositions to argue that certain things cannot be meaningfully said. Any formalization must pick a side — either the ladder is meaningful (in which case the self-undermining thesis fails) or it is not (in which case the formalization formalizes nothing). We take the first option: the formal skeleton is mathematically meaningful, and the philosophical claim about its limitations is carried by the annotations, not the code.",
+    "mathContext": "The self-undermining character of TLP 6.54 is formally analogous to Gödel's incompleteness: a system powerful enough to express its own limitations is powerful enough to expose them as limitations. In Lean, the theorems about what the object language *cannot* say (`saying_showing_triviality`, `nontrivial_cannot_express_world_independent`) are provable *in the metalanguage* — they use Lean's full logical power. The object language itself cannot state them — that is precisely TLP 6.54's point.",
     "significance": "critical",
+    "prerequisites": [
+      "TLP 6.54",
+      "saying vs showing",
+      "metalanguage vs object language",
+      "Gödel incompleteness"
+    ],
     "relatedConcepts": ["TLP 6.54", "saying vs showing", "self-reference", "limits of formalization", "Wittgenstein's ladder"]
   },
   {
@@ -351,6 +588,12 @@
     "content": "TLP 7: *Wovon man nicht sprechen kann, darueber muss man schweigen.* — 'Whereof one cannot speak, thereof one must be silent.'\n\nThe theorem `proposition_seven` proves that any proposition expressing a world-independent truth must be either a tautology or a contradiction. The object language can formally match any world-independent truth P — a tautology matches True, a contradiction matches False — but this matching is trivial. The proposition does not 'say' P in any meaningful sense.\n\nThe `axiom silence : True` enacts Wittgenstein's silence as a formal gesture — a deliberately axiomatic declaration that marks the boundary of formalization. It is trivially true but axiomatic by design, not by necessity.",
     "mathContext": "The type of `proposition_seven` is `forall (q : Proposition S) (P : Prop), [Nonempty S] -> (forall w : World S, q.eval w <-> P) -> IsTautology q or IsContradiction q`. This says: if a proposition's truth value is the same constant P in every world, then the proposition must be a tautology (if P is true) or a contradiction (if P is false). No proposition can non-trivially express a metalogical property.",
     "significance": "critical",
+    "prerequisites": [
+      "TLP 7",
+      "metalanguage vs object language",
+      "expressibility",
+      "Tarski undefinability"
+    ],
     "relatedConcepts": ["TLP 7", "axiom silence", "Tarski undefinability", "saying vs showing", "metalanguage", "object language", "silence"]
   },
   {
@@ -362,27 +605,13 @@
     "content": "TLP 5.52: 'If the values of xi are the total values of a function f(x) for all values of x, then N(xi) = ~(exists x).f(x).'\n\nThe companion file TractatusQuantifiers.lean extends the propositional calculus with first-order quantifiers. The type `FOProp S D` adds universal and existential quantification over a domain `D` to the propositional base.\n\nThe binding mechanism uses higher-order abstract syntax (HOAS): `forall_ : (D -> FOProp S D) -> FOProp S D`. Lean functions represent variable binding, avoiding the machinery of variable names, alpha-equivalence, and capture-avoiding substitution. The tradeoff is that induction over HOAS terms requires care — Lean's structural recursion handles evaluation, but proof by induction requires the recursor to supply induction hypotheses that apply pointwise under binders.\n\n**[Interpretive choice]** HOAS imports Lean's own binding mechanism into the object language. A purist encoding would use de Bruijn indices, which are self-contained but harder to read. We chose HOAS for clarity, accepting that it ties the formalization more tightly to Lean's metatheory.",
     "mathContext": "The `FOProp` inductive type has five constructors: `lift` (embed propositional formulas), `negFO`, `conjFO`, `forall_`, and `exists_`. The `lift` constructor makes the extension conservative — every propositional formula is a first-order formula. Lean accepts the HOAS constructors because the occurrences of `FOProp` in `D -> FOProp S D` are strictly positive.",
     "significance": "critical",
+    "prerequisites": [
+      "first-order logic",
+      "HOAS",
+      "TLP 5.52",
+      "N-operator",
+      "variable binding"
+    ],
     "relatedConcepts": ["TLP 5.52", "HOAS", "higher-order abstract syntax", "de Bruijn indices", "first-order logic", "quantifiers", "variable binding"]
-  },
-  {
-    "id": "ann-tractatus-compositionality-fo",
-    "proofId": "tractatus-ontology",
-    "range": { "startLine": 49, "endLine": 55 },
-    "type": "theorem",
-    "title": "First-Order Compositionality (TLP 5, extended) [Companion File]",
-    "content": "The compositionality theorem — if two worlds agree on all elementary states of affairs, they agree on every proposition — extends to the first-order language including quantifiers.\n\nThe proof by structural induction on `FOProp` handles five cases. The propositional cases (`lift`, `negFO`, `conjFO`) are routine. The quantifier cases are the interesting ones: for `forall_ f`, the induction hypothesis states that compositionality holds for `f d` for each `d : D`. We apply it pointwise to transfer the universal quantification from one world to the other.\n\nThis theorem validates Wittgenstein's thesis (TLP 5) in the extended setting: truth-values of first-order propositions are still determined entirely by elementary truth-values, even when quantifiers range over an external domain.",
-    "mathContext": "The key technical step is that Lean's recursor for HOAS inductives provides an induction hypothesis of the form `forall d, (f d).eval w1 <-> (f d).eval w2`, which is exactly what is needed. This is stronger than what a naive induction would provide — it quantifies over all domain elements, not just structurally smaller terms.",
-    "significance": "critical",
-    "relatedConcepts": ["TLP 5", "compositionality", "structural induction", "HOAS induction", "first-order truth-functionality"]
-  },
-  {
-    "id": "ann-tractatus-infinite-domains",
-    "proofId": "tractatus-ontology",
-    "range": { "startLine": 49, "endLine": 55 },
-    "type": "insight",
-    "title": "The Infinite Domain Problem (TLP 5.52, Geach 1981, Soames 1983) [Companion File]",
-    "content": "TLP 5.52 claims quantifiers are N-operator applications: the universal quantifier over f(x) is N applied to all values {f(a), f(b), f(c), ...}. For finite domains this works — the universal quantifier is a finite conjunction, and the N-operator handles finite lists.\n\nFor infinite domains, Wittgenstein's claim is philosophically problematic. The N-operator is a finitary syntactic construction: it takes a finite list of propositions and produces their joint denial. Applying it to infinitely many values requires an infinitary extension that the Tractatus does not provide.\n\nGeach (1981) argues this is a fundamental gap: the Tractatus cannot express genuinely infinite quantification within its truth-functional framework. Soames (1983) strengthens the point, showing that the claim in TLP 5 — that all propositions are truth-functions of elementary propositions — fails for infinite-domain quantification.\n\nOur formalization sidesteps this problem by defining `FOProp.eval` directly using Lean's `forall` and `exists`, which handle infinite domains natively. The philosophical question — whether Wittgenstein's finitary framework can be extended to the infinite case — remains open.",
-    "significance": "critical",
-    "relatedConcepts": ["TLP 5.52", "N-operator", "infinitary logic", "Geach", "Soames", "truth-functions", "finite vs infinite domains"]
   }
 ]


### PR DESCRIPTION
## Summary

Enriched four proof gallery entries with deeper mathematical context and cross-references:

- **tractatus-ontology** (36 anns): Added mathContext to 11 missing annotations (IndependentWorlds triviality, Gödel analogy for TLP 6.54, formal type signatures, proof strategies); added prerequisites to all 36 annotations
- **ramanujan-sum-fallacy** (16 anns): Added mathContext to 5 missing annotations (tsum junk-value definition, alternating series divergence, shift blocked by type system); added prerequisites to all 16
- **four-color-theorem** (12 anns): Added mathContext to 7 missing annotations; added prerequisites to 8
- **godel-incompleteness** (14 anns): Added mathContext to 6 missing annotations (inexhaustibility tower, Lucas-Penrose debate); added prerequisites to 8

## Mathematical quality

All enrichments add substantive formal content: Lean 4 type signatures, formal statement schemas, Mathlib lemma citations, quantitative details, and explicit connections between philosophical concepts and their formal counterparts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)