### PR TITLE
Fix: clamp OOB section endLine values in 5 gallery entries

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "ballot-problem-oq-03-oq-01-oq-02",
   "title": "Hook-Length Formula for Standard Young Tableaux via LGV",
   "slug": "ballot-problem-oq-03-oq-01-oq-02",
-  "description": "Formalizes the hook-length formula f^\u03bb = n!/\u220fh(u) for Standard Young Tableaux. Fully proves the formula for single-row (1\u00d7n), single-column (n\u00d71), hook-shape ((m+1,1)), 2-row rectangular (m\u00d7m), and general 2-row [a,b] families. General formula has 4 sorries via LGV approach (RSK bijection, det factorization, main theorem) or 1 sorry via corner induction (hook_walk_identity). hook_length_formula_general proved via corner induction modulo hook_walk_identity.",
+  "description": "Formalizes the hook-length formula f^λ = n!/∏h(u) for Standard Young Tableaux. Fully proves the formula for single-row (1×n), single-column (n×1), hook-shape ((m+1,1)), 2-row rectangular (m×m), and general 2-row [a,b] families. General formula has 4 sorries via LGV approach (RSK bijection, det factorization, main theorem) or 1 sorry via corner induction (hook_walk_identity). hook_length_formula_general proved via corner induction modulo hook_walk_identity.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-21",
@@ -22,57 +22,57 @@
     "sorries": 4,
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "assumptions": "Four open sorries: (1) hook_length_formula (LGV approach: requires SYT\u2194NI bijection + det factorization), (2) ni_count_eq_syt_count (Fomin/Viennot/RSK correspondence), (3) lgv_det_factors_as_hook_quotient (det factorization identity), (4) hook_walk_identity (corner induction: sum of hook-ratio over corners = n; general proof requires ~300 lines). hook_length_formula_general is proved modulo hook_walk_identity via Part XIV corner induction.",
-    "lineCount": 4726,
+    "assumptions": "Four open sorries: (1) hook_length_formula (LGV approach: requires SYT↔NI bijection + det factorization), (2) ni_count_eq_syt_count (Fomin/Viennot/RSK correspondence), (3) lgv_det_factors_as_hook_quotient (det factorization identity), (4) hook_walk_identity (corner induction: sum of hook-ratio over corners = n; general proof requires ~300 lines). hook_length_formula_general is proved modulo hook_walk_identity via Part XIV corner induction.",
+    "lineCount": 4725,
     "theoremCount": 162,
     "definitionCount": 14,
     "originalContributions": [
       "hookLength: hook length at cell (i,j) = armLen + legLen + 1 using YoungDiagram.rowLen and colLen",
-      "hookLength_pos: hook lengths are always positive (arm + leg + 1 \u2265 1) \u2014 unconditional",
+      "hookLength_pos: hook lengths are always positive (arm + leg + 1 ≥ 1) — unconditional",
       "hookProd: product of all hook lengths over YoungDiagram cells",
       "StandardYoungTableau: formal structure for SYT with row/column strict conditions",
-      "hook_length_formula_one_row: f^(1\u00d7n) = 1 (direct, 0 sorries)",
-      "hook_length_formula_one_col: f^(n\u00d71) = 1 (direct, 0 sorries)",
-      "hook_length_formula_hook_shape: f^(m+1,1) = (m+1) \u00d7 (m+2) \u00d7 m! (bijection with Fin(m+1), 0 sorries)",
-      "card_SYT_twoRectYD: card(SYT(m\u00d7m)) = Cn m via Lindstrom reflection bijection (0 sorries)",
-      "hook_length_formula_two_rect: Cn(m) \u00d7 (m+1)! \u00d7 m! = (2m)! (proved, 0 sorries)",
-      "twoRowYD: general 2-row Young diagram [a,b] for a\u2265b",
-      "hookProd_twoRowYD: hookProd([a,b]) = (a+1).descFactorial b \u00d7 (a-b)! \u00d7 b! (proved, 0 sorries)",
-      "two_row_hook_identity: numerical identity ballotSeqCount(a+1,b) \u00d7 hookProd = (a+b)! (proved, 0 sorries)",
+      "hook_length_formula_one_row: f^(1×n) = 1 (direct, 0 sorries)",
+      "hook_length_formula_one_col: f^(n×1) = 1 (direct, 0 sorries)",
+      "hook_length_formula_hook_shape: f^(m+1,1) = (m+1) × (m+2) × m! (bijection with Fin(m+1), 0 sorries)",
+      "card_SYT_twoRectYD: card(SYT(m×m)) = Cn m via Lindstrom reflection bijection (0 sorries)",
+      "hook_length_formula_two_rect: Cn(m) × (m+1)! × m! = (2m)! (proved, 0 sorries)",
+      "twoRowYD: general 2-row Young diagram [a,b] for a≥b",
+      "hookProd_twoRowYD: hookProd([a,b]) = (a+1).descFactorial b × (a-b)! × b! (proved, 0 sorries)",
+      "two_row_hook_identity: numerical identity ballotSeqCount(a+1,b) × hookProd = (a+b)! (proved, 0 sorries)",
       "hook_length_formula_two_row_gen: formula for general 2-row [a,b] (1 sorry: card_SYT_twoRowYD)",
       "Numerical verification: hook-length formula proved for (2,1), (2,2), (3,1), (3,2), (3,2,1), (4,3,2,1), (3,3), (4,4) shapes",
       "hook_length_formula_gHookYD: HLF for all generalized hook shapes [a, 1^b] (card = C(a+b-1,b), proved via double induction + inline bijection, 0 sorries)",
-      "hook_walk_identity: sum over corners c of hookProd(\u03bc)/hookProd(\u03bc\\c) = \u03bc.card \u2014 corner recursion key lemma (1 sorry, verified for all special cases)",
+      "hook_walk_identity: sum over corners c of hookProd(μ)/hookProd(μ\\c) = μ.card — corner recursion key lemma (1 sorry, verified for all special cases)",
       "hook_length_formula_general: HLF for all Young diagrams via corner induction (proved modulo hook_walk_identity, 0 sorries in the theorem itself)"
     ]
   },
   "overview": {
-    "historicalContext": "The hook-length formula (Frame-Robinson-Thrall 1954) states f^\u03bb = n!/\u220fh(u) where h(u) = arm(u) + leg(u) + 1 is the hook length at cell u of the Young diagram \u03bb. This is one of the most celebrated formulas in algebraic combinatorics, connecting enumerative combinatorics with representation theory (f^\u03bb = dim Specht module S^\u03bb). The Lindstr\u00f6m-Gessel-Viennot (LGV) approach provides a determinantal proof: SYT of shape \u03bb biject with non-intersecting lattice path systems, and the LGV determinant factors as the hook product. This file extends the Lean 4 LGV infrastructure from BallotProblemOQ03OQ02 toward a complete formalization of the hook-length formula.",
-    "problemStatement": "Given the complete n\u00d7n LGV infrastructure in BallotProblemOQ03OQ02.lean, prove the hook-length formula f^\u03bb = n!/\u220f_{u\u2208\u03bb}h(u) using: (1) the bijection between SYT(\u03bb) and non-intersecting lattice path tuples with LGV source/target encoding, and (2) the algebraic identity showing the LGV determinant equals n!/\u220fh(u).",
-    "text": "This file builds the formal mathematical infrastructure for the hook-length formula. The key definitions are: (1) hookLength \u03bc i j = (rowLen i - j - 1) + (colLen j - i - 1) + 1 (arm + leg + 1) using Mathlib's YoungDiagram API; (2) hookProd \u03bc = \u220f_{c \u2208 \u03bc.cells} hookLength \u03bc c.1 c.2; (3) StandardYoungTableau \u03bc as a structure with strict row/column monotonicity conditions. The LGV encoding uses weakly-increasing row lengths \u03c3 (reversed partition), sources(k) = k, targets(k) = \u03c3(k) + k. Numerical verification via norm_num confirms the formula for all shapes up to size 10.",
-    "proofStrategy": "Two-step approach: (Step 1) Bijection between StandardYoungTableau \u03bc and the NI-path count niTupleCount(youngLGVConfig r \u03c3 h\u03c3 m hm) via the Fomin growth diagram bijection (ni_count_eq_syt_count, open). (Step 2) Algebraic identity det[C(m + \u03c3\u2c7c + j - i, m)] = \u03bc.card! / hookProd \u03bc (lgv_det_factors_as_hook_quotient, open \u2014 Vandermonde-type for rectangular, Frame-Robinson-Thrall for general). Both combine with lgv_lemma_rxr to give the main theorem hook_length_formula.",
+    "historicalContext": "The hook-length formula (Frame-Robinson-Thrall 1954) states f^λ = n!/∏h(u) where h(u) = arm(u) + leg(u) + 1 is the hook length at cell u of the Young diagram λ. This is one of the most celebrated formulas in algebraic combinatorics, connecting enumerative combinatorics with representation theory (f^λ = dim Specht module S^λ). The Lindström-Gessel-Viennot (LGV) approach provides a determinantal proof: SYT of shape λ biject with non-intersecting lattice path systems, and the LGV determinant factors as the hook product. This file extends the Lean 4 LGV infrastructure from BallotProblemOQ03OQ02 toward a complete formalization of the hook-length formula.",
+    "problemStatement": "Given the complete n×n LGV infrastructure in BallotProblemOQ03OQ02.lean, prove the hook-length formula f^λ = n!/∏_{u∈λ}h(u) using: (1) the bijection between SYT(λ) and non-intersecting lattice path tuples with LGV source/target encoding, and (2) the algebraic identity showing the LGV determinant equals n!/∏h(u).",
+    "text": "This file builds the formal mathematical infrastructure for the hook-length formula. The key definitions are: (1) hookLength μ i j = (rowLen i - j - 1) + (colLen j - i - 1) + 1 (arm + leg + 1) using Mathlib's YoungDiagram API; (2) hookProd μ = ∏_{c ∈ μ.cells} hookLength μ c.1 c.2; (3) StandardYoungTableau μ as a structure with strict row/column monotonicity conditions. The LGV encoding uses weakly-increasing row lengths σ (reversed partition), sources(k) = k, targets(k) = σ(k) + k. Numerical verification via norm_num confirms the formula for all shapes up to size 10.",
+    "proofStrategy": "Two-step approach: (Step 1) Bijection between StandardYoungTableau μ and the NI-path count niTupleCount(youngLGVConfig r σ hσ m hm) via the Fomin growth diagram bijection (ni_count_eq_syt_count, open). (Step 2) Algebraic identity det[C(m + σⱼ + j - i, m)] = μ.card! / hookProd μ (lgv_det_factors_as_hook_quotient, open — Vandermonde-type for rectangular, Frame-Robinson-Thrall for general). Both combine with lgv_lemma_rxr to give the main theorem hook_length_formula.",
     "keyInsights": [
-      "hookLength is always positive (arm + leg + 1 \u2265 1) regardless of whether (i,j) is in \u03bc \u2014 unconditional positivity from the definition",
-      "The LGV encoding requires \u03c3 weakly INCREASING (reversed partition order) to ensure targets(k) = \u03c3(k)+k is strictly monotone",
-      "The LGV wellFormed condition needs \u03c3(0) \u2265 r-1 (minimum target \u2265 maximum source): \u03c3(0) is the smallest row length",
-      "Numerical verification: for (2,1): 3!/(3\u00d71\u00d71) = 2 \u2713; for (3,2,1): 6!/(5\u00d73\u00d71\u00d73\u00d71\u00d71) = 16 \u2713",
+      "hookLength is always positive (arm + leg + 1 ≥ 1) regardless of whether (i,j) is in μ — unconditional positivity from the definition",
+      "The LGV encoding requires σ weakly INCREASING (reversed partition order) to ensure targets(k) = σ(k)+k is strictly monotone",
+      "The LGV wellFormed condition needs σ(0) ≥ r-1 (minimum target ≥ maximum source): σ(0) is the smallest row length",
+      "Numerical verification: for (2,1): 3!/(3×1×1) = 2 ✓; for (3,2,1): 6!/(5×3×1×3×1×1) = 16 ✓",
       "The two open lemmas (NI bijection + det factorization) are HARD (known mathematics, ~200 lines each)",
-      "hookProd_empty: empty diagram \u2192 hook product 1 (empty product), connecting to n!=1 for n=0"
+      "hookProd_empty: empty diagram → hook product 1 (empty product), connecting to n!=1 for n=0"
     ],
     "prerequisites": [
-      "lgv_lemma_rxr from BallotProblemOQ03OQ02: the general n\u00d7n LGV determinant formula",
+      "lgv_lemma_rxr from BallotProblemOQ03OQ02: the general n×n LGV determinant formula",
       "YoungDiagram (Mathlib): cells, rowLen, colLen with mem_iff_lt_rowLen and mem_iff_lt_colLen",
       "LGVConfig: sources, targets, strictMono, source_le_target, wellFormed",
       "Frame-Robinson-Thrall 1954: original hook-length formula paper"
     ]
   },
   "conclusion": {
-    "summary": "Hook-length formula fully proved for five infinite families: 1\u00d7n (direct), n\u00d71 (direct), hook-shape (m+1,1) (bijection), 2\u00d7m rect (Lindstrom reflection), and general 2-row [a,b] (conditional on ballot bijection, 1 sorry). hookProd for [a,b] = (a+1).descFactorial(b) \u00d7 (a-b)! \u00d7 b! proved with 0 sorries. Part XIV (commit c0dcbcf81a) adds hook_length_formula_general as the primary result, proved via corner induction modulo hook_walk_identity (1 sorry), reducing from 3 sorries in the LGV approach to 1. Total: 4 sorries (3 LGV path + 1 corner induction).",
-    "implications": "A complete formalization would be the first Lean 4 proof of the hook-length formula, a milestone in formal combinatorics. The LGV approach connects our existing ballot problem proofs to representation theory via the Specht module dimension formula f^\u03bb = dim S^\u03bb.",
+    "summary": "Hook-length formula fully proved for five infinite families: 1×n (direct), n×1 (direct), hook-shape (m+1,1) (bijection), 2×m rect (Lindstrom reflection), and general 2-row [a,b] (conditional on ballot bijection, 1 sorry). hookProd for [a,b] = (a+1).descFactorial(b) × (a-b)! × b! proved with 0 sorries. Part XIV (commit c0dcbcf81a) adds hook_length_formula_general as the primary result, proved via corner induction modulo hook_walk_identity (1 sorry), reducing from 3 sorries in the LGV approach to 1. Total: 4 sorries (3 LGV path + 1 corner induction).",
+    "implications": "A complete formalization would be the first Lean 4 proof of the hook-length formula, a milestone in formal combinatorics. The LGV approach connects our existing ballot problem proofs to representation theory via the Specht module dimension formula f^λ = dim S^λ.",
     "openQuestions": [
-      "Formalize the SYT \u2194 NI bijection via Fomin's growth diagrams or the RSK correspondence (~200 lines)",
-      "Prove the det factorization det[C(m+\u03c3\u2c7c+j-i,m)] = n!/hookProd for general partitions via a Vandermonde-type identity",
-      "Add Fintype instance for StandardYoungTableau via column-reading bijection with Fin \u03bc.card permutations"
+      "Formalize the SYT ↔ NI bijection via Fomin's growth diagrams or the RSK correspondence (~200 lines)",
+      "Prove the det factorization det[C(m+σⱼ+j-i,m)] = n!/hookProd for general partitions via a Vandermonde-type identity",
+      "Add Fintype instance for StandardYoungTableau via column-reading bijection with Fin μ.card permutations"
     ]
   },
   "leanFile": {
@@ -86,7 +86,7 @@
       "LGV"
     ],
     "namespace": "HookLengthFormula",
-    "lineCount": 3866,
+    "lineCount": 4725,
     "axiomCount": 0,
     "sorries": 4,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",
@@ -96,17 +96,17 @@
   "crossReferences": [
     {
       "id": "ballot-problem-oq-03-oq-01",
-      "title": "LGV Lemma 2\u00d72",
+      "title": "LGV Lemma 2×2",
       "relationship": "foundational"
     },
     {
       "id": "ballot-problem-oq-03-oq-02",
-      "title": "LGV Lemma n\u00d7n",
+      "title": "LGV Lemma n×n",
       "relationship": "foundational"
     },
     {
       "id": "ballot-problem-oq-03-oq-01-oq-01",
-      "title": "General n\u00d7n LGV (restatement)",
+      "title": "General n×n LGV (restatement)",
       "relationship": "sibling"
     },
     {
@@ -121,16 +121,16 @@
       "title": "Part I: Hook Length Infrastructure",
       "startLine": 38,
       "endLine": 80,
-      "summary": "Defines armLen, legLen, hookLength. Proves hookLength_pos (always > 0) and hookLength_add_eq (avoids \u2115 subtraction).",
-      "mathContext": "hookLength \u03bc i j = (rowLen i - j - 1) + (colLen j - i - 1) + 1. Positivity: arm+leg+1 \u2265 1 always. For (i,j) \u2208 \u03bc: j < rowLen i and i < colLen j."
+      "summary": "Defines armLen, legLen, hookLength. Proves hookLength_pos (always > 0) and hookLength_add_eq (avoids ℕ subtraction).",
+      "mathContext": "hookLength μ i j = (rowLen i - j - 1) + (colLen j - i - 1) + 1. Positivity: arm+leg+1 ≥ 1 always. For (i,j) ∈ μ: j < rowLen i and i < colLen j."
     },
     {
       "id": "sec-hook-prod",
       "title": "Part II: Hook Product",
       "startLine": 85,
       "endLine": 105,
-      "summary": "Defines hookProd as \u220f over \u03bc.cells. Proves hookProd_pos and hookProd_empty = 1.",
-      "mathContext": "hookProd \u03bc = \u220f_{c \u2208 \u03bc.cells} hookLength \u03bc c.1 c.2. Positivity via Finset.prod_pos. hookProd \u22a5 = 1 by cells_bot + prod_empty."
+      "summary": "Defines hookProd as ∏ over μ.cells. Proves hookProd_pos and hookProd_empty = 1.",
+      "mathContext": "hookProd μ = ∏_{c ∈ μ.cells} hookLength μ c.1 c.2. Positivity via Finset.prod_pos. hookProd ⊥ = 1 by cells_bot + prod_empty."
     },
     {
       "id": "sec-syt",
@@ -138,23 +138,23 @@
       "startLine": 110,
       "endLine": 140,
       "summary": "Defines StandardYoungTableau structure with entry function, entry_zero, entry_range, entry_injOn, row_strict, col_strict.",
-      "mathContext": "SYT condition: entries in {1,...,|\u03bc|}, bijective on \u03bc, strictly increasing along rows and columns. Unlike SemistandardYoungTableau in Mathlib (weakly increasing rows), SYT requires STRICT row increasing."
+      "mathContext": "SYT condition: entries in {1,...,|μ|}, bijective on μ, strictly increasing along rows and columns. Unlike SemistandardYoungTableau in Mathlib (weakly increasing rows), SYT requires STRICT row increasing."
     },
     {
       "id": "sec-lgv-config",
       "title": "Part IV: LGV Configuration",
       "startLine": 145,
       "endLine": 175,
-      "summary": "Defines youngLGVConfig with sources(k)=k, targets(k)=\u03c3(k)+k for weakly increasing \u03c3. Proves wellFormed under \u03c3(0) \u2265 r-1.",
-      "mathContext": "targets_strictMono: \u03c3 monotone + i < j \u2192 \u03c3(i)+i < \u03c3(j)+j. wellFormed: uses Fin.zero_le j for \u03c3(0) \u2264 \u03c3(j)."
+      "summary": "Defines youngLGVConfig with sources(k)=k, targets(k)=σ(k)+k for weakly increasing σ. Proves wellFormed under σ(0) ≥ r-1.",
+      "mathContext": "targets_strictMono: σ monotone + i < j → σ(i)+i < σ(j)+j. wellFormed: uses Fin.zero_le j for σ(0) ≤ σ(j)."
     },
     {
       "id": "sec-main-theorem",
       "title": "Parts V-VI: Main Theorems",
       "startLine": 180,
       "endLine": 210,
-      "summary": "hook_length_formula_2row_rect (proved via OQ03OQ03), hook_length_formula (sorry), ni_count_eq_syt_count (sorry), lgv_det_factors_as_hook_quotient (sorry), card_SYT_twoRectYD (sorry \u2014 SYT count for 2-row rect = C_m).",
-      "mathContext": "Main theorem: card(SYT(\u03bc)) \u00d7 hookProd \u03bc = \u03bc.card!. The two sorry components require ~200 lines each."
+      "summary": "hook_length_formula_2row_rect (proved via OQ03OQ03), hook_length_formula (sorry), ni_count_eq_syt_count (sorry), lgv_det_factors_as_hook_quotient (sorry), card_SYT_twoRectYD (sorry — SYT count for 2-row rect = C_m).",
+      "mathContext": "Main theorem: card(SYT(μ)) × hookProd μ = μ.card!. The two sorry components require ~200 lines each."
     },
     {
       "id": "sec-numerical",
@@ -162,15 +162,15 @@
       "startLine": 215,
       "endLine": 240,
       "summary": "Proves hook-length formula for 8 specific shapes via norm_num.",
-      "mathContext": "Verified: (2,1)\u21922, (2,2)\u21922, (3,1)\u21923, (3,2)\u21925, (3,2,1)\u219216, (4,3,2,1)\u21921440, (3,3)\u21925 (C\u2083), (4,4)\u219214 (C\u2084)."
+      "mathContext": "Verified: (2,1)→2, (2,2)→2, (3,1)→3, (3,2)→5, (3,2,1)→16, (4,3,2,1)→1440, (3,3)→5 (C₃), (4,4)→14 (C₄)."
     },
     {
       "id": "sec-corner-induction",
       "title": "Part XIV: hook_length_formula_general via Corner Induction",
       "startLine": 4600,
-      "endLine": 4726,
-      "summary": "Proves hook_length_formula_general by well-founded induction on \u03bc.card, using card_SYT_corner_step (Part XIII) + hook_walk_identity (1 sorry). hook_length_formula_Q is the \u211a version proved by WF induction.",
-      "mathContext": "hook_walk_identity: \u03a3_c hookProd(\u03bc)/hookProd(\u03bc\\c) = \u03bc.card. The main theorem reduces to hook_length_formula_Q via exact_mod_cast."
+      "endLine": 4725,
+      "summary": "Proves hook_length_formula_general by well-founded induction on μ.card, using card_SYT_corner_step (Part XIII) + hook_walk_identity (1 sorry). hook_length_formula_Q is the ℚ version proved by WF induction.",
+      "mathContext": "hook_walk_identity: Σ_c hookProd(μ)/hookProd(μ\\c) = μ.card. The main theorem reduces to hook_length_formula_Q via exact_mod_cast."
     }
   ],
   "sorries": 4

--- a/src/data/proofs/erdos-135/meta.json
+++ b/src/data/proofs/erdos-135/meta.json
@@ -81,40 +81,8 @@
       "title": "Forbidden Four-Point Patterns",
       "summary": "InGeneralPosition, IsParallelogram, IsForbiddenPattern, parallelogram_forbidden",
       "startLine": 107,
-      "endLine": 204,
+      "endLine": 146,
       "mathContext": "Mathematical content: InGeneralPosition, IsParallelogram, IsForbiddenPattern, parallelogram_forbidden"
-    },
-    {
-      "id": "algebraic-construction",
-      "title": "Tao's Algebraic Construction",
-      "summary": "ParabolaParams, RandomizedParabolaApproach, parabolas over finite fields",
-      "startLine": 205,
-      "endLine": 235,
-      "mathContext": "Mathematical content: ParabolaParams, RandomizedParabolaApproach, parabolas over finite fields"
-    },
-    {
-      "id": "comparison-bounds",
-      "title": "Comparison with Erdős-Guth-Katz Bounds",
-      "summary": "trivial_distance_bound, guth_katz_lower_bound, tao_optimal_up_to_log",
-      "startLine": 236,
-      "endLine": 301,
-      "mathContext": "Bound: trivial_distance_bound, guth_katz_lower_bound, tao_optimal_up_to_log"
-    },
-    {
-      "id": "examples",
-      "title": "Example Configurations",
-      "summary": "Square (2 distances), rhombus (3), projected tetrahedron (4), generic (6)",
-      "startLine": 302,
-      "endLine": 355,
-      "mathContext": "Mathematical content: Square (2 distances), rhombus (3), projected tetrahedron (4), generic (6)"
-    },
-    {
-      "id": "summary",
-      "title": "Summary",
-      "summary": "Problem DISPROVED by Tao 2024, key techniques, historical context",
-      "startLine": 356,
-      "endLine": 392,
-      "mathContext": "Mathematical content: Problem DISPROVED by Tao 2024, key techniques, historical context"
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-249-oq-01/meta.json
+++ b/src/data/proofs/erdos-249-oq-01/meta.json
@@ -107,7 +107,7 @@
       "title": "Part VII: Second Tightening (87/64, 351/256) and 4/3 Exclusion",
       "summary": "Terms n=7..10 computed exactly. partial_sum_11 = 87/64. Tail splitting at n=11 gives upper bound < 351/256. totientPowerSum_ne_four_thirds proved since 87/64 > 4/3.",
       "startLine": 205,
-      "endLine": 308
+      "endLine": 303
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-94/meta.json
+++ b/src/data/proofs/erdos-94/meta.json
@@ -145,16 +145,8 @@
       "title": "Erdős-Fishburn Conjecture",
       "summary": "Defines `ErdosFishburnConjecture : Prop` — regular $n$-gon maximizes $\\sum f(u)^2$ for large $n$. States `conjecture_small_cases` for $n \\leq 10$ (sorry).",
       "startLine": 147,
-      "endLine": 159,
+      "endLine": 152,
       "mathContext": "Formal definition: Defines `ErdosFishburnConjecture : Prop` — regular $n$-gon maximizes $\\sum f(u)^2$ for large $n$. States `conjecture_small_cases` for $n \\leq 10$ (sorry)."
-    },
-    {
-      "id": "connections",
-      "title": "Connections",
-      "summary": "Defines `numDistinctDistances`, `maxMultiplicity`, `unitDistanceCount`. States convex bounds: $|d(P)| \\leq \\lfloor n/2 \\rfloor + 1$, $\\max f(u) \\leq 2n$, $f(1) \\leq 2n - 2$ (all sorry).",
-      "startLine": 160,
-      "endLine": 433,
-      "mathContext": "Formal definition: Defines `numDistinctDistances`, `maxMultiplicity`, `unitDistanceCount`. States convex bounds: $|d(P)| \\leq \\lfloor n/2 \\rfloor + 1$, $\\max f(u) \\leq 2n$, $f(1) \\leq 2n - 2$ (all sorry)."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/minkowski-fundamental-theorem-oq-04/meta.json
+++ b/src/data/proofs/minkowski-fundamental-theorem-oq-04/meta.json
@@ -8,11 +8,17 @@
     "proofRepoPath": "Proofs/MinkowskiFundamentalTheoremOQ04.lean",
     "author": "Lean Genius",
     "date": "2026",
-    "tags": ["number-theory", "lattices", "mathlib", "geometry-of-numbers", "api-comparison"],
+    "tags": [
+      "number-theory",
+      "lattices",
+      "mathlib",
+      "geometry-of-numbers",
+      "api-comparison"
+    ],
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 193,
+    "lineCount": 192,
     "theoremCount": 10,
     "definitionCount": 3,
     "dateAdded": "2026-04-24",
@@ -115,7 +121,7 @@
       "id": "sec-bridge",
       "title": "Bridge: Custom API Backed by ZSpan Minkowski",
       "startLine": 163,
-      "endLine": 193,
+      "endLine": 192,
       "summary": "`minkowski_custom_via_zlattice` reduces the custom Minkowski theorem to `minkowski_general_lattice_proved` via the conversion bridge; `minkowski_custom_via_zlattice_iff_fundamental` confirms extensional equality by `Iff.rfl`."
     }
   ],


### PR DESCRIPTION
Corrects 10 out-of-bounds section annotation endLine values across 5 gallery proofs. Sections whose endLine exceeded the actual Lean file length were clamped to the file boundary; sections whose startLine already exceeded the file length were removed entirely. Automated fix by lean-mechanic agent.