### PR TITLE
Enrich yang-mills-transfer-matrix-oq-01 and yang-mills-lattice-oq-01

### DIFF
--- a/src/data/proofs/yang-mills-lattice-oq-01/annotations.json
+++ b/src/data/proofs/yang-mills-lattice-oq-01/annotations.json
@@ -101,6 +101,28 @@
     ]
   },
   {
+    "id": "ym-lattice-oq01-corr-length",
+    "proofId": "yang-mills-lattice-oq-01",
+    "range": { "startLine": 165, "endLine": 218 },
+    "type": "insight",
+    "title": "Correlation Length and the Mass Gap–ξ Reciprocal Relation",
+    "content": "The correlation length ξ = 1/(-log(λ₁/λ₀)) measures how quickly the Schwinger function S₂(x,y) decays with temporal separation. The theorem mass_gap_times_corr_length establishes the exact reciprocal relation: Δ·ξ·a = 1, meaning a larger mass gap corresponds to a shorter correlation length and vice versa. This is the lattice encoding of the physical principle that a massive particle has a finite interaction range. The continuum limit requires ξ → ∞ in lattice units (a → 0) while the physical mass gap Δ stays finite — this is a second-order phase transition. The proof uses algebraic cancellation: (L/a)·(a/L) = 1 after unfolding the definition of correlationLengthLog.",
+    "mathContext": "$\\xi = 1/(-\\ln(\\lambda_1/\\lambda_0)) > 0$ when $\\lambda_1 < \\lambda_0$. Reciprocal: $\\Delta \\cdot \\xi \\cdot a = \\frac{-\\ln(\\lambda_1/\\lambda_0)}{a} \\cdot a \\cdot \\frac{1}{-\\ln(\\lambda_1/\\lambda_0)} = 1$. As $a \\to 0$: $\\xi \\to \\infty$ (long-range correlations), but $\\Delta = 1/(\\xi \\cdot a)$ stays finite if $a \\cdot \\xi \\to \\text{const}$ (renormalization group running).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "correlation length",
+      "mass gap",
+      "continuum limit",
+      "second-order phase transition",
+      "renormalization group"
+    ],
+    "prerequisites": [
+      "Real.log_neg",
+      "OSTransferMatrix",
+      "spectral gap"
+    ]
+  },
+  {
     "id": "ym-lattice-oq01-reconstruction-axiom",
     "proofId": "yang-mills-lattice-oq-01",
     "range": {

--- a/src/data/proofs/yang-mills-lattice-oq-01/index.ts
+++ b/src/data/proofs/yang-mills-lattice-oq-01/index.ts
@@ -1,9 +1,44 @@
 import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
-import sourceRaw from '../../../../proofs/Proofs/YangMillsLatticeOQ01.lean?raw'
-const meta = metaJson as unknown as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
-export const yangMillsLatticeOq01Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections || [], source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
-export const yangMillsLatticeOq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
-export const yangMillsLatticeOq01Data: ProofData = { proof: yangMillsLatticeOq01Proof, annotations: yangMillsLatticeOq01Annotations, tacticStates: [] }
-export default yangMillsLatticeOq01Data
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/YangMillsLatticeOQ01.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const proofData: ProofData = {
+  proof,
+  annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData


### PR DESCRIPTION
## Enrichment passes (enricher-3)

### PR 1: yang-mills-transfer-matrix-oq-01 (pass 1)

**Prior state**: meta.json well-populated, no annotations.json, incomplete index.ts

- Created `annotations.json` with 7 annotations covering all 5 parts:
  - Part I setup: FiniteVolumePFData, finiteVolumeMassGap definition with Perron-Frobenius context
  - Part II: finite-volume positivity via log monotonicity
  - Part III: strong coupling params, explicit gap formula ag²C₂/2, L-independence key theorem
  - SU(2)/SU(3) concrete gap values (3ag²/8 and 2ag²/3) with QCD context
  - Part IV: HasUniformMassGap definition and monotone gap condition
  - Part V: Seiler (1982) axiom with cluster expansion context and Millennium Prize
- Fixed index.ts: replaced bare `export { default as meta }` with full proof/annotations exports

### PR 2: yang-mills-lattice-oq-01 (pass 1)

**Prior state**: 9 annotations (all with mathContext), comprehensive meta.json; single-line index.ts

- Added annotation for lines 165–218 (previously uncovered):
  `ym-lattice-oq01-corr-length` covers `correlationLengthLog` definition, positivity proof,
  and `mass_gap_times_corr_length` (Δ·ξ·a = 1 reciprocal relation with continuum limit meaning)
- Reformatted index.ts to standard multi-line pattern with lazy Lean source loading

**Axiom integrity**: both proofs correctly declare their axiomCounts (1 and 2 respectively).