### PR TITLE
Fix: dissection-of-cubes-oq-02 status verified→axiomatized (ScissorsCongruent stub)

### DIFF
--- a/research/problems/erdos-268/knowledge.md
+++ b/research/problems/erdos-268/knowledge.md
@@ -118,3 +118,70 @@ over infinite A ⊆ ℕ with convergent harmonic subseries.
 1. Attempt greedy harmonic construction for d=1 (the primary remaining sorry)
 2. Try `aristotle_submit` on the greedy construction sorry
 3. Verify compilation once build resources allow
+
+---
+
+## Session 2026-04-22 (Session 3) — Greedy Harmonic Construction Implemented
+
+**Mode**: REVISIT (continuing Session 2 work)
+**Outcome**: progress — full greedy construction added; `greedySet_sum` proved without sorry;
+  `greedySet_infinite` remains as sorry (finite harmonic sum edge case)
+
+### What I Did
+
+1. Designed and implemented Part VIb (Greedy Harmonic Construction, ~250 lines)
+2. Defined `greedyBudget s : ℕ → ℝ` by primitive recursion; `greedySet s : Set ℕ`
+3. Proved `greedyBudget_eq_s_sub_sum`: key identity by induction over n (budget + partial sum = s)
+4. Proved `greedyBudget_tendsto_zero` via harmonic tail divergence contradiction:
+   - If inf L > 0: all k ≥ N₀ included → budget drops by Σ 1/(N₀+k+1) → ∞ → budget < 0
+   - Used `Real.tendsto_sum_range_one_div_nat_succ_atTop` + shift identity H(N₀+K) - H(N₀)
+5. Proved `greedySet_summable`: partial sums ≤ s via Finset max argument
+6. Proved `greedySet_sum` (no sorry): harmonic sum = s via
+   - `tsum_subtype` to lift to ℕ indicator function g
+   - `Finset.sum_filter` to connect filter sum to g-sum
+   - `hasSum_iff_tendsto_nat_of_nonneg` + `greedyBudget_tendsto_zero` for convergence
+7. Discovered `greedySet_infinite` is FALSE for some s (e.g., s=1/2 gives {2}, finite)
+8. Added Part XI: `consecutiveProductsSet n` infrastructure with `partial_sum_consec` (telescoping)
+
+### Key Findings
+
+- **greedyBudget_tendsto_zero**: The proof uses harmonic divergence as a contradiction engine.
+  If the budget has infimum L > 0, then for large k, budget ≥ L > L/2 ≥ 1/k, so every k is
+  included, making the budget drop by a divergent series. This forces budget < 0, contradiction.
+
+- **Finite termination edge case**: The greedy algorithm can terminate with budget = 0 when s
+  is an exact finite sum of distinct unit fractions (e.g., s=1={1}, s=1/2={2}, s=3/4={1,4}).
+  This is a set of measure 0 in ℝ but is countably infinite. `greedySet_infinite` is thus FALSE
+  for these s values.
+
+- **Fix needed**: Replace `greedySet` with a construction that guarantees infiniteness. Options:
+  (A) Detect finite case and apply Sylvester expansion (1/M = 1/(M+1) + 1/(M(M+1)))
+  (B) Use `consecutiveProductsSet` for remainder after initial greedy steps
+  (C) Prove `consecutiveProductsSet_sum` and use union: (greedySet \ {max}) ∪ consecProds(max)
+
+- **Mathlib APIs used**: `tendsto_atTop_ciInf`, `Finset.sum_filter`, `Classical.decPred`,
+  `hasSum_iff_tendsto_nat_of_nonneg`, `tsum_subtype`
+
+### Files Modified
+
+- `proofs/Proofs/Erdos268Problem.lean`:
+  - Added lines ~170-440: entire Part VIb (greedy construction) + Part XI (consecutiveProducts)
+  - Branch: `research/erdos-268-greedy`
+  - PR: rjwalters/lean-genius#11304
+
+### Sorry Status
+
+**2 remaining sorries**:
+1. `greedySet_infinite s hs` (line ~443): finite harmonic sum edge case; needs Sylvester expansion
+   or union with `consecutiveProductsSet`
+2. `d ≥ 2` case of `harmonicPointSet_path_connected` (line ~520): needs Kovač-Tao
+
+### Next Steps
+
+1. Prove `consecutiveProductsSet_sum n hn : harmonicSubseriesSum (consecutiveProductsSet n) = 1/n`
+   (follows from `partial_sum_consec` + limit 1/(n+N) → 0)
+2. Use union construction to fix `greedySet_infinite`:
+   If `greedySet s` is finite with max element M, let A = (greedySet s \ {M}) ∪ consecutiveProductsSet M
+   Then A is infinite, has same sum s (since 1/M = sum of consecutiveProductsSet M)
+3. Or: submit `greedySet_infinite` to Aristotle (HARD sorry — classical analysis)
+4. Once d=1 is complete, address d=2 via Kovač-Tao structural analysis

--- a/research/registry.json
+++ b/research/registry.json
@@ -17018,11 +17018,11 @@
     },
     {
       "slug": "angle-trisection-oq-02-oq-04-oq-01-incomplete-01",
-      "phase": "NEW",
+      "phase": "OBSERVE",
       "path": "full",
       "started": "2026-04-21T20:13:37.105Z",
       "status": "active",
-      "lastUpdate": "2026-04-21T20:13:37.105Z"
+      "lastUpdate": "2026-04-22T11:18:43.472Z"
     },
     {
       "slug": "fourier-series-oq-02-incomplete-01-oq-01",

--- a/src/data/proofs/dissection-of-cubes-oq-02/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Dehn (1900), Sydler (1965)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Hilbert%27s_third_problem",
     "date": "1900",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/DissectionOfCubesOQ02.lean",
     "tags": [
       "geometry",
@@ -17,7 +17,7 @@
       "polyhedra",
       "wiedijk-100"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-03-22",
     "mathlibDependencies": [
@@ -40,8 +40,8 @@
       "Conditional Hilbert's Third Problem: cube and tetrahedron not scissors congruent, assuming Dehn's theorem as hypothesis"
     ],
     "lineCount": 379,
-    "axiomCount": 0,
-    "assumptions": "No axiom declarations. Dehn's theorem is encoded as an explicit hypothesis (not an axiom) in hilbert_third_problem. ScissorsCongruent uses a simplified placeholder definition. The core number-theoretic result (arccos(1/3)/π is irrational) is fully proved.",
+    "axiomCount": 1,
+    "assumptions": "1 stub definition: `ScissorsCongruent (P Q : Type*) := ∃ (n : ℕ), True` (line 55-56 of Lean source). This placeholder makes everything trivially scissors congruent to everything — `scissors_congruent_refl` and `scissors_congruent_symm` hold vacuously. The scissors congruence relation is not mathematically formalized. Additionally, Dehn's theorem is encoded as an explicit hypothesis (not an axiom) in `hilbert_third_problem`. The core number-theoretic result (arccos(1/3)/π is irrational via Chebyshev recurrence) is fully proved with 0 sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/research/problems/erdos-268.json
+++ b/src/data/research/problems/erdos-268.json
@@ -1,16 +1,16 @@
 {
   "slug": "erdos-268",
-  "title": "Erdős #268: Path-Connectedness of Harmonic Subseries Points",
+  "title": "Erd\u0151s #268: Path-Connectedness of Harmonic Subseries Points",
   "phase": "ACT",
   "status": "in-progress",
   "tier": "B",
   "path": "full",
   "problemStatement": {
-    "formal": "theorem harmonicPointSet_path_connected (d : ℕ) : IsPathConnected (harmonicPointSet d) := by sorry",
-    "plain": "Erdos268Problem.lean has 1 remaining sorry: proving that the set X_d of harmonic subseries points is path-connected. The d=0 case is trivial (subsingleton), the d=1 case requires showing X_1 = (0,∞) via greedy construction, and d≥2 requires deeper analysis from Kovač-Tao 2024.",
+    "formal": "theorem harmonicPointSet_path_connected (d : \u2115) : IsPathConnected (harmonicPointSet d) := by sorry",
+    "plain": "Erdos268Problem.lean has 1 remaining sorry: proving that the set X_d of harmonic subseries points is path-connected. The d=0 case is trivial (subsingleton), the d=1 case requires showing X_1 = (0,\u221e) via greedy construction, and d\u22652 requires deeper analysis from Kova\u010d-Tao 2024.",
     "whyMatters": [
-      "Completes Erdős #268 formalization (currently 1 axiom + 1 sorry)",
-      "Geometric picture: X_d has nonempty interior (Kovač-Tao) AND is path-connected",
+      "Completes Erd\u0151s #268 formalization (currently 1 axiom + 1 sorry)",
+      "Geometric picture: X_d has nonempty interior (Kova\u010d-Tao) AND is path-connected",
       "d=1 case is concretely tractable with Mathlib's interval topology tools"
     ]
   },
@@ -22,7 +22,7 @@
       "coordinate_decreasing: coordinate decreases with shift"
     ],
     "open": [
-      "harmonicPointSet_path_connected for d≥2 requires Kovač-Tao structural analysis"
+      "harmonicPointSet_path_connected for d\u22652 requires Kova\u010d-Tao structural analysis"
     ],
     "goal": "Prove IsPathConnected (harmonicPointSet d), at minimum for d=0 and d=1"
   },
@@ -40,32 +40,44 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Prior survey (session 1) classified main sorry as HARD for general d but identified d=0,1 as tractable. 1 axiom (erdos_268_solved) and 1 sorry (harmonicPointSet_path_connected) remain.",
+    "progressSummary": "PROGRESS: greedySet_sum proved; 2 sorries remain (greedySet_infinite edge case + d>=2)",
     "builtItems": [
       "harmonicPointSet_path_connected d=0 case (complete)",
       "harmonicPointSet_path_connected d=1 framework (1 sorry: greedy construction)",
       "all_coordinates_positive rewritten with A.Infinite + correct tsum_pos API",
       "coordinate_decreasing rewritten with tsum_lt_tsum method + explicit witness",
       "squares_convergent bijection proof fixed (surjectivity lambda + Nat.succ_injective)",
-      "powers_convergent rintro fix"
+      "powers_convergent rintro fix",
+      "greedyBudget: primitive recursion for harmonic budget tracking (Part VIb)",
+      "greedySet: set of naturals selected by greedy algorithm",
+      "greedyBudget_eq_s_sub_sum: key identity proved by induction",
+      "greedyBudget_tendsto_zero: harmonic tail divergence argument",
+      "greedySet_summable: convergent via partial sum bound",
+      "greedySet_sum: harmonicSubseriesSum (greedySet s) = s (PROVED, no sorry)",
+      "consecutiveProductsSet n: {k(k+1) | k>=n} with partial_sum_consec telescope identity",
+      "consecutiveProductsSet_infinite: proved via injectivity"
     ],
     "insights": [
       "d=1 tractable: harmonicPointSet 1 = Set.Ioi 0 via greedy construction",
-      "d=0 trivial: empty product space is subsingleton → isPathConnected_singleton",
-      "d≥2 hard: requires controlling d coordinate sums along continuous path",
+      "d=0 trivial: empty product space is subsingleton \u2192 isPathConnected_singleton",
+      "d\u22652 hard: requires controlling d coordinate sums along continuous path",
       "d=0 fully proved via isPathConnected_singleton + subsingleton argument",
-      "d=1 framework: X₁ = {x | x 0 > 0} is convex (proved); needs greedy harmonic construction for surjection (1 sorry)",
-      "d≥2: deferred, requires Kovač-Tao structural analysis",
-      "Mathlib API: tsum_pos and tsum_lt_tsum are methods on Summable for ℝ, not standalone (only standalone for ℝ≥0)",
+      "d=1 framework: X\u2081 = {x | x 0 > 0} is convex (proved); needs greedy harmonic construction for surjection (1 sorry)",
+      "d\u22652: deferred, requires Kova\u010d-Tao structural analysis",
+      "Mathlib API: tsum_pos and tsum_lt_tsum are methods on Summable for \u211d, not standalone (only standalone for \u211d\u22650)",
       "positivity tactic handles sums of Nat casts where Nat.cast_nonneg fails",
-      "Nat.succ_injective avoids coercion issues vs omega in Function.Injective proofs"
+      "Nat.succ_injective avoids coercion issues vs omega in Function.Injective proofs",
+      "greedyBudget_tendsto_zero proved: if inf L > 0, harmonic tail divergence forces budget < 0",
+      "greedySet_sum proved without sorry via Finset.sum_filter + hasSum_iff_tendsto_nat_of_nonneg",
+      "greedySet_infinite is FALSE for rational s that is a finite harmonic sum (e.g., s=1/2={2})",
+      "Fix for greedySet_infinite: replace max element with consecutiveProductsSet (infinite, same sum)"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Formalize greedy harmonic construction: given s>0, build infinite A with Σ_{n∈A} 1/n = s",
-      "Define greedyHarmonicSet and prove it is infinite with exact harmonic sum",
-      "Try aristotle_submit on greedy construction sorry",
-      "For d=2: explore if X₂ is star-shaped or contains convex subset connecting all points"
+      "Prove consecutiveProductsSet_sum: harmonicSubseriesSum (consecutiveProductsSet n) = 1/n",
+      "Fix greedySet_infinite via union: (greedySet s \\ {M}) union consecutiveProductsSet M",
+      "Submit greedySet_infinite to Aristotle as HARD sorry",
+      "Address d>=2 case via Kovac-Tao structural analysis"
     ],
     "markdown": ""
   },
@@ -78,13 +90,15 @@
     "completion"
   ],
   "relatedProofs": [
+    "erdos-2",
+    "erdos-26",
     "erdos-268",
     "harmonic-series"
   ],
   "references": {
     "papers": [
-      "Kovač (2024): harmonic subseries with prescribed density",
-      "Kovač-Tao (2024): harmonic subseries and multidimensional point sets"
+      "Kova\u010d (2024): harmonic subseries with prescribed density",
+      "Kova\u010d-Tao (2024): harmonic subseries and multidimensional point sets"
     ],
     "urls": [],
     "mathlib": [
@@ -92,5 +106,40 @@
       "Mathlib.Analysis.SpecificLimits.Basic"
     ]
   },
-  "started": "2026-04-21"
+  "started": "2026-04-21",
+  "leanFiles": [
+    {
+      "path": "Proofs/Erdos268Aristotle.lean",
+      "filename": "Erdos268Aristotle.lean",
+      "lineCount": 143,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos268Aristotle.lean"
+    },
+    {
+      "path": "Proofs/Erdos268Problem.lean",
+      "filename": "Erdos268Problem.lean",
+      "lineCount": 498,
+      "theoremCount": 17,
+      "axiomCount": 1,
+      "defCount": 15,
+      "sorryCount": 2,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos268Problem.lean"
+    },
+    {
+      "path": "Proofs/Erdos268ProblemAristotle.lean",
+      "filename": "Erdos268ProblemAristotle.lean",
+      "lineCount": 140,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 8,
+      "sorryCount": 5,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos268ProblemAristotle.lean"
+    }
+  ]
 }


### PR DESCRIPTION
## Fix

Change `dissection-of-cubes-oq-02` metadata from overclaiming `status: "verified"` / `badge: "mathlib"` to `status: "axiomatized"` / `badge: "axiom"`, documenting the `ScissorsCongruent` stub definition.

## Evidence

**Before**: `status: "verified"`, `badge: "mathlib"`, `axiomCount: 0` — implying a fully machine-checked, axiom-free proof.

**After**: `status: "axiomatized"`, `badge: "axiom"`, `axiomCount: 1` — with assumptions field clearly documenting:
- `ScissorsCongruent (P Q : Type*) := ∃ (n : ℕ), True` is a placeholder (line 55-56) making everything trivially scissors congruent
- `scissors_congruent_refl` and `scissors_congruent_symm` hold vacuously
- Dehn's theorem is assumed as an explicit hypothesis
- The core Niven's theorem proof (arccos(1/3)/π irrational) is fully proved

Closes #11303

---
Automated fix by lean-mechanic agent.