### PR TITLE
Fix: Erdos629Aristotle — prove 10 of 15 trivial sorries

### DIFF
--- a/proofs/Proofs/Erdos629Aristotle.lean
+++ b/proofs/Proofs/Erdos629Aristotle.lean
@@ -3,12 +3,19 @@
   Routine supporting lemmas for automated proof search.
   See Erdos629Problem.lean for the main formalization.
 
-  These lemmas provide building blocks for list coloring analysis:
-  - IsBipartite structural helpers
-  - listChromaticNumber monotonicity and basic properties
-  - n(k) function arithmetic (bounds, monotonicity)
-  - Exponential growth helpers
-  - Complete bipartite graph properties
+  10 of 15 sorries proved manually:
+  - Exponential bounds (5): pow_pred_lt, pow_lt_sq_pow, recursive_upper_bound_helper,
+    pow_factor, k_plus_one_pow_le — by omega/nlinarith/ring/calc
+  - n_mono_helper: direct application of monotonicity hypothesis
+  - Complete bipartite helpers (3): card_sum simp, cases + simp_all, Sum.noConfusion
+  - clog_ge_one: Nat.clog_pos
+
+  5 sorries remain for Aristotle:
+  - bipartite_chromatic_le_two: graph coloring API
+  - empty_graph_chromatic: graph coloring API
+  - sInf_mono_subset: suspicious as stated (false when T = ∅)
+  - clog_pow_two: uncertain Mathlib API
+  - clog_le_self: uncertain Mathlib API
 -/
 import Mathlib
 
@@ -38,25 +45,30 @@ lemma empty_graph_chromatic {V : Type*} [Fintype V] [DecidableEq V]
 -/
 
 /-- 2^(k-1) < 2^k for k ≥ 1 -/
-lemma pow_pred_lt (k : ℕ) (hk : k ≥ 1) : 2 ^ (k - 1) < 2 ^ k := by
-  sorry
+lemma pow_pred_lt (k : ℕ) (hk : k ≥ 1) : 2 ^ (k - 1) < 2 ^ k :=
+  Nat.pow_lt_pow_right (by norm_num) (by omega)
 
 /-- 2^k < k^2 * 2^(k+2) for k ≥ 1 -/
 lemma pow_lt_sq_pow (k : ℕ) (hk : k ≥ 1) : 2 ^ k < k ^ 2 * 2 ^ (k + 2) := by
-  sorry
+  have hpow : 0 < 2 ^ k := Nat.pos_pow_of_pos k (by norm_num)
+  have hk2 : 2 ^ (k + 2) = 4 * 2 ^ k := by ring
+  have hksq : 1 ≤ k ^ 2 := Nat.one_le_pow 2 k hk
+  nlinarith [hk2, hpow, hksq]
 
 /-- k * n ≤ k^2 * 2^k when n ≤ k * 2^k -/
 lemma recursive_upper_bound_helper (k n : ℕ) (h : n ≤ k * 2 ^ k) :
-    k * n ≤ k ^ 2 * 2 ^ k := by
-  sorry
+    k * n ≤ k ^ 2 * 2 ^ k :=
+  calc k * n ≤ k * (k * 2 ^ k) := Nat.mul_le_mul_left k h
+    _ = k ^ 2 * 2 ^ k := by ring
 
 /-- 2^k + k * 2^k = (k+1) * 2^k -/
-lemma pow_factor (k : ℕ) : 2 ^ k + k * 2 ^ k = (k + 1) * 2 ^ k := by
-  sorry
+lemma pow_factor (k : ℕ) : 2 ^ k + k * 2 ^ k = (k + 1) * 2 ^ k := by ring
 
 /-- (k+1) * 2^k ≤ k^2 * 2^(k+2) for k ≥ 2 -/
 lemma k_plus_one_pow_le (k : ℕ) (hk : k ≥ 2) : (k + 1) * 2 ^ k ≤ k ^ 2 * 2 ^ (k + 2) := by
-  sorry
+  have hpow : 0 < 2 ^ k := Nat.pos_pow_of_pos k (by norm_num)
+  have hk2 : 2 ^ (k + 2) = 4 * 2 ^ k := by ring
+  nlinarith [hk2, hpow, hk]
 
 /-
   ## Section 3: Csínf / sInf Monotonicity
@@ -69,8 +81,8 @@ lemma sInf_mono_subset (S T : Set ℕ) (h : T ⊆ S) (hS : S.Nonempty) :
 
 /-- n(k) is monotone: n(k₁) ≤ n(k₂) for k₁ ≤ k₂ -/
 lemma n_mono_helper (n : ℕ → ℕ) (hmono : ∀ k₁ k₂, k₁ ≤ k₂ → n k₁ ≤ n k₂)
-    (k : ℕ) : n k ≤ n (k + 2) := by
-  sorry
+    (k : ℕ) : n k ≤ n (k + 2) :=
+  hmono k (k + 2) (by omega)
 
 /-
   ## Section 4: Complete Bipartite Graph Properties
@@ -79,7 +91,7 @@ lemma n_mono_helper (n : ℕ → ℕ) (hmono : ∀ k₁ k₂, k₁ ≤ k₂ → 
 /-- Complete bipartite graph K_{m,n} has m + n vertices -/
 lemma completeBipartite_card (m n : ℕ) :
     Fintype.card (Fin m ⊕ Fin n) = m + n := by
-  sorry
+  simp [Fintype.card_sum, Fintype.card_fin]
 
 /-- K_{1,1} has 1 edge (it's just one edge) -/
 lemma K11_card_adj : ∀ (u v : Fin 1 ⊕ Fin 1),
@@ -87,19 +99,20 @@ lemma K11_card_adj : ∀ (u v : Fin 1 ⊕ Fin 1),
     | Sum.inl _, Sum.inr _ => True
     | Sum.inr _, Sum.inl _ => True
     | _, _ => False) → u ≠ v := by
-  sorry
+  intro u v h
+  cases u <;> cases v <;> simp_all
 
 /-- Sum.inl and Sum.inr are always different -/
-lemma inl_ne_inr {α β : Type*} (a : α) (b : β) : Sum.inl a ≠ (Sum.inr b : α ⊕ β) := by
-  sorry
+lemma inl_ne_inr {α β : Type*} (a : α) (b : β) : Sum.inl a ≠ (Sum.inr b : α ⊕ β) :=
+  fun h => Sum.noConfusion h
 
 /-
   ## Section 5: List Chromatic Ceiling
 -/
 
 /-- Nat.clog 2 n ≥ 1 for n ≥ 2 -/
-lemma clog_ge_one (n : ℕ) (hn : n ≥ 2) : Nat.clog 2 n ≥ 1 := by
-  sorry
+lemma clog_ge_one (n : ℕ) (hn : n ≥ 2) : Nat.clog 2 n ≥ 1 :=
+  Nat.clog_pos (by norm_num) hn
 
 /-- Nat.clog 2 (2^k) = k -/
 lemma clog_pow_two (k : ℕ) : Nat.clog 2 (2 ^ k) = k := by


### PR DESCRIPTION
Proves 10 of 15 routine sorries in the Erdős #629 Aristotle companion file.

## Proved (10)

- **`pow_pred_lt`**: `Nat.pow_lt_pow_right`
- **`pow_lt_sq_pow`**: `nlinarith` with `2^(k+2) = 4·2^k`, `0 < 2^k`, `1 ≤ k^2`
- **`recursive_upper_bound_helper`**: `calc` + `Nat.mul_le_mul_left` + `ring`
- **`pow_factor`**: `ring`
- **`k_plus_one_pow_le`**: `nlinarith` with power expansion
- **`n_mono_helper`**: `hmono k (k+2) (by omega)`
- **`completeBipartite_card`**: `simp [Fintype.card_sum, Fintype.card_fin]`
- **`K11_card_adj`**: `cases u <;> cases v <;> simp_all`
- **`inl_ne_inr`**: `fun h => Sum.noConfusion h`
- **`clog_ge_one`**: `Nat.clog_pos (by norm_num) hn`

## Remaining sorry (5)

- `bipartite_chromatic_le_two` / `empty_graph_chromatic`: graph coloring API complexity
- `sInf_mono_subset`: lemma appears false as stated when `T = ∅`
- `clog_pow_two` / `clog_le_self`: uncertain Mathlib API names

🤖 Generated with [Claude Code](https://claude.ai/claude-code)