### PR TITLE
Audit: sperner-ndim-oq-04 — fix sorry count 2→3

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12932,9 +12932,9 @@
       "issues": []
     },
     "sperner-ndim-oq-04": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-22T17:12:11Z",
-      "result": "clean",
+      "auditCount": 2,
+      "lastAudited": "2026-04-22T18:25:15Z",
+      "result": "issues-fixed",
       "issues": []
     }
   },


### PR DESCRIPTION
## Integrity Fix

**Proof**: `sperner-ndim-oq-04` (Kuhn Path-Following Algorithm)
**Severity**: HIGH — sorry count mismatch

## Evidence

**meta.json claims**: `sorries: 2`
**Lean file shows**: 3 `sorry` proof terms

```
line 327: kuhn_path_terminates := by sorry
line 342: kuhn_walk_reaches_fc := by sorry
line 387: kuhnPathStart_is_fc := by sorry
```

The `assumptions` field only listed sorries (2) and (3). The `originalContributions` incorrectly listed `kuhn_path_terminates` as "Proof of..." when it is actually `sorry`'d.

## Fix

- `sorries`: 2 → 3
- `assumptions`: updated to list all 3 sorries
- `originalContributions`: corrected "Proof of kuhn_path_terminates" → "Statement of kuhn_path_terminates"

---
Discovered during gallery integrity audit.