### PR TITLE
Audit: fix lebesgue-measure-oq-06 sorry count (8→4, W_a/W_b lemmas proved)

### DIFF
--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -18,10 +18,10 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 8,
+    "sorries": 4,
     "axiomCount": 5,
-    "lineCount": 419,
-    "assumptions": "8 sorries: hausdorff_free_subgroup (free subgroup of SO(3)), banach_tarski (main theorem), banach_tarski_pieces_nonmeasurable (non-measurability of pieces), int_amenable (ℤ amenability), W_a_two_cover (W(a) two-cover), W_a_smul_disj (W(a) smul disjointness), W_b_two_cover (W(b) two-cover), W_b_smul_disj (W(b) smul disjointness). The main proof requires ~800 lines via free subgroup of SO(3) — beyond this gallery entry's scope. Note: paradoxical_no_finite_measure and free_group_not_amenable structure are fully proved.",
+    "lineCount": 563,
+    "assumptions": "4 sorries: hausdorff_free_subgroup (free subgroup of SO(3)), banach_tarski (main theorem), banach_tarski_pieces_nonmeasurable (non-measurability of pieces), int_amenable (ℤ amenability). Proved: W_a_two_cover, W_a_smul_disj, W_b_two_cover, W_b_smul_disj (word combinatorics on FreeGroup (Fin 2)), free_group_not_amenable (paradoxical decomposition argument, fully proved). The main proof requires ~800 lines via free subgroup of SO(3) — beyond this gallery entry's scope. Note: paradoxical_no_finite_measure and free_group_not_amenable are fully proved.",
     "dateAdded": "2026-04-22",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -101,7 +101,7 @@
       "title": "§VI: Amenability and the Group-Theoretic Source",
       "startLine": 249,
       "endLine": 295,
-      "summary": "Defines amenable groups. States int_amenable (ℤ is amenable via Cesàro means, sorry) and free_group_not_amenable (F₂ non-amenable via paradoxical decomposition, sorry). Closes the BanachTarski namespace.",
+      "summary": "Defines amenable groups. States int_amenable (ℤ is amenable via Cesàro means, sorry). Proves free_group_not_amenable (F₂ non-amenable via paradoxical decomposition, fully proved using W_a/W_b two-cover lemmas). Closes the BanachTarski namespace.",
       "mathContext": "A group $G$ is amenable iff $\\exists \\mu: 2^G \\to [0,\\infty]$ with $\\mu(G)=1$, $\\mu(A \\cup B) = \\mu(A) + \\mu(B)$ for disjoint $A, B$, and $\\mu(gA) = \\mu(A)$ for all $g \\in G$. Abelian groups are amenable (via Markov-Kakutani). $F_2$ is not amenable: $F_2 = W(a) \\sqcup aW(a^{-1})$ and $F_2 = W(b) \\sqcup bW(b^{-1})$ give two paradoxical coverings. `int_amenable` can likely be proved using Mathlib's Hahn-Banach (`NormedSpace.HahnBanach`) to construct a Banach limit extending the Cesàro mean on $\\ell^\\infty(\\mathbb{Z})$."
     }
   ],
@@ -201,12 +201,12 @@
       "Mathlib"
     ],
     "namespace": "BanachTarski",
-    "lineCount": 419,
+    "lineCount": 563,
     "axiomCount": 5,
     "theoremCount": 7,
     "definitionCount": 5,
     "path": "Proofs/LebesgueMeasureOQ06.lean",
-    "sorries": 8
+    "sorries": 4
   },
-  "sorries": 8
+  "sorries": 4
 }


### PR DESCRIPTION
## Summary

- Fix sorry count mismatch in `lebesgue-measure-oq-06/meta.json`: the Lean source has 4 sorries but meta.json claimed 8
- W_a_two_cover, W_a_smul_disj, W_b_two_cover, W_b_smul_disj were all proved in PR #11785 (word combinatorics on FreeGroup (Fin 2))
- free_group_not_amenable is now fully proved using those W_a/W_b two-cover lemmas
- Update lineCount from 419 to 563 to match the expanded file

**Remaining 4 sorries:**
1. `hausdorff_free_subgroup` (free subgroup of SO(3))
2. `banach_tarski` (main theorem)
3. `banach_tarski_pieces_nonmeasurable` (non-measurability of pieces)
4. `int_amenable` (Z amenability)

## Changes

- `meta.sorries`: 8 -> 4
- `meta.lineCount`: 419 -> 563
- `meta.assumptions`: updated to list 4 sorries and note proved lemmas
- `leanFile.sorries`: 8 -> 4
- `leanFile.lineCount`: 419 -> 563
- `sorries` (top-level): 8 -> 4
- Section "amenability" summary: updated to reflect free_group_not_amenable is fully proved

## Verification

Confirmed 4 sorry statements in `proofs/Proofs/LebesgueMeasureOQ06.lean` on the `main` branch (commit 488dc4d9fe from PR #11785).