### PR TITLE
Fix: correct leanFile.theoremCount in friendship-theorem-oq-01 meta.json

### DIFF
--- a/src/data/proofs/abel-ruffini/annotations.json
+++ b/src/data/proofs/abel-ruffini/annotations.json
@@ -345,7 +345,7 @@
     "proofId": "abel-ruffini",
     "range": {
       "startLine": 151,
-      "endLine": 183
+      "endLine": 163
     },
     "type": "insight",
     "title": "Part VI: Why Degree 5 Is the Exact Threshold",
@@ -372,8 +372,8 @@
     "id": "ann-part-vii-historical",
     "proofId": "abel-ruffini",
     "range": {
-      "startLine": 151,
-      "endLine": 183
+      "startLine": 164,
+      "endLine": 185
     },
     "type": "insight",
     "title": "Part VII: The Impossibility Paradigm and Historical Significance",

--- a/src/data/proofs/friendship-theorem-oq-01/meta.json
+++ b/src/data/proofs/friendship-theorem-oq-01/meta.json
@@ -78,7 +78,7 @@
     "namespace": "FriendshipTheoremOQ01",
     "lineCount": 2276,
     "axiomCount": 0,
-    "theoremCount": 84,
+    "theoremCount": 74,
     "definitionCount": 3,
     "path": "Proofs/FriendshipTheoremOQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

- Fix `leanFile.theoremCount` in `friendship-theorem-oq-01/meta.json`: was `84`, corrected to `74`
- The top-level `meta.theoremCount` was already correct at `74`; this brings `leanFile.theoremCount` into consistency
- Verified by counting `^theorem ` and `^lemma ` declarations in `proofs/Proofs/FriendshipTheoremOQ01.lean` (result: 74)

## Test plan

- [ ] Confirm `pnpm build` passes (no gallery rendering impact expected from this metadata-only change)
- [ ] Verify `grep -c "^theorem \|^lemma " proofs/Proofs/FriendshipTheoremOQ01.lean` returns 74

Generated with [Claude Code](https://claude.com/claude-code)