### PR TITLE
Enrich: add cross-references and annotations to 10 entries

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-02/annotations.json
@@ -60,6 +60,18 @@
     "prerequisites": ["abstract_rice", "EvalStructure.IsPointSurjective", "HaltingModel structure"]
   },
   {
+    "id": "ann-rice-classical-rice-model",
+    "proofId": "cantor-diagonalization-oq-03-oq-01-oq-02",
+    "range": { "startLine": 210, "endLine": 222 },
+    "type": "definition",
+    "title": "ClassicalRiceModel: Axiomatizing Kleene's Recursion Theorem",
+    "content": "ClassicalRiceModel is a structure encoding the minimal infrastructure for the classical Rice theorem: programs (Code), behaviors (Behavior), a semantics map, a compile function (h_compile: every behavior has a code), and crucially kleene_rec — Kleene's recursion theorem. kleene_rec axiomatizes that every code transformer f : Code → Code has a 'semantic fixed point': a code e* such that semantics(f(e*)) = semantics(e*). This is precisely the Lawvere fixed-point theorem applied to the evaluation structure (Code, Behavior, semantics) — if semantics were point-surjective in the type-theoretic sense, kleene_rec would follow. By packaging it as a structure field rather than a global axiom, all five theorems in Section II remain axiom-free; only classical_rice_abstract inherits the 2 assumptions via the M : ClassicalRiceModel parameter.",
+    "mathContext": "**Kleene's recursion theorem**: Given any computable function $f: \\mathbb{N} \\to \\mathbb{N}$ (code transformer), there exists a code $e^*$ such that $\\varphi_{f(e^*)} = \\varphi_{e^*}$ (the programs $f(e^*)$ and $e^*$ compute the same partial function). This follows from the s-m-n theorem + diagonal construction: define $e^* = \\varphi_d(d)$ where $d$ encodes the transformer $n \\mapsto f(\\varphi_n(n))$. The structure field `kleene_rec` is a direct Lean 4 encoding of this universality without committing to any specific computation model.",
+    "significance": "key",
+    "relatedConcepts": ["Kleene's recursion theorem", "s-m-n theorem", "structure fields as axioms", "behavioral equivalence", "code transformer"],
+    "prerequisites": ["ClassicalRiceModel structure", "Lean 4 structure syntax", "Type* for universe polymorphism"]
+  },
+  {
     "id": "ann-rice-classical",
     "proofId": "cantor-diagonalization-oq-03-oq-01-oq-02",
     "range": { "startLine": 237, "endLine": 262 },

--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-02/meta.json
@@ -96,6 +96,38 @@
       "summary": "ClassicalRiceModel axiomatizes Kleene's recursion theorem. classical_rice_abstract proves: semantic + non-trivial P leads to contradiction via the flipper code transformer and Kleene's semantic fixed point."
     }
   ],
+  "crossReferences": [
+    {
+      "targetId": "cantor-diagonalization-oq-03-oq-01",
+      "relationship": "foundational",
+      "description": "Parent entry proving the Lawvere fixed-point theorem (lawvere_fpt). This file is the direct instantiation: EvalStructure + Bool.not (no fixed point) immediately yields abstract_rice. Every theorem here invokes lawvere_fpt from the parent."
+    },
+    {
+      "targetId": "cantor-diagonalization-oq-03-oq-01-oq-03",
+      "relationship": "complementary",
+      "description": "Sibling entry deriving Gödel incompleteness as the third Lawvere instance. Together they complete the Lawvere chain: Cantor (Prop/negation) → Rice (Bool/not) → Gödel (sentences/unprovability). Both files share the same EvalStructure framework and proof pattern."
+    },
+    {
+      "targetId": "halting-problem",
+      "relationship": "related",
+      "description": "Turing's halting problem undecidability is derived here in one line as no_halting_model — a direct corollary of abstract_rice. HaltingModel's universal field is definitionally IsPointSurjective, so abstract_rice forbids any decidable halting predicate."
+    },
+    {
+      "targetId": "cantor-diagonalization-oq-03-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Categorical Lawvere FPT entry that closes the global-element bridge via the e_pt morphism parameter. Completes the abstract categorical framework (cartesian closed categories) that this file instantiates with Type* and Bool."
+    },
+    {
+      "targetId": "godel-incompleteness",
+      "relationship": "related",
+      "description": "Gödel's incompleteness theorems are the third application in the Lawvere chain formalized here. The conclusion references Gödel as the next step: extend EvalStructure to formal proof systems where the fixed-point endomorphism is negation of provability."
+    },
+    {
+      "targetId": "cantor-diagonalization",
+      "relationship": "foundational",
+      "description": "Root diagonal argument entry. Rice's theorem and Turing's halting undecidability both trace to Cantor's original diagonal construction — here abstracted through Lawvere into a single lawvere_fpt theorem that captures all three simultaneously."
+    }
+  ],
   "leanFile": {
     "namespace": "CantorDiagonalizationOQ03OQ01OQ02",
     "lineCount": 275,

--- a/src/data/proofs/erdos-19-oq-01/meta.json
+++ b/src/data/proofs/erdos-19-oq-01/meta.json
@@ -143,5 +143,37 @@
     "path": "Proofs/Erdos19OQ01Problem.lean",
     "sorries": 0
   },
+  "crossReferences": [
+    {
+      "targetId": "erdos-19",
+      "relationship": "foundational",
+      "description": "Parent entry: the EFL conjecture itself. This file is the open question extension — what is the explicit threshold N₀? The parent formalizes the conjecture statement; this file establishes the structural framework (threshold existence, finite reduction theorem) for determining N₀."
+    },
+    {
+      "targetId": "four-color-theorem",
+      "relationship": "related",
+      "description": "The Four Color Theorem is another major graph coloring result with a long proof history. Both four-coloring (planar graphs) and EFL (union of K_n copies) are chromatic number theorems resolved after decades. The proof methods differ fundamentally: 4CT used computer case checking; EFL used the absorbing method."
+    },
+    {
+      "targetId": "ramsey-r4k-extensions",
+      "relationship": "related",
+      "description": "Ramsey R(4,k) bounds: another Ramsey-type graph theory result using the probabilistic method. Like EFL, this involves clique structures and chromatic bounds. Both use extremal graph theory techniques (absorbing method for EFL, probabilistic method for R(4,k)) to establish existence results."
+    },
+    {
+      "targetId": "ramseys-theorem",
+      "relationship": "related",
+      "description": "Ramsey's theorem: the foundational result that large enough graphs contain monochromatic cliques. The EFL conjecture is framed as a Ramsey-type result — given enough edge-disjoint cliques, the chromatic number is exactly n. Ramsey theory provides the conceptual framework for understanding why such structural guarantees exist."
+    },
+    {
+      "targetId": "szemeredi-regularity",
+      "relationship": "related",
+      "description": "Szemerédi's Regularity Lemma: a cornerstone of extremal graph theory. The absorbing method used by Kang et al. (2021) to prove EFL for large n is part of the same toolkit as the regularity lemma — both control graph structure probabilistically to enable clean combinatorial arguments."
+    },
+    {
+      "targetId": "szemeredi-hypergraph-core",
+      "relationship": "related",
+      "description": "Hypergraph Szemerédi theorems: EFL can be rephrased as a hypergraph coloring problem (color the hyperedges of a clique-hypergraph with n colors). The hypergraph regularity machinery (Szemerédi-type results for hypergraphs) is the technical foundation for the KKMO 2021 proof."
+    }
+  ],
   "sorries": 0
 }


### PR DESCRIPTION
## Summary

Enrichment pass adding cross-references and new annotations to gallery proof entries with missing connections.

### Entries enriched

- **cantor-diagonalization-oq-03-oq-01-oq-03**: +8 cross-references, expanded historicalContext, +1 annotation (godel_completeness_fails theorem)
- **bezout-identity-oq-02-oq-04**: +6 cross-references
- **borsuk-ulam-oq-02-oq-03**: +6 cross-references
- **chinese-remainder-constructive-oq-03**: +6 cross-references, +2 annotations
- **erdos-1059-oq-04**: +6 cross-references
- **erdos-1208**: +6 cross-references
- **erdos-1211**: +6 cross-references, fixed pre-existing annotation schema error (ann-1211-lean-stub startLine 18→20, type concept→theorem)
- **erdos-19-oq-01**: +6 cross-references
- **cantor-diagonalization-oq-03-oq-01-oq-02**: +6 cross-references, +1 annotation (ClassicalRiceModel structure)

## Test plan
- [x] `pnpm run annotations:build` passes with no new errors for all enriched entries
- [x] All annotation startLine values verified against actual Lean construct keywords

🤖 Generated with [Claude Code](https://claude.com/claude-code)