### PR TITLE
Audit fix: sqrt2-plus-sqrt3-irrational-oq-03 — sync meta.json (sorry resolved)

### DIFF
--- a/src/data/proofs/sqrt2-plus-sqrt3-irrational-oq-03/meta.json
+++ b/src/data/proofs/sqrt2-plus-sqrt3-irrational-oq-03/meta.json
@@ -2,11 +2,11 @@
   "id": "sqrt2-plus-sqrt3-irrational-oq-03",
   "title": "Minimal Polynomial of √2 + √3",
   "slug": "sqrt2-plus-sqrt3-irrational-oq-03",
-  "description": "Proves the minimal polynomial of α = √2+√3 over ℚ is X⁴ − 10X² + 1. Establishes: f(α)=0 by direct computation (α²=5+2√6, α⁴=49+20√6), f is monic, and f is irreducible over ℚ (no rational roots, no quadratic factors). Concludes [ℚ(√2+√3):ℚ] = 4. 5 theorems, 0 definitions, 0 axioms.",
+  "description": "Proves the minimal polynomial of α = √2+√3 over ℚ is X⁴ − 10X² + 1. Establishes: f(α)=0 by direct computation (α²=5+2√6, α⁴=49+20√6), f is monic, and f is irreducible over ℚ via Gauss's lemma (irreducibility over ℤ[X]: no integer roots + coefficient analysis eliminates quadratic factors). Concludes [ℚ(√2+√3):ℚ] = 4. 0 sorries, 0 axioms.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-22",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Sqrt2PlusSqrt3IrrationalOQ03.lean",
     "tags": [
       "minimal-polynomial",
@@ -15,12 +15,12 @@
       "irreducibility",
       "square-roots"
     ],
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "mathlib",
+    "sorries": 0,
     "dateAdded": "2026-04-22",
     "axiomCount": 0,
-    "assumptions": "None. One sorry remains: irreducibility of X⁴−10X²+1 over ℚ (mathematically clear via rational root theorem + quadratic factor case analysis).",
-    "lineCount": 154,
+    "assumptions": "None. Fully proved: 0 sorries, 0 axioms. Irreducibility is proved over ℤ[X] via case analysis, then transferred to ℚ[X] via Gauss's lemma (Mathlib's IsPrimitive.Int.irreducible_iff_irreducible_map_cast).",
+    "lineCount": 403,
     "theoremCount": 5,
     "definitionCount": 0,
     "originalContributions": [
@@ -35,7 +35,7 @@
     "historicalContext": "The minimal polynomial of $\\sqrt{2}+\\sqrt{3}$ over $\\mathbb{Q}$ is a classical result in algebraic number theory. While the irrationality of $\\sqrt{2}+\\sqrt{3}$ follows from a squaring argument (proved in the parent gallery entry), the deeper question asks: what is the exact degree of this algebraic number? The answer — degree 4 with minimal polynomial $x^4 - 10x^2 + 1$ — was certainly known to 19th-century algebraists and follows easily from Galois theory: the splitting field of $x^4-10x^2+1$ over $\\mathbb{Q}$ is $\\mathbb{Q}(\\sqrt{2},\\sqrt{3})$, which has degree 4 over $\\mathbb{Q}$ by the tower law and the fact that $\\sqrt{3} \\notin \\mathbb{Q}(\\sqrt{2})$. The Galois group is the Klein 4-group $\\mathbb{Z}/2\\mathbb{Z} \\times \\mathbb{Z}/2\\mathbb{Z}$ — in particular, $x^4-10x^2+1$ factors mod every prime (explaining why Eisenstein's criterion fails), but remains irreducible over $\\mathbb{Q}$.",
     "problemStatement": "Prove that the minimal polynomial of α = √2 + √3 ∈ ℝ over ℚ is f(X) = X⁴ − 10X² + 1.",
     "text": "The proof proceeds in three stages. First, direct computation establishes f(α) = 0: since α² = (√2+√3)² = 5+2√6 and α⁴ = (5+2√6)² = 49+20√6, we get f(α) = 49+20√6 − 10(5+2√6) + 1 = 0, with the √6 terms cancelling. Second, f is irreducible over ℚ: the rational root theorem limits candidates to ±1, both of which satisfy f(±1) = −8 ≠ 0; and equating coefficients in a hypothetical factorization f = (X²+aX+b)(X²−aX+d) leads to a system with no rational solutions in all cases (the discriminant or required square roots are always irrational). Third, since f is monic, irreducible, and has α as a root, Mathlib's `minpoly.eq_of_irreducible_of_monic` gives minpoly ℚ α = f, and the degree formula yields [ℚ(√2+√3):ℚ] = 4.",
-    "proofStrategy": "Three components: (1) Root check via step-by-step algebra: prove α²=5+2√6 from sq_sqrt, then α⁴=49+20√6 by squaring again, close with linarith. (2) Irreducibility: rational root theorem (f(±1)=-8) plus quadratic factor case analysis (sorry — mathematically complete). (3) Apply minpoly.eq_of_irreducible_of_monic with the irreducibility and root check.",
+    "proofStrategy": "Three components: (1) Root check via step-by-step algebra: prove α²=5+2√6 from sq_sqrt, then α⁴=49+20√6 by squaring again, close with linarith. (2) Irreducibility over ℤ[X]: (a) no integer roots via f_no_int_root (integer root theorem + interval_cases), (b) no quadratic factors via coefficient analysis (discriminant 96 irrational, a²∈{8,12} non-square), then transfer to ℚ[X] via Gauss's lemma. (3) Apply minpoly.eq_of_irreducible_of_monic with the irreducibility and root check.",
     "keyInsights": [
       "The key cancellation: α²=5+2√6 and α⁴=49+20√6, so f(α)=49+20√6−50−20√6+1=0. The √6 terms cancel exactly, making this a 'lucky' polynomial root.",
       "The Galois group of x⁴−10x²+1 over ℚ is the Klein 4-group V₄ = {e, σ, τ, στ} where σ(√2)=−√2 and τ(√3)=−√3. This implies the polynomial factors mod every prime p — there is no prime for which it stays irreducible mod p — which is why Eisenstein and mod-p irreducibility tests all fail. The polynomial is 'invisibly irreducible' over ℚ.",
@@ -51,10 +51,10 @@
     ]
   },
   "conclusion": {
-    "summary": "Proves minpoly ℚ (√2+√3) = X⁴−10X²+1 and [ℚ(√2+√3):ℚ]=4. Root check and irrationality are fully formal; irreducibility has 1 sorry (mathematically complete argument documented). 5 theorems, ~160 lines.",
+    "summary": "Fully verified (0 sorries, 0 axioms): minpoly ℚ (√2+√3) = X⁴−10X²+1 and [ℚ(√2+√3):ℚ]=4. Irreducibility proved over ℤ[X] via integer root theorem + quadratic factor coefficient analysis, then transferred to ℚ[X] by Gauss's lemma. 5 main theorems, ~400 lines.",
     "implications": "The degree-4 result shows √2+√3 is a primitive element of the biquadratic extension ℚ(√2,√3)/ℚ. Combined with the explicit minimal polynomial, this enables computation of the full Galois group (Klein 4-group) and explains why the polynomial factors mod every prime despite being irreducible over ℚ.",
     "openQuestions": [
-      "Complete the irreducibility sorry: formalize the quadratic factor case analysis showing discriminant 96 and required a² ∈ {8,12} are non-squares.",
+      "Generalize the irreducibility proof to parametric X⁴ - (a+b+2√(ab))X² + (a-b)² for squarefree a,b.",
       "Prove √2+√3 generates ℚ(√2,√3): show √2 and √3 can be recovered from √2+√3 alone.",
       "Generalize: compute minpoly ℚ (√a+√b) for arbitrary squarefree positive integers a, b with distinct prime factors.",
       "Compute minpoly ℚ (√2+√3+√5): expected degree 8, polynomial (x²-5)²(x²-2)(x²-3)(x²-6)... requires 3-variable case."
@@ -62,12 +62,12 @@
   },
   "leanFile": {
     "namespace": "Sqrt2PlusSqrt3IrrationalOQ03",
-    "lineCount": 154,
+    "lineCount": 403,
     "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 0,
     "path": "Proofs/Sqrt2PlusSqrt3IrrationalOQ03.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "crossReferences": [
     {
@@ -103,10 +103,10 @@
     },
     {
       "id": "sec-irreducible",
-      "title": "Irreducibility over ℚ (sorry)",
+      "title": "Irreducibility over ℚ (via Gauss's Lemma)",
       "startLine": 101,
-      "endLine": 121,
-      "summary": "irred_f: Irreducible (X⁴−10X²+1 : ℚ[X]). Sorry with documented proof sketch: no rational roots (f(±1)=-8), no quadratic factors (coefficient system yields discriminant 96 or a²∈{8,12}, all irrational)."
+      "endLine": 300,
+      "summary": "irred_f: Irreducible (X⁴−10X²+1 : ℚ[X]). Proved via ℤ[X] first: f_no_int_root eliminates degree-1 factors by integer root theorem; degree-2 factor coefficient analysis yields contradiction (discriminant 96 irrational); degree-3 reduces to degree-1 by symmetry. Transfer to ℚ[X] via Gauss's lemma (IsPrimitive.Int.irreducible_iff_irreducible_map_cast). 0 sorries."
     },
     {
       "id": "sec-minpoly",
@@ -123,5 +123,5 @@
       "summary": "adjoin_sqrt2_plus_sqrt3_finrank: [ℚ(√2+√3):ℚ]=4 via adjoin.finrank and natDegree computation. sqrt2_plus_sqrt3_irrational: fully proved by direct algebra — if √2+√3=q then (q²-5)/2=√6, contradicting irrationality of √6."
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Summary

- The sorry in `irred_f` was resolved in the Lean file (0 sorries, 403 lines) but `meta.json` was never updated
- Updates `sorries: 1 → 0`, `status: formalized → verified`, `badge: wip → mathlib`
- Updates `lineCount: 154 → 403`, `assumptions`, `proofStrategy`, `conclusion.summary`, and section metadata

## Evidence

The irreducibility proof uses:
1. `f_no_int_root`: no integer roots via `interval_cases` on |k|≤3
2. Full ℤ[X] irreducibility by degree case analysis (deg 1 → root, deg 2 → coefficient contradiction via `nlinarith`, deg 3 → symmetric)
3. Transfer to ℚ[X] via Gauss's lemma (`IsPrimitive.Int.irreducible_iff_irreducible_map_cast`)

## Test plan
- [ ] `sorries: 0` in meta.json matches `grep -c sorry proofs/Proofs/Sqrt2PlusSqrt3IrrationalOQ03.lean` → 0 ✓
- [ ] `status: verified` appropriate (0 sorries, 0 axioms) ✓
- [ ] `badge: mathlib` appropriate (uses Gauss's lemma + minpoly Mathlib infrastructure) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)