### PR TITLE
Enrich shapley-folkman-oq-03: fix stale sorry count, expand open questions

### DIFF
--- a/src/data/proofs/shapley-folkman-oq-03/meta.json
+++ b/src/data/proofs/shapley-folkman-oq-03/meta.json
@@ -31,7 +31,7 @@
     "historicalContext": "Ross Starr (1969) applied the Shapley-Folkman lemma — proved by Lloyd Shapley and John Folkman in unpublished correspondence — to prove that large economies are approximately convex. The economic significance: even if each agent's feasible set is non-convex (e.g., due to indivisibilities), the aggregate market is 'nearly convex' in a quantitative sense. The approximation bound d·δ depends only on the dimension d of the commodity space, not the number of agents n. As n → ∞, the per-agent error d·δ/n → 0, validating the use of convex analysis for large market equilibria. Starr's theorem was a landmark in general equilibrium theory and provided mathematical foundations for ε-equilibrium results.",
     "problemStatement": "Given a finite-dimensional normed space E and sets {Sᵢ}ᵢ with pairwise distances bounded by δ, prove that any x ∈ conv(ΣSᵢ) has an approximant x' ∈ ΣSᵢ with ‖x - x'‖ ≤ dim(E)·δ. As a corollary, large markets are approximately convex: the per-agent error vanishes as n grows.",
     "proofStrategy": "Apply sum_close_to_convexHull (from ShapleyFolkman.lean) to decompose x as Σf(i) with f(i) ∈ conv(S(i)) and at most dim(E) 'excess' indices where f(i) ∉ S(i). For each excess index j, replace f(j) by any g(j) ∈ S(j). The sum x' = Σg(i) lies in ΣS(i). The distance bound uses convexHull_dist_le_diam (proved in this file) for each excess index. A Finset.sum_subset argument shows non-excess terms contribute zero to the difference.",
-    "assumptions": "0 axioms. 0 direct sorries. However, theorems depend on ShapleyFolkman.lean which has 4 sorry proofs pending completion (reduce_excess_by_one has 2 sorry sub-cases). Transitively incomplete until parent sorries are closed.",
+    "assumptions": "0 axioms. 0 direct sorries. However, theorems depend on ShapleyFolkman.lean which has 3 sorry proofs pending completion (at lines 117, 187, 724 — all in reduce_excess_by_one). Transitively incomplete until parent sorries are closed.",
     "axiomCount": 0,
     "lineCount": 203,
     "theoremCount": 5,
@@ -62,8 +62,9 @@
     "summary": "Formalizes Starr's (1969) economic application of the Shapley-Folkman lemma. Main contributions: convexHull_dist_le (distance lemma for convex hulls), shapley_folkman_starr (Starr's theorem with the d·δ bound), large_economy_near_convex (n-agent corollary), no_excess_for_convex (zero error for convex sets). 0 sorries, 0 local axioms; depends on 3 assumptions in parent ShapleyFolkman.lean.",
     "implications": "Validates the use of convex analysis in large-market equilibrium theory. Non-convexities (indivisibilities, increasing returns) in individual agent preferences become negligible in aggregate markets with many participants.",
     "openQuestions": [
-      "Can the 3 sorries in ShapleyFolkman.lean be eliminated to make this proof fully axiom-free?",
-      "Does the bound dim(E)·δ admit a constructive proof of the approximating point x' (not just existence)?"
+      "Can the 3 sorries in ShapleyFolkman.lean (reduce_excess_by_one, lines 117, 187, 724) be eliminated to make this proof fully axiom-free? These are the remaining gaps in `reduce_excess_by_one`: a single step that reduces the excess index count by 1, which is the inductive heart of the Shapley-Folkman lemma.",
+      "Does the bound dim(E)·δ admit a constructive proof of the approximating point x' (not just existence)? The current proof uses `Classical.choice` (via nonemptiness witnesses), so x' is not explicitly computable.",
+      "Is there a version of the theorem with a tight bound? The bound dim(E)·δ is achieved when all non-convexity is concentrated in exactly d summands. Can a lower bound be proved showing no uniform constant < d works?"
     ]
   },
   "sections": [

--- a/src/data/research/problems/erdos-622-oq-04.json
+++ b/src/data/research/problems/erdos-622-oq-04.json
@@ -29,11 +29,7 @@
     }
   },
   "knowledge": {
-<<<<<<< Updated upstream
-    "progressSummary": "COMPLETED: All sorries eliminated. Fixed flipped hypothesis in absorbing_pair_exists (|V|+2 <= 2d, not 2d <= |V|+2). Proved absorbing_pair_exists via common neighborhood bound. Proved erdos_faudree_absorbing_pairs_ge via injection argument (u -> (u, choose(N(u) \u2229 N(w)))). Fixed bug in isAbsorbingTriple_symm. Changed absorbingPairs to Prop-based filter for cleaner proofs. File: 0 sorries, 0 axioms, 9 theorems, 4 definitions.",
-=======
-    "progressSummary": "PROGRESS: Created Erdos622OQ04.lean with absorbing method infrastructure. 4 proved theorems (regular edge count, Erdos-Faudree edge count, common neighborhood bound, common ≥ 2 for EF graphs), 2 sorries (absorbing pair density). Absorbing lemma stated as definition.",
->>>>>>> Stashed changes
+    "progressSummary": "COMPLETED: All sorries eliminated. Fixed flipped hypothesis in absorbing_pair_exists (|V|+2 <= 2d, not 2d <= |V|+2). Proved absorbing_pair_exists via common neighborhood bound. Proved erdos_faudree_absorbing_pairs_ge via injection argument (u -> (u, choose(N(u) ∩ N(w)))). Fixed bug in isAbsorbingTriple_symm. Changed absorbingPairs to Prop-based filter for cleaner proofs. File: 0 sorries, 0 axioms, 9 theorems, 4 definitions.",
     "builtItems": [
       "regular_edge_count: 2|E| = |V|·d for d-regular graphs (proved)",
       "erdos_faudree_edge_count: |E| = n(n+1) (proved)",
@@ -54,7 +50,7 @@
       "Absorbing method requires: (1) absorbing pair density, (2) probabilistic path sampling, (3) concentration inequality",
       "The absorbing pair density bound needs graph theory on induced subgraph edge count",
       "The hypothesis in absorbing_pair_exists was flipped: need |V| <= 2d-2 (not |V| >= 2d-2)",
-      "Injection argument for density: u -> (u, choose(N(u) \u2229 N(w))) has distinct first coords, so is injective",
+      "Injection argument for density: u -> (u, choose(N(u) ∩ N(w))) has distinct first coords, so is injective",
       "Prop-based Finset.filter is much cleaner than Bool-based decide && for membership proofs"
     ],
     "mathlibGaps": [
@@ -75,7 +71,8 @@
   "relatedProofs": [
     "erdos-6",
     "erdos-62",
-    "erdos-622"
+    "erdos-622",
+    "erdos-622-oq-04"
   ],
   "references": {
     "papers": [],
@@ -90,26 +87,11 @@
     {
       "path": "Proofs/Erdos622OQ04.lean",
       "filename": "Erdos622OQ04.lean",
-      "lineCount": 152,
+      "lineCount": 216,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 3,
-<<<<<<< Updated upstream
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos622OQ04.lean"
-    },
-    {
-      "path": "Proofs/Erdos622OQ04.lean",
-      "filename": "Erdos622OQ04.lean",
-      "lineCount": 180,
-      "theoremCount": 9,
-      "axiomCount": 0,
-      "defCount": 4,
       "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos622OQ04.lean"
-=======
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos622OQ04.lean"
     },
@@ -123,7 +105,6 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos622Problem.lean"
->>>>>>> Stashed changes
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Fix stale `assumptions` field: was "4 sorry proofs pending completion", corrected to "3 sorry proofs pending completion (at lines 117, 187, 724 — all in reduce_excess_by_one)"
- Expand openQuestions[0] with specific line references to the 3 remaining sorries
- Expand openQuestions[1] to note `Classical.choice` noncomputability constraint
- Add new openQuestions[2] about tightness of the dim(E)·δ bound
- Fix recurring erdos-622-oq-04.json merge conflict (baked into main)

## Proof entry
`shapley-folkman-oq-03` — Starr's (1969) economic application of the Shapley-Folkman lemma

🤖 Generated with [Claude Code](https://claude.com/claude-code)