### PR TITLE
Enrich sqrt2-plus-sqrt3-irrational-oq-03: 7 annotations, fix crossRefs (quality 45→100)

### DIFF
--- a/src/data/proofs/sqrt2-plus-sqrt3-irrational-oq-03/meta.json
+++ b/src/data/proofs/sqrt2-plus-sqrt3-irrational-oq-03/meta.json
@@ -71,19 +71,19 @@
   },
   "crossReferences": [
     {
-      "id": "sqrt2-plus-sqrt3-irrational",
-      "relationship": "parent",
+      "targetId": "sqrt2-plus-sqrt3-irrational",
+      "relationship": "extends",
       "description": "Parent proof establishing √2+√3 ∉ ℚ via the squaring trick. This proof gives the stronger result: √2+√3 has degree exactly 4 over ℚ."
     },
     {
-      "id": "sqrt2-minpoly",
+      "targetId": "sqrt2-minpoly",
       "relationship": "related",
       "description": "Minimal polynomial of √2 over ℚ is X²−2 (degree 2). The techniques are similar: Eisenstein for X²−2, rational root + quadratic factor analysis for X⁴−10X²+1."
     },
     {
-      "id": "algebraic-numbers",
+      "targetId": "algebraic-numbers-countable",
       "relationship": "related",
-      "description": "Algebraic numbers over ℚ: √2+√3 has degree 4, minimal polynomial X⁴−10X²+1, and generates the biquadratic extension ℚ(√2,√3)."
+      "description": "Algebraic numbers over ℚ are countable: √2+√3 has degree 4, minimal polynomial X⁴−10X²+1, and generates the biquadratic extension ℚ(√2,√3)."
     }
   ],
   "sections": [


### PR DESCRIPTION
Enrichment pass for `sqrt2-plus-sqrt3-irrational-oq-03`. Quality: 45 → 100.

**Added 7 annotations** (was empty):
- `ann-oq03-preamble` (lines 1–36): mathematical context, biquadratic derivation, and proof roadmap
- `ann-oq03-root-witness` (lines 38–69): step-by-step root computation — how `h2,h3,hsq,h23sq,h4` chain to `f(√2+√3)=0`
- `ann-oq03-monic` (lines 71–95): natDegree boilerplate and `IsIntegral` certificate
- `ann-oq03-irreducibility` (lines 97–106): documented rational root theorem + quadratic factor case analysis behind the sorry; explains why mod-p tests fail (Klein 4-group)
- `ann-oq03-main-theorem` (lines 108–116): single-line `minpoly.eq_of_irreducible_of_monic` assembly
- `ann-oq03-finrank` (lines 118–135): field extension degree and tower law; shows √2,√3 recoverable from √2+√3
- `ann-oq03-irrationality` (lines 137–147): degree-4 vs degree-1 contradiction approach to irrationality

**Fixed crossReferences**: replaced `"id"` key with `"targetId"`, corrected `algebraic-numbers` → `algebraic-numbers-countable`