### PR TITLE
Fix: correct erdos-512 sorry count (claims 2, actual 1)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7151,9 +7151,12 @@
     },
     "erdos-512": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 5,
+      "auditCount": 6,
       "lastAudited": "2026-04-23T10:25:43Z",
-      "result": "clean"
+      "issues": [
+        "sorries 2->1 (Lean file has 1 sorry: Parseval theorem at line 194)"
+      ],
+      "result": "issues-fixed"
     },
     "erdos-513": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-512/meta.json
+++ b/src/data/proofs/erdos-512/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 1,
     "erdosNumber": 512,
     "erdosUrl": "https://erdosproblems.com/512",
     "erdosProblemStatus": "solved",
@@ -70,7 +70,7 @@
     ],
     "axiomCount": 2,
     "lineCount": 267,
-    "assumptions": "2 axioms: konyagin_theorem, mcgehee_pigno_smith_theorem. 2 sorries."
+    "assumptions": "2 axioms: konyagin_theorem, mcgehee_pigno_smith_theorem. 1 sorry (Parseval's theorem)."
   },
   "overview": {
     "historicalContext": "Littlewood conjectured in the 1960s that the $L^1$ norm of any exponential sum with $N$ terms is at least $c \\log N$. Specifically, if $A \\subset \\mathbb{Z}$ is a finite set with $|A| = N$, then $\\int_0^1 |\\sum_{n \\in A} e^{2\\pi i n\\theta}|\\,d\\theta \\geq c \\log N$ for an absolute constant $c > 0$. This is a fundamental question about how \"flat\" a trigonometric polynomial with unit coefficients can be.\n\nThe conjecture was independently proved in 1981 by two groups. Konyagin gave an analytic proof using character sum estimates and concentration inequalities. McGehee, Pigno, and Smith gave an elegant proof based on Hardy's inequality for power series. The MPS approach is widely considered the more beautiful: they showed that Hardy's classical inequality $\\sum_{n=1}^\\infty \\frac{1}{n}(\\sum_{k=1}^n a_k)^2 \\leq 4\\sum a_n^2$ applied to the Fourier coefficients of $|S_A|$ directly yields the logarithmic lower bound via the harmonic series $\\sum_{k=1}^N 1/k \\sim \\log N$.\n\nThe bound is tight: the Dirichlet kernel $D_N(\\theta) = \\sum_{n=0}^{N-1} e^{2\\pi i n\\theta} = \\sin(N\\pi\\theta)/\\sin(\\pi\\theta)$ has $L^1$ norm $(4/\\pi^2)\\log N + O(1)$, which is the Lebesgue constant from classical Fourier analysis. This means arithmetic progressions are essentially the worst-case sets for Littlewood's bound.\n\nThe result connects to several areas: the flat polynomial problem (can $|P(z)|$ be nearly constant on $|z|=1$ for polynomials with $\\pm 1$ coefficients?), the Rudin-Shapiro construction, equidistribution theory via Weyl's criterion, and character sum bounds in analytic number theory. Erdős included it as Problem #512, emphasizing its role as a bridge between harmonic analysis and combinatorial number theory.",
@@ -222,7 +222,7 @@
     "theoremCount": 11,
     "definitionCount": 16,
     "path": "Proofs/Erdos512Problem.lean",
-    "sorries": 2
+    "sorries": 1
   },
   "crossReferences": [
     {
@@ -241,5 +241,5 @@
       "description": "Related Erdős problem sharing themes: exponential-sums, harmonic-analysis"
     }
   ],
-  "sorries": 2
+  "sorries": 1
 }


### PR DESCRIPTION
## Summary
- Correct sorry count in erdos-512 meta.json: claims 2, actual 1
- The Lean file has 1 sorry (Parseval's theorem at line 194) and 2 axiom declarations (correctly counted as axiomCount: 2)
- Discovered during gallery integrity audit session 2026-04-23

## Evidence
- `meta.json claims`: sorries: 2
- `Lean file shows`: 1 sorry at line 194

Discovered during gallery integrity audit.