### PR TITLE
Fix: sync stale lineCount in 4 gallery meta.json files

### DIFF
--- a/src/data/proofs/brouwer-fixed-point-oq-04/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-04/meta.json
@@ -53,7 +53,7 @@
     ],
     "historicalContext": "Shizuo Kakutani (1941) proved this generalization of Brouwer's theorem. John Nash (1950) used it to prove the existence of Nash equilibria, earning the Nobel Prize in Economics (1994). The theorem is essential in mathematical economics (Arrow-Debreu general equilibrium) and optimal control (Filippov's lemma).",
     "axiomCount": 2,
-    "lineCount": 473,
+    "lineCount": 505,
     "assumptions": "2 axioms: kakutani_fixed_point_axiom (Kakutani fixed-point theorem for compact convex sets in ℝⁿ) and brouwer_pi_compact_convex (Brouwer FPT for products of compact convex sets — requires Schoenflies-type theorem not yet in Mathlib). 0 sorries."
   },
   "overview": {
@@ -204,7 +204,7 @@
       "Filter"
     ],
     "namespace": "KakutaniFPT",
-    "lineCount": 473,
+    "lineCount": 505,
     "axiomCount": 2,
     "theoremCount": 22,
     "definitionCount": 15,

--- a/src/data/proofs/hurwitz-theorem-oq-03/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-03/meta.json
@@ -22,7 +22,7 @@
     "dateAdded": "2026-04-02",
     "axiomCount": 0,
     "assumptions": "1 sorry: hurwitz_only_if — if an n-square identity exists, then n ∈ {1,2,4,8} (n=3 case proved; n∉{1,2,3,4,8} cases pending Clifford/Radon-Hurwitz argument). The converse (identities exist for n ∈ {1,2,4,8}) is fully proved. No axiom declarations.",
-    "lineCount": 1973,
+    "lineCount": 2027,
     "theoremCount": 32,
     "definitionCount": 15,
     "originalContributions": [
@@ -67,7 +67,7 @@
   },
   "leanFile": {
     "namespace": "HurwitzTheorem",
-    "lineCount": 1973,
+    "lineCount": 2027,
     "axiomCount": 0,
     "theoremCount": 33,
     "definitionCount": 15,

--- a/src/data/proofs/hurwitz-theorem/meta.json
+++ b/src/data/proofs/hurwitz-theorem/meta.json
@@ -45,7 +45,7 @@
     ],
     "dateAdded": "2025-12-26",
     "axiomCount": 0,
-    "lineCount": 1973,
+    "lineCount": 2027,
     "assumptions": "1 sorry: hurwitz_only_if — general non-existence for n ∉ {1,2,3,4,8} (n=3 case proved; remaining cases need Clifford/Radon-Hurwitz argument). The 8-square identity (octonions) is fully proved. No axiom declarations.",
     "mathlib_version": "4.26.0"
   },
@@ -277,7 +277,7 @@
     ],
     "opens": [],
     "namespace": "HurwitzTheorem",
-    "lineCount": 1973,
+    "lineCount": 2027,
     "axiomCount": 0,
     "theoremCount": 33,
     "definitionCount": 15,

--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 8,
     "axiomCount": 5,
-    "lineCount": 286,
+    "lineCount": 419,
     "assumptions": "8 sorries: hausdorff_free_subgroup (free subgroup of SO(3)), banach_tarski (main theorem), banach_tarski_pieces_nonmeasurable (non-measurability of pieces), int_amenable (ℤ amenability), W_a_two_cover (W(a) two-cover), W_a_smul_disj (W(a) smul disjointness), W_b_two_cover (W(b) two-cover), W_b_smul_disj (W(b) smul disjointness). The main proof requires ~800 lines via free subgroup of SO(3) — beyond this gallery entry's scope. Note: paradoxical_no_finite_measure and free_group_not_amenable structure are fully proved.",
     "dateAdded": "2026-04-22",
     "mathlib_version": "4.26.0",
@@ -201,7 +201,7 @@
       "Mathlib"
     ],
     "namespace": "BanachTarski",
-    "lineCount": 286,
+    "lineCount": 419,
     "axiomCount": 5,
     "theoremCount": 7,
     "definitionCount": 5,


### PR DESCRIPTION
## Fix

Syncs stale `lineCount` field in 4 gallery `meta.json` files where the Lean source files grew after the metadata was last recorded.

## Evidence

| Proof | Old lineCount | Actual lineCount | Diff |
|-------|--------------|-----------------|------|
| lebesgue-measure-oq-06 | 286 | 419 | +133 |
| hurwitz-theorem | 1973 | 2027 | +54 |
| hurwitz-theorem-oq-03 | 1973 | 2027 | +54 |
| brouwer-fixed-point-oq-04 | 473 | 505 | +32 |

**Before**: `lineCount` values recorded when proofs were smaller
**After**: `lineCount` matches current Lean file lengths

Re-applies the lineCount fix from the conflicting PR #11728 for the proofs where staleness persists on main.

---
Automated fix by lean-mechanic agent.