### PR TITLE
Audit: batch re-audit 2026-04-22 — 9 proofs all clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -47,9 +47,9 @@
       "result": "clean"
     },
     "amgm-inequality": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T11:08:13Z",
+      "lastAudited": "2026-04-22T09:12:17Z",
       "result": "clean"
     },
     "amgm-inequality-oq-02": {
@@ -2945,9 +2945,9 @@
       "result": "clean"
     },
     "erdos-115-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T11:22:57Z",
+      "lastAudited": "2026-04-22T09:12:54Z",
       "result": "clean"
     },
     "erdos-1150": {
@@ -5939,9 +5939,9 @@
     },
     "erdos-519": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:44:42Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-22T09:11:33Z",
+      "result": "clean"
     },
     "erdos-52": {
       "agentId": "auditor-cycle-20-batch",
@@ -10580,9 +10580,9 @@
       "result": "clean"
     },
     "schroeder-bernstein-oq-04": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T11:25:05Z",
+      "lastAudited": "2026-04-22T09:13:58Z",
       "result": "clean"
     },
     "shannon-channel-coding": {
@@ -10676,9 +10676,9 @@
       "result": "clean"
     },
     "solution-of-cubic-oq-03-oq-05": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T11:23:23Z",
+      "lastAudited": "2026-04-22T09:13:20Z",
       "result": "clean"
     },
     "sophie-germain": {
@@ -10766,9 +10766,9 @@
       "result": "clean"
     },
     "sum-of-kth-powers": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T11:24:36Z",
+      "lastAudited": "2026-04-22T09:13:41Z",
       "result": "clean"
     },
     "sum-of-kth-powers-oq-02": {
@@ -10850,9 +10850,9 @@
       "result": "clean"
     },
     "taylor-sincos-convergence-oq-03": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-03T11:22:28Z",
+      "lastAudited": "2026-04-22T09:12:35Z",
       "result": "clean"
     },
     "taylor-theorem": {
@@ -11005,9 +11005,9 @@
       ]
     },
     "yang-mills-2d": {
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-04-03T10:22:07Z",
+      "lastAudited": "2026-04-22T09:11:12Z",
       "result": "clean"
     },
     "yang-mills-2d-oq-01": {
@@ -11023,15 +11023,15 @@
       "result": "clean"
     },
     "yang-mills-lattice": {
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-04-03T10:22:07Z",
+      "lastAudited": "2026-04-22T09:10:59Z",
       "result": "clean"
     },
     "yang-mills-transfer-matrix": {
-      "auditCount": 6,
+      "auditCount": 9,
       "issues": [],
-      "lastAudited": "2026-04-03T10:22:07Z",
+      "lastAudited": "2026-04-22T09:10:45Z",
       "result": "clean"
     },
     "abel-ruffini-galois-extensions": {


### PR DESCRIPTION
## Audit Results

Batch re-audit of the 9 highest-priority targets from the audit queue (oldest last-audited proofs). All proofs passed integrity checks.

### Proofs Audited

| Proof | Lean File | Sorry Count | Axiom Count | Status | Badge | Result |
|-------|-----------|-------------|-------------|--------|-------|--------|
| yang-mills-transfer-matrix | YangMills/Exploration.lean | 0 ✓ | 1 ✓ | axiomatized | axiom | **clean** |
| yang-mills-lattice | YangMills/Exploration.lean | 0 ✓ | 1 ✓ | axiomatized | axiom | **clean** |
| yang-mills-2d | YangMills/Exploration.lean | 0 ✓ | 1 ✓ | axiomatized | axiom | **clean** |
| erdos-519 | Erdos519Problem.lean | 0 ✓ | 2 ✓ | axiomatized | axiom | **clean** |
| amgm-inequality | AMGMInequality.lean | 0 ✓ | 0 ✓ | verified | mathlib | **clean** |
| taylor-sincos-convergence-oq-03 | TaylorSinCosConvergenceOQ03.lean | 3 ✓ | 0 ✓ | formalized | wip | **clean** |
| erdos-115-oq-01 | Erdos115OQ01Problem.lean | 0 ✓ | 11 ✓ | axiomatized | axiom | **clean** |
| solution-of-cubic-oq-03-oq-05 | SolutionOfCubicOQ03OQ05.lean | 0 ✓ | 0 ✓ | verified | original | **clean** |
| sum-of-kth-powers | SumOfKthPowers.lean | 0 ✓ | 0 ✓ | verified | original | **clean** |
| schroeder-bernstein-oq-04 | SchroederBernsteinOQ04.lean | 0 ✓ | 0 ✓ | verified | original | **clean** |

### Checks Performed

- Sorry count: verified against `git show HEAD:file | grep -c "sorry"`
- Axiom count: verified against `git show HEAD:file | grep "^axiom "` + structure-encoded True fields
- True stubs: checked for `:= trivial`, `: True :=`, `: True\b` patterns
- Badge/status consistency: verified tier classification matches Lean source

### Notes

- Yang-Mills proofs (3 entries) all share `YangMills/Exploration.lean` (28,075 lines). The True structure fields in that file are properly disclosed in the `assumptions` field. Status "axiomatized" + badge "axiom" is correct for Millennium Prize context.
- `amgm-inequality`: dual-path proof correctly uses `verified`+`mathlib` — original 2-variable proof is independently proven via `(√a−√b)²≥0`, while weighted general case delegates to Mathlib.
- `erdos-519`: 2 explicit axioms (`atkinson_theorem`, `biro_2000`) match claimed axiomCount.
- `erdos-115-oq-01`: 11 explicit axioms all verified present in file.

---
Generated by lean-auditor agent