### PR TITLE
Add Aristotle companion for Erdős #901 (Property B / hypergraph coloring)

### DIFF
--- a/proofs/Proofs/Erdos901ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos901ProblemAristotle.lean
@@ -1,0 +1,73 @@
+/-
+  Aristotle targets for Erdős Problem #901: Property B and Hypergraph Coloring
+  Routine supporting lemmas for automated proof search.
+  See Erdos901Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main open problem (Erdős-Lovász Conjecture: m(n) = Θ(n · 2^n))
+  - NOT the deep bounds (Beck, Radhakrishnan-Srinivasan, Erdős upper/lower)
+  - NOT the exact values (m(2)=3, m(3)=7, m(4)=23 require explicit constructions)
+  - NOT the Lovász Local Lemma application
+  - Logical equivalences between complementary definitions
+  - Arithmetic identities (probability of monochromatic event)
+  - Concrete finite instance (hypergraph_m2 lacks Property B)
+  - No axioms, no definition sorries, no open conjectures
+  - No /-! docstring sections (use /- instead)
+
+  Included targets (3):
+  - propertyB_dichotomy_ari: HasPropertyB ↔ ¬LacksPropertyB (definitional iff)
+  - monochromatic_probability_ari: 2^(1-n) = 2/2^n (arithmetic identity)
+  - hypergraph_m2_no_propertyB_ari: concrete 3-edge triangle lacks Property B
+-/
+import Proofs.Erdos901Problem
+import Mathlib
+
+namespace Erdos901Aristotle
+
+open Erdos901 Finset Real
+
+/-
+## Section 1: Logical Equivalence Between Complementary Definitions
+
+HasPropertyB and LacksPropertyB are complementary by construction:
+  HasPropertyB H  = ∃ c, ∀ e ∈ edges, ¬IsMonochromatic c e
+  LacksPropertyB H = ∀ c, ∃ e ∈ edges,  IsMonochromatic c e
+These are logical negations of each other.
+-/
+
+/-- Property B and its negation are definitionally complementary.
+The key: ¬(∀ c, ∃ e, P c e) = ∃ c, ∀ e, ¬P c e, which matches HasPropertyB. -/
+theorem propertyB_dichotomy_ari {V : Type*} [Fintype V] [DecidableEq V] {n : ℕ}
+    (H : UniformHypergraph V n) :
+    HasPropertyB H ↔ ¬LacksPropertyB H := by
+  sorry
+
+/-
+## Section 2: Arithmetic Identity for Monochromatic Probability
+
+The probability that a uniformly random 2-coloring makes a fixed n-element edge
+monochromatic is 2 · 2^{-n} = 2^{1-n} (two choices for the common color).
+-/
+
+/-- The probability an edge is monochromatic: 2^(1-n) = 2/2^n.
+Follows from zpow arithmetic: 2^(1-n) = 2^1 · 2^(-n) = 2 · (1/2^n) = 2/2^n. -/
+theorem monochromatic_probability_ari (n : ℕ) (hn : n ≥ 1) :
+    (2 : ℝ) ^ (1 - (n : ℤ)) = 2 / 2 ^ n := by
+  sorry
+
+/-
+## Section 3: Concrete Instance — Three-Edge Triangle Lacks Property B
+
+The hypergraph on {0,1,2,3} with edges {0,1}, {0,2}, {1,2} (the triangle on
+vertices 0,1,2) fails Property B: any 2-coloring of {0,1,2} gives at least
+two vertices the same color (by pigeonhole), and the edge between them is
+monochromatic.
+-/
+
+/-- The concrete 3-edge hypergraph on Fin 4 lacks Property B.
+Under any 2-coloring c : Fin 4 → Fin 2, among c 0, c 1, c 2, two must agree
+by pigeonhole, yielding a monochromatic edge in {{0,1}, {0,2}, {1,2}}. -/
+theorem hypergraph_m2_no_propertyB_ari : LacksPropertyB hypergraph_m2 := by
+  sorry
+
+end Erdos901Aristotle


### PR DESCRIPTION
## Fix

Creates `Erdos901ProblemAristotle.lean` — Aristotle companion for Erdős Problem #901 (Property B and hypergraph coloring). The main proof has 19 sorries but lacked an Aristotle companion file.

## Evidence

**Before**: `proofs/Proofs/Erdos901Problem.lean` (19 sorries) had no companion file for automated proof search.

**After**: `Erdos901ProblemAristotle.lean` with 3 Aristotle-suitable targets:
- `propertyB_dichotomy_ari` — definitional iff between `HasPropertyB` / `LacksPropertyB` (logical negation, likely provable by `simp`/`tauto`)
- `monochromatic_probability_ari` — arithmetic identity `2^(1-n) = 2/2^n` (likely `ring`/`norm_num`)
- `hypergraph_m2_no_propertyB_ari` — concrete 3-edge triangle on `Fin 4` lacks Property B (likely `decide`)

## Pre-submission checklist

- [x] No `def ... := sorry` (definition sorries)
- [x] No `axiom` declarations
- [x] No `theorem ... : True` placeholders
- [x] No `/-!` docstring sections (using `/-` instead)
- [x] No open conjectures (Erdős-Lovász conjecture excluded)

---
Automated fix by lean-mechanic agent.