### PR TITLE
Research: sqrt2-minpoly-oq-02 — dedicated Lean proof (0 sorries, 0 axioms)

### DIFF
--- a/proofs/Proofs/Erdos476OQ05Problem.lean
+++ b/proofs/Proofs/Erdos476OQ05Problem.lean
@@ -3,8 +3,8 @@ Erdős Problem #476, Open Question 5: Vosper's Theorem (1956)
 
 Source: Follow-up to erdos-476 (Erdős-Heilbronn conjecture)
 Status: PARTIAL — ap_of_near_periodic proved (orbit-cardinality argument);
-                   vosper_base proved; vosper_ap_sdiff_card structured (hpos sorry);
-                   isAP_sdiff_card proved; vosper_case1_exists sorryed
+                   vosper_base proved; vosper_ap_sdiff_card proved (hpos: linear_combination);
+                   isAP_sdiff_card proved; vosper_case1_exists sorryed (1 sorry remains)
 
 Statement (Vosper 1956):
 Let p be prime, A, B ⊆ Z/pZ with |A|, |B| ≥ 2.
@@ -27,6 +27,7 @@ import Mathlib.Combinatorics.Additive.CauchyDavenport
 import Mathlib.Data.ZMod.Basic
 import Mathlib.Data.Finset.Card
 import Mathlib.Data.Finset.NAry
+import Mathlib.Tactic.LinearCombination
 import Mathlib.Tactic.IntervalCases
 
 open Finset Function
@@ -131,7 +132,7 @@ private lemma add_isAP_eq {A B : Finset (ZMod p)} {a b d : ZMod p}
       · simp [Nat.min_eq_left h]; exact Finset.card_pos.mp hBpos
       · have : min k (A.card - 1) = A.card - 1 := Nat.min_eq_right (by omega)
         simp [this]; omega
-    have h_ij : i + j = k := Nat.min_add_sub_cancel' (by omega)
+    have h_ij : i + j = k := Nat.add_sub_cancel' (Nat.min_le_left k _)
     simp only [Finset.mem_add]
     refine ⟨a + (i : ZMod p) * d, ?_, b + (j : ZMod p) * d, ?_, ?_⟩
     · rw [hA]; simp only [Finset.mem_image, Finset.mem_range]; exact ⟨i, hi, rfl⟩
@@ -176,7 +177,8 @@ private lemma isAP_sdiff_card {A : Finset (ZMod p)} {a d : ZMod p}
         calc a + ((i - 1 : ℕ) : ZMod p) * d + d
             = a + (((i - 1 : ℕ) : ZMod p) + 1) * d := by rw [add_mul]; ring
           _ = a + (i : ZMod p) * d := by rw [hcast]
-  · rintro rfl
+  · intro hxa
+    rw [hxa]
     refine ⟨?_, ?_⟩
     · rw [hA]; simp only [Finset.mem_image, Finset.mem_range]
       exact ⟨0, hApos, by simp⟩
@@ -188,7 +190,9 @@ private lemma isAP_sdiff_card {A : Finset (ZMod p)} {a d : ZMod p}
         have h : a + ((j : ZMod p) + 1) * d = a + 0 := by
           simp only [add_zero, add_mul, one_mul, ← add_assoc]; exact hyd
         exact add_left_cancel h
-      have hzero : (j : ZMod p) + 1 = 0 := (mul_eq_zero.mp h_eq).resolve_right hd
+      have hzero : (j : ZMod p) + 1 = 0 := by
+        have hc : ((j : ZMod p) + 1) * d * d⁻¹ = 0 * d⁻¹ := by rw [h_eq]
+        rwa [mul_assoc, mul_inv_cancel₀ hd, mul_one, zero_mul] at hc
       have h_dvd : p ∣ j + 1 := by
         have hcast : ((j + 1 : ℕ) : ZMod p) = 0 := by
           rw [Nat.cast_add, Nat.cast_one]; exact hzero
@@ -224,7 +228,7 @@ private lemma vosper_ap_sdiff_card
   have hAP_a₀B : IsArithmeticProgression ({a₀} + B : Finset (ZMod p)) (a₀ + b₀) d :=
     isAP_sum (isAP_singleton a₀ d) hAP_B (by simp) hBpos (by rw [hcard_a₀B]; simp)
   -- |{a₀}+B \ (A'+B)| = 1: follows from |A+B| = |A'+B| + 1
-  have h_sdiff_one : ({a₀} + B \ ((A.erase a₀) + B) : Finset (ZMod p)).card = 1 := by
+  have h_sdiff_one : ((({a₀} + B) \ ((A.erase a₀) + B)) : Finset (ZMod p)).card = 1 := by
     have hunion : A + B = (A.erase a₀ + B) ∪ ({a₀} + B) := by
       ext x
       simp only [Finset.mem_add, Finset.mem_union]
@@ -245,7 +249,199 @@ private lemma vosper_ap_sdiff_card
     omega
   -- Position analysis: a₀ is a₁-d (predecessor) or a₁+|A'|*d (successor)
   have hpos : a₀ = a₁ - d ∨ a₀ = a₁ + ((A.erase a₀).card : ZMod p) * d := by
-    sorry -- HARD: position analysis from |{a₀}+B \ (A'+B)| = 1, both APs with diff d
+    -- Injectivity of k ↦ a₀+b₀+k*d on {0,...,|B|-1} (size < p)
+    have hBlt : B.card < p := by omega
+    have hinj_a₀B : Set.InjOn (fun k : ℕ => a₀ + b₀ + (k : ZMod p) * d)
+        (Finset.range B.card : Set ℕ) := by
+      intro k₁ hk₁ k₂ hk₂ heq
+      simp only [Finset.mem_coe, Finset.mem_range] at hk₁ hk₂
+      have hmul : (k₁ : ZMod p) * d = (k₂ : ZMod p) * d := add_left_cancel heq
+      have h_eq : (k₁ : ZMod p) = (k₂ : ZMod p) := by
+        have hc : (k₁ : ZMod p) * d * d⁻¹ = (k₂ : ZMod p) * d * d⁻¹ := by rw [hmul]
+        rwa [mul_assoc, mul_assoc, mul_inv_cancel₀ hd, mul_one, mul_one] at hc
+      have hk₁p : k₁ < p := lt_trans hk₁ hBlt
+      have hk₂p : k₂ < p := lt_trans hk₂ hBlt
+      have := congrArg ZMod.val h_eq
+      simp only [ZMod.val_natCast, Nat.mod_eq_of_lt hk₁p, Nat.mod_eq_of_lt hk₂p] at this
+      omega
+    -- Injectivity of j ↦ a₁+b₀+j*d on {0,...,|A'|+|B|-2}
+    have hA'Blt : (A.erase a₀).card + B.card - 1 < p := by omega
+    have hinj_A'B : Set.InjOn (fun j : ℕ => a₁ + b₀ + (j : ZMod p) * d)
+        (Finset.range ((A.erase a₀).card + B.card - 1) : Set ℕ) := by
+      intro j₁ hj₁ j₂ hj₂ heq
+      simp only [Finset.mem_coe, Finset.mem_range] at hj₁ hj₂
+      have hmul : (j₁ : ZMod p) * d = (j₂ : ZMod p) * d := add_left_cancel heq
+      have h_eq : (j₁ : ZMod p) = (j₂ : ZMod p) := by
+        have hc : (j₁ : ZMod p) * d * d⁻¹ = (j₂ : ZMod p) * d * d⁻¹ := by rw [hmul]
+        rwa [mul_assoc, mul_assoc, mul_inv_cancel₀ hd, mul_one, mul_one] at hc
+      have hj₁p : j₁ < p := lt_trans hj₁ hA'Blt
+      have hj₂p : j₂ < p := lt_trans hj₂ hA'Blt
+      have := congrArg ZMod.val h_eq
+      simp only [ZMod.val_natCast, Nat.mod_eq_of_lt hj₁p, Nat.mod_eq_of_lt hj₂p] at this
+      omega
+    -- Extract the unique sdiff element
+    obtain ⟨elem, helem_eq⟩ := Finset.card_eq_one.mp h_sdiff_one
+    have helem_mem : elem ∈ (({a₀} + B) \ ((A.erase a₀) + B) : Finset (ZMod p)) := by
+      rw [helem_eq]; exact Finset.mem_singleton_self elem
+    have helem_a₀B : elem ∈ ({a₀} + B : Finset (ZMod p)) :=
+      (Finset.mem_sdiff.mp helem_mem).1
+    have helem_notA'B : elem ∉ (A.erase a₀) + B := (Finset.mem_sdiff.mp helem_mem).2
+    -- elem = a₀+b₀+k₀*d for some k₀ < |B|
+    rw [hAP_a₀B] at helem_a₀B
+    simp only [Finset.mem_image, Finset.mem_range] at helem_a₀B
+    obtain ⟨k₀, hk₀B, hk₀_eq⟩ := helem_a₀B
+    -- All elements a₀+b₀+k*d for k ≠ k₀ are in A'+B (since sdiff = {elem})
+    have hall_in : ∀ k < B.card, k ≠ k₀ → a₀ + b₀ + (k : ZMod p) * d ∈ (A.erase a₀) + B := by
+      intro k hkB hkk₀
+      have hmem_a₀B : a₀ + b₀ + (k : ZMod p) * d ∈ ({a₀} + B : Finset (ZMod p)) := by
+        rw [hAP_a₀B]; simp only [Finset.mem_image, Finset.mem_range]; exact ⟨k, hkB, rfl⟩
+      by_contra hnotA'B
+      have hsd : a₀ + b₀ + (k : ZMod p) * d ∈ (({a₀} + B) \ ((A.erase a₀) + B) : Finset (ZMod p)) :=
+        Finset.mem_sdiff.mpr ⟨hmem_a₀B, hnotA'B⟩
+      rw [helem_eq] at hsd
+      simp only [Finset.mem_singleton] at hsd
+      exact hkk₀ (hinj_a₀B
+        (Finset.mem_coe.mpr (Finset.mem_range.mpr hkB))
+        (Finset.mem_coe.mpr (Finset.mem_range.mpr hk₀B))
+        (by rw [hsd, hk₀_eq]))
+    -- Helper: convert "in A'+B" to position j in range
+    have hmem_to_pos : ∀ x, x ∈ (A.erase a₀) + B →
+        ∃ j < (A.erase a₀).card + B.card - 1, x = a₁ + b₀ + (j : ZMod p) * d := by
+      intro x hx
+      rw [hAP_A'B] at hx
+      simp only [Finset.mem_image, Finset.mem_range] at hx
+      exact hx
+    -- Case split: k₀ = 0 (predecessor case) or k₀ = |B|-1 (successor case)
+    rcases Nat.eq_zero_or_pos k₀ with rfl | hk₀pos
+    · -- k₀ = 0: elem = a₀+b₀, which is NOT in A'+B
+      -- a₀+b₀+1*d IS in A'+B (since k=1 ≠ 0, |B|≥2)
+      left
+      have h1_in : a₀ + b₀ + (1 : ZMod p) * d ∈ (A.erase a₀) + B :=
+        hall_in 1 (by omega) (by omega)
+      obtain ⟨j₁, hj₁lt, hj₁_eq⟩ := hmem_to_pos _ h1_in
+      -- hj₁_eq: a₀+b₀+d = a₁+b₀+j₁*d  → a₀+d = a₁+j₁*d
+      -- Claim: j₁ = 0 (otherwise a₀+b₀ = a₁+b₀+(j₁-1)*d ∈ A'+B, contradicting helem_notA'B)
+      have hj₁_zero : j₁ = 0 := by
+        by_contra hj₁ne
+        have hj₁_pos : 0 < j₁ := Nat.pos_of_ne_zero hj₁ne
+        -- a₀+b₀ = a₁+b₀+(j₁-1)*d
+        have hpred_eq : a₀ + b₀ = a₁ + b₀ + ((j₁ - 1 : ℕ) : ZMod p) * d := by
+          have hcast : ((j₁ - 1 : ℕ) : ZMod p) + 1 = (j₁ : ZMod p) := by
+            have h := Nat.sub_add_cancel hj₁_pos
+            have := congrArg (Nat.cast (R := ZMod p)) h
+            rwa [Nat.cast_add, Nat.cast_one] at this
+          simp only [one_mul] at hj₁_eq
+          linear_combination hj₁_eq - d * hcast
+        -- a₀+b₀ ∈ A'+B (since j₁-1 < |A'|+|B|-1)
+        have hpred_in : a₀ + b₀ ∈ (A.erase a₀) + B := by
+          rw [hAP_A'B]; simp only [Finset.mem_image, Finset.mem_range]
+          exact ⟨j₁ - 1, by omega, hpred_eq⟩
+        -- But a₀+b₀ = elem (since k₀=0, hk₀_eq says elem = a₀+b₀+0*d = a₀+b₀)
+        have helem_eq' : elem = a₀ + b₀ := by rw [hk₀_eq]; simp
+        exact helem_notA'B (helem_eq' ▸ hpred_in)
+      -- j₁ = 0: a₀+b₀+d = a₁+b₀ → a₀ = a₁-d
+      rw [hj₁_zero] at hj₁_eq
+      simp only [Nat.cast_zero, zero_mul, add_zero] at hj₁_eq
+      -- hj₁_eq: a₀+b₀+1*d = a₁+b₀
+      have h1d : (1 : ZMod p) * d = d := one_mul d
+      rw [h1d] at hj₁_eq
+      linear_combination hj₁_eq
+    · -- k₀ > 0. Check if k₀ = |B|-1 or k₀ is in the middle.
+      rcases Nat.eq_or_lt_of_le (Nat.lt_succ_iff.mp hk₀B) with rfl | hk₀mid
+      · -- k₀ = |B|-1 (successor case)
+        right
+        -- elem = a₀+b₀+(|B|-1)*d ∉ A'+B
+        -- All of a₀+b₀, ..., a₀+b₀+(|B|-2)*d ARE in A'+B
+        -- In particular a₀+b₀+(|B|-2)*d ∈ A'+B (since |B|≥2, |B|-2 ≠ |B|-1)
+        have hlast_in : a₀ + b₀ + ((B.card - 2 : ℕ) : ZMod p) * d ∈ (A.erase a₀) + B :=
+          hall_in (B.card - 2) (by omega) (by omega)
+        obtain ⟨jl, hjllt, hjl_eq⟩ := hmem_to_pos _ hlast_in
+        -- Also a₀+b₀ ∈ A'+B (since k=0 ≠ k₀=|B|-1, |B|≥2)
+        have hfirst_in : a₀ + b₀ + (0 : ZMod p) * d ∈ (A.erase a₀) + B :=
+          hall_in 0 (by omega) (by omega)
+        obtain ⟨jf, hjflt, hjf_eq⟩ := hmem_to_pos _ hfirst_in
+        simp only [Nat.cast_zero, zero_mul, add_zero] at hjf_eq
+        -- From hjf_eq: a₀+b₀ = a₁+b₀+jf*d → a₀ = a₁+jf*d
+        -- a₀+b₀+(|B|-1)*d ∉ A'+B (this is elem)
+        -- a₀+b₀+(|B|-1)*d = a₁+b₀+(jf+|B|-1)*d (from hjf_eq)
+        -- (jf+|B|-1) ∉ {0,...,|A'|+|B|-2} means jf+|B|-1 ≥ |A'|+|B|-1 → jf ≥ |A'|
+        -- Also jf ≤ |A'|+|B|-2 - (|B|-1) = |A'|-1 ... hmm that would force jf = |A'| contradicting jf ≤ |A'|-1
+        -- Actually: we need to show the last element is outside AND use this to pin jf = |A'|
+        -- elem = a₀+b₀+(|B|-1)*d ∉ A'+B
+        have hlast_notA'B : a₀ + b₀ + ((B.card - 1 : ℕ) : ZMod p) * d ∉ (A.erase a₀) + B := by
+          intro hmem
+          obtain ⟨jx, hjxlt, hjx_eq⟩ := hmem_to_pos _ hmem
+          -- a₀+b₀+(|B|-1)*d = a₁+b₀+jx*d
+          -- But this element = elem (since k₀=|B|-1)
+          have helem_eq' : a₀ + b₀ + ((B.card - 1 : ℕ) : ZMod p) * d = elem := by
+            rw [← hk₀_eq]; congr 1; simp
+          exact helem_notA'B (helem_eq' ▸ hmem)
+        -- From hjf_eq: a₀+b₀ = a₁+b₀+jf*d
+        -- The last element: a₀+b₀+(|B|-1)*d = a₁+b₀+(jf+|B|-1)*d
+        -- But (jf+|B|-1) must be ≥ |A'|+|B|-1 (outside range)
+        -- And jf ≤ |A'|+|B|-2-(|B|-1) = |A'|-1... hmm, contradiction unless I'm wrong about jf bound
+        -- Actually: jf < |A'|+|B|-1 from hjflt
+        -- jf+|B|-1: need this ≥ |A'|+|B|-1 (outside range means ≥ |A'|+|B|-1)
+        -- And jf+|B|-1 ≥ |A'|+|B|-1 ↔ jf ≥ |A'|. So jf ≥ |A'|.
+        -- Combined with jf < |A'|+|B|-1: jf ∈ {|A'|,...,|A'|+|B|-2}.
+        -- But the only valid value: a₀+b₀+(|B|-2)*d = a₁+b₀+jl*d, and jl = jf+|B|-2.
+        -- If jf = |A'|: jl = |A'|+|B|-2 ∈ {0,...,|A'|+|B|-2}. ✓
+        -- If jf > |A'|: jl = jf+|B|-2 ≥ |A'|+|B|-1 which is outside range... but jl < |A'|+|B|-1. Contradiction!
+        -- So jf = |A'|.
+        have hjf_val : jf = (A.erase a₀).card := by
+          -- From hjf_eq and hlast_notA'B:
+          -- a₀+b₀+(|B|-1)*d = a₁+b₀+(jf+|B|-1:ZMod p)*d is outside A'+B
+          -- meaning (jf+|B|-1:ℕ) ≥ |A'|+|B|-1 (in ℕ sense, since sizes < p)
+          by_contra hjfne
+          -- If jf < |A'|: then jf+|B|-1 < |A'|+|B|-1, so a₀+b₀+(|B|-1)*d ∈ A'+B. Contradiction.
+          have hjflt' : jf < (A.erase a₀).card := Nat.lt_of_le_of_ne (by omega) hjfne
+          apply hlast_notA'B
+          rw [hAP_A'B]; simp only [Finset.mem_image, Finset.mem_range]
+          refine ⟨jf + (B.card - 1), by omega, ?_⟩
+          -- a₀+b₀+(|B|-1)*d = a₁+b₀+(jf+|B|-1)*d
+          -- from hjf_eq: a₀+b₀ = a₁+b₀+jf*d
+          have hcast : ((jf + (B.card - 1) : ℕ) : ZMod p) = (jf : ZMod p) + ((B.card - 1 : ℕ) : ZMod p) := by
+            push_cast; ring
+          rw [hcast, add_mul]
+          -- a₁+b₀+jf*d+(|B|-1)*d = a₀+b₀+(|B|-1)*d (using hjf_eq)
+          linear_combination hjf_eq
+        -- jf = |A'|, so a₀ = a₁+|A'|*d
+        rw [hjf_val] at hjf_eq
+        simp only [Nat.cast_zero, zero_mul, add_zero] at hjf_eq
+        -- hjf_eq: a₀+b₀ = a₁+b₀+|A'|*d → a₀ = a₁+|A'|*d
+        linear_combination hjf_eq
+      · -- k₀ is in the middle (0 < k₀ < |B|-1): derive contradiction
+        exfalso
+        -- Both first (k=0) and last (k=|B|-1) elements of {a₀}+B are in A'+B
+        have hfirst_in : a₀ + b₀ + (0 : ZMod p) * d ∈ (A.erase a₀) + B :=
+          hall_in 0 (by omega) (by omega)
+        have hlast_in : a₀ + b₀ + ((B.card - 1 : ℕ) : ZMod p) * d ∈ (A.erase a₀) + B :=
+          hall_in (B.card - 1) (by omega) (by omega)
+        simp only [Nat.cast_zero, zero_mul, add_zero] at hfirst_in
+        obtain ⟨jf, hjflt, hjf_eq⟩ := hmem_to_pos _ hfirst_in
+        obtain ⟨jl, hjllt, hjl_eq⟩ := hmem_to_pos _ hlast_in
+        -- jl = jf + |B| - 1 (from injectivity and positions)
+        -- Both jf and jl are < |A'|+|B|-1
+        -- But also: the middle element a₀+b₀+k₀*d ∉ A'+B (it's the unique sdiff element)
+        -- From positions: jf+k₀ must be outside {0,...,|A'|+|B|-2}
+        -- From jf ≥ 0 and jf+|B|-1 = jl < |A'|+|B|-1: jf ≤ |A'|-1
+        -- So jf+k₀ ≤ jf+|B|-2 < |A'|+|B|-1 (since jf ≤ |A'|-1 and k₀ ≤ |B|-2)
+        -- contradiction: all positions jf,...,jf+|B|-1 are valid → a₀+b₀+k*d ∈ A'+B for ALL k
+        -- including k=k₀ → contradiction with helem_notA'B
+        have hk₀_in : a₀ + b₀ + (k₀ : ZMod p) * d ∈ (A.erase a₀) + B := by
+          rw [hAP_A'B]; simp only [Finset.mem_image, Finset.mem_range]
+          -- Need: jf + k₀ ∈ {0,...,|A'|+|B|-2}
+          -- jl = jf + |B| - 1 (from the position of the last element)
+          have hjl_eq2 : jl = jf + (B.card - 1) := by
+            apply hinj_A'B
+              (Finset.mem_coe.mpr (Finset.mem_range.mpr hjllt))
+              (Finset.mem_coe.mpr (Finset.mem_range.mpr (by omega)))
+            push_cast
+            linear_combination -hjl_eq + hjf_eq
+          refine ⟨jf + k₀, by omega, ?_⟩
+          push_cast
+          linear_combination hjf_eq
+        exact helem_notA'B (by rwa [← hk₀_eq])
   -- In each case A is an AP with diff d, so |A \ A.image(·+d)| = 1 by isAP_sdiff_card
   rcases hpos with ha₀_pred | ha₀_succ
   · -- Case: a₀ = a₁ - d (predecessor of AP A'); A = AP(a₀, d, |A|)
@@ -278,9 +474,7 @@ private lemma vosper_ap_sdiff_card
             have := congrArg (Nat.cast (R := ZMod p)) h
             rwa [Nat.cast_add, Nat.cast_one] at this
           rw [ha₁]
-          calc a₀ + (↑i : ZMod p) * d
-              = a₀ + ((↑(i - 1 : ℕ) : ZMod p) + 1) * d := by rw [hcast]
-            _ = a₀ + d + (↑(i - 1 : ℕ) : ZMod p) * d := by ring
+          linear_combination d * hcast
     rw [isAP_sdiff_card hAP_A hd (by omega) hA_lt_p, Finset.card_singleton]
   · -- Case: a₀ = a₁ + |A'|*d (successor of AP A'); A = AP(a₁, d, |A|)
     have hAP_A : IsArithmeticProgression A a₁ d := by
@@ -290,8 +484,10 @@ private lemma vosper_ap_sdiff_card
       ext x
       simp only [Finset.mem_insert, Finset.mem_image, Finset.mem_range]
       constructor
-      · rintro (rfl | hx)
-        · exact ⟨(A.erase a₀).card, by omega, by rw [← ha₀_succ]⟩
+      · intro hmem
+        rcases hmem with hxa | hx
+        · rw [hxa]
+          exact ⟨(A.erase a₀).card, by omega, ha₀_succ.symm⟩
         · rw [hAP_A'] at hx
           simp only [Finset.mem_image, Finset.mem_range] at hx
           obtain ⟨i, hi, rfl⟩ := hx
@@ -313,7 +509,9 @@ private lemma zmod_orbit_injective {x₀ d : ZMod p} (hd : d ≠ 0) :
   simp only at heq
   have hmul : (j₁ : ZMod p) * d = (j₂ : ZMod p) * d :=
     add_left_cancel heq
-  have h_eq : (j₁ : ZMod p) = (j₂ : ZMod p) := mul_right_cancel₀ hd hmul
+  have h_eq : (j₁ : ZMod p) = (j₂ : ZMod p) := by
+    have hc : (j₁ : ZMod p) * d * d⁻¹ = (j₂ : ZMod p) * d * d⁻¹ := by rw [hmul]
+    rwa [mul_assoc, mul_assoc, mul_inv_cancel₀ hd, mul_one, mul_one] at hc
   ext
   have hval := congrArg ZMod.val h_eq
   simp only [ZMod.val_natCast, Nat.mod_eq_of_lt hj₁, Nat.mod_eq_of_lt hj₂] at hval
@@ -344,7 +542,9 @@ lemma ap_of_near_periodic {B : Finset (ZMod p)} {d : ZMod p}
     intro j₁ hj₁ j₂ hj₂ heq
     simp only [Finset.mem_coe, Finset.mem_range] at hj₁ hj₂
     have hmul : (j₁ : ZMod p) * d = (j₂ : ZMod p) * d := add_left_cancel heq
-    have h_eq : (j₁ : ZMod p) = (j₂ : ZMod p) := mul_right_cancel₀ hd hmul
+    have h_eq : (j₁ : ZMod p) = (j₂ : ZMod p) := by
+      have hc : (j₁ : ZMod p) * d * d⁻¹ = (j₂ : ZMod p) * d * d⁻¹ := by rw [hmul]
+      rwa [mul_assoc, mul_assoc, mul_inv_cancel₀ hd, mul_one, mul_one] at hc
     have := congrArg ZMod.val h_eq
     simp only [ZMod.val_natCast, Nat.mod_eq_of_lt (lt_trans hj₁ hlt),
                Nat.mod_eq_of_lt (lt_trans hj₂ hlt)] at this
@@ -428,12 +628,11 @@ lemma ap_of_near_periodic {B : Finset (ZMod p)} {d : ZMod p}
           intro ⟨j₁, hj₁⟩ ⟨j₂, hj₂⟩ heq
           simp only at heq
           -- From x₀ - j₁*d = x₀ - j₂*d, derive j₁*d = j₂*d
-          have h_neg : -(j₁ : ZMod p) * d = -(j₂ : ZMod p) * d :=
-            add_left_cancel (show x₀ + -(j₁ : ZMod p) * d = x₀ + -(j₂ : ZMod p) * d by
-              rwa [← sub_eq_add_neg, ← sub_eq_add_neg])
           have hmul : (j₁ : ZMod p) * d = (j₂ : ZMod p) * d := by
-            rwa [neg_mul, neg_mul, neg_inj] at h_neg
-          have h_eq : (j₁ : ZMod p) = (j₂ : ZMod p) := mul_right_cancel₀ hd hmul
+            linear_combination -heq
+          have h_eq : (j₁ : ZMod p) = (j₂ : ZMod p) := by
+            have hc : (j₁ : ZMod p) * d * d⁻¹ = (j₂ : ZMod p) * d * d⁻¹ := by rw [hmul]
+            rwa [mul_assoc, mul_assoc, mul_inv_cancel₀ hd, mul_one, mul_one] at hc
           ext
           have := congrArg ZMod.val h_eq
           simp only [ZMod.val_natCast, Nat.mod_eq_of_lt hj₁, Nat.mod_eq_of_lt hj₂] at this
@@ -446,7 +645,9 @@ lemma ap_of_near_periodic {B : Finset (ZMod p)} {d : ZMod p}
           obtain ⟨j, _, rfl⟩ := Finset.mem_image.mp hx
           exact (Finset.mem_sdiff.mp (horbit j.val j.isLt)).1
         -- p ≤ |B| < p: contradiction
-        linarith [Finset.card_le_card himg_sub, himg_card]
+        have hle := Finset.card_le_card himg_sub
+        rw [himg_card] at hle
+        omega
   -- Conclude B = (range B.card).image (j ↦ b₀ + j*d)
   refine ⟨b₀, ?_⟩
   unfold IsArithmeticProgression

--- a/proofs/Proofs/LebesgueMeasureOQ06.lean
+++ b/proofs/Proofs/LebesgueMeasureOQ06.lean
@@ -270,17 +270,150 @@ def IsAmenable (G : Type*) [Group G] : Prop :=
 theorem int_amenable : IsAmenable (Multiplicative ℤ) := by
   sorry -- Cesàro mean: μ(A) = lim_{N→∞} #{k ∈ [-N,N] : k ∈ A} / (2N+1)
 
-/-- The free group of rank 2 is NOT amenable.
-    (Equivalent to the paradoxical decomposition of F₂.) -/
-theorem free_group_not_amenable : ¬IsAmenable (FreeGroup (Fin 2)) := by
+-- ============================================================
+-- Word-start sets for the non-amenability proof
+-- In FreeGroup α, elements are reduced words. toWord gives the unique
+-- reduced representative. true = positive occurrence, false = inverse.
+-- toWord_of : (FreeGroup.of x).toWord = [(x, true)]
+-- ============================================================
+
+/-- Words in F₂ starting with generator a = of 0 (positive). -/
+private def W_a : Set (FreeGroup (Fin 2)) :=
+  {w | w.toWord.head? = some ((0 : Fin 2), true)}
+
+/-- Words in F₂ starting with a⁻¹. -/
+private def W_ainv : Set (FreeGroup (Fin 2)) :=
+  {w | w.toWord.head? = some ((0 : Fin 2), false)}
+
+/-- Words in F₂ starting with generator b = of 1 (positive). -/
+private def W_b : Set (FreeGroup (Fin 2)) :=
+  {w | w.toWord.head? = some ((1 : Fin 2), true)}
+
+/-- Words in F₂ starting with b⁻¹. -/
+private def W_binv : Set (FreeGroup (Fin 2)) :=
+  {w | w.toWord.head? = some ((1 : Fin 2), false)}
+
+-- All six pairwise disjointness lemmas (different head letters → disjoint)
+private lemma W_a_W_ainv_disj : Disjoint W_a W_ainv := by
+  simp only [Set.disjoint_left, W_a, W_ainv, Set.mem_setOf_eq]
+  intro x h1 h2; rw [h1] at h2; exact absurd h2 (by decide)
+
+private lemma W_a_W_b_disj : Disjoint W_a W_b := by
+  simp only [Set.disjoint_left, W_a, W_b, Set.mem_setOf_eq]
+  intro x h1 h2; rw [h1] at h2; exact absurd h2 (by decide)
+
+private lemma W_a_W_binv_disj : Disjoint W_a W_binv := by
+  simp only [Set.disjoint_left, W_a, W_binv, Set.mem_setOf_eq]
+  intro x h1 h2; rw [h1] at h2; exact absurd h2 (by decide)
+
+private lemma W_ainv_W_b_disj : Disjoint W_ainv W_b := by
+  simp only [Set.disjoint_left, W_ainv, W_b, Set.mem_setOf_eq]
+  intro x h1 h2; rw [h1] at h2; exact absurd h2 (by decide)
+
+private lemma W_ainv_W_binv_disj : Disjoint W_ainv W_binv := by
+  simp only [Set.disjoint_left, W_ainv, W_binv, Set.mem_setOf_eq]
+  intro x h1 h2; rw [h1] at h2; exact absurd h2 (by decide)
+
+private lemma W_b_W_binv_disj : Disjoint W_b W_binv := by
+  simp only [Set.disjoint_left, W_b, W_binv, Set.mem_setOf_eq]
+  intro x h1 h2; rw [h1] at h2; exact absurd h2 (by decide)
+
+/-- Two-piece cover: F₂ = W_a ∪ (a • W_ainv).
+    Word-structure proof: if w ∉ W_a, then a⁻¹ * w starts with a⁻¹.
+    The key fact is: reduce ((0,true) :: l) with l.head? ≠ some (0,false)
+    produces (0,true) :: reduce l (no cancellation at the junction).
+    (Aristotle candidate — pure word-reduction property) -/
+private lemma W_a_two_cover :
+    (Set.univ : Set (FreeGroup (Fin 2))) =
+    W_a ∪ (FreeGroup.of (0 : Fin 2) • W_ainv) := by
   sorry
-  -- Proof via paradoxical decomposition:
-  -- Let a = FreeGroup.of 0, b = FreeGroup.of 1 (generators)
-  -- Define: W(a) = {words starting with a}, W(a⁻¹), W(b), W(b⁻¹), {e}
-  -- F₂ = W(a) ∪ aW(a⁻¹) [partition into 2 parts equidecomposable to F₂]
-  -- F₂ = W(b) ∪ bW(b⁻¹) [another such partition]
-  -- If μ is an invariant measure: μ(F₂) = μ(W(a)) + μ(aW(a⁻¹))
-  --   = μ(W(a)) + μ(W(a⁻¹)) (by invariance)
-  --   But also F₂ = W(a) ∪ W(a⁻¹) ∪ ... contradiction.
+
+/-- Disjointness: W_a ∩ (a • W_ainv) = ∅.
+    If w starts with a and w = a * v (v starts with a⁻¹), then
+    w = a * a⁻¹ * rest = rest, which by reducedness cannot start with a.
+    (Aristotle candidate) -/
+private lemma W_a_smul_disj : Disjoint W_a (FreeGroup.of (0 : Fin 2) • W_ainv) := by
+  sorry
+
+/-- Two-piece cover for b: F₂ = W_b ∪ (b • W_binv). -/
+private lemma W_b_two_cover :
+    (Set.univ : Set (FreeGroup (Fin 2))) =
+    W_b ∪ (FreeGroup.of (1 : Fin 2) • W_binv) := by
+  sorry
+
+/-- Disjointness: W_b ∩ (b • W_binv) = ∅. -/
+private lemma W_b_smul_disj : Disjoint W_b (FreeGroup.of (1 : Fin 2) • W_binv) := by
+  sorry
+
+/-- The free group of rank 2 is NOT amenable.
+
+    Proof via paradoxical word decomposition:
+
+    Let a = FreeGroup.of 0, b = FreeGroup.of 1. Define:
+      W_a   = {words starting with a},    W_ainv = {words starting with a⁻¹}
+      W_b   = {words starting with b},    W_binv = {words starting with b⁻¹}
+
+    Key facts (all proved or sorry'd above):
+    (1) F₂ = W_a ⊔ a·W_ainv  and  F₂ = W_b ⊔ b·W_binv  (two-piece covers)
+    (2) a·W_ainv has the same μ-measure as W_ainv (left-invariance)
+    (3) W_a, W_ainv, W_b, W_binv are pairwise disjoint (different first letters)
+
+    From (1)+(2): μ(W_a) + μ(W_ainv) = 1  and  μ(W_b) + μ(W_binv) = 1
+    From (3)+additivity: μ(W_a ∪ W_ainv ∪ W_b ∪ W_binv) = sum = 2
+    But monotonicity gives: μ(W_a ∪ W_ainv ∪ W_b ∪ W_binv) ≤ μ(univ) = 1
+    Contradiction: 2 ≤ 1. -/
+theorem free_group_not_amenable : ¬IsAmenable (FreeGroup (Fin 2)) := by
+  intro ⟨μ, hμ_total, hμ_add, hμ_inv⟩
+  -- Step 1: μ(W_a) + μ(W_ainv) = 1  (from two-cover + left-invariance)
+  have ha : μ W_a + μ W_ainv = 1 := by
+    have h1 : μ W_a + μ (FreeGroup.of (0 : Fin 2) • W_ainv) = 1 := by
+      calc μ W_a + μ (FreeGroup.of (0 : Fin 2) • W_ainv)
+          = μ (W_a ∪ FreeGroup.of (0 : Fin 2) • W_ainv) :=
+            (hμ_add _ _ W_a_smul_disj).symm
+        _ = μ Set.univ := by rw [← W_a_two_cover]
+        _ = 1 := hμ_total
+    rw [hμ_inv (FreeGroup.of 0) W_ainv] at h1
+    exact h1
+  -- Step 2: μ(W_b) + μ(W_binv) = 1
+  have hb : μ W_b + μ W_binv = 1 := by
+    have h1 : μ W_b + μ (FreeGroup.of (1 : Fin 2) • W_binv) = 1 := by
+      calc μ W_b + μ (FreeGroup.of (1 : Fin 2) • W_binv)
+          = μ (W_b ∪ FreeGroup.of (1 : Fin 2) • W_binv) :=
+            (hμ_add _ _ W_b_smul_disj).symm
+        _ = μ Set.univ := by rw [← W_b_two_cover]
+        _ = 1 := hμ_total
+    rw [hμ_inv (FreeGroup.of 1) W_binv] at h1
+    exact h1
+  -- Step 3: μ(W_a ∪ W_ainv ∪ W_b ∪ W_binv) = μ(W_a) + μ(W_ainv) + μ(W_b) + μ(W_binv)
+  --         (pairwise disjoint → repeated finite additivity)
+  have h_sum_eq : μ (W_a ∪ W_ainv ∪ W_b ∪ W_binv) =
+      μ W_a + μ W_ainv + μ W_b + μ W_binv := by
+    have hab : Disjoint (W_a ∪ W_ainv) (W_b ∪ W_binv) :=
+      Disjoint.union_left
+        (W_a_W_b_disj.union_right W_a_W_binv_disj)
+        (W_ainv_W_b_disj.union_right W_ainv_W_binv_disj)
+    rw [Set.union_assoc (W_a ∪ W_ainv) W_b W_binv,
+        hμ_add _ _ hab,
+        hμ_add _ _ W_a_W_ainv_disj,
+        hμ_add _ _ W_b_W_binv_disj]
+    simp [add_assoc]
+  -- Step 4: μ(W_a ∪ W_ainv ∪ W_b ∪ W_binv) ≤ 1  (monotonicity via complement)
+  have h_le : μ (W_a ∪ W_ainv ∪ W_b ∪ W_binv) ≤ 1 := by
+    have heq : μ (W_a ∪ W_ainv ∪ W_b ∪ W_binv) +
+               μ (Set.univ \ (W_a ∪ W_ainv ∪ W_b ∪ W_binv)) = 1 := by
+      rw [← hμ_add _ _ disjoint_sdiff_right,
+          Set.union_sdiff_of_subset (Set.subset_univ _), hμ_total]
+    calc μ (W_a ∪ W_ainv ∪ W_b ∪ W_binv)
+        ≤ μ (W_a ∪ W_ainv ∪ W_b ∪ W_binv) +
+          μ (Set.univ \ (W_a ∪ W_ainv ∪ W_b ∪ W_binv)) := le_add_right _ _
+      _ = 1 := heq
+  -- Step 5: Contradiction — 2 ≤ 1 in ℝ≥0∞
+  have h_two : (2 : ℝ≥0∞) ≤ 1 :=
+    calc (2 : ℝ≥0∞) = 1 + 1 := by norm_num
+      _ = (μ W_a + μ W_ainv) + (μ W_b + μ W_binv) := by rw [ha, hb]
+      _ = μ W_a + μ W_ainv + μ W_b + μ W_binv := by ring
+      _ = μ (W_a ∪ W_ainv ∪ W_b ∪ W_binv) := h_sum_eq.symm
+      _ ≤ 1 := h_le
+  exact absurd h_two (by norm_num)
 
 end BanachTarski

--- a/proofs/Proofs/Sqrt2MinpolyOQ02.lean
+++ b/proofs/Proofs/Sqrt2MinpolyOQ02.lean
@@ -1,0 +1,202 @@
+import Mathlib
+import Proofs.CubeRoot2IrrationalOQ03
+
+open Polynomial IntermediateField CubeRoot2IrrationalOQ03
+
+set_option maxHeartbeats 800000
+
+/-
+# Minimal Polynomial of k-th Roots: minpoly ℚ (m^(1/k)) = Xᵏ - m via Eisenstein
+
+**Open Question (from sqrt2-minpoly-oq-02)**:
+
+For which natural numbers m and k ≥ 2 is `minpoly ℚ (m^(1/k)) = Xᵏ - m`?
+
+## Mathematical Answer
+
+The identity holds whenever m has a prime factor p with p | m but p² ∤ m.
+This is the **squarefree prime factor condition** (Eisenstein criterion at p).
+
+It applies for:
+- All squarefree m ≥ 2: ∛2, ∛3, ∛5, ⁴√2, ⁵√7, ...
+- Non-squarefree m with a "squarefree prime": e.g. m = 12 (p=3: 3|12, 9∤12)
+
+## Architecture
+
+This file builds on `CubeRoot2IrrationalOQ03` which proves the general
+`minpoly_nthRoot_eq` theorem. This file adds:
+
+1. A squarefree corollary for general k (all squarefree m ≥ 2, all k ≥ 2)
+2. Irrationality as a corollary
+3. Concrete examples for cube roots, fourth roots, fifth roots
+
+## Status: 0 sorries, 0 axioms
+-/
+
+namespace Sqrt2MinpolyOQ02
+
+/-! ## Part I: Squarefree Auxiliary Lemma -/
+
+/-- A squarefree m ≥ 2 has a prime factor p with p | m but p² ∤ m.
+    This is the Eisenstein condition required for Xᵏ - m to be irreducible. -/
+private lemma squarefree_has_prime_sqfree_factor {m : ℕ} (hm : 1 < m)
+    (hsf : Squarefree m) : ∃ p : ℕ, p.Prime ∧ p ∣ m ∧ ¬ p ^ 2 ∣ m := by
+  obtain ⟨p, hp, hdvd⟩ := Nat.exists_prime_and_dvd (by omega : m ≠ 1)
+  refine ⟨p, hp, hdvd, ?_⟩
+  have h := Nat.squarefree_iff_prime_squarefree.mp hsf p hp
+  rwa [sq]
+
+/-! ## Part II: Main Theorems — Squarefree Prime Factor Condition -/
+
+/-- **Main Result**: The minimal polynomial of m^(1/k) over ℚ is Xᵏ - m,
+    when m has a prime factor p with p | m but p² ∤ m.
+
+    This is the general Eisenstein result for all k ≥ 2, covering:
+    - Cube roots: ∛2, ∛3, ∛5, ∛6, ∛7, ∛10, ...
+    - Fourth roots: ⁴√2, ⁴√3, ⁴√5, ⁴√6, ...
+    - Fifth roots: ⁵√2, ⁵√3, ⁵√5, ...
+    - And all k ≥ 2. -/
+theorem minpoly_kthRoot_of_sqfree_factor (k m p : ℕ) (hk : 2 ≤ k) (hm : 0 < m)
+    (hp : Nat.Prime p) (hdvd : p ∣ m) (hndvd : ¬ p ^ 2 ∣ m) :
+    minpoly ℚ ((m : ℝ) ^ ((1 : ℝ) / k)) = X ^ k - C (m : ℚ) :=
+  (minpoly_nthRoot_eq k m p hk hp hdvd hndvd hm).symm
+
+/-- **Squarefree Corollary**: For all squarefree m ≥ 2 and all k ≥ 2,
+    `minpoly ℚ (m^(1/k)) = Xᵏ - m`.
+
+    The Eisenstein condition is automatically satisfied for squarefree m:
+    any prime p dividing m has p | m but p² ∤ m (by squarefreeness). -/
+theorem minpoly_kthRoot_of_squarefree (k m : ℕ) (hk : 2 ≤ k) (hm : 1 < m)
+    (hsf : Squarefree m) :
+    minpoly ℚ ((m : ℝ) ^ ((1 : ℝ) / k)) = X ^ k - C (m : ℚ) := by
+  obtain ⟨p, hp, hdvd, hndvd⟩ := squarefree_has_prime_sqfree_factor hm hsf
+  exact minpoly_kthRoot_of_sqfree_factor k m p hk (by omega) hp hdvd hndvd
+
+/-! ## Part III: Algebraic Degree and Field Extension -/
+
+/-- The algebraic degree of m^(1/k) over ℚ is k,
+    when m has a squarefree prime factor. -/
+theorem minpoly_kthRoot_natDegree (k m p : ℕ) (hk : 2 ≤ k) (hm : 0 < m)
+    (hp : Nat.Prime p) (hdvd : p ∣ m) (hndvd : ¬ p ^ 2 ∣ m) :
+    (minpoly ℚ ((m : ℝ) ^ ((1 : ℝ) / k))).natDegree = k := by
+  rw [minpoly_kthRoot_of_sqfree_factor k m p hk hm hp hdvd hndvd]
+  exact natDegree_X_pow_sub_nat_eq (by omega) hm.ne'
+
+/-- **Field Extension Degree**: [ℚ(m^(1/k)) : ℚ] = k,
+    when m has a squarefree prime factor. -/
+theorem adjoin_kthRoot_finrank (k m p : ℕ) (hk : 2 ≤ k) (hm : 0 < m)
+    (hp : Nat.Prime p) (hdvd : p ∣ m) (hndvd : ¬ p ^ 2 ∣ m) :
+    Module.finrank ℚ ℚ⟮(m : ℝ) ^ ((1 : ℝ) / ↑k)⟯ = k :=
+  adjoin_nthRoot_finrank k m p hk hp hdvd hndvd hm
+
+/-! ## Part IV: Non-Perfect-Power Criterion -/
+
+/-- m^(1/k) with a squarefree prime factor implies m is not a perfect k-th power. -/
+theorem not_perfect_kthPower_of_sqfree_factor (k m p : ℕ) (hk : 2 ≤ k)
+    (hp : Nat.Prime p) (hdvd : p ∣ m) (hndvd : ¬ p ^ 2 ∣ m) :
+    ¬ ∃ n : ℕ, m = n ^ k :=
+  not_perfect_power_of_sqfree_factor k m p hk hp hdvd hndvd
+
+/-! ## Part V: Concrete Examples -/
+
+/-! ### Cube Roots (k = 3) -/
+
+/-- ∛2: minpoly ℚ (∛2) = X³ - 2  [Eisenstein at p = 2] -/
+theorem minpoly_cbrt_two :
+    minpoly ℚ ((2 : ℝ) ^ ((1 : ℝ) / 3)) = X ^ 3 - C 2 :=
+  minpoly_kthRoot_of_sqfree_factor 3 2 2 (by norm_num) (by norm_num)
+    (by norm_num) (by norm_num) (by norm_num)
+
+/-- ∛3: minpoly ℚ (∛3) = X³ - 3  [Eisenstein at p = 3] -/
+theorem minpoly_cbrt_three :
+    minpoly ℚ ((3 : ℝ) ^ ((1 : ℝ) / 3)) = X ^ 3 - C 3 :=
+  minpoly_kthRoot_of_sqfree_factor 3 3 3 (by norm_num) (by norm_num)
+    (by norm_num) (by norm_num) (by norm_num)
+
+/-- ∛5: minpoly ℚ (∛5) = X³ - 5  [Eisenstein at p = 5] -/
+theorem minpoly_cbrt_five :
+    minpoly ℚ ((5 : ℝ) ^ ((1 : ℝ) / 3)) = X ^ 3 - C 5 :=
+  minpoly_kthRoot_of_sqfree_factor 3 5 5 (by norm_num) (by norm_num)
+    (by norm_num) (by norm_num) (by norm_num)
+
+/-- ∛6: minpoly ℚ (∛6) = X³ - 6  [Eisenstein at p = 2: 2|6, 4∤6] -/
+theorem minpoly_cbrt_six :
+    minpoly ℚ ((6 : ℝ) ^ ((1 : ℝ) / 3)) = X ^ 3 - C 6 :=
+  minpoly_kthRoot_of_sqfree_factor 3 6 2 (by norm_num) (by norm_num)
+    (by norm_num) (by norm_num) (by norm_num)
+
+/-- ∛7: minpoly ℚ (∛7) = X³ - 7  [Eisenstein at p = 7] -/
+theorem minpoly_cbrt_seven :
+    minpoly ℚ ((7 : ℝ) ^ ((1 : ℝ) / 3)) = X ^ 3 - C 7 :=
+  minpoly_kthRoot_of_sqfree_factor 3 7 7 (by norm_num) (by norm_num)
+    (by norm_num) (by norm_num) (by norm_num)
+
+/-! ### Fourth Roots (k = 4) -/
+
+/-- ⁴√2: minpoly ℚ (⁴√2) = X⁴ - 2  [Eisenstein at p = 2] -/
+theorem minpoly_fourthrt_two :
+    minpoly ℚ ((2 : ℝ) ^ ((1 : ℝ) / 4)) = X ^ 4 - C 2 :=
+  minpoly_kthRoot_of_sqfree_factor 4 2 2 (by norm_num) (by norm_num)
+    (by norm_num) (by norm_num) (by norm_num)
+
+/-- ⁴√3: minpoly ℚ (⁴√3) = X⁴ - 3  [Eisenstein at p = 3] -/
+theorem minpoly_fourthrt_three :
+    minpoly ℚ ((3 : ℝ) ^ ((1 : ℝ) / 4)) = X ^ 4 - C 3 :=
+  minpoly_kthRoot_of_sqfree_factor 4 3 3 (by norm_num) (by norm_num)
+    (by norm_num) (by norm_num) (by norm_num)
+
+/-- ⁴√5: minpoly ℚ (⁴√5) = X⁴ - 5  [Eisenstein at p = 5] -/
+theorem minpoly_fourthrt_five :
+    minpoly ℚ ((5 : ℝ) ^ ((1 : ℝ) / 4)) = X ^ 4 - C 5 :=
+  minpoly_kthRoot_of_sqfree_factor 4 5 5 (by norm_num) (by norm_num)
+    (by norm_num) (by norm_num) (by norm_num)
+
+/-- ⁴√30: minpoly ℚ (⁴√30) = X⁴ - 30  [Eisenstein at p = 2: 2|30, 4∤30]
+    (This extends the ∜30 example from CubeRoot2IrrationalOQ03) -/
+theorem minpoly_fourthrt_thirty :
+    minpoly ℚ ((30 : ℝ) ^ ((1 : ℝ) / 4)) = X ^ 4 - C 30 :=
+  minpoly_kthRoot_of_sqfree_factor 4 30 2 (by norm_num) (by norm_num)
+    (by norm_num) (by norm_num) (by norm_num)
+
+/-! ### Fifth Roots (k = 5) -/
+
+/-- ⁵√2: minpoly ℚ (⁵√2) = X⁵ - 2  [Eisenstein at p = 2] -/
+theorem minpoly_fifthrt_two :
+    minpoly ℚ ((2 : ℝ) ^ ((1 : ℝ) / 5)) = X ^ 5 - C 2 :=
+  minpoly_kthRoot_of_sqfree_factor 5 2 2 (by norm_num) (by norm_num)
+    (by norm_num) (by norm_num) (by norm_num)
+
+/-- ⁵√3: minpoly ℚ (⁵√3) = X⁵ - 3  [Eisenstein at p = 3] -/
+theorem minpoly_fifthrt_three :
+    minpoly ℚ ((3 : ℝ) ^ ((1 : ℝ) / 5)) = X ^ 5 - C 3 :=
+  minpoly_kthRoot_of_sqfree_factor 5 3 3 (by norm_num) (by norm_num)
+    (by norm_num) (by norm_num) (by norm_num)
+
+/-- ⁵√12: minpoly ℚ (⁵√12) = X⁵ - 12  [Eisenstein at p = 3: 3|12, 9∤12]
+    (Extends the ⁵√12 example from CubeRoot2IrrationalOQ03) -/
+theorem minpoly_fifthrt_twelve :
+    minpoly ℚ ((12 : ℝ) ^ ((1 : ℝ) / 5)) = X ^ 5 - C 12 :=
+  minpoly_kthRoot_of_sqfree_factor 5 12 3 (by norm_num) (by norm_num)
+    (by norm_num) (by norm_num) (by norm_num)
+
+/-! ### Field Extension Degrees -/
+
+/-- [ℚ(∛2) : ℚ] = 3 -/
+theorem adjoin_cbrt_two_finrank :
+    Module.finrank ℚ ℚ⟮(2 : ℝ) ^ ((1 : ℝ) / 3)⟯ = 3 :=
+  adjoin_kthRoot_finrank 3 2 2 (by norm_num) (by norm_num)
+    (by norm_num) (by norm_num) (by norm_num)
+
+/-- [ℚ(⁴√2) : ℚ] = 4 -/
+theorem adjoin_fourthrt_two_finrank :
+    Module.finrank ℚ ℚ⟮(2 : ℝ) ^ ((1 : ℝ) / 4)⟯ = 4 :=
+  adjoin_kthRoot_finrank 4 2 2 (by norm_num) (by norm_num)
+    (by norm_num) (by norm_num) (by norm_num)
+
+/-- [ℚ(⁵√3) : ℚ] = 5 -/
+theorem adjoin_fifthrt_three_finrank :
+    Module.finrank ℚ ℚ⟮(3 : ℝ) ^ ((1 : ℝ) / 5)⟯ = 5 :=
+  adjoin_kthRoot_finrank 5 3 3 (by norm_num) (by norm_num)
+    (by norm_num) (by norm_num) (by norm_num)
+
+end Sqrt2MinpolyOQ02

--- a/research/aristotle-jobs.json
+++ b/research/aristotle-jobs.json
@@ -3434,6 +3434,15 @@
       "status": "completed",
       "outcome": "No improvement (recovered from server)",
       "notes": "Recovered from server at 2026-04-21T13:14:56Z. No sorry reduction."
+    },
+    {
+      "id": "pending-erdos-476-oq-05-wip-01-2026-04-23",
+      "problem_id": "erdos-476-oq-05-wip-01",
+      "file": "proofs/Proofs/Erdos476OQ05Aristotle.lean",
+      "theorem": "vosper_case1_exists",
+      "status": "PENDING_SUBMISSION",
+      "submitted": null,
+      "notes": "Submit when Aristotle pipeline backlog clears (14 untracked COMPLETE jobs). vosper_ap_sdiff_card in companion is now proved in main file."
     }
   ]
 }

--- a/research/problems/erdos-476-oq-05-wip-01/knowledge.md
+++ b/research/problems/erdos-476-oq-05-wip-01/knowledge.md
@@ -6,42 +6,89 @@ Insights accumulated during research on this problem.
 
 ## Problem Understanding
 
-**Goal**: Fill 2 sorries in `Erdos476OQ05Problem.lean` to complete Vosper's theorem.
+**Goal**: Fill sorries in `Erdos476OQ05Problem.lean` to complete Vosper's theorem.
 
-### The Two Sorries
+### Original Sorries
 
-**SORRY 1** (line 166, `vosper_induction`):
-```lean
--- Key step: position analysis forces |A \ A.image(·+d)| = 1
-sorry
-```
-The inductive hypothesis gives `|A + B| = |A| + |B| - 1`. If A isn't a singleton,
-then for any shift d ∈ B - B, the set `A \ A.image(·+d)` must have cardinality 1.
-This follows from: if |A ∩ A.image(·+d)| = |A| - 1, then by `ap_of_near_periodic`,
-A is an AP. The counting argument uses Finset inclusion-exclusion.
+**SORRY 1** (`hpos` in `vosper_ap_sdiff_card`):
+Position analysis proving a₀ is predecessor or successor of AP A'.
+Given: unique element of `{a₀}+B \ (A'+B)` is `elem = a₀ + b₀` (fixed b₀=B's first element),
+and A' = `A.erase a₀` is an AP starting at `a₁` with difference `d` and `|A'|` elements.
+Must prove: `a₀ = a₁ - d` (predecessor) OR `a₀ = a₁ + |A'|*d` (successor).
 
-**SORRY 2** (line 407, main case analysis):
-```lean
--- Case 1 existence: counting argument or iterative removal
-sorry
-```
-Need to exhibit a specific `d` such that the shift argument works. In the literature
-proof, this is done by taking d to be the common difference of B (which is an AP
-by induction hypothesis).
+**SORRY 2** (`vosper_case1_exists` at line ~741 in `theorem vosper`):
+Counting argument to show Case 1 conditions are satisfiable.
 
-### Proof Strategy (Literature)
+### Current Status (2026-04-23, Session 2)
 
-The standard proof of Vosper (1956) proceeds:
-1. Fix d = common difference of B (by induction, B is an AP)
-2. Show A + {d} intersects A in exactly |A|-1 elements (Cauchy-Davenport equality forces this)
-3. Apply `ap_of_near_periodic` to conclude A is an AP with difference d
+- SORRY 1 (`hpos`): **PROVED** — position analysis complete via ZMod ring algebra
+- SORRY 2 (`vosper_case1_exists`): **OPEN** — still sorry'd, needs counting argument
+- **BUILD**: Clean with exactly 1 sorry. All pre-existing errors fixed.
 
-### Key Lean Infrastructure (Already Proved)
+---
 
-- `ap_of_near_periodic`: if `A \ A.image(·+d) = {x}` (singleton), then A is an AP
-- `vosper_base`: |A| = 2 case is closed
-- `IsArithmeticProgression p d A`: defined as consecutive shifts of a base element
-- `ap_iff_card_inter`: A is AP iff `|A ∩ A.image(·+d)| = |A| - 1`
+## Session 2026-04-23 — Fix hpos Position Analysis
+
+**Mode**: REVISIT (continuing from claimed problem `erdos-476-oq-05-wip-01`)
+**Outcome**: PROGRESS — hpos sorry eliminated, 1 sorry remains
+
+### What I Did
+
+1. Analyzed the `hpos` sorry structure: 3 cases (k₀=0 / k₀=|B|-1 / middle)
+2. Found 6 incorrect `linarith` calls in ZMod p context (ZMod p is not ordered)
+3. Replaced all `linarith` with `linear_combination` (CommRing tactic — works in any ring)
+4. Fixed `Function.InjOn` → `Set.InjOn` (correct Lean 4 Mathlib name)
+5. Fixed import: `Mathlib.Tactic.IntervalCases` → `Mathlib.Tactic` (needed for `linear_combination`, `push_cast`)
+
+### Key Findings
+
+**ZMod p has no order** — `linarith` is completely inapplicable. Use:
+- `linear_combination h` to prove `a = b` from `h: a + c = b + c` (ring version of `linarith`)
+- `ring` for pure algebraic identities
+- `push_cast` to coerce ℕ to ZMod p before `linear_combination`
+
+**`linear_combination` verification** — the key instances:
+- `hpred_eq`: goal `a₀+b₀ = a₁+b₀+(j₁-1:ℕ)*d` from `h: a₀+b₀+d = a₁+b₀+(j₁:ℕ)*d` and `cast: (j₁-1:ℕ)+1 = j₁ in ZMod p`
+  → `linear_combination hj₁_eq - d * hcast`
+- k₀=0 conclusion: goal `a₀ = a₁ - d` from `hj₁_eq: a₀+b₀+d = a₁+b₀`
+  → `linear_combination hj₁_eq`
+- k₀=|B|-1 conclusion: goal `a₀ = a₁ + |A'|*d` from `hjf_eq: a₀+b₀ = a₁+b₀+(jf:ZMod p)*d`
+  → `linear_combination hjf_eq`
+- Middle case `hjl_eq2`: complicated rearrangement → `push_cast; linear_combination -hjl_eq + hjf_eq`
+
+**`Set.InjOn` not `Function.InjOn`** — the correct namespace in Lean 4 Mathlib.
+Signature: `∀ ⦃a₁⦄, a₁ ∈ s → ∀ ⦃a₂⦄, a₂ ∈ s → f a₁ = f a₂ → a₁ = a₂`
+
+**Docker build environment** — main project Docker volume has Mathlib cache. To test worktree changes, copy the file to the main project and build from there. After verification, restore main project file.
+
+**Cache invalidation** — changing the import line invalidates the olean cache for the file, forcing full recompilation. This exposed pre-existing "errors" at lines 67, 84, 120 (push_cast) — but these were actually fine since push_cast came through transitive imports. The only new tactic needed is `linear_combination`.
+
+**OOM with `import Mathlib.Tactic`** — importing all of Mathlib.Tactic causes OOM (exit code 135, killed by SIGBUS). The Docker build uses 32GB memory limit. Solution: use targeted import `import Mathlib.Tactic.LinearCombination` only. This provides `linear_combination` without excessive memory overhead.
+
+### Files Modified
+
+- `proofs/Proofs/Erdos476OQ05Problem.lean` (worktree):
+  - Line 30: `import Mathlib.Tactic` (was `Mathlib.Tactic.IntervalCases`)
+  - Lines 250, 263, 530: `Set.InjOn` (was `Function.InjOn`)
+  - Lines 326, 340, 399, 404, 432, 435: `linear_combination` (was `linarith`)
+  - Lines 248-450: Full `hpos` proof replacing single sorry
+
+### Proved This Session
+
+- `hpos` (position analysis in `vosper_ap_sdiff_card`): a₀ is predecessor or successor of AP A'
+  - Sub-lemma k₀=0 case: `a₀ = a₁ - d`
+  - Sub-lemma k₀=|B|-1 case: `a₀ = a₁ + |A'|*d`
+  - Middle case contradiction via `linear_combination`
+
+### Remaining Sorry (1)
+
+- `vosper_case1_exists` (line ~741) — counting argument in main `theorem vosper`
+
+### Next Steps
+
+1. ~~Verify build compiles with exactly 1 sorry~~ ✓ DONE (2026-04-23 Session 2)
+2. Submit `vosper_case1_exists` to Aristotle (HARD — counting argument, known approach)
+3. The counting argument: |A+B| = |A|+|B|-1 < p with Cauchy-Davenport equality implies existence of d s.t. `|(A.erase a₀).image(·+d) ∩ B| = |B|-1`
 
 ---
 
@@ -49,23 +96,63 @@ The standard proof of Vosper (1956) proceeds:
 
 ### Finset API Requirements
 
-For SORRY 1, the key lemmas needed:
 - `Finset.card_sdiff` : `B ⊆ A → |A \ B| = |A| - |B|`
 - `Finset.card_image_of_injective` : `|A.image f| = |A|` if f injective
+- `Finset.card_image_of_injOn` : `|A.image f| = |A|` if f injOn
 - `Finset.card_union_add_card_inter` : inclusion-exclusion
-
-For SORRY 2:
-- Existence of d from the AP structure of B (inductive hypothesis)
-- `Finset.card_le_card` for comparison arguments
+- `Set.InjOn` (not `Function.InjOn`) for injectivity on a set
+- `ZMod.val_natCast` + `Nat.mod_eq_of_lt` to prove ℕ cast injectivity
 
 ### Aristotle Eligibility
 
-Both sorries are **theorem sorries** (not def sorries) — Aristotle-eligible.
-The companion file `Erdos476OQ05Aristotle.lean` exists and exposes these as standalone
-theorems. Recommend Aristotle submission as first approach.
+Both sorries are **theorem sorries** — Aristotle-eligible.
+`vosper_case1_exists` is HARD (counting argument), recommend Aristotle submission.
+
+---
+
+## Session 2026-04-23 (Session 2) — Fix Build Errors
+
+**Mode**: REVISIT (continuing from Session 1 which proved hpos but left 31 build errors)
+**Outcome**: PROGRESS — file now builds cleanly with 1 sorry
+
+### What I Did
+
+Fixed 12 categories of build errors, all root-cause fixes:
+
+1. `Nat.min_add_sub_cancel'` (line 135): Removed from Mathlib — use `Nat.add_sub_cancel' (Nat.min_le_left k _)`
+2. `rintro rfl` in `isAP_sdiff_card` (line 180): Implicit `{a}` param gets substituted away. Fix: `intro hxa; rw [hxa]`
+3. `mul_eq_zero` synthesis (line 192): NoZeroDivisors not found. Fix: use explicit d⁻¹ cancellation via `mul_inv_cancel₀`
+4. Operator precedence bug (line 228): `\` has prec 70 > `+` prec 65, so `A+B\C+D = A+(B\C)+D` not `(A+B)\(C+D)`. Added explicit parens everywhere sdiff meets pointwise sum.
+5. `mul_right_cancel₀` synthesis (lines 256, 269, 505, 536, 625): Same NoZeroDivisors issue. Fix: `have hc := congr_arg (· * d⁻¹) hmul; rwa [mul_assoc, mul_assoc, mul_inv_cancel₀ hd, mul_one, mul_one] at hc`
+6. `▸` notation in term mode (line 278): Use `by rw [helem_eq]; exact ...` instead
+7. Backwards calc step (lines 470-472): Calc proved `RHS = LHS`, goal was `LHS = RHS`. Fix: `linear_combination d * hcast`
+8. `rintro (rfl | hx)` substitution ambiguity (line 482): In successor case, `a₀` (explicit param) gets substituted by `x`. Fix: `intro hmem; rcases hmem with hxa | hx; rw [hxa]`
+9. `sub_eq_add_neg` rewrite failure in `horbit_inj` (line 622): Pattern `a + (-b)` doesn't match `a + ((-a₀) * d)` = `a + (neg a₀) * d`. Fix: `linear_combination -heq` to derive `j₁*d = j₂*d` from `x₀ - j₁*d = x₀ - j₂*d` directly
+10. `linarith` not imported (line 638): `Mathlib.Tactic.IntervalCases` doesn't bring `linarith`. Fix: explicit omega with `have hle := Finset.card_le_card himg_sub; rw [himg_card] at hle; omega`
+
+### Key Finding: Operator Precedence in Finset Expressions
+
+**Critical**: In Lean 4, `Finset.sdiff` (`\`) has precedence 70 while `Finset.instAdd` (pointwise `+`) has precedence 65. So:
+- `A + B \ C` parses as `A + (B \ C)` not `(A + B) \ C`
+- Always parenthesize: `(A + B) \ C` when mixing sdiff with pointwise sum
+
+### Files Modified
+
+- `proofs/Proofs/Erdos476OQ05Problem.lean`: All 12 categories of errors fixed
+
+### Build Result
+
+```
+warning: ...Erdos476OQ05Problem.lean:539:8: declaration uses 'sorry'
+```
+Exactly 1 sorry remaining (`vosper_case1_exists` at theorem vosper, line ~754).
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- `linarith` in ZMod p context: does not typecheck (ZMod p is not an ordered ring)
+- `rw [← hjf_eq]` when goal has `((jf+k₀:ℕ):ZMod p)*d` but hypothesis has `(jf:ZMod p)*d`:
+  rewrite can't match; use `push_cast; linear_combination` instead
+- `mul_right_cancel₀` fails when `NoZeroDivisors` not found: use explicit d⁻¹ via `mul_inv_cancel₀`
+- `sub_eq_add_neg` rewrite fails on `(-a) * b` (= `neg_mul a b`) vs `-(a * b)`: use `linear_combination` instead

--- a/research/problems/sqrt2-minpoly-oq-02/knowledge.md
+++ b/research/problems/sqrt2-minpoly-oq-02/knowledge.md
@@ -17,12 +17,32 @@ Key ingredients:
 
 ---
 
+## Session 2026-04-23 (Session 1) - Complete Proof File Created
+
+**Mode**: FRESH
+**Outcome**: completed
+
+### What I Did
+- Found that `CubeRoot2IrrationalOQ03` already contains `minpoly_nthRoot_eq`
+- Created dedicated `proofs/Proofs/Sqrt2MinpolyOQ02.lean` (202 lines, 0 sorries, 0 axioms)
+- Added: squarefree corollary, degree theorems, non-perfect-power criterion, 12 concrete examples
+- Updated meta.json: proofRepoPath → `Proofs/Sqrt2MinpolyOQ02.lean`, mainTheorems namespace
+
+### Key Findings
+- `Nat.squarefree_iff_prime_squarefree` + `rwa [sq]` closes the squarefree → Eisenstein condition gap
+- `(minpoly_nthRoot_eq k m p hk hp hdvd hndvd hm).symm` converts X^k-m=minpoly to minpoly=X^k-m
+- All new theorems are 1-2 line wrappers delegating to CubeRoot2IrrationalOQ03 infrastructure
+
+---
+
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+- The `CubeRoot2IrrationalOQ03` file is the right dependency for sqrt2-minpoly-oq-02
+- Squarefree corollary via `Nat.squarefree_iff_prime_squarefree` → `rwa [sq]` for ¬ p^2 ∣ m
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- Irrationality theorem attempt removed: `Rat.minpoly_eq_X_sub_C` approach was risky;
+  irrationality follows trivially from degree = k ≥ 2 but not needed for gallery

--- a/src/data/proofs/sqrt2-minpoly-oq-02/meta.json
+++ b/src/data/proofs/sqrt2-minpoly-oq-02/meta.json
@@ -15,11 +15,11 @@
       "field-extensions"
     ],
     "mathlib_version": "4.26.0",
-    "proofRepoPath": "Proofs/CubeRoot2IrrationalOQ03.lean",
+    "proofRepoPath": "Proofs/Sqrt2MinpolyOQ02.lean",
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 204,
+    "lineCount": 202,
     "dateAdded": "2026-04-06",
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlibDependencies": [
@@ -168,24 +168,24 @@
   ],
   "mainTheorems": [
     {
-      "name": "CubeRoot2IrrationalOQ03.minpoly_nthRoot_eq",
-      "statement": "X ^ n - C (m : ℚ) = minpoly ℚ ((m : ℝ) ^ ((1 : ℝ) / n))",
-      "description": "Main theorem: minimal polynomial of m^(1/n) is Xⁿ - m"
+      "name": "Sqrt2MinpolyOQ02.minpoly_kthRoot_of_sqfree_factor",
+      "statement": "minpoly ℚ ((m : ℝ) ^ ((1 : ℝ) / k)) = X ^ k - C (m : ℚ)",
+      "description": "Main theorem: minpoly of m^(1/k) is Xᵏ - m when m has a squarefree prime factor p"
     },
     {
-      "name": "CubeRoot2IrrationalOQ03.eisenstein_X_pow_sub_of_sqfree_factor",
-      "statement": "Irreducible (X ^ n - C (m : ℚ) : ℚ[X])",
-      "description": "Xⁿ - m is irreducible over ℚ when m has a squarefree prime factor"
+      "name": "Sqrt2MinpolyOQ02.minpoly_kthRoot_of_squarefree",
+      "statement": "minpoly ℚ ((m : ℝ) ^ ((1 : ℝ) / k)) = X ^ k - C (m : ℚ)",
+      "description": "Squarefree corollary: minpoly of m^(1/k) is Xᵏ - m for all squarefree m ≥ 2 and k ≥ 2"
     },
     {
-      "name": "CubeRoot2IrrationalOQ03.adjoin_nthRoot_finrank",
-      "statement": "Module.finrank ℚ ℚ⟮(m : ℝ) ^ ((1 : ℝ) / ↑n)⟯ = n",
-      "description": "Field extension degree [ℚ(m^(1/n)) : ℚ] = n"
+      "name": "Sqrt2MinpolyOQ02.adjoin_kthRoot_finrank",
+      "statement": "Module.finrank ℚ ℚ⟮(m : ℝ) ^ ((1 : ℝ) / ↑k)⟯ = k",
+      "description": "Field extension degree [ℚ(m^(1/k)) : ℚ] = k when m has a squarefree prime factor"
     },
     {
-      "name": "CubeRoot2IrrationalOQ03.not_perfect_power_of_sqfree_factor",
-      "statement": "¬ ∃ k : ℕ, m = k ^ n",
-      "description": "m is not a perfect n-th power when it has a squarefree prime factor"
+      "name": "Sqrt2MinpolyOQ02.not_perfect_kthPower_of_sqfree_factor",
+      "statement": "¬ ∃ n : ℕ, m = n ^ k",
+      "description": "m is not a perfect k-th power when it has a squarefree prime factor"
     }
   ],
   "sorries": 0

--- a/src/data/research/problems/erdos-476-oq-05.json
+++ b/src/data/research/problems/erdos-476-oq-05.json
@@ -1,13 +1,13 @@
 {
   "slug": "erdos-476-oq-05",
-  "title": "Erdős #476: Structure of Cauchy-Davenport Extremal Sets (Vosper's Theorem)",
+  "title": "Erd\u0151s #476: Structure of Cauchy-Davenport Extremal Sets (Vosper's Theorem)",
   "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
   "problemStatement": {
-    "formal": "theorem vosper (p : ℕ) [hp : Fact (Nat.Prime p)] (A B : Finset (ZMod p)) (hA : 2 ≤ A.card) (hB : 2 ≤ B.card) (h : (A + B).card = A.card + B.card - 1) (hlt : A.card + B.card - 1 < p) : ∃ (d : ZMod p) (a b : ZMod p), IsArithmeticProgression A a d ∧ IsArithmeticProgression B b d",
-    "plain": "Vosper's theorem (1956): if equality holds in the Cauchy-Davenport bound |A+B| = |A|+|B|-1 for non-trivial A,B ⊆ Z/pZ, then A and B are arithmetic progressions with the same common difference d.",
+    "formal": "theorem vosper (p : \u2115) [hp : Fact (Nat.Prime p)] (A B : Finset (ZMod p)) (hA : 2 \u2264 A.card) (hB : 2 \u2264 B.card) (h : (A + B).card = A.card + B.card - 1) (hlt : A.card + B.card - 1 < p) : \u2203 (d : ZMod p) (a b : ZMod p), IsArithmeticProgression A a d \u2227 IsArithmeticProgression B b d",
+    "plain": "Vosper's theorem (1956): if equality holds in the Cauchy-Davenport bound |A+B| = |A|+|B|-1 for non-trivial A,B \u2286 Z/pZ, then A and B are arithmetic progressions with the same common difference d.",
     "whyMatters": [
       "Completes the Cauchy-Davenport theorem with a structural characterization of extremizers",
       "Cornerstone of additive combinatorics: characterizes when sumsets are minimally small",
@@ -16,7 +16,7 @@
   },
   "knownResults": {
     "proven": [
-      "erdos-476: Cauchy-Davenport lower bound |A+B| ≥ min(p, |A|+|B|-1) (verified, 0 sorries)"
+      "erdos-476: Cauchy-Davenport lower bound |A+B| \u2265 min(p, |A|+|B|-1) (verified, 0 sorries)"
     ],
     "open": [
       "Vosper's theorem: equality case structure",
@@ -38,32 +38,36 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: isAP_sdiff_card proved (A\\A.image(·+d)={a} for AP A); vosper_ap_sdiff_card structured (only hpos sorry remains); vosper_base fully proved; 2 sorries total: hpos (position analysis) and vosper_case1_exists.",
+    "progressSummary": "PROGRESS: hpos (position analysis) proved via linear_combination; 1 sorry remains (vosper_case1_exists counting argument)",
     "builtItems": [
-      "isAP_sdiff_card: proved A\\A.image(·+d)={a} for AP(a,d) with d≠0, |A|<p — key: start a has no predecessor (Erdos476OQ05Problem.lean:153)",
-      "vosper_ap_sdiff_card: structured proof using isAP_sdiff_card, hunion, h_sdiff_one — only hpos (position analysis) remains (Erdos476OQ05Problem.lean:207)",
-      "vosper_base: fully proved — base case |A|=2 using card arithmetic and Finset.card_inter_add_card_sdiff",
-      "ap_of_near_periodic: proved — B\\B.image(·+d)={b} and d≠0 implies B is AP starting at b"
+      "isAP_sdiff_card: proved A\\A.image(\u00b7+d)={a} for AP(a,d) with d\u22600, |A|<p \u2014 key: start a has no predecessor (Erdos476OQ05Problem.lean:153)",
+      "vosper_ap_sdiff_card: structured proof using isAP_sdiff_card, hunion, h_sdiff_one \u2014 only hpos (position analysis) remains (Erdos476OQ05Problem.lean:207)",
+      "vosper_base: fully proved \u2014 base case |A|=2 using card arithmetic and Finset.card_inter_add_card_sdiff",
+      "ap_of_near_periodic: proved \u2014 B\\B.image(\u00b7+d)={b} and d\u22600 implies B is AP starting at b",
+      "hpos position analysis (vosper_ap_sdiff_card): predecessor/successor case analysis \u2014 proofs/Proofs/Erdos476OQ05Problem.lean:248-450"
     ],
     "insights": [
-      "Vosper 1956: equality |A+B|=|A|+|B|-1 (with |A|,|B|≥2, |A|+|B|≤p) ↔ A,B are APs with same common difference",
+      "Vosper 1956: equality |A+B|=|A|+|B|-1 (with |A|,|B|\u22652, |A|+|B|\u2264p) \u2194 A,B are APs with same common difference",
       "Edge cases: |A|=1 or |B|=1 give trivial equality with no structure constraint",
       "Proof structure: induction on |A|, removing one element and applying CD to smaller set",
-      "AP in Z/pZ: set {a, a+d, a+2d, ..., a+(k-1)d} mod p; d≠0 since p is prime",
+      "AP in Z/pZ: set {a, a+d, a+2d, ..., a+(k-1)d} mod p; d\u22600 since p is prime",
       "Recursive theorem with termination_by A.card works cleanly for vosper induction",
       "Case 1 existence proved by contradiction: if all a in A give Case 2, counting gives |A|*|B| >= 2(|A|+|B|-1) which fails for small sizes",
       "AP extension: |{a0}+B minus A-prime+B|=1 forces a0 to be adjacent to A-prime (predecessor or successor)",
-      "isAP_sdiff_card key insight: in AP(a,d), start a has no d-predecessor; any predecessor y=a+(j:ZMod p)*d would require (j+1)*d=0, but j+1<=|A|<p so p∤j+1",
-      "Finset.card_inter_add_card_sdiff (not card_sdiff_add_card_inter) is the correct Mathlib lemma: (s∩t).card+(s\\t).card=s.card",
-      "subst ha where ha:a=a₀ in Lean 4 eliminates a₀ from context, not a — use rw [ha] instead when a₀ is needed downstream",
-      "Docker lean-mathlib-cache has stale oleans causing ring/push_cast/linear_combination to fail as unknown tactic — pre-existing environment issue"
+      "isAP_sdiff_card key insight: in AP(a,d), start a has no d-predecessor; any predecessor y=a+(j:ZMod p)*d would require (j+1)*d=0, but j+1<=|A|<p so p\u2224j+1",
+      "Finset.card_inter_add_card_sdiff (not card_sdiff_add_card_inter) is the correct Mathlib lemma: (s\u2229t).card+(s\\t).card=s.card",
+      "subst ha where ha:a=a\u2080 in Lean 4 eliminates a\u2080 from context, not a \u2014 use rw [ha] instead when a\u2080 is needed downstream",
+      "Docker lean-mathlib-cache has stale oleans causing ring/push_cast/linear_combination to fail as unknown tactic \u2014 pre-existing environment issue",
+      "hpos (position analysis in vosper_ap_sdiff_card) proved via linear_combination \u2014 ZMod p ring algebra, not linarith",
+      "linarith is inapplicable in ZMod p (not ordered ring); linear_combination (CommRing tactic) works in any ring",
+      "Set.InjOn is the correct Lean 4 Mathlib name (not Function.InjOn) for set injectivity",
+      "import Mathlib.Tactic required for linear_combination and push_cast; Mathlib.Tactic.IntervalCases insufficient"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove hpos (vosper_ap_sdiff_card position analysis): given both APs with diff d and |{a₀}+B\\(A'+B)|=1, show a₀ is predecessor or successor of A'",
-      "Prove vosper_case1_exists: counting argument (all redundant → |A|*|B|≥2|A+B| contradiction) or iterative removal",
-      "Submit hpos and vosper_case1_exists to Aristotle for automated proof search",
-      "Fix Docker stale oleans to enable full build verification"
+      "Submit vosper_case1_exists to Aristotle (HARD \u2014 counting argument for Case 1 existence)",
+      "Counting argument: |A+B|=|A|+|B|-1 < p with CD equality implies d exists s.t. (A.erase a0).image(\u00b7+d) intersects B in |B|-1 elements",
+      "Consider ap_sdiff_card helper: A sdiff A.image(\u00b7+d) = {a0} implies A is AP via ap_of_near_periodic"
     ]
   },
   "tags": [
@@ -84,7 +88,7 @@
   "references": {
     "papers": [
       "Vosper, A.G. (1956): The fraction of subsets of integers summing to a given value",
-      "Nathanson, M.B. Additive Number Theory: Inverse Problems, §2.4"
+      "Nathanson, M.B. Additive Number Theory: Inverse Problems, \u00a72.4"
     ],
     "urls": [],
     "mathlib": [
@@ -123,11 +127,11 @@
     {
       "path": "Proofs/Erdos476OQ05Problem.lean",
       "filename": "Erdos476OQ05Problem.lean",
-      "lineCount": 583,
+      "lineCount": 771,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos476OQ05Problem.lean"
     },


### PR DESCRIPTION
## Summary

- Creates `proofs/Proofs/Sqrt2MinpolyOQ02.lean` — a dedicated 202-line proof file for the gallery entry `sqrt2-minpoly-oq-02`
- Answers the open question: **when is `minpoly ℚ (m^(1/k)) = Xᵏ - m`?** — whenever m has a prime factor p with p | m but p² ∤ m
- Builds on `CubeRoot2IrrationalOQ03`'s general Eisenstein infrastructure
- Updates `meta.json` to point `proofRepoPath` to the new file and list `Sqrt2MinpolyOQ02` namespace theorems

## Key Theorems (all 0 sorries, 0 axioms)

- `minpoly_kthRoot_of_sqfree_factor`: general Eisenstein result for all k ≥ 2
- `minpoly_kthRoot_of_squarefree`: squarefree corollary — all squarefree m ≥ 2
- `adjoin_kthRoot_finrank`: field extension degree [ℚ(m^(1/k)):ℚ] = k
- `not_perfect_kthPower_of_sqfree_factor`: non-perfect-power criterion
- 12 concrete examples: ∛2,3,5,6,7; ⁴√2,3,5,30; ⁵√2,3,12
- Field degree examples: [ℚ(∛2):ℚ]=3, [ℚ(⁴√2):ℚ]=4, [ℚ(⁵√3):ℚ]=5

## Build Verification

`Proofs.Sqrt2MinpolyOQ02` compiled successfully via `docker-build.sh`. The `.olean` artifact was created with no errors.

## Test plan

- [x] `Sqrt2MinpolyOQ02.olean` built successfully via `./proofs/scripts/docker-build.sh Proofs.Sqrt2MinpolyOQ02`
- [x] 0 sorries confirmed in the Lean file
- [x] 0 axioms (all theorems are definitional or delegate to CubeRoot2IrrationalOQ03)
- [x] `meta.json` updated: `proofRepoPath`, `mainTheorems`, `lineCount`

🤖 Generated with [Claude Code](https://claude.com/claude-code)