### PR TITLE
Fix erdos-321 leanFile metadata: axiomCount 0→2, lineCount 155→174, overview text fix

### DIFF
--- a/src/data/proofs/erdos-321/meta.json
+++ b/src/data/proofs/erdos-321/meta.json
@@ -17,12 +17,12 @@
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/321",
     "erdosUrl": "https://erdosproblems.com/321",
-    "axiomCount": 0,
-    "assumptions": "0 axioms. The Bleicher–Erdős bounds (lower: R(N) ≥ N/log N, upper: R(N) ≤ C·(N/log N)·log log N) are referenced only as doc-comment descriptions, not as Lean axiom declarations. Open problem — precise asymptotic of R(N) remains unknown.",
+    "axiomCount": 2,
+    "assumptions": "2 axioms: bleicher_erdos_lower (R(N) ≥ N/log N, Bleicher–Erdős 1975) and bleicher_erdos_upper (R(N) ≤ C·(N/log N)·log log N, 1976). Open problem — precise asymptotic of R(N) remains unknown.",
     "badge": "wip",
     "proofRepoPath": "Proofs/Erdos321Problem.lean",
     "mathlib_version": "4.26.0",
-    "lineCount": 155,
+    "lineCount": 174,
     "mathlibDependencies": [
       {
         "theorem": "Finset.sup",
@@ -102,7 +102,7 @@
   "overview": {
     "historicalContext": "Paul Erdős and Ronald Graham posed this problem in their 1980 monograph 'Old and New Problems and Results in Combinatorial Number Theory' (p.43), building on work by Michael Bleicher and Erdős from the mid-1970s. Bleicher and Erdős published matching bounds in two papers: a lower bound in 'Denominators of unit fractions' (J. London Math. Soc., 1975) using a constructive argument based on prime factorization properties, and an upper bound in 'Denominators of unit fractions II' (Illinois J. Math., 1976) using a counting argument comparing $2^{|A|}$ with $\\text{lcm}(1, \\ldots, N)$. The problem sits at the intersection of additive combinatorics, Egyptian fraction theory (dating back to ancient Egypt's Rhind Papyrus, c. 1650 BCE), and the study of harmonic sums. The iterated logarithm gap between the bounds — essentially a single factor of $\\log_r N$ — has resisted closure for 50 years, making it one of the most precisely bounded yet unresolved problems in combinatorial number theory.",
     "problemStatement": "Let $R(N) = \\max\\{|A| : A \\subseteq \\{1, \\ldots, N\\}, \\text{ all reciprocal subset sums } \\sum_{n \\in S} 1/n \\text{ distinct}\\}$. Determine $R(N)$ asymptotically. Current bounds: $(N/\\log N) \\cdot \\prod \\log_i N \\leq R(N) \\leq (1/\\log 2) \\cdot \\log_r N \\cdot (N/\\log N) \\cdot \\prod \\log_i N$.",
-    "text": "A 170-line formalization of Erdős Problem #321 that builds the framework for studying $R(N)$, the maximum size of $A \\subseteq \\{1, \\ldots, N\\}$ with all $2^{|A|}$ reciprocal subset sums $\\sum_{a \\in S} 1/a$ distinct. Defines `HasDistinctReciprocalSums` over $\\mathbb{Q}$ (exact arithmetic, avoiding floating-point issues) and `maxDistinctReciprocal` via `Finset.sup` over the filtered powerset. The 3 axioms encode the Bleicher–Erdős bounds: lower $R(N) \\geq N/\\log N$ (constructive, 1975), upper $R(N) \\leq C \\cdot (N/\\log N) \\cdot \\log\\log N$ (counting, 1976), and their combination $R(N) = \\Theta(N/\\log N)$. The 6 proved theorems establish structural properties: equivalence of formulations, hereditary closure, singleton and pair cases, and the trivial verification for $A = \\{1, \\ldots, N\\}$.",
+    "text": "A 170-line formalization of Erdős Problem #321 that builds the framework for studying $R(N)$, the maximum size of $A \\subseteq \\{1, \\ldots, N\\}$ with all $2^{|A|}$ reciprocal subset sums $\\sum_{a \\in S} 1/a$ distinct. Defines `HasDistinctReciprocalSums` over $\\mathbb{Q}$ (exact arithmetic, avoiding floating-point issues) and `maxDistinctReciprocal` via `Finset.sup` over the filtered powerset. The 2 axioms encode the Bleicher–Erdős bounds: lower $R(N) \\geq N/\\log N$ (constructive, 1975), upper $R(N) \\leq C \\cdot (N/\\log N) \\cdot \\log\\log N$ (counting, 1976), and their combination $R(N) = \\Theta(N/\\log N)$. The 6 proved theorems establish structural properties: equivalence of formulations, hereditary closure, singleton and pair cases, and the trivial verification for $A = \\{1, \\ldots, N\\}$.",
     "proofStrategy": "We define `HasDistinctReciprocalSums` over $\\mathbb{Q}$ (exact arithmetic) and $R(N)$ via `Finset.sup` over the powerset. The Bleicher–Erdős bounds are axiomatized in simplified form: the lower bound as $R(N) \\geq N/\\log N$ and the upper bound as $R(N) \\leq C \\cdot (N/\\log N) \\cdot \\log\\log N$. The combined $\\Theta(N/\\log N)$ statement captures the main term. Observations on Egyptian fractions and greedy constructions are included as comments.",
     "keyInsights": [
       "**Main term is $N/\\log N$**: Both bounds agree on this leading factor — the open question is entirely about the slowly-varying iterated logarithm correction, making this one of the most precisely bounded yet unresolved extremal problems",
@@ -160,8 +160,8 @@
     }
   ],
   "leanFile": {
-    "lineCount": 155,
-    "axiomCount": 0,
+    "lineCount": 174,
+    "axiomCount": 2,
     "theoremCount": 7,
     "definitionCount": 3,
     "imports": [


### PR DESCRIPTION
## Summary

Meta.json audit fix for erdos-321: corrects leanFile.axiomCount (was 0, actually 2 axiom declarations), leanFile.lineCount (was 155, actually 174), and overview text (said '3 axioms', should be '2 axioms' since bleicher_erdos_theta is a proved theorem).

Specific changes:
- `leanFile.axiomCount`: 0 → 2 (`bleicher_erdos_lower` and `bleicher_erdos_upper` are `axiom` declarations)
- `leanFile.lineCount`: 155 → 174 (actual line count of Lean source file)
- `meta.lineCount`: 155 → 174 (matching correction)
- `meta.axiomCount`: 0 → 2 (matching correction)
- `overview.text`: "The 3 axioms encode" → "The 2 axioms encode" (`bleicher_erdos_theta` is a proved theorem, not an axiom)
- `meta.assumptions`: updated to name the two actual axiom declarations

🤖 Generated with [Claude Code](https://claude.com/claude-code)