### PR TITLE
Fix: lebesgue-measure-oq-06 sorry count 5→8, erdos-156 badge axiom→wip

### DIFF
--- a/src/data/proofs/erdos-156/meta.json
+++ b/src/data/proofs/erdos-156/meta.json
@@ -18,7 +18,7 @@
       "additive-combinatorics",
       "extremal-combinatorics"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 3,
     "erdosNumber": 156,
     "erdosUrl": "https://erdosproblems.com/156",

--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -18,10 +18,10 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 8,
     "axiomCount": 5,
     "lineCount": 286,
-    "assumptions": "5 sorries encoding axiomatized results: hausdorff_free_subgroup (free subgroup of SO(3)), banach_tarski (main theorem), banach_tarski_pieces_nonmeasurable (non-measurability of pieces), int_amenable (ℤ amenability), free_group_not_amenable (F₂ non-amenability). The main proof requires ~800 lines via free subgroup of SO(3) — beyond this gallery entry's scope. Note: paradoxical_no_finite_measure is fully proved (no sorry).",
+    "assumptions": "8 sorries: hausdorff_free_subgroup (free subgroup of SO(3)), banach_tarski (main theorem), banach_tarski_pieces_nonmeasurable (non-measurability of pieces), int_amenable (ℤ amenability), W_a_two_cover (W(a) two-cover), W_a_smul_disj (W(a) smul disjointness), W_b_two_cover (W(b) two-cover), W_b_smul_disj (W(b) smul disjointness). The main proof requires ~800 lines via free subgroup of SO(3) — beyond this gallery entry's scope. Note: paradoxical_no_finite_measure and free_group_not_amenable structure are fully proved.",
     "dateAdded": "2026-04-22",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -206,7 +206,7 @@
     "theoremCount": 7,
     "definitionCount": 5,
     "path": "Proofs/LebesgueMeasureOQ06.lean",
-    "sorries": 5
+    "sorries": 8
   },
-  "sorries": 5
+  "sorries": 8
 }


### PR DESCRIPTION
## Summary
- **lebesgue-measure-oq-06**: Lean file has 8 sorries, not 5. The 4 helper lemmas (W_a_two_cover, W_a_smul_disj, W_b_two_cover, W_b_smul_disj) were undercounted.
- **erdos-156**: Has 0 axioms and 3 sorries — badge should be `wip`, not `axiom`.

Replaces stale PRs #11683, #11685, #11686 which had accumulated divergent commits and couldn't be rebased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)