### PR TITLE
Fix collatz-structured-oq-03: correct invalid annotation types and significance

### DIFF
--- a/src/data/proofs/collatz-structured-oq-03/annotations.json
+++ b/src/data/proofs/collatz-structured-oq-03/annotations.json
@@ -2,145 +2,288 @@
   {
     "id": "ann-collatz-file-header",
     "proofId": "collatz-structured-oq-03",
-    "range": { "startLine": 1, "endLine": 23 },
-    "type": "context",
+    "range": {
+      "startLine": 1,
+      "endLine": 23
+    },
+    "type": "concept",
     "title": "Module Header: Collatz Stopping Time and the Average Asymptotic Question",
     "content": "The file header (lines 1-18) states the open question, cites known results (Terras 1976 density-1, Krasikov-Lagarias 2003 $N^{0.84}$ bound), and gives the heuristic constant $c = 1/\\log_2(4/3) \\approx 6.95$. Lines 19-23 set up the module: `import Mathlib`, `open Nat Finset`, and `namespace CollatzStoppingTime`. The `Nat` opening gives direct access to `Nat.find` and arithmetic lemmas; `Finset` provides `Finset.sum` for the total stopping time sum.",
     "mathContext": "The open question: does $\\lim_{N\\to\\infty} S(N)/\\log N$ exist, where $S(N) = \\frac{1}{N}\\sum_{n=1}^N \\sigma(n)$ and $\\sigma(n)$ is the Collatz stopping time? Known: Terras (1976) proved $|\\{n \\leq N : \\sigma(n) < \\infty\\}|/N \\to 1$; Krasikov-Lagarias (2003) gave the quantitative bound $N^{0.84}$. Heuristic: $c = 1/\\log_2(4/3) \\approx 6.95$.",
-    "significance": "context",
-    "relatedConcepts": ["Collatz conjecture", "stopping time", "Terras 1976", "Krasikov-Lagarias 2003", "heuristic constant"],
-    "prerequisites": ["Collatz problem background", "Nat.find", "Finset.sum"]
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Collatz conjecture",
+      "stopping time",
+      "Terras 1976",
+      "Krasikov-Lagarias 2003",
+      "heuristic constant"
+    ],
+    "prerequisites": [
+      "Collatz problem background",
+      "Nat.find",
+      "Finset.sum"
+    ]
   },
   {
     "id": "ann-collatz-map-defs",
     "proofId": "collatz-structured-oq-03",
-    "range": { "startLine": 24, "endLine": 49 },
+    "range": {
+      "startLine": 24,
+      "endLine": 49
+    },
     "type": "definition",
     "title": "Collatz Map, Iteration, and Stopping Time",
     "content": "The four core definitions establish the Collatz computational framework. `collatz n` is the Collatz map: n/2 if n is even, 3n+1 if n is odd. `collatzIter k n` applies the map k times via structural recursion (base case returns n, recursive case applies one more step). `reachesOneIn n k` is the predicate 'n reaches 1 in exactly k steps', and `reachesOne n` is the existential 'n eventually reaches 1'. The stopping time `stoppingTime n` uses `Nat.find h` (where h : reachesOne n) to extract the *minimum* such k. The `else 0` branch handles the case where `reachesOne n` is false — returning 0 as a sentinel for potentially divergent orbits.",
     "mathContext": "The Collatz map $T: \\mathbb{N} \\to \\mathbb{N}$ is $T(n) = n/2$ if $2 \\mid n$ and $T(n) = 3n+1$ if $2 \\nmid n$. The stopping time $\\sigma(n) = \\min\\{k \\geq 0 : T^k(n) = 1\\}$ if this minimum exists, else undefined. Lean's `Nat.find h` extracts this minimum from the proof `h : ∃ k, T^k(n) = 1`. Since termination is unknown for all $n$, `reachesOne` is not computably decidable, making `stoppingTime` necessarily `noncomputable`.",
     "significance": "key",
-    "relatedConcepts": ["Collatz conjecture", "stopping time", "Nat.find", "noncomputable definitions", "well-founded recursion"],
-    "prerequisites": ["Lean 4 def and recursion", "Nat.find API", "classical logic in Lean"]
+    "relatedConcepts": [
+      "Collatz conjecture",
+      "stopping time",
+      "Nat.find",
+      "noncomputable definitions",
+      "well-founded recursion"
+    ],
+    "prerequisites": [
+      "Lean 4 def and recursion",
+      "Nat.find API",
+      "classical logic in Lean"
+    ]
   },
   {
     "id": "ann-stopping-time-one",
     "proofId": "collatz-structured-oq-03",
-    "range": { "startLine": 50, "endLine": 64 },
-    "type": "technique",
+    "range": {
+      "startLine": 50,
+      "endLine": 64
+    },
+    "type": "tactic",
     "title": "Concrete Stopping Times: σ(1) = 0 and σ(2) = 1",
     "content": "The two concrete theorems verify the definition on small inputs. `stoppingTime_one`: 1 is the fixed terminal value, so σ(1) = 0 — proved by `Nat.find_eq_zero.mpr rfl` after confirming reachesOne 1 holds with witness k=0. `stoppingTime_two`: 2 → 1 in one step (T(2) = 1), so σ(2) = 1. This is more involved: the proof shows (a) reachesOne 2 holds with witness k=1, (b) the minimum is exactly 1 using `Nat.find_eq_iff.mpr` with two obligations — the predicate holds at k=1, and it fails at k=0 (since T⁰(2) = 2 ≠ 1). `interval_cases k` handles the k < 1 case by exhaustion.",
     "mathContext": "$\\sigma(1) = 0$ because $T^0(1) = 1$ (0 steps needed). $\\sigma(2) = 1$ because $T^1(2) = T(2) = 2/2 = 1$ and $T^0(2) = 2 \\neq 1$ (1 is minimal). The `Nat.find_eq_iff` characterization requires proving both the existence at $k$ and the non-existence at all $k' < k$.",
     "significance": "supporting",
-    "relatedConcepts": ["Nat.find_eq_zero", "Nat.find_eq_iff", "interval_cases tactic", "stopping-time computation"],
-    "prerequisites": ["stoppingTime definition", "Nat.find lemmas", "norm_num tactic"]
+    "relatedConcepts": [
+      "Nat.find_eq_zero",
+      "Nat.find_eq_iff",
+      "interval_cases tactic",
+      "stopping-time computation"
+    ],
+    "prerequisites": [
+      "stoppingTime definition",
+      "Nat.find lemmas",
+      "norm_num tactic"
+    ]
   },
   {
     "id": "ann-part-ii-header",
     "proofId": "collatz-structured-oq-03",
-    "range": { "startLine": 65, "endLine": 69 },
-    "type": "context",
+    "range": {
+      "startLine": 65,
+      "endLine": 69
+    },
+    "type": "concept",
     "title": "Part II: Average Stopping Time — Section Header",
     "content": "The transition from individual stopping times to their average is the core conceptual step. While σ(n) varies wildly (σ(27) = 111 vs σ(28) = 18), the average S(N) is expected to be smoothly growing. This section-level shift from pointwise to aggregate behavior is analogous to the transition in probability theory from individual random variables to their expectation, where wild fluctuations are tamed by averaging.",
     "mathContext": "The average $S(N) = \\frac{1}{N}\\sum_{n=1}^N \\sigma(n)$ aggregates the stopping times. The key question is whether this average is asymptotically determined — i.e., whether the 'law of large numbers' holds for Collatz stopping times despite their non-independence.",
-    "significance": "context",
-    "relatedConcepts": ["law of large numbers", "ergodic averages", "asymptotic analysis"],
-    "prerequisites": ["stoppingTime definition"]
+    "significance": "supporting",
+    "relatedConcepts": [
+      "law of large numbers",
+      "ergodic averages",
+      "asymptotic analysis"
+    ],
+    "prerequisites": [
+      "stoppingTime definition"
+    ]
   },
   {
     "id": "ann-avg-stopping-time-def",
     "proofId": "collatz-structured-oq-03",
-    "range": { "startLine": 70, "endLine": 76 },
+    "range": {
+      "startLine": 70,
+      "endLine": 76
+    },
     "type": "definition",
     "title": "Average Stopping Time S(N)",
     "content": "`totalStoppingTime N = ∑ n in range N, stoppingTime (n+1)` sums stopping times for n=1,...,N. `avgStoppingTime N = totalStoppingTime N / N` (as a real, 0 for N=0) is the average. The cast `(totalStoppingTime N : ℝ)` lifts the ℕ-valued sum to ℝ for real division. Both definitions are `noncomputable` because they depend on `stoppingTime`, which uses classical choice. The special case N=0 returns 0 to avoid division by zero. `avgStoppingTime` is the central object of the open question: does it grow like c·log N?",
     "mathContext": "$S(N) = \\frac{1}{N}\\sum_{n=1}^N \\sigma(n)$. Since `stoppingTime n = 0` for any $n$ where `reachesOne n` fails (a density-0 set by Terras), the sum effectively counts only the terminating orbits. The Terras axiom guarantees these are $(1-o(1))N$ in number, so $S(N)$ asymptotically equals the true average over terminating inputs.",
     "significance": "key",
-    "relatedConcepts": ["totalStoppingTime", "avgStoppingTimeAsymptotic", "Filter.Tendsto", "noncomputable analysis"],
-    "prerequisites": ["stoppingTime definition", "Finset.sum over range", "Real.log", "ℕ-to-ℝ coercion"]
+    "relatedConcepts": [
+      "totalStoppingTime",
+      "avgStoppingTimeAsymptotic",
+      "Filter.Tendsto",
+      "noncomputable analysis"
+    ],
+    "prerequisites": [
+      "stoppingTime definition",
+      "Finset.sum over range",
+      "Real.log",
+      "ℕ-to-ℝ coercion"
+    ]
   },
   {
     "id": "ann-part-iii-header",
     "proofId": "collatz-structured-oq-03",
-    "range": { "startLine": 77, "endLine": 87 },
-    "type": "context",
+    "range": {
+      "startLine": 77,
+      "endLine": 87
+    },
+    "type": "concept",
     "title": "Part III: Heuristic Derivation of the Growth Constant",
     "content": "The section comment derives the heuristic constant from the random-walk model. Treating each Collatz step as independent: with probability 1/2 the number halves (even case) and with probability 1/2 it is multiplied by 3/2 (odd case, since 3n+1 is immediately even and halved). The net geometric factor per step is $(1/2 \\cdot 3/2)^{1/2} = (3/4)^{1/2}$, giving expected log-decrease $\\log_2(4/3)/2$ per step. This independence assumption is the central simplification — in reality, successive Collatz values have strong correlations (e.g., 3n+1 is always even, so the next step is deterministically a halving). Despite this, empirical evidence strongly supports the heuristic prediction.",
     "mathContext": "Expected steps to reach 1 from $n$: $\\sigma(n) \\approx \\frac{\\log_2 n}{\\log_2(4/3)} \\approx 6.95 \\log_2 n$. The net factor $(3/4)^{1/2}$ means $\\log_2 n$ decreases by $\\approx 0.208$ per step on average, so $\\approx \\log_2 n / 0.208 \\approx 4.82 \\log_2 n$ odd+even steps. With the correction for even-step clustering, the total becomes $\\approx 6.95 \\log_2 n$.",
     "significance": "supporting",
-    "relatedConcepts": ["random walk model", "geometric Brownian motion", "Galton-Watson process", "correlation structure"],
-    "prerequisites": ["probability theory", "logarithmic analysis", "Collatz iteration structure"]
+    "relatedConcepts": [
+      "random walk model",
+      "geometric Brownian motion",
+      "Galton-Watson process",
+      "correlation structure"
+    ],
+    "prerequisites": [
+      "probability theory",
+      "logarithmic analysis",
+      "Collatz iteration structure"
+    ]
   },
   {
     "id": "ann-heuristic-constant",
     "proofId": "collatz-structured-oq-03",
-    "range": { "startLine": 88, "endLine": 95 },
+    "range": {
+      "startLine": 88,
+      "endLine": 95
+    },
     "type": "insight",
     "title": "Heuristic Constant c = 1/log₂(4/3)",
     "content": "`heuristicConstant = 1 / (Real.log (4/3) / Real.log 2)` is the probabilistic prediction for the Collatz stopping-time constant. The formula arises from modeling each Collatz step as an independent Bernoulli trial: with probability 1/2 the input is even (halved), and with probability 1/2 it is odd (multiplied by 3/2 after the immediate next halving of 3n+1). The geometric mean factor per step is (1/2 · 3/2)^{1/2} = (3/4)^{1/2}, giving a log-decrease of log(4/3)/2 per step. `heuristicGrowthRate` quantifies convergence: for all ε > 0, |S(N)/log N − c/log 2| < ε for large N.",
     "mathContext": "From the random-walk model: $\\mathbb{E}[\\log n \\text{ after one step}] = \\frac{1}{2}\\log(n/2) + \\frac{1}{2}\\log(3n/2) = \\log n + \\frac{1}{2}\\log(3/4)$. This geometric decrease means reaching $\\log n = 0$ (i.e., $n=1$) takes approximately $\\log n / (\\frac{1}{2}\\log(4/3)) = 2\\log_2 n / \\log_2(4/3) \\approx 6.95 \\log_2 n$ steps on average. In natural log: $\\sigma(n) \\approx c/\\log 2 \\cdot \\log n$.",
     "significance": "key",
-    "relatedConcepts": ["Galton-Watson branching process", "geometric random walk", "2-adic Collatz", "probabilistic number theory"],
-    "prerequisites": ["Real.log", "avgStoppingTime", "probabilistic heuristics in number theory"]
+    "relatedConcepts": [
+      "Galton-Watson branching process",
+      "geometric random walk",
+      "2-adic Collatz",
+      "probabilistic number theory"
+    ],
+    "prerequisites": [
+      "Real.log",
+      "avgStoppingTime",
+      "probabilistic heuristics in number theory"
+    ]
   },
   {
     "id": "ann-part-iv-header",
     "proofId": "collatz-structured-oq-03",
-    "range": { "startLine": 96, "endLine": 100 },
-    "type": "context",
+    "range": {
+      "startLine": 96,
+      "endLine": 100
+    },
+    "type": "concept",
     "title": "Part IV: Known Density Results — Section Transition",
     "content": "This section transitions from conjectural definitions to the one externally-sourced result: Terras's density theorem. The architectural choice to axiomatize Terras rather than leave it as sorry reflects that this is a *known* result (published in Acta Arithmetica, 1976) whose proof requires 2-adic measure theory not yet available in Mathlib, whereas the open questions in Part V are *unknown* results that cannot be proved regardless of Mathlib coverage.",
     "mathContext": "Terras's proof uses the observation that the pre-image set $T^{-k}(1)$ grows exponentially: each element of $T^{-k}(1)$ has at least one pre-image under $T$, and with probability approaching 1, it has two (one even, one odd pre-image). The density follows from the exponential growth of $|T^{-k}(1) \\cap [1,N]|$.",
-    "significance": "context",
-    "relatedConcepts": ["axiom vs sorry distinction", "proof architecture", "2-adic analysis"],
-    "prerequisites": ["Collatz iteration", "density-1 concept"]
+    "significance": "supporting",
+    "relatedConcepts": [
+      "axiom vs sorry distinction",
+      "proof architecture",
+      "2-adic analysis"
+    ],
+    "prerequisites": [
+      "Collatz iteration",
+      "density-1 concept"
+    ]
   },
   {
     "id": "ann-terras-density-axiom",
     "proofId": "collatz-structured-oq-03",
-    "range": { "startLine": 101, "endLine": 110 },
+    "range": {
+      "startLine": 101,
+      "endLine": 110
+    },
     "type": "concept",
     "title": "Collatz Conjecture Statement and Terras Density-1 Axiom",
     "content": "`collatzConjecture` (line 102) formally states the Collatz conjecture: every positive integer eventually reaches 1 under iteration. It is a `def` of type `Prop` — a well-typed Lean statement of the unsolved problem. `terras_density` (lines 105-110) is the only `axiom` in the file: it asserts that for any ε > 0, the fraction of n ≤ N with σ(n) < ∞ exceeds 1−ε for all sufficiently large N. This is Terras's 1976 theorem — the first major unconditional density result toward the Collatz conjecture. It is axiomatized (not proved) because the Lean proof would require 2-adic measure theory.",
     "mathContext": "Terras proved: $\\lim_{N \\to \\infty} \\frac{1}{N}|\\{1 \\leq n \\leq N : \\sigma(n) < \\infty\\}| = 1$. The proof uses backward iteration: the set of $n$ that reach 1 in $\\leq k$ steps grows as a geometric series in $k$, accumulating density 1 exponentially fast. Krasikov-Lagarias (2003) strengthened the rate to $|\\{n \\leq N : \\sigma(n) < \\infty\\}| \\geq N^{0.84}$. Formalizing Terras in Lean would require Mathlib's `padicVal` and measure theory on pro-2 groups.",
     "significance": "key",
-    "relatedConcepts": ["Terras 1976", "Collatz conjecture", "Krasikov-Lagarias 2003", "2-adic measure theory", "density-1 results"],
-    "prerequisites": ["reachesOne definition", "Finset.filter cardinality", "density arguments in number theory"]
+    "relatedConcepts": [
+      "Terras 1976",
+      "Collatz conjecture",
+      "Krasikov-Lagarias 2003",
+      "2-adic measure theory",
+      "density-1 results"
+    ],
+    "prerequisites": [
+      "reachesOne definition",
+      "Finset.filter cardinality",
+      "density arguments in number theory"
+    ]
   },
   {
     "id": "ann-part-v-header",
     "proofId": "collatz-structured-oq-03",
-    "range": { "startLine": 111, "endLine": 116 },
-    "type": "context",
+    "range": {
+      "startLine": 111,
+      "endLine": 116
+    },
+    "type": "concept",
     "title": "Part V: The Open Question — Formal Specification",
     "content": "The section poses the central question: what is the growth rate of S(N)? The following three `def`s formalize three levels of precision for the answer. This is the core contribution of the file — not proving results, but giving mathematically precise Lean types that future proofs would inhabit. The formalization serves as a *specification*: any future proof of S(N) ~ c·log N must produce a term of type `avgStoppingTimeAsymptotic`.",
     "mathContext": "The three levels form a logical chain: `exactConstant → avgStoppingTimeAsymptotic → logarithmicGrowth` (each implies the previous). The weakest (`logarithmicGrowth`) is itself unknown unconditionally.",
-    "significance": "context",
-    "relatedConcepts": ["formal specification", "proof obligation", "logical implication chain"],
-    "prerequisites": ["Lean Prop type", "Filter.Tendsto", "avgStoppingTime definition"]
+    "significance": "supporting",
+    "relatedConcepts": [
+      "formal specification",
+      "proof obligation",
+      "logical implication chain"
+    ],
+    "prerequisites": [
+      "Lean Prop type",
+      "Filter.Tendsto",
+      "avgStoppingTime definition"
+    ]
   },
   {
     "id": "ann-open-question-formalized",
     "proofId": "collatz-structured-oq-03",
-    "range": { "startLine": 117, "endLine": 133 },
+    "range": {
+      "startLine": 117,
+      "endLine": 133
+    },
     "type": "insight",
     "title": "Three Levels of the Open Question: Bounds, Convergence, Exact Constant",
     "content": "The three `def`s formalize the open conjecture at increasing precision. `logarithmicGrowth` is the weakest: ∃c,C > 0 such that c·log N ≤ S(N) ≤ C·log N for all N ≥ 2 (two-sided logarithmic bound). `avgStoppingTimeAsymptotic` is stronger: S(N)/log N converges to some c > 0 (the limit exists and is positive). `exactConstant` is strongest: the limit is exactly heuristicConstant/log 2 (the probabilistic prediction). All three are Lean `def`s of type `Prop` — formally correct statements of what remains to be proved, serving as specifications for future formalization efforts.",
     "mathContext": "The hierarchy is:\n- `logarithmicGrowth`: $\\exists c,C > 0,\\; c \\log N \\leq S(N) \\leq C \\log N$ for large $N$\n- `avgStoppingTimeAsymptotic`: $\\lim_{N\\to\\infty} S(N)/\\log N = c$ for some $c > 0$\n- `exactConstant`: $\\lim_{N\\to\\infty} S(N)/\\log N = 1/\\log(4/3)$\n\nNone are known unconditionally. Even `logarithmicGrowth` would require bounding the sum $\\sum_{n \\leq N} \\sigma(n)$ from above and below, which requires understanding the distribution of Collatz orbits — tied to the conjecture itself.",
     "significance": "key",
-    "relatedConcepts": ["Filter.Tendsto", "logarithmic growth", "asymptotic analysis", "open conjecture formalization"],
-    "prerequisites": ["avgStoppingTime", "heuristicConstant", "Filter.atTop", "Mathlib topology"]
+    "relatedConcepts": [
+      "Filter.Tendsto",
+      "logarithmic growth",
+      "asymptotic analysis",
+      "open conjecture formalization"
+    ],
+    "prerequisites": [
+      "avgStoppingTime",
+      "heuristicConstant",
+      "Filter.atTop",
+      "Mathlib topology"
+    ]
   },
   {
     "id": "ann-concrete-and-checks",
     "proofId": "collatz-structured-oq-03",
-    "range": { "startLine": 135, "endLine": 149 },
-    "type": "context",
+    "range": {
+      "startLine": 135,
+      "endLine": 149
+    },
+    "type": "concept",
     "title": "Concrete Stopping Time Values and Type-Checking",
     "content": "The final section documents concrete stopping times as comments: σ(1)=0, σ(2)=1, σ(3)=7, σ(4)=2, σ(5)=5, σ(6)=8, and corresponding averages S(1)=0, S(2)=0.5, S(3)≈2.67, S(4)=2.5, S(5)=3.0, S(6)≈3.83. These values are commented (not proved) because `stoppingTime` is noncomputable — Lean cannot evaluate it. The three `#check` commands verify that `avgStoppingTimeAsymptotic`, `logarithmicGrowth`, and `exactConstant` are well-typed Props, confirming the formal definitions are syntactically and semantically correct without requiring a proof.",
     "mathContext": "$\\sigma(3) = 7$: the trajectory $3 \\to 10 \\to 5 \\to 16 \\to 8 \\to 4 \\to 2 \\to 1$ takes 7 steps. $\\sigma(6) = 8$: $6 \\to 3 \\to 10 \\to 5 \\to 16 \\to 8 \\to 4 \\to 2 \\to 1$. The values illustrate the wild variation in stopping times (σ(4)=2 vs σ(3)=7) that makes the average behavior non-trivial to analyze.",
-    "significance": "context",
-    "relatedConcepts": ["Collatz trajectories", "noncomputable evaluation", "Lean #check command", "stopping time examples"],
-    "prerequisites": ["stoppingTime definition", "Lean noncomputable keyword", "Prop type in Lean"]
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Collatz trajectories",
+      "noncomputable evaluation",
+      "Lean #check command",
+      "stopping time examples"
+    ],
+    "prerequisites": [
+      "stoppingTime definition",
+      "Lean noncomputable keyword",
+      "Prop type in Lean"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary

Annotation schema fixes for `collatz-structured-oq-03`:

- **7 annotations** had `type: "context"` → changed to `"concept"` (valid AnnotationType)
- **1 annotation** had `type: "technique"` → changed to `"tactic"` (valid AnnotationType)
- **5 annotations** had `significance: "context"` → changed to `"supporting"` (valid AnnotationSignificance)

Valid `AnnotationType` values: `theorem | lemma | definition | tactic | concept | insight | warning`
Valid `AnnotationSignificance` values: `critical | key | supporting`

All 12 annotations now have valid types and significance values. Build verified clean.