### PR TITLE
Fix: sync cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01 lineCount 980→1125

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -16,7 +16,7 @@
     "badge": "wip",
     "sorries": 2,
     "axiomCount": 0,
-    "lineCount": 980,
+    "lineCount": 1125,
     "assumptions": "2 remaining sorries, both dead-path (not used in main proof chain): (1) truncated_rn_deriv_lq_bound (line 191) — incorrect approach, bypassed; (2) rn_deriv_memLq (line 207) — depends on (1), also bypassed. The main theorem riesz_lp_surjective_from_rn is proved via rn_deriv_memLq_from_trunc + holder_extremizer_lq_bound (all sorry-free). holder_extremizer_lq_bound proved in session 5 (2026-04-22).",
     "dateAdded": "2026-04-13"
   },
@@ -106,7 +106,7 @@
     "imports": [
       "Mathlib"
     ],
-    "lineCount": 980,
+    "lineCount": 1125,
     "axiomCount": 0,
     "theoremCount": 15,
     "definitionCount": 2,


### PR DESCRIPTION
## Fix

Corrected stale `leanFile.lineCount` and `meta.lineCount` in `cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json`.

## Evidence

**Before**: `leanFile.lineCount: 980`, `meta.lineCount: 980`
**After**: `leanFile.lineCount: 1125`, `meta.lineCount: 1125`

The committed Lean file (`Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean`) has 1125 lines (`wc -l`). The metadata was last set at 980 lines, but the file was substantially expanded in research sessions (PRs #11784 and prior) to formalize the Radon-Nikodým proof architecture. The sorry count (2) is correct in the metadata.

---
Automated fix by lean-mechanic agent.