### PR TITLE
Fix: correct axiomCount 0→N for 4 proofs with structure-encoded True assumptions

### DIFF
--- a/src/data/proofs/dissection-of-cubes-oq-01-oq-01/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01-oq-01/meta.json
@@ -46,7 +46,7 @@
       "lower_bound_tight: the lower bound from OQ-01 is exactly achieved"
     ],
     "dateAdded": "2026-04-03",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 328
   },
   "overview": {
@@ -142,7 +142,7 @@
     ],
     "namespace": "DissectionOfCubesOQ01OQ01",
     "lineCount": 328,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 26,
     "definitionCount": 5,
     "path": "Proofs/DissectionOfCubesOQ01OQ01.lean",

--- a/src/data/proofs/hilbert-14-oq-01/meta.json
+++ b/src/data/proofs/hilbert-14-oq-01/meta.json
@@ -18,7 +18,7 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "assumptions": "characterization_summary proves True (main theorem stub). GrosshansSubgroup.quotient_fg := True (struct stub). Real content: Reynolds operator theorems, invariant subring infrastructure.",
     "dateAdded": "2026-03-29",
     "mathlibDependencies": [
@@ -178,7 +178,7 @@
     ],
     "namespace": "Hilbert14.NonReductive",
     "lineCount": 323,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 12,
     "definitionCount": 5,
     "path": "Proofs/Hilbert14NonReductive.lean",

--- a/src/data/proofs/hilbert-22/meta.json
+++ b/src/data/proofs/hilbert-22/meta.json
@@ -44,7 +44,7 @@
     ],
     "dateAdded": "2025-12-29",
     "hilbertNumber": 22,
-    "axiomCount": 0,
+    "axiomCount": 2,
     "lineCount": 305,
     "assumptions": "Structure-encoded assumptions: isDiscrete : True in FuchsianGroup and HyperbolicDomain structures (proper discontinuity condition); def RiemannSurface.IsSimplyConnected : Prop := True (topological connectivity placeholder). The uniformization theorem itself remains in comments. Per CLAUDE.md: structure fields with True are counted as structure-encoded assumptions.",
     "mathlib_version": "4.26.0"
@@ -135,7 +135,7 @@
     "opens": [],
     "namespace": "Hilbert22Uniformization",
     "lineCount": 305,
-    "axiomCount": 0,
+    "axiomCount": 2,
     "sorries": 0,
     "theoremCount": 5,
     "definitionCount": 6,

--- a/src/data/proofs/hilbert-23/meta.json
+++ b/src/data/proofs/hilbert-23/meta.json
@@ -44,7 +44,7 @@
     ],
     "dateAdded": "2025-12-29",
     "hilbertNumber": 23,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 328,
     "assumptions": "Structure-encoded assumption: smooth : True in Lagrangian structure (smoothness condition). euler_lagrange_weak_form and hilbert_23_status were converted to block comments. The calculus_of_variations_active theorem proves only (1:ℕ)+1=2. The Euler-Lagrange equation and Pontryagin maximum principle remain as comment documentation. Classified axiomatized: main variational results are not formalized.",
     "mathlib_version": "4.26.0"
@@ -138,7 +138,7 @@
   "leanFile": {
     "path": "Proofs/Hilbert23CalculusVariations.lean",
     "lineCount": 328,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "sorries": 0,
     "theoremCount": 1,
     "definitionCount": 4


### PR DESCRIPTION
## Fix

Four gallery proofs have `axiomCount=0` despite having structure-encoded mathematical assumptions (`field : True` in Lean structures). Per the CLAUDE.md Axiom Integrity Policy, these count toward `axiomCount`.

## Changes

| Proof | axiomCount | Evidence |
|-------|-----------|---------|
| `hilbert-22` | 0 → **2** | `isDiscrete : True` in `DiscreteGroup` + `FuchsianGroup` structures |
| `hilbert-23` | 0 → **1** | `smooth : True` in `Lagrangian` structure |
| `hilbert-14-oq-01` | 0 → **1** | `quotient_fg : True` in `GrosshansSubgroup` structure |
| `dissection-of-cubes-oq-01-oq-01` | 0 → **1** | `covers_unit_cube : True` in `CubeDissection` (inherited from `DissectionOfCubes.lean`) |

## Policy

From CLAUDE.md:
> `axiomCount` in meta.json must reflect ALL assumptions: `axiom` declarations + assumption-carrying structure fields

These proofs correctly keep `badge=axiom` — they were excluded from the batch badge fix in #11699 for this reason. The `axiomCount=0` was the inaccuracy.

---
Automated fix by lean-mechanic agent.