### PR TITLE
Enrich erdos-1205: fix annotation schema violations

### DIFF
--- a/src/data/proofs/erdos-1205/annotations.json
+++ b/src/data/proofs/erdos-1205/annotations.json
@@ -55,7 +55,7 @@
       "startLine": 1,
       "endLine": 17
     },
-    "type": "context",
+    "type": "concept",
     "title": "Historical Context: Covering Systems and Erdős",
     "content": "A **covering system** is a finite set of congruences {a_i (mod n_i)} such that every integer satisfies at least one. Erdős introduced covering systems in the 1950s, showing that for any k, there exists a covering system with minimum modulus k. The classic example: {0(2), 0(3), 1(4), 3(8), 7(12), 23(24)}.\n\nProblem #1205 is a multi-covering variant: instead of every integer covered once (F ≥ 1), we want maximum simultaneous multi-coverage. The constraint that all moduli {1,...,x} must be used (not a subset) gives F(x) = Θ(log x) rather than the 1-coverage case.\n\nRelated: Erdős's minimum modulus conjecture was resolved by Hough (2015): every covering system with distinct moduli has a modulus ≤ 10^16.",
     "mathContext": "Covering system condition: $\\sum 1/n_i \\ge 1$. Multi-covering condition for F-fold: $\\sum 1/n_i \\ge F$. With all $n \\le x$: $\\sum_{n=1}^{x} 1/n \\approx \\ln x$, giving the optimal F \\approx \\ln x$. Hough (2015): Every covering system with distinct moduli contains a modulus $\\le 10^{16}$ (resolving Erdős's conjecture).",
@@ -78,7 +78,7 @@
       "startLine": 44,
       "endLine": 70
     },
-    "type": "technique",
+    "type": "insight",
     "title": "Probabilistic Method: fx_lower_bound Axiom",
     "content": "The lower bound axiom `fx_lower_bound` encodes the probabilistic existence argument. The strategy: choose each a_n uniformly at random from {0,...,n-1}, independently. For fixed m, the probability that n covers m is Prob[m ≡ a_n (mod n)] = 1/n. So:\n\nE[C(m)] = ∑_{n≤x} 1/n = H(x) ≈ ln(x).\n\nThe indicators I_n(m) = 1[n covers m] are independent (different moduli). By the Chernoff bound, P[C(m) < μ/2] ≤ exp(-μ/8) = exp(-ln(x)/8) = x^{-1/8}. A union bound over all x integers m gives P[min C(m) < μ/2] ≤ x·x^{-1/8} → 0. So some assignment achieves min C(m) ≥ c·ln(x).\n\nThis is not yet in Lean because Chernoff bounds for arbitrary distributions require measure theory work.",
     "mathContext": "Formal: $\\exists a: \\forall m \\le x, C_a(m) \\ge c\\ln x$. Proof uses: (1) independence of indicators across moduli; (2) Chernoff: $P[\\sum X_i < (1-\\delta)\\mu] \\le e^{-\\delta^2\\mu/2}$; (3) union bound over $x$ events. The axiom `fx_lower_bound` in Lean asserts this for `c > 0` with `∀ x ≥ 2`.",


### PR DESCRIPTION
## Summary

Fix 2 annotation schema violations in the Erdős Problem 1205 (multi-covering) entry:

- `ann-1205-covering-systems`: `type: "context"` → `"concept"` (describes historical context)
- `ann-1205-probabilistic`: `type: "technique"` → `"insight"` (the Chernoff bound argument is a key mathematical insight)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)