### PR TITLE
Fix: two meta.json integrity issues (conflict marker + wrong sorries type)

### DIFF
--- a/src/data/proofs/konigsberg-oq-02-oq-01/meta.json
+++ b/src/data/proofs/konigsberg-oq-02-oq-01/meta.json
@@ -129,13 +129,5 @@
       "description": "Original Königsberg bridges undirected case"
     }
   ],
-  "sorries": [
-    {
-      "id": "directed_euler_circuit_sufficient_corrected",
-      "description": "Main Hierholzer WF induction combining all proved sub-lemmas (splice + balance + arcCount)",
-      "type": "main_theorem",
-      "difficulty": "hard",
-      "proofSketch": "WF induction on D.arcCount - circuit.arcs.length; greedy trail → circuit (maximal_balanced_trail_is_circuit); extend via splice if not Eulerian; use removeArcList_balanced + removeArcList_arcCount for termination"
-    }
-  ]
+  "sorries": 1
 }

--- a/src/data/proofs/minkowski-fundamental-theorem-oq-04/meta.json
+++ b/src/data/proofs/minkowski-fundamental-theorem-oq-04/meta.json
@@ -64,7 +64,6 @@
       "The custom `Lattice n` is exactly `GL_n(ℝ)` in disguise: the condition `det(basis) ≠ 0` is invertibility. The bijection with `Module.Basis` shows that specifying a lattice basis is the same as choosing an invertible matrix.",
       "The key enabling lemma `basis_matrix_det_ne_zero` derives `det(Matrix.of b) ≠ 0` from the change-of-basis product identity `b.toMatrix(e) · e.toMatrix(b) = 1`. Since `det` is multiplicative and `det(1) = 1`, at least one factor must be nonzero.",
       "The `toModuleBasis_matrix_eq` theorem establishes that `Matrix.of(L.toModuleBasis n) = L.basis`. This is the bridge that makes round-trip proofs trivial: both round trips reduce to showing two lattice structures or two bases have the same underlying matrix.",
-<<<<<<< HEAD
       "The equivalence is necessarily `noncomputable`: extracting an `Invertible` instance from a `det ≠ 0` proof requires `Classical.choice`. This is a fundamental constructivity limit — you cannot algorithmically extract an inverse from mere non-vanishing of determinant.",
       "**The bridge closes the loop**: `minkowski_custom_via_zlattice` shows the custom Minkowski theorem is not independent — it is a definitional wrapper over the ZSpan-native proof. The trivial `minkowski_custom_via_zlattice_iff_fundamental` (proved by `Iff.rfl`) confirms the two proof routes are extensionally identical: the same proposition, just reached by different paths."
     ]


### PR DESCRIPTION
## Fix

Two metadata integrity issues discovered during gallery audit.

## Evidence

**Fix 1 — minkowski-fundamental-theorem-oq-04 (CRITICAL)**

**Before**: Accidental `<<<<<<< HEAD` Git conflict marker committed in PR #12201, breaking `pnpm build` with:
```
SyntaxError: Unexpected token '<', ..."matrix.", <<<<<<< HE"... is not valid JSON
```

**After**: Conflict marker removed; `keyInsights` array now has all 5 entries correctly.

**Fix 2 — konigsberg-oq-02-oq-01**

**Before**: Top-level `sorries` field was a JSON array of sorry-description objects instead of an integer:
```json
"sorries": [{"id": "directed_euler_circuit_sufficient_corrected", ...}]
```

**After**: Correct integer format matching `leanFile.sorries` and `meta.sorries`:
```json
"sorries": 1
```

The sorry description detail is preserved in `meta.assumptions`. All other gallery proofs use integer format for this field.

---
Automated fix by lean-mechanic agent.