### PR TITLE
Enrich abel-ruffini-galois-extensions: 4 new annotations, fix section gap

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions/annotations.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions/annotations.json
@@ -118,5 +118,53 @@
     "significance": "supporting",
     "relatedConcepts": ["non-abelian groups", "commutativity", "decide tactic", "native_decide", "fintype enumeration"],
     "prerequisites": ["symmetric group", "decide tactic", "Fintype.decidable_forall_fintype"]
+  },
+  {
+    "id": "arg-galois-order-subgroup",
+    "proofId": "abel-ruffini-galois-extensions",
+    "range": { "startLine": 219, "endLine": 248 },
+    "type": "insight",
+    "title": "Galois Group Order = Extension Degree, and Subgroup Solvability",
+    "content": "Two foundational results linking abstract Galois theory to concrete computation. (1) `galois_group_order`: for a finite Galois extension $E/F$, the order of the automorphism group $|\\text{Aut}(E/F)|$ equals the extension degree $[E:F]$. This is `IsGalois.card_aut_eq_finrank` — the fundamental theorem of Galois theory in numerical form. In the context of Abel-Ruffini, it means that a quintic with Galois group $S_5$ necessarily generates a degree-120 extension (since $|S_5| = 120$), which cannot be built from a radical tower (each step of which is a prime-degree extension). (2) `subgroup_solvable_of_solvable`: subgroups of solvable groups are solvable, proved trivially by `inferInstance` — Mathlib's typeclass system automatically derives `IsSolvable H` from `IsSolvable G` whenever $H \\leq G$. This closure property is essential: to conclude the Galois group of a subextension is solvable, one only needs to know the top group is solvable.",
+    "mathContext": "$|\\text{Gal}(E/F)| = [E:F]$ for finite Galois extensions (fundamental theorem). Subgroup inheritance: $H \\leq G$, $G$ solvable $\\Rightarrow H$ solvable (the derived series of $H$ is contained in the derived series of $G$: $H^{(k)} \\leq G^{(k)}$). Consequence: if $\\text{Gal}(E/F)$ is solvable, every intermediate subextension $E/K/F$ has solvable Galois group $\\text{Gal}(E/K) \\leq \\text{Gal}(E/F)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Galois group", "extension degree", "IsGalois", "IsSolvable", "subgroup solvability", "Galois correspondence", "card_aut_eq_finrank"],
+    "prerequisites": ["Galois extensions", "field extensions", "automorphism groups", "solvable groups", "typeclass inference in Lean"]
+  },
+  {
+    "id": "arg-group-cardinalities",
+    "proofId": "abel-ruffini-galois-extensions",
+    "range": { "startLine": 288, "endLine": 329 },
+    "type": "technique",
+    "title": "Group Order Computations: $|S_n| = n!$ and $|A_n| = n!/2$ for $n \\leq 6$",
+    "content": "Thirteen computational theorems verify the group orders of symmetric and alternating groups for small $n$. For $n \\leq 5$, `decide` suffices — exhaustive enumeration over the fintype is fast enough for the kernel evaluator. For $n = 6$ (720 and 360 elements), `native_decide` is required since the fintype is too large for kernel-time computation. The formula $|S_n| = n!$ reflects the definition of $S_n$ as the group of all bijections on an $n$-element set: there are $n!$ ways to arrange $n$ elements. The formula $|A_n| = n!/2$ follows from $A_n$ being an index-2 subgroup (via the sign homomorphism $\\text{sign}: S_n \\to \\{\\pm 1\\}$). These cardinalities are not just bookkeeping: $|A_5| = 60$ is the smallest possible order for a non-abelian simple group, a fact that constrains the entire classification theory of finite simple groups.",
+    "mathContext": "$|S_n| = n!$ (bijections on $n$ elements). $|A_n| = n!/2$ for $n \\geq 2$ ($A_n$ has index 2 in $S_n$ via $S_n/A_n \\cong \\mathbb{Z}/2\\mathbb{Z}$). Values: $|S_2|=2, |S_3|=6, |S_4|=24, |S_5|=120, |S_6|=720$; $|A_0|=|A_1|=|A_2|=1, |A_3|=3, |A_4|=12, |A_5|=60, |A_6|=360$. The index-2 identity follows from $|S_n| = |A_n| \\cdot [S_n:A_n] = |A_n| \\cdot 2$.",
+    "significance": "technical",
+    "relatedConcepts": ["Fintype.card", "factorial", "decide tactic", "native_decide", "symmetric group order", "index of a subgroup", "sign homomorphism"],
+    "prerequisites": ["Fintype.card", "symmetric group", "alternating group", "decide/native_decide tactics", "Lagrange's theorem"]
+  },
+  {
+    "id": "arg-specific-non-solvable",
+    "proofId": "abel-ruffini-galois-extensions",
+    "range": { "startLine": 366, "endLine": 406 },
+    "type": "insight",
+    "title": "Specific Non-Solvability: S₅–S₈, A₅–A₇, and the Alternating Obstruction",
+    "content": "Concrete non-solvability witnesses for all symmetric and alternating groups above the threshold, plus the key structural lemma `symmetric_not_solvable_of_alternating`. The latter formalizes a subtle logical direction: if $A_n$ is not solvable, then $S_n$ is not solvable. This follows by contrapositive from subgroup solvability ($A_n \\leq S_n$, so $S_n$ solvable $\\Rightarrow A_n$ solvable). In Lean: `inferInstance` derives `IsSolvable (alternatingGroup (Fin n))` from `IsSolvable (Equiv.Perm (Fin n))` automatically, so the non-solvability proof is immediate by contradiction. The eight concrete results (S₅–S₈, A₅–A₇) are all one-liners — each is a direct application of `symmetric_not_solvable_of_five_le` or `alternating_not_solvable_of_five_le` with `omega`-computed bounds. The deeper work is in those general theorems.",
+    "mathContext": "Containment chain: $A_5 \\leq A_6 \\leq A_7 \\leq \\ldots$ All $A_n$ for $n \\geq 5$ contain the non-abelian simple group $A_5$ as a subgroup, so all are non-solvable. Similarly $S_n \\supseteq A_n$ means non-solvability of $A_n$ propagates up. Logical structure: $A_n$ not solvable $\\xleftarrow{\\text{subgroup}}$ $S_n$ not solvable (contrapositive), equivalently $S_n$ solvable $\\Rightarrow A_n$ solvable.",
+    "significance": "supporting",
+    "relatedConcepts": ["symmetric_not_solvable_of_five_le", "alternating_not_solvable_of_five_le", "subgroup solvability", "alternatingGroup embedding", "IsSolvable contrapositive"],
+    "prerequisites": ["IsSolvable typeclass", "alternating group embedding in symmetric group", "subgroup solvability theorem"]
+  },
+  {
+    "id": "arg-higher-cardinalities-factorial",
+    "proofId": "abel-ruffini-galois-extensions",
+    "range": { "startLine": 464, "endLine": 516 },
+    "type": "technique",
+    "title": "Higher Group Orders (S₇, S₈, A₇, A₈) and Factorial Identity Verification",
+    "content": "Computational verification of group orders for larger symmetric and alternating groups, and formal proofs that $|S_n| = n!$ and $|A_n| = n!/2$. All proofs use `native_decide` — the groups (5040, 40320 elements) exceed `decide`'s kernel evaluation budget, requiring the native code evaluator. The factorial identities `factorial_s3/s4/s5` formally tie the abstract `Fintype.card (Equiv.Perm (Fin n))` to `Nat.factorial n`, providing definitional bridges useful as simp lemmas. The half-factorial identities `half_factorial_a3/a4/a5` verify $|A_n| = n!/2$ (note: integer division, since $n! / 2$ is always exact for $n \\geq 2$). These results serve as computational lemmas for other algebraic arguments and as regression tests confirming Mathlib's group theory infrastructure correctly handles these concrete groups. The fact that $|A_8| = 20160$ is also the order of $GL_4(\\mathbb{F}_2)$ reflects an exceptional isomorphism $A_8 \\cong GL_4(\\mathbb{F}_2)$.",
+    "mathContext": "$|S_7| = 5040 = 7!$; $|S_8| = 40320 = 8!$; $|A_7| = 2520 = 7!/2$; $|A_8| = 20160 = 8!/2$. Exceptional: $A_8 \\cong GL_4(\\mathbb{F}_2)$ (order 20160), one of the exceptional isomorphisms between alternating groups and classical groups over finite fields. `native_decide` compiles the Lean proposition to native OCaml and evaluates it, bypassing kernel reduction for speed.",
+    "significance": "technical",
+    "relatedConcepts": ["native_decide", "Fintype.card", "Nat.factorial", "symmetric group order", "alternating group order", "exceptional group isomorphisms"],
+    "prerequisites": ["native_decide tactic", "Fintype.card", "factorial function", "symmetric group", "alternating group", "integer division in Nat"]
   }
 ]

--- a/src/data/proofs/abel-ruffini-galois-extensions/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions/meta.json
@@ -179,6 +179,13 @@
       "summary": "Proves solvability of $A_n$ for $n \\leq 4$ and non-solvability for $n \\geq 5$ (complete $A_n$ classification). Group cardinalities from $|S_2|=2$ to $|S_6|=720$. Solvability preservation: subgroups, quotients, isomorphisms. Specific non-solvability of $S_5, S_6, S_7, S_8$ and $A_6, A_7$."
     },
     {
+      "id": "specific-non-solvable",
+      "title": "Specific Non-Solvability: S₅–S₈ and A₅–A₇",
+      "startLine": 366,
+      "endLine": 406,
+      "summary": "Concrete non-solvability witnesses for S₅, S₆, S₇, S₈ and A₅, A₆, A₇ — each a one-liner applying `symmetric_not_solvable_of_five_le` or `alternating_not_solvable_of_five_le`. Includes `symmetric_not_solvable_of_alternating`: if $A_n$ is not solvable then $S_n$ is not solvable (contrapositive of subgroup solvability, proved immediately by `inferInstance`)."
+    },
+    {
       "id": "chain-properties",
       "title": "Chain Properties and Sign Kernel Identity",
       "startLine": 407,


### PR DESCRIPTION
Enrichment pass for abel-ruffini-galois-extensions. Quality improvements:

**New annotations (4 added, total now 14):**
- `arg-galois-order-subgroup` (lines 219–248): Galois group order = extension degree theorem + subgroup solvability via inferInstance
- `arg-group-cardinalities` (lines 288–329): $|S_n| = n!$ and $|A_n| = n!/2$ computations for $n \leq 6$ with decide/native_decide
- `arg-specific-non-solvable` (lines 366–406): S₅–S₈ and A₅–A₇ non-solvability witnesses; `symmetric_not_solvable_of_alternating` explained
- `arg-higher-cardinalities-factorial` (lines 464–516): $|S_7|=5040$, $|S_8|=40320$, $|A_7|=2520$, $|A_8|=20160$ via native_decide; factorial identity theorems; exceptional $A_8 \cong GL_4(\mathbb{F}_2)$ noted

**Sections fix:**
- Added missing `specific-non-solvable` section (lines 366–406) to close the gap between `solvability-infrastructure` (ends 365) and `chain-properties` (starts 407)

All annotations include `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.