### PR TITLE
Fix off-by-one in critical_edge_count_formula + Aristotle companion for Erdős #613

### DIFF
--- a/proofs/Proofs/Erdos613Aristotle.lean
+++ b/proofs/Proofs/Erdos613Aristotle.lean
@@ -1,0 +1,34 @@
+/-
+  Aristotle companion for Erdős Problem #613: Graph Decomposition and Size Ramsey Numbers
+
+  This file exposes routine lemmas for automated proof search by Aristotle.
+  The main formalization is in Erdos613Problem.lean.
+
+  Targets: arithmetic lemmas about criticalEdgeCount that do not depend on
+  sorry-defined graph functions.
+-/
+
+import Mathlib
+import Proofs.Erdos613Problem
+
+namespace Erdos613Aristotle
+
+open Erdos613 Nat
+
+/-- criticalEdgeCount equals 3n(n+1)/2 - 1 (equivalently n²+n+n(n+1)/2-1).
+    This is a pure binomial coefficient identity: C(2n+1,2) - C(n,2) - 1. -/
+theorem critical_edge_count_formula_ari (n : ℕ) (hn : n ≥ 1) :
+    criticalEdgeCount n = n * n + n + (n * (n + 1)) / 2 - 1 := by
+  sorry
+
+/-- criticalEdgeCount is strictly increasing for n ≥ 1 -/
+theorem criticalEdgeCount_mono (n : ℕ) (hn : n ≥ 1) :
+    criticalEdgeCount n < criticalEdgeCount (n + 1) := by
+  sorry
+
+/-- criticalEdgeCount n ≥ 2 for all n ≥ 1 -/
+theorem criticalEdgeCount_pos (n : ℕ) (hn : n ≥ 1) :
+    criticalEdgeCount n ≥ 2 := by
+  sorry
+
+end Erdos613Aristotle

--- a/proofs/Proofs/Erdos613Problem.lean
+++ b/proofs/Proofs/Erdos613Problem.lean
@@ -33,9 +33,9 @@ variable {V : Type*} [Fintype V] [DecidableEq V]
 def criticalEdgeCount (n : ℕ) : ℕ :=
   (2*n + 1).choose 2 - n.choose 2 - 1
 
-/-- Simplified form: C(2n+1,2) - C(n,2) - 1 = 2n² + n - n(n-1)/2 - 1 -/
+/-- Simplified form: C(2n+1,2) - C(n,2) - 1 = 3n(n+1)/2 - 1 -/
 theorem critical_edge_count_formula (n : ℕ) (hn : n ≥ 1) :
-    criticalEdgeCount n = n * n + n + (n * (n + 1)) / 2 := by
+    criticalEdgeCount n = n * n + n + (n * (n + 1)) / 2 - 1 := by
   sorry
 
 /-- For n = 3: critical count = 9 + 3 + 6 - 1 = 17 -/


### PR DESCRIPTION
## Summary

- **Bug fix**: `critical_edge_count_formula` in `Erdos613Problem.lean` had a false RHS — the old claim `criticalEdgeCount n = n*n + n + n*(n+1)/2` is off by 1 for all n≥1. The correct formula is `n*n + n + n*(n+1)/2 - 1` (equivalently `3n(n+1)/2 - 1`), since `C(2n+1,2) - C(n,2) - 1 = n(2n+1) - n(n-1)/2 - 1`. Verified: `criticalEdgeCount 3 = 17` (native_decide) but old RHS gives 18.
- **Aristotle companion**: New `Erdos613Aristotle.lean` exposes three sorried lemmas for Aristotle: the corrected binomial identity, monotonicity, and positivity of `criticalEdgeCount`.

## Test plan

- [ ] `criticalEdgeCount n = n * n + n + (n * (n + 1)) / 2 - 1` is consistent with `native_decide` witnesses for n=3 (→17) and n=5 (→44)
- [ ] Companion follows pre-submission rules: no def sorries, no axiom declarations, no True placeholders
- [ ] Sorry count in meta.json unchanged (stays 12; companion is a separate file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)