### PR TITLE
Research: close card_SYT_corner_step right_inv sorry (4→3 sorries)

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean
@@ -3790,11 +3790,15 @@ private noncomputable def extendSYT_gen {μ : YoungDiagram} (c : ℕ × ℕ)
           ((mem_removeCorner hc).mpr ⟨hx₁, hx₁c⟩)
           ((mem_removeCorner hc).mpr ⟨hx₂, hx₂c⟩) hlt
 
+/-- Casting a StandardYoungTableau along a YoungDiagram equality preserves the entry function. -/
+private lemma cast_syt_entry {μ₁ μ₂ : YoungDiagram} (h : μ₁ = μ₂)
+    (T : StandardYoungTableau μ₁) (x : ℕ × ℕ) :
+    (cast (congrArg StandardYoungTableau h) T).entry x = T.entry x := by
+  subst h; rfl
+
 /-- General corner recursion: for non-empty μ,
     card(SYT(μ)) = Σ_{c ∈ corners(μ)} card(SYT(μ\c)).
-    Bijection: T ↦ (max-entry corner c, T restricted to μ\c).
-    [OPEN: right_inv requires HEq/cast argument; mathematical content is complete.
-     The restriction of extendSYT_gen to removeCorner equals the original tableau.] -/
+    Bijection: T ↦ (max-entry corner c, T restricted to μ\c). -/
 theorem card_SYT_corner_step (μ : YoungDiagram) (hn : 0 < μ.card) :
     Fintype.card (StandardYoungTableau μ) =
     ∑ c ∈ (corners μ).attach,
@@ -3830,10 +3834,33 @@ theorem card_SYT_corner_step (μ : YoungDiagram) (hn : 0 < μ.card) :
         apply maxEntryCell_unique
         · exact hc.1
         · simp [extendSYT_gen]
-      -- [OPEN sorry]: Sigma.ext for HEq - cast of restrictSYT_gen(extendSYT_gen T₁) = T₁
-      -- Mathematical content: the entries of restrictSYT_gen(extendSYT_gen T₁) equal T₁.entry
-      -- because extendSYT_gen adds entry μ.card only at c ∉ removeCorner.
-      sorry
+      have hmax_corner := maxEntryCell_isCorner (extendSYT_gen c hc T₁) hn
+      -- removeCorner with maxEntryCell = removeCorner with c (same cell, proof irrelevance)
+      have hyd : removeCorner μ (maxEntryCell (extendSYT_gen c hc T₁) hn) hmax_corner =
+                 removeCorner μ c hc := by
+        conv_lhs => rw [hmaxeq]
+        exact removeCorner_proof_irrel μ c _ _
+      refine Sigma.ext (Subtype.ext hmaxeq) ?_
+      -- Reduce HEq to regular equality via cast along hyd
+      have hEq : cast (congrArg StandardYoungTableau hyd)
+          (restrictSYT_gen (maxEntryCell (extendSYT_gen c hc T₁) hn) hmax_corner
+            (extendSYT_gen c hc T₁) (maxEntryCell_entry (extendSYT_gen c hc T₁) hn)) = T₁ := by
+        apply StandardYoungTableau.ext; intro x
+        rw [cast_syt_entry hyd]
+        simp only [restrictSYT_gen, extendSYT_gen]
+        by_cases hxrc : x ∈ removeCorner μ (maxEntryCell (extendSYT_gen c hc T₁) hn) hmax_corner
+        · simp only [hxrc, ↓reduceIte]
+          have hxne : x ≠ c := fun heq =>
+            ((mem_removeCorner hmax_corner).mp hxrc).2 (heq.trans hmaxeq.symm)
+          simp only [if_neg hxne]
+        · simp only [hxrc, ↓reduceIte]
+          symm
+          apply T₁.entry_zero
+          intro hxrc'
+          exact hxrc ((mem_removeCorner hmax_corner).mpr
+            ⟨((mem_removeCorner hc).mp hxrc').1,
+             fun h => ((mem_removeCorner hc).mp hxrc').2 (h.trans hmaxeq)⟩)
+      exact (cast_heq (congrArg StandardYoungTableau hyd) _).symm.trans (heq_of_eq hEq)
   }
 
 end HookLengthFormula

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "ballot-problem-oq-03-oq-01-oq-02",
   "title": "Hook-Length Formula for Standard Young Tableaux via LGV",
   "slug": "ballot-problem-oq-03-oq-01-oq-02",
-  "description": "Formalizes the hook-length formula f^λ = n!/∏h(u) for Standard Young Tableaux. Fully proves the formula for all single-row, single-column, hook-shape, 2-row rectangular, and general 2-row [a,b] with a≥b families, plus any YoungDiagram with at most 2 rows (via characterization lemma). Adds general corner recursion infrastructure (Part XIII): isCorner, corners, removeCorner (0 sorries), and card_SYT_corner_step bijection (1 technical HEq sorry). General formula for 3+ row shapes has 4 open sorries total.",
+  "description": "Formalizes the hook-length formula f^λ = n!/∏h(u) for Standard Young Tableaux. Fully proves the formula for all single-row, single-column, hook-shape, 2-row rectangular, and general 2-row [a,b] with a≥b families, plus any YoungDiagram with at most 2 rows (via characterization lemma). Adds general corner recursion infrastructure (Part XIII): isCorner, corners, removeCorner (0 sorries), and card_SYT_corner_step bijection (sorry-free via cast_syt_entry + HEq chain). General formula for 3+ row shapes has 3 open sorries total.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-21",
@@ -19,11 +19,11 @@
       "representation-theory"
     ],
     "badge": "wip",
-    "sorries": 4,
+    "sorries": 3,
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "assumptions": "Four remaining open sorries: (1) ni_count_eq_syt_count (RSK/Fomin growth diagram bijection, ~200 lines), (2) lgv_det_factors_as_hook_quotient (Vandermonde-type det identity, ~200 lines), (3) hook_length_formula (main theorem, pending the above two), (4) card_SYT_corner_step right_inv (HEq/cast technical issue for Sigma.ext — mathematical content complete, hmaxeq proved). hook_length_formula_atMostTwoRows fully proved (0 sorries). card_SYT_corner_step is the general corner recursion for inductive proof of the full HLF.",
-    "lineCount": 3839,
+    "assumptions": "Three remaining open sorries: (1) ni_count_eq_syt_count (RSK/Fomin growth diagram bijection, ~200 lines), (2) lgv_det_factors_as_hook_quotient (Vandermonde-type det identity, ~200 lines), (3) hook_length_formula (main theorem, pending the above two). hook_length_formula_atMostTwoRows fully proved (0 sorries). card_SYT_corner_step (general corner recursion) now fully proved via cast_syt_entry + Sigma.ext + HEq chain.",
+    "lineCount": 3866,
     "theoremCount": 120,
     "definitionCount": 19,
     "originalContributions": [
@@ -90,9 +90,9 @@
       "LGV"
     ],
     "namespace": "HookLengthFormula",
-    "lineCount": 3839,
+    "lineCount": 3866,
     "axiomCount": 0,
-    "sorries": 4,
+    "sorries": 3,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",
     "theoremCount": 120,
     "definitionCount": 19


### PR DESCRIPTION
## Summary

- Proves the `right_inv` of the `card_SYT_corner_step` bijection in `BallotProblemOQ03OQ01OQ02.lean`
- Reduces sorry count from 4 to 3
- Adds `cast_syt_entry` helper lemma (5 lines)

## Technical approach

The sorry was in the `right_inv` of the bijection `T ↦ (maxEntryCell T, restrictSYT_gen T)`. After `hmaxeq : maxEntryCell (extendSYT_gen c hc T₁) hn = c`, the proof requires:

1. **`cast_syt_entry`**: `cast (congrArg StandardYoungTableau h) T).entry x = T.entry x` by `subst h; rfl`
2. **`hyd`**: `removeCorner μ (maxEntryCell ...) hmax_corner = removeCorner μ c hc` via `conv_lhs => rw [hmaxeq]` + `removeCorner_proof_irrel`
3. **`Sigma.ext (Subtype.ext hmaxeq)`**: reduces goal to HEq of SYT second components
4. **Cast equality**: entry-by-entry case analysis on `x ∈ removeCorner μ (maxEntryCell ...) hmax_corner`:
   - Positive: `x ≠ c` (from membership), so `extendSYT_gen` entry = `T₁.entry x`
   - Negative: entry = 0 = `T₁.entry_zero x` (x outside removeCorner μ c hc)
5. **HEq composition**: `(cast_heq H _).symm.trans (heq_of_eq hEq)`

## Remaining sorries (3)

1. `ni_count_eq_syt_count` — RSK/Fomin bijection (~200 lines)
2. `lgv_det_factors_as_hook_quotient` — Vandermonde det identity (~200 lines)
3. `hook_length_formula` — main theorem (pending 1 and 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)