### PR TITLE
Fix: sqrt2-minpoly sorries field [] → 0 (type error)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12517,10 +12517,12 @@
       "result": "clean"
     },
     "sqrt2-minpoly": {
-      "auditCount": 1,
-      "issues": [],
-      "lastAudited": "2026-04-22T19:22:02Z",
-      "result": "issues-found"
+      "auditCount": 2,
+      "issues": [
+        "top-level sorries field was [] (empty array) instead of 0 (integer)"
+      ],
+      "lastAudited": "2026-04-23T04:30:00Z",
+      "result": "issues-fixed"
     },
     "sqrt2-minpoly-oq-01": {
       "auditCount": 1,
@@ -12541,10 +12543,10 @@
       "result": "issues-fixed"
     },
     "sqrt2-plus-sqrt3-irrational-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-22T20:40:28Z",
-      "result": "issues-found"
+      "lastAudited": "2026-04-23T04:30:00Z",
+      "result": "clean"
     },
     "stirling-formula": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/sqrt2-minpoly/meta.json
+++ b/src/data/proofs/sqrt2-minpoly/meta.json
@@ -208,5 +208,5 @@
       "description": "The field extension ℚ(√2)/ℚ has degree 2"
     }
   ],
-  "sorries": []
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

The `sorries` field at the top level of `src/data/proofs/sqrt2-minpoly/meta.json` was set to `[]` (empty array) instead of `0` (integer). The TypeScript schema defines this as `sorries?: number`, so an empty array is a type error.

## Evidence

**Before**:
```json
"sorries": []
```

**After**:
```json
"sorries": 0
```

The proof has 0 actual sorries and 0 axiom declarations (`Sqrt2Minpoly.lean` verified). Status `verified`, badge `original` are both correct.

Also updates `audit-tracker.json`:
- `sqrt2-minpoly`: marks `issues-fixed` with documented issue
- `sqrt2-plus-sqrt3-irrational-oq-03`: marks `clean` (metadata was already correct)

---
Automated fix by lean-mechanic agent.