### PR TITLE
Deployer: resolve conflicts from PRs #11408 + #11409

### DIFF
--- a/src/data/proofs/collatz-cycles/meta.json
+++ b/src/data/proofs/collatz-cycles/meta.json
@@ -112,6 +112,26 @@
     }
   ],
   "crossReferences": [
+    {
+      "targetId": "collatz-structured",
+      "relationship": "complementary",
+      "description": "Establishes convergence for structured families (powers of 2, specific small numbers like 27 which takes 111 steps). Together with this entry's cycle non-existence results, builds a fuller picture of Collatz dynamics."
+    },
+    {
+      "targetId": "collatz-cycles-oq-04",
+      "relationship": "extends",
+      "description": "Generalizes the j=1,2,3,4 halving constraints proved here to a unified algebraic proof for all j: the product identity ∏(3nᵢ+1) = 2^M·∏nᵢ forces 3^j < 2^M via cyclic permutation and product telescoping."
+    },
+    {
+      "targetId": "collatz-structured-oq-02",
+      "relationship": "sibling",
+      "description": "A parallel formalization of Collatz cycle non-existence with a different proof approach; the two entries together provide complementary structural constraints on hypothetical cycles."
+    },
+    {
+      "targetId": "divisibility-by-3",
+      "relationship": "technique",
+      "description": "The Collatz map sends odd n to 3n+1, making divisibility by 3 (and 4) central to cycle analysis. The mod-4 residue structure is used here to prove the 3/4 contraction theorem for n ≡ 1 mod 4."
+    }
   ],
   "mainTheorems": [
     {

--- a/src/data/proofs/hurwitz-theorem-oq-03/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-03/meta.json
@@ -22,7 +22,7 @@
     "dateAdded": "2026-04-02",
     "axiomCount": 0,
     "assumptions": "1 sorry: hurwitz_only_if — if an n-square identity exists, then n ∈ {1,2,4,8} (n=3 case proved; n∉{1,2,3,4,8} cases pending Clifford/Radon-Hurwitz argument). The converse (identities exist for n ∈ {1,2,4,8}) is fully proved. No axiom declarations.",
-    "lineCount": 1838,
+    "lineCount": 1973,
     "theoremCount": 32,
     "definitionCount": 15,
     "originalContributions": [
@@ -67,7 +67,7 @@
   },
   "leanFile": {
     "namespace": "HurwitzTheorem",
-    "lineCount": 1838,
+    "lineCount": 1973,
     "axiomCount": 0,
     "theoremCount": 33,
     "definitionCount": 15,


### PR DESCRIPTION
## Summary

- Fix stale lineCount in hurwitz-theorem-oq-03 meta.json (1838→1973)
- Add 4 cross-references to collatz-cycles meta.json

Cherry-picked changes from conflicting branches (divergent history) onto current main.
Supersedes #11408 and #11409 which had no merge base with main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)