### PR TITLE
Fix: lebesgue-measure-oq-06 build errors — file now compiles with 5 sorries

### DIFF
--- a/proofs/Proofs/LebesgueMeasureOQ06.lean
+++ b/proofs/Proofs/LebesgueMeasureOQ06.lean
@@ -34,7 +34,8 @@ set_option linter.unusedVariables false
 
 namespace BanachTarski
 
-open Set MeasureTheory
+open Set MeasureTheory ENNReal
+open scoped Pointwise NNReal
 
 variable {α : Type*}
 
@@ -60,17 +61,14 @@ def Equidecomposable (G : Type*) [Group G] [MulAction G α]
 notation:50 A " ≃ᴳ[" G "] " B => Equidecomposable G A B
 
 /-- Equidecomposability is reflexive. -/
-theorem equidecomposable_refl (G : Type*) [Group G] [MulAction G α]
-    [MulAction.IsPretransitive G α] (A : Set α) :
+theorem equidecomposable_refl (G : Type*) [Group G] [MulAction G α] (A : Set α) :
     A ≃ᴳ[G] A := by
   refine ⟨1, fun _ => A, fun _ => 1, ?_, ?_, ?_, ?_, ?_⟩
-  · intro; exact le_refl A
-  · intro i j h; exact absurd (Fin.eq_of_val_eq (Nat.lt_one_iff.mp i.isLt ▸
-      Nat.lt_one_iff.mp j.isLt ▸ rfl)) h
-  · simp
-  · simp [one_smul]
-  · intro i j h; exact absurd (Fin.eq_of_val_eq (Nat.lt_one_iff.mp i.isLt ▸
-      Nat.lt_one_iff.mp j.isLt ▸ rfl)) h
+  · intro _; exact le_refl A
+  · intro i j h; exact absurd (Subsingleton.elim i j) h
+  · exact (Set.iUnion_const A).symm
+  · simp only [one_smul, Set.iUnion_const]
+  · intro i j h; exact absurd (Subsingleton.elim i j) h
 
 /-- A set is **G-paradoxical** if it can be decomposed into two disjoint subsets,
     each equidecomposable to the whole set.
@@ -86,6 +84,20 @@ def IsParadoxical (G : Type*) [Group G] [MulAction G α] (A : Set α) : Prop :=
 -- SECTION II: Paradoxical Sets Cannot Be Measured
 -- ============================================================
 
+/-- Helper: in ENNReal, a + a = a implies a = 0 or a = ⊤.
+    Proof: if a ≠ ⊤, lift to ℝ≥0 and cast to ℝ where linarith closes the goal. -/
+private lemma ennreal_add_self_eq_self {a : ℝ≥0∞} (h : a + a = a) :
+    a = 0 ∨ a = ⊤ := by
+  rcases eq_or_ne a ⊤ with rfl | ha
+  · exact Or.inr rfl
+  · left
+    lift a to ℝ≥0 using ha
+    norm_cast at h
+    -- h : a + a = a in ℝ≥0; cast to ℝ where linarith works
+    have h' : (a : ℝ) + a = a := by exact_mod_cast h
+    have ha0_real : (a : ℝ) = 0 := by linarith
+    exact_mod_cast ha0_real
+
 /-- **Key consequence**: If `A` is G-paradoxical, then any G-invariant
     finitely-additive measure on `A` must assign it measure 0 or ∞.
 
@@ -100,56 +112,35 @@ theorem paradoxical_no_finite_measure (G : Type*) [Group G] [MulAction G α]
     (hμ_add : ∀ S T : Set α, Disjoint S T → μ (S ∪ T) = μ S + μ T)
     (hμ_inv : ∀ (g : G) (S : Set α) (hS : S ⊆ A),
       μ (g • S) = μ S)
-    (hμ_equi : ∀ B : Set α, B ⊆ A → A ≃ᴳ[G] B → μ B = μ A) :
+    (hμ_equi : ∀ S : Set α, S ⊆ A → (A ≃ᴳ[G] S) → μ S = μ A) :
     μ A = 0 ∨ μ A = ⊤ := by
   obtain ⟨B, C, hBA, hCA, hBC, hAB, hAC⟩ := hA
-  -- μ(A) = μ(B) + μ(C) since B ⊆ A, C ⊆ A, B ∩ C = ∅
-  -- and A can be covered by B ∪ C ... (for simplicity, use equidecomposability)
   -- μ(A) = μ(B) (by equidecomposability A ≃ B)
   have hμB : μ B = μ A := hμ_equi B hBA hAB
   -- μ(A) = μ(C) (by equidecomposability A ≃ C)
   have hμC : μ C = μ A := hμ_equi C hCA hAC
-  -- μ(B ∪ C) = μ(B) + μ(C) = μ(A) + μ(A) = 2·μ(A)
+  -- μ(B ∪ C) = μ(B) + μ(C) = μ(A) + μ(A)
   have hBCunion : μ (B ∪ C) = μ A + μ A := by
     rw [hμ_add B C hBC, hμB, hμC]
-  -- B ∪ C ⊆ A, so μ(B ∪ C) ≤ μ(A) ... but also B ∪ C = A under equidecomp
-  -- From the equidecomposability structure: B ∪ C ⊆ A
-  -- And the equidecomposability gives μ(A) = μ(B) + μ(C) = 2·μ(A)
-  -- So μ(A) = 2·μ(A) → μ(A) = 0 or ∞
+  -- μ(A) + μ(A) = μ(A) follows from B ∪ C ⊆ A and finite additivity
   have h2 : μ A + μ A = μ A := by
-    -- B ∪ C ⊆ A since hBA : B ⊆ A and hCA : C ⊆ A
     have hBC_sub : B ∪ C ⊆ A := Set.union_subset hBA hCA
-    -- Split A = (B ∪ C) ∪ (A \ (B ∪ C)) and apply finite additivity
-    -- to get μ(A) = μ(B ∪ C) + μ(A \ (B ∪ C)) ≥ μ(B ∪ C)
+    -- A = (B ∪ C) ∪ (A \ (B ∪ C))  (disjoint decomposition)
     have hsplit : μ A = μ (B ∪ C) + μ (A \ (B ∪ C)) := by
       have h := hμ_add (B ∪ C) (A \ (B ∪ C)) disjoint_sdiff_right
-      rw [Set.union_sdiff_of_subset hBC_sub] at h
-      exact h.symm
-    -- μ(A) + μ(A) = μ(B ∪ C) ≤ μ(A)  [monotonicity from splitting]
+      rw [Set.union_diff_cancel hBC_sub] at h
+      exact h
+    -- μ(A) + μ(A) = μ(B ∪ C) ≤ μ(A)
     have hμ_mono : μ A + μ A ≤ μ A := by
       rw [← hBCunion]
       calc μ (B ∪ C)
-          ≤ μ (B ∪ C) + μ (A \ (B ∪ C)) := le_add_right _ _
+          ≤ μ (B ∪ C) + μ (A \ (B ∪ C)) := le_add_right le_rfl
         _ = μ A := hsplit.symm
-    exact le_antisymm hμ_mono (le_add_right _ _)
+    exact le_antisymm hμ_mono (le_add_right le_rfl)
   -- From h2: μ(A) = 0 or μ(A) = ∞
-  rcases ENNReal.eq_zero_or_top_of_add_eq_self h2.symm with h | h
+  rcases ennreal_add_self_eq_self h2 with h | h
   · exact Or.inl h
   · exact Or.inr h
-
-/-- Helper: in ENNReal, a + a = a implies a = 0 or a = ⊤. -/
-private lemma ENNReal.eq_zero_or_top_of_add_eq_self {a : ℝ≥0∞} (h : a + a = a) :
-    a = 0 ∨ a = ⊤ := by
-  by_contra hc
-  push_neg at hc
-  obtain ⟨ha0, hatop⟩ := hc
-  -- a > 0 and a < ∞, so a is a finite positive real
-  lift a to ℝ≥0 using hatop
-  -- In ℝ≥0: a + a = a → a = 0 (contradiction with a > 0)
-  have : (a : ℝ≥0∞) + a = a := h
-  rw [← ENNReal.coe_add, ENNReal.coe_inj] at this
-  have : a = 0 := by linarith [this.symm, add_le_add_right (le_refl a) a]
-  exact ha0 (by simp [this])
 
 -- ============================================================
 -- SECTION III: The Banach-Tarski Paradox (Statement)

--- a/research/problems/lebesgue-measure-oq-06/knowledge.md
+++ b/research/problems/lebesgue-measure-oq-06/knowledge.md
@@ -72,10 +72,50 @@ The Banach-Tarski paradox is equivalent (via Tarski's theorem) to the statement:
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+### Lean 4 Build Fixes (2026-04-23)
+
+The original file had never successfully compiled. Fixed the following issues:
+
+1. **`ℝ≥0∞` notation requires `open ENNReal`**: Added to the `open` statement. Without it,
+   the `∞` symbol fails to parse with "expected token" errors.
+
+2. **Set SMul requires `open scoped Pointwise`**: `g • (Set α)` in the `Equidecomposable`
+   definition and in `IsAmenable` fails without this. Added `open scoped Pointwise NNReal`.
+
+3. **Forward reference bug**: `paradoxical_no_finite_measure` called a private lemma
+   (`ENNReal.eq_zero_or_top_of_add_eq_self`) that was defined AFTER it. Lean 4 doesn't
+   allow forward references. Fixed by moving the helper lemma before its caller.
+
+4. **`Set.union_sdiff_of_subset` → `Set.union_diff_cancel`**: Wrong Lean 4 name.
+   `Set.union_diff_cancel (h : s ⊆ t) : s ∪ (t \ s) = t`.
+
+5. **Notation parsing issue with `A ≃ᴳ[G] B → P`**: The custom notation consumed the `→`
+   and everything after `B` as part of the RHS argument. Fixed by wrapping `(A ≃ᴳ[G] S)`
+   in parentheses in the `hμ_equi` parameter.
+
+6. **`linarith` on ℝ≥0 requires cast to ℝ**: To prove `a = 0` from `a + a = a` in NNReal,
+   must lift to ℝ≥0, `norm_cast`, then cast to ℝ before `linarith`.
+
+7. **`le_add_right` signature in Lean 4 Mathlib**: Takes a proof `h : a ≤ b` as first
+   explicit argument. Use `le_add_right le_rfl` to get `a ≤ a + c`.
+
+8. **`[MulAction.IsPretransitive G α]` is unnecessary** for `equidecomposable_refl`.
+   Removed. Reflexivity proof uses `Subsingleton.elim` for disjointness (since `Fin 1`
+   has exactly one element), and `Set.iUnion_const` + `one_smul` for the union goals.
+
+### Build Status
+File now compiles with exactly 5 intentional `sorry`s:
+- `hausdorff_free_subgroup` (needs explicit rotation matrix freeness proof)
+- `banach_tarski` (needs full 800-line proof via Hausdorff paradox)
+- `banach_tarski_pieces_nonmeasurable` (follows from banach_tarski + measure theory)
+- `int_amenable` (needs Cesàro mean / Banach limit construction)
+- `free_group_not_amenable` (needs paradoxical decomposition of F₂)
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+### `equidecomposable_refl` with `[MulAction.IsPretransitive G α]`
+The original proof tried to use `Fin.eq_of_val_eq` for the disjointness subgoal.
+This is fragile and unnecessarily constrains the signature. `Subsingleton.elim i j`
+directly gives `i = j` for `i j : Fin 1` without needing any extra hypotheses.

--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -20,7 +20,7 @@
     "badge": "wip",
     "sorries": 5,
     "axiomCount": 5,
-    "lineCount": 295,
+    "lineCount": 286,
     "assumptions": "5 sorries encoding axiomatized results: hausdorff_free_subgroup (free subgroup of SO(3)), banach_tarski (main theorem), banach_tarski_pieces_nonmeasurable (non-measurability of pieces), int_amenable (ℤ amenability), free_group_not_amenable (F₂ non-amenability). The main proof requires ~800 lines via free subgroup of SO(3) — beyond this gallery entry's scope. Note: paradoxical_no_finite_measure is fully proved (no sorry).",
     "dateAdded": "2026-04-22",
     "mathlib_version": "4.26.0",
@@ -28,7 +28,7 @@
       "Equidecomposable (G-equidecomposability definition, with group action)",
       "IsParadoxical (paradoxical set definition)",
       "IsAmenable (amenable group definition)",
-      "ENNReal.eq_zero_or_top_of_add_eq_self (proved: a + a = a → a = 0 or a = ⊤)",
+      "ennreal_add_self_eq_self (proved: a + a = a → a = 0 or a = ⊤ in ENNReal)",
       "equidecomposable_refl (proved: every set is self-equidecomposable)",
       "Framework: paradoxical sets have no finite invariant measure (fully proved, no sorry)"
     ]
@@ -191,7 +191,7 @@
   "leanFile": {
     "imports": ["Mathlib"],
     "namespace": "BanachTarski",
-    "lineCount": 295,
+    "lineCount": 286,
     "axiomCount": 5,
     "theoremCount": 7,
     "definitionCount": 5,


### PR DESCRIPTION
## Summary

Fixes 8 build errors in `LebesgueMeasureOQ06.lean` that prevented the Banach-Tarski paradox formalization from ever compiling. The file now builds successfully with exactly 5 intended `sorry`s.

## Fixes Applied

- **`ℝ≥0∞` notation**: Added `open ENNReal` — the `∞` symbol requires this scope
- **Set SMul**: Added `open scoped Pointwise NNReal` for `g • (Set α)` to work in `Equidecomposable` and `IsAmenable`
- **Forward reference**: Moved `ennreal_add_self_eq_self` helper lemma before `paradoxical_no_finite_measure` (Lean 4 forbids forward references)
- **Wrong lemma name**: `Set.union_sdiff_of_subset` → `Set.union_diff_cancel`
- **Notation parsing bug**: `A ≃ᴳ[G] S → P` was parsed as `A ≃ᴳ[G] (S → P)`. Fixed by wrapping: `(A ≃ᴳ[G] S) → P`
- **`linarith` on ℝ≥0**: Must cast to ℝ first via `norm_cast` + `exact_mod_cast` before `linarith` can close the goal
- **`le_add_right` API**: In Lean 4 Mathlib, first argument is a proof `h : a ≤ b`. Use `le_add_right le_rfl` for `a ≤ a + c`
- **Unnecessary constraint**: Removed `[MulAction.IsPretransitive G α]` from `equidecomposable_refl`; `Subsingleton.elim` handles the `Fin 1` disjointness

## Build Result

```
⚠ [7743/7743] Built Proofs.LebesgueMeasureOQ06 (59s)
warning: ...174:8: declaration uses 'sorry'   -- hausdorff_free_subgroup
warning: ...211:8: declaration uses 'sorry'   -- banach_tarski
warning: ...233:8: declaration uses 'sorry'   -- banach_tarski_pieces_nonmeasurable
warning: ...270:8: declaration uses 'sorry'   -- int_amenable
warning: ...275:8: declaration uses 'sorry'   -- free_group_not_amenable
Build completed successfully (7743 jobs).
```

The key infrastructure (`equidecomposable_refl`, `IsParadoxical`, `IsAmenable`, and the full proof of `paradoxical_no_finite_measure`) all compile without sorry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)