### PR TITLE
Fix: erdos-658 phantom axioms removed, axiomCount corrected to 3

### DIFF
--- a/src/data/proofs/erdos-658/meta.json
+++ b/src/data/proofs/erdos-658/meta.json
@@ -50,21 +50,20 @@
       "density definition: |A|/N² ratio",
       "GrahamConjectureAxisAligned: formal statement of the conjecture",
       "graham_axis_aligned_true axiom: the main result",
-      "qualitative_threshold axiom: existence of N₀(δ)",
-      "density_hales_jewett axiom: the underlying deep theorem",
-      "solymosi_bound axiom: quantitative bounds",
+      "density_hales_jewett axiom: the underlying deep theorem (Furstenberg-Katznelson 1991)",
+      "small_case_2x2 axiom: 2×2 base case (any 3 points in 2×2 grid contain a square)",
       "erdos_658 theorem: main result",
       "erdos_658_answer theorem: final answer"
     ],
-    "axiomCount": 2,
+    "axiomCount": 3,
     "lineCount": 299,
-    "assumptions": "2 axioms: graham_axis_aligned_true, density_hales_jewett. 0 sorries."
+    "assumptions": "3 axioms: graham_axis_aligned_true (main result), density_hales_jewett (Furstenberg-Katznelson 1991), small_case_2x2 (2×2 base case). 0 sorries."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #658: Squares in Dense Grid Subsets**\n\nThis problem, attributed to Graham, asks a natural geometric question: if you have enough points in an N×N grid, must some four of them form the vertices of a square?\n\n**Key History:**\n- Graham: Posed the problem for axis-aligned squares\n- Erdős [Er97e]: Included in his list of favorite unsolved problems (ambiguous about axis-alignment)\n- Furstenberg-Katznelson (1991): Proved qualitatively via the density Hales-Jewett theorem\n- Solymosi (2004): Gave the first quantitative proof with explicit bounds\n\n**Mathematical Setting:**\nThe problem connects discrete geometry with additive combinatorics. The proof uses the density Hales-Jewett theorem, one of the deepest results in the field, showing that dense sets in high-dimensional spaces must contain combinatorial structures.",
     "problemStatement": "**Problem Statement (Proved)**\n\nLet $\\delta > 0$ and $N$ be sufficiently large depending on $\\delta$. Is it true that if $A \\subseteq \\{1,\\ldots,N\\}^2$ has $|A| \\geq \\delta N^2$ then $A$ must contain the vertices of a square?\n\n**Answer: YES**\n\nFurstenberg and Katznelson (1991) proved this follows from the density Hales-Jewett theorem. Solymosi (2004) gave explicit (but very large, tower-type) bounds on N₀(δ).",
     "text": "Do dense subsets of the N×N grid contain squares? YES, proved via density Hales-Jewett (Furstenberg-Katznelson 1991), with quantitative bounds by Solymosi (2004).",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Grid and Squares:** Define the N×N grid and what it means for four points to form a square\n\n2. **Density:** Define δ-dense subsets where |A| ≥ δN²\n\n3. **Main Conjecture:** State GrahamConjectureAxisAligned formally\n\n4. **Key Axioms:**\n   - graham_axis_aligned_true: The main theorem\n   - density_hales_jewett: The underlying deep result\n   - solymosi_bound: Quantitative version\n\n5. **Connections:** Link to Hales-Jewett and higher-dimensional generalizations",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Grid and Squares:** Define the N×N grid and what it means for four points to form a square\n\n2. **Density:** Define δ-dense subsets where |A| ≥ δN²\n\n3. **Main Conjecture:** State GrahamConjectureAxisAligned formally\n\n4. **Key Axioms:**\n   - graham_axis_aligned_true: The main theorem\n   - density_hales_jewett: The underlying deep result (Furstenberg-Katznelson 1991)\n   - small_case_2x2: 2×2 base case axiom\n\n5. **Connections:** Link to Hales-Jewett and higher-dimensional generalizations",
     "keyInsights": [
       "**Density Forces Structure:** Sufficiently dense sets in grids must contain geometric patterns like squares",
       "**Hales-Jewett Connection:** The proof reduces to the density Hales-Jewett theorem, a cornerstone of additive combinatorics",
@@ -98,10 +97,10 @@
     {
       "id": "main-result",
       "title": "Main Result",
-      "summary": "erdos_658 theorem, qualitative_threshold axiom",
+      "summary": "erdos_658 theorem (via graham_axis_aligned_true axiom)",
       "startLine": 139,
       "endLine": 168,
-      "mathContext": "Verified: erdos_658 theorem, qualitative_threshold axiom"
+      "mathContext": "Axiomatized: erdos_658 theorem follows directly from graham_axis_aligned_true axiom"
     },
     {
       "id": "hales-jewett",
@@ -113,11 +112,11 @@
     },
     {
       "id": "solymosi-bounds",
-      "title": "Solymosi's Bounds",
-      "summary": "solymosi_bound axiom, tower_type_bound",
+      "title": "Bounds and Small Cases",
+      "summary": "small_case_2x2 axiom (2×2 base case); Solymosi quantitative bounds discussed in comments only",
       "startLine": 202,
       "endLine": 229,
-      "mathContext": "Axiomatized: solymosi_bound axiom, tower_type_bound"
+      "mathContext": "Axiomatized: small_case_2x2 (any 3 points in a 2×2 grid contain a square). Solymosi (2004) tower-type bounds on N₀(δ) are described in section comments but not formalized as axioms in this file."
     },
     {
       "id": "examples",
@@ -168,7 +167,7 @@
     ],
     "namespace": "Erdos658",
     "lineCount": 299,
-    "axiomCount": 2,
+    "axiomCount": 3,
     "theoremCount": 7,
     "definitionCount": 8,
     "path": "Proofs/Erdos658Problem.lean",


### PR DESCRIPTION
## Fix

Remove phantom `qualitative_threshold` and `solymosi_bound` axiom entries from meta.json, add the actual third axiom `small_case_2x2`, and correct `axiomCount` from 2 to 3.

## Evidence

**Actual axioms in `Proofs/Erdos658Problem.lean`** (3 total):
- Line 137: `axiom graham_axis_aligned_true` — the main result
- Line 182: `axiom density_hales_jewett` — Furstenberg-Katznelson 1991
- Line 222: `axiom small_case_2x2` — 2×2 base case

**Phantom entries removed** (not present in Lean file):
- `qualitative_threshold axiom` — does not exist
- `solymosi_bound axiom` — does not exist (Solymosi bounds are discussion comments only)

**Before**: `axiomCount: 2`, `originalContributions` listed 2 phantom axioms, missing `small_case_2x2`
**After**: `axiomCount: 3`, `originalContributions` lists the 3 actual axioms, sections corrected

Note: Open PR #11833 (filed by auditor) identified the phantom entries but miscounted axioms (stated "exactly 2 axioms" while missing `small_case_2x2`). This PR supersedes that one with a complete fix.

Closes #11833

---
Automated fix by lean-mechanic agent.