### PR TITLE
Fix: sync stale leanFile.sorries in 7 gallery meta.json files

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-01/meta.json
@@ -143,7 +143,7 @@
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 4,
-    "sorries": 1,
+    "sorries": 0,
     "path": "Proofs/CantorDiagonalizationOQ03OQ01.lean"
   }
 }

--- a/src/data/proofs/derangements-convergence-oq-01/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-01/meta.json
@@ -146,7 +146,7 @@
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 1,
-    "sorries": 3,
+    "sorries": 0,
     "path": "Proofs/DerangementsConvergenceOQ01.lean"
   }
 }

--- a/src/data/proofs/law-of-sines-oq-06/meta.json
+++ b/src/data/proofs/law-of-sines-oq-06/meta.json
@@ -165,7 +165,7 @@
     "axiomCount": 0,
     "theoremCount": 24,
     "definitionCount": 8,
-    "sorries": 1,
+    "sorries": 0,
     "path": "Proofs/LawOfSinesOQ06.lean"
   }
 }

--- a/src/data/proofs/ptolemys-theorem-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01-incomplete-01/meta.json
@@ -161,7 +161,7 @@
     "axiomCount": 0,
     "theoremCount": 2,
     "definitionCount": 0,
-    "sorries": 3,
+    "sorries": 0,
     "path": "Proofs/PtolemysTheoremOQ01Incomplete01.lean"
   }
 }

--- a/src/data/proofs/schroeder-bernstein-oq-03/meta.json
+++ b/src/data/proofs/schroeder-bernstein-oq-03/meta.json
@@ -240,7 +240,7 @@
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 4,
-    "sorries": 5,
+    "sorries": 4,
     "path": "Proofs/SchroederBernsteinOQ03.lean"
   }
 }

--- a/src/data/proofs/shapley-folkman/meta.json
+++ b/src/data/proofs/shapley-folkman/meta.json
@@ -208,7 +208,7 @@
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 1,
-    "sorries": 2,
+    "sorries": 1,
     "path": "Proofs/ShapleyFolkman.lean"
   }
 }

--- a/src/data/proofs/taylor-sincos-convergence-oq-01/meta.json
+++ b/src/data/proofs/taylor-sincos-convergence-oq-01/meta.json
@@ -247,7 +247,7 @@
     "axiomCount": 0,
     "theoremCount": 9,
     "definitionCount": 0,
-    "sorries": 1,
+    "sorries": 0,
     "path": "Proofs/TaylorSinCosConvergenceOQ01.lean"
   }
 }


### PR DESCRIPTION
## Fix

7 gallery proofs where sorry tactics were resolved but `leanFile.sorries` was not updated. The top-level `meta.sorries` was already correct in all cases — only the `leanFile` subsection was stale.

## Evidence

| Proof | Before | After |
|-------|--------|-------|
| cantor-diagonalization-oq-03-oq-01-oq-01 | `leanFile.sorries: 1` | `leanFile.sorries: 0` |
| derangements-convergence-oq-01 | `leanFile.sorries: 3` | `leanFile.sorries: 0` |
| law-of-sines-oq-06 | `leanFile.sorries: 1` | `leanFile.sorries: 0` |
| ptolemys-theorem-oq-01-incomplete-01 | `leanFile.sorries: 3` | `leanFile.sorries: 0` |
| taylor-sincos-convergence-oq-01 | `leanFile.sorries: 1` | `leanFile.sorries: 0` |
| schroeder-bernstein-oq-03 | `leanFile.sorries: 5` | `leanFile.sorries: 4` |
| shapley-folkman | `leanFile.sorries: 2` | `leanFile.sorries: 1` |

**Method**: Counted sorry tactics using a depth-tracking block-comment parser (handles nested `/-...-/`) and single-line `--` comment stripping.

**Build**: `pnpm build` passes (exit code 0).

---
Automated fix by lean-mechanic agent.