### PR TITLE
Audit: full gallery pass + fixes — 2142 proofs verified (2026-04-22)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1,4 +1,11 @@
 {
+  "cantor-diagonalization-oq-02-oq-03-oq-02": {
+    "auditCount": 1,
+    "detectedIssues": null,
+    "lastAudited": "2026-04-21T17:41:37Z",
+    "notes": "Lean file has 0 actual sorries (diagInter_isUnbounded fully proved in PR #11082); stale documentation in comments mentioned \"the one sorry\". Fixed: sorries 1\u21920, badge wip\u2192original, status formalized\u2192verified.",
+    "result": "issues-fixed"
+  },
   "collatz-structured-oq-03": {
     "agentId": "auditor-cycle-2",
     "auditCount": 1,
@@ -16,10 +23,22 @@
     "result": "issues-fixed"
   },
   "entries": {
+    "No unclaimed targets available": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-03T16:57:29Z",
+      "result": "clean"
+    },
     "abel-ruffini": {
       "auditCount": 6,
       "issues": [],
       "lastAudited": "2026-04-22T20:12:20Z",
+      "result": "clean"
+    },
+    "abel-ruffini-galois-extensions": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:39:10Z",
       "result": "clean"
     },
     "abel-ruffini-oq-04": {
@@ -40,10 +59,46 @@
       "lastAudited": "2026-04-22T12:31:32Z",
       "result": "clean"
     },
+    "abel-ruffini-oq-04-oq-02-oq-02": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:35:38Z",
+      "result": "clean"
+    },
+    "abel-ruffini-oq-04-oq-02-oq-03": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:39:43Z",
+      "result": "clean"
+    },
     "abel-ruffini-oq-04-oq-03": {
       "auditCount": 4,
       "issues": [],
       "lastAudited": "2026-04-22T12:30:42Z",
+      "result": "clean"
+    },
+    "abel-ruffini-oq-04-oq-07": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:41:33Z",
+      "result": "clean"
+    },
+    "algebraic-numbers-countable": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:39:53Z",
+      "result": "clean"
+    },
+    "algebraic-numbers-countable-oq-02": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T18:28:23Z",
+      "result": "clean"
+    },
+    "algebraic-numbers-countable-oq-02-oq-02": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
       "result": "clean"
     },
     "amgm-inequality": {
@@ -58,10 +113,28 @@
       "lastAudited": "2026-04-22T21:35:36Z",
       "result": "clean"
     },
+    "amgm-inequality-oq-02-oq-01": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:41:21Z",
+      "result": "clean"
+    },
+    "amgm-inequality-oq-02-oq-01-oq-02": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
     "amgm-inequality-oq-02-oq-03": {
       "auditCount": 6,
       "issues": [],
       "lastAudited": "2026-04-22T12:35:37Z",
+      "result": "clean"
+    },
+    "amgm-inequality-oq-02-oq-03-oq-03": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:36:32Z",
       "result": "clean"
     },
     "amgm-inequality-oq-03": {
@@ -82,10 +155,40 @@
       "lastAudited": "2026-04-22T12:09:41Z",
       "result": "clean"
     },
+    "amgm-inequality-oq-03-oq-02-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T18:28:23Z",
+      "result": "clean"
+    },
+    "amgm-inequality-oq-03-oq-02-oq-01-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T11:37:16Z",
+      "result": "clean"
+    },
+    "amgm-inequality-oq-03-oq-02-oq-04": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T18:39:20Z",
+      "result": "clean"
+    },
     "amgm-inequality-oq-03-oq-03": {
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-04-22T08:47:19Z",
+      "result": "clean"
+    },
+    "amgm-inequality-oq-03-oq-03-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
+    "amgm-inequality-oq-03-oq-04": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T11:37:16Z",
       "result": "clean"
     },
     "amgm-inequality-oq-04": {
@@ -98,6 +201,36 @@
       "auditCount": 9,
       "issues": [],
       "lastAudited": "2026-04-22T12:38:08Z",
+      "result": "clean"
+    },
+    "angle-trisection-cos-20-gal": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:39:51Z",
+      "result": "clean"
+    },
+    "angle-trisection-cos-20-gal-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T18:28:23Z",
+      "result": "clean"
+    },
+    "angle-trisection-cos-20-gal-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-04-21T14:08:40Z",
+      "result": "issues-fixed"
+    },
+    "angle-trisection-cos-20-gal-oq-03": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
+    "angle-trisection-cos-20-gal-oq-03-oq-01": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-21T12:46:16Z",
       "result": "clean"
     },
     "angle-trisection-oq-01": {
@@ -123,6 +256,18 @@
       "lastAudited": "2026-04-22T12:12:38Z",
       "result": "clean"
     },
+    "angle-trisection-oq-02-oq-01-oq-02": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
+    "angle-trisection-oq-02-oq-02": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:42:01Z",
+      "result": "clean"
+    },
     "angle-trisection-oq-02-oq-03": {
       "auditCount": 5,
       "issues": [],
@@ -142,17 +287,23 @@
       "result": "clean"
     },
     "angle-trisection-oq-02-oq-04-oq-01": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [
         "sorry 7\u21923"
       ],
-      "lastAudited": "2026-04-13T03:29:17Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
     },
     "angle-trisection-oq-03": {
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-04-22T12:11:49Z",
+      "result": "clean"
+    },
+    "angle-trisection-oq-04": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:39:50Z",
       "result": "clean"
     },
     "angle-trisection-oq-05": {
@@ -197,6 +348,18 @@
       "lastAudited": "2026-04-22T12:09:43Z",
       "result": "clean"
     },
+    "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-04-21T12:07:57Z",
+      "result": "clean"
+    },
+    "area-of-circle-oq-01-oq-02-oq-01-oq-03": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
     "area-of-circle-oq-01-oq-02-oq-02": {
       "auditCount": 4,
       "issues": [],
@@ -209,6 +372,18 @@
       "lastAudited": "2026-04-22T12:16:29Z",
       "result": "clean"
     },
+    "area-of-circle-oq-01-oq-02-oq-03": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-22T12:38:31Z",
+      "result": "clean"
+    },
+    "area-of-circle-oq-01-oq-02-oq-03-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-04-21T13:15:24Z",
+      "result": "clean"
+    },
     "area-of-circle-oq-01-oq-03": {
       "auditCount": 4,
       "issues": [
@@ -217,10 +392,28 @@
       "lastAudited": "2026-04-21T14:38:37Z",
       "result": "clean"
     },
+    "area-of-circle-oq-01-oq-03-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:42:01Z",
+      "result": "clean"
+    },
     "area-of-circle-oq-02": {
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-04-22T12:30:41Z",
+      "result": "clean"
+    },
+    "area-of-circle-oq-02-oq-01": {
+      "auditCount": 4,
+      "issues": [],
+      "lastAudited": "2026-04-21T12:03:58Z",
+      "result": "issues-fixed"
+    },
+    "area-of-circle-oq-02-oq-04": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
       "result": "clean"
     },
     "area-of-circle-oq-03": {
@@ -246,10 +439,22 @@
       "lastAudited": "2026-04-22T12:30:41Z",
       "result": "clean"
     },
+    "area-of-circle-oq-03-oq-02-oq-02-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
     "area-of-circle-oq-03-oq-03": {
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-04-22T12:11:48Z",
+      "result": "clean"
+    },
+    "area-of-circle-oq-03-oq-03-oq-02": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:35:39Z",
       "result": "clean"
     },
     "area-of-circle-oq-05": {
@@ -260,10 +465,28 @@
       "lastAudited": "2026-04-21T15:42:01Z",
       "result": "clean"
     },
+    "area-of-circle-oq-05-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:35:35Z",
+      "result": "clean"
+    },
+    "area-of-circle-oq-05-oq-02": {
+      "auditCount": 4,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:29:10Z",
+      "result": "clean"
+    },
     "arithmetic-series": {
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-04-22T11:45:54Z",
+      "result": "clean"
+    },
+    "arithmetic-series-oq-00": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
       "result": "clean"
     },
     "arithmetic-series-oq-02": {
@@ -272,10 +495,28 @@
       "lastAudited": "2026-04-22T11:12:53Z",
       "result": "clean"
     },
+    "arithmetic-series-oq-02-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:39:10Z",
+      "result": "clean"
+    },
+    "arithmetic-series-oq-02-oq-01-oq-01": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-22T18:39:20Z",
+      "result": "clean"
+    },
     "arithmetic-series-oq-02-oq-02": {
       "auditCount": 4,
       "issues": [],
       "lastAudited": "2026-04-22T11:29:27Z",
+      "result": "clean"
+    },
+    "arithmetic-series-oq-02-oq-02-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:39:43Z",
       "result": "clean"
     },
     "arithmetic-series-oq-02-oq-02-oq-03": {
@@ -284,10 +525,58 @@
       "lastAudited": "2026-04-22T12:16:29Z",
       "result": "clean"
     },
+    "arithmetic-series-oq-02-oq-02-oq-03-oq-01": {
+      "auditCount": 2,
+      "issues": [
+        "sorries 1->0 (general Polya theorem now fully proved)",
+        "status formalized->verified, badge wip->verified",
+        "lineCount 365->507"
+      ],
+      "lastAudited": "2026-04-22T12:00:00Z",
+      "result": "issues-fixed"
+    },
+    "arithmetic-series-oq-02-oq-03": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
     "arithmetic-series-oq-02-oq-04": {
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-04-22T12:09:42Z",
+      "result": "clean"
+    },
+    "arithmetic-series-oq-02-oq-04-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:30:33Z",
+      "result": "issues-fixed"
+    },
+    "arithmetic-series-oq-02-oq-04-oq-01-oq-03": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T18:28:22Z",
+      "result": "clean"
+    },
+    "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02": {
+      "auditCount": 2,
+      "issues": [
+        "lineCount 122\u2192118 (corrected to match actual Lean file)"
+      ],
+      "lastAudited": "2026-04-21T13:30:00Z",
+      "result": "issues-fixed"
+    },
+    "arithmetic-series-oq-04": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:41:32Z",
+      "result": "clean"
+    },
+    "arithmetic-series-oq-04-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:35:38Z",
       "result": "clean"
     },
     "ballot-problem": {
@@ -314,10 +603,28 @@
       "lastAudited": "2026-04-22T21:53:12Z",
       "result": "clean"
     },
+    "ballot-problem-oq-01-oq-02-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
+    "ballot-problem-oq-01-oq-02-oq-04": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:35:38Z",
+      "result": "clean"
+    },
     "ballot-problem-oq-01-oq-04": {
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-04-22T12:12:37Z",
+      "result": "clean"
+    },
+    "ballot-problem-oq-01-oq-04-oq-01": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-22T11:12:59Z",
       "result": "clean"
     },
     "ballot-problem-oq-02": {
@@ -333,9 +640,21 @@
       "result": "clean"
     },
     "ballot-problem-oq-03-oq-01": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
+    "ballot-problem-oq-03-oq-01-oq-01": {
       "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-13T23:05:00Z",
+      "lastAudited": "2026-04-22T21:29:10Z",
+      "result": "clean"
+    },
+    "ballot-problem-oq-03-oq-01-oq-02": {
+      "auditCount": 7,
+      "issues": [],
+      "lastAudited": "2026-04-22T20:12:20Z",
       "result": "clean"
     },
     "ballot-problem-oq-03-oq-02": {
@@ -362,10 +681,30 @@
       "lastAudited": "2026-04-22T12:17:49Z",
       "result": "clean"
     },
+    "basel-problem-oq-01-oq-01-oq-02": {
+      "auditCount": 4,
+      "issues": [
+        "sorry 4\u21923"
+      ],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
+    "basel-problem-oq-01-oq-03": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:42:21Z",
+      "result": "clean"
+    },
     "basel-problem-oq-02": {
       "auditCount": 4,
       "issues": [],
       "lastAudited": "2026-04-22T12:31:33Z",
+      "result": "clean"
+    },
+    "basel-problem-oq-04": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
       "result": "clean"
     },
     "basel-problem-oq-05": {
@@ -386,10 +725,28 @@
       "lastAudited": "2026-04-22T11:12:57Z",
       "result": "clean"
     },
+    "bertrands-postulate-oq-03-oq-04": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:35:37Z",
+      "result": "clean"
+    },
+    "bertrands-postulate-oq-03-oq-04-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-04-21T10:45:42Z",
+      "result": "issues-fixed"
+    },
     "bezout-identity": {
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-04-22T11:45:54Z",
+      "result": "clean"
+    },
+    "bezout-identity-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:40:52Z",
       "result": "clean"
     },
     "bezout-identity-oq-02": {
@@ -404,10 +761,34 @@
       "lastAudited": "2026-04-22T11:38:17Z",
       "result": "clean"
     },
+    "bezout-identity-oq-02-oq-01-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:28:47Z",
+      "result": "issues-fixed"
+    },
+    "bezout-identity-oq-02-oq-01-oq-01-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:42:19Z",
+      "result": "clean"
+    },
     "bezout-identity-oq-02-oq-01-oq-02": {
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-04-22T12:17:49Z",
+      "result": "clean"
+    },
+    "bezout-identity-oq-02-oq-01-oq-02-oq-02": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:42:18Z",
+      "result": "clean"
+    },
+    "bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
       "result": "clean"
     },
     "bezout-identity-oq-02-oq-02": {
@@ -426,6 +807,14 @@
       "auditCount": 6,
       "issues": [],
       "lastAudited": "2026-04-22T12:12:37Z",
+      "result": "clean"
+    },
+    "bezout-identity-oq-02-oq-04": {
+      "auditCount": 3,
+      "issues": [
+        "badge original\u2192mathlib (core results are Mathlib wrappers; fixed by PR #10846)"
+      ],
+      "lastAudited": "2026-04-22T21:53:13Z",
       "result": "clean"
     },
     "bezout-identity-oq-03": {
@@ -452,10 +841,22 @@
       "lastAudited": "2026-04-22T11:13:00Z",
       "result": "clean"
     },
+    "bezout-identity-oq-03-oq-01-oq-02": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:40:52Z",
+      "result": "clean"
+    },
     "bezout-identity-oq-03-oq-04": {
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-04-22T12:11:48Z",
+      "result": "clean"
+    },
+    "bezout-identity-oq-03-oq-04-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T12:39:16Z",
       "result": "clean"
     },
     "bezout-identity-oq-04": {
@@ -470,6 +871,12 @@
       "lastAudited": "2026-04-22T12:12:38Z",
       "result": "clean"
     },
+    "bezout-identity-oq-04-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-04-21T17:27:38Z",
+      "result": "issues-fixed"
+    },
     "binary-gcd": {
       "auditCount": 3,
       "issues": [],
@@ -480,6 +887,18 @@
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-04-22T12:16:29Z",
+      "result": "clean"
+    },
+    "binary-gcd-oq-01-oq-04": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:42:07Z",
+      "result": "clean"
+    },
+    "binary-gcd-oq-03": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
       "result": "clean"
     },
     "binomial-theorem": {
@@ -512,10 +931,40 @@
       "lastAudited": "2026-04-22T12:11:48Z",
       "result": "clean"
     },
+    "binomial-theorem-oq-02-oq-01-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
+    "binomial-theorem-oq-02-oq-01-oq-02": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T12:39:16Z",
+      "result": "clean"
+    },
+    "binomial-theorem-oq-02-oq-01-oq-03": {
+      "auditCount": 5,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:13:46Z",
+      "result": "issues-fixed"
+    },
     "binomial-theorem-oq-02-oq-02": {
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-04-22T12:16:29Z",
+      "result": "clean"
+    },
+    "binomial-theorem-oq-02-oq-03": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:41:21Z",
+      "result": "clean"
+    },
+    "binomial-theorem-oq-02-oq-04": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:53:12Z",
       "result": "clean"
     },
     "binomial-theorem-oq-03": {
@@ -530,10 +979,22 @@
       "lastAudited": "2026-04-22T12:09:42Z",
       "result": "clean"
     },
+    "binomial-theorem-oq-03-oq-02-oq-03": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:42:17Z",
+      "result": "clean"
+    },
     "binomial-theorem-oq-04": {
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-04-22T11:45:54Z",
+      "result": "clean"
+    },
+    "binomial-theorem-oq-04-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:39:44Z",
       "result": "clean"
     },
     "binomial-theorem-oq-04-oq-02": {
@@ -544,25 +1005,31 @@
     },
     "binomial-theorem-oq-04-oq-02-oq-01": {
       "auditCount": 3,
+      "issues": [],
       "lastAudited": "2026-04-22T08:06:37Z",
-      "result": "issues-fixed",
-      "issues": []
+      "result": "issues-fixed"
     },
     "binomial-theorem-oq-04-oq-03": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
         "sorry 6\u21920",
         "axiomCount 1\u21920",
         "status axiomatized\u2192verified",
         "badge axiom\u2192original"
       ],
-      "lastAudited": "2026-04-13T03:29:17Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
     },
     "birch-swinnerton-dyer": {
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-04-13T23:07:49Z",
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
+    "birch-swinnerton-dyer-oq-06": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:42:16Z",
       "result": "clean"
     },
     "birthday-problem": {
@@ -577,6 +1044,12 @@
       "lastAudited": "2026-04-22T11:39:35Z",
       "result": "clean"
     },
+    "birthday-problem-oq-02-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:14:10Z",
+      "result": "clean"
+    },
     "birthday-problem-oq-03": {
       "auditCount": 3,
       "issues": [],
@@ -587,6 +1060,18 @@
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-04-22T12:16:29Z",
+      "result": "clean"
+    },
+    "birthday-problem-oq-03-oq-01-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:42:01Z",
+      "result": "clean"
+    },
+    "birthday-problem-oq-03-oq-01-oq-02": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:42:23Z",
       "result": "clean"
     },
     "birthday-problem-oq-03-oq-03": {
@@ -611,6 +1096,18 @@
       "auditCount": 4,
       "issues": [],
       "lastAudited": "2026-04-22T12:31:32Z",
+      "result": "clean"
+    },
+    "borsuk-ulam-oq-02-oq-01-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:42:15Z",
+      "result": "clean"
+    },
+    "borsuk-ulam-oq-02-oq-01-oq-03": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:42:08Z",
       "result": "clean"
     },
     "borsuk-ulam-oq-02-oq-01-oq-04": {
@@ -685,6 +1182,12 @@
       "lastAudited": "2026-04-22T12:34:32Z",
       "result": "clean"
     },
+    "bounded-prime-gaps-oq-03-oq-01-oq-04": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T20:03:41Z",
+      "result": "clean"
+    },
     "bounded-prime-gaps-oq-04": {
       "auditCount": 5,
       "issues": [],
@@ -708,6 +1211,18 @@
       "lastAudited": "2026-04-22T12:31:55Z",
       "result": "clean"
     },
+    "brouwer-fixed-point-oq-01-oq-02": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:41:34Z",
+      "result": "clean"
+    },
+    "brouwer-fixed-point-oq-01-oq-03": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:42:24Z",
+      "result": "clean"
+    },
     "brouwer-fixed-point-oq-02": {
       "auditCount": 6,
       "issues": [],
@@ -726,10 +1241,24 @@
       "lastAudited": "2026-04-22T12:35:37Z",
       "result": "clean"
     },
+    "brouwer-fixed-point-oq-04-oq-02": {
+      "auditCount": 4,
+      "issues": [
+        "NOTE: Researcher has fixed the sorry in working tree (uncommitted); HEAD has 1 sorry matching meta.json; meta.json update needed after researcher commits and proof compiles"
+      ],
+      "lastAudited": "2026-04-22T08:32:31Z",
+      "result": "clean"
+    },
     "brouwer-fixed-point-oq-04-oq-03": {
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-04-22T12:16:29Z",
+      "result": "clean"
+    },
+    "brouwer-fixed-point-oq-04-oq-04": {
+      "auditCount": 4,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:53:12Z",
       "result": "clean"
     },
     "buffons-needle": {
@@ -748,6 +1277,18 @@
       "auditCount": 6,
       "issues": [],
       "lastAudited": "2026-04-22T12:12:37Z",
+      "result": "clean"
+    },
+    "buffons-needle-oq-01-oq-01-oq-01": {
+      "auditCount": 4,
+      "issues": [],
+      "lastAudited": "2026-04-22T11:12:56Z",
+      "result": "clean"
+    },
+    "buffons-needle-oq-01-oq-01-oq-04": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
       "result": "clean"
     },
     "buffons-needle-oq-01-oq-02": {
@@ -775,9 +1316,15 @@
       "result": "clean"
     },
     "burnside-counting": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-13T23:04:08Z",
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
+    "burnside-counting-oq-03": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-22T12:39:16Z",
       "result": "clean"
     },
     "cantor-diagonalization": {
@@ -799,12 +1346,18 @@
       "result": "clean"
     },
     "cantor-diagonalization-oq-01-oq-01-oq-02": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
         "sorry 1\u21920",
         "status formalized\u2192verified"
       ],
-      "lastAudited": "2026-04-13T03:29:17Z",
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
+    "cantor-diagonalization-oq-01-oq-01-oq-02-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-04-21T10:41:07Z",
       "result": "issues-fixed"
     },
     "cantor-diagonalization-oq-02": {
@@ -819,6 +1372,18 @@
       "lastAudited": "2026-04-22T12:09:42Z",
       "result": "clean"
     },
+    "cantor-diagonalization-oq-02-oq-03": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:39:44Z",
+      "result": "clean"
+    },
+    "cantor-diagonalization-oq-02-oq-03-oq-02": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:39:56Z",
+      "result": "clean"
+    },
     "cantor-diagonalization-oq-03": {
       "auditCount": 4,
       "issues": [],
@@ -831,10 +1396,40 @@
       "lastAudited": "2026-04-22T12:17:48Z",
       "result": "clean"
     },
+    "cantor-diagonalization-oq-03-oq-01-incomplete-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:42:01Z",
+      "result": "clean"
+    },
+    "cantor-diagonalization-oq-03-oq-01-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T12:39:16Z",
+      "result": "clean"
+    },
+    "cantor-diagonalization-oq-03-oq-01-oq-02": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:33:20Z",
+      "result": "clean"
+    },
+    "cantor-diagonalization-oq-03-oq-01-oq-03": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-22T14:55:28Z",
+      "result": "clean"
+    },
     "cantor-diagonalization-oq-04": {
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-04-22T12:09:42Z",
+      "result": "clean"
+    },
+    "cantor-diagonalization-oq-04-oq-03": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
       "result": "clean"
     },
     "cantors-theorem": {
@@ -903,16 +1498,34 @@
       "lastAudited": "2026-04-22T12:17:48Z",
       "result": "clean"
     },
+    "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T18:28:22Z",
+      "result": "clean"
+    },
     "cauchy-schwarz-integral-oq-01-oq-01-oq-02": {
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-04-22T12:09:42Z",
       "result": "clean"
     },
+    "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01": {
+      "auditCount": 7,
+      "issues": [],
+      "lastAudited": "2026-04-21T11:53:37Z",
+      "result": "issues-fixed"
+    },
     "cauchy-schwarz-integral-oq-01-oq-02": {
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-04-22T11:45:55Z",
+      "result": "clean"
+    },
+    "cauchy-schwarz-integral-oq-01-oq-03": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:53:13Z",
       "result": "clean"
     },
     "cauchy-schwarz-integral-oq-02": {
@@ -933,6 +1546,12 @@
       "lastAudited": "2026-04-22T12:11:49Z",
       "result": "clean"
     },
+    "cauchy-schwarz-integral-oq-02-oq-02-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:39:24Z",
+      "result": "clean"
+    },
     "cauchy-schwarz-integral-oq-03": {
       "auditCount": 3,
       "issues": [],
@@ -951,6 +1570,12 @@
       "lastAudited": "2026-04-22T11:39:15Z",
       "result": "clean"
     },
+    "cauchy-schwarz-oq-01-oq-01-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
     "cauchy-schwarz-oq-01-oq-02": {
       "auditCount": 3,
       "issues": [],
@@ -964,9 +1589,21 @@
       "result": "clean"
     },
     "cauchy-schwarz-oq-01-oq-04": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-13T23:03:48Z",
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
+    "cauchy-schwarz-oq-02": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-22T12:30:22Z",
+      "result": "clean"
+    },
+    "cauchy-schwarz-oq-02-oq-01": {
+      "auditCount": 7,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:41:30Z",
       "result": "clean"
     },
     "cauchy-schwarz-oq-03": {
@@ -993,6 +1630,12 @@
       "lastAudited": "2026-04-22T12:30:22Z",
       "result": "clean"
     },
+    "cauchy-schwarz-oq-04-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:39:22Z",
+      "result": "clean"
+    },
     "cayley-hamilton": {
       "auditCount": 3,
       "issues": [],
@@ -1003,6 +1646,12 @@
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-04-22T11:45:55Z",
+      "result": "clean"
+    },
+    "cayley-hamilton-minpoly-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:39:44Z",
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-02": {
@@ -1039,6 +1688,12 @@
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-04-22T12:07:53Z",
+      "result": "clean"
+    },
+    "cayley-hamilton-minpoly-oq-03-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-04-21T10:43:49Z",
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-04": {
@@ -1088,6 +1743,18 @@
       "lastAudited": "2026-04-22T12:11:48Z",
       "result": "clean"
     },
+    "cayley-hamilton-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:39:11Z",
+      "result": "clean"
+    },
+    "cayley-hamilton-oq-02": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:39:12Z",
+      "result": "clean"
+    },
     "cayley-hamilton-reduction": {
       "auditCount": 3,
       "issues": [],
@@ -1098,6 +1765,12 @@
       "auditCount": 4,
       "issues": [],
       "lastAudited": "2026-04-22T11:39:35Z",
+      "result": "clean"
+    },
+    "cayley-hamilton-reduction-oq-01-oq-02": {
+      "auditCount": 4,
+      "issues": [],
+      "lastAudited": "2026-04-21T12:51:34Z",
       "result": "clean"
     },
     "cayley-hamilton-reduction-oq-02": {
@@ -1136,6 +1809,20 @@
       "lastAudited": "2026-04-22T12:07:54Z",
       "result": "clean"
     },
+    "central-limit-theorem-oq-01-oq-02-oq-01": {
+      "auditCount": 2,
+      "issues": [
+        "lineCount 98\u2192112, theoremCount 7\u21928 (enricher used stale counts)"
+      ],
+      "lastAudited": "2026-04-22T18:15:58Z",
+      "result": "issues-fixed"
+    },
+    "central-limit-theorem-oq-01-oq-02-oq-01-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
     "central-limit-theorem-oq-01-oq-03": {
       "auditCount": 3,
       "issues": [],
@@ -1165,6 +1852,18 @@
       "lastAudited": "2026-04-22T11:48:55Z",
       "result": "clean"
     },
+    "cevas-theorem-non-euclidean": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:39:21Z",
+      "result": "clean"
+    },
+    "cevas-theorem-non-euclidean-oq-02": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
     "cevas-theorem-oq-01": {
       "auditCount": 2,
       "lastAudited": "2026-04-21T15:37:09Z",
@@ -1187,6 +1886,12 @@
       "lastAudited": "2026-04-21T15:36:51Z",
       "result": "clean"
     },
+    "cevas-theorem-oq-02-oq-01-oq-03": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T12:38:08Z",
+      "result": "clean"
+    },
     "cevas-theorem-oq-02-oq-02": {
       "auditCount": 4,
       "issues": [],
@@ -1197,6 +1902,40 @@
       "auditCount": 5,
       "issues": [],
       "lastAudited": "2026-04-22T11:43:50Z",
+      "result": "clean"
+    },
+    "chebyshev-bounds": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:39:20Z",
+      "result": "clean"
+    },
+    "chebyshev-pnt-bridge": {
+      "auditCount": 4,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
+    "chebyshev-pnt-bridge-oq-01": {
+      "auditCount": 2,
+      "issues": [
+        "sorry 4\u21925",
+        "status axiomatized\u2192formalized",
+        "badge axiom\u2192wip"
+      ],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
+    "chebyshev-pnt-bridge-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-04-21T19:38:08Z",
+      "result": "clean"
+    },
+    "chebyshev-pnt-bridge-oq-02": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
       "result": "clean"
     },
     "chinese-remainder-constructive": {
@@ -1223,6 +1962,12 @@
       "lastAudited": "2026-04-22T12:11:49Z",
       "result": "clean"
     },
+    "chinese-remainder-constructive-oq-04-oq-04": {
+      "auditCount": 4,
+      "issues": [],
+      "lastAudited": "2026-04-22T11:12:56Z",
+      "result": "clean"
+    },
     "chinese-remainder-non-coprime": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
@@ -1235,6 +1980,12 @@
       "lastAudited": "2026-04-22T11:39:36Z",
       "result": "clean"
     },
+    "chinese-remainder-non-coprime-oq-01-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
     "chinese-remainder-non-coprime-oq-02": {
       "auditCount": 2,
       "lastAudited": "2026-04-21T15:36:40Z",
@@ -1245,10 +1996,28 @@
       "lastAudited": "2026-04-21T12:40:09Z",
       "result": "clean"
     },
+    "chinese-remainder-non-coprime-oq-03-oq-02": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
     "chinese-remainder-non-coprime-oq-04": {
       "auditCount": 4,
       "issues": [],
       "lastAudited": "2026-04-22T12:07:53Z",
+      "result": "clean"
+    },
+    "collatz-cycles": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:39:18Z",
+      "result": "clean"
+    },
+    "collatz-cycles-oq-04": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:53:12Z",
       "result": "clean"
     },
     "collatz-structured": {
@@ -1261,6 +2030,12 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-22T11:48:55Z",
+      "result": "clean"
+    },
+    "collatz-structured-oq-02-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:41:21Z",
       "result": "clean"
     },
     "collatz-structured-oq-03": {
@@ -1278,6 +2053,12 @@
     "combinations-formula-oq-01": {
       "auditCount": 2,
       "lastAudited": "2026-04-21T15:36:29Z",
+      "result": "clean"
+    },
+    "combinations-formula-oq-02": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
       "result": "clean"
     },
     "continuum-hypothesis": {
@@ -1310,6 +2091,12 @@
       "lastAudited": "2026-04-22T11:12:58Z",
       "result": "clean"
     },
+    "cramers-rule-oq-01-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T18:29:33Z",
+      "result": "clean"
+    },
     "cramers-rule-oq-01-oq-02": {
       "auditCount": 3,
       "issues": [],
@@ -1322,6 +2109,12 @@
       "lastAudited": "2026-04-22T11:12:55Z",
       "result": "clean"
     },
+    "cramers-rule-oq-01-oq-04": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:42:01Z",
+      "result": "clean"
+    },
     "cramers-rule-oq-02": {
       "auditCount": 4,
       "issues": [],
@@ -1332,6 +2125,30 @@
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-04-22T12:09:42Z",
+      "result": "clean"
+    },
+    "cramers-rule-oq-04": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:39:11Z",
+      "result": "clean"
+    },
+    "cube-root-2-irrational": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:39:11Z",
+      "result": "clean"
+    },
+    "cube-root-3-irrational": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:40:52Z",
+      "result": "clean"
+    },
+    "cube-root-3-irrational-oq-02": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
       "result": "clean"
     },
     "de-moivre": {
@@ -1370,9 +2187,21 @@
       "lastAudited": "2026-04-22T11:46:59Z",
       "result": "clean"
     },
+    "denumerability-rationals-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:35:38Z",
+      "result": "clean"
+    },
     "denumerability-rationals-oq-02": {
       "auditCount": 3,
       "lastAudited": "2026-04-21T15:39:10Z",
+      "result": "clean"
+    },
+    "denumerability-rationals-oq-02-oq-02": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
       "result": "clean"
     },
     "denumerability-rationals-oq-03": {
@@ -1393,6 +2222,18 @@
       "lastAudited": "2026-04-22T11:37:26Z",
       "result": "clean"
     },
+    "derangements-convergence": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:39:17Z",
+      "result": "clean"
+    },
+    "derangements-convergence-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T18:28:23Z",
+      "result": "clean"
+    },
     "derangements-oq-02": {
       "auditCount": 6,
       "issues": [],
@@ -1405,6 +2246,12 @@
       "lastAudited": "2026-04-22T11:12:59Z",
       "result": "clean"
     },
+    "derangements-oq-02-oq-02": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:39:55Z",
+      "result": "clean"
+    },
     "derangements-oq-03": {
       "auditCount": 4,
       "issues": [],
@@ -1415,6 +2262,18 @@
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-04-22T12:19:13Z",
+      "result": "clean"
+    },
+    "derangements-oq-03-oq-01-oq-02": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
+    "derangements-oq-03-oq-02": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:39:16Z",
       "result": "clean"
     },
     "desargues-theorem": {
@@ -1480,10 +2339,10 @@
       "result": "clean"
     },
     "descartes-rule-of-signs-oq-03": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-13T23:03:06Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
     },
     "descartes-rule-of-signs-oq-04": {
       "auditCount": 3,
@@ -1535,6 +2394,12 @@
       "lastAudited": "2026-04-22T12:35:37Z",
       "result": "clean"
     },
+    "dissection-of-cubes-oq-01-oq-01": {
+      "auditCount": 5,
+      "issues": [],
+      "lastAudited": "2026-04-22T12:32:12Z",
+      "result": "clean"
+    },
     "dissection-of-cubes-oq-02": {
       "auditCount": 4,
       "issues": [],
@@ -1550,6 +2415,12 @@
     "dissection-of-cubes-oq-03": {
       "auditCount": 3,
       "lastAudited": "2026-04-22T12:33:59Z",
+      "result": "clean"
+    },
+    "dissection-of-cubes-oq-04": {
+      "auditCount": 4,
+      "issues": [],
+      "lastAudited": "2026-04-22T18:06:42Z",
       "result": "clean"
     },
     "divisibility-by-3": {
@@ -1576,6 +2447,16 @@
       "lastAudited": "2026-04-22T12:12:36Z",
       "result": "clean"
     },
+    "divisibility-by-3-oq-03-oq-02": {
+      "auditCount": 2,
+      "issues": [
+        "sorry 1\u21920",
+        "status axiomatized\u2192verified",
+        "badge axiom\u2192original"
+      ],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
     "divisibility-by-3-oq-04": {
       "auditCount": 3,
       "issues": [],
@@ -1586,6 +2467,63 @@
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-04-22T12:11:49Z",
+      "result": "clean"
+    },
+    "divisibility-by-three-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:39:14Z",
+      "result": "clean"
+    },
+    "divisibility-by-three-oq-01-oq-02": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:35:35Z",
+      "result": "clean"
+    },
+    "divisibility-by-three-oq-02": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:37:41Z",
+      "result": "clean"
+    },
+    "divisibility-by-three-oq-02-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:41:48Z",
+      "result": "clean"
+    },
+    "divisibility-rules": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:39:13Z",
+      "result": "clean"
+    },
+    "divisibility-rules-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:39:12Z",
+      "result": "clean"
+    },
+    "divisibility-rules-oq-01-oq-01": {
+      "agentId": "lean-mechanic",
+      "auditCount": 3,
+      "issues": [
+        "missing Lean file DivisibilityRulesOQ01OQ01.lean created; closed #9647"
+      ],
+      "lastAudited": "2026-04-22T12:37:02Z",
+      "result": "clean"
+    },
+    "divisibility-rules-oq-01-oq-01-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:41:50Z",
+      "result": "clean"
+    },
+    "divisibility-rules-oq-02": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
       "result": "clean"
     },
     "divisibility-truncation-general": {
@@ -1612,6 +2550,12 @@
       "lastAudited": "2026-04-22T08:47:19Z",
       "result": "clean"
     },
+    "e-transcendental-oq-01-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:35:21Z",
+      "result": "clean"
+    },
     "e-transcendental-oq-03": {
       "auditCount": 3,
       "issues": [],
@@ -1629,6 +2573,12 @@
       "issues": [],
       "lastAudited": "2026-04-22T12:32:12Z",
       "result": "clean"
+    },
+    "elementary-quadratic-reciprocity-oq-01-oq-01": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:29:09Z",
+      "result": "issues-fixed"
     },
     "elementary-quadratic-reciprocity-oq-02": {
       "auditCount": 3,
@@ -1677,6 +2627,12 @@
       "lastAudited": "2026-04-22T08:47:19Z",
       "result": "clean"
     },
+    "equivariant-borsuk-ulam-compact-lie": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-22T11:12:59Z",
+      "result": "clean"
+    },
     "erdos-1": {
       "auditCount": 3,
       "issues": [],
@@ -1701,6 +2657,12 @@
       "lastAudited": "2026-04-22T12:26:27Z",
       "result": "clean"
     },
+    "erdos-10-oq-01": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-22T12:38:31Z",
+      "result": "clean"
+    },
     "erdos-100": {
       "auditCount": 3,
       "issues": [],
@@ -1717,6 +2679,12 @@
       "auditCount": 4,
       "issues": [],
       "lastAudited": "2026-04-22T12:34:32Z",
+      "result": "clean"
+    },
+    "erdos-100-oq-02-oq-02": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:35:38Z",
       "result": "clean"
     },
     "erdos-1000": {
@@ -1737,6 +2705,12 @@
       "lastAudited": "2026-04-22T12:19:36Z",
       "result": "clean"
     },
+    "erdos-1001-oq-03": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:42:01Z",
+      "result": "clean"
+    },
     "erdos-1002": {
       "auditCount": 4,
       "issues": [],
@@ -1747,6 +2721,12 @@
       "auditCount": 4,
       "issues": [],
       "lastAudited": "2026-04-22T12:20:00Z",
+      "result": "clean"
+    },
+    "erdos-1002-oq-01-oq-01": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:35:39Z",
       "result": "clean"
     },
     "erdos-1003": {
@@ -1826,10 +2806,22 @@
       "lastAudited": "2026-04-22T12:09:42Z",
       "result": "clean"
     },
+    "erdos-1008-oq-04": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:35:38Z",
+      "result": "clean"
+    },
     "erdos-1009": {
       "auditCount": 4,
       "issues": [],
       "lastAudited": "2026-04-22T12:19:36Z",
+      "result": "clean"
+    },
+    "erdos-1009-oq-02": {
+      "auditCount": 4,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:41:29Z",
       "result": "clean"
     },
     "erdos-101": {
@@ -1844,6 +2836,12 @@
       "lastAudited": "2026-04-22T12:20:00Z",
       "result": "clean"
     },
+    "erdos-1010-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T18:29:33Z",
+      "result": "clean"
+    },
     "erdos-1010-oq-02": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
@@ -1853,22 +2851,40 @@
     "erdos-1011": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 6,
+      "issues": [],
       "lastAudited": "2026-04-22T18:35:16Z",
-      "result": "clean",
-      "issues": []
+      "result": "clean"
+    },
+    "erdos-1011-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T18:29:33Z",
+      "result": "clean"
     },
     "erdos-1012": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 6,
+      "issues": [],
       "lastAudited": "2026-04-22T18:35:16Z",
-      "result": "clean",
-      "issues": []
+      "result": "clean"
+    },
+    "erdos-1012-oq-01": {
+      "auditCount": 5,
+      "issues": [],
+      "lastAudited": "2026-04-22T18:39:20Z",
+      "result": "clean"
+    },
+    "erdos-1012-oq-02": {
+      "auditCount": 4,
+      "issues": [],
+      "lastAudited": "2026-04-22T18:39:20Z",
+      "result": "clean"
     },
     "erdos-1012-oq-03": {
-      "auditCount": 15,
+      "auditCount": 16,
       "issues": [],
-      "lastAudited": "2026-04-14T00:22:06Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
     },
     "erdos-1013": {
       "agentId": "auditor-cycle-20-batch",
@@ -1937,9 +2953,15 @@
       "result": "clean"
     },
     "erdos-1018-oq-04": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-13T01:24:21Z",
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
+    "erdos-1018-oq-04-incomplete-01": {
+      "auditCount": 7,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:41:27Z",
       "result": "clean"
     },
     "erdos-1019": {
@@ -1966,6 +2988,12 @@
       "lastAudited": "2026-04-22T12:20:25Z",
       "result": "clean"
     },
+    "erdos-1021-oq-01": {
+      "auditCount": 5,
+      "issues": [],
+      "lastAudited": "2026-04-22T12:38:08Z",
+      "result": "clean"
+    },
     "erdos-1022": {
       "auditCount": 4,
       "issues": [],
@@ -1984,6 +3012,12 @@
       "lastAudited": "2026-04-22T12:20:25Z",
       "result": "clean"
     },
+    "erdos-1023-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:40:52Z",
+      "result": "clean"
+    },
     "erdos-1024": {
       "auditCount": 4,
       "issues": [],
@@ -1997,15 +3031,27 @@
       "result": "clean"
     },
     "erdos-1026": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-13T03:03:24Z",
+      "lastAudited": "2026-04-22T21:56:29Z",
       "result": "clean"
     },
     "erdos-1027": {
       "auditCount": 4,
       "issues": [],
       "lastAudited": "2026-04-22T12:20:25Z",
+      "result": "clean"
+    },
+    "erdos-1027-oq-01": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
+    "erdos-1027-oq-03": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
       "result": "clean"
     },
     "erdos-1028": {
@@ -2164,6 +3210,12 @@
       "lastAudited": "2026-04-22T08:26:40Z",
       "result": "clean"
     },
+    "erdos-105-oq-02": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
     "erdos-105-oq-05": {
       "auditCount": 4,
       "issues": [],
@@ -2236,10 +3288,40 @@
       "lastAudited": "2026-04-22T12:23:52Z",
       "result": "issues-fixed"
     },
-    "erdos-1059-oq-03": {
+    "erdos-1059-oq-01": {
       "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-13T01:24:09Z",
+      "lastAudited": "2026-04-22T12:39:16Z",
+      "result": "clean"
+    },
+    "erdos-1059-oq-01-oq-01": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
+    "erdos-1059-oq-02": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T12:35:37Z",
+      "result": "clean"
+    },
+    "erdos-1059-oq-02-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:35:38Z",
+      "result": "clean"
+    },
+    "erdos-1059-oq-03": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
+    "erdos-1059-oq-04": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:41:44Z",
       "result": "clean"
     },
     "erdos-1059-oq-05": {
@@ -2428,6 +3510,12 @@
       "lastAudited": "2026-04-21T18:53:44Z",
       "result": "issues-fixed"
     },
+    "erdos-1083-oq-02": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
     "erdos-1084": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 4,
@@ -2475,6 +3563,12 @@
       "auditCount": 3,
       "lastAudited": "2026-04-22T11:48:54Z",
       "result": "clean"
+    },
+    "erdos-109-oq-01": {
+      "auditCount": 8,
+      "issues": [],
+      "lastAudited": "2026-04-21T11:03:29Z",
+      "result": "issues-fixed"
     },
     "erdos-1090": {
       "agentId": "auditor-cycle-20-batch",
@@ -2548,6 +3642,18 @@
       "lastAudited": "2026-04-22T12:12:36Z",
       "result": "clean"
     },
+    "erdos-1098-oq-01-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:41:21Z",
+      "result": "clean"
+    },
+    "erdos-1098-oq-04": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:42:00Z",
+      "result": "clean"
+    },
     "erdos-1099": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 4,
@@ -2619,6 +3725,12 @@
       "auditCount": 3,
       "lastAudited": "2026-04-22T11:48:54Z",
       "result": "clean"
+    },
+    "erdos-1107-oq-02": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "erdos-1108": {
       "agentId": "auditor-cycle-20-batch",
@@ -2781,6 +3893,12 @@
       "issues": [],
       "lastAudited": "2026-04-21T18:53:44Z",
       "result": "issues-fixed"
+    },
+    "erdos-1129-oq-02": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
     },
     "erdos-113": {
       "auditCount": 3,
@@ -2980,6 +4098,18 @@
       "lastAudited": "2026-04-22T12:34:33Z",
       "result": "clean"
     },
+    "erdos-1155-oq-01-oq-01": {
+      "auditCount": 4,
+      "issues": [],
+      "lastAudited": "2026-04-22T12:27:49Z",
+      "result": "clean"
+    },
+    "erdos-1155-oq-01-oq-06": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:41:41Z",
+      "result": "clean"
+    },
     "erdos-1155-oq-01-oq-07": {
       "auditCount": 3,
       "issues": [],
@@ -2988,9 +4118,9 @@
     },
     "erdos-1156": {
       "auditCount": 1,
+      "issues": [],
       "lastAudited": "2026-04-22T07:42:04Z",
-      "result": "clean",
-      "issues": []
+      "result": "clean"
     },
     "erdos-1157": {
       "auditCount": 3,
@@ -3053,9 +4183,9 @@
       "result": "clean"
     },
     "erdos-1168": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-13T03:03:24Z",
+      "lastAudited": "2026-04-22T21:56:29Z",
       "result": "clean"
     },
     "erdos-1169": {
@@ -3156,9 +4286,9 @@
     },
     "erdos-1182": {
       "auditCount": 1,
+      "issues": [],
       "lastAudited": "2026-04-22T07:42:04Z",
-      "result": "clean",
-      "issues": []
+      "result": "clean"
     },
     "erdos-1183": {
       "auditCount": 3,
@@ -3170,6 +4300,12 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 4,
       "lastAudited": "2026-04-22T12:26:47Z",
+      "result": "clean"
+    },
+    "erdos-1196": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T11:37:16Z",
       "result": "clean"
     },
     "erdos-12": {
@@ -3184,10 +4320,70 @@
       "lastAudited": "2026-04-21T18:04:26Z",
       "result": "clean"
     },
+    "erdos-1202": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-04-21T10:44:38Z",
+      "result": "clean"
+    },
+    "erdos-1205": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-04-21T10:44:38Z",
+      "result": "clean"
+    },
+    "erdos-1206": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-04-21T10:44:38Z",
+      "result": "clean"
+    },
+    "erdos-1208": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-04-21T10:44:38Z",
+      "result": "clean"
+    },
     "erdos-121": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 4,
       "lastAudited": "2026-04-22T12:26:47Z",
+      "result": "clean"
+    },
+    "erdos-1211": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-04-21T10:44:38Z",
+      "result": "clean"
+    },
+    "erdos-1212": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-04-21T10:44:38Z",
+      "result": "clean"
+    },
+    "erdos-1213": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-04-21T10:48:35Z",
+      "result": "clean"
+    },
+    "erdos-1215": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-04-21T10:48:35Z",
+      "result": "clean"
+    },
+    "erdos-1216": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-04-21T10:48:35Z",
+      "result": "clean"
+    },
+    "erdos-1217": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-04-21T10:48:35Z",
       "result": "clean"
     },
     "erdos-122": {
@@ -3256,10 +4452,22 @@
       "lastAudited": "2026-04-22T12:26:46Z",
       "result": "clean"
     },
+    "erdos-130-wip-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
     "erdos-131": {
       "auditCount": 5,
       "issues": [],
       "lastAudited": "2026-04-21T16:03:36Z",
+      "result": "clean"
+    },
+    "erdos-131-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:40:53Z",
       "result": "clean"
     },
     "erdos-132": {
@@ -3316,6 +4524,12 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 4,
       "lastAudited": "2026-04-22T12:26:28Z",
+      "result": "clean"
+    },
+    "erdos-14-unique-sums": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:40:52Z",
       "result": "clean"
     },
     "erdos-140": {
@@ -3572,6 +4786,12 @@
       "lastAudited": "2026-04-21T18:53:44Z",
       "result": "issues-fixed"
     },
+    "erdos-177-oq-04": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:40:52Z",
+      "result": "clean"
+    },
     "erdos-178": {
       "auditCount": 4,
       "issues": [],
@@ -3600,6 +4820,12 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-22T11:48:52Z",
+      "result": "clean"
+    },
+    "erdos-181-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:53:13Z",
       "result": "clean"
     },
     "erdos-182": {
@@ -3767,11 +4993,11 @@
     "erdos-204": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 6,
-      "lastAudited": "2026-04-22T17:42:10Z",
-      "result": "clean",
       "issues": [
         "sorries field was 0 but file has 1 sorry (MaxCoverableDensity def); proofStrategy said 253-line but file is 189 lines; examples section listed non-existent n6_fails/n12_fails axioms"
-      ]
+      ],
+      "lastAudited": "2026-04-22T17:42:10Z",
+      "result": "clean"
     },
     "erdos-205": {
       "agentId": "auditor-cycle-20-batch",
@@ -3817,9 +5043,9 @@
     },
     "erdos-211": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-13T16:07:24Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
     },
     "erdos-212": {
       "agentId": "auditor-cycle-20-batch",
@@ -3878,9 +5104,9 @@
     "erdos-220": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 5,
+      "issues": [],
       "lastAudited": "2026-04-22T17:41:24Z",
-      "result": "clean",
-      "issues": []
+      "result": "clean"
     },
     "erdos-221": {
       "agentId": "auditor-cycle-20-batch",
@@ -3951,9 +5177,9 @@
     "erdos-231": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 8,
+      "issues": [],
       "lastAudited": "2026-04-22T17:41:21Z",
-      "result": "clean",
-      "issues": []
+      "result": "clean"
     },
     "erdos-232": {
       "agentId": "auditor-cycle-20-batch",
@@ -4057,6 +5283,12 @@
       "lastAudited": "2026-04-22T11:47:31Z",
       "result": "clean"
     },
+    "erdos-247-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:40:52Z",
+      "result": "clean"
+    },
     "erdos-248": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
@@ -4067,6 +5299,12 @@
       "auditCount": 4,
       "issues": [],
       "lastAudited": "2026-04-22T12:07:54Z",
+      "result": "clean"
+    },
+    "erdos-249-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:37:40Z",
       "result": "clean"
     },
     "erdos-25": {
@@ -4345,14 +5583,14 @@
       "result": "clean"
     },
     "erdos-29-oq-02": {
+      "agentId": "lean-mechanic",
       "auditCount": 3,
       "issues": [
         "https://github.com/rjwalters/lean-genius/issues/8636",
         "True stubs (counterexample_satisfies_correct_bound, why_original_was_wrong) converted to comments; closed #8636"
       ],
       "lastAudited": "2026-04-22T12:37:02Z",
-      "result": "clean",
-      "agentId": "lean-mechanic"
+      "result": "clean"
     },
     "erdos-290": {
       "agentId": "auditor-cycle-20-batch",
@@ -4399,9 +5637,9 @@
     "erdos-297": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 8,
+      "issues": [],
       "lastAudited": "2026-04-22T17:40:09Z",
-      "result": "clean",
-      "issues": []
+      "result": "clean"
     },
     "erdos-298": {
       "agentId": "auditor-cycle-20-batch",
@@ -4619,6 +5857,12 @@
       "lastAudited": "2026-04-22T12:12:37Z",
       "result": "clean"
     },
+    "erdos-327-oq-01-oq-04": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
     "erdos-328": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
@@ -4771,9 +6015,9 @@
     },
     "erdos-35": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-14T00:21:55Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
     },
     "erdos-350": {
       "agentId": "auditor-cycle-20-batch",
@@ -4795,10 +6039,10 @@
     },
     "erdos-353": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-13T03:03:24Z",
-      "result": "clean",
-      "issues": []
+      "auditCount": 5,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
     },
     "erdos-354": {
       "agentId": "auditor-cycle-20-batch",
@@ -5175,12 +6419,12 @@
       "result": "clean"
     },
     "erdos-409": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [
         "status axiomatized\u2192verified, badge wip\u2192original (0 sorries, 0 axioms confirmed)"
       ],
-      "lastAudited": "2026-04-13T03:03:24Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
     },
     "erdos-41": {
       "agentId": "auditor-cycle-20-batch",
@@ -5631,6 +6875,16 @@
       "auditCount": 3,
       "lastAudited": "2026-04-21T15:58:12Z",
       "result": "fixed"
+    },
+    "erdos-476-oq-05": {
+      "auditCount": 4,
+      "issues": [
+        "sorries 3->1 (ap_of_near_periodic and vosper_base now fully proved)",
+        "lineCount 194->306",
+        "theoremCount 7->8"
+      ],
+      "lastAudited": "2026-04-22T08:06:38Z",
+      "result": "issues-fixed"
     },
     "erdos-477": {
       "agentId": "auditor-cycle-20-batch",
@@ -6539,6 +7793,12 @@
       "lastAudited": "2026-04-22T21:53:13Z",
       "result": "clean"
     },
+    "erdos-606-oq-03-oq-03": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
     "erdos-607": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
@@ -6645,6 +7905,12 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-22T12:01:13Z",
+      "result": "clean"
+    },
+    "erdos-622-oq-04": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:35:39Z",
       "result": "clean"
     },
     "erdos-623": {
@@ -6789,12 +8055,12 @@
     },
     "erdos-644": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-13T03:29:17Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
       "issues": [
         "sorry 18\u219216"
-      ]
+      ],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
     },
     "erdos-645": {
       "agentId": "auditor-cycle-20-batch",
@@ -6830,6 +8096,12 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-22T12:01:12Z",
+      "result": "clean"
+    },
+    "erdos-65-oq-03": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
       "result": "clean"
     },
     "erdos-650": {
@@ -6877,9 +8149,9 @@
     "erdos-657": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 8,
+      "issues": [],
       "lastAudited": "2026-04-22T17:40:08Z",
-      "result": "clean",
-      "issues": []
+      "result": "clean"
     },
     "erdos-658": {
       "agentId": "auditor-cycle-20-batch",
@@ -6891,6 +8163,12 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-21T15:54:37Z",
+      "result": "clean"
+    },
+    "erdos-659-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:41:21Z",
       "result": "clean"
     },
     "erdos-66": {
@@ -6974,9 +8252,9 @@
     "erdos-671": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 5,
+      "issues": [],
       "lastAudited": "2026-04-22T17:40:07Z",
-      "result": "clean",
-      "issues": []
+      "result": "clean"
     },
     "erdos-672": {
       "agentId": "auditor-cycle-20-batch",
@@ -7058,10 +8336,10 @@
     },
     "erdos-684": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-13T03:03:24Z",
-      "result": "clean",
-      "issues": []
+      "auditCount": 4,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
     },
     "erdos-685": {
       "agentId": "auditor-cycle-20-batch",
@@ -7131,10 +8409,10 @@
     },
     "erdos-695": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-13T03:03:24Z",
-      "result": "clean",
-      "issues": []
+      "auditCount": 4,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
     },
     "erdos-696": {
       "agentId": "auditor-cycle-20-batch",
@@ -7504,9 +8782,9 @@
     },
     "erdos-748": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-14T00:49:33Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
     },
     "erdos-749": {
       "agentId": "auditor-cycle-20-batch",
@@ -7690,10 +8968,10 @@
     },
     "erdos-776": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-13T03:03:24Z",
-      "result": "clean",
-      "issues": []
+      "auditCount": 4,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
     },
     "erdos-777": {
       "agentId": "auditor-cycle-20-batch",
@@ -7967,9 +9245,9 @@
     },
     "erdos-817": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-14T00:06:53Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T21:54:46Z",
+      "result": "clean"
     },
     "erdos-818": {
       "agentId": "auditor-cycle-20-batch",
@@ -8103,6 +9381,12 @@
       "lastAudited": "2026-04-22T12:29:56Z",
       "result": "clean"
     },
+    "erdos-837-oq-05": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
     "erdos-838": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
@@ -8124,9 +9408,9 @@
     "erdos-840": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 5,
+      "issues": [],
       "lastAudited": "2026-04-22T17:40:05Z",
-      "result": "clean",
-      "issues": []
+      "result": "clean"
     },
     "erdos-841": {
       "agentId": "auditor-cycle-20-batch",
@@ -8174,6 +9458,12 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 4,
       "lastAudited": "2026-04-22T12:29:56Z",
+      "result": "clean"
+    },
+    "erdos-848-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:29:09Z",
       "result": "clean"
     },
     "erdos-849": {
@@ -8238,9 +9528,9 @@
     },
     "erdos-858": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-13T16:07:23Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
     },
     "erdos-859": {
       "agentId": "auditor-cycle-20-batch",
@@ -9043,9 +10333,9 @@
     "erdos-977": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 5,
+      "issues": [],
       "lastAudited": "2026-04-22T17:40:03Z",
-      "result": "clean",
-      "issues": []
+      "result": "clean"
     },
     "erdos-978": {
       "agentId": "auditor-cycle-20-batch",
@@ -9214,6 +10504,15 @@
       "lastAudited": "2026-04-22T12:11:49Z",
       "result": "clean"
     },
+    "euler-identity-oq-01-oq-01": {
+      "agentId": "lean-mechanic",
+      "auditCount": 3,
+      "issues": [
+        "missing Lean file EulerIdentityOQ01OQ01.lean created; closed #9687"
+      ],
+      "lastAudited": "2026-04-22T12:37:02Z",
+      "result": "clean"
+    },
     "euler-polyhedral-formula": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 4,
@@ -9268,6 +10567,24 @@
       "lastAudited": "2026-04-22T12:32:57Z",
       "result": "clean"
     },
+    "euler-totient-oq-02-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
+    "euler-totient-oq-03": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:35:38Z",
+      "result": "clean"
+    },
+    "euler-totient-oq-04": {
+      "auditCount": 4,
+      "issues": [],
+      "lastAudited": "2026-04-22T12:32:56Z",
+      "result": "clean"
+    },
     "factor-remainder-nullstellensatz": {
       "auditCount": 3,
       "issues": [],
@@ -9275,9 +10592,15 @@
       "result": "clean"
     },
     "factor-remainder-nullstellensatz-oq-01": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
+    "factor-remainder-nullstellensatz-oq-02": {
       "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-13T00:22:26Z",
+      "lastAudited": "2026-04-22T21:35:38Z",
       "result": "clean"
     },
     "factor-remainder-theorem": {
@@ -9304,6 +10627,24 @@
       "lastAudited": "2026-04-22T12:11:48Z",
       "result": "clean"
     },
+    "fair-games-theorem-oq-02-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
+    "fair-games-theorem-oq-02-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-04-22T12:54:20Z",
+      "result": "clean"
+    },
+    "fair-games-theorem-oq-03": {
+      "auditCount": 5,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
     "fermat-two-squares": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
@@ -9323,9 +10664,9 @@
       "result": "clean"
     },
     "fermats-last-theorem-oq-03": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-13T00:22:09Z",
+      "lastAudited": "2026-04-22T21:56:29Z",
       "result": "clean"
     },
     "feuerbachs-theorem": {
@@ -9340,6 +10681,12 @@
       "lastAudited": "2026-04-22T11:51:31Z",
       "result": "clean"
     },
+    "feuerbachs-theorem-defs-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-04-22T19:49:18Z",
+      "result": "clean"
+    },
     "feuerbachs-theorem-oq-01": {
       "auditCount": 4,
       "issues": [],
@@ -9347,12 +10694,18 @@
       "result": "clean"
     },
     "feuerbachs-theorem-oq-02": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
         "axiomCount 5\u21923"
       ],
-      "lastAudited": "2026-04-13T03:29:17Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
+    "feuerbachs-theorem-oq-05": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:37:38Z",
+      "result": "clean"
     },
     "four-color-theorem": {
       "agentId": "auditor-cycle-20-batch",
@@ -9387,10 +10740,22 @@
       "result": "clean"
     },
     "fourier-series-oq-02": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-04-13T22:00:17Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
+    "fourier-series-oq-02-incomplete-01": {
+      "auditCount": 4,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:35:37Z",
+      "result": "clean"
+    },
+    "fourier-series-oq-02-oq-01": {
+      "auditCount": 6,
+      "issues": [],
+      "lastAudited": "2026-04-21T13:16:35Z",
+      "result": "clean"
     },
     "fourier-series-oq-02-oq-03": {
       "auditCount": 5,
@@ -9411,9 +10776,9 @@
       "result": "clean"
     },
     "fourier-series-oq-04": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-13T00:21:33Z",
+      "lastAudited": "2026-04-22T21:56:29Z",
       "result": "clean"
     },
     "friendship-theorem": {
@@ -9423,9 +10788,9 @@
       "result": "clean"
     },
     "friendship-theorem-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-13T00:20:53Z",
+      "lastAudited": "2026-04-22T21:56:29Z",
       "result": "clean"
     },
     "friendship-theorem-oq-03": {
@@ -9441,9 +10806,9 @@
       "result": "clean"
     },
     "fundamental-arithmetic-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-13T00:19:13Z",
+      "lastAudited": "2026-04-22T21:56:29Z",
       "result": "clean"
     },
     "fundamental-arithmetic-oq-02": {
@@ -9512,10 +10877,22 @@
       "lastAudited": "2026-04-22T11:51:29Z",
       "result": "clean"
     },
+    "gcd-algorithm-oq-01-oq-03": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:41:21Z",
+      "result": "clean"
+    },
     "gcd-algorithm-oq-02": {
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-04-22T18:36:41Z",
+      "result": "clean"
+    },
+    "gcd-algorithm-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-04-21T13:58:19Z",
       "result": "clean"
     },
     "gelfond-schneider": {
@@ -9560,11 +10937,29 @@
       "lastAudited": "2026-04-22T18:36:41Z",
       "result": "clean"
     },
+    "geometric-series-oq-03": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:29:09Z",
+      "result": "clean"
+    },
+    "godel-first-incompleteness-oq01": {
+      "auditCount": 5,
+      "issues": [],
+      "lastAudited": "2026-04-21T13:17:20Z",
+      "result": "clean"
+    },
     "godel-incompleteness": {
       "auditCount": 4,
       "issues": [],
       "lastAudited": "2026-04-22T11:44:38Z",
       "result": "clean"
+    },
+    "godel-second-incompleteness-oq02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-04-21T13:19:31Z",
+      "result": "issues-fixed"
     },
     "greens-theorem": {
       "agentId": "auditor-cycle-20-batch",
@@ -9582,6 +10977,12 @@
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-04-22T12:11:49Z",
+      "result": "clean"
+    },
+    "greens-theorem-oq-02": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:40:01Z",
       "result": "clean"
     },
     "greens-theorem-oq-03": {
@@ -9606,6 +11007,12 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-22T11:51:28Z",
+      "result": "clean"
+    },
+    "harmonic-divergence-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:37:37Z",
       "result": "clean"
     },
     "harmonic-divergence-oq-02": {
@@ -9644,10 +11051,28 @@
       "lastAudited": "2026-04-22T18:31:56Z",
       "result": "clean"
     },
+    "herons-formula-oq-04": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:42:14Z",
+      "result": "clean"
+    },
+    "hilbert-1-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-04-22T18:37:22Z",
+      "result": "clean"
+    },
     "hilbert-10": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 4,
       "lastAudited": "2026-04-22T18:35:16Z",
+      "result": "clean"
+    },
+    "hilbert-10-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:35:39Z",
       "result": "clean"
     },
     "hilbert-11": {
@@ -9692,6 +11117,16 @@
       "lastAudited": "2026-04-22T18:31:56Z",
       "result": "clean"
     },
+    "hilbert-15-oq-02": {
+      "auditCount": 4,
+      "issues": [
+        "status verified->formalized (True stub theorems: lr_saturation_theorem, lr_positivity_in_P, lr_counting_sharp_P_complete prove True)",
+        "badge verified->wip",
+        "lineCount 360->506"
+      ],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
     "hilbert-16": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
@@ -9734,18 +11169,24 @@
       "lastAudited": "2026-04-22T12:09:43Z",
       "result": "clean"
     },
-    "hilbert-21": {
-      "auditCount": 7,
+    "hilbert-20-oq-01-oq-03": {
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-13T06:09:18Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
+    "hilbert-21": {
+      "auditCount": 8,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
     },
     "hilbert-22": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 4,
+      "issues": [],
       "lastAudited": "2026-04-22T17:40:00Z",
-      "result": "clean",
-      "issues": []
+      "result": "clean"
     },
     "hilbert-22-oq-01": {
       "auditCount": 3,
@@ -9756,9 +11197,9 @@
     "hilbert-23": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 4,
+      "issues": [],
       "lastAudited": "2026-04-22T17:39:59Z",
-      "result": "clean",
-      "issues": []
+      "result": "clean"
     },
     "hilbert-3": {
       "agentId": "auditor-cycle-20-batch",
@@ -9802,8 +11243,26 @@
       "lastAudited": "2026-04-22T08:42:37Z",
       "result": "clean"
     },
+    "hurwitz-theorem-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-04-22T18:37:22Z",
+      "result": "clean"
+    },
     "hurwitz-theorem-oq-03": {
       "auditCount": 5,
+      "issues": [],
+      "lastAudited": "2026-04-22T18:37:22Z",
+      "result": "clean"
+    },
+    "hurwitz-theorem-oq-03-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T08:42:37Z",
+      "result": "clean"
+    },
+    "hurwitz-theorem-oq-04": {
+      "auditCount": 1,
       "issues": [],
       "lastAudited": "2026-04-22T18:37:22Z",
       "result": "clean"
@@ -9814,10 +11273,28 @@
       "lastAudited": "2026-04-22T11:51:24Z",
       "result": "clean"
     },
+    "inclusion-exclusion-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:39:44Z",
+      "result": "clean"
+    },
     "infinitude-primes": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-22T11:51:24Z",
+      "result": "clean"
+    },
+    "infinitude-primes-4k1": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:39:44Z",
+      "result": "clean"
+    },
+    "infinitude-primes-4k3": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:39:44Z",
       "result": "clean"
     },
     "infinitude-primes-oq-03": {
@@ -9838,21 +11315,27 @@
       "lastAudited": "2026-04-22T11:43:50Z",
       "result": "clean"
     },
+    "intermediate-value-theorem-oq-02": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:39:43Z",
+      "result": "clean"
+    },
     "intermediate-value-theorem-oq-03": {
+      "agentId": "lean-mechanic",
       "auditCount": 3,
       "issues": [
         "https://github.com/rjwalters/lean-genius/issues/8637",
         "True stubs (ivt_from_brouwer_sketch, dimensional_summary) converted to comments; closed #8637"
       ],
       "lastAudited": "2026-04-22T12:37:02Z",
-      "result": "clean",
-      "agentId": "lean-mechanic"
+      "result": "clean"
     },
     "inverse-galois": {
-      "auditCount": 8,
+      "auditCount": 9,
       "issues": [],
-      "lastAudited": "2026-04-13T16:07:25Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
     },
     "inverse-galois-oq-01": {
       "auditCount": 7,
@@ -9888,6 +11371,12 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-22T11:51:24Z",
+      "result": "clean"
+    },
+    "isosceles-triangle-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:41:21Z",
       "result": "clean"
     },
     "kepler-conjecture": {
@@ -9931,6 +11420,18 @@
       "lastAudited": "2026-04-22T18:30:51Z",
       "result": "clean"
     },
+    "konigsberg-oq-03-oq-02": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T12:39:16Z",
+      "result": "clean"
+    },
+    "konigsberg-oq-04": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T18:37:22Z",
+      "result": "clean"
+    },
     "kroneckers-jugendtraum": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
@@ -9949,10 +11450,22 @@
       "lastAudited": "2026-04-22T12:30:21Z",
       "result": "clean"
     },
+    "kummer-theorem-oq-01-oq-01": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
     "kummer-theorem-oq-02": {
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-04-22T12:12:36Z",
+      "result": "clean"
+    },
+    "kummer-theorem-oq-03": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:37:35Z",
       "result": "clean"
     },
     "lagrange-four-squares": {
@@ -9961,15 +11474,33 @@
       "lastAudited": "2026-04-22T11:51:22Z",
       "result": "clean"
     },
+    "lagrange-four-squares-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:37:34Z",
+      "result": "clean"
+    },
     "lagrange-four-squares-oq-02": {
       "auditCount": 2,
       "lastAudited": "2026-04-21T15:33:25Z",
+      "result": "clean"
+    },
+    "lagrange-four-squares-oq-04": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
       "result": "clean"
     },
     "lagrange-theorem": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-22T11:51:22Z",
+      "result": "clean"
+    },
+    "lagrange-theorem-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:37:32Z",
       "result": "clean"
     },
     "lagrange-theorem-oq-02": {
@@ -10002,15 +11533,43 @@
       "lastAudited": "2026-04-22T12:09:43Z",
       "result": "clean"
     },
+    "law-of-cosines-oq-01-oq-05": {
+      "auditCount": 5,
+      "issues": [],
+      "lastAudited": "2026-04-21T13:19:56Z",
+      "result": "clean"
+    },
+    "law-of-cosines-oq-03": {
+      "auditCount": 4,
+      "issues": [],
+      "lastAudited": "2026-04-22T12:29:39Z",
+      "result": "clean"
+    },
     "law-of-cosines-oq-04": {
+      "agentId": "lean-mechanic",
       "auditCount": 3,
       "issues": [
         "https://github.com/rjwalters/lean-genius/issues/8640",
         "True stub (angle_bisector_stewarts) converted to comment; closed #8640"
       ],
       "lastAudited": "2026-04-22T12:35:37Z",
-      "result": "clean",
-      "agentId": "lean-mechanic"
+      "result": "clean"
+    },
+    "law-of-cosines-oq-06": {
+      "auditCount": 2,
+      "issues": [
+        "gallery entry renamed law-of-cosines-oq-06\u2192law-of-sines-oq-06; content was Law of Sines not Law of Cosines (fixed by PRs #10749, #10757)"
+      ],
+      "lastAudited": "2026-04-21T00:00:00Z",
+      "result": "issues-fixed"
+    },
+    "law-of-sines-oq-06": {
+      "auditCount": 3,
+      "issues": [
+        "id/slug mismatch: meta.json had id=law-of-cosines-oq-06; fixed by enrichment PR #10757"
+      ],
+      "lastAudited": "2026-04-22T21:53:13Z",
+      "result": "clean"
     },
     "laws-of-large-numbers": {
       "agentId": "auditor-cycle-20-batch",
@@ -10022,6 +11581,18 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-22T11:49:47Z",
+      "result": "clean"
+    },
+    "laws-of-large-numbers-oq-03": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
+    "laws-of-large-numbers-oq-04": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:42:13Z",
       "result": "clean"
     },
     "lebesgue-measure": {
@@ -10054,6 +11625,22 @@
       "lastAudited": "2026-04-22T12:38:08Z",
       "result": "clean"
     },
+    "lebesgue-measure-oq-03-oq-01": {
+      "auditCount": 2,
+      "issues": [
+        "sorry 1\u21920",
+        "status axiomatized\u2192verified",
+        "badge axiom\u2192original"
+      ],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
+    "lebesgue-measure-oq-06": {
+      "auditCount": 7,
+      "issues": [],
+      "lastAudited": "2026-04-22T20:24:34Z",
+      "result": "issues-fixed"
+    },
     "legendre-partial": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
@@ -10078,10 +11665,28 @@
       "lastAudited": "2026-04-22T11:44:37Z",
       "result": "clean"
     },
+    "leibniz-pi-oq-02": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
+    "leibniz-pi-oq-03": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T18:29:33Z",
+      "result": "clean"
+    },
     "lhopital": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-22T11:49:47Z",
+      "result": "clean"
+    },
+    "lhopital-oq-01": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:34:45Z",
       "result": "clean"
     },
     "lhopital-oq-02": {
@@ -10094,6 +11699,18 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-21T15:42:26Z",
+      "result": "clean"
+    },
+    "lovasz-local-lemma": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:37:31Z",
+      "result": "clean"
+    },
+    "lovasz-local-lemma-oq-02": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
       "result": "clean"
     },
     "mathematical-induction": {
@@ -10126,10 +11743,28 @@
       "lastAudited": "2026-04-22T11:49:47Z",
       "result": "clean"
     },
+    "minkowski-fundamental-theorem": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:37:29Z",
+      "result": "clean"
+    },
+    "minkowski-fundamental-theorem-oq-02": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
     "minkowski-theorem": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-22T11:49:47Z",
+      "result": "clean"
+    },
+    "minkowski-theorem-oq-02": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:41:21Z",
       "result": "clean"
     },
     "morleys-theorem": {
@@ -10246,6 +11881,12 @@
       "lastAudited": "2026-04-22T11:49:46Z",
       "result": "clean"
     },
+    "partition-theorem-oq-01-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
     "partition-theorem-oq-03": {
       "auditCount": 4,
       "issues": [],
@@ -10253,10 +11894,10 @@
       "result": "issues-fixed"
     },
     "pascals-hexagon": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-14T00:06:42Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
     },
     "pell-equation": {
       "agentId": "auditor-cycle-20-batch",
@@ -10265,13 +11906,13 @@
       "result": "clean"
     },
     "pell-equation-oq-01": {
+      "agentId": "lean-mechanic",
       "auditCount": 5,
       "issues": [
         "status corrected from verified to axiomatized; closed #9693"
       ],
       "lastAudited": "2026-04-22T12:35:37Z",
-      "result": "clean",
-      "agentId": "lean-mechanic"
+      "result": "clean"
     },
     "perfect-numbers": {
       "agentId": "auditor-cycle-20-batch",
@@ -10333,6 +11974,12 @@
       "lastAudited": "2026-04-22T11:49:46Z",
       "result": "clean"
     },
+    "prime-gap-bounds-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:35:38Z",
+      "result": "clean"
+    },
     "prime-number-theorem": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
@@ -10355,6 +12002,12 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-22T11:49:45Z",
+      "result": "clean"
+    },
+    "primitive-roots-oq-02": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
       "result": "clean"
     },
     "prob-method-alteration": {
@@ -10393,10 +12046,22 @@
       "lastAudited": "2026-04-22T11:49:45Z",
       "result": "clean"
     },
+    "prob-method-second-moment-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:37:28Z",
+      "result": "clean"
+    },
     "product-of-segments-of-chords": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-22T11:49:45Z",
+      "result": "clean"
+    },
+    "product-of-segments-of-chords-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:36:45Z",
       "result": "clean"
     },
     "ptolemys-complex-proof": {
@@ -10405,11 +12070,35 @@
       "lastAudited": "2026-04-22T12:12:37Z",
       "result": "clean"
     },
+    "ptolemys-complex-proof-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:41:46Z",
+      "result": "clean"
+    },
     "ptolemys-theorem": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-22T11:49:45Z",
       "result": "clean"
+    },
+    "ptolemys-theorem-oq-01": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
+    "ptolemys-theorem-oq-01-incomplete-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:53:12Z",
+      "result": "clean"
+    },
+    "ptolemys-theorem-oq-01-oq-01": {
+      "auditCount": 4,
+      "issues": [],
+      "lastAudited": "2026-04-22T11:13:07Z",
+      "result": "issues-fixed"
     },
     "puiseux-theorem": {
       "agentId": "auditor-cycle-20-batch",
@@ -10507,6 +12196,12 @@
       "lastAudited": "2026-04-22T12:39:16Z",
       "result": "clean"
     },
+    "randomized-maxcut-oq-04": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
     "rh-consequences": {
       "auditCount": 3,
       "issues": [],
@@ -10567,6 +12262,12 @@
       "lastAudited": "2026-04-22T12:38:51Z",
       "result": "clean"
     },
+    "schauder-fixed-point-oq-03-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:35:39Z",
+      "result": "clean"
+    },
     "schroeder-bernstein": {
       "auditCount": 4,
       "issues": [],
@@ -10578,6 +12279,12 @@
       "issues": [],
       "lastAudited": "2026-04-22T12:38:51Z",
       "result": "clean"
+    },
+    "schroeder-bernstein-oq-03": {
+      "auditCount": 4,
+      "issues": [],
+      "lastAudited": "2026-04-21T18:53:44Z",
+      "result": "issues-fixed"
     },
     "schroeder-bernstein-oq-04": {
       "auditCount": 3,
@@ -10597,16 +12304,54 @@
       "lastAudited": "2026-04-22T12:38:31Z",
       "result": "clean"
     },
+    "shannon-channel-coding-oq-02-oq-01": {
+      "auditCount": 3,
+      "issues": [
+        "sorry mismatch: meta claimed 1, actual 0 (fano_trivial_singleton now proved)"
+      ],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "issues-fixed"
+    },
+    "shannon-channel-coding-oq-02-oq-04": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
+    "shannon-channel-coding-oq-03": {
+      "auditCount": 4,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:29:10Z",
+      "result": "clean"
+    },
     "shannon-channel-coding-oq-04": {
       "auditCount": 4,
       "issues": [],
       "lastAudited": "2026-04-22T12:09:41Z",
       "result": "clean"
     },
+    "shannon-channel-coding-oq-04-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T18:27:01Z",
+      "result": "clean"
+    },
+    "shannon-channel-coding-oq-04-oq-01-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T18:39:20Z",
+      "result": "clean"
+    },
     "shannon-entropy": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-22T11:49:44Z",
+      "result": "clean"
+    },
+    "shannon-entropy-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:39:54Z",
       "result": "clean"
     },
     "shannon-entropy-oq-02": {
@@ -10639,11 +12384,17 @@
       "lastAudited": "2026-04-22T11:49:44Z",
       "result": "clean"
     },
-    "shapley-folkman": {
-      "auditCount": 6,
+    "shannon-source-coding-oq-04": {
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-14T00:22:08Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-21T20:08:54Z",
+      "result": "clean"
+    },
+    "shapley-folkman": {
+      "auditCount": 7,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
     },
     "solution-of-cubic": {
       "auditCount": 4,
@@ -10687,16 +12438,52 @@
       "lastAudited": "2026-04-22T11:49:44Z",
       "result": "clean"
     },
+    "sophie-germain-oq-02": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
     "sperner-ndim": {
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-04-22T12:12:37Z",
       "result": "clean"
     },
+    "sperner-ndim-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:41:21Z",
+      "result": "clean"
+    },
     "sperner-ndim-oq-03": {
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-04-22T12:38:51Z",
+      "result": "clean"
+    },
+    "sperner-ndim-oq-03-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
+    "sperner-ndim-oq-04": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T18:25:15Z",
+      "result": "issues-fixed"
+    },
+    "spherical-law-of-cosines": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:36:44Z",
+      "result": "clean"
+    },
+    "spherical-law-of-sines": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:42:12Z",
       "result": "clean"
     },
     "sqrt2-examples": {
@@ -10729,6 +12516,24 @@
       "lastAudited": "2026-04-22T11:49:44Z",
       "result": "clean"
     },
+    "sqrt2-minpoly": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-04-22T19:22:02Z",
+      "result": "issues-found"
+    },
+    "sqrt2-plus-sqrt3-irrational": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:40:52Z",
+      "result": "clean"
+    },
+    "sqrt2-plus-sqrt3-irrational-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-04-22T20:40:28Z",
+      "result": "issues-found"
+    },
     "stirling-formula": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
@@ -10759,16 +12564,43 @@
       "lastAudited": "2026-04-22T12:38:51Z",
       "result": "clean"
     },
+    "subset-count-multiset-oq-01": {
+      "agentId": "lean-mechanic",
+      "auditCount": 3,
+      "issues": [
+        "missing Lean file SubsetCountMultisetOQ01.lean created; closed #9648"
+      ],
+      "lastAudited": "2026-04-22T12:35:37Z",
+      "result": "clean"
+    },
     "subset-count-oq-02": {
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-04-22T12:38:51Z",
       "result": "clean"
     },
+    "subset-count-oq-02-oq-01": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
+    "sum-of-divisors": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:39:57Z",
+      "result": "clean"
+    },
     "sum-of-kth-powers": {
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-04-22T09:13:41Z",
+      "result": "clean"
+    },
+    "sum-of-kth-powers-oq-01": {
+      "auditCount": 4,
+      "issues": [],
+      "lastAudited": "2026-04-22T11:43:49Z",
       "result": "clean"
     },
     "sum-of-kth-powers-oq-02": {
@@ -10781,6 +12613,24 @@
       "auditCount": 5,
       "issues": [],
       "lastAudited": "2026-04-22T11:43:49Z",
+      "result": "clean"
+    },
+    "sylow-theorem": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:36:40Z",
+      "result": "clean"
+    },
+    "sylow-theorem-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:36:42Z",
+      "result": "clean"
+    },
+    "sylow-theorem-oq-04": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:36:39Z",
       "result": "clean"
     },
     "sylow-theorems": {
@@ -10831,6 +12681,18 @@
       "lastAudited": "2026-04-22T12:38:31Z",
       "result": "clean"
     },
+    "szemeredi-hypergraph-core-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:41:47Z",
+      "result": "clean"
+    },
+    "szemeredi-hypergraph-core-oq-01-incomplete-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-04-21T15:31:06Z",
+      "result": "clean"
+    },
     "szemeredi-regularity": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
@@ -10849,16 +12711,40 @@
       "lastAudited": "2026-04-22T12:07:54Z",
       "result": "clean"
     },
+    "taylor-sincos-convergence-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:35:37Z",
+      "result": "clean"
+    },
+    "taylor-sincos-convergence-oq-02": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
     "taylor-sincos-convergence-oq-03": {
       "auditCount": 4,
       "issues": [],
       "lastAudited": "2026-04-22T09:12:35Z",
       "result": "clean"
     },
+    "taylor-sincos-convergence-oq-04": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
     "taylor-theorem": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-22T11:48:56Z",
+      "result": "clean"
+    },
+    "taylor-theorem-oq-02": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
       "result": "clean"
     },
     "taylor-theorem-oq-03": {
@@ -10879,10 +12765,22 @@
       "lastAudited": "2026-04-22T12:12:37Z",
       "result": "clean"
     },
+    "tractatus-ontology": {
+      "auditCount": 3,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:53:12Z",
+      "result": "clean"
+    },
     "triangle-angle-sum": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-22T11:48:56Z",
+      "result": "clean"
+    },
+    "triangle-angle-sum-oq-01": {
+      "auditCount": 6,
+      "issues": [],
+      "lastAudited": "2026-04-22T20:35:01Z",
       "result": "clean"
     },
     "triangle-inequality": {
@@ -10895,6 +12793,18 @@
       "auditCount": 5,
       "issues": [],
       "lastAudited": "2026-04-22T12:07:55Z",
+      "result": "clean"
+    },
+    "triangle-inequality-oq-04": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:42:11Z",
+      "result": "clean"
+    },
+    "triangular-number-reciprocals": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T18:29:33Z",
       "result": "clean"
     },
     "triangular-reciprocals": {
@@ -10938,6 +12848,12 @@
       "lastAudited": "2026-04-22T11:48:55Z",
       "result": "clean"
     },
+    "vietas-formulas-oq-02": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:56:29Z",
+      "result": "clean"
+    },
     "vietas-formulas-oq-03": {
       "auditCount": 4,
       "issues": [],
@@ -10950,9 +12866,15 @@
       "lastAudited": "2026-04-22T12:11:49Z",
       "result": "clean"
     },
+    "vietas-formulas-oq-03-oq-05": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:41:42Z",
+      "result": "clean"
+    },
     "weak-goldbach": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-13T23:07:50Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:56:29Z",
       "result": "clean"
     },
     "wilsons-theorem": {
@@ -10971,10 +12893,22 @@
       "lastAudited": "2026-04-21T15:36:00Z",
       "result": "clean"
     },
+    "wilsons-theorem-oq-03": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:29:10Z",
+      "result": "clean"
+    },
     "wilsons-theorem-oq-04": {
       "auditCount": 3,
       "issues": [],
       "lastAudited": "2026-04-22T12:38:31Z",
+      "result": "clean"
+    },
+    "wilsons-theorem-oq-04-oq-02": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T17:25:17Z",
       "result": "clean"
     },
     "wolstenholme-theorem": {
@@ -10995,14 +12929,20 @@
       "lastAudited": "2026-04-22T11:48:54Z",
       "result": "clean"
     },
+    "wolstenholme-theorem-oq-03": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T21:35:39Z",
+      "result": "clean"
+    },
     "yang-mills": {
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 10,
-      "lastAudited": "2026-04-22T08:47:19Z",
-      "result": "clean",
       "issues": [
         "sorry mismatch corrected in meta.json"
-      ]
+      ],
+      "lastAudited": "2026-04-22T08:47:19Z",
+      "result": "clean"
     },
     "yang-mills-2d": {
       "auditCount": 7,
@@ -11028,1956 +12968,30 @@
       "lastAudited": "2026-04-22T09:10:59Z",
       "result": "clean"
     },
+    "yang-mills-lattice-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-21T12:01:35Z",
+      "result": "clean"
+    },
     "yang-mills-transfer-matrix": {
       "auditCount": 9,
       "issues": [],
       "lastAudited": "2026-04-22T09:10:45Z",
       "result": "clean"
-    },
-    "abel-ruffini-galois-extensions": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:39:10Z",
-      "result": "clean",
-      "issues": []
-    },
-    "abel-ruffini-oq-04-oq-02-oq-03": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:39:43Z",
-      "result": "clean",
-      "issues": []
-    },
-    "arithmetic-series-oq-02-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:39:10Z",
-      "result": "clean",
-      "issues": []
-    },
-    "arithmetic-series-oq-02-oq-02-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:39:43Z",
-      "result": "clean",
-      "issues": []
-    },
-    "bezout-identity-oq-03-oq-01-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:40:52Z",
-      "result": "clean",
-      "issues": []
-    },
-    "binomial-theorem-oq-04-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:39:44Z",
-      "result": "clean",
-      "issues": []
-    },
-    "cantor-diagonalization-oq-02-oq-03": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:39:44Z",
-      "result": "clean",
-      "issues": []
-    },
-    "cauchy-schwarz-oq-02": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T12:30:22Z",
-      "result": "clean",
-      "issues": []
-    },
-    "cayley-hamilton-minpoly-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:39:44Z",
-      "result": "clean",
-      "issues": []
-    },
-    "cayley-hamilton-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:39:11Z",
-      "result": "clean",
-      "issues": []
-    },
-    "cayley-hamilton-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:39:12Z",
-      "result": "clean",
-      "issues": []
-    },
-    "cramers-rule-oq-04": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:39:11Z",
-      "result": "clean",
-      "issues": []
-    },
-    "cube-root-2-irrational": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:39:11Z",
-      "result": "clean",
-      "issues": []
-    },
-    "cube-root-3-irrational": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:40:52Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-1012-oq-01": {
-      "auditCount": 5,
-      "lastAudited": "2026-04-22T18:39:20Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-1012-oq-02": {
-      "auditCount": 4,
-      "lastAudited": "2026-04-22T18:39:20Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-1023-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:40:52Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-14-unique-sums": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:40:52Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-177-oq-04": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:40:52Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-247-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:40:52Z",
-      "result": "clean",
-      "issues": []
-    },
-    "euler-totient-oq-04": {
-      "auditCount": 4,
-      "lastAudited": "2026-04-22T12:32:56Z",
-      "result": "clean",
-      "issues": []
-    },
-    "inclusion-exclusion-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:39:44Z",
-      "result": "clean",
-      "issues": []
-    },
-    "infinitude-primes-4k1": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:39:44Z",
-      "result": "clean",
-      "issues": []
-    },
-    "infinitude-primes-4k3": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:39:44Z",
-      "result": "clean",
-      "issues": []
-    },
-    "intermediate-value-theorem-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:39:43Z",
-      "result": "clean",
-      "issues": []
-    },
-    "sqrt2-plus-sqrt3-irrational": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:40:52Z",
-      "result": "clean",
-      "issues": []
-    },
-    "bezout-identity-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:40:52Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-131-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:40:53Z",
-      "result": "clean",
-      "issues": []
-    },
-    "law-of-cosines-oq-03": {
-      "auditCount": 4,
-      "lastAudited": "2026-04-22T12:29:39Z",
-      "result": "clean",
-      "issues": []
-    },
-    "sum-of-divisors": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T17:39:57Z",
-      "result": "clean",
-      "issues": []
-    },
-    "amgm-inequality-oq-02-oq-01": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:41:21Z",
-      "result": "clean",
-      "issues": []
-    },
-    "collatz-structured-oq-02-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:41:21Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-10-oq-01": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T12:38:31Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-1021-oq-01": {
-      "auditCount": 5,
-      "lastAudited": "2026-04-22T12:38:08Z",
-      "result": "clean",
-      "issues": []
-    },
-    "gcd-algorithm-oq-01-oq-03": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:41:21Z",
-      "result": "clean",
-      "issues": []
-    },
-    "isosceles-triangle-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:41:21Z",
-      "result": "clean",
-      "issues": []
-    },
-    "binomial-theorem-oq-02-oq-03": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:41:21Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-1018-oq-04-incomplete-01": {
-      "auditCount": 7,
-      "lastAudited": "2026-04-22T17:41:27Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-1155-oq-01-oq-01": {
-      "auditCount": 4,
-      "lastAudited": "2026-04-22T12:27:49Z",
-      "result": "clean",
-      "issues": []
-    },
-    "minkowski-theorem-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:41:21Z",
-      "result": "clean",
-      "issues": []
-    },
-    "angle-trisection-oq-02-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:42:01Z",
-      "result": "clean",
-      "issues": []
-    },
-    "area-of-circle-oq-01-oq-03-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:42:01Z",
-      "result": "clean",
-      "issues": []
-    },
-    "birthday-problem-oq-03-oq-01-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:42:01Z",
-      "result": "clean",
-      "issues": []
-    },
-    "cantor-diagonalization-oq-03-oq-01-incomplete-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:42:01Z",
-      "result": "clean",
-      "issues": []
-    },
-    "cramers-rule-oq-01-oq-04": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:42:01Z",
-      "result": "clean",
-      "issues": []
-    },
-    "dissection-of-cubes-oq-01-oq-01": {
-      "auditCount": 5,
-      "lastAudited": "2026-04-22T12:32:12Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-1001-oq-03": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:42:01Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-1009-oq-02": {
-      "auditCount": 4,
-      "lastAudited": "2026-04-22T17:41:29Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-1098-oq-01-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:41:21Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-1098-oq-04": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:42:00Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-659-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:41:21Z",
-      "result": "clean",
-      "issues": []
-    },
-    "sperner-ndim-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:41:21Z",
-      "result": "clean",
-      "issues": []
-    },
-    "cauchy-schwarz-oq-02-oq-01": {
-      "auditCount": 7,
-      "lastAudited": "2026-04-22T17:41:30Z",
-      "result": "clean",
-      "issues": []
-    },
-    "buffons-needle-oq-01-oq-01-oq-01": {
-      "auditCount": 4,
-      "lastAudited": "2026-04-22T11:12:56Z",
-      "result": "clean",
-      "issues": []
-    },
-    "chinese-remainder-constructive-oq-04-oq-04": {
-      "auditCount": 4,
-      "lastAudited": "2026-04-22T11:12:56Z",
-      "result": "clean",
-      "issues": []
-    },
-    "sum-of-kth-powers-oq-01": {
-      "auditCount": 4,
-      "lastAudited": "2026-04-22T11:43:49Z",
-      "result": "clean",
-      "issues": []
-    },
-    "equivariant-borsuk-ulam-compact-lie": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T11:12:59Z",
-      "result": "clean",
-      "issues": []
-    },
-    "ballot-problem-oq-01-oq-04-oq-01": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T11:12:59Z",
-      "result": "clean",
-      "issues": []
-    },
-    "No unclaimed targets available": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T16:57:29Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-1010-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T18:29:33Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-1011-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T18:29:33Z",
-      "result": "clean",
-      "issues": []
-    },
-    "triangular-number-reciprocals": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T18:29:33Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-1059-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T12:35:37Z",
-      "result": "clean",
-      "issues": []
-    },
-    "fair-games-theorem-oq-03": {
-      "auditCount": 4,
-      "lastAudited": "2026-04-13T03:03:24Z",
-      "result": "clean",
-      "issues": []
-    },
-    "arithmetic-series-oq-04": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T17:41:32Z",
-      "result": "clean",
-      "issues": []
-    },
-    "abel-ruffini-oq-04-oq-07": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T17:41:33Z",
-      "result": "clean",
-      "issues": []
-    },
-    "greens-theorem-oq-02": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T17:40:01Z",
-      "result": "clean",
-      "issues": []
-    },
-    "burnside-counting-oq-03": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T12:39:16Z",
-      "result": "clean",
-      "issues": []
-    },
-    "cevas-theorem-oq-02-oq-01-oq-03": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T12:38:08Z",
-      "result": "clean",
-      "issues": []
-    },
-    "brouwer-fixed-point-oq-01-oq-02": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T17:41:34Z",
-      "result": "clean",
-      "issues": []
-    },
-    "area-of-circle-oq-01-oq-02-oq-03": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T12:38:31Z",
-      "result": "clean",
-      "issues": []
-    },
-    "cramers-rule-oq-01-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T18:29:33Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-1059-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T12:39:16Z",
-      "result": "clean",
-      "issues": []
-    },
-    "binomial-theorem-oq-02-oq-01-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T12:39:16Z",
-      "result": "clean",
-      "issues": []
-    },
-    "cantor-diagonalization-oq-03-oq-01-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T12:39:16Z",
-      "result": "clean",
-      "issues": []
-    },
-    "bezout-identity-oq-03-oq-04-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T12:39:16Z",
-      "result": "clean",
-      "issues": []
-    },
-    "konigsberg-oq-03-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T12:39:16Z",
-      "result": "clean",
-      "issues": []
-    },
-    "wilsons-theorem-oq-04-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:25:17Z",
-      "result": "clean",
-      "issues": []
-    },
-    "cantor-diagonalization-oq-03-oq-01-oq-03": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T14:55:28Z",
-      "result": "clean",
-      "issues": []
-    },
-    "cantor-diagonalization-oq-03-oq-01-oq-02": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T17:33:20Z",
-      "result": "clean",
-      "issues": []
-    },
-    "amgm-inequality-oq-02-oq-03-oq-03": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:36:32Z",
-      "result": "clean",
-      "issues": []
-    },
-    "e-transcendental-oq-01-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:35:21Z",
-      "result": "clean",
-      "issues": []
-    },
-    "algebraic-numbers-countable": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:39:53Z",
-      "result": "clean",
-      "issues": []
-    },
-    "angle-trisection-cos-20-gal": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:39:51Z",
-      "result": "clean",
-      "issues": []
-    },
-    "angle-trisection-oq-04": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:39:50Z",
-      "result": "clean",
-      "issues": []
-    },
-    "arithmetic-series-oq-02-oq-04-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:30:33Z",
-      "result": "issues-fixed",
-      "issues": []
-    },
-    "bezout-identity-oq-02-oq-01-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:28:47Z",
-      "result": "issues-fixed",
-      "issues": []
-    },
-    "birthday-problem-oq-02-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:14:10Z",
-      "result": "clean",
-      "issues": []
-    },
-    "bounded-prime-gaps-oq-03-oq-01-oq-04": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T20:03:41Z",
-      "result": "clean",
-      "issues": []
-    },
-    "cauchy-schwarz-integral-oq-02-oq-02-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:39:24Z",
-      "result": "clean",
-      "issues": []
-    },
-    "cauchy-schwarz-oq-04-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:39:22Z",
-      "result": "clean",
-      "issues": []
-    },
-    "cevas-theorem-non-euclidean": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:39:21Z",
-      "result": "clean",
-      "issues": []
-    },
-    "chebyshev-bounds": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:39:20Z",
-      "result": "clean",
-      "issues": []
-    },
-    "collatz-cycles": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:39:18Z",
-      "result": "clean",
-      "issues": []
-    },
-    "derangements-convergence": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:39:17Z",
-      "result": "clean",
-      "issues": []
-    },
-    "derangements-oq-03-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:39:16Z",
-      "result": "clean",
-      "issues": []
-    },
-    "divisibility-by-three-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:39:14Z",
-      "result": "clean",
-      "issues": []
-    },
-    "divisibility-by-three-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:37:41Z",
-      "result": "clean",
-      "issues": []
-    },
-    "divisibility-rules": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:39:13Z",
-      "result": "clean",
-      "issues": []
-    },
-    "divisibility-rules-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:39:12Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-249-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:37:40Z",
-      "result": "clean",
-      "issues": []
-    },
-    "feuerbachs-theorem-oq-05": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:37:38Z",
-      "result": "clean",
-      "issues": []
-    },
-    "harmonic-divergence-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:37:37Z",
-      "result": "clean",
-      "issues": []
-    },
-    "kummer-theorem-oq-03": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:37:35Z",
-      "result": "clean",
-      "issues": []
-    },
-    "lagrange-four-squares-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:37:34Z",
-      "result": "clean",
-      "issues": []
-    },
-    "lagrange-theorem-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:37:32Z",
-      "result": "clean",
-      "issues": []
-    },
-    "lovasz-local-lemma": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:37:31Z",
-      "result": "clean",
-      "issues": []
-    },
-    "minkowski-fundamental-theorem": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:37:29Z",
-      "result": "clean",
-      "issues": []
-    },
-    "prob-method-second-moment-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:37:28Z",
-      "result": "clean",
-      "issues": []
-    },
-    "product-of-segments-of-chords-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:36:45Z",
-      "result": "clean",
-      "issues": []
-    },
-    "spherical-law-of-cosines": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:36:44Z",
-      "result": "clean",
-      "issues": []
-    },
-    "sylow-theorem": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:36:40Z",
-      "result": "clean",
-      "issues": []
-    },
-    "sylow-theorem-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:36:42Z",
-      "result": "clean",
-      "issues": []
-    },
-    "sylow-theorem-oq-04": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:36:39Z",
-      "result": "clean",
-      "issues": []
-    },
-    "derangements-oq-02-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:39:55Z",
-      "result": "clean",
-      "issues": []
-    },
-    "shannon-entropy-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:39:54Z",
-      "result": "clean",
-      "issues": []
-    },
-    "cantor-diagonalization-oq-02-oq-03-oq-02": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T17:39:56Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-1155-oq-01-oq-06": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T17:41:41Z",
-      "result": "clean",
-      "issues": []
-    },
-    "vietas-formulas-oq-03-oq-05": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:41:42Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-1059-oq-04": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T17:41:44Z",
-      "result": "clean",
-      "issues": []
-    },
-    "divisibility-rules-oq-01-oq-01": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T12:37:02Z",
-      "result": "clean",
-      "issues": [
-        "missing Lean file DivisibilityRulesOQ01OQ01.lean created; closed #9647"
-      ],
-      "agentId": "lean-mechanic"
-    },
-    "subset-count-multiset-oq-01": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T12:35:37Z",
-      "result": "clean",
-      "issues": [
-        "missing Lean file SubsetCountMultisetOQ01.lean created; closed #9648"
-      ],
-      "agentId": "lean-mechanic"
-    },
-    "ptolemys-complex-proof-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:41:46Z",
-      "result": "clean",
-      "issues": []
-    },
-    "szemeredi-hypergraph-core-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:41:47Z",
-      "result": "clean",
-      "issues": []
-    },
-    "divisibility-by-three-oq-02-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:41:48Z",
-      "result": "clean",
-      "issues": []
-    },
-    "euler-identity-oq-01-oq-01": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T12:37:02Z",
-      "result": "clean",
-      "issues": [
-        "missing Lean file EulerIdentityOQ01OQ01.lean created; closed #9687"
-      ],
-      "agentId": "lean-mechanic"
-    },
-    "divisibility-rules-oq-01-oq-01-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:41:50Z",
-      "result": "clean",
-      "issues": []
-    },
-    "binary-gcd-oq-01-oq-04": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:42:07Z",
-      "result": "clean",
-      "issues": []
-    },
-    "borsuk-ulam-oq-02-oq-01-oq-03": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T17:42:08Z",
-      "result": "clean",
-      "issues": []
-    },
-    "arithmetic-series-oq-02-oq-02-oq-03-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T12:00:00Z",
-      "result": "issues-fixed",
-      "issues": [
-        "sorries 1->0 (general Polya theorem now fully proved)",
-        "status formalized->verified, badge wip->verified",
-        "lineCount 365->507"
-      ]
-    },
-    "basel-problem-oq-01-oq-03": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:42:21Z",
-      "result": "clean",
-      "issues": []
-    },
-    "bertrands-postulate-oq-03-oq-04": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T21:35:37Z",
-      "result": "clean",
-      "issues": []
-    },
-    "bezout-identity-oq-02-oq-01-oq-01-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:42:19Z",
-      "result": "clean",
-      "issues": []
-    },
-    "bezout-identity-oq-02-oq-01-oq-02-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:42:18Z",
-      "result": "clean",
-      "issues": []
-    },
-    "binomial-theorem-oq-03-oq-02-oq-03": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:42:17Z",
-      "result": "clean",
-      "issues": []
-    },
-    "birch-swinnerton-dyer-oq-06": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:42:16Z",
-      "result": "clean",
-      "issues": []
-    },
-    "borsuk-ulam-oq-02-oq-01-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:42:15Z",
-      "result": "clean",
-      "issues": []
-    },
-    "herons-formula-oq-04": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:42:14Z",
-      "result": "clean",
-      "issues": []
-    },
-    "laws-of-large-numbers-oq-04": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:42:13Z",
-      "result": "clean",
-      "issues": []
-    },
-    "spherical-law-of-sines": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:42:12Z",
-      "result": "clean",
-      "issues": []
-    },
-    "triangle-inequality-oq-04": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:42:11Z",
-      "result": "clean",
-      "issues": []
-    },
-    "birthday-problem-oq-03-oq-01-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:42:23Z",
-      "result": "clean",
-      "issues": []
-    },
-    "algebraic-numbers-countable-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T18:28:23Z",
-      "result": "clean",
-      "issues": []
-    },
-    "amgm-inequality-oq-03-oq-02-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T18:28:23Z",
-      "result": "clean",
-      "issues": []
-    },
-    "angle-trisection-cos-20-gal-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T18:28:23Z",
-      "result": "clean",
-      "issues": []
-    },
-    "angle-trisection-cos-20-gal-oq-01-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-21T14:08:40Z",
-      "result": "issues-fixed",
-      "issues": []
-    },
-    "brouwer-fixed-point-oq-01-oq-03": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T17:42:24Z",
-      "result": "clean",
-      "issues": []
-    },
-    "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T18:28:22Z",
-      "result": "clean",
-      "issues": []
-    },
-    "derangements-convergence-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T18:28:23Z",
-      "result": "clean",
-      "issues": []
-    },
-    "central-limit-theorem-oq-01-oq-02-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T18:15:58Z",
-      "result": "issues-fixed",
-      "issues": [
-        "lineCount 98\u2192112, theoremCount 7\u21928 (enricher used stale counts)"
-      ]
-    },
-    "arithmetic-series-oq-02-oq-04-oq-01-oq-03": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T18:28:22Z",
-      "result": "clean",
-      "issues": []
-    },
-    "shannon-channel-coding-oq-04-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T18:27:01Z",
-      "result": "clean",
-      "issues": []
-    },
-    "triangle-angle-sum-oq-01": {
-      "auditCount": 6,
-      "lastAudited": "2026-04-22T20:35:01Z",
-      "result": "clean",
-      "issues": []
-    },
-    "shannon-channel-coding-oq-02-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-13T03:03:24Z",
-      "result": "issues-fixed",
-      "issues": [
-        "sorry mismatch: meta claimed 1, actual 0 (fano_trivial_singleton now proved)"
-      ]
-    },
-    "arithmetic-series-oq-02-oq-01-oq-01": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T18:39:20Z",
-      "result": "clean",
-      "issues": []
-    },
-    "elementary-quadratic-reciprocity-oq-01-oq-01": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T21:29:09Z",
-      "result": "issues-fixed",
-      "issues": []
-    },
-    "shannon-channel-coding-oq-03": {
-      "auditCount": 4,
-      "lastAudited": "2026-04-22T21:29:10Z",
-      "result": "clean",
-      "issues": []
-    },
-    "leibniz-pi-oq-03": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T18:29:33Z",
-      "result": "clean",
-      "issues": []
-    },
-    "amgm-inequality-oq-03-oq-02-oq-04": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T18:39:20Z",
-      "result": "clean",
-      "issues": []
-    },
-    "shannon-channel-coding-oq-04-oq-01-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T18:39:20Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-848-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:29:09Z",
-      "result": "clean",
-      "issues": []
-    },
-    "geometric-series-oq-03": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:29:09Z",
-      "result": "clean",
-      "issues": []
-    },
-    "ballot-problem-oq-03-oq-01-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:29:10Z",
-      "result": "clean",
-      "issues": []
-    },
-    "wilsons-theorem-oq-03": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:29:10Z",
-      "result": "clean",
-      "issues": []
-    },
-    "area-of-circle-oq-05-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:35:35Z",
-      "result": "clean",
-      "issues": []
-    },
-    "divisibility-by-three-oq-01-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:35:35Z",
-      "result": "clean",
-      "issues": []
-    },
-    "taylor-sincos-convergence-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-13T23:53:13Z",
-      "result": "issues-fixed",
-      "issues": []
-    },
-    "erdos-1002-oq-01-oq-01": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T21:35:39Z",
-      "result": "clean",
-      "issues": []
-    },
-    "fourier-series-oq-02-incomplete-01": {
-      "auditCount": 4,
-      "lastAudited": "2026-04-22T21:35:37Z",
-      "result": "clean",
-      "issues": []
-    },
-    "taylor-sincos-convergence-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:35:37Z",
-      "result": "clean",
-      "issues": []
-    },
-    "abel-ruffini-oq-04-oq-02-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:35:38Z",
-      "result": "clean",
-      "issues": []
-    },
-    "arithmetic-series-oq-04-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:35:38Z",
-      "result": "clean",
-      "issues": []
-    },
-    "ballot-problem-oq-01-oq-02-oq-04": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:35:38Z",
-      "result": "clean",
-      "issues": []
-    },
-    "denumerability-rationals-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:35:38Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-100-oq-02-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:35:38Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-1059-oq-02-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:35:38Z",
-      "result": "clean",
-      "issues": []
-    },
-    "euler-totient-oq-03": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:35:38Z",
-      "result": "clean",
-      "issues": []
-    },
-    "prime-gap-bounds-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:35:38Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-1008-oq-04": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:35:38Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-606-oq-03-oq-03": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-13T22:33:29Z",
-      "result": "issues-fixed",
-      "issues": []
-    },
-    "factor-remainder-nullstellensatz-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:35:38Z",
-      "result": "clean",
-      "issues": []
-    },
-    "hilbert-10-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:35:39Z",
-      "result": "clean",
-      "issues": []
-    },
-    "schauder-fixed-point-oq-03-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:35:39Z",
-      "result": "clean",
-      "issues": []
-    },
-    "wolstenholme-theorem-oq-03": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:35:39Z",
-      "result": "clean",
-      "issues": []
-    },
-    "chebyshev-pnt-bridge": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-13T00:56:13Z",
-      "result": "issues-fixed",
-      "issues": []
-    },
-    "erdos-622-oq-04": {
-      "auditCount": 2,
-      "issues": [],
-      "lastAudited": "2026-04-22T21:35:39Z",
-      "result": "clean"
-    },
-    "brouwer-fixed-point-oq-04-oq-04": {
-      "auditCount": 4,
-      "issues": [],
-      "lastAudited": "2026-04-22T21:53:12Z",
-      "result": "clean"
-    },
-    "area-of-circle-oq-03-oq-03-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:35:39Z",
-      "result": "clean",
-      "issues": []
-    },
-    "randomized-maxcut-oq-04": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-13T03:03:24Z",
-      "result": "clean",
-      "issues": []
-    },
-    "area-of-circle-oq-01-oq-02-oq-01-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T00:50:38Z",
-      "result": "clean",
-      "issues": []
-    },
-    "arithmetic-series-oq-00": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T00:50:38Z",
-      "result": "clean",
-      "issues": []
-    },
-    "ballot-problem-oq-01-oq-02-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T00:50:38Z",
-      "result": "clean",
-      "issues": []
-    },
-    "binary-gcd-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T00:50:38Z",
-      "result": "clean",
-      "issues": []
-    },
-    "divisibility-rules-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T00:50:38Z",
-      "result": "clean",
-      "issues": []
-    },
-    "hilbert-15-oq-02": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-13T21:05:00Z",
-      "result": "issues-fixed",
-      "issues": [
-        "status verified->formalized (True stub theorems: lr_saturation_theorem, lr_positivity_in_P, lr_counting_sharp_P_complete prove True)",
-        "badge verified->wip",
-        "lineCount 360->506"
-      ]
-    },
-    "minkowski-fundamental-theorem-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T00:50:38Z",
-      "result": "clean",
-      "issues": []
-    },
-    "primitive-roots-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T00:50:38Z",
-      "result": "clean",
-      "issues": []
-    },
-    "taylor-theorem-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T00:50:38Z",
-      "result": "clean",
-      "issues": []
-    },
-    "vietas-formulas-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T00:50:38Z",
-      "result": "clean",
-      "issues": []
-    },
-    "angle-trisection-oq-02-oq-01-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-13T03:03:24Z",
-      "result": "clean",
-      "issues": []
-    },
-    "cantor-diagonalization-oq-04-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T01:03:45Z",
-      "result": "issues-fixed",
-      "issues": []
-    },
-    "euler-totient-oq-02-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T01:03:45Z",
-      "result": "issues-fixed",
-      "issues": []
-    },
-    "binomial-theorem-oq-02-oq-01-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T01:03:45Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-65-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T01:03:45Z",
-      "result": "clean",
-      "issues": []
-    },
-    "hilbert-20-oq-01-oq-03": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-13T03:03:24Z",
-      "result": "clean",
-      "issues": []
-    },
-    "konigsberg-oq-04": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T18:37:22Z",
-      "result": "clean",
-      "issues": []
-    },
-    "laws-of-large-numbers-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T01:03:45Z",
-      "result": "clean",
-      "issues": []
-    },
-    "leibniz-pi-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T01:03:45Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-1059-oq-01-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-13T03:03:24Z",
-      "result": "clean",
-      "issues": []
-    },
-    "algebraic-numbers-countable-oq-02-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-13T03:03:24Z",
-      "result": "clean",
-      "issues": []
-    },
-    "kummer-theorem-oq-01-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-13T03:03:24Z",
-      "result": "clean",
-      "issues": []
-    },
-    "subset-count-oq-02-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-13T03:03:24Z",
-      "result": "clean",
-      "issues": []
-    },
-    "derangements-oq-03-oq-01-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-13T03:03:24Z",
-      "result": "clean",
-      "issues": []
-    },
-    "basel-problem-oq-01-oq-01-oq-02": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-13T22:38:12Z",
-      "result": "issues-fixed",
-      "issues": [
-        "sorry 4\u21923"
-      ]
-    },
-    "chebyshev-pnt-bridge-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T03:29:17Z",
-      "result": "issues-fixed",
-      "issues": [
-        "sorry 4\u21925",
-        "status axiomatized\u2192formalized",
-        "badge axiom\u2192wip"
-      ]
-    },
-    "divisibility-by-3-oq-03-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T03:29:17Z",
-      "result": "issues-fixed",
-      "issues": [
-        "sorry 1\u21920",
-        "status axiomatized\u2192verified",
-        "badge axiom\u2192original"
-      ]
-    },
-    "lebesgue-measure-oq-03-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T03:29:17Z",
-      "result": "issues-fixed",
-      "issues": [
-        "sorry 1\u21920",
-        "status axiomatized\u2192verified",
-        "badge axiom\u2192original"
-      ]
-    },
-    "area-of-circle-oq-02-oq-04": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T03:29:17Z",
-      "result": "clean",
-      "issues": []
-    },
-    "central-limit-theorem-oq-01-oq-02-oq-01-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T03:29:17Z",
-      "result": "clean",
-      "issues": []
-    },
-    "sperner-ndim-oq-03-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T03:29:17Z",
-      "result": "clean",
-      "issues": []
-    },
-    "area-of-circle-oq-03-oq-02-oq-02-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T16:10:16Z",
-      "result": "clean",
-      "issues": []
-    },
-    "arithmetic-series-oq-02-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T16:10:16Z",
-      "result": "clean",
-      "issues": []
-    },
-    "bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T16:10:16Z",
-      "result": "clean",
-      "issues": []
-    },
-    "buffons-needle-oq-01-oq-01-oq-04": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T16:10:16Z",
-      "result": "clean",
-      "issues": []
-    },
-    "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01": {
-      "auditCount": 7,
-      "lastAudited": "2026-04-21T11:53:37Z",
-      "result": "issues-fixed",
-      "issues": []
-    },
-    "chinese-remainder-non-coprime-oq-03-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T16:10:17Z",
-      "result": "clean",
-      "issues": []
-    },
-    "combinations-formula-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T16:10:17Z",
-      "result": "clean",
-      "issues": []
-    },
-    "denumerability-rationals-oq-02-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T16:10:17Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-109-oq-01": {
-      "auditCount": 8,
-      "lastAudited": "2026-04-21T11:03:29Z",
-      "result": "issues-fixed",
-      "issues": []
-    },
-    "erdos-1129-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T16:10:17Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-327-oq-01-oq-04": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T16:10:17Z",
-      "result": "clean",
-      "issues": []
-    },
-    "fair-games-theorem-oq-02-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T16:10:17Z",
-      "result": "clean",
-      "issues": []
-    },
-    "partition-theorem-oq-01-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T16:10:17Z",
-      "result": "clean",
-      "issues": []
-    },
-    "shannon-channel-coding-oq-02-oq-04": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T16:10:17Z",
-      "result": "clean",
-      "issues": []
-    },
-    "sophie-germain-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T16:10:17Z",
-      "result": "clean",
-      "issues": []
-    },
-    "amgm-inequality-oq-02-oq-01-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T20:30:52Z",
-      "result": "clean",
-      "issues": []
-    },
-    "basel-problem-oq-04": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T20:33:48Z",
-      "result": "issues-fixed",
-      "issues": []
-    },
-    "cauchy-schwarz-oq-01-oq-01-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T20:34:51Z",
-      "result": "clean",
-      "issues": []
-    },
-    "cevas-theorem-non-euclidean-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T20:35:23Z",
-      "result": "clean",
-      "issues": []
-    },
-    "chinese-remainder-non-coprime-oq-01-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T20:35:43Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-1083-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T20:36:17Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-1107-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed",
-      "issues": []
-    },
-    "erdos-837-oq-05": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T20:37:47Z",
-      "result": "clean",
-      "issues": []
-    },
-    "lagrange-four-squares-oq-04": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T20:38:12Z",
-      "result": "clean",
-      "issues": []
-    },
-    "taylor-sincos-convergence-oq-04": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T20:38:29Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-1027-oq-03": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-13T20:42:50Z",
-      "result": "clean",
-      "issues": []
-    },
-    "chebyshev-pnt-bridge-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-13T22:05:22Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-105-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-13T22:05:53Z",
-      "result": "clean",
-      "issues": []
-    },
-    "ptolemys-theorem-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-13T22:05:53Z",
-      "result": "clean",
-      "issues": []
-    },
-    "amgm-inequality-oq-03-oq-03-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T21:34:28Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-1027-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-13T22:34:36Z",
-      "result": "clean",
-      "issues": []
-    },
-    "angle-trisection-cos-20-gal-oq-03": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-13T22:34:36Z",
-      "result": "clean",
-      "issues": []
-    },
-    "lovasz-local-lemma-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-13T22:34:36Z",
-      "result": "clean",
-      "issues": []
-    },
-    "cube-root-3-irrational-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T22:34:36Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-130-wip-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T22:34:36Z",
-      "result": "clean",
-      "issues": []
-    },
-    "tractatus-ontology": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T21:53:12Z",
-      "result": "clean",
-      "issues": []
-    },
-    "collatz-cycles-oq-04": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:53:12Z",
-      "result": "clean",
-      "issues": []
-    },
-    "ptolemys-theorem-oq-01-incomplete-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:53:12Z",
-      "result": "clean",
-      "issues": []
-    },
-    "law-of-sines-oq-06": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T21:53:13Z",
-      "result": "clean",
-      "issues": [
-        "id/slug mismatch: meta.json had id=law-of-cosines-oq-06; fixed by enrichment PR #10757"
-      ]
-    },
-    "law-of-cosines-oq-06": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T00:00:00Z",
-      "result": "issues-fixed",
-      "issues": [
-        "gallery entry renamed law-of-cosines-oq-06\u2192law-of-sines-oq-06; content was Law of Sines not Law of Cosines (fixed by PRs #10749, #10757)"
-      ]
-    },
-    "bezout-identity-oq-02-oq-04": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T21:53:13Z",
-      "result": "clean",
-      "issues": [
-        "badge original\u2192mathlib (core results are Mathlib wrappers; fixed by PR #10846)"
-      ]
-    },
-    "binomial-theorem-oq-02-oq-04": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:53:12Z",
-      "result": "clean",
-      "issues": []
-    },
-    "cantor-diagonalization-oq-01-oq-01-oq-02-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-21T10:41:07Z",
-      "result": "issues-fixed",
-      "issues": []
-    },
-    "cauchy-schwarz-integral-oq-01-oq-03": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:53:13Z",
-      "result": "clean",
-      "issues": []
-    },
-    "cayley-hamilton-minpoly-oq-03-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-21T10:43:49Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-181-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:53:13Z",
-      "result": "clean",
-      "issues": []
-    },
-    "bertrands-postulate-oq-03-oq-04-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-21T10:45:42Z",
-      "result": "issues-fixed",
-      "issues": []
-    },
-    "binomial-theorem-oq-02-oq-01-oq-03": {
-      "auditCount": 5,
-      "lastAudited": "2026-04-21T15:13:46Z",
-      "result": "issues-fixed",
-      "issues": []
-    },
-    "erdos-1202": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-21T10:44:38Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-1205": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-21T10:44:38Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-1206": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-21T10:44:38Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-1208": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-21T10:44:38Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-1211": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-21T10:44:38Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-1212": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-21T10:44:38Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-1213": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-21T10:48:35Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-1215": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-21T10:48:35Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-1216": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-21T10:48:35Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-1217": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-21T10:48:35Z",
-      "result": "clean",
-      "issues": []
-    },
-    "amgm-inequality-oq-03-oq-02-oq-01-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T11:37:16Z",
-      "result": "clean",
-      "issues": []
-    },
-    "amgm-inequality-oq-03-oq-04": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T11:37:16Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-1196": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T11:37:16Z",
-      "result": "clean",
-      "issues": []
-    },
-    "area-of-circle-oq-02-oq-01": {
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T12:03:58Z",
-      "result": "issues-fixed",
-      "issues": []
-    },
-    "yang-mills-lattice-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T12:01:35Z",
-      "result": "clean",
-      "issues": []
-    },
-    "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-21T12:07:57Z",
-      "result": "clean",
-      "issues": []
-    },
-    "angle-trisection-cos-20-gal-oq-03-oq-01": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T12:46:16Z",
-      "result": "clean",
-      "issues": []
-    },
-    "cayley-hamilton-reduction-oq-01-oq-02": {
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T12:51:34Z",
-      "result": "clean",
-      "issues": []
-    },
-    "godel-first-incompleteness-oq01": {
-      "auditCount": 5,
-      "lastAudited": "2026-04-21T13:17:20Z",
-      "result": "clean",
-      "issues": []
-    },
-    "law-of-cosines-oq-01-oq-05": {
-      "auditCount": 5,
-      "lastAudited": "2026-04-21T13:19:56Z",
-      "result": "clean",
-      "issues": []
-    },
-    "fourier-series-oq-02-oq-01": {
-      "auditCount": 6,
-      "lastAudited": "2026-04-21T13:16:35Z",
-      "result": "clean",
-      "issues": []
-    },
-    "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T13:30:00Z",
-      "result": "issues-fixed",
-      "issues": [
-        "lineCount 122\u2192118 (corrected to match actual Lean file)"
-      ]
-    },
-    "area-of-circle-oq-01-oq-02-oq-03-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-21T13:15:24Z",
-      "result": "clean",
-      "issues": []
-    },
-    "godel-second-incompleteness-oq02": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-21T13:19:31Z",
-      "result": "issues-fixed",
-      "issues": []
-    },
-    "gcd-algorithm-oq-04": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-21T13:58:19Z",
-      "result": "clean",
-      "issues": []
-    },
-    "szemeredi-hypergraph-core-oq-01-incomplete-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-21T15:31:06Z",
-      "result": "clean",
-      "issues": []
-    },
-    "lhopital-oq-01": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:34:45Z",
-      "result": "clean",
-      "issues": []
-    },
-    "ballot-problem-oq-03-oq-01-oq-02": {
-      "auditCount": 7,
-      "lastAudited": "2026-04-22T20:12:20Z",
-      "result": "clean",
-      "issues": []
-    },
-    "bezout-identity-oq-04-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-21T17:27:38Z",
-      "result": "issues-fixed",
-      "issues": []
-    },
-    "schroeder-bernstein-oq-03": {
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed",
-      "issues": []
-    },
-    "hurwitz-theorem-oq-03-oq-01": {
-      "auditCount": 2,
-      "issues": [],
-      "lastAudited": "2026-04-22T08:42:37Z",
-      "result": "clean"
-    },
-    "brouwer-fixed-point-oq-04-oq-02": {
-      "auditCount": 4,
-      "lastAudited": "2026-04-22T08:32:31Z",
-      "result": "clean",
-      "issues": [
-        "NOTE: Researcher has fixed the sorry in working tree (uncommitted); HEAD has 1 sorry matching meta.json; meta.json update needed after researcher commits and proof compiles"
-      ]
-    },
-    "area-of-circle-oq-05-oq-02": {
-      "auditCount": 4,
-      "lastAudited": "2026-04-22T21:29:10Z",
-      "result": "clean",
-      "issues": []
-    },
-    "chebyshev-pnt-bridge-oq-01-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-21T19:38:08Z",
-      "result": "clean",
-      "issues": []
-    },
-    "shannon-source-coding-oq-04": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T20:08:54Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-476-oq-05": {
-      "auditCount": 4,
-      "lastAudited": "2026-04-22T08:06:38Z",
-      "result": "issues-fixed",
-      "issues": [
-        "sorries 3->1 (ap_of_near_periodic and vosper_base now fully proved)",
-        "lineCount 194->306",
-        "theoremCount 7->8"
-      ]
-    },
-    "ptolemys-theorem-oq-01-oq-01": {
-      "auditCount": 4,
-      "lastAudited": "2026-04-22T11:13:07Z",
-      "result": "issues-fixed",
-      "issues": []
-    },
-    "fair-games-theorem-oq-02-oq-04": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-22T12:54:20Z",
-      "result": "clean",
-      "issues": []
-    },
-    "lebesgue-measure-oq-06": {
-      "auditCount": 7,
-      "lastAudited": "2026-04-22T20:24:34Z",
-      "result": "issues-fixed",
-      "issues": []
-    },
-    "dissection-of-cubes-oq-04": {
-      "auditCount": 4,
-      "lastAudited": "2026-04-22T18:06:42Z",
-      "result": "clean",
-      "issues": []
-    },
-    "sperner-ndim-oq-04": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T18:25:15Z",
-      "result": "issues-fixed",
-      "issues": []
-    },
-    "hurwitz-theorem-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-22T18:37:22Z",
-      "result": "clean",
-      "issues": []
-    },
-    "hurwitz-theorem-oq-04": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-22T18:37:22Z",
-      "result": "clean",
-      "issues": []
-    },
-    "hilbert-1-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-22T18:37:22Z",
-      "result": "clean",
-      "issues": []
-    },
-    "sqrt2-minpoly": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-22T19:22:02Z",
-      "result": "issues-found",
-      "issues": []
-    },
-    "feuerbachs-theorem-defs-oq-04": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-22T19:49:18Z",
-      "result": "clean",
-      "issues": []
-    },
-    "sqrt2-plus-sqrt3-irrational-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-22T20:40:28Z",
-      "result": "issues-found",
-      "issues": []
     }
   },
   "erdos-1097-oq-01": {
     "agentId": "auditor-cycle-2",
     "auditCount": 1,
     "lastAudited": "2026-03-29T18:24:11Z",
+    "result": "issues-fixed"
+  },
+  "erdos-263": {
+    "auditCount": 1,
+    "detectedIssues": null,
+    "lastAudited": "2026-04-21T17:41:37Z",
+    "notes": "meta.sorries off by 1 (had 4, actual 5). Top-level sorries field was already correct.",
     "result": "issues-fixed"
   },
   "erdos-327-oq-01": {
@@ -13008,6 +13022,13 @@
     "lastAudited": "2026-03-29T18:47:33Z",
     "result": "issues-fixed"
   },
+  "erdos-840": {
+    "auditCount": 1,
+    "detectedIssues": null,
+    "lastAudited": "2026-04-21T17:41:37Z",
+    "notes": "All 10 sorries converted to explicit axioms in commit 01567512e4. Fixed: sorries 10\u21920, axiomCount 10\u21928 (actual axiom declarations).",
+    "result": "issues-fixed"
+  },
   "inverse-galois": {
     "agentId": "auditor-cycle-3",
     "auditCount": 1,
@@ -13020,33 +13041,12 @@
     "lastAudited": "2026-03-29T18:47:33Z",
     "result": "clean"
   },
-  "version": 1,
-  "erdos-263": {
-    "lastAudited": "2026-04-21T17:41:37Z",
-    "result": "issues-fixed",
-    "auditCount": 1,
-    "notes": "meta.sorries off by 1 (had 4, actual 5). Top-level sorries field was already correct.",
-    "detectedIssues": null
-  },
-  "cantor-diagonalization-oq-02-oq-03-oq-02": {
-    "lastAudited": "2026-04-21T17:41:37Z",
-    "result": "issues-fixed",
-    "auditCount": 1,
-    "notes": "Lean file has 0 actual sorries (diagInter_isUnbounded fully proved in PR #11082); stale documentation in comments mentioned \"the one sorry\". Fixed: sorries 1\u21920, badge wip\u2192original, status formalized\u2192verified.",
-    "detectedIssues": null
-  },
-  "erdos-840": {
-    "lastAudited": "2026-04-21T17:41:37Z",
-    "result": "issues-fixed",
-    "auditCount": 1,
-    "notes": "All 10 sorries converted to explicit axioms in commit 01567512e4. Fixed: sorries 10\u21920, axiomCount 10\u21928 (actual axiom declarations).",
-    "detectedIssues": null
-  },
   "lovasz-local-lemma-oq-02": {
-    "lastAudited": "2026-04-21T17:41:37Z",
-    "result": "issues-fixed",
     "auditCount": 1,
+    "detectedIssues": null,
+    "lastAudited": "2026-04-21T17:41:37Z",
     "notes": "1 sorry in code (line 207), 1 mention of \"sorry\" in parenthetical doc comment. Fixed: sorries 2\u21921.",
-    "detectedIssues": null
-  }
+    "result": "issues-fixed"
+  },
+  "version": 1
 }

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24,10 +24,10 @@
   },
   "entries": {
     "No unclaimed targets available": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T16:57:29Z",
-      "result": "clean"
+      "lastAudited": "2026-04-22T21:58:44Z",
+      "result": "no-meta"
     },
     "abel-ruffini": {
       "auditCount": 6,
@@ -36,9 +36,9 @@
       "result": "clean"
     },
     "abel-ruffini-galois-extensions": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T15:39:10Z",
+      "lastAudited": "2026-04-22T21:58:44Z",
       "result": "clean"
     },
     "abel-ruffini-oq-04": {
@@ -66,9 +66,9 @@
       "result": "clean"
     },
     "abel-ruffini-oq-04-oq-02-oq-03": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T15:39:43Z",
+      "lastAudited": "2026-04-22T21:59:00Z",
       "result": "clean"
     },
     "abel-ruffini-oq-04-oq-03": {
@@ -114,10 +114,10 @@
       "result": "clean"
     },
     "amgm-inequality-oq-02-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-21T15:41:21Z",
-      "result": "clean"
+      "lastAudited": "2026-04-22T21:59:00Z",
+      "result": "no-meta"
     },
     "amgm-inequality-oq-02-oq-01-oq-02": {
       "auditCount": 2,
@@ -162,9 +162,9 @@
       "result": "clean"
     },
     "amgm-inequality-oq-03-oq-02-oq-01-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T11:37:16Z",
+      "lastAudited": "2026-04-22T21:57:19Z",
       "result": "clean"
     },
     "amgm-inequality-oq-03-oq-02-oq-04": {
@@ -186,9 +186,9 @@
       "result": "clean"
     },
     "amgm-inequality-oq-03-oq-04": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T11:37:16Z",
+      "lastAudited": "2026-04-22T21:57:19Z",
       "result": "clean"
     },
     "amgm-inequality-oq-04": {
@@ -216,10 +216,10 @@
       "result": "clean"
     },
     "angle-trisection-cos-20-gal-oq-01-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-21T14:08:40Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T21:58:06Z",
+      "result": "clean"
     },
     "angle-trisection-cos-20-gal-oq-03": {
       "auditCount": 3,
@@ -228,14 +228,14 @@
       "result": "clean"
     },
     "angle-trisection-cos-20-gal-oq-03-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-21T12:46:16Z",
+      "lastAudited": "2026-04-22T21:58:06Z",
       "result": "clean"
     },
     "angle-trisection-oq-01": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:37:48Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:58:44Z",
       "result": "clean"
     },
     "angle-trisection-oq-02": {
@@ -263,9 +263,9 @@
       "result": "clean"
     },
     "angle-trisection-oq-02-oq-02": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T15:42:01Z",
+      "lastAudited": "2026-04-22T21:59:14Z",
       "result": "clean"
     },
     "angle-trisection-oq-02-oq-03": {
@@ -349,9 +349,9 @@
       "result": "clean"
     },
     "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-21T12:07:57Z",
+      "lastAudited": "2026-04-22T21:58:06Z",
       "result": "clean"
     },
     "area-of-circle-oq-01-oq-02-oq-01-oq-03": {
@@ -379,23 +379,23 @@
       "result": "clean"
     },
     "area-of-circle-oq-01-oq-02-oq-03-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-21T13:15:24Z",
+      "lastAudited": "2026-04-22T21:58:06Z",
       "result": "clean"
     },
     "area-of-circle-oq-01-oq-03": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [
         "https://github.com/rjwalters/lean-genius/pull/8651"
       ],
-      "lastAudited": "2026-04-21T14:38:37Z",
+      "lastAudited": "2026-04-22T21:58:06Z",
       "result": "clean"
     },
     "area-of-circle-oq-01-oq-03-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T15:42:01Z",
+      "lastAudited": "2026-04-22T21:59:14Z",
       "result": "clean"
     },
     "area-of-circle-oq-02": {
@@ -405,10 +405,10 @@
       "result": "clean"
     },
     "area-of-circle-oq-02-oq-01": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-21T12:03:58Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T21:58:06Z",
+      "result": "clean"
     },
     "area-of-circle-oq-02-oq-04": {
       "auditCount": 2,
@@ -423,8 +423,8 @@
       "result": "clean"
     },
     "area-of-circle-oq-03-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:37:35Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-22T21:58:44Z",
       "result": "clean"
     },
     "area-of-circle-oq-03-oq-02": {
@@ -458,11 +458,11 @@
       "result": "clean"
     },
     "area-of-circle-oq-05": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
         "sorries 1\u21920, status formalized\u2192verified, badge wip\u2192mathlib (sorry was completed)"
       ],
-      "lastAudited": "2026-04-21T15:42:01Z",
+      "lastAudited": "2026-04-22T21:59:14Z",
       "result": "clean"
     },
     "area-of-circle-oq-05-oq-01": {
@@ -496,9 +496,9 @@
       "result": "clean"
     },
     "arithmetic-series-oq-02-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T15:39:10Z",
+      "lastAudited": "2026-04-22T21:58:44Z",
       "result": "clean"
     },
     "arithmetic-series-oq-02-oq-01-oq-01": {
@@ -514,9 +514,9 @@
       "result": "clean"
     },
     "arithmetic-series-oq-02-oq-02-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T15:39:43Z",
+      "lastAudited": "2026-04-22T21:59:00Z",
       "result": "clean"
     },
     "arithmetic-series-oq-02-oq-02-oq-03": {
@@ -560,12 +560,12 @@
       "result": "clean"
     },
     "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [
         "lineCount 122\u2192118 (corrected to match actual Lean file)"
       ],
-      "lastAudited": "2026-04-21T13:30:00Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T21:58:06Z",
+      "result": "clean"
     },
     "arithmetic-series-oq-04": {
       "auditCount": 3,
@@ -732,10 +732,10 @@
       "result": "clean"
     },
     "bertrands-postulate-oq-03-oq-04-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-21T10:45:42Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T21:57:19Z",
+      "result": "clean"
     },
     "bezout-identity": {
       "auditCount": 3,
@@ -744,9 +744,9 @@
       "result": "clean"
     },
     "bezout-identity-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T15:40:52Z",
+      "lastAudited": "2026-04-22T21:59:00Z",
       "result": "clean"
     },
     "bezout-identity-oq-02": {
@@ -842,9 +842,9 @@
       "result": "clean"
     },
     "bezout-identity-oq-03-oq-01-oq-02": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T15:40:52Z",
+      "lastAudited": "2026-04-22T21:59:00Z",
       "result": "clean"
     },
     "bezout-identity-oq-03-oq-04": {
@@ -872,10 +872,10 @@
       "result": "clean"
     },
     "bezout-identity-oq-04-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-21T17:27:38Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T22:00:47Z",
+      "result": "clean"
     },
     "binary-gcd": {
       "auditCount": 3,
@@ -944,10 +944,10 @@
       "result": "clean"
     },
     "binomial-theorem-oq-02-oq-01-oq-03": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-04-21T15:13:46Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T21:58:06Z",
+      "result": "clean"
     },
     "binomial-theorem-oq-02-oq-02": {
       "auditCount": 3,
@@ -956,9 +956,9 @@
       "result": "clean"
     },
     "binomial-theorem-oq-02-oq-03": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T15:41:21Z",
+      "lastAudited": "2026-04-22T21:59:00Z",
       "result": "clean"
     },
     "binomial-theorem-oq-02-oq-04": {
@@ -992,9 +992,9 @@
       "result": "clean"
     },
     "binomial-theorem-oq-04-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T15:39:44Z",
+      "lastAudited": "2026-04-22T21:59:00Z",
       "result": "clean"
     },
     "binomial-theorem-oq-04-oq-02": {
@@ -1063,9 +1063,9 @@
       "result": "clean"
     },
     "birthday-problem-oq-03-oq-01-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T15:42:01Z",
+      "lastAudited": "2026-04-22T21:59:14Z",
       "result": "clean"
     },
     "birthday-problem-oq-03-oq-01-oq-02": {
@@ -1355,10 +1355,10 @@
       "result": "clean"
     },
     "cantor-diagonalization-oq-01-oq-01-oq-02-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-21T10:41:07Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T21:57:19Z",
+      "result": "clean"
     },
     "cantor-diagonalization-oq-02": {
       "auditCount": 7,
@@ -1373,9 +1373,9 @@
       "result": "clean"
     },
     "cantor-diagonalization-oq-02-oq-03": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T15:39:44Z",
+      "lastAudited": "2026-04-22T21:59:00Z",
       "result": "clean"
     },
     "cantor-diagonalization-oq-02-oq-03-oq-02": {
@@ -1397,9 +1397,9 @@
       "result": "clean"
     },
     "cantor-diagonalization-oq-03-oq-01-incomplete-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T15:42:01Z",
+      "lastAudited": "2026-04-22T21:59:14Z",
       "result": "clean"
     },
     "cantor-diagonalization-oq-03-oq-01-oq-01": {
@@ -1511,10 +1511,10 @@
       "result": "clean"
     },
     "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01": {
-      "auditCount": 7,
+      "auditCount": 8,
       "issues": [],
-      "lastAudited": "2026-04-21T11:53:37Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T21:58:06Z",
+      "result": "clean"
     },
     "cauchy-schwarz-integral-oq-01-oq-02": {
       "auditCount": 3,
@@ -1649,9 +1649,9 @@
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T15:39:44Z",
+      "lastAudited": "2026-04-22T21:59:00Z",
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-02": {
@@ -1691,14 +1691,14 @@
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-03-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-21T10:43:49Z",
+      "lastAudited": "2026-04-22T21:57:19Z",
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-04": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:37:25Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-22T21:58:44Z",
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-05": {
@@ -1744,15 +1744,15 @@
       "result": "clean"
     },
     "cayley-hamilton-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T15:39:11Z",
+      "lastAudited": "2026-04-22T21:58:44Z",
       "result": "clean"
     },
     "cayley-hamilton-oq-02": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T15:39:12Z",
+      "lastAudited": "2026-04-22T21:59:00Z",
       "result": "clean"
     },
     "cayley-hamilton-reduction": {
@@ -1768,9 +1768,9 @@
       "result": "clean"
     },
     "cayley-hamilton-reduction-oq-01-oq-02": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-21T12:51:34Z",
+      "lastAudited": "2026-04-22T21:58:06Z",
       "result": "clean"
     },
     "cayley-hamilton-reduction-oq-02": {
@@ -1865,8 +1865,8 @@
       "result": "clean"
     },
     "cevas-theorem-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:37:09Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-22T21:58:44Z",
       "result": "clean"
     },
     "cevas-theorem-oq-02": {
@@ -1882,8 +1882,8 @@
       "result": "clean"
     },
     "cevas-theorem-oq-02-oq-01-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:36:51Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-22T21:58:44Z",
       "result": "clean"
     },
     "cevas-theorem-oq-02-oq-01-oq-03": {
@@ -1987,13 +1987,13 @@
       "result": "clean"
     },
     "chinese-remainder-non-coprime-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:36:40Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-22T21:58:44Z",
       "result": "clean"
     },
     "chinese-remainder-non-coprime-oq-03": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T12:40:09Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-22T21:58:06Z",
       "result": "clean"
     },
     "chinese-remainder-non-coprime-oq-03-oq-02": {
@@ -2033,9 +2033,9 @@
       "result": "clean"
     },
     "collatz-structured-oq-02-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T15:41:21Z",
+      "lastAudited": "2026-04-22T21:59:00Z",
       "result": "clean"
     },
     "collatz-structured-oq-03": {
@@ -2051,8 +2051,8 @@
       "result": "clean"
     },
     "combinations-formula-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:36:29Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-22T21:58:44Z",
       "result": "clean"
     },
     "combinations-formula-oq-02": {
@@ -2110,9 +2110,9 @@
       "result": "clean"
     },
     "cramers-rule-oq-01-oq-04": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T15:42:01Z",
+      "lastAudited": "2026-04-22T21:59:14Z",
       "result": "clean"
     },
     "cramers-rule-oq-02": {
@@ -2128,21 +2128,21 @@
       "result": "clean"
     },
     "cramers-rule-oq-04": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T15:39:11Z",
+      "lastAudited": "2026-04-22T21:58:44Z",
       "result": "clean"
     },
     "cube-root-2-irrational": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T15:39:11Z",
+      "lastAudited": "2026-04-22T21:58:44Z",
       "result": "clean"
     },
     "cube-root-3-irrational": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T15:40:52Z",
+      "lastAudited": "2026-04-22T21:59:00Z",
       "result": "clean"
     },
     "cube-root-3-irrational-oq-02": {
@@ -2194,8 +2194,8 @@
       "result": "clean"
     },
     "denumerability-rationals-oq-02": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:39:10Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:58:44Z",
       "result": "clean"
     },
     "denumerability-rationals-oq-02-oq-02": {
@@ -2375,12 +2375,12 @@
       "result": "clean"
     },
     "dirichlets-theorem-oq-03": {
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [
         "sorry mismatch corrected in meta.json"
       ],
-      "lastAudited": "2026-04-21T11:34:06Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T21:57:19Z",
+      "result": "clean"
     },
     "dissection-of-cubes": {
       "auditCount": 3,
@@ -2706,9 +2706,9 @@
       "result": "clean"
     },
     "erdos-1001-oq-03": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T15:42:01Z",
+      "lastAudited": "2026-04-22T21:59:14Z",
       "result": "clean"
     },
     "erdos-1002": {
@@ -2971,10 +2971,10 @@
       "result": "clean"
     },
     "erdos-102": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T22:00:47Z",
+      "result": "clean"
     },
     "erdos-1020": {
       "auditCount": 5,
@@ -3013,9 +3013,9 @@
       "result": "clean"
     },
     "erdos-1023-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T15:40:52Z",
+      "lastAudited": "2026-04-22T21:59:00Z",
       "result": "clean"
     },
     "erdos-1024": {
@@ -3055,10 +3055,10 @@
       "result": "clean"
     },
     "erdos-1028": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T22:00:47Z",
+      "result": "clean"
     },
     "erdos-1029": {
       "auditCount": 5,
@@ -3565,10 +3565,10 @@
       "result": "clean"
     },
     "erdos-109-oq-01": {
-      "auditCount": 8,
+      "auditCount": 9,
       "issues": [],
-      "lastAudited": "2026-04-21T11:03:29Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T21:57:19Z",
+      "result": "clean"
     },
     "erdos-1090": {
       "agentId": "auditor-cycle-20-batch",
@@ -3643,15 +3643,15 @@
       "result": "clean"
     },
     "erdos-1098-oq-01-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T15:41:21Z",
+      "lastAudited": "2026-04-22T21:59:00Z",
       "result": "clean"
     },
     "erdos-1098-oq-04": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T15:42:00Z",
+      "lastAudited": "2026-04-22T21:59:14Z",
       "result": "clean"
     },
     "erdos-1099": {
@@ -3847,10 +3847,10 @@
       "result": "clean"
     },
     "erdos-1124": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-21T18:36:21Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T22:00:47Z",
+      "result": "clean"
     },
     "erdos-1124-oq-01": {
       "auditCount": 3,
@@ -3907,10 +3907,10 @@
       "result": "clean"
     },
     "erdos-1130": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-21T18:36:21Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T22:00:47Z",
+      "result": "clean"
     },
     "erdos-1131": {
       "auditCount": 3,
@@ -3925,16 +3925,16 @@
       "result": "clean"
     },
     "erdos-1132": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-21T18:36:21Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T22:00:47Z",
+      "result": "clean"
     },
     "erdos-1133": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-21T18:36:21Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T22:00:47Z",
+      "result": "clean"
     },
     "erdos-1134": {
       "auditCount": 4,
@@ -4129,10 +4129,10 @@
       "result": "clean"
     },
     "erdos-1158": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-21T18:36:21Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T22:00:47Z",
+      "result": "clean"
     },
     "erdos-1159": {
       "auditCount": 3,
@@ -4165,10 +4165,10 @@
       "result": "clean"
     },
     "erdos-1165": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-21T18:23:16Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T22:00:47Z",
+      "result": "clean"
     },
     "erdos-1166": {
       "agentId": "auditor-cycle-20-batch",
@@ -4238,8 +4238,8 @@
     },
     "erdos-1175": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:21:08Z",
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:00:47Z",
       "result": "clean"
     },
     "erdos-1176": {
@@ -4250,8 +4250,8 @@
     },
     "erdos-1177": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T18:05:59Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:47Z",
       "result": "clean"
     },
     "erdos-1178": {
@@ -4279,9 +4279,9 @@
       "result": "clean"
     },
     "erdos-1181": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-21T18:05:18Z",
+      "lastAudited": "2026-04-22T22:00:47Z",
       "result": "clean"
     },
     "erdos-1182": {
@@ -4303,9 +4303,9 @@
       "result": "clean"
     },
     "erdos-1196": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T11:37:16Z",
+      "lastAudited": "2026-04-22T21:58:06Z",
       "result": "clean"
     },
     "erdos-12": {
@@ -4316,32 +4316,32 @@
     },
     "erdos-120": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T18:04:26Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:47Z",
       "result": "clean"
     },
     "erdos-1202": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-21T10:44:38Z",
+      "lastAudited": "2026-04-22T21:57:19Z",
       "result": "clean"
     },
     "erdos-1205": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-21T10:44:38Z",
+      "lastAudited": "2026-04-22T21:57:19Z",
       "result": "clean"
     },
     "erdos-1206": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-21T10:44:38Z",
+      "lastAudited": "2026-04-22T21:57:19Z",
       "result": "clean"
     },
     "erdos-1208": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-21T10:44:38Z",
+      "lastAudited": "2026-04-22T21:57:19Z",
       "result": "clean"
     },
     "erdos-121": {
@@ -4351,39 +4351,39 @@
       "result": "clean"
     },
     "erdos-1211": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-21T10:44:38Z",
+      "lastAudited": "2026-04-22T21:57:19Z",
       "result": "clean"
     },
     "erdos-1212": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-21T10:44:38Z",
+      "lastAudited": "2026-04-22T21:57:19Z",
       "result": "clean"
     },
     "erdos-1213": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-21T10:48:35Z",
+      "lastAudited": "2026-04-22T21:57:19Z",
       "result": "clean"
     },
     "erdos-1215": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-21T10:48:35Z",
+      "lastAudited": "2026-04-22T21:57:19Z",
       "result": "clean"
     },
     "erdos-1216": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-21T10:48:35Z",
+      "lastAudited": "2026-04-22T21:57:19Z",
       "result": "clean"
     },
     "erdos-1217": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-21T10:48:35Z",
+      "lastAudited": "2026-04-22T21:57:19Z",
       "result": "clean"
     },
     "erdos-122": {
@@ -4418,8 +4418,8 @@
     },
     "erdos-126": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T18:01:41Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:47Z",
       "result": "clean"
     },
     "erdos-127": {
@@ -4442,8 +4442,8 @@
     },
     "erdos-13": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:02:52Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:47Z",
       "result": "clean"
     },
     "erdos-130": {
@@ -4459,15 +4459,15 @@
       "result": "clean"
     },
     "erdos-131": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-04-21T16:03:36Z",
+      "lastAudited": "2026-04-22T22:00:47Z",
       "result": "clean"
     },
     "erdos-131-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T15:40:53Z",
+      "lastAudited": "2026-04-22T21:59:00Z",
       "result": "clean"
     },
     "erdos-132": {
@@ -4527,9 +4527,9 @@
       "result": "clean"
     },
     "erdos-14-unique-sums": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T15:40:52Z",
+      "lastAudited": "2026-04-22T21:59:00Z",
       "result": "clean"
     },
     "erdos-140": {
@@ -4569,9 +4569,9 @@
       "result": "issues-fixed"
     },
     "erdos-146": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-21T16:02:52Z",
+      "lastAudited": "2026-04-22T22:00:47Z",
       "result": "clean"
     },
     "erdos-147": {
@@ -4599,9 +4599,9 @@
       "result": "clean"
     },
     "erdos-150": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-21T16:02:52Z",
+      "lastAudited": "2026-04-22T22:00:47Z",
       "result": "clean"
     },
     "erdos-151": {
@@ -4635,9 +4635,9 @@
       "result": "issues-fixed"
     },
     "erdos-155": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-21T16:02:52Z",
+      "lastAudited": "2026-04-22T22:00:47Z",
       "result": "clean"
     },
     "erdos-156": {
@@ -4679,9 +4679,9 @@
       "result": "clean"
     },
     "erdos-161": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-21T16:02:34Z",
+      "lastAudited": "2026-04-22T22:00:47Z",
       "result": "clean"
     },
     "erdos-162": {
@@ -4709,9 +4709,9 @@
       "result": "clean"
     },
     "erdos-166": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-21T16:02:34Z",
+      "lastAudited": "2026-04-22T22:00:47Z",
       "result": "clean"
     },
     "erdos-167": {
@@ -4739,9 +4739,9 @@
       "result": "clean"
     },
     "erdos-170": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-21T16:02:34Z",
+      "lastAudited": "2026-04-22T22:00:47Z",
       "result": "clean"
     },
     "erdos-171": {
@@ -4763,9 +4763,9 @@
       "result": "clean"
     },
     "erdos-174": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-21T16:02:14Z",
+      "lastAudited": "2026-04-22T22:00:47Z",
       "result": "clean"
     },
     "erdos-175": {
@@ -4787,9 +4787,9 @@
       "result": "issues-fixed"
     },
     "erdos-177-oq-04": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T15:40:52Z",
+      "lastAudited": "2026-04-22T21:59:00Z",
       "result": "clean"
     },
     "erdos-178": {
@@ -4836,8 +4836,8 @@
     },
     "erdos-183": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:02:13Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:47Z",
       "result": "clean"
     },
     "erdos-184": {
@@ -4854,14 +4854,14 @@
     },
     "erdos-186": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:02:12Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:34Z",
       "result": "clean"
     },
     "erdos-187": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:02:12Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:47Z",
       "result": "clean"
     },
     "erdos-188": {
@@ -4914,8 +4914,8 @@
     },
     "erdos-194": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:01:52Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:34Z",
       "result": "clean"
     },
     "erdos-195": {
@@ -5025,8 +5025,8 @@
     },
     "erdos-209": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:01:22Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:34Z",
       "result": "clean"
     },
     "erdos-21": {
@@ -5037,8 +5037,8 @@
     },
     "erdos-210": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:01:22Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:34Z",
       "result": "clean"
     },
     "erdos-211": {
@@ -5110,14 +5110,14 @@
     },
     "erdos-221": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:01:04Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:34Z",
       "result": "clean"
     },
     "erdos-222": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:01:04Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:34Z",
       "result": "clean"
     },
     "erdos-223": {
@@ -5158,8 +5158,8 @@
     },
     "erdos-229": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:01:03Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:34Z",
       "result": "clean"
     },
     "erdos-23": {
@@ -5213,8 +5213,8 @@
     },
     "erdos-237": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:00:45Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:34Z",
       "result": "clean"
     },
     "erdos-238": {
@@ -5225,8 +5225,8 @@
     },
     "erdos-239": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:00:46Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:34Z",
       "result": "clean"
     },
     "erdos-24": {
@@ -5284,9 +5284,9 @@
       "result": "clean"
     },
     "erdos-247-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T15:40:52Z",
+      "lastAudited": "2026-04-22T21:59:00Z",
       "result": "clean"
     },
     "erdos-248": {
@@ -5375,8 +5375,8 @@
     },
     "erdos-26": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:00:45Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:34Z",
       "result": "clean"
     },
     "erdos-260": {
@@ -5411,8 +5411,8 @@
     },
     "erdos-265": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:00:45Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:34Z",
       "result": "clean"
     },
     "erdos-266": {
@@ -5459,8 +5459,8 @@
     },
     "erdos-272": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:00:44Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:34Z",
       "result": "clean"
     },
     "erdos-273": {
@@ -5512,8 +5512,8 @@
       "result": "clean"
     },
     "erdos-28-additive-bases": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:36:18Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-22T21:58:44Z",
       "result": "clean"
     },
     "erdos-280": {
@@ -5542,8 +5542,8 @@
     },
     "erdos-284": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:00:32Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:34Z",
       "result": "clean"
     },
     "erdos-285": {
@@ -5554,14 +5554,14 @@
     },
     "erdos-286": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:00:32Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:34Z",
       "result": "clean"
     },
     "erdos-287": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:00:19Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:34Z",
       "result": "clean"
     },
     "erdos-288": {
@@ -5594,8 +5594,8 @@
     },
     "erdos-290": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:00:19Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:34Z",
       "result": "clean"
     },
     "erdos-291": {
@@ -5630,8 +5630,8 @@
     },
     "erdos-296": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:00:19Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:34Z",
       "result": "clean"
     },
     "erdos-297": {
@@ -5703,8 +5703,8 @@
     },
     "erdos-306": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:00:18Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:34Z",
       "result": "clean"
     },
     "erdos-307": {
@@ -5727,8 +5727,8 @@
     },
     "erdos-309": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:00:18Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:34Z",
       "result": "clean"
     },
     "erdos-31": {
@@ -5739,8 +5739,8 @@
     },
     "erdos-310": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T16:00:18Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:34Z",
       "result": "clean"
     },
     "erdos-311": {
@@ -5763,8 +5763,8 @@
     },
     "erdos-314": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:59:56Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:34Z",
       "result": "clean"
     },
     "erdos-315": {
@@ -5865,8 +5865,8 @@
     },
     "erdos-328": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:59:55Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:34Z",
       "result": "clean"
     },
     "erdos-329": {
@@ -5876,21 +5876,21 @@
       "result": "issues-fixed"
     },
     "erdos-33": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-21T15:59:42Z",
+      "lastAudited": "2026-04-22T22:00:34Z",
       "result": "clean"
     },
     "erdos-330": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:59:55Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:34Z",
       "result": "clean"
     },
     "erdos-331": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:59:55Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:34Z",
       "result": "clean"
     },
     "erdos-332": {
@@ -5919,8 +5919,8 @@
     },
     "erdos-336": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:59:41Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:21Z",
       "result": "clean"
     },
     "erdos-337": {
@@ -6118,8 +6118,8 @@
     },
     "erdos-365": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:59:41Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:21Z",
       "result": "clean"
     },
     "erdos-366": {
@@ -6208,8 +6208,8 @@
     },
     "erdos-379": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:59:41Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:21Z",
       "result": "clean"
     },
     "erdos-38": {
@@ -6292,8 +6292,8 @@
     },
     "erdos-391": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:59:28Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:21Z",
       "result": "clean"
     },
     "erdos-392": {
@@ -6306,8 +6306,8 @@
     },
     "erdos-393": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:59:28Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:21Z",
       "result": "clean"
     },
     "erdos-394": {
@@ -6330,8 +6330,8 @@
     },
     "erdos-396": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:59:28Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:21Z",
       "result": "clean"
     },
     "erdos-397": {
@@ -6530,8 +6530,8 @@
     },
     "erdos-425": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:59:05Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:21Z",
       "result": "clean"
     },
     "erdos-426": {
@@ -6572,8 +6572,8 @@
     },
     "erdos-431": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:59:04Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:21Z",
       "result": "clean"
     },
     "erdos-432": {
@@ -6596,8 +6596,8 @@
     },
     "erdos-435": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:59:04Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:21Z",
       "result": "clean"
     },
     "erdos-436": {
@@ -6656,8 +6656,8 @@
     },
     "erdos-444": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:58:51Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:21Z",
       "result": "clean"
     },
     "erdos-445": {
@@ -6860,8 +6860,8 @@
     },
     "erdos-474": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:58:50Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:21Z",
       "result": "clean"
     },
     "erdos-475": {
@@ -6872,9 +6872,9 @@
     },
     "erdos-476": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:58:12Z",
-      "result": "fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:21Z",
+      "result": "clean"
     },
     "erdos-476-oq-05": {
       "auditCount": 4,
@@ -6900,14 +6900,14 @@
     },
     "erdos-479": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:56:32Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:21Z",
       "result": "clean"
     },
     "erdos-48": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:56:32Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:21Z",
       "result": "clean"
     },
     "erdos-480": {
@@ -6924,8 +6924,8 @@
     },
     "erdos-482": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:56:32Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:21Z",
       "result": "clean"
     },
     "erdos-483": {
@@ -6990,8 +6990,8 @@
     },
     "erdos-490": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T15:56:31Z",
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:00:21Z",
       "result": "clean"
     },
     "erdos-490-oq-01": {
@@ -7026,8 +7026,8 @@
     },
     "erdos-495": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:56:16Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:21Z",
       "result": "clean"
     },
     "erdos-496": {
@@ -7061,8 +7061,8 @@
       "result": "clean"
     },
     "erdos-5-prime-gaps": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:33:59Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-22T21:58:44Z",
       "result": "clean"
     },
     "erdos-50": {
@@ -7085,8 +7085,8 @@
     },
     "erdos-502": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:56:16Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:21Z",
       "result": "clean"
     },
     "erdos-503": {
@@ -7127,8 +7127,8 @@
     },
     "erdos-509": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:56:15Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:21Z",
       "result": "clean"
     },
     "erdos-51": {
@@ -7151,8 +7151,8 @@
     },
     "erdos-512": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:56:15Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:21Z",
       "result": "clean"
     },
     "erdos-513": {
@@ -7211,8 +7211,8 @@
     },
     "erdos-521": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:56:02Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:21Z",
       "result": "clean"
     },
     "erdos-522": {
@@ -7235,8 +7235,8 @@
     },
     "erdos-525": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:56:02Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:21Z",
       "result": "clean"
     },
     "erdos-525-oq-02": {
@@ -7349,8 +7349,8 @@
     },
     "erdos-541": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:55:44Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:21Z",
       "result": "clean"
     },
     "erdos-542": {
@@ -7487,8 +7487,8 @@
     },
     "erdos-562": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:55:44Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:21Z",
       "result": "clean"
     },
     "erdos-563": {
@@ -7499,8 +7499,8 @@
     },
     "erdos-564": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:55:44Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:21Z",
       "result": "clean"
     },
     "erdos-565": {
@@ -7529,8 +7529,8 @@
     },
     "erdos-569": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:55:43Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:07Z",
       "result": "clean"
     },
     "erdos-57": {
@@ -7547,8 +7547,8 @@
     },
     "erdos-571": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:55:43Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:07Z",
       "result": "clean"
     },
     "erdos-572": {
@@ -7607,8 +7607,8 @@
     },
     "erdos-580": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:55:27Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:07Z",
       "result": "clean"
     },
     "erdos-581": {
@@ -7619,14 +7619,14 @@
     },
     "erdos-582": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:55:27Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:07Z",
       "result": "clean"
     },
     "erdos-583": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:55:27Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:07Z",
       "result": "clean"
     },
     "erdos-584": {
@@ -7861,8 +7861,8 @@
     },
     "erdos-616": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:54:53Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:07Z",
       "result": "clean"
     },
     "erdos-617": {
@@ -7873,14 +7873,14 @@
     },
     "erdos-618": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:54:52Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:07Z",
       "result": "clean"
     },
     "erdos-619": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:54:52Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:07Z",
       "result": "clean"
     },
     "erdos-62": {
@@ -8001,8 +8001,8 @@
     },
     "erdos-636": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:54:52Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:07Z",
       "result": "clean"
     },
     "erdos-637": {
@@ -8019,8 +8019,8 @@
     },
     "erdos-639": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:54:52Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:07Z",
       "result": "clean"
     },
     "erdos-64": {
@@ -8043,8 +8043,8 @@
     },
     "erdos-642": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:54:52Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:07Z",
       "result": "clean"
     },
     "erdos-643": {
@@ -8064,8 +8064,8 @@
     },
     "erdos-645": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:54:38Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:07Z",
       "result": "clean"
     },
     "erdos-646": {
@@ -8124,8 +8124,8 @@
     },
     "erdos-653": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:54:37Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:07Z",
       "result": "clean"
     },
     "erdos-654": {
@@ -8161,14 +8161,14 @@
     },
     "erdos-659": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:54:37Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:07Z",
       "result": "clean"
     },
     "erdos-659-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T15:41:21Z",
+      "lastAudited": "2026-04-22T21:59:00Z",
       "result": "clean"
     },
     "erdos-66": {
@@ -8209,14 +8209,14 @@
     },
     "erdos-665": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:54:37Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:07Z",
       "result": "clean"
     },
     "erdos-666": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T15:54:37Z",
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:00:07Z",
       "result": "clean"
     },
     "erdos-667": {
@@ -8233,8 +8233,8 @@
     },
     "erdos-669": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:54:37Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:07Z",
       "result": "clean"
     },
     "erdos-67": {
@@ -8282,8 +8282,8 @@
     },
     "erdos-676": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:54:19Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:07Z",
       "result": "clean"
     },
     "erdos-677": {
@@ -8294,9 +8294,9 @@
     },
     "erdos-678": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 6,
-      "lastAudited": "2026-04-21T12:07:57Z",
-      "result": "issues-fixed"
+      "auditCount": 7,
+      "lastAudited": "2026-04-22T21:58:06Z",
+      "result": "clean"
     },
     "erdos-679": {
       "auditCount": 4,
@@ -8391,8 +8391,8 @@
     },
     "erdos-692": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:54:19Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:07Z",
       "result": "clean"
     },
     "erdos-693": {
@@ -8422,14 +8422,14 @@
     },
     "erdos-697": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:54:19Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:07Z",
       "result": "clean"
     },
     "erdos-698": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:54:19Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:07Z",
       "result": "clean"
     },
     "erdos-699": {
@@ -8518,20 +8518,20 @@
     },
     "erdos-71": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:54:02Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:07Z",
       "result": "clean"
     },
     "erdos-710": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:54:02Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:07Z",
       "result": "clean"
     },
     "erdos-711": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:54:01Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:55Z",
       "result": "clean"
     },
     "erdos-712": {
@@ -8542,14 +8542,14 @@
     },
     "erdos-713": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:54:01Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:55Z",
       "result": "clean"
     },
     "erdos-714": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:54:01Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:55Z",
       "result": "clean"
     },
     "erdos-715": {
@@ -8586,14 +8586,14 @@
     },
     "erdos-72": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:54:01Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:07Z",
       "result": "clean"
     },
     "erdos-720": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:54:01Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:00:07Z",
       "result": "clean"
     },
     "erdos-721": {
@@ -8658,14 +8658,14 @@
     },
     "erdos-73": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T10:41:07Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T21:57:19Z",
+      "result": "clean"
     },
     "erdos-730": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:53:42Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:55Z",
       "result": "clean"
     },
     "erdos-731": {
@@ -8688,14 +8688,14 @@
     },
     "erdos-734": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:53:41Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:55Z",
       "result": "clean"
     },
     "erdos-735": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:53:42Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:55Z",
       "result": "clean"
     },
     "erdos-736": {
@@ -8718,8 +8718,8 @@
     },
     "erdos-739": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:53:27Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:55Z",
       "result": "clean"
     },
     "erdos-74": {
@@ -8736,26 +8736,26 @@
     },
     "erdos-741": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:53:27Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:55Z",
       "result": "clean"
     },
     "erdos-742": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:53:27Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:55Z",
       "result": "clean"
     },
     "erdos-743": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:53:27Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:55Z",
       "result": "clean"
     },
     "erdos-744": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:53:27Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:55Z",
       "result": "clean"
     },
     "erdos-745": {
@@ -8830,8 +8830,8 @@
     },
     "erdos-755": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T15:53:26Z",
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T21:59:55Z",
       "result": "clean"
     },
     "erdos-756": {
@@ -8866,8 +8866,8 @@
     },
     "erdos-760": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:53:12Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:55Z",
       "result": "clean"
     },
     "erdos-761": {
@@ -8890,14 +8890,14 @@
     },
     "erdos-764": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:53:12Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:55Z",
       "result": "clean"
     },
     "erdos-765": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:53:11Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:55Z",
       "result": "clean"
     },
     "erdos-766": {
@@ -8908,8 +8908,8 @@
     },
     "erdos-767": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:53:11Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:55Z",
       "result": "clean"
     },
     "erdos-768": {
@@ -8938,20 +8938,20 @@
     },
     "erdos-771": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:53:11Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:55Z",
       "result": "clean"
     },
     "erdos-772": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:53:11Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:55Z",
       "result": "clean"
     },
     "erdos-773": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:53:11Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:55Z",
       "result": "clean"
     },
     "erdos-774": {
@@ -8975,14 +8975,14 @@
     },
     "erdos-777": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:52:57Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:55Z",
       "result": "clean"
     },
     "erdos-778": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:52:57Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:55Z",
       "result": "clean"
     },
     "erdos-779": {
@@ -9023,8 +9023,8 @@
     },
     "erdos-784": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:52:56Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:55Z",
       "result": "clean"
     },
     "erdos-785": {
@@ -9047,14 +9047,14 @@
     },
     "erdos-788": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:52:56Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:55Z",
       "result": "clean"
     },
     "erdos-789": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:52:42Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:55Z",
       "result": "clean"
     },
     "erdos-79": {
@@ -9065,8 +9065,8 @@
     },
     "erdos-790": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:52:41Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:41Z",
       "result": "clean"
     },
     "erdos-791": {
@@ -9101,8 +9101,8 @@
     },
     "erdos-796": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:52:41Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:41Z",
       "result": "clean"
     },
     "erdos-797": {
@@ -9149,8 +9149,8 @@
     },
     "erdos-802": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:52:41Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:55Z",
       "result": "clean"
     },
     "erdos-803": {
@@ -9185,8 +9185,8 @@
     },
     "erdos-808": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:52:24Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:41Z",
       "result": "clean"
     },
     "erdos-809": {
@@ -9209,14 +9209,14 @@
     },
     "erdos-811": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:52:23Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:41Z",
       "result": "clean"
     },
     "erdos-812": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:52:23Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:41Z",
       "result": "clean"
     },
     "erdos-813": {
@@ -9233,14 +9233,14 @@
     },
     "erdos-815": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:52:21Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:41Z",
       "result": "clean"
     },
     "erdos-816": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:52:20Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:41Z",
       "result": "clean"
     },
     "erdos-817": {
@@ -9257,14 +9257,14 @@
     },
     "erdos-819": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:52:19Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:41Z",
       "result": "clean"
     },
     "erdos-82": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:51:41Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:41Z",
       "result": "clean"
     },
     "erdos-820": {
@@ -9275,8 +9275,8 @@
     },
     "erdos-821": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:51:41Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:41Z",
       "result": "clean"
     },
     "erdos-822": {
@@ -9287,8 +9287,8 @@
     },
     "erdos-823": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:51:40Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:41Z",
       "result": "clean"
     },
     "erdos-824": {
@@ -9323,8 +9323,8 @@
     },
     "erdos-829": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:51:38Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:41Z",
       "result": "clean"
     },
     "erdos-83": {
@@ -9365,8 +9365,8 @@
     },
     "erdos-835": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:51:37Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:41Z",
       "result": "clean"
     },
     "erdos-836": {
@@ -9414,8 +9414,8 @@
     },
     "erdos-841": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:51:09Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:41Z",
       "result": "clean"
     },
     "erdos-842": {
@@ -9426,8 +9426,8 @@
     },
     "erdos-843": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:51:09Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:41Z",
       "result": "clean"
     },
     "erdos-844": {
@@ -9450,8 +9450,8 @@
     },
     "erdos-847": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:51:08Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:41Z",
       "result": "clean"
     },
     "erdos-848": {
@@ -9510,8 +9510,8 @@
     },
     "erdos-855": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:51:08Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:41Z",
       "result": "clean"
     },
     "erdos-856": {
@@ -9594,38 +9594,38 @@
     },
     "erdos-868": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:50:52Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:41Z",
       "result": "clean"
     },
     "erdos-869": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:48:53Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:41Z",
       "result": "clean"
     },
     "erdos-87": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:50:52Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:41Z",
       "result": "clean"
     },
     "erdos-870": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:48:25Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:27Z",
       "result": "clean"
     },
     "erdos-871": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:48:53Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:41Z",
       "result": "clean"
     },
     "erdos-872": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:48:52Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:27Z",
       "result": "clean"
     },
     "erdos-873": {
@@ -9642,8 +9642,8 @@
     },
     "erdos-875": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:48:52Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:41Z",
       "result": "clean"
     },
     "erdos-876": {
@@ -9672,8 +9672,8 @@
     },
     "erdos-88": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:48:52Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:41Z",
       "result": "clean"
     },
     "erdos-880": {
@@ -9702,8 +9702,8 @@
     },
     "erdos-884": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T15:48:52Z",
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T21:59:41Z",
       "result": "clean"
     },
     "erdos-885": {
@@ -9714,8 +9714,8 @@
     },
     "erdos-886": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:50:51Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:41Z",
       "result": "clean"
     },
     "erdos-887": {
@@ -9804,8 +9804,8 @@
     },
     "erdos-9": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:48:51Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:27Z",
       "result": "clean"
     },
     "erdos-90": {
@@ -9834,20 +9834,20 @@
     },
     "erdos-903": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:48:01Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:27Z",
       "result": "clean"
     },
     "erdos-904": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:48:01Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:27Z",
       "result": "clean"
     },
     "erdos-905": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:48:01Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:27Z",
       "result": "clean"
     },
     "erdos-906": {
@@ -9900,8 +9900,8 @@
     },
     "erdos-912": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:48:00Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:27Z",
       "result": "clean"
     },
     "erdos-913": {
@@ -9930,14 +9930,14 @@
     },
     "erdos-917": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:48:00Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:27Z",
       "result": "clean"
     },
     "erdos-918": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:48:00Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:27Z",
       "result": "clean"
     },
     "erdos-919": {
@@ -9948,8 +9948,8 @@
     },
     "erdos-92": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:48:00Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:27Z",
       "result": "clean"
     },
     "erdos-920": {
@@ -9960,14 +9960,14 @@
     },
     "erdos-921": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:47:14Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:27Z",
       "result": "clean"
     },
     "erdos-922": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:47:13Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:27Z",
       "result": "clean"
     },
     "erdos-923": {
@@ -9984,8 +9984,8 @@
     },
     "erdos-925": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:47:13Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:27Z",
       "result": "clean"
     },
     "erdos-926": {
@@ -9996,8 +9996,8 @@
     },
     "erdos-927": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:47:12Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:27Z",
       "result": "clean"
     },
     "erdos-928": {
@@ -10020,8 +10020,8 @@
     },
     "erdos-930": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:47:12Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:27Z",
       "result": "clean"
     },
     "erdos-931": {
@@ -10038,14 +10038,14 @@
     },
     "erdos-933": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T15:47:12Z",
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T21:59:27Z",
       "result": "clean"
     },
     "erdos-934": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:46:29Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:27Z",
       "result": "clean"
     },
     "erdos-935": {
@@ -10074,8 +10074,8 @@
     },
     "erdos-939": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:46:29Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:27Z",
       "result": "clean"
     },
     "erdos-94": {
@@ -10085,9 +10085,9 @@
       "result": "clean"
     },
     "erdos-94-oq-02": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-21T15:46:29Z",
+      "lastAudited": "2026-04-22T21:59:27Z",
       "result": "clean"
     },
     "erdos-940": {
@@ -10134,8 +10134,8 @@
     },
     "erdos-947": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:46:29Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:27Z",
       "result": "clean"
     },
     "erdos-948": {
@@ -10158,8 +10158,8 @@
     },
     "erdos-950": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:46:06Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:27Z",
       "result": "clean"
     },
     "erdos-951": {
@@ -10194,8 +10194,8 @@
     },
     "erdos-956": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:46:06Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:27Z",
       "result": "clean"
     },
     "erdos-957": {
@@ -10248,8 +10248,8 @@
     },
     "erdos-964": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:46:06Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:27Z",
       "result": "clean"
     },
     "erdos-965": {
@@ -10260,8 +10260,8 @@
     },
     "erdos-966": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:46:05Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:27Z",
       "result": "clean"
     },
     "erdos-967": {
@@ -10272,14 +10272,14 @@
     },
     "erdos-968": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:46:05Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:27Z",
       "result": "clean"
     },
     "erdos-969": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:46:04Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:14Z",
       "result": "clean"
     },
     "erdos-97": {
@@ -10290,8 +10290,8 @@
     },
     "erdos-970": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:46:04Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:14Z",
       "result": "clean"
     },
     "erdos-971": {
@@ -10339,8 +10339,8 @@
     },
     "erdos-978": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:42:49Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:14Z",
       "result": "clean"
     },
     "erdos-979": {
@@ -10363,14 +10363,14 @@
     },
     "erdos-981": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:42:49Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:14Z",
       "result": "clean"
     },
     "erdos-982": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:42:49Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:14Z",
       "result": "clean"
     },
     "erdos-983": {
@@ -10387,8 +10387,8 @@
     },
     "erdos-985": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:42:49Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:14Z",
       "result": "clean"
     },
     "erdos-986": {
@@ -10411,14 +10411,14 @@
     },
     "erdos-989": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:42:49Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:14Z",
       "result": "clean"
     },
     "erdos-99": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:42:49Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:14Z",
       "result": "clean"
     },
     "erdos-990": {
@@ -10429,26 +10429,26 @@
     },
     "erdos-991": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:42:26Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:14Z",
       "result": "clean"
     },
     "erdos-992": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:42:27Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:14Z",
       "result": "clean"
     },
     "erdos-993": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:42:26Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:14Z",
       "result": "clean"
     },
     "erdos-994": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:42:26Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:14Z",
       "result": "clean"
     },
     "erdos-995": {
@@ -10459,8 +10459,8 @@
     },
     "erdos-996": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:42:26Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:14Z",
       "result": "clean"
     },
     "erdos-997": {
@@ -10482,8 +10482,8 @@
       "result": "clean"
     },
     "erdos-ko-rado": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:33:47Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-22T21:58:44Z",
       "result": "clean"
     },
     "erdos-szekeres": {
@@ -10752,9 +10752,9 @@
       "result": "clean"
     },
     "fourier-series-oq-02-oq-01": {
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-04-21T13:16:35Z",
+      "lastAudited": "2026-04-22T21:58:06Z",
       "result": "clean"
     },
     "fourier-series-oq-02-oq-03": {
@@ -10878,10 +10878,10 @@
       "result": "clean"
     },
     "gcd-algorithm-oq-01-oq-03": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T15:41:21Z",
-      "result": "clean"
+      "lastAudited": "2026-04-22T21:59:00Z",
+      "result": "no-meta"
     },
     "gcd-algorithm-oq-02": {
       "auditCount": 3,
@@ -10890,9 +10890,9 @@
       "result": "clean"
     },
     "gcd-algorithm-oq-04": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-21T13:58:19Z",
+      "lastAudited": "2026-04-22T21:58:06Z",
       "result": "clean"
     },
     "gelfond-schneider": {
@@ -10944,9 +10944,9 @@
       "result": "clean"
     },
     "godel-first-incompleteness-oq01": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-04-21T13:17:20Z",
+      "lastAudited": "2026-04-22T21:58:06Z",
       "result": "clean"
     },
     "godel-incompleteness": {
@@ -10956,10 +10956,10 @@
       "result": "clean"
     },
     "godel-second-incompleteness-oq02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-21T13:19:31Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T21:58:26Z",
+      "result": "clean"
     },
     "greens-theorem": {
       "agentId": "auditor-cycle-20-batch",
@@ -11274,9 +11274,9 @@
       "result": "clean"
     },
     "inclusion-exclusion-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T15:39:44Z",
+      "lastAudited": "2026-04-22T21:59:00Z",
       "result": "clean"
     },
     "infinitude-primes": {
@@ -11286,15 +11286,15 @@
       "result": "clean"
     },
     "infinitude-primes-4k1": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T15:39:44Z",
+      "lastAudited": "2026-04-22T21:59:00Z",
       "result": "clean"
     },
     "infinitude-primes-4k3": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T15:39:44Z",
+      "lastAudited": "2026-04-22T21:59:00Z",
       "result": "clean"
     },
     "infinitude-primes-oq-03": {
@@ -11316,9 +11316,9 @@
       "result": "clean"
     },
     "intermediate-value-theorem-oq-02": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T15:39:43Z",
+      "lastAudited": "2026-04-22T21:59:00Z",
       "result": "clean"
     },
     "intermediate-value-theorem-oq-03": {
@@ -11374,9 +11374,9 @@
       "result": "clean"
     },
     "isosceles-triangle-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T15:41:21Z",
+      "lastAudited": "2026-04-22T21:59:14Z",
       "result": "clean"
     },
     "kepler-conjecture": {
@@ -11404,8 +11404,8 @@
       "result": "clean"
     },
     "konigsberg-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:33:33Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-22T21:58:44Z",
       "result": "clean"
     },
     "konigsberg-oq-02": {
@@ -11481,8 +11481,8 @@
       "result": "clean"
     },
     "lagrange-four-squares-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:33:25Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-22T21:58:44Z",
       "result": "clean"
     },
     "lagrange-four-squares-oq-04": {
@@ -11534,9 +11534,9 @@
       "result": "clean"
     },
     "law-of-cosines-oq-01-oq-05": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-04-21T13:19:56Z",
+      "lastAudited": "2026-04-22T21:58:06Z",
       "result": "clean"
     },
     "law-of-cosines-oq-03": {
@@ -11556,12 +11556,12 @@
       "result": "clean"
     },
     "law-of-cosines-oq-06": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [
         "gallery entry renamed law-of-cosines-oq-06\u2192law-of-sines-oq-06; content was Law of Sines not Law of Cosines (fixed by PRs #10749, #10757)"
       ],
-      "lastAudited": "2026-04-21T00:00:00Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T21:58:44Z",
+      "result": "no-meta"
     },
     "law-of-sines-oq-06": {
       "auditCount": 3,
@@ -11684,9 +11684,9 @@
       "result": "clean"
     },
     "lhopital-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-21T15:34:45Z",
+      "lastAudited": "2026-04-22T21:58:44Z",
       "result": "clean"
     },
     "lhopital-oq-02": {
@@ -11697,8 +11697,8 @@
     },
     "liouville-theorem": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T15:42:26Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:59:14Z",
       "result": "clean"
     },
     "lovasz-local-lemma": {
@@ -11762,9 +11762,9 @@
       "result": "clean"
     },
     "minkowski-theorem-oq-02": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T15:41:21Z",
+      "lastAudited": "2026-04-22T21:59:14Z",
       "result": "clean"
     },
     "morleys-theorem": {
@@ -12451,9 +12451,9 @@
       "result": "clean"
     },
     "sperner-ndim-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T15:41:21Z",
+      "lastAudited": "2026-04-22T21:59:14Z",
       "result": "clean"
     },
     "sperner-ndim-oq-03": {
@@ -12523,9 +12523,9 @@
       "result": "issues-found"
     },
     "sqrt2-plus-sqrt3-irrational": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T15:40:52Z",
+      "lastAudited": "2026-04-22T21:59:00Z",
       "result": "clean"
     },
     "sqrt2-plus-sqrt3-irrational-oq-03": {
@@ -12688,9 +12688,9 @@
       "result": "clean"
     },
     "szemeredi-hypergraph-core-oq-01-incomplete-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-21T15:31:06Z",
+      "lastAudited": "2026-04-22T21:58:44Z",
       "result": "clean"
     },
     "szemeredi-regularity": {
@@ -12838,8 +12838,8 @@
       "result": "clean"
     },
     "unit-distance-independence": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:33:12Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-22T21:58:44Z",
       "result": "clean"
     },
     "vietas-formulas": {
@@ -12884,13 +12884,13 @@
       "result": "clean"
     },
     "wilsons-theorem-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:32:51Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-22T21:58:44Z",
       "result": "clean"
     },
     "wilsons-theorem-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T15:36:00Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-22T21:58:44Z",
       "result": "clean"
     },
     "wilsons-theorem-oq-03": {
@@ -12969,9 +12969,9 @@
       "result": "clean"
     },
     "yang-mills-lattice-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T12:01:35Z",
+      "lastAudited": "2026-04-22T21:58:06Z",
       "result": "clean"
     },
     "yang-mills-transfer-matrix": {

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -142,12 +142,12 @@
       "result": "clean"
     },
     "angle-trisection-oq-02-oq-04-oq-01": {
-      "auditCount": 5,
+      "auditCount": 4,
       "issues": [
         "sorry 7\u21923"
       ],
-      "lastAudited": "2026-04-22T21:47:35Z",
-      "result": "clean"
+      "lastAudited": "2026-04-13T03:29:17Z",
+      "result": "issues-fixed"
     },
     "angle-trisection-oq-03": {
       "auditCount": 3,
@@ -309,10 +309,10 @@
       "result": "clean"
     },
     "ballot-problem-oq-01-oq-02": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-14T18:30:04Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T21:53:12Z",
+      "result": "clean"
     },
     "ballot-problem-oq-01-oq-04": {
       "auditCount": 3,
@@ -549,15 +549,15 @@
       "issues": []
     },
     "binomial-theorem-oq-04-oq-03": {
-      "auditCount": 4,
+      "auditCount": 3,
       "issues": [
         "sorry 6\u21920",
         "axiomCount 1\u21920",
         "status axiomatized\u2192verified",
         "badge axiom\u2192original"
       ],
-      "lastAudited": "2026-04-22T21:49:45Z",
-      "result": "clean"
+      "lastAudited": "2026-04-13T03:29:17Z",
+      "result": "issues-fixed"
     },
     "birch-swinnerton-dyer": {
       "auditCount": 6,
@@ -799,13 +799,13 @@
       "result": "clean"
     },
     "cantor-diagonalization-oq-01-oq-01-oq-02": {
-      "auditCount": 4,
+      "auditCount": 3,
       "issues": [
         "sorry 1\u21920",
         "status formalized\u2192verified"
       ],
-      "lastAudited": "2026-04-22T21:49:46Z",
-      "result": "clean"
+      "lastAudited": "2026-04-13T03:29:17Z",
+      "result": "issues-fixed"
     },
     "cantor-diagonalization-oq-02": {
       "auditCount": 7,
@@ -1937,9 +1937,9 @@
       "result": "clean"
     },
     "erdos-1018-oq-04": {
-      "auditCount": 3,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-22T21:45:26Z",
+      "lastAudited": "2026-04-13T01:24:21Z",
       "result": "clean"
     },
     "erdos-1019": {
@@ -1997,9 +1997,9 @@
       "result": "clean"
     },
     "erdos-1026": {
-      "auditCount": 5,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-22T21:47:32Z",
+      "lastAudited": "2026-04-13T03:03:24Z",
       "result": "clean"
     },
     "erdos-1027": {
@@ -2237,9 +2237,9 @@
       "result": "issues-fixed"
     },
     "erdos-1059-oq-03": {
-      "auditCount": 3,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-22T21:45:26Z",
+      "lastAudited": "2026-04-13T01:24:09Z",
       "result": "clean"
     },
     "erdos-1059-oq-05": {
@@ -3053,9 +3053,9 @@
       "result": "clean"
     },
     "erdos-1168": {
-      "auditCount": 4,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-22T21:47:32Z",
+      "lastAudited": "2026-04-13T03:03:24Z",
       "result": "clean"
     },
     "erdos-1169": {
@@ -3071,10 +3071,10 @@
       "result": "clean"
     },
     "erdos-117-oq-01": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-14T22:22:03Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T21:53:13Z",
+      "result": "clean"
     },
     "erdos-1170": {
       "agentId": "auditor-cycle-20-batch",
@@ -3817,9 +3817,9 @@
     },
     "erdos-211": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-22T21:49:48Z",
-      "result": "clean"
+      "auditCount": 3,
+      "lastAudited": "2026-04-13T16:07:24Z",
+      "result": "issues-fixed"
     },
     "erdos-212": {
       "agentId": "auditor-cycle-20-batch",
@@ -4191,8 +4191,8 @@
     },
     "erdos-268": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 5,
-      "lastAudited": "2026-04-22T21:42:49Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T10:13:48Z",
       "result": "issues-fixed"
     },
     "erdos-269": {
@@ -4795,8 +4795,8 @@
     },
     "erdos-353": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 5,
-      "lastAudited": "2026-04-22T21:47:32Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-13T03:03:24Z",
       "result": "clean",
       "issues": []
     },
@@ -4940,9 +4940,9 @@
     },
     "erdos-375": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-14T00:49:34Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T21:53:12Z",
+      "result": "clean"
     },
     "erdos-376": {
       "agentId": "auditor-cycle-20-batch",
@@ -5175,12 +5175,12 @@
       "result": "clean"
     },
     "erdos-409": {
-      "auditCount": 5,
+      "auditCount": 4,
       "issues": [
         "status axiomatized\u2192verified, badge wip\u2192original (0 sorries, 0 axioms confirmed)"
       ],
-      "lastAudited": "2026-04-22T21:47:33Z",
-      "result": "clean"
+      "lastAudited": "2026-04-13T03:03:24Z",
+      "result": "issues-fixed"
     },
     "erdos-41": {
       "agentId": "auditor-cycle-20-batch",
@@ -6532,12 +6532,12 @@
       "result": "clean"
     },
     "erdos-606-oq-03": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [
         "badge axiom\u2192wip (axiomCount=0, no actual axiom declarations; consistent with open-problem survey classification)"
       ],
-      "lastAudited": "2026-04-21T00:00:00Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T21:53:13Z",
+      "result": "clean"
     },
     "erdos-607": {
       "agentId": "auditor-cycle-20-batch",
@@ -6789,9 +6789,9 @@
     },
     "erdos-644": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-22T21:49:47Z",
-      "result": "clean",
+      "auditCount": 3,
+      "lastAudited": "2026-04-13T03:29:17Z",
+      "result": "issues-fixed",
       "issues": [
         "sorry 18\u219216"
       ]
@@ -7058,8 +7058,8 @@
     },
     "erdos-684": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-22T21:47:33Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-13T03:03:24Z",
       "result": "clean",
       "issues": []
     },
@@ -7131,8 +7131,8 @@
     },
     "erdos-695": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-22T21:47:33Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-13T03:03:24Z",
       "result": "clean",
       "issues": []
     },
@@ -7690,8 +7690,8 @@
     },
     "erdos-776": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-22T21:47:33Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-13T03:03:24Z",
       "result": "clean",
       "issues": []
     },
@@ -8238,9 +8238,9 @@
     },
     "erdos-858": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-22T21:49:48Z",
-      "result": "clean"
+      "auditCount": 3,
+      "lastAudited": "2026-04-13T16:07:23Z",
+      "result": "issues-fixed"
     },
     "erdos-859": {
       "agentId": "auditor-cycle-20-batch",
@@ -9275,9 +9275,9 @@
       "result": "clean"
     },
     "factor-remainder-nullstellensatz-oq-01": {
-      "auditCount": 3,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-22T21:44:02Z",
+      "lastAudited": "2026-04-13T00:22:26Z",
       "result": "clean"
     },
     "factor-remainder-theorem": {
@@ -9323,9 +9323,9 @@
       "result": "clean"
     },
     "fermats-last-theorem-oq-03": {
-      "auditCount": 3,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-22T21:44:02Z",
+      "lastAudited": "2026-04-13T00:22:09Z",
       "result": "clean"
     },
     "feuerbachs-theorem": {
@@ -9347,12 +9347,12 @@
       "result": "clean"
     },
     "feuerbachs-theorem-oq-02": {
-      "auditCount": 4,
+      "auditCount": 3,
       "issues": [
         "axiomCount 5\u21923"
       ],
-      "lastAudited": "2026-04-22T21:49:47Z",
-      "result": "clean"
+      "lastAudited": "2026-04-13T03:29:17Z",
+      "result": "issues-fixed"
     },
     "four-color-theorem": {
       "agentId": "auditor-cycle-20-batch",
@@ -9411,9 +9411,9 @@
       "result": "clean"
     },
     "fourier-series-oq-04": {
-      "auditCount": 3,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-22T21:44:02Z",
+      "lastAudited": "2026-04-13T00:21:33Z",
       "result": "clean"
     },
     "friendship-theorem": {
@@ -9423,9 +9423,9 @@
       "result": "clean"
     },
     "friendship-theorem-oq-01": {
-      "auditCount": 3,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-22T21:44:01Z",
+      "lastAudited": "2026-04-13T00:20:53Z",
       "result": "clean"
     },
     "friendship-theorem-oq-03": {
@@ -9441,9 +9441,9 @@
       "result": "clean"
     },
     "fundamental-arithmetic-oq-01": {
-      "auditCount": 3,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-22T21:44:01Z",
+      "lastAudited": "2026-04-13T00:19:13Z",
       "result": "clean"
     },
     "fundamental-arithmetic-oq-02": {
@@ -9735,10 +9735,10 @@
       "result": "clean"
     },
     "hilbert-21": {
-      "auditCount": 8,
+      "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-04-22T21:49:48Z",
-      "result": "clean"
+      "lastAudited": "2026-04-13T06:09:18Z",
+      "result": "issues-fixed"
     },
     "hilbert-22": {
       "agentId": "auditor-cycle-20-batch",
@@ -9849,10 +9849,10 @@
       "agentId": "lean-mechanic"
     },
     "inverse-galois": {
-      "auditCount": 9,
+      "auditCount": 8,
       "issues": [],
-      "lastAudited": "2026-04-22T21:49:49Z",
-      "result": "clean"
+      "lastAudited": "2026-04-13T16:07:25Z",
+      "result": "issues-fixed"
     },
     "inverse-galois-oq-01": {
       "auditCount": 7,
@@ -11413,8 +11413,8 @@
       "issues": []
     },
     "fair-games-theorem-oq-03": {
-      "auditCount": 5,
-      "lastAudited": "2026-04-22T21:47:34Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-13T03:03:24Z",
       "result": "clean",
       "issues": []
     },
@@ -11968,8 +11968,8 @@
       "issues": []
     },
     "shannon-channel-coding-oq-02-oq-01": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T21:47:22Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-13T03:03:24Z",
       "result": "issues-fixed",
       "issues": [
         "sorry mismatch: meta claimed 1, actual 0 (fano_trivial_singleton now proved)"
@@ -12156,9 +12156,9 @@
       "issues": []
     },
     "chebyshev-pnt-bridge": {
-      "auditCount": 4,
-      "lastAudited": "2026-04-22T21:45:26Z",
-      "result": "clean",
+      "auditCount": 3,
+      "lastAudited": "2026-04-13T00:56:13Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "erdos-622-oq-04": {
@@ -12168,10 +12168,10 @@
       "result": "clean"
     },
     "brouwer-fixed-point-oq-04-oq-04": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-14T00:49:35Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T21:53:12Z",
+      "result": "clean"
     },
     "area-of-circle-oq-03-oq-03-oq-02": {
       "auditCount": 2,
@@ -12180,45 +12180,45 @@
       "issues": []
     },
     "randomized-maxcut-oq-04": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T21:47:35Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-13T03:03:24Z",
       "result": "clean",
       "issues": []
     },
     "area-of-circle-oq-01-oq-02-oq-01-oq-03": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:45:26Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T00:50:38Z",
       "result": "clean",
       "issues": []
     },
     "arithmetic-series-oq-00": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:45:26Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T00:50:38Z",
       "result": "clean",
       "issues": []
     },
     "ballot-problem-oq-01-oq-02-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:45:25Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T00:50:38Z",
       "result": "clean",
       "issues": []
     },
     "binary-gcd-oq-03": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:45:25Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T00:50:38Z",
       "result": "clean",
       "issues": []
     },
     "divisibility-rules-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:45:25Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T00:50:38Z",
       "result": "clean",
       "issues": []
     },
     "hilbert-15-oq-02": {
-      "auditCount": 4,
-      "lastAudited": "2026-04-22T21:51:45Z",
-      "result": "clean",
+      "auditCount": 3,
+      "lastAudited": "2026-04-13T21:05:00Z",
+      "result": "issues-fixed",
       "issues": [
         "status verified->formalized (True stub theorems: lr_saturation_theorem, lr_positivity_in_P, lr_counting_sharp_P_complete prove True)",
         "badge verified->wip",
@@ -12226,62 +12226,62 @@
       ]
     },
     "minkowski-fundamental-theorem-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:44:03Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T00:50:38Z",
       "result": "clean",
       "issues": []
     },
     "primitive-roots-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:44:03Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T00:50:38Z",
       "result": "clean",
       "issues": []
     },
     "taylor-theorem-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:44:02Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T00:50:38Z",
       "result": "clean",
       "issues": []
     },
     "vietas-formulas-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:44:02Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T00:50:38Z",
       "result": "clean",
       "issues": []
     },
     "angle-trisection-oq-02-oq-01-oq-02": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T21:47:31Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-13T03:03:24Z",
       "result": "clean",
       "issues": []
     },
     "cantor-diagonalization-oq-04-oq-03": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:45:26Z",
-      "result": "clean",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T01:03:45Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "euler-totient-oq-02-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:45:26Z",
-      "result": "clean",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T01:03:45Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "binomial-theorem-oq-02-oq-01-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:45:26Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T01:03:45Z",
       "result": "clean",
       "issues": []
     },
     "erdos-65-oq-03": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:45:26Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T01:03:45Z",
       "result": "clean",
       "issues": []
     },
     "hilbert-20-oq-01-oq-03": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T21:47:34Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-13T03:03:24Z",
       "result": "clean",
       "issues": []
     },
@@ -12292,44 +12292,44 @@
       "issues": []
     },
     "laws-of-large-numbers-oq-03": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:45:26Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T01:03:45Z",
       "result": "clean",
       "issues": []
     },
     "leibniz-pi-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:45:26Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T01:03:45Z",
       "result": "clean",
       "issues": []
     },
     "erdos-1059-oq-01-oq-01": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T21:47:32Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-13T03:03:24Z",
       "result": "clean",
       "issues": []
     },
     "algebraic-numbers-countable-oq-02-oq-02": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T21:47:31Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-13T03:03:24Z",
       "result": "clean",
       "issues": []
     },
     "kummer-theorem-oq-01-oq-01": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T21:47:34Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-13T03:03:24Z",
       "result": "clean",
       "issues": []
     },
     "subset-count-oq-02-oq-01": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T21:47:35Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-13T03:03:24Z",
       "result": "clean",
       "issues": []
     },
     "derangements-oq-03-oq-01-oq-02": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T21:47:31Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-13T03:03:24Z",
       "result": "clean",
       "issues": []
     },
@@ -12342,9 +12342,9 @@
       ]
     },
     "chebyshev-pnt-bridge-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:49:46Z",
-      "result": "clean",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T03:29:17Z",
+      "result": "issues-fixed",
       "issues": [
         "sorry 4\u21925",
         "status axiomatized\u2192formalized",
@@ -12352,9 +12352,9 @@
       ]
     },
     "divisibility-by-3-oq-03-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:49:47Z",
-      "result": "clean",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T03:29:17Z",
+      "result": "issues-fixed",
       "issues": [
         "sorry 1\u21920",
         "status axiomatized\u2192verified",
@@ -12362,9 +12362,9 @@
       ]
     },
     "lebesgue-measure-oq-03-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:49:47Z",
-      "result": "clean",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T03:29:17Z",
+      "result": "issues-fixed",
       "issues": [
         "sorry 1\u21920",
         "status axiomatized\u2192verified",
@@ -12372,44 +12372,44 @@
       ]
     },
     "area-of-circle-oq-02-oq-04": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:47:22Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T03:29:17Z",
       "result": "clean",
       "issues": []
     },
     "central-limit-theorem-oq-01-oq-02-oq-01-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:49:46Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T03:29:17Z",
       "result": "clean",
       "issues": []
     },
     "sperner-ndim-oq-03-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:49:47Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T03:29:17Z",
       "result": "clean",
       "issues": []
     },
     "area-of-circle-oq-03-oq-02-oq-02-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:49:49Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T16:10:16Z",
       "result": "clean",
       "issues": []
     },
     "arithmetic-series-oq-02-oq-03": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:49:49Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T16:10:16Z",
       "result": "clean",
       "issues": []
     },
     "bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:49:49Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T16:10:16Z",
       "result": "clean",
       "issues": []
     },
     "buffons-needle-oq-01-oq-01-oq-04": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:49:50Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T16:10:16Z",
       "result": "clean",
       "issues": []
     },
@@ -12420,20 +12420,20 @@
       "issues": []
     },
     "chinese-remainder-non-coprime-oq-03-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:49:50Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T16:10:17Z",
       "result": "clean",
       "issues": []
     },
     "combinations-formula-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:49:50Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T16:10:17Z",
       "result": "clean",
       "issues": []
     },
     "denumerability-rationals-oq-02-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:51:43Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T16:10:17Z",
       "result": "clean",
       "issues": []
     },
@@ -12444,74 +12444,74 @@
       "issues": []
     },
     "erdos-1129-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:51:43Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T16:10:17Z",
       "result": "clean",
       "issues": []
     },
     "erdos-327-oq-01-oq-04": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:51:43Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T16:10:17Z",
       "result": "clean",
       "issues": []
     },
     "fair-games-theorem-oq-02-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:51:43Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T16:10:17Z",
       "result": "clean",
       "issues": []
     },
     "partition-theorem-oq-01-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:51:43Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T16:10:17Z",
       "result": "clean",
       "issues": []
     },
     "shannon-channel-coding-oq-02-oq-04": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:51:43Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T16:10:17Z",
       "result": "clean",
       "issues": []
     },
     "sophie-germain-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:51:44Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T16:10:17Z",
       "result": "clean",
       "issues": []
     },
     "amgm-inequality-oq-02-oq-01-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:51:44Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T20:30:52Z",
       "result": "clean",
       "issues": []
     },
     "basel-problem-oq-04": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:51:44Z",
-      "result": "clean",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T20:33:48Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "cauchy-schwarz-oq-01-oq-01-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:51:44Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T20:34:51Z",
       "result": "clean",
       "issues": []
     },
     "cevas-theorem-non-euclidean-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:51:44Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T20:35:23Z",
       "result": "clean",
       "issues": []
     },
     "chinese-remainder-non-coprime-oq-01-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:51:44Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T20:35:43Z",
       "result": "clean",
       "issues": []
     },
     "erdos-1083-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:51:44Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T20:36:17Z",
       "result": "clean",
       "issues": []
     },
@@ -12522,26 +12522,26 @@
       "issues": []
     },
     "erdos-837-oq-05": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:51:44Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T20:37:47Z",
       "result": "clean",
       "issues": []
     },
     "lagrange-four-squares-oq-04": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:51:44Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T20:38:12Z",
       "result": "clean",
       "issues": []
     },
     "taylor-sincos-convergence-oq-04": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:51:44Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T20:38:29Z",
       "result": "clean",
       "issues": []
     },
     "erdos-1027-oq-03": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T21:51:45Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-13T20:42:50Z",
       "result": "clean",
       "issues": []
     },
@@ -12564,8 +12564,8 @@
       "issues": []
     },
     "amgm-inequality-oq-03-oq-03-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-22T21:51:45Z",
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T21:34:28Z",
       "result": "clean",
       "issues": []
     },
@@ -12600,27 +12600,27 @@
       "issues": []
     },
     "tractatus-ontology": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-14T18:01:48Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-22T21:53:12Z",
       "result": "clean",
       "issues": []
     },
     "collatz-cycles-oq-04": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-14T17:56:11Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-22T21:53:12Z",
       "result": "clean",
       "issues": []
     },
     "ptolemys-theorem-oq-01-incomplete-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-14T17:58:19Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-22T21:53:12Z",
       "result": "clean",
       "issues": []
     },
     "law-of-sines-oq-06": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T00:00:00Z",
-      "result": "issues-fixed",
+      "auditCount": 3,
+      "lastAudited": "2026-04-22T21:53:13Z",
+      "result": "clean",
       "issues": [
         "id/slug mismatch: meta.json had id=law-of-cosines-oq-06; fixed by enrichment PR #10757"
       ]
@@ -12634,16 +12634,16 @@
       ]
     },
     "bezout-identity-oq-02-oq-04": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-21T00:00:00Z",
-      "result": "issues-fixed",
+      "auditCount": 3,
+      "lastAudited": "2026-04-22T21:53:13Z",
+      "result": "clean",
       "issues": [
         "badge original\u2192mathlib (core results are Mathlib wrappers; fixed by PR #10846)"
       ]
     },
     "binomial-theorem-oq-02-oq-04": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-14T21:51:41Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-22T21:53:12Z",
       "result": "clean",
       "issues": []
     },
@@ -12654,8 +12654,8 @@
       "issues": []
     },
     "cauchy-schwarz-integral-oq-01-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-14T21:51:41Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-22T21:53:13Z",
       "result": "clean",
       "issues": []
     },
@@ -12666,8 +12666,8 @@
       "issues": []
     },
     "erdos-181-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-14T21:51:41Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-22T21:53:13Z",
       "result": "clean",
       "issues": []
     },

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1927,9 +1927,9 @@
       "result": "clean"
     },
     "chebyshev-pnt-bridge-oq-01-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-21T19:38:08Z",
+      "lastAudited": "2026-04-22T22:01:51Z",
       "result": "clean"
     },
     "chebyshev-pnt-bridge-oq-02": {
@@ -3061,10 +3061,10 @@
       "result": "clean"
     },
     "erdos-1029": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T22:01:22Z",
+      "result": "clean"
     },
     "erdos-103": {
       "auditCount": 5,
@@ -3085,16 +3085,16 @@
       "result": "clean"
     },
     "erdos-1031": {
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T22:01:22Z",
+      "result": "clean"
     },
     "erdos-1032": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T22:01:22Z",
+      "result": "clean"
     },
     "erdos-1033": {
       "auditCount": 5,
@@ -3104,9 +3104,9 @@
     },
     "erdos-1034": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 6,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 7,
+      "lastAudited": "2026-04-22T22:01:22Z",
+      "result": "clean"
     },
     "erdos-1035": {
       "agentId": "auditor-cycle-20-batch",
@@ -3169,10 +3169,10 @@
       "result": "clean"
     },
     "erdos-1044": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T22:01:22Z",
+      "result": "clean"
     },
     "erdos-1045": {
       "auditCount": 4,
@@ -3181,10 +3181,10 @@
       "result": "clean"
     },
     "erdos-1046": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T22:01:22Z",
+      "result": "clean"
     },
     "erdos-1047": {
       "auditCount": 4,
@@ -3271,16 +3271,16 @@
       "result": "clean"
     },
     "erdos-1057": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T22:01:22Z",
+      "result": "clean"
     },
     "erdos-1058": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T22:01:22Z",
+      "result": "clean"
     },
     "erdos-1059": {
       "auditCount": 4,
@@ -3397,10 +3397,10 @@
       "result": "clean"
     },
     "erdos-1067": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T22:01:22Z",
+      "result": "clean"
     },
     "erdos-1068": {
       "auditCount": 4,
@@ -3451,10 +3451,10 @@
       "result": "clean"
     },
     "erdos-1075": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T22:01:22Z",
+      "result": "clean"
     },
     "erdos-1076": {
       "auditCount": 4,
@@ -3470,15 +3470,15 @@
     },
     "erdos-1078": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:01:22Z",
+      "result": "clean"
     },
     "erdos-1079": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:01:22Z",
+      "result": "clean"
     },
     "erdos-108": {
       "agentId": "auditor-cycle-20-batch",
@@ -3500,15 +3500,15 @@
     },
     "erdos-1082": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:22Z",
+      "result": "clean"
     },
     "erdos-1083": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:22Z",
+      "result": "clean"
     },
     "erdos-1083-oq-02": {
       "auditCount": 2,
@@ -3542,21 +3542,21 @@
     },
     "erdos-1087": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 5,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 6,
+      "lastAudited": "2026-04-22T22:01:22Z",
+      "result": "clean"
     },
     "erdos-1088": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:22Z",
+      "result": "clean"
     },
     "erdos-1089": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:22Z",
+      "result": "clean"
     },
     "erdos-109": {
       "agentId": "auditor-cycle-20-batch",
@@ -3614,9 +3614,9 @@
     },
     "erdos-1096": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:22Z",
+      "result": "clean"
     },
     "erdos-1097": {
       "agentId": "auditor-cycle-20-batch",
@@ -3692,21 +3692,21 @@
     },
     "erdos-1102": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:01:22Z",
+      "result": "clean"
     },
     "erdos-1103": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:01:22Z",
+      "result": "clean"
     },
     "erdos-1104": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:01:22Z",
+      "result": "clean"
     },
     "erdos-1105": {
       "agentId": "auditor-cycle-20-batch",
@@ -3727,10 +3727,10 @@
       "result": "clean"
     },
     "erdos-1107-oq-02": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T22:01:22Z",
+      "result": "clean"
     },
     "erdos-1108": {
       "agentId": "auditor-cycle-20-batch",
@@ -3764,9 +3764,9 @@
     },
     "erdos-1112": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:01:22Z",
+      "result": "clean"
     },
     "erdos-1113": {
       "auditCount": 4,
@@ -3776,9 +3776,9 @@
     },
     "erdos-1114": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:01:22Z",
+      "result": "clean"
     },
     "erdos-1115": {
       "agentId": "auditor-cycle-20-batch",
@@ -3823,22 +3823,22 @@
       "result": "clean"
     },
     "erdos-1120": {
-      "auditCount": 3,
-      "issues": [],
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
-    },
-    "erdos-1121": {
-      "auditCount": 3,
-      "issues": [],
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
-    },
-    "erdos-1122": {
       "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T22:01:22Z",
+      "result": "clean"
+    },
+    "erdos-1121": {
+      "auditCount": 4,
+      "issues": [],
+      "lastAudited": "2026-04-22T22:01:22Z",
+      "result": "clean"
+    },
+    "erdos-1122": {
+      "auditCount": 5,
+      "issues": [],
+      "lastAudited": "2026-04-22T22:01:22Z",
+      "result": "clean"
     },
     "erdos-1123": {
       "auditCount": 5,
@@ -3877,22 +3877,22 @@
       "result": "clean"
     },
     "erdos-1127": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-21T18:53:44Z",
+      "lastAudited": "2026-04-22T22:01:22Z",
       "result": "clean"
     },
     "erdos-1128": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T22:01:22Z",
+      "result": "clean"
     },
     "erdos-1129": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T22:01:22Z",
+      "result": "clean"
     },
     "erdos-1129-oq-02": {
       "auditCount": 2,
@@ -3937,16 +3937,16 @@
       "result": "clean"
     },
     "erdos-1134": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-21T18:53:44Z",
+      "lastAudited": "2026-04-22T22:01:37Z",
       "result": "clean"
     },
     "erdos-1135": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-1136": {
       "auditCount": 3,
@@ -4069,9 +4069,9 @@
       "result": "clean"
     },
     "erdos-1150": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-21T18:53:44Z",
+      "lastAudited": "2026-04-22T22:01:37Z",
       "result": "clean"
     },
     "erdos-1151": {
@@ -4154,9 +4154,9 @@
     },
     "erdos-1161": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-1162": {
       "auditCount": 3,
@@ -4262,9 +4262,9 @@
     },
     "erdos-1179": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 5,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 6,
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-1179-oq-01": {
       "auditCount": 3,
@@ -4400,9 +4400,9 @@
     },
     "erdos-124": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-124-complete-sequences": {
       "agentId": "auditor-cycle-20-batch",
@@ -4472,9 +4472,9 @@
     },
     "erdos-132": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-133": {
       "agentId": "auditor-cycle-20-batch",
@@ -4484,9 +4484,9 @@
     },
     "erdos-134": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-135": {
       "agentId": "auditor-cycle-20-batch",
@@ -4496,9 +4496,9 @@
     },
     "erdos-136": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-137": {
       "agentId": "auditor-cycle-20-batch",
@@ -4540,9 +4540,9 @@
     },
     "erdos-141": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-142": {
       "auditCount": 3,
@@ -4563,10 +4563,10 @@
       "result": "clean"
     },
     "erdos-145": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-146": {
       "auditCount": 4,
@@ -4629,10 +4629,10 @@
       "result": "clean"
     },
     "erdos-154": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-155": {
       "auditCount": 4,
@@ -4655,16 +4655,16 @@
       "result": "clean"
     },
     "erdos-158": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-159": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-16": {
       "auditCount": 3,
@@ -4685,10 +4685,10 @@
       "result": "clean"
     },
     "erdos-162": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-163": {
       "auditCount": 3,
@@ -4715,16 +4715,16 @@
       "result": "clean"
     },
     "erdos-167": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-168": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-169": {
       "auditCount": 3,
@@ -4775,16 +4775,16 @@
       "result": "clean"
     },
     "erdos-176": {
-      "auditCount": 3,
-      "issues": [],
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
-    },
-    "erdos-177": {
       "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
+    },
+    "erdos-177": {
+      "auditCount": 5,
+      "issues": [],
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-177-oq-04": {
       "auditCount": 3,
@@ -4793,10 +4793,10 @@
       "result": "clean"
     },
     "erdos-178": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-179": {
       "auditCount": 3,
@@ -4842,15 +4842,15 @@
     },
     "erdos-184": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-185": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-186": {
       "agentId": "auditor-cycle-20-batch",
@@ -4866,15 +4866,15 @@
     },
     "erdos-188": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-189": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-19": {
       "agentId": "auditor-cycle-20-batch",
@@ -4890,15 +4890,15 @@
     },
     "erdos-190": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-191": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-192": {
       "agentId": "auditor-cycle-20-batch",
@@ -4938,15 +4938,15 @@
     },
     "erdos-198": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-199": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-2": {
       "agentId": "auditor-cycle-20-batch",
@@ -4968,15 +4968,15 @@
     },
     "erdos-200": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-201": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-202": {
       "agentId": "auditor-cycle-20-batch",
@@ -5013,9 +5013,9 @@
     },
     "erdos-207": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 5,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 6,
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-208": {
       "agentId": "auditor-cycle-20-batch",
@@ -5055,9 +5055,9 @@
     },
     "erdos-213": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-214": {
       "agentId": "auditor-cycle-20-batch",
@@ -5067,9 +5067,9 @@
     },
     "erdos-215": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-216": {
       "agentId": "auditor-cycle-20-batch",
@@ -5079,9 +5079,9 @@
     },
     "erdos-217": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-218": {
       "agentId": "auditor-cycle-20-batch",
@@ -5091,9 +5091,9 @@
     },
     "erdos-219": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-22": {
       "agentId": "auditor-cycle-20-batch",
@@ -5134,15 +5134,15 @@
     },
     "erdos-225": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-226": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-227": {
       "agentId": "auditor-cycle-20-batch",
@@ -5152,9 +5152,9 @@
     },
     "erdos-228": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-229": {
       "agentId": "auditor-cycle-20-batch",
@@ -5170,9 +5170,9 @@
     },
     "erdos-230": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-231": {
       "agentId": "auditor-cycle-20-batch",
@@ -5189,9 +5189,9 @@
     },
     "erdos-233": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-234": {
       "agentId": "auditor-cycle-20-batch",
@@ -5231,9 +5231,9 @@
     },
     "erdos-24": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-240": {
       "agentId": "auditor-cycle-20-batch",
@@ -5315,9 +5315,9 @@
     },
     "erdos-250": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-251": {
       "agentId": "auditor-cycle-20-batch",
@@ -5345,9 +5345,9 @@
     },
     "erdos-255": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-256": {
       "agentId": "auditor-cycle-20-batch",
@@ -5369,9 +5369,9 @@
     },
     "erdos-259": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-26": {
       "agentId": "auditor-cycle-20-batch",
@@ -5405,9 +5405,9 @@
     },
     "erdos-264": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-265": {
       "agentId": "auditor-cycle-20-batch",
@@ -5423,9 +5423,9 @@
     },
     "erdos-267": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-268": {
       "agentId": "auditor-cycle-20-batch",
@@ -5471,15 +5471,15 @@
     },
     "erdos-274": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-275": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-276": {
       "agentId": "auditor-cycle-20-batch",
@@ -5489,9 +5489,9 @@
     },
     "erdos-277": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-278": {
       "agentId": "auditor-cycle-20-batch",
@@ -5518,15 +5518,15 @@
     },
     "erdos-280": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:37Z",
+      "result": "clean"
     },
     "erdos-281": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-282": {
       "agentId": "auditor-cycle-20-batch",
@@ -5536,9 +5536,9 @@
     },
     "erdos-283": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-284": {
       "agentId": "auditor-cycle-20-batch",
@@ -5624,9 +5624,9 @@
     },
     "erdos-295": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-296": {
       "agentId": "auditor-cycle-20-batch",
@@ -5667,9 +5667,9 @@
     },
     "erdos-300": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-301": {
       "agentId": "auditor-cycle-20-batch",
@@ -5679,9 +5679,9 @@
     },
     "erdos-302": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-303": {
       "agentId": "auditor-cycle-20-batch",
@@ -5769,9 +5769,9 @@
     },
     "erdos-315": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-316": {
       "agentId": "auditor-cycle-20-batch",
@@ -5787,15 +5787,15 @@
     },
     "erdos-318": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-319": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-32": {
       "agentId": "auditor-cycle-20-batch",
@@ -5817,15 +5817,15 @@
     },
     "erdos-322": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-323": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-324": {
       "agentId": "auditor-cycle-20-batch",
@@ -5841,9 +5841,9 @@
     },
     "erdos-326": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-327": {
       "agentId": "auditor-cycle-20-batch",
@@ -5871,9 +5871,9 @@
     },
     "erdos-329": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-33": {
       "auditCount": 4,
@@ -5895,9 +5895,9 @@
     },
     "erdos-332": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-333": {
       "agentId": "auditor-cycle-20-batch",
@@ -5907,9 +5907,9 @@
     },
     "erdos-334": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-335": {
       "agentId": "auditor-cycle-20-batch",
@@ -5967,9 +5967,9 @@
     },
     "erdos-342": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-343": {
       "agentId": "auditor-cycle-20-batch",
@@ -5979,15 +5979,15 @@
     },
     "erdos-344": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-345": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-346": {
       "agentId": "auditor-cycle-20-batch",
@@ -6009,9 +6009,9 @@
     },
     "erdos-349": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-35": {
       "agentId": "auditor-cycle-20-batch",
@@ -6094,9 +6094,9 @@
     },
     "erdos-361": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-362": {
       "agentId": "auditor-cycle-20-batch",
@@ -6106,9 +6106,9 @@
     },
     "erdos-363": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-364": {
       "agentId": "auditor-cycle-20-batch",
@@ -6196,9 +6196,9 @@
     },
     "erdos-377": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-378": {
       "agentId": "auditor-cycle-20-batch",
@@ -6226,15 +6226,15 @@
     },
     "erdos-381": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-382": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 5,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 6,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-383": {
       "agentId": "auditor-cycle-20-batch",
@@ -6280,9 +6280,9 @@
     },
     "erdos-39": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 5,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 6,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-390": {
       "agentId": "auditor-cycle-20-batch",
@@ -6318,9 +6318,9 @@
     },
     "erdos-395": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-395-oq-01": {
       "auditCount": 5,
@@ -6336,9 +6336,9 @@
     },
     "erdos-397": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-398": {
       "agentId": "auditor-cycle-20-batch",
@@ -6396,9 +6396,9 @@
     },
     "erdos-405": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-406": {
       "agentId": "auditor-cycle-20-batch",
@@ -6408,9 +6408,9 @@
     },
     "erdos-407": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-408": {
       "agentId": "auditor-cycle-20-batch",
@@ -6428,9 +6428,9 @@
     },
     "erdos-41": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-410": {
       "agentId": "auditor-cycle-20-batch",
@@ -6512,15 +6512,15 @@
     },
     "erdos-422": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-423": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-424": {
       "agentId": "auditor-cycle-20-batch",
@@ -6536,9 +6536,9 @@
     },
     "erdos-426": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-427": {
       "agentId": "auditor-cycle-20-batch",
@@ -6602,15 +6602,15 @@
     },
     "erdos-436": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-437": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-438": {
       "agentId": "auditor-cycle-20-batch",
@@ -6620,9 +6620,9 @@
     },
     "erdos-439": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-44": {
       "agentId": "auditor-cycle-20-batch",
@@ -6632,9 +6632,9 @@
     },
     "erdos-440": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-441": {
       "agentId": "auditor-cycle-20-batch",
@@ -6644,9 +6644,9 @@
     },
     "erdos-442": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-443": {
       "agentId": "auditor-cycle-20-batch",
@@ -6704,9 +6704,9 @@
     },
     "erdos-451": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-452": {
       "agentId": "auditor-cycle-20-batch",
@@ -6764,9 +6764,9 @@
     },
     "erdos-46": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-460": {
       "agentId": "auditor-cycle-20-batch",
@@ -6830,9 +6830,9 @@
     },
     "erdos-47": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-470": {
       "agentId": "auditor-cycle-20-batch",
@@ -6866,9 +6866,9 @@
     },
     "erdos-475": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-476": {
       "agentId": "auditor-cycle-20-batch",
@@ -6888,9 +6888,9 @@
     },
     "erdos-477": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-478": {
       "agentId": "auditor-cycle-20-batch",
@@ -6966,9 +6966,9 @@
     },
     "erdos-487": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-488": {
       "agentId": "auditor-cycle-20-batch",
@@ -7044,15 +7044,15 @@
     },
     "erdos-498": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-499": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-5": {
       "agentId": "auditor-cycle-20-batch",
@@ -7139,9 +7139,9 @@
     },
     "erdos-510": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-511": {
       "agentId": "auditor-cycle-20-batch",
@@ -7157,9 +7157,9 @@
     },
     "erdos-513": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-514": {
       "agentId": "auditor-cycle-20-batch",
@@ -7169,15 +7169,15 @@
     },
     "erdos-515": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-516": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-517": {
       "agentId": "auditor-cycle-20-batch",
@@ -7217,9 +7217,9 @@
     },
     "erdos-522": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-523": {
       "agentId": "auditor-cycle-20-batch",
@@ -7247,9 +7247,9 @@
     },
     "erdos-526": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-527": {
       "agentId": "auditor-cycle-20-batch",
@@ -7283,15 +7283,15 @@
     },
     "erdos-531": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-532": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-533": {
       "agentId": "auditor-cycle-20-batch",
@@ -7307,15 +7307,15 @@
     },
     "erdos-535": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-536": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-537": {
       "agentId": "auditor-cycle-20-batch",
@@ -7337,15 +7337,15 @@
     },
     "erdos-54": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-540": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-541": {
       "agentId": "auditor-cycle-20-batch",
@@ -7385,9 +7385,9 @@
     },
     "erdos-547": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-548": {
       "agentId": "auditor-cycle-20-batch",
@@ -7403,9 +7403,9 @@
     },
     "erdos-55": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-550": {
       "agentId": "auditor-cycle-20-batch",
@@ -7481,9 +7481,9 @@
     },
     "erdos-561": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-562": {
       "agentId": "auditor-cycle-20-batch",
@@ -7505,9 +7505,9 @@
     },
     "erdos-565": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-566": {
       "agentId": "auditor-cycle-20-batch",
@@ -7541,9 +7541,9 @@
     },
     "erdos-570": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-571": {
       "agentId": "auditor-cycle-20-batch",
@@ -7583,27 +7583,27 @@
     },
     "erdos-577": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-578": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-579": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-58": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-580": {
       "agentId": "auditor-cycle-20-batch",
@@ -7643,9 +7643,9 @@
     },
     "erdos-586": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-587": {
       "agentId": "auditor-cycle-20-batch",
@@ -7655,9 +7655,9 @@
     },
     "erdos-588": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-589": {
       "agentId": "auditor-cycle-20-batch",
@@ -7667,9 +7667,9 @@
     },
     "erdos-59": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 5,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 6,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-590": {
       "agentId": "auditor-cycle-20-batch",
@@ -7679,9 +7679,9 @@
     },
     "erdos-591": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-592": {
       "agentId": "auditor-cycle-20-batch",
@@ -7709,33 +7709,33 @@
     },
     "erdos-596": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-597": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-598": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-599": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-6": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-60": {
       "auditCount": 5,
@@ -7819,9 +7819,9 @@
     },
     "erdos-61": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-610": {
       "agentId": "auditor-cycle-20-batch",
@@ -7971,9 +7971,9 @@
     },
     "erdos-631": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-632": {
       "agentId": "auditor-cycle-20-batch",
@@ -8088,9 +8088,9 @@
     },
     "erdos-649": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-65": {
       "agentId": "auditor-cycle-20-batch",
@@ -8112,9 +8112,9 @@
     },
     "erdos-651": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-652": {
       "agentId": "auditor-cycle-20-batch",
@@ -8130,9 +8130,9 @@
     },
     "erdos-654": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-655": {
       "agentId": "auditor-cycle-20-batch",
@@ -8185,9 +8185,9 @@
     },
     "erdos-661": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-662": {
       "agentId": "auditor-cycle-20-batch",
@@ -8239,9 +8239,9 @@
     },
     "erdos-67": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-670": {
       "agentId": "auditor-cycle-20-batch",
@@ -8343,9 +8343,9 @@
     },
     "erdos-685": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-686": {
       "agentId": "auditor-cycle-20-batch",
@@ -8470,9 +8470,9 @@
     },
     "erdos-702": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-703": {
       "agentId": "auditor-cycle-20-batch",
@@ -8482,9 +8482,9 @@
     },
     "erdos-704": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-705": {
       "agentId": "auditor-cycle-20-batch",
@@ -8494,9 +8494,9 @@
     },
     "erdos-706": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-707": {
       "agentId": "auditor-cycle-20-batch",
@@ -8506,9 +8506,9 @@
     },
     "erdos-708": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-709": {
       "agentId": "auditor-cycle-20-batch",
@@ -8604,15 +8604,15 @@
     },
     "erdos-722": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-723": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-724": {
       "agentId": "auditor-cycle-20-batch",
@@ -8640,9 +8640,9 @@
     },
     "erdos-728": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-728-factorial-divisibility": {
       "agentId": "auditor-cycle-20-batch",
@@ -8652,9 +8652,9 @@
     },
     "erdos-729": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 5,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 6,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-73": {
       "agentId": "auditor-cycle-20-batch",
@@ -8676,15 +8676,15 @@
     },
     "erdos-732": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-733": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-734": {
       "agentId": "auditor-cycle-20-batch",
@@ -8724,9 +8724,9 @@
     },
     "erdos-74": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-740": {
       "agentId": "auditor-cycle-20-batch",
@@ -8776,9 +8776,9 @@
     },
     "erdos-747": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-748": {
       "agentId": "auditor-cycle-20-batch",
@@ -8806,9 +8806,9 @@
     },
     "erdos-751": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-752": {
       "agentId": "auditor-cycle-20-batch",
@@ -8824,9 +8824,9 @@
     },
     "erdos-754": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-755": {
       "agentId": "auditor-cycle-20-batch",
@@ -8878,15 +8878,15 @@
     },
     "erdos-762": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-763": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-764": {
       "agentId": "auditor-cycle-20-batch",
@@ -8962,9 +8962,9 @@
     },
     "erdos-775": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-776": {
       "agentId": "auditor-cycle-20-batch",
@@ -8987,9 +8987,9 @@
     },
     "erdos-779": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-78": {
       "agentId": "auditor-cycle-20-batch",
@@ -9017,9 +9017,9 @@
     },
     "erdos-783": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-784": {
       "agentId": "auditor-cycle-20-batch",
@@ -9029,21 +9029,21 @@
     },
     "erdos-785": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-786": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-787": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-788": {
       "agentId": "auditor-cycle-20-batch",
@@ -9059,9 +9059,9 @@
     },
     "erdos-79": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-790": {
       "agentId": "auditor-cycle-20-batch",
@@ -9155,9 +9155,9 @@
     },
     "erdos-803": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-804": {
       "agentId": "auditor-cycle-20-batch",
@@ -9173,9 +9173,9 @@
     },
     "erdos-806": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-807": {
       "agentId": "auditor-cycle-20-batch",
@@ -9221,15 +9221,15 @@
     },
     "erdos-813": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-814": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-815": {
       "agentId": "auditor-cycle-20-batch",
@@ -9281,9 +9281,9 @@
     },
     "erdos-822": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-823": {
       "agentId": "auditor-cycle-20-batch",
@@ -9293,9 +9293,9 @@
     },
     "erdos-824": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-825": {
       "agentId": "auditor-cycle-20-batch",
@@ -9347,9 +9347,9 @@
     },
     "erdos-832": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-833": {
       "agentId": "auditor-cycle-20-batch",
@@ -9371,9 +9371,9 @@
     },
     "erdos-836": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-837": {
       "agentId": "auditor-cycle-20-batch",
@@ -9395,15 +9395,15 @@
     },
     "erdos-839": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 5,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 6,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-84": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-840": {
       "agentId": "auditor-cycle-20-batch",
@@ -9420,9 +9420,9 @@
     },
     "erdos-842": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-843": {
       "agentId": "auditor-cycle-20-batch",
@@ -9534,15 +9534,15 @@
     },
     "erdos-859": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-86": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-860": {
       "agentId": "auditor-cycle-20-batch",
@@ -9552,9 +9552,9 @@
     },
     "erdos-861": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-862": {
       "agentId": "auditor-cycle-20-batch",
@@ -9564,9 +9564,9 @@
     },
     "erdos-863": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-864": {
       "agentId": "auditor-cycle-20-batch",
@@ -9654,15 +9654,15 @@
     },
     "erdos-877": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-878": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-879": {
       "agentId": "auditor-cycle-20-batch",
@@ -9732,9 +9732,9 @@
     },
     "erdos-889": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-89": {
       "agentId": "auditor-cycle-20-batch",
@@ -9768,9 +9768,9 @@
     },
     "erdos-894": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-895": {
       "agentId": "auditor-cycle-20-batch",
@@ -9870,9 +9870,9 @@
     },
     "erdos-909": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-909-oq-01": {
       "auditCount": 3,
@@ -9972,15 +9972,15 @@
     },
     "erdos-923": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-924": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-925": {
       "agentId": "auditor-cycle-20-batch",
@@ -10032,9 +10032,9 @@
     },
     "erdos-932": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-933": {
       "agentId": "auditor-cycle-20-batch",
@@ -10062,9 +10062,9 @@
     },
     "erdos-937": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-938": {
       "auditCount": 4,
@@ -10104,15 +10104,15 @@
     },
     "erdos-942": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-943": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-944": {
       "agentId": "auditor-cycle-20-batch",
@@ -10140,9 +10140,9 @@
     },
     "erdos-948": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-949": {
       "agentId": "auditor-cycle-20-batch",
@@ -10266,9 +10266,9 @@
     },
     "erdos-967": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-968": {
       "agentId": "auditor-cycle-20-batch",
@@ -10314,9 +10314,9 @@
     },
     "erdos-974": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-975": {
       "agentId": "auditor-cycle-20-batch",
@@ -10326,9 +10326,9 @@
     },
     "erdos-976": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-977": {
       "agentId": "auditor-cycle-20-batch",
@@ -10381,9 +10381,9 @@
     },
     "erdos-984": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-985": {
       "agentId": "auditor-cycle-20-batch",
@@ -10453,9 +10453,9 @@
     },
     "erdos-995": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-996": {
       "agentId": "auditor-cycle-20-batch",
@@ -10471,9 +10471,9 @@
     },
     "erdos-998": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "erdos-999": {
       "agentId": "auditor-cycle-20-batch",
@@ -10963,9 +10963,9 @@
     },
     "greens-theorem": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "greens-theorem-oq-01": {
       "auditCount": 4,
@@ -11129,9 +11129,9 @@
     },
     "hilbert-16": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "hilbert-17": {
       "agentId": "auditor-cycle-20-batch",
@@ -11147,9 +11147,9 @@
     },
     "hilbert-19": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "hilbert-19-oq-03": {
       "agentId": "auditor-cycle-20-batch",
@@ -11362,10 +11362,10 @@
       "result": "clean"
     },
     "isoperimetric-theorem-oq-01": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "isosceles-triangle": {
       "agentId": "auditor-cycle-20-batch",
@@ -11859,9 +11859,9 @@
     },
     "parallel-postulate-independence": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "parallel-postulate-independence-oq-02": {
       "agentId": "auditor-cycle-20-batch",
@@ -11888,10 +11888,10 @@
       "result": "clean"
     },
     "partition-theorem-oq-03": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "pascals-hexagon": {
       "auditCount": 5,
@@ -11963,10 +11963,10 @@
       "result": "issues-fixed"
     },
     "poincare-conjecture": {
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "prime-gap-bounds": {
       "agentId": "auditor-cycle-20-batch",
@@ -12281,10 +12281,10 @@
       "result": "clean"
     },
     "schroeder-bernstein-oq-03": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-21T18:53:44Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T22:01:51Z",
+      "result": "clean"
     },
     "schroeder-bernstein-oq-04": {
       "auditCount": 3,
@@ -12385,9 +12385,9 @@
       "result": "clean"
     },
     "shannon-source-coding-oq-04": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-21T20:08:54Z",
+      "lastAudited": "2026-04-22T22:01:51Z",
       "result": "clean"
     },
     "shapley-folkman": {


### PR DESCRIPTION
## Gallery Integrity Audit

**Scope**: Complete audit of all 2142 gallery entries against Lean source files.

## Fixes

### erdos-268 (HIGH — sorry count mismatch)
- **Issue**: `meta.json` claimed `sorries: 2` but Lean file has 1
- **Root cause**: Research commit `d31f2ee9d0` proved the d=1 case of `harmonicPointSet_path_connected`
- **Fix**: sorries 2→1, lineCount 762→943, updated assumptions and conclusion

### shannon-channel-coding-oq-02-oq-01 (MEDIUM — axiomCount mismatch)
- **Issue**: `axiomCount: 1` but Lean file has 2 axiom declarations
- **Root cause**: `fano_inequality` axiom declared locally was not counted
- **Fix**: axiomCount 1→2, updated assumptions to name both axioms

## Audit Methodology Notes

Script uses `^axiom` grep which intentionally does **not** flag:
- `private axiom` (e.g., erdos-1012-oq-03)
- `noncomputable axiom` (e.g., hilbert-21)
- Structure-encoded axioms (e.g., buffons-needle RiemannianVolumeData, area-of-circle-oq-02-oq-04)
- Axioms in companion files (e.g., inverse-galois total=5 across 2 files)

These are all correctly handled by the meta.json axiomCount field.

---
Discovered during automated gallery integrity audit.