### PR TITLE
Fix: correct leanFile.path case in 4 gallery meta.json files

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius",
     "date": "2026-02-15",
     "status": "verified",
-    "proofRepoPath": "Proofs/AmgmInequalityOQ02OQ01.lean",
+    "proofRepoPath": "Proofs/AMGMInequalityOQ02OQ01.lean",
     "tags": [
       "combinatorics",
       "symmetric-polynomials",
@@ -62,7 +62,7 @@
     "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 0,
-    "path": "Proofs/AmgmInequalityOQ02OQ01.lean",
+    "path": "Proofs/AMGMInequalityOQ02OQ01.lean",
     "sorries": 0
   },
   "crossReferences": [

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01/meta.json
@@ -16,7 +16,7 @@
       "integration",
       "research"
     ],
-    "proofRepoPath": "Proofs/AreaOfCircleOq01Oq02Oq01.lean",
+    "proofRepoPath": "Proofs/AreaOfCircleOQ01OQ02OQ01.lean",
     "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
@@ -227,7 +227,7 @@
     "axiomCount": 0,
     "theoremCount": 26,
     "definitionCount": 3,
-    "path": "Proofs/AreaOfCircleOq01Oq02Oq01.lean",
+    "path": "Proofs/AreaOfCircleOQ01OQ02OQ01.lean",
     "sorries": 0
   },
   "references": [

--- a/src/data/proofs/gcd-algorithm-oq-01-oq-03/meta.json
+++ b/src/data/proofs/gcd-algorithm-oq-01-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius",
     "date": "2026-02-15",
     "status": "verified",
-    "proofRepoPath": "Proofs/GcdAlgorithmOQ01OQ03.lean",
+    "proofRepoPath": "Proofs/GCDAlgorithmOQ01OQ03.lean",
     "tags": [
       "number-theory",
       "euclidean-algorithm",
@@ -64,7 +64,7 @@
     "axiomCount": 0,
     "theoremCount": 22,
     "definitionCount": 2,
-    "path": "Proofs/GcdAlgorithmOQ01OQ03.lean",
+    "path": "Proofs/GCDAlgorithmOQ01OQ03.lean",
     "sorries": 0
   },
   "crossReferences": [

--- a/src/data/proofs/ptolemys-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01-oq-01/meta.json
@@ -153,6 +153,6 @@
     "theoremCount": 1,
     "definitionCount": 0,
     "sorries": 0,
-    "path": "Proofs/PtolemysTheoremOq01Oq01.lean"
+    "path": "Proofs/PtolemysTheoremOQ01OQ01.lean"
   }
 }


### PR DESCRIPTION
## Fix

4 gallery proofs had `leanFile.path` values with incorrect letter case. On macOS (case-insensitive filesystem) these work fine, but on Linux (case-sensitive) these paths would fail to resolve the Lean source file.

## Evidence

| Proof | Before | After |
|-------|--------|-------|
| amgm-inequality-oq-02-oq-01 | `Proofs/AmgmInequalityOQ02OQ01.lean` | `Proofs/AMGMInequalityOQ02OQ01.lean` |
| area-of-circle-oq-01-oq-02-oq-01 | `Proofs/AreaOfCircleOq01Oq02Oq01.lean` | `Proofs/AreaOfCircleOQ01OQ02OQ01.lean` |
| gcd-algorithm-oq-01-oq-03 | `Proofs/GcdAlgorithmOQ01OQ03.lean` | `Proofs/GCDAlgorithmOQ01OQ03.lean` |
| ptolemys-theorem-oq-01-oq-01 | `Proofs/PtolemysTheoremOq01Oq01.lean` | `Proofs/PtolemysTheoremOQ01OQ01.lean` |

**Build**: `pnpm build` passes (exit code 0).

---
Automated fix by lean-mechanic agent.