### PR TITLE
Enrich erdos-1037/1039/106/740: add mathlibDependencies, originalContributions

### DIFF
--- a/src/data/proofs/erdos-1037/meta.json
+++ b/src/data/proofs/erdos-1037/meta.json
@@ -25,7 +25,44 @@
     "axiomCount": 3,
     "lineCount": 324,
     "assumptions": "3 axioms: chenErdos_false (Chen-Erdős conjecture is false, Cambie-Chan-Hunter 2023), cambieChanHunter_construction (counterexample construction exists for all n≥4), ramseyNumber (Ramsey numbers axiomatized as exact values are unknown). 0 sorries.",
-    "mathlib_version": "4.26.0"
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "SimpleGraph.degree",
+        "description": "Vertex degree (neighborhood cardinality) for the degree sequence computation",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Degree"
+      },
+      {
+        "theorem": "Finset.card_image_le",
+        "description": "Card of image ≤ card of source, used to bound distinctDegreeCount ≤ vertexCount",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Real.log",
+        "description": "Natural logarithm for the O(log n) Ramsey trivial-subgraph bound",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "Fintype.card",
+        "description": "Cardinality of finite type, used throughout for vertex count n",
+        "module": "Mathlib.Data.Fintype.Basic"
+      }
+    ],
+    "originalContributions": [
+      "degreeMultiset: multiset of all vertex degrees encoding the full degree sequence",
+      "distinctDegrees / distinctDegreeCount: image and cardinality of distinct degree values in the sequence",
+      "degreeMultiplicity: count of each degree value (multiplicity function)",
+      "hasLimitedMultiplicity: predicate for each degree appearing at most twice",
+      "hasManyDistinctDegrees: predicate for distinct degrees exceeding (1/2+ε)n",
+      "isChenErdosGraph: combined Chen-Erdős condition (limited multiplicity + many distinct degrees)",
+      "maxTrivialSize: maximum size over all independent sets and cliques in G",
+      "chenErdos_false axiom: the Chen-Erdős conjecture is false (Cambie-Chan-Hunter 2025)",
+      "cambieChanHunter_construction axiom: counterexample graphs with ≥3n/4 distinct degrees and O(log n) trivial size exist for all n≥4",
+      "counterexample_works: assembles the full disproof from the construction axiom",
+      "degree_diversity_no_ramsey_help: degree diversity does not improve the Ramsey O(log n) bound",
+      "cambie_is_optimal: 3n/4 is asymptotically optimal for multiplicity-2 degree diversity",
+      "generalMultiplicityBound: formula k/(k+1) for max distinct degrees with multiplicity ≤ k"
+    ]
   },
   "overview": {
     "historicalContext": "Chen and Erdős posed this question as part of a broader program investigating how degree sequence structure constrains Ramsey-type properties of graphs. By Ramsey's theorem (1930), every n-vertex graph contains a clique or independent set of size at least (1/2) log₂ n, and Erdős (1947) showed via the probabilistic method that random graphs G(n,1/2) essentially achieve this bound. The Chen-Erdős conjecture asked whether imposing degree diversity — specifically, requiring that each degree appears at most twice and that the number of distinct degrees exceeds (1/2 + ε)n — forces significantly larger trivial (complete or empty) subgraphs. This would have provided a deterministic condition implying non-random-like Ramsey behavior. The conjecture remained open for decades until Cambie, Chan, and Hunter (2025) disproved it by constructing explicit graphs with at least 3n/4 distinct degrees (each appearing at most twice) in which the largest clique or independent set has size only O(log n). Their construction shows that degree diversity is fundamentally independent of Ramsey structure: one can have maximally diverse degree sequences while maintaining the same trivial subgraph size as random graphs. The fraction 3/4 appears to be essentially optimal for multiplicity-2 constraints, connecting this to extremal questions about degree sequence realizability.",
@@ -141,9 +178,17 @@
       "id": "resolved",
       "title": "The Resolved Question",
       "summary": "erdos_1037_disproved (the conjecture is false via counterexample) and erdos_1037_answer (degree diversity does not force large trivial subgraphs)",
-      "startLine": 239,
-      "endLine": 276,
+      "startLine": 291,
+      "endLine": 306,
       "mathContext": "DISPROVED (Cambie-Chudnovsky 2023): counterexample exists. The degree diversity does NOT force super-logarithmic trivial subgraphs."
+    },
+    {
+      "id": "summary",
+      "title": "Summary and Closing",
+      "summary": "Prose summary recapping the Chen-Erdős conjecture (degree diversity forces large trivial subgraphs), the Cambie-Chan-Hunter disproof (≥3n/4 distinct degrees with O(log n) trivial size), and the main conclusion: degree diversity and Ramsey structure are independent properties.",
+      "startLine": 307,
+      "endLine": 324,
+      "mathContext": "Conclusion: for multiplicity-2 degree sequences, Chen-Erdős conjecture is FALSE. Degree diversity $\\geq 3n/4$ distinct values is compatible with max trivial subgraph $O(\\log n)$."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-1039/meta.json
+++ b/src/data/proofs/erdos-1039/meta.json
@@ -25,7 +25,40 @@
     "axiomCount": 5,
     "lineCount": 303,
     "assumptions": "5 axioms: benchmark_upper, pommerenke_lower, klr_lower, klr_area_bound, random_polynomial_expected. 3 sorries remain (area_implies_disc_bound, degree_one_optimal, clustered_implies_large_disc). Fixed sublevelArea type (ENNReal→ℝ via toReal).",
-    "mathlib_version": "4.29.0"
+    "mathlib_version": "4.29.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.eval₂",
+        "description": "Complex polynomial evaluation, used for defining |f(z)| in the sublevel set",
+        "module": "Mathlib.RingTheory.Polynomial.Basic"
+      },
+      {
+        "theorem": "Complex.abs",
+        "description": "Complex absolute value for the sublevel set {z : |f(z)| < 1} and inscribed disc condition",
+        "module": "Mathlib.Analysis.SpecialFunctions.Complex.Circle"
+      },
+      {
+        "theorem": "MeasureTheory.volume",
+        "description": "Lebesgue measure for the sublevel area bound used in the KLR argument",
+        "module": "Mathlib.MeasureTheory.Measure.MeasureSpace"
+      },
+      {
+        "theorem": "Real.log",
+        "description": "Natural logarithm for the KLR bound ρ(f) ≥ c/(n√log n)",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      }
+    ],
+    "originalContributions": [
+      "UnitDiscPolynomial: structure bundling degree, roots list, and unit-disc-roots constraint",
+      "sublevelSet: {z : |f(z)| < 1} formalized as a set in ℂ",
+      "sublevelArea: Lebesgue measure of the sublevel set (ENNReal → ℝ via toReal)",
+      "isInscribedDisc / inscribedDiscRadius: largest open disc contained in the sublevel set",
+      "benchmark_upper axiom: ρ(zⁿ-1) ≤ π/(2n) (unit roots polynomial worst case)",
+      "pommerenke_lower axiom: ρ(f) ≥ 1/(2en²) for any UnitDiscPolynomial (Pommerenke 1961)",
+      "klr_lower axiom: ρ(f) ≥ c/(n√log n) (Krishnapur-Lundberg-Ramachandran 2025)",
+      "klr_area_bound axiom: sublevelArea ≥ c/n² (area lower bound driving the KLR result)",
+      "random_polynomial_expected axiom: expected inscribed disc radius for random roots ≫ 1/n"
+    ]
   },
   "overview": {
     "historicalContext": "This problem was posed by Erdős, Herzog, and Piranian around 1958, motivated by the geometry of polynomial lemniscates — the level curves {z : |f(z)| = c} of complex polynomials. For a monic polynomial f(z) = ∏(z - zᵢ) with all roots in the closed unit disc, the sublevel set {z : |f(z)| < 1} is a bounded open region in the complex plane. The problem asks how large a disc can be inscribed in this sublevel set. The benchmark is the polynomial zⁿ - 1, whose n roots are equally spaced on the unit circle: its sublevel set consists of n thin petals, and the largest inscribed disc has radius at most π/(2n). Pommerenke (1961) proved the first general lower bound ρ(f) ≥ 1/(2en²) using potential theory and properties of Green's functions, establishing that the inscribed disc radius is at least quadratically small. This left a large gap between the O(1/n²) lower bound and the conjectured O(1/n) behavior. The problem attracted attention from researchers in potential theory, approximation theory, and complex dynamics. After decades of incremental progress, Krishnapur, Lundberg, and Ramachandran (2025) achieved a major breakthrough, proving ρ(f) ≥ c/(n√(log n)) using area bounds for sublevel sets derived from potential-theoretic estimates on logarithmic capacity. This nearly closes the gap, leaving only a √(log n) factor between the best known lower bound and the conjectured 1/n rate. The problem connects to transfinite diameter (Problem 1040), sublevel set measure (Problem 1038), and the broader study of polynomial inequalities in complex analysis.",

--- a/src/data/proofs/erdos-106/meta.json
+++ b/src/data/proofs/erdos-106/meta.json
@@ -25,7 +25,39 @@
     "axiomCount": 6,
     "assumptions": "6 axiom declarations: f_bounded (Cauchy-Schwarz sqrt bound), f_mono (monotone increasing), f_2 (f(2)=1 Erdos), f_perfect_square (f(k^2)=k), halasz_odd (odd increment bound), bku_theorem (axis-parallel 2024 result). Proved: f_1, f_4, f_9 from f_perfect_square; f_k2_plus_1_lower from f_mono + f_perfect_square",
     "lineCount": 237,
-    "mathlib_version": "4.26.0"
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.sqrt",
+        "description": "Square root for the Cauchy-Schwarz bound f(n) ≤ √n and the f(k²)=k exact value",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Finset.sum",
+        "description": "Summation over the n squares' side lengths for the objective function",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Set.Icc",
+        "description": "Closed interval [0,1] for the unit square containment predicate",
+        "module": "Mathlib.Order.LocallyFiniteOrder"
+      },
+      {
+        "theorem": "iSup",
+        "description": "Supremum over all valid packings for the definition of f(n)",
+        "module": "Mathlib.Order.CompleteLattice"
+      }
+    ],
+    "originalContributions": [
+      "Square: structure bundling center (ℝ²) and side length with containment and interior predicates",
+      "Packing n: indexed family of n squares with containment in [0,1]² and pairwise disjoint interiors",
+      "sumSides: sum of side lengths of a packing — the objective function",
+      "f: supremum of sumSides over all valid Packing n — the extremal function",
+      "f_1, f_4, f_9: concrete values f(1)=1, f(4)=2, f(9)=3 derived from f_perfect_square",
+      "f_k2_plus_1_lower: f(k²+1) ≥ k from monotonicity + perfect square case",
+      "plateauSet: set of n where f(n+1) = f(n), reformulating the conjecture as all k² are plateaus",
+      "bku_theorem axiom: g(k²+1) = k for axis-parallel packings (Baek-Koizumi-Ueoro 2024)"
+    ]
   },
   "overview": {
     "historicalContext": "**Square Packing: From Hungarian High School to Modern Breakthrough**\n\nThis problem has one of the longest histories in Erdős's repertoire, dating back to the 1930s when a young Paul Erdős proved $f(2) = 1$ in a paper written for **Középiskolai Matematikai és Fizikai Lapok**, the Hungarian journal for high school students. The result — that two non-overlapping squares in the unit square cannot have side-length sum exceeding $1$ — became a foundational result in discrete packing theory.\n\n**Key milestones**:\n- **1930s**: Erdős proved $f(2) = 1$ and observed that $f(k^2) = k$ follows from Cauchy-Schwarz: $(\\sum s_i)^2 \\leq n \\sum s_i^2 \\leq n$\n- **~1960s**: D. J. Newman proved $f(5) = 2$ (personal communication to Erdős), confirming the first non-trivial case of the conjecture\n- **1984**: Gábor Halász gave constructive lower bounds $f(k^2 + 2c + 1) \\geq k + c/k$, showing how grid modifications can increase the sum beyond $k$\n- **1994**: Erdős restated the problem in 'Some old and new problems in combinatorial geometry'\n- **1995**: Erdős and Alexander Soifer published 'Squares packing', formulating the stronger conjecture $f(k^2 + 2c + 1) = k + c/k$ for $|c| < k$\n- **Praton**: Iwan Praton proved that the main conjecture $f(k^2+1) = k$ is equivalent to the full Erdős-Soifer conjecture\n- **2024**: Baek, Koizumi, and Ueoro solved the **axis-parallel case** completely, proving $g(k^2+1) = k$ when all squares must have sides parallel to the unit square\n\nThe problem exemplifies Erdős's gift for posing questions that are simple to state yet resist all attacks. The 2024 axis-parallel breakthrough shows the conjecture is true 'most of the way' — the remaining open question is whether rotated squares can beat axis-parallel packings.",

--- a/src/data/proofs/erdos-740/meta.json
+++ b/src/data/proofs/erdos-740/meta.json
@@ -25,7 +25,33 @@
     "axiomCount": 2,
     "lineCount": 341,
     "assumptions": "2 axiom(s) and 1 sorry(s). See the Lean source for details.",
-    "mathlib_version": "4.26.0"
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "SimpleGraph.Coloring",
+        "description": "Proper graph coloring for the chromatic number definition",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Coloring"
+      },
+      {
+        "theorem": "Cardinal",
+        "description": "Cardinal arithmetic for infinite chromatic numbers (ℵ₀, 𝔪) and the threshold function",
+        "module": "Mathlib.SetTheory.Cardinal.Basic"
+      },
+      {
+        "theorem": "SimpleGraph.Walk",
+        "description": "Graph walks for the cycle and odd-cycle predicate definitions",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Walk"
+      }
+    ],
+    "originalContributions": [
+      "chromaticNumber: Cardinal-valued chromatic number for infinite graphs (noncomputable via iInf)",
+      "isColorable: predicate checking if a graph is k-colorable via a proper coloring function",
+      "hasCycle / hasOddCycle: predicates for the presence of cycles and odd cycles of length ≤ r",
+      "avoidsOddCyclesOf: predicate for a subgraph avoiding all odd cycles of length ≤ r",
+      "erdosHajnal_conjecture: formal statement of the Erdős-Hajnal conjecture for all infinite cardinals",
+      "rodl_triangle_free axiom: Rödl's theorem for ℵ₀ chromatic number and r=3 (triangle-free case)",
+      "girth_implies_odd_avoidance: girth > 2r implies avoidance of all odd cycles of length ≤ r"
+    ]
   },
   "overview": {
     "historicalContext": "Erdős and Hajnal posed this problem about preserving chromatic number while avoiding short odd cycles. It first appeared in Erdős's 1981 paper 'On the combinatorial problems which I would most like to see solved' ([Er81]), where he listed it among approximately 50 problems he considered most important in combinatorics. Rödl proved the case 𝔪 = ℵ₀ and r = 3 (triangle-free) in 1977, using a sophisticated probabilistic argument involving random vertex selection. The problem also appears in Erdős's 1995 survey [Er95d] on combinatorial set theory. The general case and the threshold function f_r(𝔪) remain open, connecting infinite combinatorics, set theory, and structural graph theory. The problem sits at the intersection of Ramsey theory and chromatic graph theory, building on Erdős's seminal 1959 result that graphs with arbitrarily high girth and chromatic number exist.",


### PR DESCRIPTION
Enrichment pass adding standard metadata fields to 4 gallery entries.

## Changes

- **erdos-1037** (Degree Diversity & Ramsey): mathlibDeps (SimpleGraph.degree, Finset.card_image_le, Real.log, Fintype.card), 13 originalContributions, fixed section line ranges, added missing summary section (277-324)
- **erdos-1039** (Polynomial Lemniscate Disc): mathlibDeps (Polynomial.eval₂, Complex.abs, MeasureTheory.volume, Real.log), 9 originalContributions covering UnitDiscPolynomial, sublevelSet, inscribed disc radius, and 5 axioms
- **erdos-106** (Square Packing): mathlibDeps (Real.sqrt, Finset.sum, Set.Icc, iSup), 8 originalContributions for Square structure, Packing n, f(n) definition, BKU 2024 theorem
- **erdos-740** (Chromatic Number & Odd Cycles): mathlibDeps (SimpleGraph.Coloring, Cardinal, SimpleGraph.Walk), 7 originalContributions for infinite chromatic number formalization