### PR TITLE
feat(aristotle): add Erdos626Aristotle companion with coefficient and deduction lemmas

### DIFF
--- a/proofs/Proofs/Erdos626Aristotle.lean
+++ b/proofs/Proofs/Erdos626Aristotle.lean
@@ -1,0 +1,79 @@
+/-
+  Aristotle targets for Erdős Problem #626: Chromatic Number and Girth
+  Routine supporting lemmas for automated proof search.
+  See Erdos626Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main open question (LimitExists) — open conjecture
+  - NOT lemmas depending on `g` (def sorry) or `h` (def sorry)
+  - NOT the Kostochka/Erdős axiomatized bounds
+  - Algebraic coefficient identities (boundRatio formula)
+  - Positivity of coefficient gap
+  - Logical deduction from probabilistic method axiom
+  - No axioms, no definition sorries, no open conjectures
+  - No /- ! docstring sections (use /- instead)
+-/
+import Proofs.Erdos626Problem
+import Mathlib
+
+namespace Erdos626Aristotle
+
+open Erdos626 Real Filter
+
+/-
+## Section 1: Coefficient Positivity
+
+The upper and lower bound coefficients are both positive, and the upper
+coefficient exceeds the lower coefficient for all k ≥ 4.
+-/
+
+/-- The upper bound coefficient is positive for k ≥ 4.
+upperCoeff k = 2 / log(k - 2) > 0 since k - 2 ≥ 2 implies log(k - 2) > 0. -/
+lemma upperCoeff_pos_ari (k : ℕ) (hk : k ≥ 4) : upperCoeff k > 0 := by
+  sorry
+
+/-- The lower bound coefficient is positive for k ≥ 4.
+lowerCoeff k = 1 / (4 * log k) > 0 since k ≥ 4 implies log k > 0. -/
+lemma lowerCoeff_pos_ari (k : ℕ) (hk : k ≥ 4) : lowerCoeff k > 0 := by
+  sorry
+
+/-- The gap between upper and lower bound coefficients is positive for k ≥ 4.
+The upper coefficient 2/log(k-2) exceeds the lower coefficient 1/(4 log k)
+because their ratio is 8 log k / log(k-2) > 1. -/
+lemma bound_gap_ari (k : ℕ) (hk : k ≥ 4) :
+    upperCoeff k - lowerCoeff k > 0 := by
+  sorry
+
+/-
+## Section 2: Ratio Formula
+
+The ratio of the upper to lower bound coefficient simplifies to an explicit
+formula involving only log k and log(k - 2).
+-/
+
+/-- The ratio of the bound coefficients equals 8 * log k / log(k - 2).
+By definition: upperCoeff / lowerCoeff = (2/log(k-2)) / (1/(4 log k))
+  = 2 * 4 * log k / log(k-2) = 8 * log k / log(k-2). -/
+lemma bound_ratio_formula_ari (k : ℕ) (hk : k ≥ 4) :
+    boundRatio k = 8 * Real.log k / Real.log (k - 2) := by
+  sorry
+
+/-- For k = 4, the bound ratio equals 8 * log 4 / log 2 = 16. -/
+lemma bound_ratio_k4_ari : boundRatio 4 = 8 * Real.log 4 / Real.log 2 := by
+  sorry
+
+/-
+## Section 3: Logical Deduction from Probabilistic Method
+
+The existence of graphs with arbitrarily large chromatic number and girth
+follows directly from Erdős's 1959 probabilistic method result.
+-/
+
+/-- For any k, there exists a triangle-free graph with chromatic number ≥ k.
+Follows from the general erdos_1959_probabilistic_method with g = 3. -/
+lemma triangle_free_unbounded_chromatic_ari (k : ℕ) :
+    ∃ (V : Type*) [Fintype V] [DecidableEq V] (G : SimpleGraph V),
+      HasGirthGT G 3 ∧ chromaticNumber G ≥ k := by
+  sorry
+
+end Erdos626Aristotle


### PR DESCRIPTION
## Fix

Add Aristotle companion file for Erdős Problem #626 (Chromatic Number and Girth, 15 sorries) targeting routine supporting lemmas that are independent of the `g` def-sorry.

## Evidence

**Proof**: `erdos-626` has 15 sorries and no Aristotle companion.

**Lemmas included** (all independent of `g : ℕ → ℕ := sorry`):
- `upperCoeff_pos_ari`: `upperCoeff k > 0` for k ≥ 4 (log positivity)
- `lowerCoeff_pos_ari`: `lowerCoeff k > 0` for k ≥ 4 (log positivity)
- `bound_gap_ari`: `upperCoeff k - lowerCoeff k > 0` for k ≥ 4
- `bound_ratio_formula_ari`: `boundRatio k = 8 * log k / log(k - 2)` (algebra)
- `bound_ratio_k4_ari`: concrete value at k = 4
- `triangle_free_unbounded_chromatic_ari`: existence from `erdos_1959_probabilistic_method` axiom

**Excluded**: main open question (`LimitExists`), lemmas using `g`/`h` def-sorries, Kostochka/Erdős bound axioms.

---
Automated fix by lean-mechanic agent.