### PR TITLE
Fix lebesgue-measure-oq-06: correct axiomCount, sorry count, badge

### DIFF
--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -17,11 +17,11 @@
       "axiom-of-choice",
       "research"
     ],
-    "badge": "axiom",
-    "sorries": 6,
-    "axiomCount": 4,
+    "badge": "wip",
+    "sorries": 4,
+    "axiomCount": 0,
     "lineCount": 287,
-    "assumptions": "4 axioms: hausdorff_free_subgroup (Hausdorff 1914 — SO(3) contains F₂, requires 300+ lines of number theory), banach_tarski (Banach-Tarski 1924 — main paradox, requires 800+ lines via Hausdorff paradox + AC), banach_tarski_pieces_nonmeasurable (classical non-measurability corollary), int_amenable (Markov-Kakutani — ℤ is amenable via Cesàro means/ultrafilter construction). 6 sorries in supporting theorems: measure-theoretic consequence of paradoxical decomposition, SO(3) rotation matrices, banach_tarski_corollary, banach_tarski_pieces_measurable_contradiction, cesaro_mean_density, and free_group_not_amenable.",
+    "assumptions": "4 sorry'd theorems representing major unproved results: hausdorff_free_subgroup (Hausdorff 1914 — SO(3) contains F₂ as a free subgroup of rank 2, requires 300+ lines of number theory), banach_tarski (Banach-Tarski 1924 — main paradox for the unit ball in ℝ³, requires 800+ lines via Hausdorff paradox + AC), banach_tarski_pieces_nonmeasurable (non-measurability of decomposition pieces), int_amenable (ℤ is amenable via Cesàro means). No formal axiom declarations. Abstract framework (equidecomposability, paradoxical sets, F₂ non-amenability, measure-theoretic consequence) is fully proved with 0 sorries.",
     "dateAdded": "2026-04-22",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -106,7 +106,7 @@
     }
   ],
   "conclusion": {
-    "summary": "The Banach-Tarski paradox is formalized with 0 sorries and 4 axioms: Hausdorff's free subgroup theorem, the main Banach-Tarski paradox, non-measurability of pieces, and ℤ amenability. The abstract framework (equidecomposability, paradoxical sets, F₂ non-amenability) is fully proved with no axioms. The 4 axioms represent classically established results whose Lean proofs require 300–800 lines each — beyond this gallery entry's scope.",
+    "summary": "The Banach-Tarski paradox is formalized with 4 sorry'd unproved major results (hausdorff_free_subgroup, banach_tarski, banach_tarski_pieces_nonmeasurable, int_amenable) and 0 formal axiom declarations. The abstract framework (equidecomposability, paradoxical sets, F₂ non-amenability, measure-theoretic consequence) is fully proved with 0 sorries. The 4 sorry'd theorems represent classically established results whose Lean proofs require 300–800 lines each — beyond this gallery entry's scope.",
     "openQuestions": [
       "Can Hausdorff's free subgroup theorem be fully formalized in Lean? The proof requires showing that explicit 3×3 rotation matrices $\\varphi$ (rotation by $\\arccos(1/3)$ around the $z$-axis) and $\\psi$ (rotation by $\\arccos(1/3)$ around the $x$-axis) generate a free group of rank 2 in $\\text{SO}(3)$. The algebraic argument shows that nontrivial words $w(\\varphi, \\psi)$ applied to $e_1 = (1, 0, 0)$ produce vectors with coordinates in $\\mathbb{Z}[1/3, \\sqrt{2}/3]$ that are non-zero — requiring careful case analysis on the word structure and number-theoretic properties of $\\arccos(1/3)$ (specifically that it is not a rational multiple of $\\pi$).",
       "Can the full Banach-Tarski proof be formalized in Lean 4? The most likely modular path: (1) formalize the free subgroup freeness (the sorry in `hausdorff_free_subgroup`); (2) prove the paradoxical decomposition of $F_2$ acting on itself (purely algebraic, ~100 lines); (3) lift to $S^2 \\setminus D$ via the free group action (~150 lines); (4) handle the exceptional set $D$ via a rotation of infinite order (Hilbert hotel, ~100 lines); (5) extend from $S^2$ to $B^3$ by coning and handling the center (~100 lines). Estimated total: 800–1200 lines.",
@@ -202,11 +202,11 @@
     ],
     "namespace": "BanachTarski",
     "lineCount": 287,
-    "axiomCount": 4,
+    "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 5,
     "path": "Proofs/LebesgueMeasureOQ06.lean",
-    "sorries": 6
+    "sorries": 4
   },
-  "sorries": 6
+  "sorries": 4
 }


### PR DESCRIPTION
## Summary

Corrects `lebesgue-measure-oq-06/meta.json` to match the actual Lean source state, found during gallery integrity audit.

### Changes (1 file: meta.json only)
- `axiomCount`: 4 → 0 (no `axiom` declarations in Lean file; the 4 main results are sorry'd theorems, not formal axioms)
- `sorries`: 6 → 4 (two supporting theorems were proved: `free_group_not_amenable` and `banach_tarski_corollary`)
- `badge`: axiom → wip (sorries remain; no formal axiom declarations)
- `leanFile.axiomCount`: 4 → 0
- `leanFile.sorries`: 6 → 4  
- Updated `assumptions` to describe the 4 sorry'd theorems accurately
- Updated `conclusion.summary` to reflect actual proof state

### Verification
```bash
git show origin/main:proofs/Proofs/LebesgueMeasureOQ06.lean | grep -c "^axiom "  # 0
git show origin/main:proofs/Proofs/LebesgueMeasureOQ06.lean | grep -c "sorry"    # 4
```

Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)