### PR TITLE
Fix: erdos-679 badge axiom→wip (0 axioms, 10 sorries)

### DIFF
--- a/src/data/proofs/erdos-679/meta.json
+++ b/src/data/proofs/erdos-679/meta.json
@@ -17,7 +17,7 @@
       "additive-function",
       "open"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 10,
     "erdosNumber": 679,
     "erdosUrl": "https://erdosproblems.com/679",


### PR DESCRIPTION
## Fix

`meta.badge` was `"axiom"` but the Lean file (`Proofs/Erdos679Problem.lean`) has **0 axiom declarations** and **10 sorries**.

Per the badge taxonomy:
- `axiom` → has `axiom` declarations OR structure-encoded assumptions
- `wip` → has sorries remaining, no axioms

## Evidence

**Before**: `"badge": "axiom"`, `"status": "formalized"`
**After**: `"badge": "wip"`, `"status": "formalized"` (status already correct)

**Lean file verification**:
- `axiomCount: 0` (from `leanFile` in meta.json)
- `sorries: 10` (10 sorry occurrences)
- No structure-encoded assumptions found

Closes #11678

---
Automated fix by lean-mechanic agent.