### PR TITLE
Audit fix: correct axiomCount (1→2) for e-transcendental-oq-01-oq-01

### DIFF
--- a/src/data/proofs/e-transcendental-oq-01-oq-01/meta.json
+++ b/src/data/proofs/e-transcendental-oq-01-oq-01/meta.json
@@ -19,11 +19,11 @@
     "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-04",
-    "axiomCount": 1,
+    "axiomCount": 2,
     "lineCount": 341,
     "theoremCount": 9,
     "definitionCount": 0,
-    "assumptions": "1 axiom: schanuel_for_e_pi (e and π are algebraically independent, following from Schanuel's Conjecture applied with z₁=1, z₂=iπ).",
+    "assumptions": "2 axioms: (1) nesterenko_algebraic_independence (imported from ETranscendentalOQ01: π, e^π, Γ(1/4) are algebraically independent over ℚ, Nesterenko 1996); (2) schanuel_for_e_pi (e and π are algebraically independent, following from Schanuel's Conjecture applied with z₁=1, z₂=iπ).",
     "originalContributions": [
       "First formal proof that e^π is transcendental in this codebase, derived from Nesterenko's theorem",
       "Formal proof that Γ(1/4) is transcendental from Nesterenko's algebraic independence",
@@ -115,7 +115,7 @@
   "leanFile": {
     "namespace": "Real (open)",
     "lineCount": 341,
-    "axiomCount": 1,
+    "axiomCount": 2,
     "theoremCount": 9,
     "definitionCount": 0,
     "path": "Proofs/ETranscendentalOQ01OQ01.lean",


### PR DESCRIPTION
## Summary

- Corrects `axiomCount` from 1 to 2 in `e-transcendental-oq-01-oq-01/meta.json`
- Updates `assumptions` field to explicitly list both axioms: `nesterenko_algebraic_independence` (imported from parent) and `schanuel_for_e_pi` (declared locally)
- The `conclusion.summary` already correctly said "conditional on 2 axioms" — this aligns the count field with that statement

## Evidence

**meta.json claimed**: `axiomCount: 1`, assumptions listed only `schanuel_for_e_pi`
**Lean source shows**: file imports `ETranscendentalOQ01` (which has `axiom nesterenko_algebraic_independence`) and declares `axiom schanuel_for_e_pi` locally — 2 total axioms
**Inconsistency**: the `conclusion.summary` already said "conditional on 2 axioms (Nesterenko and Schanuel)" but the count field said 1

## Severity: LOW

Status is correctly `axiomatized` with badge `axiom` — no overclaiming. This is a field-level inconsistency within the file itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)