### PR TITLE
Research: sperner-ndim-oq-05 — granular imports for SpernerMathlib4.lean Mathlib PR

### DIFF
--- a/proofs/Proofs/SpernerMathlib4.lean
+++ b/proofs/Proofs/SpernerMathlib4.lean
@@ -3,7 +3,10 @@ Copyright (c) 2026 RJ Walters. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: RJ Walters
 -/
-import Mathlib
+import Mathlib.Algebra.Order.BigOperators.Group.Finset
+import Mathlib.Algebra.Ring.Parity
+import Mathlib.Data.Fintype.BigOperators
+import Mathlib.Data.ZMod.Basic
 
 /-!
 # Abstract Sperner's Lemma

--- a/research/problems/sperner-ndim-oq-05/knowledge.md
+++ b/research/problems/sperner-ndim-oq-05/knowledge.md
@@ -382,6 +382,63 @@ handling both the "equal to k" and "not in s" cases internally.
 
 ---
 
+## Session 2026-04-23 (Session 7) - Granular Imports for Mathlib PR
+
+**Mode**: REVISIT
+**Outcome**: PROGRESS — switched `SpernerMathlib4.lean` from `import Mathlib` to 4 granular imports; Docker build running
+
+### What I Did
+
+1. Read all prior sessions to understand state: 0 sorries in both files, `maxHeartbeats 200000` (default) for both
+2. Analyzed Mathlib package structure to identify the correct granular import set for `SpernerMathlib4.lean`
+3. Traced transitive import chains in installed Mathlib:
+   - `Finset.sum_involution` → `Algebra.BigOperators.Group.Finset.Basic` (via `prod_involution` + `@[to_additive]`)
+   - `Finset.card_biUnion` → `Algebra.BigOperators.Group.Finset.Basic` (line 959)
+   - `Finset.single_le_sum` → `Algebra.Order.BigOperators.Group.Finset` (line 192)
+   - `Fintype.sum_prod_type'` → `Data.Fintype.BigOperators` (line 263)
+   - `ZMod.natCast_eq_zero_iff` → `Data.ZMod.Basic` (line 508)
+   - `Nat.even_iff` → `Algebra.Group.Nat.Even` (line 27) — transitively via `Algebra.Ring.Parity`
+   - `Nat.odd_iff` → `Algebra.Ring.Parity` (namespace Nat, line 210)
+   - `Finite.injective_iff_surjective` → `Data.Fintype.Card` (line 319) — transitively via `Algebra.Order.BigOperators.Group.Finset`
+   - `Fintype.card_fin` → `Data.Fintype.Card` (line 485) — same transitive path
+4. Confirmed correct import path: `Mathlib.Algebra.BigOperators.Group.Finset.Basic` (NOT `Mathlib.Algebra.BigOperators.Group.Finset` — there's no directory entry point)
+5. Confirmed that `Mathlib.Algebra.Order.BigOperators.Group.Finset` subsumes `BigOperators.Group.Finset.Basic` and `Data.Fintype.Card` transitively (via `BigOperators.Group.Finset.Sigma`)
+6. Applied edit: replaced `import Mathlib` with 4 granular imports in worktree `SpernerMathlib4.lean`
+7. Started Docker build to verify
+
+### Key Technical Finding: Import Path Error in Previous Sessions
+
+Previous sessions recorded the import as `Mathlib.Algebra.BigOperators.Group.Finset` but there is NO `Finset.lean` file at that path. The correct import is:
+- `Mathlib.Algebra.Algebra.Order.BigOperators.Group.Finset` (the ordering module that imports the basic one)
+- OR `Mathlib.Algebra.BigOperators.Group.Finset.Basic` directly
+
+The ordering module is preferred as it subsumes Basic + adds single_le_sum.
+
+### Proposed Granular Import Set (Applied to SpernerMathlib4.lean)
+
+```lean
+import Mathlib.Algebra.Order.BigOperators.Group.Finset  -- single_le_sum; ⊇ BigOperators.Basic + Fintype.Card
+import Mathlib.Algebra.Ring.Parity                      -- Nat.odd_iff; ⊇ Nat.even_iff (Group.Nat.Even)
+import Mathlib.Data.Fintype.BigOperators                -- Fintype.sum_prod_type'
+import Mathlib.Data.ZMod.Basic                          -- ZMod.natCast_eq_zero_iff
+```
+
+**Uncertain**: `Nat.mod_mod_of_dvd` (used line 707) — appears to be in Lean core, not Mathlib. If it's missing, we may need `Mathlib.Data.Nat.ModEq` or similar.
+
+### Files Modified
+
+- `proofs/Proofs/SpernerMathlib4.lean` (line 6: `import Mathlib` → 4 granular imports)
+- Docker build running: `./proofs/scripts/docker-build.sh Proofs.SpernerMathlib4`
+
+### Next Steps
+
+1. **[AWAITING]** Docker build result — determines if import set is correct
+2. **If build succeeds**: Commit + PR; note heartbeats as 200000 (default) ✅
+3. **If build fails**: Add missing imports based on error messages; re-run Docker build
+4. **[USER ACTION]** Comment on mathlib4#25231 pointing to `SpernerSimplicialInstance.lean` as Part 2
+
+---
+
 ## Dead Ends
 
 - `FixedPointFree.lean` (GroupTheory) — about group automorphisms, not Finsets

--- a/research/problems/sperner-ndim-oq-05/knowledge.md
+++ b/research/problems/sperner-ndim-oq-05/knowledge.md
@@ -385,7 +385,7 @@ handling both the "equal to k" and "not in s" cases internally.
 ## Session 2026-04-23 (Session 7) - Granular Imports for Mathlib PR
 
 **Mode**: REVISIT
-**Outcome**: PROGRESS — switched `SpernerMathlib4.lean` from `import Mathlib` to 4 granular imports; Docker build running
+**Outcome**: PROGRESS — switched `SpernerMathlib4.lean` from `import Mathlib` to 4 granular imports; **Docker build verified SUCCESS** (9.6s, 1093 jobs)
 
 ### What I Did
 
@@ -428,14 +428,14 @@ import Mathlib.Data.ZMod.Basic                          -- ZMod.natCast_eq_zero_
 ### Files Modified
 
 - `proofs/Proofs/SpernerMathlib4.lean` (line 6: `import Mathlib` → 4 granular imports)
-- Docker build running: `./proofs/scripts/docker-build.sh Proofs.SpernerMathlib4`
+- Docker build: ✅ `Built Proofs.SpernerMathlib4 (9.6s)` — 1093 jobs, all succeeded
+- PR #11625 created
 
 ### Next Steps
 
-1. **[AWAITING]** Docker build result — determines if import set is correct
-2. **If build succeeds**: Commit + PR; note heartbeats as 200000 (default) ✅
-3. **If build fails**: Add missing imports based on error messages; re-run Docker build
-4. **[USER ACTION]** Comment on mathlib4#25231 pointing to `SpernerSimplicialInstance.lean` as Part 2
+1. **[USER ACTION]** Comment on mathlib4#25231 pointing to `SpernerSimplicialInstance.lean` as Part 2
+2. **Profile `SpernerSimplicialInstance.lean`** with `set_option profiler true` to find heartbeat bottleneck
+3. **Prepare Mathlib PR**: Fork mathlib4, copy `SpernerMathlib4.lean` to `Mathlib/Combinatorics/Sperner.lean`, submit as answer to #25231
 
 ---
 

--- a/src/data/research/problems/sperner-ndim-oq-05.json
+++ b/src/data/research/problems/sperner-ndim-oq-05.json
@@ -29,14 +29,15 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Granular imports applied to SpernerMathlib4.lean; Docker build running to verify",
+    "progressSummary": "PROGRESS: Granular imports verified for SpernerMathlib4.lean (Docker build: 9.6s success); PR #11625 created",
     "builtItems": [
       "SpernerMathlib4Opt.lean: optimized proof proposal for even_card_of_fpf_invol using sum_involution (research/problems/sperner-ndim-oq-05/lean/)",
       "even_card_of_fpf_invol: 53-line strongInduction proof replaced with 11-line sum_involution proof in SpernerMathlib4.lean",
       "boundaryFlip0.step_same: proved (SpernerGrid.lean:868-903, 2 sorries → 0)",
       "boundaryFlipLast.step_same: proved (SpernerGrid.lean:1011-1046, 2 sorries → 0)",
       "gridAdj_ne: proved in SpernerGrid.lean (1 sorry removed, 6 → 5 remaining)",
-      "Optimized adjFn_symm in SpernerSimplicialInstance.lean (line 745+)"
+      "Optimized adjFn_symm in SpernerSimplicialInstance.lean (line 745+)",
+      "Granular import set for SpernerMathlib4.lean verified: Algebra.Order.BigOperators.Group.Finset + Algebra.Ring.Parity + Data.Fintype.BigOperators + Data.ZMod.Basic (Docker build: 9.6s, 1093 jobs, success 2026-04-23)"
     ],
     "insights": [
       "All gallery files (SpernerMathlib4, SpernerSimplicialInstance, etc.) have 0 sorries — mathematical work complete",
@@ -68,11 +69,9 @@
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "[USER ACTION] Post comment on mathlib4#25231 pointing Dillies to SpernerSimplicialInstance.lean as Part 2",
-      "[AWAITING] Docker build result for granular imports in SpernerMathlib4.lean",
-      "If Docker build succeeds: commit + PR for granular imports change",
-      "Profile SpernerSimplicialInstance.lean with set_option profiler true to find expensive proofs",
-      "Submit Part 1 (SpernerMathlib4) PR to mathlib4 as initial contribution, Part 2 as follow-up"
+      "[USER ACTION] Post comment on mathlib4#25231 linking SpernerSimplicialInstance.lean as Part 2",
+      "Profile SpernerSimplicialInstance.lean with set_option profiler true to find heartbeat bottleneck",
+      "Prepare Mathlib PR: fork mathlib4, copy SpernerMathlib4.lean to Mathlib/Combinatorics/Sperner.lean"
     ],
     "markdown": "# Knowledge Base: sperner-ndim-oq-05\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },

--- a/src/data/research/problems/sperner-ndim-oq-05.json
+++ b/src/data/research/problems/sperner-ndim-oq-05.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: adjFn_symm optimized; boundary_doors_odd false for oriented gridComplex (see oq-02); Mathlib PR path clear for SpernerMathlib4+SpernerSimplicialInstance",
+    "progressSummary": "PROGRESS: Granular imports applied to SpernerMathlib4.lean; Docker build running to verify",
     "builtItems": [
       "SpernerMathlib4Opt.lean: optimized proof proposal for even_card_of_fpf_invol using sum_involution (research/problems/sperner-ndim-oq-05/lean/)",
       "even_card_of_fpf_invol: 53-line strongInduction proof replaced with 11-line sum_involution proof in SpernerMathlib4.lean",
@@ -60,18 +60,19 @@
       "split_ifs auto-closes h:none=some contradictions — only 1 bullet needed per split_ifs in helper lemmas",
       "j_step.castSucc.val syntactically ≠ j_step.val even though equal — need simp [Fin.castSucc] before omega in hlv proofs",
       "gridAdj_ne proved via 3-case split: boundary cases use verts_injective; interior case uses inc_injective + interiorFlip_incDir_kprev",
-      "adjFn_symm h_idx_eq block reduced from 28→13 lines using vertexEnum_not_mem_faceOf_iff; vertexEnum_not_mem_faceOf_iff packages both cases eliminating manual case split"
+      "adjFn_symm h_idx_eq block reduced from 28→13 lines using vertexEnum_not_mem_faceOf_iff; vertexEnum_not_mem_faceOf_iff packages both cases eliminating manual case split",
+      "Mathlib.Algebra.BigOperators.Group.Finset has no Finset.lean entry point — correct import is Mathlib.Algebra.Order.BigOperators.Group.Finset (which transitively imports Basic + Fintype.Card)",
+      "Minimal granular import set for SpernerMathlib4.lean: (1) Algebra.Order.BigOperators.Group.Finset, (2) Algebra.Ring.Parity, (3) Data.Fintype.BigOperators, (4) Data.ZMod.Basic",
+      "Nat.odd_iff is in namespace Nat section of Mathlib.Algebra.Ring.Parity (line 210)",
+      "Finset.sum_involution is @[to_additive] version of prod_involution in BigOperators.Group.Finset.Basic"
     ],
     "mathlibGaps": [],
     "nextSteps": [
       "[USER ACTION] Post comment on mathlib4#25231 pointing Dillies to SpernerSimplicialInstance.lean as Part 2",
-      "Test granular imports via Docker build for SpernerMathlib4.lean",
+      "[AWAITING] Docker build result for granular imports in SpernerMathlib4.lean",
+      "If Docker build succeeds: commit + PR for granular imports change",
       "Profile SpernerSimplicialInstance.lean with set_option profiler true to find expensive proofs",
-      "Reduce SpernerSimplicialInstance heartbeats to ≤ 800000 for Mathlib PR",
-      "Submit Part 1 (SpernerMathlib4) PR to mathlib4 as initial contribution, Part 2 as follow-up",
-      "Docker build to verify SpernerSimplicialInstance.lean optimization",
-      "Profile with set_option profiler true to find heartbeat bottleneck",
-      "USER ACTION: comment on mathlib4#25231 linking SpernerSimplicialInstance.lean as Part 2"
+      "Submit Part 1 (SpernerMathlib4) PR to mathlib4 as initial contribution, Part 2 as follow-up"
     ],
     "markdown": "# Knowledge Base: sperner-ndim-oq-05\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

- Switched `SpernerMathlib4.lean` from `import Mathlib` to 4 granular imports in preparation for a Mathlib PR submission
- Updated research knowledge with import structure analysis and Mathlib package layout findings
- Docker build verification is pending

## Import Changes

**Before**: `import Mathlib` (entire Mathlib library)

**After** (4 granular imports with rationale):
```lean
import Mathlib.Algebra.Order.BigOperators.Group.Finset  -- sum_involution, card_biUnion, single_le_sum; ⊇ Fintype.Card
import Mathlib.Algebra.Ring.Parity                      -- Nat.odd_iff; ⊇ Nat.even_iff (via Group.Nat.Even)
import Mathlib.Data.Fintype.BigOperators                -- Fintype.sum_prod_type'
import Mathlib.Data.ZMod.Basic                          -- ZMod.natCast_eq_zero_iff
```

## Key Research Finding

`Mathlib.Algebra.BigOperators.Group.Finset` is **not** a valid import path — there is no `Finset.lean` file at that path. Previous sessions incorrectly documented this. The correct import is `Mathlib.Algebra.Order.BigOperators.Group.Finset` which transitively imports `BigOperators.Group.Finset.Basic` (via Sigma).

## Current State

- `SpernerMathlib4.lean`: 0 sorries, `maxHeartbeats 200000` (default), granular imports applied ✅ (Docker verification pending)
- `SpernerSimplicialInstance.lean`: 0 sorries, `maxHeartbeats 200000` (default) — ready once heartbeat profile done
- mathlib4#25231: OPEN issue awaiting PR; user action needed to link Part 2

## Test plan

- [ ] Docker build verification: `./proofs/scripts/docker-build.sh Proofs.SpernerMathlib4` (running)
- [ ] If successful, update this PR as "build verified"
- [ ] If import set is incomplete, add missing imports and re-verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)