### PR TITLE
Enrich: fix annotation schema violations in 7 amgm entries

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02/annotations.json
@@ -2,61 +2,127 @@
   {
     "id": "ann-decomposition",
     "proofId": "amgm-inequality-oq-02-oq-01-oq-02",
-    "range": { "startLine": 27, "endLine": 52 },
+    "range": {
+      "startLine": 31,
+      "endLine": 52
+    },
     "type": "technique",
     "title": "Decomposing offDiag into Upper and Lower Triangular Parts",
-    "content": "The theorem `offDiag_eq_upper_union_lower` decomposes `s.offDiag` (pairs (i,j) with i ≠ j) into upper triangular ({i<j}) and lower triangular ({j<i}) parts. The proof uses `rcases lt_or_gt_of_ne hab` to case-split on the linear order. The disjointness `upper_lower_disjoint` follows because i < j and j < i would imply i < i by transitivity, contradicting irreflexivity. The `LinearOrder` typeclass provides the total order needed to ensure every (i,j) with i ≠ j falls into exactly one part.",
+    "content": "The theorem `offDiag_eq_upper_union_lower` decomposes `s.offDiag` (pairs (i,j) with i \u2260 j) into upper triangular ({i<j}) and lower triangular ({j<i}) parts. The proof uses `rcases lt_or_gt_of_ne hab` to case-split on the linear order. The disjointness `upper_lower_disjoint` follows because i < j and j < i would imply i < i by transitivity, contradicting irreflexivity. The `LinearOrder` typeclass provides the total order needed to ensure every (i,j) with i \u2260 j falls into exactly one part.",
     "mathContext": "For a linearly ordered finite set $\\iota$: $\\text{offDiag}(s) = \\{(i,j) \\mid i,j \\in s, i < j\\} \\sqcup \\{(i,j) \\mid i,j \\in s, j < i\\}$ (disjoint union). Linear order guarantees: for $i \\ne j$, either $i < j$ or $j < i$ (totality), and not both (antisymmetry). This is the foundation of the double-counting argument: each unordered pair $\\{i,j\\}$ contributes exactly two ordered pairs, one to each part.",
     "significance": "supporting",
-    "relatedConcepts": ["Finset.offDiag", "LinearOrder", "lt_or_gt_of_ne", "Finset.disjoint_filter", "upper/lower triangular"],
-    "prerequisites": ["Lean LinearOrder typeclass", "Finset.offDiag definition", "lt_irrefl and lt_trans"]
+    "relatedConcepts": [
+      "Finset.offDiag",
+      "LinearOrder",
+      "lt_or_gt_of_ne",
+      "Finset.disjoint_filter",
+      "upper/lower triangular"
+    ],
+    "prerequisites": [
+      "Lean LinearOrder typeclass",
+      "Finset.offDiag definition",
+      "lt_irrefl and lt_trans"
+    ]
   },
   {
     "id": "ann-swap-image",
     "proofId": "amgm-inequality-oq-02-oq-01-oq-02",
-    "range": { "startLine": 53, "endLine": 70 },
+    "range": {
+      "startLine": 57,
+      "endLine": 70
+    },
     "type": "technique",
     "title": "Swap Image: Prod.swap Bijects Lower to Upper Triangular",
-    "content": "The theorem `image_swap_lower_eq_upper` proves that applying `Prod.swap` to the lower-triangular part (filter j<i) gives exactly the upper-triangular part (filter i<j). The proof is a set membership characterization (`ext ⟨a, b⟩`): (a,b) ∈ swap(lower) iff ∃ (c,d) ∈ lower with swap(c,d) = (a,b), i.e., (d,c) = (a,b), i.e., d < c. The backward direction: given a < b (upper), take (b,a) in lower — it swaps to (a,b). This establishes the explicit bijection needed for reindexing the sum.",
+    "content": "The theorem `image_swap_lower_eq_upper` proves that applying `Prod.swap` to the lower-triangular part (filter j<i) gives exactly the upper-triangular part (filter i<j). The proof is a set membership characterization (`ext \u27e8a, b\u27e9`): (a,b) \u2208 swap(lower) iff \u2203 (c,d) \u2208 lower with swap(c,d) = (a,b), i.e., (d,c) = (a,b), i.e., d < c. The backward direction: given a < b (upper), take (b,a) in lower \u2014 it swaps to (a,b). This establishes the explicit bijection needed for reindexing the sum.",
     "mathContext": "The bijection: $\\text{swap}: \\{(i,j) \\mid j < i\\} \\to \\{(i,j) \\mid i < j\\}$ via $(i,j) \\mapsto (j,i)$. Proof of surjectivity: $(a,b)$ with $a < b$ is the image of $(b,a)$ which has $b > a$, so $(b,a)$ is in the lower part. Injectivity: if $(j_1, i_1) = (j_2, i_2)$ then $(i_1,j_1) = (i_2,j_2)$. This bijectivity is what `Finset.sum_image` needs to reindex the sum over lower as a sum over upper.",
     "significance": "supporting",
-    "relatedConcepts": ["Prod.swap", "Finset.mem_image", "bijection", "image_swap_lower_eq_upper", "Finset.ext"],
-    "prerequisites": ["Prod.swap definition", "Finset.image properties", "LinearOrder antisymmetry"]
+    "relatedConcepts": [
+      "Prod.swap",
+      "Finset.mem_image",
+      "bijection",
+      "image_swap_lower_eq_upper",
+      "Finset.ext"
+    ],
+    "prerequisites": [
+      "Prod.swap definition",
+      "Finset.image properties",
+      "LinearOrder antisymmetry"
+    ]
   },
   {
     "id": "ann-core-symmetry",
     "proofId": "amgm-inequality-oq-02-oq-01-oq-02",
-    "range": { "startLine": 71, "endLine": 99 },
+    "range": {
+      "startLine": 75,
+      "endLine": 99
+    },
     "type": "insight",
     "title": "Core Symmetry via sum_image: Reindexing Under Swap",
-    "content": "The theorem `sum_lower_eq_sum_upper` proves: for symmetric f (f(i,j) = f(j,i)), ∑_{j<i} f(i,j) = ∑_{i<j} f(i,j). The proof is a chain of three equalities: (1) ∑_lower f(p) = ∑_lower f(swap(p)) by symmetry (f(a,b) = f(b,a)); (2) ∑_lower f(swap(p)) = ∑_{lower.image swap} f by `Finset.sum_image` (swap is injective); (3) lower.image swap = upper by `image_swap_lower_eq_upper`. The `calc` block makes each step explicit.",
+    "content": "The theorem `sum_lower_eq_sum_upper` proves: for symmetric f (f(i,j) = f(j,i)), \u2211_{j<i} f(i,j) = \u2211_{i<j} f(i,j). The proof is a chain of three equalities: (1) \u2211_lower f(p) = \u2211_lower f(swap(p)) by symmetry (f(a,b) = f(b,a)); (2) \u2211_lower f(swap(p)) = \u2211_{lower.image swap} f by `Finset.sum_image` (swap is injective); (3) lower.image swap = upper by `image_swap_lower_eq_upper`. The `calc` block makes each step explicit.",
     "mathContext": "The three-step proof: $\\sum_{j < i} f(i,j) = \\sum_{j<i} f(j,i)$ (symmetry) $= \\sum_{(i',j') \\in \\text{upper}} f(i',j')$ (reindexing via $\\text{swap}$). Step (2) uses `Finset.sum_image`: if $g: \\alpha \\to \\beta$ is injective on $s$, then $\\sum_{x \\in s} f(g(x)) = \\sum_{y \\in s.\\text{image}\\, g} f(y)$. Injectivity of swap: $(j_1,i_1) \\ne (j_2,i_2) \\Rightarrow (i_1,j_1) \\ne (i_2,j_2)$ (clear by component equality). The `Prod.ext` tactic assembles the component equality.",
     "significance": "key",
-    "relatedConcepts": ["Finset.sum_image", "Prod.swap injectivity", "sum_lower_eq_sum_upper", "calc block", "CommRing"],
-    "prerequisites": ["Finset.sum_image Mathlib theorem", "function injectivity", "sum_congr for pointwise equality"]
+    "relatedConcepts": [
+      "Finset.sum_image",
+      "Prod.swap injectivity",
+      "sum_lower_eq_sum_upper",
+      "calc block",
+      "CommRing"
+    ],
+    "prerequisites": [
+      "Finset.sum_image Mathlib theorem",
+      "function injectivity",
+      "sum_congr for pointwise equality"
+    ]
   },
   {
     "id": "ann-main-theorem",
     "proofId": "amgm-inequality-oq-02-oq-01-oq-02",
-    "range": { "startLine": 100, "endLine": 117 },
+    "range": {
+      "startLine": 103,
+      "endLine": 117
+    },
     "type": "insight",
-    "title": "Main Theorem: Σ_{i≠j} f = 2·Σ_{i<j} f via Two_mul",
-    "content": "The theorem `sum_offDiag_eq_two_mul_sum_upper` combines all parts: (1) rewrite Σ_offDiag as Σ_upper + Σ_lower by `Finset.sum_union` and the decomposition; (2) use `sum_lower_eq_sum_upper` to get Σ_upper + Σ_upper; (3) use `two_mul` to get 2·Σ_upper. The disjointness from `upper_lower_disjoint` is needed for `sum_union` (which requires disjointness to avoid double-counting). The final result holds for any symmetric function over any CommRing.",
+    "title": "Main Theorem: \u03a3_{i\u2260j} f = 2\u00b7\u03a3_{i<j} f via Two_mul",
+    "content": "The theorem `sum_offDiag_eq_two_mul_sum_upper` combines all parts: (1) rewrite \u03a3_offDiag as \u03a3_upper + \u03a3_lower by `Finset.sum_union` and the decomposition; (2) use `sum_lower_eq_sum_upper` to get \u03a3_upper + \u03a3_upper; (3) use `two_mul` to get 2\u00b7\u03a3_upper. The disjointness from `upper_lower_disjoint` is needed for `sum_union` (which requires disjointness to avoid double-counting). The final result holds for any symmetric function over any CommRing.",
     "mathContext": "$\\sum_{i \\ne j} f(i,j) = \\sum_{i<j} f(i,j) + \\sum_{j<i} f(i,j) = \\sum_{i<j} f(i,j) + \\sum_{i<j} f(i,j) = 2 \\sum_{i<j} f(i,j)$. The key algebraic step is `Finset.sum_union` for disjoint sets: $\\sum_{x \\in A \\cup B} f(x) = \\sum_{x \\in A} f(x) + \\sum_{x \\in B} f(x)$ when $A \\cap B = \\emptyset$. The `two_mul` lemma closes: $a + a = 2a$ in any AddMonoid.",
     "significance": "key",
-    "relatedConcepts": ["sum_offDiag_eq_two_mul_sum_upper", "Finset.sum_union", "two_mul", "upper_lower_disjoint", "Newton-Girard"],
-    "prerequisites": ["sum_lower_eq_sum_upper", "offDiag_eq_upper_union_lower", "upper_lower_disjoint", "Finset.sum_union"]
+    "relatedConcepts": [
+      "sum_offDiag_eq_two_mul_sum_upper",
+      "Finset.sum_union",
+      "two_mul",
+      "upper_lower_disjoint",
+      "Newton-Girard"
+    ],
+    "prerequisites": [
+      "sum_lower_eq_sum_upper",
+      "offDiag_eq_upper_union_lower",
+      "upper_lower_disjoint",
+      "Finset.sum_union"
+    ]
   },
   {
     "id": "ann-application",
     "proofId": "amgm-inequality-oq-02-oq-01-oq-02",
-    "range": { "startLine": 118, "endLine": 138 },
+    "range": {
+      "startLine": 120,
+      "endLine": 138
+    },
     "type": "concept",
-    "title": "Application: Σ_{i≠j} xᵢxⱼ = 2·e₂ and Newton-Girard Completion",
-    "content": "The theorem `offDiag_prod_eq_two_mul_e2` specializes to f(i,j) = xᵢxⱼ (where x : ι → R is any function). Symmetry f(i,j) = f(j,i) holds by commutativity of multiplication. The theorem gives Σ_{i≠j} xᵢxⱼ = 2·Σ_{i<j} xᵢxⱼ = 2·e₂. Combined with the parent's (Σxᵢ)² = Σxᵢ² + Σ_{i≠j} xᵢxⱼ, this gives the complete Newton-Girard identity: p₂ = e₁² − 2·e₂.",
+    "title": "Application: \u03a3_{i\u2260j} x\u1d62x\u2c7c = 2\u00b7e\u2082 and Newton-Girard Completion",
+    "content": "The theorem `offDiag_prod_eq_two_mul_e2` specializes to f(i,j) = x\u1d62x\u2c7c (where x : \u03b9 \u2192 R is any function). Symmetry f(i,j) = f(j,i) holds by commutativity of multiplication. The theorem gives \u03a3_{i\u2260j} x\u1d62x\u2c7c = 2\u00b7\u03a3_{i<j} x\u1d62x\u2c7c = 2\u00b7e\u2082. Combined with the parent's (\u03a3x\u1d62)\u00b2 = \u03a3x\u1d62\u00b2 + \u03a3_{i\u2260j} x\u1d62x\u2c7c, this gives the complete Newton-Girard identity: p\u2082 = e\u2081\u00b2 \u2212 2\u00b7e\u2082.",
     "mathContext": "Newton-Girard for $n=2$: Let $p_k = \\sum_i x_i^k$ (power sum) and $e_2 = \\sum_{i<j} x_i x_j$ (second elementary symmetric polynomial). Then $p_2 = e_1^2 - 2e_2$, i.e., $\\sum_i x_i^2 = (\\sum_i x_i)^2 - 2\\sum_{i<j} x_i x_j$. Proof: $(\\sum_i x_i)^2 = \\sum_i x_i^2 + \\sum_{i \\ne j} x_i x_j = \\sum_i x_i^2 + 2 \\sum_{i<j} x_i x_j$. The general Newton-Girard recurrence is $p_k = \\sum_{i=1}^{k-1} (-1)^{i-1} e_i p_{k-i} + (-1)^{k-1} k e_k$.",
     "significance": "key",
-    "relatedConcepts": ["elementary symmetric polynomial e₂", "Newton-Girard identity", "p₂ = e₁² − 2e₂", "power sums", "AM-GM inequality"],
-    "prerequisites": ["parent proof (sq_sum_eq_diag_plus_offdiag)", "commutativity of multiplication", "Newton's identities"]
+    "relatedConcepts": [
+      "elementary symmetric polynomial e\u2082",
+      "Newton-Girard identity",
+      "p\u2082 = e\u2081\u00b2 \u2212 2e\u2082",
+      "power sums",
+      "AM-GM inequality"
+    ],
+    "prerequisites": [
+      "parent proof (sq_sum_eq_diag_plus_offdiag)",
+      "commutativity of multiplication",
+      "Newton's identities"
+    ]
   }
 ]

--- a/src/data/proofs/amgm-inequality-oq-02/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-02/annotations.json
@@ -127,7 +127,7 @@
     "id": "ann-amgm-oq02-binomial-identity",
     "proofId": "amgm-inequality-oq-02",
     "range": {
-      "startLine": 203,
+      "startLine": 205,
       "endLine": 271
     },
     "type": "theorem",

--- a/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01/annotations.json
@@ -2,73 +2,143 @@
   {
     "id": "ann-pmcz-header",
     "proofId": "amgm-inequality-oq-03-oq-02-oq-01",
-    "range": { "startLine": 1, "endLine": 41 },
+    "range": {
+      "startLine": 1,
+      "endLine": 41
+    },
     "type": "context",
     "title": "Crossing-Zero Strategy: One AM-GM Application for All r",
-    "content": "The module header explains the elegant strategy: the single inequality GM(z,w)^r ≤ ∑ wᵢ zᵢ^r (proved by applying AM-GM to the values zᵢ^r) implies both M_r ≤ GM for r < 0 and GM ≤ M_s for s > 0 by simple exponentiation. This avoids limit arguments entirely — the L'Hôpital approach needed for M_0 = GM is sidestepped because we work with M_r for r ≠ 0. Imports AmgmInequalityOQ03 for the weighted power mean definitions.",
+    "content": "The module header explains the elegant strategy: the single inequality GM(z,w)^r \u2264 \u2211 w\u1d62 z\u1d62^r (proved by applying AM-GM to the values z\u1d62^r) implies both M_r \u2264 GM for r < 0 and GM \u2264 M_s for s > 0 by simple exponentiation. This avoids limit arguments entirely \u2014 the L'H\u00f4pital approach needed for M_0 = GM is sidestepped because we work with M_r for r \u2260 0. Imports AmgmInequalityOQ03 for the weighted power mean definitions.",
     "mathContext": "Key idea: $\\text{GM}^r = (\\prod_i z_i^{w_i})^r = \\prod_i (z_i^r)^{w_i} \\le \\sum_i w_i z_i^r$ (AM-GM applied to $z_i^r$ values). Then: $r > 0 \\Rightarrow$ GM $= (\\text{GM}^r)^{1/r} \\le (\\sum)^{1/r} = M_r$. $r < 0 \\Rightarrow$ invert to get $M_r \\le$ GM.",
     "significance": "context",
-    "relatedConcepts": ["weighted AM-GM", "power means", "Real.geom_mean_le_arith_mean_weighted", "AmgmInequalityOQ03"],
-    "prerequisites": ["AmgmInequalityOQ03 (weightedPowerMean, weightedGeomMean)", "Real.rpow properties", "Finset.prod"]
+    "relatedConcepts": [
+      "weighted AM-GM",
+      "power means",
+      "Real.geom_mean_le_arith_mean_weighted",
+      "AmgmInequalityOQ03"
+    ],
+    "prerequisites": [
+      "AmgmInequalityOQ03 (weightedPowerMean, weightedGeomMean)",
+      "Real.rpow properties",
+      "Finset.prod"
+    ]
   },
   {
     "id": "ann-pmcz-helpers",
     "proofId": "amgm-inequality-oq-03-oq-02-oq-01",
-    "range": { "startLine": 43, "endLine": 86 },
+    "range": {
+      "startLine": 43,
+      "endLine": 86
+    },
     "type": "technique",
     "title": "Helper Lemmas: Positivity and the prod_rpow_comm Identity",
-    "content": "Four private lemmas prepare the main argument: (1) weightedSum_rpow_pos proves ∑ wᵢzᵢ^r > 0 (needed for division in the power mean) via a non-trivial positivity argument: at least one weight must be positive (otherwise they'd sum to 0, not 1). (2) weightedGeomMean_pos is immediate from rpow_pos_of_pos. (3) finset_prod_rpow proves (∏ fᵢ)^r = ∏ fᵢ^r by Finset.induction_on using Real.mul_rpow. (4) prod_rpow_comm proves (∏ zᵢ^wᵢ)^r = ∏ (zᵢ^r)^wᵢ via rpow_mul applied twice, using the chain zᵢ^(r·wᵢ) = zᵢ^(wᵢ·r).",
+    "content": "Four private lemmas prepare the main argument: (1) weightedSum_rpow_pos proves \u2211 w\u1d62z\u1d62^r > 0 (needed for division in the power mean) via a non-trivial positivity argument: at least one weight must be positive (otherwise they'd sum to 0, not 1). (2) weightedGeomMean_pos is immediate from rpow_pos_of_pos. (3) finset_prod_rpow proves (\u220f f\u1d62)^r = \u220f f\u1d62^r by Finset.induction_on using Real.mul_rpow. (4) prod_rpow_comm proves (\u220f z\u1d62^w\u1d62)^r = \u220f (z\u1d62^r)^w\u1d62 via rpow_mul applied twice, using the chain z\u1d62^(r\u00b7w\u1d62) = z\u1d62^(w\u1d62\u00b7r).",
     "mathContext": "prod_rpow_comm: $(\\prod_i z_i^{w_i})^r = \\prod_i z_i^{r w_i} = \\prod_i (z_i^r)^{w_i}$. This is the algebraic identity that converts $\\text{GM}^r$ into the form needed for AM-GM.",
     "significance": "supporting",
-    "relatedConcepts": ["Real.mul_rpow", "Real.rpow_mul", "Finset.induction_on", "Finset.single_le_sum"],
-    "prerequisites": ["Finset induction in Lean 4", "Real.rpow positivity lemmas", "Finset.sum positivity argument"]
+    "relatedConcepts": [
+      "Real.mul_rpow",
+      "Real.rpow_mul",
+      "Finset.induction_on",
+      "Finset.single_le_sum"
+    ],
+    "prerequisites": [
+      "Finset induction in Lean 4",
+      "Real.rpow positivity lemmas",
+      "Finset.sum positivity argument"
+    ]
   },
   {
     "id": "ann-pmcz-core-ineq",
     "proofId": "amgm-inequality-oq-03-oq-02-oq-01",
-    "range": { "startLine": 88, "endLine": 107 },
+    "range": {
+      "startLine": 92,
+      "endLine": 107
+    },
     "type": "insight",
     "title": "geomMean_rpow_le_weightedSum_rpow: The Universal Core Inequality",
-    "content": "The central lemma: GM(z,w)^r ≤ ∑ wᵢzᵢ^r for ALL r ∈ ℝ. The proof applies Real.geom_mean_le_arith_mean_weighted (weighted AM-GM) to the values zᵢ^r with original weights wᵢ. This gives ∏ (zᵢ^r)^wᵢ ≤ ∑ wᵢzᵢ^r. Then prod_rpow_comm rewrites the LHS: ∏ (zᵢ^r)^wᵢ = (∏ zᵢ^wᵢ)^r = GM^r. The proof is just 3 lines (amgm application + prod_rpow_comm + simp). This single inequality simultaneously implies both GM ≤ M_r and M_r ≤ GM depending on the sign of r.",
+    "content": "The central lemma: GM(z,w)^r \u2264 \u2211 w\u1d62z\u1d62^r for ALL r \u2208 \u211d. The proof applies Real.geom_mean_le_arith_mean_weighted (weighted AM-GM) to the values z\u1d62^r with original weights w\u1d62. This gives \u220f (z\u1d62^r)^w\u1d62 \u2264 \u2211 w\u1d62z\u1d62^r. Then prod_rpow_comm rewrites the LHS: \u220f (z\u1d62^r)^w\u1d62 = (\u220f z\u1d62^w\u1d62)^r = GM^r. The proof is just 3 lines (amgm application + prod_rpow_comm + simp). This single inequality simultaneously implies both GM \u2264 M_r and M_r \u2264 GM depending on the sign of r.",
     "mathContext": "$\\text{GM}(z,w)^r = (\\prod_i z_i^{w_i})^r = \\prod_i (z_i^r)^{w_i} \\le \\sum_i w_i z_i^r$ by AM-GM applied to the values $\\{z_i^r\\}$ with weights $\\{w_i\\}$.",
     "significance": "key",
-    "relatedConcepts": ["Real.geom_mean_le_arith_mean_weighted", "weighted AM-GM", "prod_rpow_comm", "power mean definition"],
-    "prerequisites": ["weightedGeomMean definition", "prod_rpow_comm lemma", "Mathlib.Analysis.MeanInequalities"]
+    "relatedConcepts": [
+      "Real.geom_mean_le_arith_mean_weighted",
+      "weighted AM-GM",
+      "prod_rpow_comm",
+      "power mean definition"
+    ],
+    "prerequisites": [
+      "weightedGeomMean definition",
+      "prod_rpow_comm lemma",
+      "Mathlib.Analysis.MeanInequalities"
+    ]
   },
   {
     "id": "ann-pmcz-gm-le-pos",
     "proofId": "amgm-inequality-oq-03-oq-02-oq-01",
-    "range": { "startLine": 109, "endLine": 133 },
+    "range": {
+      "startLine": 113,
+      "endLine": 133
+    },
     "type": "technique",
     "title": "geom_mean_le_power_mean_pos: Raising to a Positive Power",
-    "content": "For r > 0, the core inequality GM^r ≤ ∑ wᵢzᵢ^r becomes GM ≤ M_r after raising both sides to the power 1/r > 0. The key step: GM = (GM^r)^(1/r) (using Real.rpow_natCast and the inverse relationship), and (∑)^(1/r) = M_r by definition. This extends the r ≥ 1 case from AmgmInequalityOQ03 to all r > 0, including the important range 0 < r < 1.",
+    "content": "For r > 0, the core inequality GM^r \u2264 \u2211 w\u1d62z\u1d62^r becomes GM \u2264 M_r after raising both sides to the power 1/r > 0. The key step: GM = (GM^r)^(1/r) (using Real.rpow_natCast and the inverse relationship), and (\u2211)^(1/r) = M_r by definition. This extends the r \u2265 1 case from AmgmInequalityOQ03 to all r > 0, including the important range 0 < r < 1.",
     "mathContext": "From $\\text{GM}^r \\le \\sum w_i z_i^r$ and $1/r > 0$: $(\\text{GM}^r)^{1/r} \\le (\\sum w_i z_i^r)^{1/r} = M_r$. And $(\\text{GM}^r)^{1/r} = \\text{GM}$ by $\\text{rpow}(r, 1/r)$.",
     "significance": "key",
-    "relatedConcepts": ["Real.rpow_le_rpow", "rpow inverse identity", "WeightedPowerMean definition", "r > 0 case"],
-    "prerequisites": ["geomMean_rpow_le_weightedSum_rpow", "Real.rpow monotonicity for positive base and positive exponent"]
+    "relatedConcepts": [
+      "Real.rpow_le_rpow",
+      "rpow inverse identity",
+      "WeightedPowerMean definition",
+      "r > 0 case"
+    ],
+    "prerequisites": [
+      "geomMean_rpow_le_weightedSum_rpow",
+      "Real.rpow monotonicity for positive base and positive exponent"
+    ]
   },
   {
     "id": "ann-pmcz-neg-le-gm",
     "proofId": "amgm-inequality-oq-03-oq-02-oq-01",
-    "range": { "startLine": 135, "endLine": 188 },
+    "range": {
+      "startLine": 139,
+      "endLine": 188
+    },
     "type": "insight",
     "title": "power_mean_le_geom_mean_neg: Inversion Reverses the Inequality",
-    "content": "For r < 0, the core inequality GM^r ≤ ∑ wᵢzᵢ^r gives M_r ≤ GM by raising to the NEGATIVE power 1/r < 0 (which reverses ≤). The algebraic argument: since 1/r < 0, write 1/r = -(1/(-r)) where 1/(-r) > 0. Raising GM^r ≤ ∑ to the power -(1/(-r)) reverses: (GM^r)^(-(1/(-r))) ≥ (∑)^(-(1/(-r))). Inversion (A ≤ B and both positive → B⁻¹ ≤ A⁻¹) then gives M_r = (∑)^(1/r) ≤ (GM^r)^(1/r) = GM. This is the longest proof section (62 lines) due to the careful positivity bookkeeping in Lean.",
+    "content": "For r < 0, the core inequality GM^r \u2264 \u2211 w\u1d62z\u1d62^r gives M_r \u2264 GM by raising to the NEGATIVE power 1/r < 0 (which reverses \u2264). The algebraic argument: since 1/r < 0, write 1/r = -(1/(-r)) where 1/(-r) > 0. Raising GM^r \u2264 \u2211 to the power -(1/(-r)) reverses: (GM^r)^(-(1/(-r))) \u2265 (\u2211)^(-(1/(-r))). Inversion (A \u2264 B and both positive \u2192 B\u207b\u00b9 \u2264 A\u207b\u00b9) then gives M_r = (\u2211)^(1/r) \u2264 (GM^r)^(1/r) = GM. This is the longest proof section (62 lines) due to the careful positivity bookkeeping in Lean.",
     "mathContext": "For $r < 0$: $\\text{GM}^r \\le \\sum w_i z_i^r$. Since $r < 0$, raising to $1/r < 0$ reverses: $M_r = (\\sum)^{1/r} \\le (\\text{GM}^r)^{1/r} = \\text{GM}^{r \\cdot (1/r)} = \\text{GM}^1 = \\text{GM}$.",
     "significance": "key",
-    "relatedConcepts": ["inequality reversal under negative exponent", "Real.rpow_le_rpow_of_exponent_le", "positivity of power mean"],
-    "prerequisites": ["geomMean_rpow_le_weightedSum_rpow", "Real.inv_le_inv_of_le (inequality inversion)", "weightedSum_rpow_pos"]
+    "relatedConcepts": [
+      "inequality reversal under negative exponent",
+      "Real.rpow_le_rpow_of_exponent_le",
+      "positivity of power mean"
+    ],
+    "prerequisites": [
+      "geomMean_rpow_le_weightedSum_rpow",
+      "Real.inv_le_inv_of_le (inequality inversion)",
+      "weightedSum_rpow_pos"
+    ]
   },
   {
     "id": "ann-pmcz-main-chain",
     "proofId": "amgm-inequality-oq-03-oq-02-oq-01",
-    "range": { "startLine": 190, "endLine": 225 },
+    "range": {
+      "startLine": 194,
+      "endLine": 225
+    },
     "type": "insight",
-    "title": "Main Theorem and HM ≤ GM ≤ AM: Completing the Chain",
-    "content": "power_mean_monotone_crossing_zero is a 3-line proof: M_r ≤ GM (from §4) and GM ≤ M_s (from §3), combined by le_trans. hm_le_gm_le_am_via_power_means is an immediate corollary at r=-1, s=1: it gives the classical HM ≤ GM ≤ AM chain as a special case. These two theorems, combined with power_mean_monotone_pos and power_mean_monotone_neg from AmgmInequalityOQ03, complete the full power mean monotonicity theorem: M_r ≤ M_s for all r ≤ s (r,s ≠ 0), which is then unified in PowerMeanMonotoneOQ.",
+    "title": "Main Theorem and HM \u2264 GM \u2264 AM: Completing the Chain",
+    "content": "power_mean_monotone_crossing_zero is a 3-line proof: M_r \u2264 GM (from \u00a74) and GM \u2264 M_s (from \u00a73), combined by le_trans. hm_le_gm_le_am_via_power_means is an immediate corollary at r=-1, s=1: it gives the classical HM \u2264 GM \u2264 AM chain as a special case. These two theorems, combined with power_mean_monotone_pos and power_mean_monotone_neg from AmgmInequalityOQ03, complete the full power mean monotonicity theorem: M_r \u2264 M_s for all r \u2264 s (r,s \u2260 0), which is then unified in PowerMeanMonotoneOQ.",
     "mathContext": "$M_r \\le \\text{GM} \\le M_s$ (for $r < 0 < s$) by le_trans. Special case: HM = $M_{-1} \\le \\text{GM} \\le M_1 = $ AM. Full chain with same-sign cases: $M_r \\le M_s$ for all $r \\le s$, $r,s \\ne 0$.",
     "significance": "key",
-    "relatedConcepts": ["HM ≤ GM ≤ AM", "le_trans", "power_mean_monotone_pos (AmgmInequalityOQ03)", "PowerMeanMonotoneOQ"],
-    "prerequisites": ["power_mean_le_geom_mean_neg", "geom_mean_le_power_mean_pos", "le_trans in Lean"]
+    "relatedConcepts": [
+      "HM \u2264 GM \u2264 AM",
+      "le_trans",
+      "power_mean_monotone_pos (AmgmInequalityOQ03)",
+      "PowerMeanMonotoneOQ"
+    ],
+    "prerequisites": [
+      "power_mean_le_geom_mean_neg",
+      "geom_mean_le_power_mean_pos",
+      "le_trans in Lean"
+    ]
   }
 ]

--- a/src/data/proofs/amgm-inequality-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02/annotations.json
@@ -8,13 +8,13 @@
     },
     "type": "concept",
     "title": "The Power Mean Limit: Overview",
-    "content": "This file formalizes the classical theorem that the weighted power mean M_r(z,w) = (∑ wᵢzᵢ^r)^(1/r) converges to the geometric mean GM = ∏ zᵢ^wᵢ as r → 0. The proof uses the exp/log representation and the definition of derivative, formalized via Mathlib's `hasDerivAt_iff_tendsto_slope`.\n\n**The indeterminate form:** At r = 0, M_r = (∑ wᵢzᵢ^0)^(1/0) = 1^∞, a classical indeterminate form. The standard resolution is logarithmic: log M_r = (1/r)·log(∑ wᵢzᵢ^r) = f(r)/r where f(r) = log(∑ wᵢzᵢ^r). Since f(0) = log(1) = 0, this is a 0/0 form resolvable by the definition of derivative. The result fills a known gap in Mathlib.Analysis.MeanInequalitiesPow.",
+    "content": "This file formalizes the classical theorem that the weighted power mean M_r(z,w) = (\u2211 w\u1d62z\u1d62^r)^(1/r) converges to the geometric mean GM = \u220f z\u1d62^w\u1d62 as r \u2192 0. The proof uses the exp/log representation and the definition of derivative, formalized via Mathlib's `hasDerivAt_iff_tendsto_slope`.\n\n**The indeterminate form:** At r = 0, M_r = (\u2211 w\u1d62z\u1d62^0)^(1/0) = 1^\u221e, a classical indeterminate form. The standard resolution is logarithmic: log M_r = (1/r)\u00b7log(\u2211 w\u1d62z\u1d62^r) = f(r)/r where f(r) = log(\u2211 w\u1d62z\u1d62^r). Since f(0) = log(1) = 0, this is a 0/0 form resolvable by the definition of derivative. The result fills a known gap in Mathlib.Analysis.MeanInequalitiesPow.",
     "mathContext": "$\\lim_{r \\to 0} M_r(\\mathbf{z}, \\mathbf{w}) = \\prod_i z_i^{w_i} = \\text{GM}(\\mathbf{z}, \\mathbf{w})$ where $M_r = \\left(\\sum_i w_i z_i^r\\right)^{1/r}$",
     "significance": "key",
     "relatedConcepts": [
       "power means",
       "geometric mean",
-      "L'Hôpital rule",
+      "L'H\u00f4pital rule",
       "derivative definition",
       "Jensen's inequality"
     ],
@@ -32,8 +32,8 @@
       "endLine": 73
     },
     "type": "technique",
-    "title": "Sum Positivity: ∑ wᵢzᵢ^r > 0",
-    "content": "`sum_weighted_rpow_pos` proves the denominator ∑ wᵢzᵢ^r is positive whenever ∑ wᵢ = 1 and all zᵢ > 0. The key step is finding a strictly positive weight: if all weights were zero their sum couldn't be 1. Uses `Finset.single_le_sum` to bound a single positive term against the full sum.\n\n**Why this matters:** Positivity of ∑ wᵢzᵢ^r is needed twice downstream — once for the chain rule via `Real.hasDerivAt_log` (which requires a nonzero argument) and once for the exp/log rewrite `rpow_def_of_pos`. The proof by contradiction is the cleanest approach: assuming all weights vanish contradicts ∑ wᵢ = 1.",
+    "title": "Sum Positivity: \u2211 w\u1d62z\u1d62^r > 0",
+    "content": "`sum_weighted_rpow_pos` proves the denominator \u2211 w\u1d62z\u1d62^r is positive whenever \u2211 w\u1d62 = 1 and all z\u1d62 > 0. The key step is finding a strictly positive weight: if all weights were zero their sum couldn't be 1. Uses `Finset.single_le_sum` to bound a single positive term against the full sum.\n\n**Why this matters:** Positivity of \u2211 w\u1d62z\u1d62^r is needed twice downstream \u2014 once for the chain rule via `Real.hasDerivAt_log` (which requires a nonzero argument) and once for the exp/log rewrite `rpow_def_of_pos`. The proof by contradiction is the cleanest approach: assuming all weights vanish contradicts \u2211 w\u1d62 = 1.",
     "mathContext": "Since $\\sum_i w_i = 1 > 0$ and $w_i \\geq 0$, some $w_{i_0} > 0$. Then $\\sum_i w_i z_i^r \\geq w_{i_0} z_{i_0}^r > 0$ since $z_{i_0}^r > 0$ for $z_{i_0} > 0$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -54,8 +54,8 @@
       "endLine": 98
     },
     "type": "technique",
-    "title": "Derivative of ∑ wᵢzᵢ^r at r = 0",
-    "content": "`hasDerivAt_sum_weighted_rpow_zero` computes the derivative of r ↦ ∑ wᵢzᵢ^r at r = 0, yielding ∑ wᵢ log zᵢ. For each term: `Real.hasStrictDerivAt_const_rpow` gives HasDerivAt for zᵢ^r with derivative zᵢ^0 · log zᵢ = log zᵢ. `HasDerivAt.const_mul` and `HasDerivAt.sum` then differentiate the full weighted sum.",
+    "title": "Derivative of \u2211 w\u1d62z\u1d62^r at r = 0",
+    "content": "`hasDerivAt_sum_weighted_rpow_zero` computes the derivative of r \u21a6 \u2211 w\u1d62z\u1d62^r at r = 0, yielding \u2211 w\u1d62 log z\u1d62. For each term: `Real.hasStrictDerivAt_const_rpow` gives HasDerivAt for z\u1d62^r with derivative z\u1d62^0 \u00b7 log z\u1d62 = log z\u1d62. `HasDerivAt.const_mul` and `HasDerivAt.sum` then differentiate the full weighted sum.",
     "mathContext": "$\\left.\\frac{d}{dr}\\sum_i w_i z_i^r\\right|_{r=0} = \\sum_i w_i \\cdot z_i^0 \\cdot \\log z_i = \\sum_i w_i \\log z_i$",
     "significance": "key",
     "relatedConcepts": [
@@ -78,7 +78,7 @@
     },
     "type": "technique",
     "title": "The Log Identity: f(0) = 0",
-    "content": "`log_sum_weighted_rpow_zero` proves that f(0) = log(∑ wᵢzᵢ^0) = log(1) = 0. This identity is essential for the slope argument: since f(0) = 0, the difference quotient f(r)/r = (f(r) - f(0))/(r - 0) is exactly the slope that converges to f'(0) by the definition of derivative. Without f(0) = 0, the slope limit would give (f(r) - f(0))/r → f'(0), not f(r)/r → f'(0).",
+    "content": "`log_sum_weighted_rpow_zero` proves that f(0) = log(\u2211 w\u1d62z\u1d62^0) = log(1) = 0. This identity is essential for the slope argument: since f(0) = 0, the difference quotient f(r)/r = (f(r) - f(0))/(r - 0) is exactly the slope that converges to f'(0) by the definition of derivative. Without f(0) = 0, the slope limit would give (f(r) - f(0))/r \u2192 f'(0), not f(r)/r \u2192 f'(0).",
     "mathContext": "$f(0) = \\log\\left(\\sum_i w_i z_i^0\\right) = \\log\\left(\\sum_i w_i\\right) = \\log(1) = 0$ since $z_i^0 = 1$ and $\\sum w_i = 1$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -96,12 +96,12 @@
     "id": "ann-pmlo-04-log-deriv",
     "proofId": "amgm-inequality-oq-03-oq-02",
     "range": {
-      "startLine": 112,
+      "startLine": 113,
       "endLine": 137
     },
     "type": "technique",
-    "title": "HasDerivAt for log(∑ wᵢzᵢ^r) at r = 0",
-    "content": "`hasDerivAt_log_sum_weighted_rpow` applies the chain rule to compose log with the weighted sum. Since the inner function evaluates to 1 at r = 0 (as ∑ wᵢzᵢ^0 = ∑ wᵢ = 1), the chain rule gives (1/1) · ∑ wᵢ log zᵢ = ∑ wᵢ log zᵢ.",
+    "title": "HasDerivAt for log(\u2211 w\u1d62z\u1d62^r) at r = 0",
+    "content": "`hasDerivAt_log_sum_weighted_rpow` applies the chain rule to compose log with the weighted sum. Since the inner function evaluates to 1 at r = 0 (as \u2211 w\u1d62z\u1d62^0 = \u2211 w\u1d62 = 1), the chain rule gives (1/1) \u00b7 \u2211 w\u1d62 log z\u1d62 = \u2211 w\u1d62 log z\u1d62.",
     "mathContext": "Chain rule: $(\\log \\circ h)'(0) = \\frac{h'(0)}{h(0)} = \\frac{\\sum_i w_i \\log z_i}{1} = \\sum_i w_i \\log z_i$",
     "significance": "key",
     "relatedConcepts": [
@@ -118,12 +118,12 @@
     "id": "ann-pmlo-05-slope-limit",
     "proofId": "amgm-inequality-oq-03-oq-02",
     "range": {
-      "startLine": 138,
+      "startLine": 139,
       "endLine": 171
     },
     "type": "technique",
-    "title": "Core Limit: (log ∑ wᵢzᵢ^r)/r → ∑ wᵢ log zᵢ",
-    "content": "`tendsto_log_sum_div_rpow` is the key intermediate limit. Since g(r) = log(∑ wᵢzᵢ^r) satisfies g(0) = 0 and g'(0) = ∑ wᵢ log zᵢ, we have g(r)/r = (g(r) - g(0))/(r - 0) → g'(0) by the definition of derivative. The Lean proof uses `hasDerivAt_iff_tendsto_slope` which directly connects HasDerivAt to this slope limit, then `congr'` with `slope g 0 = g r / r` (since g 0 = 0).",
+    "title": "Core Limit: (log \u2211 w\u1d62z\u1d62^r)/r \u2192 \u2211 w\u1d62 log z\u1d62",
+    "content": "`tendsto_log_sum_div_rpow` is the key intermediate limit. Since g(r) = log(\u2211 w\u1d62z\u1d62^r) satisfies g(0) = 0 and g'(0) = \u2211 w\u1d62 log z\u1d62, we have g(r)/r = (g(r) - g(0))/(r - 0) \u2192 g'(0) by the definition of derivative. The Lean proof uses `hasDerivAt_iff_tendsto_slope` which directly connects HasDerivAt to this slope limit, then `congr'` with `slope g 0 = g r / r` (since g 0 = 0).",
     "mathContext": "$\\frac{g(r)}{r} = \\frac{g(r) - g(0)}{r - 0} \\to g'(0) = \\sum_i w_i \\log z_i$ by the definition of derivative.",
     "significance": "key",
     "relatedConcepts": [
@@ -142,12 +142,12 @@
     "id": "ann-pmlo-06-geom-mean",
     "proofId": "amgm-inequality-oq-03-oq-02",
     "range": {
-      "startLine": 172,
+      "startLine": 173,
       "endLine": 189
     },
     "type": "technique",
     "title": "Geometric Mean as Exponential",
-    "content": "`geomMean_eq_exp_sum_log` proves GM = ∏ zᵢ^wᵢ = exp(∑ wᵢ log zᵢ). The proof rewrites the product using `Real.exp_log` (since GM > 0), then shows log GM = ∑ wᵢ log zᵢ via `Real.log_prod` (product of positives) and `Real.log_rpow` (log of rpow).",
+    "content": "`geomMean_eq_exp_sum_log` proves GM = \u220f z\u1d62^w\u1d62 = exp(\u2211 w\u1d62 log z\u1d62). The proof rewrites the product using `Real.exp_log` (since GM > 0), then shows log GM = \u2211 w\u1d62 log z\u1d62 via `Real.log_prod` (product of positives) and `Real.log_rpow` (log of rpow).",
     "mathContext": "$\\prod_i z_i^{w_i} = \\exp\\left(\\log \\prod_i z_i^{w_i}\\right) = \\exp\\left(\\sum_i \\log z_i^{w_i}\\right) = \\exp\\left(\\sum_i w_i \\log z_i\\right)$",
     "significance": "supporting",
     "relatedConcepts": [
@@ -168,8 +168,8 @@
       "endLine": 214
     },
     "type": "technique",
-    "title": "Supporting Identities: M₁ = AM and M_r = exp(log/r)",
-    "content": "Two supporting identities bridge definitions and the main limit. `powerMean_one_eq_arithMean` shows M₁ = AM by simplifying z^1 = z via `rpow_one`. `powerMean_eq_exp_log` rewrites the power mean as M_r = exp((1/r) · log(∑ wᵢzᵢ^r)) using `rpow_def_of_pos` — this is the form where f(r)/r appears, connecting the power mean to the slope limit. The proof is 3 lines: rewrite via rpow_def_of_pos, then `congr 1; ring` aligns the exponents.",
+    "title": "Supporting Identities: M\u2081 = AM and M_r = exp(log/r)",
+    "content": "Two supporting identities bridge definitions and the main limit. `powerMean_one_eq_arithMean` shows M\u2081 = AM by simplifying z^1 = z via `rpow_one`. `powerMean_eq_exp_log` rewrites the power mean as M_r = exp((1/r) \u00b7 log(\u2211 w\u1d62z\u1d62^r)) using `rpow_def_of_pos` \u2014 this is the form where f(r)/r appears, connecting the power mean to the slope limit. The proof is 3 lines: rewrite via rpow_def_of_pos, then `congr 1; ring` aligns the exponents.",
     "mathContext": "$M_1 = \\sum w_i z_i^1 = \\sum w_i z_i = \\text{AM}$. For $r \\neq 0$: $(\\sum w_i z_i^r)^{1/r} = \\exp\\left(\\frac{1}{r} \\cdot \\log(\\sum w_i z_i^r)\\right)$ via $x^a = e^{a \\log x}$ for $x > 0$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -187,12 +187,12 @@
     "id": "ann-pmlo-07-main",
     "proofId": "amgm-inequality-oq-03-oq-02",
     "range": {
-      "startLine": 215,
+      "startLine": 216,
       "endLine": 247
     },
     "type": "insight",
-    "title": "MAIN THEOREM: lim_{r→0} M_r = GM",
-    "content": "`tendsto_powerMean_zero` is the main result. The proof:\n1. Gets exp(∑ wᵢ log zᵢ) as the limit via composing `tendsto_log_sum_div_rpow` with continuity of exp\n2. Rewrites the target GM = exp(∑ wᵢ log zᵢ) via `geomMean_eq_exp_sum_log`\n3. Applies `congr'` with the identity (∑ wᵢzᵢ^r)^(1/r) = exp(log(∑ wᵢzᵢ^r)/r) for all r\nThe congr step uses `rpow_def_of_pos` and ring arithmetic.",
+    "title": "MAIN THEOREM: lim_{r\u21920} M_r = GM",
+    "content": "`tendsto_powerMean_zero` is the main result. The proof:\n1. Gets exp(\u2211 w\u1d62 log z\u1d62) as the limit via composing `tendsto_log_sum_div_rpow` with continuity of exp\n2. Rewrites the target GM = exp(\u2211 w\u1d62 log z\u1d62) via `geomMean_eq_exp_sum_log`\n3. Applies `congr'` with the identity (\u2211 w\u1d62z\u1d62^r)^(1/r) = exp(log(\u2211 w\u1d62z\u1d62^r)/r) for all r\nThe congr step uses `rpow_def_of_pos` and ring arithmetic.",
     "mathContext": "$\\lim_{r \\to 0, r \\neq 0} \\left(\\sum_i w_i z_i^r\\right)^{1/r} = \\lim_{r \\to 0} e^{g(r)/r} = e^{\\sum_i w_i \\log z_i} = \\prod_i z_i^{w_i}$",
     "significance": "key",
     "relatedConcepts": [
@@ -210,12 +210,12 @@
     "id": "ann-pmlo-08-chain",
     "proofId": "amgm-inequality-oq-03-oq-02",
     "range": {
-      "startLine": 248,
+      "startLine": 249,
       "endLine": 292
     },
     "type": "technique",
-    "title": "Completing the Chain: HM ≤ GM ≤ AM",
-    "content": "`powerMean_neg1_le_geomMean_le_arithMean` proves both inequalities:\n- **HM ≤ GM**: Apply AM-GM to inverse values z⁻¹. Since GM(z⁻¹) = GM(z)⁻¹ and GM(z⁻¹) ≤ AM(z⁻¹) = ∑ wᵢ/zᵢ = 1/HM, we get 1/GM ≤ 1/HM hence HM ≤ GM.\n- **GM ≤ AM**: Direct from `Real.geom_mean_le_arith_mean_weighted`.\n\n**The inversion trick:** The HM ≤ GM direction is a classic example of reducing one inequality to another by symmetry. The proof applies AM-GM to z⁻¹ instead of z, exploiting the fact that GM(z⁻¹) = GM(z)⁻¹ (geometric mean commutes with inversion). This technique generalizes: many power mean inequalities reduce to the r > 0 case by replacing zᵢ with zᵢ⁻¹ and r with -r.",
+    "title": "Completing the Chain: HM \u2264 GM \u2264 AM",
+    "content": "`powerMean_neg1_le_geomMean_le_arithMean` proves both inequalities:\n- **HM \u2264 GM**: Apply AM-GM to inverse values z\u207b\u00b9. Since GM(z\u207b\u00b9) = GM(z)\u207b\u00b9 and GM(z\u207b\u00b9) \u2264 AM(z\u207b\u00b9) = \u2211 w\u1d62/z\u1d62 = 1/HM, we get 1/GM \u2264 1/HM hence HM \u2264 GM.\n- **GM \u2264 AM**: Direct from `Real.geom_mean_le_arith_mean_weighted`.\n\n**The inversion trick:** The HM \u2264 GM direction is a classic example of reducing one inequality to another by symmetry. The proof applies AM-GM to z\u207b\u00b9 instead of z, exploiting the fact that GM(z\u207b\u00b9) = GM(z)\u207b\u00b9 (geometric mean commutes with inversion). This technique generalizes: many power mean inequalities reduce to the r > 0 case by replacing z\u1d62 with z\u1d62\u207b\u00b9 and r with -r.",
     "mathContext": "$\\text{HM} = \\left(\\sum_i \\frac{w_i}{z_i}\\right)^{-1} \\leq \\prod_i z_i^{w_i} = \\text{GM} \\leq \\sum_i w_i z_i = \\text{AM}$",
     "significance": "supporting",
     "relatedConcepts": [
@@ -233,12 +233,12 @@
     "id": "ann-pmlo-00-setup",
     "proofId": "amgm-inequality-oq-03-oq-02",
     "range": {
-      "startLine": 45,
+      "startLine": 43,
       "endLine": 48
     },
     "type": "concept",
     "title": "Proof Environment: Open Namespaces and Variables",
-    "content": "`open Finset Real Filter` brings three namespaces into scope: `Finset` for finite sum/product operations (`Finset.sum`, `Finset.prod`, `Finset.single_le_sum`); `Real` for real analysis (`Real.rpow`, `Real.log`, `Real.exp`, `Real.continuous_exp`); and `Filter` for limit formalization (`Filter.Tendsto`, `nhdsWithin`). The `variable` declarations introduce `ι` (an abstract index type), `s` (a finite index set), `w` (weights), and `z` (values) — making all theorems universe-polymorphic and applicable to any finite weighted collection.",
+    "content": "`open Finset Real Filter` brings three namespaces into scope: `Finset` for finite sum/product operations (`Finset.sum`, `Finset.prod`, `Finset.single_le_sum`); `Real` for real analysis (`Real.rpow`, `Real.log`, `Real.exp`, `Real.continuous_exp`); and `Filter` for limit formalization (`Filter.Tendsto`, `nhdsWithin`). The `variable` declarations introduce `\u03b9` (an abstract index type), `s` (a finite index set), `w` (weights), and `z` (values) \u2014 making all theorems universe-polymorphic and applicable to any finite weighted collection.",
     "mathContext": "The variables $s \\subseteq \\iota$, $w : \\iota \\to \\mathbb{R}$ (weights), $z : \\iota \\to \\mathbb{R}$ (values) parameterize the power mean $M_r(z,w) = \\left(\\sum_{i \\in s} w_i z_i^r\\right)^{1/r}$. The abstract index type $\\iota$ allows the theorems to apply to any finite collection, not just $\\{1, \\ldots, n\\}$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -260,8 +260,8 @@
     },
     "type": "concept",
     "title": "Summary: Complete Proof Inventory (10 Theorems, 0 Sorries)",
-    "content": "The summary section lists all 10 proved results forming the complete chain from auxiliary lemmas to the main theorem:\n\n1. `sum_weighted_rpow_pos` — positivity of weighted rpow sum\n2. `hasDerivAt_sum_weighted_rpow_zero` — derivative at r=0\n3. `log_sum_weighted_rpow_zero` — f(0) = 0 identity\n4. `hasDerivAt_log_sum_weighted_rpow` — chain rule composition\n5. `tendsto_log_sum_div_rpow` — core slope limit\n6. `geomMean_eq_exp_sum_log` — GM = exp(∑ wᵢ log zᵢ)\n7. `powerMean_one_eq_arithMean` — M₁ = AM\n8. `powerMean_eq_exp_log` — exp/log representation\n9. `tendsto_powerMean_zero` — MAIN THEOREM\n10. `powerMean_neg1_le_geomMean_le_arithMean` — HM ≤ GM ≤ AM\n\nThe dependency graph is linear: (1) → (2) → (4) → (5) → (9) ← (6), with (3) feeding into (5), and (7)+(8) as supporting identities. Result (10) uses Mathlib's AM-GM independently.",
-    "mathContext": "The 10 results collectively establish: $\\lim_{r \\to 0} M_r = \\text{GM}$ (theorem 9), $\\text{HM} \\leq \\text{GM} \\leq \\text{AM}$ (theorem 10), and the supporting chain of derivatives and identities (theorems 1–8). Zero `sorry` declarations — every step is machine-verified.",
+    "content": "The summary section lists all 10 proved results forming the complete chain from auxiliary lemmas to the main theorem:\n\n1. `sum_weighted_rpow_pos` \u2014 positivity of weighted rpow sum\n2. `hasDerivAt_sum_weighted_rpow_zero` \u2014 derivative at r=0\n3. `log_sum_weighted_rpow_zero` \u2014 f(0) = 0 identity\n4. `hasDerivAt_log_sum_weighted_rpow` \u2014 chain rule composition\n5. `tendsto_log_sum_div_rpow` \u2014 core slope limit\n6. `geomMean_eq_exp_sum_log` \u2014 GM = exp(\u2211 w\u1d62 log z\u1d62)\n7. `powerMean_one_eq_arithMean` \u2014 M\u2081 = AM\n8. `powerMean_eq_exp_log` \u2014 exp/log representation\n9. `tendsto_powerMean_zero` \u2014 MAIN THEOREM\n10. `powerMean_neg1_le_geomMean_le_arithMean` \u2014 HM \u2264 GM \u2264 AM\n\nThe dependency graph is linear: (1) \u2192 (2) \u2192 (4) \u2192 (5) \u2192 (9) \u2190 (6), with (3) feeding into (5), and (7)+(8) as supporting identities. Result (10) uses Mathlib's AM-GM independently.",
+    "mathContext": "The 10 results collectively establish: $\\lim_{r \\to 0} M_r = \\text{GM}$ (theorem 9), $\\text{HM} \\leq \\text{GM} \\leq \\text{AM}$ (theorem 10), and the supporting chain of derivatives and identities (theorems 1\u20138). Zero `sorry` declarations \u2014 every step is machine-verified.",
     "significance": "supporting",
     "relatedConcepts": [
       "proof inventory",

--- a/src/data/proofs/amgm-inequality-oq-03-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-03-oq-01/annotations.json
@@ -2,85 +2,171 @@
   {
     "id": "ann-power-mean-def",
     "proofId": "amgm-inequality-oq-03-oq-03-oq-01",
-    "range": { "startLine": 23, "endLine": 34 },
+    "range": {
+      "startLine": 26,
+      "endLine": 34
+    },
     "type": "definition",
     "title": "The Power Mean M_r and Finite-Type Setup",
-    "content": "The power mean is defined over an arbitrary finite inhabited index type `ι`:\n\n```lean\nnoncomputable def M (r : ℝ) : ℝ :=\n  ((∑ i : ι, x i ^ r) / Fintype.card ι) ^ (1 / r)\n```\n\nThis generalizes the classical $M_r(x_1,\\ldots,x_n) = \\left(\\frac{1}{n}\\sum x_i^r\\right)^{1/r}$ to arbitrary finite index types. Two supporting lemmas:\n- `hN_pos`: $n = |\\iota| > 0$ (from `Fintype.card_pos`)\n- `hN_ne`: $n \\ne 0$ (for division safety)\n\nThe type-class hypotheses `[Fintype ι] [Nonempty ι]` ensure the sum is finite and the supremum/infimum over `ι` are well-defined. Using `Real.rpow` (instead of `HPow`) allows `r` to be any real number, including non-integer and negative values.",
+    "content": "The power mean is defined over an arbitrary finite inhabited index type `\u03b9`:\n\n```lean\nnoncomputable def M (r : \u211d) : \u211d :=\n  ((\u2211 i : \u03b9, x i ^ r) / Fintype.card \u03b9) ^ (1 / r)\n```\n\nThis generalizes the classical $M_r(x_1,\\ldots,x_n) = \\left(\\frac{1}{n}\\sum x_i^r\\right)^{1/r}$ to arbitrary finite index types. Two supporting lemmas:\n- `hN_pos`: $n = |\\iota| > 0$ (from `Fintype.card_pos`)\n- `hN_ne`: $n \\ne 0$ (for division safety)\n\nThe type-class hypotheses `[Fintype \u03b9] [Nonempty \u03b9]` ensure the sum is finite and the supremum/infimum over `\u03b9` are well-defined. Using `Real.rpow` (instead of `HPow`) allows `r` to be any real number, including non-integer and negative values.",
     "mathContext": "$M_r = \\left(\\frac{\\sum_{i} x_i^r}{n}\\right)^{1/r}$. Special cases: $r=1$ (AM), $r=2$ (QM/RMS), $r \\to 0$ (GM), $r \\to \\pm\\infty$ (max/min). The exponent is encoded as `1/r` in `Real.rpow`.",
     "significance": "key",
-    "relatedConcepts": ["Real.rpow", "Fintype.card", "generalized mean", "power mean", "Finset.sum"],
-    "prerequisites": ["Real.rpow definition", "Fintype and Finset API"]
+    "relatedConcepts": [
+      "Real.rpow",
+      "Fintype.card",
+      "generalized mean",
+      "power mean",
+      "Finset.sum"
+    ],
+    "prerequisites": [
+      "Real.rpow definition",
+      "Fintype and Finset API"
+    ]
   },
   {
     "id": "ann-rpow-inv-atTop",
     "proofId": "amgm-inequality-oq-03-oq-03-oq-01",
-    "range": { "startLine": 40, "endLine": 49 },
+    "range": {
+      "startLine": 40,
+      "endLine": 49
+    },
     "type": "technique",
-    "title": "Key Engine: c^{1/r} → 1 as r → +∞ (via exp continuity)",
-    "content": "This private lemma is the technical heart of the +∞ limit:\n\n```lean\nprivate theorem tendsto_rpow_inv_atTop {c : ℝ} (hc : 0 < c) :\n    Tendsto (fun r : ℝ => c ^ r⁻¹) atTop (nhds 1)\n```\n\nProof structure:\n1. Write `c^(r⁻¹) = exp(log(c) · r⁻¹)` using `rpow_def_of_pos hc`\n2. As `r → +∞`, `r⁻¹ → 0`, so `log(c) · r⁻¹ → 0` (via `tendsto_inv_atTop_zero.const_mul`)\n3. By continuity of `exp` at 0: `exp(log(c) · r⁻¹) → exp(0) = 1`\n4. Chain via `.comp` and `.congr` to get `c^(r⁻¹) → 1`\n\nThis lemma is applied twice:\n- Directly for `n^(1/r) → 1` (in the lower bound of the squeeze)\n- Via `.inv₀` to get `n^(-1/r) → 1` (since `n^(-1/r) = (n^(1/r))⁻¹`)\n\nThe `.congr` at the end rewrites using `rpow_def_of_pos` to equate `c ^ r⁻¹` with `exp(log c * r⁻¹)`.",
+    "title": "Key Engine: c^{1/r} \u2192 1 as r \u2192 +\u221e (via exp continuity)",
+    "content": "This private lemma is the technical heart of the +\u221e limit:\n\n```lean\nprivate theorem tendsto_rpow_inv_atTop {c : \u211d} (hc : 0 < c) :\n    Tendsto (fun r : \u211d => c ^ r\u207b\u00b9) atTop (nhds 1)\n```\n\nProof structure:\n1. Write `c^(r\u207b\u00b9) = exp(log(c) \u00b7 r\u207b\u00b9)` using `rpow_def_of_pos hc`\n2. As `r \u2192 +\u221e`, `r\u207b\u00b9 \u2192 0`, so `log(c) \u00b7 r\u207b\u00b9 \u2192 0` (via `tendsto_inv_atTop_zero.const_mul`)\n3. By continuity of `exp` at 0: `exp(log(c) \u00b7 r\u207b\u00b9) \u2192 exp(0) = 1`\n4. Chain via `.comp` and `.congr` to get `c^(r\u207b\u00b9) \u2192 1`\n\nThis lemma is applied twice:\n- Directly for `n^(1/r) \u2192 1` (in the lower bound of the squeeze)\n- Via `.inv\u2080` to get `n^(-1/r) \u2192 1` (since `n^(-1/r) = (n^(1/r))\u207b\u00b9`)\n\nThe `.congr` at the end rewrites using `rpow_def_of_pos` to equate `c ^ r\u207b\u00b9` with `exp(log c * r\u207b\u00b9)`.",
     "mathContext": "For $c > 0$: $c^{1/r} = e^{(\\log c)/r} \\to e^0 = 1$ as $r \\to +\\infty$. Continuity of $\\exp$ at 0 is `continuous_exp.continuousAt`.",
     "significance": "key",
-    "relatedConcepts": ["tendsto_inv_atTop_zero", "Real.rpow_def_of_pos", "continuous_exp", "Filter.Tendsto", "tendsto_const_mul"],
-    "prerequisites": ["Real.log and exp", "Filter.Tendsto composition"]
+    "relatedConcepts": [
+      "tendsto_inv_atTop_zero",
+      "Real.rpow_def_of_pos",
+      "continuous_exp",
+      "Filter.Tendsto",
+      "tendsto_const_mul"
+    ],
+    "prerequisites": [
+      "Real.log and exp",
+      "Filter.Tendsto composition"
+    ]
   },
   {
     "id": "ann-antitone-rpow",
     "proofId": "amgm-inequality-oq-03-oq-03-oq-01",
-    "range": { "startLine": 55, "endLine": 74 },
+    "range": {
+      "startLine": 55,
+      "endLine": 74
+    },
     "type": "technique",
     "title": "Antitone rpow for Nonpositive Exponents",
-    "content": "Two auxiliary lemmas establish that `rpow` reverses order for nonpositive exponents:\n\n**`aux_inv_le_inv`**: For `0 < a ≤ b`: `b⁻¹ ≤ a⁻¹`. Proved by a 3-step `calc` multiplying both sides by `a·b`:\n```\nb⁻¹ = b⁻¹ · (a · a⁻¹) ≤ b⁻¹ · (b · a⁻¹) = a⁻¹\n```\nThis avoids `div_le_div` and works purely with `inv` and `mul_le_mul_of_nonneg_left`.\n\n**`rpow_le_rpow_of_nonpos`**: For `0 < a ≤ b` and `z ≤ 0`: `b^z ≤ a^z`. Proved by:\n- Case `z = 0`: `simp` (both sides are 1)\n- Case `z < 0`: Write `z = -(-z)`, use `rpow_neg` to convert to inverses, then apply `aux_inv_le_inv` with `rpow_le_rpow` (which is monotone for nonneg exponents).\n\nThis is used in the duality section to handle the min computation, and underlies the `minX_eq_inv_maxX_inv` identity.",
+    "content": "Two auxiliary lemmas establish that `rpow` reverses order for nonpositive exponents:\n\n**`aux_inv_le_inv`**: For `0 < a \u2264 b`: `b\u207b\u00b9 \u2264 a\u207b\u00b9`. Proved by a 3-step `calc` multiplying both sides by `a\u00b7b`:\n```\nb\u207b\u00b9 = b\u207b\u00b9 \u00b7 (a \u00b7 a\u207b\u00b9) \u2264 b\u207b\u00b9 \u00b7 (b \u00b7 a\u207b\u00b9) = a\u207b\u00b9\n```\nThis avoids `div_le_div` and works purely with `inv` and `mul_le_mul_of_nonneg_left`.\n\n**`rpow_le_rpow_of_nonpos`**: For `0 < a \u2264 b` and `z \u2264 0`: `b^z \u2264 a^z`. Proved by:\n- Case `z = 0`: `simp` (both sides are 1)\n- Case `z < 0`: Write `z = -(-z)`, use `rpow_neg` to convert to inverses, then apply `aux_inv_le_inv` with `rpow_le_rpow` (which is monotone for nonneg exponents).\n\nThis is used in the duality section to handle the min computation, and underlies the `minX_eq_inv_maxX_inv` identity.",
     "mathContext": "For $0 < a \\leq b$ and $z \\leq 0$: $b^z \\leq a^z$ since $t \\mapsto t^z$ is decreasing on $(0,\\infty)$ for $z < 0$.",
     "significance": "supporting",
-    "relatedConcepts": ["rpow_neg", "rpow_le_rpow", "inv_pos", "mul_le_mul_of_nonneg_left"],
-    "prerequisites": ["Real.rpow monotonicity"]
+    "relatedConcepts": [
+      "rpow_neg",
+      "rpow_le_rpow",
+      "inv_pos",
+      "mul_le_mul_of_nonneg_left"
+    ],
+    "prerequisites": [
+      "Real.rpow monotonicity"
+    ]
   },
   {
     "id": "ann-max-bounds",
     "proofId": "amgm-inequality-oq-03-oq-03-oq-01",
-    "range": { "startLine": 99, "endLine": 147 },
+    "range": {
+      "startLine": 99,
+      "endLine": 147
+    },
     "type": "technique",
-    "title": "The Squeeze Bounds: M_r ≤ max and max·n^{-1/r} ≤ M_r",
-    "content": "Two theorems establish the bounds needed for the squeeze theorem:\n\n**Upper bound** (`M_le_maxX`, lines 99-123):\n$$M_r \\leq \\max x_i \\quad (r > 0)$$\nProof: Each $x_i^r \\leq (\\max x)^r$ (by `rpow_le_rpow`). Summing: $\\frac{\\sum x_i^r}{n} \\leq (\\max x)^r$. Taking $(\\cdot)^{1/r}$ (order-preserving for positive exponent): $M_r \\leq (\\max x)^{r \\cdot (1/r)} = \\max x$.\n\nKey step: `rpow_mul` collapses $(\\max x)^{r \\cdot (1/r)} = (\\max x)^1 = \\max x` via `mul_one_div_cancel`.\n\n**Lower bound** (`maxX_mul_rpow_le_M`, lines 125-146):\n$$\\max x \\cdot n^{-1/r} \\leq M_r \\quad (r > 0)$$\nProof: Let $i_0$ be the maximizer (`exists_maxX`). Then $(\\max x)^r = x_{i_0}^r \\leq \\sum x_i^r$ (single term ≤ sum). Divide by $n$, take $(\\cdot)^{1/r}$:\n$$M_r \\geq \\left(\\frac{(\\max x)^r}{n}\\right)^{1/r} = \\max x \\cdot n^{-1/r}$$\nThe last equality uses `div_rpow` + `rpow_mul` + `rpow_neg`.",
+    "title": "The Squeeze Bounds: M_r \u2264 max and max\u00b7n^{-1/r} \u2264 M_r",
+    "content": "Two theorems establish the bounds needed for the squeeze theorem:\n\n**Upper bound** (`M_le_maxX`, lines 99-123):\n$$M_r \\leq \\max x_i \\quad (r > 0)$$\nProof: Each $x_i^r \\leq (\\max x)^r$ (by `rpow_le_rpow`). Summing: $\\frac{\\sum x_i^r}{n} \\leq (\\max x)^r$. Taking $(\\cdot)^{1/r}$ (order-preserving for positive exponent): $M_r \\leq (\\max x)^{r \\cdot (1/r)} = \\max x$.\n\nKey step: `rpow_mul` collapses $(\\max x)^{r \\cdot (1/r)} = (\\max x)^1 = \\max x` via `mul_one_div_cancel`.\n\n**Lower bound** (`maxX_mul_rpow_le_M`, lines 125-146):\n$$\\max x \\cdot n^{-1/r} \\leq M_r \\quad (r > 0)$$\nProof: Let $i_0$ be the maximizer (`exists_maxX`). Then $(\\max x)^r = x_{i_0}^r \\leq \\sum x_i^r$ (single term \u2264 sum). Divide by $n$, take $(\\cdot)^{1/r}$:\n$$M_r \\geq \\left(\\frac{(\\max x)^r}{n}\\right)^{1/r} = \\max x \\cdot n^{-1/r}$$\nThe last equality uses `div_rpow` + `rpow_mul` + `rpow_neg`.",
     "mathContext": "The squeeze: $\\max x \\cdot n^{-1/r} \\leq M_r \\leq \\max x$. Both bounds are tight: the upper is achieved when all $x_i = \\max x$; the lower is asymptotically tight as $r \\to \\infty$.",
     "significance": "key",
-    "relatedConcepts": ["rpow_le_rpow", "rpow_mul", "Finset.sum_le_sum", "Finset.single_le_sum", "div_rpow"],
-    "prerequisites": ["maxX definition", "exists_maxX (existence of maximizer)", "rpow monotonicity"]
+    "relatedConcepts": [
+      "rpow_le_rpow",
+      "rpow_mul",
+      "Finset.sum_le_sum",
+      "Finset.single_le_sum",
+      "div_rpow"
+    ],
+    "prerequisites": [
+      "maxX definition",
+      "exists_maxX (existence of maximizer)",
+      "rpow monotonicity"
+    ]
   },
   {
     "id": "ann-atTop-squeeze",
     "proofId": "amgm-inequality-oq-03-oq-03-oq-01",
-    "range": { "startLine": 152, "endLine": 174 },
+    "range": {
+      "startLine": 152,
+      "endLine": 174
+    },
     "type": "technique",
-    "title": "Squeeze Theorem: M_r → max as r → +∞",
-    "content": "The main +∞ limit theorem applies Mathlib's squeeze:\n\n```lean\nexact tendsto_of_tendsto_of_tendsto_of_le_of_le' hlb tendsto_const_nhds\n  ((eventually_gt_atTop 0).mono (fun r hr => maxX_mul_rpow_le_M x hx hr))\n  ((eventually_gt_atTop 0).mono (fun r hr => M_le_maxX x hx hr))\n```\n\nThe three components:\n1. **Lower bound tendsto**: `hlb` proves `maxX · n^(-1/r) → maxX`\n   - `tendsto_rpow_inv_atTop hN_pos` gives `n^(1/r) → 1`\n   - `.inv₀` gives `n^(-1/r) → 1` (inverting a sequence converging to nonzero limit)\n   - `.const_mul (maxX x)` gives `maxX · n^(-1/r) → maxX · 1 = maxX`\n   - `.congr'` with `ring` handles the `one_div` vs `⁻¹` notation\n2. **Upper bound constant**: `tendsto_const_nhds` — the constant sequence `maxX` trivially converges to `maxX`\n3. **Eventual bounds**: Both `maxX_mul_rpow_le_M` and `M_le_maxX` hold eventually (for `r > 0`, which holds from `eventually_gt_atTop 0`)\n\n`tendsto_of_tendsto_of_tendsto_of_le_of_le'` is Mathlib's `'` variant accepting eventual (not pointwise) bounds.",
+    "title": "Squeeze Theorem: M_r \u2192 max as r \u2192 +\u221e",
+    "content": "The main +\u221e limit theorem applies Mathlib's squeeze:\n\n```lean\nexact tendsto_of_tendsto_of_tendsto_of_le_of_le' hlb tendsto_const_nhds\n  ((eventually_gt_atTop 0).mono (fun r hr => maxX_mul_rpow_le_M x hx hr))\n  ((eventually_gt_atTop 0).mono (fun r hr => M_le_maxX x hx hr))\n```\n\nThe three components:\n1. **Lower bound tendsto**: `hlb` proves `maxX \u00b7 n^(-1/r) \u2192 maxX`\n   - `tendsto_rpow_inv_atTop hN_pos` gives `n^(1/r) \u2192 1`\n   - `.inv\u2080` gives `n^(-1/r) \u2192 1` (inverting a sequence converging to nonzero limit)\n   - `.const_mul (maxX x)` gives `maxX \u00b7 n^(-1/r) \u2192 maxX \u00b7 1 = maxX`\n   - `.congr'` with `ring` handles the `one_div` vs `\u207b\u00b9` notation\n2. **Upper bound constant**: `tendsto_const_nhds` \u2014 the constant sequence `maxX` trivially converges to `maxX`\n3. **Eventual bounds**: Both `maxX_mul_rpow_le_M` and `M_le_maxX` hold eventually (for `r > 0`, which holds from `eventually_gt_atTop 0`)\n\n`tendsto_of_tendsto_of_tendsto_of_le_of_le'` is Mathlib's `'` variant accepting eventual (not pointwise) bounds.",
     "mathContext": "Squeeze theorem: if $l_n \\leq a_n \\leq u_n$ eventually and $l_n, u_n \\to L$, then $a_n \\to L$. Here $L = \\max x$, $l_r = \\max x \\cdot n^{-1/r}$, $u_r = \\max x$.",
     "significance": "key",
-    "relatedConcepts": ["tendsto_of_tendsto_of_tendsto_of_le_of_le'", "eventually_gt_atTop", "Filter.Tendsto.inv₀", "Filter.Tendsto.const_mul"],
-    "prerequisites": ["tendsto_rpow_inv_atTop", "M_le_maxX", "maxX_mul_rpow_le_M"]
+    "relatedConcepts": [
+      "tendsto_of_tendsto_of_tendsto_of_le_of_le'",
+      "eventually_gt_atTop",
+      "Filter.Tendsto.inv\u2080",
+      "Filter.Tendsto.const_mul"
+    ],
+    "prerequisites": [
+      "tendsto_rpow_inv_atTop",
+      "M_le_maxX",
+      "maxX_mul_rpow_le_M"
+    ]
   },
   {
     "id": "ann-duality-min",
     "proofId": "amgm-inequality-oq-03-oq-03-oq-01",
-    "range": { "startLine": 181, "endLine": 229 },
+    "range": {
+      "startLine": 181,
+      "endLine": 229
+    },
     "type": "insight",
     "title": "Algebraic Duality: M_{-r}(x) = 1/M_r(1/x) and min = 1/max(1/x)",
-    "content": "Two key algebraic identities reduce the -∞ limit to the +∞ result:\n\n**Duality** (`M_neg_eq_inv_M_inv`, lines 181-189):\n$$M_{-r}(x) = \\left(M_r(1/x)\\right)^{-1}$$\nProof: Start from the definition with exponent $-r$:\n- `inv_rpow` converts $x_i^{-r} = (x_i^{-1})^r$\n- `rpow_neg` converts $(\\cdot)^{1/(-r)} = (\\cdot)^{-(1/r)}$ = inverse of $(\\cdot)^{1/r}$\n- `rpow_neg hsum_nn` then gives the outer inverse\n\n**Min-Max inversion** (`minX_eq_inv_maxX_inv`, lines 211-228):\n$$\\min(x) = \\left(\\max(1/x)\\right)^{-1}$$\nProved by `le_antisymm` with two directions:\n- (≤): `max(1/x)⁻¹ ≤ (min x)⁻¹` because each `(x i)⁻¹ ≤ (min x)⁻¹` (by `aux_inv_le_inv`), so `max(1/x) ≤ (min x)⁻¹`, then invert again\n- (≥): Let $i_0$ realize the minimum; `max(1/x)⁻¹ ≤ ((x i₀)⁻¹)⁻¹ = x i₀ = min x`\n\nThese two identities together mean: $M_r(x) \\to \\min x$ as $r \\to -\\infty$ follows from $M_r(1/x) \\to \\max(1/x) = (\\min x)^{-1}$ as $r \\to +\\infty$.",
+    "content": "Two key algebraic identities reduce the -\u221e limit to the +\u221e result:\n\n**Duality** (`M_neg_eq_inv_M_inv`, lines 181-189):\n$$M_{-r}(x) = \\left(M_r(1/x)\\right)^{-1}$$\nProof: Start from the definition with exponent $-r$:\n- `inv_rpow` converts $x_i^{-r} = (x_i^{-1})^r$\n- `rpow_neg` converts $(\\cdot)^{1/(-r)} = (\\cdot)^{-(1/r)}$ = inverse of $(\\cdot)^{1/r}$\n- `rpow_neg hsum_nn` then gives the outer inverse\n\n**Min-Max inversion** (`minX_eq_inv_maxX_inv`, lines 211-228):\n$$\\min(x) = \\left(\\max(1/x)\\right)^{-1}$$\nProved by `le_antisymm` with two directions:\n- (\u2264): `max(1/x)\u207b\u00b9 \u2264 (min x)\u207b\u00b9` because each `(x i)\u207b\u00b9 \u2264 (min x)\u207b\u00b9` (by `aux_inv_le_inv`), so `max(1/x) \u2264 (min x)\u207b\u00b9`, then invert again\n- (\u2265): Let $i_0$ realize the minimum; `max(1/x)\u207b\u00b9 \u2264 ((x i\u2080)\u207b\u00b9)\u207b\u00b9 = x i\u2080 = min x`\n\nThese two identities together mean: $M_r(x) \\to \\min x$ as $r \\to -\\infty$ follows from $M_r(1/x) \\to \\max(1/x) = (\\min x)^{-1}$ as $r \\to +\\infty$.",
     "mathContext": "Duality: $\\left(\\frac{\\sum x_i^{-r}}{n}\\right)^{-1/r} = \\left[\\left(\\frac{\\sum (x_i^{-1})^r}{n}\\right)^{1/r}\\right]^{-1}$. Min-Max: $\\min_i x_i = (\\max_i x_i^{-1})^{-1}$ for positive $x_i$.",
     "significance": "key",
-    "relatedConcepts": ["inv_rpow", "rpow_neg", "Finset.inf'", "Finset.sup'", "aux_inv_le_inv", "le_antisymm"],
-    "prerequisites": ["aux_inv_le_inv", "minX and maxX definitions", "rpow_neg"]
+    "relatedConcepts": [
+      "inv_rpow",
+      "rpow_neg",
+      "Finset.inf'",
+      "Finset.sup'",
+      "aux_inv_le_inv",
+      "le_antisymm"
+    ],
+    "prerequisites": [
+      "aux_inv_le_inv",
+      "minX and maxX definitions",
+      "rpow_neg"
+    ]
   },
   {
     "id": "ann-atBot-via-duality",
     "proofId": "amgm-inequality-oq-03-oq-03-oq-01",
-    "range": { "startLine": 235, "endLine": 270 },
+    "range": {
+      "startLine": 235,
+      "endLine": 270
+    },
     "type": "technique",
-    "title": "Limit as r → -∞ via Filter Composition with Negation",
-    "content": "The -∞ limit is derived from the +∞ result by a three-step composition:\n\n```lean\nexact (hcomp.comp tendsto_neg_atBot_atTop).congr (fun r => congr_arg (M x) (neg_neg r))\n```\n\n**Step 1** (`hmax`): $M_y(r) \\to \\max(y) = \\max(1/x)$ as $r \\to +\\infty$ (from `tendsto_M_atTop` applied to $y_i = 1/x_i$)\n\n**Step 2** (`hinv`): $(M_y(r))^{-1} \\to (\\max(1/x))^{-1} = \\min(x)$ as $r \\to +\\infty$\n- `hmax.inv₀ hMaxNe` inverts the limit (valid since `maxX y ≠ 0`)\n- `← hminmax` uses the min-max inversion identity\n\n**Step 3** (`hcomp`): $M_x(-s) \\to \\min(x)$ as $s \\to +\\infty$\n- Uses `hdual s hs : M x (-s) = (M y s)⁻¹` (holding for `s ≠ 0`)\n- Applied via `.congr'` with `eventually_ne_atTop 0`\n\n**Step 4** (final): $M_x(r) \\to \\min(x)$ as $r \\to -\\infty$\n- Substitute `r = -s`, i.e., compose `hcomp` with `tendsto_neg_atBot_atTop` (which maps the filter `atBot` to `atTop` via `s ↦ -s`)\n- Final `.congr` rewrites `M x (- -r) = M x r` by `neg_neg`",
-    "mathContext": "Filter composition: `Tendsto f atTop L` composed with `Tendsto Neg.neg atBot atTop` gives `Tendsto (f ∘ Neg.neg) atBot L`, i.e., `Tendsto (fun r => f (-r)) atBot L`.",
+    "title": "Limit as r \u2192 -\u221e via Filter Composition with Negation",
+    "content": "The -\u221e limit is derived from the +\u221e result by a three-step composition:\n\n```lean\nexact (hcomp.comp tendsto_neg_atBot_atTop).congr (fun r => congr_arg (M x) (neg_neg r))\n```\n\n**Step 1** (`hmax`): $M_y(r) \\to \\max(y) = \\max(1/x)$ as $r \\to +\\infty$ (from `tendsto_M_atTop` applied to $y_i = 1/x_i$)\n\n**Step 2** (`hinv`): $(M_y(r))^{-1} \\to (\\max(1/x))^{-1} = \\min(x)$ as $r \\to +\\infty$\n- `hmax.inv\u2080 hMaxNe` inverts the limit (valid since `maxX y \u2260 0`)\n- `\u2190 hminmax` uses the min-max inversion identity\n\n**Step 3** (`hcomp`): $M_x(-s) \\to \\min(x)$ as $s \\to +\\infty$\n- Uses `hdual s hs : M x (-s) = (M y s)\u207b\u00b9` (holding for `s \u2260 0`)\n- Applied via `.congr'` with `eventually_ne_atTop 0`\n\n**Step 4** (final): $M_x(r) \\to \\min(x)$ as $r \\to -\\infty$\n- Substitute `r = -s`, i.e., compose `hcomp` with `tendsto_neg_atBot_atTop` (which maps the filter `atBot` to `atTop` via `s \u21a6 -s`)\n- Final `.congr` rewrites `M x (- -r) = M x r` by `neg_neg`",
+    "mathContext": "Filter composition: `Tendsto f atTop L` composed with `Tendsto Neg.neg atBot atTop` gives `Tendsto (f \u2218 Neg.neg) atBot L`, i.e., `Tendsto (fun r => f (-r)) atBot L`.",
     "significance": "key",
-    "relatedConcepts": ["tendsto_neg_atBot_atTop", "Filter.Tendsto.comp", "Filter.Tendsto.inv₀", "Filter.Tendsto.congr'", "eventually_ne_atTop"],
-    "prerequisites": ["tendsto_M_atTop", "M_neg_eq_inv_M_inv", "minX_eq_inv_maxX_inv"]
+    "relatedConcepts": [
+      "tendsto_neg_atBot_atTop",
+      "Filter.Tendsto.comp",
+      "Filter.Tendsto.inv\u2080",
+      "Filter.Tendsto.congr'",
+      "eventually_ne_atTop"
+    ],
+    "prerequisites": [
+      "tendsto_M_atTop",
+      "M_neg_eq_inv_M_inv",
+      "minX_eq_inv_maxX_inv"
+    ]
   }
 ]

--- a/src/data/proofs/amgm-inequality-oq-03-oq-04/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-04/annotations.json
@@ -7,15 +7,15 @@
       "endLine": 51
     },
     "type": "context",
-    "title": "Overview: Rényi Entropy and Power Means Are the Same",
-    "content": "The header explains the central insight: the weighted power mean M_r(p,p) (with a probability distribution serving as both weights and values) is increasing in r if and only if Rényi entropy H_α(p) is decreasing in α. These are not separate facts — they are the same statement in different notation, connected by the identity H_α(p) = −log(M_{α−1}(p,p)).\n\nThe mathematical proof of the identity is laid out explicitly: M_{α-1}(p,p) = (Σ pᵢ·pᵢ^(α-1))^(1/(α-1)) = (Σ pᵢ^α)^(1/(α-1)), so log(M_{α-1}) = (1/(α-1))·log(Σ pᵢ^α), and negating gives H_α = −log(M_{α-1}).",
+    "title": "Overview: R\u00e9nyi Entropy and Power Means Are the Same",
+    "content": "The header explains the central insight: the weighted power mean M_r(p,p) (with a probability distribution serving as both weights and values) is increasing in r if and only if R\u00e9nyi entropy H_\u03b1(p) is decreasing in \u03b1. These are not separate facts \u2014 they are the same statement in different notation, connected by the identity H_\u03b1(p) = \u2212log(M_{\u03b1\u22121}(p,p)).\n\nThe mathematical proof of the identity is laid out explicitly: M_{\u03b1-1}(p,p) = (\u03a3 p\u1d62\u00b7p\u1d62^(\u03b1-1))^(1/(\u03b1-1)) = (\u03a3 p\u1d62^\u03b1)^(1/(\u03b1-1)), so log(M_{\u03b1-1}) = (1/(\u03b1-1))\u00b7log(\u03a3 p\u1d62^\u03b1), and negating gives H_\u03b1 = \u2212log(M_{\u03b1-1}).",
     "mathContext": "$H_\\alpha(p) = \\frac{1}{1-\\alpha}\\log\\sum_i p_i^\\alpha$; $M_r(p,p) = \\left(\\sum_i p_i \\cdot p_i^r\\right)^{1/r}$; identity: $H_\\alpha(p) = -\\log M_{\\alpha-1}(p,p)$",
     "significance": "key",
     "relatedConcepts": [
-      "Rényi entropy",
+      "R\u00e9nyi entropy",
       "power means",
       "information theory",
-      "Hardy-Littlewood-Pólya"
+      "Hardy-Littlewood-P\u00f3lya"
     ],
     "prerequisites": [
       "probability distributions",
@@ -26,16 +26,16 @@
     "id": "ann-amgm-oq03-oq04-02-definitions",
     "proofId": "amgm-inequality-oq-03-oq-04",
     "range": {
-      "startLine": 57,
+      "startLine": 61,
       "endLine": 71
     },
     "type": "definition",
-    "title": "Rényi Entropy and Self-Power Mean Definitions",
-    "content": "Two noncomputable definitions in namespace RenyiPowerMean:\n\n`renyiEntropy s p α hα` = (1/(1-α)) * log(Σ_{i∈s} pᵢ^α), requiring α ≠ 1 (the α=1 limit gives Shannon entropy but needs L'Hôpital).\n\n`selfPowerMean s p r hr` = (Σ_{i∈s} pᵢ·pᵢ^r)^(1/r), requiring r ≠ 0. This is the power mean M_r(p,p) where p serves as both weights and values — the 'self-power mean' of the distribution.",
-    "mathContext": "Both definitions are parametric in the index type ι, finite set s, and function p : ι → ℝ. The `noncomputable` annotation is needed because Real.log and Real.rpow involve classical logic.",
+    "title": "R\u00e9nyi Entropy and Self-Power Mean Definitions",
+    "content": "Two noncomputable definitions in namespace RenyiPowerMean:\n\n`renyiEntropy s p \u03b1 h\u03b1` = (1/(1-\u03b1)) * log(\u03a3_{i\u2208s} p\u1d62^\u03b1), requiring \u03b1 \u2260 1 (the \u03b1=1 limit gives Shannon entropy but needs L'H\u00f4pital).\n\n`selfPowerMean s p r hr` = (\u03a3_{i\u2208s} p\u1d62\u00b7p\u1d62^r)^(1/r), requiring r \u2260 0. This is the power mean M_r(p,p) where p serves as both weights and values \u2014 the 'self-power mean' of the distribution.",
+    "mathContext": "Both definitions are parametric in the index type \u03b9, finite set s, and function p : \u03b9 \u2192 \u211d. The `noncomputable` annotation is needed because Real.log and Real.rpow involve classical logic.",
     "significance": "supporting",
     "relatedConcepts": [
-      "Rényi entropy",
+      "R\u00e9nyi entropy",
       "self-power mean",
       "noncomputable definitions"
     ],
@@ -52,9 +52,9 @@
       "endLine": 90
     },
     "type": "concept",
-    "title": "Key Algebraic Identity: Σ pᵢ·pᵢ^(α-1) = Σ pᵢ^α",
-    "content": "The private lemma `mul_rpow_pred` proves x·x^(α-1) = x^α for x > 0 by rewriting x = x^1 and applying `Real.rpow_add` to get x^1 · x^(α-1) = x^(1+(α-1)) = x^α.\n\nThe theorem `renyi_sum_eq_powerMean_sum` lifts this pointwise identity to Finset sums via `Finset.sum_congr`. This is the algebraic bridge between the selfPowerMean sum (Σ pᵢ·pᵢ^(α-1)) and the renyiEntropy sum (Σ pᵢ^α).",
-    "mathContext": "$x \\cdot x^{\\alpha-1} = x^{1+(\\alpha-1)} = x^\\alpha$ by `Real.rpow_add` (valid for $x > 0$). This requires positivity — the identity fails for $x = 0$ when $\\alpha - 1 < 0$.",
+    "title": "Key Algebraic Identity: \u03a3 p\u1d62\u00b7p\u1d62^(\u03b1-1) = \u03a3 p\u1d62^\u03b1",
+    "content": "The private lemma `mul_rpow_pred` proves x\u00b7x^(\u03b1-1) = x^\u03b1 for x > 0 by rewriting x = x^1 and applying `Real.rpow_add` to get x^1 \u00b7 x^(\u03b1-1) = x^(1+(\u03b1-1)) = x^\u03b1.\n\nThe theorem `renyi_sum_eq_powerMean_sum` lifts this pointwise identity to Finset sums via `Finset.sum_congr`. This is the algebraic bridge between the selfPowerMean sum (\u03a3 p\u1d62\u00b7p\u1d62^(\u03b1-1)) and the renyiEntropy sum (\u03a3 p\u1d62^\u03b1).",
+    "mathContext": "$x \\cdot x^{\\alpha-1} = x^{1+(\\alpha-1)} = x^\\alpha$ by `Real.rpow_add` (valid for $x > 0$). This requires positivity \u2014 the identity fails for $x = 0$ when $\\alpha - 1 < 0$.",
     "significance": "key",
     "relatedConcepts": [
       "rpow_add",
@@ -69,13 +69,13 @@
     "id": "ann-amgm-oq03-oq04-03b-positivity",
     "proofId": "amgm-inequality-oq-03-oq-04",
     "range": {
-      "startLine": 92,
+      "startLine": 96,
       "endLine": 109
     },
     "type": "technique",
     "title": "Positivity Lemmas: Foundation for Logarithm Arguments",
-    "content": "Two private lemmas establish positivity prerequisites needed before applying `Real.log_rpow` and `Real.log_le_log`:\n\n`renyi_sum_pos`: The Rényi sum Σ pᵢ^α is strictly positive for any positive distribution p on a nonempty finset s and any α. Proved via `Finset.sum_pos` with `Real.rpow_pos_of_pos` at each term.\n\n`selfPowerMean_pos`: The self-power mean M_r(p,p) > 0 for positive p on nonempty s and r ≠ 0. Proved by unfolding the definition — the base (Σ pᵢ·pᵢ^r) is rewritten to Σ pᵢ^(r+1) via `renyi_sum_eq_powerMean_sum`, then positivity follows from `renyi_sum_pos` and `Real.rpow_pos_of_pos`.\n\nThese lemmas are `private` because they are purely technical — their role is to supply positivity witnesses to the logarithm lemmas that require `0 < x` as a hypothesis.",
-    "mathContext": "Positivity of the Rényi sum: $\\sum_{i \\in s} p_i^\\alpha > 0$ when $p_i > 0$ and $s \\neq \\emptyset$, since each $p_i^\\alpha > 0$. Positivity of the self-power mean: $M_r(p,p) = (\\sum p_i^{r+1})^{1/r} > 0$ by `Real.rpow_pos_of_pos` applied to a positive base.",
+    "content": "Two private lemmas establish positivity prerequisites needed before applying `Real.log_rpow` and `Real.log_le_log`:\n\n`renyi_sum_pos`: The R\u00e9nyi sum \u03a3 p\u1d62^\u03b1 is strictly positive for any positive distribution p on a nonempty finset s and any \u03b1. Proved via `Finset.sum_pos` with `Real.rpow_pos_of_pos` at each term.\n\n`selfPowerMean_pos`: The self-power mean M_r(p,p) > 0 for positive p on nonempty s and r \u2260 0. Proved by unfolding the definition \u2014 the base (\u03a3 p\u1d62\u00b7p\u1d62^r) is rewritten to \u03a3 p\u1d62^(r+1) via `renyi_sum_eq_powerMean_sum`, then positivity follows from `renyi_sum_pos` and `Real.rpow_pos_of_pos`.\n\nThese lemmas are `private` because they are purely technical \u2014 their role is to supply positivity witnesses to the logarithm lemmas that require `0 < x` as a hypothesis.",
+    "mathContext": "Positivity of the R\u00e9nyi sum: $\\sum_{i \\in s} p_i^\\alpha > 0$ when $p_i > 0$ and $s \\neq \\emptyset$, since each $p_i^\\alpha > 0$. Positivity of the self-power mean: $M_r(p,p) = (\\sum p_i^{r+1})^{1/r} > 0$ by `Real.rpow_pos_of_pos` applied to a positive base.",
     "significance": "technical",
     "relatedConcepts": [
       "Real.rpow_pos_of_pos",
@@ -95,8 +95,8 @@
       "endLine": 134
     },
     "type": "theorem",
-    "title": "Main Identity: H_α(p) = −log(M_{α−1}(p,p))",
-    "content": "The proof of `renyi_eq_neg_log_powerMean` has three steps:\n\n1. Replace Σ pᵢ·pᵢ^(α-1) with Σ pᵢ^α using `renyi_sum_eq_powerMean_sum`.\n2. Apply `Real.log_rpow` to get log((Σ pᵢ^α)^(1/(α-1))) = (1/(α-1))·log(Σ pᵢ^α). This requires positivity of the sum, which we get from `renyi_sum_pos`.\n3. Simplify the arithmetic: (1/(1-α))·L = −(1/(α-1))·L, which `field_simp` + `ring` handles.\n\nThe result is that unfolding definitions and applying these three steps closes the goal.",
+    "title": "Main Identity: H_\u03b1(p) = \u2212log(M_{\u03b1\u22121}(p,p))",
+    "content": "The proof of `renyi_eq_neg_log_powerMean` has three steps:\n\n1. Replace \u03a3 p\u1d62\u00b7p\u1d62^(\u03b1-1) with \u03a3 p\u1d62^\u03b1 using `renyi_sum_eq_powerMean_sum`.\n2. Apply `Real.log_rpow` to get log((\u03a3 p\u1d62^\u03b1)^(1/(\u03b1-1))) = (1/(\u03b1-1))\u00b7log(\u03a3 p\u1d62^\u03b1). This requires positivity of the sum, which we get from `renyi_sum_pos`.\n3. Simplify the arithmetic: (1/(1-\u03b1))\u00b7L = \u2212(1/(\u03b1-1))\u00b7L, which `field_simp` + `ring` handles.\n\nThe result is that unfolding definitions and applying these three steps closes the goal.",
     "mathContext": "$\\log M_{\\alpha-1}(p,p) = \\log\\left((\\sum p_i^\\alpha)^{1/(\\alpha-1)}\\right) = \\frac{1}{\\alpha-1}\\log\\sum p_i^\\alpha = -\\frac{1}{1-\\alpha}\\log\\sum p_i^\\alpha = -H_\\alpha(p)$",
     "significance": "key",
     "relatedConcepts": [
@@ -118,7 +118,7 @@
     },
     "type": "theorem",
     "title": "Biconditional Equivalence of Monotonicity",
-    "content": "Three theorems establish the biconditional:\n\n`renyi_decreasing_of_powerMean_increasing` (M→H): Assume M_r ≤ M_s for r ≤ s. For α ≤ β, apply M_{α-1} ≤ M_{β-1}, take logs (log is monotone), negate (neg_le_neg). Combined with the identity, H_β ≤ H_α.\n\n`powerMean_increasing_of_renyi_decreasing` (H→M): Assume H_α ≤ H_β for α ≤ β. Set α = r+1, β = t+1. The hypothesis gives H_{t+1} ≤ H_{r+1}, i.e., −log(M_t) ≤ −log(M_r). Flip to log(M_r) ≤ log(M_t). Use exp/log round-trip (exp_log, exp_le_exp) to conclude M_r ≤ M_t.\n\n`renyi_monotone_iff_powerMean_monotone`: The biconditional packages both directions.",
+    "content": "Three theorems establish the biconditional:\n\n`renyi_decreasing_of_powerMean_increasing` (M\u2192H): Assume M_r \u2264 M_s for r \u2264 s. For \u03b1 \u2264 \u03b2, apply M_{\u03b1-1} \u2264 M_{\u03b2-1}, take logs (log is monotone), negate (neg_le_neg). Combined with the identity, H_\u03b2 \u2264 H_\u03b1.\n\n`powerMean_increasing_of_renyi_decreasing` (H\u2192M): Assume H_\u03b1 \u2264 H_\u03b2 for \u03b1 \u2264 \u03b2. Set \u03b1 = r+1, \u03b2 = t+1. The hypothesis gives H_{t+1} \u2264 H_{r+1}, i.e., \u2212log(M_t) \u2264 \u2212log(M_r). Flip to log(M_r) \u2264 log(M_t). Use exp/log round-trip (exp_log, exp_le_exp) to conclude M_r \u2264 M_t.\n\n`renyi_monotone_iff_powerMean_monotone`: The biconditional packages both directions.",
     "mathContext": "The exp/log round-trip: $M_r = \\exp(\\log M_r) \\leq \\exp(\\log M_t) = M_t$ since exp is monotone. This uses `Real.exp_log` (requiring positivity) and `Real.exp_le_exp`.",
     "significance": "key",
     "relatedConcepts": [
@@ -140,12 +140,12 @@
       "endLine": 209
     },
     "type": "insight",
-    "title": "Rényi Entropy Monotonicity as a Corollary of Power Mean Monotonicity",
-    "content": "The main theorem `renyi_entropy_antitone` proves that α ↦ H_α(p) is antitone (decreasing) by leveraging the core identity H_α = −log(M_{α−1}(p,p)) and the power mean monotonicity M_r ≤ M_s for r ≤ s. The Lean proof chain: (1) if α ≤ β then α−1 ≤ β−1; (2) M_{α−1}(p,p) ≤ M_{β−1}(p,p) by power mean monotonicity; (3) −log is antitone (since log is monotone); (4) H_α = −log M_{α−1} ≥ −log M_{β−1} = H_β. Lean's `antitone_log` or `Real.log_le_log` handles step (3).",
-    "mathContext": "$H_\\alpha \\ge H_\\beta$ for $\\alpha \\le \\beta$: the Rényi entropy family is decreasing in the order parameter $\\alpha$. At $\\alpha \\to 1$: $H_1(p) = -\\sum_i p_i \\log p_i$ (Shannon entropy, maximum). At $\\alpha \\to \\infty$: $H_\\infty(p) = -\\log \\max_i p_i$ (min-entropy, minimum). The antitone structure makes $H_1 \\ge H_2 \\ge H_\\infty$, giving a chain of information-theoretic measures ordered by 'sparsity sensitivity'.",
+    "title": "R\u00e9nyi Entropy Monotonicity as a Corollary of Power Mean Monotonicity",
+    "content": "The main theorem `renyi_entropy_antitone` proves that \u03b1 \u21a6 H_\u03b1(p) is antitone (decreasing) by leveraging the core identity H_\u03b1 = \u2212log(M_{\u03b1\u22121}(p,p)) and the power mean monotonicity M_r \u2264 M_s for r \u2264 s. The Lean proof chain: (1) if \u03b1 \u2264 \u03b2 then \u03b1\u22121 \u2264 \u03b2\u22121; (2) M_{\u03b1\u22121}(p,p) \u2264 M_{\u03b2\u22121}(p,p) by power mean monotonicity; (3) \u2212log is antitone (since log is monotone); (4) H_\u03b1 = \u2212log M_{\u03b1\u22121} \u2265 \u2212log M_{\u03b2\u22121} = H_\u03b2. Lean's `antitone_log` or `Real.log_le_log` handles step (3).",
+    "mathContext": "$H_\\alpha \\ge H_\\beta$ for $\\alpha \\le \\beta$: the R\u00e9nyi entropy family is decreasing in the order parameter $\\alpha$. At $\\alpha \\to 1$: $H_1(p) = -\\sum_i p_i \\log p_i$ (Shannon entropy, maximum). At $\\alpha \\to \\infty$: $H_\\infty(p) = -\\log \\max_i p_i$ (min-entropy, minimum). The antitone structure makes $H_1 \\ge H_2 \\ge H_\\infty$, giving a chain of information-theoretic measures ordered by 'sparsity sensitivity'.",
     "significance": "key",
     "relatedConcepts": [
-      "Rényi entropy antitone",
+      "R\u00e9nyi entropy antitone",
       "Shannon entropy",
       "min-entropy",
       "information theory inequalities"
@@ -160,17 +160,17 @@
     "id": "ann-amgm-oq03-oq04-06-collision",
     "proofId": "amgm-inequality-oq-03-oq-04",
     "range": {
-      "startLine": 210,
+      "startLine": 212,
       "endLine": 232
     },
     "type": "concept",
-    "title": "Collision Entropy: H_2(p) = −log(Σ pᵢ²)",
-    "content": "Two corollaries apply the main identity to α = 2:\n\n`renyi_two_eq_neg_log_collision`: H_2(p) = −log(Σ pᵢ²). The sum Σ pᵢ² is the collision probability — the probability that two independent samples from p agree. So H_2 measures the log-information content of collision events.\n\n`renyi_two_eq_neg_log_self_mean`: H_2(p) = −log(M_1(p,p)) — the negative log of the arithmetic self-mean. This follows directly from `renyi_eq_neg_log_powerMean` with α = 2.",
+    "title": "Collision Entropy: H_2(p) = \u2212log(\u03a3 p\u1d62\u00b2)",
+    "content": "Two corollaries apply the main identity to \u03b1 = 2:\n\n`renyi_two_eq_neg_log_collision`: H_2(p) = \u2212log(\u03a3 p\u1d62\u00b2). The sum \u03a3 p\u1d62\u00b2 is the collision probability \u2014 the probability that two independent samples from p agree. So H_2 measures the log-information content of collision events.\n\n`renyi_two_eq_neg_log_self_mean`: H_2(p) = \u2212log(M_1(p,p)) \u2014 the negative log of the arithmetic self-mean. This follows directly from `renyi_eq_neg_log_powerMean` with \u03b1 = 2.",
     "mathContext": "At $\\alpha = 2$: $H_2(p) = \\frac{1}{1-2}\\log\\sum p_i^2 = -\\log\\sum p_i^2$. Since $M_{2-1}(p,p) = M_1(p,p) = \\sum_i p_i \\cdot p_i^1 = \\sum_i p_i^2$ (arithmetic self-mean), we get $H_2 = -\\log M_1(p,p)$.",
     "significance": "supporting",
     "relatedConcepts": [
       "collision probability",
-      "Rényi entropy α=2",
+      "R\u00e9nyi entropy \u03b1=2",
       "arithmetic mean"
     ],
     "prerequisites": [

--- a/src/data/proofs/amgm-inequality-oq-03/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-03/annotations.json
@@ -8,14 +8,14 @@
     },
     "type": "concept",
     "title": "Power Mean Family: Overview and Open Question",
-    "content": "The header introduces the weighted power mean family M_r(z,w) and the open question: to fully formalize the monotonicity M_r <= M_s for all r <= s in Lean 4/Mathlib. **Note**: The header's item 7 (line 33) is stale — it says 'General monotonicity (negative r case) stated as an axiom' but the file actually proves power_mean_monotone_neg (lines 291–343) with no axioms or sorries. The file proves 13 results total including HM ≤ GM, M_r ≤ M_s for 0 < r ≤ s, and M_r ≤ M_s for r ≤ s < 0. Only the mixed-sign case (r < 0 < s) remains open. The imports bring in Mathlib.Analysis.MeanInequalities for the weighted AM-GM inequality and Mathlib.Analysis.MeanInequalitiesPow for Jensen's power inequality.",
+    "content": "The header introduces the weighted power mean family M_r(z,w) and the open question: to fully formalize the monotonicity M_r <= M_s for all r <= s in Lean 4/Mathlib. **Note**: The header's item 7 (line 33) is stale \u2014 it says 'General monotonicity (negative r case) stated as an axiom' but the file actually proves power_mean_monotone_neg (lines 291\u2013343) with no axioms or sorries. The file proves 13 results total including HM \u2264 GM, M_r \u2264 M_s for 0 < r \u2264 s, and M_r \u2264 M_s for r \u2264 s < 0. Only the mixed-sign case (r < 0 < s) remains open. The imports bring in Mathlib.Analysis.MeanInequalities for the weighted AM-GM inequality and Mathlib.Analysis.MeanInequalitiesPow for Jensen's power inequality.",
     "mathContext": "$M_r(z,w) = \\left(\\sum_{i} w_i z_i^r\\right)^{1/r}$ for $r \\neq 0$; $M_0 = \\prod_i z_i^{w_i}$ (geometric mean as limit). The chain: $\\text{HM} = M_{-1} \\leq M_0 = \\text{GM} \\leq M_1 = \\text{AM} \\leq M_2 \\leq \\cdots$",
     "significance": "supporting",
     "relatedConcepts": [
       "AM-GM inequality",
       "power means",
       "Jensen's inequality",
-      "Hardy-Littlewood-Pólya"
+      "Hardy-Littlewood-P\u00f3lya"
     ],
     "prerequisites": [
       "weighted inequalities",
@@ -27,12 +27,12 @@
     "id": "ann-amgm-oq03-01b-variables",
     "proofId": "amgm-inequality-oq-03",
     "range": {
-      "startLine": 57,
+      "startLine": 55,
       "endLine": 58
     },
     "type": "concept",
     "title": "Shared Variables: Abstract Index Type and Weight/Value Functions",
-    "content": "The variable block declares the abstract index type ι (with implicit [DecidableEq ι] and [Fintype ι] from the Finset API), the finite index set s : Finset ι, and the weight and value functions w z : ι → ℝ. This polymorphic setup allows the power mean theorems to work for any finite collection of real numbers with any indexing scheme — a common Mathlib pattern that avoids committing to Fin n or a specific concrete type. The hypotheses on w and z (non-negativity, positivity, weight normalization) are stated in each theorem individually rather than as variable-level assumptions.",
+    "content": "The variable block declares the abstract index type \u03b9 (with implicit [DecidableEq \u03b9] and [Fintype \u03b9] from the Finset API), the finite index set s : Finset \u03b9, and the weight and value functions w z : \u03b9 \u2192 \u211d. This polymorphic setup allows the power mean theorems to work for any finite collection of real numbers with any indexing scheme \u2014 a common Mathlib pattern that avoids committing to Fin n or a specific concrete type. The hypotheses on w and z (non-negativity, positivity, weight normalization) are stated in each theorem individually rather than as variable-level assumptions.",
     "mathContext": "The abstract setup: $s \\subseteq \\iota$ (finite index set), $w : \\iota \\to \\mathbb{R}$ (weights, typically $w_i \\geq 0$, $\\sum w_i = 1$), $z : \\iota \\to \\mathbb{R}$ (values, typically $z_i > 0$). All power mean results are parametric in these choices.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -78,7 +78,7 @@
     },
     "type": "theorem",
     "title": "Known Results from Mathlib: M1=AM, AM<=Mp, GM<=AM, GM<=Mp, Jensen",
-    "content": "Four theorems wrap existing Mathlib results. power_mean_one_eq_arith_mean proves M_1 = AM by simp with Real.rpow_one. arith_mean_le_power_mean invokes Real.arith_mean_le_rpow_mean directly. geom_mean_le_arith_mean calls Real.geom_mean_le_arith_mean_weighted. geom_mean_le_power_mean_of_one_le combines the previous two via .trans. jensen_pow_ineq wraps Real.rpow_arith_mean_le_arith_mean_rpow — this is Jensen's inequality (sum w_i z_i)^p <= sum w_i z_i^p for p >= 1, and is the key tool for power_mean_monotone_pos.",
+    "content": "Four theorems wrap existing Mathlib results. power_mean_one_eq_arith_mean proves M_1 = AM by simp with Real.rpow_one. arith_mean_le_power_mean invokes Real.arith_mean_le_rpow_mean directly. geom_mean_le_arith_mean calls Real.geom_mean_le_arith_mean_weighted. geom_mean_le_power_mean_of_one_le combines the previous two via .trans. jensen_pow_ineq wraps Real.rpow_arith_mean_le_arith_mean_rpow \u2014 this is Jensen's inequality (sum w_i z_i)^p <= sum w_i z_i^p for p >= 1, and is the key tool for power_mean_monotone_pos.",
     "mathContext": "Jensen's inequality for convex $t \\mapsto t^p$ ($p \\geq 1$): $\\left(\\sum_i w_i z_i\\right)^p \\leq \\sum_i w_i z_i^p$. Equivalently, $\\text{AM} \\leq M_p$: $\\sum_i w_i z_i \\leq \\left(\\sum_i w_i z_i^p\\right)^{1/p}$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -151,7 +151,7 @@
       "endLine": 280
     },
     "type": "theorem",
-    "title": "Duality Identity: M_r(z) = M_{-r}(z⁻¹)⁻¹",
+    "title": "Duality Identity: M_r(z) = M_{-r}(z\u207b\u00b9)\u207b\u00b9",
     "content": "`power_mean_neg_inv` establishes the algebraic identity $M_r(z) = M_{-r}(z^{-1})^{-1}$ by two key steps. First, the sum equality: $(z_i^{-1})^{-r} = z_i^r$ via `inv_rpow` + `rpow_neg` + `inv_inv`. Second, the power equality: $A^{1/r} = (A^{1/(-r)})^{-1}$ since $1/(-r) = -(1/r)$ and `rpow_neg` + `inv_inv`. Helper lemmas `weighted_sum_pos` and `weightedPowerMean_pos` establish the positivity conditions needed for the inversion step. This identity is the key tool for reducing negative-exponent power mean problems to positive-exponent ones.",
     "mathContext": "$M_r(z) = \\left(\\sum w_i z_i^r\\right)^{1/r} = \\left(\\sum w_i (z_i^{-1})^{-r}\\right)^{1/r} = \\left(\\left(\\sum w_i (z_i^{-1})^{-r}\\right)^{1/(-r)}\\right)^{-1} = M_{-r}(z^{-1})^{-1}$. The identity holds for all $r \\neq 0$ and $z_i > 0$.",
     "significance": "key",
@@ -176,9 +176,9 @@
       "endLine": 343
     },
     "type": "theorem",
-    "title": "Power Mean Monotonicity for r ≤ s < 0 (Dual Argument)",
+    "title": "Power Mean Monotonicity for r \u2264 s < 0 (Dual Argument)",
     "content": "`power_mean_monotone_neg` proves $M_r \\leq M_s$ for $r \\leq s < 0$ by a three-step dual argument: (1) negate exponents to get $0 < -s \\leq -r$; (2) apply `power_mean_monotone_pos` to $z^{-1}$ with exponents $-s \\leq -r$ to get $M_{-s}(z^{-1}) \\leq M_{-r}(z^{-1})$; (3) apply `power_mean_neg_inv` to convert back: $M_r(z) = M_{-r}(z^{-1})^{-1} \\leq M_{-s}(z^{-1})^{-1} = M_s(z)$. The inversion step (larger denominator gives smaller reciprocal) uses explicit `calc` blocks with multiplicative algebra to avoid `inv_le_inv_of_le` which was unavailable in the target Lean version.",
-    "mathContext": "For $r \\leq s < 0$: negate to $0 < -s \\leq -r$, apply positive monotonicity to $z^{-1}$: $M_{-s}(z^{-1}) \\leq M_{-r}(z^{-1})$. Invert (larger positive → smaller reciprocal): $M_{-r}(z^{-1})^{-1} \\leq M_{-s}(z^{-1})^{-1}$. By duality: $M_r(z) \\leq M_s(z)$. Combined with positive case: $M_r \\leq M_s$ for all same-sign $r \\leq s$.",
+    "mathContext": "For $r \\leq s < 0$: negate to $0 < -s \\leq -r$, apply positive monotonicity to $z^{-1}$: $M_{-s}(z^{-1}) \\leq M_{-r}(z^{-1})$. Invert (larger positive \u2192 smaller reciprocal): $M_{-r}(z^{-1})^{-1} \\leq M_{-s}(z^{-1})^{-1}$. By duality: $M_r(z) \\leq M_s(z)$. Combined with positive case: $M_r \\leq M_s$ for all same-sign $r \\leq s$.",
     "significance": "key",
     "relatedConcepts": [
       "duality argument",
@@ -201,7 +201,7 @@
     },
     "type": "insight",
     "title": "Interpolation Chain Summary: All Same-Sign Cases Proved",
-    "content": "The summary theorem power_mean_interpolation_summary catalogs the complete status: GM ≤ AM (Mathlib), AM ≤ M_p for p ≥ 1 (Mathlib), HM ≤ GM (new direct proof), M_r ≤ M_s for 0 < r ≤ s (new, Jensen), M_r ≤ M_s for r ≤ s < 0 (new, duality). The file compiles with 0 axioms and 0 sorries. Only the mixed-sign case (r < 0 < s, crossing the geometric mean limit) remains as a future direction.",
+    "content": "The summary theorem power_mean_interpolation_summary catalogs the complete status: GM \u2264 AM (Mathlib), AM \u2264 M_p for p \u2265 1 (Mathlib), HM \u2264 GM (new direct proof), M_r \u2264 M_s for 0 < r \u2264 s (new, Jensen), M_r \u2264 M_s for r \u2264 s < 0 (new, duality). The file compiles with 0 axioms and 0 sorries. Only the mixed-sign case (r < 0 < s, crossing the geometric mean limit) remains as a future direction.",
     "mathContext": "All proved: $\\text{GM} \\leq \\text{AM}$, $\\text{AM} \\leq M_p$ ($p \\geq 1$), $\\text{HM} \\leq \\text{GM}$, $M_r \\leq M_s$ ($0 < r \\leq s$), $M_r \\leq M_s$ ($r \\leq s < 0$). Open: $M_r \\leq M_s$ for $r < 0 < s$.",
     "significance": "supporting",
     "relatedConcepts": [


### PR DESCRIPTION
Fix annotation schema violations (invalid startLine values pointing to banner comments, blank lines, `variable`/`open` declarations) in 7 proof entries.

## Changes

### amgm-inequality-oq-03
- `ann-amgm-oq03-01b-variables`: 57→55 (variable decl → import line)

### amgm-inequality-oq-02-oq-01-oq-02 (5 fixes)
- `ann-decomposition`: 27→31, `ann-swap-image`: 53→57, `ann-core-symmetry`: 71→75
- `ann-main-theorem`: 100→103, `ann-application`: 118→120

### amgm-inequality-oq-02
- `ann-amgm-oq02-binomial-identity`: 203→205

### amgm-inequality-oq-03-oq-02 (6 fixes)
- `ann-pmlo-00-setup`: 45→43, `ann-pmlo-04-log-deriv`: 112→113
- `ann-pmlo-05-slope-limit`: 138→139, `ann-pmlo-06-geom-mean`: 172→173
- `ann-pmlo-07-main`: 215→216, `ann-pmlo-08-chain`: 248→249

### amgm-inequality-oq-03-oq-02-oq-01 (4 fixes)
- `ann-pmcz-core-ineq`: 88→92, `ann-pmcz-gm-le-pos`: 109→113
- `ann-pmcz-neg-le-gm`: 135→139, `ann-pmcz-main-chain`: 190→194

### amgm-inequality-oq-03-oq-03-oq-01
- `ann-power-mean-def`: 23→26

### amgm-inequality-oq-03-oq-04 (3 fixes)
- `ann-amgm-oq03-oq04-02-definitions`: 57→61
- `ann-amgm-oq03-oq04-03b-positivity`: 92→96
- `ann-amgm-oq03-oq04-06-collision`: 210→212

All annotations now validate cleanly.