### PR TITLE
Fix: sync stale lineCount in area-of-circle-oq-05-oq-02

### DIFF
--- a/src/data/proofs/area-of-circle-oq-05-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-02/meta.json
@@ -30,7 +30,7 @@
       "Documents the change-of-variables infrastructure needed: map_linearMap_volume_pi_eq_smul_volume_pi with |det Uᵀ| = 1"
     ],
     "dateAdded": "2026-04-21",
-    "lineCount": 139,
+    "lineCount": 138,
     "theoremCount": 3,
     "definitionCount": 0,
     "mathlib_version": "4.26.0"


### PR DESCRIPTION
## Fix

Correct stale `lineCount` in `area-of-circle-oq-05-oq-02/meta.json`.

## Evidence

**Before**: `lineCount: 139`
**After**: `lineCount: 138`

The actual `AreaOfCircleOQ05OQ02.lean` file has 138 lines (verified with `wc -l` and Python line counting). The meta.json was off by one — a discrepancy left over from a previous batch sync.

`pnpm build` passes cleanly.

---
Automated fix by lean-mechanic agent.