### PR TITLE
Fix: area-of-circle-oq-05-oq-02 status verified→formalized, sorries 0→1

### DIFF
--- a/src/data/proofs/area-of-circle-oq-05-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Gaussian_integral#n-dimensional_and_functional_generalization",
     "date": "Classical result, formalized 2026",
-    "status": "verified",
+    "status": "formalized",
     "tags": [
       "analysis",
       "integration",
@@ -20,7 +20,7 @@
     ],
     "proofRepoPath": "Proofs/AreaOfCircleOQ05OQ02.lean",
     "badge": "mathlib",
-    "sorries": 0,
+    "sorries": 1,
     "axiomCount": 0,
     "assumptions": "Core scalar Gaussian ∫ exp(-bx²) = √(π/b) is derived from Mathlib's `integral_gaussian` via the parent proof's `scaled_gaussian`. All three theorems are proved with 0 sorries.",
     "originalContributions": [
@@ -116,5 +116,5 @@
       "Can the proof be simplified using `MeasurePreserving.integral_comp'` instead of `integral_map` + `hmap`?"
     ]
   },
-  "sorries": 0
+  "sorries": 1
 }


### PR DESCRIPTION
## Fix

`area-of-circle-oq-05-oq-02` (Multivariate Gaussian Integral) had `status: verified` and `sorries: 0` in meta.json, but `AreaOfCircleOQ05OQ02.lean` contains 1 real `sorry` at line 136.

## Evidence

**Before**:
- `meta.status`: `"verified"` — claims fully machine-checked
- `meta.sorries`: `0` — claims no incomplete proofs
- Top-level `sorries`: `0`

**After**:
- `meta.status`: `"formalized"` — correctly reflects incomplete formalization
- `meta.sorries`: `1` — matches actual sorry count in the Lean file
- Top-level `sorries`: `1`

The sorry at line 136 is documented in the file itself (lines 25, 102, 111) as "1 sorry remaining: spectral decomposition + orthogonal change of variables" for `multivariate_gaussian_integral`. The two helper theorems (`prod_sqrt_eq_sqrt_prod` and `diagonal_gaussian`) are fully proved; only the main theorem remains incomplete.

---
Automated fix by lean-mechanic agent.