### PR TITLE
Fix: correct axiomCount, sorries, status for 7 erdos-12xx + shapley-folkman

### DIFF
--- a/src/data/proofs/erdos-1206/meta.json
+++ b/src/data/proofs/erdos-1206/meta.json
@@ -7,14 +7,14 @@
     "author": "Unknown",
     "sourceUrl": "https://erdosproblems.com/1206",
     "date": "",
-    "status": "pending",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1206Problem.lean",
     "tags": [
       "erdos"
     ],
-    "lineCount": 23,
-    "badge": "wip",
-    "sorries": 1,
+    "lineCount": 103,
+    "badge": "axiom",
+    "sorries": 0,
     "erdosNumber": 1206,
     "erdosUrl": "https://erdosproblems.com/1206",
     "erdosProblemStatus": "solved"
@@ -99,18 +99,18 @@
       "description": "The Fundamental Theorem of Arithmetic (unique prime factorization) underpins the Sidon proof via the algebraic identity n³ - m³ = (n-m)(n² + nm + m²). The Sidon condition requires all pairwise sum differences to be distinct; the factorization shows that in a short interval [N - cN^(1/2), N], the quadratic factor n²+nm+m² is nearly constant (~3N²), making distinct pairs (n,m) give distinct differences. This is a multiplicative structure argument at heart — the same principles used in factoring in FTA."
     }
   ],
-  "sorries": 1,
+  "sorries": 0,
   "leanFile": {
     "imports": [
       "Mathlib"
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 23,
-    "axiomCount": 0,
+    "lineCount": 103,
+    "axiomCount": 2,
     "theoremCount": 1,
     "definitionCount": 0,
-    "sorries": 1,
+    "sorries": 0,
     "path": "Proofs/Erdos1206Problem.lean"
   }
 }

--- a/src/data/proofs/erdos-1211/meta.json
+++ b/src/data/proofs/erdos-1211/meta.json
@@ -7,7 +7,7 @@
     "author": "Unknown",
     "sourceUrl": "https://erdosproblems.com/1211",
     "date": "",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1211Problem.lean",
     "tags": [
       "erdos",
@@ -16,9 +16,9 @@
       "density",
       "subset-sums"
     ],
-    "lineCount": 23,
-    "badge": "wip",
-    "sorries": 1,
+    "lineCount": 54,
+    "badge": "axiom",
+    "sorries": 0,
     "erdosNumber": 1211,
     "erdosUrl": "https://erdosproblems.com/1211",
     "erdosProblemStatus": "solved",
@@ -109,18 +109,18 @@
       "description": "Sibling in sum-set theory: #530 (maximum Sidon subset of a finite set) and #1211 (logarithmic density of partition sum sets) are both extremal problems about structured subsets, sharing the combinatorial density framework."
     }
   ],
-  "sorries": 1,
+  "sorries": 0,
   "leanFile": {
     "imports": [
       "Mathlib"
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 23,
-    "axiomCount": 0,
+    "lineCount": 54,
+    "axiomCount": 2,
     "theoremCount": 1,
     "definitionCount": 0,
-    "sorries": 1,
+    "sorries": 0,
     "path": "Proofs/Erdos1211Problem.lean"
   }
 }

--- a/src/data/proofs/erdos-1212/meta.json
+++ b/src/data/proofs/erdos-1212/meta.json
@@ -7,7 +7,7 @@
     "author": "Unknown",
     "sourceUrl": "https://erdosproblems.com/1212",
     "date": "",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1212Problem.lean",
     "tags": [
       "erdos",
@@ -17,9 +17,9 @@
       "prime-numbers",
       "lattice-graphs"
     ],
-    "lineCount": 23,
-    "badge": "wip",
-    "sorries": 1,
+    "lineCount": 61,
+    "badge": "axiom",
+    "sorries": 0,
     "erdosNumber": 1212,
     "erdosUrl": "https://erdosproblems.com/1212",
     "erdosProblemStatus": "solved",
@@ -128,18 +128,18 @@
       "description": "Erdős #1213 is the neighboring problem: both #1212 and #1213 are Erdős combinatorial problems marked as solved, both involve sequences with arithmetic constraints (coprimality/bounded gaps), and both have Lean stubs awaiting formalization. They share the same file structure and enrichment context."
     }
   ],
-  "sorries": 1,
+  "sorries": 0,
   "leanFile": {
     "imports": [
       "Mathlib"
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 23,
-    "axiomCount": 0,
+    "lineCount": 61,
+    "axiomCount": 1,
     "theoremCount": 1,
     "definitionCount": 0,
-    "sorries": 1,
+    "sorries": 0,
     "path": "Proofs/Erdos1212Problem.lean"
   }
 }

--- a/src/data/proofs/erdos-1213/meta.json
+++ b/src/data/proofs/erdos-1213/meta.json
@@ -7,7 +7,7 @@
     "author": "Unknown",
     "sourceUrl": "https://erdosproblems.com/1213",
     "date": "",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1213Problem.lean",
     "tags": [
       "erdos",
@@ -16,9 +16,9 @@
       "sequences",
       "pigeonhole"
     ],
-    "lineCount": 23,
-    "badge": "wip",
-    "sorries": 1,
+    "lineCount": 74,
+    "badge": "axiom",
+    "sorries": 0,
     "erdosNumber": 1213,
     "erdosUrl": "https://erdosproblems.com/1213",
     "erdosProblemStatus": "solved",
@@ -109,18 +109,18 @@
       "description": "Erdős #1211 studies logarithmic density of sumsets in a partition ℕ = A ∪ B; like #1213, it concerns how arithmetic constraints on a sequence force global additive structure (equal sums). Both probe the boundary between 'sparse' and 'structured' sequences."
     }
   ],
-  "sorries": 1,
+  "sorries": 0,
   "leanFile": {
     "imports": [
       "Mathlib"
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 23,
-    "axiomCount": 0,
+    "lineCount": 74,
+    "axiomCount": 2,
     "theoremCount": 1,
     "definitionCount": 0,
-    "sorries": 1,
+    "sorries": 0,
     "path": "Proofs/Erdos1213Problem.lean"
   }
 }

--- a/src/data/proofs/erdos-1215/meta.json
+++ b/src/data/proofs/erdos-1215/meta.json
@@ -7,7 +7,7 @@
     "author": "Unknown",
     "sourceUrl": "https://erdosproblems.com/1215",
     "date": "",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1215Problem.lean",
     "tags": [
       "erdos",
@@ -16,9 +16,9 @@
       "topology",
       "unit-circle"
     ],
-    "lineCount": 23,
-    "badge": "wip",
-    "sorries": 1,
+    "lineCount": 71,
+    "badge": "axiom",
+    "sorries": 0,
     "erdosNumber": 1215,
     "erdosUrl": "https://erdosproblems.com/1215",
     "erdosProblemStatus": "solved",
@@ -99,18 +99,18 @@
       "description": "Both represent formalization stubs pending major Mathlib infrastructure: Easton's class forcing and Mac Lane's polynomial lemniscate theory share the challenge of encoding analytic/metamathematical content in Lean 4."
     }
   ],
-  "sorries": 1,
+  "sorries": 0,
   "leanFile": {
     "imports": [
       "Mathlib"
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 23,
-    "axiomCount": 0,
+    "lineCount": 71,
+    "axiomCount": 2,
     "theoremCount": 1,
     "definitionCount": 0,
-    "sorries": 1,
+    "sorries": 0,
     "path": "Proofs/Erdos1215Problem.lean"
   }
 }

--- a/src/data/proofs/erdos-1216/meta.json
+++ b/src/data/proofs/erdos-1216/meta.json
@@ -7,7 +7,7 @@
     "author": "Unknown",
     "sourceUrl": "https://erdosproblems.com/1216",
     "date": "",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1216Problem.lean",
     "tags": [
       "erdos",
@@ -16,9 +16,9 @@
       "tournament-theory",
       "combinatorics"
     ],
-    "lineCount": 23,
-    "badge": "wip",
-    "sorries": 1,
+    "lineCount": 67,
+    "badge": "axiom",
+    "sorries": 0,
     "erdosNumber": 1216,
     "erdosUrl": "https://erdosproblems.com/1216",
     "erdosProblemStatus": "solved",
@@ -99,18 +99,18 @@
       "Is there a tournament-theoretic version of the probabilistic method that gives a sharp upper bound on $f(n)$, improving on the Erdős-Moser $2\\log_2 n$ bound?"
     ]
   },
-  "sorries": 1,
+  "sorries": 0,
   "leanFile": {
     "imports": [
       "Mathlib"
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 23,
-    "axiomCount": 0,
+    "lineCount": 67,
+    "axiomCount": 2,
     "theoremCount": 1,
     "definitionCount": 0,
-    "sorries": 1,
+    "sorries": 0,
     "path": "Proofs/Erdos1216Problem.lean"
   }
 }

--- a/src/data/proofs/erdos-1217/meta.json
+++ b/src/data/proofs/erdos-1217/meta.json
@@ -7,7 +7,7 @@
     "author": "Unknown",
     "sourceUrl": "https://erdosproblems.com/1217",
     "date": "",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1217Problem.lean",
     "tags": [
       "erdos",
@@ -16,9 +16,9 @@
       "density-theory",
       "sequences"
     ],
-    "lineCount": 23,
-    "badge": "wip",
-    "sorries": 1,
+    "lineCount": 57,
+    "badge": "axiom",
+    "sorries": 0,
     "erdosNumber": 1217,
     "erdosUrl": "https://erdosproblems.com/1217",
     "erdosProblemStatus": "solved",
@@ -104,18 +104,18 @@
       "description": "Bounded prime gaps (Zhang/Maynard-Tao) concerns the local density of primes. Problem #1217 uses global log-log density, the same scale at which primes are 'just barely' dense ($\\sum_{p \\leq x} 1/p \\sim \\log\\log x$). Both results probe the edge of prime distribution, and both would require Mertens' theorem as a foundational Lean lemma."
     }
   ],
-  "sorries": 1,
+  "sorries": 0,
   "leanFile": {
     "imports": [
       "Mathlib"
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 23,
-    "axiomCount": 0,
+    "lineCount": 57,
+    "axiomCount": 1,
     "theoremCount": 1,
     "definitionCount": 0,
-    "sorries": 1,
+    "sorries": 0,
     "path": "Proofs/Erdos1217Problem.lean"
   }
 }

--- a/src/data/proofs/shapley-folkman/meta.json
+++ b/src/data/proofs/shapley-folkman/meta.json
@@ -187,7 +187,7 @@
       "leanType": "Decomposition S t x -> d.excessIndices.card <= Module.finrank R E"
     }
   ],
-  "sorries": 1,
+  "sorries": 4,
   "leanFile": {
     "imports": [
       "Mathlib.Analysis.Convex.Caratheodory",
@@ -208,7 +208,7 @@
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 1,
-    "sorries": 1,
+    "sorries": 4,
     "path": "Proofs/ShapleyFolkman.lean"
   }
 }


### PR DESCRIPTION
## Fix

8 gallery entries had stale metadata from initial stub generation.

## Evidence

### 7 erdos-12xx files (1206, 1211, 1212, 1213, 1215, 1216, 1217)

**Root cause**: Lean files were enriched with axiom declarations (replacing the original `sorry`), but `meta.json` was never updated.

| Field | Before | After |
|-------|--------|-------|
| `sorries` | 1 | 0 |
| `axiomCount` | 0 | 1–2 (per file) |
| `lineCount` | 23 | 54–103 |
| `badge` | `wip` | `axiom` |
| `status` | `formalized`/`pending` | `axiomatized` |

### shapley-folkman

**Root cause**: 4 non-comment `sorry` statements present in `ShapleyFolkman.lean` but meta reported 1.

| Field | Before | After |
|-------|--------|-------|
| `sorries` (top-level) | 1 | 4 |
| `leanFile.sorries` | 1 | 4 |

---
Automated fix by lean-mechanic agent.