### PR TITLE
Audit: sync stale lineCount in 14 gallery meta.json files

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -23,7 +23,7 @@
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
     "assumptions": "Four open sorries: (1) hook_length_formula (requires SYT↔NI bijection + det factorization), (2) ni_count_eq_syt_count (Fomin/Viennot/RSK correspondence), (3) lgv_det_factors_as_hook_quotient (det factorization identity), (4) card_SYT_twoRectYD (SYT count for 2-row rectangular = Catalan number C_m via ballot bijection). StandardYoungTableau.ext is now fully proved (funext).",
-    "lineCount": 676,
+    "lineCount": 1274,
     "theoremCount": 12,
     "definitionCount": 5,
     "originalContributions": [
@@ -79,7 +79,7 @@
       "LGV"
     ],
     "namespace": "HookLengthFormula",
-    "lineCount": 676,
+    "lineCount": 1274,
     "axiomCount": 0,
     "sorries": 4,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",

--- a/src/data/proofs/ballot-problem-oq-03-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01/meta.json
@@ -22,7 +22,7 @@
     "dateAdded": "2026-04-02",
     "axiomCount": 0,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
-    "lineCount": 2878,
+    "lineCount": 2898,
     "theoremCount": 138,
     "definitionCount": 31,
     "originalContributions": [
@@ -70,7 +70,7 @@
   },
   "leanFile": {
     "namespace": "LatticePathLGV",
-    "lineCount": 2878,
+    "lineCount": 2898,
     "axiomCount": 0,
     "theoremCount": 138,
     "definitionCount": 31,

--- a/src/data/proofs/ballot-problem-oq-03/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03/meta.json
@@ -71,7 +71,7 @@
       "Lattice path combinatorics",
       "Basic Lean 4 induction and Fintype"
     ],
-    "lineCount": 2878,
+    "lineCount": 2898,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
   },
   "overview": {
@@ -315,7 +315,7 @@
       "List"
     ],
     "namespace": "LatticePathLGV",
-    "lineCount": 2878,
+    "lineCount": 2898,
     "axiomCount": 0,
     "theoremCount": 138,
     "definitionCount": 32,

--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02/meta.json
@@ -21,7 +21,7 @@
     "sorries": 0,
     "dateAdded": "2026-04-12",
     "axiomCount": 5,
-    "lineCount": 791,
+    "lineCount": 851,
     "assumptions": "5 axioms: aperyB_recurrence (WZ recurrence), denominator_control (lcm^3*a_n is integer), lcm_hanson_bound (3^n Hanson bound), apery_linearForm_decay (geometric decay), apery_linearForm_nonzero (L_n != 0 for n>=1). Removed unused nair_lcm_bound. Main theorem apery_theorem PROVED from these 5 axioms.",
     "mathlib_version": "4.26.0",
     "originalContributions": [

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-03/meta.json
@@ -20,7 +20,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 222,
+    "lineCount": 392,
     "assumptions": "None. All 4 theorems (normalization, mean, cross-moment, covariance) are fully machine-verified with 0 sorries and 0 axioms.",
     "theoremCount": 4,
     "mathlib_version": "4.26.0"

--- a/src/data/proofs/erdos-268/meta.json
+++ b/src/data/proofs/erdos-268/meta.json
@@ -57,7 +57,7 @@
       "Concrete examples: squares (Basel problem) and powers of 2 (geometric series)"
     ],
     "axiomCount": 1,
-    "lineCount": 497,
+    "lineCount": 762,
     "assumptions": "1 axiom: erdos_268_solved (main interior result for all dimensions). 2 sorries remaining: both inside harmonicPointSet_path_connected — (1) d=0 greedy construction (⊇ direction: any s > 0 is achievable by a Cauchy sequence argument); (2) d ≥ 2 path-connectedness (Kovač-Tao structural analysis; hard topology). Proved: shifted_summable (decomposition at n=0), harmonicPointSet_nonempty (powers-of-2 witness), harmonicPointSet_dense_somewhere (directly from interior axiom), coordinate_decreasing (tsum_lt_tsum; requires 0 ∉ A), first_coordinate_largest (from coordinate_decreasing), squares_convergent (bijection + p-series), powers_convergent (bijection + geometric series)."
   },
   "overview": {
@@ -207,7 +207,7 @@
       "Topology"
     ],
     "namespace": "Erdos268",
-    "lineCount": 497,
+    "lineCount": 762,
     "axiomCount": 1,
     "theoremCount": 15,
     "definitionCount": 14,

--- a/src/data/proofs/erdos-36/meta.json
+++ b/src/data/proofs/erdos-36/meta.json
@@ -65,7 +65,7 @@
       "Asymptotic analysis: limit of M(N)/N"
     ],
     "assumptions": "3 axiom declarations: erdos_36_limit_exists (the limit c = lim M(N)/N exists), white_lower (White's 0.379 lower bound), upper_bound (Haugland's 0.381 upper bound). small_values is now a theorem proved computationally via native_decide on a computable mirror function MC.",
-    "lineCount": 203,
+    "lineCount": 380,
     "relatedProblems": [
       {
         "id": "erdos-335",
@@ -78,7 +78,7 @@
     ]
   },
   "leanFile": {
-    "lineCount": 203,
+    "lineCount": 380,
     "axiomCount": 3,
     "theoremCount": 6,
     "definitionCount": 9,

--- a/src/data/proofs/erdos-476-oq-05/meta.json
+++ b/src/data/proofs/erdos-476-oq-05/meta.json
@@ -22,7 +22,7 @@
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
     "assumptions": "2 sorries in vosper theorem: [SORRY 1/2] Case 1 existence (counting argument for removing an element from A) and [SORRY 2/2] AP extension (a₀ adjacent to A' implies A is AP with same difference d). Both ap_of_near_periodic (backward-shift induction) and vosper_base (|A|=2 case) are fully proved. Infrastructure all proved with 0 sorries.",
-    "lineCount": 306,
+    "lineCount": 437,
     "theoremCount": 8,
     "definitionCount": 1,
     "originalContributions": [
@@ -116,7 +116,7 @@
   ],
   "leanFile": {
     "namespace": "Erdos476OQ05",
-    "lineCount": 306,
+    "lineCount": 437,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 1,

--- a/src/data/proofs/hurwitz-theorem-oq-03/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-03/meta.json
@@ -22,7 +22,7 @@
     "dateAdded": "2026-04-02",
     "axiomCount": 0,
     "assumptions": "1 sorry: hurwitz_only_if — if an n-square identity exists, then n ∈ {1,2,4,8} (n=3 case proved; n∉{1,2,3,4,8} cases pending Clifford/Radon-Hurwitz argument). The converse (identities exist for n ∈ {1,2,4,8}) is fully proved. No axiom declarations.",
-    "lineCount": 1731,
+    "lineCount": 1838,
     "theoremCount": 32,
     "definitionCount": 15,
     "originalContributions": [
@@ -67,7 +67,7 @@
   },
   "leanFile": {
     "namespace": "HurwitzTheorem",
-    "lineCount": 1731,
+    "lineCount": 1838,
     "axiomCount": 0,
     "theoremCount": 33,
     "definitionCount": 15,

--- a/src/data/proofs/hurwitz-theorem/meta.json
+++ b/src/data/proofs/hurwitz-theorem/meta.json
@@ -45,7 +45,7 @@
     ],
     "dateAdded": "2025-12-26",
     "axiomCount": 0,
-    "lineCount": 1731,
+    "lineCount": 1838,
     "assumptions": "1 sorry: hurwitz_only_if — general non-existence for n ∉ {1,2,3,4,8} (n=3 case proved; remaining cases need Clifford/Radon-Hurwitz argument). The 8-square identity (octonions) is fully proved. No axiom declarations.",
     "mathlib_version": "4.26.0"
   },
@@ -277,7 +277,7 @@
     ],
     "opens": [],
     "namespace": "HurwitzTheorem",
-    "lineCount": 1731,
+    "lineCount": 1838,
     "axiomCount": 0,
     "theoremCount": 33,
     "definitionCount": 15,

--- a/src/data/proofs/pascals-hexagon/meta.json
+++ b/src/data/proofs/pascals-hexagon/meta.json
@@ -46,7 +46,7 @@
     ],
     "dateAdded": "2025-12-29",
     "leanFile": {
-      "lineCount": 1165,
+      "lineCount": 1278,
       "structures": 1,
       "axioms": 1,
       "theorems": 26,
@@ -54,7 +54,7 @@
       "instances": 0
     },
     "axiomCount": 1,
-    "lineCount": 1165,
+    "lineCount": 1278,
     "assumptions": "1 axiom (conic_implies_pascal_constraint). 1 sorry in proof_sketch_conic_implies_pascal (pending Sylvester's law for the standard conic reduction).",
     "mathlib_version": "4.26.0"
   },
@@ -225,7 +225,7 @@
       "Matrix"
     ],
     "namespace": null,
-    "lineCount": 1165,
+    "lineCount": 1278,
     "axiomCount": 1,
     "theoremCount": 21,
     "definitionCount": 24,

--- a/src/data/proofs/ptolemys-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01-oq-01/meta.json
@@ -50,7 +50,7 @@
       "FourDistinct: Structure capturing all six pairwise distinctness conditions for four complex points",
       "ptolemy_of_cw: Ptolemy equality for CW order via relabeling and norm symmetry"
     ],
-    "lineCount": 250,
+    "lineCount": 288,
     "theoremCount": 6,
     "definitionCount": 2
   },

--- a/src/data/proofs/shannon-source-coding-oq-04/meta.json
+++ b/src/data/proofs/shannon-source-coding-oq-04/meta.json
@@ -52,7 +52,7 @@
     ],
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "lineCount": 230,
+    "lineCount": 247,
     "prerequisites": [
       "Shannon entropy H(X) = -sum p(x) log p(x)",
       "Empirical distribution (type) of a sequence",
@@ -161,7 +161,7 @@
       "BigOperators"
     ],
     "namespace": "MethodOfTypes",
-    "lineCount": 230,
+    "lineCount": 247,
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 4,

--- a/src/data/proofs/shapley-folkman/meta.json
+++ b/src/data/proofs/shapley-folkman/meta.json
@@ -61,7 +61,7 @@
       "Caratheodory's theorem (points in convex hull need at most d+1 vertices)",
       "Affine independence and dimension"
     ],
-    "lineCount": 795,
+    "lineCount": 809,
     "mathlib_version": "4.26.0",
     "leanFile": {
       "imports": [
@@ -201,7 +201,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 795,
+    "lineCount": 809,
     "structureCount": 1,
     "axiomCount": 0,
     "theoremCount": 8,


### PR DESCRIPTION
## Fix

Updates `lineCount` metadata to match actual Lean source file lengths. Research agents extended these files after the last metadata sync, leaving counts up to 598 lines out of date.

## Evidence

| Proof | Before | After | Δ |
|-------|--------|-------|---|
| ballot-problem-oq-03-oq-01-oq-02 | 676 | 1274 | +598 |
| erdos-268 | 497 | 762 | +265 |
| erdos-36 | 203 | 380 | +177 |
| binomial-theorem-oq-02-oq-01-oq-03 | 222 | 392 | +170 |
| erdos-476-oq-05 | 306 | 437 | +131 |
| pascals-hexagon | 1165 | 1278 | +113 |
| hurwitz-theorem | 1731 | 1838 | +107 |
| hurwitz-theorem-oq-03 | 1731 | 1838 | +107 |
| basel-problem-oq-01-oq-01-oq-02 | 791 | 851 | +60 |
| ballot-problem-oq-03 | 2878 | 2898 | +20 |
| ballot-problem-oq-03-oq-01 | 2878 | 2898 | +20 |
| ptolemys-theorem-oq-01-oq-01 | 250 | 288 | +38 |
| shannon-source-coding-oq-04 | 230 | 247 | +17 |
| shapley-folkman | 795 | 809 | +14 |

No sorry/axiom counts or status/badge fields were changed — those remain accurate.

---
Automated fix by lean-mechanic agent.