### PR TITLE
Enrich lebesgue-measure-oq-06 (Banach-Tarski): 2 annotations, fix schema, cross-ref

### DIFF
--- a/src/data/proofs/lebesgue-measure-oq-06/annotations.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/annotations.json
@@ -55,9 +55,33 @@
     "title": "ENNReal Helper: a + a = a implies a = 0 or ∞ (Proved)",
     "content": "This lemma is fully proved (no sorry). In ℝ≥0∞ (extended non-negative reals), if a + a = a then a must be 0 or ⊤ (infinity). The proof lifts a to ℝ≥0 using the finiteness assumption (a ≠ ⊤), then derives a = 0 from a + a = a by linarith. This captures the essential arithmetic of the paradox: 'measure doubled = original measure' forces extremal values.",
     "mathContext": "The proof uses: (1) push_neg to separate the ¬(a = 0 ∨ a = ⊤) into a ≠ 0 ∧ a ≠ ⊤; (2) lift a to ℝ≥0 using a ≠ ⊤; (3) cast the ENNReal equation to ℝ≥0 using ENNReal.coe_add and ENNReal.coe_inj; (4) linarith to conclude a = 0, contradicting a ≠ 0. The key coercion: ↑a + ↑a = ↑a in ℝ≥0 gives 2·a = a (in ℝ≥0), hence a = 0.",
-    "significance": "important",
+    "significance": "key",
     "relatedConcepts": ["ENNReal arithmetic", "extended reals", "measure paradoxes", "linarith in ℝ≥0"],
     "prerequisites": ["ENNReal.coe_add", "ENNReal.coe_inj", "NNReal.eq_zero_of_add_eq_self"]
+  },
+  {
+    "id": "ann-geometric-setup",
+    "proofId": "lebesgue-measure-oq-06",
+    "range": { "startLine": 150, "endLine": 191 },
+    "type": "definition",
+    "title": "Geometric Setup: RigidMotion3, Unit Ball/Sphere, and Hausdorff's Free Subgroup",
+    "content": "Section III defines the geometric arena for the paradox. `RigidMotion3` is defined as `EuclideanSpace ℝ (Fin 3) ≃ᵢ EuclideanSpace ℝ (Fin 3)` — isometric equivalences of ℝ³ — which forms a group under composition representing all rigid motions (rotations and translations; the actual group is SE(3), the Special Euclidean group). `unitBall3` is `Metric.closedBall 0 1` (the closed ball of radius 1 centered at the origin), and `unitSphere3` is `Metric.sphere 0 1` (its boundary).\n\nSection IV states Hausdorff's theorem: the rotation group SO(3) contains a free subgroup of rank 2. Specifically, the rotations $\\varphi$ (by $\\arccos(1/3)$ around the $z$-axis) and $\\psi$ (by $\\arccos(1/3)$ around the $x$-axis) generate a free group $F_2 = \\langle \\varphi, \\psi \\rangle$. The theorem is stated as a sorry: an injective group homomorphism from `FreeGroup Bool` into the isometry group. Freeness is proved by showing nontrivial words $w(\\varphi, \\psi)$ applied to $e_1 = (1,0,0)$ yield vectors with irrational $\\sqrt{2}/3$ components that cannot equal $e_1$, using a number-theoretic induction on word length.",
+    "mathContext": "The Hausdorff rotation matrices use $\\cos\\theta = 1/3$, $\\sin\\theta = 2\\sqrt{2}/3$ where $\\theta = \\arccos(1/3)$: $\\varphi = \\begin{pmatrix} 1/3 & -2\\sqrt{2}/3 & 0 \\\\ 2\\sqrt{2}/3 & 1/3 & 0 \\\\ 0 & 0 & 1 \\end{pmatrix}$ (rotation around $z$). Freeness: a nontrivial word $w(\\varphi, \\psi)$ in $F_2$ always moves $e_1$ — proved by tracking the form $p + q\\sqrt{2}$ of coordinates under alternating rotations, showing they cannot return to $(1,0,0)$.",
+    "significance": "key",
+    "relatedConcepts": ["SO(3) rotation group", "free group", "FreeGroup Bool", "IsometryEquiv", "Metric.closedBall", "Hausdorff paradox"],
+    "prerequisites": ["Euclidean space in Lean", "isometric equivalences", "group homomorphism", "FreeGroup", "MeasureTheory"]
+  },
+  {
+    "id": "ann-nonmeasurability",
+    "proofId": "lebesgue-measure-oq-06",
+    "range": { "startLine": 228, "endLine": 248 },
+    "type": "theorem",
+    "title": "Corollary: Banach-Tarski Pieces Are Non-Measurable",
+    "content": "This corollary (stated as a sorry) captures the essential measure-theoretic obstruction: the pieces in any Banach-Tarski decomposition of the unit ball must be non-Lebesgue-measurable. The argument is by contradiction: if all pieces $\\{P_i\\}$ were measurable, then since isometries preserve Lebesgue measure, $\\lambda(g_j^{(i)}(P_i)) = \\lambda(P_i)$ for each $i$. Finite additivity over the two reassemblies gives $\\lambda(B^3) = \\sum_i \\lambda(P_i) = \\lambda(B^3) + \\lambda(B^3) = 2\\lambda(B^3)$. Since $\\lambda(B^3) = 4\\pi/3 \\in (0, \\infty)$, this is a contradiction. Thus the Axiom of Choice is not just used for the construction — it is genuinely necessary; without non-measurable sets, the paradox cannot occur.",
+    "mathContext": "Quantitative contradiction: $\\lambda(B^3) = \\frac{4}{3}\\pi$ (volume of unit ball in $\\mathbb{R}^3$). If all $n$ pieces have well-defined measure: $\\sum_{i=1}^n \\lambda(P_i) = \\lambda(B^3) = \\frac{4\\pi}{3}$ (partition). Two equidecomposable copies: $2 \\cdot \\frac{4\\pi}{3} = \\frac{4\\pi}{3}$. Contradiction. The non-measurability is analogous to the Vitali set: choosing one representative from each $\\mathbb{Q}$-coset of $\\mathbb{R}/\\mathbb{Z}$ yields a non-measurable set.",
+    "significance": "key",
+    "relatedConcepts": ["Lebesgue measure", "isometry preserves measure", "non-measurable set", "Vitali set", "Axiom of Choice", "MeasurableSet"],
+    "prerequisites": ["MeasureTheory.Measure.isometry_invariant", "Lebesgue measure on ℝ³", "MeasurableSet", "finitely-additive measure"]
   },
   {
     "id": "ann-banach-tarski",

--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -91,7 +91,8 @@
     "summary": "The Banach-Tarski paradox is formalized at the statement level with abstract equidecomposability and paradoxical set framework fully defined. The key measure-theoretic consequence (paradoxical sets admit no finite invariant measure) is structurally proved. The main theorem and ingredient lemmas are stated as axiomatized sorries, representing the current boundary of this gallery entry's formalization.",
     "openQuestions": [
       "Can Hausdorff's free subgroup theorem be fully formalized in Lean? The proof requires showing that explicit 3×3 rotation matrices generate a free group — the algebraic argument involves showing nontrivial words produce vectors with irrational coordinates via a number-theoretic argument.",
-      "Can the full Banach-Tarski proof be formalized in Lean 4? The most likely path: build the free group paradoxical decomposition first (purely algebraic), then lift to S² (measure-theoretic), then to B³ (geometric extension). Estimated scope: 800-1200 lines."
+      "Can the full Banach-Tarski proof be formalized in Lean 4? The most likely path: build the free group paradoxical decomposition first (purely algebraic), then lift to S² (measure-theoretic), then to B³ (geometric extension). Estimated scope: 800-1200 lines.",
+      "Can Tarski's theorem (a G-set admits a G-invariant finitely-additive probability measure if and only if it is not G-paradoxical) be formalized in Lean? This requires formalizing the theory of means, the ultrafilter proof of the forward direction, and the Hahn-Banach theorem in the amenable case — a major measure-theoretic formalization project connecting this entry's `IsAmenable` definition to its full characterization."
     ],
     "implications": "The Banach-Tarski paradox shows that Lebesgue measure cannot be extended to all subsets of ℝ³ as a finitely-additive rigid-motion-invariant measure. It demonstrates that the Axiom of Choice produces sets with no reasonable notion of volume. The connection to amenability shows that this phenomenon is fundamentally group-theoretic: the non-amenability of SO(3) (via its free subgroup) is the root cause."
   },
@@ -105,6 +106,11 @@
       "targetId": "lebesgue-measure-oq-03",
       "relationship": "sibling",
       "description": "Both show fundamental limitations of Lebesgue measure — infinite-dimensional impossibility and 3D paradox"
+    },
+    {
+      "targetId": "lebesgue-measure-oq-03-oq-01",
+      "relationship": "related",
+      "description": "No Translation-Invariant Measure in Infinite Dimensions — complementary impossibility result: in infinite-dimensional spaces, no nonzero $\\sigma$-finite translation-invariant Borel measure exists. Banach-Tarski shows the same impossibility for finitely-additive rigid-motion-invariant measures on $\\mathbb{R}^3$, but the obstructions differ: infinite dimensionality vs. non-amenability of SO(3)."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for **lebesgue-measure-oq-06** (Banach-Tarski Paradox).

## Changes

### New annotations (2)
- **ann-geometric-setup** (lines 150–191): Covers the `RigidMotion3`/`unitBall3`/`unitSphere3` definitions (Section III) and Hausdorff's free subgroup theorem (Section IV). Includes mathContext with the explicit rotation matrix entries ($\cos\theta = 1/3$, $\sin\theta = 2\sqrt{2}/3$) and the number-theoretic freeness argument.
- **ann-nonmeasurability** (lines 228–248): Covers the `banach_tarski_pieces_nonmeasurable` corollary. Explains the measure-theoretic contradiction (isometries preserve measure + two reassemblies → $\lambda(B^3) = 2\lambda(B^3)$) and connects to the Vitali set analogy.

### Schema fix
- Changed `significance: "important"` → `"key"` in `ann-ennreal-lemma` (invalid enum value)

### Cross-reference added
- `lebesgue-measure-oq-03-oq-01` — No Translation-Invariant Measure in Infinite Dimensions: complementary impossibility result (infinite-dimensionality vs. non-amenability as different obstructions)

### Open question added
- Formalizing Tarski's theorem: amenability ↔ no paradoxical subset (requires ultrafilter argument, Hahn-Banach, theory of means)

## Verification
- `pnpm build` passed (8m 55s, exit 0)
- JSON validity confirmed