### PR TITLE
Fix: fourier-series-oq-02-oq-02 metadata — 1 sorry → 0 after proof completed

### DIFF
--- a/src/data/proofs/fourier-series-oq-02-oq-02/meta.json
+++ b/src/data/proofs/fourier-series-oq-02-oq-02/meta.json
@@ -2,12 +2,12 @@
   "id": "fourier-series-oq-02-oq-02",
   "title": "Fourier Coefficient Square-Summability via p-Series (Elementary Proof)",
   "slug": "fourier-series-oq-02-oq-02",
-  "description": "Elementary proof that Fourier coefficients of α-Hölder functions (α > 1/2) are square-summable, using only the Hölder decay bound and the p-series convergence criterion — no Parseval's theorem or L² theory required. 1 sorry (harmonic series sharpness), 0 axioms.",
+  "description": "Elementary proof that Fourier coefficients of α-Hölder functions (α > 1/2) are square-summable, using only the Hölder decay bound and the p-series convergence criterion — no Parseval's theorem or L² theory required. 0 sorries, 0 axioms.",
   "meta": {
     "author": "Classical result; formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Fourier_series#Convergence",
     "date": "Classical",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/FourierSeriesOQ02OQ02.lean",
     "tags": [
       "harmonic-analysis",
@@ -17,8 +17,8 @@
       "comparison-test",
       "square-summability"
     ],
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "original",
+    "sorries": 0,
     "axiomCount": 0,
     "mathlibDependencies": [
       {
@@ -64,8 +64,8 @@
       "Key insight: the condition α > 1/2 is exactly the threshold for the p-series 1/|n|^{2α} to converge (2α > 1)"
     ],
     "dateAdded": "2026-04-23",
-    "lineCount": 197,
-    "assumptions": "1 sorry: holder_half_is_critical_for_pseries (harmonic series divergence over ℤ). Main results 0 sorries.",
+    "lineCount": 226,
+    "assumptions": "0 sorries, 0 axioms. All theorems including holder_half_is_critical_for_pseries (α=1/2 critical exponent via harmonic series divergence) are fully proved.",
     "mathlib_version": "4.26.0",
     "prerequisites": [
       "FourierSeriesOQ02.lean: Hölder decay bound fourierCoeff_holder_decay",
@@ -127,9 +127,9 @@
       "id": "part-iv-corollaries",
       "title": "Part IV: Corollaries and Sharpness",
       "startLine": 165,
-      "endLine": 197,
-      "summary": "Three theorems: sq_summable_matches_parseval (aliases the main theorem, matching the parent's conclusion), fourier_coeff_l2 (existential HasSum form), and holder_half_is_critical_for_pseries (sharpness: α = 1/2 fails the p-series test — harmonic series diverges, 1 sorry).",
-      "mathContext": "Sharpness at $\\alpha = 1/2$: squared bound $= K/|n|^1$ = harmonic series, which diverges over $\\mathbb{Z}$. The sorry requires `¬Summable (fun n:ℤ => K/|↑n|)` — a consequence of `Real.summable_nat_rpow_inv` in the divergence direction, not yet transferred to $\\mathbb{Z}$ in this form."
+      "endLine": 226,
+      "summary": "Three theorems: sq_summable_matches_parseval (aliases the main theorem, matching the parent's conclusion), fourier_coeff_l2 (existential HasSum form), and holder_half_is_critical_for_pseries (sharpness: α = 1/2 fails the p-series test — harmonic series diverges, fully proved).",
+      "mathContext": "Sharpness at $\\alpha = 1/2$: squared bound $= K/|n|^1$ = harmonic series, which diverges over $\\mathbb{Z}$. Proved by extracting the ℕ positive part via `summable_int_iff_summable_nat_and_neg`, rescaling to the harmonic series, then applying `Real.summable_nat_rpow_inv.not.mpr` for the divergence case."
     }
   ],
   "conclusion": {
@@ -166,14 +166,14 @@
       "FourierHolderDecay"
     ],
     "namespace": "FourierSqSummablePSeries",
-    "lineCount": 197,
+    "lineCount": 226,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 0,
     "path": "Proofs/FourierSeriesOQ02OQ02.lean",
-    "sorries": 1
+    "sorries": 0
   },
-  "sorries": 1,
+  "sorries": 0,
   "references": [
     {
       "authors": "Parseval des Chênes, Marc-Antoine",


### PR DESCRIPTION
## Fix

Update `fourier-series-oq-02-oq-02/meta.json` to reflect that `holder_half_is_critical_for_pseries` was fully proved in commit `4d64280da7`.

## Evidence

**Before**: `"sorries": 1`, `"status": "formalized"`, `"badge": "wip"`
**After**: `"sorries": 0`, `"status": "verified"`, `"badge": "original"`

Also updated:
- `lineCount`: 197 → 226 (file grew when sorry was replaced by proof)
- `assumptions`: removed "1 sorry" note
- `leanFile.sorries`: 1 → 0
- Top-level `sorries`: 1 → 0
- `description`: removed "1 sorry (harmonic series sharpness)"
- Section `part-iv-corollaries` summary updated to describe the proved theorem

The proof shows that α = 1/2 is the critical Hölder exponent for the p-series argument: at α = 1/2 the comparison series becomes the harmonic series which diverges, proved via `Real.summable_nat_rpow_inv.not.mpr`.

Discovered via integrity audit cross-checking meta.json sorry counts against actual Lean files.

---
Automated fix by lean-mechanic agent.