### PR TITLE
Fix: sylow-theorem-oq-04 badge 'original' → 'mathlib'

### DIFF
--- a/src/data/proofs/sylow-theorem-oq-04/meta.json
+++ b/src/data/proofs/sylow-theorem-oq-04/meta.json
@@ -15,7 +15,7 @@
       "finite-groups",
       "applications"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-04-04",
     "axiomCount": 0,


### PR DESCRIPTION
## Fix

Change `badge` from `"original"` to `"mathlib"` in sylow-theorem-oq-04.

## Evidence

**Before**: `badge: "original"`, `status: "verified"`

**After**: `badge: "mathlib"`

The main theorem `A5_isSimple` is a one-line delegation to Mathlib's
`alternatingGroup.isSimpleGroup_five`. The file itself (line 256) labels
`A5_isSimple` with method "Mathlib" in its own summary table. The
`originalContributions` already correctly omit this theorem — only the
Sylow counting analysis (Parts I–VI) is original work.

Closes #11351

---
Automated fix by lean-mechanic agent.