### PR TITLE
Enrich cube-root-3-irrational and harmonic-divergence-oq-01

### DIFF
--- a/src/data/proofs/harmonic-divergence-oq-01/annotations.json
+++ b/src/data/proofs/harmonic-divergence-oq-01/annotations.json
@@ -27,6 +27,47 @@
     }
   },
   {
+    "id": "ann-euler-mascheroni-basics",
+    "proofId": "harmonic-divergence-oq-01",
+    "type": "concept",
+    "range": { "startLine": 33, "endLine": 102 },
+    "title": "Convergence, Bounds, and Basic Properties of γ",
+    "content": "This section (the largest in the file) proves the foundational properties of γ:\n\n**Convergence**: Both γ_seq (increasing, H_n − log(n+1)) and γ_seq' (decreasing, H_n − log n) converge to γ, delegating to Mathlib's `Real.tendsto_eulerMascheroniSeq` and `Real.tendsto_eulerMascheroniSeq'`.\n\n**Monotonicity**: γ_seq is strictly increasing, γ_seq' is strictly decreasing, and γ_seq(m) < γ_seq'(n) for all m, n.\n\n**Bounds**: `one_half_lt_γ`: 1/2 < γ (from `Real.one_half_lt_eulerMascheroniConstant`). `γ_lt_two_thirds`: γ < 2/3. Together: γ ∈ (1/2, 2/3).\n\n**Consequences**: γ > 0, γ ≠ 0, γ ≠ 1, γ ∈ (0,1), γ ≠ any integer. Boundary values γ_seq(0) = 0, γ_seq'(1) = 1. Also: harmonic divergence wrappers, exp(γ) bounds (1 < exp(γ) < exp(1)), and harmonic recurrence H_{n+1} = H_n + 1/(n+1).",
+    "mathContext": "The bounds $1/2 < \\gamma < 2/3$ can be verified computationally: $\\gamma \\approx 0.5772156649...$. The sandwich $\\gamma_{\\text{seq}}(n) < \\gamma < \\gamma_{\\text{seq}}'(n)$ gives: at $n=1$, $\\gamma_{\\text{seq}}(1) = 1 - \\log 2 \\approx 0.307$ and $\\gamma_{\\text{seq}}'(1) = 1 \\approx 1.000$. At $n=5$: lower $\\approx 0.548$, upper $\\approx 0.748$, showing convergence toward the true value.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Real.eulerMascheroniConstant",
+      "Real.tendsto_eulerMascheroniSeq",
+      "one_half_lt_eulerMascheroniConstant",
+      "eulerMascheroniConstant_lt_two_thirds",
+      "harmonic series divergence"
+    ],
+    "prerequisites": [
+      "Mathlib.NumberTheory.Harmonic.EulerMascheroni",
+      "Real.eulerMascheroniConstant bounds"
+    ]
+  },
+  {
+    "id": "ann-euler-mascheroni-log-bounds",
+    "proofId": "harmonic-divergence-oq-01",
+    "type": "theorem",
+    "range": { "startLine": 103, "endLine": 126 },
+    "title": "Log Bounds: log(n+1) ≤ H_n ≤ 1 + log(n)",
+    "content": "Four log-harmonic inequalities, all delegating to `Mathlib.NumberTheory.Harmonic.Bounds`:\n\n1. `harmonic_lower_log`: log(n+1) ≤ H_n — the harmonic sum exceeds the integral ∫₁ⁿ⁺¹ 1/x dx = log(n+1).\n2. `harmonic_upper_log`: H_n ≤ 1 + log(n) — the harmonic sum is bounded by 1 + ∫₁ⁿ 1/x dx = 1 + log(n).\n3. `harmonic_sum_eq`: H_n = Σ_{i=1}^n 1/i as a sum over Finset.Icc 1 n (alternate formulation).\n4. Real extensions for non-integer y: log(y) ≤ H_{⌊y⌋} and H_{⌊y⌋} ≤ 1 + log(y) for y ≥ 1.\n\nThese bounds connect the discrete harmonic series to continuous logarithm via the integral comparison: each term 1/k lies between ∫_{k-1}^k 1/x dx and ∫_k^{k+1} 1/x dx.",
+    "mathContext": "The integral comparison: $\\int_1^{n+1} \\frac{dx}{x} \\leq \\sum_{k=1}^n \\frac{1}{k} \\leq 1 + \\int_1^n \\frac{dx}{x}$, i.e., $\\log(n+1) \\leq H_n \\leq 1 + \\log n$. Combined with the definition $\\gamma = \\lim(H_n - \\log n)$, these give $\\log(n+1) - \\log n \\leq H_n - \\log n \\leq 1$, confirming $0 < \\gamma \\leq 1$. The upper bound $1 + \\log n$ vs the asymptotic $H_n \\sim \\log n + \\gamma + 1/(2n) - ...$ shows the error is exactly $\\gamma$ plus lower-order terms.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "integral comparison test",
+      "harmonic series log estimate",
+      "Harmonic.Bounds",
+      "Finset.Icc sum formulation"
+    ],
+    "prerequisites": [
+      "Mathlib.NumberTheory.Harmonic.Bounds",
+      "harmonic_le_log from Mathlib"
+    ]
+  },
+  {
     "id": "ann-euler-mascheroni-sandwich",
     "line": 148,
     "endLine": 175,

--- a/src/data/proofs/harmonic-divergence-oq-01/meta.json
+++ b/src/data/proofs/harmonic-divergence-oq-01/meta.json
@@ -117,7 +117,33 @@
       "description": "Comment-only documentation (no compiled code) of the Gamma function and Riemann Zeta function connections: \u03b3 = \u2212\u0393'(1), \u0393'(n+1) = n!(\u2212\u03b3 + H_n), \u0393'(1/2) = \u2212\u221a\u03c0(\u03b3 + 2 ln 2), and lim_{s\u21921}(\u03b6(s) \u2212 1/(s\u22121)) = \u03b3. These import from `GammaDeriv` and `ZetaAsymp` which consume >32GB during `lake build` and are excluded from production builds. Their signatures are documented here to connect \u03b3 to its deepest mathematical context."
     }
   ],
-  "crossReferences": [],
+  "crossReferences": [
+    {
+      "targetId": "harmonic-divergence",
+      "relationship": "extends",
+      "description": "The parent entry proves harmonic series divergence (Σ 1/n = ∞) and establishes basic harmonic number properties. This OQ-01 entry extends to the defining constant γ = lim(H_n − log n), bounds, rational exclusion, and Theisinger's theorem"
+    },
+    {
+      "targetId": "harmonic-divergence-oq-02",
+      "relationship": "sibling",
+      "description": "Sibling entry exploring further aspects of harmonic series and related analysis beyond the Euler-Mascheroni constant"
+    },
+    {
+      "targetId": "harmonic-divergence-oq-04",
+      "relationship": "sibling",
+      "description": "Sibling entry on additional harmonic divergence properties and extensions"
+    },
+    {
+      "targetId": "basel-problem",
+      "relationship": "related",
+      "description": "The Basel problem ζ(2) = π²/6 is the p=2 case of the p-series. This entry establishes the p-series boundary (Σ 1/n^p summable iff p > 1), of which the Basel problem is the first non-trivial summable case. The Riemann zeta function ζ(s) connects both: γ is the Laurent coefficient of ζ at s=1"
+    },
+    {
+      "targetId": "riemann-hypothesis",
+      "relationship": "related",
+      "description": "The Riemann Hypothesis concerns zeros of ζ(s); this entry documents (as comments) that γ = lim_{s→1}(ζ(s) − 1/(s−1)) — the constant term in the Laurent expansion. The connection γ → ζ → RH places γ at the heart of one of the Millennium Prize Problems"
+    }
+  ],
   "leanFile": {
     "lineCount": 253,
     "path": "Proofs/HarmonicDivergenceOQ01.lean",


### PR DESCRIPTION
Enrichment passes for two gallery entries.

## cube-root-3-irrational (Irrationality of ∛3)
- **Annotations**: 5 → 6, adding header/imports annotation documenting irrational_nrt_of_notint_nrt template
- **Cross-references**: 3 → 5 (added cube-root-3-irrational-oq-02 and sqrt2-plus-sqrt3-irrational)

## harmonic-divergence-oq-01 (Euler-Mascheroni Constant)
- **Annotations**: 5 → 7, adding:
  - Lines 33-102: basics section (convergence, bounds, monotonicity, γ ∈ (1/2, 2/3))
  - Lines 103-126: log bounds (integral comparison: log(n+1) ≤ H_n ≤ 1+log(n))
- **Cross-references**: 0 → 5 (was completely empty — added harmonic-divergence parent, siblings oq-02 and oq-04, basel-problem via p-series boundary, riemann-hypothesis via ζ Laurent coefficient)