### PR TITLE
Seeker: select feuerbachs-theorem-defs-oq-04 — Feuerbach Theorem to Mathlib Affine Geometry

### DIFF
--- a/research/problems/angle-trisection-oq-02-oq-04-oq-01-incomplete-01/knowledge.md
+++ b/research/problems/angle-trisection-oq-02-oq-04-oq-01-incomplete-01/knowledge.md
@@ -1,0 +1,85 @@
+# Knowledge: Complete Tower-Galois Equivalence
+
+**Problem**: angle-trisection-oq-02-oq-04-oq-01-incomplete-01
+**Last Updated**: 2026-04-22
+
+## Current Understanding
+
+### The File
+
+`proofs/Proofs/AngleTrisectionOQ02OQ04OQ01.lean` — 300+ lines, mostly proved.
+
+Structure:
+- Part 1: QuadraticTower inductive definition (proved)
+- Part 2: Tower degree theorem `quadratic_tower_degree` (proved: towers give 2^n degree)
+- Part 3: Solvability and index-2 subgroup infrastructure (proved)
+- Part 4: Galois → Tower direction (SORRY 1)
+- Part 5: Tower → Galois direction (SORRY 2)
+- Part 6: Full equivalence `tower_iff_galois_two_group` (stated, depends on 1+2)
+- Part 7: Feasibility assessment (commentary)
+- Part 8: √2 example (SORRY 3)
+- Part 9: Summary
+
+### Approach for Sorry 3 (Easiest — √2 in tower)
+
+The goal is:
+```lean
+∃ (K : IntermediateField ℚ ℝ), QuadraticTower ℚ ℝ K 1 ∧ Real.sqrt 2 ∈ K
+```
+
+Approach: Use `adjoin` to construct K = ℚ(√2). Key lemmas needed:
+- `IntermediateField.adjoin_simple_le_iff` or `IntermediateField.mem_adjoin`
+- `Real.sqrt_two_mul_self` or `Real.sqrt_sq`
+- Prove `[ℚ(√2):ℚ] = 2` via `minpoly ℚ (Real.sqrt 2)` = X²-2
+
+Mathlib has: `Polynomial.aeval_eq_sum_range`, `IntermediateField.adjoin.finiteDimensional`
+The degree calculation needs `minpoly.degree_dvd` and `Polynomial.Irreducible.natDegree`.
+
+### Approach for Sorry 2 (Tower → Galois, medium)
+
+Goal: `ht : ConstructibleViaTower α → IsPGroup 2 (minpoly ℚ α).Gal`
+
+Strategy via degree bounds:
+1. From `ht`, extract tower K with [K:ℚ] = 2^n via `quadratic_tower_degree`
+2. α ∈ K, so `minpoly.degree_le` gives deg(minpoly ℚ α) ≤ [K:ℚ] = 2^n
+3. The splitting field E of minpoly α has [E:ℚ] | (2^n)!
+4. Stronger: [E:ℚ] | 2^(n·deg) which is still a power of 2
+5. `IsPGroup.iff_card` converts card = 2^k to 2-group
+
+Key Mathlib lemmas:
+- `Polynomial.Splits.card_roots_le_degree`
+- `IsGalois.card_aut_eq_finrank`
+- `Module.finrank_mul_finrank` (tower law for degrees)
+
+### Approach for Sorry 1 (Galois → Tower, hardest)
+
+Goal: `IsPGroup 2 (minpoly ℚ α).Gal → ConstructibleViaTower α`
+
+This requires the full Galois correspondence + induction on |G|.
+
+Key steps:
+1. Let E = splitting field of minpoly ℚ α; G = Gal(E/ℚ)
+2. `exists_index_two_subgroup` (already proved in the file) → H ≤ G with [G:H] = 2
+3. Galois correspondence: `IntermediateField.fixedField H` = K₁ with [K₁:ℚ] = [G:H] = 2
+4. `QuadraticTower.step` gives a tower reaching K₁
+5. Restrict to Gal(E/K₁) = H, which is a 2-group (subgroup of 2-group)
+6. Induct on |H| to build the rest of the tower
+7. Show α ∈ E ⊆ final tower
+
+The hardest API gap: connecting `Polynomial.Gal` (acts on roots of the polynomial)
+to `IntermediateField.fixingSubgroup` (acts on extension E/ℚ).
+
+Possible bridge: `Polynomial.Gal.galActionHom` or `IsGalois.galoisGroup`.
+
+## What's Already Proved in the File
+
+- `QuadraticTower` definition and `QuadraticTower.degree` lemma
+- `exists_index_two_subgroup` (via Sylow theory)
+- Part infrastructure for tower induction
+- `gal_x2_minus_2_is_two_group` (uses result from AngleTrisectionOQ02.lean)
+
+## Priority Order
+
+1. **Sorry 3** (sqrt2_constructible_tower) — warm-up, good Aristotle candidate
+2. **Sorry 2** (tower_implies_galois_two_group) — degree bound argument
+3. **Sorry 1** (galois_two_group_implies_tower) — requires Galois correspondence API glue

--- a/research/problems/angle-trisection-oq-02-oq-04-oq-01-incomplete-01/problem.md
+++ b/research/problems/angle-trisection-oq-02-oq-04-oq-01-incomplete-01/problem.md
@@ -1,0 +1,90 @@
+# Problem: Complete Tower-Galois Equivalence via Mathlib Correspondence
+
+**Slug**: angle-trisection-oq-02-oq-04-oq-01-incomplete-01
+**Created**: 2026-04-22
+**Status**: Available
+**Source**: incomplete-lean (3 sorries in AngleTrisectionOQ02OQ04OQ01.lean)
+
+## Problem Statement
+
+### Plain Language
+
+The file `proofs/Proofs/AngleTrisectionOQ02OQ04OQ01.lean` formalizes the Tower-Galois
+equivalence for constructible real numbers:
+
+> For an algebraic real α: α lies in a quadratic tower ⟺ Gal(minpoly ℚ α) is a 2-group
+
+Three `sorry`s remain. The task is to prove them using Mathlib's existing infrastructure.
+
+### The Three Remaining Sorries
+
+**Sorry 1 (line 193)** — `galois_two_group_implies_tower` (hardest):
+```lean
+theorem galois_two_group_implies_tower (α : ℝ) (hα : IsIntegral ℚ α)
+    (hG : IsPGroup 2 (minpoly ℚ α).Gal) :
+    ConstructibleViaTower α := by
+  sorry -- Requires: splitting field construction, Galois correspondence,
+        -- iterative index-2 subgroup extraction, embedding α into tower
+```
+Proof sketch: G = Gal(E/ℚ) is a 2-group → has index-2 subgroup H → Galois correspondence
+gives K₁ with [K₁:ℚ] = 2 → repeat inductively on |H|.
+
+**Sorry 2 (line 216)** — `tower_implies_galois_two_group` (medium):
+```lean
+theorem tower_implies_galois_two_group (α : ℝ) (hα : IsIntegral ℚ α)
+    (ht : ConstructibleViaTower α) :
+    IsPGroup 2 (minpoly ℚ α).Gal := by
+  sorry -- Requires: degree of splitting field divides tower degree power
+```
+Proof sketch: α ∈ quadratic tower K with [K:ℚ] = 2^n → deg(minpoly α) | 2^n →
+[E:ℚ] is a power of 2 → |Gal(E/ℚ)| is a power of 2.
+
+**Sorry 3 (line 291)** — `sqrt2_constructible_tower` (easiest):
+```lean
+theorem sqrt2_constructible_tower :
+    ∃ (K : IntermediateField ℚ ℝ),
+      QuadraticTower ℚ ℝ K 1 ∧ (Real.sqrt 2 : ℝ) ∈ K := by
+  sorry -- Needs: construction of ℚ(√2) as IntermediateField with degree 2
+```
+
+## Classification
+
+```yaml
+tier: B
+significance: 7
+tractability: 5
+tags:
+  - seeker-selected
+  - algebra
+  - galois-theory
+  - tower-law
+  - angle-trisection
+  - incomplete
+```
+
+**Significance**: 7/10 — Completes the central theorem in the angle trisection proof chain
+**Tractability**: 5/10 — API glue work, ~500-800 lines estimated; no missing theorems
+
+## Mathlib Gap Analysis (from Lean file)
+
+### Available
+- `IsPGroup.isSolvable` — 2-groups are solvable
+- `IsPGroup.to_subgroup` — subgroups of 2-groups are 2-groups
+- `IsPGroup.iff_card` — card of p-group is p^n
+- `IntermediateField`, `Polynomial.Gal`, `IsGalois`
+- `IntermediateField.fixedField` / `fixingSubgroup` (Galois correspondence)
+- `exists_index_two_subgroup` for 2-groups — PROVED in the file
+
+### Missing / Needs Glue
+- Connecting `Polynomial.Gal` to `IntermediateField.fixingSubgroup`
+- Index-degree relation: `[G : H] = [Fix(H) : K]` (API connection to `Module.finrank`)
+- Iterative tower construction from repeated index-2 extraction (induction on |G|)
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| angle-trisection | Parent proof using QuadraticTower constructibility |
+| angle-trisection-oq-02-oq-04 | Defines DegreeCriterion, GaloisCriterion, TowerCriterion |
+| angle-trisection-oq-02-oq-04-oq-01 | Direct parent — partial formalization |
+| angle-trisection-oq-02 | Constructible algebraic numbers via Galois groups |

--- a/research/problems/angle-trisection-oq-02-oq-04-oq-01-incomplete-01/state.md
+++ b/research/problems/angle-trisection-oq-02-oq-04-oq-01-incomplete-01/state.md
@@ -1,0 +1,38 @@
+# Current State
+
+**Phase**: OBSERVE
+**Since**: 2026-04-22
+**Iteration**: 1
+
+## Current Focus
+
+Complete the 3 remaining `sorry`s in `proofs/Proofs/AngleTrisectionOQ02OQ04OQ01.lean`.
+
+Priority order (easiest to hardest):
+1. `sqrt2_constructible_tower` (line 291) — construct ℚ(√2) as IntermediateField
+2. `tower_implies_galois_two_group` (line 216) — degree bound argument
+3. `galois_two_group_implies_tower` (line 193) — full Galois correspondence
+
+## Active Approach
+
+None yet — initial observation phase.
+
+## Key Files
+
+- Lean source: `proofs/Proofs/AngleTrisectionOQ02OQ04OQ01.lean`
+- Dependencies: `proofs/Proofs/AngleTrisectionOQ02.lean` (gal_x2_minus_2_is_two_group)
+- Dependencies: `proofs/Proofs/AngleTrisectionOQ02OQ04.lean` (DegreeCriterion, etc.)
+
+## Blockers
+
+None.
+
+## Next Action
+
+1. Read the full Lean file to understand the sorry context precisely
+2. Search Mathlib for `IntermediateField.adjoin` API for ℚ(√2) construction
+3. Try Sorry 3 first as a warm-up
+
+## Previous Sessions
+
+None — workspace initialized by seeker 2026-04-22.

--- a/research/problems/binomial-theorem-oq-03-oq-01/knowledge.md
+++ b/research/problems/binomial-theorem-oq-03-oq-01/knowledge.md
@@ -1,0 +1,48 @@
+# Knowledge Base: binomial-theorem-oq-03-oq-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+**Goal**: Formalize the de Moivre-Laplace CLT in Lean 4, using the MGF approach
+pioneered in `binomial-theorem-oq-03`. The key computation:
+
+1. Standardized Bin(n,p): $Z_n = (X_n - np)/\sqrt{npq}$, $q = 1-p$
+2. MGF of $Z_n$: $M_n(t) = (1 - p + p e^{t/\sqrt{npq}})^n$
+3. Taylor expansion: $1 - p + pe^{t/\sqrt{npq}} = 1 + t^2/(2n) + O(n^{-3/2})$
+4. Limit: $M_n(t) \to e^{t^2/2}$ (MGF of N(0,1))
+5. Conclude: $Z_n \xrightarrow{d} N(0,1)$ by continuity theorem
+
+**Parent proof** `BinomialTheoremOQ03.lean` already proves:
+- Mean: $\mathbb{E}[X_n] = np$
+- Variance: $\text{Var}(X_n) = npq$
+- Poisson limit: $(1+x/n)^n \to e^x$ (key step reusable!)
+
+**Tractability**: Medium. The algebraic part is clear. The hard part is
+whether Mathlib has Levy's continuity theorem or weak convergence machinery.
+
+---
+
+## Insights
+
+### Seeker Selection Rationale (2026-04-22)
+- Selected as Tier B (sig=7, tract=6) with EMPTY knowledge
+- Composite score: 67 (EMPTY tier priority)
+- No prior research workspace existed
+- Probability domain — diverse from recent selections (algebra, info theory, analysis, set theory)
+- Parent `binomial-theorem-oq-03` is verified; this extends to CLT
+- The Poisson limit proof `(1+x/n)^n → e^x` in parent is directly reusable
+
+### Recommended OBSERVE Phase Steps
+1. Search Mathlib for `ProbabilityTheory.clt`, `tendsto_mgf`, `levy_continuity`
+2. Check `Mathlib.Probability.Distributions.Binomial` for existing infrastructure
+3. Read `Proofs/BinomialTheoremOQ03.lean` — extract reusable lemmas
+4. Search for any existing de Moivre-Laplace formalization in Lean 4 ecosystem
+
+---
+
+## Dead Ends
+
+[None yet — problem is freshly selected]

--- a/research/problems/binomial-theorem-oq-03-oq-01/literature/README.md
+++ b/research/problems/binomial-theorem-oq-03-oq-01/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for binomial-theorem-oq-03-oq-01
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/binomial-theorem-oq-03-oq-01/problem.md
+++ b/research/problems/binomial-theorem-oq-03-oq-01/problem.md
@@ -1,0 +1,162 @@
+# Problem: de Moivre-Laplace CLT via Moment Generating Function
+
+**Slug**: binomial-theorem-oq-03-oq-01
+**Created**: 2026-04-22T14:37:37+02:00
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+**OQ-01 of binomial-theorem-oq-03**: Can the de Moivre-Laplace CLT be proved
+using the algebraic MGF approach?
+
+$$\text{Bin}(n,p) \xrightarrow{d} \mathcal{N}(np,\, np(1-p))$$
+
+Formally: for $X_n \sim \text{Bin}(n,p)$,
+$$\frac{X_n - np}{\sqrt{np(1-p)}} \xrightarrow{d} \mathcal{N}(0,1)$$
+
+The MGF approach: $M_{X_n}(t) = (1-p+pe^{t/\sqrt{np(1-p)}})^n \to e^{t^2/2}$
+as $n \to \infty$, which is the MGF of $\mathcal{N}(0,1)$.
+
+### Plain Language
+
+The parent entry `binomial-theorem-oq-03` proves that the binomial distribution
+Bin(n,p) has mean np and variance np(1-p) using purely algebraic manipulation
+of the generating function $(p + (1-p))^n = 1$. The open question is: can the
+same algebraic approach, via the moment generating function, yield a proof of
+the de Moivre-Laplace theorem — that normalized binomials converge to Gaussian?
+
+The MGF of Bin(n,p) is $(1-p+pe^t)^n$. After standardization (shift by np,
+scale by $\sqrt{np(1-p)}$), the MGF becomes $(1-p+pe^{t/\sqrt{n p(1-p)}})^n$.
+The key limit: $(1 + t^2/(2n) + O(t^3/n^{3/2}))^n \to e^{t^2/2}$, which is
+the MGF of N(0,1). MGF convergence implies distributional convergence.
+
+### Why This Matters
+
+- Connects the algebraic binomial-distribution theory to CLT formalization
+- Mathlib has substantial probability theory (ProbabilityTheory.*)
+- Formalizing the de Moivre-Laplace special case provides stepping stone
+  toward the general CLT
+- No duplicate in gallery — new mathematical content for the project
+
+## Known Results
+
+### What's Already Proven in the Gallery
+
+- **binomial-theorem-oq-03** (verified, 0 sorries): Bin(n,p) has mean np,
+  variance np(1-p), Vandermonde convolution, Poisson limit theorem.
+  File: `Proofs/BinomialTheoremOQ03.lean`
+- The limit $(1+x/n)^n \to e^x$ is proved in that file (used for Poisson limit)
+- Mathlib: `MeasureTheory.ProbabilityMeasure`, `ProbabilityTheory.variance`
+
+### Mathlib Resources
+
+- `Mathlib.Probability.Distributions.Binomial` — binomial random variables
+- `Mathlib.Analysis.SpecialFunctions.ExpDeriv` — `Real.exp` derivatives
+- `Mathlib.MeasureTheory.Function.L2Space` — L2 convergence
+- `Mathlib.Topology.Algebra.InfiniteSum` — series/summation
+- `Mathlib.Analysis.MeanInequalities` — moment bounds
+
+### What's Still Open
+
+- A full formalization of the de Moivre-Laplace theorem in Lean 4
+- Connection from MGF convergence to distributional convergence in Mathlib
+
+### Our Goal
+
+Formalize either:
+1. **(Preferred)** The MGF proof: show $M_{X_n}(t) \to e^{t^2/2}$
+2. **(Alternative)** A direct characteristic function proof using
+   Mathlib's Fourier analysis
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `binomial-theorem-oq-03` | Parent: Bin(n,p) statistics algebraically | Generating functions |
+| `central-limit-theorem-oq-03-oq-02` | Related CLT formalization work | Probability theory |
+| `birthday-problem-oq-03-oq-01-oq-02-oq-01` | Probability/Poisson approximation | Approx methods |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **MGF Convergence** (recommended):
+   - Compute MGF of standardized Bin(n,p): $(1-p+pe^{t/\sqrt{npq}})^n$
+   - Expand $pe^{t/\sqrt{npq}} = p(1 + t/\sqrt{npq} + t^2/(2npq) + O(n^{-3/2}))$
+   - Show $\log MGF(t) \to t^2/2$ as $n \to \infty$
+   - Apply continuity theorem for MGFs
+   - Risk: Mathlib's MGF convergence → distributional convergence may be limited
+
+2. **Characteristic Function (Fourier)** approach:
+   - Use `MeasureTheory.Fourier` and Levy's continuity theorem
+   - Characteristic function of Bin(n,p): $(1-p+pe^{it})^n$
+   - After standardization: pointwise convergence to $e^{-t^2/2}$
+   - Risk: Levy's theorem may not be in Mathlib yet
+
+3. **Stirling's Approximation** (classical):
+   - Directly bound $\binom{n}{k}p^k(1-p)^{n-k}$ for $k \approx np + x\sqrt{npq}$
+   - Use $\log \binom{n}{k} \approx n H(\hat{p})$ (entropy approximation)
+   - Risk: Tedious but elementary; Stirling's formula is in Mathlib
+
+### Key Difficulties
+
+- Distributional convergence infrastructure in Mathlib (weak convergence)
+- MGF → distribution equivalence theorem in Lean 4
+- Controlling error terms in the Taylor expansion at rate $O(1/\sqrt{n})$
+
+### What Would a Proof Need?
+
+- Key lemma 1: MGF of standardized Bin(n,p) = $(1-p+pe^{t/\sqrt{npq}})^n$
+- Key lemma 2: $(1 + a_n)^n \to e^L$ when $n \cdot a_n \to L$ (from parent proof)
+- Key lemma 3: Levy's continuity theorem (MGF/CF convergence → weak convergence)
+- Technical: `ProbabilityTheory.tendsto_of_mgf_tendsto` or equivalent
+
+## Tractability Assessment
+
+**Difficulty**: Medium (with Mathlib CLT infrastructure); High (without it)
+
+**Justification**:
+- The algebraic MGF computation is straightforward
+- The bottleneck is whether Mathlib has Levy's theorem or weak-convergence infrastructure
+- If using Stirling's approach, it's more mechanical but longer
+
+**Estimated Effort**:
+- Exploration: 1 day (check Mathlib CLT/weak convergence landscape)
+- If CLT infrastructure exists: 2-3 days
+- If infrastructure missing: weeks to build it
+
+## References
+
+### Papers
+- de Moivre, A. (1738). "The Doctrine of Chances." 2nd ed. — historical CLT
+- Laplace, P.S. (1812). "Théorie Analytique des Probabilités." — formal CLT
+
+### Online Resources
+- Mathlib4 docs: `ProbabilityTheory` namespace for weak convergence
+
+### Mathlib
+- `Mathlib.Probability.Distributions.Binomial` — Bin(n,p) definition
+- `Mathlib.MeasureTheory.Measure.ProbabilityMeasure` — weak convergence
+- `Mathlib.Analysis.SpecialFunctions.ExpDeriv` — exp Taylor series
+- `Proofs/BinomialTheoremOQ03.lean` — parent proof (Poisson limit uses (1+x/n)^n → e^x)
+
+## Metadata
+
+```yaml
+tags:
+  - probability
+  - central-limit-theorem
+  - binomial-distribution
+  - moment-generating-function
+  - de-moivre-laplace
+  - analysis
+related_proofs:
+  - binomial-theorem-oq-03
+  - central-limit-theorem-oq-03-oq-02
+difficulty: medium
+source: gallery-gap
+created: 2026-04-22T14:37:37+02:00
+```

--- a/research/problems/binomial-theorem-oq-03-oq-01/state.md
+++ b/research/problems/binomial-theorem-oq-03-oq-01/state.md
@@ -1,0 +1,25 @@
+# Research State: binomial-theorem-oq-03-oq-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-04-22T14:37:37+02:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/erdos-1169-oq-04/knowledge.md
+++ b/research/problems/erdos-1169-oq-04/knowledge.md
@@ -1,0 +1,54 @@
+# Knowledge Base: erdos-1169-oq-04
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+**Goal**: Replace axioms in `Proofs/Erdos1169Problem.lean` with proved theorems.
+The gallery entry `erdos-1169` uses 3 axioms for Hajnal's CH-conditional result.
+OQ-04 asks whether Lean 4 + Mathlib can verify at least the countable case
+`ω → (ω, 3)²` without axioms.
+
+**Formal definition in `Proofs/Erdos1169Problem.lean`**:
+```lean
+def ordinalPartitionRel (α β : Ordinal) (k : ℕ) : Prop :=
+  ∀ c : Ordinal → Ordinal → Fin 2,
+    (∃ f : Ordinal → Ordinal, StrictMono f ∧ (∀ i, i < β → f i < α) ∧
+      ∀ i j, i < j → j < β → c (f i) (f j) = 0) ∨
+    (∃ g : Fin k → Ordinal, StrictMono g ∧ (∀ i, g i < α) ∧
+      ∀ i j : Fin k, i < j → c (g i) (g j) = 1)
+```
+
+**Key axiom to replace**:
+```lean
+axiom hajnal_ch_implies_partition (h : CH) (k : ℕ) (hk : 2 ≤ k) :
+  ordinalPartitionRel omega1Sq omega1Sq k
+```
+
+**Tractability**: Countable Ramsey (ω → (ω,3)²) is Medium. Full CH result is High.
+
+---
+
+## Insights
+
+### Seeker Selection Rationale (2026-04-22)
+- Selected as Tier A (sig=8, tract=5) with EMPTY knowledge
+- Composite score: 58 (EMPTY tier priority)
+- No prior research workspace existed
+- Parent `erdos-1169` is axiomatized; this OQ targets replacing axioms
+- Mathlib has finite Ramsey (`Mathlib.Combinatorics.Ramsey`) — investigate
+  if infinite case exists
+
+### Recommended OBSERVE Phase Steps
+1. Search Mathlib for `Ramsey`, `infinite`, `ordinal partition` API
+2. Check `Mathlib.Combinatorics.Ramsey` for infinite coloring theorems
+3. Read `Proofs/Erdos1169Problem.lean` in full — understand all 3 axioms
+4. Test whether `omega → (omega, 3)²` can be stated and proved from Mathlib
+
+---
+
+## Dead Ends
+
+[None yet — problem is freshly selected]

--- a/research/problems/erdos-1169-oq-04/literature/README.md
+++ b/research/problems/erdos-1169-oq-04/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for erdos-1169-oq-04
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/erdos-1169-oq-04/problem.md
+++ b/research/problems/erdos-1169-oq-04/problem.md
@@ -1,0 +1,164 @@
+# Problem: Ordinal Partition Relation Formalization in Lean 4
+
+**Slug**: erdos-1169-oq-04
+**Created**: 2026-04-22T14:30:59+02:00
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+**OQ-04 of Erdős #1169**: Can the ordinal partition relation
+$$\omega_1^2 \to (\omega_1^2, 3)^2$$
+be fully formalized in Lean 4 using Mathlib's ordinal and coloring theory,
+**replacing the current axiomatization**?
+
+Specifically: eliminate the `axiom hajnal_ch_implies_partition` and related
+axioms in `Proofs/Erdos1169Problem.lean` by deriving them from Mathlib's
+ordinal arithmetic primitives or by building a verified framework for
+ordinal partition calculus.
+
+### Plain Language
+
+The parent gallery entry `erdos-1169` uses three axioms to encode:
+1. Hajnal's CH-conditional theorem (ω₁² → (ω₁², k)² under CH)
+2. The non-disprovability result (ZFC does not refute the relation)
+3. The independence statement (under PFA/MA)
+
+The question is whether Lean 4 + Mathlib can verify at least one of these
+without the axiom shortcut. The most tractable target is:
+
+**CH implies ω₁² → (ω₁², 3)²**: prove that under the assumption CH
+(2^ℵ₀ = ℵ₁), every 2-coloring of pairs from ω₁² contains either a
+red ω₁²-copy or a blue triangle.
+
+### Why This Matters
+
+The axiomatization in `erdos-1169` is mathematically sound but vacuous as
+formal proof. Replacing even one axiom with a proved theorem would:
+- Demonstrate that ordinal partition calculus is within reach of Lean 4
+- Create reusable infrastructure for Ramsey theory on uncountable ordinals
+- Potentially connect to Mathlib's `Mathlib.SetTheory.Game.Ordinal` and
+  `Mathlib.Combinatorics.Ramsey` modules
+
+## Known Results
+
+### What's Already Proven in the Gallery
+
+- **erdos-1169** (axiomatized): The problem statement, Hajnal's result,
+  and non-disprovability encoded as axioms. File:
+  `Proofs/Erdos1169Problem.lean` (225 lines, 3 axioms)
+- `ordinalPartitionRel` defined: ∀ 2-colorings, ∃ order-type-β monochromatic-0
+  set OR k-clique (using StrictMono embeddings into Ordinal)
+- `negPartitionRel` as the negation is defined
+
+### Mathlib Resources
+
+- `Mathlib.SetTheory.Ordinal.Arithmetic` — ordinal arithmetic (mul, add, pow)
+- `Mathlib.SetTheory.Cardinal.Basic` — ℵ₀, ℵ₁, cardinal arithmetic
+- `Mathlib.SetTheory.Cardinal.Ordinal` — ordinal/cardinal relationships
+- `Mathlib.Combinatorics.Ramsey` — finite Ramsey theory
+- `Mathlib.Order.TypeTags` — order-type embeddings
+
+### What's Still Open
+
+- Proving Hajnal's theorem in Lean 4 (requires CH and transfinite induction)
+- Proving non-disprovability (requires model-theoretic argument)
+- The main ZFC status (open mathematical problem)
+
+### Our Goal
+
+**Phase 1** (most tractable): Prove `ω → (ω, 3)²` (Ramsey theorem for ω)
+without axioms, testing the infrastructure.
+
+**Phase 2** (ambitious): Formalize Hajnal's proof sketch under CH for the
+uncountable case.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `erdos-1169` | Parent problem, axioms to replace | Ordinal arithmetic, CH |
+| `erdos-476-oq-05` | Combinatorial extremal theory | Finset, induction |
+| `erdos-263` | Irrationality sequences, analytic methods | Series, real analysis |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Countable Ramsey First** (recommended starting point):
+   - Prove `ω → (ω, 3)²` via infinite Ramsey theorem
+   - Mathlib has `Mathlib.Combinatorics.Ramsey` for finite case
+   - The infinite case (Ramsey for ω) may be in `Infinite` section
+   - Why it might work: Tests infrastructure before hard uncountable case
+   - Risk: Even infinite Ramsey for ω may need significant machinery
+
+2. **Axiom Weakening**:
+   - Replace Hajnal axiom with a weaker proved theorem
+   - E.g., prove ω₁ → (ω₁, 3)² under CH (linear instead of square)
+   - Risk: Even this requires careful ordinal induction
+
+3. **Structural Infrastructure Only**:
+   - Prove monotonicity: if α → (β, k)² and α' ≥ α, then α' → (β, k)²
+   - These follow directly from `ordinalPartitionRel` definition
+   - Risk: Not mathematically deep, but good for establishing framework
+
+### Key Difficulties
+
+- Ordinal induction at ω₁ requires CH axioms in ZFC
+- Mathlib's Ramsey module is finite; extending to infinite ordinals is nontrivial
+- The coloring in `ordinalPartitionRel` is on all pairs, not just a finset
+
+### What Would a Proof Need?
+
+- Key lemma 1: Infinite Ramsey theorem for ω (i.e., ω → (ω, 3)²)
+- Key lemma 2: Monotonicity of partition relations under embedding
+- Key lemma 3: CH implies specific cardinality bounds on ω₁ subsets
+- Technical: `StrictMono` embeddings between ordinals in Mathlib
+
+## Tractability Assessment
+
+**Difficulty**: High for full Hajnal result; Medium for countable case; Low for structural lemmas
+
+**Justification**:
+- The full CH-conditional result requires significant set-theory expertise
+- Countable Ramsey (ω → (ω,3)²) may already be in Mathlib or derivable
+- Structural monotonicity lemmas follow from `ordinalPartitionRel` definition
+
+**Estimated Effort**:
+- Exploration: 1 day (inventory Mathlib ordinal/Ramsey API)
+- If countable case tractable: 2-3 days
+- Full CH-conditional: weeks (if at all possible without new Mathlib)
+
+## References
+
+### Papers
+- Hajnal, A. (1964). "Some results and problems on set theory." Acta Math. Hungarica 14.
+- Vàšíček, J. (1999). "Cardinal Arithmetic." [Va99 7.85]
+
+### Online Resources
+- https://erdosproblems.com/1169 — Problem statement and known results
+
+### Mathlib
+- `Mathlib.SetTheory.Ordinal.Arithmetic` — `Ordinal.mul`, transfinite induction
+- `Mathlib.SetTheory.Cardinal.Basic` — `Cardinal.aleph`, `Cardinal.aleph0`
+- `Mathlib.Combinatorics.Ramsey` — finite Ramsey theory
+- `Mathlib.Order.RelClasses` — `StrictMono`, order embeddings
+
+## Metadata
+
+```yaml
+tags:
+  - set-theory
+  - ramsey-theory
+  - ordinals
+  - combinatorics
+  - erdos
+  - formalization
+related_proofs:
+  - erdos-1169
+difficulty: high
+source: gallery-gap
+created: 2026-04-22T14:30:59+02:00
+```

--- a/research/problems/erdos-1169-oq-04/state.md
+++ b/research/problems/erdos-1169-oq-04/state.md
@@ -1,0 +1,25 @@
+# Research State: erdos-1169-oq-04
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-04-22T14:30:59+02:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/feuerbachs-theorem-defs-oq-04/problem.md
+++ b/research/problems/feuerbachs-theorem-defs-oq-04/problem.md
@@ -1,0 +1,114 @@
+# Problem: Feuerbach's Theorem: Connect to Mathlib Affine Geometry Framework
+
+## Statement
+
+### Plain Language
+
+The existing `FeuerbachsTheoremDefs.lean` formalizes the nine-point circle and incircle
+tangency using a **custom coordinate API** (`Point = ℝ × ℝ`, `dist2`, `Triangle` structure).
+OQ-04 asks: can we reformulate these results using **Mathlib's abstract affine and Euclidean
+geometry framework** for a more algebraic, dimension-independent treatment?
+
+Concretely: define the nine-point circle as a `Sphere` (from `Mathlib.Geometry.Euclidean.Sphere`)
+in `EuclideanSpace ℝ (Fin 2)`, prove the nine key points lie on it, and express tangency via
+Mathlib's `dist`-based sphere API rather than the custom `circlesInternallyTangent` predicate.
+
+### Formal Statement
+
+```lean
+-- Desired form: abstract Sphere version of ninePointCircleContainsAllNinePoints
+theorem ninePointCircle_nine_points_sphere
+    (T : Triangle) (hnt : T.is_nondegenerate) :
+    let pts := [T.midpoint_a, T.midpoint_b, T.midpoint_c,
+                T.foot_a, T.foot_b, T.foot_c,
+                T.midpoint_AH, T.midpoint_BH, T.midpoint_CH]
+    ∀ p ∈ pts, dist (toEuclidean T.ninePointCenter) (toEuclidean p) =
+               T.ninePointRadius := by
+  sorry
+
+-- And a sphere-based tangency:
+theorem incircle_tangent_to_ninePointCircle_sphere
+    (T : Triangle) (hnt : T.is_nondegenerate) :
+    dist (toEuclidean T.ninePointCenter) (toEuclidean T.incenter) =
+    T.ninePointRadius - T.inradius := by
+  sorry
+```
+
+## Classification
+
+```yaml
+tier: B
+significance: 7
+tractability: 7
+tags:
+  - geometry
+  - feuerbach
+  - mathlib
+  - affine-geometry
+  - formalization
+  - euclidean-space
+  - sphere
+```
+
+**Significance**: 7/10 — Connects gallery proof to Mathlib's preferred geometry API,
+enabling potential Mathlib contribution and more elegant downstream proofs.
+
+**Tractability**: 7/10 — The hard mathematical work is done; this is primarily a
+translation/bridging task between two Lean APIs. Requires Mathlib familiarity.
+
+## Why This Matters
+
+1. **Mathlib alignment**: Mathlib uses `EuclideanSpace ℝ (Fin n)` and `Sphere` types;
+   the gallery proof uses a bespoke coordinate system. Bridging them enables reuse.
+2. **Dimension abstraction**: Mathlib's framework scales to `Fin n`; a proof in this
+   setting can generalize Feuerbach-like tangency results.
+3. **Reusable API**: `toEuclidean` conversion lemmas would benefit other gallery proofs
+   that currently duplicate the same custom coordinate infrastructure.
+
+## Existing Infrastructure
+
+```
+proofs/Proofs/
+  FeuerbachsTheoremDefs.lean      -- Custom Point/Triangle definitions (base)
+  FeuerbachsTheoremDefsOQ03.lean  -- Feuerbach point uniqueness (uses custom API)
+  FeuerbachsTheoremOQ01.lean      -- Main tangency results
+  FeuerbachsTheorem.lean          -- Assembly
+```
+
+**Key existing types** (in `FeuerbachsTheorem` namespace):
+- `Point = ℝ × ℝ`
+- `dist2 P Q : ℝ` — Euclidean distance (NOT squared, despite the name)
+- `Triangle` structure with `A B C : Point` fields
+- `circlesInternallyTangent` — custom tangency predicate
+
+**Mathlib targets**:
+- `Mathlib.Geometry.Euclidean.Sphere.Basic` — `Sphere` type, membership
+- `Mathlib.Geometry.Euclidean.Circumcenter` — circumcenter, nine-point center
+- `Mathlib.Geometry.Euclidean.Triangle` — triangle defs
+- `EuclideanSpace ℝ (Fin 2)` — the abstract plane
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| `FeuerbachsTheoremDefs.lean` | Source of the custom API to be bridged |
+| `FeuerbachsTheoremDefsOQ03.lean` | Feuerbach point uniqueness (same custom API) |
+| `sperner-ndim` | Example using `EuclideanSpace ℝ (Fin n)` |
+
+## Suggested First Steps
+
+1. **OBSERVE**: Check what Mathlib's `Sphere` type looks like and what lemmas exist for
+   membership/tangency. Search: `Mathlib.Geometry.Euclidean.Sphere.Basic` definitions.
+2. **ORIENT**: Define `toEuclidean : Point → EuclideanSpace ℝ (Fin 2)` and prove
+   `dist (toEuclidean P) (toEuclidean Q) = dist2 P Q` as a bridge lemma.
+3. **DECIDE**: Can we state the nine-point membership theorem directly via this bridge,
+   or do we need to reformulate from scratch using Mathlib types throughout?
+
+## Known Obstacles
+
+- `dist2` naming in `FeuerbachsTheoremDefs.lean` is confusing (it is actual distance,
+  not distance squared); verify before bridging.
+- Mathlib's `EuclideanGeometry.circumcenter` may use a different characterization than
+  the explicit coordinate formula in the gallery.
+- `circlesInternallyTangent` uses a 3-tuple encoding; Mathlib uses `Sphere` with
+  `center : E` and `radius : ℝ`.

--- a/research/problems/feuerbachs-theorem-defs-oq-04/state.md
+++ b/research/problems/feuerbachs-theorem-defs-oq-04/state.md
@@ -1,0 +1,27 @@
+# Current State
+
+**Phase**: NEW
+**Since**: 2026-04-22T13:03:46.505Z
+**Iteration**: 1
+
+## Current Focus
+
+Initial exploration of the problem.
+
+## Active Approach
+
+None yet.
+
+## Blockers
+
+None.
+
+## Next Action
+
+Begin problem exploration.
+
+## Attempt Counts
+
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0

--- a/research/problems/lebesgue-measure-oq-01-oq-01-oq-01/state.md
+++ b/research/problems/lebesgue-measure-oq-01-oq-01-oq-01/state.md
@@ -3,8 +3,16 @@
 ## Current State
 **Phase**: OBSERVE
 **Path**: full
-**Since**: 2026-04-21T22:19:23+02:00
+**Since**: 2026-04-22T14:10:00+02:00
 **Iteration**: 1
+
+## Seeker Selection (2026-04-22)
+**Selected by**: Seeker agent (ranking algorithm)
+**Composite score**: 77 (EMPTY knowledge tier, tractability=7, significance=7)
+**Pool status at selection**: 81 available (threshold: 15) — ADEQUATE
+**Selection rationale**: Top EMPTY-knowledge candidate; Thomae's function + Lebesgue criterion
+  is well-scoped, pedagogically significant, and Mathlib has all needed measure theory
+  (MeasureTheory.Measure.countable_zero, Riemann integrability criterion).
 
 ## Current Focus
 Initial problem understanding. Read problem.md and gather context.

--- a/research/problems/lhopital-oq-04/knowledge.md
+++ b/research/problems/lhopital-oq-04/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: lhopital-oq-04
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/lhopital-oq-04/literature/README.md
+++ b/research/problems/lhopital-oq-04/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for lhopital-oq-04
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/lhopital-oq-04/problem.md
+++ b/research/problems/lhopital-oq-04/problem.md
@@ -1,0 +1,131 @@
+# Problem: L'Hôpital's Rule — Relationship to Taylor Series
+
+**Slug**: lhopital-oq-04
+**Created**: 2026-04-22
+**Status**: Active
+**Source**: gallery-gap (L'Hôpital's Rule OQ-04)
+
+## Problem Statement
+
+### Formal Statement
+
+For analytic functions $f, g$ with $f(a) = g(a) = 0$ and $g'(a) \neq 0$, L'Hôpital's rule gives:
+
+$$\lim_{x \to a} \frac{f(x)}{g(x)} = \frac{f'(a)}{g'(a)}$$
+
+The Taylor series perspective explains this: near $x = a$:
+$$f(x) = f'(a)(x-a) + \frac{f''(a)}{2!}(x-a)^2 + \cdots$$
+$$g(x) = g'(a)(x-a) + \frac{g''(a)}{2!}(x-a)^2 + \cdots$$
+
+So $f(x)/g(x) \to f'(a)/g'(a)$ because the leading-order terms dominate.
+
+**Goal**: Formalize this connection in Lean 4 — either:
+1. Prove L'Hôpital's rule *via* Taylor expansion (as an alternative to the standard MVT proof), OR
+2. Prove that repeated application of L'Hôpital on $f/g$ (when higher derivatives also vanish) is equivalent to comparing Taylor coefficients.
+
+### Plain Language
+
+L'Hôpital's rule and Taylor series are two sides of the same coin for $0/0$ indeterminate forms. The standard Lean proof of L'Hôpital uses the Mean Value Theorem. But there's a cleaner story: if both $f$ and $g$ vanish at $a$, then near $a$ they behave like their derivatives, because their Taylor expansions start at the linear term. This insight can be made precise and formalized.
+
+### Why This Matters
+
+1. **Pedagogical value**: The Taylor series derivation of L'Hôpital is more illuminating than the MVT proof
+2. **Mathlib gap**: Mathlib has `HasDerivAt.lhopital_zero_right` but may lack the Taylor series connection
+3. **Generalization**: Iterated L'Hôpital (when $f^{(k)}(a) = g^{(k)}(a) = 0$ for $k < n$) is exactly comparing $n$th Taylor coefficients — formalizing this cleanly would be a useful Mathlib lemma
+
+## Known Results
+
+### What's Already Proven
+
+- `lhopital` (gallery): L'Hôpital's rule for $0/0$ via MVT — verified
+- `HasDerivAt.lhopital_zero_right` (Mathlib): L'Hôpital for one-sided limits
+- `taylorWithRemainder` (Mathlib): Taylor's theorem with Lagrange remainder
+
+### What's Still Open
+
+- Formalization of the Taylor series *derivation* of L'Hôpital (alternative proof)
+- The iterated case: $k$-fold L'Hôpital = $k$th Taylor coefficient ratio
+- Clean Lean statement connecting `HasDerivAt` with Taylor expansion coefficients
+
+### Our Goal
+
+Formalize the precise statement: for $f, g \in C^\infty(a)$ with $f(a) = g(a) = 0$, the limit $\lim_{x \to a} f(x)/g(x) = f'(a)/g'(a)$ follows directly from Taylor's theorem applied to $f$ and $g$.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `lhopital` | Parent proof (MVT-based) | `HasDerivAt`, Mean Value Theorem |
+| `basel-problem` | Uses Taylor series machinery | `Real.sin`, `Real.cos` Taylor expansion |
+| `binomial-theorem` | Polynomial expansion techniques | `Finset.sum`, ring operations |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Direct Taylor derivation**: Use Mathlib's `taylorWithRemainder` to write $f(x) = f'(a)(x-a) + O((x-a)^2)$ and $g(x) = g'(a)(x-a) + O((x-a)^2)$, then divide and take the limit.
+   - Why it might work: All components are in Mathlib — `taylorWithRemainder`, limit theorems, continuity
+   - Risk: Division of asymptotic expansions in Lean requires care; need to handle the case $g'(a) \neq 0$
+
+2. **Iterated case formalization**: Prove that if $f^{(k)}(a) = 0$ for $k = 0, \ldots, n-1$ and $g^{(n)}(a) \neq 0$, then $\lim_{x \to a} f/g = f^{(n)}(a)/g^{(n)}(a)$.
+   - Why it might work: Induction on the vanishing order, using L'Hôpital at each step
+   - Risk: Requires n-fold differentiability and careful index management
+
+3. **Coefficient comparison lemma**: Prove `taylorCoeff_ratio`: if $f(a) = 0$ and $g(a) = 0$, then $f(x)/g(x) \to \text{taylorCoeff}(f, a, 1) / \text{taylorCoeff}(g, a, 1)$.
+   - Why it might work: Clean abstract statement connecting two existing Mathlib APIs
+   - Risk: `taylorCoeff` notation in Mathlib may need adaptation
+
+### Key Difficulties
+
+- Lean's `Filter.Tendsto` limit framework vs pointwise limits needs alignment
+- Division in a limit: need to show $g'(a) \neq 0$ prevents denominator collapse
+- `taylorWithRemainder` gives error term; need to show error is $o(x-a)$ in the limit
+
+### What Would a Proof Need?
+
+- `Real.differentiableAt_taylorWithRemainder` or similar
+- `Filter.Tendsto.div_const` — limit of quotient
+- `HasDerivAt` for both $f$ and $g$ at $a$
+- `isLittleO` framework for the error bound
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- L'Hôpital and Taylor series are both mature Mathlib topics
+- `taylorWithRemainder` and `HasDerivAt` are accessible APIs
+- The connection is mathematically straightforward (asymptotic dominance)
+- The main challenge is Lean bookkeeping for the error terms
+
+## References
+
+### Papers
+- Rudin, W. *Principles of Mathematical Analysis*, 3rd ed., Chapter 5 — L'Hôpital and Taylor
+
+### Mathlib
+- `Analysis.Calculus.MeanValue` — Mean Value Theorem (used by existing L'Hôpital)
+- `Analysis.Calculus.Taylor` — Taylor's theorem with remainder
+- `Mathlib.Analysis.Calculus.LHopital` — Existing L'Hôpital formalization
+- `Filter.isLittleO` — Asymptotic notation
+
+## Metadata
+
+```yaml
+tags:
+  - analysis
+  - calculus
+  - lhopital
+  - taylor-series
+  - formalization
+  - mathlib
+related_proofs:
+  - lhopital
+  - basel-problem
+difficulty: medium
+source: gallery-gap
+created: 2026-04-22
+```
+
+**Significance**: 7/10
+**Tractability**: 7/10

--- a/research/problems/lhopital-oq-04/state.md
+++ b/research/problems/lhopital-oq-04/state.md
@@ -1,0 +1,25 @@
+# Research State: lhopital-oq-04
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-04-22T15:01:13+02:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/shannon-source-coding-oq-04-incomplete-01/knowledge.md
+++ b/research/problems/shannon-source-coding-oq-04-incomplete-01/knowledge.md
@@ -1,0 +1,39 @@
+# Knowledge Base: shannon-source-coding-oq-04-incomplete-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+The Lean file `Proofs/ShannonSourceCodingOQ04.lean` contains a 230-line formalization of the
+method of types proof of Shannon's source coding theorem. The infrastructure is solid:
+
+**Proved theorems (0-sorry):**
+- `empDist_sum`: ∑ empDist x = n
+- `type_class_partition`: sequences partition into exactly one type class each
+- `count_types_le`: ≤ (n+1)^k distinct types
+- `total_sequences_eq`: k^n total sequences
+- `empEntropy_eq_shannonEntropy`: empirical entropy = Shannon entropy of normalized type
+- `log_typeProb_eq`: log Q^n(x) = -n H(Q) for any x ∈ T_f
+
+**Open sorries:**
+1. `type_class_size_eq_multinomial`: |T_f| = n!/∏(f_i)! — multinomial bijection (~line 67)
+2. `type_class_size_le_entropy_pow`: |T_f| ≤ exp(n H(Q)) — from probability sum (~line 172)
+3. `dominant_type_lower_bound`: max type class size ≥ k^n/(n+1)^k — pigeonhole (~line 205)
+4. `source_coding_achievability_mot`: rate H(p) achievable — full convergence (~line 225)
+
+**Key insight already exploited**: Every x ∈ T_f has Q^n(x) = exp(-n H(Q)).
+This is the bridge between the combinatorial and probabilistic views.
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/shannon-source-coding-oq-04-incomplete-01/problem.md
+++ b/research/problems/shannon-source-coding-oq-04-incomplete-01/problem.md
@@ -1,0 +1,140 @@
+# Problem: Complete Method of Types: Alternative Proof of Source Coding Theorem
+
+**Slug**: shannon-source-coding-oq-04-incomplete-01
+**Created**: 2026-04-22
+**Status**: Active
+**Source**: gallery-incomplete
+
+## Problem Statement
+
+### Formal Statement
+
+`shannon-source-coding-oq-04` (`Proofs/ShannonSourceCodingOQ04.lean`) has 4 sorries:
+
+1. **`type_class_size_eq_multinomial`** (line ~67): Prove `|T_f| = n! / ∏(f_i)!` via a bijection between the type class and multinomial arrangements.
+
+2. **`type_class_size_le_entropy_pow`** (line ~172): Prove `|T_f| ≤ exp(n H(Q))` using the identity that every `x ∈ T_f` has `Q^n(x) = exp(-n H(Q))` and probabilities sum to 1.
+
+3. **`dominant_type_lower_bound`** (line ~205): Prove the dominant type class has `≥ k^n / (n+1)^k` elements via `Finset.card_le_sum` pigeonhole.
+
+4. **`source_coding_achievability_mot`** (line ~225): Formal achievability at rate H(p) using the dominant type bound and convergence.
+
+### Plain Language
+
+The method of types proof of Shannon's source coding theorem exists in the gallery with good infrastructure (entropy definitions proved, log-probability identity proved, type class partition proved) but 4 key lemmas remain as sorries. The goal is to close all 4 sorries using Mathlib's combinatorics and measure theory APIs.
+
+### Why This Matters
+
+- Completes an otherwise solid formalization of the Csiszár-Körner method of types (1981)
+- Closes the gap between the probabilistic AEP proof and the combinatorial proof
+- The type class size bound is foundational for channel coding exponents and large deviations (Sanov's theorem)
+
+## Known Results
+
+### What's Already Proven (0-sorry in the file)
+
+- `empDist_sum`: empirical distribution sums to block length n
+- `type_class_partition`: every sequence belongs to exactly one type class
+- `count_types_le`: at most `(n+1)^k` distinct empirical distributions
+- `total_sequences_eq`: `k^n` total sequences over `Fin k` alphabet
+- `empEntropy_eq_shannonEntropy`: empirical entropy matches Shannon entropy of normalized type
+- `log_typeProb_eq`: log-probability of any x ∈ T_f equals `-n * H(Q)` where Q = f/n
+
+### What's Still Open (the 4 sorries)
+
+- `type_class_size_eq_multinomial`: bijection proof (~60 lines) — explicit counting argument
+- `type_class_size_le_entropy_pow`: sum-of-products identity via ENNReal/NNReal lifting
+- `dominant_type_lower_bound`: pigeonhole on `Finset` with polynomial denominator
+- `source_coding_achievability_mot`: convergence argument for rate achievability
+
+### Our Goal
+
+Close all 4 sorries in `Proofs/ShannonSourceCodingOQ04.lean`, producing a complete Lean 4 formalization of the method of types source coding proof.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| shannon-source-coding | Parent proof (AEP-based) | MeasureTheory, probabilistic arguments |
+| shannon-source-coding-oq-04 | The incomplete proof we're completing | Method of types, combinatorics |
+| shannon-source-coding-oq-02 | Huffman coding optimality | Optimal codes, entropy bounds |
+| shannon-entropy | Core entropy formalism | Real.log, Finset.sum |
+
+## Initial Thoughts
+
+### Approach to Each Sorry
+
+1. **`type_class_size_eq_multinomial`**:
+   - Build an explicit bijection `Fin (n! / ∏ f_i!) ≃ typeClass f`
+   - Or use `Fintype.card_perm` and `Fintype.card_subtype` to count permutations
+   - Mathlib: `Nat.multinomial`, `Finset.card_pi`, `Equiv.Perm`
+
+2. **`type_class_size_le_entropy_pow`**:
+   - Key: `∑_{x ∈ T_f} Q^n(x) ≤ 1` (sub-probability bound)
+   - Since each term equals `exp(-n H(Q))` (proved by `log_typeProb_eq`), we get `|T_f| * exp(-n H(Q)) ≤ 1`
+   - Mathlib: `Finset.sum_le_one`, `NNReal.sum_le_one`, ENNReal lifting
+   - This is likely the most direct sorry via `mul_le_one`
+
+3. **`dominant_type_lower_bound`**:
+   - Pigeonhole: total `k^n` sequences split among `≤ (n+1)^k` type classes
+   - The largest class has `≥ k^n / (n+1)^k` elements
+   - Mathlib: `Finset.exists_lt_card_fiber_of_nsmul_lt_card` or direct pigeonhole
+
+4. **`source_coding_achievability_mot`**:
+   - Formal rate: encode dominant type class in `⌈log |dominant_class|⌉` bits
+   - From sorry 3: this is `≤ n H(p) + k log(n+1)` bits, achieving rate H(p) as n → ∞
+   - May need a `Filter.Tendsto` argument or just an explicit bound
+
+### Key Difficulties
+
+- ENNReal vs NNReal vs Real arithmetic for the probability sum
+- The multinomial bijection requires careful counting infrastructure
+- `source_coding_achievability_mot` may be the hardest if it needs formal limit arguments
+
+### What Would a Proof Need?
+
+- `Finset.sum_congr` to leverage the equal-probability property
+- `div_le_iff` and `Nat.cast_le` for the pigeonhole argument
+- `Real.rpow_le_rpow` for the exponential bounds
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- Infrastructure is in place (the hard mathematical definitions are done)
+- The 4 sorries have clear mathematical statements and known proof paths
+- Sorries 2 and 3 (entropy bound + pigeonhole) are likely tractable
+- Sorry 1 (multinomial bijection) and sorry 4 (achievability) are more involved but doable
+- Good candidates for Aristotle after human-assisted setup
+
+## References
+
+### Mathlib
+- `Mathlib.Data.Nat.Choose.Multinomial` — `Nat.multinomial`
+- `Mathlib.Analysis.SpecialFunctions.Log.Basic` — `Real.log_pow`, `Real.log_prod`
+- `Mathlib.Data.Fintype.Card` — `Fintype.card_pi`, `Finset.card_le_sum`
+- `Mathlib.MeasureTheory.Probability.Basic` — probability sum constraints
+
+### Literature
+- Csiszár, I., Körner, J. (1981): "Information Theory: Coding Theorems for Discrete Memoryless Systems" — Chapter 2
+- Cover, T.M., Thomas, J.A. (2006): "Elements of Information Theory" — Chapter 11
+
+## Metadata
+
+```yaml
+tags:
+  - information-theory
+  - combinatorics
+  - method-of-types
+  - entropy
+  - source-coding
+  - completion
+  - sorries
+related_proofs:
+  - shannon-source-coding
+  - shannon-source-coding-oq-04
+difficulty: medium
+source: gallery-incomplete
+created: 2026-04-22
+```

--- a/research/problems/shannon-source-coding-oq-04-incomplete-01/state.md
+++ b/research/problems/shannon-source-coding-oq-04-incomplete-01/state.md
@@ -1,0 +1,31 @@
+# Research State: shannon-source-coding-oq-04-incomplete-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-04-22
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context from the Lean source file.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read `Proofs/ShannonSourceCodingOQ04.lean` to understand the exact sorry locations and types,
+then move to ORIENT phase to identify Mathlib lemmas for each of the 4 sorries.
+
+Priority order:
+1. `type_class_size_le_entropy_pow` (likely most direct via `mul_le_one`)
+2. `dominant_type_lower_bound` (pigeonhole on Finset)
+3. `type_class_size_eq_multinomial` (multinomial bijection)
+4. `source_coding_achievability_mot` (convergence / rate bound)

--- a/research/registry.json
+++ b/research/registry.json
@@ -15768,11 +15768,11 @@
     },
     {
       "slug": "erdos-1169-oq-04",
-      "phase": "COMPLETED",
+      "phase": "OBSERVE",
       "path": "full",
       "started": "2026-04-13T00:54:20.757Z",
       "status": "graduated",
-      "lastUpdate": "2026-04-13T22:43:37.319Z",
+      "lastUpdate": "2026-04-22T14:30:59+02:00",
       "completed": "2026-04-13T22:43:37.319Z"
     },
     {
@@ -16499,11 +16499,11 @@
     },
     {
       "slug": "binomial-theorem-oq-03-oq-01",
-      "phase": "COMPLETED",
+      "phase": "OBSERVE",
       "path": "full",
       "started": "2026-04-14T17:49:44.227Z",
       "status": "graduated",
-      "lastUpdate": "2026-04-14T21:25:05.927Z",
+      "lastUpdate": "2026-04-22T14:37:37+02:00",
       "completed": "2026-04-14T21:25:05.927Z"
     },
     {


### PR DESCRIPTION
## Problem Selection Report

**Date**: 2026-04-22
**Mode**: SELECT
**Pool Status**: 24 available, 559 in-progress, 1401 completed

## Selected Problem

- **ID**: `feuerbachs-theorem-defs-oq-04`
- **Name**: Feuerbach's Theorem: Connect to Mathlib Affine Geometry Framework
- **Tier**: B
- **Significance**: 7/10
- **Tractability**: 7/10
- **Knowledge Score**: WEAK (stub workspace, no prior research)
- **Status**: available

## Selection Rationale

1. Highest composite score among 24 available candidates (-923: tractability 7 × 10 + significance 7, WEAK tier)
2. Tied with minkowski-fundamental-theorem-oq-04 but that problem is an API comparison survey, better suited for Scout
3. Geometry domain not selected in last 6 rounds (diverse from calculus, probability, set theory, algebra, information theory, analysis)
4. Mathematically substantive: bridging custom coordinate proof to Mathlib's abstract EuclideanSpace/Sphere framework

## Problem Summary

The existing `FeuerbachsTheoremDefs.lean` uses a custom `Point = ℝ × ℝ` coordinate API.
OQ-04 asks to reformulate in Mathlib's `EuclideanSpace ℝ (Fin 2)` / `Sphere` framework.
Key first step: define `toEuclidean : Point → EuclideanSpace ℝ (Fin 2)` bridge lemma.

## Pool Health

- Pool depth: **adequate** (24 available ≥ 15 threshold)
- Next refresh: recommended after researchers claim 10+ problems

## Labels

research