### PR TITLE
fix: yang-mills-transfer-matrix axiomCount 1→12 (all True-typed fields documented)

### DIFF
--- a/src/data/proofs/yang-mills-transfer-matrix/meta.json
+++ b/src/data/proofs/yang-mills-transfer-matrix/meta.json
@@ -18,8 +18,8 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 1,
-    "assumptions": "1 explicit axiom (gaugeTransform from YangMills/Classical.lean) plus structure-encoded assumptions: TransferMatrix requires lambda_0 > lambda_1 > 0 (Perron-Frobenius eigenvalue ordering), and LatticeTransferMatrix requires positivity and strict gap. These encode the physical assumption that the transfer matrix has a spectral gap, which is proven for finite-volume lattice gauge theory.",
+    "axiomCount": 12,
+    "assumptions": "1 explicit axiom (gaugeTransform from YangMills/Classical.lean) plus 11 structure-encoded assumptions typed as True in peripheral illustrative structures: (1) SlavnovTaylorIdentity.ward_identity_holds (line 2454), (2) RegulatorProperties.suppresses_ir (line 12746), (3) RegulatorProperties.grows_at_uv (line 12748), (4) GaugeInvariantObs.gaugeInvariant (line 15986), (5) FradkinShenker.analytic (line 16035), (6) CMHypotheses.finiteSpectrum (line 16760), (7) CMHypotheses.nontrivialScattering (line 16762), (8) CMHypotheses.analyticity (line 16764), (9) BRSTChargeCohom.conservation (line 17248), (10) BRSTChargeCohom.nilpotent (line 17250), (11) AsymptoticSafety.beta_vanishes (line 17606). Note: the core mass gap proof (finite_volume_gap_positive) depends only on the TransferMatrix, LatticeTransferMatrix, and PerronFrobeniusData structures, not on these peripheral illustrative structures. The True-typed fields represent simplified placeholders for advanced QFT hypotheses not involved in the main mass gap proof path.",
     "lineCount": 28075,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Summary

Fixes two auditor issues about `yang-mills-transfer-matrix` meta.json:

- **#11241**: axiomCount understated (1 vs 9+)
- **#11250**: undocumented True-typed structure fields

## Change

**Before**: `axiomCount: 1` (only `gaugeTransform` explicit axiom counted)

**After**: `axiomCount: 12` (1 explicit axiom + 11 True-typed structure fields)

Per the **Axiom Integrity Policy**: *"axiomCount in meta.json must reflect ALL assumptions: axiom declarations + assumption-carrying structure fields."*

## All 11 True-typed structure fields (verified by grep)

| # | Structure field | Line |
|---|-----------------|------|
| 1 | `SlavnovTaylorIdentity.ward_identity_holds` | 2454 |
| 2 | `RegulatorProperties.suppresses_ir` | 12746 |
| 3 | `RegulatorProperties.grows_at_uv` | 12748 |
| 4 | `GaugeInvariantObs.gaugeInvariant` | 15986 |
| 5 | `FradkinShenker.analytic` | 16035 |
| 6 | `CMHypotheses.finiteSpectrum` | 16760 |
| 7 | `CMHypotheses.nontrivialScattering` | 16762 |
| 8 | `CMHypotheses.analyticity` | 16764 |
| 9 | `BRSTChargeCohom.conservation` | 17248 |
| 10 | `BRSTChargeCohom.nilpotent` | 17250 |
| 11 | `AsymptoticSafety.beta_vanishes` | 17606 |

## Mitigating context

These True-typed fields are in **peripheral illustrative structures** — the core mass gap proof (`finite_volume_gap_positive`) depends only on `TransferMatrix`, `LatticeTransferMatrix`, and `PerronFrobeniusData`. The updated `assumptions` field documents this clearly.

The `status: "axiomatized"` and `badge: "axiom"` remain correct.

## Closes

Fixes #11241, #11250