### PR TITLE
Fix: hilbert-15-oq-02 status formalized→axiomatized (True-stub assumptions)

### DIFF
--- a/src/data/proofs/hilbert-15-oq-02/meta.json
+++ b/src/data/proofs/hilbert-15-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius Research",
     "date": "2026",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Hilbert15OQ02.lean",
     "tags": [
       "algebraic-geometry",
@@ -16,9 +16,9 @@
       "schubert-calculus",
       "research"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 3,
     "lineCount": 506,
     "assumptions": "Three complexity-theoretic theorems (lr_saturation_theorem, lr_positivity_in_P, lr_counting_sharp_P_complete) prove `True` as explicit placeholders — the complexity theory formalism is not available in Lean/Mathlib. The 2-row LR coefficient computation (lrCoeff2) and full Gr(2,4) multiplication table are fully verified via native_decide.",
     "dateAdded": "2026-04-12",


### PR DESCRIPTION
## Fix

Correct `status`, `badge`, and `axiomCount` for `hilbert-15-oq-02` which regressed after PR #10569.

## Evidence

**Before**: `status="formalized"`, `badge="wip"`, `axiomCount=0`
**After**: `status="axiomatized"`, `badge="axiom"`, `axiomCount=3`

The Lean file (`Proofs/Hilbert15OQ02.lean`) explicitly states three complexity-theoretic theorems prove `True` as placeholders:
- `lr_saturation_theorem` — `True := trivial`
- `lr_positivity_in_P` — `∃ poly_time_alg, True`
- `lr_counting_sharp_P_complete` — `∃ reduction, True`

Per CLAUDE.md axiom integrity policy:
- `formalized` = has sorries remaining (inapplicable: 0 sorries)
- `axiomatized` = has axiom declarations OR assumption-encoded placeholders
- `axiomCount` must reflect ALL assumptions including True-stub theorems

The prior fix (PR #10569) changed `verified→formalized`. This fix completes the correction to `axiomatized` since there are 0 sorries, and updates `axiomCount` to 3 to reflect the three True-stub assumptions documented in the `assumptions` field.

This is a regression fix — commit 783f005c6d (Apr 14 law-of-sines merge conflict resolution) inadvertently recreated the meta.json from an old snapshot that predated #10569.

---
Automated fix by lean-mechanic agent.