### PR TITLE
Enrich denumerability-rationals-oq-02: add mathContext to all 13 sections (0→455-718 chars)

### DIFF
--- a/src/data/proofs/denumerability-rationals-oq-02/meta.json
+++ b/src/data/proofs/denumerability-rationals-oq-02/meta.json
@@ -81,91 +81,104 @@
       "title": "Imports and Module Header",
       "startLine": 1,
       "endLine": 38,
-      "summary": "Imports Mathlib's CountableDenseLinearOrder, Denumerable, Cardinal, and order homomorphism libraries. The module docstring explains the back-and-forth method and lists the five key results proved."
+      "summary": "Imports Mathlib's CountableDenseLinearOrder, Denumerable, Cardinal, and order homomorphism libraries. The module docstring explains the back-and-forth method and lists the five key results proved.",
+      "mathContext": "The 5 key typeclasses for a countable dense linear order without endpoints: `LinearOrder`, `Countable`, `DenselyOrdered`, `NoMinOrder`, `NoMaxOrder`. Mathlib's `Order.CountableDenseLinearOrder` provides `Order.iso_of_countable_dense`, the back-and-forth theorem.\n\nThe back-and-forth method (Cantor 1895): given a countable dense linear order $\\alpha$ and $\\mathbb{Q}$, enumerate both as sequences $(a_n)$ and $(q_n)$. Build partial isomorphisms $f_n$ inductively: at even steps, extend $f_n$ to cover $a_{k}$; at odd steps, extend to cover $q_k$. Density + no-endpoints guarantees each extension exists (`Order.exists_between_finsets`). The union $\\bigcup f_n$ is a total order isomorphism $\\alpha \\cong_o \\mathbb{Q}$."
     },
     {
       "id": "sec-cdlo-instances",
       "title": "Part I: ℚ as a CDLO",
       "startLine": 43,
       "endLine": 63,
-      "summary": "Assembles the six typeclass instances proving ℚ is a Countable Dense Linear Order Without Endpoints. States density (rationals_dense), no-minimum (rationals_no_min), and no-maximum (rationals_no_max) as explicit theorems."
+      "summary": "Assembles the six typeclass instances proving ℚ is a Countable Dense Linear Order Without Endpoints. States density (rationals_dense), no-minimum (rationals_no_min), and no-maximum (rationals_no_max) as explicit theorems.",
+      "mathContext": "$\\mathbb{Q}$ satisfies all five CDLO conditions, each proved by `inferInstance` or a direct wrapper:\n- `LinearOrder ℚ`: total order (inferInstance)\n- `Countable ℚ`: $|\\mathbb{Q}| = \\aleph_0$ (from OQ-01 / `Data.Rat.Denumerable`)\n- `DenselyOrdered ℚ`: for any $p < q$, $\\exists r$ with $p < r < q$\n- `NoMinOrder ℚ`: no smallest rational (for any $q$, $q-1 < q$)\n- `NoMaxOrder ℚ`: no largest rational (for any $q$, $q < q+1$)\n\n`rationals_dense`, `rationals_no_min`, `rationals_no_max` spell out the density and no-endpoint conditions explicitly, making the CDLO axioms accessible as named theorems rather than opaque typeclass instances."
     },
     {
       "id": "sec-cantor-theorem",
       "title": "Part II: Cantor's Characterization Theorem",
       "startLine": 65,
       "endLine": 84,
-      "summary": "The central theorem: any CDLO is order-isomorphic to ℚ (cantor_characterization), and any two CDLOs are isomorphic to each other (countable_dense_linear_orders_iso). Both delegate to Mathlib's Order.iso_of_countable_dense."
+      "summary": "The central theorem: any CDLO is order-isomorphic to ℚ (cantor_characterization), and any two CDLOs are isomorphic to each other (countable_dense_linear_orders_iso). Both delegate to Mathlib's Order.iso_of_countable_dense.",
+      "mathContext": "**Cantor's characterization theorem** (1895): every countable dense linear order without endpoints is order-isomorphic to $\\mathbb{Q}$.\n\n`cantor_characterization` (type: `Nonempty (α ≃o ℚ)`): a one-liner applying `Order.iso_of_countable_dense α ℚ`, which implements the back-and-forth argument internally.\n\n`countable_dense_linear_orders_iso` (type: `Nonempty (α ≃o β)`): the fully symmetric version — ANY two CDLOs without endpoints are order-isomorphic. Proof: `Order.iso_of_countable_dense α β`. This makes $\\mathbb{Q}$ the canonical representative of its isomorphism class — the 'unique up to isomorphism' CDLO."
     },
     {
       "id": "sec-back-forth-infra",
       "title": "Part III: Back-and-Forth Infrastructure",
       "startLine": 86,
       "endLine": 101,
-      "summary": "Exposes Mathlib's Order.PartialIso type and its .comm operation. Proves the density_extension_lemma: given finite lower and upper bound sets with lo < hi, some element lies strictly between all of them."
+      "summary": "Exposes Mathlib's Order.PartialIso type and its .comm operation. Proves the density_extension_lemma: given finite lower and upper bound sets with lo < hi, some element lies strictly between all of them.",
+      "mathContext": "`Order.PartialIso ℚ ℚ` is the type of finite partial order-isomorphisms from $\\mathbb{Q}$ to $\\mathbb{Q}$: finite injective order-preserving maps $f : S \\to \\mathbb{Q}$ where $S \\subseteq \\mathbb{Q}$ is finite.\n\n`f.comm : Order.PartialIso ℚ ℚ` takes the 'transpose' — swaps domain and codomain. The back-and-forth alternates: 'forth' extends the domain, 'back' extends the range (via `f.comm`).\n\n`density_extension_lemma`: given finite sets `lo` (lower) and `hi` (upper) with all of `lo` below all of `hi`, finds a middle element $m$ with $\\text{lo} < m < \\text{hi}$. This is the key step enabling each extension in the back-and-forth: `Order.exists_between_finsets lo hi h`."
     },
     {
       "id": "sec-self-similarity",
       "title": "Part IV: Self-Similarity of ℚ",
       "startLine": 103,
       "endLine": 111,
-      "summary": "Proves ℚ is order-isomorphic to itself (rationals_selfsimilar) via back-and-forth, and defines the trivial_automorphism as OrderIso.refl."
+      "summary": "Proves ℚ is order-isomorphic to itself (rationals_selfsimilar) via back-and-forth, and defines the trivial_automorphism as OrderIso.refl.",
+      "mathContext": "$\\mathbb{Q}$ is order-isomorphic to itself in non-trivial ways. `rationals_selfsimilar`: `Nonempty (ℚ ≃o ℚ)`, proved by applying `cantor_characterization` to $\\mathbb{Q}$ itself.\n\nExamples of non-identity automorphisms: $q \\mapsto q + 1$ (translation), $q \\mapsto 2q$ (dilation), $q \\mapsto -q$ (reversal), $q \\mapsto q^3/(|q|^2+1)$ (more exotic). The automorphism group $\\text{Aut}(\\mathbb{Q})$ is uncountable.\n\n`trivial_automorphism := OrderIso.refl ℚ` is the identity isomorphism $\\text{id} : \\mathbb{Q} \\to \\mathbb{Q}$."
     },
     {
       "id": "sec-embeddings",
       "title": "Part V: Embedding Results",
       "startLine": 113,
       "endLine": 133,
-      "summary": "Constructs explicit order embeddings: integers_embed (ℤ ↪o ℚ) and naturals_embed (ℕ ↪o ℚ) via the canonical cast maps, with explicit proofs of injectivity and order-preservation."
+      "summary": "Constructs explicit order embeddings: integers_embed (ℤ ↪o ℚ) and naturals_embed (ℕ ↪o ℚ) via the canonical cast maps, with explicit proofs of injectivity and order-preservation.",
+      "mathContext": "$\\mathbb{Z} \\hookrightarrow \\mathbb{Q}$ and $\\mathbb{N} \\hookrightarrow \\mathbb{Q}$ as order embeddings:\n\n`integers_embed : ℤ ↪o ℚ`: the map $n \\mapsto (n : \\mathbb{Q})$ is order-preserving (`Int.cast_le`) and injective (`Int.cast_injective`). Lean's `↪o` (order embedding) requires both.\n\n`naturals_embed : ℕ ↪o ℚ`: same pattern with `Nat.cast_le` and `Nat.cast_injective`.\n\nThese embeddings witness that $\\mathbb{Q}$ is 'universal' for countable linear orders in a strong sense: every countable linear order embeds order-preservingly into $\\mathbb{Q}$ (a consequence of Cantor's theorem, since any countable linear order embeds into any CDLO)."
     },
     {
       "id": "sec-density-examples",
       "title": "Part VI: Concrete Density Examples",
       "startLine": 135,
       "endLine": 154,
-      "summary": "Proves the midpoint theorem (midpoint_between), an explicit numeric witness (5/12 between 1/3 and 1/2), and half_between_zero — concrete witnesses demonstrating density using linarith."
+      "summary": "Proves the midpoint theorem (midpoint_between), an explicit numeric witness (5/12 between 1/3 and 1/2), and half_between_zero — concrete witnesses demonstrating density using linarith.",
+      "mathContext": "Concrete density witnesses:\n- `midpoint_between`: $(p+q)/2$ lies strictly between $p < q$. Proof: `linarith` on both halves.\n- Explicit example: $1/3 < 5/12 < 1/2$, verified by `norm_num`.\n- `half_between_zero`: $0 < q/2 < q$ for $q > 0$. Proof: `linarith`.\n\nThese lemmas ground the abstract density axiom in concrete arithmetic, showing that the midpoint formula suffices: density is not just an existence claim but constructively witnessed by $(p+q)/2$."
     },
     {
       "id": "sec-no-endpoints-witnesses",
       "title": "Part VII: Constructive No-Endpoint Witnesses",
       "startLine": 156,
       "endLine": 161,
-      "summary": "Two one-liners: pred_lt (q - 1 < q) and succ_gt (q < q + 1) provide explicit arithmetic witnesses for the no-minimum and no-maximum properties."
+      "summary": "Two one-liners: pred_lt (q - 1 < q) and succ_gt (q < q + 1) provide explicit arithmetic witnesses for the no-minimum and no-maximum properties.",
+      "mathContext": "Constructive witnesses for `NoMinOrder` and `NoMaxOrder`:\n- `pred_lt`: $q - 1 < q$ (for any $q$, $q-1$ is smaller). Proof: `linarith`.\n- `succ_gt`: $q < q + 1$ (for any $q$, $q+1$ is larger). Proof: `linarith`.\n\nThese ground the abstract typeclass axioms in explicit arithmetic: `NoMinOrder ℚ` is satisfied because `q - 1 < q`, and `NoMaxOrder ℚ` because `q < q + 1`. The witnesses are simpler than density witnesses (no need for a third value strictly between two given ones)."
     },
     {
       "id": "sec-density-propagation",
       "title": "Part IX: Density Propagation",
       "startLine": 163,
       "endLine": 181,
-      "summary": "Proves two_between and three_between: by iterated density, between any two rationals there exist at least two (resp. three) strictly intermediate rationals."
+      "summary": "Proves two_between and three_between: by iterated density, between any two rationals there exist at least two (resp. three) strictly intermediate rationals.",
+      "mathContext": "The density axiom (1 element between any two) implies multiple elements between any two:\n- `two_between`: $\\exists r, s$ with $p < r < s < q$. Proof: apply `dense` to get $m \\in (p,q)$, then again to get $s \\in (m,q)$.\n- `three_between`: $\\exists r, s, t$ with $p < r < s < t < q$. Proof: apply `two_between` then `dense`.\n\nBy induction, $\\exists n$ elements strictly between any two distinct rationals, for all $n$. In fact, between any two rationals there are countably infinitely many (and in any open interval of $\\mathbb{Q}$ there is a copy of the whole $\\mathbb{Q}$ by Cantor's theorem applied to the interval)."
     },
     {
       "id": "sec-cardinal-arithmetic",
       "title": "Part X: Cardinal Arithmetic",
       "startLine": 183,
       "endLine": 193,
-      "summary": "Proves card_rat_aleph0 (|ℚ| = ℵ₀) and card_rat_eq_nat (|ℚ| = |ℕ|) using Mathlib's Cardinal.mk_denumerable."
+      "summary": "Proves card_rat_aleph0 (|ℚ| = ℵ₀) and card_rat_eq_nat (|ℚ| = |ℕ|) using Mathlib's Cardinal.mk_denumerable.",
+      "mathContext": "$|\\mathbb{Q}| = \\aleph_0$:\n- `card_rat_aleph0`: `Cardinal.mk ℚ = Cardinal.aleph0`. Proof: `Cardinal.mk_denumerable ℚ` (any `Denumerable` type has cardinality $\\aleph_0$).\n- `card_rat_eq_nat`: `Cardinal.mk ℚ = Cardinal.mk ℕ`. Proof: both equal `aleph0` via `mk_denumerable`.\n\nContrast: $|\\mathbb{R}| = 2^{\\aleph_0} > \\aleph_0$. The rationals are countably infinite while the reals are uncountable — both are dense linear orders without endpoints, but only $\\mathbb{Q}$ satisfies the countability condition in Cantor's theorem. $\\mathbb{R}$ is order-isomorphic to every other *complete* dense linear order without endpoints (Dedekind completeness)."
     },
     {
       "id": "sec-contrast-integers",
       "title": "Part XI: Contrast with Discrete Orders",
       "startLine": 195,
       "endLine": 205,
-      "summary": "no_integer_between proves the discreteness of ℤ (no integer strictly between n and n+1, proved by omega). nat_has_min states ℕ's minimum. These contrast with ℚ's density."
+      "summary": "no_integer_between proves the discreteness of ℤ (no integer strictly between n and n+1, proved by omega). nat_has_min states ℕ's minimum. These contrast with ℚ's density.",
+      "mathContext": "$\\mathbb{Z}$ fails the CDLO conditions, distinguishing it from $\\mathbb{Q}$:\n- `no_integer_between`: $\\neg\\exists m : \\mathbb{Z}, n < m < n+1$. Proof: `omega` (Presburger arithmetic). This shows $\\mathbb{Z}$ is NOT densely ordered — consecutive integers have no integer between them.\n- `nat_has_min`: $\\forall n : \\mathbb{N}, 0 \\leq n$. $\\mathbb{N}$ has a minimum element, violating `NoMinOrder`.\n\nTogether: $\\mathbb{Z}$ is countable but not densely ordered; $\\mathbb{N}$ has a minimum. Neither is order-isomorphic to $\\mathbb{Q}$. The 'moral': countability alone is insufficient — all three of density, no-min, and no-max are needed for Cantor's characterization."
     },
     {
       "id": "sec-universality",
       "title": "Part XII: Universality of ℚ",
       "startLine": 207,
       "endLine": 221,
-      "summary": "fin_embeds proves any Fin n embeds strictly monotonically into ℚ via casting, establishing the finite case of ℚ's universality for all countable linear orders."
+      "summary": "fin_embeds proves any Fin n embeds strictly monotonically into ℚ via casting, establishing the finite case of ℚ's universality for all countable linear orders.",
+      "mathContext": "Every finite linear order $\\{0, \\ldots, n-1\\}$ embeds into $\\mathbb{Q}$:\n- The anonymous `example` for `Fin 3`: witness $f : \\{0,1,2\\} \\to \\mathbb{Q}$ by $f(k) = (k : \\mathbb{Q})$, strictly monotone by `Nat.cast_lt.mpr`.\n- `fin_embeds`: for any $n$, `∃ f : Fin n → ℚ, StrictMono f`. Same witness.\n\nThis holds because $\\mathbb{Q}$ contains a copy of every countable linear order (Cantor: embed into any CDLO). Combined with $\\mathbb{Z} \\hookrightarrow \\mathbb{Q}$ and $\\mathbb{N} \\hookrightarrow \\mathbb{Q}$, this establishes $\\mathbb{Q}$ as the 'universal' countable linear order."
     },
     {
       "id": "sec-verification",
       "title": "Verification Examples",
       "startLine": 223,
       "endLine": 236,
-      "summary": "Three inline examples verify: cantor_characterization applied to ℚ, the midpoint formula on 1/4 and 3/4, and integers_embed preserving 3 < 5."
+      "summary": "Three inline examples verify: cantor_characterization applied to ℚ, the midpoint formula on 1/4 and 3/4, and integers_embed preserving 3 < 5.",
+      "mathContext": "Three verification examples confirming the main theorems instantiate correctly:\n1. `cantor_characterization ℚ : Nonempty (ℚ ≃o ℚ)` — $\\mathbb{Q}$ is isomorphic to itself.\n2. `(1/4 + 3/4)/2 = 1/2` lies strictly between $1/4$ and $3/4$: `norm_num` on both `<` goals.\n3. `integers_embed 3 < integers_embed 5`: the embedding preserves order; `(3:ℚ) < 5` by `norm_num`.\n\nThese `example` blocks serve as smoke tests — they fail to compile if any definition or theorem is broken, providing end-to-end verification of the formalization without requiring named theorems for each case."
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Summary
All 13 sections had empty `mathContext` (0 chars). Added 455-718 char content grounded in `DenumerabilityRationalsOQ02.lean` (Cantor's characterization of ℚ as the unique CDLO):

- **sec-imports-header**: 5 CDLO typeclasses, back-and-forth method mechanism
- **sec-cdlo-instances**: Why each CDLO axiom holds for ℚ, `inferInstance` pattern
- **sec-cantor-theorem**: `cantor_characterization` and symmetric `countable_dense_linear_orders_iso`  
- **sec-back-forth-infra**: `Order.PartialIso`, `f.comm`, `density_extension_lemma` via `exists_between_finsets`
- **sec-self-similarity**: `rationals_selfsimilar`, Aut(ℚ) uncountable, `trivial_automorphism`
- **sec-embeddings**: ℤ ↪o ℚ and ℕ ↪o ℚ via `cast_le`/`cast_injective`, universality for countable orders
- **sec-density-examples**: Midpoint formula $(p+q)/2$ as constructive witness, explicit `5/12` example
- **sec-no-endpoints-witnesses**: `pred_lt` ($q-1<q$) and `succ_gt` ($q<q+1$) grounding the typeclass
- **sec-density-propagation**: `two_between` and `three_between` by inductive application of `dense`
- **sec-cardinal-arithmetic**: $|\mathbb{Q}| = \aleph_0 = |\mathbb{N}|$ vs $|\mathbb{R}| = 2^{\aleph_0}$
- **sec-contrast-integers**: ℤ fails density (`omega` closes gaps), ℕ has min
- **sec-universality**: `fin_embeds` shows ℚ is universal for all finite linear orders
- **sec-verification**: Three smoke-test examples for end-to-end correctness

## Proof entry
`denumerability-rationals-oq-02` — Cantor's Characterization of ℚ as the Unique Countable Dense Linear Order (passes=1, quality=100)

🤖 Generated with [Claude Code](https://claude.com/claude-code)