### PR TITLE
Audit: fix lebesgue-measure-oq-06 originalContributions (paradoxical_no_finite_measure still has sorry)

### DIFF
--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -30,7 +30,7 @@
       "IsAmenable (amenable group definition)",
       "ennreal_add_self_eq_self (proved: a + a = a → a = 0 or a = ⊤ in ENNReal)",
       "equidecomposable_refl (proved: every set is self-equidecomposable)",
-      "Framework: paradoxical sets have no finite invariant measure (fully proved, no sorry)",
+      "Framework: paradoxical sets have no finite invariant measure (proved except for one have step requiring B ∪ C monotonicity)",
       "free_group_not_amenable (proved: F₂ is not amenable via explicit paradoxical decomposition using word sets W(a), W(a⁻¹), W(b), W(b⁻¹))"
     ]
   },


### PR DESCRIPTION
## Summary

- Fix incorrect `originalContributions` entry in `lebesgue-measure-oq-06/meta.json` that claimed `paradoxical_no_finite_measure` was "fully proved, no sorry"
- The theorem still has a sorry at line 137 in the `have h2` block (needs `B ∪ C ⊆ A` monotonicity argument)
- Changed to: "proved except for one have step requiring B ∪ C monotonicity"

## Context

The previous audit commit ba331ca668 (#12175) incorrectly claimed `paradoxical_no_finite_measure` was fully proved and changed the sorry count from 5 to 4. That commit was merged to feature branches but never reached master. The sorry count fields on master are already correct at 5, and the `assumptions` field already mentions the sorry. However, the `originalContributions` text was never corrected and still falsely claims "fully proved, no sorry".

**Evidence**: `git show HEAD:proofs/Proofs/LebesgueMeasureOQ06.lean | grep -n sorry` shows line 137 has a sorry inside `paradoxical_no_finite_measure`'s `have h2` block.

## Files changed

- `src/data/proofs/lebesgue-measure-oq-06/meta.json` -- fix one `originalContributions` entry