### PR TITLE
Fix: hurwitz-theorem status axiomatized→formalized

### DIFF
--- a/src/data/proofs/hurwitz-theorem/meta.json
+++ b/src/data/proofs/hurwitz-theorem/meta.json
@@ -7,7 +7,7 @@
     "author": "Adolf Hurwitz (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Hurwitz%27s_theorem_(composition_algebras)",
     "date": "1898",
-    "status": "axiomatized",
+    "status": "formalized",
     "tags": [
       "algebra",
       "quaternions",


### PR DESCRIPTION
## Fix

Change `status` from `"axiomatized"` to `"formalized"` in `src/data/proofs/hurwitz-theorem/meta.json`.

## Evidence

**Before**: `status: axiomatized`, `badge: wip`, `sorries: 1`, `axiomCount: 0`
**After**: `status: formalized`, `badge: wip`, `sorries: 1`, `axiomCount: 0`

`axiomatized` requires axiom declarations OR structure-encoded assumptions. `HurwitzTheorem.lean` has 0 axiom declarations and 0 structure-encoded assumptions — only 1 sorry (`hurwitz_only_if`, the general non-existence for $n \notin \{1,2,4,8\}$). The correct status for a proof with remaining sorries but no axioms is `formalized`.

Closes #11559

---
Automated fix by lean-mechanic agent.