### PR TITLE
Fix: hurwitz-theorem-oq-03 and szemeredi-hypergraph-core-oq-01 status axiomatized→formalized

### DIFF
--- a/src/data/proofs/hurwitz-theorem-oq-03/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-03/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-02",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/HurwitzTheorem.lean",
     "tags": [
       "algebra",

--- a/src/data/proofs/szemeredi-hypergraph-core-oq-01/meta.json
+++ b/src/data/proofs/szemeredi-hypergraph-core-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://annals.math.princeton.edu/2007/166-3/p02",
     "date": "2026-04-04",
-    "status": "axiomatized",
+    "status": "formalized",
     "tags": [
       "combinatorics",
       "szemeredi",


### PR DESCRIPTION
## Fix

Corrects `status: axiomatized` → `status: formalized` for two gallery proofs that have sorries but no axiom declarations.

## Evidence

**hurwitz-theorem-oq-03**
- **Before**: `status: axiomatized`, `sorries: 1`, `axiomCount: 0`
- **After**: `status: formalized`
- Reason: 1 sorry (`hurwitz_only_if`), 0 `axiom` declarations. The `meta.assumptions` field explicitly states "No axiom declarations." Sibling entry `hurwitz-theorem` was already corrected to `formalized` in #11559; this entry was missed.

**szemeredi-hypergraph-core-oq-01**
- **Before**: `status: axiomatized`, `sorries: 1`, `axiomCount: 0`
- **After**: `status: formalized`
- Reason: 1 sorry (`hypergraph_regularity_lemma`, a proved theorem pending formalization), 0 `axiom` declarations. This is infrastructure for Gowers hypergraph regularity, not an open conjecture.

Per the status field rules (CLAUDE.md):
- `axiomatized` = Has `axiom` declarations OR structure-encoded assumptions
- `formalized` = Lean formalization exists with sorries remaining

---
Automated fix by lean-mechanic agent.