### PR TITLE
Fix: erdos-260 meta.json — sync sorry count (5→3) and lineCount (203→269)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4117,9 +4117,9 @@
     },
     "erdos-260": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:29:53Z",
-      "result": "clean"
+      "auditCount": 3,
+      "lastAudited": "2026-04-23T00:00:00Z",
+      "result": "issues-fixed"
     },
     "erdos-261": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-260/meta.json
+++ b/src/data/proofs/erdos-260/meta.json
@@ -17,7 +17,7 @@
       "number-theory"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 3,
     "erdosNumber": 260,
     "erdosUrl": "https://erdosproblems.com/260",
     "erdosProblemStatus": "open",
@@ -50,8 +50,8 @@
       "Proved convergence of the series under fast growth"
     ],
     "axiomCount": 1,
-    "lineCount": 203,
-    "assumptions": "1 axiom: erdos_260_conjecture (open conjecture). 5 sorries: series_converges (convergence argument), irrational_of_gaps_to_infinity (Erdős 1974 theorem), irrational_of_superlogarithmic (number-theoretic result), fastGrowth_of_gapsToInfinity (Stolz-Cesàro argument), fastGrowth_of_superlogarithmic (basic analysis)."
+    "lineCount": 269,
+    "assumptions": "1 axiom: erdos_260_conjecture (open conjecture). 3 sorries: series_converges (convergence argument), irrational_of_gaps_to_infinity (Erdős 1974 theorem), irrational_of_superlogarithmic (number-theoretic result). 2 previously-sorry'd theorems now fully proved: fastGrowth_of_gapsToInfinity (Stolz-Cesàro argument), fastGrowth_of_superlogarithmic (basic analysis)."
   },
   "overview": {
     "historicalContext": "This problem originates from Erdős's 1974 work on irrationality of series [Er74b], further developed in the landmark monograph 'Old and New Problems and Results in Combinatorial Number Theory' with Graham [ErGr80]. It explores a fundamental question at the boundary of analysis and number theory: when does a lacunary (sparse) series produce an irrational sum?\n\nErdős proved that irrationality holds under the stronger condition that the gaps a_{n+1} − aₙ tend to infinity. He also showed irrationality when aₙ grows superlogarithmically, specifically when aₙ ≫ n√(log n · log log n). These partial results demonstrate that 'sufficiently fast' growth guarantees irrationality, but the full conjecture — that the mere condition aₙ/n → ∞ suffices — remains open.\n\nThe problem has an appealing simplicity: the series ∑ aₙ/2^{aₙ} converges absolutely for any increasing sequence (the terms decrease exponentially), so the question is purely about the arithmetic nature of the limit. Erdős and Graham speculated that even having limsup of the gaps being infinite might not suffice for irrationality, but no counterexample has been found. The problem connects to the theory of lacunary series, normal numbers, and the Lindemann-Weierstrass theorem.",
@@ -107,33 +107,33 @@
     {
       "id": "implications",
       "title": "Growth Condition Implications",
-      "summary": "The implication chain: GapsToInfinity $\\Rightarrow$ FastGrowth $\\Leftarrow$ SuperlogarithmicGrowth. Both proofs use telescoping/growth comparison arguments (both `sorry`).",
+      "summary": "The implication chain: GapsToInfinity $\\Rightarrow$ FastGrowth $\\Leftarrow$ SuperlogarithmicGrowth. Both implications are fully proved: `fastGrowth_of_gapsToInfinity` uses a Stolz-Cesàro-style telescoping argument, and `fastGrowth_of_superlogarithmic` uses rpow monotonicity and log growth estimates.",
       "startLine": 101,
-      "endLine": 114,
-      "mathContext": "Verified: The implication chain: GapsToInfinity $\\Rightarrow$ FastGrowth $\\Leftarrow$ SuperlogarithmicGrowth. Both proofs use telescoping/growth comparison arguments (both `sorry`)."
+      "endLine": 184,
+      "mathContext": "The implication chain: GapsToInfinity $\\Rightarrow$ FastGrowth $\\Leftarrow$ SuperlogarithmicGrowth. Both implications are fully proved: `fastGrowth_of_gapsToInfinity` uses a Stolz-Cesàro-style telescoping argument, and `fastGrowth_of_superlogarithmic` uses rpow monotonicity and log growth estimates."
     },
     {
       "id": "examples",
       "title": "Example: Square Sequence",
       "summary": "The sequence $a_n = n^2$: strict monotonicity, fast growth ($n^2/n = n \\to \\infty$, fully proved), gaps $\\to \\infty$ ($2n+1 \\to \\infty$, fully proved), and irrationality of $\\sum n^2/2^{n^2}$ (by composition).",
-      "startLine": 115,
-      "endLine": 153,
+      "startLine": 185,
+      "endLine": 219,
       "mathContext": "The sequence $a_n = n^2$: strict monotonicity, fast growth ($n^2/n = n \\to \\infty$, fully proved), gaps $\\to \\infty$ ($2n+1 \\to \\infty$, fully proved), and irrationality of $\\sum n^2/2^{n^2}$ (by composition)."
     },
     {
       "id": "conjecture",
       "title": "Main Conjecture and Counterexample Specification",
       "summary": "The open conjecture (axiom): $\\mathrm{FastGrowth}(a) \\Rightarrow \\mathrm{Irrational}(\\sum a_n/2^{a_n})$. Plus the Erdős-Graham counterexample specification: what a sequence with $\\limsup(\\text{gaps}) = \\infty$ but rational sum would look like.",
-      "startLine": 154,
-      "endLine": 180,
+      "startLine": 220,
+      "endLine": 245,
       "mathContext": "The open conjecture (axiom): $\\mathrm{FastGrowth}(a) \\Rightarrow \\mathrm{Irrational}(\\sum a_n/2^{a_n})$. Plus the Erdős-Graham counterexample specification: what a sequence with $\\limsup(\\text{gaps}) = \\infty$ but rational sum would look like."
     },
     {
       "id": "summary",
       "title": "Summary Comments",
       "summary": "End-of-file documentation: status (OPEN), what's formalized, key sorries, and what a proof would require.",
-      "startLine": 181,
-      "endLine": 203,
+      "startLine": 247,
+      "endLine": 269,
       "mathContext": "Verified: End-of-file documentation: status (OPEN), what's formalized, key sorries, and what a proof would require."
     }
   ],
@@ -161,12 +161,12 @@
       "Topology"
     ],
     "namespace": "Erdos260",
-    "lineCount": 203,
+    "lineCount": 269,
     "axiomCount": 1,
     "theoremCount": 8,
     "definitionCount": 8,
     "path": "Proofs/Erdos260Problem.lean",
-    "sorries": 5
+    "sorries": 3
   },
   "references": [
     {
@@ -197,5 +197,5 @@
       "description": "Related Erdős problem sharing themes: irrationality, number-theory, series"
     }
   ],
-  "sorries": 5
+  "sorries": 3
 }


### PR DESCRIPTION
## Summary

- Sorry count corrected from 5 to 3: `fastGrowth_of_gapsToInfinity` (lines 105–144) and `fastGrowth_of_superlogarithmic` (lines 145–184) are now fully proved in the Lean file, so they are no longer sorries.
- Line count updated from 203 to 269 to reflect the added proof bodies (~40 lines each).
- Section line numbers updated: `implications` endLine 114→184, `examples` startLine 115→185 / endLine 153→219, `conjecture` startLine 154→220 / endLine 180→245, `summary` startLine 181→247 / endLine 203→269.
- `meta.assumptions` updated to accurately describe 1 axiom + 3 remaining sorries + 2 newly proved theorems.
- `implications` section summary and mathContext updated to remove stale "both \`sorry\`" language and describe the actual proof techniques used.
- Audit tracker entry for `erdos-260`: `result` changed to `"issues-fixed"`, `lastAudited` updated to `2026-04-23T00:00:00Z`, `auditCount` incremented to 3.

## Test plan

- [ ] Verify `meta.sorries`, `leanFile.sorries`, and top-level `sorries` all read `3`
- [ ] Verify `leanFile.lineCount` and `meta.lineCount` both read `269`
- [ ] Verify section line ranges are consistent with grep of `git show HEAD:proofs/Proofs/Erdos260Problem.lean`
- [ ] Confirm audit-tracker entry for `erdos-260` shows `issues-fixed` with today's date

🤖 Generated with [Claude Code](https://claude.com/claude-code)