### PR TITLE
Enrich sqrt2-minpoly: add 7 annotations on Eisenstein, Gauss, minimal polynomial theory

### DIFF
--- a/src/data/proofs/sqrt2-minpoly/annotations.json
+++ b/src/data/proofs/sqrt2-minpoly/annotations.json
@@ -1,1 +1,86 @@
-[]
+[
+  {
+    "id": "ann-sqrt2-overview",
+    "proofId": "sqrt2-minpoly",
+    "range": { "startLine": 1, "endLine": 36 },
+    "type": "context",
+    "title": "Why Minimal Polynomials Matter",
+    "content": "**The central concept**: for an algebraic number $\\alpha$ (a root of some polynomial with rational coefficients), the minimal polynomial $\\text{minpoly}_{\\mathbb{Q}}(\\alpha)$ is the unique monic polynomial of smallest degree in $\\mathbb{Q}[X]$ with $\\alpha$ as a root.\n\nFor $\\sqrt{2}$, the minimal polynomial $X^2 - 2$ encodes three fundamental facts:\n1. $\\sqrt{2}$ is **irrational** — if it were rational, its minimal polynomial would have degree 1\n2. $\\mathbb{Q}(\\sqrt{2})$ is a **quadratic extension** of $\\mathbb{Q}$ with dimension 2 as a vector space\n3. The **splitting field** of $X^2 - 2$ is $\\mathbb{Q}(\\sqrt{2}) = \\{a + b\\sqrt{2} \\mid a,b \\in \\mathbb{Q}\\}$\n\nThis particular result is one of the foundational examples in Galois theory — the simplest non-trivial algebraic extension.",
+    "mathContext": "For a field extension $K \\subseteq L$ and $\\alpha \\in L$ algebraic over $K$: $\\text{minpoly}_K(\\alpha)$ is the generator of the kernel of the evaluation map $\\text{ev}_\\alpha : K[X] \\to L$, $f \\mapsto f(\\alpha)$. Since $K[X]$ is a PID, this kernel is principal, and the generator (chosen monic) is the minimal polynomial.",
+    "significance": "context",
+    "relatedConcepts": ["algebraic extension", "minimal polynomial", "PID", "evaluation map", "Galois theory"],
+    "prerequisites": ["field extensions", "polynomial rings", "principal ideal domains"]
+  },
+  {
+    "id": "ann-sqrt2-eisenstein-int",
+    "proofId": "sqrt2-minpoly",
+    "range": { "startLine": 42, "endLine": 68 },
+    "type": "technique",
+    "title": "Eisenstein's Criterion at p = 2",
+    "content": "**The Eisenstein irreducibility criterion** (1850) gives a sufficient condition for a polynomial $f = a_n X^n + \\cdots + a_0 \\in \\mathbb{Z}[X]$ to be irreducible over $\\mathbb{Z}$ and $\\mathbb{Q}$: if there exists a prime $p$ such that:\n- $p \\nmid a_n$ (leading coefficient)\n- $p \\mid a_i$ for all $i < n$\n- $p^2 \\nmid a_0$ (constant term)\n\nFor $X^2 - 2$ at $p = 2$: $a_2 = 1$, $a_1 = 0$, $a_0 = -2$. We have $2 \\nmid 1$, $2 \\mid 0$, $2 \\mid (-2)$, and $4 \\nmid (-2)$ — all conditions satisfied.\n\nIn Lean, `Polynomial.irreducible_of_eisenstein_criterion` takes 6 arguments verified in order: primality of the ideal, leading coefficient not in ideal, all lower coefficients in ideal, positive degree, constant term not in $p^2$, and primitivity.",
+    "mathContext": "Eisenstein's criterion works by contradiction: if $f = gh$ with $\\deg g, \\deg h < \\deg f$, reduce mod $p$ to get $\\bar{f} = \\bar{g}\\bar{h}$ in $(\\mathbb{Z}/p\\mathbb{Z})[X]$. Since $p \\nmid a_n$ but $p \\mid a_i$ for $i < n$, we get $\\bar{f} = X^n$ (up to unit). So $\\bar{g} = X^j$ and $\\bar{h} = X^k$, meaning $p \\mid g_0$ and $p \\mid h_0$, giving $p^2 \\mid a_0$ — contradiction.",
+    "significance": "key",
+    "relatedConcepts": ["Eisenstein criterion", "prime ideal", "primitive polynomial", "irreducibility", "interval_cases tactic"],
+    "prerequisites": ["ring theory", "polynomial arithmetic", "prime ideals", "Lean 4 norm_num"]
+  },
+  {
+    "id": "ann-sqrt2-gauss",
+    "proofId": "sqrt2-minpoly",
+    "range": { "startLine": 70, "endLine": 78 },
+    "type": "technique",
+    "title": "Gauss's Lemma: Lifting ℤ-Irreducibility to ℚ",
+    "content": "**Gauss's lemma** (one formulation): a *primitive* polynomial over $\\mathbb{Z}$ is irreducible over $\\mathbb{Z}$ if and only if it is irreducible over $\\mathbb{Q}$.\n\nA polynomial is **primitive** if the GCD of its coefficients is 1. Monic polynomials are always primitive (leading coefficient 1 is coprime to everything).\n\nThe proof chain: $X^2 - 2$ is monic (hence primitive over $\\mathbb{Z}$) + irreducible over $\\mathbb{Z}$ → by Gauss's lemma → irreducible over $\\mathbb{Q}$.\n\nIn Lean: `IsPrimitive.Int.irreducible_iff_irreducible_map_cast` lifts the ℤ result to ℚ via `Polynomial.map (Int.castRingHom ℚ)`. The `rwa` with a `show` sidestep handles the definitional equality between the mapped polynomial and the ℚ version.",
+    "mathContext": "Gauss's lemma follows from the multiplicativity of content: if $f = gh$ over $\\mathbb{Q}$, clear denominators to get $N \\cdot f = g' h'$ over $\\mathbb{Z}$. Taking contents: $\\text{cont}(N \\cdot f) = N$ (since $f$ primitive) and $\\text{cont}(g' h') = \\text{cont}(g')\\text{cont}(h')$, giving a factorization over $\\mathbb{Z}$.",
+    "significance": "key",
+    "relatedConcepts": ["Gauss's lemma", "primitive polynomial", "content", "ℤ to ℚ lift", "ring homomorphism"],
+    "prerequisites": ["polynomial rings over ℤ and ℚ", "content of a polynomial", "UFDs"]
+  },
+  {
+    "id": "ann-sqrt2-root",
+    "proofId": "sqrt2-minpoly",
+    "range": { "startLine": 82, "endLine": 92 },
+    "type": "theorem",
+    "title": "Root Witness: (√2)² = 2",
+    "content": "**Two theorems**:\n\n1. `aeval_sqrt_two_eq_zero`: evaluating $X^2 - 2$ at $\\sqrt{2}$ gives 0. The key fact is `Real.sq_sqrt : ∀ x ≥ 0, (√x)² = x`, applied at `x = 2`. After `simp` unfolds `aeval`, the goal reduces to `(√2)^2 - 2 = 0`, closed by `linarith`.\n\n2. `sqrt_two_isIntegral`: packages the root witness as an `IsIntegral ℚ (√2)` certificate — constructively providing the monic polynomial $X^2 - 2$ and its root property. This is needed downstream for `adjoin.finrank`.\n\n**Why two separate lemmas?** The minimal polynomial machinery (`minpoly.eq_of_irreducible_of_monic`) needs the `aeval = 0` form; the field extension degree theorem needs `IsIntegral`.",
+    "mathContext": "`Polynomial.aeval α f = f(α)` where $f \\in K[X]$ is evaluated at $\\alpha \\in L$. For $f = X^2 - C(2)$: $\\text{aeval}(\\sqrt{2})(X^2 - C(2)) = (\\sqrt{2})^2 - 2 = 0$. The `IsIntegral ℚ (√2)` statement says $\\sqrt{2}$ is a root of some monic polynomial in $\\mathbb{Q}[X]$; here we provide $X^2 - 2$ explicitly.",
+    "significance": "supporting",
+    "relatedConcepts": ["aeval", "IsIntegral", "Real.sq_sqrt", "algebraic numbers", "linarith tactic"],
+    "prerequisites": ["polynomial evaluation", "real square roots", "integral elements"]
+  },
+  {
+    "id": "ann-sqrt2-main",
+    "proofId": "sqrt2-minpoly",
+    "range": { "startLine": 96, "endLine": 109 },
+    "type": "theorem",
+    "title": "Main Theorem: minpoly ℚ (√2) = X² - 2",
+    "content": "**The capstone result**, combining all three ingredients:\n\n```lean\ntheorem minpoly_sqrt_two : minpoly ℚ (Real.sqrt 2) = X ^ 2 - C 2 :=\n  (minpoly.eq_of_irreducible_of_monic\n    irred_X_sq_sub_two        -- ①\n    aeval_sqrt_two_eq_zero    -- ②\n    (monic_X_pow_sub_C ...))  -- ③\n  .symm\n```\n\nThe Mathlib lemma `minpoly.eq_of_irreducible_of_monic` states: if $p \\in K[X]$ is (①) irreducible, (②) has $\\alpha$ as a root, and (③) is monic, then $p = \\text{minpoly}_K(\\alpha)$. The `.symm` flips the direction since the lemma returns `minpoly K α = p` but we want `minpoly K α = X² - 2`.\n\nThis characterization is elegant: it replaces the abstract universal-property definition of minimal polynomial with three checkable properties.",
+    "mathContext": "The minimal polynomial $\\text{minpoly}_K(\\alpha)$ is uniquely characterized as the monic irreducible polynomial in $K[X]$ with $\\alpha$ as a root. `minpoly.eq_of_irreducible_of_monic` states: if $p$ is monic, irreducible, and $p(\\alpha)=0$, then $p = \\text{minpoly}_K(\\alpha)$. The proof goes via uniqueness: both $p$ and $\\text{minpoly}$ are monic irreducibles dividing the same ideal, so they're associates in $K[X]$, hence equal (since both monic).",
+    "significance": "critical",
+    "relatedConcepts": ["minpoly.eq_of_irreducible_of_monic", "monic polynomial", "uniqueness of minimal polynomial", ".symm"],
+    "prerequisites": ["minimal polynomial theory", "irreducibility", "monicity", "Mathlib minpoly API"]
+  },
+  {
+    "id": "ann-sqrt2-degree",
+    "proofId": "sqrt2-minpoly",
+    "range": { "startLine": 113, "endLine": 127 },
+    "type": "insight",
+    "title": "Algebraic Degree 2 and Extension Degree [ℚ(√2):ℚ] = 2",
+    "content": "**Two corollaries** extracted from the main theorem:\n\n1. **Algebraic degree**: `natDegree (minpoly ℚ √2) = 2`. Substituting the main theorem, this reduces to computing the degree of $X^2 - 2$. The proof uses `natDegree_sub_eq_left_of_natDegree_lt` because $\\deg(X^2) = 2 > 0 = \\deg(C(2))$.\n\n2. **Extension degree**: `Module.finrank ℚ ℚ⟮√2⟯ = 2`. By `IntermediateField.adjoin.finrank`, the dimension of $K(\\alpha)$ over $K$ equals the degree of $\\text{minpoly}_K(\\alpha)$. Composing with the degree theorem gives 2.\n\nThis establishes $\\mathbb{Q}(\\sqrt{2}) \\cong \\mathbb{Q}[X]/(X^2 - 2)$ as a 2-dimensional $\\mathbb{Q}$-vector space with basis $\\{1, \\sqrt{2}\\}$.",
+    "mathContext": "The **tower theorem**: $[L:K] = [L:F][F:K]$ for $K \\subseteq F \\subseteq L$. For a simple algebraic extension: $[K(\\alpha):K] = \\deg(\\text{minpoly}_K(\\alpha))$. The isomorphism $K(\\alpha) \\cong K[X]/(\\text{minpoly}_K(\\alpha))$ holds because $\\text{ev}_\\alpha : K[X] \\to K(\\alpha)$ is surjective with kernel $(\\text{minpoly}_K(\\alpha))$.",
+    "significance": "key",
+    "relatedConcepts": ["field extension degree", "adjoin.finrank", "tower theorem", "simple algebraic extension", "Module.finrank"],
+    "prerequisites": ["field extension dimension", "IntermediateField", "Module.finrank API"]
+  },
+  {
+    "id": "ann-sqrt2-irrationality",
+    "proofId": "sqrt2-minpoly",
+    "range": { "startLine": 129, "endLine": 140 },
+    "type": "insight",
+    "title": "Irrationality from the Minimal Polynomial Perspective",
+    "content": "**Two irrationality theorems** providing different viewpoints:\n\n1. `sqrt_two_irrational`: delegates directly to Mathlib's `irrational_sqrt_two` (a standalone proof). This confirms the gallery has a companion irrationality entry.\n\n2. `sqrt_two_not_rational`: explicitly states $\\forall q : \\mathbb{Q}, (q : \\mathbb{R}) \\neq \\sqrt{2}$, proved by contradiction using `irrational_sqrt_two`.\n\n**The minimal polynomial perspective on irrationality**: if $\\sqrt{2}$ were rational, say $\\sqrt{2} = q \\in \\mathbb{Q}$, then its minimal polynomial would be $X - q$ (degree 1). But we proved the minimal polynomial is $X^2 - 2$ (degree 2). Contradiction. This is a clean conceptual argument, even if the actual Lean proof here uses the direct `irrational_sqrt_two`.",
+    "mathContext": "An element $\\alpha \\in L$ satisfies $\\alpha \\in K$ if and only if $\\deg(\\text{minpoly}_K(\\alpha)) = 1$. Proof: if $\\alpha \\in K$ then $X - \\alpha \\in K[X]$ is monic, irreducible, and evaluates to 0, so it's the minimal polynomial (degree 1). Conversely, if $\\text{minpoly} = X - c$ then $c = \\alpha$ by evaluating. So $\\deg = 2$ certifies $\\sqrt{2} \\notin \\mathbb{Q}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["irrational numbers", "degree-1 minimal polynomial", "Irrational type", "rational cast"],
+    "prerequisites": ["irrationality", "Mathlib.Data.Real.Irrational", "degree-1 characterization of rational elements"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `sqrt2-minpoly` (quality: 40 → annotations added).

## Changes

`annotations.json` was empty. Added 7 annotations with full coverage of the 140-line proof:

| Annotation | Lines | Topic |
|---|---|---|
| `ann-sqrt2-overview` | 1–36 | Why minimal polynomials matter; irrationality/extension/splitting-field connection |
| `ann-sqrt2-eisenstein-int` | 42–68 | Eisenstein criterion — contradiction proof sketch + 6-argument Lean API |
| `ann-sqrt2-gauss` | 70–78 | Gauss's lemma — content multiplicativity, ℤ → ℚ lift |
| `ann-sqrt2-root` | 82–92 | Two root lemmas (`aeval` vs `IsIntegral`) and their roles downstream |
| `ann-sqrt2-main` | 96–109 | `minpoly.eq_of_irreducible_of_monic` three-ingredient characterization |
| `ann-sqrt2-degree` | 113–127 | Tower theorem, `adjoin.finrank`, ℚ(√2) ≅ ℚ[X]/(X²-2) |
| `ann-sqrt2-irrationality` | 129–140 | Minimal polynomial perspective: degree-1 iff rational |

All annotations include `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.