### PR TITLE
Fix: sync lebesgue-measure-oq-06 lineCount 542→287

### DIFF
--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 6,
     "axiomCount": 4,
-    "lineCount": 542,
+    "lineCount": 287,
     "assumptions": "4 axioms: hausdorff_free_subgroup (Hausdorff 1914 — SO(3) contains F₂, requires 300+ lines of number theory), banach_tarski (Banach-Tarski 1924 — main paradox, requires 800+ lines via Hausdorff paradox + AC), banach_tarski_pieces_nonmeasurable (classical non-measurability corollary), int_amenable (Markov-Kakutani — ℤ is amenable via Cesàro means/ultrafilter construction). 6 sorries in supporting theorems: measure-theoretic consequence of paradoxical decomposition, SO(3) rotation matrices, banach_tarski_corollary, banach_tarski_pieces_measurable_contradiction, cesaro_mean_density, and free_group_not_amenable.",
     "dateAdded": "2026-04-22",
     "mathlib_version": "4.26.0",
@@ -201,7 +201,7 @@
       "Mathlib"
     ],
     "namespace": "BanachTarski",
-    "lineCount": 542,
+    "lineCount": 287,
     "axiomCount": 4,
     "theoremCount": 7,
     "definitionCount": 5,


### PR DESCRIPTION
## Fix

The `LebesgueMeasureOQ06.lean` file was refactored and now has 287 lines, but the meta.json still reported the old line count of 542. Updates both the `meta.lineCount` and `leanFile.lineCount` fields.

## Evidence

**Before**: `lineCount: 542`
**After**: `lineCount: 287`

Verified: `wc -l proofs/Proofs/LebesgueMeasureOQ06.lean` → 287 lines.

All other metadata (sorries: 6, axiomCount: 4, theoremCount: 7, definitionCount: 5) remains accurate.

## Severity

LOW — informational accuracy only. No credibility or integrity issues.

---
Automated fix by lean-mechanic agent.