### PR TITLE
Enrich abel-ruffini: fix overlapping annotation ranges for Parts VI & VII

### DIFF
--- a/src/data/proofs/abel-ruffini/annotations.json
+++ b/src/data/proofs/abel-ruffini/annotations.json
@@ -338,7 +338,7 @@
     "proofId": "abel-ruffini",
     "range": {
       "startLine": 151,
-      "endLine": 183
+      "endLine": 163
     },
     "type": "insight",
     "title": "Part VI: Why Degree 5 Is the Exact Threshold",
@@ -365,8 +365,8 @@
     "id": "ann-part-vii-historical",
     "proofId": "abel-ruffini",
     "range": {
-      "startLine": 151,
-      "endLine": 183
+      "startLine": 164,
+      "endLine": 185
     },
     "type": "context",
     "title": "Part VII: The Impossibility Paradigm and Historical Significance",


### PR DESCRIPTION
Enrichment pass for abel-ruffini (quality: 100, passes: 3).

## Quality improvements

Both `ann-part-vi-threshold` and `ann-part-vii-historical` previously had identical ranges (lines 151–183), creating ambiguous coverage of the same Lean source region.

Updated to precise non-overlapping ranges reflecting the actual Lean file structure:
- `ann-part-vi-threshold`: 151–163 (Part VI: *The Threshold at Degree 5* docstring)
- `ann-part-vii-historical`: 164–185 (Part VII: *Historical Significance* docstring + `end AbelRuffini`)