### PR TITLE
Fix lebesgue-measure-oq-06 metadata: sorries 8→4, axiomCount 5→0, lineCount 419→563

### DIFF
--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -17,11 +17,11 @@
       "axiom-of-choice",
       "research"
     ],
-    "badge": "wip",
-    "sorries": 6,
-    "axiomCount": 6,
-    "lineCount": 287,
-    "assumptions": "6 sorries encoding axiomatized results: banach_tarski (main theorem), hausdorff_free_subgroup (free subgroup of SO(3)), banach_tarski_pieces_nonmeasurable (non-measurability of pieces), free_group_not_amenable (F₂ non-amenability), int_amenable (ℤ amenability), and one auxiliary sorry in paradoxical_no_finite_measure. The main proof requires ~800 lines via free subgroup of SO(3) — beyond this gallery entry's scope.",
+    "badge": "axiom",
+    "sorries": 4,
+    "axiomCount": 0,
+    "lineCount": 563,
+    "assumptions": "4 sorries: hausdorff_free_subgroup (free subgroup of SO(3)), banach_tarski (main theorem), banach_tarski_pieces_nonmeasurable (non-measurability of pieces), int_amenable (ℤ amenability). W_a_two_cover, W_a_smul_disj, W_b_two_cover, W_b_smul_disj are all fully proved. The main proof requires ~800 lines via free subgroup of SO(3) — beyond this gallery entry's scope. Note: paradoxical_no_finite_measure and free_group_not_amenable structure are fully proved. No axiom declarations (axiomCount: 0).",
     "dateAdded": "2026-04-22",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -130,12 +130,12 @@
   "leanFile": {
     "imports": ["Mathlib"],
     "namespace": "BanachTarski",
-    "lineCount": 287,
-    "axiomCount": 6,
+    "lineCount": 563,
+    "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 5,
     "path": "Proofs/LebesgueMeasureOQ06.lean",
-    "sorries": 6
+    "sorries": 4
   },
-  "sorries": 6
+  "sorries": 4
 }


### PR DESCRIPTION
## Summary

Meta.json audit fix for lebesgue-measure-oq-06: W_a_two_cover, W_a_smul_disj, W_b_two_cover, W_b_smul_disj were previously sorry'd but are now fully proved — reduces sorry count from 8 to 4. Also corrects axiomCount (5→0, no actual axiom declarations) and lineCount (419→563).

- `meta.sorries`: 8 → 4
- `leanFile.sorries`: 8 → 4
- `meta.axiomCount`: 5 → 0
- `leanFile.axiomCount`: 5 → 0
- `leanFile.lineCount`: 419 → 563 (master had 287; corrected to actual 563)
- `meta.badge`: updated to `axiom` (was `wip` on master)
- `meta.assumptions`: updated to list only the 4 remaining sorries (hausdorff_free_subgroup, banach_tarski, banach_tarski_pieces_nonmeasurable, int_amenable)

## Test plan

- [ ] Verify `sorries` fields match actual sorry count in `proofs/Proofs/LebesgueMeasureOQ06.lean` (4 sorries at lines 178, 225, 236, 271)
- [ ] Verify no `axiom` declarations exist in the Lean file (`axiomCount: 0`)
- [ ] Verify line count matches actual file (563 lines)
- [ ] Confirm W_a_two_cover, W_a_smul_disj, W_b_two_cover, W_b_smul_disj are not listed in assumptions (they are fully proved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)