### PR TITLE
Fix: sync shapley-folkman meta.json after sorry reduction (#12006)

### DIFF
--- a/src/data/proofs/shapley-folkman/meta.json
+++ b/src/data/proofs/shapley-folkman/meta.json
@@ -16,7 +16,7 @@
       "intermediate"
     ],
     "badge": "wip",
-    "sorries": 3,
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "convexHull_eq_union",
@@ -61,7 +61,7 @@
       "Caratheodory's theorem (points in convex hull need at most d+1 vertices)",
       "Affine independence and dimension"
     ],
-    "lineCount": 833,
+    "lineCount": 904,
     "mathlib_version": "4.26.0",
     "relatedProblems": []
   },
@@ -187,7 +187,7 @@
       "leanType": "Decomposition S t x -> d.excessIndices.card <= Module.finrank R E"
     }
   ],
-  "sorries": 3,
+  "sorries": 1,
   "leanFile": {
     "imports": [
       "Mathlib.Analysis.Convex.Caratheodory",
@@ -204,11 +204,11 @@
       "Pointwise"
     ],
     "namespace": "ShapleyFolkman",
-    "lineCount": 833,
+    "lineCount": 904,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 1,
-    "sorries": 3,
+    "sorries": 1,
     "path": "Proofs/ShapleyFolkman.lean"
   }
 }


### PR DESCRIPTION
## Summary

- Updates `src/data/proofs/shapley-folkman/meta.json` to reflect the sorry reduction from PR #12006
- `sorries` 3 → 1 in all 3 locations: `meta` object (line 19), top-level field (line 190), and `leanFile` object (line 211)
- `lineCount` 833 → 904 in the `leanFile` object (line 207)

## Verification

- `grep -n "^\s*sorry\b" proofs/Proofs/ShapleyFolkman.lean` confirms exactly 1 sorry (at line 795)
- `wc -l proofs/Proofs/ShapleyFolkman.lean` confirms 904 lines

## Test plan

- [ ] Confirm meta.json has `"sorries": 1` in all 3 locations
- [ ] Confirm meta.json has `"lineCount": 904` in the `leanFile` object
- [ ] No other changes in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)