### PR TITLE
Audit: fix sqrt2-plus-sqrt3-irrational badge (original → mathlib)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5399,8 +5399,8 @@
     },
     "erdos-263": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T07:29:22Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T22:27:05Z",
       "result": "clean"
     },
     "erdos-264": {

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12523,10 +12523,10 @@
       "result": "issues-found"
     },
     "sqrt2-plus-sqrt3-irrational": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-22T21:59:00Z",
-      "result": "clean"
+      "lastAudited": "2026-04-22T22:29:01Z",
+      "result": "issues-fixed"
     },
     "sqrt2-plus-sqrt3-irrational-oq-03": {
       "auditCount": 1,

--- a/src/data/proofs/sqrt2-plus-sqrt3-irrational/meta.json
+++ b/src/data/proofs/sqrt2-plus-sqrt3-irrational/meta.json
@@ -14,7 +14,7 @@
       "square-roots",
       "number-theory"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-04-02",
     "axiomCount": 0,


### PR DESCRIPTION
## Audit Finding

**Proof**: `sqrt2-plus-sqrt3-irrational`
**Issue**: Badge `original` is inconsistent with actual Mathlib dependency

## Evidence

The proof relies on Mathlib's `irrational_sqrt_natCast_iff` to establish that √6 is irrational — the essential mathematical content that makes the whole proof work:

```lean
theorem irrational_sqrt_six : Irrational (sqrt 6) := by
  have hns : ¬ IsSquare (6 : ℕ) := by native_decide
  exact irrational_sqrt_natCast_iff.mpr hns
```

Without this Mathlib theorem, the proof has no foundation. The algebraic squaring argument (our contribution) only provides the reduction: if √2+√3 is rational, then √6 is rational — contradicting the above Mathlib result.

**Comparison**: `sqrt2-irrational` uses badge `mathlib` for the same reason (direct reliance on `irrational_sqrt_two` from Mathlib). This fix makes the classification consistent.

## Fix

```json
- "badge": "original",
+ "badge": "mathlib",
```

The `assumptions` field already correctly documents: *"Uses Mathlib's irrational_sqrt_natCast_iff and native_decide for ¬IsSquare 6."*

Status remains `verified` — the proof is fully machine-checked with 0 sorries and 0 axioms. Only the badge changes.

---
Discovered during gallery integrity audit (2026-04-23). Also records erdos-263 as clean.