### PR TITLE
Audit: erdos-268 sorry count 1→2 (both in harmonicPointSet_path_connected)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1504,9 +1504,9 @@
       "result": "clean"
     },
     "dirichlets-theorem-oq-02": {
-      "auditCount": 5,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-22T10:39:13Z",
+      "lastAudited": "2026-04-03T11:26:08Z",
       "result": "clean"
     },
     "dirichlets-theorem-oq-02-oq-01": {
@@ -1785,9 +1785,9 @@
       "result": "issues-fixed"
     },
     "erdos-1006-oq-02-oq-03": {
-      "auditCount": 7,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-04-22T10:38:54Z",
+      "lastAudited": "2026-04-03T11:26:08Z",
       "result": "clean"
     },
     "erdos-1007": {
@@ -4191,8 +4191,8 @@
     },
     "erdos-268": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-22T10:13:48Z",
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T10:19:01Z",
       "result": "issues-fixed"
     },
     "erdos-269": {
@@ -10556,9 +10556,9 @@
       "result": "issues-fixed"
     },
     "schauder-fixed-point-oq-01": {
-      "auditCount": 6,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-22T10:38:39Z",
+      "lastAudited": "2026-04-03T11:26:09Z",
       "result": "clean"
     },
     "schauder-fixed-point-oq-03": {
@@ -12414,9 +12414,9 @@
       "issues": []
     },
     "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01": {
-      "auditCount": 8,
-      "lastAudited": "2026-04-22T10:02:29Z",
-      "result": "issues-fixed",
+      "auditCount": 10,
+      "lastAudited": "2026-04-22T10:09:47Z",
+      "result": "clean",
       "issues": []
     },
     "chinese-remainder-non-coprime-oq-03-oq-02": {

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -267,9 +267,9 @@
       "result": "clean"
     },
     "arithmetic-series-oq-02": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-03T11:25:05Z",
+      "lastAudited": "2026-04-22T10:30:47Z",
       "result": "clean"
     },
     "arithmetic-series-oq-02-oq-02": {
@@ -1394,9 +1394,9 @@
       "result": "clean"
     },
     "derangements-oq-02": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-04-03T11:26:08Z",
+      "lastAudited": "2026-04-22T10:30:48Z",
       "result": "clean"
     },
     "derangements-oq-02-oq-01": {
@@ -1504,9 +1504,9 @@
       "result": "clean"
     },
     "dirichlets-theorem-oq-02": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-03T11:26:08Z",
+      "lastAudited": "2026-04-22T10:30:48Z",
       "result": "clean"
     },
     "dirichlets-theorem-oq-02-oq-01": {
@@ -1785,9 +1785,9 @@
       "result": "issues-fixed"
     },
     "erdos-1006-oq-02-oq-03": {
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-04-03T11:26:08Z",
+      "lastAudited": "2026-04-22T10:30:48Z",
       "result": "clean"
     },
     "erdos-1007": {
@@ -10556,9 +10556,9 @@
       "result": "issues-fixed"
     },
     "schauder-fixed-point-oq-01": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-04-03T11:26:09Z",
+      "lastAudited": "2026-04-22T10:30:48Z",
       "result": "clean"
     },
     "schauder-fixed-point-oq-03": {

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12414,8 +12414,8 @@
       "issues": []
     },
     "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01": {
-      "auditCount": 7,
-      "lastAudited": "2026-04-21T11:53:37Z",
+      "auditCount": 8,
+      "lastAudited": "2026-04-22T10:02:29Z",
       "result": "issues-fixed",
       "issues": []
     },

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1504,9 +1504,9 @@
       "result": "clean"
     },
     "dirichlets-theorem-oq-02": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-03T11:26:08Z",
+      "lastAudited": "2026-04-22T10:39:13Z",
       "result": "clean"
     },
     "dirichlets-theorem-oq-02-oq-01": {
@@ -1785,9 +1785,9 @@
       "result": "issues-fixed"
     },
     "erdos-1006-oq-02-oq-03": {
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-04-03T11:26:08Z",
+      "lastAudited": "2026-04-22T10:38:54Z",
       "result": "clean"
     },
     "erdos-1007": {
@@ -10556,9 +10556,9 @@
       "result": "issues-fixed"
     },
     "schauder-fixed-point-oq-01": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-04-03T11:26:09Z",
+      "lastAudited": "2026-04-22T10:38:39Z",
       "result": "clean"
     },
     "schauder-fixed-point-oq-03": {

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -17,7 +17,7 @@
     "sorries": 2,
     "axiomCount": 0,
     "lineCount": 810,
-    "assumptions": "2 remaining sorries: (1) truncated_rn_deriv_lq_bound — eLpNorm of truncated RN derivative bounded by M for finite measure; (2) holder_extremizer_lq_bound — eLpNorm of truncated RN derivative bounded by ‖φ‖. (indicator_lp_hasSum was proved in Session 6.) See Lean source for details.",
+    "assumptions": "2 remaining sorries: (1) truncated_rn_deriv_lq_bound — eLpNorm of truncated RN derivative bounded by M for finite measure (dead path, marked false in session 4); (2) holder_extremizer_lq_bound — eLpNorm of truncated RN derivative bounded by ‖φ‖ (the critical remaining sorry). indicator_lp_hasSum was proved in session 4 (2026-04-22). See Lean source for details.",
     "dateAdded": "2026-04-13"
   },
   "overview": {


### PR DESCRIPTION
## Integrity Fix

**Proof**: erdos-268  
**Issue**: sorry count mismatch — meta.json claimed 1 sorry, Lean file has 2

## Evidence

**meta.json claimed**: `"sorries": 1`  
**Lean file shows**: 2 sorries at lines 250 and 255, both inside `harmonicPointSet_path_connected`

- Line 250: d=1 case — greedy algorithm to realise any s>0 as harmonic subseries sum (requires Cauchy-sequence arguments)
- Line 255: d≥2 case — simultaneous control of d+2 coordinate sums along continuous path (requires Kovač-Tao infrastructure)

## Changes

- Updated `meta.sorries`, `leanFile.sorries`, and top-level `sorries`: 1 → 2
- Corrected `assumptions` field to describe both sorries accurately
- Updated `conclusion.summary`: replaced stale "8 sorries" with accurate "2 sorries"
- Fixed section descriptions that incorrectly marked `harmonicPointSet_nonempty` and `finite_has_convergent` as having sorries (both are fully proved)

---
Discovered during gallery integrity audit.