### PR TITLE
Fix abel-ruffini-oq-04: remove duplicate crossRef, fix invalid significance

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04/annotations.json
@@ -411,7 +411,7 @@
     "title": "Verification: Type-Checking the API Surface",
     "content": "The file concludes with four #check commands that type-check the main theorems: a5_is_simple, s5_not_solvable, symmetric_not_solvable, and five_is_the_threshold. In Lean 4, #check asks the kernel to infer and display the type of an expression without adding it to the environment. These serve as both a verification step (confirming that all four theorems have the expected types after the namespace closes) and an API summary for users who want to import specific results. The four checked types are: IsSimpleGroup (alternatingGroup (Fin 5)), ¬IsSolvable (Equiv.Perm (Fin 5)), (n : ℕ) → 5 ≤ n → ¬IsSolvable (Equiv.Perm (Fin n)), and IsSolvable (Equiv.Perm (Fin 1)) ∧ ¬IsSolvable (Equiv.Perm (Fin 5)). This pattern of ending a formalization file with #check statements is common in pedagogical Lean files and serves a similar role to a module's export list in other languages.",
     "mathContext": "Type signatures verified: $\\text{IsSimpleGroup}(A_5)$, $\\neg\\text{IsSolvable}(S_5)$, $\\forall n \\geq 5,\\, \\neg\\text{IsSolvable}(S_n)$, and the threshold conjunction $\\text{IsSolvable}(S_1) \\wedge \\neg\\text{IsSolvable}(S_5)$.",
-    "significance": "technical",
+    "significance": "supporting",
     "relatedConcepts": [
       "type checking",
       "API surface",

--- a/src/data/proofs/abel-ruffini-oq-04/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04/meta.json
@@ -111,11 +111,6 @@
       "targetId": "inverse-galois-oq-01",
       "relationship": "related",
       "description": "Proves $S_n$ and $A_n$ solvable iff $n \\leq 4$, and $[S_5, S_5] = A_5$ — the full bidirectional threshold"
-    },
-    {
-      "targetId": "angle-trisection-oq-02",
-      "relationship": "related",
-      "description": "Constructibility via 2-groups illustrates: constructible $\\subsetneq$ solvable by radicals, with $A_5$'s non-solvability marking where the broader class fails"
     }
   ],
   "overview": {


### PR DESCRIPTION
## Summary

Correctness fixes for `abel-ruffini-oq-04` (already at quality 100, 5 passes):

- **Removed duplicate crossReference**: `angle-trisection-oq-02` appeared twice in the `crossReferences` array. Kept the first (more detailed) occurrence; removed the redundant shorter duplicate. Brings count to 11 entries, within peer review's recommended 8-12 range.
- **Fixed invalid annotation significance**: `ann-verification` used `"significance": "technical"` which is not in the `AnnotationSignificance` TypeScript type (`critical | key | supporting`). Changed to `"supporting"`.

Both issues were schema violations that didn't fail the build (due to `as unknown as` casting in `index.ts`).