### PR TITLE
Add Aristotle companion for lebesgue-measure-oq-06 (Banach-Tarski)

### DIFF
--- a/proofs/Proofs/LebesgueMeasureOQ06Aristotle.lean
+++ b/proofs/Proofs/LebesgueMeasureOQ06Aristotle.lean
@@ -1,0 +1,68 @@
+/-
+  Aristotle targets for LebesgueMeasureOQ06 (Banach-Tarski Paradox)
+  Routine supporting lemmas for automated proof search.
+  See Proofs/LebesgueMeasureOQ06.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main open results (banach_tarski, hausdorff_free_subgroup)
+  - NOT theorems requiring the Axiom of Choice in essential ways
+  - Routine ENNReal arithmetic and amenability structural helpers
+  - No definition sorries
+  - No axiom declarations
+
+  Included targets (5):
+  - ennreal_add_eq_self_iff: a + a = a ↔ a = 0 ∨ a = ⊤ (public non-private version)
+  - ennreal_two_mul_ne_self: 0 < a → a ≠ ⊤ → a + a ≠ a
+  - amenable_compl_sum: μ A + μ Aᶜ = μ univ for finitely-additive μ
+  - freeGroup_generators_ne: generators 0 and 1 in FreeGroup (Fin 2) are distinct
+  - freeGroup_nontrivial: FreeGroup (Fin 2) is nontrivial
+-/
+import Mathlib
+
+open Set MeasureTheory
+
+namespace BanachTarskiAristotle
+
+/-
+  ## Section 1: ENNReal Arithmetic
+  Key arithmetic facts for the amenability and paradoxicality arguments.
+-/
+
+/-- In ℝ≥0∞, a + a = a iff a = 0 or a = ⊤.
+    This is the key "paradox equation": if a paradoxical set has a
+    finite invariant measure μ, then μ(A) = 2·μ(A) forces μ(A) ∈ {0, ⊤}. -/
+theorem ennreal_add_eq_self_iff {a : ℝ≥0∞} : a + a = a ↔ a = 0 ∨ a = ⊤ := by
+  sorry
+
+/-- If 0 < a < ⊤ then a + a ≠ a (the paradox equation fails for finite positive measures). -/
+theorem ennreal_two_mul_ne_self {a : ℝ≥0∞} (ha_pos : 0 < a) (ha_top : a ≠ ⊤) :
+    a + a ≠ a := by
+  sorry
+
+/-- A + Aᶜ = Set.univ for any set. -/
+theorem union_compl_eq_univ {α : Type*} (A : Set α) : A ∪ Aᶜ = Set.univ :=
+  Set.union_compl_self A
+
+/-- For a finitely-additive probability measure, μ A + μ Aᶜ = 1. -/
+theorem amenable_compl_sum {G : Type*}
+    (μ : Set G → ℝ≥0∞)
+    (hμ_total : μ Set.univ = 1)
+    (hμ_add : ∀ A B : Set G, Disjoint A B → μ (A ∪ B) = μ A + μ B)
+    (A : Set G) : μ A + μ Aᶜ = 1 := by
+  sorry
+
+/-
+  ## Section 2: FreeGroup Basic Facts
+  Elementary properties of FreeGroup (Fin 2) for the non-amenability proof.
+-/
+
+/-- The two generators of FreeGroup (Fin 2) are distinct elements. -/
+theorem freeGroup_generators_ne :
+    FreeGroup.of (0 : Fin 2) ≠ FreeGroup.of (1 : Fin 2) := by
+  sorry
+
+/-- FreeGroup (Fin 2) is nontrivial (contains more than just the identity). -/
+theorem freeGroup_nontrivial : Nontrivial (FreeGroup (Fin 2)) := by
+  sorry
+
+end BanachTarskiAristotle


### PR DESCRIPTION
## Fix

Adds `LebesgueMeasureOQ06Aristotle.lean` — an Aristotle companion file for the Banach-Tarski formalization — with 5 routine supporting lemmas for automated proof search.

## Evidence

**Before**: `lebesgue-measure-oq-06` (5 sorries) had no Aristotle companion file.

**After**: Companion file provides these targets:
1. `ennreal_add_eq_self_iff` — public version of the private `ENNReal.eq_zero_or_top_of_add_eq_self` lemma already proved in the main file
2. `ennreal_two_mul_ne_self` — consequence: finite positive values cannot satisfy the paradox equation
3. `amenable_compl_sum` — finitely-additive probability measure: μ A + μ Aᶜ = 1
4. `freeGroup_generators_ne` — generators 0 and 1 of FreeGroup(Fin 2) are distinct
5. `freeGroup_nontrivial` — FreeGroup(Fin 2) is nontrivial

Pre-submission checklist:
- [x] No `def ... := sorry`
- [x] No `axiom` declarations
- [x] No `theorem ... : True` placeholders
- [x] No `/-!` docstring sections
- [x] No open conjectures

---
Automated fix by lean-mechanic agent.