### PR TITLE
Audit: ballot-problem-oq-03-oq-01-oq-02 sorry count 3→4

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -19,10 +19,10 @@
       "representation-theory"
     ],
     "badge": "wip",
-    "sorries": 3,
+    "sorries": 4,
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "assumptions": "Three open sorries: (1) hook_length_formula (requires SYT↔NI bijection + det factorization), (2) ni_count_eq_syt_count (Fomin/Viennot/RSK correspondence), (3) lgv_det_factors_as_hook_quotient (det factorization identity). StandardYoungTableau.ext is now fully proved (funext).",
+    "assumptions": "Four open sorries: (1) hook_length_formula (requires SYT↔NI bijection + det factorization), (2) ni_count_eq_syt_count (Fomin/Viennot/RSK correspondence), (3) lgv_det_factors_as_hook_quotient (det factorization identity), (4) card_SYT_twoRectYD (SYT count for 2-row rectangular = Catalan number C_m via ballot bijection). StandardYoungTableau.ext is now fully proved (funext).",
     "lineCount": 676,
     "theoremCount": 12,
     "definitionCount": 5,
@@ -60,7 +60,7 @@
     ]
   },
   "conclusion": {
-    "summary": "Hook-length formula infrastructure established: hookLength, hookProd, StandardYoungTableau defined; positivity and ext proved; LGV encoding described; formula verified numerically for 8 specific shapes; 2-row formula proved via OQ03OQ03. Main theorem stated with 3 sorries identifying the two deep open components (SYT↔NI bijection and det factorization).",
+    "summary": "Hook-length formula infrastructure established: hookLength, hookProd, StandardYoungTableau defined; positivity and ext proved; LGV encoding described; formula verified numerically for 8 specific shapes. Main theorem stated with 4 sorries: hook_length_formula, ni_count_eq_syt_count, lgv_det_factors_as_hook_quotient (two deep open components requiring SYT↔NI bijection and det factorization), and card_SYT_twoRectYD (2-row rectangular SYT count = Catalan number).",
     "implications": "A complete formalization would be the first Lean 4 proof of the hook-length formula, a milestone in formal combinatorics. The LGV approach connects our existing ballot problem proofs to representation theory via the Specht module dimension formula f^λ = dim S^λ.",
     "openQuestions": [
       "Formalize the SYT ↔ NI bijection via Fomin's growth diagrams or the RSK correspondence (~200 lines)",
@@ -81,7 +81,7 @@
     "namespace": "HookLengthFormula",
     "lineCount": 676,
     "axiomCount": 0,
-    "sorries": 3,
+    "sorries": 4,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",
     "theoremCount": 12,
     "definitionCount": 5
@@ -146,7 +146,7 @@
       "title": "Parts V-VI: Main Theorems",
       "startLine": 180,
       "endLine": 210,
-      "summary": "hook_length_formula_2row_rect (proved via OQ03OQ03), hook_length_formula (sorry), ni_count_eq_syt_count (sorry), lgv_det_factors_as_hook_quotient (sorry).",
+      "summary": "hook_length_formula_2row_rect (proved via OQ03OQ03), hook_length_formula (sorry), ni_count_eq_syt_count (sorry), lgv_det_factors_as_hook_quotient (sorry), card_SYT_twoRectYD (sorry — SYT count for 2-row rect = C_m).",
       "mathContext": "Main theorem: card(SYT(μ)) × hookProd μ = μ.card!. The two sorry components require ~200 lines each."
     },
     {
@@ -158,5 +158,5 @@
       "mathContext": "Verified: (2,1)→2, (2,2)→2, (3,1)→3, (3,2)→5, (3,2,1)→16, (4,3,2,1)→1440, (3,3)→5 (C₃), (4,4)→14 (C₄)."
     }
   ],
-  "sorries": 3
+  "sorries": 4
 }


### PR DESCRIPTION
## Integrity Fix

**Proof**: ballot-problem-oq-03-oq-01-oq-02 (Hook-Length Formula for SYT via LGV)
**Issue**: sorry count mismatch — meta.json claimed 3, Lean file has 4

## Evidence

**meta.json claimed**: `"sorries": 3` with assumptions listing 3 named sorries
**Lean file shows**: 4 sorry statements at lines 219, 235, 245, 1243

The 4th sorry (`card_SYT_twoRectYD`) was added in Session 5 to prove that the SYT count for 2-row rectangular Young diagrams equals the Catalan number C_m via ballot bijection. This was added to `hook_length_formula_two_rect` but meta.json was not updated.

## Changes

- `meta.sorries`: 3 → 4
- `leanFile.sorries`: 3 → 4
- Top-level `sorries`: 3 → 4
- `assumptions`: updated to list all 4 open sorries including `card_SYT_twoRectYD`
- `conclusion.summary`: updated to mention 4 sorries and correct description
- `sections[sec-main-theorem].summary`: added `card_SYT_twoRectYD` sorry

🤖 Generated with [Claude Code](https://claude.com/claude-code)