### PR TITLE
Audit: tracker update 2026-04-23 (binomial-theorem-oq-04-oq-02 clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -998,9 +998,9 @@
       "result": "clean"
     },
     "binomial-theorem-oq-04-oq-02": {
-      "auditCount": 3,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-04-22T11:39:36Z",
+      "lastAudited": "2026-04-23T03:21:18Z",
       "result": "clean"
     },
     "binomial-theorem-oq-04-oq-02-oq-01": {
@@ -2418,9 +2418,9 @@
       "result": "clean"
     },
     "dissection-of-cubes-oq-04": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-04-23T03:12:34Z",
+      "lastAudited": "2026-04-23T03:15:17Z",
       "result": "issues-fixed"
     },
     "divisibility-by-3": {


### PR DESCRIPTION
## Audit Tracker Update

Audited `binomial-theorem-oq-04-oq-02` — result: **clean**.

- 0 sorries (confirmed vs Lean source)
- 0 axioms
- No True stubs
- Badge `mathlib` is correct (core result via `Nat.add_choose_eq`)
- Status `verified` is appropriate for a sorry-free Mathlib bridge proof

No integrity issues found.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)