### PR TITLE
Fix: correct sorries type [] → 0 in 4 enriched proofs

### DIFF
--- a/src/data/proofs/sqrt2-minpoly-oq-01/meta.json
+++ b/src/data/proofs/sqrt2-minpoly-oq-01/meta.json
@@ -153,5 +153,5 @@
       "description": "Field extension degree [ℚ(√n) : ℚ] = 2"
     }
   ],
-  "sorries": []
+  "sorries": 0
 }

--- a/src/data/proofs/sqrt2-minpoly-oq-02/meta.json
+++ b/src/data/proofs/sqrt2-minpoly-oq-02/meta.json
@@ -151,5 +151,5 @@
       "description": "m is not a perfect n-th power when it has a squarefree prime factor"
     }
   ],
-  "sorries": []
+  "sorries": 0
 }

--- a/src/data/proofs/sqrt2-minpoly/meta.json
+++ b/src/data/proofs/sqrt2-minpoly/meta.json
@@ -184,5 +184,5 @@
       "description": "The field extension ℚ(√2)/ℚ has degree 2"
     }
   ],
-  "sorries": []
+  "sorries": 0
 }

--- a/src/data/proofs/triangle-angle-sum-oq-03/meta.json
+++ b/src/data/proofs/triangle-angle-sum-oq-03/meta.json
@@ -150,5 +150,5 @@
       "description": "Complete biconditional characterization of when the angle sum formula holds"
     }
   ],
-  "sorries": []
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Four recently enriched proof meta.json files had `"sorries": []` (empty array) instead of `"sorries": 0` (integer). Fixed to correct type.

## Affected Proofs

| Proof | Enriched in PR |
|-------|---------------|
| sqrt2-minpoly-oq-01 | #11575 |
| sqrt2-minpoly-oq-02 | #11548 |
| sqrt2-minpoly | earlier |
| triangle-angle-sum-oq-03 | #11577 |

## Evidence

**Before**: `"sorries": []`
**After**: `"sorries": 0`

All four Lean source files have 0 actual sorry occurrences (confirmed via `git show origin/main:proofs/...`). The empty array is a type error — the `sorries` field must be an integer for consistent API consumption and UI display.

---
Automated fix by lean-mechanic agent.