### PR TITLE
Enrich triangle-angle-sum-oq-03: 6 annotations, sections, conclusion

### DIFF
--- a/src/data/proofs/triangle-angle-sum-oq-03/annotations.json
+++ b/src/data/proofs/triangle-angle-sum-oq-03/annotations.json
@@ -1,1 +1,74 @@
-[]
+[
+  {
+    "id": "ann-tasq03-setup",
+    "proofId": "triangle-angle-sum-oq-03",
+    "range": { "startLine": 1, "endLine": 52 },
+    "type": "context",
+    "title": "Module Setup: Mathlib's Angle Convention and the Degenerate Story",
+    "content": "The module header reveals a surprising mathematical fact: Mathlib's `EuclideanGeometry.angle_add_angle_add_angle_eq_pi` requires only ONE non-degeneracy hypothesis (`p₂ ≠ p₁`), not two. This means the gallery's standard `triangle_angle_sum` proof carried an unnecessary hypothesis `h₃ : p₃ ≠ p₁`.\n\nThe reason is Mathlib's convention for degenerate angles: `∠ p₀ p₀ p = π/2` when the first argument equals the vertex (zero direction vector → `arccos(0/0) = arccos(0) = π/2`). This 'right angle for degenerate directions' convention makes the angle function total and analytic, and it has the elegant consequence that the angle sum formula extends to almost all configurations.\n\nThe imports are minimal: `Mathlib.Geometry.Euclidean.Triangle` for `angle_add_angle_add_angle_eq_pi`, and `Mathlib.Geometry.Euclidean.Angle.Unoriented.Affine` for the degenerate angle lemmas. The variable block sets up an abstract inner product space over ℝ, so the results apply to any Euclidean space, not just ℝ².",
+    "mathContext": "**Mathlib angle function**: $\\angle\\, p_1\\, p_2\\, p_3 := \\texttt{InnerProductGeometry.angle}\\,(p_1 - p_2)\\,(p_3 - p_2)$ where $\\text{angle}\\, u\\, v = \\arccos\\frac{\\langle u, v \\rangle}{\\|u\\|\\|v\\|}$ with the convention $\\frac{0}{0} = 0$, so $\\arccos(0) = \\pi/2$ when either $u = 0$ or $v = 0$.\n\n**Degenerate conventions**: $\\angle\\,p_0\\,p_0\\,p = \\pi/2$ (left arg = vertex), $\\angle\\,p\\,p_0\\,p_0 = \\pi/2$ (right arg = vertex), $\\angle\\,p\\,p_0\\,p = 0$ for $p \\neq p_0$ (same non-vertex args).",
+    "significance": "context",
+    "relatedConcepts": ["EuclideanGeometry.angle", "InnerProductGeometry.angle", "degenerate angles", "arccos convention"],
+    "prerequisites": ["inner product spaces", "Euclidean geometry in Mathlib", "angle function definition"]
+  },
+  {
+    "id": "ann-tasq03-one-cond",
+    "proofId": "triangle-angle-sum-oq-03",
+    "range": { "startLine": 53, "endLine": 63 },
+    "type": "insight",
+    "title": "One-Condition Theorem: Only p₂ ≠ p₁ Is Needed",
+    "content": "The theorem `triangle_angle_sum_one_cond` is a one-line wrapper around Mathlib's `angle_add_angle_add_angle_eq_pi`, exposing the fact that **only one** non-degeneracy condition is required: `p₂ ≠ p₁`.\n\nThe Mathlib signature is `angle_add_angle_add_angle_eq_pi (p₃ : P) (h : p₂ ≠ p₁)` — notice that `p₃` is an unrestricted universally quantified argument, not a hypothesis. This means the theorem holds for ANY position of `p₃`, including `p₃ = p₁`, `p₃ = p₂`, or any collinear configuration.\n\nThe implication: if we only know `p₂ ≠ p₁` (but nothing about `p₃`), the angle sum is still exactly π. The gallery's original `triangle_angle_sum` required BOTH `p₂ ≠ p₁` AND `p₃ ≠ p₁`, making it strictly weaker than this theorem.",
+    "mathContext": "**Mathlib theorem** `angle_add_angle_add_angle_eq_pi`: For any point $p_3$ and any $p_1 \\neq p_2$ (equivalently $p_2 \\neq p_1$), $\\angle\\,p_1\\,p_2\\,p_3 + \\angle\\,p_2\\,p_3\\,p_1 + \\angle\\,p_3\\,p_1\\,p_2 = \\pi$.\n\nNote the cyclic symmetry of the three angles: each is the angle at a different vertex of the triangle configuration. The theorem is proved for any normed add torsor over an inner product space, so it applies to $\\mathbb{R}^n$ for all $n \\geq 1$.",
+    "significance": "key",
+    "relatedConcepts": ["angle_add_angle_add_angle_eq_pi", "redundant hypothesis", "normed add torsor"],
+    "prerequisites": ["EuclideanGeometry.angle definition", "triangle angle sum theorem"]
+  },
+  {
+    "id": "ann-tasq03-p2-eq-p1",
+    "proofId": "triangle-angle-sum-oq-03",
+    "range": { "startLine": 65, "endLine": 77 },
+    "type": "technique",
+    "title": "Degenerate Case: p₂ = p₁ with p₃ ≠ p₁ Still Gives Sum = π",
+    "content": "When `p₂ = p₁` (the vertex and one endpoint coincide), Mathlib's one-condition theorem no longer applies. But the angle sum is STILL π, as proved by `triangle_angle_sum_p2_eq_p1`.\n\nThe proof explicitly computes the three angles when `p₂ = p₁` and `p₃ ≠ p₁`:\n- `∠ p₁ p₂ p₃ = ∠ p₁ p₁ p₃ = π/2` — first arg equals vertex → `angle_self_left`\n- `∠ p₂ p₃ p₁ = ∠ p₁ p₃ p₁ = 0` — first equals third ≠ vertex → `angle_self_of_ne h₃.symm`\n- `∠ p₃ p₁ p₂ = ∠ p₃ p₁ p₁ = π/2` — third arg equals vertex → `angle_self_right`\n\nSum: π/2 + 0 + π/2 = π. The `simp only` with these three lemmas reduces the goal to `π/2 + π/2 = π`, closed by `linarith [Real.pi_pos]`.",
+    "mathContext": "Angle computation when $p_2 = p_1$ and $p_3 \\neq p_1$:\n$$\\angle\\,p_1\\,p_1\\,p_3 = \\frac{\\pi}{2} \\quad (\\text{left degenerate: } p_1 - p_1 = 0)$$\n$$\\angle\\,p_1\\,p_3\\,p_1 = 0 \\quad (\\text{same non-vertex: } \\arccos(1) = 0, \\text{ using } p_3 \\neq p_1)$$\n$$\\angle\\,p_3\\,p_1\\,p_1 = \\frac{\\pi}{2} \\quad (\\text{right degenerate: } p_1 - p_1 = 0)$$\n$$\\text{Sum} = \\frac{\\pi}{2} + 0 + \\frac{\\pi}{2} = \\pi$$",
+    "significance": "key",
+    "relatedConcepts": ["angle_self_left", "angle_self_right", "angle_self_of_ne", "degenerate triangle"],
+    "prerequisites": ["Mathlib degenerate angle conventions", "simp tactic with angle lemmas"]
+  },
+  {
+    "id": "ann-tasq03-fully-degenerate",
+    "proofId": "triangle-angle-sum-oq-03",
+    "range": { "startLine": 79, "endLine": 92 },
+    "type": "insight",
+    "title": "Fully Degenerate: All Three Points Equal Gives Sum = 3π/2",
+    "content": "When all three points coincide (`p₂ = p₁` AND `p₃ = p₁`), all three angles equal π/2 by Mathlib's degenerate convention, giving a sum of 3π/2. This is the UNIQUE exception to the angle sum formula.\n\nThe proof by `simp only [h₂, h₃]` reduces the goal to `∠ p₁ p₁ p₁ + ∠ p₁ p₁ p₁ + ∠ p₁ p₁ p₁ = 3π/2`. Then `linarith [EuclideanGeometry.angle_self_left p₁ p₁]` uses `∠ p₁ p₁ p₁ = π/2` to close.\n\nThe corollary `angle_self_self_self` packages this as `∠ p p p = π/2` — each degenerate self-angle is a right angle. This is perhaps the most geometrically surprising consequence of Mathlib's convention: a 'point triangle' has angles of 90° each, totaling 270°.",
+    "mathContext": "The exceptional case: when $p_1 = p_2 = p_3$, all three angle terms are $\\angle\\,p\\,p\\,p = \\pi/2$, giving:\n$$\\angle\\,p_1\\,p_2\\,p_3 + \\angle\\,p_2\\,p_3\\,p_1 + \\angle\\,p_3\\,p_1\\,p_2 = \\frac{\\pi}{2} + \\frac{\\pi}{2} + \\frac{\\pi}{2} = \\frac{3\\pi}{2}$$\n\nThis is the angle sum of a 'degenerate triangle' with all vertices at one point. Compare with the spherical geometry angle sum excess formula: on a sphere, $\\sum \\text{angles} = \\pi + \\text{excess} > \\pi$. Here the Euclidean sum overshoots π in the fully degenerate case.",
+    "significance": "key",
+    "relatedConcepts": ["angle_self_left", "fully degenerate triangle", "angle sum excess", "Mathlib convention"],
+    "prerequisites": ["Mathlib angle convention for zero vectors", "pi arithmetic via linarith"]
+  },
+  {
+    "id": "ann-tasq03-characterization",
+    "proofId": "triangle-angle-sum-oq-03",
+    "range": { "startLine": 94, "endLine": 114 },
+    "type": "theorem",
+    "title": "Complete Biconditional: Sum = π ↔ Not Fully Degenerate",
+    "content": "The theorem `triangle_angle_sum_iff_not_fully_degenerate` gives the complete characterization: the angle sum equals π if and only if NOT both `p₂ = p₁` AND `p₃ = p₁`.\n\n**Forward direction** (contrapositive): if the sum is π and both equalities hold, then combining with the fully degenerate case (sum = 3π/2) gives `π = 3π/2`, contradicting `pi_pos`.\n\n**Backward direction**: split on `h₂ : p₂ = p₁`:\n- If `p₂ ≠ p₁`: use `angle_add_angle_add_angle_eq_pi` directly\n- If `p₂ = p₁`: then `p₃ ≠ p₁` follows from `¬(p₂ = p₁ ∧ p₃ = p₁)`, so apply `triangle_angle_sum_p2_eq_p1`\n\nThe `by_cases` tactic on `p₂ = p₁` uses `Classical.em` (hence `open Classical` at the top), avoiding a `DecidableEq` typeclass requirement.",
+    "mathContext": "**Complete characterization**: $\\angle\\,p_1\\,p_2\\,p_3 + \\angle\\,p_2\\,p_3\\,p_1 + \\angle\\,p_3\\,p_1\\,p_2 = \\pi \\iff \\lnot(p_2 = p_1 \\land p_3 = p_1)$\n\nEquivalently: sum $= \\pi$ iff at least one of $\\{p_2 \\neq p_1, p_3 \\neq p_1\\}$ holds. The exceptional configuration has measure zero in any Euclidean space: it's a single point in $P \\times P \\times P$.",
+    "significance": "key",
+    "relatedConcepts": ["biconditional", "Classical.em", "by_cases", "contrapositive proof"],
+    "prerequisites": ["triangle_angle_sum_p2_eq_p1", "triangle_angle_sum_fully_degenerate", "linarith with pi_pos"]
+  },
+  {
+    "id": "ann-tasq03-unconditional",
+    "proofId": "triangle-angle-sum-oq-03",
+    "range": { "startLine": 116, "endLine": 140 },
+    "type": "insight",
+    "title": "Unconditional Formula: A Single if-then-else Expression",
+    "content": "The theorem `triangle_angle_sum_unconditional` expresses the angle sum formula without any hypotheses, using an if-then-else:\n\n```\n∠ p₁ p₂ p₃ + ... = if p₂ = p₁ ∧ p₃ = p₁ then 3π/2 else π\n```\n\nThis is the most general form of the theorem — it works for ALL inputs without any `h : p₂ ≠ p₁` hypothesis. The proof uses `Classical.em (p₂ = p₁ ∧ p₃ = p₁)` to split and delegates each branch to the previously proved theorems.\n\nThe two concrete `example` computations verify the formula in `EuclideanSpace ℝ (Fin 2)` (concrete 2D Euclidean space), confirming the degenerate angle conventions hold in the familiar setting.",
+    "mathContext": "The unconditional statement: for ANY $p_1, p_2, p_3 \\in P$ (in any Euclidean space):\n$$\\angle\\,p_1\\,p_2\\,p_3 + \\angle\\,p_2\\,p_3\\,p_1 + \\angle\\,p_3\\,p_1\\,p_2 = \\begin{cases} \\frac{3\\pi}{2} & \\text{if } p_1 = p_2 = p_3 \\\\ \\pi & \\text{otherwise} \\end{cases}$$\n\nThis is a total function on $P^3$ with no side conditions — the angle function and the angle sum are both total.",
+    "significance": "supporting",
+    "relatedConcepts": ["total function", "if-then-else", "Classical.em", "EuclideanSpace ℝ (Fin 2)"],
+    "prerequisites": ["triangle_angle_sum_iff_not_fully_degenerate", "triangle_angle_sum_fully_degenerate"]
+  }
+]

--- a/src/data/proofs/triangle-angle-sum-oq-03/meta.json
+++ b/src/data/proofs/triangle-angle-sum-oq-03/meta.json
@@ -58,9 +58,76 @@
       "The Mathlib angle sum theorem requires ONLY p₂ ≠ p₁, making h₃ : p₃ ≠ p₁ redundant in the standard gallery proof",
       "Mathlib convention: angle(0, v) = arccos(0/0) = arccos(0) = π/2 (degenerate direction → right angle)",
       "The exceptional configuration (all three points equal) gives sum = 3π/2 = three right angles",
-      "The formula fails ONLY when both non-degeneracy conditions fail simultaneously, not when one fails"
+      "The formula fails ONLY when both non-degeneracy conditions fail simultaneously, not when one fails",
+      "The `open Classical` at the top is load-bearing: `by_cases h₂ : p₂ = p₁` in the biconditional proof uses `Classical.em`, avoiding a `DecidableEq P` typeclass requirement that would restrict the theorem to types with decidable equality."
     ]
   },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Module Setup and Angle Conventions",
+      "startLine": 1,
+      "endLine": 52,
+      "summary": "Imports, namespace, variable setup, and docstring explaining the degenerate angle conventions and the redundant hypothesis discovery.",
+      "mathContext": "Key degenerate angle lemmas: `angle_self_left`: $\\angle p_0 p_0 p = \\pi/2$; `angle_self_right`: $\\angle p p_0 p_0 = \\pi/2$; `angle_self_of_ne`: $\\angle p p_0 p = 0$ when $p \\neq p_0$."
+    },
+    {
+      "id": "one-condition",
+      "title": "One-Condition Theorem",
+      "startLine": 53,
+      "endLine": 63,
+      "summary": "Direct corollary of Mathlib's angle_add_angle_add_angle_eq_pi: only p₂ ≠ p₁ is needed.",
+      "mathContext": "One-line proof: `EuclideanGeometry.angle_add_angle_add_angle_eq_pi p₃ h`. Shows the gallery's original h₃ hypothesis was never needed."
+    },
+    {
+      "id": "p2-eq-p1",
+      "title": "Degenerate Case: p₂ = p₁, p₃ ≠ p₁",
+      "startLine": 65,
+      "endLine": 77,
+      "summary": "When p₂ = p₁ but p₃ ≠ p₁, explicit angle computation (π/2, 0, π/2) shows the sum is still π.",
+      "mathContext": "$\\angle p_1 p_1 p_3 = \\pi/2$ + $\\angle p_1 p_3 p_1 = 0$ + $\\angle p_3 p_1 p_1 = \\pi/2 = \\pi$. Proved by `simp` with angle_self_left/right/of_ne + linarith."
+    },
+    {
+      "id": "fully-degenerate",
+      "title": "Fully Degenerate Case: All Three Points Equal",
+      "startLine": 79,
+      "endLine": 92,
+      "summary": "When p₁ = p₂ = p₃, all angles are π/2 giving sum = 3π/2 — the unique exception to the angle sum formula.",
+      "mathContext": "$\\angle p p p = \\pi/2$ by `angle_self_left`. Sum $= 3 \\cdot (\\pi/2) = 3\\pi/2$. Proved by `simp [h₂, h₃]` + `linarith [angle_self_left p₁ p₁]`."
+    },
+    {
+      "id": "characterization",
+      "title": "Complete Biconditional Characterization",
+      "startLine": 94,
+      "endLine": 114,
+      "summary": "Main result: angle sum = π ↔ ¬(p₂ = p₁ ∧ p₃ = p₁). Proved by by_cases on p₂ = p₁ using Classical.em.",
+      "mathContext": "Backward direction: `by_cases h₂ : p₂ = p₁` splits into two cases — `p₂ ≠ p₁` → Mathlib theorem, `p₂ = p₁` → extract `p₃ ≠ p₁` from the hypothesis and apply degenerate case."
+    },
+    {
+      "id": "unconditional",
+      "title": "Unconditional Formula and Concrete Verification",
+      "startLine": 116,
+      "endLine": 140,
+      "summary": "Total angle sum formula as if-then-else with no hypotheses, plus two concrete examples in EuclideanSpace ℝ (Fin 2).",
+      "mathContext": "Sum $= $ `if p₂ = p₁ ∧ p₃ = p₁ then 3π/2 else π`. Verified concretely for the self-angle `∠ p p p = π/2` and the degenerate triangle `∠ p₁ p₁ p₃ + ∠ p₁ p₃ p₁ + ∠ p₃ p₁ p₁ = π`."
+    }
+  ],
+  "conclusion": {
+    "summary": "A complete characterization of the Mathlib angle sum formula for triangles: the formula holds for ALL configurations of three points in a Euclidean space EXCEPT when all three coincide. This reveals two surprises: (1) the standard gallery proof carried an unnecessary hypothesis, and (2) Mathlib's degenerate angle convention (`arccos(0/0) = π/2`) makes the angle sum formula almost universal. The 140-line file proves 5 theorems with 0 sorries and 0 axioms.",
+    "implications": "**Simplified API**: The one-condition theorem `triangle_angle_sum_one_cond` provides a cleaner interface to the angle sum formula, requiring only `p₂ ≠ p₁` rather than two conditions. Any downstream proof needing the angle sum formula can use this weaker hypothesis.\n\n**Degenerate geometry**: The fully degenerate case (sum = 3π/2) illustrates how Mathlib's convention for degenerate angles creates mathematically coherent but geometrically unexpected values. The convention is chosen for analytic smoothness over geometric intuition.\n\n**Total functions in Lean**: The unconditional formula demonstrates a Lean proof-of-concept: by using `Classical.em` and encoding the branch in the conclusion itself, one can state theorems about partial mathematical objects (degenerate triangles) without conditions on the hypotheses.",
+    "openQuestions": [
+      "What is the angle sum for degenerate configurations in spherical or hyperbolic geometry? In spherical geometry, the angle sum of a proper triangle is always > π, but the degenerate case analysis would differ since the angle function has different conventions.",
+      "Prove the oriented angle sum theorem: for the signed angle measure (oriented triangles), what is the analog of the biconditional characterization? The oriented angle function may have different degenerate conventions.",
+      "Characterize all configurations (p₁, p₂, p₃) giving a specific angle sum value in [π/2, 3π/2] — the degenerate case gives 3π/2 and the generic case gives π; can intermediate values occur under modified conventions?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "triangle-angle-sum",
+      "relationship": "extends",
+      "description": "The parent entry proves the standard angle sum formula with two non-degeneracy conditions; this OQ-03 reveals one is redundant and analyzes the degenerate cases"
+    }
+  ],
   "mainTheorems": [
     {
       "name": "TriangleAngleSumOQ03.triangle_angle_sum_one_cond",


### PR DESCRIPTION
Enrichment pass for `triangle-angle-sum-oq-03` (quality: 18 → target 80+, passes: 0).

## Quality Improvements

### annotations.json (empty → 6 rich annotations)
- **Module setup**: degenerate angle conventions explained (arccos(0/0) = π/2 convention and why it was chosen)
- **One-condition theorem**: why only p₂ ≠ p₁ is needed, what the redundant hypothesis was
- **Degenerate case (p₂=p₁, p₃≠p₁)**: explicit π/2 + 0 + π/2 = π computation explained
- **Fully degenerate**: all-equal → sum = 3π/2, comparison with spherical angle excess
- **Complete biconditional**: proof structure with Classical.em explained, why DecidableEq avoided
- **Unconditional formula**: total function pattern in Lean, concrete examples in ℝ²

### meta.json additions
- **6 sections** added matching the 6 logical parts of the Lean file
- **conclusion** added: summary + implications (simplified API, degenerate geometry, total functions pattern) + 3 open questions
- **crossReference** added: link to triangle-angle-sum parent entry
- **5th keyInsight**: `open Classical` is load-bearing for the `by_cases` proof

## Verification
- `pnpm build` passes (exit 0)
- No changes to Lean proof files
- Axiom integrity: 0 axioms, 0 sorries confirmed