### PR TITLE
Fix: shannon-channel-coding-oq-02-oq-01 leanFile.axiomCount corrected (1→2)

### DIFF
--- a/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
@@ -148,7 +148,7 @@
     ],
     "namespace": "FanoFromConditionalEntropy",
     "lineCount": 168,
-    "axiomCount": 1,
+    "axiomCount": 2,
     "sorries": 0,
     "path": "Proofs/ShannonChannelCodingOQ02OQ01.lean",
     "theoremCount": 3,


### PR DESCRIPTION
## Fix

Correct `leanFile.axiomCount` from 1 to 2 in `shannon-channel-coding-oq-02-oq-01/meta.json`.

## Evidence

**Before**: `leanFile.axiomCount: 1`
**After**: `leanFile.axiomCount: 2`

The file `ShannonChannelCodingOQ02OQ01.lean` contains two `axiom` declarations:
- `axiom fano_inequality` (line 81)
- `axiom import_shannon_entropy_blocked` (line 119)

The `meta.axiomCount` was already correct at 2; this corrects the internal inconsistency where `leanFile.axiomCount` disagreed with the actual file contents.

---
Automated fix by lean-mechanic agent.