### PR TITLE
Add Erdos610Aristotle.lean: 3 Aristotle targets for clique transversal numbers

### DIFF
--- a/proofs/Proofs/Erdos610Aristotle.lean
+++ b/proofs/Proofs/Erdos610Aristotle.lean
@@ -1,0 +1,67 @@
+/-
+  Aristotle targets for Erdős Problem #610: Clique Transversal Numbers
+  Routine supporting lemmas for automated proof search.
+  See Erdos610Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - tau_le_card_ari: τ(G) ≤ n — the full vertex set is always a transversal
+  - tau_empty_ari: τ(⊥) = n — empty graph forces every vertex into the transversal
+  - tau_complete_ari: τ(⊤) = 1 — complete graph has one maximal clique (all of V)
+
+  Excluded:
+  - erdos_gallai_tuza: open mathematical result, not routine
+  - Lemmas depending on def-sorry `triangleFreeIndependence`: conjecture_implies_question2
+  - Lemmas depending on def-sorry `cliqueCoverNumber`: tau_clique_cover_relation
+  - Lemmas with sorry in hypothesis/conclusion type: tau_bipartite, tau_chordal, tau_perfect
+  - egt_bound_tight: requires constructing extremal graphs (non-routine)
+  - kim_triangle_free_independence: axiom, converted below but not an open conjecture target
+-/
+import Proofs.Erdos610Problem
+import Mathlib
+
+namespace Erdos610Aristotle
+
+open Finset Function SimpleGraph
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+/-
+## Section 1: Basic Bound τ(G) ≤ n
+
+The clique transversal number is at most the number of vertices,
+since the full vertex set is always a clique transversal.
+-/
+
+/-- The clique transversal number τ(G) ≤ n = |V|.
+    The full vertex set V is a clique transversal (every maximal clique
+    intersects V trivially), so the minimum transversal size is at most |V|. -/
+lemma tau_le_card_ari (G : SimpleGraph V) : τ G ≤ Fintype.card V := by
+  sorry
+
+/-
+## Section 2: Empty Graph
+
+In the bottom (empty) graph ⊥, every singleton {v} is a maximal clique.
+A clique transversal must hit each singleton, so it must include every vertex.
+-/
+
+/-- For the empty graph, τ(⊥) = n.
+    Every singleton vertex is a maximal clique in ⊥ (no edges exist).
+    Therefore the minimum transversal must include all n vertices. -/
+lemma tau_empty_ari : τ (⊥ : SimpleGraph V) = Fintype.card V := by
+  sorry
+
+/-
+## Section 3: Complete Graph
+
+In the top (complete) graph ⊤, the unique maximal clique is all of V.
+Any single vertex suffices as a transversal, giving τ(⊤) = 1.
+-/
+
+/-- For the complete graph, τ(⊤) = 1 (when V is nontrivial).
+    The only maximal clique in ⊤ is V itself. Any single vertex
+    hits that clique, so the minimum transversal has size 1. -/
+lemma tau_complete_ari [Nontrivial V] : τ (⊤ : SimpleGraph V) = 1 := by
+  sorry
+
+end Erdos610Aristotle


### PR DESCRIPTION
## Fix

Adds Aristotle companion file for Erdős Problem #610 (Clique Transversal Numbers) with 3 automated proof search targets.

## Targets

- **`tau_le_card_ari`**: `τ G ≤ Fintype.card V` — the full vertex set `Finset.univ` is always a clique transversal (proved by `univ_is_transversal`), so the minimum transversal size is ≤ |V|
- **`tau_empty_ari`**: `τ (⊥ : SimpleGraph V) = Fintype.card V` — in the empty graph, every singleton is a maximal clique, so the transversal must include all vertices
- **`tau_complete_ari`**: `τ (⊤ : SimpleGraph V) = 1` — the complete graph has exactly one maximal clique (all of V), so any single vertex suffices

## Evidence

**Before**: `Erdos610Problem.lean` has 17 sorries, no companion file
**After**: `Erdos610Aristotle.lean` provides 3 clean targets for Aristotle automated proof search

## Pre-submission checklist

- [x] No `def ... := sorry`
- [x] No `axiom` declarations
- [x] No `theorem ... : True` placeholders
- [x] No `/-!` docstring sections
- [x] No open conjectures (excluded: `erdos_gallai_tuza`, `egt_bound_tight`, `conjecture_implies_question2`)

---
Automated fix by lean-mechanic agent.