### PR TITLE
Audit: fix stale sorry references in arithmetic-series-oq-02-oq-02-oq-03-oq-01

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-01/meta.json
@@ -24,7 +24,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "theoremCount": 23,
+    "theoremCount": 27,
     "defCount": 4,
     "lineCount": 507,
     "mathlib_version": "4.26.0",
@@ -56,12 +56,12 @@
   "overview": {
     "historicalContext": "Pólya's enumeration theorem was published by George Pólya in 1937 ('Kombinatorische Anzahlbestimmungen für Gruppen, Graphen und chemische Verbindungen', Acta Mathematica 68). It gave a systematic method for counting combinatorial objects up to symmetry, with applications ranging from necklace counting to chemical isomer enumeration. The theorem generalizes Burnside's lemma (1897, also called the Cauchy-Frobenius lemma) from counting orbits to counting orbits weighted by color frequencies. Pólya's insight was the 'cycle index' of a group action: Z(G; x₁,...,xₖ) = (1/|G|) Σ_{g∈G} ∏_j xⱼ^{cⱼ(g)}, where cⱼ(g) counts j-cycles in the permutation g. Setting all variables to k gives the number of distinct k-colorings.",
     "problemStatement": "**Open Question (OQ-01):** Can the generating function approach from the parallel Vandermonde entry be extended to prove Pólya's enumeration theorem?\n\nSpecifically, formalize that for the cyclic group Cₙ acting on n-bead necklaces:\n$$n \\cdot |\\text{Necklaces}(n, k)| = \\sum_{d|n} \\varphi(d) \\cdot k^{n/d}$$",
-    "proofStrategy": "**Step 1 — Group action** (§1): Define ZColoring n k = ZMod n → Fin k and the rotation action r +ᵥ c = fun i => c(i−r). The action law follows from `sub_sub` in ZMod n, requiring no axioms.\n\n**Step 2 — Fixed-point counts** (§2): For ZMod 4 acting on binary 4-colorings, compute |Fix(r)| for each r ∈ {0,1,2,3} by `native_decide`: Fix(0)=16, Fix(1)=2, Fix(2)=4, Fix(3)=2. Sum = 24.\n\n**Step 3 — Burnside** (§3): Apply `MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group` to get |Orbits|·4 = 24, so |Orbits| = 6. The orbit quotient is exactly the necklace count.\n\n**Step 4 — Pólya formula** (§4): Verify n·|Necklaces(n,2)| = Σ_{d|n} φ(d)·2^{n/d} for n=2,3,4,6 by `norm_num` after computing totient values.\n\n**Step 5 — General theorem** (§5): The general Pólya theorem (1 sorry) requires the cycle structure theorem: rotation by r has gcd(r.val, n) cycles.",
+    "proofStrategy": "**Step 1 — Group action** (§1): Define ZColoring n k = ZMod n → Fin k and the rotation action r +ᵥ c = fun i => c(i−r). The action law follows from `sub_sub` in ZMod n, requiring no axioms.\n\n**Step 2 — Fixed-point counts** (§2): For ZMod 4 acting on binary 4-colorings, compute |Fix(r)| for each r ∈ {0,1,2,3} by `native_decide`: Fix(0)=16, Fix(1)=2, Fix(2)=4, Fix(3)=2. Sum = 24.\n\n**Step 3 — Burnside** (§3): Apply `MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group` to get |Orbits|·4 = 24, so |Orbits| = 6. The orbit quotient is exactly the necklace count.\n\n**Step 4 — Pólya formula** (§4): Verify n·|Necklaces(n,2)| = Σ_{d|n} φ(d)·2^{n/d} for n=2,3,4,6 by `norm_num` after computing totient values.\n\n**Step 5 — General theorem** (§5): The general Pólya theorem is fully proved using BurnsideCountingOQ03.polya_cyclic_fixed_count (cycle structure: rotation by r has gcd(r.val, n) fixed-point colorings k^gcd) and polya_sum_identity (totient divisor-sum grouping).",
     "keyInsights": [
       "ZMod n → Fin k colorings (instead of Fin n → Fin k) give a clean axiom-free group action: the law (r+s)+ᵥc = r+ᵥ(s+ᵥc) reduces to `sub_sub` in ZMod, a single one-line algebraic identity.",
       "Burnside's lemma is applied through the chain: fixed-point sum 24 = |Orbits|×4, so |Orbits| = 6. The key technique `hb.symm.trans h1` avoids a binder-name mismatch that would prevent `rw` from working directly.",
       "The Pólya formula Σ_{d|n} φ(d)·k^{n/d} arises from grouping the Burnside sum Σ_{r∈ZMod n} k^{gcd(r,n)} by gcd value: the number of r ∈ [0,n) with gcd(r,n) = n/d is exactly φ(d).",
-      "Rotation by r on an n-bead necklace acts as a permutation with gcd(r.val,n) cycles each of length n/gcd(r.val,n). This cycle structure theorem (left as 1 sorry) is the key missing piece for the general Pólya theorem.",
+      "Rotation by r on an n-bead necklace acts as a permutation with gcd(r.val,n) cycles each of length n/gcd(r.val,n). This cycle structure theorem — proved in BurnsideCountingOQ03 via polya_cyclic_fixed_count — is the key bridge connecting the abstract Burnside sum to the totient-weighted divisor sum.",
       "The necklace sequence [2,3,4,6,8,14] for n=1,...,6 with 2 colors appears in OEIS A000029 (necklaces of n beads of 2 colors). The values grow approximately as 2^n/(2n) for large n by the Burnside-Pólya formula."
     ],
     "prerequisites": [
@@ -153,10 +153,10 @@
     }
   ],
   "conclusion": {
-    "summary": "Fully verified formalization proving 23 theorems (0 sorries) from 0 axioms. Burnside's lemma is used to count necklaces; the Pólya divisor-sum formula is verified for small n and proved in general via Burnside + cycle structure + totient grouping.",
+    "summary": "Fully verified formalization proving 27 theorems (0 sorries) from 0 axioms. Burnside's lemma is used to count necklaces; the Pólya divisor-sum formula is verified for small n and proved in general via Burnside + cycle structure (from BurnsideCountingOQ03) + totient grouping.",
     "implications": "Pólya's enumeration theorem is the foundational tool for counting combinatorial objects up to symmetry. The formalization demonstrates that Burnside's lemma from Mathlib is powerful enough to count necklaces concretely, and that ZMod-indexed colorings provide a particularly clean Lean 4 approach. The cycle structure theorem (each rotation by r has gcd(r,n) orbits on n positions) is the key missing ingredient for the general theorem — it connects the abstract Burnside sum to the totient-weighted divisor sum. The sequence [2,3,4,6,8,14] (binary necklaces for n=1–6) appears in OEIS A000029 and has applications in chemistry (molecular isomers), music theory (necklace rhythms), and coding theory (cyclic codes).",
     "openQuestions": [
-      "Prove the cycle structure theorem: for rotation by r in ZMod n acting on ZMod n → Fin k, the number of fixed-point colorings is k^{gcd(r.val, n)}. This would close the 1 sorry and complete the general Pólya theorem.",
+      "Extend to arbitrary finite groups: the general Pólya enumeration theorem for non-cyclic groups (e.g., dihedral groups D_n for unoriented necklaces) requires formalizing the full cycle index formalism beyond cyclic symmetry.",
       "Extend to arbitrary finite groups: Pólya's theorem for non-cyclic groups (e.g., dihedral groups D_n for unoriented necklaces) requires the full cycle index formalism.",
       "Multivariate Pólya: The full theorem counts colorings with prescribed color frequencies, not just total colorings. Formalize the generating function form Z(G; x_1, ..., x_k).",
       "Connect to the generating function approach: the cycle index of C_n has a product formula related to cyclotomic polynomials. Formalize this connection."


### PR DESCRIPTION
## Audit Fix

**Proof**: arithmetic-series-oq-02-oq-02-oq-03-oq-01 (Pólya Enumeration via Cyclic Group Actions)

**Issues found and fixed**:

1. **Stale sorry references** — `keyInsights[3]` said "This cycle structure theorem (left as 1 sorry)" and `openQuestions[0]` said "This would close the 1 sorry and complete the general Pólya theorem." The proof is fully complete (0 sorries); `polya_cyclic_fixed_count` in `BurnsideCountingOQ03` supplies the cycle structure theorem. These stale references were replaced with accurate descriptions.

2. **proofStrategy** also referenced "1 sorry" in Step 5 — updated to describe the actual proof approach via BurnsideCountingOQ03.

3. **theoremCount mismatch** — `meta.theoremCount` was 23 but `leanFile.theoremCount` was 27 and the actual file has 27 top-level theorem declarations. Fixed to 27. Conclusion summary updated from "23 theorems" to "27 theorems".

**Lean source is clean**: 0 sorries, 0 axioms confirmed via `git show HEAD:proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean`.

---
Discovered during gallery integrity audit.