### PR TITLE
Fix: sync stale leanFile.lineCount in 3 gallery meta.json files

### DIFF
--- a/src/data/proofs/hurwitz-theorem-oq-03/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-03/meta.json
@@ -22,7 +22,7 @@
     "dateAdded": "2026-04-02",
     "axiomCount": 0,
     "assumptions": "1 sorry: hurwitz_only_if — if an n-square identity exists, then n ∈ {1,2,4,8} (n=3 case proved; n∉{1,2,3,4,8} cases pending Clifford/Radon-Hurwitz argument). The converse (identities exist for n ∈ {1,2,4,8}) is fully proved. No axiom declarations.",
-    "lineCount": 2027,
+    "lineCount": 2042,
     "theoremCount": 32,
     "definitionCount": 15,
     "originalContributions": [
@@ -67,7 +67,7 @@
   },
   "leanFile": {
     "namespace": "HurwitzTheorem",
-    "lineCount": 2027,
+    "lineCount": 2042,
     "axiomCount": 0,
     "theoremCount": 33,
     "definitionCount": 15,

--- a/src/data/proofs/hurwitz-theorem/meta.json
+++ b/src/data/proofs/hurwitz-theorem/meta.json
@@ -278,7 +278,7 @@
     ],
     "opens": [],
     "namespace": "HurwitzTheorem",
-    "lineCount": 2027,
+    "lineCount": 2042,
     "axiomCount": 0,
     "theoremCount": 33,
     "definitionCount": 15,

--- a/src/data/proofs/sperner-ndim-oq-04/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-04/meta.json
@@ -38,7 +38,7 @@
     ],
     "dateAdded": "2026-04-22",
     "axiomCount": 0,
-    "lineCount": 430,
+    "lineCount": 408,
     "assumptions": "2 sorries: (1) kuhn_walk_reaches_fc — non-revisiting invariant for the Kuhn walk (door graph component containing a boundary vertex is a path, not a cycle); (2) kuhnPathStart_is_fc — the simplex found by kuhnPathStart is fully colored (blocked on kuhn_walk_reaches_fc). All other theorems (fc_door_count_eq_one, nonfc_door_count_zero_or_two, nonfc_with_door_has_unique_exit, KuhnStateValid infrastructure, kuhn_path_terminates via sperner_ndim) are fully verified.",
     "mathlib_version": "4.26.0"
   },
@@ -255,7 +255,7 @@
       "BigOperators"
     ],
     "namespace": "SpernerNDimOQ04",
-    "lineCount": 430,
+    "lineCount": 408,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 5,


### PR DESCRIPTION
## Fix

Sync stale `leanFile.lineCount` fields in 3 gallery meta.json entries where the Lean source file changed but meta.json wasn't updated.

## Evidence

**hurwitz-theorem** and **hurwitz-theorem-oq-03** (both reference `HurwitzTheorem.lean`):
- **Before**: `leanFile.lineCount: 2027`
- **After**: `leanFile.lineCount: 2042`
- **Cause**: `c756e0db8a` added crossMat_sq_neg_one lemma + Clifford algebra documentation (+15 lines net)

**sperner-ndim-oq-04** (references `SpernerNDimOQ04.lean`):
- **Before**: `lineCount: 430` (both top-level and leanFile)
- **After**: `lineCount: 408`
- **Cause**: `226206a670` replaced false sorry with true non-revisiting lemma (-22 lines net)

## Validation

All three `leanFile.lineCount` values now match `wc -l` of the committed Lean files.

---
Automated fix by lean-mechanic agent.