### PR TITLE
Fix: remove conflict markers from erdos-165 files

### DIFF
--- a/proofs/Proofs/Erdos165Problem.lean
+++ b/proofs/Proofs/Erdos165Problem.lean
@@ -1,5 +1,4 @@
 /-
-<<<<<<< HEAD
   Erdős Problem #165: Asymptotic Formula for R(3,k)
 
   Source: https://erdosproblems.com/165
@@ -30,40 +29,6 @@
     [BK21]  Bohman-Keevash, "The early evolution of the H-free process" (2021)
     [CJMS25] Campos-Jenssen-Michelen-Sahasrabudhe, "A new lower bound for R(3,k)" (2025)
     [HHKP25] Hefty-Horn-King-Pfender, "Improving R(3,k) in just two bites" (2025)
-=======
-Erdős Problem #165: Asymptotic Formula for R(3,k)
-
-Source: https://erdosproblems.com/165
-Status: SOLVED
-Prize: $250
-
-Statement:
-Give an asymptotic formula for R(3,k).
-
-It is known that:
-  (c + o(1)) · k²/log k ≤ R(3,k) ≤ (1 + o(1)) · k²/log k
-
-The question asks: what is the exact value of c?
-
-Key Results:
-- Upper bound: Shearer (1983), improving Ajtai-Komlós-Szemerédi (1980)
-  R(3,k) ≤ (1 + o(1)) · k²/log k
-
-- Lower bound history:
-  - Kim (1995): c ≥ 1/162 (breakthrough using semi-random method)
-  - Bohman-Keevash (2021): c ≥ 1/4
-  - Pontiveros-Griffiths-Morris (2020): c ≥ 1/4
-  - Campos-Jenssen-Michelen-Sahasrabudhe (2025): c ≥ 1/3
-  - Hefty-Horn-King-Pfender (2025): c ≥ 1/2
-
-Conjecture: c = 1/2, meaning R(3,k) ~ (1/2) · k²/log k
-
-References:
-- Ajtai, Komlós, Szemerédi: "A note on Ramsey numbers" (1980)
-- Shearer: "A note on the independence number of triangle-free graphs" (1983)
-- Kim: "The Ramsey number R(3,t) has order of magnitude t²/log t" (1995)
-- Campos et al.: "A new lower bound for R(3,k)" (2025)
->>>>>>> 565ec31b7a (Enrich erdos-165: promote Lean file from Stubs to main Proofs directory)
 -/
 
 import Mathlib.Combinatorics.SimpleGraph.Basic
@@ -76,7 +41,6 @@ open Real
 
 namespace Erdos165
 
-<<<<<<< HEAD
 /- ## Part I: Ramsey Numbers — Basic Definitions -/
 
 /-- The Ramsey number R(m,n): the minimum N such that any 2-coloring of the
@@ -186,165 +150,11 @@ theorem current_best_bounds :
     Explicit witnesses: c₁ = 1/4 (from HHKP with ε = 1/4) and c₂ = 2
     (from Shearer with ε = 1). -/
 theorem erdos_165 :
-=======
-/-
-## Part I: Ramsey Numbers — Basic Definitions
-
-R(m,n) is the minimum N such that any 2-coloring of K_N contains
-either a red K_m or a blue K_n.
--/
-
-/-- The Ramsey number R(m,n): minimum N such that any 2-coloring of K_N
-    contains a red clique of size m or a blue clique of size n.
-
-    Axiomatized since the exact definition requires graph coloring machinery. -/
-axiom ramseyNumber (m n : ℕ) : ℕ
-
-/-- Symmetry of Ramsey numbers: R(m,n) = R(n,m) -/
-axiom ramsey_symm (m n : ℕ) : ramseyNumber m n = ramseyNumber n m
-
-/-
-### Basic Properties: Base Cases
--/
-
-/-- R(1,n) = 1: any single vertex trivially contains K₁ -/
-axiom ramsey_one_left (n : ℕ) : ramseyNumber 1 n = 1
-/-- R(2,n) = n: need n vertices to force an edge or n-independent-set -/
-axiom ramsey_two_left (n : ℕ) : ramseyNumber 2 n = n
-
-/-- Recurrence: R(m,n) ≤ R(m-1,n) + R(m,n-1) for m,n ≥ 2 -/
-axiom ramsey_recurrence (m n : ℕ) (hm : m ≥ 2) (hn : n ≥ 2) :
-    ramseyNumber m n ≤ ramseyNumber (m - 1) n + ramseyNumber m (n - 1)
-
-/-
-## Part II: R(3,k) — The Triangle vs Independent Set Ramsey Number
-
-R(3,k) is the focus of this problem: minimum N such that any graph on N
-vertices contains either a triangle (K₃) or an independent set of size k.
--/
-
-/-- R(3,k): minimum N such that any graph on N vertices contains
-    either a triangle or an independent set of size k. -/
-noncomputable def R3 (k : ℕ) : ℕ := ramseyNumber 3 k
-
-/-
-### Small Values of R(3,k)
-
-Exact values are known for k ≤ 9. Beyond that, exact determination is open.
-  R(3,3)=6, R(3,4)=9, R(3,5)=14, R(3,6)=18, R(3,7)=23, R(3,8)=28, R(3,9)=36
--/
-
-/-- Exact value: R(3,3) = 6 -/
-axiom R3_3 : R3 3 = 6
-/-- Exact value: R(3,4) = 9 -/
-axiom R3_4 : R3 4 = 9
-
-/-
-## Part III: Upper Bounds
-
-The upper bound comes from analyzing the independence number of triangle-free graphs.
--/
-
-/-
-### Ajtai-Komlós-Szemerédi Theorem (1980)
--/
-
-/--
-**Ajtai-Komlós-Szemerédi Theorem (1980):**
-R(3,k) = O(k²/log k).
-
-The first result establishing R(3,k) = o(k²). Proved using probabilistic
-arguments and the Lovász Local Lemma, introducing the log-denominator.
--/
-axiom aks_upper_bound :
-    ∃ C : ℝ, C > 0 ∧ ∀ k : ℕ, k ≥ 2 → (R3 k : ℝ) ≤ C * k^2 / log k
-
-/-
-### Shearer's Theorem (1983)
--/
-
-/--
-**Shearer's Theorem (1983):**
-R(3,k) ≤ (1 + o(1)) · k² / log k.
-
-This is essentially the tight upper bound: the leading coefficient 1
-cannot be improved by more than o(1). Proved using an entropy method
-relating the independence number of triangle-free graphs to the log.
--/
-axiom shearer_upper_bound :
-    ∀ ε > 0, ∃ k₀ : ℕ, ∀ k : ℕ, k ≥ k₀ → (R3 k : ℝ) ≤ (1 + ε) * k^2 / log k
-
-/-
-## Part IV: Lower Bounds — The History of Constant c
-
-The challenge: show R(3,k) ≥ c · k² / log k for as large c as possible.
-30 years of progress from Kim's c ≥ 1/162 to HHKP's c ≥ 1/2.
--/
-
-/-
-### Kim's Theorem (1995): The Breakthrough
--/
-
-/--
-**Kim's Theorem (1995) — Prize-Winning Breakthrough:**
-R(3,k) = Ω(k²/log k).
-
-Kim introduced the **triangle-free process** (semi-random method):
-start with an empty graph and greedily add random edges that avoid triangles.
-The resulting graphs have high density and small independence number.
-Original constant: c ≥ 1/162. This established the correct order of magnitude
-R(3,k) = Θ(k²/log k) and claimed the $250 Erdős prize.
--/
-axiom kim_lower_bound :
-    ∃ c : ℝ, c > 0 ∧ ∀ ε > 0, ∃ k₀ : ℕ,
-      ∀ k : ℕ, k ≥ k₀ → (R3 k : ℝ) ≥ (c - ε) * k^2 / log k
-
-/--
-**Bohman-Keevash (2021) / Pontiveros-Griffiths-Morris (2020):**
-c ≥ 1/4, proved independently by two groups.
-
-Used differential equation methods to track the evolution of the triangle-free
-process more precisely. Both groups conjectured c = 1/4 is optimal (PGM conjecture).
--/
-axiom bohman_keevash_lower :
-    ∀ ε > 0, ∃ k₀ : ℕ, ∀ k : ℕ, k ≥ k₀ → (R3 k : ℝ) ≥ (1/4 - ε) * k^2 / log k
-
-/--
-**Campos-Jenssen-Michelen-Sahasrabudhe (2025):**
-c ≥ 1/3.
-
-Used new structural insight about independent sets in triangle-free graphs
-to surpass the PGM barrier. This disproved the PGM conjecture (c = 1/4).
--/
-axiom cjms_lower :
-    ∀ ε > 0, ∃ k₀ : ℕ, ∀ k : ℕ, k ≥ k₀ → (R3 k : ℝ) ≥ (1/3 - ε) * k^2 / log k
-
-/--
-**Hefty-Horn-King-Pfender (2025):**
-Current best: c ≥ 1/2.
-
-Paper title: "Improving R(3,k) in just two bites."
-Both CJMS and HHKP conjecture c = 1/2 is the true asymptotic constant.
--/
-axiom hhkp_bound :
-    ∀ ε > 0, ∃ k₀ : ℕ, ∀ k : ℕ, k ≥ k₀ → (R3 k : ℝ) ≥ (1/2 - ε) * k^2 / log k
-
-/-
-## Part V: The Main Asymptotic Result
-
-Combining upper and lower bounds to establish R(3,k) = Θ(k²/log k).
--/
-
-/-- The asymptotic order of R(3,k): there exist positive constants c₁, c₂
-    such that c₁ · k²/log k ≤ R(3,k) ≤ c₂ · k²/log k for sufficiently large k. -/
-theorem R3_asymptotic_order :
->>>>>>> 565ec31b7a (Enrich erdos-165: promote Lean file from Stubs to main Proofs directory)
     ∃ c₁ c₂ : ℝ, c₁ > 0 ∧ c₂ > 0 ∧
       ∃ k₀ : ℕ, ∀ k : ℕ, k ≥ k₀ →
         c₁ * k^2 / log k ≤ R3 k ∧ (R3 k : ℝ) ≤ c₂ * k^2 / log k := by
   use 1/4, 2
   refine ⟨by norm_num, by norm_num, ?_⟩
-<<<<<<< HEAD
   obtain ⟨k₀, hk₀⟩ := current_best_bounds (1/4) (by norm_num)
   exact ⟨k₀, fun k hk => by
     obtain ⟨hl, hu⟩ := hk₀ k hk
@@ -381,69 +191,20 @@ equations and more refined methods.
     Equivalently, c = 1/2 is the exact constant. The upper bound constant is 1
     (from Shearer), so this would mean the true ratio converges to 1/2, leaving
     a factor of 2 gap in the constants. -/
-=======
-  obtain ⟨k₁, hk₁⟩ := hhkp_bound (1/4) (by norm_num)
-  obtain ⟨k₂, hk₂⟩ := shearer_upper_bound 1 one_pos
-  use max k₁ k₂
-  intro k hk
-  constructor
-  · linarith [hk₁ k (le_of_max_le_left hk)]
-  · linarith [hk₂ k (le_of_max_le_right hk)]
-
-/-- The current best explicit bounds (2025 state of the art):
-    (1/2 - o(1)) · k²/log k ≤ R(3,k) ≤ (1 + o(1)) · k²/log k -/
-axiom current_best_bounds :
-    ∀ ε > 0, ∃ k₀ : ℕ, ∀ k : ℕ, k ≥ k₀ →
-      (1/2 - ε) * k^2 / log k ≤ R3 k ∧ (R3 k : ℝ) ≤ (1 + ε) * k^2 / log k
-
-/-
-## Part VI: The Triangle-Free Process
-
-The probabilistic construction underlying all lower bounds.
--/
-
-/-- The triangle-free process: greedily add random edges avoiding triangles.
-    This process produces triangle-free graphs with small independence number,
-    providing the key construction for lower bounds on R(3,k). -/
-axiom TriangleFreeProcess : ℕ → Type
-
-/-- The triangle-free process graph has small independence number relative to k -/
-axiom tfp_independence_bound :
-    ∀ k : ℕ, k ≥ 2 →
-      ∃ n : ℕ, (k^2 / log k : ℝ) ≤ n ∧
-        ∃ _ : TriangleFreeProcess n, True  -- independence number < k
-
-/-
-## Part VII: Conjectures and Open Questions
--/
-
-/--
-**Main Conjecture (CJMS 2025 + HHKP 2025):**
-R(3,k) ~ (1/2) · k² / log k
-
-Both groups conjecture c = 1/2 is the true asymptotic constant.
--/
->>>>>>> 565ec31b7a (Enrich erdos-165: promote Lean file from Stubs to main Proofs directory)
 def mainConjecture : Prop :=
     ∀ ε > 0, ∃ k₀ : ℕ, ∀ k : ℕ, k ≥ k₀ →
       (1/2 - ε) * k^2 / log k ≤ R3 k ∧ (R3 k : ℝ) ≤ (1/2 + ε) * k^2 / log k
 
-<<<<<<< HEAD
 /-- The PGM Conjecture (Pontiveros-Griffiths-Morris 2020):
     R(3,k) ~ (1/4) · k²/log k.
 
     This was the leading conjecture before CJMS and HHKP 2025.
     It has been superseded: since R(3,k) ≥ (1/2 - o(1))k²/log k (HHKP),
     the PGM upper bound (1/4 + ε)k²/log k is now known to be wrong. -/
-=======
-/-- The PGM conjecture (Pontiveros-Griffiths-Morris 2020): c = 1/4.
-    **DISPROVED** by Campos-Jenssen-Michelen-Sahasrabudhe (2025) who showed c ≥ 1/3. -/
->>>>>>> 565ec31b7a (Enrich erdos-165: promote Lean file from Stubs to main Proofs directory)
 def pgmConjecture : Prop :=
     ∀ ε > 0, ∃ k₀ : ℕ, ∀ k : ℕ, k ≥ k₀ →
       (1/4 - ε) * k^2 / log k ≤ R3 k ∧ (R3 k : ℝ) ≤ (1/4 + ε) * k^2 / log k
 
-<<<<<<< HEAD
 /-
 **Why the PGM Conjecture is Refuted**
 
@@ -475,75 +236,4 @@ careful handling of the k²/log k positivity argument, using div_pos and log_pos
   2-coloring of K_n if the graph is not triangle-free?
 -/
 
-=======
-/-- The PGM conjecture is false: CJMS showed R(3,k) ≥ (1/3 - o(1)) · k²/log k,
-    which is inconsistent with the upper bound in pgmConjecture. -/
-theorem pgm_conjecture_false : ¬pgmConjecture := by
-  intro h
-  obtain ⟨k₀, hk₀⟩ := h (1/12) (by norm_num)
-  obtain ⟨k₁, hk₁⟩ := cjms_lower (1/12) (by norm_num)
-  -- At k = max k₀ k₁, we get R3 k ≥ (1/3 - 1/12) · k²/log k = 1/4 · k²/log k
-  -- but also R3 k ≤ (1/4 + 1/12) · k²/log k = 1/3 · k²/log k from pgmConjecture
-  -- This is consistent, but the contradiction comes from c ≥ 1/3 > 1/4
-  -- The precise refutation requires knowing log k > 0 for large k
-  sorry
-
-/-
-## Part VIII: Related Problems
--/
-
-/-
-### Erdős Problem #544: Diagonal Ramsey Numbers R(k,k)
-
-The general diagonal Ramsey number satisfies:
-  2^(k/2) ≤ R(k,k) ≤ 4^k
-Closing this exponential gap is one of the most important open problems.
--/
-
-/-
-### Erdős Problem #986: Off-Diagonal R(s,k) for Fixed s
-
-For fixed s ≥ 3: R(s,k) = Θ(k^(s-1) / (log k)^(s-2)).
-The case s = 3 is exactly Problem #165.
--/
-
-/-
-## Part IX: Main Results Summary
--/
-
-/-- **Erdős Problem #165: SOLVED (asymptotic order)**
-
-    Answer: R(3,k) = Θ(k² / log k)
-
-    Upper bound: R(3,k) ≤ (1 + o(1)) · k² / log k  [Shearer 1983]
-    Lower bound: R(3,k) ≥ (1/2 - o(1)) · k² / log k  [Hefty et al. 2025]
-
-    The exact constant c in R(3,k) ~ c · k² / log k remains open.
-    Current conjecture: c = 1/2.
-    Current best: 1/2 ≤ c ≤ 1 (where upper bound 1 is from Shearer). -/
-theorem erdos_165 : ∃ c₁ c₂ : ℝ, c₁ > 0 ∧ c₂ > 0 ∧
-    (∀ ε > 0, ∃ k₀ : ℕ, ∀ k : ℕ, k ≥ k₀ →
-      (c₁ - ε) * k^2 / log k ≤ R3 k ∧ (R3 k : ℝ) ≤ (c₂ + ε) * k^2 / log k) := by
-  use 1/2, 1
-  constructor
-  · norm_num
-  constructor
-  · norm_num
-  intro ε hε
-  obtain ⟨k₁, hk₁⟩ := hhkp_bound ε hε
-  obtain ⟨k₂, hk₂⟩ := shearer_upper_bound ε hε
-  use max k₁ k₂
-  intro k hk
-  constructor
-  · exact hk₁ k (le_of_max_le_left hk)
-  · exact hk₂ k (le_of_max_le_right hk)
-
-/-- The prize ($250) was claimed by Kim (1995) for establishing the asymptotic order.
-    The exact constant c = 1/2 (if correct) remains to be proved. -/
-theorem prize_claimed : ∃ c₁ c₂ : ℝ, c₁ > 0 ∧ c₂ > 0 ∧
-    ∃ k₀ : ℕ, ∀ k : ℕ, k ≥ k₀ →
-      c₁ * k^2 / log k ≤ R3 k ∧ (R3 k : ℝ) ≤ c₂ * k^2 / log k :=
-  R3_asymptotic_order
-
->>>>>>> 565ec31b7a (Enrich erdos-165: promote Lean file from Stubs to main Proofs directory)
 end Erdos165

--- a/src/data/proofs/erdos-165/meta.json
+++ b/src/data/proofs/erdos-165/meta.json
@@ -18,7 +18,7 @@
       "probabilistic-method"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 165,
     "erdosUrl": "https://erdosproblems.com/165",
     "erdosProblemStatus": "solved",
@@ -51,15 +51,9 @@
       "Main theorem combining upper and lower bounds",
       "Conjectures about exact constant c = 1/2"
     ],
-<<<<<<< HEAD
     "axiomCount": 10,
     "lineCount": 239,
     "assumptions": "10 axioms: ramseyNumber, ramseyNumber_symm, ramseyNumber_recurrence, R3_small_values, aks_upper_bound, shearer_upper_bound, kim_lower_bound, bk_pgm_bound, cjms_bound, hhkp_bound. 0 sorries.",
-=======
-    "axiomCount": 16,
-    "lineCount": 322,
-    "assumptions": "16 axiom(s) and 1 sorry(s).",
->>>>>>> 565ec31b7a (Enrich erdos-165: promote Lean file from Stubs to main Proofs directory)
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -163,21 +157,12 @@
       "Real"
     ],
     "namespace": "Erdos165",
-<<<<<<< HEAD
     "lineCount": 239,
     "axiomCount": 10,
     "theoremCount": 2,
     "definitionCount": 3,
     "path": "Proofs/Erdos165Problem.lean",
     "sorries": 0
-=======
-    "lineCount": 322,
-    "axiomCount": 16,
-    "theoremCount": 4,
-    "definitionCount": 3,
-    "path": "Proofs/Erdos165Problem.lean",
-    "sorries": 1
->>>>>>> 565ec31b7a (Enrich erdos-165: promote Lean file from Stubs to main Proofs directory)
   },
   "crossReferences": [
     {
@@ -222,5 +207,5 @@
       "note": "Alternative proof of Kim's bound via the triangle-free graph process"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Summary
- Cherry-pick merge of #11760 left git conflict markers in `proofs/Proofs/Erdos165Problem.lean` and `src/data/proofs/erdos-165/meta.json`
- Reverted to clean versions from #11740
- Fixes build failure caused by JSON parse error on conflict markers