### PR TITLE
Fix: ballot-problem-oq-03-oq-01-oq-02 sorry count 3→4 and false originalContributions

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "ballot-problem-oq-03-oq-01-oq-02",
   "title": "Hook-Length Formula for Standard Young Tableaux via LGV",
   "slug": "ballot-problem-oq-03-oq-01-oq-02",
-  "description": "Formalizes the hook-length formula f^λ = n!/∏h(u) for Standard Young Tableaux. Fully proves the formula for single-row, single-column, hook-shape, and 2×m rectangular Young diagrams — the last via a complete Lindstrom reflection bijection SYT(m,m) ≃ ballot m-subsets of Fin(2m) proving card(SYT(twoRectYD m)) = Cn(m). The general formula for arbitrary shapes remains open (requires RSK bijection and det factorization).",
+  "description": "Formalizes the hook-length formula f^λ = n!/∏h(u) for Standard Young Tableaux. Fully proves the formula for single-row, single-column, and hook-shape Young diagrams. The 2×m rectangular case (card_SYT_twoRectYD) and the general formula both remain open (4 sorries total).",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-23",
@@ -21,10 +21,10 @@
       "ballot-problem"
     ],
     "badge": "wip",
-    "sorries": 3,
+    "sorries": 4,
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "assumptions": "Three open sorries for the GENERAL hook-length formula: (1) hook_length_formula (main theorem, requires (2)+(3)), (2) ni_count_eq_syt_count (Fomin/Viennot/RSK correspondence, ~200 lines), (3) lgv_det_factors_as_hook_quotient (Vandermonde-type det factorization, ~200 lines). All special-case theorems (one-row, one-column, hook-shape, 2×m rectangle) are fully proved with 0 sorries.",
+    "assumptions": "Four open sorries: (1) hook_length_formula (main theorem, requires (2)+(3)), (2) ni_count_eq_syt_count (Fomin/Viennot/RSK correspondence, ~200 lines), (3) lgv_det_factors_as_hook_quotient (Vandermonde-type det factorization, ~200 lines), (4) card_SYT_twoRectYD (card(SYT(m×m)) = Cn(m) via RSK bijection with ballot sequences, ~150-200 lines). Special-case theorems for one-row, one-column, and hook-shape are fully proved.",
     "lineCount": 2727,
     "theoremCount": 85,
     "definitionCount": 12,
@@ -34,11 +34,8 @@
       "hook_length_formula_one_row: f^(1×n) = 1 × n! (direct, 0 sorries)",
       "hook_length_formula_one_col: f^(n×1) = 1 × n! (direct, 0 sorries)",
       "hook_length_formula_hook_shape: f^(m+1,1) = (m+1) × (m+2)×m! (bijection with Fin(m+1), 0 sorries)",
-      "card_SYT_twoRectYD: card(SYT(m×m)) = Cn(m) via Lindstrom reflection bijection (0 sorries)",
-      "hook_length_formula_two_rect: Cn(m) × (m+1)!×m! = (2m)! (0 sorries)",
-      "sytBallotEquiv: SYT(m×m) ≃ ballot m-subsets of Fin(2m) — complete bijection with inverses",
-      "lRefl/firstAbove/badBarrier: Lindstrom reflection machinery for counting ballot m-subsets",
-      "ballot_finset_card: |ballot m-subsets| = C(2m,m) - C(2m,m+1) = Cn(m) via reflection"
+      "card_SYT_twoRectYD: card(SYT(m×m)) = Cn(m) — stated, proof pending (1 sorry)",
+      "hook_length_formula_two_rect: Cn(m) × (m+1)!×m! = (2m)! (proved, depends transitively on card_SYT_twoRectYD sorry)"
     ]
   },
   "overview": {
@@ -62,7 +59,7 @@
     ]
   },
   "conclusion": {
-    "summary": "Hook-length formula fully proved for four families: single-row (1×n), single-column (n×1), hook-shape (m+1,1), and 2×m rectangular (m,m). The rectangular case uses a novel Lindstrom reflection bijection: SYT(m,m) ≃ ballot m-subsets of Fin(2m), proved via sytBallotEquiv and counting via lRefl/firstAbove/badBarrier involution. General formula has 3 remaining sorries: RSK bijection (~200 lines) and Vandermonde det factorization (~200 lines).",
+    "summary": "Hook-length formula fully proved for three families: single-row (1×n), single-column (n×1), hook-shape (m+1,1). The 2×m rectangular case is partially formalized: hook_length_formula_two_rect is proved conditionally on card_SYT_twoRectYD (which has 1 sorry for the RSK/ballot bijection). General formula has 3 remaining sorries: RSK bijection (~200 lines) and Vandermonde det factorization (~200 lines). Total: 4 sorries.",
     "implications": "A complete formalization of hook_length_formula_two_rect marks the first Lean 4 proof of the hook-length formula for an infinite family of non-trivial shapes. The Lindstrom reflection approach is a novel combinatorial proof technique that may extend to other ballot-type counting problems.",
     "openQuestions": [
       "Prove ni_count_eq_syt_count: SYT(λ) ↔ NI-lattice paths via Fomin growth diagrams (~200 lines)",
@@ -83,7 +80,7 @@
     "namespace": "HookLengthFormula",
     "lineCount": 2727,
     "axiomCount": 0,
-    "sorries": 3,
+    "sorries": 4,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",
     "theoremCount": 85,
     "definitionCount": 12
@@ -148,7 +145,7 @@
       "title": "Parts V-VI: Main Theorems",
       "startLine": 180,
       "endLine": 210,
-      "summary": "hook_length_formula_2row_rect (proved via OQ03OQ03), hook_length_formula (sorry), ni_count_eq_syt_count (sorry), lgv_det_factors_as_hook_quotient (sorry). card_SYT_twoRectYD is PROVED via Lindstrom reflection bijection. hook_length_formula_two_rect is PROVED (0 sorries).",
+      "summary": "hook_length_formula_2row_rect (proved via OQ03OQ03), hook_length_formula (sorry), ni_count_eq_syt_count (sorry), lgv_det_factors_as_hook_quotient (sorry). card_SYT_twoRectYD (sorry — RSK/ballot bijection, ~150 lines). hook_length_formula_two_rect is proved conditional on card_SYT_twoRectYD.",
       "mathContext": "Main theorem: card(SYT(μ)) × hookProd μ = μ.card!. The two sorry components require ~200 lines each."
     },
     {
@@ -160,5 +157,5 @@
       "mathContext": "Verified: (2,1)→2, (2,2)→2, (3,1)→3, (3,2)→5, (3,2,1)→16, (4,3,2,1)→1440, (3,3)→5 (C₃), (4,4)→14 (C₄)."
     }
   ],
-  "sorries": 3
+  "sorries": 4
 }


### PR DESCRIPTION
## Fix

Corrects metadata for `ballot-problem-oq-03-oq-01-oq-02` that falsely claimed 3 sorries and a complete proof of the 2×m rectangular case.

## Evidence

**Before**:
- `"sorries": 3` (3 locations) — **wrong**: `card_SYT_twoRectYD` at line 1258 has a sorry
- `originalContributions` included `"card_SYT_twoRectYD: ... (0 sorries)"` — **false**
- 3 non-existent entries: `sytBallotEquiv`, `lRefl/firstAbove/badBarrier`, `ballot_finset_card`
- Description/conclusion claimed "2×m rectangular" was "fully proved" — **false**

**After**:
- `"sorries": 4` in all three locations (top-level, `meta.sorries`, `leanFile.sorries`)
- `card_SYT_twoRectYD` entry updated to note it has 1 sorry
- Removed 3 non-existent `originalContributions` entries
- Description: 2×m case noted as open (depends on sorry'd `card_SYT_twoRectYD`)
- Conclusion: "three families" (not four), conditional proof noted

Closes #11786

---
Automated fix by lean-mechanic agent.