### PR TITLE
Enrich erdos-1012-oq-03: fix annotation ranges and schema violations

### DIFF
--- a/src/data/proofs/erdos-1012-oq-03/annotations.json
+++ b/src/data/proofs/erdos-1012-oq-03/annotations.json
@@ -2,157 +2,324 @@
   {
     "id": "ann-1012-module-header",
     "proofId": "erdos-1012-oq-03",
-    "range": { "startLine": 1, "endLine": 64 },
-    "type": "context",
+    "range": {
+      "startLine": 1,
+      "endLine": 64
+    },
+    "type": "concept",
     "title": "Survey of Directed Hamiltonian Cycle Theory",
     "content": "The module docstring surveys the directed Hamiltonian landscape: Ghouila-Houri (1960) gives the directed Dirac theorem (δ⁺, δ⁻ ≥ n/2 + SC → Hamiltonian cycle); Meyniel (1973) weakens this to a degree-sum condition on non-adjacent pairs; Moon-Moser (1963) proves that strongly connected tournaments always have Hamiltonian cycles; and Woodall (1972) gives an arc-count threshold for long directed cycles. The status checklist tracks all components: Rédei (proved), Moon-Moser (proved via `grow_cycle_to_hamiltonian`), Ghouila-Houri (statement proved from sorry infrastructure), and the arc-threshold result (`hamiltonian_of_few_missing_arcs`, proved by probabilistic counting). Two items remain as sorries: `sc_tournament_has_cycle` (initial cycle existence) and `tournament_cycle_extendable` (longest-cycle extension).",
     "mathContext": "The directed Hamiltonian landscape parallels the undirected one: Dirac (1952, undirected) → Ghouila-Houri (1960, directed); Rédei (1934) fills the role of König's theorem for tournaments; Moon-Moser (1963) strengthens to cycles. The critical contrast: in tournaments, Hamiltonicity goes from path (always, Rédei) to cycle (only with SC, Moon-Moser). Woodall's 1972 directed threshold is the analogue of the Erdős-Gallai threshold for cycle lengths.",
-    "significance": "context",
-    "relatedConcepts": ["Ghouila-Houri", "Moon-Moser", "Rédei", "Meyniel", "Woodall", "tournament"],
-    "prerequisites": ["directed graph theory", "Hamiltonian cycles", "tournaments"]
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Ghouila-Houri",
+      "Moon-Moser",
+      "Rédei",
+      "Meyniel",
+      "Woodall",
+      "tournament"
+    ],
+    "prerequisites": [
+      "directed graph theory",
+      "Hamiltonian cycles",
+      "tournaments"
+    ]
   },
   {
     "id": "ann-1012-digraph-definitions",
     "proofId": "erdos-1012-oq-03",
-    "range": { "startLine": 74, "endLine": 92 },
+    "range": {
+      "startLine": 74,
+      "endLine": 92
+    },
     "type": "definition",
     "title": "Digraph Structure: Arc Relation, Degrees, DecidableRel",
     "content": "`Digraph V` is a simple directed graph encoded as an `arc : V → V → Prop` with `loopless : ∀ v, ¬arc v v`. Unlike Mathlib's `SimpleGraph` (undirected), there is no symmetry requirement. The `DecidableRel` instance wraps a `DecidablePred` on pairs, allowing Finset-based computations. `outDegree v` and `inDegree v` are `noncomputable` cardinalities of subtypes `{u // arc v u}` and `{u // arc u v}`. The `noncomputable` tag is required because cardinality of a general `Prop`-indexed subtype is not computable without an explicit enumeration.",
     "mathContext": "In directed graph theory, the out-degree $\\delta^+(v) = |\\{u : v \\to u\\}|$ and in-degree $\\delta^-(v) = |\\{u : u \\to v\\}|$ satisfy $\\sum_v \\delta^+(v) = \\sum_v \\delta^-(v) = |E|$ (directed handshaking). The complete directed graph $K_n^*$ (all $n(n-1)$ arcs between distinct vertices) has $\\delta^+(v) = \\delta^-(v) = n-1$ for every $v$.",
-    "significance": "context",
-    "relatedConcepts": ["Digraph", "outDegree", "inDegree", "DecidableRel", "noncomputable"],
-    "prerequisites": ["directed graph theory", "Lean Prop-valued relations", "Fintype.card"]
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Digraph",
+      "outDegree",
+      "inDegree",
+      "DecidableRel",
+      "noncomputable"
+    ],
+    "prerequisites": [
+      "directed graph theory",
+      "Lean Prop-valued relations",
+      "Fintype.card"
+    ]
   },
   {
     "id": "ann-1012-tournament",
     "proofId": "erdos-1012-oq-03",
-    "range": { "startLine": 93, "endLine": 100 },
+    "range": {
+      "startLine": 93,
+      "endLine": 100
+    },
     "type": "definition",
     "title": "Tournament and Strong Connectivity Predicates",
     "content": "`IsTournament` formalizes the tournament condition: for every pair of distinct vertices $u \\neq v$, exactly one arc direction holds (either $u \\to v$ or $v \\to u$, but not both). This captures 'complete directed graph with no ties'. `IsStronglyConnected` requires a directed path between every ordered pair $(u, v)$ with $u \\neq v$, using a `List`-based path definition. Both predicates work over any finite `DecidableEq` vertex type `V`, keeping the formalization general.",
     "mathContext": "A tournament on $n$ vertices has exactly $\\binom{n}{2}$ arcs (one for each unordered pair). The strongly connected condition for tournaments has a clean equivalent: a tournament is strongly connected iff it is not 'reducible' (has no dominating subset). Rédei's theorem holds for all tournaments; Moon-Moser requires the additional strongly-connected hypothesis.",
     "significance": "key",
-    "relatedConcepts": ["tournament", "strongly connected", "directed graph", "arc"],
-    "prerequisites": ["graph theory", "directed graphs", "Lean structures"]
+    "relatedConcepts": [
+      "tournament",
+      "strongly connected",
+      "directed graph",
+      "arc"
+    ],
+    "prerequisites": [
+      "graph theory",
+      "directed graphs",
+      "Lean structures"
+    ]
   },
   {
     "id": "ann-1012-hamiltonian-def",
     "proofId": "erdos-1012-oq-03",
-    "range": { "startLine": 107, "endLine": 120 },
+    "range": {
+      "startLine": 107,
+      "endLine": 120
+    },
     "type": "definition",
     "title": "Hamiltonian Cycle and Path: Equiv-Based Encoding",
     "content": "`HasHamiltonianCycle D` asserts the existence of a permutation $\\sigma \\in \\text{Perm}(\\text{Fin}\\ n)$ such that $D.\\text{arc}(\\sigma(i), \\sigma(i+1 \\mod n))$ holds for all $i$. Using `Equiv.Perm` encodes the Hamiltonian cycle as a bijective traversal of all vertices in cyclic order. Similarly, `HasHamiltonianPath D` uses a bijection $\\text{Fin}\\ n \\to V$ for the path. This algebraic encoding is clean but requires converting the list-based proofs to the `Equiv` form, which `list_path_to_hamiltonian` and `list_cycle_to_hamiltonian` handle.",
     "mathContext": "A Hamiltonian cycle visits every vertex exactly once and returns to the start: $v_{\\sigma(0)} \\to v_{\\sigma(1)} \\to \\cdots \\to v_{\\sigma(n-1)} \\to v_{\\sigma(0)}$. The `Equiv.Perm` encoding ensures bijectivity (visits all $n$ vertices) while the arc conditions enforce the directed path structure.",
     "significance": "key",
-    "relatedConcepts": ["Hamiltonian cycle", "Equiv.Perm", "bijection", "cyclic ordering"],
-    "prerequisites": ["graph theory", "Lean Equiv type", "Fintype"]
+    "relatedConcepts": [
+      "Hamiltonian cycle",
+      "Equiv.Perm",
+      "bijection",
+      "cyclic ordering"
+    ],
+    "prerequisites": [
+      "graph theory",
+      "Lean Equiv type",
+      "Fintype"
+    ]
   },
   {
     "id": "ann-1012-arc-lemmas-path-def",
     "proofId": "erdos-1012-oq-03",
-    "range": { "startLine": 126, "endLine": 150 },
+    "range": {
+      "startLine": 126,
+      "endLine": 150
+    },
     "type": "definition",
     "title": "Tournament Arc Lemmas and IsDirectedPathList",
     "content": "`arc_or_arc` and `arc_of_not_arc` extract the tournament property: in a tournament, any two distinct vertices $u, v$ have at least one arc, and if $u \\not\\to v$ then $v \\to u$. These two-line lemmas are the workhorses used throughout the file — every case analysis on tournament arcs reduces to these. `IsDirectedPathList D l` defines a valid directed path as a `Nodup` list with consecutive arcs: `l.Nodup ∧ ∀ i, i+1 < l.length → arc(l[i], l[i+1])`. The list encoding (vs. `Equiv`) is more convenient for inductive arguments but requires a final conversion step to `HasHamiltonianPath`.",
     "mathContext": "The list-based path definition `IsDirectedPathList` is the inductive-proof-friendly encoding. It separates into two obligations: (1) no repeated vertices (`Nodup`), and (2) consecutive arcs. The `Equiv`-based `HasHamiltonianPath` is the clean mathematical statement. Bridging them (via `list_path_to_hamiltonian`) requires showing the list defines a bijection $\\text{Fin}\\ n \\to V$.",
     "significance": "supporting",
-    "relatedConcepts": ["arc_or_arc", "arc_of_not_arc", "IsDirectedPathList", "Nodup", "tournament property"],
-    "prerequisites": ["tournament definition", "List.Nodup", "directed path"]
+    "relatedConcepts": [
+      "arc_or_arc",
+      "arc_of_not_arc",
+      "IsDirectedPathList",
+      "Nodup",
+      "tournament property"
+    ],
+    "prerequisites": [
+      "tournament definition",
+      "List.Nodup",
+      "directed path"
+    ]
   },
   {
     "id": "ann-1012-path-insert",
     "proofId": "erdos-1012-oq-03",
-    "range": { "startLine": 151, "endLine": 220 },
+    "range": {
+      "startLine": 151,
+      "endLine": 220
+    },
     "type": "insight",
     "title": "Tournament Path Insertion: Key Lemma for Rédei",
     "content": "`tournament_path_insert` proves that given a Hamiltonian path on $k$ vertices of a tournament and a new vertex $v$, the path can be extended to a Hamiltonian path on $k+1$ vertices. The proof considers three cases: (1) $v \\to p_1$ (insert at front), (2) $p_k \\to v$ (append at back), (3) there exists $i$ with $p_i \\to v \\to p_{i+1}$ (insert in middle). In a tournament, one of these must hold: if $p_1 \\to v$ (not case 1) and $v \\to p_k$ (not case 2), then among the arc transitions $p_i \\to v$ and $v \\to p_j$, consecutive indices must transition, giving a valid middle insertion point.",
     "mathContext": "For a path $p_0 \\to p_1 \\to \\cdots \\to p_{k-1}$ and vertex $v$: define $I = \\{i : p_i \\to v\\}$ and $J = \\{j : v \\to p_j\\}$. Since $I \\cup J = \\{0,\\ldots,k-1\\}$ (tournament), if $I$ and $J$ are both nonempty, let $i = \\max I$ and $j = \\min J$; the tournament condition on $p_i, p_j$ forces $i < j$ (since $p_i \\to v \\to p_j$ and $j > i$ follows from $p_i \\to p_{i+1} \\to \\cdots \\to p_j$ in the path). So insert $v$ between $p_i$ and $p_{i+1}$.",
     "significance": "key",
-    "relatedConcepts": ["insertion lemma", "Hamiltonian path extension", "tournament property", "inductive step"],
-    "prerequisites": ["tournament definition", "directed path", "List operations in Lean"]
+    "relatedConcepts": [
+      "insertion lemma",
+      "Hamiltonian path extension",
+      "tournament property",
+      "inductive step"
+    ],
+    "prerequisites": [
+      "tournament definition",
+      "directed path",
+      "List operations in Lean"
+    ]
   },
   {
     "id": "ann-1012-redei-path-building",
     "proofId": "erdos-1012-oq-03",
-    "range": { "startLine": 221, "endLine": 285 },
-    "type": "technique",
+    "range": {
+      "startLine": 221,
+      "endLine": 285
+    },
+    "type": "tactic",
     "title": "Full Path Construction and List-to-Equiv Conversion",
     "content": "`tournament_full_path_list` builds a complete Hamiltonian path by induction on path length: start with any single vertex (length 1), then at each step apply `tournament_path_insert` to extend by one vertex. The key sub-argument: a Nodup list shorter than `card V` must miss at least one vertex (proved by a Finset cardinality argument). `list_path_to_hamiltonian` converts the resulting list to `HasHamiltonianPath` by constructing a bijection `f : Fin n → V` via `f i = l[i]` — injective by `List.Nodup.getElem_inj_iff`, surjective because every `v ∈ V` is in the full-length Nodup list. The bijection gives an `Equiv` via `Equiv.ofBijective`.",
     "mathContext": "The two-step conversion (list → Equiv) reflects a general pattern in Lean formalization: inductive proofs prefer `List`-based definitions (easy to extend), while clean mathematical statements use `Equiv` or `Finset`. The bridge `Equiv.ofBijective f hf_bij` is the standard Lean idiom for extracting an equivalence from a bijective function. The surjectivity argument uses `l.toFinset = Finset.univ` (nodup list of full length exhausts the finite type).",
     "significance": "supporting",
-    "relatedConcepts": ["tournament_full_path_list", "list_path_to_hamiltonian", "Equiv.ofBijective", "List.Nodup.getElem_inj_iff"],
-    "prerequisites": ["tournament_path_insert", "Finset.eq_univ_of_card", "Equiv.ofBijective"]
+    "relatedConcepts": [
+      "tournament_full_path_list",
+      "list_path_to_hamiltonian",
+      "Equiv.ofBijective",
+      "List.Nodup.getElem_inj_iff"
+    ],
+    "prerequisites": [
+      "tournament_path_insert",
+      "Finset.eq_univ_of_card",
+      "Equiv.ofBijective"
+    ]
   },
   {
     "id": "ann-1012-ghouila-houri",
     "proofId": "erdos-1012-oq-03",
-    "range": { "startLine": 295, "endLine": 300 },
+    "range": {
+      "startLine": 334,
+      "endLine": 945
+    },
     "type": "insight",
     "title": "Ghouila-Houri Theorem (Sorry): Directed Dirac Analogue",
     "content": "`ghouila_houri` states: a strongly connected digraph on $n \\geq 3$ vertices with $\\delta^+(v), \\delta^-(v) \\geq n/2$ for all $v$ has a Hamiltonian cycle. The proof is deferred (`sorry`). The standard proof mirrors Dirac's undirected argument: take a longest directed path $P = v_0 \\to \\cdots \\to v_k$; since $P$ is longest, $v_k$'s successors and $v_0$'s predecessors all lie in $P$. The out-neighbors of $v_k$ and in-neighbors of $v_0$ each have $\\geq n/2$ elements in $P$, so by pigeonhole some $v_i$ satisfies $v_{i-1} \\to v_0$ and $v_k \\to v_i$, closing $P$ into a Hamiltonian cycle.",
     "mathContext": "Ghouila-Houri (1960): $G$ strongly connected, $\\forall v: \\delta^+(v) \\geq n/2$ and $\\delta^-(v) \\geq n/2$ $\\Rightarrow$ $G$ Hamiltonian. Compare: Dirac (1952): $G$ undirected, $\\delta(v) \\geq n/2$ $\\Rightarrow$ Hamiltonian. The directed version requires both in- and out-degree bounds (one bound alone is insufficient).",
     "significance": "key",
-    "relatedConcepts": ["Dirac's theorem", "degree condition", "pigeonhole principle", "longest path argument"],
-    "prerequisites": ["directed graph theory", "degree conditions", "Hamiltonicity"]
+    "relatedConcepts": [
+      "Dirac's theorem",
+      "degree condition",
+      "pigeonhole principle",
+      "longest path argument"
+    ],
+    "prerequisites": [
+      "directed graph theory",
+      "degree conditions",
+      "Hamiltonicity"
+    ]
   },
   {
     "id": "ann-1012-directed-cycle-infra",
     "proofId": "erdos-1012-oq-03",
-    "range": { "startLine": 302, "endLine": 400 },
+    "range": {
+      "startLine": 946,
+      "endLine": 1030
+    },
     "type": "definition",
     "title": "Directed Cycle Infrastructure: IsDirectedCycleList and sc_tournament_has_cycle",
     "content": "`IsDirectedCycleList D l` defines a directed cycle as a `Nodup` list with $\\text{length} \\geq 2$ and modular arc condition: `arc(l[i], l[(i+1) % k])` for all $i < k$. The modular index handles the wrap-around arc $l[k-1] \\to l[0]$. `nodup_length_le_card` is a simple cardinality lemma used throughout. `sc_tournament_has_cycle` (marked `sorry` in the status checklist) extracts an initial directed cycle from a strongly connected tournament on $\\geq 3$ vertices: use the Hamiltonian path `hl`, take the SC walk from `hl[n-1]` back to `hl[0]`, find the first step `w₁ = walk[1]` in `hl` at position `j < n-1`, and return `hl.drop j` as a directed cycle of length $n-j \\geq 2$.",
     "mathContext": "The strategy for `sc_tournament_has_cycle` is: Hamiltonian path $p_0 \\to \\cdots \\to p_{n-1}$ + SC walk from $p_{n-1}$ back to $p_0$ gives a closed walk. The first internal step $p_{n-1} \\to w_1$ where $w_1 = p_j$ for $j < n-1$ (since $w_1 \\neq p_{n-1}$ by looplessness) gives the cycle $p_j \\to p_{j+1} \\to \\cdots \\to p_{n-1} \\to p_j$ — equivalently `hl.drop j`. This is a clean existence argument: the Hamiltonian path provides global structure, SC provides the closing arc.",
     "significance": "key",
-    "relatedConcepts": ["IsDirectedCycleList", "sc_tournament_has_cycle", "nodup_length_le_card", "modular indexing"],
-    "prerequisites": ["IsDirectedPathList", "tournament_full_path_list", "strong connectivity"]
+    "relatedConcepts": [
+      "IsDirectedCycleList",
+      "sc_tournament_has_cycle",
+      "nodup_length_le_card",
+      "modular indexing"
+    ],
+    "prerequisites": [
+      "IsDirectedPathList",
+      "tournament_full_path_list",
+      "strong connectivity"
+    ]
   },
   {
     "id": "ann-1012-cycle-non-insertable-extendable",
     "proofId": "erdos-1012-oq-03",
-    "range": { "startLine": 401, "endLine": 860 },
+    "range": {
+      "startLine": 1031,
+      "endLine": 1492
+    },
     "type": "insight",
     "title": "Moon-Moser Core: Non-Insertable Dichotomy and Cycle Extension",
     "content": "Part IV.B proves `tournament_cycle_non_insertable`: if vertex $u$ cannot be inserted into cycle $l$ at any position (no $i$ with $l[i] \\to u \\to l[(i+1)\\%k]$), then either all cycle vertices beat $u$ (set $S^-$) or $u$ beats all cycle vertices (set $S^+$). The proof uses successor closure: if $l[i] \\to u$ (call this the '$A$-property') then by non-insertability $l[(i+1)\\%k] \\to u$ (otherwise insert), so $A$ is closed under cyclic successor — a subset of $\\mathbb{Z}/k\\mathbb{Z}$ closed under successor is empty or everything. Part IV.C proves `tournament_cycle_extendable` (sorry-free, 400 lines): any cycle shorter than $n$ in an SC tournament can be strictly extended. The argument partitions non-cycle vertices into $S^+$ (beat all cycle) and $S^-$ (beaten by all cycle): if $S^-$ is nonempty, it is closed under arcs and disconnected from the cycle, contradicting SC; symmetrically for $S^+$; if both nonempty, SC provides an arc $a \\in S^- \\to b \\in S^+$, and appending $[a, b]$ to the cycle yields a longer cycle $l \\mathbin{++} [a, b]$.",
     "mathContext": "The $S^+/S^-$ partition argument is the Moon-Moser core idea: in a tournament, the set of non-cycle vertices decomposes into those dominated by the cycle ($S^-$) and those dominating the cycle ($S^+$). Strong connectivity forces this decomposition to be 'bridged' by an arc from $S^-$ to $S^+$. The resulting 2-extension ($l \\mathbin{++} [a, b]$) grows the cycle by exactly 2 when both sets are nonempty. When $S^+$ has an insertable vertex, the cycle grows by 1. In the fully proved version, both growth scenarios are covered, giving well-founded recursion with a decreasing measure $n - |C|$.",
     "significance": "key",
-    "relatedConcepts": ["tournament_cycle_non_insertable", "tournament_cycle_extendable", "S+ S- partition", "SC contradiction", "cyclic successor closure"],
-    "prerequisites": ["IsDirectedCycleList", "IsTournament", "IsStronglyConnected"]
+    "relatedConcepts": [
+      "tournament_cycle_non_insertable",
+      "tournament_cycle_extendable",
+      "S+ S- partition",
+      "SC contradiction",
+      "cyclic successor closure"
+    ],
+    "prerequisites": [
+      "IsDirectedCycleList",
+      "IsTournament",
+      "IsStronglyConnected"
+    ]
   },
   {
     "id": "ann-1012-list-cycle-to-hamiltonian",
     "proofId": "erdos-1012-oq-03",
-    "range": { "startLine": 861, "endLine": 942 },
-    "type": "technique",
+    "range": {
+      "startLine": 285,
+      "endLine": 333
+    },
+    "type": "tactic",
     "title": "Cycle List to HasHamiltonianCycle and GH Sorry Infrastructure",
     "content": "`list_cycle_to_hamiltonian` mirrors `list_path_to_hamiltonian`: given a Nodup list `l` with `l.length = card V` and `IsDirectedCycleList D l`, construct `HasHamiltonianCycle D`. The bijection $f : \\text{Fin}\\ n \\to V$ via `f i = l[i]` is injective (`Nodup`) and surjective (full-length list covers `V`). The arc condition for `HasHamiltonianCycle` — `arc(σ.symm i, σ.symm ((i+1)%n))` — matches the modular condition in `IsDirectedCycleList`, so the proof closes by `harcs`. The GH sorry stubs (lines 904–942) are: `sc_digraph_has_directed_cycle` (SC + positive out-degree → cycle exists), `exists_longest_directed_cycle` (finite digraph has a longest cycle), `gh_insertion_point` (degree conditions force a pigeonhole insertion point for any vertex outside the longest cycle), and `insertNth_directed_cycle` (inserting at the found point yields a valid cycle).",
     "mathContext": "The GH sorry stubs follow a well-defined logical structure: `sc_digraph_has_directed_cycle` gives the initial cycle (analogous to `sc_tournament_has_cycle` but for general SC digraphs with positive out-degree); `exists_longest_directed_cycle` uses finiteness to get a maximum-length cycle; `gh_insertion_point` is the degree-counting pigeonhole step (the heart of the Ghouila-Houri proof); `insertNth_directed_cycle` is the cycle closure step. Together they make `ghouila_houri` fully proved (no sorry in the theorem statement itself).",
     "significance": "supporting",
-    "relatedConcepts": ["list_cycle_to_hamiltonian", "sc_digraph_has_directed_cycle", "exists_longest_directed_cycle", "gh_insertion_point", "insertNth_directed_cycle"],
-    "prerequisites": ["IsDirectedCycleList", "list_path_to_hamiltonian", "Equiv.ofBijective"]
+    "relatedConcepts": [
+      "list_cycle_to_hamiltonian",
+      "sc_digraph_has_directed_cycle",
+      "exists_longest_directed_cycle",
+      "gh_insertion_point",
+      "insertNth_directed_cycle"
+    ],
+    "prerequisites": [
+      "IsDirectedCycleList",
+      "list_path_to_hamiltonian",
+      "Equiv.ofBijective"
+    ]
   },
   {
     "id": "ann-1012-final-theorems",
     "proofId": "erdos-1012-oq-03",
-    "range": { "startLine": 994, "endLine": 1039 },
+    "range": {
+      "startLine": 1493,
+      "endLine": 1538
+    },
     "type": "theorem",
     "title": "grow_cycle_to_hamiltonian, moon_moser, and redei: Main Theorems",
     "content": "`grow_cycle_to_hamiltonian` is a private noncomputable definition using well-founded recursion on `Fintype.card V - l.length` (the cycle deficit). Base case: if `l.length = card V`, convert via `list_cycle_to_hamiltonian`. Recursive case: `tournament_cycle_extendable` produces a strictly longer cycle `l'`, and the well-founded measure decreases by `omega`. `moon_moser` is a 2-line theorem: get an initial cycle via `sc_tournament_has_cycle`, then grow it to Hamiltonian via `grow_cycle_to_hamiltonian`. `redei` (at line 1034) is similarly 2 lines: build a full path list via `tournament_full_path_list`, convert via `list_path_to_hamiltonian`. Both are fully proved with 0 sorries.",
     "mathContext": "The `grow_cycle_to_hamiltonian` recursion uses Lean 4's `termination_by`/`decreasing_by` annotations. The termination measure `Fintype.card V - l.length` is a natural number that strictly decreases because `tournament_cycle_extendable` guarantees `l'.length > l.length`. The `noncomputable` tag on `grow_cycle_to_hamiltonian` propagates from `sc_tournament_has_cycle` and `tournament_cycle_extendable` which use classical reasoning. Moon-Moser and Rédei are the two jewels of this file: both fully proved, both 2 lines from their respective infrastructure.",
     "significance": "key",
-    "relatedConcepts": ["grow_cycle_to_hamiltonian", "moon_moser", "redei", "well-founded recursion", "termination_by"],
-    "prerequisites": ["sc_tournament_has_cycle", "tournament_cycle_extendable", "list_cycle_to_hamiltonian", "tournament_full_path_list"]
+    "relatedConcepts": [
+      "grow_cycle_to_hamiltonian",
+      "moon_moser",
+      "redei",
+      "well-founded recursion",
+      "termination_by"
+    ],
+    "prerequisites": [
+      "sc_tournament_has_cycle",
+      "tournament_cycle_extendable",
+      "list_cycle_to_hamiltonian",
+      "tournament_full_path_list"
+    ]
   },
   {
     "id": "ann-1012-arc-threshold",
     "proofId": "erdos-1012-oq-03",
-    "range": { "startLine": 1040, "endLine": 1372 },
+    "range": {
+      "startLine": 1539,
+      "endLine": 1827
+    },
     "type": "theorem",
     "title": "Part V: Arc Threshold via Probabilistic Counting",
     "content": "Part V proves `directed_hamiltonian_threshold`: if a digraph on $n \\geq 3$ vertices has $> (n-1)^2$ arcs, it has a Hamiltonian cycle. The proof uses a probabilistic/counting argument over permutations. `missing_arcs_le` establishes that $|E| > (n-1)^2$ implies at most $n-2$ missing arcs. `hamiltonian_of_few_missing_arcs` is the main lemma: fix a bijection $\\alpha : \\text{Fin}\\ n \\cong V$; a permutation $\\sigma$ is 'bad' if it uses some missing arc $\\alpha(\\sigma(i)) \\to \\alpha(\\sigma(i+1))$. For each missing arc $(a,b)$, the number of bad permutations is $(n-1)!$ (count: at each of $n$ positions for $a$, the position $i+1$ is forced to $b$, leaving $(n-2)!$ choices for the rest). With $\\leq n-2$ missing arcs, total bad permutations $\\leq (n-2)(n-1)! = (n-1)! \\cdot (n-2) < n! = (n-1)! \\cdot n$. So a good permutation exists, giving a Hamiltonian cycle.",
     "mathContext": "The counting argument is a classical application of the probabilistic method (Erdős-style): the 'bad event' for arc $(a,b)$ has probability $(n-1)!/n! = 1/n$, and there are $\\leq n-2$ bad arcs, so the union bound gives probability $\\leq (n-2)/n < 1$ of all bad events. A 'good' permutation exists. This is also known as the Woodall arc-threshold: $|E| > (n-1)^2$ forces Hamiltonicity in a strongly connected digraph. The Lean proof uses `Finset.filter` to build the 'bad permutation' set and `Finset.card_lt_iff_ne_univ` to find a good permutation from the cardinality inequality.",
     "significance": "key",
-    "relatedConcepts": ["probabilistic method", "arc threshold", "missing_arcs_le", "hamiltonian_of_few_missing_arcs", "permutation counting", "union bound"],
-    "prerequisites": ["Equiv.Perm", "Finset.card", "probabilistic method", "directed_hamiltonian_threshold"]
+    "relatedConcepts": [
+      "probabilistic method",
+      "arc threshold",
+      "missing_arcs_le",
+      "hamiltonian_of_few_missing_arcs",
+      "permutation counting",
+      "union bound"
+    ],
+    "prerequisites": [
+      "Equiv.Perm",
+      "Finset.card",
+      "probabilistic method",
+      "directed_hamiltonian_threshold"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-1012-oq-03/meta.json
+++ b/src/data/proofs/erdos-1012-oq-03/meta.json
@@ -67,29 +67,29 @@
       "id": "part-ii-redei-infrastructure",
       "title": "Part II.C: List-Based Path Infrastructure (Rédei)",
       "startLine": 134,
-      "endLine": 284,
-      "summary": "Defines IsDirectedPathList (list-based directed path). Proves tournament_path_insert (insert new vertex into existing Hamiltonian path), tournament_full_path_list (build full Hamiltonian path by induction), and list_path_to_hamiltonian (convert list path to Equiv-based definition)."
+      "endLine": 333,
+      "summary": "Defines IsDirectedPathList (list-based directed path). Proves tournament_path_insert (insert new vertex into existing Hamiltonian path), tournament_full_path_list (build full Hamiltonian path by induction), and list_path_to_hamiltonian (convert list path to Equiv-based definition). Also defines IsDirectedCycleList and proves list_cycle_to_hamiltonian (cycle list → Equiv), bridging to Part III."
     },
     {
       "id": "part-iii-ghouila-houri",
       "title": "Part III: Ghouila-Houri Theorem",
-      "startLine": 285,
-      "endLine": 758,
-      "summary": "Fully proves ghouila_houri: strongly connected digraph with δ⁺(v), δ⁻(v) ≥ n/2 for all v has a Hamiltonian cycle. Includes sc_degree_has_cycle (greedy path + back-arc), ghouila_houri_cycle_extendable (cycle extension under GH conditions), and grow_cycle_gh (well-founded recursion)."
+      "startLine": 334,
+      "endLine": 945,
+      "summary": "Fully proves ghouila_houri: strongly connected digraph with δ⁺(v), δ⁻(v) ≥ n/2 for all v has a Hamiltonian cycle. Includes sc_degree_has_cycle (greedy path + back-arc), ghouila_houri_cycle_extendable (cycle extension under GH conditions), grow_cycle_gh (well-founded recursion), and GH sorry stubs (sc_digraph_has_directed_cycle, exists_longest_directed_cycle, gh_insertion_point, insertNth_directed_cycle)."
     },
     {
       "id": "part-iv-moon-moser",
       "title": "Part IV: Moon-Moser Theorem and Infrastructure",
-      "startLine": 302,
-      "endLine": 941,
-      "summary": "Extensive infrastructure: IsDirectedCycleList (list-based cycle definition), sc_tournament_has_cycle (fully proved: Hamiltonian path + SC walk gives initial cycle), tournament_cycle_non_insertable (S⁺/S⁻ partition dichotomy when no insertion point exists), tournament_cycle_extendable (fully proved: SC contradiction forces cycle extension), list_cycle_to_hamiltonian (cycle list → Equiv), grow_cycle_to_hamiltonian (well-founded induction growing any cycle to Hamiltonian), moon_moser theorem (FULLY PROVED: no sorries). Ends with Rédei's theorem: fully proved by induction."
+      "startLine": 946,
+      "endLine": 1538,
+      "summary": "Extensive infrastructure: sc_tournament_has_cycle (fully proved: Hamiltonian path + SC walk gives initial cycle), tournament_cycle_non_insertable (S⁺/S⁻ partition dichotomy when no insertion point exists), tournament_cycle_extendable (fully proved: SC contradiction forces cycle extension), grow_cycle_to_hamiltonian (well-founded induction growing any cycle to Hamiltonian), moon_moser theorem (FULLY PROVED: no sorries). Ends with Rédei's theorem: fully proved by induction."
     },
     {
       "id": "part-v-threshold",
-      "title": "Part V: Edge Threshold + Proof Roadmap",
-      "startLine": 943,
-      "endLine": 991,
-      "summary": "Defines arcCount. Proves directed_hamiltonian_threshold: (n-1)² < arcCount ∧ strongly connected → Hamiltonian cycle via probabilistic counting (hamiltonian_of_few_missing_arcs, perm_arc_bad_card_le). Closes with #check commands verifying all four main theorems."
+      "title": "Part V: Arc Threshold + Verification",
+      "startLine": 1539,
+      "endLine": 1827,
+      "summary": "Defines arcCount. Proves directed_hamiltonian_threshold: (n-1)² < arcCount ∧ strongly connected → Hamiltonian cycle via probabilistic counting (hamiltonian_of_few_missing_arcs, perm_arc_bad_card_le, missing_arcs_le). Closes with #check commands verifying all four main theorems."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

- Fixed 6 annotation line ranges that drifted when the Lean file was extended to 1827 lines; ranges for the GH/Moon-Moser/threshold sections were all pointing at wrong line numbers
- Fixed TypeScript schema violations: `type: "context"` → `"concept"`, `type: "technique"` → `"tactic"`, `significance: "context"` → `"supporting"`
- Fixed meta.json section ranges for Part III (334-945), Part IV (946-1538), and Part V (1539-1827)
- Extended Part II section end from 284 to 333 to cover bridge lemmas (`IsDirectedCycleList`, `list_cycle_to_hamiltonian`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)