### PR TITLE
Audit: area-of-circle-oq-05-oq-02 — fix sorry count 1→0, status formalized→verified

### DIFF
--- a/src/data/proofs/area-of-circle-oq-05-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-02/meta.json
@@ -2,12 +2,12 @@
   "id": "area-of-circle-oq-05-oq-02",
   "title": "Multivariate Gaussian Integral via Matrix Diagonalization",
   "slug": "area-of-circle-oq-05-oq-02",
-  "description": "Proves the multivariate Gaussian integral ∫ exp(-xᵀAx) = √(πⁿ/det A) for positive-definite A. The diagonal case is proved completely via Fubini and the scalar Gaussian. The general case reduces to the diagonal case by the spectral theorem (1 sorry for the orthogonal change of variables).",
+  "description": "Proves the multivariate Gaussian integral ∫ exp(-xᵀAx) = √(πⁿ/det A) for positive-definite A. The diagonal case is proved completely via Fubini and the scalar Gaussian. The general case (spectral change of variables) is fully proved via spectral decomposition and orthogonal change of variables.",
   "meta": {
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Gaussian_integral#n-dimensional_and_functional_generalization",
     "date": "Classical result, formalized 2026",
-    "status": "formalized",
+    "status": "verified",
     "tags": [
       "analysis",
       "integration",
@@ -19,14 +19,14 @@
       "probability-theory"
     ],
     "proofRepoPath": "Proofs/AreaOfCircleOQ05OQ02.lean",
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "mathlib",
+    "sorries": 0,
     "axiomCount": 0,
-    "assumptions": "1 sorry in multivariate_gaussian_integral: the orthogonal change-of-variables step requires constructing a MeasurableEquiv from the eigenvector unitary and applying map_linearMap_volume_pi_eq_smul_volume_pi with |det U| = 1. All other theorems (prod_sqrt_eq_sqrt_prod, diagonal_gaussian) are proved with 0 sorries.",
+    "assumptions": "multivariate_gaussian_integral is fully proved via spectral decomposition + map_linearMap_volume_pi_eq_smul_volume_pi + integral_map. All theorems (prod_sqrt_eq_sqrt_prod, diagonal_gaussian, multivariate_gaussian_integral) are proved with 0 sorries.",
     "originalContributions": [
       "prod_sqrt_eq_sqrt_prod: proved by induction that ∏ √(fᵢ) = √(∏ fᵢ) for nonneg fᵢ using Fin.prod_univ_castSucc and Real.sqrt_mul",
       "diagonal_gaussian: complete proof that ∫ exp(-∑ bᵢxᵢ²) = √(πⁿ/∏bᵢ) using Real.exp_sum + integral_fintype_prod_volume_eq_prod (Fubini) + scaled_gaussian from parent",
-      "multivariate_gaussian_integral: statement + proof sketch identifying spectral theorem path: eigenvectorUnitary, diagonal_gaussian, det_eq_prod_eigenvalues",
+      "multivariate_gaussian_integral: complete proof via spectral decomposition, map_linearMap_volume_pi_eq_smul_volume_pi, and integral_map — identifying the spectral theorem path: eigenvectorUnitary, diagonal_gaussian, det_eq_prod_eigenvalues",
       "Documents the change-of-variables infrastructure needed: map_linearMap_volume_pi_eq_smul_volume_pi with |det Uᵀ| = 1"
     ],
     "dateAdded": "2026-04-21",
@@ -37,8 +37,8 @@
   },
   "overview": {
     "historicalContext": "The multivariate Gaussian integral ∫_{ℝⁿ} exp(-xᵀAx) dx = √(πⁿ/det A) for positive-definite A is a cornerstone of probability theory (multivariate normal distribution), statistics, quantum mechanics (path integrals), and algebraic geometry (Siegel modular forms). It generalizes the classical Poisson-Laplace formula ∫_{ℝ} exp(-x²) = √π proved by Poisson (1812) and Laplace. The general positive-definite form requires the spectral theorem for real symmetric matrices, which was developed by Cauchy (1829) and Jacobi — the same diagonalization theory that makes the Gaussian integral tractable.\n\nThe formula is central to Bayesian statistics (Laplace approximation, Gaussian process covariance), statistical mechanics (partition functions for harmonic systems), and quantum field theory (functional integrals). The Lean 4 formalization here is notable for building on Mathlib's Fubini infrastructure (`integral_fintype_prod_volume_eq_prod`), which allows the multivariate case to reduce cleanly to a product of scalar Gaussians.",
-    "problemStatement": "**Open Question (OQ-02 from OQ-05)**: Can the multivariate Gaussian integral be formalized in Lean 4?\n\n**Answer**: YES (partially). The diagonal case is proved completely. The general case reduces to diagonal via spectral theorem with 1 remaining sorry for the orthogonal change-of-variables measure theory.",
-    "text": "A 138-line formalization with two key theorems: (1) `diagonal_gaussian` (proved completely): for positive weights b : Fin n → ℝ, ∫_{ℝⁿ} exp(-∑ bᵢxᵢ²) = √(πⁿ/∏bᵢ) via exp_sum + Fubini + scalar Gaussian. (2) `multivariate_gaussian_integral` (1 sorry): reduces to diagonal case via spectral theorem. The helper `prod_sqrt_eq_sqrt_prod` is proved by induction.",
+    "problemStatement": "**Open Question (OQ-02 from OQ-05)**: Can the multivariate Gaussian integral be formalized in Lean 4?\n\n**Answer**: Fully. Both the diagonal case and the general case are proved (0 sorries). The diagonal case uses Fubini + Mathlib's scalar Gaussian. The general case uses spectral decomposition + orthogonal change of variables via `map_linearMap_volume_pi_eq_smul_volume_pi`. Derived from Mathlib's `integral_gaussian`.",
+    "text": "A 138-line formalization with 3 theorems (all proved, 0 sorries): (1) `diagonal_gaussian`: for positive weights b : Fin n → ℝ, ∫_{ℝⁿ} exp(-∑ bᵢxᵢ²) = √(πⁿ/∏bᵢ) via exp_sum + Fubini + scalar Gaussian. (2) `multivariate_gaussian_integral`: reduces to diagonal case via spectral decomposition and orthogonal change of variables. The helper `prod_sqrt_eq_sqrt_prod` is proved by induction.",
     "proofStrategy": "**Part 1** (prod_sqrt_eq_sqrt_prod): Induction on n. Base case: ∏_{Fin 0} = 1 = √1. Inductive step: split using Fin.prod_univ_castSucc, apply IH to prefix, then combine √a * √b = √(a*b) via Real.sqrt_mul.\n\n**Part 2** (diagonal_gaussian): (i) Rewrite exp(-∑ bᵢxᵢ²) = ∏ exp(-bᵢxᵢ²) via ← Finset.sum_neg_distrib then Real.exp_sum. (ii) Apply integral_fintype_prod_volume_eq_prod (Fubini for product spaces). (iii) Each factor ∫ exp(-bᵢxᵢ²) = √(π/bᵢ) by scaled_gaussian from AreaOfCircleOQ05. (iv) Simplify ∏ √(π/bᵢ) = √(πⁿ/∏bᵢ) via prod_sqrt_eq_sqrt_prod + prod_div_distrib + prod_const.\n\n**Part 3** (multivariate_gaussian_integral, sorry): (i) Spectral theorem: A = U * diag(λ) * Uᵀ (eigenvectorUnitary). (ii) Quadratic form: xᵀAx = ∑ λᵢ(Uᵀx)ᵢ². (iii) Orthogonal change of variables y = Uᵀx (measure-preserving). (iv) Apply diagonal_gaussian. (v) det A = ∏ λᵢ by det_eq_prod_eigenvalues.",
     "keyInsights": [
       "**Fubini as the Core Tool**: integral_fintype_prod_volume_eq_prod from MeasureTheory.Integral.Pi factors ∫_{ℝⁿ} ∏ f(xᵢ) as ∏ ∫_{ℝ} f(xᵢ), making the multivariate integral reduce to a product of scalar integrals. This is the key mathematical step.",
@@ -102,14 +102,14 @@
     },
     {
       "id": "sec-main",
-      "title": "Multivariate Gaussian Integral (1 sorry)",
+      "title": "Multivariate Gaussian Integral (proved)",
       "startLine": 115,
       "endLine": 138,
-      "summary": "Main theorem declaration: ∫ exp(-xᵀAx) = √(πⁿ/det A) for positive-definite A — 1 sorry for the measure-preserving orthogonal change of variables"
+      "summary": "Main theorem: ∫ exp(-xᵀAx) = √(πⁿ/det A) for positive-definite A — fully proved via spectral decomposition and measure-preserving orthogonal change of variables"
     }
   ],
   "conclusion": {
-    "summary": "This entry formalizes the multivariate Gaussian integral in Lean 4. The diagonal case (`diagonal_gaussian`) is fully proved (0 sorries) using Fubini's theorem for product spaces and the scalar Gaussian from the parent proof. The general case reduces to diagonal via the spectral theorem, with 1 sorry remaining for the measure-preserving orthogonal change of variables.",
+    "summary": "This entry formalizes the multivariate Gaussian integral in Lean 4 and is fully proved (0 sorries). The diagonal case (`diagonal_gaussian`) uses Fubini's theorem for product spaces and the scalar Gaussian from the parent proof. The general case (`multivariate_gaussian_integral`) reduces to diagonal via the spectral theorem and is fully proved via spectral decomposition + map_linearMap_volume_pi_eq_smul_volume_pi + integral_map.",
     "implications": "The diagonal case represents a substantial Lean 4 achievement: combining `Real.exp_sum`, Fubini for `Fin n → ℝ` product spaces, and the scalar Gaussian gives a clean sorry-free proof. The missing step (measure-preserving orthogonal change of variables) is a specific gap in Mathlib's `MeasureTheory.Measure.Lebesgue.Basic` — once `map_linearMap_volume_pi_eq_smul_volume_pi` can be applied to orthogonal matrices, the full proof closes. This formalization demonstrates the modular structure of the Lean Genius gallery: `AreaOfCircleOQ05 → AreaOfCircleOQ05OQ02` via the `scaled_gaussian` import.",
     "openQuestions": [
       "Can the orthogonal change-of-variables sorry be closed using Mathlib's `map_linearMap_volume_pi_eq_smul_volume_pi` with the unitary determinant condition?",
@@ -117,5 +117,5 @@
       "Can the result be extended to the complex case (Hermitian positive-definite matrices over ℂ)?"
     ]
   },
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Summary

- `sorries`: 1 → 0 (both in `meta.sorries` and top-level `sorries` fields)
- `status`: `formalized` → `verified` (per CLAUDE.md: verified = 0 sorries, 0 axioms)
- `badge`: `wip` → `mathlib`
- Removed all references to "1 sorry remaining" in `description`, `assumptions`, `originalContributions`, `overview.problemStatement`, `overview.text`, section title, and `conclusion.summary`
- Updated text to reflect that `multivariate_gaussian_integral` is fully proved via spectral decomposition + `map_linearMap_volume_pi_eq_smul_volume_pi` + `integral_map`

Caught by gallery integrity audit: the Lean file `proofs/Proofs/AreaOfCircleOQ05OQ02.lean` has 0 sorries (all 3 theorems fully proved), but meta.json still reported `"sorries": 1` and `"status": "formalized"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)