### PR TITLE
Fix: sync shapley-folkman leanFile.lineCount 813→867

### DIFF
--- a/src/data/proofs/shapley-folkman/meta.json
+++ b/src/data/proofs/shapley-folkman/meta.json
@@ -61,7 +61,7 @@
       "Caratheodory's theorem (points in convex hull need at most d+1 vertices)",
       "Affine independence and dimension"
     ],
-    "lineCount": 813,
+    "lineCount": 867,
     "mathlib_version": "4.26.0",
     "relatedProblems": []
   },
@@ -204,7 +204,7 @@
       "Pointwise"
     ],
     "namespace": "ShapleyFolkman",
-    "lineCount": 813,
+    "lineCount": 867,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 1,


### PR DESCRIPTION
## Fix

Syncs the stale `leanFile.lineCount` (and `meta.lineCount`) in `shapley-folkman/meta.json`.

## Evidence

**Before**: `lineCount: 813` (stale)
**After**: `lineCount: 867` (matches `wc -l proofs/Proofs/ShapleyFolkman.lean`)

The Lean file grew from 813 to 867 lines due to additional proof content added in recent research sessions. Both the `meta.lineCount` and `leanFile.lineCount` fields were updated.

---
Automated fix by lean-mechanic agent.