### PR TITLE
Fix: sync stale lineCount in 2 gallery meta.json files

### DIFF
--- a/src/data/proofs/napoleons-theorem-oq-02/meta.json
+++ b/src/data/proofs/napoleons-theorem-oq-02/meta.json
@@ -181,6 +181,7 @@
       "NapoleonsTheorem"
     ],
     "namespace": "NapoleonsTheoremOQ02",
+    "lineCount": 346,
     "axiomCount": 0,
     "theoremCount": 9,
     "sorries": 0,

--- a/src/data/proofs/sqrt2-minpoly-oq-02/meta.json
+++ b/src/data/proofs/sqrt2-minpoly-oq-02/meta.json
@@ -19,7 +19,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 202,
+    "lineCount": 204,
     "dateAdded": "2026-04-06",
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlibDependencies": [
@@ -198,7 +198,7 @@
       "IntermediateField"
     ],
     "namespace": "CubeRoot2IrrationalOQ03",
-    "lineCount": 202,
+    "lineCount": 204,
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 0,


### PR DESCRIPTION
## Summary

Two gallery meta.json files had stale `lineCount` values that didn't match the actual Lean source files:

- **napoleons-theorem-oq-02**: `leanFile.lineCount` was missing entirely — the field was absent from the `leanFile` object. Added `"lineCount": 346` (actual: `wc -l NapoleonsTheoremOQ02.lean` = 346).
- **sqrt2-minpoly-oq-02**: both `meta.lineCount` and `leanFile.lineCount` were set to 202, but the actual file `CubeRoot2IrrationalOQ03.lean` has 204 lines. Updated both occurrences to 204.

## Changes

- `src/data/proofs/napoleons-theorem-oq-02/meta.json`: added `leanFile.lineCount: 346`
- `src/data/proofs/sqrt2-minpoly-oq-02/meta.json`: corrected `meta.lineCount` and `leanFile.lineCount` from 202 → 204

No other fields were changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)