### PR TITLE
Enrich sqrt2-minpoly-oq-02: add preamble section covering lines 1-40

### DIFF
--- a/src/data/proofs/sqrt2-minpoly-oq-02/meta.json
+++ b/src/data/proofs/sqrt2-minpoly-oq-02/meta.json
@@ -63,6 +63,14 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Preamble: Problem Setup and Mathematical Framework",
+      "startLine": 1,
+      "endLine": 39,
+      "summary": "Module docstring framing the question: when is minpoly ℚ (m^(1/n)) = Xⁿ - m? States the squarefree prime factor condition, lists the four concrete examples (∛6, ∛10, ⁵√12, ∜30), and opens the Polynomial and IntermediateField namespaces. Sets maxHeartbeats to 800000 for the intensive case-split in the Eisenstein proof.",
+      "mathContext": "The **squarefree prime factor condition**: $\\exists p$ prime with $p \\mid m$ but $p^2 \\nmid m$ (equivalently, $v_p(m) = 1$). This implies $m$ is not a perfect $n$-th power: if $m = k^n$ then $v_p(m) = n v_p(k) \\in \\{0, n, 2n, \\ldots\\}$, never 1 for $n \\geq 2$."
+    },
+    {
       "id": "eisenstein-int",
       "title": "Part I: Eisenstein Criterion for X^n - m",
       "startLine": 41,


### PR DESCRIPTION
Enrichment pass for sqrt2-minpoly-oq-02 (Minimal Polynomial of k-th Roots via Eisenstein).

## Changes

- Added `sections[0]` "Preamble: Problem Setup and Mathematical Framework" covering lines 1-39
  - This was the only part of the Lean file not covered by any section entry
  - Includes `mathContext` explaining the squarefree prime factor condition $v_p(m) = 1$ and why it prevents $m$ from being a perfect $n$-th power

## Quality Assessment

The entry was already well-enriched (quality 97) with:
- 8 annotations, all with mathContext/significance/relatedConcepts/prerequisites
- 6 keyInsights including irrationality corollary
- 4 crossReferences (cube-root-2-irrational, sqrt2-minpoly, nth-root-irrational, sqrt2-minpoly-oq-01)
- Rich historicalContext (1128 chars)
- Detailed conclusion with 3 open questions

This pass completes section coverage for the full 204-line Lean file.