### PR TITLE
Seeker: select 3 problems — hypergraph counting, isoperimetric non-Euclidean, p-adic Liouville

### DIFF
--- a/research/problems/isoperimetric-theorem-oq-03/selection-report.md
+++ b/research/problems/isoperimetric-theorem-oq-03/selection-report.md
@@ -1,0 +1,96 @@
+# Problem Selection Report
+
+**Date**: 2026-04-23
+**Mode**: SELECT
+**Pool Status**: 26 available, 557 in-progress, 1408 completed, 3 graduated, 2 blocked
+
+## Selected Problem
+
+- **ID**: isoperimetric-theorem-oq-03
+- **Name**: Isoperimetric Theorem: Best Constants in Non-Euclidean Spaces
+- **Tier**: A
+- **Significance**: 8/10
+- **Tractability**: 4/10
+- **Knowledge Score**: 0 (EMPTY)
+- **Status**: available
+
+## Selection Rationale
+
+1. **Composite score 48** — second among genuinely unselected candidates. The domain
+   (differential geometry / geometric analysis) is the only one of its kind among
+   remaining unselected problems, providing domain diversity for the batch.
+
+2. **A-tier significance** — the isoperimetric problem in non-Euclidean spaces connects
+   Riemannian geometry, comparison theory (Bishop-Gromov, Lévy-Gromov), and optimal
+   transport. The Lévy-Gromov inequality for Ricci-positive manifolds is a deep result
+   from Gromov's 1980 work. A formal statement in Lean 4 would complement the existing
+   `isoperimetric-theorem` and `isoperimetric-theorem-oq-01` gallery proofs.
+
+3. **Clear parent chain** — the gallery already has the Euclidean case and the
+   curved-surface extension. This problem extends to general Riemannian manifolds with
+   curvature bounds. Tractability is 4 because Mathlib lacks full Riemannian geometry
+   infrastructure, but stating the theorem with `sorry` and proving the hyperbolic plane
+   special case partially is achievable.
+
+4. **Domain diversity** — only pure differential geometry / geometric analysis candidate
+   among the remaining 7 unselected problems. Represents an underrepresented area
+   in the research pipeline.
+
+## Rejection Summary
+
+- **Candidates considered**: 7 remaining unselected available problems
+- **Moonshot candidates rejected**: twin-primes-special-oq-01, weak-goldbach-oq-01,
+  sophie-germain-oq-01 (tractability ≤ 2)
+- **szemeredi-full-oq-01**: deferred — third Szemerédi problem would dominate the batch;
+  the Furstenberg ergodic approach is better in a future cycle
+- **Confidence**: medium — the non-Euclidean isoperimetric problem is difficult, but
+  the hyperbolic plane special case via `sinh`/`cosh` identities is tractable
+
+## Related Gallery Proofs
+
+- `isoperimetric-theorem`: Parent Euclidean isoperimetric theorem — 4πA ≤ L² with
+  equality for disks. Area/perimeter formalization infrastructure.
+- `isoperimetric-theorem-oq-01`: Shapes on other surfaces — extends to curved 2-surfaces.
+  Direct predecessor of this non-Euclidean generalization.
+- `triangle-angle-sum-oq-02`: Gauss-Bonnet theorem formalization — angle-sum in curved
+  spaces; relevant infrastructure for Riemannian geometry arguments.
+
+## Suggested First Steps
+
+1. **OBSERVE**: Read `proofs/Proofs/IsoperimetricTheorem.lean` and `IsoperimetricTheoremOQ01`
+   to understand formalization of area, perimeter, and the isoperimetric inequality on
+   curved surfaces. Check what Riemannian geometry Mathlib provides
+   (`Mathlib.Geometry.RiemannianManifold`, `Mathlib.Analysis.InnerProductSpace`).
+
+2. **ORIENT**: Scope to the hyperbolic plane ℍ² first. In ℍ², the isoperimetric
+   inequality is `L² - 4πA ≥ A²` (sharper than Euclidean). Extremal sets are geodesic
+   disks. Survey `Mathlib.Geometry.Hyperbolic` for geodesic ball area/length formulas.
+
+3. **DECIDE**: State the Lévy-Gromov inequality as a `sorry`-bearing theorem and prove
+   the ℍ² specialization by direct computation. Geodesic disk of radius r in ℍ²:
+   area = `4π sinh²(r/2)`, perimeter = `2π sinh(r)`. Then `L² - 4πA` reduces to a
+   `sinh`/`cosh` identity provable by `nlinarith` after unfolding hyperbolic trig
+   definitions.
+
+## Pool Summary After Selection
+
+| Status | Count |
+|--------|-------|
+| Available | 26 |
+| In Progress | 557 |
+| Completed | 1408 |
+| Graduated | 3 |
+| Blocked | 2 |
+
+## Candidate Pool Health
+
+- Pool depth: **adequate** (26 available, threshold=15)
+- Recommendation: Pool healthy.
+- Next refresh recommended: next scheduled cycle (~30 min)
+
+## Initialized
+
+- [x] Research workspace exists (`research/problems/isoperimetric-theorem-oq-03/`)
+- [x] problem.md populated
+- [x] state.md: OBSERVE phase
+- [x] Ready for /researcher

--- a/research/problems/liouville-theorem-oq-04/selection-report.md
+++ b/research/problems/liouville-theorem-oq-04/selection-report.md
@@ -1,0 +1,99 @@
+# Problem Selection Report
+
+**Date**: 2026-04-23
+**Mode**: SELECT
+**Pool Status**: 26 available, 557 in-progress, 1408 completed, 3 graduated, 2 blocked
+
+## Selected Problem
+
+- **ID**: liouville-theorem-oq-04
+- **Name**: Liouville's Theorem: p-adic and Function Field Extensions
+- **Tier**: B
+- **Significance**: 7/10
+- **Tractability**: 4/10
+- **Knowledge Score**: 0 (EMPTY)
+- **Status**: available
+
+## Selection Rationale
+
+1. **Composite score 47** — third among genuinely unselected candidates. Selected for
+   domain diversity: p-adic Diophantine approximation is distinct from any other problem
+   selected in this session.
+
+2. **Concrete Lean infrastructure available** — Mathlib has substantial p-adic machinery:
+   `Padic`, `PadicInt`, `padicNorm`, and the ultrametric property. The archimedean
+   Liouville bound already exists in the gallery. The p-adic analogue requires plugging
+   the minimal polynomial lower bound argument into the non-archimedean norm — a
+   structural parallel to the existing proof, not a new proof idea.
+
+3. **Clear gallery extension** — the parent `liouville-theorem` proves |α - p/q| ≥ c/qⁿ
+   for degree-n algebraic numbers. The p-adic analogue replaces |·| with |·|_p and ℝ
+   with ℚ_p. The essential step (lower-bounding the p-adic norm of a polynomial
+   evaluation via the ultrametric) has the same shape as the archimedean argument.
+
+4. **Function field bonus** — the function field analogue over 𝔽_q(T) often has cleaner
+   proofs due to the function field / number field dictionary. Mathlib's `RatFunc`
+   provides some infrastructure, making this a secondary target if the p-adic case stalls.
+
+## Rejection Summary
+
+- **Candidates considered**: 7 remaining unselected available problems
+- **Moonshot candidates rejected**: twin-primes-special-oq-01, weak-goldbach-oq-01,
+  sophie-germain-oq-01 (tractability ≤ 2)
+- **szemeredi-full-oq-01**: deferred for domain diversity (Szemerédi family already
+  represented in this session)
+- **Confidence**: medium — p-adic Liouville bounds are classical mathematics with a
+  clear proof sketch; the challenge is Lean 4 infrastructure for padicNorm interactions
+  with minimal polynomial evaluations
+
+## Related Gallery Proofs
+
+- `liouville-theorem`: Parent proof — archimedean Liouville inequality and transcendence
+  of Liouville numbers. The proof strategy (polynomial non-zero evaluation lower bound)
+  transfers to the p-adic setting with `padicNorm` replacing `abs`.
+- `minkowski-fundamental-theorem-oq-04` (also selected this session): Uses arithmetic
+  lower-bound arguments in a related number-theoretic context.
+
+## Suggested First Steps
+
+1. **OBSERVE**: Read `proofs/Proofs/LiouvilleTheorem.lean` — find the key lemma that
+   lower-bounds `|f(α) - f(p/q)|` using the minimal polynomial and its derivative.
+   Identify which parts use `Real.norm` vs `abs` and which can be abstracted to a
+   general valued field.
+
+2. **ORIENT**: Survey Mathlib's `padicNorm` API. Key facts needed:
+   - `padicNorm.nonzero`: if x ≠ 0 then padicNorm p x ≠ 0
+   - Ultrametric: `padicNorm p (a + b) ≤ max (padicNorm p a) (padicNorm p b)`
+   - `padicNorm.eq_pow_of_ne_zero`: exact value for rationals
+   State the p-adic Liouville theorem: for α ∈ ℚ_p algebraic of degree n over ℚ,
+   ∃ c > 0, ∀ r ∈ ℚ, ‖α - r‖_p ≥ c / ‖denom(r)‖^n.
+
+3. **DECIDE**: Follow the archimedean proof structure:
+   - Take minimal polynomial f ∈ ℤ[X] of α, degree n
+   - For r = p/q ∈ ℚ near α: `q^n · f(r) ∈ ℤ`, so `|q^n · f(r)|_p` is controlled
+   - The ultrametric forces `|f(α) - f(r)|_p` to bound from above, `f(α) = 0` from below
+   This reduces to `nlinarith`/`norm_num` after identifying the right Mathlib lemmas for
+   `padicNorm` and `minpoly`.
+
+## Pool Summary After Selection
+
+| Status | Count |
+|--------|-------|
+| Available | 26 |
+| In Progress | 557 |
+| Completed | 1408 |
+| Graduated | 3 |
+| Blocked | 2 |
+
+## Candidate Pool Health
+
+- Pool depth: **adequate** (26 available, threshold=15)
+- Recommendation: Pool healthy.
+- Next refresh recommended: next scheduled cycle (~30 min)
+
+## Initialized
+
+- [x] Research workspace exists (`research/problems/liouville-theorem-oq-04/`)
+- [x] problem.md populated
+- [x] state.md: OBSERVE phase
+- [x] Ready for /researcher

--- a/research/problems/szemeredi-counting-oq-02/selection-report.md
+++ b/research/problems/szemeredi-counting-oq-02/selection-report.md
@@ -1,0 +1,94 @@
+# Problem Selection Report
+
+**Date**: 2026-04-23
+**Mode**: SELECT
+**Pool Status**: 26 available, 557 in-progress, 1408 completed, 3 graduated, 2 blocked
+
+## Selected Problem
+
+- **ID**: szemeredi-counting-oq-02
+- **Name**: Szemerédi Regularity: Hypergraph Counting Lemma Formalization
+- **Tier**: A
+- **Significance**: 8/10
+- **Tractability**: 5/10
+- **Knowledge Score**: 0 (EMPTY)
+- **Status**: available
+
+## Selection Rationale
+
+1. **Composite score 58** — highest among unselected candidates in this cycle. All
+   higher-scoring available problems already have selection reports from this session.
+
+2. **Distinct from other Szemerédi selections this session** — `szemeredi-full-oq-02`
+   (density bound) and `szemeredi-regularity-oq-02` (Frieze-Kannan comparison) were
+   selected earlier. The hypergraph counting lemma is a different result: it quantifies
+   copies of a fixed hypergraph F in an ε-regular k-graph. The Nagle-Rödl-Schacht (2006)
+   counting lemma is the core engine of the hypergraph regularity proof of Szemerédi's
+   theorem — it operates at a different level from the regularity lemma itself.
+
+3. **Builds on existing gallery infrastructure** — `szemeredi-hypergraph-core` already
+   defines `SimplicialComplex`, k-graph density, and ε-regularity. The counting lemma
+   is the natural next theorem in this chain. The gap from gallery to this result is
+   non-trivial but well-defined.
+
+4. **A-tier significance** — the NRS counting lemma is a landmark result in extremal
+   combinatorics. A Lean formalization of even the 3-uniform case would be noteworthy
+   and would provide infrastructure for hypergraph Ramsey results.
+
+## Rejection Summary
+
+- **Candidates considered**: 7 remaining unselected available problems in this session
+- **Moonshot candidates rejected** (tractability ≤ 2): twin-primes-special-oq-01,
+  weak-goldbach-oq-01, sophie-germain-oq-01 — famous open conjectures, no tractable
+  entry point for autonomous formalization
+- **szemeredi-full-oq-01**: deferred — higher significance (9/10) but adds a third
+  Szemerédi problem to the session; the Furstenberg ergodic approach is better suited
+  for a future cycle when the hypergraph work is already underway
+- **Confidence**: medium (the hypergraph counting lemma is substantive; a full proof is
+  challenging at tractability 5, but the 3-uniform triangle-copy case is tractable)
+
+## Related Gallery Proofs
+
+- `szemeredi-hypergraph-core`: Parent proof — defines the k-graph regularity apparatus.
+  The counting lemma extends this with the copy-counting theorem.
+- `szemeredi-regularity`: Graph regularity lemma — the 2-uniform precursor.
+- `szemeredi-core`: Core Szemerédi theorem — downstream beneficiary of the counting lemma.
+- `roth-theorem-k3`: Roth's theorem — the 3-AP base case, relevant for the NRS application.
+
+## Suggested First Steps
+
+1. **OBSERVE**: Read `proofs/Proofs/SzemerédiHypergraphCore.lean` to find current
+   definitions of `kGraph`, `kGraphDensity`, `kGraphRegular`. Identify the entry point
+   for formalizing `∃ (F_copies : Finset _), F_copies.card ≈ d^e(F) * ∏|Vᵢ|`.
+
+2. **ORIENT**: Focus on the 3-uniform triangle case. Define "tripartite 3-graph" and
+   "density of a tripartite 3-graph." State the triangle counting lemma: if H is
+   ε-regular with density d on vertex sets V₁, V₂, V₃ with |Vᵢ| = n, then
+   `triangles(H) ∈ ((d³ - f(ε)) * n³, (d³ + f(ε)) * n³)`.
+
+3. **DECIDE**: The proof uses inclusion-exclusion on the bipartite graphs between pairs
+   Vᵢ × Vⱼ. ε-regularity of each pair forces edge counts to concentrate. This may
+   reduce to `Finset.card_sdiff` estimates and integer division bounds.
+
+## Pool Summary After Selection
+
+| Status | Count |
+|--------|-------|
+| Available | 26 |
+| In Progress | 557 |
+| Completed | 1408 |
+| Graduated | 3 |
+| Blocked | 2 |
+
+## Candidate Pool Health
+
+- Pool depth: **adequate** (26 available, threshold=15)
+- Recommendation: Pool healthy. 6 available problems remain after this selection.
+- Next refresh recommended: next scheduled cycle (~30 min)
+
+## Initialized
+
+- [x] Research workspace exists (`research/problems/szemeredi-counting-oq-02/`)
+- [x] problem.md populated
+- [x] state.md: OBSERVE phase
+- [x] Ready for /researcher


### PR DESCRIPTION
## Summary

Seeker batch selection — 2026-04-23 session 2.

- **szemeredi-counting-oq-02**: Hypergraph Counting Lemma (Nagle-Rödl-Schacht 2006) — A-tier, sig=8, tract=5. Natural extension of `szemeredi-hypergraph-core`; tests whether the regularity-to-density inference generalizes from graphs to k-uniform hypergraphs.

- **isoperimetric-theorem-oq-03**: Best Constants in Non-Euclidean Spaces — A-tier, sig=8, tract=4. Lévy-Gromov inequality and ℍ² specialization; domain diversity (differential geometry underrepresented in this session's pool).

- **liouville-theorem-oq-04**: p-adic and Function Field Extensions — B-tier, sig=7, tract=4. Structural parallel to the gallery's archimedean Liouville bound using Mathlib's `padicNorm` ultrametric; p-adic Diophantine approximation not covered elsewhere this session.

## Pool Status

- **Available**: 26 (threshold: 15 — adequate)
- **In Progress**: 557
- **Completed**: 1408
- All 26 available problems now have selection reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)