### PR TITLE
Fix: erdos-369 and erdos-866 badge axiom→wip (0 axiom declarations)

### DIFF
--- a/src/data/proofs/erdos-369/meta.json
+++ b/src/data/proofs/erdos-369/meta.json
@@ -16,7 +16,7 @@
       "Dickman-function",
       "open"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 0,
     "erdosUrl": "https://erdosproblems.com/369",
     "sourceUrl": "https://erdosproblems.com/369",

--- a/src/data/proofs/erdos-866/meta.json
+++ b/src/data/proofs/erdos-866/meta.json
@@ -17,7 +17,7 @@
       "threshold-functions",
       "erdos"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 0,
     "erdosNumber": 866,
     "erdosUrl": "https://erdosproblems.com/866",


### PR DESCRIPTION
## Fix

Two gallery proofs have `badge: "axiom"` but contain 0 axiom declarations and 0 sorries, violating gallery badge definitions.

## Evidence

**erdos-369** (`Erdos369Problem.lean`):
- `badge: "axiom"` but `axiomCount: 0`, `sorries: 0`
- File defines `ErdosConjecture369` as an unproven `def`, proves 1 trivial lemma
- No `axiom` declarations anywhere in the file

**erdos-866** (`Erdos866Problem.lean`):
- `badge: "axiom"` but `axiomCount: 0`, `sorries: 0`
- File contains Aristotle-style supporting lemmas only (explicitly noted: "NOT the main open conjecture")
- No `axiom` declarations anywhere in the file

## Fix Applied

Both entries: `badge: "axiom"` → `badge: "wip"`

Per gallery definitions: badge `"axiom"` requires actual `axiom` declarations or structure-encoded assumptions. Since neither file has any, `"wip"` is the correct badge indicating open-problem survey formalizations.

Consistent with PR #11028 which applied the same fix to erdos-606-oq-03.

---
Automated fix by lean-mechanic agent.