### PR TITLE
Fix #11993: cauchy-schwarz Hölder status verified→formalized

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-03-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/H%C3%B6lder%27s_inequality",
     "date": "2026",
-    "status": "verified",
+    "status": "formalized",
     "tags": [
       "analysis",
       "measure-theory",


### PR DESCRIPTION
## Fix

One-line metadata fix for `cauchy-schwarz-integral-oq-01-oq-03-oq-01`.

## Evidence

**Before**: `"status": "verified"` — implies an independent machine-checked proof

**After**: `"status": "formalized"` — accurately reflects Tier B status (core result via Mathlib's `ENNReal.lintegral_mul_le_Lp_mul_Lq`)

The `badge: "mathlib"` correctly discloses the Mathlib dependency. Status `"verified"` is reserved for proofs that don't rely on Mathlib for the core result. This gallery entry bridges and specializes Mathlib's Hölder inequality, which is formalized work (not independently verified).

Closes #11993

---
Automated fix by lean-mechanic agent.