### PR TITLE
Fix: remove non-existent originalContributions and stale sections in erdos-512

### DIFF
--- a/src/data/proofs/erdos-512/meta.json
+++ b/src/data/proofs/erdos-512/meta.json
@@ -59,12 +59,9 @@
       "LittlewoodConjecture, LittlewoodConjecture': formal and asymptotic statements",
       "konyagin_theorem, mcgehee_pigno_smith_theorem: solution axioms",
       "littlewoodConstant = 1/(4π): explicit constant",
-      "littlewood_explicit: explicit lower bound axiom",
-      "littlewood_sharpness: log N is optimal (axiom)",
-      "geometricProgression, arithmetic_progression_bound: extremal example",
-      "hardy_inequality: discrete Hardy inequality (axiom)",
+      "geometricProgression: extremal example (arithmetic progression {0,...,N-1})",
       "L2_norm: Parseval theorem (proved via character orthogonality)",
-      "weightedExpSum, weighted_littlewood: unit-weight generalization",
+      "weightedExpSum: unit-weight generalization",
       "erdos_512, erdos_512_main, erdos_512_solved: main theorems",
       "konyagin_equals_mps: logical equivalence of the two proofs"
     ],
@@ -121,7 +118,7 @@
     {
       "id": "l1-norm",
       "title": "The L¹ Norm",
-      "summary": "L1norm via Bochner integral on [0,1]; proved: nonnegativity; sorry: upper bound L¹ ≤ N",
+      "summary": "L1norm via Bochner integral on [0,1]; proved: nonnegativity; proved: upper bound L¹ ≤ N",
       "startLine": 86,
       "endLine": 105,
       "mathContext": "$\\\\|S_A\\\\|_1 = \\\\int_0^1 |\\\\sum_{n \\\\in A} e(n\\\\theta)| d\\\\theta$. The $L^1$ norm measures average cancellation. Non-negative, bounded above by $N$."
@@ -137,7 +134,7 @@
     {
       "id": "solution",
       "title": "The Solution (1981)",
-      "summary": "konyagin_theorem and mcgehee_pigno_smith_theorem axioms; littlewoodConstant = 1/(4π); littlewood_explicit axiom",
+      "summary": "konyagin_theorem and mcgehee_pigno_smith_theorem axioms; littlewoodConstant = 1/(4π) explicit constant",
       "startLine": 123,
       "endLine": 141,
       "mathContext": "Konyagin (1981) and McGehee-Pigno-Smith (1981): $\\\\|S_A\\\\|_1 \\\\geq c\\\\log N$ with $c = 1/(8\\\\pi^2)$. Two independent proofs in the same year."
@@ -145,7 +142,7 @@
     {
       "id": "sharpness",
       "title": "Sharpness: log N is Optimal",
-      "summary": "littlewood_sharpness axiom; geometricProgression = {0,...,N-1}; arithmetic_progression_bound: L¹ ≍ log N for APs (Lebesgue constant)",
+      "summary": "geometricProgression = {0,...,N-1}; L¹ ≍ log N for arithmetic progressions (Lebesgue constant)",
       "startLine": 142,
       "endLine": 160,
       "mathContext": "Sharp: geometric progressions $A = \\\\{0,1,\\\\ldots,N-1\\\\}$ achieve $\\\\|S_A\\\\|_1 = \\\\Theta(\\\\log N)$. The Dirichlet kernel $\\\\sum_{n=0}^{N-1} e(n\\\\theta)$ has $L^1$ norm $\\\\sim (4/\\\\pi^2)\\\\log N$."
@@ -169,7 +166,7 @@
     {
       "id": "generalizations",
       "title": "Generalizations",
-      "summary": "weightedExpSum with unit weights; weighted_littlewood axiom (same log N bound); higher-dimensional placeholder",
+      "summary": "weightedExpSum with unit weights; same log N lower bound holds for unit-weight generalizations",
       "startLine": 197,
       "endLine": 215,
       "mathContext": "Weighted version: $\\\\int |\\\\sum w_n e(n\\\\theta)| d\\\\theta \\\\geq c\\\\log N$ for $|w_n|=1$. Same $\\\\log N$ bound with unit weights."


### PR DESCRIPTION
## Fix

Remove 5 non-existent entries from `originalContributions` in `src/data/proofs/erdos-512/meta.json` and correct 4 stale section summaries.

## Evidence

**Before**: `originalContributions` listed items that do not exist in `proofs/Proofs/Erdos512Problem.lean`:
- `littlewood_explicit` — commented stub, not implemented
- `littlewood_sharpness` — section heading only, no code
- `arithmetic_progression_bound` — only `geometricProgression` def exists
- `hardy_inequality` — only `hardyConnection : Prop := True` placeholder
- `weighted_littlewood` — only `weightedExpSum` def exists

**After**:
- Removed 5 non-existent entries; merged combined entries to reflect actual code
- Fixed `l1-norm` section summary: "sorry: upper bound L¹ ≤ N" → "proved: upper bound L¹ ≤ N"
- Corrected "solution", "sharpness", "generalizations" section summaries to remove stale axiom references

Note: PR #12157 was merged but addressed a different issue (L2_norm sorry status); this PR fixes the actual reported issue.

Closes #12149

---
Automated fix by lean-mechanic agent.