### PR TITLE
Audit: erdos-138 — fix leanFile.axiomCount 7→8

### DIFF
--- a/src/data/proofs/erdos-138/meta.json
+++ b/src/data/proofs/erdos-138/meta.json
@@ -137,7 +137,7 @@
     ],
     "namespace": "Erdos138",
     "lineCount": 196,
-    "axiomCount": 7,
+    "axiomCount": 8,
     "theoremCount": 6,
     "definitionCount": 6,
     "path": "Proofs/Erdos138Problem.lean",


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: erdos-138 (Van der Waerden Numbers Growth Rate)

**Problem**: `leanFile.axiomCount` was 7, but the Lean source contains 8 axiom declarations:
- `van_der_waerden_theorem`
- `berlekamp_lower_bound`
- `gowers_upper_bound`
- `kozik_shabanov_lower_bound`
- `W_three`, `W_four`, `W_five`, `W_six` (exact small values)

**Evidence**:
- `leanFile.axiomCount`: 7 (incorrect)
- `meta.axiomCount`: 8 (was already correct)
- Actual `^axiom` declarations in Lean file: 8

## Fix

Updated `leanFile.axiomCount` from 7 to 8 to match the Lean source.

---
Discovered during gallery integrity audit.