### PR TITLE
Fix: correct status for erdos-1059-oq-03 (axiomatized+wip → verified+original)

### DIFF
--- a/src/data/proofs/erdos-1059-oq-03/meta.json
+++ b/src/data/proofs/erdos-1059-oq-03/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/1059",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos1059OQ03.lean",
     "tags": [
       "erdos",
@@ -15,14 +15,14 @@
       "factorials",
       "computational"
     ],
-    "badge": "wip",
+    "badge": "original",
     "sorries": 0,
     "erdosNumber": 1059,
     "erdosUrl": "https://erdosproblems.com/1059",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
     "lineCount": 45,
-    "assumptions": "None. All results proved by computation (decide/native_decide). Open conjecture; supporting lemmas fully verified.",
+    "assumptions": "None. All results proved by computation (decide/native_decide). All theorems fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Summary

- `erdos-1059-oq-03/meta.json` claimed `status: "axiomatized"` and `badge: "wip"` despite the Lean file (`Proofs/Erdos1059OQ03.lean`) having 0 sorries and 0 axiom declarations
- The proof contains 5 theorems (`prime_223`, `next_prime_after_211`, `prime_199`, `counterexample_223`, `smallest_failing_prime_after_211`) all closed by `decide` — no mathematical axioms, no unfinished holes
- Per CLAUDE.md integrity rules: `verified` = 0 sorries + 0 axioms + 0 structure-encoded assumptions; `axiomatized` = has axiom declarations or structure-encoded assumptions

## Changes

- `meta.status`: `"axiomatized"` → `"verified"`
- `meta.badge`: `"wip"` → `"original"` (proof uses Lean kernel `decide`, not Mathlib big theorems)
- `meta.assumptions`: updated from the misleading "Open conjecture; supporting lemmas fully verified" language to accurately state "All theorems fully verified with 0 axioms and 0 sorries"

Note: the parent Erdős problem #1059 (infinite examples question) remains open, but OQ-03 specifically asks for the smallest counterexample prime after 211, which is fully answered computationally as p=223 (via 223 - 4! = 199, prime).

Found during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)