### PR TITLE
Enrich abel-ruffini: fix overlapping Part VI/VII annotation ranges

### DIFF
--- a/src/data/proofs/abel-ruffini/annotations.json
+++ b/src/data/proofs/abel-ruffini/annotations.json
@@ -342,7 +342,7 @@
     "proofId": "abel-ruffini",
     "range": {
       "startLine": 151,
-      "endLine": 183
+      "endLine": 163
     },
     "type": "insight",
     "title": "Part VI: Why Degree 5 Is the Exact Threshold",
@@ -369,8 +369,8 @@
     "id": "ann-part-vii-historical",
     "proofId": "abel-ruffini",
     "range": {
-      "startLine": 151,
-      "endLine": 183
+      "startLine": 164,
+      "endLine": 185
     },
     "type": "context",
     "title": "Part VII: The Impossibility Paradigm and Historical Significance",


### PR DESCRIPTION
Enrichment pass for abel-ruffini. Fixes incorrect annotation line ranges.

ann-part-vi-threshold: corrected range from 151-183 to 151-163 (Part VI ends at line 163)
ann-part-vii-historical: corrected range from 151-183 to 164-185 (Part VII starts at line 164, end AbelRuffini is line 185)

Both annotations shared the same incorrect range. Ranges now match section definitions in meta.json.