### PR TITLE
Fix: correct sorry count for erdos-512 (meta.sorries 0→1)

### DIFF
--- a/src/data/proofs/erdos-512/meta.json
+++ b/src/data/proofs/erdos-512/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 512,
     "erdosUrl": "https://erdosproblems.com/512",
     "erdosProblemStatus": "solved",
@@ -70,7 +70,7 @@
     ],
     "axiomCount": 2,
     "lineCount": 267,
-    "assumptions": "2 axioms: konyagin_theorem, mcgehee_pigno_smith_theorem. 0 sorries."
+    "assumptions": "2 axioms: konyagin_theorem, mcgehee_pigno_smith_theorem. 1 sorry: L2_norm (Parseval's theorem, needs measure theory)."
   },
   "overview": {
     "historicalContext": "Littlewood conjectured in the 1960s that the $L^1$ norm of any exponential sum with $N$ terms is at least $c \\log N$. Specifically, if $A \\subset \\mathbb{Z}$ is a finite set with $|A| = N$, then $\\int_0^1 |\\sum_{n \\in A} e^{2\\pi i n\\theta}|\\,d\\theta \\geq c \\log N$ for an absolute constant $c > 0$. This is a fundamental question about how \"flat\" a trigonometric polynomial with unit coefficients can be.\n\nThe conjecture was independently proved in 1981 by two groups. Konyagin gave an analytic proof using character sum estimates and concentration inequalities. McGehee, Pigno, and Smith gave an elegant proof based on Hardy's inequality for power series. The MPS approach is widely considered the more beautiful: they showed that Hardy's classical inequality $\\sum_{n=1}^\\infty \\frac{1}{n}(\\sum_{k=1}^n a_k)^2 \\leq 4\\sum a_n^2$ applied to the Fourier coefficients of $|S_A|$ directly yields the logarithmic lower bound via the harmonic series $\\sum_{k=1}^N 1/k \\sim \\log N$.\n\nThe bound is tight: the Dirichlet kernel $D_N(\\theta) = \\sum_{n=0}^{N-1} e^{2\\pi i n\\theta} = \\sin(N\\pi\\theta)/\\sin(\\pi\\theta)$ has $L^1$ norm $(4/\\pi^2)\\log N + O(1)$, which is the Lebesgue constant from classical Fourier analysis. This means arithmetic progressions are essentially the worst-case sets for Littlewood's bound.\n\nThe result connects to several areas: the flat polynomial problem (can $|P(z)|$ be nearly constant on $|z|=1$ for polynomials with $\\pm 1$ coefficients?), the Rudin-Shapiro construction, equidistribution theory via Weyl's criterion, and character sum bounds in analytic number theory. Erdős included it as Problem #512, emphasizing its role as a bridge between harmonic analysis and combinatorial number theory.",


### PR DESCRIPTION
## Summary

- `meta.meta.sorries` was incorrectly set to `0` while the Lean source (`Erdos512Problem.lean:194`) contains 1 sorry: the `L2_norm` (Parseval's theorem, needs measure theory)
- `leanFile.sorries` and the top-level `sorries` fields were already correct (`1`)
- Updated `meta.meta.assumptions` to accurately reflect 1 sorry

## Evidence

**meta.json claimed** (`meta.sorries`): 0  
**Lean file actual** (`grep -n sorry`): 1 (line 194: `sorry -- Parseval's theorem`)

## Verification

After fix: `npx tsx scripts/auditor/find-targets.ts --issues` reports 0 issues.

---
Discovered and fixed during gallery integrity audit (auditor agent).