### PR TITLE
Audit fix: erdos-263 sorry count 8→5, lineCount 650→726

### DIFF
--- a/src/data/proofs/erdos-263/meta.json
+++ b/src/data/proofs/erdos-263/meta.json
@@ -17,13 +17,13 @@
       "analysis"
     ],
     "badge": "wip",
-    "sorries": 8,
+    "sorries": 5,
     "erdosNumber": 263,
     "erdosUrl": "https://erdosproblems.com/263",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "lineCount": 650,
-    "assumptions": "No axioms. 8 sorry(s) remain: folklore_irrationality (Mahler-type criterion needed), kovac_tao_not_irrationality (Egyptian fraction construction needed), positive_condition_irrationality (liminf analysis beyond Mathlib), truncation_insufficient (requires exhibiting a known irrationality sequence), doubleExp_tail_pos (tail positivity — Aristotle candidate), doubleExp_tail_bound (geometric tail bound — Aristotle candidate), tsum_split_at (tsum splitting lemma — Aristotle candidate), doubleExp_sum_irrational (HARD — integer-gap argument fully outlined, awaits helper lemma compilation). Proved (no sorry): doubleExp_term_eq (term rewrite), doubleExp_sum_summable (summability), doubleExp_not_folklore_growth, doubleExp_square_growth, doubleExp_strictly_increasing, doubleExp_convergent, doubleExp_superexponential, doubleExp_not_kovac_tao, factorial_no_folklore_growth, factorial_has_kovac_tao_condition, characterization_gap, connection_262_proved, doubleExp_fin_mul_nat (D*finsum ∈ ℕ via pow_sub₀).",
+    "lineCount": 726,
+    "assumptions": "No axioms. 5 sorry(s) remain: folklore_irrationality (Mahler-type criterion needed), kovac_tao_not_irrationality (Egyptian fraction construction needed), positive_condition_irrationality (liminf analysis beyond Mathlib), truncation_insufficient (requires exhibiting a known irrationality sequence), doubleExp_sum_irrational (HARD — integer-gap argument fully outlined, awaits helper lemma compilation). Proved (no sorry): doubleExp_term_eq (term rewrite), doubleExp_sum_summable (summability), doubleExp_not_folklore_growth, doubleExp_square_growth, doubleExp_strictly_increasing, doubleExp_convergent, doubleExp_superexponential, doubleExp_not_kovac_tao, factorial_no_folklore_growth, factorial_has_kovac_tao_condition, characterization_gap, connection_262_proved, doubleExp_fin_mul_nat (D*finsum ∈ ℕ via pow_sub₀), doubleExp_tail_pos (tail positivity — proved in Aristotle companion), doubleExp_tail_bound (geometric tail bound — proved in Aristotle companion), tsum_split_at (tsum splitting lemma — proved in Aristotle companion).",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -159,12 +159,12 @@
       "Real"
     ],
     "namespace": "Erdos263",
-    "lineCount": 650,
+    "lineCount": 726,
     "axiomCount": 0,
     "theoremCount": 19,
     "definitionCount": 19,
     "path": "Proofs/Stubs/Erdos263Problem.lean",
-    "sorries": 8
+    "sorries": 5
   },
   "crossReferences": [
     {
@@ -226,5 +226,5 @@
       "note": "Growth lower bounds for irrationality sequences, connected to Problem #262"
     }
   ],
-  "sorries": 8
+  "sorries": 5
 }


### PR DESCRIPTION
## Summary

- **Proof**: erdos-263 (Irrationality Sequences)
- **Issue**: meta.json claimed 8 sorries; actual Lean source has 5
- **Root cause**: Research session 8 proved `tail_pos`, `tail_bound`, `tsum_split_at` by moving them to the Aristotle companion (`Erdos263Aristotle.lean`), reducing the main stub file from 8→5 sorries, but meta.json was not updated

## Changes

- `meta.sorries`: 8 → 5
- `meta.lineCount`: 650 → 726 (actual file length)
- `meta.assumptions`: Updated sorry list (removed 3 Aristotle candidates, added them to Proved list)
- `leanFile.sorries`: 8 → 5
- `leanFile.lineCount`: 650 → 726
- Top-level `sorries`: 8 → 5

## Verification

```
grep -c "sorry" proofs/Proofs/Stubs/Erdos263Problem.lean  # → 5
wc -l proofs/Proofs/Stubs/Erdos263Problem.lean            # → 726
```

Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)