### PR TITLE
Fix: sync leanFile.path for sqrt2-minpoly-oq-02 to Sqrt2MinpolyOQ02.lean

### DIFF
--- a/src/data/proofs/sqrt2-minpoly-oq-02/meta.json
+++ b/src/data/proofs/sqrt2-minpoly-oq-02/meta.json
@@ -191,18 +191,20 @@
   "sorries": 0,
   "leanFile": {
     "imports": [
-      "Mathlib"
+      "Mathlib",
+      "Proofs.CubeRoot2IrrationalOQ03"
     ],
     "opens": [
       "Polynomial",
-      "IntermediateField"
+      "IntermediateField",
+      "CubeRoot2IrrationalOQ03"
     ],
-    "namespace": "CubeRoot2IrrationalOQ03",
-    "lineCount": 204,
+    "namespace": "Sqrt2MinpolyOQ02",
+    "lineCount": 202,
     "axiomCount": 0,
-    "theoremCount": 12,
+    "theoremCount": 20,
     "definitionCount": 0,
     "sorries": 0,
-    "path": "Proofs/CubeRoot2IrrationalOQ03.lean"
+    "path": "Proofs/Sqrt2MinpolyOQ02.lean"
   }
 }


### PR DESCRIPTION
## Fix

The `leanFile` section in `sqrt2-minpoly-oq-02/meta.json` referenced `CubeRoot2IrrationalOQ03.lean` (the underlying library file) instead of `Sqrt2MinpolyOQ02.lean` (the dedicated proof file for this research question).

This was introduced in commit `a4402e2fb0` which correctly updated `meta.proofRepoPath` to `Sqrt2MinpolyOQ02.lean` but left the `leanFile` section pointing to the old file.

## Evidence

**Before**: `leanFile.path = "Proofs/CubeRoot2IrrationalOQ03.lean"` (wrong file, belongs to `cube-root-2-irrational-oq-03`)

**After**: `leanFile.path = "Proofs/Sqrt2MinpolyOQ02.lean"` (correct dedicated proof file)

Additional corrections to match `Sqrt2MinpolyOQ02.lean` reality:
- `namespace`: `CubeRoot2IrrationalOQ03` → `Sqrt2MinpolyOQ02`
- `lineCount`: 204 → 202
- `theoremCount`: 12 → 20
- `imports`: added `Proofs.CubeRoot2IrrationalOQ03`
- `opens`: added `CubeRoot2IrrationalOQ03`

Now `leanFile.path` and `meta.proofRepoPath` are consistent.

---
Automated fix by lean-mechanic agent.