### PR TITLE
Research: erdos-1151-oq-04 — fix build errors, all 3 new lemmas compile

### DIFF
--- a/proofs/Proofs/Erdos1151OQ04.lean
+++ b/proofs/Proofs/Erdos1151OQ04.lean
@@ -297,8 +297,10 @@ theorem natDegree_T_ofNat : ∀ n : ℕ, (T ℝ (n : ℤ)).natDegree = n
         rw [natDegree_ofNat, natDegree_X_mul hne1, ihn1]
         omega
       -- natDegree(T(n)) < natDegree(2 * X * T(n+1)), so degree of difference = LHS degree
-      apply natDegree_sub_eq_left_of_natDegree_lt
-      rw [h2XTdeg, ihn]; omega
+      have key : (2 * X * T ℝ ((n : ℤ) + 1) - T ℝ (n : ℤ)).natDegree =
+                 (2 * X * T ℝ ((n : ℤ) + 1)).natDegree :=
+        natDegree_sub_eq_left_of_natDegree_lt (by rw [h2XTdeg, ihn]; omega)
+      rw [key, h2XTdeg]
 
 /-- The leading coefficient of T_n is 2^(n-1) for n ≥ 1.
     Proof by two-step induction via T_{n+2} = 2X·T_{n+1} - T_n:
@@ -306,7 +308,7 @@ theorem natDegree_T_ofNat : ∀ n : ℕ, (T ℝ (n : ℤ)).natDegree = n
     = 2 · leadingCoeff(T_{n+1}) = 2 · 2^n = 2^{n+1}. -/
 theorem leadingCoeff_T_ofNat : ∀ n : ℕ, n ≥ 1 → (T ℝ (n : ℤ)).leadingCoeff = 2 ^ (n - 1)
   | 0, h => by omega
-  | 1, _ => by simp [T_one, leadingCoeff_X]
+  | 1, _ => by simp [T_one]
   | (n + 2), _ => by
       have ihn1_lc : (T ℝ ((n + 1 : ℕ) : ℤ)).leadingCoeff = 2 ^ n :=
         leadingCoeff_T_ofNat (n + 1) (by omega)
@@ -354,7 +356,7 @@ theorem chebyshevNode_is_root (n : ℕ) (hn : 0 < n) (k : Fin n) :
       (2 * k.val + 1 : ℝ) * Real.pi / 2 := by
     push_cast
     have : (n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hn.ne'
-    field_simp; ring
+    field_simp
   rw [hmul]
   -- cos((2k+1)π/2) = 0: rewrite as cos(kπ + π/2) and use cos_add
   have h : (2 * (k.val : ℝ) + 1) * Real.pi / 2 = k.val * Real.pi + Real.pi / 2 := by ring
@@ -369,10 +371,18 @@ theorem chebyshevNode_injective (n : ℕ) (hn : 0 < n) :
   simp only [chebyshevNode] at heq
   have hi : (2 * (i.val : ℝ) + 1) * Real.pi / (2 * n) ∈ Set.Icc (0 : ℝ) Real.pi :=
     ⟨le_of_lt (div_pos (mul_pos (by positivity) Real.pi_pos) (by positivity)),
-     le_of_lt (by rw [div_lt_iff (by positivity)]; nlinarith [i.isLt, Real.pi_pos])⟩
+     le_of_lt (by
+       have hlt : 2 * i.val + 1 < 2 * n := by omega
+       have hrlt : (2 * (i.val : ℝ) + 1) < 2 * n := by exact_mod_cast hlt
+       rw [div_lt_iff₀ (by positivity)]
+       nlinarith [Real.pi_pos])⟩
   have hj : (2 * (j.val : ℝ) + 1) * Real.pi / (2 * n) ∈ Set.Icc (0 : ℝ) Real.pi :=
     ⟨le_of_lt (div_pos (mul_pos (by positivity) Real.pi_pos) (by positivity)),
-     le_of_lt (by rw [div_lt_iff (by positivity)]; nlinarith [j.isLt, Real.pi_pos])⟩
+     le_of_lt (by
+       have hlt : 2 * j.val + 1 < 2 * n := by omega
+       have hrlt : (2 * (j.val : ℝ) + 1) < 2 * n := by exact_mod_cast hlt
+       rw [div_lt_iff₀ (by positivity)]
+       nlinarith [Real.pi_pos])⟩
   have hangle_eq := Real.strictAntiOn_cos.injOn hi hj heq
   apply Fin.ext
   have hn' : (n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hn.ne'

--- a/research/problems/erdos-1151-oq-04/knowledge.md
+++ b/research/problems/erdos-1151-oq-04/knowledge.md
@@ -76,6 +76,22 @@ Estimated: 200+ lines, needs analysis of Chebyshev interpolation between differe
 **Alternative**: Baire category gives lim sup = ∞, but NOT full divergence (lim = ∞).
 May need to reconsider whether the axiom statement is too strong.
 
+## Session 2026-04-23 — Results (Session 4)
+
+**Outcome**: progress
+**Sorries closed**: 0 (build fixes — Session 3 lemmas now compile)
+**Build errors fixed** (Mathlib v4.26.0 API changes + proof bugs):
+- `natDegree_T_ofNat | (n+2)`: `apply natDegree_sub_eq_left_of_natDegree_lt` failed (conclusion `p.natDegree` doesn't unify with `n+2`); fixed using `have key + rw`
+- `chebyshevNode_is_root`: `field_simp; ring` — field_simp closes goal, `ring` had no goals; fixed by removing `ring`
+- `chebyshevNode_injective`: `div_lt_iff` renamed to `div_lt_iff₀` in Mathlib v4.26.0; `nlinarith` then needed `omega` + `exact_mod_cast` to convert ℕ→ℝ strict bound before `nlinarith` for nonlinear finish
+
+**Key technique learned**:
+- When `apply lemma` fails "could not unify conclusion", use `have key := lemma proof; rw [key, ...]` instead
+- `linarith` cannot multiply inequalities by variables (nonlinear); use `nlinarith` or provide product as hint `mul_lt_mul_of_pos_right`
+- ℕ strict inequality `j.val < n` gives only `(j.val : ℝ) < n`, NOT `2 * j.val + 1 < 2 * n` in ℝ; must use `omega` first on ℕ, then `exact_mod_cast`
+
+**PR**: rjwalters/lean-genius#11646 — all 3 Session 3 lemmas now build clean
+
 ## Session 2026-04-23 — Results (Session 3)
 
 **Outcome**: progress  
@@ -112,8 +128,11 @@ Therefore T_n = Q_n.
 
 ## Next Steps
 
-1. **IMMEDIATE**: Prove the Chebyshev product formula using T_ofNat_ne_zero + natDegree_T_ofNat + leadingCoeff_T_ofNat:
-   - Use `Polynomial.card_roots_le_degree` to show T_n - Q_n = 0
+1. **IMMEDIATE**: Prove the Chebyshev product formula using T_ofNat_ne_zero + natDegree_T_ofNat + leadingCoeff_T_ofNat (all now building):
+   - Define Q_n = 2^{n-1} · ∏_{k : Fin n} (X - C (cos φₖ))
+   - Show T_n - Q_n has natDegree ≤ n-1 (leadingCoeffs cancel: both = 2^{n-1})
+   - Show T_n - Q_n has n distinct roots (chebyshevNode_is_root + chebyshevNode_injective)
+   - Apply `Polynomial.card_roots_le_degree` to conclude T_n - Q_n = 0
    - This unblocks lagrange_basis_chebyshev_formula, chebyshev_lebesgue_eq, chebyshev_lebesgue_growth
 2. Assess divergence_from_lebesgue_growth gap more carefully; consider Banach-Steinhaus
 3. Mathlib v4.26.0 confirmed: no Chebyshev product formula; must build locally

--- a/src/data/research/problems/erdos-1151-oq-04.json
+++ b/src/data/research/problems/erdos-1151-oq-04.json
@@ -40,11 +40,12 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Session 3 proves T_ofNat_ne_zero + natDegree_T_ofNat + leadingCoeff_T_ofNat (prerequisites for product formula). 4 sorries remain in main file; product formula proof ready to attempt next session.",
+    "progressSummary": "ACT: 3 new lemmas (T_ofNat_ne_zero, natDegree_T_ofNat, leadingCoeff_T_ofNat) build cleanly; product formula proof strategy clear; 4 sorries remain",
     "builtItems": [
       "T_ofNat_ne_zero (n : \u2115) : T \u211d (n : \u2124) \u2260 0 \u2014 Erdos1151OQ04.lean:274",
       "natDegree_T_ofNat : \u2200 n : \u2115, (T \u211d (n : \u2124)).natDegree = n \u2014 Erdos1151OQ04.lean:282",
-      "leadingCoeff_T_ofNat : \u2200 n \u2265 1, (T \u211d (n : \u2124)).leadingCoeff = 2^(n-1) \u2014 Erdos1151OQ04.lean:306"
+      "leadingCoeff_T_ofNat : \u2200 n \u2265 1, (T \u211d (n : \u2124)).leadingCoeff = 2^(n-1) \u2014 Erdos1151OQ04.lean:306",
+      "Build fixes: all Session 3 lemmas compile cleanly in Proofs/Erdos1151OQ04.lean"
     ],
     "insights": [
       "Lebesgue function \u039b\u2099(x) = \u03a3\u2096 |\u2113\u2096(x)| measures worst-case interpolation amplification",
@@ -52,14 +53,16 @@
       "Divergence of interpolation sequence follows from \u039b\u2099 \u2192 \u221e via bump function",
       "natDegree and leadingCoeff of T_n proved by two-step induction on recurrence T_{n+2} = 2X\u00b7T_{n+1} - T_n",
       "Product formula proof strategy: T_n - Q_n has deg < n and n roots (by Chebyshev node roots + card_roots_le_degree) \u2192 T_n = Q_n",
-      "(2 : \u211d[X]) = C 2 via Polynomial.C_ofNat; leadingCoeff_C gives leadingCoeff = 2"
+      "(2 : \u211d[X]) = C 2 via Polynomial.C_ofNat; leadingCoeff_C gives leadingCoeff = 2",
+      "apply lemma fails when conclusion has concrete value (n+2) vs metavar (p.natDegree): use have key := lemma proof; rw [key]",
+      "\u2115 strict bound j.val < n does NOT give 2*j+1 < 2*n in \u211d via linarith; need omega on \u2115 then exact_mod_cast",
+      "div_lt_iff renamed to div_lt_iff\u2080 in Mathlib v4.26.0"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove chebyshev_product_formula: T \u211d n = 2^{n-1} \u00b7 \u220f_{k : Fin n} (X - C (chebyshevNode n k)) using Polynomial.card_roots_le_degree",
-      "Use product formula to prove lagrange_basis_chebyshev_formula (sorry #1)",
-      "Chain: lagrange_basis \u2192 chebyshev_lebesgue_eq \u2192 chebyshev_lebesgue_growth",
-      "Separately assess divergence_from_lebesgue_growth: Banach-Steinhaus vs lacunary"
+      "Prove Chebyshev product formula: define Q_n = 2^{n-1}*prod(X - cos phi_k), show T_n - Q_n = 0 via card_roots_le_degree",
+      "chebyshevNode_is_root + chebyshevNode_injective give n distinct roots of T_n - Q_n",
+      "Unblocks: lagrange_basis_chebyshev_formula, chebyshev_lebesgue_eq, chebyshev_lebesgue_growth"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Fixes build errors in Erdos1151OQ04.lean that were preventing the Session 3 work from compiling. The file now builds cleanly with 4 remaining sorries (the hard mathematical content).

**Session 3 new lemmas (now building):**
- `T_ofNat_ne_zero (n : ℕ)`: T_n ≠ 0, proved via T_n(1) = 1
- `natDegree_T_ofNat`: natDegree(T_n) = n by two-step induction
- `leadingCoeff_T_ofNat`: leadingCoeff(T_n) = 2^(n-1) for n ≥ 1 by two-step induction

These are prerequisites for the Chebyshev product formula T_n = 2^{n-1}·∏(X - cos φₖ), which is the next step toward eliminating the main sorries.

**Build fixes applied:**
1. `leadingCoeff_T_ofNat | 1`: removed redundant `leadingCoeff_X` from `simp` call
2. `chebyshevNode_is_root`: `field_simp` already closes goal, removed trailing `ring`
3. `chebyshevNode_injective`: `div_lt_iff` → `div_lt_iff₀` (Mathlib v4.26.0 rename); used `omega` + `exact_mod_cast` + `nlinarith` for ℕ→ℝ cast bound
4. `natDegree_T_ofNat | (n+2)`: replaced `apply natDegree_sub_eq_left_of_natDegree_lt` with explicit `have key` + `rw` since unification fails when goal has `n+2` instead of `p.natDegree`

## Test plan
- [x] `./proofs/scripts/docker-build.sh Proofs.Erdos1151OQ04` succeeds
- [x] 4 sorries remain (same as before — no regression)
- [x] 3 new lemmas prove without sorry

🤖 Generated with [Claude Code](https://claude.com/claude-code)