### PR TITLE
Fix: add missing top-level sorries field to 3 gallery meta.json files

### DIFF
--- a/src/data/proofs/erdos-622-oq-04/meta.json
+++ b/src/data/proofs/erdos-622-oq-04/meta.json
@@ -139,5 +139,6 @@
     "definitionCount": 4,
     "path": "Proofs/Erdos622OQ04.lean",
     "sorries": 0
-  }
+  },
+  "sorries": 0
 }

--- a/src/data/proofs/fair-games-theorem-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/fair-games-theorem-oq-02-oq-01-oq-01/meta.json
@@ -156,5 +156,6 @@
       "relationship": "sibling",
       "description": "Random walk and martingale theory. The zero-mean corollary here (wald_zero_mean_gives_zero_drift) is the total-drift companion to the OST's terminal-value result."
     }
-  ]
+  ],
+  "sorries": 0
 }

--- a/src/data/proofs/minkowski-fundamental-theorem-oq-04/meta.json
+++ b/src/data/proofs/minkowski-fundamental-theorem-oq-04/meta.json
@@ -22,5 +22,6 @@
     "latticeEquivBasis: Lattice n ≃ Module.Basis (Fin n) ℝ (Fin n → ℝ) [proved]",
     "covolume_eq_volume_fundamentalDomain: ENNReal.ofReal L.covolume = vol(ZSpan.fundamentalDomain (L.toModuleBasis n)) [not yet formalized — Lattice struct has no covolume field]"
   ],
-  "mathBackground": "The custom Lattice type wraps a basis matrix with an invertibility condition. Mathlib's ZSpan approach abstracts this as Submodule.span ℤ (Set.range b) for a Module.Basis b. The central bridge is ZSpan.volume_fundamentalDomain, which shows vol(fundamentalDomain b) = ENNReal.ofReal |(Matrix.of b).det|."
+  "mathBackground": "The custom Lattice type wraps a basis matrix with an invertibility condition. Mathlib's ZSpan approach abstracts this as Submodule.span ℤ (Set.range b) for a Module.Basis b. The central bridge is ZSpan.volume_fundamentalDomain, which shows vol(fundamentalDomain b) = ENNReal.ofReal |(Matrix.of b).det|.",
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Add missing top-level sorries field to 3 gallery meta.json files that had the count in meta.sorries but were missing the top-level field.

## Evidence

| Proof | Change |
|-------|--------|
| minkowski-fundamental-theorem-oq-04 | Added top-level sorries: 0 |
| fair-games-theorem-oq-02-oq-01-oq-01 | Added top-level sorries: 0 |
| erdos-622-oq-04 | Added top-level sorries: 0 |

---
Automated fix by lean-mechanic agent.