### PR TITLE
Enrich fourier-series-oq-02-oq-02 and ballot-problem-oq-03-oq-01-oq-04: fix stale metadata

### DIFF
--- a/src/data/proofs/fourier-series-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/fourier-series-oq-02-oq-02/annotations.json
@@ -74,14 +74,14 @@
   {
     "id": "ann-fsoq02oq02-sharpness",
     "proofId": "fourier-series-oq-02-oq-02",
-    "range": { "startLine": 189, "endLine": 196 },
+    "range": { "startLine": 189, "endLine": 224 },
     "type": "insight",
-    "title": "Sharpness: α = 1/2 is the Critical Threshold (with sorry)",
-    "content": "`holder_half_is_critical_for_pseries` states that the p-series argument fails at exactly $\\alpha = 1/2$: the squared bound becomes $O(|n|^{-1})$ and the harmonic series $\\sum 1/|n|$ diverges over $\\mathbb{Z}$.\n\nThis theorem is left with a `sorry` because harmonic series divergence over $\\mathbb{Z}$ ($\\sum_{n \\neq 0} 1/|n| = \\infty$) is not immediately available in Mathlib in this form. The real question is: `¬ Summable (fun n : ℤ => K / |n|^1)` — a consequence of `Real.summable_nat_rpow_inv` going the other direction, but requiring extra work to transfer from $\\mathbb{N}$ to $\\mathbb{Z}$.\n\nNote: The sorry is in the sharpness statement only. The main results (Parts I–III) are sorry-free.",
-    "mathContext": "At $\\alpha = 1/2$: squared bound $= K/|n|^1$ = harmonic series. Mathlib has `Real.summable_nat_rpow_inv.1 (not_lt.mpr h)` for the divergence direction over $\\mathbb{N}$; extending to $\\mathbb{Z}$ requires additional argument. The sorry has a clear statement and clear proof path — it is a definitional gap, not a conceptual gap.",
+    "title": "Sharpness: α = 1/2 is the Critical Threshold",
+    "content": "`holder_half_is_critical_for_pseries` proves that the p-series argument fails at exactly $\\alpha = 1/2$: the squared bound becomes $O(|n|^{-1})$ and the harmonic series $\\sum 1/|n|$ diverges.\n\nThe proof is fully machine-checked. The key technique avoids direct ℤ-harmonic series divergence. Instead:\n1. Assume the universal summability statement for all Hölder functions at $\\alpha = 1/2$\n2. Instantiate with the zero function $f = 0$ (trivially Hölder with constant 1, exponent $1/2$) and $T = 2\\pi$, $C = 1$\n3. Apply `summable_int_iff_summable_nat_and_neg` to extract ℕ summability of the positive half\n4. Rescale by $4/\\pi$ via `.mul_left (4 / Real.pi)` and algebraic simplification to recover `Summable (fun n : ℕ => 1 / n)`\n5. Derive contradiction: `Real.summable_nat_rpow_inv.not.mpr (by norm_num)` shows the harmonic series over ℕ diverges (p=1 fails p > 1)\n\nThis routing through ℕ elegantly sidesteps the need to prove ℤ-harmonic divergence directly.",
+    "mathContext": "The theorem negates: $\\forall C, \\alpha, f$, if $(\\alpha : \\mathbb{R}) = 1/2$ and $f$ is $\\alpha$-Hölder, then $\\sum_{n:\\mathbb{Z}} (C/2)^2 \\pi^{2\\alpha} / |n|^{2\\alpha}$ converges. Taking $f=0$, $C=1$, $\\alpha=1/2$: the summability hypothesis reduces to $\\sum_{n:\\mathbb{N}} (1/4)\\pi / |n|$ being summable. Rescaling by $4/\\pi$ gives $\\sum_{n:\\mathbb{N}} 1/n$ summable — contradicting `Real.summable_nat_rpow_inv.not.mpr (by norm_num : ¬ 1 < 1)`.",
     "significance": "supporting",
-    "relatedConcepts": ["harmonic series divergence", "sharp threshold", "critical Hölder exponent", "Mathlib sorry"],
-    "prerequisites": ["Real.summable_nat_rpow_inv divergence direction", "integer harmonic series"]
+    "relatedConcepts": ["harmonic series divergence", "sharp threshold", "critical Hölder exponent", "Real.summable_nat_rpow_inv"],
+    "prerequisites": ["Real.summable_nat_rpow_inv divergence direction", "summable_int_iff_summable_nat_and_neg"]
   },
   {
     "id": "ann-fsoq02oq02-comparison",

--- a/src/data/proofs/fourier-series-oq-02-oq-02/meta.json
+++ b/src/data/proofs/fourier-series-oq-02-oq-02/meta.json
@@ -127,9 +127,9 @@
       "id": "part-iv-corollaries",
       "title": "Part IV: Corollaries and Sharpness",
       "startLine": 165,
-      "endLine": 197,
+      "endLine": 226,
       "summary": "Three theorems: sq_summable_matches_parseval (aliases the main theorem, matching the parent's conclusion), fourier_coeff_l2 (existential HasSum form), and holder_half_is_critical_for_pseries (sharpness: α = 1/2 fails the p-series test — harmonic series diverges, fully proved).",
-      "mathContext": "Sharpness at $\\alpha = 1/2$: squared bound $= K/|n|^1$ = harmonic series, which diverges over $\\mathbb{Z}$. The sorry requires `¬Summable (fun n:ℤ => K/|↑n|)` — a consequence of `Real.summable_nat_rpow_inv` in the divergence direction, not yet transferred to $\\mathbb{Z}$ in this form."
+      "mathContext": "Sharpness at $\\alpha = 1/2$: `holder_half_is_critical_for_pseries` is fully proved. The proof assumes the universal summability statement, instantiates with the zero function (Hölder with any exponent), applies `summable_int_iff_summable_nat_and_neg` to extract the ℕ positive half, then rescales via `.mul_left (4/π)` to recover the harmonic series $\\sum 1/n$. Contradiction follows from `Real.summable_nat_rpow_inv.not.mpr (by norm_num)` (p=1 fails $p > 1$ criterion). This avoids direct ℤ-harmonic series divergence by routing through ℕ."
     }
   ],
   "conclusion": {
@@ -166,7 +166,7 @@
       "FourierHolderDecay"
     ],
     "namespace": "FourierSqSummablePSeries",
-    "lineCount": 197,
+    "lineCount": 226,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 0,


### PR DESCRIPTION
## Summary

### fourier-series-oq-02-oq-02
- `meta.json`: `leanFile.lineCount` 197 → 226 (actual file has 226 lines)
- `meta.json`: Part IV section `endLine` 197 → 226; `mathContext` updated
- `annotations.json`: `ann-fsoq02oq02-sharpness` range `endLine` 196 → 224 (theorem body spans lines 189–224)
- `annotations.json`: Removed stale `(with sorry)` title and sorry references; `holder_half_is_critical_for_pseries` is fully machine-checked

### ballot-problem-oq-03-oq-01-oq-04
- `meta.lineCount` + `leanFile.lineCount`: 120 → 182 (actual file has 182 lines)
- `leanFile.namespace`: `BallotProblemOQ03OQ01OQ04` → `BallotCatalanRecurrence`
- `leanFile.imports`: replace placeholder `[Mathlib, BallotProblemOQ03]` with actual imports
- `leanFile.opens`: `Nat + Finset + BigOperators` (was `LatticePathLGV + Finset`)
- `leanFile.theoremCount`: 3 → 10; `definitionCount`: 0 → 1 (`def Cn`)
- `sections`: rewrite all 3 entries (wrong ranges 55–115) as 5 accurate sections matching actual Parts I–V (lines 36–182)
- `mainTheorems`: fix theorem names (`cn_eq_catalan` → `Cn_eq_catalan`; replace nonexistent `ballot_catalan_recurrence` with actual `Cn_characterization`)
- `crossReferences`: remove false import claim for `BallotProblemOQ03`

🤖 Generated with [Claude Code](https://claude.com/claude-code)