### PR TITLE
feat(aristotle): prove all 5 routine sorries in Erdos97Aristotle

### DIFF
--- a/proofs/Proofs/Stubs/Erdos97Aristotle.lean
+++ b/proofs/Proofs/Stubs/Erdos97Aristotle.lean
@@ -29,29 +29,29 @@ noncomputable def dist' (p q : Point) : ℝ := ‖p - q‖
 
 -- Routine: dist' is nonneg.
 -- The norm of any vector is nonneg.
-theorem dist'_nonneg (p q : Point) : dist' p q ≥ 0 := by
-  sorry
+theorem dist'_nonneg (p q : Point) : dist' p q ≥ 0 :=
+  norm_nonneg _
 
 -- Routine: dist' to self is 0.
 -- ‖p - p‖ = ‖0‖ = 0.
 theorem dist'_self (p : Point) : dist' p p = 0 := by
-  sorry
+  simp [dist', sub_self]
 
 -- Routine: dist' is symmetric.
 -- ‖p - q‖ = ‖q - p‖ since ‖-v‖ = ‖v‖.
 theorem dist'_comm (p q : Point) : dist' p q = dist' q p := by
-  sorry
+  simp [dist', norm_sub_rev]
 
 -- Routine: 0-equidistant is vacuously true.
 -- Any p in any set A has 0 ≤ card of any filter.
 theorem hasKEquidistant_zero (A : Finset Point) (p : Point) :
-    ∃ r : ℝ, r > 0 ∧ 0 ≤ (A.filter fun q => dist' p q = r).card := by
-  sorry
+    ∃ r : ℝ, r > 0 ∧ 0 ≤ (A.filter fun q => dist' p q = r).card :=
+  ⟨1, one_pos, Nat.zero_le _⟩
 
 -- Routine: filter card ≤ card of original finset.
 -- Standard Finset.card_filter_le.
 theorem filter_card_le (A : Finset Point) (r : ℝ) (p : Point) :
-    (A.filter fun q => dist' p q = r).card ≤ A.card := by
-  sorry
+    (A.filter fun q => dist' p q = r).card ≤ A.card :=
+  Finset.card_filter_le _ _
 
 end Erdos97Aristotle


### PR DESCRIPTION
## Fix

Proves all 5 routine sorry targets in `Erdos97Aristotle.lean` (Erdős Problem #97: equidistant points in the plane).

## Evidence

**Before**: 5 `sorry` placeholders in theorem bodies
**After**: All 5 proved using standard Mathlib lemmas

| Theorem | Proof |
|---------|-------|
| `dist'_nonneg` | `norm_nonneg _` |
| `dist'_self` | `simp [dist', sub_self]` |
| `dist'_comm` | `simp [dist', norm_sub_rev]` |
| `hasKEquidistant_zero` | `⟨1, one_pos, Nat.zero_le _⟩` |
| `filter_card_le` | `Finset.card_filter_le _ _` |

---
Automated fix by lean-mechanic agent.