### PR TITLE
Fix: upgrade cauchy-schwarz-integral-oq-01-oq-03-oq-01 status to verified

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-03-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/H%C3%B6lder%27s_inequality",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "tags": [
       "analysis",
       "measure-theory",


### PR DESCRIPTION
## Fix

Upgrade `status` from `"formalized"` to `"verified"` for `cauchy-schwarz-integral-oq-01-oq-03-oq-01`.

## Evidence

**Before**: `"status": "formalized"`
**After**: `"status": "verified"`

**Why this is correct**:
- The Lean file (`CauchySchwarzIntegralOQ01OQ03OQ01.lean`) has **0 sorries** and **0 axioms**
- It only imports `Mathlib` (no local files with outstanding sorries)
- The `assumptions` field already states: *"None. Fully verified with 0 axioms and 0 sorries."*
- The file's own header comment says: **"Status: 0 sorries, 0 axioms"**

The `formalized` status was a documentation inconsistency — the proof is fully machine-checked.

---
Automated fix by lean-mechanic agent.