### PR TITLE
Enrich: fix annotation schema violations (batch: angle-trisection, area, algebraic, arithmetic)

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-01-oq-01/annotations.json
@@ -2,61 +2,125 @@
   {
     "id": "ann-qvand-identity-overview",
     "proofId": "arithmetic-series-oq-02-oq-01-oq-01",
-    "range": { "startLine": 1, "endLine": 38 },
+    "range": {
+      "startLine": 1,
+      "endLine": 38
+    },
     "type": "insight",
     "title": "q-Vandermonde: Quantum Deformation of the Classical Identity",
-    "content": "The q-Vandermonde identity [m+n choose r]_q = ∑_{k=0}^{r} q^{k(m+k-r)} [m choose r-k]_q [n choose k]_q generalizes the classical Vandermonde by replacing binomial coefficients with Gaussian binomial coefficients (q-binomials). At q=1: q^{k(m+k-r)} = 1 and [n choose k]_1 = C(n,k), recovering classical Vandermonde. The combinatorial interpretation over F_q: [n choose k]_q counts k-dimensional subspaces of F_q^n. The q-Vandermonde counts (r-dim subspaces of F_q^{m+n}) by decomposing based on the dimension of their intersection with the first m coordinates. The exponent q^{k(m+k-r)} is the 'crossing number' — the dimension of the intersection minus the expected crossing. This connects to the representation theory of GL(n, F_q) and quantum groups.",
+    "content": "The q-Vandermonde identity [m+n choose r]_q = \u2211_{k=0}^{r} q^{k(m+k-r)} [m choose r-k]_q [n choose k]_q generalizes the classical Vandermonde by replacing binomial coefficients with Gaussian binomial coefficients (q-binomials). At q=1: q^{k(m+k-r)} = 1 and [n choose k]_1 = C(n,k), recovering classical Vandermonde. The combinatorial interpretation over F_q: [n choose k]_q counts k-dimensional subspaces of F_q^n. The q-Vandermonde counts (r-dim subspaces of F_q^{m+n}) by decomposing based on the dimension of their intersection with the first m coordinates. The exponent q^{k(m+k-r)} is the 'crossing number' \u2014 the dimension of the intersection minus the expected crossing. This connects to the representation theory of GL(n, F_q) and quantum groups.",
     "mathContext": "Gaussian binomial: $\\binom{n}{k}_q = \\frac{(1-q^n)(1-q^{n-1})\\cdots(1-q^{n-k+1})}{(1-q)(1-q^2)\\cdots(1-q^k)}$. q-Vandermonde: $\\binom{m+n}{r}_q = \\sum_{k=0}^{r} q^{k(m+k-r)} \\binom{m}{r-k}_q \\binom{n}{k}_q$. At $q \\to 1$: $\\binom{n}{k}_q \\to \\binom{n}{k}$ and the identity becomes $\\binom{m+n}{r} = \\sum_k \\binom{m}{r-k}\\binom{n}{k}$ (Vandermonde).",
     "significance": "key",
-    "relatedConcepts": ["Gaussian binomial coefficients", "Vandermonde convolution", "quantum groups", "F_q vector space counting", "q-hypergeometric series"],
-    "prerequisites": ["qBinom from ArithmeticSeriesOQ02OQ01", "q-Pascal rule", "classical Vandermonde identity"]
+    "relatedConcepts": [
+      "Gaussian binomial coefficients",
+      "Vandermonde convolution",
+      "quantum groups",
+      "F_q vector space counting",
+      "q-hypergeometric series"
+    ],
+    "prerequisites": [
+      "qBinom from ArithmeticSeriesOQ02OQ01",
+      "q-Pascal rule",
+      "classical Vandermonde identity"
+    ]
   },
   {
     "id": "ann-qvand-nat-subtraction",
     "proofId": "arithmetic-series-oq-02-oq-01-oq-01",
-    "range": { "startLine": 42, "endLine": 54 },
+    "range": {
+      "startLine": 46,
+      "endLine": 54
+    },
     "type": "technique",
-    "title": "ℕ Saturating Subtraction: zify+ring for Exponent Identity",
-    "content": "The Part A exponent identity k*(m+k-r)+(r+1-k) = (r+1)+k*(m+k-(r+1)) is an integer equality that requires special handling in Lean 4 because ℕ subtraction saturates at 0. The proof (partA_exp) uses `zify [hm, hk, h1]` to convert all terms to ℤ using the hypotheses: hm : r+1 ≤ m+k (ensures m+k-r ≥ 0 in ℤ) and hk : k ≤ r+1 (ensures r+1-k ≥ 0). The side condition h1 is needed for the m+k-(r+1) subtraction. After zify, `ring` closes the goal — the algebraic identity is immediate over ℤ. The saturating subtraction design is intentional: terms where m+k < r have qBinom q m (r-k) = 0 by qBinom_eq_zero_of_lt, so the 'wrong' exponent value in those degenerate cases is harmless — the overall term vanishes. This is a recurring design pattern in q-analog proofs.",
-    "mathContext": "ℕ saturating subtraction: $a - b = 0$ when $b > a$ in $\\mathbb{N}$. Intended: $m+k-r$ should be $\\max(0, m+k-r)$, which matches ℕ. The exponent identity as integers: $k(m+k-r) + (r+1-k) = (r+1) + k(m+k-r-1)$, provable by ring. Side conditions ensure each side $\\geq 0$ in $\\mathbb{N}$.",
+    "title": "\u2115 Saturating Subtraction: zify+ring for Exponent Identity",
+    "content": "The Part A exponent identity k*(m+k-r)+(r+1-k) = (r+1)+k*(m+k-(r+1)) is an integer equality that requires special handling in Lean 4 because \u2115 subtraction saturates at 0. The proof (partA_exp) uses `zify [hm, hk, h1]` to convert all terms to \u2124 using the hypotheses: hm : r+1 \u2264 m+k (ensures m+k-r \u2265 0 in \u2124) and hk : k \u2264 r+1 (ensures r+1-k \u2265 0). The side condition h1 is needed for the m+k-(r+1) subtraction. After zify, `ring` closes the goal \u2014 the algebraic identity is immediate over \u2124. The saturating subtraction design is intentional: terms where m+k < r have qBinom q m (r-k) = 0 by qBinom_eq_zero_of_lt, so the 'wrong' exponent value in those degenerate cases is harmless \u2014 the overall term vanishes. This is a recurring design pattern in q-analog proofs.",
+    "mathContext": "\u2115 saturating subtraction: $a - b = 0$ when $b > a$ in $\\mathbb{N}$. Intended: $m+k-r$ should be $\\max(0, m+k-r)$, which matches \u2115. The exponent identity as integers: $k(m+k-r) + (r+1-k) = (r+1) + k(m+k-r-1)$, provable by ring. Side conditions ensure each side $\\geq 0$ in $\\mathbb{N}$.",
     "significance": "key",
-    "relatedConcepts": ["ℕ saturating subtraction", "zify tactic", "ring over ℤ", "qBinom_eq_zero_of_lt", "degenerate term vanishing"],
-    "prerequisites": ["ℕ vs ℤ subtraction in Lean 4", "zify tactic with hypothesis hints", "qBinom_eq_zero_of_lt for out-of-range terms"]
+    "relatedConcepts": [
+      "\u2115 saturating subtraction",
+      "zify tactic",
+      "ring over \u2124",
+      "qBinom_eq_zero_of_lt",
+      "degenerate term vanishing"
+    ],
+    "prerequisites": [
+      "\u2115 vs \u2124 subtraction in Lean 4",
+      "zify tactic with hypothesis hints",
+      "qBinom_eq_zero_of_lt for out-of-range terms"
+    ]
   },
   {
     "id": "ann-qvand-parta-lemma",
     "proofId": "arithmetic-series-oq-02-oq-01-oq-01",
-    "range": { "startLine": 63, "endLine": 91 },
+    "range": {
+      "startLine": 68,
+      "endLine": 91
+    },
     "type": "technique",
     "title": "Part A Lemma: Extracting the q^(r+1) Factor via Case Split",
-    "content": "The partA_eq lemma proves ∑_k q^{k(m+k-r)+(r+1-k)} [m choose r+1-k]_q [n choose k]_q = q^{r+1} * ∑_k q^{k(m+k-(r+1))} [m choose r+1-k]_q [n choose k]_q. The proof case-splits on r+1 ≤ m+k (normal case) vs m+k < r+1 (degenerate case). Normal case: use partA_exp to rewrite the exponent and factor out q^{r+1}. Degenerate case: both sides vanish — the LHS because qBinom q m (r+1-k) = 0 (need r+1-k > m, handled by qBinom_eq_zero_of_lt), and the RHS similarly. The Finset.sum_congr applies this case analysis pointwise. The modular design (factor out the case split into a separate lemma) keeps the main induction step readable.",
+    "content": "The partA_eq lemma proves \u2211_k q^{k(m+k-r)+(r+1-k)} [m choose r+1-k]_q [n choose k]_q = q^{r+1} * \u2211_k q^{k(m+k-(r+1))} [m choose r+1-k]_q [n choose k]_q. The proof case-splits on r+1 \u2264 m+k (normal case) vs m+k < r+1 (degenerate case). Normal case: use partA_exp to rewrite the exponent and factor out q^{r+1}. Degenerate case: both sides vanish \u2014 the LHS because qBinom q m (r+1-k) = 0 (need r+1-k > m, handled by qBinom_eq_zero_of_lt), and the RHS similarly. The Finset.sum_congr applies this case analysis pointwise. The modular design (factor out the case split into a separate lemma) keeps the main induction step readable.",
     "mathContext": "The factor extraction: $q^{k(m+k-r) + (r+1-k)} = q^{r+1} \\cdot q^{k(m+k-(r+1))}$ when $k \\leq r+1 \\leq m+k$. When $m+k < r+1$: $\\binom{m}{r+1-k}_q = 0$ since $r+1-k > m$. Both sides zero in the degenerate case.",
     "significance": "supporting",
-    "relatedConcepts": ["Finset.sum_congr", "case split on natural number comparison", "qBinom_eq_zero_of_lt", "partA_exp", "modular proof structure"],
-    "prerequisites": ["partA_exp lemma", "qBinom_eq_zero_of_lt: qBinom q n k = 0 when k > n", "Finset.sum_congr for pointwise equality"]
+    "relatedConcepts": [
+      "Finset.sum_congr",
+      "case split on natural number comparison",
+      "qBinom_eq_zero_of_lt",
+      "partA_exp",
+      "modular proof structure"
+    ],
+    "prerequisites": [
+      "partA_exp lemma",
+      "qBinom_eq_zero_of_lt: qBinom q n k = 0 when k > n",
+      "Finset.sum_congr for pointwise equality"
+    ]
   },
   {
     "id": "ann-qvand-induction",
     "proofId": "arithmetic-series-oq-02-oq-01-oq-01",
-    "range": { "startLine": 131, "endLine": 190 },
+    "range": {
+      "startLine": 131,
+      "endLine": 190
+    },
     "type": "insight",
     "title": "Induction on m: IH Applied Twice via q-Pascal",
-    "content": "The main theorem qVandermonde is proved by induction on m. Base case m=0: use Finset.sum_eq_single at k=r — all other terms vanish by qBinom_zero_succ (qBinom q 0 (l+1) = 0 for l ≥ 0). Inductive step m→m+1, r→r+1: apply q-Pascal on the LHS [m+n+1 choose r+1]_q = q^{r+1}*[m+n choose r+1]_q + [m+n choose r]_q. Apply IH at (m, r+1) and (m, r) to get two sum expressions. Use simp_rw with the ℕ identity m+1+k-(r+1) = m+k-r (proved by omega) to align exponents. Then a sorry currently handles the final assembly (combining Part A and Part B). The two-IH structure is characteristic of q-analog identities: q-Pascal decomposes the LHS into two sums, both matching the IH at the previous level.",
+    "content": "The main theorem qVandermonde is proved by induction on m. Base case m=0: use Finset.sum_eq_single at k=r \u2014 all other terms vanish by qBinom_zero_succ (qBinom q 0 (l+1) = 0 for l \u2265 0). Inductive step m\u2192m+1, r\u2192r+1: apply q-Pascal on the LHS [m+n+1 choose r+1]_q = q^{r+1}*[m+n choose r+1]_q + [m+n choose r]_q. Apply IH at (m, r+1) and (m, r) to get two sum expressions. Use simp_rw with the \u2115 identity m+1+k-(r+1) = m+k-r (proved by omega) to align exponents. Then a sorry currently handles the final assembly (combining Part A and Part B). The two-IH structure is characteristic of q-analog identities: q-Pascal decomposes the LHS into two sums, both matching the IH at the previous level.",
     "mathContext": "q-Pascal: $\\binom{n+1}{k+1}_q = q^{k+1}\\binom{n}{k+1}_q + \\binom{n}{k}_q$. IH: $\\binom{m+n}{r}_q = S(m,n,r)$ where $S(m,n,r) = \\sum_k q^{k(m+k-r)}\\binom{m}{r-k}_q\\binom{n}{k}_q$. Applied twice: LHS = $q^{r+1} S(m,n,r+1) + S(m,n,r)$; RHS = $S(m+1,n,r+1)$ via Parts A+B.",
     "significance": "key",
-    "relatedConcepts": ["induction on m", "q-Pascal rule", "IH applied twice", "Finset.sum_eq_single for base case", "simp_rw for ℕ identity alignment"],
-    "prerequisites": ["q-Pascal rule from ArithmeticSeriesOQ02OQ01", "qBinom_zero_succ: qBinom q 0 (n+1) = 0", "omega for ℕ arithmetic identities"]
+    "relatedConcepts": [
+      "induction on m",
+      "q-Pascal rule",
+      "IH applied twice",
+      "Finset.sum_eq_single for base case",
+      "simp_rw for \u2115 identity alignment"
+    ],
+    "prerequisites": [
+      "q-Pascal rule from ArithmeticSeriesOQ02OQ01",
+      "qBinom_zero_succ: qBinom q 0 (n+1) = 0",
+      "omega for \u2115 arithmetic identities"
+    ]
   },
   {
     "id": "ann-qvand-pascal-split",
     "proofId": "arithmetic-series-oq-02-oq-01-oq-01",
-    "range": { "startLine": 111, "endLine": 130 },
+    "range": {
+      "startLine": 116,
+      "endLine": 130
+    },
     "type": "technique",
     "title": "Pascal Split of Sum: Decomposing S(m+1,n,r+1)",
     "content": "The sum_split_pascal lemma applies Pascal's rule to qBinom q (m+1) (r+1-k) inside the summation, decomposing S(m+1,n,r+1) into Part A (the q^{r+1-k} terms with qBinom q m (r+1-k)) and Part B (the qBinom q m (r-k) terms). This is the key step connecting the LHS Pascal decomposition to the RHS sum. The proof uses Finset.sum_add_distrib to split the sum after pointwise Pascal expansion, then recognizes Part A and Part B as separate sub-sums that match the induction hypothesis applications.",
     "mathContext": "Pascal split: $S(m+1,n,r+1) = \\text{Part A} + \\text{Part B}$ where Part A $= q^{r+1} S(m,n,r+1)$ and Part B $= S(m,n,r)$. This follows from Pascal: $\\binom{m+1}{r+1-k}_q = q^{r+1-k}\\binom{m}{r+1-k}_q + \\binom{m}{r-k}_q$. Substituting into the sum and regrouping via Finset.sum_add_distrib gives the decomposition.",
     "significance": "supporting",
-    "relatedConcepts": ["Finset.sum_add_distrib", "q-Pascal rule", "sum decomposition", "modular proof structure"],
-    "prerequisites": ["q-Pascal rule for qBinom", "Finset.sum_add_distrib", "partA_eq and partB_eq_ih"]
+    "relatedConcepts": [
+      "Finset.sum_add_distrib",
+      "q-Pascal rule",
+      "sum decomposition",
+      "modular proof structure"
+    ],
+    "prerequisites": [
+      "q-Pascal rule for qBinom",
+      "Finset.sum_add_distrib",
+      "partA_eq and partB_eq_ih"
+    ]
   }
 ]

--- a/src/data/proofs/arithmetic-series-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-01/annotations.json
@@ -2,109 +2,212 @@
   {
     "id": "ann-qbinom-def",
     "proofId": "arithmetic-series-oq-02-oq-01",
-    "range": { "startLine": 26, "endLine": 31 },
+    "range": {
+      "startLine": 26,
+      "endLine": 31
+    },
     "type": "definition",
     "title": "Gaussian Binomial Coefficient via q-Pascal's Rule",
-    "content": "The Gaussian binomial coefficient qBinom q n k is defined recursively using q-Pascal's rule: any element of the top row equals 1, the extra-diagonal elements vanish, and the interior follows [n+1 choose k+1]_q = q^{k+1}·[n choose k+1]_q + [n choose k]_q. The noncomputable tag is needed because Lean cannot decide which branch applies from types alone; the definition works in any commutative ring R, not just in ℕ or ℤ.",
+    "content": "The Gaussian binomial coefficient qBinom q n k is defined recursively using q-Pascal's rule: any element of the top row equals 1, the extra-diagonal elements vanish, and the interior follows [n+1 choose k+1]_q = q^{k+1}\u00b7[n choose k+1]_q + [n choose k]_q. The noncomputable tag is needed because Lean cannot decide which branch applies from types alone; the definition works in any commutative ring R, not just in \u2115 or \u2124.",
     "mathContext": "$\\binom{n}{k}_q$ defined by: $\\binom{n}{0}_q = 1$, $\\binom{0}{k+1}_q = 0$, $\\binom{n+1}{k+1}_q = q^{k+1}\\binom{n}{k+1}_q + \\binom{n}{k}_q$",
     "significance": "key",
-    "relatedConcepts": ["q-Pascal triangle", "Gaussian binomial coefficients", "commutative ring", "q-deformation"],
-    "prerequisites": ["commutative ring theory", "recursive definitions in Lean 4", "natural number induction"]
+    "relatedConcepts": [
+      "q-Pascal triangle",
+      "Gaussian binomial coefficients",
+      "commutative ring",
+      "q-deformation"
+    ],
+    "prerequisites": [
+      "commutative ring theory",
+      "recursive definitions in Lean 4",
+      "natural number induction"
+    ]
   },
   {
     "id": "ann-boundary-cases",
     "proofId": "arithmetic-series-oq-02-oq-01",
-    "range": { "startLine": 37, "endLine": 45 },
+    "range": {
+      "startLine": 38,
+      "endLine": 45
+    },
     "type": "technique",
     "title": "Boundary Conditions: Top Row and Left Column",
     "content": "Two @[simp] lemmas establish the fundamental boundary conditions for the q-Pascal triangle. qBinom_zero_right proves [n choose 0]_q = 1 for all n (the top row is all ones), while qBinom_zero_succ confirms [0 choose k+1]_q = 0 (the left column beyond the diagonal is zero). These are direct from the definition; the `cases n` tactic handles n = 0 vs n+1 separately. Marking as @[simp] lets Lean discharge these goals automatically in later proofs.",
     "mathContext": "$\\binom{n}{0}_q = 1$ for all $n$; $\\binom{0}{k+1}_q = 0$ for all $k$",
     "significance": "supporting",
-    "relatedConcepts": ["base cases", "simp lemmas", "q-Pascal triangle boundary"],
-    "prerequisites": ["Lean 4 simp attribute", "pattern matching on natural numbers"]
+    "relatedConcepts": [
+      "base cases",
+      "simp lemmas",
+      "q-Pascal triangle boundary"
+    ],
+    "prerequisites": [
+      "Lean 4 simp attribute",
+      "pattern matching on natural numbers"
+    ]
   },
   {
     "id": "ann-q-pascal-rule",
     "proofId": "arithmetic-series-oq-02-oq-01",
-    "range": { "startLine": 51, "endLine": 54 },
+    "range": {
+      "startLine": 51,
+      "endLine": 54
+    },
     "type": "concept",
     "title": "q-Pascal's Rule: The Central Recurrence",
     "content": "This theorem makes the defining recurrence explicitly available as a rewrite rule. In ordinary Pascal's triangle, [n+1 choose k+1] = [n choose k+1] + [n choose k]. The q-analog introduces a weight factor q^{k+1} on the 'upper-left' term, encoding the structure of q-counting. When q = 1 all weights collapse to 1 and ordinary Pascal's rule is recovered. Combinatorially, this weights each k-dimensional subspace by the number of inversions in its basis, counted as a power of q.",
     "mathContext": "$\\binom{n+1}{k+1}_q = q^{k+1}\\binom{n}{k+1}_q + \\binom{n}{k}_q$",
     "significance": "key",
-    "relatedConcepts": ["Pascal's rule", "inversion number", "Gaussian q-binomial", "Grassmannian"],
-    "prerequisites": ["ordinary Pascal's rule", "q-analogs", "combinatorics of subspaces over finite fields"]
+    "relatedConcepts": [
+      "Pascal's rule",
+      "inversion number",
+      "Gaussian q-binomial",
+      "Grassmannian"
+    ],
+    "prerequisites": [
+      "ordinary Pascal's rule",
+      "q-analogs",
+      "combinatorics of subspaces over finite fields"
+    ]
   },
   {
     "id": "ann-vanishing",
     "proofId": "arithmetic-series-oq-02-oq-01",
-    "range": { "startLine": 60, "endLine": 70 },
+    "range": {
+      "startLine": 61,
+      "endLine": 70
+    },
     "type": "technique",
     "title": "Vanishing: [n choose k]_q = 0 when k > n",
     "content": "This is the q-analog of the fact that C(n,k) = 0 whenever k > n. The proof is by induction on n, using qBinom_succ_succ to unroll the recurrence and then applying the induction hypothesis twice (for both upper-left and upper terms). The two IH applications require careful omega-arithmetic to derive n < k+1 and n < k from the main hypothesis n+1 < k+1. The @[simp] attribute allows Lean's simplifier to automatically eliminate these zero terms in later proofs.",
     "mathContext": "If $k > n$ then $\\binom{n}{k}_q = 0$",
     "significance": "supporting",
-    "relatedConcepts": ["vanishing conditions", "induction on natural numbers", "Lean omega tactic"],
-    "prerequisites": ["natural number induction", "Lean omega arithmetic solver"]
+    "relatedConcepts": [
+      "vanishing conditions",
+      "induction on natural numbers",
+      "Lean omega tactic"
+    ],
+    "prerequisites": [
+      "natural number induction",
+      "Lean omega arithmetic solver"
+    ]
   },
   {
     "id": "ann-diagonal",
     "proofId": "arithmetic-series-oq-02-oq-01",
-    "range": { "startLine": 76, "endLine": 83 },
+    "range": {
+      "startLine": 77,
+      "endLine": 83
+    },
     "type": "concept",
     "title": "Diagonal Identity: [n choose n]_q = 1",
-    "content": "The diagonal of the q-Pascal triangle is identically 1, just as C(n,n) = 1 in ordinary combinatorics. The proof by induction peels off [n+1 choose n+1]_q = q^{n+1}·[n choose n+1]_q + [n choose n]_q, then uses qBinom_eq_zero_of_lt to kill the first term (since n < n+1), and the IH to simplify [n choose n]_q = 1. Combinatorially, there is exactly one way to choose an n-dimensional subspace of an n-dimensional space over any field.",
+    "content": "The diagonal of the q-Pascal triangle is identically 1, just as C(n,n) = 1 in ordinary combinatorics. The proof by induction peels off [n+1 choose n+1]_q = q^{n+1}\u00b7[n choose n+1]_q + [n choose n]_q, then uses qBinom_eq_zero_of_lt to kill the first term (since n < n+1), and the IH to simplify [n choose n]_q = 1. Combinatorially, there is exactly one way to choose an n-dimensional subspace of an n-dimensional space over any field.",
     "mathContext": "$\\binom{n}{n}_q = 1$ for all $n \\geq 0$",
     "significance": "supporting",
-    "relatedConcepts": ["diagonal of Pascal's triangle", "subspace counting", "Grassmannian Gr(n, F^n)"],
-    "prerequisites": ["qBinom_eq_zero_of_lt", "ordinary diagonal identity C(n,n)=1"]
+    "relatedConcepts": [
+      "diagonal of Pascal's triangle",
+      "subspace counting",
+      "Grassmannian Gr(n, F^n)"
+    ],
+    "prerequisites": [
+      "qBinom_eq_zero_of_lt",
+      "ordinary diagonal identity C(n,n)=1"
+    ]
   },
   {
     "id": "ann-q-one-specialization",
     "proofId": "arithmetic-series-oq-02-oq-01",
-    "range": { "startLine": 89, "endLine": 107 },
+    "range": {
+      "startLine": 89,
+      "endLine": 107
+    },
     "type": "insight",
     "title": "q=1 Specialization Recovers Ordinary Binomial Coefficients",
-    "content": "This theorem confirms that qBinom is a genuine q-deformation: setting q = 1 in ℤ returns exactly Nat.choose n k (when k ≤ n). The proof is an intricate induction requiring case analysis: when k+1 ≤ n both IH instances apply cleanly; when k = n only one term survives via the vanishing lemma. The arithmetic connecting qBinom q (n+1) (k+1) at q=1 to Nat.choose uses `linarith [Nat.choose_succ_succ n k]`, the Lean statement of Pascal's rule for ordinary binomials. The hypothesis k ≤ n is necessary: for k > n, both sides are 0 but the Nat.choose definition diverges from qBinom's for out-of-range inputs.",
+    "content": "This theorem confirms that qBinom is a genuine q-deformation: setting q = 1 in \u2124 returns exactly Nat.choose n k (when k \u2264 n). The proof is an intricate induction requiring case analysis: when k+1 \u2264 n both IH instances apply cleanly; when k = n only one term survives via the vanishing lemma. The arithmetic connecting qBinom q (n+1) (k+1) at q=1 to Nat.choose uses `linarith [Nat.choose_succ_succ n k]`, the Lean statement of Pascal's rule for ordinary binomials. The hypothesis k \u2264 n is necessary: for k > n, both sides are 0 but the Nat.choose definition diverges from qBinom's for out-of-range inputs.",
     "mathContext": "For $k \\leq n$: $\\binom{n}{k}_1 = \\binom{n}{k}$ (ordinary binomial). Uses ordinary Pascal: $\\binom{n+1}{k+1} = \\binom{n}{k+1} + \\binom{n}{k}$.",
     "significance": "key",
-    "relatedConcepts": ["q-deformation", "specialization at q=1", "ordinary binomial coefficients", "Nat.choose"],
-    "prerequisites": ["Nat.choose_succ_succ (Pascal's rule)", "induction on n with k generalizing", "case splitting on k ≤ n vs k = n"]
+    "relatedConcepts": [
+      "q-deformation",
+      "specialization at q=1",
+      "ordinary binomial coefficients",
+      "Nat.choose"
+    ],
+    "prerequisites": [
+      "Nat.choose_succ_succ (Pascal's rule)",
+      "induction on n with k generalizing",
+      "case splitting on k \u2264 n vs k = n"
+    ]
   },
   {
     "id": "ann-qsimplicial-def",
     "proofId": "arithmetic-series-oq-02-oq-01",
-    "range": { "startLine": 113, "endLine": 126 },
+    "range": {
+      "startLine": 113,
+      "endLine": 126
+    },
     "type": "definition",
     "title": "q-Simplicial Numbers: Counting Weighted Lattice Paths",
     "content": "The q-simplicial number qSimplicial q k n = qBinom q (n+k) k is the q-analog of the ordinary simplicial number C(n+k, k), which counts the number of ways to choose a k-element multiset from {1,...,n}. In the q-world, each such selection is weighted by q^{inv}, where inv counts the number of inversions in the corresponding lattice path. The two base cases (k=0 and n=0) both yield 1, reflecting that there is exactly one lattice path in degenerate dimensions, regardless of q.",
     "mathContext": "$\\text{qSimplicial}(q, k, n) = \\binom{n+k}{k}_q$, the $q$-analog of $\\binom{n+k}{k} = \\frac{(n+k)!}{n!k!}$",
     "significance": "supporting",
-    "relatedConcepts": ["simplicial numbers", "lattice paths", "inversion statistics", "q-series"],
-    "prerequisites": ["ordinary simplicial numbers C(n+k,k)", "qBinom definition", "inversion number on lattice paths"]
+    "relatedConcepts": [
+      "simplicial numbers",
+      "lattice paths",
+      "inversion statistics",
+      "q-series"
+    ],
+    "prerequisites": [
+      "ordinary simplicial numbers C(n+k,k)",
+      "qBinom definition",
+      "inversion number on lattice paths"
+    ]
   },
   {
     "id": "ann-qsimplicial-recurrence",
     "proofId": "arithmetic-series-oq-02-oq-01",
-    "range": { "startLine": 132, "endLine": 142 },
+    "range": {
+      "startLine": 132,
+      "endLine": 142
+    },
     "type": "technique",
     "title": "q-Simplicial Recurrence: Bridge to q-Pascal's Rule",
-    "content": "This recurrence qS(k+1, n+1) = q^{k+1}·qS(k+1, n) + qS(k, n+1) is the key lemma used in the inductive step of qHockeyStick. The proof works by translating indices via ring arithmetic: n+1+(k+1) = (n+(k+1))+1 and similar identities allow the goal to be rewritten as qBinom_succ_succ applied at a specific index pair. At q=1 this becomes S(k+1, n+1) = S(k+1, n) + S(k, n+1), which is exactly the simplicial recurrence from ArithmeticSeriesOQ02. The Lean proof is three lines — all work is done by ring normalization plus a single rewrite.",
+    "content": "This recurrence qS(k+1, n+1) = q^{k+1}\u00b7qS(k+1, n) + qS(k, n+1) is the key lemma used in the inductive step of qHockeyStick. The proof works by translating indices via ring arithmetic: n+1+(k+1) = (n+(k+1))+1 and similar identities allow the goal to be rewritten as qBinom_succ_succ applied at a specific index pair. At q=1 this becomes S(k+1, n+1) = S(k+1, n) + S(k, n+1), which is exactly the simplicial recurrence from ArithmeticSeriesOQ02. The Lean proof is three lines \u2014 all work is done by ring normalization plus a single rewrite.",
     "mathContext": "$\\binom{n+1+k+1}{k+1}_q = q^{k+1}\\binom{n+k+1}{k+1}_q + \\binom{n+1+k}{k}_q$",
     "significance": "key",
-    "relatedConcepts": ["simplicial recurrence", "q-Pascal's rule", "index arithmetic", "ring normalization"],
-    "prerequisites": ["qBinom_succ_succ", "ring tactic in Lean 4", "arithmetic identity (n+1+(k+1)) = ((n+(k+1))+1)"]
+    "relatedConcepts": [
+      "simplicial recurrence",
+      "q-Pascal's rule",
+      "index arithmetic",
+      "ring normalization"
+    ],
+    "prerequisites": [
+      "qBinom_succ_succ",
+      "ring tactic in Lean 4",
+      "arithmetic identity (n+1+(k+1)) = ((n+(k+1))+1)"
+    ]
   },
   {
     "id": "ann-hockey-stick-main",
     "proofId": "arithmetic-series-oq-02-oq-01",
-    "range": { "startLine": 148, "endLine": 172 },
+    "range": {
+      "startLine": 148,
+      "endLine": 172
+    },
     "type": "insight",
     "title": "q-Hockey Stick: Induction with Exponent Factorization",
-    "content": "The central theorem. The sum ∑_{j=0}^{N} q^{(N-j)(k+1)} · [j+k choose k]_q telescopes to [N+k+1 choose k+1]_q. The proof is by induction on N. The base case N=0 is trivial (single term, exponent 0). In the inductive step, the sum splits into the last term j=N+1 (which has exponent 0, giving qS(k, N+1)) plus the remaining sum. The key move is the exponent identity (N+1-j)(k+1) = (N-j)(k+1) + (k+1), which allows factoring q^{k+1} out of all N+1 earlier terms via Finset.sum_congr and Finset.mul_sum. The IH then identifies the factored sum as q^{k+1}·qS(k+1, N), and qSimplicial_succ_recurrence combines q^{k+1}·qS(k+1,N) + qS(k, N+1) = qS(k+1, N+1).",
+    "content": "The central theorem. The sum \u2211_{j=0}^{N} q^{(N-j)(k+1)} \u00b7 [j+k choose k]_q telescopes to [N+k+1 choose k+1]_q. The proof is by induction on N. The base case N=0 is trivial (single term, exponent 0). In the inductive step, the sum splits into the last term j=N+1 (which has exponent 0, giving qS(k, N+1)) plus the remaining sum. The key move is the exponent identity (N+1-j)(k+1) = (N-j)(k+1) + (k+1), which allows factoring q^{k+1} out of all N+1 earlier terms via Finset.sum_congr and Finset.mul_sum. The IH then identifies the factored sum as q^{k+1}\u00b7qS(k+1, N), and qSimplicial_succ_recurrence combines q^{k+1}\u00b7qS(k+1,N) + qS(k, N+1) = qS(k+1, N+1).",
     "mathContext": "$\\sum_{j=0}^{N} q^{(N-j)(k+1)} \\binom{j+k}{k}_q = \\binom{N+k+1}{k+1}_q$. Key step: $(N+1-j)(k+1) = (N-j)(k+1) + (k+1)$, so $q^{(N+1-j)(k+1)} = q^{k+1} \\cdot q^{(N-j)(k+1)}$.",
     "significance": "key",
-    "relatedConcepts": ["hockey stick identity", "q-binomial convolution", "Finset.sum_congr", "Finset.mul_sum"],
-    "prerequisites": ["qSimplicial_succ_recurrence", "induction on N", "Finset.sum_range_succ", "exponent identity for q-weights"]
+    "relatedConcepts": [
+      "hockey stick identity",
+      "q-binomial convolution",
+      "Finset.sum_congr",
+      "Finset.mul_sum"
+    ],
+    "prerequisites": [
+      "qSimplicial_succ_recurrence",
+      "induction on N",
+      "Finset.sum_range_succ",
+      "exponent identity for q-weights"
+    ]
   }
 ]

--- a/src/data/proofs/arithmetic-series-oq-02/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-02/annotations.json
@@ -9,7 +9,7 @@
     "type": "context",
     "title": "Module Header, Imports, and Setup",
     "content": "The file imports four Mathlib modules: `Data.Nat.Choose.Basic` (binomial coefficients `Nat.choose` and identities like `Nat.choose_self`, `Nat.choose_succ_succ`, `Nat.choose_one_right`), `Data.Nat.Choose.Sum` (sums involving choose), `Algebra.BigOperators.Intervals` (`Finset.sum_range_succ` for peeling off the last term), and `Tactic` (`linarith`, `nlinarith`, `ring`, `simp`, `native_decide`). The module header documents the open question, its answer via the Hockey Stick Identity, and lists all 8 key theorems. The namespace `ArithmeticSeriesOQ02` and `open Finset BigOperators` set up the notation.",
-    "mathContext": "The key Mathlib theorem is `Nat.choose_succ_succ (n k : ℕ) : Nat.choose (n+1) (k+1) = Nat.choose n k + Nat.choose n (k+1)` — Pascal's identity. This single lemma drives both the recurrence and the hockey stick inductive step.",
+    "mathContext": "The key Mathlib theorem is `Nat.choose_succ_succ (n k : \u2115) : Nat.choose (n+1) (k+1) = Nat.choose n k + Nat.choose n (k+1)` \u2014 Pascal's identity. This single lemma drives both the recurrence and the hockey stick inductive step.",
     "significance": "supporting",
     "relatedConcepts": [
       "binomial coefficients",
@@ -49,12 +49,12 @@
     "id": "ann-basic-props",
     "proofId": "arithmetic-series-oq-02",
     "range": {
-      "startLine": 55,
+      "startLine": 54,
       "endLine": 70
     },
     "type": "technique",
     "title": "Basic Properties: One-Line Simp Proofs",
-    "content": "The three basic properties — `simplicial_zero`, `simplicial_start`, `simplicial_one` — are each one-line `simp` proofs using Mathlib's choose lemmas. `simplicial_zero n : S_0(n) = 1` uses `choose_zero_right`. `simplicial_start k : S_k(0) = 1` uses `choose_self`. `simplicial_one n : S_1(n) = n+1` uses `choose_one_right`.",
+    "content": "The three basic properties \u2014 `simplicial_zero`, `simplicial_start`, `simplicial_one` \u2014 are each one-line `simp` proofs using Mathlib's choose lemmas. `simplicial_zero n : S_0(n) = 1` uses `choose_zero_right`. `simplicial_start k : S_k(0) = 1` uses `choose_self`. `simplicial_one n : S_1(n) = n+1` uses `choose_one_right`.",
     "mathContext": "These three base cases correspond to: (1) the 0-simplex is always 1 point; (2) any simplex has 1 vertex at n=0; (3) the 1-simplex sequence counts points on a line segment from 1 to n+1.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -99,7 +99,7 @@
     },
     "type": "insight",
     "title": "The Hockey Stick Identity: Inductive Proof",
-    "content": "The main theorem: ∑_{i=0}^n S_k(i) = S_{k+1}(n), proved by induction on n. Base case (n=0): ∑_{i=0}^0 S_k(i) = S_k(0) = 1 = C(k+1,k+1) = S_{k+1}(0), using `choose_self`. Inductive step: ∑_{i=0}^{n+1} S_k(i) = (∑_{i=0}^n S_k(i)) + S_k(n+1) = S_{k+1}(n) + S_k(n+1) = S_{k+1}(n+1) by the recurrence. The proof is exactly 2 lines of Lean after unfolding.",
+    "content": "The main theorem: \u2211_{i=0}^n S_k(i) = S_{k+1}(n), proved by induction on n. Base case (n=0): \u2211_{i=0}^0 S_k(i) = S_k(0) = 1 = C(k+1,k+1) = S_{k+1}(0), using `choose_self`. Inductive step: \u2211_{i=0}^{n+1} S_k(i) = (\u2211_{i=0}^n S_k(i)) + S_k(n+1) = S_{k+1}(n) + S_k(n+1) = S_{k+1}(n+1) by the recurrence. The proof is exactly 2 lines of Lean after unfolding.",
     "mathContext": "The Hockey Stick Identity $\\sum_{i=0}^{n} \\binom{i+k}{k} = \\binom{n+k+1}{k+1}$ is named after the shape it traces in Pascal's triangle: starting from C(k,k)=1 and summing diagonally, the result jumps to the next diagonal. It has a bijective proof: count (n+1)-element multisets from [k+1] by fixing the largest element.",
     "significance": "key",
     "relatedConcepts": [
@@ -123,7 +123,7 @@
     },
     "type": "concept",
     "title": "Connecting to Gauss's Formula",
-    "content": "`arithmetic_to_triangular` proves ∑_{i=0}^n (i+1) = S_2(n) by a calc proof with two steps: (1) rewrite (i+1) as simplicial 1 i using `Finset.sum_congr rfl` + `simplicial_one`; (2) apply `hockey_stick_sum 1 n`. The `sum_congr` approach is used instead of `simp_rw` to avoid accidentally rewriting `n+1` in `range (n+1)` to `simplicial 1 n`. `triangular_to_tetrahedral` is immediate from `hockey_stick_sum 2 n`.",
+    "content": "`arithmetic_to_triangular` proves \u2211_{i=0}^n (i+1) = S_2(n) by a calc proof with two steps: (1) rewrite (i+1) as simplicial 1 i using `Finset.sum_congr rfl` + `simplicial_one`; (2) apply `hockey_stick_sum 1 n`. The `sum_congr` approach is used instead of `simp_rw` to avoid accidentally rewriting `n+1` in `range (n+1)` to `simplicial 1 n`. `triangular_to_tetrahedral` is immediate from `hockey_stick_sum 2 n`.",
     "mathContext": "Gauss's formula $1 + 2 + \\cdots + (n+1) = (n+1)(n+2)/2$ is the k=1 hockey stick: $\\sum_{i=0}^{n} (i+1) = \\sum_{i=0}^{n} S_1(i) = S_2(n) = \\binom{n+2}{2} = (n+1)(n+2)/2$. The tetrahedral sum $\\sum T_i = T_n^{(3)}$ is the k=2 instance.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -171,7 +171,7 @@
     },
     "type": "context",
     "title": "Concrete Values, Summary, and Verification",
-    "content": "Concrete computations verified by `native_decide`: the 10th triangular number is 55 (S_2(9) = C(11,2) = 55), the 10th tetrahedral number is 220 (S_3(9) = C(12,3) = 220), and the sum of the first 10 triangular numbers equals 220 (confirming hockey_stick_sum at k=2, n=9). The `native_decide` tactic evaluates the Lean expression directly, serving as a computational cross-check.\n\nThe summary section documents the complete answer to OQ-02: arithmetic series is one instance of the dimension-raising principle ∑ S_k(i) = S_{k+1}(n), where each level of summation moves up one dimension in Pascal's triangle. The `#check` commands verify the types of the five main theorems.",
+    "content": "Concrete computations verified by `native_decide`: the 10th triangular number is 55 (S_2(9) = C(11,2) = 55), the 10th tetrahedral number is 220 (S_3(9) = C(12,3) = 220), and the sum of the first 10 triangular numbers equals 220 (confirming hockey_stick_sum at k=2, n=9). The `native_decide` tactic evaluates the Lean expression directly, serving as a computational cross-check.\n\nThe summary section documents the complete answer to OQ-02: arithmetic series is one instance of the dimension-raising principle \u2211 S_k(i) = S_{k+1}(n), where each level of summation moves up one dimension in Pascal's triangle. The `#check` commands verify the types of the five main theorems.",
     "mathContext": "Verification: $S_2(9) = \\binom{11}{2} = 55$, $S_3(9) = \\binom{12}{3} = 220$, $\\sum_{i=0}^{9} S_2(i) = 220 = S_3(9)$.",
     "significance": "supporting",
     "relatedConcepts": [


### PR DESCRIPTION
Fix annotation schema violations in 12 proof entries.

## Changes (arithmetic-series batch + previous)

### amgm-inequality-oq-04
- `ann-agm-value`: 248→254

### algebraic-numbers-countable-oq-02 + oq-02-oq-02

### angle-trisection (3 fixes), angle-trisection-cos-20-gal-oq-01, angle-trisection-cos-20-gal-oq-03, angle-trisection-oq-01, angle-trisection-oq-02-oq-01 (5 fixes), angle-trisection-oq-02-oq-01-oq-02

### area-of-circle

### arithmetic-series-oq-00: `ann-nicomachus-induction` 49→51

### arithmetic-series-oq-02: `ann-basic-props` 55→54

### arithmetic-series-oq-02-oq-01 (3 fixes)
- @[simp] attribute lines → theorem declarations: 37→38, 60→61, 76→77

### arithmetic-series-oq-02-oq-01-oq-01 (3 fixes)
- `ann-qvand-nat-subtraction`: 42→46
- `ann-qvand-parta-lemma`: 63→68
- `ann-qvand-pascal-split`: 111→116

All annotations now validate cleanly.