### PR TITLE
feat: Aristotle companion file for Erdős #877 (maximal sum-free sets)

### DIFF
--- a/proofs/Proofs/Erdos877ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos877ProblemAristotle.lean
@@ -1,0 +1,94 @@
+/-
+  Aristotle targets for Erdos877Problem (Erdős #877: Maximal Sum-Free Subsets)
+  Routine supporting lemmas for automated proof search.
+  See Erdos877Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main open problem (f_m(n) asymptotics)
+  - NOT results depending on deep axioms (Łuczak-Schoen, Cameron-Erdős)
+  - Structural/constructive results provable by elementary finite combinatorics
+  - No definition sorries, no axioms
+
+  Targets:
+  1. maximal_criterion': Logical consequence of isMaximalSumFree definition.
+     Every x ∉ A in a maximal sum-free set must be "covered" by A:
+     either x = a+b, or a = x+b, or x+x = a for some a,b ∈ A.
+     Proof strategy:
+     - From isMaximalSumFree: ¬isSumFree (insert x A)
+     - Unpack: ∃ p q r ∈ insert x A with p = q + r
+     - Since A is sum-free, x must appear among p,q,r
+     - Case p = x: x = q + r with q,r ∈ A → first disjunct
+     - Case q = x: p = x + r with p,r ∈ A → second disjunct
+     - Case r = x: p = q + x → a = x + b for a=p,b=q; or x+x=a if q=x too
+
+  2. odds_construction': Existence of a sum-free set of size ≥ n/2 in {0,...,n}.
+     Witness: (Finset.range (n+1)).filter (fun x => x % 2 = 1)  [odd numbers]
+     Sum-free proof: if a%2=1 and b%2=1, then (a+b)%2=0, so a+b not in filter.
+     Size proof: count of odd numbers in {0,...,n} equals (n+1)/2 ≥ n/2 (Nat div).
+     Tactic hint: induction on n; the filter size for Finset.range (n+2) is
+     1 + (filter size for range (n+1)) when n is even, or same when n is odd.
+
+  Excluded (deep results, not Aristotle targets):
+  - maximal_vs_all: requires Cameron-Erdős + Łuczak-Schoen axioms
+  - erdos_877: main theorem, assembles the axioms
+  - f_m_le_f: already sorry-free in the main file
+-/
+import Mathlib
+import Proofs.Erdos877Problem
+
+namespace Erdos877.Aristotle
+
+open Erdos877 Finset Nat
+
+-- ============================================================
+-- Aristotle Target 1: Maximal criterion
+-- ============================================================
+
+/-- **Maximal criterion** (Aristotle target):
+    For a maximal sum-free A ⊆ {0,...,n} and x ∈ {0,...,n} with x ∉ A,
+    x is covered by A in one of three ways:
+    - x = a + b (x is a sum of A-elements)
+    - a = x + b (x is a summand for an A-element)
+    - x + x = a (x is the double source of an A-element)
+
+    Proof sketch:
+    1. hmax.2.2 gives ¬isSumFree (insert x A)
+    2. push_neg yields ∃ p q r ∈ insert x A, p = q + r
+    3. Since A is sum-free (hmax.2.1), not all of p,q,r are in A; so x ∈ {p,q,r}
+    4. Cases on which of p,q,r equals x:
+       · p = x: then x = q + r; if q,r ∈ A: first disjunct. Otherwise recurse.
+       · q = x: then p = x + r; if p,r ∈ A: second disjunct.
+       · r = x: then p = q + x; if p,q ∈ A: second disjunct (a=p,b=q from heq).
+         If q = x also: x + x = p → third disjunct. -/
+theorem maximal_criterion' (n : ℕ) (A : Finset ℕ)
+    (hmax : isMaximalSumFree n A) (x : ℕ) (hx : x ∈ Finset.range (n + 1))
+    (hxA : x ∉ A) :
+    (∃ a b : ℕ, a ∈ A ∧ b ∈ A ∧ x = a + b) ∨
+    (∃ a b : ℕ, a ∈ A ∧ b ∈ A ∧ a = x + b) ∨
+    (∃ a : ℕ, a ∈ A ∧ x + x = a) := by
+  sorry
+
+-- ============================================================
+-- Aristotle Target 2: Odds construction
+-- ============================================================
+
+/-- **Odds construction** (Aristotle target):
+    For any n, the odd numbers in {0,...,n} form a sum-free set with ≥ n/2 elements.
+    Witness: (Finset.range (n+1)).filter (· % 2 = 1)
+
+    Sum-free proof:
+    Suppose a, b, c are in the odd-filter (a%2=1, b%2=1, c%2=1) and a = b + c.
+    Then a % 2 = (b + c) % 2 = (1 + 1) % 2 = 0. But a % 2 = 1. Contradiction. omega.
+
+    Size ≥ n/2 proof:
+    The count of odd numbers in {0,...,n} equals (n+1)/2 (Nat division).
+    Since (n+1)/2 ≥ n/2 for all n : ℕ (one is at least as large as the other), done.
+    Alternatively: (n+1)/2 ≥ n/2 follows from omega after establishing the count. -/
+theorem odds_construction' (n : ℕ) :
+    ∃ A : Finset ℕ,
+      A ⊆ Finset.range (n + 1) ∧
+      isSumFree A ∧
+      A.card ≥ n / 2 := by
+  sorry
+
+end Erdos877.Aristotle


### PR DESCRIPTION
## Fix

Add Aristotle companion file for Erdős #877 (maximal sum-free sets).

## Evidence

**Before**: No Aristotle targets for Erdős #877 despite two routine provable supporting lemmas.

**After**: `proofs/Proofs/Erdos877ProblemAristotle.lean` with two targets:
1. `maximal_criterion'` — logical consequence of `isMaximalSumFree` definition: any x ∉ A in a maximal sum-free set is covered by A (x=a+b, a=x+b, or x+x=a)
2. `odds_construction'` — constructive existence: odd numbers in {0,...,n} form a sum-free set with ≥ n/2 elements

Both are elementary combinatorics, suitable for automated proof search. Pre-submission checklist verified:
- No `def ... := sorry`
- No `axiom` declarations
- No `theorem ... : True` placeholders
- No `/-!` docstring sections
- No open conjectures

---
Automated fix by lean-mechanic agent.