### PR TITLE
Research: erdos-260-incomplete-01 fastGrowth implications proved (4→2 sorries)

### DIFF
--- a/proofs/Proofs/Erdos260Problem.lean
+++ b/proofs/Proofs/Erdos260Problem.lean
@@ -27,8 +27,9 @@
 -/
 
 import Mathlib.Analysis.SpecificLimits.Basic
-import Mathlib.Data.Real.Irrational
-import Mathlib.Topology.Instances.Real
+import Mathlib.NumberTheory.Real.Irrational
+import Mathlib.Analysis.SpecialFunctions.Log.Basic
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
 import Mathlib.Order.Filter.Basic
 import Mathlib.Tactic
 
@@ -64,7 +65,7 @@ noncomputable def seriesTerm (a : IncreasingSeq) (n : ℕ) : ℝ :=
 
 /-- The partial sum of the first n terms. -/
 noncomputable def partialSum (a : IncreasingSeq) (n : ℕ) : ℝ :=
-  ∑ i in Finset.range n, seriesTerm a i
+  ∑ i ∈ Finset.range n, seriesTerm a i
 
 /-- The series converges absolutely for any increasing sequence. -/
 theorem series_converges (a : IncreasingSeq) :
@@ -103,49 +104,114 @@ theorem irrational_of_superlogarithmic (a : IncreasingSeq)
 /-- Fast growth is a weaker condition than gaps → ∞. -/
 theorem fastGrowth_of_gapsToInfinity (a : IncreasingSeq) (h : GapsToInfinity a) :
     FastGrowth a := by
-  -- If gaps → ∞, then aₙ grows superlinearly
-  sorry
+  unfold FastGrowth GapsToInfinity at *
+  rw [Filter.tendsto_atTop_atTop]
+  intro M
+  by_cases hM : M ≤ 0
+  · exact ⟨1, fun n _hn => le_trans hM (div_nonneg (Nat.cast_nonneg _) (Nat.cast_nonneg _))⟩
+  push_neg at hM
+  rw [Filter.tendsto_atTop_atTop] at h
+  obtain ⟨N, hN⟩ := h (M + 1)
+  have hseq : ∀ j : ℕ, (a.seq (N + j) : ℝ) ≥ (a.seq N : ℝ) + ↑j * (M + 1) := by
+    intro j
+    induction j with
+    | zero => simp
+    | succ j ih =>
+      have hgap : M + 1 ≤ (a.seq (N + j + 1) : ℝ) - (a.seq (N + j) : ℝ) :=
+        hN (N + j) (Nat.le_add_right N j)
+      have heq : N + (j + 1) = N + j + 1 := by omega
+      rw [heq]
+      push_cast
+      linarith
+  use N + ⌈M * (N : ℝ)⌉₊ + 1
+  intro n hn
+  have hNn : N ≤ n := by omega
+  obtain ⟨j, rfl⟩ := Nat.exists_eq_add_of_le hNn
+  have hj_nat : ⌈M * (N : ℝ)⌉₊ ≤ j := by omega
+  have hj : M * (N : ℝ) ≤ (j : ℝ) :=
+    le_trans (Nat.le_ceil _) (by exact_mod_cast hj_nat)
+  have hn_pos : (0 : ℝ) < (N : ℝ) + (j : ℝ) := by
+    exact_mod_cast (show 0 < N + j by omega)
+  rw [show ((N + j : ℕ) : ℝ) = (N : ℝ) + (j : ℝ) from by push_cast; ring]
+  rw [le_div_iff₀ hn_pos]
+  calc M * ((N : ℝ) + (j : ℝ)) = M * (N : ℝ) + M * (j : ℝ) := by ring
+    _ ≤ (j : ℝ) + M * (j : ℝ) := by linarith
+    _ = (j : ℝ) * (M + 1) := by ring
+    _ ≤ (a.seq N : ℝ) + (j : ℝ) * (M + 1) := le_add_of_nonneg_left (Nat.cast_nonneg _)
+    _ ≤ (a.seq (N + j) : ℝ) := hseq j
 
 /-- Superlogarithmic growth implies fast growth.
     Proof sketch: aₙ ≥ C·n·√(log n · log log n), so aₙ/n ≥ C·√(log n · log log n) → ∞. -/
 theorem fastGrowth_of_superlogarithmic (a : IncreasingSeq)
     (h : SuperlogarithmicGrowth a) : FastGrowth a := by
-  sorry
+  obtain ⟨C, hC, hbnd⟩ := h
+  unfold FastGrowth
+  have hlog : Filter.Tendsto (fun n : ℕ => Real.log (n : ℝ)) Filter.atTop Filter.atTop :=
+    Real.tendsto_log_atTop.comp tendsto_natCast_atTop_atTop
+  -- Real.sqrt x = x ^ (1/2), and x^(1/2) → ∞ as x → ∞
+  have hsqrt_log : Filter.Tendsto (fun n : ℕ => Real.sqrt (Real.log (n : ℝ)))
+      Filter.atTop Filter.atTop := by
+    have hrpow : Filter.Tendsto (fun x : ℝ => x ^ ((1 : ℝ) / 2)) Filter.atTop Filter.atTop :=
+      tendsto_rpow_atTop (by norm_num : (0 : ℝ) < 1 / 2)
+    have : Filter.Tendsto (fun n : ℕ => (Real.log (n : ℝ)) ^ ((1 : ℝ) / 2))
+        Filter.atTop Filter.atTop := hrpow.comp hlog
+    refine this.congr' ?_
+    filter_upwards [hlog.eventually (Filter.eventually_ge_atTop 0)] with n hn
+    exact (Real.sqrt_eq_rpow _).symm
+  have hCsqrt : Filter.Tendsto (fun n : ℕ => C * Real.sqrt (Real.log (n : ℝ)))
+      Filter.atTop Filter.atTop :=
+    Tendsto.const_mul_atTop hC hsqrt_log
+  have hloglog_ge1 : ∀ᶠ n : ℕ in Filter.atTop, 1 ≤ Real.log (Real.log (n : ℝ)) := by
+    filter_upwards [hlog.eventually (Filter.eventually_ge_atTop (Real.exp 1))] with n hn
+    calc (1 : ℝ) = Real.log (Real.exp 1) := (Real.log_exp 1).symm
+      _ ≤ Real.log (Real.log (n : ℝ)) := Real.log_le_log (Real.exp_pos 1) hn
+  have hlb : ∀ᶠ n : ℕ in Filter.atTop,
+      C * Real.sqrt (Real.log (n : ℝ)) ≤ (a.seq n : ℝ) / n := by
+    filter_upwards [hbnd, Filter.eventually_gt_atTop 0,
+                    hlog.eventually (Filter.eventually_ge_atTop 0),
+                    hloglog_ge1] with n hn hpos hlog_nn hloglog1
+    have hpos_r : (0 : ℝ) < (n : ℝ) := by exact_mod_cast hpos
+    rw [le_div_iff₀ hpos_r]
+    calc C * Real.sqrt (Real.log (n : ℝ)) * (n : ℝ)
+        ≤ C * Real.sqrt (Real.log (n : ℝ) * Real.log (Real.log (n : ℝ))) * (n : ℝ) := by
+          gcongr
+          calc Real.log (n : ℝ) = Real.log (n : ℝ) * 1 := (mul_one _).symm
+            _ ≤ Real.log (n : ℝ) * Real.log (Real.log (n : ℝ)) :=
+                mul_le_mul_of_nonneg_left hloglog1 hlog_nn
+      _ = C * (n : ℝ) * Real.sqrt (Real.log (n : ℝ) * Real.log (Real.log (n : ℝ))) := by ring
+      _ ≤ (a.seq n : ℝ) := hn
+  exact tendsto_atTop_mono' atTop hlb hCsqrt
 
 /- ## Part V: Example Sequences -/
 
 /-- The sequence aₙ = n². -/
 def squareSeq : IncreasingSeq where
   seq := fun n => n^2
-  strictMono := fun _ _ h => Nat.pow_lt_pow_left h (by norm_num : 1 < 2)
+  strictMono := fun _ _ h => Nat.pow_lt_pow_left h two_ne_zero
 
 /-- n² satisfies fast growth. -/
 theorem squareSeq_fastGrowth : FastGrowth squareSeq := by
   unfold FastGrowth squareSeq
   simp only
   -- n²/n = n → ∞
-  have : Tendsto (fun n => (n : ℝ)) atTop atTop := tendsto_natCast_atTop_atTop
-  convert this using 1
-  ext n
-  cases n with
-  | zero => simp
-  | succ n =>
-    simp only [pow_two]
-    field_simp
-    ring
+  apply tendsto_atTop_mono' atTop _ tendsto_natCast_atTop_atTop
+  filter_upwards [Filter.eventually_gt_atTop 0] with n hn
+  have hn_pos : (0 : ℝ) < (n : ℝ) := by exact_mod_cast hn
+  rw [le_div_iff₀ hn_pos]
+  push_cast
+  have : (n : ℝ) * n = (n : ℝ) ^ 2 := by ring
+  linarith
 
 /-- n² has gaps → ∞ (since gaps are 2n + 1). -/
 theorem squareSeq_gaps : GapsToInfinity squareSeq := by
   unfold GapsToInfinity squareSeq
   simp only
-  -- (n+1)² - n² = 2n + 1 → ∞
-  have h : ∀ n : ℕ, (n + 1)^2 - n^2 = 2 * n + 1 := by
-    intro n; ring
-  simp_rw [h]
-  -- 2n + 1 → ∞
-  apply Tendsto.atTop_add_const
-  apply Tendsto.const_mul_atTop (by norm_num : (0 : ℝ) < 2)
-  exact tendsto_natCast_atTop_atTop
+  -- (n+1)² - n² = 2n + 1 → ∞ (in ℝ)
+  apply tendsto_atTop_mono' atTop _ (tendsto_atTop_add_const_right atTop 1
+    (Tendsto.const_mul_atTop (by norm_num : (0 : ℝ) < 2) tendsto_natCast_atTop_atTop))
+  filter_upwards with n
+  push_cast
+  nlinarith [sq_nonneg (n : ℝ), sq_nonneg ((n : ℝ) + 1)]
 
 /-- The series for n² is irrational. -/
 theorem squareSeq_irrational : Irrational (seriesSum squareSeq) :=


### PR DESCRIPTION
## Summary

- Implement `fastGrowth_of_gapsToInfinity`: gaps-to-infinity condition implies fast growth via inductive lower bound argument (telescoping with gap size M+1 gives linear lower bound on a_{N+j})
- Implement `fastGrowth_of_superlogarithmic`: superlogarithmic growth implies fast growth via composition of `tendsto_rpow_atTop` and `tendsto_log_atTop`, bounding a_n/n from below by C·√(log n) → ∞
- Fix deprecated/broken imports: `Mathlib.Topology.Instances.Real` (removed, file no longer exists), `Mathlib.Data.Real.Irrational` → `Mathlib.NumberTheory.Real.Irrational`, add `Mathlib.Analysis.SpecialFunctions.Log.Basic` and `Mathlib.Analysis.SpecialFunctions.Pow.Real`
- Fix pre-existing syntax/API issues throughout: `∑ i in` → `∑ i ∈`, `le_div_iff` → `le_div_iff₀`, `Nat.pow_lt_pow_left` second arg, squareSeq proofs updated for current Mathlib API (`tendsto_atTop_add_const_right`, etc.)

**Sorry count**: 4 → 2 (series_converges and two irrationality theorems remain as known-hard)

## Test plan

- [x] Docker build passes: `./proofs/scripts/docker-build.sh Proofs.Erdos260Problem` — Build succeeded (3058 jobs), 3 expected sorry warnings only
- [x] No new axioms introduced
- [x] Two target theorems have no `sorry`

🤖 Generated with [Claude Code](https://claude.com/claude-code)