### PR TITLE
Fix: dissection-of-cubes-oq-04 — update stale sorry count to 0

### DIFF
--- a/src/data/proofs/dissection-of-cubes-oq-04/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-04/meta.json
@@ -19,7 +19,7 @@
       "irrational-angles"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 0,
     "dateAdded": "2026-04-22",
     "axiomCount": 2,
     "assumptions": "1. tmul_infinite_order_ne_zero (from OQ02OQ02): ℝ is flat over ℤ — needed to show nonzero tensor products. 2. icoAngle_irrational: arccos(-√5/3)/π is irrational (icosahedron dihedral angle) — proof requires Chebyshev arithmetic in ℤ[√5], deferred.",


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: dissection-of-cubes-oq-04
**Problem**: Stale sorry count in meta.json

## Evidence

**meta.json claims**: `sorries: 3`, status=axiomatized, badge=axiom
**Lean file shows**: 0 code-level sorries in `DissectionOfCubesOQ04.lean`

The 3 sorries were present in an earlier draft but were subsequently proved. The meta.json was not updated to reflect the completion.

## Change

- `meta.sorries`: 3 → 0

The axiom-related fields remain correct:
- `axiomCount: 2` (icoAngle_irrational + tmul_infinite_order_ne_zero from OQ02OQ02)
- `status: axiomatized`, `badge: axiom` — correctly reflect the remaining axioms

---
Discovered during gallery integrity audit.