### PR TITLE
Fix shapley-folkman meta.json: update sorries count from 4 to 3

### DIFF
--- a/src/data/proofs/shapley-folkman/meta.json
+++ b/src/data/proofs/shapley-folkman/meta.json
@@ -16,7 +16,7 @@
       "intermediate"
     ],
     "badge": "wip",
-    "sorries": 4,
+    "sorries": 3,
     "mathlibDependencies": [
       {
         "theorem": "convexHull_eq_union",
@@ -187,7 +187,7 @@
       "leanType": "Decomposition S t x -> d.excessIndices.card <= Module.finrank R E"
     }
   ],
-  "sorries": 4,
+  "sorries": 3,
   "leanFile": {
     "imports": [
       "Mathlib.Analysis.Convex.Caratheodory",
@@ -208,7 +208,7 @@
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 1,
-    "sorries": 4,
+    "sorries": 3,
     "path": "Proofs/ShapleyFolkman.lean"
   }
 }


### PR DESCRIPTION
## Summary

- Fixes stale `"sorries": 4` in `src/data/proofs/shapley-folkman/meta.json`; the actual Lean file at HEAD has **3 sorry tokens**, not 4
- Updates all three occurrences: `meta.sorries`, top-level `sorries`, and `leanFile.sorries`
- Commit `4abbde13` updated the Lean file but missed this metadata update

## Details

Actual sorry locations confirmed from `git show HEAD:proofs/Proofs/ShapleyFolkman.lean`:
- Line 117: `exact sorry`
- Line 187: `exact sorry`  
- Line 724: `sorry`

Lines 406 and 418 mention "sorry" only inside comments — not sorry tokens.

`status: "formalized"` and `badge: "wip"` are correct and unchanged.

Closes #11933

## Test plan
- [ ] Confirm `grep -c "sorry" proofs/Proofs/ShapleyFolkman.lean` returns 5 (3 tokens + 2 in comments)
- [ ] Confirm `git show HEAD:proofs/Proofs/ShapleyFolkman.lean | grep -n "^\s*sorry\|exact sorry"` returns 3 lines
- [ ] Confirm all three `"sorries"` fields in meta.json are now `3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)