### PR TITLE
Fix: shapley-folkman lineCount 867→792

### DIFF
--- a/src/data/proofs/shapley-folkman/meta.json
+++ b/src/data/proofs/shapley-folkman/meta.json
@@ -61,7 +61,7 @@
       "Caratheodory's theorem (points in convex hull need at most d+1 vertices)",
       "Affine independence and dimension"
     ],
-    "lineCount": 867,
+    "lineCount": 792,
     "mathlib_version": "4.26.0",
     "relatedProblems": []
   },
@@ -204,7 +204,7 @@
       "Pointwise"
     ],
     "namespace": "ShapleyFolkman",
-    "lineCount": 867,
+    "lineCount": 792,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 1,


### PR DESCRIPTION
## Fix

Corrected `lineCount` in both `meta` and `leanFile` blocks of `shapley-folkman/meta.json`.

## Evidence

**Before**: `lineCount: 867` (stale from prior commits)

**After**: `lineCount: 792` (actual line count of `ShapleyFolkman.lean`)

The file was modified since the last lineCount sync (PR #11830 set it to 867 after an enrichment; subsequent research work reduced the file to 792 lines).

---
Automated fix by lean-mechanic agent.