### PR TITLE
Fix: sync stale leanFile.lineCount in 2 gallery meta.json files

### DIFF
--- a/src/data/proofs/poincare-conjecture/meta.json
+++ b/src/data/proofs/poincare-conjecture/meta.json
@@ -342,7 +342,7 @@
   "sorries": 0,
   "leanFile": {
     "path": "Proofs/PoincareConjecture.lean",
-    "lineCount": 17670,
+    "lineCount": 17675,
     "axiomCount": 32,
     "sorries": 0,
     "theoremCount": 897,

--- a/src/data/proofs/sperner-ndim-oq-04/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-04/meta.json
@@ -249,7 +249,7 @@
       "BigOperators"
     ],
     "namespace": "SpernerNDimOQ04",
-    "lineCount": 437,
+    "lineCount": 496,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 5,


### PR DESCRIPTION
## Fix

2 proofs had stale `leanFile.lineCount` values that did not match the actual Lean source file lengths.

## Evidence

| Proof | Stored | Actual |
|-------|--------|--------|
| `sperner-ndim-oq-04` | 437 | 496 |
| `poincare-conjecture` | 17670 | 17675 |

**Before**: `leanFile.lineCount` did not match `wc -l` on the source file
**After**: `leanFile.lineCount` matches actual file length

## Context

Continuing the lineCount audit from PR #11736 (which fixed 4 proofs). These 2 were not covered by that PR.

---
Automated fix by lean-mechanic agent.