### PR TITLE
Fix annotation format bugs in 4 gallery entries (shapley-folkman-oq-03, ballot, fourier, triangle)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-04/annotations.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-04/annotations.json
@@ -2,73 +2,154 @@
   {
     "id": "ann-ballot-oq04-header",
     "proofId": "ballot-problem-oq-03-oq-01-oq-04",
-    "range": { "startLine": 1, "endLine": 38 },
+    "range": {
+      "startLine": 1,
+      "endLine": 38
+    },
     "type": "concept",
     "title": "Catalan Recurrence from Ballot Theorem: Proof Architecture",
-    "content": "This file answers the open question from `ballot-problem-oq-03-oq-01` (LGV 2×2): prove the Catalan convolution recurrence using the ballot theorem. The proof has five parts:\n\n1. **Cn Definition** (`def Cn`): Ballot-formula Catalan numbers via binomial coefficients\n2. **Catalan Formula** (`catalan_formula`): The key identity Cn n * (n+1) = C(2n,n)\n3. **Bridge** (`Cn_eq_catalan`): Shows `Cn n = catalan n` (Mathlib root namespace)\n4. **Recurrence** (`Cn_recurrence`): Cₙ₊₁ = ∑Cₖ·Cₙ₋ₖ via Mathlib's `catalan_succ'`\n5. **Characterization** (`Cn_characterization`): C₀ = 1 and the recurrence uniquely determine the Catalan sequence\n\nThe proof is organized in namespace `BallotCatalanRecurrence`, opening `Nat`, `Finset`, and `BigOperators`.",
+    "content": "This file answers the open question from `ballot-problem-oq-03-oq-01` (LGV 2\u00d72): prove the Catalan convolution recurrence using the ballot theorem. The proof has five parts:\n\n1. **Cn Definition** (`def Cn`): Ballot-formula Catalan numbers via binomial coefficients\n2. **Catalan Formula** (`catalan_formula`): The key identity Cn n * (n+1) = C(2n,n)\n3. **Bridge** (`Cn_eq_catalan`): Shows `Cn n = catalan n` (Mathlib root namespace)\n4. **Recurrence** (`Cn_recurrence`): C\u2099\u208a\u2081 = \u2211C\u2096\u00b7C\u2099\u208b\u2096 via Mathlib's `catalan_succ'`\n5. **Characterization** (`Cn_characterization`): C\u2080 = 1 and the recurrence uniquely determine the Catalan sequence\n\nThe proof is organized in namespace `BallotCatalanRecurrence`, opening `Nat`, `Finset`, and `BigOperators`.",
     "mathContext": "The central identity: $C_{n+1} = \\sum_{k=0}^{n} C_k C_{n-k}$ where $C_n = \\binom{2n}{n} - \\binom{2n}{n+1} = \\frac{1}{n+1}\\binom{2n}{n}$ is the ballot Catalan number. The proof proceeds by bridging to Mathlib's `catalan` function via the shared characterization $C_n \\cdot (n+1) = \\binom{2n}{n}$.",
     "significance": "key",
-    "relatedConcepts": ["Catalan numbers", "ballot problem", "Dyck paths", "convolution recurrence", "generating functions"],
-    "prerequisites": ["binomial coefficients", "Mathlib Catalan module", "Finset operations"]
+    "relatedConcepts": [
+      "Catalan numbers",
+      "ballot problem",
+      "Dyck paths",
+      "convolution recurrence",
+      "generating functions"
+    ],
+    "prerequisites": [
+      "binomial coefficients",
+      "Mathlib Catalan module",
+      "Finset operations"
+    ]
   },
   {
     "id": "ann-ballot-oq04-definition",
     "proofId": "ballot-problem-oq-03-oq-01-oq-04",
-    "range": { "startLine": 40, "endLine": 83 },
+    "range": {
+      "startLine": 40,
+      "endLine": 83
+    },
     "type": "definition",
     "title": "Cn Definition and Catalan Formula",
-    "content": "The ballot-formula Catalan number `Cn n = C(2n,n) - C(2n,n+1)` counts monotone lattice paths from (0,0) to (2n,0) that stay non-negative (Dyck paths / ballot sequences). The private lemma `choose_2n_succ` proves `C(2n,n+1)*(n+1) = C(2n,n)*n` via Nat's absorption identity twice and row symmetry. From this, `catalan_formula` derives:\n\n- `Cn n * (n+1) = C(2n,n)*(n+1) - C(2n,n+1)*(n+1)`\n- `= C(2n,n)*(n+1) - C(2n,n)*n` (by choose_2n_succ)\n- `= C(2n,n)` ✓\n\nThe proof uses `zify` to convert natural number arithmetic to integers, then `linear_combination` to close.",
+    "content": "The ballot-formula Catalan number `Cn n = C(2n,n) - C(2n,n+1)` counts monotone lattice paths from (0,0) to (2n,0) that stay non-negative (Dyck paths / ballot sequences). The private lemma `choose_2n_succ` proves `C(2n,n+1)*(n+1) = C(2n,n)*n` via Nat's absorption identity twice and row symmetry. From this, `catalan_formula` derives:\n\n- `Cn n * (n+1) = C(2n,n)*(n+1) - C(2n,n+1)*(n+1)`\n- `= C(2n,n)*(n+1) - C(2n,n)*n` (by choose_2n_succ)\n- `= C(2n,n)` \u2713\n\nThe proof uses `zify` to convert natural number arithmetic to integers, then `linear_combination` to close.",
     "mathContext": "The formula $C_n = \\binom{2n}{n} - \\binom{2n}{n+1}$ is the ballot-counting derivation: out of all $\\binom{2n}{n}$ paths, those that touch the x-axis are in bijection with unrestricted paths to $(2n,2)$ (reflection principle), giving $\\binom{2n}{n+1}$ bad paths. The key algebraic identity $\\binom{2n}{n+1} \\cdot (n+1) = \\binom{2n}{n} \\cdot n$ follows from the absorption identity $\\binom{m}{k} \\cdot k = \\binom{m}{k-1} \\cdot (m-k+1)$.",
     "significance": "key",
-    "relatedConcepts": ["reflection principle", "Bertrand ballot theorem", "Dyck paths", "lattice paths", "binomial absorption"],
-    "prerequisites": ["Nat.choose", "absorption identity Nat.add_one_mul_choose_eq", "Nat.choose_symm_half", "zify tactic", "linear_combination tactic"]
+    "relatedConcepts": [
+      "reflection principle",
+      "Bertrand ballot theorem",
+      "Dyck paths",
+      "lattice paths",
+      "binomial absorption"
+    ],
+    "prerequisites": [
+      "Nat.choose",
+      "absorption identity Nat.add_one_mul_choose_eq",
+      "Nat.choose_symm_half",
+      "zify tactic",
+      "linear_combination tactic"
+    ]
   },
   {
     "id": "ann-ballot-oq04-bridge",
     "proofId": "ballot-problem-oq-03-oq-01-oq-04",
-    "range": { "startLine": 88, "endLine": 101 },
-    "type": "technique",
+    "range": {
+      "startLine": 88,
+      "endLine": 101
+    },
+    "type": "concept",
     "title": "Bridge Lemma: Multiplicative Characterization Uniqueness",
     "content": "The bridge `Cn_eq_catalan` uses a clean technique: two natural-number-valued functions that agree on a multiplicative characterization must be equal.\n\n- `catalan_formula`: `Cn n * (n+1) = C(2n,n) = Nat.centralBinom n`\n- `succ_mul_catalan_eq_centralBinom`: `(n+1) * catalan n = centralBinom n`\n\nApplying `Nat.eq_of_mul_eq_mul_right` with the nonzero right factor `n+1 > 0`, it suffices to show `Cn n * (n+1) = catalan n * (n+1)`, which follows from both equaling `centralBinom n`.\n\nThis bridge pattern generalizes: any natural-number function satisfying `f(n) * (n+1) = centralBinom n` equals `catalan n`. It is reusable for any Catalan-adjacent formalization in Lean 4.",
     "mathContext": "The key identities: $C_n \\cdot (n+1) = \\binom{2n}{n}$ (proved as `catalan_formula`) and $(n+1) \\cdot \\text{catalan}(n) = \\text{centralBinom}(n) = \\binom{2n}{n}$ (Mathlib's `succ_mul_catalan_eq_centralBinom`). Since both expressions equal $\\binom{2n}{n}$ and multiplication by $n+1 > 0$ is injective on $\\mathbb{N}$, we get $C_n = \\text{catalan}(n)$.",
     "significance": "key",
-    "relatedConcepts": ["multiplicative characterization", "uniqueness by cancellation", "centralBinom", "Mathlib catalan function"],
-    "prerequisites": ["catalan_formula", "succ_mul_catalan_eq_centralBinom", "Nat.centralBinom_eq_two_mul_choose", "Nat.eq_of_mul_eq_mul_right"]
+    "relatedConcepts": [
+      "multiplicative characterization",
+      "uniqueness by cancellation",
+      "centralBinom",
+      "Mathlib catalan function"
+    ],
+    "prerequisites": [
+      "catalan_formula",
+      "succ_mul_catalan_eq_centralBinom",
+      "Nat.centralBinom_eq_two_mul_choose",
+      "Nat.eq_of_mul_eq_mul_right"
+    ]
   },
   {
     "id": "ann-ballot-oq04-recurrence",
     "proofId": "ballot-problem-oq-03-oq-01-oq-04",
-    "range": { "startLine": 107, "endLine": 122 },
-    "type": "proof-step",
+    "range": {
+      "startLine": 107,
+      "endLine": 122
+    },
+    "type": "tactic",
     "title": "Catalan Recurrence via Mathlib catalan_succ'",
-    "content": "The recurrence proof `Cn_recurrence` is a 3-step rewrite chain using `simp_rw [Cn_eq_catalan]` to replace all `Cn` with `catalan`, then:\n\n1. `catalan_succ'` rewrites `catalan (n+1)` to the antidiagonal form: `∑ p ∈ antidiagonal n, catalan p.1 * catalan p.2`\n2. `Finset.Nat.sum_antidiagonal_eq_sum_range_succ` converts to the range-sum form `∑ k ∈ range (n+1), catalan k * catalan (n-k)`\n3. The goal closes because `Cn = catalan` everywhere (via `simp_rw`).\n\nThe proof is remarkably short (3 lines) because the heavy lifting is done by the bridge `Cn_eq_catalan` and Mathlib's `catalan_succ'`.",
+    "content": "The recurrence proof `Cn_recurrence` is a 3-step rewrite chain using `simp_rw [Cn_eq_catalan]` to replace all `Cn` with `catalan`, then:\n\n1. `catalan_succ'` rewrites `catalan (n+1)` to the antidiagonal form: `\u2211 p \u2208 antidiagonal n, catalan p.1 * catalan p.2`\n2. `Finset.Nat.sum_antidiagonal_eq_sum_range_succ` converts to the range-sum form `\u2211 k \u2208 range (n+1), catalan k * catalan (n-k)`\n3. The goal closes because `Cn = catalan` everywhere (via `simp_rw`).\n\nThe proof is remarkably short (3 lines) because the heavy lifting is done by the bridge `Cn_eq_catalan` and Mathlib's `catalan_succ'`.",
     "mathContext": "`catalan_succ'` is Mathlib's antidiagonal form: $C_{n+1} = \\sum_{(a,b) \\in \\text{antidiag}(n)} C_a \\cdot C_b$ where $\\text{antidiag}(n) = \\{(a,b) : a+b=n\\}$. After `sum_antidiagonal_eq_sum_range_succ`: $= \\sum_{k=0}^{n} C_k \\cdot C_{n-k}$, which is the standard range-indexed convolution.",
     "significance": "key",
-    "relatedConcepts": ["antidiagonal Finset", "convolution recurrence", "Dyck path decomposition", "Catalan generating function C(x) = 1 + x·C(x)²"],
-    "prerequisites": ["Cn_eq_catalan", "catalan_succ'", "Finset.Nat.sum_antidiagonal_eq_sum_range_succ", "simp_rw tactic"]
+    "relatedConcepts": [
+      "antidiagonal Finset",
+      "convolution recurrence",
+      "Dyck path decomposition",
+      "Catalan generating function C(x) = 1 + x\u00b7C(x)\u00b2"
+    ],
+    "prerequisites": [
+      "Cn_eq_catalan",
+      "catalan_succ'",
+      "Finset.Nat.sum_antidiagonal_eq_sum_range_succ",
+      "simp_rw tactic"
+    ]
   },
   {
     "id": "ann-ballot-oq04-consequences",
     "proofId": "ballot-problem-oq-03-oq-01-oq-04",
-    "range": { "startLine": 124, "endLine": 156 },
-    "type": "context",
+    "range": {
+      "startLine": 124,
+      "endLine": 156
+    },
+    "type": "concept",
     "title": "Verifications, Base Cases, and Symmetry",
-    "content": "Part IV establishes several consequences of the recurrence:\n\n**Numerical verifications**: `native_decide` checks Cn 1 = Cn 0 * Cn 0, Cn 2 = ..., Cn 3 = ..., Cn 4 = ... These serve as sanity checks on the definition and recurrence.\n\n**Cn_pos**: Every Catalan number is strictly positive. Proof: from `catalan_formula`, `Cn n * (n+1) = C(2n,n) > 0`, so `Cn n ≠ 0`, so `Cn n > 0`.\n\n**Base cases**: `Cn_zero : Cn 0 = 1`, `Cn_one : Cn 1 = 1`, `Cn_two : Cn 2 = 2` — proved by `simp` or `native_decide`.\n\n**Symmetry**: `Cn_recurrence_sym` notes that the convolution sum is symmetric: `∑ Cₖ · Cₙ₋ₖ = ∑ Cₙ₋ₖ · Cₖ`, proved by `ring` on each summand.",
+    "content": "Part IV establishes several consequences of the recurrence:\n\n**Numerical verifications**: `native_decide` checks Cn 1 = Cn 0 * Cn 0, Cn 2 = ..., Cn 3 = ..., Cn 4 = ... These serve as sanity checks on the definition and recurrence.\n\n**Cn_pos**: Every Catalan number is strictly positive. Proof: from `catalan_formula`, `Cn n * (n+1) = C(2n,n) > 0`, so `Cn n \u2260 0`, so `Cn n > 0`.\n\n**Base cases**: `Cn_zero : Cn 0 = 1`, `Cn_one : Cn 1 = 1`, `Cn_two : Cn 2 = 2` \u2014 proved by `simp` or `native_decide`.\n\n**Symmetry**: `Cn_recurrence_sym` notes that the convolution sum is symmetric: `\u2211 C\u2096 \u00b7 C\u2099\u208b\u2096 = \u2211 C\u2099\u208b\u2096 \u00b7 C\u2096`, proved by `ring` on each summand.",
     "mathContext": "The Catalan sequence begins $C_0=1, C_1=1, C_2=2, C_3=5, C_4=14, C_5=42, \\ldots$ (OEIS A000108). Positivity $C_n > 0$ follows from $C_n \\cdot (n+1) = \\binom{2n}{n} \\geq 1$ and $n+1 \\geq 1$. The symmetry $\\sum_{k=0}^n C_k C_{n-k} = \\sum_{k=0}^n C_{n-k} C_k$ is trivial but useful for identifying alternate forms in the literature.",
     "significance": "supporting",
-    "relatedConcepts": ["Catalan sequence OEIS A000108", "positivity of combinatorial quantities", "recurrence symmetry", "native_decide"],
-    "prerequisites": ["Cn_recurrence", "catalan_formula", "Nat.choose_pos", "Nat.pos_of_ne_zero"]
+    "relatedConcepts": [
+      "Catalan sequence OEIS A000108",
+      "positivity of combinatorial quantities",
+      "recurrence symmetry",
+      "native_decide"
+    ],
+    "prerequisites": [
+      "Cn_recurrence",
+      "catalan_formula",
+      "Nat.choose_pos",
+      "Nat.pos_of_ne_zero"
+    ]
   },
   {
     "id": "ann-ballot-oq04-ballot-form",
     "proofId": "ballot-problem-oq-03-oq-01-oq-04",
-    "range": { "startLine": 158, "endLine": 182 },
+    "range": {
+      "startLine": 158,
+      "endLine": 182
+    },
     "type": "concept",
     "title": "Ballot Interpretation and Characterization Theorem",
-    "content": "Part V provides two concluding results:\n\n**Cn_ballot_recurrence_interpretation**: The algebraic `Cn_recurrence` is restated with an attached docstring explaining the combinatorial meaning. A Dyck path of length 2(n+1) returns to 0 for the first time at step 2(k+1) for some k ∈ {0,...,n}, splitting into a prefix (length 2k) and suffix (length 2(n-k)), counted by `Cn k` and `Cn (n-k)` respectively. The convolution recurrence is thus a formal encoding of this bijection.\n\n**Cn_characterization**: Packages the initial condition `Cn 0 = 1` and the recurrence as an `And` proposition, providing the complete characterization: any sequence satisfying these two conditions is the Catalan sequence.",
-    "mathContext": "The characterization $C_0 = 1$, $C_{n+1} = \\sum_{k=0}^n C_k C_{n-k}$ uniquely determines the sequence $1, 1, 2, 5, 14, 42, \\ldots$ This is equivalent to the generating function equation $C(x) = 1 + x \\cdot C(x)^2$, whose solution is $C(x) = \\frac{1 - \\sqrt{1-4x}}{2x}$. In Lean, `Cn_characterization : Cn 0 = 1 ∧ ∀ n, Cn (n+1) = ∑ k ∈ range (n+1), Cn k * Cn (n-k)`.",
+    "content": "Part V provides two concluding results:\n\n**Cn_ballot_recurrence_interpretation**: The algebraic `Cn_recurrence` is restated with an attached docstring explaining the combinatorial meaning. A Dyck path of length 2(n+1) returns to 0 for the first time at step 2(k+1) for some k \u2208 {0,...,n}, splitting into a prefix (length 2k) and suffix (length 2(n-k)), counted by `Cn k` and `Cn (n-k)` respectively. The convolution recurrence is thus a formal encoding of this bijection.\n\n**Cn_characterization**: Packages the initial condition `Cn 0 = 1` and the recurrence as an `And` proposition, providing the complete characterization: any sequence satisfying these two conditions is the Catalan sequence.",
+    "mathContext": "The characterization $C_0 = 1$, $C_{n+1} = \\sum_{k=0}^n C_k C_{n-k}$ uniquely determines the sequence $1, 1, 2, 5, 14, 42, \\ldots$ This is equivalent to the generating function equation $C(x) = 1 + x \\cdot C(x)^2$, whose solution is $C(x) = \\frac{1 - \\sqrt{1-4x}}{2x}$. In Lean, `Cn_characterization : Cn 0 = 1 \u2227 \u2200 n, Cn (n+1) = \u2211 k \u2208 range (n+1), Cn k * Cn (n-k)`.",
     "significance": "key",
-    "relatedConcepts": ["Dyck path first-return decomposition", "ballot sequence decomposition", "Catalan generating function", "sequence characterization", "full binary trees"],
-    "prerequisites": ["Cn_zero", "Cn_recurrence", "Dyck paths", "first-return decomposition"]
+    "relatedConcepts": [
+      "Dyck path first-return decomposition",
+      "ballot sequence decomposition",
+      "Catalan generating function",
+      "sequence characterization",
+      "full binary trees"
+    ],
+    "prerequisites": [
+      "Cn_zero",
+      "Cn_recurrence",
+      "Dyck paths",
+      "first-return decomposition"
+    ]
   }
 ]

--- a/src/data/proofs/fourier-series-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/fourier-series-oq-02-oq-02/annotations.json
@@ -2,97 +2,195 @@
   {
     "id": "ann-fsoq02oq02-header",
     "proofId": "fourier-series-oq-02-oq-02",
-    "range": { "startLine": 1, "endLine": 43 },
-    "type": "context",
+    "range": {
+      "startLine": 1,
+      "endLine": 43
+    },
+    "type": "concept",
     "title": "Elementary Alternative to Parseval's Theorem",
-    "content": "This file answers the question: is there a proof of Fourier coefficient square-summability that avoids L² theory entirely? The answer is yes — for $\\alpha$-Hölder functions with $\\alpha > 1/2$, the decay bound $\\|\\hat{c}_n\\| = O(|n|^{-\\alpha})$ squared gives $O(|n|^{-2\\alpha})$, and since $2\\alpha > 1$, this is dominated by a convergent p-series.\n\nThe proof uses only three ingredients: the quantitative Hölder decay bound (from `FourierSeriesOQ02`), the p-series criterion $\\sum 1/n^{\\beta} < \\infty$ for $\\beta > 1$, and the comparison test. No measure theory, no $L^2$ spaces, no Parseval's identity required.\n\nThe `set_option maxHeartbeats 800000` reflects the cost of the algebraic manipulations involving real-power arithmetic (`Real.rpow`).",
-    "mathContext": "Main theorem: if $f : \\text{AddCircle}\\, T \\to \\mathbb{C}$ is $\\alpha$-Hölder ($\\alpha > 1/2$), then $\\sum_{n:\\mathbb{Z}} \\|\\hat{c}_n(f)\\|^2 < \\infty$. Proof path: Hölder decay $\\Rightarrow$ squared bound $O(|n|^{-2\\alpha})$ $\\Rightarrow$ p-series comparison ($2\\alpha > 1$) $\\Rightarrow$ summability.",
+    "content": "This file answers the question: is there a proof of Fourier coefficient square-summability that avoids L\u00b2 theory entirely? The answer is yes \u2014 for $\\alpha$-H\u00f6lder functions with $\\alpha > 1/2$, the decay bound $\\|\\hat{c}_n\\| = O(|n|^{-\\alpha})$ squared gives $O(|n|^{-2\\alpha})$, and since $2\\alpha > 1$, this is dominated by a convergent p-series.\n\nThe proof uses only three ingredients: the quantitative H\u00f6lder decay bound (from `FourierSeriesOQ02`), the p-series criterion $\\sum 1/n^{\\beta} < \\infty$ for $\\beta > 1$, and the comparison test. No measure theory, no $L^2$ spaces, no Parseval's identity required.\n\nThe `set_option maxHeartbeats 800000` reflects the cost of the algebraic manipulations involving real-power arithmetic (`Real.rpow`).",
+    "mathContext": "Main theorem: if $f : \\text{AddCircle}\\, T \\to \\mathbb{C}$ is $\\alpha$-H\u00f6lder ($\\alpha > 1/2$), then $\\sum_{n:\\mathbb{Z}} \\|\\hat{c}_n(f)\\|^2 < \\infty$. Proof path: H\u00f6lder decay $\\Rightarrow$ squared bound $O(|n|^{-2\\alpha})$ $\\Rightarrow$ p-series comparison ($2\\alpha > 1$) $\\Rightarrow$ summability.",
     "significance": "key",
-    "relatedConcepts": ["Fourier series", "Hölder continuity", "p-series", "comparison test", "Parseval's theorem"],
-    "prerequisites": ["Fourier coefficients", "Hölder continuity", "p-series convergence", "FourierSeriesOQ02 decay bound"]
+    "relatedConcepts": [
+      "Fourier series",
+      "H\u00f6lder continuity",
+      "p-series",
+      "comparison test",
+      "Parseval's theorem"
+    ],
+    "prerequisites": [
+      "Fourier coefficients",
+      "H\u00f6lder continuity",
+      "p-series convergence",
+      "FourierSeriesOQ02 decay bound"
+    ]
   },
   {
     "id": "ann-fsoq02oq02-pseries-nat",
     "proofId": "fourier-series-oq-02-oq-02",
-    "range": { "startLine": 52, "endLine": 56 },
-    "type": "technique",
-    "title": "p-Series over ℕ via Real.summable_nat_rpow_inv",
-    "content": "`summable_const_div_nat_rpow` packages the Mathlib p-series result for direct use. The proof `simp_rw [div_eq_mul_inv]` converts `K/n^β` to `K * (n^β)⁻¹`, then `(Real.summable_nat_rpow_inv.2 hβ).mul_left K` applies the Mathlib p-series theorem and scales by the constant $K$.\n\nThis is a clean adapter pattern: `Real.summable_nat_rpow_inv` states $\\sum 1/n^\\beta < \\infty$ iff $\\beta > 1$, and we need the `K`-scaled version with $K \\geq 0$.",
-    "mathContext": "`Real.summable_nat_rpow_inv : Summable (fun n : ℕ => (n : ℝ)⁻¹ ^ β) ↔ 1 < β`. We use the direction `.2 hβ` then scale: $(\\text{Summable}\\, g) \\Rightarrow (\\text{Summable}\\, (K \\cdot g))$ via `.mul_left K`.",
-    "significance": "technical",
-    "relatedConcepts": ["p-series", "Real.summable_nat_rpow_inv", "Mathlib analysis", "summability scaling"],
-    "prerequisites": ["real analysis", "p-series convergence", "Mathlib PSeries module"]
+    "range": {
+      "startLine": 52,
+      "endLine": 56
+    },
+    "type": "concept",
+    "title": "p-Series over \u2115 via Real.summable_nat_rpow_inv",
+    "content": "`summable_const_div_nat_rpow` packages the Mathlib p-series result for direct use. The proof `simp_rw [div_eq_mul_inv]` converts `K/n^\u03b2` to `K * (n^\u03b2)\u207b\u00b9`, then `(Real.summable_nat_rpow_inv.2 h\u03b2).mul_left K` applies the Mathlib p-series theorem and scales by the constant $K$.\n\nThis is a clean adapter pattern: `Real.summable_nat_rpow_inv` states $\\sum 1/n^\\beta < \\infty$ iff $\\beta > 1$, and we need the `K`-scaled version with $K \\geq 0$.",
+    "mathContext": "`Real.summable_nat_rpow_inv : Summable (fun n : \u2115 => (n : \u211d)\u207b\u00b9 ^ \u03b2) \u2194 1 < \u03b2`. We use the direction `.2 h\u03b2` then scale: $(\\text{Summable}\\, g) \\Rightarrow (\\text{Summable}\\, (K \\cdot g))$ via `.mul_left K`.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "p-series",
+      "Real.summable_nat_rpow_inv",
+      "Mathlib analysis",
+      "summability scaling"
+    ],
+    "prerequisites": [
+      "real analysis",
+      "p-series convergence",
+      "Mathlib PSeries module"
+    ]
   },
   {
     "id": "ann-fsoq02oq02-pseries-int",
     "proofId": "fourier-series-oq-02-oq-02",
-    "range": { "startLine": 58, "endLine": 69 },
-    "type": "technique",
-    "title": "p-Series over ℤ by Splitting into ℕ Halves",
+    "range": {
+      "startLine": 58,
+      "endLine": 69
+    },
+    "type": "concept",
+    "title": "p-Series over \u2124 by Splitting into \u2115 Halves",
     "content": "`summable_const_div_int_rpow` extends the p-series to the integer index set. The Mathlib lemma `summable_int_iff_summable_nat_and_neg` reduces $\\mathbb{Z}$-summability to two $\\mathbb{N}$-summability questions: the positive half $\\sum_{n:\\mathbb{N}} K/|n|^{\\beta}$ and the negative half $\\sum_{n:\\mathbb{N}} K/|-(n:\\mathbb{Z})|^{\\beta}$.\n\nBoth halves reduce to the same $\\mathbb{N}$ p-series after simplifying the absolute values: `abs_of_nonneg (Nat.cast_nonneg' n)` for the positive half, and `abs_neg` + `abs_of_nonneg` for the negative half. The `convert ... using 1` tactic handles the coercion bookkeeping.",
     "mathContext": "$\\sum_{n:\\mathbb{Z}} K/|n|^\\beta < \\infty$ via `summable_int_iff_summable_nat_and_neg`: splits to $\\sum_{n:\\mathbb{N}} K/n^\\beta$ (positive) and $\\sum_{n:\\mathbb{N}} K/n^\\beta$ (negative), both convergent for $\\beta > 1$. Key: $|{-(n:\\mathbb{Z})}| = |(n:\\mathbb{Z})| = n$ for $n : \\mathbb{N}$.",
     "significance": "supporting",
-    "relatedConcepts": ["integer summability", "summable_int_iff_summable_nat_and_neg", "absolute value over ℤ", "Lean convert tactic"],
-    "prerequisites": ["p-series over ℕ", "Mathlib integer summability", "absolute value arithmetic"]
+    "relatedConcepts": [
+      "integer summability",
+      "summable_int_iff_summable_nat_and_neg",
+      "absolute value over \u2124",
+      "Lean convert tactic"
+    ],
+    "prerequisites": [
+      "p-series over \u2115",
+      "Mathlib integer summability",
+      "absolute value arithmetic"
+    ]
   },
   {
     "id": "ann-fsoq02oq02-decay-helper",
     "proofId": "fourier-series-oq-02-oq-02",
-    "range": { "startLine": 78, "endLine": 83 },
-    "type": "technique",
-    "title": "Helper: (a·b^α)² = a²·b^{2α} via rpow_mul_natCast",
-    "content": "`mul_rpow_sq` is a private helper that performs the key algebraic step: squaring a product of the form $a \\cdot b^\\alpha$. The proof rewrites using `Real.rpow_mul_natCast hb α 2` to get $b^{\\alpha \\cdot 2} = (b^\\alpha)^2$, then uses `push_cast` and `ring` to complete the algebra.\n\nThe `rpow_mul_natCast` bridge is necessary because $b^\\alpha$ is a real power (`Real.rpow`) while squaring produces a natural number power. Without this bridge, `norm_cast` would fail since the exponents live in different types.",
-    "mathContext": "Identity: $(a \\cdot b^\\alpha)^2 = a^2 \\cdot b^{2\\alpha}$. Key step: `Real.rpow_mul_natCast hb α 2 : b ^ (α * 2) = (b ^ α) ^ 2` bridges `Real.rpow` and `HPow.hPow ℝ ℕ ℝ`. Then `push_cast` makes $2\\alpha = \\alpha \\cdot 2$ visible, `ring` closes.",
-    "significance": "technical",
-    "relatedConcepts": ["Real.rpow", "rpow_mul_natCast", "real power arithmetic", "Lean norm_cast"],
-    "prerequisites": ["real powers in Lean 4", "Mathlib rpow theorems", "push_cast tactic"]
+    "range": {
+      "startLine": 78,
+      "endLine": 83
+    },
+    "type": "concept",
+    "title": "Helper: (a\u00b7b^\u03b1)\u00b2 = a\u00b2\u00b7b^{2\u03b1} via rpow_mul_natCast",
+    "content": "`mul_rpow_sq` is a private helper that performs the key algebraic step: squaring a product of the form $a \\cdot b^\\alpha$. The proof rewrites using `Real.rpow_mul_natCast hb \u03b1 2` to get $b^{\\alpha \\cdot 2} = (b^\\alpha)^2$, then uses `push_cast` and `ring` to complete the algebra.\n\nThe `rpow_mul_natCast` bridge is necessary because $b^\\alpha$ is a real power (`Real.rpow`) while squaring produces a natural number power. Without this bridge, `norm_cast` would fail since the exponents live in different types.",
+    "mathContext": "Identity: $(a \\cdot b^\\alpha)^2 = a^2 \\cdot b^{2\\alpha}$. Key step: `Real.rpow_mul_natCast hb \u03b1 2 : b ^ (\u03b1 * 2) = (b ^ \u03b1) ^ 2` bridges `Real.rpow` and `HPow.hPow \u211d \u2115 \u211d`. Then `push_cast` makes $2\\alpha = \\alpha \\cdot 2$ visible, `ring` closes.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Real.rpow",
+      "rpow_mul_natCast",
+      "real power arithmetic",
+      "Lean norm_cast"
+    ],
+    "prerequisites": [
+      "real powers in Lean 4",
+      "Mathlib rpow theorems",
+      "push_cast tactic"
+    ]
   },
   {
     "id": "ann-fsoq02oq02-sq-bound",
     "proofId": "fourier-series-oq-02-oq-02",
-    "range": { "startLine": 87, "endLine": 131 },
+    "range": {
+      "startLine": 87,
+      "endLine": 131
+    },
     "type": "insight",
-    "title": "Squared Decay Bound: ‖ĉ_n‖² ≤ K/|n|^{2α}",
-    "content": "`fourierCoeff_sq_le_pseries_term` is the bridge between the Hölder decay bound and the p-series comparison. For $n \\neq 0$:\n1. Get Hölder decay from the parent proof: $\\|\\hat{c}_n(f)\\| \\leq (C/2) \\cdot (T/(2|n|))^\\alpha$\n2. Square via `pow_le_pow_left₀`: $\\|\\hat{c}_n(f)\\|^2 \\leq [(C/2)(T/(2|n|))^\\alpha]^2$  \n3. Expand the square using `mul_rpow_sq` and `Real.div_rpow` to factor out $|n|^{2\\alpha}$: $= (C/2)^2 (T/2)^{2\\alpha} / |n|^{2\\alpha}$\n\nThe field_simp step in `h_split : T/(2|n|) = (T/2)/|n|` is the key algebraic reduction that allows `Real.div_rpow` to factor the absolute value out of the exponent.",
-    "mathContext": "Final bound: $\\|\\hat{c}_n(f)\\|^2 \\leq K/|n|^{2\\alpha}$ where $K = (C/2)^2 \\cdot (T/2)^{2\\alpha}$. This converts the Hölder bound $O(|n|^{-\\alpha})$ into the p-series term $O(|n|^{-2\\alpha})$ suitable for the comparison test with $\\beta = 2\\alpha > 1$.",
+    "title": "Squared Decay Bound: \u2016\u0109_n\u2016\u00b2 \u2264 K/|n|^{2\u03b1}",
+    "content": "`fourierCoeff_sq_le_pseries_term` is the bridge between the H\u00f6lder decay bound and the p-series comparison. For $n \\neq 0$:\n1. Get H\u00f6lder decay from the parent proof: $\\|\\hat{c}_n(f)\\| \\leq (C/2) \\cdot (T/(2|n|))^\\alpha$\n2. Square via `pow_le_pow_left\u2080`: $\\|\\hat{c}_n(f)\\|^2 \\leq [(C/2)(T/(2|n|))^\\alpha]^2$  \n3. Expand the square using `mul_rpow_sq` and `Real.div_rpow` to factor out $|n|^{2\\alpha}$: $= (C/2)^2 (T/2)^{2\\alpha} / |n|^{2\\alpha}$\n\nThe field_simp step in `h_split : T/(2|n|) = (T/2)/|n|` is the key algebraic reduction that allows `Real.div_rpow` to factor the absolute value out of the exponent.",
+    "mathContext": "Final bound: $\\|\\hat{c}_n(f)\\|^2 \\leq K/|n|^{2\\alpha}$ where $K = (C/2)^2 \\cdot (T/2)^{2\\alpha}$. This converts the H\u00f6lder bound $O(|n|^{-\\alpha})$ into the p-series term $O(|n|^{-2\\alpha})$ suitable for the comparison test with $\\beta = 2\\alpha > 1$.",
     "significance": "key",
-    "relatedConcepts": ["Hölder decay", "squaring inequalities", "pow_le_pow_left₀", "Real.div_rpow", "comparison test setup"],
-    "prerequisites": ["fourierCoeff_holder_decay from FourierSeriesOQ02", "mul_rpow_sq helper", "Real.div_rpow"]
+    "relatedConcepts": [
+      "H\u00f6lder decay",
+      "squaring inequalities",
+      "pow_le_pow_left\u2080",
+      "Real.div_rpow",
+      "comparison test setup"
+    ],
+    "prerequisites": [
+      "fourierCoeff_holder_decay from FourierSeriesOQ02",
+      "mul_rpow_sq helper",
+      "Real.div_rpow"
+    ]
   },
   {
     "id": "ann-fsoq02oq02-main-theorem",
     "proofId": "fourier-series-oq-02-oq-02",
-    "range": { "startLine": 132, "endLine": 164 },
+    "range": {
+      "startLine": 132,
+      "endLine": 164
+    },
     "type": "insight",
     "title": "Main Theorem: Square-Summability via Comparison Test",
-    "content": "`fourierCoeff_sq_summable_of_holder_pseries` is the main result. The proof structure:\n1. Derive $2\\alpha > 1$ from $\\alpha > 1/2$ via `linarith`\n2. Set $K = (C/2)^2 (T/2)^{2\\alpha}$ as a local definition\n3. Get convergence of the dominating series $\\sum K/|n|^{2\\alpha}$ from `summable_const_div_int_rpow`\n4. Apply `Summable.of_norm_bounded_eventually` (the comparison test with cofinite exceptions)\n5. Handle the $n=0$ exception: `Filter.eventually_cofinite.mpr` with `Set.finite_singleton (0:ℤ)` shows $\\{0\\}$ is the only exception\n6. For $n \\neq 0$: use `fourierCoeff_sq_le_pseries_term` by contradiction\n\nThe cofinite filter approach is elegant: `Summable.of_norm_bounded_eventually` allows the bound to fail on finitely many terms (here just $n=0$ where $|n|=0$ makes $K/|n|^{2\\alpha}$ ill-defined).",
+    "content": "`fourierCoeff_sq_summable_of_holder_pseries` is the main result. The proof structure:\n1. Derive $2\\alpha > 1$ from $\\alpha > 1/2$ via `linarith`\n2. Set $K = (C/2)^2 (T/2)^{2\\alpha}$ as a local definition\n3. Get convergence of the dominating series $\\sum K/|n|^{2\\alpha}$ from `summable_const_div_int_rpow`\n4. Apply `Summable.of_norm_bounded_eventually` (the comparison test with cofinite exceptions)\n5. Handle the $n=0$ exception: `Filter.eventually_cofinite.mpr` with `Set.finite_singleton (0:\u2124)` shows $\\{0\\}$ is the only exception\n6. For $n \\neq 0$: use `fourierCoeff_sq_le_pseries_term` by contradiction\n\nThe cofinite filter approach is elegant: `Summable.of_norm_bounded_eventually` allows the bound to fail on finitely many terms (here just $n=0$ where $|n|=0$ makes $K/|n|^{2\\alpha}$ ill-defined).",
     "mathContext": "Applied theorem: `Summable.of_norm_bounded_eventually`: if $\\sum g_n < \\infty$ and $|f_n| \\leq g_n$ for all but finitely many $n$, then $\\sum f_n < \\infty$. Here $f_n = \\|\\hat{c}_n\\|^2$, $g_n = K/|n|^{2\\alpha}$, exceptions $= \\{0\\}$.",
     "significance": "key",
-    "relatedConcepts": ["comparison test", "Summable.of_norm_bounded_eventually", "cofinite filter", "square-summability"],
-    "prerequisites": ["summable_const_div_int_rpow", "fourierCoeff_sq_le_pseries_term", "cofinite filter in Lean 4"]
+    "relatedConcepts": [
+      "comparison test",
+      "Summable.of_norm_bounded_eventually",
+      "cofinite filter",
+      "square-summability"
+    ],
+    "prerequisites": [
+      "summable_const_div_int_rpow",
+      "fourierCoeff_sq_le_pseries_term",
+      "cofinite filter in Lean 4"
+    ]
   },
   {
     "id": "ann-fsoq02oq02-sharpness",
     "proofId": "fourier-series-oq-02-oq-02",
-    "range": { "startLine": 189, "endLine": 224 },
+    "range": {
+      "startLine": 189,
+      "endLine": 224
+    },
     "type": "insight",
-    "title": "Sharpness: α = 1/2 is the Critical Threshold",
-    "content": "`holder_half_is_critical_for_pseries` proves that the p-series argument fails at exactly $\\alpha = 1/2$: the squared bound becomes $O(|n|^{-1})$ and the harmonic series $\\sum 1/|n|$ diverges.\n\nThe proof is fully machine-checked. The key technique avoids direct ℤ-harmonic series divergence. Instead:\n1. Assume the universal summability statement for all Hölder functions at $\\alpha = 1/2$\n2. Instantiate with the zero function $f = 0$ (trivially Hölder with constant 1, exponent $1/2$) and $T = 2\\pi$, $C = 1$\n3. Apply `summable_int_iff_summable_nat_and_neg` to extract ℕ summability of the positive half\n4. Rescale by $4/\\pi$ via `.mul_left (4 / Real.pi)` and algebraic simplification to recover `Summable (fun n : ℕ => 1 / n)`\n5. Derive contradiction: `Real.summable_nat_rpow_inv.not.mpr (by norm_num)` shows the harmonic series over ℕ diverges (p=1 fails p > 1)\n\nThis routing through ℕ elegantly sidesteps the need to prove ℤ-harmonic divergence directly.",
-    "mathContext": "The theorem negates: $\\forall C, \\alpha, f$, if $(\\alpha : \\mathbb{R}) = 1/2$ and $f$ is $\\alpha$-Hölder, then $\\sum_{n:\\mathbb{Z}} (C/2)^2 \\pi^{2\\alpha} / |n|^{2\\alpha}$ converges. Taking $f=0$, $C=1$, $\\alpha=1/2$: the summability hypothesis reduces to $\\sum_{n:\\mathbb{N}} (1/4)\\pi / |n|$ being summable. Rescaling by $4/\\pi$ gives $\\sum_{n:\\mathbb{N}} 1/n$ summable — contradicting `Real.summable_nat_rpow_inv.not.mpr (by norm_num : ¬ 1 < 1)`.",
+    "title": "Sharpness: \u03b1 = 1/2 is the Critical Threshold",
+    "content": "`holder_half_is_critical_for_pseries` proves that the p-series argument fails at exactly $\\alpha = 1/2$: the squared bound becomes $O(|n|^{-1})$ and the harmonic series $\\sum 1/|n|$ diverges.\n\nThe proof is fully machine-checked. The key technique avoids direct \u2124-harmonic series divergence. Instead:\n1. Assume the universal summability statement for all H\u00f6lder functions at $\\alpha = 1/2$\n2. Instantiate with the zero function $f = 0$ (trivially H\u00f6lder with constant 1, exponent $1/2$) and $T = 2\\pi$, $C = 1$\n3. Apply `summable_int_iff_summable_nat_and_neg` to extract \u2115 summability of the positive half\n4. Rescale by $4/\\pi$ via `.mul_left (4 / Real.pi)` and algebraic simplification to recover `Summable (fun n : \u2115 => 1 / n)`\n5. Derive contradiction: `Real.summable_nat_rpow_inv.not.mpr (by norm_num)` shows the harmonic series over \u2115 diverges (p=1 fails p > 1)\n\nThis routing through \u2115 elegantly sidesteps the need to prove \u2124-harmonic divergence directly.",
+    "mathContext": "The theorem negates: $\\forall C, \\alpha, f$, if $(\\alpha : \\mathbb{R}) = 1/2$ and $f$ is $\\alpha$-H\u00f6lder, then $\\sum_{n:\\mathbb{Z}} (C/2)^2 \\pi^{2\\alpha} / |n|^{2\\alpha}$ converges. Taking $f=0$, $C=1$, $\\alpha=1/2$: the summability hypothesis reduces to $\\sum_{n:\\mathbb{N}} (1/4)\\pi / |n|$ being summable. Rescaling by $4/\\pi$ gives $\\sum_{n:\\mathbb{N}} 1/n$ summable \u2014 contradicting `Real.summable_nat_rpow_inv.not.mpr (by norm_num : \u00ac 1 < 1)`.",
     "significance": "supporting",
-    "relatedConcepts": ["harmonic series divergence", "sharp threshold", "critical Hölder exponent", "Real.summable_nat_rpow_inv"],
-    "prerequisites": ["Real.summable_nat_rpow_inv divergence direction", "summable_int_iff_summable_nat_and_neg"]
+    "relatedConcepts": [
+      "harmonic series divergence",
+      "sharp threshold",
+      "critical H\u00f6lder exponent",
+      "Real.summable_nat_rpow_inv"
+    ],
+    "prerequisites": [
+      "Real.summable_nat_rpow_inv divergence direction",
+      "summable_int_iff_summable_nat_and_neg"
+    ]
   },
   {
     "id": "ann-fsoq02oq02-comparison",
     "proofId": "fourier-series-oq-02-oq-02",
-    "range": { "startLine": 165, "endLine": 188 },
+    "range": {
+      "startLine": 165,
+      "endLine": 188
+    },
     "type": "insight",
     "title": "Two Routes to the Same Conclusion: p-Series vs Parseval",
-    "content": "`sq_summable_matches_parseval` makes explicit that this p-series proof gives the same conclusion as the Parseval-based proof in `FourierSeriesOQ02OQ01.lean`. The two routes differ in what they require:\n\n- **Parseval route** (sibling proof OQ02OQ01): Continuity → bounded → $L^2$ → Parseval identity $\\sum \\|\\hat{c}_n\\|^2 = \\|f\\|_{L^2}^2$. Shorter (~15 lines) but requires $L^2$ theory and measure theory.\n\n- **p-Series route** (this file): Hölder decay → squared bound → comparison. Longer (~50 lines) but elementary — no $L^2$, no measure theory beyond the definition of Fourier coefficients.\n\n`fourier_coeff_l2` re-expresses the result as an existential `HasSum` statement, giving the concrete sum value $S$ such that the Fourier coefficients sum to $S$ in the $L^2(\\mathbb{Z})$ sense.",
+    "content": "`sq_summable_matches_parseval` makes explicit that this p-series proof gives the same conclusion as the Parseval-based proof in `FourierSeriesOQ02OQ01.lean`. The two routes differ in what they require:\n\n- **Parseval route** (sibling proof OQ02OQ01): Continuity \u2192 bounded \u2192 $L^2$ \u2192 Parseval identity $\\sum \\|\\hat{c}_n\\|^2 = \\|f\\|_{L^2}^2$. Shorter (~15 lines) but requires $L^2$ theory and measure theory.\n\n- **p-Series route** (this file): H\u00f6lder decay \u2192 squared bound \u2192 comparison. Longer (~50 lines) but elementary \u2014 no $L^2$, no measure theory beyond the definition of Fourier coefficients.\n\n`fourier_coeff_l2` re-expresses the result as an existential `HasSum` statement, giving the concrete sum value $S$ such that the Fourier coefficients sum to $S$ in the $L^2(\\mathbb{Z})$ sense.",
     "mathContext": "Both prove: $\\sum_{n:\\mathbb{Z}} \\|\\hat{c}_n(f)\\|^2 < \\infty$. Parseval also gives the exact value $= \\|f\\|_{L^2}^2$. The p-series route gives only convergence but with explicit dominating rate $K \\cdot \\zeta(2\\alpha)$ where $\\zeta$ is the Riemann zeta function.",
     "significance": "key",
-    "relatedConcepts": ["Parseval's theorem", "proof comparison", "elementary vs measure-theoretic proof", "Bessel's inequality"],
-    "prerequisites": ["FourierSeriesOQ02OQ01 sibling proof", "Parseval's theorem", "L² Fourier theory"]
+    "relatedConcepts": [
+      "Parseval's theorem",
+      "proof comparison",
+      "elementary vs measure-theoretic proof",
+      "Bessel's inequality"
+    ],
+    "prerequisites": [
+      "FourierSeriesOQ02OQ01 sibling proof",
+      "Parseval's theorem",
+      "L\u00b2 Fourier theory"
+    ]
   }
 ]

--- a/src/data/proofs/shapley-folkman-oq-03/annotations.json
+++ b/src/data/proofs/shapley-folkman-oq-03/annotations.json
@@ -3,7 +3,7 @@
     "id": "ann-oq03-header",
     "proofId": "shapley-folkman-oq-03",
     "range": { "startLine": 1, "endLine": 42 },
-    "type": "context",
+    "type": "concept",
     "title": "Shapley-Folkman-Starr Theorem: Economic Context",
     "content": "This file formalizes Starr's (1969) economic application of the Shapley-Folkman lemma. The key insight: even if individual agent preferences or feasible sets are non-convex, the *aggregate* market demand is 'approximately convex' in a quantitative sense.\n\n**Historical setting**: Shapley and Folkman proved their lemma in 1967 unpublished correspondence (included as an appendix in Starr's 1969 *Econometrica* paper). Starr's contribution was recognizing the economic significance: the lemma gives a uniform bound on non-convexity that is *independent of the number of agents*, making large markets approximately competitive.\n\n**Three main results**:\n1. `convexHull_dist_le` — elementary distance lemma for convex hulls\n2. `shapley_folkman_starr` — the main theorem: dist(x, ΣSᵢ) ≤ dim(E)·δ for x ∈ conv(ΣSᵢ)\n3. `large_economy_near_convex` — corollary: per-agent error d·δ/n → 0 as n → ∞",
     "mathContext": "**Setup**: $E$ a finite-dimensional normed space, $\\{S_i\\}_{i \\in t}$ sets with pairwise distances $\\leq \\delta$, $x \\in \\text{conv}(\\sum_i S_i)$. **Main bound**: $\\|x - x'\\| \\leq d \\cdot \\delta$ where $d = \\dim(E)$ and $x' \\in \\sum_i S_i$.",

--- a/src/data/proofs/shapley-folkman-oq-03/meta.json
+++ b/src/data/proofs/shapley-folkman-oq-03/meta.json
@@ -111,12 +111,12 @@
   ],
   "crossReferences": [
     {
-      "targetId": "shapley-folkman",
+      "proofId": "shapley-folkman",
       "relationship": "depends-on",
       "description": "Uses `sum_close_to_convexHull` (Shapley-Folkman decomposition) and the `Decomposition` structure from the parent proof. The parent file has 4 pending sorries in `reduce_excess_by_one` that transitively affect this entry's completeness status."
     },
     {
-      "targetId": "brouwer-fixed-point",
+      "proofId": "brouwer-fixed-point",
       "relationship": "related",
       "description": "Brouwer's fixed-point theorem is the classical tool for proving equilibrium existence in convex economies (Arrow-Debreu 1954). The Shapley-Folkman-Starr theorem provides an alternative path to approximate equilibria in non-convex economies, bypassing the convexity requirement by bounding non-convexity error. Both results are foundational for economic equilibrium theory."
     }

--- a/src/data/proofs/triangle-angle-sum-oq-02/annotations.json
+++ b/src/data/proofs/triangle-angle-sum-oq-02/annotations.json
@@ -2,121 +2,255 @@
   {
     "id": "ann-oq02-module-overview",
     "proofId": "triangle-angle-sum-oq-02",
-    "range": { "startLine": 1, "endLine": 56 },
-    "type": "context",
+    "range": {
+      "startLine": 1,
+      "endLine": 56
+    },
+    "type": "concept",
     "title": "Module Overview: The Gauss-Bonnet Generalization",
     "content": "This file answers OQ-02: how does the triangle angle sum theorem ($\\alpha+\\beta+\\gamma=\\pi$) generalize to curved surfaces? The answer is the **local Gauss-Bonnet theorem**: the angle excess of a geodesic triangle equals the integral of Gaussian curvature $K$ over the triangle's interior. The flat case ($K=0$) recovers Euclid's theorem; positive curvature ($K>0$) gives Girard's spherical excess formula; negative curvature ($K<0$) gives Lambert's hyperbolic defect. The global Gauss-Bonnet theorem then connects the total curvature $\\int_M K\\,dA = 2\\pi\\chi(M)$ to the Euler characteristic, unifying geometry and topology. Since Mathlib 4.26 lacks Riemannian metrics and integration on manifolds, the file axiomatizes the local Gauss-Bonnet formula as a structure field and derives all consequences from it.",
     "mathContext": "Local Gauss-Bonnet: $(\\alpha+\\beta+\\gamma) - \\pi = \\int_T K\\,dA$; global: $\\int_M K\\,dA = 2\\pi\\chi(M)$",
-    "significance": "context",
-    "relatedConcepts": ["Gaussian curvature", "Gauss-Bonnet theorem", "Euler characteristic", "geodesic triangle", "Riemannian manifold"],
-    "prerequisites": ["triangle angle sum theorem", "differential geometry basics", "Euler characteristic"]
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Gaussian curvature",
+      "Gauss-Bonnet theorem",
+      "Euler characteristic",
+      "geodesic triangle",
+      "Riemannian manifold"
+    ],
+    "prerequisites": [
+      "triangle angle sum theorem",
+      "differential geometry basics",
+      "Euler characteristic"
+    ]
   },
   {
     "id": "ann-geodesic-triangle-structure",
     "proofId": "triangle-angle-sum-oq-02",
-    "range": { "startLine": 74, "endLine": 118 },
+    "range": {
+      "startLine": 74,
+      "endLine": 118
+    },
     "type": "definition",
     "title": "GeodesicTriangle: Axiomatizing Local Gauss-Bonnet",
-    "content": "The `GeodesicTriangle` structure is the heart of the formalization. It records the three angles $\\alpha,\\beta,\\gamma \\in (0,\\pi)$, the area, and the `integratedCurvature` $= \\int_T K\\,dA$. The critical axiom `gb_local : α + β + γ - π = integratedCurvature` is the local Gauss-Bonnet formula — stated as a structure field rather than as an `axiom` keyword. The `excess` and `angleSum` definitions are derived, and `excess_eq_curvature`, `angleSum_eq_pi_add_excess`, and `angleSum_eq_pi_add_curvature` follow by trivial algebra. This design separates the mathematical content (the axiom) from the algebraic bookkeeping (the derived theorems), making later proofs clean one-liners.",
+    "content": "The `GeodesicTriangle` structure is the heart of the formalization. It records the three angles $\\alpha,\\beta,\\gamma \\in (0,\\pi)$, the area, and the `integratedCurvature` $= \\int_T K\\,dA$. The critical axiom `gb_local : \u03b1 + \u03b2 + \u03b3 - \u03c0 = integratedCurvature` is the local Gauss-Bonnet formula \u2014 stated as a structure field rather than as an `axiom` keyword. The `excess` and `angleSum` definitions are derived, and `excess_eq_curvature`, `angleSum_eq_pi_add_excess`, and `angleSum_eq_pi_add_curvature` follow by trivial algebra. This design separates the mathematical content (the axiom) from the algebraic bookkeeping (the derived theorems), making later proofs clean one-liners.",
     "mathContext": "Structure: $(\\alpha, \\beta, \\gamma, \\text{area}, \\text{IC}) \\in (0,\\pi)^3 \\times \\mathbb{R}_{>0} \\times \\mathbb{R}$ with $\\alpha+\\beta+\\gamma-\\pi = \\text{IC}$; excess $:= \\alpha+\\beta+\\gamma-\\pi$",
     "significance": "key",
-    "relatedConcepts": ["structure fields as axioms", "angular excess", "integrated Gaussian curvature", "local Gauss-Bonnet formula"],
-    "prerequisites": ["Lean 4 structures", "Riemannian geometry", "Gaussian curvature integration"]
+    "relatedConcepts": [
+      "structure fields as axioms",
+      "angular excess",
+      "integrated Gaussian curvature",
+      "local Gauss-Bonnet formula"
+    ],
+    "prerequisites": [
+      "Lean 4 structures",
+      "Riemannian geometry",
+      "Gaussian curvature integration"
+    ]
   },
   {
     "id": "ann-flat-triangle-euclid",
     "proofId": "triangle-angle-sum-oq-02",
-    "range": { "startLine": 128, "endLine": 149 },
-    "type": "technique",
+    "range": {
+      "startLine": 128,
+      "endLine": 149
+    },
+    "type": "concept",
     "title": "FlatTriangle: Recovering Euclid as the K=0 Special Case",
     "content": "`FlatTriangle` extends `GeodesicTriangle` by adding the constraint `flat : integratedCurvature = 0`. From `gb_local` and `flat`, the proof of `flat_angle_sum` is a one-line `linarith`: $\\alpha+\\beta+\\gamma - \\pi = 0 \\Rightarrow \\alpha+\\beta+\\gamma = \\pi$. This is the Lean formalization of the fact that Euclid's triangle angle sum theorem is exactly the Gauss-Bonnet formula specialized to $K=0$. The `FlatTriangle extends GeodesicTriangle` pattern (structure inheritance) is efficient: it reuses all fields and axioms, adding only the flatness condition.",
     "mathContext": "$K = 0 \\Rightarrow \\int_T K\\,dA = 0 \\Rightarrow \\alpha+\\beta+\\gamma - \\pi = 0 \\Rightarrow \\alpha+\\beta+\\gamma = \\pi$ (Euclid, ~300 BCE)",
     "significance": "key",
-    "relatedConcepts": ["Euclidean geometry", "K=0 flat plane", "structure inheritance in Lean 4", "linarith tactic"],
-    "prerequisites": ["GeodesicTriangle structure", "Lean 4 structure extension", "linarith"]
+    "relatedConcepts": [
+      "Euclidean geometry",
+      "K=0 flat plane",
+      "structure inheritance in Lean 4",
+      "linarith tactic"
+    ],
+    "prerequisites": [
+      "GeodesicTriangle structure",
+      "Lean 4 structure extension",
+      "linarith"
+    ]
   },
   {
     "id": "ann-girard-theorem-1629",
     "proofId": "triangle-angle-sum-oq-02",
-    "range": { "startLine": 163, "endLine": 207 },
-    "type": "key-theorem",
+    "range": {
+      "startLine": 163,
+      "endLine": 207
+    },
+    "type": "theorem",
     "title": "Girard's Theorem (1629): Spherical Excess Formula",
-    "content": "`SphericalTriangle` adds a radius $r > 0$ and the spherical curvature constraint `spherical : integratedCurvature = area / radius^2` (since $K = 1/r^2$ on a sphere of radius $r$, so $\\int_T K\\,dA = \\text{Area}(T)/r^2$). `girard_theorem` then follows in one line by rewriting via `spherical` and applying `gb_local`. The corollaries `spherical_area_eq_radius_sq_excess` and `spherical_angle_sum_gt_pi` use `div_pos` and `sq_pos_of_pos` to establish strict inequalities. On the unit sphere ($r=1$), the formula simplifies to area $= \\alpha+\\beta+\\gamma-\\pi$, which is what Girard actually stated in 1629 — predating both calculus and Gaussian curvature by nearly two centuries.",
+    "content": "`SphericalTriangle` adds a radius $r > 0$ and the spherical curvature constraint `spherical : integratedCurvature = area / radius^2` (since $K = 1/r^2$ on a sphere of radius $r$, so $\\int_T K\\,dA = \\text{Area}(T)/r^2$). `girard_theorem` then follows in one line by rewriting via `spherical` and applying `gb_local`. The corollaries `spherical_area_eq_radius_sq_excess` and `spherical_angle_sum_gt_pi` use `div_pos` and `sq_pos_of_pos` to establish strict inequalities. On the unit sphere ($r=1$), the formula simplifies to area $= \\alpha+\\beta+\\gamma-\\pi$, which is what Girard actually stated in 1629 \u2014 predating both calculus and Gaussian curvature by nearly two centuries.",
     "mathContext": "$K = 1/r^2$ on sphere of radius $r$: $\\alpha+\\beta+\\gamma - \\pi = \\text{Area}(T)/r^2 > 0$; unit sphere: $\\text{Area}(T) = \\alpha+\\beta+\\gamma - \\pi$",
     "significance": "key",
-    "relatedConcepts": ["spherical geometry", "Girard's theorem", "spherical excess", "positive Gaussian curvature", "unit sphere"],
-    "prerequisites": ["GeodesicTriangle", "Gaussian curvature on sphere", "field_simp tactic", "div_pos"]
+    "relatedConcepts": [
+      "spherical geometry",
+      "Girard's theorem",
+      "spherical excess",
+      "positive Gaussian curvature",
+      "unit sphere"
+    ],
+    "prerequisites": [
+      "GeodesicTriangle",
+      "Gaussian curvature on sphere",
+      "field_simp tactic",
+      "div_pos"
+    ]
   },
   {
     "id": "ann-lambert-theorem-1761",
     "proofId": "triangle-angle-sum-oq-02",
-    "range": { "startLine": 220, "endLine": 250 },
-    "type": "key-theorem",
+    "range": {
+      "startLine": 220,
+      "endLine": 250
+    },
+    "type": "theorem",
     "title": "Lambert's Theorem (1761): Hyperbolic Angular Defect",
-    "content": "`HyperbolicTriangle` adds `hyperbolic : integratedCurvature = -area` (since $K = -1$ in the standard hyperbolic plane, so $\\int_T K\\,dA = -\\text{Area}(T)$). `lambert_theorem` proves $\\pi - (\\alpha+\\beta+\\gamma) = \\text{area}$: the angular defect equals the area. This has two striking corollaries: (1) `hyperbolic_angle_sum_lt_pi`: all hyperbolic triangles satisfy $\\alpha+\\beta+\\gamma < \\pi$; (2) `hyperbolic_area_lt_pi`: hyperbolic triangle area is always $< \\pi$, so there is a maximum possible area for any hyperbolic triangle (unlike Euclidean or spherical geometry). Lambert deduced these properties in 1761 from the assumption that angle sum $< \\pi$, without constructing a model — he had discovered hyperbolic geometry without realizing it.",
+    "content": "`HyperbolicTriangle` adds `hyperbolic : integratedCurvature = -area` (since $K = -1$ in the standard hyperbolic plane, so $\\int_T K\\,dA = -\\text{Area}(T)$). `lambert_theorem` proves $\\pi - (\\alpha+\\beta+\\gamma) = \\text{area}$: the angular defect equals the area. This has two striking corollaries: (1) `hyperbolic_angle_sum_lt_pi`: all hyperbolic triangles satisfy $\\alpha+\\beta+\\gamma < \\pi$; (2) `hyperbolic_area_lt_pi`: hyperbolic triangle area is always $< \\pi$, so there is a maximum possible area for any hyperbolic triangle (unlike Euclidean or spherical geometry). Lambert deduced these properties in 1761 from the assumption that angle sum $< \\pi$, without constructing a model \u2014 he had discovered hyperbolic geometry without realizing it.",
     "mathContext": "$K = -1$: $\\alpha+\\beta+\\gamma - \\pi = -\\text{Area}(T) < 0$; angular defect $\\delta = \\pi - (\\alpha+\\beta+\\gamma) = \\text{Area}(T) \\in (0, \\pi)$",
     "significance": "key",
-    "relatedConcepts": ["hyperbolic geometry", "angular defect", "Lambert's theorem", "negative Gaussian curvature", "hyperbolic plane models"],
-    "prerequisites": ["GeodesicTriangle", "hyperbolic plane", "negative curvature geometry", "linarith"]
+    "relatedConcepts": [
+      "hyperbolic geometry",
+      "angular defect",
+      "Lambert's theorem",
+      "negative Gaussian curvature",
+      "hyperbolic plane models"
+    ],
+    "prerequisites": [
+      "GeodesicTriangle",
+      "hyperbolic plane",
+      "negative curvature geometry",
+      "linarith"
+    ]
   },
   {
     "id": "ann-riemannian-triangulation",
     "proofId": "triangle-angle-sum-oq-02",
-    "range": { "startLine": 263, "endLine": 297 },
+    "range": {
+      "startLine": 263,
+      "endLine": 297
+    },
     "type": "definition",
     "title": "RiemannianTriangulation and Discrete Gauss-Bonnet",
-    "content": "`RiemannianTriangulation` encodes a triangulation of a compact closed Riemannian surface. Its key axiom `discrete_gb : (∑ i, (triangles i).excess) = 2 * π * eulerChar` is the discrete Gauss-Bonnet theorem: the total angular excess over all triangles equals $2\\pi$ times the Euler characteristic. From this, `sphere_total_curvature` ($\\chi=2 \\Rightarrow$ total excess $= 4\\pi$), `torus_total_curvature` ($\\chi=0 \\Rightarrow$ total excess $= 0$), and `genus_g_total_curvature` ($\\chi = 2-2g \\Rightarrow$ total excess $= 2\\pi(2-2g)$) all follow by `ring`. The discrete Gauss-Bonnet theorem classically follows from the local version by summing over all triangles and noting that interior angle contributions cancel — but encoding this combinatorial argument requires the full machinery of cellular homology.",
+    "content": "`RiemannianTriangulation` encodes a triangulation of a compact closed Riemannian surface. Its key axiom `discrete_gb : (\u2211 i, (triangles i).excess) = 2 * \u03c0 * eulerChar` is the discrete Gauss-Bonnet theorem: the total angular excess over all triangles equals $2\\pi$ times the Euler characteristic. From this, `sphere_total_curvature` ($\\chi=2 \\Rightarrow$ total excess $= 4\\pi$), `torus_total_curvature` ($\\chi=0 \\Rightarrow$ total excess $= 0$), and `genus_g_total_curvature` ($\\chi = 2-2g \\Rightarrow$ total excess $= 2\\pi(2-2g)$) all follow by `ring`. The discrete Gauss-Bonnet theorem classically follows from the local version by summing over all triangles and noting that interior angle contributions cancel \u2014 but encoding this combinatorial argument requires the full machinery of cellular homology.",
     "mathContext": "Discrete Gauss-Bonnet: $\\sum_{i} (\\alpha_i+\\beta_i+\\gamma_i - \\pi) = 2\\pi\\chi(M)$; for genus $g$: $\\chi = 2-2g$, total excess $= 2\\pi(2-2g)$",
     "significance": "key",
-    "relatedConcepts": ["Euler characteristic", "triangulation of surface", "discrete Gauss-Bonnet", "genus-g surfaces", "cellular homology"],
-    "prerequisites": ["GeodesicTriangle", "Euler characteristic", "Finset.sum in Lean 4", "orientable surface classification"]
+    "relatedConcepts": [
+      "Euler characteristic",
+      "triangulation of surface",
+      "discrete Gauss-Bonnet",
+      "genus-g surfaces",
+      "cellular homology"
+    ],
+    "prerequisites": [
+      "GeodesicTriangle",
+      "Euler characteristic",
+      "Finset.sum in Lean 4",
+      "orientable surface classification"
+    ]
   },
   {
     "id": "ann-curvature-sign-topology",
     "proofId": "triangle-angle-sum-oq-02",
-    "range": { "startLine": 306, "endLine": 330 },
+    "range": {
+      "startLine": 306,
+      "endLine": 330
+    },
     "type": "insight",
     "title": "Curvature Sign Constrains Surface Topology",
     "content": "Part VI proves that the sign of the total curvature (total angular excess) determines the sign of $\\chi$. `positive_curvature_positive_chi` and `negative_curvature_negative_chi` use `mul_pos_iff` / `mul_neg_iff` combined with $\\pi > 0$ to extract the sign of $\\chi$ from the sign of $2\\pi\\chi$. `flat_triangulation_chi_zero` uses `mul_eq_zero` and $2\\pi \\neq 0$ to deduce $\\chi = 0$. The topological consequence is profound: a surface admitting a metric with everywhere positive curvature must have $\\chi > 0$ (genus 0, sphere); everywhere zero curvature must have $\\chi = 0$ (genus 1, torus); everywhere negative curvature must have $\\chi < 0$ (genus $\\geq 2$). This is the Gauss-Bonnet obstruction.",
     "mathContext": "$\\text{total excess} > 0 \\Rightarrow \\chi > 0$ (sphere $S^2$); $= 0 \\Rightarrow \\chi = 0$ (torus $T^2$); $< 0 \\Rightarrow \\chi < 0$ (genus $\\geq 2$)",
     "significance": "key",
-    "relatedConcepts": ["Gauss-Bonnet obstruction", "uniformization theorem", "surface classification", "mul_pos_iff", "sign of Euler characteristic"],
-    "prerequisites": ["discrete Gauss-Bonnet", "Euler characteristic sign", "uniformization theorem (background)", "mul_pos_iff in Mathlib"]
+    "relatedConcepts": [
+      "Gauss-Bonnet obstruction",
+      "uniformization theorem",
+      "surface classification",
+      "mul_pos_iff",
+      "sign of Euler characteristic"
+    ],
+    "prerequisites": [
+      "discrete Gauss-Bonnet",
+      "Euler characteristic sign",
+      "uniformization theorem (background)",
+      "mul_pos_iff in Mathlib"
+    ]
   },
   {
     "id": "ann-three-geometries-unified",
     "proofId": "triangle-angle-sum-oq-02",
-    "range": { "startLine": 349, "endLine": 368 },
+    "range": {
+      "startLine": 349,
+      "endLine": 368
+    },
     "type": "insight",
     "title": "Three Geometries Unified: The Capstone Theorem",
-    "content": "`three_geometries_unified` is the cleanest statement of the entire file: it packages the three angle sum results into a single conjunction. `excess_classifies_curvature` shows the angle excess is in bijection with the sign of the integrated curvature — so reading off the curvature sign immediately tells you whether you are in Euclidean, spherical, or hyperbolic geometry. `euclidean_case` combines `flat_excess_zero` and `flat_angleSum_eq_pi` into the tuple $(\\text{excess}=0, \\text{sum}=\\pi)$. These theorems together formalize the conceptual claim: the triangle angle sum theorem is not an isolated fact but the $K=0$ instance of a one-parameter family indexed by Gaussian curvature.",
+    "content": "`three_geometries_unified` is the cleanest statement of the entire file: it packages the three angle sum results into a single conjunction. `excess_classifies_curvature` shows the angle excess is in bijection with the sign of the integrated curvature \u2014 so reading off the curvature sign immediately tells you whether you are in Euclidean, spherical, or hyperbolic geometry. `euclidean_case` combines `flat_excess_zero` and `flat_angleSum_eq_pi` into the tuple $(\\text{excess}=0, \\text{sum}=\\pi)$. These theorems together formalize the conceptual claim: the triangle angle sum theorem is not an isolated fact but the $K=0$ instance of a one-parameter family indexed by Gaussian curvature.",
     "mathContext": "$K=0 \\Leftrightarrow \\text{excess}=0 \\Leftrightarrow \\alpha+\\beta+\\gamma = \\pi$; $K>0 \\Leftrightarrow \\text{excess}>0 \\Leftrightarrow \\alpha+\\beta+\\gamma > \\pi$; $K<0 \\Leftrightarrow \\text{excess}<0 \\Leftrightarrow \\alpha+\\beta+\\gamma < \\pi$",
     "significance": "key",
-    "relatedConcepts": ["Euclidean geometry", "spherical geometry", "hyperbolic geometry", "Iff.rfl in Lean 4", "curvature classification"],
-    "prerequisites": ["FlatTriangle", "SphericalTriangle", "HyperbolicTriangle", "GeodesicTriangle.excess"]
+    "relatedConcepts": [
+      "Euclidean geometry",
+      "spherical geometry",
+      "hyperbolic geometry",
+      "Iff.rfl in Lean 4",
+      "curvature classification"
+    ],
+    "prerequisites": [
+      "FlatTriangle",
+      "SphericalTriangle",
+      "HyperbolicTriangle",
+      "GeodesicTriangle.excess"
+    ]
   },
   {
     "id": "ann-mathlib-euclidean-example",
     "proofId": "triangle-angle-sum-oq-02",
-    "range": { "startLine": 370, "endLine": 382 },
-    "type": "technique",
+    "range": {
+      "startLine": 370,
+      "endLine": 382
+    },
+    "type": "concept",
     "title": "Mathlib Anchor: angle_add_angle_add_angle_eq_pi",
-    "content": "The final `example` grounds the abstract axiom system in Mathlib's concrete Euclidean geometry. Given points $p_1, p_2, p_3$ in a normed inner product space $P$ with $p_2 \\neq p_1$, `EuclideanGeometry.angle_add_angle_add_angle_eq_pi` directly proves $\\angle(p_1 p_2 p_3) + \\angle(p_2 p_3 p_1) + \\angle(p_3 p_1 p_2) = \\pi$. This is the Mathlib statement of Euclid's angle sum theorem, expressed via the `angle` function from `Mathlib.Geometry.Euclidean.Triangle`. The type class stack `[NormedAddCommGroup V] [InnerProductSpace ℝ V] [MetricSpace P] [NormedAddTorsor V P]` shows that the theorem holds in any model of Euclidean geometry, not just $\\mathbb{R}^n$. The entire abstract file's axiom system captures 'why it's true in general'; this one-line Mathlib fact confirms it is machine-checked in the concrete case.",
-    "mathContext": "Mathlib: `EuclideanGeometry.angle_add_angle_add_angle_eq_pi : angle p₁ p₂ p₃ + angle p₂ p₃ p₁ + angle p₃ p₁ p₂ = π` for $p_2 \\neq p_1$",
+    "content": "The final `example` grounds the abstract axiom system in Mathlib's concrete Euclidean geometry. Given points $p_1, p_2, p_3$ in a normed inner product space $P$ with $p_2 \\neq p_1$, `EuclideanGeometry.angle_add_angle_add_angle_eq_pi` directly proves $\\angle(p_1 p_2 p_3) + \\angle(p_2 p_3 p_1) + \\angle(p_3 p_1 p_2) = \\pi$. This is the Mathlib statement of Euclid's angle sum theorem, expressed via the `angle` function from `Mathlib.Geometry.Euclidean.Triangle`. The type class stack `[NormedAddCommGroup V] [InnerProductSpace \u211d V] [MetricSpace P] [NormedAddTorsor V P]` shows that the theorem holds in any model of Euclidean geometry, not just $\\mathbb{R}^n$. The entire abstract file's axiom system captures 'why it's true in general'; this one-line Mathlib fact confirms it is machine-checked in the concrete case.",
+    "mathContext": "Mathlib: `EuclideanGeometry.angle_add_angle_add_angle_eq_pi : angle p\u2081 p\u2082 p\u2083 + angle p\u2082 p\u2083 p\u2081 + angle p\u2083 p\u2081 p\u2082 = \u03c0` for $p_2 \\neq p_1$",
     "significance": "supporting",
-    "relatedConcepts": ["EuclideanGeometry.angle", "NormedAddTorsor", "InnerProductSpace", "angle_add_angle_add_angle_eq_pi", "Mathlib geometry"],
-    "prerequisites": ["Mathlib.Geometry.Euclidean.Triangle", "inner product spaces", "NormedAddTorsor", "EuclideanGeometry.angle"]
+    "relatedConcepts": [
+      "EuclideanGeometry.angle",
+      "NormedAddTorsor",
+      "InnerProductSpace",
+      "angle_add_angle_add_angle_eq_pi",
+      "Mathlib geometry"
+    ],
+    "prerequisites": [
+      "Mathlib.Geometry.Euclidean.Triangle",
+      "inner product spaces",
+      "NormedAddTorsor",
+      "EuclideanGeometry.angle"
+    ]
   },
   {
     "id": "ann-axiom-architecture-note",
     "proofId": "triangle-angle-sum-oq-02",
-    "range": { "startLine": 74, "endLine": 95 },
+    "range": {
+      "startLine": 74,
+      "endLine": 95
+    },
     "type": "concept",
     "title": "Axiom Count: Three Structure-Encoded Assumptions",
-    "content": "The file contains no `axiom` keyword, yet it has `axiomCount: 3` in `meta.json`. The three assumptions are structure fields: `gb_local` (local Gauss-Bonnet for geodesic triangles), `spherical`/`hyperbolic` (spherical and hyperbolic curvature formulas $K=1/r^2$ and $K=-1$), and `discrete_gb` (discrete Gauss-Bonnet for triangulations). All three are classical theorems of Riemannian differential geometry requiring integration on manifolds — infrastructure not yet in Mathlib 4.26. Using structure fields rather than `axiom` declarations is a valid architectural choice: it scopes each assumption to the relevant type, prevents global namespace pollution, and makes the dependency structure explicit. But mathematically, structure fields carrying propositions are axioms.",
+    "content": "The file contains no `axiom` keyword, yet it has `axiomCount: 3` in `meta.json`. The three assumptions are structure fields: `gb_local` (local Gauss-Bonnet for geodesic triangles), `spherical`/`hyperbolic` (spherical and hyperbolic curvature formulas $K=1/r^2$ and $K=-1$), and `discrete_gb` (discrete Gauss-Bonnet for triangulations). All three are classical theorems of Riemannian differential geometry requiring integration on manifolds \u2014 infrastructure not yet in Mathlib 4.26. Using structure fields rather than `axiom` declarations is a valid architectural choice: it scopes each assumption to the relevant type, prevents global namespace pollution, and makes the dependency structure explicit. But mathematically, structure fields carrying propositions are axioms.",
     "mathContext": "3 assumptions: `gb_local` ($\\alpha+\\beta+\\gamma-\\pi = \\int K\\,dA$), `spherical`/`hyperbolic` ($K=1/r^2$, $K=-1$), `discrete_gb` ($\\sum \\text{excess} = 2\\pi\\chi$)",
-    "significance": "context",
-    "relatedConcepts": ["axiom integrity policy", "structure-encoded axioms", "Lean 4 structure fields", "axiomCount", "Mathlib coverage gaps in differential geometry"],
-    "prerequisites": ["CLAUDE.md axiom integrity policy", "Lean 4 structures", "Riemannian geometry prerequisites for Mathlib"]
+    "significance": "supporting",
+    "relatedConcepts": [
+      "axiom integrity policy",
+      "structure-encoded axioms",
+      "Lean 4 structure fields",
+      "axiomCount",
+      "Mathlib coverage gaps in differential geometry"
+    ],
+    "prerequisites": [
+      "CLAUDE.md axiom integrity policy",
+      "Lean 4 structures",
+      "Riemannian geometry prerequisites for Mathlib"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary

Fixes annotation format bugs in 4 gallery entries that were missed by the previous batch fix (these entries were added after the batch was run):

- **shapley-folkman-oq-03**: `type: context → concept` in header annotation; `crossReferences.targetId → proofId` (schema alignment)
- **ballot-problem-oq-03-oq-01-oq-04**: 3 fixes — `technique→concept`, `proof-step→tactic`, `context→concept`
- **fourier-series-oq-02-oq-02**: 6 fixes — `context→concept`, `technique→concept`, `technical→supporting`
- **triangle-angle-sum-oq-02**: 7 fixes — `context→concept`, `technique→concept`, `key-theorem→theorem`, `context sig→supporting`

Total: 16 annotation format fixes across 4 entries. All annotation `type` and `significance` values now conform to the TypeScript annotation schema.

## Test plan
- [x] `pnpm build` passes cleanly
- [x] All fixed annotations have valid `type` (one of: theorem, lemma, definition, tactic, concept, insight, warning)
- [x] All fixed annotations have valid `significance` (one of: critical, key, supporting)
- [x] `shapley-folkman-oq-03` crossReferences use `proofId` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)