### PR TITLE
Enrich ballot-problem-oq-03-oq-01-oq-01-oq-01: fix annotation format, correct line numbers, deepen content

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/annotations.json
@@ -2,113 +2,97 @@
   {
     "id": "ann-jt-header",
     "proofId": "ballot-problem-oq-03-oq-01-oq-01-oq-01",
-    "range": { "startLine": 1, "endLine": 55 },
-    "annotation": {
-      "type": "context",
-      "title": "Jacobi-Trudi Identity: Historical and Mathematical Context",
-      "content": "The Jacobi-Trudi identity (1841) is one of the foundational formulas of algebraic combinatorics. It expresses Schur polynomials — characters of GL(n) representations and a natural basis for symmetric functions — as determinants of complete homogeneous symmetric polynomials h_n. This file provides the first Lean 4 definition of Schur polynomials using this formula as the primary definition.",
-      "mathContext": "The Jacobi-Trudi identity states: $s_\\lambda = \\det[h_{\\lambda_i - i + j}]_{1 \\le i,j \\le k}$ where $h_n$ is the $n$-th complete homogeneous symmetric polynomial and the convention $h_n = 0$ for $n < 0$ is enforced. For a partition $\\lambda = (\\lambda_1 \\ge \\lambda_2 \\ge \\cdots \\ge \\lambda_k \\ge 0)$, this produces the Schur polynomial $s_\\lambda$ in variables $x_1, \\ldots, x_\\sigma$.",
-      "significance": "key",
-      "relatedConcepts": ["Schur polynomials", "complete homogeneous symmetric polynomials", "symmetric functions ring", "GL(n) representation characters", "Young tableaux"],
-      "prerequisites": ["symmetric polynomials", "determinants", "partitions and Young diagrams", "ring theory"]
-    }
+    "range": { "startLine": 1, "endLine": 29 },
+    "type": "concept",
+    "title": "Jacobi-Trudi Identity: Historical and Mathematical Context",
+    "content": "The Jacobi-Trudi identity (1841) is one of the foundational formulas of algebraic combinatorics. It expresses Schur polynomials — characters of GL(n) representations and a natural basis for symmetric functions — as determinants of complete homogeneous symmetric polynomials h_n. This file provides the first Lean 4 definition of Schur polynomials using this formula as the primary definition. The namespace JacobiTrudi works over a general commutative ring R with a general finite type σ for variables, making all results fully abstract.",
+    "mathContext": "The Jacobi-Trudi identity states: $s_\\lambda = \\det[h_{\\lambda_i - i + j}]_{1 \\le i,j \\le k}$ where $h_n$ is the $n$-th complete homogeneous symmetric polynomial and the convention $h_n = 0$ for $n < 0$ is enforced. For a partition $\\lambda = (\\lambda_1 \\ge \\lambda_2 \\ge \\cdots \\ge \\lambda_k \\ge 0)$, this produces the Schur polynomial $s_\\lambda$ in variables $\\{x_i : i \\in \\sigma\\}$. Mathlib's `hsymm σ R n` formalizes $h_n = \\sum_{|\\alpha|=n} x^\\alpha$ (sum over monomials of degree $n$).",
+    "significance": "key",
+    "relatedConcepts": ["Schur polynomials", "complete homogeneous symmetric polynomials", "symmetric functions ring", "GL(n) representation characters", "Young tableaux"],
+    "prerequisites": ["symmetric polynomials", "determinants", "partitions and Young diagrams", "ring theory"]
   },
   {
     "id": "ann-jt-matrix-def",
     "proofId": "ballot-problem-oq-03-oq-01-oq-01-oq-01",
-    "range": { "startLine": 56, "endLine": 81 },
-    "annotation": {
-      "type": "definition",
-      "title": "Jacobi-Trudi Matrix Definition",
-      "content": "The Jacobi-Trudi matrix has entry (i,j) = h_{sh_i + j - i} when the index is non-negative, and 0 otherwise. The ℕ subtraction check `if i ≤ sh_i + j` handles the convention h_n = 0 for n < 0 without needing integers. The Schur polynomial is then the determinant of this k×k matrix.",
-      "mathContext": "For a partition $\\lambda = (\\lambda_1, \\ldots, \\lambda_k)$, the Jacobi-Trudi matrix $M$ has entries $M_{ij} = h_{\\lambda_i + j - i}$ for $1 \\le i,j \\le k$, where $h_n = 0$ when $n < 0$. In Lean 4 (0-indexed), this becomes: entry $(i, j) = h_{\\texttt{sh}_i + j - i}$ when $i \\le \\texttt{sh}_i + j$, else $0$. The Schur polynomial $s_\\lambda = \\det(M)$.",
-      "significance": "key",
-      "relatedConcepts": ["jacobiTrudiMatrix", "schurPolynomial", "MvPolynomial.hsymm", "Matrix.det", "natural number subtraction"],
-      "prerequisites": ["Mathlib.RingTheory.MvPolynomial.Symmetric.Defs", "Mathlib.LinearAlgebra.Matrix.Determinant.Basic", "Lean 4 natural number subtraction semantics"]
-    }
+    "range": { "startLine": 35, "endLine": 47 },
+    "type": "definition",
+    "title": "Jacobi-Trudi Matrix and Schur Polynomial Definitions",
+    "content": "The Jacobi-Trudi matrix has entry (i,j) = h_{sh_i + j - i} when the index is non-negative, and 0 otherwise. The ℕ subtraction check `if i.val ≤ sh i + j.val` handles the convention h_n = 0 for n < 0 without needing integers. The Schur polynomial is then the determinant of this k×k matrix. Using 0-indexed Fin k, the formula shifts slightly from the 1-indexed textbook version: i goes from 0 to k-1 instead of 1 to k.",
+    "mathContext": "For a partition $\\lambda = (\\lambda_1, \\ldots, \\lambda_k)$, the Jacobi-Trudi matrix $M$ has entries $M_{ij} = h_{\\lambda_i + j - i}$ for $1 \\le i,j \\le k$, where $h_n = 0$ when $n < 0$. In Lean 4 (0-indexed), this becomes: entry $(i, j) = h_{\\texttt{sh}_i + j - i}$ when $i \\le \\texttt{sh}_i + j$, else $0$. The Schur polynomial $s_\\lambda = \\det(M)$. The `noncomputable` annotation is required because `MvPolynomial.hsymm` involves classical choice.",
+    "significance": "key",
+    "relatedConcepts": ["jacobiTrudiMatrix", "schurPolynomial", "MvPolynomial.hsymm", "Matrix.det", "natural number subtraction"],
+    "prerequisites": ["Mathlib.RingTheory.MvPolynomial.Symmetric.Defs", "Mathlib.LinearAlgebra.Matrix.Determinant.Basic", "Lean 4 natural number subtraction semantics"]
   },
   {
     "id": "ann-jt-base-cases",
     "proofId": "ballot-problem-oq-03-oq-01-oq-01-oq-01",
-    "range": { "startLine": 82, "endLine": 99 },
-    "annotation": {
-      "type": "technique",
-      "title": "Base Cases: Empty and Single-Row Partitions",
-      "content": "Two foundational base cases: (1) the empty partition () gives a 0×0 determinant equal to 1 (by convention); (2) the single-row partition (n) gives a 1×1 determinant equal to h_n, the n-th complete homogeneous symmetric polynomial. These verify the definition against the known boundary cases of the Jacobi-Trudi identity.",
-      "mathContext": "For the empty partition $\\lambda = ()$: $s_{()} = \\det(\\text{empty matrix}) = 1$ (the $0 \\times 0$ determinant). Lean: `Matrix.det_fin_zero`. For the single-row partition $\\lambda = (n)$: $s_{(n)} = h_n$ (the $n$-th complete homogeneous symmetric polynomial). Lean: `Matrix.det_fin_one` reduces the $1 \\times 1$ determinant to its single entry $h_n$.",
-      "significance": "supporting",
-      "relatedConcepts": ["det_fin_zero", "det_fin_one", "hsymm", "empty partition", "single-row Schur polynomial"],
-      "prerequisites": ["determinant conventions", "complete homogeneous symmetric polynomials", "Lean simp arithmetic"]
-    }
+    "range": { "startLine": 53, "endLine": 61 },
+    "type": "theorem",
+    "title": "Base Cases: Empty and Single-Row Partitions",
+    "content": "Two foundational base cases: (1) the empty partition () gives a 0×0 determinant equal to 1 (by convention); (2) the single-row partition (n) gives a 1×1 determinant equal to h_n, the n-th complete homogeneous symmetric polynomial. These verify the definition against the known boundary cases of the Jacobi-Trudi identity. Both proofs close with `simp` using Mathlib's `det_fin_zero` and `det_fin_one` lemmas.",
+    "mathContext": "For the empty partition $\\lambda = ()$: $s_{()} = \\det(\\text{empty matrix}) = 1$ (the $0 \\times 0$ determinant). Lean: `Matrix.det_fin_zero`. For the single-row partition $\\lambda = (n)$: $s_{(n)} = h_n$ (the $n$-th complete homogeneous symmetric polynomial). Lean: `Matrix.det_fin_one` reduces the $1 \\times 1$ determinant to its single entry. In general, $h_n(x_1,\\ldots,x_k) = \\sum_{i_1 \\le i_2 \\le \\cdots \\le i_n} x_{i_1} x_{i_2} \\cdots x_{i_n}$ counts all monomials of degree $n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["det_fin_zero", "det_fin_one", "hsymm", "empty partition", "single-row Schur polynomial"],
+    "prerequisites": ["determinant conventions", "complete homogeneous symmetric polynomials", "Lean simp arithmetic"]
   },
   {
     "id": "ann-jt-entry-symmetry",
     "proofId": "ballot-problem-oq-03-oq-01-oq-01-oq-01",
-    "range": { "startLine": 100, "endLine": 116 },
-    "annotation": {
-      "type": "technique",
-      "title": "Entry-Level Symmetry: Each h_n is Individually Symmetric",
-      "content": "Before proving the full Schur polynomial is symmetric, we first establish that each entry of the Jacobi-Trudi matrix is individually symmetric. The key lemma is `rename_hsymm`: renaming variables in h_n by any permutation leaves it unchanged. The conditional entry (h_n or 0) requires `split_ifs` to handle both branches.",
-      "mathContext": "A polynomial $\\phi \\in \\mathbb{R}[x_1,\\ldots,x_\\sigma]$ is symmetric if $\\phi(x_{e(1)},\\ldots,x_{e(\\sigma)}) = \\phi(x_1,\\ldots,x_\\sigma)$ for all permutations $e$. In Lean: `IsSymmetric φ = ∀ e : Equiv.Perm σ, MvPolynomial.rename e φ = φ`. Mathlib's `hsymm_isSymmetric` proves this for $h_n$, and `rename_hsymm` gives the explicit rewrite.",
-      "significance": "supporting",
-      "relatedConcepts": ["IsSymmetric", "rename_hsymm", "hsymm_isSymmetric", "MvPolynomial.rename", "Equiv.Perm"],
-      "prerequisites": ["symmetric polynomials", "MvPolynomial.rename", "Mathlib.RingTheory.MvPolynomial.Symmetric.Defs"]
-    }
+    "range": { "startLine": 67, "endLine": 71 },
+    "type": "theorem",
+    "title": "Entry-Level Symmetry: Each h_n is Individually Symmetric",
+    "content": "Before proving the full Schur polynomial is symmetric, we first establish that each entry of the Jacobi-Trudi matrix is individually symmetric. The key lemma is `rename_hsymm`: renaming variables in h_n by any permutation leaves it unchanged. The conditional entry (h_n or 0) requires `split_ifs` to handle both branches. This is a sorry pending resolution of a Lean unification issue with `hsymm_isSymmetric`.",
+    "mathContext": "A polynomial $\\phi \\in R[x_i : i \\in \\sigma]$ is symmetric if $\\phi(x_{e(i)}) = \\phi(x_i)$ for all permutations $e : \\sigma \\to \\sigma$. In Lean: `IsSymmetric φ = ∀ e : Equiv.Perm σ, MvPolynomial.rename e φ = φ`. Mathlib's `hsymm_isSymmetric` proves this for $h_n$, and `rename_hsymm` gives the explicit rewrite `rename e (hsymm σ R n) = hsymm σ R n`. The zero case is trivial since `rename e 0 = 0`.",
+    "significance": "supporting",
+    "relatedConcepts": ["IsSymmetric", "rename_hsymm", "hsymm_isSymmetric", "MvPolynomial.rename", "Equiv.Perm"],
+    "prerequisites": ["symmetric polynomials", "MvPolynomial.rename", "Mathlib.RingTheory.MvPolynomial.Symmetric.Defs"]
   },
   {
     "id": "ann-jt-symmetry",
     "proofId": "ballot-problem-oq-03-oq-01-oq-01-oq-01",
-    "range": { "startLine": 117, "endLine": 128 },
-    "annotation": {
-      "type": "technique",
-      "title": "Full Symmetry of Schur Polynomials via AlgHom.map_det",
-      "content": "Symmetry of the Schur polynomial follows from two facts: (1) AlgHom.map_det lifts any ring homomorphism through the determinant, and (2) rename_hsymm shows each h_n is individually symmetric. The `split_ifs` handles the conditional 0-or-h_n cases uniformly. This is a 10-line proof of a foundational theorem in symmetric function theory.",
-      "mathContext": "The key identity: for any ring algebra homomorphism $\\phi$, $\\phi(\\det M) = \\det(\\phi \\circ M)$. In Lean: `AlgHom.map_det`. Here $\\phi = \\texttt{rename}\\, e$ for a permutation $e$, so $(\\texttt{rename}\\, e)(\\det M_{JT}) = \\det(\\texttt{mapMatrix}\\,(\\texttt{rename}\\, e)\\, M_{JT})$. Each entry satisfies $(\\texttt{rename}\\, e)(h_n) = h_n$, so the mapped matrix equals $M_{JT}$, giving $(\\texttt{rename}\\, e)(s_\\lambda) = s_\\lambda$.",
-      "significance": "key",
-      "relatedConcepts": ["AlgHom.map_det", "rename_hsymm", "IsSymmetric", "Matrix.mapMatrix", "symmetric function ring"],
-      "prerequisites": ["algebra homomorphisms", "determinants", "symmetric polynomials", "Mathlib.LinearAlgebra.Matrix.Determinant.Basic"]
-    }
+    "range": { "startLine": 73, "endLine": 77 },
+    "type": "theorem",
+    "title": "Full Symmetry of Schur Polynomials via AlgHom.map_det",
+    "content": "Symmetry of the Schur polynomial follows from two facts: (1) AlgHom.map_det lifts any ring algebra homomorphism through the determinant, and (2) rename_hsymm shows each h_n is individually symmetric. This is a sorry pending the entry-symmetry result above. Once that is proved, the full symmetry proof is 10 lines: apply AlgHom.map_det, then show each matrix entry is fixed by rename via jacobiTrudiMatrix_entry_isSymmetric.",
+    "mathContext": "The key identity: for any $R$-algebra homomorphism $\\phi$, $\\phi(\\det M) = \\det(\\phi \\circ M)$. In Lean: `AlgHom.map_det`. Here $\\phi = \\texttt{rename}\\, e$ for a permutation $e : \\text{Perm}\\, \\sigma$, so $(\\texttt{rename}\\, e)(\\det M_{JT}) = \\det(\\texttt{mapMatrix}\\,(\\texttt{rename}\\, e)\\, M_{JT})$. Each entry satisfies $(\\texttt{rename}\\, e)(h_n) = h_n$, so the mapped matrix equals $M_{JT}$, giving $(\\texttt{rename}\\, e)(s_\\lambda) = s_\\lambda$. Symmetry is the defining property that distinguishes $s_\\lambda$ from ordinary polynomials.",
+    "significance": "key",
+    "relatedConcepts": ["AlgHom.map_det", "rename_hsymm", "IsSymmetric", "Matrix.mapMatrix", "symmetric function ring"],
+    "prerequisites": ["algebra homomorphisms", "determinants", "symmetric polynomials", "Mathlib.LinearAlgebra.Matrix.Determinant.Basic"]
   },
   {
     "id": "ann-jt-two-row",
     "proofId": "ballot-problem-oq-03-oq-01-oq-01-oq-01",
-    "range": { "startLine": 129, "endLine": 159 },
-    "annotation": {
-      "type": "insight",
-      "title": "Two-Row Schur Polynomial: Explicit Determinant Formula",
-      "content": "For the two-row partition (a, b) with a ≥ b ≥ 0, the Jacobi-Trudi formula gives s_{(a,b)} = h_a * h_b - h_{a+1} * h_{b-1}. This is the 2×2 determinant expansion. When b = 0, the second term vanishes. Lean's det_fin_two gives the 2×2 expansion mechanically, and Matrix.cons lemmas extract the entries.",
-      "mathContext": "For partition $\\lambda = (a, b)$ with $a \\ge b \\ge 0$: $$s_{(a,b)} = \\det\\begin{pmatrix} h_a & h_{a+1} \\\\ h_{b-1} & h_b \\end{pmatrix} = h_a h_b - h_{a+1} h_{b-1}$$ where $h_{-1} = 0$ by convention. This is the simplest non-trivial case of Jacobi-Trudi and illustrates the sign pattern characteristic of determinant formulas for symmetric functions.",
-      "significance": "supporting",
-      "relatedConcepts": ["det_fin_two", "two-row partition", "Schur polynomial", "complete homogeneous symmetric polynomials", "Pieri rule"],
-      "prerequisites": ["2×2 determinants", "partition notation", "h_n conventions"]
-    }
+    "range": { "startLine": 83, "endLine": 90 },
+    "type": "insight",
+    "title": "Two-Row Schur Polynomial: Explicit Determinant Formula",
+    "content": "For the two-row partition (a, b) with a ≥ b ≥ 0, the Jacobi-Trudi formula gives s_{(a,b)} = h_a * h_b - h_{a+1} * h_{b-1}. This is the 2×2 determinant expansion. When b = 0, the second term vanishes (h_{-1} = 0 by the ℕ convention). Lean's det_fin_two gives the 2×2 expansion mechanically, and Matrix.cons lemmas extract the entries. Currently a sorry due to the complexity of normalizing the conditional entry logic.",
+    "mathContext": "For partition $\\lambda = (a, b)$ with $a \\ge b \\ge 0$: $$s_{(a,b)} = \\det\\begin{pmatrix} h_a & h_{a+1} \\\\ h_{b-1} & h_b \\end{pmatrix} = h_a h_b - h_{a+1} h_{b-1}$$ where $h_{-1} = 0$ by convention. This is the simplest non-trivial case of Jacobi-Trudi and illustrates the alternating-sign (determinant) structure. The formula generalizes: for a hook partition $(a, 1^b)$, the Jacobi-Trudi determinant is tridiagonal. The two-row case is also used to prove the Pieri rule.",
+    "significance": "supporting",
+    "relatedConcepts": ["det_fin_two", "two-row partition", "Schur polynomial", "complete homogeneous symmetric polynomials", "Pieri rule"],
+    "prerequisites": ["2×2 determinants", "partition notation", "h_n conventions"]
   },
   {
     "id": "ann-jt-hook-connection",
     "proofId": "ballot-problem-oq-03-oq-01-oq-01-oq-01",
-    "range": { "startLine": 160, "endLine": 176 },
-    "annotation": {
-      "type": "insight",
-      "title": "Evaluation at All-Ones: Stars-and-Bars and Symmetric Group",
-      "content": "Evaluating h_n at x₁ = ⋯ = xₖ = 1 gives the number of monomials of degree n in k variables, which equals C(n+k-1, k-1) = |{weak compositions of n into k parts}| = |Sym(Fin k) n|. This connects the algebraic Jacobi-Trudi formula to combinatorial counting, and to the dimension of the degree-n component of the polynomial ring.",
-      "mathContext": "For the $n$-th complete homogeneous symmetric polynomial in $k$ variables: $h_n(1,1,\\ldots,1) = \\binom{n+k-1}{k-1}$. This equals $|\\text{Sym}(\\text{Fin}\\, k)\\, n|$ — the number of multisets of size $n$ from a $k$-element set (\"stars and bars\"). In Lean: `eval (fun _ => 1) (hsymm (Fin k) R n) = |Sym (Fin k) n|` via `map_sum` and `card_univ`.",
-      "significance": "supporting",
-      "relatedConcepts": ["stars and bars", "multisets", "binomial coefficients", "evaluation map", "hsymm at 1"],
-      "prerequisites": ["combinatorics", "MvPolynomial.eval", "Finset.card", "binomial coefficients"]
-    }
+    "range": { "startLine": 96, "endLine": 101 },
+    "type": "insight",
+    "title": "Evaluation at All-Ones: Stars-and-Bars and Symmetric Group",
+    "content": "Evaluating h_n at x₁ = ⋯ = xₖ = 1 gives the number of monomials of degree n in k variables, which equals C(n+k-1, k-1) = |{weak compositions of n into k parts}| = |Sym(Fin k) n|. This connects the algebraic Jacobi-Trudi formula to combinatorial counting, and to the dimension of the degree-n component of the polynomial ring. Currently sorry pending the `Nat.multichoose` = `Nat.choose` reduction.",
+    "mathContext": "For the $n$-th complete homogeneous symmetric polynomial in $k$ variables: $h_n(1,1,\\ldots,1) = \\binom{n+k-1}{k-1}$. This equals $|\\text{Sym}(\\text{Fin}\\, k)\\, n|$ — the number of multisets of size $n$ from a $k$-element set (\"stars and bars\"). In Lean: `eval (fun _ => 1) (hsymm (Fin k) R n) = Nat.choose (n + k - 1) (k - 1)`. When combined with Jacobi-Trudi, evaluating $s_\\lambda(1,\\ldots,1)$ counts the number of SSYT of shape $\\lambda$ with entries in $\\{1,\\ldots,k\\}$, which equals the dimension of the corresponding GL(k) representation.",
+    "significance": "supporting",
+    "relatedConcepts": ["stars and bars", "multisets", "binomial coefficients", "evaluation map", "hsymm at 1", "Nat.multichoose"],
+    "prerequisites": ["combinatorics", "MvPolynomial.eval", "Finset.card", "binomial coefficients"]
   },
   {
     "id": "ann-jt-lgv",
     "proofId": "ballot-problem-oq-03-oq-01-oq-01-oq-01",
-    "range": { "startLine": 177, "endLine": 204 },
-    "annotation": {
-      "type": "context",
-      "title": "LGV Connection (Open): SSYT ↔ Non-Intersecting Paths via RSK",
-      "content": "The combinatorial proof of the Jacobi-Trudi identity via the LGV lemma proceeds: semistandard Young tableaux (SSYT) of shape λ biject with non-intersecting lattice path systems via RSK correspondence; each lattice path from row i to shifted target encodes a weakly increasing variable sequence whose monomial weight is a term of h_n; summing over SSYT gives det[h_{sh_i+j-i}]. This sorry represents ~400 lines of Lean formalization (SSYT structure + RSK bijection).",
-      "mathContext": "The LGV proof strategy: define a weighted path digraph where the weight of a path from source $(0, i)$ to target $(n, j)$ encodes a weakly increasing sequence from the $i$-th row of a Young tableau. The LGV lemma (proved in the parent entry) then gives $\\det[h_{\\lambda_i - i + j}] = \\sum_{T \\in \\text{SSYT}(\\lambda)} \\mathbf{x}^T = s_\\lambda$, where the last equality is the combinatorial definition of Schur polynomials. The placeholder theorem `jacobiTrudi_lgv_proof` returns `True` until the RSK formalization is complete.",
-      "significance": "context",
-      "relatedConcepts": ["LGV lemma", "RSK correspondence", "semistandard Young tableaux (SSYT)", "non-intersecting lattice paths", "Schur polynomial combinatorial definition"],
-      "prerequisites": ["LGV lemma (parent proof)", "Young tableaux theory", "RSK correspondence", "generating functions"]
-    }
+    "range": { "startLine": 103, "endLine": 129 },
+    "type": "concept",
+    "title": "LGV Connection (Open): SSYT ↔ Non-Intersecting Paths via RSK",
+    "content": "The combinatorial proof of the Jacobi-Trudi identity via the LGV lemma proceeds: semistandard Young tableaux (SSYT) of shape λ biject with non-intersecting lattice path systems via RSK correspondence; each lattice path encodes a weakly increasing variable sequence whose monomial weight is a term of h_n; summing over SSYT gives det[h_{sh_i+j-i}]. This sorry represents approximately 400 lines of Lean formalization (SSYT structure ~100 lines + RSK bijection ~200 lines + weight matching ~100 lines). The placeholder theorem is stated as a tautology (schurPolynomial = schurPolynomial) until the RHS can be replaced by the SSYT generating function.",
+    "mathContext": "The LGV proof: define a weighted digraph where edge weights encode polynomial variables, with sources $A_i = (0, i-1)$ and targets $B_j = (\\lambda_j - j + k, j-1)$. A system of non-intersecting paths from $(A_1,\\ldots,A_k)$ to $(B_{\\sigma(1)},\\ldots,B_{\\sigma(k)})$ encodes a SSYT of shape $\\lambda$. The LGV lemma (proved in parent entry `ballot-problem-oq-03-oq-01-oq-01`) gives $\\det[e(A_i, B_j)] = \\sum_{\\text{NI paths}} \\text{wt}$. Matching weights shows this equals $\\sum_{T \\in \\text{SSYT}(\\lambda)} x^T = s_\\lambda$ (the combinatorial definition of Schur polynomials via SSYT).",
+    "significance": "supporting",
+    "relatedConcepts": ["LGV lemma", "RSK correspondence", "semistandard Young tableaux (SSYT)", "non-intersecting lattice paths", "Schur polynomial combinatorial definition"],
+    "prerequisites": ["LGV lemma (parent proof)", "Young tableaux theory", "RSK correspondence", "generating functions"]
   }
 ]

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -36,15 +36,16 @@
     ]
   },
   "overview": {
-    "historicalContext": "The Jacobi-Trudi identity (1841, independently rediscovered by Trudi 1864) expresses Schur polynomials as determinants of complete homogeneous symmetric polynomials: s_λ = det[h_{λᵢ-i+j}]. This is foundational in algebraic combinatorics and representation theory: Schur polynomials are characters of GL(n) representations, and the Jacobi-Trudi formula connects them to the ring of symmetric functions. The LGV lemma provides the standard combinatorial proof via non-intersecting lattice paths and RSK correspondence.",
+    "historicalContext": "Carl Gustav Jacob Jacobi stated the identity bearing his name in 1841, and Nicola Trudi independently rediscovered it in 1864. The formula $s_\\lambda = \\det[h_{\\lambda_i - i + j}]$ expresses Schur polynomials as determinants of complete homogeneous symmetric polynomials $h_n$. Issai Schur (1901–1911) developed the systematic theory connecting these polynomials to the representation theory of GL(n): each $s_\\lambda$ is the character of the irreducible polynomial representation indexed by partition $\\lambda$. This dual algebraic/combinatorial nature — both a ring-theoretic determinant formula and a character — makes the Jacobi-Trudi identity central to modern algebraic combinatorics. The combinatorial proof via the Lindström-Gessel-Viennot (LGV) lemma was developed by Gessel and Viennot in 1985, completing the picture by showing semistandard Young tableaux (SSYT) biject with non-intersecting lattice path systems. Macdonald's 1979 book 'Symmetric Functions and Hall Polynomials' systematized these connections and remains the standard reference.",
     "problemStatement": "Formalize the definition of Schur polynomials via the Jacobi-Trudi determinant formula and prove their key properties: symmetry, base cases, and the connection to the LGV lemma infrastructure already formalized in the parent gallery proofs.",
     "text": "The key insight is that Mathlib's complete homogeneous symmetric polynomials hsymm σ R n provide exactly the building blocks for the Jacobi-Trudi matrix. The entry at position (i,j) is h_{sh_i + j - i} when i ≤ sh_i + j (else 0 to handle the h_n = 0 for n < 0 convention using ℕ subtraction). Symmetry of the Schur polynomial then follows from: (1) each matrix entry is symmetric (using hsymm_isSymmetric + rename_hsymm), and (2) AlgHom.map_det lets us push rename through the determinant.",
     "proofStrategy": "For symmetry: AlgHom.map_det gives (rename e)(det M) = det((rename e).mapMatrix M), then show each entry (rename e)(h_{sh_i+j-i}) = h_{sh_i+j-i} using rename_hsymm. For base cases: det_fin_zero = 1, det_fin_one simplifies 1×1 determinant. The LGV connection (SSYT ↔ NI paths via RSK) requires ~400 lines of additional formalization.",
     "keyInsights": [
-      "Mathlib's hsymm σ R n is precisely the h_n in the Jacobi-Trudi formula — no additional definitions needed",
-      "ℕ subtraction handles the h_n = 0 for n < 0 convention cleanly: check i ≤ sh_i + j before computing sh_i + j - i",
-      "AlgHom.map_det + rename_hsymm + split_ifs handles the symmetry proof in 10 lines",
-      "The LGV connection (RSK + SSYT) requires ~400 lines — stated as open sorry"
+      "Mathlib's hsymm σ R n is precisely the h_n in the Jacobi-Trudi formula — no additional definitions needed, the whole matrix is built from Mathlib primitives",
+      "ℕ subtraction handles the h_n = 0 for n < 0 convention cleanly: checking i ≤ sh_i + j before computing sh_i + j - i avoids the need for integers or a custom 'truncated subtraction' type",
+      "AlgHom.map_det lifts any R-algebra homomorphism through det, reducing symmetry of s_λ to symmetry of each h_n — a single Mathlib lemma carries the whole argument",
+      "The 0-indexed Lean representation (Fin k) shifts the matrix entry formula: standard 1-indexed M_{ij} = h_{λᵢ+j-i} becomes 0-indexed h_{sh_i+j-i} with conditional on i.val ≤ sh_i + j.val",
+      "The LGV connection (SSYT ↔ NI paths via RSK) requires ~400 lines and is the key missing piece: once formalized, it gives a purely combinatorial proof that the determinant formula equals the tableau-sum definition"
     ],
     "prerequisites": [
       "Mathlib.RingTheory.MvPolynomial.Symmetric.Defs: hsymm, IsSymmetric, rename_hsymm, hsymm_isSymmetric",
@@ -83,69 +84,77 @@
   },
   "crossReferences": [
     {
-      "id": "ballot-problem-oq-03-oq-01-oq-01",
-      "title": "General n×n LGV Lemma",
-      "relationship": "parent"
+      "proofId": "ballot-problem-oq-03-oq-01-oq-01",
+      "relationship": "parent",
+      "description": "Parent entry providing the LGV lemma infrastructure that the jacobiTrudi_lgv_connection sorry depends on"
     },
     {
-      "id": "ballot-problem-oq-03-oq-01-oq-02",
-      "title": "Hook-Length Formula via LGV",
-      "relationship": "sibling"
+      "proofId": "ballot-problem-oq-03-oq-01-oq-02",
+      "relationship": "sibling",
+      "description": "Hook-Length Formula via LGV — another application of the same parent LGV machinery to enumerate SYT"
     },
     {
-      "id": "ballot-problem-oq-03-oq-02",
-      "title": "LGV Lemma n×n (full formalization)",
-      "relationship": "foundational"
+      "proofId": "ballot-problem-oq-03-oq-02",
+      "relationship": "foundational",
+      "description": "Full n×n LGV Lemma formalization that the LGV connection proof strategy ultimately relies upon"
     }
   ],
   "sections": [
     {
+      "id": "sec-preamble",
+      "title": "Preamble: Imports, Opens, Variables",
+      "startLine": 1,
+      "endLine": 29,
+      "summary": "File header, Mathlib imports (Symmetric.Defs, Determinant.Basic, parent proof), opens (MvPolynomial, Matrix, Finset), namespace, and variable declarations for the abstract commutative ring setting.",
+      "mathContext": "Works over `{σ R : Type*} [CommRing R] [Fintype σ] [DecidableEq σ]` — fully abstract in both the variable set σ and coefficient ring R. The parent import `Proofs.BallotProblemOQ03OQ01OQ01` supplies the LGV infrastructure."
+    },
+    {
       "id": "sec-definitions",
       "title": "Part I: Definitions",
-      "startLine": 36,
-      "endLine": 54,
-      "summary": "Defines jacobiTrudiMatrix and schurPolynomial. Entry (i,j) = h_{sh_i+j-i} if i ≤ sh_i+j, else 0.",
-      "mathContext": "jacobiTrudiMatrix k sh : Matrix (Fin k) (Fin k) (MvPolynomial σ R). schurPolynomial k sh = det(jacobiTrudiMatrix). Uses ℕ subtraction with conditional to avoid negative indices."
+      "startLine": 35,
+      "endLine": 47,
+      "summary": "Defines jacobiTrudiMatrix (k×k matrix with entries h_{sh_i+j-i} or 0) and schurPolynomial (its determinant). Both are noncomputable due to classical choice in hsymm.",
+      "mathContext": "`jacobiTrudiMatrix k sh : Matrix (Fin k) (Fin k) (MvPolynomial σ R)`. `schurPolynomial k sh = Matrix.det (jacobiTrudiMatrix k sh)`. Uses ℕ subtraction with conditional `if i.val ≤ sh i + j.val` to handle the $h_n = 0$ for $n < 0$ convention."
     },
     {
       "id": "sec-base-cases",
       "title": "Part II: Base Cases",
-      "startLine": 56,
-      "endLine": 70,
-      "summary": "schurPolynomial_empty = 1 (0×0 det). schurPolynomial_one_row = hsymm σ R n (1×1 det).",
-      "mathContext": "det_fin_zero = 1 handles empty case. det_fin_one reduces to single entry. simp reduces the ℕ arithmetic."
+      "startLine": 53,
+      "endLine": 61,
+      "summary": "schurPolynomial_empty: s_() = 1 (0×0 det via det_fin_zero). schurPolynomial_one_row: s_[n] = h_n (1×1 det via det_fin_one). Both proved with simp.",
+      "mathContext": "`Matrix.det_fin_zero`: the determinant of the unique $0 \\times 0$ matrix is $1$. `Matrix.det_fin_one`: the $1 \\times 1$ determinant reduces to the single entry. These are boundary sanity checks for the Jacobi-Trudi definition."
     },
     {
       "id": "sec-symmetry",
       "title": "Part III: Symmetry",
-      "startLine": 72,
-      "endLine": 93,
-      "summary": "Each entry is symmetric (via hsymm_isSymmetric). Full symmetry via AlgHom.map_det.",
-      "mathContext": "IsSymmetric φ = ∀ e : Perm σ, rename e φ = φ. Key lemma: AlgHom.map_det gives (rename e)(det M) = det(mapMatrix (rename e) M). Then each entry: rename e (h_n) = h_n by rename_hsymm."
+      "startLine": 63,
+      "endLine": 77,
+      "summary": "Two theorems: entry-level symmetry (each h_n invariant under variable rename, sorry) and full Schur polynomial symmetry via AlgHom.map_det (sorry, pending entry result).",
+      "mathContext": "`IsSymmetric φ` means `∀ e : Equiv.Perm σ, rename e φ = φ`. Strategy: `AlgHom.map_det` gives `rename e (det M) = det (Matrix.mapMatrix (rename e) M)`. Each entry satisfies `rename e (h_n) = h_n` by `rename_hsymm`, so the mapped matrix equals the original."
     },
     {
       "id": "sec-two-row",
       "title": "Part IV: Two-Row Formula",
-      "startLine": 96,
-      "endLine": 107,
-      "summary": "Explicit formula for Schur([a,b]) = h_a*h_b - h_{a+1}*(h_{b-1} or 0). Currently sorry.",
-      "mathContext": "det_fin_two gives the 2×2 expansion. Matrix.cons lemmas extract entries. The (1,0) entry check: if 1 ≤ b then h_{b-1} else 0. (sorry)"
+      "startLine": 79,
+      "endLine": 90,
+      "summary": "Explicit formula for s_{[a,b]} = h_a*h_b - h_{a+1}*(h_{b-1} or 0). Currently sorry pending det_fin_two normalization.",
+      "mathContext": "`Matrix.det_fin_two` expands the $2 \\times 2$ determinant as $M_{00} M_{11} - M_{01} M_{10}$. Matrix.cons lemmas extract: $M_{00} = h_a$, $M_{01} = h_{a+1}$, $M_{10} = h_{b-1}$ (if $1 \\le b$, else $0$), $M_{11} = h_b$. Result: $s_{(a,b)} = h_a h_b - h_{a+1} h_{b-1}$. (sorry)"
     },
     {
       "id": "sec-hook-connection",
       "title": "Part V: Hook-Length Connection",
-      "startLine": 110,
-      "endLine": 116,
-      "summary": "Evaluation at all-ones = C(n+k-1, k-1) = |Sym (Fin k) n|. Currently sorry.",
-      "mathContext": "eval (fun _ => 1) (hsymm (Fin k) R n) = |Sym (Fin k) n| via map_sum and card_univ. (sorry)"
+      "startLine": 92,
+      "endLine": 101,
+      "summary": "Evaluation of one-row Schur polynomial at all-ones gives C(n+k-1, k-1). Currently sorry pending Nat.multichoose reduction.",
+      "mathContext": "`eval (fun _ : Fin k => (1 : R)) (schurPolynomial 1 (fun _ => n)) = Nat.choose (n + k - 1) (k - 1)`. Uses `schurPolynomial_one_row` to reduce to `eval 1 (hsymm (Fin k) R n)`, then stars-and-bars: $h_n(1,\\ldots,1) = \\binom{n+k-1}{k-1}$. (sorry)"
     },
     {
       "id": "sec-lgv-connection",
       "title": "Part VI: LGV Connection (Open)",
-      "startLine": 119,
-      "endLine": 135,
-      "summary": "Placeholder theorem for the LGV combinatorial proof of Jacobi-Trudi. Currently sorry — requires RSK correspondence (~400 lines).",
-      "mathContext": "The full proof requires: (1) SSYT formalization, (2) RSK bijection SSYT ↔ NI paths, (3) weight matching. Each is ~100-200 lines of additional Lean. (sorry)"
+      "startLine": 103,
+      "endLine": 129,
+      "summary": "Placeholder theorem for the LGV combinatorial proof of Jacobi-Trudi. The comment block describes the ~400-line formalization roadmap (SSYT + RSK + weight matching). Currently a tautology sorry.",
+      "mathContext": "Full proof requires: (1) SSYT type and weight function (~100 lines), (2) RSK bijection SSYT ↔ NI paths (~200 lines), (3) weight matching with the LGV edge weights from the parent proof (~100 lines). The placeholder states `schurPolynomial k sh = schurPolynomial k sh` (tautology) until SSYT generating function is defined. (sorry)"
     }
   ],
   "sorries": 5


### PR DESCRIPTION
## Enrichment pass for ballot-problem-oq-03-oq-01-oq-01-oq-01

Jacobi-Trudi Identity: Schur Polynomials as Determinants of Complete Homogeneous Symmetric Polynomials

### Format Fixes (breaking issues)
- **annotations.json**: Flattened nested `"annotation"` key to top-level fields (was making `type`, `title`, `content`, etc. inaccessible to the renderer)
- Fixed invalid annotation `type` values: `"context"` → `"concept"`, `"technique"` → `"concept"`/`"theorem"`/`"insight"`
- Fixed invalid `significance` value: `"context"` → `"supporting"` in LGV annotation
- **Line ranges**: All 8 annotations had wrong line numbers (referencing lines 129–204 in a 130-line file); corrected to match actual Lean structure
- **crossReferences**: Changed `"id"` field to `"proofId"` per TypeScript `CrossReference` schema

### Content Improvements
- Added 7th section (`sec-preamble`) covering imports/opens/variable declarations (lines 1–29)
- Fixed all section `startLine`/`endLine` values to match actual Lean file structure
- Expanded `historicalContext`: added Jacobi (1841), Trudi (1864), Schur (1901–1911), Gessel-Viennot (1985), Macdonald reference; now >400 chars with real mathematical history
- Added 5th `keyInsight`: explains the 0-indexed vs 1-indexed shift in the matrix entry formula
- All annotations now have accurate line ranges, correct types, LaTeX mathContext, relatedConcepts, prerequisites