### PR TITLE
Seeker: select fourier-series-oq-02-incomplete-01-oq-01 — LipschitzWith API for Fourier modes

### DIFF
--- a/research/problems/fourier-series-oq-02-incomplete-01-oq-01/knowledge.md
+++ b/research/problems/fourier-series-oq-02-incomplete-01-oq-01/knowledge.md
@@ -1,21 +1,87 @@
 # Knowledge Base: fourier-series-oq-02-incomplete-01-oq-01
 
-Insights accumulated during research on this problem.
+**Problem**: Lipschitz Bound for Fourier Coefficients via Mathlib LipschitzWith API
+**Selected**: 2026-04-22
+**Selection Score**: composite 77 (EMPTY tier, tractability 7, significance 7)
 
 ---
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+### The Core Question
+
+Can `fourier_lipschitz_bound` be proved using Mathlib's `LipschitzWith` typeclass?
+
+Specifically, the goal is to prove:
+```lean
+LipschitzWith (2 * Real.pi * |↑n| / T) (fourier n)
+```
+— or equivalently, that for each Fourier character `fourier n : AddCircle T → ℂ`, the map
+is Lipschitz with explicit constant `2π|n|/T`.
+
+### Current State of the Parent Proof
+
+`FourierSeriesOQ02Incomplete01.lean` — fully proved (0 sorries). The key theorem is:
+
+```lean
+theorem fourier_lipschitz_bound (n : ℤ) (x y : AddCircle T) :
+    ‖fourier n x - fourier n y‖ ≤ 2 * Real.pi * |↑n| / T * dist x y
+```
+
+Proof uses direct computation via:
+1. Factoring: exp(A) - exp(B) = exp(B)·(exp(A-B) - 1)
+2. Unit norm of exp on circle
+3. Periodicity via `round(T⁻¹*(x-y))` for optimal representative
+4. Applying `norm_exp_I_mul_ofReal_sub_one_le`: ‖exp(Iθ) - 1‖ ≤ |θ|
+
+**The existing proof does NOT use `LipschitzWith`.** The OQ-01 asks whether a cleaner
+proof using Mathlib's `LipschitzWith` typeclass is possible.
+
+### Why LipschitzWith Matters
+
+`LipschitzWith K f` gives composability: if `f` and `g` are Lipschitz, Mathlib can
+automatically derive Lipschitz bounds for compositions, sums, etc. A `LipschitzWith`
+proof for `fourier n` would integrate better with the broader Mathlib ecosystem for
+harmonic analysis.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+### Key Mathlib Entry Points
+
+- `LipschitzWith.of_dist_le_mul`: Given `∀ x y, dist (f x) (f y) ≤ K * dist x y`, constructs `LipschitzWith K f`
+- The current direct bound already shows `dist (fourier n x) (fourier n y) ≤ 2π|n|/T * dist x y`
+- `Complex.exp_lipschitz`: The exponential map on ℂ is locally Lipschitz; on the unit circle it may have specialized bounds
+- `Continuous.lipschitzWith` doesn't exist directly — need `LipschitzWith.mk`
+
+### Likely Direct Approach
+
+Use `LipschitzWith.of_dist_le_mul` with the existing bound:
+```lean
+lemma fourier_lipschitz (n : ℤ) : LipschitzWith (⟨2 * Real.pi * |↑n| / T, ...⟩) (fourier n)
+```
+The `LipschitzWith` constant must be an `NNReal`, so need to bundle `2π|n|/T` with a
+nonnegativity proof.
+
+### Alternative: Derive from Circle Exponential Lipschitzness
+
+The map `θ ↦ exp(2πiθ/T)` on `ℝ` is Lipschitz with constant `2π/T`, and composing with
+`n * id` gives constant `2π|n|/T`. Then quotient by `T` to get AddCircle. Mathlib may
+have `AddCircle.lipschitzWith_toCircle` or similar.
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+### Avoid Synthesizing from Smoothness
+
+`fourier n` is smooth, but going smooth → Lipschitz in Mathlib requires explicit constant
+bounds and is more work than the direct approach. The direct `of_dist_le_mul` route reuses
+the existing computation.
+
+### NNReal Constant Requires Care
+
+`LipschitzWith K f` uses `K : NNReal`. Converting `2 * Real.pi * |↑n| / T` to `NNReal`
+requires `hT : Fact (0 < T)` (available) and `n : ℤ` (|n| ≥ 0). The cast is:
+`⟨2 * Real.pi * |↑n| / T, by positivity⟩ : NNReal`.


### PR DESCRIPTION
## Selection Report

**Date**: 2026-04-22
**Mode**: SELECT
**Pool Status**: 22 available, 511 in-progress, 1400 completed, 16 active claims

## Selected Problem

- **ID**: `fourier-series-oq-02-incomplete-01-oq-01`
- **Name**: Lipschitz Bound for Fourier Coefficients via Mathlib LipschitzWith API
- **Tier**: B
- **Significance**: 7/10
- **Tractability**: 7/10
- **Knowledge Score**: 0 (EMPTY)
- **Composite Score**: 77 (EMPTY tier: 0 + tractability×10 + significance = 77)

## Selection Rationale

1. **EMPTY knowledge tier** (highest priority): No knowledge items accumulated yet; fresh problem ready for OBSERVE phase
2. **Tied at composite 77** with `lebesgue-measure-oq-01-oq-01-oq-01`; tiebroken by domain — harmonic analysis is distinct from recent selections (information theory, Galois theory)
3. **Concrete and actionable**: Parent proof `FourierSeriesOQ02Incomplete01.lean` is fully proved (0 sorries). The OQ asks whether `LipschitzWith` typeclass gives a cleaner formulation, with a clear path via `LipschitzWith.of_dist_le_mul`

## Rejection Summary

- **Candidates considered**: 22 available
- **Candidates rejected**: 21
  - `shannon-source-coding-oq-04` (EMPTY, composite 70): same domain as recently selected `shannon-source-coding-oq-04-incomplete-01` → domain diversity penalty
  - All WEAK/MODERATE/RICH tier problems: dominated by EMPTY tier (composite gap ≥ 1000 points)
- **Confidence**: medium (two EMPTY candidates tied at 77; either would be valid)

## Related Gallery Proofs

- `fourier-series-oq-02-incomplete-01`: parent proof, fully proved, contains `fourier_lipschitz_bound` via direct computation
- `fourier-series-oq-02`: Hölder regularity → Fourier coefficient decay chain
- `FourierSeriesOQ02Incomplete01Aristotle.lean`: existing Aristotle companion already in place

## Suggested First Steps

1. **OBSERVE**: Survey Mathlib's `LipschitzWith` API — find `of_dist_le_mul`, `mk`, composition lemmas
2. **ORIENT**: Check if `toCircle` or `fourier` have existing `LipschitzWith` instances in Mathlib
3. **DECIDE**: Attempt `LipschitzWith.of_dist_le_mul` constructor using existing `fourier_lipschitz_bound` bound as a stepping stone; NNReal constant needs `positivity` proof

## Pool Summary After Selection

| Status | Count |
|--------|-------|
| Available | 22 |
| In Progress | 511 |
| Completed | 1400 |
| Graduated | 3 |
| Blocked | 2 |

## Pool Health

Pool depth: **adequate** (22 available > threshold 15). Next replenishment recommended when pool drops below 15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)