### PR TITLE
Enrich: fix annotation schema violations (arithmetic-series, ballot-problem)

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-01-oq-01/annotations.json
@@ -2,61 +2,125 @@
   {
     "id": "ann-qvand-identity-overview",
     "proofId": "arithmetic-series-oq-02-oq-01-oq-01",
-    "range": { "startLine": 1, "endLine": 38 },
+    "range": {
+      "startLine": 1,
+      "endLine": 38
+    },
     "type": "insight",
     "title": "q-Vandermonde: Quantum Deformation of the Classical Identity",
-    "content": "The q-Vandermonde identity [m+n choose r]_q = ∑_{k=0}^{r} q^{k(m+k-r)} [m choose r-k]_q [n choose k]_q generalizes the classical Vandermonde by replacing binomial coefficients with Gaussian binomial coefficients (q-binomials). At q=1: q^{k(m+k-r)} = 1 and [n choose k]_1 = C(n,k), recovering classical Vandermonde. The combinatorial interpretation over F_q: [n choose k]_q counts k-dimensional subspaces of F_q^n. The q-Vandermonde counts (r-dim subspaces of F_q^{m+n}) by decomposing based on the dimension of their intersection with the first m coordinates. The exponent q^{k(m+k-r)} is the 'crossing number' — the dimension of the intersection minus the expected crossing. This connects to the representation theory of GL(n, F_q) and quantum groups.",
+    "content": "The q-Vandermonde identity [m+n choose r]_q = \u2211_{k=0}^{r} q^{k(m+k-r)} [m choose r-k]_q [n choose k]_q generalizes the classical Vandermonde by replacing binomial coefficients with Gaussian binomial coefficients (q-binomials). At q=1: q^{k(m+k-r)} = 1 and [n choose k]_1 = C(n,k), recovering classical Vandermonde. The combinatorial interpretation over F_q: [n choose k]_q counts k-dimensional subspaces of F_q^n. The q-Vandermonde counts (r-dim subspaces of F_q^{m+n}) by decomposing based on the dimension of their intersection with the first m coordinates. The exponent q^{k(m+k-r)} is the 'crossing number' \u2014 the dimension of the intersection minus the expected crossing. This connects to the representation theory of GL(n, F_q) and quantum groups.",
     "mathContext": "Gaussian binomial: $\\binom{n}{k}_q = \\frac{(1-q^n)(1-q^{n-1})\\cdots(1-q^{n-k+1})}{(1-q)(1-q^2)\\cdots(1-q^k)}$. q-Vandermonde: $\\binom{m+n}{r}_q = \\sum_{k=0}^{r} q^{k(m+k-r)} \\binom{m}{r-k}_q \\binom{n}{k}_q$. At $q \\to 1$: $\\binom{n}{k}_q \\to \\binom{n}{k}$ and the identity becomes $\\binom{m+n}{r} = \\sum_k \\binom{m}{r-k}\\binom{n}{k}$ (Vandermonde).",
     "significance": "key",
-    "relatedConcepts": ["Gaussian binomial coefficients", "Vandermonde convolution", "quantum groups", "F_q vector space counting", "q-hypergeometric series"],
-    "prerequisites": ["qBinom from ArithmeticSeriesOQ02OQ01", "q-Pascal rule", "classical Vandermonde identity"]
+    "relatedConcepts": [
+      "Gaussian binomial coefficients",
+      "Vandermonde convolution",
+      "quantum groups",
+      "F_q vector space counting",
+      "q-hypergeometric series"
+    ],
+    "prerequisites": [
+      "qBinom from ArithmeticSeriesOQ02OQ01",
+      "q-Pascal rule",
+      "classical Vandermonde identity"
+    ]
   },
   {
     "id": "ann-qvand-nat-subtraction",
     "proofId": "arithmetic-series-oq-02-oq-01-oq-01",
-    "range": { "startLine": 42, "endLine": 54 },
+    "range": {
+      "startLine": 46,
+      "endLine": 54
+    },
     "type": "technique",
-    "title": "ℕ Saturating Subtraction: zify+ring for Exponent Identity",
-    "content": "The Part A exponent identity k*(m+k-r)+(r+1-k) = (r+1)+k*(m+k-(r+1)) is an integer equality that requires special handling in Lean 4 because ℕ subtraction saturates at 0. The proof (partA_exp) uses `zify [hm, hk, h1]` to convert all terms to ℤ using the hypotheses: hm : r+1 ≤ m+k (ensures m+k-r ≥ 0 in ℤ) and hk : k ≤ r+1 (ensures r+1-k ≥ 0). The side condition h1 is needed for the m+k-(r+1) subtraction. After zify, `ring` closes the goal — the algebraic identity is immediate over ℤ. The saturating subtraction design is intentional: terms where m+k < r have qBinom q m (r-k) = 0 by qBinom_eq_zero_of_lt, so the 'wrong' exponent value in those degenerate cases is harmless — the overall term vanishes. This is a recurring design pattern in q-analog proofs.",
-    "mathContext": "ℕ saturating subtraction: $a - b = 0$ when $b > a$ in $\\mathbb{N}$. Intended: $m+k-r$ should be $\\max(0, m+k-r)$, which matches ℕ. The exponent identity as integers: $k(m+k-r) + (r+1-k) = (r+1) + k(m+k-r-1)$, provable by ring. Side conditions ensure each side $\\geq 0$ in $\\mathbb{N}$.",
+    "title": "\u2115 Saturating Subtraction: zify+ring for Exponent Identity",
+    "content": "The Part A exponent identity k*(m+k-r)+(r+1-k) = (r+1)+k*(m+k-(r+1)) is an integer equality that requires special handling in Lean 4 because \u2115 subtraction saturates at 0. The proof (partA_exp) uses `zify [hm, hk, h1]` to convert all terms to \u2124 using the hypotheses: hm : r+1 \u2264 m+k (ensures m+k-r \u2265 0 in \u2124) and hk : k \u2264 r+1 (ensures r+1-k \u2265 0). The side condition h1 is needed for the m+k-(r+1) subtraction. After zify, `ring` closes the goal \u2014 the algebraic identity is immediate over \u2124. The saturating subtraction design is intentional: terms where m+k < r have qBinom q m (r-k) = 0 by qBinom_eq_zero_of_lt, so the 'wrong' exponent value in those degenerate cases is harmless \u2014 the overall term vanishes. This is a recurring design pattern in q-analog proofs.",
+    "mathContext": "\u2115 saturating subtraction: $a - b = 0$ when $b > a$ in $\\mathbb{N}$. Intended: $m+k-r$ should be $\\max(0, m+k-r)$, which matches \u2115. The exponent identity as integers: $k(m+k-r) + (r+1-k) = (r+1) + k(m+k-r-1)$, provable by ring. Side conditions ensure each side $\\geq 0$ in $\\mathbb{N}$.",
     "significance": "key",
-    "relatedConcepts": ["ℕ saturating subtraction", "zify tactic", "ring over ℤ", "qBinom_eq_zero_of_lt", "degenerate term vanishing"],
-    "prerequisites": ["ℕ vs ℤ subtraction in Lean 4", "zify tactic with hypothesis hints", "qBinom_eq_zero_of_lt for out-of-range terms"]
+    "relatedConcepts": [
+      "\u2115 saturating subtraction",
+      "zify tactic",
+      "ring over \u2124",
+      "qBinom_eq_zero_of_lt",
+      "degenerate term vanishing"
+    ],
+    "prerequisites": [
+      "\u2115 vs \u2124 subtraction in Lean 4",
+      "zify tactic with hypothesis hints",
+      "qBinom_eq_zero_of_lt for out-of-range terms"
+    ]
   },
   {
     "id": "ann-qvand-parta-lemma",
     "proofId": "arithmetic-series-oq-02-oq-01-oq-01",
-    "range": { "startLine": 63, "endLine": 91 },
+    "range": {
+      "startLine": 68,
+      "endLine": 91
+    },
     "type": "technique",
     "title": "Part A Lemma: Extracting the q^(r+1) Factor via Case Split",
-    "content": "The partA_eq lemma proves ∑_k q^{k(m+k-r)+(r+1-k)} [m choose r+1-k]_q [n choose k]_q = q^{r+1} * ∑_k q^{k(m+k-(r+1))} [m choose r+1-k]_q [n choose k]_q. The proof case-splits on r+1 ≤ m+k (normal case) vs m+k < r+1 (degenerate case). Normal case: use partA_exp to rewrite the exponent and factor out q^{r+1}. Degenerate case: both sides vanish — the LHS because qBinom q m (r+1-k) = 0 (need r+1-k > m, handled by qBinom_eq_zero_of_lt), and the RHS similarly. The Finset.sum_congr applies this case analysis pointwise. The modular design (factor out the case split into a separate lemma) keeps the main induction step readable.",
+    "content": "The partA_eq lemma proves \u2211_k q^{k(m+k-r)+(r+1-k)} [m choose r+1-k]_q [n choose k]_q = q^{r+1} * \u2211_k q^{k(m+k-(r+1))} [m choose r+1-k]_q [n choose k]_q. The proof case-splits on r+1 \u2264 m+k (normal case) vs m+k < r+1 (degenerate case). Normal case: use partA_exp to rewrite the exponent and factor out q^{r+1}. Degenerate case: both sides vanish \u2014 the LHS because qBinom q m (r+1-k) = 0 (need r+1-k > m, handled by qBinom_eq_zero_of_lt), and the RHS similarly. The Finset.sum_congr applies this case analysis pointwise. The modular design (factor out the case split into a separate lemma) keeps the main induction step readable.",
     "mathContext": "The factor extraction: $q^{k(m+k-r) + (r+1-k)} = q^{r+1} \\cdot q^{k(m+k-(r+1))}$ when $k \\leq r+1 \\leq m+k$. When $m+k < r+1$: $\\binom{m}{r+1-k}_q = 0$ since $r+1-k > m$. Both sides zero in the degenerate case.",
     "significance": "supporting",
-    "relatedConcepts": ["Finset.sum_congr", "case split on natural number comparison", "qBinom_eq_zero_of_lt", "partA_exp", "modular proof structure"],
-    "prerequisites": ["partA_exp lemma", "qBinom_eq_zero_of_lt: qBinom q n k = 0 when k > n", "Finset.sum_congr for pointwise equality"]
+    "relatedConcepts": [
+      "Finset.sum_congr",
+      "case split on natural number comparison",
+      "qBinom_eq_zero_of_lt",
+      "partA_exp",
+      "modular proof structure"
+    ],
+    "prerequisites": [
+      "partA_exp lemma",
+      "qBinom_eq_zero_of_lt: qBinom q n k = 0 when k > n",
+      "Finset.sum_congr for pointwise equality"
+    ]
   },
   {
     "id": "ann-qvand-induction",
     "proofId": "arithmetic-series-oq-02-oq-01-oq-01",
-    "range": { "startLine": 131, "endLine": 190 },
+    "range": {
+      "startLine": 131,
+      "endLine": 190
+    },
     "type": "insight",
     "title": "Induction on m: IH Applied Twice via q-Pascal",
-    "content": "The main theorem qVandermonde is proved by induction on m. Base case m=0: use Finset.sum_eq_single at k=r — all other terms vanish by qBinom_zero_succ (qBinom q 0 (l+1) = 0 for l ≥ 0). Inductive step m→m+1, r→r+1: apply q-Pascal on the LHS [m+n+1 choose r+1]_q = q^{r+1}*[m+n choose r+1]_q + [m+n choose r]_q. Apply IH at (m, r+1) and (m, r) to get two sum expressions. Use simp_rw with the ℕ identity m+1+k-(r+1) = m+k-r (proved by omega) to align exponents. Then a sorry currently handles the final assembly (combining Part A and Part B). The two-IH structure is characteristic of q-analog identities: q-Pascal decomposes the LHS into two sums, both matching the IH at the previous level.",
+    "content": "The main theorem qVandermonde is proved by induction on m. Base case m=0: use Finset.sum_eq_single at k=r \u2014 all other terms vanish by qBinom_zero_succ (qBinom q 0 (l+1) = 0 for l \u2265 0). Inductive step m\u2192m+1, r\u2192r+1: apply q-Pascal on the LHS [m+n+1 choose r+1]_q = q^{r+1}*[m+n choose r+1]_q + [m+n choose r]_q. Apply IH at (m, r+1) and (m, r) to get two sum expressions. Use simp_rw with the \u2115 identity m+1+k-(r+1) = m+k-r (proved by omega) to align exponents. Then a sorry currently handles the final assembly (combining Part A and Part B). The two-IH structure is characteristic of q-analog identities: q-Pascal decomposes the LHS into two sums, both matching the IH at the previous level.",
     "mathContext": "q-Pascal: $\\binom{n+1}{k+1}_q = q^{k+1}\\binom{n}{k+1}_q + \\binom{n}{k}_q$. IH: $\\binom{m+n}{r}_q = S(m,n,r)$ where $S(m,n,r) = \\sum_k q^{k(m+k-r)}\\binom{m}{r-k}_q\\binom{n}{k}_q$. Applied twice: LHS = $q^{r+1} S(m,n,r+1) + S(m,n,r)$; RHS = $S(m+1,n,r+1)$ via Parts A+B.",
     "significance": "key",
-    "relatedConcepts": ["induction on m", "q-Pascal rule", "IH applied twice", "Finset.sum_eq_single for base case", "simp_rw for ℕ identity alignment"],
-    "prerequisites": ["q-Pascal rule from ArithmeticSeriesOQ02OQ01", "qBinom_zero_succ: qBinom q 0 (n+1) = 0", "omega for ℕ arithmetic identities"]
+    "relatedConcepts": [
+      "induction on m",
+      "q-Pascal rule",
+      "IH applied twice",
+      "Finset.sum_eq_single for base case",
+      "simp_rw for \u2115 identity alignment"
+    ],
+    "prerequisites": [
+      "q-Pascal rule from ArithmeticSeriesOQ02OQ01",
+      "qBinom_zero_succ: qBinom q 0 (n+1) = 0",
+      "omega for \u2115 arithmetic identities"
+    ]
   },
   {
     "id": "ann-qvand-pascal-split",
     "proofId": "arithmetic-series-oq-02-oq-01-oq-01",
-    "range": { "startLine": 111, "endLine": 130 },
+    "range": {
+      "startLine": 116,
+      "endLine": 130
+    },
     "type": "technique",
     "title": "Pascal Split of Sum: Decomposing S(m+1,n,r+1)",
     "content": "The sum_split_pascal lemma applies Pascal's rule to qBinom q (m+1) (r+1-k) inside the summation, decomposing S(m+1,n,r+1) into Part A (the q^{r+1-k} terms with qBinom q m (r+1-k)) and Part B (the qBinom q m (r-k) terms). This is the key step connecting the LHS Pascal decomposition to the RHS sum. The proof uses Finset.sum_add_distrib to split the sum after pointwise Pascal expansion, then recognizes Part A and Part B as separate sub-sums that match the induction hypothesis applications.",
     "mathContext": "Pascal split: $S(m+1,n,r+1) = \\text{Part A} + \\text{Part B}$ where Part A $= q^{r+1} S(m,n,r+1)$ and Part B $= S(m,n,r)$. This follows from Pascal: $\\binom{m+1}{r+1-k}_q = q^{r+1-k}\\binom{m}{r+1-k}_q + \\binom{m}{r-k}_q$. Substituting into the sum and regrouping via Finset.sum_add_distrib gives the decomposition.",
     "significance": "supporting",
-    "relatedConcepts": ["Finset.sum_add_distrib", "q-Pascal rule", "sum decomposition", "modular proof structure"],
-    "prerequisites": ["q-Pascal rule for qBinom", "Finset.sum_add_distrib", "partA_eq and partB_eq_ih"]
+    "relatedConcepts": [
+      "Finset.sum_add_distrib",
+      "q-Pascal rule",
+      "sum decomposition",
+      "modular proof structure"
+    ],
+    "prerequisites": [
+      "q-Pascal rule for qBinom",
+      "Finset.sum_add_distrib",
+      "partA_eq and partB_eq_ih"
+    ]
   }
 ]

--- a/src/data/proofs/arithmetic-series-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-01/annotations.json
@@ -2,109 +2,212 @@
   {
     "id": "ann-qbinom-def",
     "proofId": "arithmetic-series-oq-02-oq-01",
-    "range": { "startLine": 26, "endLine": 31 },
+    "range": {
+      "startLine": 26,
+      "endLine": 31
+    },
     "type": "definition",
     "title": "Gaussian Binomial Coefficient via q-Pascal's Rule",
-    "content": "The Gaussian binomial coefficient qBinom q n k is defined recursively using q-Pascal's rule: any element of the top row equals 1, the extra-diagonal elements vanish, and the interior follows [n+1 choose k+1]_q = q^{k+1}·[n choose k+1]_q + [n choose k]_q. The noncomputable tag is needed because Lean cannot decide which branch applies from types alone; the definition works in any commutative ring R, not just in ℕ or ℤ.",
+    "content": "The Gaussian binomial coefficient qBinom q n k is defined recursively using q-Pascal's rule: any element of the top row equals 1, the extra-diagonal elements vanish, and the interior follows [n+1 choose k+1]_q = q^{k+1}\u00b7[n choose k+1]_q + [n choose k]_q. The noncomputable tag is needed because Lean cannot decide which branch applies from types alone; the definition works in any commutative ring R, not just in \u2115 or \u2124.",
     "mathContext": "$\\binom{n}{k}_q$ defined by: $\\binom{n}{0}_q = 1$, $\\binom{0}{k+1}_q = 0$, $\\binom{n+1}{k+1}_q = q^{k+1}\\binom{n}{k+1}_q + \\binom{n}{k}_q$",
     "significance": "key",
-    "relatedConcepts": ["q-Pascal triangle", "Gaussian binomial coefficients", "commutative ring", "q-deformation"],
-    "prerequisites": ["commutative ring theory", "recursive definitions in Lean 4", "natural number induction"]
+    "relatedConcepts": [
+      "q-Pascal triangle",
+      "Gaussian binomial coefficients",
+      "commutative ring",
+      "q-deformation"
+    ],
+    "prerequisites": [
+      "commutative ring theory",
+      "recursive definitions in Lean 4",
+      "natural number induction"
+    ]
   },
   {
     "id": "ann-boundary-cases",
     "proofId": "arithmetic-series-oq-02-oq-01",
-    "range": { "startLine": 37, "endLine": 45 },
+    "range": {
+      "startLine": 38,
+      "endLine": 45
+    },
     "type": "technique",
     "title": "Boundary Conditions: Top Row and Left Column",
     "content": "Two @[simp] lemmas establish the fundamental boundary conditions for the q-Pascal triangle. qBinom_zero_right proves [n choose 0]_q = 1 for all n (the top row is all ones), while qBinom_zero_succ confirms [0 choose k+1]_q = 0 (the left column beyond the diagonal is zero). These are direct from the definition; the `cases n` tactic handles n = 0 vs n+1 separately. Marking as @[simp] lets Lean discharge these goals automatically in later proofs.",
     "mathContext": "$\\binom{n}{0}_q = 1$ for all $n$; $\\binom{0}{k+1}_q = 0$ for all $k$",
     "significance": "supporting",
-    "relatedConcepts": ["base cases", "simp lemmas", "q-Pascal triangle boundary"],
-    "prerequisites": ["Lean 4 simp attribute", "pattern matching on natural numbers"]
+    "relatedConcepts": [
+      "base cases",
+      "simp lemmas",
+      "q-Pascal triangle boundary"
+    ],
+    "prerequisites": [
+      "Lean 4 simp attribute",
+      "pattern matching on natural numbers"
+    ]
   },
   {
     "id": "ann-q-pascal-rule",
     "proofId": "arithmetic-series-oq-02-oq-01",
-    "range": { "startLine": 51, "endLine": 54 },
+    "range": {
+      "startLine": 51,
+      "endLine": 54
+    },
     "type": "concept",
     "title": "q-Pascal's Rule: The Central Recurrence",
     "content": "This theorem makes the defining recurrence explicitly available as a rewrite rule. In ordinary Pascal's triangle, [n+1 choose k+1] = [n choose k+1] + [n choose k]. The q-analog introduces a weight factor q^{k+1} on the 'upper-left' term, encoding the structure of q-counting. When q = 1 all weights collapse to 1 and ordinary Pascal's rule is recovered. Combinatorially, this weights each k-dimensional subspace by the number of inversions in its basis, counted as a power of q.",
     "mathContext": "$\\binom{n+1}{k+1}_q = q^{k+1}\\binom{n}{k+1}_q + \\binom{n}{k}_q$",
     "significance": "key",
-    "relatedConcepts": ["Pascal's rule", "inversion number", "Gaussian q-binomial", "Grassmannian"],
-    "prerequisites": ["ordinary Pascal's rule", "q-analogs", "combinatorics of subspaces over finite fields"]
+    "relatedConcepts": [
+      "Pascal's rule",
+      "inversion number",
+      "Gaussian q-binomial",
+      "Grassmannian"
+    ],
+    "prerequisites": [
+      "ordinary Pascal's rule",
+      "q-analogs",
+      "combinatorics of subspaces over finite fields"
+    ]
   },
   {
     "id": "ann-vanishing",
     "proofId": "arithmetic-series-oq-02-oq-01",
-    "range": { "startLine": 60, "endLine": 70 },
+    "range": {
+      "startLine": 61,
+      "endLine": 70
+    },
     "type": "technique",
     "title": "Vanishing: [n choose k]_q = 0 when k > n",
     "content": "This is the q-analog of the fact that C(n,k) = 0 whenever k > n. The proof is by induction on n, using qBinom_succ_succ to unroll the recurrence and then applying the induction hypothesis twice (for both upper-left and upper terms). The two IH applications require careful omega-arithmetic to derive n < k+1 and n < k from the main hypothesis n+1 < k+1. The @[simp] attribute allows Lean's simplifier to automatically eliminate these zero terms in later proofs.",
     "mathContext": "If $k > n$ then $\\binom{n}{k}_q = 0$",
     "significance": "supporting",
-    "relatedConcepts": ["vanishing conditions", "induction on natural numbers", "Lean omega tactic"],
-    "prerequisites": ["natural number induction", "Lean omega arithmetic solver"]
+    "relatedConcepts": [
+      "vanishing conditions",
+      "induction on natural numbers",
+      "Lean omega tactic"
+    ],
+    "prerequisites": [
+      "natural number induction",
+      "Lean omega arithmetic solver"
+    ]
   },
   {
     "id": "ann-diagonal",
     "proofId": "arithmetic-series-oq-02-oq-01",
-    "range": { "startLine": 76, "endLine": 83 },
+    "range": {
+      "startLine": 77,
+      "endLine": 83
+    },
     "type": "concept",
     "title": "Diagonal Identity: [n choose n]_q = 1",
-    "content": "The diagonal of the q-Pascal triangle is identically 1, just as C(n,n) = 1 in ordinary combinatorics. The proof by induction peels off [n+1 choose n+1]_q = q^{n+1}·[n choose n+1]_q + [n choose n]_q, then uses qBinom_eq_zero_of_lt to kill the first term (since n < n+1), and the IH to simplify [n choose n]_q = 1. Combinatorially, there is exactly one way to choose an n-dimensional subspace of an n-dimensional space over any field.",
+    "content": "The diagonal of the q-Pascal triangle is identically 1, just as C(n,n) = 1 in ordinary combinatorics. The proof by induction peels off [n+1 choose n+1]_q = q^{n+1}\u00b7[n choose n+1]_q + [n choose n]_q, then uses qBinom_eq_zero_of_lt to kill the first term (since n < n+1), and the IH to simplify [n choose n]_q = 1. Combinatorially, there is exactly one way to choose an n-dimensional subspace of an n-dimensional space over any field.",
     "mathContext": "$\\binom{n}{n}_q = 1$ for all $n \\geq 0$",
     "significance": "supporting",
-    "relatedConcepts": ["diagonal of Pascal's triangle", "subspace counting", "Grassmannian Gr(n, F^n)"],
-    "prerequisites": ["qBinom_eq_zero_of_lt", "ordinary diagonal identity C(n,n)=1"]
+    "relatedConcepts": [
+      "diagonal of Pascal's triangle",
+      "subspace counting",
+      "Grassmannian Gr(n, F^n)"
+    ],
+    "prerequisites": [
+      "qBinom_eq_zero_of_lt",
+      "ordinary diagonal identity C(n,n)=1"
+    ]
   },
   {
     "id": "ann-q-one-specialization",
     "proofId": "arithmetic-series-oq-02-oq-01",
-    "range": { "startLine": 89, "endLine": 107 },
+    "range": {
+      "startLine": 89,
+      "endLine": 107
+    },
     "type": "insight",
     "title": "q=1 Specialization Recovers Ordinary Binomial Coefficients",
-    "content": "This theorem confirms that qBinom is a genuine q-deformation: setting q = 1 in ℤ returns exactly Nat.choose n k (when k ≤ n). The proof is an intricate induction requiring case analysis: when k+1 ≤ n both IH instances apply cleanly; when k = n only one term survives via the vanishing lemma. The arithmetic connecting qBinom q (n+1) (k+1) at q=1 to Nat.choose uses `linarith [Nat.choose_succ_succ n k]`, the Lean statement of Pascal's rule for ordinary binomials. The hypothesis k ≤ n is necessary: for k > n, both sides are 0 but the Nat.choose definition diverges from qBinom's for out-of-range inputs.",
+    "content": "This theorem confirms that qBinom is a genuine q-deformation: setting q = 1 in \u2124 returns exactly Nat.choose n k (when k \u2264 n). The proof is an intricate induction requiring case analysis: when k+1 \u2264 n both IH instances apply cleanly; when k = n only one term survives via the vanishing lemma. The arithmetic connecting qBinom q (n+1) (k+1) at q=1 to Nat.choose uses `linarith [Nat.choose_succ_succ n k]`, the Lean statement of Pascal's rule for ordinary binomials. The hypothesis k \u2264 n is necessary: for k > n, both sides are 0 but the Nat.choose definition diverges from qBinom's for out-of-range inputs.",
     "mathContext": "For $k \\leq n$: $\\binom{n}{k}_1 = \\binom{n}{k}$ (ordinary binomial). Uses ordinary Pascal: $\\binom{n+1}{k+1} = \\binom{n}{k+1} + \\binom{n}{k}$.",
     "significance": "key",
-    "relatedConcepts": ["q-deformation", "specialization at q=1", "ordinary binomial coefficients", "Nat.choose"],
-    "prerequisites": ["Nat.choose_succ_succ (Pascal's rule)", "induction on n with k generalizing", "case splitting on k ≤ n vs k = n"]
+    "relatedConcepts": [
+      "q-deformation",
+      "specialization at q=1",
+      "ordinary binomial coefficients",
+      "Nat.choose"
+    ],
+    "prerequisites": [
+      "Nat.choose_succ_succ (Pascal's rule)",
+      "induction on n with k generalizing",
+      "case splitting on k \u2264 n vs k = n"
+    ]
   },
   {
     "id": "ann-qsimplicial-def",
     "proofId": "arithmetic-series-oq-02-oq-01",
-    "range": { "startLine": 113, "endLine": 126 },
+    "range": {
+      "startLine": 113,
+      "endLine": 126
+    },
     "type": "definition",
     "title": "q-Simplicial Numbers: Counting Weighted Lattice Paths",
     "content": "The q-simplicial number qSimplicial q k n = qBinom q (n+k) k is the q-analog of the ordinary simplicial number C(n+k, k), which counts the number of ways to choose a k-element multiset from {1,...,n}. In the q-world, each such selection is weighted by q^{inv}, where inv counts the number of inversions in the corresponding lattice path. The two base cases (k=0 and n=0) both yield 1, reflecting that there is exactly one lattice path in degenerate dimensions, regardless of q.",
     "mathContext": "$\\text{qSimplicial}(q, k, n) = \\binom{n+k}{k}_q$, the $q$-analog of $\\binom{n+k}{k} = \\frac{(n+k)!}{n!k!}$",
     "significance": "supporting",
-    "relatedConcepts": ["simplicial numbers", "lattice paths", "inversion statistics", "q-series"],
-    "prerequisites": ["ordinary simplicial numbers C(n+k,k)", "qBinom definition", "inversion number on lattice paths"]
+    "relatedConcepts": [
+      "simplicial numbers",
+      "lattice paths",
+      "inversion statistics",
+      "q-series"
+    ],
+    "prerequisites": [
+      "ordinary simplicial numbers C(n+k,k)",
+      "qBinom definition",
+      "inversion number on lattice paths"
+    ]
   },
   {
     "id": "ann-qsimplicial-recurrence",
     "proofId": "arithmetic-series-oq-02-oq-01",
-    "range": { "startLine": 132, "endLine": 142 },
+    "range": {
+      "startLine": 132,
+      "endLine": 142
+    },
     "type": "technique",
     "title": "q-Simplicial Recurrence: Bridge to q-Pascal's Rule",
-    "content": "This recurrence qS(k+1, n+1) = q^{k+1}·qS(k+1, n) + qS(k, n+1) is the key lemma used in the inductive step of qHockeyStick. The proof works by translating indices via ring arithmetic: n+1+(k+1) = (n+(k+1))+1 and similar identities allow the goal to be rewritten as qBinom_succ_succ applied at a specific index pair. At q=1 this becomes S(k+1, n+1) = S(k+1, n) + S(k, n+1), which is exactly the simplicial recurrence from ArithmeticSeriesOQ02. The Lean proof is three lines — all work is done by ring normalization plus a single rewrite.",
+    "content": "This recurrence qS(k+1, n+1) = q^{k+1}\u00b7qS(k+1, n) + qS(k, n+1) is the key lemma used in the inductive step of qHockeyStick. The proof works by translating indices via ring arithmetic: n+1+(k+1) = (n+(k+1))+1 and similar identities allow the goal to be rewritten as qBinom_succ_succ applied at a specific index pair. At q=1 this becomes S(k+1, n+1) = S(k+1, n) + S(k, n+1), which is exactly the simplicial recurrence from ArithmeticSeriesOQ02. The Lean proof is three lines \u2014 all work is done by ring normalization plus a single rewrite.",
     "mathContext": "$\\binom{n+1+k+1}{k+1}_q = q^{k+1}\\binom{n+k+1}{k+1}_q + \\binom{n+1+k}{k}_q$",
     "significance": "key",
-    "relatedConcepts": ["simplicial recurrence", "q-Pascal's rule", "index arithmetic", "ring normalization"],
-    "prerequisites": ["qBinom_succ_succ", "ring tactic in Lean 4", "arithmetic identity (n+1+(k+1)) = ((n+(k+1))+1)"]
+    "relatedConcepts": [
+      "simplicial recurrence",
+      "q-Pascal's rule",
+      "index arithmetic",
+      "ring normalization"
+    ],
+    "prerequisites": [
+      "qBinom_succ_succ",
+      "ring tactic in Lean 4",
+      "arithmetic identity (n+1+(k+1)) = ((n+(k+1))+1)"
+    ]
   },
   {
     "id": "ann-hockey-stick-main",
     "proofId": "arithmetic-series-oq-02-oq-01",
-    "range": { "startLine": 148, "endLine": 172 },
+    "range": {
+      "startLine": 148,
+      "endLine": 172
+    },
     "type": "insight",
     "title": "q-Hockey Stick: Induction with Exponent Factorization",
-    "content": "The central theorem. The sum ∑_{j=0}^{N} q^{(N-j)(k+1)} · [j+k choose k]_q telescopes to [N+k+1 choose k+1]_q. The proof is by induction on N. The base case N=0 is trivial (single term, exponent 0). In the inductive step, the sum splits into the last term j=N+1 (which has exponent 0, giving qS(k, N+1)) plus the remaining sum. The key move is the exponent identity (N+1-j)(k+1) = (N-j)(k+1) + (k+1), which allows factoring q^{k+1} out of all N+1 earlier terms via Finset.sum_congr and Finset.mul_sum. The IH then identifies the factored sum as q^{k+1}·qS(k+1, N), and qSimplicial_succ_recurrence combines q^{k+1}·qS(k+1,N) + qS(k, N+1) = qS(k+1, N+1).",
+    "content": "The central theorem. The sum \u2211_{j=0}^{N} q^{(N-j)(k+1)} \u00b7 [j+k choose k]_q telescopes to [N+k+1 choose k+1]_q. The proof is by induction on N. The base case N=0 is trivial (single term, exponent 0). In the inductive step, the sum splits into the last term j=N+1 (which has exponent 0, giving qS(k, N+1)) plus the remaining sum. The key move is the exponent identity (N+1-j)(k+1) = (N-j)(k+1) + (k+1), which allows factoring q^{k+1} out of all N+1 earlier terms via Finset.sum_congr and Finset.mul_sum. The IH then identifies the factored sum as q^{k+1}\u00b7qS(k+1, N), and qSimplicial_succ_recurrence combines q^{k+1}\u00b7qS(k+1,N) + qS(k, N+1) = qS(k+1, N+1).",
     "mathContext": "$\\sum_{j=0}^{N} q^{(N-j)(k+1)} \\binom{j+k}{k}_q = \\binom{N+k+1}{k+1}_q$. Key step: $(N+1-j)(k+1) = (N-j)(k+1) + (k+1)$, so $q^{(N+1-j)(k+1)} = q^{k+1} \\cdot q^{(N-j)(k+1)}$.",
     "significance": "key",
-    "relatedConcepts": ["hockey stick identity", "q-binomial convolution", "Finset.sum_congr", "Finset.mul_sum"],
-    "prerequisites": ["qSimplicial_succ_recurrence", "induction on N", "Finset.sum_range_succ", "exponent identity for q-weights"]
+    "relatedConcepts": [
+      "hockey stick identity",
+      "q-binomial convolution",
+      "Finset.sum_congr",
+      "Finset.mul_sum"
+    ],
+    "prerequisites": [
+      "qSimplicial_succ_recurrence",
+      "induction on N",
+      "Finset.sum_range_succ",
+      "exponent identity for q-weights"
+    ]
   }
 ]

--- a/src/data/proofs/arithmetic-series-oq-02/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-02/annotations.json
@@ -9,7 +9,7 @@
     "type": "context",
     "title": "Module Header, Imports, and Setup",
     "content": "The file imports four Mathlib modules: `Data.Nat.Choose.Basic` (binomial coefficients `Nat.choose` and identities like `Nat.choose_self`, `Nat.choose_succ_succ`, `Nat.choose_one_right`), `Data.Nat.Choose.Sum` (sums involving choose), `Algebra.BigOperators.Intervals` (`Finset.sum_range_succ` for peeling off the last term), and `Tactic` (`linarith`, `nlinarith`, `ring`, `simp`, `native_decide`). The module header documents the open question, its answer via the Hockey Stick Identity, and lists all 8 key theorems. The namespace `ArithmeticSeriesOQ02` and `open Finset BigOperators` set up the notation.",
-    "mathContext": "The key Mathlib theorem is `Nat.choose_succ_succ (n k : ℕ) : Nat.choose (n+1) (k+1) = Nat.choose n k + Nat.choose n (k+1)` — Pascal's identity. This single lemma drives both the recurrence and the hockey stick inductive step.",
+    "mathContext": "The key Mathlib theorem is `Nat.choose_succ_succ (n k : \u2115) : Nat.choose (n+1) (k+1) = Nat.choose n k + Nat.choose n (k+1)` \u2014 Pascal's identity. This single lemma drives both the recurrence and the hockey stick inductive step.",
     "significance": "supporting",
     "relatedConcepts": [
       "binomial coefficients",
@@ -49,12 +49,12 @@
     "id": "ann-basic-props",
     "proofId": "arithmetic-series-oq-02",
     "range": {
-      "startLine": 55,
+      "startLine": 54,
       "endLine": 70
     },
     "type": "technique",
     "title": "Basic Properties: One-Line Simp Proofs",
-    "content": "The three basic properties — `simplicial_zero`, `simplicial_start`, `simplicial_one` — are each one-line `simp` proofs using Mathlib's choose lemmas. `simplicial_zero n : S_0(n) = 1` uses `choose_zero_right`. `simplicial_start k : S_k(0) = 1` uses `choose_self`. `simplicial_one n : S_1(n) = n+1` uses `choose_one_right`.",
+    "content": "The three basic properties \u2014 `simplicial_zero`, `simplicial_start`, `simplicial_one` \u2014 are each one-line `simp` proofs using Mathlib's choose lemmas. `simplicial_zero n : S_0(n) = 1` uses `choose_zero_right`. `simplicial_start k : S_k(0) = 1` uses `choose_self`. `simplicial_one n : S_1(n) = n+1` uses `choose_one_right`.",
     "mathContext": "These three base cases correspond to: (1) the 0-simplex is always 1 point; (2) any simplex has 1 vertex at n=0; (3) the 1-simplex sequence counts points on a line segment from 1 to n+1.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -99,7 +99,7 @@
     },
     "type": "insight",
     "title": "The Hockey Stick Identity: Inductive Proof",
-    "content": "The main theorem: ∑_{i=0}^n S_k(i) = S_{k+1}(n), proved by induction on n. Base case (n=0): ∑_{i=0}^0 S_k(i) = S_k(0) = 1 = C(k+1,k+1) = S_{k+1}(0), using `choose_self`. Inductive step: ∑_{i=0}^{n+1} S_k(i) = (∑_{i=0}^n S_k(i)) + S_k(n+1) = S_{k+1}(n) + S_k(n+1) = S_{k+1}(n+1) by the recurrence. The proof is exactly 2 lines of Lean after unfolding.",
+    "content": "The main theorem: \u2211_{i=0}^n S_k(i) = S_{k+1}(n), proved by induction on n. Base case (n=0): \u2211_{i=0}^0 S_k(i) = S_k(0) = 1 = C(k+1,k+1) = S_{k+1}(0), using `choose_self`. Inductive step: \u2211_{i=0}^{n+1} S_k(i) = (\u2211_{i=0}^n S_k(i)) + S_k(n+1) = S_{k+1}(n) + S_k(n+1) = S_{k+1}(n+1) by the recurrence. The proof is exactly 2 lines of Lean after unfolding.",
     "mathContext": "The Hockey Stick Identity $\\sum_{i=0}^{n} \\binom{i+k}{k} = \\binom{n+k+1}{k+1}$ is named after the shape it traces in Pascal's triangle: starting from C(k,k)=1 and summing diagonally, the result jumps to the next diagonal. It has a bijective proof: count (n+1)-element multisets from [k+1] by fixing the largest element.",
     "significance": "key",
     "relatedConcepts": [
@@ -123,7 +123,7 @@
     },
     "type": "concept",
     "title": "Connecting to Gauss's Formula",
-    "content": "`arithmetic_to_triangular` proves ∑_{i=0}^n (i+1) = S_2(n) by a calc proof with two steps: (1) rewrite (i+1) as simplicial 1 i using `Finset.sum_congr rfl` + `simplicial_one`; (2) apply `hockey_stick_sum 1 n`. The `sum_congr` approach is used instead of `simp_rw` to avoid accidentally rewriting `n+1` in `range (n+1)` to `simplicial 1 n`. `triangular_to_tetrahedral` is immediate from `hockey_stick_sum 2 n`.",
+    "content": "`arithmetic_to_triangular` proves \u2211_{i=0}^n (i+1) = S_2(n) by a calc proof with two steps: (1) rewrite (i+1) as simplicial 1 i using `Finset.sum_congr rfl` + `simplicial_one`; (2) apply `hockey_stick_sum 1 n`. The `sum_congr` approach is used instead of `simp_rw` to avoid accidentally rewriting `n+1` in `range (n+1)` to `simplicial 1 n`. `triangular_to_tetrahedral` is immediate from `hockey_stick_sum 2 n`.",
     "mathContext": "Gauss's formula $1 + 2 + \\cdots + (n+1) = (n+1)(n+2)/2$ is the k=1 hockey stick: $\\sum_{i=0}^{n} (i+1) = \\sum_{i=0}^{n} S_1(i) = S_2(n) = \\binom{n+2}{2} = (n+1)(n+2)/2$. The tetrahedral sum $\\sum T_i = T_n^{(3)}$ is the k=2 instance.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -171,7 +171,7 @@
     },
     "type": "context",
     "title": "Concrete Values, Summary, and Verification",
-    "content": "Concrete computations verified by `native_decide`: the 10th triangular number is 55 (S_2(9) = C(11,2) = 55), the 10th tetrahedral number is 220 (S_3(9) = C(12,3) = 220), and the sum of the first 10 triangular numbers equals 220 (confirming hockey_stick_sum at k=2, n=9). The `native_decide` tactic evaluates the Lean expression directly, serving as a computational cross-check.\n\nThe summary section documents the complete answer to OQ-02: arithmetic series is one instance of the dimension-raising principle ∑ S_k(i) = S_{k+1}(n), where each level of summation moves up one dimension in Pascal's triangle. The `#check` commands verify the types of the five main theorems.",
+    "content": "Concrete computations verified by `native_decide`: the 10th triangular number is 55 (S_2(9) = C(11,2) = 55), the 10th tetrahedral number is 220 (S_3(9) = C(12,3) = 220), and the sum of the first 10 triangular numbers equals 220 (confirming hockey_stick_sum at k=2, n=9). The `native_decide` tactic evaluates the Lean expression directly, serving as a computational cross-check.\n\nThe summary section documents the complete answer to OQ-02: arithmetic series is one instance of the dimension-raising principle \u2211 S_k(i) = S_{k+1}(n), where each level of summation moves up one dimension in Pascal's triangle. The `#check` commands verify the types of the five main theorems.",
     "mathContext": "Verification: $S_2(9) = \\binom{11}{2} = 55$, $S_3(9) = \\binom{12}{3} = 220$, $\\sum_{i=0}^{9} S_2(i) = 220 = S_3(9)$.",
     "significance": "supporting",
     "relatedConcepts": [

--- a/src/data/proofs/ballot-problem-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02/annotations.json
@@ -2,13 +2,13 @@
   {
     "id": "ballot-oq02-overview",
     "range": {
-      "start": 1,
-      "end": 50
+      "startLine": 1,
+      "endLine": 50
     },
     "type": "concept",
     "title": "Multi-Candidate Ballot Problem: The Projection Reduction Strategy",
-    "content": "The classical Bertrand ballot problem (1887, Mathlib Wiedijk #30) asks: if candidate A gets a votes and B gets b votes (a>b), the probability A leads throughout is (a-b)/(a+b). This file extends to m≥2 candidates via a projection argument: map multi-candidate sequences to ±1 sequences. The key insight: 'candidate 0 leads all opponents combined' depends only on the ±1 pattern, not on how opponent votes are distributed among specific candidates. Uniform fibers (equal number of multi-candidate preimages for each ±1 pattern) then preserve conditional probability, reducing to Mathlib's Ballot.ballot_problem.",
-    "mathContext": "Let a be candidate 0's vote count and b = total opponent votes. For any ±1 sequence t with count(+1)=a and count(-1)=b, the set of multi-candidate sequences projecting to t has the same size: b!/(a₁!·...·aₘ₋₁!) (the multinomial coefficient for how opponent votes distribute). Since all fibers have equal size, uniformOn(multiCountedSequence)({stays positive}) = uniformOn(countedSequence a b)(staysPositive) = (a-b)/(a+b) by Ballot.ballot_problem.",
+    "content": "The classical Bertrand ballot problem (1887, Mathlib Wiedijk #30) asks: if candidate A gets a votes and B gets b votes (a>b), the probability A leads throughout is (a-b)/(a+b). This file extends to m\u22652 candidates via a projection argument: map multi-candidate sequences to \u00b11 sequences. The key insight: 'candidate 0 leads all opponents combined' depends only on the \u00b11 pattern, not on how opponent votes are distributed among specific candidates. Uniform fibers (equal number of multi-candidate preimages for each \u00b11 pattern) then preserve conditional probability, reducing to Mathlib's Ballot.ballot_problem.",
+    "mathContext": "Let a be candidate 0's vote count and b = total opponent votes. For any \u00b11 sequence t with count(+1)=a and count(-1)=b, the set of multi-candidate sequences projecting to t has the same size: b!/(a\u2081!\u00b7...\u00b7a\u2098\u208b\u2081!) (the multinomial coefficient for how opponent votes distribute). Since all fibers have equal size, uniformOn(multiCountedSequence)({stays positive}) = uniformOn(countedSequence a b)(staysPositive) = (a-b)/(a+b) by Ballot.ballot_problem.",
     "significance": "supporting",
     "relatedConcepts": [
       "Bertrand ballot problem",
@@ -27,13 +27,13 @@
   {
     "id": "ballot-oq02-projection",
     "range": {
-      "start": 52,
-      "end": 87
+      "startLine": 52,
+      "endLine": 87
     },
     "type": "definition",
-    "title": "project: Projecting Multi-Candidate Sequences to ±1",
-    "content": "The project function maps any list over α to a list of integers: the leader maps to +1, all opponents map to -1. Four basic properties are proved: project_length (length preserved), project_nil (empty list), project_cons (cons computation), project_take (commutes with take). These are fundamental lemmas used throughout the file. The choice of +1/-1 is not accidental: it aligns with Mathlib's Ballot.countedSequence which works with ±1 lists.",
-    "mathContext": "project leader s := s.map (fun v => if v = leader then 1 else -1). project_take: (project leader s).take i = project leader (s.take i) — proved by List.map_take. This is crucial for relating prefix sums of the projection to leader vote counts in prefixes. The type α : Type* [DecidableEq α] allows any discrete type for candidates, with Fin m as the concrete instantiation later.",
+    "title": "project: Projecting Multi-Candidate Sequences to \u00b11",
+    "content": "The project function maps any list over \u03b1 to a list of integers: the leader maps to +1, all opponents map to -1. Four basic properties are proved: project_length (length preserved), project_nil (empty list), project_cons (cons computation), project_take (commutes with take). These are fundamental lemmas used throughout the file. The choice of +1/-1 is not accidental: it aligns with Mathlib's Ballot.countedSequence which works with \u00b11 lists.",
+    "mathContext": "project leader s := s.map (fun v => if v = leader then 1 else -1). project_take: (project leader s).take i = project leader (s.take i) \u2014 proved by List.map_take. This is crucial for relating prefix sums of the projection to leader vote counts in prefixes. The type \u03b1 : Type* [DecidableEq \u03b1] allows any discrete type for candidates, with Fin m as the concrete instantiation later.",
     "significance": "technical",
     "relatedConcepts": [
       "List.map",
@@ -45,20 +45,20 @@
     "prerequisites": [
       "DecidableEq for if-then-else on list elements",
       "List.map_take from Mathlib",
-      "The ±1 convention in Ballot.countedSequence"
+      "The \u00b11 convention in Ballot.countedSequence"
     ],
     "proofId": "ballot-problem-oq-01-oq-02"
   },
   {
     "id": "ballot-oq02-prefix-sums",
     "range": {
-      "start": 89,
-      "end": 141
+      "startLine": 89,
+      "endLine": 141
     },
     "type": "definition",
     "title": "Prefix Sums and the leadsAllThroughout Predicate",
-    "content": "prefixSum leader s i := sum of the first i elements of project leader s. This equals 2·(leader votes in s.take i) - i (proved as prefixSum_eq). leadsAllThroughout leader s asserts all prefix sums are positive: ∀ i > 0, i ≤ s.length → prefixSum leader s i > 0. The equivalent reformulation leadsAllThroughout_iff: 2·count(leader, s.take i) > i, i.e., the leader has strictly more than half the votes at every step.",
-    "mathContext": "prefixSum leader s i := ((project leader s).take i).sum. prefixSum_eq: = 2·↑((s.take i).count leader) - ↑i — proved using project_take and project_sum_eq (which computes the full sum as 2·count(leader,s) - s.length by induction). leadsAllThroughout_iff equivalence: prefixSum > 0 ↔ 2·count > i follows from the linear relation between prefixSum and count by omega.",
+    "content": "prefixSum leader s i := sum of the first i elements of project leader s. This equals 2\u00b7(leader votes in s.take i) - i (proved as prefixSum_eq). leadsAllThroughout leader s asserts all prefix sums are positive: \u2200 i > 0, i \u2264 s.length \u2192 prefixSum leader s i > 0. The equivalent reformulation leadsAllThroughout_iff: 2\u00b7count(leader, s.take i) > i, i.e., the leader has strictly more than half the votes at every step.",
+    "mathContext": "prefixSum leader s i := ((project leader s).take i).sum. prefixSum_eq: = 2\u00b7\u2191((s.take i).count leader) - \u2191i \u2014 proved using project_take and project_sum_eq (which computes the full sum as 2\u00b7count(leader,s) - s.length by induction). leadsAllThroughout_iff equivalence: prefixSum > 0 \u2194 2\u00b7count > i follows from the linear relation between prefixSum and count by omega.",
     "significance": "technical",
     "relatedConcepts": [
       "prefixSum",
@@ -71,20 +71,20 @@
     "prerequisites": [
       "project_take and project_sum_eq",
       "List.length_take_of_le",
-      "push_cast for ℕ → ℤ coercions"
+      "push_cast for \u2115 \u2192 \u2124 coercions"
     ],
     "proofId": "ballot-problem-oq-01-oq-02"
   },
   {
     "id": "ballot-oq02-invariance",
     "range": {
-      "start": 143,
-      "end": 216
+      "startLine": 143,
+      "endLine": 216
     },
     "type": "theorem",
     "title": "Projection Invariance: The Key Structural Theorem",
-    "content": "The core structural result: leadsAllThroughout_of_same_projection states that if two multi-candidate sequences have the same ±1 projection, they have the same 'leads throughout' property. This is the mathematical content of the reduction — the leading condition is entirely determined by the ±1 pattern. leadsAllThroughout_relabel specializes this: permuting opponent labels (via a function f fixing the leader) preserves the leading property. Part IV specializes to Fin m: FinSequence m, leader = 0 : Fin m, leaderVotes, opponentVotes, finLeadsAll.",
-    "mathContext": "leadsAllThroughout_of_same_projection: if project leader_a s = project leader_b t, then s.length = t.length (from project preserving length) and the prefix sums are identical (same projection → same take → same sum). leadsAllThroughout_relabel: project leader (s.map f) = project leader s when f leader = leader and f maps opponents to opponents. Proved via map_map and extensionality: at each position, f(v) ≠ leader iff v ≠ leader.",
+    "content": "The core structural result: leadsAllThroughout_of_same_projection states that if two multi-candidate sequences have the same \u00b11 projection, they have the same 'leads throughout' property. This is the mathematical content of the reduction \u2014 the leading condition is entirely determined by the \u00b11 pattern. leadsAllThroughout_relabel specializes this: permuting opponent labels (via a function f fixing the leader) preserves the leading property. Part IV specializes to Fin m: FinSequence m, leader = 0 : Fin m, leaderVotes, opponentVotes, finLeadsAll.",
+    "mathContext": "leadsAllThroughout_of_same_projection: if project leader_a s = project leader_b t, then s.length = t.length (from project preserving length) and the prefix sums are identical (same projection \u2192 same take \u2192 same sum). leadsAllThroughout_relabel: project leader (s.map f) = project leader s when f leader = leader and f maps opponents to opponents. Proved via map_map and extensionality: at each position, f(v) \u2260 leader iff v \u2260 leader.",
     "significance": "key",
     "relatedConcepts": [
       "leadsAllThroughout_of_same_projection",
@@ -103,13 +103,13 @@
   {
     "id": "ballot-oq02-classical-bridge",
     "range": {
-      "start": 218,
-      "end": 312
+      "startLine": 218,
+      "endLine": 312
     },
     "type": "theorem",
     "title": "Bridge to Mathlib's Classical Ballot Theorem",
-    "content": "Part V connects the multi-candidate projection to Mathlib's Ballot infrastructure: project_count_one proves count(+1, project leader s) = s.count leader; project_count_neg_one proves count(-1, project leader s) = s.length - s.count leader; project_mem_countedSequence proves project leader s ∈ Ballot.countedSequence a b when s has a leader votes and total length a+b. leadsAll_iff_projection_positive shows the leading property ↔ all prefix sums of the projected list are positive — exactly Mathlib's Ballot.staysPositive condition. Part VI proves basic bounds: denominator positivity and 0 ≤ (a-b)/(a+b) ≤ 1.",
-    "mathContext": "Ballot.countedSequence a b := {l : List ℤ | l.count 1 = a ∧ l.count (-1) = b ∧ ∀ x ∈ l, x = 1 ∨ x = -1}. project_mem_countedSequence: uses project_count_one + project_count_neg_one (proved by list induction) + project_mem_values. leadsAll_iff_projection_positive: (leadsAllThroughout leader s ↔ ...) unfolds to Iff.rfl since the definitions are definitionally equal via project_length. multi_candidate_ballot_bounds: 0 ≤ (a-b)/(a+b) ≤ 1 when b < a via div_nonneg and div_le_one.",
+    "content": "Part V connects the multi-candidate projection to Mathlib's Ballot infrastructure: project_count_one proves count(+1, project leader s) = s.count leader; project_count_neg_one proves count(-1, project leader s) = s.length - s.count leader; project_mem_countedSequence proves project leader s \u2208 Ballot.countedSequence a b when s has a leader votes and total length a+b. leadsAll_iff_projection_positive shows the leading property \u2194 all prefix sums of the projected list are positive \u2014 exactly Mathlib's Ballot.staysPositive condition. Part VI proves basic bounds: denominator positivity and 0 \u2264 (a-b)/(a+b) \u2264 1.",
+    "mathContext": "Ballot.countedSequence a b := {l : List \u2124 | l.count 1 = a \u2227 l.count (-1) = b \u2227 \u2200 x \u2208 l, x = 1 \u2228 x = -1}. project_mem_countedSequence: uses project_count_one + project_count_neg_one (proved by list induction) + project_mem_values. leadsAll_iff_projection_positive: (leadsAllThroughout leader s \u2194 ...) unfolds to Iff.rfl since the definitions are definitionally equal via project_length. multi_candidate_ballot_bounds: 0 \u2264 (a-b)/(a+b) \u2264 1 when b < a via div_nonneg and div_le_one.",
     "significance": "key",
     "relatedConcepts": [
       "Ballot.countedSequence",
@@ -121,20 +121,20 @@
     "prerequisites": [
       "Ballot.countedSequence structure in Mathlib",
       "List.count induction proofs",
-      "div_nonneg and div_le_one for ℚ bounds"
+      "div_nonneg and div_le_one for \u211a bounds"
     ],
     "proofId": "ballot-problem-oq-01-oq-02"
   },
   {
     "id": "ballot-oq02-fiber-analysis",
     "range": {
-      "start": 314,
-      "end": 504
+      "startLine": 314,
+      "endLine": 504
     },
     "type": "concept",
     "title": "Fiber Analysis and the Main Theorem",
-    "content": "The projectionFiber of a ±1 target is the set of multi-candidate sequences projecting to it. fiber_same_length and fiber_same_leader_positions: sequences in the same fiber have the same length and agree on which positions have leader votes (proved by extracting from the projection). fiber_stays_iff_target: if s is in the fiber over target, then s ∈ multiStaysPositive ↔ target ∈ Ballot.staysPositive (proved by substituting project leader s = target). positive_fiber_dichotomy: each fiber is entirely inside or entirely outside multiStaysPositive. uniformOn_fiber_transfer (axiom): the uniform measure over multiCountedSequence transfers to countedSequence under projection. multi_candidate_ballot (main theorem): proved by applying the axiom then Ballot.ballot_problem.",
-    "mathContext": "multiCountedSequence m hm a b := {s : FinSequence m | s.count (leader m hm) = a ∧ s.length = a + b}. multiStaysPositive := {s | project leader s ∈ Ballot.staysPositive}. positive_fiber_dichotomy: if target ∈ staysPositive, multiPositiveFiber = multiProjectionFiber; if target ∉ staysPositive, multiPositiveFiber = ∅. multi_candidate_ballot proof: rw [uniformOn_fiber_transfer]; exact Ballot.ballot_problem b a hab — a 2-line proof once the axiom is in place.",
+    "content": "The projectionFiber of a \u00b11 target is the set of multi-candidate sequences projecting to it. fiber_same_length and fiber_same_leader_positions: sequences in the same fiber have the same length and agree on which positions have leader votes (proved by extracting from the projection). fiber_stays_iff_target: if s is in the fiber over target, then s \u2208 multiStaysPositive \u2194 target \u2208 Ballot.staysPositive (proved by substituting project leader s = target). positive_fiber_dichotomy: each fiber is entirely inside or entirely outside multiStaysPositive. uniformOn_fiber_transfer (axiom): the uniform measure over multiCountedSequence transfers to countedSequence under projection. multi_candidate_ballot (main theorem): proved by applying the axiom then Ballot.ballot_problem.",
+    "mathContext": "multiCountedSequence m hm a b := {s : FinSequence m | s.count (leader m hm) = a \u2227 s.length = a + b}. multiStaysPositive := {s | project leader s \u2208 Ballot.staysPositive}. positive_fiber_dichotomy: if target \u2208 staysPositive, multiPositiveFiber = multiProjectionFiber; if target \u2209 staysPositive, multiPositiveFiber = \u2205. multi_candidate_ballot proof: rw [uniformOn_fiber_transfer]; exact Ballot.ballot_problem b a hab \u2014 a 2-line proof once the axiom is in place.",
     "significance": "supporting",
     "relatedConcepts": [
       "projectionFiber",
@@ -154,13 +154,13 @@
   {
     "id": "ballot-oq02-fiber-bijection",
     "range": {
-      "start": 506,
-      "end": 758
+      "startLine": 506,
+      "endLine": 758
     },
     "type": "concept",
     "title": "Fiber Bijection: Eliminating the Fiber Cardinality Axiom",
-    "content": "Part VIII-B constructs an explicit bijection between fibers. extractOpponents s target: extracts non-leader values from s at positions where target = -1. reconstructSeq target ops: rebuilds a sequence using leader at target=1 positions and consuming ops at target=-1 positions. fiberSwap t1 t2 s: extract opponents from s (using t1), then reconstruct using t2 pattern. Cancellation: reconstruct_extract_cancel (reconstruct ∘ extract = id on fibers), extract_reconstruct_cancel (extract ∘ reconstruct = id on opponent lists), fiberSwap_cancel (swap-swap = id when fiber members).",
-    "mathContext": "extractOpponents s target := (s.zip target).filterMap (if ·.2 = -1 then some ·.1 else none). reconstructSeq t ops: case split on t head being 1 (emit leader, recur on ops) or -1 (consume ops head, recur). reconstruct_extract_cancel proved by induction on s, case splitting on x = leader or x ≠ leader, using project_cons to determine the target head. fiberSwap_cancel requires: extractOpponents_nonleader (ops are non-leader), extractOpponents_count (ops length = target.count(-1)), and matching -1 counts between t1 and t2.",
+    "content": "Part VIII-B constructs an explicit bijection between fibers. extractOpponents s target: extracts non-leader values from s at positions where target = -1. reconstructSeq target ops: rebuilds a sequence using leader at target=1 positions and consuming ops at target=-1 positions. fiberSwap t1 t2 s: extract opponents from s (using t1), then reconstruct using t2 pattern. Cancellation: reconstruct_extract_cancel (reconstruct \u2218 extract = id on fibers), extract_reconstruct_cancel (extract \u2218 reconstruct = id on opponent lists), fiberSwap_cancel (swap-swap = id when fiber members).",
+    "mathContext": "extractOpponents s target := (s.zip target).filterMap (if \u00b7.2 = -1 then some \u00b7.1 else none). reconstructSeq t ops: case split on t head being 1 (emit leader, recur on ops) or -1 (consume ops head, recur). reconstruct_extract_cancel proved by induction on s, case splitting on x = leader or x \u2260 leader, using project_cons to determine the target head. fiberSwap_cancel requires: extractOpponents_nonleader (ops are non-leader), extractOpponents_count (ops length = target.count(-1)), and matching -1 counts between t1 and t2.",
     "significance": "supporting",
     "relatedConcepts": [
       "extractOpponents",
@@ -179,13 +179,13 @@
   {
     "id": "ballot-oq02-fiber-cardinality",
     "range": {
-      "start": 760,
-      "end": 877
+      "startLine": 760,
+      "endLine": 877
     },
     "type": "theorem",
     "title": "Fiber Cardinality Theorem: All Fibers Have Equal ncard",
-    "content": "Part VIII-C proves fiber_card_uniform: for any two targets t1, t2 ∈ Ballot.countedSequence a b, the fiber sizes (Set.ncard) are equal. The proof: construct injections in both directions using fiberSwap (t1→t2 and t2→t1), then apply Set.ncard_le_ncard_of_injOn in both directions for equality. multiProjectionFiber_finite proves each fiber is a finite set (subset of fixed-length lists over Fin m, which is bounded by Set.finite_range of List.ofFn). This theorem completely proves the combinatorial content of uniformOn_fiber_transfer.",
-    "mathContext": "fiber_card_uniform: Set.ncard(multiProjectionFiber m hm1 a b t1) = Set.ncard(multiProjectionFiber m hm1 a b t2). Proof: inj12 := fiberSwap t1 t2 is Set.InjOn on fiber(t1) (from fiberSwap_cancel: swap-swap-cancel-from-t1 = id). maps12 := fiberSwap sends fiber(t1) to fiber(t2) (from fiberSwap_mem_multiProjectionFiber). Both directions give ncard ≤ in both ways. multiProjectionFiber_finite: {l : List (Fin m) | l.length = a+b} ⊆ Set.range (List.ofFn) — finite since List.ofFn ranges over finitely many (Fin (a+b) → Fin m) functions.",
+    "content": "Part VIII-C proves fiber_card_uniform: for any two targets t1, t2 \u2208 Ballot.countedSequence a b, the fiber sizes (Set.ncard) are equal. The proof: construct injections in both directions using fiberSwap (t1\u2192t2 and t2\u2192t1), then apply Set.ncard_le_ncard_of_injOn in both directions for equality. multiProjectionFiber_finite proves each fiber is a finite set (subset of fixed-length lists over Fin m, which is bounded by Set.finite_range of List.ofFn). This theorem completely proves the combinatorial content of uniformOn_fiber_transfer.",
+    "mathContext": "fiber_card_uniform: Set.ncard(multiProjectionFiber m hm1 a b t1) = Set.ncard(multiProjectionFiber m hm1 a b t2). Proof: inj12 := fiberSwap t1 t2 is Set.InjOn on fiber(t1) (from fiberSwap_cancel: swap-swap-cancel-from-t1 = id). maps12 := fiberSwap sends fiber(t1) to fiber(t2) (from fiberSwap_mem_multiProjectionFiber). Both directions give ncard \u2264 in both ways. multiProjectionFiber_finite: {l : List (Fin m) | l.length = a+b} \u2286 Set.range (List.ofFn) \u2014 finite since List.ofFn ranges over finitely many (Fin (a+b) \u2192 Fin m) functions.",
     "significance": "key",
     "relatedConcepts": [
       "Set.ncard_le_ncard_of_injOn",
@@ -204,13 +204,13 @@
   {
     "id": "ballot-oq02-concrete-examples",
     "range": {
-      "start": 879,
-      "end": 906
+      "startLine": 884,
+      "endLine": 906
     },
     "type": "concept",
     "title": "Concrete Examples and Reference to Classical Theorem",
     "content": "Four concrete verifications using norm_num: (1) 3 candidates with votes (3,1,1): P = (3-2)/(3+2) = 1/5; (2) 4 candidates with votes (5,2,1,1): P = (5-4)/(5+4) = 1/9; (3) Unanimous (5,0,0): P = 1; (4) Close race (4,3): P = 1/7. A reference to Ballot.ballot_problem (Wiedijk #30) is included via #check. These examples demonstrate the formula's universality: the number of candidates m doesn't affect the answer, only the total votes a and b matter.",
-    "mathContext": "All examples are ℚ arithmetic: (3 - 2 : ℚ)/(3 + 2) = 1/5, etc., proved by norm_num. The reference #check @Ballot.ballot_problem shows the Mathlib type: uniformOn (countedSequence p q) staysPositive = (↑p - ↑q)/(↑p + ↑q). Note: the argument order in Ballot.ballot_problem is (b a hab) where hab : b < a, not (a b), which is why the proof has exact Ballot.ballot_problem b a hab.",
+    "mathContext": "All examples are \u211a arithmetic: (3 - 2 : \u211a)/(3 + 2) = 1/5, etc., proved by norm_num. The reference #check @Ballot.ballot_problem shows the Mathlib type: uniformOn (countedSequence p q) staysPositive = (\u2191p - \u2191q)/(\u2191p + \u2191q). Note: the argument order in Ballot.ballot_problem is (b a hab) where hab : b < a, not (a b), which is why the proof has exact Ballot.ballot_problem b a hab.",
     "significance": "supporting",
     "relatedConcepts": [
       "norm_num",
@@ -219,7 +219,7 @@
       "(a-b)/(a+b) formula"
     ],
     "prerequisites": [
-      "ℚ arithmetic (norm_num)",
+      "\u211a arithmetic (norm_num)",
       "Ballot.ballot_problem argument ordering (b a hab not a b hab)"
     ],
     "proofId": "ballot-problem-oq-01-oq-02"
@@ -227,16 +227,16 @@
   {
     "id": "ballot-oq02-open-problem",
     "range": {
-      "start": 907,
-      "end": 934
+      "startLine": 907,
+      "endLine": 934
     },
     "type": "concept",
-    "title": "Open Challenge: Full Ordering via Lindström-Gessel-Viennot",
-    "content": "The harder multi-candidate question: given m candidates with votes a₁ > a₂ > ... > aₘ, what is the probability that the ordering is maintained at EVERY step? This involves non-intersecting lattice paths and the Lindström-Gessel-Viennot (LGV) lemma. The answer is the determinant of pairwise ballot ratios: det||(aᵢ-aⱼ)/(aᵢ+aⱼ)||. The file defines pairwiseRatio and threeCandidateProduct (for 3 candidates) and verifies threeCandidateProduct 4 2 1 = 1/15 via norm_num.",
-    "mathContext": "For the full ordering problem, the LGV lemma relates the probability of m non-intersecting lattice paths to a determinant of individual path probabilities. In the ballot context: each lattice path from (0,0) to (aᵢ+aⱼ, aᵢ-aⱼ) staying above the x-axis has probability (aᵢ-aⱼ)/(aᵢ+aⱼ). The determinant det||(aᵢ-aⱼ)/(aᵢ+aⱼ)||_{i,j} counts non-intersecting path configurations. threeCandidateProduct 4 2 1 = (2/6)·(1/3)·(3/5) = 1/15.",
+    "title": "Open Challenge: Full Ordering via Lindstr\u00f6m-Gessel-Viennot",
+    "content": "The harder multi-candidate question: given m candidates with votes a\u2081 > a\u2082 > ... > a\u2098, what is the probability that the ordering is maintained at EVERY step? This involves non-intersecting lattice paths and the Lindstr\u00f6m-Gessel-Viennot (LGV) lemma. The answer is the determinant of pairwise ballot ratios: det||(a\u1d62-a\u2c7c)/(a\u1d62+a\u2c7c)||. The file defines pairwiseRatio and threeCandidateProduct (for 3 candidates) and verifies threeCandidateProduct 4 2 1 = 1/15 via norm_num.",
+    "mathContext": "For the full ordering problem, the LGV lemma relates the probability of m non-intersecting lattice paths to a determinant of individual path probabilities. In the ballot context: each lattice path from (0,0) to (a\u1d62+a\u2c7c, a\u1d62-a\u2c7c) staying above the x-axis has probability (a\u1d62-a\u2c7c)/(a\u1d62+a\u2c7c). The determinant det||(a\u1d62-a\u2c7c)/(a\u1d62+a\u2c7c)||_{i,j} counts non-intersecting path configurations. threeCandidateProduct 4 2 1 = (2/6)\u00b7(1/3)\u00b7(3/5) = 1/15.",
     "significance": "supporting",
     "relatedConcepts": [
-      "Lindström-Gessel-Viennot lemma",
+      "Lindstr\u00f6m-Gessel-Viennot lemma",
       "non-intersecting lattice paths",
       "determinant formula",
       "pairwiseRatio",

--- a/src/data/proofs/ballot-problem-oq-01/annotations.json
+++ b/src/data/proofs/ballot-problem-oq-01/annotations.json
@@ -76,7 +76,7 @@
     },
     "type": "concept",
     "title": "Permutation Characterization and Finiteness",
-    "content": "Every element of kCountedSequence is a permutation of the canonical witness `replicate a 1 ++ replicate b (-k)`. This is proved using `List.perm_iff_count` — two lists are permutations iff they have the same count for every element. The proof handles three cases: $x = 1$ (use $h_1$), $x = -k$ (use $h_2$), and $x \\notin \\{1, -k\\}$ (both counts are zero).\n\nThis characterization immediately gives **finiteness**: the set of permutations of a finite list is finite, so `kCountedSequence` inherits `Set.Finite`.",
+    "content": "Every element of kCountedSequence is a permutation of the canonical witness `replicate a 1 ++ replicate b (-k)`. This is proved using `List.perm_iff_count` \u2014 two lists are permutations iff they have the same count for every element. The proof handles three cases: $x = 1$ (use $h_1$), $x = -k$ (use $h_2$), and $x \\notin \\{1, -k\\}$ (both counts are zero).\n\nThis characterization immediately gives **finiteness**: the set of permutations of a finite list is finite, so `kCountedSequence` inherits `Set.Finite`.",
     "mathContext": "$$l \\in \\text{kCountedSequence}(k,a,b) \\iff l \\sim \\underbrace{[1, \\ldots, 1]}_{a} \\mathbin{\\|} \\underbrace{[-k, \\ldots, -k]}_{b}$$",
     "significance": "key",
     "relatedConcepts": [
@@ -143,7 +143,7 @@
       "startLine": 185,
       "endLine": 218
     },
-    "type": "definition",
+    "type": "theorem",
     "title": "Cyclic Rotation and Membership Preservation",
     "content": "Defines cyclic rotation as $\\text{rotate}(l, i) = \\text{drop}\\,i\\,l \\mathbin{\\|}\\, \\text{take}\\,i\\,l$ and proves key invariants: rotation preserves the sum ($\\sum \\text{rotate}(l,i) = \\sum l$), the length, and membership in kCountedSequence. The membership proof uses `List.take_append_drop` to show that counts are additive over the split.\n\nComposition of rotations satisfies $\\text{rotate}(\\text{rotate}(l, i), j) = \\text{rotate}(l, i+j)$ when indices don't exceed the boundary.",
     "mathContext": "$$\\text{rotate}(l, i) = l[i:] \\mathbin{\\|} l[:i], \\qquad \\sum \\text{rotate}(l,i) = \\sum l$$",
@@ -168,7 +168,7 @@
     },
     "type": "concept",
     "title": "Prefix Sum Relation for Rotations",
-    "content": "The key structural lemma for the cycle lemma. For rotation starting at position $i$, the prefix sum at position $j$ decomposes into two cases depending on whether $i + j$ wraps around. The non-wrapping case uses `take_drop_sum`, while the wrapping case involves `List.take_append` and a careful re-indexing via `List.take_take`.\n\nThis lemma is the technical heart of the file — it connects the combinatorial structure of rotations to the analytic property of prefix sums.",
+    "content": "The key structural lemma for the cycle lemma. For rotation starting at position $i$, the prefix sum at position $j$ decomposes into two cases depending on whether $i + j$ wraps around. The non-wrapping case uses `take_drop_sum`, while the wrapping case involves `List.take_append` and a careful re-indexing via `List.take_take`.\n\nThis lemma is the technical heart of the file \u2014 it connects the combinatorial structure of rotations to the analytic property of prefix sums.",
     "mathContext": "$$\\sigma_{\\text{rot}(i)}(j) = \\begin{cases} \\sigma(i+j) - \\sigma(i) & i+j \\leq n \\\\ \\sigma(i+j-n) + S - \\sigma(i) & i+j > n \\end{cases}$$",
     "significance": "key",
     "relatedConcepts": [
@@ -190,9 +190,9 @@
       "startLine": 289,
       "endLine": 304
     },
-    "type": "definition",
+    "type": "theorem",
     "title": "Good Rotations and Decidability",
-    "content": "A rotation is **good** if all prefix sums of the rotated sequence are strictly positive — equivalently, if the corresponding vote counting always has A leading with more than $k$ times B's votes. The `isGoodRotation` predicate is made `Decidable` by reducing to a finite conjunction over $j \\in [1, n]$, enabling `native_decide` verification of concrete examples.\n\n`goodRotations l` collects all good starting positions as a `Finset ℕ`.",
+    "content": "A rotation is **good** if all prefix sums of the rotated sequence are strictly positive \u2014 equivalently, if the corresponding vote counting always has A leading with more than $k$ times B's votes. The `isGoodRotation` predicate is made `Decidable` by reducing to a finite conjunction over $j \\in [1, n]$, enabling `native_decide` verification of concrete examples.\n\n`goodRotations l` collects all good starting positions as a `Finset \u2115`.",
     "mathContext": "$$\\text{goodRotations}(l) = \\{i < |l| \\mid \\forall\\, 0 < j \\leq |l|,\\; \\sigma_{\\text{rot}(i)}(j) > 0\\}$$",
     "significance": "key",
     "relatedConcepts": [
@@ -213,7 +213,7 @@
       "startLine": 337,
       "endLine": 413
     },
-    "type": "definition",
+    "type": "theorem",
     "title": "Rightmost Minimum Infrastructure",
     "content": "Defines `rightmostMinPos l` as the **rightmost** position where the prefix sum achieves its global minimum, and proves it is a good rotation when $S > 0$. The key insight: after the rightmost minimum, all prefix sums are strictly above the minimum (by maximality), so the non-wrapping part of the rotated prefix sums is positive. The wrapping part uses $\\sigma(j) \\geq \\min + 0$ and the positive sum $S > 0$ to stay positive.\n\nThis gives the existence of at least one good rotation, which is needed to start the counting argument.",
     "mathContext": "$$m = \\max\\{i \\leq n : \\sigma(i) = \\min_{0 \\leq j \\leq n} \\sigma(j)\\}, \\qquad \\text{rotation } m \\text{ is good}$$",


### PR DESCRIPTION
Fix annotation schema violations in 6 proof entries.

## Changes

### arithmetic-series-oq-02
- `ann-basic-props`: 55→54 (blank → /-! section doc comment)

### arithmetic-series-oq-02-oq-01 (3 fixes)
- @[simp] attribute lines → theorem declarations: 37→38, 60→61, 76→77

### arithmetic-series-oq-02-oq-01-oq-01 (3 fixes)
- `ann-qvand-nat-subtraction`: 42→46, `ann-qvand-parta-lemma`: 63→68, `ann-qvand-pascal-split`: 111→116

### ballot-problem-oq-01 (3 type fixes)
- `ann-rotation-def`, `ann-good-rotations`, `ann-rightmost-min`: type 'definition'→'theorem'

### ballot-problem-oq-01-oq-02 (structural fix + 1 line fix)
- Rename `start`/`end` keys → `startLine`/`endLine` (10 annotations)
- `ballot-oq02-concrete-examples`: 879→884 (blank → docstring)

All annotations now validate cleanly.