### PR TITLE
Fix: add missing leanFile.path to 20 gallery meta.json files

### DIFF
--- a/src/data/proofs/birch-swinnerton-dyer/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer/meta.json
@@ -718,6 +718,7 @@
   "leanFile": {
     "axiomCount": 18,
     "lineCount": 7432,
-    "sorries": 0
+    "sorries": 0,
+    "path": "Proofs/BirchSwinnertonDyer.lean"
   }
 }

--- a/src/data/proofs/brouwer-fixed-point/meta.json
+++ b/src/data/proofs/brouwer-fixed-point/meta.json
@@ -309,6 +309,7 @@
   "leanFile": {
     "axiomCount": 2,
     "lineCount": 249,
-    "sorries": 0
+    "sorries": 0,
+    "path": "Proofs/BrouwerFixedPoint.lean"
   }
 }

--- a/src/data/proofs/dissection-of-cubes-oq-04/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-04/meta.json
@@ -209,6 +209,7 @@
   "leanFile": {
     "axiomCount": 2,
     "lineCount": 436,
-    "sorries": 0
+    "sorries": 0,
+    "path": "Proofs/DissectionOfCubesOQ04.lean"
   }
 }

--- a/src/data/proofs/erdos-1002-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-1002-oq-01-oq-01/meta.json
@@ -147,6 +147,7 @@
   "leanFile": {
     "axiomCount": 1,
     "lineCount": 705,
-    "sorries": 1
+    "sorries": 1,
+    "path": "Proofs/Erdos1002OQ01OQ01.lean"
   }
 }

--- a/src/data/proofs/erdos-107/meta.json
+++ b/src/data/proofs/erdos-107/meta.json
@@ -209,6 +209,7 @@
   "leanFile": {
     "axiomCount": 6,
     "lineCount": 243,
-    "sorries": 2
+    "sorries": 2,
+    "path": "Proofs/Erdos107Problem.lean"
   }
 }

--- a/src/data/proofs/erdos-1083-oq-02/meta.json
+++ b/src/data/proofs/erdos-1083-oq-02/meta.json
@@ -153,6 +153,7 @@
   "leanFile": {
     "axiomCount": 6,
     "lineCount": 372,
-    "sorries": 0
+    "sorries": 0,
+    "path": "Proofs/Erdos1083OQ02.lean"
   }
 }

--- a/src/data/proofs/erdos-1091/meta.json
+++ b/src/data/proofs/erdos-1091/meta.json
@@ -174,6 +174,7 @@
   "leanFile": {
     "axiomCount": 5,
     "lineCount": 211,
-    "sorries": 0
+    "sorries": 0,
+    "path": "Proofs/Erdos1091Problem.lean"
   }
 }

--- a/src/data/proofs/erdos-1107-oq-02/meta.json
+++ b/src/data/proofs/erdos-1107-oq-02/meta.json
@@ -111,6 +111,7 @@
   "leanFile": {
     "axiomCount": 1,
     "lineCount": 156,
-    "sorries": 0
+    "sorries": 0,
+    "path": "Proofs/Erdos1107OQ02.lean"
   }
 }

--- a/src/data/proofs/erdos-1113/meta.json
+++ b/src/data/proofs/erdos-1113/meta.json
@@ -202,6 +202,7 @@
   "leanFile": {
     "axiomCount": 1,
     "lineCount": 172,
-    "sorries": 0
+    "sorries": 0,
+    "path": "Proofs/Erdos1113Problem.lean"
   }
 }

--- a/src/data/proofs/erdos-1202/meta.json
+++ b/src/data/proofs/erdos-1202/meta.json
@@ -161,6 +161,7 @@
   "leanFile": {
     "axiomCount": 1,
     "lineCount": 115,
-    "sorries": 0
+    "sorries": 0,
+    "path": "Proofs/Erdos1202Problem.lean"
   }
 }

--- a/src/data/proofs/erdos-1205/meta.json
+++ b/src/data/proofs/erdos-1205/meta.json
@@ -150,6 +150,7 @@
   "leanFile": {
     "axiomCount": 2,
     "lineCount": 87,
-    "sorries": 0
+    "sorries": 0,
+    "path": "Proofs/Erdos1205Problem.lean"
   }
 }

--- a/src/data/proofs/erdos-1208/meta.json
+++ b/src/data/proofs/erdos-1208/meta.json
@@ -146,6 +146,7 @@
   "leanFile": {
     "axiomCount": 2,
     "lineCount": 137,
-    "sorries": 1
+    "sorries": 1,
+    "path": "Proofs/Erdos1208Problem.lean"
   }
 }

--- a/src/data/proofs/erdos-181-oq-01/meta.json
+++ b/src/data/proofs/erdos-181-oq-01/meta.json
@@ -138,6 +138,7 @@
   "leanFile": {
     "axiomCount": 2,
     "lineCount": 170,
-    "sorries": 0
+    "sorries": 0,
+    "path": "Proofs/Erdos181OQ01.lean"
   }
 }

--- a/src/data/proofs/godel-first-incompleteness-oq01/meta.json
+++ b/src/data/proofs/godel-first-incompleteness-oq01/meta.json
@@ -167,6 +167,7 @@
   "leanFile": {
     "axiomCount": 5,
     "lineCount": 271,
-    "sorries": 0
+    "sorries": 0,
+    "path": "Proofs/GodelFirstIncompletenessOQ01.lean"
   }
 }

--- a/src/data/proofs/godel-second-incompleteness-oq02/meta.json
+++ b/src/data/proofs/godel-second-incompleteness-oq02/meta.json
@@ -162,6 +162,7 @@
   "leanFile": {
     "axiomCount": 6,
     "lineCount": 258,
-    "sorries": 0
+    "sorries": 0,
+    "path": "Proofs/GodelSecondIncompletenessOQ02.lean"
   }
 }

--- a/src/data/proofs/pascals-hexagon/meta.json
+++ b/src/data/proofs/pascals-hexagon/meta.json
@@ -227,6 +227,7 @@
   "leanFile": {
     "axiomCount": 1,
     "lineCount": 1278,
-    "sorries": 1
+    "sorries": 1,
+    "path": "Proofs/PascalsHexagon.lean"
   }
 }

--- a/src/data/proofs/picks-theorem-oq-03/meta.json
+++ b/src/data/proofs/picks-theorem-oq-03/meta.json
@@ -233,6 +233,7 @@
   "leanFile": {
     "axiomCount": 2,
     "lineCount": 710,
-    "sorries": 0
+    "sorries": 0,
+    "path": "Proofs/EhrhartPolynomialOQ03.lean"
   }
 }

--- a/src/data/proofs/picks-theorem/meta.json
+++ b/src/data/proofs/picks-theorem/meta.json
@@ -222,6 +222,7 @@
   "leanFile": {
     "axiomCount": 1,
     "lineCount": 484,
-    "sorries": 0
+    "sorries": 0,
+    "path": "Proofs/PicksTheorem.lean"
   }
 }

--- a/src/data/proofs/sylow-theorems-oq-02/meta.json
+++ b/src/data/proofs/sylow-theorems-oq-02/meta.json
@@ -209,6 +209,7 @@
   "leanFile": {
     "axiomCount": 5,
     "lineCount": 393,
-    "sorries": 0
+    "sorries": 0,
+    "path": "Proofs/SylowTheoremOQ02.lean"
   }
 }

--- a/src/data/proofs/taylor-sincos-convergence/meta.json
+++ b/src/data/proofs/taylor-sincos-convergence/meta.json
@@ -223,6 +223,7 @@
   "leanFile": {
     "axiomCount": 2,
     "lineCount": 348,
-    "sorries": 0
+    "sorries": 0,
+    "path": "Proofs/TaylorSinCosConvergence.lean"
   }
 }


### PR DESCRIPTION
## Fix

Added missing `leanFile.path` field to 20 gallery `meta.json` files that had `leanFile` sections with `axiomCount`, `lineCount`, and `sorries` populated but no `path` pointing to the Lean source file.

## Evidence

**Before**: `"leanFile": { "axiomCount": 2, "lineCount": 436, "sorries": 0 }` (no path)
**After**: `"leanFile": { "axiomCount": 2, "lineCount": 436, "sorries": 0, "path": "Proofs/DissectionOfCubesOQ04.lean" }`

## Proofs fixed (20 total)

| Slug | Lean file |
|------|-----------|
| birch-swinnerton-dyer | BirchSwinnertonDyer.lean |
| brouwer-fixed-point | BrouwerFixedPoint.lean |
| dissection-of-cubes-oq-04 | DissectionOfCubesOQ04.lean |
| erdos-1002-oq-01-oq-01 | Erdos1002OQ01OQ01.lean |
| erdos-107 | Erdos107Problem.lean |
| erdos-1083-oq-02 | Erdos1083OQ02.lean |
| erdos-1091 | Erdos1091Problem.lean |
| erdos-1107-oq-02 | Erdos1107OQ02.lean |
| erdos-1113 | Erdos1113Problem.lean |
| erdos-1202 | Erdos1202Problem.lean |
| erdos-1205 | Erdos1205Problem.lean |
| erdos-1208 | Erdos1208Problem.lean |
| erdos-181-oq-01 | Erdos181OQ01.lean |
| godel-first-incompleteness-oq01 | GodelFirstIncompletenessOQ01.lean |
| godel-second-incompleteness-oq02 | GodelSecondIncompletenessOQ02.lean |
| pascals-hexagon | PascalsHexagon.lean |
| picks-theorem-oq-03 | EhrhartPolynomialOQ03.lean |
| picks-theorem | PicksTheorem.lean |
| sylow-theorems-oq-02 | SylowTheoremOQ02.lean |
| taylor-sincos-convergence | TaylorSinCosConvergence.lean |

All paths verified against actual Lean files using line count cross-check.

---
Automated fix by lean-mechanic agent.