### PR TITLE
Fix: add missing leanFile.lineCount and leanFile.sorries to 36 gallery proofs

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-04-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-04-oq-01/meta.json
@@ -176,7 +176,8 @@
     "substantiveTheoremCount": 8,
     "duplicateTheorems": 0,
     "definitionCount": 3,
-    "path": "Proofs/AngleTrisectionOQ02OQ04OQ01.lean"
+    "path": "Proofs/AngleTrisectionOQ02OQ04OQ01.lean",
+    "sorries": 3
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/angle-trisection-oq-02-oq-04/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-04/meta.json
@@ -107,7 +107,8 @@
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 4,
-    "path": "Proofs/AngleTrisectionOQ02OQ04.lean"
+    "path": "Proofs/AngleTrisectionOQ02OQ04.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/basel-problem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-03/meta.json
@@ -109,7 +109,8 @@
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 7,
-    "path": "Proofs/BaselProblemOQ01OQ03.lean"
+    "path": "Proofs/BaselProblemOQ01OQ03.lean",
+    "sorries": 0
   },
   "references": [],
   "sorries": 0

--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -194,7 +194,8 @@
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 0,
-    "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean"
+    "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+    "sorries": 0
   },
   "sorries": 0
 }

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
@@ -140,7 +140,8 @@
     "substantiveTheoremCount": 6,
     "duplicateTheorems": 0,
     "definitionCount": 4,
-    "path": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean"
+    "path": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
+    "sorries": 7
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01/meta.json
@@ -102,7 +102,8 @@
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 1,
-    "path": "Proofs/BinomialTheoremOQ02OQ01.lean"
+    "path": "Proofs/BinomialTheoremOQ02OQ01.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/binomial-theorem-oq-03-oq-02-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-03-oq-02-oq-03/meta.json
@@ -119,7 +119,8 @@
     "defCount": 0,
     "sorryCount": 0,
     "lineCount": 208,
-    "path": "Proofs/BinomialTheoremOQ03OQ02OQ03.lean"
+    "path": "Proofs/BinomialTheoremOQ03OQ02OQ03.lean",
+    "sorries": 0
   },
   "sorries": 0
 }

--- a/src/data/proofs/binomial-theorem-oq-04-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-04-oq-03/meta.json
@@ -127,7 +127,8 @@
     "substantiveTheoremCount": 11,
     "duplicateTheorems": 0,
     "definitionCount": 4,
-    "path": "Proofs/BinomialTheoremOQ04OQ03.lean"
+    "path": "Proofs/BinomialTheoremOQ04OQ03.lean",
+    "sorries": 0
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/birch-swinnerton-dyer-oq-06/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer-oq-06/meta.json
@@ -63,7 +63,8 @@
     "sorryCount": 0,
     "lineCount": 273,
     "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirchSwinnertonDyerOQ06.lean",
-    "path": "Proofs/BirchSwinnertonDyerOQ06.lean"
+    "path": "Proofs/BirchSwinnertonDyerOQ06.lean",
+    "sorries": 0
   },
   "sections": [
     {

--- a/src/data/proofs/birch-swinnerton-dyer/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer/meta.json
@@ -716,6 +716,8 @@
   ],
   "sorries": 0,
   "leanFile": {
-    "axiomCount": 18
+    "axiomCount": 18,
+    "lineCount": 7432,
+    "sorries": 0
   }
 }

--- a/src/data/proofs/brouwer-fixed-point/meta.json
+++ b/src/data/proofs/brouwer-fixed-point/meta.json
@@ -307,6 +307,8 @@
   ],
   "sorries": 0,
   "leanFile": {
-    "axiomCount": 2
+    "axiomCount": 2,
+    "lineCount": 249,
+    "sorries": 0
   }
 }

--- a/src/data/proofs/dissection-of-cubes-oq-04/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-04/meta.json
@@ -175,6 +175,8 @@
     }
   ],
   "leanFile": {
-    "axiomCount": 2
+    "axiomCount": 2,
+    "lineCount": 436,
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1002-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-1002-oq-01-oq-01/meta.json
@@ -145,6 +145,8 @@
   ],
   "sorries": 1,
   "leanFile": {
-    "axiomCount": 1
+    "axiomCount": 1,
+    "lineCount": 705,
+    "sorries": 1
   }
 }

--- a/src/data/proofs/erdos-107/meta.json
+++ b/src/data/proofs/erdos-107/meta.json
@@ -207,6 +207,8 @@
   ],
   "sorries": 2,
   "leanFile": {
-    "axiomCount": 6
+    "axiomCount": 6,
+    "lineCount": 243,
+    "sorries": 2
   }
 }

--- a/src/data/proofs/erdos-1083-oq-02/meta.json
+++ b/src/data/proofs/erdos-1083-oq-02/meta.json
@@ -151,6 +151,8 @@
   ],
   "sorries": 0,
   "leanFile": {
-    "axiomCount": 6
+    "axiomCount": 6,
+    "lineCount": 372,
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1091/meta.json
+++ b/src/data/proofs/erdos-1091/meta.json
@@ -172,6 +172,8 @@
   ],
   "sorries": 0,
   "leanFile": {
-    "axiomCount": 5
+    "axiomCount": 5,
+    "lineCount": 211,
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1107-oq-02/meta.json
+++ b/src/data/proofs/erdos-1107-oq-02/meta.json
@@ -109,6 +109,8 @@
   ],
   "sorries": 0,
   "leanFile": {
-    "axiomCount": 1
+    "axiomCount": 1,
+    "lineCount": 156,
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1113/meta.json
+++ b/src/data/proofs/erdos-1113/meta.json
@@ -200,6 +200,8 @@
   ],
   "sorries": 0,
   "leanFile": {
-    "axiomCount": 1
+    "axiomCount": 1,
+    "lineCount": 172,
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1202/meta.json
+++ b/src/data/proofs/erdos-1202/meta.json
@@ -159,6 +159,8 @@
   ],
   "sorries": 0,
   "leanFile": {
-    "axiomCount": 1
+    "axiomCount": 1,
+    "lineCount": 115,
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1205/meta.json
+++ b/src/data/proofs/erdos-1205/meta.json
@@ -148,6 +148,8 @@
   ],
   "sorries": 0,
   "leanFile": {
-    "axiomCount": 2
+    "axiomCount": 2,
+    "lineCount": 87,
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1208/meta.json
+++ b/src/data/proofs/erdos-1208/meta.json
@@ -144,6 +144,8 @@
   ],
   "sorries": 1,
   "leanFile": {
-    "axiomCount": 2
+    "axiomCount": 2,
+    "lineCount": 137,
+    "sorries": 1
   }
 }

--- a/src/data/proofs/erdos-181-oq-01/meta.json
+++ b/src/data/proofs/erdos-181-oq-01/meta.json
@@ -136,6 +136,8 @@
   ],
   "sorries": 0,
   "leanFile": {
-    "axiomCount": 2
+    "axiomCount": 2,
+    "lineCount": 170,
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-875/meta.json
+++ b/src/data/proofs/erdos-875/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-875",
-  "title": "Erd\u0151s Problem #875: Admissible Sequences with Disjoint Sumsets",
+  "title": "Erdős Problem #875: Admissible Sequences with Disjoint Sumsets",
   "slug": "erdos-875",
-  "description": "Let A = {a\u2081 < a\u2082 < ...} with r-fold sumsets S\u1d63 pairwise disjoint for all r. How fast must A grow? For which c is a_{n+1} \u2212 a\u2099 \u2264 n^c possible? Can a_{n+1}/a\u2099 \u2192 1? Erd\u0151s noted the ratio-1 case is 'not completely trivial.'",
+  "description": "Let A = {a₁ < a₂ < ...} with r-fold sumsets Sᵣ pairwise disjoint for all r. How fast must A grow? For which c is a_{n+1} − aₙ ≤ n^c possible? Can a_{n+1}/aₙ → 1? Erdős noted the ratio-1 case is 'not completely trivial.'",
   "meta": {
-    "author": "Deshouillers, Erd\u0151s",
+    "author": "Deshouillers, Erdős",
     "sourceUrl": "https://erdosproblems.com/875",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos875Problem.lean",
@@ -28,15 +28,15 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "**Deshouillers and Erd\u0151s** posed this as an infinite variant of Problem #874. An **admissible sequence** $a_1 < a_2 < \\cdots$ has the property that the $r$-fold sumsets $S_r = \\{a_{i_1} + \\cdots + a_{i_r} : i_1 < \\cdots < i_r\\}$ are pairwise disjoint for distinct $r \\geq 1$. The simplest example is powers of 2 ($a_n = 2^n$), where binary representation ensures disjointness via popcount. The central question is **how slowly** an admissible sequence can grow. Erd\u0151s noted that the ratio-one property $a_{n+1}/a_n \\to 1$ (subexponential growth) is achievable but 'not completely trivial.' The problem connects to **Sidon sets** (where sumsets of different sizes are automatically separated by parity of the number of terms) and to the **subset sum problem** in computational complexity.",
-    "problemStatement": "For an infinite admissible sequence A with pairwise disjoint r-fold sumsets: (1) How fast must A grow? (2) For which c can a_{n+1} \u2212 a\u2099 \u2264 n^c? (3) Can a_{n+1}/a\u2099 \u2192 1?",
-    "text": "Let A = {a\u2081 < a\u2082 < ...} with r-fold sumsets S\u1d63 pairwise disjoint for all r. How fast must A grow? For which c is a_{n+1} \u2212 a\u2099 \u2264 n^c possible? Can a_{n+1}/a\u2099 \u2192 1? Erd\u0151s noted the ratio-1 case is 'not completely trivial.'",
+    "historicalContext": "**Deshouillers and Erdős** posed this as an infinite variant of Problem #874. An **admissible sequence** $a_1 < a_2 < \\cdots$ has the property that the $r$-fold sumsets $S_r = \\{a_{i_1} + \\cdots + a_{i_r} : i_1 < \\cdots < i_r\\}$ are pairwise disjoint for distinct $r \\geq 1$. The simplest example is powers of 2 ($a_n = 2^n$), where binary representation ensures disjointness via popcount. The central question is **how slowly** an admissible sequence can grow. Erdős noted that the ratio-one property $a_{n+1}/a_n \\to 1$ (subexponential growth) is achievable but 'not completely trivial.' The problem connects to **Sidon sets** (where sumsets of different sizes are automatically separated by parity of the number of terms) and to the **subset sum problem** in computational complexity.",
+    "problemStatement": "For an infinite admissible sequence A with pairwise disjoint r-fold sumsets: (1) How fast must A grow? (2) For which c can a_{n+1} − aₙ ≤ n^c? (3) Can a_{n+1}/aₙ → 1?",
+    "text": "Let A = {a₁ < a₂ < ...} with r-fold sumsets Sᵣ pairwise disjoint for all r. How fast must A grow? For which c is a_{n+1} − aₙ ≤ n^c possible? Can a_{n+1}/aₙ → 1? Erdős noted the ratio-1 case is 'not completely trivial.'",
     "proofStrategy": "The formalization defines the r-fold sumset via Finset.powersetCard and Finset.image, the admissibility condition combining strict increase with sumset disjointness, and the polynomial gap and ratio-one properties using Filter.atTop. It fully proves powers-of-2 admissibility via binary uniqueness: subsets of {2^0,...,2^(N-1)} with equal sums must be equal (by induction on N, case-splitting on the maximal power), so r-fold and s-fold sumsets with r!=s are disjoint. Also proves admissible_growth_lower (a(n) >= n+1 by induction).",
     "keyInsights": [
       "**Powers of 2 are admissible**: binary encoding uniquely determines which elements are summed, and popcount (number of 1-bits) equals the number of terms, ensuring different $r$-fold sumsets are disjoint",
-      "**Critical exponent for polynomial gaps**: there exists a threshold $c_0$ such that admissible sequences with gaps $\\leq n^c$ exist for $c > c_0$ but not for $c < c_0$\u2014the value of $c_0$ is unknown",
-      "**Ratio-one is achievable**: Erd\u0151s claimed an admissible sequence with $a_{n+1}/a_n \\to 1$ exists, meaning subexponential growth suffices for admissibility",
-      "**Proved growth lower bound**: by induction on strict increase, every admissible sequence satisfies $a(n) \\geq n+1$\u2014a crude linear bound, with the disjoint sumsets condition forcing much faster growth",
+      "**Critical exponent for polynomial gaps**: there exists a threshold $c_0$ such that admissible sequences with gaps $\\leq n^c$ exist for $c > c_0$ but not for $c < c_0$—the value of $c_0$ is unknown",
+      "**Ratio-one is achievable**: Erdős claimed an admissible sequence with $a_{n+1}/a_n \\to 1$ exists, meaning subexponential growth suffices for admissibility",
+      "**Proved growth lower bound**: by induction on strict increase, every admissible sequence satisfies $a(n) \\geq n+1$—a crude linear bound, with the disjoint sumsets condition forcing much faster growth",
       "**Finite-infinite connection**: the finite Problem #874 asks for the maximum size of an admissible subset of $\\{1, \\ldots, n\\}$, whose growth rate determines the optimal growth of infinite admissible sequences"
     ],
     "prerequisites": [
@@ -106,7 +106,7 @@
       "title": "Growth Lower Bound (Fully Proved)",
       "startLine": 105,
       "endLine": 116,
-      "summary": "Proves a(n) \u2265 n+1 for admissible sequences by induction.",
+      "summary": "Proves a(n) ≥ n+1 for admissible sequences by induction.",
       "mathContext": "Proves a(n) $\\geq$ n+1 for admissible sequences by induction."
     },
     {
@@ -127,11 +127,11 @@
     }
   ],
   "conclusion": {
-    "summary": "The formalization captures Erd\u0151s Problem #875 on admissible sequences with three proved results (powers of 2 strictly increasing, growth lower bound a(n) \u2265 n+1, partial powers-of-2 admissibility). The gap threshold and ratio-one questions remain open, with the popcount argument for full powers-of-2 admissibility axiomatized.",
-    "implications": "Understanding admissible sequences connects to Sidon set theory, the subset sum problem, additive bases, and binary coding theory. The critical exponent c\u2080 would quantify how efficiently the disjoint sumsets condition constrains growth.",
+    "summary": "The formalization captures Erdős Problem #875 on admissible sequences with three proved results (powers of 2 strictly increasing, growth lower bound a(n) ≥ n+1, partial powers-of-2 admissibility). The gap threshold and ratio-one questions remain open, with the popcount argument for full powers-of-2 admissibility axiomatized.",
+    "implications": "Understanding admissible sequences connects to Sidon set theory, the subset sum problem, additive bases, and binary coding theory. The critical exponent c₀ would quantify how efficiently the disjoint sumsets condition constrains growth.",
     "openQuestions": [
-      "What is the critical exponent c\u2080 for polynomial gaps in admissible sequences?",
-      "Can an admissible sequence have a_{n+1}/a\u2099 \u2192 1 (Erd\u0151s's 'not completely trivial' claim)?",
+      "What is the critical exponent c₀ for polynomial gaps in admissible sequences?",
+      "Can an admissible sequence have a_{n+1}/aₙ → 1 (Erdős's 'not completely trivial' claim)?",
       "What is the optimal growth rate for admissible sequences?",
       "How does the maximum admissible subset size of {1,...,n} grow with n?"
     ]
@@ -151,23 +151,24 @@
     "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 7,
-    "path": "Proofs/Erdos875Problem.lean"
+    "path": "Proofs/Erdos875Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {
       "targetId": "erdos-1103",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: additive-combinatorics, growth-rates, sumsets"
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, growth-rates, sumsets"
     },
     {
       "targetId": "erdos-109",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: additive-combinatorics, sumsets"
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, sumsets"
     },
     {
       "targetId": "erdos-1109",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: additive-combinatorics, sumsets"
+      "description": "Related Erdős problem sharing themes: additive-combinatorics, sumsets"
     }
   ],
   "sorries": 0

--- a/src/data/proofs/feuerbachs-theorem-oq-02/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-oq-02/meta.json
@@ -162,7 +162,8 @@
     "substantiveTheoremCount": 6,
     "duplicateTheorems": 0,
     "definitionCount": 35,
-    "path": "Proofs/FeuerbachsTheoremOQ02.lean"
+    "path": "Proofs/FeuerbachsTheoremOQ02.lean",
+    "sorries": 5
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/godel-first-incompleteness-oq01/meta.json
+++ b/src/data/proofs/godel-first-incompleteness-oq01/meta.json
@@ -165,6 +165,8 @@
   ],
   "sorries": 0,
   "leanFile": {
-    "axiomCount": 5
+    "axiomCount": 5,
+    "lineCount": 271,
+    "sorries": 0
   }
 }

--- a/src/data/proofs/godel-second-incompleteness-oq02/meta.json
+++ b/src/data/proofs/godel-second-incompleteness-oq02/meta.json
@@ -160,6 +160,8 @@
   ],
   "sorries": 0,
   "leanFile": {
-    "axiomCount": 6
+    "axiomCount": 6,
+    "lineCount": 258,
+    "sorries": 0
   }
 }

--- a/src/data/proofs/laws-of-large-numbers-oq-03/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-03/meta.json
@@ -185,7 +185,8 @@
     "substantiveTheoremCount": 8,
     "duplicateTheorems": 0,
     "definitionCount": 6,
-    "path": "Proofs/LawsOfLargeNumbersOQ03.lean"
+    "path": "Proofs/LawsOfLargeNumbersOQ03.lean",
+    "sorries": 1
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/leibniz-pi-oq-02/meta.json
+++ b/src/data/proofs/leibniz-pi-oq-02/meta.json
@@ -172,7 +172,8 @@
     "substantiveTheoremCount": 7,
     "duplicateTheorems": 0,
     "definitionCount": 7,
-    "path": "Proofs/LeibnizPiOQ02.lean"
+    "path": "Proofs/LeibnizPiOQ02.lean",
+    "sorries": 9
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/pascals-hexagon/meta.json
+++ b/src/data/proofs/pascals-hexagon/meta.json
@@ -225,6 +225,8 @@
   ],
   "sorries": 1,
   "leanFile": {
-    "axiomCount": 1
+    "axiomCount": 1,
+    "lineCount": 1278,
+    "sorries": 1
   }
 }

--- a/src/data/proofs/picks-theorem-oq-03/meta.json
+++ b/src/data/proofs/picks-theorem-oq-03/meta.json
@@ -231,6 +231,8 @@
   ],
   "sorries": 0,
   "leanFile": {
-    "axiomCount": 2
+    "axiomCount": 2,
+    "lineCount": 710,
+    "sorries": 0
   }
 }

--- a/src/data/proofs/picks-theorem/meta.json
+++ b/src/data/proofs/picks-theorem/meta.json
@@ -220,6 +220,8 @@
   ],
   "sorries": 0,
   "leanFile": {
-    "axiomCount": 1
+    "axiomCount": 1,
+    "lineCount": 484,
+    "sorries": 0
   }
 }

--- a/src/data/proofs/quadratic-reciprocity-algorithm-oq-01/meta.json
+++ b/src/data/proofs/quadratic-reciprocity-algorithm-oq-01/meta.json
@@ -130,7 +130,8 @@
   "leanFile": {
     "lineCount": 220,
     "axiomCount": 0,
-    "path": "Proofs/QuadraticReciprocityAlgorithmOQ01.lean"
+    "path": "Proofs/QuadraticReciprocityAlgorithmOQ01.lean",
+    "sorries": 0
   },
   "sorries": 0
 }

--- a/src/data/proofs/sperner-ndim-oq-03/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-03/meta.json
@@ -172,7 +172,8 @@
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 6,
-    "path": "Proofs/SpernerNDimOQ03.lean"
+    "path": "Proofs/SpernerNDimOQ03.lean",
+    "sorries": 0
   },
   "sorries": 0
 }

--- a/src/data/proofs/sperner-ndim-oq-04/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-04/meta.json
@@ -253,7 +253,8 @@
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 5,
-    "path": "Proofs/SpernerNDimOQ04.lean"
+    "path": "Proofs/SpernerNDimOQ04.lean",
+    "sorries": 1
   },
   "sorries": 1
 }

--- a/src/data/proofs/sylow-theorems-oq-02/meta.json
+++ b/src/data/proofs/sylow-theorems-oq-02/meta.json
@@ -207,6 +207,8 @@
   ],
   "sorries": 0,
   "leanFile": {
-    "axiomCount": 5
+    "axiomCount": 5,
+    "lineCount": 393,
+    "sorries": 0
   }
 }

--- a/src/data/proofs/taylor-sincos-convergence/meta.json
+++ b/src/data/proofs/taylor-sincos-convergence/meta.json
@@ -221,6 +221,8 @@
   ],
   "sorries": 0,
   "leanFile": {
-    "axiomCount": 2
+    "axiomCount": 2,
+    "lineCount": 348,
+    "sorries": 0
   }
 }


### PR DESCRIPTION
## Fix

Added missing `leanFile.lineCount` and `leanFile.sorries` fields to 36 gallery `meta.json` files.

## Evidence

**Root cause**: Same class as PR #11735 (missing `leanFile.axiomCount`). These proofs had a `leanFile` section present but were missing `lineCount` and/or `sorries` fields.

**Before**: `leanFile` section missing `lineCount` or `sorries` fields
**After**: Both fields present and consistent with `meta.*` values

**Fields added**:
- `leanFile.lineCount`: added to 20 proofs using `wc -l` (canonical convention)
- `leanFile.sorries`: added to 36 proofs from `meta.sorries` (already verified correct)

Notable entries:
- `birch-swinnerton-dyer`: added `lineCount=7432, sorries=0`
- `binomial-theorem-oq-02-oq-01-oq-01`: `sorries=7`
- `leibniz-pi-oq-02`: `sorries=9`
- `feuerbachs-theorem-oq-02`: `sorries=5`

**Validation**: All 36 modified files pass JSON validation. Field values match `meta.*` and `wc -l` output.

---
Automated fix by lean-mechanic agent.