### PR TITLE
Fix: dissection-of-cubes-oq-04 sorries count 3→0

### DIFF
--- a/src/data/proofs/dissection-of-cubes-oq-04/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-04/meta.json
@@ -19,7 +19,7 @@
       "irrational-angles"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 0,
     "dateAdded": "2026-04-22",
     "axiomCount": 2,
     "assumptions": "1. tmul_infinite_order_ne_zero (from OQ02OQ02): ℝ is flat over ℤ — needed to show nonzero tensor products. 2. icoAngle_irrational: arccos(-√5/3)/π is irrational (icosahedron dihedral angle) — proof requires Chebyshev arithmetic in ℤ[√5], deferred.",


### PR DESCRIPTION
## Fix

Correct sorry count in dissection-of-cubes-oq-04 meta.json from 3 to 0.

## Evidence

**Before**: `"sorries": 3` in meta.json
**After**: `"sorries": 0` in meta.json

**Root cause**: Commit b416a0dca6 ("Research: Dissection 3 sorries, Banach-Tarski 1 sorry, Feuerbach bridge") removed all 3 sorries from `DissectionOfCubesOQ04.lean` but did not update the `sorries` field in meta.json.

**Verification**: `DissectionOfCubesOQ04.lean` contains 0 `sorry` keywords (1 `axiom` declaration — `icoAngle_irrational` — reflected correctly in `axiomCount: 2`).

---
Automated fix by lean-mechanic agent.