### PR TITLE
Fix: add missing path field to leanFile objects in 17 gallery proofs

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-04-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-04-oq-01/meta.json
@@ -175,7 +175,8 @@
     "theoremCount": 12,
     "substantiveTheoremCount": 8,
     "duplicateTheorems": 0,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/AngleTrisectionOQ02OQ04OQ01.lean"
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/angle-trisection-oq-02-oq-04/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-04/meta.json
@@ -106,7 +106,8 @@
     "lineCount": 163,
     "axiomCount": 0,
     "theoremCount": 10,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/AngleTrisectionOQ02OQ04.lean"
   },
   "crossReferences": [
     {

--- a/src/data/proofs/basel-problem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-03/meta.json
@@ -108,7 +108,8 @@
     "lineCount": 213,
     "axiomCount": 0,
     "theoremCount": 6,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/BaselProblemOQ01OQ03.lean"
   },
   "references": [],
   "sorries": 0

--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -193,7 +193,8 @@
     "lineCount": 127,
     "axiomCount": 0,
     "theoremCount": 14,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean"
   },
   "sorries": 0
 }

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
@@ -139,7 +139,8 @@
     "theoremCount": 8,
     "substantiveTheoremCount": 6,
     "duplicateTheorems": 0,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean"
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01/meta.json
@@ -81,7 +81,7 @@
     "summary": "The answer to the open question is YES: the multinomial distribution and its MGF are naturally formalized via the multinomial theorem. The normalization proof is just the multinomial theorem evaluated at sum p(i) = 1, and the MGF is the theorem applied to weighted variables.",
     "implications": "This formalization reveals the deep structural connection between combinatorial algebra and probability theory: the multinomial theorem simultaneously serves as the algebraic expansion formula, the normalization proof, and the MGF derivation.",
     "openQuestions": [
-      "RESOLVED: Multinomial PMF integrated with Mathlib PMF framework in BinomialTheoremOQ02OQ01OQ01.lean \u2014 construction via Composition type + ENNReal normalization",
+      "RESOLVED: Multinomial PMF integrated with Mathlib PMF framework in BinomialTheoremOQ02OQ01OQ01.lean — construction via Composition type + ENNReal normalization",
       "Can marginal distributions be formally derived as binomials?",
       "Can the variance-covariance matrix Cov(Xi, Xj) = -n*pi*pj be proved?"
     ]
@@ -101,7 +101,8 @@
     "lineCount": 222,
     "axiomCount": 0,
     "theoremCount": 12,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/BinomialTheoremOQ02OQ01.lean"
   },
   "crossReferences": [
     {

--- a/src/data/proofs/binomial-theorem-oq-03-oq-02-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-03-oq-02-oq-03/meta.json
@@ -118,7 +118,8 @@
     "axiomCount": 0,
     "defCount": 0,
     "sorryCount": 0,
-    "lineCount": 208
+    "lineCount": 208,
+    "path": "Proofs/BinomialTheoremOQ03OQ02OQ03.lean"
   },
   "sorries": 0
 }

--- a/src/data/proofs/binomial-theorem-oq-04-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-04-oq-03/meta.json
@@ -126,7 +126,8 @@
     "theoremCount": 17,
     "substantiveTheoremCount": 11,
     "duplicateTheorems": 0,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/BinomialTheoremOQ04OQ03.lean"
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/birch-swinnerton-dyer-oq-06/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer-oq-06/meta.json
@@ -62,7 +62,8 @@
     "defCount": 2,
     "sorryCount": 0,
     "lineCount": 273,
-    "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirchSwinnertonDyerOQ06.lean"
+    "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirchSwinnertonDyerOQ06.lean",
+    "path": "Proofs/BirchSwinnertonDyerOQ06.lean"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-65-oq-03/meta.json
+++ b/src/data/proofs/erdos-65-oq-03/meta.json
@@ -114,7 +114,8 @@
     "axiomCount": 1,
     "theoremCount": 15,
     "definitionCount": 5,
-    "sorries": 0
+    "sorries": 0,
+    "path": "Proofs/Erdos65OQ03.lean"
   },
   "sorries": 0
 }

--- a/src/data/proofs/erdos-875/meta.json
+++ b/src/data/proofs/erdos-875/meta.json
@@ -150,7 +150,8 @@
     "lineCount": 212,
     "axiomCount": 0,
     "theoremCount": 4,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos875Problem.lean"
   },
   "crossReferences": [
     {

--- a/src/data/proofs/feuerbachs-theorem-oq-02/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-oq-02/meta.json
@@ -161,7 +161,8 @@
     "theoremCount": 10,
     "substantiveTheoremCount": 6,
     "duplicateTheorems": 0,
-    "definitionCount": 35
+    "definitionCount": 35,
+    "path": "Proofs/FeuerbachsTheoremOQ02.lean"
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/laws-of-large-numbers-oq-03/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-03/meta.json
@@ -184,7 +184,8 @@
     "theoremCount": 10,
     "substantiveTheoremCount": 8,
     "duplicateTheorems": 0,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/LawsOfLargeNumbersOQ03.lean"
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/leibniz-pi-oq-02/meta.json
+++ b/src/data/proofs/leibniz-pi-oq-02/meta.json
@@ -171,7 +171,8 @@
     "theoremCount": 12,
     "substantiveTheoremCount": 7,
     "duplicateTheorems": 0,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/LeibnizPiOQ02.lean"
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/quadratic-reciprocity-algorithm-oq-01/meta.json
+++ b/src/data/proofs/quadratic-reciprocity-algorithm-oq-01/meta.json
@@ -129,7 +129,8 @@
   ],
   "leanFile": {
     "lineCount": 220,
-    "axiomCount": 0
+    "axiomCount": 0,
+    "path": "Proofs/QuadraticReciprocityAlgorithmOQ01.lean"
   },
   "sorries": 0
 }

--- a/src/data/proofs/sperner-ndim-oq-03/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-03/meta.json
@@ -171,7 +171,8 @@
     "lineCount": 452,
     "axiomCount": 0,
     "theoremCount": 11,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/SpernerNDimOQ03.lean"
   },
   "sorries": 0
 }

--- a/src/data/proofs/sperner-ndim-oq-04/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-04/meta.json
@@ -248,7 +248,8 @@
     "lineCount": 437,
     "axiomCount": 0,
     "theoremCount": 8,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/SpernerNDimOQ04.lean"
   },
   "sorries": 1
 }


### PR DESCRIPTION
## Fix

Add the missing `path` field to the top-level `leanFile` objects in 17 gallery proof meta.json files.

## Evidence

**Before**: `leanFile` had metadata (lineCount, axiomCount, imports, etc.) but no `path` key, preventing the gallery from linking to the Lean source file.

**After**: Each `leanFile` object includes `"path": "Proofs/Xxx.lean"` taken from `meta.proofRepoPath`.

## Proofs Fixed (17)

- angle-trisection-oq-02-oq-04, angle-trisection-oq-02-oq-04-oq-01
- basel-problem-oq-01-oq-03
- bezout-identity-oq-02-oq-01-oq-01-oq-01
- binomial-theorem-oq-02-oq-01, binomial-theorem-oq-02-oq-01-oq-01, binomial-theorem-oq-03-oq-02-oq-03, binomial-theorem-oq-04-oq-03
- birch-swinnerton-dyer-oq-06
- erdos-65-oq-03, erdos-875
- feuerbachs-theorem-oq-02
- laws-of-large-numbers-oq-03
- leibniz-pi-oq-02
- quadratic-reciprocity-algorithm-oq-01
- sperner-ndim-oq-03, sperner-ndim-oq-04

## Note

Supersedes closed PR #11642. Fresh branch from origin/main with minimal, targeted changes.

---
Automated fix by lean-mechanic agent.