### PR TITLE
Fix: sync stale lineCount in hurwitz-theorem-oq-03 and sperner-ndim-oq-04

### DIFF
--- a/src/data/proofs/hurwitz-theorem-oq-03/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-03/meta.json
@@ -22,7 +22,7 @@
     "dateAdded": "2026-04-02",
     "axiomCount": 0,
     "assumptions": "1 sorry: hurwitz_only_if — if an n-square identity exists, then n ∈ {1,2,4,8} (n=3 case proved; n∉{1,2,3,4,8} cases pending Clifford/Radon-Hurwitz argument). The converse (identities exist for n ∈ {1,2,4,8}) is fully proved. No axiom declarations.",
-    "lineCount": 1838,
+    "lineCount": 1973,
     "theoremCount": 32,
     "definitionCount": 15,
     "originalContributions": [
@@ -67,7 +67,7 @@
   },
   "leanFile": {
     "namespace": "HurwitzTheorem",
-    "lineCount": 1838,
+    "lineCount": 1973,
     "axiomCount": 0,
     "theoremCount": 33,
     "definitionCount": 15,

--- a/src/data/proofs/sperner-ndim-oq-04/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-04/meta.json
@@ -35,7 +35,7 @@
     ],
     "dateAdded": "2026-04-22",
     "axiomCount": 0,
-    "lineCount": 420,
+    "lineCount": 408,
     "assumptions": "2 sorries: (1) kuhn_walk_reaches_fc — walk correctness requires non-revisiting invariant (detailed proof sketch provided: needs 'adjacent simplices share unique facet' axiom + door history in KuhnState), (2) kuhnPathStart_is_fc — constructive correctness, depends on kuhn_walk_reaches_fc. The non-sorry content includes fc_door_count_eq_one, nonfc_door_count_zero_or_two, nonfc_with_door_has_unique_exit, and kuhn_path_terminates (proved via sperner_ndim).",
     "mathlib_version": "4.26.0"
   },
@@ -234,7 +234,7 @@
       "BigOperators"
     ],
     "namespace": "SpernerNDimOQ04",
-    "lineCount": 420,
+    "lineCount": 408,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 5


### PR DESCRIPTION
## Summary

- `hurwitz-theorem-oq-03` meta.json: updated `meta.lineCount` and `leanFile.lineCount` from 1838 to 1973 (actual line count of `proofs/Proofs/HurwitzTheorem.lean`)
- `sperner-ndim-oq-04` meta.json: updated `meta.lineCount` and `leanFile.lineCount` from 420 to 408 (actual line count of `proofs/Proofs/SpernerNDimOQ04.lean`)

Both values were stale and did not match the current Lean source files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)