### PR TITLE
Fix: sync stale leanFile.lineCount in 6 gallery meta.json files

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01/meta.json
@@ -22,7 +22,7 @@
     "dateAdded": "2026-04-02",
     "axiomCount": 0,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
-    "lineCount": 2898,
+    "lineCount": 2922,
     "theoremCount": 138,
     "definitionCount": 31,
     "originalContributions": [

--- a/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
@@ -79,7 +79,7 @@
     "dateAdded": "2026-03-22",
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
-    "lineCount": 2311,
+    "lineCount": 2511,
     "theoremCount": 82,
     "prerequisites": [
       "Matrix determinants and permutation signs (Mathlib)",

--- a/src/data/proofs/ballot-problem-oq-03/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03/meta.json
@@ -71,7 +71,7 @@
       "Lattice path combinatorics",
       "Basic Lean 4 induction and Fintype"
     ],
-    "lineCount": 2898,
+    "lineCount": 2922,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
   },
   "overview": {

--- a/src/data/proofs/erdos-622-oq-04/meta.json
+++ b/src/data/proofs/erdos-622-oq-04/meta.json
@@ -19,7 +19,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 180,
+    "lineCount": 215,
     "assumptions": "0 axioms, 0 sorries. All theorems fully proved from Mathlib.",
     "dateAdded": "2026-04-12",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/fourier-series-oq-02-oq-02/meta.json
+++ b/src/data/proofs/fourier-series-oq-02-oq-02/meta.json
@@ -64,7 +64,7 @@
       "Key insight: the condition α > 1/2 is exactly the threshold for the p-series 1/|n|^{2α} to converge (2α > 1)"
     ],
     "dateAdded": "2026-04-23",
-    "lineCount": 197,
+    "lineCount": 226,
     "assumptions": "None. All theorems including holder_half_is_critical_for_pseries (harmonic series sharpness) are fully proved.",
     "mathlib_version": "4.26.0",
     "prerequisites": [

--- a/src/data/proofs/shapley-folkman/meta.json
+++ b/src/data/proofs/shapley-folkman/meta.json
@@ -61,7 +61,7 @@
       "Caratheodory's theorem (points in convex hull need at most d+1 vertices)",
       "Affine independence and dimension"
     ],
-    "lineCount": 792,
+    "lineCount": 833,
     "mathlib_version": "4.26.0",
     "relatedProblems": []
   },
@@ -204,7 +204,7 @@
       "Pointwise"
     ],
     "namespace": "ShapleyFolkman",
-    "lineCount": 792,
+    "lineCount": 833,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 1,


### PR DESCRIPTION
## Gallery Integrity Fix

**Problem**: 6 gallery entries have stale `leanFile.lineCount` values after researchers added lines to Lean files without updating gallery metadata.

## Evidence

| Proof | Stored | Actual | Diff |
|-------|--------|--------|------|
| ballot-problem-oq-03 | 2898 | 2922 | +24 |
| ballot-problem-oq-03-oq-01 | 2898 | 2922 | +24 (same file) |
| ballot-problem-oq-03-oq-02 | 2311 | 2511 | +200 |
| erdos-622-oq-04 | 180 | 215 | +35 |
| fourier-series-oq-02-oq-02 | 197 | 226 | +29 |
| shapley-folkman | 792 | 833 | +41 |

## Verification

All sorry counts and axiom counts confirmed correct:
- ballot-problem-oq-03: 0 code sorries ✓
- ballot-problem-oq-03-oq-01: 0 code sorries ✓
- ballot-problem-oq-03-oq-02: 0 code sorries ✓
- erdos-622-oq-04: 0 code sorries ✓
- fourier-series-oq-02-oq-02: 0 code sorries ✓
- shapley-folkman: 3 code sorries ✓ (matches meta.sorries=3)

Only `lineCount` fields updated; all other metadata unchanged.

---
Automated fix by lean-mechanic agent.