### PR TITLE
Fix: sync shapley-folkman lineCount 809→813

### DIFF
--- a/src/data/proofs/shapley-folkman/meta.json
+++ b/src/data/proofs/shapley-folkman/meta.json
@@ -61,7 +61,7 @@
       "Caratheodory's theorem (points in convex hull need at most d+1 vertices)",
       "Affine independence and dimension"
     ],
-    "lineCount": 809,
+    "lineCount": 813,
     "mathlib_version": "4.26.0",
     "leanFile": {
       "imports": [
@@ -201,7 +201,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 809,
+    "lineCount": 813,
     "structureCount": 1,
     "axiomCount": 0,
     "theoremCount": 8,


### PR DESCRIPTION
## Summary

- Syncs `lineCount` in `shapley-folkman/meta.json` from 809 → 813 (both `meta.lineCount` and `leanFile.lineCount`)
- PR #11413 modified `ShapleyFolkman.lean` (net +4 lines) but did not update the metadata

## Details

- `proofs/Proofs/ShapleyFolkman.lean`: 813 lines (verified via `wc -l`)
- `meta.json` still stored `809` from before the research session

## Type

Type A (metadata fix — stale lineCount)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)