### PR TITLE
Fix: erdos-1150 axiomCount mismatch (2→3, add flat_does_not_imply_ultraflat)

### DIFF
--- a/src/data/proofs/erdos-1150/meta.json
+++ b/src/data/proofs/erdos-1150/meta.json
@@ -38,9 +38,9 @@
       "Axiom kahane_unimodular_ultraflat (ultraflat for unimodular coefficients)",
       "Axiom rudin_shapiro_bound (concrete ≤ √(2n) family)"
     ],
-    "axiomCount": 2,
+    "axiomCount": 3,
     "lineCount": 342,
-    "assumptions": "2 axioms: parseval_lower_bound (Littlewood polynomials have sup norm ≥ √(deg+1), via Parseval), bbmst_flat (flat Littlewood polynomials with bounded sup/L²-norm ratio exist, BBMST). 0 sorries."
+    "assumptions": "3 axioms: parseval_lower_bound (Littlewood polynomials have sup norm ≥ √(deg+1), via Parseval), bbmst_flat (flat Littlewood polynomials with bounded sup/L²-norm ratio exist, BBMST), flat_does_not_imply_ultraflat (flat does not imply ultraflat: BBMST gives O(√n) but ultraflat requires sup-norm/√n → 1). 0 sorries."
   },
   "overview": {
     "historicalContext": "Erdős posed Problem #1150 as part of his investigations into extremal properties of polynomials with restricted coefficients. The study of Littlewood polynomials — polynomials with all coefficients ±1 — dates to J.E. Littlewood's 1966 monograph, where he asked about the minimal sup norm on the unit circle. By Parseval's identity, every degree-$n$ Littlewood polynomial satisfies $\\max_{|z|=1}|P(z)| \\ge \\sqrt{n+1}$, since the $L^2$ norm equals $\\sqrt{n+1}$. The question is whether this can be improved by a multiplicative constant. Kahane's 1980 breakthrough showed that for general unimodular coefficients ($|a_k| = 1$, complex phases allowed), ultraflat polynomials exist — the sup norm can be made $(1+o(1))\\sqrt{n}$. This made the ±1 restriction the essential barrier. The problem gained renewed attention after Balister, Bollobás, Morris, Sahasrabudhe, and Tiba (BBMST, 2019) proved flat Littlewood polynomials exist ($c_1\\sqrt{n} \\le |P(z)| \\le c_2\\sqrt{n}$), resolving Erdős Problem #228. But flat is weaker than ultraflat: the gap between 'bounded ratio' and 'ratio converging to 1' is precisely what Problem #1150 asks about. The Rudin-Shapiro polynomials, constructed recursively since the 1950s, provide the best explicit examples with sup norm at most $\\sqrt{2(n+1)}$.",
@@ -166,7 +166,7 @@
     ],
     "namespace": "Erdos1150",
     "lineCount": 342,
-    "axiomCount": 2,
+    "axiomCount": 3,
     "theoremCount": 10,
     "definitionCount": 4,
     "path": "Proofs/Erdos1150Problem.lean",


### PR DESCRIPTION
## Integrity Fix

**Proof**: erdos-1150 (Erdős #1150: Ultraflat Littlewood Polynomials)

**Problem**: The Lean file `Erdos1150Problem.lean` has 3 `axiom` declarations:
- `parseval_lower_bound` (line 106)
- `bbmst_flat` (line 238)
- `flat_does_not_imply_ultraflat` (line 286)

But `meta.json` claimed `axiomCount: 2`, missing `flat_does_not_imply_ultraflat`.

## Changes

- `meta.axiomCount`: 2 → 3
- `leanFile.axiomCount`: 2 → 3
- `meta.assumptions`: added `flat_does_not_imply_ultraflat` to the list

## Severity

LOW — axiom count off by 1. Status "axiomatized" with badge "axiom" is correct.

---
Discovered during gallery integrity audit (2026-04-23).