### PR TITLE
Audit: central-limit-theorem-oq-01-oq-02-oq-01 — fix theoremCount 7→8

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11942,8 +11942,8 @@
       "issues": []
     },
     "central-limit-theorem-oq-01-oq-02-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-05T12:44:33Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-22T18:15:58Z",
       "result": "issues-fixed",
       "issues": [
         "lineCount 98\u2192112, theoremCount 7\u21928 (enricher used stale counts)"

--- a/src/data/proofs/central-limit-theorem-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-02-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "central-limit-theorem-oq-01-oq-02-oq-01",
   "title": "Gaussian Lévy-Khintchine Exponent: Complex Arithmetic Properties",
   "slug": "central-limit-theorem-oq-01-oq-02-oq-01",
-  "description": "Derives explicit Complex arithmetic properties of the Gaussian Lévy-Khintchine exponent ψ(t) = iμt − σ²t²/2. Proves Re(ψ) = −σ²t²/2 (damping), Im(ψ) = μt (drift), even/odd symmetry of real/imaginary parts, and exp(ψ(0)) = 1. 7 theorems, 0 sorries, 0 axioms.",
+  "description": "Derives explicit Complex arithmetic properties of the Gaussian Lévy-Khintchine exponent ψ(t) = iμt − σ²t²/2. Proves Re(ψ) = −σ²t²/2 (damping), Im(ψ) = μt (drift), even/odd symmetry of real/imaginary parts, and exp(ψ(0)) = 1. 8 theorems, 0 sorries, 0 axioms.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-05",
@@ -21,7 +21,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified using only Mathlib's Complex arithmetic.",
     "lineCount": 112,
-    "theoremCount": 7,
+    "theoremCount": 8,
     "definitionCount": 0,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Audit Fix

**Proof**: `central-limit-theorem-oq-01-oq-02-oq-01`
**Issue**: Stale `theoremCount` value in description and meta fields

The Lean file contains 8 theorems. A previous audit pass updated `leanFile.theoremCount` to 8 but left `meta.theoremCount` and the description summary at 7.

## Fix

- `description`: "7 theorems" → "8 theorems"
- `meta.theoremCount`: 7 → 8

## Status

All substantive claims verified clean:
- `status: verified` ✓ (0 sorries, 0 axioms confirmed)
- `badge: original` ✓ (all proofs are elementary complex arithmetic, not Mathlib theorem wrappers)
- `sorries: 0` ✓
- `axiomCount: 0` ✓

---
Discovered during gallery integrity audit.