### PR TITLE
Fix: sync annotation endLine to file length in 56 gallery entries

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-03/annotations.json
@@ -197,7 +197,7 @@
     "proofId": "amgm-inequality-oq-03",
     "range": {
       "startLine": 345,
-      "endLine": 373
+      "endLine": 372
     },
     "type": "insight",
     "title": "Interpolation Chain Summary: All Same-Sign Cases Proved",

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01/annotations.json
@@ -98,7 +98,7 @@
   {
     "id": "ann-summary",
     "proofId": "area-of-circle-oq-01-oq-02-oq-01-oq-01",
-    "range": { "startLine": 123, "endLine": 151 },
+    "range": { "startLine": 123, "endLine": 150 },
     "type": "context",
     "title": "Summary and Answer to Open Question",
     "content": "The proof summary confirms: YES, all unit ball volumes are recursively computable. The key insight is that the recurrence is a direct algebraic consequence of $\\Gamma(z+1) = z\\Gamma(z)$. An important correction is noted: the formula $(2\\pi/n)\\cdot\\omega_n$ sometimes cited has an off-by-two indexing error; the correct formula is $(2\\pi/(n+2))\\cdot\\omega_n$, as verified by the computation $\\omega_2 = \\pi$.",

--- a/src/data/proofs/area-of-circle-oq-01/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-01/annotations.json
@@ -277,7 +277,7 @@
     "proofId": "area-of-circle-oq-01",
     "range": {
       "startLine": 157,
-      "endLine": 163
+      "endLine": 162
     },
     "type": "technique",
     "title": "Circumference-Derivative Duality",

--- a/src/data/proofs/bezout-identity-oq-04-oq-02/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-04-oq-02/annotations.json
@@ -95,7 +95,7 @@
     "proofId": "bezout-identity-oq-04-oq-02",
     "range": {
       "startLine": 115,
-      "endLine": 139
+      "endLine": 138
     },
     "type": "technique",
     "title": "Part IV Examples: Witnesses, Non-Achievability, and Coprimality",

--- a/src/data/proofs/cevas-theorem-oq-04/annotations.json
+++ b/src/data/proofs/cevas-theorem-oq-04/annotations.json
@@ -150,7 +150,7 @@
     "proofId": "cevas-theorem-oq-04",
     "range": {
       "startLine": 212,
-      "endLine": 243
+      "endLine": 242
     },
     "type": "context",
     "title": "Centroid Example and Summary Theorem",

--- a/src/data/proofs/continuum-hypothesis-oq-01/annotations.json
+++ b/src/data/proofs/continuum-hypothesis-oq-01/annotations.json
@@ -159,7 +159,7 @@
     "proofId": "continuum-hypothesis-oq-01",
     "range": {
       "startLine": 264,
-      "endLine": 318
+      "endLine": 317
     },
     "type": "insight",
     "title": "Summary: The Open Question Has Substantive Content on Both Sides",

--- a/src/data/proofs/cramers-rule-oq-01/annotations.json
+++ b/src/data/proofs/cramers-rule-oq-01/annotations.json
@@ -159,7 +159,7 @@
     "proofId": "cramers-rule-oq-01",
     "range": {
       "startLine": 262,
-      "endLine": 283
+      "endLine": 282
     },
     "type": "technique",
     "title": "Summary Theorem: Cramer Implies Cayley-Hamilton as One Package",

--- a/src/data/proofs/de-moivre/annotations.json
+++ b/src/data/proofs/de-moivre/annotations.json
@@ -146,7 +146,7 @@
     "proofId": "de-moivre",
     "range": {
       "startLine": 210,
-      "endLine": 240
+      "endLine": 239
     },
     "type": "concept",
     "title": "Applications and Exports",

--- a/src/data/proofs/desargues-theorem-oq-01/annotations.json
+++ b/src/data/proofs/desargues-theorem-oq-01/annotations.json
@@ -195,7 +195,7 @@
     "proofId": "desargues-theorem-oq-01",
     "range": {
       "startLine": 261,
-      "endLine": 286
+      "endLine": 285
     },
     "type": "technique",
     "title": "Corollaries: ℚ, ℤ, 𝔽_p, and Polynomial Rings",

--- a/src/data/proofs/dissection-of-cubes-oq-04/annotations.json
+++ b/src/data/proofs/dissection-of-cubes-oq-04/annotations.json
@@ -110,7 +110,7 @@
   {
     "id": "ann-cube-unique-axiom-audit",
     "proofId": "dissection-of-cubes-oq-04",
-    "range": { "startLine": 365, "endLine": 437 },
+    "range": { "startLine": 365, "endLine": 436 },
     "type": "insight",
     "title": "cube_unique_zero_dehn (Partial) and Axiom Audit",
     "content": "cube_unique_zero_dehn (lines 367-396) attempts the stronger statement: for ANY positive integer n and any non-cube Platonic dihedral angle x, the edge term n·a ⊗ [x] is nonzero. This requires a general scaling lemma: if a ⊗ [θ] ≠ 0 and c > 0, then ca ⊗ [θ] ≠ 0. The three sorries (lines 390, 393, 396) are exactly this step for octahedron, dodecahedron, and icosahedron angles. The main theorem cube_isolated_dehn_invariant (fully proved) already captures the key mathematical content; cube_unique_zero_dehn is a generalization in progress.\n\nThe axiom audit (lines 398-429) formally inventories both axioms with justifications: `icoAngle_irrational` (new to this file; the deferred ℤ[√5] Chebyshev argument) and `tmul_infinite_order_ne_zero` (inherited from OQ02OQ02; flatness of ℝ over ℤ). The `#check` lines (431-435) provide Lean elaboration verification.",

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01/annotations.json
@@ -237,7 +237,7 @@
     "proofId": "elementary-quadratic-reciprocity-oq-01-oq-01",
     "range": {
       "startLine": 159,
-      "endLine": 167
+      "endLine": 166
     },
     "type": "insight",
     "title": "Main Theorem: Gauss Sum as Third Formal QR Pathway",

--- a/src/data/proofs/erdos-1010/annotations.json
+++ b/src/data/proofs/erdos-1010/annotations.json
@@ -50,7 +50,7 @@
   {
     "id": "ann-1010-existence",
     "proofId": "erdos-1010",
-    "range": { "startLine": 84, "endLine": 94 },
+    "range": { "startLine": 84, "endLine": 93 },
     "type": "concept",
     "title": "Triangle Existence (Turán's Theorem for K₃)",
     "content": "**turán_triangle_existence** (axiom):\n\nIf $|E(G)| > \\lfloor n^2/4 \\rfloor$, then $\\text{triangleCount}(G) \\ge 1$.\n\nThe qualitative version of Turán's theorem: exceeding the threshold guarantees at least one triangle. Axiomatized separately because deriving it from the supersaturation axiom requires careful arithmetic bookkeeping.",

--- a/src/data/proofs/erdos-1087/annotations.json
+++ b/src/data/proofs/erdos-1087/annotations.json
@@ -225,7 +225,7 @@
     "proofId": "erdos-1087",
     "range": {
       "startLine": 314,
-      "endLine": 317
+      "endLine": 316
     },
     "type": "technique",
     "title": "Main Theorem",

--- a/src/data/proofs/erdos-114/annotations.json
+++ b/src/data/proofs/erdos-114/annotations.json
@@ -122,7 +122,7 @@
   {
     "id": "exact-length",
     "proofId": "erdos-114",
-    "range": {"startLine": 43, "endLine": 50},
+    "range": {"startLine": 43, "endLine": 49},
     "type": "technique",
     "title": "Exact Length Formula via Gamma Function",
     "content": "The exact length of the $z^n - 1$ lemniscate is $L(z^n - 1) = \\frac{2n \\cdot \\Gamma(1/(2n))^2}{\\sqrt{2\\pi} \\cdot \\Gamma(1/n)}$. For $n = 2$, this gives the Bernoulli lemniscate length $\\approx 7.416$. For large $n$, Stirling's approximation gives $L \\sim 2n$. This formula would be proved in the `## Lemniscate Geometry` section stub (line 49) once Mathlib has enough integration theory.",

--- a/src/data/proofs/erdos-1159/annotations.json
+++ b/src/data/proofs/erdos-1159/annotations.json
@@ -156,7 +156,7 @@
     "type": "context",
     "range": {
       "startLine": 139,
-      "endLine": 145
+      "endLine": 144
     },
     "title": "Related Problems",
     "content": "Problem 664 extends this to all pairwise balanced block designs. Projective planes are (n^2+n+1, n+1, 1)-designs; the general case is less regular.",

--- a/src/data/proofs/erdos-119/annotations.json
+++ b/src/data/proofs/erdos-119/annotations.json
@@ -167,7 +167,7 @@
     "proofId": "erdos-119",
     "range": {
       "startLine": 82,
-      "endLine": 98
+      "endLine": 97
     },
     "type": "technique",
     "title": "Basic Properties",

--- a/src/data/proofs/erdos-128/annotations.json
+++ b/src/data/proofs/erdos-128/annotations.json
@@ -141,7 +141,7 @@
     "proofId": "erdos-128",
     "range": {
       "startLine": 78,
-      "endLine": 83
+      "endLine": 82
     },
     "type": "technique",
     "title": "Krivelevich's Theorem: Subgraph Size 3n/5",

--- a/src/data/proofs/erdos-136/annotations.json
+++ b/src/data/proofs/erdos-136/annotations.json
@@ -118,7 +118,7 @@
     "proofId": "erdos-136",
     "range": {
       "startLine": 168,
-      "endLine": 186
+      "endLine": 185
     },
     "type": "concept",
     "title": "Related Values and Monotonicity",

--- a/src/data/proofs/erdos-142/annotations.json
+++ b/src/data/proofs/erdos-142/annotations.json
@@ -97,7 +97,7 @@
     "proofId": "erdos-142",
     "range": {
       "startLine": 54,
-      "endLine": 55
+      "endLine": 54
     },
     "type": "concept",
     "title": "Roth's Theorem: The $k = 3$ Case",

--- a/src/data/proofs/erdos-214/annotations.json
+++ b/src/data/proofs/erdos-214/annotations.json
@@ -205,7 +205,7 @@
     "proofId": "erdos-214",
     "range": {
       "startLine": 176,
-      "endLine": 198
+      "endLine": 197
     },
     "type": "definition",
     "title": "Examples: Scaled Lattice",

--- a/src/data/proofs/erdos-231/annotations.json
+++ b/src/data/proofs/erdos-231/annotations.json
@@ -300,7 +300,7 @@
     "proofId": "erdos-231",
     "range": {
       "startLine": 205,
-      "endLine": 214
+      "endLine": 213
     },
     "type": "technique",
     "title": "Example: abba",

--- a/src/data/proofs/erdos-339/annotations.json
+++ b/src/data/proofs/erdos-339/annotations.json
@@ -203,7 +203,7 @@
     "proofId": "erdos-339",
     "range": {
       "startLine": 206,
-      "endLine": 216
+      "endLine": 215
     },
     "type": "definition",
     "title": "Related: Sidon Sets and Bₕ Sets",

--- a/src/data/proofs/erdos-340-greedy-sidon/annotations.json
+++ b/src/data/proofs/erdos-340-greedy-sidon/annotations.json
@@ -262,7 +262,7 @@
     "proofId": "erdos-340-greedy-sidon",
     "range": {
       "startLine": 444,
-      "endLine": 506
+      "endLine": 505
     },
     "type": "insight",
     "title": "Growth Rate Bounds and Erdos's Conjecture (#340)",

--- a/src/data/proofs/erdos-377/annotations.json
+++ b/src/data/proofs/erdos-377/annotations.json
@@ -213,7 +213,7 @@
     "proofId": "erdos-377",
     "range": {
       "startLine": 129,
-      "endLine": 135
+      "endLine": 134
     },
     "type": "technique",
     "title": "Complementary Sums Lemma",

--- a/src/data/proofs/erdos-396/annotations.json
+++ b/src/data/proofs/erdos-396/annotations.json
@@ -158,7 +158,7 @@
     "proofId": "erdos-396",
     "range": {
       "startLine": 77,
-      "endLine": 79
+      "endLine": 78
     },
     "type": "concept",
     "title": "Smallest Witnesses and Computational Evidence",

--- a/src/data/proofs/erdos-486/annotations.json
+++ b/src/data/proofs/erdos-486/annotations.json
@@ -195,7 +195,7 @@
     "proofId": "erdos-486",
     "range": {
       "startLine": 105,
-      "endLine": 109
+      "endLine": 108
     },
     "type": "definition",
     "title": "Natural Density",

--- a/src/data/proofs/erdos-500/annotations.json
+++ b/src/data/proofs/erdos-500/annotations.json
@@ -143,7 +143,7 @@
     "type": "context",
     "range": {
       "startLine": 45,
-      "endLine": 59
+      "endLine": 58
     },
     "title": "Stubs: Extremal Number, Density, Bounds, and Conjecture (Incomplete)",
     "content": "Lines 45-59 are section header comments and orphaned docstrings marking out the remaining formalization work:\n\n**Turán number** (stub at line 45): `ex3_K4 n` would return the maximum number of edges in a $K_4^{(3)}$-free hypergraph on $n$ vertices, axiomatized with existence (`ex3_K4_achievable`) and optimality (`ex3_K4_optimal`) properties.\n\n**Turán density** (stub at line 49): `turanDensityK4_3` would formalize $\\pi(K_4^{(3)}) = \\lim_{n\\to\\infty} \\text{ex}_3(n)/\\binom{n}{3}$, whose existence is guaranteed by the Katona–Nemetz–Simonovits theorem (1964).\n\n**Turán's lower bound** (stub at line 50): $\\pi \\geq 5/9$ from the 3-partition construction.\n\n**Razborov's upper bound** (stub at line 52): $\\pi \\leq 0.5612$ via flag algebras (2010).\n\n**Turán's conjecture** (stub at line 54): $\\pi = 5/9$ (OPEN since 1941).\n\n**Exact small values** (stub at line 56): $\\text{ex}_3(4) = 3$, $\\text{ex}_3(5) = 7$, $\\text{ex}_3(6) = 13$.",

--- a/src/data/proofs/erdos-502/annotations.json
+++ b/src/data/proofs/erdos-502/annotations.json
@@ -231,7 +231,7 @@
     "proofId": "erdos-502",
     "range": {
       "startLine": 83,
-      "endLine": 83
+      "endLine": 82
     },
     "type": "concept",
     "title": "Three-Dimensional Case f(3) = 6",

--- a/src/data/proofs/erdos-51/annotations.json
+++ b/src/data/proofs/erdos-51/annotations.json
@@ -153,7 +153,7 @@
     "proofId": "erdos-51",
     "range": {
       "startLine": 63,
-      "endLine": 70
+      "endLine": 69
     },
     "type": "context",
     "title": "Stubs: Preimage Structure and Growth Bounds (Unformalized)",

--- a/src/data/proofs/erdos-536/annotations.json
+++ b/src/data/proofs/erdos-536/annotations.json
@@ -86,7 +86,7 @@
   {
     "id": "ann-e536-structure",
     "proofId": "erdos-536",
-    "range": { "startLine": 82, "endLine": 84 },
+    "range": { "startLine": 82, "endLine": 83 },
     "type": "concept",
     "title": "LCM Divisibility Structure Lemma",
     "content": "**lcm_structure**: Axiomatizes that if $\\text{HasEqualPairwiseLCM}(a, b, c)$ and $[a,b] = L$, then $a \\mid L$, $b \\mid L$, and $c \\mid L$. This follows from the definition of LCM: $[a,b] = L$ implies $a \\mid L$ and $b \\mid L$, and $[a,c] = L$ implies $c \\mid L$. The lemma shows that an LCM triple must consist of three divisors of a common value.",

--- a/src/data/proofs/erdos-549/annotations.json
+++ b/src/data/proofs/erdos-549/annotations.json
@@ -325,7 +325,7 @@
     "proofId": "erdos-549",
     "range": {
       "startLine": 226,
-      "endLine": 249
+      "endLine": 248
     },
     "type": "technique",
     "title": "Main Result: Conjecture Disproved",

--- a/src/data/proofs/erdos-562/annotations.json
+++ b/src/data/proofs/erdos-562/annotations.json
@@ -219,7 +219,7 @@
     "proofId": "erdos-562",
     "range": {
       "startLine": 84,
-      "endLine": 86
+      "endLine": 85
     },
     "type": "concept",
     "title": "General Lower Bound for r ≥ 3",

--- a/src/data/proofs/erdos-57/annotations.json
+++ b/src/data/proofs/erdos-57/annotations.json
@@ -146,7 +146,7 @@
     "proofId": "erdos-57",
     "range": {
       "startLine": 155,
-      "endLine": 167
+      "endLine": 166
     },
     "type": "context",
     "title": "Historical Notes and Proof Technique Overview",

--- a/src/data/proofs/erdos-575/annotations.json
+++ b/src/data/proofs/erdos-575/annotations.json
@@ -164,7 +164,7 @@
     "proofId": "erdos-575",
     "range": {
       "startLine": 84,
-      "endLine": 90
+      "endLine": 89
     },
     "type": "concept",
     "title": "Monotonicity of Extremal Functions",

--- a/src/data/proofs/erdos-576/annotations.json
+++ b/src/data/proofs/erdos-576/annotations.json
@@ -417,7 +417,7 @@
     "proofId": "erdos-576",
     "range": {
       "startLine": 220,
-      "endLine": 224
+      "endLine": 223
     },
     "type": "concept",
     "title": "Hypercubes are Bipartite",

--- a/src/data/proofs/erdos-580/annotations.json
+++ b/src/data/proofs/erdos-580/annotations.json
@@ -246,7 +246,7 @@
     "proofId": "erdos-580",
     "range": {
       "startLine": 223,
-      "endLine": 237
+      "endLine": 236
     },
     "type": "technique",
     "title": "Tightness of the LKS Condition",

--- a/src/data/proofs/erdos-593/annotations.json
+++ b/src/data/proofs/erdos-593/annotations.json
@@ -119,7 +119,7 @@
     "proofId": "erdos-593",
     "range": {
       "startLine": 99,
-      "endLine": 111
+      "endLine": 110
     },
     "type": "technique",
     "title": "2-Colorable Hypergraphs Are Unavoidable",

--- a/src/data/proofs/erdos-606/annotations.json
+++ b/src/data/proofs/erdos-606/annotations.json
@@ -336,7 +336,7 @@
     "proofId": "erdos-606",
     "range": {
       "startLine": 229,
-      "endLine": 244
+      "endLine": 243
     },
     "type": "technique",
     "title": "Szemer\u00e9di-Trotter Incidence Bound",

--- a/src/data/proofs/erdos-610/annotations.json
+++ b/src/data/proofs/erdos-610/annotations.json
@@ -289,7 +289,7 @@
     "proofId": "erdos-610",
     "range": {
       "startLine": 203,
-      "endLine": 223
+      "endLine": 222
     },
     "type": "technique",
     "title": "Main Result: erdos_610_known (OPEN)",

--- a/src/data/proofs/erdos-627/annotations.json
+++ b/src/data/proofs/erdos-627/annotations.json
@@ -486,7 +486,7 @@
     "proofId": "erdos-627",
     "range": {
       "startLine": 222,
-      "endLine": 237
+      "endLine": 236
     },
     "type": "concept",
     "title": "Main Status",

--- a/src/data/proofs/erdos-634/annotations.json
+++ b/src/data/proofs/erdos-634/annotations.json
@@ -650,7 +650,7 @@
     "proofId": "erdos-634",
     "range": {
       "startLine": 271,
-      "endLine": 299
+      "endLine": 298
     },
     "type": "technique",
     "title": "Erdős Problem #634 — Partial Answer",

--- a/src/data/proofs/erdos-636/annotations.json
+++ b/src/data/proofs/erdos-636/annotations.json
@@ -447,7 +447,7 @@
     "proofId": "erdos-636",
     "range": {
       "startLine": 240,
-      "endLine": 262
+      "endLine": 261
     },
     "type": "concept",
     "title": "Related Problems",

--- a/src/data/proofs/erdos-704/annotations.json
+++ b/src/data/proofs/erdos-704/annotations.json
@@ -188,7 +188,7 @@
     "proofId": "erdos-704",
     "range": {
       "startLine": 140,
-      "endLine": 155
+      "endLine": 154
     },
     "type": "concept",
     "title": "Proof Techniques",

--- a/src/data/proofs/erdos-724/annotations.json
+++ b/src/data/proofs/erdos-724/annotations.json
@@ -280,7 +280,7 @@
     "proofId": "erdos-724",
     "range": {
       "startLine": 305,
-      "endLine": 310
+      "endLine": 309
     },
     "type": "concept",
     "title": "Summary of Known Results",

--- a/src/data/proofs/erdos-858/annotations.json
+++ b/src/data/proofs/erdos-858/annotations.json
@@ -243,7 +243,7 @@
     "proofId": "erdos-858",
     "range": {
       "startLine": 327,
-      "endLine": 349
+      "endLine": 348
     },
     "type": "technique",
     "title": "Summary",

--- a/src/data/proofs/erdos-91/annotations.json
+++ b/src/data/proofs/erdos-91/annotations.json
@@ -187,7 +187,7 @@
     "proofId": "erdos-91",
     "range": {
       "startLine": 243,
-      "endLine": 277
+      "endLine": 276
     },
     "type": "technique",
     "title": "Problem Summary",

--- a/src/data/proofs/erdos-980/annotations.json
+++ b/src/data/proofs/erdos-980/annotations.json
@@ -352,7 +352,7 @@
     "proofId": "erdos-980",
     "range": {
       "startLine": 275,
-      "endLine": 277
+      "endLine": 276
     },
     "type": "concept",
     "title": "Polya-Vinogradov Connection",

--- a/src/data/proofs/erdos-983/annotations.json
+++ b/src/data/proofs/erdos-983/annotations.json
@@ -120,7 +120,7 @@
     "proofId": "erdos-983",
     "range": {
       "startLine": 187,
-      "endLine": 207
+      "endLine": 206
     },
     "type": "definition",
     "title": "y-Smooth Numbers and Dickman Asymptotics",

--- a/src/data/proofs/erdos-994/annotations.json
+++ b/src/data/proofs/erdos-994/annotations.json
@@ -474,7 +474,7 @@
     "type": "concept",
     "range": {
       "startLine": 209,
-      "endLine": 209
+      "endLine": 208
     },
     "title": "Main Result: Erdős Problem #994",
     "content": "The headline theorem: `erdos_994 : ¬KhintchineConjecture`, proved directly from `marstrand_disproof`. This one-line proof captures the resolution of the problem. Followed by `erdos_994_main` (alias) and `erdos_994_disproof` (pairing with Weyl's positive result).",

--- a/src/data/proofs/erdos-999/annotations.json
+++ b/src/data/proofs/erdos-999/annotations.json
@@ -119,7 +119,7 @@
     "proofId": "erdos-999",
     "range": {
       "startLine": 121,
-      "endLine": 148
+      "endLine": 147
     },
     "type": "concept",
     "title": "Consequences and Related Results",

--- a/src/data/proofs/hilbert-3/annotations.json
+++ b/src/data/proofs/hilbert-3/annotations.json
@@ -239,7 +239,7 @@
     "proofId": "hilbert-3",
     "range": {
       "startLine": 475,
-      "endLine": 515
+      "endLine": 514
     },
     "type": "context",
     "title": "Historical Impact and K-Theory Connections",

--- a/src/data/proofs/kepler-conjecture/annotations.json
+++ b/src/data/proofs/kepler-conjecture/annotations.json
@@ -194,7 +194,7 @@
     "proofId": "kepler-conjecture",
     "range": {
       "startLine": 418,
-      "endLine": 431
+      "endLine": 430
     },
     "type": "context",
     "title": "Exports and Summary",

--- a/src/data/proofs/mean-value-theorem/annotations.json
+++ b/src/data/proofs/mean-value-theorem/annotations.json
@@ -225,7 +225,7 @@
     "proofId": "mean-value-theorem",
     "range": {
       "startLine": 157,
-      "endLine": 164
+      "endLine": 163
     },
     "type": "concept",
     "title": "Type-Check Verification",

--- a/src/data/proofs/solution-of-cubic/annotations.json
+++ b/src/data/proofs/solution-of-cubic/annotations.json
@@ -215,7 +215,7 @@
     "proofId": "solution-of-cubic",
     "range": {
       "startLine": 269,
-      "endLine": 298
+      "endLine": 297
     },
     "type": "concept",
     "title": "Historical Significance and Connections",

--- a/src/data/proofs/sylow-theorems/annotations.json
+++ b/src/data/proofs/sylow-theorems/annotations.json
@@ -271,7 +271,7 @@
     "proofId": "sylow-theorems",
     "range": {
       "startLine": 234,
-      "endLine": 247
+      "endLine": 246
     },
     "type": "context",
     "title": "Verification via #check",

--- a/src/data/proofs/yang-mills/annotations.json
+++ b/src/data/proofs/yang-mills/annotations.json
@@ -418,7 +418,7 @@
     "proofId": "yang-mills",
     "range": {
       "startLine": 41,
-      "endLine": 49
+      "endLine": 48
     },
     "type": "concept",
     "title": "Summary: 50+ Theorems, 7 Axioms, and the Open Conjecture",


### PR DESCRIPTION
## Fix

56 `annotations.json` files had `range.endLine` set one line past the actual Lean source file length, making annotations reference a non-existent line 

## Evidence

**Before**: `"endLine": 437` (file is 436 lines)  
**After**: `"endLine": 436`

**Scope**: 56 files, 56 single-line changes — each a surgical `endLine` decrement using regex replacement. No JSON reformatting, no unicode changes.

**Example files fixed**:
- `dissection-of-cubes-oq-04` (437→436)
- `area-of-circle-oq-01` (163→162)
- `yang-mills` (49→48)
- 53 more across the gallery

---
Automated fix by lean-mechanic agent.