### PR TITLE
Enrich prob-method-alteration: derandomization insights, Shannon/MaxCut cross-refs

### DIFF
--- a/src/data/proofs/prob-method-alteration/annotations.json
+++ b/src/data/proofs/prob-method-alteration/annotations.json
@@ -31,15 +31,17 @@
       "endLine": 38
     },
     "type": "insight",
-    "title": "Alteration Principle (Deterministic Core)",
-    "content": "This theorem captures the deterministic essence of the alteration method. Given a nonempty finite set $S$ and integer-valued functions `good` and `bad`, if the net good value summed over $S$ is positive, then some element achieves positive net good value. This is essentially a pigeonhole argument: if every element had non-positive net value, the sum could not be positive.\n\nThe formalization uses integer coercions ($\\mathbb{Z}$) to handle the subtraction cleanly, since natural number subtraction in Lean truncates at zero.",
-    "mathContext": "If $\\sum_{a \\in S} \\text{good}(a) - \\sum_{a \\in S} \\text{bad}(a) > 0$ over a nonempty finite set $S$, then $\\exists a \\in S$ such that $\\text{good}(a) - \\text{bad}(a) > 0$. This is the first moment method in disguise: if the average of $\\text{good} - \\text{bad}$ is positive, some element exceeds the average.",
+    "title": "Alteration Principle (Deterministic Core and Derandomization Bridge)",
+    "content": "This theorem captures the deterministic essence of the alteration method. Given a nonempty finite set $S$ and integer-valued functions `good` and `bad`, if the net good value summed over $S$ is positive, then some element achieves positive net good value. This is essentially a pigeonhole argument: if every element had non-positive net value, the sum could not be positive.\n\nThe formalization uses integer coercions ($\\mathbb{Z}$) to handle the subtraction cleanly, since natural number subtraction in Lean truncates at zero.\n\n**Derandomization bridge**: The same algebraic structure (`sum positive → some element positive`) is the core of the **method of conditional expectations** — the canonical technique for converting probabilistic existence proofs into efficient deterministic algorithms. In the Erdős-Selfridge pessimistic estimator for Property B, one processes variables (vertex colorings) sequentially, always choosing the value that does not increase the potential $\\Phi = \\sum_{e} 2^{-|e \\cap S|}$. The condition $\\mathbb{E}[\\Phi] < 1$ ensures the greedy rule always has a valid choice — the same inequality this theorem proves. The gallery entry `randomized-maxcut-oq-04` formalizes this derandomization for MaxCut, showing the exact same Lean proof structure.",
+    "mathContext": "If $\\sum_{a \\in S} \\text{good}(a) - \\sum_{a \\in S} \\text{bad}(a) > 0$ over a nonempty finite set $S$, then $\\exists a \\in S$ such that $\\text{good}(a) - \\text{bad}(a) > 0$. Probabilistic version: if $\\mathbb{E}[v(X) - d(X)] > 0$, some outcome $X$ has $v(X) > d(X)$ — the first moment principle applied to $f = v - d$.",
     "significance": "key",
     "relatedConcepts": [
       "first moment method",
       "pigeonhole principle",
       "expected value linearity",
-      "integer coercion in Lean"
+      "method of conditional expectations",
+      "Erdős-Selfridge pessimistic estimator",
+      "randomized-maxcut-oq-04"
     ],
     "prerequisites": [
       "Finset.sum",

--- a/src/data/proofs/prob-method-alteration/meta.json
+++ b/src/data/proofs/prob-method-alteration/meta.json
@@ -62,7 +62,9 @@
       "Deleting defects is often cheaper than avoiding them: if expected defects are few, the altered structure retains most of the random construction's value",
       "The independent set bound n^2/(2m+n) is tight for regular graphs and was the best known for general sparse graphs for decades",
       "Property B results demonstrate that the alteration method applies beyond graph theory to hypergraph coloring",
-      "The alteration method can be derandomized via the method of conditional expectations, converting the existence proof into an efficient deterministic algorithm — this is the algorithmic significance of keeping the alteration step simple"
+      "The alteration method can be derandomized via the method of conditional expectations, converting the existence proof into an efficient deterministic algorithm — this is the algorithmic significance of keeping the alteration step simple",
+      "**Erdős-Selfridge pessimistic estimator**: The most elegant derandomization of the alteration method uses the Erdős-Selfridge potential function $\\Phi = \\sum_{e \\in \\mathcal{E}} 2^{-|e \\cap S|}$ where $S$ is the chosen set. If $\\Phi < 1$, no edge is monochromatic. At each step, choose the variable (color the next vertex) that does not increase $\\Phi$ — this greedy rule is deterministic and guaranteed to succeed by the same calculation showing the random argument works. The pessimistic estimator unifies the probabilistic and derandomization arguments: $\\mathbb{E}[\\Phi]$ is the condition making the original random argument work, and the sequential greedy rule maintains this condition deterministically.",
+      "**From existence to construction — the alteration paradigm**: The alteration method converts a non-constructive probabilistic argument ('there exists a good object') into a two-step construction: (1) random phase: pick a random object $X$; (2) fix-up phase: deterministically repair the $d(X)$ defects. The key quantitative condition is $\\mathbb{E}[v(X)] > \\mathbb{E}[d(X)]$ — the expected value exceeds the expected repair cost. This paradigm appears across computer science: Shannon's channel coding theorem uses it (random codebook + expurgation of bad codewords), network design uses it (random graph + augmentation), and compressed sensing uses it (random measurement matrix + sparse recovery). The `alteration_principle` theorem here is the abstract algebraic core of all these arguments."
     ],
     "prerequisites": [
       "Probabilistic method and first moment principle",
@@ -149,6 +151,16 @@
       "targetId": "binomial-theorem",
       "relationship": "foundational",
       "description": "Binomial coefficients underpin the probability calculations in the alteration method: random subset selection with probability $p$ creates a binomially distributed vertex count, and the expected edge count within the subset uses $\\binom{d}{2} p^2$ style calculations"
+    },
+    {
+      "targetId": "randomized-maxcut-oq-04",
+      "relationship": "related",
+      "description": "Formalizes the method of conditional expectations — the canonical derandomization of probabilistic existence proofs like the alteration method. The MaxCut derandomization processes vertices greedily, always choosing the side that doesn't increase a pessimistic estimator; this is precisely the Erdős-Selfridge technique that derandomizes the alteration argument for Property B. Both proofs have the same algebraic structure: the alteration_principle theorem (sum of net values positive → some element has positive net value) is the deterministic core of both arguments"
+    },
+    {
+      "targetId": "shannon-channel-coding",
+      "relationship": "related",
+      "description": "Shannon's proof of the channel coding theorem uses the same random-construction-then-alter paradigm as the alteration method: (1) random phase: pick a random codebook; (2) expurgation: delete the worst half of codewords (fixing decoding errors). The mathematical structure is identical to `alteration_principle`: $\\mathbb{E}[\\text{good}] > \\mathbb{E}[\\text{bad}]$ implies some codebook survives expurgation with positive rate. Both are instances of the alteration method applied in information theory vs. combinatorics"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Added 2 keyInsights: Erdős-Selfridge pessimistic estimator (the canonical derandomization of the alteration method via potential function Φ = Σ 2^{-|e∩S|}), and the abstract alteration paradigm in Shannon's channel coding theorem (random codebook + expurgation of bad codewords = alteration method in information theory)
- Added 2 cross-references: `randomized-maxcut-oq-04` (method of conditional expectations formalizes the same algebraic core as `alteration_principle`), `shannon-channel-coding` (random codebook + expurgation uses identical mathematical structure)
- Upgraded `ann-alteration-principle` annotation to include the derandomization bridge, connecting the Lean theorem to the Erdős-Selfridge pessimistic estimator and the gallery's MaxCut derandomization formalization

## Context
First enrichment pass for this entry. The alteration method's connection to derandomization (method of conditional expectations) is a major structural insight that was missing — the `alteration_principle` theorem is precisely the algebraic core that makes derandomization work, and this appears across combinatorics and information theory.

enrichment