### PR TITLE
Optimize Sperner heartbeats toward Mathlib default

### DIFF
--- a/proofs/Proofs/SpernerMathlib4.lean
+++ b/proofs/Proofs/SpernerMathlib4.lean
@@ -48,7 +48,7 @@ total doors ≡ panchromatic cells (mod 2).
 Sperner, combinatorics, parity, triangulation, door-counting
 -/
 
-set_option maxHeartbeats 400000
+set_option maxHeartbeats 200000
 
 open Finset
 
@@ -235,12 +235,14 @@ private lemma even_card_doors_of_surjective (d : ℕ)
           (fun i : Fin (d + 1) => f i = f k) :=
         mem_filter.mpr ⟨mem_univ i, hi_eq⟩
       rw [ha] at hk_in hi_in
-      simp at hk_in hi_in
+      rw [Finset.mem_singleton] at hk_in hi_in
       exact hi_ne (hk_in ▸ hi_in)
     have hk_mem : k ∈ univ.filter
         (fun i : Fin (d + 1) => f i = c₀) :=
       mem_filter.mpr ⟨mem_univ k, hfk⟩
-    rw [hpair] at hk_mem; simp at hk_mem; exact hk_mem
+    rw [hpair] at hk_mem
+    rw [mem_insert, mem_singleton] at hk_mem
+    exact hk_mem
   · intro hk j
     obtain ⟨i₀, hi₀⟩ := hcov j
     by_cases hik : i₀ = k
@@ -288,16 +290,15 @@ private lemma door_count_of_surj (d : ℕ)
       have := (f k).isLt; omega
     obtain ⟨i, hi_ne, hi_eq⟩ :=
       hk ⟨(f k).val, hfk_lt⟩
-    have hval : (f i).val = (f k).val := by
-      have h1 := congr_arg Fin.val hi_eq
-      simp at h1; exact h1
-    exact hi_ne (hinj (Fin.ext hval))
+    have hval : f i = f k :=
+      Fin.ext (Fin.ext_iff.mp hi_eq)
+    exact hi_ne (hinj hval)
   · intro hk; subst hk; intro ⟨j, hj⟩
     obtain ⟨i, hi⟩ := hsurj ⟨j, by omega⟩
     exact ⟨i,
       fun hik => by
         subst hik; rw [hk₀] at hi
-        exact absurd hi (by simp; omega),
+        simp only [Fin.mk.injEq] at hi; omega,
       by rw [hi]⟩
 
 /-- A non-surjection `Fin (d+1) → Fin (d+1)` has an even
@@ -352,13 +353,13 @@ private lemma door_count_even_of_not_surj (d : ℕ)
       simp only [mem_filter, mem_univ, true_and]
       constructor <;> intro h j
       · obtain ⟨i, hi, hfi⟩ := h j
-        exact ⟨i, hi, Fin.ext (by
-          simp [g]
-          exact congr_arg Fin.val hfi)⟩
+        refine ⟨i, hi, Fin.ext ?_⟩
+        change (f i).val = j.val
+        exact congr_arg Fin.val hfi
       · obtain ⟨i, hi, hgi⟩ := h j
-        exact ⟨i, hi, Fin.ext (by
-          have := congr_arg Fin.val hgi
-          simp [g] at this; exact this)⟩
+        refine ⟨i, hi, Fin.ext ?_⟩
+        change (f i).val = j.val
+        exact congr_arg Fin.val hgi
     · -- g not surjective: some lower color missing. No doors.
       have ⟨j₀, hj₀⟩ :
           ∃ j : Fin d, ¬∃ i, g i = j := by
@@ -372,9 +373,9 @@ private lemma door_count_even_of_not_surj (d : ℕ)
       rw [Finset.card_eq_zero, filter_eq_empty_iff]
       intro k _; push_neg
       exact ⟨j₀, fun i _ h =>
-        hj₀ ⟨i, Fin.ext (by
-          have := congr_arg Fin.val h
-          simp at this; exact this)⟩⟩
+        hj₀ ⟨i, Fin.ext (show (g i).val = j₀.val by
+          change (f i).val = j₀.val
+          exact congr_arg Fin.val h)⟩⟩
 
 /-- **Door count parity**: the number of door positions of a
 coloring `f : Fin (d+1) → Fin (d+1)` has parity equal to 1
@@ -570,11 +571,8 @@ private lemma per_cell_door_parity
           ⟨j.val, by omega⟩)) := by
     ext k
     simp only [mem_filter, mem_univ, true_and]; rfl
-  rw [h1]
-  have h2 : IsPanchromatic c K s ↔
-      Function.Surjective (c ∘ K.vertex s) := Iff.rfl
-  simp only [h2]
-  convert h using 2
+  rw [h1, h]
+  exact if_congr Iff.rfl rfl rfl
 
 private lemma sum_mod_congr {ι : Type*}
     (S : Finset ι) (a b : ι → ℕ)
@@ -582,7 +580,7 @@ private lemma sum_mod_congr {ι : Type*}
     (∑ i ∈ S, a i) % 2 =
     (∑ i ∈ S, b i) % 2 := by
   induction S using Finset.cons_induction with
-  | empty => simp
+  | empty => rfl
   | cons x s hx ih =>
     rw [sum_cons, sum_cons]
     have hx_eq :=
@@ -664,7 +662,8 @@ theorem sperner_parity (c : V → Fin (d + 1))
         if IsPanchromatic c K s
         then 1 else 0) % 2 :=
     sum_mod_congr univ _ _ (fun s _ => by
-      rw [hper s]; split <;> simp)
+      rw [hper s]
+      split_ifs <;> omega)
   have hfc_sum :
       (∑ s : K.Cell,
         if IsPanchromatic c K s

--- a/proofs/Proofs/SpernerSimplicialInstance.lean
+++ b/proofs/Proofs/SpernerSimplicialInstance.lean
@@ -56,7 +56,7 @@ interval example with fully proved axioms.
 Sperner, simplicial complex, triangulation, cell complex, bridge
 -/
 
-set_option maxHeartbeats 1600000
+set_option maxHeartbeats 400000
 
 open Finset
 
@@ -238,7 +238,7 @@ theorem boundary_doors_odd (T : Triangulation V n)
       change c (T.vertex s i) = _ at hi_color
       -- castSucc ⟨faceIdx.val, hlt⟩ = faceIdx since faceIdx.val < n < n+1
       have hcast : (⟨faceIdx.val, hlt⟩ : Fin n).castSucc = faceIdx :=
-        Fin.ext (by simp [Fin.castSucc])
+        Fin.ext rfl
       rw [hcast] at hi_color
       exact hSperner_i hi_color
     · -- faceIdx.val ≥ n, and faceIdx : Fin (n+1) so faceIdx.val ≤ n
@@ -450,7 +450,7 @@ lemma AbstractSimplicialData.vertexEnum_image_univ
     obtain ⟨idx, hidx_lt, hidx_eq⟩ := hv_sort
     have hidx_lt' : idx < n + 1 := by
       rwa [Finset.length_sort, D.card_eq s hs] at hidx_lt
-    exact ⟨⟨idx, hidx_lt'⟩, by simp [vertexEnum, List.get_eq_getElem, hidx_eq]⟩
+    exact ⟨⟨idx, hidx_lt'⟩, by show (s.sort (· ≤ ·)).get _ = v; simp only [List.get_eq_getElem]; exact hidx_eq⟩
 
 /-- Image of `univ.erase k` under vertexEnum equals faceOf. -/
 lemma AbstractSimplicialData.vertexEnum_image_erase
@@ -473,9 +473,9 @@ lemma AbstractSimplicialData.vertexEnum_image_erase
     · intro heq
       apply hne
       have : D.vertexEnum s hs ⟨idx, hidx_lt'⟩ = v := by
-        simp [vertexEnum, List.get_eq_getElem, hidx_eq]
+        show (s.sort (· ≤ ·)).get _ = v; simp only [List.get_eq_getElem]; exact hidx_eq
       rw [← this, heq]
-    · simp [vertexEnum, List.get_eq_getElem, hidx_eq]
+    · show (s.sort (· ≤ ·)).get _ = v; simp only [List.get_eq_getElem]; exact hidx_eq
 
 /-- Unfold faceOf. -/
 lemma AbstractSimplicialData.faceOf_eq
@@ -489,7 +489,7 @@ The backward direction: vertexEnum k ∉ s.erase(vertexEnum k) by Finset.not_mem
 lemma AbstractSimplicialData.vertexEnum_not_mem_faceOf_iff
     (s : Finset V) (hs : s ∈ D.topSimplices) (j k : Fin (n+1)) :
     D.vertexEnum s hs j ∉ D.faceOf s hs k ↔ j = k := by
-  simp only [faceOf, Finset.mem_erase, not_and_or, not_not, not_ne_iff]
+  simp only [faceOf, Finset.mem_erase, not_and_or, not_not]
   constructor
   · intro h
     cases h with
@@ -623,7 +623,6 @@ lemma AbstractSimplicialData.containersOf_card_eq_two_of_adjFn
   split_ifs at hadj with hc hne
   · have hcard := D.containersOf_card_one_or_two s hs k
     omega
-  all_goals simp at hadj
 
 /-- When adjFn returns some, the neighbor s' is in containersOf f. -/
 lemma AbstractSimplicialData.adjFn_s'_mem_containers
@@ -648,7 +647,6 @@ lemma AbstractSimplicialData.adjFn_s'_mem_containers
       Finset.mem_of_mem_erase ht_mem_erase
     rw [hs'_val]
     exact (Finset.mem_filter.mp ht_mem_cs).2
-  all_goals simp at hadj
 
 /-- When adjFn returns some, s' != s (as Finset values). -/
 lemma AbstractSimplicialData.adjFn_ne
@@ -670,7 +668,6 @@ lemma AbstractSimplicialData.adjFn_ne
     have ht_ne_s : hne.choose ≠ s := (Finset.mem_erase.mp ht_mem_erase).1
     rw [hs'_val]
     exact ht_ne_s
-  all_goals simp at hadj
 
 /-- When adjFn returns some, faceOf s' hs' k' = faceOf s hs k. -/
 lemma AbstractSimplicialData.adjFn_face_eq
@@ -874,7 +871,7 @@ private lemma iadj_cases {s s' : Fin m}
         by have := congr_arg Fin.val hs'_eq; simp at this; omega,
         by have := congr_arg Fin.val hk'_eq; simp at this; omega,
         h⟩
-    · rw [dif_neg h] at hadj; simp at hadj
+    · rw [dif_neg h] at hadj; exact Option.noConfusion hadj
   · -- k.val ≠ 0
     rw [dif_neg hk] at hadj
     by_cases h : (0 : ℕ) < s.val
@@ -886,7 +883,7 @@ private lemma iadj_cases {s s' : Fin m}
         by have := congr_arg Fin.val hs'_eq; simp at this; omega,
         by have := congr_arg Fin.val hk'_eq; simp at this; omega,
         h⟩
-    · rw [dif_neg h] at hadj; simp at hadj
+    · rw [dif_neg h] at hadj; exact Option.noConfusion hadj
 
 private lemma iadj_symm' {s s' : Fin m}
     {k k' : Fin 2}
@@ -941,7 +938,7 @@ private lemma iadj_vertex' {hm : 0 < m} {s s' : Fin m}
       rw [mem_erase] at ha_mem
       have ha1 : a.val = 1 := by have := a.isLt; omega
       refine ⟨⟨0, by omega⟩,
-        mem_erase.mpr ⟨by intro h; simp at h, mem_univ _⟩, ?_⟩
+        mem_erase.mpr ⟨by omega, mem_univ _⟩, ?_⟩
       rw [show a = ⟨1, by omega⟩ from Fin.ext ha1] at ha_eq
       simp [ivtx] at ha_eq ⊢; omega
     · intro hv
@@ -950,7 +947,7 @@ private lemma iadj_vertex' {hm : 0 < m} {s s' : Fin m}
       rw [mem_erase] at ha_mem
       have ha0 : a.val = 0 := by have := a.isLt; omega
       refine ⟨⟨1, by omega⟩,
-        mem_erase.mpr ⟨by intro h; simp at h, mem_univ _⟩, ?_⟩
+        mem_erase.mpr ⟨by omega, mem_univ _⟩, ?_⟩
       rw [show a = ⟨0, by omega⟩ from Fin.ext ha0] at ha_eq
       simp [ivtx] at ha_eq ⊢; omega
   · -- k.val≠0 (so k.val=1), s'=s-1, k'.val=0
@@ -965,7 +962,7 @@ private lemma iadj_vertex' {hm : 0 < m} {s s' : Fin m}
       rw [mem_erase] at ha_mem
       have ha0 : a.val = 0 := by have := a.isLt; omega
       refine ⟨⟨1, by omega⟩,
-        mem_erase.mpr ⟨by intro h; simp at h, mem_univ _⟩, ?_⟩
+        mem_erase.mpr ⟨by omega, mem_univ _⟩, ?_⟩
       rw [show a = ⟨0, by omega⟩ from Fin.ext ha0] at ha_eq
       simp [ivtx] at ha_eq ⊢; omega
     · intro hv
@@ -974,7 +971,7 @@ private lemma iadj_vertex' {hm : 0 < m} {s s' : Fin m}
       rw [mem_erase] at ha_mem
       have ha1 : a.val = 1 := by have := a.isLt; omega
       refine ⟨⟨0, by omega⟩,
-        mem_erase.mpr ⟨by intro h; simp at h, mem_univ _⟩, ?_⟩
+        mem_erase.mpr ⟨by omega, mem_univ _⟩, ?_⟩
       rw [show a = ⟨1, by omega⟩ from Fin.ext ha1] at ha_eq
       simp [ivtx] at ha_eq ⊢; omega
 


### PR DESCRIPTION
## Summary

Reduce `maxHeartbeats` in the two critical Mathlib-bound Sperner files, preparing them for the Mathlib contribution (mathlib4#25231).

### Before / After

| File | Before | After | Reduction |
|------|--------|-------|-----------|
| `SpernerMathlib4.lean` | 400,000 | **200,000** (Mathlib default) | 50% |
| `SpernerSimplicialInstance.lean` | 1,600,000 | **400,000** | 75% |

### Optimization techniques applied

- Replace expensive `convert h using 2` with direct `rw` + `if_congr Iff.rfl rfl rfl`
- Replace bare `simp` with targeted rewrites (`rw [mem_singleton]`, `rw [mem_insert, mem_singleton]`)
- Replace `simp [g]` (which unfolds local let-bindings) with explicit `change` + `congr_arg Fin.val`
- Replace `split <;> simp` with `split_ifs <;> omega`
- Replace `simp at hadj` dead-branch elimination with `exact Option.noConfusion hadj`
- Use `Fin.ext rfl` for `castSucc` identity instead of `simp [Fin.castSucc]`
- Use `rfl` instead of `simp` for empty-case base in `cons_induction`

### What was NOT changed

- No theorem statements modified
- No mathematical content changed
- No definitions altered
- Only proof tactics and structure were optimized

### Verification

Both files verified via Docker build (`./proofs/scripts/docker-build.sh`).

## Test plan

- [x] `SpernerMathlib4.lean` builds at `maxHeartbeats 200000`
- [x] `SpernerSimplicialInstance.lean` builds at `maxHeartbeats 400000`
- [x] No linter warnings in final build
- [x] Downstream file (`SpernerSimplicialInstance` imports `SpernerMathlib4`) builds correctly

Generated with [Claude Code](https://claude.com/claude-code)