### PR TITLE
Fix: sync stale lineCount in hurwitz-theorem and erdos-476-oq-05

### DIFF
--- a/src/data/proofs/erdos-476-oq-05/meta.json
+++ b/src/data/proofs/erdos-476-oq-05/meta.json
@@ -22,7 +22,7 @@
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
     "assumptions": "2 sorries in vosper theorem: [SORRY 1/2] Case 1 existence (counting argument for removing an element from A) and [SORRY 2/2] AP extension (a₀ adjacent to A' implies A is AP with same difference d). Both ap_of_near_periodic (backward-shift induction) and vosper_base (|A|=2 case) are fully proved. Infrastructure all proved with 0 sorries.",
-    "lineCount": 437,
+    "lineCount": 583,
     "theoremCount": 8,
     "definitionCount": 1,
     "originalContributions": [
@@ -116,7 +116,7 @@
   ],
   "leanFile": {
     "namespace": "Erdos476OQ05",
-    "lineCount": 437,
+    "lineCount": 583,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 1,

--- a/src/data/proofs/hurwitz-theorem/meta.json
+++ b/src/data/proofs/hurwitz-theorem/meta.json
@@ -45,7 +45,7 @@
     ],
     "dateAdded": "2025-12-26",
     "axiomCount": 0,
-    "lineCount": 1838,
+    "lineCount": 1973,
     "assumptions": "1 sorry: hurwitz_only_if — general non-existence for n ∉ {1,2,3,4,8} (n=3 case proved; remaining cases need Clifford/Radon-Hurwitz argument). The 8-square identity (octonions) is fully proved. No axiom declarations.",
     "mathlib_version": "4.26.0"
   },
@@ -277,7 +277,7 @@
     ],
     "opens": [],
     "namespace": "HurwitzTheorem",
-    "lineCount": 1838,
+    "lineCount": 1973,
     "axiomCount": 0,
     "theoremCount": 33,
     "definitionCount": 15,


### PR DESCRIPTION
## Fix

Research agent commits added lines to Lean files without updating `lineCount` in meta.json.

## Evidence

**hurwitz-theorem** (`HurwitzTheorem.lean`):
- **Before**: `lineCount: 1838`
- **After**: `lineCount: 1973`
- Source: Research commit #11378 added ~135 lines of odd-n impossibility + Vosper infrastructure

**erdos-476-oq-05** (`Erdos476OQ05Problem.lean`):
- **Before**: `lineCount: 437`
- **After**: `lineCount: 583`
- Source: Research commit #11368 added ~146 lines proving isAP_sdiff_card and structuring vosper_ap_sdiff_card

Both `sorries` and `axiomCount` are correct — only `lineCount` (in both `meta` and `leanFile` sections) needed updating.

Build validated: `pnpm build` passes cleanly.

---
Automated fix by lean-mechanic agent.