### PR TITLE
Fix: sync stale leanFile.lineCount in 41 gallery meta.json files

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
@@ -267,7 +267,7 @@
       "Topology"
     ],
     "namespace": "IsoperimetricOQ",
-    "lineCount": 1937,
+    "lineCount": 1938,
     "axiomCount": 0,
     "theoremCount": 68,
     "definitionCount": 12,

--- a/src/data/proofs/cauchy-schwarz-integral/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral/meta.json
@@ -187,7 +187,7 @@
       "MeasureTheory"
     ],
     "namespace": "BunyakovskySchwarz",
-    "lineCount": 117,
+    "lineCount": 118,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 0,

--- a/src/data/proofs/erdos-1028/meta.json
+++ b/src/data/proofs/erdos-1028/meta.json
@@ -238,7 +238,7 @@
       "Finset"
     ],
     "namespace": "Erdos1028",
-    "lineCount": 310,
+    "lineCount": 311,
     "axiomCount": 2,
     "theoremCount": 8,
     "definitionCount": 10,

--- a/src/data/proofs/erdos-1034/meta.json
+++ b/src/data/proofs/erdos-1034/meta.json
@@ -273,7 +273,7 @@
       "Finset"
     ],
     "namespace": "Erdos1034",
-    "lineCount": 778,
+    "lineCount": 779,
     "axiomCount": 1,
     "theoremCount": 17,
     "definitionCount": 22,

--- a/src/data/proofs/erdos-108/meta.json
+++ b/src/data/proofs/erdos-108/meta.json
@@ -225,7 +225,7 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos108",
-    "lineCount": 141,
+    "lineCount": 142,
     "axiomCount": 1,
     "theoremCount": 2,
     "definitionCount": 0,

--- a/src/data/proofs/erdos-109/meta.json
+++ b/src/data/proofs/erdos-109/meta.json
@@ -242,7 +242,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos109",
-    "lineCount": 437,
+    "lineCount": 438,
     "axiomCount": 1,
     "theoremCount": 13,
     "definitionCount": 9,

--- a/src/data/proofs/erdos-1161/meta.json
+++ b/src/data/proofs/erdos-1161/meta.json
@@ -143,7 +143,7 @@
       "Nat"
     ],
     "namespace": null,
-    "lineCount": 323,
+    "lineCount": 324,
     "axiomCount": 0,
     "theoremCount": 15,
     "definitionCount": 3,

--- a/src/data/proofs/erdos-123/meta.json
+++ b/src/data/proofs/erdos-123/meta.json
@@ -116,7 +116,7 @@
       "Pointwise"
     ],
     "namespace": "Erdos123",
-    "lineCount": 317,
+    "lineCount": 318,
     "axiomCount": 3,
     "theoremCount": 22,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-139/meta.json
+++ b/src/data/proofs/erdos-139/meta.json
@@ -113,7 +113,7 @@
       "Topology"
     ],
     "namespace": "Erdos139",
-    "lineCount": 260,
+    "lineCount": 261,
     "axiomCount": 4,
     "theoremCount": 8,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-143/meta.json
+++ b/src/data/proofs/erdos-143/meta.json
@@ -219,7 +219,7 @@
       "Topology"
     ],
     "namespace": "Erdos143",
-    "lineCount": 119,
+    "lineCount": 120,
     "axiomCount": 3,
     "theoremCount": 1,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-157/meta.json
+++ b/src/data/proofs/erdos-157/meta.json
@@ -159,7 +159,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos157",
-    "lineCount": 535,
+    "lineCount": 536,
     "axiomCount": 3,
     "theoremCount": 7,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-167/meta.json
+++ b/src/data/proofs/erdos-167/meta.json
@@ -136,7 +136,7 @@
       "Set"
     ],
     "namespace": "Erdos167",
-    "lineCount": 274,
+    "lineCount": 275,
     "axiomCount": 1,
     "theoremCount": 4,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-168/meta.json
+++ b/src/data/proofs/erdos-168/meta.json
@@ -141,7 +141,7 @@
       "Finset"
     ],
     "namespace": "Erdos168",
-    "lineCount": 180,
+    "lineCount": 181,
     "axiomCount": 2,
     "theoremCount": 4,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-171/meta.json
+++ b/src/data/proofs/erdos-171/meta.json
@@ -197,7 +197,7 @@
       "Metric"
     ],
     "namespace": "Erdos171",
-    "lineCount": 302,
+    "lineCount": 303,
     "axiomCount": 2,
     "theoremCount": 16,
     "definitionCount": 4,

--- a/src/data/proofs/erdos-172/meta.json
+++ b/src/data/proofs/erdos-172/meta.json
@@ -155,7 +155,7 @@
       "Finset"
     ],
     "namespace": "Erdos172",
-    "lineCount": 144,
+    "lineCount": 145,
     "axiomCount": 3,
     "theoremCount": 4,
     "definitionCount": 6,

--- a/src/data/proofs/erdos-202/meta.json
+++ b/src/data/proofs/erdos-202/meta.json
@@ -175,7 +175,7 @@
       "Classical"
     ],
     "namespace": "Erdos202",
-    "lineCount": 859,
+    "lineCount": 860,
     "axiomCount": 0,
     "theoremCount": 40,
     "definitionCount": 19,

--- a/src/data/proofs/erdos-29/meta.json
+++ b/src/data/proofs/erdos-29/meta.json
@@ -171,7 +171,7 @@
       "Filter"
     ],
     "namespace": "Erdos29",
-    "lineCount": 523,
+    "lineCount": 524,
     "axiomCount": 5,
     "theoremCount": 12,
     "definitionCount": 12,

--- a/src/data/proofs/erdos-299/meta.json
+++ b/src/data/proofs/erdos-299/meta.json
@@ -170,7 +170,7 @@
       "Finset"
     ],
     "namespace": "Erdos299",
-    "lineCount": 386,
+    "lineCount": 387,
     "axiomCount": 1,
     "theoremCount": 10,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-303/meta.json
+++ b/src/data/proofs/erdos-303/meta.json
@@ -144,7 +144,7 @@
       "Set"
     ],
     "namespace": "Erdos303",
-    "lineCount": 258,
+    "lineCount": 259,
     "axiomCount": 2,
     "theoremCount": 8,
     "definitionCount": 8,

--- a/src/data/proofs/erdos-355/meta.json
+++ b/src/data/proofs/erdos-355/meta.json
@@ -147,7 +147,7 @@
       "Set"
     ],
     "namespace": "Erdos355",
-    "lineCount": 391,
+    "lineCount": 392,
     "axiomCount": 2,
     "theoremCount": 15,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-37/meta.json
+++ b/src/data/proofs/erdos-37/meta.json
@@ -225,7 +225,7 @@
       "Filter"
     ],
     "namespace": "Erdos37",
-    "lineCount": 367,
+    "lineCount": 368,
     "axiomCount": 6,
     "theoremCount": 6,
     "definitionCount": 10,

--- a/src/data/proofs/erdos-370/meta.json
+++ b/src/data/proofs/erdos-370/meta.json
@@ -69,7 +69,7 @@
   },
   "leanFile": {
     "path": "Proofs/Erdos370Problem.lean",
-    "lineCount": 284,
+    "lineCount": 285,
     "namespace": "Erdos370",
     "imports": [
       "Mathlib"

--- a/src/data/proofs/erdos-402/meta.json
+++ b/src/data/proofs/erdos-402/meta.json
@@ -177,7 +177,7 @@
       "Finset"
     ],
     "namespace": "Erdos402",
-    "lineCount": 693,
+    "lineCount": 694,
     "axiomCount": 0,
     "theoremCount": 25,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-45/meta.json
+++ b/src/data/proofs/erdos-45/meta.json
@@ -133,7 +133,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos45",
-    "lineCount": 141,
+    "lineCount": 142,
     "axiomCount": 3,
     "theoremCount": 3,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-485/meta.json
+++ b/src/data/proofs/erdos-485/meta.json
@@ -115,7 +115,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos485",
-    "lineCount": 225,
+    "lineCount": 226,
     "axiomCount": 1,
     "theoremCount": 3,
     "definitionCount": 6,

--- a/src/data/proofs/erdos-517/meta.json
+++ b/src/data/proofs/erdos-517/meta.json
@@ -145,7 +145,7 @@
       "Topology"
     ],
     "namespace": "Erdos517",
-    "lineCount": 175,
+    "lineCount": 176,
     "axiomCount": 1,
     "theoremCount": 3,
     "definitionCount": 3,

--- a/src/data/proofs/erdos-551/meta.json
+++ b/src/data/proofs/erdos-551/meta.json
@@ -175,7 +175,7 @@
       "Finset"
     ],
     "namespace": "Erdos551",
-    "lineCount": 603,
+    "lineCount": 604,
     "axiomCount": 0,
     "theoremCount": 26,
     "definitionCount": 14,

--- a/src/data/proofs/erdos-60/meta.json
+++ b/src/data/proofs/erdos-60/meta.json
@@ -182,7 +182,7 @@
       "Finset"
     ],
     "namespace": "Erdos60",
-    "lineCount": 385,
+    "lineCount": 386,
     "axiomCount": 8,
     "theoremCount": 10,
     "definitionCount": 12,

--- a/src/data/proofs/erdos-604/meta.json
+++ b/src/data/proofs/erdos-604/meta.json
@@ -184,7 +184,7 @@
       "Set"
     ],
     "namespace": null,
-    "lineCount": 223,
+    "lineCount": 224,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 11,

--- a/src/data/proofs/erdos-624/meta.json
+++ b/src/data/proofs/erdos-624/meta.json
@@ -172,7 +172,7 @@
       "Set"
     ],
     "namespace": "Erdos624",
-    "lineCount": 218,
+    "lineCount": 219,
     "axiomCount": 5,
     "theoremCount": 4,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-629/meta.json
+++ b/src/data/proofs/erdos-629/meta.json
@@ -175,7 +175,7 @@
       "Finset"
     ],
     "namespace": "Erdos629",
-    "lineCount": 911,
+    "lineCount": 912,
     "axiomCount": 0,
     "theoremCount": 37,
     "definitionCount": 14,

--- a/src/data/proofs/erdos-643/meta.json
+++ b/src/data/proofs/erdos-643/meta.json
@@ -186,7 +186,7 @@
       "Classical"
     ],
     "namespace": "Harmonic.GeneralizeProofs",
-    "lineCount": 1402,
+    "lineCount": 1403,
     "axiomCount": 3,
     "theoremCount": 45,
     "definitionCount": 15,

--- a/src/data/proofs/erdos-69/meta.json
+++ b/src/data/proofs/erdos-69/meta.json
@@ -194,7 +194,7 @@
       "Finset"
     ],
     "namespace": "Erdos69",
-    "lineCount": 188,
+    "lineCount": 189,
     "axiomCount": 1,
     "theoremCount": 5,
     "definitionCount": 2,

--- a/src/data/proofs/erdos-795/meta.json
+++ b/src/data/proofs/erdos-795/meta.json
@@ -167,7 +167,7 @@
     ],
     "opens": [],
     "namespace": "Erdos795",
-    "lineCount": 499,
+    "lineCount": 500,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-866/meta.json
+++ b/src/data/proofs/erdos-866/meta.json
@@ -158,7 +158,7 @@
       "Real"
     ],
     "namespace": "Erdos866",
-    "lineCount": 84,
+    "lineCount": 85,
     "axiomCount": 0,
     "theoremCount": 3,
     "definitionCount": 10,

--- a/src/data/proofs/erdos-941/meta.json
+++ b/src/data/proofs/erdos-941/meta.json
@@ -178,7 +178,7 @@
       "Nat"
     ],
     "namespace": "Erdos941",
-    "lineCount": 323,
+    "lineCount": 324,
     "axiomCount": 4,
     "theoremCount": 11,
     "definitionCount": 13,

--- a/src/data/proofs/navier-stokes-existence/meta.json
+++ b/src/data/proofs/navier-stokes-existence/meta.json
@@ -264,7 +264,7 @@
       "TwoDimensionalGlobal"
     ],
     "namespace": "NavierStokesRegularity",
-    "lineCount": 21110,
+    "lineCount": 21111,
     "axiomCount": 5,
     "theoremCount": 845,
     "definitionCount": 104,

--- a/src/data/proofs/navier-stokes-oq-01/meta.json
+++ b/src/data/proofs/navier-stokes-oq-01/meta.json
@@ -181,7 +181,7 @@
       "TwoDimensionalGlobal"
     ],
     "namespace": "NavierStokesRegularity",
-    "lineCount": 21110,
+    "lineCount": 21111,
     "axiomCount": 0,
     "theoremCount": 845,
     "definitionCount": 104,

--- a/src/data/proofs/navier-stokes-oq-02/meta.json
+++ b/src/data/proofs/navier-stokes-oq-02/meta.json
@@ -202,7 +202,7 @@
       "TwoDimensionalGlobal"
     ],
     "namespace": "NavierStokesRegularity",
-    "lineCount": 21110,
+    "lineCount": 21111,
     "axiomCount": 0,
     "theoremCount": 845,
     "definitionCount": 104,

--- a/src/data/proofs/navier-stokes/meta.json
+++ b/src/data/proofs/navier-stokes/meta.json
@@ -335,7 +335,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 21110,
+    "lineCount": 21111,
     "structureCount": 249,
     "axiomCount": 5,
     "theoremCount": 845,

--- a/src/data/proofs/sqrt2-minpoly-oq-02/meta.json
+++ b/src/data/proofs/sqrt2-minpoly-oq-02/meta.json
@@ -198,7 +198,7 @@
       "IntermediateField"
     ],
     "namespace": "CubeRoot2IrrationalOQ03",
-    "lineCount": 204,
+    "lineCount": 202,
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Corrected stale `leanFile.lineCount` values in 41 gallery `meta.json` files.

## Evidence

**Before**: `leanFile.lineCount` values did not match actual line count of the Lean source files. 40 files were off by +1 (files gained a trailing newline); `sqrt2-minpoly-oq-02` was off by −2.

**After**: `leanFile.lineCount` matches `wc -l` of the actual `.lean` file for all 41 affected proofs.

**Affected proofs** (41):
area-of-circle-oq-01-oq-03, cauchy-schwarz-integral, erdos-1028, erdos-1034, erdos-108, erdos-109, erdos-1161, erdos-123, erdos-139, erdos-143, erdos-157, erdos-167, erdos-168, erdos-171, erdos-172, erdos-202, erdos-29, erdos-299, erdos-303, erdos-355, erdos-37, erdos-370, erdos-402, erdos-45, erdos-485, erdos-517, erdos-551, erdos-60, erdos-604, erdos-624, erdos-629, erdos-643, erdos-69, erdos-795, erdos-866, erdos-941, navier-stokes, navier-stokes-existence, navier-stokes-oq-01, navier-stokes-oq-02, sqrt2-minpoly-oq-02.

---
Automated fix by lean-mechanic agent.