### PR TITLE
Fix erdos-620: correct sorry count (5→4)

### DIFF
--- a/src/data/proofs/erdos-620/meta.json
+++ b/src/data/proofs/erdos-620/meta.json
@@ -17,7 +17,7 @@
       "erdos"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 4,
     "erdosNumber": 620,
     "erdosUrl": "https://erdosproblems.com/620",
     "erdosProblemStatus": "open",
@@ -240,7 +240,7 @@
     "theoremCount": 8,
     "definitionCount": 15,
     "path": "Proofs/Erdos620Problem.lean",
-    "sorries": 5
+    "sorries": 4
   },
-  "sorries": 5
+  "sorries": 4
 }


### PR DESCRIPTION
## Summary

Gallery integrity fix — `meta.json` claimed 5 sorries but the committed Lean file (`proofs/Proofs/Erdos620Problem.lean`) has only 4 actual `sorry` instances (at lines 184, 209, 231, 247).

## Changes

Updated all three `"sorries"` fields in `src/data/proofs/erdos-620/meta.json`:
- `meta.sorries`: 5 → 4
- `leanFile.sorries`: 5 → 4
- Top-level `sorries`: 5 → 4

## Test plan

- [x] Verified diff touches only the three `"sorries": 5` → `"sorries": 4` lines
- [x] JSON validated with `python3 -m json.tool` (no syntax errors)
- [x] Confirmed no remaining `"sorries": 5` in the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)