### PR TITLE
Fix documentation inconsistency in konigsberg-oq-02-oq-01 meta.json

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12980,6 +12980,12 @@
       "lastAudited": "2026-04-24T04:27:46Z",
       "result": "clean",
       "issues": []
+    },
+    "konigsberg-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-24T09:11:12Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {

--- a/src/data/proofs/konigsberg-oq-02-oq-01/meta.json
+++ b/src/data/proofs/konigsberg-oq-02-oq-01/meta.json
@@ -21,7 +21,7 @@
     "sorries": 1,
     "dateAdded": "2026-04-24",
     "axiomCount": 0,
-    "assumptions": "1 sorry remains: directed_euler_circuit_sufficient_corrected (WF induction on arcCount combining splice + balance lemmas). Supporting lemmas removeArcList_arcCount and removeArcList_balanced are now fully proved.",
+    "assumptions": "1 sorry remains: directed_euler_circuit_sufficient_corrected (WF induction on arcCount combining splice + balance lemmas). Supporting lemmas removeArcList_arcCount and removeArcList_balanced are not yet formalized.",
     "lineCount": 286,
     "theoremCount": 6,
     "definitionCount": 1,
@@ -47,7 +47,7 @@
     ]
   },
   "conclusion": {
-    "summary": "Key infrastructure for Hierholzer's algorithm proved: maximal trail sub-lemma (0 sorries), Walk.splice (0 sorries), removeArcList_arcCount (0 sorries), removeArcList_balanced (0 sorries). 1 sorry remains for the WF induction combining all proved sub-lemmas.",
+    "summary": "Key infrastructure proved: maximal trail sub-lemma (0 sorries), degree counting lemmas fst_count_eq_outDegree_stuck and snd_count_le_inDegree (0 sorries). 1 sorry remains for the full Hierholzer WF induction (directed_euler_circuit_sufficient_corrected); Walk.splice and removeArcList_arcCount/removeArcList_balanced are not yet formalized.",
     "implications": [
       "Fixes bug in KonigsbergOQ02 directed Eulerian sufficiency axiom",
       "Walk.splice enables circuit extension proofs beyond this result",


### PR DESCRIPTION
## Summary
- Fix documentation inconsistency in konigsberg-oq-02-oq-01 meta.json: conclusion.summary and meta.assumptions falsely claimed Walk.splice, removeArcList_arcCount, and removeArcList_balanced were proved; these functions do not exist in the Lean file

## Test plan
- [ ] meta.json conclusion.summary accurately reflects what is proved in KonigsbergOQ02OQ01.lean
- [ ] meta.assumptions no longer claims unimplemented lemmas are proved

🤖 Generated with [Claude Code](https://claude.ai/claude-code)