### PR TITLE
Enrich abel-ruffini-oq-04-oq-01: fix annotation line ranges for Vandermonde sections

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01/annotations.json
@@ -248,8 +248,8 @@
     "id": "ann-abeloq04oq01-vandermonde",
     "proofId": "abel-ruffini-oq-04-oq-01",
     "range": {
-      "startLine": 635,
-      "endLine": 826
+      "startLine": 508,
+      "endLine": 634
     },
     "type": "technique",
     "title": "Vandermonde Product Infrastructure and Permutation Identity",
@@ -477,8 +477,8 @@
     "id": "ann-abeloq04oq01-sq-val",
     "proofId": "abel-ruffini-oq-04-oq-01",
     "range": {
-      "startLine": 723,
-      "endLine": 756
+      "startLine": 635,
+      "endLine": 826
     },
     "type": "technique",
     "title": "The Discriminant Computation: Δ² = -212144 (Tour de Force)",


### PR DESCRIPTION
Fix overlapping ranges for Part VI and VII annotations. ann-part-vi-threshold: 151-163, ann-part-vii-historical: 164-185.