### PR TITLE
Fix: sync stale lineCount in 3 gallery meta.json files

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -25,7 +25,7 @@
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
     "assumptions": "Four open sorries: (1) hook_length_formula (main theorem, requires (2)+(3)), (2) ni_count_eq_syt_count (Fomin/Viennot/RSK correspondence, ~200 lines), (3) lgv_det_factors_as_hook_quotient (Vandermonde-type det factorization, ~200 lines), (4) card_SYT_twoRectYD (card(SYT(m×m)) = Cn(m) via RSK bijection with ballot sequences, ~150-200 lines). Special-case theorems for one-row, one-column, and hook-shape are fully proved.",
-    "lineCount": 2727,
+    "lineCount": 1274,
     "theoremCount": 85,
     "definitionCount": 12,
     "originalContributions": [
@@ -78,7 +78,7 @@
       "LGV"
     ],
     "namespace": "HookLengthFormula",
-    "lineCount": 2727,
+    "lineCount": 1274,
     "axiomCount": 0,
     "sorries": 4,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -16,7 +16,7 @@
     "badge": "wip",
     "sorries": 2,
     "axiomCount": 0,
-    "lineCount": 980,
+    "lineCount": 1125,
     "assumptions": "2 remaining sorries, both dead-path (not used in main proof chain): (1) truncated_rn_deriv_lq_bound (line 191) — incorrect approach, bypassed; (2) rn_deriv_memLq (line 207) — depends on (1), also bypassed. The main theorem riesz_lp_surjective_from_rn is proved via rn_deriv_memLq_from_trunc + holder_extremizer_lq_bound (all sorry-free). holder_extremizer_lq_bound proved in session 5 (2026-04-22).",
     "dateAdded": "2026-04-13"
   },
@@ -106,7 +106,7 @@
     "imports": [
       "Mathlib"
     ],
-    "lineCount": 980,
+    "lineCount": 1125,
     "axiomCount": 0,
     "theoremCount": 15,
     "definitionCount": 2,

--- a/src/data/proofs/triangle-angle-sum-oq-02/meta.json
+++ b/src/data/proofs/triangle-angle-sum-oq-02/meta.json
@@ -22,7 +22,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 3,
-    "lineCount": 320,
+    "lineCount": 382,
     "assumptions": "gb_local (local Gauss-Bonnet: angle excess = integrated curvature, for each geodesic triangle), spherical/flat/hyperbolic curvature formulas (K=1/r², K=0, K=-1 respectively), discrete_gb (discrete Gauss-Bonnet for triangulations: total excess = 2π·χ). All are classical theorems of differential geometry requiring Riemannian geometry infrastructure not yet in Mathlib.",
     "mathlib_version": "4.26.0"
   },
@@ -121,7 +121,7 @@
       "Real"
     ],
     "namespace": "TriangleAngleSumGaussBonnet",
-    "lineCount": 320,
+    "lineCount": 382,
     "axiomCount": 3,
     "sorries": 0,
     "path": "Proofs/TriangleAngleSumOQ02.lean",


### PR DESCRIPTION
## Fix

Corrects stale `lineCount` values in 3 gallery `meta.json` files where the Lean source files were extended after the metadata was last updated.

## Evidence

| Entry | Before | After | Cause |
|-------|--------|-------|-------|
| `ballot-problem-oq-03-oq-01-oq-02` | 2727 | 1274 | Researcher session 8 (commit 35da43bb) set incorrect count — file has always been 1274 lines |
| `triangle-angle-sum-oq-02` | 320 | 382 | Gauss-Bonnet additions landed in PR #11784, meta not updated |
| `cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01` | 980 | 1125 | File grew incrementally, meta not updated |

## Validation

- All three Lean files exist at the paths specified in `leanFile.path`
- `wc -l` confirms the new counts match the actual files
- Both `meta.lineCount` and `leanFile.lineCount` updated in each file

---
Automated fix by lean-mechanic agent.