### PR TITLE
Enrich napoleons-theorem-oq-02: add index.ts, annotations, fix section ranges

### DIFF
--- a/src/data/proofs/napoleons-theorem-oq-02/annotations.json
+++ b/src/data/proofs/napoleons-theorem-oq-02/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-napoq02-header",
+    "proofId": "napoleons-theorem-oq-02",
+    "range": { "startLine": 8, "endLine": 63 },
+    "type": "concept",
+    "title": "Napoleon's Theorem as a DFT Filter: Overview",
+    "content": "The module docstring introduces the central insight: the Napoleon triangle construction is equivalent to applying the 3-point Discrete Fourier Transform to triangle vertices and then filtering specific frequency components.\n\n**DFT of triangle (z₁, z₂, z₃)**:\n- X₀ = z₁ + z₂ + z₃  (DC / centroid component)\n- X₁ = z₁ + ω·z₂ + ω²·z₃  (frequency-1 component)\n- X₂ = z₁ + ω²·z₂ + ω·z₃  (frequency-2 component)\n\n**Outer Napoleon DFT**:\n- Y₀ = X₀ (centroid preserved)\n- Y₁ = -X₁ (frequency-1 negated)\n- Y₂ = 0 (frequency-2 eliminated)\n\n**Inner Napoleon DFT**:\n- Y₀' = X₀ (centroid preserved)\n- Y₁' = 0 (frequency-1 eliminated)\n- Y₂' = -X₂ (frequency-2 negated)\n\nSince an equilateral triangle is characterized by X₂ = 0, the outer Napoleon triangle is ALWAYS equilateral — this algebraic identity is the mathematical heart of Napoleon's theorem.",
+    "mathContext": "The 3-point DFT is defined by $X_k = \\sum_{j=1}^{3} z_j \\cdot \\omega^{(j-1)k}$ where $\\omega = e^{2\\pi i/3}$. The outer Napoleon map acts diagonally: $(X_0, X_1, X_2) \\mapsto (X_0, -X_1, 0)$. Equilateral triangles satisfy $X_2 = 0$, so $Y_2 = 0$ immediately implies equilaterality.",
+    "significance": "supporting",
+    "relatedConcepts": ["discrete Fourier transform", "Napoleon's theorem", "equilateral triangles", "frequency components"],
+    "prerequisites": ["Napoleon's theorem (parent proof)", "complex numbers", "cube roots of unity", "DFT basics"]
+  },
+  {
+    "id": "ann-napoq02-omega-def",
+    "proofId": "napoleons-theorem-oq-02",
+    "range": { "startLine": 65, "endLine": 83 },
+    "type": "definition",
+    "title": "omega and omegaSq: Primitive Cube Root of Unity",
+    "content": "Defines the primitive cube root of unity and its key algebraic properties:\n\n- `omega : ℂ = (-1 + I·√3) / 2` — the standard formula for e^{2πi/3}\n- `omegaSq : ℂ = (-1 - I·√3) / 2` — equals ω² (complex conjugate of ω)\n- `sqrt3_sq_real` (private lemma): √3 · √3 = 3, proved via `Real.mul_self_sqrt`\n\nThe use of `(-1 + I·√3)/2` rather than a trigonometric definition (`exp (2πi/3)`) allows algebraic proof strategies using `nlinarith` after expanding real and imaginary parts. The key challenge is that Lean's `Real.sqrt` requires explicit squaring lemmas rather than computing with `sqrt 3 = 3^{1/2}` directly.",
+    "mathContext": "$\\omega = e^{2\\pi i/3} = -\\frac{1}{2} + \\frac{\\sqrt{3}}{2}i$. Both $\\omega$ and $\\omega^2$ are declared `noncomputable` because they involve `Real.sqrt 3`. The private lemma `sqrt3_sq_real : Real.sqrt 3 * Real.sqrt 3 = 3` is used in every subsequent proof to discharge `nlinarith` goals involving $\\sqrt{3}^2$.",
+    "significance": "key",
+    "relatedConcepts": ["primitive cube root of unity", "Real.sqrt", "Complex.I", "noncomputable definition"],
+    "prerequisites": ["complex number arithmetic", "Real.mul_self_sqrt", "Lean noncomputable declarations"]
+  },
+  {
+    "id": "ann-napoq02-cube-identity",
+    "proofId": "napoleons-theorem-oq-02",
+    "range": { "startLine": 86, "endLine": 116 },
+    "type": "theorem",
+    "title": "Cube Root Identities: ω² = ω^2, 1+ω+ω²=0, ω³=1",
+    "content": "Three foundational theorems establishing the algebraic properties of ω:\n\n1. **`omegaSq_eq_sq`**: omegaSq = omega^2. Proved by `Complex.ext` (separating real/imaginary parts) then `nlinarith` using `sqrt3_sq_real`. The `ring_nf; nlinarith [h3]` pattern handles nonlinear arithmetic involving √3.\n\n2. **`one_add_omega_add_omegaSq`**: 1 + ω + ω² = 0. Direct computation by `simp + ring`. This is the key identity used throughout all four main DFT theorems.\n\n3. **`omega_cube`**: ω³ = 1. Similarly proved by expanding and using nlinarith.\n\nAll three proofs follow the pattern: `apply Complex.ext`, `simp` to reduce to real/imaginary arithmetic, then `ring_nf; nlinarith [sqrt3_sq_real]`.",
+    "mathContext": "The three identities follow from $\\omega = e^{2\\pi i/3}$: $1 + e^{2\\pi i/3} + e^{4\\pi i/3} = 0$ (sum of 3rd roots of unity) and $e^{2\\pi i} = 1$. In Lean, these are proved purely algebraically without invoking exponential/trigonometric identities.",
+    "significance": "key",
+    "relatedConcepts": ["cube roots of unity", "Complex.ext", "nlinarith", "ring_nf"],
+    "prerequisites": ["complex number arithmetic", "omega definition", "sqrt3_sq_real lemma"]
+  },
+  {
+    "id": "ann-napoq02-outer-dft1",
+    "proofId": "napoleons-theorem-oq-02",
+    "range": { "startLine": 122, "endLine": 156 },
+    "type": "theorem",
+    "title": "napoleon_outer_dft1: Outer Napoleon Negates Frequency-1 (Y₁ = -X₁)",
+    "content": "**Main theorem**: G₁ + ω·G₂ + ω²·G₃ = -(z₁ + ω·z₂ + ω²·z₃)\n\nThe frequency-1 DFT component of the outer Napoleon triangle equals the negation of the original triangle's frequency-1 component. This is the 'frequency-1 negation' part of the Napoleon filter.\n\n**Proof technique**: Expand G₁, G₂, G₃ via `napoleonCenter`, substitute ω = (-1+I√3)/2 and ω² = (-1-I√3)/2, then apply `Complex.ext` to separate real and imaginary parts. Each part is a polynomial identity in z₁.re, z₁.im, ..., √3, proved by `ring_nf; nlinarith [sqrt3_sq_real, ...]`.\n\nThe `nlinarith` call requires 8 hint terms: the squaring lemma h3, `sq_nonneg (Real.sqrt 3)`, and 6 commutativity hints `mul_comm (Real.sqrt 3) zₖ.re/im` to guide the nonlinear arithmetic.",
+    "mathContext": "Coefficient computation for the $z_1$ term in $Y_1 = G_1 + \\omega G_2 + \\omega^2 G_3$:\n$$\\text{coeff}(z_1) = \\frac{\\omega(1-\\omega^2) + \\omega^2(1-\\omega)}{3} = \\frac{\\omega+\\omega^2-2\\omega^3}{3} = \\frac{-1-2}{3} = -1$$\nSimilarly $\\text{coeff}(z_2) = -\\omega$ and $\\text{coeff}(z_3) = -\\omega^2$, giving $Y_1 = -(z_1 + \\omega z_2 + \\omega^2 z_3) = -X_1$.",
+    "significance": "critical",
+    "relatedConcepts": ["napoleon_outer_dft2", "napoleonCenter", "G₁ G₂ G₃", "Complex.ext"],
+    "prerequisites": ["NapoleonsTheorem.lean (G₁, G₂, G₃, napoleonCenter)", "omega definition", "cube root identities"]
+  },
+  {
+    "id": "ann-napoq02-outer-dft2",
+    "proofId": "napoleons-theorem-oq-02",
+    "range": { "startLine": 158, "endLine": 191 },
+    "type": "theorem",
+    "title": "napoleon_outer_dft2: Outer Napoleon Kills Frequency-2 (Y₂ = 0)",
+    "content": "**Main theorem**: G₁ + ω²·G₂ + ω·G₃ = 0\n\nThe frequency-2 DFT component of the outer Napoleon triangle is identically zero. This is the **deepest** result in the file: since equilateral triangles are precisely those with vanishing frequency-2 DFT component, this immediately explains why the outer Napoleon triangle is ALWAYS equilateral.\n\n**Mathematical insight**: The coefficient of z₁ in Y₂ is (ω²(1-ω²)+ω(1-ω))/3. Using 1+ω+ω²=0 (so ω+ω²=-1 and ω²·ω=ω³=1), this simplifies to (ω²-ω⁴+ω-ω²)/3 = (ω-ω)/3 = 0. The same holds for z₂ and z₃ by symmetry, giving Y₂ = 0.\n\n**Proof structure**: Identical to napoleon_outer_dft1 — Complex.ext, simp, ring_nf, nlinarith.",
+    "mathContext": "$Y_2 = G_1 + \\omega^2 G_2 + \\omega G_3 = 0$. Mechanically: expand via `napoleonCenter`, distribute $\\omega, \\omega^2$, and use $\\sqrt{3}^2 = 3$ to eliminate all radicals. The result is 0 by polynomial identity. **Consequence**: the outer Napoleon triangle $G$ has DFT $(X_0, -X_1, 0)$, so it has zero $X_2$ component — the necessary and sufficient condition for equilaterality.",
+    "significance": "critical",
+    "relatedConcepts": ["napoleon_outer_dft1", "equilateral triangle characterization", "frequency-2 component"],
+    "prerequisites": ["napoleon_outer_dft1", "cube root identities", "napoleonCenter formula"]
+  },
+  {
+    "id": "ann-napoq02-inner-dft",
+    "proofId": "napoleons-theorem-oq-02",
+    "range": { "startLine": 197, "endLine": 265 },
+    "type": "theorem",
+    "title": "Inner Napoleon DFT: Outer/Inner Symmetry (Y₁'=0, Y₂'=-X₂)",
+    "content": "Two theorems establishing the inner Napoleon triangle's DFT action:\n\n**`napoleon_inner_dft1`**: G₁' + ω·G₂' + ω²·G₃' = 0 (frequency-1 is eliminated)\n\n**`napoleon_inner_dft2`**: G₁' + ω²·G₂' + ω·G₃' = -(z₁ + ω²·z₂ + ω·z₃) (frequency-2 is negated)\n\nThis reveals the outer/inner symmetry: the outer Napoleon construction kills X₂ while preserving X₁ (negated), while the inner kills X₁ while preserving X₂ (negated). The two constructions are 'complex conjugates' of each other in the DFT domain — outer uses +I√3, inner uses -I√3 in the napoleonCenter formula.\n\n**Proof**: Uses `innerNapoleonCenter` and `G₁', G₂', G₃'` from NapoleonsTheorem.lean (the inner construction uses -I√3/6 instead of +I√3/6). Same nlinarith strategy.",
+    "mathContext": "Inner Napoleon center: $G_k' = \\frac{z_{k-1}+z_{k+1}}{2} - \\frac{i\\sqrt{3}}{6}(z_{k+1}-z_{k-1})$. In the DFT basis: $(X_0, X_1, X_2) \\mapsto (X_0, 0, -X_2)$. Outer/inner symmetry: conjugating $i \\to -i$ swaps $X_1 \\leftrightarrow X_2$ in the filter action.",
+    "significance": "key",
+    "relatedConcepts": ["innerNapoleonCenter", "G₁' G₂' G₃'", "outer/inner Napoleon symmetry", "complex conjugation"],
+    "prerequisites": ["napoleon_outer_dft1", "napoleon_outer_dft2", "NapoleonsTheorem.lean inner construction"]
+  },
+  {
+    "id": "ann-napoq02-filter",
+    "proofId": "napoleons-theorem-oq-02",
+    "range": { "startLine": 271, "endLine": 311 },
+    "type": "theorem",
+    "title": "napoleon_as_dft_filter: Complete Filter Characterization",
+    "content": "**`napoleon_as_dft_filter`** bundles all three outer Napoleon DFT actions into one conjunction:\n- (G₁+G₂+G₃)/3 = (z₁+z₂+z₃)/3  (Y₀ = X₀: centroid preserved)\n- G₁+ω·G₂+ω²·G₃ = -(z₁+ω·z₂+ω²·z₃)  (Y₁ = -X₁)\n- G₁+ω²·G₂+ω·G₃ = 0  (Y₂ = 0)\n\nProof is trivial: `⟨napoleon_centroid_eq_original, napoleon_outer_dft1, napoleon_outer_dft2⟩`.\n\n**`inner_napoleon_as_dft_filter`**: Same for inner — bundles the inner centroid, Y₁'=0, Y₂'=-X₂ theorems. Both bundle theorems are purely propositional consequences of the four main DFT theorems.",
+    "mathContext": "The outer Napoleon map is a *circulant* linear operator on $(z_1, z_2, z_3) \\in \\mathbb{C}^3$. Circulant matrices are diagonalized by the DFT, with eigenvalues being the DFT of the first row. The eigenvalues here are $(1, -1, 0)$, confirming the filter interpretation.",
+    "significance": "critical",
+    "relatedConcepts": ["napoleon_centroid_eq_original", "circulant matrix", "DFT diagonalization", "eigenvalues"],
+    "prerequisites": ["napoleon_outer_dft1", "napoleon_outer_dft2", "napoleon_inner_dft1", "napoleon_inner_dft2"]
+  },
+  {
+    "id": "ann-napoq02-idft",
+    "proofId": "napoleons-theorem-oq-02",
+    "range": { "startLine": 313, "endLine": 336 },
+    "type": "theorem",
+    "title": "napoleon_center_idft_recovery: Explicit DFT Formula for G₁",
+    "content": "**`napoleon_center_idft_recovery`**: G₁(z₁,z₂,z₃) = ((z₁+z₂+z₃) - (z₁+ω·z₂+ω²·z₃)) / 3\n\nThis is the inverse DFT (IDFT) formula: given the filter output (X₀, -X₁, 0), the k=0 frequency component (index 1 in the DFT) yields G₁ directly. The formula simplifies to G₁ = (z₂·(1-ω) + z₃·(1-ω²))/3, which matches the napoleonCenter definition.\n\n**Significance**: This provides an alternative algebraic derivation of the napoleonCenter formula itself — it says G₁ IS the IDFT recovery from the filtered DFT. The proof is a straightforward `ring_nf; nlinarith` computation.",
+    "mathContext": "IDFT at index 1: $G_1 = \\frac{1}{3}(Y_0 + Y_1 + Y_2) = \\frac{X_0 + (-X_1) + 0}{3} = \\frac{(z_1+z_2+z_3)-(z_1+\\omega z_2 + \\omega^2 z_3)}{3} = \\frac{z_2(1-\\omega) + z_3(1-\\omega^2)}{3}$. Since $1-\\omega = (3+i\\sqrt{3})/2$ and $1-\\omega^2 = (3-i\\sqrt{3})/2$, this recovers the napoleonCenter formula exactly.",
+    "significance": "key",
+    "relatedConcepts": ["inverse DFT", "napoleonCenter", "IDFT recovery", "G₁ formula"],
+    "prerequisites": ["napoleon_as_dft_filter", "napoleonCenter definition", "cube root identities"]
+  }
+]

--- a/src/data/proofs/napoleons-theorem-oq-02/index.ts
+++ b/src/data/proofs/napoleons-theorem-oq-02/index.ts
@@ -1,0 +1,46 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+// Type assertion for JSON import
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+// Import the Lean source file
+const leanSource = () => import('../../../../proofs/Proofs/NapoleonsTheoremOQ02.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '', // Loaded dynamically
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const proofData: ProofData = {
+  proof,
+  annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/napoleons-theorem-oq-02/meta.json
+++ b/src/data/proofs/napoleons-theorem-oq-02/meta.json
@@ -50,42 +50,42 @@
   "sections": [
     {
       "title": "Primitive Cube Root of Unity",
-      "startLine": 45,
-      "endLine": 100,
-      "description": "Define ω = (-1+I√3)/2 and its square ω² = (-1-I√3)/2. Prove the fundamental identities ω³=1 and 1+ω+ω²=0.",
-      "summary": "omega and its algebraic properties",
+      "startLine": 65,
+      "endLine": 116,
+      "description": "Define ω = (-1+I√3)/2 and its square ω² = (-1-I√3)/2. Prove the fundamental identities ω³=1 and 1+ω+ω²=0 using sqrt3_sq_real and nlinarith.",
+      "summary": "omega, omegaSq definitions and cube root identity proofs",
       "id": "primitive-cube-root"
     },
     {
       "title": "Outer Napoleon DFT at Frequency 1",
-      "startLine": 105,
-      "endLine": 150,
+      "startLine": 118,
+      "endLine": 156,
       "description": "Prove G₁+ω·G₂+ω²·G₃ = -(z₁+ω·z₂+ω²·z₃): the frequency-1 DFT component of the outer Napoleon triangle is the negation of the original triangle's frequency-1 component.",
       "summary": "Y₁ = -X₁ for outer Napoleon triangle",
       "id": "outer-dft-freq1"
     },
     {
       "title": "Outer Napoleon DFT at Frequency 2",
-      "startLine": 155,
-      "endLine": 195,
+      "startLine": 158,
+      "endLine": 191,
       "description": "Prove G₁+ω²·G₂+ω·G₃ = 0: the frequency-2 DFT component vanishes. Since equilateral triangles are characterized by vanishing X₂, this explains why Napoleon triangles are always equilateral.",
       "summary": "Y₂ = 0 for outer Napoleon triangle",
       "id": "outer-dft-freq2"
     },
     {
       "title": "Inner Napoleon DFT",
-      "startLine": 200,
-      "endLine": 240,
-      "description": "The inner Napoleon triangle has DFT Y₁'=0 and Y₂'=-X₂: exactly swapping the roles of X₁ and X₂ compared to the outer construction.",
+      "startLine": 193,
+      "endLine": 265,
+      "description": "The inner Napoleon triangle has DFT Y₁'=0 (napoleon_inner_dft1) and Y₂'=-X₂ (napoleon_inner_dft2): exactly swapping the roles of X₁ and X₂ compared to the outer construction.",
       "summary": "Y₁'=0 and Y₂'=-X₂ for inner Napoleon triangle",
       "id": "inner-dft"
     },
     {
       "title": "Complete DFT Filter Picture",
-      "startLine": 245,
-      "endLine": 275,
-      "description": "Bundle theorems: outer Napoleon acts as (X₀↦X₀, X₁↦-X₁, X₂↦0) and inner as (X₀↦X₀, X₁↦0, X₂↦-X₂). IDFT recovery formula: G₁=(X₀-X₁)/3.",
-      "summary": "Napoleon construction as explicit DFT filter",
+      "startLine": 267,
+      "endLine": 346,
+      "description": "Bundle theorems: outer Napoleon acts as (X₀↦X₀, X₁↦-X₁, X₂↦0) and inner as (X₀↦X₀, X₁↦0, X₂↦-X₂). IDFT recovery formula: G₁=(X₀-X₁)/3. Summary #check lines.",
+      "summary": "Napoleon construction as explicit DFT filter with IDFT recovery",
       "id": "dft-filter-complete"
     }
   ],


### PR DESCRIPTION
## Summary
- Add `annotations.json` with 8 high-quality annotations covering the full 346-line proof:
  - Module header explaining the DFT filter framing
  - `omega`/`omegaSq` definitions and `sqrt3_sq_real` private lemma
  - Cube root identity theorems (ω³=1, 1+ω+ω²=0, omegaSq=ω²)
  - `napoleon_outer_dft1`: Y₁ = -X₁ (critical — outer Napoleon negates frequency-1)
  - `napoleon_outer_dft2`: Y₂ = 0 (critical — explains why Napoleon triangles are always equilateral)
  - Inner Napoleon DFT: Y₁'=0 and Y₂'=-X₂ (outer/inner symmetry)
  - `napoleon_as_dft_filter` / `inner_napoleon_as_dft_filter`: complete filter bundle theorems
  - `napoleon_center_idft_recovery`: IDFT formula for G₁
- Add `index.ts` with standard proof data export and dynamic Lean source import
- Fix meta.json section `startLine`/`endLine` to match actual Lean file structure (45-275 → 65-346)

🤖 Generated by enricher-3