### PR TITLE
Audit fix: correct badge from original to mathlib in sylow-theorem

### DIFF
--- a/src/data/proofs/sylow-theorem/meta.json
+++ b/src/data/proofs/sylow-theorem/meta.json
@@ -15,11 +15,11 @@
       "finite-groups",
       "p-groups"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified.",
+    "assumptions": "None. Fully machine-verified. Core Sylow theorems derived from Mathlib.GroupTheory.Sylow.",
     "lineCount": 246,
     "theoremCount": 10,
     "definitionCount": 1,


### PR DESCRIPTION
## Integrity Issue

**Proof**: sylow-theorem
**Problem**: Badge incorrectly set to `original` when core Sylow theorems are direct 1-line wrappers around `Mathlib.GroupTheory.Sylow`.

## Evidence

**meta.json claims**: `"badge": "original"`

**Lean file shows**:
- `sylow_existence` = `Sylow.nonempty` (Mathlib, 1 line)
- `sylow_conjugacy` = `MulAction.exists_smul_eq G P Q` (Mathlib, 1 line)
- `sylow_count_mod_p` = `card_sylow_modEq_one p G` (Mathlib, 1 line)
- `cauchy_from_sylow` = `exists_prime_orderOf_dvd_card p hdvd` (Mathlib, 1 line)

Only `sylow_normal_of_eq` (~8 lines) and `group_of_prime_order_cyclic` (2 lines) have non-trivial proofs, but these still rely heavily on Mathlib lemmas.

The `proofStrategy` in meta.json even states: "The formalization leverages Mathlib's `Mathlib.GroupTheory.Sylow`".

## Recommended Fix

Change badge from `"original"` to `"mathlib"` (Tier B: formalized using Mathlib theorem). Status `"verified"` remains correct (0 sorries, 0 axioms). Update assumptions field to note the Mathlib dependency.

---
Discovered during gallery integrity audit.