### PR TITLE
Fix: erdos-260 meta.json — correct sorry count from 5 to 3

### DIFF
--- a/src/data/proofs/erdos-260/meta.json
+++ b/src/data/proofs/erdos-260/meta.json
@@ -17,7 +17,7 @@
       "number-theory"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 3,
     "erdosNumber": 260,
     "erdosUrl": "https://erdosproblems.com/260",
     "erdosProblemStatus": "open",
@@ -51,7 +51,7 @@
     ],
     "axiomCount": 1,
     "lineCount": 203,
-    "assumptions": "1 axiom: erdos_260_conjecture (open conjecture). 5 sorries: series_converges (convergence argument), irrational_of_gaps_to_infinity (Erdős 1974 theorem), irrational_of_superlogarithmic (number-theoretic result), fastGrowth_of_gapsToInfinity (Stolz-Cesàro argument), fastGrowth_of_superlogarithmic (basic analysis)."
+    "assumptions": "1 axiom: erdos_260_conjecture (open conjecture). 3 sorries: series_converges (convergence argument), irrational_of_gaps_to_infinity (Erdős 1974 theorem), irrational_of_superlogarithmic (number-theoretic result)."
   },
   "overview": {
     "historicalContext": "This problem originates from Erdős's 1974 work on irrationality of series [Er74b], further developed in the landmark monograph 'Old and New Problems and Results in Combinatorial Number Theory' with Graham [ErGr80]. It explores a fundamental question at the boundary of analysis and number theory: when does a lacunary (sparse) series produce an irrational sum?\n\nErdős proved that irrationality holds under the stronger condition that the gaps a_{n+1} − aₙ tend to infinity. He also showed irrationality when aₙ grows superlogarithmically, specifically when aₙ ≫ n√(log n · log log n). These partial results demonstrate that 'sufficiently fast' growth guarantees irrationality, but the full conjecture — that the mere condition aₙ/n → ∞ suffices — remains open.\n\nThe problem has an appealing simplicity: the series ∑ aₙ/2^{aₙ} converges absolutely for any increasing sequence (the terms decrease exponentially), so the question is purely about the arithmetic nature of the limit. Erdős and Graham speculated that even having limsup of the gaps being infinite might not suffice for irrationality, but no counterexample has been found. The problem connects to the theory of lacunary series, normal numbers, and the Lindemann-Weierstrass theorem.",
@@ -166,7 +166,7 @@
     "theoremCount": 8,
     "definitionCount": 8,
     "path": "Proofs/Erdos260Problem.lean",
-    "sorries": 5
+    "sorries": 3
   },
   "references": [
     {
@@ -197,5 +197,5 @@
       "description": "Related Erdős problem sharing themes: irrationality, number-theory, series"
     }
   ],
-  "sorries": 5
+  "sorries": 3
 }


### PR DESCRIPTION
## Summary

- Corrects stale sorry count in `src/data/proofs/erdos-260/meta.json` from 5 to 3
- Updates `meta.sorries`, `leanFile.sorries`, and top-level `sorries` fields
- Updates `assumptions` text to reflect the 3 remaining sorries

## Context

Found during gallery integrity audit. The Lean file `proofs/Proofs/Erdos260Problem.lean` has had 2 sorries resolved since the last meta.json update:

- `fastGrowth_of_gapsToInfinity` -- now fully proved (Stolz-Cesaro argument, ~40 lines)
- `fastGrowth_of_superlogarithmic` -- now fully proved (basic analysis, ~40 lines)

The 3 remaining sorries are:
1. `series_converges` (line 75) -- convergence argument
2. `irrational_of_gaps_to_infinity` (line 91) -- Erdos 1974 theorem
3. `irrational_of_superlogarithmic` (line 100) -- number-theoretic result

## Test plan

- [ ] Verify `meta.sorries`, `leanFile.sorries`, and top-level `sorries` all read 3
- [ ] Verify `assumptions` text lists only the 3 remaining sorries
- [ ] Confirm no other fields were modified