### PR TITLE
Fix: dissection-of-cubes-oq-03 leanFile.axiomCount corrected (0→2)

### DIFF
--- a/src/data/proofs/dissection-of-cubes-oq-03/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-03/meta.json
@@ -164,7 +164,7 @@
   "leanFile": {
     "namespace": "(builds on DissectionOfCubes namespace)",
     "lineCount": 599,
-    "axiomCount": 0,
+    "axiomCount": 2,
     "theoremCount": 17,
     "definitionCount": 13,
     "path": "Proofs/DissectionOfCubesOQ03.lean",


### PR DESCRIPTION
## Fix

Corrects `leanFile.axiomCount: 0` → `leanFile.axiomCount: 2` for `dissection-of-cubes-oq-03`.

## Evidence

**Before**: `leanFile.axiomCount: 0`, `meta.axiomCount: 2`
**After**: `leanFile.axiomCount: 2`, `meta.axiomCount: 2`

The file `Proofs/DissectionOfCubesOQ03.lean` imports and uses axioms from the parent `DissectionOfCubes.lean`:
- `smaller_cube_above_axiom` (line 206 in DissectionOfCubes.lean)
- `all_different_implies_long_chains_axiom` (line 221 in DissectionOfCubes.lean)

The top-level `meta.axiomCount` correctly says 2, and `meta.assumptions` correctly describes both inherited axioms. The `leanFile.axiomCount: 0` was an oversight counting only direct axiom declarations in the file itself, not inherited ones. Per the Axiom Integrity Policy, `axiomCount` must reflect ALL assumptions including transitively inherited axioms.

---
Automated fix by lean-mechanic agent.