### PR TITLE
Fix: shapley-folkman meta.sorries mismatch (1→4)

### DIFF
--- a/src/data/proofs/shapley-folkman/meta.json
+++ b/src/data/proofs/shapley-folkman/meta.json
@@ -16,7 +16,7 @@
       "intermediate"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 4,
     "mathlibDependencies": [
       {
         "theorem": "convexHull_eq_union",


### PR DESCRIPTION
## Integrity Fix

**Proof**: shapley-folkman (Shapley-Folkman Theorem)

**Problem**: `meta.sorries` was 1 (based on an outdated header comment) but the Lean file has 4 actual proof-level sorries:
- Line 114: `exact sorry`
- Line 184: `exact sorry`
- Line 467: `sorry]`
- Line 683: `sorry`

The `leanFile.sorries` field was already correct at 4.

## Changes

- `meta.sorries`: 1 → 4

## Severity

HIGH — sorry count mismatch. Status "formalized" with badge "wip" is still correct.

---
Discovered during gallery integrity audit (2026-04-23).