### PR TITLE
Fix: add missing top-level sorries and leanFile fields to 8 gallery proofs

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-04-oq-02-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-04-oq-02-oq-01/meta.json
@@ -180,5 +180,6 @@
       "venue": "Cambridge University Press",
       "note": "Chapter 3: Gaussian polynomials and their combinatorial interpretations"
     }
-  ]
+  ],
+  "sorries": 0
 }

--- a/src/data/proofs/erdos-1156/meta.json
+++ b/src/data/proofs/erdos-1156/meta.json
@@ -145,5 +145,6 @@
       "relationship": "related",
       "description": "Erdos #39 involves chromatic number bounds in graph theory"
     }
-  ]
+  ],
+  "sorries": 0
 }

--- a/src/data/proofs/erdos-1182/meta.json
+++ b/src/data/proofs/erdos-1182/meta.json
@@ -161,5 +161,6 @@
       "relationship": "related",
       "description": "Erdos #888 involves extremal graph theory and edge-counting thresholds"
     }
-  ]
+  ],
+  "sorries": 0
 }

--- a/src/data/proofs/erdos-1212/meta.json
+++ b/src/data/proofs/erdos-1212/meta.json
@@ -127,5 +127,19 @@
       "relationship": "related",
       "description": "Erdős #1213 is the neighboring problem: both #1212 and #1213 are Erdős combinatorial problems marked as solved, both involve sequences with arithmetic constraints (coprimality/bounded gaps), and both have Lean stubs awaiting formalization. They share the same file structure and enrichment context."
     }
-  ]
+  ],
+  "sorries": 1,
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": null,
+    "lineCount": 23,
+    "axiomCount": 0,
+    "theoremCount": 1,
+    "definitionCount": 0,
+    "sorries": 1,
+    "path": "Proofs/Erdos1212Problem.lean"
+  }
 }

--- a/src/data/proofs/erdos-1213/meta.json
+++ b/src/data/proofs/erdos-1213/meta.json
@@ -21,8 +21,7 @@
     "sorries": 1,
     "erdosNumber": 1213,
     "erdosUrl": "https://erdosproblems.com/1213",
-    "erdosProblemStatus": "solved",
-    "lineCount": 23
+    "erdosProblemStatus": "solved"
   },
   "overview": {
     "historicalContext": "This problem is in the tradition of Erdős's combinatorial number theory questions about arithmetic properties of integer sequences. The idea that any sufficiently long sequence with bounded gaps must have two sub-intervals with equal sums is a pigeonhole-type result: the number of possible interval sums is bounded by the range of the sequence, while the number of intervals grows quadratically. Hegyvári proved in 1986 that the threshold $f(a,K)$ exists and satisfies $f(a,K) \\ll a \\cdot e^{O(K)}$, but the exponential dependence on $K$ seems too large. The problem is marked as solved—meaning the existence of $f(a,K)$ is confirmed—but the optimal bound is an open refinement.",
@@ -108,5 +107,19 @@
       "relationship": "related",
       "description": "Erdős #1211 studies logarithmic density of sumsets in a partition ℕ = A ∪ B; like #1213, it concerns how arithmetic constraints on a sequence force global additive structure (equal sums). Both probe the boundary between 'sparse' and 'structured' sequences."
     }
-  ]
+  ],
+  "sorries": 1,
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": null,
+    "lineCount": 23,
+    "axiomCount": 0,
+    "theoremCount": 1,
+    "definitionCount": 0,
+    "sorries": 1,
+    "path": "Proofs/Erdos1213Problem.lean"
+  }
 }

--- a/src/data/proofs/erdos-1217/meta.json
+++ b/src/data/proofs/erdos-1217/meta.json
@@ -21,8 +21,7 @@
     "sorries": 1,
     "erdosNumber": 1217,
     "erdosUrl": "https://erdosproblems.com/1217",
-    "erdosProblemStatus": "solved",
-    "lineCount": 23
+    "erdosProblemStatus": "solved"
   },
   "overview": {
     "historicalContext": "Erdős Problem #1217 concerns sequences of positive integers and their 'upper log-log density': the quantity $\\limsup_{x\\to\\infty} \\frac{1}{\\log\\log x}\\sum_{a_n \\leq x} \\frac{1}{a_n}$. This measure is modeled on Mertens' second theorem, which states $\\sum_{p \\leq x} \\frac{1}{p} \\sim \\log\\log x$, so the primes are the canonical sequence with upper log-log density equal to 1. A sequence A has positive upper log-log density iff its reciprocal sums grow (at least along a subsequence of $x$ values) as fast as a positive fraction of the prime reciprocal sum. The problem references [ESS66], the paper of Erdős, Sárközy, and Sós from 1966, who proved a key result about sequences with this density condition.\n\nThe source problem statement in the Lean file and meta.json is severely corrupted (garbled by encoding issues), so the precise formulation cannot be recovered from the current source. Based on the fragments, the result concerns: given a sequence A with positive upper log-log density, one can extract a subsequence $\\{a_{n_i}\\}$ with some additional structural property (e.g., primitivity, or sum-free, or B₂) while preserving positive log-log density.\n\nThe Erdős-Sárközy-Sós 1966 collaboration was prolific in combinatorial number theory, covering Sidon sets, additive bases, primitive sets, and density problems. Their results on 'density-preserving' subsequence extraction are fundamental in the area. This problem is listed as solved on erdosproblems.com.",
@@ -103,5 +102,19 @@
       "relationship": "related",
       "description": "Bounded prime gaps (Zhang/Maynard-Tao) concerns the local density of primes. Problem #1217 uses global log-log density, the same scale at which primes are 'just barely' dense ($\\sum_{p \\leq x} 1/p \\sim \\log\\log x$). Both results probe the edge of prime distribution, and both would require Mertens' theorem as a foundational Lean lemma."
     }
-  ]
+  ],
+  "sorries": 1,
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": null,
+    "lineCount": 23,
+    "axiomCount": 0,
+    "theoremCount": 1,
+    "definitionCount": 0,
+    "sorries": 1,
+    "path": "Proofs/Erdos1217Problem.lean"
+  }
 }

--- a/src/data/proofs/lhopital-oq-01/meta.json
+++ b/src/data/proofs/lhopital-oq-01/meta.json
@@ -136,8 +136,14 @@
     }
   ],
   "leanFile": {
-    "imports": ["Mathlib"],
-    "opens": ["Real", "Filter", "Topology"],
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "Filter",
+      "Topology"
+    ],
     "namespace": "LHopitalFailure",
     "lineCount": 142,
     "axiomCount": 0,
@@ -161,5 +167,6 @@
       "venue": "Paris",
       "note": "First calculus textbook; the rule was actually discovered by Bernoulli"
     }
-  ]
+  ],
+  "sorries": 0
 }

--- a/src/data/proofs/ptolemys-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01-oq-01/meta.json
@@ -140,5 +140,19 @@
       "relationship": "ancestor",
       "description": "The original Ptolemy theorem formalization using complex numbers"
     }
-  ]
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": null,
+    "lineCount": 288,
+    "axiomCount": 0,
+    "theoremCount": 1,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/PtolemysTheoremOq01Oq01.lean"
+  }
 }


### PR DESCRIPTION
## Fix

8 gallery proofs were missing the top-level `sorries` field (and in some cases `leanFile.sorries`/`leanFile.path`), causing false-positive mismatch alerts in auditor scans.

## Evidence

**Before**: 8 proofs had `sorries: null` at the top level
**After**: All 8 have correct `sorries` values matching their Lean source files

| Proof | Change |
|-------|--------|
| `binomial-theorem-oq-04-oq-02-oq-01` | add `sorries: 0` |
| `erdos-1156` | add `sorries: 0` |
| `erdos-1182` | add `sorries: 0` |
| `erdos-1212` | add `sorries: 1` + populate `leanFile` |
| `erdos-1213` | add `sorries: 1` + populate `leanFile` |
| `erdos-1217` | add `sorries: 1` + populate `leanFile` |
| `lhopital-oq-01` | add `sorries: 0` |
| `ptolemys-theorem-oq-01-oq-01` | add `sorries: 0` + populate `leanFile` |

All values verified against actual Lean source files via sorry-tactic counting (excluding comments and block comments).

---
Automated fix by lean-mechanic agent.