### PR TITLE
Enrich 2 entries: dissection-of-cubes-oq-04 + sperner-ndim-oq-04

### DIFF
--- a/src/data/proofs/sperner-ndim-oq-04/annotations.json
+++ b/src/data/proofs/sperner-ndim-oq-04/annotations.json
@@ -1,46 +1,110 @@
-{
-  "annotations": [
-    {
-      "id": "ann-kuhn-compatible-def",
-      "type": "insight",
-      "title": "Kuhn Compatibility Axiom",
-      "content": "A Sperner triangulation is Kuhn-compatible if each simplex has door degree ≤ 2. This is the key axiom that makes the path-following algorithm deterministic: each simplex has at most 2 doors, so entering through one uniquely determines the exit.",
-      "tags": ["kuhn", "door-graph", "axiom"]
-    },
-    {
-      "id": "ann-door-degree-parity",
-      "type": "technique",
-      "title": "Door Degree Parity from Abstract Theorem",
-      "content": "The door degree of a simplex satisfies: FC simplices have odd degree, non-FC simplices have even degree. Under Kuhn compatibility (degree ≤ 2), this gives exact counts: FC = 1 door, non-FC = 0 or 2 doors.",
-      "tags": ["door-parity", "abstract-door-parity", "fc-characterization"]
-    },
-    {
-      "id": "ann-unique-exit",
-      "type": "result",
-      "title": "Unique Exit Door (existsUnique)",
-      "content": "The formal statement that Kuhn's algorithm is deterministic: any non-FC simplex with an entry door k_in has a UNIQUE other door k_out ≠ k_in. Proved using Finset.card_eq_two to extract both elements of the 2-element door set.",
-      "tags": ["unique-exit", "determinism", "finset-card"]
-    },
-    {
-      "id": "ann-fuel-recursion",
-      "type": "technique",
-      "title": "Fuel-Based Recursion for Path Definition",
-      "content": "The kuhnWalk definition uses a fuel parameter (maximum steps) to avoid well-founded recursion obligations. With fuel = Fintype.card K.Simplex, sufficient fuel is guaranteed by the non-revisiting invariant (each step visits a new simplex).",
-      "tags": ["termination", "fuel-recursion", "well-founded"]
-    },
-    {
-      "id": "ann-non-revisiting",
-      "type": "insight",
-      "title": "Non-Revisiting Invariant (Key Open Problem)",
-      "content": "The hard part of formalizing Kuhn's algorithm is proving the non-revisiting invariant: the walk never visits a simplex twice. This follows from the door graph structure: the component containing a boundary door is a path (not a cycle), because the boundary door is a degree-1 vertex with no return path.",
-      "tags": ["non-revisiting", "open-problem", "door-graph-cycles"]
-    },
-    {
-      "id": "ann-door-preservation",
-      "type": "technique",
-      "title": "Door Property Preservation Across Steps",
-      "content": "The door_transfer lemma from SpernerNDim ensures: if K.adj s k = some (s', k') and isDoorAt c K s k, then isDoorAt c K s' k'. This allows the algorithm to maintain its invariants across each step.",
-      "tags": ["door-transfer", "invariant-preservation"]
-    }
-  ]
-}
+[
+  {
+    "id": "ann-kuhn-module-overview",
+    "proofId": "sperner-ndim-oq-04",
+    "range": { "startLine": 1, "endLine": 51 },
+    "type": "concept",
+    "title": "Kuhn's Path-Following Algorithm: Constructive Sperner's Lemma",
+    "content": "The module header succinctly captures why Kuhn's 1968 result matters: it gives a CONSTRUCTIVE proof of Sperner's lemma. The non-constructive proof (using a parity argument over door counts) shows that a fully-colored simplex must exist, but does not find it. Kuhn's algorithm finds it in polynomial time by following a deterministic path through the door graph from a known boundary door to an FC simplex.\n\nThe door graph structure is described precisely: each simplex has a 'door degree' (number of facets where the opposite face carries all d colors). The abstract door parity theorem guarantees FC simplices have odd degree and non-FC have even degree. Under the Kuhn compatibility axiom (degree ≤ 2), this forces FC = degree 1 (terminal) and non-FC = degree 0 or 2 (isolated or pass-through).",
+    "mathContext": "A door at (s, k) means the d vertices of s excluding vertex k carry all d colors {0,...,d-1}. Interior doors pair with adjacent simplex doors via K.adj. Boundary doors (K.adj s k = none) are degree-1 in the door graph. The Kuhn walk starts at a boundary door and follows the unique path: enter through one door, exit through the unique other (for non-FC simplices), until reaching an FC simplex (degree 1, no exit).",
+    "significance": "key",
+    "relatedConcepts": ["Sperner's lemma", "door graph", "path-following algorithms", "constructive proofs", "fixed-point computation"],
+    "prerequisites": ["SpernerNDim.lean abstract door parity", "IsKuhnCompatible axiom"]
+  },
+  {
+    "id": "ann-kuhn-compatible-def",
+    "proofId": "sperner-ndim-oq-04",
+    "range": { "startLine": 59, "endLine": 67 },
+    "type": "definition",
+    "title": "doorDegree and IsKuhnCompatible: Bounding the Door Graph Degree",
+    "content": "The `doorDegree` function counts how many facets of a simplex carry a door — it's the degree of the simplex in the door graph. `IsKuhnCompatible` asserts this degree is at most 2 for every simplex. This is the key structural axiom that makes Kuhn's algorithm deterministic: with at most 2 doors, entering through one uniquely determines the exit (if any).\n\nIn practice, Freudenthal triangulations (and many standard triangulations) are Kuhn-compatible. The compatibility axiom is an abstract property of the triangulation type, so the theorem applies to any compatible triangulation.",
+    "mathContext": "$\\text{doorDegree}(c, K, s) = |\\{k : \\text{isDoorAt}(c, K, s, k)\\}|$. IsKuhnCompatible: $\\forall s, \\text{doorDegree}(c, K, s) \\leq 2$. In the door graph $G$: vertices are (simplex, facet) pairs, edges connect adjacent door pairs via K.adj. IsKuhnCompatible ≡ max vertex degree ≤ 2, making $G$ a disjoint union of paths and cycles.",
+    "significance": "key",
+    "relatedConcepts": ["door graph", "degree bound", "Freudenthal triangulation", "IsKuhnCompatible"],
+    "prerequisites": ["isDoorAt (from SpernerNDim)", "SpernerTriangulation.adj"]
+  },
+  {
+    "id": "ann-door-parity",
+    "proofId": "sperner-ndim-oq-04",
+    "range": { "startLine": 70, "endLine": 90 },
+    "type": "technique",
+    "title": "Deriving Per-Simplex Door Parity from the Abstract Theorem",
+    "content": "The `door_degree_parity` lemma translates the abstract door parity theorem (from SpernerNDim) into the concrete statement about doorDegree. The key step is proving that the Finset filter for isDoorAt matches the abstract condition (surjectivity of the coloring restricted to the d facets), allowing a direct `convert` from the abstract theorem.\n\nThe abstract theorem states that for any coloring f: Fin(d+1) → Fin(d), the number of indices k such that f∣_{Fin(d+1)∖{k}} is surjective has the same parity as the surjectivity of f itself. This is applied with f = c ∘ K.vertices s.",
+    "mathContext": "Abstract theorem: $|\\{k : f|_{[d+1]\\setminus\\{k\\}} \\text{ surjective}\\}| \\equiv [f \\text{ surjective}] \\pmod{2}$. Applied with $f = c \\circ K.\\text{vertices}(s)$: $\\text{doorDegree}(c,K,s) \\equiv [\\text{IsFC}(c,K,s)] \\pmod{2}$. FC ↔ surjective ↔ odd door degree; non-FC ↔ not surjective ↔ even door degree.",
+    "significance": "supporting",
+    "relatedConcepts": ["abstract_door_parity", "IsFC", "parity argument", "surjective coloring"],
+    "prerequisites": ["abstract_door_parity (SpernerNDim)", "IsFC definition"]
+  },
+  {
+    "id": "ann-door-counts",
+    "proofId": "sperner-ndim-oq-04",
+    "range": { "startLine": 92, "endLine": 114 },
+    "type": "technique",
+    "title": "Exact Door Counts via Parity + Degree Bound",
+    "content": "The two theorems `fc_door_count_eq_one` and `nonfc_door_count_zero_or_two` are straightforward omega arguments: combining 'door degree is odd/even' (from door_degree_parity) with 'door degree ≤ 2' (from IsKuhnCompatible), the only solutions are 1 (for FC) or 0/2 (for non-FC).\n\nThe elegance is that both proofs are single `omega` calls after unfolding the hypotheses. This is characteristic of Lean 4 proofs that reduce to linear arithmetic: once the constraints are stated correctly, omega handles all the case analysis automatically.",
+    "mathContext": "FC case: $\\text{doorDeg} \\equiv 1 \\pmod{2}$ and $\\text{doorDeg} \\leq 2$ ⟹ $\\text{doorDeg} \\in \\{1\\}$ (since 3 > 2). Non-FC case: $\\text{doorDeg} \\equiv 0 \\pmod{2}$ and $\\text{doorDeg} \\leq 2$ ⟹ $\\text{doorDeg} \\in \\{0, 2\\}$. Both proofs: one omega call combining hpar (parity) and hle (degree bound).",
+    "significance": "supporting",
+    "relatedConcepts": ["omega tactic", "Nat.mod", "linear arithmetic", "case analysis"],
+    "prerequisites": ["door_degree_parity", "IsKuhnCompatible", "omega"]
+  },
+  {
+    "id": "ann-unique-exit",
+    "proofId": "sperner-ndim-oq-04",
+    "range": { "startLine": 119, "endLine": 178 },
+    "type": "technique",
+    "title": "Unique Exit Door: The Determinism Core of Kuhn's Algorithm",
+    "content": "The theorem `nonfc_with_door_has_unique_exit` is the mathematical heart of Kuhn's algorithm: it proves that any non-FC simplex with an entry door has exactly one other door. The proof uses `Finset.card_eq_two` to decompose the 2-element door set and then case-splits on which element is the entry door.\n\nThe `∃!` (exists unique) formulation is precise: k_out ≠ k_in and isDoorAt c K s k_out, and uniqueness holds for any other door. The proof handles both cases (k_in = k₁ or k_in = k₂) symmetrically, using simp to simplify the membership of the {k₁, k₂} pair.",
+    "mathContext": "Proof sketch: (1) If doorDeg = 0: contradicts k_in being a door (card_pos argument). (2) If doorDeg = 2: apply card_eq_two to get k₁, k₂. Since k_in ∈ {k₁, k₂}, by cases k_in = k₁ (exit = k₂) or k_in = k₂ (exit = k₁). Uniqueness: any other door must be in {k₁, k₂} and ≠ k_in, so it equals the exit. The ∃! is the formal statement that Kuhn's algorithm is **deterministic**.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.card_eq_two", "existsUnique", "determinism", "2-element sets"],
+    "prerequisites": ["nonfc_door_count_zero_or_two", "Finset.card_eq_two", "Finset.min'_mem"]
+  },
+  {
+    "id": "ann-door-transfer",
+    "proofId": "sperner-ndim-oq-04",
+    "range": { "startLine": 183, "endLine": 202 },
+    "type": "technique",
+    "title": "Door Transfer: Adjacency Preserves the Door Property",
+    "content": "The `door_transfer` lemma establishes that the door property is symmetric across adjacency: if K.adj s k = some (s', k'), then isDoorAt c K s k ↔ isDoorAt c K s' k'. This is proved by showing that the d-vertex images of (s excluding k) and (s' excluding k') are equal, which is exactly the definition of K.adj_vertices.\n\nThis lemma is re-proved locally because the version in SpernerNDim is private. The proof uses `local_door_transfer_one_dir` for both directions: if the two vertex images are equal, a door at one implies a door at the other (the required color can be found in either simplex).",
+    "mathContext": "K.adj_vertices guarantees: K.adj s k = some (s', k') ⟹ (Finset.univ.erase k).image (K.vertices s) = (Finset.univ.erase k').image (K.vertices s'). This equal image condition means the same set of d colors is available at both (s,k) and (s',k'), so isDoorAt c K s k ↔ isDoorAt c K s' k'.",
+    "significance": "supporting",
+    "relatedConcepts": ["adjacency", "door property", "SpernerTriangulation.adj_vertices", "symmetry"],
+    "prerequisites": ["SpernerTriangulation.adj_vertices", "isDoorAt definition"]
+  },
+  {
+    "id": "ann-kuhn-step",
+    "proofId": "sperner-ndim-oq-04",
+    "range": { "startLine": 207, "endLine": 244 },
+    "type": "definition",
+    "title": "kuhnStep: One Deterministic Step of the Algorithm",
+    "content": "The `kuhnStep` function implements one step: if s is FC, return None (done); otherwise find the unique exit door k_out using Finset.min' on the exit_doors filter, then return K.adj s k_out. The use of Finset.min' (minimum element) is a standard Lean 4 pattern for extracting an element from a nonempty Finset with a well-defined choice.\n\nThe companion lemma `kuhnStep_door_preserved` shows the next step's entry door (k_out') maintains the door property — using the nonfc_with_door_has_unique_exit result to prove exit_doors is nonempty, then applying door_transfer to conclude isDoorAt at the new simplex.",
+    "mathContext": "kuhnStep returns: None if IsFC s (terminal state); Some (s', k_out') where k_out = exit_doors.min' (the minimum exit door index) and K.adj s k_out = some (s', k_out'). The door preservation: isDoorAt c K s k_out (from filter membership) + K.adj s k_out = some (s', k_out') + door_transfer ⟹ isDoorAt c K s' k_out'.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.min'", "option type", "step function", "invariant preservation"],
+    "prerequisites": ["nonfc_with_door_has_unique_exit", "door_transfer", "Finset.min'_mem"]
+  },
+  {
+    "id": "ann-kuhn-walk",
+    "proofId": "sperner-ndim-oq-04",
+    "range": { "startLine": 250, "endLine": 297 },
+    "type": "definition",
+    "title": "KuhnState and kuhnWalk: Fuel-Based Path Following",
+    "content": "The `KuhnState` structure captures the full algorithm state: current simplex, entry door (with proof it's a door), and visited set (with proof current is not in visited). The visited set enforces the non-revisiting invariant: if the next simplex is already visited, the walk terminates early (a safety guard).\n\nThe `kuhnWalk` function uses a fuel parameter to avoid well-founded recursion obligations. With fuel = Fintype.card K.Simplex (at most as many simplices as exist), sufficient fuel is guaranteed if the non-revisiting invariant holds — each step visits a new simplex, so at most |K.Simplex| steps are needed. The fuel approach avoids proving termination upfront, deferring it to the correctness theorem.",
+    "mathContext": "Fuel-based recursion: kuhnWalk fuel state matches on fuel (0 → terminate; n+1 → step or continue). When fuel = Fintype.card K.Simplex and the walk is non-revisiting: each step adds one simplex to visited, so after ≤ Fintype.card K.Simplex steps, either FC is found or fuel runs out. The non-revisiting guard (hs' : s' ∉ visited ∪ {current}) catches would-be revisits, terminating early.",
+    "significance": "key",
+    "relatedConcepts": ["fuel-based recursion", "well-founded recursion", "Fintype.card", "visited set", "termination"],
+    "prerequisites": ["KuhnState structure", "kuhnStep", "door_transfer"]
+  },
+  {
+    "id": "ann-main-theorems",
+    "proofId": "sperner-ndim-oq-04",
+    "range": { "startLine": 299, "endLine": 389 },
+    "type": "insight",
+    "title": "Main Theorems and the Non-Revisiting Invariant",
+    "content": "The three sorry-using theorems represent what remains to be proved:\n\n1. `kuhn_path_terminates`: Existence of an FC simplex, derived from the boundary door assumption and sperner_ndim. Currently sorry'd; could be filled by applying sperner_ndim directly (parity of boundary door count implies FC existence).\n\n2. `kuhn_walk_reaches_fc`: The walk with sufficient fuel actually reaches an FC simplex. This requires the non-revisiting invariant: the door graph path from a boundary vertex has no cycles. This is the core open sorry.\n\n3. `kuhnPathStart_is_fc`: The top-level correctness theorem combining the start condition and the walk result.\n\nThe non-revisiting invariant is why Kuhn's algorithm works: the door graph component containing a boundary door is a path (not a cycle), because any cycle would require an even number of boundary vertices, but each path component has exactly 2 endpoints and the boundary door provides only 1.",
+    "mathContext": "The door graph G has: interior edges (from K.adj), boundary half-edges (from K.adj = none). Each vertex has degree ≤ 2 under IsKuhnCompatible. The boundary vertex (K.adj s₀ k₀ = none) has degree 1 in G. In a graph with max degree 2, components are paths and cycles; degree-1 vertices force the component to be a path. The path starts at the boundary door and ends at either another boundary door or an FC simplex (degree 1). Since only one boundary door was given as a starting point, the path terminus must be an FC simplex.",
+    "significance": "main-result",
+    "relatedConcepts": ["non-revisiting invariant", "path-cycle decomposition", "door graph components", "Sperner's lemma"],
+    "prerequisites": ["kuhnWalk", "IsKuhnCompatible", "sperner_ndim (existence)", "door graph structure"]
+  }
+]

--- a/src/data/proofs/sperner-ndim-oq-04/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-04/meta.json
@@ -141,18 +141,30 @@
       "significance": "Main correctness theorem for Kuhn's algorithm (sorry pending non-revisiting invariant)"
     }
   ],
-  "relatedProofs": [
+  "conclusion": {
+    "summary": "This formalization establishes the door-counting infrastructure for Kuhn's constructive proof of n-dimensional Sperner's lemma. The fully-proved results (fc_door_count_eq_one, nonfc_door_count_zero_or_two, nonfc_with_door_has_unique_exit) rigorously verify that Kuhn's algorithm is well-defined and deterministic. Three sorries remain for the termination/correctness theorems, pending formalization of the non-revisiting invariant.",
+    "implications": "Kuhn's 1968 result is historically significant as the first polynomial-time algorithm for finding a fully-colored simplex. Path-following algorithms descended from Kuhn's work underlie Scarf's algorithm for computing approximate fixed points and (through Lemke-Howson) Nash equilibrium computation. The abstract formulation using IsKuhnCompatible applies to any Sperner triangulation satisfying the degree bound, including Freudenthal triangulations and simplicial complexes arising in topological data analysis.",
+    "openQuestions": [
+      "Can the non-revisiting invariant (the door graph component containing a boundary door is a path) be proved in Lean 4 using graph theory from Mathlib?",
+      "Does the Freudenthal triangulation from sperner-ndim-oq-01 satisfy IsKuhnCompatible, allowing Kuhn's algorithm to apply concretely in dimension d?",
+      "Can kuhn_path_terminates be derived directly from sperner_ndim (existence of FC simplex) without the full non-revisiting argument?"
+    ]
+  },
+  "crossReferences": [
     {
-      "id": "sperner-ndim",
-      "relationship": "Builds on abstract SpernerTriangulation and uses abstract_door_parity"
+      "targetId": "sperner-ndim",
+      "relationship": "extends",
+      "description": "Builds directly on SpernerNDim's abstract SpernerTriangulation, uses abstract_door_parity theorem, and applies sperner_ndim existence result"
     },
     {
-      "id": "sperner-ndim-oq-01",
-      "relationship": "Freudenthal triangulation satisfies adjacency requirements; likely satisfies IsKuhnCompatible"
+      "targetId": "sperner-ndim-oq-01",
+      "relationship": "related",
+      "description": "Freudenthal triangulation satisfies adjacency requirements; likely satisfies IsKuhnCompatible, making Kuhn's algorithm concrete in dimension d"
     },
     {
-      "id": "sperner-ndim-oq-03",
-      "relationship": "Displacement coloring uses similar door structure for Brouwer FPT"
+      "targetId": "sperner-ndim-oq-03",
+      "relationship": "related",
+      "description": "Displacement coloring uses similar door structure for Brouwer fixed-point theorem; both entries work within the abstract SpernerTriangulation framework"
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for two gallery entries.

## Entry 1: dissection-of-cubes-oq-04 (Dehn Invariants: Cube Isolation)

Added 4 annotations for previously uncovered code sections:
- **ann-header** [1-59]: module overview with classification table context; axiom budget transparency
- **ann-cos-relation-proof** [113-175]: paired strong induction for cosine relation
- **ann-dehn-application** [261-320]: flatness axiom → nonzero Dehn invariant; icosahedron axiom justification
- **ann-axiom-audit** [396-437]: explicit axiom budget commentary

Added to meta.json: `conclusion.implications`, 5 `crossReferences` (targetId format), 3rd openQuestion.

## Entry 2: sperner-ndim-oq-04 (Kuhn Path-Following Algorithm)

**Primary fix**: annotations.json was in broken format (`{ "annotations": [...] }` wrapper instead of flat array). All annotations also lacked required fields (`proofId`, `range`, `mathContext`, etc.).

Rewrote with 9 annotations covering full file (lines 1–389):
- Algorithm overview, IsKuhnCompatible definition, door parity translation
- FC/non-FC exact door counts, unique exit door determinism theorem
- Door transfer lemma, kuhnStep, KuhnState/kuhnWalk fuel recursion
- Main sorry theorems with non-revisiting invariant explanation

Added `conclusion` field and `crossReferences` (targetId format) to meta.json.

## Axiom Integrity

Both entries correctly reflect their axiom/sorry status. No overclaiming.