### PR TITLE
Fix: fourier-series-oq-02-oq-02 — prove holder_half_is_critical_for_pseries (1 sorry → 0)

### DIFF
--- a/proofs/Proofs/FourierSeriesOQ02OQ02.lean
+++ b/proofs/Proofs/FourierSeriesOQ02OQ02.lean
@@ -219,7 +219,7 @@ theorem holder_half_is_critical_for_pseries :
   have h_not_harm : ¬ Summable (fun n : ℕ => (1 : ℝ) / (n : ℝ)) := by
     intro hs
     have : Summable (fun n : ℕ => (n : ℝ)⁻¹ ^ (1 : ℝ)) :=
-      hs.congr (fun n => by simp [Real.rpow_one, inv_eq_one_div])
+      hs.congr (fun n => by simp only [Real.rpow_one, one_div])
     exact absurd this (Real.summable_nat_rpow_inv.not.mpr (by norm_num))
   exact h_not_harm h_harm
 

--- a/proofs/Proofs/FourierSeriesOQ02OQ02.lean
+++ b/proofs/Proofs/FourierSeriesOQ02OQ02.lean
@@ -190,8 +190,37 @@ theorem holder_half_is_critical_for_pseries :
     ¬ (∀ (C : ℝ≥0) (α : ℝ≥0), (α : ℝ) = 1/2 →
        ∀ f : AddCircle (2 * Real.pi) → ℂ, IsHolderOnCircle C α f →
        Summable (fun n : ℤ => ((C : ℝ) / 2) ^ 2 * (Real.pi) ^ (2 * (α : ℝ)) / |↑n| ^ (2 * (α : ℝ)))) := by
-  -- The p-series ∑ 1/|n|^1 diverges (harmonic series), so α = 1/2 is the critical threshold.
-  -- Full proof requires: harmonic series divergence over ℤ (not in Mathlib in this form)
-  sorry
+  -- Strategy: assume universal statement, use f=0 witness, extract harmonic series contradiction.
+  intro hall
+  -- Zero function is Hölder with constant 1 and exponent 1/2
+  have h0 : IsHolderOnCircle 1 ⟨1/2, by norm_num⟩ (0 : AddCircle (2 * Real.pi) → ℂ) := by
+    intro x y
+    simp only [IsHolderOnCircle, HolderWith, Pi.zero_apply, edist_self, NNReal.coe_one,
+               ENNReal.coe_one, zero_le]
+  have hα_eq : ((⟨1/2, by norm_num⟩ : ℝ≥0) : ℝ) = 1/2 := by norm_num
+  -- Apply the universal statement with C=1, α=1/2, f=0
+  have hsum := hall 1 ⟨1/2, by norm_num⟩ hα_eq 0 h0
+  -- Extract the ℕ positive part: Summable (fun n : ℕ => (1/4) * π / |n|)
+  rw [summable_int_iff_summable_nat_and_neg] at hsum
+  obtain ⟨h_pos, _⟩ := hsum
+  -- Rescale: multiply by 4/π to get harmonic series summability
+  have h_pi_pos : (0 : ℝ) < Real.pi := Real.pi_pos
+  have h_harm : Summable (fun n : ℕ => (1 : ℝ) / (n : ℝ)) := by
+    refine (h_pos.mul_left (4 / Real.pi)).congr fun n => ?_
+    rcases Nat.eq_zero_or_pos n with rfl | hn
+    · simp
+    · have hn_pos : (0 : ℝ) < (n : ℝ) := Nat.cast_pos.mpr hn
+      rw [Int.cast_natCast, abs_of_nonneg hn_pos.le]
+      have h2 : (2 : ℝ) * (1 / 2) = 1 := by norm_num
+      simp only [NNReal.coe_one, NNReal.coe_mk, h2, Real.rpow_one]
+      field_simp [h_pi_pos.ne', hn_pos.ne']
+      ring
+  -- Contradiction: harmonic series diverges (Real.summable_nat_rpow_inv for p=1)
+  have h_not_harm : ¬ Summable (fun n : ℕ => (1 : ℝ) / (n : ℝ)) := by
+    intro hs
+    have : Summable (fun n : ℕ => (n : ℝ)⁻¹ ^ (1 : ℝ)) :=
+      hs.congr (fun n => by simp [Real.rpow_one, inv_eq_one_div])
+    exact absurd this (Real.summable_nat_rpow_inv.not.mpr (by norm_num))
+  exact h_not_harm h_harm
 
 end FourierSqSummablePSeries

--- a/src/data/proofs/fourier-series-oq-02-oq-02/meta.json
+++ b/src/data/proofs/fourier-series-oq-02-oq-02/meta.json
@@ -2,12 +2,12 @@
   "id": "fourier-series-oq-02-oq-02",
   "title": "Fourier Coefficient Square-Summability via p-Series (Elementary Proof)",
   "slug": "fourier-series-oq-02-oq-02",
-  "description": "Elementary proof that Fourier coefficients of α-Hölder functions (α > 1/2) are square-summable, using only the Hölder decay bound and the p-series convergence criterion — no Parseval's theorem or L² theory required. 1 sorry (harmonic series sharpness), 0 axioms.",
+  "description": "Elementary proof that Fourier coefficients of α-Hölder functions (α > 1/2) are square-summable, using only the Hölder decay bound and the p-series convergence criterion — no Parseval's theorem or L² theory required. 0 sorries, 0 axioms.",
   "meta": {
     "author": "Classical result; formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Fourier_series#Convergence",
     "date": "Classical",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/FourierSeriesOQ02OQ02.lean",
     "tags": [
       "harmonic-analysis",
@@ -17,8 +17,8 @@
       "comparison-test",
       "square-summability"
     ],
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "verified",
+    "sorries": 0,
     "axiomCount": 0,
     "mathlibDependencies": [
       {
@@ -65,7 +65,7 @@
     ],
     "dateAdded": "2026-04-23",
     "lineCount": 197,
-    "assumptions": "1 sorry: holder_half_is_critical_for_pseries (harmonic series divergence over ℤ). Main results 0 sorries.",
+    "assumptions": "0 sorries, 0 axioms. All theorems fully proved including holder_half_is_critical_for_pseries (harmonic series divergence via Real.summable_nat_rpow_inv).",
     "mathlib_version": "4.26.0",
     "prerequisites": [
       "FourierSeriesOQ02.lean: Hölder decay bound fourierCoeff_holder_decay",
@@ -170,7 +170,7 @@
     "theoremCount": 7,
     "definitionCount": 0,
     "path": "Proofs/FourierSeriesOQ02OQ02.lean",
-    "sorries": 1
+    "sorries": 0
   },
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Proves the remaining sorry in `FourierSeriesOQ02OQ02.lean` and syncs `meta.json`.

## Evidence

**Before**: `holder_half_is_critical_for_pseries` had `sorry` — harmonic series divergence over ℤ was unproven.

**After**: Full elementary proof:
1. Assume the universal statement holds
2. Instantiate with f=0 (zero function, Hölder with any constant)
3. Extract ℕ positive-half summability via `summable_int_iff_summable_nat_and_neg`
4. Rescale by 4/π to obtain harmonic series summability
5. Derive contradiction via `Real.summable_nat_rpow_inv.not.mpr` (divergence at p=1)

**meta.json changes**:
- `sorries`: 1 → 0
- `status`: formalized → verified
- `badge`: wip → verified
- `assumptions`: updated to document no remaining sorries

The proof was developed on branch `research/fourier-oq02-oq02-session4` and cherry-picked here with meta.json sync.

---
Automated fix by lean-mechanic agent.