### PR TITLE
Enrich napoleons-theorem-oq-02: add mathContext to all 5 sections

### DIFF
--- a/src/data/proofs/napoleons-theorem-oq-02/meta.json
+++ b/src/data/proofs/napoleons-theorem-oq-02/meta.json
@@ -54,7 +54,8 @@
       "endLine": 116,
       "description": "Define ω = (-1+I√3)/2 and its square ω² = (-1-I√3)/2. Prove the fundamental identities ω³=1 and 1+ω+ω²=0 using sqrt3_sq_real and nlinarith.",
       "summary": "omega, omegaSq definitions and cube root identity proofs",
-      "id": "primitive-cube-root"
+      "id": "primitive-cube-root",
+      "mathContext": "$\\omega = e^{2\\pi i/3} = \\cos(2\\pi/3) + i\\sin(2\\pi/3) = (-1 + i\\sqrt{3})/2$. The three key identities: $\\omega^3 = 1$ (`omega_cube`), $1 + \\omega + \\omega^2 = 0$ (`one_add_omega_add_omegaSq`), and $\\omega^2 = (-1 - i\\sqrt{3})/2$ (`omegaSq_eq_sq`, verified by direct computation).\n\nAll proofs use `nlinarith` with the auxiliary `sqrt3_sq_real : \\sqrt{3} \\cdot \\sqrt{3} = 3`, since Lean's `norm_num` cannot directly compute $\\sqrt{3}^2 = 3$ for the noncomputable `Real.sqrt`. The pattern `simp [omega, omegaSq] \\to` `apply Complex.ext` `\\to` `simp [...]` `\\to` `nlinarith [sqrt3_sq_real]` is the standard idiom throughout this file."
     },
     {
       "title": "Outer Napoleon DFT at Frequency 1",
@@ -62,7 +63,8 @@
       "endLine": 156,
       "description": "Prove G₁+ω·G₂+ω²·G₃ = -(z₁+ω·z₂+ω²·z₃): the frequency-1 DFT component of the outer Napoleon triangle is the negation of the original triangle's frequency-1 component.",
       "summary": "Y₁ = -X₁ for outer Napoleon triangle",
-      "id": "outer-dft-freq1"
+      "id": "outer-dft-freq1",
+      "mathContext": "The outer DFT at frequency 1: $G_1 + \\omega G_2 + \\omega^2 G_3 = -(z_1 + \\omega z_2 + \\omega^2 z_3)$.\n\nProof: substitute $G_k = \\text{napoleonCenter}(z_{k-1}, z_{k+1})$, expand with $\\omega = (-1+i\\sqrt{3})/2$, and collect real and imaginary parts. The coefficient of $z_1$ in the expanded sum is $-1$, of $z_2$ is $-\\omega$, of $z_3$ is $-\\omega^2$ — exactly $-X_1$. Verified by `nlinarith` on the real and imaginary parts using $\\sqrt{3}^2 = 3$."
     },
     {
       "title": "Outer Napoleon DFT at Frequency 2",
@@ -70,7 +72,8 @@
       "endLine": 191,
       "description": "Prove G₁+ω²·G₂+ω·G₃ = 0: the frequency-2 DFT component vanishes. Since equilateral triangles are characterized by vanishing X₂, this explains why Napoleon triangles are always equilateral.",
       "summary": "Y₂ = 0 for outer Napoleon triangle",
-      "id": "outer-dft-freq2"
+      "id": "outer-dft-freq2",
+      "mathContext": "The critical theorem: $G_1 + \\omega^2 G_2 + \\omega G_3 = 0$.\n\nThis is the mathematical reason Napoleon's theorem holds: a triangle $(P_1, P_2, P_3)$ is equilateral iff its 3-point DFT frequency-2 component $X_2 = z_1 + \\omega^2 z_2 + \\omega z_3 = 0$. Since $Y_2 = 0$ for ANY input triangle, the outer Napoleon triangle is always equilateral — not just sometimes, but as a structural consequence of the DFT filter.\n\nProof: same expansion as `napoleon_outer_dft1`, but the coefficient of each vertex becomes zero (the $\\omega^2$ and $\\omega$ weights cancel). The $\\sqrt{3}$ terms cancel out symmetrically."
     },
     {
       "title": "Inner Napoleon DFT",
@@ -78,7 +81,8 @@
       "endLine": 265,
       "description": "The inner Napoleon triangle has DFT Y₁'=0 (napoleon_inner_dft1) and Y₂'=-X₂ (napoleon_inner_dft2): exactly swapping the roles of X₁ and X₂ compared to the outer construction.",
       "summary": "Y₁'=0 and Y₂'=-X₂ for inner Napoleon triangle",
-      "id": "inner-dft"
+      "id": "inner-dft",
+      "mathContext": "Complementary to Part 2: the inner Napoleon triangle kills $X_1$ (frequency 1) instead of $X_2$.\n\n`napoleon_inner_dft1`: $G_1' + \\omega G_2' + \\omega^2 G_3' = 0$ — inner kills freq 1.\n`napoleon_inner_dft2`: $G_1' + \\omega^2 G_2' + \\omega G_3' = -(z_1 + \\omega^2 z_2 + \\omega z_3)$ — inner negates freq 2.\n\nThe outer/inner symmetry: replace $\\omega \\leftrightarrow \\omega^2$ (complex conjugation) and the roles of $X_1$ and $X_2$ swap. The inner Napoleon construction is the complex conjugate of the outer in the DFT domain: $\\text{outer}: (X_0, -X_1, 0)$ vs $\\text{inner}: (X_0, 0, -X_2)$."
     },
     {
       "title": "Complete DFT Filter Picture",
@@ -86,7 +90,8 @@
       "endLine": 346,
       "description": "Bundle theorems: outer Napoleon acts as (X₀↦X₀, X₁↦-X₁, X₂↦0) and inner as (X₀↦X₀, X₁↦0, X₂↦-X₂). IDFT recovery formula: G₁=(X₀-X₁)/3. Summary #check lines.",
       "summary": "Napoleon construction as explicit DFT filter with IDFT recovery",
-      "id": "dft-filter-complete"
+      "id": "dft-filter-complete",
+      "mathContext": "Bundles the individual theorems into two clean 'DFT filter' characterizations:\n\n`napoleon_as_dft_filter`: outer maps $(X_0, X_1, X_2) \\mapsto (X_0, -X_1, 0)$.\n`inner_napoleon_as_dft_filter`: inner maps $(X_0, X_1, X_2) \\mapsto (X_0, 0, -X_2)$.\n\n`napoleon_center_idft_recovery`: $G_1 = (X_0 - X_1)/3 = ((z_1+z_2+z_3) - (z_1+\\omega z_2+\\omega^2 z_3))/3$. This is the IDFT of $(X_0, -X_1, 0)$ at index 1 — the Napoleon centroid is recovered from the original DFT components as $(X_0 - X_1)/3$, making explicit the filter interpretation.\n\nThe `#check` lines confirm all six theorems are in scope: `napoleon_outer_dft1`, `napoleon_outer_dft2`, `napoleon_inner_dft1`, `napoleon_inner_dft2`, `napoleon_as_dft_filter`, `inner_napoleon_as_dft_filter`."
     }
   ],
   "overview": {


### PR DESCRIPTION
## Summary
All 5 sections in `napoleons-theorem-oq-02` had empty `mathContext` fields. Added precise mathematical content grounded in the Lean source (`NapoleonsTheoremOQ02.lean`):

- **primitive-cube-root**: $\omega = e^{2\pi i/3} = (-1+i\sqrt{3})/2$, the key identities $\omega^3 = 1$ and $1 + \omega + \omega^2 = 0$, and the `nlinarith + sqrt3_sq_real` proof pattern
- **outer-dft-freq1**: $G_1 + \omega G_2 + \omega^2 G_3 = -(z_1 + \omega z_2 + \omega^2 z_3)$ — coefficient verification for the DFT expansion
- **outer-dft-freq2**: The critical $Y_2 = 0$ theorem — why the outer Napoleon triangle is always equilateral (equilateral $\Leftrightarrow X_2 = 0$ in DFT)
- **inner-dft**: Complementary inner construction kills $X_1$ not $X_2$; outer/inner symmetry is complex conjugation swapping $X_1 \leftrightarrow X_2$ roles
- **dft-filter-complete**: The bundled filter theorems and IDFT recovery formula $G_1 = (X_0 - X_1)/3$

## Proof entry
`napoleons-theorem-oq-02` — Napoleon's Theorem: DFT Characterization (passes=0, quality=100)

🤖 Generated with [Claude Code](https://claude.com/claude-code)