### PR TITLE
Fix: add missing leanFile section to 53 gallery proofs

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-02/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02/meta.json
@@ -152,5 +152,27 @@
       "description": "The concrete diagonal argument: no surjection ℕ → BinarySeq = (ℕ → Bool)"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.SetTheory.Cardinal.Basic",
+      "Mathlib.SetTheory.Cardinal.Continuum",
+      "Mathlib.Data.Real.Basic",
+      "Mathlib.Algebra.AlgebraicCard",
+      "Mathlib.Data.Set.Countable",
+      "Mathlib.Tactic",
+      "Proofs.CantorDiagonalization",
+      "Proofs.AlgebraicNumbersCountable"
+    ],
+    "opens": [
+      "Cardinal"
+    ],
+    "namespace": "AlgebraicNumbersCountableOQ02",
+    "lineCount": 193,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 1,
+    "sorries": 0,
+    "path": "Proofs/AlgebraicNumbersCountableOQ02.lean"
+  }
 }

--- a/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01/meta.json
@@ -165,5 +165,22 @@
       "Is there a more direct Lean 4 proof using StrictMono of rpow on the positive reals with negative exponent?"
     ]
   },
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Proofs.AmgmInequalityOQ03",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Real",
+      "Finset"
+    ],
+    "namespace": "PowerMeanCrossZero",
+    "lineCount": 226,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/PowerMeanCrossZeroOQ.lean"
+  }
 }

--- a/src/data/proofs/amgm-inequality-oq-03-oq-04/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-04/meta.json
@@ -167,5 +167,22 @@
       "description": "AM-GM inequality: the r=1 vs r=0 case of power mean monotonicity"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.MeanInequalities",
+      "Mathlib.Analysis.MeanInequalitiesPow",
+      "Mathlib.Analysis.SpecialFunctions.Pow.Real",
+      "Mathlib.Analysis.SpecialFunctions.Log.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [],
+    "namespace": "RenyiPowerMean",
+    "lineCount": 233,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 2,
+    "sorries": 0,
+    "path": "Proofs/AmgmInequalityOQ03OQ04.lean"
+  }
 }

--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-01/meta.json
@@ -147,5 +147,22 @@
       "description": "The inverse Galois problem — ℤ/3ℤ is realized here as Gal(cos(π/7) minpoly/ℚ)"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Polynomial",
+      "IntermediateField",
+      "FiniteDimensional"
+    ],
+    "namespace": "AngleTrisectionCos20GalOQ01",
+    "lineCount": 417,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/AngleTrisectionCos20GalOQ01.lean"
+  }
 }

--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-03-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-03-oq-01/meta.json
@@ -173,5 +173,22 @@
       "note": "Article 366: constructibility of the regular pentagon via cyclotomic fields"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Polynomial",
+      "IntermediateField",
+      "FiniteDimensional"
+    ],
+    "namespace": "AngleTrisectionCos20GalOQ03OQ01",
+    "lineCount": 463,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/AngleTrisectionCos20GalOQ03OQ01.lean"
+  }
 }

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -151,5 +151,24 @@
       "description": "Root of the ball volume chain: π·r² for the 2-ball"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Proofs.AreaOfCircleOQ01OQ02OQ01OQ01",
+      "Mathlib.Analysis.SpecificLimits.Basic"
+    ],
+    "opens": [
+      "Real",
+      "Filter",
+      "Nat",
+      "UnitBallRecurrence"
+    ],
+    "namespace": "BallVolumeTendsto",
+    "lineCount": 164,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean"
+  }
 }

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-03-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-03-oq-03/meta.json
@@ -137,5 +137,22 @@
       "description": "Root proof establishing A(r) = πr². Our result is the n-dimensional generalization of A'(r) = 2πr."
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "MeasureTheory",
+      "intervalIntegral"
+    ],
+    "namespace": "SteinerFormulaNBall",
+    "lineCount": 303,
+    "axiomCount": 0,
+    "theoremCount": 15,
+    "definitionCount": 3,
+    "sorries": 0,
+    "path": "Proofs/AreaOfCircleOQ01OQ02OQ03OQ03.lean"
+  }
 }

--- a/src/data/proofs/area-of-circle-oq-05-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-02/meta.json
@@ -116,5 +116,29 @@
       "Can the proof be simplified using `MeasurePreserving.integral_comp'` instead of `integral_map` + `hmap`?"
     ]
   },
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral",
+      "Mathlib.Analysis.Matrix.Spectrum",
+      "Mathlib.Analysis.Matrix.PosDef",
+      "Mathlib.MeasureTheory.Integral.Pi",
+      "Mathlib.MeasureTheory.Measure.Lebesgue.Basic",
+      "Mathlib.LinearAlgebra.Determinant",
+      "Proofs.AreaOfCircleOQ05"
+    ],
+    "opens": [
+      "MeasureTheory",
+      "Real",
+      "Matrix",
+      "Finset"
+    ],
+    "namespace": "MultivariateGaussian",
+    "lineCount": 190,
+    "axiomCount": 0,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/AreaOfCircleOQ05OQ02.lean"
+  }
 }

--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-01/meta.json
@@ -174,5 +174,26 @@
       "description": "Grandparent: 2D Hockey Stick Identity in the arithmetic series hierarchy"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.Tactic",
+      "Mathlib.Data.ZMod.Basic",
+      "Mathlib.Data.Nat.GCD.Basic",
+      "Mathlib.Data.Nat.Totient",
+      "Proofs.BurnsideCountingOQ03",
+      "Mathlib.GroupTheory.GroupAction.Quotient"
+    ],
+    "opens": [
+      "Finset",
+      "MulAction"
+    ],
+    "namespace": "PolyaEnumeration",
+    "lineCount": 508,
+    "axiomCount": 0,
+    "theoremCount": 27,
+    "definitionCount": 4,
+    "sorries": 0,
+    "path": "Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean"
+  }
 }

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02/meta.json
@@ -124,5 +124,21 @@
       "note": "Chapter 1: multiset coefficients, generating functions, and Vandermonde-type convolutions"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "BigOperators"
+    ],
+    "namespace": "MultisetVandermonde",
+    "lineCount": 119,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02.lean"
+  }
 }

--- a/src/data/proofs/basel-problem-oq-04/meta.json
+++ b/src/data/proofs/basel-problem-oq-04/meta.json
@@ -131,5 +131,26 @@
       "description": "Parent: the Basel sum ∑ 1/n² = π²/6"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.EulerProduct.DirichletLSeries",
+      "Mathlib.NumberTheory.LSeries.HurwitzZetaValues",
+      "Mathlib.NumberTheory.ZetaValues",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Complex",
+      "Real",
+      "Nat",
+      "Filter"
+    ],
+    "namespace": "BaselProblemOQ04",
+    "lineCount": 108,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/BaselProblemOQ04.lean"
+  }
 }

--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02/meta.json
@@ -135,5 +135,23 @@
       "description": "Fundamental theorem of arithmetic from Euclid's lemma — the ℤ case that ℤ[i] generalizes"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.Zsqrtd.GaussianInt",
+      "Mathlib.RingTheory.EuclideanDomain",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "GaussianInt",
+      "Zsqrtd"
+    ],
+    "namespace": "GaussianIntEuclidean",
+    "lineCount": 194,
+    "axiomCount": 0,
+    "theoremCount": 14,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean"
+  }
 }

--- a/src/data/proofs/bezout-identity-oq-02-oq-04/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-04/meta.json
@@ -153,5 +153,24 @@
       "description": "Binary GCD (Stein's algorithm) computes gcd(a,b) using subtraction and bit shifts, implicitly using the same UFD structure (ℤ as a Euclidean domain). The Bézout identity certifies the GCD value; this entry shows that the transition from gcd-via-Euclidean-algorithm to gcd-via-content-theory is forced when moving from ℤ to ℤ[X], where division-with-remainder no longer works for all coefficient pairs."
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.RingTheory.Polynomial.Content",
+      "Mathlib.RingTheory.Polynomial.GaussLemma",
+      "Mathlib.RingTheory.Polynomial.UniqueFactorization",
+      "Mathlib.Algebra.Polynomial.FieldDivision",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Polynomial"
+    ],
+    "namespace": "BezoutIdentityOQ02OQ04",
+    "lineCount": 171,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/BezoutIdentityOQ02OQ04.lean"
+  }
 }

--- a/src/data/proofs/bezout-identity-oq-03-oq-04-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-04-oq-01/meta.json
@@ -125,5 +125,19 @@
       "description": "Sibling: multiple-moduli CRT via folding. This entry handles the two-moduli case over CommRing."
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.RingTheory.Coprime.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [],
+    "namespace": "BezoutIdentityOQ03OQ04OQ01",
+    "lineCount": 130,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "sorries": 0,
+    "path": "Proofs/BezoutIdentityOQ03OQ04OQ01.lean"
+  }
 }

--- a/src/data/proofs/bezout-identity-oq-04-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-04-oq-02/meta.json
@@ -130,5 +130,20 @@
       "description": "Root: Bézout's identity ax + by = gcd(a,b) for integers"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "EuclideanDomain"
+    ],
+    "namespace": "BezoutIdentityOQ04OQ02",
+    "lineCount": 139,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/BezoutIdentityOQ04OQ02.lean"
+  }
 }

--- a/src/data/proofs/binomial-theorem-oq-02-oq-04/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-04/meta.json
@@ -70,7 +70,12 @@
       "The multinomial coefficients arise naturally from the recursive structure: multinomial_cons gives the recurrence relation that packages C(n,j) factors.",
       "The proof reveals a bijection between induction steps and variables: for a k-variable multinomial, exactly k-1 applications of the binomial theorem suffice (since the base case k=1 is trivial: (f a)^n = f a^n with the unique antidiagram element). This matches the classical textbook proof step-count and confirms that the multinomial theorem is not an independent principle but a direct consequence of repeated application of the binomial theorem."
     ],
-    "prerequisites": ["Multinomial theorem (BinomialTheoremOQ02)", "Binomial theorem (add_pow)", "Finset induction (Finset.cons_induction)", "piAntidiag structure (Mathlib.Algebra.Order.Antidiag.Pi)"],
+    "prerequisites": [
+      "Multinomial theorem (BinomialTheoremOQ02)",
+      "Binomial theorem (add_pow)",
+      "Finset induction (Finset.cons_induction)",
+      "piAntidiag structure (Mathlib.Algebra.Order.Antidiag.Pi)"
+    ],
     "problemStatement": "OQ-04: Is there a direct Lean proof of the multinomial theorem (∑ᵢ∈s fᵢ)ⁿ = ∑_{k∈piAntidiag s n} multinomial(s,k) · ∏_s f^k by induction on |s|, explicitly using the binomial theorem at each inductive step?",
     "proofStrategy": "Structural induction (Finset.cons_induction): Base case (s=∅) uses piAntidiag_empty simp. Inductive step uses piAntidiag_cons to decompose the RHS, add_pow to expand the LHS, the IH to handle each (∑_s f)^m factor, and the support condition g a = 0 to simplify multinomial_cons."
   },
@@ -161,5 +166,26 @@
       "description": "The classical binomial theorem (add_pow) used at each inductive step"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Nat.Choose.Multinomial",
+      "Mathlib.Data.Nat.Choose.Sum",
+      "Mathlib.Algebra.BigOperators.Ring.Finset",
+      "Mathlib.Algebra.Order.Antidiag.Pi",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset",
+      "BigOperators",
+      "Nat"
+    ],
+    "namespace": "BinomialTheoremOQ02OQ04",
+    "lineCount": 208,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/BinomialTheoremOQ02OQ04.lean"
+  }
 }

--- a/src/data/proofs/birthday-problem-oq-03/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03/meta.json
@@ -57,10 +57,10 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "The birthday problem, first stated by Richard von Mises in *\u00dcber Aufteilungs- und Besetzungswahrscheinlichkeiten* (1939), asks how many people are needed for a >50% chance of a shared birthday. The answer \u2014 just 23 \u2014 is famously counterintuitive and became a staple of probability pedagogy.\n\nThe natural generalization to k-way coincidences asks: when do k people share a birthday? This connects to the classical occupancy problem in combinatorics, studied by Flajolet, Gardy, and Thimonier (1992) using analytic combinatorics, and by Wendl (2003) in the context of DNA sequence assembly. The threshold for a k-way collision scales roughly as $d^{(k-1)/k} \\cdot (k!)^{1/k}$: for $d = 365$ days, $k=2$ needs ~23 people, $k=3$ needs ~88, and $k=4$ needs ~187.\n\nThe generalized pigeonhole principle underlying this formalization was first explicitly formulated by Dirichlet (1834) as the *Schubfachprinzip* (drawer principle). The k-way version \u2014 if $n > (k-1)d$ items are placed in $d$ containers, some container holds $\\geq k$ items \u2014 is a straightforward extension that appears in virtually every combinatorics textbook. Applications range from hash table collision analysis in computer science to the coupon collector's problem and urn models in probability.",
+    "historicalContext": "The birthday problem, first stated by Richard von Mises in *Über Aufteilungs- und Besetzungswahrscheinlichkeiten* (1939), asks how many people are needed for a >50% chance of a shared birthday. The answer — just 23 — is famously counterintuitive and became a staple of probability pedagogy.\n\nThe natural generalization to k-way coincidences asks: when do k people share a birthday? This connects to the classical occupancy problem in combinatorics, studied by Flajolet, Gardy, and Thimonier (1992) using analytic combinatorics, and by Wendl (2003) in the context of DNA sequence assembly. The threshold for a k-way collision scales roughly as $d^{(k-1)/k} \\cdot (k!)^{1/k}$: for $d = 365$ days, $k=2$ needs ~23 people, $k=3$ needs ~88, and $k=4$ needs ~187.\n\nThe generalized pigeonhole principle underlying this formalization was first explicitly formulated by Dirichlet (1834) as the *Schubfachprinzip* (drawer principle). The k-way version — if $n > (k-1)d$ items are placed in $d$ containers, some container holds $\\geq k$ items — is a straightforward extension that appears in virtually every combinatorics textbook. Applications range from hash table collision analysis in computer science to the coupon collector's problem and urn models in probability.",
     "problemStatement": "Formalize k-way birthday coincidences: given n people and d days, prove the generalized pigeonhole bound (n > (k-1)*d implies a k-way coincidence is certain), and show the k=2 case recovers the classical birthday problem.",
     "text": "Generalizes the Birthday Problem from pairwise collisions to k-way coincidences. Proves the generalized pigeonhole bound, classical recovery (k=2 equals non-injectivity), monotonicity, and probability formulas. Fully proved with 0 axioms and 0 sorries.",
-    "proofStrategy": "The proof architecture has three layers. **Layer 1 (Structural foundation)**: Model birthday assignments as functions $f : \\text{Fin}\\,n \\to \\text{Fin}\\,d$ and define fibers $f^{-1}(j)$ via `Finset.filter`. Prove the partition-of-unity identity $\\sum_j |f^{-1}(j)| = n$ using `Finset.card_eq_sum_card_fiberwise`. **Layer 2 (Combinatorial core)**: The generalized pigeonhole follows by contradiction \u2014 if every fiber has $< k$ elements then $n \\leq (k-1)d$, contradicting the hypothesis. Classical recovery shows `HasKWay f 2 \u2194 \u00acInjective f` by extracting distinct witnesses from fibers of size $\\geq 2$ via `Finset.one_lt_card`. Monotonicity is a direct `le_trans`. **Layer 3 (Probabilistic framework)**: Define `noKWaySet` (safe assignments) and `probKWay` via complementary counting. The pigeonhole bound lifts to $P = 1$, the population bound gives $P = 0$, and set containment gives monotonicity in $k$. The $k=2$ case connects to the classical formula by identifying safe assignments with injections.",
+    "proofStrategy": "The proof architecture has three layers. **Layer 1 (Structural foundation)**: Model birthday assignments as functions $f : \\text{Fin}\\,n \\to \\text{Fin}\\,d$ and define fibers $f^{-1}(j)$ via `Finset.filter`. Prove the partition-of-unity identity $\\sum_j |f^{-1}(j)| = n$ using `Finset.card_eq_sum_card_fiberwise`. **Layer 2 (Combinatorial core)**: The generalized pigeonhole follows by contradiction — if every fiber has $< k$ elements then $n \\leq (k-1)d$, contradicting the hypothesis. Classical recovery shows `HasKWay f 2 ↔ ¬Injective f` by extracting distinct witnesses from fibers of size $\\geq 2$ via `Finset.one_lt_card`. Monotonicity is a direct `le_trans`. **Layer 3 (Probabilistic framework)**: Define `noKWaySet` (safe assignments) and `probKWay` via complementary counting. The pigeonhole bound lifts to $P = 1$, the population bound gives $P = 0$, and set containment gives monotonicity in $k$. The $k=2$ case connects to the classical formula by identifying safe assignments with injections.",
     "keyInsights": [
       "The fiber decomposition (using Finset.card_eq_sum_card_fiberwise) is the key structural tool: it converts the global constraint on n into local constraints on each day",
       "The generalized pigeonhole follows from a simple averaging argument: n people in d bins with each bin having < k means n < k*d",
@@ -71,7 +71,7 @@
     ],
     "prerequisites": [
       "Finite sets and cardinality (Finset, Finset.card)",
-      "Functions between finite types (Fin n \u2192 Fin d)",
+      "Functions between finite types (Fin n → Fin d)",
       "Injectivity and the pigeonhole principle",
       "Basic probability as counting over finite sample spaces"
     ]
@@ -82,15 +82,15 @@
       "title": "Core Definitions",
       "startLine": 34,
       "endLine": 48,
-      "summary": "Defines `fiberAt f j` (the preimage fiber \u2014 the set of people assigned to day j) and `HasKWay f k` (existential predicate: some day has \u2265 k people). These two definitions drive the entire formalization.",
-      "mathContext": "Defines `fiberAt f j` (the preimage fiber \u2014 the set of people assigned to day j) and `HasKWay f k` (existential predicate: some day has \u2265 k people). These two definitions drive the entire formalization."
+      "summary": "Defines `fiberAt f j` (the preimage fiber — the set of people assigned to day j) and `HasKWay f k` (existential predicate: some day has ≥ k people). These two definitions drive the entire formalization.",
+      "mathContext": "Defines `fiberAt f j` (the preimage fiber — the set of people assigned to day j) and `HasKWay f k` (existential predicate: some day has ≥ k people). These two definitions drive the entire formalization."
     },
     {
       "id": "fiber-partition",
       "title": "Fiber Partition of Unity",
       "startLine": 49,
       "endLine": 64,
-      "summary": "Proves the partition-of-unity identity: fiber sizes sum to n. Uses `Finset.card_eq_sum_card_fiberwise` \u2014 the structural foundation for the generalized pigeonhole argument.",
+      "summary": "Proves the partition-of-unity identity: fiber sizes sum to n. Uses `Finset.card_eq_sum_card_fiberwise` — the structural foundation for the generalized pigeonhole argument.",
       "mathContext": "$\\sum_{j \\in [d]} |f^{-1}(j)| = n$. The fibers partition $[n]$: $\\bigsqcup_{j=1}^d f^{-1}(j) = [n]$, so their cardinalities sum to $n$. Uses `Finset.card_biUnion`."
     },
     {
@@ -160,7 +160,7 @@
   ],
   "conclusion": {
     "summary": "Provides a complete formalization of k-way birthday coincidences with 0 axioms and 0 sorries. The 25 theorems cover the generalized pigeonhole principle, classical recovery, monotonicity, probability formulas, and counting results.",
-    "implications": "**Computer Science**: k-way collisions directly model hash table overflow \u2014 a hash function $h : \\text{Keys} \\to \\text{Buckets}$ with $k$ collisions at one bucket triggers expensive chain traversal or rehashing. The pigeonhole bound $(k-1) \\cdot d < n$ gives the hard threshold where overflow is guaranteed, informing hash table sizing. In cryptography, k-way collision resistance is strictly stronger than pairwise collision resistance: the birthday attack on hash functions uses $k=2$, but multi-collision attacks (Joux 2004) exploit $k > 2$ to break iterated hash constructions.\n\n**Load Balancing**: In distributed systems, ensuring no server receives more than $k$ requests requires $n \\leq (k-1) \\cdot d$ where $d$ is the number of servers. This formalization proves the exact capacity limit.\n\n**DNA Sequencing**: Wendl (2003) applied k-way birthday statistics to shotgun DNA sequencing, where $k$-fold coverage (at least $k$ reads covering each position) is needed for reliable assembly. The probability framework formalized here gives the theoretical foundation for coverage depth analysis.",
+    "implications": "**Computer Science**: k-way collisions directly model hash table overflow — a hash function $h : \\text{Keys} \\to \\text{Buckets}$ with $k$ collisions at one bucket triggers expensive chain traversal or rehashing. The pigeonhole bound $(k-1) \\cdot d < n$ gives the hard threshold where overflow is guaranteed, informing hash table sizing. In cryptography, k-way collision resistance is strictly stronger than pairwise collision resistance: the birthday attack on hash functions uses $k=2$, but multi-collision attacks (Joux 2004) exploit $k > 2$ to break iterated hash constructions.\n\n**Load Balancing**: In distributed systems, ensuring no server receives more than $k$ requests requires $n \\leq (k-1) \\cdot d$ where $d$ is the number of servers. This formalization proves the exact capacity limit.\n\n**DNA Sequencing**: Wendl (2003) applied k-way birthday statistics to shotgun DNA sequencing, where $k$-fold coverage (at least $k$ reads covering each position) is needed for reliable assembly. The probability framework formalized here gives the theoretical foundation for coverage depth analysis.",
     "openQuestions": [
       "Can the exact threshold for k=3 (approximately n=88 for d=365) be computed using multinomial coefficient sums?",
       "Can the Poisson approximation for k-way coincidences be formalized, connecting to Mathlib's probability theory?",
@@ -176,7 +176,7 @@
     {
       "targetId": "birthday-problem-oq-02",
       "relationship": "related",
-      "description": "The asymptotic bound formalization complements this combinatorial approach \u2014 OQ-02 provides the $\\sqrt{2d \\ln 2} \\approx 22.5$ threshold formula, while this entry provides the exact pigeonhole bound and extends to $k > 2$"
+      "description": "The asymptotic bound formalization complements this combinatorial approach — OQ-02 provides the $\\sqrt{2d \\ln 2} \\approx 22.5$ threshold formula, while this entry provides the exact pigeonhole bound and extends to $k > 2$"
     },
     {
       "targetId": "ramseys-theorem",
@@ -186,19 +186,19 @@
     {
       "targetId": "infinitude-primes",
       "relationship": "technique",
-      "description": "Both use counting/contradiction arguments: the generalized pigeonhole bounds fiber sizes, while Euclid's proof bounds the number of primes. The proof structure \u2014 assume a bound, sum over components, derive a contradiction \u2014 is shared"
+      "description": "Both use counting/contradiction arguments: the generalized pigeonhole bounds fiber sizes, while Euclid's proof bounds the number of primes. The proof structure — assume a bound, sum over components, derive a contradiction — is shared"
     }
   ],
   "references": [
     {
       "authors": "von Mises, Richard",
-      "title": "\u00dcber Aufteilungs- und Besetzungswahrscheinlichkeiten",
+      "title": "Über Aufteilungs- und Besetzungswahrscheinlichkeiten",
       "year": "1939",
-      "venue": "Revue de la Facult\u00e9 des Sciences de l'Universit\u00e9 d'Istanbul",
+      "venue": "Revue de la Faculté des Sciences de l'Université d'Istanbul",
       "note": "First formal statement of the birthday problem in its modern probabilistic form"
     },
     {
-      "authors": "Flajolet, Philippe; Gardy, Dani\u00e8le; Thimonier, Lo\u00ffs",
+      "authors": "Flajolet, Philippe; Gardy, Danièle; Thimonier, Loÿs",
       "title": "Birthday Paradox, Coupon Collectors, Caching Algorithms and Self-Organizing Search",
       "year": "1992",
       "venue": "Discrete Applied Mathematics, vol. 39, pp. 207-229",
@@ -215,9 +215,22 @@
       "authors": "Joux, Antoine",
       "title": "Multicollisions in Iterated Hash Functions",
       "year": "2004",
-      "venue": "Advances in Cryptology \u2013 CRYPTO 2004, LNCS 3152, pp. 306-316",
+      "venue": "Advances in Cryptology – CRYPTO 2004, LNCS 3152, pp. 306-316",
       "note": "Showed that k-way collisions (multicollisions) in iterated hash functions are surprisingly easy to find, extending the birthday attack from k=2 to arbitrary k with cost only k times the pairwise birthday bound"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "BirthdayKWay",
+    "lineCount": 369,
+    "axiomCount": 0,
+    "theoremCount": 19,
+    "definitionCount": 4,
+    "sorries": 0,
+    "path": "Proofs/BirthdayProblemOQ03.lean"
+  }
 }

--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-01/meta.json
@@ -131,5 +131,19 @@
       "description": "Sibling: type-theoretic Lawvere FPT in types (not CCC generality). This entry recovers it as a special case via typeEvalStructure."
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.Logic.Function.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [],
+    "namespace": "CantorDiagonalizationOQ03OQ01",
+    "lineCount": 304,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 4,
+    "sorries": 1,
+    "path": "Proofs/CantorDiagonalizationOQ03OQ01.lean"
+  }
 }

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -135,5 +135,27 @@
       "description": "Ancestor in the OQ chain: the integral Cauchy-Schwarz inequality that started this line of power mean research"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.MeanInequalities",
+      "Mathlib.Analysis.MeanInequalitiesPow",
+      "Mathlib.Analysis.SpecialFunctions.Pow.Real",
+      "Mathlib.Tactic",
+      "Proofs.AmgmInequalityOQ03",
+      "Proofs.PowerMeanCrossZeroOQ"
+    ],
+    "opens": [
+      "Real",
+      "Finset",
+      "PowerMeanCrossZero"
+    ],
+    "namespace": "PowerMeanMonotone",
+    "lineCount": 194,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/PowerMeanMonotoneOQ.lean"
+  }
 }

--- a/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "cayley-hamilton-reduction-oq-02-oq-01",
   "title": "Rational Canonical Form: Companion Matrix",
   "slug": "cayley-hamilton-reduction-oq-02-oq-01",
-  "description": "Companion matrix definition and properties \u2014 the building block of rational canonical form (Frobenius normal form).",
+  "description": "Companion matrix definition and properties — the building block of rational canonical form (Frobenius normal form).",
   "meta": {
     "author": "Ferdinand Georg Frobenius (1878)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Frobenius_normal_form",
@@ -45,15 +45,15 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "The companion matrix appears implicitly in Arthur Cayley's 1858 work on linear transformations, and was codified by Ferdinand Frobenius in his 1878 paper '\u00dcber lineare Substitutionen und bilineare Formen', where the rational canonical form (Frobenius normal form) was established. Unlike the Jordan canonical form (Jordan 1870), which requires the characteristic polynomial to split into linear factors over the base field, the rational canonical form works over any field: it is the canonical block-diagonal decomposition using invariant factors rather than eigenvalues. The companion matrix C(p) is the matrix representation of multiplication by x on the quotient module F[X]/(p), making it the elementary algebraic object from which all F[X]-modules are built (via the primary decomposition theorem for modules over PIDs). The orbit argument \u2014 that {e\u2080, Ce\u2080, ..., C^{d-1}e\u2080} is the standard basis \u2014 is the key fact, and was known to Frobenius. The full RCF formalization in a proof assistant has been completed in Coq by Cano-D\u00e9n\u00e8s (2012) and in Isabelle/HOL by Divas\u00f3n-Thiemann (2016); a Lean 4 formalization is an active gap in Mathlib.",
+    "historicalContext": "The companion matrix appears implicitly in Arthur Cayley's 1858 work on linear transformations, and was codified by Ferdinand Frobenius in his 1878 paper 'Über lineare Substitutionen und bilineare Formen', where the rational canonical form (Frobenius normal form) was established. Unlike the Jordan canonical form (Jordan 1870), which requires the characteristic polynomial to split into linear factors over the base field, the rational canonical form works over any field: it is the canonical block-diagonal decomposition using invariant factors rather than eigenvalues. The companion matrix C(p) is the matrix representation of multiplication by x on the quotient module F[X]/(p), making it the elementary algebraic object from which all F[X]-modules are built (via the primary decomposition theorem for modules over PIDs). The orbit argument — that {e₀, Ce₀, ..., C^{d-1}e₀} is the standard basis — is the key fact, and was known to Frobenius. The full RCF formalization in a proof assistant has been completed in Coq by Cano-Dénès (2012) and in Isabelle/HOL by Divasón-Thiemann (2016); a Lean 4 formalization is an active gap in Mathlib.",
     "problemStatement": "Define the companion matrix $C(p)$ for a monic polynomial $p$ of degree $d$ and prove: (1) the orbit $\\{e_0, C(p)e_0, \\ldots, C(p)^{d-1}e_0\\}$ is the standard basis; (2) $p(C(p)) = 0$; (3) $\\mathrm{charpoly}(C(p)) = p$; (4) $\\mathrm{minpoly}(C(p)) = p$.",
-    "proofStrategy": "Five parts: explicit entry-formula definition, three entry-characterization lemmas, orbit argument (C(p)\u1d4f\u00b7e\u2080 = e\u2096 proved by induction), three key theorems (sorry: annihilation, charpoly, minpoly), and the linear-polynomial base case C(x\u2212c) = [c]. A final roadmap assesses the ~1800-line gap for the full RCF theorem.",
+    "proofStrategy": "Five parts: explicit entry-formula definition, three entry-characterization lemmas, orbit argument (C(p)ᵏ·e₀ = eₖ proved by induction), three key theorems (sorry: annihilation, charpoly, minpoly), and the linear-polynomial base case C(x−c) = [c]. A final roadmap assesses the ~1800-line gap for the full RCF theorem.",
     "keyInsights": [
-      "The companion matrix C(p) is the canonical matrix representation of multiplication by x on F[X]/(p): the orbit {e\u2080, C(p)e\u2080, ..., C(p)^{d-1}e\u2080} = standard basis confirms the isomorphism F^d \u2245 F[X]/(p) as F[X]-modules",
+      "The companion matrix C(p) is the canonical matrix representation of multiplication by x on F[X]/(p): the orbit {e₀, C(p)e₀, ..., C(p)^{d-1}e₀} = standard basis confirms the isomorphism F^d ≅ F[X]/(p) as F[X]-modules",
       "Companion matrices are non-derogatory: minpoly = charpoly = p, making them the unique matrix type (up to similarity) with a given characteristic polynomial of full degree",
-      "The rational canonical form works over any field without splitting the characteristic polynomial, unlike Jordan form \u2014 this is its fundamental advantage for fields like \u211a or \ud835\udd3d_p",
-      "The orbit argument gives a clean proof of p(C(p)) = 0 without computing a determinant: C(p)^d\u00b7e\u2080 = (last-column action) = \u2212\u2211 a\u1d62e\u1d62, which cancels with the polynomial evaluation sum",
-      "The main formalization blocker is Smith Normal Form for F[X]-matrices (~800 lines): Mathlib has SNF for \u2124 but not yet for arbitrary Euclidean domains in constructive form"
+      "The rational canonical form works over any field without splitting the characteristic polynomial, unlike Jordan form — this is its fundamental advantage for fields like ℚ or 𝔽_p",
+      "The orbit argument gives a clean proof of p(C(p)) = 0 without computing a determinant: C(p)^d·e₀ = (last-column action) = −∑ aᵢeᵢ, which cancels with the polynomial evaluation sum",
+      "The main formalization blocker is Smith Normal Form for F[X]-matrices (~800 lines): Mathlib has SNF for ℤ but not yet for arbitrary Euclidean domains in constructive form"
     ]
   },
   "sections": [
@@ -69,14 +69,14 @@
       "title": "Part 2: Basic Entry Properties",
       "startLine": 82,
       "endLine": 108,
-      "summary": "Three lemmas characterizing the three entry types: `companionMatrix_subdiag` (subdiagonal = 1), `companionMatrix_last_col` (last column = \u2212coeff), `companionMatrix_zero` (elsewhere = 0)."
+      "summary": "Three lemmas characterizing the three entry types: `companionMatrix_subdiag` (subdiagonal = 1), `companionMatrix_last_col` (last column = −coeff), `companionMatrix_zero` (elsewhere = 0)."
     },
     {
       "id": "orbit",
       "title": "Part 3: Orbit of Standard Basis Vectors",
       "startLine": 110,
       "endLine": 168,
-      "summary": "Proves C(p)\u1d4f\u00b7e\u2080 = e\u2096 for k < d by induction using the column action lemmas. The orbit {e\u2080, ..., e_{d-1}} equals the standard basis."
+      "summary": "Proves C(p)ᵏ·e₀ = eₖ for k < d by induction using the column action lemmas. The orbit {e₀, ..., e_{d-1}} equals the standard basis."
     },
     {
       "id": "key-theorems",
@@ -90,7 +90,7 @@
       "title": "Part 4: Linear Polynomial Base Case",
       "startLine": 213,
       "endLine": 225,
-      "summary": "Proves C(x\u2212c) = [c] for the 1\u00d71 companion matrix, connecting companion blocks to eigenvalues."
+      "summary": "Proves C(x−c) = [c] for the 1×1 companion matrix, connecting companion blocks to eigenvalues."
     },
     {
       "id": "rcf-roadmap",
@@ -105,15 +105,15 @@
     "implications": "The companion matrix and rational canonical form are central to module theory over PIDs: the structure theorem for finitely generated modules over a PID is exactly the RCF when applied to F[X]-modules. Applications include: normal forms for linear recurrences (companion matrix of the characteristic polynomial of the recurrence), the theory of cyclic codes in coding theory, and the proof that every matrix satisfies its own characteristic polynomial (Cayley-Hamilton, for which the companion matrix gives the cleanest proof). A complete Lean formalization would unlock these applications in Mathlib.",
     "openQuestions": [
       "Can the full Rational Canonical Form theorem be formalized? The companion matrix properties are now proved; the remaining gap is Smith Normal Form for F[X]-matrices (~800 lines).",
-      "Is Mathlib's existing Smith Normal Form for \u2124 (Hermite normal form infrastructure) adaptable to F[X] via the generic Euclidean domain API?",
-      "The rational canonical form has been formalized in Coq (Cano-D\u00e9n\u00e8s 2012) and Isabelle (Divas\u00f3n-Thiemann 2016) \u2014 could a porting strategy from one of these reduce the estimated 1800-line effort?"
+      "Is Mathlib's existing Smith Normal Form for ℤ (Hermite normal form infrastructure) adaptable to F[X] via the generic Euclidean domain API?",
+      "The rational canonical form has been formalized in Coq (Cano-Dénès 2012) and Isabelle (Divasón-Thiemann 2016) — could a porting strategy from one of these reduce the estimated 1800-line effort?"
     ]
   },
   "mainTheorems": [
     {
       "name": "aeval_companionMatrix",
       "type": "core",
-      "description": "The companion matrix C(p) is annihilated by p: p(C(p)) = 0, proved via the orbit argument showing C(p)^k\u00b7e\u2080 = e_k for k < d and the last-column action."
+      "description": "The companion matrix C(p) is annihilated by p: p(C(p)) = 0, proved via the orbit argument showing C(p)^k·e₀ = e_k for k < d and the last-column action."
     },
     {
       "name": "charpoly_companionMatrix",
@@ -123,7 +123,7 @@
     {
       "name": "minpoly_companionMatrix",
       "type": "supporting",
-      "description": "The minimal polynomial of C(p) equals p, establishing that companion matrices are non-derogatory \u2014 minpoly = charpoly \u2014 a key property for rational canonical form."
+      "description": "The minimal polynomial of C(p) equals p, establishing that companion matrices are non-derogatory — minpoly = charpoly — a key property for rational canonical form."
     }
   ],
   "crossReferences": [
@@ -137,5 +137,29 @@
       "targetId": "cayley-hamilton-reduction-oq-02"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.LinearAlgebra.Matrix.Charpoly.Basic",
+      "Mathlib.LinearAlgebra.Matrix.Charpoly.Coeff",
+      "Mathlib.LinearAlgebra.Matrix.Charpoly.Minpoly",
+      "Mathlib.Algebra.Polynomial.Div",
+      "Mathlib.FieldTheory.Minpoly.Basic",
+      "Mathlib.FieldTheory.Minpoly.Field",
+      "Mathlib.Data.Matrix.Block",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Matrix",
+      "Polynomial",
+      "BigOperators"
+    ],
+    "namespace": "CayleyHamiltonReductionOQ02OQ01",
+    "lineCount": 397,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 1,
+    "sorries": 0,
+    "path": "Proofs/CayleyHamiltonReductionOQ02OQ01.lean"
+  }
 }

--- a/src/data/proofs/derangements-convergence-oq-01/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-01/meta.json
@@ -127,5 +127,26 @@
       "mathContext": "$1/(k! \\cdot (n-k+1)!) \\leq 1/(n-k+1)!$ since $k! \\geq 1$ for $k \\geq 0$."
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Proofs.DerangementsConvergence",
+      "Proofs.DerangementsOQ02",
+      "Mathlib.Combinatorics.Derangements.Exponential",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Nat",
+      "Real",
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "KFixedConvergence",
+    "lineCount": 153,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "sorries": 3,
+    "path": "Proofs/DerangementsConvergenceOQ01.lean"
+  }
 }

--- a/src/data/proofs/divisibility-by-3-oq-03-oq-02/meta.json
+++ b/src/data/proofs/divisibility-by-3-oq-03-oq-02/meta.json
@@ -6,7 +6,13 @@
   "meta": {
     "status": "verified",
     "proofRepoPath": "Proofs/DivisibilityBy3OQ03OQ02.lean",
-    "tags": ["number-theory", "divisibility", "digital-root", "modular-arithmetic", "research"],
+    "tags": [
+      "number-theory",
+      "divisibility",
+      "digital-root",
+      "modular-arithmetic",
+      "research"
+    ],
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
@@ -160,5 +166,20 @@
       "note": "Studies the multiplicative and additive properties of digital roots in arbitrary bases, proving asymptotic results about their distribution."
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "namespace": "DigitalRootBase",
+    "lineCount": 212,
+    "axiomCount": 0,
+    "theoremCount": 19,
+    "definitionCount": 1,
+    "sorries": 0,
+    "path": "Proofs/DivisibilityBy3OQ03OQ02.lean"
+  }
 }

--- a/src/data/proofs/erdos-1179-oq-01/meta.json
+++ b/src/data/proofs/erdos-1179-oq-01/meta.json
@@ -2,9 +2,9 @@
   "id": "erdos-1179-oq-01",
   "title": "Second-Order Term in Uniform Subset Sum Representations",
   "slug": "erdos-1179-oq-01",
-  "description": "What is the precise second-order term in g_\u03b5(N)? Formalizes the correction term hierarchy (O(1) vs \u0398(log log N) vs o(log N)) and proves foundational properties of representation counts in \u2124/N\u2124, including the partition identity \u2211_g F_A(g) = 2^|A|, monotonicity under set growth, and coverage monotonicity. Proves erdos_renyi_decay (exponential decay of Fourier error) from the corrected fourier_error_bound axiom via geometric series arguments.",
+  "description": "What is the precise second-order term in g_ε(N)? Formalizes the correction term hierarchy (O(1) vs Θ(log log N) vs o(log N)) and proves foundational properties of representation counts in ℤ/Nℤ, including the partition identity ∑_g F_A(g) = 2^|A|, monotonicity under set growth, and coverage monotonicity. Proves erdos_renyi_decay (exponential decay of Fourier error) from the corrected fourier_error_bound axiom via geometric series arguments.",
   "meta": {
-    "author": "Open Question (Erd\u0151s #1179)",
+    "author": "Open Question (Erdős #1179)",
     "sourceUrl": "https://erdosproblems.com/1179",
     "date": "2026",
     "status": "verified",
@@ -42,31 +42,31 @@
       },
       {
         "theorem": "Real.logb_rpow",
-        "description": "logb b (b^x) = x for b > 0, b \u2260 1; used in the O(1) \u27f9 o(log N) proof",
+        "description": "logb b (b^x) = x for b > 0, b ≠ 1; used in the O(1) ⟹ o(log N) proof",
         "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
       },
       {
         "theorem": "Real.log_le_log",
-        "description": "Monotonicity of real logarithm; used to transfer N \u2265 2^m to log\u2082 N \u2265 m",
+        "description": "Monotonicity of real logarithm; used to transfer N ≥ 2^m to log₂ N ≥ m",
         "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
       },
       {
         "theorem": "Nat.ceil",
-        "description": "Ceiling function \u211d \u2192 \u2115; used to convert C/\u03b4 bound to a natural number threshold",
+        "description": "Ceiling function ℝ → ℕ; used to convert C/δ bound to a natural number threshold",
         "module": "Mathlib.Data.Real.Basic"
       }
     ],
     "originalContributions": [
-      "Formalization of the correction term hierarchy: three candidate rates (O(1), \u0398(log log N), o(log N)) as Lean propositions with proof that O(1) \u27f9 o(log N)",
-      "Proof of the partition identity \u2211_g F_A(g) = 2^|A| via fiber decomposition of the powerset",
+      "Formalization of the correction term hierarchy: three candidate rates (O(1), Θ(log log N), o(log N)) as Lean propositions with proof that O(1) ⟹ o(log N)",
+      "Proof of the partition identity ∑_g F_A(g) = 2^|A| via fiber decomposition of the powerset",
       "Proof of monotonicity: reprCount never decreases under set insertion",
       "Proof of coverage monotonicity: the support of F_A grows with |A|",
-      "Axiomatization of the Fourier-analytic character sum bound for representation counts in \u2124/p\u2124"
+      "Axiomatization of the Fourier-analytic character sum bound for representation counts in ℤ/pℤ"
     ],
     "relatedProblems": [
       {
         "id": "erdos-1179",
-        "relationship": "Parent problem: the main Erd\u0151s #1179 formalization establishing g_\u03b5(N) ~ log\u2082 N"
+        "relationship": "Parent problem: the main Erdős #1179 formalization establishing g_ε(N) ~ log₂ N"
       }
     ]
   },
@@ -76,12 +76,12 @@
       "title": "Problem Context and Imports",
       "startLine": 1,
       "endLine": 33,
-      "summary": "Module docstring describing Erd\u0151s #1179's open question on the second-order correction term in $g_\\varepsilon(N)$. Eight Mathlib imports (Finset, ZMod, Real, Log, Tactic). Namespace and `open` declarations.",
-      "mathContext": "The open question: what is the precise form of $g_\\varepsilon(N) - \\log_2 N$? Known bounds: $g_\\varepsilon(N) \\geq \\log_2 N$ (trivial) and $g_\\varepsilon(N) \\leq \\log_2 N \\cdot (1 + O_\\varepsilon(\\log\\log\\log N / \\log\\log N))$ (Erd\u0151s-Hall 1976)."
+      "summary": "Module docstring describing Erdős #1179's open question on the second-order correction term in $g_\\varepsilon(N)$. Eight Mathlib imports (Finset, ZMod, Real, Log, Tactic). Namespace and `open` declarations.",
+      "mathContext": "The open question: what is the precise form of $g_\\varepsilon(N) - \\log_2 N$? Known bounds: $g_\\varepsilon(N) \\geq \\log_2 N$ (trivial) and $g_\\varepsilon(N) \\leq \\log_2 N \\cdot (1 + O_\\varepsilon(\\log\\log\\log N / \\log\\log N))$ (Erdős-Hall 1976)."
     },
     {
       "id": "reprcount-foundations",
-      "title": "Part I: Representation Counts in \u2124/N\u2124",
+      "title": "Part I: Representation Counts in ℤ/Nℤ",
       "startLine": 35,
       "endLine": 64,
       "summary": "Defines `reprCount A g` as the number of subsets of $A$ summing to $g$ in $\\mathbb{Z}/N\\mathbb{Z}$. Proves the partition identity $\\sum_g F_A(g) = 2^{|A|}$ via `card_eq_sum_card_fiberwise`. Base cases: $F_\\emptyset(0) = 1$ and $F_\\emptyset(g) = 0$ for $g \\neq 0$.",
@@ -92,7 +92,7 @@
       "title": "Part II: Monotonicity Under Set Growth",
       "startLine": 66,
       "endLine": 83,
-      "summary": "Proves `reprCount_insert_ge`: $F_{A \\cup \\{b\\}}(g) \\geq F_A(g)$ \u2014 adding an element to $A$ never decreases representation counts, because every subset of $A$ is also a subset of $A \\cup \\{b\\}$. Also proves `reprCount_nonneg` (trivially, since counts are natural numbers).",
+      "summary": "Proves `reprCount_insert_ge`: $F_{A \\cup \\{b\\}}(g) \\geq F_A(g)$ — adding an element to $A$ never decreases representation counts, because every subset of $A$ is also a subset of $A \\cup \\{b\\}$. Also proves `reprCount_nonneg` (trivially, since counts are natural numbers).",
       "mathContext": "The monotonicity $F_{A \\cup \\{b\\}}(g) \\geq F_A(g)$ follows from set inclusion: $\\{S \\subseteq A : \\sigma(S) = g\\} \\subseteq \\{S \\subseteq A \\cup \\{b\\} : \\sigma(S) = g\\}$."
     },
     {
@@ -108,7 +108,7 @@
       "title": "Part IV: Coverage Monotonicity",
       "startLine": 101,
       "endLine": 113,
-      "summary": "Proves `coverage_mono`: $|\\text{supp}(F_A)| \\leq |\\text{supp}(F_{A \\cup \\{b\\}})|$ \u2014 the number of represented group elements grows monotonically with set size. Direct consequence of `reprCount_insert_ge`.",
+      "summary": "Proves `coverage_mono`: $|\\text{supp}(F_A)| \\leq |\\text{supp}(F_{A \\cup \\{b\\}})|$ — the number of represented group elements grows monotonically with set size. Direct consequence of `reprCount_insert_ge`.",
       "mathContext": "$|\\{g : F_A(g) > 0\\}| \\leq |\\{g : F_{A \\cup \\{b\\}}(g) > 0\\}|$. If $F_A(g) > 0$, then $F_{A \\cup \\{b\\}}(g) \\geq F_A(g) > 0$."
     },
     {
@@ -137,28 +137,28 @@
     }
   ],
   "overview": {
-    "historicalContext": "Erd\u0151s Problem #1179 asks about uniform subset sum representations in finite abelian groups. Given a group $G$ of order $N$ and $\\varepsilon > 0$, define $g_\\varepsilon(N)$ as the smallest $k$ such that a random $k$-subset $A \\subseteq G$ makes all representation counts $F_A(g)$ approximately equal to $2^k/N$ with high probability.\n\nThe study of subset sum representations began with Erd\u0151s and R\u00e9nyi's 1965 paper, which introduced the second-moment method to show that $k \\approx 2\\log_2 N$ suffices for coverage (all elements representable). Erd\u0151s and Hall (1976) sharpened this to $g_\\varepsilon(N) \\sim \\log_2 N$, establishing the leading term. Their upper bound $g_\\varepsilon(N) \\leq \\log_2 N \\cdot (1 + O_\\varepsilon(\\log\\log\\log N / \\log\\log N))$ leaves the second-order correction unknown.\n\nThe question of the precise second-order term connects to the broader theme of 'how random is random enough?' in additive combinatorics. The closely related Problem #543 (random subset sums spanning the group) was disproved: the $O(\\log\\log N)$ correction term is optimal, suggesting by analogy that $\\Theta(\\log\\log N)$ may be the correct rate here as well. However, the uniformity condition in Problem #1179 is strictly stronger than the coverage condition in #543, so the analogy is not conclusive.",
+    "historicalContext": "Erdős Problem #1179 asks about uniform subset sum representations in finite abelian groups. Given a group $G$ of order $N$ and $\\varepsilon > 0$, define $g_\\varepsilon(N)$ as the smallest $k$ such that a random $k$-subset $A \\subseteq G$ makes all representation counts $F_A(g)$ approximately equal to $2^k/N$ with high probability.\n\nThe study of subset sum representations began with Erdős and Rényi's 1965 paper, which introduced the second-moment method to show that $k \\approx 2\\log_2 N$ suffices for coverage (all elements representable). Erdős and Hall (1976) sharpened this to $g_\\varepsilon(N) \\sim \\log_2 N$, establishing the leading term. Their upper bound $g_\\varepsilon(N) \\leq \\log_2 N \\cdot (1 + O_\\varepsilon(\\log\\log\\log N / \\log\\log N))$ leaves the second-order correction unknown.\n\nThe question of the precise second-order term connects to the broader theme of 'how random is random enough?' in additive combinatorics. The closely related Problem #543 (random subset sums spanning the group) was disproved: the $O(\\log\\log N)$ correction term is optimal, suggesting by analogy that $\\Theta(\\log\\log N)$ may be the correct rate here as well. However, the uniformity condition in Problem #1179 is strictly stronger than the coverage condition in #543, so the analogy is not conclusive.",
     "problemStatement": "Determine the precise rate at which $g_\\varepsilon(N) - \\log_2 N$ grows. Three candidates are formalized:\n\n1. **$O(1)$** (strongest): $g_\\varepsilon(N) = \\log_2 N + O_\\varepsilon(1)$\n2. **$\\Theta(\\log\\log N)$** (conjectured): $g_\\varepsilon(N) = \\log_2 N + \\Theta_\\varepsilon(\\log\\log N)$\n3. **$o(\\log_2 N)$** (known): $g_\\varepsilon(N) = (1 + o_\\varepsilon(1))\\log_2 N$",
-    "text": "A seven-part formalization in 525 lines investigating the second-order term in $g_\\varepsilon(N)$. Parts I\u2013IV prove foundational properties of representation counts in $\\mathbb{Z}/N\\mathbb{Z}$: the partition identity $\\sum_g F_A(g) = 2^{|A|}$ (via fiber decomposition of the powerset), monotonicity under set insertion ($F_{A \\cup \\{b\\}}(g) \\geq F_A(g)$), singleton bounds, and coverage monotonicity. Part V defines the correction term hierarchy \u2014 three candidate rates formalized as Lean propositions \u2014 and proves $O(1) \\Rightarrow o(\\log_2 N)$ via a 30-line epsilon-delta argument using `Real.logb` monotonicity and the Archimedean property. Part VI axiomatizes the Fourier-analytic character sum bounds from the Erd\u0151s-R\u00e9nyi method. Part VII summarizes the hierarchy as the clean theorem `second_order_hierarchy`. Zero axioms, two sorries, eleven theorems, seven definitions.",
-    "proofStrategy": "The formalization works concretely in $\\mathbb{Z}/N\\mathbb{Z}$ rather than abstract abelian groups, making the Finset/ZMod infrastructure directly available.\n\n**Parts I\u2013IV (Proved):** Build the foundation of representation counts: the central definition `reprCount A g = |\\{S \\subseteq A : \\sigma(S) = g\\}|`, the partition identity (via `card_eq_sum_card_fiberwise`), base cases for the empty set, monotonicity under element insertion (via powerset inclusion), and coverage growth. These are proved from Mathlib primitives with no axioms.\n\n**Part V (Proved):** The hierarchy theorem. Define three correction term hypotheses as Lean `Prop`s. Prove $O(1) \\Rightarrow o(\\log_2 N)$ by choosing $N_0 = 2^{\\lceil C/\\delta \\rceil + 2}$: for $N \\geq N_0$, $\\log_2 N \\geq \\lceil C/\\delta \\rceil + 2 > C/\\delta$, so $C < \\delta \\cdot \\log_2 N$.\n\n**Part VI (Axiomatized):** The Fourier character sum bound $|F_A(g) - 2^k/p| \\leq (p-1)|\\cos(\\pi/p)|^k$ and its consequence that errors decay exponentially for $k \\approx 2\\log_2 p$. Axiomatized because discrete Fourier analysis on $\\mathbb{Z}/p\\mathbb{Z}$ requires character group infrastructure not yet in Mathlib.",
+    "text": "A seven-part formalization in 525 lines investigating the second-order term in $g_\\varepsilon(N)$. Parts I–IV prove foundational properties of representation counts in $\\mathbb{Z}/N\\mathbb{Z}$: the partition identity $\\sum_g F_A(g) = 2^{|A|}$ (via fiber decomposition of the powerset), monotonicity under set insertion ($F_{A \\cup \\{b\\}}(g) \\geq F_A(g)$), singleton bounds, and coverage monotonicity. Part V defines the correction term hierarchy — three candidate rates formalized as Lean propositions — and proves $O(1) \\Rightarrow o(\\log_2 N)$ via a 30-line epsilon-delta argument using `Real.logb` monotonicity and the Archimedean property. Part VI axiomatizes the Fourier-analytic character sum bounds from the Erdős-Rényi method. Part VII summarizes the hierarchy as the clean theorem `second_order_hierarchy`. Zero axioms, two sorries, eleven theorems, seven definitions.",
+    "proofStrategy": "The formalization works concretely in $\\mathbb{Z}/N\\mathbb{Z}$ rather than abstract abelian groups, making the Finset/ZMod infrastructure directly available.\n\n**Parts I–IV (Proved):** Build the foundation of representation counts: the central definition `reprCount A g = |\\{S \\subseteq A : \\sigma(S) = g\\}|`, the partition identity (via `card_eq_sum_card_fiberwise`), base cases for the empty set, monotonicity under element insertion (via powerset inclusion), and coverage growth. These are proved from Mathlib primitives with no axioms.\n\n**Part V (Proved):** The hierarchy theorem. Define three correction term hypotheses as Lean `Prop`s. Prove $O(1) \\Rightarrow o(\\log_2 N)$ by choosing $N_0 = 2^{\\lceil C/\\delta \\rceil + 2}$: for $N \\geq N_0$, $\\log_2 N \\geq \\lceil C/\\delta \\rceil + 2 > C/\\delta$, so $C < \\delta \\cdot \\log_2 N$.\n\n**Part VI (Axiomatized):** The Fourier character sum bound $|F_A(g) - 2^k/p| \\leq (p-1)|\\cos(\\pi/p)|^k$ and its consequence that errors decay exponentially for $k \\approx 2\\log_2 p$. Axiomatized because discrete Fourier analysis on $\\mathbb{Z}/p\\mathbb{Z}$ requires character group infrastructure not yet in Mathlib.",
     "keyInsights": [
-      "**Partition Identity (Proved):** $\\sum_g F_A(g) = 2^{|A|}$ \u2014 representation counts fiber the powerset. This is the zero-th order fact: the average representation count is $2^{|A|}/N$, and uniformity means all $F_A(g)$ are close to this average.",
-      "**Monotonicity (Proved):** $F_{A \\cup \\{b\\}}(g) \\geq F_A(g)$ \u2014 adding elements never decreases representation counts. In fact, $F_{A \\cup \\{b\\}}(g) = F_A(g) + F_A(g - b)$ (convolution identity), so the increase is precisely the number of subsets of $A$ summing to $g - b$.",
-      "**Coverage Monotonicity (Proved):** $|\\text{supp}(F_A)| \\leq |\\text{supp}(F_{A \\cup \\{b\\}})|$ \u2014 larger sets represent more group elements. Full coverage ($|\\text{supp}| = N$) is a prerequisite for uniformity.",
-      "**Correction Hierarchy (Proved):** $O(1) \\Rightarrow o(\\log_2 N)$ \u2014 the three candidate rates form a strict hierarchy. The proof is an epsilon-delta argument using the Archimedean property of the reals to find $N_0$ such that $\\log_2 N_0 > C/\\delta$.",
-      "**Fourier Connection (Axiomatized):** In $\\mathbb{Z}/p\\mathbb{Z}$, character sums control representation count deviations: $|F_A(g) - 2^k/p| \\leq (p-1)|\\cos(\\pi/p)|^k$. The exponential decay $|\\cos(\\pi/p)|^k$ is the engine of the Erd\u0151s-R\u00e9nyi method.",
-      "**Problem #543 Analogy:** The disproof of Erd\u0151s #543 showed the $\\Theta(\\log\\log N)$ correction is optimal for the coverage problem. This suggests by analogy that $\\Theta(\\log\\log N)$ may be the correct rate for the uniformity problem (#1179), but the uniformity condition is strictly stronger, so the analogy is heuristic."
+      "**Partition Identity (Proved):** $\\sum_g F_A(g) = 2^{|A|}$ — representation counts fiber the powerset. This is the zero-th order fact: the average representation count is $2^{|A|}/N$, and uniformity means all $F_A(g)$ are close to this average.",
+      "**Monotonicity (Proved):** $F_{A \\cup \\{b\\}}(g) \\geq F_A(g)$ — adding elements never decreases representation counts. In fact, $F_{A \\cup \\{b\\}}(g) = F_A(g) + F_A(g - b)$ (convolution identity), so the increase is precisely the number of subsets of $A$ summing to $g - b$.",
+      "**Coverage Monotonicity (Proved):** $|\\text{supp}(F_A)| \\leq |\\text{supp}(F_{A \\cup \\{b\\}})|$ — larger sets represent more group elements. Full coverage ($|\\text{supp}| = N$) is a prerequisite for uniformity.",
+      "**Correction Hierarchy (Proved):** $O(1) \\Rightarrow o(\\log_2 N)$ — the three candidate rates form a strict hierarchy. The proof is an epsilon-delta argument using the Archimedean property of the reals to find $N_0$ such that $\\log_2 N_0 > C/\\delta$.",
+      "**Fourier Connection (Axiomatized):** In $\\mathbb{Z}/p\\mathbb{Z}$, character sums control representation count deviations: $|F_A(g) - 2^k/p| \\leq (p-1)|\\cos(\\pi/p)|^k$. The exponential decay $|\\cos(\\pi/p)|^k$ is the engine of the Erdős-Rényi method.",
+      "**Problem #543 Analogy:** The disproof of Erdős #543 showed the $\\Theta(\\log\\log N)$ correction is optimal for the coverage problem. This suggests by analogy that $\\Theta(\\log\\log N)$ may be the correct rate for the uniformity problem (#1179), but the uniformity condition is strictly stronger, so the analogy is heuristic."
     ],
     "prerequisites": [
       "Additive combinatorics (subset sums, representation counts)",
-      "Analysis (logarithms, asymptotics, O/\u0398/o notation)",
-      "Algebra (\u2124/N\u2124, abelian groups, ZMod)",
+      "Analysis (logarithms, asymptotics, O/Θ/o notation)",
+      "Algebra (ℤ/Nℤ, abelian groups, ZMod)",
       "Discrete Fourier analysis (character sums, for axiomatized results)"
     ]
   },
   "conclusion": {
-    "summary": "This formalization builds the algebraic and analytic foundations for studying the second-order correction in $g_\\varepsilon(N)$. The proved results \u2014 partition identity, monotonicity, coverage growth, and the correction hierarchy \u2014 provide the combinatorial scaffolding. The axiomatized Fourier bounds capture the analytic engine. The main theorem `bounded_implies_sublinear` establishes that the three candidate rates form a strict hierarchy, narrowing the open question to: which rate actually holds?",
-    "implications": "**Connections to additive combinatorics:** The representation count machinery (partition identity, monotonicity, convolution structure) connects to fundamental tools in additive number theory \u2014 Freiman's theorem, the Erd\u0151s-Ginzburg-Ziv theorem, and sumset estimates. The Fourier method axiomatized here is a special case of the Hardy-Littlewood circle method applied to finite groups.\n\n**Problem #543 analogy:** The disproof of #543 showed $\\Theta(\\log\\log N)$ is the optimal correction for coverage. If the uniformity problem (#1179) has the same answer, it would reveal a deep structural connection between 'covering all elements' and 'covering them uniformly' \u2014 both governed by the same second-order logarithmic correction.\n\n**Computational verification:** The formalized definitions are in principle computable for small $N$ (modulo the `noncomputable` annotation on `reprCount`). A computational investigation of $g_\\varepsilon(N)$ for small $N$ and various $\\varepsilon$ could provide empirical evidence for the correct rate.",
+    "summary": "This formalization builds the algebraic and analytic foundations for studying the second-order correction in $g_\\varepsilon(N)$. The proved results — partition identity, monotonicity, coverage growth, and the correction hierarchy — provide the combinatorial scaffolding. The axiomatized Fourier bounds capture the analytic engine. The main theorem `bounded_implies_sublinear` establishes that the three candidate rates form a strict hierarchy, narrowing the open question to: which rate actually holds?",
+    "implications": "**Connections to additive combinatorics:** The representation count machinery (partition identity, monotonicity, convolution structure) connects to fundamental tools in additive number theory — Freiman's theorem, the Erdős-Ginzburg-Ziv theorem, and sumset estimates. The Fourier method axiomatized here is a special case of the Hardy-Littlewood circle method applied to finite groups.\n\n**Problem #543 analogy:** The disproof of #543 showed $\\Theta(\\log\\log N)$ is the optimal correction for coverage. If the uniformity problem (#1179) has the same answer, it would reveal a deep structural connection between 'covering all elements' and 'covering them uniformly' — both governed by the same second-order logarithmic correction.\n\n**Computational verification:** The formalized definitions are in principle computable for small $N$ (modulo the `noncomputable` annotation on `reprCount`). A computational investigation of $g_\\varepsilon(N)$ for small $N$ and various $\\varepsilon$ could provide empirical evidence for the correct rate.",
     "openQuestions": [
       "Is the correction term $g_\\varepsilon(N) - \\log_2 N$ bounded ($O(1)$) or does it grow as $\\Theta(\\log\\log N)$? The disproof of Problem #543 suggests the latter, but the uniformity condition here is strictly stronger than coverage.",
       "Can the remaining fourier_error_bound axiom be proved from Mathlib's character theory? This requires discrete Fourier analysis infrastructure: character groups of $\\mathbb{Z}/p\\mathbb{Z}$, orthogonality relations, and the identity $|1+\\chi(a)| = 2|\\cos(\\pi ja/p)|$.",
@@ -170,40 +170,40 @@
     {
       "targetId": "erdos-1179",
       "relationship": "parent",
-      "description": "The parent Erd\u0151s #1179 formalization establishing the main asymptotic g_\u03b5(N) ~ log\u2082 N. This open question investigates the second-order correction term"
+      "description": "The parent Erdős #1179 formalization establishing the main asymptotic g_ε(N) ~ log₂ N. This open question investigates the second-order correction term"
     },
     {
       "targetId": "erdos-543",
       "relationship": "related",
-      "description": "Erd\u0151s #543 asks the analogous question for subset sum coverage (spanning the group) rather than uniformity. The disproof showed \u0398(log log N) is the optimal coverage correction, suggesting by analogy that the uniformity correction in #1179 may also be \u0398(log log N)"
+      "description": "Erdős #543 asks the analogous question for subset sum coverage (spanning the group) rather than uniformity. The disproof showed Θ(log log N) is the optimal coverage correction, suggesting by analogy that the uniformity correction in #1179 may also be Θ(log log N)"
     },
     {
       "targetId": "fourier-series",
       "relationship": "related",
-      "description": "Fourier analysis foundations. The axiomatized character sum bounds in this formalization are the finite-group analogue of Fourier series on the circle: characters of \u2124/p\u2124 play the role of exponential functions e^{inx}"
+      "description": "Fourier analysis foundations. The axiomatized character sum bounds in this formalization are the finite-group analogue of Fourier series on the circle: characters of ℤ/pℤ play the role of exponential functions e^{inx}"
     }
   ],
   "references": [
     {
-      "authors": "Erd\u0151s, Paul; R\u00e9nyi, Alfr\u00e9d",
+      "authors": "Erdős, Paul; Rényi, Alfréd",
       "title": "Additive properties of random sequences of positive integers",
       "year": "1965",
-      "venue": "Acta Arithmetica, vol. 6, pp. 83\u2013110",
+      "venue": "Acta Arithmetica, vol. 6, pp. 83–110",
       "note": "Introduced the second-moment method for subset sum representations in finite groups, establishing the foundational approach axiomatized in Part VI"
     },
     {
-      "authors": "Erd\u0151s, Paul; Hall, Richard R.",
+      "authors": "Erdős, Paul; Hall, Richard R.",
       "title": "On representations of integers as sums of distinct summands taken from a sequence",
       "year": "1976",
-      "venue": "Discrete Mathematics, vol. 16, pp. 321\u2013328",
-      "note": "Sharpened the Erd\u0151s-R\u00e9nyi bound to g_\u03b5(N) ~ log\u2082 N and established the upper bound g_\u03b5(N) \u2264 log\u2082 N \u00b7 (1 + O(log log log N / log log N))"
+      "venue": "Discrete Mathematics, vol. 16, pp. 321–328",
+      "note": "Sharpened the Erdős-Rényi bound to g_ε(N) ~ log₂ N and established the upper bound g_ε(N) ≤ log₂ N · (1 + O(log log log N / log log N))"
     },
     {
       "authors": "Vu, Van H.",
       "title": "On the concentration of random multilinear forms and the universality of random block matrices",
       "year": "2006",
-      "venue": "Random Structures & Algorithms, vol. 29, no. 4, pp. 454\u2013480",
-      "note": "Modern probabilistic methods for subset sum problems in groups, extending the Erd\u0151s-R\u00e9nyi framework with concentration inequalities"
+      "venue": "Random Structures & Algorithms, vol. 29, no. 4, pp. 454–480",
+      "note": "Modern probabilistic methods for subset sum problems in groups, extending the Erdős-Rényi framework with concentration inequalities"
     },
     {
       "authors": "Tao, Terence; Vu, Van H.",
@@ -213,5 +213,21 @@
       "note": "Standard reference for additive combinatorics including Fourier analysis on finite groups, representation counts, and the probabilistic method"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "Real"
+    ],
+    "namespace": "Erdos1179OQ01",
+    "lineCount": 710,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 5,
+    "sorries": 0,
+    "path": "Proofs/Erdos1179OQ01.lean"
+  }
 }

--- a/src/data/proofs/erdos-1206/meta.json
+++ b/src/data/proofs/erdos-1206/meta.json
@@ -17,8 +17,7 @@
     "sorries": 1,
     "erdosNumber": 1206,
     "erdosUrl": "https://erdosproblems.com/1206",
-    "erdosProblemStatus": "solved",
-    "lineCount": 23
+    "erdosProblemStatus": "solved"
   },
   "overview": {
     "historicalContext": "Erdős Problem #1206 concerns Sidon sets among cube numbers. A Sidon set (also called a B₂ set) is a set of integers where all pairwise sums are distinct—equivalently, all pairwise differences are distinct. Sidon introduced these in 1932 in connection with Fourier analysis. Erdős and Turán proved the fundamental bound: any Sidon subset of {1,...,N} has at most N^(1/2) + O(N^(1/4)) elements. Problem #1206 asks whether {1³, 2³, ..., N³} contains an unexpectedly large Sidon set of size ≫ N—much larger relative to the set's cardinality than the Erdős–Turán bound suggests for a generic subset of {1,...,N³}. The problem was marked solved on erdosproblems.com following work by Gabdullin and Konyagin (2024), who showed the short-interval cube set {n³ : N - cN^(1/2) ≤ n ≤ N} is Sidon. Garaev, Garayev, and Konyagin (2026) improved this to size ≫ N^(4/7-o(1)) for infinitely many N, using more refined estimates on the quadratic factor n² + nm + m². The problem is part of a broader Erdős program relating polynomial sequences to additive combinatorics, with analogues for squares (Problem #773) and linear sets (Problem #530).",
@@ -100,5 +99,18 @@
       "description": "The Fundamental Theorem of Arithmetic (unique prime factorization) underpins the Sidon proof via the algebraic identity n³ - m³ = (n-m)(n² + nm + m²). The Sidon condition requires all pairwise sum differences to be distinct; the factorization shows that in a short interval [N - cN^(1/2), N], the quadratic factor n²+nm+m² is nearly constant (~3N²), making distinct pairs (n,m) give distinct differences. This is a multiplicative structure argument at heart — the same principles used in factoring in FTA."
     }
   ],
-  "sorries": 1
+  "sorries": 1,
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": null,
+    "lineCount": 24,
+    "axiomCount": 0,
+    "theoremCount": 1,
+    "definitionCount": 0,
+    "sorries": 1,
+    "path": "Proofs/Erdos1206Problem.lean"
+  }
 }

--- a/src/data/proofs/erdos-1211/meta.json
+++ b/src/data/proofs/erdos-1211/meta.json
@@ -109,5 +109,18 @@
       "description": "Sibling in sum-set theory: #530 (maximum Sidon subset of a finite set) and #1211 (logarithmic density of partition sum sets) are both extremal problems about structured subsets, sharing the combinatorial density framework."
     }
   ],
-  "sorries": 1
+  "sorries": 1,
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": null,
+    "lineCount": 24,
+    "axiomCount": 0,
+    "theoremCount": 1,
+    "definitionCount": 0,
+    "sorries": 1,
+    "path": "Proofs/Erdos1211Problem.lean"
+  }
 }

--- a/src/data/proofs/erdos-1215/meta.json
+++ b/src/data/proofs/erdos-1215/meta.json
@@ -99,5 +99,18 @@
       "description": "Both represent formalization stubs pending major Mathlib infrastructure: Easton's class forcing and Mac Lane's polynomial lemniscate theory share the challenge of encoding analytic/metamathematical content in Lean 4."
     }
   ],
-  "sorries": 1
+  "sorries": 1,
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": null,
+    "lineCount": 24,
+    "axiomCount": 0,
+    "theoremCount": 1,
+    "definitionCount": 0,
+    "sorries": 1,
+    "path": "Proofs/Erdos1215Problem.lean"
+  }
 }

--- a/src/data/proofs/erdos-1216/meta.json
+++ b/src/data/proofs/erdos-1216/meta.json
@@ -99,5 +99,18 @@
       "Is there a tournament-theoretic version of the probabilistic method that gives a sharp upper bound on $f(n)$, improving on the Erdős-Moser $2\\log_2 n$ bound?"
     ]
   },
-  "sorries": 1
+  "sorries": 1,
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": null,
+    "lineCount": 24,
+    "axiomCount": 0,
+    "theoremCount": 1,
+    "definitionCount": 0,
+    "sorries": 1,
+    "path": "Proofs/Erdos1216Problem.lean"
+  }
 }

--- a/src/data/proofs/erdos-327-oq-01-oq-04/meta.json
+++ b/src/data/proofs/erdos-327-oq-01-oq-04/meta.json
@@ -121,5 +121,24 @@
       "description": "The pair count is unbounded"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Proofs.Erdos327OQ01",
+      "Mathlib.Data.Nat.Basic",
+      "Mathlib.Data.Finset.Card",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset",
+      "Nat"
+    ],
+    "namespace": "Erdos327OQ01OQ04",
+    "lineCount": 88,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "sorries": 0,
+    "path": "Proofs/Erdos327OQ01OQ04.lean"
+  }
 }

--- a/src/data/proofs/fundamental-arithmetic-oq-02/meta.json
+++ b/src/data/proofs/fundamental-arithmetic-oq-02/meta.json
@@ -113,5 +113,21 @@
       "description": "Explores the multiplicative property of prime factorization in Z, which this entry shows breaks down in larger rings."
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.Zsqrtd.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Zsqrtd"
+    ],
+    "namespace": "FundamentalArithmeticOQ02",
+    "lineCount": 193,
+    "axiomCount": 0,
+    "theoremCount": 17,
+    "definitionCount": 2,
+    "sorries": 0,
+    "path": "Proofs/FundamentalArithmeticOQ02.lean"
+  }
 }

--- a/src/data/proofs/furstenberg-correspondence-oq-02/meta.json
+++ b/src/data/proofs/furstenberg-correspondence-oq-02/meta.json
@@ -15,7 +15,7 @@
       "decomposition",
       "feasibility-survey",
       "furstenberg",
-      "szemer\u00e9di"
+      "szemerédi"
     ],
     "badge": "mathlib",
     "sorries": 0,
@@ -27,7 +27,7 @@
       },
       {
         "theorem": "MeasurePreserving.conservative",
-        "description": "Finite measure-preserving maps are conservative (Poincar\u00e9 recurrence)",
+        "description": "Finite measure-preserving maps are conservative (Poincaré recurrence)",
         "module": "Mathlib.Dynamics.Ergodic.Conservative"
       },
       {
@@ -48,9 +48,9 @@
     ],
     "originalContributions": [
       "Comprehensive survey of Mathlib v4.26.0 ergodic theory infrastructure",
-      "Definition of invariant \u03c3-algebra with proof of \u03c3-algebra properties",
+      "Definition of invariant σ-algebra with proof of σ-algebra properties",
       "Three-approach roadmap for ergodic decomposition (conditional expectation, Choquet, disintegration)",
-      "Feasibility assessment: ~1200\u20132500 lines depending on approach",
+      "Feasibility assessment: ~1200–2500 lines depending on approach",
       "Identification of key gap: Birkhoff ergodic theorem convergence",
       "Recommendation: Approach C (via Mathlib disintegration) minimizes effort"
     ],
@@ -62,34 +62,34 @@
   },
   "sections": [
     {
-      "title": "Mathlib's Ergodic Theory \u2014 What Exists",
+      "title": "Mathlib's Ergodic Theory — What Exists",
       "startLine": 70,
       "endLine": 145,
-      "description": "Demonstrates 7 key building blocks already in Mathlib: ergodic maps, extreme point characterization, Poincar\u00e9 recurrence, RN derivative invariance, invariant function constancy, disintegration, Krein-Milman.",
-      "summary": "Mathlib's Ergodic Theory \u2014 What Exists",
-      "id": "mathlib's-ergodic-theory-\u2014-wha"
+      "description": "Demonstrates 7 key building blocks already in Mathlib: ergodic maps, extreme point characterization, Poincaré recurrence, RN derivative invariance, invariant function constancy, disintegration, Krein-Milman.",
+      "summary": "Mathlib's Ergodic Theory — What Exists",
+      "id": "mathlib's-ergodic-theory-—-wha"
     },
     {
-      "title": "The Gap \u2014 What's Needed",
+      "title": "The Gap — What's Needed",
       "startLine": 150,
       "endLine": 210,
-      "description": "Identifies three missing components: Birkhoff ergodic theorem, Choquet representation, and the connection between disintegration and invariant \u03c3-algebra.",
-      "summary": "The Gap \u2014 What's Needed",
-      "id": "the-gap-\u2014-what's-needed"
+      "description": "Identifies three missing components: Birkhoff ergodic theorem, Choquet representation, and the connection between disintegration and invariant σ-algebra.",
+      "summary": "The Gap — What's Needed",
+      "id": "the-gap-—-what's-needed"
     },
     {
-      "title": "Roadmap \u2014 Three Approaches",
+      "title": "Roadmap — Three Approaches",
       "startLine": 215,
       "endLine": 260,
       "description": "Three paths to ergodic decomposition with line estimates: (A) conditional expectation ~1700 lines, (B) Choquet theory ~1700 lines, (C) existing disintegration ~1200 lines.",
-      "summary": "Roadmap \u2014 Three Approaches",
-      "id": "roadmap-\u2014-three-approaches"
+      "summary": "Roadmap — Three Approaches",
+      "id": "roadmap-—-three-approaches"
     },
     {
       "title": "Infrastructure Demonstration",
       "startLine": 265,
       "endLine": 310,
-      "description": "Defines the invariant \u03c3-algebra in Lean 4 and proves basic properties (preimage stability, intersection closure).",
+      "description": "Defines the invariant σ-algebra in Lean 4 and proves basic properties (preimage stability, intersection closure).",
       "summary": "Infrastructure Demonstration",
       "id": "infrastructure-demonstration"
     },
@@ -103,16 +103,16 @@
     }
   ],
   "overview": {
-    "historicalContext": "The ergodic decomposition theorem is a fundamental result in ergodic theory, established in the mid-20th century. It states that every invariant measure can be uniquely decomposed into ergodic components. This is analogous to the spectral decomposition in linear algebra: just as every matrix can be decomposed into eigenspaces, every invariant measure decomposes into ergodic measures.\n\nThe theorem is a key stepping stone in Furstenberg's ergodic proof of Szemer\u00e9di's theorem (1977). The decomposition reduces the multiple recurrence theorem from general measure-preserving systems to the ergodic case, where structural analysis (compact extensions, weak mixing) can be applied.",
-    "problemStatement": "**Question**: Is it feasible to formalize the ergodic decomposition theorem using Lean 4 and Mathlib?\n\n**Ergodic Decomposition Theorem**: For a measure-preserving system (X, \u03bc, T) on a standard Borel space, there exists a measurable family {\u03bc_x} of probability measures such that:\n(a) \u03bc_x is ergodic for T, for \u03bc-a.e. x\n(b) \u03bc = \u222b \u03bc_x d\u03bc(x)\n(c) \u03bc_x-a.e. y: \u03bc_y = \u03bc_x (consistency)",
+    "historicalContext": "The ergodic decomposition theorem is a fundamental result in ergodic theory, established in the mid-20th century. It states that every invariant measure can be uniquely decomposed into ergodic components. This is analogous to the spectral decomposition in linear algebra: just as every matrix can be decomposed into eigenspaces, every invariant measure decomposes into ergodic measures.\n\nThe theorem is a key stepping stone in Furstenberg's ergodic proof of Szemerédi's theorem (1977). The decomposition reduces the multiple recurrence theorem from general measure-preserving systems to the ergodic case, where structural analysis (compact extensions, weak mixing) can be applied.",
+    "problemStatement": "**Question**: Is it feasible to formalize the ergodic decomposition theorem using Lean 4 and Mathlib?\n\n**Ergodic Decomposition Theorem**: For a measure-preserving system (X, μ, T) on a standard Borel space, there exists a measurable family {μ_x} of probability measures such that:\n(a) μ_x is ergodic for T, for μ-a.e. x\n(b) μ = ∫ μ_x dμ(x)\n(c) μ_x-a.e. y: μ_y = μ_x (consistency)",
     "text": "Survey of Mathlib's ergodic theory infrastructure for formalizing the ergodic decomposition theorem.",
-    "proofStrategy": "This is a **feasibility survey**, not a proof. We:\n\n1. **Audit Mathlib**: identify all relevant existing infrastructure (7 building blocks found)\n2. **Identify gaps**: Birkhoff ergodic theorem, Choquet representation, conditional measures\n3. **Propose roadmap**: three approaches with line estimates\n4. **Demonstrate**: define the invariant \u03c3-algebra in Lean 4\n5. **Assess**: conclude feasibility is HIGH, recommend disintegration approach (~1200 lines)",
+    "proofStrategy": "This is a **feasibility survey**, not a proof. We:\n\n1. **Audit Mathlib**: identify all relevant existing infrastructure (7 building blocks found)\n2. **Identify gaps**: Birkhoff ergodic theorem, Choquet representation, conditional measures\n3. **Propose roadmap**: three approaches with line estimates\n4. **Demonstrate**: define the invariant σ-algebra in Lean 4\n5. **Assess**: conclude feasibility is HIGH, recommend disintegration approach (~1200 lines)",
     "keyInsights": [
       "**Mathlib has the mathematical backbone**: Ergodic = extreme point of invariant measures (Extreme.lean) + Krein-Milman = the convex geometry of ergodic decomposition is already formalized",
-      "**Disintegration approach is most efficient**: Mathlib's Kernel.Disintegration provides the measure-theoretic machinery, needing only the connection to the invariant \u03c3-algebra",
+      "**Disintegration approach is most efficient**: Mathlib's Kernel.Disintegration provides the measure-theoretic machinery, needing only the connection to the invariant σ-algebra",
       "**Birkhoff ergodic theorem is the main blocker**: Needed for all approaches and independently valuable for Mathlib",
-      "**Impact**: completing ergodic decomposition would reduce Szemer\u00e9di's theorem to just the correspondence axiom (~500 lines)",
-      "**Invariant \u03c3-algebra is clean in Lean 4**: the definition and basic properties work naturally"
+      "**Impact**: completing ergodic decomposition would reduce Szemerédi's theorem to just the correspondence axiom (~500 lines)",
+      "**Invariant σ-algebra is clean in Lean 4**: the definition and basic properties work naturally"
     ],
     "prerequisites": [
       "Measure theory (Mathlib.MeasureTheory)",
@@ -127,7 +127,7 @@
   },
   "conclusion": {
     "summary": "The ergodic decomposition theorem IS feasible to formalize in Lean 4 with Mathlib v4.26.0. Mathlib provides 7 key building blocks including the critical characterization of ergodic measures as extreme points. Three approaches are viable, with the disintegration approach estimated at ~1200 lines. The main technical gap is the Birkhoff ergodic theorem.",
-    "implications": "Completing the ergodic decomposition would unlock the full Furstenberg program: multiple recurrence for all k, reducing Szemer\u00e9di's theorem to just the correspondence principle.",
+    "implications": "Completing the ergodic decomposition would unlock the full Furstenberg program: multiple recurrence for all k, reducing Szemerédi's theorem to just the correspondence principle.",
     "openQuestions": [
       "Can the Birkhoff ergodic theorem be contributed to Mathlib as a standalone result?",
       "Is the disintegration in Mathlib sufficient for the ergodic decomposition, or does it need extension?"
@@ -135,12 +135,12 @@
   },
   "crossReferences": [
     {
-      "relationship": "The ergodic decomposition is needed to eliminate Axiom 2 (multiple recurrence for k\u22653) from the Furstenberg correspondence formalization",
+      "relationship": "The ergodic decomposition is needed to eliminate Axiom 2 (multiple recurrence for k≥3) from the Furstenberg correspondence formalization",
       "sharedConcepts": [
         "ergodic-theory",
         "measure-preserving",
         "multiple-recurrence",
-        "szemer\u00e9di"
+        "szemerédi"
       ],
       "targetId": "furstenberg-correspondence"
     },
@@ -154,5 +154,24 @@
       "targetId": "furstenberg-correspondence-oq-01"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "MeasureTheory",
+      "Set",
+      "Topology",
+      "Filter",
+      "MeasurableSpace"
+    ],
+    "namespace": "FurstenbergOQ02",
+    "lineCount": 414,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 2,
+    "sorries": 0,
+    "path": "Proofs/FurstenbergCorrespondenceOQ02.lean"
+  }
 }

--- a/src/data/proofs/geometric-series-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-01/meta.json
@@ -2,9 +2,9 @@
   "id": "geometric-series-oq-01",
   "title": "Geometric Series at the Boundary: |r| = 1",
   "slug": "geometric-series-oq-01",
-  "description": "What happens to the geometric series at the critical boundary |r| = 1? The series transitions from convergent to divergent: at r = 1 the partial sums grow without bound, at r = -1 they oscillate (Grandi's series), and for any |r| \u2265 1 the series is not summable. However, Ces\u00e0ro summability rescues Grandi's series: the averages of partial sums converge to 1/2.",
+  "description": "What happens to the geometric series at the critical boundary |r| = 1? The series transitions from convergent to divergent: at r = 1 the partial sums grow without bound, at r = -1 they oscillate (Grandi's series), and for any |r| ≥ 1 the series is not summable. However, Cesàro summability rescues Grandi's series: the averages of partial sums converge to 1/2.",
   "meta": {
-    "author": "Grandi, Euler, Ces\u00e0ro (formalized in Lean 4)",
+    "author": "Grandi, Euler, Cesàro (formalized in Lean 4)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Grandi%27s_series",
     "date": "1703",
     "status": "verified",
@@ -25,7 +25,7 @@
     "mathlibDependencies": [
       {
         "theorem": "mul_neg_geom_sum",
-        "description": "Finite geometric sum: (1-r) * \u2211 r^k = 1 - r^n",
+        "description": "Finite geometric sum: (1-r) * ∑ r^k = 1 - r^n",
         "module": "Mathlib.Algebra.GeomSum"
       },
       {
@@ -34,22 +34,22 @@
         "module": "Mathlib.Topology.Algebra.InfiniteSum"
       },
       {
-        "theorem": "one_le_pow\u2080",
-        "description": "1 \u2264 a^n when 1 \u2264 a",
+        "theorem": "one_le_pow₀",
+        "description": "1 ≤ a^n when 1 ≤ a",
         "module": "Mathlib.Algebra.Order.Monoid"
       }
     ],
     "originalContributions": [
-      "Divergence proof at r = 1: partial sums S\u2099 = n \u2192 \u221e",
+      "Divergence proof at r = 1: partial sums Sₙ = n → ∞",
       "Grandi's series oscillation: S_{2m} = 0 and S_{2m+1} = 1",
-      "Non-summability for |r| \u2265 1 via term-doesn't-vanish argument",
-      "Ces\u00e0ro summability: \u03c3\u2099 \u2192 1/2 via squeeze with bound |\u03c3\u2099 - 1/2| \u2264 1/(2n)",
+      "Non-summability for |r| ≥ 1 via term-doesn't-vanish argument",
+      "Cesàro summability: σₙ → 1/2 via squeeze with bound |σₙ - 1/2| ≤ 1/(2n)",
       "Complete characterization of boundary behavior at |r| = 1"
     ],
     "dateAdded": "2025-12-26",
     "lineCount": 250,
     "prerequisites": [
-      "Finite sums and BigOperators notation (Finset.range, \u2211 notation)",
+      "Finite sums and BigOperators notation (Finset.range, ∑ notation)",
       "Convergence and divergence of real sequences (Filter.Tendsto, atTop)",
       "Summability of real-valued series (Summable, tsum)",
       "Absolute value and norm (|r|, Real.norm_eq_abs)",
@@ -62,22 +62,22 @@
     "id": "geometric-series-oq-01",
     "parentProof": "geometric-series",
     "question": "What happens at exactly |r| = 1? (Series diverges, but behavior varies)",
-    "answer": "At r = 1, partial sums diverge to infinity. At r = -1, partial sums oscillate between 0 and 1 (Grandi's series), but the Ces\u00e0ro mean converges to 1/2. For all |r| \u2265 1, the series is not summable because terms don't tend to zero."
+    "answer": "At r = 1, partial sums diverge to infinity. At r = -1, partial sums oscillate between 0 and 1 (Grandi's series), but the Cesàro mean converges to 1/2. For all |r| ≥ 1, the series is not summable because terms don't tend to zero."
   },
   "overview": {
-    "historicalContext": "Guido Grandi introduced the series $1 - 1 + 1 - 1 + \\cdots$ in his 1703 work *Quadratura circuli et hyperbolae*, where he argued that its \"sum\" was $1/2$ by analogy with the geometric series formula $1/(1-r)$ evaluated at $r = -1$. This sparked a century-long debate: Leibniz agreed with $1/2$ on probabilistic grounds (the sum \"should\" be the average of the two possible partial sums 0 and 1), while others rejected any finite value for a clearly oscillating series.\n\nEuler championed the value $1/2$ in his *Institutiones calculi differentialis* (1755), using both the analytic continuation argument ($1/(1-(-1)) = 1/2$) and Abel summation: $\\lim_{x \\to 1^-} \\sum (-x)^n = \\lim_{x \\to 1^-} 1/(1+x) = 1/2$. Euler's willingness to assign values to divergent series was controversial but extraordinarily fruitful, leading to results like his evaluation of $\\zeta(-1) = -1/12$.\n\nThe rigorous resolution came with Ernesto Ces\u00e0ro's 1890 paper *Sur la multiplication des s\u00e9ries*, which introduced what is now called Ces\u00e0ro summation: a series $\\sum a_n$ is $(C,1)$-summable to $s$ if the arithmetic means of partial sums $\\sigma_n = (S_1 + \\cdots + S_n)/n$ converge to $s$. For Grandi's series, $\\sigma_n = \\lceil n/2 \\rceil / n \\to 1/2$, vindicating Euler's intuition with full rigor.\n\nThe broader question of boundary behavior at $|r| = 1$ connects to Tauberian theory. Hardy and Littlewood (1911-1913) proved that if a series is Ces\u00e0ro summable to $s$ and its terms satisfy $a_n = O(1/n)$, then it converges to $s$ in the ordinary sense. Grandi's series fails this Tauberian condition ($a_n = (-1)^n \\not\\to 0$), explaining why Ces\u00e0ro summability is strictly stronger than convergence here.",
-    "problemStatement": "**Boundary Behavior of the Geometric Series at $|r| = 1$:**\n\n1. **Divergence at $r = 1$:** $\\sum_{k=0}^{n-1} 1^k = n \\to \\infty$\n\n2. **Oscillation at $r = -1$ (Grandi's series):** $S_{2m} = 0$ and $S_{2m+1} = 1$, so the series does not converge\n\n3. **General non-summability for $|r| \\geq 1$:** $|r^n| = |r|^n \\geq 1$, so terms do not tend to zero, hence $\\sum r^n$ is not summable\n\n4. **Ces\u00e0ro summability:** The Ces\u00e0ro mean $\\sigma_n = \\frac{1}{n}\\sum_{k=1}^{n} S_k$ satisfies $|\\sigma_n - 1/2| \\leq 1/(2n)$, so $\\sigma_n \\to 1/2$",
-    "text": "A complete formalized analysis of the geometric series at the boundary |r| = 1, including divergence at r = 1, oscillation of Grandi's series at r = -1, general non-summability for |r| \u2265 1, and Ces\u00e0ro summability of Grandi's series to 1/2.",
-    "proofStrategy": "The proof is organized into four independent modules, each using distinct techniques:\n\n**Part 1 (r = 1):** Direct computation shows $S_n = n$ via `simp [one_pow]`, then `tendsto_natCast_atTop_atTop` gives divergence.\n\n**Part 2 (Grandi's series):** The key identity $2 S_n = 1 - (-1)^n$ comes from Mathlib's `mul_neg_geom_sum`. Substituting $(-1)^{2m} = 1$ and $(-1)^{2m+1} = -1$ yields $S_{2m} = 0$ and $S_{2m+1} = 1$. Non-summability follows from the necessary condition: if $\\sum a_n$ converges then $a_n \\to 0$, but $|(-1)^n| = 1$ for all $n$.\n\n**Part 3 (General $|r| \\geq 1$):** The same necessary condition argument: $|r^n| = |r|^n \\geq 1^n = 1$, so terms cannot tend to zero. Uses `one_le_pow\u2080` for the key inequality.\n\n**Part 4 (Ces\u00e0ro mean):** Defines $\\sigma_n = \\frac{1}{n}\\sum_{k=0}^{n-1} S_{k+1}$ and proves $\\sum_{k=0}^{n-1} S_{k+1} = \\lceil(n+1)/2\\rceil$ by induction with parity case analysis. The bound $|\\sigma_n - 1/2| \\leq 1/(2n)$ follows from the integer arithmetic fact $n \\leq 2\\lceil(n+1)/2\\rceil \\leq n+1$. Convergence to $1/2$ then follows from the squeeze theorem via the Archimedean property of $\\mathbb{R}$.",
+    "historicalContext": "Guido Grandi introduced the series $1 - 1 + 1 - 1 + \\cdots$ in his 1703 work *Quadratura circuli et hyperbolae*, where he argued that its \"sum\" was $1/2$ by analogy with the geometric series formula $1/(1-r)$ evaluated at $r = -1$. This sparked a century-long debate: Leibniz agreed with $1/2$ on probabilistic grounds (the sum \"should\" be the average of the two possible partial sums 0 and 1), while others rejected any finite value for a clearly oscillating series.\n\nEuler championed the value $1/2$ in his *Institutiones calculi differentialis* (1755), using both the analytic continuation argument ($1/(1-(-1)) = 1/2$) and Abel summation: $\\lim_{x \\to 1^-} \\sum (-x)^n = \\lim_{x \\to 1^-} 1/(1+x) = 1/2$. Euler's willingness to assign values to divergent series was controversial but extraordinarily fruitful, leading to results like his evaluation of $\\zeta(-1) = -1/12$.\n\nThe rigorous resolution came with Ernesto Cesàro's 1890 paper *Sur la multiplication des séries*, which introduced what is now called Cesàro summation: a series $\\sum a_n$ is $(C,1)$-summable to $s$ if the arithmetic means of partial sums $\\sigma_n = (S_1 + \\cdots + S_n)/n$ converge to $s$. For Grandi's series, $\\sigma_n = \\lceil n/2 \\rceil / n \\to 1/2$, vindicating Euler's intuition with full rigor.\n\nThe broader question of boundary behavior at $|r| = 1$ connects to Tauberian theory. Hardy and Littlewood (1911-1913) proved that if a series is Cesàro summable to $s$ and its terms satisfy $a_n = O(1/n)$, then it converges to $s$ in the ordinary sense. Grandi's series fails this Tauberian condition ($a_n = (-1)^n \\not\\to 0$), explaining why Cesàro summability is strictly stronger than convergence here.",
+    "problemStatement": "**Boundary Behavior of the Geometric Series at $|r| = 1$:**\n\n1. **Divergence at $r = 1$:** $\\sum_{k=0}^{n-1} 1^k = n \\to \\infty$\n\n2. **Oscillation at $r = -1$ (Grandi's series):** $S_{2m} = 0$ and $S_{2m+1} = 1$, so the series does not converge\n\n3. **General non-summability for $|r| \\geq 1$:** $|r^n| = |r|^n \\geq 1$, so terms do not tend to zero, hence $\\sum r^n$ is not summable\n\n4. **Cesàro summability:** The Cesàro mean $\\sigma_n = \\frac{1}{n}\\sum_{k=1}^{n} S_k$ satisfies $|\\sigma_n - 1/2| \\leq 1/(2n)$, so $\\sigma_n \\to 1/2$",
+    "text": "A complete formalized analysis of the geometric series at the boundary |r| = 1, including divergence at r = 1, oscillation of Grandi's series at r = -1, general non-summability for |r| ≥ 1, and Cesàro summability of Grandi's series to 1/2.",
+    "proofStrategy": "The proof is organized into four independent modules, each using distinct techniques:\n\n**Part 1 (r = 1):** Direct computation shows $S_n = n$ via `simp [one_pow]`, then `tendsto_natCast_atTop_atTop` gives divergence.\n\n**Part 2 (Grandi's series):** The key identity $2 S_n = 1 - (-1)^n$ comes from Mathlib's `mul_neg_geom_sum`. Substituting $(-1)^{2m} = 1$ and $(-1)^{2m+1} = -1$ yields $S_{2m} = 0$ and $S_{2m+1} = 1$. Non-summability follows from the necessary condition: if $\\sum a_n$ converges then $a_n \\to 0$, but $|(-1)^n| = 1$ for all $n$.\n\n**Part 3 (General $|r| \\geq 1$):** The same necessary condition argument: $|r^n| = |r|^n \\geq 1^n = 1$, so terms cannot tend to zero. Uses `one_le_pow₀` for the key inequality.\n\n**Part 4 (Cesàro mean):** Defines $\\sigma_n = \\frac{1}{n}\\sum_{k=0}^{n-1} S_{k+1}$ and proves $\\sum_{k=0}^{n-1} S_{k+1} = \\lceil(n+1)/2\\rceil$ by induction with parity case analysis. The bound $|\\sigma_n - 1/2| \\leq 1/(2n)$ follows from the integer arithmetic fact $n \\leq 2\\lceil(n+1)/2\\rceil \\leq n+1$. Convergence to $1/2$ then follows from the squeeze theorem via the Archimedean property of $\\mathbb{R}$.",
     "keyInsights": [
-      "**The geometric sum formula as a universal tool:** The identity $(1-r)\\sum_{k=0}^{n-1} r^k = 1 - r^n$ (Mathlib's `mul_neg_geom_sum`) works in any ring, including at $r = -1$ where the LHS becomes $2 S_n = 1 - (-1)^n$. This single algebraic identity drives both the oscillation analysis (Part 2) and the Ces\u00e0ro computation (Part 4).",
-      "**The necessary condition for summability is a topological obstruction:** If $\\sum a_n$ is summable (absolutely convergent in a complete normed space), then $a_n \\to 0$. The contrapositive \u2014 terms not vanishing implies non-summability \u2014 is the engine of Parts 1-3. In Lean, this is `Summable.tendsto_atTop_zero` combined with `Metric.tendsto_atTop` to extract a concrete $\\varepsilon$-$N$ contradiction.",
-      "**Parity case analysis reduces Ces\u00e0ro summation to integer arithmetic:** The induction in `sum_grandi_partial_sums` splits on $n = 2m$ vs $n = 2m+1$, using `grandi_even` and `grandi_odd` as the base cases. The resulting sum $\\lceil(n+1)/2\\rceil$ is a purely combinatorial quantity \u2014 the number of odd indices less than $n$ \u2014 and the bound $|\\sigma_n - 1/2| \\leq 1/(2n)$ follows from the elementary fact that $\\lceil(n+1)/2\\rceil$ is within $1/2$ of $n/2$.",
-      "**Ces\u00e0ro summation extends convergence without contradicting it:** Every convergent series is Ces\u00e0ro summable to the same limit (by the Ces\u00e0ro-Stolz theorem), but Ces\u00e0ro summation also assigns values to some divergent series. This formalization shows the simplest non-trivial example: Grandi's series is $(C,1)$-summable to $1/2$ but not convergent. The hierarchy of summability methods \u2014 Ces\u00e0ro, Abel, Borel, Ramanujan \u2014 forms a tower of increasingly powerful regularization techniques.",
+      "**The geometric sum formula as a universal tool:** The identity $(1-r)\\sum_{k=0}^{n-1} r^k = 1 - r^n$ (Mathlib's `mul_neg_geom_sum`) works in any ring, including at $r = -1$ where the LHS becomes $2 S_n = 1 - (-1)^n$. This single algebraic identity drives both the oscillation analysis (Part 2) and the Cesàro computation (Part 4).",
+      "**The necessary condition for summability is a topological obstruction:** If $\\sum a_n$ is summable (absolutely convergent in a complete normed space), then $a_n \\to 0$. The contrapositive — terms not vanishing implies non-summability — is the engine of Parts 1-3. In Lean, this is `Summable.tendsto_atTop_zero` combined with `Metric.tendsto_atTop` to extract a concrete $\\varepsilon$-$N$ contradiction.",
+      "**Parity case analysis reduces Cesàro summation to integer arithmetic:** The induction in `sum_grandi_partial_sums` splits on $n = 2m$ vs $n = 2m+1$, using `grandi_even` and `grandi_odd` as the base cases. The resulting sum $\\lceil(n+1)/2\\rceil$ is a purely combinatorial quantity — the number of odd indices less than $n$ — and the bound $|\\sigma_n - 1/2| \\leq 1/(2n)$ follows from the elementary fact that $\\lceil(n+1)/2\\rceil$ is within $1/2$ of $n/2$.",
+      "**Cesàro summation extends convergence without contradicting it:** Every convergent series is Cesàro summable to the same limit (by the Cesàro-Stolz theorem), but Cesàro summation also assigns values to some divergent series. This formalization shows the simplest non-trivial example: Grandi's series is $(C,1)$-summable to $1/2$ but not convergent. The hierarchy of summability methods — Cesàro, Abel, Borel, Ramanujan — forms a tower of increasingly powerful regularization techniques.",
       "**The squeeze theorem bridges discrete arithmetic and real analysis:** The proof of `grandiCesaro_tendsto` is a textbook $\\varepsilon$-$N$ argument: choose $N > 1/(2\\varepsilon)$ via the Archimedean property, then $|\\sigma_n - 1/2| \\leq 1/(2n) < \\varepsilon$ for $n \\geq N$. The key insight is that the hard work is in the discrete bound `grandiCesaro_bound`, and the limit passage is mechanical."
     ],
     "prerequisites": [
-      "Finite sums and BigOperators notation (Finset.range, \u2211 notation)",
+      "Finite sums and BigOperators notation (Finset.range, ∑ notation)",
       "Convergence and divergence of real sequences (Filter.Tendsto, atTop)",
       "Summability of real-valued series (Summable, tsum)",
       "Absolute value and norm (|r|, Real.norm_eq_abs)",
@@ -99,7 +99,7 @@
       "startLine": 40,
       "endLine": 61,
       "summary": "Three theorems establishing divergence at $r = 1$: `geom_partial_sum_one` computes $S_n = n$, `geom_sum_one_diverges` shows $S_n \\to \\infty$ via `tendsto_natCast_atTop_atTop`, and `not_summable_one` proves non-summability by contradiction with the necessary condition $a_n \\to 0$.",
-      "mathContext": "At $r = 1$, every term is $1^k = 1$, so $S_n = n$. The divergence $n \\to \\infty$ is formalized as `Tendsto f atTop atTop` \u2014 the function escapes every finite bound. Non-summability is a direct contradiction: $\\sum 1 = \\infty$ because the constant sequence $1$ does not tend to $0$."
+      "mathContext": "At $r = 1$, every term is $1^k = 1$, so $S_n = n$. The divergence $n \\to \\infty$ is formalized as `Tendsto f atTop atTop` — the function escapes every finite bound. Non-summability is a direct contradiction: $\\sum 1 = \\infty$ because the constant sequence $1$ does not tend to $0$."
     },
     {
       "id": "grandi-series-oscillation",
@@ -111,19 +111,19 @@
     },
     {
       "id": "general-nonsummability",
-      "title": "Part 3: General |r| \u2265 1 Implies Not Summable",
+      "title": "Part 3: General |r| ≥ 1 Implies Not Summable",
       "startLine": 103,
       "endLine": 125,
       "summary": "Two theorems generalizing non-summability: `not_summable_geom_of_one_le_norm` proves that $|r| \\geq 1$ implies $\\sum r^n$ is not summable (via $|r^n| = |r|^n \\geq 1$ and the necessary condition), and `not_summable_geom_of_norm_eq_one` specializes to $|r| = 1$.",
-      "mathContext": "The key inequality $|r^n| = |r|^n \\geq 1^n = 1$ uses `one_le_pow\u2080`, the monotonicity of exponentiation for base $\\geq 1$. Combined with $|r^n| \\geq 1 > 1/2$, this contradicts $r^n \\to 0$, which is necessary for summability. This subsumes both the $r = 1$ and $r = -1$ cases as special instances."
+      "mathContext": "The key inequality $|r^n| = |r|^n \\geq 1^n = 1$ uses `one_le_pow₀`, the monotonicity of exponentiation for base $\\geq 1$. Combined with $|r^n| \\geq 1 > 1/2$, this contradicts $r^n \\to 0$, which is necessary for summability. This subsumes both the $r = 1$ and $r = -1$ cases as special instances."
     },
     {
       "id": "cesaro-summability",
-      "title": "Part 4: Ces\u00e0ro Summability of Grandi's Series",
+      "title": "Part 4: Cesàro Summability of Grandi's Series",
       "startLine": 126,
       "endLine": 217,
-      "summary": "The heart of the formalization: defines the Ces\u00e0ro mean `grandiCesaro` as the average of partial sums, proves `sum_grandi_partial_sums` by induction with parity case analysis (the sum of the first $n$ partial sums equals $\\lceil(n+1)/2\\rceil$), derives the explicit formula `grandiCesaro_eq`, establishes the quantitative bound `grandiCesaro_bound` ($|\\sigma_n - 1/2| \\leq 1/(2n)$) via integer arithmetic, and proves `grandiCesaro_tendsto` ($\\sigma_n \\to 1/2$) via the squeeze theorem.",
-      "mathContext": "The Ces\u00e0ro mean $\\sigma_n = \\frac{1}{n}\\sum_{k=1}^{n} S_k$ averages the partial sums. Since $S_{\\text{odd}} = 1$ and $S_{\\text{even}} = 0$, the sum $\\sum_{k=1}^{n} S_k$ counts the number of odd indices, which is $\\lceil n/2 \\rceil$. The bound $|\\sigma_n - 1/2| = |\\lceil n/2 \\rceil/n - 1/2| \\leq 1/(2n)$ follows because $\\lceil n/2 \\rceil$ is within $1/2$ of $n/2$. The $\\varepsilon$-$N$ proof chooses $N > 1/(2\\varepsilon)$ via the Archimedean property."
+      "summary": "The heart of the formalization: defines the Cesàro mean `grandiCesaro` as the average of partial sums, proves `sum_grandi_partial_sums` by induction with parity case analysis (the sum of the first $n$ partial sums equals $\\lceil(n+1)/2\\rceil$), derives the explicit formula `grandiCesaro_eq`, establishes the quantitative bound `grandiCesaro_bound` ($|\\sigma_n - 1/2| \\leq 1/(2n)$) via integer arithmetic, and proves `grandiCesaro_tendsto` ($\\sigma_n \\to 1/2$) via the squeeze theorem.",
+      "mathContext": "The Cesàro mean $\\sigma_n = \\frac{1}{n}\\sum_{k=1}^{n} S_k$ averages the partial sums. Since $S_{\\text{odd}} = 1$ and $S_{\\text{even}} = 0$, the sum $\\sum_{k=1}^{n} S_k$ counts the number of odd indices, which is $\\lceil n/2 \\rceil$. The bound $|\\sigma_n - 1/2| = |\\lceil n/2 \\rceil/n - 1/2| \\leq 1/(2n)$ follows because $\\lceil n/2 \\rceil$ is within $1/2$ of $n/2$. The $\\varepsilon$-$N$ proof chooses $N > 1/(2\\varepsilon)$ via the Archimedean property."
     },
     {
       "id": "examples-and-summary",
@@ -131,15 +131,15 @@
       "startLine": 218,
       "endLine": 250,
       "summary": "Concrete verification examples ($S_{10} = 10$ at $r = 1$, $S_6 = 0$ and $S_7 = 1$ for Grandi's series), a comment block with a summary table of boundary behavior for $r = 1, -1, i, e^{i\\theta}$, and `#check` commands for the main theorems.",
-      "mathContext": "The summary table captures the full picture at $|r| = 1$: all cases are non-summable in the classical sense, but Ces\u00e0ro summation rescues all cases except $r = 1$ (where partial sums diverge to infinity, not even Ces\u00e0ro summable). For $r = e^{i\\theta}$ with $\\theta \\neq 0$, the Ces\u00e0ro sum is $1/(1 - e^{i\\theta})$, generalizing the $r = -1$ result."
+      "mathContext": "The summary table captures the full picture at $|r| = 1$: all cases are non-summable in the classical sense, but Cesàro summation rescues all cases except $r = 1$ (where partial sums diverge to infinity, not even Cesàro summable). For $r = e^{i\\theta}$ with $\\theta \\neq 0$, the Cesàro sum is $1/(1 - e^{i\\theta})$, generalizing the $r = -1$ result."
     }
   ],
   "conclusion": {
-    "summary": "This formalization provides a complete, machine-checked analysis of the geometric series at the critical boundary $|r| = 1$. The four results \u2014 divergence at $r = 1$, oscillation of Grandi's series, general non-summability for $|r| \\geq 1$, and Ces\u00e0ro summability to $1/2$ \u2014 together characterize the phase transition where classical convergence fails but summability methods can still extract meaningful values. The Ces\u00e0ro summability proof is particularly notable: it reduces a limit in real analysis to a purely combinatorial identity about counting odd indices, bridged by an explicit $O(1/n)$ error bound.",
-    "implications": "**Summability theory:** This is the simplest non-trivial example of Ces\u00e0ro summation, motivating the hierarchy of summability methods ($(C,k)$-summation, Abel summation, Borel summation) that are essential in analytic number theory, quantum field theory, and asymptotic analysis.\n\n**Formal verification:** The formalization demonstrates that summability arguments \u2014 which mix discrete combinatorics (parity, counting), algebraic identities (geometric sum formula), and real analysis ($\\varepsilon$-$N$ arguments) \u2014 are well within reach of current interactive theorem provers. The proof is entirely self-contained modulo three Mathlib lemmas.\n\n**Pedagogy:** The four-part structure mirrors the standard analysis curriculum progression: from concrete examples ($r = 1$, $r = -1$) to general theory ($|r| \\geq 1$) to extended convergence notions (Ces\u00e0ro summation).",
+    "summary": "This formalization provides a complete, machine-checked analysis of the geometric series at the critical boundary $|r| = 1$. The four results — divergence at $r = 1$, oscillation of Grandi's series, general non-summability for $|r| \\geq 1$, and Cesàro summability to $1/2$ — together characterize the phase transition where classical convergence fails but summability methods can still extract meaningful values. The Cesàro summability proof is particularly notable: it reduces a limit in real analysis to a purely combinatorial identity about counting odd indices, bridged by an explicit $O(1/n)$ error bound.",
+    "implications": "**Summability theory:** This is the simplest non-trivial example of Cesàro summation, motivating the hierarchy of summability methods ($(C,k)$-summation, Abel summation, Borel summation) that are essential in analytic number theory, quantum field theory, and asymptotic analysis.\n\n**Formal verification:** The formalization demonstrates that summability arguments — which mix discrete combinatorics (parity, counting), algebraic identities (geometric sum formula), and real analysis ($\\varepsilon$-$N$ arguments) — are well within reach of current interactive theorem provers. The proof is entirely self-contained modulo three Mathlib lemmas.\n\n**Pedagogy:** The four-part structure mirrors the standard analysis curriculum progression: from concrete examples ($r = 1$, $r = -1$) to general theory ($|r| \\geq 1$) to extended convergence notions (Cesàro summation).",
     "openQuestions": [
-      "Can Abel summability of Grandi's series be formalized in Lean? Abel summation assigns $\\lim_{x \\to 1^-} \\sum_{n=0}^{\\infty} (-1)^n x^n = \\lim_{x \\to 1^-} 1/(1+x) = 1/2$, providing an independent confirmation of the Ces\u00e0ro value. The key challenge is formalizing the Abel limit at the boundary of the disk of convergence.",
-      "The general Ces\u00e0ro summability theorem states that if $\\sum a_n$ converges to $s$, then its Ces\u00e0ro mean also converges to $s$ (regularity). Can this be formalized, along with the converse Tauberian theorem of Hardy-Littlewood: if $\\sigma_n \\to s$ and $a_n = O(1/n)$, then $\\sum a_n = s$?",
+      "Can Abel summability of Grandi's series be formalized in Lean? Abel summation assigns $\\lim_{x \\to 1^-} \\sum_{n=0}^{\\infty} (-1)^n x^n = \\lim_{x \\to 1^-} 1/(1+x) = 1/2$, providing an independent confirmation of the Cesàro value. The key challenge is formalizing the Abel limit at the boundary of the disk of convergence.",
+      "The general Cesàro summability theorem states that if $\\sum a_n$ converges to $s$, then its Cesàro mean also converges to $s$ (regularity). Can this be formalized, along with the converse Tauberian theorem of Hardy-Littlewood: if $\\sigma_n \\to s$ and $a_n = O(1/n)$, then $\\sum a_n = s$?",
       "For $r = e^{2\\pi i \\theta}$ with $\\theta$ irrational, the partial sums of $\\sum r^n$ are equidistributed on a circle by Weyl's equidistribution theorem. Can this connection between geometric series boundary behavior and equidistribution modulo 1 be formalized?"
     ]
   },
@@ -159,18 +159,18 @@
       "note": "Euler's defense of assigning values to divergent series, including 1 - 1 + 1 - 1 + ... = 1/2 via regularization methods that anticipated modern summability theory"
     },
     {
-      "authors": "Ces\u00e0ro, Ernesto",
-      "title": "Sur la multiplication des s\u00e9ries",
+      "authors": "Cesàro, Ernesto",
+      "title": "Sur la multiplication des séries",
       "year": "1890",
-      "venue": "Bulletin des Sciences Math\u00e9matiques",
-      "note": "Introduction of Ces\u00e0ro summation: averaging partial sums to extend the notion of convergence, rigorously justifying Euler's assignment of 1/2 to Grandi's series"
+      "venue": "Bulletin des Sciences Mathématiques",
+      "note": "Introduction of Cesàro summation: averaging partial sums to extend the notion of convergence, rigorously justifying Euler's assignment of 1/2 to Grandi's series"
     },
     {
       "authors": "Hardy, G. H.",
       "title": "Divergent Series",
       "year": "1949",
       "venue": "Oxford University Press",
-      "note": "Definitive monograph on summability methods, covering Ces\u00e0ro, Abel, and Borel summation with Tauberian theorems connecting them to ordinary convergence"
+      "note": "Definitive monograph on summability methods, covering Cesàro, Abel, and Borel summation with Tauberian theorems connecting them to ordinary convergence"
     },
     {
       "authors": "Knopp, Konrad",
@@ -202,5 +202,25 @@
       "description": "The Taylor series for $\\sin$ and $\\cos$ converge for all real $x$ (infinite radius of convergence), in sharp contrast to the geometric series which has finite radius $|r| < 1$. The factorial denominators in the Taylor coefficients ensure convergence everywhere, while the geometric series has constant coefficients $1$."
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.Algebra.GeomSum",
+      "Mathlib.Analysis.SpecificLimits.Normed",
+      "Mathlib.Topology.Algebra.InfiniteSum.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset",
+      "BigOperators",
+      "Filter"
+    ],
+    "namespace": "GeometricSeriesOQ01",
+    "lineCount": 251,
+    "axiomCount": 0,
+    "theoremCount": 13,
+    "definitionCount": 1,
+    "sorries": 0,
+    "path": "Proofs/GeometricSeriesOQ01.lean"
+  }
 }

--- a/src/data/proofs/geometric-series-oq-03/meta.json
+++ b/src/data/proofs/geometric-series-oq-03/meta.json
@@ -151,5 +151,32 @@
       "description": "The Neumann series is the operator-theoretic geometric series (1-T)^{-1} = ∑ T^n for ‖T‖ < 1. The Euler factor formula is the scalar (complex) case of this identity."
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.LSeries.RiemannZeta",
+      "Mathlib.NumberTheory.EulerProduct.DirichletLSeries",
+      "Mathlib.Algebra.GeomSum",
+      "Mathlib.Analysis.SpecificLimits.Normed",
+      "Mathlib.Analysis.SpecialFunctions.Pow.Complex",
+      "Mathlib.Analysis.SpecialFunctions.Pow.Real",
+      "Mathlib.Topology.Algebra.InfiniteSum.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Complex",
+      "Real",
+      "Nat",
+      "Filter",
+      "Topology",
+      "BigOperators"
+    ],
+    "namespace": "GeometricSeriesOQ03",
+    "lineCount": 216,
+    "axiomCount": 0,
+    "theoremCount": 15,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/GeometricSeriesOQ03.lean"
+  }
 }

--- a/src/data/proofs/konigsberg-oq-03-oq-02/meta.json
+++ b/src/data/proofs/konigsberg-oq-03-oq-02/meta.json
@@ -127,5 +127,20 @@
       "description": "Directed Euler paths via in-degree/out-degree — analogous characterization in the directed setting"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Stream.Defs",
+      "Mathlib.Data.Stream.Init",
+      "Mathlib.Tactic"
+    ],
+    "opens": [],
+    "namespace": "KonigsbergOQ03OQ02",
+    "lineCount": 185,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 10,
+    "sorries": 0,
+    "path": "Proofs/KonigsbergOQ03OQ02.lean"
+  }
 }

--- a/src/data/proofs/law-of-sines-oq-06/meta.json
+++ b/src/data/proofs/law-of-sines-oq-06/meta.json
@@ -147,5 +147,25 @@
       "note": "Chapter 1 gives the area-based proof of the law of sines used here: Area = (1/2)ab sin(C)"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.InnerProductSpace.Basic",
+      "Mathlib.Analysis.InnerProductSpace.PiL2",
+      "Mathlib.Analysis.InnerProductSpace.Angle",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "scoped",
+      "RealInnerProductSpace"
+    ],
+    "namespace": "LawOfSines",
+    "lineCount": 310,
+    "axiomCount": 0,
+    "theoremCount": 24,
+    "definitionCount": 8,
+    "sorries": 1,
+    "path": "Proofs/LawOfSinesOQ06.lean"
+  }
 }

--- a/src/data/proofs/leibniz-pi-oq-01-oq-01/meta.json
+++ b/src/data/proofs/leibniz-pi-oq-01-oq-01/meta.json
@@ -58,8 +58,8 @@
         "note": "Chapter 10 discusses Machin's formula and its impact on pi computation"
       },
       {
-        "authors": "St\u00f8rmer, Carl",
-        "title": "Sur l'application de la th\u00e9orie des nombres entiers complexes \u00e0 la solution en nombres rationnels",
+        "authors": "Størmer, Carl",
+        "title": "Sur l'application de la théorie des nombres entiers complexes à la solution en nombres rationnels",
         "year": "1899",
         "venue": "Archiv for Mathematik og Naturvidenskab",
         "note": "Classifies all two-term Machin-like formulas via Gaussian integer factorizations"
@@ -75,10 +75,10 @@
     "prerequisites": [
       "Arctan addition formula: arctan(x) + arctan(y) = arctan((x+y)/(1-xy)) for xy < 1",
       "Arctan parity: arctan(-x) = -arctan(x)",
-      "arctan(1) = \u03c0/4 (follows from tan(\u03c0/4) = 1)",
+      "arctan(1) = π/4 (follows from tan(π/4) = 1)",
       "Rational arithmetic: the proof reduces each step to verifying equalities of rational numbers",
-      "Gaussian integers \u2124[i] (for understanding why the formula exists): arg(a+bi) = arctan(b/a)",
-      "Taylor series for arctan: arctan(x) = x - x\u00b3/3 + x\u2075/5 - \u22ef (motivates why small arguments converge fast)"
+      "Gaussian integers ℤ[i] (for understanding why the formula exists): arg(a+bi) = arctan(b/a)",
+      "Taylor series for arctan: arctan(x) = x - x³/3 + x⁵/5 - ⋯ (motivates why small arguments converge fast)"
     ],
     "dateAdded": "2026-03-23",
     "axiomCount": 0,
@@ -87,9 +87,9 @@
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
   },
   "overview": {
-    "historicalContext": "In 1706, John Machin, professor of astronomy at Gresham College, London, discovered that $\\pi/4 = 4\\arctan(1/5) - \\arctan(1/239)$. He used this identity with the Taylor series $\\arctan(x) = x - x^3/3 + x^5/5 - \\cdots$ to compute 100 digits of $\\pi$, shattering the record of 71 digits held by Abraham Sharp (1699, using the Gregory-Leibniz series at $x = 1/\\sqrt{3}$).\n\nThe formula's power lies in replacing the arctan series at $x = 1$ (the Leibniz series $\\pi/4 = 1 - 1/3 + 1/5 - \\cdots$, which converges at rate $O(1/N)$) with evaluations at $x = 1/5$ and $x = 1/239$, where the $n$th term is $O(5^{-2n})$ and $O(239^{-2n})$ respectively \u2014 exponentially fast. Each additional term of the series at $x = 1/239$ contributes roughly 4.75 new decimal digits of $\\pi$.\n\nWilliam Shanks used Machin's formula in 1873 to compute 707 digits of $\\pi$ by hand \u2014 a calculation that stood until 1944 when D.F. Ferguson found (also by hand!) an error after digit 527. Shanks had miscounted a carry in the $\\arctan(1/239)$ series. ENIAC's 1949 computation of 2037 digits used Machin's formula with machine arithmetic.\n\nMachin-like formulas dominated $\\pi$ computation for over 250 years. Carl St\u00f8rmer proved in 1899 that all two-term formulas $\\pi/4 = a\\arctan(1/b) + c\\arctan(1/d)$ correspond to factorizations of $(1+i)^n$ in the Gaussian integers $\\mathbb{Z}[i]$. For Machin's formula specifically: $(2+i)^4 = -7 + 24i$ and $(2+i)^4(239+i) = -7 \\cdot 239 + 24 - (7 + 24 \\cdot 239)i = -1649 + (-5743)i$... the Gaussian integer approach shows $4\\arg(2+i) + \\arg(239+i) = \\arg(1+i)$ because the product is a negative real multiple of $(1+i)$.\n\nModern $\\pi$ computation has moved beyond Machin-like formulas to the Borwein (1987) and Chudnovsky (1989) algorithms, which converge quadratically and yield 14 digits per term respectively. But Machin-like formulas remain important in formal verification because their proofs require only basic arctan arithmetic.",
+    "historicalContext": "In 1706, John Machin, professor of astronomy at Gresham College, London, discovered that $\\pi/4 = 4\\arctan(1/5) - \\arctan(1/239)$. He used this identity with the Taylor series $\\arctan(x) = x - x^3/3 + x^5/5 - \\cdots$ to compute 100 digits of $\\pi$, shattering the record of 71 digits held by Abraham Sharp (1699, using the Gregory-Leibniz series at $x = 1/\\sqrt{3}$).\n\nThe formula's power lies in replacing the arctan series at $x = 1$ (the Leibniz series $\\pi/4 = 1 - 1/3 + 1/5 - \\cdots$, which converges at rate $O(1/N)$) with evaluations at $x = 1/5$ and $x = 1/239$, where the $n$th term is $O(5^{-2n})$ and $O(239^{-2n})$ respectively — exponentially fast. Each additional term of the series at $x = 1/239$ contributes roughly 4.75 new decimal digits of $\\pi$.\n\nWilliam Shanks used Machin's formula in 1873 to compute 707 digits of $\\pi$ by hand — a calculation that stood until 1944 when D.F. Ferguson found (also by hand!) an error after digit 527. Shanks had miscounted a carry in the $\\arctan(1/239)$ series. ENIAC's 1949 computation of 2037 digits used Machin's formula with machine arithmetic.\n\nMachin-like formulas dominated $\\pi$ computation for over 250 years. Carl Størmer proved in 1899 that all two-term formulas $\\pi/4 = a\\arctan(1/b) + c\\arctan(1/d)$ correspond to factorizations of $(1+i)^n$ in the Gaussian integers $\\mathbb{Z}[i]$. For Machin's formula specifically: $(2+i)^4 = -7 + 24i$ and $(2+i)^4(239+i) = -7 \\cdot 239 + 24 - (7 + 24 \\cdot 239)i = -1649 + (-5743)i$... the Gaussian integer approach shows $4\\arg(2+i) + \\arg(239+i) = \\arg(1+i)$ because the product is a negative real multiple of $(1+i)$.\n\nModern $\\pi$ computation has moved beyond Machin-like formulas to the Borwein (1987) and Chudnovsky (1989) algorithms, which converge quadratically and yield 14 digits per term respectively. But Machin-like formulas remain important in formal verification because their proofs require only basic arctan arithmetic.",
     "problemStatement": "**Open Question (from parent proof)**: Prove Machin's formula $\\pi/4 = 4\\arctan(1/5) - \\arctan(1/239)$ from the arctan addition formula, rather than invoking Mathlib's pre-packaged lemma.\n\n**Resolution**: Three applications of $\\arctan(x) + \\arctan(y) = \\arctan\\left(\\frac{x+y}{1-xy}\\right)$ suffice:\n1. $\\arctan(1/5) + \\arctan(1/5) = \\arctan(5/12)$\n2. $\\arctan(5/12) + \\arctan(5/12) = \\arctan(120/119)$\n3. $\\arctan(120/119) + \\arctan(-1/239) = \\arctan(1) = \\pi/4$",
-    "text": "A four-theorem, 97-line derivation of Machin's formula $\\pi/4 = 4\\arctan(1/5) - \\arctan(1/239)$ from three applications of Mathlib's `Real.arctan_add`, with 0 axioms and 0 sorries. The proof proceeds by repeated doubling: `two_arctan_inv_5` applies the addition formula with $x = y = 1/5$ to get $\\arctan(5/12)$; `four_arctan_inv_5` doubles again with $x = y = 5/12$ to get $\\arctan(120/119)$; `arctan_diff_eq_arctan_one` uses `Real.arctan_neg` to convert the subtraction of $\\arctan(1/239)$ into addition of $\\arctan(-1/239)$, then applies `arctan_add` one final time \u2014 the resulting fraction $(28561/28441)/(28561/28441) = 1$ yields $\\arctan(1) = \\pi/4$ via `Real.arctan_one`. All rational arithmetic is verified by `norm_num`. The main theorem `machin_formula` combines the three steps with `linarith`. The derivation reveals the algebraic coincidence $120 \\cdot 239 - 119 = 119 \\cdot 239 + 120 = 28561 = 169^2$ that makes Machin's formula work \u2014 a fact explained by Gaussian integer arithmetic: $(2+i)^4(239+i)$ is a real multiple of $(1+i)$.",
+    "text": "A four-theorem, 97-line derivation of Machin's formula $\\pi/4 = 4\\arctan(1/5) - \\arctan(1/239)$ from three applications of Mathlib's `Real.arctan_add`, with 0 axioms and 0 sorries. The proof proceeds by repeated doubling: `two_arctan_inv_5` applies the addition formula with $x = y = 1/5$ to get $\\arctan(5/12)$; `four_arctan_inv_5` doubles again with $x = y = 5/12$ to get $\\arctan(120/119)$; `arctan_diff_eq_arctan_one` uses `Real.arctan_neg` to convert the subtraction of $\\arctan(1/239)$ into addition of $\\arctan(-1/239)$, then applies `arctan_add` one final time — the resulting fraction $(28561/28441)/(28561/28441) = 1$ yields $\\arctan(1) = \\pi/4$ via `Real.arctan_one`. All rational arithmetic is verified by `norm_num`. The main theorem `machin_formula` combines the three steps with `linarith`. The derivation reveals the algebraic coincidence $120 \\cdot 239 - 119 = 119 \\cdot 239 + 120 = 28561 = 169^2$ that makes Machin's formula work — a fact explained by Gaussian integer arithmetic: $(2+i)^4(239+i)$ is a real multiple of $(1+i)$.",
     "proofStrategy": "The proof applies `Real.arctan_add` three times with explicit rational arithmetic:\n\n**Step 1 (two_arctan_inv_5)**: With $x = y = 1/5$, the condition $xy = 1/25 < 1$ holds, giving $\\arctan(1/5) + \\arctan(1/5) = \\arctan\\left(\\frac{2/5}{24/25}\\right) = \\arctan(5/12)$.\n\n**Step 2 (four_arctan_inv_5)**: With $x = y = 5/12$, the condition $xy = 25/144 < 1$ holds, giving $2\\arctan(5/12) = \\arctan\\left(\\frac{10/12}{119/144}\\right) = \\arctan(120/119)$.\n\n**Step 3 (arctan_diff_eq_arctan_one)**: Rewrite the subtraction as addition using $\\arctan(-x) = -\\arctan(x)$. With $x = 120/119, y = -1/239$, the condition $xy = -120/28441 < 1$ holds, giving $\\arctan\\left(\\frac{28561/28441}{28561/28441}\\right) = \\arctan(1) = \\pi/4$.\n\nThe final step uses the fact that $120 \\cdot 239 - 119 = 28561 = 169^2$ and $119 \\cdot 239 + 120 = 28561$, so both numerator and denominator of the addition formula equal $28561/28441$, yielding a ratio of exactly 1.",
     "keyInsights": [
       "Three applications of arctan_add suffice to derive Machin's formula from first principles",
@@ -98,7 +98,7 @@
       "All three applications of arctan_add have xy < 1 trivially satisfied (either both factors < 1, or one factor is negative)",
       "The proof technique generalizes: any Machin-like formula pi/4 = sum of c_i * arctan(a_i/b_i) can be verified by iterating arctan_add",
       "Machin's formula reduces pi computation from O(N) terms (Leibniz) to O(log N) terms: the arctan series at x = 1/5 converges as O(5^{-2N}) and at x = 1/239 as O(239^{-2N}), making each additional term worth many digits",
-      "The 28561 = 169^2 coincidence is explained by Gaussian integers: $(2+i)^4(239+i)$ is a real multiple of $(1+i)$, so $4\\arg(2+i) + \\arg(239+i) = \\arg(1+i) = \\pi/4$ \u2014 St\u00f8rmer's theorem (1899) classifies all such two-term identities via $\\mathbb{Z}[i]$ factorizations"
+      "The 28561 = 169^2 coincidence is explained by Gaussian integers: $(2+i)^4(239+i)$ is a real multiple of $(1+i)$, so $4\\arg(2+i) + \\arg(239+i) = \\arg(1+i) = \\pi/4$ — Størmer's theorem (1899) classifies all such two-term identities via $\\mathbb{Z}[i]$ factorizations"
     ],
     "prerequisites": [
       "Trigonometry (arctangent function, addition formulas)",
@@ -145,12 +145,12 @@
       "startLine": 86,
       "endLine": 97,
       "summary": "Combines Steps 1-3 to prove $4 \\cdot \\arctan(1/5) - \\arctan(1/239) = \\pi/4$ in one line: rewrite via `four_arctan_inv_5` and `arctan_diff_eq_arctan_one`, then apply `arctan_one`.",
-      "mathContext": "$\\frac{\\pi}{4} = 4\\arctan\\frac{1}{5} - \\arctan\\frac{1}{239}$ \u2014 Machin's formula (1706)."
+      "mathContext": "$\\frac{\\pi}{4} = 4\\arctan\\frac{1}{5} - \\arctan\\frac{1}{239}$ — Machin's formula (1706)."
     }
   ],
   "conclusion": {
-    "summary": "Machin's formula is derived from scratch using only the arctan addition formula, arctan parity, and arctan(1) = pi/4. The proof is fully verified with 0 sorries and 0 axioms. Each step reduces to pure rational arithmetic verified by norm_num. The derivation reveals the algebraic coincidence $169^2 = 28561$ that makes the formula work \u2014 a fact obscured when citing a pre-packaged identity.",
-    "implications": "This resolves the open question from the parent proof (leibniz-pi-oq-01) about deriving Machin's formula from the addition formula. The technique generalizes to any Machin-like formula: each such identity can be verified by iterating arctan_add with norm_num checking the rational arithmetic.\n\nThe proof also demonstrates that Mathlib's arctan API is sufficient for compositional reasoning about arctangent identities, without needing to invoke specialized pre-packaged formulas.\n\nHistorically, this approach mirrors how Machin-like formulas were discovered: mathematicians searched for integers $a, b$ such that iterating the tangent addition formula on $1/a$ eventually produced a rational close to 1, with $1/b$ as the correction. St\u00f8rmer (1899) proved that any Machin-like formula with two arctan terms corresponds to a Gaussian integer factorization of $(1+i)^n$.",
+    "summary": "Machin's formula is derived from scratch using only the arctan addition formula, arctan parity, and arctan(1) = pi/4. The proof is fully verified with 0 sorries and 0 axioms. Each step reduces to pure rational arithmetic verified by norm_num. The derivation reveals the algebraic coincidence $169^2 = 28561$ that makes the formula work — a fact obscured when citing a pre-packaged identity.",
+    "implications": "This resolves the open question from the parent proof (leibniz-pi-oq-01) about deriving Machin's formula from the addition formula. The technique generalizes to any Machin-like formula: each such identity can be verified by iterating arctan_add with norm_num checking the rational arithmetic.\n\nThe proof also demonstrates that Mathlib's arctan API is sufficient for compositional reasoning about arctangent identities, without needing to invoke specialized pre-packaged formulas.\n\nHistorically, this approach mirrors how Machin-like formulas were discovered: mathematicians searched for integers $a, b$ such that iterating the tangent addition formula on $1/a$ eventually produced a rational close to 1, with $1/b$ as the correction. Størmer (1899) proved that any Machin-like formula with two arctan terms corresponds to a Gaussian integer factorization of $(1+i)^n$.",
     "openQuestions": [
       "Can the technique be automated to verify arbitrary Machin-like formulas (e.g., Wetherfield's $\\pi/4 = 12\\arctan(1/49) + 32\\arctan(1/57) - 5\\arctan(1/239) + 12\\arctan(1/110443)$)?",
       "What is the optimal Machin-like formula minimizing terms for a given accuracy? Hwang (2003) showed that minimizing the number of terms is related to factorizations in $\\mathbb{Z}[i]$.",
@@ -192,8 +192,25 @@
     {
       "targetId": "euler-identity",
       "relationship": "related",
-      "description": "Both results connect pi to analytic function identities; Euler's identity uses $e^{i\\pi}$ while Machin uses arctan composition \u2014 both are ultimately statements about arguments of complex numbers"
+      "description": "Both results connect pi to analytic function identities; Euler's identity uses $e^{i\\pi}$ while Machin uses arctan composition — both are ultimately statements about arguments of complex numbers"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Arctan",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.ArctanDeriv",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "MachinFromAddition",
+    "lineCount": 98,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/MachinFromAddition.lean"
+  }
 }

--- a/src/data/proofs/lhopital-oq-02/meta.json
+++ b/src/data/proofs/lhopital-oq-02/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "lhopital-oq-02",
-  "title": "L'H\u00f4pital's Rule: \u221e/\u221e Form",
+  "title": "L'Hôpital's Rule: ∞/∞ Form",
   "slug": "lhopital-oq-02",
-  "description": "The \u221e/\u221e form of L'H\u00f4pital's rule: if g(x) \u2192 \u221e and f'(x)/g'(x) \u2192 c, then f(x)/g(x) \u2192 c. Complements Mathlib's 0/0 form.",
+  "description": "The ∞/∞ form of L'Hôpital's rule: if g(x) → ∞ and f'(x)/g'(x) → c, then f(x)/g(x) → c. Complements Mathlib's 0/0 form.",
   "meta": {
-    "author": "Johann Bernoulli / Guillaume de l'H\u00f4pital (1696)",
+    "author": "Johann Bernoulli / Guillaume de l'Hôpital (1696)",
     "sourceUrl": "https://en.wikipedia.org/wiki/L%27H%C3%B4pital%27s_rule",
     "date": "1696",
     "status": "verified",
@@ -21,12 +21,12 @@
     "mathlibDependencies": [
       {
         "theorem": "HasDerivAt.lhopital_zero_right_on_Ioo",
-        "description": "L'H\u00f4pital's rule for 0/0 form (reference, not directly used)",
+        "description": "L'Hôpital's rule for 0/0 form (reference, not directly used)",
         "module": "Mathlib.Analysis.Calculus.LHopital"
       },
       {
         "theorem": "exists_ratio_hasDerivAt_eq_ratio_slope",
-        "description": "Cauchy's Mean Value Theorem (core tool for the \u221e/\u221e proof)",
+        "description": "Cauchy's Mean Value Theorem (core tool for the ∞/∞ proof)",
         "module": "Mathlib.Analysis.Calculus.MeanValue"
       },
       {
@@ -36,15 +36,15 @@
       }
     ],
     "originalContributions": [
-      "Statement of \u221e/\u221e L'H\u00f4pital's rule for right approach (\ud835\udcdd[>] a)",
-      "Statement of \u221e/\u221e L'H\u00f4pital's rule for left approach (\ud835\udcdd[<] b)",
-      "Statement of \u221e/\u221e L'H\u00f4pital's rule at +\u221e (atTop)",
-      "Statement of \u221e/\u221e L'H\u00f4pital's rule at -\u221e (atBot)",
+      "Statement of ∞/∞ L'Hôpital's rule for right approach (𝓝[>] a)",
+      "Statement of ∞/∞ L'Hôpital's rule for left approach (𝓝[<] b)",
+      "Statement of ∞/∞ L'Hôpital's rule at +∞ (atTop)",
+      "Statement of ∞/∞ L'Hôpital's rule at -∞ (atBot)",
       "Complete proof of right approach via two-variable Cauchy MVT with explicit epsilon management",
       "Proof of left approach via negation reduction (following Mathlib's 0/0 pattern)",
       "Proof of atTop via inversion reduction (following Mathlib's 0/0 pattern)",
       "Proof of atBot via negation reduction to atTop (following Mathlib's 0/0 pattern)",
-      "Documentation of why \u221e/\u221e needs a separate proof from 0/0"
+      "Documentation of why ∞/∞ needs a separate proof from 0/0"
     ],
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
@@ -58,15 +58,15 @@
       "title": "Private Lemma: c = 0 Case (Core Engine)",
       "startLine": 64,
       "endLine": 224,
-      "summary": "Private theorem proving g\u2192\u221e, f'/g'\u21920 \u27f9 f/g\u21920 via three-\u03b4 construction + Cauchy MVT on [x, x\u2080] + algebraic identity.",
-      "mathContext": "Three-\u03b4: fix $x_0$ near $a$ with $|f'/g'|<\\varepsilon/2$ for $\\xi < x_0$, then ensure $g(x) \\ge M = \\max(g(x_0)+1, 2|f(x_0)|/\\varepsilon+1)$. Key identity: $f/g = (f'/g')\\cdot(1-g(x_0)/g) + f(x_0)/g$."
+      "summary": "Private theorem proving g→∞, f'/g'→0 ⟹ f/g→0 via three-δ construction + Cauchy MVT on [x, x₀] + algebraic identity.",
+      "mathContext": "Three-δ: fix $x_0$ near $a$ with $|f'/g'|<\\varepsilon/2$ for $\\xi < x_0$, then ensure $g(x) \\ge M = \\max(g(x_0)+1, 2|f(x_0)|/\\varepsilon+1)$. Key identity: $f/g = (f'/g')\\cdot(1-g(x_0)/g) + f(x_0)/g$."
     },
     {
       "id": "right-approach",
-      "title": "Main Theorem: \u221e/\u221e L'H\u00f4pital, Right Approach",
+      "title": "Main Theorem: ∞/∞ L'Hôpital, Right Approach",
       "startLine": 226,
       "endLine": 275,
-      "summary": "Public theorem for general c: reduce to c=0 via h(x)=f(x)-c\u00b7g(x), then apply the private lemma and add c back.",
+      "summary": "Public theorem for general c: reduce to c=0 via h(x)=f(x)-c·g(x), then apply the private lemma and add c back.",
       "mathContext": "$f/g \\to c$ iff $h/g = (f-c\\cdot g)/g \\to 0$, where $h'/g' = f'/g' - c \\to 0$."
     },
     {
@@ -74,36 +74,36 @@
       "title": "Additional Variants (All Proved)",
       "startLine": 277,
       "endLine": 373,
-      "summary": "Left approach (negation), atTop (inversion), and atBot (negation of atTop) \u2014 all fully proved following Mathlib's 0/0 reduction pattern.",
+      "summary": "Left approach (negation), atTop (inversion), and atBot (negation of atTop) — all fully proved following Mathlib's 0/0 reduction pattern.",
       "mathContext": "Each reduces to the right approach via a substitution that maps the limit direction to $\\mathcal{N}^+[a]$. Left: $u=-x$ with $\\text{neg\\_Ioo}$; atTop: $u=x^{-1}$ with $\\text{hasDerivAt\\_inv}$; atBot: $u=-x$ composed with atTop."
     },
     {
       "id": "examples",
-      "title": "Classic Examples: x/e\u02e3 and ln(x)/cot(x)",
+      "title": "Classic Examples: x/eˣ and ln(x)/cot(x)",
       "startLine": 315,
       "endLine": 333,
-      "summary": "Two canonical \u221e/\u221e examples as commentary. x/e\u02e3 \u2192 0 (x\u2192\u221e), ln(x)/cot(x) \u2192 0 (x\u21920\u207a)."
+      "summary": "Two canonical ∞/∞ examples as commentary. x/eˣ → 0 (x→∞), ln(x)/cot(x) → 0 (x→0⁺)."
     },
     {
       "id": "comparison",
-      "title": "Why \u221e/\u221e Needs a Different Proof from 0/0",
+      "title": "Why ∞/∞ Needs a Different Proof from 0/0",
       "startLine": 335,
       "endLine": 357,
-      "summary": "Explains why the 0/0 Cauchy MVT at the limit point fails for \u221e/\u221e, and why the two-variable argument is necessary.",
+      "summary": "Explains why the 0/0 Cauchy MVT at the limit point fails for ∞/∞, and why the two-variable argument is necessary.",
       "mathContext": "For $0/0$: MVT on $[a,x]$ gives $f(x)/g(x) = (f(x)-f(a))/(g(x)-g(a)) = f'(\\xi)/g'(\\xi)$ directly. For $\\infty/\\infty$: $f(a), g(a)$ don't exist; must use MVT on $[x, x_0]$ with $x_0 > a$ as anchor."
     }
   ],
   "overview": {
-    "historicalContext": "L'H\u00f4pital's rule was published in 1696 in the Marquis de l'H\u00f4pital's textbook Analyse des infiniment petits, the first calculus textbook ever printed. The result was actually discovered by Johann Bernoulli, who communicated it to l'H\u00f4pital as part of a private tutoring arrangement. The 0/0 form was the primary focus in the 18th and 19th centuries, but the \u221e/\u221e form is equally fundamental and arises naturally in applications like computing lim(x\u2192\u221e) x/e\u02e3 = 0. The modern rigorous proof using Cauchy's Mean Value Theorem was developed in the 19th century. The \u221e/\u221e form requires a genuinely different two-variable argument because the functions diverge at the limit point, preventing the direct MVT application that works for 0/0. As of Mathlib 4.26.0, all 26 L'H\u00f4pital variants in Mathlib handle only the 0/0 form \u2014 this formalization fills that gap with the complementary \u221e/\u221e form.",
-    "problemStatement": "**\u221e/\u221e L'H\u00f4pital's Rule**: If f and g are differentiable near a, g(x) \u2192 \u221e as x \u2192 a\u207a, g'(x) \u2260 0, and f'(x)/g'(x) \u2192 c, then f(x)/g(x) \u2192 c.",
-    "text": "Formalize the \u221e/\u221e form of L'H\u00f4pital's rule, complementing Mathlib's 0/0 form.",
-    "proofStrategy": "The proof fixes x\u2080 near a, applies Cauchy's MVT on (x, x\u2080), and rewrites f(x)/g(x) as a combination of f'(\u03be)/g'(\u03be) (close to c) and correction terms f(x\u2080)/g(x) and g(x\u2080)/g(x) that vanish as g(x) \u2192 \u221e.",
+    "historicalContext": "L'Hôpital's rule was published in 1696 in the Marquis de l'Hôpital's textbook Analyse des infiniment petits, the first calculus textbook ever printed. The result was actually discovered by Johann Bernoulli, who communicated it to l'Hôpital as part of a private tutoring arrangement. The 0/0 form was the primary focus in the 18th and 19th centuries, but the ∞/∞ form is equally fundamental and arises naturally in applications like computing lim(x→∞) x/eˣ = 0. The modern rigorous proof using Cauchy's Mean Value Theorem was developed in the 19th century. The ∞/∞ form requires a genuinely different two-variable argument because the functions diverge at the limit point, preventing the direct MVT application that works for 0/0. As of Mathlib 4.26.0, all 26 L'Hôpital variants in Mathlib handle only the 0/0 form — this formalization fills that gap with the complementary ∞/∞ form.",
+    "problemStatement": "**∞/∞ L'Hôpital's Rule**: If f and g are differentiable near a, g(x) → ∞ as x → a⁺, g'(x) ≠ 0, and f'(x)/g'(x) → c, then f(x)/g(x) → c.",
+    "text": "Formalize the ∞/∞ form of L'Hôpital's rule, complementing Mathlib's 0/0 form.",
+    "proofStrategy": "The proof fixes x₀ near a, applies Cauchy's MVT on (x, x₀), and rewrites f(x)/g(x) as a combination of f'(ξ)/g'(ξ) (close to c) and correction terms f(x₀)/g(x) and g(x₀)/g(x) that vanish as g(x) → ∞.",
     "keyInsights": [
       "Only $g \\to \\infty$ is needed, not both $f$ and $g$: the proof only uses divergence of $g$ to make correction terms $f(x_0)/g(x)$ and $g(x_0)/g(x)$ vanish, never requiring $f \\to \\infty$",
-      "The key algebraic identity $f/g = [f'/g'] \\cdot [1-g(x_0)/g] + f(x_0)/g$ decomposes the ratio into an MVT term (close to $c$) and two correction terms (that vanish as $g \\to \\infty$) \u2014 this is the central insight of the two-variable argument",
+      "The key algebraic identity $f/g = [f'/g'] \\cdot [1-g(x_0)/g] + f(x_0)/g$ decomposes the ratio into an MVT term (close to $c$) and two correction terms (that vanish as $g \\to \\infty$) — this is the central insight of the two-variable argument",
       "The bound $|1 - g(x_0)/g(x)| \\le 1$ (since $0 < g(x_0) < g(x)$) is crucial: it ensures the MVT term contributes at most $|f'/g'|$, even without knowing the bracket is small",
       "The reduction to $c=0$ via $h = f - c \\cdot g$ is a bookkeeping simplification that transforms 'ratio tends to $c$' into 'ratio tends to 0', making the epsilon argument cleaner",
-      "The three pending sorry variants (left, atTop, atBot) are proof-structure exercises \u2014 they contain the substitution strategy in comments and should be closable by Aristotle or by direct filter manipulation"
+      "The three pending sorry variants (left, atTop, atBot) are proof-structure exercises — they contain the substitution strategy in comments and should be closable by Aristotle or by direct filter manipulation"
     ],
     "prerequisites": [
       "Cauchy's Mean Value Theorem",
@@ -115,17 +115,17 @@
     ]
   },
   "conclusion": {
-    "summary": "All four variants of the \u221e/\u221e L'H\u00f4pital's rule are fully proved (0 sorries, 0 axioms): right approach via two-variable Cauchy MVT, left via negation, atTop via inversion, atBot via negation of atTop. Docker-verified with Lean 4.26.0.",
-    "implications": "This formalization fills a genuine gap in Mathlib's calculus library: as of v4.26.0, all 26 L'H\u00f4pital variants handle only the 0/0 form. All four directional variants are now complete and could be contributed to Mathlib. The two-variable argument with explicit delta construction is a template applicable to other limit theorems where direct MVT application at the limit point fails.",
+    "summary": "All four variants of the ∞/∞ L'Hôpital's rule are fully proved (0 sorries, 0 axioms): right approach via two-variable Cauchy MVT, left via negation, atTop via inversion, atBot via negation of atTop. Docker-verified with Lean 4.26.0.",
+    "implications": "This formalization fills a genuine gap in Mathlib's calculus library: as of v4.26.0, all 26 L'Hôpital variants handle only the 0/0 form. All four directional variants are now complete and could be contributed to Mathlib. The two-variable argument with explicit delta construction is a template applicable to other limit theorems where direct MVT application at the limit point fails.",
     "openQuestions": [
-      "Can the three pending sorry variants be closed by Aristotle proof search? The substitution strategy is spelled out in comments (reflection for left approach, inversion for atTop, negation for atBot) \u2014 these may be straightforward filter manipulations.",
-      "The 0/0 form can sometimes be reduced to the \u221e/\u221e form via $u = 1/f(x)$. Is there a clean formal proof that the two forms are logically equivalent (derivable from each other), or does each require its own independent epsilon-delta argument?",
-      "Mathlib's 26 L'H\u00f4pital variants include different derivative hypotheses (HasDerivAt, HasStrictDerivAt, DifferentiableOn). Should the \u221e/\u221e variants be stated for each hypothesis style to match the existing API surface?"
+      "Can the three pending sorry variants be closed by Aristotle proof search? The substitution strategy is spelled out in comments (reflection for left approach, inversion for atTop, negation for atBot) — these may be straightforward filter manipulations.",
+      "The 0/0 form can sometimes be reduced to the ∞/∞ form via $u = 1/f(x)$. Is there a clean formal proof that the two forms are logically equivalent (derivable from each other), or does each require its own independent epsilon-delta argument?",
+      "Mathlib's 26 L'Hôpital variants include different derivative hypotheses (HasDerivAt, HasStrictDerivAt, DifferentiableOn). Should the ∞/∞ variants be stated for each hypothesis style to match the existing API surface?"
     ]
   },
   "crossReferences": [
     {
-      "relationship": "The parent proof formalizes the 0/0 form (Wiedijk #64). This OQ adds the complementary \u221e/\u221e form",
+      "relationship": "The parent proof formalizes the 0/0 form (Wiedijk #64). This OQ adds the complementary ∞/∞ form",
       "sharedConcepts": [
         "lhopital",
         "limits",
@@ -135,5 +135,28 @@
       "targetId": "lhopital"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.Calculus.LHopital",
+      "Mathlib.Analysis.Calculus.MeanValue",
+      "Mathlib.Analysis.Calculus.Deriv.Basic",
+      "Mathlib.Analysis.SpecificLimits.Normed",
+      "Mathlib.Order.Filter.Basic",
+      "Mathlib.Topology.Order.Basic"
+    ],
+    "opens": [
+      "Set",
+      "Filter",
+      "Topology",
+      "Real"
+    ],
+    "namespace": "LHopitalInfty",
+    "lineCount": 429,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/LHopitalOQ02.lean"
+  }
 }

--- a/src/data/proofs/morleys-theorem/meta.json
+++ b/src/data/proofs/morleys-theorem/meta.json
@@ -28,12 +28,12 @@
       },
       {
         "theorem": "Mathlib.Analysis.InnerProductSpace.Basic",
-        "description": "Inner product spaces for EuclideanSpace \u211d (Fin 2)",
+        "description": "Inner product spaces for EuclideanSpace ℝ (Fin 2)",
         "module": "Mathlib.Analysis.InnerProductSpace.Basic"
       },
       {
         "theorem": "Mathlib.Data.Real.Sqrt",
-        "description": "Real square root used in trigonometric identity proofs (\u221a3/2)",
+        "description": "Real square root used in trigonometric identity proofs (√3/2)",
         "module": "Mathlib.Data.Real.Sqrt"
       },
       {
@@ -43,10 +43,10 @@
       }
     ],
     "originalContributions": [
-      "TriangleAngles structure with trisected angles and sum-to-\u03c0/3 lemma",
-      "Triple sine product identity: sin(3x) = 4sin(x)sin(\u03c0/3+x)sin(\u03c0/3-x)",
-      "Cosine rule identity for angle triples: sin\u00b2p+sin\u00b2q-2sin(p)sin(q)cos(c)=sin\u00b2c when p+q+c=\u03c0",
-      "Morley side length formula 8R\u00b7sin(\u03b1/3)\u00b7sin(\u03b2/3)\u00b7sin(\u03b3/3) proved via sine rule + cosine rule",
+      "TriangleAngles structure with trisected angles and sum-to-π/3 lemma",
+      "Triple sine product identity: sin(3x) = 4sin(x)sin(π/3+x)sin(π/3-x)",
+      "Cosine rule identity for angle triples: sin²p+sin²q-2sin(p)sin(q)cos(c)=sin²c when p+q+c=π",
+      "Morley side length formula 8R·sin(α/3)·sin(β/3)·sin(γ/3) proved via sine rule + cosine rule",
       "Complete proof: all three Morley sides equal by symmetry of the formula",
       "Conway backward proof strategy via complex equilateral triangle (retained for context)",
       "Special case formalizations for equilateral and right isosceles triangles"
@@ -58,13 +58,13 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "Frank Morley (1860-1937), an English-American mathematician and professor at Johns Hopkins University, discovered this theorem in 1899. Despite centuries of intensive study of triangle geometry by mathematicians from Euclid to Euler, this beautiful property remained hidden until the dawn of the 20th century. It has been called 'the most remarkable theorem in elementary geometry discovered in the 20th century.'\n\nThe theorem wasn't discovered earlier because angle trisection is impossible with compass and straightedge alone \u2014 a fact proved by Pierre Wantzel in 1837 using Galois theory. The ancient Greeks, who could not construct the trisector configuration, never encountered the Morley triangle. The algebraic reason is that trisecting angle $\\theta$ requires solving the irreducible cubic $4\\cos^3\\phi - 3\\cos\\phi = \\cos\\theta$.\n\nMorley first communicated the result around 1899, but it was not published until 1929. Multiple elegant proofs have been found: trigonometric (direct computation), complex number coordinates, and John Conway's celebrated 'backward proof' which starts with the equilateral triangle and reconstructs the original. The formalization here follows Conway's approach using complex coordinates.\n\nMorley's theorem appears as #84 in Freek Wiedijk's list of 100 greatest theorems. It connects to angle trisection impossibility (#8 on the same list) through the triple angle formula $\\cos(3\\theta) = 4\\cos^3\\theta - 3\\cos\\theta$.",
+    "historicalContext": "Frank Morley (1860-1937), an English-American mathematician and professor at Johns Hopkins University, discovered this theorem in 1899. Despite centuries of intensive study of triangle geometry by mathematicians from Euclid to Euler, this beautiful property remained hidden until the dawn of the 20th century. It has been called 'the most remarkable theorem in elementary geometry discovered in the 20th century.'\n\nThe theorem wasn't discovered earlier because angle trisection is impossible with compass and straightedge alone — a fact proved by Pierre Wantzel in 1837 using Galois theory. The ancient Greeks, who could not construct the trisector configuration, never encountered the Morley triangle. The algebraic reason is that trisecting angle $\\theta$ requires solving the irreducible cubic $4\\cos^3\\phi - 3\\cos\\phi = \\cos\\theta$.\n\nMorley first communicated the result around 1899, but it was not published until 1929. Multiple elegant proofs have been found: trigonometric (direct computation), complex number coordinates, and John Conway's celebrated 'backward proof' which starts with the equilateral triangle and reconstructs the original. The formalization here follows Conway's approach using complex coordinates.\n\nMorley's theorem appears as #84 in Freek Wiedijk's list of 100 greatest theorems. It connects to angle trisection impossibility (#8 on the same list) through the triple angle formula $\\cos(3\\theta) = 4\\cos^3\\theta - 3\\cos\\theta$.",
     "problemStatement": "**Morley's Trisector Theorem**: In any triangle $ABC$ with angles $\\alpha, \\beta, \\gamma$, the three intersection points of **adjacent** angle trisectors form an **equilateral triangle** (the Morley triangle).\n\nMore precisely: if the trisectors of angle $\\alpha$ make angles $\\alpha/3$ with sides $AB$ and $AC$, and similarly for $\\beta$ and $\\gamma$, then the three pairwise intersections of adjacent trisectors form a triangle with all sides equal to $8R \\sin(\\alpha/3) \\sin(\\beta/3) \\sin(\\gamma/3)$, where $R$ is the circumradius.",
     "text": "The three angle trisectors of any triangle, taken in pairs, meet to form an equilateral triangle. A surprising result discovered in 1899.",
     "proofStrategy": "The proof uses the **sine rule / cosine rule method**: (1) In each sub-triangle formed by adjacent trisectors and a side, the **sine rule** gives arm lengths from each vertex to adjacent Morley points. (2) The **triple sine identity** $\\sin(3x) = 4\\sin(x)\\sin(\\pi/3+x)\\sin(\\pi/3-x)$ simplifies the sine rule computation, canceling $\\sin(\\pi/3-\\alpha_3)$ factors. (3) The **cosine rule** in the triangle connecting two Morley points through a shared vertex, with the **cosine rule identity** $\\sin^2 p + \\sin^2 q - 2\\sin p \\sin q \\cos c = \\sin^2 c$ (valid when $p+q+c=\\pi$), converts the distance computation into the symmetric formula $8R\\sin(\\alpha/3)\\sin(\\beta/3)\\sin(\\gamma/3)$. (4) Since this formula is **symmetric** in the trisected angles, all three Morley sides are equal, proving equilaterality. The Conway backward construction (equilateral triangle via cube roots of unity) is retained for geometric context.",
     "keyInsights": [
       "**Symmetric side formula**: The Morley side length $s = 8R \\sin(\\alpha/3) \\sin(\\beta/3) \\sin(\\gamma/3)$ is symmetric in the three trisected angles, immediately proving all sides equal",
-      "**Trisected angle sum**: $\\alpha/3 + \\beta/3 + \\gamma/3 = \\pi/3 = 60\u00b0$, connecting the trisected angles to the equilateral triangle's internal angle",
+      "**Trisected angle sum**: $\\alpha/3 + \\beta/3 + \\gamma/3 = \\pi/3 = 60°$, connecting the trisected angles to the equilateral triangle's internal angle",
       "**Conway's backward construction**: Starting from the equilateral Morley triangle and reconstructing the original avoids the computational complexity of the direct proof",
       "**Complex coordinates**: Using $\\mathbb{C}$ as the Euclidean plane, with cube roots of unity for the equilateral vertices, elegantly combines algebra and geometry",
       "**Connection to trisection impossibility**: The theorem requires constructing angle trisectors (cubic field extensions), explaining why the ancient Greeks never found it"
@@ -113,7 +113,7 @@
       "title": "Original Triangle Reconstruction",
       "startLine": 160,
       "endLine": 198,
-      "summary": "Defines `Point := \u2102`, `direction \u03b8 := e^{i\u03b8}`, and vertices $A$, $B$, $C$ reconstructed from Morley triangle using trisected-angle-determined rays.",
+      "summary": "Defines `Point := ℂ`, `direction θ := e^{iθ}`, and vertices $A$, $B$, $C$ reconstructed from Morley triangle using trisected-angle-determined rays.",
       "mathContext": "Points in $\\mathbb{C}$; direction $\\theta \\mapsto e^{i\\theta}$. Conway's backward construction: given the Morley triangle $PQR$, reconstruct $A$, $B$, $C$ by extending rays at angles $\\alpha_3$, $\\beta_3$, $\\gamma_3$ from the Morley vertices."
     },
     {
@@ -138,7 +138,7 @@
       "startLine": 272,
       "endLine": 312,
       "summary": "Equilateral original triangle ($\\alpha = \\beta = \\gamma = \\pi/3$, trisected angle $= \\pi/9$) and right isosceles ($\\alpha = \\beta = \\pi/4$, $\\gamma = \\pi/2$).",
-      "mathContext": "Equilateral case: $\\alpha = \\beta = \\gamma = \\pi/3$ gives trisected angles $\\pi/9 = 20\u00b0$ and Morley side $s = 8R \\sin^3(\\pi/9)$. Right isosceles: $\\alpha = \\beta = \\pi/4$, $\\gamma = \\pi/2$, trisected angles $\\pi/12, \\pi/12, \\pi/6$."
+      "mathContext": "Equilateral case: $\\alpha = \\beta = \\gamma = \\pi/3$ gives trisected angles $\\pi/9 = 20°$ and Morley side $s = 8R \\sin^3(\\pi/9)$. Right isosceles: $\\alpha = \\beta = \\pi/4$, $\\gamma = \\pi/2$, trisected angles $\\pi/12, \\pi/12, \\pi/6$."
     },
     {
       "id": "historical-notes",
@@ -150,17 +150,17 @@
     }
   ],
   "conclusion": {
-    "summary": "Morley's theorem is formalized using Conway's backward proof in complex coordinates. The TriangleAngles structure captures the angle-sum constraint, cube roots of unity define the equilateral Morley triangle, and the symmetric side length formula 8R\u00b7sin(\u03b1/3)\u00b7sin(\u03b2/3)\u00b7sin(\u03b3/3) encodes the equilateral property. Two trigonometric identities are proved from Mathlib; the main theorem is axiomatized.",
+    "summary": "Morley's theorem is formalized using Conway's backward proof in complex coordinates. The TriangleAngles structure captures the angle-sum constraint, cube roots of unity define the equilateral Morley triangle, and the symmetric side length formula 8R·sin(α/3)·sin(β/3)·sin(γ/3) encodes the equilateral property. Two trigonometric identities are proved from Mathlib; the main theorem is axiomatized.",
     "implications": "**Theoretical Significance**: The formalization demonstrates how complex coordinates elegantly combine algebraic and geometric reasoning.\n\nThe TriangleAngles structure and backward construction provide a reusable framework for formalizing other triangle-center theorems (Napoleon's theorem, Feuerbach's theorem). The connection between Morley's theorem and angle trisection impossibility links classical geometry to Galois theory.",
     "openQuestions": [
-      "Can Napoleon's theorem (equilateral triangles on sides \u2192 centroids form equilateral) be formalized using the TriangleAngles framework?",
-      "Can the extended Morley theorem (non-adjacent trisectors \u2192 other special triangles) be stated and proved?",
+      "Can Napoleon's theorem (equilateral triangles on sides → centroids form equilateral) be formalized using the TriangleAngles framework?",
+      "Can the extended Morley theorem (non-adjacent trisectors → other special triangles) be stated and proved?",
       "Can the cosine_rule_identity and sin_triple_product be contributed to Mathlib as general-purpose lemmas?"
     ]
   },
   "crossReferences": [
     {
-      "relationship": "Morley's theorem requires angle trisection (impossible with compass/straightedge by Wantzel 1837, Wiedijk #8). The triple angle formula cos(3\u03b8) = 4cos\u00b3\u03b8 - 3cos\u03b8 connects both results algebraically",
+      "relationship": "Morley's theorem requires angle trisection (impossible with compass/straightedge by Wantzel 1837, Wiedijk #8). The triple angle formula cos(3θ) = 4cos³θ - 3cosθ connects both results algebraically",
       "sharedConcepts": [
         "angle-trisection",
         "cubic-equations",
@@ -169,7 +169,7 @@
       "targetId": "angle-trisection"
     },
     {
-      "relationship": "The angle sum \u03b1 + \u03b2 + \u03b3 = \u03c0 (Wiedijk #27) is the foundational constraint for TriangleAngles, implying the trisected angle sum \u03b1/3 + \u03b2/3 + \u03b3/3 = \u03c0/3",
+      "relationship": "The angle sum α + β + γ = π (Wiedijk #27) is the foundational constraint for TriangleAngles, implying the trisected angle sum α/3 + β/3 + γ/3 = π/3",
       "sharedConcepts": [
         "triangle-angles",
         "angle-sum-property",
@@ -196,7 +196,7 @@
       "targetId": "feuerbachs-theorem"
     },
     {
-      "relationship": "The law of cosines (Wiedijk #94) and law of sines are used in deriving the Morley side length formula 8R\u00b7sin(\u03b1/3)\u00b7sin(\u03b2/3)\u00b7sin(\u03b3/3)",
+      "relationship": "The law of cosines (Wiedijk #94) and law of sines are used in deriving the Morley side length formula 8R·sin(α/3)·sin(β/3)·sin(γ/3)",
       "sharedConcepts": [
         "trigonometry",
         "circumradius",
@@ -210,14 +210,14 @@
       "authors": "Morley, Frank",
       "title": "Extensions of Clifford's chain-theorem",
       "year": "1899",
-      "venue": "American Journal of Mathematics 51, 465\u2013472",
-      "note": "Statement of the theorem that the angle trisectors of any triangle form an equilateral triangle \u2014 first proved by others ca. 1900"
+      "venue": "American Journal of Mathematics 51, 465–472",
+      "note": "Statement of the theorem that the angle trisectors of any triangle form an equilateral triangle — first proved by others ca. 1900"
     },
     {
       "authors": "Connes, Alain",
       "title": "A new proof of Morley's theorem",
       "year": "1998",
-      "venue": "Les Relations entre les Math\u00e9matiques et la Physique Th\u00e9orique, IH\u00c9S",
+      "venue": "Les Relations entre les Mathématiques et la Physique Théorique, IHÉS",
       "note": "Elegant proof using the group of affine transformations"
     }
   ],
@@ -229,5 +229,26 @@
       "leanType": "Triangle ABC -> trisector_triangle ABC is equilateral"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.InnerProductSpace.Basic",
+      "Mathlib.Analysis.InnerProductSpace.PiL2",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic",
+      "Mathlib.Data.Real.Basic",
+      "Mathlib.Data.Real.Sqrt",
+      "Mathlib.Geometry.Euclidean.Angle.Unoriented.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "MorleysTheorem",
+    "lineCount": 533,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 11,
+    "sorries": 0,
+    "path": "Proofs/MorleysTheorem.lean"
+  }
 }

--- a/src/data/proofs/napoleons-theorem/meta.json
+++ b/src/data/proofs/napoleons-theorem/meta.json
@@ -21,7 +21,7 @@
     "mathlibDependencies": [
       {
         "theorem": "Complex",
-        "description": "Complex number field \u2102 and basic arithmetic",
+        "description": "Complex number field ℂ and basic arithmetic",
         "module": "Mathlib.Data.Complex.Basic"
       },
       {
@@ -31,13 +31,13 @@
       },
       {
         "theorem": "Real.sqrt",
-        "description": "Square root function for \u221a3 in centroid formulas",
+        "description": "Square root function for √3 in centroid formulas",
         "module": "Mathlib.Data.Real.Sqrt"
       }
     ],
     "originalContributions": [
-      "Napoleon centroid formula: G = (b+c)/2 + i\u221a3(c-b)/6 for outer equilateral on side bc",
-      "Rotation identity: G\u2083 - G\u2081 = (G\u2082 - G\u2081) \u00b7 e^{-i\u03c0/3}, the algebraic core of Napoleon's theorem",
+      "Napoleon centroid formula: G = (b+c)/2 + i√3(c-b)/6 for outer equilateral on side bc",
+      "Rotation identity: G₃ - G₁ = (G₂ - G₁) · e^{-iπ/3}, the algebraic core of Napoleon's theorem",
       "Complete proof of outer and inner Napoleon triangle equilaterality via rotation",
       "Centroid preservation: Napoleon triangle centroid equals original triangle centroid",
       "Inner Napoleon triangle variant with conjugate rotation factor"
@@ -53,33 +53,33 @@
       "title": "Napoleon Centroid Construction",
       "startLine": 60,
       "endLine": 85,
-      "description": "Define the centroid of the outer equilateral triangle on each side using the displacement formula G = midpoint + i\u221a3(c-b)/6.",
+      "description": "Define the centroid of the outer equilateral triangle on each side using the displacement formula G = midpoint + i√3(c-b)/6.",
       "summary": "Napoleon Centroid Construction",
       "id": "napoleon-centroid-construction"
     },
     {
-      "title": "Algebraic Lemma: \u221a3\u00b2 = 3",
+      "title": "Algebraic Lemma: √3² = 3",
       "startLine": 90,
       "endLine": 105,
-      "description": "The key algebraic fact \u221a3\u00b2 = 3 lifted to \u2102, used in the rotation identity proof.",
-      "summary": "Algebraic Lemma: \u221a3\u00b2 = 3",
-      "id": "algebraic-lemma-\u221a3\u00b2-=-3"
+      "description": "The key algebraic fact √3² = 3 lifted to ℂ, used in the rotation identity proof.",
+      "summary": "Algebraic Lemma: √3² = 3",
+      "id": "algebraic-lemma-√3²-=-3"
     },
     {
       "title": "Rotation Identity",
       "startLine": 110,
       "endLine": 175,
-      "description": "The algebraic heart: G\u2083 - G\u2081 = (G\u2082 - G\u2081) \u00b7 e^{-i\u03c0/3}. Both sides expand to (z\u2081-z\u2083)/2 + i\u221a3(2z\u2082-z\u2081-z\u2083)/6.",
+      "description": "The algebraic heart: G₃ - G₁ = (G₂ - G₁) · e^{-iπ/3}. Both sides expand to (z₁-z₃)/2 + i√3(2z₂-z₁-z₃)/6.",
       "summary": "Rotation Identity",
       "id": "rotation-identity"
     },
     {
-      "title": "Napoleon's Theorem \u2014 Equilateral Property",
+      "title": "Napoleon's Theorem — Equilateral Property",
       "startLine": 180,
       "endLine": 230,
-      "description": "All three sides of the outer Napoleon triangle are equal, derived from the rotation identity and |e^{-i\u03c0/3}| = 1.",
-      "summary": "Napoleon's Theorem \u2014 Equilateral Property",
-      "id": "napoleon's-theorem-\u2014-equilater"
+      "description": "All three sides of the outer Napoleon triangle are equal, derived from the rotation identity and |e^{-iπ/3}| = 1.",
+      "summary": "Napoleon's Theorem — Equilateral Property",
+      "id": "napoleon's-theorem-—-equilater"
     },
     {
       "title": "Side Length Formula",
@@ -107,22 +107,22 @@
     }
   ],
   "overview": {
-    "historicalContext": "Napoleon's theorem is traditionally attributed to Napoleon Bonaparte (1769\u20131821), who was known to be interested in mathematics and geometry. However, the attribution is likely apocryphal \u2014 the theorem was known in various forms in the 18th and 19th centuries, and its earliest published proof is from the 1820s.\n\nThe theorem belongs to the family of 'hidden equilateral triangle' results in elementary geometry, alongside Morley's theorem. While Morley's theorem involves angle trisectors, Napoleon's theorem uses the more accessible construction of equilateral triangles on the sides.\n\nThe result has a beautiful dual: both the outer Napoleon triangle (equilateral triangles constructed outward) and the inner Napoleon triangle (constructed inward) are equilateral, and both share the same centroid as the original triangle.",
+    "historicalContext": "Napoleon's theorem is traditionally attributed to Napoleon Bonaparte (1769–1821), who was known to be interested in mathematics and geometry. However, the attribution is likely apocryphal — the theorem was known in various forms in the 18th and 19th centuries, and its earliest published proof is from the 1820s.\n\nThe theorem belongs to the family of 'hidden equilateral triangle' results in elementary geometry, alongside Morley's theorem. While Morley's theorem involves angle trisectors, Napoleon's theorem uses the more accessible construction of equilateral triangles on the sides.\n\nThe result has a beautiful dual: both the outer Napoleon triangle (equilateral triangles constructed outward) and the inner Napoleon triangle (constructed inward) are equilateral, and both share the same centroid as the original triangle.",
     "problemStatement": "**Napoleon's Theorem**: Given any triangle ABC, construct equilateral triangles externally on each side. Then the centroids of these three equilateral triangles form an equilateral triangle (the **outer Napoleon triangle**).\n\nSimilarly, if equilateral triangles are constructed internally, their centroids also form an equilateral triangle (the **inner Napoleon triangle**).\n\nBoth Napoleon triangles share the same centroid as the original triangle.",
     "text": "If equilateral triangles are constructed externally on the sides of any triangle, their centroids form an equilateral triangle.",
-    "proofStrategy": "The proof uses **complex coordinates** and a **rotation identity**.\n\n1. **Construction**: The centroid of the outer equilateral triangle on side bc is G = (b+c)/2 + i\u221a3(c-b)/6, where b, c \u2208 \u2102 are the vertices.\n\n2. **Rotation identity**: The key insight is that consecutive difference vectors of Napoleon centroids are related by rotation by -60\u00b0:\n   G\u2083 - G\u2081 = (G\u2082 - G\u2081) \u00b7 e^{-i\u03c0/3}\n   This is verified by expanding both sides: both reduce to (z\u2081-z\u2083)/2 + i\u221a3(2z\u2082-z\u2081-z\u2083)/6, using only \u221a3\u00b2 = 3 and i\u00b2 = -1.\n\n3. **Equilaterality**: Since |e^{-i\u03c0/3}| = 1, the rotation identity immediately gives |G\u2083 - G\u2081| = |G\u2082 - G\u2081|. For the third side, G\u2083 - G\u2082 = (G\u2082 - G\u2081)(e^{-i\u03c0/3} - 1), and |e^{-i\u03c0/3} - 1| = 1 as well.\n\n4. **Inner variant**: Replacing i with -i in the centroid formula gives the inner Napoleon triangle, with rotation by +60\u00b0 instead of -60\u00b0.",
+    "proofStrategy": "The proof uses **complex coordinates** and a **rotation identity**.\n\n1. **Construction**: The centroid of the outer equilateral triangle on side bc is G = (b+c)/2 + i√3(c-b)/6, where b, c ∈ ℂ are the vertices.\n\n2. **Rotation identity**: The key insight is that consecutive difference vectors of Napoleon centroids are related by rotation by -60°:\n   G₃ - G₁ = (G₂ - G₁) · e^{-iπ/3}\n   This is verified by expanding both sides: both reduce to (z₁-z₃)/2 + i√3(2z₂-z₁-z₃)/6, using only √3² = 3 and i² = -1.\n\n3. **Equilaterality**: Since |e^{-iπ/3}| = 1, the rotation identity immediately gives |G₃ - G₁| = |G₂ - G₁|. For the third side, G₃ - G₂ = (G₂ - G₁)(e^{-iπ/3} - 1), and |e^{-iπ/3} - 1| = 1 as well.\n\n4. **Inner variant**: Replacing i with -i in the centroid formula gives the inner Napoleon triangle, with rotation by +60° instead of -60°.",
     "keyInsights": [
-      "**Rotation identity**: G\u2083 - G\u2081 = (G\u2082 - G\u2081) \u00b7 e^{-i\u03c0/3} \u2014 consecutive Napoleon sides differ by a 60\u00b0 rotation, the defining property of equilateral triangles",
-      "**Complex coordinate elegance**: The centroid formula G = (b+c)/2 + i\u221a3(c-b)/6 makes the proof purely algebraic",
-      "**Dual theorem**: Both outer (rotation -60\u00b0) and inner (rotation +60\u00b0) Napoleon triangles are equilateral",
+      "**Rotation identity**: G₃ - G₁ = (G₂ - G₁) · e^{-iπ/3} — consecutive Napoleon sides differ by a 60° rotation, the defining property of equilateral triangles",
+      "**Complex coordinate elegance**: The centroid formula G = (b+c)/2 + i√3(c-b)/6 makes the proof purely algebraic",
+      "**Dual theorem**: Both outer (rotation -60°) and inner (rotation +60°) Napoleon triangles are equilateral",
       "**Centroid preservation**: The average of Napoleon centroids equals the average of the original vertices, so all three triangles share the same centroid",
-      "**|e^{\u00b1i\u03c0/3}| = |e^{\u00b1i\u03c0/3} - 1| = 1**: This coincidence (both the rotation and rotation-minus-1 have unit modulus) is why all three sides are equal, not just two"
+      "**|e^{±iπ/3}| = |e^{±iπ/3} - 1| = 1**: This coincidence (both the rotation and rotation-minus-1 have unit modulus) is why all three sides are equal, not just two"
     ],
     "prerequisites": [
-      "Complex numbers and arithmetic in \u2102",
+      "Complex numbers and arithmetic in ℂ",
       "Absolute value of complex numbers",
-      "Real square root (\u221a3)",
-      "Basic trigonometry (cos(\u03c0/3) = 1/2, sin(\u03c0/3) = \u221a3/2)"
+      "Real square root (√3)",
+      "Basic trigonometry (cos(π/3) = 1/2, sin(π/3) = √3/2)"
     ],
     "openQuestions": [
       "Can the Napoleon-Douglas-Neumann theorem (generalization to n-gons) be formalized?",
@@ -130,8 +130,8 @@
     ]
   },
   "conclusion": {
-    "summary": "Napoleon's theorem is formalized using complex coordinates. The centroid displacement formula G = (b+c)/2 + i\u221a3(c-b)/6 encodes the construction, and the rotation identity G\u2083 - G\u2081 = (G\u2082 - G\u2081)\u00b7e^{-i\u03c0/3} provides an elegant algebraic proof. Both outer and inner Napoleon triangles are proved equilateral, and centroid preservation is established.",
-    "implications": "**Theoretical Significance**: The proof demonstrates the power of complex coordinates in plane geometry \u2014 what appears to be a non-trivial geometric theorem reduces to a polynomial identity over \u2102.\n\nThe rotation identity approach generalizes: any construction where consecutive sides differ by a fixed rotation produces a regular polygon. This connects to the discrete Fourier transform view of polygon geometry.",
+    "summary": "Napoleon's theorem is formalized using complex coordinates. The centroid displacement formula G = (b+c)/2 + i√3(c-b)/6 encodes the construction, and the rotation identity G₃ - G₁ = (G₂ - G₁)·e^{-iπ/3} provides an elegant algebraic proof. Both outer and inner Napoleon triangles are proved equilateral, and centroid preservation is established.",
+    "implications": "**Theoretical Significance**: The proof demonstrates the power of complex coordinates in plane geometry — what appears to be a non-trivial geometric theorem reduces to a polynomial identity over ℂ.\n\nThe rotation identity approach generalizes: any construction where consecutive sides differ by a fixed rotation produces a regular polygon. This connects to the discrete Fourier transform view of polygon geometry.",
     "openQuestions": [
       "Can the Napoleon-Douglas-Neumann theorem (generalization to n-gons) be formalized?",
       "Can the connection between Napoleon's theorem and the discrete Fourier transform be made explicit?"
@@ -148,5 +148,25 @@
       "targetId": "morleys-theorem"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic",
+      "Mathlib.Data.Complex.Basic",
+      "Mathlib.Data.Complex.Exponential",
+      "Mathlib.Data.Real.Sqrt",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Complex",
+      "Real"
+    ],
+    "namespace": "NapoleonsTheorem",
+    "lineCount": 355,
+    "axiomCount": 0,
+    "theoremCount": 15,
+    "definitionCount": 10,
+    "sorries": 0,
+    "path": "Proofs/NapoleonsTheorem.lean"
+  }
 }

--- a/src/data/proofs/partition-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/partition-theorem-oq-01-oq-01/meta.json
@@ -149,5 +149,21 @@
       "description": "Both identities hold for all n ≤ 8"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Proofs.PartitionTheoremOQ01",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "RogersRamanujan"
+    ],
+    "namespace": "PartitionTheoremOQ01OQ01",
+    "lineCount": 72,
+    "axiomCount": 0,
+    "theoremCount": 19,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/PartitionTheoremOQ01OQ01.lean"
+  }
 }

--- a/src/data/proofs/prime-reciprocal-divergence-oq-03/meta.json
+++ b/src/data/proofs/prime-reciprocal-divergence-oq-03/meta.json
@@ -1,11 +1,11 @@
 {
   "id": "prime-reciprocal-divergence-oq-03",
-  "title": "Erd\u0151s's Elementary Proof of Prime Divergence",
+  "title": "Erdős's Elementary Proof of Prime Divergence",
   "slug": "prime-reciprocal-divergence-oq-03",
-  "description": "Erd\u0151s's elementary proof that there are infinitely many primes via smooth number counting, without analytic infrastructure.",
+  "description": "Erdős's elementary proof that there are infinitely many primes via smooth number counting, without analytic infrastructure.",
   "meta": {
-    "author": "Paul Erd\u0151s",
-    "sourceUrl": "https://en.wikipedia.org/wiki/Euclid%27s_theorem#Erd\u0151s's_proof",
+    "author": "Paul Erdős",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Euclid%27s_theorem#Erdős's_proof",
     "date": "1938",
     "status": "verified",
     "proofRepoPath": "Proofs/PrimeReciprocalDivergenceOQ03.lean",
@@ -52,25 +52,25 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "Erd\u0151s's 1938 paper '\u00dcber die Reihe \u03a31/p' (On the series \u03a31/p) introduced a purely combinatorial proof that the sum of reciprocals of primes diverges. Euler had proved this in 1737 using his product formula for \u03b6(s) and analysis. Erd\u0151s's contribution was to show the result \u2014 and even the infinitude of primes \u2014 follows from simple counting: the squarefree decomposition k = b\u00b2\u00b7a shows that N-smooth numbers up to n number at most \u221an \u00b7 2^{\u03c0(N)}. If all primes were \u2264 N, then [1..n] would be entirely smooth, but \u221an \u00b7 2^{\u03c0(N)} < n for large n \u2014 contradiction. The proof exemplified Erd\u0151s's 'BOOK proof' philosophy: find the most elegant, elementary argument. The squarefree decomposition it uses was known since Gauss; the smooth number counting bound prefigures the theory of friable numbers (\u03a8(x, y)) central to modern analytic number theory and integer factorization algorithms (quadratic sieve, ECM).",
-    "problemStatement": "Prove that there are infinitely many primes using only combinatorial counting, without real analysis. The proof gives the combinatorial core of Erd\u0151s's \u03a31/p = \u221e argument.",
-    "text": "The squarefree decomposition k = b\u00b2\u00b7a (Nat.sq_mul_squarefree_of_pos) injects N-smooth numbers in [1,n] into range(\u221an) \u00d7 powerset(primesUpTo N), giving |smoothSet N n| \u2264 \u221an \u00b7 2^{\u03c0(N)}. If all primes \u2264 N, every integer is smooth, but for n = (2^{\u03c0(N)+1})\u00b2 + 1 the bound \u221an \u00b7 2^{\u03c0(N)} \u2264 2^{\u03c0(N)+1} \u00b7 2^{\u03c0(N)} = 2^{2\u03c0(N)+1} < 2^{2\u03c0(N)+2} + 1 = n \u2014 contradiction. The injection's injectivity uses squarefree_eq_of_prime_dvd_iff: two squarefree numbers with the same prime support are equal.",
-    "proofStrategy": "By contradiction: if all primes \u2264 N, then every integer is N-smooth. But smooth numbers up to n are bounded by \u221an \u00b7 2^{\u03c0(N)}, which is < n for large n (taking n = (2^{K+1})\u00b2 + 1 with K = \u03c0(N)).",
+    "historicalContext": "Erdős's 1938 paper 'Über die Reihe Σ1/p' (On the series Σ1/p) introduced a purely combinatorial proof that the sum of reciprocals of primes diverges. Euler had proved this in 1737 using his product formula for ζ(s) and analysis. Erdős's contribution was to show the result — and even the infinitude of primes — follows from simple counting: the squarefree decomposition k = b²·a shows that N-smooth numbers up to n number at most √n · 2^{π(N)}. If all primes were ≤ N, then [1..n] would be entirely smooth, but √n · 2^{π(N)} < n for large n — contradiction. The proof exemplified Erdős's 'BOOK proof' philosophy: find the most elegant, elementary argument. The squarefree decomposition it uses was known since Gauss; the smooth number counting bound prefigures the theory of friable numbers (Ψ(x, y)) central to modern analytic number theory and integer factorization algorithms (quadratic sieve, ECM).",
+    "problemStatement": "Prove that there are infinitely many primes using only combinatorial counting, without real analysis. The proof gives the combinatorial core of Erdős's Σ1/p = ∞ argument.",
+    "text": "The squarefree decomposition k = b²·a (Nat.sq_mul_squarefree_of_pos) injects N-smooth numbers in [1,n] into range(√n) × powerset(primesUpTo N), giving |smoothSet N n| ≤ √n · 2^{π(N)}. If all primes ≤ N, every integer is smooth, but for n = (2^{π(N)+1})² + 1 the bound √n · 2^{π(N)} ≤ 2^{π(N)+1} · 2^{π(N)} = 2^{2π(N)+1} < 2^{2π(N)+2} + 1 = n — contradiction. The injection's injectivity uses squarefree_eq_of_prime_dvd_iff: two squarefree numbers with the same prime support are equal.",
+    "proofStrategy": "By contradiction: if all primes ≤ N, then every integer is N-smooth. But smooth numbers up to n are bounded by √n · 2^{π(N)}, which is < n for large n (taking n = (2^{K+1})² + 1 with K = π(N)).",
     "keyInsights": [
-      "Squarefree decomposition k = b\u00b2\u00b7a: b \u2264 \u221an (sqRtPart_le_sqrt) and a \u2286 powerset of primes \u2264 N, giving the injection into \u221an \u00d7 2^{\u03c0(N)} target",
-      "Two squarefree numbers with the same prime divisors are equal (squarefree_eq_of_prime_dvd_iff) \u2014 this is the injectivity core",
-      "n = (2^{K+1})\u00b2 + 1 is chosen so Nat.sqrt n \u2264 2^{K+1}, making the arithmetic clean for omega",
-      "The file proves infinitely many primes (combinatorial core) but not \u03a31/p = \u221e \u2014 that requires real-valued series in the parent proof",
-      "Zero analysis required: no limits, no topology, no measure theory \u2014 only Finset.card, Nat.sqrt, and ring arithmetic"
+      "Squarefree decomposition k = b²·a: b ≤ √n (sqRtPart_le_sqrt) and a ⊆ powerset of primes ≤ N, giving the injection into √n × 2^{π(N)} target",
+      "Two squarefree numbers with the same prime divisors are equal (squarefree_eq_of_prime_dvd_iff) — this is the injectivity core",
+      "n = (2^{K+1})² + 1 is chosen so Nat.sqrt n ≤ 2^{K+1}, making the arithmetic clean for omega",
+      "The file proves infinitely many primes (combinatorial core) but not Σ1/p = ∞ — that requires real-valued series in the parent proof",
+      "Zero analysis required: no limits, no topology, no measure theory — only Finset.card, Nat.sqrt, and ring arithmetic"
     ]
   },
   "conclusion": {
-    "summary": "Erd\u0151s's combinatorial proof of infinitely many primes formalized with 0 sorries. Squarefree decomposition injection gives smooth count \u2264 \u221an \u00b7 2^{\u03c0(N)}, yielding contradiction for n = (2^{\u03c0(N)+1})\u00b2 + 1. 5 public theorems, 8 private lemmas, 7 definitions, 0 axioms, 388 lines.",
-    "implications": "The combinatorial core of Erd\u0151s's \u03a31/p divergence proof can be formalized without analytic machinery. The squarefree decomposition and smooth number counting are templates for sieve theory and integer factorization algorithms. This file stands alone as a complete elementary proof of infinitely many primes, complementing both Euclid's classical argument and Mathlib's analytic approach.",
+    "summary": "Erdős's combinatorial proof of infinitely many primes formalized with 0 sorries. Squarefree decomposition injection gives smooth count ≤ √n · 2^{π(N)}, yielding contradiction for n = (2^{π(N)+1})² + 1. 5 public theorems, 8 private lemmas, 7 definitions, 0 axioms, 388 lines.",
+    "implications": "The combinatorial core of Erdős's Σ1/p divergence proof can be formalized without analytic machinery. The squarefree decomposition and smooth number counting are templates for sieve theory and integer factorization algorithms. This file stands alone as a complete elementary proof of infinitely many primes, complementing both Euclid's classical argument and Mathlib's analytic approach.",
     "openQuestions": [
-      "Formalize the full Erd\u0151s proof of \u03a31/p = \u221e using the smooth/rough dichotomy and real-valued sums",
-      "Prove the Mertens theorem: \u03a3_{p\u2264x} 1/p = log log x + M + o(1), connecting the divergence rate to the Mertens constant M",
-      "Extend smooth number counting to prove \u03a8(x, y) \u2265 x^{\u03c1+o(1)} where \u03c1 = u\u207b\u00b9 and u = log x / log y \u2014 the Canfield-Erd\u0151s-Pomerance theorem"
+      "Formalize the full Erdős proof of Σ1/p = ∞ using the smooth/rough dichotomy and real-valued sums",
+      "Prove the Mertens theorem: Σ_{p≤x} 1/p = log log x + M + o(1), connecting the divergence rate to the Mertens constant M",
+      "Extend smooth number counting to prove Ψ(x, y) ≥ x^{ρ+o(1)} where ρ = u⁻¹ and u = log x / log y — the Canfield-Erdős-Pomerance theorem"
     ]
   },
   "sections": [
@@ -79,7 +79,7 @@
       "title": "Imports and Proof Overview",
       "startLine": 1,
       "endLine": 52,
-      "summary": "Imports Mathlib basics (including Squarefree) and documents Erd\u0151s's elementary proof strategy."
+      "summary": "Imports Mathlib basics (including Squarefree) and documents Erdős's elementary proof strategy."
     },
     {
       "id": "definitions",
@@ -100,7 +100,7 @@
       "title": "Smooth Count Bound",
       "startLine": 179,
       "endLine": 243,
-      "summary": "Proves |smoothSet N n| \u2264 \u221an \u00b7 2^{\u03c0(N)} via injection into range(\u221an) \u00d7 powerset(primesUpTo N). Fully proved, no sorries."
+      "summary": "Proves |smoothSet N n| ≤ √n · 2^{π(N)} via injection into range(√n) × powerset(primesUpTo N). Fully proved, no sorries."
     },
     {
       "id": "rough-count",
@@ -111,7 +111,7 @@
     },
     {
       "id": "main-theorem",
-      "title": "Infinitely Many Primes (Erd\u0151s's Argument)",
+      "title": "Infinitely Many Primes (Erdős's Argument)",
       "startLine": 288,
       "endLine": 353,
       "summary": "Proves infinitely_many_primes_erdos by contradiction and derives prime_reciprocals_unbounded."
@@ -121,18 +121,39 @@
     {
       "targetId": "prime-reciprocal-divergence",
       "relationship": "related",
-      "description": "Parent proof using Mathlib's analytic Nat.Primes.not_summable_one_div \u2014 same result via real series vs combinatorial counting"
+      "description": "Parent proof using Mathlib's analytic Nat.Primes.not_summable_one_div — same result via real series vs combinatorial counting"
     },
     {
       "targetId": "infinitude-primes-4k3",
       "relationship": "related",
-      "description": "Another elementary proof of infinitely many primes (\u22613 mod 4), using Euclid-style factorial construction vs smooth number counting"
+      "description": "Another elementary proof of infinitely many primes (≡3 mod 4), using Euclid-style factorial construction vs smooth number counting"
     },
     {
       "targetId": "gcd-algorithm-oq-01-oq-03",
       "relationship": "related",
-      "description": "Binet's formula and Fibonacci: smooth numbers appear in the Lam\u00e9 complexity argument via Fibonacci growth"
+      "description": "Binet's formula and Fibonacci: smooth numbers appear in the Lamé complexity argument via Fibonacci growth"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Nat.Prime.Basic",
+      "Mathlib.Data.Nat.Squarefree",
+      "Mathlib.Data.Finset.Basic",
+      "Mathlib.Data.Finset.Card",
+      "Mathlib.Data.Finset.Powerset",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset",
+      "Nat"
+    ],
+    "namespace": "ErdosElementary",
+    "lineCount": 389,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 4,
+    "sorries": 0,
+    "path": "Proofs/PrimeReciprocalDivergenceOQ03.lean"
+  }
 }

--- a/src/data/proofs/ptolemys-theorem-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01-incomplete-01/meta.json
@@ -143,5 +143,25 @@
       "description": "Source of ptolemy_equality_implies_proportional, the first step of the converse proof"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Proofs.PtolemysTheoremOQ01",
+      "Proofs.PtolemysComplexProofOQ01",
+      "Proofs.PtolemysComplexProof",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Complex",
+      "Real"
+    ],
+    "namespace": "PtolemysTheoremOQ01Incomplete01",
+    "lineCount": 490,
+    "axiomCount": 0,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "sorries": 3,
+    "path": "Proofs/PtolemysTheoremOQ01Incomplete01.lean"
+  }
 }

--- a/src/data/proofs/schroeder-bernstein-oq-03/meta.json
+++ b/src/data/proofs/schroeder-bernstein-oq-03/meta.json
@@ -221,5 +221,26 @@
       "status": "proved",
       "description": "Packages reflexivity, symmetry, transitivity as an Equivalence"
     }
-  ]
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Computability.Reduce",
+      "Mathlib.Computability.Partrec",
+      "Mathlib.Computability.Primrec",
+      "Mathlib.Data.Nat.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Primcodable",
+      "Function",
+      "Computable"
+    ],
+    "namespace": "MyhillIsomorphism",
+    "lineCount": 258,
+    "axiomCount": 0,
+    "theoremCount": 14,
+    "definitionCount": 4,
+    "sorries": 5,
+    "path": "Proofs/SchroederBernsteinOQ03.lean"
+  }
 }

--- a/src/data/proofs/shapley-folkman/meta.json
+++ b/src/data/proofs/shapley-folkman/meta.json
@@ -187,5 +187,28 @@
       "leanType": "Decomposition S t x -> d.excessIndices.card <= Module.finrank R E"
     }
   ],
-  "sorries": 1
+  "sorries": 1,
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.Convex.Caratheodory",
+      "Mathlib.Analysis.Convex.Combination",
+      "Mathlib.Analysis.Convex.Hull",
+      "Mathlib.LinearAlgebra.AffineSpace.Independent",
+      "Mathlib.LinearAlgebra.Dimension.Finrank",
+      "Mathlib.Order.Filter.Basic",
+      "Mathlib.Data.Finset.Pointwise"
+    ],
+    "opens": [
+      "Set",
+      "Finset",
+      "Pointwise"
+    ],
+    "namespace": "ShapleyFolkman",
+    "lineCount": 814,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "sorries": 2,
+    "path": "Proofs/ShapleyFolkman.lean"
+  }
 }

--- a/src/data/proofs/sophie-germain-oq-02/meta.json
+++ b/src/data/proofs/sophie-germain-oq-02/meta.json
@@ -145,5 +145,24 @@
       "note": "Comprehensive reference for records and heuristics on special prime types, including Sophie Germain primes. Chapter 5 covers their distribution and computational searches."
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Proofs.SophieGermain",
+      "Mathlib.Data.Nat.Prime.Basic",
+      "Mathlib.Data.Finset.Card",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "SophieGermain",
+      "Finset"
+    ],
+    "namespace": "SophieGermainOQ02",
+    "lineCount": 157,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 3,
+    "sorries": 0,
+    "path": "Proofs/SophieGermainOQ02.lean"
+  }
 }

--- a/src/data/proofs/spherical-law-of-sines/meta.json
+++ b/src/data/proofs/spherical-law-of-sines/meta.json
@@ -8,7 +8,14 @@
     "date": "2026-04-04",
     "status": "verified",
     "proofRepoPath": "Proofs/SphericalLawOfSines.lean",
-    "tags": ["geometry", "spherical-geometry", "trigonometry", "law-of-sines", "non-euclidean-geometry", "cross-product"],
+    "tags": [
+      "geometry",
+      "spherical-geometry",
+      "trigonometry",
+      "law-of-sines",
+      "non-euclidean-geometry",
+      "cross-product"
+    ],
     "badge": "original",
     "sorries": 0,
     "dateAdded": "2026-04-04",
@@ -102,5 +109,22 @@
       "description": "The spherical law of cosines and law of sines are the two fundamental identities of spherical trigonometry, both proved using unit vectors in ℝ³"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.LinearAlgebra.CrossProduct",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "SphericalLawOfSines",
+    "lineCount": 324,
+    "axiomCount": 0,
+    "theoremCount": 21,
+    "definitionCount": 7,
+    "sorries": 0,
+    "path": "Proofs/SphericalLawOfSines.lean"
+  }
 }

--- a/src/data/proofs/sqrt2-minpoly-oq-01/meta.json
+++ b/src/data/proofs/sqrt2-minpoly-oq-01/meta.json
@@ -161,5 +161,23 @@
       "description": "General theorem: all non-perfect-square n, not just Eisenstein cases. Covers n=8=2³, n=27=3³, n=32=2⁵ and all others where the Eisenstein condition fails."
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.CubeRoot2IrrationalOQ03"
+    ],
+    "opens": [
+      "Polynomial",
+      "IntermediateField",
+      "CubeRoot2IrrationalOQ03"
+    ],
+    "namespace": "Sqrt2MinpolyOQ01",
+    "lineCount": 253,
+    "axiomCount": 0,
+    "theoremCount": 17,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/Sqrt2MinpolyOQ01.lean"
+  }
 }

--- a/src/data/proofs/sqrt2-minpoly-oq-02/meta.json
+++ b/src/data/proofs/sqrt2-minpoly-oq-02/meta.json
@@ -188,5 +188,21 @@
       "description": "m is not a perfect n-th power when it has a squarefree prime factor"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Polynomial",
+      "IntermediateField"
+    ],
+    "namespace": "CubeRoot2IrrationalOQ03",
+    "lineCount": 205,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/CubeRoot2IrrationalOQ03.lean"
+  }
 }

--- a/src/data/proofs/sylow-theorems-oq-04/meta.json
+++ b/src/data/proofs/sylow-theorems-oq-04/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "sylow-theorems-oq-04",
-  "title": "Sylow-Based Simplicity Proof for A\u2085",
+  "title": "Sylow-Based Simplicity Proof for A₅",
   "slug": "sylow-theorems-oq-04",
-  "description": "Formalizes the Sylow counting argument for the simplicity of A\u2085. Proves |A\u2085| = 60 = 2\u00b2\u00b73\u00b75, computes the exact Sylow numbers n\u2082 = 5, n\u2083 = 10, n\u2085 = 6, shows no Sylow subgroup is normal, and verifies the conjugacy class arithmetic {1,12,12,15,20} prevents intermediate normal subgroups.",
+  "description": "Formalizes the Sylow counting argument for the simplicity of A₅. Proves |A₅| = 60 = 2²·3·5, computes the exact Sylow numbers n₂ = 5, n₃ = 10, n₅ = 6, shows no Sylow subgroup is normal, and verifies the conjugacy class arithmetic {1,12,12,15,20} prevents intermediate normal subgroups.",
   "meta": {
     "author": "Sylow (1872); Galois (1832)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Alternating_group#Properties",
@@ -24,31 +24,31 @@
     "lineCount": 276
   },
   "overview": {
-    "historicalContext": "The simplicity of A\u2085 was first understood by Galois (1832), who recognized that A\u2085 is the smallest non-abelian simple group. The Sylow counting approach, using theorems from Sylow's 1872 paper, provides a concrete arithmetic proof: for |A\u2085| = 60 = 2\u00b2\u00b73\u00b75, the Sylow constraints force n\u2082 = 5, n\u2083 = 10, n\u2085 = 6, meaning no Sylow subgroup is normal. Combined with the conjugacy class sizes {1, 12, 12, 15, 20} (no subset sum divides 60), this proves A\u2085 has no proper nontrivial normal subgroups. This result is foundational for the Abel-Ruffini theorem (unsolvability of the quintic) and the classification of finite simple groups.",
-    "problemStatement": "Prove that A\u2085 is simple using Sylow counting arguments: compute the exact number of Sylow p-subgroups for each prime p dividing |A\u2085| = 60, show all are greater than 1, and verify no intermediate normal subgroup exists.",
-    "text": "A 260-line formalization proving the simplicity of A\u2085 via Sylow theory. Establishes |A\u2085| = 60, computes the p-adic valuations (v\u2082 = 2, v\u2083 = 1, v\u2085 = 1), derives Sylow counting constraints from Sylow III, and verifies the exact Sylow numbers n\u2082 = 5, n\u2083 = 10, n\u2085 = 6 by native_decide. Proves no Sylow subgroup is normal (via uniqueness contradiction), verifies the conjugacy class arithmetic prevents intermediate normal subgroups, and establishes A\u2085 is simple and not solvable.",
-    "proofStrategy": "**Step 1**: Compute |A\u2085| = 60 = 2\u00b2\u00b73\u00b75 using native_decide.\n**Step 2**: Apply Sylow III to get n_p \u2261 1 (mod p) and n_p | [A\u2085 : P_p].\n**Step 3**: Compute exact Sylow numbers by exhaustive enumeration via native_decide.\n**Step 4**: Show n_p > 1 for all p, so no Sylow subgroup is unique/normal.\n**Step 5**: Verify conjugacy class arithmetic: no subset of {1,12,12,15,20} sums to a proper divisor of 60 greater than 1.\n**Step 6**: Conclude simplicity via Mathlib's alternatingGroup.isSimpleGroup_five.",
+    "historicalContext": "The simplicity of A₅ was first understood by Galois (1832), who recognized that A₅ is the smallest non-abelian simple group. The Sylow counting approach, using theorems from Sylow's 1872 paper, provides a concrete arithmetic proof: for |A₅| = 60 = 2²·3·5, the Sylow constraints force n₂ = 5, n₃ = 10, n₅ = 6, meaning no Sylow subgroup is normal. Combined with the conjugacy class sizes {1, 12, 12, 15, 20} (no subset sum divides 60), this proves A₅ has no proper nontrivial normal subgroups. This result is foundational for the Abel-Ruffini theorem (unsolvability of the quintic) and the classification of finite simple groups.",
+    "problemStatement": "Prove that A₅ is simple using Sylow counting arguments: compute the exact number of Sylow p-subgroups for each prime p dividing |A₅| = 60, show all are greater than 1, and verify no intermediate normal subgroup exists.",
+    "text": "A 260-line formalization proving the simplicity of A₅ via Sylow theory. Establishes |A₅| = 60, computes the p-adic valuations (v₂ = 2, v₃ = 1, v₅ = 1), derives Sylow counting constraints from Sylow III, and verifies the exact Sylow numbers n₂ = 5, n₃ = 10, n₅ = 6 by native_decide. Proves no Sylow subgroup is normal (via uniqueness contradiction), verifies the conjugacy class arithmetic prevents intermediate normal subgroups, and establishes A₅ is simple and not solvable.",
+    "proofStrategy": "**Step 1**: Compute |A₅| = 60 = 2²·3·5 using native_decide.\n**Step 2**: Apply Sylow III to get n_p ≡ 1 (mod p) and n_p | [A₅ : P_p].\n**Step 3**: Compute exact Sylow numbers by exhaustive enumeration via native_decide.\n**Step 4**: Show n_p > 1 for all p, so no Sylow subgroup is unique/normal.\n**Step 5**: Verify conjugacy class arithmetic: no subset of {1,12,12,15,20} sums to a proper divisor of 60 greater than 1.\n**Step 6**: Conclude simplicity via Mathlib's alternatingGroup.isSimpleGroup_five.",
     "keyInsights": [
-      "**Sylow counting forces non-normality**: For |G| = 60, the constraints n\u2082 | 15, n\u2082 \u2261 1 (mod 2) give n\u2082 \u2208 {1,3,5,15}; n\u2083 | 20, n\u2083 \u2261 1 (mod 3) give n\u2083 \u2208 {1,4,10}; n\u2085 | 12, n\u2085 \u2261 1 (mod 5) give n\u2085 \u2208 {1,6}. For A\u2085 specifically, n\u2082 = 5, n\u2083 = 10, n\u2085 = 6.",
-      "**Conjugacy class arithmetic**: The 5 conjugacy classes of A\u2085 have sizes {1, 12, 12, 15, 20}. A normal subgroup must be a union of classes including {e}. No partial sum 1 + (subset of {12,12,15,20}) divides 60 except 1 and 60 themselves.",
-      "**A\u2085 is the smallest non-abelian simple group**: With only 60 elements, it's computationally feasible to verify all Sylow subgroups by native_decide, making this a fully decidable result.",
-      "**Connection to Abel-Ruffini**: The non-solvability of A\u2085 (proved from simplicity via the short exact sequence A\u2085 \u2192 S\u2085 \u2192 \u2124/2) is the key ingredient in proving the general quintic is not solvable by radicals.",
+      "**Sylow counting forces non-normality**: For |G| = 60, the constraints n₂ | 15, n₂ ≡ 1 (mod 2) give n₂ ∈ {1,3,5,15}; n₃ | 20, n₃ ≡ 1 (mod 3) give n₃ ∈ {1,4,10}; n₅ | 12, n₅ ≡ 1 (mod 5) give n₅ ∈ {1,6}. For A₅ specifically, n₂ = 5, n₃ = 10, n₅ = 6.",
+      "**Conjugacy class arithmetic**: The 5 conjugacy classes of A₅ have sizes {1, 12, 12, 15, 20}. A normal subgroup must be a union of classes including {e}. No partial sum 1 + (subset of {12,12,15,20}) divides 60 except 1 and 60 themselves.",
+      "**A₅ is the smallest non-abelian simple group**: With only 60 elements, it's computationally feasible to verify all Sylow subgroups by native_decide, making this a fully decidable result.",
+      "**Connection to Abel-Ruffini**: The non-solvability of A₅ (proved from simplicity via the short exact sequence A₅ → S₅ → ℤ/2) is the key ingredient in proving the general quintic is not solvable by radicals.",
       "**Element counting as an obstruction**: The Sylow subgroups collectively account for a large fraction of A_5's 60 elements -- the 6 Sylow 5-subgroups contribute 24 elements of order 5, and the 10 Sylow 3-subgroups contribute 20 elements of order 3, leaving only 16 elements for the 5 Sylow 2-subgroups (which share elements). This tight element budget is what forces the exact Sylow numbers and prevents any from being 1."
     ],
     "prerequisites": [
       "Sylow's theorems: existence, conjugacy, and counting of Sylow p-subgroups",
       "Normal subgroups and simplicity: a group is simple iff it has no proper nontrivial normal subgroups",
-      "Alternating group: A_n = ker(sign : S_n \u2192 \u2124/2), the even permutations",
+      "Alternating group: A_n = ker(sign : S_n → ℤ/2), the even permutations",
       "Solvable groups: the derived series terminates at {e}; non-abelian simple groups are not solvable"
     ]
   },
   "sections": [
     {
       "id": "order",
-      "title": "Order of A\u2085",
+      "title": "Order of A₅",
       "startLine": 28,
       "endLine": 48,
-      "summary": "Defines A\u2085 = alternatingGroup(Fin 5) and proves |A\u2085| = 60 via native_decide.",
+      "summary": "Defines A₅ = alternatingGroup(Fin 5) and proves |A₅| = 60 via native_decide.",
       "mathContext": "$|A_5| = 5!/2 = 60$. Uses Mathlib's `alternatingGroup` as the kernel of `Equiv.Perm.sign`."
     },
     {
@@ -56,7 +56,7 @@
       "title": "Prime Factorization of 60",
       "startLine": 49,
       "endLine": 63,
-      "summary": "Establishes the p-adic valuations: v\u2082(60) = 2, v\u2083(60) = 1, v\u2085(60) = 1, confirming 60 = 2\u00b2\u00b73\u00b75.",
+      "summary": "Establishes the p-adic valuations: v₂(60) = 2, v₃(60) = 1, v₅(60) = 1, confirming 60 = 2²·3·5.",
       "mathContext": "$60 = 2^2 \\cdot 3 \\cdot 5$. The Sylow p-subgroup orders are $p^{v_p(60)}$: 4, 3, 5 respectively."
     },
     {
@@ -64,7 +64,7 @@
       "title": "Sylow Counting Constraints",
       "startLine": 64,
       "endLine": 110,
-      "summary": "Applies Sylow III to A\u2085: n_p \u2261 1 (mod p) and n_p | [A\u2085:P_p] for p \u2208 {2,3,5}. Uses Mathlib's card_sylow_modEq_one and card_sylow_dvd_index.",
+      "summary": "Applies Sylow III to A₅: n_p ≡ 1 (mod p) and n_p | [A₅:P_p] for p ∈ {2,3,5}. Uses Mathlib's card_sylow_modEq_one and card_sylow_dvd_index.",
       "mathContext": "$n_2 \\mid 15,\\, n_2 \\equiv 1 \\pmod{2}$; $n_3 \\mid 20,\\, n_3 \\equiv 1 \\pmod{3}$; $n_5 \\mid 12,\\, n_5 \\equiv 1 \\pmod{5}$."
     },
     {
@@ -72,7 +72,7 @@
       "title": "Exact Sylow Numbers",
       "startLine": 111,
       "endLine": 136,
-      "summary": "Computes by native_decide: n\u2082 = 5 (Klein 4-groups), n\u2083 = 10 (cyclic order 3), n\u2085 = 6 (cyclic order 5). All are greater than 1.",
+      "summary": "Computes by native_decide: n₂ = 5 (Klein 4-groups), n₃ = 10 (cyclic order 3), n₅ = 6 (cyclic order 5). All are greater than 1.",
       "mathContext": "The 5 Sylow 2-subgroups are the Klein 4-groups $V_4 \\cong \\mathbb{Z}/2 \\times \\mathbb{Z}/2$ inside $A_5$."
     },
     {
@@ -80,7 +80,7 @@
       "title": "Non-Normality of Sylow Subgroups",
       "startLine": 137,
       "endLine": 171,
-      "summary": "Proves no Sylow p-subgroup of A\u2085 is normal: if any were, Sylow.unique_of_normal would force Fintype.card = 1, contradicting the computed values 5, 10, 6.",
+      "summary": "Proves no Sylow p-subgroup of A₅ is normal: if any were, Sylow.unique_of_normal would force Fintype.card = 1, contradicting the computed values 5, 10, 6.",
       "mathContext": "$n_p = 1 \\iff P_p \\trianglelefteq G$. Since $n_2 = 5,\\, n_3 = 10,\\, n_5 = 6$, no Sylow subgroup is normal."
     },
     {
@@ -93,10 +93,10 @@
     },
     {
       "id": "simplicity",
-      "title": "Simplicity of A\u2085",
+      "title": "Simplicity of A₅",
       "startLine": 206,
       "endLine": 220,
-      "summary": "States A\u2085 is simple using Mathlib's alternatingGroup.isSimpleGroup_five. The Sylow analysis provides the concrete counting argument for why this holds.",
+      "summary": "States A₅ is simple using Mathlib's alternatingGroup.isSimpleGroup_five. The Sylow analysis provides the concrete counting argument for why this holds.",
       "mathContext": "$A_5$ is the smallest non-abelian simple group. Simplicity: the only normal subgroups are $\\{e\\}$ and $A_5$ itself."
     },
     {
@@ -104,33 +104,33 @@
       "title": "Corollaries: Non-Solvability and Normal Subgroup Classification",
       "startLine": 221,
       "endLine": 244,
-      "summary": "Proves A\u2085 is not solvable (via short exact sequence A\u2085 \u2192 S\u2085 \u2192 \u2124/2 and Perm.not_solvable) and classifies its normal subgroups as only \u22a5 and \u22a4.",
+      "summary": "Proves A₅ is not solvable (via short exact sequence A₅ → S₅ → ℤ/2 and Perm.not_solvable) and classifies its normal subgroups as only ⊥ and ⊤.",
       "mathContext": "If $A_5$ were solvable, then $S_5$ (extension of $A_5$ by $\\mathbb{Z}/2$) would be solvable, contradicting $S_n$ non-solvable for $n \\geq 5$."
     }
   ],
   "conclusion": {
-    "summary": "Fully verified (0 sorries, 0 axioms) Sylow counting analysis of A\u2085 with 18 theorems and 1 definition. Computes all Sylow numbers, proves non-normality of all Sylow subgroups, verifies conjugacy class arithmetic, and establishes simplicity and non-solvability.",
-    "implications": "The simplicity of A\u2085 is the foundational obstruction in the Abel-Ruffini theorem: since A\u2085 is a composition factor of S\u2085 and is not solvable, the general quintic polynomial has no radical solution. The Sylow counting technique demonstrated here generalizes: for any finite group, the Sylow constraints n_p \u2261 1 (mod p) and n_p | m (where |G| = p^k\u00b7m) are the primary tool for establishing simplicity or ruling it out.",
+    "summary": "Fully verified (0 sorries, 0 axioms) Sylow counting analysis of A₅ with 18 theorems and 1 definition. Computes all Sylow numbers, proves non-normality of all Sylow subgroups, verifies conjugacy class arithmetic, and establishes simplicity and non-solvability.",
+    "implications": "The simplicity of A₅ is the foundational obstruction in the Abel-Ruffini theorem: since A₅ is a composition factor of S₅ and is not solvable, the general quintic polynomial has no radical solution. The Sylow counting technique demonstrated here generalizes: for any finite group, the Sylow constraints n_p ≡ 1 (mod p) and n_p | m (where |G| = p^k·m) are the primary tool for establishing simplicity or ruling it out.",
     "openQuestions": [
-      "Compute the full subgroup lattice of A\u2085 in Lean: A\u2085 has exactly 59 subgroups, organized by order {1, 2, 3, 4, 5, 6, 10, 12, 60}. The subgroups of order 12 are isomorphic to A\u2084.",
-      "Formalize the proof that A\u2085 is the unique simple group of order 60 (up to isomorphism). This requires showing that the Sylow structure uniquely determines the multiplication table."
+      "Compute the full subgroup lattice of A₅ in Lean: A₅ has exactly 59 subgroups, organized by order {1, 2, 3, 4, 5, 6, 10, 12, 60}. The subgroups of order 12 are isomorphic to A₄.",
+      "Formalize the proof that A₅ is the unique simple group of order 60 (up to isomorphism). This requires showing that the Sylow structure uniquely determines the multiplication table."
     ]
   },
   "crossReferences": [
     {
       "targetId": "sylow-theorems",
       "relationship": "extends",
-      "description": "Applies the Sylow counting theorems (n_p \u2261 1 mod p, n_p | index) to the concrete case of A\u2085"
+      "description": "Applies the Sylow counting theorems (n_p ≡ 1 mod p, n_p | index) to the concrete case of A₅"
     },
     {
       "targetId": "sylow-theorems-oq-01",
       "relationship": "related",
-      "description": "Both use Sylow counting to analyze group structure; OQ01 classifies pq-groups, OQ04 proves simplicity of A\u2085"
+      "description": "Both use Sylow counting to analyze group structure; OQ01 classifies pq-groups, OQ04 proves simplicity of A₅"
     },
     {
       "targetId": "abel-ruffini",
       "relationship": "foundational",
-      "description": "The simplicity and non-solvability of A\u2085 is the key ingredient for the unsolvability of the general quintic by radicals"
+      "description": "The simplicity and non-solvability of A₅ is the key ingredient for the unsolvability of the general quintic by radicals"
     },
     {
       "targetId": "lagrange-theorem",
@@ -140,17 +140,17 @@
   ],
   "references": [
     {
-      "authors": "Galois, \u00c9variste",
-      "title": "M\u00e9moire sur les conditions de r\u00e9solubilit\u00e9 des \u00e9quations par radicaux",
+      "authors": "Galois, Évariste",
+      "title": "Mémoire sur les conditions de résolubilité des équations par radicaux",
       "year": "1832",
-      "venue": "Journal de Math\u00e9matiques Pures et Appliqu\u00e9es (published 1846)",
-      "note": "First identification of A\u2085 as simple and non-solvable, the key to proving the quintic is not solvable by radicals"
+      "venue": "Journal de Mathématiques Pures et Appliquées (published 1846)",
+      "note": "First identification of A₅ as simple and non-solvable, the key to proving the quintic is not solvable by radicals"
     },
     {
       "authors": "Sylow, Peter Ludwig Mejdell",
-      "title": "Th\u00e9or\u00e8mes sur les groupes de substitutions",
+      "title": "Théorèmes sur les groupes de substitutions",
       "year": "1872",
-      "venue": "Mathematische Annalen, vol. 5, pp. 584\u2013594",
+      "venue": "Mathematische Annalen, vol. 5, pp. 584–594",
       "note": "The three Sylow theorems providing the counting constraints used in the simplicity proof"
     },
     {
@@ -158,34 +158,51 @@
       "title": "An Introduction to the Theory of Groups",
       "year": "1995",
       "venue": "Springer GTM 148, 4th edition",
-      "note": "Section 4.4: simplicity of A\u2085 via Sylow counting and conjugacy class analysis"
+      "note": "Section 4.4: simplicity of A₅ via Sylow counting and conjugacy class analysis"
     }
   ],
   "mainTheorems": [
     {
       "name": "card_A5",
       "type": "core",
-      "description": "|A\u2085| = 60",
+      "description": "|A₅| = 60",
       "leanType": "Fintype.card A5 = 60"
     },
     {
       "name": "n2_eq / n3_eq / n5_eq",
       "type": "key",
-      "description": "Exact Sylow numbers: n\u2082 = 5, n\u2083 = 10, n\u2085 = 6",
+      "description": "Exact Sylow numbers: n₂ = 5, n₃ = 10, n₅ = 6",
       "leanType": "Fintype.card (Sylow p A5) = n"
     },
     {
       "name": "A5_isSimple",
       "type": "core",
-      "description": "A\u2085 is simple (no proper nontrivial normal subgroups)",
+      "description": "A₅ is simple (no proper nontrivial normal subgroups)",
       "leanType": "IsSimpleGroup A5"
     },
     {
       "name": "A5_not_solvable",
       "type": "key",
-      "description": "A\u2085 is not solvable",
-      "leanType": "\u00ac IsSolvable A5"
+      "description": "A₅ is not solvable",
+      "leanType": "¬ IsSolvable A5"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Subgroup",
+      "Fintype",
+      "Equiv.Perm"
+    ],
+    "namespace": "SylowA5",
+    "lineCount": 277,
+    "axiomCount": 0,
+    "theoremCount": 21,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/SylowTheoremOQ04.lean"
+  }
 }

--- a/src/data/proofs/sylow-theorems/meta.json
+++ b/src/data/proofs/sylow-theorems/meta.json
@@ -44,21 +44,21 @@
     "dateAdded": "2025-12-27",
     "axiomCount": 0,
     "lineCount": 246,
-    "assumptions": "None. Fully verified with 0 axioms, 0 sorries, and 0 structure-encoded assumptions. All three Sylow theorems delegate to Mathlib's `Sylow` module: existence via `Sylow.exists`, conjugacy via `Sylow.equiv`, and counting via `Sylow.card_sylow_modEq_one`. Original contributions are pedagogical wrappers \u2014 `unique_sylow_normal` (unique Sylow subgroup is normal) and `cauchy_theorem` (Cauchy's theorem as corollary) provide accessible named statements composing Mathlib results.",
+    "assumptions": "None. Fully verified with 0 axioms, 0 sorries, and 0 structure-encoded assumptions. All three Sylow theorems delegate to Mathlib's `Sylow` module: existence via `Sylow.exists`, conjugacy via `Sylow.equiv`, and counting via `Sylow.card_sylow_modEq_one`. Original contributions are pedagogical wrappers — `unique_sylow_normal` (unique Sylow subgroup is normal) and `cauchy_theorem` (Cauchy's theorem as corollary) provide accessible named statements composing Mathlib results.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "Peter Ludwig Mejdell Sylow (1832-1918) was a Norwegian mathematician who spent most of his career as a high school teacher in Halden, proving these landmark theorems as a side pursuit. He published them in *Mathematische Annalen* (1872, vol. 5) \u2014 a single paper that transformed finite group theory.\n\nGeorg Frobenius (1849-1917) gave streamlined alternative proofs in 1887 and strengthened the counting theorem. William Burnside (1852-1927) deployed Sylow's theorems extensively, proving in 1904 that all groups of order p^a\u00b7q^b are solvable \u2014 a result later reproved by Feit-Thompson (1963) as part of the monumental Odd Order Theorem.\n\nThe theorems became a cornerstone of the Classification of Finite Simple Groups (CFSG), completed ~2004 by Aschbacher, Smith, and others: Sylow counting immediately eliminates most orders from being simple, while conjugacy ensures uniform subgroup structure within each prime family.",
-    "problemStatement": "**The Three Sylow Theorems** for a group G of order n = p^k * m where p is prime and p does not divide m:\n\n1. **Existence**: G has a subgroup of order p^k (Sylow p-subgroup)\n2. **Conjugacy**: All Sylow p-subgroups are conjugate to each other\n3. **Counting**: The number n_p of Sylow p-subgroups satisfies: n_p divides m and n_p \u2261 1 (mod p)\n\nThis is Wiedijk's 100 Theorems #72.",
+    "historicalContext": "Peter Ludwig Mejdell Sylow (1832-1918) was a Norwegian mathematician who spent most of his career as a high school teacher in Halden, proving these landmark theorems as a side pursuit. He published them in *Mathematische Annalen* (1872, vol. 5) — a single paper that transformed finite group theory.\n\nGeorg Frobenius (1849-1917) gave streamlined alternative proofs in 1887 and strengthened the counting theorem. William Burnside (1852-1927) deployed Sylow's theorems extensively, proving in 1904 that all groups of order p^a·q^b are solvable — a result later reproved by Feit-Thompson (1963) as part of the monumental Odd Order Theorem.\n\nThe theorems became a cornerstone of the Classification of Finite Simple Groups (CFSG), completed ~2004 by Aschbacher, Smith, and others: Sylow counting immediately eliminates most orders from being simple, while conjugacy ensures uniform subgroup structure within each prime family.",
+    "problemStatement": "**The Three Sylow Theorems** for a group G of order n = p^k * m where p is prime and p does not divide m:\n\n1. **Existence**: G has a subgroup of order p^k (Sylow p-subgroup)\n2. **Conjugacy**: All Sylow p-subgroups are conjugate to each other\n3. **Counting**: The number n_p of Sylow p-subgroups satisfies: n_p divides m and n_p ≡ 1 (mod p)\n\nThis is Wiedijk's 100 Theorems #72.",
     "text": "A 247-line formalization of the three Sylow theorems (Wiedijk #72) with 25 declarations, 0 sorries, 0 axioms. Sylow I (`sylow_existence`): delegates to Mathlib's `Sylow` type and `Sylow.nonempty` for groups of order $p^k \\cdot m$. Sylow II (`sylow_conjugacy`): all Sylow $p$-subgroups are conjugate via `Sylow.equiv_smul`. Sylow III (`sylow_counting`): the count $n_p$ satisfies $n_p \\mid m$ and $n_p \\equiv 1 \\pmod{p}$ via `Sylow.card_sylow_modEq_one`. Includes applications: groups of order $pq$ analyzed via Sylow counting, no simple group of order 12 (`no_simple_group_order_12`), and the classification of groups of order $p^2$ as abelian. Uses `Nat.Factorization` for prime decomposition.",
     "proofStrategy": "**Sylow I (Existence)**:\nUse induction on |G| and analyze the class equation.\n\n**Sylow II (Conjugacy)**:\nLet P act on cosets G/Q by multiplication and use orbit-stabilizer.\n\n**Sylow III (Counting)**:\nP acts on the set of Sylow p-subgroups by conjugation; the only fixed point is P itself.",
     "keyInsights": [
       "**Sylow I via Class Equation:** $|G| = |Z(G)| + \\sum |\\text{Cl}(x)|$. If $p \\mid |Z(G)|$, Cauchy gives an order-$p$ element. Otherwise some conjugacy class has $p \\nmid |\\text{Cl}(x)|$, giving a proper subgroup $C_G(x)$ with $p^k \\mid |C_G(x)|$ for induction.",
-      "**Sylow II via Orbit-Stabilizer:** Let $P$ act on $G/Q$. If $P \\neq Q$, then $|P \\cap Q| < |P|$ so all $P$-orbits have size $> 1$. Since $P$ is a $p$-group, orbit sizes are $p$-powers, so $|G/Q| \\equiv 0 \\pmod{p}$ \u2014 but $|G/Q| = m$ with $p \\nmid m$. Contradiction: $P = gQg^{-1}$.",
+      "**Sylow II via Orbit-Stabilizer:** Let $P$ act on $G/Q$. If $P \\neq Q$, then $|P \\cap Q| < |P|$ so all $P$-orbits have size $> 1$. Since $P$ is a $p$-group, orbit sizes are $p$-powers, so $|G/Q| \\equiv 0 \\pmod{p}$ — but $|G/Q| = m$ with $p \\nmid m$. Contradiction: $P = gQg^{-1}$.",
       "**Arithmetic Classification:** $n_p \\equiv 1 \\pmod{p}$ and $n_p \\mid m$ severely constrain group structure. For $|G| = 15 = 3 \\cdot 5$: $n_3 \\mid 5$ and $n_3 \\equiv 1 \\pmod{3}$ force $n_3 = 1$; similarly $n_5 = 1$. Both Sylow subgroups are normal $\\Rightarrow$ $G \\cong \\mathbb{Z}/15\\mathbb{Z}$.",
-      "**Normality Criterion:** $n_p = 1 \\iff P \\trianglelefteq G$ (unique conjugate = self-conjugate = normal). This is the primary method for establishing normality in finite group theory \u2014 check the arithmetic constraints from Sylow III.",
-      "Sylow's theorems are a blueprint for the Classification of Finite Simple Groups: any simple group must have n_p > 1 for every prime p dividing its order (otherwise a normal Sylow subgroup exists), and Sylow counting constraints then force |G| to be extremely large \u2014 ruling out all 'small' orders from being simple",
-      "**Wielandt's proof** (1959) derives Sylow I purely combinatorially: G acts on the set $\\binom{G}{p^k}$ of subsets of size $p^k$. The key is $\\binom{|G|}{p^k} \\not\\equiv 0 \\pmod{p}$ (by Kummer's theorem), so some orbit has size not divisible by $p$, and its stabilizer has order divisible by $p^k$ \u2014 giving a Sylow subgroup. This avoids induction entirely."
+      "**Normality Criterion:** $n_p = 1 \\iff P \\trianglelefteq G$ (unique conjugate = self-conjugate = normal). This is the primary method for establishing normality in finite group theory — check the arithmetic constraints from Sylow III.",
+      "Sylow's theorems are a blueprint for the Classification of Finite Simple Groups: any simple group must have n_p > 1 for every prime p dividing its order (otherwise a normal Sylow subgroup exists), and Sylow counting constraints then force |G| to be extremely large — ruling out all 'small' orders from being simple",
+      "**Wielandt's proof** (1959) derives Sylow I purely combinatorially: G acts on the set $\\binom{G}{p^k}$ of subsets of size $p^k$. The key is $\\binom{|G|}{p^k} \\not\\equiv 0 \\pmod{p}$ (by Kummer's theorem), so some orbit has size not divisible by $p$, and its stabilizer has order divisible by $p^k$ — giving a Sylow subgroup. This avoids induction entirely."
     ],
     "prerequisites": [
       "Finite group theory: subgroups, normal subgroups, quotient groups, Lagrange's theorem ($|H|$ divides $|G|$)",
@@ -82,7 +82,7 @@
       "startLine": 73,
       "endLine": 79,
       "summary": "Documents Mathlib's representation of Sylow subgroups as a type `Sylow p G`, with coercion to `Subgroup G`. This type-theoretic approach enables reasoning about the collection of all Sylow p-subgroups as a first-class object.",
-      "mathContext": "`Sylow p G : Type*` \u2014 the type of all Sylow $p$-subgroups of $G$. `Fintype (Sylow p G)` for finite groups; `Nat.card (Sylow p G) = n_p$."
+      "mathContext": "`Sylow p G : Type*` — the type of all Sylow $p$-subgroups of $G$. `Fintype (Sylow p G)` for finite groups; `Nat.card (Sylow p G) = n_p$."
     },
     {
       "id": "existence",
@@ -105,7 +105,7 @@
       "title": "Third Sylow Theorem (Counting)",
       "startLine": 130,
       "endLine": 149,
-      "summary": "States Sylow III: the number n_p of Sylow p-subgroups satisfies n_p \u2261 1 (mod p) and n_p divides the index [G:P]. These two constraints together severely restrict possible group structures.",
+      "summary": "States Sylow III: the number n_p of Sylow p-subgroups satisfies n_p ≡ 1 (mod p) and n_p divides the index [G:P]. These two constraints together severely restrict possible group structures.",
       "mathContext": "$n_p \\equiv 1 \\pmod{p}$, $n_p \\mid [G:P] = m$ where $|G| = p^k m$."
     },
     {
@@ -121,7 +121,7 @@
       "title": "Cauchy's Theorem as Corollary",
       "startLine": 182,
       "endLine": 196,
-      "summary": "Derives Cauchy's theorem from Sylow I: if prime p divides |G|, then G has an element of order p. The Sylow p-subgroup has order p^k \u2265 p, so it contains an element whose order is a power of p.",
+      "summary": "Derives Cauchy's theorem from Sylow I: if prime p divides |G|, then G has an element of order p. The Sylow p-subgroup has order p^k ≥ p, so it contains an element whose order is a power of p.",
       "mathContext": "$p \\mid |G| \\Rightarrow \\exists g \\in G,\\, \\text{ord}(g) = p$. Cauchy (1845) predates Sylow (1872); Sylow I generalizes Cauchy."
     },
     {
@@ -129,7 +129,7 @@
       "title": "Examples and Applications",
       "startLine": 197,
       "endLine": 233,
-      "summary": "Proves groups of prime order are cyclic (via isCyclic_of_prime_card). The documentation summarizes all results in a table and demonstrates classification applications: groups of order pq (unique normal Sylow q-subgroup), groups of order p\u00b2 (abelian), and simple group obstruction arguments.",
+      "summary": "Proves groups of prime order are cyclic (via isCyclic_of_prime_card). The documentation summarizes all results in a table and demonstrates classification applications: groups of order pq (unique normal Sylow q-subgroup), groups of order p² (abelian), and simple group obstruction arguments.",
       "mathContext": "$|G| = p$ prime $\\Rightarrow G \\cong \\mathbb{Z}/p\\mathbb{Z}$. For $|G| = pq$ ($p < q$): $n_q \\mid p$ and $n_q \\equiv 1 \\pmod{q}$ force $n_q = 1$."
     },
     {
@@ -143,12 +143,12 @@
   ],
   "conclusion": {
     "summary": "Fully verified (0 sorries, 0 axioms) formalization of all three Sylow theorems with 10 theorems and 1 definition in 247 lines. The formalization covers existence (Sylow I), conjugacy (Sylow II), counting (Sylow III), the normality-uniqueness biconditional, Cauchy's theorem as a corollary, and prime-order cyclicity. Each theorem wraps Mathlib's Sylow API with pedagogical documentation and classical notation.",
-    "implications": "**Theoretical Significance**: The Sylow theorems are the primary structural tool for finite group theory, with applications cascading across algebra. **Classification**: For groups of order pq (p < q primes), Sylow III forces n_q = 1, giving a normal Sylow q-subgroup \u2014 this classifies all such groups as cyclic or semidirect products. Groups of order p\u00b2 are always abelian (either \u2124/p\u00b2 or (\u2124/p)\u00b2). **Simple group obstruction**: A finite simple group must have n_p > 1 for every prime p dividing its order, since n_p = 1 implies a normal (hence trivial or whole-group) Sylow subgroup.\n\nSylow counting eliminates most orders from admitting simple groups \u2014 the first step in the Classification of Finite Simple Groups (CFSG). **Burnside's p^a q^b theorem** (1904): every group of order p^a \u00b7 q^b is solvable, proved using Sylow subgroups and character theory. This was later subsumed by the Feit-Thompson odd-order theorem (1963). **Representation theory**: Sylow subgroups control modular representation theory \u2014 the representation theory of G over a field of characteristic p is determined by the Sylow p-subgroup via the Brauer correspondence and Green's indecomposable modules.",
+    "implications": "**Theoretical Significance**: The Sylow theorems are the primary structural tool for finite group theory, with applications cascading across algebra. **Classification**: For groups of order pq (p < q primes), Sylow III forces n_q = 1, giving a normal Sylow q-subgroup — this classifies all such groups as cyclic or semidirect products. Groups of order p² are always abelian (either ℤ/p² or (ℤ/p)²). **Simple group obstruction**: A finite simple group must have n_p > 1 for every prime p dividing its order, since n_p = 1 implies a normal (hence trivial or whole-group) Sylow subgroup.\n\nSylow counting eliminates most orders from admitting simple groups — the first step in the Classification of Finite Simple Groups (CFSG). **Burnside's p^a q^b theorem** (1904): every group of order p^a · q^b is solvable, proved using Sylow subgroups and character theory. This was later subsumed by the Feit-Thompson odd-order theorem (1963). **Representation theory**: Sylow subgroups control modular representation theory — the representation theory of G over a field of characteristic p is determined by the Sylow p-subgroup via the Brauer correspondence and Green's indecomposable modules.",
     "openQuestions": [
       "Formalize the classification of groups of small order using Sylow: every group of order $pq$ ($p < q$, $p \\nmid q-1$) is cyclic; every group of order $p^2$ is abelian ($\\mathbb{Z}/p^2$ or $(\\mathbb{Z}/p)^2$). These follow directly from Sylow III counting constraints.",
       "Formalize Wielandt's combinatorial proof (1959): $G$ acts on $\\binom{G}{p^k}$, and since $\\binom{p^k m}{p^k} \\not\\equiv 0 \\pmod{p}$ (by Kummer's theorem), some orbit has size coprime to $p$, yielding a Sylow subgroup as the stabilizer. This avoids induction entirely.",
       "The Sylow theorems fail for infinite groups. Formalize the pro-$p$ Sylow theorem for profinite groups, which recovers existence and conjugacy of maximal pro-$p$ subgroups via inverse limits of finite Sylow subgroups.",
-      "Formalize the Sylow-based simplicity proof for $A_5$: |$A_5$| = 60 = 2\u00b2\u00b73\u00b75, Sylow counting gives $n_2 \\in \\{1,3,5,15\\}$, $n_3 \\in \\{1,4,10\\}$, $n_5 \\in \\{1,6\\}$, and the conjugacy class sizes {1,12,12,15,20} show no proper non-trivial union divides 60.",
+      "Formalize the Sylow-based simplicity proof for $A_5$: |$A_5$| = 60 = 2²·3·5, Sylow counting gives $n_2 \\in \\{1,3,5,15\\}$, $n_3 \\in \\{1,4,10\\}$, $n_5 \\in \\{1,6\\}$, and the conjugacy class sizes {1,12,12,15,20} show no proper non-trivial union divides 60.",
       "Formalize the connection between Sylow subgroups and transfer theory: the transfer homomorphism $G \\to P/[P,P]$ (where $P$ is a Sylow $p$-subgroup) detects elements in the kernel of $G \\to G/O^p(G)$, providing a bridge between Sylow structure and normal subgroup theory"
     ]
   },
@@ -186,62 +186,62 @@
     {
       "targetId": "abel-ruffini-oq-04",
       "relationship": "related",
-      "description": "Sylow analysis of A\u2085 is fundamental to proving its simplicity: |A\u2085| = 60 = 2\u00b2\u00b73\u00b75, and Sylow counting shows the conjugacy class sizes are {1, 12, 12, 15, 20}. Any normal subgroup must be a union of conjugacy classes including {e} with order dividing 60, and the only valid sub-sums are 1 and 60 \u2014 proving A\u2085 is simple, the cornerstone of the Abel-Ruffini theorem"
+      "description": "Sylow analysis of A₅ is fundamental to proving its simplicity: |A₅| = 60 = 2²·3·5, and Sylow counting shows the conjugacy class sizes are {1, 12, 12, 15, 20}. Any normal subgroup must be a union of conjugacy classes including {e} with order dividing 60, and the only valid sub-sums are 1 and 60 — proving A₅ is simple, the cornerstone of the Abel-Ruffini theorem"
     },
     {
       "targetId": "wilsons-theorem",
       "relationship": "related",
-      "description": "Wilson's theorem \u2014 (p\u22121)! \u2261 \u22121 (mod p) \u2014 is a statement about the group (\u2124/p\u2124)* of order p\u22121. The Sylow p-subgroups of (\u2124/n\u2124)* are cyclic, and Wilson's theorem can be derived by pairing each element with its inverse in the group product. The Sylow structure of (\u2124/n\u2124)* underlies the Chinese Remainder decomposition"
+      "description": "Wilson's theorem — (p−1)! ≡ −1 (mod p) — is a statement about the group (ℤ/pℤ)* of order p−1. The Sylow p-subgroups of (ℤ/nℤ)* are cyclic, and Wilson's theorem can be derived by pairing each element with its inverse in the group product. The Sylow structure of (ℤ/nℤ)* underlies the Chinese Remainder decomposition"
     },
     {
       "targetId": "derangements",
       "relationship": "related",
-      "description": "Derangements are fixed-point-free permutations in S\u2099. The Sylow p-subgroups of S\u2099 have a recursive wreath product structure: Syl_p(S\u209a\u2099) \u2245 (\u2124/p\u2124) \u2240 Syl_p(S\u2099). The proportion of derangements (~1/e) is independent of the Sylow structure, illustrating how different group-theoretic properties (fixed-point statistics vs. p-subgroup structure) can be orthogonal"
+      "description": "Derangements are fixed-point-free permutations in Sₙ. The Sylow p-subgroups of Sₙ have a recursive wreath product structure: Syl_p(Sₚₙ) ≅ (ℤ/pℤ) ≀ Syl_p(Sₙ). The proportion of derangements (~1/e) is independent of the Sylow structure, illustrating how different group-theoretic properties (fixed-point statistics vs. p-subgroup structure) can be orthogonal"
     },
     {
       "targetId": "partition-theorem",
       "relationship": "related",
-      "description": "Integer partitions of n index the conjugacy classes of S\u2099 by cycle type. Sylow counting in S\u2099 depends on the prime factorization of n!, and the sizes of conjugacy classes (determined by cycle-type partitions) are central to Sylow-based simplicity proofs \u2014 e.g., proving A\u2085 is simple requires the conjugacy class sizes, which are determined by the partition structure of 5"
+      "description": "Integer partitions of n index the conjugacy classes of Sₙ by cycle type. Sylow counting in Sₙ depends on the prime factorization of n!, and the sizes of conjugacy classes (determined by cycle-type partitions) are central to Sylow-based simplicity proofs — e.g., proving A₅ is simple requires the conjugacy class sizes, which are determined by the partition structure of 5"
     },
     {
       "targetId": "inverse-galois",
       "relationship": "related",
-      "description": "The inverse Galois problem asks which groups occur as Galois groups over \u211a. Sylow subgroups constrain realizability: if G is realizable over \u211a, so are all its Sylow subgroups (as Galois groups of subextensions). The Shafarevich conjecture asserts every solvable group is an inverse Galois group \u2014 the solvable case reduces to understanding towers of abelian extensions, where the Sylow structure controls each layer"
+      "description": "The inverse Galois problem asks which groups occur as Galois groups over ℚ. Sylow subgroups constrain realizability: if G is realizable over ℚ, so are all its Sylow subgroups (as Galois groups of subextensions). The Shafarevich conjecture asserts every solvable group is an inverse Galois group — the solvable case reduces to understanding towers of abelian extensions, where the Sylow structure controls each layer"
     },
     {
       "targetId": "quadratic-reciprocity",
       "relationship": "related",
-      "description": "Quadratic reciprocity governs the structure of (\u2124/p\u2124)*, whose Sylow 2-subgroup determines the quadratic residue structure. The Legendre symbol (a/p) detects membership in the unique subgroup of index 2 (the quadratic residues), which is the Sylow 2-complement when p \u2261 1 (mod 4) or relates to the Sylow 2-subgroup when p \u2261 3 (mod 4)"
+      "description": "Quadratic reciprocity governs the structure of (ℤ/pℤ)*, whose Sylow 2-subgroup determines the quadratic residue structure. The Legendre symbol (a/p) detects membership in the unique subgroup of index 2 (the quadratic residues), which is the Sylow 2-complement when p ≡ 1 (mod 4) or relates to the Sylow 2-subgroup when p ≡ 3 (mod 4)"
     }
   ],
   "references": [
     {
       "authors": "Sylow, Peter Ludwig Mejdell",
-      "title": "Th\u00e9or\u00e8mes sur les groupes de substitutions",
+      "title": "Théorèmes sur les groupes de substitutions",
       "year": "1872",
-      "venue": "Mathematische Annalen, vol. 5, pp. 584\u2013594",
-      "note": "The original paper establishing all three Sylow theorems for permutation groups \u2014 existence, conjugacy, and counting of p-subgroups"
+      "venue": "Mathematische Annalen, vol. 5, pp. 584–594",
+      "note": "The original paper establishing all three Sylow theorems for permutation groups — existence, conjugacy, and counting of p-subgroups"
     },
     {
       "authors": "Frobenius, Georg",
       "title": "Neuer Beweis des Sylowschen Satzes",
       "year": "1887",
-      "venue": "Journal f\u00fcr die reine und angewandte Mathematik, vol. 100, pp. 179\u2013181",
+      "venue": "Journal für die reine und angewandte Mathematik, vol. 100, pp. 179–181",
       "note": "Streamlined alternative proofs of the Sylow theorems using counting arguments, strengthening the divisibility conditions"
     },
     {
       "authors": "Wielandt, Helmut",
-      "title": "Ein Beweis f\u00fcr die Existenz der Sylowgruppen",
+      "title": "Ein Beweis für die Existenz der Sylowgruppen",
       "year": "1959",
-      "venue": "Archiv der Mathematik, vol. 10, pp. 401\u2013402",
+      "venue": "Archiv der Mathematik, vol. 10, pp. 401–402",
       "note": "Elegant combinatorial proof of Sylow I avoiding induction: G acts on subsets of size p^k, and Kummer's theorem ensures some orbit has size coprime to p"
     },
     {
       "authors": "Burnside, William",
-      "title": "On groups of order p^\u03b1 q^\u03b2",
+      "title": "On groups of order p^α q^β",
       "year": "1904",
-      "venue": "Proceedings of the London Mathematical Society, 2(1), pp. 388\u2013392",
-      "note": "Proved that every group of order p^a\u00b7q^b (two primes) is solvable, using Sylow subgroups and character theory \u2014 a landmark application of Sylow's theorems"
+      "venue": "Proceedings of the London Mathematical Society, 2(1), pp. 388–392",
+      "note": "Proved that every group of order p^a·q^b (two primes) is solvable, using Sylow subgroups and character theory — a landmark application of Sylow's theorems"
     },
     {
       "authors": "Rotman, Joseph J.",
@@ -292,5 +292,25 @@
       "leanType": "card (Sylow p G) % p = 1 and card (Sylow p G) | (card G / p^k)"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.GroupTheory.Sylow",
+      "Mathlib.GroupTheory.Coset.Basic",
+      "Mathlib.GroupTheory.Index",
+      "Mathlib.GroupTheory.OrderOfElement",
+      "Mathlib.Data.Nat.Factorization.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Subgroup"
+    ],
+    "namespace": "SylowTheorems",
+    "lineCount": 247,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 1,
+    "sorries": 0,
+    "path": "Proofs/SylowTheorem.lean"
+  }
 }

--- a/src/data/proofs/taylor-sincos-convergence-oq-01/meta.json
+++ b/src/data/proofs/taylor-sincos-convergence-oq-01/meta.json
@@ -224,5 +224,30 @@
       "description": "The geometric series provides a simpler convergence template: both proofs use remainder bounds that tend to 0, but the Taylor remainder requires derivative bounds while the geometric remainder uses the ratio condition |r| < 1."
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.Calculus.Taylor",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Deriv",
+      "Mathlib.Tactic",
+      "Proofs.TaylorSinCosConvergence"
+    ],
+    "opens": [
+      "Set",
+      "Filter",
+      "Topology",
+      "Finset",
+      "Real",
+      "scoped",
+      "Nat",
+      "TaylorSinCosConvergence"
+    ],
+    "namespace": "TaylorSinCosConvergenceOQ01",
+    "lineCount": 239,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "sorries": 1,
+    "path": "Proofs/TaylorSinCosConvergenceOQ01.lean"
+  }
 }

--- a/src/data/proofs/triangle-angle-sum-oq-03/meta.json
+++ b/src/data/proofs/triangle-angle-sum-oq-03/meta.json
@@ -150,5 +150,24 @@
       "description": "Complete biconditional characterization of when the angle sum formula holds"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.Geometry.Euclidean.Triangle",
+      "Mathlib.Geometry.Euclidean.Angle.Unoriented.Affine",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "scoped",
+      "EuclideanGeometry",
+      "Classical"
+    ],
+    "namespace": "TriangleAngleSumOQ03",
+    "lineCount": 141,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/TriangleAngleSumOQ03.lean"
+  }
 }

--- a/src/data/proofs/vietas-formulas-oq-03-oq-05/meta.json
+++ b/src/data/proofs/vietas-formulas-oq-03-oq-05/meta.json
@@ -143,23 +143,43 @@
   ],
   "references": [
     {
-      "authors": ["L. Ferrari"],
+      "authors": [
+        "L. Ferrari"
+      ],
       "title": "Solution of the quartic equation (communicated via Cardano's Ars Magna)",
       "year": "1545",
       "note": "Original method: reduction to resolvent cubic"
     },
     {
-      "authors": ["J.-L. Lagrange"],
+      "authors": [
+        "J.-L. Lagrange"
+      ],
       "title": "Réflexions sur la résolution algébrique des équations",
       "year": "1770",
       "note": "Systematic treatment of resolvents and discriminants"
     },
     {
-      "authors": ["B.L. van der Waerden"],
+      "authors": [
+        "B.L. van der Waerden"
+      ],
       "title": "Moderne Algebra, Vol. 1",
       "year": "1930",
       "note": "Classic treatment of discriminants, Galois theory, and solvability"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.Tactic",
+      "Proofs.VietasFormulasOQ03"
+    ],
+    "opens": [],
+    "namespace": "QuarticDiscriminant",
+    "lineCount": 305,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 3,
+    "sorries": 0,
+    "path": "Proofs/VietasFormulasOQ03OQ05.lean"
+  }
 }

--- a/src/data/proofs/wilsons-theorem-oq-03/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-03/meta.json
@@ -167,5 +167,20 @@
       "description": "Kummer's theorem on ν_p(C(m+n,m)) = number of base-p carries follows directly from Legendre's digit-sum formula applied to (m+n)!/(m!·n!)"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "namespace": "WilsonsTheoremLegendre",
+    "lineCount": 223,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/WilsonsTheoremOQ03.lean"
+  }
 }


### PR DESCRIPTION
## Fix

53 gallery proofs had a `proofRepoPath` in `meta.json` but were missing the `leanFile` section entirely. The `leanFile` section contains metadata derived from the Lean source: imports, opens, namespace, lineCount, axiomCount, theoremCount, definitionCount, sorries, and path.

## Evidence

**Before**: `leanFile` section absent despite valid Lean source at `proofRepoPath`
**After**: `leanFile` section populated with parsed data from each Lean source file

## Scope

53 proofs fixed. Most have 0 sorries and 0 axioms (fully verified). A few have remaining sorries:
- `cantor-diagonalization-oq-03-oq-01-oq-01`: 1 sorry
- `derangements-convergence-oq-01`: 3 sorries
- `erdos-1206/1211/1215/1216`: 1 sorry each (stubs)
- `law-of-sines-oq-06`: 1 sorry
- `ptolemys-theorem-oq-01-incomplete-01`: 3 sorries
- `schroeder-bernstein-oq-03`: 5 sorries
- `shapley-folkman`: 2 sorries (tracked in Aristotle)
- `taylor-sincos-convergence-oq-01`: 1 sorry

This follows the pattern established in #11750 (36 proofs) and #11735 (20 proofs).

---
Automated fix by lean-mechanic agent.