### PR TITLE
Fix: erdos-807 leanFile.axiomCount corrected (1→0)

### DIFF
--- a/src/data/proofs/erdos-807/meta.json
+++ b/src/data/proofs/erdos-807/meta.json
@@ -178,7 +178,7 @@
     ],
     "namespace": "Erdos807",
     "lineCount": 236,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 3,
     "definitionCount": 4,
     "path": "Proofs/Erdos807Problem.lean",


### PR DESCRIPTION
## Fix

`leanFile.axiomCount` in `src/data/proofs/erdos-807/meta.json` was set to 1 but should be 0.

## Evidence

**Before**: `leanFile.axiomCount: 1`
**After**: `leanFile.axiomCount: 0`

The lean file `proofs/Proofs/Erdos807Problem.lean` has **0 `axiom` declarations** (confirmed by grep — no `axiom`, `private axiom`, or `noncomputable axiom` keywords).

Internal inconsistency in meta.json:
- `meta.axiomCount`: already correctly 0
- `leanFile.axiomCount`: was incorrectly 1
- `meta.assumptions`: "0 axioms, 0 sorries." (confirms 0)

The file uses True-stub theorems (not `axiom` declarations), which are consistent with `axiomCount=0`.

---
Automated fix by lean-mechanic agent.