### PR TITLE
Fix: cap OOB section endLine in 8 gallery entries

### DIFF
--- a/src/data/proofs/erdos-577/meta.json
+++ b/src/data/proofs/erdos-577/meta.json
@@ -135,7 +135,7 @@
       "title": "Final Theorem and Summary",
       "summary": "Canonical `erdos_577 : ErdosFaudreeConjecture := wang_theorem` resolving Problem #577",
       "startLine": 185,
-      "endLine": 197,
+      "endLine": 192,
       "mathContext": "Verified: Canonical `erdos_577 : ErdosFaudreeConjecture := wang_theorem` resolving Problem #577"
     }
   ],

--- a/src/data/proofs/erdos-736/meta.json
+++ b/src/data/proofs/erdos-736/meta.json
@@ -141,7 +141,7 @@
       "id": "special-cases",
       "title": "Special Cases",
       "startLine": 198,
-      "endLine": 207,
+      "endLine": 203,
       "summary": "Countable and finite chromatic number cases",
       "mathContext": "Countable case: if $\\chi(G) = \\aleph_0$, finite subgraphs determine everything by compactness. The critical gap is at $\\chi(G) = \\aleph_1$ where set-theoretic independence emerges."
     }

--- a/src/data/proofs/erdos-745/meta.json
+++ b/src/data/proofs/erdos-745/meta.json
@@ -131,7 +131,7 @@
       "title": "Summary",
       "summary": "erdos_745_summary, erdos_745_answer, component_gap theorems",
       "startLine": 268,
-      "endLine": 309,
+      "endLine": 298,
       "mathContext": "Verified: erdos_745_summary, erdos_745_answer, component_gap theorems"
     }
   ],

--- a/src/data/proofs/erdos-789/meta.json
+++ b/src/data/proofs/erdos-789/meta.json
@@ -151,7 +151,7 @@
       "title": "Summary",
       "summary": "Main theorem combining bounds, problem OPEN",
       "startLine": 170,
-      "endLine": 244,
+      "endLine": 242,
       "mathContext": "Main theorem combining bounds, problem OPEN"
     }
   ],

--- a/src/data/proofs/erdos-856/meta.json
+++ b/src/data/proofs/erdos-856/meta.json
@@ -113,7 +113,7 @@
       "id": "examples",
       "title": "Examples and Gap Analysis",
       "startLine": 226,
-      "endLine": 267,
+      "endLine": 260,
       "summary": "Proves divisor sets satisfy $\\text{lcm}(a,b) \\mid n$ (genuine Lean proof). Axiomatizes prime power LCM $\\text{lcm}(p^j, p^k) = p^k$, the open problem formalization, and gap analysis for $k = 3$.",
       "mathContext": "Verified: Proves divisor sets satisfy $\\text{lcm}(a,b) \\mid n$ (genuine Lean proof). Axiomatizes prime power LCM $\\text{lcm}(p^j, p^k) = p^k$, the open problem formalization, and gap analysis for $k = 3$."
     }

--- a/src/data/proofs/erdos-876/meta.json
+++ b/src/data/proofs/erdos-876/meta.json
@@ -130,7 +130,7 @@
       "title": "Examples and Connections",
       "summary": "States `powers_of_two_sumfree`: $\\{2^n : n \\in \\mathbb{N}\\}$ is sum-free (sorry \u2014 the proof uses binary uniqueness). Notes connections to Sidon sets and $B_h$ sequences.",
       "startLine": 227,
-      "endLine": 263,
+      "endLine": 257,
       "mathContext": "States `powers_of_two_sumfree`: $\\{$2^{n}$ : n \\in \\mathbb{N}\\}$ is sum-free (sorry \u2014 the proof uses binary uniqueness). Notes connections to Sidon sets and $B_h$ sequences."
     }
   ],

--- a/src/data/proofs/erdos-912/meta.json
+++ b/src/data/proofs/erdos-912/meta.json
@@ -121,14 +121,6 @@
       "endLine": 221,
       "summary": "Connections to prime distribution",
       "mathContext": "Placeholder axioms `conjecture_difficulty` and `prime_distribution_connection` (both `True`). The key difficulty is closing the gap between constants $c_1$ and $c_2$ to a single $c$, which requires understanding fine prime gap statistics."
-    },
-    {
-      "id": "summary",
-      "title": "Summary",
-      "startLine": 222,
-      "endLine": 224,
-      "summary": "Main results and current state of knowledge",
-      "mathContext": "`erdos_912_summary = \u27e8erdos_selfridge_asymptotic, trivial\u27e9`. `constant_gap` axiomatizes $\\sqrt{2\\pi} \\in (2.5, 2.51)$. The open question is whether $\\lim h(n)/\\sqrt{n/\\log n}$ exists and equals $\\sqrt{2\\pi}$."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-967/meta.json
+++ b/src/data/proofs/erdos-967/meta.json
@@ -160,7 +160,7 @@
       "id": "summary",
       "title": "Summary",
       "startLine": 234,
-      "endLine": 245,
+      "endLine": 240,
       "summary": "Main results: conjecture disproved, finite case open.",
       "description": "The 60-year-old conjecture was disproved in 2025. Key questions about finite sequences remain.",
       "mathContext": "Mathematical content: Main results: conjecture disproved, finite case open."


### PR DESCRIPTION
## Summary

Corrects section `endLine` values that exceeded the actual Lean file `lineCount` in 8 gallery `meta.json` entries. Out-of-bounds endLine fields can cause gallery rendering errors when sections are displayed.

**All 8 fixes (split across 2 commits on this branch):**

| Entry | Section | Old endLine | New endLine | lineCount |
|-------|---------|-------------|-------------|-----------|
| erdos-577 | summary | 197 | 192 | 192 |
| erdos-736 | special-cases | 207 | 203 | 203 |
| erdos-745 | summary | 309 | 298 | 298 |
| erdos-789 | summary | 244 | 242 | 242 |
| erdos-856 | examples | 267 | 260 | 260 |
| erdos-876 | examples | 263 | 257 | 257 |
| erdos-912 | summary | removed | — | 221 (startLine=222 was OOB) |
| erdos-967 | summary | 245 | 240 | 240 |

## Test plan

- [ ] Verify `meta.json` section endLine values do not exceed `leanFile.lineCount` for all 8 entries
- [ ] Confirm gallery builds without section-range errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)