### PR TITLE
Enrich triangle-angle-sum-oq-02: Gauss-Bonnet generalization

### DIFF
--- a/src/data/proofs/triangle-angle-sum-oq-02/annotations.json
+++ b/src/data/proofs/triangle-angle-sum-oq-02/annotations.json
@@ -1,44 +1,122 @@
-{
-  "annotations": [
-    {
-      "id": "local-gauss-bonnet",
-      "line": 75,
-      "type": "key-theorem",
-      "label": "Local Gauss-Bonnet (Axiom)",
-      "content": "The core axiom: angle excess = integrated Gaussian curvature. This is the local version of the Gauss-Bonnet theorem, valid for any geodesic triangle on a Riemannian surface.",
-      "mathContent": "α + β + γ - π = ∫_T K dA"
-    },
-    {
-      "id": "girard-theorem",
-      "line": 155,
-      "type": "key-theorem",
-      "label": "Girard's Theorem (1629)",
-      "content": "The spherical excess formula: the area of a geodesic triangle on a sphere of radius r equals r² times the angular excess. Proved as the K=1/r² case of local Gauss-Bonnet.",
-      "mathContent": "α + β + γ - π = Area(T) / r²"
-    },
-    {
-      "id": "lambert-theorem",
-      "line": 220,
-      "type": "key-theorem",
-      "label": "Lambert's Theorem (1761)",
-      "content": "The angular defect of a hyperbolic triangle equals its area. Proved as the K=-1 case of local Gauss-Bonnet. This implies all hyperbolic triangles have angle sum < π.",
-      "mathContent": "π - (α + β + γ) = Area(T)"
-    },
-    {
-      "id": "discrete-gb",
-      "line": 278,
-      "type": "key-theorem",
-      "label": "Discrete Gauss-Bonnet",
-      "content": "For a triangulation of a compact surface, the total angular excess equals 2π times the Euler characteristic. This is the discrete version of the global Gauss-Bonnet theorem.",
-      "mathContent": "∑_i (α_i + β_i + γ_i - π) = 2π · χ(M)"
-    },
-    {
-      "id": "three-geometries",
-      "line": 320,
-      "type": "insight",
-      "label": "The Three Geometries Unified",
-      "content": "The Gauss-Bonnet framework unifies all three classical geometries in a single theorem. The triangle angle sum theorem is recovered as the K=0 special case.",
-      "mathContent": "K=0: sum=π | K>0: sum>π | K<0: sum<π"
-    }
-  ]
-}
+[
+  {
+    "id": "ann-oq02-module-overview",
+    "proofId": "triangle-angle-sum-oq-02",
+    "range": { "startLine": 1, "endLine": 56 },
+    "type": "context",
+    "title": "Module Overview: The Gauss-Bonnet Generalization",
+    "content": "This file answers OQ-02: how does the triangle angle sum theorem ($\\alpha+\\beta+\\gamma=\\pi$) generalize to curved surfaces? The answer is the **local Gauss-Bonnet theorem**: the angle excess of a geodesic triangle equals the integral of Gaussian curvature $K$ over the triangle's interior. The flat case ($K=0$) recovers Euclid's theorem; positive curvature ($K>0$) gives Girard's spherical excess formula; negative curvature ($K<0$) gives Lambert's hyperbolic defect. The global Gauss-Bonnet theorem then connects the total curvature $\\int_M K\\,dA = 2\\pi\\chi(M)$ to the Euler characteristic, unifying geometry and topology. Since Mathlib 4.26 lacks Riemannian metrics and integration on manifolds, the file axiomatizes the local Gauss-Bonnet formula as a structure field and derives all consequences from it.",
+    "mathContext": "Local Gauss-Bonnet: $(\\alpha+\\beta+\\gamma) - \\pi = \\int_T K\\,dA$; global: $\\int_M K\\,dA = 2\\pi\\chi(M)$",
+    "significance": "context",
+    "relatedConcepts": ["Gaussian curvature", "Gauss-Bonnet theorem", "Euler characteristic", "geodesic triangle", "Riemannian manifold"],
+    "prerequisites": ["triangle angle sum theorem", "differential geometry basics", "Euler characteristic"]
+  },
+  {
+    "id": "ann-geodesic-triangle-structure",
+    "proofId": "triangle-angle-sum-oq-02",
+    "range": { "startLine": 74, "endLine": 118 },
+    "type": "definition",
+    "title": "GeodesicTriangle: Axiomatizing Local Gauss-Bonnet",
+    "content": "The `GeodesicTriangle` structure is the heart of the formalization. It records the three angles $\\alpha,\\beta,\\gamma \\in (0,\\pi)$, the area, and the `integratedCurvature` $= \\int_T K\\,dA$. The critical axiom `gb_local : α + β + γ - π = integratedCurvature` is the local Gauss-Bonnet formula — stated as a structure field rather than as an `axiom` keyword. The `excess` and `angleSum` definitions are derived, and `excess_eq_curvature`, `angleSum_eq_pi_add_excess`, and `angleSum_eq_pi_add_curvature` follow by trivial algebra. This design separates the mathematical content (the axiom) from the algebraic bookkeeping (the derived theorems), making later proofs clean one-liners.",
+    "mathContext": "Structure: $(\\alpha, \\beta, \\gamma, \\text{area}, \\text{IC}) \\in (0,\\pi)^3 \\times \\mathbb{R}_{>0} \\times \\mathbb{R}$ with $\\alpha+\\beta+\\gamma-\\pi = \\text{IC}$; excess $:= \\alpha+\\beta+\\gamma-\\pi$",
+    "significance": "key",
+    "relatedConcepts": ["structure fields as axioms", "angular excess", "integrated Gaussian curvature", "local Gauss-Bonnet formula"],
+    "prerequisites": ["Lean 4 structures", "Riemannian geometry", "Gaussian curvature integration"]
+  },
+  {
+    "id": "ann-flat-triangle-euclid",
+    "proofId": "triangle-angle-sum-oq-02",
+    "range": { "startLine": 128, "endLine": 149 },
+    "type": "technique",
+    "title": "FlatTriangle: Recovering Euclid as the K=0 Special Case",
+    "content": "`FlatTriangle` extends `GeodesicTriangle` by adding the constraint `flat : integratedCurvature = 0`. From `gb_local` and `flat`, the proof of `flat_angle_sum` is a one-line `linarith`: $\\alpha+\\beta+\\gamma - \\pi = 0 \\Rightarrow \\alpha+\\beta+\\gamma = \\pi$. This is the Lean formalization of the fact that Euclid's triangle angle sum theorem is exactly the Gauss-Bonnet formula specialized to $K=0$. The `FlatTriangle extends GeodesicTriangle` pattern (structure inheritance) is efficient: it reuses all fields and axioms, adding only the flatness condition.",
+    "mathContext": "$K = 0 \\Rightarrow \\int_T K\\,dA = 0 \\Rightarrow \\alpha+\\beta+\\gamma - \\pi = 0 \\Rightarrow \\alpha+\\beta+\\gamma = \\pi$ (Euclid, ~300 BCE)",
+    "significance": "key",
+    "relatedConcepts": ["Euclidean geometry", "K=0 flat plane", "structure inheritance in Lean 4", "linarith tactic"],
+    "prerequisites": ["GeodesicTriangle structure", "Lean 4 structure extension", "linarith"]
+  },
+  {
+    "id": "ann-girard-theorem-1629",
+    "proofId": "triangle-angle-sum-oq-02",
+    "range": { "startLine": 163, "endLine": 207 },
+    "type": "key-theorem",
+    "title": "Girard's Theorem (1629): Spherical Excess Formula",
+    "content": "`SphericalTriangle` adds a radius $r > 0$ and the spherical curvature constraint `spherical : integratedCurvature = area / radius^2` (since $K = 1/r^2$ on a sphere of radius $r$, so $\\int_T K\\,dA = \\text{Area}(T)/r^2$). `girard_theorem` then follows in one line by rewriting via `spherical` and applying `gb_local`. The corollaries `spherical_area_eq_radius_sq_excess` and `spherical_angle_sum_gt_pi` use `div_pos` and `sq_pos_of_pos` to establish strict inequalities. On the unit sphere ($r=1$), the formula simplifies to area $= \\alpha+\\beta+\\gamma-\\pi$, which is what Girard actually stated in 1629 — predating both calculus and Gaussian curvature by nearly two centuries.",
+    "mathContext": "$K = 1/r^2$ on sphere of radius $r$: $\\alpha+\\beta+\\gamma - \\pi = \\text{Area}(T)/r^2 > 0$; unit sphere: $\\text{Area}(T) = \\alpha+\\beta+\\gamma - \\pi$",
+    "significance": "key",
+    "relatedConcepts": ["spherical geometry", "Girard's theorem", "spherical excess", "positive Gaussian curvature", "unit sphere"],
+    "prerequisites": ["GeodesicTriangle", "Gaussian curvature on sphere", "field_simp tactic", "div_pos"]
+  },
+  {
+    "id": "ann-lambert-theorem-1761",
+    "proofId": "triangle-angle-sum-oq-02",
+    "range": { "startLine": 220, "endLine": 250 },
+    "type": "key-theorem",
+    "title": "Lambert's Theorem (1761): Hyperbolic Angular Defect",
+    "content": "`HyperbolicTriangle` adds `hyperbolic : integratedCurvature = -area` (since $K = -1$ in the standard hyperbolic plane, so $\\int_T K\\,dA = -\\text{Area}(T)$). `lambert_theorem` proves $\\pi - (\\alpha+\\beta+\\gamma) = \\text{area}$: the angular defect equals the area. This has two striking corollaries: (1) `hyperbolic_angle_sum_lt_pi`: all hyperbolic triangles satisfy $\\alpha+\\beta+\\gamma < \\pi$; (2) `hyperbolic_area_lt_pi`: hyperbolic triangle area is always $< \\pi$, so there is a maximum possible area for any hyperbolic triangle (unlike Euclidean or spherical geometry). Lambert deduced these properties in 1761 from the assumption that angle sum $< \\pi$, without constructing a model — he had discovered hyperbolic geometry without realizing it.",
+    "mathContext": "$K = -1$: $\\alpha+\\beta+\\gamma - \\pi = -\\text{Area}(T) < 0$; angular defect $\\delta = \\pi - (\\alpha+\\beta+\\gamma) = \\text{Area}(T) \\in (0, \\pi)$",
+    "significance": "key",
+    "relatedConcepts": ["hyperbolic geometry", "angular defect", "Lambert's theorem", "negative Gaussian curvature", "hyperbolic plane models"],
+    "prerequisites": ["GeodesicTriangle", "hyperbolic plane", "negative curvature geometry", "linarith"]
+  },
+  {
+    "id": "ann-riemannian-triangulation",
+    "proofId": "triangle-angle-sum-oq-02",
+    "range": { "startLine": 263, "endLine": 297 },
+    "type": "definition",
+    "title": "RiemannianTriangulation and Discrete Gauss-Bonnet",
+    "content": "`RiemannianTriangulation` encodes a triangulation of a compact closed Riemannian surface. Its key axiom `discrete_gb : (∑ i, (triangles i).excess) = 2 * π * eulerChar` is the discrete Gauss-Bonnet theorem: the total angular excess over all triangles equals $2\\pi$ times the Euler characteristic. From this, `sphere_total_curvature` ($\\chi=2 \\Rightarrow$ total excess $= 4\\pi$), `torus_total_curvature` ($\\chi=0 \\Rightarrow$ total excess $= 0$), and `genus_g_total_curvature` ($\\chi = 2-2g \\Rightarrow$ total excess $= 2\\pi(2-2g)$) all follow by `ring`. The discrete Gauss-Bonnet theorem classically follows from the local version by summing over all triangles and noting that interior angle contributions cancel — but encoding this combinatorial argument requires the full machinery of cellular homology.",
+    "mathContext": "Discrete Gauss-Bonnet: $\\sum_{i} (\\alpha_i+\\beta_i+\\gamma_i - \\pi) = 2\\pi\\chi(M)$; for genus $g$: $\\chi = 2-2g$, total excess $= 2\\pi(2-2g)$",
+    "significance": "key",
+    "relatedConcepts": ["Euler characteristic", "triangulation of surface", "discrete Gauss-Bonnet", "genus-g surfaces", "cellular homology"],
+    "prerequisites": ["GeodesicTriangle", "Euler characteristic", "Finset.sum in Lean 4", "orientable surface classification"]
+  },
+  {
+    "id": "ann-curvature-sign-topology",
+    "proofId": "triangle-angle-sum-oq-02",
+    "range": { "startLine": 306, "endLine": 330 },
+    "type": "insight",
+    "title": "Curvature Sign Constrains Surface Topology",
+    "content": "Part VI proves that the sign of the total curvature (total angular excess) determines the sign of $\\chi$. `positive_curvature_positive_chi` and `negative_curvature_negative_chi` use `mul_pos_iff` / `mul_neg_iff` combined with $\\pi > 0$ to extract the sign of $\\chi$ from the sign of $2\\pi\\chi$. `flat_triangulation_chi_zero` uses `mul_eq_zero` and $2\\pi \\neq 0$ to deduce $\\chi = 0$. The topological consequence is profound: a surface admitting a metric with everywhere positive curvature must have $\\chi > 0$ (genus 0, sphere); everywhere zero curvature must have $\\chi = 0$ (genus 1, torus); everywhere negative curvature must have $\\chi < 0$ (genus $\\geq 2$). This is the Gauss-Bonnet obstruction.",
+    "mathContext": "$\\text{total excess} > 0 \\Rightarrow \\chi > 0$ (sphere $S^2$); $= 0 \\Rightarrow \\chi = 0$ (torus $T^2$); $< 0 \\Rightarrow \\chi < 0$ (genus $\\geq 2$)",
+    "significance": "key",
+    "relatedConcepts": ["Gauss-Bonnet obstruction", "uniformization theorem", "surface classification", "mul_pos_iff", "sign of Euler characteristic"],
+    "prerequisites": ["discrete Gauss-Bonnet", "Euler characteristic sign", "uniformization theorem (background)", "mul_pos_iff in Mathlib"]
+  },
+  {
+    "id": "ann-three-geometries-unified",
+    "proofId": "triangle-angle-sum-oq-02",
+    "range": { "startLine": 349, "endLine": 368 },
+    "type": "insight",
+    "title": "Three Geometries Unified: The Capstone Theorem",
+    "content": "`three_geometries_unified` is the cleanest statement of the entire file: it packages the three angle sum results into a single conjunction. `excess_classifies_curvature` shows the angle excess is in bijection with the sign of the integrated curvature — so reading off the curvature sign immediately tells you whether you are in Euclidean, spherical, or hyperbolic geometry. `euclidean_case` combines `flat_excess_zero` and `flat_angleSum_eq_pi` into the tuple $(\\text{excess}=0, \\text{sum}=\\pi)$. These theorems together formalize the conceptual claim: the triangle angle sum theorem is not an isolated fact but the $K=0$ instance of a one-parameter family indexed by Gaussian curvature.",
+    "mathContext": "$K=0 \\Leftrightarrow \\text{excess}=0 \\Leftrightarrow \\alpha+\\beta+\\gamma = \\pi$; $K>0 \\Leftrightarrow \\text{excess}>0 \\Leftrightarrow \\alpha+\\beta+\\gamma > \\pi$; $K<0 \\Leftrightarrow \\text{excess}<0 \\Leftrightarrow \\alpha+\\beta+\\gamma < \\pi$",
+    "significance": "key",
+    "relatedConcepts": ["Euclidean geometry", "spherical geometry", "hyperbolic geometry", "Iff.rfl in Lean 4", "curvature classification"],
+    "prerequisites": ["FlatTriangle", "SphericalTriangle", "HyperbolicTriangle", "GeodesicTriangle.excess"]
+  },
+  {
+    "id": "ann-mathlib-euclidean-example",
+    "proofId": "triangle-angle-sum-oq-02",
+    "range": { "startLine": 370, "endLine": 382 },
+    "type": "technique",
+    "title": "Mathlib Anchor: angle_add_angle_add_angle_eq_pi",
+    "content": "The final `example` grounds the abstract axiom system in Mathlib's concrete Euclidean geometry. Given points $p_1, p_2, p_3$ in a normed inner product space $P$ with $p_2 \\neq p_1$, `EuclideanGeometry.angle_add_angle_add_angle_eq_pi` directly proves $\\angle(p_1 p_2 p_3) + \\angle(p_2 p_3 p_1) + \\angle(p_3 p_1 p_2) = \\pi$. This is the Mathlib statement of Euclid's angle sum theorem, expressed via the `angle` function from `Mathlib.Geometry.Euclidean.Triangle`. The type class stack `[NormedAddCommGroup V] [InnerProductSpace ℝ V] [MetricSpace P] [NormedAddTorsor V P]` shows that the theorem holds in any model of Euclidean geometry, not just $\\mathbb{R}^n$. The entire abstract file's axiom system captures 'why it's true in general'; this one-line Mathlib fact confirms it is machine-checked in the concrete case.",
+    "mathContext": "Mathlib: `EuclideanGeometry.angle_add_angle_add_angle_eq_pi : angle p₁ p₂ p₃ + angle p₂ p₃ p₁ + angle p₃ p₁ p₂ = π` for $p_2 \\neq p_1$",
+    "significance": "supporting",
+    "relatedConcepts": ["EuclideanGeometry.angle", "NormedAddTorsor", "InnerProductSpace", "angle_add_angle_add_angle_eq_pi", "Mathlib geometry"],
+    "prerequisites": ["Mathlib.Geometry.Euclidean.Triangle", "inner product spaces", "NormedAddTorsor", "EuclideanGeometry.angle"]
+  },
+  {
+    "id": "ann-axiom-architecture-note",
+    "proofId": "triangle-angle-sum-oq-02",
+    "range": { "startLine": 74, "endLine": 95 },
+    "type": "concept",
+    "title": "Axiom Count: Three Structure-Encoded Assumptions",
+    "content": "The file contains no `axiom` keyword, yet it has `axiomCount: 3` in `meta.json`. The three assumptions are structure fields: `gb_local` (local Gauss-Bonnet for geodesic triangles), `spherical`/`hyperbolic` (spherical and hyperbolic curvature formulas $K=1/r^2$ and $K=-1$), and `discrete_gb` (discrete Gauss-Bonnet for triangulations). All three are classical theorems of Riemannian differential geometry requiring integration on manifolds — infrastructure not yet in Mathlib 4.26. Using structure fields rather than `axiom` declarations is a valid architectural choice: it scopes each assumption to the relevant type, prevents global namespace pollution, and makes the dependency structure explicit. But mathematically, structure fields carrying propositions are axioms.",
+    "mathContext": "3 assumptions: `gb_local` ($\\alpha+\\beta+\\gamma-\\pi = \\int K\\,dA$), `spherical`/`hyperbolic` ($K=1/r^2$, $K=-1$), `discrete_gb` ($\\sum \\text{excess} = 2\\pi\\chi$)",
+    "significance": "context",
+    "relatedConcepts": ["axiom integrity policy", "structure-encoded axioms", "Lean 4 structure fields", "axiomCount", "Mathlib coverage gaps in differential geometry"],
+    "prerequisites": ["CLAUDE.md axiom integrity policy", "Lean 4 structures", "Riemannian geometry prerequisites for Mathlib"]
+  }
+]

--- a/src/data/proofs/triangle-angle-sum-oq-02/index.ts
+++ b/src/data/proofs/triangle-angle-sum-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/TriangleAngleSumOQ02.lean?raw'
+
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const triangleAngleSumOq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const triangleAngleSumOq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const triangleAngleSumOq02Data: ProofData = {
+  proof: triangleAngleSumOq02Proof,
+  annotations: triangleAngleSumOq02Annotations,
+}

--- a/src/data/proofs/triangle-angle-sum-oq-02/meta.json
+++ b/src/data/proofs/triangle-angle-sum-oq-02/meta.json
@@ -22,7 +22,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 3,
-    "lineCount": 320,
+    "lineCount": 382,
     "assumptions": "gb_local (local Gauss-Bonnet: angle excess = integrated curvature, for each geodesic triangle), spherical/flat/hyperbolic curvature formulas (K=1/r², K=0, K=-1 respectively), discrete_gb (discrete Gauss-Bonnet for triangulations: total excess = 2π·χ). All are classical theorems of differential geometry requiring Riemannian geometry infrastructure not yet in Mathlib.",
     "mathlib_version": "4.26.0"
   },
@@ -47,42 +47,58 @@
     {
       "id": "geodesic-triangle",
       "title": "Geodesic Triangle Structure",
-      "startLine": 65,
-      "endLine": 100,
-      "summary": "Axiomatized structure encoding angles, area, curvature integral, and the local Gauss-Bonnet formula as a structure field.",
-      "mathContext": "GeodesicTriangle with fields α, β, γ ∈ (0,π), area > 0, integratedCurvature, and gb_local : α+β+γ-π = integratedCurvature."
+      "startLine": 64,
+      "endLine": 118,
+      "summary": "GeodesicTriangle structure axiomatizes local Gauss-Bonnet as gb_local : α+β+γ-π = integratedCurvature. Defines excess and angleSum, with immediate algebraic corollaries.",
+      "mathContext": "GeodesicTriangle: fields α, β, γ ∈ (0,π), area > 0, integratedCurvature ∈ ℝ, gb_local : α+β+γ-π = integratedCurvature; excess := α+β+γ-π."
     },
     {
       "id": "flat-case",
       "title": "Flat Case: Euclid's Theorem",
-      "startLine": 115,
-      "endLine": 140,
-      "summary": "FlatTriangle (K=0, integratedCurvature=0) proves the classical angle sum theorem α+β+γ=π.",
-      "mathContext": "K=0 → excess=0 → α+β+γ=π. Direct from local Gauss-Bonnet with zero curvature."
+      "startLine": 120,
+      "endLine": 149,
+      "summary": "FlatTriangle extends GeodesicTriangle with flat : integratedCurvature = 0. Proves α+β+γ=π (Euclid) as the K=0 special case of local Gauss-Bonnet.",
+      "mathContext": "K=0 → excess=0 → α+β+γ=π. FlatTriangle inherits all GeodesicTriangle fields and adds the flatness constraint."
     },
     {
       "id": "spherical-case",
       "title": "Spherical Case: Girard's Theorem (1629)",
-      "startLine": 155,
-      "endLine": 210,
-      "summary": "SphericalTriangle (K=1/r²) proves Girard's formula: area = r²·(α+β+γ-π) and angle sum > π.",
-      "mathContext": "K = 1/r² → integratedCurvature = area/r² → α+β+γ-π = area/r² > 0 → α+β+γ > π."
+      "startLine": 151,
+      "endLine": 207,
+      "summary": "SphericalTriangle (K=1/r²) proves Girard's formula: area = r²·(α+β+γ-π), angle sum > π, area bounded by r²·(3π-π)=2πr². Unit sphere: area = excess.",
+      "mathContext": "K = 1/r² → integratedCurvature = area/r² → α+β+γ-π = area/r² > 0 → α+β+γ > π; unit sphere: area = α+β+γ-π."
     },
     {
       "id": "hyperbolic-case",
       "title": "Hyperbolic Case: Lambert's Theorem (1761)",
-      "startLine": 220,
-      "endLine": 260,
-      "summary": "HyperbolicTriangle (K=-1) proves Lambert's formula: area = π-α-β-γ and angle sum < π.",
-      "mathContext": "K = -1 → integratedCurvature = -area → α+β+γ-π = -area < 0 → α+β+γ < π. Area bounded by π."
+      "startLine": 209,
+      "endLine": 250,
+      "summary": "HyperbolicTriangle (K=-1) proves Lambert's formula: angular defect = area, angle sum < π, and area < π (maximum possible hyperbolic triangle area).",
+      "mathContext": "K = -1 → integratedCurvature = -area → δ := π-(α+β+γ) = area ∈ (0,π). All hyperbolic triangles have angle sum < π."
     },
     {
       "id": "discrete-gauss-bonnet",
       "title": "Discrete Gauss-Bonnet for Triangulations",
-      "startLine": 265,
-      "endLine": 310,
-      "summary": "RiemannianTriangulation with axiom Σ excess = 2π·χ. Proves sphere (4π), torus (0), genus-g (2π(2-2g)) total curvature.",
-      "mathContext": "For a closed triangulated surface: Σ_i (α_i+β_i+γ_i-π) = 2π·χ. Derives topology from curvature sign."
+      "startLine": 252,
+      "endLine": 297,
+      "summary": "RiemannianTriangulation axiomatizes Σ excess = 2π·χ. Derives sphere total curvature 4π (χ=2), torus 0 (χ=0), genus-g surface 2π(2-2g).",
+      "mathContext": "Σ_i (α_i+β_i+γ_i-π) = 2π·χ(M); sphere: 4π; torus: 0; genus-g: 2π(2-2g). Finset.sum over all triangles."
+    },
+    {
+      "id": "curvature-topology",
+      "title": "Curvature Sign Determines Topology",
+      "startLine": 299,
+      "endLine": 330,
+      "summary": "Proves the Gauss-Bonnet sign constraint: positive total curvature → χ > 0 (sphere), zero → χ = 0 (torus), negative → χ < 0 (higher genus ≥ 2).",
+      "mathContext": "total excess > 0 → χ > 0; = 0 → χ = 0; < 0 → χ < 0. Uses mul_pos_iff, mul_neg_iff with 2π > 0."
+    },
+    {
+      "id": "unification-summary",
+      "title": "The Unification: Three Geometries and Mathlib Anchor",
+      "startLine": 332,
+      "endLine": 382,
+      "summary": "Part VII capstone: excess_classifies_curvature (excess sign ↔ curvature sign), three_geometries_unified (flat/spherical/hyperbolic in one statement), euclidean_case. Closes with a direct Mathlib EuclideanGeometry.angle_add_angle_add_angle_eq_pi example as the concrete anchor.",
+      "mathContext": "three_geometries_unified: (∀ FlatTriangle, sum=π) ∧ (∀ SphericalTriangle, sum>π) ∧ (∀ HyperbolicTriangle, sum<π). Mathlib: angle_add_angle_add_angle_eq_pi for concrete Euclidean points."
     }
   ],
   "conclusion": {
@@ -121,7 +137,7 @@
       "Real"
     ],
     "namespace": "TriangleAngleSumGaussBonnet",
-    "lineCount": 320,
+    "lineCount": 382,
     "axiomCount": 3,
     "sorries": 0,
     "path": "Proofs/TriangleAngleSumOQ02.lean",


### PR DESCRIPTION
## Enrichment Pass: triangle-angle-sum-oq-02

**Quality improvements for the Gauss-Bonnet generalization entry.**

### Changes

- **Created `index.ts`** — proof page was returning "proof not found" on the live site without it
- **Rewrote `annotations.json`** — replaced 5 stub annotations (wrong schema: `line`, `label`, `mathContent`) with 10 full annotations using the correct schema (`range`, `title`, `mathContext`, `significance`, `relatedConcepts`, `prerequisites`). Full coverage of all 7 parts of the 382-line Lean file
- **Fixed `meta.json` lineCount** — was 320, actual file is 382 lines
- **Expanded sections array** — added missing Part VI (Curvature Sign → Topology, lines 299–330) and Part VII (Unification Summary + Mathlib anchor, lines 332–382); fixed line ranges for all existing sections

### Annotation coverage

| Annotation | Lines | Type |
|---|---|---|
| Module Overview | 1–56 | context |
| GeodesicTriangle Structure | 74–118 | definition |
| FlatTriangle: Euclid K=0 | 128–149 | technique |
| Girard's Theorem 1629 | 163–207 | key-theorem |
| Lambert's Theorem 1761 | 220–250 | key-theorem |
| RiemannianTriangulation | 263–297 | definition |
| Curvature Sign → Topology | 306–330 | insight |
| Three Geometries Unified | 349–368 | insight |
| Mathlib anchor example | 370–382 | technique |
| Axiom count architecture | 74–95 | concept |

### Axiom integrity

`axiomCount: 3` is correct. Three structure-encoded assumptions: `gb_local`, `spherical`/`hyperbolic` curvature formulas, and `discrete_gb`. No `axiom` keyword but these ARE mathematical axioms — the annotation `ann-axiom-architecture-note` now explains this explicitly.

🤖 Enrichment by enricher-3