### PR TITLE
Fix: correct status axiomatized→formalized for 19 gallery proofs with 0 axioms

### DIFF
--- a/src/data/proofs/erdos-1021/meta.json
+++ b/src/data/proofs/erdos-1021/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Simonovits",
     "sourceUrl": "https://erdosproblems.com/1021",
     "date": "1971",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1021Problem.lean",
     "tags": [
       "graph-theory",

--- a/src/data/proofs/erdos-1100/meta.json
+++ b/src/data/proofs/erdos-1100/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős",
     "sourceUrl": "https://erdosproblems.com/1100",
     "date": "1978",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1100ProblemProvable.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-1168/meta.json
+++ b/src/data/proofs/erdos-1168/meta.json
@@ -5,7 +5,7 @@
   "description": "Prove ℵ_{ω+1} ↛ (ℵ_{ω+1}, 3, …, 3)_{ℵ₀}² without GCH. Open problem in set-theoretic combinatorics at the intersection of partition calculus and pcf theory.",
   "meta": {
     "erdosNumber": 1168,
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1168Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-156/meta.json
+++ b/src/data/proofs/erdos-156/meta.json
@@ -10,7 +10,7 @@
       "Sós"
     ],
     "sourceUrl": "https://erdosproblems.com/156",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos156Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-202/meta.json
+++ b/src/data/proofs/erdos-202/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős, Endre Szemerédi",
     "sourceUrl": "https://erdosproblems.com/202",
     "date": "1968",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos202Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-263/meta.json
+++ b/src/data/proofs/erdos-263/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős",
     "sourceUrl": "https://erdosproblems.com/263",
     "date": "1980s",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Stubs/Erdos263Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-307/meta.json
+++ b/src/data/proofs/erdos-307/meta.json
@@ -7,7 +7,7 @@
     "author": "Barbeau (1976), Cambie",
     "sourceUrl": "https://erdosproblems.com/307",
     "date": "1976",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos307Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-501/meta.json
+++ b/src/data/proofs/erdos-501/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős, András Hajnal",
     "sourceUrl": "https://erdosproblems.com/501",
     "date": "1960",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos501Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-552/meta.json
+++ b/src/data/proofs/erdos-552/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős, S.A. Burr, R.J. Faudree, C.C. Rousseau, R.H. Schelp",
     "sourceUrl": "https://erdosproblems.com/552",
     "date": "1989",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Stubs/Erdos552Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-604/meta.json
+++ b/src/data/proofs/erdos-604/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/604",
     "date": "1957-1997",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos604Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-609/meta.json
+++ b/src/data/proofs/erdos-609/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Graham, bounds by Day-Johnson, Janzer-Yip",
     "sourceUrl": "https://erdosproblems.com/609",
     "date": "",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Stubs/Erdos609Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-629/meta.json
+++ b/src/data/proofs/erdos-629/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős, Arthur Rubin, Herbert Taylor",
     "sourceUrl": "https://erdosproblems.com/629",
     "date": "1980",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos629Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-633/meta.json
+++ b/src/data/proofs/erdos-633/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős, investigated by Soifer",
     "sourceUrl": "https://erdosproblems.com/633",
     "date": "",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos633Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-660/meta.json
+++ b/src/data/proofs/erdos-660/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős",
     "sourceUrl": "https://erdosproblems.com/660",
     "date": "1975",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos660Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-678/meta.json
+++ b/src/data/proofs/erdos-678/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős (1979), solved by Cambie (2024)",
     "sourceUrl": "https://erdosproblems.com/678",
     "date": "1979",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos678Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-679/meta.json
+++ b/src/data/proofs/erdos-679/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős",
     "sourceUrl": "https://erdosproblems.com/679",
     "date": "1979",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos679Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-736/meta.json
+++ b/src/data/proofs/erdos-736/meta.json
@@ -7,7 +7,7 @@
     "author": "Walter Taylor (conjecture), Komjáth-Shelah (consistency result)",
     "sourceUrl": "https://erdosproblems.com/736",
     "date": "2005",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos736Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-901/meta.json
+++ b/src/data/proofs/erdos-901/meta.json
@@ -25,7 +25,7 @@
     "author": "Paul Erdős, László Lovász",
     "sourceUrl": "https://erdosproblems.com/901",
     "date": "1963-1975",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Stubs/Erdos901Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-977/meta.json
+++ b/src/data/proofs/erdos-977/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős, Andrzej Schinzel, Cameron Stewart",
     "sourceUrl": "https://erdosproblems.com/977",
     "date": "1965-2013",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos977Problem.lean",
     "tags": [
       "erdos",


### PR DESCRIPTION
## Fix

Corrects `status: axiomatized` → `status: formalized` for 19 gallery proofs that have sorries but **no axiom declarations and no structure-encoded assumptions**.

## Evidence

Per CLAUDE.md status field definitions:
- `axiomatized` = Has `axiom` declarations OR structure-encoded assumptions
- `formalized` = Lean formalization exists, has sorries remaining

All 19 proofs have `axiomCount: 0` in meta.json and their `assumptions` fields explicitly confirm **"0 axioms"** / **"No axioms"** / **"0 axiom declarations"** — they only have `sorry` placeholders.

This is the same pattern corrected in PR #11643 for `hurwitz-theorem-oq-03` and `szemeredi-hypergraph-core-oq-01`.

**Proofs fixed (19 total)**:
- `erdos-156` — 3 sorries, assumptions: "0 axioms. 3 sorries..."
- `erdos-202` — 3 sorries, assumptions: "3 sorry(s). No axioms."
- `erdos-263` — 4 sorries, assumptions: "No axioms. 4 sorry(s)..."
- `erdos-307` — 2 sorries, assumptions: "0 axiom declarations. 2 sorries..."
- `erdos-501` — 3 sorries, assumptions: "0 axioms, 3 sorries. CH is defined as Prop..."
- `erdos-552` — 12 sorries, assumptions: "No axioms. 12 sorry(s)..."
- `erdos-604` — 1 sorry, assumptions: "No axioms. 1 sorry remaining..."
- `erdos-609` — 16 sorries, assumptions: "No axioms. 16 sorry(s)..."
- `erdos-629` — 7 sorries, assumptions: "7 sorry(s). No axioms."
- `erdos-633` — 8 sorries, assumptions: "0 axiom(s) and 8 sorry(s)."
- `erdos-660` — 10 sorries, assumptions: "0 axiom(s) and 10 sorry(s)."
- `erdos-678` — 4 sorries, assumptions: "0 axiom(s) and 4 sorry(s)."
- `erdos-679` — 10 sorries, assumptions: "0 axiom(s) and 10 sorry(s)."
- `erdos-736` — 1 sorry, assumptions: "0 axiom declarations. All former axioms replaced with theorems..."
- `erdos-901` — 19 sorries, assumptions: "No axioms. 19 sorry(s)..."
- `erdos-977` — 23 sorries, assumptions: "0 axiom(s) and 23 sorry(s)."
- `erdos-1021` — 2 sorries, assumptions: "0 axiom declarations. 2 sorries remain."
- `erdos-1100` — 3 sorries, assumptions: "0 axioms. 3 sorries..."
- `erdos-1168` — 2 sorries, assumptions: "0 axioms (previous axiom replaced...)..."

---
Automated fix by lean-mechanic agent.