### PR TITLE
Fix: yang-mills-transfer-matrix axiomCount corrected (12→1)

### DIFF
--- a/src/data/proofs/yang-mills-transfer-matrix/meta.json
+++ b/src/data/proofs/yang-mills-transfer-matrix/meta.json
@@ -18,8 +18,8 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 12,
-    "assumptions": "1 explicit axiom (gaugeTransform from YangMills/Classical.lean) plus 11 structure-encoded assumptions typed as True in peripheral illustrative structures: (1) SlavnovTaylorIdentity.ward_identity_holds (line 2454), (2) RegulatorProperties.suppresses_ir (line 12746), (3) RegulatorProperties.grows_at_uv (line 12748), (4) GaugeInvariantObs.gaugeInvariant (line 15986), (5) FradkinShenker.analytic (line 16035), (6) CMHypotheses.finiteSpectrum (line 16760), (7) CMHypotheses.nontrivialScattering (line 16762), (8) CMHypotheses.analyticity (line 16764), (9) BRSTChargeCohom.conservation (line 17248), (10) BRSTChargeCohom.nilpotent (line 17250), (11) AsymptoticSafety.beta_vanishes (line 17606). Note: the core mass gap proof (finite_volume_gap_positive) depends only on the TransferMatrix, LatticeTransferMatrix, and PerronFrobeniusData structures, not on these peripheral illustrative structures. The True-typed fields represent simplified placeholders for advanced QFT hypotheses not involved in the main mass gap proof path.",
+    "axiomCount": 1,
+    "assumptions": "1 explicit axiom: gaugeTransform (YangMills/Classical.lean line 126). Additionally, 11 structure fields typed as ': True' in peripheral illustrative structures (SlavnovTaylorIdentity, RegulatorProperties, GaugeInvariantObs, FradkinShenker, CMHypotheses, BRSTChargeCohom, AsymptoticSafety) — these are trivially satisfied placeholders (provable by 'trivial') that carry no mathematical content and do not constitute real assumptions. The core mass gap proof (finite_volume_gap_positive) depends only on TransferMatrix, LatticeTransferMatrix, and PerronFrobeniusData structures, none of which use True-typed fields.",
     "lineCount": 28075,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Fix

Corrects `axiomCount` for `yang-mills-transfer-matrix` from 12 to 1.

## Evidence

**Before**: `axiomCount: 12` (1 real axiom + 11 `: True` structure fields incorrectly counted)
**After**: `axiomCount: 1` (only the real `gaugeTransform` axiom in `YangMills/Classical.lean`)

The 11 `: True`-typed structure fields (`ward_identity_holds`, `suppresses_ir`, `grows_at_uv`, etc.) in peripheral illustrative structures are trivially satisfied placeholders — any instance satisfies them with `trivial`. They carry no mathematical content and do not constitute real assumptions per the project's Axiom Integrity Policy.

The core mass gap proof (`finite_volume_gap_positive`) depends only on `TransferMatrix`, `LatticeTransferMatrix`, and `PerronFrobeniusData` structures — none of which use `: True` fields.

The `assumptions` text is updated to clearly document this distinction.

Closes #11563

---
Automated fix by lean-mechanic agent.