### PR TITLE
Audit: fix sorry counts for 2 gallery entries (apr22)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -543,8 +543,8 @@
       "result": "clean"
     },
     "binomial-theorem-oq-04-oq-02-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:45:43Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-22T08:06:37Z",
       "result": "issues-fixed",
       "issues": []
     },
@@ -12898,8 +12898,8 @@
       "issues": []
     },
     "erdos-476-oq-05": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T12:00:00Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T08:06:38Z",
       "result": "issues-fixed",
       "issues": [
         "sorries 3->1 (ap_of_near_periodic and vosper_base now fully proved)",

--- a/src/data/proofs/binomial-theorem-oq-04-oq-02-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-04-oq-02-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Gaussian_binomial_coefficient",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "tags": [
       "combinatorics",
       "algebra",
@@ -17,7 +17,7 @@
     ],
     "proofRepoPath": "Proofs/BinomialTheoremOQ04OQ02OQ01.lean",
     "badge": "research",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Nat.choose_succ_succ",
@@ -30,13 +30,13 @@
       "gaussBinom_eq_zero_of_lt: vanishing property [n choose k]_q = 0 when k > n",
       "gaussBinom_self: [n choose n]_q = 1 for all n",
       "gaussBinom_one: classical limit — [n choose k]_1 = C(n,k)",
-      "q_vandermonde: main identity (1 sorry for inductive step Finset.sum manipulation)",
+      "q_vandermonde: main identity — fully proved via q-Pascal split and per-term identity lemma",
       "vandermonde_from_q: classical Vandermonde as corollary via q=1 specialization"
     ],
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
     "lineCount": 154,
-    "assumptions": "1 sorry in q_vandermonde inductive step (Finset.sum reindexing). All other theorems fully proved.",
+    "assumptions": "0 sorries. All 6 theorems fully proved including q_vandermonde (inductive step completed via per-term identity lemma and Finset.sum manipulation).",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -92,7 +92,7 @@
     {
       "id": "q-vandermonde",
       "title": "q-Vandermonde Identity",
-      "summary": "Main result: [m+n choose r]_q = Σ_{k=0}^r [m choose k]_q · [n choose r-k]_q · q^(k·(n+k-r)). Proof by induction on n; inductive step left as sorry (Finset.sum reindexing).",
+      "summary": "Main result: [m+n choose r]_q = Σ_{k=0}^r [m choose k]_q · [n choose r-k]_q · q^(k·(n+k-r)). Proof by induction on n; inductive step completed via per-term identity lemma (q_vand_step_term) and Finset.sum manipulation. 0 sorries.",
       "startLine": 108,
       "endLine": 130,
       "mathContext": "Base ($n=0$): the sum collapses to the $k=r$ term since $\\binom{0}{r-k}_q = 0$ for $k < r$. Inductive step: apply the q-Pascal rule to $\\binom{m+n+1}{r}_q$, use IH on both components, and match exponents. The exponent arithmetic: $q^{(k)(n+1+k-r)} = q^{k(n+k-r)} \\cdot q^k$ on the LHS contribution vs. $q^{k(n+k-(r-1))} = q^{k(n+k-r+1)} = q^{k(n+k-r)} \\cdot q^k$ on the RHS — they match after reindexing."
@@ -107,7 +107,7 @@
     }
   ],
   "conclusion": {
-    "summary": "6 theorems proved (5 without sorry, 1 with sorry for the inductive step of q_vandermonde). The Gaussian binomial infrastructure is new to this gallery: definition, vanishing, self-choice, and classical limit are all fully proved. The q-Vandermonde identity is stated with the correct formulation and the inductive step is documented; the remaining sorry is the Finset.sum reindexing step.",
+    "summary": "6 theorems fully proved (0 sorries). The Gaussian binomial infrastructure is new to this gallery: definition, vanishing, self-choice, classical limit, q-Vandermonde identity, and classical Vandermonde corollary are all machine-verified. The q_vandermonde inductive step was completed via a per-term identity lemma and Finset.sum manipulation.",
     "implications": "**Theoretical Significance**: Gaussian binomials [n choose k]_q are ubiquitous in combinatorics and representation theory. This formalization provides a foundation for q-analogs of other binomial identities: the q-binomial theorem, the q-Chu-Vandermonde identity, and generating functions for set-valued tableaux.\n\n**Practical**: The gaussBinom definition can serve as infrastructure for formalizing quantum group representations, counting formulas in algebraic combinatorics, and the theory of basic hypergeometric series in Lean 4.",
     "openQuestions": [
       "Can the inductive step of q_vandermonde be completed by proving the q-Pascal identity in its P2 form and then using Finset.sum_range_succ manipulations?",
@@ -144,7 +144,7 @@
     "theoremCount": 6,
     "definitionCount": 1,
     "path": "Proofs/BinomialTheoremOQ04OQ02OQ01.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-476-oq-05/meta.json
+++ b/src/data/proofs/erdos-476-oq-05/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-476-oq-05",
   "title": "Erdős #476 OQ5: Vosper's Theorem — Equality Case of Cauchy-Davenport",
   "slug": "erdos-476-oq-05",
-  "description": "Vosper's theorem (1956): if |A+B| = |A|+|B|-1 in Z/pZ with |A|,|B|≥2 and |A+B|<p, then A and B are arithmetic progressions with the same common difference d. Infrastructure fully proved: IsArithmeticProgression definition, singleton/pair AP lemmas, translation invariance, ap_of_near_periodic (backward-shift induction), and vosper_base (|A|=2 case). Full Vosper induction (1 sorry) remains open.",
+  "description": "Vosper's theorem (1956): if |A+B| = |A|+|B|-1 in Z/pZ with |A|,|B|≥2 and |A+B|<p, then A and B are arithmetic progressions with the same common difference d. Infrastructure fully proved: IsArithmeticProgression definition, singleton/pair AP lemmas, translation invariance, ap_of_near_periodic (backward-shift induction), and vosper_base (|A|=2 case). Full Vosper induction (2 sorries) remains open.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-21",
@@ -18,10 +18,10 @@
       "zmod"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 2,
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "assumptions": "1 sorry: vosper — full Vosper theorem by induction on |A|. Both ap_of_near_periodic (backward-shift induction) and vosper_base (|A|=2 case) are now fully proved. Infrastructure (IsArithmeticProgression, isAP_singleton, isAP_pair, isAP_shift, shift_card_eq) all proved with 0 sorries.",
+    "assumptions": "2 sorries in vosper theorem: [SORRY 1/2] Case 1 existence (counting argument for removing an element from A) and [SORRY 2/2] AP extension (a₀ adjacent to A' implies A is AP with same difference d). Both ap_of_near_periodic (backward-shift induction) and vosper_base (|A|=2 case) are fully proved. Infrastructure all proved with 0 sorries.",
     "lineCount": 306,
     "theoremCount": 8,
     "definitionCount": 1,
@@ -33,7 +33,7 @@
       "shift_card_eq: |B.image (·+d)| = |B| via add_right_injective (proved, 0 sorries)",
       "ap_of_near_periodic: B is AP if |B\\(B+d)|=1 (proved — backward-shift induction)",
       "vosper_base: Vosper for |A|=2 (proved — uses ap_of_near_periodic)",
-      "vosper: full Vosper theorem (1 sorry — induction on |A|)"
+      "vosper: full Vosper theorem (2 sorries — Case 1 existence and AP extension in induction on |A|)"
     ]
   },
   "overview": {
@@ -56,7 +56,7 @@
     ]
   },
   "conclusion": {
-    "summary": "Infrastructure for Vosper's theorem fully established and mostly proved: IsArithmeticProgression defined, basic AP lemmas proved (singleton, pair, shift, cardinality), ap_of_near_periodic proved (backward-shift induction), vosper_base proved (|A|=2 case). One sorry remains: the full Vosper induction on |A|.",
+    "summary": "Infrastructure for Vosper's theorem fully established and mostly proved: IsArithmeticProgression defined, basic AP lemmas proved (singleton, pair, shift, cardinality), ap_of_near_periodic proved (backward-shift induction), vosper_base proved (|A|=2 case). Two sorries remain in the full Vosper induction: Case 1 existence (counting/iterative removal) and AP extension (a₀ adjacent to A' forces A to be AP).",
     "implications": "Once ap_of_near_periodic is formalized (the backward-shift induction), the full Vosper theorem follows from standard induction. Vosper's theorem would then complement ZMod.cauchy_davenport in Mathlib, completing the picture of additive structure in Z/pZ.",
     "openQuestions": [
       "Formalize ap_of_near_periodic: B is an AP if |B \\ (B+d)| = 1 (needs backward-shift induction on |B|)",
@@ -111,7 +111,7 @@
       "title": "Vosper's Theorem: Base Case and Full Induction",
       "startLine": 128,
       "endLine": 165,
-      "summary": "vosper_base (|A|=2, inclusion-exclusion → ap_of_near_periodic, fully proved), vosper (strong induction on |A|, 1 sorry). vosper_base now proved; only the full induction remains open."
+      "summary": "vosper_base (|A|=2, inclusion-exclusion → ap_of_near_periodic, fully proved), vosper (strong induction on |A|, 2 sorries: Case 1 existence and AP extension). vosper_base now proved; two specific sub-goals in the induction remain open."
     }
   ],
   "leanFile": {
@@ -121,7 +121,7 @@
     "theoremCount": 8,
     "definitionCount": 1,
     "path": "Proofs/Erdos476OQ05Problem.lean",
-    "sorries": 1
+    "sorries": 2
   },
-  "sorries": 1
+  "sorries": 2
 }


### PR DESCRIPTION
## Gallery Integrity Fixes

Two sorry count mismatches corrected by gallery auditor.

### binomial-theorem-oq-04-oq-02-oq-01
- **Issue**: `sorries: 1` claimed, actual Lean file has 0 sorries
- **Cause**: `q_vandermonde` sorry was resolved (likely by Aristotle) but meta.json was not updated at merge time
- **Fix**: `sorries: 1 → 0`, `status: formalized → verified`; updated `assumptions`, `originalContributions`, `conclusion.summary`, and section summary

### erdos-476-oq-05
- **Issue**: `sorries: 1` claimed, actual Lean file has 2 sorries
- **Cause**: Today's research commit (c303ecc) split the vosper inductive step into 2 specific labeled sorries ([SORRY 1/2] Case 1 existence, [SORRY 2/2] AP extension); meta.json still reflected the pre-split count
- **Fix**: `sorries: 1 → 2`; updated `assumptions`, `originalContributions`, `conclusion.summary`, and section summary with specific sorry descriptions

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)