### PR TITLE
Enrich sqrt2-minpoly-oq-02: deepen historicalContext, add keyInsight, crossReferences

### DIFF
--- a/src/data/proofs/sqrt2-minpoly-oq-02/meta.json
+++ b/src/data/proofs/sqrt2-minpoly-oq-02/meta.json
@@ -4,6 +4,8 @@
   "slug": "sqrt2-minpoly-oq-02",
   "description": "A complete Lean 4 proof that the minimal polynomial of m^(1/n) over ℚ is Xⁿ - m, when m has a prime factor p with p | m but p² ∤ m. Includes algebraic degree and field extension degree theorems.",
   "meta": {
+    "author": "Lean Genius",
+    "date": "2026-04-06",
     "status": "verified",
     "tags": [
       "algebraic-number-theory",
@@ -47,7 +49,7 @@
     ]
   },
   "overview": {
-    "historicalContext": "Eisenstein's irreducibility criterion (1850) is one of the most powerful tools in elementary algebraic number theory. For a polynomial Xⁿ - m, the criterion applies at any prime p with p | m but p² ∤ m, yielding irreducibility over ℤ. Gauss's lemma then transfers this to ℚ.\n\nThis result generalizes the fundamental examples (minpoly ℚ (√2) = X² - 2, minpoly ℚ (∛2) = X³ - 2) to all n-th roots of numbers with a squarefree prime factor.",
+    "historicalContext": "Eisenstein's irreducibility criterion was introduced by Ferdinand Gotthold Max Eisenstein in 1850, in a paper on cyclotomic polynomials and algebraic number theory. Eisenstein used it to prove that the p-th cyclotomic polynomial $(X^p - 1)/(X - 1) = X^{p-1} + \\cdots + 1$ is irreducible over $\\mathbb{Q}$ (by a substitution $X \\mapsto X+1$). The criterion for binomials $X^n - m$ is among its most direct applications.\n\nGauss's Lemma, from Gauss's *Disquisitiones Arithmeticae* (1801), establishes that the product of primitive polynomials over $\\mathbb{Z}$ is primitive — which implies that ℤ-irreducibility of a primitive polynomial transfers to ℚ-irreducibility. Together, Eisenstein's criterion and Gauss's Lemma form the backbone of elementary algebraic irreducibility proofs.\n\nThis result generalizes the fundamental examples (minpoly ℚ (√2) = X² - 2, minpoly ℚ (∛2) = X³ - 2) to all n-th roots of numbers with a squarefree prime factor. The Mathlib formalization uses `Polynomial.irreducible_of_eisenstein_criterion` and `IsPrimitive.Int.irreducible_iff_irreducible_map_cast` to carry this classical argument into Lean 4.",
     "problemStatement": "For n ≥ 2 and m > 0, when does `minpoly ℚ (m^(1/n)) = Xⁿ - m`?\n\n**Answer**: Whenever m has a prime factor p with p | m but p² ∤ m. This is equivalent to saying the p-adic valuation v_p(m) is odd for some prime p.",
     "proofStrategy": "**Four steps**:\n1. **Eisenstein over ℤ**: Apply Eisenstein at p — 1 ∉ (p), all lower coefficients ∈ (p), constant term ∉ (p)²\n2. **Transfer to ℚ**: Gauss's lemma (primitive ℤ-polynomial is ℚ-irreducible iff ℤ-irreducible)\n3. **Root witness**: (m^(1/n))^n = m, so m^(1/n) is a root of Xⁿ - m\n4. **Minimal polynomial**: Apply `minpoly.eq_of_irreducible_of_monic`",
     "keyInsights": [
@@ -55,7 +57,8 @@
       "This condition implies m is NOT a perfect n-th power: if m = k^n then v_p(m) = n·v_p(k) ≥ 0 or ≥ n, never exactly 1",
       "The proof works uniformly for all n ≥ 2, covering square, cube, fourth, fifth roots, etc.",
       "The squarefree prime factor condition is NOT necessary — it's sufficient. X² - 8 is also irreducible but not Eisenstein.",
-      "The proof architecture — Eisenstein (ℤ) → Gauss → minimal polynomial → field degree — is a reusable template for any irreducibility argument in algebraic number theory."
+      "The proof architecture — Eisenstein (ℤ) → Gauss → minimal polynomial → field degree — is a reusable template for any irreducibility argument in algebraic number theory.",
+      "Irrationality is an immediate corollary: if $m^{1/n}$ were rational $= a/b$, then $\\mathrm{minpoly}(\\mathbb{Q}, m^{1/n})$ would have degree 1 (linear), contradicting degree $= n \\geq 2$. So the Eisenstein criterion provides a unified algebraic proof of irrationality for all n-th roots satisfying the squarefree condition."
     ]
   },
   "sections": [
@@ -127,6 +130,16 @@
       "targetId": "sqrt2-minpoly",
       "relationship": "generalizes",
       "description": "The square root 2 minimal polynomial (X² - 2) is the n=2, m=2 special case"
+    },
+    {
+      "targetId": "nth-root-irrational",
+      "relationship": "related",
+      "description": "The n-th root irrationality proof uses a different approach; this file provides the stronger result of computing the minimal polynomial explicitly via Eisenstein"
+    },
+    {
+      "targetId": "sqrt2-minpoly-oq-01",
+      "relationship": "extends",
+      "description": "OQ-01 proved the degree-n case for prime m; this file extends to all m with a squarefree prime factor (composite m like ∛6, ⁵√12)"
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
Enrichment pass for `sqrt2-minpoly-oq-02` (Minimal Polynomial of k-th Roots via Eisenstein).

## Changes

**meta.json** quality improvements:
- Added missing `author` and `date` fields to the meta section
- Deepened `historicalContext`: added Eisenstein's 1850 cyclotomy context, Gauss's *Disquisitiones Arithmeticae* (1801) origin for Gauss's Lemma, and Mathlib API connection
- Added 6th `keyInsight`: irrationality is a direct corollary of algebraic degree = n ≥ 2 (linear minimal polynomial ↔ rational)
- Added 2 new `crossReferences`: `nth-root-irrational` (related approach via different method) and `sqrt2-minpoly-oq-01` (this file extends OQ-01 from prime m to composite m)

## Notes

The annotations.json already had 8 complete annotations with full `mathContext`, `significance`, `relatedConcepts`, and `prerequisites` fields from a previous enrichment pass (#11548). This PR addresses the remaining meta.json quality gaps.

Build: JSON validated.