### PR TITLE
Fix: sync sorry counts in 2 gallery meta.json files

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -14,10 +14,10 @@
       "measure-theory"
     ],
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 16,
     "axiomCount": 0,
-    "lineCount": 980,
-    "assumptions": "2 remaining sorries, both dead-path (not used in main proof chain): (1) truncated_rn_deriv_lq_bound (line 191) — incorrect approach, bypassed; (2) rn_deriv_memLq (line 207) — depends on (1), also bypassed. The main theorem riesz_lp_surjective_from_rn is proved via rn_deriv_memLq_from_trunc + holder_extremizer_lq_bound (all sorry-free). holder_extremizer_lq_bound proved in session 5 (2026-04-22).",
+    "lineCount": 863,
+    "assumptions": "16 active sorries across supporting infrastructure lemmas (functionalSetFn_null, truncated_memLq, truncated_rn_deriv_lq_bound, rn_deriv_memLq, rn_deriv_memLq_from_trunc, holder_product_integrable, integrationCLM, integrationCLM_eq, integral_representation_from_rn, indicator_lp_hasSum, functional_hasSum_parts, signedMeasureOfFunctional def, signedMeasureOfFunctional_spec, signedMeasureOfFunctional_ac, rnDeriv_integral_eq, holder_extremizer_lq_bound). Dead code section (lines 390–755) is commented out.",
     "dateAdded": "2026-04-13"
   },
   "overview": {
@@ -106,7 +106,7 @@
     "imports": [
       "Mathlib"
     ],
-    "lineCount": 980,
+    "lineCount": 863,
     "axiomCount": 0,
     "theoremCount": 15,
     "definitionCount": 2,
@@ -133,7 +133,7 @@
       }
     ],
     "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-    "sorries": 2
+    "sorries": 16
   },
-  "sorries": 2
+  "sorries": 16
 }

--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -18,10 +18,10 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 8,
+    "sorries": 4,
     "axiomCount": 5,
-    "lineCount": 419,
-    "assumptions": "8 sorries: hausdorff_free_subgroup (free subgroup of SO(3)), banach_tarski (main theorem), banach_tarski_pieces_nonmeasurable (non-measurability of pieces), int_amenable (ℤ amenability), W_a_two_cover (W(a) two-cover), W_a_smul_disj (W(a) smul disjointness), W_b_two_cover (W(b) two-cover), W_b_smul_disj (W(b) smul disjointness). The main proof requires ~800 lines via free subgroup of SO(3) — beyond this gallery entry's scope. Note: paradoxical_no_finite_measure and free_group_not_amenable structure are fully proved.",
+    "lineCount": 563,
+    "assumptions": "4 sorries: hausdorff_free_subgroup (free subgroup of SO(3)), banach_tarski (main theorem), banach_tarski_pieces_nonmeasurable (non-measurability of pieces), int_amenable (ℤ amenability). W_a_two_cover, W_a_smul_disj, W_b_two_cover, W_b_smul_disj were resolved. The main proof requires ~800 lines via free subgroup of SO(3) — beyond this gallery entry's scope. Note: paradoxical_no_finite_measure and free_group_not_amenable structure are fully proved.",
     "dateAdded": "2026-04-22",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -206,7 +206,7 @@
     "theoremCount": 7,
     "definitionCount": 5,
     "path": "Proofs/LebesgueMeasureOQ06.lean",
-    "sorries": 8
+    "sorries": 4
   },
-  "sorries": 8
+  "sorries": 4
 }


### PR DESCRIPTION
## Fix

Corrects stale sorry counts in two gallery entries where the Lean files diverged from metadata.

## Evidence

**cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01**
- **Before**: sorries=2, lineCount=980 (metadata from early development session)
- **After**: sorries=16, lineCount=863 (actual counts: 16 active sorry tactics in code, 863-line file)
- The file has a large dead-code block (lines 390–755) correctly excluded from count

**lebesgue-measure-oq-06** (Banach-Tarski)
- **Before**: sorries=8, lineCount=419
- **After**: sorries=4, lineCount=563
- W_a_two_cover, W_a_smul_disj, W_b_two_cover, W_b_smul_disj were resolved
- Remaining: hausdorff_free_subgroup, banach_tarski, banach_tarski_pieces_nonmeasurable, int_amenable

---
Automated fix by lean-mechanic agent.