### PR TITLE
Auditor: fix sorry/axiom counts for lebesgue-oq-06 and ballot-oq-03-oq-01-oq-01-oq-01

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -18,11 +18,11 @@
       "representation-theory"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 0,
     "dateAdded": "2026-04-23",
     "axiomCount": 0,
-    "assumptions": "1 sorry: schurPolynomial_one_row_at_one (eval at 1 requires Nat.multichoose computation). All other theorems proved: jacobiTrudiMatrix_entry_isSymmetric (split_ifs + hsymm_isSymmetric), schurPolynomial_isSymmetric (AlgHom.map_det), schurPolynomial_two_row (det_fin_two expansion), jacobiTrudi_lgv_connection (proved as tautology rfl — placeholder until RSK is formalized). Base cases (empty, one_row) are proved.",
-    "lineCount": 130,
+    "assumptions": "0 sorries. All theorems proved: jacobiTrudiMatrix_entry_isSymmetric (split_ifs + hsymm_isSymmetric), schurPolynomial_isSymmetric (AlgHom.map_det), schurPolynomial_two_row (det_fin_two expansion), schurPolynomial_one_row_at_one (proved), jacobiTrudi_lgv_connection (proved as tautology rfl — placeholder until RSK is formalized). Base cases (empty, one_row) are proved.",
+    "lineCount": 178,
     "theoremCount": 7,
     "definitionCount": 2,
     "originalContributions": [
@@ -54,10 +54,9 @@
     ]
   },
   "conclusion": {
-    "summary": "Defines Schur polynomials via the Jacobi-Trudi formula and proves base cases, symmetry, and the two-row formula. 1 sorry remains: schurPolynomial_one_row_at_one (hook-length evaluation). The LGV combinatorial connection is a tautology placeholder pending RSK correspondence (~400 lines).",
-    "implications": "This provides the first Lean 4 definition of Schur polynomials via the Jacobi-Trudi formula, which is the algebraically canonical definition connecting them to the representation theory of GL(n). The remaining sorry (hook evaluation at 1 via `Nat.multichoose`) and the LGV placeholder (RSK + SSYT, ~400 lines) are the outstanding research items. A completed formalization would unlock: the Pieri rule $s_\\lambda h_n = \\sum_\\mu s_\\mu$, the Murnaghan-Nakayama rule for character values, and connections to Schubert calculus. Schur polynomials are the backbone of algebraic combinatorics — once formalized, they would serve as building blocks for representation-theoretic calculations across the gallery.",
+    "summary": "Defines Schur polynomials via the Jacobi-Trudi formula and proves base cases, symmetry, and the two-row formula. 0 sorries remain. The LGV combinatorial connection is a tautology placeholder pending RSK correspondence (~400 lines).",
+    "implications": "This provides the first Lean 4 definition of Schur polynomials via the Jacobi-Trudi formula, which is the algebraically canonical definition connecting them to the representation theory of GL(n). All theorems are proved (0 sorries). The LGV placeholder (RSK + SSYT, ~400 lines) is the outstanding research item. A completed formalization would unlock: the Pieri rule $s_\\lambda h_n = \\sum_\\mu s_\\mu$, the Murnaghan-Nakayama rule for character values, and connections to Schubert calculus. Schur polynomials are the backbone of algebraic combinatorics — once formalized, they would serve as building blocks for representation-theoretic calculations across the gallery.",
     "openQuestions": [
-      "Prove schurPolynomial_one_row_at_one via Nat.multichoose",
       "Formalize the RSK correspondence and SSYT→NI-path bijection to prove jacobiTrudi_lgv_proof",
       "Prove the Pieri rule: s_λ * h_n = Σ_{μ} s_μ where μ ranges over partitions obtained by adding n boxes to λ"
     ]
@@ -74,12 +73,12 @@
       "Finset"
     ],
     "namespace": "JacobiTrudi",
-    "lineCount": 125,
+    "lineCount": 178,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 2,
     "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "crossReferences": [
     {
@@ -154,8 +153,8 @@
       "title": "Part V: Hook-Length Connection",
       "startLine": 92,
       "endLine": 101,
-      "summary": "Evaluation of one-row Schur polynomial at all-ones gives C(n+k-1, k-1). Currently sorry pending Nat.multichoose reduction.",
-      "mathContext": "`eval (fun _ : Fin k => (1 : R)) (schurPolynomial 1 (fun _ => n)) = Nat.choose (n + k - 1) (k - 1)`. Uses `schurPolynomial_one_row` to reduce to `eval 1 (hsymm (Fin k) R n)`, then stars-and-bars: $h_n(1,\\ldots,1) = \\binom{n+k-1}{k-1}$. (sorry)"
+      "summary": "Evaluation of one-row Schur polynomial at all-ones gives C(n+k-1, k-1). Proved via Nat.multichoose reduction.",
+      "mathContext": "`eval (fun _ : Fin k => (1 : R)) (schurPolynomial 1 (fun _ => n)) = Nat.choose (n + k - 1) (k - 1)`. Uses `schurPolynomial_one_row` to reduce to `eval 1 (hsymm (Fin k) R n)`, then stars-and-bars: $h_n(1,\\ldots,1) = \\binom{n+k-1}{k-1}$."
     },
     {
       "id": "sec-lgv-connection",
@@ -166,5 +165,5 @@
       "mathContext": "Full proof requires: (1) SSYT type and weight function (~100 lines), (2) RSK bijection SSYT ↔ NI paths (~200 lines), (3) weight matching with the LGV edge weights from the parent proof (~100 lines). The placeholder states `schurPolynomial k sh = schurPolynomial k sh` (tautology) until SSYT generating function is defined."
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }

--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -17,11 +17,11 @@
       "axiom-of-choice",
       "research"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 4,
     "axiomCount": 0,
-    "lineCount": 287,
-    "assumptions": "4 sorry'd theorems representing major unproved results: hausdorff_free_subgroup (Hausdorff 1914 — SO(3) contains F₂ as a free subgroup of rank 2, requires 300+ lines of number theory), banach_tarski (Banach-Tarski 1924 — main paradox for the unit ball in ℝ³, requires 800+ lines via Hausdorff paradox + AC), banach_tarski_pieces_nonmeasurable (non-measurability of decomposition pieces), int_amenable (ℤ is amenable via Cesàro means). No formal axiom declarations. Abstract framework (equidecomposability, paradoxical sets, F₂ non-amenability, measure-theoretic consequence) is fully proved with 0 sorries.",
+    "lineCount": 510,
+    "assumptions": "0 axiom declarations. 4 sorries in supporting theorems: hausdorff_free_subgroup (Hausdorff 1914 — SO(3) contains F₂, requires 300+ lines of number theory), banach_tarski (Banach-Tarski 1924 — main paradox, requires 800+ lines via Hausdorff paradox + AC), banach_tarski_pieces_nonmeasurable (classical non-measurability corollary), int_amenable (Markov-Kakutani — ℤ is amenable via Cesàro means/ultrafilter construction). free_group_not_amenable is fully proved. Abstract framework (equidecomposability, paradoxical sets, F₂ non-amenability, measure-theoretic consequence) is fully proved with 0 sorries.",
     "dateAdded": "2026-04-22",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -30,7 +30,8 @@
       "IsAmenable (amenable group definition)",
       "ennreal_add_self_eq_self (proved: a + a = a → a = 0 or a = ⊤ in ENNReal)",
       "equidecomposable_refl (proved: every set is self-equidecomposable)",
-      "Framework: paradoxical sets have no finite invariant measure (fully proved, no sorry)"
+      "Framework: paradoxical sets have no finite invariant measure (fully proved, no sorry)",
+      "free_group_not_amenable: fully proved — F₂ is not amenable via word-set paradoxical decomposition"
     ]
   },
   "overview": {
@@ -101,12 +102,12 @@
       "title": "§VI: Amenability and the Group-Theoretic Source",
       "startLine": 249,
       "endLine": 295,
-      "summary": "Defines amenable groups. States int_amenable (ℤ is amenable via Cesàro means, sorry) and free_group_not_amenable (F₂ non-amenable via paradoxical decomposition, sorry). Closes the BanachTarski namespace.",
+      "summary": "Defines amenable groups. States int_amenable (ℤ is amenable via Cesàro means, sorry). Proves free_group_not_amenable (F₂ non-amenable via word-set paradoxical decomposition, fully proved). Closes the BanachTarski namespace.",
       "mathContext": "A group $G$ is amenable iff $\\exists \\mu: 2^G \\to [0,\\infty]$ with $\\mu(G)=1$, $\\mu(A \\cup B) = \\mu(A) + \\mu(B)$ for disjoint $A, B$, and $\\mu(gA) = \\mu(A)$ for all $g \\in G$. Abelian groups are amenable (via Markov-Kakutani). $F_2$ is not amenable: $F_2 = W(a) \\sqcup aW(a^{-1})$ and $F_2 = W(b) \\sqcup bW(b^{-1})$ give two paradoxical coverings. `int_amenable` can likely be proved using Mathlib's Hahn-Banach (`NormedSpace.HahnBanach`) to construct a Banach limit extending the Cesàro mean on $\\ell^\\infty(\\mathbb{Z})$."
     }
   ],
   "conclusion": {
-    "summary": "The Banach-Tarski paradox is formalized with 4 sorry'd unproved major results (hausdorff_free_subgroup, banach_tarski, banach_tarski_pieces_nonmeasurable, int_amenable) and 0 formal axiom declarations. The abstract framework (equidecomposability, paradoxical sets, F₂ non-amenability, measure-theoretic consequence) is fully proved with 0 sorries. The 4 sorry'd theorems represent classically established results whose Lean proofs require 300–800 lines each — beyond this gallery entry's scope.",
+    "summary": "The Banach-Tarski paradox is formalized with 4 sorries and 0 axioms (all as sorry'd theorems, not axiom declarations): Hausdorff's free subgroup theorem, the main Banach-Tarski paradox, non-measurability of pieces, and ℤ amenability. The framework (equidecomposability, paradoxical sets, and F₂ non-amenability) is fully proved with no remaining sorry.",
     "openQuestions": [
       "Can Hausdorff's free subgroup theorem be fully formalized in Lean? The proof requires showing that explicit 3×3 rotation matrices $\\varphi$ (rotation by $\\arccos(1/3)$ around the $z$-axis) and $\\psi$ (rotation by $\\arccos(1/3)$ around the $x$-axis) generate a free group of rank 2 in $\\text{SO}(3)$. The algebraic argument shows that nontrivial words $w(\\varphi, \\psi)$ applied to $e_1 = (1, 0, 0)$ produce vectors with coordinates in $\\mathbb{Z}[1/3, \\sqrt{2}/3]$ that are non-zero — requiring careful case analysis on the word structure and number-theoretic properties of $\\arccos(1/3)$ (specifically that it is not a rational multiple of $\\pi$).",
       "Can the full Banach-Tarski proof be formalized in Lean 4? The most likely modular path: (1) formalize the free subgroup freeness (the sorry in `hausdorff_free_subgroup`); (2) prove the paradoxical decomposition of $F_2$ acting on itself (purely algebraic, ~100 lines); (3) lift to $S^2 \\setminus D$ via the free group action (~150 lines); (4) handle the exceptional set $D$ via a rotation of infinite order (Hilbert hotel, ~100 lines); (5) extend from $S^2$ to $B^3$ by coning and handling the center (~100 lines). Estimated total: 800–1200 lines.",
@@ -201,7 +202,7 @@
       "Mathlib"
     ],
     "namespace": "BanachTarski",
-    "lineCount": 287,
+    "lineCount": 510,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 5,


### PR DESCRIPTION
## Summary

Fixes two sorry-count mismatches detected during gallery integrity audit.

### lebesgue-measure-oq-06
- `lineCount`: 287 -> 510 (Lean file grew as new proofs were added)
- `badge`: wip -> axiom (sorry'd theorems treated as axioms)
- `assumptions`: updated to reflect `free_group_not_amenable` is now fully proved
- `originalContributions`: added `free_group_not_amenable` (F2 non-amenable via word-set paradoxical decomposition)
- `conclusion.summary`: corrected to "4 sorries and 0 axioms"
- Amenability section summary: updated to show `free_group_not_amenable` is proved, not sorry

### ballot-problem-oq-03-oq-01-oq-01-oq-01
- `sorries`: 1 -> 0 (all theorems now proved, including `schurPolynomial_one_row_at_one`)
- `lineCount`: 125/130 -> 178
- Updated assumptions, conclusion, implications, openQuestions, section summaries

All sorry counts verified against actual Lean source files on main.