### PR TITLE
Audit: fix stale narrative in erdos-753 meta.json

### DIFF
--- a/src/data/proofs/erdos-753/meta.json
+++ b/src/data/proofs/erdos-753/meta.json
@@ -115,8 +115,8 @@
       "title": "Alon's Counterexample (1992)",
       "startLine": 134,
       "endLine": 162,
-      "summary": "alon_counterexample (axiom): exists C > 0, forall n >= 2, exists G with sum <= C*sqrt(n*log(n)). conjecture_false: not ERTConjecture (1 sorry in asymptotic contradiction).",
-      "mathContext": "alon_counterexample (axiom): exists C > 0, forall n >= 2, exists G with sum <= C*$\\sqrt{n*log(n}$). conjecture_false: not ERTConjecture (1 sorry in asymptotic contradiction)."
+      "summary": "alon_counterexample (axiom): exists C > 0, forall n >= 2, exists G with sum <= C*sqrt(n*log(n)). conjecture_false: not ERTConjecture (PROVED via multi-step asymptotic contradiction using isLittleO_log_rpow_atTop).",
+      "mathContext": "alon_counterexample (axiom): exists C > 0, forall n >= 2, exists G with sum <= C*$\\sqrt{n*log(n}$). conjecture_false: not ERTConjecture (PROVED via multi-step asymptotic contradiction using isLittleO_log_rpow_atTop)."
     },
     {
       "id": "bounds-relations",
@@ -131,8 +131,8 @@
       "title": "Probabilistic Construction",
       "startLine": 190,
       "endLine": 208,
-      "summary": "alon_construction_probabilistic and random_half_symmetry (both := True): document that G(n,1/2) provides counterexamples via self-complementary distribution.",
-      "mathContext": "Mathematical content: alon_construction_probabilistic and random_half_symmetry (both := True): document that G(n,1/2) provides counterexamples via self-complementary distribution."
+      "summary": "Discussion of Alon's probabilistic construction: G(n,1/2) provides counterexamples via self-complementary distribution. Section consists of explanatory comments; the main result is formalized in the alon-counterexample section via alon_counterexample (axiom) and conjecture_false (proved).",
+      "mathContext": "Discussion of Alon's probabilistic construction: G(n,1/2) provides counterexamples via self-complementary distribution. Section consists of explanatory comments; the main result is formalized in the alon-counterexample section via alon_counterexample (axiom) and conjecture_false (proved)."
     },
     {
       "id": "related-results",
@@ -160,7 +160,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #753 is SOLVED/DISPROVED. Alon (1992) showed that the conjectured lower bound χ_L(G) + χ_L(G^c) > n^{1/2+c} fails: for every n, there exist graphs where the sum is only O((n log n)^{1/2}). The counterexamples come from random graphs near the threshold p = 1/2, where G and G^c have similar structure. The formalization has 1 sorry (in the asymptotic contradiction step).",
+    "summary": "Erdős Problem #753 is SOLVED/DISPROVED. Alon (1992) showed that the conjectured lower bound χ_L(G) + χ_L(G^c) > n^{1/2+c} fails: for every n, there exist graphs where the sum is only O((n log n)^{1/2}). The counterexamples come from random graphs near the threshold p = 1/2, where G and G^c have similar structure. The formalization has 2 axioms (listChromaticNumber and alon_counterexample) and 0 sorries; conjecture_false is fully proved via asymptotic analysis.",
     "implications": "1. **List Coloring Theory**: The result shows that Nordhaus-Gaddum type bounds do not extend to list chromatic numbers in the hoped-for way, revealing a fundamental difference between chi and chi_L\n\n**2. Probabilistic Method**: Alon's proof is a landmark application of random graphs to disprove combinatorial conjectures, exploiting the self-complementary structure of G(n,1/2)\n\n3. **Open Gap**: The remaining gap between sqrt(n) (lower bound from Ramsey) and sqrt(n log n) (Alon's upper bound) is a natural open problem\n\n4. **Choosability vs Colorability**: The result adds to the growing understanding that list chromatic number can differ fundamentally from ordinary chromatic number.",
     "openQuestions": [
       "What is the correct order of magnitude: is chi_L(G) + chi_L(G^c) = Theta(sqrt(n)) or Theta(sqrt(n log n))?",


### PR DESCRIPTION
## Summary

Gallery integrity audit found stale narrative text in `erdos-753` meta.json. Core integrity fields (status, sorries, axiomCount, badge) were all correct — only descriptive text was stale from a prior version of the Lean file.

**Issues fixed:**
- `alon-counterexample` section summary: removed "(1 sorry in asymptotic contradiction)" — `conjecture_false` is now fully proved via `isLittleO_log_rpow_atTop`
- `probabilistic` section summary: removed mention of `alon_construction_probabilistic` and `random_half_symmetry` True-stub theorems that no longer exist in the Lean file
- `conclusion.summary`: corrected "The formalization has 1 sorry" to "0 sorries"

**Verification:** `git show HEAD:proofs/Proofs/Erdos753Problem.lean | grep sorry` returns no matches. The file has 2 axioms and 0 sorries, matching meta.json fields.

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)