### PR TITLE
Fix: correct badge wip→axiom for 185 axiomatized gallery proofs

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-02-oq-02/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-02/meta.json
@@ -14,7 +14,7 @@
       "representation theory",
       "Lie groups"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 160,

--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-01/meta.json
@@ -36,7 +36,7 @@
       "forcing",
       "open-question"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-03-28",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/dissection-of-cubes-oq-01-oq-01/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01-oq-01/meta.json
@@ -17,7 +17,7 @@
       "open-problem",
       "wiedijk-100"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
@@ -15,7 +15,7 @@
       "jacobi-symbol",
       "research"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "axiomCount": 0,
     "theoremCount": 13,

--- a/src/data/proofs/erdos-10/meta.json
+++ b/src/data/proofs/erdos-10/meta.json
@@ -16,7 +16,7 @@
       "powers of 2",
       "density"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 10,
     "erdosUrl": "https://erdosproblems.com/10",

--- a/src/data/proofs/erdos-1003/meta.json
+++ b/src/data/proofs/erdos-1003/meta.json
@@ -17,7 +17,7 @@
       "asymptotic-density",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1003,
     "erdosUrl": "https://erdosproblems.com/1003",

--- a/src/data/proofs/erdos-101/meta.json
+++ b/src/data/proofs/erdos-101/meta.json
@@ -19,7 +19,7 @@
     "erdosUrl": "https://erdosproblems.com/101",
     "axiomCount": 0,
     "lineCount": 757,
-    "badge": "wip",
+    "badge": "axiom",
     "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-1016/meta.json
+++ b/src/data/proofs/erdos-1016/meta.json
@@ -16,7 +16,7 @@
       "extremal graph theory",
       "Hamiltonian graphs"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1016,
     "erdosUrl": "https://erdosproblems.com/1016",

--- a/src/data/proofs/erdos-1021/meta.json
+++ b/src/data/proofs/erdos-1021/meta.json
@@ -16,7 +16,7 @@
       "turan-type",
       "bipartite-graphs"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 2,
     "erdosNumber": 1021,
     "erdosUrl": "https://erdosproblems.com/1021",

--- a/src/data/proofs/erdos-103/meta.json
+++ b/src/data/proofs/erdos-103/meta.json
@@ -16,7 +16,7 @@
       "congruence",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 103,
     "erdosUrl": "https://erdosproblems.com/103",

--- a/src/data/proofs/erdos-1038/meta.json
+++ b/src/data/proofs/erdos-1038/meta.json
@@ -16,7 +16,7 @@
       "potential-theory",
       "real-analysis"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1038,
     "erdosUrl": "https://erdosproblems.com/1038",

--- a/src/data/proofs/erdos-1041/meta.json
+++ b/src/data/proofs/erdos-1041/meta.json
@@ -17,7 +17,7 @@
       "level-sets",
       "paths"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1041,
     "erdosUrl": "https://erdosproblems.com/1041",

--- a/src/data/proofs/erdos-1051/meta.json
+++ b/src/data/proofs/erdos-1051/meta.json
@@ -15,7 +15,7 @@
       "series",
       "transcendence-theory"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1051,
     "erdosUrl": "https://erdosproblems.com/1051",

--- a/src/data/proofs/erdos-1052/meta.json
+++ b/src/data/proofs/erdos-1052/meta.json
@@ -1,6 +1,6 @@
 {
   "id": "erdos-1052",
-  "title": "Erd\u0151s #1052: Unitary Perfect Numbers",
+  "title": "Erdős #1052: Unitary Perfect Numbers",
   "slug": "erdos-1052",
   "description": "A unitary perfect number equals the sum of its proper unitary divisors (where d is unitary if gcd(d, n/d)=1). All unitary perfect numbers are even; finiteness is OPEN. Three examples verified by native_decide.",
   "meta": {
@@ -16,7 +16,7 @@
       "perfect-numbers",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1052,
     "erdosUrl": "https://erdosproblems.com/1052",
@@ -46,7 +46,7 @@
       }
     ],
     "originalContributions": [
-      "properUnitaryDivisors: Finset \u2115 via Ico and filter",
+      "properUnitaryDivisors: Finset ℕ via Ico and filter",
       "IsUnitaryPerfect with Decidable instance for native_decide",
       "one_mem_properUnitaryDivisors: basic membership proof",
       "odd_of_unitaryDivisor_of_odd: parity transfer via divisibility",
@@ -60,18 +60,18 @@
     ],
     "axiomCount": 0,
     "lineCount": 518,
-    "assumptions": "0 axioms, 0 sorries. even_of_isUnitaryPerfect is fully proved via multiplicativity + prime decomposition. Finiteness conjecture not formally stated as axiom \u2014 open problem described in closing comment."
+    "assumptions": "0 axioms, 0 sorries. even_of_isUnitaryPerfect is fully proved via multiplicativity + prime decomposition. Finiteness conjecture not formally stated as axiom — open problem described in closing comment."
   },
   "overview": {
-    "historicalContext": "Unitary divisors were introduced by Eckford Cohen in the 1960s as a natural refinement of classical divisor theory. A divisor $d$ of $n$ is **unitary** if $\\gcd(d, n/d) = 1$, meaning $d$ and its complement share no common prime factors. For example, 4 is a divisor of 12 but not a unitary divisor (since $\\gcd(4, 3) = 1$ \u2014 actually it is unitary), while 4 is not a unitary divisor of 24 (since $\\gcd(4, 6) = 2 \\neq 1$).\n\nSubbarao and Warren (1966) initiated the study of **unitary perfect numbers** \u2014 positive integers equal to the sum of their proper unitary divisors \u2014 and found the first four: 6, 60, 90, and 87360. Wall (1972) discovered the fifth: $146361946186458562560000 = 2^{18} \\cdot 3 \\cdot 5^4 \\cdot 7 \\cdot 11 \\cdot 13 \\cdot 19 \\cdot 37 \\cdot 79 \\cdot 109 \\cdot 157 \\cdot 313$, a 24-digit number with 12 distinct prime factors. No sixth has been found despite extensive computation.\n\nErd\u0151s conjectured there are only finitely many, contrasting sharply with classical perfect numbers where Euclid's construction $2^{p-1}(2^p - 1)$ yields infinitely many (contingent on the infinitude of Mersenne primes). The key structural difference is the product formula: $\\sigma^*(n) = \\prod(1 + p_i^{a_i})$ for unitary divisors versus $\\sigma(n) = \\prod(1 + p_i + \\cdots + p_i^{a_i})$ for standard divisors. The unitary sum grows much more slowly, making the equation $\\sigma^*(n) = 2n$ increasingly hard to satisfy as $n$ grows.\n\nAll unitary perfect numbers are provably even, by an elegant argument: if $n$ were odd, each factor $1 + p_i^{a_i}$ in the product formula would be even, making $\\sigma^*(n)$ divisible by $2^{\\omega(n)}$ where $\\omega(n)$ is the number of distinct prime factors. But $\\sigma^*(n) = 2n$ allows at most one factor of 2, forcing $\\omega(n) \\leq 1$ \u2014 and both cases $\\omega(n) = 0,1$ lead to contradictions.",
-    "problemStatement": "**OPEN CONJECTURE**: Are there only finitely many unitary perfect numbers?\n\n**SOLVED**: All unitary perfect numbers are even.\n\nKnown unitary perfect numbers:\n- 6 = 2 \u00b7 3\n- 60 = 2\u00b2 \u00b7 3 \u00b7 5\n- 90 = 2 \u00b7 3\u00b2 \u00b7 5\n- 87360 = 2\u2076 \u00b7 3 \u00b7 5 \u00b7 7 \u00b7 13\n- 146361946186458562560000 = 2\u00b9\u2078 \u00b7 3 \u00b7 5\u2074 \u00b7 7 \u00b7 11 \u00b7 13 \u00b7 19 \u00b7 37 \u00b7 79 \u00b7 109 \u00b7 157 \u00b7 313",
+    "historicalContext": "Unitary divisors were introduced by Eckford Cohen in the 1960s as a natural refinement of classical divisor theory. A divisor $d$ of $n$ is **unitary** if $\\gcd(d, n/d) = 1$, meaning $d$ and its complement share no common prime factors. For example, 4 is a divisor of 12 but not a unitary divisor (since $\\gcd(4, 3) = 1$ — actually it is unitary), while 4 is not a unitary divisor of 24 (since $\\gcd(4, 6) = 2 \\neq 1$).\n\nSubbarao and Warren (1966) initiated the study of **unitary perfect numbers** — positive integers equal to the sum of their proper unitary divisors — and found the first four: 6, 60, 90, and 87360. Wall (1972) discovered the fifth: $146361946186458562560000 = 2^{18} \\cdot 3 \\cdot 5^4 \\cdot 7 \\cdot 11 \\cdot 13 \\cdot 19 \\cdot 37 \\cdot 79 \\cdot 109 \\cdot 157 \\cdot 313$, a 24-digit number with 12 distinct prime factors. No sixth has been found despite extensive computation.\n\nErdős conjectured there are only finitely many, contrasting sharply with classical perfect numbers where Euclid's construction $2^{p-1}(2^p - 1)$ yields infinitely many (contingent on the infinitude of Mersenne primes). The key structural difference is the product formula: $\\sigma^*(n) = \\prod(1 + p_i^{a_i})$ for unitary divisors versus $\\sigma(n) = \\prod(1 + p_i + \\cdots + p_i^{a_i})$ for standard divisors. The unitary sum grows much more slowly, making the equation $\\sigma^*(n) = 2n$ increasingly hard to satisfy as $n$ grows.\n\nAll unitary perfect numbers are provably even, by an elegant argument: if $n$ were odd, each factor $1 + p_i^{a_i}$ in the product formula would be even, making $\\sigma^*(n)$ divisible by $2^{\\omega(n)}$ where $\\omega(n)$ is the number of distinct prime factors. But $\\sigma^*(n) = 2n$ allows at most one factor of 2, forcing $\\omega(n) \\leq 1$ — and both cases $\\omega(n) = 0,1$ lead to contradictions.",
+    "problemStatement": "**OPEN CONJECTURE**: Are there only finitely many unitary perfect numbers?\n\n**SOLVED**: All unitary perfect numbers are even.\n\nKnown unitary perfect numbers:\n- 6 = 2 · 3\n- 60 = 2² · 3 · 5\n- 90 = 2 · 3² · 5\n- 87360 = 2⁶ · 3 · 5 · 7 · 13\n- 146361946186458562560000 = 2¹⁸ · 3 · 5⁴ · 7 · 11 · 13 · 19 · 37 · 79 · 109 · 157 · 313",
     "text": "A unitary perfect number equals the sum of its proper unitary divisors (where d is unitary if gcd(d, n/d)=1). All unitary perfect numbers are even; finiteness is OPEN. Three examples verified by native_decide.",
-    "proofStrategy": "**Formalization Approach**\n\nThe Lean file provides a complete framework in 196 lines:\n\n1. **Definitions (lines 30-37):** Define `properUnitaryDivisors` via `Finset.Ico 1 n |>.filter` and `IsUnitaryPerfect` as sum equality plus positivity. Derive `Decidable` instance for `native_decide`.\n\n2. **Basic Properties (lines 47-58):** Prove `one_mem_properUnitaryDivisors` (1 is always unitary) and `mem_properUnitaryDivisors` (membership characterization).\n\n3. **Parity (lines 61-98):** Prove `odd_of_unitaryDivisor_of_odd` (divisibility transfer) and `sum_odd_parity` (Finset induction: sum of odds is odd iff count is odd).\n\n4. **Structure (lines 104-129):** Prove `unitary_iff_no_common_prime` via `Nat.exists_prime_and_dvd`, `unitary_complement` via `Nat.div_div_self`, and define `unitaryDivisorSum`.\n\n5. **Main Theorem (lines 131-150):** Axiomatize `even_of_isUnitaryPerfect` with detailed proof sketch in comments using the product formula \u03c3*(n) = \u220f(1 + p\u1d62^{a\u1d62}).\n\n6. **Examples (lines 156-166):** Verify `isUnitaryPerfect_6`, `isUnitaryPerfect_60`, `isUnitaryPerfect_90` by `native_decide`.\n\n7. **Conjecture (lines 191-194):** State `erdos_1052_conjecture : { n | IsUnitaryPerfect n }.Finite`.",
+    "proofStrategy": "**Formalization Approach**\n\nThe Lean file provides a complete framework in 196 lines:\n\n1. **Definitions (lines 30-37):** Define `properUnitaryDivisors` via `Finset.Ico 1 n |>.filter` and `IsUnitaryPerfect` as sum equality plus positivity. Derive `Decidable` instance for `native_decide`.\n\n2. **Basic Properties (lines 47-58):** Prove `one_mem_properUnitaryDivisors` (1 is always unitary) and `mem_properUnitaryDivisors` (membership characterization).\n\n3. **Parity (lines 61-98):** Prove `odd_of_unitaryDivisor_of_odd` (divisibility transfer) and `sum_odd_parity` (Finset induction: sum of odds is odd iff count is odd).\n\n4. **Structure (lines 104-129):** Prove `unitary_iff_no_common_prime` via `Nat.exists_prime_and_dvd`, `unitary_complement` via `Nat.div_div_self`, and define `unitaryDivisorSum`.\n\n5. **Main Theorem (lines 131-150):** Axiomatize `even_of_isUnitaryPerfect` with detailed proof sketch in comments using the product formula σ*(n) = ∏(1 + pᵢ^{aᵢ}).\n\n6. **Examples (lines 156-166):** Verify `isUnitaryPerfect_6`, `isUnitaryPerfect_60`, `isUnitaryPerfect_90` by `native_decide`.\n\n7. **Conjecture (lines 191-194):** State `erdos_1052_conjecture : { n | IsUnitaryPerfect n }.Finite`.",
     "keyInsights": [
-      "**Decidable IsUnitaryPerfect**: The `Decidable` instance via `instDecidableAnd` enables `native_decide` proofs for concrete examples \u2014 the kernel evaluates the Finset computation and checks equality. This is the most elegant verification approach.",
-      "**Finset Induction for Parity**: The `sum_odd_parity` proof uses `Finset.induction` to show \u2211(odd values) \u2261 card (mod 2). Each induction step splits on whether adding an odd number flips the parity, using `Odd.add_even` and `Odd.add_odd`.",
+      "**Decidable IsUnitaryPerfect**: The `Decidable` instance via `instDecidableAnd` enables `native_decide` proofs for concrete examples — the kernel evaluates the Finset computation and checks equality. This is the most elegant verification approach.",
+      "**Finset Induction for Parity**: The `sum_odd_parity` proof uses `Finset.induction` to show ∑(odd values) ≡ card (mod 2). Each induction step splits on whether adding an odd number flips the parity, using `Odd.add_even` and `Odd.add_odd`.",
       "**Prime Characterization**: `unitary_iff_no_common_prime` uses `Nat.exists_prime_and_dvd` (every non-unit has a prime factor) to characterize coprimality. The forward direction uses divisibility of gcd; the reverse constructs a contradiction via prime factorization.",
-      "**Product Formula Argument**: The evenness proof (in comments) uses \u03c3*(n) = \u220f(1 + p\u1d62^{a\u1d62}) \u2014 a product over prime power components. For odd n, each factor is even, making \u03c3* divisible by 2^\u03c9(n), but \u03c3* = 2n forces at most one factor of 2.",
+      "**Product Formula Argument**: The evenness proof (in comments) uses σ*(n) = ∏(1 + pᵢ^{aᵢ}) — a product over prime power components. For odd n, each factor is even, making σ* divisible by 2^ω(n), but σ* = 2n forces at most one factor of 2.",
       "**Only 5 Known**: Despite computational searches to very large bounds, only 5 unitary perfect numbers are known. The conjecture of finiteness remains one of the accessible open problems in number theory."
     ],
     "prerequisites": [
@@ -96,7 +96,7 @@
     {
       "targetId": "erdos-544",
       "relationship": "related",
-      "description": "Erd\u0151s #544 concerns off-diagonal Ramsey numbers, but Problem #1052's parity analysis echoes the parity constraints in classical perfect number theory \u2014 both ask whether perfection conditions force evenness"
+      "description": "Erdős #544 concerns off-diagonal Ramsey numbers, but Problem #1052's parity analysis echoes the parity constraints in classical perfect number theory — both ask whether perfection conditions force evenness"
     },
     {
       "targetId": "erdos-987",
@@ -106,22 +106,22 @@
     {
       "targetId": "perfect-numbers",
       "relationship": "related",
-      "description": "Classical perfect numbers satisfy \u03c3(n) = 2n (standard divisor sum). Unitary perfect numbers satisfy \u03c3*(n) = 2n (unitary divisor sum). The Euclid-Euler theorem classifies even perfect numbers as 2^{p-1}(2^p - 1); no analogous classification exists for unitary perfect numbers"
+      "description": "Classical perfect numbers satisfy σ(n) = 2n (standard divisor sum). Unitary perfect numbers satisfy σ*(n) = 2n (unitary divisor sum). The Euclid-Euler theorem classifies even perfect numbers as 2^{p-1}(2^p - 1); no analogous classification exists for unitary perfect numbers"
     },
     {
       "targetId": "euler-totient",
       "relationship": "foundational",
-      "description": "Euler's totient \u03c6(n) and the unitary divisor sum \u03c3*(n) are both multiplicative arithmetic functions. The multiplicativity \u03c3*(mn) = \u03c3*(m)\u03c3*(n) for coprime m,n (axiomatized here) parallels \u03c6(mn) = \u03c6(m)\u03c6(n), and both factor over prime powers"
+      "description": "Euler's totient φ(n) and the unitary divisor sum σ*(n) are both multiplicative arithmetic functions. The multiplicativity σ*(mn) = σ*(m)σ*(n) for coprime m,n (axiomatized here) parallels φ(mn) = φ(m)φ(n), and both factor over prime powers"
     },
     {
       "targetId": "infinitude-primes",
       "relationship": "foundational",
-      "description": "The prime factorization n = p\u2081^{a\u2081}\u00b7\u00b7\u00b7p\u2096^{a\u2096} underlying the product formula \u03c3*(n) = \u220f(1 + p\u1d62^{a\u1d62}) depends on the fundamental theorem of arithmetic. The infinitude of primes ensures an unbounded supply of potential prime factors for unitary perfect numbers"
+      "description": "The prime factorization n = p₁^{a₁}···pₖ^{aₖ} underlying the product formula σ*(n) = ∏(1 + pᵢ^{aᵢ}) depends on the fundamental theorem of arithmetic. The infinitude of primes ensures an unbounded supply of potential prime factors for unitary perfect numbers"
     },
     {
       "targetId": "bezout-identity",
       "relationship": "foundational",
-      "description": "The coprimality condition gcd(d, n/d) = 1 defining unitary divisors is characterized via B\u00e9zout's identity. The theorem unitary_iff_no_common_prime gives the prime-theoretic equivalent: no prime divides both d and n/d"
+      "description": "The coprimality condition gcd(d, n/d) = 1 defining unitary divisors is characterized via Bézout's identity. The theorem unitary_iff_no_common_prime gives the prime-theoretic equivalent: no prime divides both d and n/d"
     }
   ],
   "sections": [
@@ -130,7 +130,7 @@
       "title": "Core Definitions",
       "startLine": 26,
       "endLine": 42,
-      "summary": "Defines properUnitaryDivisors (n : \u2115) : Finset \u2115 via Finset.Ico 1 n filtered by d \u2223 n \u2227 d.Coprime (n / d). Defines IsUnitaryPerfect as sum equality plus positivity. Derives Decidable instance for native_decide.",
+      "summary": "Defines properUnitaryDivisors (n : ℕ) : Finset ℕ via Finset.Ico 1 n filtered by d ∣ n ∧ d.Coprime (n / d). Defines IsUnitaryPerfect as sum equality plus positivity. Derives Decidable instance for native_decide.",
       "mathContext": "$\\text{properUnitaryDivisors}(n) = \\{d \\in [1,n) : d \\mid n \\wedge \\gcd(d, n/d) = 1\\}$. $\\text{IsUnitaryPerfect}(n) \\iff \\sum_{d \\in \\text{properUnitaryDivisors}(n)} d = n \\wedge n > 0$. Decidable instance enables `native_decide`."
     },
     {
@@ -138,7 +138,7 @@
       "title": "Basic Properties",
       "startLine": 43,
       "endLine": 59,
-      "summary": "Proves one_mem_properUnitaryDivisors (1 is always unitary for n > 1) and mem_properUnitaryDivisors (membership \u2194 characterization) using simp and omega.",
+      "summary": "Proves one_mem_properUnitaryDivisors (1 is always unitary for n > 1) and mem_properUnitaryDivisors (membership ↔ characterization) using simp and omega.",
       "mathContext": "$1 \\in \\text{properUnitaryDivisors}(n)$ for $n > 1$, since $1 \\mid n$ and $\\gcd(1, n) = 1$. Membership characterized by: $d \\in [1,n) \\wedge d \\mid n \\wedge \\gcd(d, n/d) = 1$."
     },
     {
@@ -154,7 +154,7 @@
       "title": "Unitary Divisor Structure",
       "startLine": 100,
       "endLine": 130,
-      "summary": "Proves unitary_iff_no_common_prime (coprime \u2194 no common prime divisor) via Nat.exists_prime_and_dvd. Proves unitary_complement via Nat.div_div_self and Coprime.symm. Defines unitaryDivisorSum.",
+      "summary": "Proves unitary_iff_no_common_prime (coprime ↔ no common prime divisor) via Nat.exists_prime_and_dvd. Proves unitary_complement via Nat.div_div_self and Coprime.symm. Defines unitaryDivisorSum.",
       "mathContext": "$\\gcd(d, n/d) = 1 \\iff \\neg\\exists p$ prime with $p \\mid d$ and $p \\mid n/d$. Complement: if $d$ is a unitary divisor of $n$, so is $n/d$. $\\sigma^*(n) = \\sum_{d \\mid n,\\, \\gcd(d,n/d)=1} d$."
     },
     {
@@ -162,15 +162,15 @@
       "title": "Main Theorem: Even Unitary Perfect Numbers",
       "startLine": 131,
       "endLine": 151,
-      "summary": "Axiomatizes even_of_isUnitaryPerfect with detailed proof sketch: \u03c3*(n) = \u220f(1 + p\u1d62^a\u1d62) factors, odd n makes all factors even, 2^\u03c9(n) | 2n forces contradiction for k \u2265 2, k = 1 gives 1 = p^a impossible, k = 0 gives n = 1 not perfect.",
-      "mathContext": "For $n = p_1^{a_1} \\cdots p_k^{a_k}$: $\\sigma^*(n) = \\prod_{i=1}^{k}(1 + p_i^{a_i})$. If $n$ odd: each $1 + p_i^{a_i}$ is even, so $2^k \\mid \\sigma^*(n) = 2n$, giving $2^{k-1} \\mid n$ \u2014 contradiction for $k \\geq 2$."
+      "summary": "Axiomatizes even_of_isUnitaryPerfect with detailed proof sketch: σ*(n) = ∏(1 + pᵢ^aᵢ) factors, odd n makes all factors even, 2^ω(n) | 2n forces contradiction for k ≥ 2, k = 1 gives 1 = p^a impossible, k = 0 gives n = 1 not perfect.",
+      "mathContext": "For $n = p_1^{a_1} \\cdots p_k^{a_k}$: $\\sigma^*(n) = \\prod_{i=1}^{k}(1 + p_i^{a_i})$. If $n$ odd: each $1 + p_i^{a_i}$ is even, so $2^k \\mid \\sigma^*(n) = 2n$, giving $2^{k-1} \\mid n$ — contradiction for $k \\geq 2$."
     },
     {
       "id": "examples",
       "title": "Verified Examples",
       "startLine": 152,
       "endLine": 167,
-      "summary": "Proves isUnitaryPerfect_6, isUnitaryPerfect_60, isUnitaryPerfect_90 by native_decide \u2014 the Lean kernel evaluates the Finset computation and checks sum = n.",
+      "summary": "Proves isUnitaryPerfect_6, isUnitaryPerfect_60, isUnitaryPerfect_90 by native_decide — the Lean kernel evaluates the Finset computation and checks sum = n.",
       "mathContext": "$6 = 2 \\cdot 3$: unitary divisors $\\{1,2,3\\}$, sum $= 6$. $60 = 2^2 \\cdot 3 \\cdot 5$: unitary divisors $\\{1,3,4,5,12,15,20\\}$, sum $= 60$. $90 = 2 \\cdot 3^2 \\cdot 5$: unitary divisors $\\{1,2,5,9,10,18,45\\}$, sum $= 90$."
     },
     {
@@ -178,7 +178,7 @@
       "title": "Further Properties",
       "startLine": 168,
       "endLine": 226,
-      "summary": "Proves unitaryDivisors_primePow (only 1 and p^k for prime powers). Axiomatizes unitaryDivisorSum_mul_coprime (multiplicativity) and properUnitaryDivisors_pairing (d \u2194 n/d pairing).",
+      "summary": "Proves unitaryDivisors_primePow (only 1 and p^k for prime powers). Axiomatizes unitaryDivisorSum_mul_coprime (multiplicativity) and properUnitaryDivisors_pairing (d ↔ n/d pairing).",
       "mathContext": "For $p^k$ prime power: unitary divisors are exactly $\\{1, p^k\\}$ (proved). Multiplicativity: $\\sigma^*(mn) = \\sigma^*(m)\\sigma^*(n)$ for $\\gcd(m,n)=1$ (axiom). Pairing: $d \\mapsto n/d$ gives an involution on unitary divisors (axiom)."
     },
     {
@@ -186,18 +186,18 @@
       "title": "Open Conjecture",
       "startLine": 227,
       "endLine": 236,
-      "summary": "States erdos_1052_conjecture : { n : \u2115 | IsUnitaryPerfect n }.Finite as an axiom \u2014 the OPEN finiteness conjecture.",
+      "summary": "States erdos_1052_conjecture : { n : ℕ | IsUnitaryPerfect n }.Finite as an axiom — the OPEN finiteness conjecture.",
       "mathContext": "$\\{n \\in \\mathbb{N} \\mid \\text{IsUnitaryPerfect}(n)\\}$ is finite. Only 5 known: $6, 60, 90, 87360, 146361946186458562560000$. Open since 1972."
     }
   ],
   "conclusion": {
-    "summary": "Erd\u0151s Problem #1052 is formalized with 8 proved theorems (including 3 verified examples via native_decide, Finset induction parity lemma, prime characterization of coprimality, and unitary complement symmetry), 4 axioms (evenness of unitary perfect numbers, prime power structure, multiplicativity, pairing, and the open finiteness conjecture), and 3 definitions. The main computational verification uses native_decide through a Decidable instance on IsUnitaryPerfect.",
-    "implications": "**Theoretical Significance**: **Significance for Number Theory**\n\n1. **Unitary Divisor Theory**: The unitary divisor structure provides a natural generalization of classical divisor theory. The multiplicativity \u03c3*(mn) = \u03c3*(m)\u03c3*(n) for coprime m, n enables product formulas.\n\n**2. Parity Constraints**: The evenness proof illustrates how the factorization \u03c3*(n) = \u220f(1 + p\u1d62^{a\u1d62}) imposes strong arithmetic constraints. The argument generalizes to show unitary k-perfect numbers (\u03c3*(n) = kn) have restricted prime structures.\n\n3. **Computational Verification**: The `native_decide` approach demonstrates Lean 4's ability to verify number-theoretic properties computationally, avoiding manual divisor enumeration.\n\n4. **Open Problems**: The finiteness conjecture remains one of the most accessible open problems in number theory, requiring only elementary methods but resisting resolution for 50+ years.",
+    "summary": "Erdős Problem #1052 is formalized with 8 proved theorems (including 3 verified examples via native_decide, Finset induction parity lemma, prime characterization of coprimality, and unitary complement symmetry), 4 axioms (evenness of unitary perfect numbers, prime power structure, multiplicativity, pairing, and the open finiteness conjecture), and 3 definitions. The main computational verification uses native_decide through a Decidable instance on IsUnitaryPerfect.",
+    "implications": "**Theoretical Significance**: **Significance for Number Theory**\n\n1. **Unitary Divisor Theory**: The unitary divisor structure provides a natural generalization of classical divisor theory. The multiplicativity σ*(mn) = σ*(m)σ*(n) for coprime m, n enables product formulas.\n\n**2. Parity Constraints**: The evenness proof illustrates how the factorization σ*(n) = ∏(1 + pᵢ^{aᵢ}) imposes strong arithmetic constraints. The argument generalizes to show unitary k-perfect numbers (σ*(n) = kn) have restricted prime structures.\n\n3. **Computational Verification**: The `native_decide` approach demonstrates Lean 4's ability to verify number-theoretic properties computationally, avoiding manual divisor enumeration.\n\n4. **Open Problems**: The finiteness conjecture remains one of the most accessible open problems in number theory, requiring only elementary methods but resisting resolution for 50+ years.",
     "openQuestions": [
       "Are there only finitely many unitary perfect numbers?",
       "Is there a sixth unitary perfect number?",
       "What constraints exist on the prime factorization of unitary perfect numbers?",
-      "Are there infinitely many odd abundant numbers (\u03c3*(n) > 2n) that are squarefree?"
+      "Are there infinitely many odd abundant numbers (σ*(n) > 2n) that are squarefree?"
     ]
   },
   "references": [

--- a/src/data/proofs/erdos-1056/meta.json
+++ b/src/data/proofs/erdos-1056/meta.json
@@ -15,7 +15,7 @@
       "open"
     ],
     "erdosProblemStatus": "open",
-    "badge": "wip",
+    "badge": "axiom",
     "proofRepoPath": "Proofs/Erdos1056Problem.lean",
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/1056",

--- a/src/data/proofs/erdos-1059/meta.json
+++ b/src/data/proofs/erdos-1059/meta.json
@@ -17,7 +17,7 @@
       "composite-numbers",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1059,
     "erdosUrl": "https://erdosproblems.com/1059",

--- a/src/data/proofs/erdos-1060/meta.json
+++ b/src/data/proofs/erdos-1060/meta.json
@@ -15,7 +15,7 @@
       "counting-solutions",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1060,
     "erdosUrl": "https://erdosproblems.com/1060",

--- a/src/data/proofs/erdos-1062/meta.json
+++ b/src/data/proofs/erdos-1062/meta.json
@@ -14,7 +14,7 @@
       "extremal-combinatorics",
       "divisibility"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1062,
     "erdosUrl": "https://erdosproblems.com/1062",

--- a/src/data/proofs/erdos-1068/meta.json
+++ b/src/data/proofs/erdos-1068/meta.json
@@ -15,7 +15,7 @@
       "chromatic-number",
       "infinite-connectivity"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1068,
     "erdosUrl": "https://erdosproblems.com/1068",

--- a/src/data/proofs/erdos-1074/meta.json
+++ b/src/data/proofs/erdos-1074/meta.json
@@ -18,7 +18,7 @@
       "density",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1074,
     "erdosUrl": "https://erdosproblems.com/1074",

--- a/src/data/proofs/erdos-1077/meta.json
+++ b/src/data/proofs/erdos-1077/meta.json
@@ -16,7 +16,7 @@
       "balanced-graphs",
       "degree-regularity"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1077,
     "erdosUrl": "https://erdosproblems.com/1077",

--- a/src/data/proofs/erdos-11/meta.json
+++ b/src/data/proofs/erdos-11/meta.json
@@ -16,7 +16,7 @@
       "additive-combinatorics",
       "wieferich-primes"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 11,
     "erdosUrl": "https://erdosproblems.com/11",

--- a/src/data/proofs/erdos-1100/meta.json
+++ b/src/data/proofs/erdos-1100/meta.json
@@ -15,7 +15,7 @@
       "divisors",
       "coprimality"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 3,
     "erdosNumber": 1100,
     "erdosUrl": "https://erdosproblems.com/1100",

--- a/src/data/proofs/erdos-1101/meta.json
+++ b/src/data/proofs/erdos-1101/meta.json
@@ -17,7 +17,7 @@
       "gaps",
       "asymptotics"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1101,
     "erdosUrl": "https://erdosproblems.com/1101",

--- a/src/data/proofs/erdos-1108/meta.json
+++ b/src/data/proofs/erdos-1108/meta.json
@@ -17,7 +17,7 @@
       "powerful-numbers",
       "diophantine"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1108,
     "erdosUrl": "https://erdosproblems.com/1108",

--- a/src/data/proofs/erdos-1117/meta.json
+++ b/src/data/proofs/erdos-1117/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "erdos-1117",
-  "title": "Erd\u0151s Problem #1117: Maximum Modulus Points on Circles",
+  "title": "Erdős Problem #1117: Maximum Modulus Points on Circles",
   "slug": "erdos-1117",
-  "description": "For a non-monomial entire f, let \u03bd(r) count maximum modulus points on |z|=r. Can lim sup \u03bd(r) = \u221e? YES (Herzog\u2013Piranian 1968). Can lim inf \u03bd(r) = \u221e? OPEN. Approximate answer by Gl\u00fccksam\u2013Pardo-Sim\u00f3n (2024).",
+  "description": "For a non-monomial entire f, let ν(r) count maximum modulus points on |z|=r. Can lim sup ν(r) = ∞? YES (Herzog–Piranian 1968). Can lim inf ν(r) = ∞? OPEN. Approximate answer by Glücksam–Pardo-Simón (2024).",
   "meta": {
     "erdosNumber": 1117,
     "status": "axiomatized",
@@ -19,7 +19,7 @@
     "sourceUrl": "https://erdosproblems.com/1117",
     "erdosUrl": "https://erdosproblems.com/1117",
     "erdosProblemStatus": "open",
-    "badge": "wip",
+    "badge": "axiom",
     "axiomCount": 0,
     "lineCount": 83,
     "assumptions": "0 axioms. 0 sorries. All results formalized without axioms.",
@@ -44,40 +44,40 @@
     },
     {
       "id": "question-1",
-      "title": "Question 1: lim sup \u03bd(r) = \u221e (Solved)",
+      "title": "Question 1: lim sup ν(r) = ∞ (Solved)",
       "startLine": 61,
       "endLine": 69,
-      "summary": "The solved part: Herzog\u2013Piranian (1968) showed $\\limsup_{r \\to \\infty} \\nu(r) = \\infty$ is achievable. Formalized as: for every $N$, there exists a non-monomial entire $f$ and arbitrarily large $r$ with $\\nu(r) \\ge N$.",
-      "mathContext": "The solved part: Herzog\u2013Piranian (1968) showed $\\limsup_{r \\to \\infty} \\nu(r) = \\infty$ is achievable. Formalized as: for every $N$, there exists a non-monomial entire $f$ and arbitrarily large $r$ with $\\nu(r) \\ge N$."
+      "summary": "The solved part: Herzog–Piranian (1968) showed $\\limsup_{r \\to \\infty} \\nu(r) = \\infty$ is achievable. Formalized as: for every $N$, there exists a non-monomial entire $f$ and arbitrarily large $r$ with $\\nu(r) \\ge N$.",
+      "mathContext": "The solved part: Herzog–Piranian (1968) showed $\\limsup_{r \\to \\infty} \\nu(r) = \\infty$ is achievable. Formalized as: for every $N$, there exists a non-monomial entire $f$ and arbitrarily large $r$ with $\\nu(r) \\ge N$."
     },
     {
       "id": "question-2",
-      "title": "Question 2: lim inf \u03bd(r) = \u221e (Open)",
+      "title": "Question 2: lim inf ν(r) = ∞ (Open)",
       "startLine": 70,
       "endLine": 80,
-      "summary": "The open part: can $\\liminf_{r \\to \\infty} \\nu(r) = \\infty$ for a non-monomial entire function? Formalized as a disjunction \u2014 either such $f$ exists, or every non-monomial has $\\nu(r)$ bounded infinitely often.",
-      "mathContext": "The open part: can $\\liminf_{r \\to \\infty} \\nu(r) = \\infty$ for a non-monomial entire function? Formalized as a disjunction \u2014 either such $f$ exists, or every non-monomial has $\\nu(r)$ bounded infinitely often."
+      "summary": "The open part: can $\\liminf_{r \\to \\infty} \\nu(r) = \\infty$ for a non-monomial entire function? Formalized as a disjunction — either such $f$ exists, or every non-monomial has $\\nu(r)$ bounded infinitely often.",
+      "mathContext": "The open part: can $\\liminf_{r \\to \\infty} \\nu(r) = \\infty$ for a non-monomial entire function? Formalized as a disjunction — either such $f$ exists, or every non-monomial has $\\nu(r)$ bounded infinitely often."
     },
     {
       "id": "approximate-context",
       "title": "Approximate Result and Hadamard Context",
       "startLine": 81,
       "endLine": 83,
-      "summary": "Gl\u00fccksam\u2013Pardo-Sim\u00f3n (2024): for any $\\varepsilon > 0$ and $N$, there exists entire $f$ with $N$ points achieving $(1-\\varepsilon)M(r)$ for all large $r$. Also states monotonicity of $M(r)$ from the maximum modulus principle and the Hadamard three-circles theorem.",
-      "mathContext": "Gl\u00fccksam\u2013Pardo-Sim\u00f3n (2024): for any $\\varepsilon > 0$ and $N$, there exists entire $f$ with $N$ points achieving $(1-\\varepsilon)M(r)$ for all large $r$. Also states monotonicity of $M(r)$ from the maximum modulus principle and the Hadamard three-circles theorem."
+      "summary": "Glücksam–Pardo-Simón (2024): for any $\\varepsilon > 0$ and $N$, there exists entire $f$ with $N$ points achieving $(1-\\varepsilon)M(r)$ for all large $r$. Also states monotonicity of $M(r)$ from the maximum modulus principle and the Hadamard three-circles theorem.",
+      "mathContext": "Glücksam–Pardo-Simón (2024): for any $\\varepsilon > 0$ and $N$, there exists entire $f$ with $N$ points achieving $(1-\\varepsilon)M(r)$ for all large $r$. Also states monotonicity of $M(r)$ from the maximum modulus principle and the Hadamard three-circles theorem."
     }
   ],
   "overview": {
-    "historicalContext": "**Maximum Modulus Points and Erd\u0151s's Question (1974)**\n\nThis problem appears as Problem 2.16 in W. K. Hayman's influential 1974 collection *\"Research Problems in Function Theory\"*, attributed to Paul Erd\u0151s. It belongs to a rich tradition of studying the **maximum modulus function** $M(r) = \\max_{|z|=r} |f(z)|$ of entire functions, dating back to the foundational work of Jacques Hadamard (1896), Anders Wiman (1903), and G\u00e1bor Szeg\u0151 (1920s).\n\nThe maximum modulus principle \u2014 that a nonconstant holomorphic function cannot attain its maximum in the interior of its domain \u2014 implies that $M(r)$ captures essential boundary behavior. For monomials $f(z) = cz^n$, the modulus $|f(z)| = |c|r^n$ is constant on each circle, so every point is a maximum point. For any other entire function, the maximum is achieved at only finitely many points on each circle.\n\nFritz Herzog and George Piranian (1968) answered the first question: they constructed an entire function with $\\limsup_{r \\to \\infty} \\nu(r) = \\infty$, using lacunary power series whose dominant term rotates, creating many near-maximum points at specific radii. The much harder second question \u2014 whether $\\liminf \\nu(r) = \\infty$ is possible \u2014 has resisted attack for over 50 years.\n\nIn 2024, Adi Gl\u00fccksam (Tel Aviv University) and Leticia Pardo-Sim\u00f3n provided the closest approach yet: they showed that for every $\\varepsilon > 0$, one can construct entire functions with many points achieving at least $(1-\\varepsilon) M(r)$ on every sufficiently large circle. Closing the gap from $(1-\\varepsilon)M(r)$ to the exact maximum $M(r)$ remains the key challenge.",
-    "problemStatement": "For a non-monomial entire function $f$, let $\\nu(r) = \\#\\{z : |z| = r,\\, |f(z)| = M(r)\\}$ count the maximum modulus points on the circle of radius $r$.\n\n**Question 1** (Solved): Can $\\limsup_{r \\to \\infty} \\nu(r) = \\infty$? **YES** \u2014 Herzog\u2013Piranian (1968).\n\n**Question 2** (Open): Can $\\liminf_{r \\to \\infty} \\nu(r) = \\infty$?\n\n**Approximate answer**: YES in the $(1-\\varepsilon)$ sense \u2014 Gl\u00fccksam\u2013Pardo-Sim\u00f3n (2024).",
-    "text": "For a non-monomial entire f, let \u03bd(r) count maximum modulus points on |z|=r. Can lim sup \u03bd(r) = \u221e? YES (Herzog\u2013Piranian 1968). Can lim inf \u03bd(r) = \u221e? OPEN. Approximate answer by Gl\u00fccksam\u2013Pardo-Sim\u00f3n (2024).",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Axiomatized primitives**: `IsEntire`, `maxModulus`, and `nu` are declared as axioms rather than fully formalized, since Lean's Mathlib does not yet have a complete theory of entire functions. The logical relationships between them are faithfully captured.\n\n2. **Concrete definition**: `IsMonomial` is the one fully-defined predicate ($f(z) = cz^n$), providing the boundary case where $\\nu(r) = \\infty$.\n\n3. **Three main results**: The Herzog\u2013Piranian theorem (1968), the open question as a disjunction, and the Gl\u00fccksam\u2013Pardo-Sim\u00f3n approximate result (2024) are each stated as axioms with their precise quantifier structure.\n\n4. **Supporting context**: Monotonicity of $M(r)$ from the maximum modulus principle, and the connection to Hadamard's three-circles theorem.",
+    "historicalContext": "**Maximum Modulus Points and Erdős's Question (1974)**\n\nThis problem appears as Problem 2.16 in W. K. Hayman's influential 1974 collection *\"Research Problems in Function Theory\"*, attributed to Paul Erdős. It belongs to a rich tradition of studying the **maximum modulus function** $M(r) = \\max_{|z|=r} |f(z)|$ of entire functions, dating back to the foundational work of Jacques Hadamard (1896), Anders Wiman (1903), and Gábor Szegő (1920s).\n\nThe maximum modulus principle — that a nonconstant holomorphic function cannot attain its maximum in the interior of its domain — implies that $M(r)$ captures essential boundary behavior. For monomials $f(z) = cz^n$, the modulus $|f(z)| = |c|r^n$ is constant on each circle, so every point is a maximum point. For any other entire function, the maximum is achieved at only finitely many points on each circle.\n\nFritz Herzog and George Piranian (1968) answered the first question: they constructed an entire function with $\\limsup_{r \\to \\infty} \\nu(r) = \\infty$, using lacunary power series whose dominant term rotates, creating many near-maximum points at specific radii. The much harder second question — whether $\\liminf \\nu(r) = \\infty$ is possible — has resisted attack for over 50 years.\n\nIn 2024, Adi Glücksam (Tel Aviv University) and Leticia Pardo-Simón provided the closest approach yet: they showed that for every $\\varepsilon > 0$, one can construct entire functions with many points achieving at least $(1-\\varepsilon) M(r)$ on every sufficiently large circle. Closing the gap from $(1-\\varepsilon)M(r)$ to the exact maximum $M(r)$ remains the key challenge.",
+    "problemStatement": "For a non-monomial entire function $f$, let $\\nu(r) = \\#\\{z : |z| = r,\\, |f(z)| = M(r)\\}$ count the maximum modulus points on the circle of radius $r$.\n\n**Question 1** (Solved): Can $\\limsup_{r \\to \\infty} \\nu(r) = \\infty$? **YES** — Herzog–Piranian (1968).\n\n**Question 2** (Open): Can $\\liminf_{r \\to \\infty} \\nu(r) = \\infty$?\n\n**Approximate answer**: YES in the $(1-\\varepsilon)$ sense — Glücksam–Pardo-Simón (2024).",
+    "text": "For a non-monomial entire f, let ν(r) count maximum modulus points on |z|=r. Can lim sup ν(r) = ∞? YES (Herzog–Piranian 1968). Can lim inf ν(r) = ∞? OPEN. Approximate answer by Glücksam–Pardo-Simón (2024).",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Axiomatized primitives**: `IsEntire`, `maxModulus`, and `nu` are declared as axioms rather than fully formalized, since Lean's Mathlib does not yet have a complete theory of entire functions. The logical relationships between them are faithfully captured.\n\n2. **Concrete definition**: `IsMonomial` is the one fully-defined predicate ($f(z) = cz^n$), providing the boundary case where $\\nu(r) = \\infty$.\n\n3. **Three main results**: The Herzog–Piranian theorem (1968), the open question as a disjunction, and the Glücksam–Pardo-Simón approximate result (2024) are each stated as axioms with their precise quantifier structure.\n\n4. **Supporting context**: Monotonicity of $M(r)$ from the maximum modulus principle, and the connection to Hadamard's three-circles theorem.",
     "keyInsights": [
       "**Monomials as the degenerate case**: For $f(z) = cz^n$, the modulus $|f(z)| = |c|r^n$ is constant on $|z| = r$, so $\\nu(r) = \\infty$. Non-monomials break this rotational symmetry, making $\\nu(r)$ finite. The problem asks how badly the symmetry can be broken while keeping many maximum points.",
-      "**The lim sup vs lim inf gap**: $\\limsup \\nu(r) = \\infty$ means $\\nu(r)$ is occasionally large (along a subsequence of radii). $\\liminf \\nu(r) = \\infty$ means $\\nu(r)$ is eventually always large. The gap between 'occasionally' and 'always' is the fundamental difficulty \u2014 occasional large values can be achieved by engineering the power series to create resonance at specific radii.",
-      "**Wiman\u2013Valiron theory connection**: The maximum modulus theory for entire functions is closely linked to Wiman\u2013Valiron theory, which describes the behavior of $f$ near points where $|f|$ is maximal in terms of the **central index** $N(r)$ (the index of the dominant term in the power series). The central index controls the local geometry of maximum modulus points.",
-      "**The $(1-\\varepsilon)$ barrier**: Gl\u00fccksam and Pardo-Sim\u00f3n showed that **near**-maximum points ($|f(z)| \\ge (1-\\varepsilon)M(r)$) can be made plentiful on every circle. But the exact maximum is achieved on a measure-zero subset of the circle, and perturbing from near-maximum to exact maximum requires fundamentally different techniques.",
-      "**No sorry's \u2014 pure axiomatization**: Unusually for this gallery, the file has 0 sorry's because all mathematical content is axiomatized rather than proved. This reflects the current state of Lean's complex analysis library \u2014 entire function theory is not yet formalized enough for constructive proofs."
+      "**The lim sup vs lim inf gap**: $\\limsup \\nu(r) = \\infty$ means $\\nu(r)$ is occasionally large (along a subsequence of radii). $\\liminf \\nu(r) = \\infty$ means $\\nu(r)$ is eventually always large. The gap between 'occasionally' and 'always' is the fundamental difficulty — occasional large values can be achieved by engineering the power series to create resonance at specific radii.",
+      "**Wiman–Valiron theory connection**: The maximum modulus theory for entire functions is closely linked to Wiman–Valiron theory, which describes the behavior of $f$ near points where $|f|$ is maximal in terms of the **central index** $N(r)$ (the index of the dominant term in the power series). The central index controls the local geometry of maximum modulus points.",
+      "**The $(1-\\varepsilon)$ barrier**: Glücksam and Pardo-Simón showed that **near**-maximum points ($|f(z)| \\ge (1-\\varepsilon)M(r)$) can be made plentiful on every circle. But the exact maximum is achieved on a measure-zero subset of the circle, and perturbing from near-maximum to exact maximum requires fundamentally different techniques.",
+      "**No sorry's — pure axiomatization**: Unusually for this gallery, the file has 0 sorry's because all mathematical content is axiomatized rather than proved. This reflects the current state of Lean's complex analysis library — entire function theory is not yet formalized enough for constructive proofs."
     ],
     "prerequisites": [
       "Combinatorics and number theory",
@@ -85,51 +85,51 @@
     ]
   },
   "conclusion": {
-    "summary": "Erd\u0151s Problem #1117 formalizes a two-part question about the growth of maximum modulus point counts on circles for non-monomial entire functions. Part 1 ($\\limsup \\nu(r) = \\infty$) was solved by Herzog\u2013Piranian in 1968 via lacunary series constructions. Part 2 ($\\liminf \\nu(r) = \\infty$) remains open after more than 50 years, with the best partial result being the 2024 approximate answer by Gl\u00fccksam\u2013Pardo-Sim\u00f3n showing that near-maximum points can be made abundant on every circle.",
-    "implications": "1. **Value distribution theory**: A resolution would advance the classical theory of Nevanlinna, Ahlfors, and Hayman on how entire functions distribute their values, specifically the geometric structure of level sets.\n\n2. **Wiman\u2013Valiron theory extensions**: The problem is intimately connected to how the central index $N(r)$ controls the angular distribution of maximum modulus points, potentially requiring new asymptotic techniques.\n\n**3. Approximation theory**: Understanding the distribution of maximum points connects to best polynomial approximation on circles and the theory of Chebyshev-like extremal problems.\n\n4. **Ergodic aspects**: The $\\liminf$ question has an ergodic flavor \u2014 asking whether a property that holds 'infinitely often' (as in the $\\limsup$ result) can be upgraded to 'eventually always'. This connects to density and recurrence phenomena in dynamical systems.",
+    "summary": "Erdős Problem #1117 formalizes a two-part question about the growth of maximum modulus point counts on circles for non-monomial entire functions. Part 1 ($\\limsup \\nu(r) = \\infty$) was solved by Herzog–Piranian in 1968 via lacunary series constructions. Part 2 ($\\liminf \\nu(r) = \\infty$) remains open after more than 50 years, with the best partial result being the 2024 approximate answer by Glücksam–Pardo-Simón showing that near-maximum points can be made abundant on every circle.",
+    "implications": "1. **Value distribution theory**: A resolution would advance the classical theory of Nevanlinna, Ahlfors, and Hayman on how entire functions distribute their values, specifically the geometric structure of level sets.\n\n2. **Wiman–Valiron theory extensions**: The problem is intimately connected to how the central index $N(r)$ controls the angular distribution of maximum modulus points, potentially requiring new asymptotic techniques.\n\n**3. Approximation theory**: Understanding the distribution of maximum points connects to best polynomial approximation on circles and the theory of Chebyshev-like extremal problems.\n\n4. **Ergodic aspects**: The $\\liminf$ question has an ergodic flavor — asking whether a property that holds 'infinitely often' (as in the $\\limsup$ result) can be upgraded to 'eventually always'. This connects to density and recurrence phenomena in dynamical systems.",
     "openQuestions": [
       "Can $\\liminf_{r \\to \\infty} \\nu(r) = \\infty$ for a non-monomial entire function, or is there an intrinsic obstruction?",
-      "Can the Gl\u00fccksam\u2013Pardo-Sim\u00f3n $(1-\\varepsilon)$ approximate result be strengthened to the exact maximum?",
+      "Can the Glücksam–Pardo-Simón $(1-\\varepsilon)$ approximate result be strengthened to the exact maximum?",
       "What is the typical behavior of $\\nu(r)$ for 'generic' entire functions of given order $\\rho$?",
       "How does the order of growth of $f$ constrain the growth of $\\nu(r)$? Is there a relationship between $\\nu(r)$ and the central index $N(r)$?",
-      "For the Herzog\u2013Piranian construction, what is the density of radii $r$ where $\\nu(r) \\ge N$?"
+      "For the Herzog–Piranian construction, what is the density of radii $r$ where $\\nu(r) \\ge N$?"
     ]
   },
   "crossReferences": [
     {
       "slug": "erdos-513",
-      "title": "Erd\u0151s Problem #513: Maximum Term of a Power Series",
-      "relationship": "Both problems concern the maximum modulus function M(r) = max_{|z|=r} |f(z)| for entire functions. Problem #513 studies the ratio \u03bc(r)/M(r) of the maximum term to maximum modulus, while #1117 studies the count of points achieving M(r). The Wiman\u2013Valiron central index N(r) connects both problems.",
+      "title": "Erdős Problem #513: Maximum Term of a Power Series",
+      "relationship": "Both problems concern the maximum modulus function M(r) = max_{|z|=r} |f(z)| for entire functions. Problem #513 studies the ratio μ(r)/M(r) of the maximum term to maximum modulus, while #1117 studies the count of points achieving M(r). The Wiman–Valiron central index N(r) connects both problems.",
       "targetId": "erdos-513"
     },
     {
       "slug": "erdos-516",
-      "title": "Erd\u0151s Problem #516: Gap Series and the Minimum Modulus Problem",
-      "relationship": "Problem #516 studies minimum modulus m(r) vs maximum modulus M(r) for lacunary (Fabry gap) series. The Herzog\u2013Piranian 1968 construction resolving Problem #1117 Question 1 also uses lacunary power series techniques, creating functions where dominant terms rotate to produce many maximum-modulus points at specific radii.",
+      "title": "Erdős Problem #516: Gap Series and the Minimum Modulus Problem",
+      "relationship": "Problem #516 studies minimum modulus m(r) vs maximum modulus M(r) for lacunary (Fabry gap) series. The Herzog–Piranian 1968 construction resolving Problem #1117 Question 1 also uses lacunary power series techniques, creating functions where dominant terms rotate to produce many maximum-modulus points at specific radii.",
       "targetId": "erdos-516"
     },
     {
       "slug": "erdos-1115",
-      "title": "Erd\u0151s Problem #1115: Path Length for Entire Functions",
-      "relationship": "Neighboring problem from the same 1974 Hayman collection, also studying asymptotic behavior related to M(r). Problem #1115 asks about paths to infinity along which growth is controlled relative to M(r), with Gol'dberg\u2013Eremenko providing the disproof \u2014 sharing the same classical function theory context and authors.",
+      "title": "Erdős Problem #1115: Path Length for Entire Functions",
+      "relationship": "Neighboring problem from the same 1974 Hayman collection, also studying asymptotic behavior related to M(r). Problem #1115 asks about paths to infinity along which growth is controlled relative to M(r), with Gol'dberg–Eremenko providing the disproof — sharing the same classical function theory context and authors.",
       "targetId": "erdos-1115"
     },
     {
       "slug": "erdos-1116",
-      "title": "Erd\u0151s Problem #1116: Extreme Value Distribution of Entire Functions",
-      "relationship": "Direct neighbor in Hayman's collection: Problem #1116 asks whether entire functions can have extreme asymmetry in the counting function n(r,a) of a-points (Nevanlinna theory). Problem #1117 similarly asks about the counting function \u03bd(r) of maximum-modulus points, representing dual aspects of value distribution theory for entire functions.",
+      "title": "Erdős Problem #1116: Extreme Value Distribution of Entire Functions",
+      "relationship": "Direct neighbor in Hayman's collection: Problem #1116 asks whether entire functions can have extreme asymmetry in the counting function n(r,a) of a-points (Nevanlinna theory). Problem #1117 similarly asks about the counting function ν(r) of maximum-modulus points, representing dual aspects of value distribution theory for entire functions.",
       "targetId": "erdos-1116"
     },
     {
       "slug": "erdos-1118",
-      "title": "Erd\u0151s Problem #1118: Entire Functions with Finite Measure Superlevel Sets",
+      "title": "Erdős Problem #1118: Entire Functions with Finite Measure Superlevel Sets",
       "relationship": "Neighboring problem about the geometry of level sets {z : |f(z)| > c}. Problem #1117 counts points on the level set |f(z)| = M(r) (the maximum modulus level set on a circle), while #1118 studies area properties of superlevel sets. Both probe the measure-theoretic and geometric structure of entire function level sets.",
       "targetId": "erdos-1118"
     },
     {
       "slug": "erdos-906",
-      "title": "Erd\u0151s Problem #906: Dense Zeros of Derivative Subsequences",
-      "relationship": "Both problems involve entire functions with remarkable asymptotic or geometric properties that appear hard to achieve simultaneously. Problem #906 asks for transcendental entire functions with dense zeros of derivative subsequences; both exemplify Erd\u0151s's interest in extremal entire function constructions.",
+      "title": "Erdős Problem #906: Dense Zeros of Derivative Subsequences",
+      "relationship": "Both problems involve entire functions with remarkable asymptotic or geometric properties that appear hard to achieve simultaneously. Problem #906 asks for transcendental entire functions with dense zeros of derivative subsequences; both exemplify Erdős's interest in extremal entire function constructions.",
       "targetId": "erdos-906"
     }
   ],
@@ -141,32 +141,32 @@
     },
     {
       "key": "HP68",
-      "citation": "Herzog, F. and Piranian, G. (1968). The counting function for the level sets of meromorphic functions. Michigan Math. J., 15(4), 377\u2013383.",
+      "citation": "Herzog, F. and Piranian, G. (1968). The counting function for the level sets of meromorphic functions. Michigan Math. J., 15(4), 377–383.",
       "type": "paper"
     },
     {
       "key": "GPS24",
-      "citation": "Gl\u00fccksam, A. and Pardo-Sim\u00f3n, L. (2024). On the number of connected components of polynomial lemniscates. arXiv:2412.01234.",
+      "citation": "Glücksam, A. and Pardo-Simón, L. (2024). On the number of connected components of polynomial lemniscates. arXiv:2412.01234.",
       "type": "paper"
     },
     {
       "key": "WV14",
-      "citation": "Wiman, A. (1905). \u00dcber den Zusammenhang zwischen dem Maximalbetrage einer analytischen Funktion und dem gr\u00f6\u00dften Gliede der zugeh\u00f6rigen Taylorschen Reihe. Acta Math., 37, 305\u2013326. [See also: Valiron, G. (1914). Sur les fonctions enti\u00e8res d'ordre nul et d'ordre fini. Ann. Fac. Sci. Toulouse, 5, 117\u2013257.]",
+      "citation": "Wiman, A. (1905). Über den Zusammenhang zwischen dem Maximalbetrage einer analytischen Funktion und dem größten Gliede der zugehörigen Taylorschen Reihe. Acta Math., 37, 305–326. [See also: Valiron, G. (1914). Sur les fonctions entières d'ordre nul et d'ordre fini. Ann. Fac. Sci. Toulouse, 5, 117–257.]",
       "type": "paper"
     },
     {
       "key": "Ne25",
-      "citation": "Nevanlinna, R. (1925). Zur Theorie der meromorphen Funktionen. Acta Math., 46, 1\u201399.",
+      "citation": "Nevanlinna, R. (1925). Zur Theorie der meromorphen Funktionen. Acta Math., 46, 1–99.",
       "type": "paper"
     },
     {
       "key": "Ha89",
-      "citation": "Hayman, W. K. (1989). Subharmonic Functions, Vol. 2. Academic Press. [Chapter 7 covers maximum modulus and Wiman\u2013Valiron theory for entire functions.]",
+      "citation": "Hayman, W. K. (1989). Subharmonic Functions, Vol. 2. Academic Press. [Chapter 7 covers maximum modulus and Wiman–Valiron theory for entire functions.]",
       "type": "book"
     },
     {
       "key": "Be54",
-      "citation": "Bergweiler, W. (review); Iversen, F. (1914). Recherches sur les fonctions inverses des fonctions m\u00e9romorphes. Thesis, Helsingfors. [Background on level sets of meromorphic functions and the inverse function structure underlying \u03bd(r).]",
+      "citation": "Bergweiler, W. (review); Iversen, F. (1914). Recherches sur les fonctions inverses des fonctions méromorphes. Thesis, Helsingfors. [Background on level sets of meromorphic functions and the inverse function structure underlying ν(r).]",
       "type": "paper"
     }
   ],

--- a/src/data/proofs/erdos-112/meta.json
+++ b/src/data/proofs/erdos-112/meta.json
@@ -17,7 +17,7 @@
     "sourceUrl": "https://erdosproblems.com/112",
     "erdosUrl": "https://erdosproblems.com/112",
     "axiomCount": 0,
-    "badge": "wip",
+    "badge": "axiom",
     "assumptions": "0 axioms, 0 sorries. Partial formalization of Directed Ramsey Theory: defines tournament structures and chromatic number concepts. The main open bounds (erdos_112_well_defined, ramsey_lower, hunter_upper) are referenced in comments but not formalized as Lean axioms.",
     "proofRepoPath": "Proofs/Erdos112Problem.lean",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/erdos-1135/meta.json
+++ b/src/data/proofs/erdos-1135/meta.json
@@ -17,7 +17,7 @@
     "sourceUrl": "https://erdosproblems.com/1135",
     "erdosUrl": "https://erdosproblems.com/1135",
     "axiomCount": 0,
-    "badge": "wip",
+    "badge": "axiom",
     "assumptions": "0 axioms, 0 sorries. All results proved from Lean primitives.",
     "proofRepoPath": "Proofs/Erdos1135Problem.lean",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/erdos-1138/meta.json
+++ b/src/data/proofs/erdos-1138/meta.json
@@ -16,7 +16,7 @@
       "analysis",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1138,
     "erdosUrl": "https://erdosproblems.com/1138",

--- a/src/data/proofs/erdos-1139/meta.json
+++ b/src/data/proofs/erdos-1139/meta.json
@@ -16,7 +16,7 @@
       "analytic-number-theory",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1139,
     "erdosUrl": "https://erdosproblems.com/1139",

--- a/src/data/proofs/erdos-114/meta.json
+++ b/src/data/proofs/erdos-114/meta.json
@@ -15,7 +15,7 @@
       "extremal-problems",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/114",
     "erdosUrl": "https://erdosproblems.com/114",

--- a/src/data/proofs/erdos-1155-oq-01-oq-06/meta.json
+++ b/src/data/proofs/erdos-1155-oq-01-oq-06/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "erdos-1155-oq-01-oq-06",
-  "title": "Erd\u0151s #1155 OQ-01-OQ-06: Terminal Graph Structure",
+  "title": "Erdős #1155 OQ-01-OQ-06: Terminal Graph Structure",
   "slug": "erdos-1155-oq-01-oq-06",
-  "description": "Placeholder stub pending full formalization (researcher PR #9455). Planned result: the Tur\u00e1n ratio f(n)/(n\u00b2/4) \u2192 0, showing the terminal graph of the triangle removal process is NOT asymptotically Tur\u00e1n-like. Full formalization will prove 11 theorems (0 sorries) from axioms inherited from the parent file.",
+  "description": "Placeholder stub pending full formalization (researcher PR #9455). Planned result: the Turán ratio f(n)/(n²/4) → 0, showing the terminal graph of the triangle removal process is NOT asymptotically Turán-like. Full formalization will prove 11 theorems (0 sorries) from axioms inherited from the parent file.",
   "meta": {
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://erdosproblems.com/1155",
@@ -21,7 +21,7 @@
       "extension",
       "research"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 10,
@@ -33,12 +33,12 @@
       },
       {
         "theorem": "Real.rpow_le_rpow",
-        "description": "Monotonicity of real power: 0 \u2264 x \u2264 y \u2192 x^r \u2264 y^r for r \u2265 0.",
+        "description": "Monotonicity of real power: 0 ≤ x ≤ y → x^r ≤ y^r for r ≥ 0.",
         "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
       },
       {
         "theorem": "Real.rpow_natCast",
-        "description": "Compatibility: x^(n:\u211d) = x^n for natural number exponents.",
+        "description": "Compatibility: x^(n:ℝ) = x^n for natural number exponents.",
         "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
       },
       {
@@ -48,7 +48,7 @@
       },
       {
         "theorem": "Metric.tendsto_atTop",
-        "description": "Characterize convergence via \u03b5-N metric definition.",
+        "description": "Characterize convergence via ε-N metric definition.",
         "module": "Mathlib.Topology.MetricSpace.Basic"
       }
     ]
@@ -56,8 +56,8 @@
   "sections": [
     {
       "id": "turan-framework",
-      "title": "The Tur\u00e1n Density Framework",
-      "summary": "Defines the Tur\u00e1n bound turanBound(n) = n\u00b2/4 (Mantel's extremal number for triangle-free graphs) and the Tur\u00e1n ratio turanRatio(n) = f(n)/(n\u00b2/4). The ratio measures how Tur\u00e1n-like the terminal graph is. Shows turanBound is positive for n \u2265 1 and turanRatio \u2264 1 (from the Mantel bound).",
+      "title": "The Turán Density Framework",
+      "summary": "Defines the Turán bound turanBound(n) = n²/4 (Mantel's extremal number for triangle-free graphs) and the Turán ratio turanRatio(n) = f(n)/(n²/4). The ratio measures how Turán-like the terminal graph is. Shows turanBound is positive for n ≥ 1 and turanRatio ≤ 1 (from the Mantel bound).",
       "theorems": [
         "turanBound_pos",
         "triangleRemoval_le_turan",
@@ -67,18 +67,18 @@
     },
     {
       "id": "main-structural-result",
-      "title": "Main Result: Terminal Graph Is Not Tur\u00e1n-Like",
-      "summary": "Proves the main structural theorem: for any \u03b4 > 0, eventually f(n) \u2264 \u03b4\u00b7(n\u00b2/4), and consequently turanRatio(n) \u2192 0. The proof uses BFL (\u03b5=1/4) to get f(n) \u2264 n^{7/4}, then shows n^{7/4} \u2264 \u03b4\u00b7n\u00b2/4 for n \u2265 (4/\u03b4)^4, via the estimate n^{1/4} \u2265 4/\u03b4.",
+      "title": "Main Result: Terminal Graph Is Not Turán-Like",
+      "summary": "Proves the main structural theorem: for any δ > 0, eventually f(n) ≤ δ·(n²/4), and consequently turanRatio(n) → 0. The proof uses BFL (ε=1/4) to get f(n) ≤ n^{7/4}, then shows n^{7/4} ≤ δ·n²/4 for n ≥ (4/δ)^4, via the estimate n^{1/4} ≥ 4/δ.",
       "theorems": [
         "terminal_sub_turan",
         "turanRatio_tendsto_zero"
       ],
-      "mathContext": "Key identity: n^{7/4} = n^{1/4} \u00b7 n^{3/2} and n\u00b2 = n^{1/4} \u00b7 n^{7/4} (both via Real.rpow_add). From (4/\u03b4)^4 \u2264 n, monotonicity gives n^{1/4} \u2265 4/\u03b4, hence \u03b4\u00b7n^{1/4}/4 \u2265 1, so n^{7/4} \u2264 (\u03b4\u00b7n^{1/4}/4)\u00b7n^{7/4} = \u03b4\u00b7n\u00b2/4."
+      "mathContext": "Key identity: n^{7/4} = n^{1/4} · n^{3/2} and n² = n^{1/4} · n^{7/4} (both via Real.rpow_add). From (4/δ)^4 ≤ n, monotonicity gives n^{1/4} ≥ 4/δ, hence δ·n^{1/4}/4 ≥ 1, so n^{7/4} ≤ (δ·n^{1/4}/4)·n^{7/4} = δ·n²/4."
     },
     {
       "id": "exponent-gap",
       "title": "Exponent Gap: 3/2 vs 2",
-      "summary": "Formalizes the exponent-level distinction: the terminal graph has exponent 3/2 (BFL) while the Tur\u00e1n maximum has exponent 2 (Mantel). For any \u03b1 \u2208 (3/2, 2), eventually f(n) \u2264 n^\u03b1. The terminal graph eventually has strictly fewer edges than the Tur\u00e1n bound.",
+      "summary": "Formalizes the exponent-level distinction: the terminal graph has exponent 3/2 (BFL) while the Turán maximum has exponent 2 (Mantel). For any α ∈ (3/2, 2), eventually f(n) ≤ n^α. The terminal graph eventually has strictly fewer edges than the Turán bound.",
       "theorems": [
         "turan_exponent_gap",
         "terminal_sub_power",
@@ -87,8 +87,8 @@
     },
     {
       "id": "no-lower-bound",
-      "title": "No Positive Tur\u00e1n Fraction from Below",
-      "summary": "Proves that no constant c > 0 satisfies c\u00b7(n\u00b2/4) \u2264 f(n) eventually. This is the contrapositive of Tur\u00e1n-likeness: the terminal graph cannot be bounded below by any fixed fraction of the Tur\u00e1n density. Equivalently, the turanRatio has no positive lower limit.",
+      "title": "No Positive Turán Fraction from Below",
+      "summary": "Proves that no constant c > 0 satisfies c·(n²/4) ≤ f(n) eventually. This is the contrapositive of Turán-likeness: the terminal graph cannot be bounded below by any fixed fraction of the Turán density. Equivalently, the turanRatio has no positive lower limit.",
       "theorems": [
         "terminal_not_positive_turan_density",
         "bipartite_cannot_be_turan_dense"
@@ -97,46 +97,46 @@
     {
       "id": "open-questions",
       "title": "Open Questions: Bipartiteness and Structure",
-      "summary": "Formally states the bipartiteness question (Is the terminal graph bipartite?) and the Tur\u00e1n ratio monotonicity question. Being bipartite is compatible with the BFL scaling \u2014 a sparse bipartite graph can have n^{3/2} edges. The question is whether the random process produces bipartite graphs.",
+      "summary": "Formally states the bipartiteness question (Is the terminal graph bipartite?) and the Turán ratio monotonicity question. Being bipartite is compatible with the BFL scaling — a sparse bipartite graph can have n^{3/2} edges. The question is whether the random process produces bipartite graphs.",
       "theorems": [
         "structural_summary"
       ]
     }
   ],
   "overview": {
-    "background": "The triangle removal process on K_n terminates with a triangle-free graph G_\u221e. By Mantel's theorem (1907), any triangle-free graph has at most n\u00b2/4 edges, achieved by the complete bipartite Tur\u00e1n graph T(n,2) = K_{n/2,n/2}. The BFL result (2015) shows the terminal graph has only n^{3/2+o(1)} edges \u2014 much less than the Tur\u00e1n maximum.",
-    "mainResult": "The Tur\u00e1n ratio f(n)/(n\u00b2/4) \u2192 0. This means the terminal graph achieves only a vanishing fraction of the maximum possible triangle-free edge density. Qualitatively: the random greedy triangle removal process does NOT produce Tur\u00e1n-like triangle-free graphs.",
-    "historicalContext": "The extremal theory of triangle-free graphs has roots in Mantel's 1907 theorem \u2014 the first Tur\u00e1n-type result \u2014 which showed the maximum number of edges in a triangle-free graph on $n$ vertices is $\\lfloor n^2/4 \\rfloor$, achieved uniquely by the balanced complete bipartite graph $K_{\\lfloor n/2 \\rfloor, \\lceil n/2 \\rceil}$. Tur\u00e1n (1941) generalized this to $K_{r+1}$-free graphs. The triangle removal process was introduced and studied by Bollob\u00e1s, Erd\u0151s, and others in the context of random greedy graph processes. The decisive breakthrough came with Bohman, Frieze, and Lubetzky (BFL, 2015), who proved $f(n) = n^{3/2+o(1)}$ \u2014 far below the Tur\u00e1n maximum $n^2/4$. This entry formalizes the qualitative consequence: the random process terminates far from the Tur\u00e1n extremal structure, ruling out any notion of approximate bipartiteness at the Tur\u00e1n scale.",
+    "background": "The triangle removal process on K_n terminates with a triangle-free graph G_∞. By Mantel's theorem (1907), any triangle-free graph has at most n²/4 edges, achieved by the complete bipartite Turán graph T(n,2) = K_{n/2,n/2}. The BFL result (2015) shows the terminal graph has only n^{3/2+o(1)} edges — much less than the Turán maximum.",
+    "mainResult": "The Turán ratio f(n)/(n²/4) → 0. This means the terminal graph achieves only a vanishing fraction of the maximum possible triangle-free edge density. Qualitatively: the random greedy triangle removal process does NOT produce Turán-like triangle-free graphs.",
+    "historicalContext": "The extremal theory of triangle-free graphs has roots in Mantel's 1907 theorem — the first Turán-type result — which showed the maximum number of edges in a triangle-free graph on $n$ vertices is $\\lfloor n^2/4 \\rfloor$, achieved uniquely by the balanced complete bipartite graph $K_{\\lfloor n/2 \\rfloor, \\lceil n/2 \\rceil}$. Turán (1941) generalized this to $K_{r+1}$-free graphs. The triangle removal process was introduced and studied by Bollobás, Erdős, and others in the context of random greedy graph processes. The decisive breakthrough came with Bohman, Frieze, and Lubetzky (BFL, 2015), who proved $f(n) = n^{3/2+o(1)}$ — far below the Turán maximum $n^2/4$. This entry formalizes the qualitative consequence: the random process terminates far from the Turán extremal structure, ruling out any notion of approximate bipartiteness at the Turán scale.",
     "proofStrategy": "The main theorem `turanRatio_tendsto_zero` follows from `terminal_sub_turan`, which uses the BFL axiom with $\\varepsilon = 1/4$ to get $f(n) \\le n^{7/4}$ eventually, then proves $n^{7/4} \\le \\delta \\cdot n^2/4$ for $n \\ge (4/\\delta)^4$ via real power arithmetic: $n^{7/4} = n^{1/4} \\cdot n^{3/2}$ and $n^2 = n^{1/4} \\cdot n^{7/4}$ (both from `Real.rpow_add`), so the bound reduces to showing $n^{1/4} \\ge 4/\\delta$, which holds when $n \\ge (4/\\delta)^4$ by `Real.rpow_le_rpow`. The tendsto proof uses the $\\varepsilon$-$N$ characterization via `Metric.tendsto_atTop`.",
     "keyInsights": [
-      "The BFL bound $f(n) \\le n^{3/2+\\varepsilon}$ combined with Mantel's bound $f(n) \\le n^2/4$ gives a dramatic exponent gap: $3/2$ versus $2$. The ratio $n^{3/2}/n^2 = n^{-1/2}$ goes to zero, explaining why the Tur\u00e1n ratio vanishes",
+      "The BFL bound $f(n) \\le n^{3/2+\\varepsilon}$ combined with Mantel's bound $f(n) \\le n^2/4$ gives a dramatic exponent gap: $3/2$ versus $2$. The ratio $n^{3/2}/n^2 = n^{-1/2}$ goes to zero, explaining why the Turán ratio vanishes",
       "The proof of `terminal_sub_turan` uses the algebraic decomposition $n^{7/4} = n^{1/4} \\cdot n^{3/2}$ and $n^2 = n^{1/4} \\cdot n^{7/4}$ to isolate the $n^{1/4}$ factor that can be made large, reducing the bound to a threshold estimate $n^{1/4} \\ge 4/\\delta$",
-      "The negative result `terminal_not_positive_turan_density` is proved by contradiction: if some $c > 0$ gave $c \\le \\mathrm{turanRatio}(n)$ eventually, that would contradict `turanRatio_tendsto_zero` (which gives turanRatio $< c/2$ eventually) \u2014 producing two eventually-true statements that eventually have opposite truth values",
+      "The negative result `terminal_not_positive_turan_density` is proved by contradiction: if some $c > 0$ gave $c \\le \\mathrm{turanRatio}(n)$ eventually, that would contradict `turanRatio_tendsto_zero` (which gives turanRatio $< c/2$ eventually) — producing two eventually-true statements that eventually have opposite truth values",
       "The file formally defines two still-open questions as Lean Prop terms (`bipartitenessQuestion`, `turanRatioMonotoneQuestion`), making them machine-checkable specifications that could in principle be proved or refuted in future work",
-      "All proved results are consequences of 5 axioms in the parent file (Erdos1155Problem.lean), notably the BFL bound. The 0-sorry count reflects that all derivable structural consequences are fully formalized \u2014 only the open questions remain as axioms"
+      "All proved results are consequences of 5 axioms in the parent file (Erdos1155Problem.lean), notably the BFL bound. The 0-sorry count reflects that all derivable structural consequences are fully formalized — only the open questions remain as axioms"
     ],
-    "significance": "This resolves the structural question of Tur\u00e1n-proximity in the negative. The terminal graph is 'sparse triangle-free' rather than 'dense triangle-free'. Any complete answer to the structural question (bipartiteness, chromatic number, degree distribution) must be consistent with this extreme sparsity relative to Tur\u00e1n.",
-    "openQuestion": "Whether the terminal graph is bipartite, approximately bipartite, or has some other specific structural property remains open. The vanishing Tur\u00e1n ratio is the principal structural fact currently known."
+    "significance": "This resolves the structural question of Turán-proximity in the negative. The terminal graph is 'sparse triangle-free' rather than 'dense triangle-free'. Any complete answer to the structural question (bipartiteness, chromatic number, degree distribution) must be consistent with this extreme sparsity relative to Turán.",
+    "openQuestion": "Whether the terminal graph is bipartite, approximately bipartite, or has some other specific structural property remains open. The vanishing Turán ratio is the principal structural fact currently known."
   },
   "conclusion": {
-    "summary": "Placeholder stub file on main pending researcher PR #9455. Planned: 294-line formalization of 11 theorems showing Tur\u00e1n ratio f(n)/(n\u00b2/4) \u2192 0, machine-verified using BFL bounds and real power arithmetic.",
-    "implications": "The terminal graph structure of the triangle removal process has implications for extremal graph theory: understanding f(n) and the structure of the terminal graph connects the Tur\u00e1n problem (maximum triangle-free graphs) to the iterative process of removing triangles. The fact that f(n)/(n\u00b2/4) \u2192 0 means the terminal graph is asymptotically far from Tur\u00e1n-dense, suggesting a sharp phase transition in triangle-free graph structure.",
+    "summary": "Placeholder stub file on main pending researcher PR #9455. Planned: 294-line formalization of 11 theorems showing Turán ratio f(n)/(n²/4) → 0, machine-verified using BFL bounds and real power arithmetic.",
+    "implications": "The terminal graph structure of the triangle removal process has implications for extremal graph theory: understanding f(n) and the structure of the terminal graph connects the Turán problem (maximum triangle-free graphs) to the iterative process of removing triangles. The fact that f(n)/(n²/4) → 0 means the terminal graph is asymptotically far from Turán-dense, suggesting a sharp phase transition in triangle-free graph structure.",
     "openQuestions": [
-      "Is the terminal graph of the triangle removal process bipartite (with high probability as n \u2192 \u221e)?",
+      "Is the terminal graph of the triangle removal process bipartite (with high probability as n → ∞)?",
       "What is the chromatic number of the terminal graph?",
-      "Is the Tur\u00e1n ratio f(n)/(n\u00b2/4) monotone decreasing in n?",
+      "Is the Turán ratio f(n)/(n²/4) monotone decreasing in n?",
       "Does the terminal graph have a specific degree distribution (e.g., approximately regular)?"
     ]
   },
   "crossReferences": [
     {
       "id": "erdos-1155",
-      "title": "Erd\u0151s #1155: Triangle Removal Process",
+      "title": "Erdős #1155: Triangle Removal Process",
       "relationship": "parent"
     },
     {
       "id": "erdos-1155-oq-01",
-      "title": "Exact Asymptotics (Erd\u0151s Conjecture)",
+      "title": "Exact Asymptotics (Erdős Conjecture)",
       "relationship": "sibling"
     },
     {
@@ -167,15 +167,15 @@
       ],
       "title": "Problem 28",
       "year": "1907",
-      "note": "Mantel's theorem: triangle-free graphs have at most n\u00b2/4 edges"
+      "note": "Mantel's theorem: triangle-free graphs have at most n²/4 edges"
     },
     {
       "authors": [
-        "P. Tur\u00e1n"
+        "P. Turán"
       ],
       "title": "On an extremal problem in graph theory",
       "year": "1941",
-      "note": "Tur\u00e1n's theorem generalizing Mantel: K_{r+1}-free graphs have at most (1-1/(r))n\u00b2/2 edges"
+      "note": "Turán's theorem generalizing Mantel: K_{r+1}-free graphs have at most (1-1/(r))n²/2 edges"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/erdos-116/meta.json
+++ b/src/data/proofs/erdos-116/meta.json
@@ -14,7 +14,7 @@
       "polynomial theory",
       "measure theory"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 116,
     "erdosUrl": "https://erdosproblems.com/116",

--- a/src/data/proofs/erdos-1161/meta.json
+++ b/src/data/proofs/erdos-1161/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-1161",
-  "title": "Erd\u0151s Problem #1161: Maximizing Permutation Count by Order",
+  "title": "Erdős Problem #1161: Maximizing Permutation Count by Order",
   "slug": "erdos-1161",
   "description": "For permutations of [n], which cyclic orders k maximize the count of permutations having order k? SOLVED by Beker: max_k f_k(n) ~ (n-1)! and the maximizer is characterized by lcm divisibility.",
   "meta": {
-    "author": "Erd\u0151s",
+    "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/1161",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1161Problem.lean",
@@ -15,7 +15,7 @@
       "analysis",
       "solved"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1161,
     "erdosUrl": "https://erdosproblems.com/1161",
@@ -47,9 +47,9 @@
       "permCountByOrder: f_k(n) counting permutations of order k",
       "maxPermCountByOrder: max_k f_k(n) via Finset.sup",
       "lcmRange: lcm(1,...,m) via Finset.lcm",
-      "Beker characterization: f_k(n) \u2265 (n-1)! implies lcm(1,...,n-k) | k",
+      "Beker characterization: f_k(n) ≥ (n-1)! implies lcm(1,...,n-k) | k",
       "Beker maximizer: minimal k with lcm(1,...,n-k) | k achieves (n-1)!",
-      "Asymptotic: max_k f_k(n) \u2265 (n-1)! for n \u2265 2",
+      "Asymptotic: max_k f_k(n) ≥ (n-1)! for n ≥ 2",
       "Prime cycle counting: for prime p, permCountByOrder p p = (p-1)! (proved via cycleType characterization)",
       "Small cases: explicit counts for S_1, S_2, S_3"
     ],
@@ -58,12 +58,12 @@
     "assumptions": "0 axioms, 0 sorries. All results proved from Lean primitives."
   },
   "overview": {
-    "historicalContext": "The distribution of permutation orders is a classical topic in probabilistic group theory initiated by Erd\u0151s and Tur\u00e1n in their 1965 series of papers. They proved that for a random permutation $\\sigma \\in S_n$, $\\log(\\mathrm{ord}(\\sigma))$ is approximately normally distributed with mean $\\frac{1}{2}(\\log n)^2$ and variance $\\frac{1}{3}(\\log n)^3$\u2014the celebrated Erd\u0151s-Tur\u00e1n law.\n\nProblem #1161 asks a different but related question: among all possible orders $k$, which value of $k$ maximizes the count $f_k(n) = |\\{\\sigma \\in S_n : \\mathrm{ord}(\\sigma) = k\\}|$? This was listed as Problem 5.72 in Vardi's \"Computational Recreations in Mathematica\" (1999) and on the Erd\u0151s Problems database.\n\nThe problem was resolved by Beker, who proved three precise results: (1) $\\max_{k \\geq 1} f_k(n) \\sim (n-1)!$ as $n \\to \\infty$, meaning the maximum count is asymptotically the number of $(n-1)$-cycles; (2) for large $n$, if $f_k(n) \\geq (n-1)!$ then $\\mathrm{lcm}(1, \\ldots, n-k)$ divides $k$; (3) the maximum is achieved precisely when $k$ is the minimal positive integer satisfying this lcm divisibility condition.\n\nThe connection between the maximizer and the lcm function is surprising and deep, linking the combinatorial structure of cycle types to number-theoretic properties of the least common multiple.\n\n**Status**: SOLVED (Beker [Be25d]).",
+    "historicalContext": "The distribution of permutation orders is a classical topic in probabilistic group theory initiated by Erdős and Turán in their 1965 series of papers. They proved that for a random permutation $\\sigma \\in S_n$, $\\log(\\mathrm{ord}(\\sigma))$ is approximately normally distributed with mean $\\frac{1}{2}(\\log n)^2$ and variance $\\frac{1}{3}(\\log n)^3$—the celebrated Erdős-Turán law.\n\nProblem #1161 asks a different but related question: among all possible orders $k$, which value of $k$ maximizes the count $f_k(n) = |\\{\\sigma \\in S_n : \\mathrm{ord}(\\sigma) = k\\}|$? This was listed as Problem 5.72 in Vardi's \"Computational Recreations in Mathematica\" (1999) and on the Erdős Problems database.\n\nThe problem was resolved by Beker, who proved three precise results: (1) $\\max_{k \\geq 1} f_k(n) \\sim (n-1)!$ as $n \\to \\infty$, meaning the maximum count is asymptotically the number of $(n-1)$-cycles; (2) for large $n$, if $f_k(n) \\geq (n-1)!$ then $\\mathrm{lcm}(1, \\ldots, n-k)$ divides $k$; (3) the maximum is achieved precisely when $k$ is the minimal positive integer satisfying this lcm divisibility condition.\n\nThe connection between the maximizer and the lcm function is surprising and deep, linking the combinatorial structure of cycle types to number-theoretic properties of the least common multiple.\n\n**Status**: SOLVED (Beker [Be25d]).",
     "problemStatement": "**Problem Statement**\n\nLet $f_k(n) = |\\{\\sigma \\in S_n : \\mathrm{ord}(\\sigma) = k\\}|$ denote the number of permutations in $S_n$ having order exactly $k$.\n\nFor which values of $k$ is $f_k(n)$ maximized?\n\n**Answer (Beker)**:\n- $\\max_{k \\geq 1} f_k(n) \\sim (n-1)!$ as $n \\to \\infty$\n- For large $n$: $f_k(n) \\geq (n-1)!$ iff $\\mathrm{lcm}(1, \\ldots, n-k) \\mid k$\n- The maximizer is the minimal such $k$\n\n**Status**: SOLVED",
     "text": "For permutations of [n], which cyclic orders k maximize the count of permutations having order k? SOLVED by Beker: max_k f_k(n) ~ (n-1)! and the maximizer is characterized by lcm divisibility.",
     "proofStrategy": "**Formalization Strategy**\n\nThe Lean file formalizes the problem in 332 lines with 14 proved theorems and 2 axioms:\n\n1. **Core definitions**: $f_k(n)$ = `permCountByOrder`, $\\max_k f_k(n)$ = `maxPermCountByOrder`, $\\mathrm{lcm}(1,\\ldots,m)$ = `lcmRange`\n2. **Basic properties** (all proved): identity has order 1, order divides $n!$, total count equals $n!$, $f_k(n) = 0$ if $k \\nmid n!$\n3. **Small cases** (all proved): explicit counts for $S_1$, $S_2$, $S_3$ via `decide`\n4. **Beker's results** (axioms): characterization and maximizer theorems from [Be25d]\n5. **Key theorem** (proved, axiom-independent): `max_permCount_ge_sub_factorial` via direct n-cycle counting\n6. **Structural lemmas** (all proved): prime cycle counting, lcmRange monotonicity and divisibility",
     "keyInsights": [
-      "The order of a permutation $\\sigma \\in S_n$ equals the lcm of its cycle lengths, so the distribution of orders is controlled by the distribution of cycle types\u2014a classical combinatorial object",
+      "The order of a permutation $\\sigma \\in S_n$ equals the lcm of its cycle lengths, so the distribution of orders is controlled by the distribution of cycle types—a classical combinatorial object",
       "The maximum $\\max_k f_k(n) \\sim (n-1)!$ means the most common order has almost as many representatives as there are $(n-1)$-cycles, suggesting the maximizer is close to $n$ itself",
       "Beker's lcm divisibility condition $\\mathrm{lcm}(1, \\ldots, n-k) \\mid k$ provides a precise arithmetic characterization of which orders $k$ can achieve the maximum count",
       "The function lcmRange$(m) = \\mathrm{lcm}(1, \\ldots, m)$ grows like $e^m$ by the prime number theorem ($\\log \\mathrm{lcm}(1,\\ldots,m) \\sim m$), controlling how the maximizer $k$ relates to $n$",
@@ -101,7 +101,7 @@
     {
       "id": "beker-results",
       "title": "Beker's Main Results",
-      "summary": "States the three key results resolving the problem: (1) `beker_characterization`\u2014if $f_k(n) \\geq (n-1)!$ then $\\mathrm{lcm}(1,\\ldots,n-k) \\mid k$; (2) `beker_maximizer_achieves`\u2014the minimal $k$ with this property achieves exactly $(n-1)!$; (3) `max_permCount_ge_sub_factorial`\u2014there exists $k$ with $f_k(n) \\geq (n-1)!$.",
+      "summary": "States the three key results resolving the problem: (1) `beker_characterization`—if $f_k(n) \\geq (n-1)!$ then $\\mathrm{lcm}(1,\\ldots,n-k) \\mid k$; (2) `beker_maximizer_achieves`—the minimal $k$ with this property achieves exactly $(n-1)!$; (3) `max_permCount_ge_sub_factorial`—there exists $k$ with $f_k(n) \\geq (n-1)!$.",
       "startLine": 97,
       "endLine": 134
     },
@@ -114,11 +114,11 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erd\u0151s Problem #1161 in full: the definition of $f_k(n)$ counting permutations of order $k$, Beker's resolution showing $\\max_k f_k(n) \\sim (n-1)!$ with the maximizer characterized by the lcm divisibility condition $\\mathrm{lcm}(1,\\ldots,n-k) \\mid k$, basic properties proved directly in Lean (order divides $n!$, identity has order 1), and structural lemmas about the lcm function.",
-    "implications": "1. **Probabilistic Group Theory**: Connects to the Erd\u0151s-Tur\u00e1n law on the distribution of permutation orders, now complemented by precise extremal results\n\n**2. Analytic Combinatorics**: The asymptotic $(n-1)!$ reveals that the most common order has an exponentially large count, nearly matching the count of $n$-cycles\n\n3. **Number Theory Meets Combinatorics**: The characterization via $\\mathrm{lcm}(1,\\ldots,m)$ divisibility is a surprising connection between the arithmetic of the lcm function and the cycle structure of permutations\n\n4. **Prime Number Theorem Connection**: Since $\\log \\mathrm{lcm}(1,\\ldots,m) \\sim m$ (by PNT), the lcm condition controls which orders $k$ can be maximizers, linking this problem to deep results in analytic number theory.",
+    "summary": "This formalization captures Erdős Problem #1161 in full: the definition of $f_k(n)$ counting permutations of order $k$, Beker's resolution showing $\\max_k f_k(n) \\sim (n-1)!$ with the maximizer characterized by the lcm divisibility condition $\\mathrm{lcm}(1,\\ldots,n-k) \\mid k$, basic properties proved directly in Lean (order divides $n!$, identity has order 1), and structural lemmas about the lcm function.",
+    "implications": "1. **Probabilistic Group Theory**: Connects to the Erdős-Turán law on the distribution of permutation orders, now complemented by precise extremal results\n\n**2. Analytic Combinatorics**: The asymptotic $(n-1)!$ reveals that the most common order has an exponentially large count, nearly matching the count of $n$-cycles\n\n3. **Number Theory Meets Combinatorics**: The characterization via $\\mathrm{lcm}(1,\\ldots,m)$ divisibility is a surprising connection between the arithmetic of the lcm function and the cycle structure of permutations\n\n4. **Prime Number Theorem Connection**: Since $\\log \\mathrm{lcm}(1,\\ldots,m) \\sim m$ (by PNT), the lcm condition controls which orders $k$ can be maximizers, linking this problem to deep results in analytic number theory.",
     "openQuestions": [
       "What is the exact second-order term in max_k f_k(n) - (n-1)!?",
-      "How many values of k achieve f_k(n) \u2265 (n-1)! for a given n?",
+      "How many values of k achieve f_k(n) ≥ (n-1)! for a given n?",
       "Can the sorry placeholders (small cases, sum formula) be filled with decidable computations?",
       "What is the analogous result for other finite groups beyond S_n?"
     ]
@@ -163,7 +163,7 @@
     },
     {
       "key": "ET65",
-      "citation": "Erd\u0151s, P. and Tur\u00e1n, P. (1965). On some problems of a statistical group-theory, I. Zeitschrift f\u00fcr Wahrscheinlichkeitstheorie, 4, 175-186.",
+      "citation": "Erdős, P. and Turán, P. (1965). On some problems of a statistical group-theory, I. Zeitschrift für Wahrscheinlichkeitstheorie, 4, 175-186.",
       "type": "paper"
     }
   ],
@@ -171,17 +171,17 @@
     {
       "targetId": "erdos-1138",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: analysis, combinatorics, number-theory"
+      "description": "Related Erdős problem sharing themes: analysis, combinatorics, number-theory"
     },
     {
       "targetId": "erdos-1166",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: analysis, combinatorics, solved"
+      "description": "Related Erdős problem sharing themes: analysis, combinatorics, solved"
     },
     {
       "targetId": "erdos-1179",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: analysis, combinatorics, solved"
+      "description": "Related Erdős problem sharing themes: analysis, combinatorics, solved"
     }
   ],
   "sorries": 0

--- a/src/data/proofs/erdos-1168/meta.json
+++ b/src/data/proofs/erdos-1168/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "erdos-1168",
-  "title": "Erd\u0151s Problem #1168: Negative Partition Relation for \u2135_{\u03c9+1}",
+  "title": "Erdős Problem #1168: Negative Partition Relation for ℵ_{ω+1}",
   "slug": "erdos-1168",
-  "description": "Prove \u2135_{\u03c9+1} \u219b (\u2135_{\u03c9+1}, 3, \u2026, 3)_{\u2135\u2080}\u00b2 without GCH. Open problem in set-theoretic combinatorics at the intersection of partition calculus and pcf theory.",
+  "description": "Prove ℵ_{ω+1} ↛ (ℵ_{ω+1}, 3, …, 3)_{ℵ₀}² without GCH. Open problem in set-theoretic combinatorics at the intersection of partition calculus and pcf theory.",
   "meta": {
     "erdosNumber": 1168,
     "status": "axiomatized",
@@ -19,26 +19,26 @@
     "sourceUrl": "https://erdosproblems.com/1168",
     "erdosUrl": "https://erdosproblems.com/1168",
     "erdosProblemStatus": "open",
-    "badge": "wip",
+    "badge": "axiom",
     "axiomCount": 0,
     "lineCount": 255,
     "theoremCount": 11,
     "definitionCount": 9,
-    "assumptions": "0 axioms (previous axiom replaced with theorem + stepping-up decomposition). 2 sorries: base_case_under_gch (Erd\u0151s-Rado base case), stepping_up (stepping-up lemma). Open conjecture is a def, not an axiom.",
+    "assumptions": "0 axioms (previous axiom replaced with theorem + stepping-up decomposition). 2 sorries: base_case_under_gch (Erdős-Rado base case), stepping_up (stepping-up lemma). Open conjecture is a def, not an axiom.",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-03-28"
   },
   "overview": {
-    "historicalContext": "Partition calculus \u2014 the study of the arrow notation \u03ba \u2192 (\u03b1)\u00b2_\u03bb \u2014 was systematically developed by Erd\u0151s and Rado in their 1956 paper 'A partition calculus in set theory.' The notation \u03ba \u2192 (\u03b1\u2080, \u03b1\u2081, \u2026)\u00b2_c (due to Erd\u0151s-Hajnal-Rado 1965) means: for any c-coloring of 2-element subsets of \u03ba, there exists a color i and a homogeneous set of size \u03b1\u1d62. The problem of negative partition relations for \u2135_{\u03c9+1} \u2014 the successor of the first singular cardinal \u2135_\u03c9 \u2014 sits at the heart of 'pcf theory' (possible cofinalities), developed by Shelah in the 1970s-1980s. The singular nature of \u2135_\u03c9 (it is the supremum of the sequence \u2135_0, \u2135_1, \u2135_2, \u2026 with countable cofinality) gives its successor special combinatorial properties. Under GCH, the desired negative partition relation follows from the Erd\u0151s-Hajnal-Rado 'stepping-up lemma' applied at \u2135_\u03c9. Proving it in ZFC alone \u2014 without assuming GCH \u2014 requires the much deeper structural theory of singular cardinals that Shelah pioneered. Shelah's 1992 result that \u2135_\u03c9^{\u2135_0} < \u2135_{\u03c9_4} (provable in ZFC) exemplifies the power of pcf theory for such problems.",
-    "problemStatement": "Prove in ZFC (without assuming GCH) that\n$$\\aleph_{\\omega+1} \\not\\to (\\aleph_{\\omega+1}, 3, 3, \\ldots)^2_{\\aleph_0}$$\nThat is, there exists a coloring $f : [\\aleph_{\\omega+1}]^2 \\to \\omega$ of 2-element subsets using countably many colors such that:\n- Color 0: has no monochromatic set of cardinality $\\aleph_{\\omega+1}$\n- Colors $i \\geq 1$: each has no monochromatic triangle (3-element set)\n\nFormal Lean definition: `\u00ac partitionRelation aleph_omega_succ targets` where `targets 0 = \u2135_{\u03c9+1}` and `targets (i+1) = 3`.",
-    "proofStrategy": "The file decomposes the known GCH result into a stepping-up framework with two clear subgoals: (1) base_case_under_gch \u2014 under GCH, each \u2135_{n+1} has a 2-coloring where color 0 avoids homogeneous sets of size \u2135_{n+1} and color 1 avoids cliques of size n+3; (2) stepping_up \u2014 these base colorings combine into a countably-colored partition of \u2135_{\u03c9+1} witnessing the negative relation. The theorem erdos_1168_under_gch is proved by composing these two (sorry) lemmas. Cardinal infrastructure is proved from Mathlib: \u2135_{\u03c9+1} is regular, cf(\u2135_\u03c9) = \u2135\u2080, \u2135_n < \u2135_\u03c9 < \u2135_{\u03c9+1}. The open conjecture (ZFC-only proof) is formalized as a Lean Prop without being asserted.",
+    "historicalContext": "Partition calculus — the study of the arrow notation κ → (α)²_λ — was systematically developed by Erdős and Rado in their 1956 paper 'A partition calculus in set theory.' The notation κ → (α₀, α₁, …)²_c (due to Erdős-Hajnal-Rado 1965) means: for any c-coloring of 2-element subsets of κ, there exists a color i and a homogeneous set of size αᵢ. The problem of negative partition relations for ℵ_{ω+1} — the successor of the first singular cardinal ℵ_ω — sits at the heart of 'pcf theory' (possible cofinalities), developed by Shelah in the 1970s-1980s. The singular nature of ℵ_ω (it is the supremum of the sequence ℵ_0, ℵ_1, ℵ_2, … with countable cofinality) gives its successor special combinatorial properties. Under GCH, the desired negative partition relation follows from the Erdős-Hajnal-Rado 'stepping-up lemma' applied at ℵ_ω. Proving it in ZFC alone — without assuming GCH — requires the much deeper structural theory of singular cardinals that Shelah pioneered. Shelah's 1992 result that ℵ_ω^{ℵ_0} < ℵ_{ω_4} (provable in ZFC) exemplifies the power of pcf theory for such problems.",
+    "problemStatement": "Prove in ZFC (without assuming GCH) that\n$$\\aleph_{\\omega+1} \\not\\to (\\aleph_{\\omega+1}, 3, 3, \\ldots)^2_{\\aleph_0}$$\nThat is, there exists a coloring $f : [\\aleph_{\\omega+1}]^2 \\to \\omega$ of 2-element subsets using countably many colors such that:\n- Color 0: has no monochromatic set of cardinality $\\aleph_{\\omega+1}$\n- Colors $i \\geq 1$: each has no monochromatic triangle (3-element set)\n\nFormal Lean definition: `¬ partitionRelation aleph_omega_succ targets` where `targets 0 = ℵ_{ω+1}` and `targets (i+1) = 3`.",
+    "proofStrategy": "The file decomposes the known GCH result into a stepping-up framework with two clear subgoals: (1) base_case_under_gch — under GCH, each ℵ_{n+1} has a 2-coloring where color 0 avoids homogeneous sets of size ℵ_{n+1} and color 1 avoids cliques of size n+3; (2) stepping_up — these base colorings combine into a countably-colored partition of ℵ_{ω+1} witnessing the negative relation. The theorem erdos_1168_under_gch is proved by composing these two (sorry) lemmas. Cardinal infrastructure is proved from Mathlib: ℵ_{ω+1} is regular, cf(ℵ_ω) = ℵ₀, ℵ_n < ℵ_ω < ℵ_{ω+1}. The open conjecture (ZFC-only proof) is formalized as a Lean Prop without being asserted.",
     "keyInsights": [
-      "The arrow notation \u2135_{\u03c9+1} \u219b (\u2135_{\u03c9+1}, 3, 3, \u2026)\u00b2_{\u2135\u2080} packs a complex combinatorial statement: there is a 'wild' countably-colored Ramsey coloring of pairs from \u2135_{\u03c9+1} where no single color achieves its target homogeneous set. Color 0 fails at \u2135_{\u03c9+1} (a large homogeneous set), while colors 1, 2, \u2026 fail at triangles (a small target).",
-      "The singularity of \u2135_\u03c9 \u2014 specifically its cofinality cf(\u2135_\u03c9) = \u2135_0 \u2014 is the key feature making \u2135_{\u03c9+1} interesting. Successor cardinals of regular cardinals (like \u2135_2 = (\u2135_1)\u207a) behave differently from successors of singular cardinals. The 'singular cardinal hypothesis' (a strengthening of GCH for singular cardinals) is independent of ZFC, making the problem delicate.",
-      "Under GCH, the result uses the stepping-up lemma: if \u2135_\u03c9 \u219b (\u2135_\u03c9, 3, \u2026)\u00b2_{\u2135_0} holds, then \u2135_{\u03c9+1} \u219b (\u2135_{\u03c9+1}, 3, \u2026)\u00b2_{\u2135_0} follows. GCH gives good control over cardinal arithmetic at \u2135_\u03c9. Without GCH, one must instead use pcf theory to control possible values of \u2135_\u03c9^{\u2135_0}.",
-      "pcf theory (Shelah) is the main candidate tool for a ZFC proof. For a set A of regular cardinals, pcf(A) = {cf(\u220fA/U) : U ultrafilter on A} is the set of possible cofinalities. Shelah proved that |pcf({\u2135_n : n < \u03c9})| < \u2135_\u03c9 (in ZFC!), which gives cardinal arithmetic results without GCH. Whether this is enough to prove Problem 1168 in ZFC is the core difficulty.",
-      "The Lean formalization is exemplary: IsHomogeneous uses a symmetric relation (f a b = i for all distinct a, b in S), and partitionRelation is universe-polymorphic (works for any type V with cardinality \u03ba). The five proved theorems cover the basic combinatorial properties without requiring any set-theoretic set theory beyond Mathlib's cardinal library.",
-      "The target function uses Lean's `fun | 0 => ... | _ + 1 => ...` pattern matching to define countably many targets: color 0 targets \u2135_{\u03c9+1} (the big homogeneous set) and all other colors target 3 (triangles). This clean encoding shows that Lean's dependent type system handles the countable-color partition relation naturally."
+      "The arrow notation ℵ_{ω+1} ↛ (ℵ_{ω+1}, 3, 3, …)²_{ℵ₀} packs a complex combinatorial statement: there is a 'wild' countably-colored Ramsey coloring of pairs from ℵ_{ω+1} where no single color achieves its target homogeneous set. Color 0 fails at ℵ_{ω+1} (a large homogeneous set), while colors 1, 2, … fail at triangles (a small target).",
+      "The singularity of ℵ_ω — specifically its cofinality cf(ℵ_ω) = ℵ_0 — is the key feature making ℵ_{ω+1} interesting. Successor cardinals of regular cardinals (like ℵ_2 = (ℵ_1)⁺) behave differently from successors of singular cardinals. The 'singular cardinal hypothesis' (a strengthening of GCH for singular cardinals) is independent of ZFC, making the problem delicate.",
+      "Under GCH, the result uses the stepping-up lemma: if ℵ_ω ↛ (ℵ_ω, 3, …)²_{ℵ_0} holds, then ℵ_{ω+1} ↛ (ℵ_{ω+1}, 3, …)²_{ℵ_0} follows. GCH gives good control over cardinal arithmetic at ℵ_ω. Without GCH, one must instead use pcf theory to control possible values of ℵ_ω^{ℵ_0}.",
+      "pcf theory (Shelah) is the main candidate tool for a ZFC proof. For a set A of regular cardinals, pcf(A) = {cf(∏A/U) : U ultrafilter on A} is the set of possible cofinalities. Shelah proved that |pcf({ℵ_n : n < ω})| < ℵ_ω (in ZFC!), which gives cardinal arithmetic results without GCH. Whether this is enough to prove Problem 1168 in ZFC is the core difficulty.",
+      "The Lean formalization is exemplary: IsHomogeneous uses a symmetric relation (f a b = i for all distinct a, b in S), and partitionRelation is universe-polymorphic (works for any type V with cardinality κ). The five proved theorems cover the basic combinatorial properties without requiring any set-theoretic set theory beyond Mathlib's cardinal library.",
+      "The target function uses Lean's `fun | 0 => ... | _ + 1 => ...` pattern matching to define countably many targets: color 0 targets ℵ_{ω+1} (the big homogeneous set) and all other colors target 3 (triangles). This clean encoding shows that Lean's dependent type system handles the countable-color partition relation naturally."
     ]
   },
   "sections": [
@@ -47,14 +47,14 @@
       "title": "Problem Statement and Context",
       "startLine": 1,
       "endLine": 34,
-      "summary": "Docstring stating Erd\u0151s Problem #1168: prove \u2135_{\u03c9+1} \u219b (\u2135_{\u03c9+1}, 3, \u2026, 3)\u00b2_{\u2135\u2080} in ZFC without GCH. Provides context: GCH case known via Erd\u0151s-Hajnal-Rado, ZFC case requires pcf theory (Shelah)."
+      "summary": "Docstring stating Erdős Problem #1168: prove ℵ_{ω+1} ↛ (ℵ_{ω+1}, 3, …, 3)²_{ℵ₀} in ZFC without GCH. Provides context: GCH case known via Erdős-Hajnal-Rado, ZFC case requires pcf theory (Shelah)."
     },
     {
       "id": "cardinals",
       "title": "Part I: Cardinal Infrastructure",
       "startLine": 37,
       "endLine": 78,
-      "summary": "Defines aleph_omega and aleph_omega_succ. Proves 6 cardinal facts from Mathlib: \u2135_{\u03c9+1} = aleph(succ \u03c9), \u2135_{\u03c9+1} is regular, cf(\u2135_\u03c9) = \u2135\u2080, \u2135_\u03c9 < \u2135_{\u03c9+1}, \u2135\u2080 < \u2135_\u03c9, \u2135_n < \u2135_\u03c9 for all n."
+      "summary": "Defines aleph_omega and aleph_omega_succ. Proves 6 cardinal facts from Mathlib: ℵ_{ω+1} = aleph(succ ω), ℵ_{ω+1} is regular, cf(ℵ_ω) = ℵ₀, ℵ_ω < ℵ_{ω+1}, ℵ₀ < ℵ_ω, ℵ_n < ℵ_ω for all n."
     },
     {
       "id": "partition-framework",
@@ -68,7 +68,7 @@
       "title": "Part IV: GCH Stepping-Up Framework",
       "startLine": 120,
       "endLine": 189,
-      "summary": "Decomposes the GCH proof into base_case_under_gch (sorry: Erd\u0151s-Rado for each \u2135_{n+1}), stepping_up (sorry: combines base colorings into \u2135\u2080-coloring of \u2135_{\u03c9+1}), and erdos_1168_under_gch (proved by composition). Also defines GCH_at, GCH, and negPartition2."
+      "summary": "Decomposes the GCH proof into base_case_under_gch (sorry: Erdős-Rado for each ℵ_{n+1}), stepping_up (sorry: combines base colorings into ℵ₀-coloring of ℵ_{ω+1}), and erdos_1168_under_gch (proved by composition). Also defines GCH_at, GCH, and negPartition2."
     },
     {
       "id": "structural-theorems",
@@ -121,13 +121,13 @@
     }
   ],
   "conclusion": {
-    "summary": "This file provides a clean Lean 4 formalization of Erd\u0151s Problem #1168: the open question of whether \u2135_{\u03c9+1} \u219b (\u2135_{\u03c9+1}, 3, 3, \u2026)\u00b2_{\u2135\u2080} holds in ZFC. The GCH case is decomposed into two sorry lemmas (base_case_under_gch and stepping_up), the open conjecture is defined as a Lean Prop, and ten structural theorems and cardinal facts are proved. The file correctly represents the state of the art: the ZFC case is open.",
-    "implications": "A ZFC proof of Erd\u0151s 1168 would be a significant advance in set-theoretic combinatorics, demonstrating that pcf theory can resolve partition relation questions that previously required GCH. It would also provide a non-trivial theorem in Lean about large cardinals (at the level of \u2135_\u03c9 and its successor), extending Mathlib's cardinal library into research territory. Such a formalization would likely require encoding Shelah's pcf theory \u2014 a substantial Lean project in its own right.",
+    "summary": "This file provides a clean Lean 4 formalization of Erdős Problem #1168: the open question of whether ℵ_{ω+1} ↛ (ℵ_{ω+1}, 3, 3, …)²_{ℵ₀} holds in ZFC. The GCH case is decomposed into two sorry lemmas (base_case_under_gch and stepping_up), the open conjecture is defined as a Lean Prop, and ten structural theorems and cardinal facts are proved. The file correctly represents the state of the art: the ZFC case is open.",
+    "implications": "A ZFC proof of Erdős 1168 would be a significant advance in set-theoretic combinatorics, demonstrating that pcf theory can resolve partition relation questions that previously required GCH. It would also provide a non-trivial theorem in Lean about large cardinals (at the level of ℵ_ω and its successor), extending Mathlib's cardinal library into research territory. Such a formalization would likely require encoding Shelah's pcf theory — a substantial Lean project in its own right.",
     "openQuestions": [
-      "Can pcf theory be encoded in Lean 4 using Mathlib's existing ordinal and cardinal infrastructure? The key pcf result needed is |pcf({\u2135_n : n < \u03c9})| < \u2135_\u03c9 \u2014 can this be proved in Lean from ZFC?",
-      "Is there a simpler combinatorial proof of Erd\u0151s 1168 not going through pcf theory, perhaps using a direct Ramsey-theoretic construction of the required coloring?",
-      "Does the Lean formulation of partitionRelation correctly capture the set-theoretic partition relation \u03ba \u2192 (\u03b1\u2080, \u03b1\u2081, \u2026)\u00b2_c? In particular, does the use of a Lean type V with #V = \u03ba accurately model the ordinal-based version?",
-      "Can the stepping-up lemma (used in the GCH proof) be formalized in Lean 4 using Mathlib's cardinal arithmetic, and would it suffice to prove Erd\u0151s 1168 under a weaker assumption than full GCH?"
+      "Can pcf theory be encoded in Lean 4 using Mathlib's existing ordinal and cardinal infrastructure? The key pcf result needed is |pcf({ℵ_n : n < ω})| < ℵ_ω — can this be proved in Lean from ZFC?",
+      "Is there a simpler combinatorial proof of Erdős 1168 not going through pcf theory, perhaps using a direct Ramsey-theoretic construction of the required coloring?",
+      "Does the Lean formulation of partitionRelation correctly capture the set-theoretic partition relation κ → (α₀, α₁, …)²_c? In particular, does the use of a Lean type V with #V = κ accurately model the ordinal-based version?",
+      "Can the stepping-up lemma (used in the GCH proof) be formalized in Lean 4 using Mathlib's cardinal arithmetic, and would it suffice to prove Erdős 1168 under a weaker assumption than full GCH?"
     ]
   },
   "leanFile": {

--- a/src/data/proofs/erdos-117/meta.json
+++ b/src/data/proofs/erdos-117/meta.json
@@ -15,7 +15,7 @@
       "covering-number",
       "Ramsey-theory"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 117,
     "erdosUrl": "https://erdosproblems.com/117",

--- a/src/data/proofs/erdos-1173/meta.json
+++ b/src/data/proofs/erdos-1173/meta.json
@@ -14,7 +14,7 @@
       "set-theory",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1173,
     "erdosUrl": "https://erdosproblems.com/1173",

--- a/src/data/proofs/erdos-1174/meta.json
+++ b/src/data/proofs/erdos-1174/meta.json
@@ -16,7 +16,7 @@
       "ramsey-theory",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1174,
     "erdosUrl": "https://erdosproblems.com/1174",

--- a/src/data/proofs/erdos-1183/meta.json
+++ b/src/data/proofs/erdos-1183/meta.json
@@ -16,7 +16,7 @@
       "lattice-theory",
       "powerset"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1183,
     "erdosUrl": "https://erdosproblems.com/1183",

--- a/src/data/proofs/erdos-119/meta.json
+++ b/src/data/proofs/erdos-119/meta.json
@@ -15,7 +15,7 @@
       "unit-circle",
       "extremal-problems"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 119,
     "erdosUrl": "https://erdosproblems.com/119",

--- a/src/data/proofs/erdos-12/meta.json
+++ b/src/data/proofs/erdos-12/meta.json
@@ -16,7 +16,7 @@
       "density",
       "additive-combinatorics"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 12,
     "erdosUrl": "https://erdosproblems.com/12",

--- a/src/data/proofs/erdos-121/meta.json
+++ b/src/data/proofs/erdos-121/meta.json
@@ -15,7 +15,7 @@
       "multiplicative number theory",
       "extremal"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 121,
     "erdosUrl": "https://erdosproblems.com/121",

--- a/src/data/proofs/erdos-124/meta.json
+++ b/src/data/proofs/erdos-124/meta.json
@@ -16,7 +16,7 @@
       "additive-combinatorics",
       "complete-sequences"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 124,
     "erdosUrl": "https://erdosproblems.com/124",

--- a/src/data/proofs/erdos-125/meta.json
+++ b/src/data/proofs/erdos-125/meta.json
@@ -15,7 +15,7 @@
       "density",
       "additive-combinatorics"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 125,
     "erdosUrl": "https://erdosproblems.com/125",

--- a/src/data/proofs/erdos-128/meta.json
+++ b/src/data/proofs/erdos-128/meta.json
@@ -18,7 +18,7 @@
     "erdosUrl": "https://erdosproblems.com/128",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "badge": "wip",
+    "badge": "axiom",
     "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean.",
     "proofRepoPath": "Proofs/Erdos128Problem.lean",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/erdos-129/meta.json
+++ b/src/data/proofs/erdos-129/meta.json
@@ -15,7 +15,7 @@
       "combinatorics",
       "edge-coloring"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 129,
     "erdosUrl": "https://erdosproblems.com/129",

--- a/src/data/proofs/erdos-130/meta.json
+++ b/src/data/proofs/erdos-130/meta.json
@@ -15,7 +15,7 @@
       "open"
     ],
     "proofRepoPath": "Proofs/Erdos130Problem.lean",
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/130",
     "erdosUrl": "https://erdosproblems.com/130",

--- a/src/data/proofs/erdos-14/meta.json
+++ b/src/data/proofs/erdos-14/meta.json
@@ -15,7 +15,7 @@
       "sumsets",
       "sidon-sets"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 14,
     "erdosUrl": "https://erdosproblems.com/14",

--- a/src/data/proofs/erdos-141/meta.json
+++ b/src/data/proofs/erdos-141/meta.json
@@ -16,7 +16,7 @@
       "number-theory",
       "additive-combinatorics"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 141,
     "erdosUrl": "https://erdosproblems.com/141",

--- a/src/data/proofs/erdos-156/meta.json
+++ b/src/data/proofs/erdos-156/meta.json
@@ -18,7 +18,7 @@
       "additive-combinatorics",
       "extremal-combinatorics"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 3,
     "erdosNumber": 156,
     "erdosUrl": "https://erdosproblems.com/156",

--- a/src/data/proofs/erdos-159/meta.json
+++ b/src/data/proofs/erdos-159/meta.json
@@ -15,7 +15,7 @@
       "extremal-graph-theory",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 159,
     "erdosUrl": "https://erdosproblems.com/159",

--- a/src/data/proofs/erdos-196/meta.json
+++ b/src/data/proofs/erdos-196/meta.json
@@ -15,7 +15,7 @@
       "arithmetic progressions",
       "monotone subsequences"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 196,
     "erdosUrl": "https://erdosproblems.com/196",

--- a/src/data/proofs/erdos-202/meta.json
+++ b/src/data/proofs/erdos-202/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-202",
-  "title": "Erd\u0151s #202: Disjoint Covering Systems",
+  "title": "Erdős #202: Disjoint Covering Systems",
   "slug": "erdos-202",
-  "description": "How many disjoint congruence classes can have moduli bounded by N? Bounds involve L(N) = exp(\u221a(log N \u00b7 log log N)).",
+  "description": "How many disjoint congruence classes can have moduli bounded by N? Bounds involve L(N) = exp(√(log N · log log N)).",
   "meta": {
-    "author": "Paul Erd\u0151s, Endre Szemer\u00e9di",
+    "author": "Paul Erdős, Endre Szemerédi",
     "sourceUrl": "https://erdosproblems.com/202",
     "date": "1968",
     "status": "axiomatized",
@@ -15,7 +15,7 @@
       "covering-systems",
       "combinatorics"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 3,
     "erdosNumber": 202,
     "erdosUrl": "https://erdosproblems.com/202",
@@ -48,8 +48,8 @@
       "Formalized CongruenceClass structure with modular containment",
       "Defined DisjointSystem and pairwise disjointness property",
       "Defined f(N) as supremum of disjoint system sizes bounded by N",
-      "Defined L(N) = exp(\u221a(log N \u00b7 log log N)) with growth properties",
-      "Stated Erd\u0151s-Stein conjecture f(N) = o(N) and modern BFV bounds",
+      "Defined L(N) = exp(√(log N · log log N)) with growth properties",
+      "Stated Erdős-Stein conjecture f(N) = o(N) and modern BFV bounds",
       "Multiple theorems proved by Aristotle including f_mono, f_le_N, L_mono, L_subpolynomial"
     ],
     "axiomCount": 0,
@@ -57,14 +57,14 @@
     "assumptions": "3 sorry(s). No axioms."
   },
   "overview": {
-    "historicalContext": "**From Covering Systems to Smooth Number Bounds**\n\n**Erd\u0151s** and **Stein** conjectured in the 1960s that $f(N) = o(N)$, where $f(N)$ is the maximum number of pairwise disjoint congruence classes with moduli $\\leq N$. **Erd\u0151s** and **Szemer\u00e9di** proved this conjecture in 1968 using sieve methods, showing $f(N) < N/(\\log N)^c$ for some $c > 0$.\n\nThe precise asymptotics involve the **subexponential function** $L(N) = \\exp(\\sqrt{\\log N \\cdot \\log\\log N})$, which arises naturally from smooth number theory. **Croot** (2003) established bounds $N/L(N)^{\\sqrt{2}+o(1)} < f(N) < N/L(N)^{1/6-o(1)}$, introducing character sum techniques. **Chen** (2005) and **de la Bret\u00e8che\u2013Ford\u2013Vandehey** (2013) tightened these to:\n$$\\frac{N}{L(N)^{1+o(1)}} < f(N) < \\frac{N}{L(N)^{\\sqrt{3}/2+o(1)}}$$\n\nThe lower bound is conjectured to be tight. The problem connects to the **Erd\u0151s covering system conjecture** (disproved by Hough 2015), **smooth number distribution** (Dickman's function), and **sieve theory**. This is one of 798 lines of Lean formalization, with 7 theorems proved by the Aristotle proof search system.",
-    "problemStatement": "**Erd\u0151s Problem 202**\n\nLet $n_1 < n_2 < \\cdots < n_r \\leq N$ with associated residues $a_i \\pmod{n_i}$ such that the congruence classes are pairwise disjoint. Define $f(N)$ as the maximum $r$.\n\nWhat is $f(N)$ asymptotically? Current bounds:\n$$\\frac{N}{L(N)^{1+o(1)}} < f(N) < \\frac{N}{L(N)^{\\sqrt{3}/2+o(1)}}$$\nwhere $L(N) = \\exp(\\sqrt{\\log N \\cdot \\log\\log N})$.",
-    "text": "How many disjoint congruence classes can have moduli bounded by N? Bounds involve L(N) = exp(\u221a(log N \u00b7 log log N)).",
-    "proofStrategy": "**Formalization Strategy**\n\n1. **Congruence infrastructure:** Define `CongruenceClass` with modular containment via `Int.ModEq`, disjointness predicate, and `DisjointSystem` structure.\n2. **Extremal function:** Define $f(N)$ via `sSup` over all disjoint system sizes with moduli $\\leq N$.\n3. **Density constraint:** Prove $\\sum 1/n_i \\leq 1$ for any disjoint system (key structural lemma), implying $f(N) \\leq N$.\n4. **Full system construction:** Build $\\{0, 1, \\ldots, N-1\\} \\bmod N$ to show $f(N) \\geq N$, establishing $f(N) = N$.\n5. **$L$ function:** Define $L(N) = \\exp(\\sqrt{\\log N \\cdot \\log\\log N})$ with monotonicity and subpolynomial growth.\n6. **Historical bounds:** State Erd\u0151s\u2013Stein ($f(N) = o(N)$), Erd\u0151s\u2013Szemer\u00e9di ($f(N) < N/(\\log N)^c$), and BFV bounds.\n7. **Aristotle integration:** 7 theorems proved by automated proof search, including `f_mono`, `f_le_N`, `L_mono`, `L_subpolynomial`, `lower_bound_BFV`.",
+    "historicalContext": "**From Covering Systems to Smooth Number Bounds**\n\n**Erdős** and **Stein** conjectured in the 1960s that $f(N) = o(N)$, where $f(N)$ is the maximum number of pairwise disjoint congruence classes with moduli $\\leq N$. **Erdős** and **Szemerédi** proved this conjecture in 1968 using sieve methods, showing $f(N) < N/(\\log N)^c$ for some $c > 0$.\n\nThe precise asymptotics involve the **subexponential function** $L(N) = \\exp(\\sqrt{\\log N \\cdot \\log\\log N})$, which arises naturally from smooth number theory. **Croot** (2003) established bounds $N/L(N)^{\\sqrt{2}+o(1)} < f(N) < N/L(N)^{1/6-o(1)}$, introducing character sum techniques. **Chen** (2005) and **de la Bretèche–Ford–Vandehey** (2013) tightened these to:\n$$\\frac{N}{L(N)^{1+o(1)}} < f(N) < \\frac{N}{L(N)^{\\sqrt{3}/2+o(1)}}$$\n\nThe lower bound is conjectured to be tight. The problem connects to the **Erdős covering system conjecture** (disproved by Hough 2015), **smooth number distribution** (Dickman's function), and **sieve theory**. This is one of 798 lines of Lean formalization, with 7 theorems proved by the Aristotle proof search system.",
+    "problemStatement": "**Erdős Problem 202**\n\nLet $n_1 < n_2 < \\cdots < n_r \\leq N$ with associated residues $a_i \\pmod{n_i}$ such that the congruence classes are pairwise disjoint. Define $f(N)$ as the maximum $r$.\n\nWhat is $f(N)$ asymptotically? Current bounds:\n$$\\frac{N}{L(N)^{1+o(1)}} < f(N) < \\frac{N}{L(N)^{\\sqrt{3}/2+o(1)}}$$\nwhere $L(N) = \\exp(\\sqrt{\\log N \\cdot \\log\\log N})$.",
+    "text": "How many disjoint congruence classes can have moduli bounded by N? Bounds involve L(N) = exp(√(log N · log log N)).",
+    "proofStrategy": "**Formalization Strategy**\n\n1. **Congruence infrastructure:** Define `CongruenceClass` with modular containment via `Int.ModEq`, disjointness predicate, and `DisjointSystem` structure.\n2. **Extremal function:** Define $f(N)$ via `sSup` over all disjoint system sizes with moduli $\\leq N$.\n3. **Density constraint:** Prove $\\sum 1/n_i \\leq 1$ for any disjoint system (key structural lemma), implying $f(N) \\leq N$.\n4. **Full system construction:** Build $\\{0, 1, \\ldots, N-1\\} \\bmod N$ to show $f(N) \\geq N$, establishing $f(N) = N$.\n5. **$L$ function:** Define $L(N) = \\exp(\\sqrt{\\log N \\cdot \\log\\log N})$ with monotonicity and subpolynomial growth.\n6. **Historical bounds:** State Erdős–Stein ($f(N) = o(N)$), Erdős–Szemerédi ($f(N) < N/(\\log N)^c$), and BFV bounds.\n7. **Aristotle integration:** 7 theorems proved by automated proof search, including `f_mono`, `f_le_N`, `L_mono`, `L_subpolynomial`, `lower_bound_BFV`.",
     "keyInsights": [
-      "**Density Constraint:** The fundamental obstruction is $\\sum_{i=1}^r 1/n_i \\leq 1$ for any disjoint system \u2014 each class $(a_i, n_i)$ covers a proportion $1/n_i$ of the integers, and disjointness forces the total proportion to be at most $1$.",
+      "**Density Constraint:** The fundamental obstruction is $\\sum_{i=1}^r 1/n_i \\leq 1$ for any disjoint system — each class $(a_i, n_i)$ covers a proportion $1/n_i$ of the integers, and disjointness forces the total proportion to be at most $1$.",
       "**$f(N) = N$ Exactly:** The trivial system $\\{0, 1, \\ldots, N-1\\} \\bmod N$ achieves $|S| = N$, and the density constraint with moduli $\\leq N$ gives $|S| \\leq N$. The asymptotic question is about systems with distinct moduli.",
-      "**Subexponential Threshold:** The function $L(N) = \\exp(\\sqrt{\\log N \\cdot \\log\\log N})$ is the natural boundary between polynomial and logarithmic \u2014 it satisfies $L(N) = N^{o(1)}$ yet $L(N) \\gg (\\log N)^c$ for all $c$.",
+      "**Subexponential Threshold:** The function $L(N) = \\exp(\\sqrt{\\log N \\cdot \\log\\log N})$ is the natural boundary between polynomial and logarithmic — it satisfies $L(N) = N^{o(1)}$ yet $L(N) \\gg (\\log N)^c$ for all $c$.",
       "**Smooth Number Connection:** The bounds involve counting $y$-smooth numbers (integers with all prime factors $\\leq y$). The Dickman function $\\rho(u)$ satisfying $\\Psi(x, x^{1/u}) \\sim x\\rho(u)$ underlies the $L(N)$ appearance.",
       "**Aristotle Success:** 7 of the file's theorems were proved automatically by Aristotle, including the nontrivial `L_subpolynomial` which requires a nested chain of limit arguments ($y = \\log N$, $z = \\sqrt{y}$, squeeze lemma)."
     ],
@@ -125,7 +125,7 @@
     },
     {
       "id": "erdos-stein",
-      "title": "Erd\u0151s\u2013Stein Conjecture and Szemer\u00e9di Bound",
+      "title": "Erdős–Stein Conjecture and Szemerédi Bound",
       "startLine": 420,
       "endLine": 546,
       "summary": "States erdos_stein_conjecture: $f(N) = o(N)$ (sorry). Proves `erdos_szemeredi_upper`: $f(N) < N/(\\log N)^c$ (Aristotle). Includes `trivialSystem` and `full_system` constructions.",
@@ -149,8 +149,8 @@
     }
   ],
   "conclusion": {
-    "summary": "This 798-line formalization captures Erd\u0151s Problem #202 on disjoint covering systems, with 7 theorems proved by Aristotle. The density constraint $\\sum 1/n_i \\leq 1$ is the key structural lemma, proved via a counting argument over common multiples. The extremal function $f(N) = N$ is established exactly, and the asymptotic question reduces to understanding the gap between $L(N)^1$ and $L(N)^{\\sqrt{3}/2}$ in the exponent. The subexponential function $L(N) = \\exp(\\sqrt{\\log N \\cdot \\log\\log N})$ is defined with full monotonicity and growth properties.",
-    "implications": "**Theoretical Significance**: **Implications and Connections**\n\n1. **Covering System Theory:** Disjoint covering systems are the simplest case of the general covering system problem. Hough (2015) disproved the Erd\u0151s minimum modulus conjecture for covering systems, but the disjoint case remains open.\n\n2. **Smooth Number Distribution:** The $L(N)$ function connects to the Dickman\u2013de Bruijn function $\\rho(u)$: the count $\\Psi(x, y)$ of $y$-smooth numbers up to $x$ satisfies $\\Psi(x, x^{1/u}) = x \\cdot \\rho(u)(1 + o(1))$, and $L(x)$ appears as the transition scale.\n\n**3. Sieve Theory:** The Erd\u0151s\u2013Szemer\u00e9di proof uses large sieve estimates. The BFV bounds use Dirichlet character sum techniques, connecting to the distribution of primes in arithmetic progressions.\n\n4. **Combinatorial Number Theory:** The density constraint $\\sum 1/n_i \\leq 1$ is a number-theoretic analogue of the fractional matching condition in hypergraph theory.\n\n5. **Automated Proof Search:** This file demonstrates significant Aristotle success: 7 theorems proved automatically, including the nontrivial `L_subpolynomial` requiring nested substitutions and squeeze lemma arguments.",
+    "summary": "This 798-line formalization captures Erdős Problem #202 on disjoint covering systems, with 7 theorems proved by Aristotle. The density constraint $\\sum 1/n_i \\leq 1$ is the key structural lemma, proved via a counting argument over common multiples. The extremal function $f(N) = N$ is established exactly, and the asymptotic question reduces to understanding the gap between $L(N)^1$ and $L(N)^{\\sqrt{3}/2}$ in the exponent. The subexponential function $L(N) = \\exp(\\sqrt{\\log N \\cdot \\log\\log N})$ is defined with full monotonicity and growth properties.",
+    "implications": "**Theoretical Significance**: **Implications and Connections**\n\n1. **Covering System Theory:** Disjoint covering systems are the simplest case of the general covering system problem. Hough (2015) disproved the Erdős minimum modulus conjecture for covering systems, but the disjoint case remains open.\n\n2. **Smooth Number Distribution:** The $L(N)$ function connects to the Dickman–de Bruijn function $\\rho(u)$: the count $\\Psi(x, y)$ of $y$-smooth numbers up to $x$ satisfies $\\Psi(x, x^{1/u}) = x \\cdot \\rho(u)(1 + o(1))$, and $L(x)$ appears as the transition scale.\n\n**3. Sieve Theory:** The Erdős–Szemerédi proof uses large sieve estimates. The BFV bounds use Dirichlet character sum techniques, connecting to the distribution of primes in arithmetic progressions.\n\n4. **Combinatorial Number Theory:** The density constraint $\\sum 1/n_i \\leq 1$ is a number-theoretic analogue of the fractional matching condition in hypergraph theory.\n\n5. **Automated Proof Search:** This file demonstrates significant Aristotle success: 7 theorems proved automatically, including the nontrivial `L_subpolynomial` requiring nested substitutions and squeeze lemma arguments.",
     "openQuestions": [
       "Is $f(N) = N/L(N)^{1+o(1)}$ (matching the lower bound), or is the true exponent strictly between $1$ and $\\sqrt{3}/2$?",
       "Can the BFV upper bound exponent $\\sqrt{3}/2 \\approx 0.866$ be improved toward the conjectured $1$?",
@@ -186,24 +186,24 @@
     {
       "targetId": "erdos-2",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: combinatorics, covering-systems, number-theory"
+      "description": "Related Erdős problem sharing themes: combinatorics, covering-systems, number-theory"
     },
     {
       "targetId": "erdos-586",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: combinatorics, covering-systems, number-theory"
+      "description": "Related Erdős problem sharing themes: combinatorics, covering-systems, number-theory"
     },
     {
       "targetId": "erdos-7",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: combinatorics, covering-systems, number-theory"
+      "description": "Related Erdős problem sharing themes: combinatorics, covering-systems, number-theory"
     }
   ],
   "references": [
     {
       "key": "Er50d",
       "authors": [
-        "P. Erd\u0151s"
+        "P. Erdős"
       ],
       "title": "On a problem concerning congruence systems",
       "venue": "Matematikai Lapok",

--- a/src/data/proofs/erdos-236/meta.json
+++ b/src/data/proofs/erdos-236/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-236",
-  "title": "Erd\u0151s Problem #236: Growth of Prime Plus Power Representations",
+  "title": "Erdős Problem #236: Growth of Prime Plus Power Representations",
   "slug": "erdos-236",
-  "description": "Is it true that f(n) = o(log n), where f(n) counts solutions to n = p + 2^k with p prime? Erd\u0151s proved infinitely many n have f(n) \u226b log log n, showing the conjecture is tight if true.",
+  "description": "Is it true that f(n) = o(log n), where f(n) counts solutions to n = p + 2^k with p prime? Erdős proved infinitely many n have f(n) ≫ log log n, showing the conjecture is tight if true.",
   "meta": {
-    "author": "Paul Erd\u0151s (1950)",
+    "author": "Paul Erdős (1950)",
     "sourceUrl": "https://erdosproblems.com/236",
     "date": "1950",
     "status": "axiomatized",
@@ -16,7 +16,7 @@
       "primes",
       "asymptotic-analysis"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 236,
     "erdosUrl": "https://erdosproblems.com/236",
@@ -42,27 +42,27 @@
     ],
     "originalContributions": [
       "Definition of f(n) counting p + 2^k representations",
-      "Proved f_trivial_upper_bound: f(n) \u2264 log\u2082(n) + 1",
+      "Proved f_trivial_upper_bound: f(n) ≤ log₂(n) + 1",
       "Proved f(2)=0, f(3)=1, f(5)=1 by decide",
       "Axiomatized f(9)=2, f(15)=3 with verifications",
       "Definition of HasAllPrimeProperty",
       "Proved 4, 7 have all-prime property",
-      "Axiomatized Erd\u0151s-Guy conjecture on all-prime numbers",
+      "Axiomatized Erdős-Guy conjecture on all-prime numbers",
       "Stated main conjecture f(n) = o(log n) formally",
-      "Axiomatized Erd\u0151s lower bound and Vaughan sparsity bound"
+      "Axiomatized Erdős lower bound and Vaughan sparsity bound"
     ],
     "axiomCount": 0,
     "lineCount": 175,
     "assumptions": "0 axioms. 0 sorries. All results formalized without axioms."
   },
   "overview": {
-    "historicalContext": "This problem connects two fundamental themes in Erd\u0151s's work: the representation of integers as sums involving primes, and the asymptotic growth of counting functions. The question emerged from his 1950 paper on representing integers as 2^k + p, where he showed that infinitely many n cannot be written in this form. Problem #236 asks about the opposite extreme: how many ways can a given n be represented? Erd\u0151s's lower bound f(n) \u226b log log n infinitely often shows that representations can be surprisingly abundant. The related conjecture that only 7 numbers have ALL residues n - 2^k prime (the 'all-prime' property) has been verified to 2^44 by Mientka-Weitzenkamp.",
-    "problemStatement": "Let f(n) count the number of solutions to n = p + 2^k for prime p and k \u2265 0. Is it true that f(n) = o(log n)? Equivalently, does the ratio f(n)/log(n) tend to 0 as n \u2192 \u221e?",
-    "text": "Is it true that f(n) = o(log n), where f(n) counts solutions to n = p + 2^k with p prime? Erd\u0151s proved infinitely many n have f(n) \u226b log log n, showing the conjecture is tight if true.",
-    "proofStrategy": "We formalize the counting function f(n) computationally and state the main conjecture using Mathlib's asymptotic notation. Since the problem is OPEN, we use axioms for the main conjecture and known bounds. We prove concrete values f(2)=0, f(3)=1, f(5)=1 and verify the 'all-prime' property for small cases {4, 7} directly. The Erd\u0151s-Guy conjecture listing all 7 all-prime numbers and Vaughan's upper bound on their density are stated as axioms with proper attribution.",
+    "historicalContext": "This problem connects two fundamental themes in Erdős's work: the representation of integers as sums involving primes, and the asymptotic growth of counting functions. The question emerged from his 1950 paper on representing integers as 2^k + p, where he showed that infinitely many n cannot be written in this form. Problem #236 asks about the opposite extreme: how many ways can a given n be represented? Erdős's lower bound f(n) ≫ log log n infinitely often shows that representations can be surprisingly abundant. The related conjecture that only 7 numbers have ALL residues n - 2^k prime (the 'all-prime' property) has been verified to 2^44 by Mientka-Weitzenkamp.",
+    "problemStatement": "Let f(n) count the number of solutions to n = p + 2^k for prime p and k ≥ 0. Is it true that f(n) = o(log n)? Equivalently, does the ratio f(n)/log(n) tend to 0 as n → ∞?",
+    "text": "Is it true that f(n) = o(log n), where f(n) counts solutions to n = p + 2^k with p prime? Erdős proved infinitely many n have f(n) ≫ log log n, showing the conjecture is tight if true.",
+    "proofStrategy": "We formalize the counting function f(n) computationally and state the main conjecture using Mathlib's asymptotic notation. Since the problem is OPEN, we use axioms for the main conjecture and known bounds. We prove concrete values f(2)=0, f(3)=1, f(5)=1 and verify the 'all-prime' property for small cases {4, 7} directly. The Erdős-Guy conjecture listing all 7 all-prime numbers and Vaughan's upper bound on their density are stated as axioms with proper attribution.",
     "keyInsights": [
-      "The trivial upper bound f(n) \u2264 log\u2082(n) + 1 is immediate from the definition",
-      "Erd\u0151s's lower bound f(n) \u226b log log n infinitely often shows the conjecture, if true, is essentially tight",
+      "The trivial upper bound f(n) ≤ log₂(n) + 1 is immediate from the definition",
+      "Erdős's lower bound f(n) ≫ log log n infinitely often shows the conjecture, if true, is essentially tight",
       "Numbers with the 'all-prime' property (n - 2^k prime for all valid k) are extremely rare",
       "Vaughan proved the all-prime numbers have density decaying faster than any polynomial",
       "This problem connects to Problem #10 (existence of representations) and #237 (related bounds)"
@@ -111,7 +111,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erd\u0151s Problem #236 on the growth rate of representations n = p + 2^k. We define the counting function f, verify concrete values, formalize the 'all-prime' property and Erd\u0151s-Guy conjecture, and state the main asymptotic conjecture along with known bounds from Erd\u0151s and Vaughan.",
+    "summary": "This formalization captures Erdős Problem #236 on the growth rate of representations n = p + 2^k. We define the counting function f, verify concrete values, formalize the 'all-prime' property and Erdős-Guy conjecture, and state the main asymptotic conjecture along with known bounds from Erdős and Vaughan.",
     "implications": "Understanding the growth of f(n) would illuminate the distribution of primes in arithmetic progressions and the structure of sums involving prime and exponential components.",
     "openQuestions": [
       "Is f(n) = o(log n)?",
@@ -139,17 +139,17 @@
     {
       "targetId": "erdos-141",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: additive-combinatorics, number-theory, primes"
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, number-theory, primes"
     },
     {
       "targetId": "erdos-200",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: additive-combinatorics, number-theory, primes"
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, number-theory, primes"
     },
     {
       "targetId": "erdos-237",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: additive-combinatorics, number-theory, primes"
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, number-theory, primes"
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-241/meta.json
+++ b/src/data/proofs/erdos-241/meta.json
@@ -14,7 +14,7 @@
       "sidon-sets",
       "b3-sets"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 241,
     "erdosUrl": "https://erdosproblems.com/241",

--- a/src/data/proofs/erdos-251/meta.json
+++ b/src/data/proofs/erdos-251/meta.json
@@ -16,7 +16,7 @@
       "infinite-series",
       "primes"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 251,
     "erdosUrl": "https://erdosproblems.com/251",

--- a/src/data/proofs/erdos-258/meta.json
+++ b/src/data/proofs/erdos-258/meta.json
@@ -16,7 +16,7 @@
       "divisor-function",
       "infinite-series"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 258,
     "erdosUrl": "https://erdosproblems.com/258",

--- a/src/data/proofs/erdos-261/meta.json
+++ b/src/data/proofs/erdos-261/meta.json
@@ -15,7 +15,7 @@
       "representations",
       "binary-arithmetic"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 261,
     "erdosUrl": "https://erdosproblems.com/261",

--- a/src/data/proofs/erdos-263/meta.json
+++ b/src/data/proofs/erdos-263/meta.json
@@ -16,7 +16,7 @@
       "sequences",
       "analysis"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 4,
     "erdosNumber": 263,
     "erdosUrl": "https://erdosproblems.com/263",

--- a/src/data/proofs/erdos-267/meta.json
+++ b/src/data/proofs/erdos-267/meta.json
@@ -16,7 +16,7 @@
       "irrationality",
       "reciprocal-sums"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 267,
     "erdosUrl": "https://erdosproblems.com/267",

--- a/src/data/proofs/erdos-276/meta.json
+++ b/src/data/proofs/erdos-276/meta.json
@@ -12,7 +12,7 @@
     "date": "1964",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos276Problem.lean",
-    "badge": "wip",
+    "badge": "axiom",
     "tags": [
       "erdos",
       "number-theory",

--- a/src/data/proofs/erdos-289/meta.json
+++ b/src/data/proofs/erdos-289/meta.json
@@ -15,7 +15,7 @@
       "intervals",
       "harmonic series"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 289,
     "erdosUrl": "https://erdosproblems.com/289",

--- a/src/data/proofs/erdos-307/meta.json
+++ b/src/data/proofs/erdos-307/meta.json
@@ -16,7 +16,7 @@
       "egyptian-fractions",
       "reciprocals"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 2,
     "erdosNumber": 307,
     "erdosUrl": "https://erdosproblems.com/307",

--- a/src/data/proofs/erdos-311/meta.json
+++ b/src/data/proofs/erdos-311/meta.json
@@ -16,7 +16,7 @@
       "approximation",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 311,
     "erdosUrl": "https://erdosproblems.com/311",

--- a/src/data/proofs/erdos-313/meta.json
+++ b/src/data/proofs/erdos-313/meta.json
@@ -18,7 +18,7 @@
       "pseudoperfect-numbers",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 313,
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-321/meta.json
+++ b/src/data/proofs/erdos-321/meta.json
@@ -19,7 +19,7 @@
     "erdosUrl": "https://erdosproblems.com/321",
     "axiomCount": 0,
     "assumptions": "0 axioms. The Bleicher–Erdős bounds (lower: R(N) ≥ N/log N, upper: R(N) ≤ C·(N/log N)·log log N) are referenced only as doc-comment descriptions, not as Lean axiom declarations. Open problem — precise asymptotic of R(N) remains unknown.",
-    "badge": "wip",
+    "badge": "axiom",
     "proofRepoPath": "Proofs/Erdos321Problem.lean",
     "mathlib_version": "4.26.0",
     "lineCount": 155,

--- a/src/data/proofs/erdos-325/meta.json
+++ b/src/data/proofs/erdos-325/meta.json
@@ -16,7 +16,7 @@
       "power-sums",
       "asymptotics"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 325,
     "erdosUrl": "https://erdosproblems.com/325",

--- a/src/data/proofs/erdos-326/meta.json
+++ b/src/data/proofs/erdos-326/meta.json
@@ -16,7 +16,7 @@
       "bases",
       "growth-rates"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 326,
     "erdosUrl": "https://erdosproblems.com/326",

--- a/src/data/proofs/erdos-346/meta.json
+++ b/src/data/proofs/erdos-346/meta.json
@@ -15,7 +15,7 @@
       "golden ratio",
       "Fibonacci numbers"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 346,
     "erdosUrl": "https://erdosproblems.com/346",

--- a/src/data/proofs/erdos-349/meta.json
+++ b/src/data/proofs/erdos-349/meta.json
@@ -27,7 +27,7 @@
       "erdos-267"
     ],
     "axiomCount": 0,
-    "badge": "wip",
+    "badge": "axiom",
     "assumptions": "0 axioms, 0 sorries. All results proved from Lean primitives.",
     "mathlib_version": "4.26.0",
     "lineCount": 84

--- a/src/data/proofs/erdos-350/meta.json
+++ b/src/data/proofs/erdos-350/meta.json
@@ -16,7 +16,7 @@
       "dissociated-sets",
       "sidon-sets"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 350,
     "erdosUrl": "https://erdosproblems.com/350",

--- a/src/data/proofs/erdos-351/meta.json
+++ b/src/data/proofs/erdos-351/meta.json
@@ -16,7 +16,7 @@
       "completeness",
       "polynomials"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 351,
     "erdosUrl": "https://erdosproblems.com/351",

--- a/src/data/proofs/erdos-359/meta.json
+++ b/src/data/proofs/erdos-359/meta.json
@@ -16,7 +16,7 @@
       "density",
       "consecutive-sums"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 359,
     "erdosUrl": "https://erdosproblems.com/359",

--- a/src/data/proofs/erdos-361/meta.json
+++ b/src/data/proofs/erdos-361/meta.json
@@ -15,7 +15,7 @@
       "combinatorics",
       "asymptotics"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 361,
     "erdosUrl": "https://erdosproblems.com/361",

--- a/src/data/proofs/erdos-364/meta.json
+++ b/src/data/proofs/erdos-364/meta.json
@@ -17,7 +17,7 @@
       "modular-arithmetic",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 364,
     "erdosUrl": "https://erdosproblems.com/364",

--- a/src/data/proofs/erdos-377/meta.json
+++ b/src/data/proofs/erdos-377/meta.json
@@ -16,7 +16,7 @@
       "prime-divisibility",
       "analytic-number-theory"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 377,
     "erdosUrl": "https://erdosproblems.com/377",

--- a/src/data/proofs/erdos-38/meta.json
+++ b/src/data/proofs/erdos-38/meta.json
@@ -16,7 +16,7 @@
       "additive-basis",
       "number-theory"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 38,
     "erdosUrl": "https://erdosproblems.com/38",

--- a/src/data/proofs/erdos-383/meta.json
+++ b/src/data/proofs/erdos-383/meta.json
@@ -16,7 +16,7 @@
       "dickman",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 383,
     "erdosUrl": "https://erdosproblems.com/383",

--- a/src/data/proofs/erdos-385/meta.json
+++ b/src/data/proofs/erdos-385/meta.json
@@ -16,7 +16,7 @@
       "sieve-theory",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 385,
     "erdosUrl": "https://erdosproblems.com/385",

--- a/src/data/proofs/erdos-388/meta.json
+++ b/src/data/proofs/erdos-388/meta.json
@@ -16,7 +16,7 @@
       "factorials",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 388,
     "erdosUrl": "https://erdosproblems.com/388",

--- a/src/data/proofs/erdos-399/meta.json
+++ b/src/data/proofs/erdos-399/meta.json
@@ -15,7 +15,7 @@
       "diophantine-equations",
       "factorials"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 399,
     "erdosUrl": "https://erdosproblems.com/399",

--- a/src/data/proofs/erdos-400/meta.json
+++ b/src/data/proofs/erdos-400/meta.json
@@ -16,7 +16,7 @@
       "combinatorics",
       "divisibility"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 400,
     "erdosUrl": "https://erdosproblems.com/400",

--- a/src/data/proofs/erdos-411/meta.json
+++ b/src/data/proofs/erdos-411/meta.json
@@ -16,7 +16,7 @@
       "totient",
       "arithmetic-dynamics"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 411,
     "erdosUrl": "https://erdosproblems.com/411",

--- a/src/data/proofs/erdos-416/meta.json
+++ b/src/data/proofs/erdos-416/meta.json
@@ -30,7 +30,7 @@
       "asymptotics",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 416,
     "erdosUrl": "https://erdosproblems.com/416",

--- a/src/data/proofs/erdos-418/meta.json
+++ b/src/data/proofs/erdos-418/meta.json
@@ -16,7 +16,7 @@
       "cototient",
       "goldbach"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 418,
     "erdosUrl": "https://erdosproblems.com/418",

--- a/src/data/proofs/erdos-42/meta.json
+++ b/src/data/proofs/erdos-42/meta.json
@@ -15,7 +15,7 @@
       "additive-combinatorics",
       "difference-sets"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 42,
     "erdosUrl": "https://erdosproblems.com/42",

--- a/src/data/proofs/erdos-422/meta.json
+++ b/src/data/proofs/erdos-422/meta.json
@@ -15,7 +15,7 @@
       "recursion",
       "self-referential"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 422,
     "erdosUrl": "https://erdosproblems.com/422",

--- a/src/data/proofs/erdos-424/meta.json
+++ b/src/data/proofs/erdos-424/meta.json
@@ -15,7 +15,7 @@
       "density",
       "multiplicative-combinatorics"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 424,
     "erdosUrl": "https://erdosproblems.com/424",

--- a/src/data/proofs/erdos-456/meta.json
+++ b/src/data/proofs/erdos-456/meta.json
@@ -18,7 +18,7 @@
       "natural-density",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 456,
     "erdosUrl": "https://erdosproblems.com/456",

--- a/src/data/proofs/erdos-46/meta.json
+++ b/src/data/proofs/erdos-46/meta.json
@@ -17,7 +17,7 @@
       "colouring",
       "solved"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 46,
     "erdosUrl": "https://erdosproblems.com/46",

--- a/src/data/proofs/erdos-466/meta.json
+++ b/src/data/proofs/erdos-466/meta.json
@@ -17,7 +17,7 @@
       "extremal-combinatorics",
       "solved"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/466",
     "erdosUrl": "https://erdosproblems.com/466",

--- a/src/data/proofs/erdos-477/meta.json
+++ b/src/data/proofs/erdos-477/meta.json
@@ -15,7 +15,7 @@
       "tilings",
       "polynomials"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 477,
     "erdosUrl": "https://erdosproblems.com/477",

--- a/src/data/proofs/erdos-478/meta.json
+++ b/src/data/proofs/erdos-478/meta.json
@@ -20,7 +20,7 @@
       "birthday-problem",
       "multiplicative-walks"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 478,
     "erdosUrl": "https://erdosproblems.com/478",

--- a/src/data/proofs/erdos-486/meta.json
+++ b/src/data/proofs/erdos-486/meta.json
@@ -16,7 +16,7 @@
       "modular-arithmetic",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 486,
     "erdosUrl": "https://erdosproblems.com/486",

--- a/src/data/proofs/erdos-49/meta.json
+++ b/src/data/proofs/erdos-49/meta.json
@@ -15,7 +15,7 @@
       "euler totient",
       "analytic number theory"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 49,
     "erdosUrl": "https://erdosproblems.com/49",

--- a/src/data/proofs/erdos-496/meta.json
+++ b/src/data/proofs/erdos-496/meta.json
@@ -15,7 +15,7 @@
       "quadratic forms",
       "homogeneous dynamics"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 496,
     "erdosUrl": "https://erdosproblems.com/496",

--- a/src/data/proofs/erdos-498/meta.json
+++ b/src/data/proofs/erdos-498/meta.json
@@ -20,7 +20,7 @@
     "erdosUrl": "https://erdosproblems.com/498",
     "axiomCount": 0,
     "lineCount": 70,
-    "badge": "wip",
+    "badge": "axiom",
     "assumptions": "0 axioms, 0 sorries. All results proved from Lean primitives.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-500/meta.json
+++ b/src/data/proofs/erdos-500/meta.json
@@ -17,7 +17,7 @@
       "flag-algebras",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 500,
     "erdosUrl": "https://erdosproblems.com/500",

--- a/src/data/proofs/erdos-501/meta.json
+++ b/src/data/proofs/erdos-501/meta.json
@@ -16,7 +16,7 @@
       "combinatorics",
       "independence"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 3,
     "erdosNumber": 501,
     "erdosUrl": "https://erdosproblems.com/501",

--- a/src/data/proofs/erdos-506/meta.json
+++ b/src/data/proofs/erdos-506/meta.json
@@ -15,7 +15,7 @@
       "circles",
       "incidence geometry"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 506,
     "erdosUrl": "https://erdosproblems.com/506",

--- a/src/data/proofs/erdos-507/meta.json
+++ b/src/data/proofs/erdos-507/meta.json
@@ -16,7 +16,7 @@
       "combinatorial-geometry",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 507,
     "erdosUrl": "https://erdosproblems.com/507",

--- a/src/data/proofs/erdos-510/meta.json
+++ b/src/data/proofs/erdos-510/meta.json
@@ -17,7 +17,7 @@
       "open"
     ],
     "proofRepoPath": "Proofs/Erdos510Problem.lean",
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/510",
     "erdosUrl": "https://erdosproblems.com/510",

--- a/src/data/proofs/erdos-52/meta.json
+++ b/src/data/proofs/erdos-52/meta.json
@@ -14,7 +14,7 @@
       "sum-product",
       "number-theory"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 52,
     "erdosUrl": "https://erdosproblems.com/52",

--- a/src/data/proofs/erdos-523/meta.json
+++ b/src/data/proofs/erdos-523/meta.json
@@ -18,7 +18,7 @@
       "littlewood",
       "solved"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 523,
     "erdosUrl": "https://erdosproblems.com/523",

--- a/src/data/proofs/erdos-524/meta.json
+++ b/src/data/proofs/erdos-524/meta.json
@@ -17,7 +17,7 @@
       "open"
     ],
     "proofRepoPath": "Proofs/Erdos524Problem.lean",
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/524",
     "erdosUrl": "https://erdosproblems.com/524",

--- a/src/data/proofs/erdos-53/meta.json
+++ b/src/data/proofs/erdos-53/meta.json
@@ -14,7 +14,7 @@
       "additive combinatorics",
       "sum-product phenomenon"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 53,
     "erdosUrl": "https://erdosproblems.com/53",

--- a/src/data/proofs/erdos-54/meta.json
+++ b/src/data/proofs/erdos-54/meta.json
@@ -17,7 +17,7 @@
       "additive-combinatorics",
       "solved"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 54,
     "erdosUrl": "https://erdosproblems.com/54",

--- a/src/data/proofs/erdos-542/meta.json
+++ b/src/data/proofs/erdos-542/meta.json
@@ -15,7 +15,7 @@
       "reciprocal-sums",
       "extremal-combinatorics"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 542,
     "erdosUrl": "https://erdosproblems.com/542",

--- a/src/data/proofs/erdos-552/meta.json
+++ b/src/data/proofs/erdos-552/meta.json
@@ -15,7 +15,7 @@
       "ramsey-theory",
       "combinatorics"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 12,
     "erdosNumber": 552,
     "erdosUrl": "https://erdosproblems.com/552",

--- a/src/data/proofs/erdos-555/meta.json
+++ b/src/data/proofs/erdos-555/meta.json
@@ -14,7 +14,7 @@
       "graph theory",
       "extremal combinatorics"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 555,
     "erdosUrl": "https://erdosproblems.com/555",

--- a/src/data/proofs/erdos-566/meta.json
+++ b/src/data/proofs/erdos-566/meta.json
@@ -18,7 +18,7 @@
     "sourceUrl": "https://erdosproblems.com/566",
     "erdosUrl": "https://erdosproblems.com/566",
     "axiomCount": 0,
-    "badge": "wip",
+    "badge": "axiom",
     "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean.",
     "proofRepoPath": "Proofs/Erdos566Problem.lean",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/erdos-574/meta.json
+++ b/src/data/proofs/erdos-574/meta.json
@@ -18,7 +18,7 @@
     "sourceUrl": "https://erdosproblems.com/574",
     "erdosUrl": "https://erdosproblems.com/574",
     "axiomCount": 0,
-    "badge": "wip",
+    "badge": "axiom",
     "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean.",
     "proofRepoPath": "Proofs/Erdos574Problem.lean",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/erdos-575/meta.json
+++ b/src/data/proofs/erdos-575/meta.json
@@ -15,7 +15,7 @@
       "bipartite graphs",
       "combinatorics"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 575,
     "erdosUrl": "https://erdosproblems.com/575",

--- a/src/data/proofs/erdos-579/meta.json
+++ b/src/data/proofs/erdos-579/meta.json
@@ -15,7 +15,7 @@
       "turan-theory",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 579,
     "erdosUrl": "https://erdosproblems.com/579",

--- a/src/data/proofs/erdos-585/meta.json
+++ b/src/data/proofs/erdos-585/meta.json
@@ -14,7 +14,7 @@
       "extremal graph theory",
       "cycles"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 585,
     "erdosUrl": "https://erdosproblems.com/585",

--- a/src/data/proofs/erdos-593/meta.json
+++ b/src/data/proofs/erdos-593/meta.json
@@ -15,7 +15,7 @@
       "chromatic-number",
       "graph-theory"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 593,
     "erdosUrl": "https://erdosproblems.com/593",

--- a/src/data/proofs/erdos-598/meta.json
+++ b/src/data/proofs/erdos-598/meta.json
@@ -14,7 +14,7 @@
       "ramsey-theory",
       "cardinal-arithmetic"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 598,
     "erdosUrl": "https://erdosproblems.com/598",

--- a/src/data/proofs/erdos-604/meta.json
+++ b/src/data/proofs/erdos-604/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-604",
-  "title": "Erd\u0151s Problem #604: The Pinned Distance Problem",
+  "title": "Erdős Problem #604: The Pinned Distance Problem",
   "slug": "erdos-604",
   "description": "Given n distinct points in the plane, must some point have nearly n distinct distances to other points? The 'pinned' version of the distinct distances problem. OPEN with $500 prize.",
   "meta": {
-    "author": "Erd\u0151s",
+    "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/604",
     "date": "1957-1997",
     "status": "axiomatized",
@@ -16,7 +16,7 @@
       "combinatorial-geometry",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 1,
     "erdosNumber": 604,
     "erdosUrl": "https://erdosproblems.com/604",
@@ -55,7 +55,7 @@
       "Euclidean distance and metric spaces",
       "Finite set combinatorics (cardinality, image, filter)",
       "Asymptotic notation and exponent bounds",
-      "Incidence geometry (Szemer\u00e9di-Trotter theorem)",
+      "Incidence geometry (Szemerédi-Trotter theorem)",
       "Crossing number inequality",
       "Number theory (sums of two squares, Landau's theorem)"
     ],
@@ -64,22 +64,22 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "The pinned distance problem is a stronger variant of the famous Erd\u0151s distinct distances problem (#89). Rather than counting all distinct pairwise distances in a point set, it asks: must some point 'see' many different distances to other points?\n\nErd\u0151s posed this across multiple papers from 1957 to 1997, offering a $500 prize. The integer lattice {1,...,\u221an} \u00d7 {1,...,\u221an} shows the answer cannot exceed O(n/\u221alog n), suggesting this might be the truth. The 'unpinned' version of the problem was famously resolved by Guth and Katz in 2015 using the polynomial method and algebraic geometry, achieving the near-optimal \u03a9(n/log n) bound, but their techniques have not yet been adapted to give the optimal pinned result. Katz and Tardos obtained the best known pinned lower bound of n^{(48-14e)/(55-16e)} \u2248 n^{0.864} in 2004 using entropy methods.",
-    "problemStatement": "Given n distinct points A \u2282 \u211d\u00b2, must there exist a point x \u2208 A such that:\n\n|{d(x,y) : y \u2208 A, y \u2260 x}| \u226b n^(1-o(1))?\n\nOr even |{d(x,y) : y \u2208 A}| \u226b n/\u221a(log n)?\n\nThe 'pinned point' x has this many distinct distances to other points in the set.",
+    "historicalContext": "The pinned distance problem is a stronger variant of the famous Erdős distinct distances problem (#89). Rather than counting all distinct pairwise distances in a point set, it asks: must some point 'see' many different distances to other points?\n\nErdős posed this across multiple papers from 1957 to 1997, offering a $500 prize. The integer lattice {1,...,√n} × {1,...,√n} shows the answer cannot exceed O(n/√log n), suggesting this might be the truth. The 'unpinned' version of the problem was famously resolved by Guth and Katz in 2015 using the polynomial method and algebraic geometry, achieving the near-optimal Ω(n/log n) bound, but their techniques have not yet been adapted to give the optimal pinned result. Katz and Tardos obtained the best known pinned lower bound of n^{(48-14e)/(55-16e)} ≈ n^{0.864} in 2004 using entropy methods.",
+    "problemStatement": "Given n distinct points A ⊂ ℝ², must there exist a point x ∈ A such that:\n\n|{d(x,y) : y ∈ A, y ≠ x}| ≫ n^(1-o(1))?\n\nOr even |{d(x,y) : y ∈ A}| ≫ n/√(log n)?\n\nThe 'pinned point' x has this many distinct distances to other points in the set.",
     "text": "Given n distinct points in the plane, must some point have nearly n distinct distances to other points? The 'pinned' version of the distinct distances problem. OPEN with $500 prize.",
-    "proofStrategy": "This formalization:\n\n1. Defines `pinnedDistances x A` as the set of distances from x to points in A\n2. States the weak conjecture (exponent 1-\u03b5) and strong conjecture (n/\u221alog n)\n3. Formalizes the Katz-Tardos bound with exponent c \u2248 0.864\n4. Proves basic structural results connecting pinned to total distances\n\nThe main conjectures remain OPEN with substantial sorries marking unproven claims.",
+    "proofStrategy": "This formalization:\n\n1. Defines `pinnedDistances x A` as the set of distances from x to points in A\n2. States the weak conjecture (exponent 1-ε) and strong conjecture (n/√log n)\n3. Formalizes the Katz-Tardos bound with exponent c ≈ 0.864\n4. Proves basic structural results connecting pinned to total distances\n\nThe main conjectures remain OPEN with substantial sorries marking unproven claims.",
     "keyInsights": [
       "**Pinned vs Total:** Counting distances from one 'pinned' point is harder than counting all pairwise distances, yet gives useful lower bounds.",
-      "**Integer Lattice Barrier:** The \u221an \u00d7 \u221an integer grid has O(n/\u221alog n) representable distances, setting the conjectured upper bound.",
-      "**Katz-Tardos Bound:** Best known lower bound achieves exponent c = (48-14e)/(55-16e) \u2248 0.864, far from the conjectured 1.",
-      "**Harborth's Counterexample:** Erd\u0151s initially thought the sum of pinned distances equaled total distinct distances; Harborth showed these differ.",
+      "**Integer Lattice Barrier:** The √n × √n integer grid has O(n/√log n) representable distances, setting the conjectured upper bound.",
+      "**Katz-Tardos Bound:** Best known lower bound achieves exponent c = (48-14e)/(55-16e) ≈ 0.864, far from the conjectured 1.",
+      "**Harborth's Counterexample:** Erdős initially thought the sum of pinned distances equaled total distinct distances; Harborth showed these differ.",
       "**Prize Ambiguity:** The $500 prize's exact condition (one point or many points with high pinned count) remains unclear."
     ],
     "prerequisites": [
       "Euclidean distance and metric spaces",
       "Finite set combinatorics (cardinality, image, filter)",
       "Asymptotic notation and exponent bounds",
-      "Incidence geometry (Szemer\u00e9di-Trotter theorem)",
+      "Incidence geometry (Szemerédi-Trotter theorem)",
       "Crossing number inequality",
       "Number theory (sums of two squares, Landau's theorem)"
     ]
@@ -102,7 +102,7 @@
     {
       "id": "katz-tardos",
       "title": "Katz-Tardos Bound",
-      "summary": "The best known lower bound with exponent \u2248 0.864",
+      "summary": "The best known lower bound with exponent ≈ 0.864",
       "startLine": 69,
       "endLine": 80
     },
@@ -116,7 +116,7 @@
     {
       "id": "sum-conjecture",
       "title": "Sum of Pinned Distances",
-      "summary": "Erd\u0151s's conjecture on the total pinned distance sum",
+      "summary": "Erdős's conjecture on the total pinned distance sum",
       "startLine": 104,
       "endLine": 114
     },
@@ -133,7 +133,7 @@
     "implications": "**Theoretical Significance**: This problem connects to:\n\n1. **Distinct Distances (#89):** The 'unpinned' version solved by Guth-Katz\n**2. Sum-Product Phenomena:** Additive/multiplicative structure in distance sets\n3. **Incidence Geometry:** Connections to point-line incidences\n4. **Algebraic Methods:** Polynomial method techniques from Elekes, Guth-Katz.",
     "openQuestions": [
       "Prove the exponent approaches 1 (the $500 prize!)",
-      "Prove the strong form with n/\u221a(log n) distances",
+      "Prove the strong form with n/√(log n) distances",
       "Improve Katz-Tardos beyond exponent 0.864",
       "Determine if the prize requires one point or many points with high count"
     ]
@@ -141,14 +141,14 @@
   "references": [
     {
       "authors": "Guth, Larry; Katz, Nets Hawk",
-      "title": "On the Erd\u0151s distinct distances problem in the plane",
+      "title": "On the Erdős distinct distances problem in the plane",
       "year": "2015",
       "venue": "Annals of Mathematics 181(1), pp. 155-190",
       "note": "Solved the 'unpinned' distinct distances problem; techniques relevant to the pinned version"
     },
     {
-      "authors": "Katz, Nets Hawk; Tardos, G\u00e1bor",
-      "title": "A new entropy inequality for the Erd\u0151s distance problem",
+      "authors": "Katz, Nets Hawk; Tardos, Gábor",
+      "title": "A new entropy inequality for the Erdős distance problem",
       "year": "2004",
       "venue": "Contemporary Mathematics 342, pp. 119-126",
       "note": "Best known bound for the pinned version: exponent 0.864"
@@ -158,12 +158,12 @@
     {
       "targetId": "erdos-483",
       "relationship": "related",
-      "description": "Both are Erd\u0151s problems with prize money: #483 concerns Schur numbers ($250), #604 concerns pinned distances ($500)"
+      "description": "Both are Erdős problems with prize money: #483 concerns Schur numbers ($250), #604 concerns pinned distances ($500)"
     },
     {
       "targetId": "erdos-224",
       "relationship": "related",
-      "description": "Both are extremal problems in discrete geometry. Problem #224 concerns point sets avoiding obtuse angles, while #604 (pinned distance problem) concerns the minimum number of distinct distances from a fixed point \u2014 both ask how point configurations constrain metric properties"
+      "description": "Both are extremal problems in discrete geometry. Problem #224 concerns point sets avoiding obtuse angles, while #604 (pinned distance problem) concerns the minimum number of distinct distances from a fixed point — both ask how point configurations constrain metric properties"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/erdos-606-oq-03/meta.json
+++ b/src/data/proofs/erdos-606-oq-03/meta.json
@@ -16,7 +16,7 @@
       "erdos",
       "research"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 100,

--- a/src/data/proofs/erdos-609/meta.json
+++ b/src/data/proofs/erdos-609/meta.json
@@ -17,7 +17,7 @@
       "extremal-combinatorics",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 16,
     "erdosNumber": 609,
     "erdosUrl": "https://erdosproblems.com/609",

--- a/src/data/proofs/erdos-61/meta.json
+++ b/src/data/proofs/erdos-61/meta.json
@@ -16,7 +16,7 @@
       "induced-subgraph",
       "conjecture"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 61,
     "erdosUrl": "https://erdosproblems.com/61",

--- a/src/data/proofs/erdos-629/meta.json
+++ b/src/data/proofs/erdos-629/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-629",
-  "title": "Erd\u0151s #629: List Chromatic Number of Bipartite Graphs",
+  "title": "Erdős #629: List Chromatic Number of Bipartite Graphs",
   "slug": "erdos-629",
-  "description": "Find n(k) = minimal vertices in bipartite G with list chromatic number \u03c7_L(G) > k. Surprisingly, \u03c7_L can be arbitrarily large even though \u03c7 \u2264 2!",
+  "description": "Find n(k) = minimal vertices in bipartite G with list chromatic number χ_L(G) > k. Surprisingly, χ_L can be arbitrarily large even though χ ≤ 2!",
   "meta": {
-    "author": "Paul Erd\u0151s, Arthur Rubin, Herbert Taylor",
+    "author": "Paul Erdős, Arthur Rubin, Herbert Taylor",
     "sourceUrl": "https://erdosproblems.com/629",
     "date": "1980",
     "status": "axiomatized",
@@ -16,7 +16,7 @@
       "list-coloring",
       "bipartite-graphs"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 7,
     "erdosNumber": 629,
     "erdosUrl": "https://erdosproblems.com/629",
@@ -27,16 +27,16 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "Erd\u0151s, Rubin, and Taylor introduced the concept of list coloring (choosability) in their landmark 1979/1980 paper, which revealed a fundamental surprise: bipartite graphs, though 2-colorable, can have arbitrarily large list chromatic number. They proved the first bounds $2^{k-1} < n(k) < k^2 \\cdot 2^{k+2}$ and computed $n(2) = 6$ using $K_{3,3}$ with a clever adversarial list assignment. Hanson, MacGillivray, and Toft (1996) determined $n(3) = 14$ through exhaustive case analysis and gave the recursive bound $n(k) \\leq k \\cdot n(k-2) + 2^k$. Radhakrishnan and Srinivasan (2000) improved the lower bound to $n(k) \\geq c \\cdot 2^k \\sqrt{k/\\ln k}$ using an entropy-based refinement of the probabilistic method. Galvin's 1995 theorem that $\\chi_L(K_{n,n}) = \\lceil\\log_2 n\\rceil + 1$, proved via the kernel method, provides the key structural result for complete bipartite graphs. The problem connects to Property B (Erd\u0151s Problem #901) via the sandwich inequality $m(k) \\leq n(k) \\leq m(k+1)$, linking list coloring to hypergraph 2-coloring theory.",
+    "historicalContext": "Erdős, Rubin, and Taylor introduced the concept of list coloring (choosability) in their landmark 1979/1980 paper, which revealed a fundamental surprise: bipartite graphs, though 2-colorable, can have arbitrarily large list chromatic number. They proved the first bounds $2^{k-1} < n(k) < k^2 \\cdot 2^{k+2}$ and computed $n(2) = 6$ using $K_{3,3}$ with a clever adversarial list assignment. Hanson, MacGillivray, and Toft (1996) determined $n(3) = 14$ through exhaustive case analysis and gave the recursive bound $n(k) \\leq k \\cdot n(k-2) + 2^k$. Radhakrishnan and Srinivasan (2000) improved the lower bound to $n(k) \\geq c \\cdot 2^k \\sqrt{k/\\ln k}$ using an entropy-based refinement of the probabilistic method. Galvin's 1995 theorem that $\\chi_L(K_{n,n}) = \\lceil\\log_2 n\\rceil + 1$, proved via the kernel method, provides the key structural result for complete bipartite graphs. The problem connects to Property B (Erdős Problem #901) via the sandwich inequality $m(k) \\leq n(k) \\leq m(k+1)$, linking list coloring to hypergraph 2-coloring theory.",
     "problemStatement": "The list chromatic number $\\chi_L(G)$ is the minimal $k$ such that for any assignment of lists of $k$ colors to vertices, a proper coloring exists from the lists. Find $n(k) =$ minimum number of vertices in a bipartite graph $G$ with $\\chi_L(G) > k$.",
-    "text": "Find n(k) = minimal vertices in bipartite G with list chromatic number \u03c7_L(G) > k. Surprisingly, \u03c7_L can be arbitrarily large even though \u03c7 \u2264 2!",
+    "text": "Find n(k) = minimal vertices in bipartite G with list chromatic number χ_L(G) > k. Surprisingly, χ_L can be arbitrarily large even though χ ≤ 2!",
     "proofStrategy": "The formalization builds on Mathlib's `SimpleGraph` and defines list coloring from scratch: `ColorListAssignment`, `RespectsLists`, `IsKListColorable`, and `listChromaticNumber` via infimum. The function $n(k)$ is defined as the infimum over bipartite witnesses. Aristotle proved 6 key results: `bipartite_chromatic_le_two`, `bipartite_list_chromatic_unbounded` (via the hitting-set construction on $(k+1)$-subsets), `n_well_defined`, `n_mono`, `n_2_eq_6` (using $K_{3,3}$ + case analysis), and `ert_lower_bound` (via the probabilistic method with random 2-coloring of colors). The remaining 8 sorries include $n(3) = 14$, the upper bound, improved bounds, Property B connection, and asymptotic results.",
     "keyInsights": [
-      "**The choosability surprise**: Bipartite graphs have $\\chi(G) \\leq 2$ but $\\chi_L(G)$ can be arbitrarily large \u2014 list coloring is fundamentally harder than ordinary coloring because an adversary controls the color lists",
+      "**The choosability surprise**: Bipartite graphs have $\\chi(G) \\leq 2$ but $\\chi_L(G)$ can be arbitrarily large — list coloring is fundamentally harder than ordinary coloring because an adversary controls the color lists",
       "**Hitting set construction**: The unboundedness proof uses $V = \\binom{[2k+1]}{k+1}$ as vertices of a complete bipartite graph; each vertex's list is its subset; the pigeonhole principle forces $\\geq k+1$ colors per side from only $2k+1$ total, guaranteeing a collision",
-      "**Probabilistic lower bound**: The proof that $2^{k-1} < n(k)$ uses a random 2-partition of colors \u2014 if $|V| < 2^k$, the union bound shows with positive probability every vertex has a usable color from its partition side",
+      "**Probabilistic lower bound**: The proof that $2^{k-1} < n(k)$ uses a random 2-partition of colors — if $|V| < 2^k$, the union bound shows with positive probability every vertex has a usable color from its partition side",
       "**Property B bridge**: The inequality $m(k) \\leq n(k) \\leq m(k+1)$ connects list coloring of bipartite graphs to Property B of set families, reducing questions about $n(k)$ to hypergraph 2-coloring thresholds",
-      "**Galvin's theorem context**: $\\chi_L(K_{n,n}) = \\lceil\\log_2 n\\rceil + 1$ (Galvin 1995) via the kernel method shows that for balanced complete bipartite graphs, the list chromatic number grows logarithmically \u2014 a key structural result underlying the bounds on $n(k)$"
+      "**Galvin's theorem context**: $\\chi_L(K_{n,n}) = \\lceil\\log_2 n\\rceil + 1$ (Galvin 1995) via the kernel method shows that for balanced complete bipartite graphs, the list chromatic number grows logarithmically — a key structural result underlying the bounds on $n(k)$"
     ],
     "prerequisites": [
       "Combinatorics and number theory",
@@ -62,7 +62,7 @@
     },
     {
       "id": "bipartite",
-      "title": "Bipartite Graphs and the \u03c7 vs \u03c7_L Gap",
+      "title": "Bipartite Graphs and the χ vs χ_L Gap",
       "summary": "Defines `IsBipartite G` (2-colorable via `Fin 2`), proves `bipartite_chromatic_le_two` ($\\chi(G) \\leq 2$, Aristotle), and builds the `MyGraph k` construction with Aristotle-proved lemmas showing `MyGraph k` is bipartite and not $(k+1)$-list-colorable via the hitting-set argument.",
       "startLine": 91,
       "endLine": 259,
@@ -111,23 +111,23 @@
     {
       "id": "property-b",
       "title": "Property B Connection",
-      "summary": "Defines `propertyB_threshold k` ($m(k)$ = smallest family of $k$-sets without Property B). States `n_property_b_bounds` (sorry): $m(k) \\leq n(k) \\leq m(k+1)$, connecting list coloring to Erd\u0151s Problem #901.",
+      "summary": "Defines `propertyB_threshold k` ($m(k)$ = smallest family of $k$-sets without Property B). States `n_property_b_bounds` (sorry): $m(k) \\leq n(k) \\leq m(k+1)$, connecting list coloring to Erdős Problem #901.",
       "startLine": 831,
       "endLine": 846,
-      "mathContext": "Defines `propertyB_threshold k` ($m(k)$ = smallest family of $k$-sets without Property B). States `n_property_b_bounds` (sorry): $m(k) \\leq n(k) \\leq m(k+1)$, connecting list coloring to Erd\u0151s Problem #901."
+      "mathContext": "Defines `propertyB_threshold k` ($m(k)$ = smallest family of $k$-sets without Property B). States `n_property_b_bounds` (sorry): $m(k) \\leq n(k) \\leq m(k+1)$, connecting list coloring to Erdős Problem #901."
     },
     {
       "id": "constructions",
       "title": "Complete Bipartite Graphs and Asymptotics",
-      "summary": "Defines `completeBipartite m n` ($K_{m,n}$ on `Fin m \u2295 Fin n`). States `knn_list_chromatic` (sorry): $\\chi_L(K_{n,n}) \\approx \\log_2 n + 1$. States `n_exponential_growth` (sorry) and defines `ExactAsymptoticConjecture`: $n(k) = \\Theta(2^k \\cdot k^\\alpha)$.",
+      "summary": "Defines `completeBipartite m n` ($K_{m,n}$ on `Fin m ⊕ Fin n`). States `knn_list_chromatic` (sorry): $\\chi_L(K_{n,n}) \\approx \\log_2 n + 1$. States `n_exponential_growth` (sorry) and defines `ExactAsymptoticConjecture`: $n(k) = \\Theta(2^k \\cdot k^\\alpha)$.",
       "startLine": 847,
       "endLine": 912,
-      "mathContext": "Defines `completeBipartite m n` ($K_{m,n}$ on `Fin m \u2295 Fin n`). States `knn_list_chromatic` (sorry): $\\chi_L(K_{n,n}) \\approx \\log_2 n + 1$. States `n_exponential_growth` (sorry) and defines `ExactAsymptoticConjecture`: $n(k) = \\Theta(2^k \\cdot k^\\alpha)$."
+      "mathContext": "Defines `completeBipartite m n` ($K_{m,n}$ on `Fin m ⊕ Fin n`). States `knn_list_chromatic` (sorry): $\\chi_L(K_{n,n}) \\approx \\log_2 n + 1$. States `n_exponential_growth` (sorry) and defines `ExactAsymptoticConjecture`: $n(k) = \\Theta(2^k \\cdot k^\\alpha)$."
     }
   ],
   "conclusion": {
-    "summary": "This 907-line formalization captures Erd\u0151s Problem #629 on list chromatic numbers of bipartite graphs. Aristotle proved 6 of the 14 key results, including the unboundedness of $\\chi_L$ for bipartite graphs, $n(2) = 6$, monotonicity of $n$, and the lower bound $2^{k-1} < n(k)$ via the probabilistic method. The 8 remaining sorries cover the upper bound, improved bounds, $n(3) = 14$, Property B connection, and asymptotic behavior.",
-    "implications": "**Theoretical Significance**: The gap between $\\chi(G)$ and $\\chi_L(G)$ for bipartite graphs reveals that list coloring is a fundamentally different problem from ordinary coloring. The connection to Property B links this to hypergraph coloring theory and Erd\u0151s Problem #901.\n\nUnderstanding the exact asymptotics of $n(k)$ would clarify the probabilistic-vs-structural boundary in extremal combinatorics. The formalization demonstrates that even for 'simple' graph classes (bipartite), list coloring problems can be remarkably deep.",
+    "summary": "This 907-line formalization captures Erdős Problem #629 on list chromatic numbers of bipartite graphs. Aristotle proved 6 of the 14 key results, including the unboundedness of $\\chi_L$ for bipartite graphs, $n(2) = 6$, monotonicity of $n$, and the lower bound $2^{k-1} < n(k)$ via the probabilistic method. The 8 remaining sorries cover the upper bound, improved bounds, $n(3) = 14$, Property B connection, and asymptotic behavior.",
+    "implications": "**Theoretical Significance**: The gap between $\\chi(G)$ and $\\chi_L(G)$ for bipartite graphs reveals that list coloring is a fundamentally different problem from ordinary coloring. The connection to Property B links this to hypergraph coloring theory and Erdős Problem #901.\n\nUnderstanding the exact asymptotics of $n(k)$ would clarify the probabilistic-vs-structural boundary in extremal combinatorics. The formalization demonstrates that even for 'simple' graph classes (bipartite), list coloring problems can be remarkably deep.",
     "openQuestions": [
       "What is the exact asymptotic exponent $\\alpha$ in $n(k) = \\Theta(2^k \\cdot k^\\alpha)$? Current bounds: $\\alpha \\in [1/2, 2]$",
       "Can $n(4)$ be computed exactly? ($n(2) = 6$, $n(3) = 14$ are known)",
@@ -186,17 +186,17 @@
     {
       "targetId": "erdos-630",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: bipartite-graphs, chromatic-number, graph-theory, list-coloring"
+      "description": "Related Erdős problem sharing themes: bipartite-graphs, chromatic-number, graph-theory, list-coloring"
     },
     {
       "targetId": "erdos-111",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: bipartite-graphs, chromatic-number, graph-theory"
+      "description": "Related Erdős problem sharing themes: bipartite-graphs, chromatic-number, graph-theory"
     },
     {
       "targetId": "erdos-631",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: chromatic-number, graph-theory, list-coloring"
+      "description": "Related Erdős problem sharing themes: chromatic-number, graph-theory, list-coloring"
     }
   ],
   "sorries": 7

--- a/src/data/proofs/erdos-633/meta.json
+++ b/src/data/proofs/erdos-633/meta.json
@@ -17,7 +17,7 @@
       "open-problem",
       "tiling-theory"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 8,
     "erdosNumber": 633,
     "erdosUrl": "https://erdosproblems.com/633",

--- a/src/data/proofs/erdos-64/meta.json
+++ b/src/data/proofs/erdos-64/meta.json
@@ -17,7 +17,7 @@
       "graph-theory",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 64,
     "erdosUrl": "https://erdosproblems.com/64",

--- a/src/data/proofs/erdos-654/meta.json
+++ b/src/data/proofs/erdos-654/meta.json
@@ -18,7 +18,7 @@
     "sourceUrl": "https://erdosproblems.com/654",
     "erdosUrl": "https://erdosproblems.com/654",
     "axiomCount": 0,
-    "badge": "wip",
+    "badge": "axiom",
     "assumptions": "0 axioms, 0 sorries. All results proved from Lean primitives.",
     "proofRepoPath": "Proofs/Erdos654Problem.lean",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/erdos-655/meta.json
+++ b/src/data/proofs/erdos-655/meta.json
@@ -15,7 +15,7 @@
       "concyclicity",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 655,
     "erdosUrl": "https://erdosproblems.com/655",

--- a/src/data/proofs/erdos-66/meta.json
+++ b/src/data/proofs/erdos-66/meta.json
@@ -16,7 +16,7 @@
       "representation-function",
       "conjecture"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 66,
     "erdosUrl": "https://erdosproblems.com/66",

--- a/src/data/proofs/erdos-660/meta.json
+++ b/src/data/proofs/erdos-660/meta.json
@@ -18,7 +18,7 @@
       "convex-geometry",
       "3D-geometry"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 10,
     "erdosNumber": 660,
     "erdosUrl": "https://erdosproblems.com/660",

--- a/src/data/proofs/erdos-661/meta.json
+++ b/src/data/proofs/erdos-661/meta.json
@@ -14,7 +14,7 @@
       "discrete-geometry",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/661",
     "erdosUrl": "https://erdosproblems.com/661",

--- a/src/data/proofs/erdos-678/meta.json
+++ b/src/data/proofs/erdos-678/meta.json
@@ -16,7 +16,7 @@
       "prime-powers",
       "computational"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 4,
     "erdosNumber": 678,
     "erdosUrl": "https://erdosproblems.com/678",

--- a/src/data/proofs/erdos-679/meta.json
+++ b/src/data/proofs/erdos-679/meta.json
@@ -17,7 +17,7 @@
       "additive-function",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 10,
     "erdosNumber": 679,
     "erdosUrl": "https://erdosproblems.com/679",

--- a/src/data/proofs/erdos-685/meta.json
+++ b/src/data/proofs/erdos-685/meta.json
@@ -15,7 +15,7 @@
       "binomial-coefficients",
       "prime-factors"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 685,
     "erdosUrl": "https://erdosproblems.com/685",

--- a/src/data/proofs/erdos-688/meta.json
+++ b/src/data/proofs/erdos-688/meta.json
@@ -16,7 +16,7 @@
       "congruences",
       "sieve theory"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 688,
     "erdosUrl": "https://erdosproblems.com/688",

--- a/src/data/proofs/erdos-691/meta.json
+++ b/src/data/proofs/erdos-691/meta.json
@@ -16,7 +16,7 @@
       "sieve-theory",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 691,
     "erdosUrl": "https://erdosproblems.com/691",

--- a/src/data/proofs/erdos-693/meta.json
+++ b/src/data/proofs/erdos-693/meta.json
@@ -16,7 +16,7 @@
       "density",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 693,
     "erdosUrl": "https://erdosproblems.com/693",

--- a/src/data/proofs/erdos-70/meta.json
+++ b/src/data/proofs/erdos-70/meta.json
@@ -16,7 +16,7 @@
       "ramsey-theory",
       "ordinals"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 70,
     "erdosUrl": "https://erdosproblems.com/70",

--- a/src/data/proofs/erdos-700/meta.json
+++ b/src/data/proofs/erdos-700/meta.json
@@ -15,7 +15,7 @@
     ],
     "proofRepoPath": "Proofs/Erdos700Problem.lean",
     "sorries": 0,
-    "badge": "wip",
+    "badge": "axiom",
     "sourceUrl": "https://erdosproblems.com/700",
     "erdosUrl": "https://erdosproblems.com/700",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-736/meta.json
+++ b/src/data/proofs/erdos-736/meta.json
@@ -17,7 +17,7 @@
       "set-theory",
       "independence"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 1,
     "erdosNumber": 736,
     "erdosUrl": "https://erdosproblems.com/736",

--- a/src/data/proofs/erdos-74/meta.json
+++ b/src/data/proofs/erdos-74/meta.json
@@ -16,7 +16,7 @@
       "bipartite",
       "conjecture"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 74,
     "erdosUrl": "https://erdosproblems.com/74",

--- a/src/data/proofs/erdos-745/meta.json
+++ b/src/data/proofs/erdos-745/meta.json
@@ -16,7 +16,7 @@
       "probabilistic-combinatorics",
       "solved"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 745,
     "erdosUrl": "https://erdosproblems.com/745",

--- a/src/data/proofs/erdos-75/meta.json
+++ b/src/data/proofs/erdos-75/meta.json
@@ -16,7 +16,7 @@
       "infinite-combinatorics",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 75,
     "erdosUrl": "https://erdosproblems.com/75",

--- a/src/data/proofs/erdos-750/meta.json
+++ b/src/data/proofs/erdos-750/meta.json
@@ -15,7 +15,7 @@
       "ramsey-theory",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/750",
     "erdosUrl": "https://erdosproblems.com/750",

--- a/src/data/proofs/erdos-768/meta.json
+++ b/src/data/proofs/erdos-768/meta.json
@@ -15,7 +15,7 @@
       "asymptotics",
       "group-theory"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 768,
     "erdosUrl": "https://erdosproblems.com/768",

--- a/src/data/proofs/erdos-783/meta.json
+++ b/src/data/proofs/erdos-783/meta.json
@@ -15,7 +15,7 @@
       "prime-numbers",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/783",
     "erdosUrl": "https://erdosproblems.com/783",

--- a/src/data/proofs/erdos-807/meta.json
+++ b/src/data/proofs/erdos-807/meta.json
@@ -17,7 +17,7 @@
       "probabilistic-combinatorics",
       "disproved"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 807,
     "erdosUrl": "https://erdosproblems.com/807",

--- a/src/data/proofs/erdos-817/meta.json
+++ b/src/data/proofs/erdos-817/meta.json
@@ -16,7 +16,7 @@
       "subset-sums",
       "extremal-combinatorics"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 817,
     "erdosUrl": "https://erdosproblems.com/817",

--- a/src/data/proofs/erdos-825/meta.json
+++ b/src/data/proofs/erdos-825/meta.json
@@ -15,7 +15,7 @@
       "weird numbers",
       "semiperfect numbers"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 825,
     "erdosUrl": "https://erdosproblems.com/825",

--- a/src/data/proofs/erdos-826/meta.json
+++ b/src/data/proofs/erdos-826/meta.json
@@ -15,7 +15,7 @@
       "arithmetic-functions",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 826,
     "erdosUrl": "https://erdosproblems.com/826",

--- a/src/data/proofs/erdos-830/meta.json
+++ b/src/data/proofs/erdos-830/meta.json
@@ -16,7 +16,7 @@
       "amicable-numbers",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 830,
     "erdosUrl": "https://erdosproblems.com/830",

--- a/src/data/proofs/erdos-837/meta.json
+++ b/src/data/proofs/erdos-837/meta.json
@@ -45,7 +45,7 @@
       "Axiomatized 0 ∈ A_3 (zero is a jump for 3-uniform hypergraphs)"
     ],
     "axiomCount": 0,
-    "badge": "wip",
+    "badge": "axiom",
     "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean.",
     "proofRepoPath": "Proofs/Erdos837Problem.lean",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/erdos-845/meta.json
+++ b/src/data/proofs/erdos-845/meta.json
@@ -17,7 +17,7 @@
       "representations",
       "density"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 845,
     "erdosUrl": "https://erdosproblems.com/845",

--- a/src/data/proofs/erdos-85/meta.json
+++ b/src/data/proofs/erdos-85/meta.json
@@ -17,7 +17,7 @@
       "minimum-degree",
       "conjecture"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 85,
     "erdosUrl": "https://erdosproblems.com/85",

--- a/src/data/proofs/erdos-854/meta.json
+++ b/src/data/proofs/erdos-854/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-854",
-  "title": "Erd\u0151s Problem #854: Gaps Between Coprime Residues of Primorials",
+  "title": "Erdős Problem #854: Gaps Between Coprime Residues of Primorials",
   "slug": "erdos-854",
-  "description": "Study the gaps between consecutive integers coprime to primorials. Erd\u0151s asked to estimate the smallest missing gap and whether the number of distinct gaps is proportional to the maximal gap.",
+  "description": "Study the gaps between consecutive integers coprime to primorials. Erdős asked to estimate the smallest missing gap and whether the number of distinct gaps is proportional to the maximal gap.",
   "meta": {
-    "author": "Erd\u0151s",
+    "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/854",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos854Problem.lean",
@@ -17,7 +17,7 @@
       "jacobsthal-function",
       "coprime-residues"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 854,
     "erdosUrl": "https://erdosproblems.com/854",
@@ -28,14 +28,14 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "**Erd\u0151s** posed this problem about the gap structure of coprime residues modulo primorials. The sequence $1 = a_1 < a_2 < \\cdots < a_{\\varphi(n_k)} = n_k - 1$ of integers coprime to the $k$-th primorial $n_k = p_1 \\cdots p_k$ exhibits a rich gap structure. Erd\u0151s initially conjectured that **all even integers** up to the maximal gap appear as consecutive differences, but computational work by **Lacampagne and Selfridge** for $n_6 = 30030$ disproved this strong form. The problem connects to the **Jacobsthal function** $j(n)$, the maximum gap between consecutive integers coprime to $n$, studied by Jacobsthal (1960), Iwaniec (1978), and Pintz (1997). Iwaniec proved $j(n) \\ll (\\log n)^2$, giving the sharpest known upper bound. The two remaining open questions\u2014growth rate of the smallest missing gap and proportionality of distinct gap counts\u2014connect coprimality patterns to distribution of primes in arithmetic progressions.",
-    "problemStatement": "Let n\u2096 be the k-th primorial and 1 = a\u2081 < a\u2082 < \u22ef < a_{\u03c6(n\u2096)} = n\u2096\u22121 be the coprime residues. (1) Estimate the smallest even integer not of the form a\u1d62\u208a\u2081 \u2212 a\u1d62. (2) Is the number of distinct gap values \u226b max(a\u1d62\u208a\u2081 \u2212 a\u1d62)?",
-    "text": "Study the gaps between consecutive integers coprime to primorials. Erd\u0151s asked to estimate the smallest missing gap and whether the number of distinct gaps is proportional to the maximal gap.",
-    "proofStrategy": "Prime enumeration uses Mathlib's `Nat.nth Nat.Prime` (0-indexed), replacing 4 former axioms with proved theorems. Coprime residues defined computationally via `Finset.filter`, with sorted list strict ordering proved from `Finset.sort` properties. Gap evenness proved via three-lemma chain: (1) two_dvd_primorial shows primorial k is even for k \u2265 1, (2) coprimeResidues_odd shows coprime residues of even numbers are odd via Nat.dvd_gcd, (3) zipWith_sub_dvd_two proves differences of odd numbers are even by structural induction. Maximal gap membership and first missing gap existence both proved. Remaining 4 axioms: Jacobsthal bound, Lacampagne-Selfridge counterexample, and both parts of the open conjecture.",
+    "historicalContext": "**Erdős** posed this problem about the gap structure of coprime residues modulo primorials. The sequence $1 = a_1 < a_2 < \\cdots < a_{\\varphi(n_k)} = n_k - 1$ of integers coprime to the $k$-th primorial $n_k = p_1 \\cdots p_k$ exhibits a rich gap structure. Erdős initially conjectured that **all even integers** up to the maximal gap appear as consecutive differences, but computational work by **Lacampagne and Selfridge** for $n_6 = 30030$ disproved this strong form. The problem connects to the **Jacobsthal function** $j(n)$, the maximum gap between consecutive integers coprime to $n$, studied by Jacobsthal (1960), Iwaniec (1978), and Pintz (1997). Iwaniec proved $j(n) \\ll (\\log n)^2$, giving the sharpest known upper bound. The two remaining open questions—growth rate of the smallest missing gap and proportionality of distinct gap counts—connect coprimality patterns to distribution of primes in arithmetic progressions.",
+    "problemStatement": "Let nₖ be the k-th primorial and 1 = a₁ < a₂ < ⋯ < a_{φ(nₖ)} = nₖ−1 be the coprime residues. (1) Estimate the smallest even integer not of the form aᵢ₊₁ − aᵢ. (2) Is the number of distinct gap values ≫ max(aᵢ₊₁ − aᵢ)?",
+    "text": "Study the gaps between consecutive integers coprime to primorials. Erdős asked to estimate the smallest missing gap and whether the number of distinct gaps is proportional to the maximal gap.",
+    "proofStrategy": "Prime enumeration uses Mathlib's `Nat.nth Nat.Prime` (0-indexed), replacing 4 former axioms with proved theorems. Coprime residues defined computationally via `Finset.filter`, with sorted list strict ordering proved from `Finset.sort` properties. Gap evenness proved via three-lemma chain: (1) two_dvd_primorial shows primorial k is even for k ≥ 1, (2) coprimeResidues_odd shows coprime residues of even numbers are odd via Nat.dvd_gcd, (3) zipWith_sub_dvd_two proves differences of odd numbers are even by structural induction. Maximal gap membership and first missing gap existence both proved. Remaining 4 axioms: Jacobsthal bound, Lacampagne-Selfridge counterexample, and both parts of the open conjecture.",
     "keyInsights": [
-      "**All gaps are even for k \u2265 2**: since the primorial $n_k$ is divisible by 2, all coprime residues are odd, so all consecutive differences are even",
+      "**All gaps are even for k ≥ 2**: since the primorial $n_k$ is divisible by 2, all coprime residues are odd, so all consecutive differences are even",
       "**Jacobsthal function bound**: the maximal gap satisfies $g(n_k) \\leq 2p_k$, connecting to the deep sieve-theoretic bounds of Iwaniec ($j(n) \\ll (\\log n)^2$)",
-      "**Lacampagne-Selfridge disproof**: computational verification for $n_6 = 30030$ (with $\\varphi(30030) = 5760$ coprime residues) showed that not all even integers up to $g(30030)$ appear as gaps, disproving Erd\u0151s's original strong conjecture",
+      "**Lacampagne-Selfridge disproof**: computational verification for $n_6 = 30030$ (with $\\varphi(30030) = 5760$ coprime residues) showed that not all even integers up to $g(30030)$ appear as gaps, disproving Erdős's original strong conjecture",
       "**Two-part open problem**: Part 1 asks for the growth rate of the smallest missing gap; Part 2 asks whether the number of distinct gap values is proportional to the maximal gap",
       "**Computable vs axiomatized**: the coprime residue set is defined computationally via `Finset.filter`, while the sorted enumeration and gap set are axiomatized to separate the combinatorial structure from computational concerns"
     ],
@@ -67,7 +67,7 @@
       "startLine": 45,
       "endLine": 49,
       "summary": "Defines the k-th primorial recursively as the product of the first k primes (0-indexed).",
-      "mathContext": "Formal definition: primorial k = p\u2080 \u00b7 p\u2081 \u00b7 \u22ef \u00b7 p\u2096\u208b\u2081."
+      "mathContext": "Formal definition: primorial k = p₀ · p₁ · ⋯ · pₖ₋₁."
     },
     {
       "id": "coprime-residues",
@@ -82,7 +82,7 @@
       "title": "Gap Set, Maximal Gap, and Evenness (Proved)",
       "startLine": 72,
       "endLine": 152,
-      "summary": "Defines gap set from consecutive coprime differences. Gap evenness proved: primorial divisible by 2 \u2192 coprime residues odd \u2192 differences even, via structural induction on zipWith. Maximal gap membership proved via sup=max' for nonempty finsets.",
+      "summary": "Defines gap set from consecutive coprime differences. Gap evenness proved: primorial divisible by 2 → coprime residues odd → differences even, via structural induction on zipWith. Maximal gap membership proved via sup=max' for nonempty finsets.",
       "mathContext": "Verified: gaps_even proved from three helper theorems (two_dvd_primorial, coprimeResidues_odd, zipWith_sub_dvd_two). maxGap_mem proved for nonempty gap sets."
     },
     {
@@ -98,7 +98,7 @@
       "title": "Lacampagne-Selfridge Counterexample",
       "startLine": 130,
       "endLine": 133,
-      "summary": "Records the computational disproof of Erd\u0151s's strong conjecture for n\u2086 = 30030.",
+      "summary": "Records the computational disproof of Erdős's strong conjecture for n₆ = 30030.",
       "mathContext": "Axiomatized: Computational fact about specific primorial."
     },
     {
@@ -119,7 +119,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Erd\u0151s Problem 854 explores the rich combinatorial structure of gaps between coprime residues of primorials. The original strong conjecture (all even gaps up to the maximum) was disproved by Lacampagne and Selfridge for n\u2086 = 30030, but both the growth rate of the smallest missing gap and the proportionality of distinct gap counts remain open.",
+    "summary": "Erdős Problem 854 explores the rich combinatorial structure of gaps between coprime residues of primorials. The original strong conjecture (all even gaps up to the maximum) was disproved by Lacampagne and Selfridge for n₆ = 30030, but both the growth rate of the smallest missing gap and the proportionality of distinct gap counts remain open.",
     "implications": "Understanding these gap patterns connects to the Jacobsthal function, sieve methods, and the distribution of primes in arithmetic progressions. Resolution would illuminate the fine structure of integers surviving sieving by small primes.",
     "openQuestions": [
       "How fast does the smallest missing gap grow with k?",
@@ -150,17 +150,17 @@
     {
       "targetId": "erdos-852",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: number-theory, prime-gaps, sieve-theory"
+      "description": "Related Erdős problem sharing themes: number-theory, prime-gaps, sieve-theory"
     },
     {
       "targetId": "erdos-1055",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: number-theory, prime-gaps"
+      "description": "Related Erdős problem sharing themes: number-theory, prime-gaps"
     },
     {
       "targetId": "erdos-1101",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: number-theory, sieve-theory"
+      "description": "Related Erdős problem sharing themes: number-theory, sieve-theory"
     }
   ],
   "sorries": 0

--- a/src/data/proofs/erdos-863/meta.json
+++ b/src/data/proofs/erdos-863/meta.json
@@ -14,7 +14,7 @@
       "sidon-sets",
       "number-theory"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 863,
     "erdosUrl": "https://erdosproblems.com/863",

--- a/src/data/proofs/erdos-866/meta.json
+++ b/src/data/proofs/erdos-866/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-866",
-  "title": "Erd\u0151s Problem #866: Pairwise Sums Threshold",
+  "title": "Erdős Problem #866: Pairwise Sums Threshold",
   "slug": "erdos-866",
-  "description": "For k \u2265 3, define g_k(N) as the minimal threshold such that A \u2286 {1,...,2N} with |A| \u2265 N + g_k(N) contains all pairwise sums of some b\u2081,...,b_k. Known: g\u2083=2, g\u2084\u22642032, g\u2085\u224dlog N, g\u2086\u224d\u221aN. General bounds have gaps.",
+  "description": "For k ≥ 3, define g_k(N) as the minimal threshold such that A ⊆ {1,...,2N} with |A| ≥ N + g_k(N) contains all pairwise sums of some b₁,...,b_k. Known: g₃=2, g₄≤2032, g₅≍log N, g₆≍√N. General bounds have gaps.",
   "meta": {
-    "author": "Choi, Erd\u0151s, Szemer\u00e9di",
+    "author": "Choi, Erdős, Szemerédi",
     "sourceUrl": "https://erdosproblems.com/866",
     "date": "1975",
     "mathlib_version": "4.26.0",
@@ -17,7 +17,7 @@
       "threshold-functions",
       "erdos"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 866,
     "erdosUrl": "https://erdosproblems.com/866",
@@ -35,21 +35,21 @@
       },
       {
         "theorem": "Real.log",
-        "description": "Logarithm for g\u2085 bounds",
+        "description": "Logarithm for g₅ bounds",
         "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
       },
       {
         "theorem": "Real.sqrt",
-        "description": "Square root for g\u2086 bounds",
+        "description": "Square root for g₆ bounds",
         "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
       }
     ],
     "originalContributions": [
-      "Formal definition of HasAllPairwiseSums and PairwiseSumCondition using Fin k \u2192 \u2124 witnesses",
+      "Formal definition of HasAllPairwiseSums and PairwiseSumCondition using Fin k → ℤ witnesses",
       "Threshold function g_k(N) via Nat.find with vacuous existence proof",
-      "Complete case analysis: g\u2083=2 (exact), g\u2084\u22642032 (van Doorn), g\u2085\u224dlog N, g\u2086\u224d\u221aN",
+      "Complete case analysis: g₃=2 (exact), g₄≤2032 (van Doorn), g₅≍log N, g₆≍√N",
       "General upper bound N^{1-2^{-k}} with upperExponent monotonicity",
-      "General lower bound N^{1-\u03b5} for large k, with threshold_approaches_N corollary",
+      "General lower bound N^{1-ε} for large k, with threshold_approaches_N corollary",
       "Odd numbers construction as fundamental extremal example",
       "Four open problems formalized as Lean propositions"
     ],
@@ -58,17 +58,17 @@
     "assumptions": "0 axioms. 0 sorries. All results formalized without axioms."
   },
   "overview": {
-    "historicalContext": "Erd\u0151s Problem #866 originates from the work of Choi, Erd\u0151s, and Szemer\u00e9di on sumsets and additive combinatorics, building on their unpublished manuscript 'On sums and products of integers.' The problem asks: how large must a subset A of {1,...,2N} be to guarantee that some k integers have all their pairwise sums in A?\n\nThe foundational observation is the odd numbers construction: the set {1, 3, 5, ..., 2N-1} has N elements but avoids all pairwise sums (since odd + odd = even). This shows the threshold must be at least 1 above N. For k=3, the exact answer is g\u2083(N) = 2, proved via a complementary pairs pigeonhole argument.\n\nThe most striking feature is the phase transition as k increases: g\u2083 = 2 (constant), g\u2084 \u2264 2032 (bounded constant, van Doorn), g\u2085 \u224d log N (logarithmic), g\u2086 \u224d \u221aN (polynomial). The general upper bound g_k(N) \u226a N^{1-2^{-k}} (Choi\u2013Erd\u0151s\u2013Szemer\u00e9di) shows the exponent approaches 1 geometrically, while the lower bound g_k(N) > N^{1-\u03b5} for large k shows the threshold eventually approaches N.\n\nThis growth rate transition\u2014from constant through logarithmic and polynomial to nearly linear\u2014is rare in combinatorics and reflects deep structural changes in the extremal problem. The gap between upper and lower bounds for intermediate and large k remains one of the central open questions in additive combinatorics.",
-    "problemStatement": "**Problem Statement**\n\nFor k \u2265 3, let g_k(N) be the minimal value such that if A \u2286 {1,...,2N} has |A| \u2265 N + g_k(N), then there exist integers b\u2081,...,b_k such that all $\\binom{k}{2}$ pairwise sums b_i + b_j are in A (the b_i need not be in A).\n\n**Goal**: Estimate g_k(N) for all k.\n\n**Status**: PARTIALLY SOLVED\n- Small k (3,4,5,6): Well characterized\n- Large k: Gap between upper and lower bounds",
-    "text": "For k \u2265 3, define g_k(N) as the minimal threshold such that A \u2286 {1,...,2N} with |A| \u2265 N + g_k(N) contains all pairwise sums of some b\u2081,...,b_k. Known: g\u2083=2, g\u2084\u22642032, g\u2085\u224dlog N, g\u2086\u224d\u221aN. General bounds have gaps.",
-    "proofStrategy": "The formalization is organized into eleven parts:\n\n1. **Definitions**: Interval, HasAllPairwiseSums (using Fin k \u2192 \u2124), PairwiseSumCondition, and g via Nat.find\n2. **Case k=3**: g\u2083(N) = 2 exactly (axiom), with lower bound from odd numbers construction\n3. **Case k=4**: g\u2084(N) bounded (axiom), van Doorn's explicit g\u2084 \u2264 2032 (axiom)\n4. **Case k=5**: g\u2085(N) \u224d log N (axiom), lower bound extracted as corollary via `obtain`\n5. **Case k=6**: g\u2086(N) \u224d \u221aN (axiom)\n6. **General upper**: g_k(N) \u226a N^{1-2^{-k}} with upperExponent monotonicity (proved)\n7. **General lower**: g_k(N) > N^{1-\u03b5} for large k (axiom), threshold_approaches_N (proved)\n8. **Odd numbers**: Extremal construction with cardinality (proved) and avoidance (proved) proofs\n9. **Summary table**: Four summary theorems directly referencing axioms\n10. **Open problems**: Four formalized as Lean Props\n11. **Main summary**: Conjunction of g\u2083 exact and g\u2084 bounded",
+    "historicalContext": "Erdős Problem #866 originates from the work of Choi, Erdős, and Szemerédi on sumsets and additive combinatorics, building on their unpublished manuscript 'On sums and products of integers.' The problem asks: how large must a subset A of {1,...,2N} be to guarantee that some k integers have all their pairwise sums in A?\n\nThe foundational observation is the odd numbers construction: the set {1, 3, 5, ..., 2N-1} has N elements but avoids all pairwise sums (since odd + odd = even). This shows the threshold must be at least 1 above N. For k=3, the exact answer is g₃(N) = 2, proved via a complementary pairs pigeonhole argument.\n\nThe most striking feature is the phase transition as k increases: g₃ = 2 (constant), g₄ ≤ 2032 (bounded constant, van Doorn), g₅ ≍ log N (logarithmic), g₆ ≍ √N (polynomial). The general upper bound g_k(N) ≪ N^{1-2^{-k}} (Choi–Erdős–Szemerédi) shows the exponent approaches 1 geometrically, while the lower bound g_k(N) > N^{1-ε} for large k shows the threshold eventually approaches N.\n\nThis growth rate transition—from constant through logarithmic and polynomial to nearly linear—is rare in combinatorics and reflects deep structural changes in the extremal problem. The gap between upper and lower bounds for intermediate and large k remains one of the central open questions in additive combinatorics.",
+    "problemStatement": "**Problem Statement**\n\nFor k ≥ 3, let g_k(N) be the minimal value such that if A ⊆ {1,...,2N} has |A| ≥ N + g_k(N), then there exist integers b₁,...,b_k such that all $\\binom{k}{2}$ pairwise sums b_i + b_j are in A (the b_i need not be in A).\n\n**Goal**: Estimate g_k(N) for all k.\n\n**Status**: PARTIALLY SOLVED\n- Small k (3,4,5,6): Well characterized\n- Large k: Gap between upper and lower bounds",
+    "text": "For k ≥ 3, define g_k(N) as the minimal threshold such that A ⊆ {1,...,2N} with |A| ≥ N + g_k(N) contains all pairwise sums of some b₁,...,b_k. Known: g₃=2, g₄≤2032, g₅≍log N, g₆≍√N. General bounds have gaps.",
+    "proofStrategy": "The formalization is organized into eleven parts:\n\n1. **Definitions**: Interval, HasAllPairwiseSums (using Fin k → ℤ), PairwiseSumCondition, and g via Nat.find\n2. **Case k=3**: g₃(N) = 2 exactly (axiom), with lower bound from odd numbers construction\n3. **Case k=4**: g₄(N) bounded (axiom), van Doorn's explicit g₄ ≤ 2032 (axiom)\n4. **Case k=5**: g₅(N) ≍ log N (axiom), lower bound extracted as corollary via `obtain`\n5. **Case k=6**: g₆(N) ≍ √N (axiom)\n6. **General upper**: g_k(N) ≪ N^{1-2^{-k}} with upperExponent monotonicity (proved)\n7. **General lower**: g_k(N) > N^{1-ε} for large k (axiom), threshold_approaches_N (proved)\n8. **Odd numbers**: Extremal construction with cardinality (proved) and avoidance (proved) proofs\n9. **Summary table**: Four summary theorems directly referencing axioms\n10. **Open problems**: Four formalized as Lean Props\n11. **Main summary**: Conjunction of g₃ exact and g₄ bounded",
     "keyInsights": [
-      "**Phase transition in growth rates**: The sequence constant \u2192 log \u2192 \u221aN \u2192 N^{1-o(1)} as k increases from 3 to \u221e represents a rare and striking phenomenon in combinatorics. Each transition (k=4\u21925, k=5\u21926, finite\u2192\u221e) requires fundamentally different techniques.",
-      "**The odd numbers construction is universal**: The set of odd integers in [2N] has exactly N elements and avoids ALL pairwise sum configurations (for any k), because two integers of the same parity sum to an even number. This single construction provides the base lower bound g_k(N) \u2265 1 for all k.",
-      "**Witnesses need not be in A**: The b_i are arbitrary integers whose pairwise sums land in A. Allowing b_i \u2209 A and b_i < 0 (via Fin k \u2192 \u2124) is essential\u2014the problem would be much harder if we required b_i \u2208 A.",
-      "**The k=4 to k=5 transition is the sharpest**: g\u2084 = O(1) while g\u2085 = \u0398(log N). Adding one more integer to the required pattern (4\u21925 witnesses, 6\u219210 pairwise sums) causes the threshold to jump from bounded to unbounded. This is the point where the combinatorial complexity qualitatively changes.",
-      "**The exponent 1-2^{-k} comes from induction**: The general upper bound proceeds by induction on k: given k-1 witnesses, the remaining density suffices to find the k-th. Each inductive step squares the deficiency (from N^\u03b1 to N^{(1+\u03b1)/2}), giving the geometric approach to exponent 1.",
-      "**The gap between bounds is the main open problem**: For large k, the upper exponent 1-2^{-k} and lower exponent 1-\u03b5 don't match. Finding the true exponent \u03b1_k with g_k(N) = N^{\u03b1_k+o(1)} is the central challenge."
+      "**Phase transition in growth rates**: The sequence constant → log → √N → N^{1-o(1)} as k increases from 3 to ∞ represents a rare and striking phenomenon in combinatorics. Each transition (k=4→5, k=5→6, finite→∞) requires fundamentally different techniques.",
+      "**The odd numbers construction is universal**: The set of odd integers in [2N] has exactly N elements and avoids ALL pairwise sum configurations (for any k), because two integers of the same parity sum to an even number. This single construction provides the base lower bound g_k(N) ≥ 1 for all k.",
+      "**Witnesses need not be in A**: The b_i are arbitrary integers whose pairwise sums land in A. Allowing b_i ∉ A and b_i < 0 (via Fin k → ℤ) is essential—the problem would be much harder if we required b_i ∈ A.",
+      "**The k=4 to k=5 transition is the sharpest**: g₄ = O(1) while g₅ = Θ(log N). Adding one more integer to the required pattern (4→5 witnesses, 6→10 pairwise sums) causes the threshold to jump from bounded to unbounded. This is the point where the combinatorial complexity qualitatively changes.",
+      "**The exponent 1-2^{-k} comes from induction**: The general upper bound proceeds by induction on k: given k-1 witnesses, the remaining density suffices to find the k-th. Each inductive step squares the deficiency (from N^α to N^{(1+α)/2}), giving the geometric approach to exponent 1.",
+      "**The gap between bounds is the main open problem**: For large k, the upper exponent 1-2^{-k} and lower exponent 1-ε don't match. Finding the true exponent α_k with g_k(N) = N^{α_k+o(1)} is the central challenge."
     ],
     "prerequisites": [
       "Additive combinatorics (sumsets, density)",
@@ -79,23 +79,23 @@
     {
       "id": "basic-definitions",
       "title": "Basic Definitions",
-      "summary": "Defines Interval(N) = {1,...,2N}, HasAllPairwiseSums via Fin k \u2192 \u2124 witnesses, PairwiseSumCondition as the universal threshold statement, and g(k,N) via Nat.find.",
+      "summary": "Defines Interval(N) = {1,...,2N}, HasAllPairwiseSums via Fin k → ℤ witnesses, PairwiseSumCondition as the universal threshold statement, and g(k,N) via Nat.find.",
       "startLine": 41,
       "endLine": 66,
       "mathContext": "$[2N] = \\{1,\\ldots,2N\\}$. $\\text{HasAllPairwiseSums}(A,b) :\\equiv \\forall i < j,\\; b_i + b_j \\in A$ for witnesses $b : \\text{Fin}\\,k \\to \\mathbb{Z}$. $g_k(N) = \\min\\{g : \\forall A \\subseteq [2N], |A| \\ge N+g \\Rightarrow \\exists b, \\text{HasAllPairwiseSums}(A,b)\\}$."
     },
     {
       "id": "case-k3",
-      "title": "Case k=3: Exact Value g\u2083=2",
-      "summary": "Axiomatizes g\u2083(N) = 2 (Choi\u2013Erd\u0151s\u2013Szemer\u00e9di). Lower bound g\u2083 \u2265 2 from odd numbers + parity pigeonhole.",
+      "title": "Case k=3: Exact Value g₃=2",
+      "summary": "Axiomatizes g₃(N) = 2 (Choi–Erdős–Szemerédi). Lower bound g₃ ≥ 2 from odd numbers + parity pigeonhole.",
       "startLine": 67,
       "endLine": 82,
-      "mathContext": "$g_3(N) = 2$ exactly. Upper bound: axiom (Choi\u2013Erd\u0151s\u2013Szemer\u00e9di pigeonhole on complementary pairs). Lower bound: $O_N = \\{1,3,\\ldots,2N-1\\}$ has $|O_N|=N$ but odd+odd=even $\\notin O_N$, so $g_3 \\ge 2$."
+      "mathContext": "$g_3(N) = 2$ exactly. Upper bound: axiom (Choi–Erdős–Szemerédi pigeonhole on complementary pairs). Lower bound: $O_N = \\{1,3,\\ldots,2N-1\\}$ has $|O_N|=N$ but odd+odd=even $\\notin O_N$, so $g_3 \\ge 2$."
     },
     {
       "id": "case-k4",
-      "title": "Case k=4: Bounded Threshold g\u2084\u22642032",
-      "summary": "Two axioms: g\u2084(N) \u2264 C absolutely (Choi\u2013Erd\u0151s\u2013Szemer\u00e9di) and g\u2084(N) \u2264 2032 (van Doorn).",
+      "title": "Case k=4: Bounded Threshold g₄≤2032",
+      "summary": "Two axioms: g₄(N) ≤ C absolutely (Choi–Erdős–Szemerédi) and g₄(N) ≤ 2032 (van Doorn).",
       "startLine": 83,
       "endLine": 100,
       "mathContext": "$\\exists C \\in \\mathbb{N},\\; \\forall N,\\; g_4(N) \\le C$ (bounded). Explicit: $g_4(N) \\le 2032$ (van Doorn). Stark contrast: $g_4 = O(1)$ while $g_5 = \\Theta(\\log N)$."
@@ -103,15 +103,15 @@
     {
       "id": "case-k5-k6",
       "title": "Cases k=5,6: Logarithmic and Polynomial Growth",
-      "summary": "g\u2085\u224dlog N (Choi\u2013Erd\u0151s\u2013Szemer\u00e9di), g\u2086\u224d\u221aN. Lower bound for g\u2085 extracted via `obtain` from the asymptotic axiom.",
+      "summary": "g₅≍log N (Choi–Erdős–Szemerédi), g₆≍√N. Lower bound for g₅ extracted via `obtain` from the asymptotic axiom.",
       "startLine": 101,
       "endLine": 128,
       "mathContext": "$g_5(N) \\asymp \\log N$: $\\exists c_1,c_2 > 0,\\; c_1 \\log N \\le g_5(N) \\le c_2 \\log N$. $g_6(N) \\asymp \\sqrt{N}$. The transition $O(1) \\to \\Theta(\\log N) \\to \\Theta(\\sqrt{N})$ reflects the jump from $\\binom{4}{2}=6$ to $\\binom{5}{2}=10$ to $\\binom{6}{2}=15$ required sums."
     },
     {
       "id": "general-bounds",
-      "title": "General Bounds: Upper N^{1-2^{-k}} and Lower N^{1-\u03b5}",
-      "summary": "General upper bound g_k(N) \u226a N^{1-2^{-k}} with upperExponent monotonicity (proved). General lower: g_k > N^{1-\u03b5} for large k (axiom). threshold_approaches_N corollary.",
+      "title": "General Bounds: Upper N^{1-2^{-k}} and Lower N^{1-ε}",
+      "summary": "General upper bound g_k(N) ≪ N^{1-2^{-k}} with upperExponent monotonicity (proved). General lower: g_k > N^{1-ε} for large k (axiom). threshold_approaches_N corollary.",
       "startLine": 129,
       "endLine": 172,
       "mathContext": "Upper: $g_k(N) \\le C_k N^{1-2^{-k}}$ (exponent $\\nearrow 1$ geometrically). Lower: $\\forall \\varepsilon>0,\\; \\exists k_0,\\; k \\ge k_0 \\Rightarrow g_k(N) > N^{1-\\varepsilon}$. Together: $g_k(N) = N^{1-o(1)}$ as $k \\to \\infty$. Gap: true exponent $\\alpha_k \\in (1-2^{-k}, 1-\\varepsilon)$ unknown."
@@ -127,19 +127,19 @@
     {
       "id": "summary-open",
       "title": "Summary Table and Four Open Problems",
-      "summary": "Theorems referencing all case axioms (g\u2083=2, g\u2084\u22642032, g\u2085\u224dlog N, g\u2086\u224d\u221aN, general bounds). Four open problems formalized as Props.",
+      "summary": "Theorems referencing all case axioms (g₃=2, g₄≤2032, g₅≍log N, g₆≍√N, general bounds). Four open problems formalized as Props.",
       "startLine": 196,
       "endLine": 274,
       "mathContext": "Summary: $g_3=2,\\; g_4 \\le 2032,\\; g_5 \\asymp \\log N,\\; g_6 \\asymp \\sqrt{N},\\; g_k \\ll N^{1-2^{-k}},\\; g_k > N^{1-\\varepsilon} \\text{ (large } k)$. Opens: (1) exact $g_4$, (2) constants in $g_5 \\asymp \\log N$, (3) true exponent $\\alpha_k$, (4) structural characterization of extremal sets."
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erd\u0151s Problem #866 on pairwise sums threshold functions, organizing the theory into case analysis (k=3,4,5,6), general bounds, extremal constructions, and open problems. All supporting lemmas proved by Aristotle: upperExponent monotonicity, oddNumbers cardinality, and oddNumbers avoidance. 7 axioms encode the known mathematical results.",
-    "implications": "The problem reveals fundamental phase transitions in additive combinatorics: (1) the jump from bounded to unbounded threshold at k=4\u21925 shows a qualitative complexity barrier; (2) the growth rate hierarchy (constant \u2192 log \u2192 \u221aN \u2192 N^{1-o(1)}) is exceptionally clean; (3) the gap between upper exponent 1-2^{-k} and lower exponent 1-\u03b5 for large k represents a major open frontier. The formalization demonstrates how Lean can cleanly separate exact results (g\u2083=2) from asymptotic bounds (g\u2085, g\u2086) and open questions, providing precise statements for future work.",
+    "summary": "This formalization captures Erdős Problem #866 on pairwise sums threshold functions, organizing the theory into case analysis (k=3,4,5,6), general bounds, extremal constructions, and open problems. All supporting lemmas proved by Aristotle: upperExponent monotonicity, oddNumbers cardinality, and oddNumbers avoidance. 7 axioms encode the known mathematical results.",
+    "implications": "The problem reveals fundamental phase transitions in additive combinatorics: (1) the jump from bounded to unbounded threshold at k=4→5 shows a qualitative complexity barrier; (2) the growth rate hierarchy (constant → log → √N → N^{1-o(1)}) is exceptionally clean; (3) the gap between upper exponent 1-2^{-k} and lower exponent 1-ε for large k represents a major open frontier. The formalization demonstrates how Lean can cleanly separate exact results (g₃=2) from asymptotic bounds (g₅, g₆) and open questions, providing precise statements for future work.",
     "openQuestions": [
-      "What is the exact value of g\u2084(N)? Is g\u2084(N) constant, and if so, what is the constant?",
-      "What are the optimal constants c\u2081, c\u2082 in g\u2085(N) \u224d log N? Does g\u2085(N)/log N converge?",
-      "Can the gap between N^{1-2^{-k}} and N^{1-\u03b5} for large k be closed? What is the true exponent \u03b1_k?",
+      "What is the exact value of g₄(N)? Is g₄(N) constant, and if so, what is the constant?",
+      "What are the optimal constants c₁, c₂ in g₅(N) ≍ log N? Does g₅(N)/log N converge?",
+      "Can the gap between N^{1-2^{-k}} and N^{1-ε} for large k be closed? What is the true exponent α_k?",
       "What is the structural characterization of extremal sets (maximum-size sets avoiding the pairwise sums condition)?",
       "Is there a unified proof technique that handles all values of k, or must each case use fundamentally different methods?"
     ]
@@ -169,17 +169,17 @@
     {
       "targetId": "erdos-109",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: additive-combinatorics, sumsets"
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, sumsets"
     },
     {
       "targetId": "erdos-1103",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: additive-combinatorics, sumsets"
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, sumsets"
     },
     {
       "targetId": "erdos-1109",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: additive-combinatorics, sumsets"
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, sumsets"
     }
   ],
   "sorries": 0

--- a/src/data/proofs/erdos-873/meta.json
+++ b/src/data/proofs/erdos-873/meta.json
@@ -16,7 +16,7 @@
       "sequences",
       "multiplicative-structure"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 873,
     "erdosUrl": "https://erdosproblems.com/873",

--- a/src/data/proofs/erdos-89/meta.json
+++ b/src/data/proofs/erdos-89/meta.json
@@ -16,7 +16,7 @@
       "extremal",
       "conjecture"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 89,
     "erdosUrl": "https://erdosproblems.com/89",

--- a/src/data/proofs/erdos-891/meta.json
+++ b/src/data/proofs/erdos-891/meta.json
@@ -18,7 +18,7 @@
       "intervals",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 891,
     "erdosUrl": "https://erdosproblems.com/891",

--- a/src/data/proofs/erdos-90/meta.json
+++ b/src/data/proofs/erdos-90/meta.json
@@ -15,7 +15,7 @@
       "incidence-geometry",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 90,
     "erdosUrl": "https://erdosproblems.com/90",

--- a/src/data/proofs/erdos-901/meta.json
+++ b/src/data/proofs/erdos-901/meta.json
@@ -36,7 +36,7 @@
       "probabilistic-method",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 19,
     "erdosNumber": 901,
     "erdosUrl": "https://erdosproblems.com/901",

--- a/src/data/proofs/erdos-929/meta.json
+++ b/src/data/proofs/erdos-929/meta.json
@@ -15,7 +15,7 @@
       "sieve methods",
       "prime gaps"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 929,
     "erdosUrl": "https://erdosproblems.com/929",

--- a/src/data/proofs/erdos-938/meta.json
+++ b/src/data/proofs/erdos-938/meta.json
@@ -16,7 +16,7 @@
       "squarefull-numbers",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 938,
     "erdosUrl": "https://erdosproblems.com/938",

--- a/src/data/proofs/erdos-945/meta.json
+++ b/src/data/proofs/erdos-945/meta.json
@@ -16,7 +16,7 @@
       "consecutive-integers",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 945,
     "erdosUrl": "https://erdosproblems.com/945",

--- a/src/data/proofs/erdos-954/meta.json
+++ b/src/data/proofs/erdos-954/meta.json
@@ -18,7 +18,7 @@
       "open-problem",
       "sidon-sets"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 954,
     "erdosUrl": "https://erdosproblems.com/954",

--- a/src/data/proofs/erdos-971/meta.json
+++ b/src/data/proofs/erdos-971/meta.json
@@ -17,7 +17,7 @@
       "analytic-number-theory",
       "sieve-methods"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 971,
     "erdosUrl": "https://erdosproblems.com/971",

--- a/src/data/proofs/erdos-975/meta.json
+++ b/src/data/proofs/erdos-975/meta.json
@@ -16,7 +16,7 @@
       "analytic-number-theory",
       "polynomials"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 975,
     "erdosUrl": "https://erdosproblems.com/975",

--- a/src/data/proofs/erdos-977/meta.json
+++ b/src/data/proofs/erdos-977/meta.json
@@ -15,7 +15,7 @@
       "prime-factors",
       "mersenne"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 23,
     "erdosNumber": 977,
     "erdosUrl": "https://erdosproblems.com/977",

--- a/src/data/proofs/erdos-98/meta.json
+++ b/src/data/proofs/erdos-98/meta.json
@@ -14,7 +14,7 @@
       "distinct-distances",
       "incidence-geometry"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 98,
     "erdosUrl": "https://erdosproblems.com/98",

--- a/src/data/proofs/fourier-series-oq-02-oq-03/meta.json
+++ b/src/data/proofs/fourier-series-oq-02-oq-03/meta.json
@@ -16,7 +16,7 @@
       "research",
       "open-question"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "axiomCount": 0,
     "theoremCount": 6,

--- a/src/data/proofs/godel-incompleteness/meta.json
+++ b/src/data/proofs/godel-incompleteness/meta.json
@@ -16,7 +16,7 @@
       "advanced",
       "wiedijk-100"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/hilbert-14-oq-01/meta.json
+++ b/src/data/proofs/hilbert-14-oq-01/meta.json
@@ -16,7 +16,7 @@
       "hilbert-problems",
       "algebraic-geometry"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "characterization_summary proves True (main theorem stub). GrosshansSubgroup.quotient_fg := True (struct stub). Real content: Reynolds operator theorems, invariant subring infrastructure.",

--- a/src/data/proofs/hilbert-22/meta.json
+++ b/src/data/proofs/hilbert-22/meta.json
@@ -16,7 +16,7 @@
       "automorphic-functions",
       "advanced"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/hilbert-23/meta.json
+++ b/src/data/proofs/hilbert-23/meta.json
@@ -16,7 +16,7 @@
       "research-program",
       "intermediate"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/hurwitz-theorem-oq-03/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-03/meta.json
@@ -17,7 +17,7 @@
       "sum-of-squares",
       "hurwitz-theorem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 1,
     "dateAdded": "2026-04-02",
     "axiomCount": 0,

--- a/src/data/proofs/konigsberg-oq-03/meta.json
+++ b/src/data/proofs/konigsberg-oq-03/meta.json
@@ -14,7 +14,7 @@
       "hypergraphs",
       "infinite-graphs"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-03-30",
     "axiomCount": 0,

--- a/src/data/proofs/lebesgue-measure-oq-03/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-03/meta.json
@@ -14,7 +14,7 @@
       "gaussian-measure",
       "research"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 136,

--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -17,7 +17,7 @@
       "axiom-of-choice",
       "research"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 5,
     "axiomCount": 5,
     "lineCount": 295,
@@ -189,7 +189,9 @@
     }
   ],
   "leanFile": {
-    "imports": ["Mathlib"],
+    "imports": [
+      "Mathlib"
+    ],
     "namespace": "BanachTarski",
     "lineCount": 295,
     "axiomCount": 5,

--- a/src/data/proofs/pac-learning-bounds/meta.json
+++ b/src/data/proofs/pac-learning-bounds/meta.json
@@ -16,7 +16,7 @@
       "cs-math-bridge",
       "advanced"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/pell-equation-oq-01/meta.json
+++ b/src/data/proofs/pell-equation-oq-01/meta.json
@@ -16,7 +16,7 @@
       "computational-complexity",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-03-30",

--- a/src/data/proofs/platonic-solids-oq-02/meta.json
+++ b/src/data/proofs/platonic-solids-oq-02/meta.json
@@ -18,7 +18,7 @@
       "research",
       "open-question"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "axiomCount": 0,
     "theoremCount": 21,

--- a/src/data/proofs/prob-method-applications/meta.json
+++ b/src/data/proofs/prob-method-applications/meta.json
@@ -16,7 +16,7 @@
       "graph-theory",
       "advanced"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/puiseux-theorem/meta.json
+++ b/src/data/proofs/puiseux-theorem/meta.json
@@ -18,7 +18,7 @@
       "wiedijk-100",
       "classic"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/shannon-source-coding/meta.json
+++ b/src/data/proofs/shannon-source-coding/meta.json
@@ -16,7 +16,7 @@
       "coding-theory",
       "advanced"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/solution-of-cubic-oq-03-oq-02/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-03-oq-02/meta.json
@@ -18,7 +18,7 @@
       "galois-theory",
       "research"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "axiomCount": 0,
     "theoremCount": 11,

--- a/src/data/proofs/szemeredi-hypergraph-core-oq-01/meta.json
+++ b/src/data/proofs/szemeredi-hypergraph-core-oq-01/meta.json
@@ -17,7 +17,7 @@
       "advanced"
     ],
     "proofRepoPath": "Proofs/SzemerediHypergraphCoreOQ01.lean",
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 1,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Fix

185 gallery proofs had `badge: "wip"` but `status: "axiomatized"`. Per the CLAUDE.md spec, `status=axiomatized` requires `badge=axiom`.

## Evidence

**Before**: 185 proofs with `{status: "axiomatized", badge: "wip"}`
**After**: All 185 corrected to `{status: "axiomatized", badge: "axiom"}`

**CLAUDE.md spec**:
> `axiomatized` badge `axiom`: "Formalized with stated assumptions" | Has `axiom` declarations OR structure-encoded assumptions

## Proofs Fixed (185)

Primarily Erdős problem stubs plus several named proofs:
`borsuk-ulam-oq-02-oq-02`, `cantor-diagonalization-oq-01-oq-01`, `dissection-of-cubes-oq-01-oq-01`, `elementary-quadratic-reciprocity-oq-03-oq-02`, `fourier-series-oq-02-oq-03`, `godel-incompleteness`, `hilbert-14-oq-01`, `hilbert-22`, `hilbert-23`, `hurwitz-theorem-oq-03`, `konigsberg-oq-03`, `lebesgue-measure-oq-03`, `lebesgue-measure-oq-06`, `pac-learning-bounds`, `pell-equation-oq-01`, `platonic-solids-oq-02`, `prob-method-applications`, `puiseux-theorem`, `shannon-source-coding`, `solution-of-cubic-oq-03-oq-02`, `szemeredi-hypergraph-core-oq-01` + 164 Erdős problems.

## Validation

- `pnpm build` passed (exit code 0)
- Post-fix verification: 0 remaining `axiomatized+wip` entries across all 2134 gallery proofs

---
Automated fix by lean-mechanic agent.