### PR TITLE
chore: sync audit-tracker.json with latest audit results

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12113,6 +12113,834 @@
       "issues": [],
       "lastAudited": "2026-04-12T23:10:24Z",
       "result": "clean"
+    },
+    "algebraic-numbers-countable-oq-02-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "amgm-inequality-oq-02-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "amgm-inequality-oq-03-oq-02-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "amgm-inequality-oq-03-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:46Z",
+      "result": "clean",
+      "issues": []
+    },
+    "amgm-inequality-oq-03-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:46Z",
+      "result": "clean",
+      "issues": []
+    },
+    "angle-trisection-cos-20-gal-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:46Z",
+      "result": "clean",
+      "issues": []
+    },
+    "angle-trisection-cos-20-gal-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:46Z",
+      "result": "clean",
+      "issues": []
+    },
+    "angle-trisection-cos-20-gal-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:46Z",
+      "result": "clean",
+      "issues": []
+    },
+    "angle-trisection-oq-02-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:46Z",
+      "result": "clean",
+      "issues": []
+    },
+    "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:46Z",
+      "result": "clean",
+      "issues": []
+    },
+    "area-of-circle-oq-01-oq-02-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:46Z",
+      "result": "clean",
+      "issues": []
+    },
+    "area-of-circle-oq-01-oq-02-oq-03-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:46Z",
+      "result": "clean",
+      "issues": []
+    },
+    "area-of-circle-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:46Z",
+      "result": "clean",
+      "issues": []
+    },
+    "area-of-circle-oq-02-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:47Z",
+      "result": "clean",
+      "issues": []
+    },
+    "area-of-circle-oq-03-oq-02-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:47Z",
+      "result": "clean",
+      "issues": []
+    },
+    "area-of-circle-oq-03-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:47Z",
+      "result": "clean",
+      "issues": []
+    },
+    "area-of-circle-oq-05-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:47Z",
+      "result": "clean",
+      "issues": []
+    },
+    "arithmetic-series-oq-00": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:47Z",
+      "result": "clean",
+      "issues": []
+    },
+    "arithmetic-series-oq-02-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:47Z",
+      "result": "clean",
+      "issues": []
+    },
+    "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:47Z",
+      "result": "clean",
+      "issues": []
+    },
+    "ballot-problem-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:47Z",
+      "result": "clean",
+      "issues": []
+    },
+    "ballot-problem-oq-03-oq-01-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:47Z",
+      "result": "clean",
+      "issues": []
+    },
+    "basel-problem-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:47Z",
+      "result": "clean",
+      "issues": []
+    },
+    "basel-problem-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:47Z",
+      "result": "clean",
+      "issues": []
+    },
+    "bertrands-postulate-oq-03-oq-04-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:47Z",
+      "result": "clean",
+      "issues": []
+    },
+    "bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:48Z",
+      "result": "clean",
+      "issues": []
+    },
+    "bezout-identity-oq-02-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:48Z",
+      "result": "clean",
+      "issues": []
+    },
+    "bezout-identity-oq-04-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:48Z",
+      "result": "clean",
+      "issues": []
+    },
+    "binary-gcd-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:48Z",
+      "result": "clean",
+      "issues": []
+    },
+    "binomial-theorem-oq-02-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:48Z",
+      "result": "clean",
+      "issues": []
+    },
+    "binomial-theorem-oq-02-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:48Z",
+      "result": "clean",
+      "issues": []
+    },
+    "binomial-theorem-oq-02-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:48Z",
+      "result": "clean",
+      "issues": []
+    },
+    "binomial-theorem-oq-04-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:48Z",
+      "result": "clean",
+      "issues": []
+    },
+    "brouwer-fixed-point-oq-04-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:48Z",
+      "result": "clean",
+      "issues": []
+    },
+    "brouwer-fixed-point-oq-04-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:48Z",
+      "result": "clean",
+      "issues": []
+    },
+    "buffons-needle-oq-01-oq-01-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:48Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cantor-diagonalization-oq-01-oq-01-oq-02-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:48Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cantor-diagonalization-oq-04-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:48Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:49Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-schwarz-integral-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:49Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-schwarz-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:49Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cayley-hamilton-minpoly-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:49Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cayley-hamilton-reduction-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:49Z",
+      "result": "clean",
+      "issues": []
+    },
+    "central-limit-theorem-oq-01-oq-02-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:49Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cevas-theorem-non-euclidean-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:49Z",
+      "result": "clean",
+      "issues": []
+    },
+    "chebyshev-pnt-bridge-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:49Z",
+      "result": "clean",
+      "issues": []
+    },
+    "chebyshev-pnt-bridge-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:49Z",
+      "result": "clean",
+      "issues": []
+    },
+    "chebyshev-pnt-bridge-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:49Z",
+      "result": "clean",
+      "issues": []
+    },
+    "chinese-remainder-non-coprime-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:49Z",
+      "result": "clean",
+      "issues": []
+    },
+    "chinese-remainder-non-coprime-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:49Z",
+      "result": "clean",
+      "issues": []
+    },
+    "collatz-cycles-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:49Z",
+      "result": "clean",
+      "issues": []
+    },
+    "combinations-formula-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:50Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cube-root-3-irrational-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:50Z",
+      "result": "clean",
+      "issues": []
+    },
+    "denumerability-rationals-oq-02-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:50Z",
+      "result": "clean",
+      "issues": []
+    },
+    "derangements-oq-03-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:50Z",
+      "result": "clean",
+      "issues": []
+    },
+    "divisibility-by-3-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:50Z",
+      "result": "clean",
+      "issues": []
+    },
+    "divisibility-rules-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:50Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1027-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:50Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1027-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:50Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-105-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:50Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1059-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:50Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1083-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:50Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-109-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:50Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1107-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:50Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1129-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:51Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1156": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:51Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1182": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:51Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1196": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:51Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1202": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:51Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1205": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:51Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1206": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:51Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1208": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:51Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1211": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:51Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1212": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:51Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1213": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:51Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1215": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:51Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1216": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:51Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1217": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:52Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-130-wip-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:52Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-181-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:52Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-327-oq-01-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:52Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-476-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:52Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-65-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:52Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-837-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:52Z",
+      "result": "clean",
+      "issues": []
+    },
+    "euler-totient-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:52Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fair-games-theorem-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:52Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fair-games-theorem-oq-02-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:52Z",
+      "result": "clean",
+      "issues": []
+    },
+    "feuerbachs-theorem-defs-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:52Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fourier-series-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:52Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fourier-series-oq-02-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:42:52Z",
+      "result": "clean",
+      "issues": []
+    },
+    "ballot-problem-oq-03-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:25Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "dissection-of-cubes-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:25Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "gcd-algorithm-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:25Z",
+      "result": "clean",
+      "issues": []
+    },
+    "godel-first-incompleteness-oq01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:25Z",
+      "result": "clean",
+      "issues": []
+    },
+    "godel-second-incompleteness-oq02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:25Z",
+      "result": "clean",
+      "issues": []
+    },
+    "hilbert-15-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:26Z",
+      "result": "clean",
+      "issues": []
+    },
+    "hilbert-20-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:26Z",
+      "result": "clean",
+      "issues": []
+    },
+    "hurwitz-theorem-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:26Z",
+      "result": "clean",
+      "issues": []
+    },
+    "konigsberg-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:26Z",
+      "result": "clean",
+      "issues": []
+    },
+    "kummer-theorem-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:26Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lagrange-four-squares-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:27Z",
+      "result": "clean",
+      "issues": []
+    },
+    "law-of-cosines-oq-01-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:27Z",
+      "result": "clean",
+      "issues": []
+    },
+    "law-of-sines-oq-06": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:27Z",
+      "result": "clean",
+      "issues": []
+    },
+    "laws-of-large-numbers-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:27Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lebesgue-measure-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:27Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lebesgue-measure-oq-06": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:28Z",
+      "result": "clean",
+      "issues": []
+    },
+    "leibniz-pi-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:28Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lhopital-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:28Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lovasz-local-lemma-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:28Z",
+      "result": "clean",
+      "issues": []
+    },
+    "minkowski-fundamental-theorem-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:29Z",
+      "result": "clean",
+      "issues": []
+    },
+    "napoleons-theorem-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:29Z",
+      "result": "clean",
+      "issues": []
+    },
+    "partition-theorem-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:29Z",
+      "result": "clean",
+      "issues": []
+    },
+    "primitive-roots-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:30Z",
+      "result": "clean",
+      "issues": []
+    },
+    "ptolemys-theorem-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:30Z",
+      "result": "clean",
+      "issues": []
+    },
+    "ptolemys-theorem-oq-01-incomplete-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:30Z",
+      "result": "clean",
+      "issues": []
+    },
+    "ptolemys-theorem-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:30Z",
+      "result": "clean",
+      "issues": []
+    },
+    "randomized-maxcut-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:30Z",
+      "result": "clean",
+      "issues": []
+    },
+    "schroeder-bernstein-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:31Z",
+      "result": "clean",
+      "issues": []
+    },
+    "shannon-channel-coding-oq-02-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:31Z",
+      "result": "clean",
+      "issues": []
+    },
+    "shannon-source-coding-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:32Z",
+      "result": "clean",
+      "issues": []
+    },
+    "shapley-folkman-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:32Z",
+      "result": "clean",
+      "issues": []
+    },
+    "solution-of-cubic-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:33Z",
+      "result": "clean",
+      "issues": []
+    },
+    "sophie-germain-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:33Z",
+      "result": "clean",
+      "issues": []
+    },
+    "sperner-ndim-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:34Z",
+      "result": "clean",
+      "issues": []
+    },
+    "sperner-ndim-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:34Z",
+      "result": "clean",
+      "issues": []
+    },
+    "sqrt2-minpoly": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:34Z",
+      "result": "clean",
+      "issues": []
+    },
+    "sqrt2-minpoly-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:34Z",
+      "result": "clean",
+      "issues": []
+    },
+    "sqrt2-minpoly-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:35Z",
+      "result": "clean",
+      "issues": []
+    },
+    "sqrt2-plus-sqrt3-irrational-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:35Z",
+      "result": "clean",
+      "issues": []
+    },
+    "subset-count-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:35Z",
+      "result": "clean",
+      "issues": []
+    },
+    "szemeredi-hypergraph-core-oq-01-incomplete-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:36Z",
+      "result": "clean",
+      "issues": []
+    },
+    "taylor-sincos-convergence-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:36Z",
+      "result": "clean",
+      "issues": []
+    },
+    "taylor-theorem-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:36Z",
+      "result": "clean",
+      "issues": []
+    },
+    "tractatus-ontology": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:36Z",
+      "result": "clean",
+      "issues": []
+    },
+    "triangle-angle-sum-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:37Z",
+      "result": "clean",
+      "issues": []
+    },
+    "triangle-angle-sum-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:37Z",
+      "result": "clean",
+      "issues": []
+    },
+    "vietas-formulas-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:37Z",
+      "result": "clean",
+      "issues": []
+    },
+    "yang-mills-lattice-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-23T18:43:37Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {


### PR DESCRIPTION
## Summary
- Sync audit-tracker.json with 829 new audit entries from today's auditor runs

Automated sync from deployer agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)