### PR TITLE
Enrich erdos-110-oq-03: fix annotation schema violations

### DIFF
--- a/src/data/proofs/erdos-110-oq-03/annotations.json
+++ b/src/data/proofs/erdos-110-oq-03/annotations.json
@@ -2,73 +2,152 @@
   {
     "id": "ann-ehs-higher-header",
     "proofId": "erdos-110-oq-03",
-    "range": { "startLine": 1, "endLine": 30 },
-    "type": "context",
+    "range": {
+      "startLine": 1,
+      "endLine": 30
+    },
+    "type": "concept",
     "title": "EHS Conjecture at Higher Cardinals: Survey and Techniques",
     "content": "This file generalizes the Erdős-Hajnal-Szemerédi (EHS) conjecture from ℵ₁ to all uncountable cardinals and proves it fails at every successor aleph. The key technique is Todorcevic's walks on ordinals: at each successor ordinal ω_{α+1}, one constructs C-sequences (coherent sequences of closed unbounded sets) whose incompatibility properties produce graphs with the desired chromatic behavior. The file has 9 parts: (I) restated definitions, (II) the generalized conjecture, (III) successor counterexamples via axiom, (IV) ℵ₁ as special case, (V) counterexample graph structure, (VI) limit cardinal open question, (VII) no universal bound, (VIII) independence of failures, (IX) summary.",
     "mathContext": "The **Erdős-Hajnal-Szemerédi Conjecture** (1982): For every graph $G$ with $\\chi(G) = \\aleph_1$, there exists $F : \\mathbb{N} \\to \\mathbb{N}$ and $N_0$ such that for all $n \\geq N_0$, $G$ has an $n$-chromatic induced subgraph on $\\leq F(n)$ vertices. Lambie-Hanson (2020) disproved this at $\\aleph_1$ via Todorcevic's walks framework. This file asks: what happens at $\\aleph_2, \\aleph_3, \\aleph_\\omega$? Answer: all successor alephs also fail; limit alephs are unknown.",
-    "significance": "context",
-    "relatedConcepts": ["Erdős-Hajnal-Szemerédi conjecture", "Lambie-Hanson 2020", "Todorcevic walks on ordinals", "C-sequences", "chromatic numbers of uncountable graphs"],
-    "prerequisites": ["Cardinal.aleph function", "SimpleGraph in Mathlib", "chromatic number theory", "Ordinal arithmetic"]
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Erdős-Hajnal-Szemerédi conjecture",
+      "Lambie-Hanson 2020",
+      "Todorcevic walks on ordinals",
+      "C-sequences",
+      "chromatic numbers of uncountable graphs"
+    ],
+    "prerequisites": [
+      "Cardinal.aleph function",
+      "SimpleGraph in Mathlib",
+      "chromatic number theory",
+      "Ordinal arithmetic"
+    ]
   },
   {
     "id": "ann-ehs-higher-conjecture",
     "proofId": "erdos-110-oq-03",
-    "range": { "startLine": 75, "endLine": 106 },
+    "range": {
+      "startLine": 75,
+      "endLine": 106
+    },
     "type": "concept",
     "title": "GeneralizedEHSConjecture κ: Parametric Formulation and ℵ₁ Special Case",
     "content": "The central definition `GeneralizedEHSConjecture (κ : Cardinal)` formalizes the EHS conjecture for any cardinal κ: every graph G with chromatic number κ admits a bounding function F for n-chromatic subgraph sizes. `OriginalEHSConjecture` is the special case at `Cardinal.aleph 1`. The ℵ₁ disproof is stated as `generalized_ehs_fails_aleph1`, derived from `lambie_hanson_counterexample` which obtains its graph from `successor_cardinal_counterexample 0` (since ℵ₁ = ℵ_{0+1}), demonstrating that the ℵ₁ case is literally the α=0 instance of the general theorem.",
     "mathContext": "$\\text{GeneralizedEHSConjecture}(\\kappa) := \\forall G,\\, \\chi(G) = \\kappa \\Rightarrow \\exists F : \\mathbb{N} \\to \\mathbb{N},\\, N_0,\\, \\forall n \\geq N_0,\\, \\exists S \\subseteq V(G),\\, |S| \\leq F(n) \\land \\chi(G[S]) \\geq n$. The original conjecture is $\\kappa = \\aleph_1$; this file proves $\\neg\\text{GeneralizedEHSConjecture}(\\aleph_{\\alpha+1})$ for all ordinals $\\alpha$. In particular $\\aleph_1 = \\aleph_{0+1}$ and `Ordinal.zero_add` verifies $0 + 1 = 1$ to close the ℵ₁ case.",
     "significance": "key",
-    "relatedConcepts": ["GeneralizedEHSConjecture", "OriginalEHSConjecture", "Cardinal.aleph 1", "HasChromaticNumber", "HasFiniteNChromaticSubgraph"],
-    "prerequisites": ["HasChromaticNumber definition", "HasFiniteNChromaticSubgraph definition", "Cardinal.aleph in Mathlib"]
+    "relatedConcepts": [
+      "GeneralizedEHSConjecture",
+      "OriginalEHSConjecture",
+      "Cardinal.aleph 1",
+      "HasChromaticNumber",
+      "HasFiniteNChromaticSubgraph"
+    ],
+    "prerequisites": [
+      "HasChromaticNumber definition",
+      "HasFiniteNChromaticSubgraph definition",
+      "Cardinal.aleph in Mathlib"
+    ]
   },
   {
     "id": "ann-ehs-higher-successor-axiom",
     "proofId": "erdos-110-oq-03",
-    "range": { "startLine": 113, "endLine": 145 },
-    "type": "technique",
+    "range": {
+      "startLine": 113,
+      "endLine": 145
+    },
+    "type": "theorem",
     "title": "Todorcevic Walks Axiom: Counterexamples at Every Successor Aleph",
     "content": "The key axiom `successor_cardinal_counterexample (α : Ordinal)` asserts that for every ordinal α, there exists an ℵ_{α+1}-chromatic graph that defeats every proposed bounding function F. This axiomatizes the generalization of Lambie-Hanson's technique to all successor ordinals ω_{α+1}. The main theorem `generalized_ehs_fails_all_successor_alephs` follows in 5 lines: unpack the axiom to get G defeating bounds, apply the EHS conjecture to get F, then show F fails — a clean 3-step modus tollens separating mathematical depth (axiom) from logical structure.",
     "mathContext": "Todorcevic's **walks on ordinals**: on any successor ordinal $\\omega_{\\alpha+1}$, fix a C-sequence $\\langle C_\\beta : \\beta < \\omega_{\\alpha+1} \\rangle$ where each $C_\\beta$ is a closed cofinal subset of $\\beta$. The walk from $\\beta$ to $\\alpha$ follows C-sequences downward. The incompatibility of these walks yields a graph $G$ on $\\omega_{\\alpha+1}$ with $\\chi(G) = \\aleph_{\\alpha+1}$ but without uniformly bounded $n$-chromatic subgraphs. On limit ordinals, the Pressing Down and Coherence properties of C-sequences obstruct this construction.",
     "significance": "key",
-    "relatedConcepts": ["successor_cardinal_counterexample axiom", "Todorcevic walks", "C-sequences on ordinals", "cofinal subsets", "Ordinal.zero_add"],
-    "prerequisites": ["Ordinal arithmetic in Lean 4", "Cardinal.aleph", "HasChromaticNumber definition", "HasFiniteNChromaticSubgraph definition"]
+    "relatedConcepts": [
+      "successor_cardinal_counterexample axiom",
+      "Todorcevic walks",
+      "C-sequences on ordinals",
+      "cofinal subsets",
+      "Ordinal.zero_add"
+    ],
+    "prerequisites": [
+      "Ordinal arithmetic in Lean 4",
+      "Cardinal.aleph",
+      "HasChromaticNumber definition",
+      "HasFiniteNChromaticSubgraph definition"
+    ]
   },
   {
     "id": "ann-ehs-higher-structure",
     "proofId": "erdos-110-oq-03",
-    "range": { "startLine": 147, "endLine": 185 },
+    "range": {
+      "startLine": 147,
+      "endLine": 185
+    },
     "type": "concept",
     "title": "CounterexampleGraph Structure and the Limit Cardinal Open Question",
     "content": "The `CounterexampleGraph V G κ` Prop-structure packages two properties: (1) G has chromatic number exactly κ, and (2) G defeats every proposed F and N₀. It is used in `counterexample_exists_at_successor` and `counterexample_implies_failure`. The `LimitCardinalEHSOpen (λ_ord : Ordinal) (hLim : λ_ord.IsLimit)` definition marks limit cardinal instances as open — a gallery convention distinguishing 'disproved' from 'open' subcases within the same file. For limit ordinals λ, C-sequences have fundamentally different properties and the walk-based construction fails.",
     "mathContext": "A **Prop-valued structure** in Lean 4 (`structure ... : Prop where`) is a named conjunction. `CounterexampleGraph V G κ` holds iff $\\chi(G) = \\kappa \\land \\forall F,N_0,\\, \\exists n \\geq N_0,\\, \\neg\\text{HasFiniteNChromaticSubgraph}\\,G\\,n\\,(F\\,n)$. At limit ordinals $\\lambda$, the C-sequence property $\\min(C_\\beta) \\to \\lambda$ as $\\beta \\to \\lambda$ forces **Coherence**: $C_\\beta \\cap \\alpha = C_\\alpha$ for large $\\alpha < \\beta$. This coherence prevents the incompatibility needed for counterexample construction.",
     "significance": "supporting",
-    "relatedConcepts": ["CounterexampleGraph structure", "LimitCardinalEHSOpen", "Prop-valued structures", "Ordinal.IsLimit", "counterexample_implies_failure"],
-    "prerequisites": ["structure ... : Prop in Lean 4", "HasChromaticNumber", "Ordinal.IsLimit in Mathlib"]
+    "relatedConcepts": [
+      "CounterexampleGraph structure",
+      "LimitCardinalEHSOpen",
+      "Prop-valued structures",
+      "Ordinal.IsLimit",
+      "counterexample_implies_failure"
+    ],
+    "prerequisites": [
+      "structure ... : Prop in Lean 4",
+      "HasChromaticNumber",
+      "Ordinal.IsLimit in Mathlib"
+    ]
   },
   {
     "id": "ann-ehs-higher-no-universal",
     "proofId": "erdos-110-oq-03",
-    "range": { "startLine": 191, "endLine": 230 },
+    "range": {
+      "startLine": 191,
+      "endLine": 230
+    },
     "type": "insight",
     "title": "No Universal Bounding Function and Independence of Failures",
     "content": "Part VII proves a strictly stronger result than individual cardinal failures: `no_universal_bound` shows no single F works for ALL ℵ₁-chromatic graphs simultaneously. Only the ℵ₁ counterexample is needed — it already defeats any proposed universal bound. Part VIII shows the failures are independent: `independent_failures α β` (for distinct α ≠ β) shows both ℵ_{α+1} and ℵ_{β+1} fail with their OWN counterexample graphs, not one derived from the other. This rules out easy reductions like 'if it fails at ℵ₁, it trivially fails at ℵ₂ via the same graph'.",
     "mathContext": "$\\neg\\exists F : \\mathbb{N} \\to \\mathbb{N},\\, \\forall G,\\, \\chi(G) \\geq \\aleph_1 \\Rightarrow \\exists N_0,\\, \\forall n \\geq N_0,\\, \\text{HasFiniteNChromaticSubgraph}\\,G\\,n\\,(F\\,n)$. This rules out even a set-indexed family of bounding functions. Proof: take the ℵ₁ counterexample $G$ (with $\\chi(G) \\geq \\aleph_1$), apply hypothetical $F$ to get $N_0$, use $G$'s defeating property to find $n \\geq N_0$ where $F$ fails. The failures at different cardinals are **independent** (not by reduction) because each $\\omega_{\\alpha+1}$ has its own C-sequence structure.",
     "significance": "key",
-    "relatedConcepts": ["no_universal_bound", "independent_failures", "HasChromaticNumberAtLeast", "lambie_hanson_counterexample"],
-    "prerequisites": ["lambie_hanson_counterexample", "HasChromaticNumberAtLeast definition", "Ordinal inequality in Lean 4"]
+    "relatedConcepts": [
+      "no_universal_bound",
+      "independent_failures",
+      "HasChromaticNumberAtLeast",
+      "lambie_hanson_counterexample"
+    ],
+    "prerequisites": [
+      "lambie_hanson_counterexample",
+      "HasChromaticNumberAtLeast definition",
+      "Ordinal inequality in Lean 4"
+    ]
   },
   {
     "id": "ann-ehs-higher-summary",
     "proofId": "erdos-110-oq-03",
-    "range": { "startLine": 235, "endLine": 261 },
+    "range": {
+      "startLine": 235,
+      "endLine": 261
+    },
     "type": "concept",
     "title": "Summary: Complete Negative Answer at All Successor Alephs",
     "content": "`erdos_110_oq_03_summary` packages three results as a conjunction: (1) failure at ℵ₁, (2) failure at all successor alephs ℵ_{α+1}, (3) no universal bounding function. The proof is the trivial ⟨..., ..., ...⟩ constructor applied to the three already-proved theorems. These three results form a hierarchy: (3) ⟹ (1) and (2) ⟹ (1). Together with `independent_failures`, the file gives a complete picture of successor cardinal behavior — comprehensive failure — while marking limit cardinals (ℵ_ω, ℵ_{ω₁}, ...) as the genuine open frontier.",
     "mathContext": "The three conjuncts are logically independent statements of increasing generality. (1) says $\\kappa = \\aleph_1$ fails; (2) says every $\\kappa = \\aleph_{\\alpha+1}$ fails; (3) says no $F$ works for all $\\aleph_1$-chromatic graphs. Note (2) strictly extends (1): it gives uncountably many independent failures. And (3) is not implied by (2): (2) is about individual $\\kappa$-chromatic graphs, while (3) is about all $\\geq \\aleph_1$-chromatic graphs simultaneously. This triple provides maximum coverage of what is currently provable, clearly delineating the unknown territory (limit cardinals).",
     "significance": "supporting",
-    "relatedConcepts": ["erdos_110_oq_03_summary", "generalized_ehs_fails_aleph1", "generalized_ehs_fails_all_successor_alephs", "no_universal_bound", "LimitCardinalEHSOpen"],
-    "prerequisites": ["generalized_ehs_fails_aleph1", "generalized_ehs_fails_all_successor_alephs", "no_universal_bound"]
+    "relatedConcepts": [
+      "erdos_110_oq_03_summary",
+      "generalized_ehs_fails_aleph1",
+      "generalized_ehs_fails_all_successor_alephs",
+      "no_universal_bound",
+      "LimitCardinalEHSOpen"
+    ],
+    "prerequisites": [
+      "generalized_ehs_fails_aleph1",
+      "generalized_ehs_fails_all_successor_alephs",
+      "no_universal_bound"
+    ]
   }
 ]


### PR DESCRIPTION
Fix invalid annotation type/significance values in erdos-110-oq-03:
- ann-ehs-higher-header: type context→concept, significance context→supporting
- ann-ehs-higher-successor-axiom: type technique→theorem

Build passes ✓