### PR TITLE
Seeker: select sqrt2-plus-sqrt3-irrational-oq-03 — Minimal Polynomial of √2+√3 over ℚ

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -17483,6 +17483,13 @@
       "path": "full",
       "started": "2026-04-22T15:58:45+02:00",
       "status": "active"
+    },
+    {
+      "slug": "sqrt2-plus-sqrt3-irrational-oq-03",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-22T19:03:06+02:00",
+      "status": "active"
     }
   ],
   "config": {


### PR DESCRIPTION
## Problem Selection Report

**Date**: 2026-04-22
**Mode**: SELECT
**Pool Status**: 48 available, threshold 15 — ADEQUATE

## Selected Problem

- **ID**: `sqrt2-plus-sqrt3-irrational-oq-03`
- **Name**: Minimal Polynomial of √2+√3 over ℚ: irreducibility of x⁴-10x²+1 via Eisenstein
- **Tier**: B
- **Significance**: 6/10
- **Tractability**: 9/10
- **Knowledge Score**: EMPTY (0 items)
- **Composite Score**: 96

## Goal

```lean
theorem sqrt2_add_sqrt3_minpoly :
    Polynomial.minpoly ℚ (Real.sqrt 2 + Real.sqrt 3) = X^4 - C 10 * X^2 + 1
```

## Selection Rationale

1. **Highest composite score** (96) among 48 available problems — tractability=9 dominates because the mathematics is fully determined
2. **Well-specified**: (1) verify f(α)=0 by expanding (√2+√3)⁴, (2) prove irreducibility via rational root theorem + no quadratic factor
3. **Domain diversity**: algebraic number theory, underrepresented vs recent topology/analysis focus (Sperner, Lebesgue, Hurwitz)

## Rejection Summary

- **Candidates considered**: 48 available
- **Top rejections**: `sperner-ndim-oq-02` (boundary_doors_odd found FALSE, needs architectural fix), `lebesgue-measure-oq-06` (recently enriched), `sperner-ndim-oq-04` (recently researched), `shapley-folkman-oq-03` (active claim)
- **Open conjectures skipped**: twin-primes, Goldbach, Sophie Germain (tractability ≤ 2)
- **Confidence**: high (score spread: 96 vs 77 for second-tier candidates)

## Suggested First Steps

1. **OBSERVE**: Check `Polynomial.minpoly` API in Mathlib — find `minpoly.eq_X_pow_add_C_of_isSplittingField` or similar
2. **ORIENT**: Verify f(α)=0 computation using `Real.sqrt_mul` and `ring` tactic; confirm no Mathlib lemma for this degree
3. **DECIDE**: Use `Polynomial.irreducible_of_degree_eq_one` or show f has no rational roots (rational root theorem) + no quadratic factor

🤖 Generated with [Claude Code](https://claude.com/claude-code)