### PR TITLE
Fix: correct badge for 68 axiomatized proofs (mathlib/original → axiom)

### DIFF
--- a/src/data/proofs/erdos-1/meta.json
+++ b/src/data/proofs/erdos-1/meta.json
@@ -15,7 +15,7 @@
       "subset-sums",
       "extremal-combinatorics"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1,
     "erdosUrl": "https://erdosproblems.com/1",

--- a/src/data/proofs/erdos-1002-oq-01/meta.json
+++ b/src/data/proofs/erdos-1002-oq-01/meta.json
@@ -16,7 +16,7 @@
       "distribution-functions",
       "axiom-elimination"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1002,
     "erdosUrl": "https://erdosproblems.com/1002",

--- a/src/data/proofs/erdos-1009-oq-02/meta.json
+++ b/src/data/proofs/erdos-1009-oq-02/meta.json
@@ -19,7 +19,7 @@
       "open",
       "extremal-combinatorics"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1009,
     "erdosUrl": "https://erdosproblems.com/1009",

--- a/src/data/proofs/erdos-1022-oq-01/meta.json
+++ b/src/data/proofs/erdos-1022-oq-01/meta.json
@@ -15,7 +15,7 @@
       "Property B",
       "open question"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1022,
     "erdosUrl": "https://erdosproblems.com/1022",

--- a/src/data/proofs/erdos-1035/meta.json
+++ b/src/data/proofs/erdos-1035/meta.json
@@ -15,7 +15,7 @@
       "extremal-graph-theory",
       "minimum-degree"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1035,
     "erdosUrl": "https://erdosproblems.com/1035",

--- a/src/data/proofs/erdos-104/meta.json
+++ b/src/data/proofs/erdos-104/meta.json
@@ -16,7 +16,7 @@
       "unit-circles",
       "open-problem"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 104,
     "erdosUrl": "https://erdosproblems.com/104",

--- a/src/data/proofs/erdos-1059-oq-03/meta.json
+++ b/src/data/proofs/erdos-1059-oq-03/meta.json
@@ -15,7 +15,7 @@
       "factorials",
       "computational"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1059,
     "erdosUrl": "https://erdosproblems.com/1059",

--- a/src/data/proofs/erdos-1059-oq-05/meta.json
+++ b/src/data/proofs/erdos-1059-oq-05/meta.json
@@ -17,7 +17,7 @@
       "automation",
       "tactics"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1059,
     "erdosUrl": "https://erdosproblems.com/1059",

--- a/src/data/proofs/erdos-1061/meta.json
+++ b/src/data/proofs/erdos-1061/meta.json
@@ -16,7 +16,7 @@
       "asymptotic-analysis",
       "open-problem"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1061,
     "erdosUrl": "https://erdosproblems.com/1061",

--- a/src/data/proofs/erdos-1073/meta.json
+++ b/src/data/proofs/erdos-1073/meta.json
@@ -16,7 +16,7 @@
       "divisibility",
       "wilson-theorem"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1073,
     "erdosUrl": "https://erdosproblems.com/1073",

--- a/src/data/proofs/erdos-1094/meta.json
+++ b/src/data/proofs/erdos-1094/meta.json
@@ -14,7 +14,7 @@
       "binomial-coefficients",
       "prime-factorization"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1094,
     "erdosUrl": "https://erdosproblems.com/1094",

--- a/src/data/proofs/erdos-1095-oq-01/meta.json
+++ b/src/data/proofs/erdos-1095-oq-01/meta.json
@@ -16,7 +16,7 @@
       "smooth-numbers",
       "asymptotics"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1095,
     "erdosUrl": "https://erdosproblems.com/1095",

--- a/src/data/proofs/erdos-1097-oq-01/meta.json
+++ b/src/data/proofs/erdos-1097-oq-01/meta.json
@@ -15,7 +15,7 @@
       "k-AP",
       "open question"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1097,
     "erdosUrl": "https://erdosproblems.com/1097",

--- a/src/data/proofs/erdos-1098-oq-04/meta.json
+++ b/src/data/proofs/erdos-1098-oq-04/meta.json
@@ -18,7 +18,7 @@
       "commuting-probability",
       "open"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1098,
     "erdosUrl": "https://erdosproblems.com/1098",

--- a/src/data/proofs/erdos-1142/meta.json
+++ b/src/data/proofs/erdos-1142/meta.json
@@ -13,7 +13,7 @@
       "number-theory",
       "open"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1142,
     "erdosUrl": "https://erdosproblems.com/1142",

--- a/src/data/proofs/erdos-130-wip-01/meta.json
+++ b/src/data/proofs/erdos-130-wip-01/meta.json
@@ -16,7 +16,7 @@
       "finiteness",
       "algebraic-geometry"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 130,
     "erdosUrl": "https://erdosproblems.com/130",

--- a/src/data/proofs/erdos-142/meta.json
+++ b/src/data/proofs/erdos-142/meta.json
@@ -7,7 +7,7 @@
     "erdosNumber": 142,
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos142Problem.lean",
-    "badge": "mathlib",
+    "badge": "axiom",
     "erdosProblemStatus": "open",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-152-oq-01/meta.json
+++ b/src/data/proofs/erdos-152-oq-01/meta.json
@@ -15,7 +15,7 @@
       "sumsets",
       "isolated elements"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 152,
     "erdosUrl": "https://erdosproblems.com/152",

--- a/src/data/proofs/erdos-152/meta.json
+++ b/src/data/proofs/erdos-152/meta.json
@@ -14,7 +14,7 @@
       "sidon-sets",
       "sumsets"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 152,
     "erdosUrl": "https://erdosproblems.com/152",

--- a/src/data/proofs/erdos-18/meta.json
+++ b/src/data/proofs/erdos-18/meta.json
@@ -16,7 +16,7 @@
       "divisor-sums",
       "open-problem"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 18,
     "erdosUrl": "https://erdosproblems.com/18",

--- a/src/data/proofs/erdos-203/meta.json
+++ b/src/data/proofs/erdos-203/meta.json
@@ -16,7 +16,7 @@
       "sierpinski",
       "open"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 203,
     "erdosUrl": "https://erdosproblems.com/203",

--- a/src/data/proofs/erdos-208/meta.json
+++ b/src/data/proofs/erdos-208/meta.json
@@ -16,7 +16,7 @@
       "gaps",
       "open-problem"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 208,
     "erdosUrl": "https://erdosproblems.com/208",

--- a/src/data/proofs/erdos-249-oq-01/meta.json
+++ b/src/data/proofs/erdos-249-oq-01/meta.json
@@ -17,7 +17,7 @@
       "bounds",
       "open"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 249,
     "erdosUrl": "https://erdosproblems.com/249",

--- a/src/data/proofs/erdos-249/meta.json
+++ b/src/data/proofs/erdos-249/meta.json
@@ -16,7 +16,7 @@
       "series",
       "open"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 249,
     "erdosUrl": "https://erdosproblems.com/249",

--- a/src/data/proofs/erdos-273/meta.json
+++ b/src/data/proofs/erdos-273/meta.json
@@ -16,7 +16,7 @@
       "modular-arithmetic",
       "combinatorial-number-theory"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 273,
     "erdosUrl": "https://erdosproblems.com/273",

--- a/src/data/proofs/erdos-278/meta.json
+++ b/src/data/proofs/erdos-278/meta.json
@@ -16,7 +16,7 @@
       "density",
       "open"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 278,
     "erdosUrl": "https://erdosproblems.com/278",

--- a/src/data/proofs/erdos-30/meta.json
+++ b/src/data/proofs/erdos-30/meta.json
@@ -16,7 +16,7 @@
       "sidon-sets",
       "b2-sequences"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 30,
     "erdosUrl": "https://erdosproblems.com/30",

--- a/src/data/proofs/erdos-301/meta.json
+++ b/src/data/proofs/erdos-301/meta.json
@@ -15,7 +15,7 @@
       "extremal-combinatorics",
       "egyptian-fractions"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 301,
     "erdosUrl": "https://erdosproblems.com/301",

--- a/src/data/proofs/erdos-317/meta.json
+++ b/src/data/proofs/erdos-317/meta.json
@@ -16,7 +16,7 @@
       "diophantine-approximation",
       "open-problem"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 317,
     "erdosUrl": "https://erdosproblems.com/317",

--- a/src/data/proofs/erdos-327-oq-01/meta.json
+++ b/src/data/proofs/erdos-327-oq-01/meta.json
@@ -15,7 +15,7 @@
       "divisibility",
       "open question"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 327,
     "erdosUrl": "https://erdosproblems.com/327",

--- a/src/data/proofs/erdos-340/meta.json
+++ b/src/data/proofs/erdos-340/meta.json
@@ -16,7 +16,7 @@
       "greedy-algorithms",
       "open"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 340,
     "erdosUrl": "https://erdosproblems.com/340",

--- a/src/data/proofs/erdos-341/meta.json
+++ b/src/data/proofs/erdos-341/meta.json
@@ -16,7 +16,7 @@
       "periodicity",
       "open"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 341,
     "erdosUrl": "https://erdosproblems.com/341",

--- a/src/data/proofs/erdos-352/meta.json
+++ b/src/data/proofs/erdos-352/meta.json
@@ -16,7 +16,7 @@
       "lebesgue-measure",
       "convexity"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 352,
     "erdosUrl": "https://erdosproblems.com/352",

--- a/src/data/proofs/erdos-358/meta.json
+++ b/src/data/proofs/erdos-358/meta.json
@@ -16,7 +16,7 @@
       "primes",
       "open"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 358,
     "erdosUrl": "https://erdosproblems.com/358",

--- a/src/data/proofs/erdos-366/meta.json
+++ b/src/data/proofs/erdos-366/meta.json
@@ -17,7 +17,7 @@
       "consecutive-integers",
       "open-problem"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 366,
     "erdosUrl": "https://erdosproblems.com/366",

--- a/src/data/proofs/erdos-373/meta.json
+++ b/src/data/proofs/erdos-373/meta.json
@@ -16,7 +16,7 @@
       "diophantine-equations",
       "abc-conjecture"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 373,
     "erdosUrl": "https://erdosproblems.com/373",

--- a/src/data/proofs/erdos-374/meta.json
+++ b/src/data/proofs/erdos-374/meta.json
@@ -15,7 +15,7 @@
       "perfect-squares",
       "open"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 374,
     "erdosUrl": "https://erdosproblems.com/374",

--- a/src/data/proofs/erdos-389/meta.json
+++ b/src/data/proofs/erdos-389/meta.json
@@ -15,7 +15,7 @@
       "consecutive integers",
       "products"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 389,
     "erdosUrl": "https://erdosproblems.com/389",

--- a/src/data/proofs/erdos-409/meta.json
+++ b/src/data/proofs/erdos-409/meta.json
@@ -16,7 +16,7 @@
       "primes",
       "dynamical-systems"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 409,
     "erdosUrl": "https://erdosproblems.com/409",

--- a/src/data/proofs/erdos-412/meta.json
+++ b/src/data/proofs/erdos-412/meta.json
@@ -18,7 +18,7 @@
       "open",
       "dynamical-systems"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 412,
     "erdosUrl": "https://erdosproblems.com/412",

--- a/src/data/proofs/erdos-432/meta.json
+++ b/src/data/proofs/erdos-432/meta.json
@@ -18,7 +18,7 @@
       "density",
       "open"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/432",
     "erdosUrl": "https://erdosproblems.com/432",

--- a/src/data/proofs/erdos-458/meta.json
+++ b/src/data/proofs/erdos-458/meta.json
@@ -16,7 +16,7 @@
       "primes",
       "open-problem"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 458,
     "erdosUrl": "https://erdosproblems.com/458",

--- a/src/data/proofs/erdos-463/meta.json
+++ b/src/data/proofs/erdos-463/meta.json
@@ -18,7 +18,7 @@
       "rough-numbers",
       "sieve-theory"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 463,
     "erdosUrl": "https://erdosproblems.com/463",

--- a/src/data/proofs/erdos-468/meta.json
+++ b/src/data/proofs/erdos-468/meta.json
@@ -15,7 +15,7 @@
       "partial-sums",
       "combinatorial-number-theory"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 468,
     "erdosUrl": "https://erdosproblems.com/468",

--- a/src/data/proofs/erdos-488/meta.json
+++ b/src/data/proofs/erdos-488/meta.json
@@ -15,7 +15,7 @@
       "density",
       "inclusion-exclusion"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 488,
     "erdosUrl": "https://erdosproblems.com/488",

--- a/src/data/proofs/erdos-50/meta.json
+++ b/src/data/proofs/erdos-50/meta.json
@@ -17,7 +17,7 @@
       "singular-functions",
       "measure-theory"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 50,
     "erdosUrl": "https://erdosproblems.com/50",

--- a/src/data/proofs/erdos-51/meta.json
+++ b/src/data/proofs/erdos-51/meta.json
@@ -17,7 +17,7 @@
       "carmichael-conjecture",
       "open"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 51,
     "erdosUrl": "https://erdosproblems.com/51",

--- a/src/data/proofs/erdos-520/meta.json
+++ b/src/data/proofs/erdos-520/meta.json
@@ -16,7 +16,7 @@
       "random-multiplicative-functions",
       "law-of-iterated-logarithm"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 520,
     "erdosUrl": "https://erdosproblems.com/520",

--- a/src/data/proofs/erdos-539/meta.json
+++ b/src/data/proofs/erdos-539/meta.json
@@ -17,7 +17,7 @@
       "additive-combinatorics",
       "open"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 539,
     "erdosUrl": "https://erdosproblems.com/539",

--- a/src/data/proofs/erdos-563/meta.json
+++ b/src/data/proofs/erdos-563/meta.json
@@ -15,7 +15,7 @@
       "probabilistic method",
       "edge coloring"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 563,
     "erdosUrl": "https://erdosproblems.com/563",

--- a/src/data/proofs/erdos-602/meta.json
+++ b/src/data/proofs/erdos-602/meta.json
@@ -17,7 +17,7 @@
       "infinite-sets",
       "open"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 602,
     "erdosUrl": "https://erdosproblems.com/602",

--- a/src/data/proofs/erdos-638/meta.json
+++ b/src/data/proofs/erdos-638/meta.json
@@ -15,7 +15,7 @@
       "infinite combinatorics",
       "cardinals"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 638,
     "erdosUrl": "https://erdosproblems.com/638",

--- a/src/data/proofs/erdos-663/meta.json
+++ b/src/data/proofs/erdos-663/meta.json
@@ -15,7 +15,7 @@
       "consecutive-products",
       "asymptotic-bounds"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 663,
     "erdosUrl": "https://erdosproblems.com/663",

--- a/src/data/proofs/erdos-681/meta.json
+++ b/src/data/proofs/erdos-681/meta.json
@@ -15,7 +15,7 @@
       "least-prime-factor",
       "composites"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 681,
     "erdosUrl": "https://erdosproblems.com/681",

--- a/src/data/proofs/erdos-686/meta.json
+++ b/src/data/proofs/erdos-686/meta.json
@@ -17,7 +17,7 @@
       "binomials",
       "open-problem"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 686,
     "erdosUrl": "https://erdosproblems.com/686",

--- a/src/data/proofs/erdos-70-oq-01/meta.json
+++ b/src/data/proofs/erdos-70-oq-01/meta.json
@@ -18,7 +18,7 @@
       "research",
       "open-problem"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 240,

--- a/src/data/proofs/erdos-701/meta.json
+++ b/src/data/proofs/erdos-701/meta.json
@@ -15,7 +15,7 @@
       "intersecting-families",
       "extremal-set-theory"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 701,
     "erdosUrl": "https://erdosproblems.com/701",

--- a/src/data/proofs/erdos-757/meta.json
+++ b/src/data/proofs/erdos-757/meta.json
@@ -16,7 +16,7 @@
       "additive-combinatorics",
       "extremal-combinatorics"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 757,
     "erdosUrl": "https://erdosproblems.com/757",

--- a/src/data/proofs/erdos-770/meta.json
+++ b/src/data/proofs/erdos-770/meta.json
@@ -14,7 +14,7 @@
       "coprimality",
       "open"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/770",
     "erdosUrl": "https://erdosproblems.com/770",

--- a/src/data/proofs/erdos-828/meta.json
+++ b/src/data/proofs/erdos-828/meta.json
@@ -17,7 +17,7 @@
       "lehmer-conjecture",
       "open"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 828,
     "erdosUrl": "https://erdosproblems.com/828",

--- a/src/data/proofs/erdos-831/meta.json
+++ b/src/data/proofs/erdos-831/meta.json
@@ -15,7 +15,7 @@
       "extremal-geometry",
       "open-problem"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 831,
     "erdosUrl": "https://erdosproblems.com/831",

--- a/src/data/proofs/erdos-856/meta.json
+++ b/src/data/proofs/erdos-856/meta.json
@@ -17,7 +17,7 @@
       "sunflower-conjecture",
       "open"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 856,
     "erdosUrl": "https://erdosproblems.com/856",

--- a/src/data/proofs/erdos-885/meta.json
+++ b/src/data/proofs/erdos-885/meta.json
@@ -16,7 +16,7 @@
       "divisors",
       "combinatorics"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 885,
     "erdosUrl": "https://erdosproblems.com/885",

--- a/src/data/proofs/erdos-897/meta.json
+++ b/src/data/proofs/erdos-897/meta.json
@@ -16,7 +16,7 @@
       "analytic-number-theory",
       "arithmetic-functions"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 897,
     "erdosUrl": "https://erdosproblems.com/897",

--- a/src/data/proofs/erdos-919/meta.json
+++ b/src/data/proofs/erdos-919/meta.json
@@ -16,7 +16,7 @@
       "ordinals",
       "infinite-combinatorics"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 919,
     "erdosUrl": "https://erdosproblems.com/919",

--- a/src/data/proofs/erdos-935/meta.json
+++ b/src/data/proofs/erdos-935/meta.json
@@ -14,7 +14,7 @@
       "powerful-numbers",
       "consecutive-products"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 935,
     "erdosUrl": "https://erdosproblems.com/935",

--- a/src/data/proofs/erdos-944/meta.json
+++ b/src/data/proofs/erdos-944/meta.json
@@ -16,7 +16,7 @@
       "critical-graphs",
       "vertex-critical"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 944,
     "erdosUrl": "https://erdosproblems.com/944",

--- a/src/data/proofs/erdos-951/meta.json
+++ b/src/data/proofs/erdos-951/meta.json
@@ -18,7 +18,7 @@
       "prime-counting",
       "open"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 951,
     "erdosUrl": "https://erdosproblems.com/951",


### PR DESCRIPTION
## Fix

68 gallery proofs had `status=axiomatized` but incorrect badge (`mathlib` or `original`). Per CLAUDE.md Axiom Integrity Policy, `status=axiomatized` always maps to `badge=axiom`.

## Evidence

**badge=mathlib + status=axiomatized (55 proofs):**
- `badge=mathlib` implies the core result was derived from a Mathlib theorem
- For open conjectures (`axiomatized`), the main result is an open question — `mathlib` overstates what is proved

**badge=original + status=axiomatized (13 proofs):**
- `badge=original` implies fully machine-checked with no assumptions (0 sorries, 0 axioms)
- `status=axiomatized` directly contradicts this — it means the proof has stated assumptions
- Per CLAUDE.md: "verified: badge original or verified ... Requirements: 0 sorries, 0 axiom declarations, 0 structure-encoded assumptions"

**Before**: `badge: "mathlib"` or `badge: "original"`, `status: "axiomatized"`
**After**: `badge: "axiom"`, `status: "axiomatized"`

This is the same class of issue as erdos-369 (fixed in #11718). Note: erdos-369 excluded from this batch (already in #11718).

## Proofs Fixed (68 total)

| Old Badge | Count | Sample proofs |
|-----------|-------|---------------|
| `mathlib` | 55 | erdos-1, erdos-104, erdos-142, erdos-18, erdos-50, erdos-51, ... |
| `original` | 13 | erdos-278, erdos-341, erdos-686, erdos-757, erdos-831, ... |

See commit message for full list.

---
Automated fix by lean-mechanic agent.