### PR TITLE
Enrich proofs: Lawvere FPT, DFX lower bound, Erdős-Szekeres, Carmichael, Jacobi, FTA-EDs, Directed Hamiltonicity

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01/meta.json
@@ -56,9 +56,11 @@
       "**The categorical bridge**: lawvere_categorical is proved by adding e_pt : Pt A → Pt (exp A B) as a parameter (the Yoneda-level action of the morphism e : A → B^A on global elements) and constructing EvalStructure with Ob = Pt A, Val = Pt B, eval a x = apply (e_pt a) x. The proof then reduces to lawvere_abstract in one line. This is the minimal categorical data needed: e_pt is exactly what a 'point-surjective morphism' provides at the global-element level."
     ],
     "prerequisites": [
-      "Lawvere fixed-point theorem from CantorDiagonalizationOQ03",
-      "Diagonal argument and Cantor's theorem",
-      "Basic category theory: cartesian closed categories, exponentials"
+      "Lawvere fixed-point theorem in type theory (CantorDiagonalizationOQ03.lean)",
+      "Diagonal argument and Cantor's theorem: no surjection A → A → Prop",
+      "Basic category theory: cartesian closed categories (CCCs), exponential objects B^A, global elements 1 → B",
+      "Lean 4 type universe: Type u, Prop as subobject classifier, function types A → B as exponential hom-sets",
+      "Mathlib.Logic.Function.Basic: Function.Surjective, Function.Injective, funext/congr_fun for function extensionality"
     ]
   },
   "sections": [
@@ -139,24 +141,34 @@
   },
   "crossReferences": [
     {
-      "id": "cantor-diagonalization-oq-03",
+      "targetId": "cantor-diagonalization-oq-03",
       "relationship": "extends",
-      "description": "Parent: type-theoretic Lawvere FPT in the Lean type system. This file generalizes to abstract evaluation structures and the categorical setting."
-    },
-    {
-      "id": "schauder-fixed-point-oq-03",
-      "relationship": "related",
-      "description": "Kakutani fixed-point theorem — another fixed-point theorem in the gallery, topological rather than diagonal in nature, with different hypotheses and proof structure"
+      "description": "Parent: type-theoretic Lawvere FPT in the Lean type system (CantorDiagonalizationOQ03.lean). This file generalizes to abstract EvalStructure and the categorical CCC setting, proving lawvere_categorical by adding e_pt : Pt A → Pt (exp A B) as a global-element action parameter and reducing to lawvere_abstract."
     },
     {
       "targetId": "cantor-diagonalization",
       "relationship": "related",
-      "description": "The root entry for Cantor's diagonalization argument. This categorical generalization shows Cantor's theorem is a special case of Lawvere's abstract fixed-point theorem with Val=Prop and f=Not."
+      "description": "The root entry for Cantor's diagonalization argument. This categorical generalization shows Cantor's theorem (no surjection A → P(A)) is a special case of Lawvere's abstract fixed-point theorem with Val=Prop and f=Not — the `cantor_instance` and `cantor_recovery` theorems make this connection explicit."
     },
     {
       "targetId": "godel-incompleteness",
       "relationship": "related",
-      "description": "Gödel's incompleteness theorem uses a diagonal construction (the diagonalization lemma) that is a Lawvere instance with Val=sentences and f=negation-of-provability. This file's abstract theorem unifies both results."
+      "description": "Gödel's incompleteness theorem uses a diagonal construction (the diagonalization lemma) that is a Lawvere instance with Val=sentences and f=negation-of-provability. This file's abstract EvalStructure unifies Cantor and Gödel as instances of a single 2-line diagonal argument. An open question here asks for the Gödel derivation to be formalized explicitly as a Lawvere instance."
+    },
+    {
+      "targetId": "halting-problem",
+      "relationship": "related",
+      "description": "Turing's halting problem undecidability is a Lawvere instance: Val = {halt, loop}, f = 'swap' (no fixed point), and the 'universal evaluator' gives a point-surjective map if the halting problem were decidable. The abstract `no_surjection_abstract` theorem in this entry is the categorical statement of why no such universal evaluator can exist. Cantor, Gödel, and Turing are all recovered from the same 2-line diagonal proof."
+    },
+    {
+      "targetId": "schauder-fixed-point-oq-03",
+      "relationship": "related",
+      "description": "Kakutani Fixed-Point Theorem — a topological fixed-point theorem in contrast to the diagonal fixed-point theorem here. Kakutani requires convexity and continuity of a set-valued map; Lawvere requires only a point-surjective evaluation structure. The contrast illustrates that 'fixed-point theorem' is a vast umbrella: topological (Brouwer, Schauder, Kakutani), algebraic (Banach), and diagonal (Lawvere) results all guarantee fixed points via completely different mechanisms."
+    },
+    {
+      "targetId": "cantor-diagonalization-oq-03-oq-01-oq-01",
+      "relationship": "sibling",
+      "description": "Sibling OQ in the Lawvere chain — extends the categorical framework in a different direction. Together these siblings explore the full scope of the Lawvere OQ chain, each taking the abstract evaluation structure in a distinct direction."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Enrichment batch — 7 gallery entries

### cantor-diagonalization-oq-03-oq-01 (Lawvere Fixed-Point Theorem)
- Fix bug: 2 crossReferences used "id" instead of "targetId"
- Expand prerequisites (5 items); enrich 3 existing cross-refs
- New cross-refs: halting-problem (Turing as Lawvere instance), schauder-fixed-point-oq-03 (topological vs diagonal contrast), cantor-diagonalization-oq-03-oq-01-oq-01 (sibling)

### erdos-1-oq-02 (DFX Lower Bound)
- Expand proofStrategy from stub to 3-stage description
- Add 5th keyInsight: DFX vs Conway-Guy constant gap
- New cross-refs: cauchy-schwarz, central-limit-theorem

### erdos-1015-oq-05 (Erdős-Szekeres Bound / Axiom Elimination)
- Add prerequisites (5 items)
- New cross-refs: erdos-1015-oq-01 (sibling), ramseys-theorem-oq-04 (hypergraph extension)

### euler-totient-oq-01 (Carmichael's Function λ(n))
- Fix bug: crossReference used "lagranges-theorem" (should be "lagrange-theorem")
- Add prerequisites (5 items)
- New cross-refs: euler-totient-oq-02, euler-totient-oq-03

### elementary-quadratic-reciprocity-oq-03-oq-01-oq-02 (Certified Jacobi Computation)
- Add prerequisites (5 items)
- New cross-refs: kronecker symbol sibling, gcd-algorithm (structural parallel), elementary-quadratic-reciprocity (foundational)

### bezout-identity-oq-02-oq-01-oq-02 (FTA over Euclidean Domains)
- Fix bug: all 3 crossReferences used "id" instead of "targetId"
- Add prerequisites (5 items); new cross-refs: polynomial rings sibling, Gaussian integers, CRT

### erdos-1012-oq-03 (Directed Hamiltonian Cycles)
- Add prerequisites (5 items)
- New cross-refs: konigsberg-oq-02 (Eulerian vs Hamiltonian duality), konigsberg-oq-04 (BEST theorem counting contrast)
- Add 3rd open question: Meyniel's conjecture

Labels: enrichment