### PR TITLE
Research: sperner-ndim-oq-02 — boundary_doors_odd is provably false, architectural fix needed

### DIFF
--- a/research/problems/sperner-ndim-oq-02/knowledge.md
+++ b/research/problems/sperner-ndim-oq-02/knowledge.md
@@ -1,0 +1,108 @@
+# sperner-ndim-oq-02: Boundary-Door Oddness by Dimensional Induction
+
+## Problem Summary
+
+**Goal**: Prove `SpernerGrid.boundary_doors_odd`: for the concrete Freudenthal grid
+triangulation, the count of "boundary doors" (pairs (s, k) with `adj(s,k) = none`
+and `IsDoor(c, gridComplex, s, k)`) is odd, for any Sperner coloring c.
+
+This lemma is the key input to `CellComplex.sperner`, which then gives `sperner_grid`.
+
+---
+
+## Session 2026-04-22 (Session 1) - Critical Architectural Finding
+
+**Mode**: FRESH
+**Outcome**: BLOCKED — `boundary_doors_odd` is provably FALSE as stated.
+
+### What I Did
+
+1. Read `SpernerGrid.lean` thoroughly to understand the sorry structure (5 sorries)
+2. Analyzed the abstract Sperner theorem in `SpernerMathlib4.lean`
+3. Worked through a concrete counterexample for d=1, N=1
+
+### Key Finding: `boundary_doors_odd` Is FALSE
+
+**Counterexample**: d=1, N=1, unique Sperner coloring c(1,0)=0, c(0,1)=1.
+
+The `gridComplex 1 1` has **2 GridSimplices** (not 1):
+- S1: `miss=0, incDir(0)=1, verts(0)=(1,0), verts(1)=(0,1)`
+- S2: `miss=1, incDir(0)=0, verts(0)=(0,1), verts(1)=(1,0)`
+
+Both are valid (satisfy all `GridSimplex` axioms). They represent the **same geometric
+edge** [(1,0),(0,1)] in **opposite orientations**.
+
+**All 4 boundary pairs** (S1,k=0), (S1,k=1), (S2,k=0), (S2,k=1) have `adj = none`
+(for N=1, all facets are boundary). Door check:
+- (S1, k=1): c(verts 0) = c(1,0) = 0. **IS a door.** ✓
+- (S1, k=0): c(verts 1) = c(0,1) = 1 ≠ 0. NOT a door.
+- (S2, k=0): c(verts 1) = c(1,0) = 0. **IS a door.** ✓
+- (S2, k=1): c(verts 0) = c(0,1) = 1 ≠ 0. NOT a door.
+
+**Boundary door count = 2 (EVEN)**. The theorem claims Odd. **FALSE.**
+
+### Root Cause
+
+The `GridSimplex` structure uses ORIENTED simplices with a fixed "miss" direction.
+Each geometric simplex appears **twice** in `gridComplex` — once per orientation:
+- Orientation 1: `(miss=m1, incDir=σ1, verts=v₀→...→v_d)`
+- Orientation 2: `(miss=m2, incDir=σ2, verts=v_d→...→v₀)` (reversed)
+
+Consequence: both panchromatic count and boundary door count are ALWAYS EVEN.
+The `sperner_parity` theorem still holds (both even ≡ both even mod 2), but
+`CellComplex.sperner` (which needs ODD boundary doors) cannot be applied.
+
+### Verification via `sperner_parity`
+
+For d=1, N=1: panchromatic count = 2 (both S1 and S2 are panchromatic, since both
+have vertex set {(1,0),(0,1)} with colors {0,1}). Boundary door count = 2. 
+2 ≡ 2 (mod 2) ✓ — `sperner_parity` is consistent, but boundary ≠ odd.
+
+### What IS Correct
+
+- `sperner_parity`: panchromatic count ≡ boundary door count (mod 2) — **TRUE** (proved in SpernerMathlib4)
+- `boundary_doors_odd` as stated in SpernerGrid.lean — **FALSE** (false for d ≥ 1)
+- `sperner_grid` (conclusion): **TRUE** (panchromatic simplices do exist, count ≥ 2)
+
+### The Fix Required
+
+`boundary_doors_odd` cannot be proved as stated. The proof of `sperner_grid`
+needs one of these alternatives:
+
+**Option A: Canonical-orientation sub-complex**
+- Define H ⊆ gridComplex using only "canonical" oriented simplices (one per geometric simplex)
+- For d=1: choose the simplex with smaller miss coordinate
+- H has boundary door count = (# geometric boundary doors) = ODD
+- Apply `CellComplex.sperner` to H, conclude panchromatic in H → panchromatic in gridComplex
+
+**Option B: Direct "reversal pairs" argument**
+- Every GridSimplex s has a "reverse" s' (same vertex set, opposite orientation)
+- s' is always a distinct valid GridSimplex
+- panchromatic count in gridComplex = 2 × (# geometric panchromatic) = 2 × (odd) ≥ 2
+- Requires proving the geometric count is odd via a separate argument
+
+**Option C: Use SpernerNDim abstract structure**
+- SpernerNDim.lean already has a working abstract Sperner theorem
+- Define a `SpernerTriangulation` instance for the Freudenthal grid (with UNORIENTED simplices)
+- Apply the existing abstract theorem
+
+**Recommendation**: Option C is cleanest since the infrastructure in SpernerNDim.lean
+already handles the parity argument correctly (using unoriented abstract simplices).
+
+### Files Modified
+
+None — pure analysis session.
+
+### Other Sorries in SpernerGrid.lean
+
+Beyond the false `boundary_doors_odd`, there are 2 other provable sorries:
+1. `gridAdj_symm` (line 1154): adjacency symmetry — PROVABLE by case analysis
+2. `gridAdj_vertex` (line 1163): shared vertices — PROVABLE for interior case at least
+3. `boundary_verts_on_face` (line 1239): also appears incorrect (used only for `boundary_doors_odd` chain, which is now known-false)
+
+### Next Steps
+
+1. **Architectural decision**: Choose Option A, B, or C above
+2. If Option C: define `SpernerTriangulation` instance for Freudenthal grid and apply SpernerNDim.sperner
+3. Optionally prove `gridAdj_symm` and `gridAdj_vertex` (useful for any gridComplex application)
+4. Remove or replace `boundary_doors_odd` and `boundary_verts_on_face` with correct formulations

--- a/src/data/proofs/enrichment-tracker.json
+++ b/src/data/proofs/enrichment-tracker.json
@@ -127,8 +127,8 @@
       "quality": 100
     },
     "erdos-1050": {
-      "passes": 1,
-      "lastEnriched": "2026-02-11T00:10:00Z",
+      "passes": 2,
+      "lastEnriched": "2026-04-22T12:07:04Z",
       "quality": 100
     },
     "erdos-1053": {
@@ -763,8 +763,8 @@
       "quality": 100
     },
     "erdos-625": {
-      "passes": 1,
-      "lastEnriched": "2026-03-24T18:06:50Z",
+      "passes": 2,
+      "lastEnriched": "2026-04-22T12:07:09Z",
       "quality": 100
     },
     "erdos-497": {
@@ -810,9 +810,9 @@
       "quality": 74
     },
     "elementary-quadratic-reciprocity-oq-03-oq-03": {
-      "passes": 1,
-      "lastEnriched": "2026-04-03T05:51:18Z",
-      "quality": 93
+      "passes": 2,
+      "lastEnriched": "2026-04-22T12:06:48Z",
+      "quality": 100
     },
     "erdos-115-oq-01": {
       "passes": 1,
@@ -840,9 +840,9 @@
       "quality": 80
     },
     "erdos-100-oq-01": {
-      "passes": 2,
-      "lastEnriched": "2026-04-03T07:18:35Z",
-      "quality": 9
+      "passes": 3,
+      "lastEnriched": "2026-04-22T12:06:50Z",
+      "quality": 100
     },
     "collatz-structured-oq-03": {
       "passes": 1,
@@ -1030,18 +1030,18 @@
       "quality": 90
     },
     "erdos-1005": {
-      "passes": 10,
-      "lastEnriched": "2026-04-05T05:40:00Z",
+      "passes": 11,
+      "lastEnriched": "2026-04-22T12:06:56Z",
       "quality": 100
     },
     "erdos-1017": {
-      "passes": 10,
-      "lastEnriched": "2026-04-05T05:45:00Z",
-      "quality": 92
+      "passes": 11,
+      "lastEnriched": "2026-04-22T12:07:00Z",
+      "quality": 100
     },
     "erdos-1036": {
-      "passes": 10,
-      "lastEnriched": "2026-04-05T05:50:00Z",
+      "passes": 11,
+      "lastEnriched": "2026-04-22T12:07:03Z",
       "quality": 100
     },
     "erdos-1059-oq-04": {
@@ -1070,8 +1070,8 @@
       "quality": 100
     },
     "erdos-1098-oq-01": {
-      "passes": 1,
-      "lastEnriched": "2026-04-04",
+      "passes": 2,
+      "lastEnriched": "2026-04-22T12:07:06Z",
       "quality": 100
     },
     "quadratic-reciprocity-algorithm": {
@@ -1095,8 +1095,8 @@
       "quality": 100
     },
     "angle-trisection-oq-02-oq-04-oq-01": {
-      "passes": 1,
-      "lastEnriched": "2026-04-04",
+      "passes": 2,
+      "lastEnriched": "2026-04-22T12:06:37Z",
       "quality": 100
     },
     "area-of-circle-oq-03-oq-02-oq-02": {
@@ -1233,6 +1233,231 @@
       "passes": 1,
       "lastEnriched": "2026-04-21T13:20:54Z",
       "quality": 97
+    },
+    "abel-ruffini-galois-extensions": {
+      "passes": 4,
+      "lastEnriched": "2026-04-22T12:04:57Z",
+      "quality": 100
+    },
+    "angle-trisection-oq-04": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:06:39Z",
+      "quality": 100
+    },
+    "area-of-circle-oq-03-oq-01": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:06:39Z",
+      "quality": 100
+    },
+    "arithmetic-series-oq-02-oq-01-oq-01": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:06:40Z",
+      "quality": 100
+    },
+    "arithmetic-series-oq-02-oq-02-oq-01": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:06:41Z",
+      "quality": 100
+    },
+    "bezout-identity-oq-03-oq-04": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:06:42Z",
+      "quality": 100
+    },
+    "brouwer-fixed-point-oq-01": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:06:43Z",
+      "quality": 100
+    },
+    "cantor-diagonalization-oq-02": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:06:43Z",
+      "quality": 100
+    },
+    "cantor-diagonalization-oq-03-oq-01-incomplete-01": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:06:44Z",
+      "quality": 100
+    },
+    "chebyshev-bounds": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:06:45Z",
+      "quality": 100
+    },
+    "descartes-rule-of-signs-oq-02-oq-01": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:06:46Z",
+      "quality": 100
+    },
+    "e-transcendental-oq-01-oq-01": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:06:47Z",
+      "quality": 100
+    },
+    "elementary-quadratic-reciprocity-oq-03-oq-01-oq-01": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:06:47Z",
+      "quality": 100
+    },
+    "erdos-1004": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:06:53Z",
+      "quality": 100
+    },
+    "erdos-1008": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:06:58Z",
+      "quality": 100
+    },
+    "erdos-1010-oq-02": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:06:59Z",
+      "quality": 100
+    },
+    "erdos-1022-oq-01": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:07:01Z",
+      "quality": 100
+    },
+    "erdos-1022": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:07:02Z",
+      "quality": 100
+    },
+    "erdos-1027": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:07:02Z",
+      "quality": 100
+    },
+    "erdos-1097-oq-01": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:07:05Z",
+      "quality": 100
+    },
+    "erdos-1162": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:07:06Z",
+      "quality": 100
+    },
+    "erdos-19-oq-01": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:07:07Z",
+      "quality": 100
+    },
+    "erdos-220": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:07:08Z",
+      "quality": 100
+    },
+    "erdos-633": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:07:10Z",
+      "quality": 100
+    },
+    "erdos-644": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:07:10Z",
+      "quality": 100
+    },
+    "erdos-659-oq-01": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:07:11Z",
+      "quality": 100
+    },
+    "erdos-660": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:07:12Z",
+      "quality": 100
+    },
+    "erdos-671": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:07:13Z",
+      "quality": 100
+    },
+    "erdos-678": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:07:14Z",
+      "quality": 100
+    },
+    "erdos-840": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:07:14Z",
+      "quality": 100
+    },
+    "erdos-977": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:07:15Z",
+      "quality": 100
+    },
+    "gcd-algorithm-oq-02": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:07:16Z",
+      "quality": 100
+    },
+    "harmonic-divergence-oq-01": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:07:17Z",
+      "quality": 100
+    },
+    "herons-formula-oq-01": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:07:18Z",
+      "quality": 100
+    },
+    "hilbert-15-oq-01": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:07:18Z",
+      "quality": 100
+    },
+    "hilbert-20-oq-01": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:07:19Z",
+      "quality": 100
+    },
+    "infinitude-primes-4k3": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:07:20Z",
+      "quality": 100
+    },
+    "konigsberg-oq-01": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:07:21Z",
+      "quality": 100
+    },
+    "lagrange-four-squares-oq-02": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:07:22Z",
+      "quality": 100
+    },
+    "law-of-cosines-oq-03": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:07:22Z",
+      "quality": 100
+    },
+    "lebesgue-measure-oq-02": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:07:23Z",
+      "quality": 100
+    },
+    "prime-reciprocal-divergence-oq-03": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:07:24Z",
+      "quality": 100
+    },
+    "roth-theorem-k3-oq-02": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:07:25Z",
+      "quality": 100
+    },
+    "sqrt2-plus-sqrt3-irrational": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:07:26Z",
+      "quality": 100
+    },
+    "sylow-theorem-oq-04": {
+      "passes": 1,
+      "lastEnriched": "2026-04-22T12:07:26Z",
+      "quality": 100
     }
   },
   "elementary-quadratic-reciprocity-oq-03-oq-03": {


### PR DESCRIPTION
## Summary

- **Key finding**: `SpernerGrid.boundary_doors_odd` (line 1286) is **provably FALSE** for d ≥ 1
- **Counterexample**: d=1, N=1 gives boundary door count = 2 (even, not odd)
- **Root cause**: `gridComplex` uses oriented simplices; each geometric simplex appears **twice** (both orientations), making boundary door count always even
- **Architectural fix required**: canonical-orientation subcomplex, reversal-pair argument, or `SpernerTriangulation` instance for Freudenthal grid

## Analysis

The `gridComplex d N` `CellComplex` instance from `SpernerGrid.lean` double-counts
geometric simplices by including both orientations. For d=1, N=1:
- 1 geometric edge → 2 `GridSimplex`s (miss=0 and miss=1)
- Boundary door count = 2 (even), not odd
- `sperner_parity` still holds (2 ≡ 2 mod 2) but `CellComplex.sperner` requires odd

The sorry `boundary_doors_odd` cannot be proved as stated. The `sperner_grid`
theorem needs a different proof path:
1. **Option A**: Define canonical-orientation sub-complex (pick one orientation per geometric simplex) and prove boundary doors = 1 (mod 2) for it
2. **Option B**: Reversal-pairs argument showing panchromatic count ≥ 2
3. **Option C**: Define `Triangulation (BaryPoint d N) d` instance (unoriented) and use `SpernerSimplicialInstance.lean`

## Test plan

- [ ] Verify counterexample: `gridComplex 1 1` has 2 oriented simplices with boundary door count = 2
- [ ] Review architectural fix options; select and implement one in a follow-up session
- [ ] Other provable sorries (`gridAdj_symm`, `gridAdj_vertex`) remain for future sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)