### PR TITLE
Enrich: fix annotation schema violations in amgm-inequality-oq-02, oq-02-oq-01-oq-02, oq-03

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02/annotations.json
@@ -2,61 +2,127 @@
   {
     "id": "ann-decomposition",
     "proofId": "amgm-inequality-oq-02-oq-01-oq-02",
-    "range": { "startLine": 27, "endLine": 52 },
+    "range": {
+      "startLine": 31,
+      "endLine": 52
+    },
     "type": "technique",
     "title": "Decomposing offDiag into Upper and Lower Triangular Parts",
-    "content": "The theorem `offDiag_eq_upper_union_lower` decomposes `s.offDiag` (pairs (i,j) with i ≠ j) into upper triangular ({i<j}) and lower triangular ({j<i}) parts. The proof uses `rcases lt_or_gt_of_ne hab` to case-split on the linear order. The disjointness `upper_lower_disjoint` follows because i < j and j < i would imply i < i by transitivity, contradicting irreflexivity. The `LinearOrder` typeclass provides the total order needed to ensure every (i,j) with i ≠ j falls into exactly one part.",
+    "content": "The theorem `offDiag_eq_upper_union_lower` decomposes `s.offDiag` (pairs (i,j) with i \u2260 j) into upper triangular ({i<j}) and lower triangular ({j<i}) parts. The proof uses `rcases lt_or_gt_of_ne hab` to case-split on the linear order. The disjointness `upper_lower_disjoint` follows because i < j and j < i would imply i < i by transitivity, contradicting irreflexivity. The `LinearOrder` typeclass provides the total order needed to ensure every (i,j) with i \u2260 j falls into exactly one part.",
     "mathContext": "For a linearly ordered finite set $\\iota$: $\\text{offDiag}(s) = \\{(i,j) \\mid i,j \\in s, i < j\\} \\sqcup \\{(i,j) \\mid i,j \\in s, j < i\\}$ (disjoint union). Linear order guarantees: for $i \\ne j$, either $i < j$ or $j < i$ (totality), and not both (antisymmetry). This is the foundation of the double-counting argument: each unordered pair $\\{i,j\\}$ contributes exactly two ordered pairs, one to each part.",
     "significance": "supporting",
-    "relatedConcepts": ["Finset.offDiag", "LinearOrder", "lt_or_gt_of_ne", "Finset.disjoint_filter", "upper/lower triangular"],
-    "prerequisites": ["Lean LinearOrder typeclass", "Finset.offDiag definition", "lt_irrefl and lt_trans"]
+    "relatedConcepts": [
+      "Finset.offDiag",
+      "LinearOrder",
+      "lt_or_gt_of_ne",
+      "Finset.disjoint_filter",
+      "upper/lower triangular"
+    ],
+    "prerequisites": [
+      "Lean LinearOrder typeclass",
+      "Finset.offDiag definition",
+      "lt_irrefl and lt_trans"
+    ]
   },
   {
     "id": "ann-swap-image",
     "proofId": "amgm-inequality-oq-02-oq-01-oq-02",
-    "range": { "startLine": 53, "endLine": 70 },
+    "range": {
+      "startLine": 57,
+      "endLine": 70
+    },
     "type": "technique",
     "title": "Swap Image: Prod.swap Bijects Lower to Upper Triangular",
-    "content": "The theorem `image_swap_lower_eq_upper` proves that applying `Prod.swap` to the lower-triangular part (filter j<i) gives exactly the upper-triangular part (filter i<j). The proof is a set membership characterization (`ext ⟨a, b⟩`): (a,b) ∈ swap(lower) iff ∃ (c,d) ∈ lower with swap(c,d) = (a,b), i.e., (d,c) = (a,b), i.e., d < c. The backward direction: given a < b (upper), take (b,a) in lower — it swaps to (a,b). This establishes the explicit bijection needed for reindexing the sum.",
+    "content": "The theorem `image_swap_lower_eq_upper` proves that applying `Prod.swap` to the lower-triangular part (filter j<i) gives exactly the upper-triangular part (filter i<j). The proof is a set membership characterization (`ext \u27e8a, b\u27e9`): (a,b) \u2208 swap(lower) iff \u2203 (c,d) \u2208 lower with swap(c,d) = (a,b), i.e., (d,c) = (a,b), i.e., d < c. The backward direction: given a < b (upper), take (b,a) in lower \u2014 it swaps to (a,b). This establishes the explicit bijection needed for reindexing the sum.",
     "mathContext": "The bijection: $\\text{swap}: \\{(i,j) \\mid j < i\\} \\to \\{(i,j) \\mid i < j\\}$ via $(i,j) \\mapsto (j,i)$. Proof of surjectivity: $(a,b)$ with $a < b$ is the image of $(b,a)$ which has $b > a$, so $(b,a)$ is in the lower part. Injectivity: if $(j_1, i_1) = (j_2, i_2)$ then $(i_1,j_1) = (i_2,j_2)$. This bijectivity is what `Finset.sum_image` needs to reindex the sum over lower as a sum over upper.",
     "significance": "supporting",
-    "relatedConcepts": ["Prod.swap", "Finset.mem_image", "bijection", "image_swap_lower_eq_upper", "Finset.ext"],
-    "prerequisites": ["Prod.swap definition", "Finset.image properties", "LinearOrder antisymmetry"]
+    "relatedConcepts": [
+      "Prod.swap",
+      "Finset.mem_image",
+      "bijection",
+      "image_swap_lower_eq_upper",
+      "Finset.ext"
+    ],
+    "prerequisites": [
+      "Prod.swap definition",
+      "Finset.image properties",
+      "LinearOrder antisymmetry"
+    ]
   },
   {
     "id": "ann-core-symmetry",
     "proofId": "amgm-inequality-oq-02-oq-01-oq-02",
-    "range": { "startLine": 71, "endLine": 99 },
+    "range": {
+      "startLine": 75,
+      "endLine": 99
+    },
     "type": "insight",
     "title": "Core Symmetry via sum_image: Reindexing Under Swap",
-    "content": "The theorem `sum_lower_eq_sum_upper` proves: for symmetric f (f(i,j) = f(j,i)), ∑_{j<i} f(i,j) = ∑_{i<j} f(i,j). The proof is a chain of three equalities: (1) ∑_lower f(p) = ∑_lower f(swap(p)) by symmetry (f(a,b) = f(b,a)); (2) ∑_lower f(swap(p)) = ∑_{lower.image swap} f by `Finset.sum_image` (swap is injective); (3) lower.image swap = upper by `image_swap_lower_eq_upper`. The `calc` block makes each step explicit.",
+    "content": "The theorem `sum_lower_eq_sum_upper` proves: for symmetric f (f(i,j) = f(j,i)), \u2211_{j<i} f(i,j) = \u2211_{i<j} f(i,j). The proof is a chain of three equalities: (1) \u2211_lower f(p) = \u2211_lower f(swap(p)) by symmetry (f(a,b) = f(b,a)); (2) \u2211_lower f(swap(p)) = \u2211_{lower.image swap} f by `Finset.sum_image` (swap is injective); (3) lower.image swap = upper by `image_swap_lower_eq_upper`. The `calc` block makes each step explicit.",
     "mathContext": "The three-step proof: $\\sum_{j < i} f(i,j) = \\sum_{j<i} f(j,i)$ (symmetry) $= \\sum_{(i',j') \\in \\text{upper}} f(i',j')$ (reindexing via $\\text{swap}$). Step (2) uses `Finset.sum_image`: if $g: \\alpha \\to \\beta$ is injective on $s$, then $\\sum_{x \\in s} f(g(x)) = \\sum_{y \\in s.\\text{image}\\, g} f(y)$. Injectivity of swap: $(j_1,i_1) \\ne (j_2,i_2) \\Rightarrow (i_1,j_1) \\ne (i_2,j_2)$ (clear by component equality). The `Prod.ext` tactic assembles the component equality.",
     "significance": "key",
-    "relatedConcepts": ["Finset.sum_image", "Prod.swap injectivity", "sum_lower_eq_sum_upper", "calc block", "CommRing"],
-    "prerequisites": ["Finset.sum_image Mathlib theorem", "function injectivity", "sum_congr for pointwise equality"]
+    "relatedConcepts": [
+      "Finset.sum_image",
+      "Prod.swap injectivity",
+      "sum_lower_eq_sum_upper",
+      "calc block",
+      "CommRing"
+    ],
+    "prerequisites": [
+      "Finset.sum_image Mathlib theorem",
+      "function injectivity",
+      "sum_congr for pointwise equality"
+    ]
   },
   {
     "id": "ann-main-theorem",
     "proofId": "amgm-inequality-oq-02-oq-01-oq-02",
-    "range": { "startLine": 100, "endLine": 117 },
+    "range": {
+      "startLine": 103,
+      "endLine": 117
+    },
     "type": "insight",
-    "title": "Main Theorem: Σ_{i≠j} f = 2·Σ_{i<j} f via Two_mul",
-    "content": "The theorem `sum_offDiag_eq_two_mul_sum_upper` combines all parts: (1) rewrite Σ_offDiag as Σ_upper + Σ_lower by `Finset.sum_union` and the decomposition; (2) use `sum_lower_eq_sum_upper` to get Σ_upper + Σ_upper; (3) use `two_mul` to get 2·Σ_upper. The disjointness from `upper_lower_disjoint` is needed for `sum_union` (which requires disjointness to avoid double-counting). The final result holds for any symmetric function over any CommRing.",
+    "title": "Main Theorem: \u03a3_{i\u2260j} f = 2\u00b7\u03a3_{i<j} f via Two_mul",
+    "content": "The theorem `sum_offDiag_eq_two_mul_sum_upper` combines all parts: (1) rewrite \u03a3_offDiag as \u03a3_upper + \u03a3_lower by `Finset.sum_union` and the decomposition; (2) use `sum_lower_eq_sum_upper` to get \u03a3_upper + \u03a3_upper; (3) use `two_mul` to get 2\u00b7\u03a3_upper. The disjointness from `upper_lower_disjoint` is needed for `sum_union` (which requires disjointness to avoid double-counting). The final result holds for any symmetric function over any CommRing.",
     "mathContext": "$\\sum_{i \\ne j} f(i,j) = \\sum_{i<j} f(i,j) + \\sum_{j<i} f(i,j) = \\sum_{i<j} f(i,j) + \\sum_{i<j} f(i,j) = 2 \\sum_{i<j} f(i,j)$. The key algebraic step is `Finset.sum_union` for disjoint sets: $\\sum_{x \\in A \\cup B} f(x) = \\sum_{x \\in A} f(x) + \\sum_{x \\in B} f(x)$ when $A \\cap B = \\emptyset$. The `two_mul` lemma closes: $a + a = 2a$ in any AddMonoid.",
     "significance": "key",
-    "relatedConcepts": ["sum_offDiag_eq_two_mul_sum_upper", "Finset.sum_union", "two_mul", "upper_lower_disjoint", "Newton-Girard"],
-    "prerequisites": ["sum_lower_eq_sum_upper", "offDiag_eq_upper_union_lower", "upper_lower_disjoint", "Finset.sum_union"]
+    "relatedConcepts": [
+      "sum_offDiag_eq_two_mul_sum_upper",
+      "Finset.sum_union",
+      "two_mul",
+      "upper_lower_disjoint",
+      "Newton-Girard"
+    ],
+    "prerequisites": [
+      "sum_lower_eq_sum_upper",
+      "offDiag_eq_upper_union_lower",
+      "upper_lower_disjoint",
+      "Finset.sum_union"
+    ]
   },
   {
     "id": "ann-application",
     "proofId": "amgm-inequality-oq-02-oq-01-oq-02",
-    "range": { "startLine": 118, "endLine": 138 },
+    "range": {
+      "startLine": 120,
+      "endLine": 138
+    },
     "type": "concept",
-    "title": "Application: Σ_{i≠j} xᵢxⱼ = 2·e₂ and Newton-Girard Completion",
-    "content": "The theorem `offDiag_prod_eq_two_mul_e2` specializes to f(i,j) = xᵢxⱼ (where x : ι → R is any function). Symmetry f(i,j) = f(j,i) holds by commutativity of multiplication. The theorem gives Σ_{i≠j} xᵢxⱼ = 2·Σ_{i<j} xᵢxⱼ = 2·e₂. Combined with the parent's (Σxᵢ)² = Σxᵢ² + Σ_{i≠j} xᵢxⱼ, this gives the complete Newton-Girard identity: p₂ = e₁² − 2·e₂.",
+    "title": "Application: \u03a3_{i\u2260j} x\u1d62x\u2c7c = 2\u00b7e\u2082 and Newton-Girard Completion",
+    "content": "The theorem `offDiag_prod_eq_two_mul_e2` specializes to f(i,j) = x\u1d62x\u2c7c (where x : \u03b9 \u2192 R is any function). Symmetry f(i,j) = f(j,i) holds by commutativity of multiplication. The theorem gives \u03a3_{i\u2260j} x\u1d62x\u2c7c = 2\u00b7\u03a3_{i<j} x\u1d62x\u2c7c = 2\u00b7e\u2082. Combined with the parent's (\u03a3x\u1d62)\u00b2 = \u03a3x\u1d62\u00b2 + \u03a3_{i\u2260j} x\u1d62x\u2c7c, this gives the complete Newton-Girard identity: p\u2082 = e\u2081\u00b2 \u2212 2\u00b7e\u2082.",
     "mathContext": "Newton-Girard for $n=2$: Let $p_k = \\sum_i x_i^k$ (power sum) and $e_2 = \\sum_{i<j} x_i x_j$ (second elementary symmetric polynomial). Then $p_2 = e_1^2 - 2e_2$, i.e., $\\sum_i x_i^2 = (\\sum_i x_i)^2 - 2\\sum_{i<j} x_i x_j$. Proof: $(\\sum_i x_i)^2 = \\sum_i x_i^2 + \\sum_{i \\ne j} x_i x_j = \\sum_i x_i^2 + 2 \\sum_{i<j} x_i x_j$. The general Newton-Girard recurrence is $p_k = \\sum_{i=1}^{k-1} (-1)^{i-1} e_i p_{k-i} + (-1)^{k-1} k e_k$.",
     "significance": "key",
-    "relatedConcepts": ["elementary symmetric polynomial e₂", "Newton-Girard identity", "p₂ = e₁² − 2e₂", "power sums", "AM-GM inequality"],
-    "prerequisites": ["parent proof (sq_sum_eq_diag_plus_offdiag)", "commutativity of multiplication", "Newton's identities"]
+    "relatedConcepts": [
+      "elementary symmetric polynomial e\u2082",
+      "Newton-Girard identity",
+      "p\u2082 = e\u2081\u00b2 \u2212 2e\u2082",
+      "power sums",
+      "AM-GM inequality"
+    ],
+    "prerequisites": [
+      "parent proof (sq_sum_eq_diag_plus_offdiag)",
+      "commutativity of multiplication",
+      "Newton's identities"
+    ]
   }
 ]

--- a/src/data/proofs/amgm-inequality-oq-02/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-02/annotations.json
@@ -127,7 +127,7 @@
     "id": "ann-amgm-oq02-binomial-identity",
     "proofId": "amgm-inequality-oq-02",
     "range": {
-      "startLine": 203,
+      "startLine": 205,
       "endLine": 271
     },
     "type": "theorem",

--- a/src/data/proofs/amgm-inequality-oq-03/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-03/annotations.json
@@ -8,14 +8,14 @@
     },
     "type": "concept",
     "title": "Power Mean Family: Overview and Open Question",
-    "content": "The header introduces the weighted power mean family M_r(z,w) and the open question: to fully formalize the monotonicity M_r <= M_s for all r <= s in Lean 4/Mathlib. **Note**: The header's item 7 (line 33) is stale — it says 'General monotonicity (negative r case) stated as an axiom' but the file actually proves power_mean_monotone_neg (lines 291–343) with no axioms or sorries. The file proves 13 results total including HM ≤ GM, M_r ≤ M_s for 0 < r ≤ s, and M_r ≤ M_s for r ≤ s < 0. Only the mixed-sign case (r < 0 < s) remains open. The imports bring in Mathlib.Analysis.MeanInequalities for the weighted AM-GM inequality and Mathlib.Analysis.MeanInequalitiesPow for Jensen's power inequality.",
+    "content": "The header introduces the weighted power mean family M_r(z,w) and the open question: to fully formalize the monotonicity M_r <= M_s for all r <= s in Lean 4/Mathlib. **Note**: The header's item 7 (line 33) is stale \u2014 it says 'General monotonicity (negative r case) stated as an axiom' but the file actually proves power_mean_monotone_neg (lines 291\u2013343) with no axioms or sorries. The file proves 13 results total including HM \u2264 GM, M_r \u2264 M_s for 0 < r \u2264 s, and M_r \u2264 M_s for r \u2264 s < 0. Only the mixed-sign case (r < 0 < s) remains open. The imports bring in Mathlib.Analysis.MeanInequalities for the weighted AM-GM inequality and Mathlib.Analysis.MeanInequalitiesPow for Jensen's power inequality.",
     "mathContext": "$M_r(z,w) = \\left(\\sum_{i} w_i z_i^r\\right)^{1/r}$ for $r \\neq 0$; $M_0 = \\prod_i z_i^{w_i}$ (geometric mean as limit). The chain: $\\text{HM} = M_{-1} \\leq M_0 = \\text{GM} \\leq M_1 = \\text{AM} \\leq M_2 \\leq \\cdots$",
     "significance": "supporting",
     "relatedConcepts": [
       "AM-GM inequality",
       "power means",
       "Jensen's inequality",
-      "Hardy-Littlewood-Pólya"
+      "Hardy-Littlewood-P\u00f3lya"
     ],
     "prerequisites": [
       "weighted inequalities",
@@ -27,12 +27,12 @@
     "id": "ann-amgm-oq03-01b-variables",
     "proofId": "amgm-inequality-oq-03",
     "range": {
-      "startLine": 57,
+      "startLine": 55,
       "endLine": 58
     },
     "type": "concept",
     "title": "Shared Variables: Abstract Index Type and Weight/Value Functions",
-    "content": "The variable block declares the abstract index type ι (with implicit [DecidableEq ι] and [Fintype ι] from the Finset API), the finite index set s : Finset ι, and the weight and value functions w z : ι → ℝ. This polymorphic setup allows the power mean theorems to work for any finite collection of real numbers with any indexing scheme — a common Mathlib pattern that avoids committing to Fin n or a specific concrete type. The hypotheses on w and z (non-negativity, positivity, weight normalization) are stated in each theorem individually rather than as variable-level assumptions.",
+    "content": "The variable block declares the abstract index type \u03b9 (with implicit [DecidableEq \u03b9] and [Fintype \u03b9] from the Finset API), the finite index set s : Finset \u03b9, and the weight and value functions w z : \u03b9 \u2192 \u211d. This polymorphic setup allows the power mean theorems to work for any finite collection of real numbers with any indexing scheme \u2014 a common Mathlib pattern that avoids committing to Fin n or a specific concrete type. The hypotheses on w and z (non-negativity, positivity, weight normalization) are stated in each theorem individually rather than as variable-level assumptions.",
     "mathContext": "The abstract setup: $s \\subseteq \\iota$ (finite index set), $w : \\iota \\to \\mathbb{R}$ (weights, typically $w_i \\geq 0$, $\\sum w_i = 1$), $z : \\iota \\to \\mathbb{R}$ (values, typically $z_i > 0$). All power mean results are parametric in these choices.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -78,7 +78,7 @@
     },
     "type": "theorem",
     "title": "Known Results from Mathlib: M1=AM, AM<=Mp, GM<=AM, GM<=Mp, Jensen",
-    "content": "Four theorems wrap existing Mathlib results. power_mean_one_eq_arith_mean proves M_1 = AM by simp with Real.rpow_one. arith_mean_le_power_mean invokes Real.arith_mean_le_rpow_mean directly. geom_mean_le_arith_mean calls Real.geom_mean_le_arith_mean_weighted. geom_mean_le_power_mean_of_one_le combines the previous two via .trans. jensen_pow_ineq wraps Real.rpow_arith_mean_le_arith_mean_rpow — this is Jensen's inequality (sum w_i z_i)^p <= sum w_i z_i^p for p >= 1, and is the key tool for power_mean_monotone_pos.",
+    "content": "Four theorems wrap existing Mathlib results. power_mean_one_eq_arith_mean proves M_1 = AM by simp with Real.rpow_one. arith_mean_le_power_mean invokes Real.arith_mean_le_rpow_mean directly. geom_mean_le_arith_mean calls Real.geom_mean_le_arith_mean_weighted. geom_mean_le_power_mean_of_one_le combines the previous two via .trans. jensen_pow_ineq wraps Real.rpow_arith_mean_le_arith_mean_rpow \u2014 this is Jensen's inequality (sum w_i z_i)^p <= sum w_i z_i^p for p >= 1, and is the key tool for power_mean_monotone_pos.",
     "mathContext": "Jensen's inequality for convex $t \\mapsto t^p$ ($p \\geq 1$): $\\left(\\sum_i w_i z_i\\right)^p \\leq \\sum_i w_i z_i^p$. Equivalently, $\\text{AM} \\leq M_p$: $\\sum_i w_i z_i \\leq \\left(\\sum_i w_i z_i^p\\right)^{1/p}$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -151,7 +151,7 @@
       "endLine": 280
     },
     "type": "theorem",
-    "title": "Duality Identity: M_r(z) = M_{-r}(z⁻¹)⁻¹",
+    "title": "Duality Identity: M_r(z) = M_{-r}(z\u207b\u00b9)\u207b\u00b9",
     "content": "`power_mean_neg_inv` establishes the algebraic identity $M_r(z) = M_{-r}(z^{-1})^{-1}$ by two key steps. First, the sum equality: $(z_i^{-1})^{-r} = z_i^r$ via `inv_rpow` + `rpow_neg` + `inv_inv`. Second, the power equality: $A^{1/r} = (A^{1/(-r)})^{-1}$ since $1/(-r) = -(1/r)$ and `rpow_neg` + `inv_inv`. Helper lemmas `weighted_sum_pos` and `weightedPowerMean_pos` establish the positivity conditions needed for the inversion step. This identity is the key tool for reducing negative-exponent power mean problems to positive-exponent ones.",
     "mathContext": "$M_r(z) = \\left(\\sum w_i z_i^r\\right)^{1/r} = \\left(\\sum w_i (z_i^{-1})^{-r}\\right)^{1/r} = \\left(\\left(\\sum w_i (z_i^{-1})^{-r}\\right)^{1/(-r)}\\right)^{-1} = M_{-r}(z^{-1})^{-1}$. The identity holds for all $r \\neq 0$ and $z_i > 0$.",
     "significance": "key",
@@ -176,9 +176,9 @@
       "endLine": 343
     },
     "type": "theorem",
-    "title": "Power Mean Monotonicity for r ≤ s < 0 (Dual Argument)",
+    "title": "Power Mean Monotonicity for r \u2264 s < 0 (Dual Argument)",
     "content": "`power_mean_monotone_neg` proves $M_r \\leq M_s$ for $r \\leq s < 0$ by a three-step dual argument: (1) negate exponents to get $0 < -s \\leq -r$; (2) apply `power_mean_monotone_pos` to $z^{-1}$ with exponents $-s \\leq -r$ to get $M_{-s}(z^{-1}) \\leq M_{-r}(z^{-1})$; (3) apply `power_mean_neg_inv` to convert back: $M_r(z) = M_{-r}(z^{-1})^{-1} \\leq M_{-s}(z^{-1})^{-1} = M_s(z)$. The inversion step (larger denominator gives smaller reciprocal) uses explicit `calc` blocks with multiplicative algebra to avoid `inv_le_inv_of_le` which was unavailable in the target Lean version.",
-    "mathContext": "For $r \\leq s < 0$: negate to $0 < -s \\leq -r$, apply positive monotonicity to $z^{-1}$: $M_{-s}(z^{-1}) \\leq M_{-r}(z^{-1})$. Invert (larger positive → smaller reciprocal): $M_{-r}(z^{-1})^{-1} \\leq M_{-s}(z^{-1})^{-1}$. By duality: $M_r(z) \\leq M_s(z)$. Combined with positive case: $M_r \\leq M_s$ for all same-sign $r \\leq s$.",
+    "mathContext": "For $r \\leq s < 0$: negate to $0 < -s \\leq -r$, apply positive monotonicity to $z^{-1}$: $M_{-s}(z^{-1}) \\leq M_{-r}(z^{-1})$. Invert (larger positive \u2192 smaller reciprocal): $M_{-r}(z^{-1})^{-1} \\leq M_{-s}(z^{-1})^{-1}$. By duality: $M_r(z) \\leq M_s(z)$. Combined with positive case: $M_r \\leq M_s$ for all same-sign $r \\leq s$.",
     "significance": "key",
     "relatedConcepts": [
       "duality argument",
@@ -201,7 +201,7 @@
     },
     "type": "insight",
     "title": "Interpolation Chain Summary: All Same-Sign Cases Proved",
-    "content": "The summary theorem power_mean_interpolation_summary catalogs the complete status: GM ≤ AM (Mathlib), AM ≤ M_p for p ≥ 1 (Mathlib), HM ≤ GM (new direct proof), M_r ≤ M_s for 0 < r ≤ s (new, Jensen), M_r ≤ M_s for r ≤ s < 0 (new, duality). The file compiles with 0 axioms and 0 sorries. Only the mixed-sign case (r < 0 < s, crossing the geometric mean limit) remains as a future direction.",
+    "content": "The summary theorem power_mean_interpolation_summary catalogs the complete status: GM \u2264 AM (Mathlib), AM \u2264 M_p for p \u2265 1 (Mathlib), HM \u2264 GM (new direct proof), M_r \u2264 M_s for 0 < r \u2264 s (new, Jensen), M_r \u2264 M_s for r \u2264 s < 0 (new, duality). The file compiles with 0 axioms and 0 sorries. Only the mixed-sign case (r < 0 < s, crossing the geometric mean limit) remains as a future direction.",
     "mathContext": "All proved: $\\text{GM} \\leq \\text{AM}$, $\\text{AM} \\leq M_p$ ($p \\geq 1$), $\\text{HM} \\leq \\text{GM}$, $M_r \\leq M_s$ ($0 < r \\leq s$), $M_r \\leq M_s$ ($r \\leq s < 0$). Open: $M_r \\leq M_s$ for $r < 0 < s$.",
     "significance": "supporting",
     "relatedConcepts": [


### PR DESCRIPTION
Fix annotation schema violations (invalid startLine values) in three proof entries.

## Changes

### amgm-inequality-oq-03
- `ann-amgm-oq03-01b-variables`: 57 → 55 (variable decl → import line)

### amgm-inequality-oq-02-oq-01-oq-02
- `ann-decomposition`: 27 → 31 (banner comment → docstring)
- `ann-swap-image`: 53 → 57 (banner comment → docstring)
- `ann-core-symmetry`: 71 → 75 (banner comment → docstring)
- `ann-main-theorem`: 100 → 103 (banner comment → docstring)
- `ann-application`: 118 → 120 (banner comment → docstring)

### amgm-inequality-oq-02
- `ann-amgm-oq02-binomial-identity`: 203 → 205 (blank line → `private theorem`)

All annotations now validate cleanly.