### PR TITLE
Enrich lebesgue-measure-oq-06 (Banach-Tarski Paradox): fix annotation gaps, add missing section

### DIFF
--- a/src/data/proofs/lebesgue-measure-oq-06/annotations.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/annotations.json
@@ -72,18 +72,6 @@
     "prerequisites": ["Euclidean space in Lean", "isometric equivalences", "group homomorphism", "FreeGroup", "MeasureTheory"]
   },
   {
-    "id": "ann-nonmeasurability",
-    "proofId": "lebesgue-measure-oq-06",
-    "range": { "startLine": 228, "endLine": 248 },
-    "type": "theorem",
-    "title": "Corollary: Banach-Tarski Pieces Are Non-Measurable",
-    "content": "This corollary (stated as a sorry) captures the essential measure-theoretic obstruction: the pieces in any Banach-Tarski decomposition of the unit ball must be non-Lebesgue-measurable. The argument is by contradiction: if all pieces $\\{P_i\\}$ were measurable, then since isometries preserve Lebesgue measure, $\\lambda(g_j^{(i)}(P_i)) = \\lambda(P_i)$ for each $i$. Finite additivity over the two reassemblies gives $\\lambda(B^3) = \\sum_i \\lambda(P_i) = \\lambda(B^3) + \\lambda(B^3) = 2\\lambda(B^3)$. Since $\\lambda(B^3) = 4\\pi/3 \\in (0, \\infty)$, this is a contradiction. Thus the Axiom of Choice is not just used for the construction — it is genuinely necessary; without non-measurable sets, the paradox cannot occur.",
-    "mathContext": "Quantitative contradiction: $\\lambda(B^3) = \\frac{4}{3}\\pi$ (volume of unit ball in $\\mathbb{R}^3$). If all $n$ pieces have well-defined measure: $\\sum_{i=1}^n \\lambda(P_i) = \\lambda(B^3) = \\frac{4\\pi}{3}$ (partition). Two equidecomposable copies: $2 \\cdot \\frac{4\\pi}{3} = \\frac{4\\pi}{3}$. Contradiction. The non-measurability is analogous to the Vitali set: choosing one representative from each $\\mathbb{Q}$-coset of $\\mathbb{R}/\\mathbb{Z}$ yields a non-measurable set.",
-    "significance": "key",
-    "relatedConcepts": ["Lebesgue measure", "isometry preserves measure", "non-measurable set", "Vitali set", "Axiom of Choice", "MeasurableSet"],
-    "prerequisites": ["MeasureTheory.Measure.isometry_invariant", "Lebesgue measure on ℝ³", "MeasurableSet", "finitely-additive measure"]
-  },
-  {
     "id": "ann-banach-tarski",
     "proofId": "lebesgue-measure-oq-06",
     "range": { "startLine": 192, "endLine": 226 },
@@ -115,7 +103,7 @@
     "title": "Amenable Groups: The Group-Theoretic Obstruction",
     "content": "IsAmenable G defines amenability: the group G admits a finitely-additive left-invariant probability measure on ALL subsets of G. Amenable groups include ℤ (via Cesàro means, stated as int_amenable with sorry) and all finite groups, but NOT F₂ (free group on 2 generators, stated as free_group_not_amenable with sorry). The non-amenability of F₂ is the group-theoretic root cause of Banach-Tarski: F₂ ↪ SO(3) → SO(3) not amenable → unit ball paradoxical.",
     "mathContext": "Day's theorem (1949): a group $G$ is amenable iff every $G$-set has no paradoxical subset. Equivalently (Tarski), every $G$-set admits a $G$-invariant finitely-additive probability measure. The free group $F_2$ has a paradoxical decomposition: $F_2 = W(a) \\sqcup aW(a^{-1})$ where $F_2 \\sim W(a)$ (via $a$) and $F_2 \\sim aW(a^{-1})$ directly. The Cesàro mean construction for ℤ: $\\mu(A) = \\lim_{N \\to \\infty} |A \\cap [-N, N]| / (2N+1)$ (when the limit exists; extend via Banach limits).",
-    "significance": "important",
+    "significance": "key",
     "relatedConcepts": ["Day's theorem", "Tarski's theorem", "Cesaro mean", "Banach limit", "free group paradox"],
     "prerequisites": ["FreeGroup", "Group action", "finitely-additive measure", "left-invariant measure"]
   }

--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -79,6 +79,13 @@
       "mathContext": "The full statement: $\\exists n, \\{P_i\\}_{i<n}, g_1^{(i)}, g_2^{(i)}$ such that $\\{P_i\\}$ partitions $B^3$, $B^3 = \\bigsqcup_i g_1^{(i)}(P_i)$, and $B^3 + 2e_1 = \\bigsqcup_i g_2^{(i)}(P_i)$. Hausdorff's rotation matrices have entries involving $\\sqrt{1 - 1/9} = 2\\sqrt{2}/3$, producing algebraically independent column vectors."
     },
     {
+      "id": "nonmeasurability-corollary",
+      "title": "§V-Corollary: Pieces Must Be Non-Measurable",
+      "startLine": 228,
+      "endLine": 248,
+      "summary": "States that the Banach-Tarski pieces must be non-Lebesgue-measurable (axiomatized sorry). The contradiction: if all pieces were measurable, isometry-invariance of Lebesgue measure and finite additivity would force λ(B³) = λ(B³) + λ(B³), contradicting the known value 4π/3 ∈ (0,∞). This corollary explains why Banach-Tarski does not violate conservation of volume — the pieces simply have no measurable volume to conserve."
+    },
+    {
       "id": "amenability",
       "title": "§VI: Amenability and the Group-Theoretic Source",
       "startLine": 249,
@@ -91,7 +98,8 @@
     "summary": "The Banach-Tarski paradox is formalized at the statement level with abstract equidecomposability and paradoxical set framework fully defined. The key measure-theoretic consequence (paradoxical sets admit no finite invariant measure) is structurally proved. The main theorem and ingredient lemmas are stated as axiomatized sorries, representing the current boundary of this gallery entry's formalization.",
     "openQuestions": [
       "Can Hausdorff's free subgroup theorem be fully formalized in Lean? The proof requires showing that explicit 3×3 rotation matrices generate a free group — the algebraic argument involves showing nontrivial words produce vectors with irrational coordinates via a number-theoretic argument.",
-      "Can the full Banach-Tarski proof be formalized in Lean 4? The most likely path: build the free group paradoxical decomposition first (purely algebraic), then lift to S² (measure-theoretic), then to B³ (geometric extension). Estimated scope: 800-1200 lines."
+      "Can the full Banach-Tarski proof be formalized in Lean 4? The most likely path: build the free group paradoxical decomposition first (purely algebraic), then lift to S² (measure-theoretic), then to B³ (geometric extension). Estimated scope: 800-1200 lines.",
+      "Is Tarski's theorem (a G-set X is G-paradoxical iff it admits no G-invariant finitely-additive probability measure) fully formalizable in Mathlib? The 'only if' direction is proved here; the 'if' direction requires Zorn's lemma applied to extend invariant functionals and connects to the Hahn-Banach theorem."
     ],
     "implications": "The Banach-Tarski paradox shows that Lebesgue measure cannot be extended to all subsets of ℝ³ as a finitely-additive rigid-motion-invariant measure. It demonstrates that the Axiom of Choice produces sets with no reasonable notion of volume. The connection to amenability shows that this phenomenon is fundamentally group-theoretic: the non-amenability of SO(3) (via its free subgroup) is the root cause."
   },


### PR DESCRIPTION
## Summary

Enrichment pass for `lebesgue-measure-oq-06` (Banach-Tarski Paradox). This entry was already high quality (score 98) but had structural gaps:

- **Removed duplicate annotation**: `ann-nonmeasurability` and `ann-nonmeasurable-corollary` both covered lines 228–248 with overlapping content. Kept the more detailed `ann-nonmeasurable-corollary`.
- **Added missing section**: Lines 227–248 (the non-measurability corollary between §V and §VI) were not covered in the `sections` array. Added `nonmeasurability-corollary` section with a clear summary of the measure-theoretic contradiction argument.
- **Upgraded amenability significance**: `ann-amenability` was marked `"important"` but amenability is the fundamental group-theoretic root cause of the paradox — upgraded to `"key"`.
- **Deepened conclusion**: Added a third open question about formalizing the full Tarski's theorem (the 'if' direction — non-paradoxical iff invariant measure exists — requires Zorn's lemma and connects to Hahn-Banach).

## Axiom integrity

No change to `axiomCount` (6) or `status` (axiomatized). The 6 sorries faithfully represent the axiomatized results.