### PR TITLE
Fix: 24 proofs leanFile.axiomCount undercount (0 vs meta.axiomCount)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03/meta.json
@@ -117,7 +117,7 @@
   "leanFile": {
     "namespace": "AmgmInequalityOQ02OQ03OQ03",
     "lineCount": 66,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 3,
     "definitionCount": 0,
     "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",

--- a/src/data/proofs/amgm-inequality-oq-02-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03/meta.json
@@ -132,7 +132,7 @@
     ],
     "namespace": "AmgmInequalityOQ02OQ03",
     "lineCount": 226,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 7,
     "definitionCount": 1,
     "path": "Proofs/AmgmInequalityOQ02OQ03.lean",

--- a/src/data/proofs/angle-trisection/meta.json
+++ b/src/data/proofs/angle-trisection/meta.json
@@ -99,7 +99,7 @@
     "namespace": "AngleTrisection",
     "lineCount": 383,
     "structureCount": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 23,
     "lemmaCount": 0,
     "defCount": 6,

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-04/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-04/meta.json
@@ -160,7 +160,7 @@
     }
   ],
   "leanFile": {
-    "axiomCount": 0,
+    "axiomCount": 4,
     "lineCount": 251,
     "path": "Proofs/BorsukUlamOQ02OQ01OQ04.lean",
     "sorries": 0

--- a/src/data/proofs/borsuk-ulam-oq-04/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-04/meta.json
@@ -138,7 +138,7 @@
     "opens": [],
     "namespace": "BorsukUlamOQ04",
     "lineCount": 300,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 7,
     "definitionCount": 11,
     "path": "Proofs/BorsukUlamOQ04.lean",

--- a/src/data/proofs/bounded-prime-gaps-oq-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-01/meta.json
@@ -69,7 +69,7 @@
   "leanFile": {
     "namespace": "BoundedPrimeGapsOQ01",
     "lineCount": 438,
-    "axiomCount": 0,
+    "axiomCount": 3,
     "theoremCount": 26,
     "definitionCount": 5,
     "path": "Proofs/BoundedPrimeGapsOQ01.lean",

--- a/src/data/proofs/brouwer-fixed-point-oq-04-oq-02/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-04-oq-02/meta.json
@@ -147,7 +147,7 @@
     ],
     "namespace": "NashBrouwer",
     "lineCount": 519,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "sorries": 0,
     "path": "Proofs/BrouwerFixedPointOQ04OQ02.lean"
   },

--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-03/meta.json
@@ -129,7 +129,7 @@
   "leanFile": {
     "namespace": "CantorDiagonalizationOQ03OQ01OQ03",
     "lineCount": 256,
-    "axiomCount": 0,
+    "axiomCount": 5,
     "theoremCount": 7,
     "definitionCount": 5,
     "path": "Proofs/CantorDiagonalizationOQ03OQ01OQ03.lean",

--- a/src/data/proofs/dissection-of-cubes-oq-01/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01/meta.json
@@ -140,7 +140,7 @@
     ],
     "namespace": "DissectionOfCubesOQ01",
     "lineCount": 274,
-    "axiomCount": 0,
+    "axiomCount": 2,
     "theoremCount": 5,
     "definitionCount": 4,
     "path": "Proofs/DissectionOfCubesOQ01.lean",

--- a/src/data/proofs/erdos-100-oq-02/meta.json
+++ b/src/data/proofs/erdos-100-oq-02/meta.json
@@ -114,7 +114,7 @@
     ],
     "namespace": "Erdos100OQ02",
     "lineCount": 60,
-    "axiomCount": 0,
+    "axiomCount": 2,
     "theoremCount": 2,
     "definitionCount": 0,
     "path": "Proofs/Erdos100OQ02.lean",

--- a/src/data/proofs/erdos-1007-oq-05/meta.json
+++ b/src/data/proofs/erdos-1007-oq-05/meta.json
@@ -133,7 +133,7 @@
     ],
     "namespace": "Erdos1007OQ05",
     "lineCount": 141,
-    "axiomCount": 0,
+    "axiomCount": 4,
     "theoremCount": 4,
     "definitionCount": 0,
     "path": "Proofs/Erdos1007OQ05.lean",

--- a/src/data/proofs/erdos-1014-oq-02/meta.json
+++ b/src/data/proofs/erdos-1014-oq-02/meta.json
@@ -141,7 +141,7 @@
     ],
     "namespace": "Erdos1014OQ02",
     "lineCount": 186,
-    "axiomCount": 0,
+    "axiomCount": 12,
     "theoremCount": 4,
     "definitionCount": 0,
     "substantiveTheoremCount": 4,

--- a/src/data/proofs/erdos-105-oq-05/meta.json
+++ b/src/data/proofs/erdos-105-oq-05/meta.json
@@ -184,7 +184,7 @@
     ],
     "namespace": "Erdos105OQ05",
     "lineCount": 206,
-    "axiomCount": 0,
+    "axiomCount": 3,
     "theoremCount": 4,
     "definitionCount": 9,
     "path": "Proofs/Erdos105OQ05.lean",

--- a/src/data/proofs/erdos-1059-oq-04/meta.json
+++ b/src/data/proofs/erdos-1059-oq-04/meta.json
@@ -64,7 +64,7 @@
   },
   "leanFile": {
     "lineCount": 147,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "note": "axiomCount=0 reflects declarations in this file only; meta.axiomCount=1 counts the inherited axiom from Proofs.Erdos1059OQ01 (density_one_conjecture)",
     "sorries": 0,
     "path": "Proofs/Erdos1059OQ04.lean"

--- a/src/data/proofs/erdos-1155-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-1155-oq-01-oq-01/meta.json
@@ -181,7 +181,7 @@
   "leanFile": {
     "lineCount": 296,
     "path": "Proofs/Erdos1155OQ01OQ01.lean",
-    "axiomCount": 0,
+    "axiomCount": 6,
     "sorries": 0
   },
   "sorries": 0

--- a/src/data/proofs/erdos-1155-oq-01/meta.json
+++ b/src/data/proofs/erdos-1155-oq-01/meta.json
@@ -338,7 +338,7 @@
   "leanFile": {
     "lineCount": 411,
     "structureCount": 0,
-    "axiomCount": 0,
+    "axiomCount": 6,
     "theoremCount": 18,
     "lemmaCount": 0,
     "defCount": 3,

--- a/src/data/proofs/erdos-25/meta.json
+++ b/src/data/proofs/erdos-25/meta.json
@@ -150,7 +150,7 @@
     ],
     "namespace": null,
     "lineCount": 166,
-    "axiomCount": 0,
+    "axiomCount": 3,
     "theoremCount": 7,
     "definitionCount": 6,
     "path": "Proofs/Erdos25Problem.lean",

--- a/src/data/proofs/euler-polyhedral-formula-oq-02-oq-01/meta.json
+++ b/src/data/proofs/euler-polyhedral-formula-oq-02-oq-01/meta.json
@@ -238,7 +238,7 @@
     ],
     "namespace": "SmoothGaussBonnet",
     "lineCount": 786,
-    "axiomCount": 0,
+    "axiomCount": 10,
     "theoremCount": 60,
     "definitionCount": 4,
     "path": "Proofs/EulerPolyhedralOQ02OQ01.lean",

--- a/src/data/proofs/four-color-theorem-oq-02/meta.json
+++ b/src/data/proofs/four-color-theorem-oq-02/meta.json
@@ -94,7 +94,7 @@
     ]
   },
   "leanFile": {
-    "axiomCount": 0,
+    "axiomCount": 2,
     "lineCount": 86,
     "path": "Proofs/FourColorTheoremOQ02.lean",
     "sorries": 0

--- a/src/data/proofs/hilbert-15-oq-02/meta.json
+++ b/src/data/proofs/hilbert-15-oq-02/meta.json
@@ -103,7 +103,7 @@
     "opens": [],
     "namespace": "LRComplexity",
     "lineCount": 506,
-    "axiomCount": 0,
+    "axiomCount": 3,
     "theoremCount": 17,
     "definitionCount": 3,
     "path": "Proofs/Hilbert15OQ02.lean",

--- a/src/data/proofs/law-of-cosines-oq-03/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-03/meta.json
@@ -60,7 +60,7 @@
   "leanFile": {
     "namespace": "HyperbolicLawOfCosines",
     "lineCount": 192,
-    "axiomCount": 0,
+    "axiomCount": 3,
     "theoremCount": 12,
     "definitionCount": 2,
     "path": "Proofs/LawOfCosinesOQ03.lean",

--- a/src/data/proofs/navier-stokes-existence/meta.json
+++ b/src/data/proofs/navier-stokes-existence/meta.json
@@ -265,7 +265,7 @@
     ],
     "namespace": "NavierStokesRegularity",
     "lineCount": 21111,
-    "axiomCount": 0,
+    "axiomCount": 5,
     "theoremCount": 845,
     "definitionCount": 104,
     "path": "Proofs/NavierStokes.lean",

--- a/src/data/proofs/navier-stokes/meta.json
+++ b/src/data/proofs/navier-stokes/meta.json
@@ -337,7 +337,7 @@
   "leanFile": {
     "lineCount": 21111,
     "structureCount": 249,
-    "axiomCount": 0,
+    "axiomCount": 5,
     "theoremCount": 845,
     "lemmaCount": 14,
     "defCount": 104,

--- a/src/data/proofs/shannon-channel-coding-oq-02/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02/meta.json
@@ -174,7 +174,7 @@
     }
   ],
   "leanFile": {
-    "axiomCount": 0,
+    "axiomCount": 4,
     "lineCount": 297,
     "path": "Proofs/ShannonChannelCodingOQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

`leanFile.axiomCount` was 0 for 24 proofs that have inherited or structure-encoded axioms. The `meta.axiomCount` field was already correct. This fix aligns both fields so they agree.

## Evidence

**Before**: `leanFile.axiomCount: 0` — counted only `axiom` declarations in the file itself
**After**: `leanFile.axiomCount: N` — matches `meta.axiomCount` (includes inherited/structure-encoded assumptions)

**Pattern**: Same as the recently-merged fix for `dissection-of-cubes-oq-02` (#11676).

All 24 proofs are correctly `status=axiomatized` / `badge=axiom`. The `meta.axiomCount` field correctly describes inherited axioms or structure-encoded assumptions (e.g., `NSAxioms`, `buDim`, Selberg class). The `leanFile.axiomCount` field was populated by counting only `^axiom ` declarations in the file itself, missing imports.

## Proofs Fixed

| Proof | leanFile.axiomCount | Source of assumptions |
|-------|--------------------|-----------------------|
| angle-trisection | 0→1 | `lindemann_theorem` from PiTranscendental.lean |
| amgm-inequality-oq-02-oq-03 | 0→1 | `newton_log_concavity` inherited |
| amgm-inequality-oq-02-oq-03-oq-03 | 0→1 | `newton_log_concavity` inherited |
| borsuk-ulam-oq-02-oq-01-oq-04 | 0→4 | `buDim` axioms inherited |
| borsuk-ulam-oq-04 | 0→1 | `buDim_two` inherited |
| bounded-prime-gaps-oq-01 | 0→3 | Zhang/Maynard axioms inherited |
| brouwer-fixed-point-oq-04-oq-02 | 0→1 | Sperner axiom inherited |
| cantor-diagonalization-oq-03-oq-01-oq-03 | 0→5 | ClassicalRiceModel assumptions |
| dissection-of-cubes-oq-01 | 0→2 | Scissors-congruence axioms |
| erdos-100-oq-02 | 0→2 | Inherited from parent |
| erdos-1007-oq-05 | 0→4 | Inherited from parent |
| erdos-1014-oq-02 | 0→12 | 12 Ramsey axioms inherited |
| erdos-105-oq-05 | 0→3 | Inherited from parent |
| erdos-1059-oq-04 | 0→1 | Inherited from parent |
| erdos-1155-oq-01 | 0→6 | Selberg class axioms |
| erdos-1155-oq-01-oq-01 | 0→6 | Selberg class axioms |
| erdos-25 | 0→3 | Inherited from parent |
| euler-polyhedral-formula-oq-02-oq-01 | 0→10 | Gauss-Bonnet structure |
| four-color-theorem-oq-02 | 0→2 | Inherited from parent |
| hilbert-15-oq-02 | 0→3 | Inherited from parent |
| law-of-cosines-oq-03 | 0→3 | Inherited from parent |
| navier-stokes | 0→5 | NSAxioms structure (5 hypotheses) |
| navier-stokes-existence | 0→5 | NSAxioms structure (5 hypotheses) |
| shannon-channel-coding-oq-02 | 0→4 | Inherited from parent |

---
Automated fix by lean-mechanic agent.