### PR TITLE
Fix: correct overclaimed ¬UFD conclusion in fundamental-arithmetic-oq-02

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12941,6 +12941,36 @@
       "lastAudited": "2026-04-23T18:43:37Z",
       "result": "clean",
       "issues": []
+    },
+    "yang-mills-transfer-matrix-oq-01": {
+      "auditCount": 2,
+      "lastAudited": "2026-04-24T04:27:46Z",
+      "result": "clean",
+      "issues": []
+    },
+    "ballot-problem-oq-03-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-24T04:27:46Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-schwarz-integral-oq-01-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-24T04:27:46Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fair-games-theorem-oq-02-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-24T04:27:46Z",
+      "result": "clean",
+      "issues": []
+    },
+    "minkowski-fundamental-theorem-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-24T04:27:46Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {

--- a/src/data/proofs/fundamental-arithmetic-oq-02/meta.json
+++ b/src/data/proofs/fundamental-arithmetic-oq-02/meta.json
@@ -31,11 +31,6 @@
         "theorem": "Irreducible",
         "description": "Element is irreducible in a monoid",
         "module": "Mathlib.Algebra.Prime.Basic"
-      },
-      {
-        "theorem": "UniqueFactorizationMonoid",
-        "description": "Unique factorization domain structure",
-        "module": "Mathlib.RingTheory.UniqueFactorizationDomain.Basic"
       }
     ],
     "assumptions": []
@@ -93,7 +88,7 @@
     }
   ],
   "conclusion": {
-    "summary": "The formalization provides a complete, machine-verified proof that $\\mathbb{Z}[\\sqrt{-5}]$ is not a unique factorization domain. Every step — from the multiplicativity of the norm, through the irreducibility of 2 and its non-primality, to the two genuinely distinct factorizations of 6 — is formally verified with zero sorries and zero axioms. The proof demonstrates how elementary norm arguments can resolve deep algebraic questions.",
+    "summary": "The formalization provides a complete, machine-verified proof of the key witness: 2 is irreducible in $\\mathbb{Z}[\\sqrt{-5}]$ but fails to divide $(1+\\sqrt{-5})$, establishing that 2 is irreducible but not prime. Every step — from the multiplicativity of the norm, through the irreducibility of 2 and its non-primality, to the two genuinely distinct factorizations of 6 — is formally verified with zero sorries and zero axioms. This constitutes the formal witness that $\\mathbb{Z}[\\sqrt{-5}]$ is not a UFD (since in a UFD, irreducible implies prime), though the final $\\neg\\text{UniqueFactorizationMonoid}$ statement is not yet formalized in Lean.",
     "implications": "This counterexample lies at the foundation of algebraic number theory. The failure of unique factorization in $\\mathbb{Z}[\\sqrt{-5}]$ directly motivated Kummer's invention of ideal numbers and Dedekind's theory of ideals, which restored unique factorization at the ideal level and became cornerstones of modern algebra. The class group $\\mathrm{Cl}(\\mathbb{Z}[\\sqrt{-5}]) \\cong \\mathbb{Z}/2\\mathbb{Z}$ precisely quantifies the failure. Understanding which rings have unique factorization remains central to number theory, connecting to the Heegner-Stark theorem (only 9 imaginary quadratic fields are PIDs) and the Cohen-Lenstra heuristics on class group statistics.",
     "openQuestions": [
       "Can the full ideal-theoretic unique factorization in the ring of integers of Q(sqrt(-5)) be formalized in Lean 4, showing that every ideal factors uniquely into prime ideals?",


### PR DESCRIPTION
## Fix

Update `conclusion.summary` to accurately reflect what is formalized in Lean, and remove an unused `mathlibDependencies` entry.

## Evidence

**Before**: `conclusion.summary` claimed "a complete, machine-verified proof that ℤ[√(−5)] is not a unique factorization domain." The Lean file proves the key witness (2 is irreducible but not prime) but never states `¬UniqueFactorizationMonoid (ℤ√(-5))`.

**After**: `conclusion.summary` accurately describes the formalized witness proof and notes that the final `¬UniqueFactorizationMonoid` statement is not yet in Lean. The mathematical significance is preserved.

**Secondary fix**: Removed `UniqueFactorizationMonoid` from `mathlibDependencies` — this module (`Mathlib.RingTheory.UniqueFactorizationDomain.Basic`) is never imported in the Lean file.

Closes #12136

---
Automated fix by lean-mechanic agent.