### PR TITLE
Audit fix: correct sorry count 1→2 for erdos-476-oq-05

### DIFF
--- a/src/data/proofs/erdos-476-oq-05/meta.json
+++ b/src/data/proofs/erdos-476-oq-05/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-476-oq-05",
   "title": "Erdős #476 OQ5: Vosper's Theorem — Equality Case of Cauchy-Davenport",
   "slug": "erdos-476-oq-05",
-  "description": "Vosper's theorem (1956): if |A+B| = |A|+|B|-1 in Z/pZ with |A|,|B|≥2 and |A+B|<p, then A and B are arithmetic progressions with the same common difference d. Infrastructure fully proved: IsArithmeticProgression definition, singleton/pair AP lemmas, translation invariance, ap_of_near_periodic (backward-shift induction), vosper_base (|A|=2 case), and vosper_ap_sdiff_card (AP extension). Full Vosper induction (1 sorry) remains open.",
+  "description": "Vosper's theorem (1956): if |A+B| = |A|+|B|-1 in Z/pZ with |A|,|B|≥2 and |A+B|<p, then A and B are arithmetic progressions with the same common difference d. Infrastructure largely proved: IsArithmeticProgression definition, singleton/pair AP lemmas, translation invariance, ap_of_near_periodic (backward-shift induction), vosper_base (|A|=2 case). Two sorries remain: position analysis in vosper_ap_sdiff_card and Case 1 existence in the full Vosper induction.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-21",
@@ -18,10 +18,10 @@
       "zmod"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 2,
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "assumptions": "1 sorry in vosper theorem: [SORRY 1/1] Case 1 existence (counting argument for removing a non-redundant element a₀ from A). ap_of_near_periodic (backward-shift induction), vosper_base (|A|=2 case), and vosper_ap_sdiff_card (AP extension: a₀ adjacent to A' implies A is AP with same difference d) are all fully proved. Infrastructure all proved with 0 sorries.",
+    "assumptions": "2 sorries remain: [SORRY 1/2] vosper_ap_sdiff_card position analysis — given |{a₀}+B \\ (A'+B)| = 1 with both APs of difference d, prove a₀ = a₁-d or a₀ = a₁+|A'|*d. [SORRY 2/2] vosper Case 1 existence — counting argument to find a non-redundant a₀ ∈ A. ap_of_near_periodic (backward-shift induction), vosper_base (|A|=2 case), and all infrastructure lemmas are fully proved with 0 sorries.",
     "lineCount": 583,
     "theoremCount": 8,
     "definitionCount": 1,
@@ -33,7 +33,8 @@
       "shift_card_eq: |B.image (·+d)| = |B| via add_right_injective (proved, 0 sorries)",
       "ap_of_near_periodic: B is AP if |B\\(B+d)|=1 (proved — backward-shift induction)",
       "vosper_base: Vosper for |A|=2 (proved — uses ap_of_near_periodic)",
-      "vosper: full Vosper theorem (1 sorry — Case 1 existence in induction on |A|; AP extension proved via vosper_ap_sdiff_card)"
+      "vosper_ap_sdiff_card: AP extension helper — if |{a₀}+B \\ (A'+B)| = 1 then A is AP with diff d (1 sorry: position analysis)",
+      "vosper: full Vosper theorem (1 sorry — Case 1 existence in strong induction on |A|)"
     ]
   },
   "overview": {
@@ -56,9 +57,10 @@
     ]
   },
   "conclusion": {
-    "summary": "Infrastructure for Vosper's theorem fully established and mostly proved: IsArithmeticProgression defined, basic AP lemmas proved (singleton, pair, shift, cardinality), ap_of_near_periodic proved (backward-shift induction), vosper_base proved (|A|=2 case), vosper_ap_sdiff_card proved (AP extension: a₀ adjacent to A' forces A to be AP). One sorry remains in the full Vosper induction: Case 1 existence (counting/iterative removal argument).",
+    "summary": "Infrastructure for Vosper's theorem fully established and mostly proved: IsArithmeticProgression defined, basic AP lemmas proved (singleton, pair, shift, cardinality), ap_of_near_periodic proved (backward-shift induction), vosper_base proved (|A|=2 case). Two sorries remain in the full Vosper induction: Case 1 existence (counting/iterative removal) and AP extension (a₀ adjacent to A' forces A to be AP).",
     "implications": "Once ap_of_near_periodic is formalized (the backward-shift induction), the full Vosper theorem follows from standard induction. Vosper's theorem would then complement ZMod.cauchy_davenport in Mathlib, completing the picture of additive structure in Z/pZ.",
     "openQuestions": [
+      "Prove position analysis in vosper_ap_sdiff_card: from |{a₀}+B \\ (A'+B)| = 1 with both APs of difference d, show a₀ = a₁-d or a₀ = a₁+|A'|*d",
       "Prove Case 1 existence in vosper: find a non-redundant a₀ ∈ A via counting argument or iterative removal",
       "Extend Vosper to the case |A|=1 or |B|=1 (trivial but needs separate statement)",
       "Generalize to other groups: Vosper has analogs in other settings (e.g., non-prime orders with different extremal sets)"
@@ -110,7 +112,7 @@
       "title": "Vosper's Theorem: Base Case and Full Induction",
       "startLine": 128,
       "endLine": 165,
-      "summary": "vosper_base (|A|=2, inclusion-exclusion → ap_of_near_periodic, fully proved), vosper_ap_sdiff_card (AP extension proved), vosper (strong induction on |A|, 1 sorry: Case 1 existence). vosper_base and vosper_ap_sdiff_card now proved; one sub-goal in the induction remains open."
+      "summary": "vosper_base (|A|=2, inclusion-exclusion → ap_of_near_periodic, fully proved), vosper_ap_sdiff_card (AP extension helper, 1 sorry: position analysis — a₀ predecessor or successor of A'), vosper (strong induction on |A|, 1 sorry: Case 1 existence). Two open sub-goals across these two theorems."
     }
   ],
   "leanFile": {
@@ -120,7 +122,7 @@
     "theoremCount": 8,
     "definitionCount": 1,
     "path": "Proofs/Erdos476OQ05Problem.lean",
-    "sorries": 1
+    "sorries": 2
   },
-  "sorries": 1
+  "sorries": 2
 }


### PR DESCRIPTION
## Summary

- `vosper_ap_sdiff_card` has an open sorry at line 248 (position analysis: proving a₀ is predecessor or successor of AP A')
- Previous audit commit 04b74475 incorrectly marked `vosper_ap_sdiff_card` as fully proved and set sorry count to 1
- Lean source (`Erdos476OQ05Problem.lean`) actually has **2 sorries**:
  - `[SORRY 1/2]` `vosper_ap_sdiff_card` line 248: position analysis (geometric argument from two APs with same difference)
  - `[SORRY 2/2]` `vosper` line 553: Case 1 existence (counting/iterative removal)

## Changes

- `meta.sorries`: 1 → 2
- `leanFile.sorries`: 1 → 2  
- `sorries` (top-level): 1 → 2
- Updated `assumptions` to accurately identify both sorry locations
- Updated `originalContributions` to list `vosper_ap_sdiff_card` separately with its sorry
- Updated `conclusion.summary` and `openQuestions` to reflect both open goals
- Updated section summary for `vosper-theorem`

## Verification

```bash
git show HEAD:proofs/Proofs/Erdos476OQ05Problem.lean | grep -n "^  sorry\|^    sorry\|^      sorry"
# Line 248:     sorry -- HARD: position analysis
# Line 553:       sorry -- [SORRY 1/2] Case 1 existence
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)