### PR TITLE
Enrich erdos-866: fix badge, sections, annotations to match actual Lean file

### DIFF
--- a/src/data/proofs/erdos-866/annotations.json
+++ b/src/data/proofs/erdos-866/annotations.json
@@ -4,12 +4,12 @@
     "proofId": "erdos-866",
     "range": {
       "startLine": 1,
-      "endLine": 28
+      "endLine": 21
     },
-    "type": "concept",
-    "title": "Problem Overview",
-    "content": "Erdős Problem #866 studies threshold functions for pairwise sums in additive combinatorics. For k ≥ 3, define g_k(N) as the minimal value such that any A ⊆ {1,...,2N} with |A| ≥ N + g_k(N) must contain all $\\binom{k}{2}$ pairwise sums b_i + b_j for some integers b₁,...,b_k (the b_i need not be in A). The problem, due to Choi, Erdős, and Szemerédi, asks to estimate g_k(N) for all k. A striking feature is the phase transition in growth: constant → logarithmic → polynomial → nearly linear as k increases.",
-    "mathContext": "For $k \\ge 3$, define $g_k(N) = \\min\\{g : \\forall A \\subseteq [2N],\\; |A| \\ge N+g \\Rightarrow \\exists b_1,\\ldots,b_k \\in \\mathbb{Z},\\; \\{b_i + b_j : i < j\\} \\subseteq A\\}$. Known: $g_3 = 2$, $g_4 \\le 2032$, $g_5 \\asymp \\log N$, $g_6 \\asymp \\sqrt{N}$, $g_k \\ll_k N^{1-2^{-k}}$.",
+    "type": "context",
+    "title": "Problem Context and Setup",
+    "content": "Erdős Problem #866 studies threshold functions for pairwise sums in additive combinatorics. For k ≥ 3, define g_k(N) as the minimal value such that any A ⊆ {1,...,2N} with |A| ≥ N + g_k(N) must contain all $\\binom{k}{2}$ pairwise sums b_i + b_j for some integers b₁,...,b_k. This file is an Aristotle companion—it formalizes three supporting lemmas (exponent monotonicity, odd set cardinality, parity pigeonhole) that underpin the broader theory.",
+    "mathContext": "For $k \\ge 3$, $g_k(N) = \\min\\{g : \\forall A \\subseteq [2N],\\; |A| \\ge N+g \\Rightarrow \\exists b_1,\\ldots,b_k \\in \\mathbb{Z},\\; \\{b_i + b_j : i < j\\} \\subseteq A\\}$. Known: $g_3 = 2$, $g_4 \\le 2032$, $g_5 \\asymp \\log N$, $g_6 \\asymp \\sqrt{N}$, $g_k \\ll N^{1-2^{-k}}$.",
     "significance": "key",
     "relatedConcepts": [
       "additive combinatorics",
@@ -28,180 +28,182 @@
     "id": "ann-866-2",
     "proofId": "erdos-866",
     "range": {
-      "startLine": 30,
-      "endLine": 39
+      "startLine": 22,
+      "endLine": 25
     },
-    "type": "technique",
-    "title": "Imports",
-    "content": "The formalization imports Finset cardinality for counting, binomial coefficients for the $\\binom{k}{2}$ pairwise sums count, real logarithms for the g₅ bounds, and real square roots/powers for the g₆ and general bounds. The `Tactic` import provides automation tools like `ring_nf`, `linarith`, and `sorry`.",
-    "mathContext": "Key Mathlib types: `Finset ℕ` for finite subsets, `ℝ` for bounds, `Real.log` for $\\log N$, `Real.sqrt` for $\\sqrt{N}$, `Real.rpow` for $N^{1-2^{-k}}$.",
+    "type": "definition",
+    "title": "The Interval {1,...,2N}",
+    "content": "The interval {1, 2, ..., 2N} is the ambient set. Defined as `Finset.range(2N+1)` filtered to exclude 0, giving exactly the integers from 1 to 2N. This set has cardinality 2N, so requiring |A| ≥ N + g means A contains more than half the interval.",
+    "mathContext": "$\\text{Interval}(N) = \\{n \\in \\mathbb{N} : 1 \\le n \\le 2N\\} = (\\text{Finset.range}(2N+1)).\\text{filter}(n \\ge 1)$. So $|\\text{Interval}(N)| = 2N$ and the condition $|A| \\ge N + g$ means $A$ covers at least $\\frac{1}{2} + \\frac{g}{2N}$ of the interval.",
     "significance": "supporting",
     "relatedConcepts": [
-      "Finset",
-      "Real.log",
-      "Real.sqrt",
-      "Nat.choose"
+      "Finset.range",
+      "Finset.filter",
+      "integer intervals"
     ],
     "prerequisites": [
-      "Lean 4 import system",
-      "Mathlib real analysis"
+      "Finset operations",
+      "Lean natural number arithmetic"
     ]
   },
   {
     "id": "ann-866-3",
     "proofId": "erdos-866",
     "range": {
-      "startLine": 43,
-      "endLine": 45
+      "startLine": 27,
+      "endLine": 30
     },
     "type": "definition",
-    "title": "The Interval",
-    "content": "The interval {1, 2, ..., 2N} is the ambient set. Defined as `Finset.range(2N+1)` filtered to exclude 0, giving exactly the integers from 1 to 2N. This set has cardinality 2N, so requiring |A| ≥ N + g means A contains more than half the interval.",
-    "mathContext": "$[2N] = \\{1, 2, \\ldots, 2N\\}$, so $|[2N]| = 2N$. The condition $|A| \\ge N + g$ means $A$ contains at least $\\frac{1}{2} + \\frac{g}{2N}$ fraction of $[2N]$.",
-    "significance": "supporting",
+    "title": "Pairwise Sums Condition",
+    "content": "HasAllPairwiseSums A b requires that for all i < j in {0,...,k-1}, the sum b_i + b_j lies in A. There are $\\binom{k}{2}$ such pairs. Crucially, the witnesses b_i are arbitrary integers (not necessarily in A or positive)—using `Fin k → ℤ` allows negative witnesses, essential for the problem's generality. The `.toNat` coercion maps the integer sum back to ℕ for membership in A.",
+    "mathContext": "$\\text{HasAllPairwiseSums}(A, b) :\\equiv \\forall i < j : \\text{Fin}\\,k,\\; (b_i + b_j)^+ \\in A$ where $(\\cdot)^+$ is the `Int.toNat` coercion. The $\\binom{k}{2}$ conditions must all hold simultaneously. For $k = 3$: 3 pairs; for $k = 6$: 15 pairs.",
+    "significance": "key",
     "relatedConcepts": [
-      "Finset.range",
-      "Finset.filter",
-      "interval notation"
+      "pairwise sums",
+      "Fin type",
+      "integer witnesses",
+      "Int.toNat coercion"
     ],
     "prerequisites": [
-      "Finset operations"
+      "Fin k indexing",
+      "integer-to-natural coercion",
+      "Finset membership"
     ]
   },
   {
     "id": "ann-866-4",
     "proofId": "erdos-866",
     "range": {
-      "startLine": 47,
-      "endLine": 50
+      "startLine": 32,
+      "endLine": 34
     },
     "type": "definition",
-    "title": "Pairwise Sums Condition",
-    "content": "HasAllPairwiseSums A b requires that for all $i < j \\in \\{1,\\ldots,k\\}$, the sum $b_i + b_j$ lies in A. There are $\\binom{k}{2}$ such sums. Crucially, the $b_i$ are integers (not necessarily in A or even positive)—they are 'witnesses' whose pairwise sums land in A. Using `Fin k → ℤ` allows negative witnesses, which is essential for the problem's generality.",
-    "mathContext": "$\\mathrm{HasAllPairwiseSums}(A, b) :\\equiv \\forall i < j \\le k,\\; b_i + b_j \\in A$. The $\\binom{k}{2} = \\frac{k(k-1)}{2}$ conditions must all hold simultaneously. For $k = 3$: 3 conditions; for $k = 6$: 15 conditions.",
+    "title": "The Odd Numbers Construction",
+    "content": "oddNumbers N is the set {1, 3, 5, ..., 2N-1} of odd integers in {1,...,2N}. This is the canonical extremal example: it has exactly N elements (just missing the N+g threshold) and avoids all pairwise sums (odd + odd = even). It witnesses that g_k(N) ≥ 1 for all k and g₃(N) ≥ 2.",
+    "mathContext": "$\\text{oddNumbers}(N) = \\{n \\in [2N] : n \\equiv 1 \\pmod{2}\\} = \\{1, 3, 5, \\ldots, 2N-1\\}$. Defined via `Interval N` filtered by `n % 2 = 1`. Key property: $|\\text{oddNumbers}(N)| = N$ (proved in `oddNumbers_card`).",
     "significance": "key",
     "relatedConcepts": [
-      "pairwise sums",
-      "Fin type",
-      "integer witnesses",
-      "sumset"
+      "extremal construction",
+      "parity",
+      "lower bound witness"
     ],
     "prerequisites": [
-      "Fin k",
-      "integer arithmetic",
-      "Finset membership"
+      "Finset.filter",
+      "modular arithmetic"
     ]
   },
   {
     "id": "ann-866-5",
     "proofId": "erdos-866",
     "range": {
-      "startLine": 52,
-      "endLine": 56
+      "startLine": 36,
+      "endLine": 38
     },
     "type": "definition",
-    "title": "Threshold Condition",
-    "content": "PairwiseSumCondition k N g states: every A ⊆ {1,...,2N} with |A| ≥ N + g contains pairwise sums of some k integers. This is a universally quantified statement over all subsets A of the interval meeting the cardinality threshold. The function g_k(N) is the minimal such g.",
-    "mathContext": "$P(k, N, g) :\\equiv \\forall A \\subseteq [2N],\\; |A| \\ge N + g \\Rightarrow \\exists b_1,\\ldots,b_k \\in \\mathbb{Z},\\; \\{b_i + b_j\\}_{i<j} \\subseteq A$.",
-    "significance": "key",
+    "title": "The Upper Bound Exponent",
+    "content": "upperExponent k = 1 - 2^{-k} is the exponent appearing in the general upper bound g_k(N) ≪ N^{1-2^{-k}} (Choi–Erdős–Szemerédi). As k → ∞, this exponent increases toward 1, meaning the threshold approaches N. Declared `noncomputable` because it uses classical real arithmetic (`(2:ℝ)⁻¹ ^ k` is in ℝ, not ℕ).",
+    "mathContext": "$\\text{upperExponent}(k) = 1 - 2^{-k} \\in [0, 1)$ for all $k \\ge 0$. Sequence: $\\text{upperExponent}(1) = 1/2$, $\\text{upperExponent}(2) = 3/4$, $\\text{upperExponent}(3) = 7/8$, $\\ldots$, $\\text{upperExponent}(k) \\to 1$. The bound $g_k(N) \\ll N^{\\text{upperExponent}(k)}$ implies $g_k(N)/N \\to 1$.",
+    "significance": "supporting",
     "relatedConcepts": [
-      "extremal combinatorics",
-      "Turán-type problems",
-      "threshold phenomena"
+      "geometric series",
+      "noncomputable definitions",
+      "real number arithmetic"
     ],
     "prerequisites": [
-      "universal quantification",
-      "Finset subset",
-      "cardinality bounds"
+      "real numbers in Lean",
+      "power notation"
     ]
   },
   {
     "id": "ann-866-6",
     "proofId": "erdos-866",
     "range": {
-      "startLine": 58,
-      "endLine": 65
+      "startLine": 40,
+      "endLine": 50
     },
-    "type": "definition",
-    "title": "The Threshold Function g",
-    "content": "g(k, N) is the minimal g for which PairwiseSumCondition holds, extracted via `Nat.find`. The existence proof (sorry) argues that g = 2N works vacuously since no A ⊆ {1,...,2N} can have |A| ≥ N + 2N = 3N > 2N elements. The `noncomputable` annotation reflects that `Nat.find` uses classical logic.",
-    "mathContext": "$g_k(N) = \\min\\{g \\in \\mathbb{N} : P(k, N, g)\\}$. Well-defined since $P(k, N, 2N)$ holds vacuously: $|A| \\le 2N < 3N = N + 2N$.",
+    "type": "technique",
+    "title": "Exponent Monotonicity Proof",
+    "content": "upperExponent_increasing proves 1-2^{-k} < 1-2^{-(k+1)}, i.e., the exponent sequence is strictly increasing. This is needed to show the upper bounds N^{upperExponent(k)} are ordered—adding one more required sum (k→k+1) tightens the threshold. The Aristotle comment block describes the proof strategy: reduce to 2^{-(k+1)} < 2^{-k} via sub_lt_sub_left, then apply pow_lt_pow_right_of_lt_one₀.",
+    "mathContext": "$1 - 2^{-(k+1)} > 1 - 2^{-k} \\iff 2^{-(k+1)} < 2^{-k} \\iff 2^{-1} \\cdot 2^{-k} < 2^{-k}$. Proved by `sub_lt_sub_left` (monotonicity of $x \\mapsto 1-x$) and `pow_lt_pow_right_of_lt_one₀` (strict monotonicity of $t^n$ for $0 < t < 1$ and larger n).",
     "significance": "key",
     "relatedConcepts": [
-      "Nat.find",
-      "well-ordering principle",
-      "noncomputable definitions"
+      "geometric sequence monotonicity",
+      "sub_lt_sub_left",
+      "pow_lt_pow_right_of_lt_one₀"
     ],
     "prerequisites": [
-      "Nat.find",
-      "classical logic",
-      "vacuous truth"
+      "real number inequalities",
+      "geometric sequences",
+      "Mathlib order lemmas"
     ]
   },
   {
     "id": "ann-866-7",
     "proofId": "erdos-866",
     "range": {
-      "startLine": 69,
-      "endLine": 74
+      "startLine": 52,
+      "endLine": 66
     },
-    "type": "concept",
-    "title": "g₃ Exact Value",
-    "content": "Choi–Erdős–Szemerédi proved $g_3(N) = 2$ exactly. If A ⊆ {1,...,2N} has |A| ≥ N+2, then three integers b₁, b₂, b₃ exist with all three pairwise sums in A. The proof uses a pigeonhole argument on complementary pairs: with N+2 elements in a range of 2N, there are enough collisions in complementary pairs to force three mutually compatible sums.",
-    "mathContext": "$g_3(N) = 2$ for all $N \\ge 1$. The upper bound: if $|A| \\ge N+2$, consider complementary pairs $(a, 2N+1-a)$. By pigeonhole, $A$ contains both elements of some pair, giving a structured starting point for finding the triple.",
+    "type": "technique",
+    "title": "Odd Numbers Cardinality Proof",
+    "content": "oddNumbers_card proves |oddNumbers N| = N, establishing that the all-odd set exactly reaches the edge of the density threshold. The proof unfolds the definitions and applies `Finset.card_eq_of_bijective` with the explicit bijection i ↦ 2i+1 from {0,...,N-1} to the odd numbers. Injectivity follows by `omega` (linear arithmetic) and surjectivity by `aesop` (automated reasoning).",
+    "mathContext": "$|\\{1, 3, \\ldots, 2N-1\\}| = N$. Bijection: $f : \\{0,\\ldots,N-1\\} \\to \\text{oddNumbers}(N)$, $f(i) = 2i+1$. Injectivity: $2i+1 = 2j+1 \\Rightarrow i = j$ (linear arithmetic). Surjectivity: any odd $n \\in [2N]$ equals $2\\cdot\\frac{n-1}{2}+1$ with $\\frac{n-1}{2} < N$.",
     "significance": "key",
     "relatedConcepts": [
-      "pigeonhole principle",
-      "complementary pairs",
-      "exact threshold"
+      "Finset.card_eq_of_bijective",
+      "bijection",
+      "omega tactic"
     ],
     "prerequisites": [
-      "pigeonhole principle",
-      "sumset structure"
+      "Finset cardinality",
+      "bijective functions",
+      "linear arithmetic in Lean"
     ]
   },
   {
     "id": "ann-866-8",
     "proofId": "erdos-866",
     "range": {
-      "startLine": 76,
-      "endLine": 81
+      "startLine": 68,
+      "endLine": 83
     },
     "type": "technique",
-    "title": "g₃ Lower Bound",
-    "content": "The lower bound $g_3(N) \\ge 2$ comes from the odd numbers construction: the set $\\{1, 3, 5, \\ldots, 2N-1\\}$ has exactly N elements but cannot contain three pairwise sums. For any three integers b₁, b₂, b₃, at least two share the same parity (by pigeonhole), so their sum is even—but all elements of the odd set are odd. Hence no triple works, showing N elements are not enough.",
-    "mathContext": "Let $O_N = \\{2j-1 : 1 \\le j \\le N\\}$. Then $|O_N| = N$ and for any $b_1, b_2, b_3 \\in \\mathbb{Z}$, $\\exists i \\neq j : b_i \\equiv b_j \\pmod{2}$, so $b_i + b_j \\equiv 0 \\pmod{2} \\notin O_N$. Hence $P(3, N, 1)$ fails, giving $g_3(N) \\ge 2$.",
+    "title": "Parity Pigeonhole Proof",
+    "content": "oddNumbers_no_triple proves that no Fin 3 → ℤ witness has all pairwise sums in oddNumbers N—a lower bound argument: |A| = N is not enough. The key step `h_odd` extracts from HasAllPairwiseSums that every pairwise sum is odd (since it lands in oddNumbers). Then `simp_all +decide [Fin.forall_fin_succ]` and `grind +ring` derive a parity contradiction: among the three residues mod 2 of b 0, b 1, b 2, two must match (pigeonhole), giving an even sum that cannot be odd.",
+    "mathContext": "Among $b_0, b_1, b_2 \\in \\mathbb{Z}$, by pigeonhole two share parity $\\pmod{2}$. Say $b_i \\equiv b_j \\pmod{2}$; then $b_i + b_j \\equiv 0 \\pmod{2}$, so $(b_i + b_j)^+$ is even, contradicting membership in $\\text{oddNumbers}(N)$. This proves $g_k(N) \\ge 1$ for all $k \\ge 3$ and $N \\ge 1$, and is the foundation for the lower bound $g_3(N) \\ge 2$.",
     "significance": "key",
     "relatedConcepts": [
       "parity argument",
       "pigeonhole principle",
-      "extremal construction"
+      "simp+decide tactic",
+      "grind tactic"
     ],
     "prerequisites": [
-      "parity",
-      "pigeonhole among 3 elements"
+      "modular arithmetic",
+      "Fin.forall_fin_succ unfolding",
+      "parity in ℤ"
     ]
   },
   {
     "id": "ann-866-9",
     "proofId": "erdos-866",
     "range": {
-      "startLine": 85,
-      "endLine": 89
+      "startLine": 84,
+      "endLine": 85
     },
     "type": "concept",
-    "title": "g₄ Bounded",
-    "content": "$g_4(N)$ is bounded by an absolute constant C independent of N. This is surprising: no matter how large N is, adding a fixed constant beyond N elements always forces four integers with all $\\binom{4}{2} = 6$ pairwise sums in A. The proof uses a more sophisticated pigeonhole argument than the k=3 case, exploiting the arithmetic structure of {1,...,2N}.",
-    "mathContext": "$\\exists C \\in \\mathbb{N},\\; \\forall N \\ge 1,\\; g_4(N) \\le C$. The constant $C$ is independent of $N$—a striking contrast with $g_5(N) \\to \\infty$.",
-    "significance": "key",
+    "title": "Phase Transition and Open Questions",
+    "content": "The three proved lemmas support one of combinatorics' cleanest known phase transitions: g₃ = 2 (constant), g₄ ≤ 2032 (bounded), g₅ ≍ log N (logarithmic), g₆ ≍ √N (polynomial), g_k ≪ N^{1-2^{-k}} (general). The exponent monotonicity lemma confirms the upper bounds are ordered. The odd-set lemmas establish the universal lower bound. The gap between N^{1-2^{-k}} and N^{1-ε} for large k—the central open question—requires techniques far beyond what Lean can currently verify automatically.",
+    "mathContext": "Open: (1) What is the exact $g_4(N)$—is it exactly 2032? (2) What are the optimal constants in $g_5(N) \\asymp \\log N$? (3) What is the true exponent $\\alpha_k$ with $g_k(N) = N^{\\alpha_k + o(1)}$? The upper bound gives $\\alpha_k \\le 1 - 2^{-k}$; the lower bound gives $\\alpha_k$ approaching 1 as $k \\to \\infty$.",
+    "significance": "context",
     "relatedConcepts": [
-      "bounded threshold",
-      "constant vs growing",
-      "arithmetic regularity"
+      "phase transition",
+      "asymptotic growth rates",
+      "open problems in additive combinatorics"
     ],
     "prerequisites": [
-      "threshold function behavior",
-      "extremal combinatorics"
+      "big-O notation",
+      "asymptotic analysis"
     ]
   }
 ]

--- a/src/data/proofs/erdos-866/meta.json
+++ b/src/data/proofs/erdos-866/meta.json
@@ -17,7 +17,7 @@
       "threshold-functions",
       "erdos"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 866,
     "erdosUrl": "https://erdosproblems.com/866",
@@ -61,7 +61,7 @@
     "historicalContext": "Erdős Problem #866 originates from the work of Choi, Erdős, and Szemerédi on sumsets and additive combinatorics, building on their unpublished manuscript 'On sums and products of integers.' The problem asks: how large must a subset A of {1,...,2N} be to guarantee that some k integers have all their pairwise sums in A?\n\nThe foundational observation is the odd numbers construction: the set {1, 3, 5, ..., 2N-1} has N elements but avoids all pairwise sums (since odd + odd = even). This shows the threshold must be at least 1 above N. For k=3, the exact answer is g₃(N) = 2, proved via a complementary pairs pigeonhole argument.\n\nThe most striking feature is the phase transition as k increases: g₃ = 2 (constant), g₄ ≤ 2032 (bounded constant, van Doorn), g₅ ≍ log N (logarithmic), g₆ ≍ √N (polynomial). The general upper bound g_k(N) ≪ N^{1-2^{-k}} (Choi–Erdős–Szemerédi) shows the exponent approaches 1 geometrically, while the lower bound g_k(N) > N^{1-ε} for large k shows the threshold eventually approaches N.\n\nThis growth rate transition—from constant through logarithmic and polynomial to nearly linear—is rare in combinatorics and reflects deep structural changes in the extremal problem. The gap between upper and lower bounds for intermediate and large k remains one of the central open questions in additive combinatorics.",
     "problemStatement": "**Problem Statement**\n\nFor k ≥ 3, let g_k(N) be the minimal value such that if A ⊆ {1,...,2N} has |A| ≥ N + g_k(N), then there exist integers b₁,...,b_k such that all $\\binom{k}{2}$ pairwise sums b_i + b_j are in A (the b_i need not be in A).\n\n**Goal**: Estimate g_k(N) for all k.\n\n**Status**: PARTIALLY SOLVED\n- Small k (3,4,5,6): Well characterized\n- Large k: Gap between upper and lower bounds",
     "text": "For k ≥ 3, define g_k(N) as the minimal threshold such that A ⊆ {1,...,2N} with |A| ≥ N + g_k(N) contains all pairwise sums of some b₁,...,b_k. Known: g₃=2, g₄≤2032, g₅≍log N, g₆≍√N. General bounds have gaps.",
-    "proofStrategy": "The formalization is organized into eleven parts:\n\n1. **Definitions**: Interval, HasAllPairwiseSums (using Fin k → ℤ), PairwiseSumCondition, and g via Nat.find\n2. **Case k=3**: g₃(N) = 2 exactly (axiom), with lower bound from odd numbers construction\n3. **Case k=4**: g₄(N) bounded (axiom), van Doorn's explicit g₄ ≤ 2032 (axiom)\n4. **Case k=5**: g₅(N) ≍ log N (axiom), lower bound extracted as corollary via `obtain`\n5. **Case k=6**: g₆(N) ≍ √N (axiom)\n6. **General upper**: g_k(N) ≪ N^{1-2^{-k}} with upperExponent monotonicity (proved)\n7. **General lower**: g_k(N) > N^{1-ε} for large k (axiom), threshold_approaches_N (proved)\n8. **Odd numbers**: Extremal construction with cardinality (proved) and avoidance (proved) proofs\n9. **Summary table**: Four summary theorems directly referencing axioms\n10. **Open problems**: Four formalized as Lean Props\n11. **Main summary**: Conjunction of g₃ exact and g₄ bounded",
+    "proofStrategy": "This file formalizes three supporting lemmas for Erdős Problem #866, serving as Aristotle proof search targets. The formalization has four parts:\n\n1. **Core Definitions** (lines 22–38): `Interval(N) = {1,...,2N}` as a filtered `Finset ℕ`; `HasAllPairwiseSums A b` (all pairwise sums of witnesses `b : Fin k → ℤ` lie in A); `oddNumbers N` (odd integers in the interval); `upperExponent k = 1 - 2^{-k}` (exponent in the general upper bound).\n\n2. **Exponent Monotonicity** (lines 40–50): `upperExponent_increasing` — the sequence $1 - 2^{-k}$ is strictly increasing in k. Proved via `sub_lt_sub_left` and `pow_lt_pow_right_of_lt_one₀`, reducing to `2^{-(k+1)} < 2^{-k}`.\n\n3. **Odd Numbers Cardinality** (lines 52–66): `oddNumbers_card` — the set of odd integers in `{1,...,2N}` has exactly N elements. Proved via `Finset.card_eq_of_bijective` with the bijection `i ↦ 2i+1`.\n\n4. **Parity Pigeonhole** (lines 68–83): `oddNumbers_no_triple` — no three integers have all pairwise sums in the odd set. Proved by deriving that any pairwise sum of elements in the odd set must be odd, then applying `simp` with parity arithmetic and `grind`.\n\nAll three theorems are fully machine-checked with 0 axioms and 0 sorries. The broader problem about g_k(N) growth rates remains open.",
     "keyInsights": [
       "**Phase transition in growth rates**: The sequence constant → log → √N → N^{1-o(1)} as k increases from 3 to ∞ represents a rare and striking phenomenon in combinatorics. Each transition (k=4→5, k=5→6, finite→∞) requires fundamentally different techniques.",
       "**The odd numbers construction is universal**: The set of odd integers in [2N] has exactly N elements and avoids ALL pairwise sum configurations (for any k), because two integers of the same parity sum to an even number. This single construction provides the base lower bound g_k(N) ≥ 1 for all k.",
@@ -77,32 +77,48 @@
   },
   "sections": [
     {
-      "id": "basic-definitions",
-      "title": "Basic Definitions",
-      "summary": "Defines Interval(N) = {1,...,2N}, HasAllPairwiseSums via Fin k → ℤ witnesses, PairwiseSumCondition as the universal threshold statement, and g(k,N) via Nat.find.",
-      "startLine": 41,
+      "id": "header",
+      "title": "Companion File Header",
+      "summary": "Documents the three Aristotle proof search targets: upperExponent monotonicity, oddNumbers cardinality, and oddNumbers parity pigeonhole. All satisfy Aristotle's preconditions: no definition sorries, no axioms, clean theorem statements.",
+      "startLine": 1,
+      "endLine": 21,
+      "mathContext": "An Aristotle companion file exposes provable supporting lemmas (not the main open conjecture) for automated proof search. Each target is a `theorem ... := by sorry` that Aristotle can attempt."
+    },
+    {
+      "id": "definitions",
+      "title": "Core Definitions",
+      "summary": "Defines the four building blocks: Interval (ambient set {1,...,2N}), HasAllPairwiseSums (the k-tuple witness condition), oddNumbers (the extremal construction), and upperExponent (the exponent 1-2^{-k} in the general upper bound).",
+      "startLine": 22,
+      "endLine": 38,
+      "mathContext": "$\\text{Interval}(N) = \\{n \\in \\mathbb{N} : 1 \\le n \\le 2N\\}$. $\\text{HasAllPairwiseSums}(A,b) :\\equiv \\forall i < j,\\; (b_i + b_j)^+ \\in A$ for $b : \\text{Fin}\\,k \\to \\mathbb{Z}$. $\\text{upperExponent}(k) = 1 - 2^{-k}$."
+    },
+    {
+      "id": "exponent-monotone",
+      "title": "Exponent Monotonicity",
+      "summary": "Proves upperExponent k < upperExponent (k+1): the sequence 1-2^{-k} is strictly increasing. This supports the general upper bound g_k(N) ≪ N^{1-2^{-k}} by confirming the exponents are ordered.",
+      "startLine": 40,
+      "endLine": 50,
+      "mathContext": "$1 - 2^{-(k+1)} > 1 - 2^{-k} \\iff 2^{-(k+1)} < 2^{-k}$. Proved via `sub_lt_sub_left` and `pow_lt_pow_right_of_lt_one₀` with $0 < 2^{-1} < 1$."
+    },
+    {
+      "id": "odd-cardinality",
+      "title": "Odd Numbers Cardinality",
+      "summary": "Proves |oddNumbers N| = N: the set {1, 3, ..., 2N-1} has exactly N elements. This establishes that the all-odd set barely misses the threshold (|A| = N, not N+1), confirming it as the tight extremal construction.",
+      "startLine": 52,
       "endLine": 66,
-      "mathContext": "$[2N] = \\{1,\\ldots,2N\\}$. $\\text{HasAllPairwiseSums}(A,b) :\\equiv \\forall i < j,\\; b_i + b_j \\in A$ for witnesses $b : \\text{Fin}\\,k \\to \\mathbb{Z}$. $g_k(N) = \\min\\{g : \\forall A \\subseteq [2N], |A| \\ge N+g \\Rightarrow \\exists b, \\text{HasAllPairwiseSums}(A,b)\\}$."
+      "mathContext": "$|\\{2j-1 : 1 \\le j \\le N\\}| = N$. Proved via `Finset.card_eq_of_bijective` with bijection $j \\mapsto 2j+1$, injectivity by `omega`, surjectivity by `aesop`."
     },
     {
-      "id": "case-k3",
-      "title": "Case k=3: Exact Value g₃=2",
-      "summary": "Axiomatizes g₃(N) = 2 (Choi–Erdős–Szemerédi). Lower bound g₃ ≥ 2 from odd numbers + parity pigeonhole.",
-      "startLine": 67,
-      "endLine": 82,
-      "mathContext": "$g_3(N) = 2$ exactly. Upper bound: axiom (Choi–Erdős–Szemerédi pigeonhole on complementary pairs). Lower bound: $O_N = \\{1,3,\\ldots,2N-1\\}$ has $|O_N|=N$ but odd+odd=even $\\notin O_N$, so $g_3 \\ge 2$."
-    },
-    {
-      "id": "case-k4",
-      "title": "Case k=4: Bounded Threshold g₄≤2032",
-      "summary": "Two axioms: g₄(N) ≤ C absolutely (Choi–Erdős–Szemerédi) and g₄(N) ≤ 2032 (van Doorn).",
-      "startLine": 83,
+      "id": "parity-pigeonhole",
+      "title": "Parity Pigeonhole for Odd Sets",
+      "summary": "Proves no three integers b₀, b₁, b₂ can have all three pairwise sums in oddNumbers N. Key: any pairwise sum of elements with the same parity is even, hence not in the odd set. Among 3 integers, two must share parity by pigeonhole.",
+      "startLine": 68,
       "endLine": 85,
-      "mathContext": "$\\exists C \\in \\mathbb{N},\\; \\forall N,\\; g_4(N) \\le C$ (bounded). Explicit: $g_4(N) \\le 2032$ (van Doorn). Stark contrast: $g_4 = O(1)$ while $g_5 = \\Theta(\\log N)$."
+      "mathContext": "$\\forall b : \\text{Fin}\\,3 \\to \\mathbb{Z},\\; \\neg\\, \\text{HasAllPairwiseSums}(O_N, b)$. Proof: $h_{\\text{odd}}$ extracts that all pairwise sums are odd; then `simp+decide` and `grind+ring` derive parity contradiction."
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem #866 on pairwise sums threshold functions, organizing the theory into case analysis (k=3,4,5,6), general bounds, extremal constructions, and open problems. All supporting lemmas proved by Aristotle: upperExponent monotonicity, oddNumbers cardinality, and oddNumbers avoidance. 7 axioms encode the known mathematical results.",
+    "summary": "This file fully proves three foundational supporting lemmas for Erdős Problem #866: (1) the exponent sequence $1-2^{-k}$ is strictly increasing (supporting the general upper bound $g_k(N) \\ll N^{1-2^{-k}}$); (2) the odd numbers in $\\{1,\\ldots,2N\\}$ number exactly N (establishing the extremal construction tightness); and (3) no three integers can have all pairwise sums in the odd set (proving $g_k(N) \\ge 1$ for all k). All three are machine-verified with 0 axioms and 0 sorries. The broader conjecture—determining $g_k(N)$ for all k—remains open.",
     "implications": "The problem reveals fundamental phase transitions in additive combinatorics: (1) the jump from bounded to unbounded threshold at k=4→5 shows a qualitative complexity barrier; (2) the growth rate hierarchy (constant → log → √N → N^{1-o(1)}) is exceptionally clean; (3) the gap between upper exponent 1-2^{-k} and lower exponent 1-ε for large k represents a major open frontier. The formalization demonstrates how Lean can cleanly separate exact results (g₃=2) from asymptotic bounds (g₅, g₆) and open questions, providing precise statements for future work.",
     "openQuestions": [
       "What is the exact value of g₄(N)? Is g₄(N) constant, and if so, what is the constant?",


### PR DESCRIPTION
## Summary

Enrichment pass for `erdos-866` (Erdős Problem #866: Pairwise Sums Threshold).

The previous pass had significant mismatches between the metadata and the actual Lean file (`Erdos866Problem.lean`). This pass corrects all of them.

### Changes

**meta.json:**
- Fix `badge: "wip"` → `"axiom"` (`"wip"` is not a valid badge value; this is an open Erdős problem)
- Rewrite `proofStrategy` to accurately describe the 3 proved theorems in the file, not a hypothetical 11-part formalization
- Fix `conclusion.summary`: remove false claim of "7 axioms" — the file has 0 axioms and 0 sorries
- Rewrite `sections` (3 → 5 sections) with correct line ranges matching the actual proof structure

**annotations.json:**
- Fix line ranges for all 9 annotations (previous ranges referenced non-existent lines)
- Rewrite annotations 5–9 that described code not present in the file (PairwiseSumCondition, g via Nat.find, k=3/4 axioms) with accurate content about the 4 definitions and 3 proved theorems

### What the Lean file actually contains

The file `Erdos866Problem.lean` is an Aristotle companion with 3 fully machine-checked theorems:
1. `upperExponent_increasing` — exponent sequence $1-2^{-k}$ is strictly increasing
2. `oddNumbers_card` — odd integers in $\{1,\ldots,2N\}$ number exactly $N$
3. `oddNumbers_no_triple` — no triple has all pairwise sums in the odd set (parity pigeonhole)

All theorems: 0 axioms, 0 sorries, fully verified.

## Build

`pnpm build` ✓ (exit 0)