### PR TITLE
Audit fix: erdos-609 badge wip→axiom

### DIFF
--- a/src/data/proofs/erdos-609/meta.json
+++ b/src/data/proofs/erdos-609/meta.json
@@ -17,7 +17,7 @@
       "extremal-combinatorics",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 609,
     "erdosUrl": "https://erdosproblems.com/609",


### PR DESCRIPTION
## Summary

- `erdos-609` had `badge: wip` but `status: axiomatized` with 11 axiom declarations and 0 sorries
- Per CLAUDE.md: `axiomatized` status requires `badge: axiom` when axiom declarations are present
- `wip` badge implies unfinished work, but this proof is a complete axiomatization

## Evidence

**meta.json claimed**: `badge: wip`, `status: axiomatized`, `axiomCount: 11`, `sorries: 0`

**Lean file shows**: 11 `axiom` declarations, 0 sorries — fully axiomatized, not a WIP

## Fix

Changed `badge: wip` → `badge: axiom` in `src/data/proofs/erdos-609/meta.json`

---
Discovered during gallery integrity audit (2026-04-23).