### PR TITLE
Audit: update tracker — napoleons-theorem-oq-02

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13131,5 +13131,13 @@
     "lastAudited": "2026-04-23T05:17:37Z",
     "result": "issues-fixed",
     "issues": []
+  },
+  "napoleons-theorem-oq-02": {
+    "agentId": "auditor-cycle-23-batch",
+    "auditCount": 1,
+    "lastAudited": "2026-04-23T16:00:00Z",
+    "detectedIssues": null,
+    "notes": "Verified: 0 sorries, 0 axioms, 0 True stubs. All theorems proved via ring_nf/nlinarith. DFT characterization of Napoleon construction. status:verified, badge:original correctly set.",
+    "result": "clean"
   }
 }


### PR DESCRIPTION
## Summary

- Adds audit tracker entry for `napoleons-theorem-oq-02` (previously untracked)

## Audit Result: CLEAN

**Proof**: napoleons-theorem-oq-02 (Napoleon's Theorem: DFT Connection)
**Status in meta.json**: `verified` / `original`

**Checks performed**:
- ✅ 0 sorries (grep confirms — no `sorry` in Lean file)
- ✅ 0 axioms (no `axiom` declarations)
- ✅ 0 True stubs (no `: True :=` patterns)
- ✅ lineCount = 346 matches meta.json
- ✅ All theorems (napoleon_outer_dft1, napoleon_outer_dft2, napoleon_inner_dft1, napoleon_inner_dft2) proved via ring_nf/nlinarith
- ✅ Imports Proofs.NapoleonsTheorem (also 0 sorries/axioms)
- ✅ `verified`/`original` badge appropriate — algebraic DFT computations are original contributions

---
Discovered during gallery integrity audit session 2026-04-23.