### PR TITLE
Fix: sorry count mismatches in 3 proofs (lebesgue-oq-06, sperner-ndim-oq-04, dissection-oq-04)

### DIFF
--- a/src/data/proofs/dissection-of-cubes-oq-04/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-04/meta.json
@@ -19,10 +19,10 @@
       "irrational-angles"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 3,
     "dateAdded": "2026-04-22",
     "axiomCount": 2,
-    "assumptions": "1. tmul_infinite_order_ne_zero (from OQ02OQ02): ℝ is flat over ℤ — needed to show nonzero tensor products. 2. icoAngle_irrational: arccos(-√5/3)/π is irrational (icosahedron dihedral angle) — proof requires Chebyshev arithmetic in ℤ[√5], deferred.",
+    "assumptions": "2 axioms: (1) tmul_infinite_order_ne_zero (from OQ02OQ02): ℝ is flat over ℤ — needed to show nonzero tensor products. (2) icoAngle_irrational: arccos(-√5/3)/π is irrational (icosahedron dihedral angle) — proof requires Chebyshev arithmetic in ℤ[√5], deferred. Additionally 3 WIP sorries in cube_isolated_dehn_invariant proof steps: octahedron, dodecahedron, and icosahedron cases need 'general edge count scaling' helper (applies oct_dehn_ne_zero/dod_dehn_ne_zero/ico_dehn_ne_zero lemmas to the full table).",
     "lineCount": 436,
     "theoremCount": 15,
     "definitionCount": 4,
@@ -146,5 +146,6 @@
       "Can icoAngle_irrational be proved by extending the Chebyshev argument to ℤ[√5], completing the proof for all five Platonic solids with 0 axioms?",
       "Are any two of the four non-cube Platonic solids scissors congruent to each other? Their Dehn invariants are all nonzero, but they may still differ — this requires comparing the angle classes [arccos(1/3)], [arccos(-1/3)], [arccos(-1/√5)], [arccos(-√5/3)] in ℝ/πℤ, which reduces to algebraic independence questions."
     ]
-  }
+  },
+  "sorries": 3
 }

--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -18,10 +18,10 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 0,
-    "axiomCount": 4,
+    "sorries": 6,
+    "axiomCount": 5,
     "lineCount": 542,
-    "assumptions": "4 axioms: hausdorff_free_subgroup (Hausdorff 1914 — SO(3) contains F₂, requires 300+ lines of number theory), banach_tarski (Banach-Tarski 1924 — main paradox, requires 800+ lines via Hausdorff paradox + AC), banach_tarski_pieces_nonmeasurable (classical non-measurability corollary), int_amenable (Markov-Kakutani — ℤ is amenable via Cesàro means/ultrafilter construction). All 4 are known mathematical results; the framework (equidecomposability, paradoxical sets, F₂ non-amenability) is fully proved with 0 sorries.",
+    "assumptions": "5 sorry'd theorems (intentional axioms): hausdorff_free_subgroup (Hausdorff 1914 — SO(3) contains F₂, requires 300+ lines of number theory), banach_tarski (Banach-Tarski 1924 — main paradox, requires 800+ lines via Hausdorff paradox + AC), banach_tarski_pieces_nonmeasurable (classical non-measurability corollary), int_amenable (Markov-Kakutani — ℤ is amenable via Cesàro means/ultrafilter construction), free_group_not_amenable (F₂ is not amenable — equivalent to its paradoxical decomposition). Additionally 1 WIP sorry in banach_tarski_nonmeasurable_measure proof step (h2: μ A + μ A = μ A, needs monotonicity of μ via B ∪ C ⊆ A). Total: 6 sorry tactics in file.",
     "dateAdded": "2026-04-22",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -206,7 +206,7 @@
     "theoremCount": 7,
     "definitionCount": 5,
     "path": "Proofs/LebesgueMeasureOQ06.lean",
-    "sorries": 0
+    "sorries": 6
   },
-  "sorries": 0
+  "sorries": 6
 }

--- a/src/data/proofs/sperner-ndim-oq-04/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-04/meta.json
@@ -21,7 +21,7 @@
       "advanced"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 2,
     "originalContributions": [
       "Definition of door degree and IsKuhnCompatible for abstract Sperner triangulations",
       "Proof that FC simplices have exactly 1 door under Kuhn compatibility",
@@ -39,7 +39,7 @@
     "dateAdded": "2026-04-22",
     "axiomCount": 0,
     "lineCount": 430,
-    "assumptions": "1 sorry: kuhn_walk_result_not_in_visited — TRIVIAL induction; all cases reduce to current_not_visited or subset monotonicity via the IH. Submitted to Aristotle for automated resolution. kuhn_path_terminates is PROVED (non-constructively via sperner_ndim). All other theorems (fc_door_count_eq_one, nonfc_door_count_zero_or_two, nonfc_with_door_has_unique_exit, KuhnStateValid infrastructure) are fully verified. Note: the previously-present kuhn_walk_reaches_fc theorem was REMOVED as mathematically incorrect (mid-walk boundary exits can terminate the walk at a non-FC simplex).",
+    "assumptions": "2 sorries: (1) kuhn_walk_reaches_fc — non-revisiting invariant: the walk with sufficient fuel reaches an FC simplex (pending: door graph path invariant, requires adding unique-facet axiom to SpernerTriangulation and tracking per-visited door history in KuhnState); (2) kuhnPathStart_is_fc — blocked on kuhn_walk_reaches_fc. kuhn_path_terminates is PROVED (non-constructively via sperner_ndim). All door-counting infrastructure (fc_door_count_eq_one, nonfc_door_count_zero_or_two, nonfc_with_door_has_unique_exit, KuhnStateValid) is fully verified.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -260,7 +260,7 @@
     "theoremCount": 8,
     "definitionCount": 5,
     "path": "Proofs/SpernerNDimOQ04.lean",
-    "sorries": 1
+    "sorries": 2
   },
-  "sorries": 1
+  "sorries": 2
 }


### PR DESCRIPTION
## Summary

Gallery integrity audit found 3 proofs with `sorries` fields in meta.json inconsistent with actual sorry tactics in committed Lean source files.

## Proofs Fixed

### lebesgue-measure-oq-06 (0 → 6)
- **meta.json claimed**: `sorries: 0`, `axiomCount: 4`
- **Lean file has**: 6 actual `sorry` tactics
  - Lines 179, 226, 237, 272: 4 listed axiom-theorems (hausdorff_free_subgroup, banach_tarski, banach_tarski_pieces_nonmeasurable, int_amenable)
  - Line 277: `free_group_not_amenable` — sorry'd but missing from axiomCount
  - Line 126: WIP proof step in banach_tarski_nonmeasurable_measure (μ monotonicity)
- **Fix**: sorries 0→6, axiomCount 4→5, updated assumptions

### sperner-ndim-oq-04 (1 → 2)
- **meta.json claimed**: `sorries: 1`, referenced `kuhn_walk_result_not_in_visited`
- **Lean file has**: 2 actual `sorry` tactics
  - Line 357: `kuhn_walk_reaches_fc` (non-revisiting invariant)
  - Line 406: `kuhnPathStart_is_fc` (blocked on walk correctness)
  - `kuhn_walk_result_not_in_visited` is NOT in the file
- **Fix**: sorries 1→2, updated assumptions to name actual sorry'd theorems

### dissection-of-cubes-oq-04 (0 → 3)
- **meta.json claimed**: `sorries: 0` (top-level field was missing)
- **Lean file has**: 3 actual `sorry` tactics (lines 390, 393, 396)
  - 3 WIP proof steps in `cube_isolated_dehn_invariant` for octahedron/dodecahedron/icosahedron edge-count scaling
- **Fix**: added `sorries: 3`, updated assumptions

## Status Fields

Status and badge fields are unchanged — these proofs are correctly classified as `formalized/wip` or `axiomatized/axiom`.

---
Discovered during gallery integrity audit.