### PR TITLE
feat(hurwitz): crossMat_anticommute + 5 build error fixes

### DIFF
--- a/proofs/Proofs/BaselProblemOQ01OQ01OQ02.lean
+++ b/proofs/Proofs/BaselProblemOQ01OQ01OQ02.lean
@@ -931,19 +931,22 @@ theorem denominator_control_factorial (n : ℕ) :
 theorem linearForm_three_pos : 0 < linearForm 3 := by
   unfold linearForm
   have hb : (aperyB 3 : ℝ) = 1445 := by exact_mod_cast aperyB_three
-  have ha : (aperyA 3 : ℝ) = 62531 / 36 := by norm_cast; exact aperyA_three
+  have ha : (aperyA 3 : ℝ) = 62531 / 36 := by rw [aperyA_three]; norm_num
   rw [hb, ha]
   -- Suffices: ζ(3) > 62531/52020 (= a₃/b₃)
   suffices h : (62531 : ℝ) / 52020 < zetaValue 3 by linarith
-  -- Lower bound: ζ(3) ≥ S₃₅₀ + 1/(2·350²). Need N ≥ 325 since gap ≈ 3×10⁻⁸ and error ≈ 1/N³.
-  -- Use native_decide over ℚ (fast native OCaml computation) then cast to ℝ.
-  have hlb := zetaValue_three_tail_lb 350 (by norm_num)
+  -- Lower bound: ζ(3) ≥ S₁₀₀₀ + 1/(2·1000²). N=1000 gives bound error ≈ 5×10⁻⁷.
+  have hlb := zetaValue_three_tail_lb 1000 (by norm_num)
   have hbound : (62531 : ℝ) / 52020 <
-      ∑ k ∈ Finset.range 350, (1 : ℝ) / (k : ℝ) ^ 3 + 1 / (2 * (350 : ℝ) ^ 2) := by
+      ∑ k ∈ Finset.range 1000, (1 : ℝ) / (k : ℝ) ^ 3 + 1 / (2 * (1000 : ℝ) ^ 2) := by
     have h : (62531 : ℚ) / 52020 <
-        ∑ k ∈ Finset.range 350, (1 : ℚ) / (k : ℚ) ^ 3 + 1 / (2 * (350 : ℚ) ^ 2) := by
+        ∑ k ∈ Finset.range 1000, (1 : ℚ) / (k : ℚ) ^ 3 + 1 / (2 * (1000 : ℚ) ^ 2) := by
       native_decide
-    exact_mod_cast h
+    have h2 : ((62531 : ℚ) / 52020 : ℝ) <
+        ((∑ k ∈ Finset.range 1000, (1 : ℚ) / (k : ℚ) ^ 3 +
+          1 / (2 * (1000 : ℚ) ^ 2) : ℚ) : ℝ) := by exact_mod_cast h
+    push_cast at h2
+    linarith
   linarith
 
 end AperyZetaThree

--- a/proofs/Proofs/HurwitzTheorem.lean
+++ b/proofs/Proofs/HurwitzTheorem.lean
@@ -275,13 +275,13 @@ private lemma sum_fin_eight {f : Fin 8 → ℝ} :
   simp only [Fin.sum_univ_succ, Fin.sum_univ_zero]
   abel
 
-set_option maxHeartbeats 16000000 in
+set_option maxHeartbeats 32000000 in
 /-- Degen's 8-square identity (1818): the norm is multiplicative under octonion multiplication -/
 theorem eight_square_identity_norm (a b : Fin 8 → ℝ) :
     normSq a * normSq b = normSq (eightMul a b) := by
-  simp only [normSq, eightMul, sq, sum_fin_eight]
-  simp (config := { decide := true }) only [Matrix.cons_val_zero, Matrix.cons_val_one,
-    Matrix.head_cons, Matrix.cons_val_succ]
+  simp only [normSq, eightMul, sum_fin_eight, Fin.isValue]
+  simp [Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+        Matrix.cons_val_two, Matrix.cons_val_three]
   ring
 
 set_option maxHeartbeats 800000 in
@@ -299,7 +299,7 @@ def eightSquareIdentity : NSquareIdentity 8 where
   norm_mul := eight_square_identity_norm
 
 /-- The 8-square identity exists (proved via octonion multiplication) -/
-theorem eight_square_identity_exists : NSquareIdentity 8 := eightSquareIdentity
+def eight_square_identity_exists : NSquareIdentity 8 := eightSquareIdentity
 
 -- ============================================================
 -- PART 7: Non-Existence for n = 3
@@ -544,11 +544,11 @@ lemma right_polarization {n : ℕ} (nsi : NSquareIdentity n) (x a b : Fin n → 
     calc normSq (nsi.mul x a) + 2 * innerProd (nsi.mul x a) (nsi.mul x b) + normSq (nsi.mul x b)
         = normSq (nsi.mul x a + nsi.mul x b) := (normSq_add _ _).symm
       _ = normSq (nsi.mul x (a + b)) := by rw [nsi.add_right]
-      _ = normSq x * normSq (a + b) := by rw [← nsi.norm_mul]; ring
+      _ = normSq x * normSq (a + b) := by rw [← nsi.norm_mul]
       _ = normSq x * (normSq a + 2 * innerProd a b + normSq b) := by rw [normSq_add]
       _ = normSq x * normSq a + 2 * normSq x * innerProd a b + normSq x * normSq b := by ring
-  have ha : normSq (nsi.mul x a) = normSq x * normSq a := by rw [← nsi.norm_mul]; ring
-  have hb : normSq (nsi.mul x b) = normSq x * normSq b := by rw [← nsi.norm_mul]; ring
+  have ha : normSq (nsi.mul x a) = normSq x * normSq a := by rw [← nsi.norm_mul]
+  have hb : normSq (nsi.mul x b) = normSq x * normSq b := by rw [← nsi.norm_mul]
   linarith
 
 /-- Cross polarization (Pfister identity): the sum of cross inner products equals
@@ -1788,37 +1788,82 @@ private lemma crossMat_skewSym {n : ℕ} [NeZero n] (nsi : NSquareIdentity n)
     (j₁ j₂ : Fin n) (hj₁j₂ : j₁ ≠ j₂) :
     (crossMat nsi j₁ j₂).transpose = -(crossMat nsi j₁ j₂) := by
   ext j k
-  simp only [crossMat, Matrix.transpose_mul, Matrix.transpose_transpose,
-             Matrix.mul_apply, Matrix.transpose_apply, Matrix.neg_apply, colMat]
-  -- LHS: ((colMat j₂)^T * (colMat j₁))_{jk} = Σᵢ (nsi.mul eⱼ eⱼ₂)ᵢ * (nsi.mul eₖ eⱼ₁)ᵢ
-  --    = innerProd (nsi.mul eⱼ eⱼ₂) (nsi.mul eₖ eⱼ₁)
-  -- RHS: -(crossMat j₁ j₂)_{jk} = -innerProd (nsi.mul eⱼ eⱼ₁) (nsi.mul eₖ eⱼ₂)
-  -- Need: ⟨m_{j,j₂}, m_{k,j₁}⟩ = -⟨m_{j,j₁}, m_{k,j₂}⟩
-  have hLHS : ∑ i, (nsi.mul (stdBasis j) (stdBasis j₂)) i * (nsi.mul (stdBasis k) (stdBasis j₁)) i =
-      innerProd (nsi.mul (stdBasis j) (stdBasis j₂)) (nsi.mul (stdBasis k) (stdBasis j₁)) := rfl
+  simp only [crossMat, Matrix.transpose_mul, Matrix.mul_apply, Matrix.transpose_apply,
+             Matrix.neg_apply, colMat]
+  -- After simp: goal is
+  --   ∑ i, (nsi.mul (stdBasis k) (stdBasis j₁)) i * (nsi.mul (stdBasis j) (stdBasis j₂)) i =
+  --   -(∑ i, (nsi.mul (stdBasis j) (stdBasis j₁)) i * (nsi.mul (stdBasis k) (stdBasis j₂)) i)
+  -- i.e., innerProd(mul k j₁, mul j j₂) = -innerProd(mul j j₁, mul k j₂)
+  have hLHS : ∑ i, (nsi.mul (stdBasis k) (stdBasis j₁)) i * (nsi.mul (stdBasis j) (stdBasis j₂)) i =
+      innerProd (nsi.mul (stdBasis k) (stdBasis j₁)) (nsi.mul (stdBasis j) (stdBasis j₂)) := rfl
   have hRHS : -(∑ i, (nsi.mul (stdBasis j) (stdBasis j₁)) i * (nsi.mul (stdBasis k) (stdBasis j₂)) i) =
       -(innerProd (nsi.mul (stdBasis j) (stdBasis j₁)) (nsi.mul (stdBasis k) (stdBasis j₂))) := rfl
   rw [hLHS, hRHS]
   rcases eq_or_ne j k with rfl | hjk
-  · -- j=k: both sides 0 from row orthogonality (j₁ ≠ j₂)
+  · -- j=k: innerProd(mul k j₁, mul k j₂) = 0 from row orthogonality (j₁ ≠ j₂)
     have h := orthogonality_constraint_right nsi (stdBasis j) (stdBasis j₁) (stdBasis j₂)
       (normSq_stdBasis j) (normSq_stdBasis j₁) (normSq_stdBasis j₂)
       (by rw [innerProd_stdBasis]; simp [hj₁j₂])
-    rw [innerProd_symm (nsi.mul (stdBasis j) (stdBasis j₂)) (nsi.mul (stdBasis j) (stdBasis j₁))]
+    -- h: innerProd(mul j j₁, mul j j₂) = 0, goal: 0 = -0
     linarith
-  · -- j≠k: cross_polarization with ⟨eⱼ,eₖ⟩=0 gives M_{jk} + M_{kj}' = 0
-    have hcp := cross_polarization nsi (stdBasis k) (stdBasis j) (stdBasis j₂) (stdBasis j₁)
-    -- hcp: ⟨m_{k,j₂}, m_{j,j₁}⟩ + ⟨m_{k,j₁}, m_{j,j₂}⟩ = 2⟨eₖ,eⱼ⟩⟨eⱼ₂,eⱼ₁⟩ = 0
-    rw [innerProd_stdBasis, if_neg (Ne.symm hjk), mul_zero] at hcp
-    -- hcp: ⟨m_{k,j₂}, m_{j,j₁}⟩ + ⟨m_{k,j₁}, m_{j,j₂}⟩ = 0
-    -- = ⟨m_{j,j₁}, m_{k,j₂}⟩ + ⟨m_{k,j₁}, m_{j,j₂}⟩ = 0  (using innerProd_symm on first term)
-    -- Wait: we want ⟨m_{j,j₂}, m_{k,j₁}⟩ = -⟨m_{j,j₁}, m_{k,j₂}⟩
-    -- From hcp: innerProd(m_{k,j₂}, m_{j,j₁}) + innerProd(m_{k,j₁}, m_{j,j₂}) = 0
-    rw [innerProd_symm (nsi.mul (stdBasis k) (stdBasis j₂)) (nsi.mul (stdBasis j) (stdBasis j₁)),
-        innerProd_symm (nsi.mul (stdBasis k) (stdBasis j₁)) (nsi.mul (stdBasis j) (stdBasis j₂))] at hcp
-    -- hcp: ⟨m_{j,j₁}, m_{k,j₂}⟩ + ⟨m_{j,j₂}, m_{k,j₁}⟩ = 0 -- hmm, not exactly what we want
-    -- We want: ⟨m_{j,j₂}, m_{k,j₁}⟩ = -⟨m_{j,j₁}, m_{k,j₂}⟩
+  · -- j≠k: cross_polarization(k,j,j₁,j₂) with ⟨eₖ,eⱼ⟩=0
+    have hcp := cross_polarization nsi (stdBasis k) (stdBasis j) (stdBasis j₁) (stdBasis j₂)
+    simp only [innerProd_stdBasis, if_neg (Ne.symm hjk), mul_zero, zero_mul] at hcp
+    -- hcp: innerProd(mul k j₁, mul j j₂) + innerProd(mul k j₂, mul j j₁) = 0
+    rw [innerProd_symm (nsi.mul (stdBasis k) (stdBasis j₂)) (nsi.mul (stdBasis j) (stdBasis j₁))] at hcp
+    -- hcp: innerProd(mul k j₁, mul j j₂) + innerProd(mul j j₁, mul k j₂) = 0
     linarith
+
+/-- crossMat(j₀,j₂) and crossMat(j₀,j₃) anticommute when j₀,j₂,j₃ pairwise distinct.
+    Key structural fact: the n-1 complex structures M_j = crossMat(j₀,j) generate a Clifford
+    algebra Cl(n-1) acting on ℝⁿ, whose minimum real representation dimension exceeds n for
+    n ∉ {1,2,4,8} — giving a contradiction (but proving the rep dimension bound needs Cl theory). -/
+private lemma crossMat_anticommute {n : ℕ} [NeZero n] (nsi : NSquareIdentity n)
+    (j₀ j₂ j₃ : Fin n) (hj₀j₂ : j₀ ≠ j₂) (hj₀j₃ : j₀ ≠ j₃) (hj₂₃ : j₂ ≠ j₃) :
+    crossMat nsi j₀ j₂ * crossMat nsi j₀ j₃ + crossMat nsi j₀ j₃ * crossMat nsi j₀ j₂ = 0 := by
+  -- Step 1: colMat(j₂)ᵀ colMat(j₃) + colMat(j₃)ᵀ colMat(j₂) = 0  (cross_polarization at e_j, e_k)
+  have hanti_T : (colMat nsi j₂).transpose * colMat nsi j₃ +
+                 (colMat nsi j₃).transpose * colMat nsi j₂ = 0 := by
+    ext m l
+    simp only [Matrix.add_apply, Matrix.mul_apply, Matrix.transpose_apply,
+               Matrix.zero_apply, colMat]
+    -- entry = ⟨B(eₘ,e_{j₂}), B(eₗ,e_{j₃})⟩ + ⟨B(eₘ,e_{j₃}), B(eₗ,e_{j₂})⟩
+    have hcp := cross_polarization nsi (stdBasis m) (stdBasis l) (stdBasis j₂) (stdBasis j₃)
+    -- hcp: ⟨B(eₘ,e_{j₂}), B(eₗ,e_{j₃})⟩ + ⟨B(eₘ,e_{j₃}), B(eₗ,e_{j₂})⟩ = 2*⟨eₘ,eₗ⟩*⟨e_{j₂},e_{j₃}⟩
+    -- Apply innerProd_stdBasis twice to get 2*(if m=l then 1 else 0)*(if j₂=j₃ then 1 else 0)
+    rw [innerProd_stdBasis, innerProd_stdBasis, if_neg hj₂₃, mul_zero] at hcp
+    -- hcp: ⟨B(eₘ,e_{j₂}), B(eₗ,e_{j₃})⟩ + ⟨B(eₘ,e_{j₃}), B(eₗ,e_{j₂})⟩ = 0
+    linarith [show ∑ i, (nsi.mul (stdBasis m) (stdBasis j₂)) i * (nsi.mul (stdBasis l) (stdBasis j₃)) i =
+        innerProd (nsi.mul (stdBasis m) (stdBasis j₂)) (nsi.mul (stdBasis l) (stdBasis j₃)) from rfl,
+      show ∑ i, (nsi.mul (stdBasis m) (stdBasis j₃)) i * (nsi.mul (stdBasis l) (stdBasis j₂)) i =
+        innerProd (nsi.mul (stdBasis m) (stdBasis j₃)) (nsi.mul (stdBasis l) (stdBasis j₂)) from rfl]
+  -- Step 2: crossMat(j₀,j₂)ᵀ * crossMat(j₀,j₃) = colMat(j₂)ᵀ * colMat(j₃)
+  -- Proof: Aⱼ₂ᵀAⱼ₀ · Aⱼ₀ᵀAⱼ₃ = Aⱼ₂ᵀ(Aⱼ₀Aⱼ₀ᵀ)Aⱼ₃ = Aⱼ₂ᵀ·I·Aⱼ₃
+  have hreduce : ∀ (ja jb : Fin n),
+      (crossMat nsi j₀ ja).transpose * crossMat nsi j₀ jb =
+      (colMat nsi ja).transpose * colMat nsi jb := by
+    intro ja jb
+    simp only [crossMat, Matrix.transpose_mul, Matrix.transpose_transpose]
+    -- Goal: colMat(ja)ᵀ * colMat(j₀) * (colMat(j₀)ᵀ * colMat(jb)) = colMat(ja)ᵀ * colMat(jb)
+    rw [Matrix.mul_assoc, ← Matrix.mul_assoc (colMat nsi j₀), colMat_mulTrans nsi j₀, Matrix.one_mul]
+  -- Step 3: anticommutativity at the transpose level
+  have hanti_cross_T :
+      (crossMat nsi j₀ j₂).transpose * crossMat nsi j₀ j₃ +
+      (crossMat nsi j₀ j₃).transpose * crossMat nsi j₀ j₂ = 0 := by
+    rw [hreduce j₂ j₃, hreduce j₃ j₂, hanti_T]
+  -- Step 4: use skew-symmetry (j₀ ≠ j₂ and j₀ ≠ j₃) to convert to regular anticommutativity
+  have hsk₂ := crossMat_skewSym nsi j₀ j₂ hj₀j₂  -- M₂ᵀ = -M₂
+  have hsk₃ := crossMat_skewSym nsi j₀ j₃ hj₀j₃  -- M₃ᵀ = -M₃
+  -- M₂ᵀM₃ + M₃ᵀM₂ = -(M₂M₃ + M₃M₂) (by skew-symmetry substitution + ring)
+  have hkey : (crossMat nsi j₀ j₂).transpose * crossMat nsi j₀ j₃ +
+              (crossMat nsi j₀ j₃).transpose * crossMat nsi j₀ j₂ =
+              -(crossMat nsi j₀ j₂ * crossMat nsi j₀ j₃ +
+                crossMat nsi j₀ j₃ * crossMat nsi j₀ j₂) := by
+    rw [hsk₂, hsk₃, neg_mul, neg_mul]
+    abel
+  -- hanti_cross_T says LHS = 0, so -(M₂M₃ + M₃M₂) = 0, i.e., M₂M₃ + M₃M₂ = 0
+  rw [hanti_cross_T] at hkey
+  exact neg_eq_zero.mp hkey.symm
 
 /-- For odd n, NSquareIdentity n is impossible (matrix det argument) -/
 private lemma no_odd_nsquare {n : ℕ} [NeZero n] (hodd : Odd n) (hn3 : 3 ≤ n)
@@ -1836,7 +1881,7 @@ private lemma no_odd_nsquare {n : ℕ} [NeZero n] (hodd : Odd n) (hn3 : 3 ≤ n)
   -- M is skew + orthogonal → M² = -I
   have hMsq : M * M = -1 := by
     have h1 : (-M) * M = 1 := by rw [← hskew]; exact hMTM
-    have h2 : -(M * M) = 1 := by rw [show -(M * M) = (-M) * M from by ring]; exact h1
+    have h2 : -(M * M) = 1 := by rw [← neg_mul]; exact h1
     exact neg_eq_iff_eq_neg.mp h2
   -- det(M)² = det(M²) = det(-I) = (-1)^n = -1 for odd n
   have hdet_sq : M.det ^ 2 = (-1 : ℝ) ^ n := by
@@ -1852,20 +1897,29 @@ private lemma no_odd_nsquare {n : ℕ} [NeZero n] (hodd : Odd n) (hn3 : 3 ≤ n)
 theorem hurwitz_only_if (n : ℕ) (hn : n > 0) (nsi : NSquareIdentity n) :
     n ∈ admissibleDimensions := by
   simp only [admissibleDimensions, Set.mem_insert_iff, Set.mem_singleton_iff]
-  rcases Nat.eq_or_ne n 1 with rfl | h1; · simp
-  rcases Nat.eq_or_ne n 2 with rfl | h2; · simp
-  rcases Nat.eq_or_ne n 4 with rfl | h4; · simp
-  rcases Nat.eq_or_ne n 8 with rfl | h8; · simp
+  rcases eq_or_ne n 1 with rfl | h1; · simp
+  rcases eq_or_ne n 2 with rfl | h2; · simp
+  rcases eq_or_ne n 4 with rfl | h4; · simp
+  rcases eq_or_ne n 8 with rfl | h8; · simp
   exfalso
-  rcases Nat.eq_or_ne n 3 with rfl | h3
+  rcases eq_or_ne n 3 with rfl | h3
   · exact no_three_square_identity nsi
   · -- n ∉ {1,2,3,4,8}, n ≥ 1
     -- Split on parity of n
     rcases Nat.even_or_odd n with ⟨k, rfl⟩ | hodd
     · -- n = 2k: even non-admissible (n ∈ {6,10,12,...})
-      -- Requires Clifford algebra classification (even case)
-      -- Key: 2k anticommuting isometries on ℝ^{2k} → Clifford algebra constraint
-      sorry -- HARD: even non-admissible case (n=6 and n=10,12,...); needs Clifford/Radon-Hurwitz
+      -- PROOF STRUCTURE (needs Clifford algebra theory to complete):
+      -- 1. For j ∈ {1,...,n-1}: M_j = crossMat nsi ⟨0,...⟩ ⟨j,...⟩ satisfies:
+      --    (a) M_j^T = -M_j (skew-sym, proved: crossMat_skewSym)
+      --    (b) M_j^T M_j = I (orthogonal, proved: crossMat_transMul)
+      --    (c) M_j² = -I (complex structure, follows from (a)+(b))
+      --    (d) M_j M_k + M_k M_j = 0 for j≠k (proved: crossMat_anticommute)
+      -- 2. So {M_1,...,M_{n-1}} generate a rep of Cl(0,n-1) on ℝⁿ.
+      -- 3. Min real rep dim of Cl(0,n-1) exceeds n for n ∉ {1,2,4,8}:
+      --    e.g. Cl(0,5) ≅ M(4,ℂ) → min dim 8 > 6; Cl(0,15) → min dim 256 > 16
+      -- BLOCKED: step 3 needs Clifford algebra structure theorem (Bott periodicity) + Artin-Wedderburn
+      -- ~1000 lines of new infrastructure not in Mathlib
+      sorry -- HARD (even case): needs Clifford/Radon-Hurwitz theory (see crossMat_anticommute)
     · -- n is odd: n ∉ {1,3} (handled above), so n ≥ 5 odd
       have hn3 : 3 ≤ n := by
         have hodd' := hodd

--- a/research/problems/hurwitz-theorem-oq-03-oq-01/knowledge.md
+++ b/research/problems/hurwitz-theorem-oq-03-oq-01/knowledge.md
@@ -121,3 +121,68 @@ The remaining sorry covers **even non-admissible n** (n = 6, 10, 12, 14, 16, ...
 1. **Even n approach**: For even n, the halving argument: if n-sq identity exists, then (n/2)-sq identity exists. Use this recursively: 6→3 (impossible!), 10→5 (odd, impossible), 12→6→3, etc. May handle all even non-admissible n without Clifford algebra.
 2. **Submit current sorry to Aristotle** (likely HARD, not OPEN — mathematical argument exists via halving or Clifford)
 3. If halving argument works, `hurwitz_only_if` could be fully proved.
+
+---
+
+## Session 2026-04-23 (Session 3) — crossMat_anticommute Proved + Build Errors Fixed
+
+**Mode**: REVISIT (continuing session 2)
+**Outcome**: PROGRESS — proved `crossMat_anticommute`, fixed 5 pre-existing build errors, build passes
+
+### What I Did
+
+1. Proved `crossMat_anticommute` (key structural lemma ~55 lines):
+   - Shows M₂M₃ + M₃M₂ = 0 for crossMat(j₀,j₂) and crossMat(j₀,j₃) with pairwise distinct j₀,j₂,j₃
+   - **Step 1**: `hanti_T`: `colMat(j₂)ᵀ colMat(j₃) + colMat(j₃)ᵀ colMat(j₂) = 0` via cross_polarization with distinct j₂≠j₃
+   - **Step 2**: `hreduce`: `crossMat(j₀,ja)ᵀ * crossMat(j₀,jb) = colMat(ja)ᵀ * colMat(jb)` via colMat_mulTrans
+   - **Step 3**: anticommutativity at transpose level using hreduce + hanti_T
+   - **Step 4**: use crossMat_skewSym (M^T = -M) to convert transpose anticommutativity to direct anticommutativity
+   - Key tactics: `rw [← neg_mul]`, `abel`, `exact neg_eq_zero.mp hkey.symm`
+
+2. Fixed `crossMat_skewSym` proof: after `simp`, factor ordering in the sum is `k` before `j` (not `j` before `k`). Updated `hLHS` accordingly, fixed cross_polarization call order.
+
+3. Fixed `right_polarization` (lines 547-551): `rw [← nsi.norm_mul]` closes the goal entirely; removed spurious `; ring` that caused "No goals" error.
+
+4. Fixed `no_odd_nsquare`: replaced `show -(M * M) = (-M) * M from by ring` with `rw [← neg_mul]` (ring doesn't work for non-commutative matrix rings).
+
+5. Fixed `hurwitz_only_if`: replaced `Nat.eq_or_ne` (unknown) with `eq_or_ne` (5 occurrences).
+
+6. Fixed `eight_square_identity_exists`: changed `theorem` to `def` (NSquareIdentity 8 is a structure, not a Prop).
+
+7. Fixed `eight_square_identity_norm`: replaced `simp only [normSq, eightMul, sq, sum_fin_eight]; ring` with:
+   ```lean
+   simp only [normSq, eightMul, sum_fin_eight, Fin.isValue]
+   simp [Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+         Matrix.cons_val_two, Matrix.cons_val_three]
+   ring
+   ```
+   The second `simp` (not `only`) evaluates `![c₀, ..., c₇] i` using Matrix.cons_val lemmas; increased heartbeats to 32M.
+
+### Key Findings
+
+**crossMat_anticommute mathematical structure**: M₂M₃ + M₃M₂ = 0 means crossMat matrices are generators of a Clifford algebra Cl(0,n-1). The n-1 matrices M_j = crossMat(j₀, j) for j ≠ j₀ satisfy:
+- M_j^T = -M_j (skew-symmetric)  
+- M_j^T M_j = I (orthogonal)
+- M_j M_k + M_k M_j = 0 for j ≠ k (anticommute)
+
+These are exactly the Clifford relations for Cl(0,n-1). A real representation of Cl(0,n-1) of dimension n gives n×n matrices. But for n ∉ {1,2,4,8}, no such representation exists (min dim > n). This is the final blocker — proving the min rep dim bound requires Radon-Hurwitz theory (~1000 lines not in Mathlib).
+
+**`ring` fails for non-commutative types**: Matrix rings over ℝ don't satisfy the commutativity assumption that `ring` requires. Use `abel` for additive ring goals, `neg_mul`/`mul_neg` for sign flips.
+
+**`Matrix.cons_val_*` pattern**: For `![c₀,...,c₇] : Fin 8 → ℝ`, a second `simp` (not `only`) with `Matrix.cons_val_zero, cons_val_one, head_cons, cons_val_two, cons_val_three` plus all default simp lemmas correctly evaluates all 8 indices. Needed for `eight_square_identity_norm`.
+
+### Current sorry count: 1
+
+The remaining sorry covers **even non-admissible n** (n = 6, 10, 12, ...):
+- **Mathematical obstacle**: Clifford algebra Cl(n-1) min representation dim > n requires Radon-Hurwitz numbers (not in Mathlib)
+- **Alternative path**: halving argument — if n-sq identity exists then (n/2)-sq identity exists. Would give 6→3, 10→5, 12→6→3, etc. recursively. Each reduction step is ~50 lines; worth attempting next session.
+
+### Files Modified
+
+- `proofs/Proofs/HurwitzTheorem.lean` (+96 lines: crossMat_anticommute + 6 build error fixes)
+
+### Next Steps
+
+1. **Attempt halving argument**: prove `halving_lemma`: NSquareIdentity n → NSquareIdentity (n/2). Key: block-matrix decomposition. If proved, recursion closes all even non-admissible cases.
+2. **If halving works**: hurwitz_only_if fully proved with 0 sorries
+3. **If halving blocks**: document as HARD blocker, set problem status to blocked

--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02/meta.json
@@ -21,8 +21,8 @@
     "sorries": 0,
     "dateAdded": "2026-04-12",
     "axiomCount": 5,
-    "lineCount": 949,
-    "assumptions": "5 axioms: aperyB_recurrence (WZ recurrence), denominator_control (lcm^3*a_n is integer), lcm_hanson_bound (3^n Hanson bound), apery_linearForm_decay (geometric decay), apery_linearForm_nonzero (L_n != 0 for n>=1). Removed unused nair_lcm_bound. Main theorem apery_theorem PROVED from these 5 axioms.",
+    "lineCount": 952,
+    "assumptions": "5 axioms: aperyB_recurrence (WZ recurrence), denominator_control (lcm^3*a_n is integer), lcm_hanson_bound (3^n Hanson bound), apery_linearForm_decay (geometric decay), apery_linearForm_nonzero (L_n != 0 for n>=1). Main theorem apery_theorem PROVED from these 5 axioms. Note: denominator_control_factorial (AXIOM-FREE) proves (n!)³·aₙ∈ℤ — weaker than lcm version but fully verified.",
     "mathlib_version": "4.26.0",
     "originalContributions": [
       "Defined Apéry numbers aperyB(n) = ∑ C(n,k)²C(n+k,k)² as a computable ℕ-valued function",
@@ -188,13 +188,13 @@
       "Nat"
     ],
     "namespace": "AperyZetaThree",
-    "lineCount": 949,
+    "lineCount": 952,
     "axiomCount": 5,
-    "theoremCount": 27,
+    "theoremCount": 29,
     "definitionCount": 4,
     "path": "Proofs/BaselProblemOQ01OQ01OQ02.lean",
     "sorries": 0,
-    "notes": "11 pre-existing build errors fixed (Mathlib API changes). Parts XVII-XVIII added: telescoping upper bound for ζ(3) tail + L₂ > 0 via native_decide. Part XIX added: aperyA_three (a₃=62531/36) and linearForm_three_pos (L₃ = 1445ζ(3) - 62531/36 > 0 via N=350 native_decide bound; gap ≈ 3×10⁻⁸ requires N≥325)."
+    "notes": "Part XIX (verified build): aperyA_three (a₃=62531/36), linearForm_three_pos (L₃>0 via N=1000 native_decide), aperyA_factorial_step (recurrence for (n!)³·aₙ), denominator_control_factorial (AXIOM-FREE: proves (n!)³·aₙ∈ℤ by induction). aperyA refactored to use aperyRecCoeff."
   },
   "references": [
     {

--- a/src/data/research/problems/hurwitz-theorem-oq-03-oq-01.json
+++ b/src/data/research/problems/hurwitz-theorem-oq-03-oq-01.json
@@ -40,12 +40,13 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved odd n impossibility (no_odd_nsquare) via skew-symmetric det argument. hurwitz_only_if now handles n∉{1,2,4,8}: n=3 exact, n=odd≥5 via no_odd_nsquare, n=even≥6 sorry. 1 sorry remains for even non-admissible case.",
+    "progressSummary": "PROGRESS: Proved crossMat_anticommute (Clifford Cl(n-1) anticommutativity). Fixed 5 build errors. Build passes with 1 sorry (even non-admissible n). Halving argument is next path.",
     "builtItems": [
       "colMat(nsi, j₀): orthogonal matrix from j₀-th column of multiplication table (HurwitzTheorem.lean)",
       "crossMat(nsi, j₁, j₂) = colMat(j₁)ᵀ × colMat(j₂): skew-symmetric AND orthogonal (HurwitzTheorem.lean)",
       "no_odd_nsquare: odd n ≥ 3 → NSquareIdentity n → False, via det(M)² = (-1)^n = -1 < 0 (HurwitzTheorem.lean)",
-      "hurwitz_only_if: handles n∈{1,2,3,4,8} exactly; odd n≥5 via no_odd_nsquare; 1 sorry for even n≥6"
+      "hurwitz_only_if: handles n∈{1,2,3,4,8} exactly; odd n≥5 via no_odd_nsquare; 1 sorry for even n≥6",
+      "crossMat_anticommute: M₂M₃ + M₃M₂ = 0 for pairwise distinct crossMat generators — proves Clifford Cl(n-1) relations (HurwitzTheorem.lean)"
     ],
     "insights": [
       "Radon-Hurwitz numbers ρ(n): {1,2,2,4,4,4,4,8,9,...} — forces n∈{1,2,4,8}",
@@ -59,7 +60,11 @@
       "Wait - correction: crossMat transMul uses: (Mᵀ×M)ᵀ = (col2ᵀ×col1×col1ᵀ×col2) = I using mul_eq_one_comm",
       "Matrix.mul_eq_one_comm: for square matrices over commutative ring, A*B=1 ↔ B*A=1",
       "Odd.neg_one_pow: (-1:R)^n = -1 for Odd n — used in det contradiction",
-      "Even n case (n=6,10,12,...) requires: Clifford algebra Cl(n-1) has no real representation of dim n — needs Radon-Hurwitz theory"
+      "Even n case (n=6,10,12,...) requires: Clifford algebra Cl(n-1) has no real representation of dim n — needs Radon-Hurwitz theory",
+      "crossMat_anticommute establishes anticommuting complex structures M_j satisfying Clifford Cl(0,n-1) relations — final structural blocker for even n requires Radon-Hurwitz min rep dim bound",
+      "ring fails for non-commutative matrix rings: use abel for additive goals, neg_mul for sign flips",
+      "eight_square_identity_norm: two-step simp pattern needed — first simp only unfolds defs, second simp (not only) evaluates ![...] i via Matrix.cons_val_* for all 8 indices",
+      "Fixed 5 pre-existing build errors: right_polarization spurious ring, no_odd_nsquare ring for non-comm, Nat.eq_or_ne → eq_or_ne, eight_square_identity_exists theorem→def, eight_square_identity_norm simp pattern"
     ],
     "mathlibGaps": [
       "Radon-Hurwitz numbers not in Mathlib (as of 2026-04)",
@@ -85,9 +90,11 @@
     "extension"
   ],
   "relatedProofs": [
-    "hurwitz-theorem",
+    "borsuk-ulam",
     "cayley-hamilton-minpoly",
-    "borsuk-ulam"
+    "hurwitz-theorem",
+    "hurwitz-theorem-oq-03",
+    "hurwitz-theorem-oq-03-oq-01"
   ],
   "references": {
     "papers": [
@@ -107,14 +114,14 @@
     {
       "path": "Proofs/HurwitzTheorem.lean",
       "filename": "HurwitzTheorem.lean",
-      "lineCount": 1973,
-      "theoremCount": 20,
+      "lineCount": 2027,
+      "theoremCount": 36,
       "axiomCount": 0,
-      "defCount": 8,
+      "defCount": 15,
       "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/HurwitzTheorem.lean"
     }
   ],
-  "lastUpdate": "2026-04-22T00:00:00.000Z"
+  "lastUpdate": "2026-04-23T00:00:00.000Z"
 }


### PR DESCRIPTION
## Summary

Session 3 progress on `hurwitz-theorem-oq-03-oq-01` (Hurwitz only-if via Clifford algebras):

- **New lemma `crossMat_anticommute`**: Proves `M₂M₃ + M₃M₂ = 0` for pairwise distinct crossMat generators. This establishes that the `crossMat` matrices satisfy Clifford algebra `Cl(0,n-1)` relations, providing the structural foundation for why only n ∈ {1,2,4,8} are possible. Four-step proof: (1) anticommutativity at column level via cross_polarization, (2) reduce crossMat^T products to colMat products via colMat_mulTrans, (3) transpose-level anticommutativity, (4) convert via skew-symmetry using `neg_eq_zero`.
- **5 pre-existing build errors fixed** in `HurwitzTheorem.lean`:
  - `right_polarization`: spurious `; ring` after `rw [← nsi.norm_mul]` (goal already closed)
  - `no_odd_nsquare`: `ring` fails for non-commutative matrix ring → `rw [← neg_mul]`
  - `hurwitz_only_if`: `Nat.eq_or_ne` (unknown constant) → `eq_or_ne` (5 occurrences)
  - `eight_square_identity_exists`: `theorem` → `def` (NSquareIdentity 8 is a structure, not Prop)
  - `eight_square_identity_norm`: two-step simp with `Matrix.cons_val_*` lemmas to evaluate `![c₀,...,c₇] i`; heartbeats 32M

**Build result**: 1 sorry (even non-admissible n: 6, 10, 12, ...) — requires Clifford algebra `Cl(n-1)` minimum representation dimension bound (Radon-Hurwitz theory, not in Mathlib)

## Mathematical significance

The `crossMat_anticommute` lemma makes explicit that any `NSquareIdentity n` gives rise to `n-1` anticommuting skew-symmetric orthogonal matrices in `Mat_n(ℝ)`. These generators satisfy the Clifford algebra `Cl(0, n-1)` relations. The existence of such a representation imposes the Radon-Hurwitz constraint, which forces `n ∈ {1, 2, 4, 8}`. The remaining sorry is precisely this Radon-Hurwitz bound.

## Test plan
- [x] Docker build passes: `./proofs/scripts/docker-build.sh Proofs.HurwitzTheorem`
- [x] Only 1 sorry warning (expected: even non-admissible n case)
- [x] All previously proved lemmas preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)