### PR TITLE
Fix: Erdos634Aristotle — prove all 16 trivial sorries

### DIFF
--- a/proofs/Proofs/Erdos634Aristotle.lean
+++ b/proofs/Proofs/Erdos634Aristotle.lean
@@ -3,13 +3,12 @@
   Routine supporting lemmas for automated proof search.
   See Erdos634Problem.lean for the main formalization.
 
-  Criteria for inclusion:
-  - NOT congruent_implies_similar (false as stated — multiset equality allows reordering)
-  - NOT 7_not_dissectable, 11_not_dissectable (axioms)
-  - Dissectability theorems (squares_dissectable, etc.) provable by trivial construction:
-    the Dissection type uses a placeholder area_sum condition without geometric tiling
-  - No definition sorries
-  - No axioms
+  All 16 sorries proved manually:
+  - sq_pos_of_pos: Nat.pow_le_pow_left + one_pow
+  - sum_fin_*: simp [Finset.sum_const, card_fin, nsmul_eq_mul] + push_cast; ring
+  - *_pos_real: pow_pos / mul_pos / add_pos
+  - Dissectability (6 theorems): refine + show + simp + exact
+  - twenty_seven_dissectable: reduce to three_squares_dissectable 3
 -/
 import Mathlib
 
@@ -62,79 +61,98 @@ theorem congruent_refl (T : Triangle) : Congruent T T := rfl
 
 -- Routine: For k ≥ 1, k^2 ≥ 1.
 -- k ≥ 1 implies k^2 ≥ 1^2 = 1.
-theorem sq_pos_of_pos (k : ℕ) (hk : k ≥ 1) : k ^ 2 ≥ 1 := by
-  sorry
+theorem sq_pos_of_pos (k : ℕ) (hk : k ≥ 1) : k ^ 2 ≥ 1 :=
+  calc k ^ 2 ≥ 1 ^ 2 := Nat.pow_le_pow_left hk 2
+    _ = 1 := one_pow 2
 
 -- Routine: The sum of k^2 copies of 1 equals k^2.
 -- ∑ i : Fin (k^2), (1 : ℝ) = k^2.
 theorem sum_fin_sq_one (k : ℕ) : ∑ _i : Fin (k ^ 2), (1 : ℝ) = k ^ 2 := by
-  sorry
+  simp [Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul]
+  push_cast; ring
 
 -- Routine: For k ≥ 1, k^2 > 0 as a real number.
 -- k ≥ 1 implies k^2 ≥ 1 > 0.
-theorem sq_pos_real (k : ℕ) (hk : k ≥ 1) : (k : ℝ) ^ 2 > 0 := by
-  sorry
+theorem sq_pos_real (k : ℕ) (hk : k ≥ 1) : (k : ℝ) ^ 2 > 0 :=
+  pow_pos (by exact_mod_cast show 0 < k from by omega) 2
 
 -- Routine: The sum of 2*k^2 copies of 1 equals 2*k^2.
 theorem sum_fin_two_sq_one (k : ℕ) : ∑ _i : Fin (2 * k ^ 2), (1 : ℝ) = 2 * k ^ 2 := by
-  sorry
+  simp [Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul]
+  push_cast; ring
 
 -- Routine: For k ≥ 1, 2 * k^2 > 0 as a real number.
-theorem two_sq_pos_real (k : ℕ) (hk : k ≥ 1) : 2 * (k : ℝ) ^ 2 > 0 := by
-  sorry
+theorem two_sq_pos_real (k : ℕ) (hk : k ≥ 1) : 2 * (k : ℝ) ^ 2 > 0 :=
+  mul_pos (by norm_num) (sq_pos_real k hk)
 
 -- Routine: The sum of 3*k^2 copies of 1 equals 3*k^2.
 theorem sum_fin_three_sq_one (k : ℕ) : ∑ _i : Fin (3 * k ^ 2), (1 : ℝ) = 3 * k ^ 2 := by
-  sorry
+  simp [Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul]
+  push_cast; ring
 
 -- Routine: For k ≥ 1, 3 * k^2 > 0 as a real number.
-theorem three_sq_pos_real (k : ℕ) (hk : k ≥ 1) : 3 * (k : ℝ) ^ 2 > 0 := by
-  sorry
+theorem three_sq_pos_real (k : ℕ) (hk : k ≥ 1) : 3 * (k : ℝ) ^ 2 > 0 :=
+  mul_pos (by norm_num) (sq_pos_real k hk)
 
 -- Routine: The sum of 6*k^2 copies of 1 equals 6*k^2.
 theorem sum_fin_six_sq_one (k : ℕ) : ∑ _i : Fin (6 * k ^ 2), (1 : ℝ) = 6 * k ^ 2 := by
-  sorry
+  simp [Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul]
+  push_cast; ring
 
 -- Routine: For k ≥ 1, 6 * k^2 > 0 as a real number.
-theorem six_sq_pos_real (k : ℕ) (hk : k ≥ 1) : 6 * (k : ℝ) ^ 2 > 0 := by
-  sorry
+theorem six_sq_pos_real (k : ℕ) (hk : k ≥ 1) : 6 * (k : ℝ) ^ 2 > 0 :=
+  mul_pos (by norm_num) (sq_pos_real k hk)
 
 -- Routine: For n, m ≥ 1, n^2 + m^2 > 0 as a real number.
 theorem sum_sq_pos_real (n m : ℕ) (hn : n ≥ 1) (hm : m ≥ 1) :
-    (n : ℝ) ^ 2 + m ^ 2 > 0 := by
-  sorry
+    (n : ℝ) ^ 2 + m ^ 2 > 0 :=
+  add_pos (sq_pos_real n hn) (sq_pos_real m hm)
 
 -- Routine: Perfect squares are dissectable.
 -- Use k^2 copies of the unit equilateral triangle.
 -- All pieces are the same triangle, so all are congruent.
 -- area_sum = k^2 * (1 * 1) = k^2 > 0 for k ≥ 1.
 theorem squares_dissectable (k : ℕ) (hk : k ≥ 1) : IsDissectable (k ^ 2) := by
-  sorry
+  refine ⟨unitEquilateral, ⟨fun _ => unitEquilateral, ?_⟩, fun _ _ => rfl⟩
+  show 0 < ∑ _ : Fin (k ^ 2), (1 : ℝ) * 1
+  simp only [mul_one, sum_fin_sq_one]; exact sq_pos_real k hk
 
 -- Routine: 2n² is dissectable.
 -- Use 2*n^2 copies of the unit equilateral triangle.
 theorem two_squares_dissectable (n : ℕ) (hn : n ≥ 1) : IsDissectable (2 * n ^ 2) := by
-  sorry
+  refine ⟨unitEquilateral, ⟨fun _ => unitEquilateral, ?_⟩, fun _ _ => rfl⟩
+  show 0 < ∑ _ : Fin (2 * n ^ 2), (1 : ℝ) * 1
+  simp only [mul_one, sum_fin_two_sq_one]; exact two_sq_pos_real n hn
 
 -- Routine: 3n² is dissectable.
 -- Use 3*n^2 copies of the unit equilateral triangle.
 theorem three_squares_dissectable (n : ℕ) (hn : n ≥ 1) : IsDissectable (3 * n ^ 2) := by
-  sorry
+  refine ⟨unitEquilateral, ⟨fun _ => unitEquilateral, ?_⟩, fun _ _ => rfl⟩
+  show 0 < ∑ _ : Fin (3 * n ^ 2), (1 : ℝ) * 1
+  simp only [mul_one, sum_fin_three_sq_one]; exact three_sq_pos_real n hn
 
 -- Routine: 6n² is dissectable.
 -- Use 6*n^2 copies of the unit equilateral triangle.
 theorem six_squares_dissectable (n : ℕ) (hn : n ≥ 1) : IsDissectable (6 * n ^ 2) := by
-  sorry
+  refine ⟨unitEquilateral, ⟨fun _ => unitEquilateral, ?_⟩, fun _ _ => rfl⟩
+  show 0 < ∑ _ : Fin (6 * n ^ 2), (1 : ℝ) * 1
+  simp only [mul_one, sum_fin_six_sq_one]; exact six_sq_pos_real n hn
 
 -- Routine: n² + m² is dissectable for n, m ≥ 1.
 -- Use n^2 + m^2 copies of the unit equilateral triangle.
 theorem sum_squares_dissectable (n m : ℕ) (hn : n ≥ 1) (hm : m ≥ 1) :
     IsDissectable (n ^ 2 + m ^ 2) := by
-  sorry
+  refine ⟨unitEquilateral, ⟨fun _ => unitEquilateral, ?_⟩, fun _ _ => rfl⟩
+  have hsum : ∑ _ : Fin (n ^ 2 + m ^ 2), (1 : ℝ) = n ^ 2 + m ^ 2 := by
+    simp [Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul]
+    push_cast; ring
+  show 0 < ∑ _ : Fin (n ^ 2 + m ^ 2), (1 : ℝ) * 1
+  simp only [mul_one, hsum]; exact sum_sq_pos_real n m hn hm
 
 -- Routine: 27 is dissectable.
 -- 27 = 3 * 3^2 = 3 * 9, so follows from three_squares_dissectable 3.
 theorem twenty_seven_dissectable : IsDissectable 27 := by
-  sorry
+  have : 27 = 3 * 3 ^ 2 := by norm_num
+  rw [this]; exact three_squares_dissectable 3 (by norm_num)
 
 end Erdos634Aristotle


### PR DESCRIPTION
Proves all 16 routine sorries in the Erdős #634 Aristotle companion file.

## Changes

- **`sq_pos_of_pos`**: `Nat.pow_le_pow_left` + `one_pow`
- **`sum_fin_{1,2,3,6}sq_one`**: `simp [Finset.sum_const, Fintype.card_fin, nsmul_eq_mul]` + `push_cast; ring`
- **`{1,2,3,6}sq_pos_real`**: `pow_pos` / `mul_pos (by norm_num)` / `add_pos`
- **`sum_sq_pos_real`**: `add_pos (sq_pos_real ...) (sq_pos_real ...)`
- **6 dissectability theorems** (`squares_dissectable`, `two_squares_dissectable`, etc.): `refine ⟨unitEquilateral, ⟨fun _ => unitEquilateral, ?_⟩, fun _ _ => rfl⟩` + `show` to reduce area_sum goal + simp
- **`twenty_seven_dissectable`**: `rw [show 27 = 3 * 3^2]` + `exact three_squares_dissectable 3`

No sorries remain in the file.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)