### PR TITLE
Fix: correct sorry count and description for minkowski-fundamental-theorem-oq-04

### DIFF
--- a/src/data/proofs/minkowski-fundamental-theorem-oq-04/meta.json
+++ b/src/data/proofs/minkowski-fundamental-theorem-oq-04/meta.json
@@ -4,22 +4,22 @@
   "slug": "minkowski-fundamental-theorem-oq-04",
   "parentId": "minkowski-fundamental-theorem",
   "openQuestionIndex": 4,
-  "description": "A planned formal comparison between the custom Lattice API used in the parent Minkowski proof and Mathlib's ZSpan/ZLattice infrastructure. The central goal is to prove the equivalence: the custom covolume |det(L.basis)| equals the ZSpan fundamental domain volume. Also aims to construct the inverse map (Module.Basis → Lattice) and show the ZSpan-native Minkowski theorem implies the custom-API version. NOTE: The Lean source file has not yet been created.",
+  "description": "A formal comparison between the custom Lattice API used in the parent Minkowski proof and Mathlib's ZSpan/ZLattice infrastructure. The central goal is to prove the equivalence: the custom covolume |det(L.basis)| equals the ZSpan fundamental domain volume. Also constructs the inverse map (Module.Basis → Lattice) and shows the ZSpan-native Minkowski theorem implies the custom-API version. The covolume bridge theorem and round-trip lemma are proved; two theorems remain as sorries.",
   "meta": {
     "status": "axiomatized",
     "proofRepoPath": "Proofs/MinkowskiFundamentalTheoremOQ04.lean",
     "tags": ["number-theory", "lattices", "mathlib", "geometry-of-numbers", "api-comparison"],
     "badge": "wip",
-    "sorries": 0,
+    "sorries": 2,
     "axiomCount": 0,
     "dateAdded": "2026-04-24"
   },
   "keyResults": [
-    "covolume_eq_volume_fundamentalDomain: ENNReal.ofReal L.covolume = vol(ZSpan.fundamentalDomain (L.toModuleBasis n)) [planned]",
-    "basis_det_ne_zero: (Matrix.of b).det ≠ 0 for any Basis (Fin n) ℝ (Fin n → ℝ) [planned]",
-    "Lattice.ofBasis: every Module.Basis gives a custom Lattice [planned]",
-    "instIsZLatticeCustom: the ZSpan of a custom lattice is IsZLattice [planned]",
-    "minkowski_custom_via_zlattice: custom Minkowski ← ZSpan Minkowski [planned]"
+    "covolume_eq_volume_fundamentalDomain: ENNReal.ofReal L.covolume = vol(ZSpan.fundamentalDomain (L.toModuleBasis n)) [proved]",
+    "basis_det_ne_zero: (Matrix.of b).det ≠ 0 for any Basis (Fin n) ℝ (Fin n → ℝ) [sorry]",
+    "Lattice.ofBasis: every Module.Basis gives a custom Lattice [proved (depends on basis_det_ne_zero)]",
+    "ofBasis_toModuleBasis: round-trip identity on basis matrix [proved]",
+    "minkowski_custom_via_zlattice: custom Minkowski ← ZSpan Minkowski [sorry]"
   ],
   "mathBackground": "The custom Lattice type wraps a basis matrix with an invertibility condition. Mathlib's ZSpan approach abstracts this as Submodule.span ℤ (Set.range b) for a Module.Basis b. The central bridge is ZSpan.volume_fundamentalDomain, which shows vol(fundamentalDomain b) = ENNReal.ofReal |(Matrix.of b).det|."
 }


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: minkowski-fundamental-theorem-oq-04

## Issues Found

1. **Sorry count mismatch (HIGH)**: `meta.json` claimed `sorries: 0` but the Lean file `MinkowskiFundamentalTheoremOQ04.lean` has 2 actual `sorry`s:
   - Line 47: `basis_det_ne_zero` theorem
   - Line 82: `minkowski_custom_via_zlattice` theorem

2. **Stale description**: Description said "NOTE: The Lean source file has not yet been created" but the file exists and contains partial proofs.

## Changes

- `sorries: 0` → `sorries: 2`
- Removed stale note about missing Lean file
- Updated `keyResults` to accurately reflect which theorems are proved vs sorry'd

---
Discovered during gallery integrity audit.