### PR TITLE
Fix: close 26 Aristotle sorries across 9 files (batch fixes)

### DIFF
--- a/proofs/Proofs/Erdos620Problem.lean
+++ b/proofs/Proofs/Erdos620Problem.lean
@@ -190,7 +190,9 @@ def turanGraph3 (n : ℕ) : SimpleGraph (Fin n) where
   loopless := by intro i h; exact h rfl
 
 theorem turan_is_K4Free (n : ℕ) : K4Free (turanGraph3 n) := by
-  sorry
+  rintro ⟨a, b, c, d, -, -, -, -, -, -, hab, hac, had, hbc, hbd, hcd⟩
+  simp only [turanGraph3] at hab hac had hbc hbd hcd
+  omega
 
 /- ## Part VIII: Ramsey Connection -/
 

--- a/proofs/Proofs/Erdos620ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos620ProblemAristotle.lean
@@ -46,6 +46,8 @@ but only 3 residues (0, 1, 2) exist — contradiction by omega.
     4. All four are < 3 (by Nat.mod_lt with divisor 3).
     5. Four pairwise-distinct naturals all < 3 is impossible: omega. -/
 theorem turan_is_K4Free (n : ℕ) : Erdos620.K4Free (Erdos620.turanGraph3 n) := by
-  sorry
+  rintro ⟨a, b, c, d, -, -, -, -, -, -, hab, hac, had, hbc, hbd, hcd⟩
+  simp only [Erdos620.turanGraph3] at hab hac had hbc hbd hcd
+  omega
 
 end Erdos620.Aristotle

--- a/proofs/Proofs/Erdos922Aristotle.lean
+++ b/proofs/Proofs/Erdos922Aristotle.lean
@@ -20,8 +20,7 @@ open SimpleGraph
 -- Bipartite means Colorable 2, and Colorable n → chromaticNumber ≤ n.
 theorem bipartite_chromatic_le_two {V : Type*} [Fintype V]
     (G : SimpleGraph V) [DecidableRel G.Adj] (hbip : G.IsBipartite) :
-    G.chromaticNumber ≤ 2 := by
-  sorry
+    G.chromaticNumber ≤ 2 := hbip.chromaticNumber_le
 
 -- Routine: Rational arithmetic for the Folkman density bound.
 -- Given 2 * S ≥ W - k in ℕ (natural subtraction) and W > 0,
@@ -30,6 +29,17 @@ theorem bipartite_chromatic_le_two {V : Type*} [Fintype V]
 theorem ratio_ge_of_two_card_bound (S W k : ℕ) (hW : 0 < W)
     (h : 2 * S ≥ W - k) :
     (S : ℚ) / W ≥ ((W : ℚ) - k) / (2 * W) := by
-  sorry
+  have hWQ : (0 : ℚ) < W := by exact_mod_cast hW
+  rw [ge_iff_le, div_le_div_iff (by positivity) hWQ]
+  -- (W - k) * W ≤ S * (2 * W) follows from (W - k : ℚ) ≤ 2 * S
+  have hkey : (W : ℚ) - k ≤ 2 * S := by
+    rcases Nat.le_or_lt k W with hle | hlt
+    · have h1 : ((W - k : ℕ) : ℚ) ≤ 2 * S := by exact_mod_cast h
+      rwa [Nat.cast_sub hle] at h1
+    · have hWkQ : (W : ℚ) - k ≤ 0 := by
+        have : (W : ℚ) ≤ k := by exact_mod_cast hlt.le
+        linarith
+      linarith [show (0 : ℚ) ≤ 2 * S from by positivity]
+  nlinarith
 
 end Erdos922Aristotle

--- a/proofs/Proofs/Erdos933ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos933ProblemAristotle.lean
@@ -43,12 +43,16 @@ For n > 0, n+1 > 0 always, so Nat.factorization_mul applies.
 theorem power2_consecutive_ari (n : ℕ) :
     (n * (n + 1)).factorization 2 =
       n.factorization 2 + (n + 1).factorization 2 := by
-  sorry
+  rcases Nat.eq_zero_or_pos n with rfl | hn
+  · simp
+  · rw [Nat.factorization_mul hn.ne' (Nat.succ_ne_zero n), Finsupp.add_apply]
 
 /-- The 3-adic valuation of n*(n+1) equals the sum of 3-adic valuations of n and n+1. -/
 theorem power3_consecutive_ari (n : ℕ) :
     (n * (n + 1)).factorization 3 =
       n.factorization 3 + (n + 1).factorization 3 := by
-  sorry
+  rcases Nat.eq_zero_or_pos n with rfl | hn
+  · simp
+  · rw [Nat.factorization_mul hn.ne' (Nat.succ_ne_zero n), Finsupp.add_apply]
 
 end Erdos933ProblemAristotle

--- a/proofs/Proofs/SchroederBernsteinOQ03Aristotle.lean
+++ b/proofs/Proofs/SchroederBernsteinOQ03Aristotle.lean
@@ -35,11 +35,15 @@ lemma partialInverse_partrec {g : ℕ → ℕ} (hg : Computable g) :
     If n ∈ partialInverse g m, then g n = m. -/
 lemma partialInverse_spec {g : ℕ → ℕ} (hg_inj : Injective g)
     {m n : ℕ} (h : n ∈ partialInverse g m) : g n = m := by
-  sorry
+  unfold partialInverse at h
+  exact of_decide_eq_true (Nat.rfind_spec h)
 
 /-- If m is in the range of g, the partial inverse is defined at m. -/
 lemma partialInverse_dom {g : ℕ → ℕ} {m : ℕ} (hm : ∃ k, g k = m) :
     (partialInverse g m).Dom := by
-  sorry
+  unfold partialInverse
+  obtain ⟨k, hk⟩ := hm
+  obtain ⟨n, hn, -⟩ := Nat.rfind_min' (p := fun n => decide (g n = m)) (by simp [hk])
+  exact Part.dom_iff_mem.mpr ⟨n, hn⟩
 
 end SchroederBernsteinOQ03.Aristotle


### PR DESCRIPTION
## Summary

Closes 26 Aristotle sorries across 9 Lean proof files by providing direct proofs using Mathlib lemmas.

**Batch 1 (commit 1):**
- `BezoutIdentityOQ01Aristotle.lean`: 5 gcd lemmas (Nat.gcd_self, gcd_comm, gcd_zero_left, gcd_dvd_left, gcd_pos_of_pos_left)
- `AlgebraicNumbersCountableAristotle.lean`: 5 countability lemmas (Set.countable_univ, Finset.countable_toSet, Finite.countable)
- `DivisibilityByThreeOQ01OQ02Aristotle.lean`: digitSum_pos for n ≥ 10 via List.getLast_mem + List.single_le_sum + omega

**Batch 2 (commit 2):**
- `AMGMInequalityAristotle.lean`: 5 real number lemmas (sq_nonneg, nlinarith, sqrt_sq, mul_nonneg, div_nonneg)

**Batch 3 (commit 3):**
- `Erdos512Aristotle.lean`: expSumNorm_continuous (Complex.continuous_abs.comp + continuous_finset_sum + fun_prop); L1norm_le_card (setIntegral_mono_on + Real.volume_Icc)
- `Erdos620Problem.lean` + `Erdos620ProblemAristotle.lean`: turan_is_K4Free (rintro + omega on residues mod 3)
- `Erdos625ProblemAristotle.lean`: cochromatic_coloring_exists_ari (Fintype.equivFin singleton coloring)
- `Erdos922Aristotle.lean`: bipartite_chromatic_le_two (IsBipartite.chromaticNumber_le); ratio_ge_of_two_card_bound (cast + nlinarith)
- `Erdos933ProblemAristotle.lean`: power2/power3_consecutive_ari (factorization_mul + Finsupp.add_apply)
- `SchroederBernsteinOQ03Aristotle.lean`: partialInverse_spec (rfind_spec + of_decide_eq_true); partialInverse_dom (rfind_min' + Part.dom_iff_mem)

## Test plan
- [ ] CI/lake build validates Lean proofs compile
- [ ] No new axioms introduced
- [ ] All sorries are removed from targeted theorems

🤖 Generated with [Claude Code](https://claude.com/claude-code)