### PR TITLE
Fix: sync stale lineCount in 12 gallery meta.json files

### DIFF
--- a/src/data/proofs/area-of-circle-oq-05-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-02/meta.json
@@ -30,7 +30,7 @@
       "Documents the change-of-variables infrastructure needed: map_linearMap_volume_pi_eq_smul_volume_pi with |det Uᵀ| = 1"
     ],
     "dateAdded": "2026-04-21",
-    "lineCount": 138,
+    "lineCount": 189,
     "theoremCount": 3,
     "definitionCount": 0,
     "mathlib_version": "4.26.0"

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -23,7 +23,7 @@
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
     "assumptions": "Three open sorries: (1) hook_length_formula (requires SYT↔NI bijection + det factorization), (2) ni_count_eq_syt_count (Fomin/Viennot/RSK correspondence), (3) lgv_det_factors_as_hook_quotient (det factorization identity). StandardYoungTableau.ext is now fully proved (funext).",
-    "lineCount": 2991,
+    "lineCount": 3866,
     "theoremCount": 100,
     "definitionCount": 14,
     "originalContributions": [
@@ -83,7 +83,7 @@
       "LGV"
     ],
     "namespace": "HookLengthFormula",
-    "lineCount": 2991,
+    "lineCount": 3866,
     "axiomCount": 0,
     "sorries": 3,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",

--- a/src/data/proofs/ballot-problem-oq-03-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01/meta.json
@@ -22,7 +22,7 @@
     "dateAdded": "2026-04-02",
     "axiomCount": 0,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
-    "lineCount": 2898,
+    "lineCount": 2922,
     "theoremCount": 138,
     "definitionCount": 31,
     "originalContributions": [
@@ -70,7 +70,7 @@
   },
   "leanFile": {
     "namespace": "LatticePathLGV",
-    "lineCount": 2898,
+    "lineCount": 2922,
     "axiomCount": 0,
     "theoremCount": 138,
     "definitionCount": 31,

--- a/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
@@ -79,7 +79,7 @@
     "dateAdded": "2026-03-22",
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
-    "lineCount": 2311,
+    "lineCount": 2511,
     "theoremCount": 82,
     "prerequisites": [
       "Matrix determinants and permutation signs (Mathlib)",
@@ -286,7 +286,7 @@
       "Finset"
     ],
     "namespace": "LGV",
-    "lineCount": 2311,
+    "lineCount": 2511,
     "axiomCount": 0,
     "theoremCount": 88,
     "definitionCount": 29,

--- a/src/data/proofs/ballot-problem-oq-03/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03/meta.json
@@ -71,7 +71,7 @@
       "Lattice path combinatorics",
       "Basic Lean 4 induction and Fintype"
     ],
-    "lineCount": 2898,
+    "lineCount": 2922,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
   },
   "overview": {
@@ -315,7 +315,7 @@
       "List"
     ],
     "namespace": "LatticePathLGV",
-    "lineCount": 2898,
+    "lineCount": 2922,
     "axiomCount": 0,
     "theoremCount": 138,
     "definitionCount": 32,

--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02/meta.json
@@ -21,7 +21,7 @@
     "sorries": 0,
     "dateAdded": "2026-04-12",
     "axiomCount": 5,
-    "lineCount": 851,
+    "lineCount": 952,
     "assumptions": "5 axioms: aperyB_recurrence (WZ recurrence), denominator_control (lcm^3*a_n is integer), lcm_hanson_bound (3^n Hanson bound), apery_linearForm_decay (geometric decay), apery_linearForm_nonzero (L_n != 0 for n>=1). Removed unused nair_lcm_bound. Main theorem apery_theorem PROVED from these 5 axioms.",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -180,7 +180,7 @@
       "Nat"
     ],
     "namespace": "AperyZetaThree",
-    "lineCount": 851,
+    "lineCount": 952,
     "axiomCount": 5,
     "theoremCount": 25,
     "definitionCount": 4,

--- a/src/data/proofs/erdos-260/meta.json
+++ b/src/data/proofs/erdos-260/meta.json
@@ -50,7 +50,7 @@
       "Proved convergence of the series under fast growth"
     ],
     "axiomCount": 1,
-    "lineCount": 203,
+    "lineCount": 269,
     "assumptions": "1 axiom: erdos_260_conjecture (open conjecture). 3 sorries: series_converges (convergence argument), irrational_of_gaps_to_infinity (Erdős 1974 theorem), irrational_of_superlogarithmic (number-theoretic result)."
   },
   "overview": {
@@ -161,7 +161,7 @@
       "Topology"
     ],
     "namespace": "Erdos260",
-    "lineCount": 203,
+    "lineCount": 269,
     "axiomCount": 1,
     "theoremCount": 8,
     "definitionCount": 8,

--- a/src/data/proofs/erdos-268/meta.json
+++ b/src/data/proofs/erdos-268/meta.json
@@ -57,7 +57,7 @@
       "Concrete examples: squares (Basel problem) and powers of 2 (geometric series)"
     ],
     "axiomCount": 2,
-    "lineCount": 762,
+    "lineCount": 951,
     "assumptions": "2 axioms: erdos_268_solved (main interior result for all dimensions), harmonicPointSet_path_connected_large (path-connectedness for d ≥ 2, Kovač-Tao structural analysis). 0 sorries. Proved: shifted_summable (decomposition at n=0), harmonicPointSet_nonempty (powers-of-2 witness), harmonicPointSet_dense_somewhere (directly from interior axiom), coordinate_decreasing (tsum_lt_tsum; requires 0 ∉ A), first_coordinate_largest (from coordinate_decreasing), squares_convergent (bijection + p-series), powers_convergent (bijection + geometric series)."
   },
   "overview": {
@@ -207,7 +207,7 @@
       "Topology"
     ],
     "namespace": "Erdos268",
-    "lineCount": 762,
+    "lineCount": 951,
     "axiomCount": 2,
     "theoremCount": 15,
     "definitionCount": 14,

--- a/src/data/proofs/hurwitz-theorem-oq-03/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-03/meta.json
@@ -22,7 +22,7 @@
     "dateAdded": "2026-04-02",
     "axiomCount": 0,
     "assumptions": "1 sorry: hurwitz_only_if — if an n-square identity exists, then n ∈ {1,2,4,8} (n=3 case proved; n∉{1,2,3,4,8} cases pending Clifford/Radon-Hurwitz argument). The converse (identities exist for n ∈ {1,2,4,8}) is fully proved. No axiom declarations.",
-    "lineCount": 1973,
+    "lineCount": 2042,
     "theoremCount": 32,
     "definitionCount": 15,
     "originalContributions": [
@@ -67,7 +67,7 @@
   },
   "leanFile": {
     "namespace": "HurwitzTheorem",
-    "lineCount": 1973,
+    "lineCount": 2042,
     "axiomCount": 0,
     "theoremCount": 33,
     "definitionCount": 15,

--- a/src/data/proofs/hurwitz-theorem/meta.json
+++ b/src/data/proofs/hurwitz-theorem/meta.json
@@ -45,7 +45,7 @@
     ],
     "dateAdded": "2025-12-26",
     "axiomCount": 0,
-    "lineCount": 1973,
+    "lineCount": 2042,
     "assumptions": "1 sorry: hurwitz_only_if — general non-existence for n ∉ {1,2,3,4,8} (n=3 case proved; remaining cases need Clifford/Radon-Hurwitz argument). The 8-square identity (octonions) is fully proved. No axiom declarations.",
     "mathlib_version": "4.26.0"
   },
@@ -277,7 +277,7 @@
     ],
     "opens": [],
     "namespace": "HurwitzTheorem",
-    "lineCount": 1973,
+    "lineCount": 2042,
     "axiomCount": 0,
     "theoremCount": 33,
     "definitionCount": 15,

--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -20,7 +20,7 @@
     "badge": "wip",
     "sorries": 6,
     "axiomCount": 0,
-    "lineCount": 557,
+    "lineCount": 281,
     "assumptions": "6 sorries: hausdorff_free_subgroup (Hausdorff 1914 — SO(3) contains F₂), banach_tarski (Banach-Tarski 1924 — main paradox, requires AC), banach_tarski_pieces_nonmeasurable (classical non-measurability corollary), int_amenable (Markov-Kakutani — ℤ amenable via Cesàro means/ultrafilter), plus 2 additional sorries added in recent session. The framework (equidecomposability, paradoxical sets, F₂ non-amenability) is fully proved.",
     "dateAdded": "2026-04-22",
     "mathlib_version": "4.26.0",
@@ -201,7 +201,7 @@
       "Mathlib"
     ],
     "namespace": "BanachTarski",
-    "lineCount": 557,
+    "lineCount": 281,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 5,

--- a/src/data/proofs/shapley-folkman/meta.json
+++ b/src/data/proofs/shapley-folkman/meta.json
@@ -61,7 +61,7 @@
       "Caratheodory's theorem (points in convex hull need at most d+1 vertices)",
       "Affine independence and dimension"
     ],
-    "lineCount": 809,
+    "lineCount": 904,
     "mathlib_version": "4.26.0",
     "leanFile": {
       "imports": [
@@ -201,7 +201,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 809,
+    "lineCount": 904,
     "structureCount": 1,
     "axiomCount": 0,
     "theoremCount": 8,


### PR DESCRIPTION
## Fix

Corrects `meta.lineCount` and `leanFile.lineCount` fields that diverged from the actual Lean source files.

## Evidence

| Gallery entry | Before | After |
|---|---|---|
| area-of-circle-oq-05-oq-02 | 138 | 189 |
| ballot-problem-oq-03 | 2898 | 2922 |
| ballot-problem-oq-03-oq-01 | 2898 | 2922 |
| ballot-problem-oq-03-oq-01-oq-02 | 2991 | 3866 |
| ballot-problem-oq-03-oq-02 | 2311 | 2511 |
| basel-problem-oq-01-oq-01-oq-02 | 851 | 952 |
| erdos-260 | 203 | 269 |
| erdos-268 | 762 | 951 |
| hurwitz-theorem | 1973 | 2042 |
| hurwitz-theorem-oq-03 | 1973 | 2042 |
| lebesgue-measure-oq-06 | 557 | 281 |
| shapley-folkman | 809 | 904 |

---
Automated fix by lean-mechanic agent.