### PR TITLE
Add Aristotle companion for Erdős #626 (Chromatic Number and Girth)

### DIFF
--- a/proofs/Proofs/Erdos626ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos626ProblemAristotle.lean
@@ -1,0 +1,58 @@
+/-
+  Aristotle targets for Erdős Problem #626 (Chromatic Number and Girth)
+  Routine supporting lemmas for automated proof search.
+  See Erdos626Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main open questions (LimitExists, g_unbounded, probabilistic_lower_bound)
+  - NOT definition sorries (g, h, ramseyNumber)
+  - NOT deep bounds (k4_bounds, g_ramsey_connection)
+  - Routine algebraic/arithmetic facts about the bound coefficients
+
+  Excluded (too deep or malformed for Aristotle):
+  - g_unbounded: depends on axiom with complex existential
+  - limit_if_exists_bounded: depends on axioms with noncomputable g
+  - bound_ratio_limit: requires limit theory for ratio of logs
+  - k4_bounds: depends on def sorry (g) and deep bounds (axioms)
+  - triangle_free_unbounded_chromatic: depends on def sorry (g)
+  - probabilistic_lower_bound: deep probabilistic argument
+  - g_ramsey_connection: depends on def sorry (ramseyNumber)
+  - g_h_relationship: depends on two def sorries (g, h)
+  - g / h / ramseyNumber: definition sorries
+-/
+import Mathlib
+import Proofs.Erdos626Problem
+
+open Finset Function Nat GraphCore
+open SimpleGraph hiding chromaticNumber
+
+namespace Erdos626Aristotle
+
+open Erdos626
+
+/-- lowerCoeff k > 0 for k ≥ 4.
+    Strategy: lowerCoeff k = 1 / (4 * Real.log k). For k ≥ 4 > 1, log k > 0,
+    so 4 * log k > 0, hence 1 / (4 * log k) > 0. -/
+theorem lowerCoeff_pos (k : ℕ) (hk : k ≥ 4) : lowerCoeff k > 0 := by
+  sorry
+
+/-- upperCoeff k > 0 for k ≥ 4.
+    Strategy: upperCoeff k = 2 / Real.log (k - 2). For k ≥ 4, k - 2 ≥ 2 > 1,
+    so log(k-2) > 0, hence 2 / log(k-2) > 0. -/
+theorem upperCoeff_pos (k : ℕ) (hk : k ≥ 4) : upperCoeff k > 0 := by
+  sorry
+
+/-- The gap between upper and lower bounds is positive for k ≥ 4.
+    Strategy: both coefficients are positive, and upper > lower because
+    2 / log(k-2) > 1 / (4 * log k) for k ≥ 4. -/
+theorem bound_gap (k : ℕ) (hk : k ≥ 4) :
+    upperCoeff k - lowerCoeff k > 0 := by
+  sorry
+
+/-- The ratio of bounds equals 8 · log k / log(k-2).
+    Strategy: algebra from definitions of boundRatio, upperCoeff, lowerCoeff. -/
+theorem bound_ratio_formula (k : ℕ) (hk : k ≥ 4) :
+    boundRatio k = 8 * Real.log k / Real.log (k - 2) := by
+  sorry
+
+end Erdos626Aristotle


### PR DESCRIPTION
## Fix

Adds `Erdos626ProblemAristotle.lean` — an Aristotle companion file for `Erdos626Problem.lean` (15 sorries, previously no companion).

## Evidence

**Before**: `erdos-626` had 15 sorries and no Aristotle companion file.

**After**: 4 routine algebraic/arithmetic lemmas available for automated proof search:
- `lowerCoeff_pos`: 1/(4·log k) > 0 for k ≥ 4 (log is positive for k > 1)
- `upperCoeff_pos`: 2/log(k-2) > 0 for k ≥ 4 (log(k-2) > 0 since k-2 ≥ 2)
- `bound_gap`: upperCoeff k - lowerCoeff k > 0 (Erdős upper bound exceeds Kostochka lower)
- `bound_ratio_formula`: boundRatio k = 8·log k / log(k-2) (algebraic manipulation)

**Excluded** (correct per Aristotle pre-submission checklist):
- Definition sorries: `g`, `h`, `ramseyNumber`
- Deep results: `g_unbounded`, `limit_if_exists_bounded`, `bound_ratio_limit`, `k4_bounds`
- Main open question: `LimitExists`, `limit_question_open`
- Probabilistic argument: `probabilistic_lower_bound`

No `axiom` declarations, no `def ... := sorry`, no `theorem ... : True`, no `/-!` sections.

---
Automated fix by lean-mechanic agent.