### PR TITLE
Fix: sync stale leanFile.lineCount in 3 gallery meta.json files

### DIFF
--- a/src/data/proofs/erdos-512/meta.json
+++ b/src/data/proofs/erdos-512/meta.json
@@ -187,7 +187,7 @@
       "title": "Summary and Main Theorems",
       "summary": "erdos_512 = konyagin_theorem; erdos_512_solved packages both proofs; konyagin_equals_mps shows logical equivalence",
       "startLine": 232,
-      "endLine": 240,
+      "endLine": 267,
       "mathContext": "SOLVED (1981). $\\\\|S_A\\\\|_1 \\\\geq c\\\\log N$ with $c = 1/(8\\\\pi^2)$. Sharp: arithmetic progressions achieve $\\\\Theta(\\\\log N)$."
     }
   ],
@@ -217,7 +217,7 @@
       "MeasureTheory"
     ],
     "namespace": "Erdos512",
-    "lineCount": 240,
+    "lineCount": 267,
     "axiomCount": 2,
     "theoremCount": 11,
     "definitionCount": 16,

--- a/src/data/proofs/napoleons-theorem/meta.json
+++ b/src/data/proofs/napoleons-theorem/meta.json
@@ -100,7 +100,7 @@
     {
       "title": "Centroid Preservation",
       "startLine": 345,
-      "endLine": 354,
+      "endLine": 355,
       "description": "Both inner and outer Napoleon triangle centroids coincide with the original triangle's centroid.",
       "summary": "Centroid Preservation",
       "id": "centroid-preservation"
@@ -162,7 +162,7 @@
       "Real"
     ],
     "namespace": "NapoleonsTheorem",
-    "lineCount": 354,
+    "lineCount": 355,
     "axiomCount": 0,
     "theoremCount": 15,
     "definitionCount": 10,

--- a/src/data/proofs/sqrt2-minpoly-oq-02/meta.json
+++ b/src/data/proofs/sqrt2-minpoly-oq-02/meta.json
@@ -19,7 +19,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 202,
+    "lineCount": 204,
     "dateAdded": "2026-04-06",
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlibDependencies": [
@@ -198,7 +198,7 @@
       "IntermediateField"
     ],
     "namespace": "CubeRoot2IrrationalOQ03",
-    "lineCount": 202,
+    "lineCount": 204,
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Corrects stale `leanFile.lineCount` values in 3 gallery entries where the stored count no longer matches the actual Lean source file.

## Evidence

| Entry | Field | Before | After | Actual |
|-------|-------|--------|-------|--------|
| erdos-512 | leanFile.lineCount | 240 | 267 | 267 |
| erdos-512 | sections[summary].endLine | 240 | 267 | — |
| napoleons-theorem | leanFile.lineCount | 354 | 355 | 355 |
| napoleons-theorem | sections[centroid-preservation].endLine | 354 | 355 | — |
| sqrt2-minpoly-oq-02 | meta.lineCount | 202 | 204 | 204 |
| sqrt2-minpoly-oq-02 | leanFile.lineCount | 202 | 204 | 204 |

Note: `erdos-476-oq-05` also has a lineCount mismatch but is already addressed in PR #11883.

---
Automated fix by lean-mechanic agent.