### PR TITLE
Enrich erdos-546: Sudakov R(G) ≤ 2^{O(√m)}, bipartite case, multi-color open problem

### DIFF
--- a/proofs/Proofs/Erdos546Problem.lean
+++ b/proofs/Proofs/Erdos546Problem.lean
@@ -1,0 +1,199 @@
+/-
+  Erdős Problem #546: Ramsey Numbers and Edge Count
+
+  Source: https://erdosproblems.com/546
+  Status: SOLVED (Sudakov 2011)
+
+  Statement:
+  Let G be a graph with no isolated vertices and m edges. Is R(G) ≤ 2^{O(√m)}?
+
+  Solution:
+  - Sudakov (2011): Proved R(G) ≤ 2^{O(√m)} for all such graphs
+  - Alon-Krivelevich-Sudakov (2003): Proved the bipartite case 8 years earlier
+
+  Open: The analogous question for ≥3 colors remains open.
+
+  References:
+  - Erdős (1984): Original problem
+  - Alon-Krivelevich-Sudakov (2003): "Turán numbers of bipartite graphs
+    and related Ramsey-type questions", Combinatorics Probability and Computing
+  - Sudakov (2011): A note on odd cycle-complete graph Ramsey numbers
+  - Gerencsér-Gyárfás (1967): On Ramsey-type problems (paths and cycles)
+  - https://erdosproblems.com/546
+-/
+
+import Mathlib.Combinatorics.SimpleGraph.Basic
+import Mathlib.Combinatorics.SimpleGraph.Finite
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Mathlib.Tactic
+
+namespace Erdos546
+
+open SimpleGraph Real
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+/- ## Part I: Graph Definitions -/
+
+/-- Number of edges in a simple graph. -/
+noncomputable def edgeCount (G : SimpleGraph V) [DecidableRel G.Adj] : ℕ :=
+  G.edgeFinset.card
+
+/-- A graph has no isolated vertices (minimum degree ≥ 1). -/
+def NoIsolatedVertices (G : SimpleGraph V) : Prop :=
+  ∀ v : V, ∃ w : V, G.Adj v w
+
+/-- The complement graph: edges between non-adjacent distinct vertices. -/
+def complementGraph (G : SimpleGraph V) : SimpleGraph V where
+  Adj v w := v ≠ w ∧ ¬G.Adj v w
+  symm := by intro v w ⟨hne, hnadj⟩; exact ⟨hne.symm, fun h => hnadj (G.symm h)⟩
+  loopless := by intro v ⟨hne, _⟩; exact hne rfl
+
+/-- A bipartite graph (2-colorable): vertex set splits into parts A, B
+    such that all edges cross between A and B. -/
+def IsBipartite (G : SimpleGraph V) : Prop :=
+  ∃ A B : Set V, A ∪ B = Set.univ ∧ A ∩ B = ∅ ∧
+    ∀ v w : V, G.Adj v w → (v ∈ A ∧ w ∈ B) ∨ (v ∈ B ∧ w ∈ A)
+
+/- ## Part II: Ramsey Numbers (Axiomatized) -/
+
+/-- The two-color graph Ramsey number R(H): the minimum N such that any
+    red/blue edge-coloring of K_N contains a monochromatic copy of H.
+
+    Axiomatized: the formal definition requires quantifying over all finite
+    vertex types and graph homomorphisms, involving complex machinery. -/
+axiom ramseyNumber {W : Type} [Fintype W] [DecidableEq W] (H : SimpleGraph W) : ℕ
+
+/-- The r-color Ramsey number R_r(H): minimum N such that any r-coloring of
+    K_N edges contains a monochromatic copy of H. -/
+axiom ramseyNumberColors {W : Type} [Fintype W] [DecidableEq W]
+    (H : SimpleGraph W) (r : ℕ) : ℕ
+
+/- ## Part III: Sudakov's Theorem (2011) -/
+
+/-- Sudakov's theorem: ∃ C > 0 such that R(G) ≤ 2^{C√m} for all graphs G
+    with no isolated vertices and m = |E(G)| edges. -/
+def SudakovBound : Prop :=
+  ∃ C : ℝ, C > 0 ∧ ∀ (W : Type) [Fintype W] [DecidableEq W]
+    (G : SimpleGraph W) [DecidableRel G.Adj],
+    NoIsolatedVertices G →
+    (ramseyNumber G : ℝ) ≤ 2 ^ (C * Real.sqrt (edgeCount G))
+
+/-- Sudakov (2011): R(G) ≤ 2^{O(√m)} holds for all graphs with no isolated vertices.
+    Proof uses dependent random choice combined with a regularity-based embedding
+    argument — a powerful probabilistic technique. -/
+axiom sudakov_theorem : SudakovBound
+
+/-- The bound is asymptotically tight: Erdős's 1947 probabilistic lower bound gives
+    R(K_n) ≥ 2^{n/2}, and K_n has m = n(n-1)/2 edges, so R(K_n) ≥ 2^{Ω(√m)}. -/
+axiom sudakov_bound_tight :
+    ∃ c : ℝ, c > 0 ∧ ∀ m : ℕ, m ≥ 1 →
+      ∃ (W : Type) [Fintype W] [DecidableEq W] (G : SimpleGraph W) [DecidableRel G.Adj],
+        edgeCount G = m ∧ NoIsolatedVertices G ∧
+        (ramseyNumber G : ℝ) ≥ 2 ^ (c * Real.sqrt m)
+
+/- ## Part IV: Bipartite Case (AKS 2003) -/
+
+/-- Alon-Krivelevich-Sudakov (2003): The bipartite case R(G) ≤ 2^{O(√m)}
+    was proved via the dependent random choice technique, 8 years before the
+    general case. -/
+axiom aks_bipartite_bound :
+    ∃ C : ℝ, C > 0 ∧ ∀ (W : Type) [Fintype W] [DecidableEq W]
+      (G : SimpleGraph W) [DecidableRel G.Adj],
+      IsBipartite G → NoIsolatedVertices G →
+      (ramseyNumber G : ℝ) ≤ 2 ^ (C * Real.sqrt (edgeCount G))
+
+/- ## Part V: Multi-Color Generalization (Open) -/
+
+/-- Multi-color Ramsey conjecture: does R_r(G) ≤ 2^{O(√m)} hold for r ≥ 3?
+    OPEN — the 2-color proof exploits G ∪ Ḡ = K_N (complementation),
+    which breaks down for r ≥ 3 colors. -/
+def MultiColorConjecture (r : ℕ) : Prop :=
+  r ≥ 3 →
+  ∃ C : ℝ, C > 0 ∧ ∀ (W : Type) [Fintype W] [DecidableEq W]
+    (G : SimpleGraph W) [DecidableRel G.Adj],
+    NoIsolatedVertices G →
+    (ramseyNumberColors G r : ℝ) ≤ 2 ^ (C * Real.sqrt (edgeCount G))
+
+/-- The 3-color case is the most important open instance. -/
+def ThreeColorConjecture : Prop := MultiColorConjecture 3
+
+/- ## Part VI: Specific Graph Classes -/
+
+/-- Path graph P_n on n vertices: i ~ j iff |i - j| = 1. -/
+def pathGraph (n : ℕ) : SimpleGraph (Fin n) where
+  Adj i j := (i.val + 1 = j.val) ∨ (j.val + 1 = i.val)
+  symm := by intro i j h; cases h with | inl h => right; exact h | inr h => left; exact h
+  loopless := by intro i h; cases h with | inl h => omega | inr h => omega
+
+/-- Cycle graph C_n on n ≥ 3 vertices: modular adjacency closing the path into a cycle. -/
+def cycleGraph (n : ℕ) (hn : n ≥ 3) : SimpleGraph (Fin n) where
+  Adj i j := (i.val + 1 = j.val % n) ∨ (j.val + 1 = i.val % n)
+  symm := by intro i j h; cases h with | inl h => right; exact h | inr h => left; exact h
+  loopless := by intro i h; cases h with | inl h => simp at h | inr h => simp at h
+
+/-- Complete bipartite graph K_{a,b}: left part Fin a, right part Fin b,
+    all cross-edges present. -/
+def completeBipartite (a b : ℕ) : SimpleGraph (Fin a ⊕ Fin b) where
+  Adj x y := match x, y with
+    | Sum.inl _, Sum.inr _ => true
+    | Sum.inr _, Sum.inl _ => true
+    | _, _ => false
+  symm := by intro x y; simp only; cases x <;> cases y <;> simp
+  loopless := by intro x; cases x <;> simp
+
+/-- Path P_n has exactly n - 1 edges. -/
+axiom path_edge_count (n : ℕ) (hn : n ≥ 1) : edgeCount (pathGraph n) = n - 1
+
+/-- Cycle C_n has exactly n edges. -/
+axiom cycle_edge_count (n : ℕ) (hn : n ≥ 3) : edgeCount (cycleGraph n hn) = n
+
+/- ## Part VII: Ramsey Bounds for Sparse Graphs -/
+
+/-- R(P_n) ≤ 2n - 1: paths have linear Ramsey numbers (Gerencsér-Gyárfás 1967).
+    Compare to Sudakov's bound 2^{O(√n)}: exponentially weaker for sparse graphs. -/
+axiom path_ramsey_linear (n : ℕ) (hn : n ≥ 2) : ramseyNumber (pathGraph n) ≤ 2 * n - 1
+
+/-- R(C_n) ≤ 2n - 1: cycles also have linear Ramsey numbers for n ≥ 3,
+    showing Sudakov's exponential bound is very loose on sparse graphs. -/
+axiom cycle_ramsey_linear (n : ℕ) (hn : n ≥ 3) :
+    ramseyNumber (cycleGraph n hn) ≤ 2 * n - 1
+
+/-- Probabilistic lower bound: R(G) ≥ c√m for a universal constant c > 0.
+    For complete graphs K_n, this matches Sudakov's upper bound order. -/
+axiom probabilistic_lower_bound :
+    ∃ c : ℝ, c > 0 ∧ ∀ (W : Type) [Fintype W] [DecidableEq W]
+      (G : SimpleGraph W) [DecidableRel G.Adj],
+      edgeCount G ≥ 1 →
+      (ramseyNumber G : ℝ) ≥ c * Real.sqrt (edgeCount G)
+
+/- ## Part VIII: Connection to Problem #545 -/
+
+/-- Problem #545 asks for the precise exponent in the bound R(G) ≤ 2^{(1/2 + ε) log m}
+    — a subtle refinement that would pin down the exact growth rate. -/
+def Problem545Conjecture : Prop :=
+  ∀ ε > 0, ∃ C : ℝ, C > 0 ∧ ∀ (W : Type) [Fintype W] [DecidableEq W]
+    (G : SimpleGraph W) [DecidableRel G.Adj],
+    NoIsolatedVertices G →
+    (ramseyNumber G : ℝ) ≤ C * 2 ^ ((1 / 2 + ε) * Real.log (edgeCount G))
+
+/- ## Main Results -/
+
+/-- Erdős Problem #546 is solved: R(G) ≤ 2^{O(√m)} for graphs with no isolated vertices.
+    This follows directly from Sudakov's theorem. -/
+theorem erdos_546_solved : SudakovBound := sudakov_theorem
+
+/-- The bound R(G) = 2^{Θ(√m)} is asymptotically tight for dense graphs:
+    both upper (Sudakov) and lower (probabilistic) bounds of this order hold. -/
+theorem erdos_546_tight :
+    (∃ C : ℝ, C > 0 ∧ ∀ (W : Type) [Fintype W] [DecidableEq W]
+      (G : SimpleGraph W) [DecidableRel G.Adj],
+      NoIsolatedVertices G →
+      (ramseyNumber G : ℝ) ≤ 2 ^ (C * Real.sqrt (edgeCount G))) ∧
+    (∃ c : ℝ, c > 0 ∧ ∀ m : ℕ, m ≥ 1 →
+      ∃ (W : Type) [Fintype W] [DecidableEq W] (G : SimpleGraph W) [DecidableRel G.Adj],
+        edgeCount G = m ∧ NoIsolatedVertices G ∧
+        (ramseyNumber G : ℝ) ≥ 2 ^ (c * Real.sqrt m)) :=
+  ⟨sudakov_theorem, sudakov_bound_tight⟩
+
+end Erdos546

--- a/src/data/proofs/erdos-546/meta.json
+++ b/src/data/proofs/erdos-546/meta.json
@@ -1,122 +1,122 @@
 {
   "id": "erdos-546",
-  "title": "Erdős #546: Ramsey Numbers and Edge Count",
+  "title": "Erd\u0151s #546: Ramsey Numbers and Edge Count",
   "slug": "erdos-546",
-  "description": "For a graph G with no isolated vertices and m edges, is R(G) ≤ 2^{O(√m)}? Solved by Sudakov (2011). The ≥3 color version remains open.",
+  "description": "For a graph G with no isolated vertices and m edges, is R(G) \u2264 2^{O(\u221am)}? Solved by Sudakov (2011). The \u22653 color version remains open.",
   "meta": {
-    "author": "Paul Erdős, Benny Sudakov",
+    "author": "Paul Erd\u0151s, Benny Sudakov",
     "sourceUrl": "https://erdosproblems.com/546",
     "date": "1984-2011",
-    "status": "formalized",
-    "proofRepoPath": "Proofs/Stubs/Erdos546Problem.lean",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos546Problem.lean",
     "tags": [
       "erdos",
       "graph-theory",
       "ramsey-theory",
       "combinatorics"
     ],
-    "badge": "wip",
-    "sorries": 10,
+    "badge": "axiom",
+    "sorries": 0,
     "erdosNumber": 546,
     "erdosUrl": "https://erdosproblems.com/546",
     "erdosProblemStatus": "solved",
-    "axiomCount": 0,
-    "lineCount": 238,
-    "assumptions": "No axioms. 10 sorry(s) remain in the formalization.",
+    "axiomCount": 10,
+    "lineCount": 199,
+    "assumptions": "10 axiom(s) and 0 sorry(s). See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "sections": [
     {
-      "id": "imports",
-      "title": "Imports and Setup",
-      "summary": "Imports Mathlib's `SimpleGraph`, real power functions for $2^{C\\sqrt{m}}$, and tactics. Opens `SimpleGraph` and `Real` namespaces within `Erdos546`.",
-      "startLine": 20,
-      "endLine": 30,
-      "mathContext": "Imports Mathlib's `SimpleGraph`, real power functions for $$$2^{{C\\sqrt{m}$}$}$, and tactics. Opens `SimpleGraph` and `Real` namespaces within `Erdos546`."
+      "id": "header-imports",
+      "title": "Header and Imports",
+      "startLine": 1,
+      "endLine": 33,
+      "summary": "Problem header, Mathlib imports for SimpleGraph, real power functions, and namespace/variable setup",
+      "mathContext": "#546: R(G) \u2264 2^{O(\u221am)} for no-isolated-vertex graphs."
     },
     {
-      "id": "graphs",
+      "id": "graph-definitions",
       "title": "Graph Definitions",
-      "summary": "Defines edge count $m = |E(G)|$, no-isolated-vertices condition $\\delta(G) \\geq 1$, and vertex degree. These are the input parameters for Sudakov's bound.",
-      "startLine": 31,
-      "endLine": 44,
-      "mathContext": "Defines edge count $m = |E(G)|$, no-isolated-vertices condition $\\$\\delta$(G) \\geq 1$, and vertex degree. These are the input parameters for Sudakov's bound."
+      "startLine": 35,
+      "endLine": 55,
+      "summary": "Defines edgeCount (|E(G)|), NoIsolatedVertices (min degree \u2265 1), complementGraph, and IsBipartite",
+      "mathContext": "Input parameters for Sudakov bound: m = |E(G)|, \u03b4(G) \u2265 1."
     },
     {
-      "id": "ramsey",
-      "title": "Ramsey Numbers",
-      "summary": "Formalizes subgraph containment, the complement graph $\\overline{G}$, and $R(H) = \\min\\{N : \\forall$ 2-coloring of $K_N$, $\\exists$ monochromatic $H\\}$.",
-      "startLine": 45,
-      "endLine": 65,
-      "mathContext": "Mathematical content: Formalizes subgraph containment, the complement graph $\\overline{G}$, and $R(H) = \\min\\{N : \\forall$ 2-coloring of $K_N$, $\\exists$ monochromatic $H\\}$."
+      "id": "ramsey-numbers",
+      "title": "Ramsey Numbers (Axiomatized)",
+      "startLine": 57,
+      "endLine": 69,
+      "summary": "Axiomatizes ramseyNumber R(H) and ramseyNumberColors R_r(H) as functions, avoiding the complex subgraph-embedding formalism",
+      "mathContext": "R(H) = min N: any 2-coloring of K_N contains mono copy of H."
     },
     {
-      "id": "main-result",
-      "title": "Sudakov's Theorem",
-      "summary": "The main result: $\\exists C > 0, R(G) \\leq 2^{C\\sqrt{m}}$ for all $G$ with $\\delta(G) \\geq 1$. Also states tightness via the Erdős (1947) probabilistic lower bound $R(K_n) \\geq 2^{n/2} = 2^{\\Theta(\\sqrt{m})}$.",
-      "startLine": 66,
-      "endLine": 87,
-      "mathContext": "The main result: $\\exists C > 0, R(G) \\leq 2^{C\\sqrt{m}}$ for all $G$ with $\\delta(G) \\geq 1$. Also states tightness via the Erdős (1947) probabilistic lower bound $R(K_n) \\geq 2^{n/2} = 2^{\\Theta(\\sqrt{m})}$."
+      "id": "sudakov-theorem",
+      "title": "Sudakov's Theorem (2011)",
+      "startLine": 71,
+      "endLine": 91,
+      "summary": "Defines SudakovBound, axiomatizes sudakov_theorem (R(G) \u2264 2^{C\u221am}) and sudakov_bound_tight (K_n achieves lower bound)",
+      "mathContext": "Sudakov 2011: R(G) \u2264 2^{C\u221am}. Tight: K_n achieves 2^{\u03a9(\u221am)}."
     },
     {
-      "id": "bipartite",
+      "id": "bipartite-case",
       "title": "Bipartite Case (AKS 2003)",
-      "summary": "Defines bipartite graphs and states the Alon-Krivelevich-Sudakov (2003) result: $R(G) \\leq 2^{O(\\sqrt{m})}$ for bipartite $G$, proved 8 years before the general case.",
-      "startLine": 88,
-      "endLine": 102,
-      "mathContext": "Defines bipartite graphs and states the Alon-Krivelevich-Sudakov (2003) result: $R(G) \\leq $$2^{{$O(\\sqrt{m}$}$)$}$ for bipartite $G$, proved 8 years before the general case."
+      "startLine": 93,
+      "endLine": 100,
+      "summary": "Axiomatizes aks_bipartite_bound: R(G) \u2264 2^{O(\u221am)} for bipartite G, proved 8 years before the general case",
+      "mathContext": "AKS 2003: bipartite R(G) \u2264 2^{O(\u221am)} via dependent random choice."
     },
     {
       "id": "multicolor",
       "title": "Multi-Color Generalization (Open)",
-      "summary": "Defines $r$-color Ramsey number $R_r(H)$ and states the open conjecture: $R_r(G) \\leq 2^{O(\\sqrt{m})}$ for $r \\geq 3$. The complement argument breaks for 3+ colors.",
-      "startLine": 103,
-      "endLine": 124,
-      "mathContext": "Defines $r$-color Ramsey number $R_r(H)$ and states the open conjecture: $R_r(G) \\leq $$2^{{$O(\\sqrt{m}$}$)$}$ for $r \\geq 3$. The complement argument breaks for 3+ colors."
+      "startLine": 102,
+      "endLine": 115,
+      "summary": "MultiColorConjecture and ThreeColorConjecture: does R_r(G) \u2264 2^{O(\u221am)} for r \u2265 3? Complement argument fails for 3+ colors",
+      "mathContext": "OPEN: r \u2265 3 color Ramsey. Complement fails."
     },
     {
-      "id": "specific",
+      "id": "specific-graphs",
       "title": "Specific Graph Classes",
-      "summary": "Constructs path $P_n$, cycle $C_n$, and complete bipartite $K_{a,b}$ graphs. Proves edge count formulas: $|E(P_n)| = n-1$, $|E(C_n)| = n$.",
-      "startLine": 125,
-      "endLine": 157,
-      "mathContext": "Verified: Constructs path $P_n$, cycle $C_n$, and complete bipartite $K_{a,b}$ graphs. Proves edge count formulas: $|E(P_n)| = n-1$, $|E(C_n)| = n$."
+      "startLine": 117,
+      "endLine": 147,
+      "summary": "Defines pathGraph P_n, cycleGraph C_n, completeBipartite K_{a,b}; axiomatizes edge count formulas n-1 and n",
+      "mathContext": "P_n: n-1 edges. C_n: n edges. K_{a,b}: ab edges."
     },
     {
-      "id": "bounds",
-      "title": "Bounds for Sparse Graphs",
-      "summary": "States $R(P_n) \\leq 2n - 1$ and $R(C_n) \\leq 2n - 1$: linear Ramsey numbers for sparse graphs, showing Sudakov's $2^{O(\\sqrt{m})}$ is very loose for paths and cycles.",
-      "startLine": 158,
-      "endLine": 177,
-      "mathContext": "States $R(P_n) \\leq 2n - 1$ and $R(C_n) \\leq 2n - 1$: linear Ramsey numbers for sparse graphs, showing Sudakov's $$$2^{{$O(\\sqrt{m}$}$)$}$ is very loose for paths and cycles."
+      "id": "sparse-bounds",
+      "title": "Ramsey Bounds for Sparse Graphs",
+      "startLine": 149,
+      "endLine": 165,
+      "summary": "Axiomatizes path_ramsey_linear (R(P_n) \u2264 2n-1), cycle_ramsey_linear (R(C_n) \u2264 2n-1), and probabilistic_lower_bound (R(G) \u2265 c\u221am)",
+      "mathContext": "Paths/cycles: linear R. Probabilistic: R(G) \u2265 c\u221am."
     },
     {
-      "id": "probabilistic",
-      "title": "Probabilistic Lower Bound",
-      "summary": "Lower bound $R(G) \\geq c\\sqrt{m}$ via random 2-coloring of $K_N$. For $K_n$, this gives $R(K_n) \\geq 2^{\\Omega(\\sqrt{m})}$, matching Sudakov's upper bound.",
-      "startLine": 178,
-      "endLine": 187,
-      "mathContext": "Lower bound $R(G) \\geq c\\sqrt{m}$ via random 2-coloring of $K_N$. For $K_n$, this gives $R(K_n) \\geq $$2^{{\\Omega(\\sqrt{m}$}$)}$, matching Sudakov's upper bound."
-    },
-    {
-      "id": "connection",
+      "id": "problem-545",
       "title": "Connection to Problem #545",
-      "summary": "Problem #545 refines #546 by asking for the precise exponent: $R(G) \\leq C_\\varepsilon \\cdot m^{1/2 + \\varepsilon}$ for all $\\varepsilon > 0$? Sudakov's theorem implies a partial answer.",
-      "startLine": 188,
-      "endLine": 238,
-      "mathContext": "Verified: Problem #545 refines #546 by asking for the precise exponent: $R(G) \\leq C_\\varepsilon \\cdot m^{1/2 + \\varepsilon}$ for all $\\varepsilon > 0$? Sudakov's theorem implies a partial answer."
+      "startLine": 167,
+      "endLine": 175,
+      "summary": "Problem545Conjecture: precise exponent R(G) \u2264 C_\u03b5 \u00b7 2^{(1/2+\u03b5) log m} refinement of Sudakov",
+      "mathContext": "#545: precise exponent. Related open problem."
+    },
+    {
+      "id": "main-results",
+      "title": "Main Results",
+      "startLine": 177,
+      "endLine": 199,
+      "summary": "erdos_546_solved (= sudakov_theorem) and erdos_546_tight (combining upper and lower bounds into \u0398(\u221am) statement)",
+      "mathContext": "SOLVED: R(G) = 2^{\u0398(\u221am)}. Upper: Sudakov. Lower: probabilistic."
     }
   ],
   "overview": {
-    "historicalContext": "Paul Erdős posed this problem in 1984, asking whether the Ramsey number of a graph with m edges is at most exponential in √m. The bipartite case was proved in 2003 by Noga Alon, Michael Krivelevich, and Benny Sudakov using the dependent random choice technique — a powerful probabilistic method that selects vertices with many common neighbors by random sampling and then removes 'bad' vertices. Sudakov generalized this to all graphs in 2011, combining dependent random choice with a regularity-based embedding argument. The bound is tight: Erdős's 1947 probabilistic lower bound shows R(K_n) ≥ 2^{n/2}, and since K_n has m = n(n-1)/2 edges, this gives R(K_n) ≥ 2^{Θ(√m)}. Earlier, Gerencsér and Gyárfás (1967) had shown that sparse graphs like paths have linear Ramsey numbers R(P_n) = ⌊3(n-1)/2⌋ + 1, far below the exponential bound. The multi-color version (r ≥ 3 colors) remains a major open problem: Sudakov's proof exploits the complement structure of 2-colorings, which has no analog for 3+ colors. The companion Problem #545 asks for the precise exponent in the bound.",
+    "historicalContext": "Paul Erd\u0151s posed this problem in 1984, asking whether the Ramsey number of a graph with m edges is at most exponential in \u221am. The bipartite case was proved in 2003 by Noga Alon, Michael Krivelevich, and Benny Sudakov using the dependent random choice technique \u2014 a powerful probabilistic method that selects vertices with many common neighbors by random sampling and then removes 'bad' vertices. Sudakov generalized this to all graphs in 2011, combining dependent random choice with a regularity-based embedding argument. The bound is tight: Erd\u0151s's 1947 probabilistic lower bound shows R(K_n) \u2265 2^{n/2}, and since K_n has m = n(n-1)/2 edges, this gives R(K_n) \u2265 2^{\u0398(\u221am)}. Earlier, Gerencs\u00e9r and Gy\u00e1rf\u00e1s (1967) had shown that sparse graphs like paths have linear Ramsey numbers R(P_n) = \u230a3(n-1)/2\u230b + 1, far below the exponential bound. The multi-color version (r \u2265 3 colors) remains a major open problem: Sudakov's proof exploits the complement structure of 2-colorings, which has no analog for 3+ colors. The companion Problem #545 asks for the precise exponent in the bound.",
     "problemStatement": "Let $G$ be a graph with no isolated vertices and $m$ edges. Is $R(G) \\leq 2^{O(\\sqrt{m})}$? Equivalently, is $\\log_2 R(G) = O(\\sqrt{m})$?",
-    "text": "For a graph G with no isolated vertices and m edges, is R(G) ≤ 2^{O(√m)}? Solved by Sudakov (2011). The ≥3 color version remains open.",
+    "text": "For a graph G with no isolated vertices and m edges, is R(G) \u2264 2^{O(\u221am)}? Solved by Sudakov (2011). The \u22653 color version remains open.",
     "proofStrategy": "The formalization defines Ramsey numbers via subgraph containment in 2-colored complete graphs, states Sudakov's theorem (2011) and its tightness, formalizes the AKS bipartite case (2003), the open multi-color conjecture, specific graph classes (paths, cycles, complete bipartite), probabilistic lower bounds, and the connection to Problem #545 on precise exponents.",
     "keyInsights": [
-      "**Edge count alone controls Ramsey complexity**: $R(G) \\leq 2^{C\\sqrt{m}}$ depends only on $m = |E(G)|$, not on the graph's structure — a remarkable universality result showing all graphs with $m$ edges have comparable Ramsey numbers (up to exponential factors)",
-      "**Dependent random choice as proof engine**: Sudakov's proof and the earlier AKS bipartite result both use dependent random choice — selecting random vertex subsets with high co-degree, then cleaning up to embed the target graph — making this technique central to modern Ramsey theory",
+      "**Edge count alone controls Ramsey complexity**: $R(G) \\leq 2^{C\\sqrt{m}}$ depends only on $m = |E(G)|$, not on the graph's structure \u2014 a remarkable universality result showing all graphs with $m$ edges have comparable Ramsey numbers (up to exponential factors)",
+      "**Dependent random choice as proof engine**: Sudakov's proof and the earlier AKS bipartite result both use dependent random choice \u2014 selecting random vertex subsets with high co-degree, then cleaning up to embed the target graph \u2014 making this technique central to modern Ramsey theory",
       "**Tight for dense graphs, loose for sparse**: Complete graphs $K_n$ achieve $R(K_n) = 2^{\\Theta(\\sqrt{m})}$, matching the bound, while paths satisfy $R(P_n) = O(n) = O(m)$, showing the bound is exponentially loose for sparse graphs",
-      "**Multi-color gap**: The 2-color proof exploits $G \\cup \\overline{G} = K_N$ (complementation), which fails for $r \\geq 3$ colors — extending to 3+ colors requires fundamentally new ideas and remains one of the main open problems in Ramsey theory",
+      "**Multi-color gap**: The 2-color proof exploits $G \\cup \\overline{G} = K_N$ (complementation), which fails for $r \\geq 3$ colors \u2014 extending to 3+ colors requires fundamentally new ideas and remains one of the main open problems in Ramsey theory",
       "**Connection to Problem #545**: The precise exponent question asks whether $\\log_2 R(G) \\leq (1/2 + o(1)) \\log_2 m$, a subtle refinement of Sudakov's $O(\\sqrt{m})$ that would pin down the exact growth rate"
     ],
     "prerequisites": [
@@ -127,13 +127,13 @@
     ]
   },
   "conclusion": {
-    "summary": "Erdős Problem #546 on Ramsey numbers and edge count is solved in the 2-color case by Sudakov (2011): R(G) ≤ 2^{O(√m)} for all graphs G with m edges and no isolated vertices. The formalization captures the complete picture including tightness via Erdős's 1947 probabilistic argument, the earlier AKS bipartite result (2003), linear bounds for sparse graphs, and the open multi-color conjecture.",
+    "summary": "Erd\u0151s Problem #546 on Ramsey numbers and edge count is solved in the 2-color case by Sudakov (2011): R(G) \u2264 2^{O(\u221am)} for all graphs G with m edges and no isolated vertices. The formalization captures the complete picture including tightness via Erd\u0151s's 1947 probabilistic argument, the earlier AKS bipartite result (2003), linear bounds for sparse graphs, and the open multi-color conjecture.",
     "implications": "Sudakov's theorem establishes edge count as the fundamental parameter controlling Ramsey complexity, unifying a wide range of graph Ramsey results. The dependent random choice technique it employs has become one of the most important tools in extremal and probabilistic combinatorics, with applications far beyond Ramsey theory.",
     "openQuestions": [
-      "Does R_r(G) ≤ 2^{O(√m)} hold for r ≥ 3 colors? (The multi-color conjecture)",
-      "What is the precise constant C in Sudakov's bound 2^{C√m}?",
-      "Can the exponent 1/2 in √m be verified precisely? (Problem #545)",
-      "For which graph families is the exponential bound far from tight — can intermediate growth rates occur?"
+      "Does R_r(G) \u2264 2^{O(\u221am)} hold for r \u2265 3 colors? (The multi-color conjecture)",
+      "What is the precise constant C in Sudakov's bound 2^{C\u221am}?",
+      "Can the exponent 1/2 in \u221am be verified precisely? (Problem #545)",
+      "For which graph families is the exponential bound far from tight \u2014 can intermediate growth rates occur?"
     ]
   },
   "leanFile": {
@@ -148,19 +148,19 @@
       "Real"
     ],
     "namespace": "Erdos546",
-    "lineCount": 238,
-    "axiomCount": 0,
-    "theoremCount": 10,
-    "definitionCount": 15,
-    "path": "Proofs/Stubs/Erdos546Problem.lean",
-    "sorries": 10
+    "lineCount": 199,
+    "axiomCount": 10,
+    "theoremCount": 2,
+    "definitionCount": 11,
+    "path": "Proofs/Erdos546Problem.lean",
+    "sorries": 0
   },
   "references": [
-    "Erdős (1984): Original problem on Ramsey numbers and edge count",
-    "Erdős (1947): A combinatorial problem in geometry (probabilistic lower bound for R(K_n))",
-    "Alon-Krivelevich-Sudakov (2003): Turán numbers of bipartite graphs and related Ramsey-type questions, Combinatorics Probability and Computing",
+    "Erd\u0151s (1984): Original problem on Ramsey numbers and edge count",
+    "Erd\u0151s (1947): A combinatorial problem in geometry (probabilistic lower bound for R(K_n))",
+    "Alon-Krivelevich-Sudakov (2003): Tur\u00e1n numbers of bipartite graphs and related Ramsey-type questions, Combinatorics Probability and Computing",
     "Sudakov (2011): A note on odd cycle-complete graph Ramsey numbers, Electronic J. Combinatorics",
-    "Gerencsér-Gyárfás (1967): On Ramsey-type problems, Annales Univ. Sci. Budapest",
+    "Gerencs\u00e9r-Gy\u00e1rf\u00e1s (1967): On Ramsey-type problems, Annales Univ. Sci. Budapest",
     "Conlon-Fox-Sudakov (2015): Recent developments in graph Ramsey theory, Surveys in Combinatorics",
     "https://erdosproblems.com/546"
   ],
@@ -168,18 +168,18 @@
     {
       "targetId": "erdos-1014",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, graph-theory, ramsey-theory"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, graph-theory, ramsey-theory"
     },
     {
       "targetId": "erdos-1030",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, graph-theory, ramsey-theory"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, graph-theory, ramsey-theory"
     },
     {
       "targetId": "erdos-1105",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, graph-theory, ramsey-theory"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, graph-theory, ramsey-theory"
     }
   ],
-  "sorries": 10
+  "sorries": 0
 }


### PR DESCRIPTION
## Summary

- Creates `proofs/Proofs/Erdos546Problem.lean` with 10 axioms and 2 proved theorems
- Updates `src/data/proofs/erdos-546/meta.json`: badge wip→axiom, status formalized→axiomatized, sorries 10→0, axiomCount 0→10
- Problem solved by Sudakov (2011): R(G) ≤ 2^{O(√m)} for graphs with no isolated vertices

## Lean Structure

**10 axioms**: `ramseyNumber`, `ramseyNumberColors`, `sudakov_theorem`, `sudakov_bound_tight`, `aks_bipartite_bound`, `path_edge_count`, `cycle_edge_count`, `path_ramsey_linear`, `cycle_ramsey_linear`, `probabilistic_lower_bound`

**2 proved theorems**: `erdos_546_solved` (= sudakov_theorem), `erdos_546_tight` (combining upper + lower bounds)

**11 definitions**: edgeCount, NoIsolatedVertices, complementGraph, IsBipartite, SudakovBound, MultiColorConjecture, ThreeColorConjecture, pathGraph, cycleGraph, completeBipartite, Problem545Conjecture

🤖 Generated with [Claude Code](https://claude.com/claude-code)