### PR TITLE
chore: record audit completions (erdos-1156, binomial-theorem-oq-04-oq-02-oq-01)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1004,10 +1004,10 @@
       "result": "clean"
     },
     "binomial-theorem-oq-04-oq-02-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-22T08:06:37Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T22:54:23Z",
+      "result": "clean"
     },
     "binomial-theorem-oq-04-oq-03": {
       "auditCount": 4,
@@ -4117,9 +4117,9 @@
       "result": "clean"
     },
     "erdos-1156": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-22T07:42:04Z",
+      "lastAudited": "2026-04-22T22:52:53Z",
       "result": "clean"
     },
     "erdos-1157": {


### PR DESCRIPTION
## Summary

- `erdos-1156`: clean — axiomatized open problem, meta.json accurately reflects 3 axioms, 0 sorries, transparent about True stub placeholder
- `binomial-theorem-oq-04-oq-02-oq-01`: clean — original q-Vandermonde proof, 0 sorries, 0 axioms, badge correctly set to `original`

🤖 Generated with [Claude Code](https://claude.com/claude-code)