### PR TITLE
Fix: correct non-standard badge values in 9 gallery proofs

### DIFF
--- a/src/data/proofs/feuerbachs-theorem-defs/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs/meta.json
@@ -20,7 +20,7 @@
       "infrastructure",
       "wiedijk-100"
     ],
-    "badge": "infrastructure",
+    "badge": "original",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/halting-problem/meta.json
+++ b/src/data/proofs/halting-problem/meta.json
@@ -14,7 +14,7 @@
       "classic",
       "intermediate"
     ],
-    "badge": "from-axioms",
+    "badge": "original",
     "sorries": 0,
     "mathlibDependencies": [],
     "originalContributions": [

--- a/src/data/proofs/newton-inductive-step/meta.json
+++ b/src/data/proofs/newton-inductive-step/meta.json
@@ -17,7 +17,7 @@
       "newton",
       "infrastructure"
     ],
-    "badge": "infrastructure",
+    "badge": "original",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/nth-root-irrational-oq-01/meta.json
+++ b/src/data/proofs/nth-root-irrational-oq-01/meta.json
@@ -17,7 +17,7 @@
       "galois-theory",
       "infrastructure"
     ],
-    "badge": "infrastructure",
+    "badge": "original",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/prime-gap-bounds/meta.json
+++ b/src/data/proofs/prime-gap-bounds/meta.json
@@ -17,7 +17,7 @@
       "prime-counting",
       "infrastructure"
     ],
-    "badge": "infrastructure",
+    "badge": "original",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/russell-1-plus-1/meta.json
+++ b/src/data/proofs/russell-1-plus-1/meta.json
@@ -16,7 +16,7 @@
       "beginner"
     ],
     "proofRepoPath": "Proofs/OnePlusOne.lean",
-    "badge": "from-axioms",
+    "badge": "original",
     "sorries": 0,
     "mathlibDependencies": [],
     "originalContributions": [

--- a/src/data/proofs/szemeredi-core/meta.json
+++ b/src/data/proofs/szemeredi-core/meta.json
@@ -16,7 +16,7 @@
       "regularity",
       "infrastructure"
     ],
-    "badge": "infrastructure",
+    "badge": "original",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/szemeredi-hypergraph-core-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/szemeredi-hypergraph-core-oq-01-incomplete-01/meta.json
@@ -18,7 +18,7 @@
       "research"
     ],
     "proofRepoPath": "Proofs/SzemerediHypergraphGowers.lean",
-    "badge": "research",
+    "badge": "wip",
     "sorries": 1,
     "mathlibDependencies": [
       {
@@ -128,7 +128,9 @@
     "imports": [
       "Proofs.SzemerediHypergraphCore"
     ],
-    "opens": ["Classical"],
+    "opens": [
+      "Classical"
+    ],
     "namespace": "Szemeredi.Hypergraph",
     "lineCount": 244,
     "axiomCount": 0,

--- a/src/data/proofs/szemeredi-hypergraph-core/meta.json
+++ b/src/data/proofs/szemeredi-hypergraph-core/meta.json
@@ -16,7 +16,7 @@
       "regularity",
       "infrastructure"
     ],
-    "badge": "infrastructure",
+    "badge": "original",
     "sorries": 0,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Fix

9 gallery proofs used non-standard badge values outside the valid vocabulary.

**Valid badge values**: `original` | `mathlib` | `axiom` | `verified` | `wip` | `sibling`

## Evidence

**`infrastructure` → `original`** (6 proofs — fully verified infrastructure code):
These proofs have `status=verified, sorries=0, axiomCount=0` and are original Lean formalizations.
- feuerbachs-theorem-defs, newton-inductive-step, nth-root-irrational-oq-01, prime-gap-bounds, szemeredi-core, szemeredi-hypergraph-core

**`from-axioms` → `original`** (2 proofs — self-contained, no Mathlib):
`halting-problem` and `russell-1-plus-1` both state explicitly in their source: "Foundation (from Mathlib): None! This file uses no Mathlib imports." They are fully original proofs from first principles.

**`research` → `wip`** (1 proof — formalized with sorries):
`szemeredi-hypergraph-core-oq-01-incomplete-01` has `status=formalized, sorries=1`. Work in progress = `wip` badge.

---
Automated fix by lean-mechanic agent.