### PR TITLE
Fix: eliminate irrationality sorry in Sqrt2PlusSqrt3IrrationalOQ03

### DIFF
--- a/proofs/Proofs/Sqrt2PlusSqrt3IrrationalOQ03.lean
+++ b/proofs/Proofs/Sqrt2PlusSqrt3IrrationalOQ03.lean
@@ -31,7 +31,7 @@ Equivalently:
 3. **Minimal polynomial**: Since f is monic, irreducible, and vanishes at α,
    apply `minpoly.eq_of_irreducible_of_monic`.
 
-## Status: 3 sorries (irreducibility and consequences)
+## Status: 1 sorry (irreducibility of X⁴ − 10X² + 1 over ℚ)
 -/
 
 namespace Sqrt2PlusSqrt3IrrationalOQ03
@@ -135,13 +135,20 @@ theorem adjoin_sqrt2_plus_sqrt3_finrank :
     _ = 4 := h2
 
 /-- **Irrationality**: √2+√3 is not rational.
-    The degree-4 minimal polynomial certifies this: rational elements have
-    minimal polynomials of degree 1. -/
+    If √2+√3 = q ∈ ℚ, squaring gives (q²−5)/2 = √6, contradicting irrationality of √6. -/
 theorem sqrt2_plus_sqrt3_irrational : Irrational (Real.sqrt 2 + Real.sqrt 3) := by
+  have h2 : (0 : ℝ) ≤ 2 := by norm_num
+  have h3 : (0 : ℝ) ≤ 3 := by norm_num
+  have h6mult : sqrt 2 * sqrt 3 = sqrt 6 := by rw [← sqrt_mul h2]; norm_num
+  have hsix : Irrational (sqrt 6) :=
+    irrational_sqrt_natCast_iff.mpr (by native_decide)
   intro ⟨q, hq⟩
-  have := minpoly_sqrt2_plus_sqrt3
-  rw [show (Real.sqrt 2 + Real.sqrt 3) = (q : ℝ) from hq.symm] at this
-  simp [minpoly.eq_X_sub_C_of_algebraMap_inj] at this
-  sorry
+  have hsq : (q : ℝ) ^ 2 = 5 + 2 * sqrt 6 := by
+    have : (sqrt 2 + sqrt 3) ^ 2 = 5 + 2 * sqrt 6 := by
+      have : (sqrt 2 + sqrt 3) ^ 2 = sqrt 2 ^ 2 + 2 * (sqrt 2 * sqrt 3) + sqrt 3 ^ 2 := by ring
+      rw [this, sq_sqrt h2, sq_sqrt h3, h6mult]; ring
+    rw [hq]; exact this
+  have h6eq : sqrt 6 = ((q : ℝ) ^ 2 - 5) / 2 := by linarith
+  exact hsix ⟨(q ^ 2 - 5) / 2, by push_cast; linarith⟩
 
 end Sqrt2PlusSqrt3IrrationalOQ03

--- a/src/data/proofs/sqrt2-plus-sqrt3-irrational-oq-03/meta.json
+++ b/src/data/proofs/sqrt2-plus-sqrt3-irrational-oq-03/meta.json
@@ -16,10 +16,10 @@
       "square-roots"
     ],
     "badge": "original",
-    "sorries": 2,
+    "sorries": 1,
     "dateAdded": "2026-04-22",
     "axiomCount": 0,
-    "assumptions": "None. Two sorries remain: irreducibility of X⁴−10X²+1 over ℚ (mathematically clear via rational root + quadratic factor analysis) and the irrationality consequence.",
+    "assumptions": "None. One sorry remains: irreducibility of X⁴−10X²+1 over ℚ (mathematically clear via rational root theorem + quadratic factor case analysis).",
     "lineCount": 147,
     "theoremCount": 5,
     "definitionCount": 0,
@@ -51,7 +51,7 @@
     ]
   },
   "conclusion": {
-    "summary": "Proves minpoly ℚ (√2+√3) = X⁴−10X²+1 and [ℚ(√2+√3):ℚ]=4. Root check is fully formal; irreducibility has 2 sorries (mathematically complete arguments documented). 5 theorems, 147 lines.",
+    "summary": "Proves minpoly ℚ (√2+√3) = X⁴−10X²+1 and [ℚ(√2+√3):ℚ]=4. Root check and irrationality are fully formal; irreducibility has 1 sorry (mathematically complete argument documented). 5 theorems, ~160 lines.",
     "implications": "The degree-4 result shows √2+√3 is a primitive element of the biquadratic extension ℚ(√2,√3)/ℚ. Combined with the explicit minimal polynomial, this enables computation of the full Galois group (Klein 4-group) and explains why the polynomial factors mod every prime despite being irreducible over ℚ.",
     "openQuestions": [
       "Complete the irreducibility sorry: formalize the quadratic factor case analysis showing discriminant 96 and required a² ∈ {8,12} are non-squares.",
@@ -67,7 +67,7 @@
     "theoremCount": 5,
     "definitionCount": 0,
     "path": "Proofs/Sqrt2PlusSqrt3IrrationalOQ03.lean",
-    "sorries": 2
+    "sorries": 1
   },
   "crossReferences": [
     {
@@ -120,8 +120,8 @@
       "title": "Field Extension Degree and Irrationality",
       "startLine": 133,
       "endLine": 147,
-      "summary": "adjoin_sqrt2_plus_sqrt3_finrank: [ℚ(√2+√3):ℚ]=4 via adjoin.finrank and natDegree computation. sqrt2_plus_sqrt3_irrational: irrationality from minpoly (sorry — requires extracting from rational minpoly being degree 1)."
+      "summary": "adjoin_sqrt2_plus_sqrt3_finrank: [ℚ(√2+√3):ℚ]=4 via adjoin.finrank and natDegree computation. sqrt2_plus_sqrt3_irrational: fully proved by direct algebra — if √2+√3=q then (q²-5)/2=√6, contradicting irrationality of √6."
     }
   ],
-  "sorries": 2
+  "sorries": 1
 }


### PR DESCRIPTION
## Fix

Replace the sorry-based irrationality proof with a direct algebraic argument,
reducing sorry count from 2 → 1 in `Sqrt2PlusSqrt3IrrationalOQ03.lean`.

## Evidence

**Before**: `sqrt2_plus_sqrt3_irrational` was proved via `sorry`, with a broken
proof attempt that depended on `minpoly_sqrt2_plus_sqrt3` (which itself depended
on the remaining sorry `irred_f`).

**After**: Proved directly — if √2+√3 = q ∈ ℚ, squaring gives (q²−5)/2 = √6,
contradicting `irrational_sqrt_natCast_iff` (√6 is irrational since 6 is not a
perfect square, verified by `native_decide`). Proof does not depend on `irred_f`.

Gallery `meta.json` updated: `"sorries": 1` (down from 2). Only `irred_f`
remains (irreducibility of X⁴−10X²+1 over ℚ).

---
Automated fix by lean-mechanic agent.