### PR TITLE
Audit fix: erdos-476-oq-05 sorry 2→1, lineCount 583→784, theoremCount 8→13

### DIFF
--- a/src/data/proofs/erdos-476-oq-05/meta.json
+++ b/src/data/proofs/erdos-476-oq-05/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-476-oq-05",
   "title": "Erdős #476 OQ5: Vosper's Theorem — Equality Case of Cauchy-Davenport",
   "slug": "erdos-476-oq-05",
-  "description": "Vosper's theorem (1956): if |A+B| = |A|+|B|-1 in Z/pZ with |A|,|B|≥2 and |A+B|<p, then A and B are arithmetic progressions with the same common difference d. Infrastructure partially proved: IsArithmeticProgression definition, singleton/pair AP lemmas, translation invariance, ap_of_near_periodic (backward-shift induction), and vosper_base (|A|=2 case) are fully proved. Two sorries remain: position analysis in vosper_ap_sdiff_card and Case 1 existence in the full Vosper induction.",
+  "description": "Vosper's theorem (1956): if |A+B| = |A|+|B|-1 in Z/pZ with |A|,|B|≥2 and |A+B|<p, then A and B are arithmetic progressions with the same common difference d. Infrastructure largely proved: IsArithmeticProgression definition, singleton/pair AP lemmas, translation invariance, ap_of_near_periodic (backward-shift induction), vosper_base (|A|=2 case), and vosper_ap_sdiff_card (AP extension lemma, proved via linear_combination) are all fully proved. One sorry remains: Case 1 existence in the full Vosper induction.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-21",
@@ -18,12 +18,12 @@
       "zmod"
     ],
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 1,
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "assumptions": "2 sorries remain: [SORRY 1/2] vosper_ap_sdiff_card position analysis — given |{a₀}+B \\ (A'+B)| = 1 with both APs having diff d, prove a₀ = a₁-d or a₀ = a₁+|A'|*d (HARD). [SORRY 2/2] vosper Case 1 existence — find non-redundant a₀ ∈ A via counting argument or iterative removal. ap_of_near_periodic (backward-shift induction), vosper_base (|A|=2 case) are fully proved. Infrastructure all proved with 0 sorries.",
-    "lineCount": 583,
-    "theoremCount": 8,
+    "assumptions": "1 sorry remains: vosper Case 1 existence — find non-redundant a₀ ∈ A via counting argument or iterative removal (by contradiction: if all a ∈ A are redundant, a counting argument fails for small |A|,|B|). vosper_ap_sdiff_card (position analysis: a₀ is predecessor/successor of A' in the AP) is now fully proved via linear_combination. ap_of_near_periodic (backward-shift induction), vosper_base (|A|=2 case), and all infrastructure are proved with 0 sorries.",
+    "lineCount": 784,
+    "theoremCount": 13,
     "definitionCount": 1,
     "originalContributions": [
       "IsArithmeticProgression: AP definition for Finset (ZMod p) with starting point a and difference d",
@@ -33,8 +33,9 @@
       "shift_card_eq: |B.image (·+d)| = |B| via add_right_injective (proved, 0 sorries)",
       "ap_of_near_periodic: B is AP if |B\\(B+d)|=1 (proved — backward-shift induction)",
       "vosper_base: Vosper for |A|=2 (proved — uses ap_of_near_periodic)",
-      "vosper_ap_sdiff_card: AP extension lemma (1 sorry — position analysis: given |{a₀}+B \\ (A'+B)|=1, prove a₀ is predecessor or successor in AP)",
-      "vosper: full Vosper theorem (1 sorry — Case 1 existence: find non-redundant a₀ ∈ A via counting argument)"
+      "vosper_ap_sdiff_card: AP extension lemma (proved — position analysis: given |{a₀}+B \\ (A'+B)|=1, proves a₀ = a₁-d or a₀ = a₁+|A'|·d via linear_combination)",
+      "vosper_case1_exists: Case 1 existence in vosper (1 sorry — find non-redundant a₀ ∈ A via counting argument or iterative removal)",
+      "vosper: full Vosper theorem (1 sorry — delegates to vosper_case1_exists for Case 1 existence)"
     ]
   },
   "overview": {
@@ -57,11 +58,10 @@
     ]
   },
   "conclusion": {
-    "summary": "Infrastructure for Vosper's theorem largely established: IsArithmeticProgression defined, basic AP lemmas proved (singleton, pair, shift, cardinality), ap_of_near_periodic proved (backward-shift induction), vosper_base proved (|A|=2 case). Two sorries remain: position analysis in vosper_ap_sdiff_card (HARD: proving a₀ is predecessor or successor given |{a₀}+B \\ (A'+B)|=1) and Case 1 existence in the full Vosper induction (finding a non-redundant element via counting).",
-    "implications": "Once the two remaining sorries are closed, Vosper's theorem would complement ZMod.cauchy_davenport in Mathlib, completing the picture of additive structure in Z/pZ.",
+    "summary": "Infrastructure for Vosper's theorem largely established: IsArithmeticProgression defined, basic AP lemmas proved (singleton, pair, shift, cardinality, d_ne_zero, add_isAP_eq, isAP_sum, isAP_sdiff_card), ap_of_near_periodic proved (backward-shift induction), vosper_base proved (|A|=2 case), vosper_ap_sdiff_card proved (position analysis via linear_combination). One sorry remains: Case 1 existence in the full Vosper induction (finding a non-redundant element via counting/contradiction).",
+    "implications": "Once the remaining sorry is closed, Vosper's theorem would complement ZMod.cauchy_davenport in Mathlib, completing the picture of additive structure in Z/pZ.",
     "openQuestions": [
-      "Prove position analysis in vosper_ap_sdiff_card: given |{a₀}+B \\ (A'+B)|=1 with both APs having diff d, prove a₀ = a₁-d or a₀ = a₁+|A'|*d (HARD)",
-      "Prove Case 1 existence in vosper: find a non-redundant a₀ ∈ A via counting argument or iterative removal",
+      "Prove Case 1 existence in vosper: find a non-redundant a₀ ∈ A by contradiction — if all a ∈ A are redundant, a counting argument on |A|·|B| ≥ 2(|A|+|B|-1) gives a contradiction",
       "Extend Vosper to the case |A|=1 or |B|=1 (trivial but needs separate statement)",
       "Generalize to other groups: Vosper has analogs in other settings (e.g., non-prime orders with different extremal sets)"
     ]
@@ -95,34 +95,41 @@
     },
     {
       "id": "ap-infrastructure",
-      "title": "AP Infrastructure: Four Proved Lemmas",
-      "startLine": 59,
-      "endLine": 105,
-      "summary": "shift_card_eq (|B+d| = |B|), isAP_singleton, isAP_pair (uses interval_cases), isAP_shift (uses Finset.image_image + ring). All 0 sorries."
+      "title": "AP Infrastructure: Proved Lemmas",
+      "startLine": 48,
+      "endLine": 203,
+      "summary": "shift_card_eq (|B+d| = |B|), isAP_singleton, isAP_pair (uses interval_cases), isAP_shift (uses Finset.image_image + ring), d_ne_zero_of_isAP, add_isAP_eq, isAP_sum, isAP_sdiff_card. All 0 sorries."
+    },
+    {
+      "id": "vosper-ap-sdiff-card",
+      "title": "Key Sublemma: AP Extension via Position Analysis",
+      "startLine": 204,
+      "endLine": 520,
+      "summary": "vosper_ap_sdiff_card: given |{a₀}+B \\ (A'+B)| = 1 with A' and B both APs with diff d, proves a₀ = a₁-d or a₀ = a₁+|A'|·d via linear_combination. Fully proved (0 sorries). Also includes zmod_orbit_injective helper."
     },
     {
       "id": "near-periodic-lemma",
       "title": "Key Sublemma: Near-Periodicity Forces AP",
-      "startLine": 106,
-      "endLine": 127,
+      "startLine": 521,
+      "endLine": 663,
       "summary": "ap_of_near_periodic: |B \\ (B+d)| = 1 ∧ d≠0 ∧ |B|<p → B is AP with difference d. Fully proved via backward-shift induction on |B| using well-founded recursion."
     },
     {
       "id": "vosper-theorem",
       "title": "Vosper's Theorem: Base Case and Full Induction",
-      "startLine": 128,
-      "endLine": 165,
-      "summary": "vosper_base (|A|=2, inclusion-exclusion → ap_of_near_periodic, fully proved), vosper_ap_sdiff_card (AP extension, 1 sorry: position analysis proving a₀ is predecessor/successor), vosper (strong induction on |A|, 1 sorry: Case 1 existence). Two sorries remain across these two theorems."
+      "startLine": 664,
+      "endLine": 784,
+      "summary": "vosper_base (|A|=2, inclusion-exclusion → ap_of_near_periodic, fully proved), vosper (strong induction on |A|, 1 sorry: Case 1 existence — finding non-redundant a₀ ∈ A). One sorry remains."
     }
   ],
   "leanFile": {
     "namespace": "Erdos476OQ05",
-    "lineCount": 583,
+    "lineCount": 784,
     "axiomCount": 0,
-    "theoremCount": 8,
+    "theoremCount": 13,
     "definitionCount": 1,
     "path": "Proofs/Erdos476OQ05Problem.lean",
-    "sorries": 2
+    "sorries": 1
   },
-  "sorries": 2
+  "sorries": 1
 }


### PR DESCRIPTION
## Audit Fix

**Proof**: erdos-476-oq-05 (Vosper's Theorem)

**Problem**: meta.json had stale values after research commit `983107d` proved `vosper_ap_sdiff_card` (position analysis via `linear_combination`) without updating meta.json.

## Evidence

| Field | meta.json (stale) | HEAD Lean file (actual) |
|-------|-------------------|------------------------|
| `sorries` | 2 | 1 |
| `lineCount` | 583 | 784 |
| `theoremCount` | 8 | 13 |
| `leanFile.sorries` | 2 | 1 |
| `leanFile.lineCount` | 583 | 784 |
| `leanFile.theoremCount` | 8 | 13 |

**Verification**: `git show HEAD:proofs/Proofs/Erdos476OQ05Problem.lean | grep -n "sorry"` shows only 1 actual sorry at line 754 (vosper Case 1 existence). The other grep hits are comments.

`vosper_ap_sdiff_card` (position analysis) is now fully proved via `linear_combination`, as confirmed by line 6 of the file header: "vosper_ap_sdiff_card proved (hpos: linear_combination)".

## Changes

- Sync all sorry/lineCount/theoremCount fields to match HEAD Lean file
- Update description, assumptions, originalContributions to reflect vosper_ap_sdiff_card being proved
- Update conclusion summary and open questions
- Update sections with correct line ranges

---
Discovered during gallery integrity audit.