### PR TITLE
Fix: prime-reciprocal-divergence-oq-03 badge 'mathlib' → 'original'

### DIFF
--- a/src/data/proofs/prime-reciprocal-divergence-oq-03/meta.json
+++ b/src/data/proofs/prime-reciprocal-divergence-oq-03/meta.json
@@ -16,7 +16,7 @@
       "erdos",
       "elementary"
     ],
-    "badge": "mathlib",
+    "badge": "original",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -50,7 +50,7 @@
       "lineCount": 388,
       "structures": 0,
       "axioms": 0,
-      "theorems": 12,
+      "theorems": 13,
       "definitions": 7,
       "instances": 0
     },
@@ -73,7 +73,7 @@
     ]
   },
   "conclusion": {
-    "summary": "Erd\u0151s's combinatorial proof of infinitely many primes formalized with 0 sorries. Squarefree decomposition injection gives smooth count \u2264 \u221an \u00b7 2^{\u03c0(N)}, yielding contradiction for n = (2^{\u03c0(N)+1})\u00b2 + 1. 12 theorems, 7 definitions, 0 axioms, 388 lines.",
+    "summary": "Erd\u0151s's combinatorial proof of infinitely many primes formalized with 0 sorries. Squarefree decomposition injection gives smooth count \u2264 \u221an \u00b7 2^{\u03c0(N)}, yielding contradiction for n = (2^{\u03c0(N)+1})\u00b2 + 1. 5 public theorems, 8 private lemmas, 7 definitions, 0 axioms, 388 lines.",
     "implications": "The combinatorial core of Erd\u0151s's \u03a31/p divergence proof can be formalized without analytic machinery. The squarefree decomposition and smooth number counting are templates for sieve theory and integer factorization algorithms. This file stands alone as a complete elementary proof of infinitely many primes, complementing both Euclid's classical argument and Mathlib's analytic approach.",
     "openQuestions": [
       "Formalize the full Erd\u0151s proof of \u03a31/p = \u221e using the smooth/rough dichotomy and real-valued sums",


### PR DESCRIPTION
## Fix

Change `badge` from `"mathlib"` to `"original"` in prime-reciprocal-divergence-oq-03, and correct theorem count.

## Evidence

**Before**: `badge: "mathlib"`, `theorems: 12`, `conclusion.summary: "12 theorems, 7 definitions"`

**After**: `badge: "original"`, `theorems: 13`, `conclusion.summary: "5 public theorems, 8 private lemmas, 7 definitions"`

The file header explicitly states: "This proof uses NO analysis: no limits, no topology, no measure theory."
The Mathlib imports are only utilities (`Nat.Prime`, `Finset`, `Nat.sq_mul_squarefree_of_pos`) —
not the core proof of infinitely many primes. The main theorems `smooth_count_bound` and
`infinitely_many_primes_erdos` are proved originally via squarefree decomposition injection.

Theorem count corrected from 12→13: grep of the Lean file finds 5 public theorems +
8 private lemmas = 13 total (the previous count missed `prime_reciprocals_unbounded`).

Closes #11348

---
Automated fix by lean-mechanic agent.