### PR TITLE
Fix: correct badge verified→wip for 2 axiomatized proofs (0 axioms, 0 sorries)

### DIFF
--- a/src/data/proofs/erdos-1092/meta.json
+++ b/src/data/proofs/erdos-1092/meta.json
@@ -15,7 +15,7 @@
       "extremal-graph-theory",
       "open"
     ],
-    "badge": "verified",
+    "badge": "wip",
     "sorries": 0,
     "erdosNumber": 1092,
     "erdosUrl": "https://erdosproblems.com/1092",

--- a/src/data/proofs/erdos-875/meta.json
+++ b/src/data/proofs/erdos-875/meta.json
@@ -17,7 +17,7 @@
       "binary-representation",
       "popcount"
     ],
-    "badge": "verified",
+    "badge": "wip",
     "sorries": 0,
     "erdosNumber": 875,
     "erdosUrl": "https://erdosproblems.com/875",


### PR DESCRIPTION
## Fix

2 proofs had `badge='verified'` but `status='axiomatized'` — inconsistent because `verified` requires `status=verified`. Both are open conjectures (axiomatized) with 0 axiom declarations and 0 sorries, so the correct badge is `wip`.

## Evidence

| Proof | Old Badge | Correct Badge | Reason |
|-------|-----------|---------------|--------|
| `erdos-875` | `verified` | `wip` | status=axiomatized (Deshouillers-Erdős admissible sequence problem, open) |
| `erdos-1092` | `verified` | `wip` | status=axiomatized (Chromatic decomposition threshold, open) |

**Before**: `badge=verified`, `status=axiomatized`, `axiomCount=0`, `sorries=0`
**After**: `badge=wip`, `status=axiomatized` (unchanged), `axiomCount=0`, `sorries=0`

## Context

`badge=verified` is only valid when `status=verified`. Both these proofs are open mathematical conjectures formalized as `status=axiomatized`. The supporting lemmas are fully proved (0 sorries, 0 axioms) but the main open conjectures are not. This is the same fix pattern as PRs #11699, #11700, and #11737.

---
Automated fix by lean-mechanic agent.