### PR TITLE
Fix triangle-angle-sum-oq-02 lineCount: 320→382

### DIFF
--- a/src/data/proofs/triangle-angle-sum-oq-02/meta.json
+++ b/src/data/proofs/triangle-angle-sum-oq-02/meta.json
@@ -22,7 +22,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 3,
-    "lineCount": 320,
+    "lineCount": 382,
     "assumptions": "gb_local (local Gauss-Bonnet: angle excess = integrated curvature, for each geodesic triangle), spherical/flat/hyperbolic curvature formulas (K=1/r², K=0, K=-1 respectively), discrete_gb (discrete Gauss-Bonnet for triangulations: total excess = 2π·χ). All are classical theorems of differential geometry requiring Riemannian geometry infrastructure not yet in Mathlib.",
     "mathlib_version": "4.26.0"
   },
@@ -121,7 +121,7 @@
       "Real"
     ],
     "namespace": "TriangleAngleSumGaussBonnet",
-    "lineCount": 320,
+    "lineCount": 382,
     "axiomCount": 3,
     "sorries": 0,
     "path": "Proofs/TriangleAngleSumOQ02.lean",


### PR DESCRIPTION
Meta.json audit fix: leanFile.lineCount corrected from 320 to 382 for triangle-angle-sum-oq-02.

Also updated meta.lineCount (the `meta` section's `lineCount` field) from 320 to 382 to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)