### PR TITLE
Fix: sync stale meta.lineCount (40 proofs) + correct invalid status (7 proofs)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
@@ -56,7 +56,7 @@
     ],
     "dateAdded": "2026-02-24",
     "axiomCount": 0,
-    "lineCount": 1938,
+    "lineCount": 1937,
     "assumptions": "0 sorries. The IBP formula fourierCoeffOn_deriv_periodic is now proved via import from AreaOfCircleOQ01OQ02OQ02.lean.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/cauchy-schwarz-integral/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral/meta.json
@@ -43,7 +43,7 @@
     ],
     "dateAdded": "2026-02-11",
     "axiomCount": 0,
-    "lineCount": 118,
+    "lineCount": 117,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-1028/meta.json
+++ b/src/data/proofs/erdos-1028/meta.json
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "solved",
     "relatedProblems": [],
     "axiomCount": 2,
-    "lineCount": 311,
+    "lineCount": 310,
     "assumptions": "2 axioms: erdos_upper, erdos_spencer_lower. 0 sorries.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-1034/meta.json
+++ b/src/data/proofs/erdos-1034/meta.json
@@ -26,7 +26,7 @@
       "erdos-1033"
     ],
     "axiomCount": 1,
-    "lineCount": 779,
+    "lineCount": 778,
     "assumptions": "1 axiom: maTang_counterexample. 3 sorries.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-108/meta.json
+++ b/src/data/proofs/erdos-108/meta.json
@@ -46,7 +46,7 @@
       "Special case extraction for Rödl's r=4 theorem"
     ],
     "axiomCount": 1,
-    "lineCount": 142,
+    "lineCount": 141,
     "assumptions": "1 axiom: erdos_hajnal_rodl_theorem. See Lean source for the complete statement."
   },
   "overview": {

--- a/src/data/proofs/erdos-109/meta.json
+++ b/src/data/proofs/erdos-109/meta.json
@@ -49,7 +49,7 @@
       "Verified example for even numbers"
     ],
     "axiomCount": 1,
-    "lineCount": 438,
+    "lineCount": 437,
     "assumptions": "1 axiom: moreira_richter_robertson. See Lean source for the complete statement."
   },
   "overview": {

--- a/src/data/proofs/erdos-1161/meta.json
+++ b/src/data/proofs/erdos-1161/meta.json
@@ -54,7 +54,7 @@
       "Small cases: explicit counts for S_1, S_2, S_3"
     ],
     "axiomCount": 0,
-    "lineCount": 324,
+    "lineCount": 323,
     "assumptions": "0 axioms, 0 sorries. All results proved from Lean primitives."
   },
   "overview": {

--- a/src/data/proofs/erdos-1206/meta.json
+++ b/src/data/proofs/erdos-1206/meta.json
@@ -7,7 +7,7 @@
     "author": "Unknown",
     "sourceUrl": "https://erdosproblems.com/1206",
     "date": "",
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1206Problem.lean",
     "tags": [
       "erdos"
@@ -18,7 +18,7 @@
     "erdosNumber": 1206,
     "erdosUrl": "https://erdosproblems.com/1206",
     "erdosProblemStatus": "solved",
-    "lineCount": 23
+    "axiomCount": 0
   },
   "overview": {
     "historicalContext": "Erdős Problem #1206 concerns Sidon sets among cube numbers. A Sidon set (also called a B₂ set) is a set of integers where all pairwise sums are distinct—equivalently, all pairwise differences are distinct. Sidon introduced these in 1932 in connection with Fourier analysis. Erdős and Turán proved the fundamental bound: any Sidon subset of {1,...,N} has at most N^(1/2) + O(N^(1/4)) elements. Problem #1206 asks whether {1³, 2³, ..., N³} contains an unexpectedly large Sidon set of size ≫ N—much larger relative to the set's cardinality than the Erdős–Turán bound suggests for a generic subset of {1,...,N³}. The problem was marked solved on erdosproblems.com following work by Gabdullin and Konyagin (2024), who showed the short-interval cube set {n³ : N - cN^(1/2) ≤ n ≤ N} is Sidon. Garaev, Garayev, and Konyagin (2026) improved this to size ≫ N^(4/7-o(1)) for infinitely many N, using more refined estimates on the quadratic factor n² + nm + m². The problem is part of a broader Erdős program relating polynomial sequences to additive combinatorics, with analogues for squares (Problem #773) and linear sets (Problem #530).",

--- a/src/data/proofs/erdos-1211/meta.json
+++ b/src/data/proofs/erdos-1211/meta.json
@@ -7,7 +7,7 @@
     "author": "Unknown",
     "sourceUrl": "https://erdosproblems.com/1211",
     "date": "",
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1211Problem.lean",
     "tags": [
       "erdos",
@@ -22,7 +22,7 @@
     "erdosNumber": 1211,
     "erdosUrl": "https://erdosproblems.com/1211",
     "erdosProblemStatus": "solved",
-    "lineCount": 23
+    "axiomCount": 0
   },
   "overview": {
     "historicalContext": "This problem belongs to Erdős's deep program on the density theory of sum sets and additive bases. The foundational concept of density for additive number theory was Schnirelmann density (1930), defined as $d(A) = \\inf_{n \\ge 1} |A \\cap \\{1,\\ldots,n\\}|/n$. Schnirelmann proved every integer > 1 is the sum of at most $C$ elements of $A$ whenever $A \\cup (2A) \\cup \\ldots$ covers $\\mathbb{N}$, giving the first quantitative version of Waring's problem. However, Schnirelmann density is insensitive to sparse sets: a set containing all powers of 2 has Schnirelmann density 0 yet generates $\\mathbb{N}$ as subset sums (binary representations).\n\nThe logarithmic density $\\overline{\\delta}(X) = \\limsup_{x \\to \\infty} \\frac{1}{\\log x} \\sum_{n \\in X, n \\leq x} \\frac{1}{n}$ is better adapted to multiplicative and harmonic structure. It satisfies $\\overline{\\delta}(\\mathbb{N}) = 1$ (harmonic series diverges), $\\overline{\\delta}(\\text{primes}) = 0$ (Mertens: $\\sum_{p \\le x} 1/p \\sim \\ln \\ln x$), and $\\overline{\\delta}(\\text{even integers}) = 1/2$. Unlike natural density, it weighs small integers more heavily, which matches how subset sums build up: small elements of $A$ generate many small subset sums, and these dominate the logarithmic sum.\n\nErdős systematically studied how the logarithmic density of $A$ controls the logarithmic density of its subset sum set $S(A)$. The generating Dirichlet series $\\sum_{n \\in S(A)} n^{-s} = \\prod_{a \\in A}(1 + a^{-s})$ connects analytic continuation near $s=1$ to the logarithmic density of $S(A)$: by Mertens's formula, $\\log \\prod_{a \\in A}(1 + a^{-1}) \\approx \\sum_{a \\in A} 1/a$, so large harmonic sum of $A$ implies large density of $S(A)$. Problem #1211 asks for the optimal partition constant, in the spirit of Ramsey theory: any partition must have at least one dense sum set.",

--- a/src/data/proofs/erdos-1212/meta.json
+++ b/src/data/proofs/erdos-1212/meta.json
@@ -7,7 +7,7 @@
     "author": "Unknown",
     "sourceUrl": "https://erdosproblems.com/1212",
     "date": "",
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1212Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-1213/meta.json
+++ b/src/data/proofs/erdos-1213/meta.json
@@ -7,7 +7,7 @@
     "author": "Unknown",
     "sourceUrl": "https://erdosproblems.com/1213",
     "date": "",
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1213Problem.lean",
     "tags": [
       "erdos",
@@ -21,7 +21,8 @@
     "sorries": 1,
     "erdosNumber": 1213,
     "erdosUrl": "https://erdosproblems.com/1213",
-    "erdosProblemStatus": "solved"
+    "erdosProblemStatus": "solved",
+    "axiomCount": 0
   },
   "overview": {
     "historicalContext": "This problem is in the tradition of Erdős's combinatorial number theory questions about arithmetic properties of integer sequences. The idea that any sufficiently long sequence with bounded gaps must have two sub-intervals with equal sums is a pigeonhole-type result: the number of possible interval sums is bounded by the range of the sequence, while the number of intervals grows quadratically. Hegyvári proved in 1986 that the threshold $f(a,K)$ exists and satisfies $f(a,K) \\ll a \\cdot e^{O(K)}$, but the exponential dependence on $K$ seems too large. The problem is marked as solved—meaning the existence of $f(a,K)$ is confirmed—but the optimal bound is an open refinement.",

--- a/src/data/proofs/erdos-1215/meta.json
+++ b/src/data/proofs/erdos-1215/meta.json
@@ -7,7 +7,7 @@
     "author": "Unknown",
     "sourceUrl": "https://erdosproblems.com/1215",
     "date": "",
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1215Problem.lean",
     "tags": [
       "erdos",
@@ -22,7 +22,7 @@
     "erdosNumber": 1215,
     "erdosUrl": "https://erdosproblems.com/1215",
     "erdosProblemStatus": "solved",
-    "lineCount": 23
+    "axiomCount": 0
   },
   "overview": {
     "historicalContext": "This problem sits at the intersection of complex analysis and topology. Polynomials $P$ with all roots on the unit circle and $P(0) = 1$ arise naturally in number theory (Mahler measure, cyclotomic polynomials, Lehmer's problem) and harmonic analysis. The sublevel set $\\{z : |P(z)| < 1\\}$ is bounded by a polynomial lemniscate $\\{|P(z)| = 1\\}$, which can have complex topology—up to $\\deg(P) - 1$ connected components of the boundary. Erdős asked whether a simple path from the origin region to the unit circle in the sublevel set has bounded length depending on $\\deg(P)$. Mac Lane [Ma53] resolved this negatively: the sublevel sets can form labyrinthine structures forcing any path to be arbitrarily long. This connects to the theory of polynomial lemniscates developed by Walsh, Szegő, and others.",

--- a/src/data/proofs/erdos-1216/meta.json
+++ b/src/data/proofs/erdos-1216/meta.json
@@ -7,7 +7,7 @@
     "author": "Unknown",
     "sourceUrl": "https://erdosproblems.com/1216",
     "date": "",
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1216Problem.lean",
     "tags": [
       "erdos",
@@ -22,7 +22,7 @@
     "erdosNumber": 1216,
     "erdosUrl": "https://erdosproblems.com/1216",
     "erdosProblemStatus": "solved",
-    "lineCount": 23
+    "axiomCount": 0
   },
   "overview": {
     "historicalContext": "Tournament theory is a classical area of graph theory, with tournaments arising naturally from round-robin competitions where every player beats or loses to every other. The question of how large a 'totally ordered' (transitive) sub-tournament exists in any tournament is the directed analogue of the Ramsey problem for cliques. Stearns (1959) proved the elegant lower bound $f(n) \\geq \\lfloor \\log_2 n \\rfloor + 1$ by a greedy algorithm. Erdős and Moser (1964) proved $f(n) \\leq 2\\lfloor \\log_2 n \\rfloor + 1$ and noted $f(7) = 3$. Erdős asked whether $f(n) = \\lfloor \\log_2 n \\rfloor + 1$ exactly. Reid and Parker (1970) answered NO for $n \\geq 14$: $f(n) \\geq \\lfloor \\log_2 n + 4 - \\log_2 7 \\rfloor > \\lfloor \\log_2 n \\rfloor + 1$, with further improvements by Sanchez-Flores (1994). The exact growth rate of $f(n)$ between $\\log_2 n$ and $2\\log_2 n$ remains open.",

--- a/src/data/proofs/erdos-1217/meta.json
+++ b/src/data/proofs/erdos-1217/meta.json
@@ -7,7 +7,7 @@
     "author": "Unknown",
     "sourceUrl": "https://erdosproblems.com/1217",
     "date": "",
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1217Problem.lean",
     "tags": [
       "erdos",
@@ -21,7 +21,8 @@
     "sorries": 1,
     "erdosNumber": 1217,
     "erdosUrl": "https://erdosproblems.com/1217",
-    "erdosProblemStatus": "solved"
+    "erdosProblemStatus": "solved",
+    "axiomCount": 0
   },
   "overview": {
     "historicalContext": "Erdős Problem #1217 concerns sequences of positive integers and their 'upper log-log density': the quantity $\\limsup_{x\\to\\infty} \\frac{1}{\\log\\log x}\\sum_{a_n \\leq x} \\frac{1}{a_n}$. This measure is modeled on Mertens' second theorem, which states $\\sum_{p \\leq x} \\frac{1}{p} \\sim \\log\\log x$, so the primes are the canonical sequence with upper log-log density equal to 1. A sequence A has positive upper log-log density iff its reciprocal sums grow (at least along a subsequence of $x$ values) as fast as a positive fraction of the prime reciprocal sum. The problem references [ESS66], the paper of Erdős, Sárközy, and Sós from 1966, who proved a key result about sequences with this density condition.\n\nThe source problem statement in the Lean file and meta.json is severely corrupted (garbled by encoding issues), so the precise formulation cannot be recovered from the current source. Based on the fragments, the result concerns: given a sequence A with positive upper log-log density, one can extract a subsequence $\\{a_{n_i}\\}$ with some additional structural property (e.g., primitivity, or sum-free, or B₂) while preserving positive log-log density.\n\nThe Erdős-Sárközy-Sós 1966 collaboration was prolific in combinatorial number theory, covering Sidon sets, additive bases, primitive sets, and density problems. Their results on 'density-preserving' subsequence extraction are fundamental in the area. This problem is listed as solved on erdosproblems.com.",

--- a/src/data/proofs/erdos-123/meta.json
+++ b/src/data/proofs/erdos-123/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/123",
     "erdosProblemStatus": "open",
     "axiomCount": 3,
-    "lineCount": 318,
+    "lineCount": 317,
     "assumptions": "3 axiom(s): powers23_repr, erdos_123_conjecture, erdos_lewin_357. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-139/meta.json
+++ b/src/data/proofs/erdos-139/meta.json
@@ -30,7 +30,7 @@
       "Szemerédi regularity lemma (for understanding the proof chain)",
       "Roth's theorem and the corners theorem (k=3 case)"
     ],
-    "lineCount": 261,
+    "lineCount": 260,
     "assumptions": "4 axioms: kelley_meka_bound (r₃(N) ≤ N·exp(−c(log N)^(1/12)), Kelley-Meka 2023), gowers_bound (r_k(N) ≤ N/(log log N)^c for k≥4, Gowers 2001), behrend_lower_bound (r₃(N) ≥ N·exp(−c√(log N)), Behrend 1946), szemeredi_theorem (sets with positive density contain k-APs for all k). 1 sorry: main density-to-zero proof.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-143/meta.json
+++ b/src/data/proofs/erdos-143/meta.json
@@ -46,7 +46,7 @@
       "Formalized the KLL 2025 partial resolution"
     ],
     "axiomCount": 3,
-    "lineCount": 120,
+    "lineCount": 119,
     "assumptions": "3 axiom(s): kll_theorem, well_separated_integers_primitive, erdos_1935_primitive. See Lean source for complete statements."
   },
   "overview": {

--- a/src/data/proofs/erdos-157/meta.json
+++ b/src/data/proofs/erdos-157/meta.json
@@ -59,7 +59,7 @@
       "Verified theorem: powers_of_two_sidon"
     ],
     "axiomCount": 3,
-    "lineCount": 536,
+    "lineCount": 535,
     "assumptions": "3 axioms: (1) pilatte_existence — the Pilatte 2023 existence result (infinite Sidon set that is an asymptotic basis of order 3); (2) sidon_counting_bound — counting bound for Sidon sets; (3) basis_counting_lower — lower bound for basis counting. 0 sorries (previously 1 sorry for pilatte_existence was axiomatized; sidon_counting_contradiction proved by Aristotle)."
   },
   "overview": {

--- a/src/data/proofs/erdos-167/meta.json
+++ b/src/data/proofs/erdos-167/meta.json
@@ -28,7 +28,7 @@
       "extremal combinatorics",
       "linear programming relaxation"
     ],
-    "lineCount": 275,
+    "lineCount": 274,
     "assumptions": "1 axiom: IsPlanar. 0 sorries.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-168/meta.json
+++ b/src/data/proofs/erdos-168/meta.json
@@ -55,7 +55,7 @@
       "Formalized the irrationality question"
     ],
     "axiomCount": 2,
-    "lineCount": 181,
+    "lineCount": 180,
     "assumptions": "2 axioms: gsw_limit_exists, better_construction. 0 sorries."
   },
   "overview": {

--- a/src/data/proofs/erdos-171/meta.json
+++ b/src/data/proofs/erdos-171/meta.json
@@ -56,7 +56,7 @@
       "Aristotle-verified: no_4_clique (no tetrahedron in ℝ²)"
     ],
     "axiomCount": 2,
-    "lineCount": 303,
+    "lineCount": 302,
     "references": [
       {
         "title": "The chromatic number of the plane is at least 5",

--- a/src/data/proofs/erdos-172/meta.json
+++ b/src/data/proofs/erdos-172/meta.json
@@ -46,7 +46,7 @@
       "Explicit connection between finite and infinite versions"
     ],
     "axiomCount": 3,
-    "lineCount": 145,
+    "lineCount": 144,
     "references": [
       {
         "title": "Monochromatic sums and products in ℕ",

--- a/src/data/proofs/erdos-202/meta.json
+++ b/src/data/proofs/erdos-202/meta.json
@@ -53,7 +53,7 @@
       "Multiple theorems proved by Aristotle including f_mono, f_le_N, L_mono, L_subpolynomial"
     ],
     "axiomCount": 0,
-    "lineCount": 860,
+    "lineCount": 859,
     "assumptions": "3 sorry(s). No axioms."
   },
   "overview": {

--- a/src/data/proofs/erdos-29/meta.json
+++ b/src/data/proofs/erdos-29/meta.json
@@ -22,7 +22,7 @@
     "erdosProblemStatus": "solved",
     "erdosPrizeValue": "$100",
     "axiomCount": 5,
-    "lineCount": 524,
+    "lineCount": 523,
     "assumptions": "5 axioms: JPSZ_set (explicit construction), JPSZ_is_basis, JPSZ_representation_bound, JPSZ_explicit, JPSZ_size_optimal. JPSZ_is_economical and JPSZ_density_zero fully proved as consequences (not independent axioms): economical follows from representation bound via exp(C√(log n) - ε·log n) → -∞, density zero follows from size optimal via squeeze with C·√(log N/N) → 0. 0 sorries.",
     "prerequisites": [
       "Additive bases and Waring's problem",

--- a/src/data/proofs/erdos-299/meta.json
+++ b/src/data/proofs/erdos-299/meta.json
@@ -54,7 +54,7 @@
       "Proof that powers of 2 have unbounded gaps"
     ],
     "axiomCount": 1,
-    "lineCount": 387,
+    "lineCount": 386,
     "assumptions": "1 axiom (bloom_theorem: Bloom's 2021 result on positive density sets). 0 sorries."
   },
   "overview": {

--- a/src/data/proofs/erdos-303/meta.json
+++ b/src/data/proofs/erdos-303/meta.json
@@ -54,7 +54,7 @@
       "Connection to density version (Erdős #302)"
     ],
     "axiomCount": 2,
-    "lineCount": 259,
+    "lineCount": 258,
     "assumptions": "2 axioms: brownRodl_theorem, erdos303_true. See Lean source for complete statements."
   },
   "overview": {

--- a/src/data/proofs/erdos-355/meta.json
+++ b/src/data/proofs/erdos-355/meta.json
@@ -48,7 +48,7 @@
       "Fibonacci-like sequence example with ratio approximately φ"
     ],
     "axiomCount": 2,
-    "lineCount": 392,
+    "lineCount": 391,
     "assumptions": "2 axiom(s) and 0 sorry(s). See the Lean source for details."
   },
   "overview": {

--- a/src/data/proofs/erdos-37/meta.json
+++ b/src/data/proofs/erdos-37/meta.json
@@ -80,7 +80,7 @@
       "Classical axioms: schnirelmann_theorem, mann_theorem"
     ],
     "axiomCount": 6,
-    "lineCount": 368,
+    "lineCount": 367,
     "prerequisites": [
       "Essential components in additive number theory",
       "Lacunary sequences and their properties",

--- a/src/data/proofs/erdos-370/meta.json
+++ b/src/data/proofs/erdos-370/meta.json
@@ -64,7 +64,7 @@
       "erdos_370: injective-function encoding of infinitude (sorry'd)"
     ],
     "axiomCount": 2,
-    "lineCount": 285,
+    "lineCount": 284,
     "assumptions": "2 axioms (gpf_mul_le, dickman_density) and 2 sorries. gpf function and 7 properties now proved from Mathlib."
   },
   "leanFile": {

--- a/src/data/proofs/erdos-402/meta.json
+++ b/src/data/proofs/erdos-402/meta.json
@@ -60,7 +60,7 @@
       "erdos_402_contains_one: conjecture proved when 1 ∈ A"
     ],
     "axiomCount": 0,
-    "lineCount": 694,
+    "lineCount": 693,
     "assumptions": "1 sorry: erdos_402_graham_conjecture (main conjecture, requires Balasubramanian-Soundararajan sieve argument). Quadruple case fully proved."
   },
   "overview": {

--- a/src/data/proofs/erdos-45/meta.json
+++ b/src/data/proofs/erdos-45/meta.json
@@ -40,7 +40,7 @@
       }
     ],
     "axiomCount": 3,
-    "lineCount": 142,
+    "lineCount": 141,
     "prerequisites": [
       "Egyptian fractions and unit fraction decompositions",
       "Ramsey theory and monochromatic structures",

--- a/src/data/proofs/erdos-485/meta.json
+++ b/src/data/proofs/erdos-485/meta.json
@@ -23,7 +23,7 @@
     "erdosUrl": "https://erdosproblems.com/485",
     "erdosProblemStatus": "solved",
     "axiomCount": 1,
-    "lineCount": 226,
+    "lineCount": 225,
     "assumptions": "1 axiom: schinzel_zannier_improved (Schinzel-Zannier 2009: f(k) ≫ log k). This deep algebraic result is not yet in Mathlib.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-517/meta.json
+++ b/src/data/proofs/erdos-517/meta.json
@@ -51,7 +51,7 @@
       "Verified example showing exponential sequences have Fejér gaps"
     ],
     "dateAdded": "2025-12-22",
-    "lineCount": 176,
+    "lineCount": 175,
     "prerequisites": [
       "Complex analysis: entire functions, power series",
       "Lacunary (gap) series and Fabry/Fejér gap conditions",

--- a/src/data/proofs/erdos-551/meta.json
+++ b/src/data/proofs/erdos-551/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/551",
     "erdosProblemStatus": "solved",
     "axiomCount": 0,
-    "lineCount": 604,
+    "lineCount": 603,
     "assumptions": "No axioms. 22 sorry(s) remain in the formalization.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-60/meta.json
+++ b/src/data/proofs/erdos-60/meta.json
@@ -51,7 +51,7 @@
       "conjecture_implies_two_copies: Aristotle-proved implication"
     ],
     "axiomCount": 8,
-    "lineCount": 386,
+    "lineCount": 385,
     "prerequisites": [
       "Extremal graph theory (Turán-type problems)",
       "4-cycles (C₄) in graphs",

--- a/src/data/proofs/erdos-604/meta.json
+++ b/src/data/proofs/erdos-604/meta.json
@@ -59,7 +59,7 @@
       "Crossing number inequality",
       "Number theory (sums of two squares, Landau's theorem)"
     ],
-    "lineCount": 224,
+    "lineCount": 223,
     "assumptions": "No axioms. 1 sorry remaining: integerLattice_pinnedDistances (deep constructive existence). maxPinnedDistances and pinnedDistance_le are now sorry-free.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-624/meta.json
+++ b/src/data/proofs/erdos-624/meta.json
@@ -57,7 +57,7 @@
     ],
     "dateAdded": "2025-12-27",
     "axiomCount": 5,
-    "lineCount": 219,
+    "lineCount": 218,
     "assumptions": "5 axioms: erdos_hajnal_upper_bound, erdos_624_open, weaker_conjecture_open, and 2 more. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-629/meta.json
+++ b/src/data/proofs/erdos-629/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/629",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "lineCount": 912,
+    "lineCount": 911,
     "assumptions": "7 sorry(s). No axioms.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-643/meta.json
+++ b/src/data/proofs/erdos-643/meta.json
@@ -49,7 +49,7 @@
       "Statement of Erdős-Rado Sunflower Lemma connection"
     ],
     "axiomCount": 3,
-    "lineCount": 1403,
+    "lineCount": 1402,
     "assumptions": "3 axiom(s) and 1 sorry(s). See the Lean source for details."
   },
   "overview": {

--- a/src/data/proofs/erdos-69/meta.json
+++ b/src/data/proofs/erdos-69/meta.json
@@ -45,7 +45,7 @@
       "Structure connecting Problem 69 to Problem 257"
     ],
     "axiomCount": 1,
-    "lineCount": 189,
+    "lineCount": 188,
     "prerequisites": [
       "Arithmetic functions (ω, d, Ω) and prime factorization",
       "Infinite series, absolute convergence, and summation interchange",

--- a/src/data/proofs/erdos-795/meta.json
+++ b/src/data/proofs/erdos-795/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/795",
     "erdosProblemStatus": "solved",
     "axiomCount": 0,
-    "lineCount": 500,
+    "lineCount": 499,
     "assumptions": "15 sorry(s).",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-866/meta.json
+++ b/src/data/proofs/erdos-866/meta.json
@@ -54,7 +54,7 @@
       "Four open problems formalized as Lean propositions"
     ],
     "axiomCount": 0,
-    "lineCount": 85,
+    "lineCount": 84,
     "assumptions": "0 axioms. 0 sorries. All results formalized without axioms."
   },
   "overview": {

--- a/src/data/proofs/erdos-941/meta.json
+++ b/src/data/proofs/erdos-941/meta.json
@@ -58,7 +58,7 @@
       "generalizedQuestion: Problem #1107 connection"
     ],
     "axiomCount": 4,
-    "lineCount": 324,
+    "lineCount": 323,
     "assumptions": "4 axiom(s) and 0 sorry(s)."
   },
   "overview": {

--- a/src/data/proofs/navier-stokes-existence/meta.json
+++ b/src/data/proofs/navier-stokes-existence/meta.json
@@ -63,7 +63,7 @@
     ],
     "dateAdded": "2026-03-14",
     "relatedProblems": [],
-    "lineCount": 21111,
+    "lineCount": 21110,
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/navier-stokes-oq-01/meta.json
+++ b/src/data/proofs/navier-stokes-oq-01/meta.json
@@ -60,7 +60,7 @@
       "Theorem total_dissipation_bound: ∫₀ᵀ 2νP(t) dt ≤ E(0), total dissipation bounded by initial enstrophy"
     ],
     "dateAdded": "2026-02-26",
-    "lineCount": 21111,
+    "lineCount": 21110,
     "assumptions": "None. Formalized with 0 axioms and 0 sorries remain.",
     "relatedProblems": [
       {

--- a/src/data/proofs/navier-stokes-oq-02/meta.json
+++ b/src/data/proofs/navier-stokes-oq-02/meta.json
@@ -59,7 +59,7 @@
       "Theorem continuous_dependence_2d: for any ε > 0, threshold δ = ε·exp(-C·E(0)·T) gives W(0) ≤ δ implies W(t) ≤ ε, establishing Hadamard well-posedness"
     ],
     "dateAdded": "2026-02-28",
-    "lineCount": 21111,
+    "lineCount": 21110,
     "assumptions": "None. Formalized with 0 axioms and 0 sorries remain.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/navier-stokes/meta.json
+++ b/src/data/proofs/navier-stokes/meta.json
@@ -73,7 +73,7 @@
     "millenniumProblem": "navier-stokes",
     "proofRepoPath": "Proofs/NavierStokes.lean",
     "mathlib_version": "4.26.0",
-    "lineCount": 21111
+    "lineCount": 21110
   },
   "objection": {
     "verdict": "CONDITIONAL 3D + PROVEN 2D",


### PR DESCRIPTION
## Fix 1: Sync stale meta.lineCount in 40 proofs

PR #11583 corrected `leanFile.lineCount` for 40 proofs that were off by 1 from the actual `wc -l` count. However, each of these same proofs also has a `meta.lineCount` field which was **not updated** — creating an internal inconsistency where the two lineCount fields disagree within the same `meta.json`.

**Fix**: Corrects `meta.lineCount` (decremented by 1) to match `leanFile.lineCount` and the actual file size for all 40 affected proofs.

Affected proofs: area-of-circle-oq-01-oq-03, cauchy-schwarz-integral, erdos-1028, erdos-1034, erdos-108, erdos-109, erdos-1161, erdos-123, erdos-139, erdos-143, erdos-157, erdos-167, erdos-168, erdos-171, erdos-172, erdos-202, erdos-29, erdos-299, erdos-303, erdos-355, erdos-37, erdos-370, erdos-402, erdos-45, erdos-485, erdos-517, erdos-551, erdos-60, erdos-604, erdos-624, erdos-629, erdos-643, erdos-69, erdos-795, erdos-866, erdos-941, navier-stokes, navier-stokes-existence, navier-stokes-oq-01, navier-stokes-oq-02.

## Fix 2: Correct invalid status 'pending' in 7 Erdős proofs

7 gallery entries had `status="pending"` which is not a valid gallery status. Each has `sorries=1` and no axiom declarations, making `"formalized"` (with `badge="wip"`) the correct status. Also adds `axiomCount=0` where the field was missing.

**Valid gallery status values**: `verified` | `axiomatized` | `formalized`

Affected proofs: erdos-1206, erdos-1211, erdos-1212, erdos-1213, erdos-1215, erdos-1216, erdos-1217.

---
Automated fix by lean-mechanic agent.