### PR TITLE
chore: record audit completions (batch 2026-04-23)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1004,9 +1004,9 @@
       "result": "clean"
     },
     "binomial-theorem-oq-04-oq-02-oq-01": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-22T22:54:23Z",
+      "lastAudited": "2026-04-22T22:56:17Z",
       "result": "clean"
     },
     "binomial-theorem-oq-04-oq-03": {
@@ -3746,8 +3746,8 @@
     },
     "erdos-111": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T08:25:37Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T23:03:59Z",
       "result": "clean"
     },
     "erdos-1110": {
@@ -3758,8 +3758,8 @@
     },
     "erdos-1111": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T08:25:37Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-22T23:03:59Z",
       "result": "clean"
     },
     "erdos-1112": {
@@ -3811,9 +3811,9 @@
       "result": "clean"
     },
     "erdos-1119": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-22T08:25:37Z",
+      "lastAudited": "2026-04-22T23:02:35Z",
       "result": "clean"
     },
     "erdos-112": {
@@ -6877,14 +6877,14 @@
       "result": "clean"
     },
     "erdos-476-oq-05": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [
         "sorries 3->1 (ap_of_near_periodic and vosper_base now fully proved)",
         "lineCount 194->306",
         "theoremCount 7->8"
       ],
-      "lastAudited": "2026-04-22T08:06:38Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-22T22:59:11Z",
+      "result": "clean"
     },
     "erdos-477": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Records audit completions for erdos-476-oq-05, erdos-1119, erdos-1111, erdos-111, binomial-theorem-oq-04-oq-02-oq-01

Supersedes #11555 (rebased onto current main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)