### PR TITLE
Fix: minkowski badge + erdos-512 annotations + area-of-circle seeker

### DIFF
--- a/research/problems/area-of-circle-oq-01-oq-03-oq-01-oq-03/knowledge.md
+++ b/research/problems/area-of-circle-oq-01-oq-03-oq-01-oq-03/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: area-of-circle-oq-01-oq-03-oq-01-oq-03
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/area-of-circle-oq-01-oq-03-oq-01-oq-03/literature/README.md
+++ b/research/problems/area-of-circle-oq-01-oq-03-oq-01-oq-03/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for area-of-circle-oq-01-oq-03-oq-01-oq-03
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/area-of-circle-oq-01-oq-03-oq-01-oq-03/problem.md
+++ b/research/problems/area-of-circle-oq-01-oq-03-oq-01-oq-03/problem.md
@@ -1,0 +1,132 @@
+# Problem: Remove Change-of-Variables Axioms via MeasureTheory
+
+**Slug**: area-of-circle-oq-01-oq-03-oq-01-oq-03
+**Created**: 2026-04-24T10:35:16+02:00
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+The source proof `area-of-circle-oq-01-oq-03-oq-01` (Arc-Length Reparametrization for
+Smooth Closed Curves) uses axiom declarations for change-of-variables steps in the
+circumference integral. Replace these with the Mathlib lemma:
+
+```lean
+MeasureTheory.integral_image_eq_integral_abs_deriv_smul
+```
+
+### Plain Language
+
+The isoperimetric inequality proof chain includes a sub-proof about arc-length
+reparametrization for smooth closed curves. That sub-proof relies on `axiom`
+declarations for change-of-variables steps in integrals. The task is to eliminate
+these axioms using Mathlib's measure-theory infrastructure, specifically
+`MeasureTheory.integral_image_eq_integral_abs_deriv_smul`, which handles the
+change-of-variables formula for the circumference integral.
+
+### Why This Matters
+
+Eliminating axioms from the proof chain improves the mathematical soundness of the
+isoperimetric inequality formalization. Each removed axiom moves the proof toward
+`status: verified` (0 axioms, 0 sorries). This continues the pattern established by
+the LP duality synthesis.
+
+## Known Results
+
+### What's Already Proven
+
+- `area-of-circle-oq-01-oq-03-oq-01`: Arc-length reparametrization for smooth closed
+  curves — exists but uses axioms for change-of-variables steps
+- `MeasureTheory.integral_image_eq_integral_abs_deriv_smul` — exists in Mathlib 4,
+  handles measure-preserving change of variables with absolute derivative
+
+### What's Still Open
+
+- Whether the Mathlib lemma's hypotheses (injectivity, differentiability) can be
+  discharged for the arc-length reparametrization case
+- Whether auxiliary lemmas about arc-length are in Mathlib or need to be proved
+
+### Our Goal
+
+Replace the change-of-variables axiom declarations in the source proof with formal
+proofs using `MeasureTheory.integral_image_eq_integral_abs_deriv_smul`.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| area-of-circle-oq-01-oq-03-oq-01 | Direct source — contains axioms to eliminate | Arc-length, reparametrization |
+| area-of-circle-oq-01 | Top-level isoperimetric inequality | Integration, Fourier |
+| cauchy-schwarz-integral-lp-duality-synthesis | Same pattern: axiom elimination via Mathlib | Lp duality, measure theory |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Direct application of `integral_image_eq_integral_abs_deriv_smul`**:
+   - Show arc-length reparametrization φ is C¹ and injective
+   - Apply the lemma to transform the circumference integral
+   - Why it might work: lemma exists and matches mathematical content
+   - Risk: may need to establish injectivity and |φ'| ≠ 0
+
+2. **Use IFT for the inverse arc-length map**:
+   - Arc-length s(t) is strictly increasing when |γ'| > 0
+   - Inverse s⁻¹ is C¹ by the inverse function theorem
+   - Then apply change-of-variables to the circumference integral
+   - Risk: IFT in Mathlib may require careful hypothesis matching
+
+### Key Difficulties
+
+- Arc-length reparametrization injectivity: need φ'(t) ≠ 0 a.e.
+- The `abs_deriv` condition: |φ'(t)| = 1/|γ'(φ(t))| for the inverse reparametrization
+- Connecting smooth curve hypotheses to Mathlib's `HasDerivAt` framework
+
+### What Would a Proof Need?
+
+- Key lemma: arc-length function is C¹ with nonzero derivative (from |γ'| > 0)
+- `HasDerivAt` for the arc-length reparametrization inverse
+- Application of `integral_image_eq_integral_abs_deriv_smul` with computed Jacobian
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- The target Mathlib lemma is identified exactly
+- Mathematical argument is standard (IFT + change of variables)
+- Same axiom-elimination pattern succeeded for LP duality synthesis
+- Main challenge: navigating Mathlib's API for arc-length and smooth curves
+
+**Estimated Effort**:
+- Exploration: 1-2 days (find relevant Mathlib lemmas, understand the API)
+- If tractable: 2-5 days (write proof connecting the pieces)
+- If hard: may need auxiliary lemmas about arc-length not yet in Mathlib
+
+## References
+
+### Mathlib
+- `MeasureTheory.integral_image_eq_integral_abs_deriv_smul` — change of variables
+- `ContDiff.hasStrictFDerivAt_of_hasStrictFDerivAt` — C¹ inverse
+- `Real.hasStrictDerivAt_inv` — pointwise derivative of inverse
+- `MeasureTheory` arc-length infrastructure (search `ArcLength`, `pathLength`)
+
+## Metadata
+
+```yaml
+tags:
+  - measure-theory
+  - real-analysis
+  - axiom-elimination
+  - arc-length
+  - reparametrization
+  - isoperimetric
+related_proofs:
+  - area-of-circle-oq-01-oq-03-oq-01
+  - area-of-circle-oq-01
+  - cauchy-schwarz-integral-lp-duality-synthesis
+difficulty: medium
+source: gallery-gap
+created: 2026-04-24T10:35:16+02:00
+```

--- a/research/problems/area-of-circle-oq-01-oq-03-oq-01-oq-03/state.md
+++ b/research/problems/area-of-circle-oq-01-oq-03-oq-01-oq-03/state.md
@@ -1,0 +1,25 @@
+# Research State: area-of-circle-oq-01-oq-03-oq-01-oq-03
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-04-24T10:35:16+02:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/registry.json
+++ b/research/registry.json
@@ -17517,6 +17517,13 @@
       "path": "full",
       "started": "2026-04-23T02:11:45+02:00",
       "status": "active"
+    },
+    {
+      "slug": "area-of-circle-oq-01-oq-03-oq-01-oq-03",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-24T10:35:16+02:00",
+      "status": "active"
     }
   ],
   "config": {

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5870,7 +5870,12 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-24T05:03:47Z",
-      "result": "issues-found"
+      "result": "issues-fixed",
+      "issuesFixed": [
+        "stale originalContributions items (#12149)",
+        "annotation L1norm_upper_bound incorrectly labelled (sorry) \u2014 proved",
+        "annotation L2_norm incorrectly labelled (sorry) \u2014 proved pending expSumNorm_sq_double; range updated to 257-295"
+      ]
     },
     "erdos-513": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-512/annotations.json
+++ b/src/data/proofs/erdos-512/annotations.json
@@ -81,7 +81,7 @@
     },
     "type": "definition",
     "title": "L¹ Norm and Basic Properties",
-    "content": "**L1norm A:** The $L^1$ norm $\\int_0^1 |\\sum_{n \\in A} e(n\\theta)|\\,d\\theta$, formalized using Bochner integration over the interval $[0,1]$.\n\n**L1norm_nonneg (proved):** The $L^1$ norm is nonneg, since the integrand $|S_A(\\theta)| \\geq 0$.\n\n**L1norm_upper_bound (sorry):** $L^1 \\leq N$ from the pointwise bound $|S_A(\\theta)| \\leq N$ and $\\mu([0,1]) = 1$. Requires measure-theoretic integration.",
+    "content": "**L1norm A:** The $L^1$ norm $\\int_0^1 |\\sum_{n \\in A} e(n\\theta)|\\,d\\theta$, formalized using Bochner integration over the interval $[0,1]$.\n\n**L1norm_nonneg (proved):** The $L^1$ norm is nonneg, since the integrand $|S_A(\\theta)| \\geq 0$.\n\n**L1norm_upper_bound (proved):** $L^1 \\leq N$ from the pointwise bound $|S_A(\\theta)| \\leq N$ and $\\mu([0,1]) = 1$. Uses `IntegrableOn` from continuity on compact set and monotone integration (`setIntegral_mono_on`).",
     "mathContext": "The $L^1$ norm $\\|S_A\\|_1 = \\int_0^1 |S_A(\\theta)|\\,d\\theta$ satisfies $1 \\leq \\|S_A\\|_1 \\leq N$. The lower bound $\\|S_A\\|_1 \\geq 1$ follows from $|\\int_0^1 S_A(\\theta)\\,d\\theta| = |\\sum_{n \\in A} \\hat{1}(n)| \\geq 1$ when $0 \\in A$ (and in general from orthogonality). Littlewood's conjecture sharpens this to $\\|S_A\\|_1 \\geq c \\log N$.",
     "significance": "key",
     "relatedConcepts": [
@@ -196,12 +196,12 @@
     "id": "ann-512-related",
     "proofId": "erdos-512",
     "range": {
-      "startLine": 176,
-      "endLine": 195
+      "startLine": 257,
+      "endLine": 295
     },
     "type": "concept",
     "title": "Related Results: Parseval, Flat Polynomials",
-    "content": "**L2_norm (sorry):** The $L^2$ norm of $S_A$ is $\\sqrt{N}$ by Parseval's theorem. This is because $\\int_0^1 |S_A(\\theta)|^2\\,d\\theta = \\sum_{n \\in A} |\\hat{1}_A(n)|^2 = |A| = N$.\n\n**L1_vs_L2_comparison:** The dramatic gap $\\log N \\ll \\sqrt{N}$ between $L^1$ and $L^2$ norms shows that $|S_A(\\theta)|$ is highly non-constant — it must have large peaks near $\\theta = 0$ and deep cancellations elsewhere.\n\n**flatPolynomialProblem:** Littlewood's conjecture implies no trigonometric polynomial with $\\pm 1$ coefficients can be \"flat\" (nearly constant modulus) on the circle.",
+    "content": "**L2_norm (proved, pending 2 sorries in expSumNorm_sq_double):** The $L^2$ norm of $S_A$ is $\\sqrt{N}$ by Parseval's theorem. The theorem is structurally proved via character orthogonality (`integral_cos_character`) and sum interchange, but relies on the private helper `expSumNorm_sq_double` which has 2 remaining sorries in the normSq double-sum expansion.\n\n**L1_vs_L2_comparison:** The dramatic gap $\\log N \\ll \\sqrt{N}$ between $L^1$ and $L^2$ norms shows that $|S_A(\\theta)|$ is highly non-constant — it must have large peaks near $\\theta = 0$ and deep cancellations elsewhere.\n\n**flatPolynomialProblem:** Littlewood's conjecture implies no trigonometric polynomial with $\\pm 1$ coefficients can be \"flat\" (nearly constant modulus) on the circle.",
     "mathContext": "The norm hierarchy for $S_A$ with $|A| = N$: $\\|S_A\\|_1 \\asymp \\log N$, $\\|S_A\\|_2 = \\sqrt{N}$, $\\|S_A\\|_\\infty = N$. By Hölder: $\\|S_A\\|_1 \\leq \\|S_A\\|_2 = \\sqrt{N}$, but Littlewood's conjecture says $\\|S_A\\|_1$ is only logarithmic, far below the Hölder bound. This means $|S_A(\\theta)|$ is typically small ($\\sim \\sqrt{N}$ at most points) but has a spike of height $N$ near $\\theta = 0$.",
     "significance": "supporting",
     "relatedConcepts": [

--- a/src/data/proofs/minkowski-fundamental-theorem-oq-04/meta.json
+++ b/src/data/proofs/minkowski-fundamental-theorem-oq-04/meta.json
@@ -9,7 +9,7 @@
     "author": "Lean Genius",
     "date": "2026",
     "tags": ["number-theory", "lattices", "mathlib", "geometry-of-numbers", "api-comparison"],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 193,


### PR DESCRIPTION
## Changes

Three fixes bundled on this branch:

### 1. Audit: minkowski-fundamental-theorem-oq-04 badge fix (`db539c5d22`)
- Changed `badge: "original"` → `badge: "mathlib"` — result uses Mathlib's ZSpan definitions

### 2. Seeker: area-of-circle-oq-01-oq-03-oq-01-oq-03 (`e85b4a2a24`)
- Adds axiom-elimination problem targeting MeasureTheory.integral_image_eq_integral_abs_deriv_smul
- Tier B, sig 7, tract 7

### 3. Fix erdos-512: stale annotations + audit tracker (`0c1400ecbb`)
- `ann-512-l1norm`: `L1norm_upper_bound (sorry)` → `(proved)` — theorem is fully proved via IntegrableOn + setIntegral_mono_on (lines 102–131)
- `ann-512-related`: `L2_norm (sorry)` → `(proved, pending 2 sorries in expSumNorm_sq_double)` — accurate description; range corrected 176–195 → 257–295
- `audit-tracker.json`: erdos-512 `issues-found` → `issues-fixed` with documented resolution

---
Automated fix by lean-mechanic agent.