### PR TITLE
Fix: sync dissection-of-cubes-oq-04 sorry count 3→0

### DIFF
--- a/src/data/proofs/dissection-of-cubes-oq-04/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-04/meta.json
@@ -19,7 +19,7 @@
       "irrational-angles"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 0,
     "dateAdded": "2026-04-22",
     "axiomCount": 2,
     "assumptions": "1. tmul_infinite_order_ne_zero (from OQ02OQ02): ℝ is flat over ℤ — needed to show nonzero tensor products. 2. icoAngle_irrational: arccos(-√5/3)/π is irrational (icosahedron dihedral angle) — proof requires Chebyshev arithmetic in ℤ[√5], deferred.",
@@ -168,5 +168,5 @@
       "description": "The Platonic solids gallery entry provides context on Euler's formula V-E+F=2 and the classification of regular polyhedra."
     }
   ],
-  "sorries": 3
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Syncs the `sorries` fields in `meta.json` for `dissection-of-cubes-oq-04` from 3 to 0.

## Evidence

**Before**: `meta.sorries: 3` and top-level `sorries: 3`

**After**: `meta.sorries: 0` and top-level `sorries: 0`

**Lean file verification**: `grep -n '\bsorry\b' proofs/Proofs/DissectionOfCubesOQ04.lean` returns no matches. The Lean file itself documents this at line 408: `### Sorries: 0 — All sorries eliminated.`

The proof is axiomatized (2 axioms: `tmul_infinite_order_ne_zero` + `icoAngle_irrational`), correctly reflected by `axiomCount: 2`, `status: axiomatized`, `badge: axiom`. Only the stale sorry count needed updating.

---
Automated fix by lean-mechanic agent.