### PR TITLE
Fix: Erdos83Aristotle — prove all 5 routine sorries

### DIFF
--- a/proofs/Proofs/Stubs/Erdos83Aristotle.lean
+++ b/proofs/Proofs/Stubs/Erdos83Aristotle.lean
@@ -10,12 +10,12 @@
   - No definition sorries
   - No axioms
 
-  Included targets (5):
-  - is_zero_intersecting: isTIntersecting F 0 always holds
-  - isKUniform_empty: isKUniform ∅ k for any k
-  - isTIntersecting_mono: t-intersecting implies j-intersecting for j ≤ t
-  - isTIntersecting_singleton: singleton family is t-intersecting for any t ≤ k
-  - isKUniform_card_bound: isKUniform F k → F.card ≤ (Finset.univ.powerset).card
+  Included targets (5) — all proved:
+  - is_zero_intersecting: isTIntersecting F 0 (Nat.zero_le)
+  - isKUniform_empty: isKUniform ∅ k (vacuously true)
+  - isTIntersecting_mono: t-intersecting → j-intersecting for j ≤ t (Nat.le_trans)
+  - isTIntersecting_singleton: singleton {S} is t-intersecting for t ≤ |S| (inter_self)
+  - isTIntersecting_empty: isTIntersecting ∅ t (vacuously true)
 -/
 import Mathlib
 
@@ -33,32 +33,40 @@ def isTIntersecting {α : Type*} [DecidableEq α] (F : Finset (Finset α)) (t : 
 -- The intersection of any two sets has card ≥ 0.
 theorem is_zero_intersecting {α : Type*} [DecidableEq α] (F : Finset (Finset α)) :
     isTIntersecting F 0 := by
-  sorry
+  intro A _ B _
+  exact Nat.zero_le _
 
 -- Routine: the empty family is k-uniform for any k.
 -- Vacuously true since ∅ has no members.
 theorem isKUniform_empty {α : Type*} [DecidableEq α] (k : ℕ) :
     isKUniform (∅ : Finset (Finset α)) k := by
-  sorry
+  intro A h
+  exact absurd h (Finset.not_mem_empty _)
 
 -- Routine: t-intersecting implies j-intersecting for j ≤ t.
 -- If every pair intersects in ≥ t elements, they intersect in ≥ j elements too.
 theorem isTIntersecting_mono {α : Type*} [DecidableEq α]
     (F : Finset (Finset α)) (j t : ℕ) (hjt : j ≤ t) (h : isTIntersecting F t) :
     isTIntersecting F j := by
-  sorry
+  intro A hA B hB
+  exact Nat.le_trans hjt (h A hA B hB)
 
 -- Routine: a singleton family {S} is t-intersecting for t ≤ S.card.
 -- S ∩ S = S, so card ≥ t whenever |S| ≥ t.
 theorem isTIntersecting_singleton {α : Type*} [DecidableEq α]
     (S : Finset α) (t : ℕ) (ht : t ≤ S.card) :
     isTIntersecting ({S} : Finset (Finset α)) t := by
-  sorry
+  intro A hA B hB
+  rw [Finset.mem_singleton] at hA hB
+  subst hA; subst hB
+  simp only [Finset.inter_self]
+  exact ht
 
 -- Routine: the empty family is t-intersecting for any t.
 -- Vacuously true.
 theorem isTIntersecting_empty {α : Type*} [DecidableEq α] (t : ℕ) :
     isTIntersecting (∅ : Finset (Finset α)) t := by
-  sorry
+  intro A h
+  exact absurd h (Finset.not_mem_empty _)
 
 end Erdos83Aristotle


### PR DESCRIPTION
## Summary
- Cherry-picked from #11539 (rebased onto current main to resolve conflicts)
- Proves all 5 routine sorries in Erdos83Aristotle companion file

Supersedes #11539 (old branch had spurious conflicts from ancient base commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)