### PR TITLE
Fix: add missing top-level sorries field to dissection-of-cubes-oq-04

### DIFF
--- a/src/data/proofs/dissection-of-cubes-oq-04/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-04/meta.json
@@ -144,5 +144,6 @@
       "Can the remaining axiom (tmul_infinite_order_ne_zero — flatness of ℝ over ℤ) be proved using Mathlib's Module.Flat infrastructure?",
       "Can icoAngle_irrational be proved by extending the Chebyshev argument to ℤ[√5], completing the proof for all five Platonic solids with 0 axioms?"
     ]
-  }
+  },
+  "sorries": 3
 }


### PR DESCRIPTION
## Fix

The `dissection-of-cubes-oq-04` meta.json had `meta.sorries: 3` but no top-level `sorries` field (reading as null). The Lean file `DissectionOfCubesOQ04.lean` actually has 3 sorries:
- Line 390: octahedron edge count scaling
- Line 393: dodecahedron edge count scaling
- Line 396: icosahedron edge count scaling

Add `"sorries": 3` at the top level to match `meta.sorries` and the actual Lean source.

## Evidence

**Before**: top-level `sorries: null`, `meta.sorries: 3`, `leanFile.sorries: null`
**After**: top-level `sorries: 3`, `meta.sorries: 3` (unchanged)

Verified by: `grep -n "sorry" proofs/Proofs/DissectionOfCubesOQ04.lean` → 3 matches at lines 390, 393, 396

---
Automated fix by lean-mechanic agent.