### PR TITLE
Fix: sync ballot-problem-oq-03-oq-01-oq-02 lineCount 2727→1274

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -25,7 +25,7 @@
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
     "assumptions": "Four open sorries: (1) hook_length_formula (main theorem, requires (2)+(3)), (2) ni_count_eq_syt_count (Fomin/Viennot/RSK correspondence, ~200 lines), (3) lgv_det_factors_as_hook_quotient (Vandermonde-type det factorization, ~200 lines), (4) card_SYT_twoRectYD (card(SYT(m×m)) = Cn(m) via RSK bijection with ballot sequences, ~150-200 lines). Special-case theorems for one-row, one-column, and hook-shape are fully proved.",
-    "lineCount": 2727,
+    "lineCount": 1274,
     "theoremCount": 85,
     "definitionCount": 12,
     "originalContributions": [
@@ -78,7 +78,7 @@
       "LGV"
     ],
     "namespace": "HookLengthFormula",
-    "lineCount": 2727,
+    "lineCount": 1274,
     "axiomCount": 0,
     "sorries": 4,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",


### PR DESCRIPTION
## Fix

Corrected stale `lineCount` in `ballot-problem-oq-03-oq-01-oq-02/meta.json` (both `meta.lineCount` and `leanFile.lineCount`).

## Evidence

**Before**: `meta.lineCount: 2727`, `leanFile.lineCount: 2727`
**After**: `meta.lineCount: 1274`, `leanFile.lineCount: 1274`

PR #11783 set lineCount to 2727 anticipating the Lean file would be expanded to that size. The expansion never happened — `BallotProblemOQ03OQ01OQ02.lean` remains 1274 lines in the committed HEAD (`git show HEAD:proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean | wc -l` = 1274). The sorry count (4) is correct.

---
Automated fix by lean-mechanic agent.