### PR TITLE
Audit: fix ballot-problem-oq-03-oq-01-oq-02 sorry count (3→4, add hook_walk_identity)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "ballot-problem-oq-03-oq-01-oq-02",
   "title": "Hook-Length Formula for Standard Young Tableaux via LGV",
   "slug": "ballot-problem-oq-03-oq-01-oq-02",
-  "description": "Formalizes the hook-length formula f^\u03bb = n!/\u220fh(u) for Standard Young Tableaux. Fully proves the formula for single-row (1\u00d7n), single-column (n\u00d71), hook-shape ((m+1,1)), 2-row rectangular (m\u00d7m), and general 2-row [a,b] families. General formula has 3 sorries (RSK bijection, det factorization, main theorem).",
+  "description": "Formalizes the hook-length formula f^\u03bb = n!/\u220fh(u) for Standard Young Tableaux. Fully proves the formula for single-row (1\u00d7n), single-column (n\u00d71), hook-shape ((m+1,1)), 2-row rectangular (m\u00d7m), and general 2-row [a,b] families. General formula has 4 sorries via LGV approach (RSK bijection, det factorization, main theorem) or 1 sorry via corner induction (hook_walk_identity). hook_length_formula_general proved via corner induction modulo hook_walk_identity.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-21",
@@ -19,11 +19,11 @@
       "representation-theory"
     ],
     "badge": "wip",
-    "sorries": 3,
+    "sorries": 4,
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "assumptions": "Three open sorries: (1) hook_length_formula (requires SYT\u2194NI bijection + det factorization), (2) ni_count_eq_syt_count (Fomin/Viennot/RSK correspondence), (3) lgv_det_factors_as_hook_quotient (det factorization identity). StandardYoungTableau.ext is now fully proved (funext).",
-    "lineCount": 4611,
+    "assumptions": "Four open sorries: (1) hook_length_formula (LGV approach: requires SYT\u2194NI bijection + det factorization), (2) ni_count_eq_syt_count (Fomin/Viennot/RSK correspondence), (3) lgv_det_factors_as_hook_quotient (det factorization identity), (4) hook_walk_identity (corner induction: sum of hook-ratio over corners = n; general proof requires ~300 lines). hook_length_formula_general is proved modulo hook_walk_identity via Part XIV corner induction.",
+    "lineCount": 4726,
     "theoremCount": 162,
     "definitionCount": 14,
     "originalContributions": [
@@ -41,7 +41,9 @@
       "two_row_hook_identity: numerical identity ballotSeqCount(a+1,b) \u00d7 hookProd = (a+b)! (proved, 0 sorries)",
       "hook_length_formula_two_row_gen: formula for general 2-row [a,b] (1 sorry: card_SYT_twoRowYD)",
       "Numerical verification: hook-length formula proved for (2,1), (2,2), (3,1), (3,2), (3,2,1), (4,3,2,1), (3,3), (4,4) shapes",
-      "hook_length_formula_gHookYD: HLF for all generalized hook shapes [a, 1^b] (card = C(a+b-1,b), proved via double induction + inline bijection, 0 sorries)"
+      "hook_length_formula_gHookYD: HLF for all generalized hook shapes [a, 1^b] (card = C(a+b-1,b), proved via double induction + inline bijection, 0 sorries)",
+      "hook_walk_identity: sum over corners c of hookProd(\u03bc)/hookProd(\u03bc\\c) = \u03bc.card \u2014 corner recursion key lemma (1 sorry, verified for all special cases)",
+      "hook_length_formula_general: HLF for all Young diagrams via corner induction (proved modulo hook_walk_identity, 0 sorries in the theorem itself)"
     ]
   },
   "overview": {
@@ -65,7 +67,7 @@
     ]
   },
   "conclusion": {
-    "summary": "Hook-length formula fully proved for five infinite families: 1\u00d7n (direct), n\u00d71 (direct), hook-shape (m+1,1) (bijection), 2\u00d7m rect (Lindstrom reflection), and general 2-row [a,b] (conditional on ballot bijection, 1 sorry). hookProd for [a,b] = (a+1).descFactorial(b) \u00d7 (a-b)! \u00d7 b! proved with 0 sorries. General formula has 3 remaining sorries (RSK bijection, det factorization, main theorem).",
+    "summary": "Hook-length formula fully proved for five infinite families: 1\u00d7n (direct), n\u00d71 (direct), hook-shape (m+1,1) (bijection), 2\u00d7m rect (Lindstrom reflection), and general 2-row [a,b] (conditional on ballot bijection, 1 sorry). hookProd for [a,b] = (a+1).descFactorial(b) \u00d7 (a-b)! \u00d7 b! proved with 0 sorries. Part XIV (commit c0dcbcf81a) adds hook_length_formula_general as the primary result, proved via corner induction modulo hook_walk_identity (1 sorry), reducing from 3 sorries in the LGV approach to 1. Total: 4 sorries (3 LGV path + 1 corner induction).",
     "implications": "A complete formalization would be the first Lean 4 proof of the hook-length formula, a milestone in formal combinatorics. The LGV approach connects our existing ballot problem proofs to representation theory via the Specht module dimension formula f^\u03bb = dim S^\u03bb.",
     "openQuestions": [
       "Formalize the SYT \u2194 NI bijection via Fomin's growth diagrams or the RSK correspondence (~200 lines)",
@@ -86,7 +88,7 @@
     "namespace": "HookLengthFormula",
     "lineCount": 3866,
     "axiomCount": 0,
-    "sorries": 3,
+    "sorries": 4,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",
     "theoremCount": 100,
     "definitionCount": 14
@@ -161,7 +163,15 @@
       "endLine": 240,
       "summary": "Proves hook-length formula for 8 specific shapes via norm_num.",
       "mathContext": "Verified: (2,1)\u21922, (2,2)\u21922, (3,1)\u21923, (3,2)\u21925, (3,2,1)\u219216, (4,3,2,1)\u21921440, (3,3)\u21925 (C\u2083), (4,4)\u219214 (C\u2084)."
+    },
+    {
+      "id": "sec-corner-induction",
+      "title": "Part XIV: hook_length_formula_general via Corner Induction",
+      "startLine": 4600,
+      "endLine": 4726,
+      "summary": "Proves hook_length_formula_general by well-founded induction on \u03bc.card, using card_SYT_corner_step (Part XIII) + hook_walk_identity (1 sorry). hook_length_formula_Q is the \u211a version proved by WF induction.",
+      "mathContext": "hook_walk_identity: \u03a3_c hookProd(\u03bc)/hookProd(\u03bc\\c) = \u03bc.card. The main theorem reduces to hook_length_formula_Q via exact_mod_cast."
     }
   ],
-  "sorries": 3
+  "sorries": 4
 }


### PR DESCRIPTION
## Summary

Gallery integrity audit fix for `ballot-problem-oq-03-oq-01-oq-02` (Hook-Length Formula via LGV).

**Root cause**: Part XIV commit (`c0dcbcf81a`, "hook_length_formula_general via corner induction") added `hook_walk_identity` as a new sorry at line 4642 of `BallotProblemOQ03OQ01OQ02.lean`, but `meta.json` was not updated — it still claimed 3 sorries.

**Changes to `src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json`**:

- `meta.sorries`: 3 → 4
- `leanFile.sorries`: 3 → 4
- Top-level `sorries`: 3 → 4
- `meta.lineCount`: 4611 → 4726 (reflecting the Part XIV additions)
- `meta.assumptions`: updated from "Three open sorries" to "Four open sorries", adding `hook_walk_identity` (corner induction key lemma)
- `meta.description`: updated to note 4 sorries via LGV approach or 1 sorry via corner induction, and that `hook_length_formula_general` is proved modulo `hook_walk_identity`
- `meta.originalContributions`: added `hook_walk_identity` and `hook_length_formula_general` entries
- `sections`: added `sec-corner-induction` (Part XIV, lines 4600–4726)
- `conclusion.summary`: updated to note Part XIV result — `hook_length_formula_general` is now the primary result, proved via corner induction

**The 4 sorries in the Lean file**:
1. Line 219: `hook_length_formula` (main theorem, LGV approach)
2. Line 235: `ni_count_eq_syt_count` (RSK bijection auxiliary)
3. Line 245: `lgv_det_factors_as_hook_quotient` (det factorization auxiliary)
4. Line 4642: `hook_walk_identity` (added in Part XIV — sum of hook-ratio over corners = n)

## Test plan

- [ ] Verify `meta.json` is valid JSON (`jq . meta.json`)
- [ ] Confirm all 4 sorry locations in `BallotProblemOQ03OQ01OQ02.lean` match the assumptions field
- [ ] Gallery build (`pnpm build`) should pass with updated metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)