### PR TITLE
Fix: sync sorry counts in 3 gallery meta.json files

### DIFF
--- a/src/data/proofs/area-of-circle-oq-05-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-02/meta.json
@@ -116,5 +116,6 @@
       "Does Mathlib's `MeasurePreserving.integral_comp'` provide the right API for `∫ f(Uᵀx) = ∫ f(y)` when U is orthogonal?",
       "Can the result be extended to the complex case (Hermitian positive-definite matrices over ℂ)?"
     ]
-  }
+  },
+  "sorries": 1
 }

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -14,10 +14,10 @@
       "measure-theory"
     ],
     "badge": "wip",
-    "sorries": 3,
+    "sorries": 2,
     "axiomCount": 0,
     "lineCount": 810,
-    "assumptions": "3 remaining sorries: (1) truncated_rn_deriv_lq_bound — eLpNorm of truncated RN derivative bounded by M for finite measure; (2) indicator_lp_hasSum — indicator functions form a HasSum in Lp for countably disjoint sets; (3) holder_extremizer_lq_bound — eLpNorm of truncated RN derivative bounded by ‖φ‖. See Lean source for details.",
+    "assumptions": "2 remaining sorries: (1) truncated_rn_deriv_lq_bound — eLpNorm of truncated RN derivative bounded by M for finite measure; (2) holder_extremizer_lq_bound — eLpNorm of truncated RN derivative bounded by ‖φ‖. (indicator_lp_hasSum was proved in Session 6.) See Lean source for details.",
     "dateAdded": "2026-04-13"
   },
   "overview": {
@@ -133,7 +133,7 @@
       }
     ],
     "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-    "sorries": 3
+    "sorries": 2
   },
-  "sorries": 3
+  "sorries": 2
 }

--- a/src/data/proofs/szemeredi-hypergraph-core-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/szemeredi-hypergraph-core-oq-01-incomplete-01/meta.json
@@ -159,5 +159,6 @@
       "venue": "Random Structures & Algorithms, 25(1), 1-42",
       "note": "First regularity lemma for k-uniform hypergraphs"
     }
-  ]
+  ],
+  "sorries": 1
 }


### PR DESCRIPTION
## Fix

Corrects `sorries` field in three gallery `meta.json` files where the count drifted from the actual Lean source.

## Evidence

**cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01**
- **Before**: `sorries: 3`, assumptions listed `indicator_lp_hasSum` as open
- **After**: `sorries: 2` — `indicator_lp_hasSum` was proved in #11269

**szemeredi-hypergraph-core-oq-01-incomplete-01**
- **Before**: top-level `sorries` field missing (treated as 0), actual Lean file has 1 sorry
- **After**: `sorries: 1` added at top level (meta.sorries and leanFile.sorries were already correct)

**area-of-circle-oq-05-oq-02**
- **Before**: top-level `sorries` field missing (treated as 0), actual Lean file has 1 sorry
- **After**: `sorries: 1` added at top level (meta.sorries was already 1)

## Validation

- `pnpm build` passes ✓
- Sorry count re-check confirms all three now match actual Lean source ✓

---
Automated fix by lean-mechanic agent.