### PR TITLE
feat(aristotle): prove all 5 routine sorries in Erdos104Aristotle

### DIFF
--- a/proofs/Proofs/Stubs/Erdos104Aristotle.lean
+++ b/proofs/Proofs/Stubs/Erdos104Aristotle.lean
@@ -1,0 +1,62 @@
+/-
+  Aristotle targets for Erdős Problem #104
+  Routine supporting lemmas for automated proof search.
+  See Stubs/Erdos104Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the open conjecture (o(n²) unit circles with 3+ points)
+  - NOT theorems depending on axiomatized background results
+  - Routine geometric distance facts and membership facts
+  - No definition sorries
+  - No axioms
+
+  Included targets (5):
+  - dist_nonneg: dist p q ≥ 0
+  - dist_self: dist p p = 0
+  - dist_comm: dist p q = dist q p
+  - circle_contains_zero: CircleContainsKPoints c P 0 (trivially)
+  - filter_le_card: (P.filter ...).card ≤ P.card
+-/
+import Mathlib
+
+namespace Erdos104Aristotle
+
+open Finset
+
+abbrev Point := EuclideanSpace ℝ (Fin 2)
+
+noncomputable def dist' (p q : Point) : ℝ := ‖p - q‖
+
+structure UnitCircle where
+  center : Point
+
+def OnCircle (p : Point) (c : UnitCircle) : Prop := dist' p c.center = 1
+
+-- Routine: dist' is nonneg.
+-- The norm of any vector is nonneg.
+theorem dist_nonneg (p q : Point) : dist' p q ≥ 0 := by
+  sorry
+
+-- Routine: dist' to self is 0.
+-- ‖p - p‖ = ‖0‖ = 0.
+theorem dist_self (p : Point) : dist' p p = 0 := by
+  sorry
+
+-- Routine: dist' is symmetric.
+-- ‖p - q‖ = ‖-(q - p)‖ = ‖q - p‖.
+theorem dist_comm (p q : Point) : dist' p q = dist' q p := by
+  sorry
+
+-- Routine: 0 points on any circle (trivially).
+-- 0 ≤ card of any filter.
+theorem circle_contains_zero (c : UnitCircle) (P : Finset Point) :
+    0 ≤ (P.filter fun p => dist' p c.center = 1).card := by
+  sorry
+
+-- Routine: filter count is at most total count.
+-- Finset.card_filter_le.
+theorem filter_le_card (P : Finset Point) (c : UnitCircle) :
+    (P.filter fun p => dist' p c.center = 1).card ≤ P.card := by
+  sorry
+
+end Erdos104Aristotle

--- a/proofs/Proofs/Stubs/Erdos104Aristotle.lean
+++ b/proofs/Proofs/Stubs/Erdos104Aristotle.lean
@@ -34,29 +34,29 @@ def OnCircle (p : Point) (c : UnitCircle) : Prop := dist' p c.center = 1
 
 -- Routine: dist' is nonneg.
 -- The norm of any vector is nonneg.
-theorem dist_nonneg (p q : Point) : dist' p q ≥ 0 := by
-  sorry
+theorem dist_nonneg (p q : Point) : dist' p q ≥ 0 :=
+  norm_nonneg _
 
 -- Routine: dist' to self is 0.
 -- ‖p - p‖ = ‖0‖ = 0.
 theorem dist_self (p : Point) : dist' p p = 0 := by
-  sorry
+  simp [dist', sub_self]
 
 -- Routine: dist' is symmetric.
 -- ‖p - q‖ = ‖-(q - p)‖ = ‖q - p‖.
 theorem dist_comm (p q : Point) : dist' p q = dist' q p := by
-  sorry
+  simp [dist', norm_sub_rev]
 
 -- Routine: 0 points on any circle (trivially).
 -- 0 ≤ card of any filter.
 theorem circle_contains_zero (c : UnitCircle) (P : Finset Point) :
-    0 ≤ (P.filter fun p => dist' p c.center = 1).card := by
-  sorry
+    0 ≤ (P.filter fun p => dist' p c.center = 1).card :=
+  Nat.zero_le _
 
 -- Routine: filter count is at most total count.
 -- Finset.card_filter_le.
 theorem filter_le_card (P : Finset Point) (c : UnitCircle) :
-    (P.filter fun p => dist' p c.center = 1).card ≤ P.card := by
-  sorry
+    (P.filter fun p => dist' p c.center = 1).card ≤ P.card :=
+  Finset.card_filter_le _ _
 
 end Erdos104Aristotle


### PR DESCRIPTION
## Fix

Proves all 5 remaining sorries in `proofs/Proofs/Stubs/Erdos104Aristotle.lean`.

## Evidence

| Theorem | Proof |
|---------|-------|
| `dist_nonneg` | `norm_nonneg _` |
| `dist_self` | `simp [dist', sub_self]` |
| `dist_comm` | `simp [dist', norm_sub_rev]` |
| `circle_contains_zero` | `Nat.zero_le _` |
| `filter_le_card` | `Finset.card_filter_le _ _` |

---
Automated fix by lean-mechanic agent.