### PR TITLE
Add Part XIII: corner recursion infrastructure for hook-length formula

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean
@@ -3581,4 +3581,259 @@ theorem hook_length_formula_atMostTwoRows (μ : YoungDiagram) (h2 : μ.rowLen 2 
   rw [hμ]
   exact hook_length_formula_two_row_gen (μ.rowLen 0) (μ.rowLen 1) hab
 
+-- ============================================================
+-- PART XIII: General Corner Recursion for SYT Counts
+-- ============================================================
+
+/-
+  We prove the general corner recursion:
+    card(SYT(μ)) = Σ_{c ∈ corners(μ)} card(SYT(μ\c))  (for non-empty μ)
+  where corners(μ) are cells c with arm(c)=0 and leg(c)=0 (hookLength = 1).
+  The bijection T ↦ (max-entry corner, restricted SYT) is the key tool.
+-/
+
+/-- A corner of μ: a cell c ∈ μ with no cell immediately to its right or below.
+    Equivalently arm(c) = 0 and leg(c) = 0, so hookLength(μ,c) = 1. -/
+private def isCorner (μ : YoungDiagram) (c : ℕ × ℕ) : Prop :=
+  c ∈ μ ∧ (c.1, c.2 + 1) ∉ μ ∧ (c.1 + 1, c.2) ∉ μ
+
+/-- Finset of corner cells of μ. -/
+private def corners (μ : YoungDiagram) : Finset (ℕ × ℕ) :=
+  μ.cells.filter (fun c => (c.1, c.2 + 1) ∉ μ ∧ (c.1 + 1, c.2) ∉ μ)
+
+private lemma mem_corners {μ : YoungDiagram} {c : ℕ × ℕ} :
+    c ∈ corners μ ↔ isCorner μ c := by
+  simp only [corners, Finset.mem_filter, YoungDiagram.mem_cells, isCorner]
+
+/-- Removing a corner cell preserves the lower-set property. -/
+private noncomputable def removeCorner (μ : YoungDiagram) (c : ℕ × ℕ)
+    (hc : isCorner μ c) : YoungDiagram where
+  cells := μ.cells.erase c
+  isLowerSet := by
+    intro a b hab hb
+    rw [Finset.coe_erase, Set.mem_diff, Set.mem_singleton_iff] at hb ⊢
+    obtain ⟨hb_mem, hb_ne⟩ := hb
+    refine ⟨μ.isLowerSet hab hb_mem, ?_⟩
+    intro ha_eq
+    subst ha_eq
+    obtain ⟨_, h_right, h_below⟩ := hc
+    have h1 : a.1 ≤ b.1 ∧ a.2 ≤ b.2 := Prod.mk_le_mk.mp hab
+    rcases Nat.lt_or_eq_of_le h1.1 with h1' | rfl
+    · exact h_below (μ.isLowerSet (Prod.mk_le_mk.mpr ⟨by omega, h1.2⟩) hb_mem)
+    · rcases Nat.lt_or_eq_of_le h1.2 with h2' | rfl
+      · exact h_right (μ.isLowerSet (Prod.mk_le_mk.mpr ⟨le_refl _, by omega⟩) hb_mem)
+      · exact hb_ne rfl
+
+/-- Membership in removeCorner: all cells except c. -/
+private lemma mem_removeCorner {μ : YoungDiagram} {c x : ℕ × ℕ} (hc : isCorner μ c) :
+    x ∈ removeCorner μ c hc ↔ x ∈ μ ∧ x ≠ c := by
+  simp only [removeCorner, YoungDiagram.mem_mk, Finset.mem_erase, YoungDiagram.mem_cells]
+  tauto
+
+/-- Cardinality of removeCorner is μ.card - 1. -/
+private lemma removeCorner_card {μ : YoungDiagram} {c : ℕ × ℕ} (hc : isCorner μ c) :
+    (removeCorner μ c hc).card = μ.card - 1 := by
+  simp [YoungDiagram.card, removeCorner,
+    Finset.card_erase_of_mem (YoungDiagram.mem_cells.mpr hc.1)]
+
+/-- removeCorner doesn't depend on which proof of isCorner we use.
+    (The cells are just μ.cells.erase c, independent of the proof.) -/
+private lemma removeCorner_proof_irrel (μ : YoungDiagram) (c : ℕ × ℕ)
+    (hc₁ hc₂ : isCorner μ c) :
+    removeCorner μ c hc₁ = removeCorner μ c hc₂ := by
+  apply YoungDiagram.ext
+  simp [removeCorner]
+
+/-- For any SYT, its entries surject onto {1,...,μ.card}. -/
+private lemma syt_entry_image {μ : YoungDiagram} (T : StandardYoungTableau μ)
+    (hn : 0 < μ.card) :
+    μ.cells.image T.entry = Finset.Icc 1 μ.card := by
+  apply Finset.eq_of_subset_of_card_le
+  · intro k hk
+    obtain ⟨c, hc, rfl⟩ := Finset.mem_image.mp hk
+    exact Finset.mem_Icc.mpr (T.entry_range c (YoungDiagram.mem_cells.mp hc))
+  · rw [Finset.card_Icc, Nat.add_sub_cancel,
+      Finset.card_image_of_injOn (fun c₁ hc₁ c₂ hc₂ h =>
+        T.entry_injOn c₁ c₂ (YoungDiagram.mem_cells.mp hc₁)
+          (YoungDiagram.mem_cells.mp hc₂) h)]
+
+/-- The unique cell of μ where T.entry achieves μ.card (the maximum). -/
+private noncomputable def maxEntryCell {μ : YoungDiagram}
+    (T : StandardYoungTableau μ) (hn : 0 < μ.card) : ℕ × ℕ :=
+  Classical.choose (Finset.mem_image.mp
+    (show μ.card ∈ μ.cells.image T.entry by
+      rw [syt_entry_image T hn]; simp [Finset.mem_Icc, hn]))
+
+private lemma maxEntryCell_spec {μ : YoungDiagram}
+    (T : StandardYoungTableau μ) (hn : 0 < μ.card) :
+    maxEntryCell T hn ∈ μ.cells ∧ T.entry (maxEntryCell T hn) = μ.card :=
+  Classical.choose_spec (Finset.mem_image.mp
+    (show μ.card ∈ μ.cells.image T.entry by
+      rw [syt_entry_image T hn]; simp [Finset.mem_Icc, hn]))
+
+private lemma maxEntryCell_mem {μ : YoungDiagram}
+    (T : StandardYoungTableau μ) (hn : 0 < μ.card) :
+    maxEntryCell T hn ∈ μ :=
+  YoungDiagram.mem_cells.mp (maxEntryCell_spec T hn).1
+
+private lemma maxEntryCell_entry {μ : YoungDiagram}
+    (T : StandardYoungTableau μ) (hn : 0 < μ.card) :
+    T.entry (maxEntryCell T hn) = μ.card :=
+  (maxEntryCell_spec T hn).2
+
+/-- The cell achieving the maximum entry is a corner (no larger entries can exist to right/below). -/
+private lemma maxEntryCell_isCorner {μ : YoungDiagram}
+    (T : StandardYoungTableau μ) (hn : 0 < μ.card) :
+    isCorner μ (maxEntryCell T hn) := by
+  set c := maxEntryCell T hn
+  refine ⟨maxEntryCell_mem T hn, ?_, ?_⟩
+  · intro h
+    have := T.row_strict c.1 c.2 (c.2 + 1) (maxEntryCell_mem T hn) h (Nat.lt_succ_self _)
+    rw [maxEntryCell_entry T hn] at this; exact Nat.lt_irrefl _ this
+  · intro h
+    have := T.col_strict c.1 (c.1 + 1) c.2 (maxEntryCell_mem T hn) h (Nat.lt_succ_self _)
+    rw [maxEntryCell_entry T hn] at this; exact Nat.lt_irrefl _ this
+
+private lemma maxEntryCell_in_corners {μ : YoungDiagram}
+    (T : StandardYoungTableau μ) (hn : 0 < μ.card) :
+    maxEntryCell T hn ∈ corners μ :=
+  mem_corners.mpr (maxEntryCell_isCorner T hn)
+
+/-- maxEntryCell is unique: if T.entry x = μ.card and x ∈ μ, then x = maxEntryCell T hn. -/
+private lemma maxEntryCell_unique {μ : YoungDiagram}
+    (T : StandardYoungTableau μ) (hn : 0 < μ.card)
+    (x : ℕ × ℕ) (hx : x ∈ μ) (heq : T.entry x = μ.card) :
+    x = maxEntryCell T hn := by
+  apply T.entry_injOn x (maxEntryCell T hn) hx (maxEntryCell_mem T hn)
+  rw [heq, maxEntryCell_entry T hn]
+
+/-- Restrict a SYT to shape μ\c, given the max entry is at c. -/
+private noncomputable def restrictSYT_gen {μ : YoungDiagram} (c : ℕ × ℕ)
+    (hc : isCorner μ c) (T : StandardYoungTableau μ)
+    (hT : T.entry c = μ.card) :
+    StandardYoungTableau (removeCorner μ c hc) where
+  entry x := if x ∈ removeCorner μ c hc then T.entry x else 0
+  entry_zero x hx := by simp [hx]
+  entry_range x hx := by
+    simp only [hx, ↓reduceIte]
+    obtain ⟨hxmem, hxne⟩ := (mem_removeCorner hc).mp hx
+    have hne : T.entry x ≠ μ.card := by
+      intro h; exact hxne (T.entry_injOn x c hxmem hc.1 (h.trans hT.symm))
+    exact ⟨(T.entry_range x hxmem).1,
+      by rw [removeCorner_card hc]; have := (T.entry_range x hxmem).2; omega⟩
+  entry_injOn x₁ x₂ hx₁ hx₂ h := by
+    simp only [hx₁, hx₂, ↓reduceIte] at h
+    exact T.entry_injOn x₁ x₂ ((mem_removeCorner hc).mp hx₁).1
+      ((mem_removeCorner hc).mp hx₂).1 h
+  row_strict i j₁ j₂ hx₁ hx₂ hlt := by
+    simp only [hx₁, hx₂, ↓reduceIte]
+    exact T.row_strict i j₁ j₂ ((mem_removeCorner hc).mp hx₁).1
+      ((mem_removeCorner hc).mp hx₂).1 hlt
+  col_strict i₁ i₂ j hx₁ hx₂ hlt := by
+    simp only [hx₁, hx₂, ↓reduceIte]
+    exact T.col_strict i₁ i₂ j ((mem_removeCorner hc).mp hx₁).1
+      ((mem_removeCorner hc).mp hx₂).1 hlt
+
+/-- Extend a SYT of shape μ\c to shape μ by placing μ.card at the corner c. -/
+private noncomputable def extendSYT_gen {μ : YoungDiagram} (c : ℕ × ℕ)
+    (hc : isCorner μ c) (T₁ : StandardYoungTableau (removeCorner μ c hc)) :
+    StandardYoungTableau μ where
+  entry x := if x = c then μ.card else T₁.entry x
+  entry_zero x hx := by
+    have hne : x ≠ c := fun h => hx (h ▸ hc.1)
+    rw [if_neg hne]
+    exact T₁.entry_zero x (fun hm => (mem_removeCorner hc).mp hm |>.1 |> hx)
+  entry_range x hx := by
+    by_cases hxc : x = c
+    · simp [hxc, hc.1]
+    · rw [if_neg hxc]
+      have hxrc : x ∈ removeCorner μ c hc := (mem_removeCorner hc).mpr ⟨hx, hxc⟩
+      exact ⟨(T₁.entry_range x hxrc).1,
+        by have := (T₁.entry_range x hxrc).2; rw [removeCorner_card hc] at this; omega⟩
+  entry_injOn x₁ x₂ hx₁ hx₂ heq := by
+    by_cases hx₁c : x₁ = c <;> by_cases hx₂c : x₂ = c
+    · exact hx₁c.trans hx₂c.symm
+    · simp [hx₁c, if_neg hx₂c] at heq
+      have := (T₁.entry_range x₂ ((mem_removeCorner hc).mpr ⟨hx₂, hx₂c⟩)).2
+      rw [removeCorner_card hc] at this; omega
+    · simp [if_neg hx₁c, hx₂c] at heq
+      have := (T₁.entry_range x₁ ((mem_removeCorner hc).mpr ⟨hx₁, hx₁c⟩)).2
+      rw [removeCorner_card hc] at this; omega
+    · simp only [if_neg hx₁c, if_neg hx₂c] at heq
+      exact T₁.entry_injOn x₁ x₂
+        ((mem_removeCorner hc).mpr ⟨hx₁, hx₁c⟩)
+        ((mem_removeCorner hc).mpr ⟨hx₂, hx₂c⟩) heq
+  row_strict i j₁ j₂ hx₁ hx₂ hlt := by
+    by_cases hx₁c : (i, j₁) = c
+    · exfalso  -- arm(c) = 0: no cell to right
+      exact hc.2.1 (μ.isLowerSet
+        (by simp only [← hx₁c]; exact Prod.mk_le_mk.mpr ⟨le_refl _, by omega⟩) hx₂)
+    · by_cases hx₂c : (i, j₂) = c
+      · rw [if_neg hx₁c, hx₂c, if_pos rfl]
+        have := (T₁.entry_range _ ((mem_removeCorner hc).mpr ⟨hx₁, hx₁c⟩)).2
+        rw [removeCorner_card hc] at this; omega
+      · rw [if_neg hx₁c, if_neg hx₂c]
+        exact T₁.row_strict i j₁ j₂
+          ((mem_removeCorner hc).mpr ⟨hx₁, hx₁c⟩)
+          ((mem_removeCorner hc).mpr ⟨hx₂, hx₂c⟩) hlt
+  col_strict i₁ i₂ j hx₁ hx₂ hlt := by
+    by_cases hx₁c : (i₁, j) = c
+    · exfalso  -- leg(c) = 0: no cell below
+      exact hc.2.2 (μ.isLowerSet
+        (by simp only [← hx₁c]; exact Prod.mk_le_mk.mpr ⟨by omega, le_refl _⟩) hx₂)
+    · by_cases hx₂c : (i₂, j) = c
+      · rw [if_neg hx₁c, hx₂c, if_pos rfl]
+        have := (T₁.entry_range _ ((mem_removeCorner hc).mpr ⟨hx₁, hx₁c⟩)).2
+        rw [removeCorner_card hc] at this; omega
+      · rw [if_neg hx₁c, if_neg hx₂c]
+        exact T₁.col_strict i₁ i₂ j
+          ((mem_removeCorner hc).mpr ⟨hx₁, hx₁c⟩)
+          ((mem_removeCorner hc).mpr ⟨hx₂, hx₂c⟩) hlt
+
+/-- General corner recursion: for non-empty μ,
+    card(SYT(μ)) = Σ_{c ∈ corners(μ)} card(SYT(μ\c)).
+    Bijection: T ↦ (max-entry corner c, T restricted to μ\c).
+    [OPEN: right_inv requires HEq/cast argument; mathematical content is complete.
+     The restriction of extendSYT_gen to removeCorner equals the original tableau.] -/
+theorem card_SYT_corner_step (μ : YoungDiagram) (hn : 0 < μ.card) :
+    Fintype.card (StandardYoungTableau μ) =
+    ∑ c ∈ (corners μ).attach,
+      Fintype.card (StandardYoungTableau (removeCorner μ c.val
+        (mem_corners.mp c.prop))) := by
+  rw [← Fintype.card_sigma]
+  apply Fintype.card_congr
+  exact {
+    toFun := fun T =>
+      ⟨⟨maxEntryCell T hn, maxEntryCell_in_corners T hn⟩,
+        restrictSYT_gen (maxEntryCell T hn) (maxEntryCell_isCorner T hn) T
+          (maxEntryCell_entry T hn)⟩
+    invFun := fun ⟨⟨c, hc_corners⟩, T₁⟩ =>
+      extendSYT_gen c (mem_corners.mp hc_corners) T₁
+    left_inv := fun T => by
+      apply StandardYoungTableau.ext; intro x
+      simp only [extendSYT_gen, restrictSYT_gen]
+      split_ifs with hxc hxrc
+      · -- x = maxEntryCell T hn
+        rw [hxc]; exact (maxEntryCell_entry T hn).symm
+      · -- x ∈ removeCorner (so x ≠ maxEntryCell)
+        rfl
+      · -- x ∉ removeCorner and x ≠ maxEntryCell
+        apply T.entry_zero
+        intro hxμ
+        exact hxrc ((mem_removeCorner (maxEntryCell_isCorner T hn)).mpr
+          ⟨hxμ, fun h => hxc h.symm⟩)
+    right_inv := fun ⟨⟨c, hc_corners⟩, T₁⟩ => by
+      simp only
+      have hc := mem_corners.mp hc_corners
+      -- maxEntryCell of extendSYT_gen is c (unique cell with max entry)
+      have hmaxeq : maxEntryCell (extendSYT_gen c hc T₁) hn = c := by
+        apply maxEntryCell_unique
+        · exact hc.1
+        · simp [extendSYT_gen]
+      -- [OPEN sorry]: Sigma.ext for HEq - cast of restrictSYT_gen(extendSYT_gen T₁) = T₁
+      -- Mathematical content: the entries of restrictSYT_gen(extendSYT_gen T₁) equal T₁.entry
+      -- because extendSYT_gen adds entry μ.card only at c ∉ removeCorner.
+      sorry
+  }
+
 end HookLengthFormula

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/knowledge.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/knowledge.md
@@ -375,3 +375,64 @@ Then: LHS × (a+1-b) × (a+b+1) = RHS × (a+1-b) × (a+b+1), cancel both sides.
 2. Consider: fix `lgv_det_factors_as_hook_quotient` statement to add μ = f(r,σ,m) hypothesis
 3. Consider: corner-cell induction approach for 3-row special cases
 4. The general hook_length_formula (3+ rows) remains open
+
+---
+
+## Session 2026-04-23 (Session 12) — Corner Recursion Infrastructure (Part XIII)
+
+**Mode**: REVISIT (RICH knowledge tier, score 70)
+**Outcome**: progress — 16 new defs/lemmas (0 sorries), card_SYT_corner_step with 1 HEq sorry (mathematical content complete)
+
+### What I Did
+
+1. Assessed state: 3 sorries remain; LGV chain sorries FALSE as stated; corner-cell induction is the path forward
+2. Added PART XIII (~255 lines) to `BallotProblemOQ03OQ01OQ02.lean` (3584 → 3839 lines):
+   - `isCorner μ c`: predicate — c ∈ μ ∧ arm(c)=0 ∧ leg(c)=0
+   - `corners μ`: Finset of corner cells via filter on μ.cells
+   - `mem_corners`: characterization lemma
+   - `removeCorner μ c hc`: YoungDiagram with c removed (lower-set property preserved, 0 sorries)
+   - `mem_removeCorner`, `removeCorner_card`, `removeCorner_proof_irrel`
+   - `syt_entry_image`: entries of SYT form Finset.image T.entry μ.cells = Icc 1 μ.card
+   - `maxEntryCell T hn`: unique cell c with T.entry c = μ.card
+   - `maxEntryCell_spec`, `_mem`, `_entry`, `_isCorner`, `_in_corners`, `_unique` (all 0 sorries)
+   - `restrictSYT_gen`: SYT(μ) → SYT(removeCorner μ c hc) when T.entry c = μ.card (0 sorries)
+   - `extendSYT_gen`: SYT(removeCorner μ c hc) → SYT(μ) adding entry μ.card at c (0 sorries)
+   - `card_SYT_corner_step`: general corner recursion theorem (1 HEq sorry in right_inv)
+
+### Key Findings
+
+**removeCorner preserves lower-set**: If a ≤ b ∈ μ\\{c} and a were c, then b is above/right of c.
+- b.2 > c.2 → (c.1, c.2+1) ∈ μ contradicts arm(c)=0
+- b.1 > c.1 → (c.1+1, c.2) ∈ μ contradicts leg(c)=0
+- b=c contradicts b≠c. QED (0 sorries)
+
+**maxEntryCell is a corner**: If T.entry c = μ.card and (c.1, c.2+1) ∈ μ, then T.entry(c.1, c.2+1) > μ.card by row_strict, contradicting range ⊆ {1,...,μ.card}.
+
+**card_SYT_corner_step left_inv**: fully proved — maxEntryCell maps back to itself, entries roundtrip exactly.
+
+**HEq issue in right_inv**: After proving `hmaxeq : maxEntryCell (extendSYT_gen c hc T₁) hn = c`, the goal becomes:
+```
+⟨⟨maxEntryCell ..., hc_corners'⟩, restrictSYT_gen ...⟩ = ⟨⟨c, hc_corners⟩, T₁⟩
+```
+The two SYTs have types `SYT(removeCorner μ (maxEntryCell ..) hc₁)` vs `SYT(removeCorner μ c hc₂)`. Even though `removeCorner_proof_irrel` shows these YoungDiagrams are equal, HEq on SYT types requires `cast` reasoning in Lean 4 that creates proof obligations not yet resolved.
+
+**Mathematical content is complete**: entries of `restrictSYT_gen(extendSYT_gen T₁)` equal `T₁.entry` because `extendSYT_gen` only adds entry at `c`, which is not in `removeCorner μ c hc`.
+
+### Files Modified
+
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean` (3584 → 3839 lines, PART XIII added)
+- `src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json` (lineCount 3839, sorries 4, theoremCount 120)
+- `src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json` (knowledge updated)
+- `research/problems/ballot-problem-oq-03-oq-01-oq-02/knowledge.md` (this file)
+
+### Sorry Count: 3 → 4
+
+The sorry count increased by 1 (net) because:
+- `card_SYT_corner_step` adds 1 new sorry (right_inv HEq issue)
+- No existing sorries were resolved this session
+
+### Next Steps
+
+1. **Resolve card_SYT_corner_step right_inv**: Use `cast` + `removeCorner_proof_irrel` to prove the HEq for the second sigma component. `heq_of_cast` or `eq_mpr_iff_cast` may help.
+2. **Prove hook_walk_identity**: `Σ_{c ∈ corners(μ)} hookProd(μ) / hookProd(removeCorner μ c) = μ.card` — needed to close inductive proof of `hook_length_formula` via `card_SYT_corner_step`.
+3. **Strong induction with card_SYT_corner_step**: Once hook_walk_identity is available, `hook_length_formula` follows by strong induction on μ.card.

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "ballot-problem-oq-03-oq-01-oq-02",
   "title": "Hook-Length Formula for Standard Young Tableaux via LGV",
   "slug": "ballot-problem-oq-03-oq-01-oq-02",
-  "description": "Formalizes the hook-length formula f^λ = n!/∏h(u) for Standard Young Tableaux. Fully proves the formula for all single-row, single-column, hook-shape, 2-row rectangular, and general 2-row [a,b] with a≥b families, plus any YoungDiagram with at most 2 rows (via characterization lemma). The general formula for 3+ row shapes has 3 open sorries (RSK bijection, det factorization, main theorem).",
+  "description": "Formalizes the hook-length formula f^λ = n!/∏h(u) for Standard Young Tableaux. Fully proves the formula for all single-row, single-column, hook-shape, 2-row rectangular, and general 2-row [a,b] with a≥b families, plus any YoungDiagram with at most 2 rows (via characterization lemma). Adds general corner recursion infrastructure (Part XIII): isCorner, corners, removeCorner (0 sorries), and card_SYT_corner_step bijection (1 technical HEq sorry). General formula for 3+ row shapes has 4 open sorries total.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-21",
@@ -19,13 +19,13 @@
       "representation-theory"
     ],
     "badge": "wip",
-    "sorries": 3,
+    "sorries": 4,
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "assumptions": "Three remaining open sorries in hook_length_formula (general, 3+ row case): (1) ni_count_eq_syt_count (RSK/Fomin growth diagram bijection, ~200 lines), (2) lgv_det_factors_as_hook_quotient (Vandermonde-type det identity, ~200 lines, fundamental μ/(r,σ,m) disconnect issue), (3) hook_length_formula (main theorem, sorry pending the above two). hook_length_formula_atMostTwoRows is fully proved (0 sorries) for ALL YoungDiagrams with rowLen 2 = 0.",
-    "lineCount": 3584,
-    "theoremCount": 104,
-    "definitionCount": 14,
+    "assumptions": "Four remaining open sorries: (1) ni_count_eq_syt_count (RSK/Fomin growth diagram bijection, ~200 lines), (2) lgv_det_factors_as_hook_quotient (Vandermonde-type det identity, ~200 lines), (3) hook_length_formula (main theorem, pending the above two), (4) card_SYT_corner_step right_inv (HEq/cast technical issue for Sigma.ext — mathematical content complete, hmaxeq proved). hook_length_formula_atMostTwoRows fully proved (0 sorries). card_SYT_corner_step is the general corner recursion for inductive proof of the full HLF.",
+    "lineCount": 3839,
+    "theoremCount": 120,
+    "definitionCount": 19,
     "originalContributions": [
       "hookLength: hook length at cell (i,j) = armLen + legLen + 1 using YoungDiagram.rowLen and colLen",
       "hookLength_pos: hook lengths are always positive (arm + leg + 1 ≥ 1) — unconditional",
@@ -43,7 +43,11 @@
       "card_SYT_twoRowYD: card(SYT([a,b])) = ballotSeqCount(a+1, b) proved by strong induction + corner bijection (0 sorries)",
       "card_SYT_twoRowYD_step: Pascal step via corner-cell bijection Equiv SYT(a,b) ≃ SYT(a-1,b) ⊕ SYT(a,b-1) (0 sorries)",
       "eq_twoRowYD_of_atMostTwoRows: any YoungDiagram with rowLen 2 = 0 equals twoRowYD (rowLen 0) (rowLen 1) — cell membership characterization (0 sorries)",
-      "hook_length_formula_atMostTwoRows: hook-length formula for ALL 2-row YoungDiagrams via eq_twoRowYD_of_atMostTwoRows + hook_length_formula_two_row_gen (0 sorries)"
+      "hook_length_formula_atMostTwoRows: hook-length formula for ALL 2-row YoungDiagrams via eq_twoRowYD_of_atMostTwoRows + hook_length_formula_two_row_gen (0 sorries)",
+      "Part XIII - isCorner/corners: corner cells = cells with arm=0 and leg=0 (0 sorries), mem_corners characterization",
+      "Part XIII - removeCorner: removes a corner from YoungDiagram preserving lower-set property (0 sorries), removeCorner_proof_irrel, removeCorner_card",
+      "Part XIII - restrictSYT_gen/extendSYT_gen: bijection components between SYT(μ) and SYT(μ\\c) for corner c (0 sorries each)",
+      "Part XIII - card_SYT_corner_step: general corner recursion card(SYT(μ)) = Σ_{c ∈ corners(μ)} card(SYT(μ\\c)) (1 HEq sorry in right_inv, mathematical content complete)"
     ]
   },
   "overview": {
@@ -86,12 +90,12 @@
       "LGV"
     ],
     "namespace": "HookLengthFormula",
-    "lineCount": 3584,
+    "lineCount": 3839,
     "axiomCount": 0,
-    "sorries": 3,
+    "sorries": 4,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",
-    "theoremCount": 104,
-    "definitionCount": 14
+    "theoremCount": 120,
+    "definitionCount": 19
   },
   "crossReferences": [
     {
@@ -165,5 +169,5 @@
       "mathContext": "Verified: (2,1)→2, (2,2)→2, (3,1)→3, (3,2)→5, (3,2,1)→16, (4,3,2,1)→1440, (3,3)→5 (C₃), (4,4)→14 (C₄)."
     }
   ],
-  "sorries": 3
+  "sorries": 4
 }

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
@@ -143,7 +143,9 @@
     "ballot-problem-oq-03",
     "ballot-problem-oq-03-oq-01",
     "ballot-problem-oq-03-oq-01-oq-01",
+    "ballot-problem-oq-03-oq-01-oq-01-oq-01",
     "ballot-problem-oq-03-oq-01-oq-02",
+    "ballot-problem-oq-03-oq-01-oq-04",
     "ballot-problem-oq-03-oq-02",
     "ballot-problem-oq-03-oq-03"
   ],
@@ -266,7 +268,7 @@
     {
       "path": "Proofs/BallotProblemOQ01OQ04OQ01.lean",
       "filename": "BallotProblemOQ01OQ04OQ01.lean",
-      "lineCount": 1102,
+      "lineCount": 1165,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
@@ -299,7 +301,7 @@
     {
       "path": "Proofs/BallotProblemOQ03.lean",
       "filename": "BallotProblemOQ03.lean",
-      "lineCount": 2879,
+      "lineCount": 2923,
       "theoremCount": 119,
       "axiomCount": 0,
       "defCount": 31,
@@ -319,20 +321,42 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01.lean"
     },
     {
+      "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
+      "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
+      "lineCount": 131,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 6,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",
       "filename": "BallotProblemOQ03OQ01OQ02.lean",
-      "lineCount": 1260,
-      "theoremCount": 48,
+      "lineCount": 3585,
+      "theoremCount": 62,
       "axiomCount": 0,
-      "defCount": 9,
-      "sorryCount": 8,
+      "defCount": 10,
+      "sorryCount": 9,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean"
     },
     {
+      "path": "Proofs/BallotProblemOQ03OQ01OQ04.lean",
+      "filename": "BallotProblemOQ03OQ01OQ04.lean",
+      "lineCount": 183,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ04.lean"
+    },
+    {
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
-      "lineCount": 2315,
+      "lineCount": 2512,
       "theoremCount": 28,
       "axiomCount": 0,
       "defCount": 23,


### PR DESCRIPTION
## Summary

- Adds **16 new definitions and lemmas with 0 sorries** for general corner-cell recursion (Part XIII)
- Proves `card_SYT_corner_step`: the general recursion `f^μ = Σ_{c∈corners(μ)} f^{μ\c}` (left_inv fully proved; right_inv has 1 technical HEq sorry, mathematical content complete)
- Grows `BallotProblemOQ03OQ01OQ02.lean` from 3584 → 3839 lines
- Updates knowledge.md (Session 12), meta.json (lineCount/sorryCount/theoremCount), and knowledge.json

## New infrastructure

- **`isCorner`/`corners`/`mem_corners`**: corner cell predicate and Finset filter
- **`removeCorner`**: removes a corner from a YoungDiagram, proving lower-set preserved (0 sorries)
- **`removeCorner_proof_irrel`**: proof-irrelevant — same corner with different proofs gives same diagram
- **`maxEntryCell` + helpers**: unique cell with maximum entry = μ.card; proved to be a corner
- **`restrictSYT_gen`/`extendSYT_gen`**: bijection components between SYT(μ) and SYT(μ\c) — all 0 sorries
- **`card_SYT_corner_step`**: the key general theorem enabling strong induction over μ

## Mathematical strategy

The remaining path to `hook_length_formula` (general, 3+ rows):
1. Resolve `card_SYT_corner_step` right_inv sorry (HEq/cast technical issue)
2. Prove `hook_walk_identity`: `Σ_c hookProd(μ)/hookProd(μ\c) = μ.card`
3. Strong induction: `hook_length_formula` follows from `card_SYT_corner_step` + `hook_walk_identity`

## Test plan

- [ ] Verify `./proofs/scripts/docker-build.sh Proofs.BallotProblemOQ03OQ01OQ02` builds cleanly (all prior layers 0 sorries)
- [ ] Confirm sorry count: 4 total (3 original + 1 new HEq sorry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)