### PR TITLE
Fix: sync stale leanFile.lineCount in 12 gallery meta.json files

### DIFF
--- a/src/data/proofs/erdos-1033/meta.json
+++ b/src/data/proofs/erdos-1033/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-1033",
-  "title": "Erdős Problem #1033: Triangle Degree Sums in Dense Graphs",
+  "title": "Erd\u0151s Problem #1033: Triangle Degree Sums in Dense Graphs",
   "slug": "erdos-1033",
-  "description": "Let h(n) = max k such that every graph on n vertices with > n²/4 edges contains a triangle with degree sum ≥ k. Conjecture: h(n) ≥ (2(√3−1)−o(1))n ≈ 1.464n. Known: (21/16)n ≤ h(n) ≤ 2(√3−1)n.",
+  "description": "Let h(n) = max k such that every graph on n vertices with > n\u00b2/4 edges contains a triangle with degree sum \u2265 k. Conjecture: h(n) \u2265 (2(\u221a3\u22121)\u2212o(1))n \u2248 1.464n. Known: (21/16)n \u2264 h(n) \u2264 2(\u221a3\u22121)n.",
   "meta": {
-    "author": "Erdős-Laskar (1985), Fan (1988)",
+    "author": "Erd\u0151s-Laskar (1985), Fan (1988)",
     "sourceUrl": "https://erdosproblems.com/1033",
     "date": "1985",
     "status": "axiomatized",
@@ -47,23 +47,23 @@
     "originalContributions": [
       "Formal definition of h(n) as supremum of valid lower bounds",
       "Triangle structure with degree sum formalization",
-      "Statement of Erdős-Laskar and Fan bounds as axioms",
+      "Statement of Erd\u0151s-Laskar and Fan bounds as axioms",
       "Formalization of the main conjecture and its asymptotic equivalent"
     ],
     "relatedProblems": [],
     "axiomCount": 3,
-    "lineCount": 1016,
+    "lineCount": 1018,
     "assumptions": "3 axioms (erdos_laskar_upper, erdos_laskar_lower, fan_lower). 0 sorries (h_as_min, turan_plus_one, h_four, h_spec all proved). Note: erdos_laskar_upper and fan_lower axioms are too strong for small n (asymptotic results stated as universal)."
   },
   "overview": {
-    "historicalContext": "Pál Turán proved in 1941 that every graph on $n$ vertices with more than $\\lfloor n^2/4 \\rfloor$ edges contains a triangle — establishing the foundational result of extremal graph theory. This problem, posed by Erdős and Laskar, asks a refined question: given that triangles must exist above the Turán threshold, how large must the degree sum of the *heaviest* triangle be?\n\nErdős and Renu Laskar (1985) proved the initial bounds $(1+c)n \\leq h(n) \\leq 2(\\sqrt{3}-1)n$, where the upper bound $2(\\sqrt{3}-1) \\approx 1.464$ comes from optimizing triangle configurations in nearly-bipartite graphs close to the Turán graph $T(n,2)$. Genghua Fan (1988) improved the lower bound to $(21/16)n = 1.3125n$ via careful degree counting arguments.\n\nThe gap between $1.3125n$ and $1.464n$ remains open. The conjectured answer is $h(n) = (2(\\sqrt{3}-1) - o(1))n$, which would mean the Erdős-Laskar construction is essentially optimal.",
-    "problemStatement": "**Problem Statement**\n\nLet h(n) be such that every graph on n vertices with > n²/4 edges contains a triangle whose vertices have degrees summing to at least h(n). Estimate h(n).\n\n**Conjecture**: h(n) ≥ (2(√3−1)−o(1))n ≈ 1.464n\n\n**Status**: OPEN",
-    "text": "Let h(n) = max k such that every graph on n vertices with > n²/4 edges contains a triangle with degree sum ≥ k. Conjecture: h(n) ≥ (2(√3−1)−o(1))n ≈ 1.464n. Known: (21/16)n ≤ h(n) ≤ 2(√3−1)n.",
-    "proofStrategy": "**Known Approach**\n\n1. **Upper Bound**: Erdős-Laskar construct graphs just above Turán threshold where all triangles have degree sum ≤ 2(√3−1)n.\n\n2. **Lower Bound (Fan)**: Careful analysis shows h(n) ≥ (21/16)n via degree counting in triangles.\n\n3. **Key Insight**: The constant 2(√3−1) arises from optimizing triangle configurations in nearly-bipartite graphs.\n\n4. **Gap**: Closing the 0.15n gap between bounds remains open.",
+    "historicalContext": "P\u00e1l Tur\u00e1n proved in 1941 that every graph on $n$ vertices with more than $\\lfloor n^2/4 \\rfloor$ edges contains a triangle \u2014 establishing the foundational result of extremal graph theory. This problem, posed by Erd\u0151s and Laskar, asks a refined question: given that triangles must exist above the Tur\u00e1n threshold, how large must the degree sum of the *heaviest* triangle be?\n\nErd\u0151s and Renu Laskar (1985) proved the initial bounds $(1+c)n \\leq h(n) \\leq 2(\\sqrt{3}-1)n$, where the upper bound $2(\\sqrt{3}-1) \\approx 1.464$ comes from optimizing triangle configurations in nearly-bipartite graphs close to the Tur\u00e1n graph $T(n,2)$. Genghua Fan (1988) improved the lower bound to $(21/16)n = 1.3125n$ via careful degree counting arguments.\n\nThe gap between $1.3125n$ and $1.464n$ remains open. The conjectured answer is $h(n) = (2(\\sqrt{3}-1) - o(1))n$, which would mean the Erd\u0151s-Laskar construction is essentially optimal.",
+    "problemStatement": "**Problem Statement**\n\nLet h(n) be such that every graph on n vertices with > n\u00b2/4 edges contains a triangle whose vertices have degrees summing to at least h(n). Estimate h(n).\n\n**Conjecture**: h(n) \u2265 (2(\u221a3\u22121)\u2212o(1))n \u2248 1.464n\n\n**Status**: OPEN",
+    "text": "Let h(n) = max k such that every graph on n vertices with > n\u00b2/4 edges contains a triangle with degree sum \u2265 k. Conjecture: h(n) \u2265 (2(\u221a3\u22121)\u2212o(1))n \u2248 1.464n. Known: (21/16)n \u2264 h(n) \u2264 2(\u221a3\u22121)n.",
+    "proofStrategy": "**Known Approach**\n\n1. **Upper Bound**: Erd\u0151s-Laskar construct graphs just above Tur\u00e1n threshold where all triangles have degree sum \u2264 2(\u221a3\u22121)n.\n\n2. **Lower Bound (Fan)**: Careful analysis shows h(n) \u2265 (21/16)n via degree counting in triangles.\n\n3. **Key Insight**: The constant 2(\u221a3\u22121) arises from optimizing triangle configurations in nearly-bipartite graphs.\n\n4. **Gap**: Closing the 0.15n gap between bounds remains open.",
     "keyInsights": [
-      "Turán threshold: n²/4 edges forces a triangle",
+      "Tur\u00e1n threshold: n\u00b2/4 edges forces a triangle",
       "h(n) = guaranteed minimum of max triangle degree sum",
-      "Upper bound 2(√3−1)n ≈ 1.464n from Erdős-Laskar",
+      "Upper bound 2(\u221a3\u22121)n \u2248 1.464n from Erd\u0151s-Laskar",
       "Lower bound (21/16)n = 1.3125n from Fan",
       "Gap of about 0.15n remains open"
     ],
@@ -86,11 +86,11 @@
     },
     {
       "id": "turan-threshold",
-      "title": "Turán Threshold",
+      "title": "Tur\u00e1n Threshold",
       "summary": "turanThreshold, isAboveTuran, turan_has_triangle",
       "startLine": 43,
       "endLine": 60,
-      "mathContext": "Turán (1941): $|E(G)| > \\lfloor n^2/4 \\rfloor \\Rightarrow G$ contains a triangle."
+      "mathContext": "Tur\u00e1n (1941): $|E(G)| > \\lfloor n^2/4 \\rfloor \\Rightarrow G$ contains a triangle."
     },
     {
       "id": "triangles",
@@ -110,15 +110,15 @@
     },
     {
       "id": "constant",
-      "title": "The Constant 2(√3−1)",
+      "title": "The Constant 2(\u221a3\u22121)",
       "summary": "erdosLaskarConstant, erdosLaskar_approx",
       "startLine": 119,
       "endLine": 140,
-      "mathContext": "$2(\\sqrt{3}-1) \\approx 1.464$. Arises from optimizing triangle degree sums in nearly-bipartite graphs near the Turán graph $T(n,2)$."
+      "mathContext": "$2(\\sqrt{3}-1) \\approx 1.464$. Arises from optimizing triangle degree sums in nearly-bipartite graphs near the Tur\u00e1n graph $T(n,2)$."
     },
     {
       "id": "upper-bound",
-      "title": "Erdős-Laskar Upper Bound",
+      "title": "Erd\u0151s-Laskar Upper Bound",
       "summary": "erdos_laskar_upper, upper_bound_tight",
       "startLine": 141,
       "endLine": 158,
@@ -126,7 +126,7 @@
     },
     {
       "id": "original-lower",
-      "title": "Erdős-Laskar Lower Bound",
+      "title": "Erd\u0151s-Laskar Lower Bound",
       "summary": "erdos_laskar_lower, lower_beats_n",
       "startLine": 159,
       "endLine": 176,
@@ -182,7 +182,7 @@
     },
     {
       "id": "turan-graph",
-      "title": "Relation to Turán Graph",
+      "title": "Relation to Tur\u00e1n Graph",
       "summary": "bipartite_no_triangle, turan_plus_one",
       "startLine": 298,
       "endLine": 321,
@@ -197,10 +197,10 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #1033 asks to estimate h(n), where every graph on n vertices with > n²/4 edges contains a triangle with degree sum ≥ h(n). Erdős-Laskar (1985) proved h(n) ≤ 2(√3−1)n, and Fan (1988) proved h(n) ≥ (21/16)n. The gap remains open.",
-    "implications": "1. **Turán Theory Extension**: Refines our understanding beyond triangle existence\n\n**2. Degree-Sum Problems**: Template for similar extremal questions\n\n3. **Extremal Graph Structure**: Near-Turán graphs have specific triangle properties\n\n4. **Algorithmic Implications**: Finding high-degree-sum triangles.",
+    "summary": "Erd\u0151s Problem #1033 asks to estimate h(n), where every graph on n vertices with > n\u00b2/4 edges contains a triangle with degree sum \u2265 h(n). Erd\u0151s-Laskar (1985) proved h(n) \u2264 2(\u221a3\u22121)n, and Fan (1988) proved h(n) \u2265 (21/16)n. The gap remains open.",
+    "implications": "1. **Tur\u00e1n Theory Extension**: Refines our understanding beyond triangle existence\n\n**2. Degree-Sum Problems**: Template for similar extremal questions\n\n3. **Extremal Graph Structure**: Near-Tur\u00e1n graphs have specific triangle properties\n\n4. **Algorithmic Implications**: Finding high-degree-sum triangles.",
     "openQuestions": [
-      "Is h(n) = (2(√3−1)−o(1))n? (Main conjecture)",
+      "Is h(n) = (2(\u221a3\u22121)\u2212o(1))n? (Main conjecture)",
       "What are the extremal graphs achieving h(n)?",
       "Can the lower bound be improved beyond (21/16)n?",
       "What about k-cliques instead of triangles?",
@@ -210,40 +210,40 @@
   "crossReferences": [
     {
       "relationship": "foundational",
-      "description": "Erdős #905 establishes that every dense graph (above Turán threshold) has an edge in at least n/6 triangles. This codegree result is a prerequisite for understanding triangle degree-sum guarantees and underlies the book lemma used in related lower bound arguments.",
+      "description": "Erd\u0151s #905 establishes that every dense graph (above Tur\u00e1n threshold) has an edge in at least n/6 triangles. This codegree result is a prerequisite for understanding triangle degree-sum guarantees and underlies the book lemma used in related lower bound arguments.",
       "targetId": "erdos-905"
     },
     {
       "relationship": "companion",
-      "description": "Erdős #1034 asks about triangle neighbor counts in dense graphs and is directly companion to #1033. Both probe the structure of triangles above the Turán threshold, with #1034 measuring neighborhood size and #1033 measuring degree sums of triangle vertices.",
+      "description": "Erd\u0151s #1034 asks about triangle neighbor counts in dense graphs and is directly companion to #1033. Both probe the structure of triangles above the Tur\u00e1n threshold, with #1034 measuring neighborhood size and #1033 measuring degree sums of triangle vertices.",
       "targetId": "erdos-1034"
     },
     {
       "relationship": "related",
-      "description": "Erdős #1032 studies 4-chromatic critical graphs with linear minimum degree, connecting the Turán-type threshold with chromatic criticality. Minimum degree conditions are closely tied to degree-sum phenomena in dense graphs.",
+      "description": "Erd\u0151s #1032 studies 4-chromatic critical graphs with linear minimum degree, connecting the Tur\u00e1n-type threshold with chromatic criticality. Minimum degree conditions are closely tied to degree-sum phenomena in dense graphs.",
       "targetId": "erdos-1032"
     },
     {
       "relationship": "context",
-      "description": "Ramsey's theorem guarantees clique or independent set structure in dense graphs. Triangle existence above the Turán threshold is the r=3 instance of Ramsey-type problems, and the degree-sum question refines the structural information forced by Ramsey thresholds.",
+      "description": "Ramsey's theorem guarantees clique or independent set structure in dense graphs. Triangle existence above the Tur\u00e1n threshold is the r=3 instance of Ramsey-type problems, and the degree-sum question refines the structural information forced by Ramsey thresholds.",
       "targetId": "ramseys-theorem"
     },
     {
       "relationship": "related",
-      "description": "Erdős #1031 studies induced regular subgraphs in graphs below the Ramsey threshold. The interplay between degree regularity and extremal thresholds is shared with #1033's analysis of degree sums in triangles near the Turán threshold.",
+      "description": "Erd\u0151s #1031 studies induced regular subgraphs in graphs below the Ramsey threshold. The interplay between degree regularity and extremal thresholds is shared with #1033's analysis of degree sums in triangles near the Tur\u00e1n threshold.",
       "targetId": "erdos-1031"
     }
   ],
   "references": [
     {
       "authors": [
-        "P. Erdős",
+        "P. Erd\u0151s",
         "R. Laskar"
       ],
       "title": "A note on the size of a chordal subgraph",
       "venue": "Congressus Numerantium",
       "year": "1985",
-      "note": "Original paper introducing h(n) and establishing both the upper bound 2(√3−1)n and an initial lower bound for the degree-sum problem."
+      "note": "Original paper introducing h(n) and establishing both the upper bound 2(\u221a3\u22121)n and an initial lower bound for the degree-sum problem."
     },
     {
       "authors": [
@@ -253,41 +253,41 @@
       "venue": "Journal of Graph Theory",
       "volume": "12",
       "year": "1988",
-      "pages": "249–263",
-      "note": "Improves the lower bound to h(n) ≥ (21/16)n via careful degree-counting arguments in triangles above the Turán threshold."
+      "pages": "249\u2013263",
+      "note": "Improves the lower bound to h(n) \u2265 (21/16)n via careful degree-counting arguments in triangles above the Tur\u00e1n threshold."
     },
     {
       "authors": [
-        "P. Turán"
+        "P. Tur\u00e1n"
       ],
       "title": "On an extremal problem in graph theory",
-      "venue": "Matematikai és Fizikai Lapok",
+      "venue": "Matematikai \u00e9s Fizikai Lapok",
       "volume": "48",
       "year": "1941",
-      "pages": "436–452",
-      "note": "Foundational result proving that every graph on n vertices with more than n²/4 edges contains a triangle, establishing the threshold that underlies the entire h(n) problem."
+      "pages": "436\u2013452",
+      "note": "Foundational result proving that every graph on n vertices with more than n\u00b2/4 edges contains a triangle, establishing the threshold that underlies the entire h(n) problem."
     },
     {
       "authors": [
-        "B. Bollobás"
+        "B. Bollob\u00e1s"
       ],
       "title": "Extremal Graph Theory",
       "venue": "Academic Press, London",
       "year": "1978",
-      "note": "Comprehensive treatment of Turán-type problems, extremal thresholds, and degree-sum methods in graphs. Standard reference for the techniques used in proving bounds on h(n)."
+      "note": "Comprehensive treatment of Tur\u00e1n-type problems, extremal thresholds, and degree-sum methods in graphs. Standard reference for the techniques used in proving bounds on h(n)."
     },
     {
       "authors": [
-        "T. Kővári",
-        "V.T. Sós",
-        "P. Turán"
+        "T. K\u0151v\u00e1ri",
+        "V.T. S\u00f3s",
+        "P. Tur\u00e1n"
       ],
       "title": "On a problem of K. Zarankiewicz",
       "venue": "Colloquium Mathematicum",
       "volume": "3",
       "year": "1954",
-      "pages": "50–57",
-      "note": "Kővári–Sós–Turán theorem on bipartite subgraph densities; the nearly-bipartite structure of Turán graph T(n,2) that achieves the upper bound in the h(n) problem relies on bipartite extremal results from this line of work."
+      "pages": "50\u201357",
+      "note": "K\u0151v\u00e1ri\u2013S\u00f3s\u2013Tur\u00e1n theorem on bipartite subgraph densities; the nearly-bipartite structure of Tur\u00e1n graph T(n,2) that achieves the upper bound in the h(n) problem relies on bipartite extremal results from this line of work."
     }
   ],
   "leanFile": {
@@ -303,7 +303,7 @@
       "Finset"
     ],
     "namespace": "Erdos1033",
-    "lineCount": 1016,
+    "lineCount": 1018,
     "axiomCount": 3,
     "theoremCount": 16,
     "definitionCount": 17,

--- a/src/data/proofs/erdos-577/meta.json
+++ b/src/data/proofs/erdos-577/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-577",
-  "title": "Erdős Problem #577: Vertex-Disjoint 4-Cycles in Dense Graphs",
+  "title": "Erd\u0151s Problem #577: Vertex-Disjoint 4-Cycles in Dense Graphs",
   "slug": "erdos-577",
-  "description": "If G is a graph with 4k vertices and minimum degree at least 2k, must G contain k vertex-disjoint 4-cycles? SOLVED by Wang (2010): YES, the Erdős-Faudree conjecture is true.",
+  "description": "If G is a graph with 4k vertices and minimum degree at least 2k, must G contain k vertex-disjoint 4-cycles? SOLVED by Wang (2010): YES, the Erd\u0151s-Faudree conjecture is true.",
   "meta": {
-    "author": "Erdős, Faudree, Wang",
+    "author": "Erd\u0151s, Faudree, Wang",
     "sourceUrl": "https://erdosproblems.com/577",
     "date": "2010",
     "status": "axiomatized",
@@ -44,25 +44,25 @@
       "degree_bound_sharp: sharpness result"
     ],
     "axiomCount": 1,
-    "lineCount": 197,
+    "lineCount": 192,
     "assumptions": "1 axiom: wang_theorem. 0 sorries."
   },
   "overview": {
-    "historicalContext": "Erdős and Faudree conjectured in 1985 that graphs with 4k vertices and minimum degree at least 2k contain k vertex-disjoint 4-cycles (quadrilaterals). This conjecture belongs to a rich family of 'cycle partition' problems in extremal graph theory, with roots in Dirac's theorem (1952) that δ(G) ≥ n/2 implies Hamiltonicity. The Corrádi-Hajnal theorem (1963) established the triangle case: 3k vertices with δ(G) ≥ 2k contain k vertex-disjoint triangles. El-Zahar (1984) proposed the general conjecture for mixed cycle lengths. The Erdős-Faudree conjecture is notable because the degree threshold 2k = n/2 exactly matches the Dirac threshold — unlike the Corrádi-Hajnal case where 2k on 3k vertices gives δ ≥ 2n/3 (above Dirac). After 25 years open, Hong Wang completely resolved the conjecture in a 45-page proof published in Graphs and Combinatorics (2010). Wang's approach analyzes minimal counterexamples, studying the neighborhood structure of high-degree vertices and using greedy cycle extraction with careful bookkeeping to derive contradictions. The degree bound 2k is sharp: there exist counterexample graphs with δ = 2k - 1.",
+    "historicalContext": "Erd\u0151s and Faudree conjectured in 1985 that graphs with 4k vertices and minimum degree at least 2k contain k vertex-disjoint 4-cycles (quadrilaterals). This conjecture belongs to a rich family of 'cycle partition' problems in extremal graph theory, with roots in Dirac's theorem (1952) that \u03b4(G) \u2265 n/2 implies Hamiltonicity. The Corr\u00e1di-Hajnal theorem (1963) established the triangle case: 3k vertices with \u03b4(G) \u2265 2k contain k vertex-disjoint triangles. El-Zahar (1984) proposed the general conjecture for mixed cycle lengths. The Erd\u0151s-Faudree conjecture is notable because the degree threshold 2k = n/2 exactly matches the Dirac threshold \u2014 unlike the Corr\u00e1di-Hajnal case where 2k on 3k vertices gives \u03b4 \u2265 2n/3 (above Dirac). After 25 years open, Hong Wang completely resolved the conjecture in a 45-page proof published in Graphs and Combinatorics (2010). Wang's approach analyzes minimal counterexamples, studying the neighborhood structure of high-degree vertices and using greedy cycle extraction with careful bookkeeping to derive contradictions. The degree bound 2k is sharp: there exist counterexample graphs with \u03b4 = 2k - 1.",
     "problemStatement": "If G is a graph with 4k vertices and minimum degree at least 2k, must G contain k vertex-disjoint 4-cycles?",
-    "text": "If G is a graph with 4k vertices and minimum degree at least 2k, must G contain k vertex-disjoint 4-cycles? SOLVED by Wang (2010): YES, the Erdős-Faudree conjecture is true.",
-    "proofStrategy": "The formalization defines FourCycle as a Lean structure with 4 distinct vertices and 4 edges forming a cycle, then builds vertex sets, disjointness predicates, and pairwise disjointness. The Erdős-Faudree conjecture is stated as a Prop universally quantifying over all finite simple graphs. Wang's theorem is axiomatized, and two consequences are derived: the base case k=1 (from Wang's theorem with norm_num) and the final resolution erdos_577. Sharpness is axiomatized separately. Related results (Dirac, El-Zahar, Corrádi-Hajnal) are documented as comments.",
+    "text": "If G is a graph with 4k vertices and minimum degree at least 2k, must G contain k vertex-disjoint 4-cycles? SOLVED by Wang (2010): YES, the Erd\u0151s-Faudree conjecture is true.",
+    "proofStrategy": "The formalization defines FourCycle as a Lean structure with 4 distinct vertices and 4 edges forming a cycle, then builds vertex sets, disjointness predicates, and pairwise disjointness. The Erd\u0151s-Faudree conjecture is stated as a Prop universally quantifying over all finite simple graphs. Wang's theorem is axiomatized, and two consequences are derived: the base case k=1 (from Wang's theorem with norm_num) and the final resolution erdos_577. Sharpness is axiomatized separately. Related results (Dirac, El-Zahar, Corr\u00e1di-Hajnal) are documented as comments.",
     "keyInsights": [
       "**Dirac threshold is exact**: The condition $\\delta(G) \\geq 2k = n/2$ on $4k$ vertices is exactly the Dirac Hamiltonicity threshold, and it suffices for the much stronger $C_4$-partition property",
-      "**Degree bound is sharp**: Cannot weaken to $\\delta(G) \\geq 2k - 1$ — counterexamples exist for every $k$",
-      "**Cycle partition hierarchy**: Corrádi-Hajnal (1963, triangles) → Erdős-Faudree (1985/2010, quadrilaterals) → El-Zahar (1984, general, still open)",
+      "**Degree bound is sharp**: Cannot weaken to $\\delta(G) \\geq 2k - 1$ \u2014 counterexamples exist for every $k$",
+      "**Cycle partition hierarchy**: Corr\u00e1di-Hajnal (1963, triangles) \u2192 Erd\u0151s-Faudree (1985/2010, quadrilaterals) \u2192 El-Zahar (1984, general, still open)",
       "**25-year proof gap**: The conjecture required 25 years and a 45-page proof by Wang, reflecting the difficulty of upgrading Hamiltonicity to cycle partitions",
-      "**Structural method**: Wang's proof uses minimal counterexample analysis and neighborhood structure — no algebraic or probabilistic techniques"
+      "**Structural method**: Wang's proof uses minimal counterexample analysis and neighborhood structure \u2014 no algebraic or probabilistic techniques"
     ],
     "prerequisites": [
       "Combinatorics and number theory",
       "Graph theory (vertices, edges, colorings)",
-      "Extremal graph theory (Turán-type problems)"
+      "Extremal graph theory (Tur\u00e1n-type problems)"
     ]
   },
   "sections": [
@@ -92,7 +92,7 @@
     },
     {
       "id": "conjecture",
-      "title": "Erdős-Faudree Conjecture",
+      "title": "Erd\u0151s-Faudree Conjecture",
       "summary": "Formal statement: $\\forall k > 0$, if $|V| = 4k$ and $\\delta(G) \\geq 2k$, then $\\exists$ $k$ pairwise vertex-disjoint $C_4$'s",
       "startLine": 75,
       "endLine": 93,
@@ -117,10 +117,10 @@
     {
       "id": "related",
       "title": "Related Results",
-      "summary": "Connections to Dirac's theorem ($\\delta \\geq n/2 \\Rightarrow$ Hamiltonian), El-Zahar's conjecture (general cycle lengths), and Corrádi-Hajnal ($C_3$ partition)",
+      "summary": "Connections to Dirac's theorem ($\\delta \\geq n/2 \\Rightarrow$ Hamiltonian), El-Zahar's conjecture (general cycle lengths), and Corr\u00e1di-Hajnal ($C_3$ partition)",
       "startLine": 141,
       "endLine": 164,
-      "mathContext": "Connections to Dirac's theorem ($\\$\\delta$ \\geq n/2 \\Rightarrow$ Hamiltonian), El-Zahar's conjecture (general cycle lengths), and Corrádi-Hajnal ($C_3$ partition)"
+      "mathContext": "Connections to Dirac's theorem ($\\$\\delta$ \\geq n/2 \\Rightarrow$ Hamiltonian), El-Zahar's conjecture (general cycle lengths), and Corr\u00e1di-Hajnal ($C_3$ partition)"
     },
     {
       "id": "techniques",
@@ -140,21 +140,21 @@
     }
   ],
   "references": [
-    "Wang, H. (2010). 'Proof of the Erdős-Faudree conjecture on quadrilaterals.' Graphs and Combinatorics, 26(6), 833–877.",
-    "Erdős, P. and Faudree, R.J. (1985). 'On a class of degenerate extremal graph problems.' Combinatorica, 5(2), 99–108.",
-    "Corrádi, K. and Hajnal, A. (1963). 'On the maximal number of independent circuits in a graph.' Acta Math. Acad. Sci. Hungar., 14, 423–439.",
-    "El-Zahar, M.H. (1984). 'On circuits in graphs.' Discrete Math., 50, 227–230.",
-    "Dirac, G.A. (1952). 'Some theorems on abstract graphs.' Proc. London Math. Soc., 3(2), 69–81.",
+    "Wang, H. (2010). 'Proof of the Erd\u0151s-Faudree conjecture on quadrilaterals.' Graphs and Combinatorics, 26(6), 833\u2013877.",
+    "Erd\u0151s, P. and Faudree, R.J. (1985). 'On a class of degenerate extremal graph problems.' Combinatorica, 5(2), 99\u2013108.",
+    "Corr\u00e1di, K. and Hajnal, A. (1963). 'On the maximal number of independent circuits in a graph.' Acta Math. Acad. Sci. Hungar., 14, 423\u2013439.",
+    "El-Zahar, M.H. (1984). 'On circuits in graphs.' Discrete Math., 50, 227\u2013230.",
+    "Dirac, G.A. (1952). 'Some theorems on abstract graphs.' Proc. London Math. Soc., 3(2), 69\u201381.",
     "https://erdosproblems.com/577"
   ],
   "conclusion": {
-    "summary": "Erdős Problem #577 (the Erdős-Faudree conjecture) was SOLVED by Hong Wang in 2010 after 25 years open. The result establishes that graphs with 4k vertices and minimum degree at least 2k contain k vertex-disjoint 4-cycles. The Lean formalization defines the FourCycle structure, disjointness predicates, and the conjecture as a universally quantified Prop, with Wang's theorem axiomatized and the final resolution derived. The degree bound 2k is proved sharp.",
-    "implications": "**Theoretical Significance**: Wang's theorem confirms the C₄ case of the cycle partition program, validating a special case of El-Zahar's general conjecture.\n\nThe result shows that the Dirac threshold δ ≥ n/2 — originally sufficient only for Hamiltonicity — actually guarantees the much stronger partition-into-quadrilaterals property. The structural proof technique (minimal counterexample with neighborhood analysis) has influenced subsequent work on cycle decomposition problems.",
+    "summary": "Erd\u0151s Problem #577 (the Erd\u0151s-Faudree conjecture) was SOLVED by Hong Wang in 2010 after 25 years open. The result establishes that graphs with 4k vertices and minimum degree at least 2k contain k vertex-disjoint 4-cycles. The Lean formalization defines the FourCycle structure, disjointness predicates, and the conjecture as a universally quantified Prop, with Wang's theorem axiomatized and the final resolution derived. The degree bound 2k is proved sharp.",
+    "implications": "**Theoretical Significance**: Wang's theorem confirms the C\u2084 case of the cycle partition program, validating a special case of El-Zahar's general conjecture.\n\nThe result shows that the Dirac threshold \u03b4 \u2265 n/2 \u2014 originally sufficient only for Hamiltonicity \u2014 actually guarantees the much stronger partition-into-quadrilaterals property. The structural proof technique (minimal counterexample with neighborhood analysis) has influenced subsequent work on cycle decomposition problems.",
     "openQuestions": [
-      "Does El-Zahar's conjecture hold in full generality for all cycle length sequences (n₁, ..., nₖ)?",
+      "Does El-Zahar's conjecture hold in full generality for all cycle length sequences (n\u2081, ..., n\u2096)?",
       "Can Wang's proof be simplified or shortened from its current 45 pages?",
       "Is there a polynomial-time algorithm to explicitly find the k vertex-disjoint 4-cycles?",
-      "What is the minimum degree threshold for vertex-disjoint C₅ partitions on 5k vertices?"
+      "What is the minimum degree threshold for vertex-disjoint C\u2085 partitions on 5k vertices?"
     ]
   },
   "leanFile": {
@@ -168,7 +168,7 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos577",
-    "lineCount": 197,
+    "lineCount": 192,
     "axiomCount": 1,
     "theoremCount": 3,
     "definitionCount": 7,
@@ -179,17 +179,17 @@
     {
       "targetId": "erdos-64",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: cycles, extremal-graph-theory, graph-theory, minimum-degree"
+      "description": "Related Erd\u0151s problem sharing themes: cycles, extremal-graph-theory, graph-theory, minimum-degree"
     },
     {
       "targetId": "erdos-1035",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: extremal-graph-theory, graph-theory, minimum-degree"
+      "description": "Related Erd\u0151s problem sharing themes: extremal-graph-theory, graph-theory, minimum-degree"
     },
     {
       "targetId": "erdos-1080",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: cycles, extremal-graph-theory, graph-theory"
+      "description": "Related Erd\u0151s problem sharing themes: cycles, extremal-graph-theory, graph-theory"
     }
   ],
   "sorries": 0

--- a/src/data/proofs/erdos-601/meta.json
+++ b/src/data/proofs/erdos-601/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-601",
-  "title": "Erdős #601: Infinite Paths and Independent Sets in Ordinal Graphs",
+  "title": "Erd\u0151s #601: Infinite Paths and Independent Sets in Ordinal Graphs",
   "slug": "erdos-601",
-  "description": "For which limit ordinals α must every graph on α have infinite path OR independent set of order type α? Known for α < ω₁^{ω+2}. Prize: $500.",
+  "description": "For which limit ordinals \u03b1 must every graph on \u03b1 have infinite path OR independent set of order type \u03b1? Known for \u03b1 < \u03c9\u2081^{\u03c9+2}. Prize: $500.",
   "meta": {
-    "author": "Paul Erdős, András Hajnal, Eric Milner, Jean Larson",
+    "author": "Paul Erd\u0151s, Andr\u00e1s Hajnal, Eric Milner, Jean Larson",
     "sourceUrl": "https://erdosproblems.com/601",
     "date": "1970",
     "status": "axiomatized",
@@ -52,7 +52,7 @@
       "IsIndependent: independence predicate",
       "HasOrderType: order type of vertex subsets",
       "PropertyP: path-vs-independent-set dichotomy",
-      "criticalOrdinal: ω₁^{ω+2} definition",
+      "criticalOrdinal: \u03c9\u2081^{\u03c9+2} definition",
       "erdos_hajnal_milner: main theorem (1970)",
       "CriticalCaseConjecture: $250 prize problem",
       "MartinsAxiom: set-theoretic axiom",
@@ -61,7 +61,7 @@
       "GeneralConjecture: $500 prize problem"
     ],
     "axiomCount": 4,
-    "lineCount": 262,
+    "lineCount": 259,
     "assumptions": "4 axioms: critical_case_open, MartinsAxiom, ordinal_ramsey, general_conjecture_open. 10 sorries remain."
   },
   "sections": [
@@ -107,7 +107,7 @@
     },
     {
       "id": "ehm",
-      "title": "Erdős-Hajnal-Milner Theorem (1970)",
+      "title": "Erd\u0151s-Hajnal-Milner Theorem (1970)",
       "summary": "Defines `criticalOrdinal` $= \\omega_1^{\\omega+2}$ and axiomatizes the main result: $P(\\alpha)$ holds for all $\\alpha < \\omega_1^{\\omega+2}$. The proof uses transfinite induction on Cantor normal form.",
       "startLine": 88,
       "endLine": 101,
@@ -116,10 +116,10 @@
     {
       "id": "critical",
       "title": "The Critical Case: $\\omega_1^{\\omega+2}$ ($250)",
-      "summary": "States the `CriticalCaseConjecture`: does $P(\\omega_1^{\\omega+2})$ hold? This is the exact boundary where the Erdős-Hajnal-Milner induction breaks down. \\$250 prize.",
+      "summary": "States the `CriticalCaseConjecture`: does $P(\\omega_1^{\\omega+2})$ hold? This is the exact boundary where the Erd\u0151s-Hajnal-Milner induction breaks down. \\$250 prize.",
       "startLine": 102,
       "endLine": 116,
-      "mathContext": "Bound: States the `CriticalCaseConjecture`: does $P(\\omega_1^{\\omega+2})$ hold? This is the exact boundary where the Erdős-Hajnal-Milner induction breaks down. \\$250 prize."
+      "mathContext": "Bound: States the `CriticalCaseConjecture`: does $P(\\omega_1^{\\omega+2})$ hold? This is the exact boundary where the Erd\u0151s-Hajnal-Milner induction breaks down. \\$250 prize."
     },
     {
       "id": "martins-axiom",
@@ -140,10 +140,10 @@
     {
       "id": "graph-tools",
       "title": "Graph-Theoretic Tools",
-      "summary": "States König's lemma (infinite finitely-branching trees have rays) and ordinal Ramsey partition regularity for large ordinals.",
+      "summary": "States K\u00f6nig's lemma (infinite finitely-branching trees have rays) and ordinal Ramsey partition regularity for large ordinals.",
       "startLine": 152,
       "endLine": 165,
-      "mathContext": "Mathematical content: States König's lemma (infinite finitely-branching trees have rays) and ordinal Ramsey partition regularity for large ordinals."
+      "mathContext": "Mathematical content: States K\u00f6nig's lemma (infinite finitely-branching trees have rays) and ordinal Ramsey partition regularity for large ordinals."
     },
     {
       "id": "independence",
@@ -163,13 +163,13 @@
     }
   ],
   "overview": {
-    "historicalContext": "**Infinite Graph Theory and Ordinal Dichotomies (1970-1990)**\n\n**Erdős, Hajnal, and Milner** posed this problem around 1970 as part of their systematic study of infinite graphs on ordinal vertex sets. The question asks whether every graph on a limit ordinal $\\alpha$ must exhibit a fundamental dichotomy: either it contains an **infinite path** (ray) or an **independent set of order type $\\alpha$**. This connects graph theory with set theory and ordinal arithmetic.\n\nThe landmark result is the **Erdős-Hajnal-Milner theorem (1970)**: Property $P(\\alpha)$ holds for all $\\alpha < \\omega_1^{\\omega+2}$. The proof uses transfinite induction on the Cantor normal form of $\\alpha$, with the inductive step becoming increasingly difficult as the ordinal exponent grows. The boundary $\\omega_1^{\\omega+2}$ marks the point where the induction breaks down.\n\n**Larson (1990)** extended the result under **Martin's Axiom**: assuming MA, $P(\\alpha)$ holds for all $\\alpha$ with cardinality $< 2^{\\aleph_0}$. This showed the problem has deep connections to set-theoretic axioms beyond ZFC. The critical case $P(\\omega_1^{\\omega+2})$ carries a $250 prize, and the general conjecture carries $500.",
-    "problemStatement": "**Open Problem ($500 Prize)**\n\nFor which limit ordinals $\\alpha$ is it true that every graph with vertex set $\\alpha$ must have either an infinite path or an independent set of order type $\\alpha$? The conjecture is that this holds for **all** limit ordinals.\n\nThe critical test case is $\\alpha = \\omega_1^{\\omega+2}$ ($250 prize), the exact boundary of the Erdős-Hajnal-Milner theorem.",
-    "text": "For which limit ordinals α must every graph on α have infinite path OR independent set of order type α? Known for α < ω₁^{ω+2}. Prize: $500.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Core definitions:** Define ordinal graphs, infinite paths, independent sets with order types, and the property $P(\\alpha)$.\n2. **Base cases:** Prove $P(n)$ for finite $n$ (trivial) and $P(\\omega)$ (via Ramsey's theorem).\n3. **Main theorem:** Axiomatize the Erdős-Hajnal-Milner theorem for $\\alpha < \\omega_1^{\\omega+2}$.\n4. **Critical case:** State the $250 conjecture at $\\omega_1^{\\omega+2}$.\n5. **Martin's Axiom:** Axiomatize MA and Larson's extension to $|\\alpha| < 2^{\\aleph_0}$.\n6. **General conjecture:** State the $500 conjecture for all limit ordinals.\n7. **Supporting tools:** Ordinal hierarchy, König's lemma, independence number, transfinite induction.",
+    "historicalContext": "**Infinite Graph Theory and Ordinal Dichotomies (1970-1990)**\n\n**Erd\u0151s, Hajnal, and Milner** posed this problem around 1970 as part of their systematic study of infinite graphs on ordinal vertex sets. The question asks whether every graph on a limit ordinal $\\alpha$ must exhibit a fundamental dichotomy: either it contains an **infinite path** (ray) or an **independent set of order type $\\alpha$**. This connects graph theory with set theory and ordinal arithmetic.\n\nThe landmark result is the **Erd\u0151s-Hajnal-Milner theorem (1970)**: Property $P(\\alpha)$ holds for all $\\alpha < \\omega_1^{\\omega+2}$. The proof uses transfinite induction on the Cantor normal form of $\\alpha$, with the inductive step becoming increasingly difficult as the ordinal exponent grows. The boundary $\\omega_1^{\\omega+2}$ marks the point where the induction breaks down.\n\n**Larson (1990)** extended the result under **Martin's Axiom**: assuming MA, $P(\\alpha)$ holds for all $\\alpha$ with cardinality $< 2^{\\aleph_0}$. This showed the problem has deep connections to set-theoretic axioms beyond ZFC. The critical case $P(\\omega_1^{\\omega+2})$ carries a $250 prize, and the general conjecture carries $500.",
+    "problemStatement": "**Open Problem ($500 Prize)**\n\nFor which limit ordinals $\\alpha$ is it true that every graph with vertex set $\\alpha$ must have either an infinite path or an independent set of order type $\\alpha$? The conjecture is that this holds for **all** limit ordinals.\n\nThe critical test case is $\\alpha = \\omega_1^{\\omega+2}$ ($250 prize), the exact boundary of the Erd\u0151s-Hajnal-Milner theorem.",
+    "text": "For which limit ordinals \u03b1 must every graph on \u03b1 have infinite path OR independent set of order type \u03b1? Known for \u03b1 < \u03c9\u2081^{\u03c9+2}. Prize: $500.",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Core definitions:** Define ordinal graphs, infinite paths, independent sets with order types, and the property $P(\\alpha)$.\n2. **Base cases:** Prove $P(n)$ for finite $n$ (trivial) and $P(\\omega)$ (via Ramsey's theorem).\n3. **Main theorem:** Axiomatize the Erd\u0151s-Hajnal-Milner theorem for $\\alpha < \\omega_1^{\\omega+2}$.\n4. **Critical case:** State the $250 conjecture at $\\omega_1^{\\omega+2}$.\n5. **Martin's Axiom:** Axiomatize MA and Larson's extension to $|\\alpha| < 2^{\\aleph_0}$.\n6. **General conjecture:** State the $500 conjecture for all limit ordinals.\n7. **Supporting tools:** Ordinal hierarchy, K\u00f6nig's lemma, independence number, transfinite induction.",
     "keyInsights": [
-      "**Erdős-Hajnal-Milner (1970):** $P(\\alpha)$ holds for all $\\alpha < \\omega_1^{\\omega+2}$ via transfinite induction on Cantor normal form",
-      "**Critical boundary:** The induction breaks at $\\omega_1^{\\omega+2}$ due to the complexity of the exponent $\\omega + 2$ — new techniques are needed",
+      "**Erd\u0151s-Hajnal-Milner (1970):** $P(\\alpha)$ holds for all $\\alpha < \\omega_1^{\\omega+2}$ via transfinite induction on Cantor normal form",
+      "**Critical boundary:** The induction breaks at $\\omega_1^{\\omega+2}$ due to the complexity of the exponent $\\omega + 2$ \u2014 new techniques are needed",
       "**Larson (1990):** Under Martin's Axiom, $P(\\alpha)$ extends to all $\\alpha$ with $|\\alpha| < 2^{\\aleph_0}$, showing set-theoretic dependence",
       "**Ramsey-type dichotomy:** The problem generalizes the infinite Ramsey theorem from $\\omega$ to arbitrary ordinals with order type requirements",
       "**Two-tier prize:** $250 for the critical case $P(\\omega_1^{\\omega+2})$, $500 for the full generalization to all limit ordinals"
@@ -181,13 +181,13 @@
     ]
   },
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem #601 on the path-vs-independent-set dichotomy for ordinal graphs. The Erdős-Hajnal-Milner theorem (1970) establishes $P(\\alpha)$ for $\\alpha < \\omega_1^{\\omega+2}$, and Larson (1990) extends this under Martin's Axiom. The critical case $\\alpha = \\omega_1^{\\omega+2}$ and the general conjecture for all limit ordinals remain open, with $250 and $500 prizes respectively.",
-    "implications": "**Theoretical Significance**: **Implications**\n\n1. **Infinite combinatorics:** Resolution would illuminate the structure of infinite graphs on ordinal vertex sets and the role of ordinal arithmetic in graph theory.\n**2. Set theory connections:** Larson's result suggests the answer may depend on set-theoretic axioms — the problem may be independent of ZFC.\n3. **Partition calculus:** The techniques connect to the broader Erdős-Rado partition calculus and ordinal Ramsey theory.\n4. **Structural graph theory:** Would establish a fundamental dichotomy principle for infinite graphs, analogous to finite Ramsey theory.",
+    "summary": "This formalization captures Erd\u0151s Problem #601 on the path-vs-independent-set dichotomy for ordinal graphs. The Erd\u0151s-Hajnal-Milner theorem (1970) establishes $P(\\alpha)$ for $\\alpha < \\omega_1^{\\omega+2}$, and Larson (1990) extends this under Martin's Axiom. The critical case $\\alpha = \\omega_1^{\\omega+2}$ and the general conjecture for all limit ordinals remain open, with $250 and $500 prizes respectively.",
+    "implications": "**Theoretical Significance**: **Implications**\n\n1. **Infinite combinatorics:** Resolution would illuminate the structure of infinite graphs on ordinal vertex sets and the role of ordinal arithmetic in graph theory.\n**2. Set theory connections:** Larson's result suggests the answer may depend on set-theoretic axioms \u2014 the problem may be independent of ZFC.\n3. **Partition calculus:** The techniques connect to the broader Erd\u0151s-Rado partition calculus and ordinal Ramsey theory.\n4. **Structural graph theory:** Would establish a fundamental dichotomy principle for infinite graphs, analogous to finite Ramsey theory.",
     "openQuestions": [
-      "Does P(ω₁^{ω+2}) hold? ($250 — the critical boundary case)",
-      "Does P(α) hold for all limit ordinals α? ($500 — the general conjecture)",
+      "Does P(\u03c9\u2081^{\u03c9+2}) hold? ($250 \u2014 the critical boundary case)",
+      "Does P(\u03b1) hold for all limit ordinals \u03b1? ($500 \u2014 the general conjecture)",
       "Is the answer independent of ZFC (provable under MA but not in ZFC alone)?",
-      "Can the Erdős-Hajnal-Milner bound ω₁^{ω+2} be improved in ZFC?",
+      "Can the Erd\u0151s-Hajnal-Milner bound \u03c9\u2081^{\u03c9+2} be improved in ZFC?",
       "What happens for singular cardinals and their ordinal powers?"
     ]
   },
@@ -205,7 +205,7 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos601",
-    "lineCount": 262,
+    "lineCount": 259,
     "axiomCount": 4,
     "theoremCount": 19,
     "definitionCount": 13,
@@ -215,17 +215,17 @@
   "references": [
     {
       "key": "EHM70",
-      "citation": "Erdős, Paul, Hajnal, András, and Milner, Eric C., On sets of almost disjoint subsets of a set, Acta Math. Acad. Sci. Hungar. 19 (1968/1970), 209-218.",
+      "citation": "Erd\u0151s, Paul, Hajnal, Andr\u00e1s, and Milner, Eric C., On sets of almost disjoint subsets of a set, Acta Math. Acad. Sci. Hungar. 19 (1968/1970), 209-218.",
       "type": "paper"
     },
     {
       "key": "La90",
-      "citation": "Larson, Jean A., A short proof of a partition theorem for the ordinal ω^ω, Ann. Pure Appl. Logic 48 (1990), 253-255.",
+      "citation": "Larson, Jean A., A short proof of a partition theorem for the ordinal \u03c9^\u03c9, Ann. Pure Appl. Logic 48 (1990), 253-255.",
       "type": "paper"
     },
     {
       "key": "EH77",
-      "citation": "Erdős, Paul and Hajnal, András, Unsolved problems in set theory, Proc. Sympos. Pure Math. 13 (1977), 17-48.",
+      "citation": "Erd\u0151s, Paul and Hajnal, Andr\u00e1s, Unsolved problems in set theory, Proc. Sympos. Pure Math. 13 (1977), 17-48.",
       "type": "paper"
     },
     {
@@ -235,7 +235,7 @@
     },
     {
       "key": "EP",
-      "citation": "Erdős Problems, Problem #601, https://erdosproblems.com/601.",
+      "citation": "Erd\u0151s Problems, Problem #601, https://erdosproblems.com/601.",
       "type": "website"
     }
   ],
@@ -243,17 +243,17 @@
     {
       "targetId": "erdos-111",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: graph-theory, open, set-theory"
+      "description": "Related Erd\u0151s problem sharing themes: graph-theory, open, set-theory"
     },
     {
       "targetId": "erdos-1169",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: graph-theory, open, set-theory"
+      "description": "Related Erd\u0151s problem sharing themes: graph-theory, open, set-theory"
     },
     {
       "targetId": "erdos-1174",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: graph-theory, open, set-theory"
+      "description": "Related Erd\u0151s problem sharing themes: graph-theory, open, set-theory"
     }
   ],
   "sorries": 10

--- a/src/data/proofs/erdos-666/meta.json
+++ b/src/data/proofs/erdos-666/meta.json
@@ -57,7 +57,7 @@
       "GeneralizedConjecture: open question for C_{2k}"
     ],
     "axiomCount": 1,
-    "lineCount": 270,
+    "lineCount": 263,
     "assumptions": "1 axiom: chung_1992. 1 sorries."
   },
   "overview": {
@@ -165,7 +165,7 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos666",
-    "lineCount": 270,
+    "lineCount": 263,
     "axiomCount": 1,
     "theoremCount": 4,
     "definitionCount": 10,

--- a/src/data/proofs/erdos-688/meta.json
+++ b/src/data/proofs/erdos-688/meta.json
@@ -2,9 +2,9 @@
   "id": "erdos-688",
   "title": "Covering by Large Prime Congruences",
   "slug": "erdos-688",
-  "description": "Define εₙ as the max ε such that choosing one residue class per prime in (n^ε, n] covers [1,n]. Estimate εₙ; is εₙ = o(1)? Erdős showed εₙ ≫ (log log log n)/(log log n).",
+  "description": "Define \u03b5\u2099 as the max \u03b5 such that choosing one residue class per prime in (n^\u03b5, n] covers [1,n]. Estimate \u03b5\u2099; is \u03b5\u2099 = o(1)? Erd\u0151s showed \u03b5\u2099 \u226b (log log log n)/(log log n).",
   "meta": {
-    "author": "Erdős",
+    "author": "Erd\u0151s",
     "sourceUrl": "https://erdosproblems.com/688",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos688Problem.lean",
@@ -26,7 +26,7 @@
       "erdos-689"
     ],
     "axiomCount": 0,
-    "lineCount": 129,
+    "lineCount": 126,
     "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean."
   },
   "sections": [
@@ -35,8 +35,8 @@
       "title": "Problem Statement and Background",
       "startLine": 1,
       "endLine": 18,
-      "summary": "Module docstring introducing Erdős Problem #688: define the covering exponent $\\varepsilon_n$ and estimate it. Cites Erdős's 1979 lower bound $\\varepsilon_n \\gg (\\log\\log\\log n)/(\\log\\log n)$ and notes the problem is open.",
-      "mathContext": "Module docstring introducing Erdős Problem #688: define the covering exponent $\\varepsilon_n$ and estimate it. Cites Erdős's 1979 lower bound $\\varepsilon_n \\gg (\\log\\log\\log n)/(\\log\\log n)$ and notes the problem is open."
+      "summary": "Module docstring introducing Erd\u0151s Problem #688: define the covering exponent $\\varepsilon_n$ and estimate it. Cites Erd\u0151s's 1979 lower bound $\\varepsilon_n \\gg (\\log\\log\\log n)/(\\log\\log n)$ and notes the problem is open.",
+      "mathContext": "Module docstring introducing Erd\u0151s Problem #688: define the covering exponent $\\varepsilon_n$ and estimate it. Cites Erd\u0151s's 1979 lower bound $\\varepsilon_n \\gg (\\log\\log\\log n)/(\\log\\log n)$ and notes the problem is open."
     },
     {
       "id": "imports",
@@ -67,8 +67,8 @@
       "title": "Known Bounds",
       "startLine": 61,
       "endLine": 72,
-      "summary": "Erdős's lower bound $\\varepsilon_n \\ge c \\cdot (\\log\\log\\log n)/(\\log\\log n)$ via counting/probabilistic argument, and the trivial upper bound $\\varepsilon_n < 1$.",
-      "mathContext": "Erdős's lower bound $\\varepsilon_n \\ge c \\cdot (\\log\\log\\$\\log n$)/(\\log\\$\\log n$)$ via counting/probabilistic argument, and the trivial upper bound $\\varepsilon_n < 1$."
+      "summary": "Erd\u0151s's lower bound $\\varepsilon_n \\ge c \\cdot (\\log\\log\\log n)/(\\log\\log n)$ via counting/probabilistic argument, and the trivial upper bound $\\varepsilon_n < 1$.",
+      "mathContext": "Erd\u0151s's lower bound $\\varepsilon_n \\ge c \\cdot (\\log\\log\\$\\log n$)/(\\log\\$\\log n$)$ via counting/probabilistic argument, and the trivial upper bound $\\varepsilon_n < 1$."
     },
     {
       "id": "per-prime-coverage",
@@ -104,15 +104,15 @@
     }
   ],
   "overview": {
-    "historicalContext": "Erdős posed this problem in 1979 (paper Er79d) as part of his extensive study of covering systems and the interplay between prime distribution and modular arithmetic. Classical covering systems, studied by Erdős since the 1950s (with his celebrated conjecture that the minimum modulus of a covering system is bounded, resolved by Hough in 2015), use all moduli. Problem #688 restricts to prime moduli in a specific range (n^ε, n], asking how 'local' the primes can be while still covering an interval. The key analytic input is Mertens' theorem (1874): the sum of prime reciprocals up to x is log log x + M + o(1), where M ≈ 0.2615 is the Meissel-Mertens constant. This gives the total coverage capacity ∑ n/p ≈ n · log(1/ε) for primes in (n^ε, n]. Erdős proved that εₙ ≫ (log log log n)/(log log n), a bound involving triply-iterated logarithms — characteristic of number-theoretic extremal problems. The conjecture εₙ = o(1) remains open and connects to Problems #687 (covering with one class per prime up to n) and #689 (similar questions for composite moduli). The problem also has a dual relationship to sieve theory, where one excludes rather than includes residue classes.",
+    "historicalContext": "Erd\u0151s posed this problem in 1979 (paper Er79d) as part of his extensive study of covering systems and the interplay between prime distribution and modular arithmetic. Classical covering systems, studied by Erd\u0151s since the 1950s (with his celebrated conjecture that the minimum modulus of a covering system is bounded, resolved by Hough in 2015), use all moduli. Problem #688 restricts to prime moduli in a specific range (n^\u03b5, n], asking how 'local' the primes can be while still covering an interval. The key analytic input is Mertens' theorem (1874): the sum of prime reciprocals up to x is log log x + M + o(1), where M \u2248 0.2615 is the Meissel-Mertens constant. This gives the total coverage capacity \u2211 n/p \u2248 n \u00b7 log(1/\u03b5) for primes in (n^\u03b5, n]. Erd\u0151s proved that \u03b5\u2099 \u226b (log log log n)/(log log n), a bound involving triply-iterated logarithms \u2014 characteristic of number-theoretic extremal problems. The conjecture \u03b5\u2099 = o(1) remains open and connects to Problems #687 (covering with one class per prime up to n) and #689 (similar questions for composite moduli). The problem also has a dual relationship to sieve theory, where one excludes rather than includes residue classes.",
     "problemStatement": "Define $\\varepsilon_n$ as the supremum of $\\varepsilon \\in (0,1)$ for which there exists a choice of one residue class $a_p \\pmod{p}$ for each prime $p \\in (n^\\varepsilon, n]$ such that every integer in $[1, n]$ lies in at least one chosen class. Is $\\varepsilon_n = o(1)$?",
-    "text": "Define εₙ as the max ε such that choosing one residue class per prime in (n^ε, n] covers [1,n]. Estimate εₙ; is εₙ = o(1)? Erdős showed εₙ ≫ (log log log n)/(log log n).",
-    "proofStrategy": "The formalization defines covering assignments as dependent functions from primes to their residue classes, the interval coverage predicate, the prime range set, and the covering exponent via supremum. It axiomatizes the main conjecture (εₙ → 0 via Filter.Tendsto), Erdős's lower bound, and structural properties including Mertens' coverage estimate, monotonicity, full prime covering, and sieve duality.",
+    "text": "Define \u03b5\u2099 as the max \u03b5 such that choosing one residue class per prime in (n^\u03b5, n] covers [1,n]. Estimate \u03b5\u2099; is \u03b5\u2099 = o(1)? Erd\u0151s showed \u03b5\u2099 \u226b (log log log n)/(log log n).",
+    "proofStrategy": "The formalization defines covering assignments as dependent functions from primes to their residue classes, the interval coverage predicate, the prime range set, and the covering exponent via supremum. It axiomatizes the main conjecture (\u03b5\u2099 \u2192 0 via Filter.Tendsto), Erd\u0151s's lower bound, and structural properties including Mertens' coverage estimate, monotonicity, full prime covering, and sieve duality.",
     "keyInsights": [
-      "**Mertens' theorem is the key tool**: $\\sum_{n^\\varepsilon < p \\le n} 1/p \\approx \\log(1/\\varepsilon)$, so the total coverage capacity grows logarithmically as $\\varepsilon \\to 0$ — just barely enough to potentially cover $[1, n]$ with careful class choices",
-      "**Iterated logarithm lower bound**: Erdős's bound $\\varepsilon_n \\gg (\\log\\log\\log n)/(\\log\\log n)$ shows the covering exponent decreases extremely slowly, if at all",
+      "**Mertens' theorem is the key tool**: $\\sum_{n^\\varepsilon < p \\le n} 1/p \\approx \\log(1/\\varepsilon)$, so the total coverage capacity grows logarithmically as $\\varepsilon \\to 0$ \u2014 just barely enough to potentially cover $[1, n]$ with careful class choices",
+      "**Iterated logarithm lower bound**: Erd\u0151s's bound $\\varepsilon_n \\gg (\\log\\log\\log n)/(\\log\\log n)$ shows the covering exponent decreases extremely slowly, if at all",
       "**Covering vs. sieving duality**: Including one class per prime to cover is dual to excluding one class per prime to sieve; this connects to Legendre's sieve and the Brun-Selberg machinery",
-      "**CRT independence**: By the Chinese Remainder Theorem, residues modulo distinct primes are independent, making probabilistic arguments viable — a random assignment covers each $m$ with probability $1 - \\prod(1-1/p)$",
+      "**CRT independence**: By the Chinese Remainder Theorem, residues modulo distinct primes are independent, making probabilistic arguments viable \u2014 a random assignment covers each $m$ with probability $1 - \\prod(1-1/p)$",
       "**Connected cluster**: Problems #687, #688, #689 form a family studying covering by prime congruence classes with different range restrictions"
     ],
     "prerequisites": [
@@ -121,12 +121,12 @@
     ]
   },
   "conclusion": {
-    "summary": "Formalizes Erdős Problem #688 on covering intervals [1, n] using one residue class per prime in (n^ε, n]. The covering exponent εₙ measures how 'local' the primes can be while maintaining coverage. Erdős's iterated-logarithm lower bound εₙ ≫ (log log log n)/(log log n) is the best known; whether εₙ → 0 remains open after 47 years.",
-    "implications": "Understanding εₙ reveals the covering power of large primes and connects three fundamental areas: the distribution of primes (via PNT and Mertens), the structure of covering systems (via CRT and inclusion-exclusion), and sieve theory (via the covering-sieving duality). A resolution would also inform the design of efficient hash functions and pseudorandom generators based on modular arithmetic.",
+    "summary": "Formalizes Erd\u0151s Problem #688 on covering intervals [1, n] using one residue class per prime in (n^\u03b5, n]. The covering exponent \u03b5\u2099 measures how 'local' the primes can be while maintaining coverage. Erd\u0151s's iterated-logarithm lower bound \u03b5\u2099 \u226b (log log log n)/(log log n) is the best known; whether \u03b5\u2099 \u2192 0 remains open after 47 years.",
+    "implications": "Understanding \u03b5\u2099 reveals the covering power of large primes and connects three fundamental areas: the distribution of primes (via PNT and Mertens), the structure of covering systems (via CRT and inclusion-exclusion), and sieve theory (via the covering-sieving duality). A resolution would also inform the design of efficient hash functions and pseudorandom generators based on modular arithmetic.",
     "openQuestions": [
-      "Is εₙ = o(1), as Erdős conjectured? Can the lower bound be improved beyond the triply-iterated logarithm?",
-      "What is the true order of magnitude of εₙ — is it closer to 1/log log n or to (log log log n)/(log log n)?",
-      "Can the Lovász Local Lemma or entropy compression give better probabilistic bounds for the covering?",
+      "Is \u03b5\u2099 = o(1), as Erd\u0151s conjectured? Can the lower bound be improved beyond the triply-iterated logarithm?",
+      "What is the true order of magnitude of \u03b5\u2099 \u2014 is it closer to 1/log log n or to (log log log n)/(log log n)?",
+      "Can the Lov\u00e1sz Local Lemma or entropy compression give better probabilistic bounds for the covering?",
       "How does the answer change if multiple residue classes per prime are allowed (Problem #689 variant)?"
     ]
   },
@@ -136,7 +136,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 129,
+    "lineCount": 126,
     "axiomCount": 0,
     "theoremCount": 3,
     "definitionCount": 4,
@@ -144,7 +144,7 @@
     "sorries": 0
   },
   "references": [
-    "Erdős (1979): Problems and results on combinatorial number theory III (Er79d)",
+    "Erd\u0151s (1979): Problems and results on combinatorial number theory III (Er79d)",
     "Mertens (1874): Ein Beitrag zur analytischen Zahlentheorie (prime reciprocal sums)",
     "Harborth (1986): On the covering number (covering systems with large moduli)",
     "Halberstam & Richert (1974): Sieve Methods (sieve-covering duality)",
@@ -155,12 +155,12 @@
     {
       "targetId": "erdos-281",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: congruences, covering systems, number theory"
+      "description": "Related Erd\u0151s problem sharing themes: congruences, covering systems, number theory"
     },
     {
       "targetId": "erdos-687",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: covering systems, number theory, sieve theory"
+      "description": "Related Erd\u0151s problem sharing themes: covering systems, number theory, sieve theory"
     }
   ],
   "sorries": 0

--- a/src/data/proofs/erdos-736/meta.json
+++ b/src/data/proofs/erdos-736/meta.json
@@ -2,9 +2,9 @@
   "id": "erdos-736",
   "title": "Chromatic Numbers and Finite Subgraph Inheritance",
   "slug": "erdos-736",
-  "description": "Taylor's conjecture: If G has chromatic number ℵ₁, can we build graphs of any chromatic number using only finite subgraphs of G? Komjáth-Shelah showed this is independent of ZFC - it can fail in some models.",
+  "description": "Taylor's conjecture: If G has chromatic number \u2135\u2081, can we build graphs of any chromatic number using only finite subgraphs of G? Komj\u00e1th-Shelah showed this is independent of ZFC - it can fail in some models.",
   "meta": {
-    "author": "Walter Taylor (conjecture), Komjáth-Shelah (consistency result)",
+    "author": "Walter Taylor (conjecture), Komj\u00e1th-Shelah (consistency result)",
     "sourceUrl": "https://erdosproblems.com/736",
     "date": "2005",
     "status": "formalized",
@@ -46,44 +46,44 @@
       },
       {
         "theorem": "aleph",
-        "description": "Aleph cardinals (ℵ₀, ℵ₁, etc.)",
+        "description": "Aleph cardinals (\u2135\u2080, \u2135\u2081, etc.)",
         "module": "Mathlib.SetTheory.Cardinal.Ordinal"
       }
     ],
     "originalContributions": [
       "Lean formalization of chromatic number for infinite graphs",
       "Formal statement of Taylor's conjecture using cardinals",
-      "Generalized conjecture for arbitrary uncountable κ",
-      "Formalization of Komjáth-Shelah consistency result",
-      "Related De Bruijn-Erdős theorem statement"
+      "Generalized conjecture for arbitrary uncountable \u03ba",
+      "Formalization of Komj\u00e1th-Shelah consistency result",
+      "Related De Bruijn-Erd\u0151s theorem statement"
     ],
     "dateAdded": "2026-01-19",
     "axiomCount": 0,
     "assumptions": "0 axiom declarations. All former axioms (komjath_shelah_consistency, taylor_conjecture_independent, de_bruijn_erdos, chromatic_compactness, chromatic_cardinal_interaction, countable_case) now proved as theorems or definitions. 1 sorry remains in finite_case.",
-    "lineCount": 207,
+    "lineCount": 203,
     "theoremCount": 2,
     "prerequisites": [
-      "Set-theoretic graph theory: infinite chromatic numbers (ℵ₁, ℵ₂)",
-      "De Bruijn-Erdős theorem: compactness for finite chromatic numbers",
+      "Set-theoretic graph theory: infinite chromatic numbers (\u2135\u2081, \u2135\u2082)",
+      "De Bruijn-Erd\u0151s theorem: compactness for finite chromatic numbers",
       "ZFC independence: forcing and consistency results",
       "Subgraph containment and finite approximation"
     ]
   },
   "overview": {
-    "historicalContext": "Walter Taylor conjectured that if a graph G has chromatic number ℵ₁, then its finite subgraphs are 'rich enough' to build graphs of any chromatic number. Komjáth and Shelah (2005) proved this is independent of ZFC, showing in some models there exists a counterexample where the bound is ℵ₂. The background to this problem lies in the De Bruijn-Erdős theorem (1951), which established that for finite chromatic numbers, colorability is determined entirely by finite subgraphs. Erdős was fascinated by whether similar compactness principles extend to uncountable chromatic numbers, and Taylor's conjecture was one attempt to make that precise at the ℵ₁ level. The Komjáth-Shelah independence result places this question firmly at the boundary between combinatorics and set-theoretic forcing.",
-    "problemStatement": "Let G be a graph with chromatic number ℵ₁. Is there, for every cardinal m, some graph G_m of chromatic number m such that every finite subgraph of G_m is a subgraph of G?",
-    "text": "Taylor's conjecture: If G has chromatic number ℵ₁, can we build graphs of any chromatic number using only finite subgraphs of G? Komjáth-Shelah showed this is independent of ZFC - it can fail in some models.",
-    "proofStrategy": "The formalization defines chromatic number for infinite graphs, states Taylor's conjecture formally, and axiomatizes the Komjáth-Shelah consistency result showing independence from ZFC.",
+    "historicalContext": "Walter Taylor conjectured that if a graph G has chromatic number \u2135\u2081, then its finite subgraphs are 'rich enough' to build graphs of any chromatic number. Komj\u00e1th and Shelah (2005) proved this is independent of ZFC, showing in some models there exists a counterexample where the bound is \u2135\u2082. The background to this problem lies in the De Bruijn-Erd\u0151s theorem (1951), which established that for finite chromatic numbers, colorability is determined entirely by finite subgraphs. Erd\u0151s was fascinated by whether similar compactness principles extend to uncountable chromatic numbers, and Taylor's conjecture was one attempt to make that precise at the \u2135\u2081 level. The Komj\u00e1th-Shelah independence result places this question firmly at the boundary between combinatorics and set-theoretic forcing.",
+    "problemStatement": "Let G be a graph with chromatic number \u2135\u2081. Is there, for every cardinal m, some graph G_m of chromatic number m such that every finite subgraph of G_m is a subgraph of G?",
+    "text": "Taylor's conjecture: If G has chromatic number \u2135\u2081, can we build graphs of any chromatic number using only finite subgraphs of G? Komj\u00e1th-Shelah showed this is independent of ZFC - it can fail in some models.",
+    "proofStrategy": "The formalization defines chromatic number for infinite graphs, states Taylor's conjecture formally, and axiomatizes the Komj\u00e1th-Shelah consistency result showing independence from ZFC.",
     "keyInsights": [
       "The problem connects finite combinatorics to infinite graph theory",
       "Independence from ZFC means the answer depends on set-theoretic axioms",
-      "Komjáth-Shelah: In some models, χ(H) ≤ ℵ₂ for all H with G's finite subgraphs",
-      "The De Bruijn-Erdős theorem provides a compactness principle for finite chromatic numbers",
-      "The gap between finite and uncountable chromatic numbers is fundamental: finite χ is computable from finite subgraphs, but uncountable χ requires genuinely infinite combinatorics"
+      "Komj\u00e1th-Shelah: In some models, \u03c7(H) \u2264 \u2135\u2082 for all H with G's finite subgraphs",
+      "The De Bruijn-Erd\u0151s theorem provides a compactness principle for finite chromatic numbers",
+      "The gap between finite and uncountable chromatic numbers is fundamental: finite \u03c7 is computable from finite subgraphs, but uncountable \u03c7 requires genuinely infinite combinatorics"
     ],
     "prerequisites": [
-      "Set-theoretic graph theory: infinite chromatic numbers (ℵ₁, ℵ₂)",
-      "De Bruijn-Erdős theorem: compactness for finite chromatic numbers",
+      "Set-theoretic graph theory: infinite chromatic numbers (\u2135\u2081, \u2135\u2082)",
+      "De Bruijn-Erd\u0151s theorem: compactness for finite chromatic numbers",
       "ZFC independence: forcing and consistency results",
       "Subgraph containment and finite approximation"
     ]
@@ -95,7 +95,7 @@
       "startLine": 1,
       "endLine": 44,
       "summary": "Module docstring documenting the problem statement, background, and references; 6 Mathlib imports covering required modules; `open` declarations (Cardinal SimpleGraph); namespace `Erdos736`",
-      "mathContext": "Let G be a graph with chromatic number ℵ₁. Is there, for every cardinal m, some graph G_m of chromatic number m such that every finite subgraph of G_m is a subgraph of G?"
+      "mathContext": "Let G be a graph with chromatic number \u2135\u2081. Is there, for every cardinal m, some graph G_m of chromatic number m such that every finite subgraph of G_m is a subgraph of G?"
     },
     {
       "id": "basic-definitions",
@@ -115,27 +115,27 @@
     },
     {
       "id": "general-question",
-      "title": "Erdős's General Question",
+      "title": "Erd\u0151s's General Question",
       "startLine": 112,
       "endLine": 139,
       "summary": "Characterizing realizable families of finite graphs",
-      "mathContext": "$\\mathcal{F}$ is realizable at $\\aleph_\\alpha$ iff $\\exists G: \\chi(G) = \\aleph_\\alpha \\wedge \\{\\text{fin. subgraphs of } G\\} = \\mathcal{F}$. Erdős's generalization: characterize which families $\\mathcal{F}$ are realizable at each cardinal."
+      "mathContext": "$\\mathcal{F}$ is realizable at $\\aleph_\\alpha$ iff $\\exists G: \\chi(G) = \\aleph_\\alpha \\wedge \\{\\text{fin. subgraphs of } G\\} = \\mathcal{F}$. Erd\u0151s's generalization: characterize which families $\\mathcal{F}$ are realizable at each cardinal."
     },
     {
       "id": "consistency-result",
-      "title": "Komjáth-Shelah Consistency",
+      "title": "Komj\u00e1th-Shelah Consistency",
       "startLine": 140,
       "endLine": 166,
-      "summary": "Independence from ZFC and the ℵ₂ bound",
-      "mathContext": "$\\text{Con}(\\text{ZFC} + \\exists G: \\chi(G) = \\aleph_1 \\wedge \\forall H\\,(\\text{fin. sub. of } H \\subseteq \\text{fin. sub. of } G \\implies \\chi(H) \\le \\aleph_2))$. Komjáth-Shelah: Taylor's conjecture is independent of ZFC."
+      "summary": "Independence from ZFC and the \u2135\u2082 bound",
+      "mathContext": "$\\text{Con}(\\text{ZFC} + \\exists G: \\chi(G) = \\aleph_1 \\wedge \\forall H\\,(\\text{fin. sub. of } H \\subseteq \\text{fin. sub. of } G \\implies \\chi(H) \\le \\aleph_2))$. Komj\u00e1th-Shelah: Taylor's conjecture is independent of ZFC."
     },
     {
       "id": "related-concepts",
       "title": "Related Concepts",
       "startLine": 167,
       "endLine": 197,
-      "summary": "De Bruijn-Erdős theorem and chromatic compactness",
-      "mathContext": "De Bruijn-Erdős: $(\\forall \\text{finite } S \\subseteq V,\\, G[S] \\text{ is } k\\text{-colorable}) \\implies \\chi(G) \\le k$. Finite chromatic number IS determined by finite subgraphs, but infinite ones may not be."
+      "summary": "De Bruijn-Erd\u0151s theorem and chromatic compactness",
+      "mathContext": "De Bruijn-Erd\u0151s: $(\\forall \\text{finite } S \\subseteq V,\\, G[S] \\text{ is } k\\text{-colorable}) \\implies \\chi(G) \\le k$. Finite chromatic number IS determined by finite subgraphs, but infinite ones may not be."
     },
     {
       "id": "special-cases",
@@ -147,12 +147,12 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #736 is OPEN but shown to be independent of ZFC. Taylor's conjecture asking whether ℵ₁-chromatic graphs contain enough finite structure to build arbitrary chromatic numbers cannot be decided in ZFC alone.",
+    "summary": "Erd\u0151s Problem #736 is OPEN but shown to be independent of ZFC. Taylor's conjecture asking whether \u2135\u2081-chromatic graphs contain enough finite structure to build arbitrary chromatic numbers cannot be decided in ZFC alone.",
     "implications": "This problem demonstrates the deep connection between combinatorics and set theory. The chromatic number of infinite graphs depends on foundational axioms beyond ZFC.",
     "openQuestions": [
       "What additional axioms make Taylor's conjecture true?",
-      "Can the ℵ₂ bound in the Komjáth-Shelah result be improved?",
-      "Can we characterize realizable families F_α for ℵ_α?"
+      "Can the \u2135\u2082 bound in the Komj\u00e1th-Shelah result be improved?",
+      "Can we characterize realizable families F_\u03b1 for \u2135_\u03b1?"
     ]
   },
   "leanFile": {
@@ -169,7 +169,7 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos736",
-    "lineCount": 207,
+    "lineCount": 203,
     "axiomCount": 0,
     "theoremCount": 2,
     "definitionCount": 9,
@@ -180,17 +180,17 @@
     {
       "targetId": "erdos-1067",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: chromatic-number, graph-theory, infinite-graphs, set-theory"
+      "description": "Related Erd\u0151s problem sharing themes: chromatic-number, graph-theory, infinite-graphs, set-theory"
     },
     {
       "targetId": "erdos-110",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: chromatic-number, graph-theory, infinite-graphs, set-theory"
+      "description": "Related Erd\u0151s problem sharing themes: chromatic-number, graph-theory, infinite-graphs, set-theory"
     },
     {
       "targetId": "erdos-594",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: chromatic-number, graph-theory, infinite-graphs, set-theory"
+      "description": "Related Erd\u0151s problem sharing themes: chromatic-number, graph-theory, infinite-graphs, set-theory"
     }
   ],
   "sorries": 1

--- a/src/data/proofs/erdos-745/meta.json
+++ b/src/data/proofs/erdos-745/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-745",
-  "title": "Erdős Problem #745: Second Largest Component of Random Graphs",
+  "title": "Erd\u0151s Problem #745: Second Largest Component of Random Graphs",
   "slug": "erdos-745",
-  "description": "Describe the second largest component of G(n, 1/n). Answer: It has size Θ(log n) almost surely. Proved by Komlós-Sulyok-Szemerédi (1980).",
+  "description": "Describe the second largest component of G(n, 1/n). Answer: It has size \u0398(log n) almost surely. Proved by Koml\u00f3s-Sulyok-Szemer\u00e9di (1980).",
   "meta": {
-    "author": "Komlós-Sulyok-Szemerédi (1980)",
+    "author": "Koml\u00f3s-Sulyok-Szemer\u00e9di (1980)",
     "sourceUrl": "https://erdosproblems.com/745",
     "date": "1980",
     "status": "axiomatized",
@@ -41,24 +41,24 @@
       "criticalRandomGraph definition: G(n, 1/n)",
       "ComponentSizes, largestComponentSize, secondLargestComponentSize",
       "subcritical_components, supercritical_giant axioms",
-      "critical_giant_size axiom: giant is Θ(n^{2/3})",
+      "critical_giant_size axiom: giant is \u0398(n^{2/3})",
       "komlos_sulyok_szemeredi axiom: second largest is O(log n)",
-      "second_largest_lower_bound axiom: second largest is Ω(log n)",
+      "second_largest_lower_bound axiom: second largest is \u03a9(log n)",
       "erdos_745 theorem: combining upper and lower bounds",
       "critical_window axiom: phase transition width n^{-1/3}"
     ],
     "axiomCount": 0,
-    "lineCount": 312,
-    "assumptions": "0 axioms, 0 sorries. critical_giant_size, komlos_sulyok_szemeredi, second_largest_lower_bound are theorem declarations using True-stub proofs (∃ c, c > 0 ∧ True), not real axiom declarations."
+    "lineCount": 298,
+    "assumptions": "0 axioms, 0 sorries. critical_giant_size, komlos_sulyok_szemeredi, second_largest_lower_bound are theorem declarations using True-stub proofs (\u2203 c, c > 0 \u2227 True), not real axiom declarations."
   },
   "overview": {
-    "historicalContext": "**Erdős Problem #745: Random Graph Components**\n\nThis problem concerns the Erdős-Rényi random graph model G(n, p), one of the foundational models in probabilistic combinatorics.\n\n**Historical Timeline:**\n- 1959-1960: Erdős and Rényi introduce the random graph model G(n, p)\n- 1960: They discover the phase transition at p = 1/n\n- 1960s-70s: The structure of the giant component is studied\n- 1980: Komlós, Sulyok, and Szemerédi prove Erdős's conjecture about the second largest component\n- 1980s-90s: Łuczak and others refine understanding of the critical window\n\n**The Phase Transition:**\nAt p = 1/n, the random graph undergoes a dramatic change:\n- p < 1/n: All components small (size O(log n))\n- p = 1/n: Giant emerges with size Θ(n^{2/3})\n- p > 1/n: Unique giant of size Θ(n)",
-    "problemStatement": "**Problem Statement (Solved)**\n\nDescribe the size of the second largest component of the random graph $G(n, 1/n)$, where each edge is included independently with probability $1/n$.\n\n**Answer:**\nAlmost surely, the second largest component has size $\\Theta(\\log n)$.\n\nMore precisely:\n- Upper bound: second largest $\\leq c \\log n$ w.h.p.\n- Lower bound: second largest $\\geq c' \\log n$ w.h.p.\n\nThis was conjectured by Erdős and proved by Komlós, Sulyok, and Szemerédi in 1980.\n\n**The contrast is striking:**\n- Giant (largest): $\\Theta(n^{2/3})$\n- Second largest: $\\Theta(\\log n)$\n\nThe gap is polynomial!",
-    "text": "Describe the second largest component of G(n, 1/n). Answer: It has size Θ(log n) almost surely. Proved by Komlós-Sulyok-Szemerédi (1980).",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Random Graph Model:** Define G(n, p) structure with edge probability\n\n2. **Critical Threshold:** Define p = 1/n as the critical probability\n\n3. **Phase Transition:** Axiomatize subcritical, critical, and supercritical regimes\n\n4. **Giant Component:** Axiomatize that the giant has size Θ(n^{2/3})\n\n5. **KSS Theorem:** Axiomatize Komlós-Sulyok-Szemerédi result\n\n6. **Main Theorem:** Combine upper and lower bounds\n\n**Why Axioms?** Probability theory and concentration inequalities required for the proof are not fully developed in Mathlib.",
+    "historicalContext": "**Erd\u0151s Problem #745: Random Graph Components**\n\nThis problem concerns the Erd\u0151s-R\u00e9nyi random graph model G(n, p), one of the foundational models in probabilistic combinatorics.\n\n**Historical Timeline:**\n- 1959-1960: Erd\u0151s and R\u00e9nyi introduce the random graph model G(n, p)\n- 1960: They discover the phase transition at p = 1/n\n- 1960s-70s: The structure of the giant component is studied\n- 1980: Koml\u00f3s, Sulyok, and Szemer\u00e9di prove Erd\u0151s's conjecture about the second largest component\n- 1980s-90s: \u0141uczak and others refine understanding of the critical window\n\n**The Phase Transition:**\nAt p = 1/n, the random graph undergoes a dramatic change:\n- p < 1/n: All components small (size O(log n))\n- p = 1/n: Giant emerges with size \u0398(n^{2/3})\n- p > 1/n: Unique giant of size \u0398(n)",
+    "problemStatement": "**Problem Statement (Solved)**\n\nDescribe the size of the second largest component of the random graph $G(n, 1/n)$, where each edge is included independently with probability $1/n$.\n\n**Answer:**\nAlmost surely, the second largest component has size $\\Theta(\\log n)$.\n\nMore precisely:\n- Upper bound: second largest $\\leq c \\log n$ w.h.p.\n- Lower bound: second largest $\\geq c' \\log n$ w.h.p.\n\nThis was conjectured by Erd\u0151s and proved by Koml\u00f3s, Sulyok, and Szemer\u00e9di in 1980.\n\n**The contrast is striking:**\n- Giant (largest): $\\Theta(n^{2/3})$\n- Second largest: $\\Theta(\\log n)$\n\nThe gap is polynomial!",
+    "text": "Describe the second largest component of G(n, 1/n). Answer: It has size \u0398(log n) almost surely. Proved by Koml\u00f3s-Sulyok-Szemer\u00e9di (1980).",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Random Graph Model:** Define G(n, p) structure with edge probability\n\n2. **Critical Threshold:** Define p = 1/n as the critical probability\n\n3. **Phase Transition:** Axiomatize subcritical, critical, and supercritical regimes\n\n4. **Giant Component:** Axiomatize that the giant has size \u0398(n^{2/3})\n\n5. **KSS Theorem:** Axiomatize Koml\u00f3s-Sulyok-Szemer\u00e9di result\n\n6. **Main Theorem:** Combine upper and lower bounds\n\n**Why Axioms?** Probability theory and concentration inequalities required for the proof are not fully developed in Mathlib.",
     "keyInsights": [
       "**Critical Threshold:** At p = 1/n, the random graph is 'on the edge' of containing a giant",
-      "**Giant Size:** At criticality, giant has size Θ(n^{2/3}), not Θ(n) as in supercritical case",
+      "**Giant Size:** At criticality, giant has size \u0398(n^{2/3}), not \u0398(n) as in supercritical case",
       "**Winner Takes All:** The giant is polynomially larger than the second component",
       "**Log n Bound:** All non-giant components are O(log n) in size",
       "**Critical Window:** Phase transition has width n^{-1/3} around p = 1/n",
@@ -104,7 +104,7 @@
     },
     {
       "id": "kss-theorem",
-      "title": "Komlós-Sulyok-Szemerédi Theorem",
+      "title": "Koml\u00f3s-Sulyok-Szemer\u00e9di Theorem",
       "summary": "komlos_sulyok_szemeredi, second_largest bounds, erdos_745 theorem",
       "startLine": 158,
       "endLine": 207,
@@ -136,7 +136,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #745 asked about the second largest component of G(n, 1/n). Erdős conjectured it is O(log n), which was proved by Komlós, Sulyok, and Szemerédi in 1980. The answer is Θ(log n) - dramatically smaller than the giant component of size Θ(n^{2/3}).",
+    "summary": "Erd\u0151s Problem #745 asked about the second largest component of G(n, 1/n). Erd\u0151s conjectured it is O(log n), which was proved by Koml\u00f3s, Sulyok, and Szemer\u00e9di in 1980. The answer is \u0398(log n) - dramatically smaller than the giant component of size \u0398(n^{2/3}).",
     "implications": "**Theoretical Significance**: **Impact on Random Graph Theory**\n\n1. **Phase Transitions:** Demonstrates the dramatic nature of the critical threshold\n\n2. **Winner Takes All:** At criticality, one component dominates all others\n\n**3. Scaling Exponents:** The exponents 2/3 (giant) and log (others) are universal\n\n4. **Percolation Theory:** Foundational for understanding mean-field critical phenomena\n\n5. **Algorithmic Applications:** Finding the giant component is a key subroutine.",
     "openQuestions": [
       "Exact distribution of the second largest component size",
@@ -158,7 +158,7 @@
       "Real"
     ],
     "namespace": "Erdos745",
-    "lineCount": 312,
+    "lineCount": 298,
     "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 7,
@@ -169,17 +169,17 @@
     {
       "targetId": "erdos-747",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: probabilistic-combinatorics, random-graphs, solved"
+      "description": "Related Erd\u0151s problem sharing themes: probabilistic-combinatorics, random-graphs, solved"
     },
     {
       "targetId": "erdos-799",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: probabilistic-combinatorics, random-graphs, solved"
+      "description": "Related Erd\u0151s problem sharing themes: probabilistic-combinatorics, random-graphs, solved"
     },
     {
       "targetId": "erdos-578",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: probabilistic-combinatorics, random-graphs"
+      "description": "Related Erd\u0151s problem sharing themes: probabilistic-combinatorics, random-graphs"
     }
   ],
   "sorries": 0

--- a/src/data/proofs/erdos-789/meta.json
+++ b/src/data/proofs/erdos-789/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-789",
-  "title": "Erdős Problem #789: Sum-Length-Free Subsets",
+  "title": "Erd\u0151s Problem #789: Sum-Length-Free Subsets",
   "slug": "erdos-789",
-  "description": "Estimate h(n) where h(n) is the max |B| such that equal sums in B have equal length. Known: (n log n)^{1/3} ≪ h(n) ≪ √n. Status: OPEN.",
+  "description": "Estimate h(n) where h(n) is the max |B| such that equal sums in B have equal length. Known: (n log n)^{1/3} \u226a h(n) \u226a \u221an. Status: OPEN.",
   "meta": {
-    "author": "Erdős, Straus, Choi",
+    "author": "Erd\u0151s, Straus, Choi",
     "sourceUrl": "https://erdosproblems.com/789",
     "date": "1962-1974",
     "status": "axiomatized",
@@ -48,7 +48,7 @@
       "h function axiom (maximal sum-length-free subset)",
       "h_achievable axiom (existence)",
       "erdos_1962_upper axiom (n^{5/6})",
-      "straus_1966_upper axiom (√n, best upper)",
+      "straus_1966_upper axiom (\u221an, best upper)",
       "erdos_1962_lower axiom (n^{1/3})",
       "erdos_choi_1974_lower axiom ((n log n)^{1/3}, best lower)",
       "combined_bounds theorem",
@@ -60,27 +60,27 @@
     "relatedProblems": [
       {
         "id": "erdos-1109",
-        "relationship": "Related Erdős problem on additive combinatorics and sumset constraints"
+        "relationship": "Related Erd\u0151s problem on additive combinatorics and sumset constraints"
       }
     ],
     "erdosNumber": 789,
     "erdosUrl": "https://erdosproblems.com/789",
     "erdosProblemStatus": "open",
     "axiomCount": 3,
-    "lineCount": 244,
+    "lineCount": 242,
     "assumptions": "3 axioms: h, straus_1966_upper, erdos_choi_1974_lower. 0 sorries."
   },
   "overview": {
-    "historicalContext": "**The Sum-Length-Free Property**\\n\\nA set B is sum-length-free if whenever two sums of elements from B are equal, they must involve the same number of terms. This is weaker than the Sidon property (which requires the actual terms to be equal).\\n\\n**Erdős's Original Work (1962)**\\n\\nErdős proved h(n) ≪ n^{5/6} and h(n) ≫ n^{1/3}. The lower bound used a beautiful probabilistic construction: for random α, the set of elements whose fractional parts {αa} lie in a small interval tends to be sum-length-free.\\n\\n**Straus's Improvement (1966)**\\n\\nStraus dramatically improved the upper bound to h(n) ≪ √n using a clever counting argument on sum representations.\\n\\n**Erdős-Choi (1974)**\\n\\nChoi improved the lower bound to h(n) ≫ (n log n)^{1/3} by refining Erdős's probabilistic argument.\\n\\n**The Gap**\\n\\nThe gap between (n log n)^{1/3} and √n is substantial. For n = 10^6, this is roughly 239 vs 1000. Closing this gap is the main open problem.",
-    "problemStatement": "Let h(n) be maximal such that if A ⊆ ℤ with |A| = n then there is B ⊆ A with |B| ≥ h(n) such that if a₁+⋯+aᵣ = b₁+⋯+bₛ with aᵢ,bᵢ ∈ B then r = s. Estimate h(n).",
-    "text": "Estimate h(n) where h(n) is the max |B| such that equal sums in B have equal length. Known: (n log n)^{1/3} ≪ h(n) ≪ √n. Status: OPEN.",
-    "proofStrategy": "We formalize the sum-length-free property via SumRep structures and the SumLengthFree predicate. The function h(n) is axiomatized with bounds from Straus (upper) and Erdős-Choi (lower). We connect to Sidon sets and show computational examples. The main theorem combines all known bounds.",
+    "historicalContext": "**The Sum-Length-Free Property**\\n\\nA set B is sum-length-free if whenever two sums of elements from B are equal, they must involve the same number of terms. This is weaker than the Sidon property (which requires the actual terms to be equal).\\n\\n**Erd\u0151s's Original Work (1962)**\\n\\nErd\u0151s proved h(n) \u226a n^{5/6} and h(n) \u226b n^{1/3}. The lower bound used a beautiful probabilistic construction: for random \u03b1, the set of elements whose fractional parts {\u03b1a} lie in a small interval tends to be sum-length-free.\\n\\n**Straus's Improvement (1966)**\\n\\nStraus dramatically improved the upper bound to h(n) \u226a \u221an using a clever counting argument on sum representations.\\n\\n**Erd\u0151s-Choi (1974)**\\n\\nChoi improved the lower bound to h(n) \u226b (n log n)^{1/3} by refining Erd\u0151s's probabilistic argument.\\n\\n**The Gap**\\n\\nThe gap between (n log n)^{1/3} and \u221an is substantial. For n = 10^6, this is roughly 239 vs 1000. Closing this gap is the main open problem.",
+    "problemStatement": "Let h(n) be maximal such that if A \u2286 \u2124 with |A| = n then there is B \u2286 A with |B| \u2265 h(n) such that if a\u2081+\u22ef+a\u1d63 = b\u2081+\u22ef+b\u209b with a\u1d62,b\u1d62 \u2208 B then r = s. Estimate h(n).",
+    "text": "Estimate h(n) where h(n) is the max |B| such that equal sums in B have equal length. Known: (n log n)^{1/3} \u226a h(n) \u226a \u221an. Status: OPEN.",
+    "proofStrategy": "We formalize the sum-length-free property via SumRep structures and the SumLengthFree predicate. The function h(n) is axiomatized with bounds from Straus (upper) and Erd\u0151s-Choi (lower). We connect to Sidon sets and show computational examples. The main theorem combines all known bounds.",
     "keyInsights": [
       "Sum-length-free is weaker than Sidon: only length must match",
-      "Upper bound h(n) ≪ √n (Straus 1966) matches Sidon bound",
-      "Lower bound h(n) ≫ (n log n)^{1/3} (Erdős-Choi 1974)",
+      "Upper bound h(n) \u226a \u221an (Straus 1966) matches Sidon bound",
+      "Lower bound h(n) \u226b (n log n)^{1/3} (Erd\u0151s-Choi 1974)",
       "Gap between exponents 1/3 and 1/2 is significant",
-      "Probabilistic construction uses fractional parts {αa}",
+      "Probabilistic construction uses fractional parts {\u03b1a}",
       "Sidon sets are automatically sum-length-free",
       "Related to Problems 186 (sum-free) and 874"
     ],
@@ -109,26 +109,26 @@
     {
       "id": "upper-bounds",
       "title": "Upper Bounds",
-      "summary": "Erdős n^{5/6}, Straus √n (best known)",
+      "summary": "Erd\u0151s n^{5/6}, Straus \u221an (best known)",
       "startLine": 79,
       "endLine": 98,
-      "mathContext": "Erdős n^{5/6}, Straus √n (best known)"
+      "mathContext": "Erd\u0151s n^{5/6}, Straus \u221an (best known)"
     },
     {
       "id": "lower-bounds",
       "title": "Lower Bounds",
-      "summary": "Erdős n^{1/3}, Choi (n log n)^{1/3} (best known)",
+      "summary": "Erd\u0151s n^{1/3}, Choi (n log n)^{1/3} (best known)",
       "startLine": 99,
       "endLine": 121,
-      "mathContext": "Erdős n^{1/3}, Choi (n log n)^{1/3} (best known)"
+      "mathContext": "Erd\u0151s n^{1/3}, Choi (n log n)^{1/3} (best known)"
     },
     {
       "id": "gap",
       "title": "The Gap and Combined Bounds",
-      "summary": "Combined bounds theorem: (n log n)^{1/3} ≪ h(n) ≪ √n",
+      "summary": "Combined bounds theorem: (n log n)^{1/3} \u226a h(n) \u226a \u221an",
       "startLine": 122,
       "endLine": 133,
-      "mathContext": "Combined bounds theorem: (n log n)^{1/3} ≪ h(n) ≪ √n"
+      "mathContext": "Combined bounds theorem: (n log n)^{1/3} \u226a h(n) \u226a \u221an"
     },
     {
       "id": "sidon",
@@ -141,10 +141,10 @@
     {
       "id": "examples",
       "title": "Computational Examples",
-      "summary": "√1000 and √10^6 via native_decide",
+      "summary": "\u221a1000 and \u221a10^6 via native_decide",
       "startLine": 155,
       "endLine": 169,
-      "mathContext": "√1000 and √10^6 via native_decide"
+      "mathContext": "\u221a1000 and \u221a10^6 via native_decide"
     },
     {
       "id": "summary",
@@ -156,12 +156,12 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #789 asks for the growth rate of h(n), the maximum size of a sum-length-free subset. Straus proved h(n) ≪ √n (1966) and Erdős-Choi proved h(n) ≫ (n log n)^{1/3} (1974). The gap between these bounds remains open.",
+    "summary": "Erd\u0151s Problem #789 asks for the growth rate of h(n), the maximum size of a sum-length-free subset. Straus proved h(n) \u226a \u221an (1966) and Erd\u0151s-Choi proved h(n) \u226b (n log n)^{1/3} (1974). The gap between these bounds remains open.",
     "implications": "Understanding h(n) would illuminate the structure of additive combinatorics. The sum-length-free property sits between arbitrary sets and Sidon sets in terms of constraint strength.",
     "openQuestions": [
       "What is the true growth rate of h(n)?",
-      "Is h(n) ~ √n (Straus bound tight)?",
-      "Is h(n) ~ n^α for some 1/3 < α < 1/2?",
+      "Is h(n) ~ \u221an (Straus bound tight)?",
+      "Is h(n) ~ n^\u03b1 for some 1/3 < \u03b1 < 1/2?",
       "Can the probabilistic construction be improved?",
       "What is the connection to other sum problems?"
     ]
@@ -179,7 +179,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos789",
-    "lineCount": 244,
+    "lineCount": 242,
     "axiomCount": 3,
     "theoremCount": 4,
     "definitionCount": 6,
@@ -190,7 +190,7 @@
     {
       "targetId": "erdos-1109",
       "relationship": "related",
-      "description": "Related Erdős problem on additive combinatorics and sumset constraints"
+      "description": "Related Erd\u0151s problem on additive combinatorics and sumset constraints"
     },
     {
       "targetId": "erdos-332",

--- a/src/data/proofs/erdos-856/meta.json
+++ b/src/data/proofs/erdos-856/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-856",
-  "title": "Erdős Problem #856: LCM-Free Sets and Logarithmic Density",
+  "title": "Erd\u0151s Problem #856: LCM-Free Sets and Logarithmic Density",
   "slug": "erdos-856",
   "description": "Estimate f_k(N), the maximum harmonic sum of subsets of {1,...,N} with no k elements having uniform pairwise LCM. Status: OPEN. Bounds relate to sunflower conjecture.",
   "meta": {
-    "author": "Erdős",
+    "author": "Erd\u0151s",
     "sourceUrl": "https://erdosproblems.com/856",
     "date": "1970",
     "status": "axiomatized",
@@ -23,20 +23,20 @@
     "erdosUrl": "https://erdosproblems.com/856",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "lineCount": 267,
+    "lineCount": 260,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries. Open conjecture; supporting lemmas fully verified.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "Erdős posed this problem in 1970 in his paper 'Some extremal problems in combinatorial number theory' dedicated to A. J. Macintyre, asking for the maximum harmonic sum of subsets of $\\{1, \\ldots, N\\}$ that avoid $k$ elements with uniform pairwise LCM. The uniform pairwise LCM condition means every distinct pair $(a, b)$ in the forbidden subset has $\\text{lcm}(a, b) = t$ for the same $t$. Erdős proved $f_k(N) \\ll \\log N / \\log\\log N$ using the observation that for each $t$, the set $\\{a \\in A : \\exists p \\text{ prime},\\, t = ap\\}$ has size $< k$. The problem lay dormant for decades until Tang and Zhang (2025) made significant progress, proving $(\\log N)^{b_k} \\leq f_k(N) \\leq (\\log N)^{c_k}$ for explicit constants $0 < b_k \\leq c_k \\leq 1$, and establishing for $k = 3$ the bounds $(\\log N)^{0.438} \\leq f_3(N) \\leq (\\log N)^{0.889}$. The deep connection to the sunflower conjecture — proved via the Erdős–Ko–Rado theorem and its LCM analogues — shows that $c_k < 1$ if and only if the sunflower conjecture holds for $k$-sunflowers. The sunflower lemma of Erdős and Rado (1960) gives $c_k \\leq 1$, while the conjecture would improve this to $c_k < 1$. Alweiss, Lovett, Wu, and Zhang (2021) made a breakthrough on the sunflower conjecture, which has implications for the upper bound exponents here.",
+    "historicalContext": "Erd\u0151s posed this problem in 1970 in his paper 'Some extremal problems in combinatorial number theory' dedicated to A. J. Macintyre, asking for the maximum harmonic sum of subsets of $\\{1, \\ldots, N\\}$ that avoid $k$ elements with uniform pairwise LCM. The uniform pairwise LCM condition means every distinct pair $(a, b)$ in the forbidden subset has $\\text{lcm}(a, b) = t$ for the same $t$. Erd\u0151s proved $f_k(N) \\ll \\log N / \\log\\log N$ using the observation that for each $t$, the set $\\{a \\in A : \\exists p \\text{ prime},\\, t = ap\\}$ has size $< k$. The problem lay dormant for decades until Tang and Zhang (2025) made significant progress, proving $(\\log N)^{b_k} \\leq f_k(N) \\leq (\\log N)^{c_k}$ for explicit constants $0 < b_k \\leq c_k \\leq 1$, and establishing for $k = 3$ the bounds $(\\log N)^{0.438} \\leq f_3(N) \\leq (\\log N)^{0.889}$. The deep connection to the sunflower conjecture \u2014 proved via the Erd\u0151s\u2013Ko\u2013Rado theorem and its LCM analogues \u2014 shows that $c_k < 1$ if and only if the sunflower conjecture holds for $k$-sunflowers. The sunflower lemma of Erd\u0151s and Rado (1960) gives $c_k \\leq 1$, while the conjecture would improve this to $c_k < 1$. Alweiss, Lovett, Wu, and Zhang (2021) made a breakthrough on the sunflower conjecture, which has implications for the upper bound exponents here.",
     "problemStatement": "Let $k \\geq 3$ and $f_k(N)$ be the maximum value of $\\sum_{n \\in A} 1/n$, where $A$ ranges over all subsets of $\\{1, \\ldots, N\\}$ containing no subset of size $k$ with the same pairwise least common multiple. Estimate $f_k(N)$.",
     "text": "Estimate f_k(N), the maximum harmonic sum of subsets of {1,...,N} with no k elements having uniform pairwise LCM. Status: OPEN. Bounds relate to sunflower conjecture.",
-    "proofStrategy": "The formalization defines LCM, uniform pairwise LCM, $k$-LCM-free sets, and the harmonic sum $\\sum 1/n$. The extremal function $f_k(N)$ is defined via `sSup`. Erdős's 1970 upper bound and Tang–Zhang's 2025 improved bounds are axiomatized. The sunflower conjecture connection is formalized as an equivalence: $c_k < 1 \\iff$ sunflower conjecture for $k$. Examples (divisor sets, prime powers) and the natural density variant $g_k(N)$ are also included. Two results are proved in Lean: LCM commutativity and the divisor set LCM property.",
+    "proofStrategy": "The formalization defines LCM, uniform pairwise LCM, $k$-LCM-free sets, and the harmonic sum $\\sum 1/n$. The extremal function $f_k(N)$ is defined via `sSup`. Erd\u0151s's 1970 upper bound and Tang\u2013Zhang's 2025 improved bounds are axiomatized. The sunflower conjecture connection is formalized as an equivalence: $c_k < 1 \\iff$ sunflower conjecture for $k$. Examples (divisor sets, prime powers) and the natural density variant $g_k(N)$ are also included. Two results are proved in Lean: LCM commutativity and the divisor set LCM property.",
     "keyInsights": [
       "**Harmonic vs. natural density**: The problem measures $f_k(N) = \\max \\sum 1/n$ (logarithmic density) rather than $\\max |A|$ (natural density). This is subtler: for $k \\geq 4$, sets of linear size can avoid the LCM condition, but the harmonic sum is bounded.",
-      "**Erdős's prime factorization trick**: For each $t$, the set $\\{a \\in A : \\exists p \\text{ prime},\\, t = ap\\}$ has $< k$ elements (else $k$ elements have $\\text{lcm} = t$). Summing over primes dividing elements of $A$ yields $f_k(N) \\ll \\log N / \\log\\log N$.",
-      "**Tang–Zhang breakthrough (2025)**: Improved Erdős's bound from $\\log N / \\log\\log N$ to $(\\log N)^{c_k}$ with $c_k \\leq 1$. For $k = 3$: exponents between $0.438$ and $0.889$, leaving a significant gap.",
-      "**Sunflower equivalence**: The upper bound exponent $c_k < 1$ holds if and only if the Erdős–Rado sunflower conjecture holds for $k$-petalled sunflowers. This connects a number-theoretic problem to a purely set-theoretic conjecture.",
+      "**Erd\u0151s's prime factorization trick**: For each $t$, the set $\\{a \\in A : \\exists p \\text{ prime},\\, t = ap\\}$ has $< k$ elements (else $k$ elements have $\\text{lcm} = t$). Summing over primes dividing elements of $A$ yields $f_k(N) \\ll \\log N / \\log\\log N$.",
+      "**Tang\u2013Zhang breakthrough (2025)**: Improved Erd\u0151s's bound from $\\log N / \\log\\log N$ to $(\\log N)^{c_k}$ with $c_k \\leq 1$. For $k = 3$: exponents between $0.438$ and $0.889$, leaving a significant gap.",
+      "**Sunflower equivalence**: The upper bound exponent $c_k < 1$ holds if and only if the Erd\u0151s\u2013Rado sunflower conjecture holds for $k$-petalled sunflowers. This connects a number-theoretic problem to a purely set-theoretic conjecture.",
       "**Divisor structure and LCM**: If $A = \\{d : d \\mid n\\}$, all pairs have $\\text{lcm}(a,b) \\mid n$, creating rich LCM structure. Avoiding uniform LCM subsets constrains how 'divisor-rich' $A$ can be."
     ],
     "prerequisites": [
@@ -50,8 +50,8 @@
       "title": "Problem Statement and Imports",
       "startLine": 1,
       "endLine": 46,
-      "summary": "Header documenting Erdős Problem #856 with full background, key results, and references. Imports `Nat.GCD.Basic`, `Finset.Basic`, `Real.Basic`, `Real.log`, and `BigOperators` for the formalization.",
-      "mathContext": "Mathematical content: Header documenting Erdős Problem #856 with full background, key results, and references. Imports `Nat.GCD.Basic`, `Finset.Basic`, `Real.Basic`, `Real.log`, and `BigOperators` for the formalization."
+      "summary": "Header documenting Erd\u0151s Problem #856 with full background, key results, and references. Imports `Nat.GCD.Basic`, `Finset.Basic`, `Real.Basic`, `Real.log`, and `BigOperators` for the formalization.",
+      "mathContext": "Mathematical content: Header documenting Erd\u0151s Problem #856 with full background, key results, and references. Imports `Nat.GCD.Basic`, `Finset.Basic`, `Real.Basic`, `Real.log`, and `BigOperators` for the formalization."
     },
     {
       "id": "lcm-basics",
@@ -79,7 +79,7 @@
     },
     {
       "id": "erdos-bound",
-      "title": "Erdős 1970 Upper Bound",
+      "title": "Erd\u0151s 1970 Upper Bound",
       "startLine": 108,
       "endLine": 132,
       "summary": "Axiomatizes $f_k(N) \\leq C \\cdot \\log N / \\log\\log N$ for some $C > 0$, and the key lemma: for each $t$, the set $\\{a \\in A : \\exists p \\text{ prime},\\, t = ap\\}$ has $< k$ elements.",
@@ -87,7 +87,7 @@
     },
     {
       "id": "tang-zhang",
-      "title": "Tang–Zhang 2025 Bounds",
+      "title": "Tang\u2013Zhang 2025 Bounds",
       "startLine": 133,
       "endLine": 158,
       "summary": "Axiomatizes $\\exists b_k \\leq c_k$ with $(\\log N)^{b_k - \\varepsilon} \\leq f_k(N) \\leq (\\log N)^{c_k + \\varepsilon}$ for all $\\varepsilon > 0$ eventually. For $k = 3$: $(\\log N)^{0.438} \\leq f_3(N) \\leq (\\log N)^{0.889}$.",
@@ -106,8 +106,8 @@
       "title": "Natural Density Variant",
       "startLine": 197,
       "endLine": 225,
-      "summary": "Defines $g_k(N) = \\max |A|$ over $k$-LCM-free subsets (natural density). Axiomatizes Erdős's result $g_4(N) \\gg N$ and the $k = 3$ variant, connecting to Problem #536.",
-      "mathContext": "Formal definition: Defines $g_k(N) = \\max |A|$ over $k$-LCM-free subsets (natural density). Axiomatizes Erdős's result $g_4(N) \\gg N$ and the $k = 3$ variant, connecting to Problem #536."
+      "summary": "Defines $g_k(N) = \\max |A|$ over $k$-LCM-free subsets (natural density). Axiomatizes Erd\u0151s's result $g_4(N) \\gg N$ and the $k = 3$ variant, connecting to Problem #536.",
+      "mathContext": "Formal definition: Defines $g_k(N) = \\max |A|$ over $k$-LCM-free subsets (natural density). Axiomatizes Erd\u0151s's result $g_4(N) \\gg N$ and the $k = 3$ variant, connecting to Problem #536."
     },
     {
       "id": "examples",
@@ -119,12 +119,12 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #856 formalizes the maximum harmonic sum of k-LCM-free subsets. The Lean file proves LCM properties and the divisor set lemma, axiomatizes Erdős's 1970 bound, Tang–Zhang's 2025 improvement, and the sunflower equivalence. The formalization covers 10 sections across 307 lines.",
-    "implications": "**Theoretical Significance**: Resolution would bridge combinatorial number theory and the sunflower conjecture.\n\nThe equivalence c_k < 1 ⟺ sunflower conjecture shows that progress on either problem implies progress on the other. The Alweiss–Lovett–Wu–Zhang (2021) sunflower breakthrough may lead to improved bounds on f_k(N).",
+    "summary": "Erd\u0151s Problem #856 formalizes the maximum harmonic sum of k-LCM-free subsets. The Lean file proves LCM properties and the divisor set lemma, axiomatizes Erd\u0151s's 1970 bound, Tang\u2013Zhang's 2025 improvement, and the sunflower equivalence. The formalization covers 10 sections across 307 lines.",
+    "implications": "**Theoretical Significance**: Resolution would bridge combinatorial number theory and the sunflower conjecture.\n\nThe equivalence c_k < 1 \u27fa sunflower conjecture shows that progress on either problem implies progress on the other. The Alweiss\u2013Lovett\u2013Wu\u2013Zhang (2021) sunflower breakthrough may lead to improved bounds on f_k(N).",
     "openQuestions": [
       "What is the precise growth exponent $c_k$ for $f_k(N) \\sim (\\log N)^{c_k}$? Is it rational?",
-      "Can the Tang–Zhang gap for $k = 3$ ($0.438 \\leq c_3 \\leq 0.889$) be narrowed?",
-      "Does the Alweiss–Lovett–Wu–Zhang sunflower improvement give a concrete value of $c_k < 1$?",
+      "Can the Tang\u2013Zhang gap for $k = 3$ ($0.438 \\leq c_3 \\leq 0.889$) be narrowed?",
+      "Does the Alweiss\u2013Lovett\u2013Wu\u2013Zhang sunflower improvement give a concrete value of $c_k < 1$?",
       "Is there a polynomial-time algorithm to compute (or approximate) $f_k(N)$ for given $k$ and $N$?"
     ]
   },
@@ -142,7 +142,7 @@
       "Nat"
     ],
     "namespace": "Erdos856",
-    "lineCount": 267,
+    "lineCount": 260,
     "axiomCount": 0,
     "sorries": 0
   },
@@ -150,12 +150,12 @@
     {
       "targetId": "erdos-855",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: number-neighbor"
+      "description": "Related Erd\u0151s problem sharing themes: number-neighbor"
     },
     {
       "targetId": "erdos-857",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: number-neighbor"
+      "description": "Related Erd\u0151s problem sharing themes: number-neighbor"
     }
   ],
   "sorries": 0

--- a/src/data/proofs/erdos-876/meta.json
+++ b/src/data/proofs/erdos-876/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-876",
-  "title": "Erdős Problem #876: Sum-Free Sets and Gap Growth",
+  "title": "Erd\u0151s Problem #876: Sum-Free Sets and Gap Growth",
   "slug": "erdos-876",
-  "description": "For an infinite sum-free set A = {a₁ < a₂ < ⋯}, how small can gaps aₙ₊₁ - aₙ be? Graham showed n^{1+o(1)} is achievable; whether gaps < n is possible remains OPEN.",
+  "description": "For an infinite sum-free set A = {a\u2081 < a\u2082 < \u22ef}, how small can gaps a\u2099\u208a\u2081 - a\u2099 be? Graham showed n^{1+o(1)} is achievable; whether gaps < n is possible remains OPEN.",
   "meta": {
-    "author": "Erdős, Graham, Łuczak-Schoen, Deshouillers-Erdős-Melfi",
+    "author": "Erd\u0151s, Graham, \u0141uczak-Schoen, Deshouillers-Erd\u0151s-Melfi",
     "sourceUrl": "https://erdosproblems.com/876",
     "date": "2000",
     "status": "axiomatized",
@@ -37,28 +37,28 @@
     ],
     "originalContributions": [
       "IsSumFreeErdos definition: no element is sum of distinct predecessors",
-      "IsSumFreeClassical definition: classical x + y ≠ z",
+      "IsSumFreeClassical definition: classical x + y \u2260 z",
       "IsIncreasingEnumeration, gap, HasGapBound, HasLinearGapBound",
       "ErdosQuestion876: the main open question",
-      "graham_result axiom: gaps < n^{1+ε} achievable",
+      "graham_result axiom: gaps < n^{1+\u03b5} achievable",
       "erdos_density_zero axiom: sum-free sets have density zero",
       "luczak_schoen_upper/lower axioms: density bounds",
-      "dem_growth axiom: aₙ ~ n^{3+o(1)} achievable",
+      "dem_growth axiom: a\u2099 ~ n^{3+o(1)} achievable",
       "reciprocalSum definition and sullivan_bound axiom",
       "powers_of_two_sumfree theorem sketch"
     ],
     "axiomCount": 1,
-    "lineCount": 263,
+    "lineCount": 257,
     "assumptions": "1 axiom: graham_result. 2 sorries."
   },
   "overview": {
-    "historicalContext": "**Erdős Problem #876: Sum-Free Sets and Gap Growth**\n\nA **sum-free set** in Erdős's sense is an infinite set $A = \\{a_1 < a_2 < \\cdots\\} \\subset \\mathbb{N}$ where no element equals a sum of distinct smaller elements from $A$. This is strictly stronger than the classical sum-free condition (no $a + b = c$), as it forbids all subset sums, not just pairs.\n\nPaul Erdős proved in 1962 that such sets must have asymptotic density zero, establishing a fundamental sparsity constraint. The natural follow-up question — how sparse must they be? — was pursued through several key developments:\n\n- **Erdős (1962):** Proved density zero and the crude reciprocal sum bound $\\sum_{a \\in A} 1/a < 100$.\n- **Ronald Graham (c. 1998):** Showed that for any $\\varepsilon > 0$, there exists a sum-free set with gaps $a_{n+1} - a_n < n^{1+\\varepsilon}$ for large $n$. This is the best positive result toward the linear gap question.\n- **Jean-Marc Deshouillers, Erdős, and Giuseppe Melfi (1999):** Constructed a sum-free set with $a_n \\sim n^{3+o(1)}$, establishing the cubic growth rate as achievable.\n- **Tomasz Łuczak and Tomasz Schoen (2000):** Proved tight bounds on the counting function: $|A \\cap [1,N]| = O(\\sqrt{N \\log N})$ for any sum-free $A$, and there exists $B$ with $|B \\cap [1,N]| \\gg \\sqrt{N/(\\log N)^{1/2+o(1)}}$.\n- **Steven Sullivan:** Improved Erdős's reciprocal sum bound to $\\sum 1/a < 4$ and conjectured the supremum is slightly above 2.\n\nThe central open question remains: **can the gaps be made linear**, i.e., is $a_{n+1} - a_n < n$ achievable? Graham's result shows we can get arbitrarily close to linear ($n^{1+\\varepsilon}$), suggesting the answer might be yes, but the problem has resisted resolution for over two decades.",
+    "historicalContext": "**Erd\u0151s Problem #876: Sum-Free Sets and Gap Growth**\n\nA **sum-free set** in Erd\u0151s's sense is an infinite set $A = \\{a_1 < a_2 < \\cdots\\} \\subset \\mathbb{N}$ where no element equals a sum of distinct smaller elements from $A$. This is strictly stronger than the classical sum-free condition (no $a + b = c$), as it forbids all subset sums, not just pairs.\n\nPaul Erd\u0151s proved in 1962 that such sets must have asymptotic density zero, establishing a fundamental sparsity constraint. The natural follow-up question \u2014 how sparse must they be? \u2014 was pursued through several key developments:\n\n- **Erd\u0151s (1962):** Proved density zero and the crude reciprocal sum bound $\\sum_{a \\in A} 1/a < 100$.\n- **Ronald Graham (c. 1998):** Showed that for any $\\varepsilon > 0$, there exists a sum-free set with gaps $a_{n+1} - a_n < n^{1+\\varepsilon}$ for large $n$. This is the best positive result toward the linear gap question.\n- **Jean-Marc Deshouillers, Erd\u0151s, and Giuseppe Melfi (1999):** Constructed a sum-free set with $a_n \\sim n^{3+o(1)}$, establishing the cubic growth rate as achievable.\n- **Tomasz \u0141uczak and Tomasz Schoen (2000):** Proved tight bounds on the counting function: $|A \\cap [1,N]| = O(\\sqrt{N \\log N})$ for any sum-free $A$, and there exists $B$ with $|B \\cap [1,N]| \\gg \\sqrt{N/(\\log N)^{1/2+o(1)}}$.\n- **Steven Sullivan:** Improved Erd\u0151s's reciprocal sum bound to $\\sum 1/a < 4$ and conjectured the supremum is slightly above 2.\n\nThe central open question remains: **can the gaps be made linear**, i.e., is $a_{n+1} - a_n < n$ achievable? Graham's result shows we can get arbitrarily close to linear ($n^{1+\\varepsilon}$), suggesting the answer might be yes, but the problem has resisted resolution for over two decades.",
     "problemStatement": "**Problem Statement (Partially Solved)**\n\nLet $A = \\{a_1 < a_2 < \\cdots\\} \\subset \\mathbb{N}$ be an infinite sum-free set, meaning no $a \\in A$ equals $b_1 + b_2 + \\cdots + b_r$ for distinct $b_i \\in A$ with $b_i < a$.\n\n**Questions:**\n1. How small can the gaps $a_{n+1} - a_n$ be?\n2. Is it possible that $a_{n+1} - a_n < n$?\n\n**Known:**\n- Graham: Gaps can be $< n^{1+o(1)}$\n- Main question (linear gaps) is OPEN\n\n**Additional Question:**\nWhat is $\\max \\sum_{a \\in A} 1/a$? Sullivan shows $< 4$, conjectures $\\approx 2$.",
-    "text": "For an infinite sum-free set A = {a₁ < a₂ < ⋯}, how small can gaps aₙ₊₁ - aₙ be? Graham showed n^{1+o(1)} is achievable; whether gaps < n is possible remains OPEN.",
-    "proofStrategy": "**Formalization Approach**\n\nThe formalization distinguishes two sum-free notions and builds toward the open question:\n\n1. **Two Definitions (Lines 49–76):** `IsSumFreeErdos` forbids any subset sum of distinct predecessors equaling an element; `IsSumFreeClassical` only forbids $a + b = c$. The implication `erdos_implies_classical` has a sorry.\n\n2. **Gap Machinery (Lines 84–109):** Defines `gap a n = a(n+1) - a(n)`, `HasGapBound`, and the critical `HasLinearGapBound` condition $a_{n+1} - a_n < n$.\n\n3. **The Open Question (Lines 117–136):** `ErdosQuestion876` existentially asserts a sum-free set with linear gaps. Graham's axiom shows near-linear ($n^{1+\\varepsilon}$) gaps are achievable.\n\n4. **Density and Growth (Lines 142–194):** Axiomatizes Erdős's density-zero result, Łuczak-Schoen's tight counting bounds $\\Theta(\\sqrt{N \\log N})$, and DEM's cubic growth construction.\n\n5. **Reciprocal Sums (Lines 199–226):** Defines `reciprocalSum` via `tsum` and axiomatizes Erdős's bound, Sullivan's improvement, and Sullivan's conjecture.\n\n6. **Examples and Summary (Lines 230–298):** Powers of 2 as a basic sum-free set (sorry in proof), connections to Sidon sets, and the summary theorem.",
+    "text": "For an infinite sum-free set A = {a\u2081 < a\u2082 < \u22ef}, how small can gaps a\u2099\u208a\u2081 - a\u2099 be? Graham showed n^{1+o(1)} is achievable; whether gaps < n is possible remains OPEN.",
+    "proofStrategy": "**Formalization Approach**\n\nThe formalization distinguishes two sum-free notions and builds toward the open question:\n\n1. **Two Definitions (Lines 49\u201376):** `IsSumFreeErdos` forbids any subset sum of distinct predecessors equaling an element; `IsSumFreeClassical` only forbids $a + b = c$. The implication `erdos_implies_classical` has a sorry.\n\n2. **Gap Machinery (Lines 84\u2013109):** Defines `gap a n = a(n+1) - a(n)`, `HasGapBound`, and the critical `HasLinearGapBound` condition $a_{n+1} - a_n < n$.\n\n3. **The Open Question (Lines 117\u2013136):** `ErdosQuestion876` existentially asserts a sum-free set with linear gaps. Graham's axiom shows near-linear ($n^{1+\\varepsilon}$) gaps are achievable.\n\n4. **Density and Growth (Lines 142\u2013194):** Axiomatizes Erd\u0151s's density-zero result, \u0141uczak-Schoen's tight counting bounds $\\Theta(\\sqrt{N \\log N})$, and DEM's cubic growth construction.\n\n5. **Reciprocal Sums (Lines 199\u2013226):** Defines `reciprocalSum` via `tsum` and axiomatizes Erd\u0151s's bound, Sullivan's improvement, and Sullivan's conjecture.\n\n6. **Examples and Summary (Lines 230\u2013298):** Powers of 2 as a basic sum-free set (sorry in proof), connections to Sidon sets, and the summary theorem.",
     "keyInsights": [
-      "**Erdős vs Classical Sum-Free:** The Erdős condition ($\\nexists$ subset sum of predecessors $= a$) is strictly stronger than classical ($a + b \\neq c$). The set $\\{1, 5, 6\\}$ is classically sum-free ($1+5=6$ violates classical!) but illustrates the distinction — Erdős sum-free sets avoid ALL subset sums, making them much sparser.",
-      "**Density-Growth Duality:** The Łuczak-Schoen counting bound $|A \\cap [1,N]| = O(\\sqrt{N \\log N})$ and the DEM growth rate $a_n \\sim n^{3+o(1)}$ are dual perspectives: if $|A \\cap [1,N]| \\sim \\sqrt{N}$, inverting gives $a_n \\sim n^2$. The $\\log N$ correction explains the cubic (rather than quadratic) growth.",
+      "**Erd\u0151s vs Classical Sum-Free:** The Erd\u0151s condition ($\\nexists$ subset sum of predecessors $= a$) is strictly stronger than classical ($a + b \\neq c$). The set $\\{1, 5, 6\\}$ is classically sum-free ($1+5=6$ violates classical!) but illustrates the distinction \u2014 Erd\u0151s sum-free sets avoid ALL subset sums, making them much sparser.",
+      "**Density-Growth Duality:** The \u0141uczak-Schoen counting bound $|A \\cap [1,N]| = O(\\sqrt{N \\log N})$ and the DEM growth rate $a_n \\sim n^{3+o(1)}$ are dual perspectives: if $|A \\cap [1,N]| \\sim \\sqrt{N}$, inverting gives $a_n \\sim n^2$. The $\\log N$ correction explains the cubic (rather than quadratic) growth.",
       "**Graham's Near-Linear Gaps:** Graham's construction achieves gaps $< n^{1+\\varepsilon}$ for any $\\varepsilon > 0$ using a careful recursive procedure that balances element selection with sum-avoidance. The gap between $n^{1+\\varepsilon}$ (achievable) and $n$ (open) represents a fundamental barrier in understanding subset-sum structure.",
       "**Reciprocal Sum as Structure Measure:** The convergence $\\sum 1/a < 4$ (Sullivan) quantifies sparsity differently from density: it says elements grow fast enough that their reciprocals converge. Sullivan's conjecture that the supremum is $\\approx 2$ would determine the precise balance between density and growth.",
       "**Powers of 2 as Base Case:** $\\{1, 2, 4, 8, \\ldots\\}$ is sum-free by uniqueness of binary representation: $2^n$ cannot equal any sum of distinct smaller powers of $2$ since each power contributes to a unique bit. This gives exponential gaps ($2^{n+1} - 2^n = 2^n$), far from linear."
@@ -80,10 +80,10 @@
     {
       "id": "sum-free-sets",
       "title": "Sum-Free Set Definitions",
-      "summary": "Defines `IsSumFreeErdos A`: $\\forall a \\in A,\\; \\forall S \\subseteq A$ with $|S| \\geq 2$ and $\\max S < a$, we have $\\sum S \\neq a$. Defines `IsSumFreeClassical A`: $\\forall a,b \\in A,\\; a+b \\notin A$. Proves (with sorry) that Erdős implies classical.",
+      "summary": "Defines `IsSumFreeErdos A`: $\\forall a \\in A,\\; \\forall S \\subseteq A$ with $|S| \\geq 2$ and $\\max S < a$, we have $\\sum S \\neq a$. Defines `IsSumFreeClassical A`: $\\forall a,b \\in A,\\; a+b \\notin A$. Proves (with sorry) that Erd\u0151s implies classical.",
       "startLine": 43,
       "endLine": 77,
-      "mathContext": "Defines `IsSumFreeErdos A`: $\\forall a \\in A,\\; \\forall S \\subseteq A$ with $|S| \\geq 2$ and $\\max S < a$, we have $\\sum S \\neq a$. Defines `IsSumFreeClassical A`: $\\forall a,b \\in A,\\; a+b \\notin A$. Proves (with sorry) that Erdős implies classical."
+      "mathContext": "Defines `IsSumFreeErdos A`: $\\forall a \\in A,\\; \\forall S \\subseteq A$ with $|S| \\geq 2$ and $\\max S < a$, we have $\\sum S \\neq a$. Defines `IsSumFreeClassical A`: $\\forall a,b \\in A,\\; a+b \\notin A$. Proves (with sorry) that Erd\u0151s implies classical."
     },
     {
       "id": "gap-sequences",
@@ -104,43 +104,43 @@
     {
       "id": "density-results",
       "title": "Density Results",
-      "summary": "Axiomatizes Erdős's density-zero theorem ($|A \\cap [1,N]|/N \\to 0$), Łuczak-Schoen upper bound $|A \\cap [1,N]| \\leq c\\sqrt{N \\log N}$, and lower bound $|B \\cap [1,N]| \\geq \\sqrt{N}/(\\log N)^{1/2+o(1)}$ for an explicit construction $B$.",
+      "summary": "Axiomatizes Erd\u0151s's density-zero theorem ($|A \\cap [1,N]|/N \\to 0$), \u0141uczak-Schoen upper bound $|A \\cap [1,N]| \\leq c\\sqrt{N \\log N}$, and lower bound $|B \\cap [1,N]| \\geq \\sqrt{N}/(\\log N)^{1/2+o(1)}$ for an explicit construction $B$.",
       "startLine": 138,
       "endLine": 172,
-      "mathContext": "Axiomatizes Erdős's density-zero theorem ($|A \\cap [1,N]|/N \\to 0$), Łuczak-Schoen upper bound $|A \\cap [1,N]| \\leq c\\sqrt{N \\log N}$, and lower bound $|B \\cap [1,N]| \\geq \\sqrt{N}/(\\log N)^{1/2+o(1)}$ for an explicit construction $B$."
+      "mathContext": "Axiomatizes Erd\u0151s's density-zero theorem ($|A \\cap [1,N]|/N \\to 0$), \u0141uczak-Schoen upper bound $|A \\cap [1,N]| \\leq c\\sqrt{N \\log N}$, and lower bound $|B \\cap [1,N]| \\geq \\sqrt{N}/(\\log N)^{1/2+o(1)}$ for an explicit construction $B$."
     },
     {
       "id": "growth-rate",
       "title": "Growth Rate: DEM Construction",
-      "summary": "Axiomatizes the Deshouillers-Erdős-Melfi result: $\\exists a$ sum-free with $n^{3-\\varepsilon} < a_n < n^{3+\\varepsilon}$ for large $n$. The cubic exponent relates to the counting function via $a_n \\sim n^3 \\iff |A \\cap [1,N]| \\sim N^{1/3}$.",
+      "summary": "Axiomatizes the Deshouillers-Erd\u0151s-Melfi result: $\\exists a$ sum-free with $n^{3-\\varepsilon} < a_n < n^{3+\\varepsilon}$ for large $n$. The cubic exponent relates to the counting function via $a_n \\sim n^3 \\iff |A \\cap [1,N]| \\sim N^{1/3}$.",
       "startLine": 173,
       "endLine": 194,
-      "mathContext": "Axiomatizes the Deshouillers-Erdős-Melfi result: $\\exists a$ sum-free with $n^{3-\\varepsilon} < a_n < n^{3+\\varepsilon}$ for large $n$. The cubic exponent relates to the counting function via $a_n \\sim n^3 \\iff |A \\cap [1,N]| \\sim N^{1/3}$."
+      "mathContext": "Axiomatizes the Deshouillers-Erd\u0151s-Melfi result: $\\exists a$ sum-free with $n^{3-\\varepsilon} < a_n < n^{3+\\varepsilon}$ for large $n$. The cubic exponent relates to the counting function via $a_n \\sim n^3 \\iff |A \\cap [1,N]| \\sim N^{1/3}$."
     },
     {
       "id": "reciprocal-sum",
       "title": "Reciprocal Sum Bounds",
-      "summary": "Defines `reciprocalSum A = \\sum_{a \\in A,\\, a \\geq 1} 1/a$ via `tsum`. Axiomatizes Erdős's crude bound ($< 100$), Sullivan's improvement ($< 4$), and Sullivan's conjecture ($\\exists A$ with $\\sum 1/a > 2$).",
+      "summary": "Defines `reciprocalSum A = \\sum_{a \\in A,\\, a \\geq 1} 1/a$ via `tsum`. Axiomatizes Erd\u0151s's crude bound ($< 100$), Sullivan's improvement ($< 4$), and Sullivan's conjecture ($\\exists A$ with $\\sum 1/a > 2$).",
       "startLine": 195,
       "endLine": 226,
-      "mathContext": "Defines `reciprocalSum A = \\sum_{a \\in A,\\, a \\geq 1} 1/a$ via `tsum`. Axiomatizes Erdős's crude bound ($< 100$), Sullivan's improvement ($< 4$), and Sullivan's conjecture ($\\exists A$ with $\\sum 1/a > 2$)."
+      "mathContext": "Defines `reciprocalSum A = \\sum_{a \\in A,\\, a \\geq 1} 1/a$ via `tsum`. Axiomatizes Erd\u0151s's crude bound ($< 100$), Sullivan's improvement ($< 4$), and Sullivan's conjecture ($\\exists A$ with $\\sum 1/a > 2$)."
     },
     {
       "id": "examples",
       "title": "Examples and Connections",
-      "summary": "States `powers_of_two_sumfree`: $\\{2^n : n \\in \\mathbb{N}\\}$ is sum-free (sorry — the proof uses binary uniqueness). Notes connections to Sidon sets and $B_h$ sequences.",
+      "summary": "States `powers_of_two_sumfree`: $\\{2^n : n \\in \\mathbb{N}\\}$ is sum-free (sorry \u2014 the proof uses binary uniqueness). Notes connections to Sidon sets and $B_h$ sequences.",
       "startLine": 227,
       "endLine": 263,
-      "mathContext": "States `powers_of_two_sumfree`: $\\{$2^{n}$ : n \\in \\mathbb{N}\\}$ is sum-free (sorry — the proof uses binary uniqueness). Notes connections to Sidon sets and $B_h$ sequences."
+      "mathContext": "States `powers_of_two_sumfree`: $\\{$2^{n}$ : n \\in \\mathbb{N}\\}$ is sum-free (sorry \u2014 the proof uses binary uniqueness). Notes connections to Sidon sets and $B_h$ sequences."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #876 asks how small gaps in infinite sum-free sets can be. Graham showed gaps $< n^{1+\\varepsilon}$ are achievable for any $\\varepsilon > 0$, but whether gaps can be made linear ($< n$) remains open. The counting function is $\\Theta(\\sqrt{N \\log N})$ (Łuczak-Schoen), elements grow as $n^{3+o(1)}$ (DEM), and the reciprocal sum is bounded between 2 and 4 (Sullivan). The formalization has 2 sorry statements in the `erdos_implies_classical` and `powers_of_two_sumfree` proofs.",
-    "implications": "**Theoretical Significance**: **Broader Mathematical Connections**\n\n1. **Schur's Theorem and Ramsey Theory:** Sum-free subsets of $\\{1,\\ldots,N\\}$ are exactly the independent sets avoiding Schur triples $x + y = z$. Schur's theorem (1916) guarantees any $r$-coloring of $[N]$ contains a monochromatic Schur triple for large $N$, so no single color class can be sum-free and cover all of $[N]$.\n\n2. **Subset Sum Problem:** The Erdős sum-free condition is intimately related to the NP-complete Subset Sum problem.\n\nA sum-free set is one where the subset sum problem has no solutions of a specific form, connecting combinatorics to computational complexity.\n\n3. **Binary Representation and Uniqueness:** The powers-of-2 example connects to number representation theory: uniqueness of binary representation is equivalent to sum-freeness of $\\{2^n\\}$, linking to the theory of numeration systems.\n\n4. **Greedy Algorithms:** Sum-free sets can be constructed greedily (add the smallest number not representable as a subset sum of existing elements). The greedy construction gives cubic growth, matching the DEM bound — suggesting the greedy approach is near-optimal.\n\n5. **Probabilistic Methods:** Random constructions provide lower bounds on counting functions and suggest that most sum-free sets have gaps close to $n^{3+o(1)}$, far from the linear gap frontier.",
+    "summary": "Erd\u0151s Problem #876 asks how small gaps in infinite sum-free sets can be. Graham showed gaps $< n^{1+\\varepsilon}$ are achievable for any $\\varepsilon > 0$, but whether gaps can be made linear ($< n$) remains open. The counting function is $\\Theta(\\sqrt{N \\log N})$ (\u0141uczak-Schoen), elements grow as $n^{3+o(1)}$ (DEM), and the reciprocal sum is bounded between 2 and 4 (Sullivan). The formalization has 2 sorry statements in the `erdos_implies_classical` and `powers_of_two_sumfree` proofs.",
+    "implications": "**Theoretical Significance**: **Broader Mathematical Connections**\n\n1. **Schur's Theorem and Ramsey Theory:** Sum-free subsets of $\\{1,\\ldots,N\\}$ are exactly the independent sets avoiding Schur triples $x + y = z$. Schur's theorem (1916) guarantees any $r$-coloring of $[N]$ contains a monochromatic Schur triple for large $N$, so no single color class can be sum-free and cover all of $[N]$.\n\n2. **Subset Sum Problem:** The Erd\u0151s sum-free condition is intimately related to the NP-complete Subset Sum problem.\n\nA sum-free set is one where the subset sum problem has no solutions of a specific form, connecting combinatorics to computational complexity.\n\n3. **Binary Representation and Uniqueness:** The powers-of-2 example connects to number representation theory: uniqueness of binary representation is equivalent to sum-freeness of $\\{2^n\\}$, linking to the theory of numeration systems.\n\n4. **Greedy Algorithms:** Sum-free sets can be constructed greedily (add the smallest number not representable as a subset sum of existing elements). The greedy construction gives cubic growth, matching the DEM bound \u2014 suggesting the greedy approach is near-optimal.\n\n5. **Probabilistic Methods:** Random constructions provide lower bounds on counting functions and suggest that most sum-free sets have gaps close to $n^{3+o(1)}$, far from the linear gap frontier.",
     "openQuestions": [
       "Is the linear gap bound $a_{n+1} - a_n < n$ achievable for an infinite sum-free set? This is the central open question of Problem #876.",
-      "What is the exact supremum of $\\sum_{a \\in A} 1/a$ over all sum-free sets $A$? Sullivan conjectures it is slightly above 2 — can this be proved or disproved?",
-      "Can the Łuczak-Schoen counting bounds be tightened: is $|A \\cap [1,N]| = \\Theta(\\sqrt{N \\log N})$ or is the logarithmic factor removable?",
+      "What is the exact supremum of $\\sum_{a \\in A} 1/a$ over all sum-free sets $A$? Sullivan conjectures it is slightly above 2 \u2014 can this be proved or disproved?",
+      "Can the \u0141uczak-Schoen counting bounds be tightened: is $|A \\cap [1,N]| = \\Theta(\\sqrt{N \\log N})$ or is the logarithmic factor removable?",
       "What is the structure of sum-free sets that maximize the counting function $|A \\cap [1,N]|$? Are they related to specific number-theoretic constructions?",
       "Extend the analysis to the multi-dimensional setting: for sum-free subsets of $\\mathbb{N}^d$, how do the gap and density bounds generalize?"
     ]
@@ -157,7 +157,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos876",
-    "lineCount": 263,
+    "lineCount": 257,
     "axiomCount": 1,
     "theoremCount": 3,
     "definitionCount": 9,
@@ -168,17 +168,17 @@
     {
       "targetId": "erdos-13",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, sum-free-sets"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, sum-free-sets"
     },
     {
       "targetId": "erdos-329",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: additive-number-theory, combinatorics"
+      "description": "Related Erd\u0151s problem sharing themes: additive-number-theory, combinatorics"
     },
     {
       "targetId": "erdos-711",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, partially-solved"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, partially-solved"
     }
   ],
   "sorries": 2

--- a/src/data/proofs/erdos-912/meta.json
+++ b/src/data/proofs/erdos-912/meta.json
@@ -2,9 +2,9 @@
   "id": "erdos-912",
   "title": "Distinct Exponents in Factorial Factorization",
   "slug": "erdos-912",
-  "description": "If n! = ∏ pᵢ^{kᵢ}, let h(n) count distinct exponents kᵢ. Prove h(n) ~ c·√(n/log n) for some c > 0. Known: h(n) ≍ √(n/log n). Conjectured: c = √(2π).",
+  "description": "If n! = \u220f p\u1d62^{k\u1d62}, let h(n) count distinct exponents k\u1d62. Prove h(n) ~ c\u00b7\u221a(n/log n) for some c > 0. Known: h(n) \u224d \u221a(n/log n). Conjectured: c = \u221a(2\u03c0).",
   "meta": {
-    "author": "Paul Erdős, John Selfridge",
+    "author": "Paul Erd\u0151s, John Selfridge",
     "sourceUrl": "https://erdosproblems.com/912",
     "date": "2026-03-12",
     "status": "axiomatized",
@@ -46,26 +46,26 @@
     ],
     "originalContributions": [
       "Lean formalization of h(n) counting distinct exponents",
-      "Formal statement of Erdős-Selfridge bounds",
-      "Erdős conjecture and Tao's conjectured constant",
+      "Formal statement of Erd\u0151s-Selfridge bounds",
+      "Erd\u0151s conjecture and Tao's conjectured constant",
       "Connection to Legendre's formula",
       "Proved erdos_selfridge_asymptotic by combining axiomatized bounds with max threshold"
     ],
     "dateAdded": "2026-01-19",
     "axiomCount": 2,
-    "lineCount": 224,
+    "lineCount": 221,
     "assumptions": "2 axioms: erdos_selfridge_lower_bound, erdos_selfridge_upper_bound. 0 sorries."
   },
   "overview": {
-    "historicalContext": "This problem was posed by Erdős and Selfridge in their 1982 paper in Congressus Numerantium. They proved the asymptotic order h(n) ≍ √(n/log n) using estimates from the prime number theorem and Legendre's formula (1808) for the p-adic valuation of factorials. The function h(n) is recorded as OEIS sequence A071626. The exact limiting constant remains open; Terence Tao developed a heuristic argument using Cramér's random model for primes (1936), which suggests c = √(2π) ≈ 2.506. This value arises from a central limit theorem argument applied to the distribution of exponents.",
-    "problemStatement": "Let n! = ∏ᵢ pᵢ^{kᵢ} be the prime factorization. Define h(n) as the count of distinct exponents kᵢ. Prove there exists c > 0 such that h(n) ~ c·√(n/log n) as n → ∞.",
-    "text": "If n! = ∏ pᵢ^{kᵢ}, let h(n) count distinct exponents kᵢ. Prove h(n) ~ c·√(n/log n) for some c > 0. Known: h(n) ≍ √(n/log n). Conjectured: c = √(2π).",
-    "proofStrategy": "The formalization defines h(n) using p-adic valuations, states the Erdős-Selfridge bounds as axioms, and formally expresses the conjecture about the exact constant.",
+    "historicalContext": "This problem was posed by Erd\u0151s and Selfridge in their 1982 paper in Congressus Numerantium. They proved the asymptotic order h(n) \u224d \u221a(n/log n) using estimates from the prime number theorem and Legendre's formula (1808) for the p-adic valuation of factorials. The function h(n) is recorded as OEIS sequence A071626. The exact limiting constant remains open; Terence Tao developed a heuristic argument using Cram\u00e9r's random model for primes (1936), which suggests c = \u221a(2\u03c0) \u2248 2.506. This value arises from a central limit theorem argument applied to the distribution of exponents.",
+    "problemStatement": "Let n! = \u220f\u1d62 p\u1d62^{k\u1d62} be the prime factorization. Define h(n) as the count of distinct exponents k\u1d62. Prove there exists c > 0 such that h(n) ~ c\u00b7\u221a(n/log n) as n \u2192 \u221e.",
+    "text": "If n! = \u220f p\u1d62^{k\u1d62}, let h(n) count distinct exponents k\u1d62. Prove h(n) ~ c\u00b7\u221a(n/log n) for some c > 0. Known: h(n) \u224d \u221a(n/log n). Conjectured: c = \u221a(2\u03c0).",
+    "proofStrategy": "The formalization defines h(n) using p-adic valuations, states the Erd\u0151s-Selfridge bounds as axioms, and formally expresses the conjecture about the exact constant.",
     "keyInsights": [
       "h(n) counts distinct exponents in n!'s prime factorization",
-      "Erdős-Selfridge proved h(n) ≍ √(n/log n) (asymptotic order)",
-      "The exact constant c in h(n) ~ c·√(n/log n) is unknown",
-      "Tao's heuristic suggests c = √(2π) via Cramér model — the √(2π) arises from CLT considerations on independent prime events",
+      "Erd\u0151s-Selfridge proved h(n) \u224d \u221a(n/log n) (asymptotic order)",
+      "The exact constant c in h(n) ~ c\u00b7\u221a(n/log n) is unknown",
+      "Tao's heuristic suggests c = \u221a(2\u03c0) via Cram\u00e9r model \u2014 the \u221a(2\u03c0) arises from CLT considerations on independent prime events",
       "The formalization proves erdos_selfridge_asymptotic constructively by combining the two axiomatized bounds using max to unify thresholds"
     ],
     "prerequisites": [
@@ -84,10 +84,10 @@
     },
     {
       "id": "erdos-selfridge-bounds",
-      "title": "Erdős-Selfridge Bounds",
+      "title": "Erd\u0151s-Selfridge Bounds",
       "startLine": 84,
       "endLine": 119,
-      "summary": "Known asymptotic bounds h(n) ≍ √(n/log n)",
+      "summary": "Known asymptotic bounds h(n) \u224d \u221a(n/log n)",
       "mathContext": "Axioms: $\\exists c_1 > 0, h(n) \\geq c_1\\sqrt{n/\\log n}$ and $\\exists c_2 > 0, h(n) \\leq c_2\\sqrt{n/\\log n}$. Combined in `erdos_selfridge_asymptotic` using `max N_1 N_2`."
     },
     {
@@ -96,7 +96,7 @@
       "startLine": 120,
       "endLine": 150,
       "summary": "Formal statement of the conjecture and Tao's constant",
-      "mathContext": "`ErdosConjecture912`: $\\exists c > 0$, `Filter.Tendsto (h(n)/√(n/log n)) atTop (nhds c)`. `taoConstant = √(2π)`. `TaoConjecture`: the specific $c = \\sqrt{2\\pi}$ claim."
+      "mathContext": "`ErdosConjecture912`: $\\exists c > 0$, `Filter.Tendsto (h(n)/\u221a(n/log n)) atTop (nhds c)`. `taoConstant = \u221a(2\u03c0)`. `TaoConjecture`: the specific $c = \\sqrt{2\\pi}$ claim."
     },
     {
       "id": "related-properties",
@@ -128,16 +128,16 @@
       "startLine": 222,
       "endLine": 224,
       "summary": "Main results and current state of knowledge",
-      "mathContext": "`erdos_912_summary = ⟨erdos_selfridge_asymptotic, trivial⟩`. `constant_gap` axiomatizes $\\sqrt{2\\pi} \\in (2.5, 2.51)$. The open question is whether $\\lim h(n)/\\sqrt{n/\\log n}$ exists and equals $\\sqrt{2\\pi}$."
+      "mathContext": "`erdos_912_summary = \u27e8erdos_selfridge_asymptotic, trivial\u27e9`. `constant_gap` axiomatizes $\\sqrt{2\\pi} \\in (2.5, 2.51)$. The open question is whether $\\lim h(n)/\\sqrt{n/\\log n}$ exists and equals $\\sqrt{2\\pi}$."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #912 is OPEN. The asymptotic order h(n) ≍ √(n/log n) is known (Erdős-Selfridge). The exact constant c in h(n) ~ c·√(n/log n) remains unknown, with Tao conjecturing c = √(2π) ≈ 2.506 based on the Cramér model.",
+    "summary": "Erd\u0151s Problem #912 is OPEN. The asymptotic order h(n) \u224d \u221a(n/log n) is known (Erd\u0151s-Selfridge). The exact constant c in h(n) ~ c\u00b7\u221a(n/log n) remains unknown, with Tao conjecturing c = \u221a(2\u03c0) \u2248 2.506 based on the Cram\u00e9r model.",
     "implications": "This problem connects factorials, prime distribution, and asymptotic analysis. Solving it would require understanding the fine structure of how exponents distribute in factorial prime factorizations.",
     "openQuestions": [
-      "Does the limit c = lim h(n)/√(n/log n) exist?",
-      "Is c = √(2π) as Tao's heuristic suggests?",
-      "What are the precise values of c₁ and c₂ in the Erdős-Selfridge bounds?"
+      "Does the limit c = lim h(n)/\u221a(n/log n) exist?",
+      "Is c = \u221a(2\u03c0) as Tao's heuristic suggests?",
+      "What are the precise values of c\u2081 and c\u2082 in the Erd\u0151s-Selfridge bounds?"
     ]
   },
   "leanFile": {
@@ -154,7 +154,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos912",
-    "lineCount": 224,
+    "lineCount": 221,
     "axiomCount": 2,
     "theoremCount": 3,
     "definitionCount": 8,
@@ -163,21 +163,21 @@
   },
   "references": [
     {
-      "authors": "Erdős, P.",
+      "authors": "Erd\u0151s, P.",
       "title": "Miscellaneous problems in number theory",
       "year": "1982",
       "venue": "Congr. Numer. 34, 25-45",
-      "note": "Proved h(n) ≍ √(n/log n) with Selfridge"
+      "note": "Proved h(n) \u224d \u221a(n/log n) with Selfridge"
     },
     {
       "authors": "Legendre, A.-M.",
-      "title": "Essai sur la théorie des nombres",
+      "title": "Essai sur la th\u00e9orie des nombres",
       "year": "1808",
       "venue": "Courcier, Paris",
-      "note": "Legendre's formula for v_p(n!) = Σ floor(n/p^j)"
+      "note": "Legendre's formula for v_p(n!) = \u03a3 floor(n/p^j)"
     },
     {
-      "authors": "Cramér, H.",
+      "authors": "Cram\u00e9r, H.",
       "title": "On the order of magnitude of the difference between consecutive prime numbers",
       "year": "1936",
       "venue": "Acta Arith. 2, 23-46",
@@ -188,17 +188,17 @@
     {
       "targetId": "erdos-1056",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: factorials, number-theory"
+      "description": "Related Erd\u0151s problem sharing themes: factorials, number-theory"
     },
     {
       "targetId": "erdos-1058",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: factorials, number-theory"
+      "description": "Related Erd\u0151s problem sharing themes: factorials, number-theory"
     },
     {
       "targetId": "erdos-1059",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: factorials, number-theory"
+      "description": "Related Erd\u0151s problem sharing themes: factorials, number-theory"
     }
   ],
   "sorries": 0

--- a/src/data/proofs/erdos-967/meta.json
+++ b/src/data/proofs/erdos-967/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-967",
-  "title": "Erdős Problem #967: Zeros of Generalized Dirichlet Sums",
+  "title": "Erd\u0151s Problem #967: Zeros of Generalized Dirichlet Sums",
   "slug": "erdos-967",
-  "description": "For integers 1 < a₁ < a₂ < ... with ∑(1/aᵢ) < ∞, is 1 + ∑ₖ 1/aₖ^(1+it) ≠ 0 for all t ∈ ℝ? Answer: NO - disproved by Yip (2025).",
+  "description": "For integers 1 < a\u2081 < a\u2082 < ... with \u2211(1/a\u1d62) < \u221e, is 1 + \u2211\u2096 1/a\u2096^(1+it) \u2260 0 for all t \u2208 \u211d? Answer: NO - disproved by Yip (2025).",
   "meta": {
-    "author": "Erdős-Ingham (1964 conjecture), Yip (2025 disproof)",
+    "author": "Erd\u0151s-Ingham (1964 conjecture), Yip (2025 disproof)",
     "sourceUrl": "https://erdosproblems.com/967",
     "date": "2025",
     "status": "axiomatized",
@@ -47,10 +47,10 @@
     ],
     "originalContributions": [
       "IntegerSequence structure: strictly increasing integers > 1",
-      "hasConvergentReciprocalSum: convergence condition ∑(1/aᵢ) < ∞",
+      "hasConvergentReciprocalSum: convergence condition \u2211(1/a\u1d62) < \u221e",
       "complexPow: complex power a^(1+it)",
       "reciprocalPow: term 1/a^(1+it) in the sum",
-      "generalizedDirichletSum: the sum 1 + ∑ₖ 1/aₖ^(1+it)",
+      "generalizedDirichletSum: the sum 1 + \u2211\u2096 1/a\u2096^(1+it)",
       "erdosInghamConjecture: the original conjecture",
       "finiteSequenceConjecture: the remaining open question",
       "sum235: the {2,3,5} special case",
@@ -62,16 +62,16 @@
       "powers_of_2_convergent theorem: verified convergence"
     ],
     "axiomCount": 1,
-    "lineCount": 245,
+    "lineCount": 240,
     "assumptions": "1 axiom: yip_counterexample. 0 sorries."
   },
   "overview": {
-    "historicalContext": "**The Erdős-Ingham Paper (1964)**\n\nThis problem originates from 'Arithmetical Tauberian Theorems' by Erdős and Ingham (1964). They discovered a remarkable equivalence: the non-vanishing of 1 + ∑ₖ 1/aₖ^(1+it) for all t is equivalent to a Tauberian implication about functional equations. If f(x) + ∑ₖ f(x/aₖ) = (C + o(1))x for non-decreasing f, does f(x) = (1 + o(1))x follow? The answer depends on whether the Dirichlet sum has zeros.\n\n**The Simplest Unsolved Case (1964-2025)**\n\nRemarkably, Erdős and Ingham could not resolve even the simplest finite case: {2, 3, 5}. Does 1 + 2^(-1-it) + 3^(-1-it) + 5^(-1-it) = 0 for some real t? This connects to deep questions in transcendence theory - specifically the Four Exponentials Conjecture. If 4EC holds, the {2,3,5} sum never vanishes.\n\n**Yip's Breakthrough (2025)**\n\nAfter 60 years, Chi Hoi Yip (arXiv:2512.16528) settled the infinite sequence case definitively: the conjecture is FALSE. For any nonzero t, Yip constructs a sequence where the sum equals zero. The construction exploits the oscillatory nature of a^(it) to achieve precise phase cancellation. However, the finite sequence case - including {2,3,5} - remains tantalizingly open.",
-    "problemStatement": "**Problem**: Let 1 < a₁ < a₂ < ... be integers with ∑(1/aᵢ) < ∞. Is it true that for every t ∈ ℝ:\n\n1 + ∑ₖ 1/aₖ^(1+it) ≠ 0?\n\n**Answer**: NO - The conjecture is FALSE.\n\nYip (2025) proved that for any nonzero real t, there exists a sequence with convergent reciprocal sum where the generalized Dirichlet sum equals zero.\n\n**Open Question**: Does the conjecture hold for finite sequences of integers?",
-    "text": "For integers 1 < a₁ < a₂ < ... with ∑(1/aᵢ) < ∞, is 1 + ∑ₖ 1/aₖ^(1+it) ≠ 0 for all t ∈ ℝ? Answer: NO - disproved by Yip (2025).",
-    "proofStrategy": "The formalization captures the problem structure:\n\n1. **Definitions**: Integer sequences, convergence conditions, complex powers a^(1+it)\n\n2. **The Sum**: generalizedDirichletSum(a, t) = 1 + ∑ₖ 1/aₖ^(1+it)\n\n3. **The Conjecture**: erdosInghamConjecture states the sum is never zero\n\n4. **The Disproof**: yip_counterexample axiom provides counterexamples for each t ≠ 0\n\n5. **Main Theorem**: erdos_967 proves ¬erdosInghamConjecture\n\n6. **Special Cases**: The {2,3,5} case, t = 0 case, and finite sequences",
+    "historicalContext": "**The Erd\u0151s-Ingham Paper (1964)**\n\nThis problem originates from 'Arithmetical Tauberian Theorems' by Erd\u0151s and Ingham (1964). They discovered a remarkable equivalence: the non-vanishing of 1 + \u2211\u2096 1/a\u2096^(1+it) for all t is equivalent to a Tauberian implication about functional equations. If f(x) + \u2211\u2096 f(x/a\u2096) = (C + o(1))x for non-decreasing f, does f(x) = (1 + o(1))x follow? The answer depends on whether the Dirichlet sum has zeros.\n\n**The Simplest Unsolved Case (1964-2025)**\n\nRemarkably, Erd\u0151s and Ingham could not resolve even the simplest finite case: {2, 3, 5}. Does 1 + 2^(-1-it) + 3^(-1-it) + 5^(-1-it) = 0 for some real t? This connects to deep questions in transcendence theory - specifically the Four Exponentials Conjecture. If 4EC holds, the {2,3,5} sum never vanishes.\n\n**Yip's Breakthrough (2025)**\n\nAfter 60 years, Chi Hoi Yip (arXiv:2512.16528) settled the infinite sequence case definitively: the conjecture is FALSE. For any nonzero t, Yip constructs a sequence where the sum equals zero. The construction exploits the oscillatory nature of a^(it) to achieve precise phase cancellation. However, the finite sequence case - including {2,3,5} - remains tantalizingly open.",
+    "problemStatement": "**Problem**: Let 1 < a\u2081 < a\u2082 < ... be integers with \u2211(1/a\u1d62) < \u221e. Is it true that for every t \u2208 \u211d:\n\n1 + \u2211\u2096 1/a\u2096^(1+it) \u2260 0?\n\n**Answer**: NO - The conjecture is FALSE.\n\nYip (2025) proved that for any nonzero real t, there exists a sequence with convergent reciprocal sum where the generalized Dirichlet sum equals zero.\n\n**Open Question**: Does the conjecture hold for finite sequences of integers?",
+    "text": "For integers 1 < a\u2081 < a\u2082 < ... with \u2211(1/a\u1d62) < \u221e, is 1 + \u2211\u2096 1/a\u2096^(1+it) \u2260 0 for all t \u2208 \u211d? Answer: NO - disproved by Yip (2025).",
+    "proofStrategy": "The formalization captures the problem structure:\n\n1. **Definitions**: Integer sequences, convergence conditions, complex powers a^(1+it)\n\n2. **The Sum**: generalizedDirichletSum(a, t) = 1 + \u2211\u2096 1/a\u2096^(1+it)\n\n3. **The Conjecture**: erdosInghamConjecture states the sum is never zero\n\n4. **The Disproof**: yip_counterexample axiom provides counterexamples for each t \u2260 0\n\n5. **Main Theorem**: erdos_967 proves \u00acerdosInghamConjecture\n\n6. **Special Cases**: The {2,3,5} case, t = 0 case, and finite sequences",
     "keyInsights": [
-      "**Disproved Conjecture**: The Erdős-Ingham conjecture is FALSE for infinite sequences",
+      "**Disproved Conjecture**: The Erd\u0151s-Ingham conjecture is FALSE for infinite sequences",
       "**Yip's Construction (2025)**: For any nonzero t, there exists a counterexample sequence - the sequence depends on t",
       "**The {2,3,5} Mystery**: Whether 1 + 2^(-1-it) + 3^(-1-it) + 5^(-1-it) = 0 has solutions connects to the Four Exponentials conjecture",
       "**Tauberian Connection**: The no-zeros condition is equivalent to certain Tauberian implications about functional equations",
@@ -90,7 +90,7 @@
       "startLine": 30,
       "endLine": 50,
       "summary": "Defines IntegerSequence structure and convergence condition.",
-      "description": "An IntegerSequence is strictly increasing with all terms > 1. The convergence condition ∑(1/aᵢ) < ∞ ensures the Dirichlet series converges.",
+      "description": "An IntegerSequence is strictly increasing with all terms > 1. The convergence condition \u2211(1/a\u1d62) < \u221e ensures the Dirichlet series converges.",
       "mathContext": "Formal definition: Defines IntegerSequence structure and convergence condition."
     },
     {
@@ -99,12 +99,12 @@
       "startLine": 51,
       "endLine": 75,
       "summary": "Defines complex power a^(1+it) and the generalized Dirichlet sum.",
-      "description": "The key object is 1 + ∑ₖ 1/aₖ^(1+it), where a^(1+it) = a · e^(it·log(a)) involves oscillating complex exponentials.",
+      "description": "The key object is 1 + \u2211\u2096 1/a\u2096^(1+it), where a^(1+it) = a \u00b7 e^(it\u00b7log(a)) involves oscillating complex exponentials.",
       "mathContext": "Formal definition: Defines complex power a^(1+it) and the generalized Dirichlet sum."
     },
     {
       "id": "conjecture",
-      "title": "The Erdős-Ingham Conjecture",
+      "title": "The Erd\u0151s-Ingham Conjecture",
       "startLine": 76,
       "endLine": 96,
       "summary": "States the original conjecture and the finite sequence variant.",
@@ -116,9 +116,9 @@
       "title": "The {2, 3, 5} Case",
       "startLine": 97,
       "endLine": 117,
-      "summary": "The simplest case Erdős-Ingham couldn't resolve, connected to Four Exponentials.",
+      "summary": "The simplest case Erd\u0151s-Ingham couldn't resolve, connected to Four Exponentials.",
       "description": "Whether sum235(t) = 0 for some t is related to transcendence questions in number theory.",
-      "mathContext": "Mathematical content: The simplest case Erdős-Ingham couldn't resolve, connected to Four Exponentials."
+      "mathContext": "Mathematical content: The simplest case Erd\u0151s-Ingham couldn't resolve, connected to Four Exponentials."
     },
     {
       "id": "tauberian",
@@ -126,7 +126,7 @@
       "startLine": 118,
       "endLine": 132,
       "summary": "The connection to Tauberian theorems that motivated the problem.",
-      "description": "Erdős-Ingham proved the no-zeros condition is equivalent to certain asymptotic implications for functional equations.",
+      "description": "Erd\u0151s-Ingham proved the no-zeros condition is equivalent to certain asymptotic implications for functional equations.",
       "mathContext": "Verified: The connection to Tauberian theorems that motivated the problem."
     },
     {
@@ -135,7 +135,7 @@
       "startLine": 133,
       "endLine": 167,
       "summary": "Yip's theorem disproving the conjecture and the main result.",
-      "description": "For any t ≠ 0, there exists a sequence where the sum equals zero. This proves ¬erdosInghamConjecture.",
+      "description": "For any t \u2260 0, there exists a sequence where the sum equals zero. This proves \u00acerdosInghamConjecture.",
       "mathContext": "Verified: Yip's theorem disproving the conjecture and the main result."
     },
     {
@@ -167,10 +167,10 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #967 asked whether 1 + ∑ₖ 1/aₖ^(1+it) ≠ 0 for all convergent integer sequences and all real t. Yip (2025) proved this is FALSE - for any nonzero t, counterexample sequences exist. The finite sequence case remains open, with the {2,3,5} case connected to the Four Exponentials conjecture.",
-    "implications": "**Theoretical Significance**: Yip's result has several implications:\n\n1. **Tauberian Theory**: The Erdős-Ingham Tauberian equivalence no longer provides the hoped-for general result\n\n**2. Complex Analysis**: Shows oscillation in a^(it) factors can be exploited to create zeros\n\n3. **Transcendence Theory**: The finite case connects to deep questions about algebraic independence of logarithms.",
+    "summary": "Erd\u0151s Problem #967 asked whether 1 + \u2211\u2096 1/a\u2096^(1+it) \u2260 0 for all convergent integer sequences and all real t. Yip (2025) proved this is FALSE - for any nonzero t, counterexample sequences exist. The finite sequence case remains open, with the {2,3,5} case connected to the Four Exponentials conjecture.",
+    "implications": "**Theoretical Significance**: Yip's result has several implications:\n\n1. **Tauberian Theory**: The Erd\u0151s-Ingham Tauberian equivalence no longer provides the hoped-for general result\n\n**2. Complex Analysis**: Shows oscillation in a^(it) factors can be exploited to create zeros\n\n3. **Transcendence Theory**: The finite case connects to deep questions about algebraic independence of logarithms.",
     "openQuestions": [
-      "Does 1 + ∑ₖ 1/aₖ^(1+it) ≠ 0 hold for all finite sequences and all t?",
+      "Does 1 + \u2211\u2096 1/a\u2096^(1+it) \u2260 0 hold for all finite sequences and all t?",
       "Does 1 + 2^(-1-it) + 3^(-1-it) + 5^(-1-it) = 0 for some real t?",
       "What is the structure of Yip's counterexample sequences?",
       "Are there 'universal' counterexamples that work for multiple values of t?"
@@ -188,7 +188,7 @@
       "Complex"
     ],
     "namespace": "Erdos967",
-    "lineCount": 245,
+    "lineCount": 240,
     "axiomCount": 1,
     "theoremCount": 5,
     "definitionCount": 10,
@@ -199,17 +199,17 @@
     {
       "targetId": "erdos-1048",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: complex-analysis, disproved"
+      "description": "Related Erd\u0151s problem sharing themes: complex-analysis, disproved"
     },
     {
       "targetId": "erdos-1081",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: disproved, number-theory"
+      "description": "Related Erd\u0151s problem sharing themes: disproved, number-theory"
     },
     {
       "targetId": "erdos-1115",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: complex-analysis, disproved"
+      "description": "Related Erd\u0151s problem sharing themes: complex-analysis, disproved"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Fix

Sync stale `leanFile.lineCount` (and `meta.lineCount`) fields in 12 gallery entries
where the Lean source files were modified but metadata was not updated.

## Evidence

| Entry | Before | After |
|-------|--------|-------|
| erdos-577 | 197 | 192 |
| erdos-601 | 262 | 259 |
| erdos-666 | 270 | 263 |
| erdos-688 | 129 | 126 |
| erdos-736 | 207 | 203 |
| erdos-745 | 312 | 298 |
| erdos-789 | 244 | 242 |
| erdos-856 | 267 | 260 |
| erdos-876 | 263 | 257 |
| erdos-912 | 224 | 221 |
| erdos-967 | 245 | 240 |
| erdos-1033 | 1016 | 1018 |

All values verified by `wc -l` against `proofs/<path>.lean`.

---
Automated fix by lean-mechanic agent.