### PR TITLE
Fix: migrate meta.leanFile to top-level leanFile for 4 gallery proofs

### DIFF
--- a/src/data/proofs/inverse-galois-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-oq-01/meta.json
@@ -31,22 +31,7 @@
       "Group theory (symmetric groups, alternating groups, solvability, simplicity)",
       "Field extensions (finrank, tower law)"
     ],
-    "assumptions": "1 axiom total (0 in main file, 1 transitive via InverseGaloisA5.lean: three_dvd_gal_card \u2014 Dedekind's theorem that 3 divides the Galois group order). 1 sorry: the open Inverse Galois Conjecture (intentional). Census theorem sorry-free via imports. AbelRuffiniOQ04OQ01.lean and AbelRuffiniGaloisExtensions.lean are axiom-free. Commutator theorem [S5,S5]=A5 fully proved.",
-    "leanFile": {
-      "lineCount": 723,
-      "theoremCount": 46,
-      "lemmaCount": 0,
-      "defCount": 1,
-      "axiomCount": 1,
-      "sorryCount": 1,
-      "imports": [
-        "Mathlib",
-        "Proofs.AbelRuffiniGaloisExtensions",
-        "Proofs.InverseGaloisA5",
-        "Proofs.AbelRuffiniOQ04OQ01"
-      ],
-      "note": "Key results: sn_solvable_iff, an_solvable_iff, a5_simple, a5_commutator_eq_top, s5_commutator_eq_alternating ([S5,S5]=A5), finrank_over_fixed_field, finrank_fixed_field_over_base, cayley_card, nonsolvable_realized_orders (sorry-free census), inverse_galois_conjecture (open). Census of 18+ explicitly realized groups."
-    },
+    "assumptions": "1 axiom total (0 in main file, 1 transitive via InverseGaloisA5.lean: three_dvd_gal_card — Dedekind's theorem that 3 divides the Galois group order). 1 sorry: the open Inverse Galois Conjecture (intentional). Census theorem sorry-free via imports. AbelRuffiniOQ04OQ01.lean and AbelRuffiniGaloisExtensions.lean are axiom-free. Commutator theorem [S5,S5]=A5 fully proved.",
     "relatedProblems": [
       {
         "id": "inverse-galois",
@@ -57,17 +42,17 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "The Inverse Galois Problem \u2014 does every finite group appear as the Galois group of some extension of $\\mathbb{Q}$? \u2014 is one of the oldest and most important open questions in algebra. David Hilbert (1892) proved that all symmetric groups $S_n$ are Galois groups over $\\mathbb{Q}$ via his irreducibility theorem, establishing that the generic polynomial of degree $n$ has Galois group $S_n$. Emmy Noether (1918) proposed a strategy: if $G$ acts faithfully on a vector space $V$, is $k(V)^G$ purely transcendental over $k$? A positive answer (Noether's problem) would imply $G$ is a Galois group over $\\mathbb{Q}$, but Swan (1969) and Lenstra (1974) found counterexamples.\n\nIgor Shafarevich (1954) proved the deepest general result: every solvable group is a Galois group over $\\mathbb{Q}$. His proof uses class field theory and is highly non-constructive. For the non-solvable realm, progress has been case-by-case: Thompson (1984) proved the Monster group is realizable, and subsequent work by Malle, Matzat, and others has verified realizability for all but one of the 26 sporadic simple groups (the Mathieu group $M_{23}$ remains open as of 2024). All alternating groups $A_n$ are known to be realizable (Hilbert 1892 for $S_n$ implies $A_n$ by taking the discriminant).\n\nThis formalization explores the solvability frontier \u2014 the boundary at $n = 5$ where symmetric groups transition from solvable to non-solvable. It proves the complete characterization $S_n$ solvable $\\Leftrightarrow$ $n \\leq 4$, establishes that $A_5$ is simple, perfect, and not solvable, develops Galois-theoretic fixed field formulas, and states the full Inverse Galois Conjecture as an open problem.",
+    "historicalContext": "The Inverse Galois Problem — does every finite group appear as the Galois group of some extension of $\\mathbb{Q}$? — is one of the oldest and most important open questions in algebra. David Hilbert (1892) proved that all symmetric groups $S_n$ are Galois groups over $\\mathbb{Q}$ via his irreducibility theorem, establishing that the generic polynomial of degree $n$ has Galois group $S_n$. Emmy Noether (1918) proposed a strategy: if $G$ acts faithfully on a vector space $V$, is $k(V)^G$ purely transcendental over $k$? A positive answer (Noether's problem) would imply $G$ is a Galois group over $\\mathbb{Q}$, but Swan (1969) and Lenstra (1974) found counterexamples.\n\nIgor Shafarevich (1954) proved the deepest general result: every solvable group is a Galois group over $\\mathbb{Q}$. His proof uses class field theory and is highly non-constructive. For the non-solvable realm, progress has been case-by-case: Thompson (1984) proved the Monster group is realizable, and subsequent work by Malle, Matzat, and others has verified realizability for all but one of the 26 sporadic simple groups (the Mathieu group $M_{23}$ remains open as of 2024). All alternating groups $A_n$ are known to be realizable (Hilbert 1892 for $S_n$ implies $A_n$ by taking the discriminant).\n\nThis formalization explores the solvability frontier — the boundary at $n = 5$ where symmetric groups transition from solvable to non-solvable. It proves the complete characterization $S_n$ solvable $\\Leftrightarrow$ $n \\leq 4$, establishes that $A_5$ is simple, perfect, and not solvable, develops Galois-theoretic fixed field formulas, and states the full Inverse Galois Conjecture as an open problem.",
     "problemStatement": "**The Inverse Galois Problem**: For every finite group $G$, does there exist a Galois extension $K/\\mathbb{Q}$ such that $\\text{Gal}(K/\\mathbb{Q}) \\cong G$?\n\nThis file addresses the structural question: which groups are solvable (hence covered by Shafarevich's theorem) and which require explicit polynomial constructions? The main result is the complete characterization:\n\n$$S_n \\text{ is solvable} \\iff n \\leq 4$$",
     "text": "An 11-part, 723-line formalization exploring the non-solvable frontier of the Inverse Galois Problem, with 46 declarations and 0 axioms. Part I proves the solvability divide: $S_1$ through $S_4$ are solvable (via `inferInstance` from `AbelRuffiniGaloisExtensions`), while $S_n$ for $n \\geq 5$ is not (from Mathlib's `Equiv.Perm.not_solvable`). Part II computes cardinalities ($|S_5| = 120$, $|A_5| = 60$). Part III is the mathematical core: $A_5$ is simple (Mathlib), not solvable (by the short exact sequence $1 \\to A_5 \\to S_5 \\to C_2 \\to 1$), not abelian (from non-solvability), and perfect ($[A_5, A_5] = A_5$ by simplicity + non-commutativity). Part VI develops the Galois-theoretic fixed field machinery: $[K:K^H] = |H|$ and $[K^H:F] = [G:H]$. Part X proves the synthesis: `sn_solvable_iff` ($S_n$ solvable $\\Leftrightarrow$ $n \\leq 4$) via `interval_cases`. Part XI gives Cayley's embedding theorem. The file includes a census of 18+ explicitly realized groups across the formalization and states the open Inverse Galois Conjecture.",
-    "proofStrategy": "The development follows a systematic progression:\n\n1. **SOLVABILITY EXAMPLES** (Part I): Demonstrate $S_1, S_2, S_3, S_4$ are solvable via `inferInstance`, pulling from composition series proved in `AbelRuffiniGaloisExtensions.lean`. Then show $S_5, S_6, S_7$ are not solvable via Mathlib's `Equiv.Perm.not_solvable` with a Cardinal bridge.\n\n2. **CARDINALITIES** (Part II): Compute $|S_n| = n!$ and $|A_5| = 60$ explicitly. These numerical facts are needed for the structural analysis.\n\n3. **A\u2085 ANALYSIS** (Part III): The mathematical heart. Prove $A_5$ is simple (Mathlib), then derive three consequences: (a) $A_5$ is not solvable (if it were, $S_5$ would be solvable via the short exact sequence); (b) $A_5$ is not abelian (abelian implies solvable); (c) $A_5$ is perfect (commutator subgroup is normal, hence $\\{e\\}$ or $A_5$ by simplicity; if $\\{e\\}$, then $A_5$ abelian \u2014 contradiction).\n\n4. **GALOIS CORRESPONDENCE** (Part VI): Develop fixed field degree formulas from Mathlib's fundamental theorem: $[K:K^H] = |H|$ and $[K^H:F] = [G:H]$ for any subgroup $H \\leq \\text{Gal}(K/F)$.\n\n5. **SYNTHESIS** (Part X): Combine all parts into `sn_solvable_iff`: the forward direction uses `sn_not_solvable_of_ge_five`; the backward direction uses `interval_cases n` with all five cases ($n = 0, 1, 2, 3, 4$) discharged by `infer_instance`.",
+    "proofStrategy": "The development follows a systematic progression:\n\n1. **SOLVABILITY EXAMPLES** (Part I): Demonstrate $S_1, S_2, S_3, S_4$ are solvable via `inferInstance`, pulling from composition series proved in `AbelRuffiniGaloisExtensions.lean`. Then show $S_5, S_6, S_7$ are not solvable via Mathlib's `Equiv.Perm.not_solvable` with a Cardinal bridge.\n\n2. **CARDINALITIES** (Part II): Compute $|S_n| = n!$ and $|A_5| = 60$ explicitly. These numerical facts are needed for the structural analysis.\n\n3. **A₅ ANALYSIS** (Part III): The mathematical heart. Prove $A_5$ is simple (Mathlib), then derive three consequences: (a) $A_5$ is not solvable (if it were, $S_5$ would be solvable via the short exact sequence); (b) $A_5$ is not abelian (abelian implies solvable); (c) $A_5$ is perfect (commutator subgroup is normal, hence $\\{e\\}$ or $A_5$ by simplicity; if $\\{e\\}$, then $A_5$ abelian — contradiction).\n\n4. **GALOIS CORRESPONDENCE** (Part VI): Develop fixed field degree formulas from Mathlib's fundamental theorem: $[K:K^H] = |H|$ and $[K^H:F] = [G:H]$ for any subgroup $H \\leq \\text{Gal}(K/F)$.\n\n5. **SYNTHESIS** (Part X): Combine all parts into `sn_solvable_iff`: the forward direction uses `sn_not_solvable_of_ge_five`; the backward direction uses `interval_cases n` with all five cases ($n = 0, 1, 2, 3, 4$) discharged by `infer_instance`.",
     "keyInsights": [
       "**The solvability divide at $n = 5$**: For $n \\leq 4$, $S_n$ is solvable (covered by Shafarevich's theorem). For $n \\geq 5$, $S_n$ is not solvable, requiring explicit polynomial constructions to realize these groups as Galois groups.",
-      "**$A_5$ is the minimal obstruction**: $|A_5| = 60$ is the smallest non-abelian simple group. Every non-solvable group contains a copy of $A_5$ as a composition factor (by Jordan-H\u00f6lder), making $A_5$ the universal obstruction to solvability.",
-      "**$A_5$ is perfect**: The proof that $[A_5, A_5] = A_5$ chains through simplicity \u2192 commutator is $\\{e\\}$ or $A_5$ \u2192 if $\\{e\\}$ then abelian \u2192 abelian implies solvable \u2192 contradiction. This 25-line argument is the deepest original proof in the file.",
+      "**$A_5$ is the minimal obstruction**: $|A_5| = 60$ is the smallest non-abelian simple group. Every non-solvable group contains a copy of $A_5$ as a composition factor (by Jordan-Hölder), making $A_5$ the universal obstruction to solvability.",
+      "**$A_5$ is perfect**: The proof that $[A_5, A_5] = A_5$ chains through simplicity → commutator is $\\{e\\}$ or $A_5$ → if $\\{e\\}$ then abelian → abelian implies solvable → contradiction. This 25-line argument is the deepest original proof in the file.",
       "**Fixed field degree formulas encode the Galois correspondence**: $[K:K^H] = |H|$ and $[K^H:F] = [G:H]$ are the quantitative content of the fundamental theorem of Galois theory. They connect subgroup structure to field extension degrees, enabling the quotient realizability argument.",
       "**Cayley's theorem connects IGP to symmetric groups**: Every group of order $n$ embeds into $S_n$, so realizing all symmetric groups is a necessary (but not sufficient) condition for IGP. The quotient argument in Part VI shows that realizing $G$ yields all quotients $G/N$ as Galois groups.",
-      "**The census reveals the non-solvable frontier**: 18+ groups are explicitly realized across the formalization, with $A_5$ (order 60) and $S_5$ (order 120) as the only non-solvable cases. The next targets \u2014 $\\text{PSL}(2,7)$ (order 168), $A_6$ (order 360) \u2014 represent the advancing edge of formalized inverse Galois theory."
+      "**The census reveals the non-solvable frontier**: 18+ groups are explicitly realized across the formalization, with $A_5$ (order 60) and $S_5$ (order 120) as the only non-solvable cases. The next targets — $\\text{PSL}(2,7)$ (order 168), $A_6$ (order 360) — represent the advancing edge of formalized inverse Galois theory."
     ],
     "prerequisites": [
       "Galois theory (Galois groups, splitting fields, fixed fields)",
@@ -102,11 +87,11 @@
     },
     {
       "id": "a5-simplicity",
-      "title": "Part III: A\u2085 Simplicity \u2014 The Core Obstruction",
+      "title": "Part III: A₅ Simplicity — The Core Obstruction",
       "startLine": 126,
       "endLine": 187,
-      "summary": "Four theorems forming the mathematical heart: `a5_simple` (Mathlib), `a5_not_solvable` (if $A_5$ solvable then $S_5$ solvable via the short exact sequence \u2014 contradiction), `a5_not_commutative` (commutative implies solvable \u2014 contradiction), and `a5_commutator_eq_top` ($[A_5, A_5] = A_5$ by simplicity: the commutator is normal, hence $\\{e\\}$ or $A_5$; if $\\{e\\}$ then $A_5$ abelian \u2014 contradiction).",
-      "mathContext": "The chain of implications: $A_5$ simple \u2192 $A_5$ has no proper normal subgroups \u2192 commutator $[A_5, A_5]$ is $\\{e\\}$ or $A_5$ \u2192 if $\\{e\\}$ then abelian \u2192 abelian implies solvable \u2192 contradicts $A_5$ not solvable \u2192 therefore $[A_5, A_5] = A_5$ (perfect). This is the structural reason the derived series of $S_5$ stalls: $D^1(S_5) = A_5$ and $D^k(S_5) = [A_5, A_5] = A_5$ for all $k \\geq 1$."
+      "summary": "Four theorems forming the mathematical heart: `a5_simple` (Mathlib), `a5_not_solvable` (if $A_5$ solvable then $S_5$ solvable via the short exact sequence — contradiction), `a5_not_commutative` (commutative implies solvable — contradiction), and `a5_commutator_eq_top` ($[A_5, A_5] = A_5$ by simplicity: the commutator is normal, hence $\\{e\\}$ or $A_5$; if $\\{e\\}$ then $A_5$ abelian — contradiction).",
+      "mathContext": "The chain of implications: $A_5$ simple → $A_5$ has no proper normal subgroups → commutator $[A_5, A_5]$ is $\\{e\\}$ or $A_5$ → if $\\{e\\}$ then abelian → abelian implies solvable → contradicts $A_5$ not solvable → therefore $[A_5, A_5] = A_5$ (perfect). This is the structural reason the derived series of $S_5$ stalls: $D^1(S_5) = A_5$ and $D^k(S_5) = [A_5, A_5] = A_5$ for all $k \\geq 1$."
     },
     {
       "id": "alternating-characterization",
@@ -121,7 +106,7 @@
       "title": "Part V: Non-Solvable Realm Analysis",
       "startLine": 204,
       "endLine": 239,
-      "summary": "Commentary partitioning all finite groups into the solvable realm (covered by Shafarevich: cyclic, abelian, dihedral, $p$-groups, $S_1$\u2013$S_4$, all groups of order $< 60$) and the non-solvable realm (requiring explicit constructions: $A_5$, $S_5$, $\\text{PSL}(2,7)$, etc.). Proves `trivial_realizable`: the trivial group is realized by $\\mathbb{Q}/\\mathbb{Q}$.",
+      "summary": "Commentary partitioning all finite groups into the solvable realm (covered by Shafarevich: cyclic, abelian, dihedral, $p$-groups, $S_1$–$S_4$, all groups of order $< 60$) and the non-solvable realm (requiring explicit constructions: $A_5$, $S_5$, $\\text{PSL}(2,7)$, etc.). Proves `trivial_realizable`: the trivial group is realized by $\\mathbb{Q}/\\mathbb{Q}$.",
       "mathContext": "Shafarevich's theorem (1954): every solvable group $G$ is isomorphic to $\\text{Gal}(K/\\mathbb{Q})$ for some Galois extension $K$. This covers all groups of order $< 60$ (since the smallest non-solvable group is $A_5$ with $|A_5| = 60$). The Burnside $p^aq^b$ theorem further implies all groups of order $p^aq^b$ (two prime factors) are solvable."
     },
     {
@@ -153,7 +138,7 @@
       "title": "Part IX: The Inverse Galois Conjecture",
       "startLine": 380,
       "endLine": 402,
-      "summary": "Formal statement of the open Inverse Galois Conjecture: for every finite group $G$, there exists a Galois extension $K/\\mathbb{Q}$ with $\\text{Gal}(K/\\mathbb{Q}) \\cong G$. The `sorry` is intentional \u2014 no general proof is known. Commentary notes known cases: all solvable groups (Shafarevich), all symmetric and alternating groups (Hilbert), 25 of 26 sporadic simple groups.",
+      "summary": "Formal statement of the open Inverse Galois Conjecture: for every finite group $G$, there exists a Galois extension $K/\\mathbb{Q}$ with $\\text{Gal}(K/\\mathbb{Q}) \\cong G$. The `sorry` is intentional — no general proof is known. Commentary notes known cases: all solvable groups (Shafarevich), all symmetric and alternating groups (Hilbert), 25 of 26 sporadic simple groups.",
       "mathContext": "The Inverse Galois Conjecture is Problem 12.10 in the Open Problem Garden and appears in multiple problem lists. The strongest evidence is that all simple groups except possibly $M_{23}$ are known to be realizable. Thompson's 1984 paper proving the Monster group $M$ ($|M| \\approx 8 \\times 10^{53}$) is realizable over $\\mathbb{Q}$ is one of the most remarkable results in the area."
     },
     {
@@ -162,7 +147,7 @@
       "startLine": 404,
       "endLine": 420,
       "summary": "The synthesis theorem `sn_solvable_iff`: $S_n$ is solvable if and only if $n \\leq 4$. Forward direction: if $S_n$ solvable and $n > 4$, then $5 \\leq n$, contradicting `sn_not_solvable_of_ge_five`. Backward direction: `interval_cases n` produces 5 cases ($n = 0, 1, 2, 3, 4$), each solved by `infer_instance`.",
-      "mathContext": "$S_n$ solvable $\\Leftrightarrow$ $n \\leq 4$. This is the complete answer to 'which symmetric groups are solvable?' \u2014 the question that drives both Abel-Ruffini (impossibility of radical solutions) and the Inverse Galois Problem (which groups require explicit constructions beyond Shafarevich)."
+      "mathContext": "$S_n$ solvable $\\Leftrightarrow$ $n \\leq 4$. This is the complete answer to 'which symmetric groups are solvable?' — the question that drives both Abel-Ruffini (impossibility of radical solutions) and the Inverse Galois Problem (which groups require explicit constructions beyond Shafarevich)."
     },
     {
       "id": "embedding-and-verification",
@@ -190,12 +175,12 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization maps the solvability frontier of the Inverse Galois Problem in 723 lines with 46 declarations, 0 axioms, and 1 sorry (intentional: the open Inverse Galois Conjecture). The central result `sn_solvable_iff` ($S_n$ solvable $\\Leftrightarrow$ $n \\leq 4$) precisely delineates the boundary between groups covered by Shafarevich's theorem and those requiring explicit polynomial constructions. The deep structural analysis of $A_5$ \u2014 simple, not solvable, not abelian, and perfect \u2014 reveals why this boundary is sharp and irreversible.",
-    "implications": "**Connection to Abel-Ruffini**: The solvability characterization is the group-theoretic half of Abel-Ruffini. Combined with the Galois bridge (`solvableByRad.isSolvable'`), it gives: a polynomial of degree $n$ with generic Galois group $S_n$ is solvable by radicals iff $n \\leq 4$ \u2014 explaining exactly why the quadratic, cubic, and quartic formulas exist but the quintic formula does not.\n\n**Toward the full IGP**: The census shows 18+ groups formally realized over $\\mathbb{Q}$, with the non-solvable frontier at $A_5$ and $S_5$. Extending to $\\text{PSL}(2,7)$ (order 168), $A_6$ (order 360), and sporadic groups would advance the formalized frontier significantly.\n\n**Fixed field machinery**: The degree formulas $[K:K^H] = |H|$ and $[K^H:F] = [G:H]$ provide reusable infrastructure for future Galois-theoretic formalizations \u2014 any result needing the fundamental theorem of Galois theory can build on these.",
+    "summary": "This formalization maps the solvability frontier of the Inverse Galois Problem in 723 lines with 46 declarations, 0 axioms, and 1 sorry (intentional: the open Inverse Galois Conjecture). The central result `sn_solvable_iff` ($S_n$ solvable $\\Leftrightarrow$ $n \\leq 4$) precisely delineates the boundary between groups covered by Shafarevich's theorem and those requiring explicit polynomial constructions. The deep structural analysis of $A_5$ — simple, not solvable, not abelian, and perfect — reveals why this boundary is sharp and irreversible.",
+    "implications": "**Connection to Abel-Ruffini**: The solvability characterization is the group-theoretic half of Abel-Ruffini. Combined with the Galois bridge (`solvableByRad.isSolvable'`), it gives: a polynomial of degree $n$ with generic Galois group $S_n$ is solvable by radicals iff $n \\leq 4$ — explaining exactly why the quadratic, cubic, and quartic formulas exist but the quintic formula does not.\n\n**Toward the full IGP**: The census shows 18+ groups formally realized over $\\mathbb{Q}$, with the non-solvable frontier at $A_5$ and $S_5$. Extending to $\\text{PSL}(2,7)$ (order 168), $A_6$ (order 360), and sporadic groups would advance the formalized frontier significantly.\n\n**Fixed field machinery**: The degree formulas $[K:K^H] = |H|$ and $[K^H:F] = [G:H]$ provide reusable infrastructure for future Galois-theoretic formalizations — any result needing the fundamental theorem of Galois theory can build on these.",
     "openQuestions": [
       "Can $\\text{PSL}(2,7)$ (order 168, the second smallest non-abelian simple group) be formally realized as a Galois group over $\\mathbb{Q}$? The standard approach uses the polynomial $x^7 - 7x + 3$, which has Galois group $\\text{PSL}(2,7)$.",
       "Can the quotient realizability theorem be applied constructively to derive new Galois groups from S5? (S5/A5 = C2 is trivial; more interesting quotients require larger realized groups.)",
-      "The Inverse Galois Conjecture is stated but marked `sorry` (intentionally \u2014 it is open). Can partial results (e.g., all alternating groups are realizable via Hilbert's irreducibility theorem) be formalized as intermediate steps?",
+      "The Inverse Galois Conjecture is stated but marked `sorry` (intentionally — it is open). Can partial results (e.g., all alternating groups are realizable via Hilbert's irreducibility theorem) be formalized as intermediate steps?",
       "Can the solvability characterization be generalized to alternating groups: $A_n$ solvable $\\Leftrightarrow$ $n \\leq 4$? The forward direction (simplicity of $A_n$ for $n \\geq 5$ implies non-solvability) follows from Mathlib."
     ]
   },
@@ -223,7 +208,7 @@
     {
       "targetId": "sylow-theorems",
       "relationship": "foundational",
-      "description": "Sylow theorems provide structural constraints on finite groups that complement the solvability analysis \u2014 for instance, the Sylow subgroups of $A_5$ (of orders 4, 3, and 5) help establish that $A_5$ has no normal subgroups of intermediate order"
+      "description": "Sylow theorems provide structural constraints on finite groups that complement the solvability analysis — for instance, the Sylow subgroups of $A_5$ (of orders 4, 3, and 5) help establish that $A_5$ has no normal subgroups of intermediate order"
     },
     {
       "targetId": "lagrange-theorem",
@@ -233,12 +218,12 @@
     {
       "targetId": "solution-of-cubic",
       "relationship": "complementary",
-      "description": "The cubic formula exists precisely because $S_3$ is solvable \u2014 the composition series $S_3 \\triangleright A_3 \\triangleright \\{e\\}$ with abelian quotients corresponds to the radical extraction steps in Cardano's formula. This file's Part I confirms $S_3$ solvable via `inferInstance`"
+      "description": "The cubic formula exists precisely because $S_3$ is solvable — the composition series $S_3 \\triangleright A_3 \\triangleright \\{e\\}$ with abelian quotients corresponds to the radical extraction steps in Cardano's formula. This file's Part I confirms $S_3$ solvable via `inferInstance`"
     },
     {
       "targetId": "general-quartic",
       "relationship": "complementary",
-      "description": "Ferrari's quartic formula exists because $S_4$ is solvable \u2014 confirmed by `inferInstance` in Part I. The composition series $S_4 \\triangleright A_4 \\triangleright V_4 \\triangleright C_2 \\triangleright \\{e\\}$ yields the nested radical structure of the quartic formula"
+      "description": "Ferrari's quartic formula exists because $S_4$ is solvable — confirmed by `inferInstance` in Part I. The composition series $S_4 \\triangleright A_4 \\triangleright V_4 \\triangleright C_2 \\triangleright \\{e\\}$ yields the nested radical structure of the quartic formula"
     },
     {
       "targetId": "kroneckers-jugendtraum",
@@ -254,16 +239,16 @@
   "references": [
     {
       "authors": "Hilbert, David",
-      "title": "\u00dcber die Irreducibilit\u00e4t ganzer rationaler Functionen mit ganzzahligen Coefficienten",
+      "title": "Über die Irreducibilität ganzer rationaler Functionen mit ganzzahligen Coefficienten",
       "year": "1892",
-      "venue": "Journal f\u00fcr die reine und angewandte Mathematik, vol. 110, pp. 104\u2013129",
-      "note": "Hilbert's irreducibility theorem: if f(t,x) is irreducible over Q(t), then f(a,x) is irreducible over Q for 'most' a in Q. Implies that all Sn and An are Galois groups over Q \u2014 the first major result on the Inverse Galois Problem"
+      "venue": "Journal für die reine und angewandte Mathematik, vol. 110, pp. 104–129",
+      "note": "Hilbert's irreducibility theorem: if f(t,x) is irreducible over Q(t), then f(a,x) is irreducible over Q for 'most' a in Q. Implies that all Sn and An are Galois groups over Q — the first major result on the Inverse Galois Problem"
     },
     {
       "authors": "Shafarevich, Igor R.",
       "title": "Construction of fields of algebraic numbers with given solvable Galois group",
       "year": "1954",
-      "venue": "Izvestiya Akademii Nauk SSSR, Ser. Mat., vol. 18, pp. 525\u2013578",
+      "venue": "Izvestiya Akademii Nauk SSSR, Ser. Mat., vol. 18, pp. 525–578",
       "note": "Proved that every solvable group is a Galois group over Q. This is the deepest general result on IGP and defines the boundary explored in this formalization: solvable groups are 'easy', non-solvable groups require individual constructions"
     },
     {
@@ -282,32 +267,47 @@
     },
     {
       "authors": "Thompson, John G.",
-      "title": "Some finite groups which appear as Gal(L/K), where K \u2286 Q(\u03bcn)",
+      "title": "Some finite groups which appear as Gal(L/K), where K ⊆ Q(μn)",
       "year": "1984",
-      "venue": "Journal of Algebra, vol. 89, pp. 437\u2013499",
-      "note": "Proved the Monster group (order ~8\u00d710^53) is realizable as a Galois group over Q \u2014 one of the most spectacular results in inverse Galois theory, achieved through the theory of rational points on modular curves"
+      "venue": "Journal of Algebra, vol. 89, pp. 437–499",
+      "note": "Proved the Monster group (order ~8×10^53) is realizable as a Galois group over Q — one of the most spectacular results in inverse Galois theory, achieved through the theory of rational points on modular curves"
     },
     {
       "authors": "Noether, Emmy",
       "title": "Gleichungen mit vorgeschriebener Gruppe",
       "year": "1918",
-      "venue": "Mathematische Annalen, vol. 78, pp. 221\u2013229",
-      "note": "Proposed that if G acts faithfully on a vector space V over k, then k(V)^G is purely transcendental over k \u2014 which would imply G is a Galois group over k. Swan (1969) found counterexamples, but Noether's problem remains a central strategy in inverse Galois theory"
+      "venue": "Mathematische Annalen, vol. 78, pp. 221–229",
+      "note": "Proposed that if G acts faithfully on a vector space V over k, then k(V)^G is purely transcendental over k — which would imply G is a Galois group over k. Swan (1969) found counterexamples, but Noether's problem remains a central strategy in inverse Galois theory"
     },
     {
       "authors": "Jordan, Camille",
-      "title": "Trait\u00e9 des substitutions et des \u00e9quations alg\u00e9briques",
+      "title": "Traité des substitutions et des équations algébriques",
       "year": "1870",
       "venue": "Gauthier-Villars, Paris",
-      "note": "First systematic treatment of permutation groups. Proved that the only normal subgroups of Sn for n >= 5 are {e}, An, and Sn itself \u2014 a result directly relevant to Part III's analysis of A5 and the quotient realizability argument"
+      "note": "First systematic treatment of permutation groups. Proved that the only normal subgroups of Sn for n >= 5 are {e}, An, and Sn itself — a result directly relevant to Part III's analysis of A5 and the quotient realizability argument"
     },
     {
       "authors": "Burnside, William",
-      "title": "On groups of order p^\u03b1 q^\u03b2",
+      "title": "On groups of order p^α q^β",
       "year": "1904",
-      "venue": "Proceedings of the London Mathematical Society, 2(1), pp. 388\u2013392",
-      "note": "Proved that every group of order p^a q^b is solvable. This implies that non-solvability requires at least 3 distinct prime factors: |A5| = 60 = 2\u00b2\u00b73\u00b75 is the smallest example, connecting to the solvability frontier explored in this file"
+      "venue": "Proceedings of the London Mathematical Society, 2(1), pp. 388–392",
+      "note": "Proved that every group of order p^a q^b is solvable. This implies that non-solvability requires at least 3 distinct prime factors: |A5| = 60 = 2²·3·5 is the smallest example, connecting to the solvability frontier explored in this file"
     }
   ],
-  "sorries": 1
+  "sorries": 1,
+  "leanFile": {
+    "path": "Proofs/InverseGaloisOQ01.lean",
+    "lineCount": 723,
+    "axiomCount": 1,
+    "sorries": 1,
+    "theoremCount": 46,
+    "definitionCount": 1,
+    "imports": [
+      "Mathlib",
+      "Proofs.AbelRuffiniGaloisExtensions",
+      "Proofs.InverseGaloisA5",
+      "Proofs.AbelRuffiniOQ04OQ01"
+    ],
+    "lemmaCount": 0
+  }
 }

--- a/src/data/proofs/inverse-galois-oq-02/meta.json
+++ b/src/data/proofs/inverse-galois-oq-02/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "inverse-galois-oq-02",
-  "title": "Inverse Galois Problem: The Mathieu Group M\u2082\u2083",
+  "title": "Inverse Galois Problem: The Mathieu Group M₂₃",
   "slug": "inverse-galois-oq-02",
-  "description": "Formalizes the structural properties of the Mathieu group M\u2082\u2083, the only sporadic simple group not yet known to be a Galois group over \u211a. Proves M\u2082\u2083 is perfect (commutator equals the whole group), non-solvable, and not covered by Shafarevich's theorem. Includes the prime factorization |M\u2082\u2083| = 2\u2077 \u00b7 3\u00b2 \u00b7 5 \u00b7 7 \u00b7 11 \u00b7 23, divisibility results for Sylow analysis, and the open realizability question.",
+  "description": "Formalizes the structural properties of the Mathieu group M₂₃, the only sporadic simple group not yet known to be a Galois group over ℚ. Proves M₂₃ is perfect (commutator equals the whole group), non-solvable, and not covered by Shafarevich's theorem. Includes the prime factorization |M₂₃| = 2⁷ · 3² · 5 · 7 · 11 · 23, divisibility results for Sylow analysis, and the open realizability question.",
   "meta": {
     "author": "Lean Genius Research",
     "date": "2026-03-30",
@@ -25,21 +25,7 @@
       "Group theory (simple groups, solvability, commutator subgroups, derived series)",
       "Finite group classification (sporadic groups, Mathieu groups)"
     ],
-    "assumptions": "3 axioms: M23 (existence of M\u2082\u2083 as subgroup of S\u2082\u2083), M23_card (|M\u2082\u2083| = 10200960), M23_isSimple (M\u2082\u2083 is simple). The 3 axioms are well-established mathematical facts, not conjectures. 6 sorries in this file.",
-    "leanFile": {
-      "lineCount": 388,
-      "theoremCount": 18,
-      "lemmaCount": 0,
-      "defCount": 0,
-      "axiomCount": 3,
-      "sorryCount": 6,
-      "imports": [
-        "Mathlib",
-        "Proofs.InverseGalois",
-        "Proofs.InverseGaloisOQ01"
-      ],
-      "note": "M\u2082\u2083 axiomatized as subgroup of Perm(Fin 23). Key results: order factorization (2\u2077\u00b73\u00b2\u00b75\u00b77\u00b711\u00b723), non-prime cardinality, prime divisibility results, perfectness, non-solvability, Shafarevich gap, S\u2082\u2083 index relation. 1 sorry is intentional (open problem). 5 sorries are Aristotle candidates for Mathlib API chains."
-    },
+    "assumptions": "3 axioms: M23 (existence of M₂₃ as subgroup of S₂₃), M23_card (|M₂₃| = 10200960), M23_isSimple (M₂₃ is simple). The 3 axioms are well-established mathematical facts, not conjectures. 6 sorries in this file.",
     "relatedProblems": [
       {
         "id": "inverse-galois",
@@ -54,13 +40,13 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "The Mathieu groups, discovered by \u00c9mile Mathieu in 1861 and 1873, were the first sporadic simple groups to be identified. There are five: $M_{11}$, $M_{12}$, $M_{22}$, $M_{23}$, and $M_{24}$, with orders ranging from 7,920 to 244,823,040. They arise as automorphism groups of Steiner systems and are deeply connected to coding theory through the Golay codes.\n\nIn the context of the Inverse Galois Problem, the sporadic simple groups represent the most challenging frontier. Thompson (1984) established realizability for many sporadics, including the Monster group. Matzat (1984, 1987) handled most Mathieu groups: $M_{11}$, $M_{12}$, and $M_{24}$ were shown realizable in 1984, and $M_{22}$ followed in 1987. However, $M_{23}$ has resisted all known methods.\n\nThe difficulty is structural: Thompson's rigidity criterion\u2014the main tool for sporadic realizability\u2014requires finding conjugacy class triples $(C_1, C_2, C_3)$ that are simultaneously compatible (product $= 1$), generating, rigid (unique solution up to conjugation), and rational (invariant under outer automorphisms). For $M_{23}$, with its 17 conjugacy classes and trivial outer automorphism group, no such triple exists.\n\nDettweiler and Reiter (1999) achieved a partial result: $M_{23}$ is a regular Galois group over $\\mathbb{Q}(t)$, the rational function field. This means $M_{23}$ occurs as a Galois group over a transcendental extension of $\\mathbb{Q}$, but specializing from $\\mathbb{Q}(t)$ to $\\mathbb{Q}$ requires additional number-theoretic arguments that remain incomplete.",
+    "historicalContext": "The Mathieu groups, discovered by Émile Mathieu in 1861 and 1873, were the first sporadic simple groups to be identified. There are five: $M_{11}$, $M_{12}$, $M_{22}$, $M_{23}$, and $M_{24}$, with orders ranging from 7,920 to 244,823,040. They arise as automorphism groups of Steiner systems and are deeply connected to coding theory through the Golay codes.\n\nIn the context of the Inverse Galois Problem, the sporadic simple groups represent the most challenging frontier. Thompson (1984) established realizability for many sporadics, including the Monster group. Matzat (1984, 1987) handled most Mathieu groups: $M_{11}$, $M_{12}$, and $M_{24}$ were shown realizable in 1984, and $M_{22}$ followed in 1987. However, $M_{23}$ has resisted all known methods.\n\nThe difficulty is structural: Thompson's rigidity criterion—the main tool for sporadic realizability—requires finding conjugacy class triples $(C_1, C_2, C_3)$ that are simultaneously compatible (product $= 1$), generating, rigid (unique solution up to conjugation), and rational (invariant under outer automorphisms). For $M_{23}$, with its 17 conjugacy classes and trivial outer automorphism group, no such triple exists.\n\nDettweiler and Reiter (1999) achieved a partial result: $M_{23}$ is a regular Galois group over $\\mathbb{Q}(t)$, the rational function field. This means $M_{23}$ occurs as a Galois group over a transcendental extension of $\\mathbb{Q}$, but specializing from $\\mathbb{Q}(t)$ to $\\mathbb{Q}$ requires additional number-theoretic arguments that remain incomplete.",
     "problemStatement": "**Is the Mathieu group $M_{23}$ realizable as a Galois group over $\\mathbb{Q}$?**\n\nEquivalently: does there exist a Galois extension $K/\\mathbb{Q}$ with $\\text{Gal}(K/\\mathbb{Q}) \\cong M_{23}$?\n\nThis is the **last sporadic simple group** whose realizability over $\\mathbb{Q}$ remains unknown. All other 25 of the 26 sporadic groups have been shown to be Galois groups over $\\mathbb{Q}$.",
-    "text": "A 388-line formalization in 9 parts exploring the Mathieu group $M_{23}$ and its position in the Inverse Galois Problem. Part I axiomatizes $M_{23}$ as a subgroup of $S_{23}$ with three axioms: existence, cardinality ($|M_{23}| = 10200960$), and simplicity. Part II develops order-theoretic properties: the prime factorization $|M_{23}| = 2^7 \\cdot 3^2 \\cdot 5 \\cdot 7 \\cdot 11 \\cdot 23$, non-primality of the order, and prime divisibility results for all 7 prime factors. Part III contains the core structural analysis: $M_{23}$ is not abelian (abelian simple groups have prime order, but 10200960 is composite), perfect ($[M_{23}, M_{23}] = M_{23}$ by simplicity), and not solvable (derived series stays constant). Part IV connects this to the broader program: since $M_{23}$ is not solvable, Shafarevich's theorem (all solvable groups are Galois over $\\mathbb{Q}$) does not apply. Part V states the open realizability question. Parts VI\u2013IX provide mathematical context: the rigidity obstruction (no rigid rational triples among 17 conjugacy classes), comparison with other Mathieu groups ($M_{11}, M_{12}, M_{22}, M_{24}$ are all realized), and Sylow subgroup existence.",
-    "proofStrategy": "The development follows a systematic structural analysis:\n\n1. **AXIOMATIZATION** (Part I): $M_{23}$ is introduced as a subgroup of $S_{23}$ with three axioms encoding well-established mathematical facts: existence, order 10200960, and simplicity. These are not conjectures\u2014they are classical results verified computationally and by multiple independent proofs.\n\n2. **ORDER ANALYSIS** (Part II): The prime factorization $2^7 \\cdot 3^2 \\cdot 5 \\cdot 7 \\cdot 11 \\cdot 23 = 10200960$ is verified by `norm_num`. Non-primality is proved by exhibiting the factor 2. Individual prime divisibility results support Sylow analysis.\n\n3. **STRUCTURAL CORE** (Parts III\u2013IV): The chain non-abelian $\\to$ perfect $\\to$ non-solvable is established:\n   - **Non-abelian**: Abelian simple groups have prime order (Lagrange + no proper subgroups), but $|M_{23}|$ is not prime.\n   - **Perfect**: The commutator $[M_{23}, M_{23}]$ is normal in $M_{23}$. By simplicity, it equals $\\bot$ or $\\top$. If $\\bot$, then $M_{23}$ is abelian\u2014contradiction. So $[M_{23}, M_{23}] = M_{23}$.\n   - **Non-solvable**: The derived series of a perfect group is constant at $\\top$. A solvable group's derived series reaches $\\bot$. Since $\\top \\neq \\bot$ (nontrivial), contradiction.\n\n4. **OPEN PROBLEM** (Part V): The realizability question is stated as a sorry\u2014marking it as genuinely unresolved, not as a gap in our formalization.\n\n5. **CONTEXT** (Parts VI\u2013IX): The rigidity obstruction explains WHY $M_{23}$ is hard: Thompson's method fails due to the absence of rigid rational triples among the 17 conjugacy classes.",
+    "text": "A 388-line formalization in 9 parts exploring the Mathieu group $M_{23}$ and its position in the Inverse Galois Problem. Part I axiomatizes $M_{23}$ as a subgroup of $S_{23}$ with three axioms: existence, cardinality ($|M_{23}| = 10200960$), and simplicity. Part II develops order-theoretic properties: the prime factorization $|M_{23}| = 2^7 \\cdot 3^2 \\cdot 5 \\cdot 7 \\cdot 11 \\cdot 23$, non-primality of the order, and prime divisibility results for all 7 prime factors. Part III contains the core structural analysis: $M_{23}$ is not abelian (abelian simple groups have prime order, but 10200960 is composite), perfect ($[M_{23}, M_{23}] = M_{23}$ by simplicity), and not solvable (derived series stays constant). Part IV connects this to the broader program: since $M_{23}$ is not solvable, Shafarevich's theorem (all solvable groups are Galois over $\\mathbb{Q}$) does not apply. Part V states the open realizability question. Parts VI–IX provide mathematical context: the rigidity obstruction (no rigid rational triples among 17 conjugacy classes), comparison with other Mathieu groups ($M_{11}, M_{12}, M_{22}, M_{24}$ are all realized), and Sylow subgroup existence.",
+    "proofStrategy": "The development follows a systematic structural analysis:\n\n1. **AXIOMATIZATION** (Part I): $M_{23}$ is introduced as a subgroup of $S_{23}$ with three axioms encoding well-established mathematical facts: existence, order 10200960, and simplicity. These are not conjectures—they are classical results verified computationally and by multiple independent proofs.\n\n2. **ORDER ANALYSIS** (Part II): The prime factorization $2^7 \\cdot 3^2 \\cdot 5 \\cdot 7 \\cdot 11 \\cdot 23 = 10200960$ is verified by `norm_num`. Non-primality is proved by exhibiting the factor 2. Individual prime divisibility results support Sylow analysis.\n\n3. **STRUCTURAL CORE** (Parts III–IV): The chain non-abelian $\\to$ perfect $\\to$ non-solvable is established:\n   - **Non-abelian**: Abelian simple groups have prime order (Lagrange + no proper subgroups), but $|M_{23}|$ is not prime.\n   - **Perfect**: The commutator $[M_{23}, M_{23}]$ is normal in $M_{23}$. By simplicity, it equals $\\bot$ or $\\top$. If $\\bot$, then $M_{23}$ is abelian—contradiction. So $[M_{23}, M_{23}] = M_{23}$.\n   - **Non-solvable**: The derived series of a perfect group is constant at $\\top$. A solvable group's derived series reaches $\\bot$. Since $\\top \\neq \\bot$ (nontrivial), contradiction.\n\n4. **OPEN PROBLEM** (Part V): The realizability question is stated as a sorry—marking it as genuinely unresolved, not as a gap in our formalization.\n\n5. **CONTEXT** (Parts VI–IX): The rigidity obstruction explains WHY $M_{23}$ is hard: Thompson's method fails due to the absence of rigid rational triples among the 17 conjugacy classes.",
     "keyInsights": [
       "**$M_{23}$ is the unique sporadic holdout**: Of the 26 sporadic simple groups in the classification of finite simple groups, 25 are known Galois groups over $\\mathbb{Q}$. $M_{23}$ is the sole exception, making it perhaps the most important specific open case in inverse Galois theory.",
-      "**The rigidity obstruction**: Thompson's rigidity method\u2014the workhorse for sporadic realizability\u2014fails for $M_{23}$ because no triple of conjugacy classes satisfies all four conditions simultaneously (compatibility, generation, rigidity, rationality). This is not just a gap in current techniques; it's a structural property of $M_{23}$'s conjugacy class geometry.",
+      "**The rigidity obstruction**: Thompson's rigidity method—the workhorse for sporadic realizability—fails for $M_{23}$ because no triple of conjugacy classes satisfies all four conditions simultaneously (compatibility, generation, rigidity, rationality). This is not just a gap in current techniques; it's a structural property of $M_{23}$'s conjugacy class geometry.",
       "**Asymmetry among Mathieu groups**: $M_{24}$ (the most complex Mathieu group, order 244,823,040) IS realizable over $\\mathbb{Q}$, but $M_{23}$ (its point stabilizer, order 10,200,960) is not known to be. This asymmetry reflects subtle differences in conjugacy class structures, not group complexity.",
       "**The non-solvable structural chain**: $M_{23}$ simple $\\to$ non-abelian (non-prime order) $\\to$ perfect ($[G,G] = G$) $\\to$ non-solvable. This chain places $M_{23}$ firmly beyond Shafarevich's theorem, requiring explicit construction methods.",
       "**Connection to coding theory**: $M_{23}$ is the automorphism group of the Steiner system $S(4,7,23)$, which is related to the binary Golay code of length 23. This connection to information theory suggests unconventional approaches to the realizability problem.",
@@ -75,77 +61,77 @@
   "sections": [
     {
       "id": "axiomatization",
-      "title": "Part I: Axiomatization of M\u2082\u2083",
+      "title": "Part I: Axiomatization of M₂₃",
       "startLine": 62,
       "endLine": 92,
-      "summary": "Three axioms defining M\u2082\u2083 as a subgroup of S\u2082\u2083 with specified cardinality and simplicity"
+      "summary": "Three axioms defining M₂₃ as a subgroup of S₂₃ with specified cardinality and simplicity"
     },
     {
       "id": "order-properties",
       "title": "Part II: Order-Theoretic Properties",
       "startLine": 94,
       "endLine": 146,
-      "summary": "Prime factorization |M\u2082\u2083| = 2\u2077\u00b73\u00b2\u00b75\u00b77\u00b711\u00b723, non-primality, and divisibility results"
+      "summary": "Prime factorization |M₂₃| = 2⁷·3²·5·7·11·23, non-primality, and divisibility results"
     },
     {
       "id": "non-solvability",
       "title": "Part III: Non-Solvability Analysis",
       "startLine": 148,
       "endLine": 219,
-      "summary": "The core structural result: M\u2082\u2083 is non-abelian, perfect, and not solvable"
+      "summary": "The core structural result: M₂₃ is non-abelian, perfect, and not solvable"
     },
     {
       "id": "shafarevich-gap",
       "title": "Part IV: Position in the Inverse Galois Program",
       "startLine": 221,
       "endLine": 245,
-      "summary": "Shafarevich's theorem does not cover M\u2082\u2083; any realization requires non-solvable methods"
+      "summary": "Shafarevich's theorem does not cover M₂₃; any realization requires non-solvable methods"
     },
     {
       "id": "open-question",
       "title": "Part V: The Open Question",
       "startLine": 247,
       "endLine": 270,
-      "summary": "Statement of the open realizability problem for M\u2082\u2083 over \u211a"
+      "summary": "Statement of the open realizability problem for M₂₃ over ℚ"
     },
     {
       "id": "rigidity-obstruction",
       "title": "Part VI: The Rigidity Obstruction",
       "startLine": 272,
       "endLine": 314,
-      "summary": "Why Thompson's rigidity criterion fails for M\u2082\u2083: no rigid rational triples"
+      "summary": "Why Thompson's rigidity criterion fails for M₂₃: no rigid rational triples"
     },
     {
       "id": "sporadic-comparison",
       "title": "Part VII: Comparison with Other Sporadic Groups",
       "startLine": 316,
       "endLine": 349,
-      "summary": "Status of all Mathieu groups for IGP and the M\u2082\u2083/M\u2082\u2084 asymmetry"
+      "summary": "Status of all Mathieu groups for IGP and the M₂₃/M₂₄ asymmetry"
     },
     {
       "id": "sylow-structure",
       "title": "Part VIII: Sylow Structure",
       "startLine": 351,
       "endLine": 362,
-      "summary": "Existence of Sylow subgroups for each prime dividing |M\u2082\u2083|"
+      "summary": "Existence of Sylow subgroups for each prime dividing |M₂₃|"
     },
     {
       "id": "broader-program",
       "title": "Part IX: Connection to the Broader Program",
       "startLine": 364,
       "endLine": 388,
-      "summary": "Impact of resolving M\u2082\u2083 realizability and possible approaches"
+      "summary": "Impact of resolving M₂₃ realizability and possible approaches"
     }
   ],
   "conclusion": {
-    "mainResult": "M\u2082\u2083 is axiomatized as a simple subgroup of S\u2082\u2083 with |M\u2082\u2083| = 10200960 = 2\u2077\u00b73\u00b2\u00b75\u00b77\u00b711\u00b723. We establish it is perfect and not solvable, placing it beyond the reach of Shafarevich's theorem. The realizability of M\u2082\u2083 as a Galois group over \u211a remains open \u2014 the last sporadic simple group with unknown status.",
+    "mainResult": "M₂₃ is axiomatized as a simple subgroup of S₂₃ with |M₂₃| = 10200960 = 2⁷·3²·5·7·11·23. We establish it is perfect and not solvable, placing it beyond the reach of Shafarevich's theorem. The realizability of M₂₃ as a Galois group over ℚ remains open — the last sporadic simple group with unknown status.",
     "openQuestions": [
-      "Is M\u2082\u2083 a Galois group over \u211a? (The central open question)",
-      "Can middle convolution specialization from \u211a(t) to \u211a be completed for M\u2082\u2083?",
-      "Does M\u2082\u2083's connection to the binary Golay code suggest coding-theoretic approaches to realizability?"
+      "Is M₂₃ a Galois group over ℚ? (The central open question)",
+      "Can middle convolution specialization from ℚ(t) to ℚ be completed for M₂₃?",
+      "Does M₂₃'s connection to the binary Golay code suggest coding-theoretic approaches to realizability?"
     ],
-    "summary": "M\u2082\u2083 is axiomatized as a simple subgroup of S\u2082\u2083 with |M\u2082\u2083| = 10200960 = 2\u2077\u00b73\u00b2\u00b75\u00b77\u00b711\u00b723. We establish it is perfect and not solvable, placing it beyond the reach of Shafarevich's theorem. The realizability of M\u2082\u2083 as a Galois group over \u211a remains open \u2014 the last sporadic simple group with unknown status.",
-    "implications": "Resolving M\u2082\u2083 realizability would complete the sporadic group chapter of the Inverse Galois Problem, demonstrating all 26 sporadic simple groups are Galois groups over \u211a."
+    "summary": "M₂₃ is axiomatized as a simple subgroup of S₂₃ with |M₂₃| = 10200960 = 2⁷·3²·5·7·11·23. We establish it is perfect and not solvable, placing it beyond the reach of Shafarevich's theorem. The realizability of M₂₃ as a Galois group over ℚ remains open — the last sporadic simple group with unknown status.",
+    "implications": "Resolving M₂₃ realizability would complete the sporadic group chapter of the Inverse Galois Problem, demonstrating all 26 sporadic simple groups are Galois groups over ℚ."
   },
   "crossReferences": [
     {
@@ -154,8 +140,22 @@
     },
     {
       "id": "inverse-galois-oq-01",
-      "relationship": "Sister entry proving the solvability divide (S_n solvable iff n \u2264 4) and A\u2085 analysis"
+      "relationship": "Sister entry proving the solvability divide (S_n solvable iff n ≤ 4) and A₅ analysis"
     }
   ],
-  "sorries": 6
+  "sorries": 6,
+  "leanFile": {
+    "path": "Proofs/InverseGaloisOQ02.lean",
+    "lineCount": 388,
+    "axiomCount": 3,
+    "sorries": 6,
+    "theoremCount": 18,
+    "definitionCount": 0,
+    "imports": [
+      "Mathlib",
+      "Proofs.InverseGalois",
+      "Proofs.InverseGaloisOQ01"
+    ],
+    "lemmaCount": 0
+  }
 }

--- a/src/data/proofs/inverse-galois/meta.json
+++ b/src/data/proofs/inverse-galois/meta.json
@@ -2,7 +2,7 @@
   "id": "inverse-galois",
   "title": "The Inverse Galois Problem",
   "slug": "inverse-galois",
-  "description": "A comprehensive formalization of the Inverse Galois Problem (1882 lines, 5 axioms). We prove explicit Galois group realizations for 23 finite groups including the first non-solvable case (A\u2085 via Gal(x\u2075-5x\u2074+10x\u00b3-10x\u00b2+25x-5) with Sylow-theoretic proof, Vandermonde discriminant analysis via \u2102 embedding and Sophie Germain identity), D\u2084 via X\u2074-2, F\u2082\u2080 via X\u2075-2, and a systematic census of all groups of order \u2264 8 via cyclotomic fields.",
+  "description": "A comprehensive formalization of the Inverse Galois Problem (1882 lines, 5 axioms). We prove explicit Galois group realizations for 23 finite groups including the first non-solvable case (A₅ via Gal(x⁵-5x⁴+10x³-10x²+25x-5) with Sylow-theoretic proof, Vandermonde discriminant analysis via ℂ embedding and Sophie Germain identity), D₄ via X⁴-2, F₂₀ via X⁵-2, and a systematic census of all groups of order ≤ 8 via cyclotomic fields.",
   "meta": {
     "author": "David Hilbert (1892), Igor Shafarevich (1954), various",
     "date": "1892",
@@ -35,30 +35,6 @@
       "Algebraic number theory (Eisenstein criterion, Dedekind's theorem)"
     ],
     "assumptions": "5 axioms: inverse_galois_problem_open_conjecture (OPEN PROBLEM), abelian_realizable (Kronecker-Weber), shafarevich_theorem (solvable groups realizable), symmetric_group_realizable (Hilbert irreducibility), three_dvd_gal_card (Dedekind's theorem, in InverseGaloisA5.lean). 0 sorries.",
-    "leanFile": {
-      "lineCount": 1882,
-      "theoremCount": 105,
-      "lemmaCount": 1,
-      "defCount": 1,
-      "axiomCount": 5,
-      "sorryCount": 0,
-      "imports": [
-        "Mathlib.NumberTheory.Cyclotomic.Basic",
-        "Mathlib.NumberTheory.Cyclotomic.Gal",
-        "Mathlib.NumberTheory.Cyclotomic.PrimitiveRoots",
-        "Mathlib.FieldTheory.AbelRuffini",
-        "Mathlib.GroupTheory.Solvable",
-        "Mathlib.GroupTheory.SpecificGroups.Alternating",
-        "Mathlib.FieldTheory.Galois.Basic",
-        "Mathlib.GroupTheory.Perm.Sign",
-        "Mathlib.FieldTheory.SplittingField.Construction",
-        "Mathlib.RingTheory.Polynomial.Cyclotomic.Basic",
-        "Mathlib.RingTheory.Polynomial.Eisenstein.Criterion",
-        "Mathlib.RingTheory.Polynomial.GaussLemma",
-        "Mathlib.NumberTheory.LSeries.PrimesInAP"
-      ],
-      "note": "Total across 6 files (5879 lines, 313 thms, 5 axioms, 0 sorries): InverseGalois.lean (1882 lines, 106 thms, 4 axioms, 0 sorries), InverseGaloisA5.lean (2067 lines, 85 thms, 1 axiom, 0 sorries), InverseGaloisD4.lean (682 lines, 27 thms, 0 axioms, 0 sorries), InverseGaloisF20.lean (529 lines, 27 thms, 0 axioms, 0 sorries), AbelRuffiniGaloisExtensions.lean (534 lines, 59 thms, 0 sorries), AbelRuffini.lean (185 lines, 9 thms, 0 sorries). vandermondeProduct_sq_eq PROVED via \u2102 embedding + Sophie Germain identity. q_derivative_eq PROVED via ext + coefficient case analysis. disc_q_val sorry removed (proved as disc_q_val_proved via Vandermonde chain)."
-    },
     "mathlibDependencies": [
       {
         "theorem": "IsCyclotomicExtension.isGalois",
@@ -72,7 +48,7 @@
       },
       {
         "theorem": "galCyclotomicEquivUnitsZMod",
-        "description": "Gal(Q(\u03b6\u2099)/Q) \u2245 (ZMod n)\u02e3 when cyclotomic poly is irreducible",
+        "description": "Gal(Q(ζₙ)/Q) ≅ (ZMod n)ˣ when cyclotomic poly is irreducible",
         "module": "Mathlib.NumberTheory.Cyclotomic.Gal"
       },
       {
@@ -87,17 +63,17 @@
       },
       {
         "theorem": "IsPrimitive.Int.irreducible_iff_irreducible_map_cast",
-        "description": "Gauss lemma: \u2124-irreducibility transfers to \u211a for primitive polynomials",
+        "description": "Gauss lemma: ℤ-irreducibility transfers to ℚ for primitive polynomials",
         "module": "Mathlib.RingTheory.Polynomial.GaussLemma"
       },
       {
         "theorem": "Equiv.Perm.not_solvable",
-        "description": "S_n is not solvable for n \u2265 5",
+        "description": "S_n is not solvable for n ≥ 5",
         "module": "Mathlib.GroupTheory.SpecificGroups.Alternating"
       },
       {
         "theorem": "alternatingGroup.isSimpleGroup_five",
-        "description": "A\u2085 is a simple group",
+        "description": "A₅ is a simple group",
         "module": "Mathlib.GroupTheory.SpecificGroups.Alternating"
       },
       {
@@ -110,31 +86,31 @@
       "Formal Lean statement of the Inverse Galois Conjecture",
       "Cyclotomic Galois theory for explicit abelian realizations",
       "Cyclotomic irreducibility proved via Polynomial.cyclotomic.irreducible_rat",
-      "Gal(X\u00b3-2/\u211a) \u2245 S\u2083 proved from scratch (coprimality argument for [K:\u211a]=6)",
-      "A\u2085 realization: Gal(x\u2075-5x\u2074+10x\u00b3-10x\u00b2+25x-5) \u2245 A\u2085 with full isomorphism proof",
-      "Eisenstein irreducibility for q at p=5 with Gauss lemma transfer \u2124\u2192\u211a",
-      "no_subgroup_order_15: Sylow theory + native_decide (no order-5/order-3 commutation in S\u2085)",
-      "no_subgroup_order_30: A\u2085 simplicity + sign homomorphism kernel analysis",
-      "D\u2084 realization via X\u2074-2 (680 lines, 0 axioms, 0 sorries)",
-      "F\u2082\u2080 (Frobenius) realization via X\u2075-2 (529 lines, 0 axioms, 0 sorries)",
-      "Systematic census: 14/15 groups of order \u2264 8 realized with sorry-free proofs (Q\u2088 unformalized)",
-      "Order 16 abelian groups: C\u2082\u00d7C\u2088 via (\u2124/32\u2124)\u02e3, C\u2082\u00b2\u00d7C\u2084 via (\u2124/40\u2124)\u02e3",
-      "Order 20-24 abelian groups: C\u2082\u00d7C\u2081\u2080 via (\u2124/33\u2124)\u02e3, C\u2084\u00d7C\u2086 via (\u2124/35\u2124)\u02e3",
-      "S_n solvable iff n \u2264 4 (sharp threshold, 59 theorems in extension file)",
+      "Gal(X³-2/ℚ) ≅ S₃ proved from scratch (coprimality argument for [K:ℚ]=6)",
+      "A₅ realization: Gal(x⁵-5x⁴+10x³-10x²+25x-5) ≅ A₅ with full isomorphism proof",
+      "Eisenstein irreducibility for q at p=5 with Gauss lemma transfer ℤ→ℚ",
+      "no_subgroup_order_15: Sylow theory + native_decide (no order-5/order-3 commutation in S₅)",
+      "no_subgroup_order_30: A₅ simplicity + sign homomorphism kernel analysis",
+      "D₄ realization via X⁴-2 (680 lines, 0 axioms, 0 sorries)",
+      "F₂₀ (Frobenius) realization via X⁵-2 (529 lines, 0 axioms, 0 sorries)",
+      "Systematic census: 14/15 groups of order ≤ 8 realized with sorry-free proofs (Q₈ unformalized)",
+      "Order 16 abelian groups: C₂×C₈ via (ℤ/32ℤ)ˣ, C₂²×C₄ via (ℤ/40ℤ)ˣ",
+      "Order 20-24 abelian groups: C₂×C₁₀ via (ℤ/33ℤ)ˣ, C₄×C₆ via (ℤ/35ℤ)ˣ",
+      "S_n solvable iff n ≤ 4 (sharp threshold, 59 theorems in extension file)",
       "23 groups realized with sorry-free proofs across orders 1-60",
       "Vandermonde permutation chain: gal_card_dvd_60 derived from transparent vandermondeProduct_sq_eq axiom",
-      "Order 20-24 extended census: C\u2082\u00b2\u00d7C\u2086 via (\u2124/84\u2124)\u02e3, C\u2084\u00d7C\u2086 via (\u2124/35\u2124)\u02e3",
-      "vandermondeProduct_sq_eq PROVED: VP\u00b2 = disc(q) via \u2102 embedding, Sophie Germain identity (y\u2074+4=(y\u00b2+2y+2)(y\u00b2-2y+2)), product-roots evaluation at Gaussian integers q(\u00b1I) and q(2\u00b1I)"
+      "Order 20-24 extended census: C₂²×C₆ via (ℤ/84ℤ)ˣ, C₄×C₆ via (ℤ/35ℤ)ˣ",
+      "vandermondeProduct_sq_eq PROVED: VP² = disc(q) via ℂ embedding, Sophie Germain identity (y⁴+4=(y²+2y+2)(y²-2y+2)), product-roots evaluation at Gaussian integers q(±I) and q(2±I)"
     ],
     "dateAdded": "2026-02-21",
     "researchStatus": "ongoing",
     "openQuestions": [
-      "Is M\u2082\u2083 (Mathieu group) realizable as a Galois group over \u211a?",
-      "Can Dedekind's theorem (mod-p factorization \u2192 cycle types) be formalized?",
-      "Can the discriminant\u2194alternating group connection be formalized?",
+      "Is M₂₃ (Mathieu group) realizable as a Galois group over ℚ?",
+      "Can Dedekind's theorem (mod-p factorization → cycle types) be formalized?",
+      "Can the discriminant↔alternating group connection be formalized?",
       "Can we formalize Shafarevich's theorem on solvable groups?",
       "Can we formalize the Kronecker-Weber theorem in Lean?",
-      "Can Q\u2088 (quaternion group) be explicitly realized? (last missing group of order \u2264 8)"
+      "Can Q₈ (quaternion group) be explicitly realized? (last missing group of order ≤ 8)"
     ],
     "lineCount": 1882,
     "mathlib_version": "4.26.0",
@@ -147,19 +123,19 @@
     ]
   },
   "overview": {
-    "historicalContext": "The Inverse Galois Problem (IGP) emerged naturally from Galois theory, which \u00c9variste Galois developed in 1832 (published posthumously). Galois theory provides a dictionary between field extensions and groups: every Galois extension K/F has a group Gal(K/F), and vice versa. But the 'vice versa' direction\u2014given a group G, finding K\u2014is the challenge.\n\nHilbert in 1892 proved that all symmetric groups S\u2099 are realizable using his irreducibility theorem. Shafarevich's 1954 theorem resolved all solvable groups. The problem remains open in general.\n\nThe IGP is intimately connected to understanding the absolute Galois group Gal(\u211a\u0304/\u211a), one of the most mysterious objects in mathematics. It is related to Grothendieck's 'Esquisse d'un Programme' (1984), which proposed using the IGP to understand the absolute Galois group via its action on algebraic curves.\n\nAs of 2026, the general problem remains unsolved, though most finite simple groups have been realized over \u211a. The holdout cases include certain sporadic simple groups.",
-    "problemStatement": "**The Inverse Galois Problem**: Does every finite group G occur as the Galois group Gal(K/\u211a) of some Galois extension K of \u211a?\n\nFormally: \u2200 (G : finite group), \u2203 (K : Galois extension of \u211a), Gal(K/\u211a) \u2245 G.\n\nGalois theory gives us a rich supply of examples. The cyclotomic field \u211a(\u03b6\u2099) has Galois group (\u2124/n\u2124)\u02e3. But can we realize EVERY finite group? The answer is unknown.\n\n**Known results**:\n- All abelian groups: Kronecker-Weber theorem gives all abelian extensions of \u211a as cyclotomic subfields\n- All solvable groups: Shafarevich (1954)\n- All symmetric groups S\u2099: Hilbert's irreducibility theorem\n- Most finite simple groups: case-by-case constructions\n- **Open**: the general case",
-    "text": "A comprehensive formalization of the Inverse Galois Problem across 6 Lean files (5879 lines, 313 theorems, 5 axioms). We prove explicit Galois group realizations for 23 finite groups including the first non-solvable case (A\u2085 via Gal(x\u2075-5x\u2074+10x\u00b3-10x\u00b2+25x-5) with Sylow-theoretic proof, Vandermonde discriminant analysis via \u2102 embedding and Sophie Germain identity), D\u2084 via X\u2074-2, F\u2082\u2080 via X\u2075-2, and a systematic census of all groups of order \u2264 8 via cyclotomic fields.",
-    "proofStrategy": "The formalization spans 6 Lean files (5879 lines total) with 313 theorems.\n\n**InverseGalois.lean** (1882 lines, 106 thms) is the main file: states the IGP, proves cyclotomic realizations for abelian groups via Gal(\u211a(\u03b6\u2099)/\u211a) \u2245 (\u2124/n\u2124)\u02e3, and builds a comprehensive census of 23 realized groups. Key proof: Gal(X\u00b3-2/\u211a) \u2245 S\u2083 from scratch using coprimality.\n\n**InverseGaloisA5.lean** (2067 lines, 85 thms) proves A\u2085 realizability \u2014 the first non-solvable case. Eisenstein irreducibility at p=5 (Gauss lemma transfer \u2124\u2192\u211a), |Gal|=60 via Sylow theory (no_subgroup_order_15 + no_subgroup_order_30), explicit Gal \u2245 A\u2085 isomorphism via index-2 detection. 0 sorries, 1 axiom (Dedekind's theorem).\n\n**InverseGaloisD4.lean** (682 lines, 27 thms) proves D\u2084 realizability via Gal(X\u2074-2/\u211a) with 0 axioms, 0 sorries.\n\n**InverseGaloisF20.lean** (529 lines, 27 thms) proves F\u2082\u2080 (Frobenius group) realizability via Gal(X\u2075-2/\u211a) with 0 axioms, 0 sorries.\n\n**AbelRuffiniGaloisExtensions.lean** (534 lines, 59 thms) proves the sharp solvability threshold: S_n solvable iff n \u2264 4.\n\n**AbelRuffini.lean** (185 lines, 9 thms) connects to Mathlib's Abel-Ruffini infrastructure.",
+    "historicalContext": "The Inverse Galois Problem (IGP) emerged naturally from Galois theory, which Évariste Galois developed in 1832 (published posthumously). Galois theory provides a dictionary between field extensions and groups: every Galois extension K/F has a group Gal(K/F), and vice versa. But the 'vice versa' direction—given a group G, finding K—is the challenge.\n\nHilbert in 1892 proved that all symmetric groups Sₙ are realizable using his irreducibility theorem. Shafarevich's 1954 theorem resolved all solvable groups. The problem remains open in general.\n\nThe IGP is intimately connected to understanding the absolute Galois group Gal(ℚ̄/ℚ), one of the most mysterious objects in mathematics. It is related to Grothendieck's 'Esquisse d'un Programme' (1984), which proposed using the IGP to understand the absolute Galois group via its action on algebraic curves.\n\nAs of 2026, the general problem remains unsolved, though most finite simple groups have been realized over ℚ. The holdout cases include certain sporadic simple groups.",
+    "problemStatement": "**The Inverse Galois Problem**: Does every finite group G occur as the Galois group Gal(K/ℚ) of some Galois extension K of ℚ?\n\nFormally: ∀ (G : finite group), ∃ (K : Galois extension of ℚ), Gal(K/ℚ) ≅ G.\n\nGalois theory gives us a rich supply of examples. The cyclotomic field ℚ(ζₙ) has Galois group (ℤ/nℤ)ˣ. But can we realize EVERY finite group? The answer is unknown.\n\n**Known results**:\n- All abelian groups: Kronecker-Weber theorem gives all abelian extensions of ℚ as cyclotomic subfields\n- All solvable groups: Shafarevich (1954)\n- All symmetric groups Sₙ: Hilbert's irreducibility theorem\n- Most finite simple groups: case-by-case constructions\n- **Open**: the general case",
+    "text": "A comprehensive formalization of the Inverse Galois Problem across 6 Lean files (5879 lines, 313 theorems, 5 axioms). We prove explicit Galois group realizations for 23 finite groups including the first non-solvable case (A₅ via Gal(x⁵-5x⁴+10x³-10x²+25x-5) with Sylow-theoretic proof, Vandermonde discriminant analysis via ℂ embedding and Sophie Germain identity), D₄ via X⁴-2, F₂₀ via X⁵-2, and a systematic census of all groups of order ≤ 8 via cyclotomic fields.",
+    "proofStrategy": "The formalization spans 6 Lean files (5879 lines total) with 313 theorems.\n\n**InverseGalois.lean** (1882 lines, 106 thms) is the main file: states the IGP, proves cyclotomic realizations for abelian groups via Gal(ℚ(ζₙ)/ℚ) ≅ (ℤ/nℤ)ˣ, and builds a comprehensive census of 23 realized groups. Key proof: Gal(X³-2/ℚ) ≅ S₃ from scratch using coprimality.\n\n**InverseGaloisA5.lean** (2067 lines, 85 thms) proves A₅ realizability — the first non-solvable case. Eisenstein irreducibility at p=5 (Gauss lemma transfer ℤ→ℚ), |Gal|=60 via Sylow theory (no_subgroup_order_15 + no_subgroup_order_30), explicit Gal ≅ A₅ isomorphism via index-2 detection. 0 sorries, 1 axiom (Dedekind's theorem).\n\n**InverseGaloisD4.lean** (682 lines, 27 thms) proves D₄ realizability via Gal(X⁴-2/ℚ) with 0 axioms, 0 sorries.\n\n**InverseGaloisF20.lean** (529 lines, 27 thms) proves F₂₀ (Frobenius group) realizability via Gal(X⁵-2/ℚ) with 0 axioms, 0 sorries.\n\n**AbelRuffiniGaloisExtensions.lean** (534 lines, 59 thms) proves the sharp solvability threshold: S_n solvable iff n ≤ 4.\n\n**AbelRuffini.lean** (185 lines, 9 thms) connects to Mathlib's Abel-Ruffini infrastructure.",
     "keyInsights": [
-      "Cyclotomic fields provide a systematic source of abelian Galois groups over \u211a",
-      "The Galois group Gal(\u211a(\u03b6\u2099)/\u211a) \u2245 (\u2124/n\u2124)\u02e3 whenever the n-th cyclotomic polynomial is irreducible over \u211a",
+      "Cyclotomic fields provide a systematic source of abelian Galois groups over ℚ",
+      "The Galois group Gal(ℚ(ζₙ)/ℚ) ≅ (ℤ/nℤ)ˣ whenever the n-th cyclotomic polynomial is irreducible over ℚ",
       "Eisenstein's criterion + Gauss lemma is a powerful tool for proving irreducibility of specific polynomials",
       "Sylow theory provides an elegant alternative to discriminant analysis for eliminating impossible Galois group orders",
-      "no_subgroup_order_15 in S\u2085: uses native_decide to verify no order-5 and order-3 elements commute",
-      "no_subgroup_order_30 in S\u2085: uses A\u2085 simplicity \u2014 any index-2 subgroup of A\u2085 would be normal, contradicting simplicity",
-      "The A\u2085 case demonstrates that going beyond Shafarevich's theorem requires fundamentally different techniques",
-      "The general case reduces to the question: does Gal(\u211a\u0304/\u211a) surject onto all finite groups?"
+      "no_subgroup_order_15 in S₅: uses native_decide to verify no order-5 and order-3 elements commute",
+      "no_subgroup_order_30 in S₅: uses A₅ simplicity — any index-2 subgroup of A₅ would be normal, contradicting simplicity",
+      "The A₅ case demonstrates that going beyond Shafarevich's theorem requires fundamentally different techniques",
+      "The general case reduces to the question: does Gal(ℚ̄/ℚ) surject onto all finite groups?"
     ],
     "prerequisites": [
       "Galois theory (field extensions, Galois groups, splitting fields)",
@@ -182,94 +158,94 @@
       "title": "Cyclotomic Fields Are Galois",
       "startLine": 82,
       "endLine": 121,
-      "summary": "CyclotomicField n \u211a is Galois over \u211a (IsCyclotomicExtension.isGalois), and its Galois group is abelian (commutative).",
+      "summary": "CyclotomicField n ℚ is Galois over ℚ (IsCyclotomicExtension.isGalois), and its Galois group is abelian (commutative).",
       "mathContext": "$\\mathbb{Q}(\\zeta_n)/\\mathbb{Q}$ is a Galois extension with $\\operatorname{Gal}(\\mathbb{Q}(\\zeta_n)/\\mathbb{Q})$ abelian, since cyclotomic extensions are always Galois."
     },
     {
       "id": "galois-group-structure",
-      "title": "Galois Group \u2245 (ZMod n)\u02e3",
+      "title": "Galois Group ≅ (ZMod n)ˣ",
       "startLine": 122,
       "endLine": 170,
-      "summary": "The Galois group of the n-th cyclotomic polynomial is isomorphic to (ZMod n)\u02e3. Cyclotomic irreducibility proved via Polynomial.cyclotomic.irreducible_rat.",
-      "mathContext": "The Galois group of the n-th cyclotomic polynomial is isomorphic to (ZMod n)\u02e3. Cyclotomic irreducibility proved via Polynomial.cyclotomic.irreducible_rat."
+      "summary": "The Galois group of the n-th cyclotomic polynomial is isomorphic to (ZMod n)ˣ. Cyclotomic irreducibility proved via Polynomial.cyclotomic.irreducible_rat.",
+      "mathContext": "The Galois group of the n-th cyclotomic polynomial is isomorphic to (ZMod n)ˣ. Cyclotomic irreducibility proved via Polynomial.cyclotomic.irreducible_rat."
     },
     {
       "id": "s3-realization",
-      "title": "S\u2083 Realization via X\u00b3-2",
+      "title": "S₃ Realization via X³-2",
       "startLine": 367,
       "endLine": 700,
-      "summary": "Gal(X\u00b3-2/\u211a) \u2245 S\u2083 proved from scratch: Eisenstein irreducibility at p=2, 3||Gal| (prime degree), |Gal||6 (Gal \u21aa S\u2083), 2||Gal| (cube root of unity), coprimality gives |Gal|=6, bijectivity of galActionHom.",
+      "summary": "Gal(X³-2/ℚ) ≅ S₃ proved from scratch: Eisenstein irreducibility at p=2, 3||Gal| (prime degree), |Gal||6 (Gal ↪ S₃), 2||Gal| (cube root of unity), coprimality gives |Gal|=6, bijectivity of galActionHom.",
       "mathContext": "$\\operatorname{Gal}(\\mathbb{Q}(\\sqrt[3]{2}, \\zeta_3)/\\mathbb{Q}) \\cong S_3$. Eisenstein at $p=2$ gives irreducibility; $3 \\mid |\\operatorname{Gal}|$ (prime degree), $|\\operatorname{Gal}| \\mid 6$ ($\\operatorname{Gal} \\hookrightarrow S_3$), $2 \\mid |\\operatorname{Gal}|$ ($\\zeta_3 \\notin \\mathbb{Q}$), so $|\\operatorname{Gal}|=6$."
     },
     {
       "id": "a5-realization",
-      "title": "A\u2085 Realization (First Non-Solvable Group)",
+      "title": "A₅ Realization (First Non-Solvable Group)",
       "startLine": 1,
       "endLine": 992,
-      "summary": "In InverseGaloisA5.lean: A\u2085 \u2245 Gal(x\u2075-5x\u2074+10x\u00b3-10x\u00b2+25x-5/\u211a). Eisenstein irreducibility at p=5, |Gal|=60 via Sylow theory (no S\u2085 subgroups of order 15 or 30), explicit MulEquiv with alternatingGroup(Fin 5). 85 theorems, 1 axiom (Dedekind's theorem), 0 sorries. VP\u00b2 proved via \u2102 embedding + Sophie Germain identity.",
+      "summary": "In InverseGaloisA5.lean: A₅ ≅ Gal(x⁵-5x⁴+10x³-10x²+25x-5/ℚ). Eisenstein irreducibility at p=5, |Gal|=60 via Sylow theory (no S₅ subgroups of order 15 or 30), explicit MulEquiv with alternatingGroup(Fin 5). 85 theorems, 1 axiom (Dedekind's theorem), 0 sorries. VP² proved via ℂ embedding + Sophie Germain identity.",
       "file": "Proofs/InverseGaloisA5.lean",
       "mathContext": "$A_5 \\cong \\operatorname{Gal}(q/\\mathbb{Q})$ where $q = x^5 - 5x^4 + 10x^3 - 10x^2 + 25x - 5$. Eisenstein at $p=5$; $|\\operatorname{Gal}| = 60$ by Sylow theory (no subgroups of order 15 or 30 in $S_5$); index-2 subgroup detection yields $\\operatorname{Gal} \\cong A_5$."
     },
     {
       "id": "d4-realization",
-      "title": "D\u2084 Realization via X\u2074-2",
+      "title": "D₄ Realization via X⁴-2",
       "startLine": 1,
       "endLine": 680,
-      "summary": "In InverseGaloisD4.lean: D\u2084 \u2245 Gal(X\u2074-2/\u211a). 27 theorems, 0 axioms, 0 sorries. Proves the dihedral group of order 8 is realizable as a Galois group over \u211a.",
+      "summary": "In InverseGaloisD4.lean: D₄ ≅ Gal(X⁴-2/ℚ). 27 theorems, 0 axioms, 0 sorries. Proves the dihedral group of order 8 is realizable as a Galois group over ℚ.",
       "file": "Proofs/InverseGaloisD4.lean",
       "mathContext": "$D_4 \\cong \\operatorname{Gal}(X^4 - 2 / \\mathbb{Q})$: the dihedral group of order 8 realized as the Galois group of the splitting field $\\mathbb{Q}(\\sqrt[4]{2}, i)$. Fully proved (0 axioms, 0 sorries)."
     },
     {
       "id": "f20-realization",
-      "title": "F\u2082\u2080 (Frobenius) Realization via X\u2075-2",
+      "title": "F₂₀ (Frobenius) Realization via X⁵-2",
       "startLine": 1,
       "endLine": 529,
-      "summary": "In InverseGaloisF20.lean: F\u2082\u2080 \u2245 Gal(X\u2075-2/\u211a). The Frobenius group of order 20 (the unique solvable transitive subgroup of S\u2085 of order 20). 27 theorems, 0 axioms, 0 sorries.",
+      "summary": "In InverseGaloisF20.lean: F₂₀ ≅ Gal(X⁵-2/ℚ). The Frobenius group of order 20 (the unique solvable transitive subgroup of S₅ of order 20). 27 theorems, 0 axioms, 0 sorries.",
       "file": "Proofs/InverseGaloisF20.lean",
       "mathContext": "$F_{20} \\cong \\operatorname{Gal}(X^5 - 2 / \\mathbb{Q})$: the Frobenius group $F_{20} = \\mathbb{Z}/5\\mathbb{Z} \\rtimes \\mathbb{Z}/4\\mathbb{Z}$, the unique solvable transitive subgroup of $S_5$ of order 20. Fully proved (0 axioms, 0 sorries)."
     },
     {
       "id": "group-census",
-      "title": "Realizability Census (Orders \u2264 8 and Beyond)",
+      "title": "Realizability Census (Orders ≤ 8 and Beyond)",
       "startLine": 1100,
       "endLine": 1530,
-      "summary": "Systematic census of all groups of order \u2264 8: 14 of 15 groups realized with sorry-free proofs. Only Q\u2088 (quaternion) remains. Extended census covers 21+ groups including order 16 (C\u2082\u00d7C\u2088, C\u2082\u00b2\u00d7C\u2084), order 20 (C\u2082\u00d7C\u2081\u2080), and order 24 (C\u2084\u00d7C\u2086). Uses cyclotomic fields with totient/exponent analysis and native_decide verification.",
+      "summary": "Systematic census of all groups of order ≤ 8: 14 of 15 groups realized with sorry-free proofs. Only Q₈ (quaternion) remains. Extended census covers 21+ groups including order 16 (C₂×C₈, C₂²×C₄), order 20 (C₂×C₁₀), and order 24 (C₄×C₆). Uses cyclotomic fields with totient/exponent analysis and native_decide verification.",
       "mathContext": "Realizability census: for $|G| \\leq 8$, 14 of 15 groups realized via $\\operatorname{Gal}(\\mathbb{Q}(\\zeta_n)/\\mathbb{Q}) \\cong (\\mathbb{Z}/n\\mathbb{Z})^{\\times}$ and totient analysis. Extended to $C_2 \\times C_8$ via $(\\mathbb{Z}/32\\mathbb{Z})^{\\times}$, $C_2^2 \\times C_4$ via $(\\mathbb{Z}/40\\mathbb{Z})^{\\times}$, etc. Only $Q_8$ unformalized."
     },
     {
       "id": "sharp-threshold",
-      "title": "Sharp Threshold: S_n Solvable iff n \u2264 4",
+      "title": "Sharp Threshold: S_n Solvable iff n ≤ 4",
       "startLine": 158,
       "endLine": 1881,
-      "summary": "In AbelRuffiniGaloisExtensions.lean: S_n is solvable iff n \u2264 4. Uses Equiv.Perm.not_solvable for n \u2265 5. This is the fundamental threshold in the Abel-Ruffini theorem. 59 theorems, all fully proved.",
+      "summary": "In AbelRuffiniGaloisExtensions.lean: S_n is solvable iff n ≤ 4. Uses Equiv.Perm.not_solvable for n ≥ 5. This is the fundamental threshold in the Abel-Ruffini theorem. 59 theorems, all fully proved.",
       "file": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "mathContext": "Sharp solvability threshold: $S_n$ is solvable $\\iff n \\leq 4$. For $n \\geq 5$, the commutator series $S_n \\supset A_n \\supset \\{e\\}$ fails since $A_n$ is simple and non-abelian. This is the group-theoretic core of Abel-Ruffini."
     }
   ],
   "conclusion": {
-    "summary": "The Inverse Galois Problem remains one of the great open questions in algebra. Across 5879 lines in 6 files (313 theorems, 5 axiom declarations, 0 sorries), we formalize: the IGP conjecture, cyclotomic Galois theory with Gal(\u211a(\u03b6\u2099)/\u211a) \u2245 (\u2124/n\u2124)\u02e3, explicit realizations for S\u2083 (X\u00b3-2), D\u2084 (X\u2074-2), F\u2082\u2080 (X\u2075-2), and A\u2085 (x\u2075-5x\u2074+10x\u00b3-10x\u00b2+25x-5), the sharp solvability threshold S_n solvable iff n \u2264 4, and a comprehensive census of 23 groups. The A\u2085 realization (2067 lines, 0 sorries, 1 axiom) is the crown jewel: the first non-solvable group realized, using Eisenstein's criterion, Sylow theory, Vandermonde discriminant analysis via \u2102 embedding and Sophie Germain identity, and the uniqueness of the index-2 subgroup A\u2085 in S\u2085. The 5 axioms represent the open conjecture itself and well-known theorems blocked on Mathlib infrastructure (Kronecker-Weber, Shafarevich, Hilbert irreducibility, Dedekind's theorem).",
-    "implications": "**Theoretical Significance**: The IGP has profound implications:\n\n1. **ABSOLUTE GALOIS GROUP**: A positive answer would mean the absolute Galois group Gal(\u211a\u0304/\u211a) surjects onto every finite group \u2014 revealing its structure.\n\n2. **GALOIS REPRESENTATIONS**: The IGP is connected to the theory of Galois representations, central to the Langlands program and the proof of Fermat's Last Theorem.\n\n**3. ARITHMETIC GEOMETRY**: Via Grothendieck's programme, the IGP connects to the study of algebraic curves and their fundamental groups.\n\n4. **ALGORITHM DESIGN**: Positive answers might come with explicit polynomial constructions, useful for cryptography and computation.\n\n5. **DIFFERENTIAL GALOIS THEORY**: The analogous question for differential equations (Kovacic's problem) has been solved, suggesting approaches for the classical case.",
+    "summary": "The Inverse Galois Problem remains one of the great open questions in algebra. Across 5879 lines in 6 files (313 theorems, 5 axiom declarations, 0 sorries), we formalize: the IGP conjecture, cyclotomic Galois theory with Gal(ℚ(ζₙ)/ℚ) ≅ (ℤ/nℤ)ˣ, explicit realizations for S₃ (X³-2), D₄ (X⁴-2), F₂₀ (X⁵-2), and A₅ (x⁵-5x⁴+10x³-10x²+25x-5), the sharp solvability threshold S_n solvable iff n ≤ 4, and a comprehensive census of 23 groups. The A₅ realization (2067 lines, 0 sorries, 1 axiom) is the crown jewel: the first non-solvable group realized, using Eisenstein's criterion, Sylow theory, Vandermonde discriminant analysis via ℂ embedding and Sophie Germain identity, and the uniqueness of the index-2 subgroup A₅ in S₅. The 5 axioms represent the open conjecture itself and well-known theorems blocked on Mathlib infrastructure (Kronecker-Weber, Shafarevich, Hilbert irreducibility, Dedekind's theorem).",
+    "implications": "**Theoretical Significance**: The IGP has profound implications:\n\n1. **ABSOLUTE GALOIS GROUP**: A positive answer would mean the absolute Galois group Gal(ℚ̄/ℚ) surjects onto every finite group — revealing its structure.\n\n2. **GALOIS REPRESENTATIONS**: The IGP is connected to the theory of Galois representations, central to the Langlands program and the proof of Fermat's Last Theorem.\n\n**3. ARITHMETIC GEOMETRY**: Via Grothendieck's programme, the IGP connects to the study of algebraic curves and their fundamental groups.\n\n4. **ALGORITHM DESIGN**: Positive answers might come with explicit polynomial constructions, useful for cryptography and computation.\n\n5. **DIFFERENTIAL GALOIS THEORY**: The analogous question for differential equations (Kovacic's problem) has been solved, suggesting approaches for the classical case.",
     "openQuestions": [
-      "Does every finite group appear as a Galois group over \u211a?",
-      "Is the Mathieu group M\u2082\u2083 realizable over \u211a?",
-      "Can Q\u2088 (quaternion group) be explicitly realized? (last missing group of order \u2264 8)",
-      "Can Dedekind's theorem be formalized to eliminate the last A\u2085 axiom (three_dvd_gal_card)?",
+      "Does every finite group appear as a Galois group over ℚ?",
+      "Is the Mathieu group M₂₃ realizable over ℚ?",
+      "Can Q₈ (quaternion group) be explicitly realized? (last missing group of order ≤ 8)",
+      "Can Dedekind's theorem be formalized to eliminate the last A₅ axiom (three_dvd_gal_card)?",
       "Can we formalize Shafarevich's theorem on solvable groups?",
       "Can we formalize the Kronecker-Weber theorem in Lean/Mathlib?",
-      "What is the structure of Gal(\u211a\u0304/\u211a)?",
-      "Is there a uniform method to realize all finite groups over \u211a?"
+      "What is the structure of Gal(ℚ̄/ℚ)?",
+      "Is there a uniform method to realize all finite groups over ℚ?"
     ]
   },
   "crossReferences": [
     {
       "targetId": "abel-ruffini",
       "relationship": "complementary",
-      "description": "Abel-Ruffini uses that S5 occurs as a Galois group; the Inverse Galois Problem asks which groups appear as Galois groups over Q \u2014 directly extending the question Abel-Ruffini raises about the structure of polynomial symmetry groups"
+      "description": "Abel-Ruffini uses that S5 occurs as a Galois group; the Inverse Galois Problem asks which groups appear as Galois groups over Q — directly extending the question Abel-Ruffini raises about the structure of polynomial symmetry groups"
     },
     {
       "targetId": "abel-ruffini-oq-04",
       "relationship": "related",
-      "description": "The OQ-04 extension of Abel-Ruffini exposes the A5 simplicity chain \u2014 the same A5 realization proved here via Gal(x^5-5x^4+10x^3-10x^2+25x-5) is the first non-solvable case"
+      "description": "The OQ-04 extension of Abel-Ruffini exposes the A5 simplicity chain — the same A5 realization proved here via Gal(x^5-5x^4+10x^3-10x^2+25x-5) is the first non-solvable case"
     },
     {
       "targetId": "lagrange-theorem",
@@ -279,7 +255,7 @@
     {
       "targetId": "sylow-theorems",
       "relationship": "foundational",
-      "description": "Sylow theorems are essential for the A5 realization \u2014 proving |Gal(q)| divides 60 and identifying the Galois group by its Sylow subgroup structure"
+      "description": "Sylow theorems are essential for the A5 realization — proving |Gal(q)| divides 60 and identifying the Galois group by its Sylow subgroup structure"
     },
     {
       "targetId": "fundamental-theorem-algebra",
@@ -320,8 +296,32 @@
       "name": "inverse_galois_sn",
       "type": "core",
       "description": "Every symmetric group S_n occurs as a Galois group over Q",
-      "leanType": "(n : Nat) -> exists K : IntermediateField Q, Gal(K/Q) \u2245 Perm (Fin n)"
+      "leanType": "(n : Nat) -> exists K : IntermediateField Q, Gal(K/Q) ≅ Perm (Fin n)"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/InverseGalois.lean",
+    "lineCount": 1882,
+    "axiomCount": 5,
+    "sorries": 0,
+    "theoremCount": 105,
+    "definitionCount": 1,
+    "imports": [
+      "Mathlib.NumberTheory.Cyclotomic.Basic",
+      "Mathlib.NumberTheory.Cyclotomic.Gal",
+      "Mathlib.NumberTheory.Cyclotomic.PrimitiveRoots",
+      "Mathlib.FieldTheory.AbelRuffini",
+      "Mathlib.GroupTheory.Solvable",
+      "Mathlib.GroupTheory.SpecificGroups.Alternating",
+      "Mathlib.FieldTheory.Galois.Basic",
+      "Mathlib.GroupTheory.Perm.Sign",
+      "Mathlib.FieldTheory.SplittingField.Construction",
+      "Mathlib.RingTheory.Polynomial.Cyclotomic.Basic",
+      "Mathlib.RingTheory.Polynomial.Eisenstein.Criterion",
+      "Mathlib.RingTheory.Polynomial.GaussLemma",
+      "Mathlib.NumberTheory.LSeries.PrimesInAP"
+    ],
+    "lemmaCount": 1
+  }
 }

--- a/src/data/proofs/poincare-conjecture/meta.json
+++ b/src/data/proofs/poincare-conjecture/meta.json
@@ -1,6 +1,6 @@
 {
   "id": "poincare-conjecture",
-  "title": "The Poincar\u00e9 Conjecture",
+  "title": "The Poincaré Conjecture",
   "slug": "poincare-conjecture",
   "description": "Every simply connected, closed 3-manifold is homeomorphic to the 3-sphere. Solved by Grigori Perelman in 2002-2003 using Ricci flow with surgery.",
   "meta": {
@@ -26,7 +26,7 @@
       },
       {
         "theorem": "FundamentalGroup",
-        "description": "Fundamental group \u03c0\u2081(X,x) as automorphisms in fundamental groupoid",
+        "description": "Fundamental group π₁(X,x) as automorphisms in fundamental groupoid",
         "module": "Mathlib.AlgebraicTopology.FundamentalGroupoid.FundamentalGroup"
       },
       {
@@ -41,7 +41,7 @@
       },
       {
         "theorem": "EuclideanSpace",
-        "description": "Finite-dimensional inner product space \u211d\u207f",
+        "description": "Finite-dimensional inner product space ℝⁿ",
         "module": "Mathlib.Analysis.InnerProductSpace.PiL2"
       },
       {
@@ -51,20 +51,20 @@
       }
     ],
     "originalContributions": [
-      "Formal statement of the Poincar\u00e9 Conjecture using Mathlib's SimplyConnectedSpace",
-      "S\u00b3 topological properties proved: nonempty, compact, connected, path-connected, locally Euclidean",
+      "Formal statement of the Poincaré Conjecture using Mathlib's SimplyConnectedSpace",
+      "S³ topological properties proved: nonempty, compact, connected, path-connected, locally Euclidean",
       "General n-sphere S^n properties proved for all dimensions (compact, connected, locally Euclidean via stereographic projection)",
-      "Punctured sphere contractibility: S^n \\ {v} \u2243\u209c (\u211d\u00b7v)\u15ee via stereographic projection \u2192 contractible \u2192 simply connected",
+      "Punctured sphere contractibility: S^n \\ {v} ≃ₜ (ℝ·v)ᗮ via stereographic projection → contractible → simply connected",
       "Bridge between FundamentalGroup triviality and SimplyConnectedSpace",
-      "poincare_of_trivial_pi1: \u03c0\u2081(M,x) trivial \u2200x \u27f9 M \u2245 S\u00b3",
-      "poincare_all_dimensions: unified theorem for all n \u2265 2",
-      "closed_3_manifold_classification: SC \u27fa homeomorphic to S\u00b3",
+      "poincare_of_trivial_pi1: π₁(M,x) trivial ∀x ⟹ M ≅ S³",
+      "poincare_all_dimensions: unified theorem for all n ≥ 2",
+      "closed_3_manifold_classification: SC ⟺ homeomorphic to S³",
       "Thurston's 8 geometries enumerated with count proved via native_decide",
-      "Connected sum, prime decomposition, S\u00b3 primality, Milnor uniqueness (axiomatized)",
+      "Connected sum, prime decomposition, S³ primality, Milnor uniqueness (axiomatized)",
       "Axiomatization of Perelman's Ricci flow surgery approach with finite extinction",
-      "Hopf fibration S\u00b3 \u2192 S\u00b2 constructed explicitly: \u03c0(a,b,c,d) = (a\u00b2+b\u00b2-c\u00b2-d\u00b2, 2(ac+bd), 2(bc-ad))",
+      "Hopf fibration S³ → S² constructed explicitly: π(a,b,c,d) = (a²+b²-c²-d², 2(ac+bd), 2(bc-ad))",
       "Hopf map proved continuous and surjective (hopf_map_exists)",
-      "RP\u00b3 = S\u00b3/{x ~ -x} constructed as quotient with antipodal equivalence (reflexive, symmetric, transitive)",
+      "RP³ = S³/{x ~ -x} constructed as quotient with antipodal equivalence (reflexive, symmetric, transitive)",
       "Covering space theory: CoveringSpace structure, FiberBundle structure, deck transformations",
       "JSJ decomposition and Seifert fiber spaces axiomatized",
       "Papakyriakopoulos trilogy: Dehn's lemma, loop theorem, sphere theorem (axiomatized)",
@@ -74,32 +74,20 @@
       "Gordon-Luecke theorem: knot complements determine knots, Alexander polynomial data, hyperbolic volume, genus-crossing bounds",
       "590 theorems proved, 137 structures defined, 218 definitions, 82 parts across 11574 lines"
     ],
-    "leanFile": {
-      "lineCount": 17670,
-      "theoremCount": 897,
-      "lemmaCount": 0,
-      "defCount": 365,
-      "axiomCount": 33,
-      "sorryCount": 0,
-      "structureCount": 183,
-      "instanceCount": 21,
-      "parts": 100,
-      "note": "Single file formalization. 100 parts covering: topology of S\u00b3 and S^n, closed manifolds, simple connectivity, Perelman's proof strategy, counterexamples, geometrization, connected sum theory, covering spaces, Hopf fibration, knot surgery, JSJ decomposition, foliations, Papakyriakopoulos results, Heegaard Floer homology, L-space conjecture, contact structures, Virtual Haken conjecture, Gordon-Luecke theorem, Chern-Simons theory, h-cobordism, TQFT axioms, \u03ba-solutions, surgery algorithm, Kneser-Milnor, finite extinction, proof architecture, generalized Poincar\u00e9, open problems, legacy."
-    },
     "dateAdded": "2025-12-29",
     "millenniumProblem": "poincare",
     "lineCount": 17675,
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "Henri Poincar\u00e9 posed the conjecture in 1904 in his fifth complement to Analysis Situs, after discovering that homology alone does not characterize the 3-sphere (the Poincar\u00e9 homology sphere $\\Sigma(2,3,5)$ has $H_*(M) \\cong H_*(S^3)$ but $|\\pi_1| = 120$). The problem resisted all attempts for nearly a century.\n\nRichard Hamilton introduced Ricci flow in his landmark 1982 paper in J. Differential Geometry, proving that closed 3-manifolds with positive Ricci curvature are diffeomorphic to $S^3$. Grigori Perelman extended this in three arXiv preprints (2002\u20132003): 'The entropy formula for the Ricci flow' (math/0211159), 'Ricci flow with surgery on three-manifolds' (math/0303109), and 'Finite extinction time for the solutions to the Ricci flow' (math/0307245). His proof also established Thurston's Geometrization Conjecture.\n\nPerelman was awarded the Fields Medal in 2006 (declined) and the Clay Millennium Prize of $1 million in 2010 (also declined), saying 'I'm not interested in money or fame.' The detailed verification was completed by Kleiner\u2013Lott (2008), Morgan\u2013Tian (2007), and Cao\u2013Zhu (2006).",
+    "historicalContext": "Henri Poincaré posed the conjecture in 1904 in his fifth complement to Analysis Situs, after discovering that homology alone does not characterize the 3-sphere (the Poincaré homology sphere $\\Sigma(2,3,5)$ has $H_*(M) \\cong H_*(S^3)$ but $|\\pi_1| = 120$). The problem resisted all attempts for nearly a century.\n\nRichard Hamilton introduced Ricci flow in his landmark 1982 paper in J. Differential Geometry, proving that closed 3-manifolds with positive Ricci curvature are diffeomorphic to $S^3$. Grigori Perelman extended this in three arXiv preprints (2002–2003): 'The entropy formula for the Ricci flow' (math/0211159), 'Ricci flow with surgery on three-manifolds' (math/0303109), and 'Finite extinction time for the solutions to the Ricci flow' (math/0307245). His proof also established Thurston's Geometrization Conjecture.\n\nPerelman was awarded the Fields Medal in 2006 (declined) and the Clay Millennium Prize of $1 million in 2010 (also declined), saying 'I'm not interested in money or fame.' The detailed verification was completed by Kleiner–Lott (2008), Morgan–Tian (2007), and Cao–Zhu (2006).",
     "problemStatement": "**Theorem (Perelman, 2003):** Every simply connected, closed 3-manifold is homeomorphic to the 3-sphere $S^3$.\n\nFormally: $\\forall M, \\; \\text{Closed3Manifold}(M) \\to \\text{SimplyConnectedSpace}(M) \\to M \\cong_t S^3$.\n\nThis was the first of the seven Millennium Prize Problems to be solved. The conjecture is equivalent to: $\\pi_1(M) = 1$ characterizes $S^3$ among closed 3-manifolds.",
-    "text": "Formalizes the Poincar\u00e9 Conjecture: every simply connected, closed 3-manifold is homeomorphic to $S^3$. Defines $S^3 \\subset \\mathbb{R}^4$ and proves its topological properties via Mathlib. Axiomatizes Perelman's Ricci flow with surgery approach (finite extinction time from $\\pi_1 = 1$). Extends to generalized Poincar\u00e9 for all $n \\geq 2$, Thurston geometrization (8 model geometries), connected sum decomposition, Hopf fibration, covering spaces, and the biconditional classification $\\pi_1(M) = 1 \\iff M \\cong S^3$.",
-    "proofStrategy": "The Lean formalization defines the 3-sphere $S^3 \\subset \\mathbb{R}^4$, proves its topological properties (compact, connected, path-connected, nonempty), and uses Mathlib's `SimplyConnectedSpace` and `FundamentalGroup` infrastructure. Perelman's Ricci flow with surgery approach is axiomatized: the surgery procedure preserves simple connectivity, and finite extinction time forces convergence to $S^3$. The main theorem is derived from these axioms. The file extends to Thurston's geometrization (8 model geometries), the generalized Poincar\u00e9 Conjecture for all dimensions $\\geq 2$, connected sum / prime decomposition, and the biconditional classification theorem.",
+    "text": "Formalizes the Poincaré Conjecture: every simply connected, closed 3-manifold is homeomorphic to $S^3$. Defines $S^3 \\subset \\mathbb{R}^4$ and proves its topological properties via Mathlib. Axiomatizes Perelman's Ricci flow with surgery approach (finite extinction time from $\\pi_1 = 1$). Extends to generalized Poincaré for all $n \\geq 2$, Thurston geometrization (8 model geometries), connected sum decomposition, Hopf fibration, covering spaces, and the biconditional classification $\\pi_1(M) = 1 \\iff M \\cong S^3$.",
+    "proofStrategy": "The Lean formalization defines the 3-sphere $S^3 \\subset \\mathbb{R}^4$, proves its topological properties (compact, connected, path-connected, nonempty), and uses Mathlib's `SimplyConnectedSpace` and `FundamentalGroup` infrastructure. Perelman's Ricci flow with surgery approach is axiomatized: the surgery procedure preserves simple connectivity, and finite extinction time forces convergence to $S^3$. The main theorem is derived from these axioms. The file extends to Thurston's geometrization (8 model geometries), the generalized Poincaré Conjecture for all dimensions $\\geq 2$, connected sum / prime decomposition, and the biconditional classification theorem.",
     "keyInsights": [
       "**Ricci flow as heat equation for geometry:** The PDE $\\partial g/\\partial t = -2\\operatorname{Ric}(g)$ smooths curvature irregularities, driving simply connected manifolds toward constant positive curvature (the round $S^3$ metric)",
       "**Surgery handles singularities:** When Ricci flow develops singularities (necks pinching off), Perelman's surgery cuts at the neck and caps with standard pieces, preserving $\\pi_1 = 1$",
-      "**Finite extinction from simple connectivity:** The key insight \u2014 $\\pi_1(M) = 1$ prevents incompressible tori that would allow infinite-time survival. The $W$-entropy monotonicity forces extinction in finite time",
+      "**Finite extinction from simple connectivity:** The key insight — $\\pi_1(M) = 1$ prevents incompressible tori that would allow infinite-time survival. The $W$-entropy monotonicity forces extinction in finite time",
       "**Dimensional paradox:** The conjecture was hardest in dimension 3, despite being solved earlier in all other dimensions: $n \\geq 5$ (Smale 1961), $n = 4$ (Freedman 1982), $n = 2$ (classical). The Whitney trick fails in low dimensions",
       "**Thurston's geometrization:** Every closed 3-manifold decomposes into pieces carrying one of exactly 8 model geometries. Simply connected manifolds can only carry spherical geometry, so they must be $S^3$"
     ],
@@ -140,12 +128,12 @@
       "title": "Homeomorphism",
       "startLine": 184,
       "endLine": 202,
-      "summary": "Defines `AreHomeomorphic X Y` and **proves** reflexivity, symmetry, transitivity \u2014 establishing homeomorphism as an equivalence relation.",
+      "summary": "Defines `AreHomeomorphic X Y` and **proves** reflexivity, symmetry, transitivity — establishing homeomorphism as an equivalence relation.",
       "mathContext": "M ~ N: continuous bijection with continuous inverse. Proved: equivalence relation."
     },
     {
       "id": "poincare-statement",
-      "title": "The Poincar\u00e9 Conjecture (Statement)",
+      "title": "The Poincaré Conjecture (Statement)",
       "startLine": 203,
       "endLine": 213,
       "summary": "States `PoincareConjectureStatement` : $\\forall M$, closed 3-manifold $\\wedge$ simply connected $\\implies M \\cong_t S^3$.",
@@ -169,11 +157,11 @@
     },
     {
       "id": "generalized-dims",
-      "title": "Generalized Poincar\u00e9 (Per Dimension)",
+      "title": "Generalized Poincaré (Per Dimension)",
       "startLine": 279,
       "endLine": 297,
       "summary": "Axiomatizes the generalized conjecture for $n = 2$ (uniformization), $n = 4$ (Freedman), $n \\geq 5$ (Smale).",
-      "mathContext": "Generalized Poincar\u00e9: $n = 2$ (classification of surfaces), $n = 4$ (Freedman 1982, topological), $n \\geq 5$ (Smale 1961, h-cobordism). Smooth $n = 4$ remains open."
+      "mathContext": "Generalized Poincaré: $n = 2$ (classification of surfaces), $n = 4$ (Freedman 1982, topological), $n \\geq 5$ (Smale 1961, h-cobordism). Smooth $n = 4$ remains open."
     },
     {
       "id": "consequences",
@@ -193,7 +181,7 @@
     },
     {
       "id": "all-dimensions",
-      "title": "Poincar\u00e9 for All Dimensions $\\geq 2$",
+      "title": "Poincaré for All Dimensions $\\geq 2$",
       "startLine": 378,
       "endLine": 418,
       "summary": "**Proves** `poincare_all_dimensions` by case analysis: Smale for $n \\geq 5$, then `interval_cases` dispatching $n \\in \\{2, 3, 4\\}$.",
@@ -228,7 +216,7 @@
       "title": "$S^3$ Type Class Instances",
       "startLine": 468,
       "endLine": 521,
-      "summary": "Lifts $S^3$ properties to type class instances. Axiomatizes locally Euclidean and simple connectivity (Seifert\u2013van Kampen needed).",
+      "summary": "Lifts $S^3$ properties to type class instances. Axiomatizes locally Euclidean and simple connectivity (Seifert–van Kampen needed).",
       "mathContext": "S^3 type class instances: topological space, compact, connected. Locally Euclidean axiomatized."
     },
     {
@@ -268,39 +256,39 @@
     {
       "targetId": "hurwitz-theorem",
       "relationship": "thematic",
-      "description": "Both establish classification theorems: Hurwitz classifies normed division algebras ($n \\in \\{1,2,4,8\\}$), Poincar\u00e9 classifies simply connected closed 3-manifolds (only $S^3$). Both use biconditional characterizations"
+      "description": "Both establish classification theorems: Hurwitz classifies normed division algebras ($n \\in \\{1,2,4,8\\}$), Poincaré classifies simply connected closed 3-manifolds (only $S^3$). Both use biconditional characterizations"
     },
     {
       "targetId": "brouwer-fixed-point",
       "relationship": "foundational",
-      "description": "The Brouwer fixed point theorem is a cornerstone of algebraic topology \u2014 the same homotopy-theoretic machinery (fundamental group, simple connectivity) that underlies the Poincar\u00e9 conjecture's statement"
+      "description": "The Brouwer fixed point theorem is a cornerstone of algebraic topology — the same homotopy-theoretic machinery (fundamental group, simple connectivity) that underlies the Poincaré conjecture's statement"
     },
     {
       "targetId": "borsuk-ulam",
       "relationship": "foundational",
-      "description": "The Borsuk-Ulam theorem ($f: S^n \\to \\mathbb{R}^n$ has a point with $f(x) = f(-x)$) is another deep result about sphere topology \u2014 both rely on the topological properties of $S^n$ that the Poincar\u00e9 conjecture characterizes"
+      "description": "The Borsuk-Ulam theorem ($f: S^n \\to \\mathbb{R}^n$ has a point with $f(x) = f(-x)$) is another deep result about sphere topology — both rely on the topological properties of $S^n$ that the Poincaré conjecture characterizes"
     },
     {
       "targetId": "navier-stokes",
       "relationship": "thematic",
-      "description": "Both are Clay Millennium Prize Problems \u2014 the Poincar\u00e9 conjecture (solved by Perelman, 2003) and Navier-Stokes existence/smoothness (open) represent the pinnacle of mathematical challenges in topology and PDE theory respectively"
+      "description": "Both are Clay Millennium Prize Problems — the Poincaré conjecture (solved by Perelman, 2003) and Navier-Stokes existence/smoothness (open) represent the pinnacle of mathematical challenges in topology and PDE theory respectively"
     },
     {
       "targetId": "hodge-conjecture",
       "relationship": "thematic",
-      "description": "Another Clay Millennium Prize Problem \u2014 the Hodge conjecture concerns the algebraic topology of complex manifolds, complementing the Poincar\u00e9 conjecture's classification of topological manifolds"
+      "description": "Another Clay Millennium Prize Problem — the Hodge conjecture concerns the algebraic topology of complex manifolds, complementing the Poincaré conjecture's classification of topological manifolds"
     },
     {
       "targetId": "godel-incompleteness",
       "relationship": "thematic",
-      "description": "G\u00f6del's incompleteness theorems constrain what formal systems can prove \u2014 Perelman's proof of the Poincar\u00e9 conjecture was verified in this formalization using axiomatized deep results (Ricci flow, surgery), raising questions about the boundary between verified and axiomatized mathematics"
+      "description": "Gödel's incompleteness theorems constrain what formal systems can prove — Perelman's proof of the Poincaré conjecture was verified in this formalization using axiomatized deep results (Ricci flow, surgery), raising questions about the boundary between verified and axiomatized mathematics"
     }
   ],
   "conclusion": {
-    "summary": "The Poincar\u00e9 Conjecture is SOLVED (Perelman, 2002\u20132003): every simply connected, closed 3-manifold is homeomorphic to S\u00b3. The formalization provides 17302 lines covering 100 parts, with 922 theorems and 36 axioms. Coverage includes Ricci flow, surgery theory, \u03ba-solutions, normal surfaces, taut foliations, Casson invariant, Heegaard Floer homology, the L-space conjecture, contact structures, and computational complexity.",
-    "implications": "Perelman's proof also established Thurston's Geometrization Conjecture, revolutionizing 3-manifold topology. The Ricci flow technique has since been applied to the differentiable sphere theorem (Brendle\u2013Schoen 2009), classification of manifolds with positive isotropic curvature, and the study of K\u00e4hler\u2013Ricci flow in complex geometry.",
+    "summary": "The Poincaré Conjecture is SOLVED (Perelman, 2002–2003): every simply connected, closed 3-manifold is homeomorphic to S³. The formalization provides 17302 lines covering 100 parts, with 922 theorems and 36 axioms. Coverage includes Ricci flow, surgery theory, κ-solutions, normal surfaces, taut foliations, Casson invariant, Heegaard Floer homology, the L-space conjecture, contact structures, and computational complexity.",
+    "implications": "Perelman's proof also established Thurston's Geometrization Conjecture, revolutionizing 3-manifold topology. The Ricci flow technique has since been applied to the differentiable sphere theorem (Brendle–Schoen 2009), classification of manifolds with positive isotropic curvature, and the study of Kähler–Ricci flow in complex geometry.",
     "openQuestions": [
-      "The smooth 4-dimensional Poincar\u00e9 conjecture: is every smooth homotopy 4-sphere diffeomorphic to $S^4$?",
+      "The smooth 4-dimensional Poincaré conjecture: is every smooth homotopy 4-sphere diffeomorphic to $S^4$?",
       "Can Perelman's surgery procedure be made effective/algorithmic for computational topology?",
       "What are the optimal constants in the no-local-collapsing theorem?",
       "Can Ricci flow techniques prove the Borel conjecture for aspherical manifolds?"
@@ -312,35 +300,35 @@
       "title": "The entropy formula for the Ricci flow and its geometric applications",
       "year": "2002",
       "venue": "arXiv:math/0211159",
-      "note": "First of three preprints proving the Poincar\u00e9 conjecture via Ricci flow with surgery \u2014 declined the Fields Medal and Clay Prize"
+      "note": "First of three preprints proving the Poincaré conjecture via Ricci flow with surgery — declined the Fields Medal and Clay Prize"
     },
     {
       "authors": "Morgan, John; Tian, Gang",
-      "title": "Ricci Flow and the Poincar\u00e9 Conjecture",
+      "title": "Ricci Flow and the Poincaré Conjecture",
       "year": "2007",
       "venue": "American Mathematical Society, Clay Mathematics Monographs 3",
-      "note": "Complete detailed verification of Perelman's proof of the Poincar\u00e9 conjecture"
+      "note": "Complete detailed verification of Perelman's proof of the Poincaré conjecture"
     },
     {
       "authors": "Hamilton, Richard S.",
       "title": "Three-manifolds with positive Ricci curvature",
       "year": "1982",
-      "venue": "Journal of Differential Geometry 17(2), 255\u2013306",
-      "note": "Introduced the Ricci flow equation $\\partial g/\\partial t = -2\\text{Ric}(g)$ and proved convergence to constant curvature for positive Ricci 3-manifolds \u2014 the foundation for Perelman's approach"
+      "venue": "Journal of Differential Geometry 17(2), 255–306",
+      "note": "Introduced the Ricci flow equation $\\partial g/\\partial t = -2\\text{Ric}(g)$ and proved convergence to constant curvature for positive Ricci 3-manifolds — the foundation for Perelman's approach"
     },
     {
       "authors": "Smale, Stephen",
-      "title": "Generalized Poincar\u00e9's conjecture in dimensions greater than four",
+      "title": "Generalized Poincaré's conjecture in dimensions greater than four",
       "year": "1961",
-      "venue": "Annals of Mathematics 74(2), 391\u2013406",
-      "note": "Proved the generalized Poincar\u00e9 conjecture for dimensions \u2265 5 using h-cobordism, earning the Fields Medal"
+      "venue": "Annals of Mathematics 74(2), 391–406",
+      "note": "Proved the generalized Poincaré conjecture for dimensions ≥ 5 using h-cobordism, earning the Fields Medal"
     },
     {
       "authors": "Freedman, Michael H.",
       "title": "The topology of four-dimensional manifolds",
       "year": "1982",
-      "venue": "Journal of Differential Geometry 17(3), 357\u2013453",
-      "note": "Proved the topological Poincar\u00e9 conjecture in dimension 4, earning the Fields Medal \u2014 the smooth case remains open"
+      "venue": "Journal of Differential Geometry 17(3), 357–453",
+      "note": "Proved the topological Poincaré conjecture in dimension 4, earning the Fields Medal — the smooth case remains open"
     }
   ],
   "mainTheorems": [
@@ -351,5 +339,14 @@
       "leanType": "SimplyConnected M -> ClosedManifold M -> dim M = 3 -> M homeomorphic S3"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/PoincareConjecture.lean",
+    "lineCount": 17670,
+    "axiomCount": 32,
+    "sorries": 0,
+    "theoremCount": 897,
+    "definitionCount": 365,
+    "lemmaCount": 0
+  }
 }


### PR DESCRIPTION
## Fix

Migrates the `leanFile` metadata from inside the `meta` sub-object to the canonical top-level `leanFile` location for 4 gallery proofs that were missed by PR #11649.

## Evidence

**Before**: `meta.json` files had a `leanFile` object nested inside the `meta` sub-object — the old schema format with no top-level `leanFile`.

**After**: A canonical top-level `leanFile` object exists with the proper schema fields (`path`, `lineCount`, `axiomCount`, `sorries`, `theoremCount`, `definitionCount`, `imports`). The stale `meta.leanFile` field is removed.

## Proofs Fixed (4)

- `inverse-galois` — axiomCount=5, sorries=0 (Hilbert's Inverse Galois Problem)
- `inverse-galois-oq-01` — axiomCount=1, sorries=1  
- `inverse-galois-oq-02` — axiomCount=3, sorries=6
- `poincare-conjecture` — axiomCount=32, sorries=0 (also corrects axiomCount 33→32 to match actual file)

## Why Missed by PR #11649

PR #11649 fixed cases where `meta.leanFile` was a duplicate of an existing top-level `leanFile`. For these 4 files, the data only existed in `meta.leanFile` (no top-level `leanFile`), so they required data migration rather than simple deletion.

---
Automated fix by lean-mechanic agent.