### PR TITLE
Seeker: select sqrt2-minpoly + sqrt2-plus-sqrt3-oq-03 + solution-of-cubic-oq-05

### DIFF
--- a/research/problems/sqrt2-minpoly/knowledge.md
+++ b/research/problems/sqrt2-minpoly/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: sqrt2-minpoly
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/sqrt2-minpoly/literature/README.md
+++ b/research/problems/sqrt2-minpoly/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for sqrt2-minpoly
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/sqrt2-minpoly/problem.md
+++ b/research/problems/sqrt2-minpoly/problem.md
@@ -1,0 +1,147 @@
+# Problem: Minimal Polynomial of √2 over ℚ
+
+**Slug**: sqrt2-minpoly
+**Created**: 2026-04-22
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\text{minpoly}(\mathbb{Q}, \sqrt{2}) = X^2 - 2
+$$
+
+Equivalently: $X^2 - 2$ is irreducible over $\mathbb{Q}$ and $(\sqrt{2})^2 - 2 = 0$.
+
+In Lean 4 (Mathlib):
+```lean
+theorem sqrt2_minpoly : Polynomial.minpoly ℚ (Real.sqrt 2) = X ^ 2 - C 2 := by sorry
+```
+
+### Plain Language
+
+The minimal polynomial of an algebraic number α over a field K is the unique monic irreducible polynomial in K[X] that has α as a root.
+
+For α = √2 over ℚ:
+1. **Root verification**: (√2)² - 2 = 2 - 2 = 0, so X²-2 vanishes at √2.
+2. **Irreducibility**: X²-2 has no rational roots (±1, ±2 don't satisfy it), so it is irreducible in ℚ[X] by the rational root theorem (degree 2 case).
+3. **Minimality**: Therefore X²-2 is the minimal polynomial of √2 over ℚ, and [ℚ(√2):ℚ] = 2.
+
+### Why This Matters
+
+The minimal polynomial is the fundamental algebraic invariant of an algebraic number. This result:
+- Establishes that √2 is algebraic of degree 2 over ℚ
+- Proves [ℚ(√2):ℚ] = 2, so {1, √2} is a ℚ-basis for ℚ(√2)
+- Complements the gallery's `sqrt2-irrational` proof with algebraic structure
+- Provides a bridge to `sqrt2-plus-sqrt3-irrational-oq-03` (which proves the degree-4 minpoly of √2+√3)
+- Connects to `cayley-hamilton-minpoly` (general minimal polynomial theory)
+
+## Known Results
+
+### What's Already Proven
+
+- `sqrt2-irrational`: √2 is irrational (uses `irrational_sqrt_two` from Mathlib) — gallery
+- `Mathlib.Data.Real.Irrational`: `irrational_sqrt_two`, `Nat.Prime.irrational_sqrt` — Mathlib
+- `Mathlib.RingTheory.Polynomial.Cyclotomic.Basic`: minimal polynomial API — Mathlib
+- `Polynomial.minpoly.irreducible`: minpoly is irreducible over the base field — Mathlib
+- `Polynomial.minpoly.eq_X_pow_sub_C_of_isSplittingField`: specialized minpoly computations — Mathlib
+
+### What's Still Open
+
+- Explicit computation: `Polynomial.minpoly ℚ (Real.sqrt 2) = X ^ 2 - C 2`
+- This connects irrationality (existence of no rational root) to irreducibility (minimal polynomial degree)
+
+### Our Goal
+
+Prove `Polynomial.minpoly ℚ (Real.sqrt 2) = X ^ 2 - C 2` in Lean 4 using Mathlib.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `sqrt2-irrational` | Irrationality of √2; implies no degree-1 rational polynomial vanishes at √2 | `irrational_sqrt_two`, modular arithmetic |
+| `sqrt2-plus-sqrt3-irrational-oq-03` | Minpoly of √2+√3 is X⁴-10X²+1 (degree 4 analogue) | `Polynomial.minpoly`, irreducibility |
+| `cayley-hamilton-minpoly` | General minimal polynomial theory over fields | `Polynomial.minpoly` API |
+| `sqrt2-from-axioms` | Axiomatic construction of √2 | algebraic properties of √2 |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Direct via `Polynomial.minpoly.eq_of_irreducible`**:
+   - Show X²-2 is irreducible over ℚ (rational root theorem / Eisenstein criterion with p=2)
+   - Show `aeval (Real.sqrt 2) (X ^ 2 - C 2) = 0` (direct computation)
+   - Apply `Polynomial.minpoly.eq_of_irreducible_of_monic`
+   - Why it might work: Mathlib has this API path
+   - Risk: Need correct lemma names; `Real.sq_sqrt` should give (√2)² = 2
+
+2. **Eisenstein criterion**:
+   - X²-2 is Eisenstein at p=2: 2|(-2) and 2∤1 (leading coeff) and 4∤(-2)
+   - Mathlib has `Polynomial.Irreducible.of_eisenstein_criterion`
+   - Why it might work: Clean, well-supported path
+   - Risk: Need to verify Eisenstein API exists for ℤ and then lift to ℚ
+
+3. **Via degree argument**:
+   - √2 is algebraic of degree ≥ 2 (irrational means degree > 1)
+   - X²-2 annihilates √2, so degree ≤ 2
+   - Therefore degree = 2 and X²-2 is the minpoly
+   - Why it might work: Conceptually clear
+   - Risk: Need to formalize "degree exactly 2" argument
+
+### Key Difficulties
+
+- Connecting `Real.sqrt 2` (analysis) to `Polynomial.minpoly ℚ` (algebra) requires coercion infrastructure
+- `Real.sqrt 2` is defined analytically; algebraic properties need `Real.sq_sqrt`, `Real.sqrt_nonneg`
+- Verifying `aeval (Real.sqrt 2) (X ^ 2 - C 2) = 0` requires `Real.sq_sqrt (by norm_num : (2:ℝ) ≥ 0)`
+
+### What Would a Proof Need?
+
+- `Real.sq_sqrt`: (√x)² = x for x ≥ 0
+- `Polynomial.minpoly.eq_of_irreducible_of_monic` or similar API
+- Irreducibility of X²-2 over ℚ: either by Eisenstein or rational root theorem
+- `Polynomial.Monic` for X²-2
+- Cast from ℚ to ℝ for evaluation
+
+## Tractability Assessment
+
+**Difficulty**: Low
+
+**Justification**:
+- The mathematics is completely determined: X²-2, irreducibility via Eisenstein (p=2)
+- Mathlib has `Polynomial.minpoly` API, `Real.sq_sqrt`, and `irrational_sqrt_two`
+- The analogous proof for √2+√3 (`sqrt2-plus-sqrt3-irrational-oq-03`) is the harder version
+- Degree 2 case is simpler than degree 4
+
+**Estimated Effort**:
+- Exploration: 1-2 hours to find correct API calls
+- If tractable: 1 session (high confidence)
+- Fallback: axiomatize with Eisenstein manually proven in ℤ, lifted to ℚ
+
+## References
+
+### Mathlib
+- `Mathlib.RingTheory.Polynomial.Basic` — `Polynomial.minpoly` definitions and API
+- `Mathlib.Data.Real.Sqrt` — `Real.sqrt`, `Real.sq_sqrt`
+- `Mathlib.Data.Real.Irrational` — `irrational_sqrt_two`
+- `Mathlib.RingTheory.Polynomial.Cyclotomic.Irreducible` — irreducibility tools
+- `Mathlib.RingTheory.Eisenstein.Basic` — Eisenstein criterion
+
+## Metadata
+
+```yaml
+tags:
+  - algebraic-number-theory
+  - minimal-polynomial
+  - sqrt2
+  - irrationality
+  - irreducibility
+related_proofs:
+  - sqrt2-irrational
+  - sqrt2-plus-sqrt3-irrational
+  - cayley-hamilton-minpoly
+difficulty: low
+source: gallery-gap
+created: 2026-04-22
+```

--- a/research/problems/sqrt2-minpoly/state.md
+++ b/research/problems/sqrt2-minpoly/state.md
@@ -1,0 +1,25 @@
+# Research State: sqrt2-minpoly
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-04-22T19:23:25+02:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/registry.json
+++ b/research/registry.json
@@ -14985,7 +14985,7 @@
     {
       "slug": "area-of-circle-oq-03-oq-03-oq-01",
       "id": "area-of-circle-oq-03-oq-03-oq-01",
-      "title": "Ellipse area π·a·b via Mathlib measure-theoretic change of variables",
+      "title": "Ellipse area \u03c0\u00b7a\u00b7b via Mathlib measure-theoretic change of variables",
       "status": "active",
       "tier": "B",
       "significance": 6,
@@ -15047,7 +15047,7 @@
       "started": "2026-04-05T22:23:02.409Z",
       "status": "active",
       "lastUpdate": "2026-04-05T22:26:32Z",
-      "notes": "Seeker selected: Fourier transform of Gaussian — removes gaussian_fourier_identity axiom from CLT proof"
+      "notes": "Seeker selected: Fourier transform of Gaussian \u2014 removes gaussian_fourier_identity axiom from CLT proof"
     },
     {
       "slug": "four-color-theorem-oq-02-oq-03",
@@ -17489,6 +17489,13 @@
       "phase": "OBSERVE",
       "path": "full",
       "started": "2026-04-22T19:03:06+02:00",
+      "status": "active"
+    },
+    {
+      "slug": "sqrt2-minpoly",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-22T19:23:25+02:00",
       "status": "active"
     }
   ],


### PR DESCRIPTION
## Summary

Three new research problems selected for the pipeline:

1. **sqrt2-minpoly** — Minimal Polynomial of √2 over ℚ (Tier B, sig 6, tract 8)
   - Prove `Polynomial.minpoly ℚ (Real.sqrt 2) = X^2 - C 2`
   - Extends `sqrt2-irrational` into algebraic number theory
   - Establishes [ℚ(√2):ℚ] = 2

2. **sqrt2-plus-sqrt3-irrational-oq-03** — Minimal Polynomial of √2+√3 over ℚ (Tier B, sig 6, tract 9)
   - Prove irreducibility of x⁴-10x²+1; establishes degree-4 extension
   - Complements sqrt2-minpoly (degree-2 case)

3. **solution-of-cubic-oq-05** — Connection to Quartic via Resolvent Cubic (Tier B, sig 7, tract 6)
   - Link Cardano's cubic to Ferrari's quartic via resolvent cubic
   - Fills TODO in `GeneralQuartic.lean`

Also fixed: `sqrt2-plus-sqrt3-irrational-oq-03` was missing from `knowledge.db` — registered with correct tier/scores.

**Pool status after selection**: 30 available (threshold: 15) — adequate

🤖 Generated with [Claude Code](https://claude.com/claude-code)