### PR TITLE
Audit: fix cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01 sorry count 3→2

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -14,10 +14,10 @@
       "measure-theory"
     ],
     "badge": "wip",
-    "sorries": 3,
+    "sorries": 2,
     "axiomCount": 0,
-    "lineCount": 810,
-    "assumptions": "3 remaining sorries: (1) truncated_rn_deriv_lq_bound — eLpNorm of truncated RN derivative bounded by M for finite measure; (2) indicator_lp_hasSum — indicator functions form a HasSum in Lp for countably disjoint sets; (3) holder_extremizer_lq_bound — eLpNorm of truncated RN derivative bounded by ‖φ‖. See Lean source for details.",
+    "lineCount": 882,
+    "assumptions": "2 remaining sorries: (1) truncated_rn_deriv_lq_bound — eLpNorm of truncated RN derivative bounded by M for finite measure (dead path, marked FALSE in source); (2) holder_extremizer_lq_bound — eLpNorm of truncated RN derivative bounded by ‖φ‖ via Hölder extremizer argument (~100 lines). indicator_lp_hasSum proved in session 4 (PR #11269). See Lean source for details.",
     "dateAdded": "2026-04-13"
   },
   "overview": {
@@ -106,7 +106,7 @@
     "imports": [
       "Mathlib"
     ],
-    "lineCount": 810,
+    "lineCount": 882,
     "axiomCount": 0,
     "theoremCount": 15,
     "definitionCount": 2,
@@ -133,7 +133,7 @@
       }
     ],
     "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-    "sorries": 3
+    "sorries": 2
   },
-  "sorries": 3
+  "sorries": 2
 }


### PR DESCRIPTION
## Summary

- `indicator_lp_hasSum` was proved in PR #11269 (session 4), reducing the file from 3 to 2 actual sorry statements
- PR #11269 updated research progress files but not the gallery meta.json
- Also corrects stale `lineCount`: 810 → 882

## Evidence

**meta.json claimed**: `sorries: 3`, `lineCount: 810`
**Lean file shows**: 2 sorry statements (`truncated_rn_deriv_lq_bound` and `holder_extremizer_lq_bound`), 882 lines

## Changes

- `meta.sorries`: 3 → 2
- `leanFile.sorries`: 3 → 2
- `sorries` (top-level): 3 → 2
- `meta.lineCount`: 810 → 882
- `leanFile.lineCount`: 810 → 882
- `meta.assumptions`: Updated to remove proved `indicator_lp_hasSum`, accurately describe 2 remaining sorries

---
Discovered during gallery integrity audit.