### PR TITLE
Fix: correct sorry count 2→1 for erdos-476-oq-05

### DIFF
--- a/src/data/proofs/erdos-476-oq-05/meta.json
+++ b/src/data/proofs/erdos-476-oq-05/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-476-oq-05",
   "title": "Erdős #476 OQ5: Vosper's Theorem — Equality Case of Cauchy-Davenport",
   "slug": "erdos-476-oq-05",
-  "description": "Vosper's theorem (1956): if |A+B| = |A|+|B|-1 in Z/pZ with |A|,|B|≥2 and |A+B|<p, then A and B are arithmetic progressions with the same common difference d. Infrastructure fully proved: IsArithmeticProgression definition, singleton/pair AP lemmas, translation invariance, ap_of_near_periodic (backward-shift induction), and vosper_base (|A|=2 case). Full Vosper induction (2 sorries) remains open.",
+  "description": "Vosper's theorem (1956): if |A+B| = |A|+|B|-1 in Z/pZ with |A|,|B|≥2 and |A+B|<p, then A and B are arithmetic progressions with the same common difference d. Infrastructure fully proved: IsArithmeticProgression definition, singleton/pair AP lemmas, translation invariance, ap_of_near_periodic (backward-shift induction), vosper_base (|A|=2 case), and vosper_ap_sdiff_card (AP extension). Full Vosper induction (1 sorry) remains open.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-21",
@@ -18,10 +18,10 @@
       "zmod"
     ],
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 1,
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "assumptions": "2 sorries in vosper theorem: [SORRY 1/2] Case 1 existence (counting argument for removing an element from A) and [SORRY 2/2] AP extension (a₀ adjacent to A' implies A is AP with same difference d). Both ap_of_near_periodic (backward-shift induction) and vosper_base (|A|=2 case) are fully proved. Infrastructure all proved with 0 sorries.",
+    "assumptions": "1 sorry in vosper theorem: [SORRY 1/1] Case 1 existence (counting argument for removing a non-redundant element a₀ from A). ap_of_near_periodic (backward-shift induction), vosper_base (|A|=2 case), and vosper_ap_sdiff_card (AP extension: a₀ adjacent to A' implies A is AP with same difference d) are all fully proved. Infrastructure all proved with 0 sorries.",
     "lineCount": 583,
     "theoremCount": 8,
     "definitionCount": 1,
@@ -33,7 +33,7 @@
       "shift_card_eq: |B.image (·+d)| = |B| via add_right_injective (proved, 0 sorries)",
       "ap_of_near_periodic: B is AP if |B\\(B+d)|=1 (proved — backward-shift induction)",
       "vosper_base: Vosper for |A|=2 (proved — uses ap_of_near_periodic)",
-      "vosper: full Vosper theorem (2 sorries — Case 1 existence and AP extension in induction on |A|)"
+      "vosper: full Vosper theorem (1 sorry — Case 1 existence in induction on |A|; AP extension proved via vosper_ap_sdiff_card)"
     ]
   },
   "overview": {
@@ -56,12 +56,11 @@
     ]
   },
   "conclusion": {
-    "summary": "Infrastructure for Vosper's theorem fully established and mostly proved: IsArithmeticProgression defined, basic AP lemmas proved (singleton, pair, shift, cardinality), ap_of_near_periodic proved (backward-shift induction), vosper_base proved (|A|=2 case). Two sorries remain in the full Vosper induction: Case 1 existence (counting/iterative removal) and AP extension (a₀ adjacent to A' forces A to be AP).",
+    "summary": "Infrastructure for Vosper's theorem fully established and mostly proved: IsArithmeticProgression defined, basic AP lemmas proved (singleton, pair, shift, cardinality), ap_of_near_periodic proved (backward-shift induction), vosper_base proved (|A|=2 case), vosper_ap_sdiff_card proved (AP extension: a₀ adjacent to A' forces A to be AP). One sorry remains in the full Vosper induction: Case 1 existence (counting/iterative removal argument).",
     "implications": "Once ap_of_near_periodic is formalized (the backward-shift induction), the full Vosper theorem follows from standard induction. Vosper's theorem would then complement ZMod.cauchy_davenport in Mathlib, completing the picture of additive structure in Z/pZ.",
     "openQuestions": [
-      "Formalize ap_of_near_periodic: B is an AP if |B \\ (B+d)| = 1 (needs backward-shift induction on |B|)",
+      "Prove Case 1 existence in vosper: find a non-redundant a₀ ∈ A via counting argument or iterative removal",
       "Extend Vosper to the case |A|=1 or |B|=1 (trivial but needs separate statement)",
-      "Prove the full Vosper theorem with the inductive step on |A|",
       "Generalize to other groups: Vosper has analogs in other settings (e.g., non-prime orders with different extremal sets)"
     ]
   },
@@ -111,7 +110,7 @@
       "title": "Vosper's Theorem: Base Case and Full Induction",
       "startLine": 128,
       "endLine": 165,
-      "summary": "vosper_base (|A|=2, inclusion-exclusion → ap_of_near_periodic, fully proved), vosper (strong induction on |A|, 2 sorries: Case 1 existence and AP extension). vosper_base now proved; two specific sub-goals in the induction remain open."
+      "summary": "vosper_base (|A|=2, inclusion-exclusion → ap_of_near_periodic, fully proved), vosper_ap_sdiff_card (AP extension proved), vosper (strong induction on |A|, 1 sorry: Case 1 existence). vosper_base and vosper_ap_sdiff_card now proved; one sub-goal in the induction remains open."
     }
   ],
   "leanFile": {
@@ -121,7 +120,7 @@
     "theoremCount": 8,
     "definitionCount": 1,
     "path": "Proofs/Erdos476OQ05Problem.lean",
-    "sorries": 2
+    "sorries": 1
   },
-  "sorries": 2
+  "sorries": 1
 }


### PR DESCRIPTION
## Summary

- The AP extension sorry (`SORRY 2/2`) in `erdos-476-oq-05` (Vosper's theorem) was resolved in a prior commit by proving `vosper_ap_sdiff_card`
- The Lean file header already says "1 sorry remains" and only one `sorry` tactic exists in the file
- meta.json was not updated and still claimed `"sorries": 2`

## Changes

- `meta.sorries`: 2 → 1
- `leanFile.sorries`: 2 → 1
- Top-level `sorries`: 2 → 1
- `assumptions`: updated to describe only the remaining Case 1 existence sorry
- `originalContributions`: credited `vosper_ap_sdiff_card` as proved
- `conclusion.summary`: updated to reflect 1 remaining sorry
- `sections[vosper-theorem].summary`: updated
- `openQuestions`: removed stale entry about `ap_of_near_periodic` (proved), updated to focus on Case 1 existence

## Test plan

- [ ] Verify `git show HEAD:proofs/Proofs/Erdos476OQ05Problem.lean | grep -c "^.*sorry"` returns 1 (tactical sorry only)
- [ ] Gallery build passes with corrected metadata

---
Discovered and fixed during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)