### PR TITLE
Enrich triangle-angle-sum-oq-02: expand all 7 section mathContexts (94-185→651-921 chars)

### DIFF
--- a/src/data/proofs/triangle-angle-sum-oq-02/meta.json
+++ b/src/data/proofs/triangle-angle-sum-oq-02/meta.json
@@ -50,7 +50,7 @@
       "startLine": 64,
       "endLine": 118,
       "summary": "GeodesicTriangle structure axiomatizes local Gauss-Bonnet as gb_local : α+β+γ-π = integratedCurvature. Defines excess and angleSum, with immediate algebraic corollaries.",
-      "mathContext": "GeodesicTriangle: fields α, β, γ ∈ (0,π), area > 0, integratedCurvature ∈ ℝ, gb_local : α+β+γ-π = integratedCurvature; excess := α+β+γ-π."
+      "mathContext": "`GeodesicTriangle` is a Lean structure axiomatizing the local Gauss-Bonnet theorem: fields $\\alpha, \\beta, \\gamma \\in (0,\\pi)$, $\\text{area} > 0$, $\\text{integratedCurvature} \\in \\mathbb{R}$, and the key axiom `gb_local : $\\alpha+\\beta+\\gamma-\\pi = \\text{integratedCurvature}$`.\n\nWhy a structure (not a theorem)? The local Gauss-Bonnet formula requires Riemannian geometry (covariant derivatives, the Gauss map, geodesic curvature along edges) not yet in Mathlib. Encoding it as a structure field axiom allows the algebraic consequences to be proved in Lean while deferring the analytic content.\n\nDerived theorems: `excess_eq_curvature`: $\\text{excess} = \\text{integratedCurvature}$; `angleSum_eq_pi_add_excess`: $\\alpha+\\beta+\\gamma = \\pi + \\text{excess}$; `angleSum_eq_pi_add_curvature`: $\\alpha+\\beta+\\gamma = \\pi + \\int_T K\\,dA$."
     },
     {
       "id": "flat-case",
@@ -58,7 +58,7 @@
       "startLine": 120,
       "endLine": 149,
       "summary": "FlatTriangle extends GeodesicTriangle with flat : integratedCurvature = 0. Proves α+β+γ=π (Euclid) as the K=0 special case of local Gauss-Bonnet.",
-      "mathContext": "K=0 → excess=0 → α+β+γ=π. FlatTriangle inherits all GeodesicTriangle fields and adds the flatness constraint."
+      "mathContext": "`FlatTriangle extends GeodesicTriangle` with one field: `flat : integratedCurvature = 0`. Lean's structure inheritance brings all parent fields and axioms into scope automatically.\n\nThree theorems follow by `linarith` from `gb_local` and `flat`:\n- `flat_angle_sum`: $\\alpha+\\beta+\\gamma = \\pi$ (Euclid's theorem; proof: `linarith [T.gb_local, T.flat]`)\n- `flat_excess_zero`: $\\text{excess} = 0$\n- `flat_angleSum_eq_pi`: $\\text{angleSum} = \\pi$\n\nThe key step: `T.flat : integratedCurvature = 0` substituted into `T.gb_local : $\\alpha+\\beta+\\gamma-\\pi = \\text{integratedCurvature}$` gives $\\alpha+\\beta+\\gamma-\\pi = 0$, hence `linarith` closes the goal."
     },
     {
       "id": "spherical-case",
@@ -66,7 +66,7 @@
       "startLine": 151,
       "endLine": 207,
       "summary": "SphericalTriangle (K=1/r²) proves Girard's formula: area = r²·(α+β+γ-π), angle sum > π, area bounded by r²·(3π-π)=2πr². Unit sphere: area = excess.",
-      "mathContext": "K = 1/r² → integratedCurvature = area/r² → α+β+γ-π = area/r² > 0 → α+β+γ > π; unit sphere: area = α+β+γ-π."
+      "mathContext": "`SphericalTriangle extends GeodesicTriangle` with `radius : ℝ`, `radius_pos : 0 < radius`, and `spherical : integratedCurvature = area / radius^2` (Gaussian curvature $K = 1/r^2$, integrated gives $\\text{area}/r^2$).\n\nFour theorems:\n- `girard_theorem` (Girard 1629): $\\alpha+\\beta+\\gamma-\\pi = \\text{area}/r^2$. Proof: rewrite `T.spherical` into `T.gb_local`.\n- `spherical_area_eq_radius_sq_excess`: $\\text{area} = r^2 \\cdot (\\alpha+\\beta+\\gamma-\\pi)$. Uses `field_simp` + `linarith`.\n- `spherical_angle_sum_gt_pi`: $\\alpha+\\beta+\\gamma > \\pi$. Follows from `div_pos area_pos (sq_pos_of_pos radius_pos)`.\n- `spherical_sum_bound`: $\\pi < \\alpha+\\beta+\\gamma < 3\\pi$. Upper bound from each angle $< \\pi$.\n\nUnit sphere ($r=1$): `unit_sphere_area_eq_excess` gives area $= \\alpha+\\beta+\\gamma-\\pi$, the classic form of Girard's theorem."
     },
     {
       "id": "hyperbolic-case",
@@ -74,7 +74,7 @@
       "startLine": 209,
       "endLine": 250,
       "summary": "HyperbolicTriangle (K=-1) proves Lambert's formula: angular defect = area, angle sum < π, and area < π (maximum possible hyperbolic triangle area).",
-      "mathContext": "K = -1 → integratedCurvature = -area → δ := π-(α+β+γ) = area ∈ (0,π). All hyperbolic triangles have angle sum < π."
+      "mathContext": "`HyperbolicTriangle extends GeodesicTriangle` with `hyperbolic : integratedCurvature = -area` (Gaussian curvature $K = -1$, integrated gives $-\\text{area}$).\n\nFour theorems:\n- `lambert_theorem` (Lambert 1761): $\\pi - (\\alpha+\\beta+\\gamma) = \\text{area}$. Proof: `linarith [T.gb_local, T.hyperbolic]`.\n- `hyperbolic_angle_sum_lt_pi`: $\\alpha+\\beta+\\gamma < \\pi$. Immediate from `lambert_theorem` + `area_pos`.\n- `hyperbolic_area_lt_pi`: $\\text{area} < \\pi$. Remarkable: ALL hyperbolic triangles have area $< \\pi$ (the 'ideal triangle' with three ideal vertices achieves area $= \\pi$).\n- `hyperbolic_area_eq_defect`: $\\text{area} = \\pi - \\alpha - \\beta - \\gamma$ (the angle defect formula).\n\nLambert's theorem is historically notable: he derived it in 1761 from the properties of what he called 'imaginary spherical geometry' (hyperbolic geometry, formally understood only after Bolyai-Lobachevsky in the 1820s-30s)."
     },
     {
       "id": "discrete-gauss-bonnet",
@@ -82,7 +82,7 @@
       "startLine": 252,
       "endLine": 297,
       "summary": "RiemannianTriangulation axiomatizes Σ excess = 2π·χ. Derives sphere total curvature 4π (χ=2), torus 0 (χ=0), genus-g surface 2π(2-2g).",
-      "mathContext": "Σ_i (α_i+β_i+γ_i-π) = 2π·χ(M); sphere: 4π; torus: 0; genus-g: 2π(2-2g). Finset.sum over all triangles."
+      "mathContext": "`RiemannianTriangulation` records: `faceCount : ℕ`, `triangles : Fin faceCount → GeodesicTriangle`, `eulerChar : ℝ`, and the axiom `discrete_gb : (∑ i, (triangles i).excess) = 2π · χ`.\n\nFour corollaries by `ring`/`linarith` from `discrete_gb`:\n- `total_curvature_eq`: $\\sum \\int_{T_i} K\\,dA = 2\\pi\\chi$ (swaps `excess` for `integratedCurvature` via `Finset.sum_congr`).\n- `sphere_total_curvature`: $\\chi = 2 \\Rightarrow \\sum \\text{excess} = 4\\pi$ (sphere).\n- `torus_total_curvature`: $\\chi = 0 \\Rightarrow \\sum \\text{excess} = 0$ (torus).\n- `genus_g_total_curvature`: $\\chi = 2-2g \\Rightarrow \\sum \\text{excess} = 2\\pi(2-2g)$.\n\nThe Euler characteristic: $\\chi = V - E + F$ for any triangulation (independent of the triangulation choice). For orientable surfaces: sphere $\\chi=2$, torus $\\chi=0$, genus-$g$ surface $\\chi=2-2g$."
     },
     {
       "id": "curvature-topology",
@@ -90,7 +90,7 @@
       "startLine": 299,
       "endLine": 330,
       "summary": "Proves the Gauss-Bonnet sign constraint: positive total curvature → χ > 0 (sphere), zero → χ = 0 (torus), negative → χ < 0 (higher genus ≥ 2).",
-      "mathContext": "total excess > 0 → χ > 0; = 0 → χ = 0; < 0 → χ < 0. Uses mul_pos_iff, mul_neg_iff with 2π > 0."
+      "mathContext": "From `discrete_gb : \\sum \\text{excess} = 2\\pi\\chi` and $2\\pi > 0$, the sign of total excess determines the sign of $\\chi$:\n\n- `positive_curvature_positive_chi`: $\\sum \\text{excess} > 0 \\Rightarrow \\chi > 0$. Proof: `mul_pos_iff.mp` with $2\\pi > 0$ gives two cases; the case $2\\pi < 0$ is dismissed by `linarith [pi_pos]`.\n- `negative_curvature_negative_chi`: $\\sum \\text{excess} < 0 \\Rightarrow \\chi < 0$. Same pattern with `mul_neg_iff`.\n- `flat_triangulation_chi_zero`: $\\sum \\text{excess} = 0 \\Rightarrow \\chi = 0$. Uses `mul_eq_zero.mp` and `(2\\pi \\neq 0)` from `positivity`.\n\nTopological interpretation: $\\chi > 0$ means the surface is topologically a sphere; $\\chi = 0$ means a torus (or Klein bottle); $\\chi < 0$ means genus $\\geq 2$. Gauss-Bonnet is the bridge from differential geometry (curvature) to algebraic topology ($\\chi$)."
     },
     {
       "id": "unification-summary",
@@ -98,7 +98,7 @@
       "startLine": 332,
       "endLine": 382,
       "summary": "Part VII capstone: excess_classifies_curvature (excess sign ↔ curvature sign), three_geometries_unified (flat/spherical/hyperbolic in one statement), euclidean_case. Closes with a direct Mathlib EuclideanGeometry.angle_add_angle_add_angle_eq_pi example as the concrete anchor.",
-      "mathContext": "three_geometries_unified: (∀ FlatTriangle, sum=π) ∧ (∀ SphericalTriangle, sum>π) ∧ (∀ HyperbolicTriangle, sum<π). Mathlib: angle_add_angle_add_angle_eq_pi for concrete Euclidean points."
+      "mathContext": "The final section bundles the three geometry cases and provides the Mathlib connection:\n\n- `excess_classifies_curvature`: $\\text{excess} > 0 \\Leftrightarrow \\text{integratedCurvature} > 0$ (etc.). Proof: `rw [T.gb_local]` reduces all three equivalences to `Iff.rfl`.\n- `euclidean_case`: `FlatTriangle` has excess $= 0$ and angleSum $= \\pi$ (conjunction).\n- `three_geometries_unified`: $(\\forall \\text{FlatTriangle}, \\text{sum}=\\pi) \\wedge (\\forall \\text{SphericalTriangle}, \\text{sum}>\\pi) \\wedge (\\forall \\text{HyperbolicTriangle}, \\text{sum}<\\pi)$. Proof: anonymous constructor referencing the three main theorems.\n\nMathlib anchor: the closing `example` demonstrates `EuclideanGeometry.angle_add_angle_add_angle_eq_pi p₃ h` — the flat case proved in full generality over any inner product space with a `NormedAddTorsor` structure. This is the concrete Mathlib witness that the axiomatized `FlatTriangle` is non-vacuous."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
All 7 sections had very thin `mathContext` (94-185 chars). Expanded to 651-921 chars each with precise mathematical content grounded in `TriangleAngleSumOQ02.lean`:

- **geodesic-triangle**: Explains `GeodesicTriangle` structure design, why `gb_local` is an axiom (Riemannian geometry infrastructure gap in Mathlib), and the 3 derived theorems
- **flat-case**: `FlatTriangle` structure inheritance, `linarith [T.gb_local, T.flat]` proof pattern, 3 Euclidean theorems
- **spherical-case**: `SphericalTriangle` with `radius` field, `girard_theorem` (1629), `spherical_angle_sum_gt_pi`, unit sphere area = excess
- **hyperbolic-case**: `HyperbolicTriangle`, `lambert_theorem` (1761), remarkable bound $\text{area} < \pi$ for ALL hyperbolic triangles, Lambert's historical context
- **discrete-gauss-bonnet**: `RiemannianTriangulation` structure with `Finset.sum` over geodesic triangles, sphere ($\chi=2 \Rightarrow 4\pi$), torus ($\chi=0$), genus-$g$ cases
- **curvature-topology**: `mul_pos_iff`/`mul_neg_iff` proof pattern, `positivity` for $2\pi \neq 0$, topological interpretation ($\chi$ sign → genus)
- **unification-summary**: `three_geometries_unified` conjunction proof, Mathlib anchor via `EuclideanGeometry.angle_add_angle_add_angle_eq_pi`

## Proof entry
`triangle-angle-sum-oq-02` — Triangle Angle Sum: Gauss-Bonnet as the Curved Generalization (passes=0, quality=100)

🤖 Generated with [Claude Code](https://claude.com/claude-code)