### PR TITLE
Fix: correct sorry count for ballot-problem-oq-03-oq-01-oq-01-oq-01 (2→0)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -18,10 +18,10 @@
       "representation-theory"
     ],
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 0,
     "dateAdded": "2026-04-23",
     "axiomCount": 0,
-    "assumptions": "2 open sorries: ssytSchurFin_one_row (bijection SSYT→Sym, requires sorted-multiset bijection proof, line 251) and jacobi_trudi_ssyt_eq (general k≥2 case, requires RSK correspondence, line 283).",
+    "assumptions": "0 sorries. `jacobiTrudi_lgv_connection` is a proved tautology (schurPolynomial k sh = schurPolynomial k sh, by rfl) serving as a placeholder for the full LGV-SSYT combinatorial proof. The RSK correspondence (~400 lines) is the outstanding research item to replace this placeholder with a meaningful theorem.",
     "lineCount": 178,
     "theoremCount": 7,
     "definitionCount": 2,
@@ -54,8 +54,8 @@
     ]
   },
   "conclusion": {
-    "summary": "Defines Schur polynomials via the Jacobi-Trudi formula and proves base cases, symmetry, and the two-row formula. 2 sorries remain: ssytSchurFin_one_row (bijection SSYT→Sym) and jacobi_trudi_ssyt_eq (general k≥2, requires RSK correspondence).",
-    "implications": "This provides the first Lean 4 definition of Schur polynomials via the Jacobi-Trudi formula, which is the algebraically canonical definition connecting them to the representation theory of GL(n). 2 sorries remain (ssytSchurFin_one_row and jacobi_trudi_ssyt_eq). The RSK correspondence (~400 lines) is the outstanding research item. A completed formalization would unlock: the Pieri rule $s_\\lambda h_n = \\sum_\\mu s_\\mu$, the Murnaghan-Nakayama rule for character values, and connections to Schubert calculus. Schur polynomials are the backbone of algebraic combinatorics — once formalized, they would serve as building blocks for representation-theoretic calculations across the gallery.",
+    "summary": "Defines Schur polynomials via the Jacobi-Trudi formula and proves base cases, symmetry, and the two-row formula. 0 sorries remain. The LGV combinatorial connection theorem is a proved tautology (LHS = RHS by rfl) — a placeholder pending SSYT/RSK formalization (~400 lines).",
+    "implications": "This provides the first Lean 4 definition of Schur polynomials via the Jacobi-Trudi formula, which is the algebraically canonical definition connecting them to the representation theory of GL(n). All 7 theorems are proved (no sorries). The outstanding research item is formalizing the RSK correspondence (~400 lines) to replace the tautological `jacobiTrudi_lgv_connection` placeholder with a meaningful LGV-SSYT combinatorial proof. A completed formalization would unlock: the Pieri rule $s_\\lambda h_n = \\sum_\\mu s_\\mu$, the Murnaghan-Nakayama rule for character values, and connections to Schubert calculus. Schur polynomials are the backbone of algebraic combinatorics — once formalized, they would serve as building blocks for representation-theoretic calculations across the gallery.",
     "openQuestions": [
       "Formalize the RSK correspondence and SSYT→NI-path bijection to prove jacobiTrudi_lgv_proof",
       "Prove the Pieri rule: s_λ * h_n = Σ_{μ} s_μ where μ ranges over partitions obtained by adding n boxes to λ"
@@ -78,13 +78,13 @@
     "theoremCount": 7,
     "definitionCount": 2,
     "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
-    "sorries": 2
+    "sorries": 0
   },
   "crossReferences": [
     {
       "targetId": "ballot-problem-oq-03-oq-01-oq-01",
       "relationship": "parent",
-      "description": "Parent entry providing the LGV lemma infrastructure that the jacobiTrudi_lgv_connection sorry depends on. The parent formalizes the path-weight machinery and non-intersecting path determinant identity that, once connected to SSYT, gives the combinatorial proof of Jacobi-Trudi."
+      "description": "Parent entry providing the LGV lemma infrastructure that the jacobiTrudi_lgv_connection placeholder depends on. The parent formalizes the path-weight machinery and non-intersecting path determinant identity that, once connected to SSYT, gives the combinatorial proof of Jacobi-Trudi."
     },
     {
       "targetId": "ballot-problem-oq-03-oq-01-oq-02",
@@ -165,5 +165,5 @@
       "mathContext": "Full proof requires: (1) SSYT type and weight function (~100 lines), (2) RSK bijection SSYT ↔ NI paths (~200 lines), (3) weight matching with the LGV edge weights from the parent proof (~100 lines). The placeholder states `schurPolynomial k sh = schurPolynomial k sh` (tautology) until SSYT generating function is defined."
     }
   ],
-  "sorries": 2
+  "sorries": 0
 }


### PR DESCRIPTION
## Summary

- Corrects `"sorries": 2` → `"sorries": 0` in meta.json (3 occurrences: `meta.sorries`, `leanFile.sorries`, top-level `sorries`)
- Updates `assumptions` field: removes references to non-existent theorems `ssytSchurFin_one_row` (claimed at line 251) and `jacobi_trudi_ssyt_eq` (claimed at line 283) — the file is only 178 lines and contains neither
- Updates `conclusion.summary` and `conclusion.implications` to reflect the 0-sorry state
- Clarifies that `jacobiTrudi_lgv_connection` is a proved tautology (`rfl`), not a sorry

## Evidence

```bash
git show HEAD:proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean | grep -c "sorry"
# Output: 0
git show HEAD:proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean | wc -l
# Output: 178
```

The Lean file's own docstring confirms: `"## Status: badge=wip / All sorries proved."`

PR #12091 ("Fix: correct sorry count ... (0→2)") introduced the regression by referencing theorems that were never added to the file.

## Test plan

- [x] Verified 0 sorries in Lean source via `grep`
- [x] Verified file is 178 lines (no room for the claimed lines 251 and 283)
- [x] All 3 `"sorries"` fields corrected to 0

---
🤖 Gallery integrity audit — discovered by Lean Auditor