### PR TITLE
Add Aristotle companion for Erdős #548 (Erdős-Sós Conjecture)

### DIFF
--- a/proofs/Proofs/Erdos548ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos548ProblemAristotle.lean
@@ -1,0 +1,57 @@
+/-
+  Aristotle targets for Erdős Problem #548 (Erdős-Sós Conjecture)
+  Routine supporting lemmas for automated proof search.
+  See Erdos548Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - sum_degrees_eq_twice_edges: handshaking lemma (standard graph theory)
+  - star_is_tree: star graph K_{1,k} is a tree (connected + acyclic structure)
+  - NOT ErdosSosConjecture (open problem)
+  - NOT trivial_tree_bound / brandt_dobson / sacle_wozniak (axioms — major results)
+  - NOT erdos_sos_implies_extremal (requires open conjecture as hypothesis)
+  - NOT star_easier (requires complex combinatorial argument)
+-/
+import Mathlib
+
+namespace Erdos548Aristotle
+
+open SimpleGraph Finset Function
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+/-- Number of edges in a graph. -/
+noncomputable def edgeCount (G : SimpleGraph V) : ℕ := G.edgeFinset.card
+
+/-- The star graph K_{1,k} with k leaves.
+    Vertex 0 is the center; vertices 1..k are the leaves. -/
+def starGraph (k : ℕ) : SimpleGraph (Fin (k + 1)) where
+  Adj i j := (i.val = 0 ∧ j.val ≠ 0) ∨ (j.val = 0 ∧ i.val ≠ 0)
+  symm := by
+    intro i j h
+    cases h with
+    | inl h => right; exact ⟨h.2, h.1⟩
+    | inr h => left; exact ⟨h.2, h.1⟩
+  loopless := by
+    intro i h
+    cases h with
+    | inl h => exact h.2 h.1
+    | inr h => exact h.2 h.1
+
+-- Routine: The handshaking lemma — sum of degrees = 2 * edge count.
+-- This is a standard result: SimpleGraph.sum_degrees_eq_twice_card_edges.
+theorem sum_degrees_eq_twice_edges (G : SimpleGraph V) [DecidableRel G.Adj] :
+    (Finset.univ.sum fun v => G.degree v) = 2 * edgeCount G := by
+  sorry
+
+-- Routine: The star graph K_{1,k} is connected for k ≥ 1.
+-- Every leaf is adjacent to the center (vertex 0), and 0 reaches all vertices.
+theorem starGraph_connected (k : ℕ) (hk : k ≥ 1) : (starGraph k).Connected := by
+  sorry
+
+-- Routine: Each edge of the star K_{1,k} contributes to reachability.
+-- Adjacent vertices in the star are reachable (trivially: direct adjacency).
+theorem starGraph_adj_reachable (k : ℕ) (i j : Fin (k + 1))
+    (h : (starGraph k).Adj i j) : (starGraph k).Reachable i j := by
+  sorry
+
+end Erdos548Aristotle


### PR DESCRIPTION
## Fix

Creates `Erdos548ProblemAristotle.lean` — an Aristotle companion file for the Erdős-Sós Conjecture formalization, containing 3 routine lemmas suitable for automated proof search.

## Evidence

**Before**: `Erdos548Problem.lean` has 6 sorries with no Aristotle companion targeting the provable supporting lemmas.

**After**: Companion file provides 3 Aristotle-eligible targets:
- `sum_degrees_eq_twice_edges`: handshaking lemma — `∑ degree = 2 * |edges|`; should follow from `SimpleGraph.sum_degrees_eq_twice_card_edges`
- `starGraph_connected`: star K_{1,k} is connected for k ≥ 1; center reaches all leaves
- `starGraph_adj_reachable`: adjacent vertices in a star are reachable

**Excluded** (per pre-submission checklist):
- Open conjecture `ErdosSosConjecture` — Aristotle cannot discover new proofs
- Axiomatized major results (`trivial_tree_bound`, `brandt_dobson`, etc.)
- `erdos_sos_implies_extremal` — conditionally depends on the open conjecture
- `star_easier` — requires complex combinatorial argument

---
Automated fix by lean-mechanic agent.