### PR TITLE
Enrich fourier-series-oq-02-oq-02: add index.ts and annotations.json

### DIFF
--- a/src/data/proofs/fourier-series-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/fourier-series-oq-02-oq-02/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-fsoq02oq02-header",
+    "proofId": "fourier-series-oq-02-oq-02",
+    "range": { "startLine": 1, "endLine": 43 },
+    "type": "context",
+    "title": "Elementary Alternative to Parseval's Theorem",
+    "content": "This file answers the question: is there a proof of Fourier coefficient square-summability that avoids L² theory entirely? The answer is yes — for $\\alpha$-Hölder functions with $\\alpha > 1/2$, the decay bound $\\|\\hat{c}_n\\| = O(|n|^{-\\alpha})$ squared gives $O(|n|^{-2\\alpha})$, and since $2\\alpha > 1$, this is dominated by a convergent p-series.\n\nThe proof uses only three ingredients: the quantitative Hölder decay bound (from `FourierSeriesOQ02`), the p-series criterion $\\sum 1/n^{\\beta} < \\infty$ for $\\beta > 1$, and the comparison test. No measure theory, no $L^2$ spaces, no Parseval's identity required.\n\nThe `set_option maxHeartbeats 800000` reflects the cost of the algebraic manipulations involving real-power arithmetic (`Real.rpow`).",
+    "mathContext": "Main theorem: if $f : \\text{AddCircle}\\, T \\to \\mathbb{C}$ is $\\alpha$-Hölder ($\\alpha > 1/2$), then $\\sum_{n:\\mathbb{Z}} \\|\\hat{c}_n(f)\\|^2 < \\infty$. Proof path: Hölder decay $\\Rightarrow$ squared bound $O(|n|^{-2\\alpha})$ $\\Rightarrow$ p-series comparison ($2\\alpha > 1$) $\\Rightarrow$ summability.",
+    "significance": "key",
+    "relatedConcepts": ["Fourier series", "Hölder continuity", "p-series", "comparison test", "Parseval's theorem"],
+    "prerequisites": ["Fourier coefficients", "Hölder continuity", "p-series convergence", "FourierSeriesOQ02 decay bound"]
+  },
+  {
+    "id": "ann-fsoq02oq02-pseries-nat",
+    "proofId": "fourier-series-oq-02-oq-02",
+    "range": { "startLine": 52, "endLine": 56 },
+    "type": "technique",
+    "title": "p-Series over ℕ via Real.summable_nat_rpow_inv",
+    "content": "`summable_const_div_nat_rpow` packages the Mathlib p-series result for direct use. The proof `simp_rw [div_eq_mul_inv]` converts `K/n^β` to `K * (n^β)⁻¹`, then `(Real.summable_nat_rpow_inv.2 hβ).mul_left K` applies the Mathlib p-series theorem and scales by the constant $K$.\n\nThis is a clean adapter pattern: `Real.summable_nat_rpow_inv` states $\\sum 1/n^\\beta < \\infty$ iff $\\beta > 1$, and we need the `K`-scaled version with $K \\geq 0$.",
+    "mathContext": "`Real.summable_nat_rpow_inv : Summable (fun n : ℕ => (n : ℝ)⁻¹ ^ β) ↔ 1 < β`. We use the direction `.2 hβ` then scale: $(\\text{Summable}\\, g) \\Rightarrow (\\text{Summable}\\, (K \\cdot g))$ via `.mul_left K`.",
+    "significance": "technical",
+    "relatedConcepts": ["p-series", "Real.summable_nat_rpow_inv", "Mathlib analysis", "summability scaling"],
+    "prerequisites": ["real analysis", "p-series convergence", "Mathlib PSeries module"]
+  },
+  {
+    "id": "ann-fsoq02oq02-pseries-int",
+    "proofId": "fourier-series-oq-02-oq-02",
+    "range": { "startLine": 58, "endLine": 69 },
+    "type": "technique",
+    "title": "p-Series over ℤ by Splitting into ℕ Halves",
+    "content": "`summable_const_div_int_rpow` extends the p-series to the integer index set. The Mathlib lemma `summable_int_iff_summable_nat_and_neg` reduces $\\mathbb{Z}$-summability to two $\\mathbb{N}$-summability questions: the positive half $\\sum_{n:\\mathbb{N}} K/|n|^{\\beta}$ and the negative half $\\sum_{n:\\mathbb{N}} K/|-(n:\\mathbb{Z})|^{\\beta}$.\n\nBoth halves reduce to the same $\\mathbb{N}$ p-series after simplifying the absolute values: `abs_of_nonneg (Nat.cast_nonneg' n)` for the positive half, and `abs_neg` + `abs_of_nonneg` for the negative half. The `convert ... using 1` tactic handles the coercion bookkeeping.",
+    "mathContext": "$\\sum_{n:\\mathbb{Z}} K/|n|^\\beta < \\infty$ via `summable_int_iff_summable_nat_and_neg`: splits to $\\sum_{n:\\mathbb{N}} K/n^\\beta$ (positive) and $\\sum_{n:\\mathbb{N}} K/n^\\beta$ (negative), both convergent for $\\beta > 1$. Key: $|{-(n:\\mathbb{Z})}| = |(n:\\mathbb{Z})| = n$ for $n : \\mathbb{N}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["integer summability", "summable_int_iff_summable_nat_and_neg", "absolute value over ℤ", "Lean convert tactic"],
+    "prerequisites": ["p-series over ℕ", "Mathlib integer summability", "absolute value arithmetic"]
+  },
+  {
+    "id": "ann-fsoq02oq02-decay-helper",
+    "proofId": "fourier-series-oq-02-oq-02",
+    "range": { "startLine": 78, "endLine": 83 },
+    "type": "technique",
+    "title": "Helper: (a·b^α)² = a²·b^{2α} via rpow_mul_natCast",
+    "content": "`mul_rpow_sq` is a private helper that performs the key algebraic step: squaring a product of the form $a \\cdot b^\\alpha$. The proof rewrites using `Real.rpow_mul_natCast hb α 2` to get $b^{\\alpha \\cdot 2} = (b^\\alpha)^2$, then uses `push_cast` and `ring` to complete the algebra.\n\nThe `rpow_mul_natCast` bridge is necessary because $b^\\alpha$ is a real power (`Real.rpow`) while squaring produces a natural number power. Without this bridge, `norm_cast` would fail since the exponents live in different types.",
+    "mathContext": "Identity: $(a \\cdot b^\\alpha)^2 = a^2 \\cdot b^{2\\alpha}$. Key step: `Real.rpow_mul_natCast hb α 2 : b ^ (α * 2) = (b ^ α) ^ 2` bridges `Real.rpow` and `HPow.hPow ℝ ℕ ℝ`. Then `push_cast` makes $2\\alpha = \\alpha \\cdot 2$ visible, `ring` closes.",
+    "significance": "technical",
+    "relatedConcepts": ["Real.rpow", "rpow_mul_natCast", "real power arithmetic", "Lean norm_cast"],
+    "prerequisites": ["real powers in Lean 4", "Mathlib rpow theorems", "push_cast tactic"]
+  },
+  {
+    "id": "ann-fsoq02oq02-sq-bound",
+    "proofId": "fourier-series-oq-02-oq-02",
+    "range": { "startLine": 85, "endLine": 113 },
+    "type": "key-theorem",
+    "title": "Squared Decay Bound: ‖ĉ_n‖² ≤ K/|n|^{2α}",
+    "content": "`fourierCoeff_sq_le_pseries_term` is the bridge between the Hölder decay bound and the p-series comparison. For $n \\neq 0$:\n1. Get Hölder decay from the parent proof: $\\|\\hat{c}_n(f)\\| \\leq (C/2) \\cdot (T/(2|n|))^\\alpha$\n2. Square via `pow_le_pow_left₀`: $\\|\\hat{c}_n(f)\\|^2 \\leq [(C/2)(T/(2|n|))^\\alpha]^2$  \n3. Expand the square using `mul_rpow_sq` and `Real.div_rpow` to factor out $|n|^{2\\alpha}$: $= (C/2)^2 (T/2)^{2\\alpha} / |n|^{2\\alpha}$\n\nThe field_simp step in `h_split : T/(2|n|) = (T/2)/|n|` is the key algebraic reduction that allows `Real.div_rpow` to factor the absolute value out of the exponent.",
+    "mathContext": "Final bound: $\\|\\hat{c}_n(f)\\|^2 \\leq K/|n|^{2\\alpha}$ where $K = (C/2)^2 \\cdot (T/2)^{2\\alpha}$. This converts the Hölder bound $O(|n|^{-\\alpha})$ into the p-series term $O(|n|^{-2\\alpha})$ suitable for the comparison test with $\\beta = 2\\alpha > 1$.",
+    "significance": "key",
+    "relatedConcepts": ["Hölder decay", "squaring inequalities", "pow_le_pow_left₀", "Real.div_rpow", "comparison test setup"],
+    "prerequisites": ["fourierCoeff_holder_decay from FourierSeriesOQ02", "mul_rpow_sq helper", "Real.div_rpow"]
+  },
+  {
+    "id": "ann-fsoq02oq02-main-theorem",
+    "proofId": "fourier-series-oq-02-oq-02",
+    "range": { "startLine": 121, "endLine": 157 },
+    "type": "key-theorem",
+    "title": "Main Theorem: Square-Summability via Comparison Test",
+    "content": "`fourierCoeff_sq_summable_of_holder_pseries` is the main result. The proof structure:\n1. Derive $2\\alpha > 1$ from $\\alpha > 1/2$ via `linarith`\n2. Set $K = (C/2)^2 (T/2)^{2\\alpha}$ as a local definition\n3. Get convergence of the dominating series $\\sum K/|n|^{2\\alpha}$ from `summable_const_div_int_rpow`\n4. Apply `Summable.of_norm_bounded_eventually` (the comparison test with cofinite exceptions)\n5. Handle the $n=0$ exception: `Filter.eventually_cofinite.mpr` with `Set.finite_singleton (0:ℤ)` shows $\\{0\\}$ is the only exception\n6. For $n \\neq 0$: use `fourierCoeff_sq_le_pseries_term` by contradiction\n\nThe cofinite filter approach is elegant: `Summable.of_norm_bounded_eventually` allows the bound to fail on finitely many terms (here just $n=0$ where $|n|=0$ makes $K/|n|^{2\\alpha}$ ill-defined).",
+    "mathContext": "Applied theorem: `Summable.of_norm_bounded_eventually`: if $\\sum g_n < \\infty$ and $|f_n| \\leq g_n$ for all but finitely many $n$, then $\\sum f_n < \\infty$. Here $f_n = \\|\\hat{c}_n\\|^2$, $g_n = K/|n|^{2\\alpha}$, exceptions $= \\{0\\}$.",
+    "significance": "key",
+    "relatedConcepts": ["comparison test", "Summable.of_norm_bounded_eventually", "cofinite filter", "square-summability"],
+    "prerequisites": ["summable_const_div_int_rpow", "fourierCoeff_sq_le_pseries_term", "cofinite filter in Lean 4"]
+  },
+  {
+    "id": "ann-fsoq02oq02-sharpness",
+    "proofId": "fourier-series-oq-02-oq-02",
+    "range": { "startLine": 181, "endLine": 195 },
+    "type": "insight",
+    "title": "Sharpness: α = 1/2 is the Critical Threshold (with sorry)",
+    "content": "`holder_half_is_critical_for_pseries` states that the p-series argument fails at exactly $\\alpha = 1/2$: the squared bound becomes $O(|n|^{-1})$ and the harmonic series $\\sum 1/|n|$ diverges over $\\mathbb{Z}$.\n\nThis theorem is left with a `sorry` because harmonic series divergence over $\\mathbb{Z}$ ($\\sum_{n \\neq 0} 1/|n| = \\infty$) is not immediately available in Mathlib in this form. The real question is: `¬ Summable (fun n : ℤ => K / |n|^1)` — a consequence of `Real.summable_nat_rpow_inv` going the other direction, but requiring extra work to transfer from $\\mathbb{N}$ to $\\mathbb{Z}$.\n\nNote: The sorry is in the sharpness statement only. The main results (Parts I–III) are sorry-free.",
+    "mathContext": "At $\\alpha = 1/2$: squared bound $= K/|n|^1$ = harmonic series. Mathlib has `Real.summable_nat_rpow_inv.1 (not_lt.mpr h)` for the divergence direction over $\\mathbb{N}$; extending to $\\mathbb{Z}$ requires additional argument. The sorry has a clear statement and clear proof path — it is a definitional gap, not a conceptual gap.",
+    "significance": "supporting",
+    "relatedConcepts": ["harmonic series divergence", "sharp threshold", "critical Hölder exponent", "Mathlib sorry"],
+    "prerequisites": ["Real.summable_nat_rpow_inv divergence direction", "integer harmonic series"]
+  },
+  {
+    "id": "ann-fsoq02oq02-comparison",
+    "proofId": "fourier-series-oq-02-oq-02",
+    "range": { "startLine": 163, "endLine": 179 },
+    "type": "insight",
+    "title": "Two Routes to the Same Conclusion: p-Series vs Parseval",
+    "content": "`sq_summable_matches_parseval` makes explicit that this p-series proof gives the same conclusion as the Parseval-based proof in `FourierSeriesOQ02OQ01.lean`. The two routes differ in what they require:\n\n- **Parseval route** (sibling proof OQ02OQ01): Continuity → bounded → $L^2$ → Parseval identity $\\sum \\|\\hat{c}_n\\|^2 = \\|f\\|_{L^2}^2$. Shorter (~15 lines) but requires $L^2$ theory and measure theory.\n\n- **p-Series route** (this file): Hölder decay → squared bound → comparison. Longer (~50 lines) but elementary — no $L^2$, no measure theory beyond the definition of Fourier coefficients.\n\n`fourier_coeff_l2` re-expresses the result as an existential `HasSum` statement, giving the concrete sum value $S$ such that the Fourier coefficients sum to $S$ in the $L^2(\\mathbb{Z})$ sense.",
+    "mathContext": "Both prove: $\\sum_{n:\\mathbb{Z}} \\|\\hat{c}_n(f)\\|^2 < \\infty$. Parseval also gives the exact value $= \\|f\\|_{L^2}^2$. The p-series route gives only convergence but with explicit dominating rate $K \\cdot \\zeta(2\\alpha)$ where $\\zeta$ is the Riemann zeta function.",
+    "significance": "key",
+    "relatedConcepts": ["Parseval's theorem", "proof comparison", "elementary vs measure-theoretic proof", "Bessel's inequality"],
+    "prerequisites": ["FourierSeriesOQ02OQ01 sibling proof", "Parseval's theorem", "L² Fourier theory"]
+  }
+]

--- a/src/data/proofs/fourier-series-oq-02-oq-02/index.ts
+++ b/src/data/proofs/fourier-series-oq-02-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/FourierSeriesOQ02OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const fourierSeriesOQ02OQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const fourierSeriesOQ02OQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const fourierSeriesOQ02OQ02Data: ProofData = {
+  proof: fourierSeriesOQ02OQ02Proof,
+  annotations: fourierSeriesOQ02OQ02Annotations,
+}


### PR DESCRIPTION
## Summary

- Created missing index.ts for fourier-series-oq-02-oq-02 (proof page was inaccessible on the live site)
- Created annotations.json with 8 mathematical context annotations covering the p-series proof of Fourier square-summability
- Annotations cover: module header (elementary Parseval alternative), p-Series over N, p-Series over Z, mul_rpow_sq helper, squared decay bound, main theorem, sharpness threshold, and two-routes comparison

## Context

This entry proves Fourier coefficient square-summability for alpha-Holder functions (alpha > 1/2) without L2 theory, using only the quantitative Holder decay bound, the p-series criterion, and the comparison test.

Generated with Claude Code