### PR TITLE
Sync: lineCount fixes + research registry update

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -16937,11 +16937,12 @@
     },
     {
       "slug": "area-of-circle-oq-05-oq-02",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-04-21T18:07:30.995892+00:00",
-      "status": "active",
-      "lastUpdate": "2026-04-21T18:07:30.995892+00:00"
+      "status": "graduated",
+      "lastUpdate": "2026-04-23T01:30:19.724Z",
+      "completed": "2026-04-23T01:30:19.719Z"
     },
     {
       "slug": "angle-trisection-oq-04-oq-03",
@@ -17186,11 +17187,11 @@
     },
     {
       "slug": "szemeredi-counting-oq-02",
-      "phase": "NEW",
+      "phase": "OBSERVE",
       "path": "full",
       "started": "2026-04-22T13:25:38.671Z",
       "status": "active",
-      "lastUpdate": "2026-04-22T13:25:38.671Z"
+      "lastUpdate": "2026-04-23T01:30:20.616Z"
     },
     {
       "slug": "szemeredi-full-oq-01",

--- a/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "area-of-circle-oq-01-oq-03",
-  "title": "Isoperimetric Inequality: C² ≥ 4πA",
+  "title": "Isoperimetric Inequality: C\u00b2 \u2265 4\u03c0A",
   "slug": "area-of-circle-oq-01-oq-03",
-  "description": "For any regular closed curve with circumference C enclosing area A, the isoperimetric inequality C² ≥ 4πA holds, with equality iff the curve is a circle. Proves 60+ theorems/lemmas (0 sorries, 0 axioms) including arc-length reparametrization infrastructure, Wirtinger's inequality (proved from Fourier decomposition), Parseval's identity, the general isoperimetric inequality (for regular curves), equality characterization, and concrete verification for circles, squares, regular n-gons, and equilateral triangles.",
+  "description": "For any regular closed curve with circumference C enclosing area A, the isoperimetric inequality C\u00b2 \u2265 4\u03c0A holds, with equality iff the curve is a circle. Proves 60+ theorems/lemmas (0 sorries, 0 axioms) including arc-length reparametrization infrastructure, Wirtinger's inequality (proved from Fourier decomposition), Parseval's identity, the general isoperimetric inequality (for regular curves), equality characterization, and concrete verification for circles, squares, regular n-gons, and equilateral triangles.",
   "meta": {
     "author": "Hurwitz (1901), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Isoperimetric_inequality",
@@ -24,7 +24,7 @@
     "mathlibDependencies": [
       {
         "theorem": "Real.pi_lt_four",
-        "description": "π < 4, used to prove square is suboptimal",
+        "description": "\u03c0 < 4, used to prove square is suboptimal",
         "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Bounds"
       },
       {
@@ -39,20 +39,20 @@
       }
     ],
     "originalContributions": [
-      "Equality case for circles: C² = 4πA proved by ring computation",
-      "Strict inequality for squares: C² > 4πA from π < 4",
-      "Regular n-gon isoperimetric ratio: 4πA/C² = π/(n·tan(π/n))",
+      "Equality case for circles: C\u00b2 = 4\u03c0A proved by ring computation",
+      "Strict inequality for squares: C\u00b2 > 4\u03c0A from \u03c0 < 4",
+      "Regular n-gon isoperimetric ratio: 4\u03c0A/C\u00b2 = \u03c0/(n\u00b7tan(\u03c0/n))",
       "Connection to OQ01: C = dA/dr links to the circumference-as-derivative result",
       "Proof architecture: Wirtinger's inequality implies isoperimetric via Cauchy-Schwarz + AM-GM",
-      "SmoothClosedCurve structure for parametric curves in ℝ²",
-      "2D Cauchy-Schwarz (algebraic): |xv-yu|² ≤ (x²+y²)(u²+v²) proved via nlinarith",
-      "Arithmetic kernel of Hurwitz proof: from Wirtinger bounds (Sxy≤2πc², S²≤2πSxy, 2A≤cS) to 4πA≤L² — all inequalities fully proved",
-      "Integral Cauchy-Schwarz on [0,2π]: (∫f)² ≤ 2π·∫f² via discriminant method",
+      "SmoothClosedCurve structure for parametric curves in \u211d\u00b2",
+      "2D Cauchy-Schwarz (algebraic): |xv-yu|\u00b2 \u2264 (x\u00b2+y\u00b2)(u\u00b2+v\u00b2) proved via nlinarith",
+      "Arithmetic kernel of Hurwitz proof: from Wirtinger bounds (Sxy\u22642\u03c0c\u00b2, S\u00b2\u22642\u03c0Sxy, 2A\u2264cS) to 4\u03c0A\u2264L\u00b2 \u2014 all inequalities fully proved",
+      "Integral Cauchy-Schwarz on [0,2\u03c0]: (\u222bf)\u00b2 \u2264 2\u03c0\u00b7\u222bf\u00b2 via discriminant method",
       "Wirtinger's inequality: PROVED from Fourier decomposition axiom via hasSum_le comparison",
       "Fourier decomposition axiom: captures Parseval + IBP for Fourier coefficients",
-      "Wirtinger sum-of-squares bound: ∫(x²+y²) ≤ 2πc² from Wirtinger theorem + integral linearity",
-      "Area bound: 2A ≤ c·∫√(x²+y²) via 2D Cauchy-Schwarz + abs_le + integral monotonicity",
-      "equality_implies_circle: PROVED (was axiom) — if 4πA=C², set r=C/(2π), then C=2πr and A=πr² by field_simp+linarith"
+      "Wirtinger sum-of-squares bound: \u222b(x\u00b2+y\u00b2) \u2264 2\u03c0c\u00b2 from Wirtinger theorem + integral linearity",
+      "Area bound: 2A \u2264 c\u00b7\u222b\u221a(x\u00b2+y\u00b2) via 2D Cauchy-Schwarz + abs_le + integral monotonicity",
+      "equality_implies_circle: PROVED (was axiom) \u2014 if 4\u03c0A=C\u00b2, set r=C/(2\u03c0), then C=2\u03c0r and A=\u03c0r\u00b2 by field_simp+linarith"
     ],
     "dateAdded": "2026-02-24",
     "axiomCount": 0,
@@ -61,15 +61,15 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "The isoperimetric problem — find the shape of maximum area for a given perimeter — is one of the oldest optimization problems in mathematics, traced to ancient Dido of Carthage (~900 BCE). The problem asks: among all closed curves of length $L$, which encloses the most area? The answer is a circle, and the isoperimetric inequality $C^2 \\geq 4\\pi A$ quantifies how much any curve falls short. Archimedes knew the result informally (~250 BCE), but a rigorous proof waited until the 19th century. Steiner (1838) gave an elegant proof using symmetrization, but didn't prove existence of the maximizer. Weierstrass (1870s) gave the first complete proof using calculus of variations. The most elegant proof is due to Hurwitz (1901), who used Fourier series and the Wirtinger inequality.",
+    "historicalContext": "The isoperimetric problem \u2014 find the shape of maximum area for a given perimeter \u2014 is one of the oldest optimization problems in mathematics, traced to ancient Dido of Carthage (~900 BCE). The problem asks: among all closed curves of length $L$, which encloses the most area? The answer is a circle, and the isoperimetric inequality $C^2 \\geq 4\\pi A$ quantifies how much any curve falls short. Archimedes knew the result informally (~250 BCE), but a rigorous proof waited until the 19th century. Steiner (1838) gave an elegant proof using symmetrization, but didn't prove existence of the maximizer. Weierstrass (1870s) gave the first complete proof using calculus of variations. The most elegant proof is due to Hurwitz (1901), who used Fourier series and the Wirtinger inequality.",
     "problemStatement": "**Isoperimetric Inequality**:\n\nFor any simple closed curve $\\gamma$ in the plane with circumference $C$ and enclosed area $A$:\n$$C^2 \\geq 4\\pi A$$\nwith equality if and only if $\\gamma$ is a circle.\n\n**Connection to OQ Chain**:\n- OQ01: $C = \\frac{dA}{dr}$ (circumference from differentiating area)\n- OQ01-OQ02: $A = \\int_0^r C(\\rho)\\,d\\rho$ (area from integrating circumference)\n- OQ01-OQ03 (this file): $C^2 \\geq 4\\pi A$ for ALL closed curves (isoperimetric inequality)",
-    "text": "A comprehensive 1478-line formalization of the isoperimetric inequality $C^2 \\geq 4\\pi A$ via the Hurwitz proof (1901). Defines `SmoothClosedCurve` (x, y smooth 2π-periodic) with circumference (arc length) and area (Green's theorem). Proves Parseval's identity for periodic functions, then Wirtinger's inequality from the Fourier decomposition: $\\int_0^{2\\pi} f^2 \\leq \\int_0^{2\\pi} (f')^2$ for zero-mean $f$, using Parseval's theorem ($\\int f^2 = 2\\pi \\sum \\|\\hat{c}_n\\|^2$ implies $\\int (f')^2 = 2\\pi \\sum n^2 \\|\\hat{c}_n\\|^2 \\geq \\int f^2$). Combined with Green's theorem for area, mean subtraction, integral Cauchy-Schwarz, and the arithmetic kernel, this yields the isoperimetric inequality. Equality holds iff the curve is a circle (proved algebraically). Concrete verifications for circles (ratio $= 1$), squares ($\\pi/4 \\approx 0.785$), equilateral triangles ($\\pi\\sqrt{3}/9 \\approx 0.605$), and regular $n$-gons ($\\pi/(n \\cdot \\tan(\\pi/n)) \\to 1$). 52 theorems/lemmas, 0 sorries, 0 axioms.",
+    "text": "A comprehensive 1478-line formalization of the isoperimetric inequality $C^2 \\geq 4\\pi A$ via the Hurwitz proof (1901). Defines `SmoothClosedCurve` (x, y smooth 2\u03c0-periodic) with circumference (arc length) and area (Green's theorem). Proves Parseval's identity for periodic functions, then Wirtinger's inequality from the Fourier decomposition: $\\int_0^{2\\pi} f^2 \\leq \\int_0^{2\\pi} (f')^2$ for zero-mean $f$, using Parseval's theorem ($\\int f^2 = 2\\pi \\sum \\|\\hat{c}_n\\|^2$ implies $\\int (f')^2 = 2\\pi \\sum n^2 \\|\\hat{c}_n\\|^2 \\geq \\int f^2$). Combined with Green's theorem for area, mean subtraction, integral Cauchy-Schwarz, and the arithmetic kernel, this yields the isoperimetric inequality. Equality holds iff the curve is a circle (proved algebraically). Concrete verifications for circles (ratio $= 1$), squares ($\\pi/4 \\approx 0.785$), equilateral triangles ($\\pi\\sqrt{3}/9 \\approx 0.605$), and regular $n$-gons ($\\pi/(n \\cdot \\tan(\\pi/n)) \\to 1$). 52 theorems/lemmas, 0 sorries, 0 axioms.",
     "proofStrategy": "The **Hurwitz proof** (1901) uses Fourier analysis:\n1. Parameterize the curve $\\gamma(t) = (x(t), y(t))$ with $t \\in [0, 2\\pi]$\n2. Apply **Green's theorem**: $A = \\frac{1}{2}|\\int_0^{2\\pi}(xy' - yx')\\,dt|$\n3. Apply **Wirtinger's inequality**: for $f$ with zero mean, $\\int_0^{2\\pi} f^2\\,dt \\leq \\int_0^{2\\pi}(f')^2\\,dt$\n4. Combined with **Cauchy-Schwarz** and **AM-GM**: this gives $4\\pi A \\leq L^2$\n\nWirtinger follows from **Parseval's theorem** for Fourier series: with $f(t) = \\sum_{n \\geq 1}(a_n \\cos(nt) + b_n \\sin(nt))$, Parseval gives $\\int f^2 = \\pi \\sum(a_n^2 + b_n^2)$ and $\\int(f')^2 = \\pi \\sum n^2(a_n^2 + b_n^2) \\geq \\int f^2$.",
     "keyInsights": [
       "**Equality for circles** is a trivial ring computation: $(2\\pi r)^2 = 4\\pi \\cdot \\pi r^2$",
       "**Squares are suboptimal** because $4\\pi/16 = \\pi/4 < 1$ (equivalently $C^2/(4\\pi A) = 16/\\pi > 1$)",
       "**Regular n-gons** have ratio $\\pi/(n\\tan(\\pi/n)) \\to 1$ as $n \\to \\infty$, converging to circles from below",
-      "**Wirtinger's inequality** is NOW PROVED from a Fourier decomposition axiom via hasSum_le — the axiom captures Parseval + IBP for Fourier coefficients, both available in Mathlib",
+      "**Wirtinger's inequality** is NOW PROVED from a Fourier decomposition axiom via hasSum_le \u2014 the axiom captures Parseval + IBP for Fourier coefficients, both available in Mathlib",
       "**The proof reduces to Wirtinger**: once Wirtinger is proved, the isoperimetric inequality follows by ~100 lines of Cauchy-Schwarz + AM-GM arguments",
       "**Connection to OQ01**: the equality $C = dA/dr$ for circles is exactly what makes circles special in the isoperimetric inequality"
     ],
@@ -85,23 +85,23 @@
       "title": "Problem Statement, Imports, and Overview",
       "startLine": 1,
       "endLine": 85,
-      "summary": "File header with Aristotle proof credits, the OQ chain explanation (OQ01 → OQ02 → OQ03), the isoperimetric inequality C²≥4πA, Hurwitz's Fourier proof strategy, and Mathlib imports.",
+      "summary": "File header with Aristotle proof credits, the OQ chain explanation (OQ01 \u2192 OQ02 \u2192 OQ03), the isoperimetric inequality C\u00b2\u22654\u03c0A, Hurwitz's Fourier proof strategy, and Mathlib imports.",
       "mathContext": "File header explaining the OQ chain (OQ01 $\\to$ OQ02 $\\to$ OQ03), the isoperimetric inequality $C^2 \\geq 4\\pi A$, and Hurwitz's Fourier proof strategy. Imports from Mathlib trigonometry, calculus, and Fourier analysis."
     },
     {
       "id": "part-i-circle",
-      "title": "Part I: The Circle Case — Equality C² = 4πA",
+      "title": "Part I: The Circle Case \u2014 Equality C\u00b2 = 4\u03c0A",
       "startLine": 86,
       "endLine": 139,
-      "summary": "circleCirc, circleArea definitions. circle_isoperimetric_equality: (2πr)²=4π·πr² by ring. circle_isoperimetric_ratio=1. circumference_is_deriv_of_area: C = dA/dr (connection to OQ01). circleCirc_pos, circleArea_pos positivity results.",
+      "summary": "circleCirc, circleArea definitions. circle_isoperimetric_equality: (2\u03c0r)\u00b2=4\u03c0\u00b7\u03c0r\u00b2 by ring. circle_isoperimetric_ratio=1. circumference_is_deriv_of_area: C = dA/dr (connection to OQ01). circleCirc_pos, circleArea_pos positivity results.",
       "mathContext": "circleCirc, circleArea definitions. circle\\_isoperimetric\\_equality: $(2\\pi r)^2 = 4\\pi \\cdot \\pi r^2$ by ring. circle\\_isoperimetric\\_ratio $= 1$. circumference\\_is\\_deriv\\_of\\_area: $C = dA/dr$ (connection to OQ01)."
     },
     {
       "id": "part-ii-square",
-      "title": "Part II: The Square Case — Strict Inequality C² > 4πA",
+      "title": "Part II: The Square Case \u2014 Strict Inequality C\u00b2 > 4\u03c0A",
       "startLine": 139,
       "endLine": 173,
-      "summary": "squareCirc, squareArea definitions. square_isoperimetric_strict: C²>4πA for squares, proved by π<4 (Real.pi_lt_four). square_isoperimetric_ratio = π/4. square_ratio_lt_one: π/4 < 1.",
+      "summary": "squareCirc, squareArea definitions. square_isoperimetric_strict: C\u00b2>4\u03c0A for squares, proved by \u03c0<4 (Real.pi_lt_four). square_isoperimetric_ratio = \u03c0/4. square_ratio_lt_one: \u03c0/4 < 1.",
       "mathContext": "squareCirc, squareArea definitions. square\\_isoperimetric\\_strict: $C^2 > 4\\pi A$ for squares, proved by $\\pi < 4$. square\\_isoperimetric\\_ratio $= \\pi/4 \\approx 0.785$."
     },
     {
@@ -109,7 +109,7 @@
       "title": "Part III: Regular n-gons Approach the Circle",
       "startLine": 173,
       "endLine": 277,
-      "summary": "regular_ngon_isoperimetric_ratio = π/(n·tan(π/n)) for circumradius R. ngon_limit_tendsto_circle: the ratio tends to 1 as n→∞, proved using Real.hasDerivAt_tan and hasDerivAt_iff_tendsto_slope (tan(h)/h→1 at h=0).",
+      "summary": "regular_ngon_isoperimetric_ratio = \u03c0/(n\u00b7tan(\u03c0/n)) for circumradius R. ngon_limit_tendsto_circle: the ratio tends to 1 as n\u2192\u221e, proved using Real.hasDerivAt_tan and hasDerivAt_iff_tendsto_slope (tan(h)/h\u21921 at h=0).",
       "mathContext": "regular\\_ngon\\_isoperimetric\\_ratio $= \\pi/(n\\tan(\\pi/n))$ for circumradius $R$. ngon\\_limit\\_tendsto\\_circle: the ratio tends to 1 as $n \\to \\infty$, proved via $\\tan(h)/h \\to 1$ at $h=0$."
     },
     {
@@ -117,7 +117,7 @@
       "title": "Part IV: Wirtinger's Inequality and the Isoperimetric Deduction",
       "startLine": 277,
       "endLine": 666,
-      "summary": "Parseval's identity (parseval_periodic_real, proved via Aristotle). Fourier coefficient IBP (fourierCoeffOn_deriv_periodic, proved). Fourier decomposition theorem (proved from Parseval + IBP). SmoothClosedCurve structure. circleGamma with verified circumference 2πr and area πr². Wirtinger's inequality proved from Fourier decomposition via hasSum_le.",
+      "summary": "Parseval's identity (parseval_periodic_real, proved via Aristotle). Fourier coefficient IBP (fourierCoeffOn_deriv_periodic, proved). Fourier decomposition theorem (proved from Parseval + IBP). SmoothClosedCurve structure. circleGamma with verified circumference 2\u03c0r and area \u03c0r\u00b2. Wirtinger's inequality proved from Fourier decomposition via hasSum_le.",
       "mathContext": "**Parseval**: $\\int_0^{2\\pi} f^2 = 2\\pi \\sum \\|\\hat{c}_n\\|^2$ (proved). **IBP**: $\\hat{c}_n(f') = in \\cdot \\hat{c}_n(f)$ (proved). **Fourier decomposition**: combines Parseval + IBP. **Wirtinger**: $\\int_0^{2\\pi} f^2 \\leq \\int_0^{2\\pi} (f')^2$ for mean-zero periodic $f$ (proved from Fourier decomposition)."
     },
     {
@@ -125,7 +125,7 @@
       "title": "Part IV-B: Arithmetic Foundations for the Isoperimetric Proof",
       "startLine": 666,
       "endLine": 732,
-      "summary": "cross_product_sq_le: 2D Cauchy-Schwarz (xv-yu)² ≤ (x²+y²)(u²+v²) by nlinarith. isoperimetric_from_wirtinger_bounds: arithmetic kernel — from Wirtinger bounds (Sxy≤2πc², S²≤2πSxy, 2A≤cS) to 4πA≤L². All inequalities fully proved.",
+      "summary": "cross_product_sq_le: 2D Cauchy-Schwarz (xv-yu)\u00b2 \u2264 (x\u00b2+y\u00b2)(u\u00b2+v\u00b2) by nlinarith. isoperimetric_from_wirtinger_bounds: arithmetic kernel \u2014 from Wirtinger bounds (Sxy\u22642\u03c0c\u00b2, S\u00b2\u22642\u03c0Sxy, 2A\u2264cS) to 4\u03c0A\u2264L\u00b2. All inequalities fully proved.",
       "mathContext": "**2D Cauchy-Schwarz**: $(xv-yu)^2 \\leq (x^2+y^2)(u^2+v^2)$. **Arithmetic kernel**: chain $S^2 \\leq 2\\pi S_{xy} \\leq (2\\pi c)^2$, then $2A \\leq cS \\leq 2\\pi c^2$, giving $4\\pi A \\leq L^2$."
     },
     {
@@ -133,7 +133,7 @@
       "title": "Part V: The Isoperimetric Inequality for Smooth Curves",
       "startLine": 732,
       "endLine": 1235,
-      "summary": "Mean subtraction infrastructure (preserves circumference and area, achieves zero mean). Arc-length reparametrization (exists_arclength_reparam, proved). Wirtinger sum-of-squares bound. Integral Cauchy-Schwarz on [0,2π]. Area bound from constant speed. isoperimetric_inequality_smooth: the main theorem — fully proved via reparametrization + Wirtinger bounds + arithmetic kernel.",
+      "summary": "Mean subtraction infrastructure (preserves circumference and area, achieves zero mean). Arc-length reparametrization (exists_arclength_reparam, proved). Wirtinger sum-of-squares bound. Integral Cauchy-Schwarz on [0,2\u03c0]. Area bound from constant speed. isoperimetric_inequality_smooth: the main theorem \u2014 fully proved via reparametrization + Wirtinger bounds + arithmetic kernel.",
       "mathContext": "**Main theorem** `isoperimetric_inequality_smooth`: $4\\pi A \\leq C^2$ for any SmoothClosedCurve. Proved by: (1) reparametrize to constant speed + zero mean, (2) apply Wirtinger bounds, (3) apply arithmetic kernel."
     },
     {
@@ -141,7 +141,7 @@
       "title": "Part VI: Equality Characterization",
       "startLine": 1235,
       "endLine": 1274,
-      "summary": "circle_satisfies_isoperimetric: circles achieve equality C²=4πA. equality_implies_circle: proved (was axiom) — if 4πA=C², set r=C/(2π), then C=circleCirc r and A=circleArea r (purely algebraic).",
+      "summary": "circle_satisfies_isoperimetric: circles achieve equality C\u00b2=4\u03c0A. equality_implies_circle: proved (was axiom) \u2014 if 4\u03c0A=C\u00b2, set r=C/(2\u03c0), then C=circleCirc r and A=circleArea r (purely algebraic).",
       "mathContext": "circle\\_satisfies\\_isoperimetric: circles achieve equality. equality\\_implies\\_circle: if $4\\pi A = C^2$, set $r = C/(2\\pi)$, then $C = 2\\pi r$ and $A = \\pi r^2$ by field\\_simp + linarith."
     },
     {
@@ -149,25 +149,25 @@
       "title": "Part VII: Algebraic Corollaries of the Isoperimetric Inequality",
       "startLine": 1274,
       "endLine": 1422,
-      "summary": "isoperimetric_area_bound: A ≤ C²/(4π). minimum_circumference_for_area: C ≥ 2√(πA). isoperimetric_ratio_scale_invariant: ratio unchanged by scaling. circle_maximizes_area: circle is optimal for fixed circumference. non_circle_area_lt_circle: non-circles have strictly less area.",
+      "summary": "isoperimetric_area_bound: A \u2264 C\u00b2/(4\u03c0). minimum_circumference_for_area: C \u2265 2\u221a(\u03c0A). isoperimetric_ratio_scale_invariant: ratio unchanged by scaling. circle_maximizes_area: circle is optimal for fixed circumference. non_circle_area_lt_circle: non-circles have strictly less area.",
       "mathContext": "Corollaries: $A \\leq C^2/(4\\pi)$, $C \\geq 2\\sqrt{\\pi A}$, scale invariance, circle maximizes area for fixed perimeter."
     },
     {
       "id": "part-viii-triangle",
-      "title": "Part VIII: Equilateral Triangle — A Concrete Example",
+      "title": "Part VIII: Equilateral Triangle \u2014 A Concrete Example",
       "startLine": 1422,
       "endLine": 1478,
-      "summary": "equiTriCirc, equiTriArea definitions. equi_tri_isoperimetric_ratio = π√3/9. equi_tri_ratio_lt_one: π√3/9 < 1 (strict inequality). equi_tri_strict_inequality: 4πA < C² for equilateral triangles.",
+      "summary": "equiTriCirc, equiTriArea definitions. equi_tri_isoperimetric_ratio = \u03c0\u221a3/9. equi_tri_ratio_lt_one: \u03c0\u221a3/9 < 1 (strict inequality). equi_tri_strict_inequality: 4\u03c0A < C\u00b2 for equilateral triangles.",
       "mathContext": "Equilateral triangle with side $a$: $C = 3a$, $A = \\sqrt{3}a^2/4$, ratio $= \\pi\\sqrt{3}/9 \\approx 0.605 < 1$."
     }
   ],
   "conclusion": {
-    "summary": "This file formalizes the isoperimetric inequality C²≥4πA in the context of the area-of-circle OQ chain. Circles achieve equality (proved by ring computation). Squares satisfy strict inequality (from π<4). Regular n-gons converge to the circle's ratio as n→∞ (proved via tan(h)/h→1). Equilateral triangles have ratio π√3/9 ≈ 0.605. The Hurwitz proof architecture is fully established: Parseval's identity (proved), Wirtinger's inequality (proved from Fourier decomposition), SmoothClosedCurve structure, arithmetic kernel, and reparametrization infrastructure. The main theorem isoperimetric_inequality_smooth is fully proved. equality_implies_circle is a theorem (purely algebraic). Total: 52 theorems/lemmas, 0 sorries, 0 axioms.",
-    "implications": "**Theoretical Significance**: The isoperimetric inequality is one of the deepest results in classical geometry: it quantifies how far any curve is from the optimum (circle).\n\nThe Hurwitz proof via Fourier analysis is particularly elegant — it reduces the geometric inequality to a spectral-theoretic fact (Parseval's theorem). This file's approach through the OQ chain (C=dA/dr → A=∫C dρ → C²≥4πA) reveals that the three results about circles form a complete picture: the circumference is the derivative of area, the area is the integral of circumference, and the square of circumference bounds 4π times area — the last being an upper bound that circles uniquely achieve.",
+    "summary": "This file formalizes the isoperimetric inequality C\u00b2\u22654\u03c0A in the context of the area-of-circle OQ chain. Circles achieve equality (proved by ring computation). Squares satisfy strict inequality (from \u03c0<4). Regular n-gons converge to the circle's ratio as n\u2192\u221e (proved via tan(h)/h\u21921). Equilateral triangles have ratio \u03c0\u221a3/9 \u2248 0.605. The Hurwitz proof architecture is fully established: Parseval's identity (proved), Wirtinger's inequality (proved from Fourier decomposition), SmoothClosedCurve structure, arithmetic kernel, and reparametrization infrastructure. The main theorem isoperimetric_inequality_smooth is fully proved. equality_implies_circle is a theorem (purely algebraic). Total: 52 theorems/lemmas, 0 sorries, 0 axioms.",
+    "implications": "**Theoretical Significance**: The isoperimetric inequality is one of the deepest results in classical geometry: it quantifies how far any curve is from the optimum (circle).\n\nThe Hurwitz proof via Fourier analysis is particularly elegant \u2014 it reduces the geometric inequality to a spectral-theoretic fact (Parseval's theorem). This file's approach through the OQ chain (C=dA/dr \u2192 A=\u222bC d\u03c1 \u2192 C\u00b2\u22654\u03c0A) reveals that the three results about circles form a complete picture: the circumference is the derivative of area, the area is the integral of circumference, and the square of circumference bounds 4\u03c0 times area \u2014 the last being an upper bound that circles uniquely achieve.",
     "openQuestions": [
-      "Both previously open sorries have been resolved: (1) fourierCoeffOn_deriv_periodic (IBP: ĉₙ(f') = in·ĉₙ(f)) proved via import from AreaOfCircleOQ01OQ02OQ02.lean, and (2) exists_arclength_reparam proved via arc-length reparametrization infrastructure.",
+      "Both previously open sorries have been resolved: (1) fourierCoeffOn_deriv_periodic (IBP: \u0109\u2099(f') = in\u00b7\u0109\u2099(f)) proved via import from AreaOfCircleOQ01OQ02OQ02.lean, and (2) exists_arclength_reparam proved via arc-length reparametrization infrastructure.",
       "Can the isoperimetric inequality be proved for Lipschitz (not just smooth) curves? (Requires a measure-theoretic formulation of arc length and area)",
-      "What is the sharp constant in the isoperimetric inequality for non-Euclidean geometries (hyperbolic plane, sphere)? (This requires curvature corrections to 4πA ≤ C²)",
+      "What is the sharp constant in the isoperimetric inequality for non-Euclidean geometries (hyperbolic plane, sphere)? (This requires curvature corrections to 4\u03c0A \u2264 C\u00b2)",
       "Is there a constructive (computable) proof of the isoperimetric inequality? (Classical proofs use non-constructive analysis via Parseval, but Bishop-style constructive analysis might work)"
     ]
   },
@@ -185,7 +185,7 @@
     {
       "targetId": "area-of-circle-oq-01-oq-02",
       "relationship": "extends",
-      "description": "OQ01-OQ02 proves A = ∫C dρ; OQ03 proves C²≥4πA completes the circle"
+      "description": "OQ01-OQ02 proves A = \u222bC d\u03c1; OQ03 proves C\u00b2\u22654\u03c0A completes the circle"
     },
     {
       "targetId": "isoperimetric-theorem",
@@ -195,7 +195,7 @@
     {
       "targetId": "area-of-circle-oq-01-oq-02-oq-02",
       "relationship": "uses",
-      "description": "The IBP formula for Fourier coefficients ĉₙ(f') = in·ĉₙ(f) proved there is a key ingredient in Hurwitz's Fourier-analytic proof of the isoperimetric inequality"
+      "description": "The IBP formula for Fourier coefficients \u0109\u2099(f') = in\u00b7\u0109\u2099(f) proved there is a key ingredient in Hurwitz's Fourier-analytic proof of the isoperimetric inequality"
     },
     {
       "targetId": "fourier-series",
@@ -205,34 +205,34 @@
     {
       "targetId": "cauchy-schwarz",
       "relationship": "uses",
-      "description": "The 2D Cauchy-Schwarz inequality (xv-yu)² ≤ (x²+y²)(u²+v²) proved here as cross_product_sq_le is used in the arithmetic kernel of the isoperimetric proof"
+      "description": "The 2D Cauchy-Schwarz inequality (xv-yu)\u00b2 \u2264 (x\u00b2+y\u00b2)(u\u00b2+v\u00b2) proved here as cross_product_sq_le is used in the arithmetic kernel of the isoperimetric proof"
     },
     {
       "targetId": "borsuk-ulam",
       "relationship": "thematic",
-      "description": "The Borsuk-Ulam theorem and the isoperimetric inequality are both topological/geometric results about the structure of continuous maps on spheres. While the isoperimetric inequality characterizes the circle as the area-optimal curve, Borsuk-Ulam provides topological constraints on continuous mappings of spheres — both reveal deep geometric rigidity phenomena"
+      "description": "The Borsuk-Ulam theorem and the isoperimetric inequality are both topological/geometric results about the structure of continuous maps on spheres. While the isoperimetric inequality characterizes the circle as the area-optimal curve, Borsuk-Ulam provides topological constraints on continuous mappings of spheres \u2014 both reveal deep geometric rigidity phenomena"
     }
   ],
   "references": [
     {
       "authors": "Hurwitz, Adolf",
-      "title": "Sur le problème des isopérimètres",
+      "title": "Sur le probl\u00e8me des isop\u00e9rim\u00e8tres",
       "year": "1901",
-      "venue": "Comptes Rendus de l'Académie des Sciences, vol. 132, pp. 401–403",
-      "note": "Elegant proof of the isoperimetric inequality using Fourier series and the Wirtinger inequality — the approach formalized in this file"
+      "venue": "Comptes Rendus de l'Acad\u00e9mie des Sciences, vol. 132, pp. 401\u2013403",
+      "note": "Elegant proof of the isoperimetric inequality using Fourier series and the Wirtinger inequality \u2014 the approach formalized in this file"
     },
     {
       "authors": "Steiner, Jakob",
-      "title": "Einfache Beweise der isoperimetrischen Hauptsätze",
+      "title": "Einfache Beweise der isoperimetrischen Haupts\u00e4tze",
       "year": "1838",
-      "venue": "Journal für die reine und angewandte Mathematik (Crelle's Journal), vol. 18, pp. 281–296",
-      "note": "Pioneering proof via symmetrization that any non-circular shape can be improved — established the geometric approach but lacked a rigorous existence proof"
+      "venue": "Journal f\u00fcr die reine und angewandte Mathematik (Crelle's Journal), vol. 18, pp. 281\u2013296",
+      "note": "Pioneering proof via symmetrization that any non-circular shape can be improved \u2014 established the geometric approach but lacked a rigorous existence proof"
     },
     {
       "authors": "Osserman, Robert",
       "title": "The isoperimetric inequality",
       "year": "1978",
-      "venue": "Bulletin of the American Mathematical Society, vol. 84, no. 6, pp. 1182–1238",
+      "venue": "Bulletin of the American Mathematical Society, vol. 84, no. 6, pp. 1182\u20131238",
       "note": "Comprehensive survey of proofs and generalizations of the isoperimetric inequality, including the Hurwitz Fourier proof, Steiner symmetrization, and higher-dimensional analogues"
     },
     {
@@ -254,7 +254,7 @@
       "title": "Isoperimetric Inequalities: Differential Geometric and Analytic Perspectives",
       "year": "2001",
       "venue": "Cambridge University Press, Cambridge Tracts in Mathematics 145",
-      "note": "Modern treatment covering the isoperimetric inequality in Euclidean space, on manifolds, and in Gauss space — includes the Fourier-analytic proof (Chapter 2) and generalizations to curved spaces relevant to the open question about non-Euclidean geometry"
+      "note": "Modern treatment covering the isoperimetric inequality in Euclidean space, on manifolds, and in Gauss space \u2014 includes the Fourier-analytic proof (Chapter 2) and generalizations to curved spaces relevant to the open question about non-Euclidean geometry"
     }
   ],
   "leanFile": {
@@ -267,44 +267,44 @@
       "Topology"
     ],
     "namespace": "IsoperimetricOQ",
-    "lineCount": 1937,
+    "lineCount": 1938,
     "axiomCount": 0,
     "theoremCount": 68,
     "definitionCount": 12,
     "mainTheorems": [
       {
         "name": "isoperimetric_inequality_smooth",
-        "statement": "For any SmoothClosedCurve γ, 4π · area(γ) ≤ circumference(γ)²",
+        "statement": "For any SmoothClosedCurve \u03b3, 4\u03c0 \u00b7 area(\u03b3) \u2264 circumference(\u03b3)\u00b2",
         "line": 1113
       },
       {
         "name": "wirtinger_inequality",
-        "statement": "For smooth mean-zero 2π-periodic f: ∫₀²π f² ≤ ∫₀²π (f')²",
+        "statement": "For smooth mean-zero 2\u03c0-periodic f: \u222b\u2080\u00b2\u03c0 f\u00b2 \u2264 \u222b\u2080\u00b2\u03c0 (f')\u00b2",
         "line": 643
       },
       {
         "name": "equality_implies_circle",
-        "statement": "If 4πA = C² then the curve is a circle (C = 2πr, A = πr² for r = C/(2π))",
+        "statement": "If 4\u03c0A = C\u00b2 then the curve is a circle (C = 2\u03c0r, A = \u03c0r\u00b2 for r = C/(2\u03c0))",
         "line": 1253
       },
       {
         "name": "circle_isoperimetric_equality",
-        "statement": "For a circle: (2πr)² = 4π · πr²",
+        "statement": "For a circle: (2\u03c0r)\u00b2 = 4\u03c0 \u00b7 \u03c0r\u00b2",
         "line": 102
       },
       {
         "name": "ngon_limit_tendsto_circle",
-        "statement": "Regular n-gon isoperimetric ratio π/(n·tan(π/n)) → 1 as n → ∞",
+        "statement": "Regular n-gon isoperimetric ratio \u03c0/(n\u00b7tan(\u03c0/n)) \u2192 1 as n \u2192 \u221e",
         "line": 219
       },
       {
         "name": "parseval_periodic_real",
-        "statement": "Parseval's identity: ∫₀²π f² = 2π · Σ ‖ĉₙ‖² for periodic C¹ functions",
+        "statement": "Parseval's identity: \u222b\u2080\u00b2\u03c0 f\u00b2 = 2\u03c0 \u00b7 \u03a3 \u2016\u0109\u2099\u2016\u00b2 for periodic C\u00b9 functions",
         "line": 350
       },
       {
         "name": "fourier_decomposition",
-        "statement": "Fourier decomposition with Parseval + derivative identity for periodic C¹ functions",
+        "statement": "Fourier decomposition with Parseval + derivative identity for periodic C\u00b9 functions",
         "line": 526
       }
     ],

--- a/src/data/proofs/cauchy-schwarz-integral/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral/meta.json
@@ -48,16 +48,16 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "**From Discrete Sums to Integrals: A Three-Generation Story**\n\nAugustin-Louis Cauchy first stated the discrete inequality $(\\sum a_i b_i)^2 \\leq (\\sum a_i^2)(\\sum b_i^2)$ in his 1821 *Cours d'Analyse*, proving it as a lemma for bounding products of sums. The proof was algebraic: expand $(\\sum a_i b_j - a_j b_i)^2 \\geq 0$ and rearrange — the Binet-Cauchy identity. This inequality became a workhorse of 19th-century analysis.\n\nViktor Yakovlevich Bunyakovsky (1804–1889) recognized in 1859 that Cauchy's argument extends to integrals. In his memoir *Sur quelques inégalités concernant les intégrales ordinaires et les intégrales aux différences finies*, published in the Memoirs of the St. Petersburg Academy, he proved the continuous version:\n$$\\left(\\int_a^b f(x) g(x) \\, dx\\right)^2 \\leq \\int_a^b f(x)^2 \\, dx \\cdot \\int_a^b g(x)^2 \\, dx$$\nfor Riemann-integrable functions on $[a,b]$. His proof replaced finite sums with Riemann sums and passed to the limit — the natural generalization of Cauchy's method.\n\nHermann Amandus Schwarz (1843–1921) independently proved the integral form in 1885 in the context of minimal surfaces and variational calculus, using it to bound the first variation of area functionals. Because Bunyakovsky's work was published in Russian and French in the St. Petersburg memoirs, it was less widely known in Western Europe, and the inequality is often called 'Cauchy-Schwarz' despite Bunyakovsky's priority.\n\nThe modern measure-theoretic formulation replaces Riemann integrals with Lebesgue integrals and works in $L^2(\\mu)$ for arbitrary measures. This version was established through the work of Frigyes Riesz (1907) and Ernst Fischer (1907), who independently proved the completeness of $L^2$ — the Fischer-Riesz theorem. With $L^2$ as a complete inner product space (Hilbert space), Cauchy-Schwarz becomes a consequence of the abstract inner product axioms.\n\n**Modern Formalization Strategy**\n\nIn Mathlib, $L^2(\\mu)$ is already equipped with an `InnerProductSpace` instance, where $\\langle f, g \\rangle = \\int f \\cdot g \\, d\\mu$. The abstract Cauchy-Schwarz inequality $|\\langle f, g \\rangle| \\leq \\|f\\| \\cdot \\|g\\|$ therefore immediately gives the integral form. The key insight is that the bridge theorem connecting the abstract inner product to the concrete integral is the critical step — once established, the integral inequality is a one-line rewrite.",
+    "historicalContext": "**From Discrete Sums to Integrals: A Three-Generation Story**\n\nAugustin-Louis Cauchy first stated the discrete inequality $(\\sum a_i b_i)^2 \\leq (\\sum a_i^2)(\\sum b_i^2)$ in his 1821 *Cours d'Analyse*, proving it as a lemma for bounding products of sums. The proof was algebraic: expand $(\\sum a_i b_j - a_j b_i)^2 \\geq 0$ and rearrange \u2014 the Binet-Cauchy identity. This inequality became a workhorse of 19th-century analysis.\n\nViktor Yakovlevich Bunyakovsky (1804\u20131889) recognized in 1859 that Cauchy's argument extends to integrals. In his memoir *Sur quelques in\u00e9galit\u00e9s concernant les int\u00e9grales ordinaires et les int\u00e9grales aux diff\u00e9rences finies*, published in the Memoirs of the St. Petersburg Academy, he proved the continuous version:\n$$\\left(\\int_a^b f(x) g(x) \\, dx\\right)^2 \\leq \\int_a^b f(x)^2 \\, dx \\cdot \\int_a^b g(x)^2 \\, dx$$\nfor Riemann-integrable functions on $[a,b]$. His proof replaced finite sums with Riemann sums and passed to the limit \u2014 the natural generalization of Cauchy's method.\n\nHermann Amandus Schwarz (1843\u20131921) independently proved the integral form in 1885 in the context of minimal surfaces and variational calculus, using it to bound the first variation of area functionals. Because Bunyakovsky's work was published in Russian and French in the St. Petersburg memoirs, it was less widely known in Western Europe, and the inequality is often called 'Cauchy-Schwarz' despite Bunyakovsky's priority.\n\nThe modern measure-theoretic formulation replaces Riemann integrals with Lebesgue integrals and works in $L^2(\\mu)$ for arbitrary measures. This version was established through the work of Frigyes Riesz (1907) and Ernst Fischer (1907), who independently proved the completeness of $L^2$ \u2014 the Fischer-Riesz theorem. With $L^2$ as a complete inner product space (Hilbert space), Cauchy-Schwarz becomes a consequence of the abstract inner product axioms.\n\n**Modern Formalization Strategy**\n\nIn Mathlib, $L^2(\\mu)$ is already equipped with an `InnerProductSpace` instance, where $\\langle f, g \\rangle = \\int f \\cdot g \\, d\\mu$. The abstract Cauchy-Schwarz inequality $|\\langle f, g \\rangle| \\leq \\|f\\| \\cdot \\|g\\|$ therefore immediately gives the integral form. The key insight is that the bridge theorem connecting the abstract inner product to the concrete integral is the critical step \u2014 once established, the integral inequality is a one-line rewrite.",
     "problemStatement": "**Bunyakovsky-Schwarz Integral Inequality**\n\nFor $L^2$ functions $f, g$:\n$$\\left|\\int f \\cdot g \\, d\\mu\\right| \\leq \\|f\\|_{L^2} \\cdot \\|g\\|_{L^2}$$\n\nEquivalently in squared form:\n$$(\\int f \\cdot g \\, d\\mu)^2 \\leq \\|f\\|_{L^2}^2 \\cdot \\|g\\|_{L^2}^2$$\n\nEquality holds if and only if $f$ and $g$ are linearly dependent in $L^2$.",
-    "text": "A 118-line formalization of the Bunyakovsky-Schwarz integral inequality in Lean 4, with 0 sorries and 0 axioms. The proof exploits Mathlib's `InnerProductSpace` instance on `Lp ℝ 2 μ`: since $L^2(\\mu)$ is an inner product space, the abstract Cauchy-Schwarz `abs_real_inner_le_norm` gives $|\\langle f, g \\rangle| \\leq \\|f\\| \\cdot \\|g\\|$ immediately. The critical bridge theorem `L2_inner_eq_integral` rewrites $\\langle f, g \\rangle = \\int f \\cdot g \\, d\\mu$, converting the abstract inequality into the concrete integral form $(\\int fg\\,d\\mu)^2 \\leq (\\int f^2\\,d\\mu)(\\int g^2\\,d\\mu)$ via a single rewrite. Both absolute value and squared forms are proved, plus the equality characterization: $|\\int fg| = \\|f\\|\\|g\\|$ iff $f$ and $g$ are linearly dependent in $L^2$ (via `norm_inner_eq_norm_iff`). The formalization works over arbitrary $\\sigma$-finite measure spaces, subsuming Lebesgue measure, counting measure (recovering discrete Cauchy-Schwarz), and probability measures (bounding the Pearson correlation $|\\rho| \\leq 1$).",
+    "text": "A 118-line formalization of the Bunyakovsky-Schwarz integral inequality in Lean 4, with 0 sorries and 0 axioms. The proof exploits Mathlib's `InnerProductSpace` instance on `Lp \u211d 2 \u03bc`: since $L^2(\\mu)$ is an inner product space, the abstract Cauchy-Schwarz `abs_real_inner_le_norm` gives $|\\langle f, g \\rangle| \\leq \\|f\\| \\cdot \\|g\\|$ immediately. The critical bridge theorem `L2_inner_eq_integral` rewrites $\\langle f, g \\rangle = \\int f \\cdot g \\, d\\mu$, converting the abstract inequality into the concrete integral form $(\\int fg\\,d\\mu)^2 \\leq (\\int f^2\\,d\\mu)(\\int g^2\\,d\\mu)$ via a single rewrite. Both absolute value and squared forms are proved, plus the equality characterization: $|\\int fg| = \\|f\\|\\|g\\|$ iff $f$ and $g$ are linearly dependent in $L^2$ (via `norm_inner_eq_norm_iff`). The formalization works over arbitrary $\\sigma$-finite measure spaces, subsuming Lebesgue measure, counting measure (recovering discrete Cauchy-Schwarz), and probability measures (bounding the Pearson correlation $|\\rho| \\leq 1$).",
     "proofStrategy": "**Formalization Strategy**\n\n1. **L2 is an InnerProductSpace:** Mathlib provides `InnerProductSpace \\mathbb{R} (Lp \\mathbb{R} 2 \\mu)` as an instance.\n2. **Abstract Cauchy-Schwarz:** Apply `abs_real_inner_le_norm` to get $|\\langle f, g \\rangle| \\leq \\|f\\| \\cdot \\|g\\|$.\n3. **Bridge theorem:** Show $\\langle f, g \\rangle = \\int f \\cdot g \\, d\\mu$ using `L2.inner_def`.\n4. **Rewrite:** Substitute the bridge into the abstract inequality to obtain the integral form.\n5. **Equality:** Use `norm_inner_eq_norm_iff` to characterize equality as linear dependence in $L^2$.",
     "keyInsights": [
       "**L2 as InnerProductSpace:** Mathlib's `Lp \\mathbb{R} 2 \\mu` carries an `InnerProductSpace` instance where $\\langle f, g \\rangle = \\int f \\cdot g \\, d\\mu$. This means the abstract Cauchy-Schwarz inequality *is* the integral form.",
       "**Bridge Theorem:** The key formalization step is `L2_inner_eq_integral`: proving that the abstract inner product notation $\\langle f, g \\rangle$ equals the concrete integral $\\int f(a) \\cdot g(a) \\, d\\mu(a)$. This uses `L2.inner_def` and the fact that `inner x y = x * y` for reals.",
       "**Squared Form:** The squared inequality $(\\int fg)^2 \\leq \\|f\\|^2 \\|g\\|^2$ follows directly from the absolute value form, avoiding square roots entirely.",
       "**Equality = Linear Dependence in L2:** Equality holds iff $\\exists c: f = c \\cdot g$ in $L^2$, meaning $f(x) = c \\cdot g(x)$ almost everywhere.",
-      "**Measure-theoretic generality:** The formalization works for arbitrary $\\sigma$-finite measure spaces $(\\Omega, \\mathcal{F}, \\mu)$, not just Lebesgue measure on $\\mathbb{R}$ — encompassing counting measure (recovering the discrete Cauchy-Schwarz) and probability measures (covariance bounds)"
+      "**Measure-theoretic generality:** The formalization works for arbitrary $\\sigma$-finite measure spaces $(\\Omega, \\mathcal{F}, \\mu)$, not just Lebesgue measure on $\\mathbb{R}$ \u2014 encompassing counting measure (recovering the discrete Cauchy-Schwarz) and probability measures (covariance bounds)"
     ],
     "prerequisites": [
       "Measure theory (Lebesgue integration, $\\sigma$-algebras, measurable functions)",
@@ -98,7 +98,7 @@
       "summary": "States and proves the integral form in both absolute value ($|\\int fg| \\leq \\|f\\|\\|g\\|$) and squared ($(\\int fg)^2 \\leq \\|f\\|^2\\|g\\|^2$) versions by rewriting the bridge theorem into the abstract inequality.",
       "startLine": 75,
       "endLine": 94,
-      "mathContext": "The integral Cauchy-Schwarz: $\\left|\\int_\\alpha f \\cdot g \\, d\\mu\\right| \\leq \\left(\\int_\\alpha f^2 \\, d\\mu\\right)^{1/2} \\left(\\int_\\alpha g^2 \\, d\\mu\\right)^{1/2}$. Each proof is a single rewrite substituting the bridge theorem into the abstract inequality — the entire mathematical content is in the type-level identification $L^2(\\mu) \\cong \\text{InnerProductSpace}$, and the proofs are purely structural."
+      "mathContext": "The integral Cauchy-Schwarz: $\\left|\\int_\\alpha f \\cdot g \\, d\\mu\\right| \\leq \\left(\\int_\\alpha f^2 \\, d\\mu\\right)^{1/2} \\left(\\int_\\alpha g^2 \\, d\\mu\\right)^{1/2}$. Each proof is a single rewrite substituting the bridge theorem into the abstract inequality \u2014 the entire mathematical content is in the type-level identification $L^2(\\mu) \\cong \\text{InnerProductSpace}$, and the proofs are purely structural."
     },
     {
       "id": "equality",
@@ -106,12 +106,12 @@
       "summary": "Proves equality holds iff $f$ and $g$ are linearly dependent in $L^2$: $|\\langle f, g \\rangle| = \\|f\\|\\|g\\| \\iff \\exists c: f = c \\cdot g$, using `norm_inner_eq_norm_iff`.",
       "startLine": 95,
       "endLine": 118,
-      "mathContext": "Equality $|\\langle f, g \\rangle| = \\|f\\| \\cdot \\|g\\|$ holds iff $f = cg$ a.e. for some $c \\in \\mathbb{R}$. Geometrically, this means the 'angle' between $f$ and $g$ in $L^2$ is $0$ or $\\pi$ — they point in the same or opposite directions. The proof uses the standard Hilbert space fact: $\\|u - tv\\|^2 = 0$ for some $t$ iff $u$ and $v$ are proportional. In probability, equality means $Y = aX + b$ a.s. (perfect linear correlation $|\\rho| = 1$)."
+      "mathContext": "Equality $|\\langle f, g \\rangle| = \\|f\\| \\cdot \\|g\\|$ holds iff $f = cg$ a.e. for some $c \\in \\mathbb{R}$. Geometrically, this means the 'angle' between $f$ and $g$ in $L^2$ is $0$ or $\\pi$ \u2014 they point in the same or opposite directions. The proof uses the standard Hilbert space fact: $\\|u - tv\\|^2 = 0$ for some $t$ iff $u$ and $v$ are proportional. In probability, equality means $Y = aX + b$ a.s. (perfect linear correlation $|\\rho| = 1$)."
     }
   ],
   "conclusion": {
     "summary": "The formalization proves the Bunyakovsky-Schwarz integral inequality by exploiting Mathlib's L2 inner product space structure. The key insight is that the bridge theorem `L2_inner_eq_integral` connecting abstract inner products to concrete integrals turns the abstract Cauchy-Schwarz into the integral form in a single rewrite. All proofs are complete with zero sorries.",
-    "implications": "**Implications and Connections**\n\n1. **Hilbert Space Theory:** The inequality is the fundamental tool showing that $L^2(\\mu)$ is a Hilbert space, with $\\langle f, g \\rangle = \\int fg \\, d\\mu$ as a well-defined inner product. The completeness of $L^2$ (Fischer-Riesz theorem, 1907) together with Cauchy-Schwarz makes $L^2$ the canonical example of an infinite-dimensional Hilbert space.\n\n2. **Quantum Mechanics:** The Heisenberg uncertainty principle $\\Delta x \\cdot \\Delta p \\geq \\hbar/2$ is a direct consequence of this inequality applied to wave functions in $L^2(\\mathbb{R}^3)$. Robertson's generalization (1929) shows $\\sigma_A \\sigma_B \\geq \\frac{1}{2}|\\langle [A,B] \\rangle|$ for any observables $A, B$, which reduces to Cauchy-Schwarz when the commutator is a scalar.\n\n3. **Probability Theory:** For random variables $X, Y$ with finite variance, $\\text{Cov}(X,Y)^2 \\leq \\text{Var}(X) \\cdot \\text{Var}(Y)$, bounding the Pearson correlation coefficient $|\\rho_{XY}| \\leq 1$. This is Cauchy-Schwarz applied to centered random variables in $L^2(\\Omega, \\mathcal{F}, P)$.\n\n4. **Signal Processing:** The matched filter theorem — that correlation detection is optimal for detecting a known signal in Gaussian noise — follows from Cauchy-Schwarz in $L^2$: the signal-to-noise ratio $\\text{SNR} = |\\int s(t)h(t)\\,dt|^2 / \\int |h(t)|^2\\,dt$ is maximized when $h \\propto s$.\n\n5. **Extends Cauchy-Schwarz Gallery:** This proof completes the Cauchy-Schwarz trilogy: discrete (finite sums), abstract (inner product spaces), and integral (measure-theoretic $L^2$). The measure-theoretic generality subsumes all three: counting measure recovers the discrete case, and any inner product space embeds into some $L^2$.",
+    "implications": "**Implications and Connections**\n\n1. **Hilbert Space Theory:** The inequality is the fundamental tool showing that $L^2(\\mu)$ is a Hilbert space, with $\\langle f, g \\rangle = \\int fg \\, d\\mu$ as a well-defined inner product. The completeness of $L^2$ (Fischer-Riesz theorem, 1907) together with Cauchy-Schwarz makes $L^2$ the canonical example of an infinite-dimensional Hilbert space.\n\n2. **Quantum Mechanics:** The Heisenberg uncertainty principle $\\Delta x \\cdot \\Delta p \\geq \\hbar/2$ is a direct consequence of this inequality applied to wave functions in $L^2(\\mathbb{R}^3)$. Robertson's generalization (1929) shows $\\sigma_A \\sigma_B \\geq \\frac{1}{2}|\\langle [A,B] \\rangle|$ for any observables $A, B$, which reduces to Cauchy-Schwarz when the commutator is a scalar.\n\n3. **Probability Theory:** For random variables $X, Y$ with finite variance, $\\text{Cov}(X,Y)^2 \\leq \\text{Var}(X) \\cdot \\text{Var}(Y)$, bounding the Pearson correlation coefficient $|\\rho_{XY}| \\leq 1$. This is Cauchy-Schwarz applied to centered random variables in $L^2(\\Omega, \\mathcal{F}, P)$.\n\n4. **Signal Processing:** The matched filter theorem \u2014 that correlation detection is optimal for detecting a known signal in Gaussian noise \u2014 follows from Cauchy-Schwarz in $L^2$: the signal-to-noise ratio $\\text{SNR} = |\\int s(t)h(t)\\,dt|^2 / \\int |h(t)|^2\\,dt$ is maximized when $h \\propto s$.\n\n5. **Extends Cauchy-Schwarz Gallery:** This proof completes the Cauchy-Schwarz trilogy: discrete (finite sums), abstract (inner product spaces), and integral (measure-theoretic $L^2$). The measure-theoretic generality subsumes all three: counting measure recovers the discrete case, and any inner product space embeds into some $L^2$.",
     "openQuestions": [
       "Can Holder's inequality be formalized as a generalization, recovering Cauchy-Schwarz for p=q=2?",
       "Can the Minkowski inequality for integrals be derived as a corollary?",
@@ -123,27 +123,27 @@
     {
       "targetId": "cauchy-schwarz",
       "relationship": "extends",
-      "description": "The discrete Cauchy-Schwarz inequality (∑ aᵢbᵢ)² ≤ (∑ aᵢ²)(∑ bᵢ²) is the finite-dimensional ancestor. The integral form generalizes from finite sums to measure-theoretic integrals, with L² replacing ℝⁿ."
+      "description": "The discrete Cauchy-Schwarz inequality (\u2211 a\u1d62b\u1d62)\u00b2 \u2264 (\u2211 a\u1d62\u00b2)(\u2211 b\u1d62\u00b2) is the finite-dimensional ancestor. The integral form generalizes from finite sums to measure-theoretic integrals, with L\u00b2 replacing \u211d\u207f."
     },
     {
       "targetId": "fourier-series",
       "relationship": "technique",
-      "description": "The Cauchy-Schwarz integral inequality is the backbone of Fourier analysis: Parseval's identity, Bessel's inequality, and the convergence theory of Fourier series all depend on the L² inner product structure that Cauchy-Schwarz validates."
+      "description": "The Cauchy-Schwarz integral inequality is the backbone of Fourier analysis: Parseval's identity, Bessel's inequality, and the convergence theory of Fourier series all depend on the L\u00b2 inner product structure that Cauchy-Schwarz validates."
     },
     {
       "targetId": "basel-problem",
       "relationship": "related",
-      "description": "The Basel identity ζ(2) = π²/6 can be derived using Parseval's theorem applied to f(x) = x on [-π,π], which is a direct application of the L² inner product structure that the Cauchy-Schwarz integral inequality governs."
+      "description": "The Basel identity \u03b6(2) = \u03c0\u00b2/6 can be derived using Parseval's theorem applied to f(x) = x on [-\u03c0,\u03c0], which is a direct application of the L\u00b2 inner product structure that the Cauchy-Schwarz integral inequality governs."
     },
     {
       "targetId": "triangle-inequality",
       "relationship": "implication",
-      "description": "The Minkowski inequality (L^p triangle inequality) ‖f+g‖_p ≤ ‖f‖_p + ‖g‖_p for p=2 follows directly from the integral Cauchy-Schwarz, exactly as the discrete triangle inequality follows from the discrete Cauchy-Schwarz"
+      "description": "The Minkowski inequality (L^p triangle inequality) \u2016f+g\u2016_p \u2264 \u2016f\u2016_p + \u2016g\u2016_p for p=2 follows directly from the integral Cauchy-Schwarz, exactly as the discrete triangle inequality follows from the discrete Cauchy-Schwarz"
     },
     {
       "targetId": "amgm-inequality-oq-03",
       "relationship": "related",
-      "description": "Power mean monotonicity M₁ ≤ M₂ is the discrete Cauchy-Schwarz for equal weights; the integral analog extends this to continuous power means on measure spaces, connecting power mean theory to L^p analysis"
+      "description": "Power mean monotonicity M\u2081 \u2264 M\u2082 is the discrete Cauchy-Schwarz for equal weights; the integral analog extends this to continuous power means on measure spaces, connecting power mean theory to L^p analysis"
     },
     {
       "targetId": "cauchy-schwarz-oq-01",
@@ -158,12 +158,12 @@
     {
       "targetId": "fundamental-theorem-calculus",
       "relationship": "related",
-      "description": "FTC connects differentiation and integration — the same Lebesgue integral framework that defines the $L^2$ inner product $\\langle f, g \\rangle = \\int fg\\,d\\mu$. Both theorems rely on Mathlib's Bochner integration infrastructure"
+      "description": "FTC connects differentiation and integration \u2014 the same Lebesgue integral framework that defines the $L^2$ inner product $\\langle f, g \\rangle = \\int fg\\,d\\mu$. Both theorems rely on Mathlib's Bochner integration infrastructure"
     },
     {
       "targetId": "cauchy-schwarz-integral-oq-01",
       "relationship": "extended-by",
-      "description": "Hölder's inequality $\\|fg\\|_1 \\leq \\|f\\|_p \\cdot \\|g\\|_q$ (for $1/p + 1/q = 1$) generalizes the integral Cauchy-Schwarz from $p = q = 2$ to arbitrary conjugate exponents. The $p = 2$ case recovers Cauchy-Schwarz exactly: $\\int |fg| \\leq (\\int |f|^2)^{1/2}(\\int |g|^2)^{1/2}$"
+      "description": "H\u00f6lder's inequality $\\|fg\\|_1 \\leq \\|f\\|_p \\cdot \\|g\\|_q$ (for $1/p + 1/q = 1$) generalizes the integral Cauchy-Schwarz from $p = q = 2$ to arbitrary conjugate exponents. The $p = 2$ case recovers Cauchy-Schwarz exactly: $\\int |fg| \\leq (\\int |f|^2)^{1/2}(\\int |g|^2)^{1/2}$"
     },
     {
       "targetId": "cauchy-schwarz-integral-oq-02",
@@ -187,7 +187,7 @@
       "MeasureTheory"
     ],
     "namespace": "BunyakovskySchwarz",
-    "lineCount": 117,
+    "lineCount": 118,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 0,
@@ -197,38 +197,38 @@
   "references": [
     {
       "authors": "Cauchy, A.-L.",
-      "title": "Cours d'Analyse de l'École Royale Polytechnique, Première Partie: Analyse Algébrique",
+      "title": "Cours d'Analyse de l'\u00c9cole Royale Polytechnique, Premi\u00e8re Partie: Analyse Alg\u00e9brique",
       "year": "1821",
       "venue": "Imprimerie Royale, Paris",
-      "note": "Contains the original discrete Cauchy-Schwarz inequality (Note III) as $(\\sum a_i b_i)^2 \\leq (\\sum a_i^2)(\\sum b_i^2)$ — the finite-dimensional ancestor of the integral form"
+      "note": "Contains the original discrete Cauchy-Schwarz inequality (Note III) as $(\\sum a_i b_i)^2 \\leq (\\sum a_i^2)(\\sum b_i^2)$ \u2014 the finite-dimensional ancestor of the integral form"
     },
     {
       "authors": "Bunyakovsky, V. Y.",
-      "title": "Sur quelques inégalités concernant les intégrales ordinaires et les intégrales aux différences finies",
+      "title": "Sur quelques in\u00e9galit\u00e9s concernant les int\u00e9grales ordinaires et les int\u00e9grales aux diff\u00e9rences finies",
       "year": "1859",
-      "venue": "Mémoires de l'Académie Impériale des Sciences de St.-Pétersbourg, VIIe série, vol. 1, no. 9",
+      "venue": "M\u00e9moires de l'Acad\u00e9mie Imp\u00e9riale des Sciences de St.-P\u00e9tersbourg, VIIe s\u00e9rie, vol. 1, no. 9",
       "note": "First proof of the integral form, extending Cauchy's discrete inequality to continuous functions via Riemann sum limits"
     },
     {
       "authors": "Schwarz, H. A.",
-      "title": "Über ein die Flächen kleinsten Flächeninhalts betreffendes Problem der Variationsrechnung",
+      "title": "\u00dcber ein die Fl\u00e4chen kleinsten Fl\u00e4cheninhalts betreffendes Problem der Variationsrechnung",
       "year": "1885",
-      "venue": "Acta Societatis Scientiarum Fennicae, vol. 15, pp. 315–362",
+      "venue": "Acta Societatis Scientiarum Fennicae, vol. 15, pp. 315\u2013362",
       "note": "Independent proof of the integral version in the context of minimal surface problems and variational calculus"
     },
     {
       "authors": "Riesz, F.",
-      "title": "Sur les systèmes orthogonaux de fonctions",
+      "title": "Sur les syst\u00e8mes orthogonaux de fonctions",
       "year": "1907",
-      "venue": "Comptes Rendus de l'Académie des Sciences, vol. 144, pp. 615–619",
-      "note": "Proved completeness of L² (Fischer-Riesz theorem), establishing L² as a Hilbert space where the abstract Cauchy-Schwarz applies"
+      "venue": "Comptes Rendus de l'Acad\u00e9mie des Sciences, vol. 144, pp. 615\u2013619",
+      "note": "Proved completeness of L\u00b2 (Fischer-Riesz theorem), establishing L\u00b2 as a Hilbert space where the abstract Cauchy-Schwarz applies"
     },
     {
       "authors": "Steele, J. M.",
       "title": "The Cauchy-Schwarz Master Class: An Introduction to the Art of Mathematical Inequalities",
       "year": "2004",
       "venue": "Cambridge University Press",
-      "note": "Comprehensive treatment of Cauchy-Schwarz and its generalizations, including the integral form, Hölder's inequality, and applications across mathematics"
+      "note": "Comprehensive treatment of Cauchy-Schwarz and its generalizations, including the integral form, H\u00f6lder's inequality, and applications across mathematics"
     }
   ],
   "mainTheorems": [

--- a/src/data/proofs/erdos-1028/meta.json
+++ b/src/data/proofs/erdos-1028/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-1028",
-  "title": "Erdős Problem #1028: Discrepancy of Sign Functions",
+  "title": "Erd\u0151s Problem #1028: Discrepancy of Sign Functions",
   "slug": "erdos-1028",
-  "description": "Let H(n) = min_f max_X |∑_{x≠y∈X} f(x,y)| where f: pairs → {±1}. Erdős (1963) proved n/4 ≤ H(n) ≪ n^(3/2). Erdős-Spencer (1971) proved H(n) ≫ n^(3/2). Answer: H(n) = Θ(n^(3/2)).",
+  "description": "Let H(n) = min_f max_X |\u2211_{x\u2260y\u2208X} f(x,y)| where f: pairs \u2192 {\u00b11}. Erd\u0151s (1963) proved n/4 \u2264 H(n) \u226a n^(3/2). Erd\u0151s-Spencer (1971) proved H(n) \u226b n^(3/2). Answer: H(n) = \u0398(n^(3/2)).",
   "meta": {
-    "author": "Erdős (1963), Erdős-Spencer (1971)",
+    "author": "Erd\u0151s (1963), Erd\u0151s-Spencer (1971)",
     "sourceUrl": "https://erdosproblems.com/1028",
     "date": "1971",
     "status": "axiomatized",
@@ -28,16 +28,16 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "Erdős Problem #1028 concerns the discrepancy of sign functions: given a function f mapping pairs from {1,...,n} to {±1}, the discrepancy of a subset X is |∑_{x≠y∈X} f(x,y)|. The function H(n) is the minimum over all sign functions f of the maximum discrepancy over all subsets X. This measures the unavoidable imbalance in signed complete graphs.\n\nErdős (1963) established the upper bound H(n) = O(n^{3/2}) using the probabilistic method: a random sign function achieves maximum discrepancy O(n^{3/2}) with positive probability. For a subset of size k, the expected discrepancy of a random signing is √(k(k-1)) ≈ k, and optimizing over k ≈ √n gives the n^{3/2} bound. Note: the originally proposed lower bound H(n) ≥ n/4 was found to be incorrect (Aristotle verified a counterexample for n=8).\n\nErdős and Spencer (1971) proved the matching lower bound H(n) = Ω(n^{3/2}) using entropy and counting arguments, establishing H(n) = Θ(n^{3/2}). Their proof showed that any sign function must have some subset with discrepancy at least cn^{3/2}, confirming that random signs are essentially optimal. The formalization includes several theorems proved by Aristotle (Harmonic), including the well-definedness of H(n), symmetric pair sum decomposition, and discrepancy bounds.",
-    "problemStatement": "**Problem Statement**\n\nLet H(n) = min_f max_{X ⊆ {1,...,n}} |∑_{x≠y∈X} f(x,y)|, where f ranges over all functions f: X² → {-1, 1}.\n\nEstimate H(n).\n\n**Status**: SOLVED\n\n**Answer**: H(n) = Θ(n^(3/2))",
-    "text": "Let H(n) = min_f max_X |∑_{x≠y∈X} f(x,y)| where f: pairs → {±1}. Erdős (1963) proved n/4 ≤ H(n) ≪ n^(3/2). Erdős-Spencer (1971) proved H(n) ≫ n^(3/2). Answer: H(n) = Θ(n^(3/2)).",
-    "proofStrategy": "**Proof Approach**\n\n1. **Upper Bound (Probabilistic)**: Random sign functions have max discrepancy O(n^(3/2)) with high probability.\n\n2. **Lower Bound (Erdős 1963)**: Linear bound n/4 via simple counting.\n\n3. **Improved Lower Bound (Erdős-Spencer 1971)**: Entropy or counting arguments give n^(3/2).\n\n4. **Key Insight**: The n^(3/2) bound arises from the √(pairs in subset of size k) ≈ k for k ≈ √n.",
+    "historicalContext": "Erd\u0151s Problem #1028 concerns the discrepancy of sign functions: given a function f mapping pairs from {1,...,n} to {\u00b11}, the discrepancy of a subset X is |\u2211_{x\u2260y\u2208X} f(x,y)|. The function H(n) is the minimum over all sign functions f of the maximum discrepancy over all subsets X. This measures the unavoidable imbalance in signed complete graphs.\n\nErd\u0151s (1963) established the upper bound H(n) = O(n^{3/2}) using the probabilistic method: a random sign function achieves maximum discrepancy O(n^{3/2}) with positive probability. For a subset of size k, the expected discrepancy of a random signing is \u221a(k(k-1)) \u2248 k, and optimizing over k \u2248 \u221an gives the n^{3/2} bound. Note: the originally proposed lower bound H(n) \u2265 n/4 was found to be incorrect (Aristotle verified a counterexample for n=8).\n\nErd\u0151s and Spencer (1971) proved the matching lower bound H(n) = \u03a9(n^{3/2}) using entropy and counting arguments, establishing H(n) = \u0398(n^{3/2}). Their proof showed that any sign function must have some subset with discrepancy at least cn^{3/2}, confirming that random signs are essentially optimal. The formalization includes several theorems proved by Aristotle (Harmonic), including the well-definedness of H(n), symmetric pair sum decomposition, and discrepancy bounds.",
+    "problemStatement": "**Problem Statement**\n\nLet H(n) = min_f max_{X \u2286 {1,...,n}} |\u2211_{x\u2260y\u2208X} f(x,y)|, where f ranges over all functions f: X\u00b2 \u2192 {-1, 1}.\n\nEstimate H(n).\n\n**Status**: SOLVED\n\n**Answer**: H(n) = \u0398(n^(3/2))",
+    "text": "Let H(n) = min_f max_X |\u2211_{x\u2260y\u2208X} f(x,y)| where f: pairs \u2192 {\u00b11}. Erd\u0151s (1963) proved n/4 \u2264 H(n) \u226a n^(3/2). Erd\u0151s-Spencer (1971) proved H(n) \u226b n^(3/2). Answer: H(n) = \u0398(n^(3/2)).",
+    "proofStrategy": "**Proof Approach**\n\n1. **Upper Bound (Probabilistic)**: Random sign functions have max discrepancy O(n^(3/2)) with high probability.\n\n2. **Lower Bound (Erd\u0151s 1963)**: Linear bound n/4 via simple counting.\n\n3. **Improved Lower Bound (Erd\u0151s-Spencer 1971)**: Entropy or counting arguments give n^(3/2).\n\n4. **Key Insight**: The n^(3/2) bound arises from the \u221a(pairs in subset of size k) \u2248 k for k \u2248 \u221an.",
     "keyInsights": [
-      "Sign function f: pairs → {±1}",
+      "Sign function f: pairs \u2192 {\u00b11}",
       "Discrepancy of X = |sum of f over pairs in X|",
       "H(n) = min over f of max discrepancy",
-      "Erdős: n/4 ≤ H(n) ≪ n^(3/2)",
-      "Erdős-Spencer: H(n) = Θ(n^(3/2))"
+      "Erd\u0151s: n/4 \u2264 H(n) \u226a n^(3/2)",
+      "Erd\u0151s-Spencer: H(n) = \u0398(n^(3/2))"
     ],
     "prerequisites": [
       "Combinatorics (counting, extremal problems)",
@@ -70,14 +70,14 @@
     },
     {
       "id": "erdos-upper",
-      "title": "Erdős's Upper Bound (1963)",
+      "title": "Erd\u0151s's Upper Bound (1963)",
       "summary": "erdos_upper",
       "startLine": 136,
       "endLine": 144
     },
     {
       "id": "erdos-spencer",
-      "title": "Erdős-Spencer (1971)",
+      "title": "Erd\u0151s-Spencer (1971)",
       "summary": "erdos_spencer_lower, erdos_spencer_improves",
       "startLine": 145,
       "endLine": 157,
@@ -125,7 +125,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #1028 asked to estimate H(n), the minimum possible maximum discrepancy over sign functions on pairs. Erdős (1963) gave n/4 ≤ H(n) ≪ n^(3/2), and Erdős-Spencer (1971) closed the gap: H(n) = Θ(n^(3/2)).",
+    "summary": "Erd\u0151s Problem #1028 asked to estimate H(n), the minimum possible maximum discrepancy over sign functions on pairs. Erd\u0151s (1963) gave n/4 \u2264 H(n) \u226a n^(3/2), and Erd\u0151s-Spencer (1971) closed the gap: H(n) = \u0398(n^(3/2)).",
     "implications": "1. **Discrepancy Theory**: Fundamental result on unavoidable imbalance\n\n**2. Signed Graphs**: Minimum imbalance in edge-signed complete graphs\n\n3. **Probabilistic Method**: Upper bound via random signs\n\n4. **Ramsey Connection**: Large homogeneous subsets relate to discrepancy.",
     "openQuestions": [
       "What are the exact constants in the asymptotic?",
@@ -141,19 +141,19 @@
       "targetId": "ramseys-theorem"
     },
     {
-      "relationship": "Erdős #1 (Sidon sets / sum-free sets) shares the probabilistic-method toolkit used to establish the O(n^{3/2}) upper bound.",
+      "relationship": "Erd\u0151s #1 (Sidon sets / sum-free sets) shares the probabilistic-method toolkit used to establish the O(n^{3/2}) upper bound.",
       "targetId": "erdos-1"
     },
     {
-      "relationship": "Erdős #1025 studies signed graph imbalance; the two problems share the signed-complete-graph model and discrepancy extremal questions.",
+      "relationship": "Erd\u0151s #1025 studies signed graph imbalance; the two problems share the signed-complete-graph model and discrepancy extremal questions.",
       "targetId": "erdos-1025"
     },
     {
-      "relationship": "Adjacent Erdős problem in the discrepancy-theory cluster; formalized with the same axiom structure and proof approach.",
+      "relationship": "Adjacent Erd\u0151s problem in the discrepancy-theory cluster; formalized with the same axiom structure and proof approach.",
       "targetId": "erdos-1029"
     },
     {
-      "relationship": "Erdős #500 involves combinatorial counting over pairs; the pair-sum decomposition technique used here appears in related Erdős pair-counting problems.",
+      "relationship": "Erd\u0151s #500 involves combinatorial counting over pairs; the pair-sum decomposition technique used here appears in related Erd\u0151s pair-counting problems.",
       "targetId": "erdos-500"
     },
     {
@@ -164,7 +164,7 @@
   "references": [
     {
       "authors": [
-        "P. Erdős"
+        "P. Erd\u0151s"
       ],
       "title": "On some problems in graph theory, combinatorial analysis and combinatorial number theory",
       "venue": "Graph Theory and Combinatorics (Cambridge, 1983)",
@@ -173,15 +173,15 @@
     },
     {
       "authors": [
-        "P. Erdős",
+        "P. Erd\u0151s",
         "J. Spencer"
       ],
       "title": "Imbalances in k-colorations",
       "venue": "Networks",
       "volume": "1",
-      "pages": "379–385",
+      "pages": "379\u2013385",
       "year": "1971",
-      "note": "Establishes the matching Ω(n^{3/2}) lower bound, completing H(n) = Θ(n^{3/2})."
+      "note": "Establishes the matching \u03a9(n^{3/2}) lower bound, completing H(n) = \u0398(n^{3/2})."
     },
     {
       "authors": [
@@ -190,19 +190,19 @@
       "title": "Six standard deviations suffice",
       "venue": "Transactions of the American Mathematical Society",
       "volume": "289",
-      "pages": "679–706",
+      "pages": "679\u2013706",
       "year": "1985",
-      "note": "Landmark discrepancy result proving the entropy method; directly related to the Erdős-Spencer lower bound technique used here."
+      "note": "Landmark discrepancy result proving the entropy method; directly related to the Erd\u0151s-Spencer lower bound technique used here."
     },
     {
       "authors": [
-        "J. Matoušek",
+        "J. Matou\u0161ek",
         "J. Spencer"
       ],
       "title": "Discrepancy in arithmetic progressions",
       "venue": "Journal of the American Mathematical Society",
       "volume": "9",
-      "pages": "195–204",
+      "pages": "195\u2013204",
       "year": "1996",
       "note": "Illustrates the discrepancy-theory framework connecting signed-sum estimates with combinatorial lower bounds."
     },
@@ -238,7 +238,7 @@
       "Finset"
     ],
     "namespace": "Erdos1028",
-    "lineCount": 310,
+    "lineCount": 311,
     "axiomCount": 2,
     "theoremCount": 8,
     "definitionCount": 10,

--- a/src/data/proofs/erdos-1034/meta.json
+++ b/src/data/proofs/erdos-1034/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-1034",
-  "title": "Erdős Problem #1034: Triangle Neighbors in Dense Graphs",
+  "title": "Erd\u0151s Problem #1034: Triangle Neighbors in Dense Graphs",
   "slug": "erdos-1034",
-  "description": "Let G have n vertices and > n²/4 edges. Must there exist a triangle T with > (1/2 - o(1))n vertices each adjacent to ≥ 2 of T's vertices? NO (Ma-Tang). Bounds: (1/6)n ≤ h(n) ≤ (2 - √(5/2))n ≈ 0.419n.",
+  "description": "Let G have n vertices and > n\u00b2/4 edges. Must there exist a triangle T with > (1/2 - o(1))n vertices each adjacent to \u2265 2 of T's vertices? NO (Ma-Tang). Bounds: (1/6)n \u2264 h(n) \u2264 (2 - \u221a(5/2))n \u2248 0.419n.",
   "meta": {
-    "author": "Erdős-Faudree (conjecture), Ma-Tang (disproof)",
+    "author": "Erd\u0151s-Faudree (conjecture), Ma-Tang (disproof)",
     "sourceUrl": "https://erdosproblems.com/1034",
     "date": "2020",
     "status": "axiomatized",
@@ -31,16 +31,16 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "**Turán's Theorem and Triangle Structure**\n\nPál Turán's seminal 1941 theorem established that the maximum number of edges in a triangle-free graph on $n$ vertices is $\\lfloor n^2/4 \\rfloor$, achieved uniquely by the complete bipartite graph $K_{\\lfloor n/2 \\rfloor, \\lceil n/2 \\rceil}$. This launched extremal graph theory. A natural follow-up: when a graph *exceeds* the Turán threshold, what structural properties must its triangles have?\n\n**The Erdős-Faudree Conjecture**: Paul Erdős and Ralph Faudree conjectured that every graph with $> n^2/4$ edges contains a triangle $T$ with $> (1/2 - o(1))n$ 'good neighbors' — vertices adjacent to at least two of $T$'s three vertices. Erdős himself was skeptical, writing 'perhaps this conjecture is a bit too optimistic.'\n\n**Ma-Tang Disproof (2020)**: Jie Ma and Zixiang Tang disproved the conjecture by constructing explicit graph families where every triangle has at most $(2 - \\sqrt{5/2} + o(1))n \\approx 0.419n$ good neighbors. The **book lemma** (a classical result in graph theory) provides the lower bound $h(n) \\ge n/6$: every dense graph has a 'book' — a triangle with $\\ge n/6$ common neighbors of all three vertices. The exact value of $h(n)$ between $n/6$ and $(2 - \\sqrt{5/2})n$ remains open.",
-    "problemStatement": "**Problem Statement**\n\nLet G be a graph on n vertices with > n²/4 edges. Must there exist a triangle T and t > (1/2 - o(1))n vertices, each adjacent to at least two vertices of T?\n\n**Status**: DISPROVED (Ma-Tang)\n\n**Answer**: NO - max t ≤ (2 - √(5/2))n ≈ 0.419n",
-    "text": "Let G have n vertices and > n²/4 edges. Must there exist a triangle T with > (1/2 - o(1))n vertices each adjacent to ≥ 2 of T's vertices? NO (Ma-Tang). Bounds: (1/6)n ≤ h(n) ≤ (2 - √(5/2))n ≈ 0.419n.",
-    "proofStrategy": "**Two-Sided Bound via Counterexample and Book Lemma**\n\nThe formalization establishes both an upper and lower bound on the extremal function $h(n)$.\n\n**Upper Bound (Ma-Tang Construction)**: The counterexample family is axiomatized via `maTang_counterexample`. Ma and Tang construct graphs $G_n$ on $n$ vertices with $|E(G_n)| > n^2/4$ where every triangle $T$ satisfies $|N_2(T)| \\leq (2 - \\sqrt{5/2} + o(1))n$. The constant $2 - \\sqrt{5/2} \\approx 0.4189$ arises from optimizing parameters of a blow-up construction. Aristotle verified the numerical bounds $0.418 < 2 - \\sqrt{5/2} < 0.42$.\n\n**Lower Bound (Book Lemma)**: The `book_lemma` (axiomatized) guarantees that every above-Turán graph contains a triangle with $\\geq n/6$ common neighbors of all three vertices. Since common neighbors have adjacency count 3, they are good neighbors, yielding $h(n) \\geq n/6$.\n\n**Disproof**: The conjecture negation `erdos_faudree_false` (proved by Aristotle via the `negate_state` tactic) follows because $2 - \\sqrt{5/2} < 1/2$.\n\n**$K_4$-free variant**: Without $K_4$, the upper bound rises to $(2\\sqrt{3} - 3)n \\approx 0.464n$, showing the clique structure matters.",
+    "historicalContext": "**Tur\u00e1n's Theorem and Triangle Structure**\n\nP\u00e1l Tur\u00e1n's seminal 1941 theorem established that the maximum number of edges in a triangle-free graph on $n$ vertices is $\\lfloor n^2/4 \\rfloor$, achieved uniquely by the complete bipartite graph $K_{\\lfloor n/2 \\rfloor, \\lceil n/2 \\rceil}$. This launched extremal graph theory. A natural follow-up: when a graph *exceeds* the Tur\u00e1n threshold, what structural properties must its triangles have?\n\n**The Erd\u0151s-Faudree Conjecture**: Paul Erd\u0151s and Ralph Faudree conjectured that every graph with $> n^2/4$ edges contains a triangle $T$ with $> (1/2 - o(1))n$ 'good neighbors' \u2014 vertices adjacent to at least two of $T$'s three vertices. Erd\u0151s himself was skeptical, writing 'perhaps this conjecture is a bit too optimistic.'\n\n**Ma-Tang Disproof (2020)**: Jie Ma and Zixiang Tang disproved the conjecture by constructing explicit graph families where every triangle has at most $(2 - \\sqrt{5/2} + o(1))n \\approx 0.419n$ good neighbors. The **book lemma** (a classical result in graph theory) provides the lower bound $h(n) \\ge n/6$: every dense graph has a 'book' \u2014 a triangle with $\\ge n/6$ common neighbors of all three vertices. The exact value of $h(n)$ between $n/6$ and $(2 - \\sqrt{5/2})n$ remains open.",
+    "problemStatement": "**Problem Statement**\n\nLet G be a graph on n vertices with > n\u00b2/4 edges. Must there exist a triangle T and t > (1/2 - o(1))n vertices, each adjacent to at least two vertices of T?\n\n**Status**: DISPROVED (Ma-Tang)\n\n**Answer**: NO - max t \u2264 (2 - \u221a(5/2))n \u2248 0.419n",
+    "text": "Let G have n vertices and > n\u00b2/4 edges. Must there exist a triangle T with > (1/2 - o(1))n vertices each adjacent to \u2265 2 of T's vertices? NO (Ma-Tang). Bounds: (1/6)n \u2264 h(n) \u2264 (2 - \u221a(5/2))n \u2248 0.419n.",
+    "proofStrategy": "**Two-Sided Bound via Counterexample and Book Lemma**\n\nThe formalization establishes both an upper and lower bound on the extremal function $h(n)$.\n\n**Upper Bound (Ma-Tang Construction)**: The counterexample family is axiomatized via `maTang_counterexample`. Ma and Tang construct graphs $G_n$ on $n$ vertices with $|E(G_n)| > n^2/4$ where every triangle $T$ satisfies $|N_2(T)| \\leq (2 - \\sqrt{5/2} + o(1))n$. The constant $2 - \\sqrt{5/2} \\approx 0.4189$ arises from optimizing parameters of a blow-up construction. Aristotle verified the numerical bounds $0.418 < 2 - \\sqrt{5/2} < 0.42$.\n\n**Lower Bound (Book Lemma)**: The `book_lemma` (axiomatized) guarantees that every above-Tur\u00e1n graph contains a triangle with $\\geq n/6$ common neighbors of all three vertices. Since common neighbors have adjacency count 3, they are good neighbors, yielding $h(n) \\geq n/6$.\n\n**Disproof**: The conjecture negation `erdos_faudree_false` (proved by Aristotle via the `negate_state` tactic) follows because $2 - \\sqrt{5/2} < 1/2$.\n\n**$K_4$-free variant**: Without $K_4$, the upper bound rises to $(2\\sqrt{3} - 3)n \\approx 0.464n$, showing the clique structure matters.",
     "keyInsights": [
       "**Good neighbor**: vertex $y \\notin T$ with $|\\{v \\in T : y \\sim v\\}| \\ge 2$, measuring how strongly $y$ interacts with triangle $T$",
-      "**Erdős-Faudree conjecture DISPROVED**: the conjectured bound $h(n) > (1/2 - o(1))n$ is false, as Erdős himself suspected",
+      "**Erd\u0151s-Faudree conjecture DISPROVED**: the conjectured bound $h(n) > (1/2 - o(1))n$ is false, as Erd\u0151s himself suspected",
       "**Ma-Tang upper bound**: $h(n) \\le (2 - \\sqrt{5/2})n \\approx 0.419n$ from explicit counterexample construction (2020)",
       "**Book lemma lower bound**: $h(n) \\ge n/6$ because every dense graph has a triangle with $\\ge n/6$ vertices adjacent to all three vertices",
-      "**$K_4$-free variant**: the bound improves to $(2\\sqrt{3} - 3)n \\approx 0.464n > 0.419n$ — counterintuitively, forbidding $K_4$ allows *more* good neighbors"
+      "**$K_4$-free variant**: the bound improves to $(2\\sqrt{3} - 3)n \\approx 0.464n > 0.419n$ \u2014 counterintuitively, forbidding $K_4$ allows *more* good neighbors"
     ],
     "prerequisites": [
       "Extremal graph theory (Turan threshold $\\\\text{ex}(n, K_r)$)",
@@ -62,7 +62,7 @@
     {
       "id": "graph-setup",
       "title": "Graph Setup",
-      "summary": "$|E(G)|$, $\\lfloor n^2/4 \\rfloor$ Turán threshold, and `isAboveTuran` predicate",
+      "summary": "$|E(G)|$, $\\lfloor n^2/4 \\rfloor$ Tur\u00e1n threshold, and `isAboveTuran` predicate",
       "startLine": 27,
       "endLine": 45,
       "mathContext": "$e(G) = |E(G)|$, Turan threshold $\\\\lfloor n^2/4 \\\\rfloor$. The predicate isAboveTuran means $e(G) > \\\\lfloor n^2/4 \\\\rfloor$."
@@ -81,12 +81,12 @@
       "summary": "$\\text{goodNeighbors}(G, T) = \\{y \\notin T : |\\{v \\in T : y \\sim v\\}| \\ge 2\\}$ and cardinality",
       "startLine": 72,
       "endLine": 101,
-      "mathContext": "$\\\\text{goodNeighbors}(G,T) = \\\\{y \\\\notin T : |N(y) \\\\cap T| \\\\geq 2\\\\}$ — vertices adjacent to at least 2 of the 3 triangle vertices."
+      "mathContext": "$\\\\text{goodNeighbors}(G,T) = \\\\{y \\\\notin T : |N(y) \\\\cap T| \\\\geq 2\\\\}$ \u2014 vertices adjacent to at least 2 of the 3 triangle vertices."
     },
     {
       "id": "h-function",
       "title": "The Function h(n)",
-      "summary": "$h(n) = \\max\\{k : \\forall G \\text{ above Turán}, \\exists T, |\\text{goodNeighbors}| \\ge k\\}$",
+      "summary": "$h(n) = \\max\\{k : \\forall G \\text{ above Tur\u00e1n}, \\exists T, |\\text{goodNeighbors}| \\ge k\\}$",
       "startLine": 102,
       "endLine": 123,
       "mathContext": "$h(n) = \\\\max\\\\{k : \\\\forall G \\\\text{ above Turan}, \\\\exists T, |\\\\text{goodNeighbors}(G,T)| \\\\geq k\\\\}$."
@@ -125,7 +125,7 @@
     },
     {
       "id": "k4-free",
-      "title": "K₄-free Variant",
+      "title": "K\u2084-free Variant",
       "summary": "$K_4$-free bound: $(2\\sqrt{3} - 3)n \\approx 0.464n > 0.419n$ (counterintuitively larger)",
       "startLine": 219,
       "endLine": 248,
@@ -165,8 +165,8 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures the complete resolution of Erdős Problem #1034. The Erdős-Faudree conjecture — that every graph with $> n^2/4$ edges contains a triangle with $> (1/2 - o(1))n$ good neighbors — is **false**. Ma and Tang (2020) constructed counterexample families achieving at most $(2 - \\sqrt{5/2})n \\approx 0.419n$ good neighbors per triangle. The book lemma provides a matching lower bound of $h(n) \\geq n/6$. Four theorems were proved by Aristotle (Harmonic): numerical verifications of the Ma-Tang and $K_4$-free constants, the gap bound, and the conjecture negation.",
-    "implications": "1. **Limits of Turán-type conjectures**: The disproof shows that dense graph structure is more subtle than initially conjectured — exceeding the Turán threshold forces triangles but cannot force triangle neighborhoods to cover half the graph.\n\n2. **Book lemma as a universal tool**: The lower bound $h(n) \\geq n/6$ via the book lemma demonstrates that common-neighbor counting (a.k.a.\n\ncodegree arguments) gives non-trivial structural information for any triangle in a dense graph.\n\n3. **$K_4$-free phenomena**: The higher bound $(2\\sqrt{3} - 3)n \\approx 0.464n$ in $K_4$-free graphs reveals that forbidding higher cliques paradoxically *increases* the good neighbor guarantee — the Turán graph $T(n,3)$ distributes edges more uniformly.\n\n4. **Connection to Erdős Problem #905**: The formalized implication $h(n) \\geq 1 \\implies$ Problem #905 places this result in the network of Erdős problems on triangle structure in dense graphs.\n\n5. **Formalization approach**: The axiomatization of the Ma-Tang construction and book lemma separates the combinatorial existence claims from the quantitative verification, allowing Aristotle to handle the numerical components automatically.",
+    "summary": "This formalization captures the complete resolution of Erd\u0151s Problem #1034. The Erd\u0151s-Faudree conjecture \u2014 that every graph with $> n^2/4$ edges contains a triangle with $> (1/2 - o(1))n$ good neighbors \u2014 is **false**. Ma and Tang (2020) constructed counterexample families achieving at most $(2 - \\sqrt{5/2})n \\approx 0.419n$ good neighbors per triangle. The book lemma provides a matching lower bound of $h(n) \\geq n/6$. Four theorems were proved by Aristotle (Harmonic): numerical verifications of the Ma-Tang and $K_4$-free constants, the gap bound, and the conjecture negation.",
+    "implications": "1. **Limits of Tur\u00e1n-type conjectures**: The disproof shows that dense graph structure is more subtle than initially conjectured \u2014 exceeding the Tur\u00e1n threshold forces triangles but cannot force triangle neighborhoods to cover half the graph.\n\n2. **Book lemma as a universal tool**: The lower bound $h(n) \\geq n/6$ via the book lemma demonstrates that common-neighbor counting (a.k.a.\n\ncodegree arguments) gives non-trivial structural information for any triangle in a dense graph.\n\n3. **$K_4$-free phenomena**: The higher bound $(2\\sqrt{3} - 3)n \\approx 0.464n$ in $K_4$-free graphs reveals that forbidding higher cliques paradoxically *increases* the good neighbor guarantee \u2014 the Tur\u00e1n graph $T(n,3)$ distributes edges more uniformly.\n\n4. **Connection to Erd\u0151s Problem #905**: The formalized implication $h(n) \\geq 1 \\implies$ Problem #905 places this result in the network of Erd\u0151s problems on triangle structure in dense graphs.\n\n5. **Formalization approach**: The axiomatization of the Ma-Tang construction and book lemma separates the combinatorial existence claims from the quantitative verification, allowing Aristotle to handle the numerical components automatically.",
     "openQuestions": [
       "What is the exact asymptotic constant $c = \\lim_{n \\to \\infty} h(n)/n$? It lies in $[1/6, 2 - \\sqrt{5/2}] \\approx [0.167, 0.419]$.",
       "Can the lower bound be improved beyond $n/6$ using techniques beyond the book lemma (e.g., flag algebras or regularity lemma)?",
@@ -177,27 +177,27 @@
   },
   "crossReferences": [
     {
-      "relationship": "The book lemma underlying the $h(n) \\ge n/6$ lower bound in #1034 is equivalent to the edge-triangle multiplicity result of #905: every above-Turán graph has an edge in $\\ge n/6$ triangles, which directly yields the common-neighbor lower bound.",
+      "relationship": "The book lemma underlying the $h(n) \\ge n/6$ lower bound in #1034 is equivalent to the edge-triangle multiplicity result of #905: every above-Tur\u00e1n graph has an edge in $\\ge n/6$ triangles, which directly yields the common-neighbor lower bound.",
       "targetId": "erdos-905"
     },
     {
-      "relationship": "Companion problem: #1033 asks for the maximum triangle degree sum in above-Turán graphs; #1034 asks for the maximum good-neighbor count. Both set up analogous extremal functions $h(n)$ with the same Turán threshold $n^2/4$ and similar gap phenomena between lower (book lemma) and upper (Ma-Tang-style constructions) bounds.",
+      "relationship": "Companion problem: #1033 asks for the maximum triangle degree sum in above-Tur\u00e1n graphs; #1034 asks for the maximum good-neighbor count. Both set up analogous extremal functions $h(n)$ with the same Tur\u00e1n threshold $n^2/4$ and similar gap phenomena between lower (book lemma) and upper (Ma-Tang-style constructions) bounds.",
       "targetId": "erdos-1033"
     },
     {
-      "relationship": "Triangle supersaturation (#1010) quantifies how many triangles appear once the Turán threshold is exceeded. Problem #1034 studies the neighborhood structure of those forced triangles; together they describe both the abundance and the reach of triangles in dense graphs.",
+      "relationship": "Triangle supersaturation (#1010) quantifies how many triangles appear once the Tur\u00e1n threshold is exceeded. Problem #1034 studies the neighborhood structure of those forced triangles; together they describe both the abundance and the reach of triangles in dense graphs.",
       "targetId": "erdos-1010"
     },
     {
-      "relationship": "Bollobás-Erdős problem #904 proves that above-Turán graphs contain a triangle with degree sum $\\ge (3/2)n$. High degree sum is a prerequisite for having many good neighbors, making #904 a structural precursor to the bounds studied in #1034.",
+      "relationship": "Bollob\u00e1s-Erd\u0151s problem #904 proves that above-Tur\u00e1n graphs contain a triangle with degree sum $\\ge (3/2)n$. High degree sum is a prerequisite for having many good neighbors, making #904 a structural precursor to the bounds studied in #1034.",
       "targetId": "erdos-904"
     },
     {
-      "relationship": "The book lemma used for the $h(n) \\ge n/6$ lower bound in #1034 is closely related to the book-size questions in #80. Both study how large the common neighborhood of a triangle edge must be in a dense graph, differing only in the density regime (all above-Turán vs. triangle-saturated).",
+      "relationship": "The book lemma used for the $h(n) \\ge n/6$ lower bound in #1034 is closely related to the book-size questions in #80. Both study how large the common neighborhood of a triangle edge must be in a dense graph, differing only in the density regime (all above-Tur\u00e1n vs. triangle-saturated).",
       "targetId": "erdos-80"
     },
     {
-      "relationship": "Edge-disjoint triangle packing (#1009) and triangle neighborhood structure (#1034) both operate at the same $\\lfloor n^2/4 \\rfloor + k$ edge density. The Györi packing result and the Ma-Tang neighborhood bound together constrain the combinatorial geometry of triangles just above the Turán threshold.",
+      "relationship": "Edge-disjoint triangle packing (#1009) and triangle neighborhood structure (#1034) both operate at the same $\\lfloor n^2/4 \\rfloor + k$ edge density. The Gy\u00f6ri packing result and the Ma-Tang neighborhood bound together constrain the combinatorial geometry of triangles just above the Tur\u00e1n threshold.",
       "targetId": "erdos-1009"
     }
   ],
@@ -210,26 +210,26 @@
       "title": "On the structure of graphs with given odd girth and large minimum degree",
       "venue": "Journal of Graph Theory",
       "year": "2020",
-      "note": "Disproves the Erdős-Faudree conjecture by constructing graphs with $> n^2/4$ edges where every triangle has at most $(2 - \\sqrt{5/2} + o(1))n$ good neighbors; establishes the upper bound $h(n) \\le (2 - \\sqrt{5/2})n$."
+      "note": "Disproves the Erd\u0151s-Faudree conjecture by constructing graphs with $> n^2/4$ edges where every triangle has at most $(2 - \\sqrt{5/2} + o(1))n$ good neighbors; establishes the upper bound $h(n) \\le (2 - \\sqrt{5/2})n$."
     },
     {
       "authors": [
-        "Paul Erdős",
+        "Paul Erd\u0151s",
         "Ralph Faudree"
       ],
       "title": "Problems and results in graph theory",
       "venue": "The Theory and Applications of Graphs (Kalamazoo, MI, 1980), Wiley",
       "year": "1981",
-      "note": "Source of the Erdős-Faudree conjecture that every above-Turán graph contains a triangle with $> (1/2 - o(1))n$ good neighbors; Erdős himself noted the conjecture 'may be a bit too optimistic'."
+      "note": "Source of the Erd\u0151s-Faudree conjecture that every above-Tur\u00e1n graph contains a triangle with $> (1/2 - o(1))n$ good neighbors; Erd\u0151s himself noted the conjecture 'may be a bit too optimistic'."
     },
     {
       "authors": [
-        "Pál Turán"
+        "P\u00e1l Tur\u00e1n"
       ],
       "title": "On an extremal problem in graph theory",
-      "venue": "Matematikai és Fizikai Lapok",
+      "venue": "Matematikai \u00e9s Fizikai Lapok",
       "year": "1941",
-      "note": "Establishes Turán's theorem: the maximum triangle-free graph on $n$ vertices has $\\lfloor n^2/4 \\rfloor$ edges (the complete bipartite graph $K_{\\lfloor n/2 \\rfloor, \\lceil n/2 \\rceil}$), fixing the threshold above which #1034 operates."
+      "note": "Establishes Tur\u00e1n's theorem: the maximum triangle-free graph on $n$ vertices has $\\lfloor n^2/4 \\rfloor$ edges (the complete bipartite graph $K_{\\lfloor n/2 \\rfloor, \\lceil n/2 \\rceil}$), fixing the threshold above which #1034 operates."
     },
     {
       "authors": [
@@ -244,8 +244,8 @@
     },
     {
       "authors": [
-        "Paul Erdős",
-        "Miklós Simonovits"
+        "Paul Erd\u0151s",
+        "Mikl\u00f3s Simonovits"
       ],
       "title": "Supersaturated graphs and hypergraphs",
       "venue": "Combinatorica",
@@ -273,7 +273,7 @@
       "Finset"
     ],
     "namespace": "Erdos1034",
-    "lineCount": 778,
+    "lineCount": 779,
     "axiomCount": 1,
     "theoremCount": 17,
     "definitionCount": 22,

--- a/src/data/proofs/erdos-108/meta.json
+++ b/src/data/proofs/erdos-108/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-108",
-  "title": "Erdős Problem #108: High Chromatic Subgraphs with Large Girth",
+  "title": "Erd\u0151s Problem #108: High Chromatic Subgraphs with Large Girth",
   "slug": "erdos-108",
   "description": "For every r >= 4 and k >= 2, does there exist f(k,r) such that every graph with chromatic number >= f(k,r) contains a subgraph of girth >= r and chromatic number >= k?",
   "meta": {
-    "author": "Rödl (1977, r=4 case); general case resolved",
+    "author": "R\u00f6dl (1977, r=4 case); general case resolved",
     "sourceUrl": "https://erdosproblems.com/108",
     "date": "1977",
     "status": "axiomatized",
@@ -41,24 +41,24 @@
       }
     ],
     "originalContributions": [
-      "Formal statement of the Erdős-Hajnal conjecture in Lean 4",
-      "Axiomatization of the Erdős-Hajnal-Rödl theorem",
-      "Special case extraction for Rödl's r=4 theorem"
+      "Formal statement of the Erd\u0151s-Hajnal conjecture in Lean 4",
+      "Axiomatization of the Erd\u0151s-Hajnal-R\u00f6dl theorem",
+      "Special case extraction for R\u00f6dl's r=4 theorem"
     ],
     "axiomCount": 1,
     "lineCount": 141,
     "assumptions": "1 axiom: erdos_hajnal_rodl_theorem. See Lean source for the complete statement."
   },
   "overview": {
-    "historicalContext": "This problem was posed by Erdős and Hajnal in the 1960s, connecting two fundamental graph parameters: chromatic number and girth. The chromatic number measures global coloring complexity, while girth measures local sparsity (absence of short cycles).\n\nThe question asks whether high chromatic number forces the existence of subgraphs that are simultaneously highly chromatic AND locally sparse (large girth). This is surprising because high-girth graphs resemble trees locally, and trees are trivially 2-colorable.\n\nVojtěch Rödl proved the r=4 case in 1977, showing that graphs with sufficiently high chromatic number must contain triangle-free subgraphs of arbitrarily high chromatic number. This connected to the classical Mycielski construction of triangle-free graphs with high chromatic number, but went further by showing such subgraphs exist inside ANY sufficiently chromatic graph.",
-    "problemStatement": "For every $r \\geq 4$ and $k \\geq 2$, is there a finite threshold $f(k,r)$ such that every graph $G$ with chromatic number $\\chi(G) \\geq f(k,r)$ contains a subgraph $H$ satisfying:\n- $g(H) \\geq r$ (girth at least $r$, meaning no cycles of length less than $r$)\n- $\\chi(H) \\geq k$ (chromatic number at least $k$)\n\n**Answer**: YES — Rödl (1977) proved the $r=4$ case; the general result follows from extensions of his probabilistic methods.",
+    "historicalContext": "This problem was posed by Erd\u0151s and Hajnal in the 1960s, connecting two fundamental graph parameters: chromatic number and girth. The chromatic number measures global coloring complexity, while girth measures local sparsity (absence of short cycles).\n\nThe question asks whether high chromatic number forces the existence of subgraphs that are simultaneously highly chromatic AND locally sparse (large girth). This is surprising because high-girth graphs resemble trees locally, and trees are trivially 2-colorable.\n\nVojt\u011bch R\u00f6dl proved the r=4 case in 1977, showing that graphs with sufficiently high chromatic number must contain triangle-free subgraphs of arbitrarily high chromatic number. This connected to the classical Mycielski construction of triangle-free graphs with high chromatic number, but went further by showing such subgraphs exist inside ANY sufficiently chromatic graph.",
+    "problemStatement": "For every $r \\geq 4$ and $k \\geq 2$, is there a finite threshold $f(k,r)$ such that every graph $G$ with chromatic number $\\chi(G) \\geq f(k,r)$ contains a subgraph $H$ satisfying:\n- $g(H) \\geq r$ (girth at least $r$, meaning no cycles of length less than $r$)\n- $\\chi(H) \\geq k$ (chromatic number at least $k$)\n\n**Answer**: YES \u2014 R\u00f6dl (1977) proved the $r=4$ case; the general result follows from extensions of his probabilistic methods.",
     "text": "For every r >= 4 and k >= 2, does there exist f(k,r) such that every graph with chromatic number >= f(k,r) contains a subgraph of girth >= r and chromatic number >= k?",
     "proofStrategy": "The proof uses probabilistic methods and Ramsey-theoretic arguments:\n\n1. **Random subgraph selection**: Consider random vertex subsets of the original graph\n2. **Girth control**: With high probability, small subgraphs avoid short cycles\n3. **Chromatic preservation**: Carefully choose parameters so chromatic number is maintained\n4. **Iteration**: Combine multiple rounds to achieve both girth and chromatic bounds\n\nThe explicit bounds for f(k,r) involve tower functions, making direct formalization impractical. We axiomatize the main result and derive the r=4 special case.",
     "keyInsights": [
-      "**Chromatic number χ(G)**: The minimum number of colors needed to color vertices so no adjacent vertices share a color. For complete graph K_n, χ(K_n) = n.",
-      "**Girth g(G)**: Length of the shortest cycle. Girth ≥ 4 means triangle-free. Girth = ∞ for forests (no cycles).",
+      "**Chromatic number \u03c7(G)**: The minimum number of colors needed to color vertices so no adjacent vertices share a color. For complete graph K_n, \u03c7(K_n) = n.",
+      "**Girth g(G)**: Length of the shortest cycle. Girth \u2265 4 means triangle-free. Girth = \u221e for forests (no cycles).",
       "**The paradox resolved**: High girth graphs CAN have high chromatic number (Mycielski's construction), and this result shows such subgraphs are forced to exist in ANY highly chromatic graph.",
-      "**Rödl's r=4 case**: Every graph with χ(G) ≥ f(k,4) contains a triangle-free subgraph with χ ≥ k. This is the most important special case.",
+      "**R\u00f6dl's r=4 case**: Every graph with \u03c7(G) \u2265 f(k,4) contains a triangle-free subgraph with \u03c7 \u2265 k. This is the most important special case.",
       "**Open question**: The infinite version (whether graphs of infinite chromatic number contain subgraphs of infinite chromatic number and arbitrarily large girth) remains unsolved."
     ],
     "prerequisites": [
@@ -89,20 +89,20 @@
       "title": "Main Axiom",
       "startLine": 70,
       "endLine": 92,
-      "summary": "The Erdős-Hajnal-Rödl theorem stated as an axiom, with justification for why formalization is beyond current Mathlib.",
-      "mathContext": "The Erdős-Hajnal-Rödl theorem stated as an axiom, with justification for why formalization is beyond current Mathlib."
+      "summary": "The Erd\u0151s-Hajnal-R\u00f6dl theorem stated as an axiom, with justification for why formalization is beyond current Mathlib.",
+      "mathContext": "The Erd\u0151s-Hajnal-R\u00f6dl theorem stated as an axiom, with justification for why formalization is beyond current Mathlib."
     },
     {
       "id": "main-theorem",
       "title": "Main Theorem",
       "startLine": 93,
       "endLine": 102,
-      "summary": "Erdős Problem #108 stated as a theorem, derived directly from the axiom.",
-      "mathContext": "Erdős Problem #108 stated as a theorem, derived directly from the axiom."
+      "summary": "Erd\u0151s Problem #108 stated as a theorem, derived directly from the axiom.",
+      "mathContext": "Erd\u0151s Problem #108 stated as a theorem, derived directly from the axiom."
     },
     {
       "id": "special-case",
-      "title": "Rödl's Theorem (r=4)",
+      "title": "R\u00f6dl's Theorem (r=4)",
       "startLine": 103,
       "endLine": 142,
       "summary": "The special case for r=4: triangle-free highly chromatic subgraphs. Historical note on Mycielski's construction.",
@@ -110,71 +110,71 @@
     }
   ],
   "conclusion": {
-    "summary": "We formalize Erdős Problem #108, which asks whether high chromatic number forces highly chromatic subgraphs of large girth. The answer is YES, first proved by Rödl for the r=4 case in 1977. We axiomatize the general Erdős-Hajnal-Rödl theorem and derive the key special cases.",
-    "implications": "**Theoretical Significance**: This result reveals a deep connection between global (chromatic number) and local (girth) graph properties.\n\nIt shows that chromatic complexity cannot be 'explained away' by local density—even locally tree-like subgraphs can require many colors. The proof techniques (probabilistic method, Ramsey theory) are central to modern combinatorics.",
+    "summary": "We formalize Erd\u0151s Problem #108, which asks whether high chromatic number forces highly chromatic subgraphs of large girth. The answer is YES, first proved by R\u00f6dl for the r=4 case in 1977. We axiomatize the general Erd\u0151s-Hajnal-R\u00f6dl theorem and derive the key special cases.",
+    "implications": "**Theoretical Significance**: This result reveals a deep connection between global (chromatic number) and local (girth) graph properties.\n\nIt shows that chromatic complexity cannot be 'explained away' by local density\u2014even locally tree-like subgraphs can require many colors. The proof techniques (probabilistic method, Ramsey theory) are central to modern combinatorics.",
     "openQuestions": [
       "What are the best explicit bounds for f(k,r)?",
       "Does every graph of infinite chromatic number contain a subgraph of infinite chromatic number and girth > k for all k?",
-      "Does lim_{k→∞} f(k,r+1)/f(k,r) = ∞ as Erdős asked?"
+      "Does lim_{k\u2192\u221e} f(k,r+1)/f(k,r) = \u221e as Erd\u0151s asked?"
     ]
   },
   "crossReferences": [
     {
       "relationship": "companion problem",
-      "description": "Erdős Problem #58 asks whether graphs with sufficiently high chromatic number must contain odd cycles of every length, a complementary question about how chromatic number forces cycle structure. Together with #108, it forms part of Erdős's program relating chromatic number to cycle properties.",
+      "description": "Erd\u0151s Problem #58 asks whether graphs with sufficiently high chromatic number must contain odd cycles of every length, a complementary question about how chromatic number forces cycle structure. Together with #108, it forms part of Erd\u0151s's program relating chromatic number to cycle properties.",
       "targetId": "erdos-58"
     },
     {
       "relationship": "closely related result",
-      "description": "Erdős Problem #57 addresses whether graphs of infinite chromatic number must contain odd cycles, an infinite analogue of the finite chromatic/cycle questions. The relationship between girth and chromatic number studied in #108 is directly relevant.",
+      "description": "Erd\u0151s Problem #57 addresses whether graphs of infinite chromatic number must contain odd cycles, an infinite analogue of the finite chromatic/cycle questions. The relationship between girth and chromatic number studied in #108 is directly relevant.",
       "targetId": "erdos-57"
     },
     {
       "relationship": "related conjecture",
-      "description": "The Erdős–Hajnal Conjecture (#61) asks whether every graph with a forbidden induced subgraph has a large clique or independent set. It shares the theme of extracting structured subgraphs from dense/chromatic graphs, and Erdős and Hajnal are co-authors of both problems.",
+      "description": "The Erd\u0151s\u2013Hajnal Conjecture (#61) asks whether every graph with a forbidden induced subgraph has a large clique or independent set. It shares the theme of extracting structured subgraphs from dense/chromatic graphs, and Erd\u0151s and Hajnal are co-authors of both problems.",
       "targetId": "erdos-61"
     },
     {
       "relationship": "shared technique",
-      "description": "Erdős Problem #77 concerns Ramsey number growth rates and relies on the same probabilistic method (random graph constructions) that underlies Rödl's proof of the r=4 case of #108. Both illustrate the power of the probabilistic method in extremal combinatorics.",
+      "description": "Erd\u0151s Problem #77 concerns Ramsey number growth rates and relies on the same probabilistic method (random graph constructions) that underlies R\u00f6dl's proof of the r=4 case of #108. Both illustrate the power of the probabilistic method in extremal combinatorics.",
       "targetId": "erdos-77"
     },
     {
       "relationship": "shared technique",
-      "description": "Erdős Problem #78 seeks constructive lower bounds for Ramsey numbers, using probabilistic arguments similar to those in the proof of #108. The girth control in #108's proof uses random subgraph selection analogous to Ramsey constructions.",
+      "description": "Erd\u0151s Problem #78 seeks constructive lower bounds for Ramsey numbers, using probabilistic arguments similar to those in the proof of #108. The girth control in #108's proof uses random subgraph selection analogous to Ramsey constructions.",
       "targetId": "erdos-78"
     },
     {
       "relationship": "related problem",
-      "description": "Erdős Problem #74 asks whether graphs of high chromatic number contain almost-bipartite subgraphs of high chromatic number—a variant of the same theme in #108 where the structural constraint is near-bipartiteness rather than large girth.",
+      "description": "Erd\u0151s Problem #74 asks whether graphs of high chromatic number contain almost-bipartite subgraphs of high chromatic number\u2014a variant of the same theme in #108 where the structural constraint is near-bipartiteness rather than large girth.",
       "targetId": "erdos-74"
     }
   ],
   "references": [
     {
       "authors": [
-        "V. Rödl"
+        "V. R\u00f6dl"
       ],
       "title": "On the chromatic number of subgraphs of a given graph",
       "venue": "Proceedings of the American Mathematical Society",
       "year": "1977",
       "volume": "64",
-      "pages": "370–371",
+      "pages": "370\u2013371",
       "doi": "10.1090/S0002-9939-1977-0469909-7",
-      "note": "Proves the r=4 case: every graph with sufficiently high chromatic number contains a triangle-free subgraph of chromatic number ≥ k."
+      "note": "Proves the r=4 case: every graph with sufficiently high chromatic number contains a triangle-free subgraph of chromatic number \u2265 k."
     },
     {
       "authors": [
-        "P. Erdős",
+        "P. Erd\u0151s",
         "A. Hajnal"
       ],
       "title": "On chromatic number of graphs and set-systems",
       "venue": "Acta Mathematica Hungarica",
       "year": "1966",
       "volume": "17",
-      "pages": "61–99",
+      "pages": "61\u201399",
       "doi": "10.1007/BF02020444",
-      "note": "Original paper posing the problem of high-chromatic subgraphs with large girth, establishing the foundational questions addressed in Erdős Problem #108."
+      "note": "Original paper posing the problem of high-chromatic subgraphs with large girth, establishing the foundational questions addressed in Erd\u0151s Problem #108."
     },
     {
       "authors": [
@@ -184,21 +184,21 @@
       "venue": "Colloquium Mathematicum",
       "year": "1955",
       "volume": "3",
-      "pages": "161–162",
+      "pages": "161\u2013162",
       "doi": "10.4064/cm-3-2-161-162",
       "note": "Mycielski's construction of triangle-free graphs with arbitrarily high chromatic number, a key precursor showing that high girth and high chromatic number are compatible."
     },
     {
       "authors": [
-        "P. Erdős"
+        "P. Erd\u0151s"
       ],
       "title": "Graph theory and probability",
       "venue": "Canadian Journal of Mathematics",
       "year": "1959",
       "volume": "11",
-      "pages": "34–38",
+      "pages": "34\u201338",
       "doi": "10.4153/CJM-1959-003-9",
-      "note": "Erdős's seminal paper introducing the probabilistic method in graph theory, used to construct graphs with high girth and high chromatic number, directly motivating the problem in #108."
+      "note": "Erd\u0151s's seminal paper introducing the probabilistic method in graph theory, used to construct graphs with high girth and high chromatic number, directly motivating the problem in #108."
     },
     {
       "authors": [
@@ -210,7 +210,7 @@
       "year": "2016",
       "edition": "4th",
       "isbn": "978-1-119-06195-3",
-      "note": "Comprehensive treatment of probabilistic techniques including the girth-chromatic number constructions and Lovász Local Lemma used in proofs related to #108. Chapter 5 covers high girth, high chromatic number graphs."
+      "note": "Comprehensive treatment of probabilistic techniques including the girth-chromatic number constructions and Lov\u00e1sz Local Lemma used in proofs related to #108. Chapter 5 covers high girth, high chromatic number graphs."
     }
   ],
   "leanFile": {
@@ -225,7 +225,7 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos108",
-    "lineCount": 141,
+    "lineCount": 142,
     "axiomCount": 1,
     "theoremCount": 2,
     "definitionCount": 0,

--- a/src/data/proofs/erdos-109/meta.json
+++ b/src/data/proofs/erdos-109/meta.json
@@ -1,6 +1,6 @@
 {
   "id": "erdos-109",
-  "title": "Erdős Problem #109: The Sumset Conjecture",
+  "title": "Erd\u0151s Problem #109: The Sumset Conjecture",
   "slug": "erdos-109",
   "description": "Any subset A of natural numbers with positive upper density contains a sumset B + C where both B and C are infinite.",
   "meta": {
@@ -53,14 +53,14 @@
     "assumptions": "1 axiom: moreira_richter_robertson. See Lean source for the complete statement."
   },
   "overview": {
-    "historicalContext": "The Erdős Sumset Conjecture was a longstanding open problem connecting density and additive structure. Erdős asked whether sets of positive upper density must contain rich additive structure in the form of infinite sumsets.\n\nThe conjecture was proved in 2019 by Joel Moreira, Florian Richter, and Donald Robertson in their paper 'A proof of a sumset conjecture of Erdős' published in the Annals of Mathematics. This was a major breakthrough in additive combinatorics, establishing a fundamental connection between asymptotic density and additive structure.\n\nThe proof uses sophisticated techniques from ergodic theory, including the Furstenberg correspondence principle and recurrence along polynomial sequences. This connects to Szemerédi's theorem (arithmetic progressions in dense sets) but establishes a different kind of additive structure.",
-    "problemStatement": "Let $A \\subseteq \\mathbb{N}$ have positive upper density, meaning\n$$\\limsup_{N \\to \\infty} \\frac{|A \\cap \\{1,\\ldots,N\\}|}{N} > 0$$\n\nMust $A$ contain a sumset $B + C = \\{b + c : b \\in B, c \\in C\\}$ where both $B$ and $C$ are infinite?\n\n**Answer**: YES — proved by Moreira, Richter, and Robertson (2019).",
+    "historicalContext": "The Erd\u0151s Sumset Conjecture was a longstanding open problem connecting density and additive structure. Erd\u0151s asked whether sets of positive upper density must contain rich additive structure in the form of infinite sumsets.\n\nThe conjecture was proved in 2019 by Joel Moreira, Florian Richter, and Donald Robertson in their paper 'A proof of a sumset conjecture of Erd\u0151s' published in the Annals of Mathematics. This was a major breakthrough in additive combinatorics, establishing a fundamental connection between asymptotic density and additive structure.\n\nThe proof uses sophisticated techniques from ergodic theory, including the Furstenberg correspondence principle and recurrence along polynomial sequences. This connects to Szemer\u00e9di's theorem (arithmetic progressions in dense sets) but establishes a different kind of additive structure.",
+    "problemStatement": "Let $A \\subseteq \\mathbb{N}$ have positive upper density, meaning\n$$\\limsup_{N \\to \\infty} \\frac{|A \\cap \\{1,\\ldots,N\\}|}{N} > 0$$\n\nMust $A$ contain a sumset $B + C = \\{b + c : b \\in B, c \\in C\\}$ where both $B$ and $C$ are infinite?\n\n**Answer**: YES \u2014 proved by Moreira, Richter, and Robertson (2019).",
     "text": "Any subset A of natural numbers with positive upper density contains a sumset B + C where both B and C are infinite.",
-    "proofStrategy": "We formalize the problem by defining:\n\n1. **Upper density**: Using limsup of the counting function ratio\n2. **Lower density**: Using liminf, with a proof that lower ≤ upper\n3. **Sumsets**: Custom definition B +ₛ C with commutativity proof\n4. **Main theorem**: Axiomatized as the Moreira-Richter-Robertson theorem\n\nThe actual proof (not formalized) uses:\n- Furstenberg correspondence: Convert density to measure theory\n- IP-sets and recurrence along polynomial sequences\n- Sophisticated ergodic-theoretic arguments\n\nWe derive consequences including that positive density sets are infinite, and provide the even numbers as a concrete example.",
+    "proofStrategy": "We formalize the problem by defining:\n\n1. **Upper density**: Using limsup of the counting function ratio\n2. **Lower density**: Using liminf, with a proof that lower \u2264 upper\n3. **Sumsets**: Custom definition B +\u209b C with commutativity proof\n4. **Main theorem**: Axiomatized as the Moreira-Richter-Robertson theorem\n\nThe actual proof (not formalized) uses:\n- Furstenberg correspondence: Convert density to measure theory\n- IP-sets and recurrence along polynomial sequences\n- Sophisticated ergodic-theoretic arguments\n\nWe derive consequences including that positive density sets are infinite, and provide the even numbers as a concrete example.",
     "keyInsights": [
       "**Upper density**: The proportion of A in {1,...,N} may fluctuate; upper density captures the 'best case' via limsup.",
       "**Sumsets are structured**: B + C contains all pairwise sums, giving rich additive structure when B and C are infinite.",
-      "**Density vs structure**: High density forces additive structure—this parallels Szemerédi (APs) but gives sumsets instead.",
+      "**Density vs structure**: High density forces additive structure\u2014this parallels Szemer\u00e9di (APs) but gives sumsets instead.",
       "**Ergodic theory connection**: The proof uses dynamics to translate the combinatorial problem to measure theory.",
       "**Consequences**: A corollary shows positive density sets are necessarily infinite (since they contain infinite sumsets)."
     ],
@@ -77,8 +77,8 @@
       "title": "Density Definitions",
       "startLine": 31,
       "endLine": 94,
-      "summary": "Define counting function, upper/lower density, and prove lower ≤ upper density.",
-      "mathContext": "Define counting function, upper/lower density, and prove lower ≤ upper density."
+      "summary": "Define counting function, upper/lower density, and prove lower \u2264 upper density.",
+      "mathContext": "Define counting function, upper/lower density, and prove lower \u2264 upper density."
     },
     {
       "id": "sumset-defs",
@@ -90,7 +90,7 @@
     },
     {
       "id": "main-theorem",
-      "title": "The Erdős Sumset Conjecture",
+      "title": "The Erd\u0151s Sumset Conjecture",
       "startLine": 118,
       "endLine": 144,
       "summary": "State the conjecture as ErdosSumsetConjecture and axiomatize the Moreira-Richter-Robertson theorem.",
@@ -109,13 +109,13 @@
       "title": "Examples",
       "startLine": 208,
       "endLine": 438,
-      "summary": "Verify that ℕ has full density, define even numbers, and prove even + even ⊆ even.",
-      "mathContext": "Verify that ℕ has full density, define even numbers, and prove even + even ⊆ even."
+      "summary": "Verify that \u2115 has full density, define even numbers, and prove even + even \u2286 even.",
+      "mathContext": "Verify that \u2115 has full density, define even numbers, and prove even + even \u2286 even."
     }
   ],
   "conclusion": {
-    "summary": "We formalize Erdős Problem #109, the Sumset Conjecture, which asks whether positive density sets contain infinite sumsets B + C. The answer is YES, proved by Moreira-Richter-Robertson in 2019. We provide a complete density framework, axiomatize the main theorem, derive key consequences, and verify concrete examples.",
-    "implications": "**Theoretical Significance**: This result establishes a deep connection between asymptotic density and additive structure.\n\nIt shows that positive density is not just about 'being large'—it forces specific algebraic structure (infinite sumsets). The ergodic-theoretic proof technique has broad applications in combinatorics.",
+    "summary": "We formalize Erd\u0151s Problem #109, the Sumset Conjecture, which asks whether positive density sets contain infinite sumsets B + C. The answer is YES, proved by Moreira-Richter-Robertson in 2019. We provide a complete density framework, axiomatize the main theorem, derive key consequences, and verify concrete examples.",
+    "implications": "**Theoretical Significance**: This result establishes a deep connection between asymptotic density and additive structure.\n\nIt shows that positive density is not just about 'being large'\u2014it forces specific algebraic structure (infinite sumsets). The ergodic-theoretic proof technique has broad applications in combinatorics.",
     "openQuestions": [
       "Can we strengthen to find B, C with specific gap conditions?",
       "What is the minimal density threshold for various sumset structures?",
@@ -125,38 +125,38 @@
   "crossReferences": [
     {
       "slug": "erdos-656",
-      "title": "Erdős Problem #656: Density Version of Hindman's Theorem",
+      "title": "Erd\u0151s Problem #656: Density Version of Hindman's Theorem",
       "relationship": "Direct strengthening by the same team: Kra, Moreira, and Richter extended their sumset techniques to prove that positive-density sets contain B+B+t for some infinite B and integer t, a density analogue of Hindman's theorem.",
       "targetId": "erdos-656"
     },
     {
       "slug": "erdos-139",
-      "title": "Erdős #139: Szemerédi's Theorem",
-      "relationship": "Paradigmatic parallel: Szemerédi's theorem shows positive upper density forces arithmetic progressions; Problem #109 shows it forces infinite sumsets B+C. Both use the Furstenberg correspondence principle to translate density hypotheses into ergodic recurrence.",
+      "title": "Erd\u0151s #139: Szemer\u00e9di's Theorem",
+      "relationship": "Paradigmatic parallel: Szemer\u00e9di's theorem shows positive upper density forces arithmetic progressions; Problem #109 shows it forces infinite sumsets B+C. Both use the Furstenberg correspondence principle to translate density hypotheses into ergodic recurrence.",
       "targetId": "erdos-139"
     },
     {
       "slug": "erdos-3",
-      "title": "Erdős Problem #3: Arithmetic Progressions in Large Sets",
-      "relationship": "Companion density-forces-structure conjecture: Erdős conjectures that divergent reciprocal sum (a weaker condition than positive density) still forces arbitrarily long arithmetic progressions, making Problem #3 harder than Szemerédi and philosophically linked to Problem #109.",
+      "title": "Erd\u0151s Problem #3: Arithmetic Progressions in Large Sets",
+      "relationship": "Companion density-forces-structure conjecture: Erd\u0151s conjectures that divergent reciprocal sum (a weaker condition than positive density) still forces arbitrarily long arithmetic progressions, making Problem #3 harder than Szemer\u00e9di and philosophically linked to Problem #109.",
       "targetId": "erdos-3"
     },
     {
       "slug": "erdos-31",
-      "title": "Erdős Problem #31: Additive Complements",
-      "relationship": "Sumset covering perspective: while Problem #31 asks when A+B covers ℕ (with B of density 0), Problem #109 asks when A itself contains an infinite sumset — complementary questions about the additive structure forced by density conditions.",
+      "title": "Erd\u0151s Problem #31: Additive Complements",
+      "relationship": "Sumset covering perspective: while Problem #31 asks when A+B covers \u2115 (with B of density 0), Problem #109 asks when A itself contains an infinite sumset \u2014 complementary questions about the additive structure forced by density conditions.",
       "targetId": "erdos-31"
     },
     {
       "slug": "erdos-245",
-      "title": "Erdős Problem #245: Sumset Growth Ratio",
-      "relationship": "Sumset size and structure: Freiman's result (limsup |A+A|/|A| ≥ 3 for zero-density A) and Plünnecke-Ruzsa theory provide the finite sumset toolkit that informs the infinite sumset theory underlying Problem #109.",
+      "title": "Erd\u0151s Problem #245: Sumset Growth Ratio",
+      "relationship": "Sumset size and structure: Freiman's result (limsup |A+A|/|A| \u2265 3 for zero-density A) and Pl\u00fcnnecke-Ruzsa theory provide the finite sumset toolkit that informs the infinite sumset theory underlying Problem #109.",
       "targetId": "erdos-245"
     },
     {
       "slug": "szemeredi-theorem",
-      "title": "Szemerédi's Theorem (k=3 via Mathlib)",
-      "relationship": "Lean formalization of the k=3 Szemerédi theorem (Roth's theorem); shares the density framework and limsup-based definitions that appear in the Erdős-109 Lean file, making it a direct technical companion in the gallery.",
+      "title": "Szemer\u00e9di's Theorem (k=3 via Mathlib)",
+      "relationship": "Lean formalization of the k=3 Szemer\u00e9di theorem (Roth's theorem); shares the density framework and limsup-based definitions that appear in the Erd\u0151s-109 Lean file, making it a direct technical companion in the gallery.",
       "targetId": "szemeredi-theorem"
     }
   ],
@@ -167,10 +167,10 @@
         "Florian K. Richter",
         "Donald Robertson"
       ],
-      "title": "A proof of a sumset conjecture of Erdős",
+      "title": "A proof of a sumset conjecture of Erd\u0151s",
       "volume": "189",
       "number": "2",
-      "pages": "605–652",
+      "pages": "605\u2013652",
       "year": "2019",
       "doi": "10.4007/annals.2019.189.2.4",
       "note": "The primary source proving the conjecture; uses Furstenberg correspondence and polynomial ergodic recurrence.",
@@ -181,37 +181,37 @@
         "Vitaly Bergelson",
         "Alexander Leibman"
       ],
-      "title": "Polynomial extensions of van der Waerden's and Szemerédi's theorems",
+      "title": "Polynomial extensions of van der Waerden's and Szemer\u00e9di's theorems",
       "volume": "9",
       "number": "3",
-      "pages": "725–753",
+      "pages": "725\u2013753",
       "year": "1996",
       "doi": "10.1090/S0894-0347-96-00194-4",
-      "note": "Foundational ergodic theory paper on polynomial recurrence; key precursor to the Moreira–Richter–Robertson proof.",
+      "note": "Foundational ergodic theory paper on polynomial recurrence; key precursor to the Moreira\u2013Richter\u2013Robertson proof.",
       "venue": "Journal of the American Mathematical Society"
     },
     {
       "authors": [
         "Hillel Furstenberg"
       ],
-      "title": "Ergodic behavior of diagonal measures and a theorem of Szemerédi on arithmetic progressions",
+      "title": "Ergodic behavior of diagonal measures and a theorem of Szemer\u00e9di on arithmetic progressions",
       "volume": "31",
-      "pages": "204–256",
+      "pages": "204\u2013256",
       "year": "1977",
       "doi": "10.1007/BF02813304",
       "note": "Introduces the Furstenberg correspondence principle connecting combinatorial density to measure-theoretic recurrence; central tool in the sumset conjecture proof.",
-      "venue": "Journal d'Analyse Mathématique"
+      "venue": "Journal d'Analyse Math\u00e9matique"
     },
     {
       "authors": [
-        "Endre Szemerédi"
+        "Endre Szemer\u00e9di"
       ],
       "title": "On sets of integers containing no k elements in arithmetic progression",
       "volume": "27",
-      "pages": "199–245",
+      "pages": "199\u2013245",
       "year": "1975",
       "doi": "10.4064/aa-27-1-199-245",
-      "note": "Szemerédi's theorem: positive-density sets contain k-term arithmetic progressions; the parallel density-forces-structure result whose proof technique influenced Problem #109.",
+      "note": "Szemer\u00e9di's theorem: positive-density sets contain k-term arithmetic progressions; the parallel density-forces-structure result whose proof technique influenced Problem #109.",
       "venue": "Acta Arithmetica"
     },
     {
@@ -224,10 +224,10 @@
       "title": "Infinite sumsets in sets with positive density",
       "volume": "26",
       "number": "10",
-      "pages": "3709–3735",
+      "pages": "3709\u20133735",
       "year": "2024",
       "doi": "10.4171/JEMS/1388",
-      "note": "Follow-up extending the sumset result; proves density versions of Hindman's theorem and related combinatorial results (Erdős Problem #656).",
+      "note": "Follow-up extending the sumset result; proves density versions of Hindman's theorem and related combinatorial results (Erd\u0151s Problem #656).",
       "venue": "Journal of the European Mathematical Society"
     }
   ],
@@ -242,7 +242,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos109",
-    "lineCount": 437,
+    "lineCount": 438,
     "axiomCount": 1,
     "theoremCount": 13,
     "definitionCount": 9,

--- a/src/data/proofs/erdos-1161/meta.json
+++ b/src/data/proofs/erdos-1161/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-1161",
-  "title": "Erdős Problem #1161: Maximizing Permutation Count by Order",
+  "title": "Erd\u0151s Problem #1161: Maximizing Permutation Count by Order",
   "slug": "erdos-1161",
   "description": "For permutations of [n], which cyclic orders k maximize the count of permutations having order k? SOLVED by Beker: max_k f_k(n) ~ (n-1)! and the maximizer is characterized by lcm divisibility.",
   "meta": {
-    "author": "Erdős",
+    "author": "Erd\u0151s",
     "sourceUrl": "https://erdosproblems.com/1161",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1161Problem.lean",
@@ -47,9 +47,9 @@
       "permCountByOrder: f_k(n) counting permutations of order k",
       "maxPermCountByOrder: max_k f_k(n) via Finset.sup",
       "lcmRange: lcm(1,...,m) via Finset.lcm",
-      "Beker characterization: f_k(n) ≥ (n-1)! implies lcm(1,...,n-k) | k",
+      "Beker characterization: f_k(n) \u2265 (n-1)! implies lcm(1,...,n-k) | k",
       "Beker maximizer: minimal k with lcm(1,...,n-k) | k achieves (n-1)!",
-      "Asymptotic: max_k f_k(n) ≥ (n-1)! for n ≥ 2",
+      "Asymptotic: max_k f_k(n) \u2265 (n-1)! for n \u2265 2",
       "Prime cycle counting: for prime p, permCountByOrder p p = (p-1)! (proved via cycleType characterization)",
       "Small cases: explicit counts for S_1, S_2, S_3"
     ],
@@ -58,12 +58,12 @@
     "assumptions": "0 axioms, 0 sorries. All results proved from Lean primitives."
   },
   "overview": {
-    "historicalContext": "The distribution of permutation orders is a classical topic in probabilistic group theory initiated by Erdős and Turán in their 1965 series of papers. They proved that for a random permutation $\\sigma \\in S_n$, $\\log(\\mathrm{ord}(\\sigma))$ is approximately normally distributed with mean $\\frac{1}{2}(\\log n)^2$ and variance $\\frac{1}{3}(\\log n)^3$—the celebrated Erdős-Turán law.\n\nProblem #1161 asks a different but related question: among all possible orders $k$, which value of $k$ maximizes the count $f_k(n) = |\\{\\sigma \\in S_n : \\mathrm{ord}(\\sigma) = k\\}|$? This was listed as Problem 5.72 in Vardi's \"Computational Recreations in Mathematica\" (1999) and on the Erdős Problems database.\n\nThe problem was resolved by Beker, who proved three precise results: (1) $\\max_{k \\geq 1} f_k(n) \\sim (n-1)!$ as $n \\to \\infty$, meaning the maximum count is asymptotically the number of $(n-1)$-cycles; (2) for large $n$, if $f_k(n) \\geq (n-1)!$ then $\\mathrm{lcm}(1, \\ldots, n-k)$ divides $k$; (3) the maximum is achieved precisely when $k$ is the minimal positive integer satisfying this lcm divisibility condition.\n\nThe connection between the maximizer and the lcm function is surprising and deep, linking the combinatorial structure of cycle types to number-theoretic properties of the least common multiple.\n\n**Status**: SOLVED (Beker [Be25d]).",
+    "historicalContext": "The distribution of permutation orders is a classical topic in probabilistic group theory initiated by Erd\u0151s and Tur\u00e1n in their 1965 series of papers. They proved that for a random permutation $\\sigma \\in S_n$, $\\log(\\mathrm{ord}(\\sigma))$ is approximately normally distributed with mean $\\frac{1}{2}(\\log n)^2$ and variance $\\frac{1}{3}(\\log n)^3$\u2014the celebrated Erd\u0151s-Tur\u00e1n law.\n\nProblem #1161 asks a different but related question: among all possible orders $k$, which value of $k$ maximizes the count $f_k(n) = |\\{\\sigma \\in S_n : \\mathrm{ord}(\\sigma) = k\\}|$? This was listed as Problem 5.72 in Vardi's \"Computational Recreations in Mathematica\" (1999) and on the Erd\u0151s Problems database.\n\nThe problem was resolved by Beker, who proved three precise results: (1) $\\max_{k \\geq 1} f_k(n) \\sim (n-1)!$ as $n \\to \\infty$, meaning the maximum count is asymptotically the number of $(n-1)$-cycles; (2) for large $n$, if $f_k(n) \\geq (n-1)!$ then $\\mathrm{lcm}(1, \\ldots, n-k)$ divides $k$; (3) the maximum is achieved precisely when $k$ is the minimal positive integer satisfying this lcm divisibility condition.\n\nThe connection between the maximizer and the lcm function is surprising and deep, linking the combinatorial structure of cycle types to number-theoretic properties of the least common multiple.\n\n**Status**: SOLVED (Beker [Be25d]).",
     "problemStatement": "**Problem Statement**\n\nLet $f_k(n) = |\\{\\sigma \\in S_n : \\mathrm{ord}(\\sigma) = k\\}|$ denote the number of permutations in $S_n$ having order exactly $k$.\n\nFor which values of $k$ is $f_k(n)$ maximized?\n\n**Answer (Beker)**:\n- $\\max_{k \\geq 1} f_k(n) \\sim (n-1)!$ as $n \\to \\infty$\n- For large $n$: $f_k(n) \\geq (n-1)!$ iff $\\mathrm{lcm}(1, \\ldots, n-k) \\mid k$\n- The maximizer is the minimal such $k$\n\n**Status**: SOLVED",
     "text": "For permutations of [n], which cyclic orders k maximize the count of permutations having order k? SOLVED by Beker: max_k f_k(n) ~ (n-1)! and the maximizer is characterized by lcm divisibility.",
     "proofStrategy": "**Formalization Strategy**\n\nThe Lean file formalizes the problem in 332 lines with 14 proved theorems and 2 axioms:\n\n1. **Core definitions**: $f_k(n)$ = `permCountByOrder`, $\\max_k f_k(n)$ = `maxPermCountByOrder`, $\\mathrm{lcm}(1,\\ldots,m)$ = `lcmRange`\n2. **Basic properties** (all proved): identity has order 1, order divides $n!$, total count equals $n!$, $f_k(n) = 0$ if $k \\nmid n!$\n3. **Small cases** (all proved): explicit counts for $S_1$, $S_2$, $S_3$ via `decide`\n4. **Beker's results** (axioms): characterization and maximizer theorems from [Be25d]\n5. **Key theorem** (proved, axiom-independent): `max_permCount_ge_sub_factorial` via direct n-cycle counting\n6. **Structural lemmas** (all proved): prime cycle counting, lcmRange monotonicity and divisibility",
     "keyInsights": [
-      "The order of a permutation $\\sigma \\in S_n$ equals the lcm of its cycle lengths, so the distribution of orders is controlled by the distribution of cycle types—a classical combinatorial object",
+      "The order of a permutation $\\sigma \\in S_n$ equals the lcm of its cycle lengths, so the distribution of orders is controlled by the distribution of cycle types\u2014a classical combinatorial object",
       "The maximum $\\max_k f_k(n) \\sim (n-1)!$ means the most common order has almost as many representatives as there are $(n-1)$-cycles, suggesting the maximizer is close to $n$ itself",
       "Beker's lcm divisibility condition $\\mathrm{lcm}(1, \\ldots, n-k) \\mid k$ provides a precise arithmetic characterization of which orders $k$ can achieve the maximum count",
       "The function lcmRange$(m) = \\mathrm{lcm}(1, \\ldots, m)$ grows like $e^m$ by the prime number theorem ($\\log \\mathrm{lcm}(1,\\ldots,m) \\sim m$), controlling how the maximizer $k$ relates to $n$",
@@ -101,7 +101,7 @@
     {
       "id": "beker-results",
       "title": "Beker's Main Results",
-      "summary": "States the three key results resolving the problem: (1) `beker_characterization`—if $f_k(n) \\geq (n-1)!$ then $\\mathrm{lcm}(1,\\ldots,n-k) \\mid k$; (2) `beker_maximizer_achieves`—the minimal $k$ with this property achieves exactly $(n-1)!$; (3) `max_permCount_ge_sub_factorial`—there exists $k$ with $f_k(n) \\geq (n-1)!$.",
+      "summary": "States the three key results resolving the problem: (1) `beker_characterization`\u2014if $f_k(n) \\geq (n-1)!$ then $\\mathrm{lcm}(1,\\ldots,n-k) \\mid k$; (2) `beker_maximizer_achieves`\u2014the minimal $k$ with this property achieves exactly $(n-1)!$; (3) `max_permCount_ge_sub_factorial`\u2014there exists $k$ with $f_k(n) \\geq (n-1)!$.",
       "startLine": 97,
       "endLine": 134
     },
@@ -114,11 +114,11 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem #1161 in full: the definition of $f_k(n)$ counting permutations of order $k$, Beker's resolution showing $\\max_k f_k(n) \\sim (n-1)!$ with the maximizer characterized by the lcm divisibility condition $\\mathrm{lcm}(1,\\ldots,n-k) \\mid k$, basic properties proved directly in Lean (order divides $n!$, identity has order 1), and structural lemmas about the lcm function.",
-    "implications": "1. **Probabilistic Group Theory**: Connects to the Erdős-Turán law on the distribution of permutation orders, now complemented by precise extremal results\n\n**2. Analytic Combinatorics**: The asymptotic $(n-1)!$ reveals that the most common order has an exponentially large count, nearly matching the count of $n$-cycles\n\n3. **Number Theory Meets Combinatorics**: The characterization via $\\mathrm{lcm}(1,\\ldots,m)$ divisibility is a surprising connection between the arithmetic of the lcm function and the cycle structure of permutations\n\n4. **Prime Number Theorem Connection**: Since $\\log \\mathrm{lcm}(1,\\ldots,m) \\sim m$ (by PNT), the lcm condition controls which orders $k$ can be maximizers, linking this problem to deep results in analytic number theory.",
+    "summary": "This formalization captures Erd\u0151s Problem #1161 in full: the definition of $f_k(n)$ counting permutations of order $k$, Beker's resolution showing $\\max_k f_k(n) \\sim (n-1)!$ with the maximizer characterized by the lcm divisibility condition $\\mathrm{lcm}(1,\\ldots,n-k) \\mid k$, basic properties proved directly in Lean (order divides $n!$, identity has order 1), and structural lemmas about the lcm function.",
+    "implications": "1. **Probabilistic Group Theory**: Connects to the Erd\u0151s-Tur\u00e1n law on the distribution of permutation orders, now complemented by precise extremal results\n\n**2. Analytic Combinatorics**: The asymptotic $(n-1)!$ reveals that the most common order has an exponentially large count, nearly matching the count of $n$-cycles\n\n3. **Number Theory Meets Combinatorics**: The characterization via $\\mathrm{lcm}(1,\\ldots,m)$ divisibility is a surprising connection between the arithmetic of the lcm function and the cycle structure of permutations\n\n4. **Prime Number Theorem Connection**: Since $\\log \\mathrm{lcm}(1,\\ldots,m) \\sim m$ (by PNT), the lcm condition controls which orders $k$ can be maximizers, linking this problem to deep results in analytic number theory.",
     "openQuestions": [
       "What is the exact second-order term in max_k f_k(n) - (n-1)!?",
-      "How many values of k achieve f_k(n) ≥ (n-1)! for a given n?",
+      "How many values of k achieve f_k(n) \u2265 (n-1)! for a given n?",
       "Can the sorry placeholders (small cases, sum formula) be filled with decidable computations?",
       "What is the analogous result for other finite groups beyond S_n?"
     ]
@@ -143,7 +143,7 @@
       "Nat"
     ],
     "namespace": null,
-    "lineCount": 323,
+    "lineCount": 324,
     "axiomCount": 0,
     "theoremCount": 15,
     "definitionCount": 3,
@@ -163,7 +163,7 @@
     },
     {
       "key": "ET65",
-      "citation": "Erdős, P. and Turán, P. (1965). On some problems of a statistical group-theory, I. Zeitschrift für Wahrscheinlichkeitstheorie, 4, 175-186.",
+      "citation": "Erd\u0151s, P. and Tur\u00e1n, P. (1965). On some problems of a statistical group-theory, I. Zeitschrift f\u00fcr Wahrscheinlichkeitstheorie, 4, 175-186.",
       "type": "paper"
     }
   ],
@@ -171,17 +171,17 @@
     {
       "targetId": "erdos-1138",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: analysis, combinatorics, number-theory"
+      "description": "Related Erd\u0151s problem sharing themes: analysis, combinatorics, number-theory"
     },
     {
       "targetId": "erdos-1166",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: analysis, combinatorics, solved"
+      "description": "Related Erd\u0151s problem sharing themes: analysis, combinatorics, solved"
     },
     {
       "targetId": "erdos-1179",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: analysis, combinatorics, solved"
+      "description": "Related Erd\u0151s problem sharing themes: analysis, combinatorics, solved"
     }
   ],
   "sorries": 0

--- a/src/data/proofs/erdos-123/meta.json
+++ b/src/data/proofs/erdos-123/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-123",
-  "title": "Erdős #123: d-Complete Sequences",
+  "title": "Erd\u0151s #123: d-Complete Sequences",
   "slug": "erdos-123",
-  "description": "Is the set {a^i·b^j·c^k : i,j,k ≥ 0} d-complete for pairwise coprime a,b,c? OPEN in general; {2^k·3^l} case is SOLVED.",
+  "description": "Is the set {a^i\u00b7b^j\u00b7c^k : i,j,k \u2265 0} d-complete for pairwise coprime a,b,c? OPEN in general; {2^k\u00b73^l} case is SOLVED.",
   "meta": {
-    "author": "Erdős-Lewin",
+    "author": "Erd\u0151s-Lewin",
     "sourceUrl": "https://erdosproblems.com/123",
     "date": "1992",
     "status": "axiomatized",
@@ -27,16 +27,16 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "Erdős Problem #123 concerns d-complete sequences — sets where every sufficiently large integer is the sum of distinct elements forming a divisibility antichain (no element divides another). Erdős introduced this concept in 1992, calling it a 'nice and difficult' problem.\n\nThe simplest case {2^k · 3^l} (3-smooth numbers) was quickly proved by Jansen using an elegant even/odd induction: for even n, halve and double all summands; for odd n, subtract the largest power of 3 and recurse on the even remainder. The parity separation — 3 provides odd elements while 2 provides the doubling — is the key insight.\n\nErdős and Lewin (1996) extended this to {3^i · 5^j · 7^k} using more complex residue analysis, since all three generators are odd (no parity trick available). The general conjecture for arbitrary pairwise coprime triples remains OPEN.\n\nThe formalization was processed by Aristotle, which verified the structural lemmas (divisibility characterization, antichain preservation, parity arguments) but flagged the main representation lemma powers23_repr as an unexpected axiom — the full Finset bookkeeping was not completed.",
-    "problemStatement": "Let a, b, c be three pairwise coprime integers > 1. Is the set {a^i · b^j · c^k : i, j, k ≥ 0} d-complete?\n\nA set A is **d-complete** if every sufficiently large integer n can be written as n = a₁ + a₂ + ⋯ + a_r where a_i ∈ A, the a_i are distinct, and no a_i divides a_j for i ≠ j.\n\n**Status**: OPEN in general. Specific cases like {2^k · 3^l} and {3^i · 5^j · 7^k} are SOLVED.",
-    "text": "Is the set {a^i·b^j·c^k : i,j,k ≥ 0} d-complete for pairwise coprime a,b,c? OPEN in general; {2^k·3^l} case is SOLVED.",
-    "proofStrategy": "The formalization proves {2^k · 3^l} is d-complete via a layered approach: (1) Define IsDComplete using Filter.Eventually atTop, Finset, IsAntichain (· ∣ ·), and Finset.sum id. (2) Define Powers23 = {n | ∃ k l, n = 2^k * 3^l}. (3) Prove the divisibility characterization Powers23_dvd_iff (fully verified): 2^k₁·3^l₁ | 2^k₂·3^l₂ iff k₁ ≤ k₂ ∧ l₁ ≤ l₂, using coprimality of 2 and 3. (4) Prove antichain helper Powers23_antichain_pair. (5) Define largestPow3 and prove parity lemmas (pow_three_odd, odd_sub_largest_pow3_even). (6) Axiomatize powers23_repr (the inductive step). (7) Prove powers_2_3_dComplete from powers23_repr. (8) State the OPEN general conjecture erdos_123_conjecture and axiomatize erdos_lewin_357.",
+    "historicalContext": "Erd\u0151s Problem #123 concerns d-complete sequences \u2014 sets where every sufficiently large integer is the sum of distinct elements forming a divisibility antichain (no element divides another). Erd\u0151s introduced this concept in 1992, calling it a 'nice and difficult' problem.\n\nThe simplest case {2^k \u00b7 3^l} (3-smooth numbers) was quickly proved by Jansen using an elegant even/odd induction: for even n, halve and double all summands; for odd n, subtract the largest power of 3 and recurse on the even remainder. The parity separation \u2014 3 provides odd elements while 2 provides the doubling \u2014 is the key insight.\n\nErd\u0151s and Lewin (1996) extended this to {3^i \u00b7 5^j \u00b7 7^k} using more complex residue analysis, since all three generators are odd (no parity trick available). The general conjecture for arbitrary pairwise coprime triples remains OPEN.\n\nThe formalization was processed by Aristotle, which verified the structural lemmas (divisibility characterization, antichain preservation, parity arguments) but flagged the main representation lemma powers23_repr as an unexpected axiom \u2014 the full Finset bookkeeping was not completed.",
+    "problemStatement": "Let a, b, c be three pairwise coprime integers > 1. Is the set {a^i \u00b7 b^j \u00b7 c^k : i, j, k \u2265 0} d-complete?\n\nA set A is **d-complete** if every sufficiently large integer n can be written as n = a\u2081 + a\u2082 + \u22ef + a_r where a_i \u2208 A, the a_i are distinct, and no a_i divides a_j for i \u2260 j.\n\n**Status**: OPEN in general. Specific cases like {2^k \u00b7 3^l} and {3^i \u00b7 5^j \u00b7 7^k} are SOLVED.",
+    "text": "Is the set {a^i\u00b7b^j\u00b7c^k : i,j,k \u2265 0} d-complete for pairwise coprime a,b,c? OPEN in general; {2^k\u00b73^l} case is SOLVED.",
+    "proofStrategy": "The formalization proves {2^k \u00b7 3^l} is d-complete via a layered approach: (1) Define IsDComplete using Filter.Eventually atTop, Finset, IsAntichain (\u00b7 \u2223 \u00b7), and Finset.sum id. (2) Define Powers23 = {n | \u2203 k l, n = 2^k * 3^l}. (3) Prove the divisibility characterization Powers23_dvd_iff (fully verified): 2^k\u2081\u00b73^l\u2081 | 2^k\u2082\u00b73^l\u2082 iff k\u2081 \u2264 k\u2082 \u2227 l\u2081 \u2264 l\u2082, using coprimality of 2 and 3. (4) Prove antichain helper Powers23_antichain_pair. (5) Define largestPow3 and prove parity lemmas (pow_three_odd, odd_sub_largest_pow3_even). (6) Axiomatize powers23_repr (the inductive step). (7) Prove powers_2_3_dComplete from powers23_repr. (8) State the OPEN general conjecture erdos_123_conjecture and axiomatize erdos_lewin_357.",
     "keyInsights": [
-      "**d-completeness combines additive and multiplicative constraints**: Representations must be antichain sums — distinct elements where no element divides another. This mixes additive number theory (sums) with divisibility structure (antichains in the partial order).",
+      "**d-completeness combines additive and multiplicative constraints**: Representations must be antichain sums \u2014 distinct elements where no element divides another. This mixes additive number theory (sums) with divisibility structure (antichains in the partial order).",
       "**Parity separation via coprimality**: The {2,3} proof works because 2 provides the doubling operation (preserves membership and antichains) while 3 provides odd elements for parity adjustment. This clean separation relies on gcd(2,3) = 1 and 2 being the unique even prime.",
-      "**Product order characterizes divisibility**: For 3-smooth numbers, 2^a·3^b | 2^c·3^d iff (a,b) ≤ (c,d) componentwise. Antichains in the divisibility order correspond to incomparable pairs in ℕ², making the antichain condition geometric.",
+      "**Product order characterizes divisibility**: For 3-smooth numbers, 2^a\u00b73^b | 2^c\u00b73^d iff (a,b) \u2264 (c,d) componentwise. Antichains in the divisibility order correspond to incomparable pairs in \u2115\u00b2, making the antichain condition geometric.",
       "**Doubling preserves antichains**: If S is a divisibility antichain, then 2S is also an antichain (by cancellation: a|b iff 2a|2b). This structural lemma is the engine of the even-case induction.",
-      "**General case resists the parity trick**: For odd triples like {5,7,11}, no generator has a parity role. The Erdős-Lewin proof of {3,5,7} uses Chinese Remainder Theorem-style residue analysis, but a uniform approach for all coprime triples remains elusive."
+      "**General case resists the parity trick**: For odd triples like {5,7,11}, no generator has a parity role. The Erd\u0151s-Lewin proof of {3,5,7} uses Chinese Remainder Theorem-style residue analysis, but a uniform approach for all coprime triples remains elusive."
     ],
     "prerequisites": [
       "Combinatorics and number theory",
@@ -50,21 +50,21 @@
       "title": "Core Definitions",
       "startLine": 26,
       "endLine": 40,
-      "summary": "IsDComplete (∀ᶠ n in atTop, ∃ antichain sum), Powers23 = {2^k · 3^l}"
+      "summary": "IsDComplete (\u2200\u1da0 n in atTop, \u2203 antichain sum), Powers23 = {2^k \u00b7 3^l}"
     },
     {
       "id": "basic-properties",
       "title": "Basic Properties of Powers23",
       "startLine": 41,
       "endLine": 69,
-      "summary": "Membership lemmas (1, 2, 3, 4, 6, 8, 9 ∈ Powers23), double_mem_Powers23, pow_two/three_mem_Powers23"
+      "summary": "Membership lemmas (1, 2, 3, 4, 6, 8, 9 \u2208 Powers23), double_mem_Powers23, pow_two/three_mem_Powers23"
     },
     {
       "id": "divisibility",
       "title": "Divisibility Characterization",
       "startLine": 70,
       "endLine": 132,
-      "summary": "Powers23_dvd_iff (2^k₁·3^l₁ | 2^k₂·3^l₂ ↔ k₁≤k₂ ∧ l₁≤l₂, fully proved), Powers23_antichain_pair"
+      "summary": "Powers23_dvd_iff (2^k\u2081\u00b73^l\u2081 | 2^k\u2082\u00b73^l\u2082 \u2194 k\u2081\u2264k\u2082 \u2227 l\u2081\u2264l\u2082, fully proved), Powers23_antichain_pair"
     },
     {
       "id": "induction-helpers",
@@ -78,7 +78,7 @@
       "title": "Main Theorem",
       "startLine": 181,
       "endLine": 222,
-      "summary": "powers23_repr (axiom: ∀ n ≥ 1, ∃ antichain representation), powers_2_3_dComplete (proved from axiom)"
+      "summary": "powers23_repr (axiom: \u2200 n \u2265 1, \u2203 antichain representation), powers_2_3_dComplete (proved from axiom)"
     },
     {
       "id": "general-conjecture",
@@ -96,11 +96,11 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #123 asks whether {a^i · b^j · c^k} is d-complete for all pairwise coprime a, b, c > 1. The formalization proves the {2^k · 3^l} case via even/odd induction exploiting the parity separation between generators 2 and 3. The divisibility characterization (product order on exponent pairs) and antichain preservation under doubling are fully verified. The general conjecture and the Erdős-Lewin {3,5,7} result are axiomatized. The one axiom (powers23_repr) captures the inductive step whose full Finset bookkeeping was not completed.",
-    "implications": "**Theoretical Significance**: The d-completeness framework connects additive number theory with lattice theory and divisibility.\n\nThe proof technique — using coprimality to create a parity-based modular decomposition — suggests that d-completeness may hold whenever the generators provide sufficient 'modular coverage'. For three pairwise coprime generators a, b, c, the Chinese Remainder Theorem guarantees representability of residues mod abc, but translating this to d-complete representations requires controlling the antichain condition, which is the main open challenge.",
+    "summary": "Erd\u0151s Problem #123 asks whether {a^i \u00b7 b^j \u00b7 c^k} is d-complete for all pairwise coprime a, b, c > 1. The formalization proves the {2^k \u00b7 3^l} case via even/odd induction exploiting the parity separation between generators 2 and 3. The divisibility characterization (product order on exponent pairs) and antichain preservation under doubling are fully verified. The general conjecture and the Erd\u0151s-Lewin {3,5,7} result are axiomatized. The one axiom (powers23_repr) captures the inductive step whose full Finset bookkeeping was not completed.",
+    "implications": "**Theoretical Significance**: The d-completeness framework connects additive number theory with lattice theory and divisibility.\n\nThe proof technique \u2014 using coprimality to create a parity-based modular decomposition \u2014 suggests that d-completeness may hold whenever the generators provide sufficient 'modular coverage'. For three pairwise coprime generators a, b, c, the Chinese Remainder Theorem guarantees representability of residues mod abc, but translating this to d-complete representations requires controlling the antichain condition, which is the main open challenge.",
     "openQuestions": [
       "Is the general conjecture true for all pairwise coprime a, b, c > 1? (The main OPEN problem)",
-      "What is the threshold N₀ beyond which all n ≥ N₀ have d-complete representations from PowersABC(a,b,c)?",
+      "What is the threshold N\u2080 beyond which all n \u2265 N\u2080 have d-complete representations from PowersABC(a,b,c)?",
       "Can the proof be extended from 3 to 4 or more coprime generators?",
       "Is there a uniform approach (not relying on case-specific modular arithmetic) for all pairwise coprime triples?",
       "What is the connection between d-completeness and Brown's criterion for complete sequences?"
@@ -116,7 +116,7 @@
       "Pointwise"
     ],
     "namespace": "Erdos123",
-    "lineCount": 317,
+    "lineCount": 318,
     "axiomCount": 3,
     "theoremCount": 22,
     "definitionCount": 5,
@@ -127,26 +127,26 @@
     {
       "targetId": "erdos-11",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: additive-combinatorics, number-theory"
+      "description": "Related Erd\u0151s problem sharing themes: additive-combinatorics, number-theory"
     },
     {
       "targetId": "erdos-1103",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: additive-combinatorics, number-theory"
+      "description": "Related Erd\u0151s problem sharing themes: additive-combinatorics, number-theory"
     },
     {
       "targetId": "erdos-1107",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: additive-combinatorics, number-theory"
+      "description": "Related Erd\u0151s problem sharing themes: additive-combinatorics, number-theory"
     }
   ],
   "references": [
     {
       "key": "Er62b",
       "authors": [
-        "P. Erdős"
+        "P. Erd\u0151s"
       ],
-      "title": "On a problem of Grünbaum",
+      "title": "On a problem of Gr\u00fcnbaum",
       "venue": "Canadian Mathematical Bulletin",
       "year": "1964",
       "volume": "7",

--- a/src/data/proofs/erdos-139/meta.json
+++ b/src/data/proofs/erdos-139/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-139",
-  "title": "Erdős #139: Szemerédi's Theorem",
+  "title": "Erd\u0151s #139: Szemer\u00e9di's Theorem",
   "slug": "erdos-139",
-  "description": "Szemerédi's theorem states that any subset of natural numbers with positive upper density contains arbitrarily long arithmetic progressions. This formalization covers the equivalent density formulation: r_k(N) = o(N), where r_k(N) is the maximum size of a k-AP-free subset of {1,...,N}.",
+  "description": "Szemer\u00e9di's theorem states that any subset of natural numbers with positive upper density contains arbitrarily long arithmetic progressions. This formalization covers the equivalent density formulation: r_k(N) = o(N), where r_k(N) is the maximum size of a k-AP-free subset of {1,...,N}.",
   "meta": {
-    "author": "Endre Szemerédi (solver), Erdős-Turán (conjecture)",
+    "author": "Endre Szemer\u00e9di (solver), Erd\u0151s-Tur\u00e1n (conjecture)",
     "sourceUrl": "https://erdosproblems.com/139",
     "date": "1975",
     "status": "axiomatized",
@@ -14,7 +14,7 @@
       "combinatorics",
       "arithmetic-progressions",
       "density",
-      "szemerédi"
+      "szemer\u00e9di"
     ],
     "badge": "axiom",
     "sorries": 1,
@@ -27,30 +27,30 @@
       "Basic combinatorics and finite set theory",
       "Arithmetic progressions and additive number theory",
       "Density and asymptotic analysis (o-notation, limits)",
-      "Szemerédi regularity lemma (for understanding the proof chain)",
+      "Szemer\u00e9di regularity lemma (for understanding the proof chain)",
       "Roth's theorem and the corners theorem (k=3 case)"
     ],
     "lineCount": 260,
-    "assumptions": "4 axioms: kelley_meka_bound (r₃(N) ≤ N·exp(−c(log N)^(1/12)), Kelley-Meka 2023), gowers_bound (r_k(N) ≤ N/(log log N)^c for k≥4, Gowers 2001), behrend_lower_bound (r₃(N) ≥ N·exp(−c√(log N)), Behrend 1946), szemeredi_theorem (sets with positive density contain k-APs for all k). 1 sorry: main density-to-zero proof.",
+    "assumptions": "4 axioms: kelley_meka_bound (r\u2083(N) \u2264 N\u00b7exp(\u2212c(log N)^(1/12)), Kelley-Meka 2023), gowers_bound (r_k(N) \u2264 N/(log log N)^c for k\u22654, Gowers 2001), behrend_lower_bound (r\u2083(N) \u2265 N\u00b7exp(\u2212c\u221a(log N)), Behrend 1946), szemeredi_theorem (sets with positive density contain k-APs for all k). 1 sorry: main density-to-zero proof.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "Erdős and Pál Turán conjectured in 1936 that any set of integers with positive upper density contains arbitrarily long arithmetic progressions. Klaus Roth proved the $k=3$ case in 1953 (earning a Fields Medal in 1958 partly for this work), and Endre Szemerédi proved the full conjecture in 1975 using a groundbreaking combinatorial regularity lemma, receiving the $\\$1000$ prize from Erdős.\n\nHillel Furstenberg gave a fundamentally different proof in 1977 using ergodic theory (the Furstenberg correspondence principle), opening a new bridge between combinatorics and dynamics. Timothy Gowers (2001) gave a quantitative proof using higher-order Fourier analysis, introducing the Gowers norms $\\|f\\|_{U^k}$. The quantitative bounds have been dramatically improved: Green and Tao (2017) gave polynomial bounds for $k=4$, and Kelley and Meka (2023) achieved the breakthrough bound $r_3(N) \\leq N \\cdot \\exp(-c(\\log N)^{1/12})$ for 3-term progressions, nearly matching the Behrend (1946) lower bound.",
+    "historicalContext": "Erd\u0151s and P\u00e1l Tur\u00e1n conjectured in 1936 that any set of integers with positive upper density contains arbitrarily long arithmetic progressions. Klaus Roth proved the $k=3$ case in 1953 (earning a Fields Medal in 1958 partly for this work), and Endre Szemer\u00e9di proved the full conjecture in 1975 using a groundbreaking combinatorial regularity lemma, receiving the $\\$1000$ prize from Erd\u0151s.\n\nHillel Furstenberg gave a fundamentally different proof in 1977 using ergodic theory (the Furstenberg correspondence principle), opening a new bridge between combinatorics and dynamics. Timothy Gowers (2001) gave a quantitative proof using higher-order Fourier analysis, introducing the Gowers norms $\\|f\\|_{U^k}$. The quantitative bounds have been dramatically improved: Green and Tao (2017) gave polynomial bounds for $k=4$, and Kelley and Meka (2023) achieved the breakthrough bound $r_3(N) \\leq N \\cdot \\exp(-c(\\log N)^{1/12})$ for 3-term progressions, nearly matching the Behrend (1946) lower bound.",
     "problemStatement": "Let r_k(N) be the size of the largest subset of {1,...,N} which does not contain a non-trivial k-term arithmetic progression. Prove that r_k(N) = o(N). Equivalently: any subset of integers with positive upper density contains arbitrarily long arithmetic progressions.",
-    "text": "Szemerédi's theorem states that any subset of natural numbers with positive upper density contains arbitrarily long arithmetic progressions. This formalization covers the equivalent density formulation: r_k(N) = o(N), where r_k(N) is the maximum size of a k-AP-free subset of {1,...,N}.",
-    "proofStrategy": "The formalization defines k-AP-free sets and the r_k(N) function, then states Szemerédi's theorem in density formulation. For k=3 (Roth's theorem), we prove it using Mathlib's corners theorem chain: Regularity Lemma → Triangle Removal → Corners Theorem → Roth's Theorem. The general case k≥4 requires hypergraph regularity lemma (not yet in Mathlib) and is axiomatized.",
+    "text": "Szemer\u00e9di's theorem states that any subset of natural numbers with positive upper density contains arbitrarily long arithmetic progressions. This formalization covers the equivalent density formulation: r_k(N) = o(N), where r_k(N) is the maximum size of a k-AP-free subset of {1,...,N}.",
+    "proofStrategy": "The formalization defines k-AP-free sets and the r_k(N) function, then states Szemer\u00e9di's theorem in density formulation. For k=3 (Roth's theorem), we prove it using Mathlib's corners theorem chain: Regularity Lemma \u2192 Triangle Removal \u2192 Corners Theorem \u2192 Roth's Theorem. The general case k\u22654 requires hypergraph regularity lemma (not yet in Mathlib) and is axiomatized.",
     "keyInsights": [
       "k=3 case (Roth's theorem) is fully proved in Mathlib via corners theorem",
       "Our IsKAPFree definition is equivalent to Mathlib's ThreeAPFree for k=3",
-      "k≥4 requires hypergraph regularity lemma, not available in Mathlib",
-      "Quantitative bounds: Kelley-Meka (2023) gives r₃(N) ≤ N·exp(-c(log N)^{1/12})",
-      "Lower bound: Behrend (1946) shows r₃(N) ≥ N·exp(-c√(log N))"
+      "k\u22654 requires hypergraph regularity lemma, not available in Mathlib",
+      "Quantitative bounds: Kelley-Meka (2023) gives r\u2083(N) \u2264 N\u00b7exp(-c(log N)^{1/12})",
+      "Lower bound: Behrend (1946) shows r\u2083(N) \u2265 N\u00b7exp(-c\u221a(log N))"
     ],
     "prerequisites": [
       "Basic combinatorics and finite set theory",
       "Arithmetic progressions and additive number theory",
       "Density and asymptotic analysis (o-notation, limits)",
-      "Szemerédi regularity lemma (for understanding the proof chain)",
+      "Szemer\u00e9di regularity lemma (for understanding the proof chain)",
       "Roth's theorem and the corners theorem (k=3 case)"
     ]
   },
@@ -67,7 +67,7 @@
       "title": "Main Theorem Statement",
       "startLine": 58,
       "endLine": 93,
-      "summary": "Erdős #139: r_k(N)/N → 0 as N → ∞"
+      "summary": "Erd\u0151s #139: r_k(N)/N \u2192 0 as N \u2192 \u221e"
     },
     {
       "id": "trivial-cases",
@@ -92,10 +92,10 @@
     }
   ],
   "conclusion": {
-    "summary": "Szemerédi's theorem is one of the landmark results in combinatorics. Our formalization captures the density formulation and proves the equivalence between our definitions and Mathlib's for k=3. Roth's theorem (k=3) is fully proved using Mathlib's corners theorem chain. The general k≥4 case awaits hypergraph regularity formalization in Mathlib.",
+    "summary": "Szemer\u00e9di's theorem is one of the landmark results in combinatorics. Our formalization captures the density formulation and proves the equivalence between our definitions and Mathlib's for k=3. Roth's theorem (k=3) is fully proved using Mathlib's corners theorem chain. The general k\u22654 case awaits hypergraph regularity formalization in Mathlib.",
     "implications": "This theorem has profound implications for additive combinatorics, ergodic theory, and theoretical computer science. It implies that pseudorandom sets must contain long arithmetic progressions, which has applications in PCP constructions and property testing.",
     "openQuestions": [
-      "Formalize hypergraph regularity lemma for k≥4 proof",
+      "Formalize hypergraph regularity lemma for k\u22654 proof",
       "Connect to Furstenberg's ergodic theory proof",
       "Formalize the Kelley-Meka quantitative bounds"
     ]
@@ -113,7 +113,7 @@
       "Topology"
     ],
     "namespace": "Erdos139",
-    "lineCount": 260,
+    "lineCount": 261,
     "axiomCount": 4,
     "theoremCount": 8,
     "definitionCount": 5,
@@ -124,43 +124,43 @@
     {
       "targetId": "erdos-1075",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, density"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, density"
     },
     {
       "targetId": "erdos-109",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, density"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, density"
     },
     {
       "targetId": "erdos-138",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: arithmetic-progressions, combinatorics"
+      "description": "Related Erd\u0151s problem sharing themes: arithmetic-progressions, combinatorics"
     }
   ],
   "references": [
     {
       "key": "Sz75",
       "authors": [
-        "E. Szemerédi"
+        "E. Szemer\u00e9di"
       ],
       "title": "On sets of integers containing no k elements in arithmetic progression",
       "venue": "Acta Arithmetica",
       "year": "1975",
       "volume": "27",
       "pages": "199-245",
-      "note": "The original proof of Szemerédi's theorem: any positive-density subset of integers contains arbitrarily long APs"
+      "note": "The original proof of Szemer\u00e9di's theorem: any positive-density subset of integers contains arbitrarily long APs"
     },
     {
       "key": "Go01",
       "authors": [
         "W.T. Gowers"
       ],
-      "title": "A new proof of Szemerédi's theorem",
+      "title": "A new proof of Szemer\u00e9di's theorem",
       "venue": "Geometric and Functional Analysis",
       "year": "2001",
       "volume": "11",
       "pages": "465-588",
-      "note": "Gowers's analytic proof giving the first effective bounds for Szemerédi's theorem"
+      "note": "Gowers's analytic proof giving the first effective bounds for Szemer\u00e9di's theorem"
     }
   ],
   "sorries": 1

--- a/src/data/proofs/erdos-143/meta.json
+++ b/src/data/proofs/erdos-143/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "erdos-143",
-  "title": "Erdős Problem #143: Sparseness of Dilation-Avoiding Sets",
+  "title": "Erd\u0151s Problem #143: Sparseness of Dilation-Avoiding Sets",
   "slug": "erdos-143",
-  "description": "If A ⊂ (1,∞) satisfies |kx - y| ≥ 1 for all distinct x,y ∈ A and k ≥ 1, must A be sparse?",
+  "description": "If A \u2282 (1,\u221e) satisfies |kx - y| \u2265 1 for all distinct x,y \u2208 A and k \u2265 1, must A be sparse?",
   "meta": {
     "author": "Koukoulopoulos-Lamzouri-Lichtman (2025)",
     "sourceUrl": "https://erdosproblems.com/143",
@@ -50,16 +50,16 @@
     "assumptions": "3 axiom(s): kll_theorem, well_separated_integers_primitive, erdos_1935_primitive. See Lean source for complete statements."
   },
   "overview": {
-    "historicalContext": "Erdős Problem #143 belongs to a family of questions about how structural constraints on sets force sparseness. A set $A \\subset (1, \\infty)$ is *well-separated under integer dilation* if $|kx - y| \\geq 1$ for all distinct $x, y \\in A$ and positive integers $k$ — no element can be close to any integer multiple of another. This condition arises naturally in the study of primitive sets, lattice-free configurations, and Diophantine approximation.\n\nFor **integer sets**, well-separation implies primitivity: if $a \\mid b$ with $b = ka$, then $|ka - b| = 0 < 1$, violating the condition. Erdős initiated the study of primitive sets in 1935, proving that for any infinite primitive set $A \\subset \\mathbb{N}$, the series $\\sum_{a \\in A} 1/(a \\log a)$ converges — a result that quantifies how sparse primitive sets must be. Felix Behrend independently obtained the density estimate $\\sum_{a \\leq x, a \\in A} 1/a \\ll \\sqrt{\\log x / \\log \\log x}$ in the same year. The question of whether these density bounds extend from primitive integer sets to the broader class of real well-separated sets remained open for nearly 90 years.\n\nThe breakthrough came in 2025 when Dimitris Koukoulopoulos, Youness Lamzouri, and Jared Duker Lichtman proved that for any well-separated set $A$, the partial reciprocal sum $\\sum_{x < n, x \\in A} 1/x = o(\\log n)$ — resolving the weakest of Erdős's three conjectures. Their proof uses a novel graph-theoretic approach: they construct a GCD graph on elements of $A$ and use structural properties of this graph together with bounds from multiplicative number theory to control the reciprocal sum. The two stronger conjectures — (i) that the lower density $\\liminf |A \\cap [1,x]|/x = 0$, and (ii) that $\\sum_{x \\in A} 1/(x \\log x)$ converges — remain open, with the $500 prize still partially unclaimed.\n\nThe problem connects to several areas of modern number theory: the structure of multiplicative functions (Halász's theorem), sieve methods for controlling divisor sums, and the Hardy-Ramanujan theory of the number of prime factors.",
+    "historicalContext": "Erd\u0151s Problem #143 belongs to a family of questions about how structural constraints on sets force sparseness. A set $A \\subset (1, \\infty)$ is *well-separated under integer dilation* if $|kx - y| \\geq 1$ for all distinct $x, y \\in A$ and positive integers $k$ \u2014 no element can be close to any integer multiple of another. This condition arises naturally in the study of primitive sets, lattice-free configurations, and Diophantine approximation.\n\nFor **integer sets**, well-separation implies primitivity: if $a \\mid b$ with $b = ka$, then $|ka - b| = 0 < 1$, violating the condition. Erd\u0151s initiated the study of primitive sets in 1935, proving that for any infinite primitive set $A \\subset \\mathbb{N}$, the series $\\sum_{a \\in A} 1/(a \\log a)$ converges \u2014 a result that quantifies how sparse primitive sets must be. Felix Behrend independently obtained the density estimate $\\sum_{a \\leq x, a \\in A} 1/a \\ll \\sqrt{\\log x / \\log \\log x}$ in the same year. The question of whether these density bounds extend from primitive integer sets to the broader class of real well-separated sets remained open for nearly 90 years.\n\nThe breakthrough came in 2025 when Dimitris Koukoulopoulos, Youness Lamzouri, and Jared Duker Lichtman proved that for any well-separated set $A$, the partial reciprocal sum $\\sum_{x < n, x \\in A} 1/x = o(\\log n)$ \u2014 resolving the weakest of Erd\u0151s's three conjectures. Their proof uses a novel graph-theoretic approach: they construct a GCD graph on elements of $A$ and use structural properties of this graph together with bounds from multiplicative number theory to control the reciprocal sum. The two stronger conjectures \u2014 (i) that the lower density $\\liminf |A \\cap [1,x]|/x = 0$, and (ii) that $\\sum_{x \\in A} 1/(x \\log x)$ converges \u2014 remain open, with the $500 prize still partially unclaimed.\n\nThe problem connects to several areas of modern number theory: the structure of multiplicative functions (Hal\u00e1sz's theorem), sieve methods for controlling divisor sums, and the Hardy-Ramanujan theory of the number of prime factors.",
     "problemStatement": "Let $A \\subset (1, \\infty)$ be a countably infinite set such that for all $x \\neq y \\in A$ and integers $k \\geq 1$ we have $|kx - y| \\geq 1$. Must $A$ be sparse?\n\n**Partially Solved (2025)**: Koukoulopoulos-Lamzouri-Lichtman proved that $\\sum_{x < n, x \\in A} \\frac{1}{x} = o(\\log n)$.\n\n**Still Open**: (i) $\\liminf |A \\cap [1,x]|/x = 0$? (ii) $\\sum_{x \\in A} \\frac{1}{x \\log x} < \\infty$?",
-    "text": "A 120-line formalization of Erdős Problem #143 ($500 prize, partially solved) on the sparseness of sets avoiding integer-dilation proximity. The file defines `WellSeparatedSet A` — the condition that $|kx - y| \\geq 1$ for all distinct $x, y \\in A$ and $k \\geq 1$ — and formalizes three progressively stronger sparseness conjectures: (i) zero lower density, (ii) convergence of $\\sum 1/(x \\log x)$, (iii) partial sums $\\sum_{x < n} 1/x = o(\\log n)$. The 2025 breakthrough of Koukoulopoulos, Lamzouri, and Lichtman resolving conjecture (iii) is axiomatized as `kll_theorem`. The file connects the real-valued problem to the classical theory of primitive integer sets via `IsPrimitiveSet` and axiomatizes Erdős's 1935 result on convergence of $\\sum 1/(n \\log n)$ for primitive sets. Three axioms encode results from multiplicative number theory and GCD graph theory; all definitions and the structural application (`erdos_143_partial`) are fully proved.",
+    "text": "A 120-line formalization of Erd\u0151s Problem #143 ($500 prize, partially solved) on the sparseness of sets avoiding integer-dilation proximity. The file defines `WellSeparatedSet A` \u2014 the condition that $|kx - y| \\geq 1$ for all distinct $x, y \\in A$ and $k \\geq 1$ \u2014 and formalizes three progressively stronger sparseness conjectures: (i) zero lower density, (ii) convergence of $\\sum 1/(x \\log x)$, (iii) partial sums $\\sum_{x < n} 1/x = o(\\log n)$. The 2025 breakthrough of Koukoulopoulos, Lamzouri, and Lichtman resolving conjecture (iii) is axiomatized as `kll_theorem`. The file connects the real-valued problem to the classical theory of primitive integer sets via `IsPrimitiveSet` and axiomatizes Erd\u0151s's 1935 result on convergence of $\\sum 1/(n \\log n)$ for primitive sets. Three axioms encode results from multiplicative number theory and GCD graph theory; all definitions and the structural application (`erdos_143_partial`) are fully proved.",
     "proofStrategy": "We formalize the definitions and axiomatize the main results:\n\n1. **WellSeparatedSet**: Captures the dilation-avoidance condition\n2. **Conjecture variants**: Three different sparseness conditions (i), (ii), (iii)\n3. **KLL Theorem**: The 2025 partial resolution as an axiom\n4. **Primitive sets**: Connection to the integer case\n\nThe KLL theorem is axiomatized because its proof requires GCD graph arguments and multiplicative number theory bounds not yet in Mathlib.",
     "keyInsights": [
-      "**Dilation avoidance**: The condition |kx - y| ≥ 1 prevents clustering around integer multiples",
+      "**Dilation avoidance**: The condition |kx - y| \u2265 1 prevents clustering around integer multiples",
       "**Primitive connection**: For integers, this implies no element divides another",
       "**Density questions**: Three levels of sparseness - lower density zero, series convergence, partial sum bounds",
       "**2025 breakthrough**: KLL proved the weakest form, opening the door to the stronger conjectures",
-      "**Hierarchy of sparseness**: The three conjectures form a strict hierarchy: $\\sum 1/(x\\log x) < \\infty$ implies $\\liminf |A \\cap [1,x]|/x = 0$ implies $\\sum_{x<n} 1/x = o(\\log n)$ — the KLL result resolves the weakest, leaving the two stronger forms as future targets"
+      "**Hierarchy of sparseness**: The three conjectures form a strict hierarchy: $\\sum 1/(x\\log x) < \\infty$ implies $\\liminf |A \\cap [1,x]|/x = 0$ implies $\\sum_{x<n} 1/x = o(\\log n)$ \u2014 the KLL result resolves the weakest, leaving the two stronger forms as future targets"
     ],
     "prerequisites": [
       "Combinatorics and number theory",
@@ -99,7 +99,7 @@
       "startLine": 61,
       "endLine": 85,
       "summary": "The KLL theorem and its application",
-      "mathContext": "KLL theorem (Klurman-Lunnon-Lewko): if $A$ is well-separated, then $A(x) = o(x/\\sqrt{\\log x})$ — a density bound slightly better than trivial."
+      "mathContext": "KLL theorem (Klurman-Lunnon-Lewko): if $A$ is well-separated, then $A(x) = o(x/\\sqrt{\\log x})$ \u2014 a density bound slightly better than trivial."
     },
     {
       "id": "primitive-sets",
@@ -114,17 +114,17 @@
       "title": "Historical Results",
       "startLine": 98,
       "endLine": 120,
-      "summary": "Erdős 1935 theorem on primitive sets",
-      "mathContext": "Erdős (1935): primitive sets satisfy $\\sum_{a \\in A} 1/(a \\log a) < \\infty$. But this doesn't resolve $\\sum 1/a$ convergence for dilation-avoiding sets."
+      "summary": "Erd\u0151s 1935 theorem on primitive sets",
+      "mathContext": "Erd\u0151s (1935): primitive sets satisfy $\\sum_{a \\in A} 1/(a \\log a) < \\infty$. But this doesn't resolve $\\sum 1/a$ convergence for dilation-avoiding sets."
     }
   ],
   "conclusion": {
-    "summary": "We formalize Erdős Problem #143 on the sparseness of dilation-avoiding sets. The main theorem (KLL 2025) proves that partial reciprocal sums are o(log n), resolving one of Erdős's three conjectures. The stronger questions about lower density zero and series convergence remain open.",
-    "implications": "**Theoretical Significance**: The KLL resolution of conjecture (iii) establishes a fundamental dichotomy: sets satisfying the dilation-avoidance condition $|kx - y| \\geq 1$ cannot have reciprocal sums growing as fast as the harmonic series. Since $\\sum_{n \\leq N} 1/n \\sim \\log N$, the $o(\\log N)$ bound means well-separated sets are strictly sparser than the integers themselves.\n\nThe GCD graph technique introduced by KLL is novel: vertices are elements of $A$, with edges encoding dilation-proximity constraints. Graph-theoretic arguments (bounding clique numbers and chromatic numbers) then translate to density bounds. This approach may generalize to other Erdős-type density problems where multiplicative structure constrains additive density.\n\n**Connection to the Erdős conjecture on primitive sets**: Erdős conjectured (and Lichtman-Pomerance recently proved in 2019) that the maximum of $\\sum_{a \\in A} f(a)$ over primitive sets $A \\subset [1, N]$ is achieved by the set of primes — formalizing the intuition that primes are the 'densest' primitive set. Problem #143 asks whether this density constraint extends from integer primitive sets to the larger class of real well-separated sets.\n\n**Connections to sieve theory**: The well-separation condition $|kx - y| \\geq 1$ is reminiscent of sieve exclusion conditions, where elements are removed from a set based on divisibility or proximity constraints. The density bounds on well-separated sets may be approachable via large sieve inequalities or Selberg sieve methods.",
+    "summary": "We formalize Erd\u0151s Problem #143 on the sparseness of dilation-avoiding sets. The main theorem (KLL 2025) proves that partial reciprocal sums are o(log n), resolving one of Erd\u0151s's three conjectures. The stronger questions about lower density zero and series convergence remain open.",
+    "implications": "**Theoretical Significance**: The KLL resolution of conjecture (iii) establishes a fundamental dichotomy: sets satisfying the dilation-avoidance condition $|kx - y| \\geq 1$ cannot have reciprocal sums growing as fast as the harmonic series. Since $\\sum_{n \\leq N} 1/n \\sim \\log N$, the $o(\\log N)$ bound means well-separated sets are strictly sparser than the integers themselves.\n\nThe GCD graph technique introduced by KLL is novel: vertices are elements of $A$, with edges encoding dilation-proximity constraints. Graph-theoretic arguments (bounding clique numbers and chromatic numbers) then translate to density bounds. This approach may generalize to other Erd\u0151s-type density problems where multiplicative structure constrains additive density.\n\n**Connection to the Erd\u0151s conjecture on primitive sets**: Erd\u0151s conjectured (and Lichtman-Pomerance recently proved in 2019) that the maximum of $\\sum_{a \\in A} f(a)$ over primitive sets $A \\subset [1, N]$ is achieved by the set of primes \u2014 formalizing the intuition that primes are the 'densest' primitive set. Problem #143 asks whether this density constraint extends from integer primitive sets to the larger class of real well-separated sets.\n\n**Connections to sieve theory**: The well-separation condition $|kx - y| \\geq 1$ is reminiscent of sieve exclusion conditions, where elements are removed from a set based on divisibility or proximity constraints. The density bounds on well-separated sets may be approachable via large sieve inequalities or Selberg sieve methods.",
     "openQuestions": [
-      "Does liminf |A ∩ [1,x]|/x = 0 for all well-separated A?",
-      "Does ∑ 1/(x log x) converge for all well-separated A?",
-      "Can the o(log n) bound be strengthened to O(log n / √(log log n))?"
+      "Does liminf |A \u2229 [1,x]|/x = 0 for all well-separated A?",
+      "Does \u2211 1/(x log x) converge for all well-separated A?",
+      "Can the o(log n) bound be strengthened to O(log n / \u221a(log log n))?"
     ]
   },
   "crossReferences": [
@@ -136,7 +136,7 @@
     {
       "targetId": "prime-reciprocal-divergence",
       "relationship": "related",
-      "description": "The divergence of $\\sum 1/p$ over primes contrasts with the convergence of $\\sum 1/(p \\log p)$ — Erdős's 1935 result shows primitive sets (which include well-separated integer sets) have convergent $\\sum 1/(n \\log n)$, while the primes themselves form the 'densest' primitive set"
+      "description": "The divergence of $\\sum 1/p$ over primes contrasts with the convergence of $\\sum 1/(p \\log p)$ \u2014 Erd\u0151s's 1935 result shows primitive sets (which include well-separated integer sets) have convergent $\\sum 1/(n \\log n)$, while the primes themselves form the 'densest' primitive set"
     },
     {
       "targetId": "harmonic-divergence",
@@ -146,17 +146,17 @@
     {
       "targetId": "prime-number-theorem",
       "relationship": "related",
-      "description": "PNT gives $\\pi(x) \\sim x/\\log x$, establishing the density of primes. The primes form a primitive set (no prime divides another prime), and Erdős's 1935 theorem implies $\\sum 1/(p \\log p)$ converges — the same type of series convergence conjectured for well-separated sets in conjecture (ii)"
+      "description": "PNT gives $\\pi(x) \\sim x/\\log x$, establishing the density of primes. The primes form a primitive set (no prime divides another prime), and Erd\u0151s's 1935 theorem implies $\\sum 1/(p \\log p)$ converges \u2014 the same type of series convergence conjectured for well-separated sets in conjecture (ii)"
     },
     {
       "targetId": "erdos-4",
       "relationship": "related",
-      "description": "Erdős #4 concerns the additive structure of sets with constraints on sums and differences. Like #143, it asks how algebraic constraints (here dilation-avoidance, there sum-free conditions) force sparseness of the underlying set"
+      "description": "Erd\u0151s #4 concerns the additive structure of sets with constraints on sums and differences. Like #143, it asks how algebraic constraints (here dilation-avoidance, there sum-free conditions) force sparseness of the underlying set"
     },
     {
       "targetId": "erdos-36",
       "relationship": "related",
-      "description": "Both are Erdős problems about density constraints on number-theoretic sets. #36 concerns sets avoiding arithmetic progressions, #143 concerns sets avoiding integer dilation proximity — both instantiate the general theme of structural constraints forcing sparseness"
+      "description": "Both are Erd\u0151s problems about density constraints on number-theoretic sets. #36 concerns sets avoiding arithmetic progressions, #143 concerns sets avoiding integer dilation proximity \u2014 both instantiate the general theme of structural constraints forcing sparseness"
     },
     {
       "targetId": "roth-theorem-k3",
@@ -166,17 +166,17 @@
     {
       "targetId": "szemeredi-theorem",
       "relationship": "related",
-      "description": "Szemerédi's theorem (sets of positive upper density contain arbitrarily long arithmetic progressions) provides the paradigm for density-vs-structure results. Problem #143 asks a similar question: does the structural constraint of dilation-avoidance force zero density? The KLL result gives a partial answer"
+      "description": "Szemer\u00e9di's theorem (sets of positive upper density contain arbitrarily long arithmetic progressions) provides the paradigm for density-vs-structure results. Problem #143 asks a similar question: does the structural constraint of dilation-avoidance force zero density? The KLL result gives a partial answer"
     },
     {
       "targetId": "bertrands-postulate",
       "relationship": "related",
-      "description": "Bertrand's postulate (there is always a prime between $n$ and $2n$) implies that primes have positive lower density in logarithmic scale. For well-separated sets, the open conjecture (i) asks whether the lower density must be zero — a much stronger sparseness condition than what primes satisfy"
+      "description": "Bertrand's postulate (there is always a prime between $n$ and $2n$) implies that primes have positive lower density in logarithmic scale. For well-separated sets, the open conjecture (i) asks whether the lower density must be zero \u2014 a much stronger sparseness condition than what primes satisfy"
     },
     {
       "targetId": "erdos-25",
       "relationship": "related",
-      "description": "Erdős #25 concerns the distribution of prime gaps. Both #25 and #143 study how number-theoretic constraints affect the spacing and density of elements in structured sets"
+      "description": "Erd\u0151s #25 concerns the distribution of prime gaps. Both #25 and #143 study how number-theoretic constraints affect the spacing and density of elements in structured sets"
     }
   ],
   "references": [
@@ -188,25 +188,25 @@
       "note": "Proved conjecture (iii): for well-separated A, the partial reciprocal sum is o(log n). Uses GCD graph methods and multiplicative number theory"
     },
     {
-      "authors": "Erdős, Paul",
+      "authors": "Erd\u0151s, Paul",
       "title": "Note on sequences of integers no one of which is divisible by any other",
       "year": "1935",
-      "venue": "Journal of the London Mathematical Society, vol. 10, pp. 126–128",
-      "note": "Proved that primitive integer sets satisfy ∑ 1/(n log n) < ∞ — the result axiomatized as erdos_1935_primitive"
+      "venue": "Journal of the London Mathematical Society, vol. 10, pp. 126\u2013128",
+      "note": "Proved that primitive integer sets satisfy \u2211 1/(n log n) < \u221e \u2014 the result axiomatized as erdos_1935_primitive"
     },
     {
       "authors": "Behrend, Felix",
       "title": "On sequences of numbers not divisible one by another",
       "year": "1935",
-      "venue": "Journal of the London Mathematical Society, vol. 10, pp. 42–44",
-      "note": "Proved the density estimate ∑_{n≤x} 1/n ≪ √(log x / log log x) for primitive sets"
+      "venue": "Journal of the London Mathematical Society, vol. 10, pp. 42\u201344",
+      "note": "Proved the density estimate \u2211_{n\u2264x} 1/n \u226a \u221a(log x / log log x) for primitive sets"
     },
     {
       "authors": "Lichtman, Jared Duker; Pomerance, Carl",
-      "title": "The Erdős conjecture for primitive sets",
+      "title": "The Erd\u0151s conjecture for primitive sets",
       "year": "2019",
-      "venue": "Proceedings of the American Mathematical Society, vol. 147, pp. 4825–4836",
-      "note": "Proved that the primes maximize ∑ f(a) over primitive sets — formalizing the intuition that primes are the densest primitive set"
+      "venue": "Proceedings of the American Mathematical Society, vol. 147, pp. 4825\u20134836",
+      "note": "Proved that the primes maximize \u2211 f(a) over primitive sets \u2014 formalizing the intuition that primes are the densest primitive set"
     }
   ],
   "leanFile": {
@@ -219,7 +219,7 @@
       "Topology"
     ],
     "namespace": "Erdos143",
-    "lineCount": 119,
+    "lineCount": 120,
     "axiomCount": 3,
     "theoremCount": 1,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-157/meta.json
+++ b/src/data/proofs/erdos-157/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-157",
-  "title": "Erdős Problem #157: Infinite Sidon Set as Asymptotic Basis",
+  "title": "Erd\u0151s Problem #157: Infinite Sidon Set as Asymptotic Basis",
   "slug": "erdos-157",
   "description": "Does there exist an infinite Sidon set which is an asymptotic basis of order 3? YES (Pilatte 2023). Two theorems verified: sidon_iff_sidon_alt and powers_of_two_sidon.",
   "meta": {
-    "author": "Pilatte (2023), Erdős-Turán (1941)",
+    "author": "Pilatte (2023), Erd\u0151s-Tur\u00e1n (1941)",
     "sourceUrl": "https://erdosproblems.com/157",
     "date": "2023",
     "status": "axiomatized",
@@ -47,29 +47,29 @@
       }
     ],
     "originalContributions": [
-      "Definition of IsSidon (B₂ sequence property)",
+      "Definition of IsSidon (B\u2082 sequence property)",
       "Alternative characterization IsSidonAlt via sumset cardinality",
       "Verified theorem: sidon_iff_sidon_alt (equivalence of definitions)",
       "Definition of SumsetK for k-fold sums",
       "Definition of IsAsymptoticBasis for asymptotic bases",
       "Erdos157Conjecture formalization",
       "Pilatte's existence theorem statement",
-      "Sidon density upper bound (Erdős-Turán)",
+      "Sidon density upper bound (Erd\u0151s-Tur\u00e1n)",
       "Basis density lower bound",
       "Verified theorem: powers_of_two_sidon"
     ],
     "axiomCount": 3,
     "lineCount": 535,
-    "assumptions": "3 axioms: (1) pilatte_existence — the Pilatte 2023 existence result (infinite Sidon set that is an asymptotic basis of order 3); (2) sidon_counting_bound — counting bound for Sidon sets; (3) basis_counting_lower — lower bound for basis counting. 0 sorries (previously 1 sorry for pilatte_existence was axiomatized; sidon_counting_contradiction proved by Aristotle)."
+    "assumptions": "3 axioms: (1) pilatte_existence \u2014 the Pilatte 2023 existence result (infinite Sidon set that is an asymptotic basis of order 3); (2) sidon_counting_bound \u2014 counting bound for Sidon sets; (3) basis_counting_lower \u2014 lower bound for basis counting. 0 sorries (previously 1 sorry for pilatte_existence was axiomatized; sidon_counting_contradiction proved by Aristotle)."
   },
   "overview": {
-    "historicalContext": "Sidon sets (B$_2$ sequences) — sets where all pairwise sums are distinct — were introduced by Simon Sidon in correspondence with Erdős in the 1930s. Erdős and Pál Turán proved in 1941 that a Sidon subset of $\\{1, \\ldots, N\\}$ has at most $(1+o(1))\\sqrt{N}$ elements, establishing their fundamental sparsity.\n\nAsymptotic bases of order $k$ — sets $A$ where every sufficiently large integer is a sum of at most $k$ elements of $A$ — require density at least $N^{1/k}$ by a counting argument. The tension between Sidon sparsity ($\\leq N^{1/2}$) and basis density ($\\geq N^{1/k}$) creates a natural threshold: coexistence requires $1/k \\leq 1/2$, i.e., $k \\geq 2$. But $k = 2$ is exactly the boundary and fails for subtle arithmetic reasons.\n\nErdős conjectured that order 3 should work, and this was open for decades despite partial results by Deshouillers and Plagne (2003) on finite Sidon sets. Cédric Pilatte (Oxford) settled the conjecture affirmatively in 2023 using a probabilistic construction, applying the Lovász Local Lemma and a careful densification argument. His proof is non-explicit: it shows such sets exist without constructing one.\n\nThis formalization includes two fully verified theorems: the equivalence of two Sidon set definitions, and the proof that $\\{2^k : k \\in \\mathbb{N}\\}$ forms a Sidon set (since binary representations are unique).",
-    "problemStatement": "**Erdős Problem #157 (SOLVED)**: Does there exist an infinite Sidon set which is an asymptotic basis of order 3?\n\n**Answer**: YES (Pilatte 2023)\n\n**Definitions**:\n- **Sidon set**: A ⊆ ℕ where a + b = c + d (a ≤ b, c ≤ d) implies (a,b) = (c,d)\n- **Asymptotic basis of order k**: ∃ N₀, ∀ n ≥ N₀, n is a sum of ≤ k elements of A\n\n**Key insight**: Sidon sets grow like √N = N^{1/2}. Order-k bases need N^{1/k} density. Since 1/3 < 1/2, order 3 is feasible while order 2 is not.",
+    "historicalContext": "Sidon sets (B$_2$ sequences) \u2014 sets where all pairwise sums are distinct \u2014 were introduced by Simon Sidon in correspondence with Erd\u0151s in the 1930s. Erd\u0151s and P\u00e1l Tur\u00e1n proved in 1941 that a Sidon subset of $\\{1, \\ldots, N\\}$ has at most $(1+o(1))\\sqrt{N}$ elements, establishing their fundamental sparsity.\n\nAsymptotic bases of order $k$ \u2014 sets $A$ where every sufficiently large integer is a sum of at most $k$ elements of $A$ \u2014 require density at least $N^{1/k}$ by a counting argument. The tension between Sidon sparsity ($\\leq N^{1/2}$) and basis density ($\\geq N^{1/k}$) creates a natural threshold: coexistence requires $1/k \\leq 1/2$, i.e., $k \\geq 2$. But $k = 2$ is exactly the boundary and fails for subtle arithmetic reasons.\n\nErd\u0151s conjectured that order 3 should work, and this was open for decades despite partial results by Deshouillers and Plagne (2003) on finite Sidon sets. C\u00e9dric Pilatte (Oxford) settled the conjecture affirmatively in 2023 using a probabilistic construction, applying the Lov\u00e1sz Local Lemma and a careful densification argument. His proof is non-explicit: it shows such sets exist without constructing one.\n\nThis formalization includes two fully verified theorems: the equivalence of two Sidon set definitions, and the proof that $\\{2^k : k \\in \\mathbb{N}\\}$ forms a Sidon set (since binary representations are unique).",
+    "problemStatement": "**Erd\u0151s Problem #157 (SOLVED)**: Does there exist an infinite Sidon set which is an asymptotic basis of order 3?\n\n**Answer**: YES (Pilatte 2023)\n\n**Definitions**:\n- **Sidon set**: A \u2286 \u2115 where a + b = c + d (a \u2264 b, c \u2264 d) implies (a,b) = (c,d)\n- **Asymptotic basis of order k**: \u2203 N\u2080, \u2200 n \u2265 N\u2080, n is a sum of \u2264 k elements of A\n\n**Key insight**: Sidon sets grow like \u221aN = N^{1/2}. Order-k bases need N^{1/k} density. Since 1/3 < 1/2, order 3 is feasible while order 2 is not.",
     "text": "Does there exist an infinite Sidon set which is an asymptotic basis of order 3? YES (Pilatte 2023). Two theorems verified: sidon_iff_sidon_alt and powers_of_two_sidon.",
-    "proofStrategy": "The formalization captures the problem structure:\n\n1. **Sidon definitions**: IsSidon (direct) and IsSidonAlt (via cardinality)\n2. **Verified equivalence**: sidon_iff_sidon_alt proved using Set.ncard\n3. **Basis definitions**: SumsetK and IsAsymptoticBasis\n4. **Counting bounds**: Sidon upper bound (√N), basis lower bound (N^{1/k})\n5. **Pilatte's theorem**: Existence statement (sorry - probabilistic construction)\n6. **Verified example**: powers_of_two_sidon shows {2^k} is Sidon",
+    "proofStrategy": "The formalization captures the problem structure:\n\n1. **Sidon definitions**: IsSidon (direct) and IsSidonAlt (via cardinality)\n2. **Verified equivalence**: sidon_iff_sidon_alt proved using Set.ncard\n3. **Basis definitions**: SumsetK and IsAsymptoticBasis\n4. **Counting bounds**: Sidon upper bound (\u221aN), basis lower bound (N^{1/k})\n5. **Pilatte's theorem**: Existence statement (sorry - probabilistic construction)\n6. **Verified example**: powers_of_two_sidon shows {2^k} is Sidon",
     "keyInsights": [
       "**Order 3 is the boundary**: Order 2 impossible (density too low), order 3 achievable (Pilatte's construction).",
-      "**Density arithmetic**: Sidon ≤ √N = N^{1/2}, basis needs ≥ N^{1/k}. Compatible iff k ≥ 3.",
+      "**Density arithmetic**: Sidon \u2264 \u221aN = N^{1/2}, basis needs \u2265 N^{1/k}. Compatible iff k \u2265 3.",
       "**Powers of 2 example**: The canonical Sidon set {1, 2, 4, 8, ...} demonstrates the definition (verified).",
       "**Probabilistic proof**: Pilatte's construction is non-explicit, using the probabilistic method.",
       "**Bug discovery**: The original example set was NOT Sidon - formal verification caught this error."
@@ -119,8 +119,8 @@
     }
   ],
   "conclusion": {
-    "summary": "We formalize Erdős Problem #157 on infinite Sidon sets as asymptotic bases. The answer is YES for order 3 (Pilatte 2023), while order 2 is impossible due to density constraints. The formalization includes two verified theorems: the equivalence of Sidon definitions, and the proof that powers of 2 form a Sidon set.",
-    "implications": "This result clarifies the boundary between sparse sets with unique-sum structure and dense sets capable of representing all integers. The interplay between Sidon sparsity (√N) and basis density (N^{1/k}) is fundamental to understanding additive structure.",
+    "summary": "We formalize Erd\u0151s Problem #157 on infinite Sidon sets as asymptotic bases. The answer is YES for order 3 (Pilatte 2023), while order 2 is impossible due to density constraints. The formalization includes two verified theorems: the equivalence of Sidon definitions, and the proof that powers of 2 form a Sidon set.",
+    "implications": "This result clarifies the boundary between sparse sets with unique-sum structure and dense sets capable of representing all integers. The interplay between Sidon sparsity (\u221aN) and basis density (N^{1/k}) is fundamental to understanding additive structure.",
     "openQuestions": [
       "Can an explicit infinite Sidon set that is an order-3 basis be constructed?",
       "What is the smallest order k such that every infinite Sidon set is NOT an order-k basis?",
@@ -130,22 +130,22 @@
   "crossReferences": [
     {
       "relationship": "related",
-      "description": "Erdős #156 (Minimum Size of Maximal Sidon Sets) — both problems study Sidon sets; #156 asks about maximality while #157 asks about basis properties",
+      "description": "Erd\u0151s #156 (Minimum Size of Maximal Sidon Sets) \u2014 both problems study Sidon sets; #156 asks about maximality while #157 asks about basis properties",
       "targetId": "erdos-156"
     },
     {
       "relationship": "related",
-      "description": "Erdős #158 (B₂[g] Sets) — generalizes Sidon sets (B₂ = B₂[1]) to allow g representations per sum; the density constraints change as g grows",
+      "description": "Erd\u0151s #158 (B\u2082[g] Sets) \u2014 generalizes Sidon sets (B\u2082 = B\u2082[1]) to allow g representations per sum; the density constraints change as g grows",
       "targetId": "erdos-158"
     },
     {
       "relationship": "related",
-      "description": "Erdős #1 (Distinct Subset Sums) — another problem about additive structure of sets, exploring how sums interact with set density",
+      "description": "Erd\u0151s #1 (Distinct Subset Sums) \u2014 another problem about additive structure of sets, exploring how sums interact with set density",
       "targetId": "erdos-1"
     },
     {
       "relationship": "foundational",
-      "description": "Pilatte's proof uses the probabilistic method (specifically the Lovász Local Lemma) — the alteration method is a key technique in this family of arguments",
+      "description": "Pilatte's proof uses the probabilistic method (specifically the Lov\u00e1sz Local Lemma) \u2014 the alteration method is a key technique in this family of arguments",
       "targetId": "prob-method-alteration"
     }
   ],
@@ -159,7 +159,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos157",
-    "lineCount": 535,
+    "lineCount": 536,
     "axiomCount": 3,
     "theoremCount": 7,
     "definitionCount": 7,
@@ -170,8 +170,8 @@
     {
       "key": "ET41b",
       "authors": [
-        "P. Erdős",
-        "P. Turán"
+        "P. Erd\u0151s",
+        "P. Tur\u00e1n"
       ],
       "title": "On a problem of Sidon in additive number theory, and on some related problems",
       "venue": "Journal of the London Mathematical Society",

--- a/src/data/proofs/erdos-167/meta.json
+++ b/src/data/proofs/erdos-167/meta.json
@@ -1,6 +1,6 @@
 {
   "id": "erdos-167",
-  "title": "Erdős Problem #167: Tuza's Conjecture",
+  "title": "Erd\u0151s Problem #167: Tuza's Conjecture",
   "slug": "erdos-167",
   "description": "If G is a graph with at most k edge-disjoint triangles, can G be made triangle-free by removing at most 2k edges? Tuza's Conjecture (1981) remains open in general.",
   "meta": {
@@ -33,17 +33,17 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "Zsolt Tuza conjectured in 1981 that $\\tau(G) \\leq 2\\nu(G)$ for every graph $G$, where $\\tau(G)$ is the minimum number of edges whose removal destroys all triangles and $\\nu(G)$ is the maximum number of edge-disjoint triangles. The trivial bound $\\tau \\leq 3\\nu$ follows from removing all three edges of each triangle in a maximum packing. Penny Haxell and Yoshiharu Kohayakawa (1998) proved $\\tau \\leq (3 - 3/23)\\nu \\approx 2.87\\nu$ using probabilistic and structural methods. Haxell (1999) verified the conjecture for $K_4$-free graphs. The conjecture also holds for planar graphs (Tuza 1994, Krivelevich 1995) and Erdős-Rényi random graphs $G(n,p)$ for most $p$. The fractional relaxation $\\tau^*(G) \\leq 2\\nu^*(G)$ was proved by Krivelevich via LP duality. Despite four decades of work, the integral conjecture remains open, and the gap between the best general bound 2.87 and the conjectured 2 has resisted improvement.",
+    "historicalContext": "Zsolt Tuza conjectured in 1981 that $\\tau(G) \\leq 2\\nu(G)$ for every graph $G$, where $\\tau(G)$ is the minimum number of edges whose removal destroys all triangles and $\\nu(G)$ is the maximum number of edge-disjoint triangles. The trivial bound $\\tau \\leq 3\\nu$ follows from removing all three edges of each triangle in a maximum packing. Penny Haxell and Yoshiharu Kohayakawa (1998) proved $\\tau \\leq (3 - 3/23)\\nu \\approx 2.87\\nu$ using probabilistic and structural methods. Haxell (1999) verified the conjecture for $K_4$-free graphs. The conjecture also holds for planar graphs (Tuza 1994, Krivelevich 1995) and Erd\u0151s-R\u00e9nyi random graphs $G(n,p)$ for most $p$. The fractional relaxation $\\tau^*(G) \\leq 2\\nu^*(G)$ was proved by Krivelevich via LP duality. Despite four decades of work, the integral conjecture remains open, and the gap between the best general bound 2.87 and the conjectured 2 has resisted improvement.",
     "problemStatement": "Let $\\nu(G)$ be the maximum number of edge-disjoint triangles in $G$, and $\\tau(G)$ the minimum number of edges whose removal makes $G$ triangle-free. **Tuza's Conjecture**: $\\tau(G) \\leq 2\\nu(G)$ for all graphs $G$. Complete graphs $K_4$ and $K_5$ show the factor 2 is best possible.",
     "text": "If G is a graph with at most k edge-disjoint triangles, can G be made triangle-free by removing at most 2k edges? Tuza's Conjecture (1981) remains open in general.",
     "proofStrategy": "The formalization builds from first principles: triangles as 3-element vertex subsets, edge-disjoint packings as sets of non-overlapping triangles, and triangle covers as edge sets whose removal eliminates all triangles. Aristotle verified three key theorems: (1) `trivial_bound`: $\\tau \\leq 3\\nu$ via constructing a cover by taking all edges from a maximum packing, using `Finset.biUnion` and `offDiag` to enumerate edges; (2) `k4_tight`: $\\nu(K_4)=1, \\tau(K_4)=2$ by exhaustive search over `Fin 4`; (3) `k5_tight`: $\\nu(K_5)=2, \\tau(K_5)=4$ using `native_decide` for finite verification. The remaining axioms capture deep results (Haxell-Kohayakawa bound, special graph classes, fractional version) whose proofs rely on probabilistic and LP duality methods beyond the current formalization scope.",
     "keyInsights": [
-      "Trivial bound: remove one edge per triangle in maximum packing → τ ≤ 3ν",
-      "K₄ achieves equality in Tuza: ν(K₄) = 1, τ(K₄) = 2",
-      "K₅ also achieves equality: ν(K₅) = 2, τ(K₅) = 4",
-      "Best general bound: τ ≤ (3 - 3/23)ν ≈ 2.87ν (Haxell-Kohayakawa)",
-      "Fractional version is true: τ* ≤ 2ν*",
-      "Proven for special classes: K₄-free, planar, random graphs"
+      "Trivial bound: remove one edge per triangle in maximum packing \u2192 \u03c4 \u2264 3\u03bd",
+      "K\u2084 achieves equality in Tuza: \u03bd(K\u2084) = 1, \u03c4(K\u2084) = 2",
+      "K\u2085 also achieves equality: \u03bd(K\u2085) = 2, \u03c4(K\u2085) = 4",
+      "Best general bound: \u03c4 \u2264 (3 - 3/23)\u03bd \u2248 2.87\u03bd (Haxell-Kohayakawa)",
+      "Fractional version is true: \u03c4* \u2264 2\u03bd*",
+      "Proven for special classes: K\u2084-free, planar, random graphs"
     ],
     "prerequisites": [
       "graph theory fundamentals",
@@ -58,7 +58,7 @@
       "title": "Problem Statement and Context",
       "startLine": 20,
       "endLine": 53,
-      "summary": "Documentation of Erdős Problem #167: Tuza's 1981 conjecture that τ(G) ≤ 2ν(G), where τ is the minimum triangle edge cover and ν is the maximum triangle packing. Includes status, references, and formalization roadmap."
+      "summary": "Documentation of Erd\u0151s Problem #167: Tuza's 1981 conjecture that \u03c4(G) \u2264 2\u03bd(G), where \u03c4 is the minimum triangle edge cover and \u03bd is the maximum triangle packing. Includes status, references, and formalization roadmap."
     },
     {
       "id": "core-definitions",
@@ -72,40 +72,40 @@
       "title": "Tuza's Conjecture Statement",
       "startLine": 86,
       "endLine": 94,
-      "summary": "Formal statement of Tuza's conjecture: for every graph G, the minimum triangle cover size τ(G) is at most 2ν(G) where ν(G) is the maximum triangle packing size. Axiomatized as the conjecture is open."
+      "summary": "Formal statement of Tuza's conjecture: for every graph G, the minimum triangle cover size \u03c4(G) is at most 2\u03bd(G) where \u03bd(G) is the maximum triangle packing size. Axiomatized as the conjecture is open."
     },
     {
       "id": "trivial-bound",
-      "title": "Trivial Bound: τ ≤ 3ν",
+      "title": "Trivial Bound: \u03c4 \u2264 3\u03bd",
       "startLine": 95,
       "endLine": 175,
-      "summary": "Proves the trivial bound τ(G) ≤ 3ν(G): given a maximum packing of ν edge-disjoint triangles, removing all 3 edges of each triangle yields a cover of size 3ν. Aristotle-verified."
+      "summary": "Proves the trivial bound \u03c4(G) \u2264 3\u03bd(G): given a maximum packing of \u03bd edge-disjoint triangles, removing all 3 edges of each triangle yields a cover of size 3\u03bd. Aristotle-verified."
     },
     {
       "id": "known-results",
-      "title": "Known Results: K₄ and K₅ Tightness, Haxell-Kohayakawa",
+      "title": "Known Results: K\u2084 and K\u2085 Tightness, Haxell-Kohayakawa",
       "startLine": 176,
       "endLine": 253,
-      "summary": "Tightness examples: K₄ has ν=1, τ=2 (ratio 2, matching conjecture) and K₅ has ν=2, τ=4 (also ratio 2). Both verified by native_decide. Axiomatizes the Haxell-Kohayakawa bound τ ≤ (3-3/23)ν ≈ 2.87ν and special cases (K₄-free, planar)."
+      "summary": "Tightness examples: K\u2084 has \u03bd=1, \u03c4=2 (ratio 2, matching conjecture) and K\u2085 has \u03bd=2, \u03c4=4 (also ratio 2). Both verified by native_decide. Axiomatizes the Haxell-Kohayakawa bound \u03c4 \u2264 (3-3/23)\u03bd \u2248 2.87\u03bd and special cases (K\u2084-free, planar)."
     },
     {
       "id": "fractional-version",
       "title": "Fractional Version",
       "startLine": 254,
       "endLine": 265,
-      "summary": "Axiomatizes the fractional relaxation τ*(G) ≤ 2ν*(G), which is known to be true via LP duality. The integral conjecture would follow from suitable rounding."
+      "summary": "Axiomatizes the fractional relaxation \u03c4*(G) \u2264 2\u03bd*(G), which is known to be true via LP duality. The integral conjecture would follow from suitable rounding."
     },
     {
       "id": "summary",
       "title": "Summary",
       "startLine": 266,
       "endLine": 275,
-      "summary": "Summary of formalization status: 3 Aristotle-verified theorems (trivial bound, K₄ tightness, K₅ tightness), 5 axioms (Tuza conjecture, Haxell-Kohayakawa bound, special cases, fractional version). The main conjecture remains open."
+      "summary": "Summary of formalization status: 3 Aristotle-verified theorems (trivial bound, K\u2084 tightness, K\u2085 tightness), 5 axioms (Tuza conjecture, Haxell-Kohayakawa bound, special cases, fractional version). The main conjecture remains open."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #167 (Tuza's Conjecture) is PARTIALLY SOLVED. This formalization includes three Aristotle-verified theorems: the trivial 3ν bound and tightness examples K₄ and K₅. The conjecture τ ≤ 2ν remains open for general graphs.",
-    "implications": "**Theoretical Significance**: Tuza's conjecture sits at the intersection of extremal graph theory, combinatorial optimization, and polyhedral combinatorics.\n\nThe fractional version $\\tau^* = 2\\nu^*$ (proved via LP duality) shows the conjecture holds 'on average' — the obstruction is purely an integrality gap question. If the conjecture holds, it would give a tight characterization of the packing-covering tradeoff for triangles, analogous to König's theorem for bipartite matchings.",
+    "summary": "Erd\u0151s Problem #167 (Tuza's Conjecture) is PARTIALLY SOLVED. This formalization includes three Aristotle-verified theorems: the trivial 3\u03bd bound and tightness examples K\u2084 and K\u2085. The conjecture \u03c4 \u2264 2\u03bd remains open for general graphs.",
+    "implications": "**Theoretical Significance**: Tuza's conjecture sits at the intersection of extremal graph theory, combinatorial optimization, and polyhedral combinatorics.\n\nThe fractional version $\\tau^* = 2\\nu^*$ (proved via LP duality) shows the conjecture holds 'on average' \u2014 the obstruction is purely an integrality gap question. If the conjecture holds, it would give a tight characterization of the packing-covering tradeoff for triangles, analogous to K\u00f6nig's theorem for bipartite matchings.",
     "openQuestions": [
       "Does $\\tau(G) \\leq 2\\nu(G)$ hold for all graphs? (The main conjecture, open since 1981)",
       "Can the Haxell-Kohayakawa bound $\\tau \\leq 2.87\\nu$ be improved below $2.5\\nu$?",
@@ -123,7 +123,7 @@
     {
       "targetId": "erdos-136",
       "relationship": "related",
-      "description": "Both are graph coloring/structure problems from Erdős. #136 concerns the Erdős-Gyárfás function f(n,4,5) relating graph size to clique/independence structure, #167 concerns triangle substructure"
+      "description": "Both are graph coloring/structure problems from Erd\u0151s. #136 concerns the Erd\u0151s-Gy\u00e1rf\u00e1s function f(n,4,5) relating graph size to clique/independence structure, #167 concerns triangle substructure"
     }
   ],
   "leanFile": {
@@ -136,7 +136,7 @@
       "Set"
     ],
     "namespace": "Erdos167",
-    "lineCount": 274,
+    "lineCount": 275,
     "axiomCount": 1,
     "theoremCount": 4,
     "definitionCount": 7,
@@ -147,14 +147,14 @@
     {
       "key": "Tu41b",
       "authors": [
-        "P. Turán"
+        "P. Tur\u00e1n"
       ],
       "title": "Eine Extremalaufgabe aus der Graphentheorie",
-      "venue": "Matematikai és Fizikai Lapok",
+      "venue": "Matematikai \u00e9s Fizikai Lapok",
       "year": "1941",
       "volume": "48",
       "pages": "436-452",
-      "note": "Turán's theorem: foundation for triangle covering and extremal graph problems"
+      "note": "Tur\u00e1n's theorem: foundation for triangle covering and extremal graph problems"
     }
   ],
   "sorries": 0

--- a/src/data/proofs/erdos-168/meta.json
+++ b/src/data/proofs/erdos-168/meta.json
@@ -1,6 +1,6 @@
 {
   "id": "erdos-168",
-  "title": "Erdős Problem #168: {n, 2n, 3n}-Free Sets",
+  "title": "Erd\u0151s Problem #168: {n, 2n, 3n}-Free Sets",
   "slug": "erdos-168",
   "description": "Let F(N) be the maximum size of a subset of {1,...,N} avoiding {n, 2n, 3n} triples. What is lim F(N)/N? Is it irrational?",
   "meta": {
@@ -48,10 +48,10 @@
     "originalContributions": [
       "Definition of {n, 2n, 3n}-free sets (ContainsTriple, IsTripleFree)",
       "Definition of F(N) as maximum cardinality",
-      "Proved: density_bounded (0 ≤ F(N)/N ≤ 1)",
-      "Proved: F_monotone (F(N) ≤ F(N+1))",
-      "Proved: simple_lower_bound (F(N) ≥ 2N/3 - 1)",
-      "Axiomatized GSW limit theorem and numerical approximation ≈ 0.5564",
+      "Proved: density_bounded (0 \u2264 F(N)/N \u2264 1)",
+      "Proved: F_monotone (F(N) \u2264 F(N+1))",
+      "Proved: simple_lower_bound (F(N) \u2265 2N/3 - 1)",
+      "Axiomatized GSW limit theorem and numerical approximation \u2248 0.5564",
       "Formalized the irrationality question"
     ],
     "axiomCount": 2,
@@ -59,14 +59,14 @@
     "assumptions": "2 axioms: gsw_limit_exists, better_construction. 0 sorries."
   },
   "overview": {
-    "historicalContext": "This problem concerns the maximum size of subsets avoiding 'ternary' arithmetic progressions of the form {n, 2n, 3n}. Graham, Spencer, and Witsenhausen (1977) proved the limit lim F(N)/N exists and gave a formula involving 3-smooth numbers.\n\nThe 3-smooth numbers are numbers of the form 2^a · 3^b: 1, 2, 3, 4, 6, 8, 9, 12, 16, 18, 24, ...\n\nThe limit formula is L = (1/3) · Σ_{k ∈ K} 1/d_k where d_1 < d_2 < ... are the 3-smooth numbers and K is determined by a greedy algorithm.\n\nEberhard computed the numerical value as approximately 0.5564. Erdős asked whether this limit is irrational—this remains open.",
+    "historicalContext": "This problem concerns the maximum size of subsets avoiding 'ternary' arithmetic progressions of the form {n, 2n, 3n}. Graham, Spencer, and Witsenhausen (1977) proved the limit lim F(N)/N exists and gave a formula involving 3-smooth numbers.\n\nThe 3-smooth numbers are numbers of the form 2^a \u00b7 3^b: 1, 2, 3, 4, 6, 8, 9, 12, 16, 18, 24, ...\n\nThe limit formula is L = (1/3) \u00b7 \u03a3_{k \u2208 K} 1/d_k where d_1 < d_2 < ... are the 3-smooth numbers and K is determined by a greedy algorithm.\n\nEberhard computed the numerical value as approximately 0.5564. Erd\u0151s asked whether this limit is irrational\u2014this remains open.",
     "problemStatement": "**Question**: Let $F(N)$ be the maximum size of a subset of $\\{1, \\ldots, N\\}$ containing no triple $\\{n, 2n, 3n\\}$. \n\n(i) What is $\\lim_{N \\to \\infty} F(N)/N$?\n\n(ii) Is this limit irrational?\n\n**Answers**:\n- (i) The limit exists (GSW 1977) and equals approximately **0.5564**\n- (ii) **OPEN** - irrationality is not known\n\n**Lower bound**: $F(N) \\geq 2N/3 - 1$ (remove all multiples of 3)",
     "text": "Let F(N) be the maximum size of a subset of {1,...,N} avoiding {n, 2n, 3n} triples. What is lim F(N)/N? Is it irrational?",
-    "proofStrategy": "We formalize the problem and known results:\n\n1. **ContainsTriple**: A set contains some {n, 2n, 3n}\n2. **IsTripleFree**: A set avoids all such triples\n3. **F(N)**: Maximum cardinality of triple-free subsets of {1,...,N}\n4. **density_bounded**: Prove 0 ≤ F(N)/N ≤ 1\n5. **F_monotone**: Prove F(N) ≤ F(N+1)\n6. **simple_lower_bound**: Prove F(N) ≥ 2N/3 - 1\n7. **gsw_limit_exists**: Axiomatize that the limit exists\n8. **IrrationalityQuestion**: Formalize the open irrationality question",
+    "proofStrategy": "We formalize the problem and known results:\n\n1. **ContainsTriple**: A set contains some {n, 2n, 3n}\n2. **IsTripleFree**: A set avoids all such triples\n3. **F(N)**: Maximum cardinality of triple-free subsets of {1,...,N}\n4. **density_bounded**: Prove 0 \u2264 F(N)/N \u2264 1\n5. **F_monotone**: Prove F(N) \u2264 F(N+1)\n6. **simple_lower_bound**: Prove F(N) \u2265 2N/3 - 1\n7. **gsw_limit_exists**: Axiomatize that the limit exists\n8. **IrrationalityQuestion**: Formalize the open irrationality question",
     "keyInsights": [
       "**{n, 2n, 3n} triples**: These are 'multiplicative' arithmetic progressions with ratio 2, not additive.",
-      "**Simple construction**: Removing multiples of 3 gives a triple-free set of size ≈ 2N/3.",
-      "**3-smooth connection**: The limit formula involves the 3-smooth numbers 2^a · 3^b.",
+      "**Simple construction**: Removing multiples of 3 gives a triple-free set of size \u2248 2N/3.",
+      "**3-smooth connection**: The limit formula involves the 3-smooth numbers 2^a \u00b7 3^b.",
       "**Numerical value**: The limit is approximately 0.5564, better than the 2/3 lower bound.",
       "**Open problem**: Whether the limit is irrational remains unknown."
     ],
@@ -103,14 +103,14 @@
       "title": "Lower Bound Constructions",
       "startLine": 111,
       "endLine": 140,
-      "summary": "Prove F(N) ≥ 2N/3 - 1 and axiomatize 0.55 bound."
+      "summary": "Prove F(N) \u2265 2N/3 - 1 and axiomatize 0.55 bound."
     },
     {
       "id": "irrationality",
       "title": "Irrationality Question",
       "startLine": 141,
       "endLine": 149,
-      "summary": "Formalize Erdős's open question on irrationality."
+      "summary": "Formalize Erd\u0151s's open question on irrationality."
     },
     {
       "id": "examples",
@@ -121,13 +121,13 @@
     }
   ],
   "conclusion": {
-    "summary": "We formalize Erdős Problem #168 on {n, 2n, 3n}-free sets. The Lean proof establishes the basic properties (bounded density, monotonicity), proves lower bounds, axiomatizes the GSW limit theorem, and formalizes the open irrationality question.",
-    "implications": "This problem connects extremal set theory with the structure of 3-smooth numbers. The formula L = (1/3) · Σ 1/d_k shows how multiplicative structure (powers of 2 and 3) governs the density of triple-free sets.",
+    "summary": "We formalize Erd\u0151s Problem #168 on {n, 2n, 3n}-free sets. The Lean proof establishes the basic properties (bounded density, monotonicity), proves lower bounds, axiomatizes the GSW limit theorem, and formalizes the open irrationality question.",
+    "implications": "This problem connects extremal set theory with the structure of 3-smooth numbers. The formula L = (1/3) \u00b7 \u03a3 1/d_k shows how multiplicative structure (powers of 2 and 3) governs the density of triple-free sets.",
     "openQuestions": [
       "Is the limit lim F(N)/N irrational?",
       "What is the exact computational complexity of determining F(N)?",
       "Are there similar results for {n, 2n, 4n} or other multiplicative patterns?",
-      "What is the optimal constant in F(N) ≥ cN for finite N?"
+      "What is the optimal constant in F(N) \u2265 cN for finite N?"
     ]
   },
   "leanFile": {
@@ -141,7 +141,7 @@
       "Finset"
     ],
     "namespace": "Erdos168",
-    "lineCount": 180,
+    "lineCount": 181,
     "axiomCount": 2,
     "theoremCount": 4,
     "definitionCount": 7,
@@ -152,24 +152,24 @@
     {
       "targetId": "erdos-1054",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: density, number-theory"
+      "description": "Related Erd\u0151s problem sharing themes: density, number-theory"
     },
     {
       "targetId": "erdos-1062",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: extremal-combinatorics, number-theory"
+      "description": "Related Erd\u0151s problem sharing themes: extremal-combinatorics, number-theory"
     },
     {
       "targetId": "erdos-1064",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: density, number-theory"
+      "description": "Related Erd\u0151s problem sharing themes: density, number-theory"
     }
   ],
   "references": [
     {
       "key": "RS04",
       "authors": [
-        "V. Rödl",
+        "V. R\u00f6dl",
         "J. Skokan"
       ],
       "title": "Regularity lemma for k-uniform hypergraphs",

--- a/src/data/proofs/erdos-171/meta.json
+++ b/src/data/proofs/erdos-171/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "erdos-171",
-  "title": "Erdős Problem #171: Unit Distance Chromatic Number",
+  "title": "Erd\u0151s Problem #171: Unit Distance Chromatic Number",
   "slug": "erdos-171",
-  "description": "What is the chromatic number χ(ℝ²) of the unit distance graph? The Hadwiger-Nelson problem. Nelson (1950): χ ≥ 4. Isbell (1950): χ ≤ 7. de Grey (2018): χ ≥ 5. Current knowledge: 5 ≤ χ(ℝ²) ≤ 7.",
+  "description": "What is the chromatic number \u03c7(\u211d\u00b2) of the unit distance graph? The Hadwiger-Nelson problem. Nelson (1950): \u03c7 \u2265 4. Isbell (1950): \u03c7 \u2264 7. de Grey (2018): \u03c7 \u2265 5. Current knowledge: 5 \u2264 \u03c7(\u211d\u00b2) \u2264 7.",
   "meta": {
     "author": "Nelson (1950), Isbell (1950), de Grey (2018)",
     "sourceUrl": "https://erdosproblems.com/171",
@@ -31,7 +31,7 @@
       },
       {
         "theorem": "EuclideanSpace",
-        "description": "d-dimensional Euclidean space ℝ^d",
+        "description": "d-dimensional Euclidean space \u211d^d",
         "module": "Mathlib.Analysis.InnerProductSpace.EuclideanDist"
       },
       {
@@ -46,14 +46,14 @@
       }
     ],
     "originalContributions": [
-      "Definition of UnitDistanceGraph as SimpleGraph on ℝ²",
+      "Definition of UnitDistanceGraph as SimpleGraph on \u211d\u00b2",
       "Definition of IsProperColoring for unit distance graph",
       "Definition of chromaticNumberPlane via sInf",
       "Axiom moser_spindle (7-vertex 4-chromatic graph)",
       "Axiom de_grey_graph (<2000 vertex 5-chromatic graph)",
-      "Axiom isbell_upper_bound (χ ≤ 7 via hexagonal tiling)",
+      "Axiom isbell_upper_bound (\u03c7 \u2264 7 via hexagonal tiling)",
       "Aristotle-verified: clique_number_3 (equilateral triangle)",
-      "Aristotle-verified: no_4_clique (no tetrahedron in ℝ²)"
+      "Aristotle-verified: no_4_clique (no tetrahedron in \u211d\u00b2)"
     ],
     "axiomCount": 2,
     "lineCount": 302,
@@ -64,7 +64,7 @@
         "year": 2018,
         "venue": "Geombinatorics",
         "url": "https://arxiv.org/abs/1804.02385",
-        "description": "Breakthrough result improving the lower bound to χ(ℝ²) ≥ 5, ending a 68-year stalemate"
+        "description": "Breakthrough result improving the lower bound to \u03c7(\u211d\u00b2) \u2265 5, ending a 68-year stalemate"
       },
       {
         "title": "The Mathematical Coloring Book",
@@ -82,20 +82,20 @@
         "description": "Optimizes de Grey's construction to 553 vertices requiring 5 colors"
       }
     ],
-    "assumptions": "2 axioms: isbell_coloring (7-coloring of plane exists via hexagonal tiling), de_grey_graph (de Grey's 2018 finite graph non-4-colorable). moser_spindle PROVED with explicit Q(√3,√11) coordinates + native_decide. 0 sorries."
+    "assumptions": "2 axioms: isbell_coloring (7-coloring of plane exists via hexagonal tiling), de_grey_graph (de Grey's 2018 finite graph non-4-colorable). moser_spindle PROVED with explicit Q(\u221a3,\u221a11) coordinates + native_decide. 0 sorries."
   },
   "overview": {
-    "historicalContext": "The **Hadwiger-Nelson problem** asks for the chromatic number χ(ℝ²) of the unit distance graph: the minimum number of colors needed to color the plane so no two points at distance 1 share a color.\n\n**Historical Timeline**:\n- **1950**: Edward Nelson proved χ ≥ 4 using a 7-vertex graph (later called the Moser spindle)\n- **1950**: John Isbell proved χ ≤ 7 using a hexagonal tiling\n- **1950-2018**: No progress on the bounds for 68 years!\n- **2018**: Aubrey de Grey proved χ ≥ 5, finding a unit distance graph with ~1581 vertices that requires 5 colors\n\n**The de Grey Breakthrough**: After nearly 70 years with no improvement, de Grey used computer-aided construction to find a graph embedding where 4 colors are insufficient. This was later optimized to 553 vertices by Exoo and Ismailescu.\n\n**Current State**: 5 ≤ χ(ℝ²) ≤ 7. The exact value remains unknown.",
-    "problemStatement": "**Erdős Problem #171**: What is the chromatic number $\\chi(\\mathbb{R}^2)$ of the unit distance graph?\n\n**Definition**: The **unit distance graph** $G$ has:\n- Vertices: All points in $\\mathbb{R}^2$\n- Edges: Connect points at Euclidean distance exactly 1\n\n**Question**: What is $\\chi(G)$, the minimum number of colors needed for a proper coloring (adjacent vertices have different colors)?\n\n**Known Bounds**:\n- **Lower**: $\\chi \\geq 5$ (de Grey 2018)\n- **Upper**: $\\chi \\leq 7$ (Isbell 1950)\n\n**Related Results**:\n- Clique number $\\omega = 3$ (equilateral triangle)\n- Fractional chromatic number $\\chi_f = 4$",
-    "text": "What is the chromatic number χ(ℝ²) of the unit distance graph? The Hadwiger-Nelson problem. Nelson (1950): χ ≥ 4. Isbell (1950): χ ≤ 7. de Grey (2018): χ ≥ 5. Current knowledge: 5 ≤ χ(ℝ²) ≤ 7.",
-    "proofStrategy": "The formalization captures the structure of the problem and known results:\n\n1. **Core Definitions**:\n   - `UnitDistanceGraph`: SimpleGraph on EuclideanSpace ℝ (Fin 2)\n   - `IsProperColoring`: No adjacent vertices share colors\n   - `chromaticNumberPlane`: sInf of valid coloring counts\n\n2. **Lower Bounds** (proved):\n   - `moser_spindle`: 7-vertex graph requiring 4 colors (axiom)\n   - `lower_bound_4`: χ ≥ 4 (proved from Moser spindle via le_csInf + Fin restriction)\n   - `de_grey_graph`: <2000 vertex graph requiring 5 colors (axiom)\n   - `de_grey`: χ ≥ 5 (proved from de Grey graph via same pattern)\n\n3. **Upper Bound**:\n   - `isbell_coloring`: Witness axiom — a proper 7-coloring exists\n   - `isbell_upper_bound`: χ ≤ 7 (proved from isbell_coloring via Nat.sInf_le)\n\n4. **Clique Results** (Aristotle verified):\n   - `clique_number_3`: Equilateral triangle is a 3-clique\n   - `no_4_clique`: No 4-clique exists in ℝ²",
+    "historicalContext": "The **Hadwiger-Nelson problem** asks for the chromatic number \u03c7(\u211d\u00b2) of the unit distance graph: the minimum number of colors needed to color the plane so no two points at distance 1 share a color.\n\n**Historical Timeline**:\n- **1950**: Edward Nelson proved \u03c7 \u2265 4 using a 7-vertex graph (later called the Moser spindle)\n- **1950**: John Isbell proved \u03c7 \u2264 7 using a hexagonal tiling\n- **1950-2018**: No progress on the bounds for 68 years!\n- **2018**: Aubrey de Grey proved \u03c7 \u2265 5, finding a unit distance graph with ~1581 vertices that requires 5 colors\n\n**The de Grey Breakthrough**: After nearly 70 years with no improvement, de Grey used computer-aided construction to find a graph embedding where 4 colors are insufficient. This was later optimized to 553 vertices by Exoo and Ismailescu.\n\n**Current State**: 5 \u2264 \u03c7(\u211d\u00b2) \u2264 7. The exact value remains unknown.",
+    "problemStatement": "**Erd\u0151s Problem #171**: What is the chromatic number $\\chi(\\mathbb{R}^2)$ of the unit distance graph?\n\n**Definition**: The **unit distance graph** $G$ has:\n- Vertices: All points in $\\mathbb{R}^2$\n- Edges: Connect points at Euclidean distance exactly 1\n\n**Question**: What is $\\chi(G)$, the minimum number of colors needed for a proper coloring (adjacent vertices have different colors)?\n\n**Known Bounds**:\n- **Lower**: $\\chi \\geq 5$ (de Grey 2018)\n- **Upper**: $\\chi \\leq 7$ (Isbell 1950)\n\n**Related Results**:\n- Clique number $\\omega = 3$ (equilateral triangle)\n- Fractional chromatic number $\\chi_f = 4$",
+    "text": "What is the chromatic number \u03c7(\u211d\u00b2) of the unit distance graph? The Hadwiger-Nelson problem. Nelson (1950): \u03c7 \u2265 4. Isbell (1950): \u03c7 \u2264 7. de Grey (2018): \u03c7 \u2265 5. Current knowledge: 5 \u2264 \u03c7(\u211d\u00b2) \u2264 7.",
+    "proofStrategy": "The formalization captures the structure of the problem and known results:\n\n1. **Core Definitions**:\n   - `UnitDistanceGraph`: SimpleGraph on EuclideanSpace \u211d (Fin 2)\n   - `IsProperColoring`: No adjacent vertices share colors\n   - `chromaticNumberPlane`: sInf of valid coloring counts\n\n2. **Lower Bounds** (proved):\n   - `moser_spindle`: 7-vertex graph requiring 4 colors (axiom)\n   - `lower_bound_4`: \u03c7 \u2265 4 (proved from Moser spindle via le_csInf + Fin restriction)\n   - `de_grey_graph`: <2000 vertex graph requiring 5 colors (axiom)\n   - `de_grey`: \u03c7 \u2265 5 (proved from de Grey graph via same pattern)\n\n3. **Upper Bound**:\n   - `isbell_coloring`: Witness axiom \u2014 a proper 7-coloring exists\n   - `isbell_upper_bound`: \u03c7 \u2264 7 (proved from isbell_coloring via Nat.sInf_le)\n\n4. **Clique Results** (Aristotle verified):\n   - `clique_number_3`: Equilateral triangle is a 3-clique\n   - `no_4_clique`: No 4-clique exists in \u211d\u00b2",
     "keyInsights": [
-      "**The 68-year gap**: From 1950 to 2018, the best known bounds were 4 ≤ χ ≤ 7. De Grey's improvement to χ ≥ 5 was a major breakthrough.",
+      "**The 68-year gap**: From 1950 to 2018, the best known bounds were 4 \u2264 \u03c7 \u2264 7. De Grey's improvement to \u03c7 \u2265 5 was a major breakthrough.",
       "**Why is this hard?**: The graph is uncountable and highly symmetric. Local constructions (like Moser spindle) give limited information about the global chromatic number.",
-      "**Clique vs chromatic**: The clique number ω = 3 (equilateral triangle), but χ ≥ 5. This gap shows the problem isn't about dense local structure.",
-      "**Fractional chromatic number**: χ_f = 4 exactly. That χ ≥ 5 > χ_f shows integrality is essential.",
+      "**Clique vs chromatic**: The clique number \u03c9 = 3 (equilateral triangle), but \u03c7 \u2265 5. This gap shows the problem isn't about dense local structure.",
+      "**Fractional chromatic number**: \u03c7_f = 4 exactly. That \u03c7 \u2265 5 > \u03c7_f shows integrality is essential.",
       "**De Grey's approach**: Used algebraic coordinates and computer search to find a graph with specific properties that force 5 colors.",
-      "**Remaining question**: Is χ = 5, 6, or 7? Most researchers conjecture χ ∈ {5, 6}, but this is open."
+      "**Remaining question**: Is \u03c7 = 5, 6, or 7? Most researchers conjecture \u03c7 \u2208 {5, 6}, but this is open."
     ],
     "prerequisites": [
       "Combinatorial geometry (incidence bounds, configurations)",
@@ -118,8 +118,8 @@
       "title": "Unit Distance Graph",
       "startLine": 78,
       "endLine": 83,
-      "summary": "Definition of UnitDistanceGraph as SimpleGraph on ℝ².",
-      "mathContext": "Formal definition: Definition of UnitDistanceGraph as SimpleGraph on ℝ²."
+      "summary": "Definition of UnitDistanceGraph as SimpleGraph on \u211d\u00b2.",
+      "mathContext": "Formal definition: Definition of UnitDistanceGraph as SimpleGraph on \u211d\u00b2."
     },
     {
       "id": "chromatic",
@@ -134,32 +134,32 @@
       "title": "Lower Bounds",
       "startLine": 97,
       "endLine": 120,
-      "summary": "Moser spindle (χ ≥ 4) and de Grey (χ ≥ 5).",
-      "mathContext": "Moser spindle (χ $\\geq$ 4) and de Grey (χ $\\geq$ 5)."
+      "summary": "Moser spindle (\u03c7 \u2265 4) and de Grey (\u03c7 \u2265 5).",
+      "mathContext": "Moser spindle (\u03c7 $\\geq$ 4) and de Grey (\u03c7 $\\geq$ 5)."
     },
     {
       "id": "upper-bounds",
       "title": "Upper Bounds",
       "startLine": 121,
       "endLine": 127,
-      "summary": "Isbell's hexagonal tiling (χ ≤ 7).",
-      "mathContext": "Isbell's hexagonal tiling (χ $\\leq$ 7)."
+      "summary": "Isbell's hexagonal tiling (\u03c7 \u2264 7).",
+      "mathContext": "Isbell's hexagonal tiling (\u03c7 $\\leq$ 7)."
     },
     {
       "id": "current",
       "title": "Current State",
       "startLine": 128,
       "endLine": 134,
-      "summary": "Combined bounds: 5 ≤ χ(ℝ²) ≤ 7.",
-      "mathContext": "Combined bounds: 5 $\\leq$ χ(ℝ²) $\\leq$ 7."
+      "summary": "Combined bounds: 5 \u2264 \u03c7(\u211d\u00b2) \u2264 7.",
+      "mathContext": "Combined bounds: 5 $\\leq$ \u03c7(\u211d\u00b2) $\\leq$ 7."
     },
     {
       "id": "clique",
       "title": "Clique Number",
       "startLine": 144,
       "endLine": 159,
-      "summary": "Aristotle-verified: ω = 3 (equilateral triangle, no 4-clique).",
-      "mathContext": "Mathematical content: Aristotle-verified: ω = 3 (equilateral triangle, no 4-clique)."
+      "summary": "Aristotle-verified: \u03c9 = 3 (equilateral triangle, no 4-clique).",
+      "mathContext": "Mathematical content: Aristotle-verified: \u03c9 = 3 (equilateral triangle, no 4-clique)."
     },
     {
       "id": "summary",
@@ -171,13 +171,13 @@
     }
   ],
   "conclusion": {
-    "summary": "We formalize Erdős Problem #171 on the chromatic number of the unit distance graph (Hadwiger-Nelson problem). The problem was 'solved' in 2018 when de Grey improved the lower bound from 4 to 5, breaking a 68-year stalemate. The current knowledge is 5 ≤ χ(ℝ²) ≤ 7. Aristotle verified the clique number results: an equilateral triangle gives ω = 3, and no 4-clique exists in ℝ².",
-    "implications": "**Theoretical Significance**: This problem sits at the intersection of combinatorics, geometry, and graph theory.\n\nThe de Grey breakthrough showed that computer-aided mathematical discovery can solve long-standing open problems. The gap between χ and χ_f demonstrates the importance of integrality constraints in coloring problems.",
+    "summary": "We formalize Erd\u0151s Problem #171 on the chromatic number of the unit distance graph (Hadwiger-Nelson problem). The problem was 'solved' in 2018 when de Grey improved the lower bound from 4 to 5, breaking a 68-year stalemate. The current knowledge is 5 \u2264 \u03c7(\u211d\u00b2) \u2264 7. Aristotle verified the clique number results: an equilateral triangle gives \u03c9 = 3, and no 4-clique exists in \u211d\u00b2.",
+    "implications": "**Theoretical Significance**: This problem sits at the intersection of combinatorics, geometry, and graph theory.\n\nThe de Grey breakthrough showed that computer-aided mathematical discovery can solve long-standing open problems. The gap between \u03c7 and \u03c7_f demonstrates the importance of integrality constraints in coloring problems.",
     "openQuestions": [
-      "Is χ(ℝ²) = 5, 6, or 7?",
+      "Is \u03c7(\u211d\u00b2) = 5, 6, or 7?",
       "Can the de Grey construction be simplified or made more explicit?",
       "What is the chromatic number in higher dimensions?",
-      "Is there a 'natural' proof that χ ≥ 5 without massive computer search?"
+      "Is there a 'natural' proof that \u03c7 \u2265 5 without massive computer search?"
     ]
   },
   "leanFile": {
@@ -197,7 +197,7 @@
       "Metric"
     ],
     "namespace": "Erdos171",
-    "lineCount": 302,
+    "lineCount": 303,
     "axiomCount": 2,
     "theoremCount": 16,
     "definitionCount": 4,
@@ -206,18 +206,18 @@
   },
   "crossReferences": [
     {
-      "title": "Erdős Problem #173: Monochromatic Triangles in Plane Colorings",
-      "relationship": "Both concern chromatic properties of the Euclidean plane — #171 asks for χ(ℝ²) under unit distance constraints, #173 asks about monochromatic triangles under arbitrary plane colorings",
+      "title": "Erd\u0151s Problem #173: Monochromatic Triangles in Plane Colorings",
+      "relationship": "Both concern chromatic properties of the Euclidean plane \u2014 #171 asks for \u03c7(\u211d\u00b2) under unit distance constraints, #173 asks about monochromatic triangles under arbitrary plane colorings",
       "targetId": "erdos-173"
     },
     {
-      "title": "Erdős Problem #174: Euclidean Ramsey Sets",
+      "title": "Erd\u0151s Problem #174: Euclidean Ramsey Sets",
       "relationship": "Both involve geometric Ramsey theory in Euclidean space; unit distance graphs and Euclidean Ramsey sets both study unavoidable monochromatic geometric configurations",
       "targetId": "erdos-174"
     },
     {
-      "title": "Lovász Local Lemma",
-      "relationship": "The Lovász Local Lemma is a key tool in chromatic number bounds for geometric graphs, including approaches to the Hadwiger-Nelson problem",
+      "title": "Lov\u00e1sz Local Lemma",
+      "relationship": "The Lov\u00e1sz Local Lemma is a key tool in chromatic number bounds for geometric graphs, including approaches to the Hadwiger-Nelson problem",
       "targetId": "prob-method-lovasz-local"
     }
   ],

--- a/src/data/proofs/erdos-172/meta.json
+++ b/src/data/proofs/erdos-172/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "erdos-172",
-  "title": "Erdős Problem #172: Monochromatic Sums and Products",
+  "title": "Erd\u0151s Problem #172: Monochromatic Sums and Products",
   "slug": "erdos-172",
-  "description": "In any finite coloring of ℕ, do there exist arbitrarily large sets A with all sums and products of elements monochromatic?",
+  "description": "In any finite coloring of \u2115, do there exist arbitrarily large sets A with all sums and products of elements monochromatic?",
   "meta": {
     "author": "Hindman (original); Moreira 2017 (partial); OPEN for full conjecture",
     "sourceUrl": "https://erdosproblems.com/172",
@@ -49,20 +49,20 @@
     "lineCount": 144,
     "references": [
       {
-        "title": "Monochromatic sums and products in ℕ",
+        "title": "Monochromatic sums and products in \u2115",
         "authors": "J. Moreira",
         "year": 2017,
         "venue": "Annals of Mathematics",
         "url": "https://doi.org/10.4007/annals.2017.185.3.10",
-        "description": "Proves monochromatic {x, x+y, xy} exists in any finite coloring of ℕ"
+        "description": "Proves monochromatic {x, x+y, xy} exists in any finite coloring of \u2115"
       },
       {
-        "title": "Monochromatic sums and products in ℚ",
+        "title": "Monochromatic sums and products in \u211a",
         "authors": "R. Alweiss",
         "year": 2023,
         "venue": "Preprint",
         "url": "https://arxiv.org/abs/2305.02065",
-        "description": "Proves the full sum-product monochromatic conjecture over the rationals ℚ\\{0}"
+        "description": "Proves the full sum-product monochromatic conjecture over the rationals \u211a\\{0}"
       },
       {
         "title": "Finite sums from sequences within cells of a partition of N",
@@ -70,20 +70,20 @@
         "year": 1974,
         "venue": "Journal of Combinatorial Theory, Series A",
         "url": "https://doi.org/10.1016/0097-3165(74)90023-5",
-        "description": "Hindman's theorem on monochromatic finite sums — the additive-only precursor to Erdős #172"
+        "description": "Hindman's theorem on monochromatic finite sums \u2014 the additive-only precursor to Erd\u0151s #172"
       }
     ],
     "assumptions": "3 axiom(s): moreira_2017, alweiss_2023_rationals, hindman_1980_counterexample. See Lean source for complete statements."
   },
   "overview": {
-    "historicalContext": "This problem was first asked by Neil Hindman and concerns the interplay between additive and multiplicative structure in Ramsey theory. The question asks whether the additive and multiplicative structures of ℕ can be simultaneously exploited to find arbitrarily large monochromatic configurations.\n\nHindman himself proved in 1980 that the infinite version is false - with 7 colors, no infinite set can have all sums and products monochromatic. This left open the finite version.\n\nJoel Moreira made breakthrough progress in 2017, proving that for any finite coloring, there exist x, y such that {x, x+y, xy} are all the same color. This was the first non-trivial case (|A| = 2). Ryan Alweiss (2023) proved the full conjecture over ℚ\\{0}, suggesting the answer over ℕ might also be positive.",
+    "historicalContext": "This problem was first asked by Neil Hindman and concerns the interplay between additive and multiplicative structure in Ramsey theory. The question asks whether the additive and multiplicative structures of \u2115 can be simultaneously exploited to find arbitrarily large monochromatic configurations.\n\nHindman himself proved in 1980 that the infinite version is false - with 7 colors, no infinite set can have all sums and products monochromatic. This left open the finite version.\n\nJoel Moreira made breakthrough progress in 2017, proving that for any finite coloring, there exist x, y such that {x, x+y, xy} are all the same color. This was the first non-trivial case (|A| = 2). Ryan Alweiss (2023) proved the full conjecture over \u211a\\{0}, suggesting the answer over \u2115 might also be positive.",
     "problemStatement": "**Problem**: In any finite coloring of $\\mathbb{N}$, do there exist arbitrarily large finite sets $A$ such that all sums and products of distinct elements of $A$ are the same color?\n\n**Status**: OPEN\n\n**Partial results**:\n- Moreira (2017): TRUE for |A| = 2\n- Alweiss (2023): TRUE over $\\mathbb{Q}\\setminus\\{0\\}$\n- Hindman (1980): FALSE for infinite A with 7 colors",
-    "text": "In any finite coloring of ℕ, do there exist arbitrarily large sets A with all sums and products of elements monochromatic?",
-    "proofStrategy": "Since the problem is open, we formalize:\n\n1. **The conjecture**: For any k-coloring and m, there exists A with |A| ≥ m where all subset sums and products share a color\n2. **Moreira's theorem**: Axiomatized - monochromatic {x, x+y, xy} exists\n3. **Alweiss's theorem**: Axiomatized - full conjecture holds over rationals\n4. **Hindman's counterexample**: Axiomatized - infinite version fails\n\nWe also prove basic properties: singletons are trivially monochromatic, and the empty set satisfies the property vacuously.",
+    "text": "In any finite coloring of \u2115, do there exist arbitrarily large sets A with all sums and products of elements monochromatic?",
+    "proofStrategy": "Since the problem is open, we formalize:\n\n1. **The conjecture**: For any k-coloring and m, there exists A with |A| \u2265 m where all subset sums and products share a color\n2. **Moreira's theorem**: Axiomatized - monochromatic {x, x+y, xy} exists\n3. **Alweiss's theorem**: Axiomatized - full conjecture holds over rationals\n4. **Hindman's counterexample**: Axiomatized - infinite version fails\n\nWe also prove basic properties: singletons are trivially monochromatic, and the empty set satisfies the property vacuously.",
     "keyInsights": [
-      "**Sum-product monochromatic**: A set A where for every nonempty S ⊆ A, both Σ S and Π S have the same color.",
+      "**Sum-product monochromatic**: A set A where for every nonempty S \u2286 A, both \u03a3 S and \u03a0 S have the same color.",
       "**Finite vs infinite**: The infinite version fails (Hindman 1980), but the finite version remains open.",
-      "**Rationals vs naturals**: Alweiss proved the full conjecture over ℚ\\{0}, but naturals remain elusive.",
+      "**Rationals vs naturals**: Alweiss proved the full conjecture over \u211a\\{0}, but naturals remain elusive.",
       "**Moreira's breakthrough**: The |A| = 2 case (monochromatic {x, x+y, xy}) was only proved in 2017.",
       "**Ramsey theory meets arithmetic**: This combines partition regularity with additive/multiplicative structure."
     ],
@@ -106,7 +106,7 @@
       "title": "The Main Conjecture",
       "startLine": 44,
       "endLine": 58,
-      "summary": "Formal statement of Erdős Problem #172."
+      "summary": "Formal statement of Erd\u0151s Problem #172."
     },
     {
       "id": "positive",
@@ -138,10 +138,10 @@
     }
   ],
   "conclusion": {
-    "summary": "We formalize Erdős Problem #172, which asks whether any finite coloring of ℕ admits arbitrarily large sum-product monochromatic sets. The problem remains open despite significant partial progress: Moreira (2017) proved the |A| = 2 case, and Alweiss (2023) proved the full conjecture over rationals.",
+    "summary": "We formalize Erd\u0151s Problem #172, which asks whether any finite coloring of \u2115 admits arbitrarily large sum-product monochromatic sets. The problem remains open despite significant partial progress: Moreira (2017) proved the |A| = 2 case, and Alweiss (2023) proved the full conjecture over rationals.",
     "implications": "**Theoretical Significance**: This problem lies at the intersection of Ramsey theory and arithmetic combinatorics.\n\nA positive answer would reveal deep structural properties of how addition and multiplication interact under partitions. The fact that the rational case is solved suggests the integer case may also be true.",
     "openQuestions": [
-      "Does the full conjecture hold for ℕ?",
+      "Does the full conjecture hold for \u2115?",
       "What is the minimum number of colors needed to avoid infinite monochromatic sets?",
       "Can Moreira's result be extended to |A| = 3?",
       "Is there a quantitative version giving bounds on the smallest such A?"
@@ -155,7 +155,7 @@
       "Finset"
     ],
     "namespace": "Erdos172",
-    "lineCount": 144,
+    "lineCount": 145,
     "axiomCount": 3,
     "theoremCount": 4,
     "definitionCount": 6,
@@ -164,18 +164,18 @@
   },
   "crossReferences": [
     {
-      "title": "Erdős Problem #160: Rainbow-Free Colorings of Arithmetic Progressions",
-      "relationship": "Both concern partition regularity and monochromatic structures under finite colorings of ℕ — #172 seeks monochromatic sum-product sets, #160 avoids rainbow APs",
+      "title": "Erd\u0151s Problem #160: Rainbow-Free Colorings of Arithmetic Progressions",
+      "relationship": "Both concern partition regularity and monochromatic structures under finite colorings of \u2115 \u2014 #172 seeks monochromatic sum-product sets, #160 avoids rainbow APs",
       "targetId": "erdos-160"
     },
     {
       "title": "Ramsey's Theorem",
-      "relationship": "Ramsey's theorem is the foundational result in partition regularity; Erdős #172 extends the Ramsey paradigm to combined additive and multiplicative structure",
+      "relationship": "Ramsey's theorem is the foundational result in partition regularity; Erd\u0151s #172 extends the Ramsey paradigm to combined additive and multiplicative structure",
       "targetId": "ramseys-theorem"
     },
     {
-      "title": "Erdős Problem #174: Euclidean Ramsey Sets",
-      "relationship": "Both are Ramsey-type problems asking for unavoidable monochromatic configurations — #172 in arithmetic, #174 in geometry",
+      "title": "Erd\u0151s Problem #174: Euclidean Ramsey Sets",
+      "relationship": "Both are Ramsey-type problems asking for unavoidable monochromatic configurations \u2014 #172 in arithmetic, #174 in geometry",
       "targetId": "erdos-174"
     }
   ],

--- a/src/data/proofs/erdos-202/meta.json
+++ b/src/data/proofs/erdos-202/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-202",
-  "title": "Erdős #202: Disjoint Covering Systems",
+  "title": "Erd\u0151s #202: Disjoint Covering Systems",
   "slug": "erdos-202",
-  "description": "How many disjoint congruence classes can have moduli bounded by N? Bounds involve L(N) = exp(√(log N · log log N)).",
+  "description": "How many disjoint congruence classes can have moduli bounded by N? Bounds involve L(N) = exp(\u221a(log N \u00b7 log log N)).",
   "meta": {
-    "author": "Paul Erdős, Endre Szemerédi",
+    "author": "Paul Erd\u0151s, Endre Szemer\u00e9di",
     "sourceUrl": "https://erdosproblems.com/202",
     "date": "1968",
     "status": "axiomatized",
@@ -48,8 +48,8 @@
       "Formalized CongruenceClass structure with modular containment",
       "Defined DisjointSystem and pairwise disjointness property",
       "Defined f(N) as supremum of disjoint system sizes bounded by N",
-      "Defined L(N) = exp(√(log N · log log N)) with growth properties",
-      "Stated Erdős-Stein conjecture f(N) = o(N) and modern BFV bounds",
+      "Defined L(N) = exp(\u221a(log N \u00b7 log log N)) with growth properties",
+      "Stated Erd\u0151s-Stein conjecture f(N) = o(N) and modern BFV bounds",
       "Multiple theorems proved by Aristotle including f_mono, f_le_N, L_mono, L_subpolynomial"
     ],
     "axiomCount": 0,
@@ -57,14 +57,14 @@
     "assumptions": "3 sorry(s). No axioms."
   },
   "overview": {
-    "historicalContext": "**From Covering Systems to Smooth Number Bounds**\n\n**Erdős** and **Stein** conjectured in the 1960s that $f(N) = o(N)$, where $f(N)$ is the maximum number of pairwise disjoint congruence classes with moduli $\\leq N$. **Erdős** and **Szemerédi** proved this conjecture in 1968 using sieve methods, showing $f(N) < N/(\\log N)^c$ for some $c > 0$.\n\nThe precise asymptotics involve the **subexponential function** $L(N) = \\exp(\\sqrt{\\log N \\cdot \\log\\log N})$, which arises naturally from smooth number theory. **Croot** (2003) established bounds $N/L(N)^{\\sqrt{2}+o(1)} < f(N) < N/L(N)^{1/6-o(1)}$, introducing character sum techniques. **Chen** (2005) and **de la Bretèche–Ford–Vandehey** (2013) tightened these to:\n$$\\frac{N}{L(N)^{1+o(1)}} < f(N) < \\frac{N}{L(N)^{\\sqrt{3}/2+o(1)}}$$\n\nThe lower bound is conjectured to be tight. The problem connects to the **Erdős covering system conjecture** (disproved by Hough 2015), **smooth number distribution** (Dickman's function), and **sieve theory**. This is one of 798 lines of Lean formalization, with 7 theorems proved by the Aristotle proof search system.",
-    "problemStatement": "**Erdős Problem 202**\n\nLet $n_1 < n_2 < \\cdots < n_r \\leq N$ with associated residues $a_i \\pmod{n_i}$ such that the congruence classes are pairwise disjoint. Define $f(N)$ as the maximum $r$.\n\nWhat is $f(N)$ asymptotically? Current bounds:\n$$\\frac{N}{L(N)^{1+o(1)}} < f(N) < \\frac{N}{L(N)^{\\sqrt{3}/2+o(1)}}$$\nwhere $L(N) = \\exp(\\sqrt{\\log N \\cdot \\log\\log N})$.",
-    "text": "How many disjoint congruence classes can have moduli bounded by N? Bounds involve L(N) = exp(√(log N · log log N)).",
-    "proofStrategy": "**Formalization Strategy**\n\n1. **Congruence infrastructure:** Define `CongruenceClass` with modular containment via `Int.ModEq`, disjointness predicate, and `DisjointSystem` structure.\n2. **Extremal function:** Define $f(N)$ via `sSup` over all disjoint system sizes with moduli $\\leq N$.\n3. **Density constraint:** Prove $\\sum 1/n_i \\leq 1$ for any disjoint system (key structural lemma), implying $f(N) \\leq N$.\n4. **Full system construction:** Build $\\{0, 1, \\ldots, N-1\\} \\bmod N$ to show $f(N) \\geq N$, establishing $f(N) = N$.\n5. **$L$ function:** Define $L(N) = \\exp(\\sqrt{\\log N \\cdot \\log\\log N})$ with monotonicity and subpolynomial growth.\n6. **Historical bounds:** State Erdős–Stein ($f(N) = o(N)$), Erdős–Szemerédi ($f(N) < N/(\\log N)^c$), and BFV bounds.\n7. **Aristotle integration:** 7 theorems proved by automated proof search, including `f_mono`, `f_le_N`, `L_mono`, `L_subpolynomial`, `lower_bound_BFV`.",
+    "historicalContext": "**From Covering Systems to Smooth Number Bounds**\n\n**Erd\u0151s** and **Stein** conjectured in the 1960s that $f(N) = o(N)$, where $f(N)$ is the maximum number of pairwise disjoint congruence classes with moduli $\\leq N$. **Erd\u0151s** and **Szemer\u00e9di** proved this conjecture in 1968 using sieve methods, showing $f(N) < N/(\\log N)^c$ for some $c > 0$.\n\nThe precise asymptotics involve the **subexponential function** $L(N) = \\exp(\\sqrt{\\log N \\cdot \\log\\log N})$, which arises naturally from smooth number theory. **Croot** (2003) established bounds $N/L(N)^{\\sqrt{2}+o(1)} < f(N) < N/L(N)^{1/6-o(1)}$, introducing character sum techniques. **Chen** (2005) and **de la Bret\u00e8che\u2013Ford\u2013Vandehey** (2013) tightened these to:\n$$\\frac{N}{L(N)^{1+o(1)}} < f(N) < \\frac{N}{L(N)^{\\sqrt{3}/2+o(1)}}$$\n\nThe lower bound is conjectured to be tight. The problem connects to the **Erd\u0151s covering system conjecture** (disproved by Hough 2015), **smooth number distribution** (Dickman's function), and **sieve theory**. This is one of 798 lines of Lean formalization, with 7 theorems proved by the Aristotle proof search system.",
+    "problemStatement": "**Erd\u0151s Problem 202**\n\nLet $n_1 < n_2 < \\cdots < n_r \\leq N$ with associated residues $a_i \\pmod{n_i}$ such that the congruence classes are pairwise disjoint. Define $f(N)$ as the maximum $r$.\n\nWhat is $f(N)$ asymptotically? Current bounds:\n$$\\frac{N}{L(N)^{1+o(1)}} < f(N) < \\frac{N}{L(N)^{\\sqrt{3}/2+o(1)}}$$\nwhere $L(N) = \\exp(\\sqrt{\\log N \\cdot \\log\\log N})$.",
+    "text": "How many disjoint congruence classes can have moduli bounded by N? Bounds involve L(N) = exp(\u221a(log N \u00b7 log log N)).",
+    "proofStrategy": "**Formalization Strategy**\n\n1. **Congruence infrastructure:** Define `CongruenceClass` with modular containment via `Int.ModEq`, disjointness predicate, and `DisjointSystem` structure.\n2. **Extremal function:** Define $f(N)$ via `sSup` over all disjoint system sizes with moduli $\\leq N$.\n3. **Density constraint:** Prove $\\sum 1/n_i \\leq 1$ for any disjoint system (key structural lemma), implying $f(N) \\leq N$.\n4. **Full system construction:** Build $\\{0, 1, \\ldots, N-1\\} \\bmod N$ to show $f(N) \\geq N$, establishing $f(N) = N$.\n5. **$L$ function:** Define $L(N) = \\exp(\\sqrt{\\log N \\cdot \\log\\log N})$ with monotonicity and subpolynomial growth.\n6. **Historical bounds:** State Erd\u0151s\u2013Stein ($f(N) = o(N)$), Erd\u0151s\u2013Szemer\u00e9di ($f(N) < N/(\\log N)^c$), and BFV bounds.\n7. **Aristotle integration:** 7 theorems proved by automated proof search, including `f_mono`, `f_le_N`, `L_mono`, `L_subpolynomial`, `lower_bound_BFV`.",
     "keyInsights": [
-      "**Density Constraint:** The fundamental obstruction is $\\sum_{i=1}^r 1/n_i \\leq 1$ for any disjoint system — each class $(a_i, n_i)$ covers a proportion $1/n_i$ of the integers, and disjointness forces the total proportion to be at most $1$.",
+      "**Density Constraint:** The fundamental obstruction is $\\sum_{i=1}^r 1/n_i \\leq 1$ for any disjoint system \u2014 each class $(a_i, n_i)$ covers a proportion $1/n_i$ of the integers, and disjointness forces the total proportion to be at most $1$.",
       "**$f(N) = N$ Exactly:** The trivial system $\\{0, 1, \\ldots, N-1\\} \\bmod N$ achieves $|S| = N$, and the density constraint with moduli $\\leq N$ gives $|S| \\leq N$. The asymptotic question is about systems with distinct moduli.",
-      "**Subexponential Threshold:** The function $L(N) = \\exp(\\sqrt{\\log N \\cdot \\log\\log N})$ is the natural boundary between polynomial and logarithmic — it satisfies $L(N) = N^{o(1)}$ yet $L(N) \\gg (\\log N)^c$ for all $c$.",
+      "**Subexponential Threshold:** The function $L(N) = \\exp(\\sqrt{\\log N \\cdot \\log\\log N})$ is the natural boundary between polynomial and logarithmic \u2014 it satisfies $L(N) = N^{o(1)}$ yet $L(N) \\gg (\\log N)^c$ for all $c$.",
       "**Smooth Number Connection:** The bounds involve counting $y$-smooth numbers (integers with all prime factors $\\leq y$). The Dickman function $\\rho(u)$ satisfying $\\Psi(x, x^{1/u}) \\sim x\\rho(u)$ underlies the $L(N)$ appearance.",
       "**Aristotle Success:** 7 of the file's theorems were proved automatically by Aristotle, including the nontrivial `L_subpolynomial` which requires a nested chain of limit arguments ($y = \\log N$, $z = \\sqrt{y}$, squeeze lemma)."
     ],
@@ -125,7 +125,7 @@
     },
     {
       "id": "erdos-stein",
-      "title": "Erdős–Stein Conjecture and Szemerédi Bound",
+      "title": "Erd\u0151s\u2013Stein Conjecture and Szemer\u00e9di Bound",
       "startLine": 420,
       "endLine": 546,
       "summary": "States erdos_stein_conjecture: $f(N) = o(N)$ (sorry). Proves `erdos_szemeredi_upper`: $f(N) < N/(\\log N)^c$ (Aristotle). Includes `trivialSystem` and `full_system` constructions.",
@@ -149,8 +149,8 @@
     }
   ],
   "conclusion": {
-    "summary": "This 798-line formalization captures Erdős Problem #202 on disjoint covering systems, with 7 theorems proved by Aristotle. The density constraint $\\sum 1/n_i \\leq 1$ is the key structural lemma, proved via a counting argument over common multiples. The extremal function $f(N) = N$ is established exactly, and the asymptotic question reduces to understanding the gap between $L(N)^1$ and $L(N)^{\\sqrt{3}/2}$ in the exponent. The subexponential function $L(N) = \\exp(\\sqrt{\\log N \\cdot \\log\\log N})$ is defined with full monotonicity and growth properties.",
-    "implications": "**Theoretical Significance**: **Implications and Connections**\n\n1. **Covering System Theory:** Disjoint covering systems are the simplest case of the general covering system problem. Hough (2015) disproved the Erdős minimum modulus conjecture for covering systems, but the disjoint case remains open.\n\n2. **Smooth Number Distribution:** The $L(N)$ function connects to the Dickman–de Bruijn function $\\rho(u)$: the count $\\Psi(x, y)$ of $y$-smooth numbers up to $x$ satisfies $\\Psi(x, x^{1/u}) = x \\cdot \\rho(u)(1 + o(1))$, and $L(x)$ appears as the transition scale.\n\n**3. Sieve Theory:** The Erdős–Szemerédi proof uses large sieve estimates. The BFV bounds use Dirichlet character sum techniques, connecting to the distribution of primes in arithmetic progressions.\n\n4. **Combinatorial Number Theory:** The density constraint $\\sum 1/n_i \\leq 1$ is a number-theoretic analogue of the fractional matching condition in hypergraph theory.\n\n5. **Automated Proof Search:** This file demonstrates significant Aristotle success: 7 theorems proved automatically, including the nontrivial `L_subpolynomial` requiring nested substitutions and squeeze lemma arguments.",
+    "summary": "This 798-line formalization captures Erd\u0151s Problem #202 on disjoint covering systems, with 7 theorems proved by Aristotle. The density constraint $\\sum 1/n_i \\leq 1$ is the key structural lemma, proved via a counting argument over common multiples. The extremal function $f(N) = N$ is established exactly, and the asymptotic question reduces to understanding the gap between $L(N)^1$ and $L(N)^{\\sqrt{3}/2}$ in the exponent. The subexponential function $L(N) = \\exp(\\sqrt{\\log N \\cdot \\log\\log N})$ is defined with full monotonicity and growth properties.",
+    "implications": "**Theoretical Significance**: **Implications and Connections**\n\n1. **Covering System Theory:** Disjoint covering systems are the simplest case of the general covering system problem. Hough (2015) disproved the Erd\u0151s minimum modulus conjecture for covering systems, but the disjoint case remains open.\n\n2. **Smooth Number Distribution:** The $L(N)$ function connects to the Dickman\u2013de Bruijn function $\\rho(u)$: the count $\\Psi(x, y)$ of $y$-smooth numbers up to $x$ satisfies $\\Psi(x, x^{1/u}) = x \\cdot \\rho(u)(1 + o(1))$, and $L(x)$ appears as the transition scale.\n\n**3. Sieve Theory:** The Erd\u0151s\u2013Szemer\u00e9di proof uses large sieve estimates. The BFV bounds use Dirichlet character sum techniques, connecting to the distribution of primes in arithmetic progressions.\n\n4. **Combinatorial Number Theory:** The density constraint $\\sum 1/n_i \\leq 1$ is a number-theoretic analogue of the fractional matching condition in hypergraph theory.\n\n5. **Automated Proof Search:** This file demonstrates significant Aristotle success: 7 theorems proved automatically, including the nontrivial `L_subpolynomial` requiring nested substitutions and squeeze lemma arguments.",
     "openQuestions": [
       "Is $f(N) = N/L(N)^{1+o(1)}$ (matching the lower bound), or is the true exponent strictly between $1$ and $\\sqrt{3}/2$?",
       "Can the BFV upper bound exponent $\\sqrt{3}/2 \\approx 0.866$ be improved toward the conjectured $1$?",
@@ -175,7 +175,7 @@
       "Classical"
     ],
     "namespace": "Erdos202",
-    "lineCount": 859,
+    "lineCount": 860,
     "axiomCount": 0,
     "theoremCount": 40,
     "definitionCount": 19,
@@ -186,24 +186,24 @@
     {
       "targetId": "erdos-2",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, covering-systems, number-theory"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, covering-systems, number-theory"
     },
     {
       "targetId": "erdos-586",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, covering-systems, number-theory"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, covering-systems, number-theory"
     },
     {
       "targetId": "erdos-7",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, covering-systems, number-theory"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, covering-systems, number-theory"
     }
   ],
   "references": [
     {
       "key": "Er50d",
       "authors": [
-        "P. Erdős"
+        "P. Erd\u0151s"
       ],
       "title": "On a problem concerning congruence systems",
       "venue": "Matematikai Lapok",

--- a/src/data/proofs/erdos-29/meta.json
+++ b/src/data/proofs/erdos-29/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-29",
-  "title": "Erdős Problem #29: Explicit Economical Additive Basis",
+  "title": "Erd\u0151s Problem #29: Explicit Economical Additive Basis",
   "slug": "erdos-29",
-  "description": "Is there an explicit construction of A ⊆ ℕ such that A + A = ℕ but r_A(n) = o(n^ε) for every ε > 0? SOLVED by Jain-Pham-Sawhney-Zakharov (2024).",
+  "description": "Is there an explicit construction of A \u2286 \u2115 such that A + A = \u2115 but r_A(n) = o(n^\u03b5) for every \u03b5 > 0? SOLVED by Jain-Pham-Sawhney-Zakharov (2024).",
   "meta": {
-    "author": "Sidon, Erdős",
+    "author": "Sidon, Erd\u0151s",
     "sourceUrl": "https://erdosproblems.com/29",
     "date": "1932",
     "status": "axiomatized",
@@ -23,7 +23,7 @@
     "erdosPrizeValue": "$100",
     "axiomCount": 5,
     "lineCount": 523,
-    "assumptions": "5 axioms: JPSZ_set (explicit construction), JPSZ_is_basis, JPSZ_representation_bound, JPSZ_explicit, JPSZ_size_optimal. JPSZ_is_economical and JPSZ_density_zero fully proved as consequences (not independent axioms): economical follows from representation bound via exp(C√(log n) - ε·log n) → -∞, density zero follows from size optimal via squeeze with C·√(log N/N) → 0. 0 sorries.",
+    "assumptions": "5 axioms: JPSZ_set (explicit construction), JPSZ_is_basis, JPSZ_representation_bound, JPSZ_explicit, JPSZ_size_optimal. JPSZ_is_economical and JPSZ_density_zero fully proved as consequences (not independent axioms): economical follows from representation bound via exp(C\u221a(log n) - \u03b5\u00b7log n) \u2192 -\u221e, density zero follows from size optimal via squeeze with C\u00b7\u221a(log N/N) \u2192 0. 0 sorries.",
     "prerequisites": [
       "Additive bases and Waring's problem",
       "Explicit vs. probabilistic constructions",
@@ -33,17 +33,17 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "In 1932, the Hungarian mathematician Simon Sidon posed a question to Paul Erdős: can one explicitly construct a set $A \\subseteq \\mathbb{N}$ that is simultaneously an additive basis of order 2 ($A + A = \\mathbb{N}$) and 'economical' (the representation function $r_A(n)$ grows slower than any polynomial)?\n\nErdős, one of the most prolific mathematicians of the 20th century, proved that such sets **exist** using the probabilistic method: include $n \\in A$ with probability $p_n \\approx n^{-1/2+o(1)}$. A second-moment calculation shows that with positive probability, the random set satisfies both properties simultaneously. However, this argument is **non-constructive** — it guarantees existence without providing an algorithm to compute $A$.\n\nFor 90+ years, no explicit construction was known. The problem appeared on Erdős's list of $100 prize problems. The difficulty is that the two requirements — coverage (basis) and sparsity (economical) — pull in opposite directions: making $A$ denser helps coverage but hurts the representation count.\n\nIn 2024, Siddharth Jain, Huy Tuan Pham, Mehtaab Sawhney, and Dmitriy Zakharov (JPSZ) solved the problem with a breakthrough construction (arXiv:2405.08650). Their approach derandomizes Erdős's probabilistic argument using a carefully designed hash function, yielding a computable set with $r_A(n) \\leq \\exp(C\\sqrt{\\log n})$ — far stronger than the required $o(n^\\varepsilon)$ for all $\\varepsilon > 0$. This resolved a 90+ year open problem and claimed Erdős's $100 prize.",
-    "problemStatement": "Is there an explicit construction of a set A ⊆ ℕ such that A + A = ℕ (additive basis) but r_A(n) = o(n^ε) for every ε > 0 (economical)?",
-    "text": "Is there an explicit construction of A ⊆ ℕ such that A + A = ℕ but r_A(n) = o(n^ε) for every ε > 0? SOLVED by Jain-Pham-Sawhney-Zakharov (2024).",
-    "proofStrategy": "The formalization defines sumsets, representation functions, and the economical condition. Key comparisons: ℕ is a basis but not economical (r(n) = n+1), Sidon sets are economical but not bases. The JPSZ construction achieves both properties with r_A(n) ≤ exp(C√(log n)).",
+    "historicalContext": "In 1932, the Hungarian mathematician Simon Sidon posed a question to Paul Erd\u0151s: can one explicitly construct a set $A \\subseteq \\mathbb{N}$ that is simultaneously an additive basis of order 2 ($A + A = \\mathbb{N}$) and 'economical' (the representation function $r_A(n)$ grows slower than any polynomial)?\n\nErd\u0151s, one of the most prolific mathematicians of the 20th century, proved that such sets **exist** using the probabilistic method: include $n \\in A$ with probability $p_n \\approx n^{-1/2+o(1)}$. A second-moment calculation shows that with positive probability, the random set satisfies both properties simultaneously. However, this argument is **non-constructive** \u2014 it guarantees existence without providing an algorithm to compute $A$.\n\nFor 90+ years, no explicit construction was known. The problem appeared on Erd\u0151s's list of $100 prize problems. The difficulty is that the two requirements \u2014 coverage (basis) and sparsity (economical) \u2014 pull in opposite directions: making $A$ denser helps coverage but hurts the representation count.\n\nIn 2024, Siddharth Jain, Huy Tuan Pham, Mehtaab Sawhney, and Dmitriy Zakharov (JPSZ) solved the problem with a breakthrough construction (arXiv:2405.08650). Their approach derandomizes Erd\u0151s's probabilistic argument using a carefully designed hash function, yielding a computable set with $r_A(n) \\leq \\exp(C\\sqrt{\\log n})$ \u2014 far stronger than the required $o(n^\\varepsilon)$ for all $\\varepsilon > 0$. This resolved a 90+ year open problem and claimed Erd\u0151s's $100 prize.",
+    "problemStatement": "Is there an explicit construction of a set A \u2286 \u2115 such that A + A = \u2115 (additive basis) but r_A(n) = o(n^\u03b5) for every \u03b5 > 0 (economical)?",
+    "text": "Is there an explicit construction of A \u2286 \u2115 such that A + A = \u2115 but r_A(n) = o(n^\u03b5) for every \u03b5 > 0? SOLVED by Jain-Pham-Sawhney-Zakharov (2024).",
+    "proofStrategy": "The formalization defines sumsets, representation functions, and the economical condition. Key comparisons: \u2115 is a basis but not economical (r(n) = n+1), Sidon sets are economical but not bases. The JPSZ construction achieves both properties with r_A(n) \u2264 exp(C\u221a(log n)).",
     "keyInsights": [
-      "**The Goldilocks Problem:** Two constraints pull in opposite directions — thick enough to be a basis ($A+A=\\mathbb{N}$) vs. thin enough to be economical ($r_A(n) = o(n^\\varepsilon)$). ℕ fails economical ($r_\\mathbb{N}(n) = n+1$); Sidon sets fail basis ($|A \\cap [1,N]| = O(\\sqrt{N})$ is too sparse). JPSZ threads the needle.",
-      "**Representation Bound:** JPSZ achieves $r_A(n) \\leq \\exp(C\\sqrt{\\log n})$, which is $o(n^\\varepsilon)$ for all $\\varepsilon > 0$ since $C\\sqrt{\\log n} < \\varepsilon \\log n$ eventually. This quantitative bound is much stronger than merely $o(n^\\varepsilon)$ — it implies, for example, $r_A(n) = O(\\log^k n)$ for any fixed $k$.",
+      "**The Goldilocks Problem:** Two constraints pull in opposite directions \u2014 thick enough to be a basis ($A+A=\\mathbb{N}$) vs. thin enough to be economical ($r_A(n) = o(n^\\varepsilon)$). \u2115 fails economical ($r_\\mathbb{N}(n) = n+1$); Sidon sets fail basis ($|A \\cap [1,N]| = O(\\sqrt{N})$ is too sparse). JPSZ threads the needle.",
+      "**Representation Bound:** JPSZ achieves $r_A(n) \\leq \\exp(C\\sqrt{\\log n})$, which is $o(n^\\varepsilon)$ for all $\\varepsilon > 0$ since $C\\sqrt{\\log n} < \\varepsilon \\log n$ eventually. This quantitative bound is much stronger than merely $o(n^\\varepsilon)$ \u2014 it implies, for example, $r_A(n) = O(\\log^k n)$ for any fixed $k$.",
       "**Sidon Sets Cannot Be Bases:** The proof (76 lines!) derives that if A is Sidon AND a basis, then $0,1,3,5 \\in A$, $2,4,6 \\notin A$, but then $6 = 1+5 = 3+3$ gives two representations, contradicting the Sidon property. This is proved in full Lean by Aristotle.",
       "**Aristotle Disproves a Theorem:** The claimed lower bound $|A \\cap [1,N]| \\geq \\sqrt{N}$ for any basis $A$ is **FALSE**. Aristotle constructed the counterexample $A = \\{0,1\\} \\cup \\{n \\geq 3\\}$ which is a basis but has $|A \\cap [1,2]| = 1 < \\sqrt{2}$ for $N=2$. The theorem remains in the file as `sorry`, illustrating how automated verification catches errors.",
-      "**Derandomization:** JPSZ's breakthrough converts Erdős's probabilistic argument into a deterministic algorithm. The key technique is finding a hash function $h : \\mathbb{N} \\to [0,1]$ such that $n \\in A \\iff h(n) \\leq p_n$ has the same coverage and sparsity properties as the random set. `ExplicitSet` in Lean formalizes this: `DecidablePred (· ∈ A)` ensures membership is algorithmically checkable.",
-      "**90 Years, $100:** From Sidon's question (1932) to JPSZ's answer (2024) — 92 years. The formalization covers the full mathematical landscape: Erdős's non-constructive proof (`erdos_probabilistic_existence`), the 2024 explicit construction (`JPSZ_set`, `JPSZ_is_basis`, `JPSZ_is_economical`), and four Lean-verified supporting theorems (`economical_equiv`, `univ_not_economical`, `squares_not_basis`, `sidon_not_basis`)."
+      "**Derandomization:** JPSZ's breakthrough converts Erd\u0151s's probabilistic argument into a deterministic algorithm. The key technique is finding a hash function $h : \\mathbb{N} \\to [0,1]$ such that $n \\in A \\iff h(n) \\leq p_n$ has the same coverage and sparsity properties as the random set. `ExplicitSet` in Lean formalizes this: `DecidablePred (\u00b7 \u2208 A)` ensures membership is algorithmically checkable.",
+      "**90 Years, $100:** From Sidon's question (1932) to JPSZ's answer (2024) \u2014 92 years. The formalization covers the full mathematical landscape: Erd\u0151s's non-constructive proof (`erdos_probabilistic_existence`), the 2024 explicit construction (`JPSZ_set`, `JPSZ_is_basis`, `JPSZ_is_economical`), and four Lean-verified supporting theorems (`economical_equiv`, `univ_not_economical`, `squares_not_basis`, `sidon_not_basis`)."
     ],
     "prerequisites": [
       "Additive bases and Waring's problem",
@@ -56,18 +56,18 @@
     {
       "id": "header",
       "title": "Problem Statement",
-      "summary": "Sidon's 1932 question to Erdős: is there an explicit $A \\subseteq \\mathbb{N}$ with $A+A=\\mathbb{N}$ and $r_A(n) = o(n^\\varepsilon)$ for all $\\varepsilon > 0$? JPSZ (2024) answered YES with explicit construction. The Aristotle header records 4 proved theorems and 1 negated theorem (`basis_size_lower_bound` is FALSE).",
+      "summary": "Sidon's 1932 question to Erd\u0151s: is there an explicit $A \\subseteq \\mathbb{N}$ with $A+A=\\mathbb{N}$ and $r_A(n) = o(n^\\varepsilon)$ for all $\\varepsilon > 0$? JPSZ (2024) answered YES with explicit construction. The Aristotle header records 4 proved theorems and 1 negated theorem (`basis_size_lower_bound` is FALSE).",
       "startLine": 1,
       "endLine": 80,
-      "mathContext": "Sidon's 1932 question to Erdős: is there an explicit $A \\subseteq \\mathbb{N}$ with $A+A=\\mathbb{N}$ and $r_A(n) = o(n^\\varepsilon)$ for all $\\varepsilon > 0$? The Aristotle header records 4 proved theorems and 1 negated theorem (`basis_size_lower_bound` is FALSE)."
+      "mathContext": "Sidon's 1932 question to Erd\u0151s: is there an explicit $A \\subseteq \\mathbb{N}$ with $A+A=\\mathbb{N}$ and $r_A(n) = o(n^\\varepsilon)$ for all $\\varepsilon > 0$? The Aristotle header records 4 proved theorems and 1 negated theorem (`basis_size_lower_bound` is FALSE)."
     },
     {
       "id": "basic-definitions",
       "title": "Sumsets and Representation",
-      "summary": "Core definitions: `Sumset A B = {a+b : a ∈ A, b ∈ B}` with notation `+ₛ`; `Doubling A = A +ₛ A`; `representationCount A n = |{(a,b) : a+b=n}|`; `orderedRepCount A n = |{(a,b) : a ≤ b, a+b=n}|`. All `noncomputable` (use `Set.ncard`).",
+      "summary": "Core definitions: `Sumset A B = {a+b : a \u2208 A, b \u2208 B}` with notation `+\u209b`; `Doubling A = A +\u209b A`; `representationCount A n = |{(a,b) : a+b=n}|`; `orderedRepCount A n = |{(a,b) : a \u2264 b, a+b=n}|`. All `noncomputable` (use `Set.ncard`).",
       "startLine": 81,
       "endLine": 98,
-      "mathContext": "Core definitions: `Sumset A B = {a+b : a ∈ A, b ∈ B}` with notation `+ₛ`; `Doubling A = A +ₛ A`; `representationCount A n = |{(a,b) : a+b=n}|`; `orderedRepCount A n = |{(a,b) : a ≤ b, a+b=n}|`. All `noncomputable` (use `Set.ncard`)."
+      "mathContext": "Core definitions: `Sumset A B = {a+b : a \u2208 A, b \u2208 B}` with notation `+\u209b`; `Doubling A = A +\u209b A`; `representationCount A n = |{(a,b) : a+b=n}|`; `orderedRepCount A n = |{(a,b) : a \u2264 b, a+b=n}|`. All `noncomputable` (use `Set.ncard`)."
     },
     {
       "id": "additive-basis",
@@ -80,26 +80,26 @@
     {
       "id": "economical-condition",
       "title": "The Economical Condition",
-      "summary": "`IsEconomical A`: $\\forall \\varepsilon > 0$, `Tendsto (r_A(n)/n^ε) atTop (nhds 0)`; `IsEconomical'`: $\\forall \\varepsilon, C > 0, \\exists N_0 : r_A(n) < C \\cdot n^\\varepsilon$ for $n \\geq N_0$. `economical_equiv : IsEconomical ↔ IsEconomical'` (Aristotle-proved via filter limit theory).",
+      "summary": "`IsEconomical A`: $\\forall \\varepsilon > 0$, `Tendsto (r_A(n)/n^\u03b5) atTop (nhds 0)`; `IsEconomical'`: $\\forall \\varepsilon, C > 0, \\exists N_0 : r_A(n) < C \\cdot n^\\varepsilon$ for $n \\geq N_0$. `economical_equiv : IsEconomical \u2194 IsEconomical'` (Aristotle-proved via filter limit theory).",
       "startLine": 118,
       "endLine": 150,
-      "mathContext": "`IsEconomical A`: $\\forall \\varepsilon > 0$, `Tendsto (r_A(n)/n^ε) atTop (nhds 0)`; `IsEconomical'`: $\\forall \\varepsilon, C > 0, \\exists N_0 : r_A(n) < C \\cdot n^\\varepsilon$ for $n \\geq N_0$."
+      "mathContext": "`IsEconomical A`: $\\forall \\varepsilon > 0$, `Tendsto (r_A(n)/n^\u03b5) atTop (nhds 0)`; `IsEconomical'`: $\\forall \\varepsilon, C > 0, \\exists N_0 : r_A(n) < C \\cdot n^\\varepsilon$ for $n \\geq N_0$."
     },
     {
       "id": "probabilistic-existence",
-      "title": "Erdős's Probabilistic Existence",
-      "summary": "`Erdos29Statement`: $\\exists A$, basis and economical. `axiom erdos_probabilistic_existence`: proved by Erdős's probabilistic method (include $n \\in A$ with prob $n^{-1/2+o(1)}$). Axiom because Aristotle failed to load it.",
+      "title": "Erd\u0151s's Probabilistic Existence",
+      "summary": "`Erdos29Statement`: $\\exists A$, basis and economical. `axiom erdos_probabilistic_existence`: proved by Erd\u0151s's probabilistic method (include $n \\in A$ with prob $n^{-1/2+o(1)}$). Axiom because Aristotle failed to load it.",
       "startLine": 151,
       "endLine": 159,
-      "mathContext": "`Erdos29Statement`: $\\exists A$, basis and economical. `axiom erdos_probabilistic_existence`: proved by Erdős's probabilistic method (include $n \\in A$ with prob $n^{-1/2+o(1)}$). Axiom because Aristotle failed to load it."
+      "mathContext": "`Erdos29Statement`: $\\exists A$, basis and economical. `axiom erdos_probabilistic_existence`: proved by Erd\u0151s's probabilistic method (include $n \\in A$ with prob $n^{-1/2+o(1)}$). Axiom because Aristotle failed to load it."
     },
     {
       "id": "jpsz-construction",
       "title": "JPSZ Explicit Construction (2024)",
-      "summary": "`axiom JPSZ_set : Set ℕ` (computable), `JPSZ_is_basis`, `JPSZ_is_economical`; `erdos_29_solved : Erdos29Statement` (Lean-proved as `⟨JPSZ_set, JPSZ_is_basis, JPSZ_is_economical⟩`). Properties: density 0, $r_A(n) \\leq \\exp(C\\sqrt{\\log n})$.",
+      "summary": "`axiom JPSZ_set : Set \u2115` (computable), `JPSZ_is_basis`, `JPSZ_is_economical`; `erdos_29_solved : Erdos29Statement` (Lean-proved as `\u27e8JPSZ_set, JPSZ_is_basis, JPSZ_is_economical\u27e9`). Properties: density 0, $r_A(n) \\leq \\exp(C\\sqrt{\\log n})$.",
       "startLine": 160,
       "endLine": 204,
-      "mathContext": "`axiom JPSZ_set : Set ℕ` (computable), `JPSZ_is_basis`, `JPSZ_is_economical`; `erdos_29_solved : Erdos29Statement` (Lean-proved as `⟨JPSZ_set, JPSZ_is_basis, JPSZ_is_economical⟩`). Properties: density 0, $r_A(n) \\leq \\exp(C\\sqrt{\\log n})$."
+      "mathContext": "`axiom JPSZ_set : Set \u2115` (computable), `JPSZ_is_basis`, `JPSZ_is_economical`; `erdos_29_solved : Erdos29Statement` (Lean-proved as `\u27e8JPSZ_set, JPSZ_is_basis, JPSZ_is_economical\u27e9`). Properties: density 0, $r_A(n) \\leq \\exp(C\\sqrt{\\log n})$."
     },
     {
       "id": "comparisons",
@@ -112,39 +112,39 @@
     {
       "id": "sidon-sets",
       "title": "Sidon Sets Cannot Be Bases",
-      "summary": "`IsSidon A`: `orderedRepCount A n ≤ 1`. `sidon_not_basis`: 76-line Lean proof that $0,1,3,5 \\in A$ and $2,4,6 \\notin A$ must hold, but $6 = 1+5 = 3+3$ gives `orderedRepCount A 6 ≥ 2` — contradiction. Aristotle-verified. Sidon sets have $|A \\cap [1,N]| = O(\\sqrt{N})$, too sparse for a basis.",
+      "summary": "`IsSidon A`: `orderedRepCount A n \u2264 1`. `sidon_not_basis`: 76-line Lean proof that $0,1,3,5 \\in A$ and $2,4,6 \\notin A$ must hold, but $6 = 1+5 = 3+3$ gives `orderedRepCount A 6 \u2265 2` \u2014 contradiction. Aristotle-verified. Sidon sets have $|A \\cap [1,N]| = O(\\sqrt{N})$, too sparse for a basis.",
       "startLine": 246,
       "endLine": 323,
-      "mathContext": "`sidon_not_basis`: 76-line Lean proof that $0,1,3,5 \\in A$ and $2,4,6 \\notin A$ must hold, but $6 = 1+5 = 3+3$ gives `orderedRepCount A 6 ≥ 2` — contradiction. Sidon sets have $|A \\cap [1,N]| = O(\\sqrt{N})$, too sparse for a basis."
+      "mathContext": "`sidon_not_basis`: 76-line Lean proof that $0,1,3,5 \\in A$ and $2,4,6 \\notin A$ must hold, but $6 = 1+5 = 3+3$ gives `orderedRepCount A 6 \u2265 2` \u2014 contradiction. Sidon sets have $|A \\cap [1,N]| = O(\\sqrt{N})$, too sparse for a basis."
     },
     {
       "id": "explicit-class",
       "title": "Explicit vs Probabilistic",
-      "summary": "`class ExplicitSet (A : Set ℕ)` with `membership_decidable : DecidablePred (· ∈ A)`. `JPSZ_explicit : ExplicitSet JPSZ_set`. Erdős's proof: $\\exists A$ (no algorithm). JPSZ: here is $A$ with computable membership — key distinction formalizing 'constructive'.",
+      "summary": "`class ExplicitSet (A : Set \u2115)` with `membership_decidable : DecidablePred (\u00b7 \u2208 A)`. `JPSZ_explicit : ExplicitSet JPSZ_set`. Erd\u0151s's proof: $\\exists A$ (no algorithm). JPSZ: here is $A$ with computable membership \u2014 key distinction formalizing 'constructive'.",
       "startLine": 329,
       "endLine": 357,
-      "mathContext": "Erdős's proof: $\\exists A$ (no algorithm). JPSZ: here is $A$ with computable membership — key distinction formalizing 'constructive'."
+      "mathContext": "Erd\u0151s's proof: $\\exists A$ (no algorithm). JPSZ: here is $A$ with computable membership \u2014 key distinction formalizing 'constructive'."
     },
     {
       "id": "lower-bounds",
       "title": "Size Lower Bounds",
-      "summary": "`basis_size_lower_bound` (claimed: $|A \\cap [1,N]| \\geq \\sqrt{N}$) is **FALSE** — Aristotle built counterexample `CounterexampleA = {0,1} ∪ {n ≥ 3}`, a basis with $|A \\cap [1,2]| = 1 < \\sqrt{2}$ for $N=2$. Theorem remains as `sorry`. `JPSZ_size_optimal`: $|\\text{JPSZ} \\cap [1,N]| \\leq C\\sqrt{N \\log N}$.",
+      "summary": "`basis_size_lower_bound` (claimed: $|A \\cap [1,N]| \\geq \\sqrt{N}$) is **FALSE** \u2014 Aristotle built counterexample `CounterexampleA = {0,1} \u222a {n \u2265 3}`, a basis with $|A \\cap [1,2]| = 1 < \\sqrt{2}$ for $N=2$. Theorem remains as `sorry`. `JPSZ_size_optimal`: $|\\text{JPSZ} \\cap [1,N]| \\leq C\\sqrt{N \\log N}$.",
       "startLine": 358,
       "endLine": 422,
-      "mathContext": "`basis_size_lower_bound` (claimed: $|A \\cap [1,N]| \\geq \\sqrt{N}$) is **FALSE** — Aristotle built counterexample `CounterexampleA = {0,1} ∪ {n ≥ 3}`, a basis with $|A \\cap [1,2]| = 1 < \\sqrt{2}$ for $N=2$. Theorem remains as `sorry`. `JPSZ_size_optimal`: $|\\text{JPSZ} \\cap [1,N]| \\leq C\\sqrt{N \\log N}$."
+      "mathContext": "`basis_size_lower_bound` (claimed: $|A \\cap [1,N]| \\geq \\sqrt{N}$) is **FALSE** \u2014 Aristotle built counterexample `CounterexampleA = {0,1} \u222a {n \u2265 3}`, a basis with $|A \\cap [1,2]| = 1 < \\sqrt{2}$ for $N=2$. Theorem remains as `sorry`. `JPSZ_size_optimal`: $|\\text{JPSZ} \\cap [1,N]| \\leq C\\sqrt{N \\log N}$."
     },
     {
       "id": "summary",
       "title": "Summary",
-      "summary": "1932: Sidon asks; ~1950s: Erdős proves existence; 2024: JPSZ explicit construction. JPSZ properties: `ExplicitSet`, $A+A=\\mathbb{N}$, $r_A(n) \\leq \\exp(C\\sqrt{\\log n})$, $|A \\cap [1,N]| \\leq C\\sqrt{N \\log N}$. Verified theorems: 4 Aristotle-proved, 1 Aristotle-negated (false lower bound).",
+      "summary": "1932: Sidon asks; ~1950s: Erd\u0151s proves existence; 2024: JPSZ explicit construction. JPSZ properties: `ExplicitSet`, $A+A=\\mathbb{N}$, $r_A(n) \\leq \\exp(C\\sqrt{\\log n})$, $|A \\cap [1,N]| \\leq C\\sqrt{N \\log N}$. Verified theorems: 4 Aristotle-proved, 1 Aristotle-negated (false lower bound).",
       "startLine": 423,
       "endLine": 454,
-      "mathContext": "1932: Sidon asks; ~1950s: Erdős proves existence; 2024: JPSZ explicit construction. JPSZ properties: `ExplicitSet`, $A+A=\\mathbb{N}$, $r_A(n) \\leq \\exp(C\\sqrt{\\log n})$, $|A \\cap [1,N]| \\leq C\\sqrt{N \\log N}$. Verified theorems: 4 Aristotle-proved, 1 Aristotle-negated (false lower bound)."
+      "mathContext": "1932: Sidon asks; ~1950s: Erd\u0151s proves existence; 2024: JPSZ explicit construction. JPSZ properties: `ExplicitSet`, $A+A=\\mathbb{N}$, $r_A(n) \\leq \\exp(C\\sqrt{\\log n})$, $|A \\cap [1,N]| \\leq C\\sqrt{N \\log N}$. Verified theorems: 4 Aristotle-proved, 1 Aristotle-negated (false lower bound)."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #29 is SOLVED. Jain-Pham-Sawhney-Zakharov (2024) gave the first explicit economical additive basis after 90+ years. The formalization includes verified proofs that ℕ is not economical, squares are not a basis, and Sidon sets cannot be bases.",
-    "implications": "Transforms Erdős's probabilistic existence proof into a constructive algorithm. Demonstrates the power of modern combinatorics to resolve long-standing problems explicitly.",
+    "summary": "Erd\u0151s Problem #29 is SOLVED. Jain-Pham-Sawhney-Zakharov (2024) gave the first explicit economical additive basis after 90+ years. The formalization includes verified proofs that \u2115 is not economical, squares are not a basis, and Sidon sets cannot be bases.",
+    "implications": "Transforms Erd\u0151s's probabilistic existence proof into a constructive algorithm. Demonstrates the power of modern combinatorics to resolve long-standing problems explicitly.",
     "openQuestions": [
       "The JPSZ axioms (`JPSZ_set`, `JPSZ_is_basis`, `JPSZ_is_economical`) fail to load in Aristotle due to `harmonicSorry` axioms. Can the JPSZ construction be formalized in Lean WITHOUT axioms, using Mathlib's existing library for hash functions, pseudorandomness, or derandomization?",
       "The `basis_size_lower_bound` theorem is FALSE as stated (Aristotle found the counterexample $A = \\{0,1\\} \\cup \\{n \\geq 3\\}$). The correct statement involves asymptotics: $|A \\cap [1,N]| \\geq (\\frac{1}{2} - o(1))\\sqrt{N}$ for large N. Can this corrected version be proved in Lean using the `Filter.Tendsto` machinery already used for `IsEconomical`?",
@@ -171,7 +171,7 @@
       "Filter"
     ],
     "namespace": "Erdos29",
-    "lineCount": 523,
+    "lineCount": 524,
     "axiomCount": 5,
     "theoremCount": 12,
     "definitionCount": 12,
@@ -182,7 +182,7 @@
     {
       "targetId": "erdos-28",
       "relationship": "related",
-      "description": "Problem #28 asks about representation functions of bases. Problem #29 asks for explicit economical bases — both concern the fundamental structure of additive bases of order 2"
+      "description": "Problem #28 asks about representation functions of bases. Problem #29 asks for explicit economical bases \u2014 both concern the fundamental structure of additive bases of order 2"
     },
     {
       "targetId": "erdos-35",
@@ -193,9 +193,9 @@
   "references": [
     {
       "authors": "Schnirelmann, Lev G.",
-      "title": "Über additive Eigenschaften von Zahlen",
+      "title": "\u00dcber additive Eigenschaften von Zahlen",
       "year": "1933",
-      "venue": "Mathematische Annalen, vol. 107, pp. 649–690",
+      "venue": "Mathematische Annalen, vol. 107, pp. 649\u2013690",
       "note": "Proved every set with positive Schnirelmann density is an additive basis, motivating the search for explicit thin bases"
     },
     {

--- a/src/data/proofs/erdos-299/meta.json
+++ b/src/data/proofs/erdos-299/meta.json
@@ -1,6 +1,6 @@
 {
   "id": "erdos-299",
-  "title": "Erdős Problem #299: Bounded Gap Sequences and Unit Fractions",
+  "title": "Erd\u0151s Problem #299: Bounded Gap Sequences and Unit Fractions",
   "slug": "erdos-299",
   "description": "Is there an infinite sequence with bounded gaps such that no finite sum of reciprocals equals 1? The answer is NO, as proved by Bloom (2021).",
   "meta": {
@@ -58,16 +58,16 @@
     "assumptions": "1 axiom (bloom_theorem: Bloom's 2021 result on positive density sets). 0 sorries."
   },
   "overview": {
-    "historicalContext": "Erdős Problem #299 asks whether there exists an infinite sequence a₁ < a₂ < ... with bounded gaps (a_{i+1} - a_i = O(1)) such that no finite subset has reciprocals summing to exactly 1.\n\nThis question connects to the ancient study of Egyptian fractions (representing 1 as sums of distinct unit fractions) and modern density arguments. The key insight is that sequences with bounded gaps have positive density.\n\nThe problem was resolved by Thomas Bloom in 2021, who proved the stronger result (Problem #298) that any set of positive upper density contains a finite subset whose reciprocals sum to 1. Since bounded-gap sequences necessarily have positive density, no such sequence can avoid containing a unit fraction sum.\n\nBloom's work built on deep techniques from additive combinatorics and resolved a long-standing conjecture of Erdős and Graham.",
+    "historicalContext": "Erd\u0151s Problem #299 asks whether there exists an infinite sequence a\u2081 < a\u2082 < ... with bounded gaps (a_{i+1} - a_i = O(1)) such that no finite subset has reciprocals summing to exactly 1.\n\nThis question connects to the ancient study of Egyptian fractions (representing 1 as sums of distinct unit fractions) and modern density arguments. The key insight is that sequences with bounded gaps have positive density.\n\nThe problem was resolved by Thomas Bloom in 2021, who proved the stronger result (Problem #298) that any set of positive upper density contains a finite subset whose reciprocals sum to 1. Since bounded-gap sequences necessarily have positive density, no such sequence can avoid containing a unit fraction sum.\n\nBloom's work built on deep techniques from additive combinatorics and resolved a long-standing conjecture of Erd\u0151s and Graham.",
     "problemStatement": "Is there an infinite sequence $a_1 < a_2 < \\cdots$ such that:\n1. $a_{i+1} - a_i = O(1)$ (bounded gaps)\n2. No finite sum $\\frac{1}{a_{i_1}} + \\frac{1}{a_{i_2}} + \\cdots + \\frac{1}{a_{i_k}} = 1$\n\n**Answer**: NO. Such a sequence does not exist.\n\n**Proof**: Bounded-gap sequences have positive density. By Bloom's theorem (Problem #298), any set of positive upper density contains a finite subset whose reciprocals sum to 1. Therefore, bounded-gap sequences must contain unit fraction sums.",
     "text": "Is there an infinite sequence with bounded gaps such that no finite sum of reciprocals equals 1? The answer is NO, as proved by Bloom (2021).",
     "proofStrategy": "The proof has two main steps:\n\n1. **Bounded gaps imply positive density**: If a strictly increasing sequence has gaps bounded by C, then approximately N/C elements are below N, giving density at least 1/C.\n\n2. **Positive density implies unit fraction sum**: Bloom's theorem (2021) shows that any set of positive upper density contains a finite subset with reciprocals summing to 1.\n\nWe formalize Bloom's theorem as an axiom since its full proof requires sophisticated techniques from additive combinatorics beyond current Mathlib. We verify concrete examples of Egyptian fractions and prove structural properties of bounded-gap sequences.",
     "keyInsights": [
       "**Egyptian fractions**: Sums of distinct unit fractions equaling 1, like 1/2 + 1/3 + 1/6 = 1. The ancient Egyptians used only such fractions.",
-      "**Bounded gaps and density**: A sequence with gaps ≤ C has density at least 1/C, since it contains roughly N/C elements below N.",
-      "**Bloom's breakthrough**: The 2021 result showing positive density sets contain unit fraction sums resolved a 50+ year old Erdős-Graham conjecture.",
+      "**Bounded gaps and density**: A sequence with gaps \u2264 C has density at least 1/C, since it contains roughly N/C elements below N.",
+      "**Bloom's breakthrough**: The 2021 result showing positive density sets contain unit fraction sums resolved a 50+ year old Erd\u0151s-Graham conjecture.",
       "**Contrast with sparse sequences**: Powers of 2 have unbounded gaps and their reciprocals sum to less than 1 (geometric series). Bounded gaps prevent such avoidance.",
-      "**Greedy algorithm connection**: The greedy algorithm for Egyptian fractions (Sylvester 1880) always terminates, but finding a subset of a given sequence summing to 1 is computationally harder — the bounded-gap condition provides the structural guarantee that such subsets must exist"
+      "**Greedy algorithm connection**: The greedy algorithm for Egyptian fractions (Sylvester 1880) always terminates, but finding a subset of a given sequence summing to 1 is computationally harder \u2014 the bounded-gap condition provides the structural guarantee that such subsets must exist"
     ],
     "prerequisites": [
       "Combinatorics and number theory",
@@ -143,8 +143,8 @@
     }
   ],
   "conclusion": {
-    "summary": "We formalize Erdős Problem #299, proving that no infinite sequence with bounded gaps can avoid containing a finite subset whose reciprocals sum to 1. The proof relies on Bloom's 2021 theorem connecting positive density to Egyptian fractions.",
-    "implications": "**Theoretical Significance**: This result has implications for:\n\n1. **Egyptian fractions**: Shows unit fraction representations of 1 are unavoidable in dense sequences\n\n**2. Density and structure**: Demonstrates how density conditions force arithmetic structure\n\n3. **Additive combinatorics**: Connects classical Erdős problems to modern techniques.",
+    "summary": "We formalize Erd\u0151s Problem #299, proving that no infinite sequence with bounded gaps can avoid containing a finite subset whose reciprocals sum to 1. The proof relies on Bloom's 2021 theorem connecting positive density to Egyptian fractions.",
+    "implications": "**Theoretical Significance**: This result has implications for:\n\n1. **Egyptian fractions**: Shows unit fraction representations of 1 are unavoidable in dense sequences\n\n**2. Density and structure**: Demonstrates how density conditions force arithmetic structure\n\n3. **Additive combinatorics**: Connects classical Erd\u0151s problems to modern techniques.",
     "openQuestions": [
       "What is the minimum density required to guarantee a unit fraction sum?",
       "Can we compute explicit bounds on the size of the subset needed?",
@@ -170,7 +170,7 @@
       "Finset"
     ],
     "namespace": "Erdos299",
-    "lineCount": 386,
+    "lineCount": 387,
     "axiomCount": 1,
     "theoremCount": 10,
     "definitionCount": 7,
@@ -181,17 +181,17 @@
     {
       "targetId": "erdos-298",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: additive-combinatorics, density, egyptian-fractions, number-theory, unit-fractions"
+      "description": "Related Erd\u0151s problem sharing themes: additive-combinatorics, density, egyptian-fractions, number-theory, unit-fractions"
     },
     {
       "targetId": "erdos-292",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: density, egyptian-fractions, number-theory, unit-fractions"
+      "description": "Related Erd\u0151s problem sharing themes: density, egyptian-fractions, number-theory, unit-fractions"
     },
     {
       "targetId": "erdos-310",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: density, egyptian-fractions, number-theory, unit-fractions"
+      "description": "Related Erd\u0151s problem sharing themes: density, egyptian-fractions, number-theory, unit-fractions"
     }
   ],
   "sorries": 0

--- a/src/data/proofs/erdos-303/meta.json
+++ b/src/data/proofs/erdos-303/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-303",
-  "title": "Erdős Problem #303: Monochromatic Unit Fraction Solutions",
+  "title": "Erd\u0151s Problem #303: Monochromatic Unit Fraction Solutions",
   "slug": "erdos-303",
-  "description": "In any finite colouring of the integers, does there exist a monochromatic solution to 1/a = 1/b + 1/c with distinct a, b, c? A Ramsey-theoretic problem solved affirmatively by Brown and Rödl (1991).",
+  "description": "In any finite colouring of the integers, does there exist a monochromatic solution to 1/a = 1/b + 1/c with distinct a, b, c? A Ramsey-theoretic problem solved affirmatively by Brown and R\u00f6dl (1991).",
   "meta": {
-    "author": "Brown and Rödl (1991)",
+    "author": "Brown and R\u00f6dl (1991)",
     "sourceUrl": "https://erdosproblems.com/303",
     "date": "1991",
     "status": "axiomatized",
@@ -48,25 +48,25 @@
       "Formal definition of unit fraction equation",
       "Equivalence with algebraic form bc = a(b+c)",
       "Definition of finite colouring and monochromaticity",
-      "Brown-Rödl theorem as axiom",
+      "Brown-R\u00f6dl theorem as axiom",
       "Verified examples: 1/2=1/3+1/6, 1/3=1/4+1/12, etc.",
       "Infinite family of solutions: 1/n = 1/(n+1) + 1/(n(n+1))",
-      "Connection to density version (Erdős #302)"
+      "Connection to density version (Erd\u0151s #302)"
     ],
     "axiomCount": 2,
     "lineCount": 258,
     "assumptions": "2 axioms: brownRodl_theorem, erdos303_true. See Lean source for complete statements."
   },
   "overview": {
-    "historicalContext": "This problem combines Ramsey theory with the arithmetic of unit fractions. The equation 1/a = 1/b + 1/c, also known as the 'Egyptian fraction equation' (since Egyptians preferred writing fractions as sums of unit fractions), has been studied since antiquity.\n\nErdős asked whether any finite colouring of the integers must contain three integers of the same colour satisfying this equation. This is a Ramsey-theoretic question: no matter how you partition the integers into finitely many classes, some class contains a 'pattern' (here, a unit fraction triple).\n\nBrown and Rödl proved the affirmative answer in 1991 using Ramsey-theoretic techniques. The related density version (Erdős #302) asks whether sets of positive density contain such solutions.",
-    "problemStatement": "**Problem (Erdős)**: Is it true that in any finite colouring of the integers there exists a monochromatic solution to\n$$\\frac{1}{a} = \\frac{1}{b} + \\frac{1}{c}$$\nwith distinct $a, b, c$?\n\n**Answer**: YES\n\n**Proved by**: Brown and Rödl (1991)",
-    "text": "In any finite colouring of the integers, does there exist a monochromatic solution to 1/a = 1/b + 1/c with distinct a, b, c? A Ramsey-theoretic problem solved affirmatively by Brown and Rödl (1991).",
-    "proofStrategy": "We formalize the problem and the solution:\n\n1. **Unit Fraction Equation**: Define UnitFractionEq a b c as (1/a : ℝ) = 1/b + 1/c. Prove equivalence with the algebraic form bc = a(b+c).\n\n2. **Verified Examples**: Prove concrete instances like 1/2 = 1/3 + 1/6 and 1/3 = 1/4 + 1/12 using norm_num.\n\n3. **Colourings**: Define IsFiniteColouring and Monochromatic. Prove two equivalent definitions of monochromaticity.\n\n4. **Main Theorem**: State Brown-Rödl's theorem as an axiom: in any finite colouring, a monochromatic valid solution exists.\n\n5. **Infinite Solutions**: Prove infinitely many solutions exist of the form 1/n = 1/(n+1) + 1/(n(n+1)).",
+    "historicalContext": "This problem combines Ramsey theory with the arithmetic of unit fractions. The equation 1/a = 1/b + 1/c, also known as the 'Egyptian fraction equation' (since Egyptians preferred writing fractions as sums of unit fractions), has been studied since antiquity.\n\nErd\u0151s asked whether any finite colouring of the integers must contain three integers of the same colour satisfying this equation. This is a Ramsey-theoretic question: no matter how you partition the integers into finitely many classes, some class contains a 'pattern' (here, a unit fraction triple).\n\nBrown and R\u00f6dl proved the affirmative answer in 1991 using Ramsey-theoretic techniques. The related density version (Erd\u0151s #302) asks whether sets of positive density contain such solutions.",
+    "problemStatement": "**Problem (Erd\u0151s)**: Is it true that in any finite colouring of the integers there exists a monochromatic solution to\n$$\\frac{1}{a} = \\frac{1}{b} + \\frac{1}{c}$$\nwith distinct $a, b, c$?\n\n**Answer**: YES\n\n**Proved by**: Brown and R\u00f6dl (1991)",
+    "text": "In any finite colouring of the integers, does there exist a monochromatic solution to 1/a = 1/b + 1/c with distinct a, b, c? A Ramsey-theoretic problem solved affirmatively by Brown and R\u00f6dl (1991).",
+    "proofStrategy": "We formalize the problem and the solution:\n\n1. **Unit Fraction Equation**: Define UnitFractionEq a b c as (1/a : \u211d) = 1/b + 1/c. Prove equivalence with the algebraic form bc = a(b+c).\n\n2. **Verified Examples**: Prove concrete instances like 1/2 = 1/3 + 1/6 and 1/3 = 1/4 + 1/12 using norm_num.\n\n3. **Colourings**: Define IsFiniteColouring and Monochromatic. Prove two equivalent definitions of monochromaticity.\n\n4. **Main Theorem**: State Brown-R\u00f6dl's theorem as an axiom: in any finite colouring, a monochromatic valid solution exists.\n\n5. **Infinite Solutions**: Prove infinitely many solutions exist of the form 1/n = 1/(n+1) + 1/(n(n+1)).",
     "keyInsights": [
-      "**Unit fraction identity**: 1/n = 1/(n+1) + 1/(n(n+1)) for all n ≥ 2, providing infinitely many solutions.",
+      "**Unit fraction identity**: 1/n = 1/(n+1) + 1/(n(n+1)) for all n \u2265 2, providing infinitely many solutions.",
       "**Algebraic reformulation**: 1/a = 1/b + 1/c is equivalent to bc = a(b+c), avoiding division.",
-      "**Ramsey principle**: No matter how you colour ℤ with finitely many colours, some colour class contains a unit fraction triple.",
-      "**Density connection**: The colouring version (this problem) is the Ramsey analog of the density version (Erdős #302).",
+      "**Ramsey principle**: No matter how you colour \u2124 with finitely many colours, some colour class contains a unit fraction triple.",
+      "**Density connection**: The colouring version (this problem) is the Ramsey analog of the density version (Erd\u0151s #302).",
       "**Computable witnesses**: The identity 1/n = 1/(n+1) + 1/(n(n+1)) is verified by native_decide for specific n, showing that formalized number theory can produce machine-checkable computational certificates alongside abstract theorems"
     ],
     "prerequisites": [
@@ -106,7 +106,7 @@
     },
     {
       "id": "theorem",
-      "title": "Brown-Rödl Theorem (SOLVED)",
+      "title": "Brown-R\u00f6dl Theorem (SOLVED)",
       "startLine": 108,
       "endLine": 139,
       "summary": "The main result as an axiom"
@@ -123,15 +123,15 @@
       "title": "Connection to Density Version",
       "startLine": 190,
       "endLine": 259,
-      "summary": "Relation to Erdős #302 and the general pattern"
+      "summary": "Relation to Erd\u0151s #302 and the general pattern"
     }
   ],
   "conclusion": {
-    "summary": "We formalize Erdős Problem #303, which asks whether any finite colouring of the integers contains a monochromatic solution to 1/a = 1/b + 1/c. Brown and Rödl proved this affirmatively in 1991. We define the unit fraction equation, prove concrete examples, and state the main theorem as an axiom along with the infinite family 1/n = 1/(n+1) + 1/(n(n+1)).",
+    "summary": "We formalize Erd\u0151s Problem #303, which asks whether any finite colouring of the integers contains a monochromatic solution to 1/a = 1/b + 1/c. Brown and R\u00f6dl proved this affirmatively in 1991. We define the unit fraction equation, prove concrete examples, and state the main theorem as an axiom along with the infinite family 1/n = 1/(n+1) + 1/(n(n+1)).",
     "implications": "This result shows that the unit fraction equation is 'unavoidable' under any finite colouring, a strong Ramsey-theoretic property. It connects to broader questions about which equations have this property (partition regularity).",
     "openQuestions": [
       "What is the minimum number of colours needed for no monochromatic solution?",
-      "Does the density version (Erdős #302) also hold?",
+      "Does the density version (Erd\u0151s #302) also hold?",
       "Which other Diophantine equations are partition regular?",
       "Can the proof be made constructive with explicit bounds?"
     ]
@@ -144,7 +144,7 @@
       "Set"
     ],
     "namespace": "Erdos303",
-    "lineCount": 258,
+    "lineCount": 259,
     "axiomCount": 2,
     "theoremCount": 8,
     "definitionCount": 8,
@@ -155,17 +155,17 @@
     {
       "targetId": "erdos-46",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: colouring, number-theory, ramsey-theory, unit-fractions"
+      "description": "Related Erd\u0151s problem sharing themes: colouring, number-theory, ramsey-theory, unit-fractions"
     },
     {
       "targetId": "erdos-148",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: number-theory, unit-fractions"
+      "description": "Related Erd\u0151s problem sharing themes: number-theory, unit-fractions"
     },
     {
       "targetId": "erdos-242",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: number-theory, unit-fractions"
+      "description": "Related Erd\u0151s problem sharing themes: number-theory, unit-fractions"
     }
   ],
   "sorries": 0

--- a/src/data/proofs/erdos-355/meta.json
+++ b/src/data/proofs/erdos-355/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-355",
-  "title": "Erdős Problem #355: Lacunary Sequences and Rational Representation",
+  "title": "Erd\u0151s Problem #355: Lacunary Sequences and Rational Representation",
   "slug": "erdos-355",
-  "description": "Can a lacunary sequence's reciprocal sums cover all rationals in an open interval? YES for lacunarity constant in (1,2), proved by van Doorn and Kovač (2025).",
+  "description": "Can a lacunary sequence's reciprocal sums cover all rationals in an open interval? YES for lacunarity constant in (1,2), proved by van Doorn and Kova\u010d (2025).",
   "meta": {
-    "author": "van Doorn and Kovač (2025)",
+    "author": "van Doorn and Kova\u010d (2025)",
     "sourceUrl": "https://erdosproblems.com/355",
     "date": "2025",
     "status": "axiomatized",
@@ -44,24 +44,24 @@
       "Definition of IsLacunaryWith capturing the ratio condition",
       "Definition of ReciprocalSums for achievable sums from a sequence",
       "Proof that powers of 2 form a lacunary sequence with ratio 2",
-      "Formalization of van Doorn-Kovač theorem as axiom",
-      "Fibonacci-like sequence example with ratio approximately φ"
+      "Formalization of van Doorn-Kova\u010d theorem as axiom",
+      "Fibonacci-like sequence example with ratio approximately \u03c6"
     ],
     "axiomCount": 2,
     "lineCount": 391,
     "assumptions": "2 axiom(s) and 0 sorry(s). See the Lean source for details."
   },
   "overview": {
-    "historicalContext": "Erdős Problem #355 asks whether a lacunary sequence (where consecutive terms have ratio at least λ > 1) can have its finite reciprocal sums cover all rationals in some open interval.\n\nBleicher and Erdős originally conjectured the answer was NO [BlEr76, p.167]. They reasoned that sparse sequences like powers of 2 have reciprocal sums that form a discrete set (dyadic rationals), unable to fill any interval.\n\nThe problem was resolved in 2025 by van Doorn and Kovač, who proved that for any lacunarity constant λ ∈ (1, 2), there exist sequences whose reciprocal sums do cover all rationals in an interval. Crucially, λ = 2 is the sharp boundary: powers of 2 (λ = 2) cannot achieve this, but any λ < 2 suffices.\n\nThe proof constructs explicit sequences that balance being sparse enough to be lacunary while having enough 'overlap' between levels to achieve density in reciprocal sums.",
-    "problemStatement": "Is there a **lacunary sequence** $A \\subseteq \\mathbb{N}$ (where $A = \\{a_1 < a_2 < \\cdots\\}$ and there exists $\\lambda > 1$ such that $a_{n+1}/a_n \\geq \\lambda$ for all $n$) such that\n$$\\left\\{ \\sum_{a \\in A'} \\frac{1}{a} : A' \\subseteq A \\text{ finite} \\right\\}$$\ncontains all rationals in some open interval?\n\n**Answer**: YES, for any $\\lambda \\in (1, 2)$, though not for $\\lambda = 2$.\n\n**Proof**: van Doorn and Kovač [DoKo25] constructed explicit lacunary sequences achieving this property.",
-    "text": "Can a lacunary sequence's reciprocal sums cover all rationals in an open interval? YES for lacunarity constant in (1,2), proved by van Doorn and Kovač (2025).",
-    "proofStrategy": "We formalize the problem by defining:\n\n1. **IsLacunaryWith**: A sequence is lacunary with parameter λ if a_{n+1}/a_n ≥ λ for all n\n2. **ReciprocalSums**: The set of all finite reciprocal sums from a sequence\n3. **RepresentsRationalsIn**: The property that all rationals in an interval are achievable\n\nThe main result (van Doorn-Kovač theorem) is stated as an axiom since its proof requires sophisticated constructions beyond current Mathlib.\n\nWe prove that powers of 2 form a lacunary sequence with λ = 2, illustrating the boundary case. For λ < 2, the van Doorn-Kovač theorem guarantees existence of suitable sequences.",
+    "historicalContext": "Erd\u0151s Problem #355 asks whether a lacunary sequence (where consecutive terms have ratio at least \u03bb > 1) can have its finite reciprocal sums cover all rationals in some open interval.\n\nBleicher and Erd\u0151s originally conjectured the answer was NO [BlEr76, p.167]. They reasoned that sparse sequences like powers of 2 have reciprocal sums that form a discrete set (dyadic rationals), unable to fill any interval.\n\nThe problem was resolved in 2025 by van Doorn and Kova\u010d, who proved that for any lacunarity constant \u03bb \u2208 (1, 2), there exist sequences whose reciprocal sums do cover all rationals in an interval. Crucially, \u03bb = 2 is the sharp boundary: powers of 2 (\u03bb = 2) cannot achieve this, but any \u03bb < 2 suffices.\n\nThe proof constructs explicit sequences that balance being sparse enough to be lacunary while having enough 'overlap' between levels to achieve density in reciprocal sums.",
+    "problemStatement": "Is there a **lacunary sequence** $A \\subseteq \\mathbb{N}$ (where $A = \\{a_1 < a_2 < \\cdots\\}$ and there exists $\\lambda > 1$ such that $a_{n+1}/a_n \\geq \\lambda$ for all $n$) such that\n$$\\left\\{ \\sum_{a \\in A'} \\frac{1}{a} : A' \\subseteq A \\text{ finite} \\right\\}$$\ncontains all rationals in some open interval?\n\n**Answer**: YES, for any $\\lambda \\in (1, 2)$, though not for $\\lambda = 2$.\n\n**Proof**: van Doorn and Kova\u010d [DoKo25] constructed explicit lacunary sequences achieving this property.",
+    "text": "Can a lacunary sequence's reciprocal sums cover all rationals in an open interval? YES for lacunarity constant in (1,2), proved by van Doorn and Kova\u010d (2025).",
+    "proofStrategy": "We formalize the problem by defining:\n\n1. **IsLacunaryWith**: A sequence is lacunary with parameter \u03bb if a_{n+1}/a_n \u2265 \u03bb for all n\n2. **ReciprocalSums**: The set of all finite reciprocal sums from a sequence\n3. **RepresentsRationalsIn**: The property that all rationals in an interval are achievable\n\nThe main result (van Doorn-Kova\u010d theorem) is stated as an axiom since its proof requires sophisticated constructions beyond current Mathlib.\n\nWe prove that powers of 2 form a lacunary sequence with \u03bb = 2, illustrating the boundary case. For \u03bb < 2, the van Doorn-Kova\u010d theorem guarantees existence of suitable sequences.",
     "keyInsights": [
-      "**Lacunary sequences**: Sequences where terms grow at least exponentially (a_{n+1}/a_n ≥ λ > 1). Powers of 2 are the canonical example with λ = 2.",
-      "**The critical threshold λ = 2**: For λ = 2, reciprocal sums are dyadic rationals and cannot fill an interval. For λ < 2, there's enough 'overlap' to achieve density.",
+      "**Lacunary sequences**: Sequences where terms grow at least exponentially (a_{n+1}/a_n \u2265 \u03bb > 1). Powers of 2 are the canonical example with \u03bb = 2.",
+      "**The critical threshold \u03bb = 2**: For \u03bb = 2, reciprocal sums are dyadic rationals and cannot fill an interval. For \u03bb < 2, there's enough 'overlap' to achieve density.",
       "**Egyptian fractions connection**: Finite sums of distinct unit fractions. The question asks when these can cover all rationals in an interval.",
-      "**Disproving Bleicher-Erdős**: The 2025 result showed their NO conjecture was wrong for λ < 2, demonstrating the subtlety of the problem.",
-      "**Density vs sparsity tradeoff**: The construction must balance exponential growth (lacunarity) against arithmetic density of reciprocal sums — the sweet spot at λ ∈ (1,2) allows terms close enough for sum overlaps but far enough apart for the growth condition"
+      "**Disproving Bleicher-Erd\u0151s**: The 2025 result showed their NO conjecture was wrong for \u03bb < 2, demonstrating the subtlety of the problem.",
+      "**Density vs sparsity tradeoff**: The construction must balance exponential growth (lacunarity) against arithmetic density of reciprocal sums \u2014 the sweet spot at \u03bb \u2208 (1,2) allows terms close enough for sum overlaps but far enough apart for the growth condition"
     ],
     "prerequisites": [
       "Combinatorics and number theory",
@@ -85,39 +85,39 @@
     },
     {
       "id": "boundary",
-      "title": "The Critical λ = 2 Boundary",
+      "title": "The Critical \u03bb = 2 Boundary",
       "startLine": 106,
       "endLine": 126,
-      "summary": "Why λ = 2 fails: dyadic rationals don't fill intervals."
+      "summary": "Why \u03bb = 2 fails: dyadic rationals don't fill intervals."
     },
     {
       "id": "main-result",
-      "title": "van Doorn-Kovač Theorem",
+      "title": "van Doorn-Kova\u010d Theorem",
       "startLine": 127,
       "endLine": 153,
-      "summary": "Main result: for λ ∈ (1,2), lacunary sequences can represent all rationals in an interval."
+      "summary": "Main result: for \u03bb \u2208 (1,2), lacunary sequences can represent all rationals in an interval."
     },
     {
       "id": "sharp-boundary",
       "title": "Sharp Boundary",
       "startLine": 168,
       "endLine": 186,
-      "summary": "The threshold λ = 2 is sharp: (1,2) works, [2,∞) doesn't."
+      "summary": "The threshold \u03bb = 2 is sharp: (1,2) works, [2,\u221e) doesn't."
     },
     {
       "id": "examples",
       "title": "Examples and Intuition",
       "startLine": 187,
       "endLine": 387,
-      "summary": "Fibonacci-like sequence example and intuition for why λ < 2 works."
+      "summary": "Fibonacci-like sequence example and intuition for why \u03bb < 2 works."
     }
   ],
   "conclusion": {
-    "summary": "We formalize Erdős Problem #355, which asks whether lacunary sequences can have reciprocal sums covering all rationals in an interval. The van Doorn-Kovač theorem (2025) proves YES for λ ∈ (1,2), disproving the Bleicher-Erdős conjecture.",
+    "summary": "We formalize Erd\u0151s Problem #355, which asks whether lacunary sequences can have reciprocal sums covering all rationals in an interval. The van Doorn-Kova\u010d theorem (2025) proves YES for \u03bb \u2208 (1,2), disproving the Bleicher-Erd\u0151s conjecture.",
     "implications": "**Theoretical Significance**: This result has implications for:\n\n1. **Egyptian fractions**: Shows that certain structured sequences can achieve full rational coverage\n\n**2. Number theory**: Demonstrates subtle threshold phenomena in sequence properties\n\n3. **Additive combinatorics**: Connects sequence growth rates to density of achievable sums.",
     "openQuestions": [
-      "What is the smallest interval achievable for a given λ ∈ (1,2)?",
-      "Can explicit constructions be given for specific λ values?",
+      "What is the smallest interval achievable for a given \u03bb \u2208 (1,2)?",
+      "Can explicit constructions be given for specific \u03bb values?",
       "What happens for sequences with weaker growth conditions than lacunarity?"
     ]
   },
@@ -147,7 +147,7 @@
       "Set"
     ],
     "namespace": "Erdos355",
-    "lineCount": 391,
+    "lineCount": 392,
     "axiomCount": 2,
     "theoremCount": 15,
     "definitionCount": 7,
@@ -158,17 +158,17 @@
     {
       "targetId": "erdos-148",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: egyptian-fractions, number-theory"
+      "description": "Related Erd\u0151s problem sharing themes: egyptian-fractions, number-theory"
     },
     {
       "targetId": "erdos-206",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: egyptian-fractions, number-theory"
+      "description": "Related Erd\u0151s problem sharing themes: egyptian-fractions, number-theory"
     },
     {
       "targetId": "erdos-242",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: egyptian-fractions, number-theory"
+      "description": "Related Erd\u0151s problem sharing themes: egyptian-fractions, number-theory"
     }
   ],
   "sorries": 0

--- a/src/data/proofs/erdos-37/meta.json
+++ b/src/data/proofs/erdos-37/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "erdos-37",
-  "title": "Erdős Problem #37: Essential Components and Lacunary Sets",
+  "title": "Erd\u0151s Problem #37: Essential Components and Lacunary Sets",
   "slug": "erdos-37",
-  "description": "Can a lacunary set A ⊂ ℕ be an essential component? NO (Ruzsa 1987). Essential components need |A ∩ {1,...,N}| ≥ (log N)^{1+c}, but lacunary sets have only O(log N) elements. Open: Is {2^m · 3^n} essential?",
+  "description": "Can a lacunary set A \u2282 \u2115 be an essential component? NO (Ruzsa 1987). Essential components need |A \u2229 {1,...,N}| \u2265 (log N)^{1+c}, but lacunary sets have only O(log N) elements. Open: Is {2^m \u00b7 3^n} essential?",
   "meta": {
     "author": "Aristotle (Harmonic), Ruzsa (1987, 1999)",
     "sourceUrl": "https://erdosproblems.com/37",
@@ -66,7 +66,7 @@
       "Definition of countingFunction for set elements",
       "Definition of schnirelmannDensity via infimum",
       "Theorem schnirelmannDensity_mem_Icc (proved by Aristotle)",
-      "Definition of sumset with +ₛ notation",
+      "Definition of sumset with +\u209b notation",
       "Definition of IsEssentialComponent",
       "Definition of IsLacunarySeq and IsLacunarySet",
       "Theorem powersOfTwo_lacunary (proved by Aristotle)",
@@ -90,16 +90,16 @@
     "assumptions": "6 axioms: ruzsa_essential_component_lower_bound, ruzsa_essential_component_construction, erdos_37_disproved, and 3 more. See Lean source for complete statements."
   },
   "overview": {
-    "historicalContext": "**Essential components** were introduced in additive number theory to describe sets that 'help' increase Schnirelmann density. A set A is essential if adding it to any B with positive density strictly increases the density: d_s(A + B) > d_s(B).\n\n**Lacunary sets** have exponentially growing elements (like powers of 2). They are extremely sparse but have rich structure in harmonic analysis.\n\n**Erdős's Question**: Can such sparse sets still be essential components?\n\n**Ruzsa's Resolution (1987)**: NO. Ruzsa proved that essential components must grow at least as (log N)^{1+c}, which rules out lacunary sets (growing only as log N). Furthermore, this bound is tight.\n\n**Remaining Open Problem**: Ruzsa (1999) asked whether {2^m · 3^n : m,n ∈ ℕ} is an essential component. This set grows as (log N)², which is faster than lacunary but doesn't meet the (log N)^{1+c} threshold. The answer remains unknown.",
-    "problemStatement": "**Erdős Problem #37**: Can a lacunary set $A \\subset \\mathbb{N}$ be an essential component?\n\n**Definitions**:\n- **Schnirelmann density**: $d_s(A) = \\inf_{n \\geq 1} \\frac{|A \\cap \\{1,...,n\\}|}{n}$\n- **Essential component**: A set A where $d_s(A + B) > d_s(B)$ for all B with $0 < d_s(B) < 1$\n- **Lacunary set**: A set enumerated as $\\{a_n\\}$ with $a_{n+1}/a_n \\geq r > 1$\n\n**Answer**: NO (Ruzsa 1987)\n\n**Ruzsa's Theorem**: If A is an essential component, then $\\exists c > 0$ such that\n$$|A \\cap \\{1,...,N\\}| \\geq (\\log N)^{1+c}$$\nfor all large N. Lacunary sets have only $O(\\log N)$ elements, so they fail this requirement.",
-    "text": "Can a lacunary set A ⊂ ℕ be an essential component? NO (Ruzsa 1987). Essential components need |A ∩ {1,...,N}| ≥ (log N)^{1+c}, but lacunary sets have only O(log N) elements. Open: Is {2^m · 3^n} essential?",
-    "proofStrategy": "The formalization captures Ruzsa's characterization:\n\n1. **Density Infrastructure**:\n   - `countingFunction`: Count elements up to N\n   - `schnirelmannDensity`: Infimum-based density\n   - `sumset`: The A + B operation\n\n2. **Key Definitions**:\n   - `IsEssentialComponent`: The property that adding A increases density\n   - `IsLacunarySet`: Exponentially growing element sequence\n   - `powersOfTwo`: Canonical lacunary example (verified!)\n\n3. **Ruzsa's Results**:\n   - `ruzsa_essential_component_lower_bound`: (log N)^{1+c} is required\n   - `ruzsa_essential_component_construction`: This is tight\n   - `erdos_37_disproved`: Lacunary ⟹ not essential\n\n4. **Verified Theorems**:\n   - `powersOfTwo_lacunary`: {2^n} is lacunary\n   - `erdos_37_answer`: The main negative result\n\n5. **Open Question**:\n   - `smoothNumbers23`: {2^m · 3^n}\n   - `RuzsaOpenQuestion`: Is this essential?",
+    "historicalContext": "**Essential components** were introduced in additive number theory to describe sets that 'help' increase Schnirelmann density. A set A is essential if adding it to any B with positive density strictly increases the density: d_s(A + B) > d_s(B).\n\n**Lacunary sets** have exponentially growing elements (like powers of 2). They are extremely sparse but have rich structure in harmonic analysis.\n\n**Erd\u0151s's Question**: Can such sparse sets still be essential components?\n\n**Ruzsa's Resolution (1987)**: NO. Ruzsa proved that essential components must grow at least as (log N)^{1+c}, which rules out lacunary sets (growing only as log N). Furthermore, this bound is tight.\n\n**Remaining Open Problem**: Ruzsa (1999) asked whether {2^m \u00b7 3^n : m,n \u2208 \u2115} is an essential component. This set grows as (log N)\u00b2, which is faster than lacunary but doesn't meet the (log N)^{1+c} threshold. The answer remains unknown.",
+    "problemStatement": "**Erd\u0151s Problem #37**: Can a lacunary set $A \\subset \\mathbb{N}$ be an essential component?\n\n**Definitions**:\n- **Schnirelmann density**: $d_s(A) = \\inf_{n \\geq 1} \\frac{|A \\cap \\{1,...,n\\}|}{n}$\n- **Essential component**: A set A where $d_s(A + B) > d_s(B)$ for all B with $0 < d_s(B) < 1$\n- **Lacunary set**: A set enumerated as $\\{a_n\\}$ with $a_{n+1}/a_n \\geq r > 1$\n\n**Answer**: NO (Ruzsa 1987)\n\n**Ruzsa's Theorem**: If A is an essential component, then $\\exists c > 0$ such that\n$$|A \\cap \\{1,...,N\\}| \\geq (\\log N)^{1+c}$$\nfor all large N. Lacunary sets have only $O(\\log N)$ elements, so they fail this requirement.",
+    "text": "Can a lacunary set A \u2282 \u2115 be an essential component? NO (Ruzsa 1987). Essential components need |A \u2229 {1,...,N}| \u2265 (log N)^{1+c}, but lacunary sets have only O(log N) elements. Open: Is {2^m \u00b7 3^n} essential?",
+    "proofStrategy": "The formalization captures Ruzsa's characterization:\n\n1. **Density Infrastructure**:\n   - `countingFunction`: Count elements up to N\n   - `schnirelmannDensity`: Infimum-based density\n   - `sumset`: The A + B operation\n\n2. **Key Definitions**:\n   - `IsEssentialComponent`: The property that adding A increases density\n   - `IsLacunarySet`: Exponentially growing element sequence\n   - `powersOfTwo`: Canonical lacunary example (verified!)\n\n3. **Ruzsa's Results**:\n   - `ruzsa_essential_component_lower_bound`: (log N)^{1+c} is required\n   - `ruzsa_essential_component_construction`: This is tight\n   - `erdos_37_disproved`: Lacunary \u27f9 not essential\n\n4. **Verified Theorems**:\n   - `powersOfTwo_lacunary`: {2^n} is lacunary\n   - `erdos_37_answer`: The main negative result\n\n5. **Open Question**:\n   - `smoothNumbers23`: {2^m \u00b7 3^n}\n   - `RuzsaOpenQuestion`: Is this essential?",
     "keyInsights": [
       "**Growth is the key**: The minimum growth rate for essential components is exactly (log N)^{1+c}. This is both necessary (Ruzsa lower bound) and sufficient (Ruzsa construction).",
       "**Lacunary sets are too sparse**: With only O(log N) elements, they cannot meet the (log N)^{1+c} threshold.",
-      "**The boundary case**: Sets growing as (log N)^k for k ≤ 1 cannot be essential. The question for (log N)² (smooth 2-3 numbers) remains open.",
+      "**The boundary case**: Sets growing as (log N)^k for k \u2264 1 cannot be essential. The question for (log N)\u00b2 (smooth 2-3 numbers) remains open.",
       "**Schnirelmann vs natural density**: The infimum-based Schnirelmann density is better suited for sumset problems than limit-based natural density.",
-      "**Classical context**: Schnirelmann's theorem (d_s(A) + d_s(B) ≥ 1 ⟹ A + B = ℕ⁺) and Mann's theorem underpin this area."
+      "**Classical context**: Schnirelmann's theorem (d_s(A) + d_s(B) \u2265 1 \u27f9 A + B = \u2115\u207a) and Mann's theorem underpin this area."
     ],
     "prerequisites": [
       "Essential components in additive number theory",
@@ -186,13 +186,13 @@
       "title": "Summary",
       "startLine": 352,
       "endLine": 368,
-      "summary": "Recap: Erdős #37 answered NO (Ruzsa 1987). Essential components need $(\\log N)^{1+c}$ growth; lacunary sets have only $O(\\log N)$. The $\\{2^m \\cdot 3^n\\}$ question remains OPEN.",
-      "mathContext": "Recap: Erdős #37 answered NO (Ruzsa 1987). Essential components need $(\\log N)^{1+c}$ growth; lacunary sets have only $$O(\\log N)$$. The $\\{$2^{m}$ \\cdot $3^{n}$\\}$ question remains OPEN."
+      "summary": "Recap: Erd\u0151s #37 answered NO (Ruzsa 1987). Essential components need $(\\log N)^{1+c}$ growth; lacunary sets have only $O(\\log N)$. The $\\{2^m \\cdot 3^n\\}$ question remains OPEN.",
+      "mathContext": "Recap: Erd\u0151s #37 answered NO (Ruzsa 1987). Essential components need $(\\log N)^{1+c}$ growth; lacunary sets have only $$O(\\log N)$$. The $\\{$2^{m}$ \\cdot $3^{n}$\\}$ question remains OPEN."
     }
   ],
   "conclusion": {
-    "summary": "This formalization resolves Erdős Problem #37 in the negative: lacunary sets cannot be essential components. Ruzsa's (1987) tight characterization — essential components need $|A \\cap [1,N]| \\ge (\\log N)^{1+c}$ growth, but lacunary sets have only $O(\\log N)$ — is the core argument. Four of the file's theorems were proved automatically by Aristotle (Harmonic). The remaining deep results (Ruzsa's bounds) are axiomatized. The file is complete with 0 sorries.",
-    "implications": "**Theoretical Significance**: Ruzsa's characterization draws a sharp line between sets that are 'additively helpful' and those that are too sparse.\n\nThe threshold $(\\log N)^{1+c}$ sits between polynomial sparsity and logarithmic sparsity, precisely at the boundary where additive structure can boost Schnirelmann density. The tight construction shows this boundary is optimal — no simpler characterization exists.",
+    "summary": "This formalization resolves Erd\u0151s Problem #37 in the negative: lacunary sets cannot be essential components. Ruzsa's (1987) tight characterization \u2014 essential components need $|A \\cap [1,N]| \\ge (\\log N)^{1+c}$ growth, but lacunary sets have only $O(\\log N)$ \u2014 is the core argument. Four of the file's theorems were proved automatically by Aristotle (Harmonic). The remaining deep results (Ruzsa's bounds) are axiomatized. The file is complete with 0 sorries.",
+    "implications": "**Theoretical Significance**: Ruzsa's characterization draws a sharp line between sets that are 'additively helpful' and those that are too sparse.\n\nThe threshold $(\\log N)^{1+c}$ sits between polynomial sparsity and logarithmic sparsity, precisely at the boundary where additive structure can boost Schnirelmann density. The tight construction shows this boundary is optimal \u2014 no simpler characterization exists.",
     "openQuestions": [
       "Is $\\{2^m \\cdot 3^n : m,n \\in \\mathbb{N}\\}$ an essential component? Its growth $(\\log N)^2$ is exactly at Ruzsa's threshold with $c = 1$ (Ruzsa 1999).",
       "For $k$-smooth numbers $\\{p_1^{a_1} \\cdots p_k^{a_k}\\}$ with counting function $\\sim C(\\log N)^k$, for which $k$ is the set essential?",
@@ -206,11 +206,11 @@
       },
       {
         "proofId": "erdos-320",
-        "relationship": "Distinct sums of unit fractions — another problem where set sparsity interacts with additive structure. The counting function growth rate determines feasibility."
+        "relationship": "Distinct sums of unit fractions \u2014 another problem where set sparsity interacts with additive structure. The counting function growth rate determines feasibility."
       },
       {
         "proofId": "erdos-330",
-        "relationship": "Minimal additive bases with positive density — complementary question about sets that form bases (representation property) vs. essential components (density-boosting property)."
+        "relationship": "Minimal additive bases with positive density \u2014 complementary question about sets that form bases (representation property) vs. essential components (density-boosting property)."
       }
     ]
   },
@@ -225,7 +225,7 @@
       "Filter"
     ],
     "namespace": "Erdos37",
-    "lineCount": 367,
+    "lineCount": 368,
     "axiomCount": 6,
     "theoremCount": 6,
     "definitionCount": 10,
@@ -246,17 +246,17 @@
   ],
   "references": [
     {
-      "authors": "Erdős, Paul",
+      "authors": "Erd\u0151s, Paul",
       "title": "On the representation of integers as sums of distinct terms from a fixed set",
       "year": "1962",
-      "venue": "Acta Arithmetica, vol. 7, pp. 345–354",
+      "venue": "Acta Arithmetica, vol. 7, pp. 345\u2013354",
       "note": "Studied essential components and their connection to lacunary sequences"
     },
     {
       "authors": "Linnik, Yuri V.",
       "title": "All large numbers are sums of a prime and two squares",
       "year": "1960",
-      "venue": "Matematicheskii Sbornik, vol. 52, pp. 661–700",
+      "venue": "Matematicheskii Sbornik, vol. 52, pp. 661\u2013700",
       "note": "Used essential component ideas in additive prime number theory"
     }
   ],

--- a/src/data/proofs/erdos-370/meta.json
+++ b/src/data/proofs/erdos-370/meta.json
@@ -69,7 +69,7 @@
   },
   "leanFile": {
     "path": "Proofs/Erdos370Problem.lean",
-    "lineCount": 284,
+    "lineCount": 285,
     "namespace": "Erdos370",
     "imports": [
       "Mathlib"
@@ -104,12 +104,12 @@
     {
       "targetId": "erdos-1136",
       "relationship": "related-problem",
-      "description": "Both are Erdős problems about sets of integers satisfying arithmetic constraints, resolved by clever constructions. Erdős #1136 uses binary structure; #370 uses difference of squares."
+      "description": "Both are Erd\u0151s problems about sets of integers satisfying arithmetic constraints, resolved by clever constructions. Erd\u0151s #1136 uses binary structure; #370 uses difference of squares."
     },
     {
       "targetId": "erdos-984",
       "relationship": "related-problem",
-      "description": "Both are Erdős problems in combinatorial number theory where extremal constructions play a central role in resolving density/existence questions."
+      "description": "Both are Erd\u0151s problems in combinatorial number theory where extremal constructions play a central role in resolving density/existence questions."
     },
     {
       "targetId": "erdos-527",
@@ -123,7 +123,7 @@
     }
   ],
   "overview": {
-    "historicalContext": "This problem appears in Erdős and Graham's influential monograph *Old and New Problems and Results in Combinatorial Number Theory* (1980, p. 69). They asked whether infinitely many consecutive integers $n$, $n+1$ both have their largest prime factor less than their square root. Such numbers are called *sqrt-smooth* --- their prime factorizations are dominated by small primes relative to the number's magnitude.\n\nThe trivial observation is that sqrt-smooth numbers exist (e.g., any perfect square $p^2$ with $p$ prime has $\\operatorname{gpf} = p = \\sqrt{p^2}$, though this gives equality not strict inequality) but finding consecutive pairs is much harder. Carl Pomerance observed that if the exponent $1/2$ is relaxed to $1/\\sqrt{e} - \\varepsilon$ (approximately $0.6065 - \\varepsilon$), the statement follows from density considerations via the **Dickman-de Bruijn function** $\\rho(u)$, which gives the proportion of $u$-smooth numbers. At $u = \\sqrt{e}$, exactly half of all integers are $u$-smooth, making consecutive pairs abundant by a simple probability argument.\n\nStefan Steinerberger found the elegant constructive solution: take $n = m^2 - 1 = (m-1)(m+1)$. Then $n+1 = m^2$, so $\\operatorname{gpf}(n+1) = \\operatorname{gpf}(m)$. If $m$ is a power of 2, $\\operatorname{gpf}(m^2) = 2 < m = \\sqrt{m^2}$. For $n$ itself, we need $\\operatorname{gpf}((m-1)(m+1)) < m$. The first valid case is $m = 8$: $n = 63 = 7 \\times 9$, $\\operatorname{gpf}(63) = 7 < \\sqrt{63} \\approx 7.94$, and $\\operatorname{gpf}(64) = 2 < 8 = \\sqrt{64}$. There are infinitely many valid choices of $m$, resolving the problem completely.\n\nThe proof was partially verified by the Aristotle proof search system, which confirmed the $n=63$ example and the key identity $n+1 = m^2$. The main infinitude theorem remains sorry'd, requiring a proof that infinitely many $m$ yield valid constructions.",
+    "historicalContext": "This problem appears in Erd\u0151s and Graham's influential monograph *Old and New Problems and Results in Combinatorial Number Theory* (1980, p. 69). They asked whether infinitely many consecutive integers $n$, $n+1$ both have their largest prime factor less than their square root. Such numbers are called *sqrt-smooth* --- their prime factorizations are dominated by small primes relative to the number's magnitude.\n\nThe trivial observation is that sqrt-smooth numbers exist (e.g., any perfect square $p^2$ with $p$ prime has $\\operatorname{gpf} = p = \\sqrt{p^2}$, though this gives equality not strict inequality) but finding consecutive pairs is much harder. Carl Pomerance observed that if the exponent $1/2$ is relaxed to $1/\\sqrt{e} - \\varepsilon$ (approximately $0.6065 - \\varepsilon$), the statement follows from density considerations via the **Dickman-de Bruijn function** $\\rho(u)$, which gives the proportion of $u$-smooth numbers. At $u = \\sqrt{e}$, exactly half of all integers are $u$-smooth, making consecutive pairs abundant by a simple probability argument.\n\nStefan Steinerberger found the elegant constructive solution: take $n = m^2 - 1 = (m-1)(m+1)$. Then $n+1 = m^2$, so $\\operatorname{gpf}(n+1) = \\operatorname{gpf}(m)$. If $m$ is a power of 2, $\\operatorname{gpf}(m^2) = 2 < m = \\sqrt{m^2}$. For $n$ itself, we need $\\operatorname{gpf}((m-1)(m+1)) < m$. The first valid case is $m = 8$: $n = 63 = 7 \\times 9$, $\\operatorname{gpf}(63) = 7 < \\sqrt{63} \\approx 7.94$, and $\\operatorname{gpf}(64) = 2 < 8 = \\sqrt{64}$. There are infinitely many valid choices of $m$, resolving the problem completely.\n\nThe proof was partially verified by the Aristotle proof search system, which confirmed the $n=63$ example and the key identity $n+1 = m^2$. The main infinitude theorem remains sorry'd, requiring a proof that infinitely many $m$ yield valid constructions.",
     "problemStatement": "Are there infinitely many n such that gpf(n) < sqrt(n) and gpf(n+1) < sqrt(n+1), where gpf denotes the greatest prime factor?",
     "text": "Are there infinitely many n such that both n and n+1 have their largest prime factor less than their square root? Steinerberger found an elegant solution using n = m^2 - 1.",
     "proofStrategy": "The formalization axiomatizes gpf with 6 properties (value at 1, divisibility, primality, prime/prime-power values, product bound) and defines three smoothness predicates. The Steinerberger construction $n = m^2 - 1$ is formalized with the factorization $(m-1)(m+1)$ axiomatized and the successor identity $n+1 = m^2$ verified. The worked example $n=63$ is fully verified (Aristotle proved all 4 component theorems). The main infinitude theorem is stated in two forms (`Set.Infinite` and injective function) but remains sorry'd. Pomerance's density perspective is included with the critical exponent $1/\\sqrt{e}$ and a weak Dickman density axiom.",
@@ -153,7 +153,7 @@
       "title": "Problem Overview",
       "startLine": 12,
       "endLine": 49,
-      "summary": "Problem statement, history (Erdős-Graham 1980, Pomerance density observation, Steinerberger construction), key insight $n = m^2 - 1$, worked example $n = 63$."
+      "summary": "Problem statement, history (Erd\u0151s-Graham 1980, Pomerance density observation, Steinerberger construction), key insight $n = m^2 - 1$, worked example $n = 63$."
     },
     {
       "id": "gpf-definition",
@@ -192,13 +192,13 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #370 is SOLVED: there are infinitely many $n$ where both $n$ and $n+1$ are sqrt-smooth. Steinerberger's construction $n = m^2 - 1 = (m-1)(m+1)$ provides an elegant infinite family. The formalization verifies the concrete case $n = 63$ (via Aristotle proof search) and connects to smooth number density theory via Pomerance's observation and the Dickman-de Bruijn function.",
+    "summary": "Erd\u0151s Problem #370 is SOLVED: there are infinitely many $n$ where both $n$ and $n+1$ are sqrt-smooth. Steinerberger's construction $n = m^2 - 1 = (m-1)(m+1)$ provides an elegant infinite family. The formalization verifies the concrete case $n = 63$ (via Aristotle proof search) and connects to smooth number density theory via Pomerance's observation and the Dickman-de Bruijn function.",
     "implications": "**Theoretical Significance**: The Steinerberger solution demonstrates how difference-of-squares factorization can reduce deep-sounding number-theoretic questions to elementary observations.\n\nThe connection to the Dickman function reveals that the exponent $1/2$ lies below the density threshold $1/\\sqrt{e}$, explaining why the problem requires constructive methods rather than probabilistic arguments. This distinction between 'density-easy' and 'construction-required' exponents is a recurring theme in smooth number theory.",
     "openQuestions": [
       "What is the asymptotic count of $n \\leq N$ with $\\text{ConsecutiveSqrtSmooth}(n)$? Can the Steinerberger construction be optimized to find the densest infinite family?",
       "Are there infinitely many $n$ with $\\operatorname{gpf}(n), \\operatorname{gpf}(n+1), \\operatorname{gpf}(n+2)$ all less than their square roots (consecutive triples)?",
       "Can the main infinitude theorem be proved in Lean by showing infinitely many $m = 2^k$ yield $\\operatorname{gpf}((2^k-1)(2^k+1)) < 2^k$?",
-      "What is the exact critical exponent below which the Erdős-Graham problem requires constructive rather than density-based proofs?"
+      "What is the exact critical exponent below which the Erd\u0151s-Graham problem requires constructive rather than density-based proofs?"
     ]
   },
   "sorries": 2

--- a/src/data/proofs/erdos-402/meta.json
+++ b/src/data/proofs/erdos-402/meta.json
@@ -2,9 +2,9 @@
   "id": "erdos-402",
   "title": "Graham's GCD Conjecture",
   "slug": "erdos-402",
-  "description": "For any finite set A ⊂ ℕ, there exist a, b ∈ A such that gcd(a, b) ≤ a/|A|. Graham's conjecture was proved by Balasubramanian and Soundararajan in 1996.",
+  "description": "For any finite set A \u2282 \u2115, there exist a, b \u2208 A such that gcd(a, b) \u2264 a/|A|. Graham's conjecture was proved by Balasubramanian and Soundararajan in 1996.",
   "meta": {
-    "author": "Graham (1970), solved by Balasubramanian–Soundararajan (1996)",
+    "author": "Graham (1970), solved by Balasubramanian\u2013Soundararajan (1996)",
     "sourceUrl": "https://erdosproblems.com/402",
     "date": "1970",
     "status": "formalized",
@@ -56,8 +56,8 @@
       "Aristotle: {1,2,4} counterexample falsifying equality characterization",
       "dvd_lt_imp_le_half: proper divisors bounded by half",
       "erdos_402_pair: conjecture proved for two-element sets",
-      "max_ge_card_of_pos: max of positive Finset ≥ cardinality",
-      "erdos_402_contains_one: conjecture proved when 1 ∈ A"
+      "max_ge_card_of_pos: max of positive Finset \u2265 cardinality",
+      "erdos_402_contains_one: conjecture proved when 1 \u2208 A"
     ],
     "axiomCount": 0,
     "lineCount": 693,
@@ -65,15 +65,15 @@
   },
   "overview": {
     "historicalContext": "Graham posed this conjecture in 1970 as an **extremal problem** on GCD structure in finite sets. The conjecture attracted attention because it connects the multiplicative structure (GCD) of a set to its combinatorial size. **Szegedy** (1986) proved the conjecture for sets larger than an effective constant $N_0$, using a probabilistic argument on prime factorizations. **Zaharescu** (1987) obtained an independent proof for large sets via analytic methods. **Balasubramanian and Soundararajan** (1996) completed the proof for all finite sets by a refined sieve argument, handling the difficult small-set cases. Graham also conjectured that equality $\\gcd(a,b) = \\lfloor a/|A| \\rfloor$ for the optimal pair occurs only for three families of primitive sets, but Aristotle's automated proof search discovered that $\\{1, 2, 4\\}$ is a counterexample to this characterization.",
-    "problemStatement": "For any finite set A ⊂ ℕ with positive elements, prove there exist a, b ∈ A such that gcd(a, b) ≤ a/|A|.",
-    "text": "For any finite set A ⊂ ℕ, there exist a, b ∈ A such that gcd(a, b) ≤ a/|A|. Graham's conjecture was proved by Balasubramanian and Soundararajan in 1996.",
-    "proofStrategy": "We formalize the main statement and prove special cases: singleton sets, the Graham special set {2,3,4,6}, and derive a key lemma that coprime pairs suffice when |A| ≤ a.",
+    "problemStatement": "For any finite set A \u2282 \u2115 with positive elements, prove there exist a, b \u2208 A such that gcd(a, b) \u2264 a/|A|.",
+    "text": "For any finite set A \u2282 \u2115, there exist a, b \u2208 A such that gcd(a, b) \u2264 a/|A|. Graham's conjecture was proved by Balasubramanian and Soundararajan in 1996.",
+    "proofStrategy": "We formalize the main statement and prove special cases: singleton sets, the Graham special set {2,3,4,6}, and derive a key lemma that coprime pairs suffice when |A| \u2264 a.",
     "keyInsights": [
-      "**GCD bound**: $\\forall A \\subseteq \\mathbb{N}^+$ finite, $\\exists a,b \\in A: \\gcd(a,b) \\le \\lfloor a/|A| \\rfloor$ — proved by Balasubramanian–Soundararajan (1996)",
-      "**Coprime reduction**: if $\\gcd(a,b) = 1$ and $|A| \\le a$, the bound holds immediately — finding coprime pairs in large sets suffices",
+      "**GCD bound**: $\\forall A \\subseteq \\mathbb{N}^+$ finite, $\\exists a,b \\in A: \\gcd(a,b) \\le \\lfloor a/|A| \\rfloor$ \u2014 proved by Balasubramanian\u2013Soundararajan (1996)",
+      "**Coprime reduction**: if $\\gcd(a,b) = 1$ and $|A| \\le a$, the bound holds immediately \u2014 finding coprime pairs in large sets suffices",
       "**Equality families**: $\\{1,\\ldots,n\\}$, $\\{L/1,\\ldots,L/n\\}$, and $\\{2,3,4,6\\}$ are primitive sets achieving equality",
-      "**Counterexample discovery**: Aristotle proved that $\\{1,2,4\\}$ satisfies the equality condition but is not a Graham equality case — the characterization is incomplete",
-      "**Equivalent rational form**: $\\exists a,b \\in A: \\gcd(a,b)/a \\le 1/|A|$ — cleaner formulation avoiding the floor function, proved by Aristotle from the main conjecture"
+      "**Counterexample discovery**: Aristotle proved that $\\{1,2,4\\}$ satisfies the equality condition but is not a Graham equality case \u2014 the characterization is incomplete",
+      "**Equivalent rational form**: $\\exists a,b \\in A: \\gcd(a,b)/a \\le 1/|A|$ \u2014 cleaner formulation avoiding the floor function, proved by Aristotle from the main conjecture"
     ],
     "prerequisites": [
       "GCD and Nat.gcd from Mathlib",
@@ -112,7 +112,7 @@
       "title": "The {2, 3, 4, 6} Example",
       "startLine": 83,
       "endLine": 103,
-      "summary": "**GrahamSpecialSet** $= \\{2,3,4,6\\}$ with $|A| = 4$. Verified: $\\gcd(4,3) = 1 = \\lfloor 4/4 \\rfloor$ — sporadic equality case.",
+      "summary": "**GrahamSpecialSet** $= \\{2,3,4,6\\}$ with $|A| = 4$. Verified: $\\gcd(4,3) = 1 = \\lfloor 4/4 \\rfloor$ \u2014 sporadic equality case.",
       "mathContext": "$A = \\{2,3,4,6\\}$: $\\gcd(4,3) = 1 = \\lfloor 4/4 \\rfloor$. Equality case: one of three primitive families achieving $\\gcd(a,b) = \\lfloor a/|A| \\rfloor$."
     },
     {
@@ -120,7 +120,7 @@
       "title": "Graham's Equality Characterization",
       "startLine": 104,
       "endLine": 136,
-      "summary": "**HasNoCommonDivisor** ($\\gcd(A) = 1$) and **IsGrahamEqualityCase**: three primitive families. Aristotle discovered $\\{1,2,4\\}$ counterexample — characterization incomplete.",
+      "summary": "**HasNoCommonDivisor** ($\\gcd(A) = 1$) and **IsGrahamEqualityCase**: three primitive families. Aristotle discovered $\\{1,2,4\\}$ counterexample \u2014 characterization incomplete.",
       "mathContext": "Primitive equality cases: $\\{1,\\ldots,n\\}$, $\\{\\text{lcm}(1,\\ldots,n)/1, \\ldots, \\text{lcm}(1,\\ldots,n)/n\\}$, or $\\{2,3,4,6\\}$. A set is primitive if $\\gcd(A) = 1$."
     },
     {
@@ -133,7 +133,7 @@
     }
   ],
   "conclusion": {
-    "summary": "We formalize Graham's GCD Conjecture (Erdős #402). For any finite set A of positive integers, there exist a, b in A with gcd(a,b) ≤ a/|A|. The proof was completed by Balasubramanian and Soundararajan in 1996. Notably, Aristotle's automated proof search discovered a counterexample to the equality characterization.",
+    "summary": "We formalize Graham's GCD Conjecture (Erd\u0151s #402). For any finite set A of positive integers, there exist a, b in A with gcd(a,b) \u2264 a/|A|. The proof was completed by Balasubramanian and Soundararajan in 1996. Notably, Aristotle's automated proof search discovered a counterexample to the equality characterization.",
     "implications": "This result connects combinatorial properties of finite sets to the structure of their greatest common divisors, with applications in additive combinatorics and multiplicative number theory.",
     "openQuestions": [
       "What is the correct characterization of equality cases? ({1,2,4} is missing from the current formulation)",
@@ -144,18 +144,18 @@
   },
   "crossReferences": [
     {
-      "relationship": "Problem 403 concerns related GCD and divisibility questions in finite sets, sharing the Erdős–Graham framework",
+      "relationship": "Problem 403 concerns related GCD and divisibility questions in finite sets, sharing the Erd\u0151s\u2013Graham framework",
       "targetId": "erdos-403"
     },
     {
       "targetId": "euler-totient",
       "relationship": "related",
-      "description": "Euler's totient function $\\varphi(n)$ counts integers coprime to $n$, and GCD computations are central to both problems. Graham's conjecture bounds $\\gcd(a,b)$ relative to set size, while $\\varphi$ measures coprimality density — both probe the multiplicative structure of finite sets"
+      "description": "Euler's totient function $\\varphi(n)$ counts integers coprime to $n$, and GCD computations are central to both problems. Graham's conjecture bounds $\\gcd(a,b)$ relative to set size, while $\\varphi$ measures coprimality density \u2014 both probe the multiplicative structure of finite sets"
     },
     {
       "targetId": "gcd-algorithm",
       "relationship": "foundational",
-      "description": "The Euclidean algorithm for GCD is the computational foundation for Graham's conjecture. Every instance of the conjecture requires evaluating $\\gcd(a,b)$ for pairs in a finite set, and the algorithmic properties of GCD underpin both verification and the sieve arguments in Balasubramanian–Soundararajan's proof"
+      "description": "The Euclidean algorithm for GCD is the computational foundation for Graham's conjecture. Every instance of the conjecture requires evaluating $\\gcd(a,b)$ for pairs in a finite set, and the algorithmic properties of GCD underpin both verification and the sieve arguments in Balasubramanian\u2013Soundararajan's proof"
     }
   ],
   "leanFile": {
@@ -177,7 +177,7 @@
       "Finset"
     ],
     "namespace": "Erdos402",
-    "lineCount": 693,
+    "lineCount": 694,
     "axiomCount": 0,
     "theoremCount": 25,
     "definitionCount": 5,
@@ -200,7 +200,7 @@
     {
       "title": "On a conjecture of R. L. Graham",
       "year": "1996",
-      "authors": "Balasubramanian–Soundararajan 1996",
+      "authors": "Balasubramanian\u2013Soundararajan 1996",
       "note": "Complete proof of the conjecture for all finite sets of positive integers"
     }
   ],

--- a/src/data/proofs/erdos-45/meta.json
+++ b/src/data/proofs/erdos-45/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-45",
-  "title": "Erdős #45: Monochromatic Egyptian Fractions",
+  "title": "Erd\u0151s #45: Monochromatic Egyptian Fractions",
   "slug": "erdos-45",
-  "description": "For k ≥ 2, does there exist n_k such that any k-coloring of proper divisors of n_k contains a monochromatic D' with Σ 1/d = 1? YES (Croot 2003). Bounds: n_k ≈ exp(C^k) doubly exponential (Sawhney).",
+  "description": "For k \u2265 2, does there exist n_k such that any k-coloring of proper divisors of n_k contains a monochromatic D' with \u03a3 1/d = 1? YES (Croot 2003). Bounds: n_k \u2248 exp(C^k) doubly exponential (Sawhney).",
   "meta": {
-    "author": "Paul Erdős, Ernest Croot, Mehtaab Sawhney",
+    "author": "Paul Erd\u0151s, Ernest Croot, Mehtaab Sawhney",
     "erdosNumber": 45,
     "status": "axiomatized",
     "tags": [
@@ -28,11 +28,11 @@
     "relatedProblems": [
       {
         "id": "erdos-444",
-        "relation": "Generalized divisor functions d_A(n); the reciprocal sum σ_{-1}(n) central to #45 is the case s = -1 of the generalized divisor sum"
+        "relation": "Generalized divisor functions d_A(n); the reciprocal sum \u03c3_{-1}(n) central to #45 is the case s = -1 of the generalized divisor sum"
       },
       {
         "id": "erdos-414",
-        "relation": "Iterated h(n) = n + τ(n); shares the divisor function as core ingredient, studying dynamics vs. Ramsey theory"
+        "relation": "Iterated h(n) = n + \u03c4(n); shares the divisor function as core ingredient, studying dynamics vs. Ramsey theory"
       },
       {
         "id": "erdos-381",
@@ -56,7 +56,7 @@
       "title": "Core Definitions",
       "startLine": 42,
       "endLine": 61,
-      "summary": "**properDivisors n** = {d : 1 < d < n, d | n}. **IsColoring k S c**: assignment of k colors. **IsMonochromatic c S**: all elements same color. **reciprocalSum S** = Σ 1/d over ℚ. These define the combinatorial setting for the Ramsey-type problem."
+      "summary": "**properDivisors n** = {d : 1 < d < n, d | n}. **IsColoring k S c**: assignment of k colors. **IsMonochromatic c S**: all elements same color. **reciprocalSum S** = \u03a3 1/d over \u211a. These define the combinatorial setting for the Ramsey-type problem."
     },
     {
       "id": "main-property",
@@ -70,41 +70,41 @@
       "title": "Croot's Existence Theorem (2003)",
       "startLine": 74,
       "endLine": 84,
-      "summary": "**croot_existence**: ∀ k ≥ 2, ∃ n_k with the k-Egyptian property. Proved using the probabilistic method on n = lcm(1,...,M). One `sorry` remains — the proof is non-constructive and uses deep probabilistic arguments."
+      "summary": "**croot_existence**: \u2200 k \u2265 2, \u2203 n_k with the k-Egyptian property. Proved using the probabilistic method on n = lcm(1,...,M). One `sorry` remains \u2014 the proof is non-constructive and uses deep probabilistic arguments."
     },
     {
       "id": "bounds",
       "title": "Sawhney's Doubly Exponential Bounds",
       "startLine": 85,
       "endLine": 104,
-      "summary": "**sawhney_upper_bound**: n_k ≤ exp(C^k) via n = lcm(1,...,C^k). **sawhney_lower_bound**: n_k ≥ exp(c^k) from the necessary condition σ_{-1}(n) ≥ k, which requires primes up to exp(exp(k)) by Mertens' theorem. The bounds match, establishing doubly exponential growth."
+      "summary": "**sawhney_upper_bound**: n_k \u2264 exp(C^k) via n = lcm(1,...,C^k). **sawhney_lower_bound**: n_k \u2265 exp(c^k) from the necessary condition \u03c3_{-1}(n) \u2265 k, which requires primes up to exp(exp(k)) by Mertens' theorem. The bounds match, establishing doubly exponential growth."
     },
     {
       "id": "basic-facts",
       "title": "Basic Facts and Proved Lemma",
       "startLine": 105,
       "endLine": 117,
-      "summary": "**divisor_reciprocal_sum**: Σ_{d|n} 1/d = σ_{-1}(n). **egyptian_fraction_bound**: if Σ 1/d_i = 1 then each d_i ≤ Π d_j — **proved by Aristotle** using `Finset.dvd_prod_of_mem` and `Nat.le_of_dvd`."
+      "summary": "**divisor_reciprocal_sum**: \u03a3_{d|n} 1/d = \u03c3_{-1}(n). **egyptian_fraction_bound**: if \u03a3 1/d_i = 1 then each d_i \u2264 \u03a0 d_j \u2014 **proved by Aristotle** using `Finset.dvd_prod_of_mem` and `Nat.le_of_dvd`."
     },
     {
       "id": "small-cases",
       "title": "Small Cases: k = 2",
       "startLine": 118,
       "endLine": 141,
-      "summary": "**case_k_2**: n = 120 = 2³·3·5 has the 2-Egyptian property. With σ_{-1}(120) = 3 and 14 proper divisors, any 2-coloring forces a monochromatic Egyptian subset. The smallest known example for k = 2."
+      "summary": "**case_k_2**: n = 120 = 2\u00b3\u00b73\u00b75 has the 2-Egyptian property. With \u03c3_{-1}(120) = 3 and 14 proper divisors, any 2-coloring forces a monochromatic Egyptian subset. The smallest known example for k = 2."
     }
   ],
   "overview": {
-    "historicalContext": "Erdős posed Problem #45 around 1995, connecting two of his favorite topics: **Egyptian fractions** (unit fraction representations, a subject he contributed to extensively) and **Ramsey theory** (unavoidable structures under colorings). The question asks whether highly composite numbers have enough divisor structure to force monochromatic Egyptian representations under any coloring. **Ernest Croot** resolved this affirmatively in his 2003 Annals of Mathematics paper 'On a coloring conjecture about unit fractions', using the probabilistic method. **Mehtaab Sawhney** later established tight doubly exponential bounds: n_k ≈ exp(C^k). The doubly exponential growth is forced by the logarithmic growth of the reciprocal sum σ_{-1}(n): to achieve σ_{-1}(n) ≥ k, one needs n divisible by primes up to exp(exp(k)).",
-    "problemStatement": "Let k ≥ 2. Is there an integer n_k such that for D = {d : 1 < d < n_k, d | n_k}, any k-coloring of D contains a monochromatic subset D' ⊆ D with Σ_{d ∈ D'} 1/d = 1?",
-    "text": "For k ≥ 2, does there exist n_k such that any k-coloring of proper divisors of n_k contains a monochromatic D' with Σ 1/d = 1? YES (Croot 2003). Bounds: n_k ≈ exp(C^k) doubly exponential (Sawhney).",
+    "historicalContext": "Erd\u0151s posed Problem #45 around 1995, connecting two of his favorite topics: **Egyptian fractions** (unit fraction representations, a subject he contributed to extensively) and **Ramsey theory** (unavoidable structures under colorings). The question asks whether highly composite numbers have enough divisor structure to force monochromatic Egyptian representations under any coloring. **Ernest Croot** resolved this affirmatively in his 2003 Annals of Mathematics paper 'On a coloring conjecture about unit fractions', using the probabilistic method. **Mehtaab Sawhney** later established tight doubly exponential bounds: n_k \u2248 exp(C^k). The doubly exponential growth is forced by the logarithmic growth of the reciprocal sum \u03c3_{-1}(n): to achieve \u03c3_{-1}(n) \u2265 k, one needs n divisible by primes up to exp(exp(k)).",
+    "problemStatement": "Let k \u2265 2. Is there an integer n_k such that for D = {d : 1 < d < n_k, d | n_k}, any k-coloring of D contains a monochromatic subset D' \u2286 D with \u03a3_{d \u2208 D'} 1/d = 1?",
+    "text": "For k \u2265 2, does there exist n_k such that any k-coloring of proper divisors of n_k contains a monochromatic D' with \u03a3 1/d = 1? YES (Croot 2003). Bounds: n_k \u2248 exp(C^k) doubly exponential (Sawhney).",
     "proofStrategy": "The formalization defines proper divisors, k-colorings, monochromatic subsets, reciprocal sums, and the k-Egyptian property in Lean 4. Croot's existence theorem is stated with one sorry (the probabilistic proof). Sawhney's upper and lower bounds are axiomatized. The file includes a basic lemma on divisor reciprocal sums (proved by `rfl`) and the Egyptian fraction bound (proved by Aristotle). The case k = 2 with n = 120 is axiomatized.",
     "keyInsights": [
-      "**Ramsey meets Egyptian fractions**: the problem asks for an unavoidable monochromatic structure (Ramsey) with a specific arithmetic property (Σ 1/d = 1, Egyptian)",
+      "**Ramsey meets Egyptian fractions**: the problem asks for an unavoidable monochromatic structure (Ramsey) with a specific arithmetic property (\u03a3 1/d = 1, Egyptian)",
       "**Probabilistic proof**: Croot's argument shows that for n = lcm(1,...,M), the density of Egyptian representations grows so fast that no coloring can avoid all of them",
-      "**Doubly exponential bounds are tight**: n_k ≈ exp(C^k) because σ_{-1}(n) grows only as log log n for 'optimal' n (via Mertens), so achieving σ_{-1} ≥ k forces n ≥ exp(exp(k))",
-      "**Highly composite numbers are optimal**: numbers with many small prime factors (like 120 = 2³·3·5) maximize the reciprocal sum for their size",
-      "**Aristotle proved one lemma**: the bound d ≤ Π d' for Egyptian fractions was automatically proved via Finset.dvd_prod_of_mem"
+      "**Doubly exponential bounds are tight**: n_k \u2248 exp(C^k) because \u03c3_{-1}(n) grows only as log log n for 'optimal' n (via Mertens), so achieving \u03c3_{-1} \u2265 k forces n \u2265 exp(exp(k))",
+      "**Highly composite numbers are optimal**: numbers with many small prime factors (like 120 = 2\u00b3\u00b73\u00b75) maximize the reciprocal sum for their size",
+      "**Aristotle proved one lemma**: the bound d \u2264 \u03a0 d' for Egyptian fractions was automatically proved via Finset.dvd_prod_of_mem"
     ],
     "prerequisites": [
       "Egyptian fractions and unit fraction decompositions",
@@ -114,10 +114,10 @@
     ]
   },
   "conclusion": {
-    "summary": "Erdős Problem #45 is SOLVED: for any k ≥ 2, there exists n_k such that any k-coloring of the proper divisors of n_k contains a monochromatic subset with reciprocal sum 1. Proved by Croot (2003) with tight doubly exponential bounds n_k ≈ exp(C^k) by Sawhney.",
+    "summary": "Erd\u0151s Problem #45 is SOLVED: for any k \u2265 2, there exists n_k such that any k-coloring of the proper divisors of n_k contains a monochromatic subset with reciprocal sum 1. Proved by Croot (2003) with tight doubly exponential bounds n_k \u2248 exp(C^k) by Sawhney.",
     "implications": "The result reveals a deep connection between the multiplicative structure of integers (divisors, reciprocal sums) and Ramsey-type combinatorics (unavoidable monochromatic structures). The doubly exponential growth demonstrates that forcing monochromatic Egyptian fractions is an inherently 'expensive' Ramsey property, much harder than classical Ramsey numbers which grow merely exponentially.",
     "openQuestions": [
-      "What is the exact value of the optimal constant C in n_k ≈ exp(C^k)?",
+      "What is the exact value of the optimal constant C in n_k \u2248 exp(C^k)?",
       "Can explicit (non-probabilistic) constructions achieve the k-Egyptian property?",
       "What is the smallest n_k for k = 2, 3, 4?",
       "Is there a 'strong' version: can we guarantee multiple disjoint monochromatic Egyptian subsets?",
@@ -133,7 +133,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos45",
-    "lineCount": 141,
+    "lineCount": 142,
     "axiomCount": 3,
     "theoremCount": 3,
     "definitionCount": 5,
@@ -154,24 +154,24 @@
   ],
   "references": [
     {
-      "authors": "Erdős, Paul; Graham, Ronald L.",
+      "authors": "Erd\u0151s, Paul; Graham, Ronald L.",
       "title": "Old and New Problems and Results in Combinatorial Number Theory",
       "year": "1980",
-      "venue": "L'Enseignement Mathématique, Monographie no. 28, Geneva",
-      "note": "Comprehensive collection of Erdős-Graham problems including Egyptian fraction questions"
+      "venue": "L'Enseignement Math\u00e9matique, Monographie no. 28, Geneva",
+      "note": "Comprehensive collection of Erd\u0151s-Graham problems including Egyptian fraction questions"
     },
     {
       "authors": "Croot, Ernie",
       "title": "On a coloring conjecture about unit fractions",
       "year": "2003",
-      "venue": "Annals of Mathematics, vol. 157, no. 2, pp. 545–556",
-      "note": "Major progress on the Erdős-Graham conjecture on monochromatic Egyptian fractions"
+      "venue": "Annals of Mathematics, vol. 157, no. 2, pp. 545\u2013556",
+      "note": "Major progress on the Erd\u0151s-Graham conjecture on monochromatic Egyptian fractions"
     },
-    "Erdős, P. and Graham, R.L. (1980): 'Old and new problems and results in combinatorial number theory', Monographies de L'Enseignement Mathématique 28",
-    "Croot, E.S. (2003): 'On a coloring conjecture about unit fractions', Annals of Mathematics 157, 545–556",
+    "Erd\u0151s, P. and Graham, R.L. (1980): 'Old and new problems and results in combinatorial number theory', Monographies de L'Enseignement Math\u00e9matique 28",
+    "Croot, E.S. (2003): 'On a coloring conjecture about unit fractions', Annals of Mathematics 157, 545\u2013556",
     "Sawhney, M.: 'On the bounds for the monochromatic Egyptian fraction problem' (tight doubly exponential bounds)",
-    "Ramanujan, S. (1915): 'Highly composite numbers', Proc. London Math. Soc. 14, 347–409",
-    "Mertens, F. (1874): 'Ein Beitrag zur analytischen Zahlentheorie', J. Reine Angew. Math. 78, 46–62",
+    "Ramanujan, S. (1915): 'Highly composite numbers', Proc. London Math. Soc. 14, 347\u2013409",
+    "Mertens, F. (1874): 'Ein Beitrag zur analytischen Zahlentheorie', J. Reine Angew. Math. 78, 46\u201362",
     "https://erdosproblems.com/45"
   ],
   "sorries": 0

--- a/src/data/proofs/erdos-485/meta.json
+++ b/src/data/proofs/erdos-485/meta.json
@@ -2,9 +2,9 @@
   "id": "erdos-485",
   "title": "Minimum Terms in Squared Polynomials",
   "slug": "erdos-485",
-  "description": "Let f(k) be the minimum number of terms in P(x)², where P ranges over polynomials with exactly k non-zero terms. Is f(k) → ∞ as k → ∞?",
+  "description": "Let f(k) be the minimum number of terms in P(x)\u00b2, where P ranges over polynomials with exactly k non-zero terms. Is f(k) \u2192 \u221e as k \u2192 \u221e?",
   "meta": {
-    "author": "Erdős-Rényi",
+    "author": "Erd\u0151s-R\u00e9nyi",
     "sourceUrl": "https://erdosproblems.com/485",
     "date": "",
     "status": "axiomatized",
@@ -24,21 +24,21 @@
     "erdosProblemStatus": "solved",
     "axiomCount": 1,
     "lineCount": 225,
-    "assumptions": "1 axiom: schinzel_zannier_improved (Schinzel-Zannier 2009: f(k) ≫ log k). This deep algebraic result is not yet in Mathlib.",
+    "assumptions": "1 axiom: schinzel_zannier_improved (Schinzel-Zannier 2009: f(k) \u226b log k). This deep algebraic result is not yet in Mathlib.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "The problem originates in the 1947 investigation by Rényi and Rédei on the multiplicative structure of polynomial term counts.  Erdős (1949) proved the upper bound f(k) < k^{1-c} for some c > 0, demonstrating that squaring can achieve genuinely sublinear term compression.  The conjecture that f(k) → ∞ is attributed to Erdős and Rényi, appearing as Problem 4.4 in Hayman's 'Research Problems in Function Theory' (1974).  Schinzel (1987) resolved the conjecture affirmatively, proving f(k) > (log log k)/log 2 via an algebraic height argument that bounds the number of coefficient cancellations by the algebraic complexity of the support set.  Schinzel and Zannier (2009) significantly improved this to f(k) ≫ log k, using the Skolem–Mahler–Lech theorem on zeros of linear recurrence sequences and techniques from the geometry of numbers.  The precise growth rate of f(k) remains unknown: the gap between the log k lower bound and the k^{1-c} upper bound is exponential.",
-    "problemStatement": "Let f(k) be the minimum number of terms in P(x)², where P ∈ ℚ[x] ranges over all polynomials with exactly k non-zero terms. Is it true that f(k) → ∞ as k → ∞?",
-    "text": "Let f(k) be the minimum number of terms in P(x)², where P ranges over polynomials with exactly k non-zero terms. Is f(k) → ∞ as k → ∞?",
-    "proofStrategy": "The formalization defines termCount via Polynomial.support.card, then f(k) as sInf over k-term polynomials.  Base cases f(1) = 1 (monomials) and f(2) = 3 (binomials) are fully proved by Aristotle automated proof search, including the nontrivial lower bound for f(2) which shows every binomial square has exactly 3 terms.  The main results — Erdős's upper bound, Schinzel's lower bound, and the Schinzel–Zannier improvement — are axiomatized as theorem sorries since the proofs require deep algebraic techniques beyond current Mathlib automation.  The formalization also treats the generalization g(k,n) for P^n.",
+    "historicalContext": "The problem originates in the 1947 investigation by R\u00e9nyi and R\u00e9dei on the multiplicative structure of polynomial term counts.  Erd\u0151s (1949) proved the upper bound f(k) < k^{1-c} for some c > 0, demonstrating that squaring can achieve genuinely sublinear term compression.  The conjecture that f(k) \u2192 \u221e is attributed to Erd\u0151s and R\u00e9nyi, appearing as Problem 4.4 in Hayman's 'Research Problems in Function Theory' (1974).  Schinzel (1987) resolved the conjecture affirmatively, proving f(k) > (log log k)/log 2 via an algebraic height argument that bounds the number of coefficient cancellations by the algebraic complexity of the support set.  Schinzel and Zannier (2009) significantly improved this to f(k) \u226b log k, using the Skolem\u2013Mahler\u2013Lech theorem on zeros of linear recurrence sequences and techniques from the geometry of numbers.  The precise growth rate of f(k) remains unknown: the gap between the log k lower bound and the k^{1-c} upper bound is exponential.",
+    "problemStatement": "Let f(k) be the minimum number of terms in P(x)\u00b2, where P \u2208 \u211a[x] ranges over all polynomials with exactly k non-zero terms. Is it true that f(k) \u2192 \u221e as k \u2192 \u221e?",
+    "text": "Let f(k) be the minimum number of terms in P(x)\u00b2, where P ranges over polynomials with exactly k non-zero terms. Is f(k) \u2192 \u221e as k \u2192 \u221e?",
+    "proofStrategy": "The formalization defines termCount via Polynomial.support.card, then f(k) as sInf over k-term polynomials.  Base cases f(1) = 1 (monomials) and f(2) = 3 (binomials) are fully proved by Aristotle automated proof search, including the nontrivial lower bound for f(2) which shows every binomial square has exactly 3 terms.  The main results \u2014 Erd\u0151s's upper bound, Schinzel's lower bound, and the Schinzel\u2013Zannier improvement \u2014 are axiomatized as theorem sorries since the proofs require deep algebraic techniques beyond current Mathlib automation.  The formalization also treats the generalization g(k,n) for P^n.",
     "keyInsights": [
-      "The term count of P² connects to sumset theory: termCount(P²) = |supp(P) + supp(P)| minus cancellations, linking the problem to additive combinatorics",
-      "Erdős's sublinear upper bound f(k) < k^{1-c} uses signed-coefficient constructions akin to Sidon sets, showing that signs can engineer massive cancellation",
-      "Schinzel's height argument shows that achieving few terms in P² forces the support set into rigid algebraic configurations that become impossible as k grows",
-      "The f(2) = 3 proof is a complete formal verification: distinctness of exponents 2d₁ < d₁+d₂ < 2d₂ plus nonvanishing of coefficients in characteristic 0",
-      "The gap between log k and k^{1-c} is exponential — determining the true growth rate is the main open problem",
-      "Schinzel's method generalizes to P^n for any n ≥ 1, showing g(k,n) → ∞ via the same algebraic framework"
+      "The term count of P\u00b2 connects to sumset theory: termCount(P\u00b2) = |supp(P) + supp(P)| minus cancellations, linking the problem to additive combinatorics",
+      "Erd\u0151s's sublinear upper bound f(k) < k^{1-c} uses signed-coefficient constructions akin to Sidon sets, showing that signs can engineer massive cancellation",
+      "Schinzel's height argument shows that achieving few terms in P\u00b2 forces the support set into rigid algebraic configurations that become impossible as k grows",
+      "The f(2) = 3 proof is a complete formal verification: distinctness of exponents 2d\u2081 < d\u2081+d\u2082 < 2d\u2082 plus nonvanishing of coefficients in characteristic 0",
+      "The gap between log k and k^{1-c} is exponential \u2014 determining the true growth rate is the main open problem",
+      "Schinzel's method generalizes to P^n for any n \u2265 1, showing g(k,n) \u2192 \u221e via the same algebraic framework"
     ],
     "prerequisites": [
       "Combinatorics and number theory",
@@ -59,7 +59,7 @@
       "title": "The Function f(k)",
       "startLine": 70,
       "endLine": 78,
-      "summary": "Defines f(k) = sInf {termCount(P²) : hasTerms(P,k)} as the minimum achievable term count after squaring a k-term polynomial.",
+      "summary": "Defines f(k) = sInf {termCount(P\u00b2) : hasTerms(P,k)} as the minimum achievable term count after squaring a k-term polynomial.",
       "mathContext": "The use of $\\text{sInf}$ (infimum in $\\mathbb{N}$) is justified by well-ordering: the set is nonempty for $k \\geq 1$ (take any $k$-term polynomial), and every nonempty subset of $\\mathbb{N}$ has a minimum.  Equivalently, $f(k) = \\min\\{|S + S| - r(S) : S \\subseteq \\mathbb{N},\\, |S| = k\\}$ where $r(S)$ counts cancellations achievable by coefficient choice."
     },
     {
@@ -67,15 +67,15 @@
       "title": "Basic Properties (Aristotle-proved)",
       "startLine": 79,
       "endLine": 135,
-      "summary": "Fully proved: f(1) = 1 (monomial), f(2) = 3 (binomial), f(k) ≥ 1 for k ≥ 1. The f(2) = 3 proof constructs the witness (1+x) and shows every binomial square has support ⊇ {2d₁, d₁+d₂, 2d₂}.",
+      "summary": "Fully proved: f(1) = 1 (monomial), f(2) = 3 (binomial), f(k) \u2265 1 for k \u2265 1. The f(2) = 3 proof constructs the witness (1+x) and shows every binomial square has support \u2287 {2d\u2081, d\u2081+d\u2082, 2d\u2082}.",
       "mathContext": "The proof of $f(2) = 3$ is the most substantial: for the lower bound, given $P = c_1 x^{d_1} + c_2 x^{d_2}$ with $d_1 < d_2$ and $c_1, c_2 \\neq 0$, the square $P^2 = c_1^2 x^{2d_1} + 2c_1 c_2 x^{d_1+d_2} + c_2^2 x^{2d_2}$ has three terms because (1) the exponents $2d_1 < d_1 + d_2 < 2d_2$ are strictly increasing, and (2) all coefficients are nonzero since $\\text{char}(\\mathbb{Q}) = 0$."
     },
     {
       "id": "upper-bound",
-      "title": "Erdős Upper Bound",
+      "title": "Erd\u0151s Upper Bound",
       "startLine": 136,
       "endLine": 145,
-      "summary": "Erdős (1949): ∃ c > 0 such that f(k) < k^{1-c} for large k. Squaring can achieve sublinear compression. Axiomatized.",
+      "summary": "Erd\u0151s (1949): \u2203 c > 0 such that f(k) < k^{1-c} for large k. Squaring can achieve sublinear compression. Axiomatized.",
       "mathContext": "The construction uses polynomials with $\\pm 1$ coefficients whose support forms a set with large additive energy, enabling massive cancellation in the square.  The constant $c$ is small; the best known value gives $f(k) < k^{1-c}$ for $c \\approx 1/\\log \\log k$."
     },
     {
@@ -83,8 +83,8 @@
       "title": "Main Divergence Result",
       "startLine": 148,
       "endLine": 174,
-      "summary": "The three main theorems: Schinzel's (log log k)/log 2 lower bound, Schinzel–Zannier's log k improvement, and the main divergence f(k) → ∞. All axiomatized.",
-      "mathContext": "The bounds satisfy $\\frac{\\log \\log k}{\\log 2} < f(k) \\ll \\log k \\ll f(k) < k^{1-c}$, with the Schinzel–Zannier bound as the state of the art.  The main theorem $f(k) \\to \\infty$ follows from either lower bound via the monotone convergence criterion."
+      "summary": "The three main theorems: Schinzel's (log log k)/log 2 lower bound, Schinzel\u2013Zannier's log k improvement, and the main divergence f(k) \u2192 \u221e. All axiomatized.",
+      "mathContext": "The bounds satisfy $\\frac{\\log \\log k}{\\log 2} < f(k) \\ll \\log k \\ll f(k) < k^{1-c}$, with the Schinzel\u2013Zannier bound as the state of the art.  The main theorem $f(k) \\to \\infty$ follows from either lower bound via the monotone convergence criterion."
     },
     {
       "id": "related",
@@ -96,12 +96,12 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization of Erdős Problem #485 captures the full arc from problem statement through resolution.  The base cases f(1) = 1 and f(2) = 3 are fully machine-verified (by Aristotle), while the deep results — Erdős's sublinear upper bound and Schinzel(–Zannier)'s logarithmic lower bound — are axiomatized.  The formalization includes the natural generalization g(k,n) → ∞ for P^n.",
+    "summary": "This formalization of Erd\u0151s Problem #485 captures the full arc from problem statement through resolution.  The base cases f(1) = 1 and f(2) = 3 are fully machine-verified (by Aristotle), while the deep results \u2014 Erd\u0151s's sublinear upper bound and Schinzel(\u2013Zannier)'s logarithmic lower bound \u2014 are axiomatized.  The formalization includes the natural generalization g(k,n) \u2192 \u221e for P^n.",
     "implications": "The result establishes a fundamental limitation on polynomial compression through powering: term counts cannot be made arbitrarily small.  This has implications for sparse polynomial arithmetic in computer algebra (the complexity of polynomial multiplication depends on output sparsity) and connects to additive combinatorics through the sumset structure of polynomial supports.",
     "openQuestions": [
       "What is the exact asymptotic growth rate of f(k)? The gap between log k and k^{1-c} is enormous.",
-      "Is there a combinatorial (non-algebraic) proof of f(k) → ∞, e.g., via sumset bounds?",
-      "For which fields F does f_F(k) → ∞? The result holds in characteristic 0 and large characteristic, but positive characteristic allows new cancellations.",
+      "Is there a combinatorial (non-algebraic) proof of f(k) \u2192 \u221e, e.g., via sumset bounds?",
+      "For which fields F does f_F(k) \u2192 \u221e? The result holds in characteristic 0 and large characteristic, but positive characteristic allows new cancellations.",
       "What are the extremal polynomials achieving f(k)? No explicit optimal constructions are known for large k."
     ]
   },
@@ -115,7 +115,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos485",
-    "lineCount": 225,
+    "lineCount": 226,
     "axiomCount": 1,
     "theoremCount": 3,
     "definitionCount": 6,
@@ -126,17 +126,17 @@
     {
       "targetId": "erdos-1114",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: polynomials, solved"
+      "description": "Related Erd\u0151s problem sharing themes: polynomials, solved"
     },
     {
       "targetId": "erdos-391",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: asymptotics, solved"
+      "description": "Related Erd\u0151s problem sharing themes: asymptotics, solved"
     },
     {
       "targetId": "erdos-523",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: polynomials, solved"
+      "description": "Related Erd\u0151s problem sharing themes: polynomials, solved"
     }
   ],
   "sorries": 0

--- a/src/data/proofs/erdos-517/meta.json
+++ b/src/data/proofs/erdos-517/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-517",
-  "title": "Erdős Problem #517: Lacunary Entire Functions and Value Distribution",
+  "title": "Erd\u0151s Problem #517: Lacunary Entire Functions and Value Distribution",
   "slug": "erdos-517",
-  "description": "Do entire functions with Fabry gaps (nₖ/k → ∞) assume every value infinitely often? The main conjecture is OPEN, but Biernacki proved the stronger Fejér gap case.",
+  "description": "Do entire functions with Fabry gaps (n\u2096/k \u2192 \u221e) assume every value infinitely often? The main conjecture is OPEN, but Biernacki proved the stronger Fej\u00e9r gap case.",
   "meta": {
-    "author": "Fejér-Pólya Conjecture; Biernacki (1928) for Fejér gaps",
+    "author": "Fej\u00e9r-P\u00f3lya Conjecture; Biernacki (1928) for Fej\u00e9r gaps",
     "sourceUrl": "https://erdosproblems.com/517",
     "date": "1928",
     "status": "axiomatized",
@@ -45,41 +45,41 @@
       }
     ],
     "originalContributions": [
-      "Clear formalization of Fabry and Fejér gap conditions",
+      "Clear formalization of Fabry and Fej\u00e9r gap conditions",
       "Statement of the open Fabry gap conjecture",
       "Biernacki's theorem as an axiom with educational documentation",
-      "Verified example showing exponential sequences have Fejér gaps"
+      "Verified example showing exponential sequences have Fej\u00e9r gaps"
     ],
     "dateAdded": "2025-12-22",
     "lineCount": 175,
     "prerequisites": [
       "Complex analysis: entire functions, power series",
-      "Lacunary (gap) series and Fabry/Fejér gap conditions",
-      "Summability conditions (∑1/nₖ convergence)",
+      "Lacunary (gap) series and Fabry/Fej\u00e9r gap conditions",
+      "Summability conditions (\u22111/n\u2096 convergence)",
       "Value distribution theory (Picard/Borel)",
       "Basic series convergence from Mathlib"
     ],
     "axiomCount": 1,
     "assumptions": [
-      "biernacki_theorem: Under Fejér gaps (∑1/nₖ < ∞), entire functions assume every value infinitely often. Deep complex analysis result beyond Mathlib."
+      "biernacki_theorem: Under Fej\u00e9r gaps (\u22111/n\u2096 < \u221e), entire functions assume every value infinitely often. Deep complex analysis result beyond Mathlib."
     ]
   },
   "overview": {
-    "historicalContext": "This problem concerns lacunary power series - series f(z) = ∑ aₖz^{nₖ} where the exponents have gaps. The question of how these gaps affect value distribution goes back to the early 20th century.\n\nFejér (1908) proved that if ∑1/nₖ < ∞, the function assumes every value at least once. Biernacki (1928) strengthened this to show every value is assumed infinitely often under the same condition.\n\nThe Fejér-Pólya conjecture asks whether the weaker Fabry gap condition (nₖ/k → ∞) is sufficient. Pólya (1929) proved partial results for functions of finite order, but the general case remains open. This is a fundamental question connecting gap conditions in power series to complex function theory.",
-    "problemStatement": "**Conjecture (Fejér-Pólya)**: Let $f(z) = \\sum_{k=1}^{\\infty} a_k z^{n_k}$ be an entire function with $a_k \\neq 0$. If the exponents satisfy the **Fabry gap condition** $n_k/k \\to \\infty$, does $f(z)$ assume every complex value infinitely often?\n\n**Status**: OPEN\n\n**Related Result (Biernacki 1928)**: Under the stronger **Fejér gap condition** $\\sum 1/n_k < \\infty$, the answer is YES.",
-    "text": "Do entire functions with Fabry gaps (nₖ/k → ∞) assume every value infinitely often? The main conjecture is OPEN, but Biernacki proved the stronger Fejér gap case.",
-    "proofStrategy": "We formalize both the open conjecture and the related solved result:\n\n1. **Gap Conditions**: Define HasFabryGaps (nₖ/k → ∞) and HasFejerGaps (∑1/nₖ < ∞)\n\n2. **Hierarchy**: Prove that Fejér gaps imply Fabry gaps (the converse is false)\n\n3. **Open Conjecture**: State the Fabry gap conjecture as a Prop that can be true or false\n\n4. **Biernacki's Theorem**: State the solved Fejér gap case as an axiom, since the complex analysis proof is beyond current Mathlib\n\n5. **Example**: Verify that nₖ = 2^k has Fejér gaps, demonstrating the applicability of Biernacki's theorem",
+    "historicalContext": "This problem concerns lacunary power series - series f(z) = \u2211 a\u2096z^{n\u2096} where the exponents have gaps. The question of how these gaps affect value distribution goes back to the early 20th century.\n\nFej\u00e9r (1908) proved that if \u22111/n\u2096 < \u221e, the function assumes every value at least once. Biernacki (1928) strengthened this to show every value is assumed infinitely often under the same condition.\n\nThe Fej\u00e9r-P\u00f3lya conjecture asks whether the weaker Fabry gap condition (n\u2096/k \u2192 \u221e) is sufficient. P\u00f3lya (1929) proved partial results for functions of finite order, but the general case remains open. This is a fundamental question connecting gap conditions in power series to complex function theory.",
+    "problemStatement": "**Conjecture (Fej\u00e9r-P\u00f3lya)**: Let $f(z) = \\sum_{k=1}^{\\infty} a_k z^{n_k}$ be an entire function with $a_k \\neq 0$. If the exponents satisfy the **Fabry gap condition** $n_k/k \\to \\infty$, does $f(z)$ assume every complex value infinitely often?\n\n**Status**: OPEN\n\n**Related Result (Biernacki 1928)**: Under the stronger **Fej\u00e9r gap condition** $\\sum 1/n_k < \\infty$, the answer is YES.",
+    "text": "Do entire functions with Fabry gaps (n\u2096/k \u2192 \u221e) assume every value infinitely often? The main conjecture is OPEN, but Biernacki proved the stronger Fej\u00e9r gap case.",
+    "proofStrategy": "We formalize both the open conjecture and the related solved result:\n\n1. **Gap Conditions**: Define HasFabryGaps (n\u2096/k \u2192 \u221e) and HasFejerGaps (\u22111/n\u2096 < \u221e)\n\n2. **Hierarchy**: Prove that Fej\u00e9r gaps imply Fabry gaps (the converse is false)\n\n3. **Open Conjecture**: State the Fabry gap conjecture as a Prop that can be true or false\n\n4. **Biernacki's Theorem**: State the solved Fej\u00e9r gap case as an axiom, since the complex analysis proof is beyond current Mathlib\n\n5. **Example**: Verify that n\u2096 = 2^k has Fej\u00e9r gaps, demonstrating the applicability of Biernacki's theorem",
     "keyInsights": [
       "**Lacunary series**: Power series with gaps in exponents have special properties. The 'density' of gaps determines value distribution behavior.",
-      "**Gap hierarchy**: Fejér gaps (∑1/nₖ < ∞) ⊂ Fabry gaps (nₖ/k → ∞). The former is easier to analyze but more restrictive.",
+      "**Gap hierarchy**: Fej\u00e9r gaps (\u22111/n\u2096 < \u221e) \u2282 Fabry gaps (n\u2096/k \u2192 \u221e). The former is easier to analyze but more restrictive.",
       "**Value distribution**: Picard's theorem says entire functions miss at most one value. Gap conditions can force every value to be assumed infinitely often.",
       "**The gap**: Despite 100+ years of study, we don't know if the weaker Fabry condition suffices for infinite value coverage.",
-      "**Nevanlinna-theoretic perspective**: The counting function $n(r,w)$ of $w$-points in $|z| < r$ grows without bound for each $w$ under Fejér gaps. The open question is whether Fabry gaps — which only control the *rate* of exponent growth rather than their summability — still force this growth for every value simultaneously."
+      "**Nevanlinna-theoretic perspective**: The counting function $n(r,w)$ of $w$-points in $|z| < r$ grows without bound for each $w$ under Fej\u00e9r gaps. The open question is whether Fabry gaps \u2014 which only control the *rate* of exponent growth rather than their summability \u2014 still force this growth for every value simultaneously."
     ],
     "prerequisites": [
       "Complex analysis: entire functions, power series",
-      "Lacunary (gap) series and Fabry/Fejér gap conditions",
-      "Summability conditions (∑1/nₖ convergence)",
+      "Lacunary (gap) series and Fabry/Fej\u00e9r gap conditions",
+      "Summability conditions (\u22111/n\u2096 convergence)",
       "Value distribution theory (Picard/Borel)",
       "Basic series convergence from Mathlib"
     ]
@@ -90,16 +90,16 @@
       "title": "File Headers and Imports",
       "startLine": 1,
       "endLine": 47,
-      "summary": "Aristotle proof attribution header, module docstring with problem statement, historical references (Fejér 1908, Biernacki 1928, Pólya 1929), and Mathlib imports.",
-      "mathContext": "Problem: if $f(z) = \\sum a_k z^{n_k}$ is entire with Fabry gaps ($n_k/k \\to \\infty$), does $f$ assume every value infinitely often? **OPEN.** Solved under stronger Fejér gaps ($\\sum 1/n_k < \\infty$)."
+      "summary": "Aristotle proof attribution header, module docstring with problem statement, historical references (Fej\u00e9r 1908, Biernacki 1928, P\u00f3lya 1929), and Mathlib imports.",
+      "mathContext": "Problem: if $f(z) = \\sum a_k z^{n_k}$ is entire with Fabry gaps ($n_k/k \\to \\infty$), does $f$ assume every value infinitely often? **OPEN.** Solved under stronger Fej\u00e9r gaps ($\\sum 1/n_k < \\infty$)."
     },
     {
       "id": "gap-conditions",
       "title": "Gap Conditions and Their Relationship",
       "startLine": 48,
       "endLine": 101,
-      "summary": "Defines HasFabryGaps (nₖ/k → ∞) and HasFejerGaps (∑1/nₖ < ∞), then proves HasFejerGaps.hasFabryGaps: Fejér gaps imply Fabry gaps via a squeeze argument on (nₖ)⁻¹·k → 0. This theorem was proved by Aristotle.",
-      "mathContext": "Fabry: $n_k/k \\to \\infty$ (gaps grow superlinearly). Fejér: $\\sum 1/n_k < \\infty$ (reciprocals summable). Implication: $\\sum 1/n_k < \\infty \\Rightarrow n_k/k \\to \\infty$. Proof: if $\\sum (n_k)^{-1}$ converges, a squeeze via $\\sum_{i \\in [k/2, k)} (n_i)^{-1} \\geq (k/2)(n_k)^{-1}$ shows $(n_k)^{-1} \\cdot k \\to 0$."
+      "summary": "Defines HasFabryGaps (n\u2096/k \u2192 \u221e) and HasFejerGaps (\u22111/n\u2096 < \u221e), then proves HasFejerGaps.hasFabryGaps: Fej\u00e9r gaps imply Fabry gaps via a squeeze argument on (n\u2096)\u207b\u00b9\u00b7k \u2192 0. This theorem was proved by Aristotle.",
+      "mathContext": "Fabry: $n_k/k \\to \\infty$ (gaps grow superlinearly). Fej\u00e9r: $\\sum 1/n_k < \\infty$ (reciprocals summable). Implication: $\\sum 1/n_k < \\infty \\Rightarrow n_k/k \\to \\infty$. Proof: if $\\sum (n_k)^{-1}$ converges, a squeeze via $\\sum_{i \\in [k/2, k)} (n_i)^{-1} \\geq (k/2)(n_k)^{-1}$ shows $(n_k)^{-1} \\cdot k \\to 0$."
     },
     {
       "id": "main-conjecture",
@@ -114,7 +114,7 @@
       "title": "Biernacki's Theorem (1928)",
       "startLine": 128,
       "endLine": 150,
-      "summary": "States Biernacki's theorem as an axiom: under Fejér gaps, entire functions assume every value infinitely often. Axiomatized because the proof requires deep complex analysis (Picard theory, growth estimates) beyond Mathlib.",
+      "summary": "States Biernacki's theorem as an axiom: under Fej\u00e9r gaps, entire functions assume every value infinitely often. Axiomatized because the proof requires deep complex analysis (Picard theory, growth estimates) beyond Mathlib.",
       "mathContext": "Axiom `biernacki_theorem`: $\\text{HasFejerGaps}(n) \\wedge (\\forall z,\\; \\sum a_k z^{n_k} = f(z)) \\Rightarrow \\forall w,\\; \\{z : f(z) = w\\}$ is infinite. Combines Picard's theorem, lacunary series boundary behavior, and growth analysis."
     },
     {
@@ -122,15 +122,15 @@
       "title": "Example: Exponential Gaps and Application",
       "startLine": 151,
       "endLine": 176,
-      "summary": "Verifies nₖ = 2^k has Fejér gaps (geometric series ∑1/2^k converges), then applies Biernacki's theorem to conclude any entire function f(z) = ∑ aₖz^{2^k} assumes every value infinitely often.",
+      "summary": "Verifies n\u2096 = 2^k has Fej\u00e9r gaps (geometric series \u22111/2^k converges), then applies Biernacki's theorem to conclude any entire function f(z) = \u2211 a\u2096z^{2^k} assumes every value infinitely often.",
       "mathContext": "$n_k = 2^k$: strictly increasing (powers of 2), and $\\sum 2^{-k} = 1 < \\infty$ (geometric series). By Biernacki: $\\forall w \\in \\mathbb{C},\\; |\\{z : f(z) = w\\}| = \\infty$ for any entire $f(z) = \\sum a_k z^{2^k}$."
     }
   ],
   "conclusion": {
-    "summary": "We formalize the Fejér-Pólya conjecture on lacunary entire functions. The main question - whether Fabry gaps suffice for infinite value coverage - remains open after over a century. We state Biernacki's 1928 theorem for the stronger Fejér gap condition and demonstrate its application to exponential sequences.",
+    "summary": "We formalize the Fej\u00e9r-P\u00f3lya conjecture on lacunary entire functions. The main question - whether Fabry gaps suffice for infinite value coverage - remains open after over a century. We state Biernacki's 1928 theorem for the stronger Fej\u00e9r gap condition and demonstrate its application to exponential sequences.",
     "implications": "This problem sits at the intersection of gap Tauberian theory and Nevanlinna theory. Its resolution would clarify the precise relationship between power series gaps and value distribution in complex analysis.",
     "openQuestions": [
-      "Does the Fabry gap condition nₖ/k → ∞ imply every value is assumed infinitely often?",
+      "Does the Fabry gap condition n\u2096/k \u2192 \u221e imply every value is assumed infinitely often?",
       "What is the weakest gap condition that guarantees infinite value coverage?",
       "Can techniques from Nevanlinna theory be extended to handle Fabry gaps?"
     ]
@@ -145,7 +145,7 @@
       "Topology"
     ],
     "namespace": "Erdos517",
-    "lineCount": 175,
+    "lineCount": 176,
     "axiomCount": 1,
     "theoremCount": 3,
     "definitionCount": 3,
@@ -154,22 +154,22 @@
   },
   "references": [
     {
-      "authors": "Fejér, Leopold",
-      "title": "Über die Wurzel vom kleinsten absoluten Betrage einer algebraischen Gleichung",
+      "authors": "Fej\u00e9r, Leopold",
+      "title": "\u00dcber die Wurzel vom kleinsten absoluten Betrage einer algebraischen Gleichung",
       "year": "1908",
       "venue": "Mathematische Annalen, 65, pp. 413-423",
-      "note": "Proved entire functions with ∑1/nₖ < ∞ assume every value at least once"
+      "note": "Proved entire functions with \u22111/n\u2096 < \u221e assume every value at least once"
     },
     {
-      "authors": "Biernacki, Mieczysław",
-      "title": "Sur les équations algébriques contenant des paramètres arbitraires",
+      "authors": "Biernacki, Mieczys\u0142aw",
+      "title": "Sur les \u00e9quations alg\u00e9briques contenant des param\u00e8tres arbitraires",
       "year": "1928",
-      "venue": "Bulletin de l'Académie Polonaise des Sciences",
-      "note": "Strengthened Fejér's result: under ∑1/nₖ < ∞, every value is assumed infinitely often"
+      "venue": "Bulletin de l'Acad\u00e9mie Polonaise des Sciences",
+      "note": "Strengthened Fej\u00e9r's result: under \u22111/n\u2096 < \u221e, every value is assumed infinitely often"
     },
     {
-      "authors": "Pólya, George",
-      "title": "Untersuchungen über Lücken und Singularitäten von Potenzreihen",
+      "authors": "P\u00f3lya, George",
+      "title": "Untersuchungen \u00fcber L\u00fccken und Singularit\u00e4ten von Potenzreihen",
       "year": "1929",
       "venue": "Mathematische Zeitschrift, 29, pp. 549-640",
       "note": "Proved partial results for functions of finite order, posed the conjecture for the general Fabry case"
@@ -179,17 +179,17 @@
     {
       "targetId": "erdos-1116",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: complex-analysis, entire-functions, value-distribution"
+      "description": "Related Erd\u0151s problem sharing themes: complex-analysis, entire-functions, value-distribution"
     },
     {
       "targetId": "erdos-1117",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: complex-analysis, entire-functions, value-distribution"
+      "description": "Related Erd\u0151s problem sharing themes: complex-analysis, entire-functions, value-distribution"
     },
     {
       "targetId": "erdos-1115",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: complex-analysis, entire-functions"
+      "description": "Related Erd\u0151s problem sharing themes: complex-analysis, entire-functions"
     }
   ],
   "sorries": 0

--- a/src/data/proofs/erdos-551/meta.json
+++ b/src/data/proofs/erdos-551/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-551",
-  "title": "Erdős #551: Ramsey Numbers for Cycles vs Complete Graphs",
+  "title": "Erd\u0151s #551: Ramsey Numbers for Cycles vs Complete Graphs",
   "slug": "erdos-551",
-  "description": "Prove R(C_k, K_n) = (k-1)(n-1) + 1 for k ≥ n ≥ 3 (except n=k=3). Bondy-Erdős (1973): k > n²-2. Nikiforov (2005): k ≥ 4n+2. Keevash-Long-Skokan (2021): k ≥ C log n / log log n.",
+  "description": "Prove R(C_k, K_n) = (k-1)(n-1) + 1 for k \u2265 n \u2265 3 (except n=k=3). Bondy-Erd\u0151s (1973): k > n\u00b2-2. Nikiforov (2005): k \u2265 4n+2. Keevash-Long-Skokan (2021): k \u2265 C log n / log log n.",
   "meta": {
-    "author": "Paul Erdős, Bondy, Nikiforov, Keevash, Long, Skokan",
+    "author": "Paul Erd\u0151s, Bondy, Nikiforov, Keevash, Long, Skokan",
     "sourceUrl": "https://erdosproblems.com/551",
     "date": "1973-2021",
     "status": "formalized",
@@ -26,15 +26,15 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "The asymmetric Ramsey number R(C_k, K_n) asks for the minimum N such that every 2-coloring of the edges of K_N contains either a red k-cycle or a blue n-clique. Erdős, Faudree, Rousseau, and Schelp conjectured in 1978 that R(C_k, K_n) = (k-1)(n-1) + 1 for all k ≥ n ≥ 3, with a single exception at (k,n) = (3,3) where the formula gives 5 but the actual value is R(K_3, K_3) = 6. The lower bound comes from a beautiful construction: (n-1) disjoint copies of K_{k-1}, which has (k-1)(n-1) vertices, contains no C_k (each component is too small) and its complement contains no K_n (independence number n-1). Bondy and Erdős (1973) proved the formula for k > n² - 2, a quadratic threshold. Nikiforov (2005) dramatically improved this to k ≥ 4n + 2 using spectral graph theory and eigenvalue bounds. Finally, Keevash, Long, and Skokan (2021) achieved the near-optimal threshold k ≥ C log n / log log n using the stability method and extremal graph theory. The special case R(C_k, K_3) = 2k - 1 for k ≥ 4 was proved independently by Faudree-Schelp (1974) and Rosta (1973) using Dirac's theorem. The formalization includes a formally verified proof (by Aristotle) that the KLS threshold improves on Nikiforov's for n ≥ 100, using the bound e < 3.",
+    "historicalContext": "The asymmetric Ramsey number R(C_k, K_n) asks for the minimum N such that every 2-coloring of the edges of K_N contains either a red k-cycle or a blue n-clique. Erd\u0151s, Faudree, Rousseau, and Schelp conjectured in 1978 that R(C_k, K_n) = (k-1)(n-1) + 1 for all k \u2265 n \u2265 3, with a single exception at (k,n) = (3,3) where the formula gives 5 but the actual value is R(K_3, K_3) = 6. The lower bound comes from a beautiful construction: (n-1) disjoint copies of K_{k-1}, which has (k-1)(n-1) vertices, contains no C_k (each component is too small) and its complement contains no K_n (independence number n-1). Bondy and Erd\u0151s (1973) proved the formula for k > n\u00b2 - 2, a quadratic threshold. Nikiforov (2005) dramatically improved this to k \u2265 4n + 2 using spectral graph theory and eigenvalue bounds. Finally, Keevash, Long, and Skokan (2021) achieved the near-optimal threshold k \u2265 C log n / log log n using the stability method and extremal graph theory. The special case R(C_k, K_3) = 2k - 1 for k \u2265 4 was proved independently by Faudree-Schelp (1974) and Rosta (1973) using Dirac's theorem. The formalization includes a formally verified proof (by Aristotle) that the KLS threshold improves on Nikiforov's for n \u2265 100, using the bound e < 3.",
     "problemStatement": "Prove $R(C_k, K_n) = (k-1)(n-1) + 1$ for $k \\geq n \\geq 3$, except when $n = k = 3$ where $R(C_3, K_3) = 6$. The lower bound comes from $(n-1)$ disjoint copies of $K_{k-1}$. The upper bound requires showing any graph on $(k-1)(n-1)+1$ vertices contains $C_k$ or its complement contains $K_n$.",
-    "text": "Prove R(C_k, K_n) = (k-1)(n-1) + 1 for k ≥ n ≥ 3 (except n=k=3). Bondy-Erdős (1973): k > n²-2. Nikiforov (2005): k ≥ 4n+2. Keevash-Long-Skokan (2021): k ≥ C log n / log log n.",
-    "proofStrategy": "The formalization defines cycle graphs $C_k$, complete graphs $K_n$, and formalizes containment of cycles and cliques via injective embeddings. The Ramsey number $R(C_k, K_n)$ is defined via `Nat.find`. The lower bound graph — $(n-1)$ disjoint copies of $K_{k-1}$ — is explicitly constructed with adjacency determined by integer division. Three progressively stronger theorems are stated: Bondy-Erdős (quadratic threshold), Nikiforov (linear threshold), and Keevash-Long-Skokan (near-logarithmic threshold). The theorem `kls_improves` was formally verified by Aristotle using the bound $e < 3$. Special cases include $R(C_k, K_3) = 2k-1$ and verified values $R(C_4, K_3) = 7$, $R(C_5, K_3) = 9$. Monotonicity in both parameters and the path-cycle upper bound method complete the picture.",
+    "text": "Prove R(C_k, K_n) = (k-1)(n-1) + 1 for k \u2265 n \u2265 3 (except n=k=3). Bondy-Erd\u0151s (1973): k > n\u00b2-2. Nikiforov (2005): k \u2265 4n+2. Keevash-Long-Skokan (2021): k \u2265 C log n / log log n.",
+    "proofStrategy": "The formalization defines cycle graphs $C_k$, complete graphs $K_n$, and formalizes containment of cycles and cliques via injective embeddings. The Ramsey number $R(C_k, K_n)$ is defined via `Nat.find`. The lower bound graph \u2014 $(n-1)$ disjoint copies of $K_{k-1}$ \u2014 is explicitly constructed with adjacency determined by integer division. Three progressively stronger theorems are stated: Bondy-Erd\u0151s (quadratic threshold), Nikiforov (linear threshold), and Keevash-Long-Skokan (near-logarithmic threshold). The theorem `kls_improves` was formally verified by Aristotle using the bound $e < 3$. Special cases include $R(C_k, K_3) = 2k-1$ and verified values $R(C_4, K_3) = 7$, $R(C_5, K_3) = 9$. Monotonicity in both parameters and the path-cycle upper bound method complete the picture.",
     "keyInsights": [
-      "The threshold progression is dramatic: $n^2 - 1$ (Bondy-Erdős 1973) $\\to$ $4n + 2$ (Nikiforov 2005) $\\to$ $C \\log n / \\log \\log n$ (KLS 2021) — from quadratic to near-logarithmic over 48 years",
+      "The threshold progression is dramatic: $n^2 - 1$ (Bondy-Erd\u0151s 1973) $\\to$ $4n + 2$ (Nikiforov 2005) $\\to$ $C \\log n / \\log \\log n$ (KLS 2021) \u2014 from quadratic to near-logarithmic over 48 years",
       "The lower bound graph $(n-1) \\sqcup K_{k-1}$ is simultaneously $C_k$-free (components too small for a $k$-cycle) and its complement is $K_n$-free (independence number $n-1$), giving $R(C_k, K_n) \\geq (k-1)(n-1) + 1$",
       "The exception at $(3,3)$: since $C_3 = K_3$, $R(C_3, K_3) = R(K_3, K_3) = 6$ by classical Ramsey theory, but the formula gives $(3-1)(3-1)+1 = 5$",
-      "For $n = 100$: Bondy-Erdős needs $k \\geq 9999$, Nikiforov needs $k \\geq 402$, KLS needs $k \\geq 3C$ — the improvement is thousandfold",
+      "For $n = 100$: Bondy-Erd\u0151s needs $k \\geq 9999$, Nikiforov needs $k \\geq 402$, KLS needs $k \\geq 3C$ \u2014 the improvement is thousandfold",
       "The triangle case $R(C_k, K_3) = 2k - 1$ for $k \\geq 4$ follows from Dirac's theorem: a graph on $2k-1$ vertices with no triangle in the complement has minimum degree $\\geq k$, hence a Hamiltonian cycle",
       "Aristotle formally verified `kls_improves`: for $n \\geq 100$, $\\log n / \\log \\log n < 4n + 2$, using $e < 3$ proved via Taylor expansion bounds"
     ],
@@ -42,7 +42,7 @@
       "Ramsey numbers ($R(G,H)$ for specific graphs)",
       "Cycle graphs ($C_k$) and complete graphs ($K_n$)",
       "Turan-type stability arguments",
-      "Szemerédi regularity lemma",
+      "Szemer\u00e9di regularity lemma",
       "Graph coloring (red-blue edge colorings)"
     ]
   },
@@ -74,7 +74,7 @@
     {
       "id": "conjecture",
       "title": "The Main Conjecture and Exception",
-      "summary": "ConjecturedFormula (k-1)(n-1)+1, MainConjecture for k ≥ n ≥ 3 excluding (3,3), exception_3_3 showing R(C_3,K_3) = 6, formula_wrong_at_3_3 proved by native_decide",
+      "summary": "ConjecturedFormula (k-1)(n-1)+1, MainConjecture for k \u2265 n \u2265 3 excluding (3,3), exception_3_3 showing R(C_3,K_3) = 6, formula_wrong_at_3_3 proved by native_decide",
       "startLine": 145,
       "endLine": 174,
       "mathContext": "Conjectured formula: $R(C_k, K_n) = (k-1)(n-1)+1$ for $k \\\\geq n \\\\geq 3$, $(k,n) \\\\neq (3,3)$. Exception: $R(K_3, K_3) = 6 \\\\neq 5$."
@@ -89,8 +89,8 @@
     },
     {
       "id": "bondy-erdos",
-      "title": "Bondy-Erdős (1973): Quadratic Threshold",
-      "summary": "bondy_erdos theorem for k > n²-2, BondyErdosThreshold definition, above_bondy_erdos_threshold corollary",
+      "title": "Bondy-Erd\u0151s (1973): Quadratic Threshold",
+      "summary": "bondy_erdos theorem for k > n\u00b2-2, BondyErdosThreshold definition, above_bondy_erdos_threshold corollary",
       "startLine": 243,
       "endLine": 267,
       "mathContext": "Bondy-Erdos (1973): formula holds for $k > n^2 - 2$. The first threshold result."
@@ -98,7 +98,7 @@
     {
       "id": "nikiforov",
       "title": "Nikiforov (2005): Linear Threshold",
-      "summary": "nikiforov theorem for k ≥ 4n+2, NikiforovThreshold definition, nikiforov_improves proved by omega for n ≥ 5",
+      "summary": "nikiforov theorem for k \u2265 4n+2, NikiforovThreshold definition, nikiforov_improves proved by omega for n \u2265 5",
       "startLine": 278,
       "endLine": 293,
       "mathContext": "Nikiforov (2005): formula holds for $k \\\\geq 4n + 2$. Significant improvement from $n^2$ to $4n$."
@@ -106,7 +106,7 @@
     {
       "id": "kls",
       "title": "Keevash-Long-Skokan (2021): Near-Logarithmic Threshold",
-      "summary": "keevash_long_skokan with existential constant C, KLSThreshold as log n / log log n, exp_one_lt_3 lemma via Taylor bounds, kls_improves PROVED by Aristotle for n ≥ 100",
+      "summary": "keevash_long_skokan with existential constant C, KLSThreshold as log n / log log n, exp_one_lt_3 lemma via Taylor bounds, kls_improves PROVED by Aristotle for n \u2265 100",
       "startLine": 312,
       "endLine": 358,
       "mathContext": "Keevash-Long-Skokan: formula holds for $k \\\\geq C\\\\log n / \\\\log\\\\log n$ for some constant $C$. Near-optimal threshold."
@@ -114,7 +114,7 @@
     {
       "id": "special-cases",
       "title": "Special Cases: Small Parameters and R(C_k, K_3)",
-      "summary": "cycle_3_is_triangle (C_3 = K_3), ramsey_C4_K3 = 7, ramsey_C5_K3 = 9, ramsey_Ck_K3 = 2k-1 for k ≥ 4 (triangle case via Dirac's theorem)",
+      "summary": "cycle_3_is_triangle (C_3 = K_3), ramsey_C4_K3 = 7, ramsey_C5_K3 = 9, ramsey_Ck_K3 = 2k-1 for k \u2265 4 (triangle case via Dirac's theorem)",
       "startLine": 376,
       "endLine": 420,
       "mathContext": "$R(C_4, K_3) = 7$, $R(C_5, K_3) = 9$. For $k \\\\geq 4$, $n = 3$: $R(C_k, K_3) = 2k-1$ (Faudree-Schelp)."
@@ -122,7 +122,7 @@
     {
       "id": "related",
       "title": "Related Questions: SmallestValidK and MinRamseyValue",
-      "summary": "SmallestValidK via Nat.find for threshold where formula holds, MinRamseyValue as infimum of R(C_k, K_n) over k ≥ n, min_ramsey_achieved existence",
+      "summary": "SmallestValidK via Nat.find for threshold where formula holds, MinRamseyValue as infimum of R(C_k, K_n) over k \u2265 n, min_ramsey_achieved existence",
       "startLine": 425,
       "endLine": 461,
       "mathContext": "SmallestValidK: the minimum $k$ where $(k-1)(n-1)+1$ holds for all $n$. Approaches 3 or 4 as theorems improve."
@@ -138,7 +138,7 @@
     {
       "id": "upper-bound",
       "title": "Upper Bound: Path-Cycle Method",
-      "summary": "upper_bound theorem R(C_k, K_n) ≤ (k-1)(n-1)+1 for k ≥ n ≥ 3 excluding (3,3), path_cycle_method establishing RamseyProperty for N ≥ (k-1)(n-1)+1",
+      "summary": "upper_bound theorem R(C_k, K_n) \u2264 (k-1)(n-1)+1 for k \u2265 n \u2265 3 excluding (3,3), path_cycle_method establishing RamseyProperty for N \u2265 (k-1)(n-1)+1",
       "startLine": 522,
       "endLine": 542,
       "mathContext": "$R(C_k, K_n) \\\\leq (k-1)(n-1)+1$ for $k \\\\geq n \\\\geq 3$, $(k,n) \\\\neq (3,3)$. Proved by stability + regularity arguments."
@@ -146,19 +146,19 @@
     {
       "id": "summary",
       "title": "Main Theorem, Current Best, and Asymptotic Resolution",
-      "summary": "main_theorem combining all progress (formula ↔ k ≥ SmallestValidK), current_best via KLS bound, solved_asymptotically showing formula holds for all but finitely many k per fixed n",
+      "summary": "main_theorem combining all progress (formula \u2194 k \u2265 SmallestValidK), current_best via KLS bound, solved_asymptotically showing formula holds for all but finitely many k per fixed n",
       "startLine": 560,
       "endLine": 604,
       "mathContext": "Conjectured: $R(C_k,K_n) = (k-1)(n-1)+1$ for $k \\\\geq n \\\\geq 3$, $(k,n) \\\\neq (3,3)$. Known thresholds: $k \\\\geq 4n+2$ (Nikiforov), $k \\\\geq C\\\\log n/\\\\log\\\\log n$ (KLS)."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #551 on R(C_k, K_n) = (k-1)(n-1) + 1 is SOLVED for sufficiently large parameters. The 604-line formalization captures the full 48-year progression: Bondy-Erdős (1973, quadratic threshold), Nikiforov (2005, linear threshold), and KLS (2021, near-logarithmic threshold). The lower bound construction via disjoint cliques, the (3,3) exception, the triangle case R(C_k, K_3) = 2k-1, monotonicity properties, and the path-cycle upper bound method are all formalized. Aristotle formally proved kls_improves and formula_mono; formula_wrong_at_3_3 was verified by native_decide.",
-    "implications": "**Theoretical Significance**: The near-logarithmic threshold from KLS essentially closes the problem: for any fixed n, the formula holds for all but at most O(log n / log log n) values of k.\n\nThe linear dependence on n in the formula (k-1)(n-1)+1 has a clean structural explanation via the disjoint cliques lower bound. The progression from quadratic to near-logarithmic thresholds illustrates how spectral methods (Nikiforov) and stability methods (KLS) can dramatically improve on classical combinatorial arguments (Bondy-Erdős).",
+    "summary": "Erd\u0151s Problem #551 on R(C_k, K_n) = (k-1)(n-1) + 1 is SOLVED for sufficiently large parameters. The 604-line formalization captures the full 48-year progression: Bondy-Erd\u0151s (1973, quadratic threshold), Nikiforov (2005, linear threshold), and KLS (2021, near-logarithmic threshold). The lower bound construction via disjoint cliques, the (3,3) exception, the triangle case R(C_k, K_3) = 2k-1, monotonicity properties, and the path-cycle upper bound method are all formalized. Aristotle formally proved kls_improves and formula_mono; formula_wrong_at_3_3 was verified by native_decide.",
+    "implications": "**Theoretical Significance**: The near-logarithmic threshold from KLS essentially closes the problem: for any fixed n, the formula holds for all but at most O(log n / log log n) values of k.\n\nThe linear dependence on n in the formula (k-1)(n-1)+1 has a clean structural explanation via the disjoint cliques lower bound. The progression from quadratic to near-logarithmic thresholds illustrates how spectral methods (Nikiforov) and stability methods (KLS) can dramatically improve on classical combinatorial arguments (Bondy-Erd\u0151s).",
     "openQuestions": [
-      "For fixed n, what is the exact smallest k₀(n) where R(C_k, K_n) = (k-1)(n-1)+1 for all k ≥ k₀(n)?",
+      "For fixed n, what is the exact smallest k\u2080(n) where R(C_k, K_n) = (k-1)(n-1)+1 for all k \u2265 k\u2080(n)?",
       "Can the KLS constant C be determined explicitly, and what is its optimal value?",
-      "What is the minimum of R(C_k, K_n) over k ≥ n for fixed n — does it occur near k = n or at a larger value?",
+      "What is the minimum of R(C_k, K_n) over k \u2265 n for fixed n \u2014 does it occur near k = n or at a larger value?",
       "Can the regularity-free approach (used by AKS for bipartite graphs in Problem #546) be adapted to the cycle-vs-clique setting?"
     ]
   },
@@ -175,7 +175,7 @@
       "Finset"
     ],
     "namespace": "Erdos551",
-    "lineCount": 603,
+    "lineCount": 604,
     "axiomCount": 0,
     "theoremCount": 26,
     "definitionCount": 14,
@@ -186,17 +186,17 @@
     {
       "targetId": "erdos-570",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: cycles, graph-theory, ramsey-theory"
+      "description": "Related Erd\u0151s problem sharing themes: cycles, graph-theory, ramsey-theory"
     },
     {
       "targetId": "erdos-720",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: cycles, graph-theory, ramsey-theory"
+      "description": "Related Erd\u0151s problem sharing themes: cycles, graph-theory, ramsey-theory"
     },
     {
       "targetId": "erdos-1008",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: cycles, graph-theory"
+      "description": "Related Erd\u0151s problem sharing themes: cycles, graph-theory"
     },
     {
       "targetId": "ramseys-theorem",
@@ -206,15 +206,15 @@
     {
       "targetId": "erdos-szekeres",
       "relationship": "thematic",
-      "description": "The Erdős-Szekeres theorem on monotone subsequences is another foundational result in Ramsey theory, sharing the combinatorial paradigm of guaranteed structure in large systems"
+      "description": "The Erd\u0151s-Szekeres theorem on monotone subsequences is another foundational result in Ramsey theory, sharing the combinatorial paradigm of guaranteed structure in large systems"
     }
   ],
   "references": [
-    "Bondy, J.A.; Erdős, P. (1973): Ramsey numbers for cycles in graphs, J. Combin. Theory Ser. B 14, 46–54",
-    "Nikiforov, V. (2005): The cycle-complete graph Ramsey numbers, Combinatorics, Probability and Computing 14, 349–370",
+    "Bondy, J.A.; Erd\u0151s, P. (1973): Ramsey numbers for cycles in graphs, J. Combin. Theory Ser. B 14, 46\u201354",
+    "Nikiforov, V. (2005): The cycle-complete graph Ramsey numbers, Combinatorics, Probability and Computing 14, 349\u2013370",
     "Keevash, P.; Long, E.; Skokan, J. (2021): Cycle-complete graph Ramsey numbers, arXiv:2105.06939",
-    "Faudree, R.J.; Schelp, R.H. (1974): All Ramsey numbers for cycles in graphs, Discrete Math. 8, 313–329",
-    "Erdős, P.; Faudree, R.J.; Rousseau, C.C.; Schelp, R.H. (1978): The Ramsey number for the pair complete graph-cycle",
+    "Faudree, R.J.; Schelp, R.H. (1974): All Ramsey numbers for cycles in graphs, Discrete Math. 8, 313\u2013329",
+    "Erd\u0151s, P.; Faudree, R.J.; Rousseau, C.C.; Schelp, R.H. (1978): The Ramsey number for the pair complete graph-cycle",
     "https://erdosproblems.com/551"
   ],
   "sorries": 22

--- a/src/data/proofs/erdos-60/meta.json
+++ b/src/data/proofs/erdos-60/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-60",
-  "title": "Erdős Problem #60: Supersaturation of 4-Cycles",
+  "title": "Erd\u0151s Problem #60: Supersaturation of 4-Cycles",
   "slug": "erdos-60",
-  "description": "Does every graph on n vertices with > ex(n; C_4) edges contain Ω(n^{1/2}) copies of C_4? OPEN problem. Even proving ≥ 2 copies remains open. He-Ma-Yang (2021) confirmed for projective plane orders with even q.",
+  "description": "Does every graph on n vertices with > ex(n; C_4) edges contain \u03a9(n^{1/2}) copies of C_4? OPEN problem. Even proving \u2265 2 copies remains open. He-Ma-Yang (2021) confirmed for projective plane orders with even q.",
   "meta": {
-    "author": "Erdős-Simonovits",
+    "author": "Erd\u0151s-Simonovits",
     "sourceUrl": "https://erdosproblems.com/60",
     "date": "",
     "status": "axiomatized",
@@ -44,18 +44,18 @@
       "IsC4Copy: 4-cycle copy predicate",
       "C4Copies: set of all labeled C_4 copies",
       "countC4: unlabeled C_4 count (labeled/8)",
-      "exC4: Turán number axiom",
+      "exC4: Tur\u00e1n number axiom",
       "ExceedsTuranC4: supersaturation threshold predicate",
-      "erdos_60_conjecture: formal Ω(n^{1/2}) conjecture",
-      "two_copies_conjecture: weaker ≥ 2 copies conjecture",
+      "erdos_60_conjecture: formal \u03a9(n^{1/2}) conjecture",
+      "two_copies_conjecture: weaker \u2265 2 copies conjecture",
       "conjecture_implies_two_copies: Aristotle-proved implication"
     ],
     "axiomCount": 8,
     "lineCount": 385,
     "prerequisites": [
-      "Extremal graph theory (Turán-type problems)",
-      "4-cycles (C₄) in graphs",
-      "Kővári-Sós-Turán theorem",
+      "Extremal graph theory (Tur\u00e1n-type problems)",
+      "4-cycles (C\u2084) in graphs",
+      "K\u0151v\u00e1ri-S\u00f3s-Tur\u00e1n theorem",
       "Zarankiewicz problem"
     ],
     "assumptions": "8 axiom(s). No sorries. 0 sorries remain.(s) remain."
@@ -79,11 +79,11 @@
     },
     {
       "id": "turan",
-      "title": "Turán Number for $C_4$",
-      "summary": "Axiomatizes $\\text{ex}(n; C_4)$ and its asymptotics: $\\text{ex}(n; C_4) = \\frac{1}{2}(1+o(1))n^{3/2}$ via Kővári-Sós-Turán (upper) and Reiman polarity graphs (lower).",
+      "title": "Tur\u00e1n Number for $C_4$",
+      "summary": "Axiomatizes $\\text{ex}(n; C_4)$ and its asymptotics: $\\text{ex}(n; C_4) = \\frac{1}{2}(1+o(1))n^{3/2}$ via K\u0151v\u00e1ri-S\u00f3s-Tur\u00e1n (upper) and Reiman polarity graphs (lower).",
       "startLine": 62,
       "endLine": 87,
-      "mathContext": "Axiomatized: Axiomatizes $\\text{ex}(n; C_4)$ and its asymptotics: $\\text{ex}(n; C_4) = \\frac{1}{2}(1+o(1))n^{3/2}$ via Kővári-Sós-Turán (upper) and Reiman polarity graphs (lower)."
+      "mathContext": "Axiomatized: Axiomatizes $\\text{ex}(n; C_4)$ and its asymptotics: $\\text{ex}(n; C_4) = \\frac{1}{2}(1+o(1))n^{3/2}$ via K\u0151v\u00e1ri-S\u00f3s-Tur\u00e1n (upper) and Reiman polarity graphs (lower)."
     },
     {
       "id": "supersaturation",
@@ -96,10 +96,10 @@
     {
       "id": "conjecture",
       "title": "Main Conjecture (OPEN)",
-      "summary": "Formalizes Erdős Problem 60: $\\exists c > 0$ such that $|E(G)| > \\text{ex}(n; C_4) \\Rightarrow \\text{countC4}(G) \\geq c \\cdot n^{1/2}$. The $\\Omega(n^{1/2})$ bound is conjectured to be tight.",
+      "summary": "Formalizes Erd\u0151s Problem 60: $\\exists c > 0$ such that $|E(G)| > \\text{ex}(n; C_4) \\Rightarrow \\text{countC4}(G) \\geq c \\cdot n^{1/2}$. The $\\Omega(n^{1/2})$ bound is conjectured to be tight.",
       "startLine": 94,
       "endLine": 108,
-      "mathContext": "Bound: Formalizes Erdős Problem 60: $\\exists c > 0$ such that $|E(G)| > \\text{ex}(n; C_4) \\Rightarrow \\text{countC4}(G) \\geq c \\cdot n^{1/2}$. The $\\Omega(n^{1/2})$ bound is conjectured to be tight."
+      "mathContext": "Bound: Formalizes Erd\u0151s Problem 60: $\\exists c > 0$ such that $|E(G)| > \\text{ex}(n; C_4) \\Rightarrow \\text{countC4}(G) \\geq c \\cdot n^{1/2}$. The $\\Omega(n^{1/2})$ bound is conjectured to be tight."
     },
     {
       "id": "partial-results",
@@ -120,10 +120,10 @@
     {
       "id": "general-supersaturation",
       "title": "General Supersaturation Theorem",
-      "summary": "Axiomatizes the Erdős-Simonovits supersaturation theorem: exceeding $\\text{ex}(n; C_4)$ by factor $(1+\\varepsilon)$ forces $\\geq \\delta \\cdot n^2$ copies, giving a weaker but general bound.",
+      "summary": "Axiomatizes the Erd\u0151s-Simonovits supersaturation theorem: exceeding $\\text{ex}(n; C_4)$ by factor $(1+\\varepsilon)$ forces $\\geq \\delta \\cdot n^2$ copies, giving a weaker but general bound.",
       "startLine": 149,
       "endLine": 166,
-      "mathContext": "Axiomatizes the Erdős-Simonovits supersaturation theorem: exceeding $\\text{ex}(n; C_4)$ by factor $(1+\\varepsilon)$ forces $\\geq \\$\\delta$ \\cdot $n^{2}$$ copies, giving a weaker but general bound."
+      "mathContext": "Axiomatizes the Erd\u0151s-Simonovits supersaturation theorem: exceeding $\\text{ex}(n; C_4)$ by factor $(1+\\varepsilon)$ forces $\\geq \\$\\delta$ \\cdot $n^{2}$$ copies, giving a weaker but general bound."
     },
     {
       "id": "extremal-graphs",
@@ -143,32 +143,32 @@
     }
   ],
   "overview": {
-    "historicalContext": "**Supersaturation in Extremal Graph Theory (1966-2021)**\n\nThe **Turán problem** asks for the maximum number of edges in an $H$-free graph on $n$ vertices. For $C_4$, the answer is $\\text{ex}(n; C_4) \\sim \\frac{1}{2}n^{3/2}$, determined by **Kővári, Sós, and Turán** (1954, upper bound) and **Reiman** (1958, lower bound via polarity graphs of projective planes). Brown (1966) gave an alternative algebraic construction.\n\n**Supersaturation** asks what happens just beyond the Turán threshold. **Erdős and Simonovits** (1966, published 1983) proved their foundational supersaturation theorem: exceeding $\\text{ex}(n; H)$ by a constant factor forces a positive density of $H$-copies. However, this says nothing about exceeding by just one edge.\n\nFor $C_4$, Erdős and Simonovits conjectured that a single extra edge forces $\\Omega(n^{1/2})$ copies — a much more delicate claim. Remarkably, they noted they could not even prove $\\geq 2$ copies. **He, Ma, and Yang** (2021) confirmed the conjecture for $n = q^2+q+1$ with even prime power $q$, using the uniqueness of extremal graphs for these parameters. The general case remains **OPEN**.",
+    "historicalContext": "**Supersaturation in Extremal Graph Theory (1966-2021)**\n\nThe **Tur\u00e1n problem** asks for the maximum number of edges in an $H$-free graph on $n$ vertices. For $C_4$, the answer is $\\text{ex}(n; C_4) \\sim \\frac{1}{2}n^{3/2}$, determined by **K\u0151v\u00e1ri, S\u00f3s, and Tur\u00e1n** (1954, upper bound) and **Reiman** (1958, lower bound via polarity graphs of projective planes). Brown (1966) gave an alternative algebraic construction.\n\n**Supersaturation** asks what happens just beyond the Tur\u00e1n threshold. **Erd\u0151s and Simonovits** (1966, published 1983) proved their foundational supersaturation theorem: exceeding $\\text{ex}(n; H)$ by a constant factor forces a positive density of $H$-copies. However, this says nothing about exceeding by just one edge.\n\nFor $C_4$, Erd\u0151s and Simonovits conjectured that a single extra edge forces $\\Omega(n^{1/2})$ copies \u2014 a much more delicate claim. Remarkably, they noted they could not even prove $\\geq 2$ copies. **He, Ma, and Yang** (2021) confirmed the conjecture for $n = q^2+q+1$ with even prime power $q$, using the uniqueness of extremal graphs for these parameters. The general case remains **OPEN**.",
     "problemStatement": "**Open Problem**\n\nDoes every graph on $n$ vertices with $> \\text{ex}(n; C_4)$ edges contain $\\gg n^{1/2}$ copies of $C_4$? Even proving $\\geq 2$ copies is open.\n\nThe conjectured $\\Omega(n^{1/2})$ bound would be tight: polarity graphs show one can have $\\text{ex}(n; C_4)$ edges with zero 4-cycles, and perturbation arguments suggest only $O(n^{1/2})$ copies appear just above the threshold.",
-    "text": "Does every graph on n vertices with > ex(n; C_4) edges contain Ω(n^{1/2}) copies of C_4? OPEN problem. Even proving ≥ 2 copies remains open. He-Ma-Yang (2021) confirmed for projective plane orders with even q.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Cycle counting:** Define $C_4$ copies as ordered 4-tuples, count unlabeled copies by dividing by $|\\text{Aut}(C_4)| = 8$.\n2. **Turán number:** Axiomatize $\\text{ex}(n; C_4)$ with upper and lower asymptotic bounds.\n3. **Conjecture:** Formalize the $\\Omega(n^{1/2})$ supersaturation conjecture and the weaker two-copies conjecture.\n4. **Partial results:** Axiomatize He-Ma-Yang (2021) for projective plane orders with even $q$.\n5. **General framework:** Axiomatize the Erdős-Simonovits supersaturation theorem and polarity graph existence.\n6. **Aristotle proofs:** Automated proof of `conjecture_implies_two_copies` and supporting lemmas.",
+    "text": "Does every graph on n vertices with > ex(n; C_4) edges contain \u03a9(n^{1/2}) copies of C_4? OPEN problem. Even proving \u2265 2 copies remains open. He-Ma-Yang (2021) confirmed for projective plane orders with even q.",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Cycle counting:** Define $C_4$ copies as ordered 4-tuples, count unlabeled copies by dividing by $|\\text{Aut}(C_4)| = 8$.\n2. **Tur\u00e1n number:** Axiomatize $\\text{ex}(n; C_4)$ with upper and lower asymptotic bounds.\n3. **Conjecture:** Formalize the $\\Omega(n^{1/2})$ supersaturation conjecture and the weaker two-copies conjecture.\n4. **Partial results:** Axiomatize He-Ma-Yang (2021) for projective plane orders with even $q$.\n5. **General framework:** Axiomatize the Erd\u0151s-Simonovits supersaturation theorem and polarity graph existence.\n6. **Aristotle proofs:** Automated proof of `conjecture_implies_two_copies` and supporting lemmas.",
     "keyInsights": [
-      "**Turán threshold:** $\\text{ex}(n; C_4) \\sim \\frac{1}{2}n^{3/2}$ from incidence geometry (polarity graphs of projective planes match the Kővári-Sós-Turán upper bound)",
-      "**Conjectured supersaturation:** A single extra edge above $\\text{ex}(n; C_4)$ should force $\\Omega(n^{1/2})$ copies — tight by perturbation of extremal graphs",
+      "**Tur\u00e1n threshold:** $\\text{ex}(n; C_4) \\sim \\frac{1}{2}n^{3/2}$ from incidence geometry (polarity graphs of projective planes match the K\u0151v\u00e1ri-S\u00f3s-Tur\u00e1n upper bound)",
+      "**Conjectured supersaturation:** A single extra edge above $\\text{ex}(n; C_4)$ should force $\\Omega(n^{1/2})$ copies \u2014 tight by perturbation of extremal graphs",
       "**Remarkable gap:** Even proving $\\geq 2$ copies from one extra edge is open, highlighting the difficulty of exact-threshold supersaturation",
       "**He-Ma-Yang (2021):** Confirmed the conjecture for even projective plane orders by exploiting the algebraic structure of the unique extremal graph",
       "**Aristotle contribution:** Automatically proved that the main conjecture implies the two-copies conjecture via contraposition"
     ],
     "prerequisites": [
-      "Extremal graph theory (Turán-type problems)",
-      "4-cycles (C₄) in graphs",
-      "Kővári-Sós-Turán theorem",
+      "Extremal graph theory (Tur\u00e1n-type problems)",
+      "4-cycles (C\u2084) in graphs",
+      "K\u0151v\u00e1ri-S\u00f3s-Tur\u00e1n theorem",
       "Zarankiewicz problem"
     ]
   },
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem #60, an open supersaturation problem in extremal graph theory. The conjecture asserts that exceeding $\\text{ex}(n; C_4) \\sim \\frac{1}{2}n^{3/2}$ edges forces $\\Omega(n^{1/2})$ copies of $C_4$. He-Ma-Yang (2021) confirmed this for projective plane orders with even $q$. Even the weaker claim of $\\geq 2$ copies remains open. Aristotle proved the logical implication between the conjectures.",
-    "implications": "**Theoretical Significance**: **Implications**\n\n1. **Exact-threshold supersaturation:** Would establish precise quantitative behavior at the Turán threshold for $C_4$, a model case for general forbidden subgraph problems.\n**2. Extremal stability:** The conjecture is deeply connected to the uniqueness and rigidity of extremal $C_4$-free graphs.\n3. **Incidence geometry connections:** Resolution likely requires understanding the algebraic structure of polarity graphs and their perturbations.\n4. **General theory:** Could inform supersaturation bounds for other forbidden subgraphs beyond the Erdős-Simonovits constant-factor framework.",
+    "summary": "This formalization captures Erd\u0151s Problem #60, an open supersaturation problem in extremal graph theory. The conjecture asserts that exceeding $\\text{ex}(n; C_4) \\sim \\frac{1}{2}n^{3/2}$ edges forces $\\Omega(n^{1/2})$ copies of $C_4$. He-Ma-Yang (2021) confirmed this for projective plane orders with even $q$. Even the weaker claim of $\\geq 2$ copies remains open. Aristotle proved the logical implication between the conjectures.",
+    "implications": "**Theoretical Significance**: **Implications**\n\n1. **Exact-threshold supersaturation:** Would establish precise quantitative behavior at the Tur\u00e1n threshold for $C_4$, a model case for general forbidden subgraph problems.\n**2. Extremal stability:** The conjecture is deeply connected to the uniqueness and rigidity of extremal $C_4$-free graphs.\n3. **Incidence geometry connections:** Resolution likely requires understanding the algebraic structure of polarity graphs and their perturbations.\n4. **General theory:** Could inform supersaturation bounds for other forbidden subgraphs beyond the Erd\u0151s-Simonovits constant-factor framework.",
     "openQuestions": [
-      "Prove the full Ω(n^{1/2}) bound for all n (the main conjecture)",
-      "Prove even ≥ 2 copies are guaranteed — remarkably still open",
+      "Prove the full \u03a9(n^{1/2}) bound for all n (the main conjecture)",
+      "Prove even \u2265 2 copies are guaranteed \u2014 remarkably still open",
       "Extend He-Ma-Yang to odd prime power projective plane orders",
-      "Determine the exact constant c in the lower bound countC4(G) ≥ c·n^{1/2}",
+      "Determine the exact constant c in the lower bound countC4(G) \u2265 c\u00b7n^{1/2}",
       "Does the conjecture generalize to C_6, C_8, and other even cycles?"
     ]
   },
@@ -182,7 +182,7 @@
       "Finset"
     ],
     "namespace": "Erdos60",
-    "lineCount": 385,
+    "lineCount": 386,
     "axiomCount": 8,
     "theoremCount": 10,
     "definitionCount": 12,
@@ -193,7 +193,7 @@
     {
       "targetId": "erdos-22",
       "relationship": "related",
-      "description": "Problem #22 (Ramsey-Turán for K₄) and Problem #60 (supersaturation of C₄) are both extremal graph theory problems about counting specific subgraphs in dense graphs"
+      "description": "Problem #22 (Ramsey-Tur\u00e1n for K\u2084) and Problem #60 (supersaturation of C\u2084) are both extremal graph theory problems about counting specific subgraphs in dense graphs"
     },
     {
       "targetId": "erdos-24",
@@ -203,32 +203,32 @@
   ],
   "references": [
     {
-      "authors": "Kővári, Tamás; Sós, Vera T.; Turán, Paul",
+      "authors": "K\u0151v\u00e1ri, Tam\u00e1s; S\u00f3s, Vera T.; Tur\u00e1n, Paul",
       "title": "On a problem of K. Zarankiewicz",
       "year": "1954",
-      "venue": "Colloquium Mathematicum, vol. 3, pp. 50–57",
-      "note": "The KST theorem bounding the number of edges in C₄-free bipartite graphs — the extremal result underlying Problem #60"
+      "venue": "Colloquium Mathematicum, vol. 3, pp. 50\u201357",
+      "note": "The KST theorem bounding the number of edges in C\u2084-free bipartite graphs \u2014 the extremal result underlying Problem #60"
     },
     {
-      "authors": "Erdős, Paul; Simonovits, Miklós",
+      "authors": "Erd\u0151s, Paul; Simonovits, Mikl\u00f3s",
       "title": "Supersaturated graphs and hypergraphs",
       "year": "1983",
-      "venue": "Combinatorica, vol. 3, no. 2, pp. 181–192",
-      "note": "Introduced supersaturation theory: how many copies of H appear when the number of edges exceeds the Turán number"
+      "venue": "Combinatorica, vol. 3, no. 2, pp. 181\u2013192",
+      "note": "Introduced supersaturation theory: how many copies of H appear when the number of edges exceeds the Tur\u00e1n number"
     },
     {
       "key": "Re58",
-      "citation": "Reiman, I., Über ein Problem von K. Zarankiewicz, Acta Math. Acad. Sci. Hungar. 9 (1958), 269-273.",
+      "citation": "Reiman, I., \u00dcber ein Problem von K. Zarankiewicz, Acta Math. Acad. Sci. Hungar. 9 (1958), 269-273.",
       "type": "paper"
     },
     {
       "key": "KST54",
-      "citation": "Kővári, T., Sós, V. T., and Turán, P., On a problem of K. Zarankiewicz, Colloq. Math. 3 (1954), 50-57.",
+      "citation": "K\u0151v\u00e1ri, T., S\u00f3s, V. T., and Tur\u00e1n, P., On a problem of K. Zarankiewicz, Colloq. Math. 3 (1954), 50-57.",
       "type": "paper"
     },
     {
       "key": "ES83",
-      "citation": "Erdős, Paul and Simonovits, Miklós, Supersaturated graphs and hypergraphs, Combinatorica 3 (1983), 181-192.",
+      "citation": "Erd\u0151s, Paul and Simonovits, Mikl\u00f3s, Supersaturated graphs and hypergraphs, Combinatorica 3 (1983), 181-192.",
       "type": "paper"
     },
     {
@@ -243,7 +243,7 @@
     },
     {
       "key": "EP",
-      "citation": "Erdős Problems, Problem #60, https://erdosproblems.com/60.",
+      "citation": "Erd\u0151s Problems, Problem #60, https://erdosproblems.com/60.",
       "type": "website"
     }
   ],

--- a/src/data/proofs/erdos-604/meta.json
+++ b/src/data/proofs/erdos-604/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-604",
-  "title": "Erdős Problem #604: The Pinned Distance Problem",
+  "title": "Erd\u0151s Problem #604: The Pinned Distance Problem",
   "slug": "erdos-604",
   "description": "Given n distinct points in the plane, must some point have nearly n distinct distances to other points? The 'pinned' version of the distinct distances problem. OPEN with $500 prize.",
   "meta": {
-    "author": "Erdős",
+    "author": "Erd\u0151s",
     "sourceUrl": "https://erdosproblems.com/604",
     "date": "1957-1997",
     "status": "axiomatized",
@@ -55,7 +55,7 @@
       "Euclidean distance and metric spaces",
       "Finite set combinatorics (cardinality, image, filter)",
       "Asymptotic notation and exponent bounds",
-      "Incidence geometry (Szemerédi-Trotter theorem)",
+      "Incidence geometry (Szemer\u00e9di-Trotter theorem)",
       "Crossing number inequality",
       "Number theory (sums of two squares, Landau's theorem)"
     ],
@@ -64,22 +64,22 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "The pinned distance problem is a stronger variant of the famous Erdős distinct distances problem (#89). Rather than counting all distinct pairwise distances in a point set, it asks: must some point 'see' many different distances to other points?\n\nErdős posed this across multiple papers from 1957 to 1997, offering a $500 prize. The integer lattice {1,...,√n} × {1,...,√n} shows the answer cannot exceed O(n/√log n), suggesting this might be the truth. The 'unpinned' version of the problem was famously resolved by Guth and Katz in 2015 using the polynomial method and algebraic geometry, achieving the near-optimal Ω(n/log n) bound, but their techniques have not yet been adapted to give the optimal pinned result. Katz and Tardos obtained the best known pinned lower bound of n^{(48-14e)/(55-16e)} ≈ n^{0.864} in 2004 using entropy methods.",
-    "problemStatement": "Given n distinct points A ⊂ ℝ², must there exist a point x ∈ A such that:\n\n|{d(x,y) : y ∈ A, y ≠ x}| ≫ n^(1-o(1))?\n\nOr even |{d(x,y) : y ∈ A}| ≫ n/√(log n)?\n\nThe 'pinned point' x has this many distinct distances to other points in the set.",
+    "historicalContext": "The pinned distance problem is a stronger variant of the famous Erd\u0151s distinct distances problem (#89). Rather than counting all distinct pairwise distances in a point set, it asks: must some point 'see' many different distances to other points?\n\nErd\u0151s posed this across multiple papers from 1957 to 1997, offering a $500 prize. The integer lattice {1,...,\u221an} \u00d7 {1,...,\u221an} shows the answer cannot exceed O(n/\u221alog n), suggesting this might be the truth. The 'unpinned' version of the problem was famously resolved by Guth and Katz in 2015 using the polynomial method and algebraic geometry, achieving the near-optimal \u03a9(n/log n) bound, but their techniques have not yet been adapted to give the optimal pinned result. Katz and Tardos obtained the best known pinned lower bound of n^{(48-14e)/(55-16e)} \u2248 n^{0.864} in 2004 using entropy methods.",
+    "problemStatement": "Given n distinct points A \u2282 \u211d\u00b2, must there exist a point x \u2208 A such that:\n\n|{d(x,y) : y \u2208 A, y \u2260 x}| \u226b n^(1-o(1))?\n\nOr even |{d(x,y) : y \u2208 A}| \u226b n/\u221a(log n)?\n\nThe 'pinned point' x has this many distinct distances to other points in the set.",
     "text": "Given n distinct points in the plane, must some point have nearly n distinct distances to other points? The 'pinned' version of the distinct distances problem. OPEN with $500 prize.",
-    "proofStrategy": "This formalization:\n\n1. Defines `pinnedDistances x A` as the set of distances from x to points in A\n2. States the weak conjecture (exponent 1-ε) and strong conjecture (n/√log n)\n3. Formalizes the Katz-Tardos bound with exponent c ≈ 0.864\n4. Proves basic structural results connecting pinned to total distances\n\nThe main conjectures remain OPEN with substantial sorries marking unproven claims.",
+    "proofStrategy": "This formalization:\n\n1. Defines `pinnedDistances x A` as the set of distances from x to points in A\n2. States the weak conjecture (exponent 1-\u03b5) and strong conjecture (n/\u221alog n)\n3. Formalizes the Katz-Tardos bound with exponent c \u2248 0.864\n4. Proves basic structural results connecting pinned to total distances\n\nThe main conjectures remain OPEN with substantial sorries marking unproven claims.",
     "keyInsights": [
       "**Pinned vs Total:** Counting distances from one 'pinned' point is harder than counting all pairwise distances, yet gives useful lower bounds.",
-      "**Integer Lattice Barrier:** The √n × √n integer grid has O(n/√log n) representable distances, setting the conjectured upper bound.",
-      "**Katz-Tardos Bound:** Best known lower bound achieves exponent c = (48-14e)/(55-16e) ≈ 0.864, far from the conjectured 1.",
-      "**Harborth's Counterexample:** Erdős initially thought the sum of pinned distances equaled total distinct distances; Harborth showed these differ.",
+      "**Integer Lattice Barrier:** The \u221an \u00d7 \u221an integer grid has O(n/\u221alog n) representable distances, setting the conjectured upper bound.",
+      "**Katz-Tardos Bound:** Best known lower bound achieves exponent c = (48-14e)/(55-16e) \u2248 0.864, far from the conjectured 1.",
+      "**Harborth's Counterexample:** Erd\u0151s initially thought the sum of pinned distances equaled total distinct distances; Harborth showed these differ.",
       "**Prize Ambiguity:** The $500 prize's exact condition (one point or many points with high pinned count) remains unclear."
     ],
     "prerequisites": [
       "Euclidean distance and metric spaces",
       "Finite set combinatorics (cardinality, image, filter)",
       "Asymptotic notation and exponent bounds",
-      "Incidence geometry (Szemerédi-Trotter theorem)",
+      "Incidence geometry (Szemer\u00e9di-Trotter theorem)",
       "Crossing number inequality",
       "Number theory (sums of two squares, Landau's theorem)"
     ]
@@ -102,7 +102,7 @@
     {
       "id": "katz-tardos",
       "title": "Katz-Tardos Bound",
-      "summary": "The best known lower bound with exponent ≈ 0.864",
+      "summary": "The best known lower bound with exponent \u2248 0.864",
       "startLine": 69,
       "endLine": 80
     },
@@ -116,7 +116,7 @@
     {
       "id": "sum-conjecture",
       "title": "Sum of Pinned Distances",
-      "summary": "Erdős's conjecture on the total pinned distance sum",
+      "summary": "Erd\u0151s's conjecture on the total pinned distance sum",
       "startLine": 104,
       "endLine": 114
     },
@@ -133,7 +133,7 @@
     "implications": "**Theoretical Significance**: This problem connects to:\n\n1. **Distinct Distances (#89):** The 'unpinned' version solved by Guth-Katz\n**2. Sum-Product Phenomena:** Additive/multiplicative structure in distance sets\n3. **Incidence Geometry:** Connections to point-line incidences\n4. **Algebraic Methods:** Polynomial method techniques from Elekes, Guth-Katz.",
     "openQuestions": [
       "Prove the exponent approaches 1 (the $500 prize!)",
-      "Prove the strong form with n/√(log n) distances",
+      "Prove the strong form with n/\u221a(log n) distances",
       "Improve Katz-Tardos beyond exponent 0.864",
       "Determine if the prize requires one point or many points with high count"
     ]
@@ -141,14 +141,14 @@
   "references": [
     {
       "authors": "Guth, Larry; Katz, Nets Hawk",
-      "title": "On the Erdős distinct distances problem in the plane",
+      "title": "On the Erd\u0151s distinct distances problem in the plane",
       "year": "2015",
       "venue": "Annals of Mathematics 181(1), pp. 155-190",
       "note": "Solved the 'unpinned' distinct distances problem; techniques relevant to the pinned version"
     },
     {
-      "authors": "Katz, Nets Hawk; Tardos, Gábor",
-      "title": "A new entropy inequality for the Erdős distance problem",
+      "authors": "Katz, Nets Hawk; Tardos, G\u00e1bor",
+      "title": "A new entropy inequality for the Erd\u0151s distance problem",
       "year": "2004",
       "venue": "Contemporary Mathematics 342, pp. 119-126",
       "note": "Best known bound for the pinned version: exponent 0.864"
@@ -158,12 +158,12 @@
     {
       "targetId": "erdos-483",
       "relationship": "related",
-      "description": "Both are Erdős problems with prize money: #483 concerns Schur numbers ($250), #604 concerns pinned distances ($500)"
+      "description": "Both are Erd\u0151s problems with prize money: #483 concerns Schur numbers ($250), #604 concerns pinned distances ($500)"
     },
     {
       "targetId": "erdos-224",
       "relationship": "related",
-      "description": "Both are extremal problems in discrete geometry. Problem #224 concerns point sets avoiding obtuse angles, while #604 (pinned distance problem) concerns the minimum number of distinct distances from a fixed point — both ask how point configurations constrain metric properties"
+      "description": "Both are extremal problems in discrete geometry. Problem #224 concerns point sets avoiding obtuse angles, while #604 (pinned distance problem) concerns the minimum number of distinct distances from a fixed point \u2014 both ask how point configurations constrain metric properties"
     }
   ],
   "leanFile": {
@@ -184,7 +184,7 @@
       "Set"
     ],
     "namespace": null,
-    "lineCount": 223,
+    "lineCount": 224,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 11,

--- a/src/data/proofs/erdos-624/meta.json
+++ b/src/data/proofs/erdos-624/meta.json
@@ -2,9 +2,9 @@
   "id": "erdos-624",
   "title": "Covering Properties of Subset Functions",
   "slug": "erdos-624",
-  "description": "Let X be a finite set of size n. What is the minimum H(n) such that some function f: P(X) -> X covers all of X from any subset Y of size at least H(n)? Known: log₂(n) ≤ H(n) < log₂(n) + O(log log n). Conjecture (OPEN): H(n) - log₂(n) → ∞.",
+  "description": "Let X be a finite set of size n. What is the minimum H(n) such that some function f: P(X) -> X covers all of X from any subset Y of size at least H(n)? Known: log\u2082(n) \u2264 H(n) < log\u2082(n) + O(log log n). Conjecture (OPEN): H(n) - log\u2082(n) \u2192 \u221e.",
   "meta": {
-    "author": "Erdős, Hajnal",
+    "author": "Erd\u0151s, Hajnal",
     "sourceUrl": "https://erdosproblems.com/624",
     "date": "1968",
     "status": "axiomatized",
@@ -29,17 +29,17 @@
       },
       {
         "theorem": "Finset.card_image_le",
-        "description": "The image of a finset under any function has at most as many elements as the original: |s.image f| ≤ |s|",
+        "description": "The image of a finset under any function has at most as many elements as the original: |s.image f| \u2264 |s|",
         "module": "Mathlib.Data.Finset.Image"
       },
       {
         "theorem": "Nat.clog",
-        "description": "Ceiling logarithm: Nat.clog b n = ⌈log_b(n)⌉, used for the lower bound H(n) ≥ ⌈log₂(n)⌉",
+        "description": "Ceiling logarithm: Nat.clog b n = \u2308log_b(n)\u2309, used for the lower bound H(n) \u2265 \u2308log\u2082(n)\u2309",
         "module": "Mathlib.Data.Nat.Log"
       },
       {
         "theorem": "sInf",
-        "description": "Infimum in ℕ (well-ordered): used to define coveringNumber X as the minimum H with an H-covering function",
+        "description": "Infimum in \u2115 (well-ordered): used to define coveringNumber X as the minimum H with an H-covering function",
         "module": "Mathlib.Order.ConditionallyCompleteLattice.Basic"
       },
       {
@@ -49,11 +49,11 @@
       }
     ],
     "originalContributions": [
-      "Formalization of the covering number H(n) as sInf over ℕ with IsCoveringFunction predicate",
-      "Lower bound counting argument: IsCoveringFunction X f H → 2^H ≥ |X|, hence H(n) ≥ ⌈log₂(n)⌉ (proved by Aristotle)",
-      "Axiomatized Erdős-Hajnal upper bound H < log₂(n) + 3·log₂(log₂(n)) + 10 for n ≥ 4",
-      "Formal statement of main conjecture (H(n) - log₂(n) → ∞) and weaker conjecture (H(2^k) ≥ k+1)",
-      "Axiomatized Alon's structural results: upper bound (1-c)·2^k on coverage and lower bound 2^k/4 construction"
+      "Formalization of the covering number H(n) as sInf over \u2115 with IsCoveringFunction predicate",
+      "Lower bound counting argument: IsCoveringFunction X f H \u2192 2^H \u2265 |X|, hence H(n) \u2265 \u2308log\u2082(n)\u2309 (proved by Aristotle)",
+      "Axiomatized Erd\u0151s-Hajnal upper bound H < log\u2082(n) + 3\u00b7log\u2082(log\u2082(n)) + 10 for n \u2265 4",
+      "Formal statement of main conjecture (H(n) - log\u2082(n) \u2192 \u221e) and weaker conjecture (H(2^k) \u2265 k+1)",
+      "Axiomatized Alon's structural results: upper bound (1-c)\u00b72^k on coverage and lower bound 2^k/4 construction"
     ],
     "dateAdded": "2025-12-27",
     "axiomCount": 5,
@@ -62,15 +62,15 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "Erdős and Hajnal (1968) introduced the covering number H(n) in their study of functions on power sets. Given a finite set X of size n, they defined H(n) as the minimum H such that some function f: P(X) → X has the property that {f(A) : A ⊆ Y} = X for every Y ⊆ X with |Y| ≥ H. They proved log₂(n) ≤ H(n) < log₂(n) + (3+o(1))·log₂(log₂(n)) using counting arguments and probabilistic constructions. Noga Alon later proved deep structural results: (1) for any f, some Y of size k has |subsetImage f Y| < (1-c)·2^k (no perfect coverage), and (2) there exist f achieving |subsetImage f Y| > 2^k/4 for all Y (good functions exist). Together these show covering functions are inherently imperfect but can be quite good. The main conjecture that H(n) - log₂(n) → ∞ — and even the weaker statement H(2^k) ≥ k+1 — remain open, making this one of the oldest unsolved problems in combinatorial set theory.",
-    "problemStatement": "**Erdős Problem #624** (Erdős-Hajnal, 1968; OPEN):\n\nLet X be a finite set of size n. Define the **covering number** H(n) = min{H : ∃f: P(X)→X, ∀Y⊆X, |Y|≥H → {f(A) : A⊆Y} = X}.\n\n**Known bounds**: log₂(n) ≤ H(n) < log₂(n) + (3+o(1))·log₂(log₂(n))\n\n**Main conjecture**: H(n) - log₂(n) → ∞\n\n**Weaker conjecture** (also OPEN): H(2^k) ≥ k + 1 for all k ≥ 1",
-    "text": "Let X be a finite set of size n. What is the minimum H(n) such that some function f: P(X) -> X covers all of X from any subset Y of size at least H(n)? Known: log₂(n) ≤ H(n) < log₂(n) + O(log log n). Conjecture (OPEN): H(n) - log₂(n) → ∞.",
-    "proofStrategy": "The formalization proceeds in three layers. First, it defines the core objects: subsetImage f Y = (Y.powerset).image f, the predicate IsCoveringFunction X f H requiring subsetImage f Y = X for all Y ⊆ X with |Y| ≥ H, and coveringNumber X = sInf {H : ℕ | ∃ f, IsCoveringFunction X f H}. Second, it proves basic bounds: |Y.powerset| = 2^|Y| (from Mathlib) and |subsetImage f Y| ≤ 2^|Y| (composing card_image_le with card_powerset). The lower bound argument — if f is H-covering then 2^H ≥ |X| — requires choosing a witness Y ⊆ X with |Y| = H and applying these cardinality bounds (both theorems proved by Aristotle automated proof search). Third, it axiomatizes the deeper results: the Erdős-Hajnal upper bound, the main and weaker conjectures, and Alon's structural theorems on coverage fractions.",
+    "historicalContext": "Erd\u0151s and Hajnal (1968) introduced the covering number H(n) in their study of functions on power sets. Given a finite set X of size n, they defined H(n) as the minimum H such that some function f: P(X) \u2192 X has the property that {f(A) : A \u2286 Y} = X for every Y \u2286 X with |Y| \u2265 H. They proved log\u2082(n) \u2264 H(n) < log\u2082(n) + (3+o(1))\u00b7log\u2082(log\u2082(n)) using counting arguments and probabilistic constructions. Noga Alon later proved deep structural results: (1) for any f, some Y of size k has |subsetImage f Y| < (1-c)\u00b72^k (no perfect coverage), and (2) there exist f achieving |subsetImage f Y| > 2^k/4 for all Y (good functions exist). Together these show covering functions are inherently imperfect but can be quite good. The main conjecture that H(n) - log\u2082(n) \u2192 \u221e \u2014 and even the weaker statement H(2^k) \u2265 k+1 \u2014 remain open, making this one of the oldest unsolved problems in combinatorial set theory.",
+    "problemStatement": "**Erd\u0151s Problem #624** (Erd\u0151s-Hajnal, 1968; OPEN):\n\nLet X be a finite set of size n. Define the **covering number** H(n) = min{H : \u2203f: P(X)\u2192X, \u2200Y\u2286X, |Y|\u2265H \u2192 {f(A) : A\u2286Y} = X}.\n\n**Known bounds**: log\u2082(n) \u2264 H(n) < log\u2082(n) + (3+o(1))\u00b7log\u2082(log\u2082(n))\n\n**Main conjecture**: H(n) - log\u2082(n) \u2192 \u221e\n\n**Weaker conjecture** (also OPEN): H(2^k) \u2265 k + 1 for all k \u2265 1",
+    "text": "Let X be a finite set of size n. What is the minimum H(n) such that some function f: P(X) -> X covers all of X from any subset Y of size at least H(n)? Known: log\u2082(n) \u2264 H(n) < log\u2082(n) + O(log log n). Conjecture (OPEN): H(n) - log\u2082(n) \u2192 \u221e.",
+    "proofStrategy": "The formalization proceeds in three layers. First, it defines the core objects: subsetImage f Y = (Y.powerset).image f, the predicate IsCoveringFunction X f H requiring subsetImage f Y = X for all Y \u2286 X with |Y| \u2265 H, and coveringNumber X = sInf {H : \u2115 | \u2203 f, IsCoveringFunction X f H}. Second, it proves basic bounds: |Y.powerset| = 2^|Y| (from Mathlib) and |subsetImage f Y| \u2264 2^|Y| (composing card_image_le with card_powerset). The lower bound argument \u2014 if f is H-covering then 2^H \u2265 |X| \u2014 requires choosing a witness Y \u2286 X with |Y| = H and applying these cardinality bounds (both theorems proved by Aristotle automated proof search). Third, it axiomatizes the deeper results: the Erd\u0151s-Hajnal upper bound, the main and weaker conjectures, and Alon's structural theorems on coverage fractions.",
     "keyInsights": [
-      "The lower bound is a pure counting argument: 2^H subsets of Y can produce at most 2^H distinct images, so covering n elements requires 2^H ≥ n, hence H ≥ log₂(n)",
-      "The Erdős-Hajnal upper bound uses the probabilistic method: a random function f achieves H-covering for H < log₂(n) + O(log log n) with positive probability",
+      "The lower bound is a pure counting argument: 2^H subsets of Y can produce at most 2^H distinct images, so covering n elements requires 2^H \u2265 n, hence H \u2265 log\u2082(n)",
+      "The Erd\u0151s-Hajnal upper bound uses the probabilistic method: a random function f achieves H-covering for H < log\u2082(n) + O(log log n) with positive probability",
       "Alon's results pin down the coverage fraction to between 1/4 and (1-c) of the theoretical maximum 2^k, showing covering functions are inherently imperfect",
-      "Even the weaker conjecture H(2^k) ≥ k+1 — that the covering number exceeds log₂(n) by at least 1 at powers of 2 — remains open",
+      "Even the weaker conjecture H(2^k) \u2265 k+1 \u2014 that the covering number exceeds log\u2082(n) by at least 1 at powers of 2 \u2014 remains open",
       "The gap between the lower and upper bounds is O(log log n); determining whether this gap is bounded or unbounded is the core open question"
     ],
     "prerequisites": [
@@ -83,7 +83,7 @@
     {
       "id": "core-defs",
       "title": "Core Definitions",
-      "summary": "Defines subsetImage f Y = (Y.powerset).image f, the predicate IsCoveringFunction X f H (universal coverage from all large subsets), and coveringNumber X = sInf over ℕ.",
+      "summary": "Defines subsetImage f Y = (Y.powerset).image f, the predicate IsCoveringFunction X f H (universal coverage from all large subsets), and coveringNumber X = sInf over \u2115.",
       "startLine": 39,
       "endLine": 54,
       "mathContext": "Defines subsetImage f Y = (Y.powerset).image f, the predicate IsCoveringFunction X f H (universal coverage from all large subsets), and coveringNumber X = sInf over $\\mathbb{N}$."
@@ -91,55 +91,55 @@
     {
       "id": "basic-props",
       "title": "Basic Cardinality Bounds",
-      "summary": "Proves |Y.powerset| = 2^|Y| (from Mathlib's Finset.card_powerset) and |subsetImage f Y| ≤ 2^|Y| (composing card_image_le with powerset cardinality).",
+      "summary": "Proves |Y.powerset| = 2^|Y| (from Mathlib's Finset.card_powerset) and |subsetImage f Y| \u2264 2^|Y| (composing card_image_le with powerset cardinality).",
       "startLine": 55,
       "endLine": 68,
       "mathContext": "Proves |Y.powerset| = 2^|Y| (from Mathlib's Finset.card_powerset) and |subsetImage f Y| $\\leq$ 2^|Y| (composing card_image_le with powerset cardinality)."
     },
     {
       "id": "lower-bound",
-      "title": "Lower Bound: H(n) ≥ log₂(n)",
-      "summary": "The counting argument: IsCoveringFunction X f H implies 2^H ≥ |X|, hence coveringNumber X ≥ Nat.clog 2 |X|. Both theorems proved by Aristotle automated proof search.",
+      "title": "Lower Bound: H(n) \u2265 log\u2082(n)",
+      "summary": "The counting argument: IsCoveringFunction X f H implies 2^H \u2265 |X|, hence coveringNumber X \u2265 Nat.clog 2 |X|. Both theorems proved by Aristotle automated proof search.",
       "startLine": 69,
       "endLine": 86,
       "mathContext": "The counting argument: IsCoveringFunction X f H implies $2^{H}$ $\\geq$ |X|, hence coveringNumber X $\\geq$ Nat.clog 2 |X|. Both theorems proved by Aristotle automated proof search."
     },
     {
       "id": "upper-bound",
-      "title": "Erdős-Hajnal Upper Bound (1968)",
-      "summary": "Axiomatized: for n ≥ 4, there exists f and H with IsCoveringFunction X f H and H < log₂(n) + 3·log₂(log₂(n)) + 10. Proved via probabilistic method.",
+      "title": "Erd\u0151s-Hajnal Upper Bound (1968)",
+      "summary": "Axiomatized: for n \u2265 4, there exists f and H with IsCoveringFunction X f H and H < log\u2082(n) + 3\u00b7log\u2082(log\u2082(n)) + 10. Proved via probabilistic method.",
       "startLine": 87,
       "endLine": 98,
-      "mathContext": "Axiomatized: for n $\\geq$ 4, there exists f and H with IsCoveringFunction X f H and H < log₂(n) + 3·log₂(log₂(n)) + 10. Proved via probabilistic method."
+      "mathContext": "Axiomatized: for n $\\geq$ 4, there exists f and H with IsCoveringFunction X f H and H < log\u2082(n) + 3\u00b7log\u2082(log\u2082(n)) + 10. Proved via probabilistic method."
     },
     {
       "id": "main-conjecture",
       "title": "Main Conjecture (OPEN)",
-      "summary": "States H(n) - log₂(n) → ∞: for all C, there exists N such that for all n > N, coveringNumber X > log₂(n) + C. Axiomatized as erdos_624_open.",
+      "summary": "States H(n) - log\u2082(n) \u2192 \u221e: for all C, there exists N such that for all n > N, coveringNumber X > log\u2082(n) + C. Axiomatized as erdos_624_open.",
       "startLine": 99,
       "endLine": 112,
-      "mathContext": "States H(n) - log₂(n) $\\to$ ∞: for all C, there exists N such that for all n > N, coveringNumber X > log₂(n) + C. Axiomatized as erdos_624_open."
+      "mathContext": "States H(n) - log\u2082(n) $\\to$ \u221e: for all C, there exists N such that for all n > N, coveringNumber X > log\u2082(n) + C. Axiomatized as erdos_624_open."
     },
     {
       "id": "weaker-statement",
       "title": "Weaker Conjecture (Also OPEN)",
-      "summary": "For n = 2^k, H(n) ≥ k + 1. Strictly weaker than the main conjecture; even this statement that H(n) > log₂(n) at powers of 2 is unproven.",
+      "summary": "For n = 2^k, H(n) \u2265 k + 1. Strictly weaker than the main conjecture; even this statement that H(n) > log\u2082(n) at powers of 2 is unproven.",
       "startLine": 113,
       "endLine": 123,
-      "mathContext": "For n = $2^{k}$, H(n) $\\geq$ k + 1. Strictly weaker than the main conjecture; even this statement that H(n) > log₂(n) at powers of 2 is unproven."
+      "mathContext": "For n = $2^{k}$, H(n) $\\geq$ k + 1. Strictly weaker than the main conjecture; even this statement that H(n) > log\u2082(n) at powers of 2 is unproven."
     },
     {
       "id": "alon-upper",
       "title": "Alon's Structural Upper Bound",
-      "summary": "Axiomatized: ∃ c > 0 such that for any f, some Y ⊆ X with |Y| = k has |subsetImage f Y| < (1-c)·2^k. No function achieves perfect coverage.",
+      "summary": "Axiomatized: \u2203 c > 0 such that for any f, some Y \u2286 X with |Y| = k has |subsetImage f Y| < (1-c)\u00b72^k. No function achieves perfect coverage.",
       "startLine": 124,
       "endLine": 137,
-      "mathContext": "Axiomatized: ∃ c > 0 such that for any f, some Y ⊆ X with |Y| = k has |subsetImage f Y| < (1-c)·$2^{k}$. No function achieves perfect coverage."
+      "mathContext": "Axiomatized: \u2203 c > 0 such that for any f, some Y \u2286 X with |Y| = k has |subsetImage f Y| < (1-c)\u00b7$2^{k}$. No function achieves perfect coverage."
     },
     {
       "id": "alon-lower",
       "title": "Alon's Construction",
-      "summary": "Axiomatized: for k ≥ 2 and |X| = 2^k, there exists f with |subsetImage f Y| > 2^k/4 for all Y of size k. Good covering functions exist.",
+      "summary": "Axiomatized: for k \u2265 2 and |X| = 2^k, there exists f with |subsetImage f Y| > 2^k/4 for all Y of size k. Good covering functions exist.",
       "startLine": 138,
       "endLine": 147,
       "mathContext": "Axiomatized: for k $\\geq$ 2 and |X| = $2^{k}$, there exists f with |subsetImage f Y| > $2^{k}$/4 for all Y of size k. Good covering functions exist."
@@ -147,19 +147,19 @@
     {
       "id": "summary",
       "title": "State of Knowledge Summary",
-      "summary": "Complete picture: log₂(n) + Ω(1) ≤ H(n) < log₂(n) + O(log log n). The gap is between a positive constant (Alon) and O(log log n) (Erdős-Hajnal). Unboundedness is OPEN.",
+      "summary": "Complete picture: log\u2082(n) + \u03a9(1) \u2264 H(n) < log\u2082(n) + O(log log n). The gap is between a positive constant (Alon) and O(log log n) (Erd\u0151s-Hajnal). Unboundedness is OPEN.",
       "startLine": 148,
       "endLine": 219,
-      "mathContext": "Complete picture: log₂(n) + Ω(1) $\\leq$ H(n) < log₂(n) + $O(log $\\log n$)$. The gap is between a positive constant (Alon) and $O(log $\\log n$)$ (Erdős-Hajnal). Unboundedness is OPEN."
+      "mathContext": "Complete picture: log\u2082(n) + \u03a9(1) $\\leq$ H(n) < log\u2082(n) + $O(log $\\log n$)$. The gap is between a positive constant (Alon) and $O(log $\\log n$)$ (Erd\u0151s-Hajnal). Unboundedness is OPEN."
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures the complete state of knowledge on Erdős Problem #624. The covering number H(n) — the minimum subset size guaranteeing full coverage under an optimal function — is known to satisfy log₂(n) + Ω(1) ≤ H(n) < log₂(n) + O(log log n). The lower bound counting argument is fully proved (covering_lower_bound and coveringNumber_ge_log completed by Aristotle), while the upper bound and structural results are axiomatized. The main conjecture that H(n) - log₂(n) → ∞ remains one of the oldest open problems in combinatorial set theory.",
+    "summary": "This formalization captures the complete state of knowledge on Erd\u0151s Problem #624. The covering number H(n) \u2014 the minimum subset size guaranteeing full coverage under an optimal function \u2014 is known to satisfy log\u2082(n) + \u03a9(1) \u2264 H(n) < log\u2082(n) + O(log log n). The lower bound counting argument is fully proved (covering_lower_bound and coveringNumber_ge_log completed by Aristotle), while the upper bound and structural results are axiomatized. The main conjecture that H(n) - log\u2082(n) \u2192 \u221e remains one of the oldest open problems in combinatorial set theory.",
     "implications": "**Theoretical Significance**: Understanding covering numbers connects to coding theory (covering codes), combinatorial optimization, and the structure of functions on power sets.\n\nThe question of whether every covering function has inherent inefficiency (Alon's result) has implications for the design of hashing and covering schemes. The O(log log n) gap mirrors similar phenomena in probabilistic combinatorics where random constructions achieve near-optimal bounds.",
     "openQuestions": [
-      "Main conjecture: prove H(n) - log₂(n) → ∞ (the gap between covering number and logarithmic lower bound is unbounded)",
-      "Weaker conjecture: prove H(2^k) ≥ k + 1 (covering number exceeds log₂(n) by at least 1 at powers of 2)",
-      "Determine the exact constant c in Alon's structural bound |subsetImage f Y| < (1-c)·2^k",
+      "Main conjecture: prove H(n) - log\u2082(n) \u2192 \u221e (the gap between covering number and logarithmic lower bound is unbounded)",
+      "Weaker conjecture: prove H(2^k) \u2265 k + 1 (covering number exceeds log\u2082(n) by at least 1 at powers of 2)",
+      "Determine the exact constant c in Alon's structural bound |subsetImage f Y| < (1-c)\u00b72^k",
       "RESOLVED: Both lower bound sorries proved by Aristotle (covering_lower_bound and coveringNumber_ge_log)"
     ]
   },
@@ -172,7 +172,7 @@
       "Set"
     ],
     "namespace": "Erdos624",
-    "lineCount": 218,
+    "lineCount": 219,
     "axiomCount": 5,
     "theoremCount": 4,
     "definitionCount": 5,
@@ -183,17 +183,17 @@
     {
       "targetId": "erdos-1167",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, set-theory"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, set-theory"
     },
     {
       "targetId": "erdos-1169",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, set-theory"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, set-theory"
     },
     {
       "targetId": "erdos-1171",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, set-theory"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, set-theory"
     }
   ],
   "sorries": 0

--- a/src/data/proofs/erdos-629/meta.json
+++ b/src/data/proofs/erdos-629/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-629",
-  "title": "Erdős #629: List Chromatic Number of Bipartite Graphs",
+  "title": "Erd\u0151s #629: List Chromatic Number of Bipartite Graphs",
   "slug": "erdos-629",
-  "description": "Find n(k) = minimal vertices in bipartite G with list chromatic number χ_L(G) > k. Surprisingly, χ_L can be arbitrarily large even though χ ≤ 2!",
+  "description": "Find n(k) = minimal vertices in bipartite G with list chromatic number \u03c7_L(G) > k. Surprisingly, \u03c7_L can be arbitrarily large even though \u03c7 \u2264 2!",
   "meta": {
-    "author": "Paul Erdős, Arthur Rubin, Herbert Taylor",
+    "author": "Paul Erd\u0151s, Arthur Rubin, Herbert Taylor",
     "sourceUrl": "https://erdosproblems.com/629",
     "date": "1980",
     "status": "axiomatized",
@@ -27,16 +27,16 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "Erdős, Rubin, and Taylor introduced the concept of list coloring (choosability) in their landmark 1979/1980 paper, which revealed a fundamental surprise: bipartite graphs, though 2-colorable, can have arbitrarily large list chromatic number. They proved the first bounds $2^{k-1} < n(k) < k^2 \\cdot 2^{k+2}$ and computed $n(2) = 6$ using $K_{3,3}$ with a clever adversarial list assignment. Hanson, MacGillivray, and Toft (1996) determined $n(3) = 14$ through exhaustive case analysis and gave the recursive bound $n(k) \\leq k \\cdot n(k-2) + 2^k$. Radhakrishnan and Srinivasan (2000) improved the lower bound to $n(k) \\geq c \\cdot 2^k \\sqrt{k/\\ln k}$ using an entropy-based refinement of the probabilistic method. Galvin's 1995 theorem that $\\chi_L(K_{n,n}) = \\lceil\\log_2 n\\rceil + 1$, proved via the kernel method, provides the key structural result for complete bipartite graphs. The problem connects to Property B (Erdős Problem #901) via the sandwich inequality $m(k) \\leq n(k) \\leq m(k+1)$, linking list coloring to hypergraph 2-coloring theory.",
+    "historicalContext": "Erd\u0151s, Rubin, and Taylor introduced the concept of list coloring (choosability) in their landmark 1979/1980 paper, which revealed a fundamental surprise: bipartite graphs, though 2-colorable, can have arbitrarily large list chromatic number. They proved the first bounds $2^{k-1} < n(k) < k^2 \\cdot 2^{k+2}$ and computed $n(2) = 6$ using $K_{3,3}$ with a clever adversarial list assignment. Hanson, MacGillivray, and Toft (1996) determined $n(3) = 14$ through exhaustive case analysis and gave the recursive bound $n(k) \\leq k \\cdot n(k-2) + 2^k$. Radhakrishnan and Srinivasan (2000) improved the lower bound to $n(k) \\geq c \\cdot 2^k \\sqrt{k/\\ln k}$ using an entropy-based refinement of the probabilistic method. Galvin's 1995 theorem that $\\chi_L(K_{n,n}) = \\lceil\\log_2 n\\rceil + 1$, proved via the kernel method, provides the key structural result for complete bipartite graphs. The problem connects to Property B (Erd\u0151s Problem #901) via the sandwich inequality $m(k) \\leq n(k) \\leq m(k+1)$, linking list coloring to hypergraph 2-coloring theory.",
     "problemStatement": "The list chromatic number $\\chi_L(G)$ is the minimal $k$ such that for any assignment of lists of $k$ colors to vertices, a proper coloring exists from the lists. Find $n(k) =$ minimum number of vertices in a bipartite graph $G$ with $\\chi_L(G) > k$.",
-    "text": "Find n(k) = minimal vertices in bipartite G with list chromatic number χ_L(G) > k. Surprisingly, χ_L can be arbitrarily large even though χ ≤ 2!",
+    "text": "Find n(k) = minimal vertices in bipartite G with list chromatic number \u03c7_L(G) > k. Surprisingly, \u03c7_L can be arbitrarily large even though \u03c7 \u2264 2!",
     "proofStrategy": "The formalization builds on Mathlib's `SimpleGraph` and defines list coloring from scratch: `ColorListAssignment`, `RespectsLists`, `IsKListColorable`, and `listChromaticNumber` via infimum. The function $n(k)$ is defined as the infimum over bipartite witnesses. Aristotle proved 6 key results: `bipartite_chromatic_le_two`, `bipartite_list_chromatic_unbounded` (via the hitting-set construction on $(k+1)$-subsets), `n_well_defined`, `n_mono`, `n_2_eq_6` (using $K_{3,3}$ + case analysis), and `ert_lower_bound` (via the probabilistic method with random 2-coloring of colors). The remaining 8 sorries include $n(3) = 14$, the upper bound, improved bounds, Property B connection, and asymptotic results.",
     "keyInsights": [
-      "**The choosability surprise**: Bipartite graphs have $\\chi(G) \\leq 2$ but $\\chi_L(G)$ can be arbitrarily large — list coloring is fundamentally harder than ordinary coloring because an adversary controls the color lists",
+      "**The choosability surprise**: Bipartite graphs have $\\chi(G) \\leq 2$ but $\\chi_L(G)$ can be arbitrarily large \u2014 list coloring is fundamentally harder than ordinary coloring because an adversary controls the color lists",
       "**Hitting set construction**: The unboundedness proof uses $V = \\binom{[2k+1]}{k+1}$ as vertices of a complete bipartite graph; each vertex's list is its subset; the pigeonhole principle forces $\\geq k+1$ colors per side from only $2k+1$ total, guaranteeing a collision",
-      "**Probabilistic lower bound**: The proof that $2^{k-1} < n(k)$ uses a random 2-partition of colors — if $|V| < 2^k$, the union bound shows with positive probability every vertex has a usable color from its partition side",
+      "**Probabilistic lower bound**: The proof that $2^{k-1} < n(k)$ uses a random 2-partition of colors \u2014 if $|V| < 2^k$, the union bound shows with positive probability every vertex has a usable color from its partition side",
       "**Property B bridge**: The inequality $m(k) \\leq n(k) \\leq m(k+1)$ connects list coloring of bipartite graphs to Property B of set families, reducing questions about $n(k)$ to hypergraph 2-coloring thresholds",
-      "**Galvin's theorem context**: $\\chi_L(K_{n,n}) = \\lceil\\log_2 n\\rceil + 1$ (Galvin 1995) via the kernel method shows that for balanced complete bipartite graphs, the list chromatic number grows logarithmically — a key structural result underlying the bounds on $n(k)$"
+      "**Galvin's theorem context**: $\\chi_L(K_{n,n}) = \\lceil\\log_2 n\\rceil + 1$ (Galvin 1995) via the kernel method shows that for balanced complete bipartite graphs, the list chromatic number grows logarithmically \u2014 a key structural result underlying the bounds on $n(k)$"
     ],
     "prerequisites": [
       "Combinatorics and number theory",
@@ -62,7 +62,7 @@
     },
     {
       "id": "bipartite",
-      "title": "Bipartite Graphs and the χ vs χ_L Gap",
+      "title": "Bipartite Graphs and the \u03c7 vs \u03c7_L Gap",
       "summary": "Defines `IsBipartite G` (2-colorable via `Fin 2`), proves `bipartite_chromatic_le_two` ($\\chi(G) \\leq 2$, Aristotle), and builds the `MyGraph k` construction with Aristotle-proved lemmas showing `MyGraph k` is bipartite and not $(k+1)$-list-colorable via the hitting-set argument.",
       "startLine": 91,
       "endLine": 259,
@@ -111,23 +111,23 @@
     {
       "id": "property-b",
       "title": "Property B Connection",
-      "summary": "Defines `propertyB_threshold k` ($m(k)$ = smallest family of $k$-sets without Property B). States `n_property_b_bounds` (sorry): $m(k) \\leq n(k) \\leq m(k+1)$, connecting list coloring to Erdős Problem #901.",
+      "summary": "Defines `propertyB_threshold k` ($m(k)$ = smallest family of $k$-sets without Property B). States `n_property_b_bounds` (sorry): $m(k) \\leq n(k) \\leq m(k+1)$, connecting list coloring to Erd\u0151s Problem #901.",
       "startLine": 831,
       "endLine": 846,
-      "mathContext": "Defines `propertyB_threshold k` ($m(k)$ = smallest family of $k$-sets without Property B). States `n_property_b_bounds` (sorry): $m(k) \\leq n(k) \\leq m(k+1)$, connecting list coloring to Erdős Problem #901."
+      "mathContext": "Defines `propertyB_threshold k` ($m(k)$ = smallest family of $k$-sets without Property B). States `n_property_b_bounds` (sorry): $m(k) \\leq n(k) \\leq m(k+1)$, connecting list coloring to Erd\u0151s Problem #901."
     },
     {
       "id": "constructions",
       "title": "Complete Bipartite Graphs and Asymptotics",
-      "summary": "Defines `completeBipartite m n` ($K_{m,n}$ on `Fin m ⊕ Fin n`). States `knn_list_chromatic` (sorry): $\\chi_L(K_{n,n}) \\approx \\log_2 n + 1$. States `n_exponential_growth` (sorry) and defines `ExactAsymptoticConjecture`: $n(k) = \\Theta(2^k \\cdot k^\\alpha)$.",
+      "summary": "Defines `completeBipartite m n` ($K_{m,n}$ on `Fin m \u2295 Fin n`). States `knn_list_chromatic` (sorry): $\\chi_L(K_{n,n}) \\approx \\log_2 n + 1$. States `n_exponential_growth` (sorry) and defines `ExactAsymptoticConjecture`: $n(k) = \\Theta(2^k \\cdot k^\\alpha)$.",
       "startLine": 847,
       "endLine": 912,
-      "mathContext": "Defines `completeBipartite m n` ($K_{m,n}$ on `Fin m ⊕ Fin n`). States `knn_list_chromatic` (sorry): $\\chi_L(K_{n,n}) \\approx \\log_2 n + 1$. States `n_exponential_growth` (sorry) and defines `ExactAsymptoticConjecture`: $n(k) = \\Theta(2^k \\cdot k^\\alpha)$."
+      "mathContext": "Defines `completeBipartite m n` ($K_{m,n}$ on `Fin m \u2295 Fin n`). States `knn_list_chromatic` (sorry): $\\chi_L(K_{n,n}) \\approx \\log_2 n + 1$. States `n_exponential_growth` (sorry) and defines `ExactAsymptoticConjecture`: $n(k) = \\Theta(2^k \\cdot k^\\alpha)$."
     }
   ],
   "conclusion": {
-    "summary": "This 907-line formalization captures Erdős Problem #629 on list chromatic numbers of bipartite graphs. Aristotle proved 6 of the 14 key results, including the unboundedness of $\\chi_L$ for bipartite graphs, $n(2) = 6$, monotonicity of $n$, and the lower bound $2^{k-1} < n(k)$ via the probabilistic method. The 8 remaining sorries cover the upper bound, improved bounds, $n(3) = 14$, Property B connection, and asymptotic behavior.",
-    "implications": "**Theoretical Significance**: The gap between $\\chi(G)$ and $\\chi_L(G)$ for bipartite graphs reveals that list coloring is a fundamentally different problem from ordinary coloring. The connection to Property B links this to hypergraph coloring theory and Erdős Problem #901.\n\nUnderstanding the exact asymptotics of $n(k)$ would clarify the probabilistic-vs-structural boundary in extremal combinatorics. The formalization demonstrates that even for 'simple' graph classes (bipartite), list coloring problems can be remarkably deep.",
+    "summary": "This 907-line formalization captures Erd\u0151s Problem #629 on list chromatic numbers of bipartite graphs. Aristotle proved 6 of the 14 key results, including the unboundedness of $\\chi_L$ for bipartite graphs, $n(2) = 6$, monotonicity of $n$, and the lower bound $2^{k-1} < n(k)$ via the probabilistic method. The 8 remaining sorries cover the upper bound, improved bounds, $n(3) = 14$, Property B connection, and asymptotic behavior.",
+    "implications": "**Theoretical Significance**: The gap between $\\chi(G)$ and $\\chi_L(G)$ for bipartite graphs reveals that list coloring is a fundamentally different problem from ordinary coloring. The connection to Property B links this to hypergraph coloring theory and Erd\u0151s Problem #901.\n\nUnderstanding the exact asymptotics of $n(k)$ would clarify the probabilistic-vs-structural boundary in extremal combinatorics. The formalization demonstrates that even for 'simple' graph classes (bipartite), list coloring problems can be remarkably deep.",
     "openQuestions": [
       "What is the exact asymptotic exponent $\\alpha$ in $n(k) = \\Theta(2^k \\cdot k^\\alpha)$? Current bounds: $\\alpha \\in [1/2, 2]$",
       "Can $n(4)$ be computed exactly? ($n(2) = 6$, $n(3) = 14$ are known)",
@@ -175,7 +175,7 @@
       "Finset"
     ],
     "namespace": "Erdos629",
-    "lineCount": 911,
+    "lineCount": 912,
     "axiomCount": 0,
     "theoremCount": 37,
     "definitionCount": 14,
@@ -186,17 +186,17 @@
     {
       "targetId": "erdos-630",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: bipartite-graphs, chromatic-number, graph-theory, list-coloring"
+      "description": "Related Erd\u0151s problem sharing themes: bipartite-graphs, chromatic-number, graph-theory, list-coloring"
     },
     {
       "targetId": "erdos-111",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: bipartite-graphs, chromatic-number, graph-theory"
+      "description": "Related Erd\u0151s problem sharing themes: bipartite-graphs, chromatic-number, graph-theory"
     },
     {
       "targetId": "erdos-631",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: chromatic-number, graph-theory, list-coloring"
+      "description": "Related Erd\u0151s problem sharing themes: chromatic-number, graph-theory, list-coloring"
     }
   ],
   "sorries": 7

--- a/src/data/proofs/erdos-643/meta.json
+++ b/src/data/proofs/erdos-643/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-643",
-  "title": "Erdős Problem #643: Crossed Pairs in Hypergraphs",
+  "title": "Erd\u0151s Problem #643: Crossed Pairs in Hypergraphs",
   "slug": "erdos-643",
-  "description": "Let f(n;t) be the minimal number of edges such that any t-uniform hypergraph on n vertices must contain four edges A,B,C,D with A∪B = C∪D and A∩B = C∩D = ∅. Conjecture: f(n;t) = (1+o(1))·C(n,t-1) for t≥3.",
+  "description": "Let f(n;t) be the minimal number of edges such that any t-uniform hypergraph on n vertices must contain four edges A,B,C,D with A\u222aB = C\u222aD and A\u2229B = C\u2229D = \u2205. Conjecture: f(n;t) = (1+o(1))\u00b7C(n,t-1) for t\u22653.",
   "meta": {
-    "author": "Open Problem (bounds by Füredi, Pikhurko-Verstraëte)",
+    "author": "Open Problem (bounds by F\u00fcredi, Pikhurko-Verstra\u00ebte)",
     "sourceUrl": "https://erdosproblems.com/643",
     "date": "",
     "status": "axiomatized",
@@ -41,33 +41,33 @@
     ],
     "originalContributions": [
       "Formal definition of t-uniform hypergraphs as sets of t-element Finsets",
-      "Definition of 'crossed pair' configuration: four edges A,B,C,D with A∪B=C∪D and A∩B=C∩D=∅",
+      "Definition of 'crossed pair' configuration: four edges A,B,C,D with A\u222aB=C\u222aD and A\u2229B=C\u2229D=\u2205",
       "Definition of the extremal function f(n,t) via Nat.find",
-      "Connection to C₄-free graphs for t=2 case (Kővári–Sós–Turán)",
-      "Axiomatization of Pikhurko-Verstraëte bound: f(n,3) ≤ (13/9)·C(n,2)",
+      "Connection to C\u2084-free graphs for t=2 case (K\u0151v\u00e1ri\u2013S\u00f3s\u2013Tur\u00e1n)",
+      "Axiomatization of Pikhurko-Verstra\u00ebte bound: f(n,3) \u2264 (13/9)\u00b7C(n,2)",
       "Construction of sunflower hypergraphs avoiding crossed pairs",
-      "Statement of Erdős-Rado Sunflower Lemma connection"
+      "Statement of Erd\u0151s-Rado Sunflower Lemma connection"
     ],
     "axiomCount": 3,
     "lineCount": 1402,
     "assumptions": "3 axiom(s) and 1 sorry(s). See the Lean source for details."
   },
   "overview": {
-    "historicalContext": "This problem belongs to extremal hypergraph theory, asking about the minimum number of edges that forces a specific forbidden configuration.\n\nThe 'crossed pair' configuration—four edges A,B,C,D where A∪B = C∪D but the pairs {A,B} and {C,D} are both disjoint—generalizes the concept of a 4-cycle in graphs. For ordinary graphs (t=2), avoiding crossed pairs is equivalent to avoiding C₄, connecting to the classical Kővári–Sós–Turán theorem.\n\nFor hypergraphs (t≥3), the problem becomes much more subtle. The natural construction is a 'sunflower': all edges share a common (t-1)-element core, with distinct single elements (petals) distinguishing them. This gives about C(n-1,t-1) edges.\n\nSignificant progress was made by Pikhurko and Verstraëte (2009) for 3-uniform hypergraphs, establishing f(n,3) ≤ (13/9)·C(n,2).\n\nThe conjecture that f(n,t) ~ C(n,t-1) would show that sunflower-type constructions are essentially optimal.",
-    "problemStatement": "Let $f(n;t)$ be the minimal number of edges such that any $t$-uniform hypergraph on $n$ vertices must contain four edges $A, B, C, D$ satisfying:\n$$A \\cup B = C \\cup D \\quad \\text{and} \\quad A \\cap B = C \\cap D = \\emptyset$$\n\n**Known Bounds**:\n- **t = 2**: $f(n;2) = (\\frac{1}{2} + o(1))n^{3/2}$ (Kővári–Sós–Turán)\n- **t = 3**: $f(n;3) \\leq \\frac{13}{9}\\binom{n}{2}$ (Pikhurko-Verstraëte 2009)\n- **General**: $\\binom{n-1}{t-1} + \\lfloor\\frac{n-1}{t}\\rfloor \\leq f(n;t) < \\frac{7}{2}\\binom{n}{t-1}$\n\n**Conjecture** (OPEN): For $t \\geq 3$,\n$$f(n;t) = (1 + o(1))\\binom{n}{t-1}$$",
-    "text": "Let f(n;t) be the minimal number of edges such that any t-uniform hypergraph on n vertices must contain four edges A,B,C,D with A∪B = C∪D and A∩B = C∩D = ∅. Conjecture: f(n;t) = (1+o(1))·C(n,t-1) for t≥3.",
-    "proofStrategy": "Our formalization:\n\n1. **Defines hypergraphs** as sets of Finsets with uniformity constraints\n\n2. **Formalizes the crossed pair configuration** with four edges having matching unions and empty intersections\n\n3. **Defines the extremal function** f(n,t) via Nat.find on the property that all hypergraphs with ≥m edges contain a crossed pair\n\n4. **Explores the t=2 case** connecting to 4-cycles and the Kővári–Sós–Turán theorem\n\n5. **Records known bounds** including the Pikhurko-Verstraëte upper bound\n\n6. **Constructs sunflower hypergraphs** as examples achieving near-optimal bounds\n\n7. **States the main conjecture** as an asymptotic limit statement",
+    "historicalContext": "This problem belongs to extremal hypergraph theory, asking about the minimum number of edges that forces a specific forbidden configuration.\n\nThe 'crossed pair' configuration\u2014four edges A,B,C,D where A\u222aB = C\u222aD but the pairs {A,B} and {C,D} are both disjoint\u2014generalizes the concept of a 4-cycle in graphs. For ordinary graphs (t=2), avoiding crossed pairs is equivalent to avoiding C\u2084, connecting to the classical K\u0151v\u00e1ri\u2013S\u00f3s\u2013Tur\u00e1n theorem.\n\nFor hypergraphs (t\u22653), the problem becomes much more subtle. The natural construction is a 'sunflower': all edges share a common (t-1)-element core, with distinct single elements (petals) distinguishing them. This gives about C(n-1,t-1) edges.\n\nSignificant progress was made by Pikhurko and Verstra\u00ebte (2009) for 3-uniform hypergraphs, establishing f(n,3) \u2264 (13/9)\u00b7C(n,2).\n\nThe conjecture that f(n,t) ~ C(n,t-1) would show that sunflower-type constructions are essentially optimal.",
+    "problemStatement": "Let $f(n;t)$ be the minimal number of edges such that any $t$-uniform hypergraph on $n$ vertices must contain four edges $A, B, C, D$ satisfying:\n$$A \\cup B = C \\cup D \\quad \\text{and} \\quad A \\cap B = C \\cap D = \\emptyset$$\n\n**Known Bounds**:\n- **t = 2**: $f(n;2) = (\\frac{1}{2} + o(1))n^{3/2}$ (K\u0151v\u00e1ri\u2013S\u00f3s\u2013Tur\u00e1n)\n- **t = 3**: $f(n;3) \\leq \\frac{13}{9}\\binom{n}{2}$ (Pikhurko-Verstra\u00ebte 2009)\n- **General**: $\\binom{n-1}{t-1} + \\lfloor\\frac{n-1}{t}\\rfloor \\leq f(n;t) < \\frac{7}{2}\\binom{n}{t-1}$\n\n**Conjecture** (OPEN): For $t \\geq 3$,\n$$f(n;t) = (1 + o(1))\\binom{n}{t-1}$$",
+    "text": "Let f(n;t) be the minimal number of edges such that any t-uniform hypergraph on n vertices must contain four edges A,B,C,D with A\u222aB = C\u222aD and A\u2229B = C\u2229D = \u2205. Conjecture: f(n;t) = (1+o(1))\u00b7C(n,t-1) for t\u22653.",
+    "proofStrategy": "Our formalization:\n\n1. **Defines hypergraphs** as sets of Finsets with uniformity constraints\n\n2. **Formalizes the crossed pair configuration** with four edges having matching unions and empty intersections\n\n3. **Defines the extremal function** f(n,t) via Nat.find on the property that all hypergraphs with \u2265m edges contain a crossed pair\n\n4. **Explores the t=2 case** connecting to 4-cycles and the K\u0151v\u00e1ri\u2013S\u00f3s\u2013Tur\u00e1n theorem\n\n5. **Records known bounds** including the Pikhurko-Verstra\u00ebte upper bound\n\n6. **Constructs sunflower hypergraphs** as examples achieving near-optimal bounds\n\n7. **States the main conjecture** as an asymptotic limit statement",
     "keyInsights": [
-      "**Crossed Pairs Generalize C₄**: For graphs (t=2), avoiding crossed pairs is equivalent to avoiding 4-cycles. The Kővári–Sós–Turán theorem gives f(n,2) = Θ(n^{3/2}).",
+      "**Crossed Pairs Generalize C\u2084**: For graphs (t=2), avoiding crossed pairs is equivalent to avoiding 4-cycles. The K\u0151v\u00e1ri\u2013S\u00f3s\u2013Tur\u00e1n theorem gives f(n,2) = \u0398(n^{3/2}).",
       "**Sunflowers Avoid Crossed Pairs**: A sunflower (all edges share a common core) cannot contain crossed pairs because any two edges intersect in the nonempty core.",
       "**The Gap to Optimal**: The lower bound C(n-1,t-1) comes from sunflower constructions. The conjecture is that this is essentially tight.",
-      "**Connection to Erdős-Rado**: The Sunflower Lemma (large uniform families contain sunflowers) is a related structural result in extremal combinatorics.",
-      "**Pikhurko-Verstraëte breakthrough**: Their upper bound f(n,t) = O(n^{t-1}/log^c n) improves the trivial O(n^{t-1}) by a logarithmic factor, suggesting the true answer lies between n^{t-1-ε} and n^{t-1}/polylog"
+      "**Connection to Erd\u0151s-Rado**: The Sunflower Lemma (large uniform families contain sunflowers) is a related structural result in extremal combinatorics.",
+      "**Pikhurko-Verstra\u00ebte breakthrough**: Their upper bound f(n,t) = O(n^{t-1}/log^c n) improves the trivial O(n^{t-1}) by a logarithmic factor, suggesting the true answer lies between n^{t-1-\u03b5} and n^{t-1}/polylog"
     ],
     "prerequisites": [
-      "Extremal hypergraph theory: $t$-uniform hypergraphs, Turán-type problems, extremal functions",
-      "The Kővári-Sós-Turán theorem: bipartite Turán problem, $\\text{ex}(n, K_{s,t}) = O(n^{2-1/s})$",
-      "Sunflower lemma (Erdős-Rado): structural constraints on large uniform families",
+      "Extremal hypergraph theory: $t$-uniform hypergraphs, Tur\u00e1n-type problems, extremal functions",
+      "The K\u0151v\u00e1ri-S\u00f3s-Tur\u00e1n theorem: bipartite Tur\u00e1n problem, $\\text{ex}(n, K_{s,t}) = O(n^{2-1/s})$",
+      "Sunflower lemma (Erd\u0151s-Rado): structural constraints on large uniform families",
       "Asymptotic analysis: $o(1)$, $\\Theta$, and Filter.Tendsto for the main conjecture"
     ]
   },
@@ -95,24 +95,24 @@
     },
     {
       "id": "graph-case",
-      "title": "Case t = 2: Graphs and C₄",
+      "title": "Case t = 2: Graphs and C\u2084",
       "startLine": 86,
       "endLine": 110,
-      "summary": "Connection to 4-cycles and Kővári–Sós–Turán"
+      "summary": "Connection to 4-cycles and K\u0151v\u00e1ri\u2013S\u00f3s\u2013Tur\u00e1n"
     },
     {
       "id": "bounds",
       "title": "Known Bounds",
       "startLine": 111,
       "endLine": 140,
-      "summary": "Pikhurko-Verstraëte and general bounds"
+      "summary": "Pikhurko-Verstra\u00ebte and general bounds"
     },
     {
       "id": "conjecture",
       "title": "The Main Conjecture",
       "startLine": 141,
       "endLine": 157,
-      "summary": "Statement of Erdős's asymptotic conjecture"
+      "summary": "Statement of Erd\u0151s's asymptotic conjecture"
     },
     {
       "id": "constructions",
@@ -123,10 +123,10 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem #643, asking about the extremal function f(n,t) for hypergraphs avoiding crossed pairs. We define the key concepts, record known bounds, explore the connection to 4-cycles in graphs, and construct sunflower hypergraphs achieving near-optimal bounds.",
+    "summary": "This formalization captures Erd\u0151s Problem #643, asking about the extremal function f(n,t) for hypergraphs avoiding crossed pairs. We define the key concepts, record known bounds, explore the connection to 4-cycles in graphs, and construct sunflower hypergraphs achieving near-optimal bounds.",
     "implications": "If the conjecture f(n,t) ~ C(n,t-1) is true, it would establish that sunflower-type constructions are essentially optimal for avoiding crossed pairs in uniform hypergraphs. This connects to deep questions in extremal combinatorics about forbidden configurations.",
     "openQuestions": [
-      "Is f(n,t) = (1+o(1))·C(n,t-1) for all t ≥ 3?",
+      "Is f(n,t) = (1+o(1))\u00b7C(n,t-1) for all t \u2265 3?",
       "What is the exact value of f(n,3) for small n?",
       "Are there constructions other than sunflowers achieving good bounds?",
       "How does the problem generalize to non-uniform hypergraphs?"
@@ -186,7 +186,7 @@
       "Classical"
     ],
     "namespace": "Harmonic.GeneralizeProofs",
-    "lineCount": 1402,
+    "lineCount": 1403,
     "axiomCount": 3,
     "theoremCount": 45,
     "definitionCount": 15,
@@ -197,17 +197,17 @@
     {
       "targetId": "erdos-1022",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, hypergraphs"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, hypergraphs"
     },
     {
       "targetId": "erdos-1023",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, extremal-combinatorics"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, extremal-combinatorics"
     },
     {
       "targetId": "erdos-1025",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, extremal-combinatorics"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, extremal-combinatorics"
     }
   ],
   "sorries": 1

--- a/src/data/proofs/erdos-69/meta.json
+++ b/src/data/proofs/erdos-69/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-69",
-  "title": "Erdős Problem #69: Irrationality of Sum of Omega over Powers of 2",
+  "title": "Erd\u0151s Problem #69: Irrationality of Sum of Omega over Powers of 2",
   "slug": "erdos-69",
-  "description": "Is the sum of ω(n)/2^n for n≥2 irrational? Proved by Tao-Teräväinen (2025) via reduction to sum of 1/(2^p-1) over primes.",
+  "description": "Is the sum of \u03c9(n)/2^n for n\u22652 irrational? Proved by Tao-Ter\u00e4v\u00e4inen (2025) via reduction to sum of 1/(2^p-1) over primes.",
   "meta": {
-    "author": "Tao-Teräväinen (2025)",
+    "author": "Tao-Ter\u00e4v\u00e4inen (2025)",
     "sourceUrl": "https://erdosproblems.com/69",
     "date": "2025",
     "status": "axiomatized",
@@ -40,39 +40,39 @@
       }
     ],
     "originalContributions": [
-      "Formalization of Tao's identity: ∑ω(n)/2^n = ∑1/(2^p-1)",
+      "Formalization of Tao's identity: \u2211\u03c9(n)/2^n = \u22111/(2^p-1)",
       "Geometric series calculation for prime multiples",
       "Structure connecting Problem 69 to Problem 257"
     ],
     "axiomCount": 1,
     "lineCount": 188,
     "prerequisites": [
-      "Arithmetic functions (ω, d, Ω) and prime factorization",
+      "Arithmetic functions (\u03c9, d, \u03a9) and prime factorization",
       "Infinite series, absolute convergence, and summation interchange",
       "Geometric series formula",
       "Irrational numbers and irrationality proofs",
-      "Basic analytic number theory (for context on the Tao-Teräväinen result)"
+      "Basic analytic number theory (for context on the Tao-Ter\u00e4v\u00e4inen result)"
     ],
-    "assumptions": "1 axiom: primeSum_irrational (Tao-Teräväinen 2025: the sum ∑ 1/(2^p-1) over primes is irrational). Formalization awaits Mathlib support for correlations of multiplicative functions, the Matomäki-Radziwił theorem, and Nesterenko's algebraic independence theory."
+    "assumptions": "1 axiom: primeSum_irrational (Tao-Ter\u00e4v\u00e4inen 2025: the sum \u2211 1/(2^p-1) over primes is irrational). Formalization awaits Mathlib support for correlations of multiplicative functions, the Matom\u00e4ki-Radziwi\u0142 theorem, and Nesterenko's algebraic independence theory."
   },
   "overview": {
-    "historicalContext": "Erdős Problem #69 (c. 1948) asks whether $\\sum_{n \\geq 2} \\omega(n)/2^n$ is irrational, where $\\omega(n)$ counts distinct prime divisors. Erdős had already proved that $\\sum d(n)/2^n$ is irrational, where $d(n)$ is the full divisor function ($d(n)$ counts divisors with multiplicity, while $\\omega(n)$ counts only distinct primes). The omega function is more subtle because it discards multiplicity information.\n\nThe key breakthrough was Tao's observation (c. 2024) that $\\sum \\omega(n)/2^n = \\sum_p 1/(2^p - 1)$, reducing Problem 69 to Problem 257 (irrationality of $\\sum 1/(2^p - 1)$). The identity follows from writing $\\omega(n) = \\sum_{p|n} 1$, swapping summation order (justified by absolute convergence), and recognizing the inner sum as a geometric series with ratio $2^{-p}$.\n\nPratt (2024) proved irrationality of $\\sum 1/(2^p - 1)$ conditional on a quantitative form of the Hardy-Littlewood prime $k$-tuples conjecture. Tao and Teräväinen (2025) removed this condition using deep results on correlations of multiplicative functions and the Matomäki-Radziwi\\l\\l theorem on multiplicative functions in short intervals. Their proof ultimately connects to Nesterenko's theory of algebraic independence of values of modular forms — the same machinery that proves the algebraic independence of $\\pi$ and $e^\\pi$.\n\nThis formalization is notable because Aristotle (automated proof search) successfully proved the combinatorial identity `tao_identity`, while the deep irrationality result `primeSum_irrational` is stated as an axiom — reflecting the mathematical reality that the identity is elementary while the irrationality is frontier analytic number theory requiring formalization of the Matomäki-Radziwił theorem and Nesterenko's algebraic independence machinery.",
-    "problemStatement": "Is\n$$\\sum_{n \\geq 2} \\frac{\\omega(n)}{2^n}$$\nirrational, where $\\omega(n)$ counts the distinct prime divisors of $n$?\n\n**Answer:** Yes, proved by Tao-Teräväinen (2025).",
-    "text": "Is the sum of ω(n)/2^n for n≥2 irrational? Proved by Tao-Teräväinen (2025) via reduction to sum of 1/(2^p-1) over primes.",
-    "proofStrategy": "The proof has two key steps:\n\n1. **Tao's Identity**: By swapping the order of summation, ∑ω(n)/2^n = ∑_p ∑_{p|n} 1/2^n = ∑_p 1/(2^p-1). The inner sum is a geometric series.\n\n2. **Irrationality**: The sum ∑1/(2^p-1) is irrational by Tao-Teräväinen's 2025 result, which uses deep analytic number theory (correlations of arithmetic functions).\n\nWe formalize the identity with proof and state the irrationality as an axiom.",
+    "historicalContext": "Erd\u0151s Problem #69 (c. 1948) asks whether $\\sum_{n \\geq 2} \\omega(n)/2^n$ is irrational, where $\\omega(n)$ counts distinct prime divisors. Erd\u0151s had already proved that $\\sum d(n)/2^n$ is irrational, where $d(n)$ is the full divisor function ($d(n)$ counts divisors with multiplicity, while $\\omega(n)$ counts only distinct primes). The omega function is more subtle because it discards multiplicity information.\n\nThe key breakthrough was Tao's observation (c. 2024) that $\\sum \\omega(n)/2^n = \\sum_p 1/(2^p - 1)$, reducing Problem 69 to Problem 257 (irrationality of $\\sum 1/(2^p - 1)$). The identity follows from writing $\\omega(n) = \\sum_{p|n} 1$, swapping summation order (justified by absolute convergence), and recognizing the inner sum as a geometric series with ratio $2^{-p}$.\n\nPratt (2024) proved irrationality of $\\sum 1/(2^p - 1)$ conditional on a quantitative form of the Hardy-Littlewood prime $k$-tuples conjecture. Tao and Ter\u00e4v\u00e4inen (2025) removed this condition using deep results on correlations of multiplicative functions and the Matom\u00e4ki-Radziwi\\l\\l theorem on multiplicative functions in short intervals. Their proof ultimately connects to Nesterenko's theory of algebraic independence of values of modular forms \u2014 the same machinery that proves the algebraic independence of $\\pi$ and $e^\\pi$.\n\nThis formalization is notable because Aristotle (automated proof search) successfully proved the combinatorial identity `tao_identity`, while the deep irrationality result `primeSum_irrational` is stated as an axiom \u2014 reflecting the mathematical reality that the identity is elementary while the irrationality is frontier analytic number theory requiring formalization of the Matom\u00e4ki-Radziwi\u0142 theorem and Nesterenko's algebraic independence machinery.",
+    "problemStatement": "Is\n$$\\sum_{n \\geq 2} \\frac{\\omega(n)}{2^n}$$\nirrational, where $\\omega(n)$ counts the distinct prime divisors of $n$?\n\n**Answer:** Yes, proved by Tao-Ter\u00e4v\u00e4inen (2025).",
+    "text": "Is the sum of \u03c9(n)/2^n for n\u22652 irrational? Proved by Tao-Ter\u00e4v\u00e4inen (2025) via reduction to sum of 1/(2^p-1) over primes.",
+    "proofStrategy": "The proof has two key steps:\n\n1. **Tao's Identity**: By swapping the order of summation, \u2211\u03c9(n)/2^n = \u2211_p \u2211_{p|n} 1/2^n = \u2211_p 1/(2^p-1). The inner sum is a geometric series.\n\n2. **Irrationality**: The sum \u22111/(2^p-1) is irrational by Tao-Ter\u00e4v\u00e4inen's 2025 result, which uses deep analytic number theory (correlations of arithmetic functions).\n\nWe formalize the identity with proof and state the irrationality as an axiom.",
     "keyInsights": [
-      "**Tao's identity**: ∑ω(n)/2^n = ∑_p 1/(2^p-1) - a non-obvious equivalence via double sum interchange",
-      "**Geometric series**: For each prime p, summing 1/2^(pk) over k≥1 gives 1/(2^p-1)",
+      "**Tao's identity**: \u2211\u03c9(n)/2^n = \u2211_p 1/(2^p-1) - a non-obvious equivalence via double sum interchange",
+      "**Geometric series**: For each prime p, summing 1/2^(pk) over k\u22651 gives 1/(2^p-1)",
       "**Reduction to Problem 257**: This transforms the original sum into the 'prime reciprocal' form",
       "**Analytic number theory**: The unconditional irrationality proof requires techniques beyond elementary methods",
-      "**Nesterenko's algebraic independence**: The resolution via modular form theory (same machinery as Erdős #250) shows that seemingly unrelated number-theoretic series are governed by common deep structures in transcendental number theory"
+      "**Nesterenko's algebraic independence**: The resolution via modular form theory (same machinery as Erd\u0151s #250) shows that seemingly unrelated number-theoretic series are governed by common deep structures in transcendental number theory"
     ],
     "prerequisites": [
-      "Arithmetic functions (ω, d, Ω) and prime factorization",
+      "Arithmetic functions (\u03c9, d, \u03a9) and prime factorization",
       "Infinite series, absolute convergence, and summation interchange",
       "Geometric series formula",
       "Irrational numbers and irrationality proofs",
-      "Basic analytic number theory (for context on the Tao-Teräväinen result)"
+      "Basic analytic number theory (for context on the Tao-Ter\u00e4v\u00e4inen result)"
     ]
   },
   "sections": [
@@ -89,7 +89,7 @@
       "title": "Sum Definitions: omegaSum and primeSum",
       "startLine": 45,
       "endLine": 52,
-      "summary": "`omegaSum` defines $\\sum_{n \\geq 2} \\omega(n)/2^n$ as `tsum` with index shift $n \\mapsto n+2$. `primeSum` defines $\\sum_p 1/(2^p - 1)$ over the prime subtype `{n : ℕ | n.Prime}`.",
+      "summary": "`omegaSum` defines $\\sum_{n \\geq 2} \\omega(n)/2^n$ as `tsum` with index shift $n \\mapsto n+2$. `primeSum` defines $\\sum_p 1/(2^p - 1)$ over the prime subtype `{n : \u2115 | n.Prime}`.",
       "mathContext": "The index shift `n + 2` avoids $n = 0, 1$ where $\\omega$ is trivially 0. The prime subtype sum over $\\{n : \\mathbb{N} \\mid \\text{Prime}\\,n\\}$ encodes the sum over the infinite set of primes via Lean's subtype mechanism."
     },
     {
@@ -105,25 +105,25 @@
       "title": "Tao's Identity (Proved by Aristotle)",
       "startLine": 91,
       "endLine": 164,
-      "summary": "`tao_identity : omegaSum = primeSum` — the central combinatorial identity, proved by Aristotle via automated proof search. The proof rewrites $\\omega(n)$ as $\\sum_{p|n} 1$, performs a Fubini-style summation interchange (justified by absolute convergence via `Summable.tsum_comm`), and applies `geometric_sum_over_multiples` to each inner sum.",
-      "mathContext": "$\\sum_{n \\geq 2} \\frac{\\omega(n)}{2^n} = \\sum_{n \\geq 2} \\frac{\\sum_{p|n} 1}{2^n} = \\sum_p \\sum_{k \\geq 1} \\frac{1}{2^{pk}} = \\sum_p \\frac{1}{2^p - 1}$\n\nThe summation interchange is the mathematical core — it requires absolute convergence of the double sum, proved by comparing $\\omega(n)/2^n \\leq n/2^n$ (since $\\omega(n) \\leq n$) and showing $\\sum n/2^n$ converges via the ratio test with limit $1/2$."
+      "summary": "`tao_identity : omegaSum = primeSum` \u2014 the central combinatorial identity, proved by Aristotle via automated proof search. The proof rewrites $\\omega(n)$ as $\\sum_{p|n} 1$, performs a Fubini-style summation interchange (justified by absolute convergence via `Summable.tsum_comm`), and applies `geometric_sum_over_multiples` to each inner sum.",
+      "mathContext": "$\\sum_{n \\geq 2} \\frac{\\omega(n)}{2^n} = \\sum_{n \\geq 2} \\frac{\\sum_{p|n} 1}{2^n} = \\sum_p \\sum_{k \\geq 1} \\frac{1}{2^{pk}} = \\sum_p \\frac{1}{2^p - 1}$\n\nThe summation interchange is the mathematical core \u2014 it requires absolute convergence of the double sum, proved by comparing $\\omega(n)/2^n \\leq n/2^n$ (since $\\omega(n) \\leq n$) and showing $\\sum n/2^n$ converges via the ratio test with limit $1/2$."
     },
     {
       "id": "irrationality",
       "title": "Irrationality and Main Theorem",
       "startLine": 165,
       "endLine": 189,
-      "summary": "`primeSum_irrational : Irrational primeSum` is the deep analytic result (sorry — Tao-Teräväinen 2025, beyond current Mathlib). `erdos_69 : Irrational omegaSum` combines `tao_identity` and `primeSum_irrational` in a two-line proof: rewrite via the identity, then apply irrationality.",
-      "mathContext": "The final proof: `rw [tao_identity]; exact primeSum_irrational`. This two-line argument is the entire reduction of Problem 69 to Problem 257 — the combinatorial identity does all the work, and the deep analytic number theory is encapsulated in the single sorry."
+      "summary": "`primeSum_irrational : Irrational primeSum` is the deep analytic result (sorry \u2014 Tao-Ter\u00e4v\u00e4inen 2025, beyond current Mathlib). `erdos_69 : Irrational omegaSum` combines `tao_identity` and `primeSum_irrational` in a two-line proof: rewrite via the identity, then apply irrationality.",
+      "mathContext": "The final proof: `rw [tao_identity]; exact primeSum_irrational`. This two-line argument is the entire reduction of Problem 69 to Problem 257 \u2014 the combinatorial identity does all the work, and the deep analytic number theory is encapsulated in the single sorry."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #69 is answered affirmatively: ∑ω(n)/2^n is irrational. The proof relies on Tao's elegant identity reducing it to Problem 257, which was settled by Tao-Teräväinen in 2025.",
-    "implications": "This result showcases the power of rewriting sums by exchanging order of summation. It connects the divisibility structure of integers (via ω) to the distribution of primes.",
+    "summary": "Erd\u0151s Problem #69 is answered affirmatively: \u2211\u03c9(n)/2^n is irrational. The proof relies on Tao's elegant identity reducing it to Problem 257, which was settled by Tao-Ter\u00e4v\u00e4inen in 2025.",
+    "implications": "This result showcases the power of rewriting sums by exchanging order of summation. It connects the divisibility structure of integers (via \u03c9) to the distribution of primes.",
     "openQuestions": [
       "Can the irrationality measure $\\mu$ of $\\sum \\omega(n)/2^n$ be bounded? An irrationality measure $\\mu$ means $|\\alpha - p/q| > q^{-\\mu - \\epsilon}$ for all $\\epsilon > 0$ and sufficiently large $q$. Nesterenko's algebraic independence methods might yield $\\mu < \\infty$, but no explicit bound is known.",
-      "Is $\\sum \\omega(n)/2^n$ transcendental? The Tao-Teräväinen proof establishes irrationality but not transcendence. The sum $\\sum 1/(2^p - 1)$ is closely related to the Erdős-Borwein constant $E = \\sum 1/(2^n - 1) \\approx 1.606695$, whose transcendence is also open.",
-      "Can the sorry for `primeSum_irrational` be eliminated by formalizing Tao-Teräväinen's proof? This would require formalizing: (a) the Matomäki-Radziwi\\l\\l theorem on multiplicative functions in short intervals, (b) correlations of multiplicative functions, and (c) Nesterenko's algebraic independence machinery — representing years of formalization effort.",
+      "Is $\\sum \\omega(n)/2^n$ transcendental? The Tao-Ter\u00e4v\u00e4inen proof establishes irrationality but not transcendence. The sum $\\sum 1/(2^p - 1)$ is closely related to the Erd\u0151s-Borwein constant $E = \\sum 1/(2^n - 1) \\approx 1.606695$, whose transcendence is also open.",
+      "Can the sorry for `primeSum_irrational` be eliminated by formalizing Tao-Ter\u00e4v\u00e4inen's proof? This would require formalizing: (a) the Matom\u00e4ki-Radziwi\\l\\l theorem on multiplicative functions in short intervals, (b) correlations of multiplicative functions, and (c) Nesterenko's algebraic independence machinery \u2014 representing years of formalization effort.",
       "Does the analogous identity hold for the big omega function $\\Omega(n)$ (counting prime factors with multiplicity)? If $\\sum \\Omega(n)/2^n = \\sum_p \\sum_{k \\geq 1} 1/(2^{p^k} - 1)$, is this sum also irrational?"
     ]
   },
@@ -136,7 +136,7 @@
     {
       "targetId": "infinitude-primes",
       "relationship": "foundational",
-      "description": "The sum $\\sum_p 1/(2^p - 1)$ ranges over the infinite set of primes. The infinitude of primes ensures this is a genuine infinite series, not a finite sum — and the rapid growth of $2^p$ ensures convergence"
+      "description": "The sum $\\sum_p 1/(2^p - 1)$ ranges over the infinite set of primes. The infinitude of primes ensures this is a genuine infinite series, not a finite sum \u2014 and the rapid growth of $2^p$ ensures convergence"
     },
     {
       "targetId": "prime-reciprocal-divergence",
@@ -146,42 +146,42 @@
     {
       "targetId": "e-transcendental",
       "relationship": "thematic",
-      "description": "Both results concern irrationality/transcendence of specific infinite series. The transcendence of $e = \\sum 1/k!$ was proved by Hermite (1873); the irrationality of $\\sum \\omega(n)/2^n$ was proved by Tao-Teräväinen (2025) — both require going beyond elementary summation techniques"
+      "description": "Both results concern irrationality/transcendence of specific infinite series. The transcendence of $e = \\sum 1/k!$ was proved by Hermite (1873); the irrationality of $\\sum \\omega(n)/2^n$ was proved by Tao-Ter\u00e4v\u00e4inen (2025) \u2014 both require going beyond elementary summation techniques"
     },
     {
       "targetId": "sqrt2-irrational",
       "relationship": "thematic",
-      "description": "The simplest irrationality proof ($\\sqrt{2} \\notin \\mathbb{Q}$) uses a descent argument. The irrationality of $\\sum \\omega(n)/2^n$ requires far more sophisticated methods — deep analytic number theory rather than elementary algebra — illustrating the vast gap in difficulty between different irrationality results"
+      "description": "The simplest irrationality proof ($\\sqrt{2} \\notin \\mathbb{Q}$) uses a descent argument. The irrationality of $\\sum \\omega(n)/2^n$ requires far more sophisticated methods \u2014 deep analytic number theory rather than elementary algebra \u2014 illustrating the vast gap in difficulty between different irrationality results"
     }
   ],
   "references": [
     {
-      "authors": "Tao, Terence; Teräväinen, Joni",
+      "authors": "Tao, Terence; Ter\u00e4v\u00e4inen, Joni",
       "title": "The structure of correlations of multiplicative functions at almost all scales, with applications to the Chowla and Elliott conjectures",
       "year": "2025",
       "venue": "Annals of Mathematics (to appear)",
-      "note": "The unconditional proof that ∑1/(2^p-1) is irrational, settling Erdős Problem 257 and (via Tao's identity) Problem 69. Uses the Matomäki-Radziwilł theorem on multiplicative functions in short intervals"
+      "note": "The unconditional proof that \u22111/(2^p-1) is irrational, settling Erd\u0151s Problem 257 and (via Tao's identity) Problem 69. Uses the Matom\u00e4ki-Radziwil\u0142 theorem on multiplicative functions in short intervals"
     },
     {
       "authors": "Pratt, Kyle",
-      "title": "On the irrationality of certain Erdős series",
+      "title": "On the irrationality of certain Erd\u0151s series",
       "year": "2024",
       "venue": "arXiv preprint",
-      "note": "Proved irrationality of ∑1/(2^p-1) conditional on a quantitative Hardy-Littlewood prime k-tuples conjecture — the first conditional result toward Problem 69"
+      "note": "Proved irrationality of \u22111/(2^p-1) conditional on a quantitative Hardy-Littlewood prime k-tuples conjecture \u2014 the first conditional result toward Problem 69"
     },
     {
-      "authors": "Erdős, Paul",
+      "authors": "Erd\u0151s, Paul",
       "title": "On arithmetical properties of Lambert series",
       "year": "1948",
-      "venue": "Journal of the Indian Mathematical Society, vol. 12, pp. 63–66",
-      "note": "Proved ∑d(n)/2^n is irrational (where d(n) is the divisor function), the direct precursor to Problem 69 which asks the same question for ω(n)"
+      "venue": "Journal of the Indian Mathematical Society, vol. 12, pp. 63\u201366",
+      "note": "Proved \u2211d(n)/2^n is irrational (where d(n) is the divisor function), the direct precursor to Problem 69 which asks the same question for \u03c9(n)"
     },
     {
       "authors": "Nesterenko, Yuri V.",
       "title": "Modular functions and transcendence questions",
       "year": "1996",
-      "venue": "Sbornik: Mathematics, vol. 187, no. 9, pp. 1319–1348",
-      "note": "Proved the algebraic independence of π, e^π, and Γ(1/4) using modular form theory — the same class of techniques that underlies the Tao-Teräväinen irrationality proof"
+      "venue": "Sbornik: Mathematics, vol. 187, no. 9, pp. 1319\u20131348",
+      "note": "Proved the algebraic independence of \u03c0, e^\u03c0, and \u0393(1/4) using modular form theory \u2014 the same class of techniques that underlies the Tao-Ter\u00e4v\u00e4inen irrationality proof"
     }
   ],
   "leanFile": {
@@ -194,7 +194,7 @@
       "Finset"
     ],
     "namespace": "Erdos69",
-    "lineCount": 188,
+    "lineCount": 189,
     "axiomCount": 1,
     "theoremCount": 5,
     "definitionCount": 2,

--- a/src/data/proofs/erdos-795/meta.json
+++ b/src/data/proofs/erdos-795/meta.json
@@ -1,6 +1,6 @@
 {
   "id": "erdos-795",
-  "title": "Erdős Problem #795",
+  "title": "Erd\u0151s Problem #795",
   "slug": "erdos-795",
   "description": "Determine tight bounds for g(n), the maximum size of a subset of {1,...,n} with all subset products distinct.",
   "meta": {
@@ -27,14 +27,14 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "Erdős introduced the function $g(n)$ in a 1966 paper 'Remarks on number theory V' published in Matematikai Lapok, as part of his broader program studying multiplicative structures in sets of integers. The problem arose naturally from the observation that the set of all primes up to $n$ has distinct subset products (by unique factorization), giving $g(n) \\geq \\pi(n)$. Erdős proved the first non-trivial upper bound $g(n) \\leq \\pi(n) + O(\\sqrt{n}/\\ln n)$ in the same paper, showing that at most $O(\\pi(\\sqrt{n}))$ non-prime elements could participate. The gap between the lower bound $\\pi(n)$ and upper bound $\\pi(n) + O(\\pi(\\sqrt{n}))$ suggested that squares of small primes (contributing $\\pi(\\sqrt{n})$ additional elements) might close the gap. This remained open for nearly 60 years until Raghavan's 2025 resolution. The problem is the multiplicative counterpart of Erdős Problem #1 on distinct subset sums, where $f(n, N) = \\max\\{|A| : A \\subseteq \\{1,\\ldots,N\\},\\; \\text{all subset sums distinct}\\}$ and the Conway-Guy conjecture similarly identifies optimal sets. The distinct products problem connects to Sidon sets in multiplicative groups, $B_h$ sequences, and the broader study of sum-free and product-free sets in additive combinatorics.",
+    "historicalContext": "Erd\u0151s introduced the function $g(n)$ in a 1966 paper 'Remarks on number theory V' published in Matematikai Lapok, as part of his broader program studying multiplicative structures in sets of integers. The problem arose naturally from the observation that the set of all primes up to $n$ has distinct subset products (by unique factorization), giving $g(n) \\geq \\pi(n)$. Erd\u0151s proved the first non-trivial upper bound $g(n) \\leq \\pi(n) + O(\\sqrt{n}/\\ln n)$ in the same paper, showing that at most $O(\\pi(\\sqrt{n}))$ non-prime elements could participate. The gap between the lower bound $\\pi(n)$ and upper bound $\\pi(n) + O(\\pi(\\sqrt{n}))$ suggested that squares of small primes (contributing $\\pi(\\sqrt{n})$ additional elements) might close the gap. This remained open for nearly 60 years until Raghavan's 2025 resolution. The problem is the multiplicative counterpart of Erd\u0151s Problem #1 on distinct subset sums, where $f(n, N) = \\max\\{|A| : A \\subseteq \\{1,\\ldots,N\\},\\; \\text{all subset sums distinct}\\}$ and the Conway-Guy conjecture similarly identifies optimal sets. The distinct products problem connects to Sidon sets in multiplicative groups, $B_h$ sequences, and the broader study of sum-free and product-free sets in additive combinatorics.",
     "problemStatement": "Let $g(n)$ be the maximal size of $A \\subseteq \\{1,\\ldots,n\\}$ such that the products $\\prod_{a \\in S} a$ are distinct for all $S \\subseteq A$. Is it true that $g(n) \\leq \\pi(n) + \\pi(n^{1/2}) + o(n^{1/2}/\\ln n)$?",
     "text": "Determine tight bounds for g(n), the maximum size of a subset of {1,...,n} with all subset products distinct.",
     "proofStrategy": "Raghavan's 2025 proof establishes both tight upper and lower bounds. The upper bound $g(n) \\leq \\pi(n) + \\pi(\\sqrt{n}) + O(n^{5/12+o(1)})$ uses a multi-layered argument: first, a structural decomposition shows that optimal sets consist almost entirely of primes and prime squares; second, careful sieve-theoretic estimates bound the contribution of remaining elements. The exponent $5/12$ comes from balancing the multiplicative energy of the non-prime-power remainder against the counting constraint. The lower bound $g(n) \\geq \\pi(n) + \\pi(\\sqrt{n}) + \\pi(\\sqrt[3]{n})/3 - O(1)$ is established by explicit construction: take all primes $\\leq n$, add $p^2$ for each prime $p \\leq \\sqrt{n}$, and additionally include $p^3$ for roughly a third of primes $p \\leq n^{1/3}$. The key observation is that including $p$, $p^2$, and $p^3$ for the same prime $p$ gives four distinguishable exponent values (0, 1, 2, 3), but only a third of cube primes can be added due to interaction constraints.",
     "keyInsights": [
       "Unique factorization is the engine: any set of distinct primes automatically has distinct products, establishing the baseline $g(n) \\geq \\pi(n)$ with no extra work",
       "Prime squares exploit exponent distinguishability: including both $p$ and $p^2$ gives exponents $\\{0, 1, 2, 3\\}$ for $p$ in subset products, all yielding different values modulo higher primes",
-      "The structural decomposition $A = P \\cup P^2 \\cup R$ with $|R| = O(\\pi(n^{1/3}))$ shows composites with multiple distinct prime factors are wasteful—they consume multiple prime 'slots' for one element",
+      "The structural decomposition $A = P \\cup P^2 \\cup R$ with $|R| = O(\\pi(n^{1/3}))$ shows composites with multiple distinct prime factors are wasteful\u2014they consume multiple prime 'slots' for one element",
       "The exponent $5/12$ in the error term is not arbitrary: it arises from the critical threshold where multiplicative energy bounds (from additive combinatorics) intersect with sieve upper bounds",
       "The cube root contribution $\\pi(n^{1/3})/3$ in the lower bound is sharp up to a constant factor, pinning the third-order term to $\\Theta(\\pi(n^{1/3}))$",
       "The problem bridges number theory and combinatorics: the upper bound needs sieve methods and multiplicative energy, while the lower bound uses explicit constructions from prime factorization theory"
@@ -51,8 +51,8 @@
       "title": "Problem Overview and References",
       "startLine": 1,
       "endLine": 49,
-      "summary": "File documentation including Aristotle proof annotations, problem statement, Erdős's original bound, Raghavan's resolution, historical context, and references to [Er66] and [Ra25]. Imports Mathlib for access to the full mathematical library.",
-      "mathContext": "File documentation including Aristotle proof annotations, problem statement, Erdős's original bound, Raghavan's resolution, historical context, and references to [Er66] and [Ra25]. Imports Mathlib for access to the full mathematical library."
+      "summary": "File documentation including Aristotle proof annotations, problem statement, Erd\u0151s's original bound, Raghavan's resolution, historical context, and references to [Er66] and [Ra25]. Imports Mathlib for access to the full mathematical library.",
+      "mathContext": "File documentation including Aristotle proof annotations, problem statement, Erd\u0151s's original bound, Raghavan's resolution, historical context, and references to [Er66] and [Ra25]. Imports Mathlib for access to the full mathematical library."
     },
     {
       "id": "sec-795-basic",
@@ -67,56 +67,56 @@
       "title": "Prime Counting Function",
       "startLine": 78,
       "endLine": 83,
-      "summary": "Defines primePi(n) = π(n) by filtering and counting primes in Finset.range(n+1). This local definition parallels Nat.Arithmetic.primePi in some Mathlib versions.",
-      "mathContext": "Formal definition: Defines primePi(n) = π(n) by filtering and counting primes in Finset.range(n+1). This local definition parallels Nat.Arithmetic.primePi in some Mathlib versions."
+      "summary": "Defines primePi(n) = \u03c0(n) by filtering and counting primes in Finset.range(n+1). This local definition parallels Nat.Arithmetic.primePi in some Mathlib versions.",
+      "mathContext": "Formal definition: Defines primePi(n) = \u03c0(n) by filtering and counting primes in Finset.range(n+1). This local definition parallels Nat.Arithmetic.primePi in some Mathlib versions."
     },
     {
       "id": "sec-795-erdos-bound",
-      "title": "Erdős's 1966 Upper Bound",
+      "title": "Erd\u0151s's 1966 Upper Bound",
       "startLine": 84,
       "endLine": 109,
-      "summary": "States Erdős's original result g(n) ≤ π(n) + O(√n/log n) as a Lean theorem with explicit existential constant. Sorry'd—this is a deep analytic number theory result.",
-      "mathContext": "States Erdős's original result g(n) $\\leq$ π(n) + $O(√n/$\\log n$)$ as a Lean theorem with explicit existential constant. Sorry'd—this is a deep analytic number theory result."
+      "summary": "States Erd\u0151s's original result g(n) \u2264 \u03c0(n) + O(\u221an/log n) as a Lean theorem with explicit existential constant. Sorry'd\u2014this is a deep analytic number theory result.",
+      "mathContext": "States Erd\u0151s's original result g(n) $\\leq$ \u03c0(n) + $O(\u221an/$\\log n$)$ as a Lean theorem with explicit existential constant. Sorry'd\u2014this is a deep analytic number theory result."
     },
     {
       "id": "sec-795-conjecture",
       "title": "The Main Conjecture",
       "startLine": 110,
       "endLine": 121,
-      "summary": "Formalizes Erdős's conjecture as a Lean definition: for all ε > 0, eventually g(n) ≤ π(n) + π(√n) + ε·√n/log n. Uses ε-N formulation of the little-o condition.",
-      "mathContext": "Formalizes Erdős's conjecture as a Lean definition: for all ε > 0, eventually g(n) $\\leq$ π(n) + π(√n) + ε·√n/$\\log n$. Uses ε-N formulation of the little-o condition."
+      "summary": "Formalizes Erd\u0151s's conjecture as a Lean definition: for all \u03b5 > 0, eventually g(n) \u2264 \u03c0(n) + \u03c0(\u221an) + \u03b5\u00b7\u221an/log n. Uses \u03b5-N formulation of the little-o condition.",
+      "mathContext": "Formalizes Erd\u0151s's conjecture as a Lean definition: for all \u03b5 > 0, eventually g(n) $\\leq$ \u03c0(n) + \u03c0(\u221an) + \u03b5\u00b7\u221an/$\\log n$. Uses \u03b5-N formulation of the little-o condition."
     },
     {
       "id": "sec-795-raghavan",
       "title": "Raghavan's Solution (2025)",
       "startLine": 122,
       "endLine": 207,
-      "summary": "The heart of the formalization: Raghavan's upper bound (with n^{5/12} error), lower bound (with π(∛n)/3 term), and the main theorem confirming the conjecture. The solved theorem chains from the upper bound through the error comparison.",
-      "mathContext": "The heart of the formalization: Raghavan's upper bound (with n^{5/12} error), lower bound (with π(∛n)/3 term), and the main theorem confirming the conjecture. The solved theorem chains from the upper bound through the error comparison."
+      "summary": "The heart of the formalization: Raghavan's upper bound (with n^{5/12} error), lower bound (with \u03c0(\u221bn)/3 term), and the main theorem confirming the conjecture. The solved theorem chains from the upper bound through the error comparison.",
+      "mathContext": "The heart of the formalization: Raghavan's upper bound (with n^{5/12} error), lower bound (with \u03c0(\u221bn)/3 term), and the main theorem confirming the conjecture. The solved theorem chains from the upper bound through the error comparison."
     },
     {
       "id": "sec-795-constructions",
       "title": "Natural Constructions",
       "startLine": 210,
       "endLine": 291,
-      "summary": "Formal statements about the building blocks: primes have distinct products (by unique factorization), adding prime squares preserves the property, and the combined construction achieves g(n) ≥ π(n) + π(√n).",
-      "mathContext": "Formal statements about the building blocks: primes have distinct products (by unique factorization), adding prime squares preserves the property, and the combined construction achieves g(n) ≥ π(n) + π(√n)."
+      "summary": "Formal statements about the building blocks: primes have distinct products (by unique factorization), adding prime squares preserves the property, and the combined construction achieves g(n) \u2265 \u03c0(n) + \u03c0(\u221an).",
+      "mathContext": "Formal statements about the building blocks: primes have distinct products (by unique factorization), adding prime squares preserves the property, and the combined construction achieves g(n) \u2265 \u03c0(n) + \u03c0(\u221an)."
     },
     {
       "id": "sec-795-structure",
       "title": "Structure of Optimal Sets",
       "startLine": 292,
       "endLine": 328,
-      "summary": "The structural decomposition theorem: any optimal set A decomposes as P ∪ P² ∪ R where P is primes, P² is prime squares, and the remainder R has size ≤ π(n^{1/3})/2.",
-      "mathContext": "The structural decomposition theorem: any optimal set A decomposes as P ∪ P² ∪ R where P is primes, P² is prime squares, and the remainder R has size $\\leq$ π(n^{1/3})/2."
+      "summary": "The structural decomposition theorem: any optimal set A decomposes as P \u222a P\u00b2 \u222a R where P is primes, P\u00b2 is prime squares, and the remainder R has size \u2264 \u03c0(n^{1/3})/2.",
+      "mathContext": "The structural decomposition theorem: any optimal set A decomposes as P \u222a P\u00b2 \u222a R where P is primes, P\u00b2 is prime squares, and the remainder R has size $\\leq$ \u03c0(n^{1/3})/2."
     },
     {
       "id": "sec-795-error",
       "title": "Error Term Comparison",
       "startLine": 332,
       "endLine": 357,
-      "summary": "Two comparison theorems: Erdős's error vs π(√n), and Raghavan's n^{5/12} vs √n/log n. The latter was proved by Aristotle, making it the only non-sorry theorem in the file.",
-      "mathContext": "Two comparison theorems: Erdős's error vs π(√n), and Raghavan's n^{5/12} vs √n/$\\log n$. The latter was proved by Aristotle, making it the only non-sorry theorem in the file."
+      "summary": "Two comparison theorems: Erd\u0151s's error vs \u03c0(\u221an), and Raghavan's n^{5/12} vs \u221an/log n. The latter was proved by Aristotle, making it the only non-sorry theorem in the file.",
+      "mathContext": "Two comparison theorems: Erd\u0151s's error vs \u03c0(\u221an), and Raghavan's n^{5/12} vs \u221an/$\\log n$. The latter was proved by Aristotle, making it the only non-sorry theorem in the file."
     },
     {
       "id": "sec-795-sidon",
@@ -131,15 +131,15 @@
       "title": "Related Problem #786",
       "startLine": 416,
       "endLine": 423,
-      "summary": "A placeholder connecting to the sister problem erdos-786 on growth of g(n) for specific families, noting Raghavan's bounds pin it to π(n) + π(√n) + Θ(π(∛n)).",
-      "mathContext": "Bound: A placeholder connecting to the sister problem erdos-786 on growth of g(n) for specific families, noting Raghavan's bounds pin it to π(n) + π(√n) + Θ(π(∛n))."
+      "summary": "A placeholder connecting to the sister problem erdos-786 on growth of g(n) for specific families, noting Raghavan's bounds pin it to \u03c0(n) + \u03c0(\u221an) + \u0398(\u03c0(\u221bn)).",
+      "mathContext": "Bound: A placeholder connecting to the sister problem erdos-786 on growth of g(n) for specific families, noting Raghavan's bounds pin it to \u03c0(n) + \u03c0(\u221an) + \u0398(\u03c0(\u221bn))."
     },
     {
       "id": "sec-795-examples",
       "title": "Examples and Small Values",
       "startLine": 424,
       "endLine": 490,
-      "summary": "Concrete examples: {2,3,5} has distinct products (all 8 products different), {2,3,6} fails (product collision at 6), and small computed values g(2)=1, g(3)=2, g(5)=3, g(10)≥5.",
+      "summary": "Concrete examples: {2,3,5} has distinct products (all 8 products different), {2,3,6} fails (product collision at 6), and small computed values g(2)=1, g(3)=2, g(5)=3, g(10)\u22655.",
       "mathContext": "Concrete examples: {2,3,5} has distinct products (all 8 products different), {2,3,6} fails (product collision at 6), and small computed values g(2)=1, g(3)=2, g(5)=3, g(10)$\\geq$5."
     },
     {
@@ -147,17 +147,17 @@
       "title": "Summary",
       "startLine": 491,
       "endLine": 500,
-      "summary": "Closing documentation block summarizing the SOLVED status, the exact asymptotic g(n) = π(n) + π(√n) + Θ(π(∛n)), and the key insight about primes and prime powers forming optimal sets.",
-      "mathContext": "Mathematical content: Closing documentation block summarizing the SOLVED status, the exact asymptotic g(n) = π(n) + π(√n) + Θ(π(∛n)), and the key insight about primes and prime powers forming optimal sets."
+      "summary": "Closing documentation block summarizing the SOLVED status, the exact asymptotic g(n) = \u03c0(n) + \u03c0(\u221an) + \u0398(\u03c0(\u221bn)), and the key insight about primes and prime powers forming optimal sets.",
+      "mathContext": "Mathematical content: Closing documentation block summarizing the SOLVED status, the exact asymptotic g(n) = \u03c0(n) + \u03c0(\u221an) + \u0398(\u03c0(\u221bn)), and the key insight about primes and prime powers forming optimal sets."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #795 is SOLVED. Raghavan (2025) proved $g(n) = \\pi(n) + \\pi(n^{1/2}) + \\Theta(\\pi(n^{1/3}))$, confirming that the natural construction of primes plus prime squares is essentially optimal, with a precisely quantified contribution from cube roots of primes. The formalization captures the full problem structure, from definitions through Erdős's original bound to Raghavan's resolution, with one theorem (the error comparison) proved by Aristotle.",
-    "implications": "**Theoretical Significance**: This result closes a 60-year-old question in multiplicative combinatorics, definitively characterizing which subsets of $\\{1,\\ldots,n\\}$ maximize the number of elements while maintaining distinct subset products.\n\nThe techniques developed—combining sieve methods with multiplicative energy bounds from additive combinatorics—have potential applications to other extremal problems involving multiplicative structure. The structural decomposition into primes, prime squares, and a small remainder gives a template for analyzing optimal sets in similar problems.",
+    "summary": "Erd\u0151s Problem #795 is SOLVED. Raghavan (2025) proved $g(n) = \\pi(n) + \\pi(n^{1/2}) + \\Theta(\\pi(n^{1/3}))$, confirming that the natural construction of primes plus prime squares is essentially optimal, with a precisely quantified contribution from cube roots of primes. The formalization captures the full problem structure, from definitions through Erd\u0151s's original bound to Raghavan's resolution, with one theorem (the error comparison) proved by Aristotle.",
+    "implications": "**Theoretical Significance**: This result closes a 60-year-old question in multiplicative combinatorics, definitively characterizing which subsets of $\\{1,\\ldots,n\\}$ maximize the number of elements while maintaining distinct subset products.\n\nThe techniques developed\u2014combining sieve methods with multiplicative energy bounds from additive combinatorics\u2014have potential applications to other extremal problems involving multiplicative structure. The structural decomposition into primes, prime squares, and a small remainder gives a template for analyzing optimal sets in similar problems.",
     "openQuestions": [
       "What is the exact leading constant in the $\\pi(n^{1/3})$ term? Raghavan's bounds give $\\pi(n^{1/3})/3$ from below and $O(n^{5/12})$ from above, but the precise coefficient remains unknown.",
       "Can the error exponent $5/12$ in the upper bound be improved to match the lower bound's $1/3$? Closing this gap would fully determine the third-order term.",
-      "What are the analogues for distinct subset sums vs. products? Erdős Problem #1 addresses the additive case, but the relationship between optimal additive and multiplicative constructions is not well understood.",
+      "What are the analogues for distinct subset sums vs. products? Erd\u0151s Problem #1 addresses the additive case, but the relationship between optimal additive and multiplicative constructions is not well understood.",
       "How does $g(n)$ behave for restricted sets, such as subsets of arithmetic progressions $\\{a, a+d, \\ldots, a+kd\\}$?"
     ]
   },
@@ -167,7 +167,7 @@
     ],
     "opens": [],
     "namespace": "Erdos795",
-    "lineCount": 499,
+    "lineCount": 500,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 7,
@@ -178,17 +178,17 @@
     {
       "targetId": "erdos-983",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, number-theory, prime-counting"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, number-theory, prime-counting"
     },
     {
       "targetId": "erdos-1005",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, number-theory"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, number-theory"
     },
     {
       "targetId": "erdos-1138",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, number-theory"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, number-theory"
     }
   ],
   "sorries": 15

--- a/src/data/proofs/erdos-866/meta.json
+++ b/src/data/proofs/erdos-866/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-866",
-  "title": "Erdős Problem #866: Pairwise Sums Threshold",
+  "title": "Erd\u0151s Problem #866: Pairwise Sums Threshold",
   "slug": "erdos-866",
-  "description": "For k ≥ 3, define g_k(N) as the minimal threshold such that A ⊆ {1,...,2N} with |A| ≥ N + g_k(N) contains all pairwise sums of some b₁,...,b_k. Known: g₃=2, g₄≤2032, g₅≍log N, g₆≍√N. General bounds have gaps.",
+  "description": "For k \u2265 3, define g_k(N) as the minimal threshold such that A \u2286 {1,...,2N} with |A| \u2265 N + g_k(N) contains all pairwise sums of some b\u2081,...,b_k. Known: g\u2083=2, g\u2084\u22642032, g\u2085\u224dlog N, g\u2086\u224d\u221aN. General bounds have gaps.",
   "meta": {
-    "author": "Choi, Erdős, Szemerédi",
+    "author": "Choi, Erd\u0151s, Szemer\u00e9di",
     "sourceUrl": "https://erdosproblems.com/866",
     "date": "1975",
     "mathlib_version": "4.26.0",
@@ -35,21 +35,21 @@
       },
       {
         "theorem": "Real.log",
-        "description": "Logarithm for g₅ bounds",
+        "description": "Logarithm for g\u2085 bounds",
         "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
       },
       {
         "theorem": "Real.sqrt",
-        "description": "Square root for g₆ bounds",
+        "description": "Square root for g\u2086 bounds",
         "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
       }
     ],
     "originalContributions": [
-      "Formal definition of HasAllPairwiseSums and PairwiseSumCondition using Fin k → ℤ witnesses",
+      "Formal definition of HasAllPairwiseSums and PairwiseSumCondition using Fin k \u2192 \u2124 witnesses",
       "Threshold function g_k(N) via Nat.find with vacuous existence proof",
-      "Complete case analysis: g₃=2 (exact), g₄≤2032 (van Doorn), g₅≍log N, g₆≍√N",
+      "Complete case analysis: g\u2083=2 (exact), g\u2084\u22642032 (van Doorn), g\u2085\u224dlog N, g\u2086\u224d\u221aN",
       "General upper bound N^{1-2^{-k}} with upperExponent monotonicity",
-      "General lower bound N^{1-ε} for large k, with threshold_approaches_N corollary",
+      "General lower bound N^{1-\u03b5} for large k, with threshold_approaches_N corollary",
       "Odd numbers construction as fundamental extremal example",
       "Four open problems formalized as Lean propositions"
     ],
@@ -58,17 +58,17 @@
     "assumptions": "0 axioms. 0 sorries. All results formalized without axioms."
   },
   "overview": {
-    "historicalContext": "Erdős Problem #866 originates from the work of Choi, Erdős, and Szemerédi on sumsets and additive combinatorics, building on their unpublished manuscript 'On sums and products of integers.' The problem asks: how large must a subset A of {1,...,2N} be to guarantee that some k integers have all their pairwise sums in A?\n\nThe foundational observation is the odd numbers construction: the set {1, 3, 5, ..., 2N-1} has N elements but avoids all pairwise sums (since odd + odd = even). This shows the threshold must be at least 1 above N. For k=3, the exact answer is g₃(N) = 2, proved via a complementary pairs pigeonhole argument.\n\nThe most striking feature is the phase transition as k increases: g₃ = 2 (constant), g₄ ≤ 2032 (bounded constant, van Doorn), g₅ ≍ log N (logarithmic), g₆ ≍ √N (polynomial). The general upper bound g_k(N) ≪ N^{1-2^{-k}} (Choi–Erdős–Szemerédi) shows the exponent approaches 1 geometrically, while the lower bound g_k(N) > N^{1-ε} for large k shows the threshold eventually approaches N.\n\nThis growth rate transition—from constant through logarithmic and polynomial to nearly linear—is rare in combinatorics and reflects deep structural changes in the extremal problem. The gap between upper and lower bounds for intermediate and large k remains one of the central open questions in additive combinatorics.",
-    "problemStatement": "**Problem Statement**\n\nFor k ≥ 3, let g_k(N) be the minimal value such that if A ⊆ {1,...,2N} has |A| ≥ N + g_k(N), then there exist integers b₁,...,b_k such that all $\\binom{k}{2}$ pairwise sums b_i + b_j are in A (the b_i need not be in A).\n\n**Goal**: Estimate g_k(N) for all k.\n\n**Status**: PARTIALLY SOLVED\n- Small k (3,4,5,6): Well characterized\n- Large k: Gap between upper and lower bounds",
-    "text": "For k ≥ 3, define g_k(N) as the minimal threshold such that A ⊆ {1,...,2N} with |A| ≥ N + g_k(N) contains all pairwise sums of some b₁,...,b_k. Known: g₃=2, g₄≤2032, g₅≍log N, g₆≍√N. General bounds have gaps.",
-    "proofStrategy": "The formalization is organized into eleven parts:\n\n1. **Definitions**: Interval, HasAllPairwiseSums (using Fin k → ℤ), PairwiseSumCondition, and g via Nat.find\n2. **Case k=3**: g₃(N) = 2 exactly (axiom), with lower bound from odd numbers construction\n3. **Case k=4**: g₄(N) bounded (axiom), van Doorn's explicit g₄ ≤ 2032 (axiom)\n4. **Case k=5**: g₅(N) ≍ log N (axiom), lower bound extracted as corollary via `obtain`\n5. **Case k=6**: g₆(N) ≍ √N (axiom)\n6. **General upper**: g_k(N) ≪ N^{1-2^{-k}} with upperExponent monotonicity (proved)\n7. **General lower**: g_k(N) > N^{1-ε} for large k (axiom), threshold_approaches_N (proved)\n8. **Odd numbers**: Extremal construction with cardinality (proved) and avoidance (proved) proofs\n9. **Summary table**: Four summary theorems directly referencing axioms\n10. **Open problems**: Four formalized as Lean Props\n11. **Main summary**: Conjunction of g₃ exact and g₄ bounded",
+    "historicalContext": "Erd\u0151s Problem #866 originates from the work of Choi, Erd\u0151s, and Szemer\u00e9di on sumsets and additive combinatorics, building on their unpublished manuscript 'On sums and products of integers.' The problem asks: how large must a subset A of {1,...,2N} be to guarantee that some k integers have all their pairwise sums in A?\n\nThe foundational observation is the odd numbers construction: the set {1, 3, 5, ..., 2N-1} has N elements but avoids all pairwise sums (since odd + odd = even). This shows the threshold must be at least 1 above N. For k=3, the exact answer is g\u2083(N) = 2, proved via a complementary pairs pigeonhole argument.\n\nThe most striking feature is the phase transition as k increases: g\u2083 = 2 (constant), g\u2084 \u2264 2032 (bounded constant, van Doorn), g\u2085 \u224d log N (logarithmic), g\u2086 \u224d \u221aN (polynomial). The general upper bound g_k(N) \u226a N^{1-2^{-k}} (Choi\u2013Erd\u0151s\u2013Szemer\u00e9di) shows the exponent approaches 1 geometrically, while the lower bound g_k(N) > N^{1-\u03b5} for large k shows the threshold eventually approaches N.\n\nThis growth rate transition\u2014from constant through logarithmic and polynomial to nearly linear\u2014is rare in combinatorics and reflects deep structural changes in the extremal problem. The gap between upper and lower bounds for intermediate and large k remains one of the central open questions in additive combinatorics.",
+    "problemStatement": "**Problem Statement**\n\nFor k \u2265 3, let g_k(N) be the minimal value such that if A \u2286 {1,...,2N} has |A| \u2265 N + g_k(N), then there exist integers b\u2081,...,b_k such that all $\\binom{k}{2}$ pairwise sums b_i + b_j are in A (the b_i need not be in A).\n\n**Goal**: Estimate g_k(N) for all k.\n\n**Status**: PARTIALLY SOLVED\n- Small k (3,4,5,6): Well characterized\n- Large k: Gap between upper and lower bounds",
+    "text": "For k \u2265 3, define g_k(N) as the minimal threshold such that A \u2286 {1,...,2N} with |A| \u2265 N + g_k(N) contains all pairwise sums of some b\u2081,...,b_k. Known: g\u2083=2, g\u2084\u22642032, g\u2085\u224dlog N, g\u2086\u224d\u221aN. General bounds have gaps.",
+    "proofStrategy": "The formalization is organized into eleven parts:\n\n1. **Definitions**: Interval, HasAllPairwiseSums (using Fin k \u2192 \u2124), PairwiseSumCondition, and g via Nat.find\n2. **Case k=3**: g\u2083(N) = 2 exactly (axiom), with lower bound from odd numbers construction\n3. **Case k=4**: g\u2084(N) bounded (axiom), van Doorn's explicit g\u2084 \u2264 2032 (axiom)\n4. **Case k=5**: g\u2085(N) \u224d log N (axiom), lower bound extracted as corollary via `obtain`\n5. **Case k=6**: g\u2086(N) \u224d \u221aN (axiom)\n6. **General upper**: g_k(N) \u226a N^{1-2^{-k}} with upperExponent monotonicity (proved)\n7. **General lower**: g_k(N) > N^{1-\u03b5} for large k (axiom), threshold_approaches_N (proved)\n8. **Odd numbers**: Extremal construction with cardinality (proved) and avoidance (proved) proofs\n9. **Summary table**: Four summary theorems directly referencing axioms\n10. **Open problems**: Four formalized as Lean Props\n11. **Main summary**: Conjunction of g\u2083 exact and g\u2084 bounded",
     "keyInsights": [
-      "**Phase transition in growth rates**: The sequence constant → log → √N → N^{1-o(1)} as k increases from 3 to ∞ represents a rare and striking phenomenon in combinatorics. Each transition (k=4→5, k=5→6, finite→∞) requires fundamentally different techniques.",
-      "**The odd numbers construction is universal**: The set of odd integers in [2N] has exactly N elements and avoids ALL pairwise sum configurations (for any k), because two integers of the same parity sum to an even number. This single construction provides the base lower bound g_k(N) ≥ 1 for all k.",
-      "**Witnesses need not be in A**: The b_i are arbitrary integers whose pairwise sums land in A. Allowing b_i ∉ A and b_i < 0 (via Fin k → ℤ) is essential—the problem would be much harder if we required b_i ∈ A.",
-      "**The k=4 to k=5 transition is the sharpest**: g₄ = O(1) while g₅ = Θ(log N). Adding one more integer to the required pattern (4→5 witnesses, 6→10 pairwise sums) causes the threshold to jump from bounded to unbounded. This is the point where the combinatorial complexity qualitatively changes.",
-      "**The exponent 1-2^{-k} comes from induction**: The general upper bound proceeds by induction on k: given k-1 witnesses, the remaining density suffices to find the k-th. Each inductive step squares the deficiency (from N^α to N^{(1+α)/2}), giving the geometric approach to exponent 1.",
-      "**The gap between bounds is the main open problem**: For large k, the upper exponent 1-2^{-k} and lower exponent 1-ε don't match. Finding the true exponent α_k with g_k(N) = N^{α_k+o(1)} is the central challenge."
+      "**Phase transition in growth rates**: The sequence constant \u2192 log \u2192 \u221aN \u2192 N^{1-o(1)} as k increases from 3 to \u221e represents a rare and striking phenomenon in combinatorics. Each transition (k=4\u21925, k=5\u21926, finite\u2192\u221e) requires fundamentally different techniques.",
+      "**The odd numbers construction is universal**: The set of odd integers in [2N] has exactly N elements and avoids ALL pairwise sum configurations (for any k), because two integers of the same parity sum to an even number. This single construction provides the base lower bound g_k(N) \u2265 1 for all k.",
+      "**Witnesses need not be in A**: The b_i are arbitrary integers whose pairwise sums land in A. Allowing b_i \u2209 A and b_i < 0 (via Fin k \u2192 \u2124) is essential\u2014the problem would be much harder if we required b_i \u2208 A.",
+      "**The k=4 to k=5 transition is the sharpest**: g\u2084 = O(1) while g\u2085 = \u0398(log N). Adding one more integer to the required pattern (4\u21925 witnesses, 6\u219210 pairwise sums) causes the threshold to jump from bounded to unbounded. This is the point where the combinatorial complexity qualitatively changes.",
+      "**The exponent 1-2^{-k} comes from induction**: The general upper bound proceeds by induction on k: given k-1 witnesses, the remaining density suffices to find the k-th. Each inductive step squares the deficiency (from N^\u03b1 to N^{(1+\u03b1)/2}), giving the geometric approach to exponent 1.",
+      "**The gap between bounds is the main open problem**: For large k, the upper exponent 1-2^{-k} and lower exponent 1-\u03b5 don't match. Finding the true exponent \u03b1_k with g_k(N) = N^{\u03b1_k+o(1)} is the central challenge."
     ],
     "prerequisites": [
       "Additive combinatorics (sumsets, density)",
@@ -79,23 +79,23 @@
     {
       "id": "basic-definitions",
       "title": "Basic Definitions",
-      "summary": "Defines Interval(N) = {1,...,2N}, HasAllPairwiseSums via Fin k → ℤ witnesses, PairwiseSumCondition as the universal threshold statement, and g(k,N) via Nat.find.",
+      "summary": "Defines Interval(N) = {1,...,2N}, HasAllPairwiseSums via Fin k \u2192 \u2124 witnesses, PairwiseSumCondition as the universal threshold statement, and g(k,N) via Nat.find.",
       "startLine": 41,
       "endLine": 66,
       "mathContext": "$[2N] = \\{1,\\ldots,2N\\}$. $\\text{HasAllPairwiseSums}(A,b) :\\equiv \\forall i < j,\\; b_i + b_j \\in A$ for witnesses $b : \\text{Fin}\\,k \\to \\mathbb{Z}$. $g_k(N) = \\min\\{g : \\forall A \\subseteq [2N], |A| \\ge N+g \\Rightarrow \\exists b, \\text{HasAllPairwiseSums}(A,b)\\}$."
     },
     {
       "id": "case-k3",
-      "title": "Case k=3: Exact Value g₃=2",
-      "summary": "Axiomatizes g₃(N) = 2 (Choi–Erdős–Szemerédi). Lower bound g₃ ≥ 2 from odd numbers + parity pigeonhole.",
+      "title": "Case k=3: Exact Value g\u2083=2",
+      "summary": "Axiomatizes g\u2083(N) = 2 (Choi\u2013Erd\u0151s\u2013Szemer\u00e9di). Lower bound g\u2083 \u2265 2 from odd numbers + parity pigeonhole.",
       "startLine": 67,
       "endLine": 82,
-      "mathContext": "$g_3(N) = 2$ exactly. Upper bound: axiom (Choi–Erdős–Szemerédi pigeonhole on complementary pairs). Lower bound: $O_N = \\{1,3,\\ldots,2N-1\\}$ has $|O_N|=N$ but odd+odd=even $\\notin O_N$, so $g_3 \\ge 2$."
+      "mathContext": "$g_3(N) = 2$ exactly. Upper bound: axiom (Choi\u2013Erd\u0151s\u2013Szemer\u00e9di pigeonhole on complementary pairs). Lower bound: $O_N = \\{1,3,\\ldots,2N-1\\}$ has $|O_N|=N$ but odd+odd=even $\\notin O_N$, so $g_3 \\ge 2$."
     },
     {
       "id": "case-k4",
-      "title": "Case k=4: Bounded Threshold g₄≤2032",
-      "summary": "Two axioms: g₄(N) ≤ C absolutely (Choi–Erdős–Szemerédi) and g₄(N) ≤ 2032 (van Doorn).",
+      "title": "Case k=4: Bounded Threshold g\u2084\u22642032",
+      "summary": "Two axioms: g\u2084(N) \u2264 C absolutely (Choi\u2013Erd\u0151s\u2013Szemer\u00e9di) and g\u2084(N) \u2264 2032 (van Doorn).",
       "startLine": 83,
       "endLine": 100,
       "mathContext": "$\\exists C \\in \\mathbb{N},\\; \\forall N,\\; g_4(N) \\le C$ (bounded). Explicit: $g_4(N) \\le 2032$ (van Doorn). Stark contrast: $g_4 = O(1)$ while $g_5 = \\Theta(\\log N)$."
@@ -103,15 +103,15 @@
     {
       "id": "case-k5-k6",
       "title": "Cases k=5,6: Logarithmic and Polynomial Growth",
-      "summary": "g₅≍log N (Choi–Erdős–Szemerédi), g₆≍√N. Lower bound for g₅ extracted via `obtain` from the asymptotic axiom.",
+      "summary": "g\u2085\u224dlog N (Choi\u2013Erd\u0151s\u2013Szemer\u00e9di), g\u2086\u224d\u221aN. Lower bound for g\u2085 extracted via `obtain` from the asymptotic axiom.",
       "startLine": 101,
       "endLine": 128,
       "mathContext": "$g_5(N) \\asymp \\log N$: $\\exists c_1,c_2 > 0,\\; c_1 \\log N \\le g_5(N) \\le c_2 \\log N$. $g_6(N) \\asymp \\sqrt{N}$. The transition $O(1) \\to \\Theta(\\log N) \\to \\Theta(\\sqrt{N})$ reflects the jump from $\\binom{4}{2}=6$ to $\\binom{5}{2}=10$ to $\\binom{6}{2}=15$ required sums."
     },
     {
       "id": "general-bounds",
-      "title": "General Bounds: Upper N^{1-2^{-k}} and Lower N^{1-ε}",
-      "summary": "General upper bound g_k(N) ≪ N^{1-2^{-k}} with upperExponent monotonicity (proved). General lower: g_k > N^{1-ε} for large k (axiom). threshold_approaches_N corollary.",
+      "title": "General Bounds: Upper N^{1-2^{-k}} and Lower N^{1-\u03b5}",
+      "summary": "General upper bound g_k(N) \u226a N^{1-2^{-k}} with upperExponent monotonicity (proved). General lower: g_k > N^{1-\u03b5} for large k (axiom). threshold_approaches_N corollary.",
       "startLine": 129,
       "endLine": 172,
       "mathContext": "Upper: $g_k(N) \\le C_k N^{1-2^{-k}}$ (exponent $\\nearrow 1$ geometrically). Lower: $\\forall \\varepsilon>0,\\; \\exists k_0,\\; k \\ge k_0 \\Rightarrow g_k(N) > N^{1-\\varepsilon}$. Together: $g_k(N) = N^{1-o(1)}$ as $k \\to \\infty$. Gap: true exponent $\\alpha_k \\in (1-2^{-k}, 1-\\varepsilon)$ unknown."
@@ -127,19 +127,19 @@
     {
       "id": "summary-open",
       "title": "Summary Table and Four Open Problems",
-      "summary": "Theorems referencing all case axioms (g₃=2, g₄≤2032, g₅≍log N, g₆≍√N, general bounds). Four open problems formalized as Props.",
+      "summary": "Theorems referencing all case axioms (g\u2083=2, g\u2084\u22642032, g\u2085\u224dlog N, g\u2086\u224d\u221aN, general bounds). Four open problems formalized as Props.",
       "startLine": 196,
       "endLine": 274,
       "mathContext": "Summary: $g_3=2,\\; g_4 \\le 2032,\\; g_5 \\asymp \\log N,\\; g_6 \\asymp \\sqrt{N},\\; g_k \\ll N^{1-2^{-k}},\\; g_k > N^{1-\\varepsilon} \\text{ (large } k)$. Opens: (1) exact $g_4$, (2) constants in $g_5 \\asymp \\log N$, (3) true exponent $\\alpha_k$, (4) structural characterization of extremal sets."
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem #866 on pairwise sums threshold functions, organizing the theory into case analysis (k=3,4,5,6), general bounds, extremal constructions, and open problems. All supporting lemmas proved by Aristotle: upperExponent monotonicity, oddNumbers cardinality, and oddNumbers avoidance. 7 axioms encode the known mathematical results.",
-    "implications": "The problem reveals fundamental phase transitions in additive combinatorics: (1) the jump from bounded to unbounded threshold at k=4→5 shows a qualitative complexity barrier; (2) the growth rate hierarchy (constant → log → √N → N^{1-o(1)}) is exceptionally clean; (3) the gap between upper exponent 1-2^{-k} and lower exponent 1-ε for large k represents a major open frontier. The formalization demonstrates how Lean can cleanly separate exact results (g₃=2) from asymptotic bounds (g₅, g₆) and open questions, providing precise statements for future work.",
+    "summary": "This formalization captures Erd\u0151s Problem #866 on pairwise sums threshold functions, organizing the theory into case analysis (k=3,4,5,6), general bounds, extremal constructions, and open problems. All supporting lemmas proved by Aristotle: upperExponent monotonicity, oddNumbers cardinality, and oddNumbers avoidance. 7 axioms encode the known mathematical results.",
+    "implications": "The problem reveals fundamental phase transitions in additive combinatorics: (1) the jump from bounded to unbounded threshold at k=4\u21925 shows a qualitative complexity barrier; (2) the growth rate hierarchy (constant \u2192 log \u2192 \u221aN \u2192 N^{1-o(1)}) is exceptionally clean; (3) the gap between upper exponent 1-2^{-k} and lower exponent 1-\u03b5 for large k represents a major open frontier. The formalization demonstrates how Lean can cleanly separate exact results (g\u2083=2) from asymptotic bounds (g\u2085, g\u2086) and open questions, providing precise statements for future work.",
     "openQuestions": [
-      "What is the exact value of g₄(N)? Is g₄(N) constant, and if so, what is the constant?",
-      "What are the optimal constants c₁, c₂ in g₅(N) ≍ log N? Does g₅(N)/log N converge?",
-      "Can the gap between N^{1-2^{-k}} and N^{1-ε} for large k be closed? What is the true exponent α_k?",
+      "What is the exact value of g\u2084(N)? Is g\u2084(N) constant, and if so, what is the constant?",
+      "What are the optimal constants c\u2081, c\u2082 in g\u2085(N) \u224d log N? Does g\u2085(N)/log N converge?",
+      "Can the gap between N^{1-2^{-k}} and N^{1-\u03b5} for large k be closed? What is the true exponent \u03b1_k?",
       "What is the structural characterization of extremal sets (maximum-size sets avoiding the pairwise sums condition)?",
       "Is there a unified proof technique that handles all values of k, or must each case use fundamentally different methods?"
     ]
@@ -158,7 +158,7 @@
       "Real"
     ],
     "namespace": "Erdos866",
-    "lineCount": 84,
+    "lineCount": 85,
     "axiomCount": 0,
     "theoremCount": 3,
     "definitionCount": 10,
@@ -169,17 +169,17 @@
     {
       "targetId": "erdos-109",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: additive-combinatorics, sumsets"
+      "description": "Related Erd\u0151s problem sharing themes: additive-combinatorics, sumsets"
     },
     {
       "targetId": "erdos-1103",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: additive-combinatorics, sumsets"
+      "description": "Related Erd\u0151s problem sharing themes: additive-combinatorics, sumsets"
     },
     {
       "targetId": "erdos-1109",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: additive-combinatorics, sumsets"
+      "description": "Related Erd\u0151s problem sharing themes: additive-combinatorics, sumsets"
     }
   ],
   "sorries": 0

--- a/src/data/proofs/erdos-941/meta.json
+++ b/src/data/proofs/erdos-941/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-941",
-  "title": "Erdős Problem #941: Sums of Three Powerful Numbers",
+  "title": "Erd\u0151s Problem #941: Sums of Three Powerful Numbers",
   "slug": "erdos-941",
-  "description": "Are all large integers the sum of at most three powerful numbers (p | n → p² | n)? SOLVED: YES (Heath-Brown 1988). Every sufficiently large integer is the sum of at most 3 powerful numbers.",
+  "description": "Are all large integers the sum of at most three powerful numbers (p | n \u2192 p\u00b2 | n)? SOLVED: YES (Heath-Brown 1988). Every sufficiently large integer is the sum of at most 3 powerful numbers.",
   "meta": {
-    "author": "Erdős-Ivić (1986, problem), Heath-Brown (1988, proof)",
+    "author": "Erd\u0151s-Ivi\u0107 (1986, problem), Heath-Brown (1988, proof)",
     "sourceUrl": "https://erdosproblems.com/941",
     "date": "1988",
     "status": "axiomatized",
@@ -27,7 +27,7 @@
     "mathlibDependencies": [
       {
         "theorem": "Nat.Prime",
-        "description": "Primality predicate for the powerful number definition (p | n → p² | n)",
+        "description": "Primality predicate for the powerful number definition (p | n \u2192 p\u00b2 | n)",
         "module": "Mathlib.Data.Nat.Basic"
       },
       {
@@ -48,7 +48,7 @@
     ],
     "originalContributions": [
       "IsPowerful, IsPowerfulAlt: powerful number definitions",
-      "powerful_iff_alt: equivalence n = a²b³",
+      "powerful_iff_alt: equivalence n = a\u00b2b\u00b3",
       "one_is_powerful, square_is_powerful, cube_is_powerful",
       "powerful_mul: product closure",
       "IsSumOf3Powerful, IsSumOf3PowerfulOrZero",
@@ -62,14 +62,14 @@
     "assumptions": "4 axiom(s) and 0 sorry(s)."
   },
   "overview": {
-    "historicalContext": "**Erdős Problem #941: Sums of Three Powerful Numbers**\n\nThis problem was posed by Erdős and Ivić at the 1986 Oberwolfach conference, asking whether every sufficiently large integer is the sum of at most three powerful (squarefull) numbers.\n\n**Historical Timeline:**\n- 1970: Golomb proved the characterization $n$ is powerful $\\iff$ $n = a^2 b^3$ for some $a, b \\ge 1$\n- 1976: Erdős studied the distribution of powerful numbers and their additive properties in [Er76d]\n- 1986: Erdős and Ivić formally posed the question at Oberwolfach\n- 1988: Heath-Brown proved the affirmative answer using ternary quadratic forms\n- 1994: Baker and Brüdern proved the complementary result that sums of $\\le 2$ powerful numbers have density 0 (Problem #940)\n\n**Heath-Brown's Method:** The proof uses deep results from the theory of ternary quadratic forms. The key idea is to write $n = a^2 + b^2 c^3 + d^2 e^3$ where each summand is automatically powerful (squarefull). Representing $n$ in this form reduces to showing that a certain ternary quadratic form represents $n$, which Heath-Brown establishes using the Hasse principle and Siegel's mass formula for ternary forms.\n\n**The Threshold Mystery:** Heath-Brown's proof is ineffective — it shows a threshold $N_0$ exists but does not compute it. The ineffectivity comes from the use of Siegel's theorem on ternary forms, which involves class number estimates with ineffective constants. Computing $N_0$ explicitly would require effective bounds in the Hasse principle.\n\n**Phase Transition:** Combined with Baker-Brüdern (1994), we know: sums of $\\le 2$ powerful numbers have density 0, but sums of $\\le 3$ powerful numbers contain all large integers. This sharp 2-to-3 transition is the central phenomenon in the additive theory of powerful numbers.",
+    "historicalContext": "**Erd\u0151s Problem #941: Sums of Three Powerful Numbers**\n\nThis problem was posed by Erd\u0151s and Ivi\u0107 at the 1986 Oberwolfach conference, asking whether every sufficiently large integer is the sum of at most three powerful (squarefull) numbers.\n\n**Historical Timeline:**\n- 1970: Golomb proved the characterization $n$ is powerful $\\iff$ $n = a^2 b^3$ for some $a, b \\ge 1$\n- 1976: Erd\u0151s studied the distribution of powerful numbers and their additive properties in [Er76d]\n- 1986: Erd\u0151s and Ivi\u0107 formally posed the question at Oberwolfach\n- 1988: Heath-Brown proved the affirmative answer using ternary quadratic forms\n- 1994: Baker and Br\u00fcdern proved the complementary result that sums of $\\le 2$ powerful numbers have density 0 (Problem #940)\n\n**Heath-Brown's Method:** The proof uses deep results from the theory of ternary quadratic forms. The key idea is to write $n = a^2 + b^2 c^3 + d^2 e^3$ where each summand is automatically powerful (squarefull). Representing $n$ in this form reduces to showing that a certain ternary quadratic form represents $n$, which Heath-Brown establishes using the Hasse principle and Siegel's mass formula for ternary forms.\n\n**The Threshold Mystery:** Heath-Brown's proof is ineffective \u2014 it shows a threshold $N_0$ exists but does not compute it. The ineffectivity comes from the use of Siegel's theorem on ternary forms, which involves class number estimates with ineffective constants. Computing $N_0$ explicitly would require effective bounds in the Hasse principle.\n\n**Phase Transition:** Combined with Baker-Br\u00fcdern (1994), we know: sums of $\\le 2$ powerful numbers have density 0, but sums of $\\le 3$ powerful numbers contain all large integers. This sharp 2-to-3 transition is the central phenomenon in the additive theory of powerful numbers.",
     "problemStatement": "**Problem Statement (Solved)**\n\nLet $n$ be a powerful number if $p \\mid n \\Rightarrow p^2 \\mid n$ for every prime $p$. Are all sufficiently large positive integers the sum of at most three powerful numbers?\n\n**Answer: YES** (Heath-Brown 1988)\n\nEvery sufficiently large positive integer can be written as $a + b + c$ where each of $a, b, c$ is either 0 or a powerful number.",
-    "text": "Are all large integers the sum of at most three powerful numbers (p | n → p² | n)? SOLVED: YES (Heath-Brown 1988). Every sufficiently large integer is the sum of at most 3 powerful numbers.",
-    "proofStrategy": "**Formalization Strategy**\n\n1. **Powerful Numbers:** `IsPowerful` ($p \\mid n \\Rightarrow p^2 \\mid n$) and `IsPowerfulAlt` ($n = a^2 b^3$), with `powerful_iff_alt` (sorry) connecting them\n2. **Structural Properties:** `one_is_powerful`, `square_is_powerful`, `cube_is_powerful`, `powerful_mul` (all proved) — establishing the multiplicative monoid structure\n3. **Sum Framework:** `IsSumOfKPowerful` (general $k$), `IsSumOf3Powerful` (exactly 3), `IsSumOf3PowerfulOrZero` (at most 3)\n4. **Main Question:** `ErdosIvicQuestion` ($\\exists N, \\forall n \\ge N$, representable)\n5. **Heath-Brown:** `heath_brown_theorem` axiom resolving the question affirmatively\n6. **Asymptotics:** `numRepresentations` and `powerful_density` (axiom, $\\sim c\\sqrt{x}$)\n7. **Generalization:** `IsRPowerful r n` and `generalizedQuestion r k` connecting to Problems #940 and #1107",
+    "text": "Are all large integers the sum of at most three powerful numbers (p | n \u2192 p\u00b2 | n)? SOLVED: YES (Heath-Brown 1988). Every sufficiently large integer is the sum of at most 3 powerful numbers.",
+    "proofStrategy": "**Formalization Strategy**\n\n1. **Powerful Numbers:** `IsPowerful` ($p \\mid n \\Rightarrow p^2 \\mid n$) and `IsPowerfulAlt` ($n = a^2 b^3$), with `powerful_iff_alt` (sorry) connecting them\n2. **Structural Properties:** `one_is_powerful`, `square_is_powerful`, `cube_is_powerful`, `powerful_mul` (all proved) \u2014 establishing the multiplicative monoid structure\n3. **Sum Framework:** `IsSumOfKPowerful` (general $k$), `IsSumOf3Powerful` (exactly 3), `IsSumOf3PowerfulOrZero` (at most 3)\n4. **Main Question:** `ErdosIvicQuestion` ($\\exists N, \\forall n \\ge N$, representable)\n5. **Heath-Brown:** `heath_brown_theorem` axiom resolving the question affirmatively\n6. **Asymptotics:** `numRepresentations` and `powerful_density` (axiom, $\\sim c\\sqrt{x}$)\n7. **Generalization:** `IsRPowerful r n` and `generalizedQuestion r k` connecting to Problems #940 and #1107",
     "keyInsights": [
       "**Golomb's characterization**: A number $n$ is powerful if and only if $n = a^2 b^3$ for some $a, b \\ge 1$. The proof uses the division algorithm on prime exponents: $e_i = 2q_i + 3r_i$ with $r_i \\in \\{0, 1\\}$",
       "**Counting function**: The number of powerful numbers $\\le x$ is $\\sim \\frac{\\zeta(3/2)}{\\zeta(3)} \\sqrt{x} \\approx 2.173\\sqrt{x}$. This sublinear growth ($x^{1/2}$) means powerful numbers are sparse, yet 3 summands suffice to represent all large integers",
-      "**Phase transition at 2-to-3 summands**: Sums of $\\le 2$ powerful numbers have density 0 (Baker-Brüdern 1994), but sums of $\\le 3$ contain all large integers (Heath-Brown 1988). The transition is sharp and mirrors similar phenomena in Waring-type problems",
+      "**Phase transition at 2-to-3 summands**: Sums of $\\le 2$ powerful numbers have density 0 (Baker-Br\u00fcdern 1994), but sums of $\\le 3$ contain all large integers (Heath-Brown 1988). The transition is sharp and mirrors similar phenomena in Waring-type problems",
       "**Ternary quadratic form method**: Heath-Brown's proof writes $n = a^2 + b^2 c^3 + d^2 e^3$ and applies the Hasse principle for ternary forms. The ineffective Siegel bound means the threshold $N_0$ is not explicitly computable",
       "**r-Powerful generalization**: For $r$-powerful numbers ($p \\mid n \\Rightarrow p^r \\mid n$), the counting function is $\\sim c_r x^{1/r}$, and Problem #1107 asks for the minimal basis order. The diagonal case $k = r$ is exactly Problem #940"
     ],
@@ -81,7 +81,7 @@
   "sections": [
     {
       "id": "erd-s-problem-941-sums-of-thre",
-      "title": "Erdős Problem #941: Sums of Three Powerful Numbers",
+      "title": "Erd\u0151s Problem #941: Sums of Three Powerful Numbers",
       "startLine": 1,
       "endLine": 37,
       "summary": "Header comment documenting the problem source, statement ($p \\mid n \\Rightarrow p^2 \\mid n$), SOLVED status (Heath-Brown 1988), and connections to Problems #940 and #1107. Imports `Nat.Basic`, `Nat.Factorization.Basic`, `NumberTheory.Divisors`, and `Finset.Basic`.",
@@ -113,7 +113,7 @@
     },
     {
       "id": "the-erd-s-ivi-question",
-      "title": "The Erdős-Ivić Question",
+      "title": "The Erd\u0151s-Ivi\u0107 Question",
       "startLine": 126,
       "endLine": 142,
       "summary": "Defines `ErdosIvicQuestion`: $\\exists N, \\forall n \\ge N$, `IsSumOf3PowerfulOrZero n`. Also `ErdosIvicQuestion'` with explicit existentials. Both capture the 'all sufficiently large integers' quantifier.",
@@ -161,13 +161,13 @@
     }
   ],
   "conclusion": {
-    "summary": "The formalization captures Erdős Problem #941 on sums of three powerful numbers. Heath-Brown's 1988 theorem (axiomatized) resolves the Erdős-Ivić question affirmatively: every sufficiently large integer is the sum of at most 3 powerful numbers. The formalization includes two equivalent definitions of powerful numbers (IsPowerful and IsPowerfulAlt), structural properties (multiplicative monoid, proved for 1, sorry for squares/cubes/products), the sum representation framework, counting functions, and the r-powerful generalization connecting to Problems #940 and #1107. 0 sorries remain. All structural lemmas (square_is_powerful, cube_is_powerful, powerful_mul, powerful_iff_alt, one_is_powerful) are fully proved.",
-    "implications": "**Theoretical Significance**: **Connections to Number Theory**\n\n1. **Ternary Quadratic Forms**: Heath-Brown's proof reduces the representation problem to the theory of ternary quadratic forms, connecting additive number theory to algebraic geometry\n2. **Phase Transition**: The 2-to-3 summand transition (density 0 for 2, density 1 for 3) is a prototype for threshold phenomena in additive combinatorics\n**3. Problem #940**: The companion problem asks whether the diagonal case (r summands of r-powerful numbers) has density 0 for r ≥ 3 — still OPEN\n4. **Problem #1107**: The natural generalization asks for the minimal k such that all large integers are sums of ≤ k r-powerful numbers\n5. **Waring's Problem**: Since perfect r-th powers are r-powerful, Waring-type results are special cases of powerful number sum problems.",
+    "summary": "The formalization captures Erd\u0151s Problem #941 on sums of three powerful numbers. Heath-Brown's 1988 theorem (axiomatized) resolves the Erd\u0151s-Ivi\u0107 question affirmatively: every sufficiently large integer is the sum of at most 3 powerful numbers. The formalization includes two equivalent definitions of powerful numbers (IsPowerful and IsPowerfulAlt), structural properties (multiplicative monoid, proved for 1, sorry for squares/cubes/products), the sum representation framework, counting functions, and the r-powerful generalization connecting to Problems #940 and #1107. 0 sorries remain. All structural lemmas (square_is_powerful, cube_is_powerful, powerful_mul, powerful_iff_alt, one_is_powerful) are fully proved.",
+    "implications": "**Theoretical Significance**: **Connections to Number Theory**\n\n1. **Ternary Quadratic Forms**: Heath-Brown's proof reduces the representation problem to the theory of ternary quadratic forms, connecting additive number theory to algebraic geometry\n2. **Phase Transition**: The 2-to-3 summand transition (density 0 for 2, density 1 for 3) is a prototype for threshold phenomena in additive combinatorics\n**3. Problem #940**: The companion problem asks whether the diagonal case (r summands of r-powerful numbers) has density 0 for r \u2265 3 \u2014 still OPEN\n4. **Problem #1107**: The natural generalization asks for the minimal k such that all large integers are sums of \u2264 k r-powerful numbers\n5. **Waring's Problem**: Since perfect r-th powers are r-powerful, Waring-type results are special cases of powerful number sum problems.",
     "openQuestions": [
       "What is the smallest threshold $N_0$ such that all $n \\ge N_0$ are sums of $\\le 3$ powerful numbers? (ineffective in Heath-Brown's proof)",
       "How does the average number of representations $r_3(n)$ grow? Is it $\\Theta(n^{1/2})$ or faster?",
       "For $r$-powerful numbers with $r \\ge 3$, what is the minimal basis order $k(r)$ such that all large integers are sums of $\\le k(r)$ $r$-powerful numbers?",
-      "Does the Baker-Brüdern density-0 result for 2 squarefull summands extend to 2 cubefull summands (the $r = 3, k = 2$ case)?"
+      "Does the Baker-Br\u00fcdern density-0 result for 2 squarefull summands extend to 2 cubefull summands (the $r = 3, k = 2$ case)?"
     ]
   },
   "leanFile": {
@@ -178,7 +178,7 @@
       "Nat"
     ],
     "namespace": "Erdos941",
-    "lineCount": 323,
+    "lineCount": 324,
     "axiomCount": 4,
     "theoremCount": 11,
     "definitionCount": 13,
@@ -189,17 +189,17 @@
     {
       "targetId": "erdos-937",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: number-theory, powerful-numbers, solved"
+      "description": "Related Erd\u0151s problem sharing themes: number-theory, powerful-numbers, solved"
     },
     {
       "targetId": "erdos-942",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: number-theory, powerful-numbers, squarefull"
+      "description": "Related Erd\u0151s problem sharing themes: number-theory, powerful-numbers, squarefull"
     },
     {
       "targetId": "erdos-943",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: additive-representation, number-theory, powerful-numbers"
+      "description": "Related Erd\u0151s problem sharing themes: additive-representation, number-theory, powerful-numbers"
     }
   ],
   "sorries": 0

--- a/src/data/proofs/navier-stokes-existence/meta.json
+++ b/src/data/proofs/navier-stokes-existence/meta.json
@@ -166,7 +166,7 @@
       "summary": "Parts XX-XXI: Energy conservation above 1/3 Holder, anomalous dissipation (zeroth law of turbulence).",
       "startLine": 3696,
       "endLine": 4177,
-      "mathContext": "Onsager: $u \\in C^{0,\\alpha}$ with $\\alpha > 1/3$ $\\Rightarrow$ energy conserved. $\\alpha < 1/3$: non-uniqueness via convex integration (Buckmaster-De Lellis-Székelyhidi-Vicol)."
+      "mathContext": "Onsager: $u \\in C^{0,\\alpha}$ with $\\alpha > 1/3$ $\\Rightarrow$ energy conserved. $\\alpha < 1/3$: non-uniqueness via convex integration (Buckmaster-De Lellis-Sz\u00e9kelyhidi-Vicol)."
     },
     {
       "id": "regularity-scaling",
@@ -219,7 +219,7 @@
   ],
   "conclusion": {
     "summary": "This is the largest proof formalization in the gallery: 20,000+ lines, 1200+ definitions/theorems, 0 sorries, across 110 parts. It provides a complete 2D Navier-Stokes proof and conditional 3D regularity (via NSAxioms structure with 5 assumptions), plus comprehensive coverage of modern NS theory including global attractors, determining modes, and exact turbulence results (Kolmogorov 4/5 law).",
-    "implications": "**Theoretical Significance**: **Mathematical Significance**\n\n1. **2D Completeness**: The 2D global existence proof is fully verified without any axioms, formalizing Ladyzhenskaya's classical result.\n**2. 3D Architecture**: The conditional 3D result demonstrates how the Millennium Problem reduces to excluding two types of singularity (via NSAxioms structure with 5 assumptions).\n3. **Theory Coverage**: 110 parts serve as a comprehensive formal reference for modern NS theory: Leray-Hopf, Serrin, CKN, BKM, Fujita-Kato, Koch-Tataru, Onsager, convex integration, global attractors, determining modes, Kolmogorov exact laws, stochastic NS, MHD, and more.\n4. **Finite-Dimensional Dynamics**: Part CIX formalizes that NS dynamics is eventually determined by finitely many modes (dim(A) ≤ cG^{2/3}), connecting infinite-dimensional PDE theory to finite-dimensional dynamical systems.",
+    "implications": "**Theoretical Significance**: **Mathematical Significance**\n\n1. **2D Completeness**: The 2D global existence proof is fully verified without any axioms, formalizing Ladyzhenskaya's classical result.\n**2. 3D Architecture**: The conditional 3D result demonstrates how the Millennium Problem reduces to excluding two types of singularity (via NSAxioms structure with 5 assumptions).\n3. **Theory Coverage**: 110 parts serve as a comprehensive formal reference for modern NS theory: Leray-Hopf, Serrin, CKN, BKM, Fujita-Kato, Koch-Tataru, Onsager, convex integration, global attractors, determining modes, Kolmogorov exact laws, stochastic NS, MHD, and more.\n4. **Finite-Dimensional Dynamics**: Part CIX formalizes that NS dynamics is eventually determined by finitely many modes (dim(A) \u2264 cG^{2/3}), connecting infinite-dimensional PDE theory to finite-dimensional dynamical systems.",
     "openQuestions": [
       "Can the NSAxioms hypotheses be proved from first principles to resolve the Millennium Problem?",
       "Can the CKN partial regularity be extended to show the singular set is empty?",
@@ -264,7 +264,7 @@
       "TwoDimensionalGlobal"
     ],
     "namespace": "NavierStokesRegularity",
-    "lineCount": 21110,
+    "lineCount": 21111,
     "axiomCount": 0,
     "theoremCount": 845,
     "definitionCount": 104,
@@ -276,8 +276,8 @@
       "authors": "Leray, Jean",
       "title": "Sur le mouvement d'un liquide visqueux emplissant l'espace",
       "year": "1934",
-      "venue": "Acta Mathematica 63, 193–248",
-      "note": "Proved existence of weak solutions (Leray solutions) to the Navier-Stokes equations — global existence in 3D with possible singularities"
+      "venue": "Acta Mathematica 63, 193\u2013248",
+      "note": "Proved existence of weak solutions (Leray solutions) to the Navier-Stokes equations \u2014 global existence in 3D with possible singularities"
     },
     {
       "authors": "Temam, Roger",
@@ -291,32 +291,32 @@
     {
       "targetId": "navier-stokes",
       "relationship": "complementary",
-      "description": "The main Navier-Stokes formalization defines the equations and basic properties, while this entry focuses specifically on the Millennium Prize existence and smoothness question — whether smooth solutions exist globally in 3D"
+      "description": "The main Navier-Stokes formalization defines the equations and basic properties, while this entry focuses specifically on the Millennium Prize existence and smoothness question \u2014 whether smooth solutions exist globally in 3D"
     },
     {
       "targetId": "yang-mills",
       "relationship": "thematic",
-      "description": "Both are Clay Millennium Prize problems concerning PDEs from physics: Navier-Stokes asks about fluid dynamics regularity, while Yang-Mills asks about existence of a mass gap in quantum gauge theory — both remain open"
+      "description": "Both are Clay Millennium Prize problems concerning PDEs from physics: Navier-Stokes asks about fluid dynamics regularity, while Yang-Mills asks about existence of a mass gap in quantum gauge theory \u2014 both remain open"
     },
     {
       "targetId": "poincare-conjecture",
       "relationship": "thematic",
-      "description": "Both are (former) Millennium Prize problems: Poincare was resolved by Perelman (2003) using Ricci flow (a PDE technique), while Navier-Stokes remains open — Ricci flow shares the nonlinear PDE regularity challenges of Navier-Stokes"
+      "description": "Both are (former) Millennium Prize problems: Poincare was resolved by Perelman (2003) using Ricci flow (a PDE technique), while Navier-Stokes remains open \u2014 Ricci flow shares the nonlinear PDE regularity challenges of Navier-Stokes"
     },
     {
       "targetId": "hilbert-19",
       "relationship": "related",
-      "description": "Hilbert's 19th (regularity of variational minimizers) was resolved by De Giorgi-Nash for elliptic PDEs. Navier-Stokes regularity is the analogous open question for parabolic-hyperbolic Navier-Stokes — the methods overlap but the Navier-Stokes nonlinearity poses additional obstacles"
+      "description": "Hilbert's 19th (regularity of variational minimizers) was resolved by De Giorgi-Nash for elliptic PDEs. Navier-Stokes regularity is the analogous open question for parabolic-hyperbolic Navier-Stokes \u2014 the methods overlap but the Navier-Stokes nonlinearity poses additional obstacles"
     },
     {
       "targetId": "hilbert-20",
       "relationship": "related",
-      "description": "Hilbert's 20th (boundary value problem existence) was resolved via Lax-Milgram for elliptic PDEs. Navier-Stokes existence is the analogous question for incompressible fluid equations — Leray's weak solutions exist but global regularity is unknown"
+      "description": "Hilbert's 20th (boundary value problem existence) was resolved via Lax-Milgram for elliptic PDEs. Navier-Stokes existence is the analogous question for incompressible fluid equations \u2014 Leray's weak solutions exist but global regularity is unknown"
     },
     {
       "targetId": "birch-swinnerton-dyer",
       "relationship": "thematic",
-      "description": "Both are unsolved Clay Millennium Prize problems: BSD concerns L-functions of elliptic curves, while Navier-Stokes concerns fluid dynamics — both represent frontier challenges in their respective fields"
+      "description": "Both are unsolved Clay Millennium Prize problems: BSD concerns L-functions of elliptic curves, while Navier-Stokes concerns fluid dynamics \u2014 both represent frontier challenges in their respective fields"
     }
   ],
   "mainTheorems": [

--- a/src/data/proofs/navier-stokes-oq-01/meta.json
+++ b/src/data/proofs/navier-stokes-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "navier-stokes-oq-01",
   "title": "2D Navier-Stokes: Quantitative Enstrophy Decay and Energy Identity",
   "slug": "navier-stokes-oq-01",
-  "description": "For 2D incompressible Navier-Stokes with Poincaré inequality, can we formalize quantitative enstrophy decay and the exact integrated energy identity? We prove: (1) E(t) ≤ E(s)·exp(-2νμ₁(t-s)) for all 0 ≤ s ≤ t (uniform decay), (2) ∫₀ᵀ -2νP(t) dt = E(T) - E(0) (FTC applied to the enstrophy ODE), and (3) ∫₀ᵀ 2νP dt ≤ E(0) (total dissipation bounded by initial enstrophy).",
+  "description": "For 2D incompressible Navier-Stokes with Poincar\u00e9 inequality, can we formalize quantitative enstrophy decay and the exact integrated energy identity? We prove: (1) E(t) \u2264 E(s)\u00b7exp(-2\u03bd\u03bc\u2081(t-s)) for all 0 \u2264 s \u2264 t (uniform decay), (2) \u222b\u2080\u1d40 -2\u03bdP(t) dt = E(T) - E(0) (FTC applied to the enstrophy ODE), and (3) \u222b\u2080\u1d40 2\u03bdP dt \u2264 E(0) (total dissipation bounded by initial enstrophy).",
   "meta": {
     "author": "Ladyzhenskaya (1969)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Navier%E2%80%93Stokes_equations",
@@ -26,38 +26,38 @@
     "mathlibDependencies": [
       {
         "theorem": "intervalIntegral.integral_eq_sub_of_hasDerivAt_of_le",
-        "description": "Fundamental Theorem of Calculus (part 2): if F is continuous on [a,b] and has derivative f on (a,b), then ∫ₐᵇ f = F(b) - F(a)",
+        "description": "Fundamental Theorem of Calculus (part 2): if F is continuous on [a,b] and has derivative f on (a,b), then \u222b\u2090\u1d47 f = F(b) - F(a)",
         "module": "Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic"
       },
       {
         "theorem": "Real.exp_add",
-        "description": "Exponential function addition law: exp(a+b) = exp(a)·exp(b), used in chaining decay bounds",
+        "description": "Exponential function addition law: exp(a+b) = exp(a)\u00b7exp(b), used in chaining decay bounds",
         "module": "Mathlib.Analysis.SpecialFunctions.Exp"
       },
       {
         "theorem": "AntitoneOn.antitone",
-        "description": "Antitone functions preserve order, used to bound the integrating factor g(t) = E(t)·exp(ct)",
+        "description": "Antitone functions preserve order, used to bound the integrating factor g(t) = E(t)\u00b7exp(ct)",
         "module": "Mathlib.Order.Monotone.Basic"
       },
       {
         "theorem": "antitoneOn_of_deriv_nonpos",
-        "description": "A differentiable function with nonpositive derivative is antitone, used for g'(t) ≤ 0",
+        "description": "A differentiable function with nonpositive derivative is antitone, used for g'(t) \u2264 0",
         "module": "Mathlib.Analysis.Calculus.Monotone"
       },
       {
-        "theorem": "div_le_of_le_mul₀",
-        "description": "Division bound: 0 ≤ a → 0 ≤ b → c ≤ b·a → c/a ≤ b, used in enstrophy ratio bound",
+        "theorem": "div_le_of_le_mul\u2080",
+        "description": "Division bound: 0 \u2264 a \u2192 0 \u2264 b \u2192 c \u2264 b\u00b7a \u2192 c/a \u2264 b, used in enstrophy ratio bound",
         "module": "Mathlib.Algebra.Order.Field.Basic"
       }
     ],
     "originalContributions": [
-      "Theorem enstrophy_uniform_decay: E(t) ≤ E(s)·exp(-2νμ₁(t-s)) for any 0 ≤ s ≤ t, via integrating factor g(t) = E(t)·exp(2νμ₁t) shown antitone",
-      "Theorem enstrophy_ratio_bound: E(t)/E(s) ≤ exp(-2νμ₁(t-s)) when E(s) > 0, quantifying the fractional decay",
-      "Theorem enstrophy_monotone_comparison: chained decay E(t) ≤ E(r)·exp(-2νμ₁(t-r)) for r ≤ s ≤ t, via exp addition law",
+      "Theorem enstrophy_uniform_decay: E(t) \u2264 E(s)\u00b7exp(-2\u03bd\u03bc\u2081(t-s)) for any 0 \u2264 s \u2264 t, via integrating factor g(t) = E(t)\u00b7exp(2\u03bd\u03bc\u2081t) shown antitone",
+      "Theorem enstrophy_ratio_bound: E(t)/E(s) \u2264 exp(-2\u03bd\u03bc\u2081(t-s)) when E(s) > 0, quantifying the fractional decay",
+      "Theorem enstrophy_monotone_comparison: chained decay E(t) \u2264 E(r)\u00b7exp(-2\u03bd\u03bc\u2081(t-r)) for r \u2264 s \u2264 t, via exp addition law",
       "Structure GlobalNSSolution2DRegular: extends GlobalNSSolution2D with ContinuousOn palinstrophy P, enabling FTC application",
-      "Theorem enstrophy_integral_identity: ∫₀ᵀ -2νP(t) dt = E(T) - E(0), FTC applied to the enstrophy ODE E' = -2νP",
-      "Theorem enstrophy_dissipation_formula: E(0) - E(T) = ∫₀ᵀ 2νP(t) dt, the exact dissipation accounting",
-      "Theorem total_dissipation_bound: ∫₀ᵀ 2νP(t) dt ≤ E(0), total dissipation bounded by initial enstrophy"
+      "Theorem enstrophy_integral_identity: \u222b\u2080\u1d40 -2\u03bdP(t) dt = E(T) - E(0), FTC applied to the enstrophy ODE E' = -2\u03bdP",
+      "Theorem enstrophy_dissipation_formula: E(0) - E(T) = \u222b\u2080\u1d40 2\u03bdP(t) dt, the exact dissipation accounting",
+      "Theorem total_dissipation_bound: \u222b\u2080\u1d40 2\u03bdP(t) dt \u2264 E(0), total dissipation bounded by initial enstrophy"
     ],
     "dateAdded": "2026-02-26",
     "lineCount": 21110,
@@ -71,21 +71,21 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "The two-dimensional Navier-Stokes equations have been known to have global smooth solutions since Ladyzhenskaya's work in 1969. The key is that vortex stretching — the primary mechanism that might cause blowup in 3D — is absent in 2D. In 2D, the vorticity ω satisfies a transport-diffusion equation without the dangerous (ω·∇)u stretching term.\n\nThe enstrophy E(t) = ∫|ω(x,t)|² dx is the squared L² norm of vorticity. In 2D, enstrophy satisfies the ODE dE/dt = -2νP where P = ∫|∇ω|² is the palinstrophy. Under a Poincaré inequality P ≥ μ₁E (where μ₁ is the first eigenvalue of -Δ on the domain), this becomes dE/dt ≤ -2νμ₁E, giving exponential decay.\n\nThis formalization extends the existing NavierStokes.lean (which already proved the asymptotic bound E(t) ≤ E(0)·exp(-2νμ₁t)) with new quantitative results: decay between arbitrary times, exact FTC integration of the enstrophy ODE, and total dissipation bounds.",
-    "problemStatement": "**Open Question (navier-stokes-oq-01)**: For 2D incompressible Navier-Stokes with Poincaré inequality, can we formalize:\n\n(a) **Quantitative inter-time decay**: E(t) ≤ E(s)·exp(-2νμ₁(t-s)) for any 0 ≤ s ≤ t, not just t compared to 0?\n\n(b) **Exact integrated identity**: The enstrophy ODE E' = -2νP can be integrated exactly: ∫₀ᵀ -2νP(t) dt = E(T) - E(0)?\n\n(c) **Total dissipation bound**: The cumulative dissipation ∫₀ᵀ 2νP dt is bounded by E(0)?\n\n**Answer: YES** — all three can be formalized in Lean 4 with 0 axioms and 0 sorries, using the integrating factor method and the Fundamental Theorem of Calculus.",
+    "historicalContext": "The two-dimensional Navier-Stokes equations have been known to have global smooth solutions since Ladyzhenskaya's work in 1969. The key is that vortex stretching \u2014 the primary mechanism that might cause blowup in 3D \u2014 is absent in 2D. In 2D, the vorticity \u03c9 satisfies a transport-diffusion equation without the dangerous (\u03c9\u00b7\u2207)u stretching term.\n\nThe enstrophy E(t) = \u222b|\u03c9(x,t)|\u00b2 dx is the squared L\u00b2 norm of vorticity. In 2D, enstrophy satisfies the ODE dE/dt = -2\u03bdP where P = \u222b|\u2207\u03c9|\u00b2 is the palinstrophy. Under a Poincar\u00e9 inequality P \u2265 \u03bc\u2081E (where \u03bc\u2081 is the first eigenvalue of -\u0394 on the domain), this becomes dE/dt \u2264 -2\u03bd\u03bc\u2081E, giving exponential decay.\n\nThis formalization extends the existing NavierStokes.lean (which already proved the asymptotic bound E(t) \u2264 E(0)\u00b7exp(-2\u03bd\u03bc\u2081t)) with new quantitative results: decay between arbitrary times, exact FTC integration of the enstrophy ODE, and total dissipation bounds.",
+    "problemStatement": "**Open Question (navier-stokes-oq-01)**: For 2D incompressible Navier-Stokes with Poincar\u00e9 inequality, can we formalize:\n\n(a) **Quantitative inter-time decay**: E(t) \u2264 E(s)\u00b7exp(-2\u03bd\u03bc\u2081(t-s)) for any 0 \u2264 s \u2264 t, not just t compared to 0?\n\n(b) **Exact integrated identity**: The enstrophy ODE E' = -2\u03bdP can be integrated exactly: \u222b\u2080\u1d40 -2\u03bdP(t) dt = E(T) - E(0)?\n\n(c) **Total dissipation bound**: The cumulative dissipation \u222b\u2080\u1d40 2\u03bdP dt is bounded by E(0)?\n\n**Answer: YES** \u2014 all three can be formalized in Lean 4 with 0 axioms and 0 sorries, using the integrating factor method and the Fundamental Theorem of Calculus.",
     "text": "A 21,110-line formalization extending the base Navier-Stokes entry with quantitative enstrophy decay and exact energy identities for 2D incompressible flow. Uses three nested structures: `GlobalNSSolution2D` (enstrophy ODE $E' = -2\\nu P$), `GlobalNSSolution2DPoincare` (adds $P \\geq \\mu_1 E$), and `GlobalNSSolution2DRegular` (adds $\\text{ContinuousOn}\\, P$). Proves: (1) $E(t) \\leq E(s) e^{-2\\nu\\mu_1(t-s)}$ for all $0 \\leq s \\leq t$ via the integrating factor $g(t) = E(t) e^{2\\nu\\mu_1 t}$ shown to be antitone; (2) $\\int_0^T (-2\\nu P) = E(T) - E(0)$ via the FTC lemma `integral_eq_sub_of_hasDerivAt_of_le` with careful handling of the open-interval derivative condition; (3) $\\int_0^T 2\\nu P \\leq E(0)$ (total dissipation bounded by initial enstrophy, since $E(T) \\geq 0$). Zero axioms, zero sorries.",
-    "proofStrategy": "**Key structures**:\n- `GlobalNSSolution2D`: has fields E (enstrophy), P (palinstrophy), ν (viscosity), enstrophy_ode (E' = -2νP)\n- `GlobalNSSolution2DPoincare`: extends with Poincaré constant μ₁ and P ≥ μ₁E  \n- `GlobalNSSolution2DRegular`: extends with ContinuousOn P, enabling FTC\n\n**Strategy for enstrophy_uniform_decay**:\n1. Define integrating factor g(t) = E(t)·exp(2νμ₁t)\n2. Show g'(t) = E'(t)·exp(...) + E(t)·2νμ₁·exp(...) = (-2νP + 2νμ₁E)·exp(...) ≤ 0\n3. g antitone: g(t) ≤ g(s)\n4. Multiply by exp(-2νμ₁t): E(t) ≤ E(s)·exp(-2νμ₁(t-s))\n\n**Strategy for enstrophy_integral_identity**:\n1. Apply `intervalIntegral.integral_eq_sub_of_hasDerivAt_of_le` (FTC with ContinuousOn + HasDerivAt on open interval)\n2. ContinuousOn E on Icc 0 T from E_cont\n3. HasDerivAt E (-2νP t) on Ioo 0 T from enstrophy_ode (requires t > 0)\n4. IntervalIntegrable from continuousOn_const.mul P_cont\n\n**Strategy for total_dissipation_bound**:\n1. From enstrophy_dissipation_formula: E(0) - E(T) = ∫ 2νP\n2. E(T) ≥ 0 (from E_nonneg)\n3. Conclude ∫ 2νP ≤ E(0) by linarith",
+    "proofStrategy": "**Key structures**:\n- `GlobalNSSolution2D`: has fields E (enstrophy), P (palinstrophy), \u03bd (viscosity), enstrophy_ode (E' = -2\u03bdP)\n- `GlobalNSSolution2DPoincare`: extends with Poincar\u00e9 constant \u03bc\u2081 and P \u2265 \u03bc\u2081E  \n- `GlobalNSSolution2DRegular`: extends with ContinuousOn P, enabling FTC\n\n**Strategy for enstrophy_uniform_decay**:\n1. Define integrating factor g(t) = E(t)\u00b7exp(2\u03bd\u03bc\u2081t)\n2. Show g'(t) = E'(t)\u00b7exp(...) + E(t)\u00b72\u03bd\u03bc\u2081\u00b7exp(...) = (-2\u03bdP + 2\u03bd\u03bc\u2081E)\u00b7exp(...) \u2264 0\n3. g antitone: g(t) \u2264 g(s)\n4. Multiply by exp(-2\u03bd\u03bc\u2081t): E(t) \u2264 E(s)\u00b7exp(-2\u03bd\u03bc\u2081(t-s))\n\n**Strategy for enstrophy_integral_identity**:\n1. Apply `intervalIntegral.integral_eq_sub_of_hasDerivAt_of_le` (FTC with ContinuousOn + HasDerivAt on open interval)\n2. ContinuousOn E on Icc 0 T from E_cont\n3. HasDerivAt E (-2\u03bdP t) on Ioo 0 T from enstrophy_ode (requires t > 0)\n4. IntervalIntegrable from continuousOn_const.mul P_cont\n\n**Strategy for total_dissipation_bound**:\n1. From enstrophy_dissipation_formula: E(0) - E(T) = \u222b 2\u03bdP\n2. E(T) \u2265 0 (from E_nonneg)\n3. Conclude \u222b 2\u03bdP \u2264 E(0) by linarith",
     "keyInsights": [
-      "The integrating factor g(t) = E(t)·exp(2νμ₁t) is the key to proving decay between arbitrary times s ≤ t, not just from time 0",
-      "enstrophy_uniform_decay generalizes the existing enstrophy_exponential_decay_exact theorem by replacing the fixed start time 0 with an arbitrary s ≥ 0",
+      "The integrating factor g(t) = E(t)\u00b7exp(2\u03bd\u03bc\u2081t) is the key to proving decay between arbitrary times s \u2264 t, not just from time 0",
+      "enstrophy_uniform_decay generalizes the existing enstrophy_exponential_decay_exact theorem by replacing the fixed start time 0 with an arbitrary s \u2265 0",
       "FTC via `integral_eq_sub_of_hasDerivAt_of_le` requires HasDerivAt only on the open interval Ioo 0 T, avoiding the issue that enstrophy_ode needs t > 0",
       "GlobalNSSolution2DRegular adds ContinuousOn P as a minimal regularity requirement for FTC integration of the enstrophy ODE",
-      "The total dissipation bound ∫₀ᵀ 2νP ≤ E(0) is immediate from the energy identity and E(T) ≥ 0: all enstrophy dissipated over any finite time comes from the initial enstrophy"
+      "The total dissipation bound \u222b\u2080\u1d40 2\u03bdP \u2264 E(0) is immediate from the energy identity and E(T) \u2265 0: all enstrophy dissipated over any finite time comes from the initial enstrophy"
     ],
     "prerequisites": [
       "Real analysis (continuity, differentiability, integration)",
       "ODE theory (Gronwall-type inequalities, integrating factors)",
-      "Functional analysis (Poincaré inequality, Sobolev spaces)",
+      "Functional analysis (Poincar\u00e9 inequality, Sobolev spaces)",
       "Fluid dynamics (enstrophy, palinstrophy, vorticity)",
       "Familiarity with Lean 4 and Mathlib"
     ]
@@ -96,21 +96,21 @@
       "title": "Uniform Exponential Decay Between Times",
       "startLine": 2489,
       "endLine": 2561,
-      "summary": "enstrophy_uniform_decay: E(t) ≤ E(s)·exp(-2νμ₁(t-s)) for 0 ≤ s ≤ t. Generalizes the s=0 case. Key technique: integrating factor g(t) = E(t)·exp(ct) is antitone via g'(t) ≤ 0."
+      "summary": "enstrophy_uniform_decay: E(t) \u2264 E(s)\u00b7exp(-2\u03bd\u03bc\u2081(t-s)) for 0 \u2264 s \u2264 t. Generalizes the s=0 case. Key technique: integrating factor g(t) = E(t)\u00b7exp(ct) is antitone via g'(t) \u2264 0."
     },
     {
       "id": "ratio-bound",
       "title": "Enstrophy Ratio Bound",
       "startLine": 2562,
       "endLine": 2578,
-      "summary": "enstrophy_ratio_bound: E(t)/E(s) ≤ exp(-2νμ₁(t-s)) when E(s) > 0. Derives from uniform decay using div_le_of_le_mul₀."
+      "summary": "enstrophy_ratio_bound: E(t)/E(s) \u2264 exp(-2\u03bd\u03bc\u2081(t-s)) when E(s) > 0. Derives from uniform decay using div_le_of_le_mul\u2080."
     },
     {
       "id": "chained-decay",
       "title": "Chained Exponential Decay",
       "startLine": 2579,
       "endLine": 2603,
-      "summary": "enstrophy_monotone_comparison: for r ≤ s ≤ t, E(t) ≤ E(r)·exp(-2νμ₁(t-r)). Uses exp_add to combine two steps of uniform decay."
+      "summary": "enstrophy_monotone_comparison: for r \u2264 s \u2264 t, E(t) \u2264 E(r)\u00b7exp(-2\u03bd\u03bc\u2081(t-r)). Uses exp_add to combine two steps of uniform decay."
     },
     {
       "id": "regular-structure",
@@ -124,24 +124,24 @@
       "title": "Integrated Enstrophy Identity via FTC",
       "startLine": 2615,
       "endLine": 2638,
-      "summary": "enstrophy_integral_identity: ∫₀ᵀ -2νP(t) dt = E(T) - E(0). Applies integral_eq_sub_of_hasDerivAt_of_le with ContinuousOn E on Icc and HasDerivAt on Ioo 0 T."
+      "summary": "enstrophy_integral_identity: \u222b\u2080\u1d40 -2\u03bdP(t) dt = E(T) - E(0). Applies integral_eq_sub_of_hasDerivAt_of_le with ContinuousOn E on Icc and HasDerivAt on Ioo 0 T."
     },
     {
       "id": "dissipation-formula",
       "title": "Enstrophy Dissipation Formula and Total Bound",
       "startLine": 2639,
       "endLine": 21110,
-      "summary": "enstrophy_dissipation_formula: E(0) - E(T) = ∫₀ᵀ 2νP dt (enstrophy decrease = integrated dissipation). total_dissipation_bound: ∫₀ᵀ 2νP ≤ E(0) (cumulative dissipation bounded by initial enstrophy)."
+      "summary": "enstrophy_dissipation_formula: E(0) - E(T) = \u222b\u2080\u1d40 2\u03bdP dt (enstrophy decrease = integrated dissipation). total_dissipation_bound: \u222b\u2080\u1d40 2\u03bdP \u2264 E(0) (cumulative dissipation bounded by initial enstrophy)."
     }
   ],
   "conclusion": {
-    "summary": "This formalization answers the open question affirmatively: all three quantitative results — inter-time decay, integrated energy identity, and total dissipation bound — can be formalized in Lean 4 with 0 axioms and 0 sorries. The key tools are the integrating factor method (for decay between arbitrary times) and the FTC via `intervalIntegral.integral_eq_sub_of_hasDerivAt_of_le` (for the integrated identity).",
-    "implications": "**Theoretical Significance**: **For 2D fluid mechanics**: The enstrophy_uniform_decay theorem provides a precise Lyapunov function argument: g(t) = E(t)·exp(2νμ₁t) is nonincreasing, certifying exponential stability of the zero state.\n\n**For Mathlib**: The correct FTC lemma for enstrophy integration is `integral_eq_sub_of_hasDerivAt_of_le` (not the simpler `integral_eq_sub_of_hasDerivAt`), because the enstrophy ODE holds for t > 0 but not necessarily at t = 0.\n\nThis version requires ContinuousOn on the closed interval [0,T] and HasDerivAt only on the open interval (0,T).\n\n**For Navier-Stokes research**: These results form part of the infrastructure for more advanced 2D results, such as proving the Ladyzhenskaya inequality in Lean 4 and connecting 2D global regularity to Fourier space energy cascades.\n\n**For the 3D problem**: The 2D results demonstrate that the enstrophy framework works cleanly in Lean 4. The 3D case differs because vortex stretching prevents the Poincaré bound P ≥ μ₁E from giving exponential decay.",
+    "summary": "This formalization answers the open question affirmatively: all three quantitative results \u2014 inter-time decay, integrated energy identity, and total dissipation bound \u2014 can be formalized in Lean 4 with 0 axioms and 0 sorries. The key tools are the integrating factor method (for decay between arbitrary times) and the FTC via `intervalIntegral.integral_eq_sub_of_hasDerivAt_of_le` (for the integrated identity).",
+    "implications": "**Theoretical Significance**: **For 2D fluid mechanics**: The enstrophy_uniform_decay theorem provides a precise Lyapunov function argument: g(t) = E(t)\u00b7exp(2\u03bd\u03bc\u2081t) is nonincreasing, certifying exponential stability of the zero state.\n\n**For Mathlib**: The correct FTC lemma for enstrophy integration is `integral_eq_sub_of_hasDerivAt_of_le` (not the simpler `integral_eq_sub_of_hasDerivAt`), because the enstrophy ODE holds for t > 0 but not necessarily at t = 0.\n\nThis version requires ContinuousOn on the closed interval [0,T] and HasDerivAt only on the open interval (0,T).\n\n**For Navier-Stokes research**: These results form part of the infrastructure for more advanced 2D results, such as proving the Ladyzhenskaya inequality in Lean 4 and connecting 2D global regularity to Fourier space energy cascades.\n\n**For the 3D problem**: The 2D results demonstrate that the enstrophy framework works cleanly in Lean 4. The 3D case differs because vortex stretching prevents the Poincar\u00e9 bound P \u2265 \u03bc\u2081E from giving exponential decay.",
     "openQuestions": [
-      "Can the Ladyzhenskaya inequality ‖u‖₄ ≤ C‖u‖₂^{1/2}‖∇u‖₂^{1/2} be formalized in Lean 4 using Mathlib's Sobolev space infrastructure?",
+      "Can the Ladyzhenskaya inequality \u2016u\u2016\u2084 \u2264 C\u2016u\u2016\u2082^{1/2}\u2016\u2207u\u2016\u2082^{1/2} be formalized in Lean 4 using Mathlib's Sobolev space infrastructure?",
       "Can the 2D Navier-Stokes existence theorem be stated and proved axiom-free? (Requires weak solutions, Galerkin approximation, compactness arguments)",
-      "Can the optimal Poincaré constant μ₁ be characterized as the smallest eigenvalue of -Δ on the domain? (Requires spectral theory for bounded domains)",
-      "What is the rate of enstrophy decay for turbulent 2D flows without Poincaré inequality? (E(t) → 0 but perhaps not exponentially)"
+      "Can the optimal Poincar\u00e9 constant \u03bc\u2081 be characterized as the smallest eigenvalue of -\u0394 on the domain? (Requires spectral theory for bounded domains)",
+      "What is the rate of enstrophy decay for turbulent 2D flows without Poincar\u00e9 inequality? (E(t) \u2192 0 but perhaps not exponentially)"
     ]
   },
   "leanFile": {
@@ -181,7 +181,7 @@
       "TwoDimensionalGlobal"
     ],
     "namespace": "NavierStokesRegularity",
-    "lineCount": 21110,
+    "lineCount": 21111,
     "axiomCount": 0,
     "theoremCount": 845,
     "definitionCount": 104,
@@ -202,12 +202,12 @@
     {
       "targetId": "fundamental-theorem-calculus",
       "relationship": "foundational",
-      "description": "The enstrophy integral identity directly applies the FTC (integral_eq_sub_of_hasDerivAt_of_le) to convert the pointwise ODE E'(t) = -2νP(t) into the global identity ∫₀ᵀ -2νP = E(T) - E(0)"
+      "description": "The enstrophy integral identity directly applies the FTC (integral_eq_sub_of_hasDerivAt_of_le) to convert the pointwise ODE E'(t) = -2\u03bdP(t) into the global identity \u222b\u2080\u1d40 -2\u03bdP = E(T) - E(0)"
     },
     {
       "targetId": "navier-stokes-existence",
       "relationship": "related",
-      "description": "Existence theory for Navier-Stokes solutions — the solutions whose enstrophy decay properties are formalized here"
+      "description": "Existence theory for Navier-Stokes solutions \u2014 the solutions whose enstrophy decay properties are formalized here"
     },
     {
       "targetId": "cauchy-schwarz-integral",

--- a/src/data/proofs/navier-stokes-oq-02/meta.json
+++ b/src/data/proofs/navier-stokes-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "navier-stokes-oq-02",
   "title": "2D Navier-Stokes: Gronwall Stability, Uniqueness, and Well-Posedness",
   "slug": "navier-stokes-oq-02",
-  "description": "For 2D incompressible Navier-Stokes, can we formalize L² stability, uniqueness, and continuous dependence on initial data using the Gronwall inequality? We prove: (1) W(t) ≤ W(0)·exp(C·E(0)·t) (Gronwall stability bound), (2) W(0) = 0 implies W(t) = 0 (uniqueness), (3) for any ε > 0, there exists δ > 0 such that W(0) ≤ δ implies W(t) ≤ ε on [0,T] (continuous dependence). Together these establish Hadamard well-posedness for 2D Navier-Stokes.",
+  "description": "For 2D incompressible Navier-Stokes, can we formalize L\u00b2 stability, uniqueness, and continuous dependence on initial data using the Gronwall inequality? We prove: (1) W(t) \u2264 W(0)\u00b7exp(C\u00b7E(0)\u00b7t) (Gronwall stability bound), (2) W(0) = 0 implies W(t) = 0 (uniqueness), (3) for any \u03b5 > 0, there exists \u03b4 > 0 such that W(0) \u2264 \u03b4 implies W(t) \u2264 \u03b5 on [0,T] (continuous dependence). Together these establish Hadamard well-posedness for 2D Navier-Stokes.",
   "meta": {
     "author": "Ladyzhenskaya (1969)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Navier%E2%80%93Stokes_equations",
@@ -32,12 +32,12 @@
       },
       {
         "theorem": "HasDerivAt.const_mul",
-        "description": "Derivative of constant times a function: d/dx(c·f(x)) = c·f'(x)",
+        "description": "Derivative of constant times a function: d/dx(c\u00b7f(x)) = c\u00b7f'(x)",
         "module": "Mathlib.Analysis.Calculus.Deriv.Mul"
       },
       {
         "theorem": "Real.exp_add",
-        "description": "Exponential function addition law: exp(a+b) = exp(a)·exp(b), used for cancelling integrating factors",
+        "description": "Exponential function addition law: exp(a+b) = exp(a)\u00b7exp(b), used for cancelling integrating factors",
         "module": "Mathlib.Analysis.SpecialFunctions.Exp"
       },
       {
@@ -47,16 +47,16 @@
       },
       {
         "theorem": "Real.exp_le_exp",
-        "description": "Monotonicity of the exponential function: a ≤ b implies exp(a) ≤ exp(b)",
+        "description": "Monotonicity of the exponential function: a \u2264 b implies exp(a) \u2264 exp(b)",
         "module": "Mathlib.Analysis.SpecialFunctions.Exp"
       }
     ],
     "originalContributions": [
-      "Structure NSSolutionPair2D: abstract framework for comparing two 2D NS solutions via difference energy W(t) with Ladyzhenskaya stability estimate W'(t) ≤ C·E(t)·W(t)",
-      "Theorem gronwall_stability_2d: W(t) ≤ W(0)·exp(C·E(0)·t) via integrating factor g(t) = W(t)·exp(-Kt) shown antitone",
+      "Structure NSSolutionPair2D: abstract framework for comparing two 2D NS solutions via difference energy W(t) with Ladyzhenskaya stability estimate W'(t) \u2264 C\u00b7E(t)\u00b7W(t)",
+      "Theorem gronwall_stability_2d: W(t) \u2264 W(0)\u00b7exp(C\u00b7E(0)\u00b7t) via integrating factor g(t) = W(t)\u00b7exp(-Kt) shown antitone",
       "Theorem uniqueness_2d: W(0) = 0 implies W(t) = 0 for all t > 0, the classical 2D NS uniqueness result",
-      "Theorem stability_amplification_2d: W(t) ≤ W(0)·exp(C·E(0)·T) uniform bound on [0,T], finite because 2D enstrophy is bounded",
-      "Theorem continuous_dependence_2d: for any ε > 0, threshold δ = ε·exp(-C·E(0)·T) gives W(0) ≤ δ implies W(t) ≤ ε, establishing Hadamard well-posedness"
+      "Theorem stability_amplification_2d: W(t) \u2264 W(0)\u00b7exp(C\u00b7E(0)\u00b7T) uniform bound on [0,T], finite because 2D enstrophy is bounded",
+      "Theorem continuous_dependence_2d: for any \u03b5 > 0, threshold \u03b4 = \u03b5\u00b7exp(-C\u00b7E(0)\u00b7T) gives W(0) \u2264 \u03b4 implies W(t) \u2264 \u03b5, establishing Hadamard well-posedness"
     ],
     "dateAdded": "2026-02-28",
     "lineCount": 21110,
@@ -64,16 +64,16 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "The theory of well-posedness for 2D Navier-Stokes equations has a rich history beginning with Jean Leray's pioneering 1934 paper, which established the existence of weak solutions in both 2D and 3D. For 2D, Leray showed that solutions remain regular for all time — a result that fails (or at least remains unproven) in 3D.\n\nThe concept of well-posedness itself was formalized by Jacques Hadamard in his 1902 lectures: a problem is well-posed if it has (1) existence, (2) uniqueness, and (3) continuous dependence on data. Hadamard argued that physically meaningful problems should satisfy all three criteria.\n\nOlga Ladyzhenskaya's landmark 1969 monograph 'The Mathematical Theory of Viscous Incompressible Flow' provided the definitive treatment of 2D well-posedness. Her key contribution was the Ladyzhenskaya inequality in 2D: $\\|u\\|_{L^4(\\mathbb{R}^2)} \\leq C \\|u\\|_{L^2}^{1/2} \\|\\nabla u\\|_{L^2}^{1/2}$, which gives the stability estimate $W'(t) \\leq C \\cdot E(t) \\cdot W(t)$ for the difference energy $W(t) = \\|u_1 - u_2\\|_{L^2}^2$. The critical feature of 2D: enstrophy $E(t) = \\|\\nabla u\\|_{L^2}^2$ is bounded by its initial value $E(0)$, making the Gronwall growth rate $K = C \\cdot E(0)$ finite.\n\nThomas Gronwall's 1919 inequality — if $u'(t) \\leq \\beta(t) u(t)$ then $u(t) \\leq u(0) \\exp(\\int_0^t \\beta)$ — is the analytic engine of the proof. Combined with bounded enstrophy, it yields exponential stability $W(t) \\leq W(0) e^{CE(0)t}$ and hence uniqueness.\n\nIn 3D, enstrophy could potentially blow up ($E(t) \\to \\infty$), making $K(t) = C \\cdot E(t)$ unbounded and the Gronwall argument ineffective. This is precisely the obstruction at the heart of the Clay Millennium Prize Problem: proving or disproving 3D global regularity. The 2D well-posedness result formalized here serves as a template showing exactly where the 3D argument breaks down.\n\nThis formalization in Lean 4 is novel: the `NSSolutionPair2D` structure encodes the Ladyzhenskaya stability estimate as a structural hypothesis, abstracting away the PDE-specific Sobolev space analysis (not yet available in Mathlib) and focusing on the Gronwall argument itself.",
-    "problemStatement": "**Open Question (navier-stokes-oq-02)**: For 2D incompressible Navier-Stokes, can we formalize:\n\n(a) **Gronwall stability**: If W'(t) ≤ C·E(t)·W(t) and E(t) ≤ E(0), then W(t) ≤ W(0)·exp(C·E(0)·t)?\n\n(b) **Uniqueness**: W(0) = 0 implies W(t) = 0 for all t?\n\n(c) **Continuous dependence**: For any ε > 0, exists δ > 0 such that W(0) ≤ δ implies W(t) ≤ ε on [0,T]?\n\n**Answer: YES** — all three are formalized with 0 axioms and 0 sorries, using the integrating factor method and the bounded enstrophy from global_enstrophy_bound.",
-    "text": "A five-theorem development of 2D Navier-Stokes well-posedness via the Gronwall inequality, with 0 axioms and 0 sorries. The `NSSolutionPair2D` structure abstracts two solutions' comparison via difference energy $W(t) = \\|u_1 - u_2\\|^2$ and the Ladyzhenskaya stability estimate $W'(t) \\leq C \\cdot E(t) \\cdot W(t)$. The central result `gronwall_stability_2d` proves $W(t) \\leq W(0) \\cdot e^{CE(0)t}$ using the integrating factor $g(t) = W(t) \\cdot e^{-Kt}$ shown antitone via `antitoneOn_of_deriv_nonpos`. Three corollaries follow: `uniqueness_2d` (from $W(0) = 0 \\Rightarrow W(t) = 0$ via `le_antisymm`), `stability_amplification_2d` (uniform bound on $[0,T]$ via `Real.exp_le_exp`), and `continuous_dependence_2d` (explicit threshold $\\delta = \\varepsilon \\cdot e^{-CE(0)T}$). Together these establish all three pillars of Hadamard well-posedness for 2D NS. The proof reveals exactly where the 3D argument fails: the bounded enstrophy $E(t) \\leq E(0)$ that makes $K = CE(0)$ finite is a specifically 2D phenomenon — in 3D, enstrophy could blow up, rendering the Gronwall bound meaningless.",
-    "proofStrategy": "**Key structure**: NSSolutionPair2D encodes two solutions via their difference energy W(t) and the stability estimate W'(t) ≤ C·E(t)·W(t).\n\n**Gronwall stability proof**:\n1. Set K = C·E(0) (uniform upper bound on growth rate, since E(t) ≤ E(0) in 2D)\n2. Define integrating factor g(t) = W(t)·exp(-K·t)\n3. Show g'(t) = (W'(t) - K·W(t))·exp(-Kt) ≤ 0 (since W' ≤ C·E(t)·W ≤ K·W)\n4. g antitone: g(t) ≤ g(0) = W(0)\n5. Multiply by exp(Kt): W(t) ≤ W(0)·exp(Kt)\n\n**Uniqueness**: From Gronwall with W(0) = 0: W(t) ≤ 0·exp(Kt) = 0. Combined with W(t) ≥ 0.\n\n**Continuous dependence**: Set δ = ε·exp(-K·T). Then W(0) ≤ δ gives W(t) ≤ δ·exp(Kt) ≤ δ·exp(KT) = ε.",
+    "historicalContext": "The theory of well-posedness for 2D Navier-Stokes equations has a rich history beginning with Jean Leray's pioneering 1934 paper, which established the existence of weak solutions in both 2D and 3D. For 2D, Leray showed that solutions remain regular for all time \u2014 a result that fails (or at least remains unproven) in 3D.\n\nThe concept of well-posedness itself was formalized by Jacques Hadamard in his 1902 lectures: a problem is well-posed if it has (1) existence, (2) uniqueness, and (3) continuous dependence on data. Hadamard argued that physically meaningful problems should satisfy all three criteria.\n\nOlga Ladyzhenskaya's landmark 1969 monograph 'The Mathematical Theory of Viscous Incompressible Flow' provided the definitive treatment of 2D well-posedness. Her key contribution was the Ladyzhenskaya inequality in 2D: $\\|u\\|_{L^4(\\mathbb{R}^2)} \\leq C \\|u\\|_{L^2}^{1/2} \\|\\nabla u\\|_{L^2}^{1/2}$, which gives the stability estimate $W'(t) \\leq C \\cdot E(t) \\cdot W(t)$ for the difference energy $W(t) = \\|u_1 - u_2\\|_{L^2}^2$. The critical feature of 2D: enstrophy $E(t) = \\|\\nabla u\\|_{L^2}^2$ is bounded by its initial value $E(0)$, making the Gronwall growth rate $K = C \\cdot E(0)$ finite.\n\nThomas Gronwall's 1919 inequality \u2014 if $u'(t) \\leq \\beta(t) u(t)$ then $u(t) \\leq u(0) \\exp(\\int_0^t \\beta)$ \u2014 is the analytic engine of the proof. Combined with bounded enstrophy, it yields exponential stability $W(t) \\leq W(0) e^{CE(0)t}$ and hence uniqueness.\n\nIn 3D, enstrophy could potentially blow up ($E(t) \\to \\infty$), making $K(t) = C \\cdot E(t)$ unbounded and the Gronwall argument ineffective. This is precisely the obstruction at the heart of the Clay Millennium Prize Problem: proving or disproving 3D global regularity. The 2D well-posedness result formalized here serves as a template showing exactly where the 3D argument breaks down.\n\nThis formalization in Lean 4 is novel: the `NSSolutionPair2D` structure encodes the Ladyzhenskaya stability estimate as a structural hypothesis, abstracting away the PDE-specific Sobolev space analysis (not yet available in Mathlib) and focusing on the Gronwall argument itself.",
+    "problemStatement": "**Open Question (navier-stokes-oq-02)**: For 2D incompressible Navier-Stokes, can we formalize:\n\n(a) **Gronwall stability**: If W'(t) \u2264 C\u00b7E(t)\u00b7W(t) and E(t) \u2264 E(0), then W(t) \u2264 W(0)\u00b7exp(C\u00b7E(0)\u00b7t)?\n\n(b) **Uniqueness**: W(0) = 0 implies W(t) = 0 for all t?\n\n(c) **Continuous dependence**: For any \u03b5 > 0, exists \u03b4 > 0 such that W(0) \u2264 \u03b4 implies W(t) \u2264 \u03b5 on [0,T]?\n\n**Answer: YES** \u2014 all three are formalized with 0 axioms and 0 sorries, using the integrating factor method and the bounded enstrophy from global_enstrophy_bound.",
+    "text": "A five-theorem development of 2D Navier-Stokes well-posedness via the Gronwall inequality, with 0 axioms and 0 sorries. The `NSSolutionPair2D` structure abstracts two solutions' comparison via difference energy $W(t) = \\|u_1 - u_2\\|^2$ and the Ladyzhenskaya stability estimate $W'(t) \\leq C \\cdot E(t) \\cdot W(t)$. The central result `gronwall_stability_2d` proves $W(t) \\leq W(0) \\cdot e^{CE(0)t}$ using the integrating factor $g(t) = W(t) \\cdot e^{-Kt}$ shown antitone via `antitoneOn_of_deriv_nonpos`. Three corollaries follow: `uniqueness_2d` (from $W(0) = 0 \\Rightarrow W(t) = 0$ via `le_antisymm`), `stability_amplification_2d` (uniform bound on $[0,T]$ via `Real.exp_le_exp`), and `continuous_dependence_2d` (explicit threshold $\\delta = \\varepsilon \\cdot e^{-CE(0)T}$). Together these establish all three pillars of Hadamard well-posedness for 2D NS. The proof reveals exactly where the 3D argument fails: the bounded enstrophy $E(t) \\leq E(0)$ that makes $K = CE(0)$ finite is a specifically 2D phenomenon \u2014 in 3D, enstrophy could blow up, rendering the Gronwall bound meaningless.",
+    "proofStrategy": "**Key structure**: NSSolutionPair2D encodes two solutions via their difference energy W(t) and the stability estimate W'(t) \u2264 C\u00b7E(t)\u00b7W(t).\n\n**Gronwall stability proof**:\n1. Set K = C\u00b7E(0) (uniform upper bound on growth rate, since E(t) \u2264 E(0) in 2D)\n2. Define integrating factor g(t) = W(t)\u00b7exp(-K\u00b7t)\n3. Show g'(t) = (W'(t) - K\u00b7W(t))\u00b7exp(-Kt) \u2264 0 (since W' \u2264 C\u00b7E(t)\u00b7W \u2264 K\u00b7W)\n4. g antitone: g(t) \u2264 g(0) = W(0)\n5. Multiply by exp(Kt): W(t) \u2264 W(0)\u00b7exp(Kt)\n\n**Uniqueness**: From Gronwall with W(0) = 0: W(t) \u2264 0\u00b7exp(Kt) = 0. Combined with W(t) \u2265 0.\n\n**Continuous dependence**: Set \u03b4 = \u03b5\u00b7exp(-K\u00b7T). Then W(0) \u2264 \u03b4 gives W(t) \u2264 \u03b4\u00b7exp(Kt) \u2264 \u03b4\u00b7exp(KT) = \u03b5.",
     "keyInsights": [
-      "The bounded enstrophy E(t) ≤ E(0) in 2D is what makes the Gronwall argument work: the growth rate C·E(t) is uniformly bounded by K = C·E(0), giving finite-time stability",
-      "In 3D, enstrophy could blow up (the Millennium Problem!), so K = C·E(0) would NOT bound C·E(t) for all t, and the Gronwall argument breaks down — this is exactly why 3D uniqueness is open",
-      "The integrating factor g(t) = W(t)·exp(-Kt) is the same technique used for enstrophy decay (Part X-B), but with opposite sign: here we bound GROWTH (W increasing) rather than DECAY (E decreasing)",
-      "The NSSolutionPair2D structure abstracts away PDE details: the Ladyzhenskaya stability estimate W'(t) ≤ C·E(t)·W(t) is a hypothesis, not derived from Sobolev spaces, making the proof modular",
-      "Continuous dependence gives an explicit stability threshold δ = ε·exp(-C·E(0)·T) that decreases with time horizon T and initial enstrophy E(0)"
+      "The bounded enstrophy E(t) \u2264 E(0) in 2D is what makes the Gronwall argument work: the growth rate C\u00b7E(t) is uniformly bounded by K = C\u00b7E(0), giving finite-time stability",
+      "In 3D, enstrophy could blow up (the Millennium Problem!), so K = C\u00b7E(0) would NOT bound C\u00b7E(t) for all t, and the Gronwall argument breaks down \u2014 this is exactly why 3D uniqueness is open",
+      "The integrating factor g(t) = W(t)\u00b7exp(-Kt) is the same technique used for enstrophy decay (Part X-B), but with opposite sign: here we bound GROWTH (W increasing) rather than DECAY (E decreasing)",
+      "The NSSolutionPair2D structure abstracts away PDE details: the Ladyzhenskaya stability estimate W'(t) \u2264 C\u00b7E(t)\u00b7W(t) is a hypothesis, not derived from Sobolev spaces, making the proof modular",
+      "Continuous dependence gives an explicit stability threshold \u03b4 = \u03b5\u00b7exp(-C\u00b7E(0)\u00b7T) that decreases with time horizon T and initial enstrophy E(0)"
     ],
     "prerequisites": [
       "Gronwall inequality and integrating factor method",
@@ -89,7 +89,7 @@
       "title": "Ladyzhenskaya Stability Estimate Derivation",
       "startLine": 2694,
       "endLine": 2709,
-      "summary": "Documents the PDE derivation of the stability estimate: take the L² inner product of the difference equation with $(u_1 - u_2)$, bound the nonlinear term via the Ladyzhenskaya inequality (2D only!), and obtain $W'(t) \\leq C \\cdot E(t) \\cdot W(t)$.",
+      "summary": "Documents the PDE derivation of the stability estimate: take the L\u00b2 inner product of the difference equation with $(u_1 - u_2)$, bound the nonlinear term via the Ladyzhenskaya inequality (2D only!), and obtain $W'(t) \\leq C \\cdot E(t) \\cdot W(t)$.",
       "mathContext": "The Ladyzhenskaya inequality in 2D: $\\|u\\|_{L^4} \\leq C \\|u\\|_{L^2}^{1/2} \\|\\nabla u\\|_{L^2}^{1/2}$. Applied to the trilinear form: $|\\langle (u_1-u_2) \\cdot \\nabla u_1, u_1-u_2 \\rangle| \\leq C \\|\\nabla u_1\\| \\|u_1-u_2\\|^2$."
     },
     {
@@ -97,15 +97,15 @@
       "title": "NSSolutionPair2D: Framework for Comparing Solutions",
       "startLine": 2710,
       "endLine": 2722,
-      "summary": "Defines the NSSolutionPair2D structure: W (difference energy), C_stab (Ladyzhenskaya constant), stability_estimate W'(t) ≤ C·E(t)·W(t). References GlobalNSSolution2D.E for enstrophy with bound E(t) ≤ E(0).",
+      "summary": "Defines the NSSolutionPair2D structure: W (difference energy), C_stab (Ladyzhenskaya constant), stability_estimate W'(t) \u2264 C\u00b7E(t)\u00b7W(t). References GlobalNSSolution2D.E for enstrophy with bound E(t) \u2264 E(0).",
       "mathContext": "Structure fields: $W : \\mathbb{R} \\to \\mathbb{R}$ (difference energy $\\|u_1 - u_2\\|^2_{L^2}$), $C_{\\text{stab}} > 0$ (Ladyzhenskaya constant), stability estimate $W'(t) \\leq C \\cdot E(t) \\cdot W(t)$."
     },
     {
       "id": "gronwall-stability",
-      "title": "Gronwall L² Stability Bound",
+      "title": "Gronwall L\u00b2 Stability Bound",
       "startLine": 2734,
       "endLine": 2816,
-      "summary": "gronwall_stability_2d: W(t) ≤ W(0)·exp(C·E(0)·t). The integrating factor g(t) = W(t)·exp(-Kt) is shown antitone via g'(t) ≤ 0, using the bounded enstrophy E(t) ≤ E(0).",
+      "summary": "gronwall_stability_2d: W(t) \u2264 W(0)\u00b7exp(C\u00b7E(0)\u00b7t). The integrating factor g(t) = W(t)\u00b7exp(-Kt) is shown antitone via g'(t) \u2264 0, using the bounded enstrophy E(t) \u2264 E(0).",
       "mathContext": "$W(t) \\leq W(0) \\cdot e^{CE(0)t}$. Proof: set $K = CE(0)$, $g(t) = W(t)e^{-Kt}$. Then $g'(t) = (W'(t) - KW(t))e^{-Kt} \\leq 0$ since $W' \\leq CE(t)W \\leq KW$. So $g$ antitone: $g(t) \\leq g(0) = W(0)$."
     },
     {
@@ -121,7 +121,7 @@
       "title": "Stability Amplification Factor",
       "startLine": 2836,
       "endLine": 2853,
-      "summary": "stability_amplification_2d: W(t) ≤ W(0)·exp(C·E(0)·T) for t ∈ (0,T). Finite amplification factor because 2D enstrophy E(0) < ∞.",
+      "summary": "stability_amplification_2d: W(t) \u2264 W(0)\u00b7exp(C\u00b7E(0)\u00b7T) for t \u2208 (0,T). Finite amplification factor because 2D enstrophy E(0) < \u221e.",
       "mathContext": "$\\sup_{t \\in [0,T]} W(t) \\leq W(0) \\cdot e^{CE(0)T}$. The amplification factor $e^{CE(0)T}$ is finite because $E(0) < \\infty$ (bounded initial enstrophy). In 3D, $E(t)$ might blow up, making the factor infinite."
     },
     {
@@ -129,17 +129,17 @@
       "title": "Continuous Dependence on Initial Data",
       "startLine": 2850,
       "endLine": 2891,
-      "summary": "continuous_dependence_2d: for any ε > 0, δ = ε·exp(-C·E(0)·T) gives W(0) ≤ δ implies W(t) ≤ ε on (0,T). Together with uniqueness, establishes Hadamard well-posedness. Section closes with `end GronwallStability`.",
+      "summary": "continuous_dependence_2d: for any \u03b5 > 0, \u03b4 = \u03b5\u00b7exp(-C\u00b7E(0)\u00b7T) gives W(0) \u2264 \u03b4 implies W(t) \u2264 \u03b5 on (0,T). Together with uniqueness, establishes Hadamard well-posedness. Section closes with `end GronwallStability`.",
       "mathContext": "$\\forall \\varepsilon > 0,\\, \\delta = \\varepsilon \\cdot e^{-CE(0)T}$: $W(0) \\leq \\delta \\Rightarrow W(t) \\leq \\delta \\cdot e^{CE(0)T} = \\varepsilon$ for $t \\in [0,T]$. This completes Hadamard's third criterion (continuous dependence on initial data)."
     }
   ],
   "conclusion": {
-    "summary": "All three components of well-posedness are formalized with 0 axioms and 0 sorries. The Gronwall stability bound W(t) ≤ W(0)·exp(C·E(0)·t) is the key result, from which uniqueness and continuous dependence follow as corollaries. The proof uses the same integrating factor technique as the enstrophy decay theorems but with reversed sign (bounding growth instead of decay).",
-    "implications": "**Theoretical Significance**: **For 2D fluid mechanics**: This completes the well-posedness theory for 2D NS in our formal framework: existence (GlobalNSSolution2D), uniqueness (uniqueness_2d), and continuous dependence (continuous_dependence_2d) — the three pillars of Hadamard well-posedness.\n\n**For 3D comparison**: The proof reveals precisely WHERE the 3D argument breaks: the Gronwall growth rate K = C·E(0) relies on E(t) ≤ E(0), which holds in 2D but may fail in 3D.\n\nIf 3D enstrophy blows up, K(t) = C·E(t) → ∞ and the exponential bound becomes meaningless. This is a formal verification of the folklore that 2D uniqueness depends on bounded enstrophy.\n\n**For Mathlib**: The NSSolutionPair2D structure provides a reusable template for stability analysis of other evolution equations: any system with a Gronwall-type estimate W' ≤ f(t)·W and bounded f(t) gives well-posedness.",
+    "summary": "All three components of well-posedness are formalized with 0 axioms and 0 sorries. The Gronwall stability bound W(t) \u2264 W(0)\u00b7exp(C\u00b7E(0)\u00b7t) is the key result, from which uniqueness and continuous dependence follow as corollaries. The proof uses the same integrating factor technique as the enstrophy decay theorems but with reversed sign (bounding growth instead of decay).",
+    "implications": "**Theoretical Significance**: **For 2D fluid mechanics**: This completes the well-posedness theory for 2D NS in our formal framework: existence (GlobalNSSolution2D), uniqueness (uniqueness_2d), and continuous dependence (continuous_dependence_2d) \u2014 the three pillars of Hadamard well-posedness.\n\n**For 3D comparison**: The proof reveals precisely WHERE the 3D argument breaks: the Gronwall growth rate K = C\u00b7E(0) relies on E(t) \u2264 E(0), which holds in 2D but may fail in 3D.\n\nIf 3D enstrophy blows up, K(t) = C\u00b7E(t) \u2192 \u221e and the exponential bound becomes meaningless. This is a formal verification of the folklore that 2D uniqueness depends on bounded enstrophy.\n\n**For Mathlib**: The NSSolutionPair2D structure provides a reusable template for stability analysis of other evolution equations: any system with a Gronwall-type estimate W' \u2264 f(t)\u00b7W and bounded f(t) gives well-posedness.",
     "openQuestions": [
-      "Can the Poincaré inequality give a tighter stability bound? With exponential enstrophy decay E(t) ≤ E(0)·exp(-2νμ₁t), the integrated growth rate ∫C·E(s)ds would be finite as t→∞, giving a UNIFORM stability bound independent of time.",
-      "Can the NSSolutionPair2D framework be extended to handle weak solutions (where W'(t) ≤ C·E(t)·W(t) holds only in the distributional sense)?",
-      "What is the optimal Ladyzhenskaya stability constant C for specific domains (torus, bounded domain, ℝ²)?",
+      "Can the Poincar\u00e9 inequality give a tighter stability bound? With exponential enstrophy decay E(t) \u2264 E(0)\u00b7exp(-2\u03bd\u03bc\u2081t), the integrated growth rate \u222bC\u00b7E(s)ds would be finite as t\u2192\u221e, giving a UNIFORM stability bound independent of time.",
+      "Can the NSSolutionPair2D framework be extended to handle weak solutions (where W'(t) \u2264 C\u00b7E(t)\u00b7W(t) holds only in the distributional sense)?",
+      "What is the optimal Ladyzhenskaya stability constant C for specific domains (torus, bounded domain, \u211d\u00b2)?",
       "Can the 3D analogue NSSolutionPair3D be formalized, making explicit where the uniqueness argument fails?"
     ]
   },
@@ -152,7 +152,7 @@
     {
       "targetId": "navier-stokes-existence",
       "relationship": "related",
-      "description": "The Clay Millennium Prize problem on 3D Navier-Stokes existence and smoothness. This 2D well-posedness result serves as a template: the same Gronwall argument would work in 3D IF enstrophy were bounded — the Millennium problem is essentially asking whether it is"
+      "description": "The Clay Millennium Prize problem on 3D Navier-Stokes existence and smoothness. This 2D well-posedness result serves as a template: the same Gronwall argument would work in 3D IF enstrophy were bounded \u2014 the Millennium problem is essentially asking whether it is"
     },
     {
       "targetId": "navier-stokes-oq-01",
@@ -202,7 +202,7 @@
       "TwoDimensionalGlobal"
     ],
     "namespace": "NavierStokesRegularity",
-    "lineCount": 21110,
+    "lineCount": 21111,
     "axiomCount": 0,
     "theoremCount": 845,
     "definitionCount": 104,
@@ -215,28 +215,28 @@
       "title": "The Mathematical Theory of Viscous Incompressible Flow",
       "year": "1969",
       "venue": "Gordon and Breach, 2nd edition (translated by R.A. Silverman)",
-      "note": "The definitive monograph on Navier-Stokes well-posedness in 2D — established the Ladyzhenskaya inequality and the Gronwall-based uniqueness argument formalized here"
+      "note": "The definitive monograph on Navier-Stokes well-posedness in 2D \u2014 established the Ladyzhenskaya inequality and the Gronwall-based uniqueness argument formalized here"
     },
     {
       "authors": "Leray, Jean",
       "title": "Sur le mouvement d'un liquide visqueux emplissant l'espace",
       "year": "1934",
-      "venue": "Acta Mathematica 63, 193–248",
+      "venue": "Acta Mathematica 63, 193\u2013248",
       "note": "Founded the mathematical theory of Navier-Stokes: proved existence of weak solutions in 2D and 3D, global regularity in 2D, and introduced the turbulent solutions concept for 3D"
     },
     {
       "authors": "Gronwall, Thomas H.",
       "title": "Note on the derivatives with respect to a parameter of the solutions of a system of differential equations",
       "year": "1919",
-      "venue": "Annals of Mathematics 20(4), 292–296",
-      "note": "Introduced the Gronwall inequality: if u'(t) ≤ β(t)u(t) then u(t) ≤ u(0)exp(∫β) — the analytic engine powering the stability and uniqueness proofs"
+      "venue": "Annals of Mathematics 20(4), 292\u2013296",
+      "note": "Introduced the Gronwall inequality: if u'(t) \u2264 \u03b2(t)u(t) then u(t) \u2264 u(0)exp(\u222b\u03b2) \u2014 the analytic engine powering the stability and uniqueness proofs"
     },
     {
       "authors": "Temam, Roger",
       "title": "Navier-Stokes Equations: Theory and Numerical Analysis",
       "year": "2001",
       "venue": "AMS Chelsea Publishing (reprint of 1984 edition)",
-      "note": "Standard reference for mathematical analysis of Navier-Stokes — covers existence, uniqueness, regularity, and the 2D/3D distinction in detail"
+      "note": "Standard reference for mathematical analysis of Navier-Stokes \u2014 covers existence, uniqueness, regularity, and the 2D/3D distinction in detail"
     },
     {
       "authors": "Constantin, Peter; Foias, Ciprian",
@@ -247,10 +247,10 @@
     },
     {
       "authors": "Hadamard, Jacques",
-      "title": "Sur les problèmes aux dérivées partielles et leur signification physique",
+      "title": "Sur les probl\u00e8mes aux d\u00e9riv\u00e9es partielles et leur signification physique",
       "year": "1902",
-      "venue": "Princeton University Bulletin 13, 49–52",
-      "note": "Introduced the concept of well-posedness (existence + uniqueness + continuous dependence) for PDEs — the three properties established in this formalization"
+      "venue": "Princeton University Bulletin 13, 49\u201352",
+      "note": "Introduced the concept of well-posedness (existence + uniqueness + continuous dependence) for PDEs \u2014 the three properties established in this formalization"
     }
   ],
   "sorries": 0

--- a/src/data/proofs/navier-stokes/meta.json
+++ b/src/data/proofs/navier-stokes/meta.json
@@ -2,7 +2,7 @@
   "id": "navier-stokes-regularity",
   "title": "Global Regularity for Navier-Stokes",
   "slug": "navier-stokes",
-  "description": "A conditional regularity theorem for the Navier-Stokes Millennium Prize Problem. We identify the precise structural obstruction (scale-bridging concentration) and formulate the minimal Bubble Persistence hypothesis B′ under which all known tools close: B′ → Type I → ESŠ → regularity.",
+  "description": "A conditional regularity theorem for the Navier-Stokes Millennium Prize Problem. We identify the precise structural obstruction (scale-bridging concentration) and formulate the minimal Bubble Persistence hypothesis B\u2032 under which all known tools close: B\u2032 \u2192 Type I \u2192 ES\u0160 \u2192 regularity.",
   "currentVersion": "v4",
   "versionHistory": [
     {
@@ -11,7 +11,7 @@
       "date": "2026-02-12",
       "status": "conditional",
       "file": null,
-      "summary": "3D regularity is CONDITIONAL on hypotheses encoded in NSAxioms structure (physical assumptions moved from axiom declarations to structure fields — mathematically equivalent). 2D global existence (Ladyzhenskaya 1969) is genuinely proven without assumptions. The Millennium Problem remains open."
+      "summary": "3D regularity is CONDITIONAL on hypotheses encoded in NSAxioms structure (physical assumptions moved from axiom declarations to structure fields \u2014 mathematically equivalent). 2D global existence (Ladyzhenskaya 1969) is genuinely proven without assumptions. The Millennium Problem remains open."
     },
     {
       "version": "v1",
@@ -19,23 +19,23 @@
       "date": "2025-12-20",
       "status": "disputed",
       "file": "versions/v1.json",
-      "summary": "Initial analysis identifying 6 unproven axioms. The critical flaw: concentration_near_blowup assumes θ ≥ 1/2, which is exactly what needs to be proven."
+      "summary": "Initial analysis identifying 6 unproven axioms. The critical flaw: concentration_near_blowup assumes \u03b8 \u2265 1/2, which is exactly what needs to be proven."
     },
     {
       "version": "v2",
-      "name": "θₖ Refactor + Literature Analysis",
+      "name": "\u03b8\u2096 Refactor + Literature Analysis",
       "date": "2025-12-22",
       "status": "conditional",
       "file": "versions/v2.json",
-      "summary": "Introduced K-ball concentration framework (θₖ). Added literature review connecting to Barker-Prange, Seregin, ESŠ."
+      "summary": "Introduced K-ball concentration framework (\u03b8\u2096). Added literature review connecting to Barker-Prange, Seregin, ES\u0160."
     },
     {
       "version": "v3",
-      "name": "Conditional Regularity Theorem (B′ → Regularity)",
+      "name": "Conditional Regularity Theorem (B\u2032 \u2192 Regularity)",
       "date": "2025-12-22",
       "status": "conditional",
       "file": "analysis/conditional-regularity-theorem.md",
-      "summary": "Identified the precise obstruction: scale-bridging concentration. Formulated minimal Bubble Persistence hypothesis B′."
+      "summary": "Identified the precise obstruction: scale-bridging concentration. Formulated minimal Bubble Persistence hypothesis B\u2032."
     }
   ],
   "meta": {
@@ -65,8 +65,8 @@
     ],
     "originalContributions": [
       "Tropical rigidity theorem formalization",
-      "Type II dynamics β → 0 proof",
-      "K-ball concentration framework (θₖ refactor)",
+      "Type II dynamics \u03b2 \u2192 0 proof",
+      "K-ball concentration framework (\u03b8\u2096 refactor)",
       "Faber-Krahn additivity for disjoint balls"
     ],
     "dateAdded": "2025-12-21",
@@ -77,68 +77,68 @@
   },
   "objection": {
     "verdict": "CONDITIONAL 3D + PROVEN 2D",
-    "summary": "We identify the precise structural obstruction to ruling out Type II blowup: the SCALE MISMATCH between the parabolic scale √(T*-t) where Barker-Prange gives concentration, and the diffusion scale R_diff = √(ν/Ω) where the proof needs it. The Bubble Persistence hypothesis B′ bridges this gap.",
-    "coreIssue": "THE SCALE MISMATCH PROBLEM:\n\n• For Type I blowup: R_diff ≈ √(T*-t), so scales match and proof closes\n• For Type II blowup: R_diff << √(T*-t), creating a gap the smoothing lemma cannot bridge\n\nV3 FORMULATION (Bubble Persistence B′):\nConcentration A(r) = (1/r)∫|∇u|² ≥ ε must persist across all DYADIC radii r ∈ {2⁻ᵏ : R_diff ≤ 2⁻ᵏ ≤ c√(T*-t)}.\n\nThis is the MINIMAL hypothesis that:\n1. Glues CKN ε-regularity to enstrophy ODE\n2. Forces Type I rates via scale comparison\n3. Enables ESŠ backward uniqueness to exclude blowup\n\nThe hypothesis rules out exactly what Tao identifies as the core obstruction: cascade/escape mechanisms.",
+    "summary": "We identify the precise structural obstruction to ruling out Type II blowup: the SCALE MISMATCH between the parabolic scale \u221a(T*-t) where Barker-Prange gives concentration, and the diffusion scale R_diff = \u221a(\u03bd/\u03a9) where the proof needs it. The Bubble Persistence hypothesis B\u2032 bridges this gap.",
+    "coreIssue": "THE SCALE MISMATCH PROBLEM:\n\n\u2022 For Type I blowup: R_diff \u2248 \u221a(T*-t), so scales match and proof closes\n\u2022 For Type II blowup: R_diff << \u221a(T*-t), creating a gap the smoothing lemma cannot bridge\n\nV3 FORMULATION (Bubble Persistence B\u2032):\nConcentration A(r) = (1/r)\u222b|\u2207u|\u00b2 \u2265 \u03b5 must persist across all DYADIC radii r \u2208 {2\u207b\u1d4f : R_diff \u2264 2\u207b\u1d4f \u2264 c\u221a(T*-t)}.\n\nThis is the MINIMAL hypothesis that:\n1. Glues CKN \u03b5-regularity to enstrophy ODE\n2. Forces Type I rates via scale comparison\n3. Enables ES\u0160 backward uniqueness to exclude blowup\n\nThe hypothesis rules out exactly what Tao identifies as the core obstruction: cascade/escape mechanisms.",
     "thetaKRefactor": {
-      "motivation": "CKN shows singular sets have dimension ≤ 1, so 'few' bad points in spacetime. But this doesn't prevent enstrophy from spreading across MANY small balls, each with vanishing ratio θ → 0. The fix: track the TOTAL enstrophy captured by K balls.",
+      "motivation": "CKN shows singular sets have dimension \u2264 1, so 'few' bad points in spacetime. But this doesn't prevent enstrophy from spreading across MANY small balls, each with vanishing ratio \u03b8 \u2192 0. The fix: track the TOTAL enstrophy captured by K balls.",
       "definitions": {
-        "thetaAtK": "θₖ(t) = sup over K-tuples of disjoint balls of (sum of local enstrophies) / E(t)",
-        "averagingLemma": "If θₖ ≥ c, then single-ball θ ≥ c/K (pigeonhole)",
-        "criticalThreshold": "2/π² ≈ 0.203 is the minimum effective concentration needed"
+        "thetaAtK": "\u03b8\u2096(t) = sup over K-tuples of disjoint balls of (sum of local enstrophies) / E(t)",
+        "averagingLemma": "If \u03b8\u2096 \u2265 c, then single-ball \u03b8 \u2265 c/K (pigeonhole)",
+        "criticalThreshold": "2/\u03c0\u00b2 \u2248 0.203 is the minimum effective concentration needed"
       },
-      "whyFaberKrahnIsAdditive": "If K disjoint balls have local enstrophies E₁,...,Eₖ, then P ≥ Σᵢ (π²/4R²)·Eᵢ = (π²/4R²)·θₖ·E. The Faber-Krahn contribution is additive because the balls are disjoint.",
+      "whyFaberKrahnIsAdditive": "If K disjoint balls have local enstrophies E\u2081,...,E\u2096, then P \u2265 \u03a3\u1d62 (\u03c0\u00b2/4R\u00b2)\u00b7E\u1d62 = (\u03c0\u00b2/4R\u00b2)\u00b7\u03b8\u2096\u00b7E. The Faber-Krahn contribution is additive because the balls are disjoint.",
       "exampleThresholds": [
-        "K = 1, c = 0.50: c/K = 0.50 > 0.203 ✓ (original axiom)",
-        "K = 1, c = 0.21: c/K = 0.21 > 0.203 ✓ (minimal single-ball)",
-        "K = 5, c = 1.10: c/K = 0.22 > 0.203 ✓ (works)",
-        "K = 10, c = 2.5: c/K = 0.25 > 0.203 ✓ (works)",
-        "K = 100, c = 25: c/K = 0.25 > 0.203 ✓ (still works if K bounded)"
+        "K = 1, c = 0.50: c/K = 0.50 > 0.203 \u2713 (original axiom)",
+        "K = 1, c = 0.21: c/K = 0.21 > 0.203 \u2713 (minimal single-ball)",
+        "K = 5, c = 1.10: c/K = 0.22 > 0.203 \u2713 (works)",
+        "K = 10, c = 2.5: c/K = 0.25 > 0.203 \u2713 (works)",
+        "K = 100, c = 25: c/K = 0.25 > 0.203 \u2713 (still works if K bounded)"
       ],
       "openQuestion": "Is K bounded independent of scale near Type II blowup? If so, what is the bound?"
     },
     "detailedAnalysis": {
       "whatIsGenuinelyProven": [
-        "CKN ε-regularity: A(r) + C(r) + D(r) ≥ ε₀ at singular points (CKN 1982)",
-        "Enstrophy ODE: dE/dt ≤ CE³ limits growth to E ~ (T*-t)^{-1/2} (standard energy methods)",
-        "Type I concentration: ‖u‖_{L³} ≥ γ at scale √(T*-t) (Barker-Prange 2020)",
-        "Backward uniqueness: Type I blowups excluded via ESŠ 2003",
-        "Type II dynamics: β = (T-t)^{α-1} → 0 for α > 1",
-        "Conditional theorem: B′ → Type I → ESŠ → regularity (v3)",
-        "Tropical rigidity theorem: IF crossing with τ ≤ 0.1, THEN θ > 0.99"
+        "CKN \u03b5-regularity: A(r) + C(r) + D(r) \u2265 \u03b5\u2080 at singular points (CKN 1982)",
+        "Enstrophy ODE: dE/dt \u2264 CE\u00b3 limits growth to E ~ (T*-t)^{-1/2} (standard energy methods)",
+        "Type I concentration: \u2016u\u2016_{L\u00b3} \u2265 \u03b3 at scale \u221a(T*-t) (Barker-Prange 2020)",
+        "Backward uniqueness: Type I blowups excluded via ES\u0160 2003",
+        "Type II dynamics: \u03b2 = (T-t)^{\u03b1-1} \u2192 0 for \u03b1 > 1",
+        "Conditional theorem: B\u2032 \u2192 Type I \u2192 ES\u0160 \u2192 regularity (v3)",
+        "Tropical rigidity theorem: IF crossing with \u03c4 \u2264 0.1, THEN \u03b8 > 0.99"
       ],
-      "theActualGap": "V3 FINDING: The gap is SCALE-BRIDGING CONCENTRATION. CKN gives concentration at singular points. Barker-Prange gives concentration at √(T*-t) for Type I. But for Type II, R_diff << √(T*-t). The smoothing lemma cannot reach the diffusion scale. Bubble Persistence (B′) is the minimal hypothesis that bridges this gap.",
-      "whyTheGapIsHard": "B′ rules out exactly what Tao identifies as the core obstruction:\n• Multi-bubble proliferation: enstrophy fragmenting into many small centers\n• Escape to infinity: concentration drifting away from blowup point\n• Diffuse cascades: energy spreading across disjoint scales without persistence\n\nThese cannot be ruled out by CKN + enstrophy ODE alone.",
-      "literatureContext": "V3 SYNTHESIS: CKN 1982 (ε-regularity), Barker-Prange 2020 (Type I concentration), Seregin 2025 (Type II exclusion via LPS), ESŠ 2003 (backward uniqueness). Our B′ is strictly weaker than Seregin's LPS condition. See analysis/conditional-regularity-theorem.md."
+      "theActualGap": "V3 FINDING: The gap is SCALE-BRIDGING CONCENTRATION. CKN gives concentration at singular points. Barker-Prange gives concentration at \u221a(T*-t) for Type I. But for Type II, R_diff << \u221a(T*-t). The smoothing lemma cannot reach the diffusion scale. Bubble Persistence (B\u2032) is the minimal hypothesis that bridges this gap.",
+      "whyTheGapIsHard": "B\u2032 rules out exactly what Tao identifies as the core obstruction:\n\u2022 Multi-bubble proliferation: enstrophy fragmenting into many small centers\n\u2022 Escape to infinity: concentration drifting away from blowup point\n\u2022 Diffuse cascades: energy spreading across disjoint scales without persistence\n\nThese cannot be ruled out by CKN + enstrophy ODE alone.",
+      "literatureContext": "V3 SYNTHESIS: CKN 1982 (\u03b5-regularity), Barker-Prange 2020 (Type I concentration), Seregin 2025 (Type II exclusion via LPS), ES\u0160 2003 (backward uniqueness). Our B\u2032 is strictly weaker than Seregin's LPS condition. See analysis/conditional-regularity-theorem.md."
     },
     "promisingDirections": [
       {
-        "name": "Prove B′ in restricted settings",
-        "description": "V3 DIRECTION: Try to prove Bubble Persistence in symmetry classes where bubble count is naturally controlled:\n• Axisymmetric solutions: symmetry constrains concentration geometry\n• Periodic domains: no escape to infinity possible\n• Finite energy with decay: spatial localization built in",
+        "name": "Prove B\u2032 in restricted settings",
+        "description": "V3 DIRECTION: Try to prove Bubble Persistence in symmetry classes where bubble count is naturally controlled:\n\u2022 Axisymmetric solutions: symmetry constrains concentration geometry\n\u2022 Periodic domains: no escape to infinity possible\n\u2022 Finite energy with decay: spatial localization built in",
         "likelihood": "Medium - restricted settings often yield results",
         "status": "RECOMMENDED - NEW"
       },
       {
-        "name": "Weaken B′ further",
-        "description": "V3 DIRECTION: Can we weaken Bubble Persistence?\n• Require concentration at only O(log(1/R_diff)) dyadic scales\n• Allow ε to decay slowly (e.g., ε ~ 1/log(1/r))\n• Replace gradient by velocity (L³ version)",
+        "name": "Weaken B\u2032 further",
+        "description": "V3 DIRECTION: Can we weaken Bubble Persistence?\n\u2022 Require concentration at only O(log(1/R_diff)) dyadic scales\n\u2022 Allow \u03b5 to decay slowly (e.g., \u03b5 ~ 1/log(1/r))\n\u2022 Replace gradient by velocity (L\u00b3 version)",
         "likelihood": "Medium - weaker hypotheses may be provable",
         "status": "UNEXPLORED"
       },
       {
-        "name": "Numerical validation of B′",
-        "description": "V3 DIRECTION: Extract from Hou's simulations or Kang-Protas optimization:\n• Does concentration persist across scales [R_diff, √(T*-t)]?\n• What is the observed ε in B′?\n• Can this be used as an applied regularity criterion?",
+        "name": "Numerical validation of B\u2032",
+        "description": "V3 DIRECTION: Extract from Hou's simulations or Kang-Protas optimization:\n\u2022 Does concentration persist across scales [R_diff, \u221a(T*-t)]?\n\u2022 What is the observed \u03b5 in B\u2032?\n\u2022 Can this be used as an applied regularity criterion?",
         "likelihood": "High - numerical evidence would validate approach",
         "status": "UNEXPLORED"
       },
       {
         "name": "Seregin-style weakening",
-        "description": "V3 DIRECTION: Seregin uses LPS condition. What is the minimal condition (weaker than LPS) forcing trivial Euler limit? B′ is already weaker than LPS.",
+        "description": "V3 DIRECTION: Seregin uses LPS condition. What is the minimal condition (weaker than LPS) forcing trivial Euler limit? B\u2032 is already weaker than LPS.",
         "likelihood": "Medium - connects to existing literature",
         "status": "CONNECTS TO SEREGIN 2025"
       },
       {
         "name": "Tropical crossing (superseded)",
-        "description": "SUPERSEDED: Tropical crossing analysis was from v2. The v3 formulation with B′ provides a cleaner minimal hypothesis. Tropical crossing may imply B′ but is harder to analyze directly.",
-        "likelihood": "Low - superseded by B′ formulation",
+        "description": "SUPERSEDED: Tropical crossing analysis was from v2. The v3 formulation with B\u2032 provides a cleaner minimal hypothesis. Tropical crossing may imply B\u2032 but is harder to analyze directly.",
+        "likelihood": "Low - superseded by B\u2032 formulation",
         "status": "SUPERSEDED BY V3"
       }
     ],
@@ -146,25 +146,25 @@
     "proofStructureAssessment": {
       "logicalSoundness": "The proof structure is mathematically sound. IF the axioms held, the conclusion would follow rigorously.",
       "sophistication": "This is not a naive circular argument. The tropical rigidity framework, Type II adiabatic analysis, and CKN-based capacity arguments represent genuine mathematical contributions.",
-      "repairability": "REVISED ASSESSMENT: The θₖ refactor makes the missing hypothesis MORE PRECISE and potentially MORE TRACTABLE. The question 'is bubble count K bounded?' is a sharper target than 'does single-ball concentration hold?'"
+      "repairability": "REVISED ASSESSMENT: The \u03b8\u2096 refactor makes the missing hypothesis MORE PRECISE and potentially MORE TRACTABLE. The question 'is bubble count K bounded?' is a sharper target than 'does single-ball concentration hold?'"
     },
-    "whatLeanActuallyVerified": "The Lean file proves: (1) 3D conditional regularity — IF the NSAxioms hypotheses hold THEN no blowup (the hypotheses encode the hard open problem), (2) ESS backward uniqueness and Type I exclusion, (3) Type II stability and beta to 0, (4) CKN dimension/capacity framework, (5) 2D global existence and enstrophy bound (Ladyzhenskaya 1969 — genuinely proven, no assumptions), (6) 2D exponential decay under Poincare inequality. NOTE: The 3D result uses NSAxioms structure fields which are mathematically equivalent to axiom declarations — the assumptions were reorganized, not eliminated.",
+    "whatLeanActuallyVerified": "The Lean file proves: (1) 3D conditional regularity \u2014 IF the NSAxioms hypotheses hold THEN no blowup (the hypotheses encode the hard open problem), (2) ESS backward uniqueness and Type I exclusion, (3) Type II stability and beta to 0, (4) CKN dimension/capacity framework, (5) 2D global existence and enstrophy bound (Ladyzhenskaya 1969 \u2014 genuinely proven, no assumptions), (6) 2D exponential decay under Poincare inequality. NOTE: The 3D result uses NSAxioms structure fields which are mathematically equivalent to axiom declarations \u2014 the assumptions were reorganized, not eliminated.",
     "millenniumPrizeStatus": "The Navier-Stokes Millennium Prize problem remains UNSOLVED. The Lean file achieves 0 axioms and 0 sorries by encoding physical hypotheses via the NSAxioms structure (not axiom declarations). The 3D conditional theorem shows: NSAxioms implies no blowup. The 2D case is fully proven (axiom-free).",
-    "axiomEliminationNote": "The Lean file uses 0 axiom declarations, but this is a technical distinction, not a mathematical one. The physical hypotheses were moved from Lean `axiom` declarations into an NSAxioms structure — the mathematical assumptions are unchanged. The 3D theorem is conditional on these structure fields. The 2D theorem (Ladyzhenskaya) is genuinely unconditional."
+    "axiomEliminationNote": "The Lean file uses 0 axiom declarations, but this is a technical distinction, not a mathematical one. The physical hypotheses were moved from Lean `axiom` declarations into an NSAxioms structure \u2014 the mathematical assumptions are unchanged. The 3D theorem is conditional on these structure fields. The 2D theorem (Ladyzhenskaya) is genuinely unconditional."
   },
   "overview": {
     "historicalContext": "The Navier-Stokes equations, formulated by Claude-Louis Navier (1822) and George Gabriel Stokes (1845), describe the motion of viscous fluids. In 2000, the Clay Mathematics Institute designated the Navier-Stokes existence and smoothness problem as one of seven Millennium Prize Problems, offering $1 million for its resolution.\n\nThe question: given smooth initial conditions, do solutions to the 3D incompressible Navier-Stokes equations remain smooth for all time, or can singularities (blowup) develop? This remains one of the great unsolved problems in mathematics.",
     "problemStatement": "The 3D incompressible Navier-Stokes equations are:\n\n$$\\partial_t u + (u \\cdot \\nabla)u = -\\nabla p + \\nu \\Delta u$$\n$$\\nabla \\cdot u = 0$$\n\nwhere $u$ is velocity, $p$ is pressure, and $\\nu > 0$ is viscosity. The global regularity problem asks: given smooth initial data, does a unique smooth solution exist for all time?",
-    "text": "A conditional regularity theorem for the Navier-Stokes Millennium Prize Problem. We identify the precise structural obstruction (scale-bridging concentration) and formulate the minimal Bubble Persistence hypothesis B′ under which all known tools close: B′ → Type I → ESŠ → regularity.",
-    "proofStrategy": "V3 CONDITIONAL THEOREM (Bubble Persistence → Regularity):\n\n1. CKN ε-regularity: A(r) + C(r) + D(r) ≥ ε₀ at singular points [PROVEN - CKN 1982]\n2. Enstrophy ODE: dE/dt ≤ CE³ limits growth to E ~ (T*-t)^{-1/2} [PROVEN]\n3. Scale bridge via B′: Concentration persists from R_diff to √(T*-t) [HYPOTHESIS]\n4. Type I concentration: ‖u‖_{L³} ≥ γ at scale √(T*-t) [PROVEN - Barker-Prange 2020]\n5. Backward uniqueness: Type I blowups excluded [PROVEN - ESŠ 2003]\n\nTHE SCALE MISMATCH:\n• Type I: R_diff ≈ √(T*-t), scales match, proof closes\n• Type II: R_diff << √(T*-t), gap requires B′ to bridge\n\nB′ is the MINIMAL hypothesis that glues all proven steps together.",
+    "text": "A conditional regularity theorem for the Navier-Stokes Millennium Prize Problem. We identify the precise structural obstruction (scale-bridging concentration) and formulate the minimal Bubble Persistence hypothesis B\u2032 under which all known tools close: B\u2032 \u2192 Type I \u2192 ES\u0160 \u2192 regularity.",
+    "proofStrategy": "V3 CONDITIONAL THEOREM (Bubble Persistence \u2192 Regularity):\n\n1. CKN \u03b5-regularity: A(r) + C(r) + D(r) \u2265 \u03b5\u2080 at singular points [PROVEN - CKN 1982]\n2. Enstrophy ODE: dE/dt \u2264 CE\u00b3 limits growth to E ~ (T*-t)^{-1/2} [PROVEN]\n3. Scale bridge via B\u2032: Concentration persists from R_diff to \u221a(T*-t) [HYPOTHESIS]\n4. Type I concentration: \u2016u\u2016_{L\u00b3} \u2265 \u03b3 at scale \u221a(T*-t) [PROVEN - Barker-Prange 2020]\n5. Backward uniqueness: Type I blowups excluded [PROVEN - ES\u0160 2003]\n\nTHE SCALE MISMATCH:\n\u2022 Type I: R_diff \u2248 \u221a(T*-t), scales match, proof closes\n\u2022 Type II: R_diff << \u221a(T*-t), gap requires B\u2032 to bridge\n\nB\u2032 is the MINIMAL hypothesis that glues all proven steps together.",
     "keyInsights": [
-      "V3: The gap is SCALE-BRIDGING CONCENTRATION, not θ ≥ c directly",
-      "Bubble Persistence B′ is the minimal hypothesis bridging the scale mismatch",
-      "B′ rules out exactly what Tao identifies as the core obstruction: cascade/escape",
-      "B′ is strictly weaker than Seregin's LPS condition (2025)",
-      "For Type I, the proof closes without B′ (Barker-Prange + ESŠ)",
-      "The diagnostic value: any unconditional proof MUST rule out failure of B′",
-      "The conditional theorem: B′ → Type I only → ESŠ → regularity"
+      "V3: The gap is SCALE-BRIDGING CONCENTRATION, not \u03b8 \u2265 c directly",
+      "Bubble Persistence B\u2032 is the minimal hypothesis bridging the scale mismatch",
+      "B\u2032 rules out exactly what Tao identifies as the core obstruction: cascade/escape",
+      "B\u2032 is strictly weaker than Seregin's LPS condition (2025)",
+      "For Type I, the proof closes without B\u2032 (Barker-Prange + ES\u0160)",
+      "The diagnostic value: any unconditional proof MUST rule out failure of B\u2032",
+      "The conditional theorem: B\u2032 \u2192 Type I only \u2192 ES\u0160 \u2192 regularity"
     ],
     "prerequisites": [
       "Partial differential equations: Navier-Stokes equations, weak solutions, regularity theory",
@@ -180,15 +180,15 @@
       "title": "Part I-VII: Foundations and Enstrophy Identity",
       "startLine": 1,
       "endLine": 715,
-      "summary": "Establishes the Navier-Stokes solution structure, enstrophy E = ∫|ω|², palinstrophy P, and the fundamental identity E' = 2S - 2νP. Numerical constants like κ·c_FK > 2 are genuinely proven via native_decide.",
-      "mathContext": "Enstrophy $E(t) = \\int |\\omega|^2\\, dx$ (total squared vorticity), palinstrophy $P(t) = \\int |\\nabla\\omega|^2\\, dx$, stretching $S = \\int \\omega \\cdot (\\nabla u)\\omega\\, dx$. The fundamental identity: $E'(t) = 2S - 2\\nu P$. The NSAxioms structure encodes 5 physical hypotheses (Type II exponent, spectral gap, theta dynamics, blowup rate, BKM criterion) — these are the unsolved parts."
+      "summary": "Establishes the Navier-Stokes solution structure, enstrophy E = \u222b|\u03c9|\u00b2, palinstrophy P, and the fundamental identity E' = 2S - 2\u03bdP. Numerical constants like \u03ba\u00b7c_FK > 2 are genuinely proven via native_decide.",
+      "mathContext": "Enstrophy $E(t) = \\int |\\omega|^2\\, dx$ (total squared vorticity), palinstrophy $P(t) = \\int |\\nabla\\omega|^2\\, dx$, stretching $S = \\int \\omega \\cdot (\\nabla u)\\omega\\, dx$. The fundamental identity: $E'(t) = 2S - 2\\nu P$. The NSAxioms structure encodes 5 physical hypotheses (Type II exponent, spectral gap, theta dynamics, blowup rate, BKM criterion) \u2014 these are the unsolved parts."
     },
     {
       "id": "part-8b",
       "title": "Part VIII-B: Concentration Framework (Original)",
       "startLine": 808,
       "endLine": 893,
-      "summary": "Defines single-ball concentration θ = sup(E_loc/E). Proves bounds θ ≤ 1 and witness theorems.",
+      "summary": "Defines single-ball concentration \u03b8 = sup(E_loc/E). Proves bounds \u03b8 \u2264 1 and witness theorems.",
       "mathContext": "Single-ball concentration: $\\theta(t) = \\sup_x \\frac{E_{\\text{loc}}(x, R, t)}{E(t)}$ where $E_{\\text{loc}} = \\int_{B(x,R)} |\\omega|^2$. The critical threshold $\\theta \\geq 2/\\pi^2 \\approx 0.203$ ensures the Faber-Krahn spectral gap dominates stretching: $2\\nu P \\geq \\kappa c_{FK} \\theta E^2 > 2S$, forcing $E' < 0$."
     },
     {
@@ -196,7 +196,7 @@
       "title": "Part VIII-B': K-Ball Concentration Framework (NEW)",
       "startLine": 896,
       "endLine": 1038,
-      "summary": "Defines K-ball concentration θₖ, proves Faber-Krahn additivity, averaging lemma (θ ≥ θₖ/K), and K-threshold analysis.",
+      "summary": "Defines K-ball concentration \u03b8\u2096, proves Faber-Krahn additivity, averaging lemma (\u03b8 \u2265 \u03b8\u2096/K), and K-threshold analysis.",
       "mathContext": "$\\theta_K(t) = \\sup_{K \\text{ disjoint balls}} \\frac{\\sum_{i=1}^K E_{\\text{loc}}(x_i, R, t)}{E(t)}$. Key: Faber-Krahn is additive for disjoint balls: $P \\geq \\sum_i \\frac{\\pi^2}{4R^2} E_{\\text{loc}}(x_i) = \\frac{\\pi^2}{4R^2} \\theta_K E$. Averaging lemma: $\\theta \\geq \\theta_K / K$ (pigeonhole). The proof works if $\\theta_K \\geq 0.203K$ for any fixed $K$."
     },
     {
@@ -204,8 +204,8 @@
       "title": "Part VIII-C: Tropical Framework and Rigidity",
       "startLine": 1022,
       "endLine": 1100,
-      "summary": "Defines tropical L function and proves rigidity theorem: IF tropical crossing with τ ≤ 0.1, THEN θ > 0.99.",
-      "mathContext": "Tropical $L$ function: $L(\\beta) = \\min(2\\beta, 1)$ (tropical analogue of the $L$-function). Rigidity theorem: if $L$ crosses level $\\tau \\leq 0.1$, then the crossing forces $\\theta > 0.99$ — a much stronger concentration than the $0.203$ threshold. This would close the proof if tropical crossings are unavoidable at blowup."
+      "summary": "Defines tropical L function and proves rigidity theorem: IF tropical crossing with \u03c4 \u2264 0.1, THEN \u03b8 > 0.99.",
+      "mathContext": "Tropical $L$ function: $L(\\beta) = \\min(2\\beta, 1)$ (tropical analogue of the $L$-function). Rigidity theorem: if $L$ crosses level $\\tau \\leq 0.1$, then the crossing forces $\\theta > 0.99$ \u2014 a much stronger concentration than the $0.203$ threshold. This would close the proof if tropical crossings are unavoidable at blowup."
     },
     {
       "id": "axioms",
@@ -213,78 +213,78 @@
       "startLine": 1270,
       "endLine": 1390,
       "summary": "The NSAxioms structure encodes 5 physical hypotheses as structure fields (not Lean axiom declarations). These are the unsolved parts of the Millennium Problem.",
-      "mathContext": "NSAxioms structure fields: (1) Type II exponent $\\alpha > 1$, (2) spectral gap $\\lambda_1 \\geq \\pi^2/R^2$, (3) concentration dynamics $\\theta \\geq c$, (4) blowup rate $E(t) \\leq C(T^* - t)^{-\\alpha}$, (5) BKM criterion $\\int_0^T \\|\\omega\\|_\\infty\\, dt < \\infty \\Rightarrow$ regularity. These are mathematically equivalent to `axiom` declarations — the assumptions were reorganized into a structure, not eliminated."
+      "mathContext": "NSAxioms structure fields: (1) Type II exponent $\\alpha > 1$, (2) spectral gap $\\lambda_1 \\geq \\pi^2/R^2$, (3) concentration dynamics $\\theta \\geq c$, (4) blowup rate $E(t) \\leq C(T^* - t)^{-\\alpha}$, (5) BKM criterion $\\int_0^T \\|\\omega\\|_\\infty\\, dt < \\infty \\Rightarrow$ regularity. These are mathematically equivalent to `axiom` declarations \u2014 the assumptions were reorganized into a structure, not eliminated."
     },
     {
       "id": "twin-engine",
       "title": "Twin Engine Stability Theorem",
       "startLine": 1390,
       "endLine": 1460,
-      "summary": "Proves that Type II + concentration implies S ≤ νP eventually, using K-ball Faber-Krahn additivity.",
-      "mathContext": "If $\\theta_K \\geq 0.203K$ (concentration) and $E(t) \\sim (T^*-t)^{-\\alpha}$ with $\\alpha > 1$ (Type II), then $2\\nu P \\geq \\kappa c_{FK} \\theta_K E^2 / K > 2S$ eventually. This forces $E'(t) < 0$, contradicting the assumed blowup rate — the 'twin engine' (viscous damping + Faber-Krahn) overpowers stretching."
+      "summary": "Proves that Type II + concentration implies S \u2264 \u03bdP eventually, using K-ball Faber-Krahn additivity.",
+      "mathContext": "If $\\theta_K \\geq 0.203K$ (concentration) and $E(t) \\sim (T^*-t)^{-\\alpha}$ with $\\alpha > 1$ (Type II), then $2\\nu P \\geq \\kappa c_{FK} \\theta_K E^2 / K > 2S$ eventually. This forces $E'(t) < 0$, contradicting the assumed blowup rate \u2014 the 'twin engine' (viscous damping + Faber-Krahn) overpowers stretching."
     },
     {
       "id": "main-theorems",
       "title": "Final Theorems (Conditional 3D + Proven 2D)",
       "startLine": 1600,
       "endLine": 1670,
-      "summary": "3D: NSAxioms → no blowup (CONDITIONAL). 2D: global existence and enstrophy bound (PROVEN — Ladyzhenskaya 1969, no assumptions).",
-      "mathContext": "3D conditional: $\\text{NSAxioms} \\Rightarrow \\nexists$ finite-time blowup (the conditional regularity theorem). 2D proven: for 2D Navier-Stokes, $E(t) \\leq E(0)e^{-c\\nu t}$ (exponential decay under Poincaré), giving global existence and smoothness unconditionally — Ladyzhenskaya's 1969 result."
+      "summary": "3D: NSAxioms \u2192 no blowup (CONDITIONAL). 2D: global existence and enstrophy bound (PROVEN \u2014 Ladyzhenskaya 1969, no assumptions).",
+      "mathContext": "3D conditional: $\\text{NSAxioms} \\Rightarrow \\nexists$ finite-time blowup (the conditional regularity theorem). 2D proven: for 2D Navier-Stokes, $E(t) \\leq E(0)e^{-c\\nu t}$ (exponential decay under Poincar\u00e9), giving global existence and smoothness unconditionally \u2014 Ladyzhenskaya's 1969 result."
     }
   ],
   "conclusion": {
-    "summary": "V3 CONCLUSION: We identify the precise structural obstruction to ruling out Type II blowup — the SCALE MISMATCH between the parabolic scale √(T*-t) and the diffusion scale R_diff = √(ν/Ω). The Bubble Persistence hypothesis B′ is the MINIMAL condition bridging this gap.\n\nThe conditional theorem is:\n• CKN ε-regularity (PROVEN)\n• Enstrophy ODE bound (PROVEN)\n• Scale bridge via B′ (HYPOTHESIS)\n• Type I concentration (PROVEN for Type I)\n• Backward uniqueness (PROVEN)\n\nResult: B′ → Type I only → ESŠ → regularity",
-    "implications": "**Theoretical Significance**: WHAT V3 REVEALS:\n\n1. DIAGNOSTIC VALUE: This is not 'just conditional.' Any unconditional proof MUST rule out failure of B′ (cascade/escape mechanisms).\n\n2. MINIMAL HYPOTHESIS: B′ is strictly weaker than Seregin's LPS condition but still captures the essential anti-escape requirement.\n\n3.\n\nSCALE INVARIANCE: The quantity A(r) = (1/r)∫|∇u|² is scale-invariant under NS scaling, making B′ a structural condition.\n\n4. COMPARISON:\n   • Barker-Prange: Type I only (scales match)\n   • Seregin: LPS condition (stronger than B′)\n   • Our B′: Minimal scale-bridging (weaker, more tractable?)\n\n5. MILLENNIUM PRIZE: Still UNSOLVED. We've clarified what it would take to solve it.",
+    "summary": "V3 CONCLUSION: We identify the precise structural obstruction to ruling out Type II blowup \u2014 the SCALE MISMATCH between the parabolic scale \u221a(T*-t) and the diffusion scale R_diff = \u221a(\u03bd/\u03a9). The Bubble Persistence hypothesis B\u2032 is the MINIMAL condition bridging this gap.\n\nThe conditional theorem is:\n\u2022 CKN \u03b5-regularity (PROVEN)\n\u2022 Enstrophy ODE bound (PROVEN)\n\u2022 Scale bridge via B\u2032 (HYPOTHESIS)\n\u2022 Type I concentration (PROVEN for Type I)\n\u2022 Backward uniqueness (PROVEN)\n\nResult: B\u2032 \u2192 Type I only \u2192 ES\u0160 \u2192 regularity",
+    "implications": "**Theoretical Significance**: WHAT V3 REVEALS:\n\n1. DIAGNOSTIC VALUE: This is not 'just conditional.' Any unconditional proof MUST rule out failure of B\u2032 (cascade/escape mechanisms).\n\n2. MINIMAL HYPOTHESIS: B\u2032 is strictly weaker than Seregin's LPS condition but still captures the essential anti-escape requirement.\n\n3.\n\nSCALE INVARIANCE: The quantity A(r) = (1/r)\u222b|\u2207u|\u00b2 is scale-invariant under NS scaling, making B\u2032 a structural condition.\n\n4. COMPARISON:\n   \u2022 Barker-Prange: Type I only (scales match)\n   \u2022 Seregin: LPS condition (stronger than B\u2032)\n   \u2022 Our B\u2032: Minimal scale-bridging (weaker, more tractable?)\n\n5. MILLENNIUM PRIZE: Still UNSOLVED. We've clarified what it would take to solve it.",
     "openQuestions": [
-      "Can B′ be proven in restricted settings (axisymmetric, periodic, finite energy)?",
-      "Can B′ be weakened to finitely many dyadic scales?",
+      "Can B\u2032 be proven in restricted settings (axisymmetric, periodic, finite energy)?",
+      "Can B\u2032 be weakened to finitely many dyadic scales?",
       "What do numerical simulations say about concentration across scales?",
       "What is the minimal LPS-type condition for Euler limit triviality?",
-      "Is there a Carleman-type argument that forces B′?"
+      "Is there a Carleman-type argument that forces B\u2032?"
     ]
   },
   "references": [
     {
       "authors": "Navier, C.L.M.H.",
-      "title": "Mémoire sur les lois du mouvement des fluides",
+      "title": "M\u00e9moire sur les lois du mouvement des fluides",
       "year": "1822",
-      "venue": "Mémoires de l'Académie Royale des Sciences de l'Institut de France",
+      "venue": "M\u00e9moires de l'Acad\u00e9mie Royale des Sciences de l'Institut de France",
       "note": "First derivation of the equations of motion for viscous fluids"
     },
     {
       "authors": "Stokes, G.G.",
       "title": "On the theories of the internal friction of fluids in motion",
       "year": "1845",
-      "venue": "Transactions of the Cambridge Philosophical Society 8, 287–305",
+      "venue": "Transactions of the Cambridge Philosophical Society 8, 287\u2013305",
       "note": "Established the modern form of the equations now bearing both names"
     },
     {
       "authors": "Leray, J.",
       "title": "Sur le mouvement d'un liquide visqueux emplissant l'espace",
       "year": "1934",
-      "venue": "Acta Mathematica 63, 193–248",
-      "note": "Foundational paper proving existence of weak solutions and introducing the blowup scenario — the starting point for the regularity problem"
+      "venue": "Acta Mathematica 63, 193\u2013248",
+      "note": "Foundational paper proving existence of weak solutions and introducing the blowup scenario \u2014 the starting point for the regularity problem"
     },
     {
       "authors": "Caffarelli, L.; Kohn, R.; Nirenberg, L.",
       "title": "Partial regularity of suitable weak solutions of the Navier-Stokes equations",
       "year": "1982",
-      "venue": "Communications on Pure and Applied Mathematics 35(6), 771–831",
-      "note": "The CKN ε-regularity theorem: singular sets have 1-dimensional parabolic Hausdorff measure zero — the key tool used in the conditional regularity analysis"
+      "venue": "Communications on Pure and Applied Mathematics 35(6), 771\u2013831",
+      "note": "The CKN \u03b5-regularity theorem: singular sets have 1-dimensional parabolic Hausdorff measure zero \u2014 the key tool used in the conditional regularity analysis"
     },
     {
-      "authors": "Escauriaza, L.; Seregin, G.; Šverák, V.",
-      "title": "L₃,∞-solutions of Navier-Stokes equations and backward uniqueness",
+      "authors": "Escauriaza, L.; Seregin, G.; \u0160ver\u00e1k, V.",
+      "title": "L\u2083,\u221e-solutions of Navier-Stokes equations and backward uniqueness",
       "year": "2003",
-      "venue": "Russian Mathematical Surveys 58(2), 211–250",
-      "note": "Proved Type I blowup exclusion via backward uniqueness — the ESŠ theorem that closes the proof chain when concentration at parabolic scale is established"
+      "venue": "Russian Mathematical Surveys 58(2), 211\u2013250",
+      "note": "Proved Type I blowup exclusion via backward uniqueness \u2014 the ES\u0160 theorem that closes the proof chain when concentration at parabolic scale is established"
     },
     {
       "authors": "Ladyzhenskaya, O.A.",
       "title": "The Mathematical Theory of Viscous Incompressible Flow",
       "year": "1969",
       "venue": "Gordon and Breach, 2nd edition",
-      "note": "Proved global existence and uniqueness for 2D Navier-Stokes — the unconditional result formalized in this file"
+      "note": "Proved global existence and uniqueness for 2D Navier-Stokes \u2014 the unconditional result formalized in this file"
     }
   ],
   "crossReferences": [
@@ -306,7 +306,7 @@
     {
       "targetId": "poincare-conjecture",
       "relationship": "thematic",
-      "description": "The only Millennium Prize Problem solved so far (Perelman 2003). Both problems involve PDEs on manifolds: Ricci flow for Poincaré, Navier-Stokes for fluid dynamics. Perelman's blowup analysis techniques have parallels in the NS singularity analysis"
+      "description": "The only Millennium Prize Problem solved so far (Perelman 2003). Both problems involve PDEs on manifolds: Ricci flow for Poincar\u00e9, Navier-Stokes for fluid dynamics. Perelman's blowup analysis techniques have parallels in the NS singularity analysis"
     },
     {
       "targetId": "schauder-fixed-point",
@@ -335,7 +335,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 21110,
+    "lineCount": 21111,
     "structureCount": 249,
     "axiomCount": 0,
     "theoremCount": 845,


### PR DESCRIPTION
## Summary
- Fix `leanFile.lineCount` for 40 gallery proofs (all off by 1)
- Sync research registry data

Automated deployer sync.