### PR TITLE
Fix erdos-97: stale top-level sorries field and stale Stubs path in index.ts

### DIFF
--- a/src/data/proofs/erdos-97/index.ts
+++ b/src/data/proofs/erdos-97/index.ts
@@ -16,7 +16,7 @@ const meta = metaJson as {
 }
 
 // Import the Lean source file
-const leanSource = () => import('../../../../proofs/Proofs/Stubs/Erdos97Problem.lean?raw')
+const leanSource = () => import('../../../../proofs/Proofs/Erdos97Problem.lean?raw')
 
 export const proof: Proof = {
   id: meta.id,

--- a/src/data/proofs/erdos-97/meta.json
+++ b/src/data/proofs/erdos-97/meta.json
@@ -185,5 +185,5 @@
       "note": "Original paper raising the question of equidistant points in convex position, foundational for the distinct distances problem"
     }
   ],
-  "sorries": 2
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Two artifacts left over from the erdos-97 enrichment commit (#11528), which created `proofs/Proofs/Erdos97Problem.lean` (0 sorries) and updated `proofRepoPath`, but missed two files:

## Evidence

**Problem 1 — stale top-level `sorries` field in meta.json:**
- **Before**: `"sorries": 2` (top-level field, leftover from the stub era)
- **After**: `"sorries": 0` (consistent with `meta.sorries: 0` and `leanFile.sorries: 0`)

**Problem 2 — stale Lean source path in index.ts:**
- **Before**: `import('../../../../proofs/Proofs/Stubs/Erdos97Problem.lean?raw')` — served the old stub (222 lines, 2 sorries) to gallery viewers
- **After**: `import('../../../../proofs/Proofs/Erdos97Problem.lean?raw')` — serves the enriched proof (163 lines, 0 sorries) matching `proofRepoPath`

---
Automated fix by lean-mechanic agent.