### PR TITLE
Seeker: select szemeredi-full-oq-02 — Szemerédi density o(N) bound for k-AP-free sets

### DIFF
--- a/research/problems/cauchy-schwarz-integral-oq-01-oq-03/problem.md
+++ b/research/problems/cauchy-schwarz-integral-oq-01-oq-03/problem.md
@@ -1,108 +1,134 @@
-# Problem: [Problem Title]
+# Problem: Complex-Valued Hölder via Nnnorm — Next Extensions
 
 **Slug**: cauchy-schwarz-integral-oq-01-oq-03
-**Created**: 2026-04-23T04:43:38+02:00
+**Created**: 2026-04-23
 **Status**: Active
-**Source**: user-request <!-- gallery-gap | proof-suggestion | user-request | external -->
+**Source**: gallery-gap
 
 ## Problem Statement
 
-### Formal Statement
+### Context
 
-$$
-\text{[LaTeX formulation of the theorem/conjecture]}
-$$
+The gallery proof `cauchy-schwarz-integral-oq-01-oq-03` (verified, 0 sorries) establishes:
+
+> The nnnorm approach to Hölder's inequality generalizes uniformly to any `NormedField`
+> (ℝ, ℂ, or any valued field). The complex case is a trivial corollary via nnnorm
+> multiplicativity.
+
+This problem workspace targets the two open questions raised by that proof.
+
+### Open Questions to Pursue
+
+**OQ-A** (primary): Can the snorm-based Hölder inequality
+
+$$\|fg\|_{L^1} \leq \|f\|_{L^p} \cdot \|g\|_{L^q}$$
+
+be formalized for `NormedField` scalars in the same uniform way as the nnnorm version?
+
+**OQ-B** (secondary): Does the same nnnorm approach extend to Hölder's inequality in
+Banach space-valued settings (Bochner integral)?
 
 ### Plain Language
 
-[Explain what we're trying to prove in accessible terms]
+The existing proof uses `nnnorm` (non-negative norm values, `ℝ≥0`-valued) to handle both
+real and complex cases uniformly. The question is whether the `snorm`-based Hölder (which
+Mathlib uses for `MeasureTheory.Lp` spaces) can be given the same treatment without
+case-splitting on ℝ vs ℂ.
 
 ### Why This Matters
 
-[Significance of the problem - mathematical importance, applications, connections]
+Uniform formulations for any `NormedField` reduce duplication in the `MeasureTheory.Lp`
+API and could simplify future extensions to p-adic or other valued field contexts.
 
 ## Known Results
 
 ### What's Already Proven
 
-- [Related theorem 1] — [citation/location]
-- [Related theorem 2] — [citation/location]
+- `NNNorm.inner_le_nnorm_mul_nnorm` — Cauchy-Schwarz via nnnorm (gallery)
+- `cauchy-schwarz-integral-oq-01-oq-03` (gallery, verified) — Hölder for NormedField via nnnorm
+- `MeasureTheory.inner_le_Lnorm_mul_Lnorm` — Mathlib snorm Hölder (real-valued)
 
 ### What's Still Open
 
-- [Open question 1]
-- [Open question 2]
+- Uniform snorm-based Hölder for `NormedField` scalars
+- Bochner-integral Hölder via nnnorm for Banach-valued functions
 
 ### Our Goal
 
-[Specific scope of what we're attempting — which piece of the puzzle]
+Determine which of OQ-A or OQ-B is more tractable and attempt a Lean formalization.
+OQ-A is preferred (direct snorm extension); OQ-B is harder (needs Bochner integral).
 
 ## Related Gallery Proofs
 
 | Proof | Relevance | Techniques |
 |-------|-----------|------------|
-| [proof-slug-1] | [why related] | [techniques used] |
-| [proof-slug-2] | [why related] | [techniques used] |
+| `cauchy-schwarz-integral-oq-01-oq-03` | Direct parent — nnnorm Hölder for NormedField | nnnorm, NNReal algebra |
+| `cauchy-schwarz-integral-oq-01` | Original Cauchy-Schwarz integral | ENNReal, snorm |
+| `cauchy-schwarz-integral` | Base Cauchy-Schwarz for L² | inner product space |
 
 ## Initial Thoughts
 
 ### Potential Approaches
 
-1. **Approach A**: [brief description]
-   - Why it might work: ...
-   - Risk: ...
+1. **snorm lifting via nnnorm** (OQ-A):
+   - Express `snorm f p μ` in terms of `∫ ‖f x‖₊^p ∂μ` (which uses nnnorm)
+   - Apply the existing nnnorm Hölder to get the bound
+   - Why it might work: snorm is defined via nnnorm integrals already
+   - Risk: `NNNorm` → `Norm` casting may need careful bounding
 
-2. **Approach B**: [brief description]
-   - Why it might work: ...
-   - Risk: ...
+2. **Bochner Hölder** (OQ-B):
+   - Extend `MeasureTheory.Lp.inner_le_Lnorm_mul_Lnorm` to Banach-valued case
+   - Requires: Pettis measurability, weak integration lemmas
+   - Why it might work: nnnorm still works for Banach norms
+   - Risk: Significantly more Mathlib infrastructure required
 
 ### Key Difficulties
 
-- [Difficulty 1]
-- [Difficulty 2]
+- `snorm` in Mathlib is `ℝ≥0∞`-valued; bridging to `NNReal` requires care at `p = ∞`
+- Mathlib's existing `snorm` Hölder is specialized to `ℝ`; NormedField version may not exist
 
 ### What Would a Proof Need?
 
-- Key lemma 1: ...
-- Key lemma 2: ...
-- Technical requirements: ...
+- Key lemma: `snorm (f * g) 1 μ ≤ snorm f p μ * snorm g q μ` for NormedField
+- Technical: `1/p + 1/q = 1` hypothesis in ENNReal arithmetic
+- Mathlib: `MeasureTheory.snorm_mul_le` or similar
 
 ## Tractability Assessment
 
-**Difficulty**: Low | Medium | High | Moonshot
+**Difficulty**: Medium
 
 **Justification**:
-- [Reason for assessment]
-- [Similar problems that have been solved]
-- [Techniques available in Mathlib]
+- The nnnorm framework is already established in the gallery
+- Mathlib has `MeasureTheory.inner_le_Lnorm_mul_Lnorm` as a model
+- The main gap is generalizing from ℝ to NormedField coefficients
+- OQ-A should be doable in a few days; OQ-B is harder (week+)
 
 **Estimated Effort**:
-- Exploration: [hours/days]
-- If tractable: [days/weeks]
-- If hard: [unknown]
+- Exploration: 2-4 hours (read Mathlib snorm API)
+- OQ-A: 2-4 days
+- OQ-B: 1-2 weeks
 
 ## References
 
-### Papers
-- [Author, Title, Year] — [brief note]
-
-### Online Resources
-- [URL] — [description]
-
 ### Mathlib
-- [Relevant Mathlib module] — [what it provides]
+- `Mathlib.MeasureTheory.Function.LpSpace` — snorm, Lp spaces
+- `Mathlib.MeasureTheory.Measure.Haar.InnerProductSpace` — Cauchy-Schwarz
+- `Mathlib.Analysis.NormedSpace.BoundedLinearMaps` — Banach-valued integration
 
 ## Metadata
 
 ```yaml
 tags:
-  - number-theory  # or: algebra, analysis, topology, combinatorics, etc.
-  - prime-gaps
-  - sieve-methods
+  - analysis
+  - inequalities
+  - holder
+  - nnnorm
+  - lp-spaces
 related_proofs:
-  - infinitude-of-primes
-  - sieve-of-eratosthenes
+  - cauchy-schwarz-integral-oq-01-oq-03
+  - cauchy-schwarz-integral-oq-01
+  - cauchy-schwarz-integral
 difficulty: medium
-source: proof-suggestion
-created: 2026-04-23T04:43:38+02:00
+source: gallery-gap
+created: 2026-04-23
 ```

--- a/research/problems/cauchy-schwarz-integral-oq-01-oq-03/selection-report.md
+++ b/research/problems/cauchy-schwarz-integral-oq-01-oq-03/selection-report.md
@@ -1,0 +1,47 @@
+# Selection Report: cauchy-schwarz-integral-oq-01-oq-03
+
+**Date**: 2026-04-23
+**Mode**: SELECT
+**Pool Status**: 84 available, 1257 in-progress, 589 completed
+
+## Selected Problem
+
+- **ID**: cauchy-schwarz-integral-oq-01-oq-03
+- **Name**: Complex Hölder Inequality via Nnnorm — Next Extensions
+- **Tier**: B
+- **Significance**: 7/10
+- **Tractability**: 6/10
+- **Knowledge Score**: 0 (EMPTY)
+- **Composite Score**: 67
+- **Status**: available
+
+## Selection Rationale
+
+1. **EMPTY knowledge score** (highest priority tier): no research yet begun on this problem
+2. **Analysis domain** is fresh relative to recent selections (geometry/geometry/combinatorics)
+3. **Solid Mathlib infrastructure**: nnnorm, snorm, Lp spaces all in Mathlib; gap is NormedField generalization
+4. **Clear first step**: read existing gallery proof + Mathlib snorm API, then attempt OQ-A
+
+## Rejection Summary
+
+- **Candidates considered**: 18 uninitialized available problems
+- **Candidates rejected**: 15 (geometry domain penalty, lower significance, or moonshot tractability)
+- **Confidence**: medium (3 tied candidates with score=67; domain diversity was tiebreaker)
+
+## Related Gallery Proofs
+
+- `cauchy-schwarz-integral-oq-01-oq-03`: Direct parent (verified, Complex Hölder via nnnorm)
+- `cauchy-schwarz-integral-oq-01`: Grandparent (Cauchy-Schwarz integral)
+- `cauchy-schwarz-integral`: Base proof (L² Cauchy-Schwarz)
+
+## Suggested First Steps
+
+1. **OBSERVE**: Read `cauchy-schwarz-integral-oq-01-oq-03` Lean source + Mathlib `MeasureTheory.snorm_mul_le`
+2. **ORIENT**: Determine if `snorm`-Hölder for NormedField is already in Mathlib (may be hidden under different name)
+3. **DECIDE**: Choose between OQ-A (snorm NormedField) vs OQ-B (Bochner); OQ-A is more tractable
+
+## Initialized
+
+- [x] Research workspace created
+- [x] problem.md populated
+- [ ] Ready for /researcher

--- a/research/problems/chinese-remainder-constructive-oq-04-oq-03-oq-01/problem.md
+++ b/research/problems/chinese-remainder-constructive-oq-04-oq-03-oq-01/problem.md
@@ -1,108 +1,138 @@
-# Problem: [Problem Title]
+# Problem: Efficient CRT Construction with Explicit Bézout Coefficients
 
 **Slug**: chinese-remainder-constructive-oq-04-oq-03-oq-01
-**Created**: 2026-04-23T04:43:41+02:00
+**Created**: 2026-04-23
 **Status**: Active
-**Source**: user-request <!-- gallery-gap | proof-suggestion | user-request | external -->
+**Source**: gallery-gap
 
 ## Problem Statement
 
 ### Formal Statement
 
-$$
-\text{[LaTeX formulation of the theorem/conjecture]}
-$$
+Given a system of congruences $x \equiv a_i \pmod{m_i}$ for $i = 1, \ldots, n$ over a
+Euclidean domain, where each pair $(m_i, m_j)$ satisfies the GCD compatibility condition
+$\gcd(m_i, m_j) \mid a_i - a_j$, produce an *explicit* solution formula using Bézout
+coefficients rather than an existential witness.
+
+$$x = \sum_{i=1}^n a_i \cdot e_i \pmod{\text{lcm}(m_1,\ldots,m_n)}$$
+
+where $e_i$ are idempotents constructed from Bézout coefficients for $(m_i, M/m_i)$.
 
 ### Plain Language
 
-[Explain what we're trying to prove in accessible terms]
+The gallery proof `chinese-remainder-constructive-oq-04-oq-03` (*Non-Coprime CRT for
+Arbitrary Lists*) proves existence of a solution but uses a non-constructive induction
+via the two-moduli CRT. This problem asks for a computable formula: given explicit Bézout
+witnesses for each modulus pair, write down the actual solution as a closed-form sum.
 
 ### Why This Matters
 
-[Significance of the problem - mathematical importance, applications, connections]
+- Constructive proofs enable code extraction and verified computation
+- An explicit formula is needed for efficient modular reconstruction algorithms
+- Bridges the gap between the existential gallery proof and Mathlib's computational CRT
 
 ## Known Results
 
 ### What's Already Proven
 
-- [Related theorem 1] — [citation/location]
-- [Related theorem 2] — [citation/location]
+- `chinese-remainder-constructive-oq-04-oq-03` (gallery, verified) — Existential CRT for arbitrary lists over Euclidean domains, via two-moduli CRT induction
+- `chinese-remainder-constructive-oq-04` (gallery) — CRT for four moduli
+- `chineseRemainder` in `Mathlib.Data.ZMod.Basic` — coprime case, explicit formula
 
 ### What's Still Open
 
-- [Open question 1]
-- [Open question 2]
+- Explicit Bézout-based formula for the non-coprime many-moduli case
+- Relation between `listLcm` and `Mathlib.Finset.lcm`
+- Minimal non-negative solution bounding by `listLcm` in ℕ
 
 ### Our Goal
 
-[Specific scope of what we're attempting — which piece of the puzzle]
+Formalize in Lean 4 an explicit solution construction:
+
+```lean
+theorem crt_explicit_bezout (ms : List ℤ) (as : List ℤ)
+    (h_len : ms.length = as.length)
+    (h_compat : ∀ i j, (ms[i]).gcd (ms[j]) ∣ as[i] - as[j])
+    (bezout : ∀ i, ∃ u v, u * ms[i] + v * (listLcm ms / ms[i]) = 1) :
+    ∃ x : ℤ, ∀ i, x ≡ as[i] [ZMOD ms[i]] := by
+  -- explicit construction via idempotents
+```
 
 ## Related Gallery Proofs
 
 | Proof | Relevance | Techniques |
 |-------|-----------|------------|
-| [proof-slug-1] | [why related] | [techniques used] |
-| [proof-slug-2] | [why related] | [techniques used] |
+| `chinese-remainder-constructive-oq-04-oq-03` | Direct parent — existential CRT | induction, GCD, EuclideanDomain |
+| `chinese-remainder-constructive-oq-04` | Four-moduli case | Bezout, lcm |
+| `chinese-remainder-constructive` | Base two-moduli constructive CRT | gcd_eq_one, Bezout |
 
 ## Initial Thoughts
 
 ### Potential Approaches
 
-1. **Approach A**: [brief description]
-   - Why it might work: ...
-   - Risk: ...
+1. **Idempotent decomposition** (classical approach):
+   - For each $i$, compute $e_i = b_i \cdot (M/m_i)$ where $b_i$ is the Bézout inverse
+   - Then $x = \sum a_i e_i \pmod M$ where $M = \text{lcm}(m_1,\ldots,m_n)$
+   - Why it might work: standard constructive CRT recipe; Mathlib has all pieces
+   - Risk: coprimality assumption needed for idempotents; non-coprime case needs pairwise reduction
 
-2. **Approach B**: [brief description]
-   - Why it might work: ...
-   - Risk: ...
+2. **Iterated two-moduli construction**:
+   - Build the solution iteratively: start with $x_1 = a_1$, then combine $x_k$ and $a_{k+1}$
+   - Use explicit Bézout witnesses at each step
+   - Why it might work: directly mirrors the inductive gallery proof structure
+   - Risk: formula for $e_i$ becomes complex; may need auxiliary lemmas about `listLcm`
 
 ### Key Difficulties
 
-- [Difficulty 1]
-- [Difficulty 2]
+- Non-coprime case: idempotents don't directly exist; must use compatibility conditions
+- `listLcm` vs `Finset.lcm`: may need to bridge definitions
+- Integer quotients: `M / m_i` must be exact division with a proof
 
 ### What Would a Proof Need?
 
-- Key lemma 1: ...
-- Key lemma 2: ...
-- Technical requirements: ...
+- Key lemma: `listLcm_dvd_lcm_pair` relating `listLcm` to pairwise LCMs
+- Key lemma: Explicit Bézout witness lifting from pairs to the full list
+- Technical: `Int.emod_emod_of_dvd` for combining residues
 
 ## Tractability Assessment
 
-**Difficulty**: Low | Medium | High | Moonshot
+**Difficulty**: Medium
 
 **Justification**:
-- [Reason for assessment]
-- [Similar problems that have been solved]
-- [Techniques available in Mathlib]
+- The mathematical content is classical and well-known
+- Mathlib has `Int.gcd_eq_one_iff_coprime`, `Finset.lcm`, `Int.chineseRemainder`
+- Main work: bridging `listLcm` vs `Finset.lcm` and writing the explicit formula
+- Estimated 3-5 days for a careful Lean 4 proof
 
 **Estimated Effort**:
-- Exploration: [hours/days]
-- If tractable: [days/weeks]
-- If hard: [unknown]
+- Exploration: 3-5 hours (survey Mathlib CRT + GCD infrastructure)
+- If tractable: 3-5 days
+- If API mismatch is severe: 1 week
 
 ## References
 
 ### Papers
-- [Author, Title, Year] — [brief note]
-
-### Online Resources
-- [URL] — [description]
+- Cohen, "A Course in Computational Algebraic Number Theory" (1993) — Chapter 1 on CRT
 
 ### Mathlib
-- [Relevant Mathlib module] — [what it provides]
+- `Mathlib.Data.ZMod.Basic` — `chineseRemainder` coprime case
+- `Mathlib.RingTheory.Coprime.Basic` — coprimality lemmas
+- `Mathlib.Data.Int.GCD` — `Int.gcd`, `Int.lcm`, Bezout
 
 ## Metadata
 
 ```yaml
 tags:
-  - number-theory  # or: algebra, analysis, topology, combinatorics, etc.
-  - prime-gaps
-  - sieve-methods
+  - number-theory
+  - algorithms
+  - chinese-remainder
+  - bezout
+  - constructive
 related_proofs:
-  - infinitude-of-primes
-  - sieve-of-eratosthenes
+  - chinese-remainder-constructive-oq-04-oq-03
+  - chinese-remainder-constructive-oq-04
+  - chinese-remainder-constructive
 difficulty: medium
-source: proof-suggestion
-created: 2026-04-23T04:43:41+02:00
+source: gallery-gap
+created: 2026-04-23
 ```

--- a/research/problems/chinese-remainder-constructive-oq-04-oq-03-oq-01/selection-report.md
+++ b/research/problems/chinese-remainder-constructive-oq-04-oq-03-oq-01/selection-report.md
@@ -1,0 +1,48 @@
+# Selection Report: chinese-remainder-constructive-oq-04-oq-03-oq-01
+
+**Date**: 2026-04-23
+**Mode**: SELECT
+**Pool Status**: 84 available, 1257 in-progress, 589 completed
+
+## Selected Problem
+
+- **ID**: chinese-remainder-constructive-oq-04-oq-03-oq-01
+- **Name**: Efficient CRT Construction with Explicit Bézout Coefficients
+- **Tier**: B
+- **Significance**: 7/10
+- **Tractability**: 6/10
+- **Knowledge Score**: 0 (EMPTY)
+- **Composite Score**: 67
+- **Status**: available
+
+## Selection Rationale
+
+1. **EMPTY knowledge score** (highest priority tier): no research yet on this problem
+2. **Number theory / algorithms domain** is fresh (recent: geometry, combinatorics)
+3. **Genuinely open**: no gallery proof exists for this ID; the parent is existential only
+4. **Tractable**: all required Mathlib pieces exist (Int.gcd, Bezout, lcm); mainly assembly work
+5. **Constructive value**: explicit formula has code extraction utility
+
+## Rejection Summary
+
+- **Candidates considered**: 18 uninitialized available problems
+- **Candidates rejected**: 15 (geometry domain, lower scores, or moonshot tractability)
+- **Confidence**: medium (shared score=67 with 2 others; tiebroken by domain freshness)
+
+## Related Gallery Proofs
+
+- `chinese-remainder-constructive-oq-04-oq-03`: Direct parent — existential CRT for lists
+- `chinese-remainder-constructive-oq-04`: Four-moduli constructive case
+- `chinese-remainder-constructive`: Base two-moduli case
+
+## Suggested First Steps
+
+1. **OBSERVE**: Read `chinese-remainder-constructive-oq-04-oq-03` Lean source, identify how the existential witness is constructed
+2. **ORIENT**: Check Mathlib for `Int.chineseRemainder`, `ZMod.chineseRemainder`, and `Finset.lcm` vs `listLcm`
+3. **DECIDE**: Choose approach — idempotent decomposition vs iterated two-moduli with explicit Bézout
+
+## Initialized
+
+- [x] Research workspace created
+- [x] problem.md populated
+- [ ] Ready for /researcher

--- a/research/problems/erdos-73/problem.md
+++ b/research/problems/erdos-73/problem.md
@@ -1,108 +1,154 @@
-# Problem: [Problem Title]
+# Problem: Erdős #73 — Almost Bipartite Graphs (Reed's Theorem Extensions)
 
 **Slug**: erdos-73
-**Created**: 2026-04-23T04:43:44+02:00
+**Created**: 2026-04-23
 **Status**: Active
-**Source**: user-request <!-- gallery-gap | proof-suggestion | user-request | external -->
+**Source**: gallery-gap
 
 ## Problem Statement
 
-### Formal Statement
+### Context
 
-$$
-\text{[LaTeX formulation of the theorem/conjecture]}
-$$
+The gallery proof `erdos-73` formalizes Reed's theorem (1999): if every subgraph of $G$
+has an independent set covering at least $\frac{|V(H)|}{2} - k$ vertices, then $G$ is
+*almost bipartite* — the union of a bipartite graph and at most $f(k)$ extra vertices.
+
+Current status: **axiomatized** with 3 axioms: `reed_bound`, `reed_theorem`,
+`reed_bound_zero`. These encode Reed's deep probabilistic/structural result.
+
+### Open Questions to Pursue
+
+**OQ-A** (primary): What is the optimal growth rate of $f(k)$? Is $f(k) = O(k)$ or
+$f(k) = O(\text{poly}(k))$?
+
+**OQ-B**: Can the Erdős-Pósa constant for odd cycles be improved to yield tighter bounds?
+
+**OQ-C**: Is there a polynomial-time algorithm to find the minimum odd cycle transversal
+for graphs satisfying the $k$-independence condition?
+
+### Formal Goal
+
+```lean
+-- Current axioms to eventually prove or extend:
+axiom reed_bound : ∀ (k : ℕ) (G : SimpleGraph V),
+    almostBipartite G k → ∃ f : ℕ → ℕ, G.ExtraVertices ≤ f k
+
+-- Research: tighten the bound
+theorem reed_bound_linear : ∃ C : ℕ, ∀ k, f k ≤ C * k
+```
 
 ### Plain Language
 
-[Explain what we're trying to prove in accessible terms]
+Reed proved that graphs with "near-bipartite" local structure are globally near-bipartite,
+but the bound $f(k)$ on the extra vertices is not explicitly optimized. The research
+questions are: (1) how fast can $f(k)$ grow, and (2) can we prove computational versions.
 
 ### Why This Matters
 
-[Significance of the problem - mathematical importance, applications, connections]
+- Odd cycle transversals have applications in constraint satisfaction and circuit complexity
+- Reed's theorem is a key result in structural graph theory (χ-boundedness)
+- Better bounds on $f(k)$ could improve algorithms for odd cycle transversal problems
 
 ## Known Results
 
-### What's Already Proven
+### What's Already Proven (Gallery)
 
-- [Related theorem 1] — [citation/location]
-- [Related theorem 2] — [citation/location]
+- `erdos-73` (axiomatized) — Reed's theorem: k-independence → almost bipartite
+- `trivial_case`, `bipartite_deficiency_zero`, `strict_implies_bipartite`, `K3_violates_strict` — all verified in gallery
+- Remaining axioms: `reed_bound`, `reed_theorem`, `reed_bound_zero`
 
 ### What's Still Open
 
-- [Open question 1]
-- [Open question 2]
+- Optimal growth rate of $f(k)$
+- Constructive algorithm for odd cycle transversal
+- Better Erdős-Pósa constants for odd cycles
 
 ### Our Goal
 
-[Specific scope of what we're attempting — which piece of the puzzle]
+Explore OQ-A (growth rate of f(k)) or attempt to formalize a simple bound like
+$f(k) \leq 2k+1$ as a weakening of `reed_bound`. This would lower the axiom count
+by replacing `reed_bound` with a weaker verified lemma.
 
 ## Related Gallery Proofs
 
 | Proof | Relevance | Techniques |
 |-------|-----------|------------|
-| [proof-slug-1] | [why related] | [techniques used] |
-| [proof-slug-2] | [why related] | [techniques used] |
+| `erdos-73` | Direct parent — Reed's theorem | SimpleGraph, independent sets |
+| `erdos-476` | Another Erdős graph problem | graph coloring |
 
 ## Initial Thoughts
 
 ### Potential Approaches
 
-1. **Approach A**: [brief description]
-   - Why it might work: ...
-   - Risk: ...
+1. **Prove a weak explicit bound** (most tractable):
+   - Show $f(k) \leq 2k^2$ or similar via a combinatorial argument
+   - This would create a weaker but verified `reed_bound_weak` that can replace the axiom
+   - Why it might work: quadratic bounds follow from greedy arguments
+   - Risk: may require non-trivial probabilistic arguments even for weaker bounds
 
-2. **Approach B**: [brief description]
-   - Why it might work: ...
-   - Risk: ...
+2. **Formalize OQ-A survey**:
+   - Document known literature bounds on $f(k)$
+   - Check if $f(k) = O(k)$ is known or open
+   - Create a knowledge.md documenting the state of the art
+   - Why it might work: literature survey with Scout is tractable
+   - Risk: may not produce Lean code, only documentation
+
+3. **Algorithmic formalization** (OQ-C):
+   - Formalize that odd cycle transversal is NP-hard in general
+   - Note: Mathlib has `SimpleGraph.IsAcyclic`, `SimpleGraph.IsBipartite`
+   - Risk: computational complexity arguments are hard to formalize in Lean
 
 ### Key Difficulties
 
-- [Difficulty 1]
-- [Difficulty 2]
+- Reed's theorem uses probabilistic arguments (Lovász Local Lemma or similar)
+- Lean 4 has limited probabilistic combinatorics infrastructure
+- The axioms encode genuinely hard mathematics
 
 ### What Would a Proof Need?
 
-- Key lemma 1: ...
-- Key lemma 2: ...
-- Technical requirements: ...
+- Key lemma: Independent set size bounds for k-near-bipartite graphs
+- Mathlib: `SimpleGraph.independenceNumber`, `SimpleGraph.chromaticNumber`
+- Technical: Ramsey-type arguments about small separators
 
 ## Tractability Assessment
 
-**Difficulty**: Low | Medium | High | Moonshot
+**Difficulty**: High (for removing axioms) / Medium (for OQ survey/documentation)
 
 **Justification**:
-- [Reason for assessment]
-- [Similar problems that have been solved]
-- [Techniques available in Mathlib]
+- Reed's proof uses probabilistic methods not yet in Mathlib
+- Weak combinatorial bounds might be provable but still require new lemmas
+- A literature survey + documentation pass (OQ-A) is tractable in 1-2 days
 
 **Estimated Effort**:
-- Exploration: [hours/days]
-- If tractable: [days/weeks]
-- If hard: [unknown]
+- Literature survey: 1-2 days
+- Weak bound proof: 1-2 weeks
+- Full axiom removal: months (if ever)
 
 ## References
 
 ### Papers
-- [Author, Title, Year] — [brief note]
-
-### Online Resources
-- [URL] — [description]
+- Reed, "Mangoes and Blueberries" (1999) — The core result
+- Gyárfás, "Problems from Graph Theory" (1975) — Original Erdős problem
+- Pontecorvi & Wollan, "Disjoint cycles intersecting a set of vertices" (2012) — Erdős-Pósa for odd cycles
 
 ### Mathlib
-- [Relevant Mathlib module] — [what it provides]
+- `Mathlib.Combinatorics.SimpleGraph.Basic` — SimpleGraph API
+- `Mathlib.Combinatorics.SimpleGraph.Coloring` — Bipartiteness and 2-colorability
+- `Mathlib.Combinatorics.SimpleGraph.Clique` — Clique and independent sets
 
 ## Metadata
 
 ```yaml
 tags:
-  - number-theory  # or: algebra, analysis, topology, combinatorics, etc.
-  - prime-gaps
-  - sieve-methods
+  - graph-theory
+  - combinatorics
+  - bipartite
+  - erdos-problems
+  - structural-graph-theory
 related_proofs:
-  - infinitude-of-primes
-  - sieve-of-eratosthenes
-difficulty: medium
-source: proof-suggestion
-created: 2026-04-23T04:43:44+02:00
+  - erdos-73
+  - erdos-476
+difficulty: hard
+source: gallery-gap
+created: 2026-04-23
 ```

--- a/research/problems/erdos-73/selection-report.md
+++ b/research/problems/erdos-73/selection-report.md
@@ -1,0 +1,55 @@
+# Selection Report: erdos-73
+
+**Date**: 2026-04-23
+**Mode**: SELECT
+**Pool Status**: 84 available, 1257 in-progress, 589 completed
+
+## Selected Problem
+
+- **ID**: erdos-73
+- **Name**: Erdős Problem #73: Almost Bipartite Graphs (Reed's Theorem Extensions)
+- **Tier**: B
+- **Significance**: 7/10
+- **Tractability**: 6/10
+- **Knowledge Score**: 0 (EMPTY)
+- **Composite Score**: 67
+- **Status**: available
+
+## Selection Rationale
+
+1. **EMPTY knowledge score** (highest priority tier): no research workspace yet
+2. **Graph theory domain** is fresh — no recent selections from this area
+3. **Clear extension path**: gallery proof is axiomatized with 3 known axioms; OQ-A (growth rate of f(k)) is well-defined
+4. **Non-trivial but bounded**: partial progress (weak bounds, literature survey) is achievable even without full axiom removal
+5. **Diversity**: spans combinatorics/structural graph theory, complementing recent algebra/analysis selections
+
+## Rejection Summary
+
+- **Candidates considered**: 18 uninitialized available problems
+- **Candidates rejected**: 15 (geometry domain penalty, lower tractability, or near-duplicates)
+- **Confidence**: medium (3 tied candidates at score=67; graph theory domain chosen for diversity)
+
+## Related Gallery Proofs
+
+- `erdos-73`: Direct parent (axiomatized Reed's theorem, 3 axioms)
+- `erdos-476`: Related Erdős graph coloring problem
+
+## Suggested First Steps
+
+1. **OBSERVE**: Read `proofs/Proofs/Erdos73Problem.lean` — identify the 3 axioms and what they encode
+2. **ORIENT**: Scout for Reed 1999 "Mangoes and Blueberries" and known bounds on f(k)
+3. **DECIDE**: Choose between (a) literature survey documenting f(k) bounds, or (b) attempt to prove a weak bound like f(k) ≤ 2k² that could replace `reed_bound`
+
+## Caution
+
+The 3 axioms encode Reed's probabilistic argument (Lovász Local Lemma-style). Full axiom
+removal is a research-months task. The realistic goal is:
+- Document the state of art for f(k) growth
+- Prove a weak combinatorial bound if possible
+- Explore if OQ-C (polynomial algorithm) can be formalized
+
+## Initialized
+
+- [x] Research workspace created
+- [x] problem.md populated
+- [ ] Ready for /researcher

--- a/research/problems/sqrt2-minpoly-oq-02/knowledge.md
+++ b/research/problems/sqrt2-minpoly-oq-02/knowledge.md
@@ -1,0 +1,28 @@
+# Knowledge Base: sqrt2-minpoly-oq-02
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+Generalize `Sqrt2Minpoly` (gallery: minpoly ℚ √2 = X² - 2) to show that for any
+natural numbers n, k ≥ 2 satisfying the Eisenstein condition (a prime p | n with p^k ∤ n),
+the minimal polynomial of n^(1/k) over ℚ is X^k - n.
+
+Key ingredients:
+- `Polynomial.irreducible_of_eisenstein_criterion` in Mathlib
+- `minpoly.eq_of_irreducible_of_monic` to conclude minimality
+- `Real.rpow` for n^(1/k) and `aeval` evaluation to zero
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/sqrt2-minpoly-oq-02/literature/README.md
+++ b/research/problems/sqrt2-minpoly-oq-02/literature/README.md
@@ -1,0 +1,24 @@
+# Literature for sqrt2-minpoly-oq-02
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+- `sqrt2-minpoly`: Direct predecessor — proves minpoly ℚ √2 = X² - 2. Identical strategy.
+- `sqrt2-irrational`: Irrationality certificate; degree > 1 minimal polynomial implies irrationality.
+- `cube-root-2-irrational`: Related proof that ∛2 is irrational (minimal poly X³ - 2).
+
+## Relevant Mathlib Modules
+
+- `Mathlib.RingTheory.Eisenstein.Basic` — `Polynomial.irreducible_of_eisenstein_criterion`
+- `Mathlib.FieldTheory.Minpoly.Basic` — `minpoly.eq_of_irreducible_of_monic`
+- `Mathlib.Analysis.SpecialFunctions.Pow.Real` — `Real.rpow` for n^(1/k)
+- `Mathlib.RingTheory.RootsOfUnity.Basic` — for the root witness evaluation
+
+## External References
+
+- Lang, *Algebra* §V.4: Eisenstein irreducibility criterion and pure extensions
+- Stewart, *Galois Theory* Ch. 3: Minimal polynomials of radicals

--- a/research/problems/sqrt2-minpoly-oq-02/selection-report.md
+++ b/research/problems/sqrt2-minpoly-oq-02/selection-report.md
@@ -1,0 +1,85 @@
+# Problem Selection Report
+
+**Date**: 2026-04-23
+**Mode**: SELECT
+**Pool Status**: 27 available, 559 in-progress, 1406 completed
+
+## Selected Problem
+
+- **ID**: sqrt2-minpoly-oq-02
+- **Name**: Minimal Polynomial of k-th Roots: minpoly ℚ (n^(1/k)) = Xᵏ - n via Eisenstein
+- **Tier**: B
+- **Significance**: 7/10
+- **Tractability**: 8/10
+- **Knowledge Score**: 0 (EMPTY)
+- **Composite Score**: 87
+- **Status**: available
+
+## Selection Rationale
+
+1. **Highest composite score among unselected problems** (87): tractability 8 drives the
+   ranking. The proof strategy is known — Eisenstein criterion + `minpoly.eq_of_irreducible_of_monic`
+   — and Mathlib has all required ingredients. This problem can realistically be closed.
+
+2. **EMPTY knowledge tier**: No research has been done yet, making any progress high-value.
+   The scratch space is clean.
+
+3. **Direct continuation of gallery work**: `sqrt2-minpoly` (verified) proves the k=2, n=2
+   case. This generalizes to all (n, k) satisfying the Eisenstein prime condition. The
+   sibling problem `sqrt2-minpoly-oq-01` handles the √n case (k=2 general); this handles
+   the k-th root case. Both are natural extensions — not shallow specializations.
+
+4. **Diversity**: Recent selections covered analysis (cauchy-schwarz), number theory/algorithms
+   (chinese-remainder-constructive), and graph theory (erdos-73). Algebraic number theory
+   is an appropriate new domain entry in the current cycle.
+
+## Rejection Summary
+
+- **Candidates considered**: 27 available (excluding 2 with active claims)
+- **Top 13 already have selection reports** from the April 23 batch — not re-selected
+- **`erdos-476-oq-05-wip-01`**: Skipped — active claim lock exists
+- **`lebesgue-measure-oq-06`**: Skipped — active claim + RICH knowledge (27 items, score −2932)
+- **`sophie-germain-oq-01`, `twin-primes-special-oq-01`, `weak-goldbach-oq-01`**: Open
+  conjectures with tractability 2 — not suitable for autonomous research
+- **`szemeredi-full-oq-01`** (sig=9, tract=4, score=49): High significance but low
+  tractability pulls it below `sqrt2-minpoly-oq-02`
+- **Confidence**: high — score gap between #1 (87) and #2 (67) is 20 points
+
+## Related Gallery Proofs
+
+- `sqrt2-minpoly`: Direct predecessor — minpoly ℚ √2 = X² - 2; same proof architecture
+- `cube-root-2-irrational`: Related irrationality result using degree argument
+- `sqrt2-irrational`: Companion proof using minimal polynomial degree
+
+## Suggested First Steps
+
+1. **OBSERVE**: Check `Mathlib.RingTheory.Eisenstein.Basic` for
+   `Polynomial.irreducible_of_eisenstein_criterion` — confirm it covers arbitrary degree k.
+   Read the existing `sqrt2-minpoly` Lean source to extract the template proof structure.
+
+2. **ORIENT**: Identify the gap: expressing `Real.rpow (n : ℝ) (1/k : ℝ)` so that Lean
+   can verify `aeval (n^(1/k)) (X^k - C n) = 0`. The `Real.rpow_natCast` lemma family
+   and `Real.rpow_mul` may bridge this. Check if `NNReal.rpow` is cleaner.
+
+3. **DECIDE**: Start with a concrete stepping stone — prove minpoly ℚ (∜2) = X⁴ - 2
+   (n=2, k=4) before generalizing. If `Real.rpow` is too cumbersome, consider using
+   `Polynomial.roots` over an algebraic closure, or work with `AdjoinRoot (X^k - C n)`.
+
+## Pool Summary After Selection
+
+| Status | Count |
+|--------|-------|
+| Available | 27 |
+| In Progress | 559 |
+| Completed | 1406 |
+| Surveyed | 0 |
+| Skipped | 0 |
+| Blocked | 1 |
+
+## Candidate Pool Health
+
+Pool is healthy and well above threshold.
+
+- **Pool depth**: adequate (27 available vs threshold 15)
+- **Recommendation**: Pool healthy — no replenishment needed
+- **Next refresh recommended**: when available drops below 15

--- a/research/problems/szemeredi-full-oq-02/knowledge.md
+++ b/research/problems/szemeredi-full-oq-02/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: szemeredi-full-oq-02
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/szemeredi-full-oq-02/literature/README.md
+++ b/research/problems/szemeredi-full-oq-02/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for szemeredi-full-oq-02
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/szemeredi-full-oq-02/problem.md
+++ b/research/problems/szemeredi-full-oq-02/problem.md
@@ -1,0 +1,164 @@
+# Problem: Szemerédi's Theorem — Uniform Sets Not Containing k-AP Are o(N) Dense
+
+**Slug**: szemeredi-full-oq-02
+**Created**: 2026-04-23T05:52:30+02:00
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\forall k \geq 1,\; \forall \varepsilon > 0,\; \exists N_0 : \forall N \geq N_0,\;
+\text{if } A \subseteq \{1, \ldots, N\} \text{ is } k\text{-AP-free, then } |A| \leq \varepsilon N
+$$
+
+Equivalently: any $k$-AP-free subset of $\{1, \ldots, N\}$ has density $o(N)$ (vanishing density).
+
+In Lean 4 (target sketch):
+```lean
+theorem szemeredi_density (k : ℕ) (hk : 1 ≤ k) :
+    ∀ ε > 0, ∃ N₀ : ℕ, ∀ N ≥ N₀, ∀ A : Finset ℕ,
+    (∀ a ∈ A, a ≤ N) →
+    IsAPFree (A : Set ℕ) k →
+    (A.card : ℝ) / N ≤ ε := by
+  sorry
+```
+
+### Plain Language
+
+Szemerédi's theorem says: any set of integers with positive upper density contains
+arbitrarily long arithmetic progressions. This formulation asks the contrapositive:
+if a set A ⊆ {1,...,N} has NO k-term arithmetic progression, then |A|/N → 0.
+
+In other words, k-AP-free sets are *sparse* — they can't occupy a positive fraction of
+any long initial segment of the integers.
+
+### Why This Matters
+
+This is the *quantitative* density statement of Szemerédi's theorem. The gallery proof
+`szemeredi-full` handles the *existence* direction (positive density ⟹ k-APs exist)
+with k≥4 axiomatized. This problem asks for the *density bound* formulation, which:
+
+1. Completes the logical picture for the gallery's Szemerédi orbit
+2. Connects to Gowers uniformity norms and quantitative bounds
+3. Links the combinatorial and ergodic-theoretic perspectives
+4. Is needed to make the `szemeredi-full-oq-01` Furstenberg approach computable
+
+## Known Results
+
+### What's Already Proven
+
+- **k=3 (Roth's theorem)**: `rothNumberNat` is in Mathlib; the `szemeredi-full` gallery
+  proof uses it via `Mathlib.Combinatorics.Additive.Corner.Roth`
+- **Szemerédi Regularity Lemma**: In Mathlib via `Mathlib.Combinatorics.SimpleGraph.Regularity.Lemma`
+- **Triangle/Corners theorem**: In Mathlib, used to prove Roth's theorem
+- **k=1,2**: Trivial (any set is 1-AP-free only if empty; 2-AP-free impossible for |A|≥2)
+- **The full theorem**: Proved by Szemerédi (1975), Furstenberg ergodic (1977), Gowers (2001)
+
+### What's Still Open in Lean
+
+- **k≥4 quantitative density bound**: Requires hypergraph regularity, NOT in Mathlib
+- The k≥4 case in `szemeredi-full` is axiomatized as `szemeredi_large_k`
+- Quantitative Gowers-norm approach not yet formalized
+
+### Our Goal
+
+Formalize the density statement for at least **k=3** (Roth) and see how far we can
+push towards **k=4** or general k. The k=3 case is tractable via Mathlib's existing
+Roth machinery. The general k case needs to either:
+1. Extract from the axiom in `szemeredi-full`, or
+2. Formalize partial density bounds that don't require full hypergraph regularity
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `szemeredi-full` | Core Szemerédi formalization; k≥4 axiomatized | Case analysis, Roth k=3 |
+| `szemeredi-regularity` | Regularity lemma (key tool for density bounds) | Graph regularity |
+| `szemeredi-counting` | Hypergraph counting lemma | Hypergraph regularity |
+| `szemeredi-theorem` | Alternative statement in the gallery | AP definition |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Roth-first (Tractable)**: Focus on k=3 density bound from Mathlib's `rothNumberNat`.
+   - Mathlib provides `rothNumberNat n` = max size of 3-AP-free subset of {0,...,n-1}
+   - The density bound is: `rothNumberNat n / n → 0` as `n → ∞`
+   - This should be extractable from Mathlib's Salem-Spencer API
+   - Why it might work: Mathlib already has the theorem, just needs wrapping
+   - Risk: API mismatch between our `IsAPFree` and Mathlib's `ThreeAPFree`/`AddSalemSpencer`
+
+2. **Axiom-derivation**: Derive density from `szemeredi-full`'s existing axiom.
+   - The `szemeredi-full` proof has `axiom szemeredi_large_k : ...`
+   - Could state density as a corollary of the existence theorem
+   - Why it might work: Logical equivalence is straightforward
+   - Risk: The axiom gives existence, not quantitative bounds
+
+3. **Furstenberg ergodic (Moonshot)**: Connect to `szemeredi-full-oq-01`'s approach
+   - Would require substantial ergodic theory infrastructure
+   - Why it might work: Furstenberg's proof is measure-theoretic, potentially more formalization-friendly
+   - Risk: Very high — ergodic theory not well-developed in Lean 4
+
+### Key Difficulties
+
+- **API surface mismatch**: Our `IsAPFree` vs Mathlib's `AddSalemSpencer`/`ThreeAPFree`
+- **Quantitative vs. qualitative**: Mathlib may only have existence, not density bounds
+- **Density formulation**: Need ε-N formulation or filter/tendsto for the o(N) statement
+- **k≥4 gap**: No hypergraph regularity in Mathlib blocks general case
+
+### What Would a Proof Need?
+
+- Equivalence lemma: `IsAPFree S k ↔` Mathlib's k-AP-free predicate
+- For k=3: `∀ ε > 0, ∃ N₀, ∀ N ≥ N₀, rothNumberNat N ≤ ε * N`
+- For k≥4: Either extract from axiom or accept as axiomatized
+
+## Tractability Assessment
+
+**Difficulty**: High (k=3 sub-problem: Medium; general k: Moonshot)
+
+**Justification**:
+- The k=3 density bound is likely available from Mathlib's `rothNumberNat` asymptotics
+- The general k case requires hypergraph regularity — not in Mathlib, very hard
+- A meaningful contribution: prove the o(N) statement for k=3, state k≥4 as axiom
+- Similar problems solved: `szemeredi-full` (existence), Roth k=3 in Mathlib
+
+**Estimated Effort**:
+- Exploration (OBSERVE/ORIENT): 1-2 iterations to understand API
+- k=3 tractable path: 3-5 iterations if Mathlib API cooperates
+- General k: Likely needs to remain axiomatized
+
+## References
+
+### Papers
+- Szemerédi, "On sets of integers containing no k elements in AP" (1975)
+- Furstenberg, "Ergodic behavior of diagonal measures" (1977)
+- Gowers, "A new proof of Szemerédi's theorem" (2001)
+- Dillies & Mehta, "Formalising Szemerédi's Regularity Lemma in Lean 4" (ITP 2022)
+
+### Mathlib
+- `Mathlib.Combinatorics.Additive.AP.Three.Defs` — 3-AP definitions
+- `Mathlib.Combinatorics.Additive.Corner.Roth` — Roth's theorem (k=3)
+- `Mathlib.Combinatorics.Additive.SalemSpencer` — Salem-Spencer (AP-free sets)
+- `Mathlib.Combinatorics.SimpleGraph.Regularity.Lemma` — Regularity lemma
+- `Mathlib.Topology.Algebra.Order.LiminfLimsup` — Asymptotic bounds if needed
+
+## Metadata
+
+```yaml
+tags:
+  - combinatorics
+  - arithmetic-progressions
+  - szemeredi
+  - density
+  - regularity
+related_proofs:
+  - szemeredi-full
+  - szemeredi-regularity
+  - szemeredi-counting
+difficulty: high
+source: gallery-gap
+created: 2026-04-23T05:52:30+02:00
+```

--- a/research/problems/szemeredi-full-oq-02/state.md
+++ b/research/problems/szemeredi-full-oq-02/state.md
@@ -1,0 +1,33 @@
+# Current State
+
+**Phase**: OBSERVE
+**Since**: 2026-04-23T05:52:30.000Z
+**Iteration**: 1
+
+## Current Focus
+
+Explore Mathlib API for k-AP-free sets and density bounds, especially:
+1. `rothNumberNat` and its asymptotics (k=3 density bound)
+2. How `IsAPFree` in `SzemerediTheorem.lean` relates to Mathlib's `ThreeAPFree`/`AddSalemSpencer`
+3. Whether any o(N) quantitative statement is derivable from existing Mathlib results
+
+## Active Approach
+
+Roth-first: attempt to prove the k=3 density bound as a formalization of
+`rothNumberNat N / N → 0`, bridging to the `szemeredi-full-oq-02` density statement.
+
+## Blockers
+
+None identified yet.
+
+## Next Action
+
+Survey Mathlib's `Combinatorics.Additive` modules for density-bound lemmas.
+Check `SzemerediTheorem.lean` for the existing `IsAPFree` definition and its
+connection to `ThreeAPFree`.
+
+## Attempt Counts
+
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0


### PR DESCRIPTION
## Summary

- Selects `szemeredi-full-oq-02` using the composite ranking algorithm (EMPTY knowledge tier, Score: 38)
- Initializes research workspace with full problem statement and tractability assessment
- Pool status: 27 available (above 15 threshold), 558 in-progress, 1407 completed

## Problem

**Szemerédi's Theorem — Uniform Sets Not Containing k-AP Are o(N) Dense**

The density formulation of Szemerédi's theorem: any k-AP-free subset of {1,...,N}
has vanishing density |A|/N → 0.

### Selection Rationale

- **Composite score**: 38 (EMPTY tier × (-1000) + tractability×10 + significance = 0 + 30 + 8)
- **Highest-scored uninitiated problem** in the available pool
- **k=3 tractable path**: Mathlib's `rothNumberNat` already provides the Roth theorem machinery
- **Domain diversity**: Szemerédi domain not recently selected individually
- **Quality gate**: Passes — distinct from `szemeredi-full-oq-01` (ergodic approach), not a shallow duplicate

### Candidates Considered: 27 available
Rejected open conjectures (twin primes, Goldbach, Sophie Germain) — tractability 2, no Lean path
Selected over WEAK-knowledge problems (minkowski-oq-04, triangle-oq-03, etc.) — EMPTY tier wins

## Workspace

`research/problems/szemeredi-full-oq-02/` initialized with:
- Full problem statement (formal + plain language)
- Related gallery proofs (szemeredi-full, szemeredi-regularity, szemeredi-counting)
- Two concrete approaches (Roth-first tractable, axiom-derivation)
- Tractability assessment: k=3 Medium, general k Moonshot
- Mathlib dependencies mapped (rothNumberNat, SalemSpencer, Corner.Roth)