### PR TITLE
feat(aristotle): prove 4 of 5 routine sorries in Erdos107Aristotle

### DIFF
--- a/proofs/Proofs/Stubs/Erdos107Aristotle.lean
+++ b/proofs/Proofs/Stubs/Erdos107Aristotle.lean
@@ -1,0 +1,75 @@
+/-
+  Aristotle targets for Erdős Problem #107 (Happy Ending / Erdős–Szekeres)
+  Routine supporting lemmas for automated proof search.
+  See Stubs/Erdos107Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the open conjecture (f(n) = 2^(n-2) + 1)
+  - NOT theorems from axiomatized bounds (ersz, suk, hmpt)
+  - Routine finset and convex position facts
+  - No definition sorries
+  - No axioms
+
+  Included targets (5):
+  - isConvexNGon_card: IsConvexNGon n S → S.card = n
+  - hasConvexNGon_of_superset: HasConvexNGon n S and S ⊆ T → HasConvexNGon n T
+  - f_ge_three: f 3 ≥ 3 (need at least 3 points for a triangle)
+  - cardSet_nonempty: (CardSet n).Nonempty for n ≥ 3
+  - inGeneralPosition_subset: general position is hereditary under subsets
+-/
+import Mathlib
+
+namespace Erdos107Aristotle
+
+open Finset
+
+abbrev Point := EuclideanSpace ℝ (Fin 2)
+
+def InGeneralPosition (S : Set Point) : Prop :=
+  ∀ p q r : Point, p ∈ S → q ∈ S → r ∈ S →
+    p ≠ q → q ≠ r → p ≠ r →
+    ¬AffineIndependent ℝ ![p, q, r] → False
+
+def IsConvexNGon (n : ℕ) (S : Finset Point) : Prop :=
+  S.card = n ∧
+  ∀ p ∈ S, p ∉ convexHull ℝ (S.erase p : Set Point)
+
+def HasConvexNGon (n : ℕ) (S : Finset Point) : Prop :=
+  ∃ T : Finset Point, T ⊆ S ∧ IsConvexNGon n T
+
+def CardSet (n : ℕ) : Set ℕ :=
+  {m : ℕ | ∀ S : Finset Point, S.card = m →
+    InGeneralPosition (S : Set Point) → HasConvexNGon n S}
+
+-- Routine: IsConvexNGon implies card = n.
+-- By definition of IsConvexNGon.
+theorem isConvexNGon_card (n : ℕ) (S : Finset Point) (h : IsConvexNGon n S) :
+    S.card = n := by
+  sorry
+
+-- Routine: HasConvexNGon is upward-closed.
+-- If T ⊆ S has an n-gon and S ⊆ U, then U has an n-gon too.
+theorem hasConvexNGon_of_superset (n : ℕ) (S T : Finset Point)
+    (hST : S ⊆ T) (hS : HasConvexNGon n S) : HasConvexNGon n T := by
+  sorry
+
+-- Routine: InGeneralPosition is hereditary.
+-- A subset of a general position set is in general position.
+theorem inGeneralPosition_subset (S T : Finset Point)
+    (hST : S ⊆ T) (hT : InGeneralPosition (T : Set Point)) :
+    InGeneralPosition (S : Set Point) := by
+  sorry
+
+-- Routine: HasConvexNGon 1 holds for any nonempty Finset.
+-- A single point is trivially a 1-gon.
+theorem hasConvexNGon_one (S : Finset Point) (hS : S.Nonempty) :
+    HasConvexNGon 1 S := by
+  sorry
+
+-- Routine: HasConvexNGon is monotone in n downward.
+-- If S contains an n-gon and m ≤ n, it contains an m-gon.
+theorem hasConvexNGon_mono (m n : ℕ) (hmn : m ≤ n) (S : Finset Point)
+    (h : HasConvexNGon n S) : HasConvexNGon m S := by
+  sorry
+
+end Erdos107Aristotle

--- a/proofs/Proofs/Stubs/Erdos107Aristotle.lean
+++ b/proofs/Proofs/Stubs/Erdos107Aristotle.lean
@@ -44,27 +44,33 @@ def CardSet (n : ℕ) : Set ℕ :=
 -- Routine: IsConvexNGon implies card = n.
 -- By definition of IsConvexNGon.
 theorem isConvexNGon_card (n : ℕ) (S : Finset Point) (h : IsConvexNGon n S) :
-    S.card = n := by
-  sorry
+    S.card = n :=
+  h.1
 
 -- Routine: HasConvexNGon is upward-closed.
 -- If T ⊆ S has an n-gon and S ⊆ U, then U has an n-gon too.
 theorem hasConvexNGon_of_superset (n : ℕ) (S T : Finset Point)
     (hST : S ⊆ T) (hS : HasConvexNGon n S) : HasConvexNGon n T := by
-  sorry
+  obtain ⟨T', hT'S, hT'⟩ := hS
+  exact ⟨T', hT'S.trans hST, hT'⟩
 
 -- Routine: InGeneralPosition is hereditary.
 -- A subset of a general position set is in general position.
 theorem inGeneralPosition_subset (S T : Finset Point)
     (hST : S ⊆ T) (hT : InGeneralPosition (T : Set Point)) :
-    InGeneralPosition (S : Set Point) := by
-  sorry
+    InGeneralPosition (S : Set Point) :=
+  fun p q r hp hq hr hpq hqr hpr h =>
+    hT p q r (hST hp) (hST hq) (hST hr) hpq hqr hpr h
 
 -- Routine: HasConvexNGon 1 holds for any nonempty Finset.
 -- A single point is trivially a 1-gon.
 theorem hasConvexNGon_one (S : Finset Point) (hS : S.Nonempty) :
     HasConvexNGon 1 S := by
-  sorry
+  obtain ⟨p, hp⟩ := hS
+  refine ⟨{p}, Finset.singleton_subset_iff.mpr hp, Finset.card_singleton p, ?_⟩
+  intro q hq
+  rw [Finset.mem_singleton] at hq; subst hq
+  simp [convexHull_empty]
 
 -- Routine: HasConvexNGon is monotone in n downward.
 -- If S contains an n-gon and m ≤ n, it contains an m-gon.


### PR DESCRIPTION
## Fix

Proves 4 of 5 remaining sorries in `proofs/Proofs/Stubs/Erdos107Aristotle.lean`.

## Evidence

| Theorem | Proof |
|---------|-------|
| `isConvexNGon_card` | `h.1` (first field of the conjunction) |
| `hasConvexNGon_of_superset` | `hT'S.trans hST` (subset transitivity) |
| `inGeneralPosition_subset` | `hST hp/hq/hr` (membership propagation) |
| `hasConvexNGon_one` | Singleton `{p} ⊆ S`; `convexHull ∅ = ∅` |

**`hasConvexNGon_mono`** (left as sorry): Showing that an m-element subset of a convex n-gon is itself in convex position requires geometric reasoning (convex position is hereditary under vertex subsets of a convex polygon), which is non-trivial to formalize from Mathlib primitives.

---
Automated fix by lean-mechanic agent.