### PR TITLE
Research ballot-problem-oq-03-oq-01-oq-02: catalan_eq_ballot lemma + proof strategy

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean
@@ -1226,18 +1226,33 @@ theorem hookProd_twoRectYD (m : ℕ) :
         ← Nat.descFactorial_eq_prod_range, Nat.descFactorial_self]
   rw [hrow0, hrow1]
 
+/-- The Catalan number Cn m equals ballotSeqCount (m+1) m.
+    Both definitions unfold to C(2m,m) - C(2m,m+1) after arithmetic simplification. -/
+lemma catalan_eq_ballot (m : ℕ) :
+    LatticePathLGV.Cn m = LatticePathLGV.ballotSeqCount (m + 1) m := by
+  simp only [LatticePathLGV.Cn, LatticePathLGV.ballotSeqCount]
+  congr 1 <;> omega
+
 /-- card(SYT(twoRectYD m)) = C_m (the m-th Catalan number).
 
-    Proof sketch (not yet formalized):
-    A SYT T of shape (m,m) is determined by its row-0 entry set
-    S = {T.entry(0,j) - 1 : j < m} ⊆ Fin(2m).
-    S has cardinality m, and column-strictness (entry(0,j) < entry(1,j) for all j)
-    is equivalent to: for each k < m, the k-th element of S (sorted) is less than
-    the k-th element of its complement — the "ballot condition" on S.
-    The number of such subsets is C(2m,m) - C(2m,m+1) = C_m by the reflection principle.
+    Proof strategy:
+    Step 1: Bijection SYT(m,m) ↔ ballot LPaths of m East + m North steps.
+      - Forward: T ↦ path where step k is North iff k+1 ∈ row-0 of T
+      - Column condition T(0,j) < T(1,j) ↔ ballot condition #North ≥ #East in every prefix
+      - Inverse: ballot path ↦ SYT with row-0 = {positions of North steps + 1}
 
-    This requires ~200 lines formalizing the bijection using Finset.orderIsoOfFin.
-    [HARD: known result, needs formalization; Aristotle-eligible once set up] -/
+    Step 2: Count ballot LPaths of m East + m North = Cn m.
+      - Bijection: prepend-North maps (ballot m,m) ↔ (strictly ballot m+1,m)
+      - ballotSeqCount (m+1) m = Cn m [by catalan_eq_ballot, trivial definitional equality]
+      - Or directly: |ballot (m,m)| = C(2m,m) - C(2m,m+1) = Cn m via reflection principle
+
+    Key ingredients available:
+      - catalan_eq_ballot: Cn m = ballotSeqCount (m+1) m (proved above)
+      - ballot_via_path_count: ballot count = |pathType m m| - |pathType (m-1) (m+1)|
+      - Finset.orderIsoOfFin: for extracting sorted elements of a Finset
+
+    Estimated ~150-200 lines to formalize the bijection using Finset.orderIsoOfFin.
+    [HARD: known result, needs formalization] -/
 theorem card_SYT_twoRectYD (m : ℕ) :
     Fintype.card (StandardYoungTableau (twoRectYD m)) = LatticePathLGV.Cn m := by
   sorry

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/knowledge.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/knowledge.md
@@ -319,3 +319,39 @@ self-contained and does not use LGV infrastructure.
 - `lgv_det_factors_as_hook_quotient` with `=` and integer division `/` (reformulated to `*`)
 - `deriving Fintype` on StandardYoungTableau (impossible: infinite function field `entry : ℕ × ℕ → ℕ`)
 - LGV chain `ni_count_eq_syt_count` + `lgv_det_factors_as_hook_quotient`: μ disconnected from (r,σ,m)
+
+---
+
+## Session 2026-04-22 (Session 6) — catalan_eq_ballot + Proof Strategy
+
+**Mode**: REVISIT (RICH knowledge tier, score 38)
+**Outcome**: progress — proved catalan_eq_ballot lemma; improved card_SYT_twoRectYD strategy
+
+### What I Did
+
+1. Proved `catalan_eq_ballot : Cn m = ballotSeqCount (m+1) m`
+   - Both definitions unfold to `C(2m,m) - C(2m,m+1)` after arithmetic: `simp [Cn, ballotSeqCount]; omega`
+2. Improved `card_SYT_twoRectYD` documentation with 2-step proof plan
+3. PR: rjwalters/lean-genius#11308
+
+### Key Findings
+
+- **catalan_eq_ballot** is trivial: both `Cn m` and `ballotSeqCount (m+1) m` unfold to the same formula
+- **card_SYT_twoRectYD** requires a bijection SYT(m,m) ↔ ballot LPaths, estimated ~150-200 lines
+  - Step 1: Forward map: step k = North iff k+1 ∈ row-0(T); ballot ↔ column-strictness
+  - Step 2: Count ballot paths = Cn m via catalan_eq_ballot + reflection principle
+- **All 4 remaining sorries are HARD**: none suitable for automated proof search
+- **Next session target**: implement the full bijection for `card_SYT_twoRectYD`
+
+### Files Modified
+
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean` (added catalan_eq_ballot + improved documentation)
+  Branch: `research/ballot-catalan-lemma`
+
+### Next Steps
+
+1. Implement `sytToLPath : SYT(twoRectYD m) → {l : pathType m m // ballot l}`
+2. Implement `lPathToSYT` (inverse)
+3. Prove they're inverses (20-30 lines each)
+4. Prove `card_ballot_lpath m = Cn m` via reflection principle (uses `ballot_via_path_count`)
+5. Assemble `card_SYT_twoRectYD` from the bijection + count


### PR DESCRIPTION
## Summary

- Proves `catalan_eq_ballot`: `Cn m = ballotSeqCount (m+1) m` — connects the two counting approaches
- Improves proof strategy documentation for `card_SYT_twoRectYD` with concrete 2-step plan

## Mathematical Content

**`catalan_eq_ballot`** (new, proved):
Both `LatticePathLGV.Cn m` and `LatticePathLGV.ballotSeqCount (m+1) m` unfold to `C(2m,m) - C(2m,m+1)` after arithmetic simplification via omega. This connects:
- Catalan number `Cn m` (defined via binomial formula)
- Ballot sequence count for (m+1) A-votes vs m B-votes

**`card_SYT_twoRectYD`** (still sorry, improved documentation):
Proof strategy now documented as:
1. Bijection SYT(m,m) ↔ ballot LPaths (m East + m North): via `step k = North iff k+1 ∈ row-0(T)`, with column strictness ↔ ballot condition
2. Count ballot LPaths = Cn m: via `catalan_eq_ballot` + `ballot_via_path_count` + reflection principle

**Sorry status**: 4 remaining (hook_length_formula, ni_count_eq_syt_count, lgv_det_factors_as_hook_quotient, card_SYT_twoRectYD)

## Test plan

- [ ] `catalan_eq_ballot` type-checks via `simp [Cn, ballotSeqCount]; omega`
- [ ] Numerical verification: `native_decide` confirms small cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)