### PR TITLE
Fix: correct axiomCount and status for navier-stokes-oq-02

### DIFF
--- a/src/data/proofs/navier-stokes-oq-02/meta.json
+++ b/src/data/proofs/navier-stokes-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Ladyzhenskaya (1969)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Navier%E2%80%93Stokes_equations",
     "date": "1969",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/NavierStokes.lean",
     "tags": [
       "pde",
@@ -21,9 +21,9 @@
       "analysis",
       "research"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "mathlibDependencies": [
       {
         "theorem": "antitoneOn_of_deriv_nonpos",
@@ -60,7 +60,7 @@
     ],
     "dateAdded": "2026-02-28",
     "lineCount": 21111,
-    "assumptions": "None. Formalized with 0 axioms and 0 sorries remain.",
+    "assumptions": "1 structure-encoded assumption: NSSolutionPair2D.stability_estimate (Ladyzhenskaya stability estimate W'(t) ≤ C·E(t)·W(t), the core PDE estimate — mathematically known but not formalized in this file)",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -203,7 +203,7 @@
     ],
     "namespace": "NavierStokesRegularity",
     "lineCount": 21111,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 845,
     "definitionCount": 104,
     "path": "Proofs/NavierStokes.lean",


### PR DESCRIPTION
## Fix

Update `navier-stokes-oq-02` metadata to correctly reflect the structure-encoded assumption in `NSSolutionPair2D.stability_estimate`.

## Evidence

**Before**:
- `axiomCount: 0`
- `status: "verified"`
- `badge: "mathlib"`
- `assumptions: "None. Formalized with 0 axioms and 0 sorries remain."`

**After**:
- `axiomCount: 1`
- `status: "axiomatized"`
- `badge: "axiom"`
- `assumptions: "1 structure-encoded assumption: NSSolutionPair2D.stability_estimate (Ladyzhenskaya stability estimate W'(t) ≤ C·E(t)·W(t), the core PDE estimate — mathematically known but not formalized in this file)"`

Per [CLAUDE.md axiom integrity policy](../../blob/main/CLAUDE.md#axiom-integrity-policy): structure fields that encode mathematical assumptions count toward `axiomCount`. All theorems in this file (`gronwall_stability_2d`, `uniqueness_2d`, `continuous_dependence_2d`) are conditional on `stability_estimate` holding.

Closes #12166

---
Automated fix by lean-mechanic agent.