### PR TITLE
Fix: sync section endLine to file length in 26 gallery entries

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-04/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-04/meta.json
@@ -139,7 +139,7 @@
       "id": "sec-min-theorem",
       "title": "Min Limit Theorem",
       "startLine": 153,
-      "endLine": 220,
+      "endLine": 219,
       "summary": "powerMean_tendsto_min: M_r → min(x) as r → -∞. Constructs g = 1/x, proves sup'(g) = (inf'(x))⁻¹ via le_antisymm (antitone inversion), applies the max theorem to g, inverts via Tendsto.inv₀, establishes the duality identity M_r(x) = (M_{-r}(g))⁻¹, and composes with Filter.tendsto_neg_atBot_atTop."
     }
   ],

--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02/meta.json
@@ -92,7 +92,7 @@
       "id": "galois-characterization",
       "title": "Galois Characterization and Summary",
       "startLine": 179,
-      "endLine": 235,
+      "endLine": 234,
       "summary": "Defines IsTwoGroup (group order is 2^k) and states the full Wantzel-Galois theorem: α constructible iff Gal(minpoly(ℚ,α)) is a 2-group. Summary of proved results and remaining sorries."
     }
   ],

--- a/src/data/proofs/area-of-circle-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01/meta.json
@@ -166,7 +166,7 @@
       "id": "isoperimetric",
       "title": "Algebraic Identity and Duality",
       "startLine": 150,
-      "endLine": 163,
+      "endLine": 162,
       "summary": "The algebraic identity $C^2 = 4\\pi A$ (verified by expanding definitions) and the circumference-from-derivative duality theorem.",
       "mathContext": "Algebraic identity: $(2\\pi r)^2 = 4\\pi \\cdot (\\pi r^2)$, i.e., $C^2 = 4\\pi A$. This is the equality case of the isoperimetric inequality, but only the algebraic identity is proved here — the optimality of circles among all curves is not formalized."
     }

--- a/src/data/proofs/area-of-circle-oq-02-oq-04/meta.json
+++ b/src/data/proofs/area-of-circle-oq-02-oq-04/meta.json
@@ -85,7 +85,7 @@
       "id": "dimension-specific",
       "title": "Part V: Dimension-Specific Corollaries",
       "startLine": 264,
-      "endLine": 273,
+      "endLine": 272,
       "summary": "Surface (n=2) doubling factor 4, 3-manifold (n=3) factor 8, and Euclidean 2D formula pi*r^2.",
       "mathContext": "For surfaces with non-negative Gauss curvature: $\\text{Vol}(B(p,2r)) \\leq 4 \\cdot \\text{Vol}(B(p,r))$."
     }

--- a/src/data/proofs/bertrands-postulate/meta.json
+++ b/src/data/proofs/bertrands-postulate/meta.json
@@ -116,14 +116,6 @@
       "endLine": 151,
       "summary": "Bertrand's Postulate as a stepping stone toward the Prime Number Theorem: π(x) ~ x/ln(x). While Bertrand guarantees ≥1 prime in (n, 2n], the PNT predicts ~n/ln(n) primes.",
       "mathContext": "$\\pi(2n) - \\pi(n) \\geq 1$ (Bertrand) vs $\\pi(2n) - \\pi(n) \\sim \\frac{n}{\\ln n}$ (PNT). The PNT ($\\pi(x) \\sim x/\\ln x$, proved 1896 by Hadamard and de la Vallée-Poussin) implies Bertrand for sufficiently large $n$, but Bertrand's elementary proof covers all $n$."
-    },
-    {
-      "id": "verification",
-      "title": "Key Theorems Summary",
-      "startLine": 156,
-      "endLine": 165,
-      "summary": "Type-checks six of the seven theorems via #check (bertrand_large is omitted) and closes the BertrandsPostulate namespace.",
-      "mathContext": "Verifies: `bertrand_postulate`, `bertrand`, `exists_prime_between`, `prime_gap_bounded`, `primes_infinite_via_bertrand`, `no_largest_prime_via_bertrand`. The seventh theorem `bertrand_large` is not #checked here."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -120,7 +120,7 @@
       "id": "chain-summary",
       "title": "UFD Chain Summary and Equivalence Notes",
       "startLine": 109,
-      "endLine": 128,
+      "endLine": 127,
       "summary": "ufd_chain_summary: the chain ℤ → ℤ[X] → ℤ[X][Y] → ℤ[X][Y][Z] all UFDs, proved by inferInstance. Notes on MvPolynomial.finSuccEquiv establishing MvPolynomial (Fin 2) R ≃ₐ Polynomial (Polynomial R). Type checks for key theorems."
     }
   ],

--- a/src/data/proofs/bezout-identity-oq-04-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-04-oq-02/meta.json
@@ -105,7 +105,7 @@
       "id": "examples",
       "title": "Part IV: Concrete Examples and Summary",
       "startLine": 115,
-      "endLine": 139,
+      "endLine": 138,
       "summary": "Four verified ℤ examples: gcd(6,15)=3 with witness 6·(-2)+15·1=3; 6 achievable; 4 NOT achievable (3∤4, proved by omega); every integer is a combination of 7 and 5 (coprime). One Polynomial ℤ example. Closing Summary block.",
       "mathContext": "`omega` handles the non-achievability: it recognizes 6x+15y ≡ 0 (mod 3) ≠ 4 (mod 3). The coprimality witness (3c, -4c) for gcd(7,5)=1 satisfies 7·(3c)+5·(-4c) = 21c-20c = c, verified by `ring`."
     }

--- a/src/data/proofs/derangements-oq-02-oq-02/meta.json
+++ b/src/data/proofs/derangements-oq-02-oq-02/meta.json
@@ -82,7 +82,7 @@
       "id": "summary-consequences",
       "title": "Section VI: Consequences and Summary",
       "startLine": 229,
-      "endLine": 250,
+      "endLine": 249,
       "summary": "Proves total_fixed_eq_card_perm: sum of fixed points equals card of Perm(Fin n) = n! (direct from sum_fixedPoints_eq_factorial and card_perm). Proves summary_expected_fixed_one: the weighted sum equals the unweighted sum (both equal n!), confirming E[#fixed]=1 and G_n'(1)=G_n(1)=n!"
     }
   ],

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01/meta.json
@@ -90,7 +90,7 @@
       "id": "main-answer",
       "title": "Answer to the Open Question",
       "startLine": 155,
-      "endLine": 167,
+      "endLine": 166,
       "summary": "The concluding theorem gauss_sum_is_third_qr_pathway states QR universally for all distinct odd primes, answering YES: the Gauss sum proof is a valid third formal QR pathway in Lean 4 alongside Eisenstein and Zolotarev. The three approaches represent geometry, algebra, and analytic number theory respectively.",
       "mathContext": "Three independent conceptual pathways, one theorem: $\\forall p, q$ odd distinct primes, $\\left(\\frac{p}{q}\\right)\\left(\\frac{q}{p}\\right) = (-1)^{\\lfloor p/2 \\rfloor \\cdot \\lfloor q/2 \\rfloor}$"
     }

--- a/src/data/proofs/erdos-1048/meta.json
+++ b/src/data/proofs/erdos-1048/meta.json
@@ -174,7 +174,7 @@
       "title": "Summary",
       "summary": "Unifies the disproof via erdos_1048 : ¬ EHPConjecture (reducing to EHP_false_for_r_gt_1), defines erdos_1048_answer and erdos_1048_status strings, and proves pommerenke_insight: for any r > 1 and any δ > 0, there exists a monic polynomial with all roots on |z| = r whose lemniscate components all have diameter < δ",
       "startLine": 233,
-      "endLine": 235,
+      "endLine": 234,
       "mathContext": "$\\neg\\,\\text{EHPConjecture}$ via `EHP_false_for_r_gt_1`. Pommerenke's insight: $\\forall r > 1,\\, \\forall \\delta > 0,\\, \\exists f$ monic with roots on $|z| = r$ such that all component diameters $< \\delta$."
     }
   ],

--- a/src/data/proofs/erdos-1206/meta.json
+++ b/src/data/proofs/erdos-1206/meta.json
@@ -68,7 +68,7 @@
       "id": "sorry-tracking",
       "title": "Sorry Tracking via #check",
       "startLine": 22,
-      "endLine": 24,
+      "endLine": 23,
       "summary": "Sorry marker comment and `#check erdos_1206` for Aristotle proof search system tracking. The sorry is tracked in the gallery's sorry count and awaits either manual proof or automated resolution.",
       "mathContext": "`#check erdos_1206` outputs `erdos_1206 : True`, confirming the theorem is well-typed. `#print axioms erdos_1206` would show `axioms used: sorryAx`, indicating the sorry axiom dependency."
     }

--- a/src/data/proofs/erdos-1212/meta.json
+++ b/src/data/proofs/erdos-1212/meta.json
@@ -76,7 +76,7 @@
       "id": "sorry-tracking",
       "title": "Sorry Check for Aristotle Tracking",
       "startLine": 22,
-      "endLine": 24,
+      "endLine": 23,
       "summary": "`#check erdos_1212` line used for sorry tracking by the Aristotle automated proof search system. This line verifies the theorem declaration is well-typed and makes the sorry visible to tooling.",
       "mathContext": "The `#check` command in Lean 4 elaborates the term and reports its type, allowing automated tools to detect the sorry dependency via `#check_axioms` or similar introspection."
     }

--- a/src/data/proofs/erdos-1215/meta.json
+++ b/src/data/proofs/erdos-1215/meta.json
@@ -73,7 +73,7 @@
       "id": "sorry-tracking",
       "title": "Sorry Check for Aristotle Tracking",
       "startLine": 22,
-      "endLine": 24,
+      "endLine": 23,
       "summary": "`#check erdos_1215` verifies the placeholder theorem declaration is well-typed. The sorry is tracked by the Aristotle automated proof search system and by the gallery's sorry count.",
       "mathContext": "The `#check` command in Lean 4 elaborates the term and verifies its type without executing the sorry. Allows tooling to detect the axiom dependency via `#print axioms erdos_1215` → `sorry`."
     }

--- a/src/data/proofs/erdos-135/meta.json
+++ b/src/data/proofs/erdos-135/meta.json
@@ -83,38 +83,6 @@
       "startLine": 107,
       "endLine": 146,
       "mathContext": "Mathematical content: InGeneralPosition, IsParallelogram, IsForbiddenPattern, parallelogram_forbidden"
-    },
-    {
-      "id": "algebraic-construction",
-      "title": "Tao's Algebraic Construction",
-      "summary": "ParabolaParams, RandomizedParabolaApproach, parabolas over finite fields",
-      "startLine": 205,
-      "endLine": 235,
-      "mathContext": "Mathematical content: ParabolaParams, RandomizedParabolaApproach, parabolas over finite fields"
-    },
-    {
-      "id": "comparison-bounds",
-      "title": "Comparison with Erd\u0151s-Guth-Katz Bounds",
-      "summary": "trivial_distance_bound, guth_katz_lower_bound, tao_optimal_up_to_log",
-      "startLine": 236,
-      "endLine": 301,
-      "mathContext": "Bound: trivial_distance_bound, guth_katz_lower_bound, tao_optimal_up_to_log"
-    },
-    {
-      "id": "examples",
-      "title": "Example Configurations",
-      "summary": "Square (2 distances), rhombus (3), projected tetrahedron (4), generic (6)",
-      "startLine": 302,
-      "endLine": 355,
-      "mathContext": "Mathematical content: Square (2 distances), rhombus (3), projected tetrahedron (4), generic (6)"
-    },
-    {
-      "id": "summary",
-      "title": "Summary",
-      "summary": "Problem DISPROVED by Tao 2024, key techniques, historical context",
-      "startLine": 356,
-      "endLine": 392,
-      "mathContext": "Mathematical content: Problem DISPROVED by Tao 2024, key techniques, historical context"
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-500/meta.json
+++ b/src/data/proofs/erdos-500/meta.json
@@ -114,7 +114,7 @@
       "id": "open-problem-stubs",
       "title": "Open Problem Stubs: Density, Bounds, Conjecture",
       "startLine": 44,
-      "endLine": 59,
+      "endLine": 58,
       "summary": "Lines 44-59 are comment-only section headers marking out the remaining formalization work: ex₃(n, K₄³) Turán number (line 45-47 docstring stub), Turán density π (line 49), Turán's lower bound 5/9 (line 50), Razborov's upper bound 0.5612 (line 52), Turán's conjecture (line 54), exact small values ex₃(4)=3, ex₃(5)=7, ex₃(6)=13 (line 56), and hypergraph context (line 58). No Lean declarations exist — these are roadmap comments for future work.",
       "mathContext": "The stubs outline the full formalization roadmap: (1) Turán density existence (KNS theorem 1964, requires sequential compactness); (2) lower bound $\\pi \\geq 5/9$ (Turán's 3-partition); (3) upper bound $\\pi \\leq 0.5612$ (Razborov's flag algebras, currently the deepest gap — requires formalizing semidefinite programming in Lean); (4) conjecture $\\pi = 5/9$ (OPEN). Formalizing step (3) would require extending Mathlib with the flag algebra framework."
     }

--- a/src/data/proofs/erdos-632/meta.json
+++ b/src/data/proofs/erdos-632/meta.json
@@ -151,14 +151,6 @@
       "startLine": 227,
       "endLine": 260,
       "mathContext": "Axiomatized: Axiomatizes cases where the ERT conjecture *does* hold: fractional choosability (Alon–Tuza–Voigt), complete graphs, bipartite graphs, and planar graphs ($m = 2$ case, via Euler's formula constraints)."
-    },
-    {
-      "id": "connections",
-      "title": "Connections to Other Problems",
-      "summary": "States the List Coloring Conjecture ($\\chi_L(L(G)) = \\chi'(G)$ for line graphs), Galvin's theorem for bipartite line graphs, and Ohba's theorem ($\\chi_L = \\chi$ when $|V| \\leq 2\\chi + 1$, proved by Noel–Reed–Wu 2015).",
-      "startLine": 264,
-      "endLine": 264,
-      "mathContext": "States the List Coloring Conjecture ($\\chi_L(L(G)) = \\chi'(G)$ for line graphs), Galvin's theorem for bipartite line graphs, and Ohba's theorem ($\\chi_L = \\chi$ when $|V| \\leq 2\\chi + 1$, proved by Noel–Reed–Wu 2015)."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-763/meta.json
+++ b/src/data/proofs/erdos-763/meta.json
@@ -141,7 +141,7 @@
       "title": "Main Results Summary",
       "summary": "erdos_763_summary, erdos_763_answer theorems",
       "startLine": 254,
-      "endLine": 273,
+      "endLine": 272,
       "mathContext": "Verified: erdos_763_summary, erdos_763_answer theorems"
     }
   ],

--- a/src/data/proofs/erdos-866/meta.json
+++ b/src/data/proofs/erdos-866/meta.json
@@ -99,38 +99,6 @@
       "startLine": 83,
       "endLine": 85,
       "mathContext": "$\\exists C \\in \\mathbb{N},\\; \\forall N,\\; g_4(N) \\le C$ (bounded). Explicit: $g_4(N) \\le 2032$ (van Doorn). Stark contrast: $g_4 = O(1)$ while $g_5 = \\Theta(\\log N)$."
-    },
-    {
-      "id": "case-k5-k6",
-      "title": "Cases k=5,6: Logarithmic and Polynomial Growth",
-      "summary": "g₅≍log N (Choi–Erdős–Szemerédi), g₆≍√N. Lower bound for g₅ extracted via `obtain` from the asymptotic axiom.",
-      "startLine": 101,
-      "endLine": 128,
-      "mathContext": "$g_5(N) \\asymp \\log N$: $\\exists c_1,c_2 > 0,\\; c_1 \\log N \\le g_5(N) \\le c_2 \\log N$. $g_6(N) \\asymp \\sqrt{N}$. The transition $O(1) \\to \\Theta(\\log N) \\to \\Theta(\\sqrt{N})$ reflects the jump from $\\binom{4}{2}=6$ to $\\binom{5}{2}=10$ to $\\binom{6}{2}=15$ required sums."
-    },
-    {
-      "id": "general-bounds",
-      "title": "General Bounds: Upper N^{1-2^{-k}} and Lower N^{1-ε}",
-      "summary": "General upper bound g_k(N) ≪ N^{1-2^{-k}} with upperExponent monotonicity (proved). General lower: g_k > N^{1-ε} for large k (axiom). threshold_approaches_N corollary.",
-      "startLine": 129,
-      "endLine": 172,
-      "mathContext": "Upper: $g_k(N) \\le C_k N^{1-2^{-k}}$ (exponent $\\nearrow 1$ geometrically). Lower: $\\forall \\varepsilon>0,\\; \\exists k_0,\\; k \\ge k_0 \\Rightarrow g_k(N) > N^{1-\\varepsilon}$. Together: $g_k(N) = N^{1-o(1)}$ as $k \\to \\infty$. Gap: true exponent $\\alpha_k \\in (1-2^{-k}, 1-\\varepsilon)$ unknown."
-    },
-    {
-      "id": "extremal-construction",
-      "title": "Odd Numbers: Universal Extremal Construction",
-      "summary": "oddNumbers(N) = {1,3,...,2N-1}: cardinality N (proved), no triple with all pairwise sums (proved). Base lower bound for all k.",
-      "startLine": 173,
-      "endLine": 195,
-      "mathContext": "$O_N = \\{n \\in [2N] : n \\text{ odd}\\}$, $|O_N| = N$. For any $b_1, b_2, b_3$: two share parity, so their sum is even $\\notin O_N$. Hence $g_k(N) \\ge 1$ for all $k \\ge 3$. The odd numbers construction is extremal: removing one element (reaching $N+1 = N + g_3$) allows three witnesses."
-    },
-    {
-      "id": "summary-open",
-      "title": "Summary Table and Four Open Problems",
-      "summary": "Theorems referencing all case axioms (g₃=2, g₄≤2032, g₅≍log N, g₆≍√N, general bounds). Four open problems formalized as Props.",
-      "startLine": 196,
-      "endLine": 274,
-      "mathContext": "Summary: $g_3=2,\\; g_4 \\le 2032,\\; g_5 \\asymp \\log N,\\; g_6 \\asymp \\sqrt{N},\\; g_k \\ll N^{1-2^{-k}},\\; g_k > N^{1-\\varepsilon} \\text{ (large } k)$. Opens: (1) exact $g_4$, (2) constants in $g_5 \\asymp \\log N$, (3) true exponent $\\alpha_k$, (4) structural characterization of extremal sets."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-869/meta.json
+++ b/src/data/proofs/erdos-869/meta.json
@@ -150,7 +150,7 @@
       "title": "Summary",
       "summary": "Summary theorem and open question statement",
       "startLine": 258,
-      "endLine": 284,
+      "endLine": 283,
       "mathContext": "Verified: Summary theorem and open question statement"
     }
   ],

--- a/src/data/proofs/erdos-946/meta.json
+++ b/src/data/proofs/erdos-946/meta.json
@@ -99,7 +99,7 @@
       "id": "bounds",
       "title": "Quantitative Bounds",
       "startLine": 115,
-      "endLine": 127,
+      "endLine": 126,
       "summary": "Lower bounds (Heath-Brown, Hildebrand) and upper bound (EPS)."
     }
   ],

--- a/src/data/proofs/euler-totient/meta.json
+++ b/src/data/proofs/euler-totient/meta.json
@@ -131,7 +131,7 @@
       "title": "Verification Checks",
       "summary": "Uses `#check` to confirm the API surface: `euler_totient`, `fermat_little_theorem`, `fermat_little_theorem_full`.",
       "startLine": 132,
-      "endLine": 136,
+      "endLine": 135,
       "mathContext": "Type-checking the main results via `#check` to confirm the API surface."
     }
   ],

--- a/src/data/proofs/fair-games-theorem/meta.json
+++ b/src/data/proofs/fair-games-theorem/meta.json
@@ -125,14 +125,6 @@
       "endLine": 417,
       "summary": "Five placeholder theorems proving `(1:ℕ)+1=2` with substantive docstrings discussing gambler's ruin, betting systems, option pricing, and Doob's inequality. The mathematical applications described are accurate but NOT formalized — these are future targets.",
       "mathContext": "Docstrings describe: gambler's ruin $P(\\text{success}) = W_0/(W_0 + a)$, Doob's inequality $P(\\max_{n \\leq N} f_n \\geq \\lambda) \\leq E[f_N]/\\lambda$, and Black-Scholes pricing. The formal content is trivial (`rfl`)."
-    },
-    {
-      "id": "historical",
-      "title": "Historical Context",
-      "startLine": 429,
-      "endLine": 475,
-      "summary": "Timeline from Bachelier (1906) through Lévy (1934), Ville (1939), Doob (1953). Explains the name 'martingale' and Wiedijk's characterization.",
-      "mathContext": "Doob (1953): $E[X_\\tau] = E[X_0]$ for bounded $\\tau$. Ville (1939) coined 'martingale'. Bachelier (1900) applied to finance."
     }
   ],
   "crossReferences": [

--- a/src/data/proofs/feuerbachs-theorem-defs-oq-04/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-04/meta.json
@@ -90,7 +90,7 @@
       "id": "namespace-end",
       "title": "Namespace Close",
       "startLine": 157,
-      "endLine": 191,
+      "endLine": 190,
       "summary": "End of the FeuerbachsTheoremDefsOQ04 namespace and the noncomputable section.",
       "mathContext": "The `end FeuerbachsTheoremDefsOQ04` and `end` close the namespace and noncomputable section, making all 12 theorems available under the `FeuerbachsTheoremDefsOQ04` prefix for import by downstream proofs."
     }

--- a/src/data/proofs/fundamental-arithmetic-oq-02/meta.json
+++ b/src/data/proofs/fundamental-arithmetic-oq-02/meta.json
@@ -88,7 +88,7 @@
       "id": "main-theorem",
       "title": "The Factorizations Are Essentially Different",
       "startLine": 182,
-      "endLine": 193,
+      "endLine": 192,
       "summary": "Concludes that the two factorizations are genuinely distinct: since 2 does not divide (1 + sqrt(-5)), the factors in one factorization cannot be obtained from the other by multiplying by units."
     }
   ],

--- a/src/data/proofs/lhopital-oq-01/meta.json
+++ b/src/data/proofs/lhopital-oq-01/meta.json
@@ -106,14 +106,6 @@
       "startLine": 93,
       "endLine": 142,
       "mathContext": "$1 + \\cos(2\\pi n) = 2$ and $1 + \\cos(\\pi + 2\\pi n) = 0$. By uniqueness of limits, no $L$ satisfies $1 + \\cos(x) \\to L$."
-    },
-    {
-      "id": "failure-statement",
-      "title": "L'Hôpital Failure Theorem",
-      "summary": "Combined statement: f/g → 1 AND f'/g' has no limit. Shows L'Hôpital's rule is one-directional.",
-      "startLine": 163,
-      "endLine": 169,
-      "mathContext": "The conjunction proves both that the original ratio converges and that the derivative ratio does not."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/quadratic-reciprocity-algorithm-oq-01/meta.json
+++ b/src/data/proofs/quadratic-reciprocity-algorithm-oq-01/meta.json
@@ -97,7 +97,7 @@
       "id": "properties",
       "title": "Algorithm Properties",
       "startLine": 199,
-      "endLine": 221,
+      "endLine": 220,
       "summary": "Proves jacobiAlgo_mod_left: the algorithm respects residue classes, J(a | b) = J(a mod b | b). Exports the three main results via #check."
     }
   ],


### PR DESCRIPTION
## Fix

32 gallery sections had `endLine` values exceeding the actual Lean source file length. These sections referenced non-existent code, causing potential gallery viewer rendering issues.

## Evidence

**20 partially out-of-bounds sections** (startLine ≤ fileLen < endLine): capped endLine to match file length (1–2 lines over).

**12 fully out-of-bounds sections** (startLine > fileLen): removed entirely — they pointed to code that no longer exists.

**Most extreme cases**:
- `erdos-135`: 4 sections removed (file=146 lines, sections up to line 392)
- `erdos-866`: 4 sections removed (file=85 lines, sections up to line 274)
- `fair-games-theorem`: 1 section removed (file=417 lines, section refs start=429)

**Root cause**: Lean source files were shortened after sections were enriched by the enricher agent, leaving stale line references.

## Scope

26 files changed, 32 sections fixed.

---
Automated fix by lean-mechanic agent.