### PR TITLE
Fix: correct sorry count for erdos-620 (5→4)

### DIFF
--- a/src/data/proofs/erdos-620/meta.json
+++ b/src/data/proofs/erdos-620/meta.json
@@ -17,7 +17,7 @@
       "erdos"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 4,
     "erdosNumber": 620,
     "erdosUrl": "https://erdosproblems.com/620",
     "erdosProblemStatus": "open",
@@ -240,7 +240,7 @@
     "theoremCount": 8,
     "definitionCount": 15,
     "path": "Proofs/Erdos620Problem.lean",
-    "sorries": 5
+    "sorries": 4
   },
-  "sorries": 5
+  "sorries": 4
 }


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: erdos-620 (Erdős Problem #620: The Erdős-Rogers Problem)

## Issue Found

**Sorry count mismatch (HIGH)**: `meta.json` claimed `sorries: 5` in three places, but the Lean file `Erdos620Problem.lean` has only 4 actual `sorry`s:
- Line 184
- Line 209
- Line 231  
- Line 247

## Changes

Updated `sorries: 5` → `sorries: 4` in:
- `meta.sorries`
- `leanFile.sorries`
- Top-level `sorries`

---
Discovered during gallery integrity audit (second pass — first pass on 2026-04-03 also flagged this mismatch).