### PR TITLE
Enrich algebraic-numbers-countable: fix annotation format, add 2 annotations, 3 cross-refs

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable/annotations.json
+++ b/src/data/proofs/algebraic-numbers-countable/annotations.json
@@ -1,62 +1,107 @@
 [
   {
     "id": "ann-algebraic-overview",
-    "line": 1,
-    "endLine": 66,
+    "proofId": "algebraic-numbers-countable",
+    "range": {
+      "startLine": 1,
+      "endLine": 66
+    },
     "type": "context",
     "title": "Cantor 1874: Algebraic Numbers Are Countable — The Theorem That Created Transcendental Number Theory",
-    "body": "This module formalizes Cantor's 1874 theorem that the algebraic numbers are countable. The result appears in the same paper ('Über eine Eigenschaft des Inbegriffes aller reellen algebraischen Zahlen') where Cantor proved the real numbers are uncountable — the first demonstration that infinite sets can have different sizes.\n\nThe historical significance is profound:\n- Before 1874: mathematicians knew of no transcendental numbers (numbers that are not roots of any rational polynomial)\n- Hermite 1873: proved e is transcendental — the first specific transcendental\n- Cantor 1874: proved 'almost all' reals are transcendental (in the sense of cardinality), before anyone knew how to construct them\n- Liouville 1844 had earlier shown transcendental numbers exist by explicit construction (Liouville's constant), but Cantor's cardinality argument showed they must be 'everywhere'\n\nThe formalization proves 18 theorems organized in 7 sections: direct results (delegating to Mathlib), bounded-degree sets, exact-degree stratification, degree union decomposition, degree 1 = rationals, cardinality equality, and exhaustive filtration. Two proof styles are used: the direct one-line delegation to `Algebraic.countable`, and the constructive degree-stratification proof via `Set.countable_iUnion`.",
+    "content": "This module formalizes Cantor's 1874 theorem that the algebraic numbers are countable. The result appears in the same paper ('Über eine Eigenschaft des Inbegriffes aller reellen algebraischen Zahlen') where Cantor proved the real numbers are uncountable — the first demonstration that infinite sets can have different sizes.\n\nThe historical significance is profound:\n- Before 1874: mathematicians knew of no transcendental numbers (numbers that are not roots of any rational polynomial)\n- Hermite 1873: proved e is transcendental — the first specific transcendental\n- Cantor 1874: proved 'almost all' reals are transcendental (in the sense of cardinality), before anyone knew how to construct them\n- Liouville 1844 had earlier shown transcendental numbers exist by explicit construction (Liouville's constant), but Cantor's cardinality argument showed they must be 'everywhere'\n\nThe formalization proves 18 theorems organized in 7 sections: direct results (delegating to Mathlib), bounded-degree sets, exact-degree stratification, degree union decomposition, degree 1 = rationals, cardinality equality, and exhaustive filtration. Two proof styles are used: the direct one-line delegation to `Algebraic.countable`, and the constructive degree-stratification proof via `Set.countable_iUnion`.",
     "mathContext": "Countability hierarchy for number systems: ℕ ≅ ℤ ≅ ℚ ≅ algebraic reals (all ℵ₀) ⊊ ℝ ≅ ℂ ≅ transcendental reals (all 2^ℵ₀). The key fact: |{degree ≤ d polynomials over ℚ}| = |ℚ^{d+1}| = ℵ₀, and each polynomial has ≤ d roots. So |{algebraic reals of degree ≤ d}| ≤ d · ℵ₀ = ℵ₀. The union over d ∈ ℕ remains ℵ₀.",
-    "significance": "This is one of the foundational results of set theory and the basis of all transcendence theory. Proving it in Lean required 18 theorems because the degree stratification reveals a rich internal structure that goes beyond the simple one-liner. The formalization connects Mathlib's abstract `Algebraic.countable` API with concrete degree-indexed definitions that make the structure explicit.",
+    "significance": "key",
     "relatedConcepts": ["Cantor-1874", "countability", "degree-stratification", "Algebraic.countable", "transcendental-numbers", "cardinality"],
     "prerequisites": ["Mathlib.Algebra.AlgebraicCard", "Set.Countable and Set.countable_iUnion", "Cardinal.mk and Cardinal.aleph0"]
   },
   {
     "id": "ann-algebraic-core-countable",
-    "line": 76,
-    "endLine": 101,
+    "proofId": "algebraic-numbers-countable",
+    "range": {
+      "startLine": 76,
+      "endLine": 101
+    },
     "type": "proof",
     "title": "algebraic_reals_countable: One-Line Proof via Mathlib's Algebraic.countable",
-    "body": "The shortest proof in the file is the most fundamental:\n\n```lean\ntheorem algebraic_reals_countable : Set.Countable {x : ℝ | IsAlgebraic ℚ x} :=\n  Algebraic.countable ℚ ℝ\n```\n\n`Algebraic.countable` (in `Mathlib.Algebra.AlgebraicCard`) proves: if R is a countable commutative ring and E is an R-algebra, then the set of R-algebraic elements of E is countable. Applied with R = ℚ (which is countable/Denumerable) and E = ℝ, this gives the result in one line.\n\nThe cardinality strengthening `card_algebraic_reals_eq_aleph0` uses `Algebraic.cardinalMk_of_countable_of_charZero ℚ ℝ`, which needs char(ℝ) = 0 (characteristic zero). This condition ensures infinitely many distinct algebraic numbers exist (ruling out the finite case). The result Cardinal.mk {...} = Cardinal.aleph0 is strictly stronger than Set.Countable — it proves countably infinite, not just countable.\n\nBoth real and complex cases are handled: `algebraic_complex_countable` and `card_algebraic_complex_eq_aleph0` use ℂ instead of ℝ, and `Algebraic.countable ℚ ℂ` works because ℂ is also a ℚ-algebra.",
+    "content": "The shortest proof in the file is the most fundamental:\n\n```lean\ntheorem algebraic_reals_countable : Set.Countable {x : ℝ | IsAlgebraic ℚ x} :=\n  Algebraic.countable ℚ ℝ\n```\n\n`Algebraic.countable` (in `Mathlib.Algebra.AlgebraicCard`) proves: if R is a countable commutative ring and E is an R-algebra, then the set of R-algebraic elements of E is countable. Applied with R = ℚ (which is countable/Denumerable) and E = ℝ, this gives the result in one line.\n\nThe cardinality strengthening `card_algebraic_reals_eq_aleph0` uses `Algebraic.cardinalMk_of_countable_of_charZero ℚ ℝ`, which needs char(ℝ) = 0 (characteristic zero). This condition ensures infinitely many distinct algebraic numbers exist (ruling out the finite case). The result Cardinal.mk {...} = Cardinal.aleph0 is strictly stronger than Set.Countable — it proves countably infinite, not just countable.\n\nBoth real and complex cases are handled: `algebraic_complex_countable` and `card_algebraic_complex_eq_aleph0` use ℂ instead of ℝ, and `Algebraic.countable ℚ ℂ` works because ℂ is also a ℚ-algebra.",
     "mathContext": "Mathlib's `Algebraic.countable` proof works as follows: algebraic elements of E over R are a subset of roots of all nonzero polynomials in R[X]. There are countably many such polynomials (R[X] is countable when R is countable), each has finitely many roots. The countable union of finite sets is countable. This is exactly the degree-stratification argument, packaged abstractly.",
-    "significance": "The one-line proof is possible because Mathlib has a fully abstract, general form of Cantor's theorem. This demonstrates the power of Mathlib's algebraic hierarchy: the countability of algebraic numbers follows from general facts about polynomial rings over countable coefficient rings, not from anything special about ℝ or ℂ.",
+    "significance": "key",
     "relatedConcepts": ["Algebraic.countable", "cardinalMk_of_countable_of_charZero", "Cardinal.aleph0", "Denumerable-ℚ"],
     "prerequisites": ["Mathlib.Algebra.AlgebraicCard", "ℚ is Denumerable (Mathlib.Data.Rat.Denumerable)"]
   },
   {
-    "id": "ann-algebraic-stratification",
-    "line": 171,
-    "endLine": 201,
-    "type": "proof",
-    "title": "Degree Stratification: algebraic_reals_eq_iUnion_degree and the Alternative Countability Proof",
-    "body": "The degree stratification theorem `algebraic_reals_eq_iUnion_degree` proves:\n{x : ℝ | IsAlgebraic ℚ x} = ⋃ d : ℕ, algebraicRealsOfDegree d\n\nThe proof is a `by ext x; simp; constructor` argument:\n- **(→)**: Given IsAlgebraic ℚ x, take d = (minpoly ℚ x).natDegree. Then x ∈ algebraicRealsOfDegree d since natDegree(minpoly ℚ x) = d by rfl.\n- **(←)**: Given ⟨d, hx, _⟩, extract IsAlgebraic from hx.1 (the first component of the conjunction defining algebraicRealsOfDegree).\n\n`algebraic_reals_countable_via_strata` then uses this to give an alternative proof:\n```lean\nrw [algebraic_reals_eq_iUnion_degree]\nexact Set.countable_iUnion algebraicRealsOfDegree_countable\n```\n\n`Set.countable_iUnion` proves: if I is a countable index type (ℕ is Countable) and each A i is countable, then ⋃ i, A i is countable. Applied with A d = algebraicRealsOfDegree d (each countable by algebraicRealsOfDegree_countable), this gives the result.",
-    "mathContext": "The key lemma `Set.countable_iUnion` requires the index type to be countable (ℕ satisfies this). Without this condition, the union of countably many countable sets could be uncountable (the union of uncountably many countable sets is not necessarily countable). The degree index is ℕ — a countable well-order — which makes this valid.",
-    "significance": "The stratification proof is more constructive than the direct Mathlib delegation: it exhibits an explicit enumeration strategy (enumerate by degree, then within each degree by polynomial). This is Cantor's original argument made precise. The two proofs of algebraic_reals_countable (direct and via strata) are equivalent but highlight different aspects: the direct proof shows it's a special case of abstract algebra; the strata proof reveals the internal structure.",
-    "relatedConcepts": ["Set.countable_iUnion", "algebraicRealsOfDegree", "minpoly.natDegree", "degree-stratification"],
-    "prerequisites": ["algebraicRealsOfDegree_countable", "Set.countable_iUnion (for countable index type)", "algebraic_reals_eq_iUnion_degree"]
-  },
-  {
     "id": "ann-algebraic-bounded-exact",
-    "line": 107,
-    "endLine": 165,
+    "proofId": "algebraic-numbers-countable",
+    "range": {
+      "startLine": 107,
+      "endLine": 165
+    },
     "type": "note",
     "title": "Two Stratification Levels: Bounded vs Exact Degree — A Filtration Structure",
-    "body": "The formalization defines two nested families of sets:\n\n**Bounded degree**: `algebraicRealsOfBoundedDegree d = {x | IsAlgebraic ℚ x ∧ natDegree(minpoly x) ≤ d}`\n- Forms a monotone chain: deg≤0 ⊆ deg≤1 ⊆ deg≤2 ⊆ ...\n- Union equals all algebraic reals (proven in §7)\n- `bounded_degree_monotone`: monotonicity proved by Nat.le_succ_of_le\n\n**Exact degree**: `algebraicRealsOfDegree d = {x | IsAlgebraic ℚ x ∧ natDegree(minpoly x) = d}`\n- Each a distinct, disjoint horizontal slice\n- `exact_degree_subset_bounded`: degree d ⊆ bounded degree d (le_of_eq converts = to ≤)\n- Union equals all algebraic reals (proven in §4)\n\nThe relationship: algebraicRealsOfBoundedDegree d = ⋃_{k≤d} algebraicRealsOfDegree k. Both are countable (as subsets of the countable set of all algebraic numbers via Set.Countable.mono).\n\nCountability of bounded-degree sets is proved first (§2), then exact-degree (§3) uses it as an intermediate step via the inclusion chain: exact d ⊆ bounded d ⊆ all algebraic (countable).",
+    "content": "The formalization defines two nested families of sets:\n\n**Bounded degree**: `algebraicRealsOfBoundedDegree d = {x | IsAlgebraic ℚ x ∧ natDegree(minpoly x) ≤ d}`\n- Forms a monotone chain: deg≤0 ⊆ deg≤1 ⊆ deg≤2 ⊆ ...\n- Union equals all algebraic reals (proven in §7)\n- `bounded_degree_monotone`: monotonicity proved by Nat.le_succ_of_le\n\n**Exact degree**: `algebraicRealsOfDegree d = {x | IsAlgebraic ℚ x ∧ natDegree(minpoly x) = d}`\n- Each a distinct, disjoint horizontal slice\n- `exact_degree_subset_bounded`: degree d ⊆ bounded degree d (le_of_eq converts = to ≤)\n- Union equals all algebraic reals (proven in §4)\n\nThe relationship: algebraicRealsOfBoundedDegree d = ⋃_{k≤d} algebraicRealsOfDegree k. Both are countable (as subsets of the countable set of all algebraic numbers via Set.Countable.mono).\n\nCountability of bounded-degree sets is proved first (§2), then exact-degree (§3) uses it as an intermediate step via the inclusion chain: exact d ⊆ bounded d ⊆ all algebraic (countable).",
     "mathContext": "The bounded-degree filtration is an algebraic analogue of truncated Taylor series: algebraicRealsOfBoundedDegree d can be thought of as 'numbers algebraically describable by polynomials of complexity ≤ d'. As d → ∞, this exhausts all algebraic numbers. This is formalized in `algebraic_reals_eq_iUnion_bounded`.",
-    "significance": "Having both bounded and exact degree stratifications provides complementary perspectives. The bounded-degree filtration is useful for approximation arguments: 'x is algebraic of degree at most d' has nicer closure properties (it's a union of finitely many exact-degree strata). The exact-degree stratification is useful for classification: 'x has degree d' is an invariant of the algebraic number. Both appear naturally in transcendence proofs.",
+    "significance": "key",
     "relatedConcepts": ["algebraicRealsOfBoundedDegree", "algebraicRealsOfDegree", "bounded_degree_monotone", "Set.Countable.mono", "minpoly.natDegree"],
     "prerequisites": ["Algebraic.countable for the outer containment", "Set.Countable.mono for inheritance to subsets"]
   },
   {
+    "id": "ann-algebraic-stratification",
+    "proofId": "algebraic-numbers-countable",
+    "range": {
+      "startLine": 171,
+      "endLine": 201
+    },
+    "type": "proof",
+    "title": "Degree Stratification: algebraic_reals_eq_iUnion_degree and the Alternative Countability Proof",
+    "content": "The degree stratification theorem `algebraic_reals_eq_iUnion_degree` proves:\n{x : ℝ | IsAlgebraic ℚ x} = ⋃ d : ℕ, algebraicRealsOfDegree d\n\nThe proof is a `by ext x; simp; constructor` argument:\n- **(→)**: Given IsAlgebraic ℚ x, take d = (minpoly ℚ x).natDegree. Then x ∈ algebraicRealsOfDegree d since natDegree(minpoly ℚ x) = d by rfl.\n- **(←)**: Given ⟨d, hx, _⟩, extract IsAlgebraic from hx.1 (the first component of the conjunction defining algebraicRealsOfDegree).\n\n`algebraic_reals_countable_via_strata` then uses this to give an alternative proof:\n```lean\nrw [algebraic_reals_eq_iUnion_degree]\nexact Set.countable_iUnion algebraicRealsOfDegree_countable\n```\n\n`Set.countable_iUnion` proves: if I is a countable index type (ℕ is Countable) and each A i is countable, then ⋃ i, A i is countable. Applied with A d = algebraicRealsOfDegree d (each countable by algebraicRealsOfDegree_countable), this gives the result.",
+    "mathContext": "The key lemma `Set.countable_iUnion` requires the index type to be countable (ℕ satisfies this). Without this condition, the union of countably many countable sets could be uncountable (the union of uncountably many countable sets is not necessarily countable). The degree index is ℕ — a countable well-order — which makes this valid.",
+    "significance": "key",
+    "relatedConcepts": ["Set.countable_iUnion", "algebraicRealsOfDegree", "minpoly.natDegree", "degree-stratification"],
+    "prerequisites": ["algebraicRealsOfDegree_countable", "Set.countable_iUnion (for countable index type)", "algebraic_reals_eq_iUnion_degree"]
+  },
+  {
+    "id": "ann-algebraic-degree1-filtration",
+    "proofId": "algebraic-numbers-countable",
+    "range": {
+      "startLine": 207,
+      "endLine": 217
+    },
+    "type": "note",
+    "title": "Degree 1 = Rationals and the Monotone Filtration ℚ ⊆ deg≤1 ⊆ deg≤2 ⊆ ...",
+    "content": "Section 5 establishes two structural facts about the degree stratification:\n\n**`rat_algebraic_degree_one`**: Every rational q ∈ ℚ is algebraic of degree 1:\n```lean\ntheorem rat_algebraic_degree_one (q : ℚ) :\n    IsAlgebraic ℚ (algebraMap ℚ ℝ q) := isAlgebraic_algebraMap q\n```\nThe proof is a single call to `isAlgebraic_algebraMap`, which states that any element mapped from the coefficient ring R into an R-algebra E via `algebraMap` is algebraic over R. For q ∈ ℚ mapped to ℝ, the minimal polynomial is X - q (degree 1), confirming degree exactly 1. This pins the bottom stratum: deg-1 ⊇ image(ℚ → ℝ).\n\n**`bounded_degree_monotone`**: The degree-bounded sets form a monotone chain:\n```lean\ntheorem bounded_degree_monotone (d : ℕ) :\n    algebraicRealsOfBoundedDegree d ⊆ algebraicRealsOfBoundedDegree (d + 1)\n```\nProof: if natDegree(minpoly x) ≤ d, then also ≤ d+1 by `Nat.le_succ_of_le`. This single-line proof establishes the filtration structure: the bounded-degree sets are nested ⋯ ⊆ B_d ⊆ B_{d+1} ⊆ ⋯ with exhaustive union (proved in §7). \n\nTogether, these give the chain: ℚ ≅ algebraicRealsOfDegree 1 ⊆ algebraicRealsOfBoundedDegree 1 ⊆ algebraicRealsOfBoundedDegree 2 ⊆ ⋯ ⊆ all algebraic, with each inclusion proper (e.g., ∛2 ∈ B_3 \\ B_2) and all having the same cardinality ℵ₀.",
+    "mathContext": "`isAlgebraic_algebraMap` is the Mathlib lemma: for any `Algebra R E`, `∀ r : R, IsAlgebraic R (algebraMap R E r)`. It works because r satisfies the polynomial X - algebraMap r, which has degree 1 and coefficient 1 ≠ 0. This is the cleanest way to connect ℚ-rationality to degree-1 algebraicity in Lean.",
+    "significance": "supporting",
+    "relatedConcepts": ["isAlgebraic_algebraMap", "algebraMap", "bounded_degree_monotone", "Nat.le_succ_of_le", "degree-1-rationals"],
+    "prerequisites": ["algebraicRealsOfBoundedDegree definition (§2)", "Algebra R E typeclass", "isAlgebraic_algebraMap from Mathlib.RingTheory.Algebraic.Basic"]
+  },
+  {
     "id": "ann-algebraic-cardinality-paradox",
-    "line": 223,
-    "endLine": 235,
+    "proofId": "algebraic-numbers-countable",
+    "range": {
+      "startLine": 223,
+      "endLine": 235
+    },
     "type": "note",
     "title": "Cardinal Paradox: Algebraic ≅ ℚ ≅ ℕ Despite Proper Containment ℕ ⊊ ℚ ⊊ Algebraic",
-    "body": "The theorem `card_algebraic_eq_card_rat` proves:\nCardinal.mk {x : ℝ // IsAlgebraic ℚ x} = Cardinal.mk ℚ\n\nProof:\n```lean\nrw [card_algebraic_reals_eq_aleph0, Cardinal.mk_denumerable]\n```\n\nBoth sides equal ℵ₀: the left by `card_algebraic_reals_eq_aleph0`, the right because ℚ is Denumerable (has an explicit bijection to ℕ), giving `Cardinal.mk ℚ = Cardinal.aleph0` via `mk_denumerable`.\n\nSimilarly `card_algebraic_eq_card_nat` gives |algebraic reals| = |ℕ|.\n\nThis formalizes the 'Hilbert Hotel' phenomenon for algebraic numbers: adding √2, √3, ∛2, and all other algebraic irrationals to ℚ doesn't change the cardinality. The proper containment ℕ ⊊ ℤ ⊊ ℚ ⊊ algebraic reals is real (no surjection in the other direction), but all these sets have the same infinite cardinality ℵ₀.\n\nThe logical structure: |algebraic| = ℵ₀ = |ℕ| = |ℤ| = |ℚ| ≠ |ℝ| = 2^ℵ₀ = |ℂ| = |transcendentals|.",
+    "content": "The theorem `card_algebraic_eq_card_rat` proves:\nCardinal.mk {x : ℝ // IsAlgebraic ℚ x} = Cardinal.mk ℚ\n\nProof:\n```lean\nrw [card_algebraic_reals_eq_aleph0, Cardinal.mk_denumerable]\n```\n\nBoth sides equal ℵ₀: the left by `card_algebraic_reals_eq_aleph0`, the right because ℚ is Denumerable (has an explicit bijection to ℕ), giving `Cardinal.mk ℚ = Cardinal.aleph0` via `mk_denumerable`.\n\nSimilarly `card_algebraic_eq_card_nat` gives |algebraic reals| = |ℕ|.\n\nThis formalizes the 'Hilbert Hotel' phenomenon for algebraic numbers: adding √2, √3, ∛2, and all other algebraic irrationals to ℚ doesn't change the cardinality. The proper containment ℕ ⊊ ℤ ⊊ ℚ ⊊ algebraic reals is real (no surjection in the other direction), but all these sets have the same infinite cardinality ℵ₀.\n\nThe logical structure: |algebraic| = ℵ₀ = |ℕ| = |ℤ| = |ℚ| ≠ |ℝ| = 2^ℵ₀ = |ℂ| = |transcendentals|.",
     "mathContext": "Cardinal.mk_denumerable states: for any type α with [Denumerable α], Cardinal.mk α = Cardinal.aleph0. A type is Denumerable if it has a bijection to ℕ. ℚ is Denumerable (proved via the Cantor pairing function on ℤ × ℕ). This gives the cardinality equality without constructing an explicit bijection between algebraic reals and ℚ.",
-    "significance": "The cardinality equality is philosophically striking: algebraic numbers include all finite algebraic extensions of ℚ, which form an infinite tower ℚ ⊊ ℚ(√2) ⊊ ℚ(∛2, √2) ⊊ ... — yet the limit has the same cardinality as the base. This counterintuitive fact is only provable via cardinal arithmetic, not by constructing explicit bijections (which would be much harder). The Lean proof elegantly avoids that difficulty by using transitivity through ℵ₀.",
+    "significance": "key",
     "relatedConcepts": ["Cardinal.mk_denumerable", "Cardinal.aleph0", "Denumerable-ℚ", "Cardinal-arithmetic", "Hilbert-Hotel"],
     "prerequisites": ["card_algebraic_reals_eq_aleph0", "Cardinal.mk_denumerable from Logic.Denumerable", "Rat.instDenumerable"]
+  },
+  {
+    "id": "ann-algebraic-iUnion-bounded",
+    "proofId": "algebraic-numbers-countable",
+    "range": {
+      "startLine": 241,
+      "endLine": 254
+    },
+    "type": "proof",
+    "title": "Exhaustive Filtration: algebraic_reals_eq_iUnion_bounded Closes the Loop",
+    "content": "`algebraic_reals_eq_iUnion_bounded` proves:\n{x : ℝ | IsAlgebraic ℚ x} = ⋃ d : ℕ, algebraicRealsOfBoundedDegree d\n\nThis is the bounded-degree analogue of `algebraic_reals_eq_iUnion_degree` (§4). The proof mirrors the exact-degree version:\n```lean\next x; simp only [Set.mem_setOf_eq, Set.mem_iUnion, algebraicRealsOfBoundedDegree]\nconstructor\n· intro hx\n  exact ⟨(minpoly ℚ x).natDegree, hx, le_refl _⟩\n· rintro ⟨d, hx, -⟩\n  exact hx\n```\nThe key difference from the exact-degree version: the witness is d = natDegree(minpoly ℚ x), and the degree bound is `le_refl _` (natDegree ≤ natDegree) rather than `rfl` (natDegree = natDegree). This is a minor change but correctly matches the `≤` vs `=` distinction in the two set definitions.\n\nTogether with `bounded_degree_monotone` (§5), this closes the loop: the monotone chain B_0 ⊆ B_1 ⊆ B_2 ⊆ ⋯ exhausts all algebraic numbers. The section ends with `end AlgebraicNumbersCountable`, closing the namespace opened at line 68.",
+    "mathContext": "The two union theorems — exact-degree and bounded-degree — are related by: ⋃ d, algebraicRealsOfDegree d = ⋃ d, algebraicRealsOfBoundedDegree d (both equal the algebraic reals). This is consistent because algebraicRealsOfBoundedDegree d = ⋃_{k=0}^{d} algebraicRealsOfDegree k, so the two unions have the same limit. The bounded-degree filtration is coarser (each B_d contains multiple exact strata) but has nicer topological properties.",
+    "significance": "supporting",
+    "relatedConcepts": ["algebraicRealsOfBoundedDegree", "algebraic_reals_eq_iUnion_degree", "bounded_degree_monotone", "Set.mem_iUnion", "le_refl"],
+    "prerequisites": ["algebraicRealsOfBoundedDegree definition (§2)", "algebraic_reals_eq_iUnion_degree (§4) for comparison", "bounded_degree_monotone (§5) for filtration structure"]
   }
 ]

--- a/src/data/proofs/algebraic-numbers-countable/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable/meta.json
@@ -111,7 +111,23 @@
       "description": "Section 6: `card_algebraic_eq_card_rat` proves |{x : \u211d // IsAlgebraic \u211a x}| = |\u211a| by rewriting both via aleph0 (card_algebraic_reals_eq_aleph0 and Cardinal.mk_denumerable). `card_algebraic_eq_card_nat` proves the same equals |\u2115|. Both illustrate the 'paradox' that a proper superset has the same cardinality. Section 7: `algebraic_reals_eq_iUnion_bounded` proves {x : \u211d | IsAlgebraic \u211a x} = \u22c3 d, algebraicRealsOfBoundedDegree d, using d = natDegree(minpoly x) and le_refl. This is the bounded-degree version of the exact-degree stratification. Ends with end AlgebraicNumbersCountable."
     }
   ],
-  "crossReferences": [],
+  "crossReferences": [
+    {
+      "targetId": "algebraic-numbers-countable-oq-02",
+      "relationship": "companion",
+      "description": "Proves ℝ is uncountable via Cantor's diagonal argument — the complementary result from Cantor's 1874 paper. Together these two results establish: algebraic numbers are countable (ℵ₀) while reals are uncountable (2^ℵ₀), implying almost all real numbers are transcendental."
+    },
+    {
+      "targetId": "cantor-diagonalization",
+      "relationship": "related",
+      "description": "Cantor's diagonal argument that ℝ is uncountable — the other half of the 1874 paper. The countability of algebraic numbers and uncountability of ℝ together imply transcendental numbers are 'most' real numbers."
+    },
+    {
+      "targetId": "cayley-hamilton-minpoly",
+      "relationship": "related",
+      "description": "The Cayley-Hamilton theorem and minimal polynomial theory (minpoly) are central to both proofs. algebraic-numbers-countable uses minpoly ℚ x extensively for the degree stratification; Cayley-Hamilton proves A satisfies its own minpoly in a matrix algebra context."
+    }
+  ],
   "leanFile": {
     "lineCount": 254,
     "path": "Proofs/AlgebraicNumbersCountable.lean",


### PR DESCRIPTION
## Summary

- Fix annotation format: convert `line`/`endLine`/`body` (old format) to `range.startLine`/`range.endLine`/`content` with `proofId` field — validator now shows **7 valid, 0 misaligned** (was 0 valid previously)
- Add 2 new annotations covering §5 and §7 (both previously unannotated)
- Add 3 cross-references to related gallery entries

## New Annotations

| Annotation | Lines | Description |
|---|---|---|
| `ann-algebraic-degree1-filtration` | 207-217 | `rat_algebraic_degree_one` + `bounded_degree_monotone` — the filtration ℚ ⊆ deg≤1 ⊆ deg≤2 ⊆ ... and `isAlgebraic_algebraMap` as the key Mathlib lemma |
| `ann-algebraic-iUnion-bounded` | 241-254 | `algebraic_reals_eq_iUnion_bounded` — explains `le_refl` vs `rfl` for bounded vs exact degree, closes the filtration loop |

## Cross-References Added

- `algebraic-numbers-countable-oq-02` (companion): ℝ is uncountable — the complementary result from Cantor's 1874 paper
- `cantor-diagonalization` (related): diagonal argument proving ℝ uncountable — the other half of Cantor 1874
- `cayley-hamilton-minpoly` (related): shares the `minpoly` infrastructure that drives the degree stratification

🤖 Generated with [Claude Code](https://claude.com/claude-code)