### PR TITLE
Fix: correct invalid status pending→formalized in 7 gallery proofs

### DIFF
--- a/src/data/proofs/erdos-1206/meta.json
+++ b/src/data/proofs/erdos-1206/meta.json
@@ -7,7 +7,7 @@
     "author": "Unknown",
     "sourceUrl": "https://erdosproblems.com/1206",
     "date": "",
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1206Problem.lean",
     "tags": [
       "erdos"

--- a/src/data/proofs/erdos-1211/meta.json
+++ b/src/data/proofs/erdos-1211/meta.json
@@ -7,7 +7,7 @@
     "author": "Unknown",
     "sourceUrl": "https://erdosproblems.com/1211",
     "date": "",
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1211Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-1212/meta.json
+++ b/src/data/proofs/erdos-1212/meta.json
@@ -7,7 +7,7 @@
     "author": "Unknown",
     "sourceUrl": "https://erdosproblems.com/1212",
     "date": "",
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1212Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-1213/meta.json
+++ b/src/data/proofs/erdos-1213/meta.json
@@ -7,7 +7,7 @@
     "author": "Unknown",
     "sourceUrl": "https://erdosproblems.com/1213",
     "date": "",
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1213Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-1215/meta.json
+++ b/src/data/proofs/erdos-1215/meta.json
@@ -7,7 +7,7 @@
     "author": "Unknown",
     "sourceUrl": "https://erdosproblems.com/1215",
     "date": "",
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1215Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-1216/meta.json
+++ b/src/data/proofs/erdos-1216/meta.json
@@ -7,7 +7,7 @@
     "author": "Unknown",
     "sourceUrl": "https://erdosproblems.com/1216",
     "date": "",
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1216Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-1217/meta.json
+++ b/src/data/proofs/erdos-1217/meta.json
@@ -7,7 +7,7 @@
     "author": "Unknown",
     "sourceUrl": "https://erdosproblems.com/1217",
     "date": "",
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1217Problem.lean",
     "tags": [
       "erdos",


### PR DESCRIPTION
## Summary

- 7 gallery proofs (erdos-1206, -1211, -1212, -1213, -1215, -1216, -1217) had non-standard `status: "pending"`
- Corrected to `status: "formalized"` — each has `sorries: 1`, `badge: "wip"`
- Valid gallery status values: `verified`, `axiomatized`, `formalized`

Replaces #11600 which had drifted too far from main (100 files, Lean conflicts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)