### PR TITLE
Fix: cap section endLine to file length in 44 gallery meta.json entries

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02/meta.json
@@ -144,7 +144,7 @@
       "id": "corollaries",
       "title": "Corollaries and Special Cases",
       "startLine": 93,
-      "endLine": 146,
+      "endLine": 141,
       "summary": "Derives: explicit form (∫₀ʳ 2πρ dρ = πr²), annulus area formula (∫_{r₁}^{r₂} 2πρ dρ = π(r₂² - r₁²)), FTC Part 1 duality (differentiating the integral recovers circumference), unit disk area (= π), and quadratic scaling law.",
       "mathContext": "Corollaries: (1) annulus area $\\int_{r_1}^{r_2} 2\\pi\\rho\\,d\\rho = \\pi(r_2^2 - r_1^2)$; (2) FTC Part 1 duality: $\\frac{d}{dr}\\int_0^r 2\\pi\\rho\\,d\\rho = 2\\pi r$, recovering the circumference by differentiating the area integral; (3) unit disk $\\int_0^1 2\\pi\\rho\\,d\\rho = \\pi$; (4) scaling: $A(cr) = c^2 A(r)$, reflecting the quadratic dependence on radius."
     }

--- a/src/data/proofs/bertrands-postulate/meta.json
+++ b/src/data/proofs/bertrands-postulate/meta.json
@@ -113,7 +113,7 @@
       "id": "pnt-connection",
       "title": "Connection to the Prime Number Theorem",
       "startLine": 143,
-      "endLine": 155,
+      "endLine": 151,
       "summary": "Bertrand's Postulate as a stepping stone toward the Prime Number Theorem: π(x) ~ x/ln(x). While Bertrand guarantees ≥1 prime in (n, 2n], the PNT predicts ~n/ln(n) primes.",
       "mathContext": "$\\pi(2n) - \\pi(n) \\geq 1$ (Bertrand) vs $\\pi(2n) - \\pi(n) \\sim \\frac{n}{\\ln n}$ (PNT). The PNT ($\\pi(x) \\sim x/\\ln x$, proved 1896 by Hadamard and de la Vallée-Poussin) implies Bertrand for sufficiently large $n$, but Bertrand's elementary proof covers all $n$."
     },

--- a/src/data/proofs/bezout-identity-oq-03/meta.json
+++ b/src/data/proofs/bezout-identity-oq-03/meta.json
@@ -153,7 +153,7 @@
       "id": "summary",
       "title": "Summary",
       "startLine": 259,
-      "endLine": 284,
+      "endLine": 276,
       "summary": "Documents the 5-step proof strategy and the key insight that bezout_int and IsCoprime are two faces of the same coin.",
       "mathContext": "Five-step proof: (1) Bézout gives $mu + nv = 1$, (2) construct $x = anv + bmu$, (3) verify $x \\equiv a \\pmod{m}$ and $x \\equiv b \\pmod{n}$, (4) uniqueness mod $mn$ via `IsCoprime.mul_dvd`, (5) package into combined theorem."
     }

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-01/meta.json
@@ -89,7 +89,7 @@
       "id": "part-v-existence",
       "title": "Part V: vec_minpoly_exists — Full Existence, Monic Form, Divisibility",
       "startLine": 158,
-      "endLine": 267,
+      "endLine": 265,
       "summary": "The main theorem vec_minpoly_exists proves existence of a monic μ with degree ≤ n, μ(M)·v = 0, μ | μ_M, and universal minimality (μ | q for every annihilating q). The proof uses degree_lt_wf to find the minimum-degree element, monic_of_isUnit_leadingCoeff_inv_smul for the monic form, and a Euclidean division + minimality contradiction for the divisibility. The closing summary comment reviews all 9 theorems."
     }
   ],

--- a/src/data/proofs/chebyshev-bounds/meta.json
+++ b/src/data/proofs/chebyshev-bounds/meta.json
@@ -101,7 +101,7 @@
       "id": "sec-chebyshev-binom-lower",
       "title": "Central Binomial Lower Bound and Log Corollary",
       "startLine": 372,
-      "endLine": 445,
+      "endLine": 439,
       "description": "Two lower bound results: `centralBinom_ge_four_pow_div`: 4^n ≤ (2n+1)·C(2n,n), proved by: 4^n = Σ_k C(2n,k) ≤ Σ_k C(2n,n) = (2n+1)·C(2n,n), using `Nat.choose_le_middle` (C(2n,n) is the maximum term). `log_centralBinom_ge`: n·log(4) − log(2n+1) ≤ log(C(2n,n)), proved by casting to ℝ, dividing, and applying `Real.log_le_log`. Summary section (lines 421-440) catalogs 8 results in two categories (upper vs. lower bounds and central binomial bounds)."
     }
   ],

--- a/src/data/proofs/dissection-of-cubes-oq-02/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-02/meta.json
@@ -131,7 +131,7 @@
       "id": "specific-angles",
       "title": "Dihedral Angles of Other Platonic Solids",
       "startLine": 200,
-      "endLine": 381,
+      "endLine": 379,
       "summary": "Defines dihedral angles for the regular octahedron (arccos(-1/3)) and icosahedron (arccos(-√5/3)). Proves positivity of the tetrahedron angle. Provides verification checks for the main results.",
       "mathContext": "Formal definition: Defines dihedral angles for the regular octahedron (arccos(-1/3)) and icosahedron (arccos(-√5/3)). Proves positivity of the tetrahedron angle. Provides verification checks for the main results."
     }

--- a/src/data/proofs/erdos-1059/meta.json
+++ b/src/data/proofs/erdos-1059/meta.json
@@ -163,7 +163,7 @@
       "title": "Verified Examples Summary",
       "summary": "Proves `prime_101`, `prime_211` via certified `decide` (trial division checked by the kernel). Packages both witnesses into `two_witnesses`: $(101).\\text{Prime} \\wedge \\text{AllFact}(101) \\wedge (211).\\text{Prime} \\wedge \\text{AllFact}(211)$.",
       "startLine": 137,
-      "endLine": 160,
+      "endLine": 155,
       "mathContext": "Summary: $101, 211 \\in $ OEIS A064152, both verified prime and factorial-avoiding. Lean's `decide` performs certified trial division."
     }
   ],

--- a/src/data/proofs/erdos-135/meta.json
+++ b/src/data/proofs/erdos-135/meta.json
@@ -81,7 +81,7 @@
       "title": "Forbidden Four-Point Patterns",
       "summary": "InGeneralPosition, IsParallelogram, IsForbiddenPattern, parallelogram_forbidden",
       "startLine": 107,
-      "endLine": 204,
+      "endLine": 146,
       "mathContext": "Mathematical content: InGeneralPosition, IsParallelogram, IsForbiddenPattern, parallelogram_forbidden"
     },
     {

--- a/src/data/proofs/erdos-181-oq-01/meta.json
+++ b/src/data/proofs/erdos-181-oq-01/meta.json
@@ -121,7 +121,7 @@
       "id": "conjecture",
       "title": "Open Conjecture and Consequences",
       "startLine": 147,
-      "endLine": 185,
+      "endLine": 170,
       "summary": "States Tikhomirov (2022) and the main conjecture as axioms. Proves bounded ratio consequence.",
       "mathContext": "If ∃ C, R_sym(Q_n) ≤ C·2^n, then R_sym(Q_n)/2^n ≤ C is bounded. The Tikhomirov exponent 2-c gives sub-exponential improvement but doesn't reach linearity."
     }

--- a/src/data/proofs/erdos-187/meta.json
+++ b/src/data/proofs/erdos-187/meta.json
@@ -78,7 +78,7 @@
       "id": "beck-bound",
       "title": "Part III: Beck's Upper Bound",
       "startLine": 53,
-      "endLine": 58,
+      "endLine": 54,
       "summary": "Axiom: ∃ C, D₀, ∀ d ≥ D₀, f(d) ≤ C · (log₂ d + 1). Beck (1980) constructs a low-discrepancy 2-coloring limiting monochromatic AP length to O(log d)."
     }
   ],

--- a/src/data/proofs/erdos-192/meta.json
+++ b/src/data/proofs/erdos-192/meta.json
@@ -110,7 +110,7 @@
       "id": "classification",
       "title": "Part IV: Complete Classification",
       "startLine": 87,
-      "endLine": 107,
+      "endLine": 103,
       "summary": "Theorem erdos_192: conjunction of d=3 unavoidability and d=4 avoidability, proved by ⟨three_term_ap_low_dim 3 (by omega), keranen_counterexample⟩; establishes threshold dimension d = 3"
     }
   ],

--- a/src/data/proofs/erdos-204/meta.json
+++ b/src/data/proofs/erdos-204/meta.json
@@ -144,7 +144,7 @@
       "id": "examples",
       "title": "Small Examples",
       "startLine": 177,
-      "endLine": 189,
+      "endLine": 185,
       "summary": "Verified: `properDivisors 6 = {2, 3, 6}` by `native_decide`. The divisibility obstruction for $n = 6$ ($2 \\mid 6$ gives $\\gcd(2,6) = 2$) is captured by `divisor_pair_not_coprime`.",
       "mathContext": "Verified: `properDivisors 6 = {2, 3, 6}` by `native_decide`. The divisibility obstruction for $n = 6$ ($2 \\mid 6$ gives $\\gcd(2,6) = 2$) is captured by `divisor_pair_not_coprime`."
     }

--- a/src/data/proofs/erdos-234/meta.json
+++ b/src/data/proofs/erdos-234/meta.json
@@ -127,7 +127,7 @@
       "id": "density-function-properties",
       "title": "Properties of the Density Function",
       "startLine": 461,
-      "endLine": 512,
+      "endLine": 510,
       "summary": "Conditional properties of the density $f(c)$ (if it exists): $f(c) \\in [0,1]$, $f$ is monotone non-decreasing, and $f(c) \\to 1$ as $c \\to \\infty$. The last result uses density_at_infinity and `tendsto_order`.",
       "mathContext": "Verified: If the density exists (the limit of gapProportion), it necessarily satisfies CDF properties. The limit approach uses `ge_of_tendsto` / `le_of_tendsto` for bounds and `tendsto_order` for the convergence $f(c) \\to 1$."
     }

--- a/src/data/proofs/erdos-279/meta.json
+++ b/src/data/proofs/erdos-279/meta.json
@@ -93,7 +93,7 @@
       "id": "conjectures",
       "title": "The Erdős Problem and Generalization",
       "startLine": 61,
-      "endLine": 85,
+      "endLine": 79,
       "summary": "States ErdosProblem279 for general k ≥ 3 (existence of a covering residue choice), ErdosProblem279_k3 for the specific k = 3 case, the GeneralizedCovering definition using a choice function on an arbitrary set A, and ErdosProblem279_generalized asserting that any set with prime-like density and log-log divergence admits a covering.",
       "mathContext": "Main conjecture: `axiom ErdosProblem279 (k : ℕ) (hk : 3 ≤ k) : ∃ a : ResidueChoice, CoversEventually a k`. The $k = 3$ instance follows by `le_refl 3`. The generalized conjecture replaces primes with arbitrary $A \\subseteq \\mathbb{N}$ satisfying density conditions, using `GeneralizedCovering A k` which existentially quantifies over a choice function on $A$."
     }

--- a/src/data/proofs/erdos-360/meta.json
+++ b/src/data/proofs/erdos-360/meta.json
@@ -141,7 +141,7 @@
       "title": "Main Result",
       "summary": "erdos_360_solved theorem showing problem is resolved",
       "startLine": 166,
-      "endLine": 187,
+      "endLine": 170,
       "mathContext": "Verified: erdos_360_solved theorem showing problem is resolved"
     }
   ],

--- a/src/data/proofs/erdos-456/meta.json
+++ b/src/data/proofs/erdos-456/meta.json
@@ -175,7 +175,7 @@
       "id": "pigeonhole",
       "title": "Density Implies Infinitely Many",
       "startLine": 249,
-      "endLine": 275,
+      "endLine": 271,
       "summary": "Proves `almostAll_infinitely_often`: if $P$ holds for almost all $n$, then for every $N$ there exists $n \\ge N$ with $P(n)$. Proof by contradiction via pigeonhole: take $\\varepsilon = 1/2$, $M = \\max(N_0, 2N+1)$; if no witness in $[N, M)$, exceptions $\\ge M - N > M/2$, contradicting the density bound."
     }
   ],

--- a/src/data/proofs/erdos-465/meta.json
+++ b/src/data/proofs/erdos-465/meta.json
@@ -157,7 +157,7 @@
       "title": "Summary",
       "summary": "erdos_465_solved = FirstConjecture ∧ SecondConjecture (genuinely proved). optimal_growth = KonyaginBound ∧ LowerBound (from axioms, no sorry). erdos_465_summary combines all four. erdos_465_status gives human-readable string.",
       "startLine": 243,
-      "endLine": 270
+      "endLine": 256
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-523/meta.json
+++ b/src/data/proofs/erdos-523/meta.json
@@ -171,7 +171,7 @@
       "id": "summary",
       "title": "Summary: SOLVED",
       "startLine": 238,
-      "endLine": 241,
+      "endLine": 238,
       "summary": "Four concluding theorems: `erdos_523`, `erdos_523_constant` ($C = 1$), `erdos_523_main`, and `erdos_523_solved`. **Status: Completely solved by Halasz (1973).**",
       "mathContext": "Verified: Four concluding theorems: `erdos_523`, `erdos_523_constant` ($C = 1$), `erdos_523_main`, and `erdos_523_solved`. **Status: Completely solved by Halasz (1973).**"
     }

--- a/src/data/proofs/erdos-617/meta.json
+++ b/src/data/proofs/erdos-617/meta.json
@@ -137,7 +137,7 @@
       "id": "summary",
       "title": "Summary",
       "startLine": 180,
-      "endLine": 210,
+      "endLine": 202,
       "summary": "erdos_617_summary theorem combining known results",
       "mathContext": "Verified: erdos_617_summary theorem combining known results"
     }

--- a/src/data/proofs/erdos-632/meta.json
+++ b/src/data/proofs/erdos-632/meta.json
@@ -149,7 +149,7 @@
       "title": "Positive Results for Special Classes",
       "summary": "Axiomatizes cases where the ERT conjecture *does* hold: fractional choosability (Alon–Tuza–Voigt), complete graphs, bipartite graphs, and planar graphs ($m = 2$ case, via Euler's formula constraints).",
       "startLine": 227,
-      "endLine": 263,
+      "endLine": 260,
       "mathContext": "Axiomatized: Axiomatizes cases where the ERT conjecture *does* hold: fractional choosability (Alon–Tuza–Voigt), complete graphs, bipartite graphs, and planar graphs ($m = 2$ case, via Euler's formula constraints)."
     },
     {

--- a/src/data/proofs/erdos-642/meta.json
+++ b/src/data/proofs/erdos-642/meta.json
@@ -167,7 +167,7 @@
       "title": "Main Results",
       "summary": "erdos_642_bounds combines both bounds: ⌊n^(3/2)/4⌋ ≤ f(n) ≤ ⌈n(log n)^8⌉ for n ≥ 10, using constructor with f_lower_bound and dmms_2024. Utility definitions record the OPEN status. bounds_gap proves the ratio is (log n)^8/√n via ring_nf. Three #check commands verify the key theorems typecheck.",
       "startLine": 231,
-      "endLine": 266,
+      "endLine": 263,
       "mathContext": "erdos_642_bounds combines both bounds: ⌊n^(3/2)/4⌋ ≤ f(n) ≤ ⌈n(log n)^8⌉ for n ≥ 10, using constructor with f_lower_bound and dmms_2024. Utility definitions record the OPEN status. bounds_gap proves the ratio is (log n)^8/√n via ring_nf. Three #check commands verify the key theorems typecheck."
     }
   ],

--- a/src/data/proofs/erdos-643/meta.json
+++ b/src/data/proofs/erdos-643/meta.json
@@ -118,7 +118,7 @@
       "id": "constructions",
       "title": "Sunflower Constructions",
       "startLine": 158,
-      "endLine": 1433,
+      "endLine": 1403,
       "summary": "Sunflower hypergraphs avoiding crossed pairs"
     }
   ],

--- a/src/data/proofs/erdos-652/meta.json
+++ b/src/data/proofs/erdos-652/meta.json
@@ -154,7 +154,7 @@
       "title": "Computational Examples",
       "summary": "Concrete constructions: regular $n$-gon center achieves $R = 1$ (extreme minimizer), and the $\\sqrt{n} \\times \\sqrt{n}$ integer grid has $R \\leq 2\\sqrt{n}$ for most points (near-extremal for distinct distances).",
       "startLine": 168,
-      "endLine": 177,
+      "endLine": 175,
       "mathContext": "Regular $n$-gon center: $R = 1$. Integer $\\sqrt{n} \\times \\sqrt{n}$ grid: $R \\sim \\sqrt{n}$ for most points."
     }
   ],

--- a/src/data/proofs/erdos-866/meta.json
+++ b/src/data/proofs/erdos-866/meta.json
@@ -97,7 +97,7 @@
       "title": "Case k=4: Bounded Threshold g₄≤2032",
       "summary": "Two axioms: g₄(N) ≤ C absolutely (Choi–Erdős–Szemerédi) and g₄(N) ≤ 2032 (van Doorn).",
       "startLine": 83,
-      "endLine": 100,
+      "endLine": 85,
       "mathContext": "$\\exists C \\in \\mathbb{N},\\; \\forall N,\\; g_4(N) \\le C$ (bounded). Explicit: $g_4(N) \\le 2032$ (van Doorn). Stark contrast: $g_4 = O(1)$ while $g_5 = \\Theta(\\log N)$."
     },
     {

--- a/src/data/proofs/erdos-926/meta.json
+++ b/src/data/proofs/erdos-926/meta.json
@@ -119,7 +119,7 @@
       "id": "probabilistic",
       "title": "Probabilistic Method Connection",
       "startLine": 219,
-      "endLine": 237,
+      "endLine": 235,
       "summary": "Axiomatizes dependent random choice (common neighborhood of random $r$-tuple gives controlled, high-codegree set) and the container method as alternative approaches.",
       "mathContext": "Axiomatized: Axiomatizes dependent random choice (common neighborhood of random $r$-tuple gives controlled, high-codegree set) and the container method as alternative approaches."
     }

--- a/src/data/proofs/erdos-93/meta.json
+++ b/src/data/proofs/erdos-93/meta.json
@@ -119,7 +119,7 @@
       "id": "summary",
       "title": "Summary Theorem",
       "startLine": 133,
-      "endLine": 155,
+      "endLine": 146,
       "summary": "erdos_93_summary combining Altman + Fishburn implication."
     }
   ],

--- a/src/data/proofs/erdos-95/meta.json
+++ b/src/data/proofs/erdos-95/meta.json
@@ -135,7 +135,7 @@
       "id": "summary",
       "title": "Summary",
       "startLine": 149,
-      "endLine": 186,
+      "endLine": 184,
       "summary": "Main theorem `erdos_95`: `ErdosConjecture ∧ Guth-Katz bound`, proved as $\\langle$`erdos_conjecture_proved`, `guth_katz_theorem`$\\rangle$. Documentation strings `erdos_95_answer` and `erdos_95_status`. `#check` commands verify key definitions.",
       "mathContext": "Main theorem `erdos_95`: `ErdosConjecture ∧ Guth-Katz bound`, proved as $\\langle$`erdos_conjecture_proved`, `guth_katz_theorem`$\\rangle$."
     }

--- a/src/data/proofs/erdos-969/meta.json
+++ b/src/data/proofs/erdos-969/meta.json
@@ -121,7 +121,7 @@
       "title": "Summary and Main Theorem",
       "summary": "erdos_969_summary combining all known bounds and open status",
       "startLine": 224,
-      "endLine": 229,
+      "endLine": 225,
       "mathContext": "Bound: erdos_969_summary combining all known bounds and open status"
     }
   ],

--- a/src/data/proofs/erdos-982/meta.json
+++ b/src/data/proofs/erdos-982/meta.json
@@ -164,7 +164,7 @@
       "title": "Main Results",
       "summary": "erdos_982_status, erdos_982_summary final theorems",
       "startLine": 314,
-      "endLine": 337,
+      "endLine": 333,
       "mathContext": "Verified: erdos_982_status, erdos_982_summary final theorems"
     }
   ],

--- a/src/data/proofs/erdos-991/meta.json
+++ b/src/data/proofs/erdos-991/meta.json
@@ -164,7 +164,7 @@
       "title": "Comparison of Bounds",
       "summary": "improvement_factor, discrepancy_summary",
       "startLine": 298,
-      "endLine": 324,
+      "endLine": 322,
       "mathContext": "Mathematical content: improvement_factor, discrepancy_summary"
     }
   ],

--- a/src/data/proofs/fair-games-theorem/meta.json
+++ b/src/data/proofs/fair-games-theorem/meta.json
@@ -122,7 +122,7 @@
       "id": "applications",
       "title": "Applications (Placeholder Theorems)",
       "startLine": 349,
-      "endLine": 428,
+      "endLine": 417,
       "summary": "Five placeholder theorems proving `(1:ℕ)+1=2` with substantive docstrings discussing gambler's ruin, betting systems, option pricing, and Doob's inequality. The mathematical applications described are accurate but NOT formalized — these are future targets.",
       "mathContext": "Docstrings describe: gambler's ruin $P(\\text{success}) = W_0/(W_0 + a)$, Doob's inequality $P(\\max_{n \\leq N} f_n \\geq \\lambda) \\leq E[f_N]/\\lambda$, and Black-Scholes pricing. The formal content is trivial (`rfl`)."
     },

--- a/src/data/proofs/fermats-last-theorem/meta.json
+++ b/src/data/proofs/fermats-last-theorem/meta.json
@@ -120,7 +120,7 @@
       "id": "special-cases",
       "title": "Classical Special Cases",
       "startLine": 141,
-      "endLine": 204,
+      "endLine": 201,
       "summary": "Elementary proofs of Fermat's Last Theorem for n = 3, n = 4, and reduction to prime exponents.",
       "mathContext": "$n = 4$: Fermat's infinite descent on $x^4 + y^4 = z^2$. $n = 3$: Euler's proof using $\\mathbb{Z}[\\omega]$. Reduction: $n \\mid m \\implies \\text{FLT}(n) \\implies \\text{FLT}(m)$."
     }

--- a/src/data/proofs/four-color-theorem-oq-02/meta.json
+++ b/src/data/proofs/four-color-theorem-oq-02/meta.json
@@ -78,7 +78,7 @@
       "id": "open-question-discussion",
       "title": "Open Question: Can 633 Be Reduced Further?",
       "startLine": 70,
-      "endLine": 91,
+      "endLine": 86,
       "summary": "Analysis of obstacles to reducing below 633 configurations: (1) computational constraint — reducibility checking grows exponentially with ring size; (2) unavoidability constraint — removing configs requires new discharging rules; (3) inherent trade-off — fewer configs typically means larger ring sizes.",
       "mathContext": "Minimum set size: lower bound ~10 (theoretical), heuristic lower bound ~200-400, current best 633 (RSST). The trade-off: fewer configurations $\\Rightarrow$ larger ring sizes $\\Rightarrow$ harder reducibility checking (exponential in ring size)."
     }

--- a/src/data/proofs/geometric-series-oq-03/meta.json
+++ b/src/data/proofs/geometric-series-oq-03/meta.json
@@ -124,7 +124,7 @@
       "id": "euler-product",
       "title": "The Euler Product Formula and Bridge Theorem",
       "startLine": 201,
-      "endLine": 235,
+      "endLine": 215,
       "summary": "euler_product_formula (from Mathlib), and zeta_eq_prod_geom_series: the main bridge theorem ζ(s) = ∏_p ∑_k (p^{-s})^k.",
       "mathContext": "The bridge theorem combines the geometric series identity for each factor with the Euler product formula. The simp_rw tactic rewrites each ∑_k ... to (1 - ...)⁻¹, then euler_product_formula closes the goal."
     }

--- a/src/data/proofs/godel-incompleteness/meta.json
+++ b/src/data/proofs/godel-incompleteness/meta.json
@@ -143,7 +143,7 @@
       "id": "second-incompleteness-and-lob",
       "title": "Second Incompleteness Theorem and Löb's Theorem",
       "startLine": 212,
-      "endLine": 465,
+      "endLine": 437,
       "summary": "Derivability conditions (axiom), Löb sentence fixed point (axiom), `second_incompleteness_theorem`: Consistent → ¬Provable Con. `lob_theorem`: if ⊢(Prov(⌜φ⌝) → φ), then ⊢ φ. Both use the Hilbert-Bernays-Löb conditions D1-D3.",
       "mathContext": "Second incompleteness: $\\text{Con}(F) \\not\\vdash \\text{Con}(F)$ where $\\text{Con}(F) = \\neg\\text{Prov}(\\ulcorner 0=1 \\urcorner)$. Derivability conditions (Hilbert-Bernays-Löb): (D1) $\\vdash \\varphi \\Rightarrow \\vdash \\text{Prov}(\\ulcorner\\varphi\\urcorner)$, (D2) $\\vdash \\text{Prov}(\\ulcorner\\varphi \\to \\psi\\urcorner) \\to (\\text{Prov}(\\ulcorner\\varphi\\urcorner) \\to \\text{Prov}(\\ulcorner\\psi\\urcorner))$, (D3) $\\vdash \\text{Prov}(\\ulcorner\\varphi\\urcorner) \\to \\text{Prov}(\\ulcorner\\text{Prov}(\\ulcorner\\varphi\\urcorner)\\urcorner)$. Löb: $\\vdash (\\text{Prov}(\\ulcorner\\varphi\\urcorner) \\to \\varphi) \\Rightarrow \\vdash \\varphi$."
     }

--- a/src/data/proofs/herons-formula/meta.json
+++ b/src/data/proofs/herons-formula/meta.json
@@ -116,7 +116,7 @@
       "id": "applications",
       "title": "Triangle Area API and Applications",
       "startLine": 244,
-      "endLine": 275,
+      "endLine": 268,
       "summary": "Defines `triangle_area(a,b,c) = \\sqrt{s(s-a)(s-b)(s-c)}` and proves non-negativity via `sqrt_nonneg`. Concludes with `#check` statements exporting the main results.",
       "mathContext": "`triangle_area(a,b,c) = Real.sqrt(heron_product(a,b,c))`. Non-negativity of area follows from `Real.sqrt_nonneg` — Lean's `sqrt` is defined to return 0 for negative inputs, so `0 ≤ sqrt x` is unconditional. The `#check` statements export: `heron_main : ∀ p₁ p₂ p₃, p₁ ≠ p₂ → p₃ ≠ p₂ → ...`; `heron_product_nonneg : ∀ a b c, 0 < a → 0 < b → 0 < c → a < b + c → ... → 0 ≤ heron_product a b c`; `triangle_area_nonneg`. These form a complete API for computing and reasoning about triangle areas."
     }

--- a/src/data/proofs/hilbert-17/meta.json
+++ b/src/data/proofs/hilbert-17/meta.json
@@ -155,7 +155,7 @@
       "id": "summary",
       "title": "Part IX: Summary",
       "startLine": 543,
-      "endLine": 570,
+      "endLine": 561,
       "summary": "Uses #check to verify main theorems and provides a final prose overview of the complete picture: PSD → rational-SOS (Artin), but PSD ↛ polynomial-SOS (Motzkin), with Pfister's 2^n bound.",
       "mathContext": "**Complete picture**: $\\text{PSD} \\xrightarrow{\\text{Artin}} \\text{rational-SOS}$ (with $\\leq 2^n$ squares by Pfister), but $\\text{PSD} \\not\\Rightarrow \\text{polynomial-SOS}$ (Motzkin). Equality holds for univariate, quadratic, and bivariate quartic polynomials (Hilbert 1888)."
     }

--- a/src/data/proofs/hurwitz-theorem-oq-03-oq-01/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-03-oq-01/meta.json
@@ -109,7 +109,7 @@
       "id": "general-case",
       "title": "General Division Ring Case (1 sorry)",
       "startLine": 81,
-      "endLine": 115,
+      "endLine": 113,
       "summary": "hurwitz_only_if_ring: the non-commutative case with a documented sorry and full proof sketch. Two resolution paths: (1) NSquareIdentity reduction via orthonormal basis transport, (2) direct Clifford algebra + Radon-Hurwitz argument.",
       "mathContext": "The sorry covers NormedDivisionRing A, NormedAlgebra ℝ A, Module.Finite ℝ A. By Frobenius, the associative case only admits dims 1, 2, 4 — the '8' entry is vacuous for NormedDivisionRing."
     }

--- a/src/data/proofs/isoperimetric-theorem/meta.json
+++ b/src/data/proofs/isoperimetric-theorem/meta.json
@@ -170,7 +170,7 @@
       "id": "applications",
       "title": "Applications and Connections",
       "startLine": 404,
-      "endLine": 449,
+      "endLine": 447,
       "summary": "Discusses applications in physics (soap bubbles), biology (cell shapes), engineering (optimal tanks), and connections to Sobolev inequalities, concentration of measure, geometric measure theory, and optimal transport.",
       "mathContext": "Discusses applications in physics (soap bubbles), biology (cell shapes), engineering (optimal tanks), and connections to Sobolev inequalities, concentration of measure, geometric measure theory, and optimal transport."
     }

--- a/src/data/proofs/kroneckers-jugendtraum/meta.json
+++ b/src/data/proofs/kroneckers-jugendtraum/meta.json
@@ -140,7 +140,7 @@
       "id": "summary",
       "title": "Summary",
       "startLine": 352,
-      "endLine": 392,
+      "endLine": 387,
       "summary": "hilbert12_summary theorem. Recaps solved cases (ℚ, imaginary quadratic) vs open cases (real quadratic, general). Lists #check statements for key definitions.",
       "mathContext": "The file's genuine Lean content comprises three machine-checked results: (1) `cyclotomic_galois_comm` proving $\\mathrm{Gal}(\\mathbb{Q}(\\zeta_n)/\\mathbb{Q})$ is abelian via the `autEquivPow` isomorphism to $(\\mathbb{Z}/n\\mathbb{Z})^\\times$, (2) `cyclotomic_degree` proving $[\\mathbb{Q}(\\zeta_n):\\mathbb{Q}] = \\varphi(n)$ via `IsCyclotomicExtension.finrank`, and (3) `cyclotomic_irreducible` proving $\\Phi_n$ is irreducible over $\\mathbb{Z}$. All other results -- Kronecker-Weber, CM theory, Artin reciprocity, Stark conjectures, and the general Hilbert 12th problem -- are formulated as `Prop := True` placeholders whose deep proofs lie beyond current Mathlib infrastructure."
     }

--- a/src/data/proofs/lhopital-oq-01/meta.json
+++ b/src/data/proofs/lhopital-oq-01/meta.json
@@ -104,7 +104,7 @@
       "title": "The Ratio of Derivatives Has No Limit",
       "summary": "Proves 1 + cos(x) → (no limit) via two subsequences: at 2πn the value is 2; at π + 2πn the value is 0. tendsto_nhds_unique gives L = 2 and L = 0, contradiction.",
       "startLine": 93,
-      "endLine": 160,
+      "endLine": 142,
       "mathContext": "$1 + \\cos(2\\pi n) = 2$ and $1 + \\cos(\\pi + 2\\pi n) = 0$. By uniqueness of limits, no $L$ satisfies $1 + \\cos(x) \\to L$."
     },
     {

--- a/src/data/proofs/ptolemys-theorem/meta.json
+++ b/src/data/proofs/ptolemys-theorem/meta.json
@@ -124,7 +124,7 @@
       "id": "history",
       "title": "Historical Context: The Almagest",
       "startLine": 233,
-      "endLine": 267,
+      "endLine": 240,
       "summary": "Historical discussion of chord tables ($\\text{chord}(\\theta) = d\\sin(\\theta/2)$), the equivalence to the sine addition formula $\\sin(\\alpha+\\beta) = \\sin\\alpha\\cos\\beta + \\cos\\alpha\\sin\\beta$, Ptolemy's legacy in astronomy (al-Khwarizmi, al-Biruni), and `#check` verification of all three exported theorems.",
       "mathContext": "Historical discussion of chord tables ($\\text{chord}(\\theta) = d\\sin(\\theta/2)$), the equivalence to the sine addition formula $\\sin(\\alpha+\\beta) = \\sin\\alpha\\cos\\beta + \\cos\\alpha\\sin\\beta$, Ptolemy's legacy in astronomy (al-Khwarizmi, al-Biruni), and `#check` verification of all three exported theorems."
     }

--- a/src/data/proofs/roth-theorem-k3-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-01/meta.json
@@ -114,7 +114,7 @@
       "id": "quantitative-bounds",
       "title": "Part III: Four Quantitative Bound Statements (All Sorried)",
       "startLine": 188,
-      "endLine": 242,
+      "endLine": 234,
       "summary": "States four landmark bounds: roth_quantitative_upper_bound (1953, O(N/log log N)), behrend_lower_bound (1946, Ω(N·exp(-c√log N))), bloom_sisask_bound (2020, O(N/(log N)^{1+c})), kelley_meka_upper_bound (2023, O(N·exp(-c(log N)^{1/12}))). All 4 carry sorries.",
       "mathContext": "Historical progression: Roth $N/\\log\\log N$ → Bourgain $N/(\\log N)^{1-\\varepsilon}$ → Sanders $N\\log\\log N/\\log N$ → Bloom-Sisask $N/(\\log N)^{1+c}$ → Kelley-Meka $N\\exp(-(\\log N)^{1/12})$. Lower bound: Behrend $N\\exp(-c\\sqrt{\\log N})$ (1946). Gap: exponent $1/12$ vs $1/2$ is open."
     }

--- a/src/data/proofs/roth-theorem-k3-oq-03/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-03/meta.json
@@ -87,7 +87,7 @@
       "id": "comparison",
       "title": "Part IX: k=3 vs k≥4 Comparison",
       "startLine": 272,
-      "endLine": 280,
+      "endLine": 277,
       "summary": "Markdown comparison table: k=3 uses U²=Fourier L⁴ with explicit δ²/100 increment; k≥4 uses U^{k-1} with tower-type c(δ,k). Documents proof length (~1400 lines for k=3 proved; ~5000+ estimated for k≥4)."
     }
   ],


### PR DESCRIPTION
## Fix

44 `meta.json` section ranges had `endLine` set past the end of the Lean source file. Sections are used for gallery navigation/highlighting; out-of-bounds values cause rendering issues.

## Evidence

**Before**: `"endLine": 146` (file is 141 lines)  
**After**: `"endLine": 141`

**Scope**: 44 files, 44 single-line changes. Only sections where `startLine ≤ actual_lines AND endLine > actual_lines + 1`.

12 fully out-of-bounds sections (startLine > file length) are reported separately in #11817 — those require enricher re-annotation.

---
Automated fix by lean-mechanic agent.