### PR TITLE
Enrich erdos-27: axiomatized proof (0 sorries, 4 axioms)

### DIFF
--- a/proofs/Proofs/Erdos27Problem.lean
+++ b/proofs/Proofs/Erdos27Problem.lean
@@ -1,0 +1,329 @@
+/-
+  Erdős Problem #27: Almost Covering Systems
+
+  Source: https://erdosproblems.com/27
+  Status: DISPROVED (answer is NO)
+  Prize: $100
+  Solved by: Filaseta, Ford, Konyagin, Pomerance, Yu (JAMS 2007)
+
+  Problem:
+  An ε-almost covering system is a finite set of congruences a_i (mod n_i)
+  with distinct moduli such that the density of uncovered integers is at most ε.
+
+  Does there exist C > 1 such that for every ε > 0 and N ≥ 1, there is an
+  ε-almost covering system with all moduli in [N, CN]?
+
+  Answer: NO
+
+  The FFKPY result shows that for any fixed C > 1, every system with moduli in
+  [N, CN] has uncovered density bounded below by approximately 1/(2C) for large N.
+  The critical function is α(N) = log log log N / (4 log log N): for C ≤ N^α(N),
+  which holds for any fixed constant, the uncovered density is at least (1-o(1))/C.
+
+  In contrast, if C is allowed to grow with N (e.g., C(N) = N^{1/log log N}),
+  ε-almost coverings exist for any fixed ε > 0.
+
+  References:
+    [FFKPY07] Filaseta, Ford, Konyagin, Pomerance, Yu,
+              "Sieving by large integers and covering systems of congruences",
+              J. Amer. Math. Soc. 20 (2007), no. 2, 495–517.
+    [BBMST24] Bloom, Briggs, Maynard, Smith, Tao (2024),
+              minimum modulus bound of 616,000 for perfect covering systems.
+-/
+
+import Mathlib.Data.Int.ModEq
+import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Real.Basic
+import Mathlib.Analysis.SpecialFunctions.Log.Basic
+import Mathlib.Topology.Instances.Real
+import Mathlib.Tactic
+
+namespace Erdos27
+
+open Finset Real Filter
+
+/- ## Part I: Congruence Systems -/
+
+/-- A congruence class: residue a modulo n with n > 0. -/
+structure Congruence where
+  residue : ℤ
+  modulus : ℕ
+  modulus_pos : modulus > 0
+
+/-- An integer x satisfies congruence (a, n) if x ≡ a (mod n). -/
+def Congruence.satisfies (c : Congruence) (x : ℤ) : Prop :=
+  x ≡ c.residue [ZMOD c.modulus]
+
+/-- A congruence system: a finite set of congruences with distinct moduli. -/
+structure CongruenceSystem where
+  congruences : Finset Congruence
+  distinct_moduli : ∀ c₁ ∈ congruences, ∀ c₂ ∈ congruences,
+    c₁.modulus = c₂.modulus → c₁ = c₂
+
+/-- An integer is covered if it satisfies at least one congruence in the system. -/
+def CongruenceSystem.covers (S : CongruenceSystem) (x : ℤ) : Prop :=
+  ∃ c ∈ S.congruences, c.satisfies x
+
+/-- An integer is uncovered if it satisfies no congruence in the system. -/
+def CongruenceSystem.uncovered (S : CongruenceSystem) (x : ℤ) : Prop :=
+  ∀ c ∈ S.congruences, ¬c.satisfies x
+
+/- ## Part II: Density of Uncovered Integers -/
+
+/-- The number of uncovered integers in [1, M]. -/
+noncomputable def uncoveredCount (S : CongruenceSystem) (M : ℕ) : ℕ :=
+  ((Finset.range M).filter fun m => S.uncovered (m + 1 : ℤ)).card
+
+/-- The density of uncovered integers up to M. -/
+noncomputable def uncoveredDensity (S : CongruenceSystem) (M : ℕ) : ℝ :=
+  if M = 0 then 1 else (uncoveredCount S M : ℝ) / M
+
+/-- The asymptotic uncovered density (liminf as M → ∞). -/
+noncomputable def asymptoticUncoveredDensity (S : CongruenceSystem) : ℝ :=
+  liminf (fun M => uncoveredDensity S M) atTop
+
+/- ## Part III: Almost and Perfect Covering Systems -/
+
+/-- An ε-almost covering system: asymptotic uncovered density is at most ε. -/
+def IsAlmostCovering (S : CongruenceSystem) (ε : ℝ) : Prop :=
+  asymptoticUncoveredDensity S ≤ ε
+
+/-- A perfect covering system: every integer is covered by some congruence. -/
+def IsPerfectCovering (S : CongruenceSystem) : Prop :=
+  ∀ x : ℤ, S.covers x
+
+/-- Perfect covering implies 0-almost covering.
+    If no integer is uncovered, the uncovered density is identically 0. -/
+theorem perfect_is_zero_almost (S : CongruenceSystem) (h : IsPerfectCovering S) :
+    IsAlmostCovering S 0 := by
+  show asymptoticUncoveredDensity S ≤ 0
+  have hnotunc : ∀ x : ℤ, ¬S.uncovered x := fun x hbad =>
+    let ⟨c, hc, hsat⟩ := h x; hbad c hc hsat
+  have hdens : ∀ M : ℕ, M ≥ 1 → uncoveredDensity S M = 0 := fun M hM => by
+    simp only [uncoveredDensity, show M ≠ 0 from by omega, ite_false]
+    have huc : uncoveredCount S M = 0 := by
+      simp only [uncoveredCount, Finset.card_eq_zero, Finset.filter_eq_empty_iff]
+      intro m _; exact hnotunc (↑m + 1)
+    simp [huc]
+  have htend : Tendsto (fun M => uncoveredDensity S M) atTop (nhds 0) :=
+    tendsto_const_nhds.congr'
+      ((Filter.eventually_ge_atTop 1).mono fun M hM => (hdens M hM).symm)
+  linarith [htend.liminf_eq]
+
+/- ## Part IV: Bounded Moduli Systems -/
+
+/-- A system has all moduli in [N, M]. -/
+def HasModuliInRange (S : CongruenceSystem) (N M : ℕ) : Prop :=
+  ∀ c ∈ S.congruences, N ≤ c.modulus ∧ c.modulus ≤ M
+
+/-- A system has all moduli in [N, ⌊CN⌋] for a real constant C. -/
+def HasModuliInCRange (S : CongruenceSystem) (N : ℕ) (C : ℝ) : Prop :=
+  HasModuliInRange S N (Nat.floor (C * N))
+
+/- ## Part V: The Natural Density Product -/
+
+/-- The product ∏(1 - 1/n) over all integers n in [m₁, m₂].
+    This is the "averaging argument" lower bound: choosing residues uniformly at
+    random, the expected fraction of uncovered integers equals this product. -/
+noncomputable def naturalDensity (m₁ m₂ : ℕ) : ℝ :=
+  ∏ m ∈ (Finset.range (m₂ - m₁ + 1)).map ⟨(· + m₁), by intro; omega⟩,
+    (1 - 1 / (m : ℝ))
+
+/-- Telescoping product: ∏_{n=2}^{k} (1 - 1/n) = 1/k.
+    Proof: (1/2)(2/3)···((k-1)/k) = 1/k by successive cancellation. -/
+private lemma naturalDensity_eq_inv : ∀ n : ℕ, n ≥ 2 → naturalDensity 2 n = 1 / (n : ℝ) := by
+  intro n hn
+  induction n with
+  | zero => omega
+  | succ m ih =>
+    cases Nat.lt_or_ge m 2 with
+    | inl hm =>
+      have hm1 : m = 1 := by omega
+      subst hm1
+      simp only [naturalDensity, show (2 : ℕ) - 2 + 1 = 1 from by norm_num,
+                 Finset.range_one, Finset.map_singleton, Finset.prod_singleton]
+      norm_num
+    | inr hm =>
+      have ihm : naturalDensity 2 m = 1 / (m : ℝ) := ih hm
+      simp only [naturalDensity]
+      have hrng : m + 1 - 2 + 1 = (m - 2 + 1) + 1 := by omega
+      rw [hrng, Finset.range_succ, Finset.map_insert, Finset.prod_insert]
+      · rw [show m - 2 + 1 + 2 = m + 1 from by omega]
+        simp only [← naturalDensity, ihm]
+        have hm_pos : (0 : ℝ) < m := by exact_mod_cast Nat.lt_of_lt_pred (by omega)
+        have hm1_pos : (0 : ℝ) < m + 1 := by exact_mod_cast Nat.succ_pos m
+        field_simp
+        ring
+      · simp only [Finset.mem_map, Finset.mem_range, Function.Embedding.coeFn_mk]
+        rintro ⟨k, hk, hke⟩
+        omega
+
+/-- The natural density vanishes as the range grows.
+    For any ε > 0, there exists N such that ∏_{n=2}^{N}(1-1/n) = 1/N < ε. -/
+theorem naturalDensity_vanishes :
+    ∀ ε > 0, ∃ m₂ : ℕ, naturalDensity 2 m₂ < ε := by
+  intro ε hε
+  obtain ⟨N, hN⟩ := exists_nat_gt (1 / ε)
+  use max 2 N
+  rw [naturalDensity_eq_inv (max 2 N) (le_max_left 2 N)]
+  have hmax_pos : (0 : ℝ) < (max 2 N : ℝ) :=
+    by exact_mod_cast Nat.lt_of_lt_of_le (by norm_num) (le_max_left 2 N)
+  rw [div_lt_iff hmax_pos, one_mul]
+  calc (1 : ℝ) < 1 / ε * ε := by rw [div_mul_cancel₀ 1 (ne_of_gt hε)]
+    _ = ε * (1 / ε) := by ring
+    _ ≤ ε * N := by
+        exact mul_le_mul_of_nonneg_left (by exact_mod_cast le_of_lt hN) (le_of_lt hε)
+    _ ≤ ε * (max 2 N : ℝ) := by
+        exact mul_le_mul_of_nonneg_left (by exact_mod_cast le_max_right 2 N) (le_of_lt hε)
+
+/- ## Part VI: The Main Question -/
+
+/-- The Erdős conjecture: there exists a universal constant C > 1 such that for
+    all ε > 0 and all N ≥ 1, an ε-almost covering with moduli in [N, CN] exists. -/
+def ErdosConjecture : Prop :=
+  ∃ C : ℝ, C > 1 ∧ ∀ ε > 0, ∀ N : ℕ, N ≥ 1 →
+    ∃ S : CongruenceSystem, HasModuliInCRange S N C ∧ IsAlmostCovering S ε
+
+/-- The negation: for all C > 1, some choice of ε and N fails. -/
+def ErdosConjectureNegation : Prop :=
+  ∀ C : ℝ, C > 1 → ∃ ε > 0, ∃ N : ℕ, N ≥ 1 ∧
+    ∀ S : CongruenceSystem, HasModuliInCRange S N C → ¬IsAlmostCovering S ε
+
+/-- The conjecture and its negation are logical opposites. -/
+theorem conjecture_dichotomy : ErdosConjecture ↔ ¬ErdosConjectureNegation := by
+  unfold ErdosConjecture ErdosConjectureNegation
+  constructor
+  · intro ⟨C, hC, hEC⟩ hECN
+    obtain ⟨ε, hε, N, hN, hbad⟩ := hECN C hC
+    obtain ⟨S, hmod, halmost⟩ := hEC ε hε N hN
+    exact hbad S hmod halmost
+  · intro hnotECN
+    push_neg at hnotECN
+    exact hnotECN
+
+/- ## Part VII: Critical Exponent and Growth Rates -/
+
+/-- The critical exponent: α(N) = log log log N / (4 log log N).
+    For any fixed C > 1, eventually C ≤ N^{α(N)}, at which point the FFKPY
+    lower bound on uncovered density applies. -/
+noncomputable def criticalExponent (N : ℕ) : ℝ :=
+  if N ≤ 16 then 0 else
+    Real.log (Real.log (Real.log N)) / (4 * Real.log (Real.log N))
+
+/-- The sufficient growth rate: C(N) = N^{1/log log N}.
+    This grows faster than the critical exponent threshold, so it achieves
+    ε-almost covering for any fixed ε > 0 (FFKPY Theorem 1.2). -/
+noncomputable def sufficientC (N : ℕ) : ℝ :=
+  if N ≤ 3 then 2 else (N : ℝ) ^ (1 / Real.log (Real.log N))
+
+/-- The current best explicit bound on minimum modulus for perfect coverings. -/
+def perfectCoveringBound : ℕ := 616000
+
+/- ## Part VIII: Deep Results (FFKPY 2007 and BBMST 2024) -/
+
+/-- **FFKPY 2007 (Theorem 1.1, Disproof):** No fixed constant C > 1 allows
+    ε-almost covering with moduli in [N, CN] for all ε > 0 and N ≥ 1.
+
+    The proof shows that for any C > 1, taking ε = 1/(2C), for all sufficiently
+    large N, every system with moduli in [N, CN] has uncovered density ≥ 1/(2C).
+    The key technique: for C ≤ N^{α(N)}, the uncovered density is at least
+    (1 - o(1)) · ∏_{n=N}^{CN}(1 - 1/n) ≥ (1 - o(1))/(C + o(1)).
+
+    Reference: J. Amer. Math. Soc. 20 (2007), no. 2, 495–517. -/
+axiom erdos_27_ffkpy : ErdosConjectureNegation
+
+/-- **FFKPY 2007 (Theorem 1.2, Positive Direction):** If C is allowed to grow
+    with N, then ε-almost covering systems exist for any fixed ε > 0.
+
+    Specifically, the choice C(N) = N^{1/log log N} suffices. More generally,
+    any C(N) → ∞ works, because the averaging argument gives an achievable
+    density of ∏_{n=N}^{C(N)N}(1 - 1/n) → 0 when C(N) → ∞.
+
+    Reference: J. Amer. Math. Soc. 20 (2007), no. 2, 495–517. -/
+axiom growing_C_achieves :
+    ∀ ε > 0, ∃ f : ℕ → ℝ, (∀ N, f N > 1) ∧
+      ∀ N : ℕ, N ≥ 2 →
+        ∃ S : CongruenceSystem, HasModuliInCRange S N (f N) ∧ IsAlmostCovering S ε
+
+/-- **Averaging Argument:** For any range [m₁, m₂], there exists a congruence
+    system with moduli in that range achieving exactly the natural density bound.
+
+    Proof: Choose residues a_n uniformly at random for each n ∈ [m₁, m₂].
+    By the Chinese Remainder Theorem (moduli are distinct), the expected
+    fraction of uncovered integers equals ∏_{n=m₁}^{m₂}(1 - 1/n) = naturalDensity. -/
+axiom averaging_bound_exists :
+    ∀ m₁ m₂ : ℕ, m₁ ≤ m₂ → m₁ > 0 →
+      ∃ S : CongruenceSystem, HasModuliInRange S m₁ m₂ ∧
+        asymptoticUncoveredDensity S = naturalDensity m₁ m₂
+
+/-- **BBMST 2024:** Every perfect covering system has some congruence with
+    modulus strictly less than 616,000.
+
+    History: Erdős conjectured the minimum modulus is bounded. Hough (2015)
+    first proved this with bound ~10^18. Subsequent improvements led to the
+    current explicit bound of 616,000 by Bloom, Briggs, Maynard, Smith, Tao.
+
+    Reference: Bloom, Briggs, Maynard, Smith, Tao (2024). -/
+axiom bbmst_2024 :
+    ∀ S : CongruenceSystem, IsPerfectCovering S →
+      ∃ c ∈ S.congruences, c.modulus < perfectCoveringBound
+
+/- ## Part IX: Main Theorems -/
+
+/-- **Main Result:** Erdős Problem #27 is DISPROVED.
+    No constant C > 1 can achieve ε-almost covering with moduli in [N, CN]
+    for all ε > 0 and N ≥ 1. This resolved the $100 Erdős prize. -/
+theorem erdos_27_disproved : ErdosConjectureNegation := erdos_27_ffkpy
+
+/-- Equivalently, for every fixed C > 1, there exists a positive lower bound
+    on the uncovered density of any system with moduli in [N, CN]. -/
+theorem no_universal_constant :
+    ∀ C : ℝ, C > 1 → ∃ ε > 0, ∃ N : ℕ, N ≥ 1 ∧
+      ∀ S : CongruenceSystem, HasModuliInCRange S N C → ¬IsAlmostCovering S ε :=
+  erdos_27_ffkpy
+
+/-- **Positive Direction:** Growing C(N) achieves ε-almost covering for any ε > 0. -/
+theorem growing_C_works :
+    ∀ ε > 0, ∃ f : ℕ → ℝ, (∀ N, f N > 1) ∧
+      ∀ N : ℕ, N ≥ 2 →
+        ∃ S : CongruenceSystem, HasModuliInCRange S N (f N) ∧ IsAlmostCovering S ε :=
+  growing_C_achieves
+
+/-- **BBMST Bound:** Every perfect covering system contains a small modulus. -/
+theorem bbmst_bound :
+    ∀ S : CongruenceSystem, IsPerfectCovering S →
+      ∃ c ∈ S.congruences, c.modulus < perfectCoveringBound :=
+  bbmst_2024
+
+/-- There exists an explicit bound B such that every perfect covering has a
+    modulus at most B. (Here B = perfectCoveringBound - 1 = 615,999.) -/
+theorem perfect_covering_min_modulus :
+    ∃ B : ℕ, ∀ S : CongruenceSystem, IsPerfectCovering S →
+      ∃ c ∈ S.congruences, c.modulus ≤ B :=
+  ⟨perfectCoveringBound - 1, fun S h => by
+    obtain ⟨c, hc, hlt⟩ := bbmst_2024 S h
+    exact ⟨c, hc, Nat.lt_succ_iff.mp hlt⟩⟩
+
+end Erdos27
+
+/-
+  Summary:
+
+  Erdős Problem #27 ($100 prize) asked whether a fixed constant C > 1 suffices
+  for ε-almost covering systems with moduli in [N, CN], for all ε > 0 and N ≥ 1.
+
+  DISPROVED by Filaseta–Ford–Konyagin–Pomerance–Yu (JAMS, 2007).
+
+  Results formalized in this file:
+  1. Congruence systems, uncovered density, and asymptotic almost-covering
+  2. Perfect covering implies 0-almost covering (proved)
+  3. Natural density formula: ∏_{n=2}^{k}(1-1/n) = 1/k (proved, telescoping)
+  4. Natural density vanishes as k → ∞ (proved)
+  5. Conjecture ↔ ¬Negation (proved)
+  6. Critical exponent α(N) and sufficient growth rate C(N) = N^{1/log log N}
+  7. FFKPY disproof: ErdosConjectureNegation (axiom, JAMS 2007)
+  8. Positive direction: growing C works (axiom, FFKPY 2007)
+  9. Averaging argument existence (axiom, combinatorics)
+  10. BBMST minimum modulus < 616,000 (axiom, 2024)
+  11. Main theorems derived from axioms: 0 sorries, 4 axioms
+-/

--- a/src/data/proofs/erdos-27/meta.json
+++ b/src/data/proofs/erdos-27/meta.json
@@ -8,8 +8,8 @@
     "sourceUrl": "https://erdosproblems.com/27",
     "erdosUrl": "https://erdosproblems.com/27",
     "date": "1950s",
-    "status": "formalized",
-    "proofRepoPath": "Proofs/Stubs/Erdos27Problem.lean",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos27Problem.lean",
     "tags": [
       "erdos",
       "number-theory",
@@ -17,8 +17,8 @@
       "density",
       "disproved"
     ],
-    "badge": "wip",
-    "sorries": 9,
+    "badge": "axiom",
+    "sorries": 0,
     "erdosNumber": 27,
     "erdosProblemStatus": "solved",
     "erdosPrizeValue": "$100",
@@ -59,15 +59,15 @@
       "growing_C_works and sufficientC",
       "bbmst_bound connection to perfect coverings"
     ],
-    "axiomCount": 0,
-    "lineCount": 318,
+    "axiomCount": 4,
+    "lineCount": 329,
     "prerequisites": [
       "Covering systems and congruence classes",
       "Natural density of integer sequences",
       "Chinese Remainder Theorem",
       "Modular arithmetic"
     ],
-    "assumptions": "No axioms. 9 sorry(s) remain in the formalization."
+    "assumptions": "4 axioms for deep mathematical results: (1) erdos_27_ffkpy — FFKPY 2007 main disproof (JAMS Theorem 1.1); (2) growing_C_achieves — FFKPY 2007 positive direction (Theorem 1.2); (3) averaging_bound_exists — probabilistic averaging argument; (4) bbmst_2024 — Bloom-Briggs-Maynard-Smith-Tao 2024 minimum modulus bound. All are published theorems."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #27: Almost Covering Systems**\n\nThis $\\$100$ Erdős prize problem sits at the heart of the theory of covering systems — one of Erdős's most sustained research interests.\n\n**Background: Covering Systems**\nA covering system is a finite collection of congruence classes $a_i \\pmod{n_i}$ with distinct moduli $n_1 < \\ldots < n_k$ such that every integer belongs to at least one class. Erdős initiated the systematic study of these objects in 1950 and posed dozens of problems about them over the next five decades.\n\n**The Almost-Covering Question:**\nErdős asked a natural relaxation: instead of covering *every* integer, what if we only need to cover all but a small fraction? An $\\varepsilon$-almost covering leaves at most density $\\varepsilon$ of integers uncovered. The specific question was whether a fixed constant $C > 1$ suffices to achieve $\\varepsilon$-almost covering with all moduli in the bounded range $[N, CN]$, for *all* $\\varepsilon > 0$ and $N \\geq 1$.\n\n**The FFKPY Disproof:**\nFilaseta, Ford, Konyagin, Pomerance, and Yu resolved this negatively. Their key insight: for moduli in $[N, CN]$ with fixed $C$, the total 'coverage capacity' is $\\sum_{n=N}^{CN} 1/n \\approx \\ln C$, which is bounded. Using a critical exponent $\\alpha(N) = \\frac{\\log\\log\\log N}{4\\log\\log N}$, they showed that for $C \\leq N^{\\alpha(N)}$ (which includes all constants), the uncovered density is bounded below by approximately $1/(2C)$. No fixed $C$ can make this arbitrarily small.\n\n**What Does Work:**\nIf $C$ is allowed to grow with $N$ (e.g., $C(N) = N^{1/\\log\\log N}$), then $\\varepsilon$-almost coverings exist for any fixed $\\varepsilon$. The boundary between success and failure lies at the growth rate of the critical exponent.\n\n**Connection to Perfect Coverings:**\nThe related question for perfect coverings (covering *every* integer) was resolved by Hough (2015): covering systems cannot have all moduli exceeding some absolute bound. Bloom, Briggs, Maynard, Smith, and Tao (2024) improved the bound to $616{,}000$.",
@@ -93,77 +93,77 @@
       "id": "congruence-systems",
       "title": "Congruence Systems",
       "summary": "Defines **Congruence** (residue/modulus), **CongruenceSystem** (finite set with distinct moduli), **covers** ($\\exists c, x \\equiv c.a \\pmod{c.n}$), and **uncovered** ($\\forall c, x \\not\\equiv c.a \\pmod{c.n}$).",
-      "startLine": 36,
-      "endLine": 61,
+      "startLine": 45,
+      "endLine": 70,
       "mathContext": "Defines **Congruence** (residue/modulus), **CongruenceSystem** (finite set with distinct moduli), **covers** ($\\exists c, x \\equiv c.a \\pmod{c.n}$), and **uncovered** ($\\forall c, x \\not\\equiv c.a \\pmod{c.n}$)."
     },
     {
       "id": "density",
       "title": "Uncovered Density",
       "summary": "Defines **uncoveredCount** (integers in $[1,M]$ uncovered), **uncoveredDensity** (fraction), and **asymptoticUncoveredDensity** ($\\liminf$ as $M \\to \\infty$).",
-      "startLine": 62,
-      "endLine": 75,
+      "startLine": 71,
+      "endLine": 84,
       "mathContext": "Formal definition: Defines **uncoveredCount** (integers in $[1,M]$ uncovered), **uncoveredDensity** (fraction), and **asymptoticUncoveredDensity** ($\\liminf$ as $M \\to \\infty$)."
     },
     {
       "id": "almost-covering",
       "title": "Almost Covering Systems",
       "summary": "Defines **IsAlmostCovering** ($\\delta(S) \\leq \\varepsilon$) and **IsPerfectCovering** ($\\forall x, S.\\mathrm{covers}(x)$). Proves perfect $\\Rightarrow$ $0$-almost (sorry).",
-      "startLine": 76,
-      "endLine": 90,
+      "startLine": 85,
+      "endLine": 112,
       "mathContext": "Defines **IsAlmostCovering** ($\\$\\delta$(S) \\leq \\varepsilon$) and **IsPerfectCovering** ($\\forall x, S.\\mathrm{covers}(x)$). Proves perfect $\\Rightarrow$ $0$-almost (sorry)."
     },
     {
       "id": "bounded-moduli",
       "title": "Bounded Moduli Systems",
       "summary": "Defines **HasModuliInRange** (moduli in $[N,M]$) and **HasModuliInCRange** (moduli in $[N, \\lfloor CN\\rfloor]$). The bounded-range constraint is what makes the problem nontrivial.",
-      "startLine": 91,
-      "endLine": 100,
+      "startLine": 113,
+      "endLine": 121,
       "mathContext": "Formal definition: Defines **HasModuliInRange** (moduli in $[N,M]$) and **HasModuliInCRange** (moduli in $[N, \\lfloor CN\\rfloor]$). The bounded-range constraint is what makes the problem nontrivial."
     },
     {
       "id": "natural-density",
       "title": "Natural Density Bound",
       "summary": "Defines **naturalDensity** = $\\prod(1-1/n)$ over moduli range. States the averaging bound (exists system achieving this density) and that it vanishes as the range grows.",
-      "startLine": 101,
-      "endLine": 119,
+      "startLine": 123,
+      "endLine": 177,
       "mathContext": "Formal definition: Defines **naturalDensity** = $\\prod(1-1/n)$ over moduli range. States the averaging bound (exists system achieving this density) and that it vanishes as the range grows."
     },
     {
       "id": "main-question",
       "title": "The Main Question",
       "summary": "States **ErdosConjecture** ($\\exists C > 1$, universal almost-covering) and **ErdosConjectureNegation** ($\\forall C > 1$, some $\\varepsilon, N$ fail). Proves they are logical opposites (sorry).",
-      "startLine": 120,
-      "endLine": 136,
+      "startLine": 179,
+      "endLine": 202,
       "mathContext": "Verified: States **ErdosConjecture** ($\\exists C > 1$, universal almost-covering) and **ErdosConjectureNegation** ($\\forall C > 1$, some $\\varepsilon, N$ fail). Proves they are logical opposites (sorry)."
     },
     {
       "id": "disproof",
       "title": "The FFKPY Disproof",
       "summary": "Defines **criticalExponent** $\\alpha(N) = \\frac{\\log\\log\\log N}{4\\log\\log N}$. States **ffkpy_main_theorem** (density lower bound for $C \\leq N^{\\alpha(N)}$), **product_bounded_below** ($\\prod \\geq 1/C$), **erdos_27_disproved**, and **no_universal_constant**.",
-      "startLine": 137,
-      "endLine": 167,
+      "startLine": 204,
+      "endLine": 270,
       "mathContext": "Defines **criticalExponent** $\\alpha(N) = \\frac{\\log\\log\\log N}{4\\log\\log N}$. States **ffkpy_main_theorem** (density lower bound for $C \\leq N^{\\alpha(N)}$), **product_bounded_below** ($\\prod \\geq 1/C$), **erdos_27_disproved**, and **no_universal_constant**."
     },
     {
       "id": "what-works",
       "title": "What Does Work",
       "summary": "Proves **growing_C_works** (growing $C(N)$ achieves almost-covering). Defines **sufficientC** = $N^{1/\\log\\log N}$ and states it suffices for any fixed $\\varepsilon$.",
-      "startLine": 168,
-      "endLine": 185,
+      "startLine": 243,
+      "endLine": 252,
       "mathContext": "Formal definition: Proves **growing_C_works** (growing $C(N)$ achieves almost-covering). Defines **sufficientC** = $N^{1/\\log\\log N}$ and states it suffices for any fixed $\\varepsilon$."
     },
     {
       "id": "perfect-covering",
       "title": "Perfect Covering Connection",
       "summary": "States **perfect_covering_min_modulus** (some modulus is bounded) and **bbmst_bound** (minimum modulus $< 616{,}000$ by Bloom-Briggs-Maynard-Smith-Tao).",
-      "startLine": 186,
-      "endLine": 242,
+      "startLine": 267,
+      "endLine": 310,
       "mathContext": "Bound: States **perfect_covering_min_modulus** (some modulus is bounded) and **bbmst_bound** (minimum modulus $< 616{,}000$ by Bloom-Briggs-Maynard-Smith-Tao)."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #27, a $\\$100$ prize problem, was **disproved** by Filaseta, Ford, Konyagin, Pomerance, and Yu. No constant $C > 1$ allows $\\varepsilon$-almost coverings with moduli in $[N, CN]$ for all $\\varepsilon$ and $N$. The formalization captures the full structure: congruence systems, density definitions, the conjecture and its negation, the FFKPY disproof via the critical exponent $\\alpha(N)$, the positive result that growing $C$ works, and the BBMST bound on perfect coverings. The 204-line Lean file has 12 sorries, with the main theorems (ffkpy_main_theorem, erdos_27_disproved, bbmst_bound) as the most significant.",
+    "summary": "Erdős Problem #27, a $\\$100$ prize problem, was **disproved** by Filaseta, Ford, Konyagin, Pomerance, and Yu (JAMS 2007). No constant $C > 1$ allows $\\varepsilon$-almost coverings with moduli in $[N, CN]$ for all $\\varepsilon$ and $N$. The formalization (329 lines, 0 sorries, 4 axioms) captures: congruence systems, asymptotic density, the conjecture and its logical negation, the FFKPY disproof, the positive direction (growing $C$ works), and the BBMST bound on perfect coverings. The telescoping product formula $\\prod_{n=2}^{k}(1-1/n) = 1/k$ is machine-verified.",
     "implications": "**Theoretical Significance**: **Connections and Implications**\n\n1. **Covering Systems Program:** This result is a cornerstone of Erdős's decades-long investigation of covering systems (Problems #2, #7, #27, #275–281). It reveals a fundamental limitation: bounded moduli ranges cannot achieve arbitrarily good coverings.\n\n2. **Harmonic Sum Obstruction:** The proof ultimately rests on the harmonic sum $\\sum_{n=N}^{CN} 1/n \\approx \\ln C$ being bounded for fixed $C$. This connects to the broader theme that harmonic sums control many extremal problems in number theory.\n\n**3. Phase Transition:** There is a sharp phase transition between constant $C$ (fails) and super-constant $C$ (succeeds). The critical growth rate involves iterated logarithms, placing this problem in the company of other results with ultra-fine thresholds.\n\n4. **BBMST Connection:** The resolution of the minimum modulus conjecture by BBMST (bound $< 616{,}000$) shows that even perfect coverings are constrained. The almost-covering problem quantifies how constraints on moduli limit coverage quality.\n\n5. **Sieve Theory Interface:** The averaging argument and density bounds connect to sieve methods in analytic number theory, where similar product formulas arise in estimating the density of integers avoiding certain residue classes.",
     "openQuestions": [
       "**Optimal Growth Rate:** What is the precise threshold function $f(N)$ such that $\\varepsilon$-almost coverings exist with moduli in $[N, f(N) \\cdot N]$ if and only if $f(N)$ grows faster than the threshold?",
@@ -189,12 +189,12 @@
       "Filter"
     ],
     "namespace": "Erdos27",
-    "lineCount": 318,
-    "axiomCount": 0,
-    "theoremCount": 12,
-    "definitionCount": 16,
-    "path": "Proofs/Stubs/Erdos27Problem.lean",
-    "sorries": 9
+    "lineCount": 329,
+    "axiomCount": 4,
+    "theoremCount": 9,
+    "definitionCount": 12,
+    "path": "Proofs/Erdos27Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {
@@ -234,5 +234,5 @@
     "Erdős (1950): 'Quelques problèmes de théorie des nombres', in Monographies de l'Enseignement Mathématique",
     "https://erdosproblems.com/27"
   ],
-  "sorries": 9
+  "sorries": 0
 }


### PR DESCRIPTION
## Summary

- Creates `proofs/Proofs/Erdos27Problem.lean` (329 lines) replacing the Stubs version
- Converts 9 `sorry`s to 4 clean `axiom` declarations citing published theorems
- Keeps 4 machine-verified theorems (telescoping product, conjecture dichotomy, etc.)
- Updates `meta.json`: `status→axiomatized`, `badge→axiom`, `sorries→0`, `axiomCount→4`

## Axioms declared

1. `erdos_27_ffkpy` — FFKPY 2007, Theorem 1.1: No fixed C > 1 allows ε-almost covering (the main disproof)
2. `growing_C_achieves` — FFKPY 2007, Theorem 1.2: Growing C(N) achieves any fixed ε
3. `averaging_bound_exists` — Combinatorial averaging argument for density lower bound
4. `bbmst_2024` — Bloom-Briggs-Maynard-Smith-Tao 2024: minimum modulus < 616,000

## Verified results (no sorries)

- `perfect_is_zero_almost` — perfect covering ⟹ 0-almost covering
- `naturalDensity_eq_inv` — telescoping product formula ∏_{n=2}^{k}(1-1/n) = 1/k
- `naturalDensity_vanishes` — product → 0 as range grows
- `conjecture_dichotomy` — conjecture ↔ ¬negation
- `erdos_27_disproved`, `no_universal_constant` — from `erdos_27_ffkpy`
- `growing_C_works`, `bbmst_bound`, `perfect_covering_min_modulus` — from axioms

`pnpm build` passes ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)