### PR TITLE
Fix sorry count mismatches in 4 gallery proofs

### DIFF
--- a/src/data/proofs/dissection-of-cubes-oq-04/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-04/meta.json
@@ -19,10 +19,10 @@
       "irrational-angles"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 3,
     "dateAdded": "2026-04-22",
     "axiomCount": 2,
-    "assumptions": "1. tmul_infinite_order_ne_zero (from OQ02OQ02): ℝ is flat over ℤ — needed to show nonzero tensor products. 2. icoAngle_irrational: arccos(-√5/3)/π is irrational (icosahedron dihedral angle) — proof requires Chebyshev arithmetic in ℤ[√5], deferred.",
+    "assumptions": "2 axioms: (1) tmul_infinite_order_ne_zero (from OQ02OQ02): ℝ is flat over ℤ — needed to show nonzero tensor products. (2) icoAngle_irrational: arccos(-√5/3)/π is irrational (icosahedron dihedral angle) — proof requires Chebyshev arithmetic in ℤ[√5], deferred. 3 sorries: edge count scaling arguments for oct_dehn_ne_zero, dod_dehn_ne_zero, and ico_dehn_ne_zero sub-proofs (general edge count scaling for the three remaining Platonic solids).",
     "lineCount": 436,
     "theoremCount": 15,
     "definitionCount": 4,

--- a/src/data/proofs/erdos-476-oq-05/meta.json
+++ b/src/data/proofs/erdos-476-oq-05/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-476-oq-05",
   "title": "Erdős #476 OQ5: Vosper's Theorem — Equality Case of Cauchy-Davenport",
   "slug": "erdos-476-oq-05",
-  "description": "Vosper's theorem (1956): if |A+B| = |A|+|B|-1 in Z/pZ with |A|,|B|≥2 and |A+B|<p, then A and B are arithmetic progressions with the same common difference d. Infrastructure largely proved: IsArithmeticProgression definition, singleton/pair AP lemmas, translation invariance, ap_of_near_periodic (backward-shift induction), vosper_base (|A|=2 case), and vosper_ap_sdiff_card (AP extension lemma, proved via linear_combination) are all fully proved. One sorry remains: Case 1 existence in the full Vosper induction.",
+  "description": "Vosper's theorem (1956): if |A+B| = |A|+|B|-1 in Z/pZ with |A|,|B|≥2 and |A+B|<p, then A and B are arithmetic progressions with the same common difference d. Infrastructure largely proved: IsArithmeticProgression definition, singleton/pair AP lemmas, translation invariance, ap_of_near_periodic (backward-shift induction), and vosper_base (|A|=2 case) are fully proved. Two sorries remain: (1) position analysis in vosper_ap_sdiff_card (a₀ is predecessor/successor of A' in the AP), and (2) Case 1 existence in the full Vosper induction.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-21",
@@ -18,10 +18,10 @@
       "zmod"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 2,
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "assumptions": "1 sorry remains: vosper Case 1 existence — find non-redundant a₀ ∈ A via counting argument or iterative removal (by contradiction: if all a ∈ A are redundant, a counting argument fails for small |A|,|B|). vosper_ap_sdiff_card (position analysis: a₀ is predecessor/successor of A' in the AP) is now fully proved via linear_combination. ap_of_near_periodic (backward-shift induction), vosper_base (|A|=2 case), and all infrastructure are proved with 0 sorries.",
+    "assumptions": "2 sorries remain: (1) vosper_ap_sdiff_card position analysis — given |{a₀}+B \\ (A'+B)| = 1 with both APs having diff d, show a₀ = a₁-d or a₀ = a₁+|A'|·d; (2) vosper Case 1 existence — find non-redundant a₀ ∈ A via counting argument or iterative removal (by contradiction: if all a ∈ A are redundant, a counting argument fails for small |A|,|B|). ap_of_near_periodic (backward-shift induction), vosper_base (|A|=2 case), and all other infrastructure are proved with 0 sorries.",
     "lineCount": 853,
     "theoremCount": 13,
     "definitionCount": 1,
@@ -33,9 +33,9 @@
       "shift_card_eq: |B.image (·+d)| = |B| via add_right_injective (proved, 0 sorries)",
       "ap_of_near_periodic: B is AP if |B\\(B+d)|=1 (proved — backward-shift induction)",
       "vosper_base: Vosper for |A|=2 (proved — uses ap_of_near_periodic)",
-      "vosper_ap_sdiff_card: AP extension lemma (proved — position analysis: given |{a₀}+B \\ (A'+B)|=1, proves a₀ = a₁-d or a₀ = a₁+|A'|·d via linear_combination)",
+      "vosper_ap_sdiff_card: AP extension lemma (1 sorry — position analysis: given |{a₀}+B \\ (A'+B)|=1, prove a₀ = a₁-d or a₀ = a₁+|A'|·d)",
       "vosper_case1_exists: Case 1 existence in vosper (1 sorry — find non-redundant a₀ ∈ A via counting argument or iterative removal)",
-      "vosper: full Vosper theorem (1 sorry — delegates to vosper_case1_exists for Case 1 existence)"
+      "vosper: full Vosper theorem (delegates to vosper_ap_sdiff_card and vosper_case1_exists)"
     ]
   },
   "overview": {
@@ -129,7 +129,7 @@
     "theoremCount": 13,
     "definitionCount": 1,
     "path": "Proofs/Erdos476OQ05Problem.lean",
-    "sorries": 1
+    "sorries": 2
   },
-  "sorries": 1
+  "sorries": 2
 }

--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -18,10 +18,10 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 6,
     "axiomCount": 4,
     "lineCount": 542,
-    "assumptions": "4 axioms: hausdorff_free_subgroup (Hausdorff 1914 — SO(3) contains F₂, requires 300+ lines of number theory), banach_tarski (Banach-Tarski 1924 — main paradox, requires 800+ lines via Hausdorff paradox + AC), banach_tarski_pieces_nonmeasurable (classical non-measurability corollary), int_amenable (Markov-Kakutani — ℤ is amenable via Cesàro means/ultrafilter construction). All 4 are known mathematical results; the framework (equidecomposability, paradoxical sets, F₂ non-amenability) is fully proved with 0 sorries.",
+    "assumptions": "4 axioms: hausdorff_free_subgroup (Hausdorff 1914 — SO(3) contains F₂, requires 300+ lines of number theory), banach_tarski (Banach-Tarski 1924 — main paradox, requires 800+ lines via Hausdorff paradox + AC), banach_tarski_pieces_nonmeasurable (classical non-measurability corollary), int_amenable (Markov-Kakutani — ℤ is amenable via Cesàro means/ultrafilter construction). 6 sorries in supporting theorems: measure-theoretic consequence of paradoxical decomposition, SO(3) rotation matrices, banach_tarski_corollary, banach_tarski_pieces_measurable_contradiction, cesaro_mean_density, and free_group_not_amenable.",
     "dateAdded": "2026-04-22",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -206,7 +206,7 @@
     "theoremCount": 7,
     "definitionCount": 5,
     "path": "Proofs/LebesgueMeasureOQ06.lean",
-    "sorries": 0
+    "sorries": 6
   },
-  "sorries": 0
+  "sorries": 6
 }

--- a/src/data/proofs/sperner-ndim-oq-04/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-04/meta.json
@@ -21,7 +21,7 @@
       "advanced"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 2,
     "originalContributions": [
       "Definition of door degree and IsKuhnCompatible for abstract Sperner triangulations",
       "Proof that FC simplices have exactly 1 door under Kuhn compatibility",
@@ -39,7 +39,7 @@
     "dateAdded": "2026-04-22",
     "axiomCount": 0,
     "lineCount": 430,
-    "assumptions": "1 sorry: kuhn_walk_result_not_in_visited — TRIVIAL induction; all cases reduce to current_not_visited or subset monotonicity via the IH. Submitted to Aristotle for automated resolution. kuhn_path_terminates is PROVED (non-constructively via sperner_ndim). All other theorems (fc_door_count_eq_one, nonfc_door_count_zero_or_two, nonfc_with_door_has_unique_exit, KuhnStateValid infrastructure) are fully verified. Note: the previously-present kuhn_walk_reaches_fc theorem was REMOVED as mathematically incorrect (mid-walk boundary exits can terminate the walk at a non-FC simplex).",
+    "assumptions": "2 sorries: (1) kuhn_walk_reaches_fc — non-revisiting invariant for the Kuhn walk (door graph component containing a boundary vertex is a path, not a cycle); (2) kuhnPathStart_is_fc — the simplex found by kuhnPathStart is fully colored (blocked on kuhn_walk_reaches_fc). All other theorems (fc_door_count_eq_one, nonfc_door_count_zero_or_two, nonfc_with_door_has_unique_exit, KuhnStateValid infrastructure, kuhn_path_terminates via sperner_ndim) are fully verified.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -131,7 +131,7 @@
       "title": "Termination and Walk Correctness Theorems",
       "startLine": 298,
       "endLine": 343,
-      "summary": "States kuhn_path_terminates (FC existence from boundary door, now proved) and kuhn_walk_reaches_fc (walk correctness, one sorry pending the non-revisiting invariant).",
+      "summary": "States kuhn_path_terminates (FC existence from boundary door, proved) and kuhn_walk_reaches_fc (walk correctness, sorry pending the non-revisiting invariant) and kuhnPathStart_is_fc (sorry, blocked on kuhn_walk_reaches_fc).",
       "mathContext": "kuhn_path_terminates can be derived from sperner_ndim (parity of boundary doors implies FC existence). kuhn_walk_reaches_fc requires the door graph path invariant: components containing boundary vertices are paths, not cycles."
     },
     {
@@ -176,7 +176,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization establishes the door-counting infrastructure and path-following algorithm for Kuhn\\u2019s constructive proof of n-dimensional Sperner\\u2019s lemma. The fully-proved results include fc_door_count_eq_one, nonfc_door_count_zero_or_two, nonfc_with_door_has_unique_exit, kuhn_path_terminates (non-constructive, via sperner_ndim), and the KuhnStateValid infrastructure (guard_entry_case_impossible, guard_current_impossible). One sorry remains in kuhn_walk_result_not_in_visited (a TRIVIAL induction submitted to Aristotle). The previously-present kuhn_walk_reaches_fc theorem was removed as mathematically incorrect — mid-walk boundary exits can terminate the walk at a non-FC simplex even with IsSperner; the correct statement requires an \\u2018FC or boundary exit\\u2019 disjunction.",
+    "summary": "This formalization establishes the door-counting infrastructure and path-following algorithm for Kuhn\\u2019s constructive proof of n-dimensional Sperner\\u2019s lemma. The fully-proved results include fc_door_count_eq_one, nonfc_door_count_zero_or_two, nonfc_with_door_has_unique_exit, kuhn_path_terminates (non-constructive, via sperner_ndim), and the KuhnStateValid infrastructure (guard_entry_case_impossible, guard_current_impossible). Two sorries remain: kuhn_walk_reaches_fc (non-revisiting invariant) and kuhnPathStart_is_fc (blocked on kuhn_walk_reaches_fc).",
     "implications": "Kuhn's 1968 result is historically significant as the first polynomial-time algorithm for finding a fully-colored simplex. Path-following algorithms descended from Kuhn's work underlie Scarf's algorithm for computing approximate fixed points and (through Lemke-Howson) Nash equilibrium computation. The abstract formulation using IsKuhnCompatible applies to any Sperner triangulation satisfying the degree bound, including Freudenthal triangulations and simplicial complexes arising in topological data analysis. The PPAD complexity connection (Papadimitriou 1994) situates this work in modern computational complexity: the door graph formalized here — a directed graph where every node has in-degree and out-degree at most 1, with a distinguished source — is exactly the End-of-Line problem that defines PPAD. The non-revisiting invariant (the hard remaining sorry) is equivalent to showing the door graph component is a directed path, not a cycle. Fully-colored simplices also appear in topological data analysis as birth-death pairs in persistent homology, making the abstract FC-finding framework relevant to TDA algorithms.",
     "openQuestions": [
       "Can the non-revisiting invariant (the door graph component containing a boundary door is a path) be proved in Lean 4 using graph theory from Mathlib?",
@@ -260,7 +260,7 @@
     "theoremCount": 8,
     "definitionCount": 5,
     "path": "Proofs/SpernerNDimOQ04.lean",
-    "sorries": 1
+    "sorries": 2
   },
-  "sorries": 1
+  "sorries": 2
 }


### PR DESCRIPTION
## Summary

- **erdos-476-oq-05**: `sorries: 1` → `sorries: 2` — `vosper_ap_sdiff_card` has a sorry for position analysis (not "proved via linear_combination" as claimed); plus the Vosper Case 1 existence sorry
- **dissection-of-cubes-oq-04**: `sorries: 0` → `sorries: 3` — three edge count scaling sorries in oct/dod/ico sub-proofs
- **lebesgue-measure-oq-06**: `sorries: 0` → `sorries: 6` — six sorries in supporting theorems beyond the 4 stated axioms
- **sperner-ndim-oq-04**: `sorries: 1` → `sorries: 2` — both `kuhn_walk_reaches_fc` and `kuhnPathStart_is_fc` have sorries

## Evidence

Verified by `git show HEAD:proofs/Proofs/*.lean | grep -n sorry` against each file's declared sorry count.

## Test plan
- [ ] `npx tsx scripts/auditor/find-targets.ts --issues` shows 0 issues after merge
- [ ] Sorry counts match `grep -c "^\s*sorry" proofs/Proofs/{Erdos476OQ05Problem,DissectionOfCubesOQ04,LebesgueMeasureOQ06,SpernerNDimOQ04}.lean`

---
Discovered during gallery integrity audit (auditor agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)