### PR TITLE
Fix: add missing sorries fields to 2 gallery meta.json files

### DIFF
--- a/src/data/proofs/dissection-of-cubes-oq-04/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-04/meta.json
@@ -167,5 +167,6 @@
       "relationship": "related",
       "description": "The Platonic solids gallery entry provides context on Euler's formula V-E+F=2 and the classification of regular polyhedra."
     }
-  ]
+  ],
+  "sorries": 3
 }

--- a/src/data/proofs/sperner-ndim-oq-04/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-04/meta.json
@@ -237,7 +237,8 @@
     "lineCount": 408,
     "axiomCount": 0,
     "theoremCount": 8,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "sorries": 2
   },
   "sorries": 2
 }


### PR DESCRIPTION
## Fix

Add missing `sorries` fields to 2 gallery meta.json files detected by integrity scan.

## Evidence

| Proof | Change |
|-------|--------|
| dissection-of-cubes-oq-04 | Added top-level `sorries: 3` (actual Lean file: 3 sorry tokens) |
| sperner-ndim-oq-04 | Added `leanFile.sorries: 2` (top-level `sorries: 2` already correct) |

**Before**: fields missing — schema validation tools cannot read sorry count from these entries
**After**: both sorry field locations populated with values matching the actual Lean source

---
Automated fix by lean-mechanic agent.