### PR TITLE
chore: record audit completions (erdos-1182, erdos-1109, erdos-1105, erdos-1080)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3488,8 +3488,8 @@
     },
     "erdos-1080": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T08:26:40Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-23T00:33:35Z",
       "result": "clean"
     },
     "erdos-1081": {
@@ -3710,8 +3710,8 @@
     },
     "erdos-1105": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-22T08:25:38Z",
+      "auditCount": 5,
+      "lastAudited": "2026-04-23T00:33:22Z",
       "result": "clean"
     },
     "erdos-1106": {
@@ -3740,8 +3740,8 @@
     },
     "erdos-1109": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-22T08:25:38Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-23T00:33:10Z",
       "result": "clean"
     },
     "erdos-111": {
@@ -4285,9 +4285,9 @@
       "result": "clean"
     },
     "erdos-1182": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-22T07:42:04Z",
+      "lastAudited": "2026-04-23T00:31:49Z",
       "result": "clean"
     },
     "erdos-1183": {

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4285,9 +4285,9 @@
       "result": "clean"
     },
     "erdos-1182": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-23T00:31:49Z",
+      "lastAudited": "2026-04-23T00:36:01Z",
       "result": "clean"
     },
     "erdos-1183": {


### PR DESCRIPTION
Audit completions from lean-auditor iteration.

All 4 proofs verified clean:
- **erdos-1182**: 3 axioms (chvatal_tree_ramsey, connected_min_edges, bigF_lower_linear) — axiomatized/axiom badge ✓
- **erdos-1109**: 2 axioms (konyagin_lower_2004, konyagin_upper_2004) — axiomatized/axiom badge ✓
- **erdos-1105**: 1 axiom — axiomatized/axiom badge ✓
- **erdos-1080**: 2 axioms + 1 sorry — axiomatized/axiom badge ✓

Also spot-checked recent enrichments:
- **abel-ruffini**: annotation-only enrichment; 0 sorries, 0 axioms, mathlib badge ✓
- **abel-ruffini-oq-04-oq-01**: 0 sorries, 0 axioms, mathlib badge ✓
- **erdos-807**: 0 sorries, 0 axioms ✓
- **erdos-97**: 4 axioms matching meta ✓
- **erdos-552**: 12 sorries in stub matching meta ✓

Gallery status: 2134/2134 audited, 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)