### PR TITLE
Enrich fourier-series-oq-02-oq-02: fix annotation types, section ranges, line precision

### DIFF
--- a/src/data/proofs/enrichment-tracker.json
+++ b/src/data/proofs/enrichment-tracker.json
@@ -7660,7 +7660,7 @@
       "lastEnriched": "2026-04-23"
     },
     "erdos-758": {
-      "passes": 1,
+      "passes": 2,
       "quality": 100,
       "lastEnriched": "2026-04-23"
     },

--- a/src/data/proofs/fourier-series-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/fourier-series-oq-02-oq-02/annotations.json
@@ -50,8 +50,8 @@
   {
     "id": "ann-fsoq02oq02-sq-bound",
     "proofId": "fourier-series-oq-02-oq-02",
-    "range": { "startLine": 85, "endLine": 113 },
-    "type": "key-theorem",
+    "range": { "startLine": 87, "endLine": 131 },
+    "type": "insight",
     "title": "Squared Decay Bound: ‖ĉ_n‖² ≤ K/|n|^{2α}",
     "content": "`fourierCoeff_sq_le_pseries_term` is the bridge between the Hölder decay bound and the p-series comparison. For $n \\neq 0$:\n1. Get Hölder decay from the parent proof: $\\|\\hat{c}_n(f)\\| \\leq (C/2) \\cdot (T/(2|n|))^\\alpha$\n2. Square via `pow_le_pow_left₀`: $\\|\\hat{c}_n(f)\\|^2 \\leq [(C/2)(T/(2|n|))^\\alpha]^2$  \n3. Expand the square using `mul_rpow_sq` and `Real.div_rpow` to factor out $|n|^{2\\alpha}$: $= (C/2)^2 (T/2)^{2\\alpha} / |n|^{2\\alpha}$\n\nThe field_simp step in `h_split : T/(2|n|) = (T/2)/|n|` is the key algebraic reduction that allows `Real.div_rpow` to factor the absolute value out of the exponent.",
     "mathContext": "Final bound: $\\|\\hat{c}_n(f)\\|^2 \\leq K/|n|^{2\\alpha}$ where $K = (C/2)^2 \\cdot (T/2)^{2\\alpha}$. This converts the Hölder bound $O(|n|^{-\\alpha})$ into the p-series term $O(|n|^{-2\\alpha})$ suitable for the comparison test with $\\beta = 2\\alpha > 1$.",
@@ -62,8 +62,8 @@
   {
     "id": "ann-fsoq02oq02-main-theorem",
     "proofId": "fourier-series-oq-02-oq-02",
-    "range": { "startLine": 121, "endLine": 157 },
-    "type": "key-theorem",
+    "range": { "startLine": 132, "endLine": 164 },
+    "type": "insight",
     "title": "Main Theorem: Square-Summability via Comparison Test",
     "content": "`fourierCoeff_sq_summable_of_holder_pseries` is the main result. The proof structure:\n1. Derive $2\\alpha > 1$ from $\\alpha > 1/2$ via `linarith`\n2. Set $K = (C/2)^2 (T/2)^{2\\alpha}$ as a local definition\n3. Get convergence of the dominating series $\\sum K/|n|^{2\\alpha}$ from `summable_const_div_int_rpow`\n4. Apply `Summable.of_norm_bounded_eventually` (the comparison test with cofinite exceptions)\n5. Handle the $n=0$ exception: `Filter.eventually_cofinite.mpr` with `Set.finite_singleton (0:ℤ)` shows $\\{0\\}$ is the only exception\n6. For $n \\neq 0$: use `fourierCoeff_sq_le_pseries_term` by contradiction\n\nThe cofinite filter approach is elegant: `Summable.of_norm_bounded_eventually` allows the bound to fail on finitely many terms (here just $n=0$ where $|n|=0$ makes $K/|n|^{2\\alpha}$ ill-defined).",
     "mathContext": "Applied theorem: `Summable.of_norm_bounded_eventually`: if $\\sum g_n < \\infty$ and $|f_n| \\leq g_n$ for all but finitely many $n$, then $\\sum f_n < \\infty$. Here $f_n = \\|\\hat{c}_n\\|^2$, $g_n = K/|n|^{2\\alpha}$, exceptions $= \\{0\\}$.",
@@ -74,7 +74,7 @@
   {
     "id": "ann-fsoq02oq02-sharpness",
     "proofId": "fourier-series-oq-02-oq-02",
-    "range": { "startLine": 181, "endLine": 195 },
+    "range": { "startLine": 189, "endLine": 196 },
     "type": "insight",
     "title": "Sharpness: α = 1/2 is the Critical Threshold (with sorry)",
     "content": "`holder_half_is_critical_for_pseries` states that the p-series argument fails at exactly $\\alpha = 1/2$: the squared bound becomes $O(|n|^{-1})$ and the harmonic series $\\sum 1/|n|$ diverges over $\\mathbb{Z}$.\n\nThis theorem is left with a `sorry` because harmonic series divergence over $\\mathbb{Z}$ ($\\sum_{n \\neq 0} 1/|n| = \\infty$) is not immediately available in Mathlib in this form. The real question is: `¬ Summable (fun n : ℤ => K / |n|^1)` — a consequence of `Real.summable_nat_rpow_inv` going the other direction, but requiring extra work to transfer from $\\mathbb{N}$ to $\\mathbb{Z}$.\n\nNote: The sorry is in the sharpness statement only. The main results (Parts I–III) are sorry-free.",
@@ -86,7 +86,7 @@
   {
     "id": "ann-fsoq02oq02-comparison",
     "proofId": "fourier-series-oq-02-oq-02",
-    "range": { "startLine": 163, "endLine": 179 },
+    "range": { "startLine": 165, "endLine": 188 },
     "type": "insight",
     "title": "Two Routes to the Same Conclusion: p-Series vs Parseval",
     "content": "`sq_summable_matches_parseval` makes explicit that this p-series proof gives the same conclusion as the Parseval-based proof in `FourierSeriesOQ02OQ01.lean`. The two routes differ in what they require:\n\n- **Parseval route** (sibling proof OQ02OQ01): Continuity → bounded → $L^2$ → Parseval identity $\\sum \\|\\hat{c}_n\\|^2 = \\|f\\|_{L^2}^2$. Shorter (~15 lines) but requires $L^2$ theory and measure theory.\n\n- **p-Series route** (this file): Hölder decay → squared bound → comparison. Longer (~50 lines) but elementary — no $L^2$, no measure theory beyond the definition of Fourier coefficients.\n\n`fourier_coeff_l2` re-expresses the result as an existential `HasSum` statement, giving the concrete sum value $S$ such that the Fourier coefficients sum to $S$ in the $L^2(\\mathbb{Z})$ sense.",

--- a/src/data/proofs/fourier-series-oq-02-oq-02/meta.json
+++ b/src/data/proofs/fourier-series-oq-02-oq-02/meta.json
@@ -92,36 +92,44 @@
   },
   "sections": [
     {
+      "id": "module-header",
+      "title": "Module Header, Imports, and Setup",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "Block comment (lines 1–33) documenting the problem and proof strategy. Line 34: import of parent FourierSeriesOQ02.lean. Lines 35–41: opens, set_option maxHeartbeats 800000 (algebraic cost of Real.rpow manipulations), and namespace FourierSqSummablePSeries.",
+      "mathContext": "Single import `Proofs.FourierSeriesOQ02` brings in `fourierCoeff_holder_decay` (the quantitative Hölder decay bound) and `IsHolderOnCircle`. The `set_option maxHeartbeats 800000` signals that `Real.rpow` arithmetic is expensive — the `rpow_mul_natCast` bridge in particular requires extended elaboration."
+    },
+    {
       "id": "part-i-pseries",
       "title": "Part I: p-Series Summability over ℤ",
-      "startLine": 45,
-      "endLine": 70,
-      "summary": "Two theorems: summable_const_div_nat_rpow (p-series over ℕ via Real.summable_nat_rpow_inv) and summable_const_div_int_rpow (p-series over ℤ by splitting into positive/negative halves).",
-      "mathContext": "The p-series ∑ 1/n^β converges for β > 1. Extension to ℤ splits into ∑_{n:ℕ} K/n^β (positive half) and ∑_{n:ℕ} K/|-(n:ℤ)|^β (negative half), both equal to the same ℕ series."
+      "startLine": 53,
+      "endLine": 78,
+      "summary": "Two theorems: summable_const_div_nat_rpow (p-series over ℕ via Real.summable_nat_rpow_inv) and summable_const_div_int_rpow (p-series over ℤ by splitting into positive/negative halves via summable_int_iff_summable_nat_and_neg).",
+      "mathContext": "The p-series $\\sum_{n:\\mathbb{N}} K/n^\\beta < \\infty$ for $\\beta > 1$ is `Real.summable_nat_rpow_inv`. Extension to $\\mathbb{Z}$: `summable_int_iff_summable_nat_and_neg` reduces to two ℕ p-series (positive and negative halves), both convergent for $\\beta > 1$."
     },
     {
       "id": "part-ii-decay-bound",
       "title": "Part II: Squared Decay Bound",
-      "startLine": 71,
-      "endLine": 114,
-      "summary": "Helper mul_rpow_sq: (a·b^α)² = a²·b^{2α}. Main: fourierCoeff_sq_le_pseries_term: ‖ĉ_n‖² ≤ K/|n|^{2α} for n ≠ 0, derived by squaring the Hölder decay bound from FourierSeriesOQ02.",
-      "mathContext": "The key algebraic manipulation: (T/(2|n|))^α → split via div_rpow → (T/2)^α/|n|^α → square → K/|n|^{2α}. Uses pow_le_pow_left₀ to square the norm inequality and Real.div_rpow to factor out |n|^{2α}."
+      "startLine": 79,
+      "endLine": 131,
+      "summary": "Helper mul_rpow_sq (line 79): (a·b^α)² = a²·b^{2α}. Main theorem fourierCoeff_sq_le_pseries_term (line 87): ‖ĉ_n‖² ≤ K/|n|^{2α} for n ≠ 0, derived by squaring the Hölder decay bound from FourierSeriesOQ02.",
+      "mathContext": "The key algebraic chain: $(T/(2|n|))^\\alpha \\xrightarrow{\\text{div\\_rpow}} (T/2)^\\alpha/|n|^\\alpha \\xrightarrow{\\text{square}} K/|n|^{2\\alpha}$ where $K = (C/2)^2(T/2)^{2\\alpha}$. Uses `pow_le_pow_left₀` to square the norm inequality and `Real.div_rpow` to factor $|n|^{2\\alpha}$ out of the power."
     },
     {
       "id": "part-iii-main",
       "title": "Part III: Main Theorem — Square-Summability via p-Series",
-      "startLine": 119,
-      "endLine": 158,
-      "summary": "fourierCoeff_sq_summable_of_holder_pseries: main theorem proving ∑ ‖ĉ_n‖² < ∞ by comparison with the p-series ∑ K/|n|^{2α}. Uses Summable.of_norm_bounded_eventually with the cofinite filter for the n=0 exception.",
-      "mathContext": "The comparison argument: h_dominated gives summability of the p-series (2α > 1 from α > 1/2). The comparison test Summable.of_norm_bounded_eventually allows finitely many exceptions — here exactly {0}."
+      "startLine": 132,
+      "endLine": 164,
+      "summary": "fourierCoeff_sq_summable_of_holder_pseries: main theorem proving ∑ ‖ĉ_n‖² < ∞ by comparison with the p-series ∑ K/|n|^{2α}. Uses Summable.of_norm_bounded_eventually with the cofinite filter for the n=0 exception (where |n|=0 makes K/|n|^{2α} undefined).",
+      "mathContext": "Comparison: $\\|\\hat{c}_n\\|^2 \\leq K/|n|^{2\\alpha}$ for $n \\neq 0$, and $\\sum_{n:\\mathbb{Z}} K/|n|^{2\\alpha} < \\infty$ since $2\\alpha > 1$. `Summable.of_norm_bounded_eventually` handles the $n=0$ exception via `Set.finite_singleton (0:ℤ)` in the cofinite filter."
     },
     {
       "id": "part-iv-corollaries",
-      "title": "Part IV: Corollaries",
-      "startLine": 159,
+      "title": "Part IV: Corollaries and Sharpness",
+      "startLine": 165,
       "endLine": 197,
-      "summary": "Three corollaries: sq_summable_matches_parseval (aliases the main theorem), fourier_coeff_l2 (existential form: ∃ S, HasSum ...), holder_half_is_critical_for_pseries (sharpness: α = 1/2 fails, 1 sorry).",
-      "mathContext": "The sharpness statement formalizes that the p-series argument fails at α = 1/2 because the harmonic series ∑ 1/|n| diverges. The sorry requires harmonic series divergence over ℤ not immediately available in this form from Mathlib."
+      "summary": "Three theorems: sq_summable_matches_parseval (aliases the main theorem, matching the parent's conclusion), fourier_coeff_l2 (existential HasSum form), and holder_half_is_critical_for_pseries (sharpness: α = 1/2 fails the p-series test — harmonic series diverges, 1 sorry).",
+      "mathContext": "Sharpness at $\\alpha = 1/2$: squared bound $= K/|n|^1$ = harmonic series, which diverges over $\\mathbb{Z}$. The sorry requires `¬Summable (fun n:ℤ => K/|↑n|)` — a consequence of `Real.summable_nat_rpow_inv` in the divergence direction, not yet transferred to $\\mathbb{Z}$ in this form."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Enrichment pass for fourier-series-oq-02-oq-02 (pass 1)

**Entry**: Fourier Coefficient Square-Summability via p-Series (quality: 98, 0 prior passes)

### Changes

**annotations.json — Schema compliance and line precision fixes:**
- Fixed `type: "key-theorem"` → `type: "insight"` on 2 annotations — `key-theorem` is not a valid type in the schema (`concept|definition|technique|insight|context`)
- Fixed `ann-fsoq02oq02-sq-bound`: startLine 85→87 (was blank/comment, now at `theorem fourierCoeff_sq_le_pseries_term`), endLine 113→131 (covers full 45-line theorem body instead of stopping mid-proof)
- Fixed `ann-fsoq02oq02-main-theorem`: startLine 121→132 (was pointing to Part III section comment, not the actual theorem declaration), endLine 157→164 (covers full theorem body)
- Fixed `ann-fsoq02oq02-sharpness`: startLine 181→189 (was in the middle of `fourier_coeff_l2`, now at `theorem holder_half_is_critical_for_pseries`)
- Fixed `ann-fsoq02oq02-comparison`: range 163-179 → 165-188 (covers both `sq_summable_matches_parseval` and `fourier_coeff_l2` precisely rather than straddling both into `sharpness`)

**meta.json — Sections restructured (4 → 5) with precise line ranges:**
- Added `module-header` section (lines 1–43): header comment, import, opens, set_option, namespace
- Fixed all section startLine/endLine values to match actual theorem positions from grep
- Added mathContext to `module-header` explaining why `set_option maxHeartbeats 800000` is needed
- Corrected `part-iii-main` startLine 119→132 and `part-iv-corollaries` startLine 159→165

### Verification
- Both JSON files pass JSON validation
- `annotations:build` shows no warnings for `fourier-series-oq-02-oq-02`