### PR TITLE
Audit fix: erdos-321 leanFile.axiomCount 0→2

### DIFF
--- a/src/data/proofs/erdos-321/meta.json
+++ b/src/data/proofs/erdos-321/meta.json
@@ -170,7 +170,7 @@
   ],
   "leanFile": {
     "lineCount": 155,
-    "axiomCount": 0,
+    "axiomCount": 2,
     "theoremCount": 7,
     "definitionCount": 3,
     "imports": [


### PR DESCRIPTION
## Summary

- Corrects `leanFile.axiomCount` from `0` to `2` in `src/data/proofs/erdos-321/meta.json`
- The Lean file `proofs/Proofs/Erdos321Problem.lean` has 2 `axiom` declarations: `bleicher_erdos_lower` (line 141) and `bleicher_erdos_upper` (line 147)
- `meta.axiomCount` was already correct at `2`; only `leanFile.axiomCount` needed updating

## Test plan
- [ ] Verify `leanFile.axiomCount` is `2` in meta.json
- [ ] Verify `meta.axiomCount` is still `2` (unchanged)
- [ ] Confirm no other fields were modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)