### PR TITLE
Enrich collatz-structured-oq-03 and konigsberg-oq-03: schema fixes

### DIFF
--- a/src/data/proofs/konigsberg-oq-03/meta.json
+++ b/src/data/proofs/konigsberg-oq-03/meta.json
@@ -139,32 +139,32 @@
   ],
   "crossReferences": [
     {
-      "targetId": "konigsberg",
+      "proofId": "konigsberg",
       "relationship": "parent",
       "description": "Königsberg Bridges Problem — the original Eulerian impossibility proof whose theorem this file generalizes to hypergraphs and infinite graphs."
     },
     {
-      "targetId": "konigsberg-oq-01",
+      "proofId": "konigsberg-oq-01",
       "relationship": "sibling",
       "description": "Eulerian Circuits in Finite Graphs — the positive characterization (connected + all even degrees) that serves as the baseline for both generalizations in this file."
     },
     {
-      "targetId": "konigsberg-oq-02",
+      "proofId": "konigsberg-oq-02",
       "relationship": "sibling",
       "description": "Directed Euler Paths — the directed analogue (in-degree = out-degree condition) that parallels the undirected theory extended here."
     },
     {
-      "targetId": "konigsberg-oq-03-oq-02",
+      "proofId": "konigsberg-oq-03-oq-02",
       "relationship": "child",
       "description": "Infinite Paths in Graphs: ℕ-Indexed Formalization — provides the foundational BiInfiniteWalk and InfiniteWalk definitions needed to formalize HasInfiniteEulerPath and HasOneWayEulerPath in this file."
     },
     {
-      "targetId": "konigsberg-oq-04",
+      "proofId": "konigsberg-oq-04",
       "relationship": "sibling",
       "description": "The BEST Theorem (de Bruijn-van Aardenne-Ehrenfest-Smith-Tutte): counts directed Eulerian circuits as a product of in-degrees, tree counts, and arborescences. While this entry asks *whether* hypergraph Euler tours exist (NP-complete), OQ-04 asks *how many* Eulerian circuits exist in the simpler directed case — the decision vs. counting complexity gap"
     },
     {
-      "targetId": "ramseys-theorem",
+      "proofId": "ramseys-theorem",
       "relationship": "related",
       "description": "Ramsey theory studies unavoidable structure in large hypergraphs: the hypergraph Ramsey number $R(r; k_1, \\ldots, k_t)$ for $r$-uniform hypergraphs parallels the graph case. The NP-completeness of Euler tours in $r$-uniform hypergraphs (Lonc-Naroski 2010) is part of the broader story of how classical P-time graph problems become NP-hard when edges gain dimension — a phenomenon Ramsey theory also exhibits"
     }


### PR DESCRIPTION
## Enrichment pass for collatz-structured-oq-03 and konigsberg-oq-03

### collatz-structured-oq-03 (Growth Rate of Average Collatz Stopping Time)
- **Added `mathContext` to all 7 sections**: Collatz map definition, $\sigma(n)$ via Nat.find, average $S(N)$, heuristic derivation, Terras density statement formulation, Filter.Tendsto semantics, concrete stopping time examples
- **Fixed annotation type**: `ann-stopping-time-one` had `type: "tactic"` → `type: "technique"`

### konigsberg-oq-03 (Eulerian Paths in Hypergraphs and Infinite Graphs)
- **Upgraded crossReference schema**: Migrated 6 crossReferences from legacy `targetId` → preferred `proofId` field per the `CrossReference` TypeScript interface (`ref.proofId ?? ref.targetId` in UI code)