### PR TITLE
Enrich sperner-ndim-oq-04: fix annotations loading, add missing sections

### DIFF
--- a/src/data/proofs/sperner-ndim-oq-04/annotations.json
+++ b/src/data/proofs/sperner-ndim-oq-04/annotations.json
@@ -98,13 +98,25 @@
   {
     "id": "ann-main-theorems",
     "proofId": "sperner-ndim-oq-04",
-    "range": { "startLine": 299, "endLine": 389 },
+    "range": { "startLine": 298, "endLine": 343 },
     "type": "insight",
-    "title": "Main Theorems and the Non-Revisiting Invariant",
-    "content": "The three sorry-using theorems represent what remains to be proved:\n\n1. `kuhn_path_terminates`: Existence of an FC simplex, derived from the boundary door assumption and sperner_ndim. Currently sorry'd; could be filled by applying sperner_ndim directly (parity of boundary door count implies FC existence).\n\n2. `kuhn_walk_reaches_fc`: The walk with sufficient fuel actually reaches an FC simplex. This requires the non-revisiting invariant: the door graph path from a boundary vertex has no cycles. This is the core open sorry.\n\n3. `kuhnPathStart_is_fc`: The top-level correctness theorem combining the start condition and the walk result.\n\nThe non-revisiting invariant is why Kuhn's algorithm works: the door graph component containing a boundary door is a path (not a cycle), because any cycle would require an even number of boundary vertices, but each path component has exactly 2 endpoints and the boundary door provides only 1.",
-    "mathContext": "The door graph G has: interior edges (from K.adj), boundary half-edges (from K.adj = none). Each vertex has degree ≤ 2 under IsKuhnCompatible. The boundary vertex (K.adj s₀ k₀ = none) has degree 1 in G. In a graph with max degree 2, components are paths and cycles; degree-1 vertices force the component to be a path. The path starts at the boundary door and ends at either another boundary door or an FC simplex (degree 1). Since only one boundary door was given as a starting point, the path terminus must be an FC simplex.",
+    "title": "Termination and Walk Correctness: The Non-Revisiting Invariant",
+    "content": "Two sorry-using theorems capture what remains formally unproved:\n\n1. `kuhn_path_terminates`: An FC simplex exists. Currently sorry'd but could be filled by applying sperner_ndim directly — the parity of boundary doors implies FC existence without any algorithm argument.\n\n2. `kuhn_walk_reaches_fc`: The kuhnWalk with sufficient fuel actually reaches an FC simplex. This requires the **non-revisiting invariant**: the door graph path from a boundary vertex has no cycles. This is the core open sorry.\n\nThe non-revisiting invariant is why Kuhn's algorithm works: the door graph component containing a boundary door is a path (not a cycle). Any cycle would require an even number of boundary vertices; but each path component has exactly 2 endpoints and the boundary door provides only 1, forcing the other endpoint to be an FC simplex.",
+    "mathContext": "Door graph G: interior edges from K.adj, boundary half-edges from K.adj = none. Under IsKuhnCompatible, max degree ≤ 2, so G is a disjoint union of paths and cycles. Boundary vertex (K.adj s₀ k₀ = none) has degree 1 in G, forcing its component to be a path (not a cycle). Both endpoints of a path in G have degree 1: either FC simplices (degree 1 by fc_door_count_eq_one) or boundary doors. Since the path starts at a boundary door, the other endpoint is an FC simplex.",
     "significance": "main-result",
     "relatedConcepts": ["non-revisiting invariant", "path-cycle decomposition", "door graph components", "Sperner's lemma"],
     "prerequisites": ["kuhnWalk", "IsKuhnCompatible", "sperner_ndim (existence)", "door graph structure"]
+  },
+  {
+    "id": "ann-kuhn-path-start",
+    "proofId": "sperner-ndim-oq-04",
+    "range": { "startLine": 344, "endLine": 389 },
+    "type": "definition",
+    "title": "kuhnPathStart: The Public API for Kuhn's Algorithm",
+    "content": "Section IX packages the algorithm into its final public-facing form. `kuhnPathStart` wraps kuhnWalk with:\n- An initial KuhnState from the boundary door (s₀, k₀) with empty visited set\n- Fuel = Fintype.card K.Simplex (at most as many steps as there are simplices)\n\nThe initial state invariant `current_not_visited` holds trivially: s₀ ∉ ∅. The fuel bound is correct because a non-revisiting walk of length n visits n+1 distinct simplices, so Fintype.card K.Simplex steps suffice.\n\n`kuhnPathStart_is_fc` is the top-level correctness theorem: it states that the simplex returned by the algorithm is fully colored. Currently sorry'd, pending formalization of the non-revisiting invariant that would chain kuhn_walk_reaches_fc to the initial boundary door condition.",
+    "mathContext": "The choice fuel = Fintype.card K.Simplex is sharp: in a triangulation with N simplices, the worst-case path visits all N simplices before reaching FC. The invariant chain: hbdry₀ (K.adj s₀ k₀ = none) ⟹ (s₀, k₀) is a boundary door ⟹ kuhnWalk path from (s₀, k₀) is non-revisiting ⟹ terminates at FC within N steps.",
+    "significance": "key",
+    "relatedConcepts": ["public API", "fuel bound", "Fintype.card", "KuhnState", "boundary door"],
+    "prerequisites": ["kuhnWalk", "KuhnState", "kuhn_walk_reaches_fc", "Fintype.card"]
   }
 ]

--- a/src/data/proofs/sperner-ndim-oq-04/index.ts
+++ b/src/data/proofs/sperner-ndim-oq-04/index.ts
@@ -28,7 +28,7 @@ export const proof: Proof = {
   crossReferences: meta.crossReferences || [],
 }
 
-export const annotations: Annotation[] = (annotationsJson as unknown as { annotations: Annotation[] }).annotations || []
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
 
 export const proofData: ProofData = {
   proof,

--- a/src/data/proofs/sperner-ndim-oq-04/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-04/meta.json
@@ -78,41 +78,57 @@
       "id": "door-counts",
       "title": "Exact Door Counts",
       "startLine": 92,
-      "endLine": 120,
+      "endLine": 114,
       "summary": "Under Kuhn compatibility: FC simplices have exactly 1 door, non-FC have 0 or 2.",
       "mathContext": "Combines parity (odd/even) with the degree bound (≤ 2) via omega."
     },
     {
       "id": "unique-exit",
       "title": "Unique Exit Door",
-      "startLine": 122,
-      "endLine": 185,
+      "startLine": 115,
+      "endLine": 178,
       "summary": "Non-FC simplex with entry door k_in has a unique exit door k_out ≠ k_in. Proved via Finset.card_eq_two.",
       "mathContext": "The existsUnique statement captures the determinism of Kuhn's algorithm."
     },
     {
+      "id": "door-transfer",
+      "title": "Door Transfer Lemma",
+      "startLine": 179,
+      "endLine": 202,
+      "summary": "Proves the door property is symmetric under adjacency: isDoorAt c K s k ↔ isDoorAt c K s' k' when K.adj s k = some (s', k').",
+      "mathContext": "K.adj_vertices guarantees the d-vertex images of (s,k) and (s',k') are equal, so the same color set is available at both ends of any door edge."
+    },
+    {
       "id": "kuhn-step",
       "title": "Kuhn Step Function",
-      "startLine": 187,
-      "endLine": 235,
+      "startLine": 203,
+      "endLine": 245,
       "summary": "Defines kuhnStep (one algorithm step) and proves door preservation across adjacency.",
-      "mathContext": "Uses door_transfer from SpernerNDim to show the door property is maintained."
+      "mathContext": "Uses door_transfer to show the door property is maintained across each step."
     },
     {
       "id": "kuhn-walk",
       "title": "Kuhn Walk Algorithm",
-      "startLine": 237,
-      "endLine": 270,
+      "startLine": 246,
+      "endLine": 297,
       "summary": "Defines KuhnState structure and kuhnWalk with fuel parameter for termination.",
-      "mathContext": "Fuel-based recursion avoids well-founded termination obligations while capturing the algorithm."
+      "mathContext": "Fuel-based recursion avoids well-founded termination obligations while capturing the algorithm. With fuel = Fintype.card K.Simplex, sufficient fuel is guaranteed when the walk is non-revisiting."
     },
     {
       "id": "main-theorem",
-      "title": "Main Theorem",
-      "startLine": 272,
-      "endLine": 280,
-      "summary": "States kuhnPathStart_is_fc: the simplex found by the Kuhn algorithm is fully colored.",
-      "mathContext": "Main correctness theorem, currently stated with sorry pending the non-revisiting invariant proof."
+      "title": "Termination and Walk Correctness Theorems",
+      "startLine": 298,
+      "endLine": 343,
+      "summary": "States kuhn_path_terminates (FC existence from boundary door) and kuhn_walk_reaches_fc (walk correctness). Both use sorry pending the non-revisiting invariant.",
+      "mathContext": "kuhn_path_terminates can be derived from sperner_ndim (parity of boundary doors implies FC existence). kuhn_walk_reaches_fc requires the door graph path invariant: components containing boundary vertices are paths, not cycles."
+    },
+    {
+      "id": "kuhn-path-start",
+      "title": "Kuhn Path from Boundary Door",
+      "startLine": 344,
+      "endLine": 389,
+      "summary": "Defines kuhnPathStart (top-level entry point) and states kuhnPathStart_is_fc (main correctness theorem). The starting state uses the boundary door as the initial entry with an empty visited set.",
+      "mathContext": "kuhnPathStart wraps kuhnWalk with fuel = Fintype.card K.Simplex, ensuring sufficient steps. kuhnPathStart_is_fc combines the walk result with the boundary door invariant to conclude the output is FC."
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
Enrichment pass for sperner-ndim-oq-04 (n-Dimensional Sperner: Kuhn Path-Following Algorithm).

## Fixes

- **Critical index.ts bug**: annotations loaded via `.annotations` on a plain array, returning `undefined` and falling back to `[]`. Annotations were silently not displaying. Fixed to direct cast: `annotationsJson as unknown as Annotation[]`.

## Content improvements

- **Added `door-transfer` section** (lines 179-202) for the door symmetry re-proof — existed in Lean file but had no section entry.
- **Fixed section line ranges** to match actual Lean file:
  - `door-counts`: endLine 120 → 114
  - `unique-exit`: 122-185 → 115-178
  - `kuhn-step`: 187-235 → 203-245
  - `kuhn-walk`: 237-270 → 246-297
  - `main-theorem`: 272-280 → 298-343 (was far too short)
- **Added `kuhn-path-start` section** (lines 344-389) for Section IX — this entire section was uncovered.
- **Split ann-main-theorems** to cover only Section VIII (298-343) with refined mathContext.
- **Added ann-kuhn-path-start** annotation (344-389) explaining the public API, fuel bound, and invariant chain.