### PR TITLE
Fix: dissection-of-cubes-oq-02 leanFile.axiomCount undercount

### DIFF
--- a/src/data/proofs/dissection-of-cubes-oq-02/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-02/meta.json
@@ -177,7 +177,7 @@
     ],
     "namespace": "DissectionOfCubesOQ02",
     "lineCount": 379,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 18,
     "definitionCount": 5,
     "opens": [


### PR DESCRIPTION
## Fix

Correct internal field inconsistency in `dissection-of-cubes-oq-02/meta.json`: `leanFile.axiomCount` was 0 but should be 1.

## Evidence

**Before**: `leanFile.axiomCount = 0`, `meta.axiomCount = 1` — mismatch
**After**: `leanFile.axiomCount = 1`, `meta.axiomCount = 1` — consistent

The stub definition `ScissorsCongruent (P Q : Type*) := ∃ (n : ℕ), True` is an assumption-carrying definition. The `meta.axiomCount` and `meta.assumptions` fields already documented it correctly; this fix aligns `leanFile.axiomCount` to match.

Public-facing `status` (`axiomatized`) and `badge` (`axiom`) were already correct — this is an internal field sync only.

Closes #11676

---
Automated fix by lean-mechanic agent.