### PR TITLE
Fix: document true-stub theorems and vacuous defs in hilbert-11 assumptions

### DIFF
--- a/src/data/proofs/hilbert-11/meta.json
+++ b/src/data/proofs/hilbert-11/meta.json
@@ -32,7 +32,7 @@
     "hilbertNumber": 11,
     "axiomCount": 5,
     "lineCount": 494,
-    "assumptions": "5 axioms: diagonalForm, sylvester_law_of_inertia, hasse_minkowski_alt, rational_classification_complete, selmer_curve_no_rational_points. See Lean source for complete statements.",
+    "assumptions": "5 axiom declarations: diagonalForm, sylvester_law_of_inertia, hasse_minkowski_alt, rational_classification_complete, selmer_curve_no_rational_points. Additionally, 5 theorem-stubs with vacuous True conclusions (proved by trivial, not genuine proofs): weak_hasse_principle, ternary_representation, witt_cancellation, dimension_five_always_isotropic, hilbert_reciprocity. Three definitions use True as a placeholder body (RepresentsZeroOverReals, RepresentsZeroOverPadic, HasseMinkowskiNumberField), so hasse_minkowski_alt reduces to IsIsotropic Q ↔ True — a vacuous axiom. HilbertSymbol is hardcoded to 1 as a placeholder. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Fix

Update `assumptions` field in hilbert-11 meta.json to document all incompleteness: 5 true-stub theorems, 3 vacuous definitions, and the HilbertSymbol placeholder.

## Evidence

**Before**: Only listed 5 `axiom` declarations; did not mention that 5 theorems use `True` as their conclusion (proved trivially), 3 definitions are defined as `True`, or that `HilbertSymbol` is hardcoded to `1`.

**After**: `assumptions` field now explicitly documents all vacuous elements:
- 5 theorem-stubs with True conclusions: `weak_hasse_principle`, `ternary_representation`, `witt_cancellation`, `dimension_five_always_isotropic`, `hilbert_reciprocity`
- 3 True-body definitions: `RepresentsZeroOverReals`, `RepresentsZeroOverPadic`, `HasseMinkowskiNumberField`
- Notes that `hasse_minkowski_alt` reduces to `IsIsotropic Q ↔ True` (vacuous) due to placeholder definitions
- Notes `HilbertSymbol` is hardcoded to `1`

badge/status remain correct (`axiom`/`axiomatized`).

Closes #11296

---
Automated fix by lean-mechanic agent.