### PR TITLE
Enrich amgm-inequality-oq-02: fix annotation schema violations

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-02/annotations.json
@@ -6,10 +6,10 @@
       "startLine": 1,
       "endLine": 34
     },
-    "type": "context",
+    "type": "concept",
     "title": "Maclaurin's Chain: AM-GM Refined by Elementary Symmetric Polynomials",
-    "content": "The module establishes the Maclaurin inequality chain M\u2081 \u2265 M\u2082 \u2265 \u22ef \u2265 M\u2099 for non-negative reals, where M\u2096 = (e\u2096/C(n,k))^(1/k) and e\u2096 is the k-th elementary symmetric polynomial. The endpoints are M\u2081 = AM (arithmetic mean) and M\u2099 = GM (geometric mean), so AM \u2265 GM is the coarsest case of this chain. The key proof engine is Newton's log-concavity: (e\u2096/C(n,k))\u00b2 \u2265 (e\u2096\u208b\u2081/C(n,k-1)) \u00b7 (e\u2096\u208a\u2081/C(n,k+1)), which implies the Maclaurin step M\u2096 \u2265 M\u2096\u208a\u2081. The formalization proves 13 results fully and axiomatizes 2 deep classical results (Newton log-concavity and the Maclaurin step).",
-    "mathContext": "For non-negative reals $x_1,\\ldots,x_n$: $e_k = \\sum_{|S|=k} \\prod_{i\\in S} x_i$, $M_k = (e_k/\\binom{n}{k})^{1/k}$. Chain: $M_1 \\geq M_2 \\geq \\cdots \\geq M_n$. Special cases: $M_1 = \\frac{\\sum x_i}{n}$ (AM), $M_n = (\\prod x_i)^{1/n}$ (GM). Newton's engine: $(e_k/\\binom{n}{k})^2 \\geq (e_{k-1}/\\binom{n}{k-1})(e_{k+1}/\\binom{n}{k+1})$ \u2014 log-concavity of the normalized sequence.",
+    "content": "The module establishes the Maclaurin inequality chain M₁ ≥ M₂ ≥ ⋯ ≥ Mₙ for non-negative reals, where Mₖ = (eₖ/C(n,k))^(1/k) and eₖ is the k-th elementary symmetric polynomial. The endpoints are M₁ = AM (arithmetic mean) and Mₙ = GM (geometric mean), so AM ≥ GM is the coarsest case of this chain. The key proof engine is Newton's log-concavity: (eₖ/C(n,k))² ≥ (eₖ₋₁/C(n,k-1)) · (eₖ₊₁/C(n,k+1)), which implies the Maclaurin step Mₖ ≥ Mₖ₊₁. The formalization proves 13 results fully and axiomatizes 2 deep classical results (Newton log-concavity and the Maclaurin step).",
+    "mathContext": "For non-negative reals $x_1,\\ldots,x_n$: $e_k = \\sum_{|S|=k} \\prod_{i\\in S} x_i$, $M_k = (e_k/\\binom{n}{k})^{1/k}$. Chain: $M_1 \\geq M_2 \\geq \\cdots \\geq M_n$. Special cases: $M_1 = \\frac{\\sum x_i}{n}$ (AM), $M_n = (\\prod x_i)^{1/n}$ (GM). Newton's engine: $(e_k/\\binom{n}{k})^2 \\geq (e_{k-1}/\\binom{n}{k-1})(e_{k+1}/\\binom{n}{k+1})$ — log-concavity of the normalized sequence.",
     "significance": "supporting",
     "relatedConcepts": [
       "Maclaurin's inequality",
@@ -31,7 +31,7 @@
       "startLine": 36,
       "endLine": 43
     },
-    "type": "context",
+    "type": "concept",
     "title": "Import and Part I: Foundation Setup",
     "content": "The single `import Mathlib` loads the entire Mathlib library, giving access to `Finset.powersetCard` (for symmetric polynomial definition), `Real.rpow` (for fractional powers in Maclaurin means), `Real.geom_mean_le_arith_mean_weighted` (for AM-GM), and `sq_nonneg` (for sum-of-squares arguments). The `open Finset Real` declaration brings Finset operations (sum, prod, powersetCard, univ) and real analysis functions (sqrt, rpow) into scope without qualification. Part I begins the formal development with elementary symmetric polynomial definitions.",
     "mathContext": "Mathlib provides the complete real analysis and combinatorics foundation. Key dependencies: `Finset.powersetCard k` (the set of $k$-element subsets), `Real.rpow` ($x^r$ for real $r$), `Real.geom_mean_le_arith_mean_weighted` (weighted AM-GM), and `sq_nonneg` ($x^2 \\geq 0$).",
@@ -54,8 +54,8 @@
     },
     "type": "definition",
     "title": "Elementary Symmetric Polynomials via Finset.powersetCard",
-    "content": "The elemSymm function defines the k-th elementary symmetric polynomial using Finset.powersetCard: e\u2096(x) = \u2211_{S \u2208 univ.powersetCard k} \u220f_{i \u2208 S} x\u1d62. This sums over all k-element subsets of {0,...,n-1}. Three immediate properties: elemSymm_zero (e\u2080 = 1, from the fact that powersetCard 0 has a single element \u2014 the empty set \u2014 with empty product = 1), elemSymm_one (e\u2081 = \u2211 x\u1d62, from powersetCard_one giving singletons), and elemSymm_nonneg (e\u2096 \u2265 0 for non-negative inputs, from Finset.sum_nonneg and Finset.prod_nonneg).",
-    "mathContext": "$e_k(x_1,\\ldots,x_n) = \\sum_{\\{i_1,\\ldots,i_k\\} \\subseteq \\{1,\\ldots,n\\}} x_{i_1}\\cdots x_{i_k}$. Base cases: $e_0 = 1$ (empty product over the empty set), $e_1 = x_1 + \\cdots + x_n$, $e_2 = \\sum_{i<j} x_i x_j$. Lean: `elemSymm k x = \u2211 s \u2208 (univ : Finset (Fin n)).powersetCard k, \u220f i \u2208 s, x i`. The `powersetCard` API replaces the older `powerset_len`.",
+    "content": "The elemSymm function defines the k-th elementary symmetric polynomial using Finset.powersetCard: eₖ(x) = ∑_{S ∈ univ.powersetCard k} ∏_{i ∈ S} xᵢ. This sums over all k-element subsets of {0,...,n-1}. Three immediate properties: elemSymm_zero (e₀ = 1, from the fact that powersetCard 0 has a single element — the empty set — with empty product = 1), elemSymm_one (e₁ = ∑ xᵢ, from powersetCard_one giving singletons), and elemSymm_nonneg (eₖ ≥ 0 for non-negative inputs, from Finset.sum_nonneg and Finset.prod_nonneg).",
+    "mathContext": "$e_k(x_1,\\ldots,x_n) = \\sum_{\\{i_1,\\ldots,i_k\\} \\subseteq \\{1,\\ldots,n\\}} x_{i_1}\\cdots x_{i_k}$. Base cases: $e_0 = 1$ (empty product over the empty set), $e_1 = x_1 + \\cdots + x_n$, $e_2 = \\sum_{i<j} x_i x_j$. Lean: `elemSymm k x = ∑ s ∈ (univ : Finset (Fin n)).powersetCard k, ∏ i ∈ s, x i`. The `powersetCard` API replaces the older `powerset_len`.",
     "significance": "key",
     "relatedConcepts": [
       "Finset.powersetCard",
@@ -78,9 +78,9 @@
       "startLine": 66,
       "endLine": 92
     },
-    "type": "technique",
-    "title": "M\u2081\u00b2 \u2265 M\u2082 for n=2,3,4: Sum-of-Squares Certificates",
-    "content": "Three small-case proofs establish M\u2081\u00b2 \u2265 M\u2082 by explicit sum-of-squares certificates. For n=2: (a+b)/2 \u2265 \u221a(ab) is proved by showing (\u221aa - \u221ab)\u00b2 \u2265 0, expanding via sq_sqrt, then using linarith. For n=3: (a+b+c)\u00b2 \u2265 3(ab+bc+ca) follows from (a-b)\u00b2 + (b-c)\u00b2 + (c-a)\u00b2 \u2265 0 \u2014 nlinarith closes the goal with sq_nonneg hints. For n=4: nlinarith handles (a+b+c+d)\u00b2 \u2265 (4/3)(ab+ac+ad+bc+bd+cd) with all 6 pairwise sq_nonneg hints. These concrete cases illustrate the sum-of-squares principle that underlies the general Cauchy-Schwarz proof.",
+    "type": "theorem",
+    "title": "M₁² ≥ M₂ for n=2,3,4: Sum-of-Squares Certificates",
+    "content": "Three small-case proofs establish M₁² ≥ M₂ by explicit sum-of-squares certificates. For n=2: (a+b)/2 ≥ √(ab) is proved by showing (√a - √b)² ≥ 0, expanding via sq_sqrt, then using linarith. For n=3: (a+b+c)² ≥ 3(ab+bc+ca) follows from (a-b)² + (b-c)² + (c-a)² ≥ 0 — nlinarith closes the goal with sq_nonneg hints. For n=4: nlinarith handles (a+b+c+d)² ≥ (4/3)(ab+ac+ad+bc+bd+cd) with all 6 pairwise sq_nonneg hints. These concrete cases illustrate the sum-of-squares principle that underlies the general Cauchy-Schwarz proof.",
     "mathContext": "n=2: $(\\sqrt{a}-\\sqrt{b})^2 \\geq 0 \\Rightarrow a + b \\geq 2\\sqrt{ab} \\Rightarrow (a+b)/2 \\geq \\sqrt{ab}$. n=3: $(a-b)^2+(b-c)^2+(c-a)^2 = 2(a^2+b^2+c^2-ab-bc-ca) \\geq 0 \\Rightarrow (a+b+c)^2 \\geq 3(ab+bc+ca)$. n=4: same with $\\binom{4}{2}=6$ pairs. General pattern: $(\\sum x_i)^2 = \\sum x_i^2 + 2e_2$ and $n\\cdot\\sum x_i^2 \\geq (\\sum x_i)^2$ (Cauchy-Schwarz) gives $\\binom{n}{2}(\\sum x_i)^2 \\geq n^2 e_2$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -103,10 +103,10 @@
       "startLine": 94,
       "endLine": 110
     },
-    "type": "technique",
-    "title": "Cauchy-Schwarz via Double Sum: n\u00b7\u2211x\u1d62\u00b2 \u2265 (\u2211x\u1d62)\u00b2",
-    "content": "The private lemma cauchy_schwarz_sum proves n\u00b7\u2211x\u1d62\u00b2 \u2265 (\u2211x\u1d62)\u00b2 for general n via the double-sum identity \u2211\u1d62\u2211\u2c7c(x\u1d62-x\u2c7c)\u00b2 = 2(n\u00b7\u2211x\u1d62\u00b2 - (\u2211x\u1d62)\u00b2) \u2265 0. The proof expands (x\u1d62-x\u2c7c)\u00b2 = x\u1d62\u00b2 - 2x\u1d62x\u2c7c + x\u2c7c\u00b2, applies simp_rw to push through the sum, and uses three auxiliary facts: h1 (\u2211\u1d62\u2211\u2c7c x\u1d62\u00b2 = n\u00b7\u2211x\u1d62\u00b2), h2 (\u2211\u1d62\u2211\u2c7c x\u2c7c\u00b2 = n\u00b7\u2211x\u2c7c\u00b2), h3 (\u2211\u1d62\u2211\u2c7c 2x\u1d62x\u2c7c = 2(\u2211x\u1d62)\u00b2). Combined with ring and linarith, this establishes the bound without any positivity hypotheses on x.",
-    "mathContext": "$\\sum_i\\sum_j (x_i-x_j)^2 = n\\sum_i x_i^2 + n\\sum_j x_j^2 - 2\\sum_i x_i \\cdot \\sum_j x_j = 2(n\\sum x_i^2 - (\\sum x_i)^2) \\geq 0$. Lean proof: `h3 : \u2211 i j, 2*x i*x j = 2*(\u2211 i, x i)^2` via `rw [sq, sum_mul]; simp_rw [mul_sum]`. This Cauchy-Schwarz is weaker than the general inner product form but suffices for the Maclaurin M\u2081\u00b2\u2265M\u2082 inequality.",
+    "type": "lemma",
+    "title": "Cauchy-Schwarz via Double Sum: n·∑xᵢ² ≥ (∑xᵢ)²",
+    "content": "The private lemma cauchy_schwarz_sum proves n·∑xᵢ² ≥ (∑xᵢ)² for general n via the double-sum identity ∑ᵢ∑ⱼ(xᵢ-xⱼ)² = 2(n·∑xᵢ² - (∑xᵢ)²) ≥ 0. The proof expands (xᵢ-xⱼ)² = xᵢ² - 2xᵢxⱼ + xⱼ², applies simp_rw to push through the sum, and uses three auxiliary facts: h1 (∑ᵢ∑ⱼ xᵢ² = n·∑xᵢ²), h2 (∑ᵢ∑ⱼ xⱼ² = n·∑xⱼ²), h3 (∑ᵢ∑ⱼ 2xᵢxⱼ = 2(∑xᵢ)²). Combined with ring and linarith, this establishes the bound without any positivity hypotheses on x.",
+    "mathContext": "$\\sum_i\\sum_j (x_i-x_j)^2 = n\\sum_i x_i^2 + n\\sum_j x_j^2 - 2\\sum_i x_i \\cdot \\sum_j x_j = 2(n\\sum x_i^2 - (\\sum x_i)^2) \\geq 0$. Lean proof: `h3 : ∑ i j, 2*x i*x j = 2*(∑ i, x i)^2` via `rw [sq, sum_mul]; simp_rw [mul_sum]`. This Cauchy-Schwarz is weaker than the general inner product form but suffices for the Maclaurin M₁²≥M₂ inequality.",
     "significance": "key",
     "relatedConcepts": [
       "Cauchy-Schwarz inequality",
@@ -130,9 +130,9 @@
       "startLine": 203,
       "endLine": 271
     },
-    "type": "technique",
-    "title": "General M\u2081\u00b2 \u2265 M\u2082: Binomial Identity + Cauchy-Schwarz",
-    "content": "This section contains two key results. First, sq_sum_eq_sum_sq_add_two_elemSymm (lines 205-224) proves the binomial identity (\u2211x\u1d62)\u00b2 = \u2211x\u1d62\u00b2 + 2\u00b7e\u2082 by induction on n using the e\u2082 recurrence from Part II. Base case (n=0): e\u2082 vanishes because no 2-element subsets exist in Fin 0 (proved by omega on cardinality). Inductive step: Fin.sum_univ_castSucc splits the sum, elemSymm_two_succ decomposes e\u2082, and nlinarith closes the goal with sq_nonneg hints.\n\nSecond, maclaurin_sq_m1_ge_m2_general (lines 226-271) proves C(n,2)\u00b7(\u2211x\u1d62)\u00b2 \u2265 n\u00b2\u00b7e\u2082 for ALL reals (no non-negativity needed) using: (1) Cauchy-Schwarz (h_cs: n\u00b7\u2211x\u1d62\u00b2 \u2265 (\u2211x\u1d62)\u00b2); (2) the binomial identity from sq_sum_eq_sum_sq_add_two_elemSymm; (3) Pascal identity (h_2cn2: 2\u00b7C(n,2) = n\u00b7(n-1), proved by induction via Nat.choose_succ_succ). The algebraic chain: 2\u00b7(C\u00b7S\u2081\u00b2 - n\u00b2\u00b7e\u2082) = n\u00b7(n\u00b7S\u2082 - S\u2081\u00b2) \u2265 0 follows from Cauchy-Schwarz, closed by nlinarith.",
+    "type": "theorem",
+    "title": "General M₁² ≥ M₂: Binomial Identity + Cauchy-Schwarz",
+    "content": "This section contains two key results. First, sq_sum_eq_sum_sq_add_two_elemSymm (lines 205-224) proves the binomial identity (∑xᵢ)² = ∑xᵢ² + 2·e₂ by induction on n using the e₂ recurrence from Part II. Base case (n=0): e₂ vanishes because no 2-element subsets exist in Fin 0 (proved by omega on cardinality). Inductive step: Fin.sum_univ_castSucc splits the sum, elemSymm_two_succ decomposes e₂, and nlinarith closes the goal with sq_nonneg hints.\n\nSecond, maclaurin_sq_m1_ge_m2_general (lines 226-271) proves C(n,2)·(∑xᵢ)² ≥ n²·e₂ for ALL reals (no non-negativity needed) using: (1) Cauchy-Schwarz (h_cs: n·∑xᵢ² ≥ (∑xᵢ)²); (2) the binomial identity from sq_sum_eq_sum_sq_add_two_elemSymm; (3) Pascal identity (h_2cn2: 2·C(n,2) = n·(n-1), proved by induction via Nat.choose_succ_succ). The algebraic chain: 2·(C·S₁² - n²·e₂) = n·(n·S₂ - S₁²) ≥ 0 follows from Cauchy-Schwarz, closed by nlinarith.",
     "mathContext": "$(\\sum_{i=1}^n x_i)^2 = \\sum_{i=1}^n x_i^2 + 2\\sum_{i<j} x_ix_j = \\sum_{i=1}^n x_i^2 + 2e_2$. Inductive proof: $(\\sum_{i=1}^{n+1} x_i)^2 = (\\sum_{i=1}^n x_i + x_{n+1})^2 = (\\sum_{i=1}^n x_i)^2 + 2x_{n+1}\\sum_{i=1}^n x_i + x_{n+1}^2 = (\\sum x_i^2 + 2e_2(x_1,\\ldots,x_n)) + 2x_{n+1}\\cdot e_1 + x_{n+1}^2$ $= \\sum_{i=1}^{n+1} x_i^2 + 2(e_2 + x_{n+1}\\cdot e_1) = \\sum_{i=1}^{n+1} x_i^2 + 2e_2(x_1,\\ldots,x_{n+1})$ using the recurrence $e_2(\\text{succ}) = e_2 + x_{n+1}\\cdot e_1$.",
     "significance": "key",
     "relatedConcepts": [
@@ -157,16 +157,16 @@
       "startLine": 273,
       "endLine": 276
     },
-    "type": "context",
-    "title": "Part III: Newton's Log-Concavity \u2014 The Deep Engine",
-    "content": "Part III introduces the deep classical machinery that powers the full Maclaurin chain. Newton's log-concavity of the normalized elementary symmetric sequence is a result from the late 17th century, first appearing in Newton's Arithmetica Universalis (published 1707, based on c. 1683-1684 lectures). The standard modern proof uses polarization (replacing one variable at a time by the arithmetic mean) and induction on n, as systematized by Hardy, Littlewood, and P\u00f3lya in Inequalities (1934, \u00a72.22). This result is currently axiomatized because the polarization technique, while elementary, requires significant Lean infrastructure for multivariate function manipulation that Mathlib does not yet provide. The Maclaurin step M\u2096 \u2265 M\u2096\u208a\u2081 follows from Newton log-concavity via monotonicity of the function t^(1/k).",
+    "type": "concept",
+    "title": "Part III: Newton's Log-Concavity — The Deep Engine",
+    "content": "Part III introduces the deep classical machinery that powers the full Maclaurin chain. Newton's log-concavity of the normalized elementary symmetric sequence is a result from the late 17th century, first appearing in Newton's Arithmetica Universalis (published 1707, based on c. 1683-1684 lectures). The standard modern proof uses polarization (replacing one variable at a time by the arithmetic mean) and induction on n, as systematized by Hardy, Littlewood, and Pólya in Inequalities (1934, §2.22). This result is currently axiomatized because the polarization technique, while elementary, requires significant Lean infrastructure for multivariate function manipulation that Mathlib does not yet provide. The Maclaurin step Mₖ ≥ Mₖ₊₁ follows from Newton log-concavity via monotonicity of the function t^(1/k).",
     "mathContext": "Newton's log-concavity: $(e_k/\\binom{n}{k})^2 \\geq (e_{k-1}/\\binom{n}{k-1})(e_{k+1}/\\binom{n}{k+1})$. Equivalently, the sequence $a_k = e_k/\\binom{n}{k}$ is log-concave: $a_k^2 \\geq a_{k-1} a_{k+1}$. This implies $a_k^{1/k}$ is decreasing, giving the Maclaurin chain.",
     "significance": "supporting",
     "relatedConcepts": [
       "Newton's inequalities",
       "log-concavity",
       "polarization",
-      "Hardy-Littlewood-P\u00f3lya"
+      "Hardy-Littlewood-Pólya"
     ],
     "prerequisites": [
       "elementary symmetric polynomials",
@@ -182,15 +182,15 @@
     },
     "type": "insight",
     "title": "Newton Log-Concavity and Maclaurin Means: The Axiom Engine",
-    "content": "The newton_log_concavity axiom states (e\u2096/C(n,k))\u00b2 \u2265 (e\u2096\u208b\u2081/C(n,k-1)) \u00b7 (e\u2096\u208a\u2081/C(n,k+1)) for non-negative inputs \u2014 log-concavity of the normalized elementary symmetric sequence. The proof strategy is polarization + induction on n (Hardy-Littlewood-P\u00f3lya \u00a72.22), currently not in Mathlib. The maclaurin_step axiom states M\u2096 \u2265 M\u2096\u208a\u2081 for consecutive Maclaurin means (following from Newton by monotonicity of t^(1/k)). The maclaurinMean definition uses Real.rpow for the (1/k) power: M\u2096 = (e\u2096/C(n,k))^(1/k), which is noncomputable. maclaurinMean_nonneg (fully proved) uses rpow_nonneg + elemSymm_nonneg.",
-    "mathContext": "Newton's inequality: $(e_k/\\binom{n}{k})^2 \\geq (e_{k-1}/\\binom{n}{k-1})(e_{k+1}/\\binom{n}{k+1})$ for $1 \\leq k < n$ and $x_i \\geq 0$. Classical proof: 1-variable case trivial; inductive step uses $e_k(x_1,\\ldots,x_n) = e_k(x_1,\\ldots,x_{n-1}) + x_n e_{k-1}(x_1,\\ldots,x_{n-1})$ and Cauchy-Schwarz (polarization). From log-concavity: $(e_k/\\binom{n}{k})^{1/k} \\geq (e_{k+1}/\\binom{n}{k+1})^{1/(k+1)}$ \u2014 i.e., $M_k \\geq M_{k+1}$.",
+    "content": "The newton_log_concavity axiom states (eₖ/C(n,k))² ≥ (eₖ₋₁/C(n,k-1)) · (eₖ₊₁/C(n,k+1)) for non-negative inputs — log-concavity of the normalized elementary symmetric sequence. The proof strategy is polarization + induction on n (Hardy-Littlewood-Pólya §2.22), currently not in Mathlib. The maclaurin_step axiom states Mₖ ≥ Mₖ₊₁ for consecutive Maclaurin means (following from Newton by monotonicity of t^(1/k)). The maclaurinMean definition uses Real.rpow for the (1/k) power: Mₖ = (eₖ/C(n,k))^(1/k), which is noncomputable. maclaurinMean_nonneg (fully proved) uses rpow_nonneg + elemSymm_nonneg.",
+    "mathContext": "Newton's inequality: $(e_k/\\binom{n}{k})^2 \\geq (e_{k-1}/\\binom{n}{k-1})(e_{k+1}/\\binom{n}{k+1})$ for $1 \\leq k < n$ and $x_i \\geq 0$. Classical proof: 1-variable case trivial; inductive step uses $e_k(x_1,\\ldots,x_n) = e_k(x_1,\\ldots,x_{n-1}) + x_n e_{k-1}(x_1,\\ldots,x_{n-1})$ and Cauchy-Schwarz (polarization). From log-concavity: $(e_k/\\binom{n}{k})^{1/k} \\geq (e_{k+1}/\\binom{n}{k+1})^{1/(k+1)}$ — i.e., $M_k \\geq M_{k+1}$.",
     "significance": "key",
     "relatedConcepts": [
       "Newton's inequalities",
       "log-concavity",
       "Real.rpow",
       "polarization inequality",
-      "Hardy-Littlewood-P\u00f3lya"
+      "Hardy-Littlewood-Pólya"
     ],
     "prerequisites": [
       "axiom",
@@ -207,9 +207,9 @@
       "startLine": 315,
       "endLine": 330
     },
-    "type": "technique",
+    "type": "theorem",
     "title": "AM-GM from Mathlib's Weighted Mean Inequality",
-    "content": "amgm_from_maclaurin derives the standard AM-GM inequality \u220f x\u1d62^(1/n) \u2264 (\u2211 x\u1d62)/n from Mathlib's Real.geom_mean_le_arith_mean_weighted with uniform weights 1/n. The proof establishes three prerequisites: hw (each weight 1/n \u2265 0, by positivity), hw' (weights sum to 1, by mul_one_div_cancel), and applies the weighted AM-GM to get \u220f x\u1d62^(1/n) \u2264 \u2211 (1/n)\u00b7x\u1d62 = (\u2211 x\u1d62)/n. The final calc block combines key and a ring simplification using mul_sum.",
+    "content": "amgm_from_maclaurin derives the standard AM-GM inequality ∏ xᵢ^(1/n) ≤ (∑ xᵢ)/n from Mathlib's Real.geom_mean_le_arith_mean_weighted with uniform weights 1/n. The proof establishes three prerequisites: hw (each weight 1/n ≥ 0, by positivity), hw' (weights sum to 1, by mul_one_div_cancel), and applies the weighted AM-GM to get ∏ xᵢ^(1/n) ≤ ∑ (1/n)·xᵢ = (∑ xᵢ)/n. The final calc block combines key and a ring simplification using mul_sum.",
     "mathContext": "Mathlib's weighted AM-GM: $\\prod_{i} z_i^{w_i} \\leq \\sum_i w_i z_i$ when $w_i \\geq 0$, $\\sum w_i = 1$. With $w_i = 1/n$: $\\prod x_i^{1/n} \\leq \\sum (1/n)x_i = (\\sum x_i)/n$. This corresponds to $M_n \\leq M_1$ in Maclaurin notation, the coarsest inequality in the chain. The `positivity` tactic closes $0 \\leq 1/n$ automatically.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -232,10 +232,10 @@
       "startLine": 366,
       "endLine": 391
     },
-    "type": "technique",
+    "type": "theorem",
     "title": "Maclaurin Chain by Induction on the Gap k-j",
-    "content": "maclaurin_chain proves M\u2c7c \u2265 M\u2096 for 0 < j \u2264 k \u2264 n by induction on d = k - j. The proof uses `obtain \u27e8d, rfl\u27e9 := Nat.exists_eq_add_of_le hjk` to write k = j + d, then inducts on d. Base case d=0: M\u2c7c \u2265 M\u2c7c (le_rfl). Inductive step: M\u2c7c \u2265 M\u2c7c\u208a\u2091 (by ih) and M\u2c7c\u208a\u2091 \u2265 M\u2c7c\u208a\u2091\u208a\u2081 (by maclaurin_step), giving M\u2c7c \u2265 M\u2c7c\u208a\u2091\u208a\u2081 via a calc block. The theorem maclaurin_m1_ge_mn (M\u2081 \u2265 M\u2099, i.e., AM \u2265 GM in Maclaurin language) is then a one-line corollary: `maclaurin_chain 1 n (by omega) (by omega) le_rfl x hx`.",
-    "mathContext": "Induction on gap: to prove $M_j \\geq M_k$ for $k = j+d$, apply $M_j \\geq M_{j+e}$ (IH) and $M_{j+e} \\geq M_{j+e+1}$ (step). The step axiom `maclaurin_step` gives $M_k \\geq M_{k+1}$ for any $0 < k < n$. Therefore $M_1 \\geq M_2 \\geq \\cdots \\geq M_n$ by transitivity. Special case: $M_1 = \\text{AM} \\geq M_n = \\text{GM}$, recovering AM-GM. The calc block in Lean: `maclaurinMean j x \u2265 maclaurinMean (j+e) x := hih` then `_ \u2265 maclaurinMean (j+e+1) x := hstep`.",
+    "content": "maclaurin_chain proves Mⱼ ≥ Mₖ for 0 < j ≤ k ≤ n by induction on d = k - j. The proof uses `obtain ⟨d, rfl⟩ := Nat.exists_eq_add_of_le hjk` to write k = j + d, then inducts on d. Base case d=0: Mⱼ ≥ Mⱼ (le_rfl). Inductive step: Mⱼ ≥ Mⱼ₊ₑ (by ih) and Mⱼ₊ₑ ≥ Mⱼ₊ₑ₊₁ (by maclaurin_step), giving Mⱼ ≥ Mⱼ₊ₑ₊₁ via a calc block. The theorem maclaurin_m1_ge_mn (M₁ ≥ Mₙ, i.e., AM ≥ GM in Maclaurin language) is then a one-line corollary: `maclaurin_chain 1 n (by omega) (by omega) le_rfl x hx`.",
+    "mathContext": "Induction on gap: to prove $M_j \\geq M_k$ for $k = j+d$, apply $M_j \\geq M_{j+e}$ (IH) and $M_{j+e} \\geq M_{j+e+1}$ (step). The step axiom `maclaurin_step` gives $M_k \\geq M_{k+1}$ for any $0 < k < n$. Therefore $M_1 \\geq M_2 \\geq \\cdots \\geq M_n$ by transitivity. Special case: $M_1 = \\text{AM} \\geq M_n = \\text{GM}$, recovering AM-GM. The calc block in Lean: `maclaurinMean j x ≥ maclaurinMean (j+e) x := hih` then `_ ≥ maclaurinMean (j+e+1) x := hstep`.",
     "significance": "key",
     "relatedConcepts": [
       "maclaurin_step axiom",
@@ -258,9 +258,9 @@
       "startLine": 62,
       "endLine": 65
     },
-    "type": "context",
-    "title": "Part II: Small-Case M\u2081 \u2265 M\u2082 via Sum-of-Squares",
-    "content": "Part II transitions from the symmetric polynomial infrastructure of Part I to concrete proofs of M\u2081\u00b2 \u2265 M\u2082 for small n. The approach is direct: for each small n, the inequality reduces to a sum-of-squares identity that nlinarith can verify automatically. These concrete cases motivate the general Cauchy-Schwarz proof that follows and illustrate the pattern: the number of squared-difference witnesses equals C(n,2), matching the normalization factor in M\u2082.",
+    "type": "concept",
+    "title": "Part II: Small-Case M₁ ≥ M₂ via Sum-of-Squares",
+    "content": "Part II transitions from the symmetric polynomial infrastructure of Part I to concrete proofs of M₁² ≥ M₂ for small n. The approach is direct: for each small n, the inequality reduces to a sum-of-squares identity that nlinarith can verify automatically. These concrete cases motivate the general Cauchy-Schwarz proof that follows and illustrate the pattern: the number of squared-difference witnesses equals C(n,2), matching the normalization factor in M₂.",
     "mathContext": "For $n = 2,3,4$: $M_1^2 \\geq M_2$ reduces to $(\\sum x_i)^2/n^2 \\geq e_2/\\binom{n}{2}$, which is equivalent to $\\binom{n}{2}(\\sum x_i)^2 \\geq n^2 e_2$. Each case has a sum-of-squares certificate with $\\binom{n}{2}$ terms.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -279,9 +279,9 @@
       "startLine": 112,
       "endLine": 118
     },
-    "type": "context",
+    "type": "concept",
     "title": "Binomial Identity Infrastructure: Setup for Inductive Proof",
-    "content": "This section introduces the private infrastructure for proving the key binomial identity (\u2211x\u1d62)\u00b2 = \u2211x\u1d62\u00b2 + 2\u00b7e\u2082 by induction on n. The identity is central to the general M\u2081\u00b2 \u2265 M\u2082 proof: combined with Cauchy-Schwarz, it yields C(n,2)\u00b7(\u2211x\u1d62)\u00b2 \u2265 n\u00b2\u00b7e\u2082 without any non-negativity assumptions. The inductive approach requires a custom castSucc embedding (csEmb) to work around API naming issues in Docker Lean 4.26.0, and a decomposition of Fin (n+1) into {0,...,n-1} \u222a {n} for splitting the elementary symmetric polynomial sum.",
+    "content": "This section introduces the private infrastructure for proving the key binomial identity (∑xᵢ)² = ∑xᵢ² + 2·e₂ by induction on n. The identity is central to the general M₁² ≥ M₂ proof: combined with Cauchy-Schwarz, it yields C(n,2)·(∑xᵢ)² ≥ n²·e₂ without any non-negativity assumptions. The inductive approach requires a custom castSucc embedding (csEmb) to work around API naming issues in Docker Lean 4.26.0, and a decomposition of Fin (n+1) into {0,...,n-1} ∪ {n} for splitting the elementary symmetric polynomial sum.",
     "mathContext": "The identity $(\\sum_{i=1}^n x_i)^2 = \\sum_{i=1}^n x_i^2 + 2e_2(x_1,\\ldots,x_n)$ is the $k=2$ case of Newton's identity $p_k - e_1 p_{k-1} + \\cdots = (-1)^{k+1} k e_k$. For $k=2$: $p_2 = e_1^2 - 2e_2$, i.e., $\\sum x_i^2 = (\\sum x_i)^2 - 2e_2$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -304,8 +304,8 @@
       "endLine": 202
     },
     "type": "definition",
-    "title": "Inductive Infrastructure: castSucc Embedding and e\u2082 Recurrence",
-    "content": "The private infrastructure for the inductive binomial identity proof centers on a custom embedding csEmb : Fin n \u21aa Fin (n+1) wrapping Fin.castSucc (line 119), needed to work around API naming issues in Docker Lean 4.26.0. The key lemma fin_univ_insert_last (line 128) decomposes (univ : Finset (Fin (n+1))) as insert (Fin.last n) (univ.map (csEmb n)) \u2014 splitting {0,...,n} into {n} \u222a {0,...,n-1}. This decomposition enables elemSymm_two_succ (line 161), the fundamental recurrence: e\u2082(x\u2080,...,x\u2099) = e\u2082(x\u2080,...,x\u2099\u208b\u2081) + x\u2099 \u00b7 e\u2081(x\u2080,...,x\u2099\u208b\u2081). The proof uses Finset.powersetCard_succ_insert to split 2-element subsets of {0,...,n} into those not containing n and those containing n, with disjointness via pc_disj (line 141). The infrastructure block concludes with the insert injectivity argument (line 174) that validates the sum decomposition.",
+    "title": "Inductive Infrastructure: castSucc Embedding and e₂ Recurrence",
+    "content": "The private infrastructure for the inductive binomial identity proof centers on a custom embedding csEmb : Fin n ↪ Fin (n+1) wrapping Fin.castSucc (line 119), needed to work around API naming issues in Docker Lean 4.26.0. The key lemma fin_univ_insert_last (line 128) decomposes (univ : Finset (Fin (n+1))) as insert (Fin.last n) (univ.map (csEmb n)) — splitting {0,...,n} into {n} ∪ {0,...,n-1}. This decomposition enables elemSymm_two_succ (line 161), the fundamental recurrence: e₂(x₀,...,xₙ) = e₂(x₀,...,xₙ₋₁) + xₙ · e₁(x₀,...,xₙ₋₁). The proof uses Finset.powersetCard_succ_insert to split 2-element subsets of {0,...,n} into those not containing n and those containing n, with disjointness via pc_disj (line 141). The infrastructure block concludes with the insert injectivity argument (line 174) that validates the sum decomposition.",
     "mathContext": "$e_2(x_0,\\ldots,x_n) = e_2(x_0,\\ldots,x_{n-1}) + x_n \\cdot e_1(x_0,\\ldots,x_{n-1})$. Proof: the 2-element subsets of $\\{0,\\ldots,n\\}$ split into those avoiding $n$ (giving $e_2(x_0,\\ldots,x_{n-1})$) and those containing $n$ (giving $x_n \\cdot \\sum_{i<n} x_i = x_n \\cdot e_1(x_0,\\ldots,x_{n-1})$). General: $e_{k+1}(n+1) = e_{k+1}(n) + x_n \\cdot e_k(n)$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -329,9 +329,9 @@
       "startLine": 393,
       "endLine": 486
     },
-    "type": "technique",
+    "type": "theorem",
     "title": "General Recurrence, Vanishing, and Product Identities",
-    "content": "Part VI (lines 393-397 header) introduces structural theorems for inductive proofs on n and boundary behavior. The private lemma pc_disj_general (lines 401-414) establishes disjointness for the generalized powersetCard decomposition, extending the k=1 case from Part II to arbitrary k \u2014 any subset in the mapped range of castSucc cannot contain Fin.last, proved by the same Fin.castSucc_lt_last argument.\n\nThree structural theorems complete the elementary symmetric polynomial toolkit. elemSymm_succ generalizes the k=1 recurrence to arbitrary k: e\u2096\u208a\u2081(x\u2081,...,x\u2099\u208a\u2081) = e\u2096\u208a\u2081(x\u2081,...,x\u2099) + x\u2099\u208a\u2081\u00b7e\u2096(x\u2081,...,x\u2099). The proof mirrors elemSymm_two_succ with pc_disj_general and an injectivity argument for insert on subsets not containing Fin.last. elemSymm_gt_eq_zero proves e\u2096 = 0 for k > n \u2014 no k-element subsets exist when k > n, so the defining sum is empty. elemSymm_n_eq_prod proves e\u2099(x\u2081,...,x\u2099) = \u220f\u1d62 x\u1d62 \u2014 the unique n-element subset of Fin n is univ itself, shown by Finset.eq_univ_of_card.",
+    "content": "Part VI (lines 393-397 header) introduces structural theorems for inductive proofs on n and boundary behavior. The private lemma pc_disj_general (lines 401-414) establishes disjointness for the generalized powersetCard decomposition, extending the k=1 case from Part II to arbitrary k — any subset in the mapped range of castSucc cannot contain Fin.last, proved by the same Fin.castSucc_lt_last argument.\n\nThree structural theorems complete the elementary symmetric polynomial toolkit. elemSymm_succ generalizes the k=1 recurrence to arbitrary k: eₖ₊₁(x₁,...,xₙ₊₁) = eₖ₊₁(x₁,...,xₙ) + xₙ₊₁·eₖ(x₁,...,xₙ). The proof mirrors elemSymm_two_succ with pc_disj_general and an injectivity argument for insert on subsets not containing Fin.last. elemSymm_gt_eq_zero proves eₖ = 0 for k > n — no k-element subsets exist when k > n, so the defining sum is empty. elemSymm_n_eq_prod proves eₙ(x₁,...,xₙ) = ∏ᵢ xᵢ — the unique n-element subset of Fin n is univ itself, shown by Finset.eq_univ_of_card.",
     "mathContext": "The recurrence $e_{k+1}(x_1,\\ldots,x_{n+1}) = e_{k+1}(x_1,\\ldots,x_n) + x_{n+1} \\cdot e_k(x_1,\\ldots,x_n)$ is the symmetric polynomial analog of Pascal's rule $\\binom{n+1}{k+1} = \\binom{n}{k+1} + \\binom{n}{k}$ (counting $k+1$-element subsets by whether they contain the last element). Boundary: $e_k = 0$ for $k > n$ (no subsets), $e_n = \\prod x_i$ (unique full subset).",
     "significance": "key",
     "relatedConcepts": [
@@ -356,7 +356,7 @@
     },
     "type": "insight",
     "title": "Newton's Inequality at k=1: Proved Without Axioms",
-    "content": "newton_k1 proves the first case of Newton's log-concavity entirely from scratch (no axioms): (e\u2081/C(n,1))\u00b2 \u2265 (e\u2080/C(n,0))\u00b7(e\u2082/C(n,2)), which simplifies to (\u2211x\u1d62/n)\u00b2 \u2265 e\u2082/C(n,2). The proof strategy: (1) simplify e\u2080 = 1, e\u2081 = \u2211x\u1d62, C(n,0) = 1, C(n,1) = n to reduce to (\u2211x\u1d62)\u00b2/n\u00b2 \u2265 e\u2082/C(n,2); (2) rewrite as (C(n,2)\u00b7(\u2211x\u1d62)\u00b2 - n\u00b2\u00b7e\u2082) / (n\u00b2\u00b7C(n,2)) \u2265 0 via field_simp; (3) apply maclaurin_sq_m1_ge_m2_general (the Cauchy-Schwarz result) via linarith for the numerator; (4) positivity (mul_pos, pow_pos) for the denominator. This is the only case of Newton's inequality proved without axioms, suggesting that extending to general k requires substantially different machinery (polarization).",
+    "content": "newton_k1 proves the first case of Newton's log-concavity entirely from scratch (no axioms): (e₁/C(n,1))² ≥ (e₀/C(n,0))·(e₂/C(n,2)), which simplifies to (∑xᵢ/n)² ≥ e₂/C(n,2). The proof strategy: (1) simplify e₀ = 1, e₁ = ∑xᵢ, C(n,0) = 1, C(n,1) = n to reduce to (∑xᵢ)²/n² ≥ e₂/C(n,2); (2) rewrite as (C(n,2)·(∑xᵢ)² - n²·e₂) / (n²·C(n,2)) ≥ 0 via field_simp; (3) apply maclaurin_sq_m1_ge_m2_general (the Cauchy-Schwarz result) via linarith for the numerator; (4) positivity (mul_pos, pow_pos) for the denominator. This is the only case of Newton's inequality proved without axioms, suggesting that extending to general k requires substantially different machinery (polarization).",
     "mathContext": "Newton at $k=1$: $(e_1/n)^2 \\geq e_2/\\binom{n}{2}$, i.e., $\\binom{n}{2}(\\sum x_i)^2 \\geq n^2 e_2$. This holds for ALL reals (not just non-negative), because it follows from $\\binom{n}{2}(\\sum x_i)^2 = \\frac{n(n-1)}{2}(\\sum x_i)^2$ and the Cauchy-Schwarz bound $n\\sum x_i^2 \\geq (\\sum x_i)^2$ combined with $(\\sum x_i)^2 = \\sum x_i^2 + 2e_2$. The general Newton inequality $(e_k/\\binom{n}{k})^2 \\geq (e_{k-1}/\\binom{n}{k-1})(e_{k+1}/\\binom{n}{k+1})$ remains open in Lean for $k \\geq 2$.",
     "significance": "key",
     "relatedConcepts": [
@@ -381,9 +381,9 @@
       "startLine": 336,
       "endLine": 364
     },
-    "type": "technique",
-    "title": "M\u2081\u00b2 \u2265 M\u2082 from Newton's Log-Concavity Axiom",
-    "content": "maclaurin_sq_m1_ge_m2_from_newton provides an alternative proof of C(n,2)\u00b7(\u2211x\u1d62)\u00b2 \u2265 n\u00b2\u00b7e\u2082 for non-negative inputs by directly invoking the newton_log_concavity axiom at k=1. The proof: (1) instantiate Newton at k=1 to get ((\u2211x\u1d62)/n)\u00b2 \u2265 e\u2082/C(n,2); (2) simplify using e\u2080=1, e\u2081=\u2211x\u1d62, C(n,0)=1, C(n,1)=n; (3) cross-multiply both sides by n\u00b2\u00b7C(n,2) > 0 via div_nonneg and field_simp. This contrasts with maclaurin_sq_m1_ge_m2_general, which proves the same inequality axiom-free for ALL reals (not just non-negative) using Cauchy-Schwarz + the binomial identity.",
+    "type": "theorem",
+    "title": "M₁² ≥ M₂ from Newton's Log-Concavity Axiom",
+    "content": "maclaurin_sq_m1_ge_m2_from_newton provides an alternative proof of C(n,2)·(∑xᵢ)² ≥ n²·e₂ for non-negative inputs by directly invoking the newton_log_concavity axiom at k=1. The proof: (1) instantiate Newton at k=1 to get ((∑xᵢ)/n)² ≥ e₂/C(n,2); (2) simplify using e₀=1, e₁=∑xᵢ, C(n,0)=1, C(n,1)=n; (3) cross-multiply both sides by n²·C(n,2) > 0 via div_nonneg and field_simp. This contrasts with maclaurin_sq_m1_ge_m2_general, which proves the same inequality axiom-free for ALL reals (not just non-negative) using Cauchy-Schwarz + the binomial identity.",
     "mathContext": "Newton at $k=1$: $((\\sum x_i)/n)^2 \\geq e_2/\\binom{n}{2}$, cross-multiplied to $\\binom{n}{2}(\\sum x_i)^2 \\geq n^2 e_2$. Requires $x_i \\geq 0$ (via the axiom), unlike the Cauchy-Schwarz proof which works for all reals.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -405,9 +405,9 @@
       "startLine": 513,
       "endLine": 543
     },
-    "type": "context",
+    "type": "concept",
     "title": "Summary: 17 Proved Theorems and 2 Axioms",
-    "content": "A comprehensive listing of all results. The 17 proved theorems span: elementary symmetric polynomial infrastructure (elemSymm_zero, elemSymm_one, elemSymm_nonneg), small-case M\u2081\u00b2\u2265M\u2082 (n=2,3,4 via sum-of-squares), the binomial identity (\u2211x\u1d62)\u00b2=\u2211x\u1d62\u00b2+2e\u2082 by induction, the general M\u2081\u00b2\u2265M\u2082 via Cauchy-Schwarz, Maclaurin mean definitions and non-negativity, AM-GM from Mathlib, the Maclaurin chain M\u2c7c\u2265M\u2096 via induction, and structural theorems (general recurrence, vanishing, product identity, Newton at k=1). The 2 axioms \u2014 newton_log_concavity and maclaurin_step \u2014 encode the deep classical results requiring polarization + induction (Hardy-Littlewood-P\u00f3lya \u00a72.22).",
+    "content": "A comprehensive listing of all results. The 17 proved theorems span: elementary symmetric polynomial infrastructure (elemSymm_zero, elemSymm_one, elemSymm_nonneg), small-case M₁²≥M₂ (n=2,3,4 via sum-of-squares), the binomial identity (∑xᵢ)²=∑xᵢ²+2e₂ by induction, the general M₁²≥M₂ via Cauchy-Schwarz, Maclaurin mean definitions and non-negativity, AM-GM from Mathlib, the Maclaurin chain Mⱼ≥Mₖ via induction, and structural theorems (general recurrence, vanishing, product identity, Newton at k=1). The 2 axioms — newton_log_concavity and maclaurin_step — encode the deep classical results requiring polarization + induction (Hardy-Littlewood-Pólya §2.22).",
     "mathContext": "17 proved results + 2 axioms. Fully proved: $e_k$ definition/properties, $(\\sum x_i)^2 = \\sum x_i^2 + 2e_2$ (inductive), $\\binom{n}{2}(\\sum x_i)^2 \\geq n^2 e_2$ (Cauchy-Schwarz), $M_j \\geq M_k$ for $j \\leq k$ (chain), Newton at $k=1$. Axiomatized: Newton log-concavity for general $k$, Maclaurin step $M_k \\geq M_{k+1}$.",
     "significance": "supporting",
     "relatedConcepts": [


### PR DESCRIPTION
Fix 13 invalid type values: 6 context→concept, 6 technique→theorem, 1 technique→lemma. Build passes ✓