### PR TITLE
Fix minkowski-fundamental-theorem-oq-04: restructure meta.json flat→nested

### DIFF
--- a/src/data/proofs/minkowski-fundamental-theorem-oq-04/meta.json
+++ b/src/data/proofs/minkowski-fundamental-theorem-oq-04/meta.json
@@ -1,22 +1,25 @@
 {
   "id": "minkowski-fundamental-theorem-oq-04",
   "title": "Minkowski's Theorem: Custom Lattice API vs ZLattice Comparison",
+  "slug": "minkowski-fundamental-theorem-oq-04",
   "parentId": "minkowski-fundamental-theorem",
   "openQuestionIndex": 4,
-  "description": "A formal comparison between the custom Lattice API used in the parent Minkowski proof and Mathlib's ZSpan/ZLattice infrastructure. Proves the central equivalence: the custom covolume |det(L.basis)| equals the ZSpan fundamental domain volume. Also constructs the inverse map (Module.Basis → Lattice) and shows the ZSpan-native Minkowski theorem implies the custom-API version.",
-  "status": "formalized",
-  "badge": "wip",
-  "sorries": 0,
-  "axiomCount": 0,
-  "leanFile": "Proofs/MinkowskiFundamentalTheoremOQ04.lean",
-  "namespace": "MinkowskiOQ04",
-  "tags": ["number-theory", "lattices", "mathlib", "geometry-of-numbers", "api-comparison"],
+  "description": "A planned formal comparison between the custom Lattice API used in the parent Minkowski proof and Mathlib's ZSpan/ZLattice infrastructure. The central goal is to prove the equivalence: the custom covolume |det(L.basis)| equals the ZSpan fundamental domain volume. Also aims to construct the inverse map (Module.Basis → Lattice) and show the ZSpan-native Minkowski theorem implies the custom-API version. NOTE: The Lean source file has not yet been created.",
+  "meta": {
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/MinkowskiFundamentalTheoremOQ04.lean",
+    "tags": ["number-theory", "lattices", "mathlib", "geometry-of-numbers", "api-comparison"],
+    "badge": "wip",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-04-24"
+  },
   "keyResults": [
-    "covolume_eq_volume_fundamentalDomain: ENNReal.ofReal L.covolume = vol(ZSpan.fundamentalDomain (L.toModuleBasis n))",
-    "basis_det_ne_zero: (Matrix.of b).det ≠ 0 for any Basis (Fin n) ℝ (Fin n → ℝ)",
-    "Lattice.ofBasis: every Module.Basis gives a custom Lattice",
-    "instIsZLatticeCustom: the ZSpan of a custom lattice is IsZLattice",
-    "minkowski_custom_via_zlattice: custom Minkowski ← ZSpan Minkowski"
+    "covolume_eq_volume_fundamentalDomain: ENNReal.ofReal L.covolume = vol(ZSpan.fundamentalDomain (L.toModuleBasis n)) [planned]",
+    "basis_det_ne_zero: (Matrix.of b).det ≠ 0 for any Basis (Fin n) ℝ (Fin n → ℝ) [planned]",
+    "Lattice.ofBasis: every Module.Basis gives a custom Lattice [planned]",
+    "instIsZLatticeCustom: the ZSpan of a custom lattice is IsZLattice [planned]",
+    "minkowski_custom_via_zlattice: custom Minkowski ← ZSpan Minkowski [planned]"
   ],
   "mathBackground": "The custom Lattice type wraps a basis matrix with an invertibility condition. Mathlib's ZSpan approach abstracts this as Submodule.span ℤ (Set.range b) for a Module.Basis b. The central bridge is ZSpan.volume_fundamentalDomain, which shows vol(fundamentalDomain b) = ENNReal.ofReal |(Matrix.of b).det|."
 }


### PR DESCRIPTION
## Summary

- **Root cause**: `minkowski-fundamental-theorem-oq-04/meta.json` used a flat JSON structure instead of the standard nested `meta` object. `find-targets.ts` reads `meta.meta` for status/badge/sorries, so it saw `claimedSorries: -1` (undefined → -1 default), triggering a false sorry-mismatch alert.
- **Secondary issue**: The referenced Lean file (`Proofs/MinkowskiFundamentalTheoremOQ04.lean`) has never existed in git history, but the entry claimed `status: "formalized"`. Changed to `status: "axiomatized"` with `badge: "wip"` and updated the description to note the file is pending creation.

## Changes

- Restructured `meta.json` to use standard nested `meta` object (adds `slug`, moves `status`, `badge`, `sorries`, `axiomCount`, `leanFile` → `proofRepoPath` into `meta` sub-object)
- `status`: `"formalized"` → `"axiomatized"` (no Lean source exists)
- Description updated to clarify this is a planned formalization
- `keyResults` entries marked `[planned]` to be accurate

## Audit Result

This was the only unaudited entry (1 of 2143). After this fix the auditor tool will correctly read the entry and report `claims 0, actual 0` (no mismatch) once the entry is re-audited.

---
Discovered during gallery integrity audit.