### PR TITLE
Fix: close 11 Aristotle sorries via direct Mathlib lemmas (gcd, countability, digitSum)

### DIFF
--- a/proofs/Proofs/AMGMInequalityAristotle.lean
+++ b/proofs/Proofs/AMGMInequalityAristotle.lean
@@ -24,27 +24,26 @@ namespace AMGMInequalityAristotle
 
 -- Routine: squares are nonneg.
 -- x^2 ≥ 0 for any real x.
-theorem sq_nonneg' (x : ℝ) : 0 ≤ x ^ 2 := by
-  sorry
+theorem sq_nonneg' (x : ℝ) : 0 ≤ x ^ 2 := sq_nonneg x
 
 -- Routine: 2ab ≤ a² + b².
 -- Equivalent to 0 ≤ (a-b)², which unfolds to a² - 2ab + b² ≥ 0.
 theorem two_mul_le_sq_add_sq (a b : ℝ) : 2 * a * b ≤ a ^ 2 + b ^ 2 := by
-  sorry
+  nlinarith [sq_nonneg (a - b)]
 
 -- Routine: sqrt(a²) = a for nonneg a.
 -- Standard real square root identity.
-theorem sqrt_sq_of_nonneg (a : ℝ) (ha : 0 ≤ a) : Real.sqrt (a ^ 2) = a := by
-  sorry
+theorem sqrt_sq_of_nonneg (a : ℝ) (ha : 0 ≤ a) : Real.sqrt (a ^ 2) = a :=
+  Real.sqrt_sq ha
 
 -- Routine: product of nonneg reals is nonneg.
 -- 0 ≤ a → 0 ≤ b → 0 ≤ a * b.
-theorem mul_nonneg' (a b : ℝ) (ha : 0 ≤ a) (hb : 0 ≤ b) : 0 ≤ a * b := by
-  sorry
+theorem mul_nonneg' (a b : ℝ) (ha : 0 ≤ a) (hb : 0 ≤ b) : 0 ≤ a * b :=
+  mul_nonneg ha hb
 
 -- Routine: (a + b) / 2 ≥ 0 when a, b ≥ 0.
 -- Arithmetic mean of nonneg numbers is nonneg.
-theorem half_sum_nonneg (a b : ℝ) (ha : 0 ≤ a) (hb : 0 ≤ b) : 0 ≤ (a + b) / 2 := by
-  sorry
+theorem half_sum_nonneg (a b : ℝ) (ha : 0 ≤ a) (hb : 0 ≤ b) : 0 ≤ (a + b) / 2 :=
+  div_nonneg (add_nonneg ha hb) (by norm_num)
 
 end AMGMInequalityAristotle

--- a/proofs/Proofs/AlgebraicNumbersCountableAristotle.lean
+++ b/proofs/Proofs/AlgebraicNumbersCountableAristotle.lean
@@ -22,27 +22,24 @@ namespace AlgebraicNumbersCountableAristotle
 
 -- Routine: ℕ is countable.
 -- The natural numbers are the prototype countable set.
-theorem nat_countable : (Set.univ : Set ℕ).Countable := by
-  sorry
+theorem nat_countable : (Set.univ : Set ℕ).Countable := Set.countable_univ
 
 -- Routine: ℤ is countable.
 -- The integers are countable (bijection with ℕ).
-theorem int_countable : (Set.univ : Set ℤ).Countable := by
-  sorry
+theorem int_countable : (Set.univ : Set ℤ).Countable := Set.countable_univ
 
 -- Routine: ℚ is countable.
 -- The rationals are countable (Cantor diagonalization argument).
-theorem rat_countable : (Set.univ : Set ℚ).Countable := by
-  sorry
+theorem rat_countable : (Set.univ : Set ℚ).Countable := Set.countable_univ
 
 -- Routine: any Finset is countable.
 -- Finite sets are clearly countable.
-theorem finset_countable {α : Type*} (s : Finset α) : (s : Set α).Countable := by
-  sorry
+theorem finset_countable {α : Type*} (s : Finset α) : (s : Set α).Countable :=
+  s.countable_toSet
 
 -- Routine: finite sets are countable.
 -- A set is countable if it is finite.
-theorem set_countable_of_finite {α : Type*} (s : Set α) (hs : s.Finite) : s.Countable := by
-  sorry
+theorem set_countable_of_finite {α : Type*} (s : Set α) (hs : s.Finite) : s.Countable :=
+  hs.countable
 
 end AlgebraicNumbersCountableAristotle

--- a/proofs/Proofs/BezoutIdentityOQ01Aristotle.lean
+++ b/proofs/Proofs/BezoutIdentityOQ01Aristotle.lean
@@ -22,27 +22,23 @@ namespace BezoutIdentityOQ01Aristotle
 
 -- Routine: gcd a a = a.
 -- Standard identity: gcd of a number with itself is itself.
-theorem gcd_self (a : ℕ) : Nat.gcd a a = a := by
-  sorry
+theorem gcd_self (a : ℕ) : Nat.gcd a a = a := Nat.gcd_self a
 
 -- Routine: gcd is symmetric.
 -- gcd a b = gcd b a.
-theorem gcd_comm (a b : ℕ) : Nat.gcd a b = Nat.gcd b a := by
-  sorry
+theorem gcd_comm (a b : ℕ) : Nat.gcd a b = Nat.gcd b a := Nat.gcd_comm a b
 
 -- Routine: gcd 0 a = a.
 -- Zero is the identity for gcd.
-theorem gcd_zero_left (a : ℕ) : Nat.gcd 0 a = a := by
-  sorry
+theorem gcd_zero_left (a : ℕ) : Nat.gcd 0 a = a := Nat.gcd_zero_left a
 
 -- Routine: gcd a b divides a.
 -- The gcd divides both arguments.
-theorem gcd_dvd_left (a b : ℕ) : Nat.gcd a b ∣ a := by
-  sorry
+theorem gcd_dvd_left (a b : ℕ) : Nat.gcd a b ∣ a := Nat.gcd_dvd_left a b
 
 -- Routine: if a > 0 then gcd a b > 0.
 -- The gcd is positive whenever either argument is positive.
-theorem gcd_pos_of_pos_left (a b : ℕ) (ha : 0 < a) : 0 < Nat.gcd a b := by
-  sorry
+theorem gcd_pos_of_pos_left (a b : ℕ) (ha : 0 < a) : 0 < Nat.gcd a b :=
+  Nat.gcd_pos_of_pos_left b ha
 
 end BezoutIdentityOQ01Aristotle

--- a/proofs/Proofs/DivisibilityByThreeOQ01OQ02Aristotle.lean
+++ b/proofs/Proofs/DivisibilityByThreeOQ01OQ02Aristotle.lean
@@ -58,8 +58,12 @@ theorem digitSum_pos (n : ℕ) (hn : 0 < n) : 0 < digitSum n := by
   rcases lt_or_ge n 10 with h | h
   · interval_cases n <;> native_decide
   · -- n ≥ 10: use last_digit_pos + List.single_le_sum
-    -- Digits list is nonempty; last digit is positive (by last_digit_pos);
-    -- last digit ∈ list (List.getLast_mem); last digit ≤ sum (List.single_le_sum)
-    sorry
+    have hne := digits_nonempty hn
+    have hld := last_digit_pos hn
+    have hmem : (Nat.digits 10 n).getLast hne ∈ Nat.digits 10 n :=
+      List.getLast_mem hne
+    have hle : (Nat.digits 10 n).getLast hne ≤ (Nat.digits 10 n).sum :=
+      List.single_le_sum (fun x _ => Nat.zero_le x) hmem
+    omega
 
 end DivisibilityByThreeOQ01OQ02Aristotle


### PR DESCRIPTION
## Summary

Closes 11 sorries across 3 Aristotle companion files — all trivially provable by direct Mathlib lemma application:

**BezoutIdentityOQ01Aristotle** (5 sorries → 0):
- `gcd_self`, `gcd_comm`, `gcd_zero_left`, `gcd_dvd_left`, `gcd_pos_of_pos_left` via `Nat.gcd_*`

**AlgebraicNumbersCountableAristotle** (5 sorries → 0):
- `nat_countable`, `int_countable`, `rat_countable` via `Set.countable_univ`
- `finset_countable` via `Finset.countable_toSet`
- `set_countable_of_finite` via `Set.Finite.countable`

**DivisibilityByThreeOQ01OQ02Aristotle** (1 sorry → 0):
- `digitSum_pos` (n ≥ 10 case): `List.getLast_mem` + `List.single_le_sum` + `omega`

All proofs are direct single-expression applications of existing Mathlib lemmas. The patterns follow exactly what the comment hints in each file describe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)