### PR TITLE
Fix: sync stale leanFile.lineCount in 5 gallery meta.json files

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -16,7 +16,7 @@
     "badge": "wip",
     "sorries": 2,
     "axiomCount": 0,
-    "lineCount": 980,
+    "lineCount": 1125,
     "assumptions": "2 remaining sorries, both dead-path (not used in main proof chain): (1) truncated_rn_deriv_lq_bound (line 191) — incorrect approach, bypassed; (2) rn_deriv_memLq (line 207) — depends on (1), also bypassed. The main theorem riesz_lp_surjective_from_rn is proved via rn_deriv_memLq_from_trunc + holder_extremizer_lq_bound (all sorry-free). holder_extremizer_lq_bound proved in session 5 (2026-04-22).",
     "dateAdded": "2026-04-13"
   },
@@ -106,7 +106,7 @@
     "imports": [
       "Mathlib"
     ],
-    "lineCount": 980,
+    "lineCount": 1125,
     "axiomCount": 0,
     "theoremCount": 15,
     "definitionCount": 2,

--- a/src/data/proofs/erdos-321/meta.json
+++ b/src/data/proofs/erdos-321/meta.json
@@ -169,7 +169,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 155,
+    "lineCount": 174,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 3,

--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 8,
     "axiomCount": 5,
-    "lineCount": 419,
+    "lineCount": 563,
     "assumptions": "8 sorries: hausdorff_free_subgroup (free subgroup of SO(3)), banach_tarski (main theorem), banach_tarski_pieces_nonmeasurable (non-measurability of pieces), int_amenable (ℤ amenability), W_a_two_cover (W(a) two-cover), W_a_smul_disj (W(a) smul disjointness), W_b_two_cover (W(b) two-cover), W_b_smul_disj (W(b) smul disjointness). The main proof requires ~800 lines via free subgroup of SO(3) — beyond this gallery entry's scope. Note: paradoxical_no_finite_measure and free_group_not_amenable structure are fully proved.",
     "dateAdded": "2026-04-22",
     "mathlib_version": "4.26.0",
@@ -201,7 +201,7 @@
       "Mathlib"
     ],
     "namespace": "BanachTarski",
-    "lineCount": 419,
+    "lineCount": 563,
     "axiomCount": 5,
     "theoremCount": 7,
     "definitionCount": 5,

--- a/src/data/proofs/sqrt2-minpoly-oq-02/meta.json
+++ b/src/data/proofs/sqrt2-minpoly-oq-02/meta.json
@@ -19,7 +19,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 202,
+    "lineCount": 204,
     "dateAdded": "2026-04-06",
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlibDependencies": [
@@ -198,7 +198,7 @@
       "IntermediateField"
     ],
     "namespace": "CubeRoot2IrrationalOQ03",
-    "lineCount": 202,
+    "lineCount": 204,
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 0,

--- a/src/data/proofs/triangle-angle-sum-oq-02/meta.json
+++ b/src/data/proofs/triangle-angle-sum-oq-02/meta.json
@@ -22,7 +22,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 3,
-    "lineCount": 320,
+    "lineCount": 382,
     "assumptions": "gb_local (local Gauss-Bonnet: angle excess = integrated curvature, for each geodesic triangle), spherical/flat/hyperbolic curvature formulas (K=1/r², K=0, K=-1 respectively), discrete_gb (discrete Gauss-Bonnet for triangulations: total excess = 2π·χ). All are classical theorems of differential geometry requiring Riemannian geometry infrastructure not yet in Mathlib.",
     "mathlib_version": "4.26.0"
   },
@@ -121,7 +121,7 @@
       "Real"
     ],
     "namespace": "TriangleAngleSumGaussBonnet",
-    "lineCount": 320,
+    "lineCount": 382,
     "axiomCount": 3,
     "sorries": 0,
     "path": "Proofs/TriangleAngleSumOQ02.lean",


### PR DESCRIPTION
## Fix

Sync `leanFile.lineCount` (and `meta.lineCount`) in 5 gallery entries where the metadata became stale after the Lean source files were updated.

## Evidence

| Proof | meta lineCount | actual lineCount | delta |
|-------|---------------|-----------------|-------|
| cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01 | 980 | 1125 | +145 |
| lebesgue-measure-oq-06 | 419 | 563 | +144 |
| triangle-angle-sum-oq-02 | 320 | 382 | +62 |
| erdos-321 (leanFile only) | 155 | 174 | +19 |
| sqrt2-minpoly-oq-02 | 202 | 204 | +2 |

**After**: All 5 entries now report correct line counts matching the Lean source.

---
Automated fix by lean-mechanic agent.