### PR TITLE
Add Aristotle companion for Erdős #628 (2 perfect graph targets)

### DIFF
--- a/proofs/Proofs/Erdos628ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos628ProblemAristotle.lean
@@ -1,0 +1,63 @@
+/-
+  Aristotle targets for Erdős Problem #628
+  Routine supporting lemmas about perfect graphs and chromatic structure
+  for automated proof search.
+  See Erdos628Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the open Tihany conjecture (general case unknown)
+  - NOT deep structural results (contains_critical, critical_min_degree, etc.)
+  - Basic consequences of the IsPerfect definition that follow immediately
+  - No definition sorries, no axioms, no open conjectures
+
+  Included targets (2):
+  - perfect_clique_free: IsPerfect G → IsCliqueFree G (chromaticNumber G + 1)
+  - perfect_tihany_vacuous: IsPerfect G → chromaticNumber G = k → ¬IsCliqueFree G k
+
+  Excluded (too deep or depends on def sorries):
+  - contains_critical: requires structure theory of chromatic number
+  - critical_min_degree: requires deletion-contraction argument
+  - weak_splittability: requires partition argument
+  - tihany_a_eq_2: requires understanding of (2,b)-splittability
+  - odd_cycle_chi_3: requires cycle graph chromatic number from Mathlib
+  - disjoint_odd_cycles_splittable: has sorry in hypothesis type (invalid)
+-/
+
+import Mathlib
+import Proofs.GraphCore
+
+open Finset Function Nat GraphCore
+open SimpleGraph hiding chromaticNumber
+
+namespace Erdos628.Aristotle
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+/- ## Definitions mirrored from main file -/
+
+/-- A graph is K_k-free (contains no k-clique) -/
+def IsCliqueFree (G : SimpleGraph V) (k : ℕ) : Prop :=
+  cliqueNumber G < k
+
+/-- A graph is perfect if χ(H) = ω(H) for all induced subgraphs -/
+def IsPerfect (G : SimpleGraph V) : Prop :=
+  ∀ S : Finset V, chromaticNumber (G.induce S) = cliqueNumber (G.induce S)
+
+/- ## Routine lemmas about perfect graphs -/
+
+/-- Perfect graphs are K_{χ+1}-free (trivially from χ = ω).
+    Proof: IsPerfect applied to Finset.univ gives chromaticNumber G = cliqueNumber G,
+    so cliqueNumber G < chromaticNumber G + 1. -/
+theorem perfect_clique_free (G : SimpleGraph V) (hperf : IsPerfect G) :
+    IsCliqueFree G (chromaticNumber G + 1) := by
+  sorry
+
+/-- For perfect graphs, Tihany is vacuous: having χ = k means ω = k, so G has K_k.
+    Proof: IsPerfect applied to Finset.univ gives chromaticNumber G = cliqueNumber G.
+    With chromaticNumber G = k, we get cliqueNumber G = k, so ¬(cliqueNumber G < k). -/
+theorem perfect_tihany_vacuous (G : SimpleGraph V) (hperf : IsPerfect G)
+    (k : ℕ) (hχ : chromaticNumber G = k) :
+    ¬IsCliqueFree G k := by
+  sorry
+
+end Erdos628.Aristotle


### PR DESCRIPTION
## Summary

Creates `proofs/Proofs/Erdos628ProblemAristotle.lean` as an Aristotle companion file for Erdős Problem #628 (the Erdős-Lovász Tihany conjecture). This exposes 2 routine perfect-graph lemmas for automated proof search.

## Included targets

- **`perfect_clique_free`**: `IsPerfect G → IsCliqueFree G (chromaticNumber G + 1)` — Perfect graphs are K_{χ+1}-free. Follows immediately from applying `IsPerfect` to `Finset.univ`, giving `chromaticNumber G = cliqueNumber G`, so `cliqueNumber G < chromaticNumber G + 1`.

- **`perfect_tihany_vacuous`**: `IsPerfect G → chromaticNumber G = k → ¬IsCliqueFree G k` — For perfect graphs, the Tihany hypothesis (χ = k, K_k-free) is vacuously unsatisfiable: if χ = ω = k then G contains K_k, contradicting K_k-freeness.

## Why these targets

These are basic consequences of the `IsPerfect` definition that follow immediately by unfolding definitions and applying `Nat.lt_succ_self` or `Nat.lt_irrefl`. No deep structural lemmas needed.

## Excluded targets

- `contains_critical` — requires structure theory of chromatic number (deep)
- `critical_min_degree` — requires deletion-contraction argument (deep)
- `weak_splittability` — requires partition argument (deep)
- `tihany_a_eq_2` — requires understanding of (2,b)-splittability (deep)
- `odd_cycle_chi_3` — requires cycle graph chromatic number from Mathlib (deep)
- `disjoint_odd_cycles_splittable` — has sorry in hypothesis type (Aristotle-invalid)

## Pre-submission checklist

- No `def` sorries
- No `axiom` declarations
- No `theorem ... : True` stubs
- No `/-!` docstrings (uses `/-` throughout)
- No open conjectures as targets