### PR TITLE
Research: sqrt2-minpoly-oq-01 — general theorem for all ¬IsSquare n

### DIFF
--- a/proofs/Proofs/Sqrt2MinpolyOQ01.lean
+++ b/proofs/Proofs/Sqrt2MinpolyOQ01.lean
@@ -19,12 +19,8 @@ This Eisenstein condition at p is satisfied for:
 - All squarefree n ≥ 2 (n = 2, 3, 5, 6, 7, 10, 11, ...)
 - Any n = p^(2k+1) · m where m has a squarefree prime factor
 
-## Key Insight
-
-The proof bridges two representations of the square root:
-  `Real.sqrt n = (n : ℝ) ^ ((1 : ℝ) / 2)`
-via `Real.sqrt_eq_rpow`, then applies the general `minpoly_nthRoot_eq`
-theorem (from CubeRoot2IrrationalOQ03) with degree 2.
+**General case (Part VII)**: The identity holds for ALL non-perfect-squares n,
+covering cases where Eisenstein fails (e.g. n = 8 = 2³, n = 27 = 3³).
 
 ## Status: 0 sorries, 0 axioms
 -/
@@ -132,5 +128,125 @@ theorem minpoly_sqrt_twelve : minpoly ℚ (Real.sqrt 12) = X ^ 2 - C 12 :=
 /-- √20: minpoly ℚ (√20) = X² - 20  (p=5: 5|20 but 25∤20) -/
 theorem minpoly_sqrt_twenty : minpoly ℚ (Real.sqrt 20) = X ^ 2 - C 20 :=
   minpoly_sqrt_of_sqfree_factor 20 5 (by norm_num) (by norm_num) (by norm_num) (by norm_num)
+
+/-! ## Part VII: General Case — All Non-Perfect-Square Natural Numbers
+
+The Eisenstein condition (p | n but p² ∤ n) is strictly weaker than ¬IsSquare n.
+Example: n = 8 = 2³ satisfies ¬IsSquare 8 (√8 = 2√2 is irrational), but
+4 | 8, so no Eisenstein prime exists.
+
+Strategy:
+1. Irrational (Real.sqrt n) when ¬IsSquare n (via irrational_nrt_of_notint_nrt)
+2. Irrationality → minpoly degree ≥ 2 (degree 1 would force Real.sqrt n ∈ ℚ)
+3. minpoly | X² - n → degree ≤ 2
+4. Both monic degree 2 with minpoly | X²-n → equal
+-/
+
+/-- If n is not a perfect square, Real.sqrt n is irrational. -/
+private lemma irrational_sqrt_of_not_sq {n : ℕ} (hn : 0 < n) (hns : ¬ IsSquare n) :
+    Irrational (Real.sqrt n) := by
+  rw [sqrt_eq_rpow_nat]
+  apply irrational_nrt_of_notint_nrt 2 n
+  · -- ((n : ℝ)^(1/2))^2 = n
+    rw [← Real.rpow_natCast ((n : ℝ) ^ ((1 : ℝ) / (2 : ℕ))) 2,
+        ← Real.rpow_mul (Nat.cast_nonneg n)]
+    norm_num
+  · -- Not an integer: k² = n would give IsSquare n, contradicting hns
+    intro ⟨k, hk⟩
+    apply hns
+    have hk2 : k ^ 2 = (n : ℤ) := by
+      have hrpow : ((n : ℝ) ^ ((1 : ℝ) / (2 : ℕ))) ^ 2 = (n : ℝ) := by
+        rw [← Real.rpow_natCast ((n : ℝ) ^ ((1 : ℝ) / (2 : ℕ))) 2,
+            ← Real.rpow_mul (Nat.cast_nonneg n)]
+        norm_num
+      rw [← hk] at hrpow
+      exact_mod_cast hrpow
+    refine ⟨k.natAbs, ?_⟩
+    have habs : k.natAbs ^ 2 = n := by
+      have h1 := Int.natAbs_pow k 2
+      rw [hk2, Int.natAbs_ofNat] at h1
+      omega
+    linarith [show k.natAbs * k.natAbs = k.natAbs ^ 2 from by ring]
+  · norm_num
+
+/-- **General Theorem**: `minpoly ℚ (Real.sqrt n) = X² - n` for ALL non-perfect-square n.
+
+    This strictly generalizes the Eisenstein-based Parts II–III:
+    - n = 8 = 2³: ¬IsSquare 8, Eisenstein fails (4|8), covered here ✓
+    - n = 27 = 3³: ¬IsSquare 27, Eisenstein fails (9|27), covered here ✓
+    - n = 32 = 2⁵: ¬IsSquare 32, Eisenstein fails (4|32), covered here ✓ -/
+theorem minpoly_sqrt_of_not_sq (n : ℕ) (hn : 0 < n) (hns : ¬ IsSquare n) :
+    minpoly ℚ (Real.sqrt n) = X ^ 2 - C (n : ℚ) := by
+  have hXn_monic : (X ^ 2 - C (n : ℚ) : ℚ[X]).Monic := monic_X_pow_sub_C _ (by norm_num)
+  have hXn_aeval : Polynomial.aeval (Real.sqrt n) (X ^ 2 - C (n : ℚ) : ℚ[X]) = 0 := by
+    simp only [map_sub, map_pow, aeval_X, aeval_C]
+    push_cast
+    linarith [Real.sq_sqrt (show (0 : ℝ) ≤ n by exact_mod_cast hn.le)]
+  have hintegral : IsIntegral ℚ (Real.sqrt n) :=
+    ⟨X ^ 2 - C (n : ℚ), hXn_monic, hXn_aeval⟩
+  have hdvd : minpoly ℚ (Real.sqrt n) ∣ X ^ 2 - C (n : ℚ) :=
+    minpoly.dvd ℚ (Real.sqrt n) hXn_aeval
+  have hXn_ne : (X ^ 2 - C (n : ℚ) : ℚ[X]) ≠ 0 := Polynomial.Monic.ne_zero hXn_monic
+  have hdeg_le : (minpoly ℚ (Real.sqrt n)).natDegree ≤ 2 := by
+    have := Polynomial.natDegree_le_of_dvd hdvd hXn_ne
+    simpa [Polynomial.natDegree_X_pow_sub_C] using this
+  have hirr : Irrational (Real.sqrt n) := irrational_sqrt_of_not_sq hn hns
+  have hdeg_ge : 2 ≤ (minpoly ℚ (Real.sqrt n)).natDegree := by
+    by_contra hlt
+    push_neg at hlt
+    have hdeg1 : (minpoly ℚ (Real.sqrt n)).natDegree = 1 := by
+      have hge1 := minpoly.natDegree_pos hintegral; omega
+    obtain ⟨a, b, ha, hfab⟩ := Polynomial.natDegree_eq_one.mp hdeg1
+    have hmonic := minpoly.monic hintegral
+    have ha1 : a = 1 := by
+      have hlc := hmonic.leadingCoeff
+      rw [hfab] at hlc
+      simp [Polynomial.leadingCoeff_add_of_degree_lt, Polynomial.degree_C_mul_X ha,
+            Polynomial.degree_C, ha] at hlc
+      exact hlc
+    rw [ha1, one_mul] at hfab
+    have heval := minpoly.aeval ℚ (Real.sqrt n)
+    rw [hfab] at heval
+    simp only [map_add, aeval_X, aeval_C] at heval
+    exact hirr ⟨-b, by push_cast at heval ⊢; linarith⟩
+  have hdeg : (minpoly ℚ (Real.sqrt n)).natDegree = 2 := Nat.le_antisymm hdeg_le hdeg_ge
+  obtain ⟨c, hc⟩ := hdvd
+  have hc_ne : c ≠ 0 := by intro hc0; simp [hc0] at hc; exact hXn_ne hc
+  have hc_deg : c.natDegree = 0 := by
+    have hmul_deg := Polynomial.natDegree_mul (minpoly.ne_zero hintegral) hc_ne
+    rw [← hc, Polynomial.natDegree_X_pow_sub_C, hdeg] at hmul_deg
+    omega
+  have hc_one : c = 1 := by
+    have hmul_lc : (minpoly ℚ (Real.sqrt n) * c).leadingCoeff = 1 := by
+      rw [← hc]; exact hXn_monic.leadingCoeff
+    rw [Polynomial.leadingCoeff_mul, (minpoly.monic hintegral).leadingCoeff, one_mul] at hmul_lc
+    have hc_const := Polynomial.eq_C_of_natDegree_eq_zero hc_deg
+    rw [hc_const, Polynomial.leadingCoeff_C] at hmul_lc
+    rw [hc_const, hmul_lc, map_one]
+  rw [hc_one, mul_one] at hc
+  exact hc.symm
+
+/-! ## Part VII Corollaries: Examples Not Covered by Eisenstein -/
+
+/-- √8 = 2√2: minpoly ℚ (√8) = X² - 8. (n=8=2³: Eisenstein fails since 4|8) -/
+theorem minpoly_sqrt_eight : minpoly ℚ (Real.sqrt 8) = X ^ 2 - C 8 :=
+  minpoly_sqrt_of_not_sq 8 (by norm_num) (by
+    rintro ⟨k, hk⟩
+    have hk_le : k ≤ 3 := by nlinarith
+    interval_cases k <;> simp_all)
+
+/-- √27 = 3√3: minpoly ℚ (√27) = X² - 27. (n=27=3³: Eisenstein fails since 9|27) -/
+theorem minpoly_sqrt_twentyseven : minpoly ℚ (Real.sqrt 27) = X ^ 2 - C 27 :=
+  minpoly_sqrt_of_not_sq 27 (by norm_num) (by
+    rintro ⟨k, hk⟩
+    have hk_le : k ≤ 5 := by nlinarith
+    interval_cases k <;> simp_all)
+
+/-- √32 = 4√2: minpoly ℚ (√32) = X² - 32. (n=32=2⁵: Eisenstein fails since 4|32) -/
+theorem minpoly_sqrt_thirtytwo : minpoly ℚ (Real.sqrt 32) = X ^ 2 - C 32 :=
+  minpoly_sqrt_of_not_sq 32 (by norm_num) (by
+    rintro ⟨k, hk⟩
+    have hk_le : k ≤ 6 := by nlinarith
+    interval_cases k <;> simp_all)
 
 end Sqrt2MinpolyOQ01

--- a/src/data/proofs/sqrt2-minpoly-oq-01/meta.json
+++ b/src/data/proofs/sqrt2-minpoly-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "sqrt2-minpoly-oq-01",
   "title": "Minimal Polynomial of √n over ℚ: Eisenstein Generalization",
   "slug": "sqrt2-minpoly-oq-01",
-  "description": "A complete Lean 4 proof that minpoly ℚ (√n) = X² - n for any natural number n with a squarefree prime factor, generalizing the √2 case via the Eisenstein criterion.",
+  "description": "A complete Lean 4 proof that minpoly ℚ (√n) = X² - n for ALL non-perfect-square natural numbers n, including cases where Eisenstein fails (n=8=2³, n=27=3³). Generalizes the √2 case via irrationality and degree bounds.",
   "meta": {
     "status": "verified",
     "tags": [
@@ -18,7 +18,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 136,
+    "lineCount": 252,
     "dateAdded": "2026-04-23",
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlibDependencies": [
@@ -45,7 +45,10 @@
       "Algebraic degree theorem: natDegree(minpoly ℚ √n) = 2",
       "Field extension degree: [ℚ(√n) : ℚ] = 2",
       "Non-perfect-square corollary: squarefree prime factor implies not a perfect square",
-      "Concrete examples: √2, √3, √5, √6, √7, √10, √12, √20"
+      "Concrete examples: √2, √3, √5, √6, √7, √10, √12, √20",
+      "General theorem (Part VII): minpoly ℚ (√n) = X² - n for ALL ¬IsSquare n",
+      "Covers Eisenstein-failing cases: √8 (n=2³), √27 (n=3³), √32 (n=2⁵)",
+      "New technique: irrationality via irrational_nrt_of_notint_nrt + degree bound argument"
     ]
   },
   "overview": {
@@ -114,9 +117,9 @@
     "summary": "A complete Lean 4 formalization proving that `minpoly ℚ (Real.sqrt n) = X² - n` for any natural number $n$ with a squarefree prime factor, covering all squarefree $n \\geq 2$ as a corollary. The 136-line file reuses the OQ03 general infrastructure, adding only the API bridge between `Real.sqrt` and `rpow` and the squarefree factor extraction lemma. Eight concrete examples (√2, √3, √5, √6, √7, √10, √12, √20) are verified with 0 sorries and 0 axioms.",
     "implications": "**Irrationality library**: This file, together with `sqrt2-minpoly-oq-02`, provides a complete Lean 4 library for proving irrationality of roots of the form $m^{1/n}$ via Eisenstein. Any irrational square root $\\sqrt{n}$ (with $n$ having a squarefree prime factor) can now be proved irrational in two lines.\n\n**Quadratic field extensions**: The result $[\\mathbb{Q}(\\sqrt{n}) : \\mathbb{Q}] = 2$ is the foundation of quadratic field theory. It confirms that $\\mathbb{Q}(\\sqrt{n})$ is a degree-2 extension, a necessary input for class field theory, quadratic reciprocity, and the arithmetic of quadratic number fields.\n\n**Modular arithmetic connection**: For squarefree $n$, the structure of $\\mathbb{Z}[\\sqrt{n}]$ (integers of the quadratic field) depends on $n \\bmod 4$: if $n \\equiv 1 \\pmod{4}$ then the ring of integers is $\\mathbb{Z}[(1+\\sqrt{n})/2]$; otherwise it is $\\mathbb{Z}[\\sqrt{n}]$. This file establishes the base case needed for this classification.",
     "openQuestions": [
-      "Characterize exactly which n give `minpoly ℚ (Real.sqrt n) = X² - n`: the condition 'p | n but p² ∤ n for some prime p' covers all non-perfect-squares with odd p-adic valuation at some prime, but n=8 (a perfect power) requires different tools.",
-      "Prove that `Real.sqrt n` is irrational for all non-perfect-squares n using a different approach (e.g., unique factorization in ℤ) and show equivalence with the Eisenstein approach formalized here.",
-      "Extend to `minpoly ℚ (Real.sqrt (p/q)) = q·X² - p` for rational p/q, covering the irrationality of square roots of rationals."
+      "Prove that `Real.sqrt n` is irrational for all non-perfect-squares n using unique factorization in ℤ, and show equivalence with the irrationality_nrt approach formalized here.",
+      "Extend to `minpoly ℚ (Real.sqrt (p/q)) = q·X² - p` for rational p/q, covering the irrationality of square roots of rationals.",
+      "Characterize the set of n where `minpoly ℚ (Real.sqrt n) ≠ X² - n` (precisely: the perfect squares), and prove this is decidable."
     ]
   },
   "crossReferences": [
@@ -151,6 +154,11 @@
       "name": "Sqrt2MinpolyOQ01.adjoin_sqrt_finrank",
       "statement": "Module.finrank ℚ ℚ⟮Real.sqrt n⟯ = 2",
       "description": "Field extension degree [ℚ(√n) : ℚ] = 2"
+    },
+    {
+      "name": "Sqrt2MinpolyOQ01.minpoly_sqrt_of_not_sq",
+      "statement": "minpoly ℚ (Real.sqrt n) = X ^ 2 - C (n : ℚ) for all ¬IsSquare n",
+      "description": "General theorem: all non-perfect-square n, not just Eisenstein cases. Covers n=8=2³, n=27=3³, n=32=2⁵ and all others where the Eisenstein condition fails."
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Summary

Adds Part VII to `Proofs/Sqrt2MinpolyOQ01.lean`: a complete proof of
`minpoly ℚ (Real.sqrt n) = X² - n` for **ALL** non-perfect-square natural numbers n.

This strictly generalizes the existing Eisenstein-based results (Parts II–III):
- **New**: n = 8 = 2³ (Eisenstein fails: 4|8, no squarefree prime factor)
- **New**: n = 27 = 3³ (Eisenstein fails: 9|27)
- **New**: n = 32 = 2⁵ (Eisenstein fails: 4|32)
- All squarefree n ≥ 2 (already covered by Part III, now also by Part VII)

### Proof Strategy

1. **Irrationality** (`irrational_sqrt_of_not_sq`): If ¬IsSquare n, then
   Real.sqrt n is irrational, proved via `irrational_nrt_of_notint_nrt 2 n`.
   Key step: if (n:ℝ)^(1/2) = k : ℤ, then k² = n, giving IsSquare n via `k.natAbs`.

2. **Degree bounds**: minpoly | X²-n gives degree ≤ 2; irrationality forces degree ≥ 2
   (degree 1 would give a rational root = Real.sqrt n, contradiction).

3. **Equality**: Both minpoly and X²-n are monic degree 2 with minpoly | X²-n.
   Factoring gives X²-n = minpoly · c where c has degree 0; leading coefficient
   analysis shows c = 1, hence minpoly = X²-n.

### Build Status

Compiled successfully with 0 sorries, 0 axioms (✔ Proofs.Sqrt2MinpolyOQ01).

## Test plan

- [x] Docker build: `./proofs/scripts/docker-build.sh Proofs.Sqrt2MinpolyOQ01`
- [x] 0 sorries confirmed in new theorems
- [x] 3 concrete examples: √8, √27, √32

🤖 Generated with [Claude Code](https://claude.com/claude-code)