### PR TITLE
Enrich sperner-ndim-oq-04 (Kuhn Path-Following): fix invalid significance, add sections, deepen history

### DIFF
--- a/src/data/proofs/sperner-ndim-oq-04/annotations.json
+++ b/src/data/proofs/sperner-ndim-oq-04/annotations.json
@@ -103,7 +103,7 @@
     "title": "Termination and Walk Correctness: The Non-Revisiting Invariant",
     "content": "Two sorry-using theorems capture what remains formally unproved:\n\n1. `kuhn_path_terminates`: An FC simplex exists. Currently sorry'd but could be filled by applying sperner_ndim directly — the parity of boundary doors implies FC existence without any algorithm argument.\n\n2. `kuhn_walk_reaches_fc`: The kuhnWalk with sufficient fuel actually reaches an FC simplex. This requires the **non-revisiting invariant**: the door graph path from a boundary vertex has no cycles. This is the core open sorry.\n\nThe non-revisiting invariant is why Kuhn's algorithm works: the door graph component containing a boundary door is a path (not a cycle). Any cycle would require an even number of boundary vertices; but each path component has exactly 2 endpoints and the boundary door provides only 1, forcing the other endpoint to be an FC simplex.",
     "mathContext": "Door graph G: interior edges from K.adj, boundary half-edges from K.adj = none. Under IsKuhnCompatible, max degree ≤ 2, so G is a disjoint union of paths and cycles. Boundary vertex (K.adj s₀ k₀ = none) has degree 1 in G, forcing its component to be a path (not a cycle). Both endpoints of a path in G have degree 1: either FC simplices (degree 1 by fc_door_count_eq_one) or boundary doors. Since the path starts at a boundary door, the other endpoint is an FC simplex.",
-    "significance": "main-result",
+    "significance": "key",
     "relatedConcepts": ["non-revisiting invariant", "path-cycle decomposition", "door graph components", "Sperner's lemma"],
     "prerequisites": ["kuhnWalk", "IsKuhnCompatible", "sperner_ndim (existence)", "door graph structure"]
   },

--- a/src/data/proofs/sperner-ndim-oq-04/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-04/meta.json
@@ -39,7 +39,7 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "Harold Kuhn (1968) gave the first algorithmic proof of Sperner's lemma, showing that a fully-colored simplex can be found in polynomial time by path-following in the door graph. This constructive approach contrasts with the combinatorial parity argument (which proves existence without construction). Kuhn's algorithm is the foundation of many fixed-point computation methods and has connections to Lemke-Howson algorithm for Nash equilibria.",
+    "historicalContext": "Harold Kuhn (1968) gave the first algorithmic proof of Sperner's lemma, showing that a fully-colored simplex can be found in polynomial time by path-following in the door graph. This constructive approach contrasts with the combinatorial parity argument (which proves existence without construction). The timing was no coincidence: Kuhn's 1968 result appeared alongside Scarf's (1967) work on computing Brouwer fixed points via primitive sets, both motivated by the desire to compute Nash equilibria and competitive equilibria in economics. These algorithms launched the field of fixed-point computation. The Lemke-Howson algorithm (1964) for Nash equilibria uses a similar path-following scheme in a complementarity pivoting framework. Kuhn's algorithm also connects to the theory of linear complementarity problems (LCP) and, through Scarf, to the computation of market equilibria in exchange economies. The abstract 'door graph path-following' structure formalized here — enter through one door, exit through the unique other — recurs throughout combinatorial optimization.",
     "problemStatement": "For a Sperner-colored abstract triangulation satisfying the Kuhn compatibility axiom (door degree ≤ 2), starting from a boundary door, construct an explicit path through the door adjacency graph that terminates at a fully-colored simplex.",
     "text": "Kuhn's algorithm provides a constructive proof of Sperner's lemma: follow the unique path in the door graph from a boundary door to reach a fully-colored simplex.",
     "proofStrategy": "The proof has three layers:\n\n1. **Door degree analysis** (fully proved): Under the Kuhn compatibility axiom (degree ≤ 2) and the abstract door parity theorem:\n   - FC simplices have odd degree ≤ 2, so degree = 1\n   - Non-FC simplices have even degree ≤ 2, so degree = 0 or 2\n\n2. **Unique exit lemma** (fully proved): A non-FC simplex with an entry door has exactly one other door (existsUnique), proved via Finset.card_eq_two and membership analysis.\n\n3. **Path termination** (stated, sorry): The Kuhn walk starting from a boundary door terminates at an FC simplex. Requires the non-revisiting invariant: the door graph component containing a boundary vertex is a path (not a cycle), because cycles in the door graph would contradict the boundary structure.",
@@ -58,6 +58,13 @@
     ]
   },
   "sections": [
+    {
+      "id": "preamble",
+      "title": "Module Setup: Imports and Door Graph Context",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "Imports Mathlib and SpernerNDim (the abstract n-dimensional Sperner framework this builds on). The module docstring precisely defines the door graph structure (interior doors via K.adj, boundary doors where K.adj = none), explains the Kuhn compatibility axiom (degree ≤ 2 makes the graph a union of paths and cycles), and lists the five main results. Sets maxHeartbeats = 400000 for the more complex Lean automation."
+    },
     {
       "id": "kuhn-compatible",
       "title": "Door Degree and Kuhn Compatibility",


### PR DESCRIPTION
## Summary

Enrichment pass for `sperner-ndim-oq-04` (Kuhn's path-following algorithm for n-dimensional Sperner's lemma):

- **Fixed invalid significance value**: `ann-main-theorems` had `"significance": "main-result"` which is not a valid schema value (valid: key/supporting/technical/context). Changed to `"key"`.
- **Added preamble section**: Lines 1–49 (module imports, door graph context, maxHeartbeats setting) were not covered in the `sections` array. Added `preamble` section with a clear summary.
- **Deepened historicalContext**: Expanded from ~400 chars to ~1076 chars, adding the economics context that motivated Kuhn's 1968 work (Scarf 1967, Lemke-Howson algorithm, LCP connection, market equilibrium computation).

## Axiom integrity

No change to `axiomCount` (0 axioms) or `status` (formalized). The 3 sorries reflect the non-revisiting invariant that is genuinely unproved.