### PR TITLE
Audit: fix badge and defCount for Pólya Enumeration entry

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-01/meta.json
@@ -21,11 +21,11 @@
       "zmod",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "theoremCount": 27,
-    "defCount": 4,
+    "defCount": 5,
     "lineCount": 507,
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
@@ -192,7 +192,7 @@
     "lineCount": 507,
     "axiomCount": 0,
     "theoremCount": 27,
-    "definitionCount": 4,
+    "definitionCount": 5,
     "sorries": 0,
     "path": "Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean"
   }


### PR DESCRIPTION
## Integrity Issue

**Proof**: arithmetic-series-oq-02-oq-02-oq-03-oq-01 (Pólya Enumeration via Cyclic Group Actions)

## Issues Found

### 1. Badge mismatch (MEDIUM)

**meta.json claims**: `"badge": "verified"`
**Lean file shows**: Core Burnside counting result obtained via `MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group` from Mathlib

The proof does original work (ZMod coloring type, fixed-point computations, Pólya formula, general theorem structure) but the core orbit counting mechanism is Mathlib's Burnside lemma. Per gallery auditor guidelines (Tier B: Formalized using Mathlib theorem), badge should be `mathlib`.

The `mathlibDependencies` field already honestly lists this dependency — this fix aligns the badge with that transparency.

### 2. Definition count off by 1 (LOW)

**meta.json claims**: `"defCount": 4`, `"definitionCount": 4`
**Lean file shows**: 5 definitions (`abbrev ZColoring`, `def rotateZColoring`, `def IsRotFixed`, `noncomputable def necklaceCount`, `def necklaceSeq`)

The `abbrev ZColoring` at line 74 was not counted. Corrected to 5.

## Evidence

```bash
git show HEAD:proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean | grep -n "^def \|^noncomputable def \|^abbrev "
# 74: abbrev ZColoring
# 79: def rotateZColoring
# 97: def IsRotFixed
# 246: noncomputable def necklaceCount
# 489: def necklaceSeq
```

## Proof Substance Unchanged

- 0 sorries ✓
- 0 axioms ✓
- 27 theorems ✓
- 507 lines ✓
- status: verified ✓

---
Discovered during gallery integrity audit.