### PR TITLE
Fix: expand leanFile string → object in 4 gallery proofs

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01/meta.json
@@ -154,6 +154,21 @@
       "note": "Comprehensive treatment of Gauss sums and their applications"
     }
   ],
-  "leanFile": "Proofs/ElementaryQuadraticReciprocityOQ01OQ01.lean",
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.LegendreSymbol.QuadraticReciprocity",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "ZMod"
+    ],
+    "namespace": "GaussSumPathway",
+    "lineCount": 166,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/ElementaryQuadraticReciprocityOQ01OQ01.lean",
+    "sorries": 0
+  },
   "sorries": 0
 }

--- a/src/data/proofs/erdos-848-oq-01/meta.json
+++ b/src/data/proofs/erdos-848-oq-01/meta.json
@@ -127,6 +127,21 @@
       "note": "Proves maxNonSqfreeSet N = N/25 for large N via additive combinatorics"
     }
   ],
-  "leanFile": "Proofs/Erdos848ProblemOQ01.lean",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Tactic",
+      "Mathlib.Data.Nat.Basic",
+      "Mathlib.Data.Nat.Prime.Basic",
+      "Proofs.Erdos848Problem"
+    ],
+    "opens": [],
+    "namespace": "Erdos848OQ01",
+    "lineCount": 160,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "path": "Proofs/Erdos848ProblemOQ01.lean",
+    "sorries": 0
+  },
   "sorries": 0
 }

--- a/src/data/proofs/laws-of-large-numbers-oq-04/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-04/meta.json
@@ -175,6 +175,25 @@
       "note": "Generalization to VC classes; foundation of statistical learning theory"
     }
   ],
-  "leanFile": "Proofs/LawsOfLargeNumbersOQ04.lean",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Probability.StrongLaw",
+      "Mathlib.Probability.Independence.Basic",
+      "Mathlib.Probability.IdentDistrib",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "MeasureTheory",
+      "ProbabilityTheory",
+      "Set"
+    ],
+    "namespace": "GlivenkoCantelli",
+    "lineCount": 208,
+    "axiomCount": 3,
+    "theoremCount": 11,
+    "definitionCount": 3,
+    "path": "Proofs/LawsOfLargeNumbersOQ04.lean",
+    "sorries": 0
+  },
   "sorries": 0
 }

--- a/src/data/proofs/leibniz-pi-oq-03/meta.json
+++ b/src/data/proofs/leibniz-pi-oq-03/meta.json
@@ -138,6 +138,29 @@
       "note": "Classical treatment of series transformation methods including Euler's transform"
     }
   ],
-  "leanFile": "Proofs/LeibnizPiOQ03.lean",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Arctan",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.ArctanDeriv",
+      "Mathlib.Analysis.Real.Pi.Leibniz",
+      "Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Real",
+      "Filter",
+      "Finset",
+      "BigOperators",
+      "intervalIntegral",
+      "MeasureTheory"
+    ],
+    "namespace": "LeibnizPiOQ03",
+    "lineCount": 277,
+    "axiomCount": 0,
+    "theoremCount": 15,
+    "definitionCount": 2,
+    "path": "Proofs/LeibnizPiOQ03.lean",
+    "sorries": 0
+  },
   "sorries": 0
 }


### PR DESCRIPTION
## Fix

Four `meta.json` files had `leanFile` as a plain string (just the file path) instead of the proper object schema. This prevents reading `leanFile.axiomCount`, `leanFile.sorries`, `leanFile.lineCount`, and other fields.

## Evidence

**Before** (all 4 files):
```json
"leanFile": "Proofs/SomFile.lean"
```

**After**:
```json
"leanFile": {
  "imports": [...],
  "opens": [...],
  "namespace": "...",
  "lineCount": N,
  "axiomCount": N,
  "theoremCount": N,
  "definitionCount": N,
  "path": "Proofs/SomeFile.lean",
  "sorries": 0
}
```

## Affected Proofs

| Proof | Lines | Axioms | Theorems | Defs |
|-------|-------|--------|----------|------|
| leibniz-pi-oq-03 | 277 | 0 | 15 | 2 |
| erdos-848-oq-01 | 160 | 0 | 11 | 0 |
| elementary-quadratic-reciprocity-oq-01-oq-01 | 166 | 0 | 8 | 0 |
| laws-of-large-numbers-oq-04 | 208 | 3 | 11 | 3 |

All values verified against actual Lean source files.

---
Automated fix by lean-mechanic agent.