### PR TITLE
Fix abel-ruffini annotation ranges: correct overlapping Part VI/VII

### DIFF
--- a/src/data/proofs/abel-ruffini/annotations.json
+++ b/src/data/proofs/abel-ruffini/annotations.json
@@ -339,7 +339,7 @@
     "proofId": "abel-ruffini",
     "range": {
       "startLine": 151,
-      "endLine": 183
+      "endLine": 163
     },
     "type": "insight",
     "title": "Part VI: Why Degree 5 Is the Exact Threshold",
@@ -366,8 +366,8 @@
     "id": "ann-part-vii-historical",
     "proofId": "abel-ruffini",
     "range": {
-      "startLine": 151,
-      "endLine": 183
+      "startLine": 164,
+      "endLine": 185
     },
     "type": "context",
     "title": "Part VII: The Impossibility Paradigm and Historical Significance",


### PR DESCRIPTION
## Summary

Fixes a structural bug in `abel-ruffini/annotations.json`: both `ann-part-vi-threshold` and `ann-part-vii-historical` shared the identical range `{startLine: 151, endLine: 183}`, causing both annotations to appear at exactly the same position in the proof viewer.

### Changes

- `ann-part-vi-threshold`: range corrected to `{151-163}` — the actual span of the Part VI comment in the Lean file ("The Threshold at Degree 5")
- `ann-part-vii-historical`: range corrected to `{164-185}` — the actual span of the Part VII comment ("Historical Significance") plus the closing `end AbelRuffini` namespace declaration

The Lean file structure confirms these boundaries:
- Line 163: last line of Part VI comment block (`A₅ has NO proper normal subgroups at all (it is simple), so A₅ is not solvable.`)
- Line 164: `## Part VII: Historical Significance` heading
- Line 185: `end AbelRuffini`

These ranges already match the `sections` array in `meta.json` (threshold: 151-163, historical-significance: 164-185). This commit makes the annotation ranges consistent with the sections metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)