### PR TITLE
Enrich amgm-inequality: fix annotation schema violations

### DIFF
--- a/src/data/proofs/amgm-inequality/annotations.json
+++ b/src/data/proofs/amgm-inequality/annotations.json
@@ -56,7 +56,7 @@
       "startLine": 53,
       "endLine": 79
     },
-    "type": "technique",
+    "type": "theorem",
     "title": "Elementary Two-Variable Proof via Square Non-negativity",
     "content": "**The Classic Proof**:\n\nStart with $(\\sqrt{a} - \\sqrt{b})^2 \\geq 0$ (squares are non-negative)\n\n**Expand**:\n$$a - 2\\sqrt{ab} + b \\geq 0$$\n\n**Rearrange**:\n$$a + b \\geq 2\\sqrt{ab} \\implies \\frac{a + b}{2} \\geq \\sqrt{ab}$$\n\nIn Lean, the proof uses `Real.sq_sqrt` to replace $(\\sqrt{a})^2$ with $a$ and `Real.sqrt_mul` to merge $\\sqrt{a} \\cdot \\sqrt{b} = \\sqrt{ab}$, then closes by `linarith` on the resulting linear arithmetic goal. This illustrates a common Lean pattern: rewrite to reduce to a canonical form, then discharge with automation.",
     "mathContext": "Lean proof mechanics: `sq_nonneg (Real.sqrt a - Real.sqrt b)` gives `0 ≤ (√a - √b)²`; `ring` expands it to `√a² - 2·√a·√b + √b²`; `Real.sq_sqrt ha` rewrites `√a² → a` and `Real.sq_sqrt hb` rewrites `√b² → b`; `Real.sqrt_mul ha b` rewrites `√a·√b → √(a·b)` (using its `.symm`); `linarith` closes the linear goal `0 ≤ a - 2·√(a·b) + b` given `(a+b)/2 ≥ √(a·b)`. The critical Mathlib lemma `Real.sqrt_mul : ∀ (hx : 0 ≤ x) (y : ℝ), Real.sqrt (x * y) = Real.sqrt x * Real.sqrt y` requires the non-negativity hypothesis on the *first* argument only.",
@@ -81,7 +81,7 @@
       "startLine": 81,
       "endLine": 87
     },
-    "type": "technique",
+    "type": "theorem",
     "title": "Alternative Formulation: a + b ≥ 2√(ab)",
     "content": "**Equivalent statement** of AM-GM without division:\n$$a + b \\geq 2\\sqrt{ab}$$\n\nThis form is often more convenient in algebraic manipulations—it avoids division by 2, making it directly applicable to sum-product estimates. The Lean proof simply delegates to `am_gm_two` via `linarith`, demonstrating how to derive equivalent forms by scaling.\n\n**Usage**: This form appears in proofs of Cauchy-Schwarz via SOS (sum of squares) decompositions and in bounding products in number theory.\n\n**Connection to Young's inequality**: Substituting $a \\to a^p/p$ and $b \\to b^q/q$ with $1/p + 1/q = 1$ yields Young's inequality $ab \\leq a^p/p + b^q/q$, which is the workhorse behind Hölder's inequality and $L^p$ space theory. The two-variable AM-GM is exactly the case $p = q = 2$.",
     "mathContext": "The Lean proof: `have h := am_gm_two a b ha hb` gives `(a+b)/2 ≥ √(ab)`; `linarith` derives `a+b ≥ 2·√(ab)` by multiplying both sides by 2. Young's inequality generalization: for $p, q > 1$ with $1/p + 1/q = 1$, $ab \\leq a^p/p + b^q/q$ (equivalent to AM-GM applied to $a^p/p$ and $b^q/q$ with weights $1/p, 1/q$). The two-variable AM-GM is the case $p = q = 2$. Young's inequality is the key step in proving Hölder's inequality $\\|fg\\|_1 \\leq \\|f\\|_p \\|g\\|_q$, which in turn proves the Cauchy-Schwarz inequality as the $p=q=2$ case.",
@@ -159,7 +159,7 @@
       "startLine": 149,
       "endLine": 160
     },
-    "type": "technique",
+    "type": "theorem",
     "title": "Two-Variable AM-GM via Weighted Means and convert",
     "content": "**Recovering the two-variable case from the general form**:\n\nThe theorem `am_gm_two_via_weighted` sets weights $w_1 = w_2 = 1/2$ in Mathlib's `Real.geom_mean_le_arith_mean2_weighted` to obtain:\n$$a^{1/2} \\cdot b^{1/2} \\leq \\frac{a + b}{2}$$\n\n**The `convert` tactic pattern**: Mathlib's statement has a slightly different normal form than the desired conclusion. The `convert` tactic produces subgoals for each position where the two sides differ, and `ring` closes each arithmetic subgoal. This `convert ... using 1` + `all_goals ring` pattern is a workhorse for adapting Mathlib results to custom formulations—it avoids the need for manual term-level manipulation.\n\n**Pedagogical value**: This theorem exists alongside `am_gm_two` to demonstrate *two independent proof routes* to the same result: the elementary algebraic proof (square non-negativity) and the general machinery (convexity + Jensen's). When formalizing mathematics, having multiple proof paths increases confidence and provides different insights into the result.",
     "mathContext": "Lean proof: `Real.geom_mean_le_arith_mean2_weighted` takes explicit weight arguments (`(0:ℝ) ≤ 1/2`, `(0:ℝ) ≤ 1/2`, `ha`, `hb`, `(1/2:ℝ) + 1/2 = 1`), yielding `a^(1/2) * (1/2) + b^(1/2) * (1/2) ≤ ...` in Mathlib's internal form. `convert h using 1` creates subgoals where the goal and `h` differ: the left side needs `a^(1/2 : ℝ) * b^(1/2 : ℝ) = ...` and the right needs `(a+b)/2 = ...`; both closed by `ring`. The `using 1` depth controls how deeply `convert` recurses — `using 1` leaves arithmetic equations as subgoals rather than trying to close them automatically.",
@@ -184,7 +184,7 @@
       "startLine": 162,
       "endLine": 181
     },
-    "type": "context",
+    "type": "concept",
     "title": "Concrete Verification Examples",
     "content": "**Three illustrative examples**:\n\n1. **Equal case** (lines 165–168): Shows $(a+a)/2 = \\sqrt{a \\cdot a} = a$—verifying that AM equals GM when both variables coincide. Uses `Real.sqrt_sq` to simplify $\\sqrt{a^2} = a$.\n\n2. **Strict inequality** (lines 171–176): The specific instance $a=1, b=4$ gives $AM = 5/2 > GM = 2$. Lean's `norm_num` verifies $\\sqrt{4} = 2$ via the characterization `Real.sqrt_eq_iff_sq_eq`.\n\n3. **Delegation** (lines 179–180): The pair $(a,b) = (2,8)$ with $AM = 5 \\geq GM = 4$ is checked by direct application of `am_gm_two`, showing how the main theorem is used in practice.\n\nThese examples serve as sanity checks and demonstrate that Lean can verify concrete numerical claims about real square roots without any `sorry`.",
     "mathContext": "The strict inequality example (lines 171–176) uses `Real.sqrt_eq_iff_sq_eq (hx : 0 ≤ x) (hy : 0 ≤ y) : √x = y ↔ x = y^2` to establish `√4 = 2` (checking `4 = 2² = 4` by `norm_num`), then `simp [this]` and `norm_num` close `5/2 > 2`. The `norm_num` tactic can evaluate rational arithmetic and known square root values. The equal-case example (lines 165–168) uses `Real.sqrt_sq ha : √(a²) = a` for `a ≥ 0` (note: `√(a·a) = √(a²)` since `a·a = a²` by `ring`). These three examples serve as integration tests: they confirm that `am_gm_two` is correctly stated and works on concrete inputs.",
@@ -235,7 +235,7 @@
       "startLine": 196,
       "endLine": 203
     },
-    "type": "context",
+    "type": "concept",
     "title": "The Mean Inequality Chain: QM ≥ AM ≥ GM",
     "content": "**The Power Mean Hierarchy**:\n\nThe `am_ge_gm` alias places AM-GM in the classical chain of mean inequalities:\n$$\\text{QM} = \\sqrt{\\frac{a^2+b^2}{2}} \\;\\geq\\; \\text{AM} = \\frac{a+b}{2} \\;\\geq\\; \\text{GM} = \\sqrt{ab} \\;\\geq\\; \\text{HM} = \\frac{2ab}{a+b}$$\n\nMore generally, the **power mean** $M_p(a,b) = \\left(\\frac{a^p+b^p}{2}\\right)^{1/p}$ satisfies $M_p \\leq M_q$ whenever $p \\leq q$, with $M_0 = \\text{GM}$, $M_1 = \\text{AM}$, $M_2 = \\text{QM}$, and $M_{-1} = \\text{HM}$. AM-GM is the single step $M_0 \\leq M_1$ in this chain.\n\nThis monotonicity of power means is equivalent to Jensen's inequality for the convex function $t \\mapsto t^{q/p}$ and unifies all classical mean comparisons under one principle.",
     "mathContext": "`am_ge_gm` is a one-line alias: `am_gm_two a b ha hb`. It exists to support the chain `QM ≥ AM ≥ GM ≥ HM` where $\\text{QM} = \\sqrt{(a^2+b^2)/2}$, $\\text{AM} = (a+b)/2$, $\\text{GM} = \\sqrt{ab}$, $\\text{HM} = 2ab/(a+b)$. The power mean $M_p = ((a^p+b^p)/2)^{1/p}$ satisfies $M_p \\leq M_q$ for $p \\leq q$ (proved via Jensen on $t \\mapsto t^{q/p}$ convex for $q/p \\geq 1$). Limits: $M_0 = \\lim_{p \\to 0} M_p = \\sqrt{ab}$ (geometric mean), $M_{\\pm\\infty} = \\max/\\min(a,b)$. The alias pattern also allows users to write `am_ge_gm` in downstream proofs, making the mathematical intent clear without coupling to the specific proof of `am_gm_two`.",
@@ -260,7 +260,7 @@
       "startLine": 205,
       "endLine": 218
     },
-    "type": "technique",
+    "type": "theorem",
     "title": "Three-Variable AM-GM via Mathlib",
     "content": "**Three-Variable AM-GM**:\n$$a^{1/3} b^{1/3} c^{1/3} \\leq \\frac{a + b + c}{3}$$\n\nEquivalently (for $a,b,c > 0$):\n$$\\sqrt[3]{abc} \\leq \\frac{a+b+c}{3}$$\n\n**Proof structure**: Calls `Real.geom_mean_le_arith_mean3_weighted` with weights $w_1 = w_2 = w_3 = 1/3$ (summing to 1). The `convert` tactic bridges the Finset-based statement to the concrete three-variable form, and `ring` closes the arithmetic goals.\n\n**Historical note**: The three-variable case was proved by Maclaurin (1729) via his symmetric function inequalities, before Cauchy's general n-variable proof. The chain $e_1/3 \\geq e_2^{1/2}/\\binom{3}{2}^{1/2} \\geq e_3^{1/3}$ (where $e_k$ are elementary symmetric polynomials) is known as Maclaurin's inequality and strictly strengthens AM-GM.",
     "mathContext": "Lean proof: `Real.geom_mean_le_arith_mean3_weighted` takes six arguments (three non-negativity proofs for weights $1/3, 1/3, 1/3$; three value non-negativity proofs `ha, hb, hc`; and the weight sum `(1/3:ℝ) + 1/3 + 1/3 = 1` by `ring`). The `convert h using 1` step: Mathlib's result has the form `a^(1/3) * 1/3 + b^(1/3) * 1/3 + c^(1/3) * 1/3 ≤ ...` which differs from the target `a^(1/3 : ℝ) * b^(1/3 : ℝ) * c^(1/3 : ℝ) ≤ (a+b+c)/3` in expression shape; `all_goals ring` closes both arithmetic subgoals. Maclaurin's inequality (1729): $e_1/\\binom{3}{1}^{1/1} \\geq e_2^{1/2}/\\binom{3}{2}^{1/2} \\geq e_3^{1/3}$ where $e_k$ are the $k$-th elementary symmetric polynomials of $(a,b,c)$ — this is strictly stronger than AM-GM, also capturing $\\sqrt{(ab+bc+ca)/3} \\geq (abc)^{1/3}$.",
@@ -285,7 +285,7 @@
       "startLine": 220,
       "endLine": 225
     },
-    "type": "context",
+    "type": "concept",
     "title": "Type-Check Verification and Namespace Close",
     "content": "Four `#check` commands verify the signatures of the main theorems at the end of the file: `am_gm_two` (elementary two-variable), `am_gm_two_eq_iff` (equality characterization), `am_gm_weighted` (general Finset-based), and `am_gm_three` (three-variable specialization). This pattern serves as a quick-reference API summary.\n\nThe namespace `AMGMInequality` closes on line 225, scoping all definitions to prevent name collisions with Mathlib's own mean inequality lemmas.",
     "mathContext": "The four theorems form a hierarchy: `am_gm_weighted` is the most general (arbitrary finite sets, arbitrary weights), `am_gm_three` and `am_gm_two_via_weighted` are specializations, and `am_gm_two` is an independent elementary proof. The equality condition `am_gm_two_eq_iff` applies only to the two-variable case.",


### PR DESCRIPTION
Fix 7 invalid type values: 3 context→concept, 4 technique→theorem. Build passes ✓