### PR TITLE
Fix: sync stale lineCount in erdos-268, area-of-circle-oq-05-oq-02, feuerbachs-theorem-defs-oq-04

### DIFF
--- a/src/data/proofs/area-of-circle-oq-05-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-02/meta.json
@@ -29,7 +29,7 @@
       "multivariate_gaussian_integral: complete proof — spectral decomposition (eigenvectorUnitary), quadratic form reduction, orthogonal change of variables via map_linearMap_volume_pi_eq_smul_volume_pi (|det Uᵀ| = 1), reduced to diagonal_gaussian"
     ],
     "dateAdded": "2026-04-21",
-    "lineCount": 138,
+    "lineCount": 189,
     "theoremCount": 3,
     "definitionCount": 0,
     "mathlib_version": "4.26.0"

--- a/src/data/proofs/erdos-268/meta.json
+++ b/src/data/proofs/erdos-268/meta.json
@@ -57,7 +57,7 @@
       "Concrete examples: squares (Basel problem) and powers of 2 (geometric series)"
     ],
     "axiomCount": 1,
-    "lineCount": 762,
+    "lineCount": 943,
     "assumptions": "1 axiom: erdos_268_solved (main interior result for all dimensions). 1 sorry remaining: inside harmonicPointSet_path_connected — d ≥ 2 path-connectedness (Kovač-Tao structural analysis; hard topology). Proved: shifted_summable (decomposition at n=0), harmonicPointSet_nonempty (powers-of-2 witness), harmonicPointSet_dense_somewhere (directly from interior axiom), coordinate_decreasing (tsum_lt_tsum; requires 0 ∉ A), first_coordinate_largest (from coordinate_decreasing), squares_convergent (bijection + p-series), powers_convergent (bijection + geometric series), d=1 case of path_connected (proved via research commit)."
   },
   "overview": {

--- a/src/data/proofs/feuerbachs-theorem-defs-oq-04/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-04/meta.json
@@ -22,7 +22,7 @@
     "dateAdded": "2026-04-22",
     "axiomCount": 0,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries. Inherits from FeuerbachsTheoremDefs.lean which is also 0-sorry.",
-    "lineCount": 155,
+    "lineCount": 190,
     "theoremCount": 12,
     "definitionCount": 1,
     "originalContributions": [
@@ -125,7 +125,7 @@
     "imports": ["Mathlib", "Proofs.FeuerbachsTheoremDefs"],
     "opens": ["FeuerbachsTheorem", "Real", "EuclideanGeometry"],
     "namespace": "FeuerbachsTheoremDefsOQ04",
-    "lineCount": 155,
+    "lineCount": 190,
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 1,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` fields in 3 gallery proof meta.json files after recent research commits updated the Lean source files without updating metadata.

## Evidence

| Proof | Before | After | Cause |
|-------|--------|-------|-------|
| erdos-268 | 762 | 943 | Sessions 4+5 added lines (#11460, #11504) |
| area-of-circle-oq-05-oq-02 | 138 | 189 | Enrichment added sections/annotations |
| feuerbachs-theorem-defs-oq-04 | 155 | 190 | Feuerbach bridge PR (#11480) |

All three proofs are otherwise clean (correct sorry/axiom counts, correct badge/status).

---
Automated fix by lean-mechanic agent.