### PR TITLE
Enrich sqrt2-minpoly-oq-02: 8 annotations, sections, conclusion, crossReferences

### DIFF
--- a/src/data/proofs/sqrt2-minpoly-oq-02/annotations.json
+++ b/src/data/proofs/sqrt2-minpoly-oq-02/annotations.json
@@ -1,1 +1,98 @@
-[]
+[
+  {
+    "id": "ann-sqrt2oq02-setup",
+    "proofId": "sqrt2-minpoly-oq-02",
+    "range": { "startLine": 1, "endLine": 39 },
+    "type": "context",
+    "title": "Setup: The General Eisenstein Criterion for n-th Roots",
+    "content": "The module docstring frames the mathematical question: under what conditions is the minimal polynomial of $m^{1/n}$ over $\\mathbb{Q}$ exactly $X^n - m$? The answer given here is a clean sufficient condition: $m$ has a prime factor $p$ with $p \\mid m$ but $p^2 \\nmid m$ — the **squarefree prime factor condition**.\n\nThis file generalizes a family of classical examples: $\\sqrt{2}$ has minimal polynomial $X^2 - 2$ (Eisenstein at $p=2$), $\\sqrt[3]{2}$ has $X^3 - 2$ (Eisenstein at $p=2$), and so on. The key insight is that the same Eisenstein criterion applies uniformly for all degrees $n \\geq 2$.\n\nThe `open Polynomial IntermediateField` brings in Mathlib's polynomial ring namespace (for `X`, `C`, `aeval`) and the intermediate field API (for `ℚ⟮·⟯` and `adjoin.finrank`).",
+    "mathContext": "The **squarefree prime factor condition** for $m$: there exists a prime $p$ with $v_p(m) = 1$ (where $v_p$ is the $p$-adic valuation). This is equivalent to $p \\mid m$ but $p^2 \\nmid m$. Examples: $6 = 2 \\cdot 3$ (works at $p=2$ or $p=3$), $10 = 2 \\cdot 5$ (works at $p=2$), $12 = 4 \\cdot 3$ (works at $p=3$ but NOT $p=2$ since $4 \\mid 12$).",
+    "significance": "context",
+    "relatedConcepts": ["Eisenstein criterion", "minimal polynomial", "squarefree factor", "p-adic valuation"],
+    "prerequisites": ["field extensions", "algebraic numbers", "irreducibility criteria"]
+  },
+  {
+    "id": "ann-sqrt2oq02-eisenstein-int",
+    "proofId": "sqrt2-minpoly-oq-02",
+    "range": { "startLine": 41, "endLine": 81 },
+    "type": "technique",
+    "title": "Eisenstein over ℤ: Proving X^n - m is ℤ-Irreducible",
+    "content": "The private theorem `eisenstein_X_pow_sub_int` applies Mathlib's `Polynomial.irreducible_of_eisenstein_criterion` to the polynomial $X^n - m \\in \\mathbb{Z}[X]$. This requires verifying five conditions for the prime ideal $\\mathfrak{p} = (p) \\subseteq \\mathbb{Z}$:\n\n1. **$(p)$ is prime**: Follows from $p$ being a prime natural number, via `Int.prime_iff_natAbs_prime`.\n2. **Leading coefficient $\\notin (p)$**: The leading coefficient of $X^n - m$ is 1, and 1 is not divisible by any prime.\n3. **All lower coefficients $\\in (p)$**: For $k < n$, the $k$-th coefficient is $-m$ (when $k=0$) or $0$ (when $0 < k < n$). Since $p \\mid m$, the constant term is in $(p)$; all others are trivially 0.\n4. **Positive degree**: $\\deg(X^n - m) = n > 0$ since $n \\geq 2$.\n5. **Constant term $\\notin (p)^2$**: The constant term is $-m$, and $p^2 \\nmid m$ by hypothesis.\n\nThe case split `by_cases hk0 : k = 0` handles conditions 3 separately for the constant term ($k=0$) versus zero coefficients ($k > 0$).",
+    "mathContext": "**Eisenstein Criterion** (Eisenstein 1850): Let $f = a_n X^n + \\cdots + a_0 \\in \\mathbb{Z}[X]$ and $p$ a prime. If $p \\nmid a_n$, $p \\mid a_i$ for all $i < n$, and $p^2 \\nmid a_0$, then $f$ is irreducible over $\\mathbb{Q}$.\n\nFor $f = X^n - m$: $a_n = 1$ (leading), $a_k = 0$ for $0 < k < n$, $a_0 = -m$ (constant). Conditions: $p \\nmid 1$ ✓, $p \\mid 0$ trivially and $p \\mid m$ by hypothesis ✓, $p^2 \\nmid m$ by hypothesis ✓.",
+    "significance": "key",
+    "relatedConcepts": ["Eisenstein criterion", "Polynomial.irreducible_of_eisenstein_criterion", "prime ideal", "Ideal.span"],
+    "prerequisites": ["ring theory", "prime ideals in ℤ", "polynomial coefficient indexing"]
+  },
+  {
+    "id": "ann-sqrt2oq02-gauss",
+    "proofId": "sqrt2-minpoly-oq-02",
+    "range": { "startLine": 83, "endLine": 95 },
+    "type": "technique",
+    "title": "Gauss's Lemma: Transferring ℤ-Irreducibility to ℚ",
+    "content": "The public theorem `eisenstein_X_pow_sub_of_sqfree_factor` wraps the private ℤ-irreducibility result with Gauss's lemma to obtain ℚ-irreducibility. The key step uses `IsPrimitive.Int.irreducible_iff_irreducible_map_cast`: a **primitive** polynomial over $\\mathbb{Z}$ is $\\mathbb{Z}$-irreducible if and only if its image in $\\mathbb{Q}[X]$ is $\\mathbb{Q}$-irreducible.\n\nThe polynomial $X^n - m$ is primitive (its content is $\\gcd(1, 0, \\ldots, 0, -m) = 1$) because the leading coefficient is 1. This makes it monic, and `monic_X_pow_sub_C` gives `IsPrimitive`.\n\nThe `convert hirr using 1` step handles the fact that the image of $X^n - m \\in \\mathbb{Z}[X]$ under the ring homomorphism $\\mathbb{Z} \\to \\mathbb{Q}$ is definitionally equal (but not syntactically identical) to $X^n - m \\in \\mathbb{Q}[X]$. The `ext k; simp` closes by checking coefficients.",
+    "mathContext": "**Gauss's Lemma**: If $f \\in \\mathbb{Z}[X]$ is primitive (content = 1) and irreducible over $\\mathbb{Z}$, then $f$ (viewed as an element of $\\mathbb{Q}[X]$) is irreducible over $\\mathbb{Q}$. More precisely: for primitive $f \\in \\mathbb{Z}[X]$, $f$ is $\\mathbb{Z}$-irreducible $\\iff$ $f$ is $\\mathbb{Q}$-irreducible.\n\nConversely: the content map $\\mathrm{cont}: \\mathbb{Q}[X] \\to \\mathbb{Q}_{\\geq 0}$ and the factorization $\\mathbb{Q}[X] \\cong \\mathbb{Q} \\times \\mathbb{Z}[X]^{\\mathrm{prim}}$ (via Gauss) are the algebraic backdrop.",
+    "significance": "key",
+    "relatedConcepts": ["Gauss's lemma", "primitive polynomial", "IsPrimitive", "content of a polynomial"],
+    "prerequisites": ["Gauss's lemma", "primitive polynomial", "ring homomorphisms ℤ → ℚ"]
+  },
+  {
+    "id": "ann-sqrt2oq02-root-integral",
+    "proofId": "sqrt2-minpoly-oq-02",
+    "range": { "startLine": 96, "endLine": 111 },
+    "type": "theorem",
+    "title": "Root Identity and Algebraic Integrality of m^(1/n)",
+    "content": "Before computing the minimal polynomial, two facts must be established about $m^{1/n}$ as a real number:\n\n**Root identity** (`aeval_nthRoot_sub_eq_zero`): $(m^{1/n})^n = m$ (in $\\mathbb{R}$), so $m^{1/n}$ satisfies $X^n - m$. The key tactic chain: `Real.rpow_natCast` converts the $n$-th power of an `rpow` expression, and `Real.rpow_mul` collapses the composition $(m^{1/n})^n = m^{(1/n) \\cdot n} = m^1 = m$.\n\n**Integrality** (`isIntegral_nthRoot`): $m^{1/n}$ is integral over $\\mathbb{Q}$, proved by exhibiting the monic polynomial $X^n - m \\in \\mathbb{Q}[X]$ that it satisfies. This is required by `minpoly.eq_of_irreducible_of_monic` in the next step.",
+    "mathContext": "For the root identity:\n$$(m^{1/n})^n = (m^{1/n})^n \\stackrel{\\text{rpow}}{=} m^{(1/n) \\cdot n} = m^1 = m$$\n\nThe subtlety is that Lean represents $m^{1/n}$ as `(m : ℝ) ^ ((1 : ℝ) / n)` using `Real.rpow`, not `HPow.hPow`. The lemma `Real.rpow_mul` requires $m \\geq 0$ (which holds for natural $m$) and gives $m^{(a \\cdot b)} = (m^a)^b$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Real.rpow", "Real.rpow_mul", "IsIntegral", "aeval"],
+    "prerequisites": ["real power function", "algebraic integrality", "aeval (polynomial evaluation)"]
+  },
+  {
+    "id": "ann-sqrt2oq02-minpoly",
+    "proofId": "sqrt2-minpoly-oq-02",
+    "range": { "startLine": 113, "endLine": 131 },
+    "type": "theorem",
+    "title": "Main Theorem: minpoly ℚ (m^(1/n)) = X^n - m",
+    "content": "The capstone theorem `minpoly_nthRoot_eq` identifies the minimal polynomial exactly, using Mathlib's `minpoly.eq_of_irreducible_of_monic`. This characterization lemma says: if $f \\in \\mathbb{Q}[X]$ is (1) irreducible, (2) monic, and (3) has $m^{1/n}$ as a root, then $f = \\mathrm{minpoly}(\\mathbb{Q}, m^{1/n})$.\n\nThe helper `natDegree_X_pow_sub_nat_eq` computes $\\deg(X^n - m) = n$ by showing the $X^n$ term has higher degree than the constant $m$ term, then applying `natDegree_sub_eq_left_of_natDegree_lt`.\n\nAll three conditions are satisfied:\n- **Irreducibility**: `eisenstein_X_pow_sub_of_sqfree_factor` (Part I)\n- **Root witness**: `aeval_nthRoot_sub_eq_zero` (Part II)\n- **Monicity**: `monic_X_pow_sub_C` from Mathlib",
+    "mathContext": "The **minimal polynomial** $\\mathrm{minpoly}(F, \\alpha)$ of an algebraic element $\\alpha$ over a field $F$ is the unique monic irreducible polynomial $f \\in F[X]$ with $f(\\alpha) = 0$. Uniqueness follows from: any polynomial vanishing at $\\alpha$ is divisible by $\\mathrm{minpoly}(F, \\alpha)$.\n\nHere: $\\mathrm{minpoly}(\\mathbb{Q}, m^{1/n}) = X^n - m$, with $\\deg = n$, establishing that $m^{1/n}$ is an algebraic number of degree exactly $n$ over $\\mathbb{Q}$.",
+    "significance": "key",
+    "relatedConcepts": ["minpoly.eq_of_irreducible_of_monic", "minimal polynomial", "monic polynomial", "algebraic degree"],
+    "prerequisites": ["minimal polynomial theory", "irreducibility + monic characterization", "Part I and Part II results"]
+  },
+  {
+    "id": "ann-sqrt2oq02-degree",
+    "proofId": "sqrt2-minpoly-oq-02",
+    "range": { "startLine": 133, "endLine": 153 },
+    "type": "insight",
+    "title": "Algebraic Degree and Field Extension Degree = n",
+    "content": "Two corollaries of the minimal polynomial result give quantitative dimension results:\n\n**Algebraic degree** (`minpoly_nthRoot_natDegree`): The natural degree of $\\mathrm{minpoly}(\\mathbb{Q}, m^{1/n})$ equals $n$. Proved by rewriting with `minpoly_nthRoot_eq` and then applying the degree computation from Part III.\n\n**Field extension degree** (`adjoin_nthRoot_finrank`): $[\\mathbb{Q}(m^{1/n}) : \\mathbb{Q}] = n$. Proved using `IntermediateField.adjoin.finrank`: for an integral element $\\alpha$, $[F(\\alpha) : F] = \\deg(\\mathrm{minpoly}(F, \\alpha))$. This is the fundamental theorem relating algebraic degree to field extension degree.\n\nThe integrality of $m^{1/n}$ (`isIntegral_nthRoot` from Part II) is the key hypothesis for `adjoin.finrank`.",
+    "mathContext": "**Fundamental theorem** of algebraic extensions: If $\\alpha$ is integral over $F$ with minimal polynomial $f$ of degree $d$, then $[F(\\alpha) : F] = d$ and $\\{1, \\alpha, \\alpha^2, \\ldots, \\alpha^{d-1}\\}$ is an $F$-basis of $F(\\alpha)$.\n\nHere: $\\{1, m^{1/n}, m^{2/n}, \\ldots, m^{(n-1)/n}\\}$ is a $\\mathbb{Q}$-basis of $\\mathbb{Q}(m^{1/n})$, giving $\\dim_{\\mathbb{Q}} \\mathbb{Q}(m^{1/n}) = n$.",
+    "significance": "key",
+    "relatedConcepts": ["Module.finrank", "IntermediateField.adjoin.finrank", "field extension degree", "algebraic degree"],
+    "prerequisites": ["linear algebra over fields", "field extension degree theorem", "adjoin.finrank"]
+  },
+  {
+    "id": "ann-sqrt2oq02-nonperfect",
+    "proofId": "sqrt2-minpoly-oq-02",
+    "range": { "startLine": 155, "endLine": 173 },
+    "type": "insight",
+    "title": "Non-Perfect-Power Criterion via p-adic Valuation",
+    "content": "The theorem `not_perfect_power_of_sqfree_factor` gives a useful corollary: if $m$ has a squarefree prime factor, then $m$ is not a perfect $n$-th power.\n\nThe proof is by contradiction: assume $m = k^n$ for some $k \\in \\mathbb{N}$. Since $p \\mid m = k^n$ and $p$ is prime, Euclid's lemma gives $p \\mid k$. Then $p^2 \\mid k^2 \\mid k^n = m$, contradicting $p^2 \\nmid m$.\n\nThe proof uses a clean `calc` chain: `p^2 ∣ k^2` from `pow_dvd_pow_of_dvd`, then `k^2 ∣ k^n` from `Nat.pow_dvd_pow k hn` (since $2 \\leq n$).\n\nThis theorem explains why the Eisenstein condition implies irrationality: if $m^{1/n}$ were rational, then $m^{1/n} = a/b$ in lowest terms, and $(a/b)^n = m$ would give $a^n = b^n m$. The unique factorization argument would then force $b = 1$ (since $a/b$ is in lowest terms and $m$ is an integer), so $m = a^n$, contradicting `not_perfect_power_of_sqfree_factor`.",
+    "mathContext": "The $p$-adic valuation argument: $v_p(m) = 1$ (since $p \\mid m$ but $p^2 \\nmid m$). If $m = k^n$, then $v_p(m) = n \\cdot v_p(k)$. So $n \\cdot v_p(k) = 1$. Since $n \\geq 2$ and $v_p(k) \\in \\mathbb{N}$, this is impossible — the product of two positive integers with one $\\geq 2$ cannot equal 1.\n\nIn Lean, the proof avoids explicitly computing valuations and instead works directly with divisibility.",
+    "significance": "supporting",
+    "relatedConcepts": ["p-adic valuation", "perfect power", "Euclid's lemma", "pow_dvd_pow_of_dvd"],
+    "prerequisites": ["prime factorization", "p-adic valuation", "Euclid's lemma for primes"]
+  },
+  {
+    "id": "ann-sqrt2oq02-examples",
+    "proofId": "sqrt2-minpoly-oq-02",
+    "range": { "startLine": 174, "endLine": 204 },
+    "type": "insight",
+    "title": "Concrete Examples: ∛6, ∛10, ⁵√12, ∜30",
+    "content": "Four concrete applications verify the general theorem for composite (non-prime) numbers, showing the Eisenstein condition applies at different primes:\n\n- **∛6** ($n=3$, $m=6$, $p=2$): $2 \\mid 6$ and $4 \\nmid 6$, so $[\\mathbb{Q}(\\sqrt[3]{6}) : \\mathbb{Q}] = 3$\n- **∛10** ($n=3$, $m=10$, $p=2$): $2 \\mid 10$ and $4 \\nmid 10$, so $[\\mathbb{Q}(\\sqrt[3]{10}) : \\mathbb{Q}] = 3$\n- **⁵√12** ($n=5$, $m=12$, $p=3$): $3 \\mid 12$ and $9 \\nmid 12$, so $[\\mathbb{Q}(\\sqrt[5]{12}) : \\mathbb{Q}] = 5$ — note $p=3$ is used, not $p=2$, since $4 \\mid 12$\n- **∜30** ($n=4$, $m=30$, $p=2$): $2 \\mid 30$ and $4 \\nmid 30$, so $[\\mathbb{Q}(\\sqrt[4]{30}) : \\mathbb{Q}] = 4$\n\nEach proof is just `adjoin_nthRoot_finrank` applied with the right numerical witnesses, closed by `norm_num`. The compactness of these proofs (2 lines each) shows the payoff of the general theorem.",
+    "mathContext": "These examples cover numbers that are **not prime** but still satisfy Eisenstein: $6 = 2 \\cdot 3$, $10 = 2 \\cdot 5$, $12 = 2^2 \\cdot 3$ (Eisenstein at $p=3$, not $p=2$), $30 = 2 \\cdot 3 \\cdot 5$.\n\nFor $m = 4$: Eisenstein at $p=2$ fails ($4 = 2^2$ so $p^2 \\mid m$), and indeed $\\sqrt{4} = 2 \\in \\mathbb{Q}$ — not a degree-2 algebraic number. This shows the condition is not vacuous.",
+    "significance": "supporting",
+    "relatedConcepts": ["concrete applications", "norm_num", "adjoin_nthRoot_finrank", "Eisenstein at composite numbers"],
+    "prerequisites": ["general theorem (adjoin_nthRoot_finrank)", "basic divisibility facts (norm_num)"]
+  }
+]

--- a/src/data/proofs/sqrt2-minpoly-oq-02/meta.json
+++ b/src/data/proofs/sqrt2-minpoly-oq-02/meta.json
@@ -54,9 +54,81 @@
       "The Eisenstein condition at p (p | m but p² ∤ m) is equivalent to: m is not divisible by p to an even power at this prime",
       "This condition implies m is NOT a perfect n-th power: if m = k^n then v_p(m) = n·v_p(k) ≥ 0 or ≥ n, never exactly 1",
       "The proof works uniformly for all n ≥ 2, covering square, cube, fourth, fifth roots, etc.",
-      "The squarefree prime factor condition is NOT necessary — it's sufficient. X² - 8 is also irreducible but not Eisenstein."
+      "The squarefree prime factor condition is NOT necessary — it's sufficient. X² - 8 is also irreducible but not Eisenstein.",
+      "The proof architecture — Eisenstein (ℤ) → Gauss → minimal polynomial → field degree — is a reusable template for any irreducibility argument in algebraic number theory."
     ]
   },
+  "sections": [
+    {
+      "id": "eisenstein-int",
+      "title": "Part I: Eisenstein Criterion for X^n - m",
+      "startLine": 41,
+      "endLine": 95,
+      "summary": "Proves X^n - m is ℤ-irreducible (private) then ℚ-irreducible (public) using Eisenstein at a squarefree prime factor, transferred to ℚ by Gauss's lemma.",
+      "mathContext": "Eisenstein criterion at prime ideal $(p)$: leading coefficient $1 \\notin (p)$, all lower coefficients in $(p)$ (since $p \\mid m$), constant term $\\notin (p)^2$ (since $p^2 \\nmid m$). Gauss's lemma: primitive ℤ-irreducible implies ℚ-irreducible."
+    },
+    {
+      "id": "root-integral",
+      "title": "Part II: Root Identity and Integrality",
+      "startLine": 96,
+      "endLine": 111,
+      "summary": "Proves (m^(1/n))^n = m (root identity) and that m^(1/n) is integral over ℚ (needed for minimal polynomial theory).",
+      "mathContext": "$(m^{1/n})^n = m$ via `Real.rpow_mul`. Integrality: $m^{1/n}$ satisfies the monic polynomial $X^n - m \\in \\mathbb{Q}[X]$."
+    },
+    {
+      "id": "minpoly",
+      "title": "Part III: Minimal Polynomial Identification",
+      "startLine": 113,
+      "endLine": 131,
+      "summary": "Identifies minpoly ℚ (m^(1/n)) = X^n - m using the irreducibility + monic + root-witness characterization.",
+      "mathContext": "`minpoly.eq_of_irreducible_of_monic`: an irreducible monic polynomial with $\\alpha$ as a root equals $\\mathrm{minpoly}(F, \\alpha)$."
+    },
+    {
+      "id": "degree",
+      "title": "Part IV: Algebraic and Field Extension Degrees",
+      "startLine": 133,
+      "endLine": 153,
+      "summary": "Derives natDegree(minpoly) = n and the field extension degree [ℚ(m^(1/n)) : ℚ] = n.",
+      "mathContext": "`IntermediateField.adjoin.finrank`: for integral $\\alpha$, $[F(\\alpha) : F] = \\deg(\\mathrm{minpoly}(F, \\alpha))$."
+    },
+    {
+      "id": "nonperfect",
+      "title": "Part V: Non-Perfect-Power Criterion",
+      "startLine": 155,
+      "endLine": 173,
+      "summary": "Proves m is not a perfect n-th power when m has a squarefree prime factor, via a clean p-divisibility argument.",
+      "mathContext": "If $m = k^n$ and $p \\mid m$, then $p \\mid k$, so $p^2 \\mid k^2 \\mid k^n = m$, contradicting $p^2 \\nmid m$."
+    },
+    {
+      "id": "examples",
+      "title": "Part VI: Concrete Applications",
+      "startLine": 174,
+      "endLine": 204,
+      "summary": "Four example applications: ∛6, ∛10, ⁵√12, ∜30, each proved in 2 lines via norm_num witnesses.",
+      "mathContext": "All four use `adjoin_nthRoot_finrank` with explicit numerical prime witnesses verified by `norm_num`."
+    }
+  ],
+  "conclusion": {
+    "summary": "A complete formalization of the general Eisenstein minimal polynomial theorem: for any $n \\geq 2$ and $m > 0$ with a squarefree prime factor $p$, the minimal polynomial of $m^{1/n}$ over $\\mathbb{Q}$ is exactly $X^n - m$. This yields the field extension degree $[\\mathbb{Q}(m^{1/n}) : \\mathbb{Q}] = n$ and confirms $m^{1/n}$ is irrational (in fact of algebraic degree $n$) as a corollary. The proof is 204 lines, 0 sorries, 0 axioms, applying Eisenstein → Gauss → minimal polynomial → field degree in a clean pipeline.",
+    "implications": "**Irrational roots**: Any $m^{1/n}$ with $m$ satisfying the squarefree condition is irrational — it has algebraic degree $n \\geq 2$ over $\\mathbb{Q}$, so it is not rational (degree 1).\n\n**Reusable template**: The proof architecture (Eisenstein over ℤ, Gauss's lemma, `minpoly.eq_of_irreducible_of_monic`, `adjoin.finrank`) is the standard approach in algebraic number theory for proving degree bounds on radical extensions. This formalization serves as a reference implementation.\n\n**Galois theory connection**: These radical extensions $\\mathbb{Q}(m^{1/n})/\\mathbb{Q}$ have Galois group $\\mathbb{Z}/n\\mathbb{Z}$ when $\\mathbb{Q}$ contains the $n$-th roots of unity, and $S_n$-subgroups otherwise. The degree computation here is the first step toward understanding the Galois structure.",
+    "openQuestions": [
+      "Prove the converse direction: if $X^n - m$ is irreducible over $\\mathbb{Q}$, does $m$ always have a squarefree prime factor? (The answer is yes by a p-adic valuation argument, but requires a complete characterization of Eisenstein-type irreducibility.)",
+      "Formalize the case $n = 2$, $m = 8$: $X^2 - 8$ is irreducible (since $\\sqrt{8} = 2\\sqrt{2} \\notin \\mathbb{Q}$) but the standard Eisenstein criterion at $p=2$ fails ($4 \\mid 8$). A substitution $X \\mapsto X+1$ makes it Eisenstein, or use a different approach.",
+      "Extend to splitting fields: prove that the splitting field of $X^n - m$ over $\\mathbb{Q}$ has degree $n \\cdot \\phi(n)$ over $\\mathbb{Q}$ (where $\\phi$ is Euler's totient), generalizing the degree theorem to include the cyclotomic part."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cube-root-2-irrational",
+      "relationship": "generalizes",
+      "description": "The cube root 2 irrationality result (minpoly ℚ (∛2) = X³ - 2) is the n=3, m=2 special case of this general theorem"
+    },
+    {
+      "targetId": "sqrt2-minpoly",
+      "relationship": "generalizes",
+      "description": "The square root 2 minimal polynomial (X² - 2) is the n=2, m=2 special case"
+    }
+  ],
   "mainTheorems": [
     {
       "name": "CubeRoot2IrrationalOQ03.minpoly_nthRoot_eq",


### PR DESCRIPTION
Enrichment pass for `sqrt2-minpoly-oq-02` (quality: 15 → target 80+, passes: 0).

## Quality Improvements

### annotations.json (empty → 8 rich annotations)
- **Module setup**: Eisenstein motivation, squarefree prime factor condition explained
- **Eisenstein over ℤ** (private theorem): all 5 Eisenstein conditions spelled out with LaTeX
- **Gauss's lemma**: ℤ → ℚ irreducibility transfer explained; `convert + simp` closure
- **Root identity and integrality**: `Real.rpow_mul` chain and `IsIntegral` construction
- **Main minpoly theorem**: `minpoly.eq_of_irreducible_of_monic` characterization
- **Degree results**: algebraic degree = field extension degree via `adjoin.finrank`
- **Non-perfect-power criterion**: p-adic valuation argument via calc divisibility chain
- **Concrete examples**: ∛6, ∛10, ⁵√12, ∜30 with Eisenstein witnesses explained

### meta.json additions
- **6 sections** added (matching the file's 6 parts), each with `mathContext`
- **conclusion** added: summary, mathematical implications (irrationality, reusable template, Galois theory connection), 3 open questions
- **crossReferences** added: links to cube-root-2-irrational and sqrt2-minpoly entries
- **5th keyInsight**: the Eisenstein→Gauss→minpoly→finrank pipeline as a reusable template

## Verification
- `pnpm build` passes (exit 0)
- No changes to Lean proof files
- Axiom integrity: 0 axioms, 0 sorries confirmed