### PR TITLE
Research: erdos-1151-oq-04 — prove x_not_chebyshev_node, lebesgue_eq_all_n (Session 6)

### DIFF
--- a/proofs/Proofs/Erdos1151OQ04.lean
+++ b/proofs/Proofs/Erdos1151OQ04.lean
@@ -25,12 +25,15 @@ The non-sorry results proved here:
   - `chebyshev_product_formula`: T_n = 2^{n-1} · ∏(X - C(cos φₖ)) [Session 5, NEW]
   - `lagrange_basis_chebyshev_formula`: explicit Lagrange basis at Chebyshev nodes [Session 5, NEW]
   - `chebyshev_lebesgue_eq`: Λₙ(cos θ) = |cos(nθ)|/n · Σₖ sin(φₖ)/|cos θ - cos φₖ| [Session 5, NEW]
+  - `x_not_chebyshev_node`: cos(πp/q) ≠ chebyshevNode n k for all n when p,q odd [Session 6, NEW]
+  - `chebyshev_lebesgue_eq_all_n`: applies lebesgue_eq for ALL n (not just n=mq) [Session 6, NEW]
 
 ## Sorry 1: chebyshev_lebesgue_growth
 Proof requires:
-  a) chebyshev_lebesgue_eq [NOW PROVED in Session 5]
+  a) chebyshev_lebesgue_eq_all_n [NOW PROVED in Session 6]
   b) Lower bound on Σₖ sin(φₖ)/|cos θ - cos φₖ| growing like log(n) [OPEN]
   c) Nonvanishing of cos(nπp/q) along n = kq subsequence [PROVED]
+  d) Key insight: for q odd, x = cos(πp/q) is never a Chebyshev node [PROVED, Session 6]
 
 ## Sorry 2: divergence_from_lebesgue_growth
 Proof requires:
@@ -42,6 +45,7 @@ Tags: analysis, approximation-theory, chebyshev, lebesgue-function, erdos-proble
 
 import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
 import Mathlib.Analysis.SpecialFunctions.Trigonometric.Chebyshev
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Complex
 import Mathlib.RingTheory.Polynomial.Chebyshev
 import Mathlib.Topology.Baire.CompleteMetrizable
 import Mathlib.Topology.Baire.Lemmas
@@ -516,6 +520,95 @@ theorem chebyshev_lebesgue_eq (n : ℕ) (hn : 0 < n) (θ : ℝ)
   simp only [abs_pow, abs_neg, abs_one, one_pow, mul_one]
   -- Now: |cos(nθ)|/n · sin(φₖ)/|cos θ - nodes k| = |cos(nθ)|/n · sin(φₖ)/|cos θ - nodes k|
   field_simp
+
+/-! ## Rational Cosine Not a Node (Session 6) -/
+
+/-- **Key helper**: For odd p and odd q, cos(πp/q) is never a Chebyshev node of any degree n.
+
+    Proof: By `Real.cos_eq_cos_iff`, the equation cos(πp/q) = cos((2k+1)π/(2n)) requires
+    either (2k+1)π/(2n) = 2jπ + πp/q or (2k+1)π/(2n) = 2jπ − πp/q for some j : ℤ.
+
+    Dividing by π and multiplying by 2nq:
+    - Case 1: q(2k+1) = 4jnq + 2np. LHS is odd (product of two odd numbers q, 2k+1).
+      RHS is even. Contradiction.
+    - Case 2: q(2k+1) + 2np = 4jnq. LHS is odd + even = odd. RHS is even. Contradiction.
+
+    This allows `chebyshev_lebesgue_eq` to be applied for ALL n (not just n = mq). -/
+lemma x_not_chebyshev_node (p q : ℕ) (hp : Odd p) (hq : Odd q) (hq_pos : 0 < q)
+    (n : ℕ) (hn : 0 < n) (k : Fin n) :
+    Real.cos (↑p * Real.pi / ↑q) ≠ chebyshevNode n k := by
+  simp only [chebyshevNode]
+  intro heq
+  rw [Real.cos_eq_cos_iff] at heq
+  obtain ⟨j, hj | hj⟩ := heq
+  · -- Case 1: (2k+1)π/(2n) = 2jπ + πp/q
+    -- → q(2k+1) = 4jnq + 2np (after ×2nq/π)
+    -- LHS is odd, RHS is even → contradiction
+    have hpi : Real.pi ≠ 0 := Real.pi_ne_zero
+    have hq_ne : (q : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hq_pos.ne'
+    have hn_ne : (n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hn.ne'
+    -- Extract the angle equation (divide by π)
+    have hangle : (2 * (k.val : ℝ) + 1) / (2 * n) = 2 * j + p / q := by
+      have h := hj
+      rw [show (2 * (k.val : ℝ) + 1) * Real.pi / (2 * ↑n) =
+            Real.pi * ((2 * k.val + 1) / (2 * n)) from by ring,
+          show 2 * (j : ℝ) * Real.pi + ↑p * Real.pi / ↑q =
+            Real.pi * (2 * j + ↑p / ↑q) from by ring] at h
+      exact mul_left_cancel₀ hpi h
+    -- Multiply by 2nq to get integer equation in ℝ
+    have hR : (q : ℝ) * (2 * k.val + 1) = 4 * j * n * q + 2 * n * p := by
+      have h := congr_arg (· * (2 * n * q)) hangle
+      field_simp [hn_ne, hq_ne] at h ⊢
+      linarith
+    -- Cast to ℤ
+    have hint : (q : ℤ) * (2 * ↑k.val + 1) = 4 * j * ↑n * ↑q + 2 * ↑n * ↑p := by
+      exact_mod_cast hR
+    -- LHS q*(2k+1) is odd (product of two odd numbers)
+    have hodd : Odd ((q : ℤ) * (2 * ↑k.val + 1)) :=
+      (by exact_mod_cast hq : Odd (q : ℤ)).mul ⟨↑k.val, by ring⟩
+    -- RHS 4jnq + 2np is even (= 2*(2jnq + np))
+    have heven : Even (4 * j * (↑n : ℤ) * ↑q + 2 * ↑n * ↑p) :=
+      ⟨2 * j * ↑n * ↑q + ↑n * ↑p, by ring⟩
+    -- hint rewrites hodd: Odd (4jnq + 2np), contradicting heven
+    exact heven.not_odd (hint ▸ hodd)
+  · -- Case 2: (2k+1)π/(2n) = 2jπ - πp/q
+    -- → q(2k+1) + 2np = 4jnq (after ×2nq/π)
+    -- LHS is odd + even = odd, RHS is even → contradiction
+    have hpi : Real.pi ≠ 0 := Real.pi_ne_zero
+    have hq_ne : (q : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hq_pos.ne'
+    have hn_ne : (n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hn.ne'
+    have hangle : (2 * (k.val : ℝ) + 1) / (2 * n) = 2 * j - p / q := by
+      have h := hj
+      rw [show (2 * (k.val : ℝ) + 1) * Real.pi / (2 * ↑n) =
+            Real.pi * ((2 * k.val + 1) / (2 * n)) from by ring,
+          show 2 * (j : ℝ) * Real.pi - ↑p * Real.pi / ↑q =
+            Real.pi * (2 * j - ↑p / ↑q) from by ring] at h
+      exact mul_left_cancel₀ hpi h
+    have hR : (q : ℝ) * (2 * k.val + 1) + 2 * n * p = 4 * j * n * q := by
+      have h := congr_arg (· * (2 * n * q)) hangle
+      field_simp [hn_ne, hq_ne] at h ⊢
+      linarith
+    have hint : (q : ℤ) * (2 * ↑k.val + 1) + 2 * ↑n * ↑p = 4 * j * ↑n * ↑q := by
+      exact_mod_cast hR
+    -- LHS: q*(2k+1) is odd (odd × odd), 2np is even → sum is odd
+    have hodd_sum : Odd ((q : ℤ) * (2 * ↑k.val + 1) + 2 * ↑n * ↑p) := by
+      apply Odd.add_even
+      · exact (by exact_mod_cast hq : Odd (q : ℤ)).mul ⟨↑k.val, by ring⟩
+      · exact ⟨↑n * ↑p, by ring⟩
+    -- RHS 4jnq is even
+    have heven_rhs : Even (4 * j * (↑n : ℤ) * ↑q) := ⟨2 * j * ↑n * ↑q, by ring⟩
+    exact heven_rhs.not_odd (hint ▸ hodd_sum)
+
+/-- The Lebesgue formula applies for ALL n when p, q are odd (not just along n = mq
+    multiples), since cos(πp/q) is never a Chebyshev node. -/
+lemma chebyshev_lebesgue_eq_all_n (p q : ℕ) (hp : Odd p) (hq : Odd q)
+    (hq_pos : 0 < q) (n : ℕ) (hn : 0 < n) :
+    chebyshevLebesgue n (Real.cos (↑p * Real.pi / ↑q)) =
+    |Real.cos (↑n * (↑p * Real.pi / ↑q))| / ↑n *
+    ∑ k : Fin n, Real.sin ((2 * k.val + 1 : ℝ) * Real.pi / (2 * n)) /
+                 |Real.cos (↑p * Real.pi / ↑q) - chebyshevNode n k| :=
+  chebyshev_lebesgue_eq n hn (↑p * Real.pi / ↑q)
+    (fun k => x_not_chebyshev_node p q hp hq hq_pos n hn k)
 
 /-! ## Key Lemmas with Sorry -/
 

--- a/research/problems/erdos-1151-oq-04/knowledge.md
+++ b/research/problems/erdos-1151-oq-04/knowledge.md
@@ -48,33 +48,53 @@ chebyshev_lebesgue_growth [sorry] + divergence_from_lebesgue_growth [sorry]
 
 ## Hard Sorries Remaining (4 in main file)
 
-### 1. `lagrange_basis_chebyshev_formula` [PARTIAL PROGRESS]
-Requires: Chebyshev product formula T_n(x) = 2^{n-1}·Π_{k=0}^{n-1}(x - cos φₖ).
-**NOT in Mathlib v4.26.0**, but now have the prerequisites:
-- `T_ofNat_ne_zero` ✓
-- `natDegree_T_ofNat` ✓  
-- `leadingCoeff_T_ofNat` ✓
-**Next**: Prove product formula using: T_n - 2^{n-1}·∏(X - cos φₖ) has degree < n with n roots → = 0.
+### Remaining Sorries (2, as of Session 6)
 
-### 2. `chebyshev_lebesgue_eq` [BLOCKED by #1]
-Reduces Λₙ(cos θ) to a trigonometric sum. Follows from #1.
+### 1. `chebyshev_lebesgue_growth` [OPEN - harmonic sum lower bound]
+Main result: Λₙ(cos(πp/q)) → ∞ for all n.
+Key insight from Session 6: cos(πp/q) is NEVER a Chebyshev node when q is odd (x_not_chebyshev_node).
+So `chebyshev_lebesgue_eq_all_n` applies for ALL n.
+Formula: Λₙ = |cos(nπp/q)| / n · Σₖ sin(φₖ) / |cos(πp/q) - cos φₖ|.
+Remaining: show Λₙ → ∞. Key step: the trig sum S(n) ≥ C·n·log(n) (harmonic lower bound).
+For the full sequence: cos(nπp/q) can vanish for some n, so need a more refined argument.
 
-### 3. `chebyshev_lebesgue_growth` [BLOCKED by #1, #2]
-Main result: Λₙ(cos(πp/q)) → ∞. Proof outline known:
-- Along n = mq: |cos(nπp/q)| = 1 (already proved: cos_rational_pi_nonzero_along_multiples)
-- Lower bound: Σₖ sin(φₖ)/|cos(πp/q) - cos φₖ| ≥ C·log(n)
-- Blocked by needing formula from #1.
+### 2. `divergence_from_lebesgue_growth` [OPEN - fundamental gap]
+Statement: Λₙ(x) → ∞ ⟹ ∃ continuous f, Lₙf(x) → +∞ (full sequence).
+**Gap**: Banach-Steinhaus gives lim sup |Lₙf(x)| = ∞ (NOT lim = +∞).
+Lacunary construction fails: cross terms from earlier n_j dominate n_k contribution.
+May need to weaken axiom statement to lim sup = ∞ or find explicit construction specific to Chebyshev nodes.
 
-### 4. `divergence_from_lebesgue_growth` [OPEN, proof sketch has gap]
-Statement: Λₙ(x) → ∞ ⟹ ∃ continuous f, Lₙf(x) → +∞.
+## Session 2026-04-23 — Results (Session 6)
 
-Proof sketch in file gives lacunary construction: f = Σₖ (1/k²) fₙₖ.
-**Gap**: Cross terms dominate: Σⱼ≠ₖ (1/j²) Λₙₖ(x) ≥ Λₙₖ(x)·(π²/6) >> Λₙₖ(x)/k².
-Fix requires de-correlation: |Lₙₖ(fₙⱼ)(x)| << Λₙₖ(x) for nₖ >> nⱼ.
-Estimated: 200+ lines, needs analysis of Chebyshev interpolation between different grids.
+**Outcome**: progress
+**Sorries closed**: 0 (new helper lemmas, no sorry reduction this session)
+**New lemmas added**:
+- `x_not_chebyshev_node (p q n k)`: For odd p, q, cos(πp/q) ≠ chebyshevNode n k for ALL n, k.
+  Proof: parity argument — cos(πp/q) = cos((2k+1)π/(2n)) requires q*(2k+1) = even, but LHS is odd (q odd, 2k+1 odd). Contradiction.
+- `chebyshev_lebesgue_eq_all_n`: applies lebesgue_eq for ALL n ≥ 1 when p, q odd.
+  Direct consequence of x_not_chebyshev_node + chebyshev_lebesgue_eq.
 
-**Alternative**: Baire category gives lim sup = ∞, but NOT full divergence (lim = ∞).
-May need to reconsider whether the axiom statement is too strong.
+**Key insight discovered**: For q ODD, x = cos(πp/q) is NEVER a Chebyshev node of any degree. This is because the node condition q*(2k+1) = 4j*n*q ± 2n*p requires an odd integer to equal an even integer. This means `chebyshev_lebesgue_eq` (the trigonometric sum formula) applies for ALL n (not just the n = mq subsequence as previously thought).
+
+**Remaining blockers**: 
+1. Harmonic sum lower bound for `chebyshev_lebesgue_growth`
+2. `divergence_from_lebesgue_growth` may require weakening (lim sup = ∞ instead of lim = +∞)
+
+**PR**: TBD (this session)
+
+## Session 2026-04-23 — Results (Session 5)
+
+**Outcome**: progress
+**Sorries closed**: 2 (lagrange_basis_chebyshev_formula ✓, chebyshev_lebesgue_eq ✓, from 4 → 2 sorries)
+**New proofs added**:
+- `chebyshev_product_formula`: T_n = 2^{n-1} · ∏(X - C(cos φₖ)) — key algebraic identity
+  Proof: T_n - Q has degree < n and n distinct roots (Chebyshev nodes) → T_n - Q = 0
+- `lagrange_basis_chebyshev_formula`: explicit Lagrange basis at Chebyshev nodes
+  Uses product formula + T_derivative_eq_U + U_real_cos
+- `chebyshev_lebesgue_eq`: Λₙ(cos θ) = |cos(nθ)|/n · Σ sin(φₖ)/|cos θ - cos φₖ|
+  Direct from lagrange_basis_chebyshev_formula
+
+**PR**: #11829 (merged)
 
 ## Session 2026-04-23 — Results (Session 4)
 
@@ -128,11 +148,13 @@ Therefore T_n = Q_n.
 
 ## Next Steps
 
-1. **IMMEDIATE**: Prove the Chebyshev product formula using T_ofNat_ne_zero + natDegree_T_ofNat + leadingCoeff_T_ofNat (all now building):
-   - Define Q_n = 2^{n-1} · ∏_{k : Fin n} (X - C (cos φₖ))
-   - Show T_n - Q_n has natDegree ≤ n-1 (leadingCoeffs cancel: both = 2^{n-1})
-   - Show T_n - Q_n has n distinct roots (chebyshevNode_is_root + chebyshevNode_injective)
-   - Apply `Polynomial.card_roots_le_degree` to conclude T_n - Q_n = 0
-   - This unblocks lagrange_basis_chebyshev_formula, chebyshev_lebesgue_eq, chebyshev_lebesgue_growth
-2. Assess divergence_from_lebesgue_growth gap more carefully; consider Banach-Steinhaus
-3. Mathlib v4.26.0 confirmed: no Chebyshev product formula; must build locally
+1. **chebyshev_lebesgue_growth**: Prove the sum S(n) = Σₖ sin(φₖ)/|cos(πp/q) - cos φₖ| ≥ C·n·log(n).
+   - Strategy: nodes near angle πp/q contribute ≈ n/π · Σ 1/j (harmonic series)
+   - `Real.tendsto_sum_range_one_div_nat_succ_atTop` from Mathlib (harmonic divergence) is available
+   - chebyshev_lebesgue_eq_all_n (new from Session 6) now applies for ALL n, not just n = mq
+   - For the |cos(nπp/q)| factor: nonzero when q is odd (parity argument used in x_not_chebyshev_node)
+   
+2. **divergence_from_lebesgue_growth**: Consider weakening the theorem.
+   - Banach-Steinhaus gives lim sup = ∞ (NOT lim = +∞ as currently stated)
+   - For lim = +∞: needs specialized construction for Chebyshev nodes at rational cosines
+   - Option: weaken axiom statement to ∃ f, lim sup |Lₙf(x)| = ∞

--- a/src/data/research/problems/erdos-1151-oq-04.json
+++ b/src/data/research/problems/erdos-1151-oq-04.json
@@ -6,8 +6,8 @@
   "tier": "B",
   "path": "full",
   "problemStatement": {
-    "formal": "axiom erdos_1941_divergence (p q : \u2115) (hp : Odd p) (hq : Odd q) (hq1 : 1 < q) (x : \u211d) (hx : x = Real.cos (\u2191p * Real.pi / \u2191q)) : Filter.Tendsto (fun n => chebyshevInterpSeq (fun _ => 0) x n) Filter.atTop Filter.atTop",
-    "plain": "Can the axiom erdos_1941_divergence be proved in Lean 4 by formalizing the Lebesgue function growth rate \u039b\u2099(cos(\u03c0p/q)) \u2192 \u221e for rational cosine points with odd p, q?",
+    "formal": "axiom erdos_1941_divergence (p q : ℕ) (hp : Odd p) (hq : Odd q) (hq1 : 1 < q) (x : ℝ) (hx : x = Real.cos (↑p * Real.pi / ↑q)) : Filter.Tendsto (fun n => chebyshevInterpSeq (fun _ => 0) x n) Filter.atTop Filter.atTop",
+    "plain": "Can the axiom erdos_1941_divergence be proved in Lean 4 by formalizing the Lebesgue function growth rate Λₙ(cos(πp/q)) → ∞ for rational cosine points with odd p, q?",
     "whyMatters": [
       "Eliminates an axiom from Erdos1151Problem.lean, moving from axiomatized to verified",
       "Connects classical approximation theory (Chebyshev nodes, Lebesgue function) to Lean 4",
@@ -21,7 +21,7 @@
       "limitPointSet_isClosed: limit point sets are closed"
     ],
     "open": [
-      "Lebesgue function growth: \u039b\u2099(cos(\u03c0p/q)) \u2192 \u221e as n \u2192 \u221e",
+      "Lebesgue function growth: Λₙ(cos(πp/q)) → ∞ as n → ∞",
       "erdos_1941_divergence: divergence of Chebyshev interpolation at rational cosines"
     ],
     "goal": "Prove erdos_1941_divergence to eliminate the axiom from the gallery"
@@ -40,29 +40,38 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ACT: 3 new lemmas (T_ofNat_ne_zero, natDegree_T_ofNat, leadingCoeff_T_ofNat) build cleanly; product formula proof strategy clear; 4 sorries remain",
+    "progressSummary": "ACT: Session 6 complete. 2 sorries remain (lebesgue_growth + divergence_from_growth). New lemmas: x_not_chebyshev_node + chebyshev_lebesgue_eq_all_n prove formula applies for ALL n when q odd.",
     "builtItems": [
-      "T_ofNat_ne_zero (n : \u2115) : T \u211d (n : \u2124) \u2260 0 \u2014 Erdos1151OQ04.lean:274",
-      "natDegree_T_ofNat : \u2200 n : \u2115, (T \u211d (n : \u2124)).natDegree = n \u2014 Erdos1151OQ04.lean:282",
-      "leadingCoeff_T_ofNat : \u2200 n \u2265 1, (T \u211d (n : \u2124)).leadingCoeff = 2^(n-1) \u2014 Erdos1151OQ04.lean:306",
-      "Build fixes: all Session 3 lemmas compile cleanly in Proofs/Erdos1151OQ04.lean"
+      "T_ofNat_ne_zero (n : ℕ) : T ℝ (n : ℤ) ≠ 0 — Erdos1151OQ04.lean:274",
+      "natDegree_T_ofNat : ∀ n : ℕ, (T ℝ (n : ℤ)).natDegree = n — Erdos1151OQ04.lean:282",
+      "leadingCoeff_T_ofNat : ∀ n ≥ 1, (T ℝ (n : ℤ)).leadingCoeff = 2^(n-1) — Erdos1151OQ04.lean:306",
+      "Build fixes: all Session 3 lemmas compile cleanly in Proofs/Erdos1151OQ04.lean",
+      "chebyshev_product_formula: T_n = 2^{n-1} * prod(X - cos phi_k) — Erdos1151OQ04.lean:309",
+      "lagrange_basis_chebyshev_formula: explicit Lagrange basis via product formula — Erdos1151OQ04.lean:388",
+      "chebyshev_lebesgue_eq: Lebesgue function explicit formula for ALL n when q odd — Erdos1151OQ04.lean:498",
+      "x_not_chebyshev_node: parity lemma, cos(pi*p/q) != chebyshevNode n k for all n when p,q odd — Erdos1151OQ04.lean:534",
+      "chebyshev_lebesgue_eq_all_n: Lebesgue formula for all n when p,q odd — Erdos1151OQ04.lean:601"
     ],
     "insights": [
-      "Lebesgue function \u039b\u2099(x) = \u03a3\u2096 |\u2113\u2096(x)| measures worst-case interpolation amplification",
-      "Growth rate for rational cosines: \u039b\u2099(cos(\u03c0p/q)) \u2265 C\u00b7log(n)",
-      "Divergence of interpolation sequence follows from \u039b\u2099 \u2192 \u221e via bump function",
-      "natDegree and leadingCoeff of T_n proved by two-step induction on recurrence T_{n+2} = 2X\u00b7T_{n+1} - T_n",
-      "Product formula proof strategy: T_n - Q_n has deg < n and n roots (by Chebyshev node roots + card_roots_le_degree) \u2192 T_n = Q_n",
-      "(2 : \u211d[X]) = C 2 via Polynomial.C_ofNat; leadingCoeff_C gives leadingCoeff = 2",
+      "Lebesgue function Λₙ(x) = Σₖ |ℓₖ(x)| measures worst-case interpolation amplification",
+      "Growth rate for rational cosines: Λₙ(cos(πp/q)) ≥ C·log(n)",
+      "Divergence of interpolation sequence follows from Λₙ → ∞ via bump function",
+      "natDegree and leadingCoeff of T_n proved by two-step induction on recurrence T_{n+2} = 2X·T_{n+1} - T_n",
+      "Product formula proof strategy: T_n - Q_n has deg < n and n roots (by Chebyshev node roots + card_roots_le_degree) → T_n = Q_n",
+      "(2 : ℝ[X]) = C 2 via Polynomial.C_ofNat; leadingCoeff_C gives leadingCoeff = 2",
       "apply lemma fails when conclusion has concrete value (n+2) vs metavar (p.natDegree): use have key := lemma proof; rw [key]",
-      "\u2115 strict bound j.val < n does NOT give 2*j+1 < 2*n in \u211d via linarith; need omega on \u2115 then exact_mod_cast",
-      "div_lt_iff renamed to div_lt_iff\u2080 in Mathlib v4.26.0"
+      "ℕ strict bound j.val < n does NOT give 2*j+1 < 2*n in ℝ via linarith; need omega on ℕ then exact_mod_cast",
+      "div_lt_iff renamed to div_lt_iff₀ in Mathlib v4.26.0",
+      "Session 5 proved product formula, lagrange basis formula, and lebesgue_eq (sorries: 4→2)",
+      "x_not_chebyshev_node: cos(pi*p/q) is NEVER a Chebyshev node when q is odd (parity: q*(2k+1) is odd, angle condition requires even = odd)",
+      "chebyshev_lebesgue_eq_all_n: applies for ALL n when p,q odd (not just n=mq subsequence)",
+      "divergence_from_lebesgue_growth fundamental gap: Banach-Steinhaus only gives lim sup = inf, not lim = +inf; axiom may be overstated"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove Chebyshev product formula: define Q_n = 2^{n-1}*prod(X - cos phi_k), show T_n - Q_n = 0 via card_roots_le_degree",
-      "chebyshevNode_is_root + chebyshevNode_injective give n distinct roots of T_n - Q_n",
-      "Unblocks: lagrange_basis_chebyshev_formula, chebyshev_lebesgue_eq, chebyshev_lebesgue_growth"
+      "Prove harmonic sum lower bound: S(n) >= C*n*log(n) for the trig sum",
+      "Use chebyshev_lebesgue_eq_all_n + harmonic lower bound to prove chebyshev_lebesgue_growth",
+      "Assess whether divergence_from_lebesgue_growth needs weakening to lim sup = inf"
     ]
   },
   "tags": [
@@ -93,11 +102,11 @@
     {
       "path": "Proofs/Erdos1151OQ04.lean",
       "filename": "Erdos1151OQ04.lean",
-      "lineCount": 323,
-      "theoremCount": 18,
+      "lineCount": 656,
+      "theoremCount": 26,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 9,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1151OQ04.lean"
     },


### PR DESCRIPTION
## Summary

Session 6 for erdos-1151-oq-04 (Chebyshev interpolation divergence). Two new lemmas proved without sorry:

- **`x_not_chebyshev_node`**: For odd `p`, `q`, the value `cos(πp/q)` is never a Chebyshev node of any degree `n`. Proof uses `Real.cos_eq_cos_iff` to reduce to two integer equations, each contradicted by parity: the node condition requires `q*(2k+1) = even`, but `q*(2k+1)` is odd (product of two odd naturals).

- **`chebyshev_lebesgue_eq_all_n`**: The trigonometric sum formula for the Lebesgue function `Λₙ(cos(πp/q)) = |cos(nπp/q)|/n · Σₖ sin(φₖ)/|cos(πp/q)-cos φₖ|` now applies for **all** `n ≥ 1` (not just `n = mq` as previously required). Follows directly from `x_not_chebyshev_node` + `chebyshev_lebesgue_eq`.

Also corrects meta.json sorry count: Session 5 (PR #11829) reduced sorries from 4→2, but meta.json was not updated.

## Progress

- Files: `Erdos1151OQ04.lean` (+93 lines), `knowledge.md` (Sessions 5+6 added), `erdos-1151-oq-04.json`
- Sorry count: 2 remain (`chebyshev_lebesgue_growth`, `divergence_from_lebesgue_growth`)
- No sorries introduced

## Remaining Work

1. `chebyshev_lebesgue_growth`: Prove harmonic sum lower bound `S(n) ≥ C·n·log(n)`
2. `divergence_from_lebesgue_growth`: May need weakening (Banach-Steinhaus gives lim sup = ∞, not lim = +∞)

🤖 Generated by researcher-7