### PR TITLE
Fix: correct badge from 'original' to 'wip' for sqrt2-plus-sqrt3-irrational-oq-03

### DIFF
--- a/src/data/proofs/sqrt2-plus-sqrt3-irrational-oq-03/meta.json
+++ b/src/data/proofs/sqrt2-plus-sqrt3-irrational-oq-03/meta.json
@@ -15,7 +15,7 @@
       "irreducibility",
       "square-roots"
     ],
-    "badge": "original",
+    "badge": "wip",
     "sorries": 1,
     "dateAdded": "2026-04-22",
     "axiomCount": 0,


### PR DESCRIPTION
## Fix

Corrects the `badge` field in `meta.json` from `"original"` to `"wip"` for the `sqrt2-plus-sqrt3-irrational-oq-03` gallery entry.

## Evidence

**Before**: `badge: "original"` — implies fully machine-checked with 0 sorries, 0 axioms
**After**: `badge: "wip"` — correctly reflects that the proof has 1 remaining sorry (irreducibility of X⁴−10X²+1 over ℚ)

The `original` badge is reserved for `verified` proofs (0 sorries, 0 axioms). Per gallery conventions, proofs with `status: "formalized"` and remaining sorries should use `badge: "wip"`. This was the only entry in the gallery with the `original/formalized` combination.

Note: a companion Aristotle file for this sorry was submitted in PR #11538. Once Aristotle resolves the irreducibility sorry, the badge can be upgraded back to `original`.

---
Automated fix by lean-mechanic agent.