### PR TITLE
Audit: fix stale meta.json for fourier-series-oq-02-oq-02 (sorries 1→0, status verified, badge mathlib)

### DIFF
--- a/src/data/proofs/fourier-series-oq-02-oq-02/meta.json
+++ b/src/data/proofs/fourier-series-oq-02-oq-02/meta.json
@@ -2,12 +2,12 @@
   "id": "fourier-series-oq-02-oq-02",
   "title": "Fourier Coefficient Square-Summability via p-Series (Elementary Proof)",
   "slug": "fourier-series-oq-02-oq-02",
-  "description": "Elementary proof that Fourier coefficients of α-Hölder functions (α > 1/2) are square-summable, using only the Hölder decay bound and the p-series convergence criterion — no Parseval's theorem or L² theory required. 1 sorry (harmonic series sharpness), 0 axioms.",
+  "description": "Elementary proof that Fourier coefficients of α-Hölder functions (α > 1/2) are square-summable, using only the Hölder decay bound and the p-series convergence criterion — no Parseval's theorem or L² theory required. 0 sorries, 0 axioms.",
   "meta": {
     "author": "Classical result; formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Fourier_series#Convergence",
     "date": "Classical",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/FourierSeriesOQ02OQ02.lean",
     "tags": [
       "harmonic-analysis",
@@ -17,8 +17,8 @@
       "comparison-test",
       "square-summability"
     ],
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "mathlib",
+    "sorries": 0,
     "axiomCount": 0,
     "mathlibDependencies": [
       {
@@ -65,7 +65,7 @@
     ],
     "dateAdded": "2026-04-23",
     "lineCount": 197,
-    "assumptions": "1 sorry: holder_half_is_critical_for_pseries (harmonic series divergence over ℤ). Main results 0 sorries.",
+    "assumptions": "0 sorries, 0 axioms. All results fully machine-checked, including holder_half_is_critical_for_pseries (harmonic series divergence over ℤ).",
     "mathlib_version": "4.26.0",
     "prerequisites": [
       "FourierSeriesOQ02.lean: Hölder decay bound fourierCoeff_holder_decay",
@@ -128,8 +128,8 @@
       "title": "Part IV: Corollaries and Sharpness",
       "startLine": 165,
       "endLine": 197,
-      "summary": "Three theorems: sq_summable_matches_parseval (aliases the main theorem, matching the parent's conclusion), fourier_coeff_l2 (existential HasSum form), and holder_half_is_critical_for_pseries (sharpness: α = 1/2 fails the p-series test — harmonic series diverges, 1 sorry).",
-      "mathContext": "Sharpness at $\\alpha = 1/2$: squared bound $= K/|n|^1$ = harmonic series, which diverges over $\\mathbb{Z}$. The sorry requires `¬Summable (fun n:ℤ => K/|↑n|)` — a consequence of `Real.summable_nat_rpow_inv` in the divergence direction, not yet transferred to $\\mathbb{Z}$ in this form."
+      "summary": "Three theorems: sq_summable_matches_parseval (aliases the main theorem, matching the parent's conclusion), fourier_coeff_l2 (existential HasSum form), and holder_half_is_critical_for_pseries (sharpness: α = 1/2 fails the p-series test — harmonic series diverges over ℤ, proved via Real.summable_nat_rpow_inv divergence at p=1).",
+      "mathContext": "Sharpness at $\\alpha = 1/2$: squared bound $= K/|n|^1$ = harmonic series, which diverges over $\\mathbb{Z}$. Proved via `Real.summable_nat_rpow_inv.not.mpr` (harmonic divergence at p=1): assume summability, instantiate with f=0 (zero function, Hölder with any constant) and α=1/2, extract the positive ℕ part via summable_int_iff_summable_nat_and_neg, rescale by 4/π to get harmonic series summability, derive contradiction."
     }
   ],
   "conclusion": {
@@ -171,9 +171,9 @@
     "theoremCount": 7,
     "definitionCount": 0,
     "path": "Proofs/FourierSeriesOQ02OQ02.lean",
-    "sorries": 1
+    "sorries": 0
   },
-  "sorries": 1,
+  "sorries": 0,
   "references": [
     {
       "authors": "Parseval des Chênes, Marc-Antoine",


### PR DESCRIPTION
## Summary

- Syncs `meta.json` for `fourier-series-oq-02-oq-02` after commit `4d64280da7` proved the last sorry without updating gallery metadata
- `sorries` corrected from 1 to 0 in all 3 locations (top-level, `meta.sorries`, `leanFile.sorries`)
- `status` updated from `"formalized"` to `"verified"` (0 sorries, 0 axioms confirmed)
- `badge` updated from `"wip"` to `"mathlib"` (proof relies on `Real.summable_nat_rpow_inv`)
- Stale sorry references removed from `description`, `meta.assumptions`, and section summaries

## Changes

| Field | Before | After |
|-------|--------|-------|
| `sorries` (top-level) | `1` | `0` |
| `meta.sorries` | `1` | `0` |
| `leanFile.sorries` | `1` | `0` |
| `meta.status` | `"formalized"` | `"verified"` |
| `meta.badge` | `"wip"` | `"mathlib"` |
| `meta.assumptions` | "1 sorry: holder_half_is_critical_for_pseries..." | "0 sorries, 0 axioms. All results fully machine-checked..." |
| `description` | "...1 sorry (harmonic series sharpness), 0 axioms." | "...0 sorries, 0 axioms." |
| `sections[part-iv].summary` | "...sharpness...1 sorry" | stale reference removed |
| `sections[part-iv].mathContext` | "The sorry requires..." | replaced with actual proof strategy |

## Verification

```bash
git show 4d64280da7 --stat
# Fix: fourier-series-oq-02-oq-02 — prove holder_half_is_critical_for_pseries (1 sorry → 0)

git show HEAD:proofs/Proofs/FourierSeriesOQ02OQ02.lean | grep -c sorry
# 0
```

Closes #11937

🤖 Generated with [Claude Code](https://claude.com/claude-code)