### PR TITLE
Audit: fix dissection-of-cubes-oq-04 sorry count 3→0

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2418,10 +2418,10 @@
       "result": "clean"
     },
     "dissection-of-cubes-oq-04": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-22T18:06:42Z",
-      "result": "clean"
+      "lastAudited": "2026-04-23T03:12:34Z",
+      "result": "issues-fixed"
     },
     "divisibility-by-3": {
       "auditCount": 3,

--- a/src/data/proofs/dissection-of-cubes-oq-04/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-04/meta.json
@@ -19,7 +19,7 @@
       "irrational-angles"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 0,
     "dateAdded": "2026-04-22",
     "axiomCount": 2,
     "assumptions": "1. tmul_infinite_order_ne_zero (from OQ02OQ02): ℝ is flat over ℤ — needed to show nonzero tensor products. 2. icoAngle_irrational: arccos(-√5/3)/π is irrational (icosahedron dihedral angle) — proof requires Chebyshev arithmetic in ℤ[√5], deferred.",


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: dissection-of-cubes-oq-04
**Issue**: `meta.json` claimed `sorries: 3` but the Lean file has 0 sorries.

## Evidence

**meta.json claimed**: `sorries: 3`
**Lean file actual**: 0 sorries (all previously deferred proofs are complete)

The file's own axiom audit comment confirms:
```
### New theorems proved (0 sorries):
- five_ndvd_cosThreeFifthsSeq
- arccos_three_fifths_irrational
- dodAngle_irrational / dod_dehn_ne_zero
- cube_isolated_dehn_invariant / cube_unique_zero_dehn
- ... (12 total proved theorems)
```

## Fix

Updated `meta.meta.sorries` from `3` to `0`. Axiom count (2) and status (`axiomatized`) remain correct.

---
Discovered during gallery integrity audit (cycle 2026-04-23).