### PR TITLE
Fix: erdos-637 axiomCount mismatch (0→2) and status correction

### DIFF
--- a/src/data/proofs/erdos-637/meta.json
+++ b/src/data/proofs/erdos-637/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős, Faudree, Sós, Bukh, Sudakov, Jenssen, Keevash, Long, Yepremyan",
     "sourceUrl": "https://erdosproblems.com/637",
     "date": "2007-2020",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos637Problem.lean",
     "tags": [
       "erdos",
@@ -15,12 +15,12 @@
       "ramsey-theory",
       "degrees"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 10,
     "erdosNumber": 637,
     "erdosUrl": "https://erdosproblems.com/637",
     "erdosProblemStatus": "solved",
-    "axiomCount": 0,
+    "axiomCount": 2,
     "prerequisites": [
       "Graph theory basics (vertices, edges, adjacency, neighborhoods)",
       "Degree sequences and regular graphs",
@@ -29,7 +29,7 @@
       "Probabilistic method and random graph models (Erdős-Rényi G(n, 1/2))"
     ],
     "lineCount": 243,
-    "assumptions": "No axioms. 10 sorry(s) remain in the formalization.",
+    "assumptions": "2 axioms: ramsey_lower_bound (Ramsey number lower bound R(k,k) ≥ 2^(k/2)), vertex_bound_from_ramsey (vertex count bounded by R(k+1,k+1)). 10 sorries remain.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -200,7 +200,7 @@
     ],
     "namespace": "Erdos637",
     "lineCount": 243,
-    "axiomCount": 0,
+    "axiomCount": 2,
     "theoremCount": 13,
     "definitionCount": 16,
     "sorries": 10,


### PR DESCRIPTION
## Integrity Fix

**Proof**: erdos-637 (Distinct Degrees in Induced Subgraphs)

**Problem**: The Lean file `Erdos637Problem.lean` has 2 `axiom` declarations:
- `ramsey_lower_bound` (line 187): Ramsey number lower bound R(k,k) ≥ 2^(k/2)
- `vertex_bound_from_ramsey` (line 192): vertex count bounded by R(k+1,k+1)

But `meta.json` claimed `axiomCount: 0` with `status: "formalized"` and `badge: "wip"`.

## Changes

- `meta.axiomCount`: 0 → 2
- `leanFile.axiomCount`: 0 → 2
- `meta.status`: `"formalized"` → `"axiomatized"` (has explicit axiom declarations)
- `meta.badge`: `"wip"` → `"axiom"`
- `meta.assumptions`: updated to list both axioms

## Severity

LOW — metadata inconsistency only, no false "verified" claims.

---
Discovered during gallery integrity audit (2026-04-23).