### PR TITLE
Fix: convert leanFile from string to object in 4 gallery proofs

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01/meta.json
@@ -154,6 +154,21 @@
       "note": "Comprehensive treatment of Gauss sums and their applications"
     }
   ],
-  "leanFile": "Proofs/ElementaryQuadraticReciprocityOQ01OQ01.lean",
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.LegendreSymbol.QuadraticReciprocity",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "ZMod"
+    ],
+    "namespace": "GaussSumPathway",
+    "lineCount": 166,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/ElementaryQuadraticReciprocityOQ01OQ01.lean",
+    "sorries": 0
+  },
   "sorries": 0
 }

--- a/src/data/proofs/erdos-848-oq-01/meta.json
+++ b/src/data/proofs/erdos-848-oq-01/meta.json
@@ -127,6 +127,21 @@
       "note": "Proves maxNonSqfreeSet N = N/25 for large N via additive combinatorics"
     }
   ],
-  "leanFile": "Proofs/Erdos848ProblemOQ01.lean",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Tactic",
+      "Mathlib.Data.Nat.Basic",
+      "Mathlib.Data.Nat.Prime.Basic",
+      "Proofs.Erdos848Problem"
+    ],
+    "opens": [],
+    "namespace": "Erdos848OQ01",
+    "lineCount": 160,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 1,
+    "path": "Proofs/Erdos848ProblemOQ01.lean",
+    "sorries": 0
+  },
   "sorries": 0
 }

--- a/src/data/proofs/laws-of-large-numbers-oq-04/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-04/meta.json
@@ -148,7 +148,9 @@
   ],
   "references": [
     {
-      "authors": ["Glivenko, V."],
+      "authors": [
+        "Glivenko, V."
+      ],
       "title": "Sulla determinazione empirica delle leggi di probabilita",
       "venue": "Giornale dell'Istituto Italiano degli Attuari",
       "volume": 4,
@@ -157,7 +159,9 @@
       "note": "Original proof of uniform convergence of empirical CDF"
     },
     {
-      "authors": ["Cantelli, F. P."],
+      "authors": [
+        "Cantelli, F. P."
+      ],
       "title": "Sulla determinazione empirica delle leggi di probabilita",
       "venue": "Giornale dell'Istituto Italiano degli Attuari",
       "volume": 4,
@@ -166,7 +170,10 @@
       "note": "Independent proof of the uniform convergence result"
     },
     {
-      "authors": ["Vapnik, V. N.", "Chervonenkis, A. Ya."],
+      "authors": [
+        "Vapnik, V. N.",
+        "Chervonenkis, A. Ya."
+      ],
       "title": "On the uniform convergence of relative frequencies of events to their probabilities",
       "venue": "Theory of Probability and its Applications",
       "volume": 16,
@@ -175,6 +182,25 @@
       "note": "Generalization to VC classes; foundation of statistical learning theory"
     }
   ],
-  "leanFile": "Proofs/LawsOfLargeNumbersOQ04.lean",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Probability.StrongLaw",
+      "Mathlib.Probability.Independence.Basic",
+      "Mathlib.Probability.IdentDistrib",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "MeasureTheory",
+      "ProbabilityTheory",
+      "Set"
+    ],
+    "namespace": "GlivenkoCantelli",
+    "lineCount": 208,
+    "axiomCount": 3,
+    "theoremCount": 11,
+    "definitionCount": 3,
+    "path": "Proofs/LawsOfLargeNumbersOQ04.lean",
+    "sorries": 0
+  },
   "sorries": 0
 }

--- a/src/data/proofs/leibniz-pi-oq-03/meta.json
+++ b/src/data/proofs/leibniz-pi-oq-03/meta.json
@@ -138,6 +138,29 @@
       "note": "Classical treatment of series transformation methods including Euler's transform"
     }
   ],
-  "leanFile": "Proofs/LeibnizPiOQ03.lean",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Arctan",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.ArctanDeriv",
+      "Mathlib.Analysis.Real.Pi.Leibniz",
+      "Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Real",
+      "Filter",
+      "Finset",
+      "BigOperators",
+      "intervalIntegral",
+      "MeasureTheory"
+    ],
+    "namespace": "LeibnizPiOQ03",
+    "lineCount": 277,
+    "axiomCount": 0,
+    "theoremCount": 15,
+    "definitionCount": 2,
+    "path": "Proofs/LeibnizPiOQ03.lean",
+    "sorries": 0
+  },
   "sorries": 0
 }


### PR DESCRIPTION
## Fix

4 gallery proofs had `leanFile` set as a plain string (path only) instead of
the standard object with imports, opens, namespace, lineCount, and file stats.

## Evidence

**Before**: `"leanFile": "Proofs/LeibnizPiOQ03.lean"` (string)
**After**: `"leanFile": { "path": "...", "lineCount": 277, "axiomCount": 0, ... }` (object)

## Proofs Fixed

| Proof | File | Lines | Axioms | Sorries |
|-------|------|-------|--------|---------|
| leibniz-pi-oq-03 | LeibnizPiOQ03.lean | 277 | 0 | 0 |
| erdos-848-oq-01 | Erdos848ProblemOQ01.lean | 160 | 0 | 0 |
| elementary-quadratic-reciprocity-oq-01-oq-01 | ElementaryQuadraticReciprocityOQ01OQ01.lean | 166 | 0 | 0 |
| laws-of-large-numbers-oq-04 | LawsOfLargeNumbersOQ04.lean | 208 | 3 | 0 |

Each `leanFile` object now includes: `imports`, `opens`, `namespace`, `lineCount`, `axiomCount`, `theoremCount`, `definitionCount`, `path`, `sorries`.

Validated with `pnpm annotations:build` (no new errors introduced).

---
Automated fix by lean-mechanic agent.