### PR TITLE
Add Aristotle companion for Erdős #644 (Covering Families of Sets)

### DIFF
--- a/proofs/Proofs/Erdos644ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos644ProblemAristotle.lean
@@ -1,0 +1,47 @@
+/-
+  Aristotle targets for Erdős Problem #644 (Covering Families of Sets)
+  Routine supporting lemmas for automated proof search.
+  See Erdos644Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the deep EFKT92 results (f_k_3, f_k_4, f_k_5, f_k_6)
+  - NOT open conjecture axioms (question1_open, question2_open, main_conjecture_open)
+  - NOT complex constructions (extremalFamily3_lower, sunflower_connection, hypergraph_equiv)
+  - Routine deductions and structural properties
+
+  Excluded (too deep or wrong type for Aristotle):
+  - f_k_3 / f_k_4 / f_k_5 / f_k_6: deep EFKT92 results (major theorems)
+  - f_k_7_lower / f_k_7_upper: deep open problem bounds
+  - extremalFamily3_lower: complex extremal construction
+  - sunflower_connection: deep combinatorial argument
+  - hypergraph_equiv: complex equivalence
+  - question1_open / question2_open / main_conjecture_open: open problem axioms
+  - known_summary: conjunction of 4 deep theorems (all sorry'd)
+-/
+import Mathlib
+import Proofs.Erdos644Problem
+
+open Finset Set
+
+namespace Erdos644Aristotle
+
+open Erdos644
+
+/-- f(k,r) ≤ k for all r ≥ 6.
+    Strategy: f_k_6 gives f(k,6) = k, and f_mono_r gives f(k,r) ≤ f(k,6) = k for r ≥ 6. -/
+theorem f_le_k (k r : ℕ) (hr : r ≥ 6) (hk : k ≥ 1) : f k r ≤ k := by
+  sorry
+
+/-- For r ≥ 6, f(k,r) ≤ k (equivalent statement with ∀). -/
+theorem f_limit_behavior (k : ℕ) (hk : k ≥ 1) :
+    ∀ r, r ≥ 6 → f k r ≤ k := by
+  sorry
+
+/-- If Question 2 holds, then for each r ≥ 3 the coefficient c_r is positive and ≤ 2.
+    Strategy: Question2 directly provides c_r > 0. The bound c_r ≤ 2 follows from
+    f_k_3 (f(k,3) = 2k) and f_mono_r (f(k,r) ≤ f(k,3) for r ≥ 3). -/
+theorem q2_implies_bounded (h : Question2) :
+    ∀ r, r ≥ 3 → ∃ c_r : ℝ, 0 < c_r ∧ c_r ≤ 2 := by
+  sorry
+
+end Erdos644Aristotle


### PR DESCRIPTION
## Fix

Adds `Erdos644ProblemAristotle.lean` — an Aristotle companion file for `Erdos644Problem.lean` (16 sorries, previously no companion).

## Evidence

**Before**: `erdos-644` had 16 sorries and no Aristotle companion file.

**After**: 3 routine lemmas available for automated proof search:
- `f_le_k`: f(k,r) ≤ k for r ≥ 6 (via `f_k_6` + `f_mono_r`)
- `f_limit_behavior`: ∀ r ≥ 6, f(k,r) ≤ k (equivalent universal formulation)
- `q2_implies_bounded`: If Question 2 holds, then c_r ∈ (0, 2] for all r ≥ 3

**Excluded** (correct per Aristotle pre-submission checklist):
- Deep EFKT92 results: `f_k_3`, `f_k_4`, `f_k_5`, `f_k_6` (major theorems)
- Open conjecture axioms: `question1_open`, `question2_open`, `main_conjecture_open`
- Complex constructions: `extremalFamily3_lower`, `sunflower_connection`, `hypergraph_equiv`
- Boundary cases depending on deep results: `f_k_2`, `f_k_7_lower`, `f_k_7_upper`

No `axiom` declarations, no `def ... := sorry`, no `theorem ... : True`, no `/-!` sections.

---
Automated fix by lean-mechanic agent.