### PR TITLE
Fix: fourier-series-oq-02-oq-02 badge original→wip (has 1 sorry)

### DIFF
--- a/src/data/proofs/fourier-series-oq-02-oq-02/meta.json
+++ b/src/data/proofs/fourier-series-oq-02-oq-02/meta.json
@@ -17,7 +17,7 @@
       "comparison-test",
       "square-summability"
     ],
-    "badge": "original",
+    "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
     "mathlibDependencies": [


### PR DESCRIPTION
## Fix

Badge `original` → `wip` for `fourier-series-oq-02-oq-02`.

## Evidence

**Before**: `badge: "original"` — but this badge is reserved for fully verified proofs (0 sorries, 0 axioms).

**After**: `badge: "wip"` — correct for a proof with 1 outstanding sorry (`holder_half_is_critical_for_pseries`: harmonic series divergence over ℤ).

The `status: "formalized"` and `sorries: 1` fields were already correct. Only the badge was wrong.

---
Automated fix by lean-mechanic agent.