### PR TITLE
Audit: tracker update — lebesgue-measure-oq-06 issues-fixed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12920,9 +12920,9 @@
       "issues": []
     },
     "lebesgue-measure-oq-06": {
-      "auditCount": 5,
-      "lastAudited": "2026-04-22T15:12:05Z",
-      "result": "clean",
+      "auditCount": 6,
+      "lastAudited": "2026-04-22T20:16:10Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "dissection-of-cubes-oq-04": {


### PR DESCRIPTION
## Summary

- Updates audit tracker for `lebesgue-measure-oq-06` from `clean` → `issues-fixed`
- Audit #6 caught sorry count mismatch: meta.json claimed 6 sorries, actual Lean file has 5
- The meta.json fix is in PR #11488

## Background

`paradoxical_no_finite_measure` is fully proved with no sorry — meta.json incorrectly listed an auxiliary sorry for it. Fix corrects all sorry/axiomCount fields from 6 to 5.

---
Gallery integrity audit tracker update.