### PR TITLE
Enrich abel-ruffini-galois-extensions: Bring-Jerrard cross-ref, Index Theorems annotation

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions/annotations.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions/annotations.json
@@ -168,6 +168,18 @@
     "prerequisites": ["Fintype.card", "symmetric group", "alternating group", "decide/native_decide tactics", "Lagrange's theorem"]
   },
   {
+    "id": "arg-index-structure",
+    "proofId": "abel-ruffini-galois-extensions",
+    "range": { "startLine": 349, "endLine": 365 },
+    "type": "technique",
+    "title": "Index and Structure Theorems: Trivial Group Orders and A₅ Instantiation",
+    "content": "Part X collects three short but structurally important results. `card_s0` and `card_s1` verify $|S_0| = 1$ and $|S_1| = 1$ by `decide` — these confirm the trivial group identities used as base cases throughout the file, providing formal anchors for the cardinality computation chain. `a5_not_solvable` is the most significant: it instantiates the general theorem `alternating_not_solvable_of_five_le` at $n = 5$ using `le_rfl` (the reflexivity proof that $5 \\leq 5$). This one-liner bridges the general theorem to the concrete $A_5$ case, making it directly importable by downstream proofs without re-proving the $n \\geq 5$ bound. The three results together serve as an index of named corollaries — a reference layer atop the general theorems, ensuring that the specific groups $S_0$, $S_1$, and $A_5$ have canonically named results for citation.",
+    "mathContext": "$|S_0| = 0! = 1$; $|S_1| = 1! = 1$. Both groups are trivial (unique element). $A_5$ not solvable: direct corollary of $A_n$ not solvable for $n \\geq 5$ (since $5 \\leq 5$). The `le_rfl` tactic supplies the proof of $5 \\leq 5$ without invoking `omega` or arithmetic — the cleanest possible instantiation of a universal bound at its base case.",
+    "significance": "supporting",
+    "relatedConcepts": ["alternating_not_solvable_of_five_le", "Fintype.card", "le_rfl", "trivial group", "a5_not_solvable"],
+    "prerequisites": ["alternating_not_solvable_of_five_le", "decide tactic", "le_rfl", "symmetric group definition"]
+  },
+  {
     "id": "arg-specific-non-solvable",
     "proofId": "abel-ruffini-galois-extensions",
     "range": { "startLine": 366, "endLine": 406 },

--- a/src/data/proofs/abel-ruffini-galois-extensions/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions/meta.json
@@ -121,6 +121,11 @@
       "description": "Finite Groups of Order $< 60$ Are Solvable — $|A_5| = 60$ is the precise boundary: every finite group of order $< 60$ is solvable. This entry proves the p-group chain $\\text{IsPGroup} \\Rightarrow \\text{IsNilpotent} \\Rightarrow \\text{IsSolvable}$, establishing the order-60 threshold that makes $A_5$ the minimal non-solvable example."
     },
     {
+      "targetId": "abel-ruffini-oq-04-oq-07",
+      "relationship": "related",
+      "description": "Bring-Jerrard Reduction: any quintic can be transformed to the canonical form $x^5 + x + t = 0$ via Tschirnhaus substitutions. The resulting Bring radical $\\mathrm{BR}(t)$ — the unique real root — provides a 'closed-form' solution to quintics, but one not expressible by radicals. This is fully consistent with this file's central result: $S_5$ not solvable means no radical tower can express roots of the reduced quintic for generic $t$. The Bring-Jerrard entry and this file together delimit the boundary between 'solvable' and 'transcendental' quintic solutions."
+    },
+    {
       "targetId": "abel-ruffini-oq-04-oq-03",
       "relationship": "related",
       "description": "Galois's Solvability Criterion: a root is solvable by radicals $\\iff$ its Galois group is solvable. This entry proves the forward direction from Mathlib and axiomatizes the reverse (Kummer theory). Complementary to this file's `not_solvable_by_rad_of_not_solvable_galois` (contrapositive form) and the `galois_group_order` result."


### PR DESCRIPTION
Enrichment pass for abel-ruffini-galois-extensions (pass 5). Quality improvements:

**New cross-reference** to `abel-ruffini-oq-04-oq-07` (Bring-Jerrard Reduction):
- Connects the canonical reduced quintic form $x^5 + x + t = 0$ to this file's central result
- Explains that the Bring radical $\mathrm{BR}(t)$ is a non-radical solution, fully consistent with $S_5$ non-solvability
- Completes the picture of the Abel-Ruffini story: the boundary between radical and transcendental quintic solutions

**New annotation** `arg-index-structure` for lines 349–365 (Part X: Index and Structure Theorems):
- Covers `card_s0`, `card_s1`, and `a5_not_solvable`
- Explains the `le_rfl` instantiation pattern used to specialize `alternating_not_solvable_of_five_le` at $n=5$
- Documents the role of the named corollaries as a reference layer over the general theorems