### PR TITLE
Fix: correct fourier-series-oq-04 status (verified→formalized, badge→wip)

### DIFF
--- a/src/data/proofs/fourier-series-oq-04/meta.json
+++ b/src/data/proofs/fourier-series-oq-04/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Fefferman (1971), Stein & Weiss (1971)",
     "date": "1971",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/FourierSeriesOQ04.lean",
     "tags": [
       "harmonic-analysis",
@@ -16,7 +16,7 @@
       "bochner-riesz",
       "carleson-conjecture"
     ],
-    "badge": "verified",
+    "badge": "wip",
     "sorries": 0,
     "dateAdded": "2026-03-30",
     "axiomCount": 0,


### PR DESCRIPTION
## Fix

Corrects the `status` and `badge` fields in `src/data/proofs/fourier-series-oq-04/meta.json`.

## Evidence

**Before**: `status: "verified"`, `badge: "verified"` — incorrectly claims the proof is fully machine-checked.

**After**: `status: "formalized"`, `badge: "wip"` — correctly identifies this as a scaffold with type definitions and placeholder stubs only.

The `assumptions` field already stated: *"Scaffold only. The Lean file contains type definitions and placeholder stubs (returning 0) but no theorems. No mathematical results are proved."* The `status` and `badge` now match this description.

Closes #12096

---
Automated fix by lean-mechanic agent.