### PR TITLE
Enrich 5 proofs: add mathlibDependencies, originalContributions, fix annotation gaps, add keyInsights

### DIFF
--- a/src/data/proofs/erdos-1-oq-02/meta.json
+++ b/src/data/proofs/erdos-1-oq-02/meta.json
@@ -23,7 +23,38 @@
     "lineCount": 194,
     "assumptions": "One axiom: anticoncentration_bound (Berry-Esseen). 1 sorry: dfx_lower_bound (statement may need correction for base cases). sum_sq_cauchy_schwarz proved via induction in Z.",
     "dateAdded": "2026-03-30",
-    "mathlib_version": "4.26.0"
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_le_sum",
+        "description": "Term-by-term summation inequality, used in sum_sq_le_card_mul_max_sq and sum_le_card_mul_max",
+        "module": "Mathlib.Algebra.BigOperators.Order"
+      },
+      {
+        "theorem": "Finset.induction_on",
+        "description": "Finset induction for sum_sq_cauchy_schwarz: proves (Σa)² ≤ n·Σa² by induction on the set",
+        "module": "Mathlib.Data.Finset.Basic"
+      },
+      {
+        "theorem": "Real.sqrt",
+        "description": "Square root for the DFX bound N ≥ √(2/π)·2ⁿ/√n and the anticoncentration_bound axiom",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "nlinarith",
+        "description": "Nonlinear arithmetic tactic for variance bounds and Cauchy-Schwarz derivation from (a-b)² ≥ 0 expansion",
+        "module": "Mathlib.Tactic.Linarith"
+      }
+    ],
+    "originalContributions": [
+      "sum_sq_le_card_mul_max_sq: Σa² ≤ |A|·N² (crude variance upper bound, term-by-term)",
+      "sum_sq_cauchy_schwarz: (Σa)² ≤ |A|·Σa² (Cauchy-Schwarz, proved by ℤ-lifting + Finset induction)",
+      "sum_le_card_mul_max: Σa ≤ |A|·max(A) (sum bounded by n times the maximum element)",
+      "anticoncentration_bound axiom: Berry-Esseen step 2^n ≤ √(2/π)·2(ΣA+1)/√(Σa²) for distinct subset sum sets",
+      "dfx_lower_bound: N ≥ √(2/π)·2ⁿ/√n (1 sorry for base-case arithmetic) — assembles the DFX framework",
+      "dfx_improves_counting: DFX bound is asymptotically better than counting bound (n < n² for n ≥ 2)",
+      "Concrete cases: f(1)=1 via Finset.subset_singleton_iff, f(2)=2 via simp"
+    ]
   },
   "overview": {
     "historicalContext": "Erdős Problem #1 ($500 prize) asks: if $A \\subseteq \\{1,\\ldots,N\\}$ has $n$ elements with all $2^n$ subset sums distinct, must $N \\geq c \\cdot 2^n$? Erdős conjectured the answer is yes with $c = 1/\\sqrt{2}$, matching the Conway–Guy sequence. The basic counting bound (1964) gives $N \\geq (2^n-1)/n$: since the sums lie in $[0, nN]$ with $nN+1$ possible values and there are $2^n$ sums, we need $nN + 1 \\geq 2^n$.\n\nDubroff, Fox, and Xu (2021) improved this to $N \\geq \\sqrt{2/\\pi} \\cdot 2^n/\\sqrt{n}$ using a variance-based anticoncentration argument rooted in the Berry–Esseen theorem. Their key idea: view the $2^n$ subset sums as values of the random variable $X = \\sum_{i=1}^n \\varepsilon_i a_i$ where $\\varepsilon_i \\in \\{0,1\\}$ are i.i.d. Bernoulli(1/2). The distinct subset sums condition forces $X$ to take $2^n$ distinct values. By the normal approximation, the density of $X$ is approximately Gaussian with mean $S/2$ and variance $V = \\sum a_i^2/4$; the anticoncentration of the Gaussian limits the number of distinct achievable values to $\\sim S/\\sqrt{V}$. Using Cauchy–Schwarz ($V \\geq S^2/(4n)$) and $S \\leq nN$, this gives $N \\geq \\sqrt{2/\\pi} \\cdot 2^n/\\sqrt{n}$, improving the counting bound by $\\sqrt{n}$.\n\nThe gap between DFX ($\\sim 2^n/\\sqrt{n}$) and the conjectured optimum ($\\sim 2^n/\\sqrt{2}$) remains open. The Conway–Guy sequence (formalized in the companion erdos-1-oq-03) suggests the true answer is $N \\sim 2^n/\\sqrt{2}$, but this has not been proved.",


### PR DESCRIPTION
## Summary

**collatz-structured-oq-03:**
- Add `mathlibDependencies` (Nat.find, Finset.sum, Real.log, Filter.Tendsto)
- Add `originalContributions` (8 items covering key definitions and theorems)
- Fix `ann-concrete-and-checks` startLine 135→134 (1-line annotation gap)

**konigsberg-oq-03:**
- Add `mathlibDependencies` (Finset.filter, WithTop, SimpleGraph, Set.toFinite)
- Add `originalContributions` (7 items for all structural definitions)
- Add 6th keyInsight: graph ends / Freudenthal compactification as topological foundation for EGW even-cut condition (Diestel-Kühn 2003)

Both entries had tracker quality=0 (stale) but were already well-enriched with 8-11 annotations, keyInsights, and crossRefs. These additions complete the standard meta fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)