### PR TITLE
Research: sperner-ndim-oq-05 — prove gridAdj_ne for gridComplex

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ02.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ02.lean
@@ -859,7 +859,7 @@ private lemma take_at_column_entry (l : LPath) (x : ℕ)
           | zero => rfl
           | succ _ => rfl
         rw [hce, show x' + 1 + colEntry l' x' = (x' + colEntry l' x') + 1 from by omega]
-        simp only [List.take_succ_cons, List.countP_cons, Bool.false_eq_false, decide_true]
+        simp only [List.take_succ_cons, List.countP_cons, decide_true]
         rw [ih x' hx']
     | true =>
       -- l = true :: l'; the first element is a North step
@@ -874,8 +874,7 @@ private lemma take_at_column_entry (l : LPath) (x : ℕ)
           simp [colEntry, northBeforeEast]
         rw [hce, show x' + 1 + (1 + colEntry l' (x' + 1)) =
             ((x' + 1) + colEntry l' (x' + 1)) + 1 from by omega]
-        simp only [List.take_succ_cons, List.countP_cons, Bool.true_eq_false, decide_false,
-          Bool.false_eq_true]
+        simp only [List.take_succ_cons, List.countP_cons, decide_false]
         exact ih (x' + 1) hx'
 
 /-- Between the x-th and (x+1)-th East steps, all list elements are North (true).
@@ -916,7 +915,7 @@ private lemma take_east_count_within_column (l : LPath) (x h : ℕ)
           simp [List.countP_cons] at hx; omega
         -- take(false :: l', (x'+1) + h) = false :: take(l', x' + h)
         rw [show x' + 1 + h = (x' + h) + 1 from by omega]
-        simp only [List.take_succ_cons, List.countP_cons, Bool.false_eq_false, decide_true]
+        simp only [List.take_succ_cons, List.countP_cons, decide_true]
         rw [ih x' h hx' hlow hhigh]
     | true =>
       cases x with
@@ -929,8 +928,7 @@ private lemma take_east_count_within_column (l : LPath) (x h : ℕ)
         | zero => simp [List.take]
         | succ h' =>
           -- take(true :: l', h'+1) = true :: take(l', h')
-          simp only [List.take_succ_cons, List.countP_cons, Bool.true_eq_false, decide_false,
-            Bool.false_eq_true]
+          simp only [List.take_succ_cons, List.countP_cons, decide_false]
           -- Need: take(l', h').countP(false) = 0
           -- colEntry(true::l', 0) = 0, colEntry(true::l', 1) = 1 + colEntry l' 1
           -- So 0 ≤ h'+1 ≤ 1 + colEntry l' 1, meaning h' ≤ colEntry l' 1
@@ -955,8 +953,7 @@ private lemma take_east_count_within_column (l : LPath) (x h : ℕ)
         have hh_pos : h ≥ 1 := by omega
         -- take(true :: l', (x'+1) + h) = true :: take(l', x' + h)
         rw [show x' + 1 + h = (x' + (h - 1)) + 1 + 1 from by omega]
-        simp only [List.take_succ_cons, List.countP_cons, Bool.true_eq_false, decide_false,
-          Bool.false_eq_true]
+        simp only [List.take_succ_cons, List.countP_cons, decide_false]
         rw [show x' + (h - 1) + 1 = x' + 1 + (h - 1) from by omega]
         exact ih (x' + 1) (h - 1) hx' (by omega) (by omega)
 
@@ -1642,12 +1639,12 @@ private lemma colEntry_at_end {m n : ℕ} (P : PathMN m n) :
       cases k with
       | zero => simp [List.countP_cons] at hk
       | succ k' =>
-        simp only [northBeforeEast, List.countP_cons, Bool.false_eq_true, decide_false,
+        simp only [northBeforeEast, List.countP_cons, decide_false,
           Nat.add_zero] at hk ⊢
         exact ih k' (by omega)
     | true =>
-      simp only [northBeforeEast, List.countP_cons, Bool.true_eq_true, decide_true,
-        Bool.true_eq_false, decide_false, Nat.add_zero] at hk ⊢
+      simp only [northBeforeEast, List.countP_cons, decide_true,
+        decide_false, Nat.add_zero] at hk ⊢
       rw [ih k (by omega)]
 
 /-- The shared y-value is within path i's y-range at the canonical crossing column. -/

--- a/proofs/Proofs/CantorDiagonalizationOQ04OQ03Aristotle.lean
+++ b/proofs/Proofs/CantorDiagonalizationOQ04OQ03Aristotle.lean
@@ -43,6 +43,22 @@ So: f b = ⨆ n, f(c n) ≥ f(c 0) = f a.
     Proof: use the step chain c(0)=a, c(n+1)=b with sup=b and apply ω-continuity. -/
 theorem omega_continuous_monotone_ari {α : Type*} [CompleteLattice α] {f : α → α}
     (hf : OmegaContinuous f) : Monotone f := by
-  sorry
+  intro a b hab
+  -- Build the step chain c(0) = a, c(n+1) = b
+  have hc_asc : ∀ n : ℕ, (fun n => if n = 0 then a else b) n ≤
+                           (fun n => if n = 0 then a else b) (n + 1) := fun n => by
+    rcases n with _ | n <;> simp [hab]
+  -- The supremum of this chain is b
+  have hc_sup : ⨆ n : ℕ, (if n = 0 then a else b) = b := by
+    apply le_antisymm
+    · exact iSup_le fun n => by rcases n with _ | n <;> simp [hab]
+    · exact le_iSup_of_le 1 (by simp)
+  -- Apply ω-continuity: f(⨆ c) = ⨆ f(c)
+  have h := hf _ hc_asc
+  rw [hc_sup] at h
+  -- f a = f(c 0) ≤ ⨆ f(c) = f b
+  calc f a = f (if (0 : ℕ) = 0 then a else b) := by simp
+       _ ≤ ⨆ n, f (if n = 0 then a else b) := le_iSup _ 0
+       _ = f b := h.symm
 
 end CantorDiagonalizationOQ04OQ03Aristotle

--- a/proofs/Proofs/SpernerGrid.lean
+++ b/proofs/Proofs/SpernerGrid.lean
@@ -640,7 +640,7 @@ noncomputable def GridSimplex.interiorFlip
           -- new_v.coords miss = v_prev.coords miss - 1
           have h_new : new_v.coords s.miss = v_prev.coords s.miss - 1 :=
             BaryPoint.transfer_coords_dec v_prev (s.incDir k) s.miss h_ne h_miss_pos
-          rw [h_new]; omega
+          omega
         · by_cases hjk : j_step = k
           · -- Case j_step = k
             have hcs_eq : (j_step.castSucc : Fin (d + 1)) = ⟨k.val, by omega⟩ := by
@@ -837,8 +837,13 @@ noncomputable def GridSimplex.boundaryFlip0
               -- Goal: new_v.coords inc0 = (s.verts ⟨j_step.val+1,_⟩).coords inc0 + 1
               -- where j_step.val + 1 = d, so s.verts ⟨d,_⟩ = last_v
               -- s.verts ⟨j_step.val+1,_⟩ = last_v since j_step.val+1=d
-              convert BaryPoint.transfer_coords_inc last_v inc0 s.miss h_ne h_pos using 1
-              congr 1; ext; simp; omega
+              have hval : j_step.val = d - 1 := by omega
+              have hlv : s.verts ⟨j_step.castSucc.val + 1, by omega⟩ = last_v := by
+                show s.verts ⟨j_step.castSucc.val + 1, by omega⟩ =
+                  s.verts ⟨d, Nat.lt_succ_iff.mpr le_rfl⟩
+                congr 1; ext; simp [Fin.castSucc]; omega
+              rw [hlv]
+              exact BaryPoint.transfer_coords_inc last_v inc0 s.miss h_ne h_pos
           step_dec := by
             intro j_step
             by_cases hj_mid : j_step.val + 1 < d
@@ -862,9 +867,12 @@ noncomputable def GridSimplex.boundaryFlip0
                          dite_true, dite_false]
               have h_new : new_v.coords s.miss = last_v.coords s.miss - 1 :=
                 BaryPoint.transfer_coords_dec last_v inc0 s.miss h_ne h_pos
-              convert_to last_v.coords s.miss = new_v.coords s.miss + 1
-              · congr 1; ext; simp; omega
-              · rw [h_new]; have := h_pos; omega
+              have hlv : s.verts ⟨j_step.castSucc.val + 1, by omega⟩ = last_v := by
+                show s.verts ⟨j_step.castSucc.val + 1, by omega⟩ =
+                  s.verts ⟨d, Nat.lt_succ_iff.mpr le_rfl⟩
+                congr 1; ext; simp [Fin.castSucc]; omega
+              rw [hlv]
+              omega
           step_same := by
             intro j_step j hj_inc hj_miss
             simp only [new_incDir] at hj_inc
@@ -964,9 +972,11 @@ noncomputable def GridSimplex.boundaryFlipLast
               -- Goal: v0.coords last_inc = new_v.coords last_inc + 1
               have h_new : new_v.coords last_inc = v0.coords last_inc - 1 :=
                 BaryPoint.transfer_coords_dec v0 s.miss last_inc (Ne.symm h_ne) h_pos
-              convert_to v0.coords last_inc = new_v.coords last_inc + 1
-              · congr 1; ext; simp; omega
-              · rw [h_new]; have := h_pos; omega
+              have hv0 : s.verts ⟨j_step.succ.val - 1, by omega⟩ = v0 := by
+                show s.verts ⟨j_step.succ.val - 1, by omega⟩ = s.verts 0
+                congr 1; ext; simp [Fin.val_succ]; omega
+              rw [hv0]
+              omega
             · -- Later step
               simp only [hj0, ite_false]
               have hcs_nz : ¬(j_step.castSucc.val = 0) := by simp [Fin.castSucc]; exact hj0
@@ -992,9 +1002,11 @@ noncomputable def GridSimplex.boundaryFlipLast
                          ite_true, ite_false]
               have h_new : new_v.coords s.miss = v0.coords s.miss + 1 :=
                 BaryPoint.transfer_coords_inc v0 s.miss last_inc (Ne.symm h_ne) h_pos
-              convert_to new_v.coords s.miss = v0.coords s.miss + 1
-              · congr 1; ext; simp; omega
-              · exact h_new
+              have hv0eq : s.verts ⟨j_step.succ.val - 1, by omega⟩ = v0 := by
+                show s.verts ⟨j_step.succ.val - 1, by omega⟩ = s.verts 0
+                congr 1; ext; simp [Fin.val_succ]; omega
+              rw [hv0eq]
+              exact h_new
             · -- Later step
               have hcs_nz : ¬(j_step.castSucc.val = 0) := by simp [Fin.castSucc]; exact hj0
               have hss_nz : ¬(j_step.succ.val = 0) := by simp [Fin.succ]
@@ -1082,6 +1094,52 @@ noncomputable def gridAdj (d N : ℕ)
     let step : Fin d := ⟨k.val, hk_lt_d⟩
     some (s.interiorFlip step (by simp [step]; exact hk_pos))
 
+-- Helper lemmas for Section VII
+
+/-- The incDir at position k_prev = k-1 in the interior flip equals the
+original incDir at k. Used to detect that s ≠ s' after interiorFlip. -/
+private lemma interiorFlip_incDir_kprev (s : GridSimplex d N)
+    (k : Fin d) (hk : 0 < k.val) :
+    (s.interiorFlip k hk).1.incDir ⟨k.val - 1, by omega⟩ = s.incDir k := by
+  simp [GridSimplex.interiorFlip, Fin.ext_iff]
+
+/-- In the interiorFlip, all vertices except index k are preserved. -/
+private lemma interiorFlip_verts_other (s : GridSimplex d N)
+    (k : Fin d) (hk : 0 < k.val)
+    (j : Fin (d + 1)) (hj : j.val ≠ k.val) :
+    (s.interiorFlip k hk).1.verts j = s.verts j := by
+  simp [GridSimplex.interiorFlip, Fin.ext_iff, hj]
+
+/-- If boundaryFlip0 succeeds and returns (s', k'), then d ≠ 0 and
+s' maps vertex 0 to s.verts 1 (the cyclic shift property). -/
+private lemma boundaryFlip0_verts_zero (s : GridSimplex d N)
+    (s' : GridSimplex d N) (k' : Fin (d + 1))
+    (h : s.boundaryFlip0 = some (s', k')) :
+    ∃ hd : d ≠ 0, s'.verts ⟨0, by omega⟩ = s.verts ⟨1, by omega⟩ := by
+  simp only [GridSimplex.boundaryFlip0] at h
+  split_ifs at h with h_pos hd
+  · simp only [Option.some.injEq, Prod.mk.injEq] at h
+    obtain ⟨hs', _⟩ := h
+    refine ⟨hd, ?_⟩
+    have := congr_fun (congr_arg GridSimplex.verts hs') (⟨0, by omega⟩ : Fin (d + 1))
+    simp [Nat.pos_of_ne_zero hd] at this
+    exact this.symm
+
+/-- If boundaryFlipLast succeeds and returns (s', k'), then d ≠ 0 and
+s' maps vertex 1 to s.verts 0 (the cyclic shift property). -/
+private lemma boundaryFlipLast_verts_one (s : GridSimplex d N)
+    (s' : GridSimplex d N) (k' : Fin (d + 1))
+    (h : s.boundaryFlipLast = some (s', k')) :
+    ∃ hd : d ≠ 0, s'.verts ⟨1, by omega⟩ = s.verts ⟨0, by omega⟩ := by
+  simp only [GridSimplex.boundaryFlipLast] at h
+  split_ifs at h with hd h_pos
+  · simp only [Option.some.injEq, Prod.mk.injEq] at h
+    obtain ⟨hs', _⟩ := h
+    refine ⟨hd, ?_⟩
+    have := congr_fun (congr_arg GridSimplex.verts hs') (⟨1, by omega⟩ : Fin (d + 1))
+    simp at this
+    exact this.symm
+
 -- ============================================================
 -- SECTION VII: CellComplex Instance
 -- ============================================================
@@ -1110,7 +1168,43 @@ theorem gridAdj_ne (s : GridSimplex d N)
     (k' : Fin (d + 1))
     (h : gridAdj d N s k = some (s', k')) :
     s ≠ s' := by
-  sorry
+  simp only [gridAdj] at h
+  split_ifs at h with hk0 hkd
+  · -- k.val = 0: uses boundaryFlip0; vertex 0 maps to vertex 1
+    obtain ⟨hd, hv⟩ := boundaryFlip0_verts_zero s s' k' h
+    intro heq
+    rw [← heq] at hv
+    have hinj := s.verts_injective hv
+    simp [Fin.ext_iff] at hinj
+  · -- k.val = d: uses boundaryFlipLast; vertex 1 maps to vertex 0
+    obtain ⟨hd, hv⟩ := boundaryFlipLast_verts_one s s' k' h
+    intro heq
+    rw [← heq] at hv
+    have hinj := s.verts_injective hv
+    simp [Fin.ext_iff] at hinj
+  · -- Interior: the incDir at k-1 changes in s' but not s
+    simp only [Option.some.injEq] at h
+    have hklt : k.val < d := by omega
+    have hkpos : 0 < k.val := by omega
+    let step : Fin d := ⟨k.val, hklt⟩
+    let kp : Fin d := ⟨k.val - 1, by omega⟩
+    -- Extract s' = (s.interiorFlip step hkpos).1
+    have hs' : (s.interiorFlip step hkpos).1 = s' := by
+      simpa using (Prod.ext_iff.mp h).1
+    -- In s, incDir(kp) ≠ incDir(step) by injectivity
+    have hkpne : kp ≠ step := by
+      simp only [kp, step, ne_eq, Fin.mk.injEq]; omega
+    have h_ne : s.incDir kp ≠ s.incDir step :=
+      fun heq => hkpne (s.inc_injective heq)
+    -- If s = s', then s.incDir kp = s'.incDir kp
+    -- But s'.incDir kp = s.incDir step (by interiorFlip_incDir_kprev)
+    -- Contradiction with h_ne
+    intro heq
+    apply h_ne
+    have h1 : s.incDir kp = s'.incDir kp :=
+      congr_fun (congr_arg GridSimplex.incDir heq) kp
+    rw [h1, ← hs']
+    exact interiorFlip_incDir_kprev s step hkpos
 
 /-- The grid CellComplex: the standard triangulation of Δ_N
 satisfies the abstract adjacency axioms. -/
@@ -1211,8 +1305,8 @@ theorem sperner_grid (d N : ℕ) (hN : 0 < N)
     (hc : IsSperner c) :
     ∃ s : (gridComplex d N).Cell,
       CellComplex.IsPanchromatic c
-        (gridComplex d N) s :=
-  CellComplex.sperner c (gridComplex d N)
+        (gridComplex d N) s := by
+  exact CellComplex.sperner c (gridComplex d N)
     (boundary_doors_odd d N hN c hc)
 
 end SpernerGrid

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/knowledge.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/knowledge.md
@@ -271,6 +271,49 @@ self-contained and does not use LGV infrastructure.
 
 ---
 
+---
+
+## Session 2026-04-22 (Session 5) - Bool Simp Fix + Deep Sorry Analysis
+
+**Mode**: REVISIT
+**Outcome**: PROGRESS — fixed Lean4/Mathlib API build failure in `BallotProblemOQ03OQ02.lean`
+
+### What I Did
+
+1. Diagnosed build failures in `BallotProblemOQ03OQ02.lean` caused by removed Bool simp lemmas
+2. Fixed 5 locations: removed `Bool.false_eq_false`, `Bool.true_eq_false`, `Bool.false_eq_true`,
+   `Bool.true_eq_true` from `simp only` calls — modern Lean4 handles these by kernel reduction
+3. Analyzed all 4 remaining sorries in `BallotProblemOQ03OQ01OQ02.lean`:
+   - `ni_count_eq_syt_count` (line 235): RSK bijection, ~200-300 lines
+   - `lgv_det_factors_as_hook_quotient` (line 245): Vandermonde det identity, ~200-300 lines
+   - `card_SYT_twoRectYD` (line 1243): Catalan number bijection, ~200-300 lines
+   - `hook_length_formula` (line 219): depends on the above two
+4. Confirmed: `hook_length_formula_two_rect` is already proved conditional on `card_SYT_twoRectYD`
+
+### Key Findings
+
+- **Bool lemmas removed in Lean4**: `Bool.false_eq_false`, `Bool.true_eq_false`, etc. are no
+  longer in Mathlib; `simp` handles Bool equalities by definitional reduction automatically
+- **`card_SYT_twoRectYD` strategy**: SYT(2×m) ↔ ballot sequences ↔ Dyck paths ↔ Cn m.
+  The bijection maps SYT to a subset S ⊂ {1,...,2m} of size m where k ∈ S means k goes to row 1.
+  Ballot condition: for each k, #{j ≤ k : j ∈ S} ≥ k - #{j ≤ k : j ∈ S}, counting to Cn m.
+- **All 4 remaining sorries are HARD**: Each requires 200-300 lines of combinatorial formalization.
+  None are suitable for Aristotle (open/specialized mathematics, not standard Mathlib results).
+
+### Files Modified
+
+- `proofs/Proofs/BallotProblemOQ03OQ02.lean` (Bool.xxx_eq_xxx removed, 5 locations, 0 sorries affected)
+
+### Next Steps
+
+1. **Prove `card_SYT_twoRectYD`**: Define ballot bijection SYT(2×m) ↔ {S ⊂ {1..2m} : |S|=m, ballot}
+   This unblocks `hook_length_formula_two_rect`.
+2. **Consider inductive approach**: Corner-cell induction formula `f^λ = Σ_{corners c} f^{λ\c}`
+   for the general hook-length formula.
+3. **Fix any remaining omega issues** in `BallotProblemOQ03OQ02.lean` if they appear in build.
+
+---
+
 ## Dead Ends
 
 - `lgv_det_factors_as_hook_quotient` with `=` and integer division `/` (reformulated to `*`)

--- a/research/problems/sperner-ndim-oq-05/knowledge.md
+++ b/research/problems/sperner-ndim-oq-05/knowledge.md
@@ -266,6 +266,50 @@ so avoids elaboration overhead.
 
 ---
 
+## Session 2026-04-22 (Session 5) - Prove gridAdj_ne
+
+**Mode**: REVISIT
+**Outcome**: PROGRESS — proved `gridAdj_ne` (6 → 5 sorries remaining)
+
+### What I Did
+
+1. Recovered from context overflow — reconstructed all edits from previous sessions
+2. Fixed pre-existing errors in `boundaryFlip0.step_inc/step_dec` and `boundaryFlipLast.step_dec`:
+   - `hlv` lemma used `j_step.val + 1` but goal had `j_step.castSucc.val + 1` (syntactically different)
+   - Fix: rewrite `hlv` with `castSucc.val` and add `simp [Fin.castSucc]` before omega
+3. Fixed `boundaryFlipLast.step_dec` first step: added `simp [Fin.val_succ]` before omega
+4. Added helper lemmas:
+   - `interiorFlip_incDir_kprev`: interior flip swaps incDir at k-1 ↔ incDir at k
+   - `interiorFlip_verts_other`: non-flipped vertices preserved
+   - `boundaryFlip0_verts_zero`: if flip succeeds, d≠0 and s'.verts[0] = s.verts[1]
+   - `boundaryFlipLast_verts_one`: if flip succeeds, d≠0 and s'.verts[1] = s.verts[0]
+5. Proved `gridAdj_ne` by case split on k:
+   - k=0: use `boundaryFlip0_verts_zero` + `verts_injective` → distinct
+   - k=d: use `boundaryFlipLast_verts_one` + `verts_injective` → distinct
+   - interior: use `interiorFlip_incDir_kprev` + `inc_injective` → incDir differs → distinct
+6. Fixed `sperner_grid` term-mode parser error (convert to `by exact ...`)
+
+### Key Technical Insights
+
+- `split_ifs` auto-closes `h : none = some(...)` goals — only 1 bullet needed per `split_ifs`
+- When `split_ifs at h with h_pos hd`, goal order: interesting case FIRST (h_pos=T, hd=F)
+- `simp [Fin.castSucc]` needed to unfold `j_step.castSucc.val = j_step.val` for omega
+
+### Files Modified
+
+- `proofs/Proofs/SpernerGrid.lean` (1 sorry removed: gridAdj_ne, 6 → 5 remaining)
+
+### Next Steps
+
+1. Prove `gridAdj_symm` — involutivity of flip operations (each flip is its own inverse)
+   - `boundaryFlip0(s) = some(s', k')` → `boundaryFlipLast(s') = some(s, 0)` (case k=0)
+   - `boundaryFlipLast(s) = some(s', k')` → `boundaryFlip0(s') = some(s, d)` (case k=d)
+   - `interiorFlip(s, step) = (s', k')` → `interiorFlip(s', step) = (s, k)` (interior)
+2. Prove `gridAdj_vertex` — shared codimension-1 face property
+3. **[USER ACTION NEEDED]** Comment on mathlib4#25231 pointing to `SpernerSimplicialInstance.lean`
+
+---
+
 ## Dead Ends
 
 - `FixedPointFree.lean` (GroupTheory) — about group automorphisms, not Finsets

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
@@ -6,26 +6,26 @@
   "tier": "A",
   "path": "full",
   "problemStatement": {
-    "formal": "theorem hook_length_formula (λ : YoungDiagram) : Fintype.card (StandardYoungTableau λ) = λ.card.factorial / ∏ u : λ, hookLength λ u",
-    "plain": "Using the fully-proved n×n LGV lemma (BallotProblemOQ03OQ02.lean), formalize the hook-length formula f^λ = n! / ∏ h(u) for standard Young tableaux of arbitrary shape. The two-row case is already proved numerically; the goal is a structural proof for general λ.",
+    "formal": "theorem hook_length_formula (\u03bb : YoungDiagram) : Fintype.card (StandardYoungTableau \u03bb) = \u03bb.card.factorial / \u220f u : \u03bb, hookLength \u03bb u",
+    "plain": "Using the fully-proved n\u00d7n LGV lemma (BallotProblemOQ03OQ02.lean), formalize the hook-length formula f^\u03bb = n! / \u220f h(u) for standard Young tableaux of arbitrary shape. The two-row case is already proved numerically; the goal is a structural proof for general \u03bb.",
     "whyMatters": [
-      "f^λ counts the dimension of the Specht module S^λ of S_n — connecting combinatorics to representation theory",
-      "The n×n LGV lemma (2315 lines, 0 sorries) provides the infrastructure; this closes the loop",
-      "No complete Lean 4 proof of the hook-length formula exists — genuine Mathlib contribution potential"
+      "f^\u03bb counts the dimension of the Specht module S^\u03bb of S_n \u2014 connecting combinatorics to representation theory",
+      "The n\u00d7n LGV lemma (2315 lines, 0 sorries) provides the infrastructure; this closes the loop",
+      "No complete Lean 4 proof of the hook-length formula exists \u2014 genuine Mathlib contribution potential"
     ]
   },
   "knownResults": {
     "proven": [
-      "2×2 LGV lemma: lgv_lemma_2x2 in BallotProblemOQ03.lean (2879 lines, 0 sorries)",
-      "General n×n LGV lemma: lgv_lemma_rxr in BallotProblemOQ03OQ02.lean (2315 lines, 0 sorries)",
+      "2\u00d72 LGV lemma: lgv_lemma_2x2 in BallotProblemOQ03.lean (2879 lines, 0 sorries)",
+      "General n\u00d7n LGV lemma: lgv_lemma_rxr in BallotProblemOQ03OQ02.lean (2315 lines, 0 sorries)",
       "2-row hook-length: hook_length_formula_two_row in BallotProblemOQ03OQ03.lean (C_m * (m+1)! * m! = (2m)!)",
       "Catalan/lattice path machinery: extensive in BallotProblemOQ03OQ02.lean"
     ],
     "open": [
       "hookLength function for YoungDiagram: h(i,j) = arm(i,j) + leg(i,j) + 1",
-      "LGV source/target encoding for arbitrary λ",
-      "Determinant factorization: det[C(λⱼ - i + j + r - 1, λⱼ - i + j)] = ∏ h(u)",
-      "Connection StandardYoungTableau count ↔ LGV non-intersecting path count",
+      "LGV source/target encoding for arbitrary \u03bb",
+      "Determinant factorization: det[C(\u03bb\u2c7c - i + j + r - 1, \u03bb\u2c7c - i + j)] = \u220f h(u)",
+      "Connection StandardYoungTableau count \u2194 LGV non-intersecting path count",
       "General hook_length_formula for arbitrary YoungDiagram"
     ],
     "goal": "Prove hook_length_formula using lgv_lemma_rxr from BallotProblemOQ03OQ02.lean, starting with rectangular shapes then generalizing"
@@ -34,9 +34,9 @@
     "phase": "ACT",
     "since": "2026-04-21T13:45:00Z",
     "iteration": 1,
-    "focus": "Read BallotProblemOQ03OQ02.lean lgv_lemma_rxr interface; assess Mathlib YoungDiagram for hookLength",
+    "focus": "card_SYT_twoRectYD via ballot bijection (Catalan number bijection for 2\u00d7m SYT)",
     "blockers": [],
-    "nextAction": "OBSERVE: Read BallotProblemOQ03OQ02.lean to understand n×n LGV types and theorem interface",
+    "nextAction": "OBSERVE: Read BallotProblemOQ03OQ02.lean to understand n\u00d7n LGV types and theorem interface",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -44,48 +44,52 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved hook-length formula for hook-shape Young diagrams (m+1,1) via explicit bijection; 3 pre-existing sorries remain for general case",
+    "progressSummary": "PROGRESS (session 5): Fixed Bool.xxx_eq_xxx simp lemma build failures in BallotProblemOQ03OQ02.lean. All 4 remaining sorries are HARD (RSK bijection, Vandermonde det, Catalan bijection, main theorem). hook_length_formula_two_rect is proved conditional on card_SYT_twoRectYD.",
     "builtItems": [
       "instFintypeSYT: Fintype instance for StandardYoungTableau (BallotProblemOQ03OQ01OQ02.lean, Part IIIb)",
       "emptyTableau: unique SYT of shape bot (BallotProblemOQ03OQ01OQ02.lean, Part IIIc)",
       "hook_length_formula_bot: proved theorem for empty diagram (BallotProblemOQ03OQ01OQ02.lean:hook_length_formula_bot)",
       "hook_length_formula_from_chain: proved conditional theorem from two sorry lemmas (BallotProblemOQ03OQ01OQ02.lean:hook_length_formula_from_chain)",
       "oneRowYD, mem_oneRowYD, oneRowYD_card, rowLen_oneRowYD_zero, colLen_oneRowYD (PART VI infrastructure)",
-      "hookLength_oneRowYD, hookProd_oneRowYD — hook computations for single-row shape",
-      "oneRowSYT, entry_oneRow_eq, oneRowSYT_unique — SYT uniqueness machinery",
-      "hook_length_formula_one_row — verified instance of hook formula, 0 sorries",
+      "hookLength_oneRowYD, hookProd_oneRowYD \u2014 hook computations for single-row shape",
+      "oneRowSYT, entry_oneRow_eq, oneRowSYT_unique \u2014 SYT uniqueness machinery",
+      "hook_length_formula_one_row \u2014 verified instance of hook formula, 0 sorries",
       "hookProd_hookShapeYD: proved hookProd(m+1,1)=(m+2)*m! in BallotProblemOQ03OQ01OQ02.lean:775",
       "card_SYT_hookShapeYD: proved |SYT(m+1,1)|=m+1 via Equiv.ofBijective hookSYT in BallotProblemOQ03OQ01OQ02.lean:1062",
-      "hook_length_formula_hook_shape: proved hook formula for hook shapes in BallotProblemOQ03OQ01OQ02.lean:1075"
+      "hook_length_formula_hook_shape: proved hook formula for hook shapes in BallotProblemOQ03OQ01OQ02.lean:1075",
+      "Bool simp lemma fix: removed Bool.false_eq_false etc. from 5 locations in BallotProblemOQ03OQ02.lean (session 5, 2026-04-22)"
     ],
     "insights": [
       "lgv_lemma_rxr in BallotProblemOQ03OQ02.lean is the key building block (Gessel-Viennot involution proof)",
-      "hook_length_formula_two_row (BallotProblemOQ03OQ03.lean) proved C_m * (m+1)! * m! = (2m)! — numerical verification only",
-      "Approach: encode λ = (λ₁ ≥ ... ≥ λ_r) via sources (0, r-i) and targets (λᵢ + r - i, 0)",
-      "instFintypeSYT: Fintype instance for SYT via injection into (μ.cells → Fin (μ.card+1)) — critical for Fintype.card to typecheck",
+      "hook_length_formula_two_row (BallotProblemOQ03OQ03.lean) proved C_m * (m+1)! * m! = (2m)! \u2014 numerical verification only",
+      "Approach: encode \u03bb = (\u03bb\u2081 \u2265 ... \u2265 \u03bb_r) via sources (0, r-i) and targets (\u03bb\u1d62 + r - i, 0)",
+      "instFintypeSYT: Fintype instance for SYT via injection into (\u03bc.cells \u2192 Fin (\u03bc.card+1)) \u2014 critical for Fintype.card to typecheck",
       "hook_length_formula_bot: proved for empty diagram (base case, 1*1=0!=1)",
-      "hook_length_formula_from_chain: proves main theorem FROM ni_count_eq_syt_count AND lgv_det_factors_as_hook_quotient — logical chain complete",
+      "hook_length_formula_from_chain: proves main theorem FROM ni_count_eq_syt_count AND lgv_det_factors_as_hook_quotient \u2014 logical chain complete",
       "lgv_det_factors_as_hook_quotient reformulated as det*hookProd=n! (avoids integer division, cleaner than det=n!/hookProd)",
       "Two sorry lemmas remain: RSK bijection (ni_count_eq_syt_count, ~200 lines) and Vandermonde-type det identity (lgv_det_factors_as_hook_quotient, ~200 lines)",
       "Single-row hook formula proved directly without LGV: unique SYT entry(0,j)=j+1, hookProd=n!",
-      "oneRowYD n = YoungDiagram.ofRowLens [n] — ofRowLens is the right Mathlib constructor",
-      "hookLength_add_eq: hookLength μ i j + 1 = rowLen i - j + colLen j — key computation lemma",
+      "oneRowYD n = YoungDiagram.ofRowLens [n] \u2014 ofRowLens is the right Mathlib constructor",
+      "hookLength_add_eq: hookLength \u03bc i j + 1 = rowLen i - j + colLen j \u2014 key computation lemma",
       "Nat.descFactorial_self n proves hookProd = n! via descFactorial_eq_prod_range",
       "SYT uniqueness: lower bound by IH on row_strict, upper bound by chain to last cell",
       "if_neg (mt mem_oneRowYD.mpr hc) is the clean pattern for entry_zero proofs",
       "Bijection technique: hookSYT maps Fin(m+1) to SYT(m+1,1) by k -> tableau with entry(1,0)=k+2; key lemma entry(0,0)=1 always holds via chain argument",
       "hookProd insert decomposition: use Finset.prod_insert to isolate j=0 arm, then handle row arm via descFactorial_eq_prod_range",
       "Hook-shape family fully formalized without LGV infrastructure - elementary bijection suffices",
-      "Pre-existing build failures in BallotProblemOQ03OQ02.lean (Bool.false_eq_false removed from Lean4) are blocking full build verification but do not affect Part VIII work"
+      "Pre-existing build failures in BallotProblemOQ03OQ02.lean (Bool.false_eq_false removed from Lean4) are blocking full build verification but do not affect Part VIII work",
+      "Bool.false_eq_false, Bool.true_eq_false, Bool.false_eq_true, Bool.true_eq_true removed from modern Lean4/Mathlib \u2014 simp handles Bool equalities by kernel/definitional reduction",
+      "card_SYT_twoRectYD strategy: SYT(2\u00d7m) \u2194 ballot sequences \u2194 Dyck paths \u2194 Cn m via subset bijection (k \u2208 S iff k goes to row 1, ballot condition enforces ordering)"
     ],
     "mathlibGaps": [
-      "hookLength may not be defined in Mathlib.Combinatorics.YoungDiagram — check arm/leg availability",
-      "StandardYoungTableau enumeration — check Mathlib.Combinatorics.YoungTableaux"
+      "hookLength may not be defined in Mathlib.Combinatorics.YoungDiagram \u2014 check arm/leg availability",
+      "StandardYoungTableau enumeration \u2014 check Mathlib.Combinatorics.YoungTableaux"
     ],
     "nextSteps": [
-      "Fix BallotProblemOQ03OQ02.lean build failures (Bool.false_eq_false -> decide_true, omega failures in take_at_column_entry)",
-      "Extend hook formula to rectangular shapes (m x n) using determinant formula",
-      "Prove main hook_length_formula theorem by reducing to hook-shape case via induction"
+      "Prove card_SYT_twoRectYD via ballot bijection: define SYT(2\u00d7m) \u2194 {S \u2282 {1..2m} : |S|=m, ballot condition}",
+      "This unblocks hook_length_formula_two_rect which is already proved conditional on card_SYT_twoRectYD",
+      "Consider corner-cell induction formula f^\u03bb = \u03a3_{corners c} f^{\u03bb\\c} for general hook-length formula",
+      "All 4 deep sorries (ni_count, lgv_det, card_SYT_twoRect, hook_formula) require 200-300 lines each"
     ]
   },
   "tags": [
@@ -115,7 +119,7 @@
     "papers": [
       "Frame-Robinson-Thrall (1954): The hook graphs of the symmetric group",
       "Gessel-Viennot (1985): Binomial determinants, paths, and hook length formulae",
-      "Lindström (1973): On the vector representations of induced matroids"
+      "Lindstr\u00f6m (1973): On the vector representations of induced matroids"
     ],
     "urls": [],
     "mathlib": [
@@ -285,11 +289,11 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",
       "filename": "BallotProblemOQ03OQ01OQ02.lean",
-      "lineCount": 226,
-      "theoremCount": 10,
+      "lineCount": 1260,
+      "theoremCount": 48,
       "axiomCount": 0,
-      "defCount": 5,
-      "sorryCount": 3,
+      "defCount": 9,
+      "sorryCount": 8,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean"
     },

--- a/src/data/research/problems/cantor-diagonalization-oq-04-oq-03.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-04-oq-03.json
@@ -34,11 +34,12 @@
       "CantorDiagonalizationOQ04OQ03.lean: 150 lines, 0 axioms, 0 sorries",
       "yCombinator: explicit Y combinator from CodesEndomorphisms",
       "knaster_tarski: from Mathlib OrderHom.lfp",
-      "structural_parallel: unified theorem"
+      "structural_parallel: unified theorem",
+      "omega_continuous_monotone_ari: \u03c9-continuous functions are monotone \u2014 proved in CantorDiagonalizationOQ04OQ03Aristotle.lean (0 sorries, 2026-04-22)"
     ],
     "insights": [
       "Y combinator = Lawvere construction: Y(f) = g(encode(g))",
-      "Lawvere needs coding, Tarski needs order — dual approaches",
+      "Lawvere needs coding, Tarski needs order \u2014 dual approaches",
       "Domain theory bridges categorical and order-theoretic FPTs",
       "OrderHom.lfp from Mathlib gives Knaster-Tarski directly"
     ],

--- a/src/data/research/problems/sperner-ndim-oq-05.json
+++ b/src/data/research/problems/sperner-ndim-oq-05.json
@@ -29,12 +29,13 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (session 4): Proved 4 step_same sorries in SpernerGrid.lean (11→6 remaining). Next: gridAdj_symm, gridAdj_vertex, gridAdj_ne, or Mathlib PR submission.",
+    "progressSummary": "PROGRESS (session 5): Proved gridAdj_ne in SpernerGrid.lean (6 → 5 sorries). gridAdj_symm and gridAdj_vertex remain (require involutivity proofs).",
     "builtItems": [
       "SpernerMathlib4Opt.lean: optimized proof proposal for even_card_of_fpf_invol using sum_involution (research/problems/sperner-ndim-oq-05/lean/)",
       "even_card_of_fpf_invol: 53-line strongInduction proof replaced with 11-line sum_involution proof in SpernerMathlib4.lean",
       "boundaryFlip0.step_same: proved (SpernerGrid.lean:868-903, 2 sorries → 0)",
-      "boundaryFlipLast.step_same: proved (SpernerGrid.lean:1011-1046, 2 sorries → 0)"
+      "boundaryFlipLast.step_same: proved (SpernerGrid.lean:1011-1046, 2 sorries → 0)",
+      "gridAdj_ne: proved in SpernerGrid.lean (1 sorry removed, 6 → 5 remaining)"
     ],
     "insights": [
       "All gallery files (SpernerMathlib4, SpernerSimplicialInstance, etc.) have 0 sorries — mathematical work complete",
@@ -54,7 +55,10 @@
       "SpernerSimplicialInstance needs Mathlib.Data.Finset.Sort for Finset.sort",
       "boundaryFlip0.step_same middle: simp [hj_mid, dite_true] at hj_inc to get j ≠ s.incDir, then delegate to s.step_same; same pattern as step_inc/step_dec",
       "boundaryFlip*.step_same boundary case: BaryPoint.transfer_coords_other is the key lemma when j ≠ inc and j ≠ dec",
-      "SpernerGrid.lean: 11 → 6 sorries after proving all four step_same cases"
+      "SpernerGrid.lean: 11 → 6 sorries after proving all four step_same cases",
+      "split_ifs auto-closes h:none=some contradictions — only 1 bullet needed per split_ifs in helper lemmas",
+      "j_step.castSucc.val syntactically ≠ j_step.val even though equal — need simp [Fin.castSucc] before omega in hlv proofs",
+      "gridAdj_ne proved via 3-case split: boundary cases use verts_injective; interior case uses inc_injective + interiorFlip_incDir_kprev"
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary

- Proves `gridAdj_ne`: adjacent simplices in the grid triangulation are distinct
- Fixes 4 pre-existing errors in `boundaryFlip0`/`boundaryFlipLast` step proofs (castSucc value mismatch)
- Adds helper lemmas for boundary flip vertex properties used by `gridAdj_ne`
- Fixes `sperner_grid` term-mode parse error (convert to tactic proof)

## Proof Strategy

`gridAdj_ne` proved by case analysis on `k`:
- `k=0` (boundaryFlip0): vertex 0 of s' maps to s.verts 1, so s≠s' by injectivity
- `k=d` (boundaryFlipLast): vertex 1 of s' maps to s.verts 0, so s≠s' by injectivity
- Interior: s'.incDir(k-1) = s.incDir(k) ≠ s.incDir(k-1) by injectivity

## Remaining Work

- `gridAdj_symm` — sorry (involutivity of flip operations, complex)
- `gridAdj_vertex` — sorry (shared codimension-1 face, complex)
- `boundary_verts_on_face` — sorry
- `boundary_doors_odd` — sorry

🤖 Generated with [Claude Code](https://claude.com/claude-code)