### PR TITLE
Audit: fix sperner-ndim-oq-04 sorry count 3→1 (PR #11622 sync)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11636,10 +11636,10 @@
       "result": "clean"
     },
     "lebesgue-measure-oq-06": {
-      "auditCount": 7,
+      "auditCount": 8,
       "issues": [],
-      "lastAudited": "2026-04-22T20:24:34Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-23T02:46:32Z",
+      "result": "clean"
     },
     "legendre-partial": {
       "agentId": "auditor-cycle-20-batch",
@@ -12469,9 +12469,9 @@
       "result": "clean"
     },
     "sperner-ndim-oq-04": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-22T18:25:15Z",
+      "lastAudited": "2026-04-23T02:42:23Z",
       "result": "issues-fixed"
     },
     "spherical-law-of-cosines": {

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -239,9 +239,9 @@
       "result": "clean"
     },
     "angle-trisection-oq-02": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-22T11:37:26Z",
+      "lastAudited": "2026-04-23T02:09:06Z",
       "result": "clean"
     },
     "angle-trisection-oq-02-oq-01": {
@@ -714,9 +714,9 @@
       "result": "clean"
     },
     "bertrands-postulate": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-22T11:38:18Z",
+      "lastAudited": "2026-04-23T02:10:37Z",
       "result": "clean"
     },
     "bertrands-postulate-oq-03": {
@@ -750,15 +750,15 @@
       "result": "clean"
     },
     "bezout-identity-oq-02": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-22T11:38:16Z",
+      "lastAudited": "2026-04-23T02:09:46Z",
       "result": "clean"
     },
     "bezout-identity-oq-02-oq-01": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-22T11:38:17Z",
+      "lastAudited": "2026-04-23T02:10:11Z",
       "result": "clean"
     },
     "bezout-identity-oq-02-oq-01-oq-01": {
@@ -792,15 +792,15 @@
       "result": "clean"
     },
     "bezout-identity-oq-02-oq-02": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-22T11:38:16Z",
+      "lastAudited": "2026-04-23T02:09:32Z",
       "result": "clean"
     },
     "bezout-identity-oq-02-oq-02-oq-01": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-22T11:38:18Z",
+      "lastAudited": "2026-04-23T02:10:22Z",
       "result": "clean"
     },
     "bezout-identity-oq-02-oq-02-oq-01-oq-01": {
@@ -818,9 +818,9 @@
       "result": "clean"
     },
     "bezout-identity-oq-03": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-22T11:38:17Z",
+      "lastAudited": "2026-04-23T02:09:58Z",
       "result": "clean"
     },
     "bezout-identity-oq-03-oq-01": {
@@ -860,9 +860,9 @@
       "result": "clean"
     },
     "bezout-identity-oq-04": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-22T11:38:15Z",
+      "lastAudited": "2026-04-23T02:09:18Z",
       "result": "clean"
     },
     "bezout-identity-oq-04-oq-01": {
@@ -1039,9 +1039,9 @@
       "result": "clean"
     },
     "birthday-problem-oq-02": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-04-22T11:39:35Z",
+      "lastAudited": "2026-04-23T02:16:16Z",
       "result": "clean"
     },
     "birthday-problem-oq-02-oq-01": {
@@ -1051,9 +1051,9 @@
       "result": "clean"
     },
     "birthday-problem-oq-03": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-22T11:37:25Z",
+      "lastAudited": "2026-04-23T02:06:49Z",
       "result": "clean"
     },
     "birthday-problem-oq-03-oq-01": {
@@ -1268,9 +1268,9 @@
       "result": "clean"
     },
     "buffons-needle-oq-01": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-22T11:38:20Z",
+      "lastAudited": "2026-04-23T02:11:17Z",
       "result": "clean"
     },
     "buffons-needle-oq-01-oq-01": {
@@ -1298,9 +1298,9 @@
       "result": "clean"
     },
     "buffons-needle-oq-02": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-04-22T11:39:16Z",
+      "lastAudited": "2026-04-23T02:14:52Z",
       "result": "clean"
     },
     "buffons-needle-oq-02-oq-01": {
@@ -1457,9 +1457,9 @@
       "result": "clean"
     },
     "cantors-theorem-oq-03": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-04-22T11:39:15Z",
+      "lastAudited": "2026-04-23T02:14:27Z",
       "result": "clean"
     },
     "cauchy-schwarz": {
@@ -1487,9 +1487,9 @@
       "result": "clean"
     },
     "cauchy-schwarz-integral-oq-01-oq-01-oq-01": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-04-22T11:38:19Z",
+      "lastAudited": "2026-04-23T02:11:02Z",
       "result": "clean"
     },
     "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02": {
@@ -1535,9 +1535,9 @@
       "result": "clean"
     },
     "cauchy-schwarz-integral-oq-02-oq-01": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-04-22T11:39:15Z",
+      "lastAudited": "2026-04-23T02:14:15Z",
       "result": "clean"
     },
     "cauchy-schwarz-integral-oq-02-oq-02": {
@@ -1565,9 +1565,9 @@
       "result": "clean"
     },
     "cauchy-schwarz-oq-01-oq-01": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-22T11:39:15Z",
+      "lastAudited": "2026-04-23T02:14:04Z",
       "result": "clean"
     },
     "cauchy-schwarz-oq-01-oq-01-oq-01": {
@@ -1613,9 +1613,9 @@
       "result": "clean"
     },
     "cauchy-schwarz-oq-03-oq-01": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-04-22T11:39:15Z",
+      "lastAudited": "2026-04-23T02:13:27Z",
       "result": "clean"
     },
     "cauchy-schwarz-oq-03-oq-02": {
@@ -1655,9 +1655,9 @@
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-02": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-04-22T11:39:15Z",
+      "lastAudited": "2026-04-23T02:12:58Z",
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-02-oq-01": {
@@ -1667,9 +1667,9 @@
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-02-oq-01-oq-01": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-22T11:39:16Z",
+      "lastAudited": "2026-04-23T02:14:40Z",
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-02-oq-02": {
@@ -1702,9 +1702,9 @@
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-05": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-22T11:39:15Z",
+      "lastAudited": "2026-04-23T02:12:27Z",
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-05-oq-01": {
@@ -1762,9 +1762,9 @@
       "result": "clean"
     },
     "cayley-hamilton-reduction-oq-01": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-22T11:39:35Z",
+      "lastAudited": "2026-04-23T02:16:02Z",
       "result": "clean"
     },
     "cayley-hamilton-reduction-oq-01-oq-02": {
@@ -1774,9 +1774,9 @@
       "result": "clean"
     },
     "cayley-hamilton-reduction-oq-02": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-22T11:39:35Z",
+      "lastAudited": "2026-04-23T02:15:47Z",
       "result": "clean"
     },
     "cayley-hamilton-reduction-oq-02-oq-01": {
@@ -1870,15 +1870,15 @@
       "result": "clean"
     },
     "cevas-theorem-oq-02": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-22T11:39:35Z",
+      "lastAudited": "2026-04-23T02:15:17Z",
       "result": "clean"
     },
     "cevas-theorem-oq-02-oq-01": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-22T11:39:15Z",
+      "lastAudited": "2026-04-23T02:11:44Z",
       "result": "clean"
     },
     "cevas-theorem-oq-02-oq-01-oq-02": {
@@ -1893,9 +1893,9 @@
       "result": "clean"
     },
     "cevas-theorem-oq-02-oq-02": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-22T11:39:36Z",
+      "lastAudited": "2026-04-23T02:16:54Z",
       "result": "clean"
     },
     "cevas-theorem-oq-04": {
@@ -1951,9 +1951,9 @@
       "result": "clean"
     },
     "chinese-remainder-constructive-oq-04": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-22T11:39:36Z",
+      "lastAudited": "2026-04-23T02:16:38Z",
       "result": "clean"
     },
     "chinese-remainder-constructive-oq-04-oq-03": {
@@ -1975,9 +1975,9 @@
       "result": "clean"
     },
     "chinese-remainder-non-coprime-oq-01": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-22T11:39:36Z",
+      "lastAudited": "2026-04-23T02:16:26Z",
       "result": "clean"
     },
     "chinese-remainder-non-coprime-oq-01-oq-01": {
@@ -2217,9 +2217,9 @@
       "result": "clean"
     },
     "derangements": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-22T11:37:26Z",
+      "lastAudited": "2026-04-23T02:08:47Z",
       "result": "clean"
     },
     "derangements-convergence": {
@@ -4051,9 +4051,9 @@
       "result": "clean"
     },
     "erdos-1149": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-22T11:38:19Z",
+      "lastAudited": "2026-04-23T02:10:50Z",
       "result": "clean"
     },
     "erdos-115": {
@@ -4123,9 +4123,9 @@
       "result": "clean"
     },
     "erdos-1157": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-22T11:37:26Z",
+      "lastAudited": "2026-04-23T02:08:34Z",
       "result": "clean"
     },
     "erdos-1158": {
@@ -4147,9 +4147,9 @@
       "result": "clean"
     },
     "erdos-1160": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-22T11:37:26Z",
+      "lastAudited": "2026-04-23T02:07:57Z",
       "result": "clean"
     },
     "erdos-1161": {
@@ -4751,9 +4751,9 @@
       "result": "clean"
     },
     "erdos-172": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-22T11:37:26Z",
+      "lastAudited": "2026-04-23T02:07:21Z",
       "result": "clean"
     },
     "erdos-173": {
@@ -6147,9 +6147,9 @@
       "result": "clean"
     },
     "erdos-37": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-22T11:37:25Z",
+      "lastAudited": "2026-04-23T02:06:15Z",
       "result": "clean"
     },
     "erdos-370": {
@@ -6565,9 +6565,9 @@
       "result": "clean"
     },
     "erdos-430": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-22T11:39:36Z",
+      "lastAudited": "2026-04-23T02:15:34Z",
       "result": "clean"
     },
     "erdos-431": {
@@ -7276,9 +7276,9 @@
       "result": "clean"
     },
     "erdos-530": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-22T11:37:26Z",
+      "lastAudited": "2026-04-23T02:06:27Z",
       "result": "clean"
     },
     "erdos-531": {
@@ -8311,9 +8311,9 @@
       "result": "clean"
     },
     "erdos-680": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-22T11:39:15Z",
+      "lastAudited": "2026-04-23T02:11:31Z",
       "result": "clean"
     },
     "erdos-681": {
@@ -9497,9 +9497,9 @@
       "result": "clean"
     },
     "erdos-853": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-22T11:39:36Z",
+      "lastAudited": "2026-04-23T02:15:05Z",
       "result": "clean"
     },
     "erdos-854": {

--- a/src/data/proofs/sperner-ndim-oq-04/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-04/meta.json
@@ -21,7 +21,7 @@
       "advanced"
     ],
     "badge": "wip",
-    "sorries": 3,
+    "sorries": 1,
     "originalContributions": [
       "Definition of door degree and IsKuhnCompatible for abstract Sperner triangulations",
       "Proof that FC simplices have exactly 1 door under Kuhn compatibility",
@@ -34,8 +34,8 @@
     ],
     "dateAdded": "2026-04-22",
     "axiomCount": 0,
-    "lineCount": 389,
-    "assumptions": "3 sorries: (1) kuhn_path_terminates — main existence theorem (derived via sorry from sperner_ndim), (2) kuhn_walk_reaches_fc — walk correctness requires non-revisiting invariant, (3) kuhnPathStart_is_fc — top-level correctness. The non-sorry content (fc_door_count_eq_one, nonfc_door_count_zero_or_two, nonfc_with_door_has_unique_exit) is fully verified.",
+    "lineCount": 437,
+    "assumptions": "1 sorry: kuhn_walk_reaches_fc — walk correctness requires the non-revisiting invariant (door graph component containing a boundary door is a path, not a cycle). kuhn_path_terminates and kuhnPathStart_is_fc are now fully proved. The non-sorry content (fc_door_count_eq_one, nonfc_door_count_zero_or_two, nonfc_with_door_has_unique_exit, kuhn_path_terminates, kuhnPathStart_is_fc) is fully verified.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -127,7 +127,7 @@
       "title": "Termination and Walk Correctness Theorems",
       "startLine": 298,
       "endLine": 343,
-      "summary": "States kuhn_path_terminates (FC existence from boundary door) and kuhn_walk_reaches_fc (walk correctness). Both use sorry pending the non-revisiting invariant.",
+      "summary": "States kuhn_path_terminates (FC existence from boundary door, now proved) and kuhn_walk_reaches_fc (walk correctness, one sorry pending the non-revisiting invariant).",
       "mathContext": "kuhn_path_terminates can be derived from sperner_ndim (parity of boundary doors implies FC existence). kuhn_walk_reaches_fc requires the door graph path invariant: components containing boundary vertices are paths, not cycles."
     },
     {
@@ -166,7 +166,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization establishes the door-counting infrastructure for Kuhn's constructive proof of n-dimensional Sperner's lemma. The fully-proved results (fc_door_count_eq_one, nonfc_door_count_zero_or_two, nonfc_with_door_has_unique_exit) rigorously verify that Kuhn's algorithm is well-defined and deterministic. Three sorries remain for the termination/correctness theorems, pending formalization of the non-revisiting invariant.",
+    "summary": "This formalization establishes the door-counting infrastructure and path-following algorithm for Kuhn's constructive proof of n-dimensional Sperner's lemma. The fully-proved results include fc_door_count_eq_one, nonfc_door_count_zero_or_two, nonfc_with_door_has_unique_exit, kuhn_path_terminates, and kuhnPathStart_is_fc. One sorry remains (kuhn_walk_reaches_fc), pending formalization of the non-revisiting invariant for the door graph walk.",
     "implications": "Kuhn's 1968 result is historically significant as the first polynomial-time algorithm for finding a fully-colored simplex. Path-following algorithms descended from Kuhn's work underlie Scarf's algorithm for computing approximate fixed points and (through Lemke-Howson) Nash equilibrium computation. The abstract formulation using IsKuhnCompatible applies to any Sperner triangulation satisfying the degree bound, including Freudenthal triangulations and simplicial complexes arising in topological data analysis. The PPAD complexity connection (Papadimitriou 1994) situates this work in modern computational complexity: the door graph formalized here — a directed graph where every node has in-degree and out-degree at most 1, with a distinguished source — is exactly the End-of-Line problem that defines PPAD. The non-revisiting invariant (the hard remaining sorry) is equivalent to showing the door graph component is a directed path, not a cycle. Fully-colored simplices also appear in topological data analysis as birth-death pairs in persistent homology, making the abstract FC-finding framework relevant to TDA algorithms.",
     "openQuestions": [
       "Can the non-revisiting invariant (the door graph component containing a boundary door is a path) be proved in Lean 4 using graph theory from Mathlib?",
@@ -245,10 +245,10 @@
       "BigOperators"
     ],
     "namespace": "SpernerNDimOQ04",
-    "lineCount": 389,
+    "lineCount": 437,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 5
   },
-  "sorries": 3
+  "sorries": 1
 }


### PR DESCRIPTION
## Summary
- Syncs sperner-ndim-oq-04 meta.json with PR #11622 (proved kuhn_path_terminates and kuhnPathStart_is_fc, reducing sorries 3→1)
- Updates sorries, lineCount, assumptions, and summaries to reflect 1 remaining sorry (kuhn_walk_reaches_fc)
- Marks lebesgue-measure-oq-06 clean in tracker (prior mismatch was false positive from mechanic branch uncommitted changes)

🤖 Generated with Claude Code