### PR TITLE
Fix: ballot-problem-oq-03-oq-01-oq-02 sorry count 4→14

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -19,11 +19,11 @@
       "representation-theory"
     ],
     "badge": "wip",
-    "sorries": 4,
+    "sorries": 14,
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "assumptions": "Four open sorries: (1) hook_length_formula (requires SYT↔NI bijection + det factorization), (2) ni_count_eq_syt_count (Fomin/Viennot/RSK correspondence), (3) lgv_det_factors_as_hook_quotient (det factorization identity), (4) card_SYT_twoRectYD (SYT count for 2-row rectangular = Catalan number C_m via ballot bijection). StandardYoungTableau.ext is now fully proved (funext).",
-    "lineCount": 1274,
+    "assumptions": "Fourteen open sorries: (1) hook_length_formula (main theorem, requires SYT↔NI bijection + det factorization), (2) ni_count_eq_syt_count (Fomin/Viennot/RSK correspondence), (3) lgv_det_factors_as_hook_quotient (det factorization identity). Plus 11 sorries in the DyckWord bijection section proving card_SYT_twoRectYD = C_m: two in row0_count_eq_card_filter, three in sytToDyckList auxiliary lemmas (count_U, count_D, dyck_cond), four in dyckToSYT structure fields (entry_range, entry_injOn, row_strict, col_strict), and two injectivity lemmas (sytToDyck_injective, dyckToSYT_injective).",
+    "lineCount": 1485,
     "theoremCount": 12,
     "definitionCount": 5,
     "originalContributions": [
@@ -60,7 +60,7 @@
     ]
   },
   "conclusion": {
-    "summary": "Hook-length formula infrastructure established: hookLength, hookProd, StandardYoungTableau defined; positivity and ext proved; LGV encoding described; formula verified numerically for 8 specific shapes. Main theorem stated with 4 sorries: hook_length_formula, ni_count_eq_syt_count, lgv_det_factors_as_hook_quotient (two deep open components requiring SYT↔NI bijection and det factorization), and card_SYT_twoRectYD (2-row rectangular SYT count = Catalan number).",
+    "summary": "Hook-length formula infrastructure established: hookLength, hookProd, StandardYoungTableau defined; positivity and ext proved; LGV encoding described; formula verified numerically for 8 specific shapes. Main theorem stated with 14 sorries: 3 deep open components (hook_length_formula, ni_count_eq_syt_count, lgv_det_factors_as_hook_quotient requiring SYT↔NI bijection and det factorization), plus 11 sorries in the DyckWord bijection construction for card_SYT_twoRectYD = C_m.",
     "implications": "A complete formalization would be the first Lean 4 proof of the hook-length formula, a milestone in formal combinatorics. The LGV approach connects our existing ballot problem proofs to representation theory via the Specht module dimension formula f^λ = dim S^λ.",
     "openQuestions": [
       "Formalize the SYT ↔ NI bijection via Fomin's growth diagrams or the RSK correspondence (~200 lines)",
@@ -79,9 +79,9 @@
       "LGV"
     ],
     "namespace": "HookLengthFormula",
-    "lineCount": 1274,
+    "lineCount": 1485,
     "axiomCount": 0,
-    "sorries": 4,
+    "sorries": 14,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",
     "theoremCount": 12,
     "definitionCount": 5
@@ -158,5 +158,5 @@
       "mathContext": "Verified: (2,1)→2, (2,2)→2, (3,1)→3, (3,2)→5, (3,2,1)→16, (4,3,2,1)→1440, (3,3)→5 (C₃), (4,4)→14 (C₄)."
     }
   ],
-  "sorries": 4
+  "sorries": 14
 }


### PR DESCRIPTION
## Fix

Corrects the sorry count and line count in `ballot-problem-oq-03-oq-01-oq-02/meta.json`.

## Evidence

**Before**: `sorries: 4`, `lineCount: 1274`
**After**: `sorries: 14`, `lineCount: 1485`

The Lean file `BallotProblemOQ03OQ01OQ02.lean` grew from 1274 to 1485 lines after a DyckWord bijection section was added to prove `card_SYT_twoRectYD = C_m`. This added 11 new sorries:
- 2 in `row0_count_eq_card_filter`
- 3 in `sytToDyckList` auxiliary lemmas (count_U, count_D, dyck_cond)
- 4 in `dyckToSYT` structure fields (entry_range, entry_injOn, row_strict, col_strict)
- 2 injectivity lemmas (sytToDyck_injective, dyckToSYT_injective)

The original 3 open sorries (hook_length_formula, ni_count_eq_syt_count, lgv_det_factors_as_hook_quotient) remain. All 14 sorries verified by direct inspection of the source file.

Updated fields: `meta.sorries`, `leanFile.sorries`, root `sorries`, `meta.lineCount`, `leanFile.lineCount`, `meta.assumptions`, `conclusion.summary`.

---
Automated fix by lean-mechanic agent.