### PR TITLE
Fix: 17 proofs badge 'axiom' → 'wip' (0 axioms, sorries remain)

### DIFF
--- a/src/data/proofs/erdos-1021/meta.json
+++ b/src/data/proofs/erdos-1021/meta.json
@@ -16,7 +16,7 @@
       "turan-type",
       "bipartite-graphs"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 2,
     "erdosNumber": 1021,
     "erdosUrl": "https://erdosproblems.com/1021",

--- a/src/data/proofs/erdos-1100/meta.json
+++ b/src/data/proofs/erdos-1100/meta.json
@@ -15,7 +15,7 @@
       "divisors",
       "coprimality"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 3,
     "erdosNumber": 1100,
     "erdosUrl": "https://erdosproblems.com/1100",

--- a/src/data/proofs/erdos-1168/meta.json
+++ b/src/data/proofs/erdos-1168/meta.json
@@ -19,7 +19,7 @@
     "sourceUrl": "https://erdosproblems.com/1168",
     "erdosUrl": "https://erdosproblems.com/1168",
     "erdosProblemStatus": "open",
-    "badge": "axiom",
+    "badge": "wip",
     "axiomCount": 0,
     "lineCount": 255,
     "theoremCount": 11,

--- a/src/data/proofs/erdos-202/meta.json
+++ b/src/data/proofs/erdos-202/meta.json
@@ -15,7 +15,7 @@
       "covering-systems",
       "combinatorics"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 3,
     "erdosNumber": 202,
     "erdosUrl": "https://erdosproblems.com/202",

--- a/src/data/proofs/erdos-263/meta.json
+++ b/src/data/proofs/erdos-263/meta.json
@@ -16,7 +16,7 @@
       "sequences",
       "analysis"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 4,
     "erdosNumber": 263,
     "erdosUrl": "https://erdosproblems.com/263",

--- a/src/data/proofs/erdos-307/meta.json
+++ b/src/data/proofs/erdos-307/meta.json
@@ -16,7 +16,7 @@
       "egyptian-fractions",
       "reciprocals"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 2,
     "erdosNumber": 307,
     "erdosUrl": "https://erdosproblems.com/307",

--- a/src/data/proofs/erdos-501/meta.json
+++ b/src/data/proofs/erdos-501/meta.json
@@ -16,7 +16,7 @@
       "combinatorics",
       "independence"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 3,
     "erdosNumber": 501,
     "erdosUrl": "https://erdosproblems.com/501",

--- a/src/data/proofs/erdos-552/meta.json
+++ b/src/data/proofs/erdos-552/meta.json
@@ -15,7 +15,7 @@
       "ramsey-theory",
       "combinatorics"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 12,
     "erdosNumber": 552,
     "erdosUrl": "https://erdosproblems.com/552",

--- a/src/data/proofs/erdos-604/meta.json
+++ b/src/data/proofs/erdos-604/meta.json
@@ -16,7 +16,7 @@
       "combinatorial-geometry",
       "open-problem"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 1,
     "erdosNumber": 604,
     "erdosUrl": "https://erdosproblems.com/604",

--- a/src/data/proofs/erdos-609/meta.json
+++ b/src/data/proofs/erdos-609/meta.json
@@ -17,7 +17,7 @@
       "extremal-combinatorics",
       "open-problem"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 16,
     "erdosNumber": 609,
     "erdosUrl": "https://erdosproblems.com/609",

--- a/src/data/proofs/erdos-629/meta.json
+++ b/src/data/proofs/erdos-629/meta.json
@@ -16,7 +16,7 @@
       "list-coloring",
       "bipartite-graphs"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 7,
     "erdosNumber": 629,
     "erdosUrl": "https://erdosproblems.com/629",

--- a/src/data/proofs/erdos-633/meta.json
+++ b/src/data/proofs/erdos-633/meta.json
@@ -17,7 +17,7 @@
       "open-problem",
       "tiling-theory"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 8,
     "erdosNumber": 633,
     "erdosUrl": "https://erdosproblems.com/633",

--- a/src/data/proofs/erdos-660/meta.json
+++ b/src/data/proofs/erdos-660/meta.json
@@ -18,7 +18,7 @@
       "convex-geometry",
       "3D-geometry"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 10,
     "erdosNumber": 660,
     "erdosUrl": "https://erdosproblems.com/660",

--- a/src/data/proofs/erdos-678/meta.json
+++ b/src/data/proofs/erdos-678/meta.json
@@ -16,7 +16,7 @@
       "prime-powers",
       "computational"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 4,
     "erdosNumber": 678,
     "erdosUrl": "https://erdosproblems.com/678",

--- a/src/data/proofs/erdos-736/meta.json
+++ b/src/data/proofs/erdos-736/meta.json
@@ -17,7 +17,7 @@
       "set-theory",
       "independence"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 1,
     "erdosNumber": 736,
     "erdosUrl": "https://erdosproblems.com/736",

--- a/src/data/proofs/erdos-901/meta.json
+++ b/src/data/proofs/erdos-901/meta.json
@@ -36,7 +36,7 @@
       "probabilistic-method",
       "open-problem"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 19,
     "erdosNumber": 901,
     "erdosUrl": "https://erdosproblems.com/901",

--- a/src/data/proofs/erdos-977/meta.json
+++ b/src/data/proofs/erdos-977/meta.json
@@ -15,7 +15,7 @@
       "prime-factors",
       "mersenne"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 23,
     "erdosNumber": 977,
     "erdosUrl": "https://erdosproblems.com/977",

--- a/src/data/proofs/hurwitz-theorem-oq-03/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-03/meta.json
@@ -17,7 +17,7 @@
       "sum-of-squares",
       "hurwitz-theorem"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 1,
     "dateAdded": "2026-04-02",
     "axiomCount": 0,

--- a/src/data/proofs/szemeredi-hypergraph-core-oq-01/meta.json
+++ b/src/data/proofs/szemeredi-hypergraph-core-oq-01/meta.json
@@ -17,7 +17,7 @@
       "advanced"
     ],
     "proofRepoPath": "Proofs/SzemerediHypergraphCoreOQ01.lean",
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 1,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Fix

19 gallery proofs have \`badge: "axiom"\` but contain no axiom declarations (\`axiomCount: 0\`) and have one or more sorry statements. Per the badge taxonomy, \`"wip"\` is the correct badge when sorries remain but no axioms exist.

This is the same class of issue as #11678 (erdos-679), now applied to 19 additional proofs discovered during gallery scan.

## Evidence

**Before**: \`"badge": "axiom"\` — implies axiom declarations exist  
**After**: \`"badge": "wip"\` — correctly reflects sorries-only incomplete state

Badge taxonomy:
- \`axiom\` → has \`axiom\` declarations OR structure-encoded assumptions
- \`wip\` → has sorries remaining, no axioms
- \`verified\`/\`original\` → 0 sorries, 0 axioms

## Proofs Fixed (sorries in parentheses)

| Proof | Sorries |
|-------|---------|
| erdos-977 | 23 |
| erdos-901 | 19 |
| erdos-609 | 16 |
| erdos-552 | 12 |
| erdos-660 | 10 |
| erdos-633 | 8 |
| erdos-629 | 7 |
| erdos-678 | 4 |
| erdos-263 | 4 |
| erdos-501 | 3 |
| erdos-1100 | 3 |
| erdos-202 | 3 |
| erdos-307 | 2 |
| erdos-1021 | 2 |
| erdos-1168 | 2 |
| hurwitz-theorem-oq-03 | 1 |
| erdos-736 | 1 |
| erdos-604 | 1 |
| szemeredi-hypergraph-core-oq-01 | 1 |

All verified: zero \`axiom\` declarations, zero structure-encoded assumptions, all have confirmed \`sorry\` statements in proof code.

---
Automated fix by lean-mechanic agent.