### PR TITLE
Research: Erdős #268 — fill 4 sorries in Aristotle companion file

### DIFF
--- a/proofs/Proofs/Erdos268ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos268ProblemAristotle.lean
@@ -51,7 +51,39 @@ theorem finite_has_convergent (A : Set ℕ) (hA : A.Finite) :
 -- If Σ 1/n converges for A, then Σ 1/(n+k) converges (comparison test)
 theorem shifted_summable (A : Set ℕ) (k : ℕ)
     (h : HasConvergentHarmonicSubseries A) :
-    Summable (fun n : A => (1 : ℝ) / (n + k)) := by sorry
+    Summable (fun n : A => (1 : ℝ) / (n + k)) := by
+  unfold HasConvergentHarmonicSubseries at h
+  rcases Nat.eq_zero_or_pos k with rfl | hk
+  · simpa using h
+  · have hdecomp : ∀ n : A, (1 : ℝ) / ((n : ℕ) + k) =
+        (if (n : ℕ) = 0 then (1 : ℝ) / k else 0) +
+        (if (n : ℕ) ≠ 0 then (1 : ℝ) / ((n : ℕ) + k) else 0) := by
+      intro ⟨n, _⟩
+      rcases Nat.eq_zero_or_pos n with rfl | hn
+      · simp
+      · simp [Nat.pos_iff_ne_zero.mp hn]
+    simp_rw [show (fun n : A => (1 : ℝ) / (↑↑n + ↑k)) =
+        fun n : A => (if (n : ℕ) = 0 then (1 : ℝ) / k else 0) +
+                     (if (n : ℕ) ≠ 0 then (1 : ℝ) / (↑↑n + ↑k) else 0) from
+        funext hdecomp]
+    apply Summable.add
+    · by_cases h0 : (0 : ℕ) ∈ A
+      · exact (hasSum_single ⟨0, h0⟩ (fun ⟨n, _⟩ hne => by
+            have : n ≠ 0 := fun heq => hne (Subtype.ext heq)
+            simp [this])).summable
+      · have : (fun n : A => if (n : ℕ) = 0 then (1 : ℝ) / k else 0) = 0 := by
+          ext ⟨n, hn⟩; simp [show n ≠ 0 from fun heq => h0 (heq ▸ hn)]
+        rw [this]; exact summable_zero
+    · apply Summable.of_nonneg_of_le
+      · intro n; split_ifs <;> positivity
+      · intro ⟨n, hn⟩
+        by_cases hn0 : n = 0
+        · simp [hn0]
+        · simp only [show n ≠ 0 from hn0, ne_eq, not_false_eq_true, ↓reduceIte]
+          exact one_div_le_one_div_of_le
+            (by exact_mod_cast Nat.pos_of_ne_zero hn0)
+            (by push_cast; linarith [Nat.cast_nonneg' (n := k)])
+      · exact h
 
 /- ## Section 2: Coordinate Properties -/
 
@@ -59,30 +91,71 @@ theorem shifted_summable (A : Set ℕ) (k : ℕ)
 theorem all_coordinates_positive (d : ℕ) (A : Set ℕ)
     (hA : A.Nonempty) (hconv : HasConvergentHarmonicSubseries A)
     (i : Fin d) :
-    (harmonicPoint d A) i > 0 := by sorry
+    (harmonicPoint d A) i > 0 := by
+  simp only [harmonicPoint, shiftedHarmonicSum]
+  obtain ⟨n, hn⟩ := hA
+  apply tsum_pos (shifted_summable A i.val hconv)
+    (fun m => div_nonneg one_nonneg (Nat.cast_nonneg' _))
+  exact ⟨⟨n, hn⟩, div_pos one_pos (Nat.cast_pos.mpr (by omega))⟩
 
 -- Coordinates decrease: 1/(n+j) < 1/(n+i) for i < j, term-by-term
+-- Requires 0 ∉ A to avoid the degenerate case (1/(0+k) varies with k for 0 ∈ A)
 theorem coordinate_decreasing (A : Set ℕ) (hA : A.Infinite)
     (hconv : HasConvergentHarmonicSubseries A)
+    (h0 : (0 : ℕ) ∉ A)
     (i j : ℕ) (hij : i < j) :
-    shiftedHarmonicSum A j < shiftedHarmonicSum A i := by sorry
+    shiftedHarmonicSum A j < shiftedHarmonicSum A i := by
+  unfold shiftedHarmonicSum
+  obtain ⟨n₀, hn₀⟩ := hA.nonempty
+  have hn₀_pos : 0 < n₀ := Nat.pos_of_ne_zero (fun h => h0 (h ▸ hn₀))
+  apply (shifted_summable A j hconv).tsum_lt_tsum (i := ⟨n₀, hn₀⟩)
+  · intro ⟨n, hn⟩
+    have hn_pos : 0 < n := Nat.pos_of_ne_zero (fun h => h0 (h ▸ hn))
+    apply one_div_le_one_div_of_le
+    · exact_mod_cast Nat.add_pos_left hn_pos i
+    · exact_mod_cast Nat.add_le_add_left (Nat.le_of_lt hij) n
+  · apply one_div_lt_one_div_of_lt
+    · exact_mod_cast Nat.add_pos_left hn₀_pos i
+    · exact_mod_cast Nat.add_lt_add_left hij n₀
+  · exact shifted_summable A i hconv
 
 -- The first coordinate is the largest (follows from decreasing)
+-- Requires 0 ∉ A to use coordinate_decreasing
 theorem first_coordinate_largest (d : ℕ) (hd : d ≥ 2) (A : Set ℕ)
-    (hA : A.Infinite) (hconv : HasConvergentHarmonicSubseries A) :
+    (hA : A.Infinite) (hconv : HasConvergentHarmonicSubseries A)
+    (h0 : (0 : ℕ) ∉ A) :
     ∀ i : Fin d, (harmonicPoint d A) 0 ≥ (harmonicPoint d A) i := by
   intro i
   simp only [harmonicPoint]
   rcases Nat.eq_zero_or_pos i.val with h | h
   · simp [h]
-  · exact le_of_lt (coordinate_decreasing A hA hconv 0 i.val h)
+  · exact le_of_lt (coordinate_decreasing A hA hconv h0 0 i.val h)
 
 /- ## Section 3: Concrete Examples -/
 
 def squaresSet : Set ℕ := {n | ∃ k : ℕ, k ≥ 1 ∧ n = k ^ 2}
 
 -- Σ 1/n² converges (Basel problem, in Mathlib)
-theorem squares_convergent : HasConvergentHarmonicSubseries squaresSet := by sorry
+theorem squares_convergent : HasConvergentHarmonicSubseries squaresSet := by
+  unfold HasConvergentHarmonicSubseries
+  -- Bijection ℕ ≃ squaresSet via k ↦ (k+1)²
+  let e : ℕ → squaresSet := fun k => ⟨(k + 1) ^ 2, k + 1, by omega, rfl⟩
+  have hinj : Function.Injective e := by
+    intro a b h
+    simp only [e, Subtype.ext_iff] at h
+    nlinarith [Nat.succ_pos a, Nat.succ_pos b]
+  have hsurj : Function.Surjective e := by
+    rintro ⟨n, k, hk, hkn⟩
+    exact ⟨k - 1, Subtype.ext (by simp only [e]; rw [Nat.sub_add_cancel hk, hkn])⟩
+  rw [← (Equiv.ofBijective e ⟨hinj, hsurj⟩).summable_iff]
+  -- After bijection: Summable (fun k : ℕ => 1/↑↑(e k)) = Summable (fun k => 1/(k+1)²)
+  -- This is the Basel nat-pow series (p=2) shifted by 1
+  apply (Real.summable_nat_pow_inv.mpr (by norm_num : 1 < 2) |>.comp_injective
+      (show Function.Injective (· + 1 : ℕ → ℕ) from fun a b h => add_right_cancel h)).congr
+  intro k
+  simp only [Function.comp, Equiv.ofBijective_apply, e]
+  push_cast
+  rw [one_div]
 
 def powersOf2Set : Set ℕ := {n | ∃ k : ℕ, n = 2 ^ k}
 


### PR DESCRIPTION
## Summary

Proves all 4 sorries in `Erdos268ProblemAristotle.lean`, the Aristotle companion file for Erdős Problem #268 (harmonic subseries path-connectedness). Also fixes a mathematical bug in `coordinate_decreasing`.

**Changes:**
- `shifted_summable`: prove using domination argument (copied from main file)
- `all_coordinates_positive`: prove using `tsum_pos` method (copied from main file)
- `coordinate_decreasing`: add missing `h0 : 0 ∉ A` hypothesis (theorem was mathematically **false** without it — when 0 ∈ A, the shift-0 sum loses the 1/0=0 term while the shift-1 sum gains 1/(0+1)=1, potentially reversing the inequality). Proves using `Summable.tsum_lt_tsum` method form.
- `first_coordinate_largest`: updated to take and propagate `h0` to `coordinate_decreasing`
- `squares_convergent`: prove via Basel series bijection using `Real.summable_nat_pow_inv`

**Mathematical note on the bug fix:**
The original `coordinate_decreasing` without `h0` was false for A = {0} ∪ {2^k | k≥1}:
- `shiftedHarmonicSum A 0` = 0 + Σ 1/2^k = 1
- `shiftedHarmonicSum A 1` = 1 + Σ 1/(2^k+1) > 1

So sum at shift 1 > sum at shift 0, violating the claimed strict decrease.

## Test plan
- [ ] The companion file now has 0 sorries (down from 4-5)
- [ ] All proofs are adapted from the verified main file `Erdos268Problem.lean`
- [ ] The `coordinate_decreasing` fix is mathematically correct
- [ ] `first_coordinate_largest` updated consistently with the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)