### PR TITLE
Fix: kroneckers-jugendtraum status/badge/axiomCount (verified→axiomatized)

### DIFF
--- a/src/data/proofs/kroneckers-jugendtraum/meta.json
+++ b/src/data/proofs/kroneckers-jugendtraum/meta.json
@@ -7,14 +7,14 @@
   "meta": {
     "author": "Kronecker (1853), Weber (1886)",
     "date": "1886",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "number-theory",
       "class-field-theory",
       "hilbert-problems",
       "advanced"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -45,7 +45,7 @@
     ],
     "dateAdded": "2025-12-29",
     "hilbertNumber": 12,
-    "axiomCount": 0,
+    "axiomCount": 4,
     "assumptions": "4 placeholder axioms defined as Prop := True: (1) KroneckerWeberTheorem — every abelian extension of ℚ is cyclotomic (requires local class field theory to prove), (2) CMSolution — CM theory for imaginary quadratic fields (deep result in arithmetic geometry), (3) ArtinReciprocity — Artin reciprocity map isomorphism (central theorem of class field theory), (4) StarkConjecture — Stark's conjectures on L-function values (open conjecture). One genuine proof: cyclotomic_galois_comm (Galois group of cyclotomic extensions is abelian, via Mathlib's autEquivPow). Two Mathlib applications: cyclotomic degree = totient, cyclotomic polynomial irreducibility.",
     "proofRepoPath": "Proofs/KroneckersJugendtraum.lean",
     "mathlib_version": "4.26.0",
@@ -270,7 +270,7 @@
     ],
     "namespace": "KroneckersJugendtraum",
     "lineCount": 387,
-    "axiomCount": 0,
+    "axiomCount": 4,
     "sorries": 0
   },
   "mainTheorems": [


### PR DESCRIPTION
## Summary

- `status`: `verified` → `axiomatized`
- `badge`: `mathlib` → `axiom`
- `axiomCount`: `0` → `4` (in both `meta.axiomCount` and `leanFile.axiomCount`)

## Problem

The gallery entry for Kronecker's Jugendtraum (Hilbert's 12th) claimed `status: "verified"` and `axiomCount: 0`, but the Lean file `KroneckersJugendtraum.lean` contains 4 placeholder `Prop := True` definitions:

1. **KroneckerWeberTheorem** — every abelian extension of ℚ is cyclotomic (requires local class field theory)
2. **CMSolution** — CM theory for imaginary quadratic fields (deep arithmetic geometry)
3. **ArtinReciprocity** — Artin reciprocity map isomorphism (central class field theory result)
4. **StarkConjecture** — Stark conjectures on L-function values (open conjecture)

Per the [Axiom Integrity Policy](../../CLAUDE.md), placeholder `Prop := True` definitions count as axioms regardless of whether they use the `axiom` keyword. The `assumptions` field already correctly documented these; this PR aligns the status/badge/axiomCount to match.

The peer reviewer flagged this issue (review.json ai-1, high priority) and marked it resolved, but the fix was never applied to meta.json.

## What was genuinely proved

Three results are authentically machine-checked:
1. `cyclotomic_galois_comm` — Gal(ℚ(ζₙ)/ℚ) is abelian via `autEquivPow`
2. `cyclotomic_degree` — [ℚ(ζₙ):ℚ] = φ(n) via `IsCyclotomicExtension.finrank`
3. `cyclotomic_irreducible` — Φₙ is irreducible over ℤ

🤖 Generated with [Claude Code](https://claude.com/claude-code)