### PR TITLE
Enrich sqrt2-minpoly-oq-01: 7 annotations, sections, conclusion, crossReferences

### DIFF
--- a/src/data/proofs/sqrt2-minpoly-oq-01/annotations.json
+++ b/src/data/proofs/sqrt2-minpoly-oq-01/annotations.json
@@ -1,1 +1,86 @@
-[]
+[
+  {
+    "id": "ann-sqrt2oq01-setup",
+    "proofId": "sqrt2-minpoly-oq-01",
+    "range": { "startLine": 1, "endLine": 32 },
+    "type": "context",
+    "title": "Setup: Building on the General nth-Root Infrastructure",
+    "content": "This file builds directly on `CubeRoot2IrrationalOQ03` (the general $n$-th root minimal polynomial theorem), specializing it to $n=2$. The `open CubeRoot2IrrationalOQ03` import brings in the general infrastructure: `minpoly_nthRoot_eq`, `adjoin_nthRoot_finrank`, `natDegree_X_pow_sub_nat_eq`, and `not_perfect_power_of_sqfree_factor`.\n\nThe key new challenge is that Mathlib has two representations for square roots:\n- `Real.sqrt n` — the standard square root API\n- `(n : ℝ) ^ ((1 : ℝ) / 2)` — the `rpow` representation used by `CubeRoot2IrrationalOQ03`\n\nThis file bridges these representations with a simple private lemma before applying the general theory.",
+    "mathContext": "Two equivalent representations in Mathlib: $\\sqrt{n} = \\texttt{Real.sqrt}\\,n$ and $n^{1/2} = (n : \\mathbb{R})^{(1/2 : \\mathbb{R})}$ (via `Real.rpow`). The bridge: `Real.sqrt_eq_rpow` states $\\sqrt{x} = x^{1/2}$ for $x \\geq 0$. After combining with `norm_cast` to handle the `(2 : ℕ)` coercion, these two APIs become interchangeable.",
+    "significance": "context",
+    "relatedConcepts": ["Real.sqrt", "Real.rpow", "CubeRoot2IrrationalOQ03", "squarefree numbers"],
+    "prerequisites": ["square root in Lean 4", "rpow vs sqrt API distinction", "CubeRoot2IrrationalOQ03 theorems"]
+  },
+  {
+    "id": "ann-sqrt2oq01-bridge",
+    "proofId": "sqrt2-minpoly-oq-01",
+    "range": { "startLine": 34, "endLine": 41 },
+    "type": "technique",
+    "title": "sqrt_eq_rpow_nat: Bridging Two Square Root APIs",
+    "content": "The private lemma `sqrt_eq_rpow_nat` proves `Real.sqrt n = (n : ℝ) ^ ((1 : ℝ) / (2 : ℕ))`. The proof is two tactics: `Real.sqrt_eq_rpow` rewrites `Real.sqrt n = (n : ℝ) ^ (1/2 : ℝ)`, and `norm_cast` handles the coercion from the division `(1 : ℝ) / (2 : ℕ)` to `(1 : ℝ) / (2 : ℝ)`.\n\nThis bridge is essential because `minpoly_nthRoot_eq` works with `rpow` (via `m ^ ((1 : ℝ) / n)`), while all of Mathlib's `Real.sqrt` lemmas work with the dedicated `Real.sqrt` function. The two are definitionally equal for non-negative reals, but Lean's type checker needs explicit rewriting.",
+    "mathContext": "For $x \\geq 0$: $\\texttt{Real.sqrt}\\,x = x^{1/2}$ where $x^{1/2} = \\exp(\\frac{1}{2} \\log x)$ (the `rpow` definition). The `norm_cast` handles: `(1 : ℝ) / (2 : ℕ) = (1 : ℝ) / (2 : ℝ)` since `(2 : ℕ) : ℝ = 2`.",
+    "significance": "supporting",
+    "relatedConcepts": ["Real.sqrt_eq_rpow", "norm_cast", "coercion", "rpow definition"],
+    "prerequisites": ["Real.sqrt in Mathlib", "real power function", "norm_cast tactic"]
+  },
+  {
+    "id": "ann-sqrt2oq01-main",
+    "proofId": "sqrt2-minpoly-oq-01",
+    "range": { "startLine": 43, "endLine": 55 },
+    "type": "theorem",
+    "title": "Main Theorem: minpoly ℚ (√n) = X² - n",
+    "content": "The main theorem `minpoly_sqrt_of_sqfree_factor` proves `minpoly ℚ (Real.sqrt n) = X² - n` when $n$ has a prime $p$ with $p \\mid n$ but $p^2 \\nmid n$. The proof is two lines:\n1. `rw [sqrt_eq_rpow_nat]`: rewrite the goal from `Real.sqrt n` to `n ^ (1/2)` form\n2. Apply `minpoly_nthRoot_eq 2 n p` from the imported OQ03 infrastructure, with `by norm_num` to discharge the `2 ≤ 2` hypothesis\n\nThe `.symm` is needed because `minpoly_nthRoot_eq` returns `X^n - C m = minpoly ...` (polynomial on the left), while the goal has `minpoly ...` on the left.\n\nThis is the cleanest possible proof: one rewrite and one application of the general theory.",
+    "mathContext": "**Theorem**: If $\\exists$ prime $p$ with $p \\mid n$ and $p^2 \\nmid n$, then $\\text{minpoly}(\\mathbb{Q}, \\sqrt{n}) = X^2 - n$.\n\nThis means $\\sqrt{n}$ has:\n- Algebraic degree 2 over $\\mathbb{Q}$\n- Minimal polynomial $X^2 - n$ (irreducible over $\\mathbb{Q}$)\n- $\\sqrt{n} \\notin \\mathbb{Q}$ (since $\\deg(\\text{minpoly}) = 2 > 1$)",
+    "significance": "key",
+    "relatedConcepts": ["minpoly", "Eisenstein criterion", "irreducibility", "algebraic degree 2"],
+    "prerequisites": ["CubeRoot2IrrationalOQ03.minpoly_nthRoot_eq", "sqrt_eq_rpow_nat bridge"]
+  },
+  {
+    "id": "ann-sqrt2oq01-squarefree",
+    "proofId": "sqrt2-minpoly-oq-01",
+    "range": { "startLine": 56, "endLine": 72 },
+    "type": "insight",
+    "title": "Squarefree Corollary: √n is Irrational for All Squarefree n ≥ 2",
+    "content": "The squarefree corollary `minpoly_sqrt_of_squarefree` handles the important special case where $n$ is squarefree (no perfect square greater than 1 divides $n$).\n\nThe key step is extracting a squarefree prime factor from a squarefree number. For squarefree $n \\geq 2$:\n1. `Nat.exists_prime_and_dvd` gives a prime $p \\mid n$ (any prime factor)\n2. `Nat.squarefree_iff_prime_squarefree.mp hsf p hp` gives $p^2 \\nmid n$ (since squarefree means no prime square divides it)\n3. Apply `minpoly_sqrt_of_sqfree_factor`\n\nThe private lemma `squarefree_has_prime_sqfree_factor` packages this into a reusable `obtain` pattern. The `rwa [sq]` at the end rewrites `p * p` to `p^2` for the hypothesis format.",
+    "mathContext": "A natural number $n$ is **squarefree** if $p^2 \\nmid n$ for every prime $p$ — equivalently, each prime appears at most once in the factorization of $n$. Squarefree numbers: 1, 2, 3, 5, 6, 7, 10, 11, 13, 14, 15, 17, ...\n\nFor squarefree $n \\geq 2$: $n$ has a prime factor $p$ (since $n > 1$), and $p^2 \\nmid n$ by squarefreeness. So the Eisenstein condition holds automatically. Therefore $\\sqrt{n} \\notin \\mathbb{Q}$ for ALL squarefree $n \\geq 2$.",
+    "significance": "key",
+    "relatedConcepts": ["squarefree numbers", "Nat.squarefree_iff_prime_squarefree", "Nat.exists_prime_and_dvd", "irrationality"],
+    "prerequisites": ["squarefree definition", "prime factorization", "Eisenstein condition"]
+  },
+  {
+    "id": "ann-sqrt2oq01-degree",
+    "proofId": "sqrt2-minpoly-oq-01",
+    "range": { "startLine": 74, "endLine": 88 },
+    "type": "theorem",
+    "title": "Degree 2: Algebraic Degree and Field Extension Degree",
+    "content": "Two corollaries give quantitative dimension results for $\\mathbb{Q}(\\sqrt{n})/\\mathbb{Q}$:\n\n**Algebraic degree 2** (`minpoly_sqrt_natDegree`): `(minpoly ℚ (Real.sqrt n)).natDegree = 2`. Proved by rewriting with the main theorem and then applying `natDegree_X_pow_sub_nat_eq`.\n\n**Field extension degree 2** (`adjoin_sqrt_finrank`): `Module.finrank ℚ ℚ⟮Real.sqrt n⟯ = 2`. The proof rewrites `Real.sqrt n` to the rpow form (via `sqrt_eq_rpow_nat`) and then applies the OQ03 infrastructure's `adjoin_nthRoot_finrank 2 n p`.\n\nThese results together say: $\\{1, \\sqrt{n}\\}$ is a $\\mathbb{Q}$-basis of $\\mathbb{Q}(\\sqrt{n})$, and $[\\mathbb{Q}(\\sqrt{n}) : \\mathbb{Q}] = 2$.",
+    "mathContext": "The tower law: $[\\mathbb{Q}(\\sqrt{n}) : \\mathbb{Q}] = \\deg(\\text{minpoly}(\\mathbb{Q}, \\sqrt{n})) = 2$.\n\nThis means every element of $\\mathbb{Q}(\\sqrt{n})$ can be written uniquely as $a + b\\sqrt{n}$ with $a, b \\in \\mathbb{Q}$. The ring $\\mathbb{Q}(\\sqrt{n}) = \\{a + b\\sqrt{n} : a, b \\in \\mathbb{Q}\\}$ is the prototypical quadratic field extension.",
+    "significance": "key",
+    "relatedConcepts": ["Module.finrank", "IntermediateField.adjoin", "quadratic field extension", "field degree"],
+    "prerequisites": ["linear algebra over fields", "field extension degree", "algebraic degree"]
+  },
+  {
+    "id": "ann-sqrt2oq01-nonsquare",
+    "proofId": "sqrt2-minpoly-oq-01",
+    "range": { "startLine": 90, "endLine": 99 },
+    "type": "insight",
+    "title": "Non-Perfect-Square: Squarefree Prime Factor Implies Not a Perfect Square",
+    "content": "The theorem `not_perfect_square_of_sqfree_factor` is an immediate corollary of the OQ03 result `not_perfect_power_of_sqfree_factor` specialized to $n=2$. It says: if $p \\mid m$ but $p^2 \\nmid m$, then $m$ is not a perfect square.\n\nThis connects the Eisenstein condition to number-theoretic irrationality: $\\sqrt{m}$ is rational iff $m$ is a perfect square ($\\sqrt{m} \\in \\mathbb{Q} \\iff m = k^2$ for some $k \\in \\mathbb{N}$). Since the Eisenstein condition prevents $m$ from being a perfect square, it directly forces $\\sqrt{m} \\notin \\mathbb{Q}$.\n\nThe proof is one line: delegate to `not_perfect_power_of_sqfree_factor 2 n p`.",
+    "mathContext": "**Irrationality via degree**: $\\sqrt{n} \\in \\mathbb{Q} \\iff [\\mathbb{Q}(\\sqrt{n}) : \\mathbb{Q}] = 1 \\iff \\deg(\\text{minpoly}) = 1$. Since we proved $\\deg = 2$, we get $\\sqrt{n} \\notin \\mathbb{Q}$.\n\n**Direct criterion**: $m$ is a perfect square $\\iff$ $v_p(m)$ is even for all primes $p$. The Eisenstein condition ($v_p(m) = 1$ at some prime) makes $m$ a non-square.",
+    "significance": "supporting",
+    "relatedConcepts": ["perfect square", "irrationality", "not_perfect_power_of_sqfree_factor", "p-adic valuation"],
+    "prerequisites": ["irrationality criterion", "perfect square definition", "OQ03 non-perfect-power theorem"]
+  },
+  {
+    "id": "ann-sqrt2oq01-examples",
+    "proofId": "sqrt2-minpoly-oq-01",
+    "range": { "startLine": 102, "endLine": 136 },
+    "type": "insight",
+    "title": "Eight Concrete Examples: √2 through √20",
+    "content": "Eight concrete applications verify the minimal polynomial for standard irrational square roots:\n- **√2**: $p=2$, $2 \\mid 2$, $4 \\nmid 2$ → minpoly = $X^2 - 2$\n- **√3**: $p=3$, $3 \\mid 3$, $9 \\nmid 3$ → minpoly = $X^2 - 3$\n- **√5**: $p=5$, $5 \\mid 5$, $25 \\nmid 5$ → minpoly = $X^2 - 5$\n- **√6**: $p=2$, $2 \\mid 6$, $4 \\nmid 6$ → minpoly = $X^2 - 6$ (non-prime)\n- **√7, √10**: similar squarefree cases\n- **√12**: $p=3$, $3 \\mid 12$, $9 \\nmid 12$ → minpoly = $X^2 - 12$ (note: $p=2$ fails since $4 \\mid 12$)\n- **√20**: $p=5$, $5 \\mid 20$, $25 \\nmid 20$ → minpoly = $X^2 - 20$\n\nThe inclusion of $n=12$ and $n=20$ (non-squarefree numbers) shows the theorem extends beyond squarefree numbers. Each proof is a single-line application of `minpoly_sqrt_of_sqfree_factor` with explicit prime witnesses closed by `norm_num`.",
+    "mathContext": "Note the different behaviors: $\\sqrt{4} = 2 \\in \\mathbb{Q}$ (perfect square, no squarefree prime factor), $\\sqrt{8} = 2\\sqrt{2} \\notin \\mathbb{Q}$ (Eisenstein fails at $p=2$ since $4 \\mid 8$, but holds at... wait, $8 = 2^3$, so $p=2$: $2 \\mid 8$ but $4 \\mid 8$, AND $8$ has no other prime factors. The theorem doesn't apply here! But $\\sqrt{8}$ is indeed irrational — it requires a different argument.)",
+    "significance": "supporting",
+    "relatedConcepts": ["concrete verification", "norm_num", "squarefree vs. non-squarefree examples"],
+    "prerequisites": ["minpoly_sqrt_of_sqfree_factor", "divisibility facts (norm_num)"]
+  }
+]

--- a/src/data/proofs/sqrt2-minpoly-oq-01/meta.json
+++ b/src/data/proofs/sqrt2-minpoly-oq-01/meta.json
@@ -56,9 +56,86 @@
       "Real.sqrt_eq_rpow bridges the gap between Mathlib's Real.sqrt API and the general rpow-based nth-root theory",
       "The Eisenstein condition (p | n but p² ∤ n) is equivalent to n having an odd prime factor valuation, which covers all non-perfect-squares with squarefree part",
       "Squarefree n ≥ 2 automatically satisfies the Eisenstein condition at any prime factor",
-      "The proof reuses CubeRoot2IrrationalOQ03's general infrastructure, specializing to degree 2"
+      "The proof reuses CubeRoot2IrrationalOQ03's general infrastructure, specializing to degree 2",
+      "The examples show the Eisenstein condition applies to non-squarefree numbers too (√12 at p=3, √20 at p=5), but fails for n=8 (a pure prime power where all prime valuations are ≥ 2). This subtlety requires care when applying the theorem."
     ]
   },
+  "sections": [
+    {
+      "id": "bridge",
+      "title": "Part I: Bridging Real.sqrt and rpow",
+      "startLine": 34,
+      "endLine": 41,
+      "summary": "Private lemma sqrt_eq_rpow_nat: Real.sqrt n = n^(1/2) as rpow, bridging the two Mathlib square root APIs.",
+      "mathContext": "`Real.sqrt_eq_rpow` + `norm_cast` converts between `Real.sqrt n` and `(n : ℝ) ^ ((1 : ℝ) / 2)`, enabling use of the general OQ03 infrastructure."
+    },
+    {
+      "id": "main-theorem",
+      "title": "Part II: Main Theorem — Squarefree Prime Factor Condition",
+      "startLine": 43,
+      "endLine": 55,
+      "summary": "Proves minpoly ℚ (√n) = X² - n when n has a prime p with p | n but p² ∤ n, by rewriting with the bridge lemma and applying the OQ03 general theorem.",
+      "mathContext": "`minpoly_nthRoot_eq 2 n p`: the degree-2 specialization. Two-line proof: rewrite sqrt → rpow, then exact the general theorem."
+    },
+    {
+      "id": "squarefree-corollary",
+      "title": "Part III: Squarefree Corollary",
+      "startLine": 56,
+      "endLine": 72,
+      "summary": "For squarefree n ≥ 2, extracts a squarefree prime factor via Nat.squarefree_iff_prime_squarefree and applies the main theorem.",
+      "mathContext": "Squarefree $\\Rightarrow$ any prime factor $p$ satisfies $p^2 \\nmid n$ \\Rightarrow$ Eisenstein condition holds. Uses `Nat.exists_prime_and_dvd` and `Nat.squarefree_iff_prime_squarefree`."
+    },
+    {
+      "id": "degree-results",
+      "title": "Part IV: Algebraic Degree and Field Extension Degree",
+      "startLine": 74,
+      "endLine": 88,
+      "summary": "Derives natDegree(minpoly ℚ (√n)) = 2 and [ℚ(√n) : ℚ] = 2 as corollaries.",
+      "mathContext": "`adjoin_nthRoot_finrank 2 n p`: the degree-2 field extension result. `{1, √n}` is a ℚ-basis of ℚ(√n)."
+    },
+    {
+      "id": "non-square",
+      "title": "Part V: Non-Perfect-Square Corollary",
+      "startLine": 90,
+      "endLine": 99,
+      "summary": "Squarefree prime factor condition implies n is not a perfect square, delegating to the OQ03 not_perfect_power result.",
+      "mathContext": "Specializes `not_perfect_power_of_sqfree_factor 2 n p` to the $k=2$ case. Connects Eisenstein condition to number-theoretic non-squareness."
+    },
+    {
+      "id": "examples",
+      "title": "Part VI: Concrete Examples",
+      "startLine": 102,
+      "endLine": 136,
+      "summary": "Eight explicit minimal polynomial theorems: √2, √3, √5, √6, √7, √10, √12, √20.",
+      "mathContext": "Each proof: `minpoly_sqrt_of_sqfree_factor n p (by norm_num) ...`. Note √12 uses p=3 (not p=2 since 4|12), √20 uses p=5 (not p=2 since 4|20)."
+    }
+  ],
+  "conclusion": {
+    "summary": "A complete Lean 4 formalization proving that `minpoly ℚ (Real.sqrt n) = X² - n` for any natural number $n$ with a squarefree prime factor, covering all squarefree $n \\geq 2$ as a corollary. The 136-line file reuses the OQ03 general infrastructure, adding only the API bridge between `Real.sqrt` and `rpow` and the squarefree factor extraction lemma. Eight concrete examples (√2, √3, √5, √6, √7, √10, √12, √20) are verified with 0 sorries and 0 axioms.",
+    "implications": "**Irrationality library**: This file, together with `sqrt2-minpoly-oq-02`, provides a complete Lean 4 library for proving irrationality of roots of the form $m^{1/n}$ via Eisenstein. Any irrational square root $\\sqrt{n}$ (with $n$ having a squarefree prime factor) can now be proved irrational in two lines.\n\n**Quadratic field extensions**: The result $[\\mathbb{Q}(\\sqrt{n}) : \\mathbb{Q}] = 2$ is the foundation of quadratic field theory. It confirms that $\\mathbb{Q}(\\sqrt{n})$ is a degree-2 extension, a necessary input for class field theory, quadratic reciprocity, and the arithmetic of quadratic number fields.\n\n**Modular arithmetic connection**: For squarefree $n$, the structure of $\\mathbb{Z}[\\sqrt{n}]$ (integers of the quadratic field) depends on $n \\bmod 4$: if $n \\equiv 1 \\pmod{4}$ then the ring of integers is $\\mathbb{Z}[(1+\\sqrt{n})/2]$; otherwise it is $\\mathbb{Z}[\\sqrt{n}]$. This file establishes the base case needed for this classification.",
+    "openQuestions": [
+      "Characterize exactly which n give `minpoly ℚ (Real.sqrt n) = X² - n`: the condition 'p | n but p² ∤ n for some prime p' covers all non-perfect-squares with odd p-adic valuation at some prime, but n=8 (a perfect power) requires different tools.",
+      "Prove that `Real.sqrt n` is irrational for all non-perfect-squares n using a different approach (e.g., unique factorization in ℤ) and show equivalence with the Eisenstein approach formalized here.",
+      "Extend to `minpoly ℚ (Real.sqrt (p/q)) = q·X² - p` for rational p/q, covering the irrationality of square roots of rationals."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "sqrt2-minpoly",
+      "relationship": "generalizes",
+      "description": "The √2 irrationality result is the n=2 special case; this file proves minpoly ℚ (√n) = X²-n for all n with a squarefree prime factor"
+    },
+    {
+      "targetId": "sqrt2-minpoly-oq-02",
+      "relationship": "sibling",
+      "description": "OQ-02 proves the same for general n-th roots (m^(1/n)); this OQ-01 specializes to square roots (n=2) with a simpler bridge lemma"
+    },
+    {
+      "targetId": "cube-root-2-irrational",
+      "relationship": "related",
+      "description": "The cube root case (minpoly ℚ (∛2) = X³ - 2) uses the same Eisenstein infrastructure; this file reuses the n=3 result's general form"
+    }
+  ],
   "mainTheorems": [
     {
       "name": "Sqrt2MinpolyOQ01.minpoly_sqrt_of_sqfree_factor",


### PR DESCRIPTION
Enrichment pass for `sqrt2-minpoly-oq-01` (quality: 18 → target 80+, passes: 0).

## Quality Improvements

### annotations.json (empty → 7 rich annotations)
- **Module setup**: OQ03 dependency explained, two sqrt API representations contrasted
- **sqrt_eq_rpow_nat bridge**: why `Real.sqrt` vs `rpow` is a Lean distinction, not math
- **Main theorem**: two-line proof walkthrough with `.symm` explained
- **Squarefree corollary**: `Nat.squarefree_iff_prime_squarefree` + `exists_prime_and_dvd` pattern
- **Degree results**: `{1, √n}` as ℚ-basis, tower law connection
- **Non-perfect-square**: Eisenstein → not a perfect square explained
- **Examples**: all 8 examples including edge cases (√12 uses p=3, not p=2; √8 would fail)

### meta.json additions
- **6 sections** added matching the 6 parts of the Lean file
- **conclusion** added: summary + 3 implications (irrationality library, quadratic fields, modular arithmetic) + 3 open questions
- **crossReferences** added: sqrt2-minpoly (specializes from), sqrt2-minpoly-oq-02 (sibling), cube-root-2-irrational (related)
- **5th keyInsight**: Eisenstein edge case for non-squarefree numbers (√12/√20 OK, √8 fails)

## Verification
- `pnpm build` passes (exit 0)
- No changes to Lean proof files
- Axiom integrity: 0 axioms, 0 sorries confirmed