### PR TITLE
Fix: Erdos437Aristotle — prove 13 of 15 trivial sorries

### DIFF
--- a/proofs/Proofs/Erdos437Aristotle.lean
+++ b/proofs/Proofs/Erdos437Aristotle.lean
@@ -3,12 +3,14 @@
   Routine supporting lemmas for automated proof search.
   See Erdos437Problem.lean for the main formalization.
 
-  These lemmas provide building blocks for partial product square counting:
-  - IsSquare and squareCount basic properties
-  - Division arithmetic for L(x)/x bound proofs
-  - Powers-of-four square counting
-  - u(x) = sqrt(log x * log log x) basic properties
-  - Real.exp inequalities for growth rate comparisons
+  13 of 15 sorries proved manually:
+  - IsSquare helpers (4): ⟨2^k, ring⟩, obtain + ring, ring, Nat.one_le_pow
+  - Division arithmetic (4): le_div_iff/div_le_iff + linarith, Nat.cast_pos, div_le_one_of_le
+  - u/exp/sqrt helpers (5): sqrt_nonneg, exp_le_exp.mpr, exp_lt_one_iff.mpr, sqrt_pos_of_pos, div_lt_iff + ring
+
+  2 sorries remain for Aristotle:
+  - partial_product_cons: complex List.foldl identity (non-trivial associativity)
+  - pow_four_range_product: complex inductive list product formula
 -/
 import Mathlib
 
@@ -21,20 +23,20 @@ namespace Erdos437.Aristotle
 -/
 
 /-- 4^k is a perfect square (= (2^k)^2) -/
-lemma isSquare_pow_four (k : ℕ) : IsSquare (4 ^ k) := by
-  sorry
+lemma isSquare_pow_four (k : ℕ) : IsSquare (4 ^ k) :=
+  ⟨2 ^ k, by ring⟩
 
 /-- Product of two squares is a square -/
 lemma isSquare_mul (a b : ℕ) (ha : IsSquare a) (hb : IsSquare b) : IsSquare (a * b) := by
-  sorry
+  obtain ⟨m, hm⟩ := ha; obtain ⟨n, hn⟩ := hb
+  exact ⟨m * n, by rw [hm, hn]; ring⟩
 
 /-- 4^i * 4^j = 4^(i+j) -/
-lemma pow_four_mul (i j : ℕ) : 4 ^ i * 4 ^ j = 4 ^ (i + j) := by
-  sorry
+lemma pow_four_mul (i j : ℕ) : 4 ^ i * 4 ^ j = 4 ^ (i + j) := by ring
 
 /-- 4^k ≥ 1 for all k -/
-lemma pow_four_pos (k : ℕ) : 4 ^ k ≥ 1 := by
-  sorry
+lemma pow_four_pos (k : ℕ) : 4 ^ k ≥ 1 :=
+  Nat.one_le_pow k 4 (by norm_num)
 
 /-
   ## Section 2: List Partial Products
@@ -56,20 +58,20 @@ lemma pow_four_range_product (k : ℕ) :
 -/
 
 /-- If a ≥ x * c and x > 0, then a / x ≥ c for reals -/
-lemma div_ge_of_ge_mul (a x c : ℝ) (hx : x > 0) (h : a ≥ x * c) : a / x ≥ c := by
-  sorry
+lemma div_ge_of_ge_mul (a x c : ℝ) (hx : x > 0) (h : a ≥ x * c) : a / x ≥ c :=
+  (le_div_iff hx).mpr (by linarith)
 
 /-- If a ≤ x * c and x > 0, then a / x ≤ c for reals -/
-lemma div_le_of_le_mul (a x c : ℝ) (hx : x > 0) (h : a ≤ x * c) : a / x ≤ c := by
-  sorry
+lemma div_le_of_le_mul (a x c : ℝ) (hx : x > 0) (h : a ≤ x * c) : a / x ≤ c :=
+  (div_le_iff hx).mpr (by linarith)
 
 /-- x > 0 as real when x ≥ 1 as natural -/
-lemma cast_pos_of_ge_one (x : ℕ) (hx : x ≥ 1) : (x : ℝ) > 0 := by
-  sorry
+lemma cast_pos_of_ge_one (x : ℕ) (hx : x ≥ 1) : (x : ℝ) > 0 :=
+  Nat.cast_pos.mpr (by omega)
 
 /-- (L x : ℝ) / x is in [0, 1] when L x ≤ x -/
-lemma div_L_le_one (L x : ℕ) (h : L ≤ x) (hx : x ≥ 1) : (L : ℝ) / x ≤ 1 := by
-  sorry
+lemma div_L_le_one (L x : ℕ) (h : L ≤ x) (hx : x ≥ 1) : (L : ℝ) / x ≤ 1 :=
+  div_le_one_of_le (by exact_mod_cast h) (by exact_mod_cast (show 0 ≤ x from by omega))
 
 /-
   ## Section 4: u(x) = sqrt(log x * log log x) Properties
@@ -77,23 +79,25 @@ lemma div_L_le_one (L x : ℕ) (h : L ≤ x) (hx : x ≥ 1) : (L : ℝ) / x ≤ 
 
 /-- u(x) ≥ 0 for x ≥ 2 -/
 lemma u_nonneg (x : ℕ) (hx : x ≥ 2) :
-    Real.sqrt (Real.log x * Real.log (Real.log x)) ≥ 0 := by
-  sorry
+    Real.sqrt (Real.log x * Real.log (Real.log x)) ≥ 0 :=
+  Real.sqrt_nonneg _
 
 /-- Real.exp is monotone -/
-lemma exp_mono (a b : ℝ) (h : a ≤ b) : Real.exp a ≤ Real.exp b := by
-  sorry
+lemma exp_mono (a b : ℝ) (h : a ≤ b) : Real.exp a ≤ Real.exp b :=
+  Real.exp_le_exp.mpr h
 
 /-- For c > 0 and u > 0, exp(-c * u) < 1 -/
-lemma exp_neg_lt_one (c u : ℝ) (hc : c > 0) (hu : u > 0) : Real.exp (-(c * u)) < 1 := by
-  sorry
+lemma exp_neg_lt_one (c u : ℝ) (hc : c > 0) (hu : u > 0) : Real.exp (-(c * u)) < 1 :=
+  Real.exp_lt_one_iff.mpr (by nlinarith [mul_pos hc hu])
 
 /-- sqrt 2 > 0 -/
-lemma sqrt_two_pos : Real.sqrt 2 > 0 := by
-  sorry
+lemma sqrt_two_pos : Real.sqrt 2 > 0 :=
+  Real.sqrt_pos_of_pos (by norm_num)
 
 /-- 1 / sqrt 2 < sqrt 2 -/
 lemma inv_sqrt_two_lt_sqrt_two : 1 / Real.sqrt 2 < Real.sqrt 2 := by
-  sorry
+  have hpos : Real.sqrt 2 > 0 := Real.sqrt_pos_of_pos (by norm_num)
+  have h2 : Real.sqrt 2 * Real.sqrt 2 = 2 := Real.mul_self_sqrt (by norm_num)
+  rw [div_lt_iff hpos, h2]; norm_num
 
 end Erdos437.Aristotle

--- a/research/problems/minkowski-fundamental-theorem-oq-04/selection-report.md
+++ b/research/problems/minkowski-fundamental-theorem-oq-04/selection-report.md
@@ -1,0 +1,65 @@
+# Problem Selection Report
+
+**Date**: 2026-04-22
+**Mode**: SELECT
+**Pool Status**: 30 available, 561 in-progress, 1404 completed, 3 graduated
+
+## Selected Problem
+
+- **ID**: minkowski-fundamental-theorem-oq-04
+- **Name**: Minkowski Fundamental Theorem: Custom Lattice API vs ZLattice Comparison
+- **Tier**: B
+- **Significance**: 7/10
+- **Tractability**: 7/10
+- **Knowledge Score**: 0 (EMPTY)
+- **Status**: available
+
+## Selection Rationale
+
+1. **Highest composite among available, unclaimed, non-recently-selected candidates**: Composite score 77 (tractability 7 × 10 + significance 7), tied with `feuerbachs-theorem-defs-oq-04` but winning on domain diversity.
+2. **Domain diversity**: Recent session selections covered geometry (triangle-angle-sum-oq-02, napoleons-theorem-oq-02), algebra (sqrt2-minpoly), and combinatorics (shapley-folkman-oq-03, newton-inductive-step-oq-03). This problem adds number theory / Lean API analysis — a distinct domain.
+3. **Tractable and bounded**: The problem is not about proving new mathematics but about analysing and comparing two Lean formalization APIs. The source proof is complete (0 sorries, 662 lines), making the research scope well-defined.
+4. **Mathlib alignment value**: A ZLattice-native reformulation would benefit the Mathlib community directly, making findings reusable without the custom `Lattice n` wrapper.
+
+## Rejection Summary
+
+- **Candidates considered**: 30 available (25 in pool JSON + 5 from DB not yet in pool JSON)
+- **Candidates rejected**:
+  - `sqrt2-plus-sqrt3-irrational-oq-03` (composite 96) — active claim lock present
+  - `sqrt2-minpoly` (composite 86) — selected this session (commit 904edf6)
+  - `triangle-angle-sum-oq-02` (composite 68) — selected this session (commit 5a99877)
+  - `shapley-folkman-oq-03` (composite 67) — selected this session (commit 31c0a70)
+  - `newton-inductive-step-oq-03` (composite 67) — selected this session (commit 1e1abc5)
+  - `napoleons-theorem-oq-02` (composite 57) — selected this session (commit dcc6c36)
+  - `feuerbachs-theorem-defs-oq-04` (composite 77, tied) — geometry domain, same as two recent selections; diversity penalty applied
+  - `triangle-angle-sum-oq-03` (composite 76) — geometry domain, diversity penalty applied
+  - Open conjectures (sophie-germain, twin-primes, weak-goldbach) — tractability ≤ 2, below threshold
+- **Confidence**: high (7-point gap over next non-geometry candidate; diversity reasoning is clear)
+
+## Related Gallery Proofs
+
+- `minkowski-fundamental-theorem`: Parent proof — custom Lattice API + ZSpan bridge, 662 lines, fully verified (0 sorries, 0 axioms)
+
+## Suggested First Steps
+
+1. **OBSERVE**: Survey `Mathlib.Algebra.Module.ZLattice.Basic` and `Mathlib.Algebra.Module.ZLattice.Covolume` — list every `ZLattice` definition and theorem that overlaps with `Lattice n` in `MinkowskiFundamentalTheorem.lean`
+2. **ORIENT**: Identify the key bridging point: does Mathlib's `ZLattice` have a `covolume` definition? Does `ZSpan.isAddFundamentalDomain` relate to `ZLattice`? Map the correspondence (or gap)
+3. **DECIDE**: Determine whether a full refactoring is feasible within a few sessions, or whether a focused comparison document (without refactoring) is the better deliverable; draft a structured API comparison table
+
+## Pool Summary After Selection
+
+| Status | Count |
+|--------|-------|
+| Available | 30 |
+| In Progress | 561 |
+| Completed | 1404 |
+| Graduated | 3 |
+| Blocked | 1 |
+
+## Candidate Pool Health
+
+Pool is healthy and well above threshold.
+
+- Pool depth: **adequate** (30 available vs. 15 threshold)
+- Recommendation: Pool healthy — no immediate replenishment needed
+- Next refresh recommended: in ~6 selections or when pool drops below 20 available


### PR DESCRIPTION
Proves 13 of 15 routine sorries in the Erdős #437 Aristotle companion file.

## Proved (13)

- **`isSquare_pow_four`**: `⟨2^k, by ring⟩` (4^k = (2^k)^2)
- **`isSquare_mul`**: obtain witnesses + `ring`
- **`pow_four_mul`**: `ring`
- **`pow_four_pos`**: `Nat.one_le_pow k 4`
- **`div_ge_of_ge_mul`**: `(le_div_iff hx).mpr (by linarith)`
- **`div_le_of_le_mul`**: `(div_le_iff hx).mpr (by linarith)`
- **`cast_pos_of_ge_one`**: `Nat.cast_pos.mpr (by omega)`
- **`div_L_le_one`**: `div_le_one_of_le`
- **`u_nonneg`**: `Real.sqrt_nonneg _`
- **`exp_mono`**: `Real.exp_le_exp.mpr h`
- **`exp_neg_lt_one`**: `Real.exp_lt_one_iff.mpr (by nlinarith [mul_pos hc hu])`
- **`sqrt_two_pos`**: `Real.sqrt_pos_of_pos (by norm_num)`
- **`inv_sqrt_two_lt_sqrt_two`**: `div_lt_iff + mul_self_sqrt + norm_num`

## Remaining sorry (2)

- `partial_product_cons`: non-trivial `List.foldl` commutativity identity
- `pow_four_range_product`: complex inductive product formula

🤖 Generated with [Claude Code](https://claude.ai/claude-code)