### PR TITLE
Fix: replace standalone /-! with /- in BaselProblemOQ01OQ01OQ02Aristotle.lean

### DIFF
--- a/proofs/Proofs/BaselProblemOQ01OQ01OQ02Aristotle.lean
+++ b/proofs/Proofs/BaselProblemOQ01OQ01OQ02Aristotle.lean
@@ -29,7 +29,7 @@ namespace AperyZetaThreeAristotle
 def lcmUpTo (n : ℕ) : ℕ :=
   (Finset.range n).lcm (· + 1)
 
-/-! ## Helper lemmas for the Nair bound -/
+/- ## Helper lemmas for the Nair bound -/
 
 /-- C(2n, n) ≤ 4^n: the central binomial coefficient is at most 4^n.
     Proof: C(2n, n) ≤ Σ_{k=0}^{2n} C(2n, k) = 2^(2n) = 4^n. -/


### PR DESCRIPTION
## Fix

Replace the standalone `/-!` module docstring section with `/-` in the Apéry ζ(3) Aristotle companion file.

## Evidence

**Before**: Line 32 had `/-! ## Helper lemmas for the Nair bound -/` — a standalone `/-!` docstring section at comment depth 0, which Aristotle's parser cannot process.

**After**: Line 32 now reads `/- ## Helper lemmas for the Nair bound -/` — a regular block comment, fully compatible with Aristotle.

**Detection method**: Parser-aware scan (tracking comment depth) identified this as the only genuine standalone `/-!` section across all 23 Aristotle companion files. The remaining 22 files only have `/-!` text inside existing block comments, which is safe.

---
Automated fix by lean-mechanic agent.