### PR TITLE
Fix stale Stubs paths in 13 index.ts files after enrichment

### DIFF
--- a/src/data/proofs/erdos-104/index.ts
+++ b/src/data/proofs/erdos-104/index.ts
@@ -16,7 +16,7 @@ const meta = metaJson as {
 }
 
 // Import the Lean source file
-const leanSource = () => import('../../../../proofs/Proofs/Stubs/Erdos104Problem.lean?raw')
+const leanSource = () => import('../../../../proofs/Proofs/Erdos104Problem.lean?raw')
 
 export const proof: Proof = {
   id: meta.id,

--- a/src/data/proofs/erdos-107/index.ts
+++ b/src/data/proofs/erdos-107/index.ts
@@ -16,7 +16,7 @@ const meta = metaJson as {
 }
 
 // Import the Lean source file
-const leanSource = () => import('../../../../proofs/Proofs/Stubs/Erdos107Problem.lean?raw')
+const leanSource = () => import('../../../../proofs/Proofs/Erdos107Problem.lean?raw')
 
 export const proof: Proof = {
   id: meta.id,

--- a/src/data/proofs/erdos-1095/index.ts
+++ b/src/data/proofs/erdos-1095/index.ts
@@ -16,7 +16,7 @@ const meta = metaJson as {
 }
 
 // Import the Lean source file
-const leanSource = () => import('../../../../proofs/Proofs/Stubs/Erdos1095Problem.lean?raw')
+const leanSource = () => import('../../../../proofs/Proofs/Erdos1095Problem.lean?raw')
 
 export const proof: Proof = {
   id: meta.id,

--- a/src/data/proofs/erdos-1100/index.ts
+++ b/src/data/proofs/erdos-1100/index.ts
@@ -16,7 +16,7 @@ const meta = metaJson as {
 }
 
 // Import the Lean source file
-const leanSource = () => import('../../../../proofs/Proofs/Stubs/Erdos1100Problem.lean?raw')
+const leanSource = () => import('../../../../proofs/Proofs/Erdos1100ProblemProvable.lean?raw')
 
 export const proof: Proof = {
   id: meta.id,

--- a/src/data/proofs/erdos-135/index.ts
+++ b/src/data/proofs/erdos-135/index.ts
@@ -16,7 +16,7 @@ const meta = metaJson as {
 }
 
 // Import the Lean source file
-const leanSource = () => import('../../../../proofs/Proofs/Stubs/Erdos135Problem.lean?raw')
+const leanSource = () => import('../../../../proofs/Proofs/Erdos135Problem.lean?raw')
 
 export const proof: Proof = {
   id: meta.id,

--- a/src/data/proofs/erdos-27/index.ts
+++ b/src/data/proofs/erdos-27/index.ts
@@ -16,7 +16,7 @@ const meta = metaJson as {
 }
 
 // Import the Lean source file
-const leanSource = () => import('../../../../proofs/Proofs/Stubs/Erdos27Problem.lean?raw')
+const leanSource = () => import('../../../../proofs/Proofs/Erdos27Problem.lean?raw')
 
 export const proof: Proof = {
   id: meta.id,

--- a/src/data/proofs/erdos-357/index.ts
+++ b/src/data/proofs/erdos-357/index.ts
@@ -16,7 +16,7 @@ const meta = metaJson as {
 }
 
 // Import the Lean source file
-const leanSource = () => import('../../../../proofs/Proofs/Stubs/Erdos357Problem.lean?raw')
+const leanSource = () => import('../../../../proofs/Proofs/Erdos357Problem.lean?raw')
 
 export const proof: Proof = {
   id: meta.id,

--- a/src/data/proofs/erdos-392/index.ts
+++ b/src/data/proofs/erdos-392/index.ts
@@ -16,7 +16,7 @@ const meta = metaJson as {
 }
 
 // Import the Lean source file
-const leanSource = () => import('../../../../proofs/Proofs/Stubs/Erdos392Problem.lean?raw')
+const leanSource = () => import('../../../../proofs/Proofs/Erdos392Problem.lean?raw')
 
 export const proof: Proof = {
   id: meta.id,

--- a/src/data/proofs/erdos-456/index.ts
+++ b/src/data/proofs/erdos-456/index.ts
@@ -9,7 +9,7 @@ const meta = metaJson as {
   crossReferences?: CrossReference[]
 }
 
-const leanSource = () => import('../../../../proofs/Proofs/Stubs/Erdos456Problem.lean?raw')
+const leanSource = () => import('../../../../proofs/Proofs/Erdos456Problem.lean?raw')
 
 export const proof: Proof = {
   id: meta.id, title: meta.title, slug: meta.slug,

--- a/src/data/proofs/erdos-76/index.ts
+++ b/src/data/proofs/erdos-76/index.ts
@@ -16,7 +16,7 @@ const meta = metaJson as {
 }
 
 // Import the Lean source file
-const leanSource = () => import('../../../../proofs/Proofs/Stubs/Erdos76Problem.lean?raw')
+const leanSource = () => import('../../../../proofs/Proofs/Erdos76Problem.lean?raw')
 
 export const proof: Proof = {
   id: meta.id,

--- a/src/data/proofs/erdos-761/index.ts
+++ b/src/data/proofs/erdos-761/index.ts
@@ -9,7 +9,7 @@ const meta = metaJson as {
   crossReferences?: CrossReference[]
 }
 
-const leanSource = () => import('../../../../proofs/Proofs/Stubs/Erdos761Problem.lean?raw')
+const leanSource = () => import('../../../../proofs/Proofs/Erdos761Problem.lean?raw')
 
 export const proof: Proof = {
   id: meta.id,

--- a/src/data/proofs/erdos-83/index.ts
+++ b/src/data/proofs/erdos-83/index.ts
@@ -16,7 +16,7 @@ const meta = metaJson as {
 }
 
 // Import the Lean source file
-const leanSource = () => import('../../../../proofs/Proofs/Stubs/Erdos83Problem.lean?raw')
+const leanSource = () => import('../../../../proofs/Proofs/Erdos83Problem.lean?raw')
 
 export const proof: Proof = {
   id: meta.id,

--- a/src/data/proofs/erdos-94/index.ts
+++ b/src/data/proofs/erdos-94/index.ts
@@ -16,7 +16,7 @@ const meta = metaJson as {
 }
 
 // Import the Lean source file
-const leanSource = () => import('../../../../proofs/Proofs/Stubs/Erdos94Problem.lean?raw')
+const leanSource = () => import('../../../../proofs/Proofs/Erdos94Problem.lean?raw')
 
 export const proof: Proof = {
   id: meta.id,


### PR DESCRIPTION
## Fix

After enrichment agents moved proofs from `Proofs/Stubs/` to `Proofs/`, they updated `proofRepoPath` in `meta.json` but forgot to update the `leanSource` import in each proof's `index.ts`. This caused gallery viewers to see the old stub file instead of the enriched proof.

## Evidence

**Pattern (for each of 13 proofs):**
- **Before**: `const leanSource = () => import('../../../../proofs/Proofs/Stubs/ErdosXxxProblem.lean?raw')`
- **After**: `const leanSource = () => import('../../../../proofs/Proofs/ErdosXxxProblem.lean?raw')`

**Affected proofs:** erdos-27, erdos-76, erdos-83, erdos-94, erdos-104, erdos-107, erdos-135, erdos-357, erdos-392, erdos-456, erdos-761, erdos-1095, erdos-1100

Note: erdos-97 fixed separately in #11542. erdos-1100 specifically corrected from `Erdos1100Problem.lean` to `Erdos1100ProblemProvable.lean` to match `proofRepoPath`.

---
Automated fix by lean-mechanic agent.