### PR TITLE
Enrich 4 gallery entries: Gauss-Bonnet, Jacobi-Trudi, Catalan recurrence, Hölder eLpNorm

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-03-oq-01/annotations.json
@@ -124,5 +124,32 @@
       "Lp spaces",
       "Mathlib Lp API"
     ]
+  },
+  {
+    "id": "ann-oq03-oq01-duality",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-03-oq-01",
+    "range": {
+      "startLine": 86,
+      "endLine": 145
+    },
+    "type": "insight",
+    "title": "Lp Duality: Hölder as the Key Step in Riesz Representation",
+    "content": "The eLpNorm form of Hölder's inequality is the analytical engine behind **Lp duality** — the identification $(L^p)^* \\cong L^q$ for conjugate exponents.\n\n**The duality argument**:\n1. For $g \\in L^q(\\mu)$, define $T_g : L^p(\\mu) \\to \\mathbb{k}$ by $T_g(f) = \\int fg \\, d\\mu$\n2. By `memLp_mul_of_memLp_ofReal`, the product $fg \\in L^1(\\mu)$, so the integral is finite\n3. By `holder_normedField_eLpNorm`, $|T_g(f)| = |\\int fg| \\leq \\text{eLpNorm}(fg,1) \\leq \\text{eLpNorm}(f,p) \\cdot \\text{eLpNorm}(g,q)$\n4. So $\\|T_g\\|_{(L^p)^*} \\leq \\|g\\|_{L^q}$ — $T_g$ is a bounded linear functional\n5. The Riesz representation theorem (not in this file, but relying on this infrastructure) shows the map $g \\mapsto T_g$ is an isometric isomorphism $L^q \\to (L^p)^*$\n\n**Why eLpNorm matters**: The Riesz representation theorem is stated in terms of `Memℒp` (Lp membership) and `eLpNorm` (Lp norm). The lintegral form of Hölder (OQ-03) is not directly applicable to Riesz representation proofs — the eLpNorm form (this file) is.",
+    "mathContext": "Riesz representation: $(L^p(\\mu))^* \\cong L^q(\\mu)$ for $1 \\le p < \\infty$, $1/p + 1/q = 1$. The isometric embedding $\\iota : L^q \\hookrightarrow (L^p)^*$ is $\\iota(g)(f) = \\int f \\cdot g \\, d\\mu$. By Hölder: $|\\iota(g)(f)| \\le \\|f\\|_p \\cdot \\|g\\|_q$, so $\\|\\iota(g)\\|_{(L^p)^*} \\le \\|g\\|_q$. The reverse inequality (isometry) requires the Hahn-Banach theorem or an explicit maximizer construction. In Mathlib: `MeasureTheory.Lp.inner_le_eLpNorm` and the `inner_product_space` instance on $L^2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Lp duality",
+      "Riesz representation theorem",
+      "bounded linear functionals",
+      "dual space",
+      "Banach space duality",
+      "Hahn-Banach theorem"
+    ],
+    "prerequisites": [
+      "Hölder inequality (this file)",
+      "Memℒp and eLpNorm",
+      "functional analysis",
+      "dual Banach spaces"
+    ]
   }
 ]

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-03-oq-01/meta.json
@@ -73,7 +73,8 @@
       "**1/p vs p**: The Lean convention uses `ENNReal.toReal_ofReal` and `one_div` to convert the exponent from the eLpNorm form to the lintegral form. This is a notational detail but critical for proof correctness.",
       "**Product Membership is the Real Payoff**: `memLp_mul_of_memLp_ofReal` is why practitioners care about Hölder. It directly answers: 'If I know f ∈ Lp and g ∈ Lq, is fg integrable?' Yes, and this proof makes it a two-line calculation.",
       "**NormedField Generality**: The theorem is stated for any NormedField 𝕜, not just ℝ or ℂ. This is automatic — the only field property used is nnnorm multiplicativity, which holds in any NormedField.",
-      "**Two-Level Architecture**: Mathlib's Lp theory has lintegral-level and eLpNorm-level lemmas. OQ-03 works at the lower level; this file bridges to the upper level, making Hölder accessible to all eLpNorm-based arguments."
+      "**Two-Level Architecture**: Mathlib's Lp theory has lintegral-level and eLpNorm-level lemmas. OQ-03 works at the lower level; this file bridges to the upper level, making Hölder accessible to all eLpNorm-based arguments.",
+      "**Lp Duality via Hölder**: The inequality eLpNorm(fg,1) ≤ eLpNorm(f,p)·eLpNorm(g,q) says the bilinear pairing ⟨f,g⟩ = ∫fg dμ is bounded on Lp × Lq. This is the key step in proving the Riesz representation theorem (Lp* ≅ Lq for 1 ≤ p < ∞): the map g ↦ ⟨·,g⟩ is an isometric embedding Lq → (Lp)*. Hölder at the eLpNorm level (this file) is exactly the right form for these functional-analytic arguments."
     ],
     "prerequisites": [
       "Lp spaces: Memℒp f p μ, AEStronglyMeasurable, eLpNorm",
@@ -129,7 +130,9 @@
     "implications": "**Why This Matters**\n\n1. **Standard API**: The eLpNorm form is what Mathlib uses in all Lp space theorems (completeness, duality, Riesz representation). Hölder at this level is directly applicable.\n\n2. **Membership Criterion**: `memLp_mul_of_memLp_ofReal` is a practical theorem: it gives a sufficient condition for integrability of a product. This is used constantly in PDE, harmonic analysis, and functional analysis proofs.\n\n3. **Complete Formalization Chain**: OQ-01 (real lintegral) → OQ-03 (NormedField lintegral) → OQ-03-OQ-01 (NormedField eLpNorm) forms a complete three-level hierarchy covering all Mathlib Hölder formulations.",
     "openQuestions": [
       "Can the Hölder inequality be lifted further to the Bochner integral (∫ f dμ in a Banach space) for Banach-space-valued Lp functions?",
-      "Is there a clean eLpNorm form of Young's convolution inequality in Mathlib, and can it be proved analogously?"
+      "Is there a clean eLpNorm form of Young's convolution inequality in Mathlib, and can it be proved analogously?",
+      "Can the Minkowski inequality (triangle inequality for Lp norms: eLpNorm(f+g) ≤ eLpNorm(f) + eLpNorm(g)) be proved at the eLpNorm level in Lean? Mathlib has it at the lintegral level; lifting requires a similar bridge strategy to this file.",
+      "Can the Riesz-Thorin interpolation theorem (if T is bounded on Lp₀ and Lp₁ then T is bounded on Lp for p₀ < p < p₁) be formalized? It requires complex interpolation and the three-lines theorem, which would be new Mathlib infrastructure."
     ]
   },
   "crossReferences": [
@@ -150,8 +153,15 @@
     }
   ],
   "leanFile": {
-    "imports": ["Mathlib"],
-    "opens": ["MeasureTheory", "ENNReal", "NNReal", "Real"],
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "MeasureTheory",
+      "ENNReal",
+      "NNReal",
+      "Real"
+    ],
     "namespace": "HolderELpNorm",
     "lineCount": 176,
     "axiomCount": 0,


### PR DESCRIPTION
## Summary

### triangle-angle-sum-oq-02 (Triangle Angle Sum: Gauss-Bonnet Generalization)
- Fix cross-reference bug: `euler-polyhedral-oq-02-oq-01` → `euler-polyhedral-formula-oq-02-oq-01`
- Add Atiyah-Singer index theorem annotation (GB → Chern-GB → Atiyah-Singer chain)
- Add 6th keyInsight, 4th openQuestion, 2 new cross-references (euler-polyhedral-formula, poincare-conjecture)

### ballot-problem-oq-03-oq-01-oq-01-oq-01 (Jacobi-Trudi Identity)
- Fix 4 stale annotations describing sorries now closed (commit 039b98ec5c)
- Add dual Jacobi-Trudi annotation (ω involution, s_λ ↦ s_{λ'} under conjugate partition)
- Add 6th keyInsight, 2 new openQuestions (LR rule, RSK upgrade)

### ballot-problem-oq-03-oq-01-oq-04 (Catalan Recurrence from Ballot Theorem)
- Add generating function annotation: C(x) = 1 + x·C(x)², 214 Stanley interpretations survey
- Add 6th keyInsight (D-finite, 214 interpretations), 4th openQuestion (PowerSeries GF)
- Add cross-reference to Jacobi-Trudi sibling

### cauchy-schwarz-integral-oq-01-oq-03-oq-01 (Hölder Inequality in eLpNorm Form)
- Add Lp duality annotation: 5-step argument from Hölder to bounded functional T_g on Lp,
  connecting to the Riesz representation theorem (Lp* ≅ Lq)
- Add 6th keyInsight (Lp duality via bilinear pairing)
- Add 3rd openQuestion (Minkowski inequality eLpNorm bridge)
- Add 4th openQuestion (Riesz-Thorin interpolation + three-lines theorem)

🤖 Generated by enricher-2