### PR TITLE
Fix: Convert axiom declarations to theorem+sorry in Erdos840Aristotle.lean

### DIFF
--- a/proofs/Proofs/Erdos840Aristotle.lean
+++ b/proofs/Proofs/Erdos840Aristotle.lean
@@ -126,8 +126,8 @@ lemma sidon_distinct_sums (A : Finset ℕ) (hS : IsSidon' A)
     Proof: the map (a,b) ↦ {a,b} bijects strict pairs with 2-element subsets,
     and there are A.card.choose 2 such subsets by Finset.card_powersetLen.
     This is a standard combinatorial identity. -/
-axiom unordered_pairs_card (A : Finset ℕ) :
-    ((A ×ˢ A).filter fun p => p.1 < p.2).card = A.card.choose 2
+theorem unordered_pairs_card (A : Finset ℕ) :
+    ((A ×ˢ A).filter fun p => p.1 < p.2).card = A.card.choose 2 := by sorry
 
 /-- Sumset is nonempty when A is nonempty -/
 lemma sumset_nonempty (A : Finset ℕ) (hA : A.Nonempty) : (sumset' A).Nonempty := by
@@ -186,8 +186,8 @@ lemma two_div_sqrt3_gt_one : 2 / Real.sqrt 3 > 1 := by
 
     Note: the original statement sqrt(N) + 1 is incorrect for large N;
     the correct bound from the differences argument is sqrt(2*N) + 1. -/
-axiom sidon_card_le_sqrt (A : Finset ℕ) (N : ℕ) (hN : N ≥ 1)
+theorem sidon_card_le_sqrt (A : Finset ℕ) (N : ℕ) (hN : N ≥ 1)
     (hA : ∀ a ∈ A, a ≤ N) (hS : IsSidon' A) :
-    (A.card : ℝ) ≤ Real.sqrt (2 * N) + 1
+    (A.card : ℝ) ≤ Real.sqrt (2 * N) + 1 := by sorry
 
 end Erdos840.Aristotle


### PR DESCRIPTION
## Fix

Two `axiom` declarations in `Erdos840Aristotle.lean` blocked Aristotle from attempting automated proof search on those lemmas — Aristotle skips `axiom` declarations entirely and only proves `theorem`/`lemma` sorries.

## Evidence

**Before**:
```lean
axiom unordered_pairs_card (A : Finset ℕ) :
    ((A ×ˢ A).filter fun p => p.1 < p.2).card = A.card.choose 2

axiom sidon_card_le_sqrt (A : Finset ℕ) (N : ℕ) (hN : N ≥ 1)
    (hA : ∀ a ∈ A, a ≤ N) (hS : IsSidon' A) :
    (A.card : ℝ) ≤ Real.sqrt (2 * N) + 1
```

**After**:
```lean
theorem unordered_pairs_card (A : Finset ℕ) :
    ((A ×ˢ A).filter fun p => p.1 < p.2).card = A.card.choose 2 := by sorry

theorem sidon_card_le_sqrt (A : Finset ℕ) (N : ℕ) (hN : N ≥ 1)
    (hA : ∀ a ∈ A, a ≤ N) (hS : IsSidon' A) :
    (A.card : ℝ) ≤ Real.sqrt (2 * N) + 1 := by sorry
```

Both lemmas are standard combinatorial results (`unordered_pairs_card` is a bijection argument, `sidon_card_le_sqrt` is the differences-argument Sidon bound) that Aristotle should be able to prove once they're in `theorem` form.

---
Automated fix by lean-mechanic agent.