### PR TITLE
Enrich bezout-identity-oq-02-oq-01-oq-02: fix 3 invalid annotation types

### DIFF
--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02/annotations.json
@@ -54,7 +54,7 @@
       "startLine": 39,
       "endLine": 45
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Irreducible ↔ Prime in Any UFD",
     "content": "`irreducible_iff_prime_in_ufd` states that in any `UniqueFactorizationMonoid`, the notions of irreducible and prime coincide. In Lean: `Irreducible p` means $p$ is not a unit and $p = ab \\Rightarrow$ $a$ or $b$ is a unit. `Prime p` means $p \\neq 0$, $p$ is not a unit, and $p \\mid ab \\Rightarrow p \\mid a$ or $p \\mid b$ (Euclid's lemma). The proof wraps `UniqueFactorizationMonoid.irreducible_iff_prime` — a theorem pre-proved in Mathlib. This equivalence distinguishes UFDs from all other domains: in non-UFDs, irreducible need not be prime.",
     "mathContext": "In $\\mathbb{Z}[\\sqrt{-5}]$: $2$ is irreducible (if $2 = ab$ then one of $|a|^2, |b|^2$ equals 1 or 4 by the norm, forcing a unit), but not prime: $2 \\mid (1+\\sqrt{-5})(1-\\sqrt{-5}) = 6$ yet $2 \\nmid (1 \\pm \\sqrt{-5})$. This non-UFD behavior is why $\\mathbb{Z}[\\sqrt{-5}]$ needs ideal theory. In any UFD, irreducible $\\Rightarrow$ prime follows from the unique factorization itself.",
@@ -79,7 +79,7 @@
       "startLine": 47,
       "endLine": 54
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Factorization Existence and Completeness",
     "content": "`factors_exist` packages two Mathlib results into a single theorem: (1) `irreducible_of_factor`: every element in `UniqueFactorizationMonoid.factors a` is irreducible (the factorization contains only irreducibles); (2) `factors_prod`: the product of the factors is associated to `a` (they differ by a unit). The `Associated` relation (`∃ u, IsUnit u, a = u * b`) is needed because factorizations in rings like $\\mathbb{Z}$ are only unique up to sign: $6 = 2 \\cdot 3 = (-2) \\cdot (-3)$. The theorem requires `CancelCommMonoidWithZero` (cancellative monoid) for uniqueness.",
     "mathContext": "In $\\mathbb{Z}$: `factors 12 = [2, 2, 3]` (multiset), `factors_prod`: $2 \\cdot 2 \\cdot 3 = 12$ (associated). In $k[x]$: `factors (x^2 - 1) = [x-1, x+1]` over $k$ with $\\text{char}(k) \\neq 2$. The uniqueness part (not stated here) says the multiset of factors is unique up to associates and permutation — this is `UniqueFactorizationMonoid.factors_unique`.",
@@ -104,7 +104,7 @@
       "startLine": 56,
       "endLine": 60
     },
-    "type": "theorem",
+    "type": "concept",
     "title": "GCD Existence: Universal Property in ℤ",
     "content": "`int_gcd_exists` proves the universal property of the GCD in $\\mathbb{Z}$: there exists $g = \\gcd(a, b)$ such that $g \\mid a$, $g \\mid b$, and every common divisor $d$ satisfies $d \\mid g$ (so $g$ is the 'greatest' in divisibility order). The proof uses `Int.gcd_dvd_left`, `Int.gcd_dvd_right`, and `Int.dvd_gcd` from Mathlib. Note: `Int.gcd : ℤ → ℤ → ℕ` returns a natural number; the proof casts appropriately. This is weaker than Bézout's identity (which gives $g = ax + by$ explicitly), but the divisibility characterization is the algebraically clean form.",
     "mathContext": "GCD universal property: $g = \\gcd(a,b)$ iff $g \\mid a$, $g \\mid b$, and $\\forall d$: $d \\mid a \\land d \\mid b \\Rightarrow d \\mid g$. In $\\mathbb{Z}$, this is equivalent to $g = |ax + by|$ for some $x, y$ (Bézout). The GCD is unique up to sign ($\\gcd(a,b) = \\gcd(a,b) \\cdot (-1) \\cdot (-1)$); Lean's `Int.gcd` returns the nonneg representative.",


### PR DESCRIPTION
## Summary

Schema fix for `bezout-identity-oq-02-oq-01-oq-02` (FTA Generalization to Euclidean Domains):

Fixed 3 annotations using `"type": "theorem"` which is not in the valid schema (`concept|definition|technique|insight|context`):

- `ann-bezout-irred-prime` (irreducible ↔ prime in UFDs): `"theorem"` → `"insight"` — this annotation reveals the key equivalence that distinguishes UFDs from general domains, making "insight" the appropriate type
- `ann-bezout-factors-exist` (factorization existence): `"theorem"` → `"insight"` — reveals the `Associated` relation for sign conventions and the `CancelCommMonoidWithZero` requirement
- `ann-bezout-gcd` (GCD universal property): `"theorem"` → `"concept"` — describes the GCD universal property concept and its connection to Bézout's identity

All annotation content preserved; only the `type` fields changed to valid values.