### PR TITLE
Fix: sync stale lineCount in 3 gallery meta.json files

### DIFF
--- a/src/data/proofs/erdos-620/meta.json
+++ b/src/data/proofs/erdos-620/meta.json
@@ -50,7 +50,7 @@
     ],
     "axiomCount": 2,
     "assumptions": "2 axioms: shearer_lower_bound, mubayi_verstraete_upper. Structure fields are object definitions, not assumptions.",
-    "lineCount": 281,
+    "lineCount": 283,
     "relatedProblems": [
       {
         "id": "ramseys-theorem",
@@ -235,7 +235,7 @@
       "Finset"
     ],
     "namespace": "Erdos620",
-    "lineCount": 281,
+    "lineCount": 283,
     "axiomCount": 2,
     "theoremCount": 8,
     "definitionCount": 15,

--- a/src/data/proofs/erdos-79/meta.json
+++ b/src/data/proofs/erdos-79/meta.json
@@ -32,7 +32,7 @@
       "erdos-562"
     ],
     "axiomCount": 4,
-    "lineCount": 237,
+    "lineCount": 238,
     "assumptions": "4 axioms: ramsey_linear_hereditary, K4_not_linear, K4_subgraphs_linear, wigderson_theorem. 1 sorry.",
     "mathlib_version": "4.26.0"
   },
@@ -174,7 +174,7 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos79",
-    "lineCount": 237,
+    "lineCount": 238,
     "axiomCount": 4,
     "theoremCount": 5,
     "definitionCount": 12,

--- a/src/data/proofs/sqrt2-minpoly-oq-02/meta.json
+++ b/src/data/proofs/sqrt2-minpoly-oq-02/meta.json
@@ -19,7 +19,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 204,
+    "lineCount": 202,
     "dateAdded": "2026-04-06",
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlibDependencies": [
@@ -198,7 +198,7 @@
       "IntermediateField"
     ],
     "namespace": "CubeRoot2IrrationalOQ03",
-    "lineCount": 204,
+    "lineCount": 202,
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` values in gallery meta.json files where the recorded line count no longer matches the actual Lean source file.

## Evidence

| Proof | Before | After |
|-------|--------|-------|
| erdos-620 | 281 | 283 |
| sqrt2-minpoly-oq-02 | 204 | 202 |
| erdos-79 | 237 | 238 |

Both `meta.lineCount` and `leanFile.lineCount` fields updated in each file.

---
Automated fix by lean-mechanic agent.