### PR TITLE
Audit: fix ptolemys-theorem-oq-01-oq-01 leanFile.axiomCount (0→1)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12908,8 +12908,8 @@
       ]
     },
     "ptolemys-theorem-oq-01-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-21T20:16:53Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-22T10:52:54Z",
       "result": "issues-fixed",
       "issues": []
     }

--- a/src/data/proofs/ptolemys-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01-oq-01/meta.json
@@ -149,7 +149,7 @@
     "opens": [],
     "namespace": null,
     "lineCount": 288,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 1,
     "definitionCount": 0,
     "sorries": 0,


### PR DESCRIPTION
## Summary

- `leanFile.axiomCount`: 0→1 to match actual `axiom positive_ratio_implies_cyclic_order` declaration at line 145
- `meta.axiomCount` was already correctly 1 — no gallery-facing change
- Status `axiomatized` / badge `axiom` are correct and unchanged

## Test plan
- [ ] `leanFile.axiomCount` matches `grep -c "^axiom " proofs/Proofs/PtolemysTheoremOq01Oq01.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)