### PR TITLE
Fix: lebesgue-measure-oq-06 metadata correction (sorries 8→4, axiomCount 5→0)

### DIFF
--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Banach, S. and Tarski, A. (1924)",
     "date": "2026",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/LebesgueMeasureOQ06.lean",
     "tags": [
       "measure-theory",
@@ -17,11 +17,11 @@
       "axiom-of-choice",
       "research"
     ],
-    "badge": "axiom",
-    "sorries": 8,
-    "axiomCount": 5,
+    "badge": "wip",
+    "sorries": 4,
+    "axiomCount": 0,
     "lineCount": 563,
-    "assumptions": "8 sorries: hausdorff_free_subgroup (free subgroup of SO(3)), banach_tarski (main theorem), banach_tarski_pieces_nonmeasurable (non-measurability of pieces), int_amenable (ℤ amenability), W_a_two_cover (W(a) two-cover), W_a_smul_disj (W(a) smul disjointness), W_b_two_cover (W(b) two-cover), W_b_smul_disj (W(b) smul disjointness). The main proof requires ~800 lines via free subgroup of SO(3) — beyond this gallery entry's scope. Note: paradoxical_no_finite_measure and free_group_not_amenable structure are fully proved.",
+    "assumptions": "4 sorries: hausdorff_free_subgroup (free subgroup of SO(3), line 178), banach_tarski (main theorem, line 225), banach_tarski_pieces_nonmeasurable (non-measurability of pieces, line 236), int_amenable (ℤ amenability via Cesàro means, line 271). The main proof requires ~800 lines via free subgroup of SO(3) — beyond this gallery entry's scope.",
     "dateAdded": "2026-04-22",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -202,11 +202,11 @@
     ],
     "namespace": "BanachTarski",
     "lineCount": 563,
-    "axiomCount": 5,
+    "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 5,
     "path": "Proofs/LebesgueMeasureOQ06.lean",
-    "sorries": 8
+    "sorries": 4
   },
-  "sorries": 8
+  "sorries": 4
 }


### PR DESCRIPTION
## Summary

- Lean source `proofs/Proofs/LebesgueMeasureOQ06.lean` has **4 sorry** statements (lines 178, 225, 236, 271) and **0 axiom** declarations
- meta.json incorrectly claimed 8 sorries and 5 axioms
- Updated `meta.sorries`, `leanFile.sorries`: 8 → 4
- Updated `meta.axiomCount`, `leanFile.axiomCount`: 5 → 0
- Updated `status`: axiomatized → formalized (has sorries, no axioms)
- Updated `badge`: axiom → wip
- Updated `assumptions` text to list only the 4 actual sorry locations

## Evidence

```bash
$ grep -n '\bsorry\b' proofs/Proofs/LebesgueMeasureOQ06.lean
178:  sorry
225:  sorry -- See mathematical outline above.
236:  sorry
271:  sorry -- Cesàro mean
500:    Key facts (all proved or sorry'd above):  # comment, not sorry

$ grep -c '^axiom ' proofs/Proofs/LebesgueMeasureOQ06.lean
0
```

## Test plan

- [ ] `pnpm build` succeeds
- [ ] Gallery page renders correctly