### PR TITLE
Audit: fix sorry count in ballot-problem-oq-03-oq-01-oq-02 (4→5)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -19,10 +19,10 @@
       "representation-theory"
     ],
     "badge": "wip",
-    "sorries": 4,
+    "sorries": 5,
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "assumptions": "Four open sorries: (1) hook_length_formula (requires SYT↔NI bijection + det factorization), (2) ni_count_eq_syt_count (Fomin/Viennot/RSK correspondence), (3) lgv_det_factors_as_hook_quotient (det factorization identity), (4) card_SYT_twoRectYD (SYT count for 2-row rectangular = Catalan number C_m via ballot bijection). StandardYoungTableau.ext is now fully proved (funext).",
+    "assumptions": "Five open sorries: (1) hook_length_formula (requires SYT↔NI bijection + det factorization), (2) ni_count_eq_syt_count (Fomin/Viennot/RSK correspondence), (3) lgv_det_factors_as_hook_quotient (det factorization identity), (4) card_SYT_twoRectYD (SYT count for 2-row rectangular = Catalan number C_m via ballot bijection), (5) card_SYT_twoRowYD (SYT count for general 2-row [a,b] = ballotSeqCount(a+1,b) via ballot subset bijection). StandardYoungTableau.ext is now fully proved (funext).",
     "lineCount": 2991,
     "theoremCount": 95,
     "definitionCount": 14,
@@ -34,8 +34,8 @@
       "hook_length_formula_one_row: f^(1×n) = 1 (direct, 0 sorries)",
       "hook_length_formula_one_col: f^(n×1) = 1 (direct, 0 sorries)",
       "hook_length_formula_hook_shape: f^(m+1,1) = (m+1) × (m+2) × m! (bijection with Fin(m+1), 0 sorries)",
-      "card_SYT_twoRectYD: card(SYT(m×m)) = Cn m via Lindstrom reflection bijection (0 sorries)",
-      "hook_length_formula_two_rect: Cn(m) × (m+1)! × m! = (2m)! (proved, 0 sorries)",
+      "card_SYT_twoRectYD: card(SYT(m×m)) = Cn m via Lindstrom reflection bijection (1 sorry: requires ~150 lines of bijection infrastructure)",
+      "hook_length_formula_two_rect: Cn(m) × (m+1)! × m! = (2m)! (conditional on card_SYT_twoRectYD sorry)",
       "twoRowYD: general 2-row Young diagram [a,b] for a≥b",
       "hookProd_twoRowYD: hookProd([a,b]) = (a+1).descFactorial b × (a-b)! × b! (proved, 0 sorries)",
       "two_row_hook_identity: numerical identity ballotSeqCount(a+1,b) × hookProd = (a+b)! (proved, 0 sorries)",
@@ -85,7 +85,7 @@
     "namespace": "HookLengthFormula",
     "lineCount": 2991,
     "axiomCount": 0,
-    "sorries": 4,
+    "sorries": 5,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",
     "theoremCount": 95,
     "definitionCount": 14
@@ -162,5 +162,5 @@
       "mathContext": "Verified: (2,1)→2, (2,2)→2, (3,1)→3, (3,2)→5, (3,2,1)→16, (4,3,2,1)→1440, (3,3)→5 (C₃), (4,4)→14 (C₄)."
     }
   ],
-  "sorries": 4
+  "sorries": 5
 }


### PR DESCRIPTION
## Summary

Gallery integrity audit found a sorry count mismatch in `ballot-problem-oq-03-oq-01-oq-02`:

- The Lean file `proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean` contains **5 sorry tactics** (verified via `git show HEAD:...`):
  1. `hook_length_formula` (line 219)
  2. `ni_count_eq_syt_count` (line 235)
  3. `lgv_det_factors_as_hook_quotient` (line 245)
  4. `card_SYT_twoRectYD` (line 1258)
  5. `card_SYT_twoRowYD` (line 1465)
- `meta.json` claimed `"sorries": 4`, missing `card_SYT_twoRowYD`

## Changes

1. `"sorries": 4` → `"sorries": 5` (in `meta`, `leanFile`, and top-level fields)
2. `assumptions` updated from "Four open sorries" to "Five open sorries", adding entry (5) for `card_SYT_twoRowYD`
3. `originalContributions`: `card_SYT_twoRectYD` corrected from "0 sorries" to "1 sorry: requires ~150 lines of bijection infrastructure"
4. `originalContributions`: `hook_length_formula_two_rect` updated to reflect its conditional status on the `card_SYT_twoRectYD` sorry

## Test plan

- [ ] Verify `jq '.sorries' src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json` returns `5`
- [ ] Confirm sorry count matches grep on `git show HEAD:proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean | grep -c 'sorry'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)