### PR TITLE
Fix: correct TypeScript types in sperner-ndim-oq-04 index.ts

### DIFF
--- a/src/data/proofs/sperner-ndim-oq-04/index.ts
+++ b/src/data/proofs/sperner-ndim-oq-04/index.ts
@@ -15,7 +15,7 @@ const meta = metaJson as {
   crossReferences?: CrossReference[]
 }
 
-export const spernerNdimOq04Proof: Proof = {
+export const proof: Proof = {
   id: meta.id,
   title: meta.title,
   slug: meta.slug,
@@ -26,7 +26,13 @@ export const spernerNdimOq04Proof: Proof = {
   overview: meta.overview,
   conclusion: meta.conclusion,
   crossReferences: meta.crossReferences || [],
-  annotations: (annotationsJson as { annotations: Annotation[] }).annotations || [],
 }
 
-export default spernerNdimOq04Proof
+export const annotations: Annotation[] = (annotationsJson as unknown as { annotations: Annotation[] }).annotations || []
+
+export const proofData: ProofData = {
+  proof,
+  annotations,
+}
+
+export default proofData


### PR DESCRIPTION
## Summary
- Remove `annotations` from `Proof` object (not part of the interface)
- Export annotations separately and wrap in `ProofData` following established pattern
- Fixes build failure from #11406

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] `pnpm build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)