### PR TITLE
Enrich 3 proofs: cantor-oq-04, area-of-circle-oq-02-oq-04, derangements-oq-03-oq-01

### DIFF
--- a/src/data/proofs/derangements-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/derangements-oq-03-oq-01/annotations.json
@@ -1,114 +1,86 @@
 [
   {
+    "id": "ann-derangements-oq03-oq01-header",
+    "proofId": "derangements-oq-03-oq-01",
+    "range": { "startLine": 1, "endLine": 47 },
+    "type": "context",
+    "title": "Header: Two-Term Asymptotic for the Derangement Ratio",
+    "content": "The module header establishes the precise theorem being proved: D(n)/n! = 1/e + (-1)^n/(n+1)! + O(1/(n+2)!), or equivalently, the residual after removing the two leading terms satisfies |D(n)/n! - 1/e - (-1)^n/(n+1)!| ≤ 1/(n+2)!. This is a refinement of the first-order rate from DerangementsOQ03.\n\nThe 5 imports supply: `Derangements.Finite` (numDerangements counting, the core combinatorial object), `Derangements.Basic` (derangement counting formula D(n) = n! · ∑ (-1)^k/k!), `SpecificLimits.Normed` (summable_pow_div_factorial, ensuring the factorial series converges), `ExpDeriv` (exp(-1) = 1/e), and `InfiniteSum.Basic` (tsum, HasSum for manipulating infinite series tails).\n\nThe key design choice is `namespace DerangementsOQ03`: this file reopens the parent namespace rather than creating a new one. This means all definitions and lemmas from DerangementsOQ03 (including `altFactTerm`, `alternating_tail_bound`, and the first-order rate) are available without qualification. The second-order proof is a direct extension — peel off one more alternating term, then apply the existing machinery to the shifted residual.",
+    "mathContext": "The Taylor series for e^{-1} = ∑_{k=0}^∞ (-1)^k/k! is an alternating decreasing series. The Leibniz alternating series theorem says the error after n+1 terms is bounded by the (n+2)-th term: |∑_{k=0}^n (-1)^k/k! - e^{-1}| ≤ 1/(n+1)!. Since D(n)/n! = ∑_{k=0}^n (-1)^k/k!, this gives the first-order rate. The second-order rate peels off one more term from the remainder: the remainder ∑_{k=n+1}^∞ (-1)^k/k! has leading term (-1)^{n+1}/(n+1)! = -(-1)^n/(n+1)!, so D(n)/n! - e^{-1} = -(-1)^n/(n+1)! + (residual), i.e., D(n)/n! - e^{-1} - (-1)^n/(n+1)! = residual with |residual| ≤ 1/(n+2)!.",
+    "significance": "supporting",
+    "relatedConcepts": ["derangement ratio", "alternating series", "Leibniz estimation theorem", "Taylor remainder", "namespace reuse"],
+    "prerequisites": ["DerangementsOQ03 (first-order rate)", "altFactTerm definition", "alternating_tail_bound lemma"]
+  },
+  {
     "id": "ann-tail-split",
     "proofId": "derangements-oq-03-oq-01",
-    "range": {
-      "startLine": 48,
-      "endLine": 76
-    },
+    "range": { "startLine": 48, "endLine": 76 },
     "type": "technique",
     "title": "Tail Splitting Lemma",
     "content": "The tail of the alternating factorial series $\\sum_{k=0}^\\infty a_{m+k}$ equals its first term $a_m$ plus the shifted tail $\\sum_{k=0}^\\infty a_{m+1+k}$. This is the key decomposition enabling the second-order bound: by splitting off one more term from the tail, we reduce the residual estimate to a smaller alternating tail.",
     "mathContext": "$\\sum_{k=0}^{\\infty} a_{m+k} = a_m + \\sum_{k=0}^{\\infty} a_{m+1+k}$",
     "significance": "key",
-    "relatedConcepts": [
-      "tsum",
-      "summable series",
-      "tail of series"
-    ],
-    "prerequisites": [
-      "summability",
-      "infinite series"
-    ]
+    "relatedConcepts": ["tsum", "summable series", "tail of series"],
+    "prerequisites": ["summability", "infinite series"]
   },
   {
     "id": "ann-second-order-rate",
     "proofId": "derangements-oq-03-oq-01",
-    "range": {
-      "startLine": 90,
-      "endLine": 121
-    },
+    "range": { "startLine": 90, "endLine": 121 },
     "type": "theorem",
     "title": "Second-Order Convergence Rate",
     "content": "The main result: $D(n)/n!$ approximates $1/e$ with correction term $(-1)^n/(n+1)!$ and residual at most $1/(n+2)!$. The proof splits the tail series at one additional term beyond the first-order bound, then applies the existing alternating series estimation to the shifted residual.",
     "mathContext": "$\\left|\\frac{D_n}{n!} - e^{-1} - \\frac{(-1)^n}{(n+1)!}\\right| \\le \\frac{1}{(n+2)!}$",
     "significance": "key",
-    "relatedConcepts": [
-      "alternating series",
-      "asymptotic expansion",
-      "derangement ratio",
-      "Taylor remainder"
-    ],
-    "prerequisites": [
-      "first-order convergence rate",
-      "tail splitting",
-      "alternating tail bound"
-    ]
+    "relatedConcepts": ["alternating series", "asymptotic expansion", "derangement ratio", "Taylor remainder"],
+    "prerequisites": ["first-order convergence rate", "tail splitting", "alternating tail bound"]
   },
   {
     "id": "ann-lower-bound",
     "proofId": "derangements-oq-03-oq-01",
-    "range": {
-      "startLine": 130,
-      "endLine": 158
-    },
+    "range": { "startLine": 130, "endLine": 158 },
     "type": "theorem",
     "title": "Tightness Lower Bound",
     "content": "Shows the first-order error bound is essentially tight: $|D(n)/n! - 1/e| \\ge 1/(n+1)! - 1/(n+2)!$. Combined with the upper bound $1/(n+1)!$, this pins down the error to within a factor of $1 - 1/(n+2) = (n+1)/(n+2)$ of the leading term.",
     "mathContext": "$\\frac{1}{(n+1)!} - \\frac{1}{(n+2)!} \\le \\left|\\frac{D_n}{n!} - e^{-1}\\right|$",
     "significance": "key",
-    "relatedConcepts": [
-      "reverse triangle inequality",
-      "tightness of bounds"
-    ],
-    "prerequisites": [
-      "second-order expansion",
-      "triangle inequality"
-    ]
+    "relatedConcepts": ["reverse triangle inequality", "tightness of bounds"],
+    "prerequisites": ["second-order expansion", "triangle inequality"]
   },
   {
     "id": "ann-error-ratio",
     "proofId": "derangements-oq-03-oq-01",
-    "range": {
-      "startLine": 165,
-      "endLine": 173
-    },
+    "range": { "startLine": 165, "endLine": 173 },
     "type": "concept",
-    "title": "Error Ratio Formula",
-    "content": "Each additional element in the permutation improves the derangement ratio approximation by a factor of $1/(n+2)$. Since $1/(n+2)! = 1/(n+1)! \\cdot 1/(n+2)$, the convergence is super-exponential — much faster than geometric decay.",
-    "mathContext": "$\\frac{1}{(n+2)!} = \\frac{1}{(n+1)!} \\cdot \\frac{1}{n+2}$",
+    "title": "Error Ratio Formula: Super-Exponential Convergence",
+    "content": "The `error_ratio_bound` theorem states 1/(n+2)! = 1/(n+1)! · 1/(n+2), directly from the factorial recurrence (n+2)! = (n+1)! · (n+2). This makes explicit that each additional element in the permutation reduces the approximation error by a factor of 1/(n+2) — super-exponential decay.\n\nThe practical significance: for n=5, the second-order residual is 1/7! = 1/5040, while the first-order error is at most 1/6! = 1/720. Each step improves accuracy by another factor of n+2. Compare with geometric series convergence (constant factor) or polynomial convergence (constant exponent): factorial convergence makes even the first-order approximation D(n)/n! ≈ 1/e highly accurate for moderately large n.\n\nIn Lean, the proof uses `factorial_succ` (which gives (n+2)! = (n+1)! · (n+2)) and `field_simp` to convert between the factorial and the reciprocal product form.",
+    "mathContext": "Factorial growth: $n! = \\Theta(\\sqrt{2\\pi n}(n/e)^n)$ by Stirling's approximation. So $1/n!$ decays super-exponentially — much faster than $e^{-cn}$ for any constant $c$. The error ratio $1/(n+2)$ means the $k$-th order approximation has error $O(1/(n+k+1)!)$, which vanishes faster than any fixed exponential as $k \\to \\infty$.",
     "significance": "supporting",
-    "relatedConcepts": [
-      "factorial decay",
-      "super-exponential convergence"
-    ],
-    "prerequisites": [
-      "factorial recurrence"
-    ]
+    "relatedConcepts": ["factorial decay", "super-exponential convergence", "factorial_succ", "field_simp"],
+    "prerequisites": ["factorial recurrence", "Nat.factorial_succ"]
   },
   {
     "id": "ann-sign-characterization",
     "proofId": "derangements-oq-03-oq-01",
-    "range": {
-      "startLine": 175,
-      "endLine": 243
-    },
+    "range": { "startLine": 175, "endLine": 195 },
     "type": "insight",
-    "title": "Sign Alternation and Concrete Bounds",
-    "content": "The correction term (-1)^n/(n+1)! alternates sign: for even n (n = 2m), (-1)^{2m} = 1 so the term is positive and D(n)/n! > 1/e (overshoot); for odd n (n = 2m+1), (-1)^{2m+1} = -1 so the term is negative and D(n)/n! < 1/e (undershoot). Lean proves this via two theorems: `correction_term_sign_even` ((-1)^{2m}/(2m+1)! ≥ 0) and `correction_term_sign_odd` ((-1)^{2m+1}/(2m+2)! ≤ 0), both using `pow_nonneg` and parity arithmetic. The concrete bounds for n=0,1,2 demonstrate the rapid decay: n=0 → error ≤ 1/2, n=1 → error ≤ 1/6, n=2 → error ≤ 1/24, with each step improving by factor ~1/n.",
-    "mathContext": "Even $n = 2m$: $\\frac{(-1)^{2m}}{(2m+1)!} = \\frac{1}{(2m+1)!} > 0$, so $D(2m)/(2m)! > 1/e$. Odd $n = 2m+1$: $\\frac{(-1)^{2m+1}}{(2m+2)!} = \\frac{-1}{(2m+2)!} < 0$, so $D(2m+1)/(2m+1)! < 1/e$. Concrete: $n=0$ gives error $\\le 1/2! = 1/2$; $n=1$ gives $\\le 1/3! = 1/6$; $n=2$ gives $\\le 1/4! = 1/24$.",
+    "title": "Sign Alternation of the Correction Term",
+    "content": "The correction term (-1)^n/(n+1)! alternates sign: for even n (n = 2m), (-1)^{2m} = 1 so the term is positive and D(n)/n! > 1/e (overshoot); for odd n (n = 2m+1), (-1)^{2m+1} = -1 so the term is negative and D(n)/n! < 1/e (undershoot). Lean proves this via two theorems: `correction_term_sign_even` ((-1)^{2m}/(2m+1)! ≥ 0) and `correction_term_sign_odd` ((-1)^{2m+1}/(2m+2)! ≤ 0), both using `pow_nonneg` and parity arithmetic.",
+    "mathContext": "Even $n = 2m$: $\\frac{(-1)^{2m}}{(2m+1)!} = \\frac{1}{(2m+1)!} > 0$, so $D(2m)/(2m)! > 1/e$. Odd $n = 2m+1$: $\\frac{(-1)^{2m+1}}{(2m+2)!} = \\frac{-1}{(2m+2)!} < 0$, so $D(2m+1)/(2m+1)! < 1/e$. This alternating over/under-shooting is the hallmark of alternating series estimation.",
     "significance": "supporting",
-    "relatedConcepts": [
-      "alternating signs",
-      "parity arithmetic",
-      "pow_nonneg",
-      "overshoot/undershoot pattern",
-      "concrete numerical bounds"
-    ],
-    "prerequisites": [
-      "correction_term formula",
-      "even/odd case split in Lean 4",
-      "norm_num for factorial values"
-    ]
+    "relatedConcepts": ["alternating signs", "parity arithmetic", "pow_nonneg", "overshoot/undershoot pattern"],
+    "prerequisites": ["correction_term formula", "even/odd case split in Lean 4"]
+  },
+  {
+    "id": "ann-concrete-bounds",
+    "proofId": "derangements-oq-03-oq-01",
+    "range": { "startLine": 197, "endLine": 243 },
+    "type": "concept",
+    "title": "Concrete Second-Order Bounds for n = 0, 1, 2",
+    "content": "The final section instantiates the second-order bound at three specific values to give fully explicit numerical guarantees:\n\n- **n=0**: |D(0)/0! - 1/e - 1/1!| ≤ 1/2! = 1/2. (D(0) = 1 since the empty permutation is a derangement; D(0)/0! - 1/e ≈ 1 - 0.368 = 0.632, and the correction 1/1! = 1 reduces it to 0.368 - 0.368 = 0.)\n- **n=1**: |D(1)/1! - 1/e - (-1)/2!| ≤ 1/3! = 1/6. (D(1) = 0; error in first-order: 1/e ≈ 0.368; second-order correction: -1/2 = -0.5; so 0 - 0.368 + 0.5 = 0.132, bounded by 1/6 ≈ 0.167.)\n- **n=2**: |D(2)/2! - 1/e - 1/3!| ≤ 1/4! = 1/24. (D(2) = 1; D(2)/2! = 0.5; 1/e ≈ 0.368; correction 1/6 ≈ 0.167; residual ≈ 0.5 - 0.368 - 0.167 = -0.035, bounded by 1/24 ≈ 0.042.)\n\nEach bound is proved by `norm_num` evaluating the explicit factorial values and combining with the abstract second-order theorem. These serve as a sanity check: the abstract machinery produces numerically correct bounds for the first few cases.",
+    "mathContext": "For the probability interpretation: if a random permutation of n elements is chosen uniformly, P(derangement) = D(n)/n!. The bounds say: for n=2, P(derangement) is within 1/24 of the limiting probability 1/e ≈ 0.368. The true value P = 1/2 = 0.5 > 1/e (since n=2 is even, we overshoot), and |0.5 - 0.368 - 0.167| = 0.035 < 0.042 = 1/24, confirming the bound.",
+    "significance": "supporting",
+    "relatedConcepts": ["norm_num", "numerical bounds", "derangement probability", "factorial evaluation"],
+    "prerequisites": ["second_order_convergence_rate", "norm_num for factorial values"]
   }
 ]


### PR DESCRIPTION
## Summary

Three proof gallery entries enriched with expanded annotation coverage.

### cantor-diagonalization-oq-04 (5 → 9 annotations)
Lawvere Fixed-Point Theorem (Retraction Version):
- Header (lines 1-57): retraction vs surjection, Lawvere 1969 historical context, constructive vs choice-based coding
- Contrapositive + Impossibility (lines 100-167): `no_coding_if_fixpoint_free`; impossibility for ℕ, Bool, Prop via Russell's paradox argument
- Cantor's Theorem (lines 169-203): `cantor_no_surjection` with categorical explanation connecting to |A| < |2^A|
- Categorical Interpretation (lines 250-293): `codes_iff_right_inverse`, CCC prerequisites, split epimorphism

### area-of-circle-oq-02-oq-04 (5 → 9 annotations)
Bishop-Gromov Volume Comparison:
- Header (lines 1-44): 6 main results, 4 references, K=0 Ric≥0 setting
- euclideanModelVolume (lines 83-112): positivity, monotonicity, scaling law V_0^n(λr) = λ^n·V_0^n(r)
- Polynomial growth + halving (lines 170-214): C·r^n bound, cross-product form, volume halving; Gromov polynomial growth connection
- Euclidean tightness + dimension corollaries (lines 232-272): sharpness in ℝⁿ, factors 4/8 for n=2/3, classic π·r² recovery

### derangements-oq-03-oq-01 (5 → 7 annotations)
Second-Order Derangement Convergence Rate:
- Header (lines 1-47): two-term asymptotic structure, namespace reuse rationale, import breakdown, Taylor remainder framing
- Concrete bounds (lines 197-243): separated from sign-characterization; n=0,1,2 numerical verification with probabilistic interpretation
- Error ratio (lines 165-173): enhanced with super-exponential convergence context, Stirling connection, Lean proof mechanics

🤖 Generated with [Claude Code](https://claude.com/claude-code)