### PR TITLE
Enrich ballot-problem-oq-03-oq-01-oq-04: Catalan Recurrence from Ballot Theorem

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-04/annotations.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-04/annotations.json
@@ -2,41 +2,73 @@
   {
     "id": "ann-ballot-oq04-header",
     "proofId": "ballot-problem-oq-03-oq-01-oq-04",
-    "range": { "startLine": 1, "endLine": 53 },
+    "range": { "startLine": 1, "endLine": 38 },
     "type": "concept",
     "title": "Catalan Recurrence from Ballot Theorem: Proof Architecture",
-    "content": "This file answers the open question from `ballot-problem-oq-03-oq-01` (LGV 2×2): prove the Catalan convolution recurrence using the ballot theorem. The proof has three layers:\n\n1. **Bridge** (`cn_eq_catalan`): Shows `LatticePathLGV.Cn n = catalan n` (Mathlib root namespace) by proving both satisfy `f(n)·(n+1) = Nat.centralBinom n`. This connects the ballot-formula Catalan numbers to Mathlib's infrastructure.\n\n2. **Recurrence** (`catalan_recurrence`): Uses Mathlib's `catalan_succ'` to prove `Cₙ₊₁ = ∑Cₖ·Cₙ₋ₖ` in the LatticePathLGV framework.\n\n3. **Ballot form** (`ballot_catalan_recurrence`): Translates the recurrence into ballot sequence counts using `catalan_eq_ballot`, giving a direct path-decomposition statement.",
-    "mathContext": "The central identity: $C_{n+1} = \\sum_{k=0}^{n} C_k C_{n-k}$ where $C_n = \\binom{2n}{n} - \\binom{2n}{n+1}$ is the ballot Catalan number. Equivalently in ballot language: $\\text{ballot}(n+2, n+1) = \\sum_{k=0}^n \\text{ballot}(k+1, k) \\cdot \\text{ballot}(n-k+1, n-k)$, where ballot$(p,q)$ counts voting sequences with $p$ A-votes and $q$ B-votes where A always leads.",
-    "significance": "key"
+    "content": "This file answers the open question from `ballot-problem-oq-03-oq-01` (LGV 2×2): prove the Catalan convolution recurrence using the ballot theorem. The proof has five parts:\n\n1. **Cn Definition** (`def Cn`): Ballot-formula Catalan numbers via binomial coefficients\n2. **Catalan Formula** (`catalan_formula`): The key identity Cn n * (n+1) = C(2n,n)\n3. **Bridge** (`Cn_eq_catalan`): Shows `Cn n = catalan n` (Mathlib root namespace)\n4. **Recurrence** (`Cn_recurrence`): Cₙ₊₁ = ∑Cₖ·Cₙ₋ₖ via Mathlib's `catalan_succ'`\n5. **Characterization** (`Cn_characterization`): C₀ = 1 and the recurrence uniquely determine the Catalan sequence\n\nThe proof is organized in namespace `BallotCatalanRecurrence`, opening `Nat`, `Finset`, and `BigOperators`.",
+    "mathContext": "The central identity: $C_{n+1} = \\sum_{k=0}^{n} C_k C_{n-k}$ where $C_n = \\binom{2n}{n} - \\binom{2n}{n+1} = \\frac{1}{n+1}\\binom{2n}{n}$ is the ballot Catalan number. The proof proceeds by bridging to Mathlib's `catalan` function via the shared characterization $C_n \\cdot (n+1) = \\binom{2n}{n}$.",
+    "significance": "key",
+    "relatedConcepts": ["Catalan numbers", "ballot problem", "Dyck paths", "convolution recurrence", "generating functions"],
+    "prerequisites": ["binomial coefficients", "Mathlib Catalan module", "Finset operations"]
+  },
+  {
+    "id": "ann-ballot-oq04-definition",
+    "proofId": "ballot-problem-oq-03-oq-01-oq-04",
+    "range": { "startLine": 40, "endLine": 83 },
+    "type": "definition",
+    "title": "Cn Definition and Catalan Formula",
+    "content": "The ballot-formula Catalan number `Cn n = C(2n,n) - C(2n,n+1)` counts monotone lattice paths from (0,0) to (2n,0) that stay non-negative (Dyck paths / ballot sequences). The private lemma `choose_2n_succ` proves `C(2n,n+1)*(n+1) = C(2n,n)*n` via Nat's absorption identity twice and row symmetry. From this, `catalan_formula` derives:\n\n- `Cn n * (n+1) = C(2n,n)*(n+1) - C(2n,n+1)*(n+1)`\n- `= C(2n,n)*(n+1) - C(2n,n)*n` (by choose_2n_succ)\n- `= C(2n,n)` ✓\n\nThe proof uses `zify` to convert natural number arithmetic to integers, then `linear_combination` to close.",
+    "mathContext": "The formula $C_n = \\binom{2n}{n} - \\binom{2n}{n+1}$ is the ballot-counting derivation: out of all $\\binom{2n}{n}$ paths, those that touch the x-axis are in bijection with unrestricted paths to $(2n,2)$ (reflection principle), giving $\\binom{2n}{n+1}$ bad paths. The key algebraic identity $\\binom{2n}{n+1} \\cdot (n+1) = \\binom{2n}{n} \\cdot n$ follows from the absorption identity $\\binom{m}{k} \\cdot k = \\binom{m}{k-1} \\cdot (m-k+1)$.",
+    "significance": "key",
+    "relatedConcepts": ["reflection principle", "Bertrand ballot theorem", "Dyck paths", "lattice paths", "binomial absorption"],
+    "prerequisites": ["Nat.choose", "absorption identity Nat.add_one_mul_choose_eq", "Nat.choose_symm_half", "zify tactic", "linear_combination tactic"]
   },
   {
     "id": "ann-ballot-oq04-bridge",
     "proofId": "ballot-problem-oq-03-oq-01-oq-04",
-    "range": { "startLine": 55, "endLine": 65 },
+    "range": { "startLine": 88, "endLine": 101 },
     "type": "technique",
     "title": "Bridge Lemma: Multiplicative Characterization Uniqueness",
-    "content": "The bridge `cn_eq_catalan` uses a clean technique: two natural-number-valued functions that agree on a multiplicative characterization must be equal.\n\n- `catalan_formula`: `Cn n * (n+1) = C(2n,n) = Nat.centralBinom n`\n- `catalan_eq_centralBinom_div`: `catalan n = Nat.centralBinom n / (n+1)`\n\nRewriting with `catalan_eq_centralBinom_div` and then `← catalan_formula` gives `Cn n = Cn n * (n+1) / (n+1)`, which closes by `Nat.mul_div_cancel`.\n\nThis bridge pattern generalizes: any function satisfying `f(n) * (n+1) = centralBinom n` equals `catalan n`. It is reusable for other Catalan-adjacent results in the LatticePathLGV framework.",
-    "mathContext": "The key identity: $C_n \\cdot (n+1) = \\binom{2n}{n}$. Combined with $\\text{catalan}(n) = \\binom{2n}{n}/(n+1)$ from Mathlib, this gives $\\text{Cn}(n) = \\text{catalan}(n)$ by natural number cancellation.",
-    "significance": "key"
+    "content": "The bridge `Cn_eq_catalan` uses a clean technique: two natural-number-valued functions that agree on a multiplicative characterization must be equal.\n\n- `catalan_formula`: `Cn n * (n+1) = C(2n,n) = Nat.centralBinom n`\n- `succ_mul_catalan_eq_centralBinom`: `(n+1) * catalan n = centralBinom n`\n\nApplying `Nat.eq_of_mul_eq_mul_right` with the nonzero right factor `n+1 > 0`, it suffices to show `Cn n * (n+1) = catalan n * (n+1)`, which follows from both equaling `centralBinom n`.\n\nThis bridge pattern generalizes: any natural-number function satisfying `f(n) * (n+1) = centralBinom n` equals `catalan n`. It is reusable for any Catalan-adjacent formalization in Lean 4.",
+    "mathContext": "The key identities: $C_n \\cdot (n+1) = \\binom{2n}{n}$ (proved as `catalan_formula`) and $(n+1) \\cdot \\text{catalan}(n) = \\text{centralBinom}(n) = \\binom{2n}{n}$ (Mathlib's `succ_mul_catalan_eq_centralBinom`). Since both expressions equal $\\binom{2n}{n}$ and multiplication by $n+1 > 0$ is injective on $\\mathbb{N}$, we get $C_n = \\text{catalan}(n)$.",
+    "significance": "key",
+    "relatedConcepts": ["multiplicative characterization", "uniqueness by cancellation", "centralBinom", "Mathlib catalan function"],
+    "prerequisites": ["catalan_formula", "succ_mul_catalan_eq_centralBinom", "Nat.centralBinom_eq_two_mul_choose", "Nat.eq_of_mul_eq_mul_right"]
   },
   {
     "id": "ann-ballot-oq04-recurrence",
     "proofId": "ballot-problem-oq-03-oq-01-oq-04",
-    "range": { "startLine": 68, "endLine": 90 },
+    "range": { "startLine": 107, "endLine": 122 },
     "type": "proof-step",
     "title": "Catalan Recurrence via Mathlib catalan_succ'",
-    "content": "The recurrence proof uses `conv_lhs => rw [cn_eq_catalan]` to rewrite only the LHS's `Cn (n+1)` as `catalan (n+1)`, avoiding issues with the RHS. Then:\n\n1. `catalan_succ'` rewrites to the antidiagonal form: `∑ p ∈ antidiagonal n, catalan p.1 * catalan p.2`\n2. `Finset.Nat.sum_antidiagonal_eq_sum_range_succ` converts to the range-sum form\n3. `Finset.sum_congr rfl` + `← cn_eq_catalan` converts each factor back to `Cn`",
-    "mathContext": "`catalan_succ'` is Mathlib's antidiagonal form: $C_{n+1} = \\sum_{(a,b) \\in \\text{antidiag}(n)} C_a \\cdot C_b$. After `sum_antidiagonal_eq_sum_range_succ`: $= \\sum_{k=0}^{n} C_k \\cdot C_{n-k}$.",
-    "significance": "key"
+    "content": "The recurrence proof `Cn_recurrence` is a 3-step rewrite chain using `simp_rw [Cn_eq_catalan]` to replace all `Cn` with `catalan`, then:\n\n1. `catalan_succ'` rewrites `catalan (n+1)` to the antidiagonal form: `∑ p ∈ antidiagonal n, catalan p.1 * catalan p.2`\n2. `Finset.Nat.sum_antidiagonal_eq_sum_range_succ` converts to the range-sum form `∑ k ∈ range (n+1), catalan k * catalan (n-k)`\n3. The goal closes because `Cn = catalan` everywhere (via `simp_rw`).\n\nThe proof is remarkably short (3 lines) because the heavy lifting is done by the bridge `Cn_eq_catalan` and Mathlib's `catalan_succ'`.",
+    "mathContext": "`catalan_succ'` is Mathlib's antidiagonal form: $C_{n+1} = \\sum_{(a,b) \\in \\text{antidiag}(n)} C_a \\cdot C_b$ where $\\text{antidiag}(n) = \\{(a,b) : a+b=n\\}$. After `sum_antidiagonal_eq_sum_range_succ`: $= \\sum_{k=0}^{n} C_k \\cdot C_{n-k}$, which is the standard range-indexed convolution.",
+    "significance": "key",
+    "relatedConcepts": ["antidiagonal Finset", "convolution recurrence", "Dyck path decomposition", "Catalan generating function C(x) = 1 + x·C(x)²"],
+    "prerequisites": ["Cn_eq_catalan", "catalan_succ'", "Finset.Nat.sum_antidiagonal_eq_sum_range_succ", "simp_rw tactic"]
+  },
+  {
+    "id": "ann-ballot-oq04-consequences",
+    "proofId": "ballot-problem-oq-03-oq-01-oq-04",
+    "range": { "startLine": 124, "endLine": 156 },
+    "type": "context",
+    "title": "Verifications, Base Cases, and Symmetry",
+    "content": "Part IV establishes several consequences of the recurrence:\n\n**Numerical verifications**: `native_decide` checks Cn 1 = Cn 0 * Cn 0, Cn 2 = ..., Cn 3 = ..., Cn 4 = ... These serve as sanity checks on the definition and recurrence.\n\n**Cn_pos**: Every Catalan number is strictly positive. Proof: from `catalan_formula`, `Cn n * (n+1) = C(2n,n) > 0`, so `Cn n ≠ 0`, so `Cn n > 0`.\n\n**Base cases**: `Cn_zero : Cn 0 = 1`, `Cn_one : Cn 1 = 1`, `Cn_two : Cn 2 = 2` — proved by `simp` or `native_decide`.\n\n**Symmetry**: `Cn_recurrence_sym` notes that the convolution sum is symmetric: `∑ Cₖ · Cₙ₋ₖ = ∑ Cₙ₋ₖ · Cₖ`, proved by `ring` on each summand.",
+    "mathContext": "The Catalan sequence begins $C_0=1, C_1=1, C_2=2, C_3=5, C_4=14, C_5=42, \\ldots$ (OEIS A000108). Positivity $C_n > 0$ follows from $C_n \\cdot (n+1) = \\binom{2n}{n} \\geq 1$ and $n+1 \\geq 1$. The symmetry $\\sum_{k=0}^n C_k C_{n-k} = \\sum_{k=0}^n C_{n-k} C_k$ is trivial but useful for identifying alternate forms in the literature.",
+    "significance": "supporting",
+    "relatedConcepts": ["Catalan sequence OEIS A000108", "positivity of combinatorial quantities", "recurrence symmetry", "native_decide"],
+    "prerequisites": ["Cn_recurrence", "catalan_formula", "Nat.choose_pos", "Nat.pos_of_ne_zero"]
   },
   {
     "id": "ann-ballot-oq04-ballot-form",
     "proofId": "ballot-problem-oq-03-oq-01-oq-04",
-    "range": { "startLine": 93, "endLine": 115 },
+    "range": { "startLine": 158, "endLine": 182 },
     "type": "concept",
-    "title": "Ballot Form: Path Decomposition Interpretation",
-    "content": "The ballot recurrence has a direct combinatorial meaning:\n\n`ballotSeqCount (n+2) (n+1)` counts voting sequences with n+2 A-votes and n+1 B-votes where A always strictly leads. Each such sequence can be decomposed at its **first return to minimum margin** (the first step where A's lead is exactly 1 again after the initial step). If this occurs at vote 2k+2:\n- The prefix (k+1 A-votes, k B-votes) is counted by `ballotSeqCount (k+1) k = Cₖ`\n- The suffix (n-k+1 A-votes, n-k B-votes) is counted by `ballotSeqCount (n-k+1) (n-k) = Cₙ₋ₖ`\n\nThe recurrence is thus a direct formalization of this bijective decomposition.",
-    "mathContext": "This is the ballot analog of the Dyck path first-return decomposition: each Dyck path of semilength $n+1$ returns to 0 for the first time at step $2k+2$ for some $k \\in \\{0, \\ldots, n\\}$, giving two shorter Dyck paths of semilengths $k$ and $n-k$.",
-    "significance": "high"
+    "title": "Ballot Interpretation and Characterization Theorem",
+    "content": "Part V provides two concluding results:\n\n**Cn_ballot_recurrence_interpretation**: The algebraic `Cn_recurrence` is restated with an attached docstring explaining the combinatorial meaning. A Dyck path of length 2(n+1) returns to 0 for the first time at step 2(k+1) for some k ∈ {0,...,n}, splitting into a prefix (length 2k) and suffix (length 2(n-k)), counted by `Cn k` and `Cn (n-k)` respectively. The convolution recurrence is thus a formal encoding of this bijection.\n\n**Cn_characterization**: Packages the initial condition `Cn 0 = 1` and the recurrence as an `And` proposition, providing the complete characterization: any sequence satisfying these two conditions is the Catalan sequence.",
+    "mathContext": "The characterization $C_0 = 1$, $C_{n+1} = \\sum_{k=0}^n C_k C_{n-k}$ uniquely determines the sequence $1, 1, 2, 5, 14, 42, \\ldots$ This is equivalent to the generating function equation $C(x) = 1 + x \\cdot C(x)^2$, whose solution is $C(x) = \\frac{1 - \\sqrt{1-4x}}{2x}$. In Lean, `Cn_characterization : Cn 0 = 1 ∧ ∀ n, Cn (n+1) = ∑ k ∈ range (n+1), Cn k * Cn (n-k)`.",
+    "significance": "key",
+    "relatedConcepts": ["Dyck path first-return decomposition", "ballot sequence decomposition", "Catalan generating function", "sequence characterization", "full binary trees"],
+    "prerequisites": ["Cn_zero", "Cn_recurrence", "Dyck paths", "first-return decomposition"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for **ballot-problem-oq-03-oq-01-oq-04** (Catalan Number Recurrence from the Ballot Theorem).

## Quality improvements

**Annotations (6, up from 4):**
- Added 2 new annotations for previously-uncovered Parts IV and V of the proof (lines 124–182)
- Added `relatedConcepts` and `prerequisites` to all annotations (previously missing on all)
- Fixed invalid `significance: "high"` → `"key"` on ballot-form annotation
- Added detailed `mathContext` for new annotations (Catalan generating function, OEIS A000108, positivity argument, Dyck path decomposition)

**Metadata corrections:**
- `lineCount`: 120 → 183 (actual Lean file is 183 lines)
- `leanFile.namespace`: `BallotProblemOQ03OQ01OQ04` → `BallotCatalanRecurrence` (actual namespace in file)
- `leanFile.imports`: removed non-existent `Proofs.BallotProblemOQ03` import; listed actual 4 Mathlib imports
- `leanFile.opens`: `[LatticePathLGV, Finset]` → `[Nat, Finset, BigOperators]` (actual opens)
- `leanFile.theoremCount`: 3 → 10 (catalan_formula, Cn_eq_catalan, Cn_recurrence, Cn_pos, Cn_zero, Cn_one, Cn_two, Cn_recurrence_sym, Cn_ballot_recurrence_interpretation, Cn_characterization)
- `leanFile.definitionCount`: 0 → 1 (`def Cn`)
- `mainTheorems`: fixed names (`cn_eq_catalan` → `Cn_eq_catalan`), replaced non-existent `ballot_catalan_recurrence` with actual `Cn_characterization`
- `assumptions` field: corrected `catalan_eq_centralBinom_div` → `succ_mul_catalan_eq_centralBinom`

**Sections (6, up from 3):**
- Split into 6 sections with accurate line ranges covering all 183 lines
- Each section has a `mathContext` field explaining the mathematics
- Added "Imports", "Definition", "Consequences", and "Characterization" sections

**keyInsights:** expanded from 4 → 5; added insight on `Cn_characterization` theorem packaging