### PR TITLE
Enrich arithmetic-series-oq-02-oq-02-oq-01: fix schema + expand 5→9 annotations

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-01/annotations.json
@@ -1,136 +1,110 @@
 [
   {
-    "id": "multi-hockey-sum-def",
-    "line": 44,
-    "endLine": 49,
+    "id": "ann-as-oq02-oq01-header",
+    "proofId": "arithmetic-series-oq-02-oq-02-oq-01",
+    "range": { "startLine": 1, "endLine": 33 },
+    "type": "context",
+    "title": "Header: k-Dimensional Hockey Stick by List Induction",
+    "content": "The module header frames this as the dimensional generalization of the 2D hockey stick (parent file: ArithmeticSeriesOQ02OQ02). The key architectural decision is to encode the k-dimensional sum as a list recursion: `multiHockeySum : List ℕ → ℕ → ℕ`. The list length is the dimension k, its sum is the weight offset Σaⱼ. This encoding turns k-dimensional induction into standard list induction — no multi-index bookkeeping required.\n\nThe single `import Proofs.ArithmeticSeriesOQ02OQ02` brings in `parallel_vandermonde` and `simplicial` from the parent file. `open ArithmeticSeriesOQ02OQ02` exposes these without qualification. The status note (0 axioms, 0 sorries) confirms the file is fully machine-verified.\n\nThe four sections: (I) recursive multiHockeySum definition, (II) main k-dimensional identity, (III) dimension-specific instances (1D/2D/3D) and concrete checks via `native_decide`, (IV) monotonicity and positivity each derived in one line from the main theorem.",
+    "mathContext": "The k-dimensional hockey stick: $\\sum_{i_1+\\cdots+i_k \\leq n} \\prod_{j=1}^k \\binom{i_j+a_j}{a_j} = \\binom{n + \\sum a_j + k}{\\sum a_j + k}$. With all $a_j=0$: the number of integer points in the simplex $\\{\\mathbf{i}: i_j \\geq 0, \\sum i_j \\leq n\\}$ equals $\\binom{n+k}{k}$ (stars-and-bars: $n$ identical balls into $k+1$ bins). The generating function proof: $\\prod_{j=1}^k (1/(1-z))^{a_j+1} = (1/(1-z))^{\\sum a_j+k}$, so the coefficient of $z^n$ is $\\binom{n+\\sum a_j+k}{\\sum a_j+k}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["k-simplex", "parallel_vandermonde", "simplicial numbers", "list induction", "stars-and-bars"],
+    "prerequisites": ["ArithmeticSeriesOQ02OQ02 parent file", "Lean 4 list induction", "Finset.sum and BigOperators"]
+  },
+  {
+    "id": "ann-as-multihockey-def",
+    "proofId": "arithmetic-series-oq-02-oq-02-oq-01",
+    "range": { "startLine": 38, "endLine": 47 },
     "type": "definition",
-    "label": "multiHockeySum (recursive definition over k-simplex)",
+    "title": "multiHockeySum: Recursive Definition by Simplex Slicing",
+    "content": "By encoding the k-dimensional sum as a list recursion (peeling off one variable at a time), the proof of `multi_hockey_stick` becomes a standard list induction. No special handling of multi-index sets is needed. Each recursive call reduces the dimension by 1 and the bound by j, matching the simplex slicing exactly.\n\nThe base case `multiHockeySum [] _ = 1` reflects the empty product: when k=0, the simplex {empty sum ≤ n} = {∅} has one point, and the empty product weight is 1. The inductive case uses `range (n+1)` to sum j ∈ {0,...,n}: the first coordinate equals j, contributing `simplicial a j = C(j+a, a)`, and the remaining k-1 coordinates sum to ≤ n-j.",
     "mathContext": "$$\\text{multiHockeySum}([], n) = 1$$\n$$\\text{multiHockeySum}(a :: as, n) = \\sum_{j=0}^{n} \\binom{j+a}{a} \\cdot \\text{multiHockeySum}(as, n-j)$$\nThis slices the $k$-simplex $\\{\\mathbf{i} : \\sum i_j \\leq n\\}$ along the first coordinate: the slice at $i_1 = j$ is the $(k-1)$-simplex $\\{\\mathbf{i}' : \\sum i'_j \\leq n-j\\}$, weighted by $\\binom{j+a_1}{a_1}$. The `range (n+1)` gives $j \\in \\{0,1,\\ldots,n\\}$.",
-    "significance": "technical",
-    "relatedConcepts": [
-      "k-simplex",
-      "simplicial numbers",
-      "stars-and-bars",
-      "recursive definition"
-    ],
-    "prerequisites": [
-      "simplicial (from ArithmeticSeriesOQ02OQ02)",
-      "Finset.range",
-      "Finset.sum"
-    ],
-    "content": "By encoding the $k$-dimensional sum as a list recursion (peeling off one variable at a time), the proof of `multi_hockey_stick` becomes a standard list induction. No special handling of multi-index sets is needed. Each recursive call reduces the dimension by 1 and the bound by $j$, matching the simplex slicing exactly.",
-    "proofId": "arithmetic-series-oq-02-oq-02-oq-01",
-    "range": {
-      "startLine": 44,
-      "endLine": 44
-    }
+    "significance": "key",
+    "relatedConcepts": ["k-simplex slicing", "simplicial numbers", "stars-and-bars", "List pattern matching", "recursive definition"],
+    "prerequisites": ["simplicial from ArithmeticSeriesOQ02OQ02", "Finset.range", "Finset.sum", "BigOperators"]
   },
   {
-    "id": "multi-hockey-stick-proof",
-    "line": 56,
-    "endLine": 86,
-    "type": "theorem",
-    "label": "multi_hockey_stick (main k-dimensional identity)",
-    "mathContext": "$$\\text{multiHockeySum}(as, n) = \\binom{n + \\sum a_j + k}{\\sum a_j + k}$$\nThe calc block has four steps:\n1. Unfold definition (definitional equality)\n2. Apply IH pointwise via `Finset.sum_congr rfl`\n3. Apply `parallel_vandermonde a (as'.sum + as'.length) n` — the key step\n4. `congr 1; simp [List.sum_cons, List.length_cons]; omega` — verify $a + (\\text{as'.sum} + \\text{as'.length}) + 1 = (a::as').\\text{sum} + (a::as').\\text{length}$",
-    "significance": "key",
-    "relatedConcepts": [
-      "parallel_vandermonde",
-      "list induction",
-      "Finset.sum_congr",
-      "simplicial numbers",
-      "dimension reduction"
-    ],
-    "prerequisites": [
-      "parallel_vandermonde (ArithmeticSeriesOQ02OQ02)",
-      "Finset.sum_congr",
-      "List.sum_cons",
-      "List.length_cons"
-    ],
-    "content": "The `parallel_vandermonde` identity ($\\sum_j C(j+a,a) C(n-j+b,b) = C(n+a+b+1,a+b+1)$) is used at every induction step as the folding operation. Each application reduces a $k$-dimensional sum to a $(k-1)$-dimensional one. The `omega` handles the arithmetic $a + b + 1 = (a::as').\\text{sum} + (a::as').\\text{length}$ — trivial but required for definiteness.",
+    "id": "ann-as-nil-base-case",
     "proofId": "arithmetic-series-oq-02-oq-02-oq-01",
-    "range": {
-      "startLine": 56,
-      "endLine": 61
-    }
+    "range": { "startLine": 64, "endLine": 67 },
+    "type": "technique",
+    "title": "Base Case (k=0): Empty Product Equals simplicial 0",
+    "content": "The nil branch of the list induction handles the 0-dimensional case. `multiHockeySum [] n = 1` by definition. The target `simplicial (as.sum + as.length) n` specializes to `simplicial (0 + 0) n = simplicial 0 n`. The lemma `simplicial_zero` (from the parent file) gives `simplicial 0 n = C(n+0, 0) = 1`. The `simp [multiHockeySum, simplicial_zero]` tactic handles this in one step.\n\nThe mathematical content: a 0-dimensional simplex `{() : 0 ≤ n}` = `{()}` has exactly one point (the empty tuple), and the empty product of binomial coefficients is 1. So the sum of weights over the simplex is 1.",
+    "mathContext": "$\\text{multiHockeySum}([], n) = 1 = \\binom{n+0}{0} = \\text{simplicial}(0, n)$. The 0-simplex is a single point: the empty tuple with the constraint $\\emptyset \\leq n$ (vacuously satisfied). $\\text{simplicial}(0, n) = C(n, 0) = 1$ for all $n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["simplicial_zero", "empty product", "0-simplex", "Nat.choose_zero_right"],
+    "prerequisites": ["multiHockeySum base case", "simplicial_zero lemma from parent file"]
   },
   {
-    "id": "special-cases",
-    "line": 90,
-    "endLine": 110,
-    "type": "theorem",
-    "label": "multi_hockey_1d/2d/3d (dimension-specific instances)",
-    "mathContext": "All three proved by `rw [multi_hockey_stick]; simp [List.sum_cons, List.length_cons]`:\n- `multi_hockey_1d (a n)`: $= \\binom{n+a+1}{a+1}$ — classical hockey stick with offset $a$\n- `multi_hockey_2d (a b n)`: $= \\binom{n+a+b+2}{a+b+2}$ — double sum identity\n- `multi_hockey_3d (a b c n)`: $= \\binom{n+a+b+c+3}{a+b+c+3}$ — triple sum identity\n\nFor `multi_hockey_1d` with $a=k-1$: recovers $\\sum_{j=0}^n \\binom{j+k}{k} = \\binom{n+k+1}{k+1}$ (classical Pascal hockey stick).",
-    "significance": "key",
-    "relatedConcepts": [
-      "classical hockey stick",
-      "Pascal's triangle",
-      "double sum",
-      "triple sum",
-      "Graham-Knuth-Patashnik"
-    ],
-    "prerequisites": [
-      "multi_hockey_stick",
-      "List.sum_cons",
-      "List.length_cons"
-    ],
-    "content": "These provide human-readable, citable instances of the general theorem. The 1D case recovers the classical identity from Pascal's *Traité* (1654). The 2D case is useful in double-sum combinatorics. All three are immediate corollaries of `multi_hockey_stick` — they demonstrate that the general list induction subsumes the specific dimensional cases.",
+    "id": "ann-as-main-theorem",
     "proofId": "arithmetic-series-oq-02-oq-02-oq-01",
-    "range": {
-      "startLine": 90,
-      "endLine": 92
-    }
+    "range": { "startLine": 53, "endLine": 85 },
+    "type": "technique",
+    "title": "multi_hockey_stick: k-Dimensional Identity by List Induction",
+    "content": "The main theorem proved by `induction as generalizing n`. The `generalizing n` is critical: without it, the IH would fix a specific `n`, but the recursive definition `multiHockeySum as' (n-j)` applies IH at `n-j` (not `n`). Generalizing makes the IH universally quantified over `n`.\n\nThe calc block has four steps:\n1. Unfold definition (`rfl`)\n2. Apply IH pointwise via `Finset.sum_congr rfl` + `congr 1; exact ih (n-j)`\n3. Apply `parallel_vandermonde a (as'.sum + as'.length) n` — the key convolution step\n4. `congr 1; simp [List.sum_cons, List.length_cons]; omega` — verify the parameter arithmetic\n\nThe final omega goal: $a + (\\text{as'.sum} + \\text{as'.length}) + 1 = (a::\\text{as'}).\\text{sum} + (a::\\text{as'}).\\text{length}$ expands to $a + s' + l' + 1 = (a + s') + (l' + 1)$, which is trivially true.",
+    "mathContext": "The proof mirrors the mathematical induction: peel off one dimension, apply the parallel Vandermonde convolution identity $\\sum_{j=0}^n \\binom{j+a}{a}\\binom{n-j+b}{b} = \\binom{n+a+b+1}{a+b+1}$, and verify the parameter update. At each step, $(a, b) = (a, \\text{as'.sum} + \\text{as'.length})$ and the result parameter $a+b+1 = (a::\\text{as'}).\\text{sum} + (a::\\text{as'}).\\text{length}$.",
+    "significance": "key",
+    "relatedConcepts": ["parallel_vandermonde", "Finset.sum_congr", "induction generalizing", "List.sum_cons", "List.length_cons"],
+    "prerequisites": ["parallel_vandermonde from ArithmeticSeriesOQ02OQ02", "List.sum and List.length lemmas", "omega tactic", "Finset.sum_congr"]
   },
   {
-    "id": "concrete-checks",
-    "line": 112,
-    "endLine": 125,
-    "type": "theorem",
-    "label": "check_3d_zeros / check_2d_a1b0 (native_decide verification)",
-    "mathContext": "`check_3d_zeros`: `multiHockeySum [0, 0, 0] 2 = 10` by `native_decide`. The 3-simplex $\\{i+j+k \\leq 2\\}$ has $\\binom{5}{3} = 10$ lattice points. Explicitly: $(0,0,0),(1,0,0),(0,1,0),(0,0,1),(2,0,0),(1,1,0),(1,0,1),(0,2,0),(0,1,1),(0,0,2)$.\n\n`check_2d_a1b0`: `multiHockeySum [1, 0] 3 = 20`. Verifies $\\sum_{i+j \\leq 3} (i+1) = \\binom{6}{3} = 20$. Computed as $\\sum_{j=0}^3 \\sum_{i=0}^{3-j}(i+1) = 10 + 6 + 3 + 1 = 20$.",
-    "significance": "key",
-    "relatedConcepts": [
-      "native_decide",
-      "lattice point counting",
-      "stars-and-bars",
-      "concrete verification",
-      "3-simplex"
-    ],
-    "prerequisites": [
-      "native_decide",
-      "multiHockeySum definition"
-    ],
-    "content": "The `native_decide` tactic evaluates the recursive definition by computation, providing a sanity check independent of the abstract induction proof. If the definition had a bug (wrong base case, off-by-one in `range`), these checks would catch it. The 3D case is particularly illuminating: it confirms that 10 lattice points in the tetrahedron equals $C(5,3)$, consistent with stars-and-bars (placing 2 objects into 4 bins).",
+    "id": "ann-as-parallel-vandermonde-application",
     "proofId": "arithmetic-series-oq-02-oq-02-oq-01",
-    "range": {
-      "startLine": 112,
-      "endLine": 113
-    }
+    "range": { "startLine": 76, "endLine": 85 },
+    "type": "technique",
+    "title": "Parallel Vandermonde as the Induction Engine",
+    "content": "After applying the IH via `Finset.sum_congr`, the sum has the form $\\sum_{j \\in \\text{range}(n+1)} \\text{simplicial}(a, j) \\cdot \\text{simplicial}(b, n-j)$ where $b = \\text{as'.sum} + \\text{as'.length}$. This exactly matches `parallel_vandermonde a b n : ∑ j ∈ range (n+1), simplicial a j * simplicial b (n-j) = simplicial (a+b+1) n`.\n\nThe equality `a + (as'.sum + as'.length) + 1 = (a::as').sum + (a::as').length` is verified by `simp [List.sum_cons, List.length_cons]` which unfolds list operations, then `omega` for arithmetic. The `congr 1` isolates the parameter argument before the simp/omega step.\n\n`parallel_vandermonde` is proved in the parent file by double induction on b then n, using the Pascal recurrence for simplicial numbers. It is the core 2D convolution identity that powers the entire k-dimensional generalization.",
+    "mathContext": "Each `parallel_vandermonde` application maps the parameter pair $(a, b) \\mapsto a+b+1$, folding two dimensions into one. In the list encoding: removing `a` from `[a, a₂,...,aₖ]` gives new offset $a + (\\text{as'.sum} + \\text{as'.length}) + 1 = (a::\\text{as'}).\\text{sum} + (a::\\text{as'}).\\text{length}$ — matching the Lean list arithmetic. After $k-1$ total applications, the offset accumulates to $\\sum a_j + k$ as claimed.",
+    "significance": "key",
+    "relatedConcepts": ["parallel_vandermonde", "simplicial numbers", "convolution", "List.sum_cons", "List.length_cons"],
+    "prerequisites": ["parallel_vandermonde statement and proof from parent file", "simplicial definition: C(n+k, k)", "Finset.sum_congr pointwise rewriting"]
   },
   {
-    "id": "monotonicity-positivity",
-    "line": 133,
-    "endLine": 150,
-    "type": "theorem",
-    "label": "multiHockeySum_mono / multiHockeySum_pos",
-    "mathContext": "`multiHockeySum_mono`: after `rw [multi_hockey_stick, multi_hockey_stick]`, reduces to `C(m+k, k) ≤ C(n+k, k)` where $k = \\text{as.sum} + \\text{as.length}$. Proved by `Nat.choose_le_choose` with `omega`.\n\n`multiHockeySum_pos`: after `rw [multi_hockey_stick]`, reduces to `0 < C(n+k, k)`. Proved by `Nat.choose_pos` with `omega` (since $n+k \\geq k$ trivially for naturals).",
-    "significance": "key",
-    "relatedConcepts": [
-      "Nat.choose_le_choose",
-      "Nat.choose_pos",
-      "monotonicity",
-      "binomial coefficient properties"
-    ],
-    "prerequisites": [
-      "multi_hockey_stick",
-      "Nat.choose_le_choose",
-      "Nat.choose_pos",
-      "omega"
-    ],
-    "content": "Both proofs are one-liners after the `multi_hockey_stick` rewrite — demonstrating the leverage of the main identity. Properties about the complex recursive sum reduce immediately to simple facts about binomial coefficients. This 'reduce via the main theorem' pattern is the standard way to derive structural properties in this file.",
+    "id": "ann-as-special-cases",
     "proofId": "arithmetic-series-oq-02-oq-02-oq-01",
-    "range": {
-      "startLine": 133,
-      "endLine": 165
-    }
+    "range": { "startLine": 91, "endLine": 106 },
+    "type": "technique",
+    "title": "Special Cases: 1D/2D/3D Instances of the k-Dimensional Identity",
+    "content": "All three proved by `rw [multi_hockey_stick]; simp [List.sum_cons, List.length_cons]` (plus `ring_nf` for 3D to normalize the arithmetic). These are immediate corollaries — the proof is a one-or-two-liner.\n\n- `multi_hockey_1d (a n)`: `multiHockeySum [a] n = simplicial (a+1) n` — recovers the classical hockey stick with offset a. Setting a=k-1: $\\sum_{j=0}^n \\binom{j+k}{k} = \\binom{n+k+1}{k+1}$.\n- `multi_hockey_2d (a b n)`: `multiHockeySum [a, b] n = simplicial (a+b+2) n` — double sum identity.\n- `multi_hockey_3d (a b c n)`: `multiHockeySum [a, b, c] n = simplicial (a+b+c+3) n` — sum over the tetrahedron.\n\nThe `ring_nf` in the 3D case normalizes `a + (b + (c + 0)) + 3` to `a + b + c + 3` — an arithmetic form that `simp` alone doesn't simplify.",
+    "mathContext": "$\\text{multi\\_hockey\\_1d}$: $\\sum_{i \\leq n} \\binom{i+a}{a} = \\binom{n+a+1}{a+1}$. Classical 1D hockey stick; for $a=0$: $\\sum_{i=0}^n 1 = n+1$. $\\text{multi\\_hockey\\_2d}$: $\\sum_{i+j \\leq n} \\binom{i+a}{a}\\binom{j+b}{b} = \\binom{n+a+b+2}{a+b+2}$. $\\text{multi\\_hockey\\_3d}$: $\\sum_{i+j+k \\leq n} \\binom{i+a}{a}\\binom{j+b}{b}\\binom{k+c}{c} = \\binom{n+a+b+c+3}{a+b+c+3}$. Setting $a=b=c=0$, $n=2$: $\\binom{5}{3} = 10$ lattice points in $\\{i+j+k \\leq 2\\}$.",
+    "significance": "key",
+    "relatedConcepts": ["classical hockey stick (Pascal 1654)", "double sum identity", "Graham-Knuth-Patashnik", "ring_nf normalization"],
+    "prerequisites": ["multi_hockey_stick", "List.sum_cons", "List.length_cons", "ring_nf"]
+  },
+  {
+    "id": "ann-as-concrete-checks",
+    "proofId": "arithmetic-series-oq-02-oq-02-oq-01",
+    "range": { "startLine": 108, "endLine": 114 },
+    "type": "technique",
+    "title": "native_decide: Concrete Numerical Verification",
+    "content": "The `native_decide` tactic evaluates the recursive definition by computation, providing a sanity check independent of the abstract induction proof. If the definition had a bug (wrong base case, off-by-one in `range`), these checks would catch it.\n\n`check_3d_zeros`: `multiHockeySum [0,0,0] 2 = 10`. The 3-simplex $\\{(i,j,k): i+j+k \\leq 2, i,j,k \\geq 0\\}$ has $\\binom{5}{3} = 10$ lattice points: $(0,0,0),(1,0,0),(0,1,0),(0,0,1),(2,0,0),(1,1,0),(1,0,1),(0,2,0),(0,1,1),(0,0,2)$.\n\n`check_2d_a1b0`: `multiHockeySum [1,0] 3 = 20`. Computes $\\sum_{i+j \\leq 3} (i+1) = \\binom{6}{3} = 20$. Explicit: $\\sum_{j=0}^3 \\sum_{i=0}^{3-j}(i+1) = 10+6+3+1 = 20$. The $a_1=1$ weight assigns each point with first coordinate $i$ a weight of $i+1$.",
+    "mathContext": "`native_decide` compiles the decision procedure to native code for efficiency. For the 3D check: $\\text{simplicial}(0+0+0+3, 2) = \\text{simplicial}(3,2) = C(2+3,3) = C(5,3) = 10$. For the 2D check: $\\text{simplicial}(1+0+2, 3) = \\text{simplicial}(3,3) = C(6,3) = 20$. Stars-and-bars verification for the 3D case: $\\binom{n+k}{k} = \\binom{5}{3} = 10$ ways to place 2 indistinct balls into 4 bins.",
+    "significance": "supporting",
+    "relatedConcepts": ["native_decide vs decide", "lattice point counting", "stars-and-bars", "independent verification"],
+    "prerequisites": ["native_decide tactic", "multiHockeySum definition", "Lean 4 kernel evaluation"]
+  },
+  {
+    "id": "ann-as-monotonicity-positivity",
+    "proofId": "arithmetic-series-oq-02-oq-02-oq-01",
+    "range": { "startLine": 120, "endLine": 135 },
+    "type": "technique",
+    "title": "Structural Properties: Monotonicity and Positivity via Main Theorem",
+    "content": "Both proofs are one-liners after the `multi_hockey_stick` rewrite — demonstrating the leverage of the main identity. Properties about the complex recursive sum reduce immediately to simple facts about binomial coefficients.\n\n`multiHockeySum_mono (as) {m n} (h : m ≤ n)`: After `rw [multi_hockey_stick, multi_hockey_stick]`, reduces to `C(m+k, k) ≤ C(n+k, k)` where $k = \\text{as.sum} + \\text{as.length}$. `Nat.choose_le_choose` provides this with `omega` verifying `m+k ≤ n+k`.\n\n`multiHockeySum_pos (as n)`: After `rw [multi_hockey_stick]`, reduces to `0 < C(n+k, k)`. `Nat.choose_pos` needs `n+k ≥ k`, proved by `omega` (trivially: $k \\leq n+k$ for naturals). The 'reduce via the main theorem' pattern is the standard approach to derive structural properties in this file.",
+    "mathContext": "`multiHockeySum_mono`: $m \\leq n \\Rightarrow \\binom{m+k}{k} \\leq \\binom{n+k}{k}$. Combinatorially: a larger bound means more lattice points in the simplex. `Nat.choose_le_choose` in Mathlib: `n ≤ m → C(n, k) ≤ C(m, k)`. Applied with `n ↦ m+k, m ↦ n+k, k ↦ k`.\n\n`multiHockeySum_pos`: The simplex is non-empty for all $n,k \\geq 0$: it always contains the all-zeros tuple $(0,\\ldots,0)$, which contributes weight $\\binom{0+a_j}{a_j} = 1$ at each coordinate.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.choose_le_choose", "Nat.choose_pos", "simplicial monotonicity", "one-liner corollaries"],
+    "prerequisites": ["multi_hockey_stick", "Nat.choose_le_choose", "Nat.choose_pos", "omega"]
+  },
+  {
+    "id": "ann-as-summary-insight",
+    "proofId": "arithmetic-series-oq-02-oq-02-oq-01",
+    "range": { "startLine": 137, "endLine": 163 },
+    "type": "insight",
+    "title": "Key Insight: k-Dimensional Identity Reduces to Repeated 1D Convolution",
+    "content": "The summary block articulates the architectural key: the entire k-dimensional hockey stick identity reduces to repeated application of the 2-variable parallel Vandermonde identity. The list induction peels off one dimension at a time, and parallel Vandermonde 'folds' it back into a single simplicial number.\n\nThe parallel between algebraic structure and combinatorial content:\n- List length k = dimension → each list element is one dimension\n- List sum Σaⱼ = weight offset → each element is the weight parameter for that dimension\n- `parallel_vandermonde` maps (a, b) → a+b+1, removing one element and adding weight+1 to the offset\n- After k steps: offset = Σaⱼ + k = `as.sum + as.length` ✓\n\nThis mirrors the generating function identity: $(1/(1-z))^{a_1+1} \\cdot (1/(1-z))^{a_2+1} \\cdots (1/(1-z))^{a_k+1} = (1/(1-z))^{\\sum a_j + k}$. Each multiplication step corresponds to one Vandermonde convolution. The list induction makes this factorization explicit at the proof level.",
+    "mathContext": "The parallel Vandermonde is a 2-input convolution: $\\sum_{j} S_{a}(j) \\cdot S_{b}(n-j) = S_{a+b+1}(n)$ where $S_k(n) = C(n+k,k)$. This is the discrete analog of the Beta integral: $\\int_0^1 t^a (1-t)^b \\, dt = B(a+1, b+1) = a! b!/(a+b+1)!$. Repeated application chains to $S_{\\sum a_j + k}(n) = \\binom{n + \\sum a_j + k}{\\sum a_j + k}$, the k-dimensional hockey stick. The lattice path interpretation: $C(n+k, k)$ counts paths in the k-simplex, and each Vandermonde step corresponds to conditioning on one coordinate.",
+    "significance": "key",
+    "relatedConcepts": ["parallel Vandermonde as convolution", "generating functions 1/(1-z)^k", "Beta function analog", "simplicial numbers", "lattice path counting"],
+    "prerequisites": ["parallel_vandermonde", "simplicial = C(n+k,k)", "generating function 1/(1-z)^{k+1}"]
   }
 ]


### PR DESCRIPTION
## Summary

- Fixes 5 schema violations: nonstandard `line`, `endLine`, `label` fields; `significance: "technical"`; incorrect range `44-44→38-47`; `special-cases` range `90-92→91-106`
- Expands annotations from 5 to 9 with 4 new additions:
  - `ann-as-oq02-oq01-header` (1-33): Module architecture, list induction encoding, generating function context
  - `ann-as-nil-base-case` (64-67): Empty product = simplicial 0 reasoning in the nil branch
  - `ann-as-parallel-vandermonde-application` (76-85): How PV maps (a,b)→a+b+1 as the induction engine
  - `ann-as-summary-insight` (137-163): k-dim identity reduces to repeated 1D convolution; Beta integral analog

🤖 Generated with [Claude Code](https://claude.com/claude-code)