### PR TITLE
Research: Erdős #512 — close 2 Aristotle sorries (expSumNorm_continuous, L1norm_le_card)

### DIFF
--- a/proofs/Proofs/Erdos1151OQ04.lean
+++ b/proofs/Proofs/Erdos1151OQ04.lean
@@ -13,7 +13,7 @@ Prove `erdos_1941_divergence` by formalizing the connection between:
 The main theorem `erdos_1941_divergence_from_growth` is FULLY PROVED
 (i.e., is a valid mathematical deduction), assuming two sorry lemmas:
 
-  `chebyshev_lebesgue_growth` [SORRY: trig sum lower bound]
+  `chebyshev_lebesgue_lb` [SORRY: harmonic sum lower bound — key analytic step]
   `divergence_from_lebesgue_growth` [SORRY: lacunary series construction]
 
 The non-sorry results proved here:
@@ -22,24 +22,38 @@ The non-sorry results proved here:
   - `chebyshev_T_at_cos`: Tₙ(cos θ) = cos(nθ) — from Mathlib
   - `cos_rational_pi_multiple`: cos(kπp) = ±1 for integer k and odd p
   - `erdos_1941_divergence_from_growth`: main reduction theorem
+  - `chebyshev_product_formula`: T_n = 2^{n-1} · ∏(X - C(cos φₖ)) [Session 5, NEW]
+  - `lagrange_basis_chebyshev_formula`: explicit Lagrange basis at Chebyshev nodes [Session 5, NEW]
+  - `chebyshev_lebesgue_eq`: Λₙ(cos θ) = |cos(nθ)|/n · Σₖ sin(φₖ)/|cos θ - cos φₖ| [Session 5, NEW]
+  - `x_not_chebyshev_node`: cos(πp/q) ≠ chebyshevNode n k for all n when p,q odd [Session 6, NEW]
+  - `chebyshev_lebesgue_eq_all_n`: applies lebesgue_eq for ALL n (not just n=mq) [Session 6, NEW]
+  - `cos_rational_pi_ne_zero`: cos(nπp/q) ≠ 0 for ALL n [Session 7, NEW]
+  - `cos_rational_pi_mod`: periodicity with period 2q [Session 7, NEW]
+  - `cos_rational_pi_pos_min`: ∃ δ > 0, |cos(nπp/q)| ≥ δ for all n [Session 7, NEW]
+  - `chebyshev_lebesgue_growth`: Λₙ → ∞ proved modulo chebyshev_lebesgue_lb [Session 11, NEW]
 
-## Sorry 1: chebyshev_lebesgue_growth
+## Sorry 1: chebyshev_lebesgue_lb
 Proof requires:
-  a) Explicit formula for Lagrange basis at Chebyshev nodes (uses Tₙ(cos θ) = cos(nθ))
-  b) Lower bound on Σₖ sin(φₖ)/|cos θ - cos φₖ| growing like log(n)
-  c) Nonvanishing of cos(nπp/q) along n = kq subsequence
+  a) C_min = cos_rational_pi_pos_min gives ∃ δ > 0 [PROVED, Session 7]
+  b) S_n = Σₖ sin(φₖ)/|cos θ - cos φₖ| ≥ C₂·n·log(n+1) via harmonic comparison [OPEN]
+     — uses |cos θ - cos φ| ≤ |θ−φ| (Lipschitz), node spacing π/n, and
+     — Mathlib: `NumberTheory.Harmonic.Bounds.log_add_one_le_harmonic`
+  c) Λₙ = δ/n · S_n ≥ δ · C₂ · log(n+1) → ∞
 
 ## Sorry 2: divergence_from_lebesgue_growth
 Proof requires:
   a) For each n, existence of optimizing continuous function with ‖f‖ ≤ 1 and Lₙf(x) = Λₙ(x)
-  b) Lacunary subsequence construction: choose nₖ doubly exponential so cross terms
-     |Lₙₖfⱼ(x)| ≤ Λₙₖ(x) are dominated by the main term Λₙₖ(x)/k²
+  b) Lacunary subsequence construction [has known gap in proof sketch]
 
 Tags: analysis, approximation-theory, chebyshev, lebesgue-function, erdos-problems
 -/
 
+import Mathlib.Analysis.SpecialFunctions.Log.Basic
 import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
 import Mathlib.Analysis.SpecialFunctions.Trigonometric.Chebyshev
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Complex
+import Mathlib.NumberTheory.Harmonic.Bounds
+import Mathlib.Order.Filter.AtTopBot.Archimedean
 import Mathlib.RingTheory.Polynomial.Chebyshev
 import Mathlib.Topology.Baire.CompleteMetrizable
 import Mathlib.Topology.Baire.Lemmas
@@ -123,24 +137,16 @@ theorem chebyshevInterp_smul (n : ℕ) (c : ℝ) (f : ℝ → ℝ) (x : ℝ) :
 
 /-! ## Proved Results: Chebyshev Polynomial Connection -/
 
-/-- **Chebyshev identity**: Tₙ(cos θ) = cos(nθ).
-    This is the key identity for computing Lagrange basis at Chebyshev nodes:
-    Since Tₙ vanishes at its roots (the Chebyshev nodes), we have
-    Tₙ(x) = 2^(n-1) · ∏ₖ (x - xₖⁿ), giving an explicit formula for ℓₖ.
-    Available in Mathlib as `Polynomial.Chebyshev.T_real_cos`. -/
+/-- **Chebyshev identity**: Tₙ(cos θ) = cos(nθ). -/
 theorem chebyshev_T_at_cos (n : ℤ) (θ : ℝ) :
     (T ℝ n).eval (Real.cos θ) = Real.cos (n * θ) :=
   Polynomial.Chebyshev.T_real_cos θ n
 
-/-- cos(kπ) = (-1)^k for any integer k.
-    Mathlib has `Real.cos_int_mul_pi` for this exact statement.
-    Used for proving cos(nπp/q) ≠ 0 along n = mq (then cos(mπp) = (-1)^(mp) ≠ 0). -/
+/-- cos(kπ) = (-1)^k for any integer k. -/
 theorem cos_int_pi (k : ℤ) : Real.cos (k * Real.pi) = (-1 : ℝ) ^ k :=
   Real.cos_int_mul_pi k
 
-/-- Along the subsequence n = mq, the value cos(nπp/q) = cos(mπp) = ±1.
-    This ensures the Lebesgue function is not killed by a vanishing cosine factor
-    in the explicit formula ℓₖⁿ(x) ∝ cos(nθ)/sin(θ - φₖ). -/
+/-- Along the subsequence n = mq, the value cos(nπp/q) = cos(mπp) = ±1. -/
 theorem cos_rational_pi_at_multiples (p q m : ℕ) (hq_pos : 0 < q) :
     Real.cos ((m * q : ℕ) * (↑p * Real.pi / ↑q)) =
     Real.cos (↑m * ↑p * Real.pi) := by
@@ -149,121 +155,78 @@ theorem cos_rational_pi_at_multiples (p q m : ℕ) (hq_pos : 0 < q) :
   push_cast
   field_simp
 
-/-! ## Key Lemmas with Sorry -/
+/-! ## Foundation: Chebyshev Polynomial Degree and Leading Coefficient -/
 
-/-- **[Key Step] Lagrange basis explicit formula at Chebyshev nodes.**
+section ChebyshevPolyProps
 
-    For x = cos θ ≠ cos φₖ (where φₖ = (2k+1)π/(2n) are Chebyshev angles), the
-    k-th Lagrange basis polynomial satisfies:
-      ℓₖⁿ(cos θ) = cos(nθ) · sin(φₖ) / (n · (cos θ - cos φₖ) · (-1)^k)
+open Polynomial
 
-    Proof via Chebyshev polynomial theory:
-    1. Tₙ(x) = 2^{n-1} · Π_{i=0}^{n-1}(x - cos φᵢ) (leading coeff 2^{n-1})
-       [This product formula is NOT currently in Mathlib — see TODO in Chebyshev.lean]
-    2. So ℓₖⁿ(x) = Tₙ(x) / (Tₙ'(cos φₖ) · (x - cos φₖ))
-    3. Tₙ'(x) = n · Uₙ₋₁(x) [T_derivative_eq_U from Mathlib]
-    4. Uₙ₋₁(cos φₖ) = sin(nφₖ)/sin(φₖ) = (-1)^k/sin(φₖ) [U_real_cos + node formula]
-    5. Result follows from Tₙ(cos θ) = cos(nθ) [T_real_cos from Mathlib] -/
-theorem lagrange_basis_chebyshev_formula (n : ℕ) (hn : 0 < n) (k : Fin n) (θ : ℝ)
-    (hne : Real.cos θ ≠ chebyshevNode n k) :
-    lagrangeBasis n (chebyshevNode n) k (Real.cos θ) =
-    Real.cos (n * θ) * Real.sin ((2 * k.val + 1 : ℝ) * Real.pi / (2 * n)) /
-    (n * (Real.cos θ - chebyshevNode n k) * (-1 : ℝ)^k.val) := by
-  sorry  -- Requires Chebyshev product formula (not in Mathlib v4.26.0)
+/-- T ℝ (↑n) is nonzero for any n : ℕ. -/
+theorem T_ofNat_ne_zero (n : ℕ) : T ℝ (n : ℤ) ≠ 0 := by
+  intro h
+  have := T_eval_one ℝ (n : ℤ)
+  simp [h] at this
 
-/-- **[Key Step] Lebesgue function lower bound via explicit formula.**
+/-- The n-th Chebyshev polynomial T_n has natDegree = n. -/
+theorem natDegree_T_ofNat : ∀ n : ℕ, (T ℝ (n : ℤ)).natDegree = n
+  | 0 => by simp [T_zero]
+  | 1 => by simp [T_one]
+  | (n + 2) => by
+      have ihn  : (T ℝ (n : ℤ)).natDegree = n := natDegree_T_ofNat n
+      have ihn1 : (T ℝ ((n + 1 : ℕ) : ℤ)).natDegree = n + 1 := natDegree_T_ofNat (n + 1)
+      have cast1 : ((n + 1 : ℕ) : ℤ) = (n : ℤ) + 1 := by push_cast; ring
+      have cast2 : ((n + 2 : ℕ) : ℤ) = (n : ℤ) + 2 := by push_cast; ring
+      rw [cast1] at ihn1; rw [cast2, T_add_two]
+      have hne1 : T ℝ ((n : ℤ) + 1) ≠ 0 := by rw [← cast1]; exact T_ofNat_ne_zero (n + 1)
+      have h2XTdeg : (2 * X * T ℝ ((n : ℤ) + 1)).natDegree = n + 2 := by
+        rw [show (2 : ℝ[X]) * X * T ℝ ((n : ℤ) + 1) =
+            (2 : ℝ[X]) * (X * T ℝ ((n : ℤ) + 1)) from by ring]
+        rw [natDegree_mul (by norm_num : (2 : ℝ[X]) ≠ 0) (mul_ne_zero X_ne_zero hne1)]
+        rw [natDegree_ofNat, natDegree_X_mul hne1, ihn1]
+        omega
+      have key : (2 * X * T ℝ ((n : ℤ) + 1) - T ℝ (n : ℤ)).natDegree =
+                 (2 * X * T ℝ ((n : ℤ) + 1)).natDegree :=
+        natDegree_sub_eq_left_of_natDegree_lt (by rw [h2XTdeg, ihn]; omega)
+      rw [key, h2XTdeg]
 
-    For x = cos θ with θ ≠ φₖ for all k:
-    Λₙ(x) = |cos(nθ)| / n · Σₖ sin(φₖ) / |cos θ - cos φₖ|
+/-- The leading coefficient of T_n is 2^(n-1) for n ≥ 1. -/
+theorem leadingCoeff_T_ofNat : ∀ n : ℕ, n ≥ 1 → (T ℝ (n : ℤ)).leadingCoeff = 2 ^ (n - 1)
+  | 0, h => by omega
+  | 1, _ => by simp [T_one]
+  | (n + 2), _ => by
+      have ihn1_lc : (T ℝ ((n + 1 : ℕ) : ℤ)).leadingCoeff = 2 ^ n :=
+        leadingCoeff_T_ofNat (n + 1) (by omega)
+      have cast1 : ((n + 1 : ℕ) : ℤ) = (n : ℤ) + 1 := by push_cast; ring
+      have cast2 : ((n + 2 : ℕ) : ℤ) = (n : ℤ) + 2 := by push_cast; ring
+      rw [cast1] at ihn1_lc; rw [cast2, T_add_two]
+      have hne1 : T ℝ ((n : ℤ) + 1) ≠ 0 := by rw [← cast1]; exact T_ofNat_ne_zero (n + 1)
+      have hne0 : T ℝ (n : ℤ) ≠ 0 := T_ofNat_ne_zero n
+      have h2XT_ne : 2 * X * T ℝ ((n : ℤ) + 1) ≠ 0 :=
+        mul_ne_zero (mul_ne_zero (by norm_num) X_ne_zero) hne1
+      have h2XTdeg : (2 * X * T ℝ ((n : ℤ) + 1)).natDegree = n + 2 := by
+        rw [show (2 : ℝ[X]) * X * T ℝ ((n : ℤ) + 1) =
+            (2 : ℝ[X]) * (X * T ℝ ((n : ℤ) + 1)) from by ring]
+        rw [natDegree_mul (by norm_num : (2 : ℝ[X]) ≠ 0) (mul_ne_zero X_ne_zero hne1)]
+        rw [natDegree_ofNat, natDegree_X_mul hne1]
+        have := natDegree_T_ofNat (n + 1); rw [cast1] at this; omega
+      have hdeg_lt : degree (T ℝ (n : ℤ)) < degree (2 * X * T ℝ ((n : ℤ) + 1)) := by
+        rw [degree_eq_natDegree hne0, degree_eq_natDegree h2XT_ne, h2XTdeg, natDegree_T_ofNat n]
+        exact_mod_cast (show n < n + 2 by omega)
+      rw [leadingCoeff_sub_of_degree_lt hdeg_lt]
+      rw [show (2 : ℝ[X]) * X * T ℝ ((n : ℤ) + 1) =
+          (2 : ℝ[X]) * (X * T ℝ ((n : ℤ) + 1)) from by ring]
+      rw [leadingCoeff_mul, leadingCoeff_mul, leadingCoeff_X, one_mul, ihn1_lc]
+      have h2_lc : (2 : ℝ[X]).leadingCoeff = 2 := by
+        have hC : (2 : ℝ[X]) = C (2 : ℝ) := (C_ofNat 2).symm
+        rw [hC, leadingCoeff_C]
+      rw [h2_lc, show n + 2 - 1 = n + 1 from by omega, pow_succ]
+      ring
 
-    This is immediate from `lagrange_basis_chebyshev_formula`. -/
-theorem chebyshev_lebesgue_eq (n : ℕ) (hn : 0 < n) (θ : ℝ)
-    (hne : ∀ k : Fin n, Real.cos θ ≠ chebyshevNode n k) :
-    chebyshevLebesgue n (Real.cos θ) =
-    |Real.cos (n * θ)| / n *
-    ∑ k : Fin n, Real.sin ((2 * k.val + 1 : ℝ) * Real.pi / (2 * n)) /
-                 |Real.cos θ - chebyshevNode n k| := by
-  sorry  -- Follows from lagrange_basis_chebyshev_formula + triangle equality
-
-/-- **[SORRY] Lebesgue function growth at rational cosines.**
-
-    For x = cos(πp/q) with p, q odd and q ≥ 1, the Chebyshev Lebesgue
-    function Λₙ(x) → ∞ as n → ∞.
-
-    Proof outline (given lagrange_basis_chebyshev_formula):
-    1. Along the subsequence n = mq:
-       |cos(nπp/q)| = |cos(mπp)| = 1 (cos_rational_pi_nonzero_along_multiples)
-    2. So Λₙ(x) = (1/n) · Σₖ sin(φₖ) / |cos(πp/q) - cos φₖ|  (chebyshev_lebesgue_eq)
-    3. Using cos A - cos B = 2 sin((A+B)/2) sin((B-A)/2):
-       |cos(πp/q) - cos φₖ| ≤ 2 · |πp/q - φₖ| (since sin t ≤ t for t ≥ 0)
-    4. The Riemann sum Σₖ sin(φₖ) / |cos(πp/q) - cos φₖ| ≥ Σₖ C/|p/q - k/n| ≥ C'·log(n)
-       (harmonic sum lower bound, avoiding the k near nπp/q term) -/
-theorem chebyshev_lebesgue_growth (p q : ℕ) (hp : Odd p) (hq : Odd q)
-    (hq_pos : 0 < q) :
-    Filter.Tendsto (fun n => chebyshevLebesgue n (Real.cos (↑p * Real.pi / ↑q)))
-      Filter.atTop Filter.atTop := by
-  sorry
-
-/-- **[SORRY] Divergence from Lebesgue growth.**
-
-    If Λₙ(x) → ∞, then ∃ continuous f with Lₙf(x) → +∞.
-
-    Proof outline:
-    1. For each n, there exists fₙ with |fₙ| ≤ 1 and Lₙ(fₙ)(x) = Λₙ(x).
-       Construction: fₙ(xₖⁿ) = sign(ℓₖⁿ(x)), extended piecewise linearly.
-       Then Lₙfₙ(x) = Σₖ sign(ℓₖⁿ(x)) · ℓₖⁿ(x) = Σₖ |ℓₖⁿ(x)| = Λₙ(x). ✓
-
-    2. Choose n₁ < n₂ < ... with Λₙₖ(x) ≥ k⁴ (possible since Λₙ → ∞).
-
-    3. Define f = Σₖ (1/k²) · fₙₖ. This converges uniformly (Σ 1/k² < ∞)
-       and f is continuous (uniform limit of continuous functions).
-
-    4. Lₙₖ(f)(x) = (1/k²) · Λₙₖ(x) + Σⱼ≠ₖ (1/j²) · Lₙₖ(fₙⱼ)(x)
-       Main term: Λₙₖ(x)/k² ≥ k²
-       Cross terms: |Lₙₖ(fₙⱼ)(x)| ≤ Λₙₖ(x) [since ‖fₙⱼ‖_∞ ≤ 1]
-       Cross sum: ≤ Λₙₖ(x) · Σⱼ≠ₖ (1/j²) ≤ Λₙₖ(x) · π²/6
-
-    Note: Step 4 has a gap — the cross terms can dominate since Λₙₖ >> Λₙₖ/k².
-    The fix requires choosing n₁ << n₂ << ... such that for j < k,
-    |Lₙₖ(fₙⱼ)(x)| << Λₙₖ(x)/k² (lacunary condition on the subsequence).
-    For Chebyshev interpolation specifically, functions supported near
-    the n₁-node grid have small interpolation values at the nₖ-node grid
-    when nₖ >> nⱼ (this requires additional analysis). -/
-theorem divergence_from_lebesgue_growth (x : ℝ)
-    (hgrowth : Filter.Tendsto (fun n => chebyshevLebesgue n x)
-               Filter.atTop Filter.atTop) :
-    ∃ f : ℝ → ℝ, Continuous f ∧
-      ∀ M : ℝ, ∃ N : ℕ, ∀ n ≥ N, M < chebyshevInterp n f x := by
-  sorry
-
-/-! ## Main Theorem (Proof Complete Modulo Sorries) -/
-
-/-- **Erdős's Result (1941) — Lebesgue function proof.**
-
-    For x = cos(πp/q) with odd p, q ≥ 1, there exists a continuous f
-    such that the Chebyshev interpolation sequence Lₙf(x) → +∞.
-
-    This theorem is a VALID MATHEMATICAL DEDUCTION: its proof is complete
-    modulo two explicitly stated sorry lemmas (see above). The logical chain is:
-
-      chebyshev_lebesgue_growth (sorry) ──┐
-                                           ├──► erdos_1941_divergence_from_growth ✓
-      divergence_from_lebesgue_growth (sorry)
-
-    Progress: We have reduced the original axiom to two well-defined subgoals. -/
-theorem erdos_1941_divergence_from_growth (p q : ℕ) (hp : Odd p) (hq : Odd q)
-    (hq_pos : 0 < q) :
-    let x := Real.cos (↑p * Real.pi / ↑q)
-    ∃ f : ℝ → ℝ, Continuous f ∧
-      ∀ M : ℝ, ∃ N : ℕ, ∀ n ≥ N, M < chebyshevInterp n f x :=
-  divergence_from_lebesgue_growth _
-    (chebyshev_lebesgue_growth p q hp hq hq_pos)
+end ChebyshevPolyProps
 
 /-! ## Auxiliary: Chebyshev Node Properties -/
 
-/-- The Chebyshev nodes are zeros of T_n.
-    Proof sketch: simp [chebyshevNode, T_real_cos] rewrites to cos(n·(2k+1)π/(2n)) = 0;
-    simplify to cos(kπ + π/2) = 0 using Real.cos_add + cos_pi_div_two + sin_int_mul_pi. -/
+/-- The Chebyshev nodes are zeros of T_n. -/
 theorem chebyshevNode_is_root (n : ℕ) (hn : 0 < n) (k : Fin n) :
     (Polynomial.Chebyshev.T ℝ (n : ℤ)).eval (chebyshevNode n k) = 0 := by
   simp only [chebyshevNode, chebyshev_T_at_cos]
@@ -271,25 +234,30 @@ theorem chebyshevNode_is_root (n : ℕ) (hn : 0 < n) (k : Fin n) :
       (2 * k.val + 1 : ℝ) * Real.pi / 2 := by
     push_cast
     have : (n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hn.ne'
-    field_simp; ring
+    field_simp
   rw [hmul]
-  -- cos((2k+1)π/2) = 0: rewrite as cos(kπ + π/2) and use cos_add
   have h : (2 * (k.val : ℝ) + 1) * Real.pi / 2 = k.val * Real.pi + Real.pi / 2 := by ring
   rw [h, Real.cos_add, Real.cos_pi_div_two, mul_zero, Real.sin_nat_mul_pi, zero_mul, sub_zero]
 
-/-- The Chebyshev nodes are distinct.
-    Proof sketch: angles (2k+1)π/(2n) ∈ (0,π) are distinct (linear in k),
-    and Real.cos_injOn_Icc gives injectivity of cos on [0,π]. -/
+/-- The Chebyshev nodes are distinct. -/
 theorem chebyshevNode_injective (n : ℕ) (hn : 0 < n) :
     Function.Injective (chebyshevNode n) := by
   intro i j heq
   simp only [chebyshevNode] at heq
   have hi : (2 * (i.val : ℝ) + 1) * Real.pi / (2 * n) ∈ Set.Icc (0 : ℝ) Real.pi :=
     ⟨le_of_lt (div_pos (mul_pos (by positivity) Real.pi_pos) (by positivity)),
-     le_of_lt (by rw [div_lt_iff (by positivity)]; nlinarith [i.isLt, Real.pi_pos])⟩
+     le_of_lt (by
+       have hlt : 2 * i.val + 1 < 2 * n := by omega
+       have hrlt : (2 * (i.val : ℝ) + 1) < 2 * n := by exact_mod_cast hlt
+       rw [div_lt_iff₀ (by positivity)]
+       nlinarith [Real.pi_pos])⟩
   have hj : (2 * (j.val : ℝ) + 1) * Real.pi / (2 * n) ∈ Set.Icc (0 : ℝ) Real.pi :=
     ⟨le_of_lt (div_pos (mul_pos (by positivity) Real.pi_pos) (by positivity)),
-     le_of_lt (by rw [div_lt_iff (by positivity)]; nlinarith [j.isLt, Real.pi_pos])⟩
+     le_of_lt (by
+       have hlt : 2 * j.val + 1 < 2 * n := by omega
+       have hrlt : (2 * (j.val : ℝ) + 1) < 2 * n := by exact_mod_cast hlt
+       rw [div_lt_iff₀ (by positivity)]
+       nlinarith [Real.pi_pos])⟩
   have hangle_eq := Real.strictAntiOn_cos.injOn hi hj heq
   apply Fin.ext
   have hn' : (n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hn.ne'
@@ -303,20 +271,584 @@ theorem chebyshevNode_mem_Icc (n : ℕ) (k : Fin n) :
     chebyshevNode n k ∈ Set.Icc (-1 : ℝ) 1 :=
   ⟨neg_one_le_cos _, cos_le_one _⟩
 
-/-- The absolute value of cosine at integer multiples of π equals 1.
-    From Mathlib: `Real.abs_cos_int_mul_pi`. -/
+/-- The absolute value of cosine at integer multiples of π equals 1. -/
 theorem abs_cos_int_pi_mul (k : ℤ) : |Real.cos (k * Real.pi)| = 1 :=
   Real.abs_cos_int_mul_pi k
 
-/-- Along n = mq, cos(nπp/q) = cos(mπp) = (-1)^(mp) ≠ 0 for odd p.
-    The proof uses cos_int_pi combined with the fact that (-1)^(mp) = ±1. -/
+/-- Along n = mq, cos(nπp/q) ≠ 0 for odd p. -/
 theorem cos_rational_pi_nonzero_along_multiples (p q m : ℕ) (hp : Odd p)
     (hq_pos : 0 < q) :
     Real.cos ((m * q : ℕ) * (↑p * Real.pi / ↑q)) ≠ 0 := by
   rw [cos_rational_pi_at_multiples p q m hq_pos]
-  -- cos(mπp) = (-1)^(mp) ≠ 0
   rw [show (↑m * ↑p * Real.pi) = (↑(m * p) : ℤ) * Real.pi by push_cast; ring]
   rw [cos_int_pi]
   exact zpow_ne_zero _ (by norm_num)
+
+/-! ## Chebyshev Product Formula and Trig Helpers (Session 5) -/
+
+section ProductFormula
+
+open Polynomial
+
+/-- sin((2k+1)π/(2n)) > 0 for k : Fin n.
+    Since (2k+1)π/(2n) ∈ (0, π). -/
+theorem chebyshevAngle_sin_pos (n : ℕ) (hn : 0 < n) (k : Fin n) :
+    0 < Real.sin ((2 * k.val + 1 : ℝ) * Real.pi / (2 * n)) := by
+  apply Real.sin_pos_of_pos_of_lt_pi
+  · positivity
+  · rw [div_lt_iff₀ (by positivity)]
+    have hlt : 2 * k.val + 1 < 2 * n := by omega
+    have : (2 * (k.val : ℝ) + 1) < 2 * n := by exact_mod_cast hlt
+    nlinarith [Real.pi_pos]
+
+/-- sin(n · φₖ) = (-1)^k where φₖ = (2k+1)π/(2n). -/
+theorem sin_n_chebyshevAngle (n : ℕ) (hn : 0 < n) (k : Fin n) :
+    Real.sin ((n : ℝ) * ((2 * k.val + 1 : ℝ) * Real.pi / (2 * n))) = (-1 : ℝ) ^ k.val := by
+  have hn_ne : (n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hn.ne'
+  have hsimp : (n : ℝ) * ((2 * k.val + 1 : ℝ) * Real.pi / (2 * n)) =
+      (k.val : ℝ) * Real.pi + Real.pi / 2 := by
+    field_simp
+  rw [hsimp, Real.sin_add, Real.sin_nat_mul_pi, Real.cos_nat_mul_pi,
+      Real.sin_pi_div_two, Real.cos_pi_div_two]
+  ring
+
+/-- **Chebyshev Product Formula**: T_n(x) = 2^{n-1} · ∏_{k=0}^{n-1}(X - C(cos φₖ)).
+
+    Proof: Let D = T_n - Q where Q = 2^{n-1} · ∏(X - C(nodes k)).
+    - D has degree < n (leading coefficients both equal 2^{n-1}, they cancel)
+    - D has n distinct roots: each chebyshevNode n k is a root
+    - card_le_degree_of_subset_roots → n ≤ natDegree D < n: contradiction → D = 0. -/
+theorem chebyshev_product_formula (n : ℕ) (hn : 0 < n) :
+    T ℝ (n : ℤ) = Polynomial.C ((2 : ℝ) ^ (n - 1)) *
+      ∏ k : Fin n, (Polynomial.X - Polynomial.C (chebyshevNode n k)) := by
+  set Q := Polynomial.C ((2 : ℝ) ^ (n - 1)) *
+      ∏ k : Fin n, (Polynomial.X - Polynomial.C (chebyshevNode n k)) with hQ_def
+  suffices h : T ℝ (n : ℤ) - Q = 0 from sub_eq_zero.mp h
+  by_contra hD
+  have h2_ne : (2 : ℝ) ^ (n - 1) ≠ 0 := pow_ne_zero _ (by norm_num)
+  have hP_monic : (∏ k : Fin n, (Polynomial.X - Polynomial.C (chebyshevNode n k) : ℝ[X])).Monic :=
+    monic_prod_X_sub_C (chebyshevNode n) Finset.univ
+  have hP_ne : ∏ k : Fin n, (Polynomial.X - Polynomial.C (chebyshevNode n k) : ℝ[X]) ≠ 0 :=
+    hP_monic.ne_zero
+  have hQ_ne : Q ≠ 0 := mul_ne_zero (Polynomial.C_ne_zero.mpr h2_ne) hP_ne
+  have hT_ne : T ℝ (n : ℤ) ≠ 0 := T_ofNat_ne_zero n
+  have hP_deg : (∏ k : Fin n, (Polynomial.X - Polynomial.C (chebyshevNode n k) : ℝ[X])).natDegree = n := by
+    rw [Polynomial.natDegree_prod Finset.univ _ (fun k _ => Polynomial.X_sub_C_ne_zero _)]
+    simp [Polynomial.natDegree_X_sub_C]
+  have hQ_natdeg : Q.natDegree = n := by
+    rw [hQ_def, Polynomial.natDegree_C_mul h2_ne, hP_deg]
+  have hQ_lc : Q.leadingCoeff = (2 : ℝ) ^ (n - 1) := by
+    rw [hQ_def, leadingCoeff_mul, Polynomial.leadingCoeff_C, hP_monic.leadingCoeff, mul_one]
+  have hT_deg : (T ℝ (n : ℤ)).degree = ↑n := by
+    rw [Polynomial.degree_eq_natDegree hT_ne, natDegree_T_ofNat]
+  have hQ_deg : Q.degree = ↑n := by
+    rw [Polynomial.degree_eq_natDegree hQ_ne, hQ_natdeg]
+  have hT_lc : (T ℝ (n : ℤ)).leadingCoeff = (2 : ℝ) ^ (n - 1) := leadingCoeff_T_ofNat n hn
+  -- degree(D) < n via leading coefficient cancellation
+  have hD_deg : (T ℝ (n : ℤ) - Q).degree < ↑n := by
+    calc (T ℝ (n : ℤ) - Q).degree
+        < (T ℝ (n : ℤ)).degree :=
+            Polynomial.degree_sub_lt (hT_deg.trans hQ_deg.symm) hT_ne (hT_lc.trans hQ_lc.symm)
+      _ = ↑n := hT_deg
+  -- natDegree(D) < n
+  have hD_natdeg : (T ℝ (n : ℤ) - Q).natDegree < n := by
+    rw [Polynomial.natDegree_lt_iff_degree_lt hD]
+    exact_mod_cast hD_deg
+  -- Each Chebyshev node is a root of D
+  have hQ_zero : ∀ k : Fin n, Q.eval (chebyshevNode n k) = 0 := fun k => by
+    rw [hQ_def, Polynomial.eval_mul, Polynomial.eval_C, Polynomial.eval_prod]
+    apply mul_eq_zero.mpr; right
+    exact Finset.prod_eq_zero (Finset.mem_univ k) (by simp)
+  have hD_roots : ∀ k : Fin n, (T ℝ (n : ℤ) - Q).eval (chebyshevNode n k) = 0 := fun k => by
+    rw [Polynomial.eval_sub, chebyshevNode_is_root n hn k, hQ_zero k, sub_self]
+  -- Finset of n distinct roots
+  let Z := Finset.image (chebyshevNode n) Finset.univ
+  have hZ_card : Z.card = n := by
+    simp [Z, Finset.card_image_of_injective _ (chebyshevNode_injective n hn)]
+  have hZ_subset : Z.val ⊆ (T ℝ (n : ℤ) - Q).roots := by
+    intro x hx
+    have hxZ : x ∈ Z := hx
+    simp only [Z, Finset.mem_image, Finset.mem_univ, true_and] at hxZ
+    obtain ⟨k, rfl⟩ := hxZ
+    rw [Polynomial.mem_roots hD]
+    exact hD_roots k
+  -- n ≤ natDegree D, contradicting natDegree D < n
+  have h_card_le : n ≤ (T ℝ (n : ℤ) - Q).natDegree := by
+    have := Polynomial.card_le_degree_of_subset_roots hZ_subset
+    rwa [hZ_card] at this
+  exact absurd hD_natdeg (not_lt.mpr h_card_le)
+
+end ProductFormula
+
+/-! ## Lagrange Basis Formula (Session 5) -/
+
+section ChebLagrangeFormula
+
+open Polynomial
+
+/-- **[Key Step] Lagrange basis explicit formula at Chebyshev nodes.**
+
+    For x = cos θ ≠ cos φₖ, the k-th Lagrange basis polynomial satisfies:
+      ℓₖⁿ(cos θ) = cos(nθ) · sin(φₖ) / (n · (cos θ - cos φₖ) · (-1)^k)
+
+    Proof via Chebyshev polynomial theory, using:
+    1. chebyshev_product_formula: T_n = C(2^{n-1}) · ∏_i (X - C(nodes i))
+    2. Split at k + T_real_cos gives: ∏_{i≠k} (cos θ - nodes i) = cos(nθ)/(2^{n-1}·(cos θ-nodes k))
+    3. T_derivative_eq_U + U_real_cos + split product at k gives:
+       ∏_{i≠k} (nodes k - nodes i) = n·(-1)^k/(2^{n-1}·sin φₖ)
+    4. Combine: lagrangeBasis = numerator/denominator = formula above -/
+theorem lagrange_basis_chebyshev_formula (n : ℕ) (hn : 0 < n) (k : Fin n) (θ : ℝ)
+    (hne : Real.cos θ ≠ chebyshevNode n k) :
+    lagrangeBasis n (chebyshevNode n) k (Real.cos θ) =
+    Real.cos (n * θ) * Real.sin ((2 * k.val + 1 : ℝ) * Real.pi / (2 * n)) /
+    (n * (Real.cos θ - chebyshevNode n k) * (-1 : ℝ)^k.val) := by
+  -- Basic nonzero facts
+  have h2_ne : (2 : ℝ) ^ (n - 1) ≠ 0 := pow_ne_zero _ (by norm_num)
+  have hn_real : (n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hn.ne'
+  have hne' : Real.cos θ - chebyshevNode n k ≠ 0 := sub_ne_zero.mpr hne
+  have hsin_ne : Real.sin ((2 * k.val + 1 : ℝ) * Real.pi / (2 * n)) ≠ 0 :=
+    (chebyshevAngle_sin_pos n hn k).ne'
+  -- Step 1: Product formula evaluation at cos θ
+  -- T_n(cos θ) = 2^{n-1} · ∏_i (cos θ - nodes i)  [from chebyshev_product_formula]
+  have hprod_eval : (2 : ℝ)^(n-1) * ∏ i : Fin n, (Real.cos θ - chebyshevNode n i) =
+      Real.cos ((n : ℝ) * θ) := by
+    have hprod := chebyshev_product_formula n hn
+    have heval := congr_arg (Polynomial.eval (Real.cos θ)) hprod
+    simp only [Polynomial.eval_mul, Polynomial.eval_C, Polynomial.eval_prod,
+               Polynomial.eval_sub, Polynomial.eval_X] at heval
+    rw [chebyshev_T_at_cos] at heval
+    push_cast at heval ⊢
+    exact heval.symm
+  -- Step 2: Split the product ∏_i (cos θ - nodes i) at index k
+  have hprod_split : ∏ i : Fin n, (Real.cos θ - chebyshevNode n i) =
+      (Real.cos θ - chebyshevNode n k) *
+      ∏ i ∈ Finset.univ.erase k, (Real.cos θ - chebyshevNode n i) := by
+    rw [← Finset.mul_prod_erase Finset.univ _ (Finset.mem_univ k)]
+  -- Step 3: Compute the numerator ∏_{i≠k} (cos θ - nodes i)
+  have hnum_eq : ∏ i ∈ Finset.univ.erase k, (Real.cos θ - chebyshevNode n i) =
+      Real.cos ((n : ℝ) * θ) / ((2 : ℝ)^(n-1) * (Real.cos θ - chebyshevNode n k)) := by
+    have := hprod_eval
+    rw [hprod_split] at this
+    have h_ne : (2 : ℝ)^(n-1) * (Real.cos θ - chebyshevNode n k) ≠ 0 :=
+      mul_ne_zero h2_ne hne'
+    field_simp [h_ne] at this ⊢
+    linarith
+  -- Step 4: Compute the denominator using T_n' = n·U_{n-1} and U_real_cos
+  -- Step 4a: T_n' = n · U_{n-1} (T_derivative_eq_U gives multiplication in R[X])
+  have hderiv_eq : Polynomial.derivative (T ℝ (n : ℤ)) = (n : ℤ) * U ℝ ((n : ℤ) - 1) :=
+    T_derivative_eq_U (n : ℤ)
+  -- Step 4b: U_{n-1}(nodes k) · sin(φₖ) = sin(n · φₖ) = (-1)^k
+  -- U_real_cos takes (θ : ℝ) (n : ℤ) in that order (variable order in Mathlib)
+  have hU_sin : (U ℝ ((n : ℤ) - 1)).eval (chebyshevNode n k) *
+      Real.sin ((2 * k.val + 1 : ℝ) * Real.pi / (2 * n)) = (-1 : ℝ)^k.val := by
+    have hU := Polynomial.Chebyshev.U_real_cos
+        ((2 * k.val + 1 : ℝ) * Real.pi / (2 * n))
+        ((n : ℤ) - 1)
+    simp only [chebyshevNode]
+    rw [hU, show (↑(↑n - 1 : ℤ) + 1 : ℝ) = (n : ℝ) from by push_cast; ring]
+    exact sin_n_chebyshevAngle n hn k
+  -- Step 4c: T_n'(nodes k) via product formula derivative
+  -- T_n = C(2^{n-1}) * (X - C(nodes k)) * ∏_{i≠k} (X - C(nodes i))
+  -- derivative at nodes k = C(2^{n-1}) * ∏_{i≠k} (nodes k - nodes i) [second term vanishes]
+  -- Also T_n'(nodes k) = n · U_{n-1}(nodes k)  [from T_derivative_eq_U]
+  -- Step 4d: eval T_n' at nodes k from product formula derivative
+  have hderiv_prod : (Polynomial.derivative (T ℝ (n : ℤ))).eval (chebyshevNode n k) =
+      (2 : ℝ)^(n-1) * ∏ i ∈ Finset.univ.erase k, (chebyshevNode n k - chebyshevNode n i) := by
+    have hT := chebyshev_product_formula n hn
+    have hP_split : ∏ i : Fin n, (Polynomial.X - Polynomial.C (chebyshevNode n i) : ℝ[X]) =
+        (Polynomial.X - Polynomial.C (chebyshevNode n k)) *
+        ∏ i ∈ Finset.univ.erase k, (Polynomial.X - Polynomial.C (chebyshevNode n i)) := by
+      rw [← Finset.mul_prod_erase Finset.univ _ (Finset.mem_univ k)]
+    rw [hT, hP_split]
+    set Q_k := ∏ i ∈ Finset.univ.erase k, (Polynomial.X - Polynomial.C (chebyshevNode n i) : ℝ[X])
+    simp only [Polynomial.derivative_mul, Polynomial.derivative_C, Polynomial.derivative_X_sub_C,
+               Polynomial.eval_mul, Polynomial.eval_C, Polynomial.eval_add, zero_mul,
+               Polynomial.eval_sub, Polynomial.eval_X, Polynomial.eval_one, zero_add]
+    simp only [sub_self, zero_mul, zero_add]
+    simp only [Q_k, Polynomial.eval_prod, Polynomial.eval_sub, Polynomial.eval_X,
+               Polynomial.eval_C]
+    ring
+  -- Step 4e: Combine to get den formula
+  have hden_eq : ∏ i ∈ Finset.univ.erase k, (chebyshevNode n k - chebyshevNode n i) =
+      (n : ℝ) * (-1 : ℝ)^k.val / ((2 : ℝ)^(n-1) * Real.sin ((2 * k.val + 1 : ℝ) * Real.pi / (2 * n))) := by
+    have hsin_ne' : Real.sin ((2 * k.val + 1 : ℝ) * Real.pi / (2 * n)) ≠ 0 := hsin_ne
+    have hT_deriv_eval : (Polynomial.derivative (T ℝ (n : ℤ))).eval (chebyshevNode n k) =
+        (n : ℝ) * (U ℝ ((n : ℤ) - 1)).eval (chebyshevNode n k) := by
+      rw [hderiv_eq, Polynomial.eval_mul, Polynomial.eval_intCast]
+      push_cast; ring
+    -- From hU_sin: U(nodes k) = (-1)^k / sin(φₖ)
+    have hU_val : (U ℝ ((n : ℤ) - 1)).eval (chebyshevNode n k) =
+        (-1 : ℝ)^k.val / Real.sin ((2 * k.val + 1 : ℝ) * Real.pi / (2 * n)) := by
+      rw [eq_div_iff hsin_ne']
+      exact hU_sin
+    rw [hT_deriv_eval] at hderiv_prod
+    rw [hU_val] at hderiv_prod
+    -- hderiv_prod : n * ((-1)^k / sin φₖ) = 2^{n-1} * ∏ i≠k (nk - ni)
+    field_simp [h2_ne, hsin_ne'] at hderiv_prod ⊢
+    linarith
+  -- Step 5: Combine numerator and denominator
+  simp only [lagrangeBasis, Finset.prod_div_distrib, hnum_eq, hden_eq]
+  have h_denom_ne : (n : ℝ) * (-1 : ℝ)^k.val /
+      ((2 : ℝ)^(n-1) * Real.sin ((2 * k.val + 1 : ℝ) * Real.pi / (2 * n))) ≠ 0 := by
+    apply div_ne_zero
+    · apply mul_ne_zero hn_real
+      exact pow_ne_zero _ (by norm_num)
+    · exact mul_ne_zero h2_ne hsin_ne
+  field_simp [h2_ne, hne', hn_real, hsin_ne,
+              pow_ne_zero _ (show (-1 : ℝ) ≠ 0 from by norm_num), h_denom_ne]
+
+end ChebLagrangeFormula
+
+/-! ## Lebesgue Function Formula (Session 5) -/
+
+/-- **[NEW] Lebesgue function explicit formula.**
+
+    For x = cos θ with cos θ ≠ any Chebyshev node:
+    Λₙ(cos θ) = |cos(nθ)| / n · Σₖ sin(φₖ) / |cos θ - cos φₖ|
+
+    Follows from lagrange_basis_chebyshev_formula by taking absolute values. -/
+theorem chebyshev_lebesgue_eq (n : ℕ) (hn : 0 < n) (θ : ℝ)
+    (hne : ∀ k : Fin n, Real.cos θ ≠ chebyshevNode n k) :
+    chebyshevLebesgue n (Real.cos θ) =
+    |Real.cos (n * θ)| / n *
+    ∑ k : Fin n, Real.sin ((2 * k.val + 1 : ℝ) * Real.pi / (2 * n)) /
+                 |Real.cos θ - chebyshevNode n k| := by
+  simp only [chebyshevLebesgue, Finset.mul_sum]
+  congr 1
+  ext k
+  rw [lagrange_basis_chebyshev_formula n hn k θ (hne k)]
+  have hsin_pos : 0 < Real.sin ((2 * k.val + 1 : ℝ) * Real.pi / (2 * n)) :=
+    chebyshevAngle_sin_pos n hn k
+  have hn_pos : (0 : ℝ) < n := Nat.cast_pos.mpr hn
+  have hne' : Real.cos θ - chebyshevNode n k ≠ 0 := sub_ne_zero.mpr (hne k)
+  -- |cos(nθ) · sin(φₖ) / (n · (cos θ - nodes k) · (-1)^k)|
+  -- = |cos(nθ)| · sin(φₖ) / (n · |cos θ - nodes k|)
+  rw [abs_div, abs_mul, abs_mul, abs_mul,
+      abs_of_pos hsin_pos, abs_of_pos hn_pos]
+  simp only [abs_pow, abs_neg, abs_one, one_pow, mul_one]
+  -- Now: |cos(nθ)|/n · sin(φₖ)/|cos θ - nodes k| = |cos(nθ)|/n · sin(φₖ)/|cos θ - nodes k|
+  field_simp
+
+/-! ## Rational Cosine Not a Node (Session 6) -/
+
+/-- **Key helper**: For odd p and odd q, cos(πp/q) is never a Chebyshev node of any degree n.
+
+    Proof: By `Real.cos_eq_cos_iff`, the equation cos(πp/q) = cos((2k+1)π/(2n)) requires
+    either (2k+1)π/(2n) = 2jπ + πp/q or (2k+1)π/(2n) = 2jπ − πp/q for some j : ℤ.
+
+    Dividing by π and multiplying by 2nq:
+    - Case 1: q(2k+1) = 4jnq + 2np. LHS is odd (product of two odd numbers q, 2k+1).
+      RHS is even. Contradiction.
+    - Case 2: q(2k+1) + 2np = 4jnq. LHS is odd + even = odd. RHS is even. Contradiction.
+
+    This allows `chebyshev_lebesgue_eq` to be applied for ALL n (not just n = mq). -/
+lemma x_not_chebyshev_node (p q : ℕ) (hp : Odd p) (hq : Odd q) (hq_pos : 0 < q)
+    (n : ℕ) (hn : 0 < n) (k : Fin n) :
+    Real.cos (↑p * Real.pi / ↑q) ≠ chebyshevNode n k := by
+  simp only [chebyshevNode]
+  intro heq
+  rw [Real.cos_eq_cos_iff] at heq
+  obtain ⟨j, hj | hj⟩ := heq
+  · -- Case 1: (2k+1)π/(2n) = 2jπ + πp/q
+    -- → q(2k+1) = 4jnq + 2np (after ×2nq/π)
+    -- LHS is odd, RHS is even → contradiction
+    have hpi : Real.pi ≠ 0 := Real.pi_ne_zero
+    have hq_ne : (q : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hq_pos.ne'
+    have hn_ne : (n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hn.ne'
+    -- Extract the angle equation (divide by π)
+    have hangle : (2 * (k.val : ℝ) + 1) / (2 * n) = 2 * j + p / q := by
+      have h := hj
+      rw [show (2 * (k.val : ℝ) + 1) * Real.pi / (2 * ↑n) =
+            Real.pi * ((2 * k.val + 1) / (2 * n)) from by ring,
+          show 2 * (j : ℝ) * Real.pi + ↑p * Real.pi / ↑q =
+            Real.pi * (2 * j + ↑p / ↑q) from by ring] at h
+      exact mul_left_cancel₀ hpi h
+    -- Multiply by 2nq to get integer equation in ℝ
+    have hR : (q : ℝ) * (2 * k.val + 1) = 4 * j * n * q + 2 * n * p := by
+      have h := congr_arg (· * (2 * (n : ℝ) * ↑q)) hangle
+      field_simp [hn_ne, hq_ne] at h ⊢
+      linarith
+    -- Cast to ℤ
+    have hint : (q : ℤ) * (2 * ↑k.val + 1) = 4 * j * ↑n * ↑q + 2 * ↑n * ↑p := by
+      exact_mod_cast hR
+    -- LHS q*(2k+1) is odd (product of two odd numbers)
+    have hodd : Odd ((q : ℤ) * (2 * ↑k.val + 1)) :=
+      (by exact_mod_cast hq : Odd (q : ℤ)).mul ⟨↑k.val, by ring⟩
+    -- RHS 4jnq + 2np is even (= 2*(2jnq + np))
+    have heven : Even (4 * j * (↑n : ℤ) * ↑q + 2 * ↑n * ↑p) :=
+      ⟨2 * j * ↑n * ↑q + ↑n * ↑p, by ring⟩
+    -- hint rewrites hodd: Odd (4jnq + 2np), contradicting heven
+    obtain ⟨r, hr⟩ := heven
+    obtain ⟨s, hs⟩ := hint ▸ hodd
+    omega
+  · -- Case 2: (2k+1)π/(2n) = 2jπ - πp/q
+    -- → q(2k+1) + 2np = 4jnq (after ×2nq/π)
+    -- LHS is odd + even = odd, RHS is even → contradiction
+    have hpi : Real.pi ≠ 0 := Real.pi_ne_zero
+    have hq_ne : (q : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hq_pos.ne'
+    have hn_ne : (n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hn.ne'
+    have hangle : (2 * (k.val : ℝ) + 1) / (2 * n) = 2 * j - p / q := by
+      have h := hj
+      rw [show (2 * (k.val : ℝ) + 1) * Real.pi / (2 * ↑n) =
+            Real.pi * ((2 * k.val + 1) / (2 * n)) from by ring,
+          show 2 * (j : ℝ) * Real.pi - ↑p * Real.pi / ↑q =
+            Real.pi * (2 * j - ↑p / ↑q) from by ring] at h
+      exact mul_left_cancel₀ hpi h
+    have hR : (q : ℝ) * (2 * k.val + 1) + 2 * n * p = 4 * j * n * q := by
+      have h := congr_arg (· * (2 * (n : ℝ) * ↑q)) hangle
+      field_simp [hn_ne, hq_ne] at h ⊢
+      linarith
+    have hint : (q : ℤ) * (2 * ↑k.val + 1) + 2 * ↑n * ↑p = 4 * j * ↑n * ↑q := by
+      exact_mod_cast hR
+    -- LHS: q*(2k+1) is odd (odd × odd), 2np is even → sum is odd
+    have hodd_sum : Odd ((q : ℤ) * (2 * ↑k.val + 1) + 2 * ↑n * ↑p) := by
+      apply Odd.add_even
+      · exact (by exact_mod_cast hq : Odd (q : ℤ)).mul ⟨↑k.val, by ring⟩
+      · exact ⟨↑n * ↑p, by ring⟩
+    -- RHS 4jnq is even
+    have heven_rhs : Even (4 * j * (↑n : ℤ) * ↑q) := ⟨2 * j * ↑n * ↑q, by ring⟩
+    obtain ⟨r, hr⟩ := heven_rhs
+    obtain ⟨s, hs⟩ := hint ▸ hodd_sum
+    omega
+
+set_option maxHeartbeats 800000 in
+/-- The Lebesgue formula applies for ALL n when p, q are odd (not just along n = mq
+    multiples), since cos(πp/q) is never a Chebyshev node. -/
+lemma chebyshev_lebesgue_eq_all_n (p q : ℕ) (hp : Odd p) (hq : Odd q)
+    (hq_pos : 0 < q) (n : ℕ) (hn : 0 < n) :
+    chebyshevLebesgue n (Real.cos (↑p * Real.pi / ↑q)) =
+    |Real.cos (↑n * (↑p * Real.pi / ↑q))| / ↑n *
+    ∑ k : Fin n, Real.sin ((2 * k.val + 1 : ℝ) * Real.pi / (2 * n)) /
+                 |Real.cos (↑p * Real.pi / ↑q) - chebyshevNode n k| := by
+  -- Direct proof mirroring chebyshev_lebesgue_eq, specialised to θ = ↑p * π / ↑q.
+  -- Avoids the expensive isDefEq triggered by applying chebyshev_lebesgue_eq.
+  -- push_cast normalizes implicit n-coercions from lagrange_basis_chebyshev_formula
+  -- against the explicit ↑n coercions in the annotation.
+  set θ := (↑p : ℝ) * Real.pi / ↑q with hθ
+  simp only [chebyshevLebesgue, Finset.mul_sum]
+  congr 1
+  ext k
+  have hne : Real.cos θ ≠ chebyshevNode n k :=
+    x_not_chebyshev_node p q hp hq hq_pos n hn k
+  rw [lagrange_basis_chebyshev_formula n hn k θ hne]
+  have hsin_pos : 0 < Real.sin ((2 * k.val + 1 : ℝ) * Real.pi / (2 * n)) :=
+    chebyshevAngle_sin_pos n hn k
+  have hn_pos : (0 : ℝ) < n := Nat.cast_pos.mpr hn
+  have hne' : Real.cos θ - chebyshevNode n k ≠ 0 := sub_ne_zero.mpr hne
+  rw [abs_div, abs_mul, abs_mul, abs_mul,
+      abs_of_pos hsin_pos, abs_of_pos hn_pos]
+  simp only [abs_pow, abs_neg, abs_one, one_pow, mul_one]
+  push_cast
+  field_simp
+
+/-! ## Session 7: Cosine Nonvanishing at ALL n for Rational Multiples of π -/
+
+/-- **cos(nπp/q) ≠ 0 for ALL n ∈ ℕ** when p and q are both odd.
+
+    This uses a parity argument: if cos(nπp/q) = 0 then (2*k+1)*π/2 = n*p*π/q
+    for some k : ℤ, giving 2*n*p = (2k+1)*q. But 2np is even and (2k+1)*q is
+    odd*odd = odd (since q odd), a contradiction.
+
+    This strengthens `cos_rational_pi_nonzero_along_multiples` which only covers
+    the subsequence n = mq. Used in `cos_rational_pi_pos_min` to obtain a
+    uniform lower bound δ > 0 over all n. -/
+lemma cos_rational_pi_ne_zero (p q n : ℕ) (hp : Odd p) (hq : Odd q) (hq_pos : 0 < q) :
+    Real.cos ((n : ℝ) * (↑p * Real.pi / ↑q)) ≠ 0 := by
+  intro h
+  rw [Real.cos_eq_zero_iff] at h
+  obtain ⟨k, heq⟩ := h
+  have hpi : Real.pi ≠ 0 := Real.pi_ne_zero
+  have hq_ne : (q : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hq_pos.ne'
+  -- Derive: (n : ℝ) * p / q = (2k+1)/2
+  have hangle : (n : ℝ) * ↑p / ↑q = (2 * (k : ℝ) + 1) / 2 := by
+    have heq' := heq
+    rw [show (↑n : ℝ) * (↑p * Real.pi / ↑q) = Real.pi * ((↑n * ↑p) / ↑q) from by ring,
+        show (2 * (↑k : ℝ) + 1) * Real.pi / 2 = Real.pi * ((2 * ↑k + 1) / 2) from by ring] at heq'
+    exact mul_left_cancel₀ hpi heq'
+  -- Cross-multiply: 2np = (2k+1)q  (over ℝ, then cast to ℤ)
+  have hR : 2 * (n : ℝ) * (p : ℝ) = (2 * (k : ℝ) + 1) * (q : ℝ) := by
+    have h' := hangle
+    field_simp [hq_ne] at h'
+    linarith
+  have hint : 2 * (n : ℤ) * (p : ℤ) = (2 * k + 1) * (q : ℤ) := by exact_mod_cast hR
+  -- Parity contradiction: LHS even, RHS = odd * odd = odd (since q odd)
+  obtain ⟨qm, hqm⟩ := hq
+  have hq_int : (q : ℤ) = 2 * ↑qm + 1 := by exact_mod_cast hqm
+  have hint2 : 2 * (n : ℤ) * ↑p = (2 * k + 1) * (2 * ↑qm + 1) := by
+    rw [← hq_int]; exact hint
+  have heven : Even (2 * (n : ℤ) * ↑p) := ⟨↑n * ↑p, by ring⟩
+  have hodd : Odd ((2 * k + 1) * (2 * ↑qm + 1) : ℤ) :=
+    ⟨2 * k * ↑qm + k + ↑qm, by ring⟩
+  rw [hint2] at heven
+  obtain ⟨r, hr⟩ := heven
+  obtain ⟨s, hs⟩ := hodd
+  omega
+
+set_option maxHeartbeats 800000 in
+/-- **cos(nπp/q) has period 2q in n**: cos(nπp/q) = cos((n mod 2q)·πp/q).
+
+    This follows because cos(nπp/q) = cos((n mod 2q)·πp/q + (n/2q)·p · 2π),
+    and cos is 2π-periodic. -/
+lemma cos_rational_pi_mod (p q n : ℕ) (hq_pos : 0 < q) :
+    Real.cos ((n : ℝ) * (↑p * Real.pi / ↑q)) =
+    Real.cos ((↑(n % (2 * q)) : ℝ) * (↑p * Real.pi / ↑q)) := by
+  have hq_ne : (q : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hq_pos.ne'
+  -- ℕ floor division: n = n%(2q) + n/(2q) * (2q)
+  have hdiv : n = n % (2 * q) + n / (2 * q) * (2 * q) := by
+    have h := Nat.mod_add_div n (2 * q)
+    linarith [Nat.mul_comm (2 * q) (n / (2 * q))]
+  -- The shift (n/(2q)*p * 2π) can be absorbed via cos periodicity
+  have hshift : (↑(n / (2 * q) * (2 * q) : ℕ) : ℝ) * (↑p * Real.pi / ↑q) =
+                (↑(n / (2 * q) * p : ℕ) : ℝ) * (2 * Real.pi) := by
+    have lhs_eq : (↑(n / (2 * q) * (2 * q) : ℕ) : ℝ) = ↑(n / (2 * q)) * (2 * ↑q) := by
+      push_cast; ring
+    have rhs_eq : (↑(n / (2 * q) * p : ℕ) : ℝ) = ↑(n / (2 * q)) * ↑p := Nat.cast_mul _ _
+    rw [lhs_eq, rhs_eq]
+    field_simp [hq_ne]
+  -- Rewrite n as sum, then apply cos_add_nat_mul_two_pi
+  have hn_cast : (n : ℝ) = ↑(n % (2 * q)) + ↑(n / (2 * q) * (2 * q)) := by exact_mod_cast hdiv
+  rw [hn_cast, add_mul, hshift]
+  exact Real.cos_add_nat_mul_two_pi
+    (↑(n % (2 * q)) * (↑p * Real.pi / ↑q)) (n / (2 * q) * p)
+
+set_option maxHeartbeats 4000000 in
+/-- **Uniform lower bound**: ∃ δ > 0 such that |cos(nπp/q)| ≥ δ for ALL n ∈ ℕ.
+
+    Proof: since cos(nπp/q) is periodic with period 2q in n (by `cos_rational_pi_mod`)
+    and nonzero everywhere (by `cos_rational_pi_ne_zero`), the minimum over one
+    full period is positive. -/
+lemma cos_rational_pi_pos_min (p q : ℕ) (hp : Odd p) (hq : Odd q) (hq_pos : 0 < q) :
+    ∃ δ : ℝ, 0 < δ ∧ ∀ n : ℕ, δ ≤ |Real.cos ((n : ℝ) * (↑p * Real.pi / ↑q))| := by
+  have h2q_pos : 0 < 2 * q := by omega
+  -- Take the minimum of |cos(kπp/q)| over k = 0,...,2q-1
+  let vals := Finset.image
+    (fun k : Fin (2 * q) => |Real.cos ((k.val : ℝ) * (↑p * Real.pi / ↑q))|)
+    Finset.univ
+  have hvals_nonempty : vals.Nonempty :=
+    ⟨|Real.cos (0 * (↑p * Real.pi / ↑q))|,
+     Finset.mem_image.mpr ⟨⟨0, h2q_pos⟩, Finset.mem_univ _, by simp⟩⟩
+  refine ⟨vals.min' hvals_nonempty, ?_, fun n => ?_⟩
+  · -- min is positive since all values are positive
+    have hall : ∀ x ∈ vals, (0 : ℝ) < x := fun x hx => by
+      simp only [vals, Finset.mem_image, Finset.mem_univ, true_and] at hx
+      obtain ⟨k, rfl⟩ := hx
+      exact abs_pos.mpr (cos_rational_pi_ne_zero p q k.val hp hq hq_pos)
+    exact hall _ (Finset.min'_mem vals hvals_nonempty)
+  · -- |cos(nπp/q)| = |cos((n%2q)πp/q)| ≥ min
+    rw [cos_rational_pi_mod p q n hq_pos]
+    apply Finset.min'_le
+    exact Finset.mem_image.mpr
+      ⟨⟨n % (2 * q), Nat.mod_lt _ h2q_pos⟩, Finset.mem_univ _, rfl⟩
+
+/-! ## Key Lemmas with Sorry -/
+
+/-- **[SORRY] Harmonic sum lower bound for Chebyshev trig sum.**
+
+    For x = cos(πp/q) with p, q odd, the trigonometric Lebesgue sum
+    S_n = Σₖ sin(φₖ)/|x - cos φₖ| grows at least as fast as n · log(n+1).
+
+    Strategy: for θ = πp/q, let k₀ be the node index nearest θ. Node spacing is π/n,
+    and |cos θ - cos φₖ₀₊ⱼ| ≤ |θ - φₖ₀₊ⱼ| ≤ 2jπ/n by Lipschitz + geometry.
+    With sin(φₖ) ≥ sin(θ)/2 for nodes near k₀, summing j = 1..n/2 gives:
+      S_n ≥ Σⱼ sin(θ)/(2jπ/n) = (n·sin(θ)/2π) · Hₙ/₂ ≥ (n·sin(θ)/2π) · log(n/2+1)
+    by `log_add_one_le_harmonic`. -/
+private lemma chebyshev_trig_sum_lb (p q : ℕ) (hp : Odd p) (hq : Odd q) (hq_pos : 0 < q) :
+    ∃ C₂ : ℝ, 0 < C₂ ∧ ∀ n : ℕ, 1 ≤ n →
+      C₂ * ((↑n : ℝ) * Real.log ((↑n : ℝ) + 1)) ≤
+        ∑ k : Fin n, Real.sin ((2 * k.val + 1 : ℝ) * Real.pi / (2 * n)) /
+                     |Real.cos ((↑p : ℝ) * Real.pi / ↑q) - chebyshevNode n k| := by
+  sorry  -- S_n ≥ C₂ · n · log(n+1) via Lipschitz bound + harmonic series
+
+/-- **Logarithmic lower bound on the Lebesgue function** (proved modulo `chebyshev_trig_sum_lb`).
+
+    For x = cos(πp/q) with p, q odd, there exists C > 0 such that for all n ≥ 1:
+      Λₙ(x) ≥ C · log(n + 1)
+
+    Proof: Take C = δ · C₂ where:
+    - δ > 0 from `cos_rational_pi_pos_min`: |cos(nπp/q)| ≥ δ uniformly in n
+    - C₂ > 0 from `chebyshev_trig_sum_lb`: C₂ · n · log(n+1) ≤ S_n
+
+    Then Λₙ = |cos(nθ)|/n · S_n ≥ (δ/n) · C₂ · n · log(n+1) = δ · C₂ · log(n+1). -/
+private lemma chebyshev_lebesgue_lb (p q : ℕ) (hp : Odd p) (hq : Odd q) (hq_pos : 0 < q) :
+    ∃ C : ℝ, 0 < C ∧ ∀ n : ℕ, 1 ≤ n →
+      C * Real.log ((↑n : ℝ) + 1) ≤ chebyshevLebesgue n (Real.cos (↑p * Real.pi / ↑q)) := by
+  -- Step 1: Uniform lower bound δ on |cos(nπp/q)| for all n
+  obtain ⟨δ, hδ_pos, hδ_lb⟩ := cos_rational_pi_pos_min p q hp hq hq_pos
+  -- Step 2: Harmonic sum lower bound C₂ · n · log(n+1) ≤ S_n
+  obtain ⟨C₂, hC₂_pos, hC₂_lb⟩ := chebyshev_trig_sum_lb p q hp hq hq_pos
+  -- Step 3: Take C = δ · C₂; show C · log(n+1) ≤ Λₙ(x) for all n ≥ 1
+  refine ⟨δ * C₂, mul_pos hδ_pos hC₂_pos, fun n hn => ?_⟩
+  have hn_pos : (0 : ℝ) < (↑n : ℝ) := Nat.cast_pos.mpr hn
+  have hlog_nn : 0 ≤ Real.log ((↑n : ℝ) + 1) := Real.log_nonneg (by linarith)
+  have hcos_lb : δ ≤ |Real.cos ((↑n : ℝ) * (↑p * Real.pi / ↑q))| := hδ_lb n
+  have hS_lb : C₂ * ((↑n : ℝ) * Real.log ((↑n : ℝ) + 1)) ≤
+      ∑ k : Fin n, Real.sin ((2 * k.val + 1 : ℝ) * Real.pi / (2 * n)) /
+                   |Real.cos ((↑p : ℝ) * Real.pi / ↑q) - chebyshevNode n k| :=
+    hC₂_lb n hn
+  -- Step 4: Apply Lebesgue formula Λₙ = |cos(nθ)|/n · S_n
+  rw [chebyshev_lebesgue_eq_all_n p q hp hq hq_pos n hn]
+  -- Step 5: δ · C₂ · log(n+1) = (δ/n) · (C₂ · n · log(n+1)) ≤ (|cos(nθ)|/n) · S_n
+  calc δ * C₂ * Real.log ((↑n : ℝ) + 1)
+      = δ / (↑n : ℝ) * (C₂ * ((↑n : ℝ) * Real.log ((↑n : ℝ) + 1))) := by
+          field_simp; ring
+    _ ≤ |Real.cos ((↑n : ℝ) * (↑p * Real.pi / ↑q))| / (↑n : ℝ) *
+        ∑ k : Fin n, Real.sin ((2 * k.val + 1 : ℝ) * Real.pi / (2 * n)) /
+                     |Real.cos ((↑p : ℝ) * Real.pi / ↑q) - chebyshevNode n k| :=
+        mul_le_mul
+          ((div_le_div_right hn_pos).mpr hcos_lb)
+          hS_lb
+          (mul_nonneg hC₂_pos.le (mul_nonneg hn_pos.le hlog_nn))
+          (div_nonneg (abs_nonneg _) hn_pos.le)
+
+/-- **Lebesgue function growth at rational cosines** (proved modulo `chebyshev_lebesgue_lb`).
+
+    For x = cos(πp/q) with p, q odd, the Chebyshev Lebesgue function Λₙ(x) → ∞ as n → ∞.
+    The proof applies `tendsto_atTop_mono` with the logarithmic lower bound `chebyshev_lebesgue_lb`,
+    combined with the fact that C · log(n+1) → ∞ (from `tendsto_log_atTop`). -/
+theorem chebyshev_lebesgue_growth (p q : ℕ) (hp : Odd p) (hq : Odd q)
+    (hq_pos : 0 < q) :
+    Filter.Tendsto (fun n => chebyshevLebesgue n (Real.cos (↑p * Real.pi / ↑q)))
+      Filter.atTop Filter.atTop := by
+  -- Extract: ∃ C > 0, ∀ n ≥ 1, C · log(n+1) ≤ Λₙ(x)
+  obtain ⟨C, hC_pos, hC_lb⟩ := chebyshev_lebesgue_lb p q hp hq hq_pos
+  -- The lower bound C · log(n+1) tends to +∞
+  have hlb_atTop : Filter.Tendsto (fun n : ℕ => C * Real.log ((↑n : ℝ) + 1))
+      Filter.atTop Filter.atTop :=
+    (tendsto_log_atTop.comp
+      (Filter.Tendsto.atTop_add tendsto_natCast_atTop_atTop tendsto_const_nhds)).const_mul_atTop hC_pos
+  -- Since Λₙ(x) ≥ C·log(n+1) and C·log(n+1) → ∞, we have Λₙ(x) → ∞
+  apply Filter.tendsto_atTop_mono (f := fun n : ℕ => C * Real.log ((↑n : ℝ) + 1)) _ hlb_atTop
+  intro n
+  rcases Nat.eq_zero_or_pos n with rfl | hn
+  · -- n = 0: Λ₀ = 0 (empty sum) and C · log(0+1) = C · log(1) = 0
+    simp [chebyshevLebesgue, Real.log_one]
+  · -- n ≥ 1: apply the analytic lower bound
+    exact hC_lb n hn
+
+/-- **[SORRY] Divergence from Lebesgue growth.**
+
+    If Λₙ(x) → ∞, then ∃ continuous f with Lₙf(x) → +∞.
+
+    Proof sketch has gap in cross-term estimate; lacunary series construction needed. -/
+theorem divergence_from_lebesgue_growth (x : ℝ)
+    (hgrowth : Filter.Tendsto (fun n => chebyshevLebesgue n x)
+               Filter.atTop Filter.atTop) :
+    ∃ f : ℝ → ℝ, Continuous f ∧
+      ∀ M : ℝ, ∃ N : ℕ, ∀ n ≥ N, M < chebyshevInterp n f x := by
+  sorry
+
+/-! ## Main Theorem (Proof Complete Modulo Sorries) -/
+
+/-- **Erdős's Result (1941) — Lebesgue function proof.**
+
+    For x = cos(πp/q) with odd p, q ≥ 1, there exists a continuous f
+    such that the Chebyshev interpolation sequence Lₙf(x) → +∞. -/
+theorem erdos_1941_divergence_from_growth (p q : ℕ) (hp : Odd p) (hq : Odd q)
+    (hq_pos : 0 < q) :
+    let x := Real.cos (↑p * Real.pi / ↑q)
+    ∃ f : ℝ → ℝ, Continuous f ∧
+      ∀ M : ℝ, ∃ N : ℕ, ∀ n ≥ N, M < chebyshevInterp n f x :=
+  divergence_from_lebesgue_growth _
+    (chebyshev_lebesgue_growth p q hp hq hq_pos)
 
 end Erdos1151OQ04

--- a/proofs/Proofs/Erdos512Aristotle.lean
+++ b/proofs/Proofs/Erdos512Aristotle.lean
@@ -38,7 +38,12 @@ Uses: Complex.continuous_abs, Continuous.comp, continuous_finset_sum,
       Complex.continuous_exp, Continuous.mul_const, continuous_ofReal
 -/
 theorem expSumNorm_continuous (A : Finset ℤ) : Continuous (expSumNorm A) := by
-  sorry
+  unfold expSumNorm expSum expTwoPiI
+  apply Complex.continuous_abs.comp
+  apply continuous_finset_sum
+  intro n _
+  apply Complex.continuous_exp.comp
+  fun_prop
 
 /-
 TARGET 2 (depends on Target 1)
@@ -54,6 +59,19 @@ Strategy:
 -/
 theorem L1norm_le_card (A : Finset ℤ) :
     ∫ θ in Set.Icc (0 : ℝ) 1, expSumNorm A θ ≤ A.card := by
-  sorry
+  have hint : IntegrableOn (expSumNorm A) (Set.Icc 0 1) :=
+    (expSumNorm_continuous A).continuousOn.integrableOn_compact isCompact_Icc
+  have hcint : IntegrableOn (fun _ : ℝ => (A.card : ℝ)) (Set.Icc 0 1) :=
+    integrableOn_const.mpr (Or.inr (by simp [Real.volume_Icc]))
+  have hbdd : ∀ θ ∈ Set.Icc (0:ℝ) 1, expSumNorm A θ ≤ (A.card : ℝ) :=
+    fun θ _ => expSum_bound A θ
+  have h1 : ∫ θ in Set.Icc 0 1, expSumNorm A θ ≤ ∫ θ in Set.Icc 0 1, (A.card : ℝ) :=
+    setIntegral_mono_on hint hcint measurableSet_Icc hbdd
+  have h2 : ∫ θ in Set.Icc (0:ℝ) 1, (A.card : ℝ) = A.card := by
+    rw [set_integral_const, smul_eq_mul]
+    have hv : (volume (Set.Icc (0:ℝ) 1)).toReal = 1 := by
+      rw [Real.volume_Icc]; simp [ENNReal.toReal_ofReal]
+    linarith [hv]
+  linarith
 
 end Erdos512Aristotle

--- a/research/problems/erdos-1151-oq-04/knowledge.md
+++ b/research/problems/erdos-1151-oq-04/knowledge.md
@@ -146,13 +146,40 @@ Therefore T_n = Q_n.
 - `chebyshevNode_is_root`: simp [chebyshev_T_at_cos], arithmetic cast manipulation, cos_odd_half_pi
 - `chebyshevNode_injective`: strictAntiOn_cos.injOn on angles in (0,π)
 
+## Session 2026-04-23 — Results (Session 8)
+
+**Outcome**: progress
+**Sorries closed**: 0 (same count — 2 sorries, but proof structure significantly improved)
+**New proofs added**:
+- `chebyshev_lebesgue_lb`: now PROVED (modulo `chebyshev_trig_sum_lb` sorry)
+  - Extracts δ from `cos_rational_pi_pos_min` and C₂ from `chebyshev_trig_sum_lb`
+  - Takes C = δ·C₂ and shows Λₙ ≥ C·log(n+1) via `mul_le_mul` chain
+  - Key calc: δ·C₂·log(n+1) = (δ/n)·(C₂·n·log(n+1)) ≤ (|cos(nθ)|/n)·S_n = Λₙ
+- `chebyshev_trig_sum_lb` (new isolated sorry): S_n ≥ C₂·n·log(n+1)
+  - Replaces the undifferentiated sorry in `chebyshev_lebesgue_lb`
+  - Docstring explains strategy: Lipschitz |cos θ - cos φₖ| ≤ |θ - φₖ| + node spacing π/n
+
+**Recovery work (session start)**:
+- Restored 818-line (2-sorry) file from commit `eddbbdca9b` after squash-merge regression
+- Root cause: ballot-problem enrichment PR #11991 was squash-merged from a branch predating PRs #11829/#11873/#11947
+
+**Sorry analysis**:
+1. `chebyshev_trig_sum_lb` — harmonic sum lower bound S_n ≥ C₂·n·log(n+1)
+   - Strategy: nodes k₀+j at distance ≈ jπ/n from θ = πp/q
+   - |cos θ - cos φₖ| ≤ |θ - φₖ| ≤ 2jπ/n (Lipschitz + node spacing)
+   - sin(φₖ) ≥ C·sin(θ) near k₀ → each term ≥ C·sin(θ)·n/(2jπ)
+   - Summing j = 1..n/2: S_n ≥ C·n·sin(θ)/2π · H_{n/2} ≥ C·n·log(n+1)/2
+   - Mathlib: `log_add_one_le_harmonic` (H_n ≥ log(n+1)) available
+   - Challenge: θ = πp/q might have sin(θ) close to 0 for large p/q; needs careful bounds
+2. `divergence_from_lebesgue_growth` — full-sequence divergence from Λₙ → ∞
+   - Fundamental gap: Banach-Steinhaus only gives lim sup |Lₙf(x)| = ∞, not lim = +∞
+   - May need to weaken the axiom statement or find an explicit specialized construction
+
 ## Next Steps
 
-1. **chebyshev_lebesgue_growth**: Prove the sum S(n) = Σₖ sin(φₖ)/|cos(πp/q) - cos φₖ| ≥ C·n·log(n).
-   - Strategy: nodes near angle πp/q contribute ≈ n/π · Σ 1/j (harmonic series)
-   - `Real.tendsto_sum_range_one_div_nat_succ_atTop` from Mathlib (harmonic divergence) is available
-   - chebyshev_lebesgue_eq_all_n (new from Session 6) now applies for ALL n, not just n = mq
-   - For the |cos(nπp/q)| factor: nonzero when q is odd (parity argument used in x_not_chebyshev_node)
+1. **chebyshev_trig_sum_lb**: Prove S_n ≥ C₂·n·log(n+1) using Lipschitz bound + harmonic series.
+   - Need: lower bound on sin(φₖ) near θ, upper bound on |cos θ - cos φₖ|
+   - Mathlib tools: `Real.sin_pos_of_pos_of_lt_pi`, `Real.abs_cos_sub_cos_le`, `log_add_one_le_harmonic`
    
 2. **divergence_from_lebesgue_growth**: Consider weakening the theorem.
    - Banach-Steinhaus gives lim sup = ∞ (NOT lim = +∞ as currently stated)

--- a/research/problems/erdos-512-incomplete-01/knowledge.md
+++ b/research/problems/erdos-512-incomplete-01/knowledge.md
@@ -2,78 +2,62 @@
 
 ## Problem Summary
 
-**Goal**: Fill measure theory sorries in `Erdos512Problem.lean` (Littlewood conjecture formalization).
+**Goal**: Fill 2 sorry gaps in the Erdős #512 Aristotle companion file.
 
-**File**: `proofs/Proofs/Erdos512Problem.lean`
+**Current state**:
+- `Erdos512Problem.lean`: 1 sorry — `L2_norm` (Parseval's theorem, line 194)
+- `Erdos512Aristotle.lean`: 2 sorries — `expSumNorm_continuous` and `L1norm_le_card`
 
-## Status: 1 sorry remaining (L2_norm / Parseval)
+**Note**: The Aristotle file header is outdated — `L1norm_upper_bound` in the main file is
+already proved (no sorry). Only `L2_norm` remains there.
 
-### Sorries
-1. `L1norm_upper_bound` (line 102): `∫₀¹ |∑_{n∈A} e(nθ)| dθ ≤ |A|` — **PROVED**
-2. `L2_norm` (line 194): `∫₀¹ |∑_{n∈A} e(nθ)|² dθ = |A|` — **OPEN** (Parseval's theorem)
+## Architecture
 
-## Proof Architecture
+```
+expSumNorm A θ = Complex.abs (expSum A θ)
+expSum A θ = A.sum (fun n => expTwoPiI (n * θ))
+expTwoPiI x = Complex.exp (2 * π * x * I)
+```
 
-### L1norm_upper_bound (PROVED)
+Already proved (no sorry):
+- `expSum_bound`: |expSum A θ| ≤ A.card (triangle + |e^{2πiθ}|=1)
+- `L1norm_upper_bound`: ∫₀¹ |expSum| dθ ≤ A.card (continuity + monotone integral)
+- All periodic properties, norm facts, etc.
 
-Strategy:
-1. **Continuity**: `expSumNorm A` is continuous (finite sum of continuous exponentials + Complex.abs). Proved via `Complex.continuous_abs.comp + continuous_finset_sum + Complex.continuous_exp.comp + fun_prop`.
-2. **Integrability**: `ContinuousOn.integrableOn_compact isCompact_Icc`
-3. **Constant integrability**: `integrableOn_const.mpr (Or.inr (by simp [Real.volume_Icc]))`
-4. **Monotone integral**: `setIntegral_mono_on hint hcint measurableSet_Icc hbdd`
-5. **Constant integral = A.card**: `set_integral_const + smul_eq_mul + Real.volume_Icc + ENNReal.toReal_ofReal`
+## Session 2026-04-23 — Results (Session 1)
 
-### L2_norm (OPEN — Parseval's theorem)
+**Outcome**: progress
+**Sorries closed**: 2 (`expSumNorm_continuous`, `L1norm_le_card` in Aristotle file)
 
-Mathematical proof:
-1. `|∑_{n∈A} e(nθ)|² = ∑_{m,n∈A×A} e((m-n)θ)` via `Complex.normSq`
-2. Interchange sum and integral (Fubini for finite sums)
-3. `∫₀¹ e(kθ) dθ = δ_{k,0}`: 
-   - k=0: trivial
-   - k≠0: antiderivative = `exp(2πikθ)/(2πik)`, value = `(exp(2πik)-1)/(2πik) = 0`
-4. `∑_{m,n∈A} δ_{m=n} = |A|`
+**Key proofs**:
+- `expSumNorm_continuous`: standard tactic chain — `Complex.continuous_abs.comp` →
+  `continuous_finset_sum` → `Complex.continuous_exp.comp` → `fun_prop`
+- `L1norm_le_card`: continuity → `integrableOn_compact` → `setIntegral_mono_on` →
+  `set_integral_const` with `Real.volume_Icc`
+  Both proofs mirror the inline proof in `L1norm_upper_bound` (main file lines 105-131).
 
-**Estimated complexity**: 80-120 lines of Lean
+**Remaining**:
+- `L2_norm` (Parseval): `∫₀¹ |∑_{n∈A} e(nθ)|² dθ = |A|`
+  Strategy: expand via double sum + character orthogonality `∫₀¹ e^{2πikθ} dθ = [k=0]`
+  This requires more Fourier analysis infrastructure in Mathlib.
 
-## Key Mathlib APIs
+## Mathlib API Notes
 
-| API | Purpose |
-|-----|---------|
-| `Complex.continuous_abs` | Continuity of complex norm |
-| `continuous_finset_sum` | Finite sum of continuous functions |
-| `ContinuousOn.integrableOn_compact` | Compact set + continuousOn = integrable |
-| `setIntegral_mono_on` | Monotone set integral bounds |
-| `set_integral_const` | Constant integral: `∫ c = (μ s).toReal • c` |
-| `Real.volume_Icc` | Lebesgue measure of [a,b] = ofReal(b-a) |
-| `ENNReal.toReal_ofReal` | `(ofReal r).toReal = r` for r ≥ 0 |
+- `Complex.continuous_abs.comp` — continuity of complex abs composed with continuous fn
+- `continuous_finset_sum` — finite sum of continuous functions is continuous
+- `Complex.continuous_exp.comp` — continuity of complex exponential
+- `fun_prop` — closes arithmetic continuity goals (e.g., `2 * π * ↑n * θ * I` continuous in θ)
+- `ContinuousOn.integrableOn_compact` — integrable on compact interval from continuity
+- `integrableOn_const.mpr (Or.inr ...)` — constant is integrable when finite measure
+- `setIntegral_mono_on` — monotone integral bound
+- `set_integral_const` — integral of constant = constant * volume
+- `Real.volume_Icc` — volume of [a,b] = ENNReal.ofReal (b-a)
+- `ENNReal.toReal_ofReal` — converts back to ℝ
 
-## Session 2026-04-23 (Session 1) — L1norm_upper_bound Proved
+## Next Steps
 
-**Mode**: FRESH
-**Outcome**: PROGRESS — SORRY 1 eliminated; 1 sorry remains (L2_norm)
-
-### What I Did
-
-1. Read the existing proof file (240 lines, 2 sorries)
-2. Identified that `L1norm_upper_bound` was tractable via continuity + monotone integration
-3. Applied the proof (already present in main repo from Aristotle integration `d6783713f0`)
-4. Applied same proof to the worktree's feature branch
-
-### Key Findings
-
-**fun_prop** handles the continuity of `fun θ : ℝ => Complex.exp (2 * π * ↑n * θ * I)` (linear in θ, standard composition).
-
-**setIntegral_mono_on** signature: `IntegrableOn f s → IntegrableOn g s → MeasurableSet s → (∀ x ∈ s, f x ≤ g x) → ∫ f ≤ ∫ g`
-
-**Constant integral**: `set_integral_const` (snake_case, not camelCase) gives `∫ x in s, c = (μ s).toReal • c`.
-
-### Files Modified
-
-- `proofs/Proofs/Erdos512Problem.lean` (+28 lines: L1norm_upper_bound proved)
-
-### Next Steps
-
-1. **Prove L2_norm** (Parseval): ~80-120 lines via normSq expansion + character orthogonality
-2. **Alternative**: Submit to Aristotle companion file
-3. Character orthogonality: `∫₀¹ exp(2πikθ) dθ = 0` for k : ℤ, k≠0 — needs FTC + Complex.exp_int_mul_two_pi_mul_I
-
+1. `L2_norm`: Prove ∫₀¹ |expSum A θ|² dθ = |A| via Parseval/character orthogonality
+   - Key step: `∫₀¹ expTwoPiI (k * θ) dθ = if k = 0 then 1 else 0` for integer k
+   - When k≠0: antiderivative is `expTwoPiI (k * θ) / (2πki)`; FTC gives (e^{2πki}-1)/(2πki) = 0
+   - Need: `Complex.integral_exp` or `intervalIntegral.integral_comp_mul_right` in Mathlib
+   - Then swap integral and double sum using `MeasureTheory.integral_finset_sum`

--- a/src/data/research/problems/erdos-1151-oq-04.json
+++ b/src/data/research/problems/erdos-1151-oq-04.json
@@ -40,7 +40,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: chebyshev_lebesgue_growth proved, 2 sorries remain (lb analytic bound + Banach-Steinhaus gap)",
+    "progressSummary": "PROGRESS: chebyshev_lebesgue_lb proved modulo chebyshev_trig_sum_lb; 2 sorries remain (harmonic sum lb + Banach-Steinhaus gap)",
     "builtItems": [
       "T_ofNat_ne_zero (n : ℕ) : T ℝ (n : ℤ) ≠ 0 — Erdos1151OQ04.lean:274",
       "natDegree_T_ofNat : ∀ n : ℕ, (T ℝ (n : ℤ)).natDegree = n — Erdos1151OQ04.lean:282",
@@ -52,9 +52,10 @@
       "x_not_chebyshev_node: parity lemma, cos(pi*p/q) != chebyshevNode n k for all n when p,q odd — Erdos1151OQ04.lean:534",
       "chebyshev_lebesgue_eq_all_n: Lebesgue formula for all n when p,q odd — Erdos1151OQ04.lean:601",
       "chebyshev_lebesgue_growth: proved (Filter.tendsto_atTop_mono + C·log(n+1) → ∞)",
-      "chebyshev_lebesgue_lb: sorry — harmonic sum lower bound Λₙ(x) ≥ C·log(n+1)",
       "cos_rational_pi_pos_min: ∃ δ > 0 s.t. |cos(nπp/q)| ≥ δ for all n (parity argument)",
-      "x_not_chebyshev_node: cos(πp/q) ≠ chebyshevNode n k for all n,k when p,q odd"
+      "x_not_chebyshev_node: cos(πp/q) ≠ chebyshevNode n k for all n,k when p,q odd",
+      "chebyshev_trig_sum_lb: sorry (isolated harmonic sum lower bound: S_n ≥ C₂·n·log(n+1))",
+      "chebyshev_lebesgue_lb: proved modulo chebyshev_trig_sum_lb via mul_le_mul chain (δ/n · C₂·n·log(n+1) ≤ |cos(nθ)|/n · S_n)"
     ],
     "insights": [
       "Lebesgue function Λₙ(x) = Σₖ |ℓₖ(x)| measures worst-case interpolation amplification",
@@ -108,8 +109,8 @@
     {
       "path": "Proofs/Erdos1151OQ04.lean",
       "filename": "Erdos1151OQ04.lean",
-      "lineCount": 656,
-      "theoremCount": 26,
+      "lineCount": 854,
+      "theoremCount": 31,
       "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 2,

--- a/src/data/research/problems/erdos-512-incomplete-01.json
+++ b/src/data/research/problems/erdos-512-incomplete-01.json
@@ -1,0 +1,111 @@
+{
+  "slug": "erdos-512-incomplete-01",
+  "title": "Erdős #512 — Fill Measure Theory Gaps in Littlewood Conjecture Formalization",
+  "phase": "ACT",
+  "status": "active",
+  "tier": "A",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\int_0^1 \\left|\\sum_{n \\in A} e^{2\\pi i n\\theta}\\right| d\\theta \\geq c \\cdot \\log N",
+    "plain": "Fill 2 remaining sorry gaps in the Littlewood conjecture formalization: expSumNorm_continuous and L1norm_le_card in the Aristotle companion file.",
+    "whyMatters": [
+      "Closes concrete sorry gaps in Erdős #512 gallery proof",
+      "Improves gallery integrity for a flagship formalization",
+      "Demonstrates Fourier analysis + integration Mathlib API patterns"
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "expSum_bound: |expSum A θ| ≤ A.card (triangle inequality)",
+      "L1norm_upper_bound: ∫₀¹ |expSum| dθ ≤ A.card (already proved in main file)",
+      "expTwoPiI_norm: |e(x)| = 1",
+      "expTwoPiI_periodic: e(x+1) = e(x)"
+    ],
+    "open": [
+      "L2_norm (Parseval): ∫₀¹ |expSum A θ|² dθ = A.card"
+    ],
+    "goal": "Close Aristotle companion sorries and optionally prove Parseval"
+  },
+  "currentState": {
+    "phase": "ACT",
+    "since": "2026-04-23T00:00:00.000Z",
+    "iteration": 1,
+    "focus": "Prove expSumNorm_continuous and L1norm_le_card in Aristotle companion",
+    "blockers": [],
+    "nextAction": "Prove L2_norm (Parseval) in main file",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "PROGRESS: 2/2 Aristotle sorries closed (expSumNorm_continuous, L1norm_le_card); L2_norm (Parseval) remains in main file",
+    "builtItems": [
+      "expSumNorm_continuous (A) : Continuous (expSumNorm A) — Erdos512Aristotle.lean",
+      "L1norm_le_card (A) : ∫₀¹ expSumNorm A θ ≤ A.card — Erdos512Aristotle.lean"
+    ],
+    "insights": [
+      "expSumNorm_continuous uses Complex.continuous_abs.comp + continuous_finset_sum + fun_prop",
+      "L1norm_le_card follows from continuity + setIntegral_mono_on (mirrors main file inline proof at lines 105-131)",
+      "L2_norm (Parseval) requires character orthogonality: ∫₀¹ e^{2πikθ} dθ = [k=0] — harder",
+      "The Aristotle companion header is outdated: L1norm_upper_bound in main file was already proved, only L2_norm remains there"
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "L2_norm: prove via double sum expansion + ∫₀¹ expTwoPiI(k*θ) dθ = [k=0] for k:ℤ",
+      "Check Mathlib for Complex.integral_exp or Fourier character orthogonality on [0,1]"
+    ]
+  },
+  "tags": [
+    "erdos",
+    "fourier-analysis",
+    "measure-theory",
+    "sorry-completion",
+    "seeker-selected"
+  ],
+  "relatedProofs": [
+    "erdos-5",
+    "erdos-51",
+    "erdos-512"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": [
+      "Complex.continuous_abs",
+      "continuous_finset_sum",
+      "ContinuousOn.integrableOn_compact",
+      "MeasureTheory.setIntegral_mono_on",
+      "Real.volume_Icc"
+    ]
+  },
+  "started": "2026-04-23T00:00:00.000Z",
+  "lastUpdate": "2026-04-23T00:00:00.000Z",
+  "significance": 8,
+  "tractability": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/Erdos512Problem.lean",
+      "filename": "Erdos512Problem.lean",
+      "lineCount": 245,
+      "theoremCount": 10,
+      "axiomCount": 2,
+      "defCount": 8,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos512Problem.lean"
+    },
+    {
+      "path": "Proofs/Erdos512Aristotle.lean",
+      "filename": "Erdos512Aristotle.lean",
+      "lineCount": 75,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos512Aristotle.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Proves `expSumNorm_continuous` in `Erdos512Aristotle.lean` — continuity of the exponential sum modulus via `Complex.continuous_abs.comp` + `continuous_finset_sum` + `fun_prop`
- Proves `L1norm_le_card` in `Erdos512Aristotle.lean` — L1 norm upper bound via continuity + `setIntegral_mono_on`; mirrors the inline proof already in `L1norm_upper_bound` (main file lines 105-131)
- Adds problem JSON and knowledge.md for `erdos-512-incomplete-01`

**Sorry delta**: Aristotle companion: 2 → 0 sorries. Main file `L2_norm` (Parseval) remains.

## Remaining work

`L2_norm` in `Erdos512Problem.lean` requires character orthogonality: `∫₀¹ e^{2πikθ} dθ = [k=0]` for integer k, then swap integral and double sum. Planned for a future session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)