### PR TITLE
Enrich dissection-of-cubes-oq-04: 4 new annotations, schema fix, cross-refs

### DIFF
--- a/src/data/proofs/dissection-of-cubes-oq-04/annotations.json
+++ b/src/data/proofs/dissection-of-cubes-oq-04/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-module-header",
+    "proofId": "dissection-of-cubes-oq-04",
+    "range": { "startLine": 1, "endLine": 59 },
+    "type": "context",
+    "title": "Module Overview: Platonic Solid Classification via Dehn Invariants",
+    "content": "The module docstring frames the central result: among the five Platonic solids (cube, tetrahedron, octahedron, dodecahedron, icosahedron), only the cube has Dehn invariant $D = 0$. The cube is therefore the unique Platonic solid in its scissors-congruence class — it cannot be obtained by cutting and rearranging any other Platonic solid.\n\nThe classification table in the docstring gives the complete picture: the cube's 12 edges all meet at dihedral angle $\\pi/2$ (a rational multiple of $\\pi$), giving $D = 0$. The other four solids have edges meeting at angles involving $\\arccos(1/3)$, $\\arccos(-1/3)$, $\\arccos(-1/\\sqrt{5})$, or $\\arccos(-\\sqrt{5}/3)$ — all irrational multiples of $\\pi$, giving $D \\neq 0$.\n\nThe file extends `DissectionOfCubesOQ02OQ02.lean` (which proved tetrahedron and octahedron have $D \\neq 0$) by handling the dodecahedron (new Chebyshev sequence argument for $\\arccos(3/5)/\\pi \\notin \\mathbb{Q}$) and axiomatizing the icosahedron. The namespace `DissectionOfCubesOQ04` and the open declarations bring in the Dehn infrastructure from `DissectionOfCubesOQ02` and the tensor product machinery from `DehnSydler`.",
+    "mathContext": "Classification table: Cube ($12$ edges, $\\pi/2$, $D=0$), Tetrahedron ($6$ edges, $\\arccos(1/3)$, $D\\neq 0$), Octahedron ($12$ edges, $\\arccos(-1/3) = \\pi - \\arccos(1/3)$, $D\\neq 0$), Dodecahedron ($30$ edges, $\\arccos(-1/\\sqrt{5})$, $D\\neq 0$), Icosahedron ($30$ edges, $\\arccos(-\\sqrt{5}/3)$, $D\\neq 0$). Scissors-congruence invariant: $D(P) = \\sum_e \\ell(e) \\otimes [\\theta(e)] \\in \\mathbb{R} \\otimes_{\\mathbb{Z}} (\\mathbb{R}/\\pi\\mathbb{Z})$.",
+    "significance": "context",
+    "relatedConcepts": ["Dehn invariant", "scissors congruence", "Platonic solids", "irrational angles", "Hilbert's Third Problem"],
+    "prerequisites": ["DissectionOfCubesOQ02OQ02.lean", "DehnSydler infrastructure", "Real.arccos", "Platonic solid geometry"]
+  },
+  {
     "id": "ann-chebyshev-sequence-design",
     "proofId": "dissection-of-cubes-oq-04",
     "range": { "startLine": 60, "endLine": 82 },
@@ -22,6 +34,18 @@
     "significance": "key",
     "relatedConcepts": ["modular arithmetic", "prime divisibility", "strong induction"],
     "prerequisites": ["Prime.dvd_or_dvd", "Int.Prime"]
+  },
+  {
+    "id": "ann-cos-seq-proof",
+    "proofId": "dissection-of-cubes-oq-04",
+    "range": { "startLine": 112, "endLine": 195 },
+    "type": "technique",
+    "title": "Chebyshev Cosine Identity and Irrationality Proof",
+    "content": "`cosThreeFifthsSeq_eq_cos` (lines 112–135) proves by strong induction that the integer sequence satisfies $d_k = 5^k \\cdot 2\\cos(k \\cdot \\arccos(3/5))$. The induction uses the Chebyshev cosine addition identity `cos_step` (from `DissectionOfCubesOQ02`): $2\\cos((n+2)\\theta) = 2\\cos\\theta \\cdot 2\\cos((n+1)\\theta) - 2\\cos(n\\theta)$. The base cases $d_0 = 2 = 1 \\cdot 2\\cos(0) = 2$ and $d_1 = 6 = 5 \\cdot 2 \\cdot (3/5)$ are verified by `simp` and `Real.cos_arccos`.\n\n`arccos_three_fifths_irrational` (lines 137–176) is the irrationality proof: assume $\\arccos(3/5)/\\pi = p/q \\in \\mathbb{Q}$. Then $q \\cdot \\arccos(3/5) = p \\cdot \\pi$, so $\\cos(q \\cdot \\arccos(3/5)) = \\cos(p\\pi) = \\pm 1$. From `cosThreeFifthsSeq_eq_cos`, $d_q = 5^q \\cdot \\pm 2$, so $5^q \\mid d_q$. But $5 \\nmid d_q$ for any $q$ (by `five_ndvd_cosThreeFifthsSeq`). Contradiction. The proof handles the $\\pm 1$ cases separately via `rcases hpm with h1 | h1`.\n\nLines 178–195 give the section II header with the irrationality chain comment: $\\arccos(3/5)$ irrational $\\to$ $\\arccos(-3/5)$ irrational $\\to$ $\\arccos(1/\\sqrt{5})$ irrational $\\to$ $\\arccos(-1/\\sqrt{5})$ irrational.",
+    "mathContext": "The proof structure: if $\\arccos(3/5)/\\pi = p/q$ then $\\cos(q \\cdot \\arccos(3/5)) = (-1)^{|p|}$, so $d_q = \\pm 2 \\cdot 5^q$. Since $5 \\mid 5^q$, we get $5 \\mid d_q$, contradicting $5 \\nmid d_q$. The `cos_int_mul_pi : cos(n \\cdot \\pi) = (-1)^{|n|}$` lemma handles the conversion. This is structurally Niven's theorem with $\\cos\\theta = 3/5$ and prime $p = 5$ instead of $\\cos\\theta = 1/3$ and prime $p = 3$.",
+    "significance": "key",
+    "relatedConcepts": ["Niven's theorem", "Chebyshev cosine identity", "irrationality by contradiction", "cos_int_mul_pi", "five_ndvd_cosThreeFifthsSeq"],
+    "prerequisites": ["cosThreeFifthsSeq_eq_cos", "cos_step (DissectionOfCubesOQ02)", "Real.cos_arccos", "Int.cast_ne_zero"]
   },
   {
     "id": "ann-half-angle-identity",
@@ -48,6 +72,18 @@
     "prerequisites": ["arccos_three_fifths_irrational", "two_arccos_sqrt5_eq", "Real.arccos_neg"]
   },
   {
+    "id": "ann-dehn-applications",
+    "proofId": "dissection-of-cubes-oq-04",
+    "range": { "startLine": 262, "endLine": 355 },
+    "type": "technique",
+    "title": "Applying Dehn Infrastructure: Dodecahedron and Icosahedron",
+    "content": "Having proved the angle irrationalities, the Dehn invariant non-zero results follow from the `tmul_infinite_order_ne_zero` axiom (from `DissectionOfCubesOQ02OQ02`), which formalizes the flatness of $\\mathbb{R}$ over $\\mathbb{Z}$: if $[\\theta]$ has infinite order in $\\mathbb{R}/\\pi\\mathbb{Z}$, then $\\ell \\otimes [\\theta] \\neq 0$ for any $\\ell > 0$.\n\n**dodAngle_infinite_order** (Section III): The angle class $[\\arccos(-1/\\sqrt{5})]$ in $\\mathbb{R}/\\pi\\mathbb{Z}$ has infinite order. Proved by contradiction: if $n \\cdot [\\arccos(-1/\\sqrt{5})] = 0$ for some $n \\neq 0$, then $\\arccos(-1/\\sqrt{5})/\\pi \\in \\mathbb{Q}$ — contradicting `dodAngle_irrational`. Uses `zsmul_eq_zero_iff` to connect the zero-condition to rationality.\n\n**dod_dehn_ne_zero**: The dodecahedron's edge term $\\text{edgeTerm}(30a, \\arccos(-1/\\sqrt{5})) \\neq 0$ for any $a > 0$. Immediate from `tmul_infinite_order_ne_zero` and `dodAngle_infinite_order`.\n\n**Section IV (Icosahedron)**: The icosahedron's dihedral angle $\\arccos(-\\sqrt{5}/3)$ is axiomatized (`icoAngle_irrational`) with the justification that a Chebyshev argument in $\\mathbb{Z}[\\sqrt{5}]$ would work but is deferred. The `icoAngle_infinite_order` and `ico_dehn_ne_zero` results follow the same pattern as the dodecahedron.\n\nLines 320–341 give the Section V classification header, explaining why the cube is isolated: all non-cube solids have $D \\neq 0$ while the cube has $D = 0$, so no scissors congruence can exist between them.",
+    "mathContext": "The `edgeTerm` function: $\\text{edgeTerm}(\\ell, \\theta) = \\ell \\otimes_{\\mathbb{Z}} [\\theta]$ in $\\mathbb{R} \\otimes_{\\mathbb{Z}} (\\mathbb{R}/\\pi\\mathbb{Z})$. By the `tmul_infinite_order_ne_zero` axiom (flatness of $\\mathbb{R}$ over $\\mathbb{Z}$): if $n \\cdot [\\theta] \\neq 0$ for all $n \\neq 0$, then $\\ell \\otimes [\\theta] \\neq 0$ for all $\\ell > 0$. The group $\\mathbb{R}/\\pi\\mathbb{Z}$ is divisible and torsion-free over $\\mathbb{Q}$; irrational angles have infinite order since $n \\cdot [\\theta] = 0$ iff $n\\theta \\in \\pi\\mathbb{Z}$ iff $\\theta/\\pi \\in \\mathbb{Q}$.",
+    "significance": "key",
+    "relatedConcepts": ["edgeTerm", "tmul_infinite_order_ne_zero", "infinite order in ℝ/πℤ", "DehnSydler", "zsmul_eq_zero_iff"],
+    "prerequisites": ["DissectionOfCubesOQ02OQ02 DehnSydler", "tmul_infinite_order_ne_zero", "dodAngle_irrational", "icoAngle_irrational"]
+  },
+  {
     "id": "ann-classification-table",
     "proofId": "dissection-of-cubes-oq-04",
     "range": { "startLine": 356, "endLine": 395 },
@@ -55,8 +91,20 @@
     "title": "Complete Platonic Solid Classification",
     "content": "The theorem cube_isolated_dehn_invariant packages the complete 5-solid classification into a single conjunction. The cube (12 edges, π/2 dihedral) has D = 0; all other Platonic solids have D ≠ 0. The tetrahedron and octahedron results come from OQ02OQ02; the dodecahedron is new in this file; the icosahedron uses the axiomatized angle irrationality. The classification has an immediate geometric consequence: no scissors-congruence exists between the cube and any other Platonic solid.",
     "mathContext": "Five Platonic solids (V-E+F = 2): Cube (8-12+6=2, π/2), Tetrahedron (4-6+4=2, arccos(1/3)), Octahedron (6-12+8=2, arccos(-1/3)), Dodecahedron (20-30+12=2, arccos(-1/√5)), Icosahedron (12-30+20=2, arccos(-√5/3)). All non-cube angles are irrational multiples of π, giving nonzero Dehn invariants. The cube's angle π/2 = (1/2)π is rational, giving D = 0.",
-    "significance": "main-result",
+    "significance": "key",
     "relatedConcepts": ["Platonic solids", "Dehn invariant", "scissors congruence", "Hilbert's third problem"],
     "prerequisites": ["cube_dehn_zero", "tet_dehn_ne_zero", "oct_dehn_ne_zero", "dod_dehn_ne_zero", "ico_dehn_ne_zero"]
+  },
+  {
+    "id": "ann-axiom-audit",
+    "proofId": "dissection-of-cubes-oq-04",
+    "range": { "startLine": 395, "endLine": 436 },
+    "type": "context",
+    "title": "Axiom Budget and Verification Checks",
+    "content": "The closing section provides a complete axiom audit. Two axioms are used: `icoAngle_irrational` (introduced here, for $\\arccos(-\\sqrt{5}/3)/\\pi \\notin \\mathbb{Q}$) and `tmul_infinite_order_ne_zero` (inherited from `DissectionOfCubesOQ02OQ02`, encoding flatness of $\\mathbb{R}$ over $\\mathbb{Z}$). There are 3 sorries in `cube_unique_zero_dehn` relating to general edge-term scaling lemmas — these are non-critical since `cube_isolated_dehn_invariant` (the main classification theorem) is fully proved without sorry.\n\nThe `#check` commands at lines 431–435 serve as final verification markers: `arccos_three_fifths_irrational`, `dodAngle_irrational`, `dod_dehn_ne_zero`, and `cube_isolated_dehn_invariant` all type-check, confirming that the main chain of results is well-formed. The `cube_isolated_dehn_invariant` uses the pair `(a : ℝ)` `(ha : a > 0)` as a witness for edge length, making the theorem universally quantified over positive edge lengths.",
+    "mathContext": "Axiom status: $\\text{axiomCount} = 2$. `tmul_infinite_order_ne_zero` formalizes: $\\ell > 0$, $n \\cdot [\\theta] \\neq 0$ for all $n \\neq 0$ $\\Rightarrow$ $\\ell \\otimes [\\theta] \\neq 0$ in $\\mathbb{R} \\otimes_{\\mathbb{Z}} (\\mathbb{R}/\\pi\\mathbb{Z})$. This is a consequence of $\\mathbb{R}$ being a flat $\\mathbb{Z}$-module (torsion-free). The 3 sorries in `cube_unique_zero_dehn` concern general-$n$ edge term scaling: $\\text{edgeTerm}(n \\cdot a, \\theta) \\neq 0$ for $n > 0$, $a > 0$ — provable from bilinearity of the tensor product and non-zero results proved individually.",
+    "significance": "technical",
+    "relatedConcepts": ["axiom budget", "flatness over ℤ", "tensor product bilinearity", "#check", "cube_unique_zero_dehn"],
+    "prerequisites": ["DissectionOfCubesOQ02OQ02 tmul_infinite_order_ne_zero", "axiom icoAngle_irrational", "cube_isolated_dehn_invariant"]
   }
 ]

--- a/src/data/proofs/dissection-of-cubes-oq-04/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-04/meta.json
@@ -142,7 +142,30 @@
     "summary": "Among the five Platonic solids, the cube is uniquely characterized by having zero Dehn invariant. This extends Hilbert's Third Problem from the single pair (cube, tetrahedron) to the complete classification of all Platonic solids under scissors congruence.",
     "openQuestions": [
       "Can the remaining axiom (tmul_infinite_order_ne_zero — flatness of ℝ over ℤ) be proved using Mathlib's Module.Flat infrastructure?",
-      "Can icoAngle_irrational be proved by extending the Chebyshev argument to ℤ[√5], completing the proof for all five Platonic solids with 0 axioms?"
+      "Can icoAngle_irrational be proved by extending the Chebyshev argument to ℤ[√5], completing the proof for all five Platonic solids with 0 axioms?",
+      "The Sydler–Jessen theorem (1965/1968) shows the Dehn invariant is a complete scissors-congruence invariant in 3D: two polyhedra are scissors congruent if and only if they have the same volume AND the same Dehn invariant. Can this completeness result be formalized to give a decision procedure for Platonic solid scissors congruence?"
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "dissection-of-cubes",
+      "relationship": "parent-problem",
+      "description": "The parent dissection-of-cubes entry states the scissors-congruence problem for cubes generally. This file answers it specifically for all five Platonic solids."
+    },
+    {
+      "targetId": "dissection-of-cubes-oq-02",
+      "relationship": "foundational",
+      "description": "3D Shape Dissection: Dehn Invariant and Hilbert's Third Problem — proves the basic Niven theorem for arccos(1/3)/π irrational and the cube/tetrahedron non-scissors-congruence result. The cosThreeFifthsSeq Chebyshev argument in this file is directly modeled on the nivenSeq technique introduced there."
+    },
+    {
+      "targetId": "dissection-of-cubes-oq-02-oq-02",
+      "relationship": "foundational",
+      "description": "Dehn-Sydler Completeness: Tensor Product Dehn Invariant — provides the DehnSydler infrastructure (edgeTerm, tmul_infinite_order_ne_zero, and the tetrahedron/octahedron results) that this file extends to the dodecahedron and icosahedron."
+    },
+    {
+      "targetId": "dissection-of-cubes-oq-03",
+      "relationship": "sibling",
+      "description": "Cube Dissection and Packing: Connections to Impossibility — a sibling entry exploring related dissection impossibility results and packing connections, complementing this file's algebraic angle-irrationality approach."
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass for **dissection-of-cubes-oq-04** (Dehn Invariants for Platonic Solids: Cube Isolation).

## Changes

### New annotations (4)
- **ann-module-header** (lines 1–59): Context annotation covering the classification table in the docstring, imports, and namespace setup
- **ann-cos-seq-proof** (lines 112–195): Covers `cosThreeFifthsSeq_eq_cos` (strong induction with Chebyshev cosine identity) and `arccos_three_fifths_irrational` (contradiction via $d_q = \pm 2 \cdot 5^q$ forcing $5 \mid d_q$); includes mathContext tying it structurally to Niven's theorem
- **ann-dehn-applications** (lines 262–355): Covers the dodecahedron and icosahedron Dehn invariant results, explaining how `tmul_infinite_order_ne_zero` (flatness axiom) converts infinite-order angle class results into nonzero tensor products; also covers the Section V classification header
- **ann-axiom-audit** (lines 395–436): Covers the axiom budget section and `#check` verification markers at the end of the file

### Schema fix
- Changed `significance: "main-result"` → `"key"` in `ann-classification-table` (invalid enum value)

### Cross-references added (4)
- `dissection-of-cubes` — parent problem
- `dissection-of-cubes-oq-02` — Niven's theorem and nivenSeq technique this file builds on
- `dissection-of-cubes-oq-02-oq-02` — DehnSydler infrastructure provider
- `dissection-of-cubes-oq-03` — sibling impossibility entry

### Open question added
- Formalizing the Sydler–Jessen completeness theorem: Dehn invariant is a complete scissors-congruence invariant in 3D (not just necessary, but sufficient)

## Verification
- `pnpm build` passed (5m 5s, exit 0)
- JSON validity confirmed