### PR TITLE
chore: add audit tracker records for sqrt2-minpoly-oq-01 and oq-02

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12522,6 +12522,18 @@
       "lastAudited": "2026-04-22T19:22:02Z",
       "result": "issues-found"
     },
+    "sqrt2-minpoly-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-04-22T22:35:04Z",
+      "result": "clean"
+    },
+    "sqrt2-minpoly-oq-02": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-22T22:41:55Z",
+      "result": "clean"
+    },
     "sqrt2-plus-sqrt3-irrational": {
       "auditCount": 4,
       "issues": [],


### PR DESCRIPTION
Supersedes #11544 (had merge conflicts).

The meta.json change from that PR was already on main (PR #11554 fixed the badge earlier). This cherry-picks only the unique audit tracker additions:
- `sqrt2-minpoly-oq-01`: auditCount 1, clean
- `sqrt2-minpoly-oq-02`: auditCount 2, clean