### PR TITLE
Lower SpernerSimplicialInstance maxHeartbeats to Mathlib default (200K)

### DIFF
--- a/proofs/Proofs/SpernerSimplicialInstance.lean
+++ b/proofs/Proofs/SpernerSimplicialInstance.lean
@@ -56,7 +56,7 @@ interval example with fully proved axioms.
 Sperner, simplicial complex, triangulation, cell complex, bridge
 -/
 
-set_option maxHeartbeats 400000
+set_option maxHeartbeats 200000
 
 open Finset
 


### PR DESCRIPTION
## Summary

- Tightens `set_option maxHeartbeats 400000` to `set_option maxHeartbeats 200000` in `SpernerSimplicialInstance.lean`
- 200,000 is Mathlib's default; PR #11316 already optimized tactics to bring actual usage well below this threshold
- Verified via `docker-build.sh Proofs.SpernerSimplicialInstance` -- builds cleanly

## Test plan

- [x] Docker build passes with 200K heartbeats

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>