### PR TITLE
Add Erdos627Aristotle.lean: 3 Aristotle targets for chi/omega ratio

### DIFF
--- a/proofs/Proofs/Erdos627Aristotle.lean
+++ b/proofs/Proofs/Erdos627Aristotle.lean
@@ -1,0 +1,70 @@
+/-
+  Aristotle targets for Erdős Problem #627: Chromatic Number and Clique Number Ratio
+  Routine supporting lemmas for automated proof search.
+  See Erdos627Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - limit_bounds_numerical_ari: pure numerical inequality, (log 2)²/4 < (log 2)²
+  - chi_ge_omega_ari: standard chi ≥ omega lower bound on chromatic number
+  - ratio_ge_one_ari: chiOmegaRatio ≥ 1 when cliqueNumber > 0
+
+  Excluded:
+  - Theorems depending on sorry-defined `f` (def sorry): f_ge_one, f_monotone,
+    f_unbounded, ratio_bounded, f_normalized_bounded
+  - Theorems depending on sorry-defined `ramseyNumber`: f_ramsey_lower_bound
+  - Theorems depending on sorry-defined `mycielskiGraph` or `kneserGraph`
+  - fNormalized (depends on sorry def f)
+  - perfect_ratio_one: complex (depends on strong_perfect_graph_theorem axiom shape)
+  - triangle_free_large_chi: sorry inside lambda (Aristotle cannot target)
+  - Main open question LimitExists — open conjecture
+-/
+import Proofs.Erdos627Problem
+import Mathlib
+
+namespace Erdos627Aristotle
+
+open Erdos627 GraphCore
+open SimpleGraph hiding chromaticNumber
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+/-
+## Section 1: Numerical Bound on Limit
+
+The lower bound on the putative limit is strictly less than the upper bound.
+Both are expressed in terms of (log 2)^2.
+-/
+
+/-- The lower bound (log 2)²/4 is strictly less than the upper bound (log 2)².
+    Since Real.log 2 > 0 (as 2 > 1), we have (log 2)² > 0, so dividing by 4 is strict. -/
+lemma limit_bounds_numerical_ari : limitLowerBound < limitUpperBound := by
+  sorry
+
+/-
+## Section 2: Chromatic Number Lower Bound
+
+The chromatic number chi(G) is always at least the clique number omega(G).
+This is a standard fact: any proper coloring must assign distinct colors to
+the vertices of a clique.
+-/
+
+/-- The chromatic number is at least the clique number: chi(G) ≥ omega(G).
+    Any k-clique requires k distinct colors in any proper coloring,
+    so chromaticNumber G ≥ k whenever G contains a k-clique. -/
+lemma chi_ge_omega_ari (G : SimpleGraph V) :
+    chromaticNumber G ≥ cliqueNumber G := by
+  sorry
+
+/-
+## Section 3: Ratio Positivity
+
+The chi/omega ratio is at least 1 when the clique number is positive.
+-/
+
+/-- The ratio chi(G)/omega(G) is at least 1 when omega(G) > 0.
+    Follows directly from chi(G) ≥ omega(G) > 0. -/
+lemma ratio_ge_one_ari (G : SimpleGraph V) (hω : cliqueNumber G > 0) :
+    chiOmegaRatio G ≥ 1 := by
+  sorry
+
+end Erdos627Aristotle


### PR DESCRIPTION
## Fix

Adds Aristotle companion file for Erdős Problem #627 (Chromatic Number and Clique Number Ratio) with 3 automated proof search targets.

## Targets

- **`limit_bounds_numerical_ari`**: `limitLowerBound < limitUpperBound`, i.e. `(log 2)²/4 < (log 2)²` — pure numerical inequality reducible to `(log 2)^2 > 0`
- **`chi_ge_omega_ari`**: `chromaticNumber G ≥ cliqueNumber G` — standard graph theory: any proper coloring assigns distinct colors to clique vertices
- **`ratio_ge_one_ari`**: `chiOmegaRatio G ≥ 1` when `cliqueNumber G > 0` — follows from chi ≥ omega

## Evidence

**Before**: `Erdos627Problem.lean` has 16 sorries, no companion file
**After**: `Erdos627Aristotle.lean` provides 3 clean targets for Aristotle automated proof search

## Pre-submission checklist

- [x] No `def ... := sorry`
- [x] No `axiom` declarations
- [x] No `theorem ... : True` placeholders
- [x] No `/-!` docstring sections
- [x] No open conjectures (excluded: `LimitExists`, `f_ge_one`, `f_monotone`, etc.)

---
Automated fix by lean-mechanic agent.