### PR TITLE
Fix: cantor-diagonalization-oq-03-oq-01-oq-02 axiomCount/status mismatch

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-04",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/CantorDiagonalizationOQ03OQ01OQ02.lean",
     "tags": [
       "computability",
@@ -16,11 +16,11 @@
       "diagonal-argument",
       "abstract-logic"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-04",
-    "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified (ClassicalRiceModel axiomatizes Kleene's recursion theorem as a hypothesis, not a global axiom).",
+    "axiomCount": 2,
+    "assumptions": "ClassicalRiceModel encodes 2 mathematical assumptions as structure fields: (1) h_compile — every behavior has a canonical code (universality); (2) kleene_rec — Kleene's recursion theorem (every code transformer has a semantic fixed point). These are hypotheses to classical_rice_abstract, not global Lean axioms. The 5 abstract theorems (abstract_rice through no_halting_model) are fully axiom-free.",
     "lineCount": 275,
     "theoremCount": 6,
     "definitionCount": 4,
@@ -99,7 +99,7 @@
   "leanFile": {
     "namespace": "CantorDiagonalizationOQ03OQ01OQ02",
     "lineCount": 275,
-    "axiomCount": 0,
+    "axiomCount": 2,
     "theoremCount": 7,
     "definitionCount": 4,
     "path": "Proofs/CantorDiagonalizationOQ03OQ01OQ02.lean",


### PR DESCRIPTION
## Fix

Correct `axiomCount`, `status`, `badge`, and `assumptions` in meta.json for the Rice's Theorem as a Lawvere Instance proof.

## Evidence

**Before**:
- `status: "verified"`, `badge: "original"`, `axiomCount: 0`
- `assumptions: "None. Fully machine-verified..."`

**After**:
- `status: "axiomatized"`, `badge: "axiom"`, `axiomCount: 2`
- `assumptions: "ClassicalRiceModel encodes 2 mathematical assumptions as structure fields: (1) h_compile — every behavior has a canonical code (universality); (2) kleene_rec — Kleene's recursion theorem (every code transformer has a semantic fixed point)..."`

The `ClassicalRiceModel` structure has two assumption-carrying fields (`h_compile` and `kleene_rec`). Per the Axiom Integrity Policy, structure-encoded hypotheses count toward `axiomCount`. The `classical_rice_abstract` theorem is conditional on these assumptions, so `verified`/`original` overclaims. The 5 abstract theorems remain genuinely axiom-free.

Closes #11356

---
Automated fix by lean-mechanic agent.