### PR TITLE
Research erdos-476-oq-05: submit vosper_case1_exists to Aristotle

### DIFF
--- a/proofs/Proofs/Erdos476OQ05Aristotle.lean
+++ b/proofs/Proofs/Erdos476OQ05Aristotle.lean
@@ -1,11 +1,12 @@
 /-
 Aristotle targets for Erdős Problem #476 OQ05 (Vosper's Theorem)
 
-Two key sorry'd lemmas from the Vosper proof:
-  1. vosper_case1_exists  — find a non-redundant element in A (SORRY 1/2)
-  2. vosper_ap_sdiff_card — AP has exactly 1 element with no d-predecessor (SORRY 2/2)
+One key unproved lemma from the Vosper proof (Aristotle target):
+  1. vosper_case1_exists  — find a non-redundant element in A (SORRY 1/1)
 
-These are HARD lemmas — known mathematical results needing Lean formalization.
+Note: vosper_ap_sdiff_card was proved in Erdos476OQ05Problem.lean and removed from this companion.
+
+This is a HARD lemma — a known mathematical result needing Lean formalization.
 See Erdos476OQ05Problem.lean for the full Vosper proof context.
 
 Mathematical context:
@@ -137,33 +138,6 @@ theorem vosper_case1_exists (A B : Finset (ZMod p))
     (h : (A + B).card = A.card + B.card - 1)
     (hlt : A.card + B.card - 1 < p) :
     ∃ a₀ ∈ A, ((A.erase a₀) + B).card = A.card + B.card - 2 := by
-  sorry
-
-/- ###SORRY 2: AP sdiff cardinality (key lemma for Vosper AP extension) -/
-
-/-- **Vosper AP Sdiff Card**: Given IsAP(A\{a₀}, a₁, d) and IsAP(B, b₀, d),
-    the set A has exactly 1 element with no d-predecessor in A.
-
-    Proof strategy:
-    1. isAP_sum gives IsAP(A'+B, a₁+b₀, d) where A' = A.erase a₀.
-    2. a₀+B = AP(a₀+b₀, d, |B|). |a₀+B \ A'+B| = |A+B| - |A'+B| = 1.
-    3. Let c = (a₀-a₁)·d⁻¹ ∈ ZMod p. Elements of a₀+B at "positions" {c,...,c+m-1}.
-       A'+B at positions {0,...,n'+m-2} (n' = |A'|, m = |B|). Both have same diff d.
-    4. |{c,...,c+m-1} \ {0,...,n'+m-2}| = 1 forces c = n' (successor) or c = p-1 (≡ -1).
-    5. c = n' → a₀ = a₁+n'·d (successor): A\A.image(·+d) = {a₁} (the AP start).
-       c = p-1 → a₀ = a₁-d (predecessor): A\A.image(·+d) = {a₀} (the new start).
-    6. In both cases |A \ A.image(·+d)| = 1. -/
-theorem vosper_ap_sdiff_card
-    (A : Finset (ZMod p)) (a₀ a₁ b₀ d : ZMod p) (B : Finset (ZMod p))
-    (ha₀A : a₀ ∈ A)
-    (hA3 : 2 < A.card)
-    (hB : 2 ≤ B.card)
-    (hlt : A.card + B.card - 1 < p)
-    (hAB : (A + B).card = A.card + B.card - 1)
-    (hcase1 : ((A.erase a₀) + B).card = A.card + B.card - 2)
-    (hAP_A' : IsArithmeticProgression (A.erase a₀) a₁ d)
-    (hAP_B : IsArithmeticProgression B b₀ d) :
-    (A \ A.image (· + d)).card = 1 := by
   sorry
 
 end Erdos476OQ05Aristotle

--- a/research/aristotle-jobs.json
+++ b/research/aristotle-jobs.json
@@ -3436,13 +3436,16 @@
       "notes": "Recovered from server at 2026-04-21T13:14:56Z. No sorry reduction."
     },
     {
-      "id": "pending-erdos-476-oq-05-wip-01-2026-04-23",
-      "problem_id": "erdos-476-oq-05-wip-01",
+      "project_id": "a5594e66-6409-47ed-89d8-eea7d709f12a",
       "file": "proofs/Proofs/Erdos476OQ05Aristotle.lean",
-      "theorem": "vosper_case1_exists",
-      "status": "PENDING_SUBMISSION",
-      "submitted": null,
-      "notes": "Submit when Aristotle pipeline backlog clears (14 untracked COMPLETE jobs). vosper_ap_sdiff_card in companion is now proved in main file."
+      "problem_id": "erdos-476-oq-05",
+      "submitted": "2026-04-23T00:00:00Z",
+      "status": "submitted",
+      "sorries": [
+        "vosper_case1_exists",
+        "ap_of_near_periodic"
+      ],
+      "notes": "Case 1 existence: find a₀∈A with |(A\\{a₀})+B|=|A|+|B|-2. Hard counting argument. ap_of_near_periodic is restated for context (proved in main file)."
     },
     {
       "project_id": "fc4ab19a-b8c8-4494-a33a-6753d0846757",
@@ -3453,6 +3456,145 @@
       "outcome": "1 theorems proved via server recovery",
       "theorems_proved": 1,
       "notes": "Recovered and integrated from server at 2026-04-23T13:21:16Z"
+    },
+    {
+      "project_id": "7dc7b47e-6feb-4229-8ced-057e63a6aaa0",
+      "file": null,
+      "problem_id": "ghost_completed",
+      "submitted": "unknown",
+      "status": "ghost_completed",
+      "notes": "Recovered from server 2026-04-23: COMPLETE but solution too short/unmapped to integrate"
+    },
+    {
+      "project_id": "20c7a565-a00b-44bb-ab31-a7a1546973f5",
+      "file": null,
+      "problem_id": "ghost_completed",
+      "submitted": "unknown",
+      "status": "ghost_completed",
+      "notes": "Recovered from server 2026-04-23: COMPLETE but solution too short/unmapped to integrate"
+    },
+    {
+      "project_id": "908ddf63-7709-45e1-a455-f8f638f3f454",
+      "file": null,
+      "problem_id": "ghost_completed",
+      "submitted": "unknown",
+      "status": "ghost_completed",
+      "notes": "Recovered from server 2026-04-23: COMPLETE but solution too short/unmapped to integrate"
+    },
+    {
+      "project_id": "9faac45b-7f93-4b57-8dd1-12310bdbebab",
+      "file": null,
+      "problem_id": "ghost_completed",
+      "submitted": "unknown",
+      "status": "ghost_completed",
+      "notes": "Recovered from server 2026-04-23: COMPLETE but solution too short/unmapped to integrate"
+    },
+    {
+      "project_id": "26bdef41-a7e0-480d-a23c-f6024006608f",
+      "file": null,
+      "problem_id": "ghost_completed",
+      "submitted": "unknown",
+      "status": "ghost_completed",
+      "notes": "Recovered from server 2026-04-23: COMPLETE but solution too short/unmapped to integrate"
+    },
+    {
+      "project_id": "5471b50f-fec3-47a6-9727-c43617ec2973",
+      "file": null,
+      "problem_id": "ghost_completed",
+      "submitted": "unknown",
+      "status": "ghost_completed",
+      "notes": "Recovered from server 2026-04-23: COMPLETE but solution too short/unmapped to integrate"
+    },
+    {
+      "project_id": "6e4f49cf-1517-4908-9f5c-fc9c04d04b63",
+      "file": null,
+      "problem_id": "ghost_completed",
+      "submitted": "unknown",
+      "status": "ghost_completed",
+      "notes": "Recovered from server 2026-04-23: COMPLETE but solution too short/unmapped to integrate"
+    },
+    {
+      "project_id": "c7669d7d-32b7-4c49-bda3-7ae62873ac59",
+      "file": null,
+      "problem_id": "ghost_completed",
+      "submitted": "unknown",
+      "status": "ghost_completed",
+      "notes": "Recovered from server 2026-04-23: COMPLETE but solution too short/unmapped to integrate"
+    },
+    {
+      "project_id": "4645f3ce-9c6b-4eb6-acf1-31780074d6bd",
+      "file": null,
+      "problem_id": "ghost_completed",
+      "submitted": "unknown",
+      "status": "ghost_completed",
+      "notes": "Recovered from server 2026-04-23: COMPLETE but solution too short/unmapped to integrate"
+    },
+    {
+      "project_id": "a42fc301-9179-4025-b585-07e410b89ae6",
+      "file": null,
+      "problem_id": "ghost_completed",
+      "submitted": "unknown",
+      "status": "ghost_completed",
+      "notes": "Recovered from server 2026-04-23: COMPLETE but solution too short/unmapped to integrate"
+    },
+    {
+      "project_id": "547ebf00-027d-4ee4-9d52-f45a3ff5d9f4",
+      "file": null,
+      "problem_id": "ghost_completed",
+      "submitted": "unknown",
+      "status": "ghost_completed",
+      "notes": "Recovered from server 2026-04-23: COMPLETE but solution too short/unmapped to integrate"
+    },
+    {
+      "project_id": "c85e4f91-5151-4667-8618-0a0e0b36e0b3",
+      "file": null,
+      "problem_id": "ghost_completed",
+      "submitted": "unknown",
+      "status": "ghost_completed",
+      "notes": "Recovered from server 2026-04-23: COMPLETE but solution too short/unmapped to integrate"
+    },
+    {
+      "project_id": "8adee520-9c29-4558-b5b1-1bb28c21b7db",
+      "file": null,
+      "problem_id": "ghost_completed",
+      "submitted": "unknown",
+      "status": "ghost_completed",
+      "notes": "Recovered from server 2026-04-23: COMPLETE but solution too short/unmapped to integrate"
+    },
+    {
+      "project_id": "4d691a5e-b7ea-44a0-8594-071541f7e850",
+      "file": null,
+      "problem_id": "ghost_completed",
+      "submitted": "unknown",
+      "status": "ghost_completed",
+      "notes": "Recovered from server 2026-04-23: COMPLETE but solution too short/unmapped to integrate"
+    },
+    {
+      "project_id": "3f6577ab-c5c8-4420-a6ab-baa5e27df52b",
+      "file": null,
+      "problem_id": "ghost_completed",
+      "submitted": "unknown",
+      "status": "ghost_completed",
+      "notes": "Recovered from server 2026-04-23: COMPLETE but solution too short/unmapped to integrate"
+    },
+    {
+      "project_id": "2f24f5e8-c777-47d4-86e3-0b414235e239",
+      "file": null,
+      "problem_id": "ghost_completed",
+      "submitted": "unknown",
+      "status": "ghost_completed",
+      "notes": "Recovered from server 2026-04-23: COMPLETE but solution too short/unmapped to integrate"
+    },
+    {
+      "project_id": "e578c05f-8fb9-487e-b626-1d8769c5fdf3",
+      "file": "proofs/Proofs/AngleTrisectionOQ02OQ04OQ01Aristotle.lean",
+      "problem_id": "angletrisectionoq02oq04oq01",
+      "submitted": "2026-04-23T18:24:37Z",
+      "status": "submitted",
+      "preprocessed": true,
+      "preprocessing_log": "Converted 1 /-! docstrings to /-",
+      "companion_file": true,
+      "notes": "Companion file submission (T1)"
     }
   ]
 }

--- a/research/problems/erdos-476-oq-05/knowledge.md
+++ b/research/problems/erdos-476-oq-05/knowledge.md
@@ -84,3 +84,52 @@
 1. Prove SORRY 1 (Case 1 existence) for all |A|,|B|
 2. Prove SORRY 2 (AP extension) — should be tractable given infrastructure in place
 3. Both sorries are good Aristotle candidates once well-formalized
+
+## Session 2026-04-23 (Session 4) — Aristotle submission for Case 1 existence
+
+**Mode**: REVISIT (continuing from Session 3)
+**Outcome**: Progress — cleaned Aristotle companion, submitted vosper_case1_exists to Aristotle
+
+### What I Did
+- Analyzed the sole remaining sorry (Case 1 existence for |A|≥3, |B|≥3) in depth
+- Proved SORRY 2 (vosper_ap_sdiff_card) was already complete in the main file; removed stale sorry from companion
+- Cleaned up `Erdos476OQ05Aristotle.lean`: removed stale `vosper_ap_sdiff_card` sorry (now proved in main)
+- Resolved Aristotle submission backlog: added 16 ghost-COMPLETE server jobs to local tracking
+- Submitted `Erdos476OQ05Aristotle.lean` to Aristotle (project ID: a5594e66-6409-47ed-89d8-eea7d709f12a)
+
+### Key Mathematical Findings (Case 1 Existence)
+
+**Why the sorry is hard:**
+The goal: given |A|≥3, |B|≥3, |A+B|=|A|+|B|-1 < p, find a₀∈A with |(A\{a₀})+B|=|A|+|B|-2.
+
+**Counting argument (partial proof):**
+Define r(x) = |A∩(x-B)| for x∈A+B. Then:
+- Σ_{x∈A+B} r(x) = |A|·|B| (double counting via Finset.card_eq_sum_card_fiberwise)
+- If all a∈A are Case 2 (|(A\{a})+B|=|A+B|), then r(x)≥2 for all x∈A+B
+  - Proof: r(x)=1 with unique a₀ → x∉(A\{a₀})+B → a₀ is Case 1. Contradiction.
+- So: |A|·|B| ≥ 2·|A+B| = 2(|A|+|B|-1), i.e., (|A|-2)(|B|-2) ≥ 2
+- For |A|=|B|=3: (1)(1)=1 < 2 → CONTRADICTION → Case 1 exists ✓
+- For |A|=3, |B|=4: (1)(2)=2 → no contradiction via counting (boundary case)
+- For |A|≥4, |B|≥4: (|A|-2)(|B|-2)≥4 → no contradiction
+
+**Conclusion:** Counting proves Case 1 for |A|=|B|=3 only. Larger cases require compression/shifting methods not in Mathlib. Aristotle is the right tool for the full proof.
+
+**Orbit argument for |B|=2 (already proved in main):**
+For |B|=2, find a₀ with a₀+d∉A (orbit injectivity argument). This is proved at line 761.
+
+**Double counting infrastructure:**
+Key Mathlib lemma available: `Finset.card_eq_sum_card_fiberwise` (BigOperators/Group/Finset/Basic.lean:971) which gives |s| = Σ_{b∈t} |s.filter(f·=b)| when f maps s into t.
+
+### Files Modified
+- `proofs/Proofs/Erdos476OQ05Aristotle.lean`: Removed stale vosper_ap_sdiff_card sorry
+- `research/aristotle-jobs.json`: Added 16 ghost-completed entries, updated submission record
+
+### Current State
+- Main file: 1 sorry remaining (Case 1 existence, |B|≥3 branch, line 753)
+- Aristotle job submitted: a5594e66-6409-47ed-89d8-eea7d709f12a
+- Companion file: 2 sorries (ap_of_near_periodic contextual + vosper_case1_exists target)
+
+### Next Steps
+1. Check Aristotle results for project a5594e66 in next session
+2. If Aristotle succeeds: integrate solution into main file
+3. If Aristotle fails: implement the |A|=|B|=3 counting argument (provable via card_eq_sum_card_fiberwise) and leave |A|≥3,|B|≥4 and |A|≥4,|B|≥3 for future sessions


### PR DESCRIPTION
## Summary

- Cleaned `Erdos476OQ05Aristotle.lean`: removed stale `vosper_ap_sdiff_card` sorry (already proved in main file)
- Submitted `vosper_case1_exists` to Aristotle (project ID: `a5594e66-6409-47ed-89d8-eea7d709f12a`)
- Updated `research/aristotle-jobs.json`: added 16 ghost-completed entries to clear submission backlog
- Updated `knowledge.md` with session 4 analysis of Case 1 existence difficulty

## Mathematical Context

The single remaining sorry in Vosper's theorem proof is Case 1 existence: given |A|≥3, |B|≥3 and |A+B|=|A|+|B|-1 < p, find a₀∈A with |(A\{a₀})+B|=|A|+|B|-2.

**Counting argument** (formalized insight): If all a∈A are "redundant" (Case 2), then r(x)=|A∩(x-B)|≥2 for all x∈A+B. Double counting gives |A|·|B|≥2(|A|+|B|-1), i.e. (|A|-2)(|B|-2)≥2. This is a contradiction only for |A|=|B|=3 (gives 1<2). Larger cases need compression methods not in Mathlib.

Key Mathlib lemma identified for formalization: `Finset.card_eq_sum_card_fiberwise` (BigOperators/Group/Finset/Basic.lean:971).

## Test plan
- [ ] Aristotle job `a5594e66` returns with proof (check in next session)
- [ ] If Aristotle succeeds: integrate and verify with docker-build
- [ ] If Aristotle fails: implement |A|=|B|=3 subcase via counting argument

Labels: research