### PR TITLE
Add Aristotle companion for Erdős #627 (2 chi/omega targets)

### DIFF
--- a/proofs/Proofs/Erdos627ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos627ProblemAristotle.lean
@@ -1,0 +1,49 @@
+/-
+  Aristotle targets for Erdős Problem #627: Chromatic Number and Clique Number Ratio
+
+  Routine supporting lemmas for automated proof search.
+  See Erdos627Problem.lean for the main formalization.
+
+  Candidates:
+  - chi_ge_omega: χ(G) ≥ ω(G) always (coloring lower bound)
+  - ratio_ge_one: chiOmegaRatio G ≥ 1 when cliqueNumber G > 0
+
+  Excluded:
+  - f (n : ℕ) : ℝ — def sorry, skip
+  - f_ge_one, f_monotone, f_unbounded — depend on def sorry f
+  - f_normalized_bounded — depends on def sorry f via fNormalized
+  - triangle_free_large_chi — sorry inside lambda (not top-level)
+  - ramseyNumber — def sorry, skip
+  - f_ramsey_lower_bound — depends on def sorry ramseyNumber
+  - mycielskiGraph, kneserGraph — def sorry, skip
+-/
+import Mathlib
+import Proofs.GraphCore
+
+namespace Erdos627Problem.Aristotle
+
+open Finset Function Nat GraphCore
+open SimpleGraph hiding chromaticNumber
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+/-- The ratio χ(G)/ω(G), mirrored from Erdos627Problem.chiOmegaRatio. -/
+noncomputable def chiOmegaRatio (G : SimpleGraph V) : ℝ :=
+  (chromaticNumber G : ℝ) / (cliqueNumber G : ℝ)
+
+/-- χ(G) ≥ ω(G) always (coloring lower bound).
+    Any k-clique S requires k distinct colors in any proper coloring,
+    so chromaticNumber G ≥ k whenever ContainsClique G k holds,
+    and therefore chromaticNumber G ≥ cliqueNumber G. -/
+theorem chi_ge_omega (G : SimpleGraph V) :
+    chromaticNumber G ≥ cliqueNumber G := by
+  sorry
+
+/-- The ratio χ(G)/ω(G) is at least 1 when ω(G) > 0.
+    Follows from chi_ge_omega: chromaticNumber G ≥ cliqueNumber G > 0,
+    so (chromaticNumber G : ℝ) / (cliqueNumber G : ℝ) ≥ 1. -/
+theorem ratio_ge_one (G : SimpleGraph V) (hω : cliqueNumber G > 0) :
+    chiOmegaRatio G ≥ 1 := by
+  sorry
+
+end Erdos627Problem.Aristotle


### PR DESCRIPTION
## Summary

- Adds `proofs/Proofs/Erdos627ProblemAristotle.lean`, a self-contained Aristotle companion for Erdős Problem #627 (Chromatic Number and Clique Number Ratio)
- Two theorem-sorry targets: `chi_ge_omega` (χ(G) ≥ ω(G) always) and `ratio_ge_one` (χ/ω ≥ 1 when ω > 0)
- Self-contained: imports `Mathlib` + `Proofs.GraphCore` directly (does not import the problem file), mirroring `chiOmegaRatio` locally

## Targets

| Theorem | Statement | Proof idea |
|---------|-----------|------------|
| `chi_ge_omega` | `chromaticNumber G ≥ cliqueNumber G` | Any k-clique needs k distinct colors; so chi ≥ k for all k with a k-clique, hence chi ≥ omega |
| `ratio_ge_one` | `chiOmegaRatio G ≥ 1` (when `cliqueNumber G > 0`) | Follows from chi_ge_omega: chi ≥ omega > 0, so real-valued ratio ≥ 1 |

## Excluded (per Aristotle rules)

- `f` — def sorry, excluded
- `f_ge_one`, `f_monotone`, `f_unbounded`, `f_normalized_bounded` — depend on def sorry `f`
- `triangle_free_large_chi` — sorry inside lambda, not a top-level theorem sorry
- `ramseyNumber`, `mycielskiGraph`, `kneserGraph` — def sorries

🤖 Generated with [Claude Code](https://claude.com/claude-code)