### PR TITLE
Research: Multivariate Gaussian Integral — proved (0 sorries)

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ05OQ02.lean
+++ b/proofs/Proofs/AreaOfCircleOQ05OQ02.lean
@@ -19,10 +19,10 @@ for any positive-definite real symmetric matrix A.
    The orthogonal change of variables y = Uᵀx preserves Lebesgue measure
    (|det Uᵀ| = 1). Then xᵀAx = yᵀDy = ∑ λᵢyᵢ², and det A = ∏ λᵢ.
 
-## Status
+## Status (all proved, 0 sorries)
 - `prod_sqrt_eq_sqrt_prod` : proved (induction on n)
 - `diagonal_gaussian` : proved (Fubini + scalar Gaussian)
-- `multivariate_gaussian_integral` : 1 sorry (spectral change of variables)
+- `multivariate_gaussian_integral` : proved (spectral decomposition + orthogonal change of variables)
 
 Parent: AreaOfCircleOQ05.lean
 -/
@@ -99,7 +99,7 @@ theorem diagonal_gaussian {n : ℕ} (b : Fin n → ℝ) (hb : ∀ i, 0 < b i) :
 
         ∫ x : Fin n → ℝ, exp(-xᵀAx) = √(πⁿ / det A)
 
-    **Proof outline** (1 sorry remaining):
+    **Proof outline**:
     1. Spectral theorem: A = U * diag(λ) * Uᵀ where U is unitary (orthogonal for ℝ)
        and all eigenvalues λᵢ > 0 (since A is positive-definite).
     2. Quadratic form: xᵀAx = (Uᵀx)ᵀ diag(λ) (Uᵀx) = ∑ᵢ λᵢ (Uᵀx)ᵢ².
@@ -108,31 +108,82 @@ theorem diagonal_gaussian {n : ℕ} (b : Fin n → ℝ) (hb : ∀ i, 0 < b i) :
     4. Apply diagonal_gaussian with b = eigenvalues.
     5. det A = ∏ λᵢ by IsHermitian.det_eq_prod_eigenvalues.
 
-    **Remaining sorry**: The measure-preserving change of variables
-    `∫ x, f(Uᵀx) = ∫ y, f(y)` requires constructing the MeasurableEquiv
-    from the orthogonal map and proving measure preservation via
-    `map_linearMap_volume_pi_eq_smul_volume_pi` with |det Uᵀ| = 1. -/
+    The measure-preserving change of variables uses `map_linearMap_volume_pi_eq_smul_volume_pi`
+    with |det Uᵀ| = 1, together with `integral_map` to substitute y = Uᵀx. -/
 theorem multivariate_gaussian_integral {n : ℕ} (A : Matrix (Fin n) (Fin n) ℝ)
     (hA : A.PosDef) :
     ∫ x : Fin n → ℝ, Real.exp (-(dotProduct x (A.mulVec x))) =
     Real.sqrt (Real.pi ^ n / A.det) := by
-  -- Let hAsymm := hA.isHermitian (over ℝ: IsHermitian = IsSymm)
-  -- Let U = hAsymm.eigenvectorUnitary : Matrix (Fin n) (Fin n) ℝ
-  -- Let λ = hAsymm.eigenvalues : Fin n → ℝ, with all λᵢ > 0
-  -- Spectral theorem: A = conjStarAlgAut ℝ _ U (diagonal (RCLike.ofReal ∘ λ))
-  -- Key steps:
-  --   (a) Rewrite xᵀAx = ∑ᵢ λᵢ ((U*ᵥx)ᵢ)² (quadratic form in eigenbasis)
-  --   (b) Change variables: ∫ x, f(Uᵀ *ᵥ x) = ∫ y, f y (measure-preserving)
-  --   (c) Apply diagonal_gaussian with b = eigenvalues
-  --   (d) Use det A = ∏ eigenvalues
-  --
-  -- SORRY: spectral decomposition + orthogonal change of variables
-  -- Needed:
-  --   · hAsymm.spectral_theorem (A = U * diag(λ) * U*)
-  --   · Matrix.PosDef.eigenvalues_pos (all λᵢ > 0)
-  --   · Matrix.IsHermitian.det_eq_prod_eigenvalues (det A = ∏ λᵢ, cast to ℝ)
-  --   · map_linearMap_volume_pi_eq_smul_volume_pi with |det U| = 1
-  --   · MeasurePreserving.integral_comp' to rewrite the integral
-  sorry
+  classical
+  have hS := hA.isHermitian
+  -- Abbreviation: U = underlying matrix of the eigenvector unitary
+  let U : Matrix (Fin n) (Fin n) ℝ := hS.eigenvectorUnitary
+  -- Step 1: det A = ∏ eigenvalues
+  have hdet : A.det = ∏ i, hS.eigenvalues i := by
+    have h := hS.det_eq_prod_eigenvalues (𝕜 := ℝ)
+    simp_rw [show ∀ x : ℝ, @RCLike.ofReal ℝ _ x = x from
+      fun x => congr_fun RCLike.ofReal_real_eq_id x] at h
+    exact h
+  rw [hdet]
+  -- Step 2: Spectral decomposition A = U * diagonal(λ) * Uᵀ
+  have hA_eq : A = U * diagonal hS.eigenvalues * Uᵀ := by
+    have h := hS.spectral_theorem (𝕜 := ℝ)
+    simp only [Unitary.conjStarAlgAut_apply, RCLike.ofReal_real_eq_id, Function.id_comp] at h
+    rw [Matrix.star_eq_conjTranspose, Matrix.conjTranspose_eq_transpose_of_trivial] at h
+    exact h
+  -- Quadratic form: x ⬝ᵥ A *ᵥ x = ∑ i, λᵢ * (Uᵀ *ᵥ x)ᵢ²
+  have hquad : ∀ x : Fin n → ℝ,
+      dotProduct x (A.mulVec x) =
+      ∑ i, hS.eigenvalues i * (Uᵀ.mulVec x i) ^ 2 := by
+    intro x
+    conv_lhs => rw [hA_eq]
+    simp only [← Matrix.mulVec_mulVec]
+    rw [Matrix.dotProduct_mulVec]
+    -- x ᵥ* U = Uᵀ *ᵥ x  [vecMul_transpose with A := Uᵀ gives x ᵥ* (Uᵀ)ᵀ = Uᵀ *ᵥ x]
+    have hvec : x ᵥ* U = Uᵀ.mulVec x := by
+      have h := Matrix.vecMul_transpose Uᵀ x
+      simp only [Matrix.transpose_transpose] at h; exact h
+    rw [hvec]
+    -- Simplify diagonal application: (Uᵀx) ⬝ᵥ (diag(λ) *ᵥ (Uᵀx)) = ∑ λᵢ (Uᵀx)ᵢ²
+    simp only [dotProduct, Matrix.mulVec_diagonal]
+    congr 1; ext i; ring
+  simp_rw [hquad]
+  -- Step 3: The map L(x) = Uᵀ *ᵥ x is measure-preserving since |det Uᵀ| = 1
+  let L : (Fin n → ℝ) →ₗ[ℝ] (Fin n → ℝ) := Uᵀ.mulVecLin
+  have hL_det : LinearMap.det L = Uᵀ.det := by
+    rw [show L = Matrix.toLin' Uᵀ from (Matrix.toLin'_apply' _).symm, LinearMap.det_toLin']
+  -- |det Uᵀ| = |det U| = 1 (U is unitary)
+  have hL_det_abs : |Uᵀ.det| = 1 := by
+    rw [Matrix.det_transpose]
+    have hmem := Matrix.det_of_mem_unitary hS.eigenvectorUnitary.property
+    -- hmem : det U ∈ unitary ℝ, i.e., det U * star (det U) = 1
+    -- Over ℝ with TrivialStar: star (det U) = det U, so det U * det U = 1
+    have h1 : U.det * U.det = 1 := by
+      have h := hmem.2  -- det U * star (det U) = 1
+      simp only [star_trivial] at h; exact h
+    have h_sq : U.det ^ 2 = 1 := by rw [pow_two]; exact h1
+    rcases sq_eq_one_iff.mp h_sq with h | h <;> simp [h]
+  have hL_det_ne : LinearMap.det L ≠ 0 := by
+    rw [hL_det]; intro h
+    simp [h] at hL_det_abs
+  -- Map volume: Measure.map L volume = volume
+  have hmap : Measure.map ⇑L volume = volume := by
+    rw [Real.map_linearMap_volume_pi_eq_smul_volume_pi hL_det_ne, hL_det]
+    rw [show |Uᵀ.det⁻¹| = 1 by rw [abs_inv, hL_det_abs, inv_one]]
+    simp
+  -- Step 4: Change of variables ∫ x, f(L x) = ∫ y, f y (via integral_map + hmap)
+  show ∫ x : Fin n → ℝ, Real.exp (-(∑ i, hS.eigenvalues i * (L x i) ^ 2)) =
+       Real.sqrt (Real.pi ^ n / ∏ i, hS.eigenvalues i)
+  -- Measurability of g = fun y => exp(-∑ λᵢ yᵢ²) under Measure.map L volume
+  have hg : AEStronglyMeasurable
+      (fun y : Fin n → ℝ => Real.exp (-(∑ i, hS.eigenvalues i * y i ^ 2)))
+      (Measure.map ⇑L volume) := by
+    rw [hmap]
+    apply Continuous.aestronglyMeasurable
+    fun_prop
+  -- integral_map: ∫ y, g y ∂(Measure.map L vol) = ∫ x, g (L x) ∂vol
+  -- ← integral_map + hmap rewrites the LHS to ∫ y, g y ∂vol
+  rw [← integral_map L.continuous_of_finiteDimensional.measurable.aemeasurable hg, hmap]
+  exact diagonal_gaussian hS.eigenvalues (fun i => hA.eigenvalues_pos i)
 
 end MultivariateGaussian

--- a/research/problems/area-of-circle-oq-05-oq-02/knowledge.md
+++ b/research/problems/area-of-circle-oq-05-oq-02/knowledge.md
@@ -1,44 +1,75 @@
 # Knowledge: area-of-circle-oq-05-oq-02
 
-## Key Facts
+## Problem Summary
 
-### Mathematical Setup
-- Positive-definite real symmetric A: all eigenvalues λᵢ > 0
-- ∫_{ℝⁿ} e^{-xᵀAx} dx = √(πⁿ/det A)
-- Proof chain: spectral decomposition → change of variables → Fubini → scalar integral
+**Goal**: Prove the multivariate Gaussian integral
+```
+∫ x : Fin n → ℝ, exp(-xᵀAx) = √(πⁿ / det A)
+```
+for positive-definite real symmetric A, via spectral decomposition.
 
-### Scalar Case (from parent)
-- ∫_{ℝ} e^{-ax²} dx = √(π/a) for a > 0
-- This is the building block for the multivariate case via Fubini
+**File**: `proofs/Proofs/AreaOfCircleOQ05OQ02.lean`
 
-### Spectral Theorem (to verify in Mathlib)
-- `Matrix.IsHermitian`: real symmetric matrices have real eigenvalues
-- `Matrix.IsHermitian.eigenvectorMatrix`: Q such that Q^T A Q = D (diagonal)
-- `Matrix.IsHermitian.spectral_theorem`: A = Q D Q^T (spectral decomposition)
-- Need: Q is orthogonal (Q^T Q = I)
+## Status: COMPLETE (0 sorries)
 
-### Change of Variables
-- y = Qx, |det Q| = 1 (orthogonal matrix)
-- `MeasureTheory.MeasurePreserving` for orthogonal transformations?
-- `MeasureTheory.integral_comp_mul_right`: f(Ax) substitution
+All three theorems proved:
+- `prod_sqrt_eq_sqrt_prod` — induction on n
+- `diagonal_gaussian` — Fubini + scalar Gaussian
+- `multivariate_gaussian_integral` — spectral decomp + orthogonal change of variables
 
-### Fubini
-- `MeasureTheory.integral_prod`: for product measures
-- For `Fin n → ℝ`, the product measure decomposes as ∏ᵢ (Lebesgue on ℝ)
-- `MeasureTheory.Measure.pi`: product measure on `Fin n → ℝ`
+## Proof Architecture
 
-### Determinant
-- `Matrix.det_diagonal`: det(diag(λ₁,...,λₙ)) = ∏ λᵢ
-- `Matrix.PosDef.det_pos`: det A > 0 for positive-definite A
-- `Real.sqrt_mul`: √(πⁿ/det A) = ∏ᵢ √(π/λᵢ) via eigenvalues
+### diagonal_gaussian
+```
+exp(-∑ bᵢxᵢ²) = ∏ exp(-bᵢxᵢ²)    [Real.exp_sum via Finset.sum_neg_distrib]
+∫ ∏ = ∏ ∫                          [integral_fintype_prod_volume_eq_prod]
+∫ exp(-bᵢxᵢ²) = √(π/bᵢ)           [GaussianIntegralCircle.scaled_gaussian]
+∏ √(π/bᵢ) = √(πⁿ/∏bᵢ)             [prod_sqrt_eq_sqrt_prod + Finset.prod_div_distrib]
+```
 
-## Open Questions
-- Does Mathlib have spectral theorem in a form usable for change-of-variables?
-- Is there a `MeasurePreserving` lemma for orthogonal linear maps?
-- How is `Fin n → ℝ` measure handled — `EuclideanSpace` or `Fin n → ℝ`?
+### multivariate_gaussian_integral
+Key steps:
+1. `det A = ∏ eigenvalues` via `IsHermitian.det_eq_prod_eigenvalues` + `RCLike.ofReal_real_eq_id`
+2. `A = U * diag(λ) * Uᵀ` via `spectral_theorem` + `conjTranspose_eq_transpose_of_trivial`
+3. Quadratic form: `xᵀAx = ∑ λᵢ (Uᵀx)ᵢ²` via `dotProduct_mulVec` + `vecMul_transpose` + `mulVec_diagonal`
+4. `|det Uᵀ| = 1`: unitary property → `det²=1` via `sq_eq_one_iff` → `|det|=1`
+5. `Measure.map L volume = volume` via `map_linearMap_volume_pi_eq_smul_volume_pi`
+6. Change of variables via `← integral_map + hmap`
+7. Apply `diagonal_gaussian`
 
-## References
-- Parent proof: `proofs/Proofs/AreaOfCircleOQ05.lean`
-- `Mathlib.LinearAlgebra.Matrix.PosDef`
-- `Mathlib.MeasureTheory.Integral.Bochner`
-- `Mathlib.MeasureTheory.Measure.Haar.Basic`
+## Key Mathlib APIs Used
+
+| API | Purpose |
+|-----|---------|
+| `Real.map_linearMap_volume_pi_eq_smul_volume_pi` | map L volume = |det L|⁻¹ • volume |
+| `MeasureTheory.integral_map` | ∫ g ∂(map L μ) = ∫ g∘L ∂μ |
+| `Matrix.det_of_mem_unitary` | det U ∈ unitary ℝ (gives det·star det = 1) |
+| `RCLike.ofReal_real_eq_id` | ofReal ∘ λ = λ over ℝ |
+| `Matrix.toLin'_apply'` | mulVecLin M = toLin' M (connects to det_toLin') |
+| `Matrix.vecMul_transpose` | x ᵥ* M = Mᵀ.mulVec x |
+| `sq_eq_one_iff` | a²=1 → a=1 or a=-1 |
+
+## Session 2026-04-22 (Session 1)
+
+**Outcome**: COMPLETE  
+**Sorries closed**: 1 (multivariate_gaussian_integral)  
+**Key insight**: The change-of-variables step doesn't need a MeasurableEquiv — just
+`map_linearMap_volume_pi_eq_smul_volume_pi` (which gives the scalar factor) combined with
+`integral_map` (which does the substitution). The measure-preserving proof follows from
+|det Uᵀ| = 1 via the unitary group property.
+
+**Pitfalls resolved**:
+- `mulVecLin` vs `toLin'`: need `Matrix.toLin'_apply'` to connect them for `det_toLin'`
+- `star U` over ℝ: `star_trivial` gives `star r = r`, then `sq_eq_one_iff` for |det|=1
+- `RCLike.ofReal ∘ eigenvalues` over ℝ: use `RCLike.ofReal_real_eq_id` (not `simp`)
+- Spectral theorem form: `conjStarAlgAut_apply u x = u * x * star u`
+
+## Session 2026-04-22 (Session 2)
+
+**Outcome**: VERIFIED BUILD (0 sorries, clean ✔)
+**Key fixes**:
+- `Matrix.dotProduct` does NOT exist — `dotProduct` is in root namespace (not `Matrix`). Use `simp only [dotProduct, ...]`
+- `fun_prop` cannot prove `AEStronglyMeasurable` for pi-types `Fin n → ℝ`. Fix: use `Continuous.aestronglyMeasurable` + `fun_prop` for continuity
+- Docker build script mounts MAIN repo, not worktree. Must run docker-build.sh FROM the worktree directory
+
+**Build output**: `✔ [3154/3154] Built Proofs.AreaOfCircleOQ05OQ02 (3.8s)` — no sorry warnings

--- a/src/data/research/problems/area-of-circle-oq-05-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-02.json
@@ -1,8 +1,8 @@
 {
   "slug": "area-of-circle-oq-05-oq-02",
   "title": "Multivariate Gaussian Integral via Matrix Diagonalization",
-  "phase": "OBSERVE",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -17,43 +17,44 @@
   "knownResults": {
     "proven": [
       "gaussian_integral_eq_sqrt_pi: ∫_{ℝ} e^{-x²} dx = √π (parent proof)",
-      "Matrix.PosDef: positive-definite matrices in Mathlib",
-      "MeasureTheory.integral_prod: Fubini for product measures"
+      "prod_sqrt_eq_sqrt_prod: ∏ √(f i) = √(∏ f i) for nonneg f (induction on n)",
+      "diagonal_gaussian: ∫ exp(-∑ bᵢxᵢ²) = √(πⁿ/∏bᵢ) for positive b (Fubini + scalar)",
+      "multivariate_gaussian_integral: ∫ exp(-xᵀAx) = √(πⁿ/det A) for pos-def A (spectral + orthogonal change of vars)"
     ],
-    "open": [
-      "Spectral theorem change of variables for orthogonal Q",
-      "Multivariate Gaussian integral formula"
-    ],
-    "goal": "Prove multivariate Gaussian integral via spectral decomposition + Fubini"
+    "open": [],
+    "goal": "Proved: multivariate Gaussian integral via spectral decomposition + Fubini"
   },
   "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-04-21",
-    "iteration": 1,
-    "focus": "Read AreaOfCircleOQ05.lean and assess Mathlib spectral theorem API",
+    "phase": "COMPLETED",
+    "since": "2026-04-22",
+    "iteration": 2,
+    "focus": "Proof complete — 0 sorries",
     "blockers": [],
-    "nextAction": "Read proofs/Proofs/AreaOfCircleOQ05.lean, search Matrix.IsHermitian spectral theorem",
+    "nextAction": "Commit and create PR",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "Problem selected by Seeker. Parent has scalar Gaussian. Key approach: diagonalize A = Q^T D Q, use Fubini and scalar case per eigenvalue.",
-    "builtItems": [],
+    "progressSummary": "COMPLETE: Full proof of multivariate_gaussian_integral with 0 sorries. Spectral theorem + orthogonal change of variables via map_linearMap_volume_pi_eq_smul_volume_pi + integral_map.",
+    "builtItems": [
+      "prod_sqrt_eq_sqrt_prod (proved): induction on n, uses Real.sqrt_mul — AreaOfCircleOQ05OQ02.lean:48",
+      "diagonal_gaussian (proved): exp_sum + Fubini (integral_fintype_prod_volume_eq_prod) + scalar Gaussian — AreaOfCircleOQ05OQ02.lean:73",
+      "multivariate_gaussian_integral (proved): spectral decomp + quadratic form rewrite + orthogonal CoV + diagonal_gaussian — AreaOfCircleOQ05OQ02.lean:115"
+    ],
     "insights": [
-      "Spectral theorem: symmetric positive-definite A = Q^T D Q, Q orthogonal",
-      "Change of variables y = Qx has Jacobian 1 (orthogonal Q)",
-      "Fubini separates: ∫ e^{-Σ λᵢyᵢ²} = ∏ ∫ e^{-λᵢyᵢ²} = ∏ √(π/λᵢ)",
-      "Product of √(π/λᵢ) = √(πⁿ/det A) via det A = ∏ λᵢ"
+      "Key API: Real.map_linearMap_volume_pi_eq_smul_volume_pi — for L: ι→ℝ →ₗ[ℝ] ι→ℝ with det L ≠ 0: map L volume = |det L|⁻¹ • volume",
+      "integral_map: ∫ y, g y ∂(Measure.map L μ) = ∫ x, g (L x) ∂μ — use ← direction with hmap to convert to ∫ over volume",
+      "Unitary det over ℝ: det_of_mem_unitary gives det U * star (det U) = 1; TrivialStar gives star = id, so det²=1, hence |det|=1 via sq_eq_one_iff",
+      "mulVecLin vs toLin': Matrix.toLin'_apply' M : Matrix.toLin' M = M.mulVecLin — needed to connect mulVecLin (used in L) to det_toLin'",
+      "RCLike.ofReal_real_eq_id: @ofReal ℝ _ = id — essential for reducing RCLike.ofReal ∘ eigenvalues = eigenvalues over ℝ",
+      "vecMul_transpose: for any M and x, x ᵥ* M = Mᵀ.mulVec x — used with M:=Uᵀ to get x ᵥ* U = Uᵀ.mulVec x",
+      "quadratic form: xᵀAx where A=UDUᵀ simplifies to (Uᵀx)ᵀ D (Uᵀx) = ∑ λᵢ (Uᵀx)ᵢ² via dotProduct_mulVec + mulVec_diagonal"
     ],
     "mathlibGaps": [],
-    "nextSteps": [
-      "Read AreaOfCircleOQ05.lean fully",
-      "Check Matrix.IsHermitian.eigenvectorMatrix in Mathlib",
-      "Search MeasureTheory for orthogonal change of variables"
-    ]
+    "nextSteps": []
   },
   "tags": [
     "analysis",
@@ -71,26 +72,29 @@
     "papers": [],
     "urls": [],
     "mathlib": [
-      "Mathlib.LinearAlgebra.Matrix.PosDef",
-      "Mathlib.MeasureTheory.Integral.Bochner",
-      "Mathlib.MeasureTheory.Measure.Haar.Basic"
+      "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral",
+      "Mathlib.Analysis.Matrix.Spectrum",
+      "Mathlib.Analysis.Matrix.PosDef",
+      "Mathlib.MeasureTheory.Integral.Pi",
+      "Mathlib.MeasureTheory.Measure.Lebesgue.Basic",
+      "Mathlib.LinearAlgebra.Determinant"
     ]
   },
   "started": "2026-04-21T19:30:00.000Z",
-  "lastUpdate": "2026-04-21T19:30:00.000Z",
+  "lastUpdate": "2026-04-22T17:46:00.000Z",
   "significance": 7,
   "tractability": 7,
   "leanFiles": [
     {
-      "path": "Proofs/AreaOfCircleOQ05.lean",
-      "filename": "AreaOfCircleOQ05.lean",
-      "lineCount": 0,
-      "theoremCount": 0,
+      "path": "Proofs/AreaOfCircleOQ05OQ02.lean",
+      "filename": "AreaOfCircleOQ05OQ02.lean",
+      "lineCount": 202,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,
       "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ05.lean"
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ05OQ02.lean"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Proves `∫ x : Fin n → ℝ, exp(-xᵀAx) = √(πⁿ/det A)` for positive-definite A
- All three theorems complete with 0 sorries: `prod_sqrt_eq_sqrt_prod`, `diagonal_gaussian`, `multivariate_gaussian_integral`
- Proof via spectral theorem + Fubini + orthogonal change of variables using `map_linearMap_volume_pi_eq_smul_volume_pi`

## Key proof steps

1. `diagonal_gaussian`: factor `exp(-∑ bᵢxᵢ²) = ∏ exp(-bᵢxᵢ²)` → Fubini → scalar Gaussian
2. `multivariate_gaussian_integral`: spectral decomp A = U·diag(λ)·Uᵀ, change variables y = Uᵀx (measure-preserving since |det Uᵀ| = 1), reduce to diagonal case

## Mathlib APIs used

- `IsHermitian.spectral_theorem`, `IsHermitian.det_eq_prod_eigenvalues`
- `Real.map_linearMap_volume_pi_eq_smul_volume_pi` + `MeasureTheory.integral_map`
- `Matrix.det_of_mem_unitary`, `Continuous.aestronglyMeasurable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)