### PR TITLE
Research: fair-games Aristotle companion — close 7/11 sorries

### DIFF
--- a/proofs/Proofs/FairGamesTheoremOQ03Aristotle.lean
+++ b/proofs/Proofs/FairGamesTheoremOQ03Aristotle.lean
@@ -25,13 +25,13 @@ namespace FairGamesOQ03.Aristotle
 lemma stoppedValue_const {Ω : Type*} {m : MeasurableSpace Ω}
     (f : ℕ → Ω → ℝ) (n : ℕ) (ω : Ω) :
     stoppedValue f (fun _ => (n : ℕ∞)) ω = f n ω := by
-  sorry
+  simp [stoppedValue]
 
 /-- stoppedValue at min(τ, N) equals stoppedValue at τ when τ ≤ N -/
 lemma stoppedValue_eq_of_le {Ω : Type*} {m : MeasurableSpace Ω}
     (f : ℕ → Ω → ℝ) (τ : Ω → ℕ∞) (N : ℕ) (ω : Ω) (h : τ ω ≤ N) :
     stoppedValue f τ ω = stoppedValue f (fun ω' => min (τ ω') N) ω := by
-  sorry
+  simp only [stoppedValue, min_eq_left h]
 
 /-- Measurability of stoppedValue for adapted processes -/
 lemma stoppedValue_measurable {Ω : Type*} {m : MeasurableSpace Ω}
@@ -47,15 +47,15 @@ lemma stoppedValue_measurable {Ω : Type*} {m : MeasurableSpace Ω}
 /-- The constant function N is a ℕ∞-stopping time -/
 lemma isStoppingTime_const {Ω : Type*} {m : MeasurableSpace Ω}
     {ℱ : Filtration ℕ m} (N : ℕ∞) :
-    IsStoppingTime ℱ (fun _ : Ω => N) := by
-  sorry
+    IsStoppingTime ℱ (fun _ : Ω => N) :=
+  MeasureTheory.isStoppingTime_const ℱ N
 
 /-- min of two stopping times is a stopping time -/
 lemma isStoppingTime_min {Ω : Type*} {m : MeasurableSpace Ω}
     {ℱ : Filtration ℕ m} (τ π : Ω → ℕ∞)
     (hτ : IsStoppingTime ℱ τ) (hπ : IsStoppingTime ℱ π) :
-    IsStoppingTime ℱ (fun ω => min (τ ω) (π ω)) := by
-  sorry
+    IsStoppingTime ℱ (fun ω => min (τ ω) (π ω)) :=
+  hτ.min hπ
 
 /-- A stopped ℕ∞-stopping time bounded by N gives integrability -/
 lemma stoppedValue_integrable {Ω : Type*} {m : MeasurableSpace Ω}
@@ -78,7 +78,10 @@ lemma martingale_stopped_integral_eq {Ω : Type*} {m : MeasurableSpace Ω}
     (τ π : Ω → ℕ∞) (hτ : IsStoppingTime ℱ τ) (hπ : IsStoppingTime ℱ π)
     (hτπ : τ ≤ π) (N : ℕ) (hπN : ∀ ω, π ω ≤ N) :
     ∫ ω, stoppedValue f τ ω ∂μ = ∫ ω, stoppedValue f π ω ∂μ := by
-  sorry
+  have h₁ := hf.submartingale.expected_stoppedValue_mono hτ hπ hτπ hπN
+  have h₂ := hf.supermartingale.neg.expected_stoppedValue_mono hτ hπ hτπ hπN
+  simp only [stoppedValue, Pi.neg_apply, integral_neg] at h₁ h₂ ⊢
+  linarith
 
 /-- For a martingale, ∫ stoppedValue f τ = ∫ f 0 when τ ≤ N -/
 lemma martingale_stopped_eq_initial {Ω : Type*} {m : MeasurableSpace Ω}
@@ -87,7 +90,12 @@ lemma martingale_stopped_eq_initial {Ω : Type*} {m : MeasurableSpace Ω}
     (hf : Martingale f ℱ μ)
     (τ : Ω → ℕ∞) (hτ : IsStoppingTime ℱ τ) (N : ℕ) (hτN : ∀ ω, τ ω ≤ N) :
     ∫ ω, stoppedValue f τ ω ∂μ = ∫ ω, f 0 ω ∂μ := by
-  sorry
+  have h₁ := hf.submartingale.expected_stoppedValue_mono
+    (MeasureTheory.isStoppingTime_const ℱ 0) hτ (fun _ => zero_le _) hτN
+  have h₂ := hf.supermartingale.neg.expected_stoppedValue_mono
+    (MeasureTheory.isStoppingTime_const ℱ 0) hτ (fun _ => zero_le _) hτN
+  simp only [stoppedValue_const, stoppedValue, Pi.neg_apply, integral_neg] at h₁ h₂ ⊢
+  linarith
 
 /-
   ## Section 4: NNReal to Real Conversion Helpers
@@ -96,8 +104,8 @@ lemma martingale_stopped_eq_initial {Ω : Type*} {m : MeasurableSpace Ω}
 /-- ENNReal.toReal of a probability measure of a set is ≤ 1 -/
 lemma measure_toReal_le_one {Ω : Type*} {m : MeasurableSpace Ω}
     {μ : Measure Ω} [IsProbabilityMeasure μ] (s : Set Ω) :
-    (μ s).toReal ≤ 1 := by
-  sorry
+    (μ s).toReal ≤ 1 :=
+  ENNReal.toReal_le_one.mpr prob_le_one
 
 /-- thresh * (μ s).toReal ≤ integral bound from Doob's maximal ineq via NNReal -/
 lemma doob_maximal_real_of_nnreal {Ω : Type*} {m : MeasurableSpace Ω}

--- a/research/problems/fair-games-theorem-oq-02-oq-01-oq-01/knowledge.md
+++ b/research/problems/fair-games-theorem-oq-02-oq-01-oq-01/knowledge.md
@@ -1,21 +1,41 @@
-# Knowledge Base: fair-games-theorem-oq-02-oq-01-oq-01
+# Knowledge: fair-games-theorem-oq-02-oq-01-oq-01
 
-Insights accumulated during research on this problem.
+## Problem Summary
 
----
+**Goal**: Formalize Wald's Identity supporting lemmas via Mathlib.
 
-## Problem Understanding
+The main file `FairGamesTheoremOQ03.lean` is already COMPLETE (0 sorries). This problem
+focuses on closing the 11 sorries in `FairGamesTheoremOQ03Aristotle.lean`, which provides
+routine supporting lemmas for automated proof search.
 
-[Initial observations about the problem will be recorded here]
+## Mathlib API Discovered
 
----
+- `MeasureTheory.isStoppingTime_const ℱ N` — proves `IsStoppingTime ℱ (fun _ => N)` for `N : ℕ∞`
+- `IsStoppingTime.min hτ hπ` (`hτ.min hπ`) — min of two stopping times is a stopping time
+- `stoppedValue_const` — simp lemma reducing `stoppedValue f (fun _ => n)` to `f n`
+- `ENNReal.toReal_le_one.mpr prob_le_one` — proves `(μ s).toReal ≤ 1` for probability measure
+- `Submartingale.expected_stoppedValue_mono` — key monotonicity for optional stopping
+- `simp [stoppedValue]` — unfolds `stoppedValue f τ ω`
+- `simp [stoppedValue, min_eq_left h]` — proves stoppedValue equality when τ ≤ N
 
-## Insights
+## Session 2026-04-23 (Session 1)
 
-[Insights from research attempts will be accumulated here]
+**Outcome**: progress
+**Sorries closed**: 7 of 11 (pending CI verification)
 
----
+### Proofs Written
 
-## Dead Ends
+1. `stoppedValue_const`: `simp [stoppedValue]`
+2. `stoppedValue_eq_of_le`: `simp only [stoppedValue, min_eq_left h]`
+3. `isStoppingTime_const`: `MeasureTheory.isStoppingTime_const ℱ N`
+4. `isStoppingTime_min`: `hτ.min hπ`
+5. `martingale_stopped_integral_eq`: sub/supermartingale sandwich (from main file)
+6. `martingale_stopped_eq_initial`: sub/supermartingale sandwich (from main file)
+7. `measure_toReal_le_one`: `ENNReal.toReal_le_one.mpr prob_le_one`
 
-[Approaches known not to work will be documented here]
+### Remaining Sorries (4)
+
+1. `stoppedValue_measurable` — needs `Adapted.stoppedValue_measurable` or similar
+2. `stoppedValue_integrable` — integrability from bounded stopping time
+3. `doob_maximal_real_of_nnreal` — NNReal/ENNReal conversion of Doob maximal ineq
+4. `maximal_set_measurable` — measurability of `{ω | ∃ n ≤ N, thresh ≤ f n ω}`

--- a/src/data/research/problems/fair-games-theorem-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/fair-games-theorem-oq-02-oq-01-oq-01.json
@@ -1,0 +1,163 @@
+{
+  "slug": "fair-games-theorem-oq-02-oq-01-oq-01",
+  "title": "Fair Games \u2014 Wald's Identity Formalization via Mathlib",
+  "phase": "ACT",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "E\\left[\\sum_{i=1}^{\\tau} Y_i\\right] = \\mu \\cdot E[\\tau]",
+    "plain": "Wald's identity says: if you stop a sequence of i.i.d. random variables at a random time",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-04-22T15:58:45+02:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "PROGRESS: 7 of 11 Aristotle sorries closed (stoppedValue_const, stoppedValue_eq_of_le, isStoppingTime_const, isStoppingTime_min, martingale_stopped_integral_eq, martingale_stopped_eq_initial, measure_toReal_le_one); 4 remain",
+    "builtItems": [
+      "stoppedValue_const: proved via simp [stoppedValue] (FairGamesTheoremOQ03Aristotle.lean)",
+      "stoppedValue_eq_of_le: proved via simp [stoppedValue, min_eq_left h]",
+      "isStoppingTime_const: proved via MeasureTheory.isStoppingTime_const \u2131 N",
+      "isStoppingTime_min: proved via h\u03c4.min h\u03c0",
+      "martingale_stopped_integral_eq: proved via sub/supermartingale sandwich",
+      "martingale_stopped_eq_initial: proved via sub/supermartingale sandwich + stoppedValue_const",
+      "measure_toReal_le_one: proved via ENNReal.toReal_le_one.mpr prob_le_one"
+    ],
+    "insights": [
+      "FairGamesTheoremOQ03.lean is complete (0 sorries) \u2014 main theorems fully proved without Wald infrastructure",
+      "Aristotle companion has 11 sorries for routine supporting lemmas",
+      "isStoppingTime_const in Mathlib: MeasureTheory.isStoppingTime_const \u2131 N",
+      "IsStoppingTime.min: h\u03c4.min h\u03c0 proves minimum of two stopping times is a stopping time",
+      "measure_toReal_le_one: ENNReal.toReal_le_one.mpr prob_le_one works",
+      "martingale_stopped_integral_eq proof: sub/supermartingale sandwich from main file",
+      "martingale_stopped_eq_initial: same proof as any_bounded_strategy_preserves_expectation"
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "stoppedValue_measurable: left as sorry \u2014 needs Adapted.stoppedValue_measurable or similar",
+      "stoppedValue_integrable: left as sorry \u2014 needs integrability from bounded stopping time",
+      "doob_maximal_real_of_nnreal: left as sorry \u2014 complex NNReal/ENNReal conversion",
+      "maximal_set_measurable: left as sorry \u2014 follows from measurability of adapted process"
+    ],
+    "markdown": "# Knowledge Base: fair-games-theorem-oq-02-oq-01-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "probability",
+    "martingale",
+    "optional-stopping",
+    "wald-identity",
+    "mathlib",
+    "sequential-analysis"
+  ],
+  "relatedProofs": [
+    "fair-games-theorem",
+    "fair-games-theorem-oq-01",
+    "fair-games-theorem-oq-02",
+    "fair-games-theorem-oq-02-oq-01",
+    "fair-games-theorem-oq-02-oq-04",
+    "fair-games-theorem-oq-03"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-04-22T15:58:45+02:00",
+  "significance": 6,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/FairGamesTheorem.lean",
+      "filename": "FairGamesTheorem.lean",
+      "lineCount": 418,
+      "theoremCount": 5,
+      "axiomCount": 1,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FairGamesTheorem.lean"
+    },
+    {
+      "path": "Proofs/FairGamesTheoremOQ01.lean",
+      "filename": "FairGamesTheoremOQ01.lean",
+      "lineCount": 633,
+      "theoremCount": 48,
+      "axiomCount": 0,
+      "defCount": 12,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FairGamesTheoremOQ01.lean"
+    },
+    {
+      "path": "Proofs/FairGamesTheoremOQ02.lean",
+      "filename": "FairGamesTheoremOQ02.lean",
+      "lineCount": 160,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FairGamesTheoremOQ02.lean"
+    },
+    {
+      "path": "Proofs/FairGamesTheoremOQ02OQ01.lean",
+      "filename": "FairGamesTheoremOQ02OQ01.lean",
+      "lineCount": 292,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FairGamesTheoremOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/FairGamesTheoremOQ02OQ04.lean",
+      "filename": "FairGamesTheoremOQ02OQ04.lean",
+      "lineCount": 346,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FairGamesTheoremOQ02OQ04.lean"
+    },
+    {
+      "path": "Proofs/FairGamesTheoremOQ03.lean",
+      "filename": "FairGamesTheoremOQ03.lean",
+      "lineCount": 331,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FairGamesTheoremOQ03.lean"
+    },
+    {
+      "path": "Proofs/FairGamesTheoremOQ03Aristotle.lean",
+      "filename": "FairGamesTheoremOQ03Aristotle.lean",
+      "lineCount": 122,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 4,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FairGamesTheoremOQ03Aristotle.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Closes 7 of 11 sorries in `FairGamesTheoremOQ03Aristotle.lean` using Mathlib API
- Creates `src/data/research/problems/fair-games-theorem-oq-02-oq-01-oq-01.json` tracking research state
- Populates `research/problems/fair-games-theorem-oq-02-oq-01-oq-01/knowledge.md` with Mathlib API discoveries

## Proofs Closed

| Lemma | Proof |
|-------|-------|
| `stoppedValue_const` | `simp [stoppedValue]` |
| `stoppedValue_eq_of_le` | `simp [stoppedValue, min_eq_left h]` |
| `isStoppingTime_const` | `MeasureTheory.isStoppingTime_const ℱ N` |
| `isStoppingTime_min` | `hτ.min hπ` |
| `martingale_stopped_integral_eq` | sub/supermartingale sandwich (from OQ03 main) |
| `martingale_stopped_eq_initial` | sub/supermartingale sandwich + stoppedValue_const |
| `measure_toReal_le_one` | `ENNReal.toReal_le_one.mpr prob_le_one` |

## Sorries Remaining (4)

- `stoppedValue_measurable` — needs `Adapted.stoppedValue_measurable` or similar
- `stoppedValue_integrable` — integrability from bounded stopping time
- `doob_maximal_real_of_nnreal` — NNReal/ENNReal conversion of Doob maximal inequality
- `maximal_set_measurable` — measurability of `{ω | ∃ n ≤ N, thresh ≤ f n ω}`

## Note

Proofs are pending CI verification (no Docker available during authoring session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)