### PR TITLE
Enrich angle-trisection Eisenstein unification: correct annotations + sections/conclusion

### DIFF
--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-01/annotations.json
@@ -1,120 +1,74 @@
 [
   {
-    "id": "ann-at-gal-oq01-oq01-01-header",
+    "id": "ann-at-oq01-oq01-01-header",
     "proofId": "angle-trisection-cos-20-gal-oq-01-oq-01",
-    "range": {
-      "startLine": 1,
-      "endLine": 35
-    },
+    "range": { "startLine": 1, "endLine": 47 },
     "type": "context",
-    "title": "Unifying Two Eisenstein Irreducibility Proofs",
-    "content": "The header frames the unification question: both cos(20°) and cos(π/7) minimal polynomials are irreducible over ℚ, proved in separate files via Eisenstein at p=3 and p=7 respectively. The common structure is the linear shift ℓ = 2X+2 — both target polynomials are of the form q_p(2X+2) where q_p is an Eisenstein polynomial at prime p. The abstract lemma irreducible_of_comp_linear unifies both proofs into a single theorem.",
-    "mathContext": "For any Eisenstein prime $p$, the polynomial $q_p \\in \\mathbb{Z}[X]$ satisfying the Eisenstein criterion at $p$ is irreducible over $\\mathbb{Z}$ (and $\\mathbb{Q}$ by Gauss). If $f = q_p(2X+2)$, then $f$ is also irreducible since the substitution $X \\mapsto 2X+2$ is invertible (with inverse $X \\mapsto \\frac{X-2}{2}$). The parameterization is $p \\in \\{3, 7\\}$.",
-    "significance": "main",
-    "relatedConcepts": [
-      "Eisenstein criterion",
-      "irreducibility",
-      "linear substitution",
-      "Galois theory"
-    ],
-    "prerequisites": [
-      "Polynomial.irreducible_of_eisenstein_criterion",
-      "IsPrimitive.Int.irreducible_iff_irreducible_map_cast"
-    ]
+    "title": "Unification Question: One Pattern Behind Two Proofs",
+    "content": "The header frames the open question: can the cos(20°) and cos(π/7) Galois results be unified into a single parameterized theorem? Both cases share the same algebraic pattern — degree-3 minimal polynomial, splitting field of degree 3 over ℚ, Galois group of order 3 — but were proved in separate files (AngleTrisectionCos20Gal and AngleTrisectionCos20GalOQ01) using different Eisenstein primes (p=3 and p=7).\n\nThe unification approach here: define `trisectionPoly p` and `eisensteinCubic p` as parameterized families, then prove all unified theorems by `rcases hp with rfl | rfl` — reducing each case to the corresponding theorem in the parent file. No abstract lemma is needed; the unification is achieved through parameterization.",
+    "mathContext": "Both polynomials arise as images of Eisenstein cubics under a linear shift: $r_3(2X+1) = 8X^3-6X-1$ (cos 20°) and $r_7(2X+2) = 8X^3-4X^2-4X+1$ (cos π/7), where $r_3 = X^3-6X^2+9X-3$ (Eisenstein at 3) and $r_7 = X^3-7X^2+14X-7$ (Eisenstein at 7).",
+    "significance": "context",
+    "relatedConcepts": ["Eisenstein criterion", "Galois theory", "minimal polynomial", "angle trisection", "unification"],
+    "prerequisites": ["Polynomial.Gal", "Polynomial.SplittingField", "angle-trisection-cos-20-gal", "angle-trisection-cos-20-gal-oq-01"]
   },
   {
-    "id": "ann-at-gal-oq01-oq01-02-abstract-lemma",
+    "id": "ann-at-oq01-oq01-02-param-defs",
     "proofId": "angle-trisection-cos-20-gal-oq-01-oq-01",
-    "range": {
-      "startLine": 44,
-      "endLine": 100
-    },
-    "type": "theorem",
-    "title": "irreducible_of_comp_linear (Abstract Key Lemma)",
-    "content": "The central theorem: irreducibility is preserved under invertible linear substitution. If q ∈ K[X] is irreducible (K infinite field, a ≠ 0), then q.comp(aX+b) is also irreducible. Proof: Define ℓ = aX+b and ℓ_inv = a⁻¹X - a⁻¹b. Prove ℓ ∘ ℓ_inv = X and ℓ_inv ∘ ℓ = X via Polynomial.funext (requires infinite K). For the 'not a unit' direction: if q.comp(ℓ) = C c, trace back q = (C c).comp(ℓ_inv) = C c, making q a unit. For factorizations: if q.comp(ℓ) = s * t, then q = (s.comp ℓ_inv) * (t.comp ℓ_inv); by irreducibility of q, one factor is a unit; trace the unit back through ℓ.",
-    "mathContext": "The key algebraic identity: for any $f \\in K[X]$, $f = f \\circ X = f \\circ (\\ell \\circ \\ell^{-1}) = (f \\circ \\ell) \\circ \\ell^{-1}$. This gives the pullback factorization: if $f \\circ \\ell = s \\cdot t$, then $f = (s \\circ \\ell^{-1}) \\cdot (t \\circ \\ell^{-1})$.",
-    "significance": "main",
-    "relatedConcepts": [
-      "polynomial composition",
-      "automorphism",
-      "irreducibility",
-      "Polynomial.funext"
-    ],
-    "prerequisites": [
-      "Polynomial.funext",
-      "Polynomial.comp_assoc",
-      "Polynomial.mul_comp",
-      "Polynomial.C_comp",
-      "Polynomial.isUnit_iff"
-    ]
+    "range": { "startLine": 48, "endLine": 78 },
+    "type": "definition",
+    "title": "Parameterized Families: trisectionPoly and eisensteinCubic",
+    "content": "`trisectionPoly p` and `eisensteinCubic p` are noncomputable ℚ[X]-valued functions of the Eisenstein prime p ∈ {3, 7} (with a default value of 1 for other inputs). The four `@[simp]` lemmas establish the concrete values by `simp [trisectionPoly]` + `norm_num`, enabling Lean's simp tactic to reduce instances in proof goals.\n\nThe parameterized design is the key to unification: instead of two separate proofs, all subsequent theorems take `(hp : p = 3 ∨ p = 7)` and reduce via `rcases hp with rfl | rfl`. The `norm_num` call in `trisectionPoly_7` and `eisensteinCubic_7` handles the arithmetic distinguishing 7 ≠ 3 ≠ 0.",
+    "mathContext": "$\\text{trisectionPoly}(3) = 8X^3-6X-1$ (minimal poly of $\\cos(\\pi/9) = \\cos 20°$); $\\text{trisectionPoly}(7) = 8X^3-4X^2-4X+1$ (minimal poly of $\\cos(\\pi/7)$). $\\text{eisensteinCubic}(3) = X^3-6X^2+9X-3$; $\\text{eisensteinCubic}(7) = X^3-7X^2+14X-7$.",
+    "significance": "key",
+    "relatedConcepts": ["noncomputable def", "@[simp] lemma", "norm_num", "parameterized family", "if-then-else case analysis"],
+    "prerequisites": ["Polynomial.X", "Polynomial.C", "ℚ[X]", "Lean 4 simp attribute"]
   },
   {
-    "id": "ann-at-gal-oq01-oq01-03-cos20",
+    "id": "ann-at-oq01-oq01-03-unified-thms",
     "proofId": "angle-trisection-cos-20-gal-oq-01-oq-01",
-    "range": {
-      "startLine": 105,
-      "endLine": 165
-    },
-    "type": "theorem",
-    "title": "cos(20°) Case: p=3 Eisenstein at 3",
-    "content": "Applies the abstract lemma to cos(20°). The Eisenstein polynomial q₃ = X³-6X²+9X-3 is irreducible over ℤ (Eisenstein at 3: all non-leading coefficients divisible by 3, constant term -3 not divisible by 9). Gauss's lemma lifts irreducibility to ℚ. The composition identity q₃(2X+2) = 8X³-6X-1 = p_cos20 is verified by evaluation (ring). Then irreducible_of_comp_linear with a=2, b=2 gives p_cos20 irreducible.",
-    "mathContext": "For $q_3 = X^3-6X^2+9X-3$: Eisenstein at $p=3$ (coefficients 9, -6, -3 all divisible by 3; -3 not divisible by 9; leading coefficient 1 not divisible by 3). Then $q_3(2x+2) = (2x+2)^3-6(2x+2)^2+9(2x+2)-3 = 8x^3-6x-1$.",
-    "significance": "main",
-    "relatedConcepts": [
-      "Eisenstein at p=3",
-      "cos(20°)",
-      "minimal polynomial"
-    ],
-    "prerequisites": [
-      "Polynomial.irreducible_of_eisenstein_criterion",
-      "IsPrimitive.Int.irreducible_iff_irreducible_map_cast",
-      "irreducible_of_comp_linear"
-    ]
+    "range": { "startLine": 80, "endLine": 108 },
+    "type": "technique",
+    "title": "Unified Galois Theorems: rcases Case Split Pattern",
+    "content": "Three unified theorems prove properties of `trisectionPoly p` for p ∈ {3, 7} by a uniform `rcases hp with rfl | rfl` pattern:\n\n1. **`trisection_gal_order_3`**: |Gal(trisectionPoly p)| = 3. Reduces to `cos20_gal_card` (p=3) or `cos_pi_7_gal_card` (p=7).\n2. **`trisection_poly_irreducible`**: trisectionPoly p is irreducible over ℚ. Reduces to `trisection_poly_irreducible` or `cos_pi_7_poly_irreducible` from parent files.\n3. **`trisection_splitting_degree`**: degree of splitting field over ℚ is 3. Reduces to `splitting_finrank` from each parent.\n\nThe `rw [trisectionPoly_3]` / `rw [trisectionPoly_7]` step uses the simp lemmas from the previous section to unfold the parameterized definition before applying the parent theorem.",
+    "mathContext": "Pattern: `rcases hp with rfl | rfl` splits the hypothesis $p = 3 \\vee p = 7$ into two definitional equalities. After `rw [trisectionPoly_3]`, the goal becomes exactly the statement in `AngleTrisectionCos20Gal`, so `exact cos20_gal_card` closes it. For $p=7$: same pattern. This is the proof-by-parameterization principle: one theorem statement, two one-line cases.",
+    "significance": "key",
+    "relatedConcepts": ["rcases", "rw (rewrite)", "exact", "Galois group order", "splitting field degree", "irreducibility"],
+    "prerequisites": ["trisectionPoly_3", "trisectionPoly_7", "AngleTrisectionCos20Gal.cos20_gal_card", "AngleTrisectionCos20GalOQ01.cos_pi_7_gal_card"]
   },
   {
-    "id": "ann-at-gal-oq01-oq01-04-cospi7",
+    "id": "ann-at-oq01-oq01-04-cyclic-cubic",
     "proofId": "angle-trisection-cos-20-gal-oq-01-oq-01",
-    "range": {
-      "startLine": 168,
-      "endLine": 220
-    },
-    "type": "theorem",
-    "title": "cos(π/7) Case: p=7 Eisenstein at 7",
-    "content": "Applies the abstract lemma to cos(π/7). The Eisenstein polynomial r₇ = X³-7X²+14X-7 is irreducible over ℤ (Eisenstein at 7: all non-leading coefficients 14, -7, -7 divisible by 7; -7 not divisible by 49). Gauss's lemma lifts to ℚ. The composition r₇(2X+2) = 8X³-4X²-4X+1 = p_cos_pi7 is verified by evaluation. Then irreducible_of_comp_linear with a=2, b=2 gives irreducibility.",
-    "mathContext": "For $r_7 = X^3-7X^2+14X-7$: Eisenstein at $p=7$ (coefficients 14, -7, -7 all divisible by 7; -7 not divisible by 49). Then $r_7(2x+2) = (2x+2)^3-7(2x+2)^2+14(2x+2)-7 = 8x^3-4x^2-4x+1$.",
-    "significance": "main",
-    "relatedConcepts": [
-      "Eisenstein at p=7",
-      "cos(π/7)",
-      "minimal polynomial"
-    ],
-    "prerequisites": [
-      "Polynomial.irreducible_of_eisenstein_criterion",
-      "IsPrimitive.Int.irreducible_iff_irreducible_map_cast",
-      "irreducible_of_comp_linear"
-    ]
+    "range": { "startLine": 109, "endLine": 138 },
+    "type": "technique",
+    "title": "CyclicCubicData: Packaging Three Properties as a Structure",
+    "content": "`CyclicCubicData poly` is a structure with three fields: irreducibility of the polynomial, degree 3 of the splitting field, and Galois group order 3. Packing these into a structure serves two purposes: (1) it names the combined property so it can be referenced concisely, and (2) it enables the parameterized theorem `trisection_cyclic_cubic_data` to assert all three properties at once for any p ∈ {3, 7}.\n\n`cos20Data` and `cosPi7Data` are concrete instances, constructed using record syntax `{ irred := ..., degree_3 := ..., gal_order := ... }`. The parameterized theorem then reduces to `exact cos20Data` or `exact cosPi7Data` via the same `rcases` pattern.",
+    "mathContext": "A cyclic cubic extension of $\\mathbb{Q}$ is a degree-3 Galois extension with cyclic Galois group $\\mathbb{Z}/3\\mathbb{Z}$. Both cos(20°) and cos(π/7) generate such extensions: irreducible degree-3 polynomial + Galois group of order 3 (which is cyclic since order 3 is prime). `CyclicCubicData` certifies exactly these properties at the type level.",
+    "significance": "supporting",
+    "relatedConcepts": ["structure", "record syntax", "CyclicCubicData", "cyclic cubic extension", "Galois group Z/3Z"],
+    "prerequisites": ["trisection_gal_order_3", "trisection_poly_irreducible", "trisection_splitting_degree", "Lean 4 structure"]
   },
   {
-    "id": "ann-at-gal-oq01-oq01-05-unification",
+    "id": "ann-at-oq01-oq01-05-eisenstein-connection",
     "proofId": "angle-trisection-cos-20-gal-oq-01-oq-01",
-    "range": {
-      "startLine": 222,
-      "endLine": 240
-    },
-    "type": "theorem",
-    "title": "Unified Summary: eisenstein_shift_unification",
-    "content": "The main unification theorem packages both results: both p_cos20 and p_cos_pi7 are irreducible. The same_shift_different_prime theorem records the structural insight: the linear shift ℓ = 2X+2 is identical in both cases, and only the Eisenstein prime differs (p=3 vs p=7). The Galois group bounds follow from prime_degree_dvd_card: 3 | |Gal(p/ℚ)| for both degree-3 polynomials.",
-    "mathContext": "For any irreducible polynomial $f$ of prime degree $p$ over $\\mathbb{Q}$, the Galois group $\\text{Gal}(f/\\mathbb{Q})$ contains a $p$-cycle (since it acts transitively on the roots), so $p \\mid |\\text{Gal}|$. For $p=3$: $3 \\mid |\\text{Gal}(\\text{p\\_cos20})|$ and $3 \\mid |\\text{Gal}(\\text{p\\_cos\\_pi7})|$.",
-    "significance": "main",
-    "relatedConcepts": [
-      "unification",
-      "Galois group",
-      "prime_degree_dvd_card"
-    ],
-    "prerequisites": [
-      "Polynomial.Gal.prime_degree_dvd_card",
-      "p_cos20_irreducible",
-      "p_cos_pi7_irreducible"
-    ]
+    "range": { "startLine": 139, "endLine": 162 },
+    "type": "insight",
+    "title": "The Eisenstein Connection: Coefficient Pattern and Substitution",
+    "content": "Two theorems document the algebraic relationship between the Eisenstein cubics and the trisection polynomials:\n\n1. **`eisensteinCubic_coeff_pattern`**: the constant term of `eisensteinCubic p` is divisible by p but not p². This is the key Eisenstein condition: for p=3, coeff 0 = -3, divisible by 3 but not 9. For p=7, coeff 0 = -7, divisible by 7 but not 49. Proved by `simp` + `norm_num`.\n\n2. **`eisenstein_cubic_to_trisection`**: the Eisenstein cubic composed with the linear shift (2X + shift) equals the trisection polynomial. Crucially, the shift differs: p=3 uses shift=1 (so 2X+1), while p=7 uses shift=2 (so 2X+2). This explains why the unification is 'almost but not quite' a uniform substitution — the shifts differ by case. Proved by `ring`.",
+    "mathContext": "Eisenstein criterion: $q_p \\in \\mathbb{Z}[X]$ is irreducible over $\\mathbb{Z}$ (hence $\\mathbb{Q}$ by Gauss) if all non-leading coefficients are divisible by prime $p$, the constant term is not divisible by $p^2$, and the leading coefficient is not divisible by $p$. The composition identity: $r_3(2x+1) = (2x+1)^3-6(2x+1)^2+9(2x+1)-3 = 8x^3-6x-1$ and $r_7(2x+2) = 8x^3-4x^2-4x+1$.",
+    "significance": "key",
+    "relatedConcepts": ["Eisenstein criterion", "polynomial composition", "linear substitution", "ring tactic", "constant term divisibility"],
+    "prerequisites": ["eisensteinCubic_3", "eisensteinCubic_7", "trisectionPoly_3", "trisectionPoly_7", "Polynomial.comp"]
+  },
+  {
+    "id": "ann-at-oq01-oq01-06-summary",
+    "proofId": "angle-trisection-cos-20-gal-oq-01-oq-01",
+    "range": { "startLine": 163, "endLine": 182 },
+    "type": "technique",
+    "title": "Main Summary: both_trisection_gal_order_3",
+    "content": "`both_trisection_gal_order_3` is the final packaged statement: all four key facts at once — Galois group order 3 for both polynomials, irreducibility for both — in a single conjunction. Constructed as a 4-tuple using angle brackets, pulling existing theorems from the parent imports (`cos20_gal_card`, `cos_pi_7_gal_card`, `trisection_poly_irreducible`, `cos_pi_7_poly_irreducible`). No new proof is needed; this theorem is documentation-as-proof.\n\nThe `end AngleTrisectionCos20GalOQ01OQ01` closes the namespace, which was opened after the imports to organize the parameterized definitions and avoid collision with the parent namespace names.",
+    "mathContext": "The four conditions in `both_trisection_gal_order_3` are: (1) $|\\text{Gal}(8X^3-6X-1/\\mathbb{Q})| = 3$, (2) $|\\text{Gal}(8X^3-4X^2-4X+1/\\mathbb{Q})| = 3$, (3) $8X^3-6X-1$ irreducible over $\\mathbb{Q}$, (4) $8X^3-4X^2-4X+1$ irreducible over $\\mathbb{Q}$. These together imply both extensions are cyclic cubic and both cosines are algebraic of degree 3.",
+    "significance": "supporting",
+    "relatedConcepts": ["And.intro (angle brackets)", "namespace end", "conjunction", "documentation theorem"],
+    "prerequisites": ["trisection_gal_order_3", "trisection_poly_irreducible", "AngleTrisectionCos20Gal", "AngleTrisectionCos20GalOQ01"]
   }
 ]

--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-01/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "angle-trisection-cos-20-gal-oq-01-oq-01",
-  "title": "Unifying cos(20°) and cos(π/7): Irreducibility via Eisenstein-Shift Pattern",
+  "title": "Unifying cos(20°) and cos(π/7): Parameterized Galois Unification via Eisenstein Primes",
   "slug": "angle-trisection-cos-20-gal-oq-01-oq-01",
-  "description": "Proves a general abstract lemma — irreducibility is preserved under invertible linear substitution — and applies it to unify the irreducibility proofs for 8X³−6X−1 (cos(20°)) and 8X³−4X²−4X+1 (cos(π/7)). Both cases use the same linear shift ℓ = 2X+2, with Eisenstein applied at p=3 and p=7 respectively.",
+  "description": "Formalizes the parameterized unification of two Eisenstein irreducibility results: both cos(20°) (8X³−6X−1) and cos(π/7) (8X³−4X²−4X+1) have Galois groups of order 3 over ℚ. The proof introduces `trisectionPoly p` and `eisensteinCubic p` parameterized by Eisenstein prime p ∈ {3,7}, proves all unified theorems via case-splitting (`rcases hp with rfl | rfl`), and packages the three key properties (irreducible, degree 3, Galois order 3) into a `CyclicCubicData` structure.",
   "meta": {
     "author": "researcher-5",
     "sourceUrl": "https://en.wikipedia.org/wiki/Eisenstein%27s_criterion",
@@ -22,64 +22,137 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 240,
-    "assumptions": "No axioms, no sorries. The abstract lemma irreducible_of_comp_linear uses [Infinite K] (satisfied by ℚ). Key tools: Polynomial.irreducible_of_eisenstein_criterion, IsPrimitive.Int.irreducible_iff_irreducible_map_cast (Gauss's lemma), Polynomial.Gal.prime_degree_dvd_card.",
+    "lineCount": 183,
+    "assumptions": "No axioms, no sorries. Imports AngleTrisectionCos20Gal and AngleTrisectionCos20GalOQ01; all key theorems reduce to those parent results via case-splitting.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "The Eisenstein criterion is a classical irreducibility test for polynomials over UFDs. When an irreducible polynomial is related to another via a linear substitution X ↦ aX+b, irreducibility is preserved — this is because the substitution map is an automorphism of the polynomial ring (over an infinite field). Both cos(20°) = cos(π/9) and cos(π/7) have minimal polynomials that are related via the shift X ↦ 2X+2 to Eisenstein-at-p polynomials (p=3 and p=7 respectively). This common structure enables a unified proof.",
-    "problemStatement": "Can the irreducibility proofs for 8X³−6X−1 (minimal polynomial of cos(20°)) and 8X³−4X²−4X+1 (minimal polynomial of cos(π/7)) be unified into a single theorem parameterized by the Eisenstein prime? Both polynomials arise as q_p(2X+2) where q_p is Eisenstein at prime p.",
-    "proofStrategy": "Three-phase proof: (1) Prove the abstract lemma irreducible_of_comp_linear: if q ∈ K[X] is irreducible (K infinite field) and a ≠ 0, then q.comp(aX+b) is irreducible. Proof uses the compositional inverse ℓ_inv = a⁻¹X − a⁻¹b to pull back any factorization. (2) For each case, prove the Eisenstein polynomial (q₃ or r₇) is irreducible over ℤ via irreducible_of_eisenstein_criterion, then lift to ℚ via Gauss's lemma. (3) Apply the abstract lemma with a=2, b=2 to derive irreducibility of p_cos20 and p_cos_pi7.",
+    "historicalContext": "The question of which angles can be trisected by compass and straightedge — one of the three classical Greek problems — was resolved by Pierre Wantzel in 1837, who proved that only angles whose cosine satisfies a rational polynomial of 2-power degree are constructible. Trisecting 60° requires that cos(20°) satisfy a degree-3 polynomial 8X³−6X−1 (its minimal polynomial over ℚ), which is irreducible and not of 2-power degree.\n\nThe Galois theory viewpoint clarifies the impossibility: irreducible degree-3 polynomials over ℚ have Galois groups of order divisible by 3, while constructibility requires 2-power order. Computing that |Gal| = 3 for both cos(20°) and cos(π/7) proves their non-constructibility.\n\nBoth minimal polynomials arise from the same algebraic pattern: an Eisenstein cubic (primitive with prime-p divisibility conditions) composed with a linear shift. This common structure — recognized independently for p=3 and p=7 in separate proofs — is unified here into a single parameterized theorem.",
+    "problemStatement": "Can the cos(20°) and cos(π/7) Galois group results be unified into a single parameterized theorem? Both polynomials arise as images of Eisenstein cubics under linear shifts; can this common pattern be formalized?",
+    "proofStrategy": "Parameterization via case splitting. Define `trisectionPoly p` and `eisensteinCubic p` as ℚ[X]-valued functions of p ∈ {3, 7} (default 1 elsewhere). Prove unified theorems by `rcases hp with rfl | rfl`, reducing each case to the corresponding theorem in the imported parent file (AngleTrisectionCos20Gal for p=3, AngleTrisectionCos20GalOQ01 for p=7). Package the three key properties (irreducible, degree 3, Galois order 3) into the `CyclicCubicData` structure for clean reuse. Document the Eisenstein connection via `eisensteinCubic_coeff_pattern` (constant term ≡ p mod p², ≢ 0 mod p²) and `eisenstein_cubic_to_trisection` (composition identity, proved by `ring`).",
     "keyInsights": [
-      "The abstract key: composition by an invertible linear polynomial is an automorphism of K[X] (over infinite K). Automorphisms preserve irreducibility. The pullback argument makes this concrete: if f = g.comp(ℓ) factors nontrivially, then g = (g.comp ℓ).comp ℓ_inv = f.comp ℓ_inv factors nontrivially, contradicting irreducibility of g.",
-      "Both cos(20°) and cos(π/7) cases use the same shift ℓ = 2X+2 — the 'Eisenstein prime parameter' is p=3 vs p=7, not the shift. This is the core of the unification: one abstract lemma, different Eisenstein primes.",
-      "The Galois group bound follows automatically: irreducible polynomials of prime degree p over ℚ have p | |Gal| (Polynomial.Gal.prime_degree_dvd_card). For degree 3, this gives 3 | |Gal| in both cases."
+      "**Unification via parameterization, not abstraction**: Instead of proving an abstract `irreducible_of_comp_linear` lemma, the proof parameterizes the family directly and case-splits. This is simpler and more idiomatic in Lean 4 — `rcases hp with rfl | rfl` reduces each instance to an already-proved theorem in one line.",
+      "**The shifts differ**: r₃ uses shift X ↦ 2X+1 while r₇ uses X ↦ 2X+2. The unification is a 'soft' one — the same Eisenstein structure applies, but with different shifts. The `eisenstein_cubic_to_trisection` theorem makes this explicit.",
+      "**CyclicCubicData as reusable certificate**: Packaging the triple (irreducible, degree 3, Galois order 3) into a structure allows future proofs to require just `CyclicCubicData poly` rather than three separate hypotheses. This is the Lean 4 equivalent of defining a mathematical concept.",
+      "**Galois order 3 implies cyclic**: A group of prime order is automatically cyclic (Z/3Z), so |Gal| = 3 not only shows impossibility of trisection but also that the splitting field is a cyclic cubic extension — an additional structural fact (abelian Galois group, normal extension).",
+      "**Eisenstein at p characterizes Wantzel's impossibility**: The same prime p that appears in the Eisenstein criterion (making the polynomial irreducible of degree 3) also encodes the angle symmetry — p=3 for 3-fold rotation (trisection of 60°), p=7 for 7-fold symmetry (heptagon cosines). The Eisenstein prime is both the algebraic tool and the geometric invariant."
     ],
     "prerequisites": [
       "angle-trisection-cos-20-gal: Galois group of 8X³−6X−1 (cos(20°) case)",
       "angle-trisection-cos-20-gal-oq-01: Galois group of 8X³−4X²−4X+1 (cos(π/7) case)",
-      "Polynomial.irreducible_of_eisenstein_criterion",
-      "IsPrimitive.Int.irreducible_iff_irreducible_map_cast (Gauss's lemma)",
-      "Polynomial.Gal.prime_degree_dvd_card"
+      "Polynomial.Gal API in Mathlib",
+      "Module.finrank for splitting field degree",
+      "Polynomial.Irreducible"
     ]
   },
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Unification Question and Imports",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "Documents the open question (can the two Galois results be unified?), lists the two polynomial cases, and imports the parent proof files."
+    },
+    {
+      "id": "param-defs",
+      "title": "Parameterized Polynomial Families",
+      "startLine": 48,
+      "endLine": 78,
+      "summary": "Defines trisectionPoly p and eisensteinCubic p as ℚ[X]-valued functions of Eisenstein prime p ∈ {3,7}. Four simp lemmas establish the concrete values.",
+      "mathContext": "$\\text{trisectionPoly}(3) = 8X^3-6X-1$; $\\text{trisectionPoly}(7) = 8X^3-4X^2-4X+1$; $\\text{eisensteinCubic}(3) = X^3-6X^2+9X-3$; $\\text{eisensteinCubic}(7) = X^3-7X^2+14X-7$."
+    },
+    {
+      "id": "unified-thms",
+      "title": "Unified Galois Theorems",
+      "startLine": 80,
+      "endLine": 108,
+      "summary": "Three unified theorems proved by rcases case split: Galois group order 3, polynomial irreducibility, and splitting field degree 3 — all for both p=3 and p=7.",
+      "mathContext": "For $p \\in \\{3, 7\\}$: $|\\text{Gal}(\\text{trisectionPoly}\\,p / \\mathbb{Q})| = 3$ and $[\\text{trisectionPoly}\\,p.\\text{SplittingField} : \\mathbb{Q}] = 3$."
+    },
+    {
+      "id": "cyclic-cubic-structure",
+      "title": "CyclicCubicData Structure and Instances",
+      "startLine": 109,
+      "endLine": 138,
+      "summary": "Defines the CyclicCubicData structure certifying three properties of a polynomial (irreducible, degree-3 splitting field, Galois order 3). Provides instances for cos(20°) and cos(π/7), then proves the parameterized version.",
+      "mathContext": "`CyclicCubicData poly` certifies: (1) $\\text{poly}$ irreducible, (2) $[\\text{SplittingField} : \\mathbb{Q}] = 3$, (3) $|\\text{Gal}| = 3$. Together these imply a cyclic cubic Galois extension."
+    },
+    {
+      "id": "eisenstein-connection",
+      "title": "The Eisenstein Connection",
+      "startLine": 139,
+      "endLine": 162,
+      "summary": "Proves that the Eisenstein cubics satisfy the Eisenstein divisibility condition (p | coeff 0, p² ∤ coeff 0) and that the substitution connecting each Eisenstein cubic to its trisection polynomial holds.",
+      "mathContext": "Constant term of eisensteinCubic p: $p \\mid c_0$ and $p^2 \\nmid c_0$. Composition: $r_3(2X+1) = 8X^3-6X-1$ and $r_7(2X+2) = 8X^3-4X^2-4X+1$."
+    },
+    {
+      "id": "joint-summary",
+      "title": "Joint Summary Theorem",
+      "startLine": 163,
+      "endLine": 182,
+      "summary": "Packages all four key facts — Galois order 3 and irreducibility for both polynomials — into a single conjunction `both_trisection_gal_order_3`.",
+      "mathContext": "$|\\text{Gal}(8X^3-6X-1)| = 3$ and $|\\text{Gal}(8X^3-4X^2-4X+1)| = 3$ and both polynomials are irreducible over $\\mathbb{Q}$."
+    }
+  ],
   "leanFile": {
-    "imports": ["Mathlib"],
-    "namespace": "AngleTrisectionEisensteinUnification",
-    "lineCount": 240,
+    "imports": ["Proofs.AngleTrisectionCos20Gal", "Proofs.AngleTrisectionCos20GalOQ01"],
+    "namespace": "AngleTrisectionCos20GalOQ01OQ01",
+    "lineCount": 183,
     "axiomCount": 0,
-    "theoremCount": 9,
+    "theoremCount": 11,
     "definitionCount": 4,
+    "structureCount": 1,
     "path": "Proofs/AngleTrisectionCos20GalOQ01OQ01.lean",
     "sorries": 0
   },
   "sorries": 0,
   "crossReferences": [
     {
-      "targetId": "angle-trisection-cos-20-gal",
-      "relationship": "unifies",
-      "description": "The cos(20°) irreducibility proof (using Eisenstein at 3) is a special case of the abstract irreducible_of_comp_linear lemma proved here."
+      "id": "angle-trisection-cos-20-gal",
+      "relationship": "parent",
+      "description": "Proves the cos(20°) Galois result (|Gal(8X³−6X−1)| = 3) used here as `cos20_gal_card` for the p=3 case."
     },
     {
-      "targetId": "angle-trisection-cos-20-gal-oq-01",
-      "relationship": "unifies",
-      "description": "The cos(π/7) irreducibility proof (using Eisenstein at 7) is the second special case of the same abstract lemma."
+      "id": "angle-trisection-cos-20-gal-oq-01",
+      "relationship": "parent",
+      "description": "Proves the cos(π/7) Galois result (|Gal(8X³−4X²−4X+1)| = 3) used here as `cos_pi_7_gal_card` for the p=7 case."
+    },
+    {
+      "id": "angle-trisection",
+      "relationship": "ancestor",
+      "description": "The root angle trisection proof establishing impossibility via Galois theory — the original context motivating these specific Galois group computations."
     }
   ],
+  "conclusion": {
+    "summary": "A complete parameterized unification of the cos(20°) and cos(π/7) Galois group results. The key structural insight — both polynomials arise from Eisenstein cubics via linear shifts at the same Eisenstein prime — is formalized through parameterized definitions and case-splitting, yielding 183 lines with 0 sorries and 0 axioms.",
+    "implications": "This proof demonstrates that unification in Lean 4 can be achieved through parameterization and case-splitting rather than abstract generalization. The `CyclicCubicData` structure packages the three properties of a cyclic cubic extension into a reusable certificate, providing a template for formalizing other cyclic cubic extensions (e.g., cubic subfields of cyclotomic fields, which also arise from Eisenstein polynomials). The proof strategy — import + parameterize + rcases — scales naturally to larger unification questions, such as unifying all 2-power subfields of cyclotomic ℚ(ζₙ) or all cases of Wantzel's constructibility criterion.",
+    "openQuestions": [
+      "Can the parameterization be extended to all primes p ≡ 1 mod 3, unifying the Galois theory of all prime-order cyclic cubic extensions of ℚ?",
+      "Is there a typeclass formulation where `CyclicCubicData` becomes an instance that Lean can synthesize automatically for Eisenstein cubics with prime constant term?",
+      "What is the computational content of the Galois group order proof — does the order-3 certificate encode an explicit description of the 3-cycle acting on the roots?"
+    ]
+  },
   "references": [
+    {
+      "authors": "Wantzel, Pierre Laurent",
+      "title": "Recherches sur les moyens de reconnaître si un problème de géométrie peut se résoudre avec la règle et le compas",
+      "year": "1837",
+      "venue": "Journal de Mathématiques Pures et Appliquées, 2",
+      "note": "Pages 366-372. Proves impossibility of angle trisection via polynomial degree arguments, anticipating Galois theory."
+    },
     {
       "authors": "Dummit, David S. and Foote, Richard M.",
       "title": "Abstract Algebra, 3rd Edition",
       "year": "2004",
       "venue": "Wiley",
-      "note": "Chapter 9.4: Eisenstein's Criterion and irreducibility tests for polynomials over UFDs"
+      "note": "Chapter 9.4: Eisenstein's Criterion; Chapter 14: Galois Theory and ruler-and-compass constructions."
     },
     {
       "authors": "Lang, Serge",
       "title": "Algebra, 3rd Edition",
       "year": "2002",
       "venue": "Springer",
-      "note": "Chapter IV §2: Eisenstein criterion; Chapter VI: Galois group of irreducible polynomials"
+      "note": "Chapter IV §2: Eisenstein criterion; Chapter VI: Galois group of irreducible polynomials; Chapter IX: cyclic extensions."
     }
   ]
 }


### PR DESCRIPTION
Enrichment pass for `angle-trisection-cos-20-gal-oq-01-oq-01` (quality 71, passes 0).

## Problem Fixed

The existing annotations described a completely different proof than what the actual Lean file contains. The file uses **parameterized definitions + CyclicCubicData structure + rcases case splitting**, not `irreducible_of_comp_linear` abstract lemma as previously documented. All 5 annotations and key meta.json fields were mismatched.

## Changes

**Rewrote annotations.json** — 6 new annotations accurately covering:
- Header/imports: unification question framing
- `trisectionPoly` and `eisensteinCubic` parameterized definitions + simp lemmas
- Unified Galois theorems via `rcases hp with rfl | rfl` pattern
- `CyclicCubicData` structure and instances
- Eisenstein coefficient pattern + cubic-to-trisection composition identity
- Joint summary theorem

**Updated meta.json:**
- Added `sections` array (6 sections covering full 183-line file)
- Added `conclusion` with summary, implications, and 3 open questions
- Expanded `keyInsights` from 3 to 5 items
- Fixed `lineCount` (240 → 183) and `leanFile.lineCount`
- Fixed `crossReferences` schema (`targetId` → `id`)
- Fixed annotation `significance` values (`"main"` → valid values)
- Updated `description` and `proofStrategy` to describe actual implementation
- Added Wantzel 1837 reference