### PR TITLE
Audit: fix sorry count mismatches in 3 gallery entries

### DIFF
--- a/src/data/proofs/dissection-of-cubes-oq-04/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-04/meta.json
@@ -19,10 +19,10 @@
       "irrational-angles"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 0,
     "dateAdded": "2026-04-22",
     "axiomCount": 2,
-    "assumptions": "1. tmul_infinite_order_ne_zero (from OQ02OQ02): ℝ is flat over ℤ — needed to show nonzero tensor products. 2. icoAngle_irrational: arccos(-√5/3)/π is irrational (icosahedron dihedral angle) — proof requires Chebyshev arithmetic in ℤ[√5], deferred.",
+    "assumptions": "2 axioms: 1. tmul_infinite_order_ne_zero (from OQ02OQ02): ℝ is flat over ℤ — needed to show nonzero tensor products. 2. icoAngle_irrational: arccos(-√5/3)/π is irrational (icosahedron dihedral angle) — proof requires Chebyshev arithmetic in ℤ[√5], deferred. All sorries are now proved (edge count scaling lemmas closed in research session).",
     "lineCount": 437,
     "theoremCount": 15,
     "definitionCount": 4,
@@ -168,5 +168,5 @@
       "description": "The Platonic solids gallery entry provides context on Euler's formula V-E+F=2 and the classification of regular polyhedra."
     }
   ],
-  "sorries": 3
+  "sorries": 0
 }

--- a/src/data/proofs/erdos-512/meta.json
+++ b/src/data/proofs/erdos-512/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 2,
     "erdosNumber": 512,
     "erdosUrl": "https://erdosproblems.com/512",
     "erdosProblemStatus": "solved",
@@ -67,7 +67,7 @@
     ],
     "axiomCount": 2,
     "lineCount": 365,
-    "assumptions": "2 axioms: konyagin_theorem, mcgehee_pigno_smith_theorem."
+    "assumptions": "2 axioms: konyagin_theorem, mcgehee_pigno_smith_theorem. 2 sorries in expSumNorm_sq_double (private lemma: normSq decomposition as double sum — ring computation steps not yet completed)."
   },
   "overview": {
     "historicalContext": "Littlewood conjectured in the 1960s that the $L^1$ norm of any exponential sum with $N$ terms is at least $c \\log N$. Specifically, if $A \\subset \\mathbb{Z}$ is a finite set with $|A| = N$, then $\\int_0^1 |\\sum_{n \\in A} e^{2\\pi i n\\theta}|\\,d\\theta \\geq c \\log N$ for an absolute constant $c > 0$. This is a fundamental question about how \"flat\" a trigonometric polynomial with unit coefficients can be.\n\nThe conjecture was independently proved in 1981 by two groups. Konyagin gave an analytic proof using character sum estimates and concentration inequalities. McGehee, Pigno, and Smith gave an elegant proof based on Hardy's inequality for power series. The MPS approach is widely considered the more beautiful: they showed that Hardy's classical inequality $\\sum_{n=1}^\\infty \\frac{1}{n}(\\sum_{k=1}^n a_k)^2 \\leq 4\\sum a_n^2$ applied to the Fourier coefficients of $|S_A|$ directly yields the logarithmic lower bound via the harmonic series $\\sum_{k=1}^N 1/k \\sim \\log N$.\n\nThe bound is tight: the Dirichlet kernel $D_N(\\theta) = \\sum_{n=0}^{N-1} e^{2\\pi i n\\theta} = \\sin(N\\pi\\theta)/\\sin(\\pi\\theta)$ has $L^1$ norm $(4/\\pi^2)\\log N + O(1)$, which is the Lebesgue constant from classical Fourier analysis. This means arithmetic progressions are essentially the worst-case sets for Littlewood's bound.\n\nThe result connects to several areas: the flat polynomial problem (can $|P(z)|$ be nearly constant on $|z|=1$ for polynomials with $\\pm 1$ coefficients?), the Rudin-Shapiro construction, equidistribution theory via Weyl's criterion, and character sum bounds in analytic number theory. Erdős included it as Problem #512, emphasizing its role as a bridge between harmonic analysis and combinatorial number theory.",
@@ -219,7 +219,7 @@
     "theoremCount": 11,
     "definitionCount": 16,
     "path": "Proofs/Erdos512Problem.lean",
-    "sorries": 0
+    "sorries": 2
   },
   "crossReferences": [
     {
@@ -238,5 +238,5 @@
       "description": "Related Erdős problem sharing themes: exponential-sums, harmonic-analysis"
     }
   ],
-  "sorries": 0
+  "sorries": 2
 }

--- a/src/data/proofs/konigsberg-oq-02-oq-01/meta.json
+++ b/src/data/proofs/konigsberg-oq-02-oq-01/meta.json
@@ -18,10 +18,10 @@
       "hierholzer"
     ],
     "badge": "wip",
-    "sorries": 3,
+    "sorries": 1,
     "dateAdded": "2026-04-24",
     "axiomCount": 0,
-    "assumptions": "3 sorries remain: (1) removeArcList_arcCount (arcCount formula for residual subgraph), (2) removeArcList_balanced (balance preserved after removing a circuit), (3) directed_euler_circuit_sufficient_corrected (WF induction combining splice + balance lemmas). The key sub-lemma (maximal trail is circuit) and Walk.splice are fully proved.",
+    "assumptions": "1 sorry remains: directed_euler_circuit_sufficient_corrected (WF induction on arcCount combining splice + balance lemmas). Supporting lemmas removeArcList_arcCount and removeArcList_balanced are now fully proved.",
     "lineCount": 436,
     "theoremCount": 8,
     "definitionCount": 5,
@@ -32,7 +32,8 @@
       "Walk.splice: proved (0 sorries) — circuit extension operation concatenating two walks",
       "Walk.splice_nodup: proved (0 sorries) — splice of disjoint Nodup walks is Nodup",
       "Digraph.removeArcList: residual subgraph definition for Hierholzer induction",
-      "removeArcList_balanced: sorry — circuit removal preserves balance (proof roadmap provided)"
+      "removeArcList_arcCount: proved — arcCount formula for residual subgraph after arc removal",
+      "removeArcList_balanced: proved — balance preserved after removing a circuit from balanced digraph"
     ]
   },
   "overview": {
@@ -47,7 +48,7 @@
     ]
   },
   "conclusion": {
-    "summary": "Key infrastructure for Hierholzer's algorithm proved: maximal trail sub-lemma (0 sorries), Walk.splice (0 sorries). 3 sorries remain for the WF induction glue and two supporting arithmetic lemmas.",
+    "summary": "Key infrastructure for Hierholzer's algorithm proved: maximal trail sub-lemma (0 sorries), Walk.splice (0 sorries), removeArcList_arcCount (0 sorries), removeArcList_balanced (0 sorries). 1 sorry remains for the WF induction combining all proved sub-lemmas.",
     "implications": [
       "Fixes bug in KonigsbergOQ02 directed Eulerian sufficiency axiom",
       "Walk.splice enables circuit extension proofs beyond this result",
@@ -66,7 +67,7 @@
     "theoremCount": 8,
     "definitionCount": 5,
     "path": "Proofs/KonigsbergOQ02OQ01.lean",
-    "sorries": 3,
+    "sorries": 1,
     "imports": [
       "Mathlib.Algebra.BigOperators.Group.Finset.Basic",
       "Mathlib.Tactic",
@@ -124,24 +125,11 @@
   ],
   "sorries": [
     {
-      "id": "removeArcList_arcCount",
-      "description": "arcCount of residual = D.arcCount - removed arcs length (for Nodup arc list)",
-      "type": "supporting_lemma",
-      "difficulty": "medium"
-    },
-    {
-      "id": "removeArcList_balanced",
-      "description": "Balance preserved when removing a circuit from balanced digraph",
-      "type": "key_lemma",
-      "difficulty": "medium",
-      "proofSketch": "Use circuit_fst_perm_snd to show per-vertex fst/snd counts are equal in circuit, then subtract equal amounts from balanced outDeg/inDeg"
-    },
-    {
       "id": "directed_euler_circuit_sufficient_corrected",
-      "description": "Main Hierholzer WF induction combining splice + balance lemmas",
+      "description": "Main Hierholzer WF induction combining all proved sub-lemmas (splice + balance + arcCount)",
       "type": "main_theorem",
       "difficulty": "hard",
-      "proofSketch": "WF induction on D.arcCount - circuit.arcs.length; greedy trail → circuit (maximal_balanced_trail_is_circuit); extend via splice if not Eulerian"
+      "proofSketch": "WF induction on D.arcCount - circuit.arcs.length; greedy trail → circuit (maximal_balanced_trail_is_circuit); extend via splice if not Eulerian; use removeArcList_balanced + removeArcList_arcCount for termination"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Fixes sorry count mismatches discovered during gallery integrity audit.

## Issues Fixed

### 1. konigsberg-oq-02-oq-01: 3 sorries → 1 (improvement)
- `removeArcList_arcCount` and `removeArcList_balanced` were proved (committed in #12121 and #12153)
- Only `directed_euler_circuit_sufficient_corrected` (WF induction) remains
- Updated: `sorries`, `assumptions`, `originalContributions`, `conclusion.summary`, `sorries[]` list

### 2. dissection-of-cubes-oq-04: 3 sorries → 0 (all proved!)
- All 3 "general edge count scaling" sorries were proved (committed in #12153)
- 2 axioms remain: `tmul_infinite_order_ne_zero` + `icoAngle_irrational` (correct)
- Updated: `sorries` (both fields), `assumptions`

### 3. erdos-512: 0 sorries → 2 [OVERCLAIM FIX — HIGH severity]
- `expSumNorm_sq_double` private lemma contains 2 actual sorry tactics (lines 225, 227)
- These prove the normSq double-sum decomposition (ring computation steps)
- meta.json was claiming 0 sorries when 2 exist in the Lean file
- Updated: `sorries` (all 3 fields), `assumptions`

## Evidence

```
konigsberg: grep -c "sorry" KonigsbergOQ02OQ01.lean → 4 lines (3 comments + 1 tactic)
dissection: grep -c "sorry" DissectionOfCubesOQ04.lean → 0
erdos-512:  grep -n "sorry" Erdos512Problem.lean → lines 225, 227
```

---
Discovered during gallery integrity audit (loom:auditor).