### PR TITLE
Fix: lebesgue-measure-oq-06 sorry/axiomCount correction 8→4

### DIFF
--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -18,10 +18,10 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 8,
-    "axiomCount": 5,
+    "sorries": 4,
+    "axiomCount": 4,
     "lineCount": 563,
-    "assumptions": "8 sorries: hausdorff_free_subgroup (free subgroup of SO(3)), banach_tarski (main theorem), banach_tarski_pieces_nonmeasurable (non-measurability of pieces), int_amenable (ℤ amenability), W_a_two_cover (W(a) two-cover), W_a_smul_disj (W(a) smul disjointness), W_b_two_cover (W(b) two-cover), W_b_smul_disj (W(b) smul disjointness). The main proof requires ~800 lines via free subgroup of SO(3) — beyond this gallery entry's scope. Note: paradoxical_no_finite_measure and free_group_not_amenable structure are fully proved.",
+    "assumptions": "4 sorries: hausdorff_free_subgroup (free subgroup of SO(3) — Hausdorff 1914), banach_tarski (main theorem — requires AC), banach_tarski_pieces_nonmeasurable (non-measurability of pieces), int_amenable (ℤ amenability via Cesàro means). The W_a/W_b cover and disjointness lemmas, free_group_not_amenable, and paradoxical_no_finite_measure are fully proved.",
     "dateAdded": "2026-04-22",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -206,7 +206,7 @@
     "theoremCount": 7,
     "definitionCount": 5,
     "path": "Proofs/LebesgueMeasureOQ06.lean",
-    "sorries": 8
+    "sorries": 4
   },
-  "sorries": 8
+  "sorries": 4
 }


### PR DESCRIPTION
## Fix

Correct sorry and axiomCount from 8 to 4: the W_a/W_b cover and disjointness lemmas (`W_a_two_cover`, `W_a_smul_disj`, `W_b_two_cover`, `W_b_smul_disj`) are fully proved in the Lean source — they were incorrectly counted as sorries.

## Evidence

**Before**: `sorries: 8`, `axiomCount: 5 (meta)/8 (assumptions text)`, listing 8 sorry obligations
**After**: `sorries: 4`, `axiomCount: 4`, listing only the 4 actual sorry obligations

The 4 actual sorries are:
- `hausdorff_free_subgroup` (line 178) — Hausdorff 1914 free subgroup of SO(3)
- `banach_tarski` (line 225) — main theorem, requires AC
- `banach_tarski_pieces_nonmeasurable` (line 236) — non-measurability of pieces
- `int_amenable` (line 271) — ℤ amenability via Cesàro means

The W_* cover/disjointness lemmas and `free_group_not_amenable` are fully proved.

Closes #11828

---
Automated fix by lean-mechanic agent.