### PR TITLE
Fix gallery integrity: lebesgue-measure-oq-06 sorry count (6→5)

### DIFF
--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -18,10 +18,10 @@
       "research"
     ],
     "badge": "wip",
-    "sorries": 6,
+    "sorries": 5,
     "axiomCount": 0,
     "lineCount": 281,
-    "assumptions": "6 sorries: hausdorff_free_subgroup (Hausdorff 1914 — SO(3) contains F₂), banach_tarski (Banach-Tarski 1924 — main paradox, requires AC), banach_tarski_pieces_nonmeasurable (classical non-measurability corollary), int_amenable (Markov-Kakutani — ℤ amenable via Cesàro means/ultrafilter), plus 2 additional sorries added in recent session. The framework (equidecomposability, paradoxical sets, F₂ non-amenability) is fully proved.",
+    "assumptions": "5 sorries: a sorry inside paradoxical_no_finite_measure (the measure subset step), hausdorff_free_subgroup (Hausdorff 1914 — SO(3) contains F₂), banach_tarski (Banach-Tarski 1924 — main paradox, requires AC), banach_tarski_pieces_nonmeasurable (classical non-measurability corollary), int_amenable (Markov-Kakutani — ℤ amenable via Cesàro means/ultrafilter). The framework (equidecomposability, paradoxical sets, F₂ non-amenability) is fully proved.",
     "dateAdded": "2026-04-22",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -106,7 +106,7 @@
     }
   ],
   "conclusion": {
-    "summary": "The Banach-Tarski paradox is formalized with 6 sorries and 0 axioms. The abstract framework (equidecomposability, paradoxical sets, F₂ non-amenability) is fully proved. The sorry theorems represent established results (Hausdorff 1914, Banach-Tarski 1924, Markov-Kakutani) whose Lean proofs require 150–800 lines each — beyond this gallery entry's scope.",
+    "summary": "The Banach-Tarski paradox is formalized with 5 sorries and 0 axioms. The abstract framework (equidecomposability, paradoxical sets, F₂ non-amenability) is fully proved. The sorry theorems represent established results (Hausdorff 1914, Banach-Tarski 1924, Markov-Kakutani) whose Lean proofs require 150–800 lines each — beyond this gallery entry's scope.",
     "openQuestions": [
       "Can Hausdorff's free subgroup theorem be fully formalized in Lean? The proof requires showing that explicit 3×3 rotation matrices $\\varphi$ (rotation by $\\arccos(1/3)$ around the $z$-axis) and $\\psi$ (rotation by $\\arccos(1/3)$ around the $x$-axis) generate a free group of rank 2 in $\\text{SO}(3)$. The algebraic argument shows that nontrivial words $w(\\varphi, \\psi)$ applied to $e_1 = (1, 0, 0)$ produce vectors with coordinates in $\\mathbb{Z}[1/3, \\sqrt{2}/3]$ that are non-zero — requiring careful case analysis on the word structure and number-theoretic properties of $\\arccos(1/3)$ (specifically that it is not a rational multiple of $\\pi$).",
       "Can the full Banach-Tarski proof be formalized in Lean 4? The most likely modular path: (1) formalize the free subgroup freeness (the sorry in `hausdorff_free_subgroup`); (2) prove the paradoxical decomposition of $F_2$ acting on itself (purely algebraic, ~100 lines); (3) lift to $S^2 \\setminus D$ via the free group action (~150 lines); (4) handle the exceptional set $D$ via a rotation of infinite order (Hilbert hotel, ~100 lines); (5) extend from $S^2$ to $B^3$ by coning and handling the center (~100 lines). Estimated total: 800–1200 lines.",
@@ -206,7 +206,7 @@
     "theoremCount": 7,
     "definitionCount": 5,
     "path": "Proofs/LebesgueMeasureOQ06.lean",
-    "sorries": 6
+    "sorries": 5
   },
-  "sorries": 6
+  "sorries": 5
 }


### PR DESCRIPTION
## Summary

- Gallery entry `lebesgue-measure-oq-06` (Banach-Tarski Paradox) incorrectly claimed `"sorries": 6` in three places (`meta.sorries`, `leanFile.sorries`, top-level `sorries`) and in the `assumptions` text and `conclusion.summary`
- The actual Lean file `proofs/Proofs/LebesgueMeasureOQ06.lean` has exactly **5 sorries** (verified via `git show HEAD:proofs/Proofs/LebesgueMeasureOQ06.lean | grep -c sorry`)
- The 5 actual sorries are: a sorry inside `paradoxical_no_finite_measure` (line 137), `hausdorff_free_subgroup` (line 178), `banach_tarski` (line 220), `banach_tarski_pieces_nonmeasurable` (line 233), and `int_amenable` (line 263)
- The stale `assumptions` text also referenced "plus 2 additional sorries added in recent session" which was incorrect

## Changes

- `src/data/proofs/lebesgue-measure-oq-06/meta.json`: corrected all sorry counts from 6 to 5, rewrote `assumptions` to list the 5 actual sorries precisely, and updated `conclusion.summary`

## Test plan

- [x] Verified sorry count in Lean file: `git show HEAD:proofs/Proofs/LebesgueMeasureOQ06.lean | grep -c "sorry"` returns 5
- [x] All three JSON sorry count fields now read `5`
- [x] `assumptions` text now accurately lists the 5 sorries without stale session notes

Gallery integrity fix caught by the auditor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)