### PR TITLE
Enrich abel-ruffini: update cross-references and resolve gap note (pass 6)

### DIFF
--- a/src/data/proofs/abel-ruffini/annotations.json
+++ b/src/data/proofs/abel-ruffini/annotations.json
@@ -247,7 +247,7 @@
     },
     "type": "insight",
     "title": "Solvable Small Symmetric Groups: The Other Side of the Threshold",
-    "content": "$S_0$ and $S_1$ are trivially solvable (both are the trivial group of order 1), and Lean's typeclass inference (`inferInstance`) finds their `IsSolvable` instances automatically. These contrast with $S_5$ and beyond, highlighting the sharp boundary.\n\nHistorically, $S_2$ (quadratic formula, ~2000 BCE), $S_3$ (Cardano's cubic formula, 1545), and $S_4$ (Ferrari's quartic formula, 1545) are all solvable — each corresponding to a classical radical formula. The gallery includes formalizations of both the cubic solution (see `solution-of-cubic`) and the quartic solution (see `general-quartic`), providing the positive counterparts to Abel-Ruffini's impossibility: those proofs construct the radical formulas that exist precisely because $S_3$ and $S_4$ are solvable. Together with Abel-Ruffini, they form a complete picture of radical solvability for polynomials of every degree.\n\nThe file notes that Mathlib did not yet provide `IsSolvable` instances for $S_2, S_3, S_4$ at time of writing.",
+    "content": "$S_0$ and $S_1$ are trivially solvable (both are the trivial group of order 1), and Lean's typeclass inference (`inferInstance`) finds their `IsSolvable` instances automatically. These contrast with $S_5$ and beyond, highlighting the sharp boundary.\n\nHistorically, $S_2$ (quadratic formula, ~2000 BCE), $S_3$ (Cardano's cubic formula, 1545), and $S_4$ (Ferrari's quartic formula, 1545) are all solvable — each corresponding to a classical radical formula. The gallery includes formalizations of both the cubic solution (see `solution-of-cubic`) and the quartic solution (see `general-quartic`), providing the positive counterparts to Abel-Ruffini's impossibility: those proofs construct the radical formulas that exist precisely because $S_3$ and $S_4$ are solvable. Together with Abel-Ruffini, they form a complete picture of radical solvability for polynomials of every degree.\n\nThe file notes that Mathlib did not yet provide `IsSolvable` instances for $S_2, S_3, S_4$ at time of writing. **[Gap now filled]** The companion entry `abel-ruffini-oq-04-oq-02` provides these instances explicitly: $S_2$ via commutativity (`isSolvable_of_comm`), $S_3$ via the short exact sequence $1 \\to A_3 \\to S_3 \\to \\mathbb{Z}^\\times \\to 1$ using `solvable_of_ker_le_range`, and $S_4$ via the Klein four-group $V_4 \\trianglelefteq A_4$ yielding the chain $\\{e\\} \\trianglelefteq V_4 \\trianglelefteq A_4 \\trianglelefteq S_4$. Together with the current entry's `symmetric_group_not_solvable`, these instances complete the full biconditional: $S_n$ is solvable if and only if $n \\leq 4$.",
     "mathContext": "$S_0 \\cong S_1 \\cong \\{e\\}$ (trivial). $S_2 \\cong \\mathbb{Z}/2$ (abelian). $S_3$: derived series $S_3 \\triangleright A_3 \\cong \\mathbb{Z}/3 \\triangleright \\{e\\}$. $S_4$: derived series $S_4 \\triangleright A_4 \\triangleright V_4 \\triangleright \\mathbb{Z}/2 \\triangleright \\{e\\}$, where $V_4 = \\{e,(12)(34),(13)(24),(14)(23)\\}$ is the Klein four-group.\n\nEach solvable $S_n$ ($n \\leq 4$) yields a composition series with abelian quotients, and the Galois correspondence converts these quotients into radical extraction steps: $S_2/A_2 \\cong \\mathbb{Z}/2$ gives square roots, $A_3 \\cong \\mathbb{Z}/3$ gives cube roots, $A_4/V_4 \\cong \\mathbb{Z}/3$ and $V_4/(\\mathbb{Z}/2) \\cong \\mathbb{Z}/2$ give the nested radicals in Ferrari's formula.",
     "significance": "supporting",
     "prerequisites": [
@@ -261,7 +261,9 @@
       "typeclass inference",
       "quadratic formula",
       "Cardano's formula",
-      "Ferrari's formula"
+      "Ferrari's formula",
+      "abel-ruffini-oq-04-oq-02",
+      "solvable_of_ker_le_range"
     ]
   },
   {
@@ -331,7 +333,9 @@
       "contrapositive reasoning",
       "proof by contradiction",
       "irreducible polynomial",
-      "Galois group computation"
+      "Galois group computation",
+      "abel-ruffini-oq-04-oq-01",
+      "inverse-galois-oq-06"
     ]
   },
   {

--- a/src/data/proofs/abel-ruffini/annotations.source.json
+++ b/src/data/proofs/abel-ruffini/annotations.source.json
@@ -254,7 +254,7 @@
     },
     "type": "insight",
     "title": "Solvable Small Symmetric Groups: The Other Side of the Threshold",
-    "content": "$S_0$ and $S_1$ are trivially solvable (both are the trivial group of order 1), and Lean's typeclass inference (`inferInstance`) finds their `IsSolvable` instances automatically. These contrast with $S_5$ and beyond, highlighting the sharp boundary.\n\nHistorically, $S_2$ (quadratic formula, ~2000 BCE), $S_3$ (Cardano's cubic formula, 1545), and $S_4$ (Ferrari's quartic formula, 1545) are all solvable — each corresponding to a classical radical formula. The gallery includes formalizations of both the cubic solution (see `solution-of-cubic`) and the quartic solution (see `general-quartic`), providing the positive counterparts to Abel-Ruffini's impossibility: those proofs construct the radical formulas that exist precisely because $S_3$ and $S_4$ are solvable. Together with Abel-Ruffini, they form a complete picture of radical solvability for polynomials of every degree.\n\nThe file notes that Mathlib did not yet provide `IsSolvable` instances for $S_2, S_3, S_4$ at time of writing.",
+    "content": "$S_0$ and $S_1$ are trivially solvable (both are the trivial group of order 1), and Lean's typeclass inference (`inferInstance`) finds their `IsSolvable` instances automatically. These contrast with $S_5$ and beyond, highlighting the sharp boundary.\n\nHistorically, $S_2$ (quadratic formula, ~2000 BCE), $S_3$ (Cardano's cubic formula, 1545), and $S_4$ (Ferrari's quartic formula, 1545) are all solvable — each corresponding to a classical radical formula. The gallery includes formalizations of both the cubic solution (see `solution-of-cubic`) and the quartic solution (see `general-quartic`), providing the positive counterparts to Abel-Ruffini's impossibility: those proofs construct the radical formulas that exist precisely because $S_3$ and $S_4$ are solvable. Together with Abel-Ruffini, they form a complete picture of radical solvability for polynomials of every degree.\n\nThe file notes that Mathlib did not yet provide `IsSolvable` instances for $S_2, S_3, S_4$ at time of writing. **[Gap now filled]** The companion entry `abel-ruffini-oq-04-oq-02` provides these instances explicitly: $S_2$ via commutativity (`isSolvable_of_comm`), $S_3$ via the short exact sequence $1 \\to A_3 \\to S_3 \\to \\mathbb{Z}^\\times \\to 1$ using `solvable_of_ker_le_range`, and $S_4$ via the Klein four-group $V_4 \\trianglelefteq A_4$ yielding the chain $\\{e\\} \\trianglelefteq V_4 \\trianglelefteq A_4 \\trianglelefteq S_4$. Together with the current entry's `symmetric_group_not_solvable`, these instances complete the full biconditional: $S_n$ is solvable if and only if $n \\leq 4$.",
     "mathContext": "$S_0 \\cong S_1 \\cong \\{e\\}$ (trivial). $S_2 \\cong \\mathbb{Z}/2$ (abelian). $S_3$: derived series $S_3 \\triangleright A_3 \\cong \\mathbb{Z}/3 \\triangleright \\{e\\}$. $S_4$: derived series $S_4 \\triangleright A_4 \\triangleright V_4 \\triangleright \\mathbb{Z}/2 \\triangleright \\{e\\}$, where $V_4 = \\{e,(12)(34),(13)(24),(14)(23)\\}$ is the Klein four-group.\n\nEach solvable $S_n$ ($n \\leq 4$) yields a composition series with abelian quotients, and the Galois correspondence converts these quotients into radical extraction steps: $S_2/A_2 \\cong \\mathbb{Z}/2$ gives square roots, $A_3 \\cong \\mathbb{Z}/3$ gives cube roots, $A_4/V_4 \\cong \\mathbb{Z}/3$ and $V_4/(\\mathbb{Z}/2) \\cong \\mathbb{Z}/2$ give the nested radicals in Ferrari's formula.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -263,7 +263,9 @@
       "typeclass inference",
       "quadratic formula",
       "Cardano's formula",
-      "Ferrari's formula"
+      "Ferrari's formula",
+      "abel-ruffini-oq-04-oq-02",
+      "solvable_of_ker_le_range"
     ],
     "prerequisites": [
       "IsSolvable typeclass",
@@ -335,7 +337,9 @@
       "contrapositive reasoning",
       "proof by contradiction",
       "irreducible polynomial",
-      "Galois group computation"
+      "Galois group computation",
+      "abel-ruffini-oq-04-oq-01",
+      "inverse-galois-oq-06"
     ],
     "prerequisites": [
       "galois_bridge",


### PR DESCRIPTION
Enrichment pass 6 for `abel-ruffini`. Entry is at quality 100 with 5 prior passes; all peer review action items already resolved. This pass updates cross-references to reflect the current state of the gallery.

## Changes

**annotations.source.json / annotations.json**

- `ann-small-solvable` content: Acknowledge that the Mathlib gap for `IsSolvable` instances of S₂, S₃, S₄ is now filled by `abel-ruffini-oq-04-oq-02`, with specifics of how each case is proved.

- `ann-small-solvable` `relatedConcepts`: Added `abel-ruffini-oq-04-oq-02` and `solvable_of_ker_le_range`.

- `ann-contrapositive` `relatedConcepts`: Added `abel-ruffini-oq-04-oq-01` and `inverse-galois-oq-06` (both mentioned in content as concrete witnesses; adding them to relatedConcepts makes cross-linking explicit).