### PR TITLE
Audit: cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01 sorry count 3→2

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12414,8 +12414,8 @@
       "issues": []
     },
     "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01": {
-      "auditCount": 7,
-      "lastAudited": "2026-04-21T11:53:37Z",
+      "auditCount": 8,
+      "lastAudited": "2026-04-22T10:02:29Z",
       "result": "issues-fixed",
       "issues": []
     },

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -14,10 +14,10 @@
       "measure-theory"
     ],
     "badge": "wip",
-    "sorries": 3,
+    "sorries": 2,
     "axiomCount": 0,
     "lineCount": 810,
-    "assumptions": "3 remaining sorries: (1) truncated_rn_deriv_lq_bound — eLpNorm of truncated RN derivative bounded by M for finite measure; (2) indicator_lp_hasSum — indicator functions form a HasSum in Lp for countably disjoint sets; (3) holder_extremizer_lq_bound — eLpNorm of truncated RN derivative bounded by ‖φ‖. See Lean source for details.",
+    "assumptions": "2 remaining sorries: (1) truncated_rn_deriv_lq_bound — eLpNorm of truncated RN derivative bounded by M for finite measure (dead path, marked false in session 4); (2) holder_extremizer_lq_bound — eLpNorm of truncated RN derivative bounded by ‖φ‖ (the critical remaining sorry). indicator_lp_hasSum was proved in session 4 (2026-04-22). See Lean source for details.",
     "dateAdded": "2026-04-13"
   },
   "overview": {
@@ -133,7 +133,7 @@
       }
     ],
     "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-    "sorries": 3
+    "sorries": 2
   },
-  "sorries": 3
+  "sorries": 2
 }


### PR DESCRIPTION
## Audit Fix

**Proof**: cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01 (Radon-Nikodým Route to Lp Duality)
**Issue**: meta.json claimed 3 sorries; Lean source has 2

## Evidence

**meta.json claimed**: `"sorries": 3` with assumptions listing `truncated_rn_deriv_lq_bound`, `indicator_lp_hasSum`, and `holder_extremizer_lq_bound`

**Lean file shows**: 2 actual `sorry` tactic uses (lines 209 and 776). `indicator_lp_hasSum` was fully proved in session 4 (2026-04-22, ~80 lines of Lp topology).

## Fix

- `meta.sorries`: 3 → 2
- `leanFile.sorries`: 3 → 2  
- Root `sorries`: 3 → 2
- `assumptions` text: removed `indicator_lp_hasSum`, noted it was proved; clarified `truncated_rn_deriv_lq_bound` is a dead path

---
Discovered during gallery integrity audit.