### PR TITLE
Fix: ballot-problem-oq-03-oq-01-oq-02 — correct sorry count from 0 to 3

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -19,7 +19,7 @@
       "representation-theory"
     ],
     "badge": "wip",
-    "sorries": 0,
+    "sorries": 3,
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
     "assumptions": "Two remaining open sorries in hook_length_formula (general case): ni_count_eq_syt_count (RSK/Fomin growth diagram bijection) and lgv_det_factors_as_hook_quotient (Vandermonde-type det identity). hook_length_formula_two_row_gen is now fully proved (0 sorries) for all 2-row shapes [a,b] with a\u2265b.",


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: ballot-problem-oq-03-oq-01-oq-02 (Hook-Length Formula for SYT via LGV)
**Problem**: Incorrect sorry count in meta.json

## Evidence

**meta.json claims**: `sorries: 0`
**Lean file shows**: 3 code-level sorries
1. `hook_length_formula` (line 219) — main theorem, requires RSK bijection
2. `ni_count_eq_syt_count` (line 235) — RSK/Fomin growth diagram bijection (~200 lines)
3. `lgv_det_factors_as_hook_quotient` (line 245) — Vandermonde-type det identity (~200 lines)

## Root Cause

PR #11951 proved `card_SYT_twoRowYD` (reducing sorries from 4 to 3) but the meta.json was set to `sorries: 0` instead of `sorries: 3`. The description text in the same file already correctly notes "General formula has 3 sorries".

## Change

- `meta.sorries`: 0 → 3

No status or badge changes needed (remains `formalized`/`wip`).

---
Discovered during gallery integrity audit.