### PR TITLE
Enrich abel-ruffini: add inverse-galois-oq-06 cross-reference, 2 annotations

### DIFF
--- a/src/data/proofs/abel-ruffini/annotations.source.json
+++ b/src/data/proofs/abel-ruffini/annotations.source.json
@@ -228,14 +228,15 @@
     },
     "type": "theorem",
     "title": "A₅ is Simple",
-    "content": "A group is simple if its only normal subgroups are {1} and the whole group. The alternating group A₅ is simple - it's the smallest non-abelian simple group, with 60 elements.\n\nThe proof analyzes cycle types: identity (1), 3-cycles (20), 5-cycles (24), double transpositions (15). Any normal subgroup containing a non-identity element must contain a 3-cycle, and 3-cycles generate all of A₅.",
+    "content": "A group is simple if its only normal subgroups are {1} and the whole group. The alternating group A₅ is simple - it's the smallest non-abelian simple group, with 60 elements.\n\nThe proof analyzes cycle types: identity (1), 3-cycles (20), 5-cycles (24), double transpositions (15). Any normal subgroup containing a non-identity element must contain a 3-cycle, and 3-cycles generate all of A₅.\n\nThe simplicity of A₅ has a direct consequence via Abel-Ruffini: since A₅ is not solvable, any polynomial over ℚ with Galois group isomorphic to A₅ has roots not expressible by radicals. The gallery entry `inverse-galois-oq-06` proves this is not vacuous — it exhibits the explicit polynomial x⁵-5x⁴+10x³-10x²+25x-5 with A₅ ≅ Gal(q/ℚ), providing a concrete quintic whose unsolvability-by-radicals follows by combining that entry with `not_solvable_by_rad_of_not_solvable_gal`.",
     "mathContext": "$A_5 = \\ker(\\text{sign} : S_5 \\to \\{\\pm 1\\}) = \\{\\sigma \\in S_5 : \\text{sign}(\\sigma) = +1\\}$, $|A_5| = 60 = 5!/2$.\n\nConjugacy classes: identity (1), products of two disjoint transpositions (15), 3-cycles (20), and two classes of 5-cycles (12 + 12). A normal subgroup $N \\trianglelefteq A_5$ must be a union of conjugacy classes containing $\\{e\\}$ (size 1), and $|N|$ must divide 60. The possible sub-sums starting with 1 are: $1, 1{+}15{=}16, 1{+}20{=}21, 1{+}12{=}13, 1{+}15{+}20{=}36, \\ldots$ — none divides 60 except 1 and 60 itself. Therefore $A_5$ has no proper nontrivial normal subgroups.\n\nLean: `alternatingGroup.isSimpleGroup_five : IsSimpleGroup (alternatingGroup (Fin 5))`.",
     "significance": "key",
     "relatedConcepts": [
       "alternating group",
       "simple group",
       "normal subgroup",
-      "cycle type"
+      "cycle type",
+      "inverse-galois-oq-06"
     ],
     "prerequisites": [
       "permutation groups",

--- a/src/data/proofs/abel-ruffini/meta.json
+++ b/src/data/proofs/abel-ruffini/meta.json
@@ -84,6 +84,10 @@
       {
         "id": "abel-ruffini-oq-04-oq-02-oq-03",
         "relationship": "All finite groups of order < 60 are solvable — A₅ (order 60) is the minimal non-solvable group"
+      },
+      {
+        "id": "inverse-galois-oq-06",
+        "relationship": "Proves A₅ ≅ Gal(x⁵-5x⁴+10x³-10x²+25x-5/ℚ) — an alternative concrete non-radical quintic witness via A₅ realizability, complementing the S₅ witness in abel-ruffini-oq-04-oq-01"
       }
     ],
     "lineCount": 185,
@@ -345,6 +349,11 @@
       "targetId": "lagrange-theorem-oq-03",
       "relationship": "complementary",
       "description": "Hall's theorem (1928) characterizes solvable groups positively: a finite group is solvable iff it has Hall subgroups of every coprime order. This provides a structural 'positive test' for solvability complementing the impossibility at degree 5 — S₅ has no subgroup of order 15 (max element order is 6), so S₅ fails Hall's criterion"
+    },
+    {
+      "targetId": "inverse-galois-oq-06",
+      "relationship": "complementary",
+      "description": "Proves A₅ ≅ Gal(x⁵-5x⁴+10x³-10x²+25x-5/ℚ) via Eisenstein at $p=5$ and Sylow theory. Since A₅ is not solvable (the simplicity of A₅ is the key obstruction in Abel-Ruffini), applying `not_solvable_by_rad_of_not_solvable_gal` yields a concrete quintic whose roots are not expressible by radicals. Provides an alternative concrete witness to `abel-ruffini-oq-04-oq-01`'s S₅-based example, completing the picture: both A₅ and S₅ appear as Galois groups over ℚ and both obstruct radical solvability"
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for abel-ruffini (quality: 100, pass 4).

## Changes

### New cross-reference: `inverse-galois-oq-06`
- `inverse-galois-oq-06` proves A₅ ≅ Gal(x⁵-5x⁴+10x³-10x²+25x-5/ℚ) via Eisenstein at p=5 and Sylow theory
- Since A₅ is not solvable, this entry + `not_solvable_by_rad_of_not_solvable_gal` yields a concrete quintic whose roots are not expressible by radicals
- Added to both `relatedProblems` and `crossReferences` in meta.json
- Complements the existing S₅ witness in `abel-ruffini-oq-04-oq-01`

### Annotation update: `ann-a5-simple`
- Extended content in `annotations.source.json` to note that `inverse-galois-oq-06` proves A₅ realizability over ℚ
- Added `inverse-galois-oq-06` to `relatedConcepts`