### PR TITLE
Audit: sync erdos-512 meta.json with L2_norm sorry fix

### DIFF
--- a/src/data/proofs/erdos-512/meta.json
+++ b/src/data/proofs/erdos-512/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 512,
     "erdosUrl": "https://erdosproblems.com/512",
     "erdosProblemStatus": "solved",
@@ -63,14 +63,14 @@
       "littlewood_sharpness: log N is optimal (axiom)",
       "geometricProgression, arithmetic_progression_bound: extremal example",
       "hardy_inequality: discrete Hardy inequality (axiom)",
-      "L2_norm: Parseval theorem (sorry, needs measure theory)",
+      "L2_norm: Parseval theorem (proved via character orthogonality)",
       "weightedExpSum, weighted_littlewood: unit-weight generalization",
       "erdos_512, erdos_512_main, erdos_512_solved: main theorems",
       "konyagin_equals_mps: logical equivalence of the two proofs"
     ],
     "axiomCount": 2,
-    "lineCount": 267,
-    "assumptions": "2 axioms: konyagin_theorem, mcgehee_pigno_smith_theorem. 1 sorry: L2_norm (Parseval's theorem, needs measure theory)."
+    "lineCount": 365,
+    "assumptions": "2 axioms: konyagin_theorem, mcgehee_pigno_smith_theorem."
   },
   "overview": {
     "historicalContext": "Littlewood conjectured in the 1960s that the $L^1$ norm of any exponential sum with $N$ terms is at least $c \\log N$. Specifically, if $A \\subset \\mathbb{Z}$ is a finite set with $|A| = N$, then $\\int_0^1 |\\sum_{n \\in A} e^{2\\pi i n\\theta}|\\,d\\theta \\geq c \\log N$ for an absolute constant $c > 0$. This is a fundamental question about how \"flat\" a trigonometric polynomial with unit coefficients can be.\n\nThe conjecture was independently proved in 1981 by two groups. Konyagin gave an analytic proof using character sum estimates and concentration inequalities. McGehee, Pigno, and Smith gave an elegant proof based on Hardy's inequality for power series. The MPS approach is widely considered the more beautiful: they showed that Hardy's classical inequality $\\sum_{n=1}^\\infty \\frac{1}{n}(\\sum_{k=1}^n a_k)^2 \\leq 4\\sum a_n^2$ applied to the Fourier coefficients of $|S_A|$ directly yields the logarithmic lower bound via the harmonic series $\\sum_{k=1}^N 1/k \\sim \\log N$.\n\nThe bound is tight: the Dirichlet kernel $D_N(\\theta) = \\sum_{n=0}^{N-1} e^{2\\pi i n\\theta} = \\sin(N\\pi\\theta)/\\sin(\\pi\\theta)$ has $L^1$ norm $(4/\\pi^2)\\log N + O(1)$, which is the Lebesgue constant from classical Fourier analysis. This means arithmetic progressions are essentially the worst-case sets for Littlewood's bound.\n\nThe result connects to several areas: the flat polynomial problem (can $|P(z)|$ be nearly constant on $|z|=1$ for polynomials with $\\pm 1$ coefficients?), the Rudin-Shapiro construction, equidistribution theory via Weyl's criterion, and character sum bounds in analytic number theory. Erdős included it as Problem #512, emphasizing its role as a bridge between harmonic analysis and combinatorial number theory.",
@@ -161,7 +161,7 @@
     {
       "id": "related-results",
       "title": "Related Results: Parseval, Flat Polynomials",
-      "summary": "L2_norm = √N (Parseval, sorry); L1 vs L2 comparison; flat polynomial problem connection",
+      "summary": "L2_norm = √N (Parseval, proved via character orthogonality); L1 vs L2 comparison; flat polynomial problem connection",
       "startLine": 176,
       "endLine": 196,
       "mathContext": "$\\\\|S_A\\\\|_2 = \\\\sqrt{N}$ (Parseval). So $L^1 = \\\\Theta(\\\\log N) \\\\ll L^2 = \\\\sqrt{N}$: exponential sums have much more $L^1$ cancellation than $L^2$ suggests."
@@ -217,12 +217,12 @@
       "MeasureTheory"
     ],
     "namespace": "Erdos512",
-    "lineCount": 267,
+    "lineCount": 365,
     "axiomCount": 2,
     "theoremCount": 11,
     "definitionCount": 16,
     "path": "Proofs/Erdos512Problem.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "crossReferences": [
     {
@@ -241,5 +241,5 @@
       "description": "Related Erdős problem sharing themes: exponential-sums, harmonic-analysis"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Summary

- Syncs `sorries` count from 1→0 across all three locations in meta.json (`meta.sorries`, `leanFile.sorries`, top-level `sorries`)
- Updates `lineCount` from 267→365 to match actual Lean file
- Updates `originalContributions` entry: removes "(sorry, needs measure theory)" → "(proved via character orthogonality)"
- Updates section summary to remove sorry reference
- Updates `assumptions` field: removes stale mention of L2_norm sorry

## Background

The `L2_norm` (Parseval's theorem) sorry was eliminated in commit `1e702aadd3` (PR #12115). The meta.json was not updated at that time. A subsequent incorrect audit commit (`5943fc6060`, PR #12117) then re-added the sorry claim based on an outdated reading of the Lean file.

This fix audits the Lean file directly (0 sorries, 365 lines) and corrects all stale fields.

## Audit Evidence

- `grep -c "sorry" proofs/Proofs/Erdos512Problem.lean` → **0**
- `wc -l proofs/Proofs/Erdos512Problem.lean` → **365**

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)