### PR TITLE
Fix: erdos-601 axiomCount mismatch (3→4, add general_conjecture_open)

### DIFF
--- a/src/data/proofs/erdos-601/meta.json
+++ b/src/data/proofs/erdos-601/meta.json
@@ -60,9 +60,9 @@
       "independenceNumber: cardinal-valued graph invariant",
       "GeneralConjecture: $500 prize problem"
     ],
-    "axiomCount": 3,
+    "axiomCount": 4,
     "lineCount": 262,
-    "assumptions": "3 axiom(s) and 10 sorry(s). See the Lean source for details."
+    "assumptions": "4 axioms: critical_case_open, MartinsAxiom, ordinal_ramsey, general_conjecture_open. 10 sorries remain."
   },
   "sections": [
     {
@@ -206,7 +206,7 @@
     ],
     "namespace": "Erdos601",
     "lineCount": 262,
-    "axiomCount": 3,
+    "axiomCount": 4,
     "theoremCount": 19,
     "definitionCount": 13,
     "sorries": 10,


### PR DESCRIPTION
## Integrity Fix

**Proof**: erdos-601 (Chromatic Number via Independent Sets)

**Problem**: The Lean file `Erdos601Problem.lean` has 4 `axiom` declarations:
- `critical_case_open` (line 114)
- `MartinsAxiom` (line 128)
- `ordinal_ramsey` (line 169)
- `general_conjecture_open` (line 217)

But `meta.json` claimed `axiomCount: 3`, missing `general_conjecture_open`.

## Changes

- `meta.axiomCount`: 3 → 4
- `leanFile.axiomCount`: 3 → 4
- `meta.assumptions`: updated to list all 4 axioms explicitly

## Severity

LOW — axiom count off by 1, no false "verified" claims (status correctly "axiomatized").

---
Discovered during gallery integrity audit (2026-04-23).