### PR TITLE
Fix: remove stale meta.leanFile field from 27 gallery proofs (v2)

### DIFF
--- a/src/data/proofs/birch-swinnerton-dyer/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer/meta.json
@@ -49,34 +49,6 @@
         "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
       }
     ],
-    "leanFile": {
-      "lineCount": 7432,
-      "structureCount": 92,
-      "axiomCount": 18,
-      "theoremCount": 253,
-      "lemmaCount": 3,
-      "defCount": 143,
-      "imports": [
-        "Mathlib.AlgebraicGeometry.EllipticCurve.Weierstrass",
-        "Mathlib.AlgebraicGeometry.EllipticCurve.Affine.Basic",
-        "Mathlib.AlgebraicGeometry.EllipticCurve.Affine.Point",
-        "Mathlib.NumberTheory.LSeries.Basic",
-        "Mathlib.NumberTheory.ArithmeticFunction.Defs",
-        "Mathlib.NumberTheory.ArithmeticFunction.Misc",
-        "Mathlib.NumberTheory.ArithmeticFunction.Moebius",
-        "Mathlib.NumberTheory.ArithmeticFunction.VonMangoldt",
-        "Mathlib.NumberTheory.ArithmeticFunction.Zeta",
-        "Mathlib.Algebra.Group.Subgroup.Basic",
-        "Mathlib.Analysis.Complex.Basic",
-        "Mathlib.Analysis.SpecialFunctions.Log.Basic",
-        "Mathlib.Analysis.SpecialFunctions.Pow.Complex",
-        "Mathlib.Analysis.Calculus.Deriv.Basic",
-        "Mathlib.Order.Filter.AtTopBot.Basic",
-        "Mathlib.Analysis.Complex.ExponentialBounds",
-        "Mathlib.Topology.Order.Basic",
-        "Mathlib.Tactic"
-      ]
-    },
     "originalContributions": [
       "EllipticCurveQ structure with verified embedding into Mathlib's WeierstrassCurve",
       "Discriminant and c4 theorems proved by ring (no sorry)",

--- a/src/data/proofs/birthday-problem-oq-03/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03/meta.json
@@ -54,17 +54,6 @@
         "relationship": "Sibling open question: asymptotic bounds for the birthday problem"
       }
     ],
-    "leanFile": {
-      "lineCount": 368,
-      "structureCount": 0,
-      "axiomCount": 0,
-      "theoremCount": 18,
-      "lemmaCount": 0,
-      "defCount": 4,
-      "imports": [
-        "Mathlib"
-      ]
-    },
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/brouwer-fixed-point/meta.json
+++ b/src/data/proofs/brouwer-fixed-point/meta.json
@@ -68,27 +68,6 @@
     ],
     "lineCount": 249,
     "mathlib_version": "4.26.0",
-    "leanFile": {
-      "imports": [
-        "Mathlib.Topology.Basic",
-        "Mathlib.Topology.Compactness.Compact",
-        "Mathlib.Topology.Connected.PathConnected",
-        "Mathlib.Topology.Order.IntermediateValue",
-        "Mathlib.Analysis.Normed.Module.FiniteDimension",
-        "Mathlib.Analysis.InnerProductSpace.Basic",
-        "Mathlib.Analysis.InnerProductSpace.PiL2",
-        "Mathlib.Topology.MetricSpace.Basic"
-      ],
-      "opens": [
-        "Set",
-        "Metric"
-      ],
-      "namespace": "Brouwer",
-      "lineCount": 249,
-      "axiomCount": 2,
-      "theoremCount": 5,
-      "definitionCount": 6
-    },
     "relatedProblems": [
       {
         "id": "brouwer-fixed-point-oq-02",

--- a/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json
@@ -39,14 +39,6 @@
       "RCF roadmap and gap assessment"
     ],
     "dateAdded": "2026-03-30",
-    "leanFile": {
-      "lineCount": 396,
-      "structures": 0,
-      "axioms": 0,
-      "theorems": 7,
-      "definitions": 1,
-      "instances": 0
-    },
     "axiomCount": 0,
     "lineCount": 396,
     "assumptions": "0 axioms, 0 sorries. All three key theorems fully proved: aeval_companionMatrix (orbit argument), charpoly_companionMatrix, and minpoly_companionMatrix. Uses Mathlib supporting lemmas.",

--- a/src/data/proofs/erdos-107/meta.json
+++ b/src/data/proofs/erdos-107/meta.json
@@ -61,16 +61,6 @@
       "HMPT bound 2^{n+O(sqrt(n log n))} with existential constant",
       "HappyEndingConjecture as Prop (correctly open)"
     ],
-    "leanFile": {
-      "lineCount": 243,
-      "structureCount": 0,
-      "axiomCount": 6,
-      "theoremCount": 12,
-      "defCount": 6,
-      "imports": [
-        "Mathlib"
-      ]
-    },
     "dateAdded": "2026-01-19",
     "axiomCount": 6,
     "lineCount": 243,

--- a/src/data/proofs/erdos-1091/meta.json
+++ b/src/data/proofs/erdos-1091/meta.json
@@ -58,19 +58,6 @@
       "K4_free_high_chi_possible: verified existence witness",
       "erdos_1091_summary: verified combined result"
     ],
-    "leanFile": {
-      "lineCount": 211,
-      "structureCount": 2,
-      "axiomCount": 5,
-      "theoremCount": 4,
-      "defCount": 8,
-      "imports": [
-        "Mathlib.Combinatorics.SimpleGraph.Basic",
-        "Mathlib.Combinatorics.SimpleGraph.Coloring",
-        "Mathlib.Combinatorics.SimpleGraph.Clique",
-        "Mathlib.Data.Finset.Basic"
-      ]
-    },
     "dateAdded": "2026-01-26",
     "axiomCount": 5,
     "lineCount": 211,

--- a/src/data/proofs/erdos-1113/meta.json
+++ b/src/data/proofs/erdos-1113/meta.json
@@ -59,19 +59,6 @@
       "erdos_1113_summary combining Izotov, perfect power, and FFK compatibility (verified)",
       "sierpinski_infinitely_many: Sierpinski's theorem that infinitely many covered numbers exist"
     ],
-    "leanFile": {
-      "lineCount": 172,
-      "structureCount": 0,
-      "axiomCount": 1,
-      "theoremCount": 5,
-      "defCount": 14,
-      "imports": [
-        "Mathlib.Data.Nat.Basic",
-        "Mathlib.Data.Nat.Prime.Basic",
-        "Mathlib.Data.Finset.Basic",
-        "Mathlib.Data.Nat.Parity"
-      ]
-    },
     "axiomCount": 1,
     "lineCount": 172,
     "assumptions": "1 axiom: `izotov_is_sierpinski` \u2014 Izotov (1995) proved that m = 734110615000775^4 is a Sierpinski number. The 8 axioms present in an earlier file version (covering_set_implies_sierpinski, selfridge_78557, covering_78557, and 5 others) have since been eliminated from the Lean source."

--- a/src/data/proofs/erdos-1179-oq-01/meta.json
+++ b/src/data/proofs/erdos-1179-oq-01/meta.json
@@ -68,69 +68,7 @@
         "id": "erdos-1179",
         "relationship": "Parent problem: the main Erd\u0151s #1179 formalization establishing g_\u03b5(N) ~ log\u2082 N"
       }
-    ],
-    "leanFile": {
-      "imports": [
-        "Mathlib.Data.Finset.Basic",
-        "Mathlib.Data.Finset.Powerset",
-        "Mathlib.Data.Finset.Card",
-        "Mathlib.Data.Fintype.Basic",
-        "Mathlib.Data.Real.Basic",
-        "Mathlib.Data.ZMod.Basic",
-        "Mathlib.Analysis.SpecialFunctions.Log.Basic",
-        "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic",
-        "Mathlib.Analysis.SpecificLimits.Normed",
-        "Mathlib.Tactic"
-      ],
-      "opens": [
-        "Finset",
-        "Real"
-      ],
-      "namespace": "Erdos1179OQ01",
-      "lineCount": 709,
-      "axiomCount": 0,
-      "sorryCount": 0,
-      "theoremCount": 23,
-      "definitionCount": 7,
-      "mainTheorems": [
-        {
-          "name": "total_reprCount",
-          "type": "proved",
-          "description": "Total representations partition: \u2211_g F_A(g) = 2^|A|",
-          "leanType": "(A : Finset (ZMod N)) \u2192 (\u2211 g : ZMod N, reprCount A g) = 2 ^ A.card"
-        },
-        {
-          "name": "reprCount_insert_ge",
-          "type": "proved",
-          "description": "Monotonicity: adding an element never decreases reprCount",
-          "leanType": "(A : Finset (ZMod N)) \u2192 (b : ZMod N) \u2192 (g : ZMod N) \u2192 b \u2209 A \u2192 reprCount A g \u2264 reprCount (insert b A) g"
-        },
-        {
-          "name": "coverage_mono",
-          "type": "proved",
-          "description": "Coverage monotonicity: the number of represented elements grows with set size",
-          "leanType": "(A : Finset (ZMod N)) \u2192 (b : ZMod N) \u2192 b \u2209 A \u2192 |{g : F_A(g) > 0}| \u2264 |{g : F_{A\u222a{b}}(g) > 0}|"
-        },
-        {
-          "name": "bounded_implies_sublinear",
-          "type": "proved",
-          "description": "The correction hierarchy: O(1) implies o(log\u2082 N)",
-          "leanType": "(gEps : \u211d \u2192 \u2115 \u2192 \u2115) \u2192 (\u03b5 : \u211d) \u2192 CorrectionIsBounded gEps \u03b5 \u2192 CorrectionIsSublinearInLog gEps \u03b5"
-        },
-        {
-          "name": "abs_cos_pi_div_prime_lt_one",
-          "type": "proved",
-          "description": "|cos(\u03c0/p)| < 1 for any prime p \u2014 key lemma for geometric decay",
-          "leanType": "(p : \u2115) \u2192 (hp : Nat.Prime p) \u2192 |cos(\u03c0/p)| < 1"
-        },
-        {
-          "name": "erdos_renyi_decay",
-          "type": "proved",
-          "description": "Erd\u0151s-R\u00e9nyi exponential decay: for k \u2265 clog\u2082 p + C, Fourier error \u2264 \u03b5 \u00b7 2^k/p. Proved from fourier_error_bound via geometric decay of |cos(\u03c0/p)|^(k-1)",
-          "leanType": "(p : \u2115) \u2192 (hp : Nat.Prime p) \u2192 \u2200 \u03b5 > 0, \u2203 C, \u2200 k \u2265 clog 2 p + C, \u2200 A, A.card = k \u2192 \u2200 g, |F_A(g) - 2^k/p| \u2264 \u03b5 \u00b7 (2^k/p)"
-        }
-      ]
-    }
+    ]
   },
   "sections": [
     {

--- a/src/data/proofs/furstenberg-correspondence-oq-02/meta.json
+++ b/src/data/proofs/furstenberg-correspondence-oq-02/meta.json
@@ -55,14 +55,6 @@
       "Recommendation: Approach C (via Mathlib disintegration) minimizes effort"
     ],
     "dateAdded": "2026-03-30",
-    "leanFile": {
-      "lineCount": 413,
-      "structures": 0,
-      "axioms": 0,
-      "theorems": 4,
-      "definitions": 2,
-      "instances": 0
-    },
     "axiomCount": 0,
     "lineCount": 413,
     "assumptions": "0 axioms. 0 sorries. Survey file with demonstrated infrastructure.",

--- a/src/data/proofs/geometric-series-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-01/meta.json
@@ -55,20 +55,6 @@
       "Absolute value and norm (|r|, Real.norm_eq_abs)",
       "Basic algebra: pow, parity, field operations"
     ],
-    "leanFile": {
-      "lineCount": 250,
-      "structureCount": 0,
-      "axiomCount": 0,
-      "theoremCount": 13,
-      "lemmaCount": 0,
-      "defCount": 1,
-      "imports": [
-        "Mathlib.Algebra.GeomSum",
-        "Mathlib.Analysis.SpecificLimits.Normed",
-        "Mathlib.Topology.Algebra.InfiniteSum.Basic",
-        "Mathlib.Tactic"
-      ]
-    },
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/leibniz-pi-oq-01-oq-01/meta.json
+++ b/src/data/proofs/leibniz-pi-oq-01-oq-01/meta.json
@@ -83,7 +83,6 @@
     "dateAdded": "2026-03-23",
     "axiomCount": 0,
     "lineCount": 97,
-    "leanFile": "Proofs/MachinFromAddition.lean",
     "mathlib_version": "4.26.0",
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
   },

--- a/src/data/proofs/lhopital-oq-02/meta.json
+++ b/src/data/proofs/lhopital-oq-02/meta.json
@@ -47,14 +47,6 @@
       "Documentation of why \u221e/\u221e needs a separate proof from 0/0"
     ],
     "dateAdded": "2026-03-30",
-    "leanFile": {
-      "lineCount": 428,
-      "structures": 0,
-      "axioms": 0,
-      "theorems": 5,
-      "definitions": 0,
-      "instances": 0
-    },
     "axiomCount": 0,
     "lineCount": 428,
     "assumptions": "0 axioms, 0 sorries. All 4 variants fully proved: right approach via Cauchy MVT, left via negation, atTop via inversion, atBot via negation of atTop.",

--- a/src/data/proofs/morleys-theorem/meta.json
+++ b/src/data/proofs/morleys-theorem/meta.json
@@ -52,14 +52,6 @@
       "Special case formalizations for equilateral and right isosceles triangles"
     ],
     "dateAdded": "2025-12-29",
-    "leanFile": {
-      "lineCount": 532,
-      "structures": 1,
-      "axioms": 0,
-      "theorems": 11,
-      "definitions": 10,
-      "instances": 0
-    },
     "axiomCount": 0,
     "lineCount": 532,
     "assumptions": "0 axioms. 0 sorries. Fully verified.",

--- a/src/data/proofs/napoleons-theorem/meta.json
+++ b/src/data/proofs/napoleons-theorem/meta.json
@@ -43,14 +43,6 @@
       "Inner Napoleon triangle variant with conjugate rotation factor"
     ],
     "dateAdded": "2026-03-30",
-    "leanFile": {
-      "lineCount": 354,
-      "structures": 0,
-      "axioms": 0,
-      "theorems": 14,
-      "definitions": 10,
-      "instances": 0
-    },
     "axiomCount": 0,
     "lineCount": 354,
     "assumptions": "0 axioms. 0 sorries. Fully verified.",

--- a/src/data/proofs/pascals-hexagon/meta.json
+++ b/src/data/proofs/pascals-hexagon/meta.json
@@ -45,14 +45,6 @@
       "Formalization of Brianchon's dual theorem structures"
     ],
     "dateAdded": "2025-12-29",
-    "leanFile": {
-      "lineCount": 1278,
-      "structures": 1,
-      "axioms": 1,
-      "theorems": 26,
-      "definitions": 24,
-      "instances": 0
-    },
     "axiomCount": 1,
     "lineCount": 1278,
     "assumptions": "1 axiom (conic_implies_pascal_constraint). 1 sorry in proof_sketch_conic_implies_pascal (pending Sylvester's law for the standard conic reduction).",

--- a/src/data/proofs/picks-theorem-oq-03/meta.json
+++ b/src/data/proofs/picks-theorem-oq-03/meta.json
@@ -63,14 +63,6 @@
       "Volume product formula: vol(\u03b2_d)\u00b7vol(\u25a1_d) = 4^d/d! (proved for all d)"
     ],
     "dateAdded": "2026-03-06",
-    "leanFile": {
-      "lineCount": 710,
-      "structures": 2,
-      "axioms": 2,
-      "theorems": 34,
-      "definitions": 20,
-      "instances": 0
-    },
     "additionalFiles": [
       {
         "path": "Proofs/PicksTheoremOQ03CrossPoly.lean",

--- a/src/data/proofs/picks-theorem/meta.json
+++ b/src/data/proofs/picks-theorem/meta.json
@@ -41,14 +41,6 @@
       "Half-integer area corollary and lattice width bounds"
     ],
     "dateAdded": "2025-12-29",
-    "leanFile": {
-      "lineCount": 484,
-      "structures": 1,
-      "axioms": 2,
-      "theorems": 12,
-      "definitions": 11,
-      "instances": 0
-    },
     "axiomCount": 1,
     "lineCount": 484,
     "assumptions": "1 axiom: picks_theorem (the main theorem statement). Removed inconsistent area_bounded_by_box_axiom (claimed A(P) \u2264 w_x*w_y for all w_x,w_y without containment hypothesis).",

--- a/src/data/proofs/prime-reciprocal-divergence-oq-03/meta.json
+++ b/src/data/proofs/prime-reciprocal-divergence-oq-03/meta.json
@@ -46,14 +46,6 @@
       "Alternative proof path avoiding Mathlib's analytic machinery"
     ],
     "dateAdded": "2026-03-30",
-    "leanFile": {
-      "lineCount": 388,
-      "structures": 0,
-      "axioms": 0,
-      "theorems": 13,
-      "definitions": 7,
-      "instances": 0
-    },
     "axiomCount": 0,
     "lineCount": 388,
     "assumptions": "0 axioms. 0 sorries. Fully verified.",

--- a/src/data/proofs/shapley-folkman/meta.json
+++ b/src/data/proofs/shapley-folkman/meta.json
@@ -63,27 +63,6 @@
     ],
     "lineCount": 813,
     "mathlib_version": "4.26.0",
-    "leanFile": {
-      "imports": [
-        "Mathlib.Analysis.Convex.Caratheodory",
-        "Mathlib.Analysis.Convex.Combination",
-        "Mathlib.Analysis.Convex.Hull",
-        "Mathlib.LinearAlgebra.AffineSpace.Independent",
-        "Mathlib.LinearAlgebra.Dimension.Finrank",
-        "Mathlib.Order.Filter.Basic",
-        "Mathlib.Data.Finset.Pointwise"
-      ],
-      "opens": [
-        "Set",
-        "Finset",
-        "Pointwise"
-      ],
-      "namespace": "ShapleyFolkman",
-      "lineCount": 629,
-      "axiomCount": 0,
-      "theoremCount": 6,
-      "definitionCount": 2
-    },
     "relatedProblems": []
   },
   "overview": {

--- a/src/data/proofs/sylow-theorems-oq-02/meta.json
+++ b/src/data/proofs/sylow-theorems-oq-02/meta.json
@@ -55,25 +55,6 @@
     ],
     "assumptions": "5 axioms encoding deep profinite group theory results: (1) Sylow pro-p existence via Zorn's lemma on closed pro-p subgroups, (2) conjugacy via finite approximation and compactness, (3) Frattini argument for profinite groups, (4) projection of Sylow pro-p subgroups to p-groups in finite quotients, (5) trivial intersection of Sylow subgroups for distinct primes.",
     "dateAdded": "2026-03-25",
-    "leanFile": {
-      "imports": [
-        "Mathlib.GroupTheory.Sylow",
-        "Mathlib.Topology.Algebra.Group.Basic",
-        "Mathlib.Topology.Connected.TotallyDisconnected",
-        "Mathlib.Topology.Compactness.Compact",
-        "Mathlib.GroupTheory.Index",
-        "Mathlib.GroupTheory.Coset.Basic",
-        "Mathlib.Tactic"
-      ],
-      "opens": [
-        "Subgroup"
-      ],
-      "namespace": "ProfiniteSylow",
-      "lineCount": 393,
-      "axiomCount": 5,
-      "theoremCount": 10,
-      "definitionCount": 5
-    },
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/sylow-theorems-oq-04/meta.json
+++ b/src/data/proofs/sylow-theorems-oq-04/meta.json
@@ -21,22 +21,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "0 axiom declarations, 0 sorries. All results fully verified. Exact Sylow numbers computed by native_decide. Simplicity uses Mathlib's alternatingGroup.isSimpleGroup_five.",
-    "lineCount": 276,
-    "leanFile": {
-      "imports": [
-        "Mathlib"
-      ],
-      "opens": [
-        "Subgroup",
-        "Fintype",
-        "Equiv.Perm"
-      ],
-      "namespace": "SylowA5",
-      "lineCount": 276,
-      "axiomCount": 0,
-      "theoremCount": 21,
-      "definitionCount": 1
-    }
+    "lineCount": 276
   },
   "overview": {
     "historicalContext": "The simplicity of A\u2085 was first understood by Galois (1832), who recognized that A\u2085 is the smallest non-abelian simple group. The Sylow counting approach, using theorems from Sylow's 1872 paper, provides a concrete arithmetic proof: for |A\u2085| = 60 = 2\u00b2\u00b73\u00b75, the Sylow constraints force n\u2082 = 5, n\u2083 = 10, n\u2085 = 6, meaning no Sylow subgroup is normal. Combined with the conjugacy class sizes {1, 12, 12, 15, 20} (no subset sum divides 60), this proves A\u2085 has no proper nontrivial normal subgroups. This result is foundational for the Abel-Ruffini theorem (unsolvability of the quintic) and the classification of finite simple groups.",

--- a/src/data/proofs/sylow-theorems/meta.json
+++ b/src/data/proofs/sylow-theorems/meta.json
@@ -44,24 +44,6 @@
     "dateAdded": "2025-12-27",
     "axiomCount": 0,
     "lineCount": 246,
-    "leanFile": {
-      "imports": [
-        "Mathlib.GroupTheory.Sylow",
-        "Mathlib.GroupTheory.Coset.Basic",
-        "Mathlib.GroupTheory.Index",
-        "Mathlib.GroupTheory.OrderOfElement",
-        "Mathlib.Data.Nat.Factorization.Basic",
-        "Mathlib.Tactic"
-      ],
-      "opens": [
-        "Subgroup"
-      ],
-      "namespace": "SylowTheorems",
-      "lineCount": 246,
-      "axiomCount": 0,
-      "theoremCount": 10,
-      "definitionCount": 1
-    },
     "assumptions": "None. Fully verified with 0 axioms, 0 sorries, and 0 structure-encoded assumptions. All three Sylow theorems delegate to Mathlib's `Sylow` module: existence via `Sylow.exists`, conjugacy via `Sylow.equiv`, and counting via `Sylow.card_sylow_modEq_one`. Original contributions are pedagogical wrappers \u2014 `unique_sylow_normal` (unique Sylow subgroup is normal) and `cauchy_theorem` (Cauchy's theorem as corollary) provide accessible named statements composing Mathlib results.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/taylor-sincos-convergence/meta.json
+++ b/src/data/proofs/taylor-sincos-convergence/meta.json
@@ -54,21 +54,6 @@
       }
     ],
     "lineCount": 348,
-    "leanFile": {
-      "lineCount": 348,
-      "structureCount": 0,
-      "axiomCount": 2,
-      "theoremCount": 29,
-      "lemmaCount": 0,
-      "defCount": 4,
-      "imports": [
-        "Mathlib.Analysis.Calculus.Taylor",
-        "Mathlib.Analysis.SpecialFunctions.Trigonometric.Deriv",
-        "Mathlib.Analysis.SpecificLimits.Normed",
-        "Mathlib.Topology.Algebra.InfiniteSum.Real",
-        "Mathlib.Tactic"
-      ]
-    },
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Fix

Remove the stale `meta.leanFile` field from inside the `meta` sub-object in 27 gallery proof meta.json files.

## Evidence

**Before**: `meta.json` files had a `leanFile` field inside the nested `meta` sub-object — a stale duplicate of either the top-level `leanFile` object or derivable from `meta.proofRepoPath`.

**After**: Only the canonical top-level `leanFile` object (or `meta.proofRepoPath`) remains. The `meta` sub-object no longer has a `leanFile` field.

## Proofs Fixed (27)

birch-swinnerton-dyer, birthday-problem-oq-03, brouwer-fixed-point, cayley-hamilton-reduction-oq-02-oq-01, erdos-107, erdos-1091, erdos-1113, erdos-1179-oq-01, furstenberg-correspondence-oq-02, geometric-series-oq-01, inverse-galois, inverse-galois-oq-01, inverse-galois-oq-02, leibniz-pi-oq-01-oq-01, lhopital-oq-02, morleys-theorem, napoleons-theorem, pascals-hexagon, picks-theorem, picks-theorem-oq-03, poincare-conjecture, prime-reciprocal-divergence-oq-03, shapley-folkman, sylow-theorems, sylow-theorems-oq-02, sylow-theorems-oq-04, taylor-sincos-convergence

## Note

Supersedes PR #11629 (`fix/mechanic-leibniz-pi-leanfile`) which conflicted with recent main changes. This fresh branch was created from origin/main and applies the same fix cleanly.

---
Automated fix by lean-mechanic agent.