### PR TITLE
Fix: erdos-679 badge 'axiom' → 'wip' (0 axioms, 10 sorries)

### DIFF
--- a/src/data/proofs/erdos-679/meta.json
+++ b/src/data/proofs/erdos-679/meta.json
@@ -17,7 +17,7 @@
       "additive-function",
       "open"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 10,
     "erdosNumber": 679,
     "erdosUrl": "https://erdosproblems.com/679",


### PR DESCRIPTION
## Fix

Change `badge` from `axiom` to `wip` in `src/data/proofs/erdos-679/meta.json`.

## Evidence

**Before**: `badge: "axiom"` — incorrect; axiom badge requires actual `axiom` declarations or structure-encoded assumptions
**After**: `badge: "wip"` — correct; proof has 10 sorries and 0 axioms

Per the badge taxonomy:
- `axiom` → has `axiom` declarations OR structure-encoded assumptions
- `wip` → has sorries remaining, no axioms

The `status: "formalized"` and `axiomCount: 0` fields are correct and unchanged.

Closes #11678

---
Automated fix by lean-mechanic agent.