### PR TITLE
Fix: sync stale lineCount in erdos-476-oq-05 meta.json

### DIFF
--- a/src/data/proofs/erdos-476-oq-05/meta.json
+++ b/src/data/proofs/erdos-476-oq-05/meta.json
@@ -22,7 +22,7 @@
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
     "assumptions": "1 sorry remains: vosper Case 1 existence — find non-redundant a₀ ∈ A via counting argument or iterative removal (by contradiction: if all a ∈ A are redundant, a counting argument fails for small |A|,|B|). vosper_ap_sdiff_card (position analysis: a₀ is predecessor/successor of A' in the AP) is now fully proved via linear_combination. ap_of_near_periodic (backward-shift induction), vosper_base (|A|=2 case), and all infrastructure are proved with 0 sorries.",
-    "lineCount": 784,
+    "lineCount": 853,
     "theoremCount": 13,
     "definitionCount": 1,
     "originalContributions": [
@@ -124,7 +124,7 @@
   ],
   "leanFile": {
     "namespace": "Erdos476OQ05",
-    "lineCount": 784,
+    "lineCount": 853,
     "axiomCount": 0,
     "theoremCount": 13,
     "definitionCount": 1,


### PR DESCRIPTION
## Fix

Updates `lineCount` from 784 to 853 in `src/data/proofs/erdos-476-oq-05/meta.json` (both the `meta` and `leanFile` sections) to match the actual line count of `Erdos476OQ05Problem.lean`.

## Evidence

**Before**: `"lineCount": 784`
**After**: `"lineCount": 853`
**Verified**: `wc -l proofs/Proofs/Erdos476OQ05Problem.lean` → 853

The file grew by 69 lines in PR #11872 (Session 3: vosper_case1_exists proof for |B|=2 via orbit argument), but the metadata `lineCount` field was not updated in that PR.

---
Automated fix by lean-mechanic agent.