### PR TITLE
Fix: sync stale leanFile.lineCount in 53 gallery meta.json files

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-02/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02/meta.json
@@ -168,7 +168,7 @@
       "Cardinal"
     ],
     "namespace": "AlgebraicNumbersCountableOQ02",
-    "lineCount": 193,
+    "lineCount": 192,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 1,

--- a/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01/meta.json
@@ -176,7 +176,7 @@
       "Finset"
     ],
     "namespace": "PowerMeanCrossZero",
-    "lineCount": 226,
+    "lineCount": 225,
     "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 0,

--- a/src/data/proofs/amgm-inequality-oq-03-oq-04/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-04/meta.json
@@ -178,7 +178,7 @@
     ],
     "opens": [],
     "namespace": "RenyiPowerMean",
-    "lineCount": 233,
+    "lineCount": 232,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 2,

--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-01/meta.json
@@ -158,7 +158,7 @@
       "FiniteDimensional"
     ],
     "namespace": "AngleTrisectionCos20GalOQ01",
-    "lineCount": 417,
+    "lineCount": 416,
     "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 0,

--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-03-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-03-oq-01/meta.json
@@ -184,7 +184,7 @@
       "FiniteDimensional"
     ],
     "namespace": "AngleTrisectionCos20GalOQ03OQ01",
-    "lineCount": 463,
+    "lineCount": 462,
     "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 0,

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -164,7 +164,7 @@
       "UnitBallRecurrence"
     ],
     "namespace": "BallVolumeTendsto",
-    "lineCount": 164,
+    "lineCount": 163,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 0,

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-03-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-03-oq-03/meta.json
@@ -148,7 +148,7 @@
       "intervalIntegral"
     ],
     "namespace": "SteinerFormulaNBall",
-    "lineCount": 303,
+    "lineCount": 302,
     "axiomCount": 0,
     "theoremCount": 15,
     "definitionCount": 3,

--- a/src/data/proofs/area-of-circle-oq-05-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-02/meta.json
@@ -134,7 +134,7 @@
       "Finset"
     ],
     "namespace": "MultivariateGaussian",
-    "lineCount": 190,
+    "lineCount": 189,
     "axiomCount": 0,
     "theoremCount": 2,
     "definitionCount": 0,

--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-01/meta.json
@@ -189,7 +189,7 @@
       "MulAction"
     ],
     "namespace": "PolyaEnumeration",
-    "lineCount": 508,
+    "lineCount": 507,
     "axiomCount": 0,
     "theoremCount": 27,
     "definitionCount": 4,

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02/meta.json
@@ -134,7 +134,7 @@
       "BigOperators"
     ],
     "namespace": "MultisetVandermonde",
-    "lineCount": 119,
+    "lineCount": 118,
     "axiomCount": 0,
     "theoremCount": 3,
     "definitionCount": 0,

--- a/src/data/proofs/basel-problem-oq-04/meta.json
+++ b/src/data/proofs/basel-problem-oq-04/meta.json
@@ -146,7 +146,7 @@
       "Filter"
     ],
     "namespace": "BaselProblemOQ04",
-    "lineCount": 108,
+    "lineCount": 107,
     "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 0,

--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02/meta.json
@@ -147,7 +147,7 @@
       "Zsqrtd"
     ],
     "namespace": "GaussianIntEuclidean",
-    "lineCount": 194,
+    "lineCount": 193,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 0,

--- a/src/data/proofs/bezout-identity-oq-02-oq-04/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-04/meta.json
@@ -166,7 +166,7 @@
       "Polynomial"
     ],
     "namespace": "BezoutIdentityOQ02OQ04",
-    "lineCount": 171,
+    "lineCount": 170,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 0,

--- a/src/data/proofs/bezout-identity-oq-03-oq-04-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-04-oq-01/meta.json
@@ -133,7 +133,7 @@
     ],
     "opens": [],
     "namespace": "BezoutIdentityOQ03OQ04OQ01",
-    "lineCount": 130,
+    "lineCount": 129,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 1,

--- a/src/data/proofs/bezout-identity-oq-04-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-04-oq-02/meta.json
@@ -139,7 +139,7 @@
       "EuclideanDomain"
     ],
     "namespace": "BezoutIdentityOQ04OQ02",
-    "lineCount": 139,
+    "lineCount": 138,
     "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 0,

--- a/src/data/proofs/binomial-theorem-oq-02-oq-04/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-04/meta.json
@@ -181,7 +181,7 @@
       "Nat"
     ],
     "namespace": "BinomialTheoremOQ02OQ04",
-    "lineCount": 208,
+    "lineCount": 207,
     "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 0,

--- a/src/data/proofs/birthday-problem-oq-03/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03/meta.json
@@ -226,7 +226,7 @@
     ],
     "opens": [],
     "namespace": "BirthdayKWay",
-    "lineCount": 369,
+    "lineCount": 368,
     "axiomCount": 0,
     "theoremCount": 19,
     "definitionCount": 4,

--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-01/meta.json
@@ -139,7 +139,7 @@
     ],
     "opens": [],
     "namespace": "CantorDiagonalizationOQ03OQ01",
-    "lineCount": 304,
+    "lineCount": 303,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 4,

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -151,7 +151,7 @@
       "PowerMeanCrossZero"
     ],
     "namespace": "PowerMeanMonotone",
-    "lineCount": 194,
+    "lineCount": 193,
     "axiomCount": 0,
     "theoremCount": 9,
     "definitionCount": 0,

--- a/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json
@@ -155,7 +155,7 @@
       "BigOperators"
     ],
     "namespace": "CayleyHamiltonReductionOQ02OQ01",
-    "lineCount": 397,
+    "lineCount": 396,
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 1,

--- a/src/data/proofs/derangements-convergence-oq-01/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-01/meta.json
@@ -142,7 +142,7 @@
       "Topology"
     ],
     "namespace": "KFixedConvergence",
-    "lineCount": 153,
+    "lineCount": 152,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 1,

--- a/src/data/proofs/divisibility-by-3-oq-03-oq-02/meta.json
+++ b/src/data/proofs/divisibility-by-3-oq-03-oq-02/meta.json
@@ -175,7 +175,7 @@
       "Nat"
     ],
     "namespace": "DigitalRootBase",
-    "lineCount": 212,
+    "lineCount": 211,
     "axiomCount": 0,
     "theoremCount": 19,
     "definitionCount": 1,

--- a/src/data/proofs/erdos-1179-oq-01/meta.json
+++ b/src/data/proofs/erdos-1179-oq-01/meta.json
@@ -223,7 +223,7 @@
       "Real"
     ],
     "namespace": "Erdos1179OQ01",
-    "lineCount": 710,
+    "lineCount": 709,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-1206/meta.json
+++ b/src/data/proofs/erdos-1206/meta.json
@@ -106,7 +106,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 24,
+    "lineCount": 23,
     "axiomCount": 0,
     "theoremCount": 1,
     "definitionCount": 0,

--- a/src/data/proofs/erdos-1211/meta.json
+++ b/src/data/proofs/erdos-1211/meta.json
@@ -116,7 +116,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 24,
+    "lineCount": 23,
     "axiomCount": 0,
     "theoremCount": 1,
     "definitionCount": 0,

--- a/src/data/proofs/erdos-1215/meta.json
+++ b/src/data/proofs/erdos-1215/meta.json
@@ -106,7 +106,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 24,
+    "lineCount": 23,
     "axiomCount": 0,
     "theoremCount": 1,
     "definitionCount": 0,

--- a/src/data/proofs/erdos-1216/meta.json
+++ b/src/data/proofs/erdos-1216/meta.json
@@ -106,7 +106,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 24,
+    "lineCount": 23,
     "axiomCount": 0,
     "theoremCount": 1,
     "definitionCount": 0,

--- a/src/data/proofs/erdos-327-oq-01-oq-04/meta.json
+++ b/src/data/proofs/erdos-327-oq-01-oq-04/meta.json
@@ -134,7 +134,7 @@
       "Nat"
     ],
     "namespace": "Erdos327OQ01OQ04",
-    "lineCount": 88,
+    "lineCount": 87,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 1,

--- a/src/data/proofs/fundamental-arithmetic-oq-02/meta.json
+++ b/src/data/proofs/fundamental-arithmetic-oq-02/meta.json
@@ -123,7 +123,7 @@
       "Zsqrtd"
     ],
     "namespace": "FundamentalArithmeticOQ02",
-    "lineCount": 193,
+    "lineCount": 192,
     "axiomCount": 0,
     "theoremCount": 17,
     "definitionCount": 2,

--- a/src/data/proofs/furstenberg-correspondence-oq-02/meta.json
+++ b/src/data/proofs/furstenberg-correspondence-oq-02/meta.json
@@ -167,7 +167,7 @@
       "MeasurableSpace"
     ],
     "namespace": "FurstenbergOQ02",
-    "lineCount": 414,
+    "lineCount": 413,
     "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 2,

--- a/src/data/proofs/geometric-series-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-01/meta.json
@@ -216,7 +216,7 @@
       "Filter"
     ],
     "namespace": "GeometricSeriesOQ01",
-    "lineCount": 251,
+    "lineCount": 250,
     "axiomCount": 0,
     "theoremCount": 13,
     "definitionCount": 1,

--- a/src/data/proofs/geometric-series-oq-03/meta.json
+++ b/src/data/proofs/geometric-series-oq-03/meta.json
@@ -172,7 +172,7 @@
       "BigOperators"
     ],
     "namespace": "GeometricSeriesOQ03",
-    "lineCount": 216,
+    "lineCount": 215,
     "axiomCount": 0,
     "theoremCount": 15,
     "definitionCount": 0,

--- a/src/data/proofs/konigsberg-oq-03-oq-02/meta.json
+++ b/src/data/proofs/konigsberg-oq-03-oq-02/meta.json
@@ -136,7 +136,7 @@
     ],
     "opens": [],
     "namespace": "KonigsbergOQ03OQ02",
-    "lineCount": 185,
+    "lineCount": 184,
     "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 10,

--- a/src/data/proofs/law-of-sines-oq-06/meta.json
+++ b/src/data/proofs/law-of-sines-oq-06/meta.json
@@ -161,7 +161,7 @@
       "RealInnerProductSpace"
     ],
     "namespace": "LawOfSines",
-    "lineCount": 310,
+    "lineCount": 309,
     "axiomCount": 0,
     "theoremCount": 24,
     "definitionCount": 8,

--- a/src/data/proofs/leibniz-pi-oq-01-oq-01/meta.json
+++ b/src/data/proofs/leibniz-pi-oq-01-oq-01/meta.json
@@ -206,7 +206,7 @@
       "Real"
     ],
     "namespace": "MachinFromAddition",
-    "lineCount": 98,
+    "lineCount": 97,
     "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 0,

--- a/src/data/proofs/lhopital-oq-02/meta.json
+++ b/src/data/proofs/lhopital-oq-02/meta.json
@@ -152,7 +152,7 @@
       "Real"
     ],
     "namespace": "LHopitalInfty",
-    "lineCount": 429,
+    "lineCount": 428,
     "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 0,

--- a/src/data/proofs/morleys-theorem/meta.json
+++ b/src/data/proofs/morleys-theorem/meta.json
@@ -244,7 +244,7 @@
       "Real"
     ],
     "namespace": "MorleysTheorem",
-    "lineCount": 533,
+    "lineCount": 532,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 11,

--- a/src/data/proofs/napoleons-theorem/meta.json
+++ b/src/data/proofs/napoleons-theorem/meta.json
@@ -162,7 +162,7 @@
       "Real"
     ],
     "namespace": "NapoleonsTheorem",
-    "lineCount": 355,
+    "lineCount": 354,
     "axiomCount": 0,
     "theoremCount": 15,
     "definitionCount": 10,

--- a/src/data/proofs/partition-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/partition-theorem-oq-01-oq-01/meta.json
@@ -159,7 +159,7 @@
       "RogersRamanujan"
     ],
     "namespace": "PartitionTheoremOQ01OQ01",
-    "lineCount": 72,
+    "lineCount": 71,
     "axiomCount": 0,
     "theoremCount": 19,
     "definitionCount": 0,

--- a/src/data/proofs/prime-reciprocal-divergence-oq-03/meta.json
+++ b/src/data/proofs/prime-reciprocal-divergence-oq-03/meta.json
@@ -149,7 +149,7 @@
       "Nat"
     ],
     "namespace": "ErdosElementary",
-    "lineCount": 389,
+    "lineCount": 388,
     "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 4,

--- a/src/data/proofs/ptolemys-theorem-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01-incomplete-01/meta.json
@@ -157,7 +157,7 @@
       "Real"
     ],
     "namespace": "PtolemysTheoremOQ01Incomplete01",
-    "lineCount": 490,
+    "lineCount": 489,
     "axiomCount": 0,
     "theoremCount": 2,
     "definitionCount": 0,

--- a/src/data/proofs/schroeder-bernstein-oq-03/meta.json
+++ b/src/data/proofs/schroeder-bernstein-oq-03/meta.json
@@ -236,7 +236,7 @@
       "Computable"
     ],
     "namespace": "MyhillIsomorphism",
-    "lineCount": 258,
+    "lineCount": 257,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 4,

--- a/src/data/proofs/shapley-folkman/meta.json
+++ b/src/data/proofs/shapley-folkman/meta.json
@@ -204,7 +204,7 @@
       "Pointwise"
     ],
     "namespace": "ShapleyFolkman",
-    "lineCount": 814,
+    "lineCount": 813,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 1,

--- a/src/data/proofs/sophie-germain-oq-02/meta.json
+++ b/src/data/proofs/sophie-germain-oq-02/meta.json
@@ -158,7 +158,7 @@
       "Finset"
     ],
     "namespace": "SophieGermainOQ02",
-    "lineCount": 157,
+    "lineCount": 156,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 3,

--- a/src/data/proofs/spherical-law-of-sines/meta.json
+++ b/src/data/proofs/spherical-law-of-sines/meta.json
@@ -120,7 +120,7 @@
       "Real"
     ],
     "namespace": "SphericalLawOfSines",
-    "lineCount": 324,
+    "lineCount": 323,
     "axiomCount": 0,
     "theoremCount": 21,
     "definitionCount": 7,

--- a/src/data/proofs/sqrt2-minpoly-oq-01/meta.json
+++ b/src/data/proofs/sqrt2-minpoly-oq-01/meta.json
@@ -173,7 +173,7 @@
       "CubeRoot2IrrationalOQ03"
     ],
     "namespace": "Sqrt2MinpolyOQ01",
-    "lineCount": 253,
+    "lineCount": 252,
     "axiomCount": 0,
     "theoremCount": 17,
     "definitionCount": 0,

--- a/src/data/proofs/sqrt2-minpoly-oq-02/meta.json
+++ b/src/data/proofs/sqrt2-minpoly-oq-02/meta.json
@@ -198,7 +198,7 @@
       "IntermediateField"
     ],
     "namespace": "CubeRoot2IrrationalOQ03",
-    "lineCount": 205,
+    "lineCount": 204,
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 0,

--- a/src/data/proofs/sylow-theorems-oq-04/meta.json
+++ b/src/data/proofs/sylow-theorems-oq-04/meta.json
@@ -198,7 +198,7 @@
       "Equiv.Perm"
     ],
     "namespace": "SylowA5",
-    "lineCount": 277,
+    "lineCount": 276,
     "axiomCount": 0,
     "theoremCount": 21,
     "definitionCount": 0,

--- a/src/data/proofs/sylow-theorems/meta.json
+++ b/src/data/proofs/sylow-theorems/meta.json
@@ -306,7 +306,7 @@
       "Subgroup"
     ],
     "namespace": "SylowTheorems",
-    "lineCount": 247,
+    "lineCount": 246,
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 1,

--- a/src/data/proofs/taylor-sincos-convergence-oq-01/meta.json
+++ b/src/data/proofs/taylor-sincos-convergence-oq-01/meta.json
@@ -243,7 +243,7 @@
       "TaylorSinCosConvergence"
     ],
     "namespace": "TaylorSinCosConvergenceOQ01",
-    "lineCount": 239,
+    "lineCount": 238,
     "axiomCount": 0,
     "theoremCount": 9,
     "definitionCount": 0,

--- a/src/data/proofs/triangle-angle-sum-oq-03/meta.json
+++ b/src/data/proofs/triangle-angle-sum-oq-03/meta.json
@@ -163,7 +163,7 @@
       "Classical"
     ],
     "namespace": "TriangleAngleSumOQ03",
-    "lineCount": 141,
+    "lineCount": 140,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 0,

--- a/src/data/proofs/vietas-formulas-oq-03-oq-05/meta.json
+++ b/src/data/proofs/vietas-formulas-oq-03-oq-05/meta.json
@@ -175,7 +175,7 @@
     ],
     "opens": [],
     "namespace": "QuarticDiscriminant",
-    "lineCount": 305,
+    "lineCount": 304,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 3,

--- a/src/data/proofs/wilsons-theorem-oq-03/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-03/meta.json
@@ -176,7 +176,7 @@
       "Nat"
     ],
     "namespace": "WilsonsTheoremLegendre",
-    "lineCount": 223,
+    "lineCount": 222,
     "axiomCount": 0,
     "theoremCount": 9,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Corrected `leanFile.lineCount` in 53 gallery `meta.json` files where the stored value was 1 higher than the actual `wc -l` count.

## Evidence

**Before**: 53 gallery proofs had `lineCount` values that were 1 too high (e.g., `meta=192, actual=191`)
**After**: All `lineCount` values match the actual `wc -l` count of their corresponding `.lean` files
**Verification**: `pnpm build` passes (exit 0, built in 9m 16s)

## Pattern

All mismatches were systematic off-by-one in the same direction — all files had `meta = actual + 1`. This was a batch metadata generation artifact.

---
Automated fix by lean-mechanic agent.