### PR TITLE
Fix: clamp OOB annotation endLine values across 478 gallery entries

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-03/annotations.json
@@ -8,14 +8,14 @@
     },
     "type": "concept",
     "title": "Power Mean Family: Overview and Open Question",
-    "content": "The header introduces the weighted power mean family M_r(z,w) and the open question: to fully formalize the monotonicity M_r <= M_s for all r <= s in Lean 4/Mathlib. **Note**: The header's item 7 (line 33) is stale \u2014 it says 'General monotonicity (negative r case) stated as an axiom' but the file actually proves power_mean_monotone_neg (lines 291\u2013343) with no axioms or sorries. The file proves 13 results total including HM \u2264 GM, M_r \u2264 M_s for 0 < r \u2264 s, and M_r \u2264 M_s for r \u2264 s < 0. Only the mixed-sign case (r < 0 < s) remains open. The imports bring in Mathlib.Analysis.MeanInequalities for the weighted AM-GM inequality and Mathlib.Analysis.MeanInequalitiesPow for Jensen's power inequality.",
+    "content": "The header introduces the weighted power mean family M_r(z,w) and the open question: to fully formalize the monotonicity M_r <= M_s for all r <= s in Lean 4/Mathlib. **Note**: The header's item 7 (line 33) is stale — it says 'General monotonicity (negative r case) stated as an axiom' but the file actually proves power_mean_monotone_neg (lines 291–343) with no axioms or sorries. The file proves 13 results total including HM ≤ GM, M_r ≤ M_s for 0 < r ≤ s, and M_r ≤ M_s for r ≤ s < 0. Only the mixed-sign case (r < 0 < s) remains open. The imports bring in Mathlib.Analysis.MeanInequalities for the weighted AM-GM inequality and Mathlib.Analysis.MeanInequalitiesPow for Jensen's power inequality.",
     "mathContext": "$M_r(z,w) = \\left(\\sum_{i} w_i z_i^r\\right)^{1/r}$ for $r \\neq 0$; $M_0 = \\prod_i z_i^{w_i}$ (geometric mean as limit). The chain: $\\text{HM} = M_{-1} \\leq M_0 = \\text{GM} \\leq M_1 = \\text{AM} \\leq M_2 \\leq \\cdots$",
     "significance": "supporting",
     "relatedConcepts": [
       "AM-GM inequality",
       "power means",
       "Jensen's inequality",
-      "Hardy-Littlewood-P\u00f3lya"
+      "Hardy-Littlewood-Pólya"
     ],
     "prerequisites": [
       "weighted inequalities",
@@ -32,7 +32,7 @@
     },
     "type": "concept",
     "title": "Shared Variables: Abstract Index Type and Weight/Value Functions",
-    "content": "The variable block declares the abstract index type \u03b9 (with implicit [DecidableEq \u03b9] and [Fintype \u03b9] from the Finset API), the finite index set s : Finset \u03b9, and the weight and value functions w z : \u03b9 \u2192 \u211d. This polymorphic setup allows the power mean theorems to work for any finite collection of real numbers with any indexing scheme \u2014 a common Mathlib pattern that avoids committing to Fin n or a specific concrete type. The hypotheses on w and z (non-negativity, positivity, weight normalization) are stated in each theorem individually rather than as variable-level assumptions.",
+    "content": "The variable block declares the abstract index type ι (with implicit [DecidableEq ι] and [Fintype ι] from the Finset API), the finite index set s : Finset ι, and the weight and value functions w z : ι → ℝ. This polymorphic setup allows the power mean theorems to work for any finite collection of real numbers with any indexing scheme — a common Mathlib pattern that avoids committing to Fin n or a specific concrete type. The hypotheses on w and z (non-negativity, positivity, weight normalization) are stated in each theorem individually rather than as variable-level assumptions.",
     "mathContext": "The abstract setup: $s \\subseteq \\iota$ (finite index set), $w : \\iota \\to \\mathbb{R}$ (weights, typically $w_i \\geq 0$, $\\sum w_i = 1$), $z : \\iota \\to \\mathbb{R}$ (values, typically $z_i > 0$). All power mean results are parametric in these choices.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -78,7 +78,7 @@
     },
     "type": "theorem",
     "title": "Known Results from Mathlib: M1=AM, AM<=Mp, GM<=AM, GM<=Mp, Jensen",
-    "content": "Four theorems wrap existing Mathlib results. power_mean_one_eq_arith_mean proves M_1 = AM by simp with Real.rpow_one. arith_mean_le_power_mean invokes Real.arith_mean_le_rpow_mean directly. geom_mean_le_arith_mean calls Real.geom_mean_le_arith_mean_weighted. geom_mean_le_power_mean_of_one_le combines the previous two via .trans. jensen_pow_ineq wraps Real.rpow_arith_mean_le_arith_mean_rpow \u2014 this is Jensen's inequality (sum w_i z_i)^p <= sum w_i z_i^p for p >= 1, and is the key tool for power_mean_monotone_pos.",
+    "content": "Four theorems wrap existing Mathlib results. power_mean_one_eq_arith_mean proves M_1 = AM by simp with Real.rpow_one. arith_mean_le_power_mean invokes Real.arith_mean_le_rpow_mean directly. geom_mean_le_arith_mean calls Real.geom_mean_le_arith_mean_weighted. geom_mean_le_power_mean_of_one_le combines the previous two via .trans. jensen_pow_ineq wraps Real.rpow_arith_mean_le_arith_mean_rpow — this is Jensen's inequality (sum w_i z_i)^p <= sum w_i z_i^p for p >= 1, and is the key tool for power_mean_monotone_pos.",
     "mathContext": "Jensen's inequality for convex $t \\mapsto t^p$ ($p \\geq 1$): $\\left(\\sum_i w_i z_i\\right)^p \\leq \\sum_i w_i z_i^p$. Equivalently, $\\text{AM} \\leq M_p$: $\\sum_i w_i z_i \\leq \\left(\\sum_i w_i z_i^p\\right)^{1/p}$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -151,7 +151,7 @@
       "endLine": 280
     },
     "type": "theorem",
-    "title": "Duality Identity: M_r(z) = M_{-r}(z\u207b\u00b9)\u207b\u00b9",
+    "title": "Duality Identity: M_r(z) = M_{-r}(z⁻¹)⁻¹",
     "content": "`power_mean_neg_inv` establishes the algebraic identity $M_r(z) = M_{-r}(z^{-1})^{-1}$ by two key steps. First, the sum equality: $(z_i^{-1})^{-r} = z_i^r$ via `inv_rpow` + `rpow_neg` + `inv_inv`. Second, the power equality: $A^{1/r} = (A^{1/(-r)})^{-1}$ since $1/(-r) = -(1/r)$ and `rpow_neg` + `inv_inv`. Helper lemmas `weighted_sum_pos` and `weightedPowerMean_pos` establish the positivity conditions needed for the inversion step. This identity is the key tool for reducing negative-exponent power mean problems to positive-exponent ones.",
     "mathContext": "$M_r(z) = \\left(\\sum w_i z_i^r\\right)^{1/r} = \\left(\\sum w_i (z_i^{-1})^{-r}\\right)^{1/r} = \\left(\\left(\\sum w_i (z_i^{-1})^{-r}\\right)^{1/(-r)}\\right)^{-1} = M_{-r}(z^{-1})^{-1}$. The identity holds for all $r \\neq 0$ and $z_i > 0$.",
     "significance": "key",
@@ -176,9 +176,9 @@
       "endLine": 343
     },
     "type": "theorem",
-    "title": "Power Mean Monotonicity for r \u2264 s < 0 (Dual Argument)",
+    "title": "Power Mean Monotonicity for r ≤ s < 0 (Dual Argument)",
     "content": "`power_mean_monotone_neg` proves $M_r \\leq M_s$ for $r \\leq s < 0$ by a three-step dual argument: (1) negate exponents to get $0 < -s \\leq -r$; (2) apply `power_mean_monotone_pos` to $z^{-1}$ with exponents $-s \\leq -r$ to get $M_{-s}(z^{-1}) \\leq M_{-r}(z^{-1})$; (3) apply `power_mean_neg_inv` to convert back: $M_r(z) = M_{-r}(z^{-1})^{-1} \\leq M_{-s}(z^{-1})^{-1} = M_s(z)$. The inversion step (larger denominator gives smaller reciprocal) uses explicit `calc` blocks with multiplicative algebra to avoid `inv_le_inv_of_le` which was unavailable in the target Lean version.",
-    "mathContext": "For $r \\leq s < 0$: negate to $0 < -s \\leq -r$, apply positive monotonicity to $z^{-1}$: $M_{-s}(z^{-1}) \\leq M_{-r}(z^{-1})$. Invert (larger positive \u2192 smaller reciprocal): $M_{-r}(z^{-1})^{-1} \\leq M_{-s}(z^{-1})^{-1}$. By duality: $M_r(z) \\leq M_s(z)$. Combined with positive case: $M_r \\leq M_s$ for all same-sign $r \\leq s$.",
+    "mathContext": "For $r \\leq s < 0$: negate to $0 < -s \\leq -r$, apply positive monotonicity to $z^{-1}$: $M_{-s}(z^{-1}) \\leq M_{-r}(z^{-1})$. Invert (larger positive → smaller reciprocal): $M_{-r}(z^{-1})^{-1} \\leq M_{-s}(z^{-1})^{-1}$. By duality: $M_r(z) \\leq M_s(z)$. Combined with positive case: $M_r \\leq M_s$ for all same-sign $r \\leq s$.",
     "significance": "key",
     "relatedConcepts": [
       "duality argument",
@@ -197,11 +197,11 @@
     "proofId": "amgm-inequality-oq-03",
     "range": {
       "startLine": 345,
-      "endLine": 373
+      "endLine": 372
     },
     "type": "insight",
     "title": "Interpolation Chain Summary: All Same-Sign Cases Proved",
-    "content": "The summary theorem power_mean_interpolation_summary catalogs the complete status: GM \u2264 AM (Mathlib), AM \u2264 M_p for p \u2265 1 (Mathlib), HM \u2264 GM (new direct proof), M_r \u2264 M_s for 0 < r \u2264 s (new, Jensen), M_r \u2264 M_s for r \u2264 s < 0 (new, duality). The file compiles with 0 axioms and 0 sorries. Only the mixed-sign case (r < 0 < s, crossing the geometric mean limit) remains as a future direction.",
+    "content": "The summary theorem power_mean_interpolation_summary catalogs the complete status: GM ≤ AM (Mathlib), AM ≤ M_p for p ≥ 1 (Mathlib), HM ≤ GM (new direct proof), M_r ≤ M_s for 0 < r ≤ s (new, Jensen), M_r ≤ M_s for r ≤ s < 0 (new, duality). The file compiles with 0 axioms and 0 sorries. Only the mixed-sign case (r < 0 < s, crossing the geometric mean limit) remains as a future direction.",
     "mathContext": "All proved: $\\text{GM} \\leq \\text{AM}$, $\\text{AM} \\leq M_p$ ($p \\geq 1$), $\\text{HM} \\leq \\text{GM}$, $M_r \\leq M_s$ ($0 < r \\leq s$), $M_r \\leq M_s$ ($r \\leq s < 0$). Open: $M_r \\leq M_s$ for $r < 0 < s$.",
     "significance": "supporting",
     "relatedConcepts": [

--- a/src/data/proofs/angle-trisection/annotations.json
+++ b/src/data/proofs/angle-trisection/annotations.json
@@ -385,7 +385,7 @@
     "proofId": "angle-trisection",
     "range": {
       "startLine": 370,
-      "endLine": 389
+      "endLine": 383
     },
     "type": "concept",
     "title": "Summary and Proof Architecture",

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01/annotations.json
@@ -180,7 +180,7 @@
     "proofId": "area-of-circle-oq-01-oq-02-oq-01-oq-01",
     "range": {
       "startLine": 123,
-      "endLine": 151
+      "endLine": 150
     },
     "type": "concept",
     "title": "Summary and Answer to Open Question",

--- a/src/data/proofs/area-of-circle-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02/annotations.json
@@ -159,7 +159,7 @@
     "proofId": "area-of-circle-oq-01-oq-02",
     "range": {
       "startLine": 133,
-      "endLine": 145
+      "endLine": 141
     },
     "type": "insight",
     "title": "Unit Disk and Scaling: Concrete Verifications of the Area Formula",

--- a/src/data/proofs/area-of-circle-oq-01/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-01/annotations.json
@@ -277,7 +277,7 @@
     "proofId": "area-of-circle-oq-01",
     "range": {
       "startLine": 157,
-      "endLine": 163
+      "endLine": 162
     },
     "type": "concept",
     "title": "Circumference-Derivative Duality",

--- a/src/data/proofs/bertrands-postulate-oq-03/annotations.json
+++ b/src/data/proofs/bertrands-postulate-oq-03/annotations.json
@@ -151,7 +151,7 @@
     "proofId": "bertrands-postulate-oq-03",
     "range": {
       "startLine": 232,
-      "endLine": 329
+      "endLine": 308
     },
     "type": "definition",
     "title": "PrimeGapConjecture: Formal Definition, Monotonicity, and Summary",

--- a/src/data/proofs/bezout-identity-oq-04-oq-02/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-04-oq-02/annotations.json
@@ -95,7 +95,7 @@
     "proofId": "bezout-identity-oq-04-oq-02",
     "range": {
       "startLine": 115,
-      "endLine": 139
+      "endLine": 138
     },
     "type": "concept",
     "title": "Part IV Examples: Witnesses, Non-Achievability, and Coprimality",

--- a/src/data/proofs/borsuk-ulam-oq-02/annotations.json
+++ b/src/data/proofs/borsuk-ulam-oq-02/annotations.json
@@ -171,7 +171,7 @@
     "proofId": "borsuk-ulam-oq-02",
     "range": {
       "startLine": 371,
-      "endLine": 435
+      "endLine": 389
     },
     "type": "concept",
     "title": "Part 7: Antipodal Involution, Fixed-Point Freeness, and Z/2 Action Completeness",

--- a/src/data/proofs/cantors-theorem-oq-01/annotations.json
+++ b/src/data/proofs/cantors-theorem-oq-01/annotations.json
@@ -153,7 +153,7 @@
     "proofId": "cantors-theorem-oq-01",
     "range": {
       "startLine": 233,
-      "endLine": 278
+      "endLine": 272
     },
     "type": "insight",
     "title": "Summary Theorem: Four ZFC-Provable Facts About |𝒫(ℝ)|",

--- a/src/data/proofs/cauchy-schwarz-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01/annotations.json
@@ -192,7 +192,7 @@
     "proofId": "cauchy-schwarz-oq-01",
     "range": {
       "startLine": 133,
-      "endLine": 145
+      "endLine": 138
     },
     "type": "concept",
     "title": "Formal Answer to the Open Question",

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-01/annotations.json
@@ -150,7 +150,7 @@
     "proofId": "cayley-hamilton-minpoly-oq-03-oq-01",
     "range": {
       "startLine": 181,
-      "endLine": 267
+      "endLine": 265
     },
     "type": "concept",
     "title": "vec_minpoly_exists: Divisibility via Euclidean Contradiction + Degree Chain",

--- a/src/data/proofs/central-limit-theorem-oq-01/annotations.json
+++ b/src/data/proofs/central-limit-theorem-oq-01/annotations.json
@@ -160,7 +160,7 @@
     "proofId": "central-limit-theorem-oq-01",
     "range": {
       "startLine": 274,
-      "endLine": 349
+      "endLine": 313
     },
     "type": "insight",
     "title": "Summary: Lévy 1/2-Stable, Non-Gaussian Distinctness, and Unified CLT",

--- a/src/data/proofs/central-limit-theorem-oq-03/annotations.json
+++ b/src/data/proofs/central-limit-theorem-oq-03/annotations.json
@@ -161,7 +161,7 @@
     "proofId": "central-limit-theorem-oq-03",
     "range": {
       "startLine": 229,
-      "endLine": 248
+      "endLine": 241
     },
     "type": "definition",
     "title": "Domain of Attraction",

--- a/src/data/proofs/cevas-theorem-oq-04/annotations.json
+++ b/src/data/proofs/cevas-theorem-oq-04/annotations.json
@@ -150,7 +150,7 @@
     "proofId": "cevas-theorem-oq-04",
     "range": {
       "startLine": 212,
-      "endLine": 243
+      "endLine": 242
     },
     "type": "concept",
     "title": "Centroid Example and Summary Theorem",

--- a/src/data/proofs/continuum-hypothesis-oq-01/annotations.json
+++ b/src/data/proofs/continuum-hypothesis-oq-01/annotations.json
@@ -159,7 +159,7 @@
     "proofId": "continuum-hypothesis-oq-01",
     "range": {
       "startLine": 264,
-      "endLine": 318
+      "endLine": 317
     },
     "type": "insight",
     "title": "Summary: The Open Question Has Substantive Content on Both Sides",

--- a/src/data/proofs/cramers-rule-oq-01/annotations.json
+++ b/src/data/proofs/cramers-rule-oq-01/annotations.json
@@ -159,7 +159,7 @@
     "proofId": "cramers-rule-oq-01",
     "range": {
       "startLine": 262,
-      "endLine": 283
+      "endLine": 282
     },
     "type": "concept",
     "title": "Summary Theorem: Cramer Implies Cayley-Hamilton as One Package",

--- a/src/data/proofs/de-moivre/annotations.json
+++ b/src/data/proofs/de-moivre/annotations.json
@@ -146,7 +146,7 @@
     "proofId": "de-moivre",
     "range": {
       "startLine": 210,
-      "endLine": 240
+      "endLine": 239
     },
     "type": "concept",
     "title": "Applications and Exports",

--- a/src/data/proofs/denumerability-rationals-oq-03/annotations.json
+++ b/src/data/proofs/denumerability-rationals-oq-03/annotations.json
@@ -199,7 +199,7 @@
     "proofId": "denumerability-rationals-oq-03",
     "range": {
       "startLine": 401,
-      "endLine": 618
+      "endLine": 600
     },
     "type": "concept",
     "title": "Concrete Verification: First Three Levels of the Tree",

--- a/src/data/proofs/desargues-theorem-oq-01/annotations.json
+++ b/src/data/proofs/desargues-theorem-oq-01/annotations.json
@@ -195,7 +195,7 @@
     "proofId": "desargues-theorem-oq-01",
     "range": {
       "startLine": 261,
-      "endLine": 286
+      "endLine": 285
     },
     "type": "concept",
     "title": "Corollaries: ℚ, ℤ, 𝔽_p, and Polynomial Rings",

--- a/src/data/proofs/dirichlets-theorem-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/dirichlets-theorem-oq-02-oq-01/annotations.json
@@ -306,7 +306,7 @@
     "proofId": "dirichlets-theorem-oq-02-oq-01",
     "range": {
       "startLine": 361,
-      "endLine": 375
+      "endLine": 366
     },
     "type": "concept",
     "title": "Equivalent Formulations of GRH",

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01/annotations.json
@@ -237,7 +237,7 @@
     "proofId": "elementary-quadratic-reciprocity-oq-01-oq-01",
     "range": {
       "startLine": 159,
-      "endLine": 167
+      "endLine": 166
     },
     "type": "insight",
     "title": "Main Theorem: Gauss Sum as Third Formal QR Pathway",

--- a/src/data/proofs/erdos-1003/annotations.json
+++ b/src/data/proofs/erdos-1003/annotations.json
@@ -270,7 +270,7 @@
     "proofId": "erdos-1003",
     "range": {
       "startLine": 261,
-      "endLine": 280
+      "endLine": 261
     },
     "type": "concept",
     "title": "Ford-Luca-Pomerance Lower Bound",

--- a/src/data/proofs/erdos-1010/annotations.json
+++ b/src/data/proofs/erdos-1010/annotations.json
@@ -103,7 +103,7 @@
     "proofId": "erdos-1010",
     "range": {
       "startLine": 84,
-      "endLine": 94
+      "endLine": 93
     },
     "type": "concept",
     "title": "Triangle Existence (Turán's Theorem for K₃)",

--- a/src/data/proofs/erdos-1011/annotations.json
+++ b/src/data/proofs/erdos-1011/annotations.json
@@ -104,7 +104,7 @@
     "proofId": "erdos-1011",
     "range": {
       "startLine": 167,
-      "endLine": 195
+      "endLine": 168
     },
     "type": "concept",
     "title": "Monotonicity and Special Values",

--- a/src/data/proofs/erdos-1021/annotations.json
+++ b/src/data/proofs/erdos-1021/annotations.json
@@ -296,7 +296,7 @@
     "proofId": "erdos-1021",
     "range": {
       "startLine": 239,
-      "endLine": 244
+      "endLine": 241
     },
     "type": "concept",
     "title": "The Conjectured Gap",

--- a/src/data/proofs/erdos-1024/annotations.json
+++ b/src/data/proofs/erdos-1024/annotations.json
@@ -144,7 +144,7 @@
     "proofId": "erdos-1024",
     "range": {
       "startLine": 214,
-      "endLine": 254
+      "endLine": 227
     },
     "type": "concept",
     "title": "Bound Comparison and Summary",

--- a/src/data/proofs/erdos-1025/annotations.json
+++ b/src/data/proofs/erdos-1025/annotations.json
@@ -124,7 +124,7 @@
     "proofId": "erdos-1025",
     "range": {
       "startLine": 197,
-      "endLine": 267
+      "endLine": 246
     },
     "type": "concept",
     "title": "Probabilistic Method, Constructions, and Historical Summary",

--- a/src/data/proofs/erdos-1032/annotations.json
+++ b/src/data/proofs/erdos-1032/annotations.json
@@ -118,7 +118,7 @@
     "proofId": "erdos-1032",
     "range": {
       "startLine": 72,
-      "endLine": 81
+      "endLine": 77
     },
     "type": "concept",
     "title": "Erdős Problem #1032 (OPEN)",

--- a/src/data/proofs/erdos-1041/annotations.json
+++ b/src/data/proofs/erdos-1041/annotations.json
@@ -194,7 +194,7 @@
     "proofId": "erdos-1041",
     "range": {
       "startLine": 153,
-      "endLine": 158
+      "endLine": 156
     },
     "type": "concept",
     "title": "Distance Bound in Unit Disk",

--- a/src/data/proofs/erdos-1042/annotations.json
+++ b/src/data/proofs/erdos-1042/annotations.json
@@ -118,7 +118,7 @@
     "proofId": "erdos-1042",
     "range": {
       "startLine": 126,
-      "endLine": 137
+      "endLine": 132
     },
     "type": "concept",
     "title": "Geometry vs Diameter Counterexample",

--- a/src/data/proofs/erdos-1044/annotations.json
+++ b/src/data/proofs/erdos-1044/annotations.json
@@ -165,7 +165,7 @@
     "proofId": "erdos-1044",
     "range": {
       "startLine": 111,
-      "endLine": 128
+      "endLine": 120
     },
     "type": "concept",
     "title": "Problem Summary: erdos_1044",

--- a/src/data/proofs/erdos-1045/annotations.json
+++ b/src/data/proofs/erdos-1045/annotations.json
@@ -142,7 +142,7 @@
     "proofId": "erdos-1045",
     "range": {
       "startLine": 111,
-      "endLine": 130
+      "endLine": 116
     },
     "type": "concept",
     "title": "Quantitative Lower Bounds: How Much Better Than Regular?",

--- a/src/data/proofs/erdos-1046/annotations.json
+++ b/src/data/proofs/erdos-1046/annotations.json
@@ -179,7 +179,7 @@
     "proofId": "erdos-1046",
     "range": {
       "startLine": 221,
-      "endLine": 246
+      "endLine": 236
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-1058/annotations.json
+++ b/src/data/proofs/erdos-1058/annotations.json
@@ -160,7 +160,7 @@
     "proofId": "erdos-1058",
     "range": {
       "startLine": 165,
-      "endLine": 175
+      "endLine": 165
     },
     "type": "concept",
     "title": "Final Status: SOLVED",

--- a/src/data/proofs/erdos-1066/annotations.json
+++ b/src/data/proofs/erdos-1066/annotations.json
@@ -100,7 +100,7 @@
     "proofId": "erdos-1066",
     "range": {
       "startLine": 111,
-      "endLine": 125
+      "endLine": 118
     },
     "type": "concept",
     "title": "Current Best Bounds and Gap",

--- a/src/data/proofs/erdos-1069/annotations.json
+++ b/src/data/proofs/erdos-1069/annotations.json
@@ -99,7 +99,7 @@
     "proofId": "erdos-1069",
     "range": {
       "startLine": 169,
-      "endLine": 185
+      "endLine": 179
     },
     "type": "concept",
     "title": "Lower Bound Constructions",

--- a/src/data/proofs/erdos-1074/annotations.json
+++ b/src/data/proofs/erdos-1074/annotations.json
@@ -168,7 +168,7 @@
     "proofId": "erdos-1074",
     "range": {
       "startLine": 117,
-      "endLine": 154
+      "endLine": 146
     },
     "type": "concept",
     "title": "Open Density Problems",

--- a/src/data/proofs/erdos-1075/annotations.json
+++ b/src/data/proofs/erdos-1075/annotations.json
@@ -213,7 +213,7 @@
     "proofId": "erdos-1075",
     "range": {
       "startLine": 164,
-      "endLine": 178
+      "endLine": 165
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-1077/annotations.json
+++ b/src/data/proofs/erdos-1077/annotations.json
@@ -189,7 +189,7 @@
     "proofId": "erdos-1077",
     "range": {
       "startLine": 144,
-      "endLine": 155
+      "endLine": 145
     },
     "type": "concept",
     "title": "Notes on the Problem Statement",

--- a/src/data/proofs/erdos-1078/annotations.json
+++ b/src/data/proofs/erdos-1078/annotations.json
@@ -187,7 +187,7 @@
     "proofId": "erdos-1078",
     "range": {
       "startLine": 198,
-      "endLine": 214
+      "endLine": 205
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-1079/annotations.json
+++ b/src/data/proofs/erdos-1079/annotations.json
@@ -105,7 +105,7 @@
     "type": "concept",
     "range": {
       "startLine": 136,
-      "endLine": 176
+      "endLine": 150
     },
     "title": "Summary and Main Theorem",
     "content": "**erdos_1079_summary** packages the Bollobás–Thomason theorem and Turán's theorem into a single conjunction. The first conjunct asserts the existence of dense-neighborhood vertices; the second provides the classical Turán bound as context.\n\n**erdos_1079** is the main entry-point theorem, proved directly from the summary axiom. It captures both the positive result (dense neighborhoods exist) and its theoretical foundation (the Turán bound these neighborhoods must exceed).\n\nThe problem is fully SOLVED: Bollobás–Thomason (1981) established the result, and Bondy (1983) identified the max-degree vertex as the canonical witness.",

--- a/src/data/proofs/erdos-1083/annotations.json
+++ b/src/data/proofs/erdos-1083/annotations.json
@@ -144,7 +144,7 @@
     "proofId": "erdos-1083",
     "range": {
       "startLine": 82,
-      "endLine": 93
+      "endLine": 86
     },
     "type": "concept",
     "title": "Main Theorem: Erdős Problem #1083",

--- a/src/data/proofs/erdos-1086/annotations.json
+++ b/src/data/proofs/erdos-1086/annotations.json
@@ -161,7 +161,7 @@
     "proofId": "erdos-1086",
     "range": {
       "startLine": 137,
-      "endLine": 161
+      "endLine": 150
     },
     "type": "concept",
     "title": "Higher-Dimensional Bounds",

--- a/src/data/proofs/erdos-1087/annotations.json
+++ b/src/data/proofs/erdos-1087/annotations.json
@@ -225,7 +225,7 @@
     "proofId": "erdos-1087",
     "range": {
       "startLine": 314,
-      "endLine": 317
+      "endLine": 316
     },
     "type": "concept",
     "title": "Main Theorem",

--- a/src/data/proofs/erdos-1098-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1098-oq-01-oq-01/annotations.json
@@ -127,7 +127,7 @@
     "proofId": "erdos-1098-oq-01-oq-01",
     "range": {
       "startLine": 169,
-      "endLine": 220
+      "endLine": 205
     },
     "type": "theorem",
     "title": "Necessary Conditions for ω = 3",

--- a/src/data/proofs/erdos-11/annotations.json
+++ b/src/data/proofs/erdos-11/annotations.json
@@ -315,7 +315,7 @@
     "proofId": "erdos-11",
     "range": {
       "startLine": 112,
-      "endLine": 118
+      "endLine": 113
     },
     "type": "concept",
     "title": "Erdős Density Result",

--- a/src/data/proofs/erdos-1104/annotations.json
+++ b/src/data/proofs/erdos-1104/annotations.json
@@ -184,7 +184,7 @@
     "type": "concept",
     "range": {
       "startLine": 176,
-      "endLine": 201
+      "endLine": 196
     },
     "title": "Mycielski Construction",
     "content": "The Mycielski graph M_k is a classical construction of triangle-free graphs with chromatic number exactly k. Starting from K₁, each step adds a 'shadow' vertex for each existing vertex plus one universal vertex, preserving triangle-freeness while increasing the chromatic number by 1. M_k has 3·2^{k−2} − 1 vertices for k ≥ 2. This gives the weak lower bound f(3·2^{k−2} − 1) ≥ k, which grows as f(n) ≥ Ω(log n / log log n)—far weaker than the true Θ(√(n/log n)) bound from probabilistic methods.",

--- a/src/data/proofs/erdos-111/annotations.json
+++ b/src/data/proofs/erdos-111/annotations.json
@@ -252,7 +252,7 @@
     "proofId": "erdos-111",
     "range": {
       "startLine": 315,
-      "endLine": 337
+      "endLine": 320
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-1111/annotations.json
+++ b/src/data/proofs/erdos-1111/annotations.json
@@ -174,7 +174,7 @@
     "proofId": "erdos-1111",
     "range": {
       "startLine": 209,
-      "endLine": 245
+      "endLine": 224
     },
     "type": "concept",
     "title": "Problem Summary",

--- a/src/data/proofs/erdos-1112/annotations.json
+++ b/src/data/proofs/erdos-1112/annotations.json
@@ -185,7 +185,7 @@
     "proofId": "erdos-1112",
     "range": {
       "startLine": 203,
-      "endLine": 210
+      "endLine": 207
     },
     "type": "concept",
     "title": "Main Theorem: The Dichotomy",

--- a/src/data/proofs/erdos-1113/annotations.json
+++ b/src/data/proofs/erdos-1113/annotations.json
@@ -158,7 +158,7 @@
     "proofId": "erdos-1113",
     "range": {
       "startLine": 159,
-      "endLine": 184
+      "endLine": 172
     },
     "type": "definition",
     "title": "Connection to Fermat Primes",

--- a/src/data/proofs/erdos-1118/annotations.json
+++ b/src/data/proofs/erdos-1118/annotations.json
@@ -192,7 +192,7 @@
     "proofId": "erdos-1118",
     "range": {
       "startLine": 227,
-      "endLine": 274
+      "endLine": 234
     },
     "type": "concept",
     "title": "Main Theorems: Both Questions Resolved",

--- a/src/data/proofs/erdos-1119/annotations.json
+++ b/src/data/proofs/erdos-1119/annotations.json
@@ -122,7 +122,7 @@
     "proofId": "erdos-1119",
     "range": {
       "startLine": 121,
-      "endLine": 147
+      "endLine": 133
     },
     "type": "concept",
     "title": "Cardinal Arithmetic and Wetzel's Question",

--- a/src/data/proofs/erdos-1122/annotations.json
+++ b/src/data/proofs/erdos-1122/annotations.json
@@ -309,7 +309,7 @@
     "proofId": "erdos-1122",
     "range": {
       "startLine": 207,
-      "endLine": 216
+      "endLine": 208
     },
     "type": "concept",
     "title": "Summary of Known Results",

--- a/src/data/proofs/erdos-1124-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1124-oq-01/annotations.json
@@ -202,7 +202,7 @@
     "proofId": "erdos-1124-oq-01",
     "range": {
       "startLine": 454,
-      "endLine": 477
+      "endLine": 454
     },
     "type": "concept",
     "title": "The Complete Bound Chain: 3 <= minPieceCount <= 10^50",

--- a/src/data/proofs/erdos-1124/annotations.json
+++ b/src/data/proofs/erdos-1124/annotations.json
@@ -238,7 +238,7 @@
     "proofId": "erdos-1124",
     "range": {
       "startLine": 190,
-      "endLine": 209
+      "endLine": 190
     },
     "type": "concept",
     "title": "Main Result: erdos_1124",

--- a/src/data/proofs/erdos-1128/annotations.json
+++ b/src/data/proofs/erdos-1128/annotations.json
@@ -118,7 +118,7 @@
     "proofId": "erdos-1128",
     "range": {
       "startLine": 150,
-      "endLine": 177
+      "endLine": 166
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-1133/annotations.json
+++ b/src/data/proofs/erdos-1133/annotations.json
@@ -257,7 +257,7 @@
     "proofId": "erdos-1133",
     "range": {
       "startLine": 194,
-      "endLine": 200
+      "endLine": 195
     },
     "type": "concept",
     "title": "exact_interpolation_case (Fully Proved)",

--- a/src/data/proofs/erdos-1135/annotations.json
+++ b/src/data/proofs/erdos-1135/annotations.json
@@ -276,7 +276,7 @@
     "proofId": "erdos-1135",
     "range": {
       "startLine": 90,
-      "endLine": 110
+      "endLine": 97
     },
     "type": "concept",
     "title": "Tao (2019) and Krasikov-Lagarias: Deep Partial Results",

--- a/src/data/proofs/erdos-114/annotations.json
+++ b/src/data/proofs/erdos-114/annotations.json
@@ -236,7 +236,7 @@
     "proofId": "erdos-114",
     "range": {
       "startLine": 43,
-      "endLine": 50
+      "endLine": 49
     },
     "type": "concept",
     "title": "Exact Length Formula via Gamma Function",

--- a/src/data/proofs/erdos-115/annotations.json
+++ b/src/data/proofs/erdos-115/annotations.json
@@ -98,7 +98,7 @@
     "proofId": "erdos-115",
     "range": {
       "startLine": 63,
-      "endLine": 73
+      "endLine": 64
     },
     "type": "concept",
     "title": "Chebyshev Polynomial Asymptotics",

--- a/src/data/proofs/erdos-1153/annotations.json
+++ b/src/data/proofs/erdos-1153/annotations.json
@@ -170,7 +170,7 @@
     "proofId": "erdos-1153",
     "range": {
       "startLine": 165,
-      "endLine": 175
+      "endLine": 169
     },
     "type": "insight",
     "title": "Chebyshev Optimality (Matching Upper Bound)",

--- a/src/data/proofs/erdos-1155-oq-01-oq-06/annotations.json
+++ b/src/data/proofs/erdos-1155-oq-01-oq-06/annotations.json
@@ -4,7 +4,7 @@
     "proofId": "erdos-1155-oq-01-oq-06",
     "range": {
       "startLine": 1,
-      "endLine": 11
+      "endLine": 10
     },
     "type": "concept",
     "title": "Pending Formalization: Terminal Graph Structure",
@@ -29,7 +29,7 @@
     "proofId": "erdos-1155-oq-01-oq-06",
     "range": {
       "startLine": 1,
-      "endLine": 11
+      "endLine": 10
     },
     "type": "concept",
     "title": "Turán Density: The Extremal Baseline",
@@ -55,7 +55,7 @@
     "proofId": "erdos-1155-oq-01-oq-06",
     "range": {
       "startLine": 1,
-      "endLine": 11
+      "endLine": 10
     },
     "type": "insight",
     "title": "BFL 2015: The Exponent Gap 3/2 vs 2",
@@ -81,7 +81,7 @@
     "proofId": "erdos-1155-oq-01-oq-06",
     "range": {
       "startLine": 1,
-      "endLine": 11
+      "endLine": 10
     },
     "type": "theorem",
     "title": "Main Result: turanRatio_tendsto_zero",
@@ -107,7 +107,7 @@
     "proofId": "erdos-1155-oq-01-oq-06",
     "range": {
       "startLine": 1,
-      "endLine": 11
+      "endLine": 10
     },
     "type": "insight",
     "title": "The Open Bipartiteness Question",
@@ -133,7 +133,7 @@
     "proofId": "erdos-1155-oq-01-oq-06",
     "range": {
       "startLine": 1,
-      "endLine": 11
+      "endLine": 10
     },
     "type": "concept",
     "title": "Gallery Hierarchy: OQ-01-OQ-06 in the Erdős #1155 Tree",

--- a/src/data/proofs/erdos-1155-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1155-oq-01/annotations.json
@@ -404,7 +404,7 @@
     "proofId": "erdos-1155-oq-01",
     "range": {
       "startLine": 404,
-      "endLine": 433
+      "endLine": 411
     },
     "type": "concept",
     "title": "Strict Hierarchy: Conjecture > BFL > Grable",

--- a/src/data/proofs/erdos-1158/annotations.json
+++ b/src/data/proofs/erdos-1158/annotations.json
@@ -310,7 +310,7 @@
     "proofId": "erdos-1158",
     "range": {
       "startLine": 280,
-      "endLine": 320
+      "endLine": 306
     },
     "type": "concept",
     "title": "Structural Properties of the Exponent",

--- a/src/data/proofs/erdos-1159/annotations.json
+++ b/src/data/proofs/erdos-1159/annotations.json
@@ -156,7 +156,7 @@
     "type": "concept",
     "range": {
       "startLine": 139,
-      "endLine": 145
+      "endLine": 144
     },
     "title": "Related Problems",
     "content": "Problem 664 extends this to all pairwise balanced block designs. Projective planes are (n^2+n+1, n+1, 1)-designs; the general case is less regular.",

--- a/src/data/proofs/erdos-116/annotations.json
+++ b/src/data/proofs/erdos-116/annotations.json
@@ -208,7 +208,7 @@
     "proofId": "erdos-116",
     "range": {
       "startLine": 74,
-      "endLine": 79
+      "endLine": 74
     },
     "type": "concept",
     "title": "Pólya's Upper Bound",

--- a/src/data/proofs/erdos-1174/annotations.json
+++ b/src/data/proofs/erdos-1174/annotations.json
@@ -288,7 +288,7 @@
     "proofId": "erdos-1174",
     "range": {
       "startLine": 224,
-      "endLine": 243
+      "endLine": 232
     },
     "type": "concept",
     "title": "Open Status Summary",

--- a/src/data/proofs/erdos-1175/annotations.json
+++ b/src/data/proofs/erdos-1175/annotations.json
@@ -167,7 +167,7 @@
     "type": "insight",
     "range": {
       "startLine": 174,
-      "endLine": 203
+      "endLine": 186
     },
     "title": "Erdős 1959 Existence and Summary",
     "content": "Erdős (1959) proved the foundational result: for every k ≥ 1 and g ≥ 3, there exist finite graphs with girth ≥ g and chromatic number ≥ k. This was one of the first applications of the probabilistic method—a random graph G(n, p) with appropriate parameters has both properties with positive probability. The summary theorem confirms Shelah's consistency result as the main known result. The formal problem statement ErdosProblem1175 is defined as erdos1175. The gap between the finite existence (Erdős 1959) and the infinite structural question (Problem 1175) is the core of the problem.",

--- a/src/data/proofs/erdos-119/annotations.json
+++ b/src/data/proofs/erdos-119/annotations.json
@@ -167,7 +167,7 @@
     "proofId": "erdos-119",
     "range": {
       "startLine": 82,
-      "endLine": 98
+      "endLine": 97
     },
     "type": "concept",
     "title": "Basic Properties",

--- a/src/data/proofs/erdos-124/annotations.json
+++ b/src/data/proofs/erdos-124/annotations.json
@@ -113,7 +113,7 @@
     ],
     "range": {
       "startLine": 77,
-      "endLine": 81
+      "endLine": 79
     }
   }
 ]

--- a/src/data/proofs/erdos-125/annotations.json
+++ b/src/data/proofs/erdos-125/annotations.json
@@ -160,7 +160,7 @@
     "proofId": "erdos-125",
     "range": {
       "startLine": 86,
-      "endLine": 107
+      "endLine": 92
     },
     "type": "concept",
     "title": "Generalization to Multiple Bases",

--- a/src/data/proofs/erdos-126/annotations.json
+++ b/src/data/proofs/erdos-126/annotations.json
@@ -159,7 +159,7 @@
     "proofId": "erdos-126",
     "range": {
       "startLine": 148,
-      "endLine": 170
+      "endLine": 152
     },
     "type": "concept",
     "title": "Summary and Logical Consequences",

--- a/src/data/proofs/erdos-128/annotations.json
+++ b/src/data/proofs/erdos-128/annotations.json
@@ -141,7 +141,7 @@
     "proofId": "erdos-128",
     "range": {
       "startLine": 78,
-      "endLine": 83
+      "endLine": 82
     },
     "type": "concept",
     "title": "Krivelevich's Theorem: Subgraph Size 3n/5",

--- a/src/data/proofs/erdos-130/annotations.json
+++ b/src/data/proofs/erdos-130/annotations.json
@@ -185,7 +185,7 @@
     "type": "concept",
     "range": {
       "startLine": 99,
-      "endLine": 109
+      "endLine": 103
     },
     "title": "Anning–Erdős Theorem and Finite Clique Consequence",
     "content": "Anning and Erdős (1945) proved that any infinite set of points in the plane with all pairwise distances integers must have all points collinear. This classical result implies that no infinite clique can exist in general position, since an infinite clique requires all pairwise integer distances.",

--- a/src/data/proofs/erdos-132/annotations.json
+++ b/src/data/proofs/erdos-132/annotations.json
@@ -217,7 +217,7 @@
     "proofId": "erdos-132",
     "range": {
       "startLine": 186,
-      "endLine": 217
+      "endLine": 204
     },
     "type": "concept",
     "title": "Summary Theorem: Combining Known Results",

--- a/src/data/proofs/erdos-134/annotations.json
+++ b/src/data/proofs/erdos-134/annotations.json
@@ -287,7 +287,7 @@
     "type": "concept",
     "range": {
       "startLine": 247,
-      "endLine": 295
+      "endLine": 270
     },
     "title": "Main Results: erdos_134_solved and erdos_134_main",
     "content": "**erdos_134_solved** (PROVED): Derives `erdosGyarfasConjecture` directly from `alon_implies_conjecture`. A one-line proof establishing the conjecture is true.\n\n**erdos_134_main** (PROVED): Packages both results as a conjunction:\n1. The conjecture is true (from alon_implies_conjecture)\n2. The stronger O(n^{2-ε}) bound (from alon_theorem)\n\nThe proof uses `constructor` to split the conjunction, then `obtain ⟨C, hC, N, hN⟩ := alon_theorem ε hε` to destructure Alon's theorem and extract the constants. These are the only two proved (non-axiom) theorems in the file.",

--- a/src/data/proofs/erdos-136/annotations.json
+++ b/src/data/proofs/erdos-136/annotations.json
@@ -118,7 +118,7 @@
     "proofId": "erdos-136",
     "range": {
       "startLine": 168,
-      "endLine": 186
+      "endLine": 185
     },
     "type": "concept",
     "title": "Related Values and Monotonicity",

--- a/src/data/proofs/erdos-14/annotations.json
+++ b/src/data/proofs/erdos-14/annotations.json
@@ -181,7 +181,7 @@
     "proofId": "erdos-14",
     "range": {
       "startLine": 83,
-      "endLine": 88
+      "endLine": 85
     },
     "type": "concept",
     "title": "Erdős-Freud Finite Analogue",

--- a/src/data/proofs/erdos-142/annotations.json
+++ b/src/data/proofs/erdos-142/annotations.json
@@ -97,7 +97,7 @@
     "proofId": "erdos-142",
     "range": {
       "startLine": 54,
-      "endLine": 55
+      "endLine": 54
     },
     "type": "concept",
     "title": "Roth's Theorem: The $k = 3$ Case",

--- a/src/data/proofs/erdos-145/annotations.json
+++ b/src/data/proofs/erdos-145/annotations.json
@@ -213,7 +213,7 @@
     "proofId": "erdos-145",
     "range": {
       "startLine": 122,
-      "endLine": 136
+      "endLine": 133
     },
     "type": "concept",
     "title": "Basic Properties",

--- a/src/data/proofs/erdos-148/annotations.json
+++ b/src/data/proofs/erdos-148/annotations.json
@@ -256,7 +256,7 @@
     "proofId": "erdos-148",
     "range": {
       "startLine": 221,
-      "endLine": 255
+      "endLine": 232
     },
     "type": "concept",
     "title": "Status Summary",

--- a/src/data/proofs/erdos-15/annotations.json
+++ b/src/data/proofs/erdos-15/annotations.json
@@ -379,7 +379,7 @@
     "proofId": "erdos-15",
     "range": {
       "startLine": 218,
-      "endLine": 221
+      "endLine": 219
     },
     "type": "concept",
     "title": "No Absolute Convergence: $\\sum n/p_n = \\infty$",

--- a/src/data/proofs/erdos-151/annotations.json
+++ b/src/data/proofs/erdos-151/annotations.json
@@ -197,7 +197,7 @@
     "proofId": "erdos-151",
     "range": {
       "startLine": 165,
-      "endLine": 203
+      "endLine": 173
     },
     "type": "concept",
     "title": "Corollaries and Summary",

--- a/src/data/proofs/erdos-158/annotations.json
+++ b/src/data/proofs/erdos-158/annotations.json
@@ -175,7 +175,7 @@
     "proofId": "erdos-158",
     "range": {
       "startLine": 119,
-      "endLine": 127
+      "endLine": 125
     },
     "type": "concept",
     "title": "Example: Perfect Squares",

--- a/src/data/proofs/erdos-16/annotations.json
+++ b/src/data/proofs/erdos-16/annotations.json
@@ -291,7 +291,7 @@
     "proofId": "erdos-16",
     "range": {
       "startLine": 189,
-      "endLine": 205
+      "endLine": 203
     },
     "type": "concept",
     "title": "Density Bounds",

--- a/src/data/proofs/erdos-161/annotations.json
+++ b/src/data/proofs/erdos-161/annotations.json
@@ -135,7 +135,7 @@
     "type": "concept",
     "range": {
       "startLine": 157,
-      "endLine": 188
+      "endLine": 158
     },
     "title": "Summary",
     "content": "**erdos_161_summary:** Combines F3_characterization (Θ(√(log n)) for α > 0) with one_jump_for_t3 (exactly one jump at α = 0) into a single theorem.\n\nThe proof uses exact ⟨F3_characterization, one_jump_for_t3⟩.\n\n**Open:** For t > 3, the one-jump structure is expected but unproven.",

--- a/src/data/proofs/erdos-163/annotations.json
+++ b/src/data/proofs/erdos-163/annotations.json
@@ -237,7 +237,7 @@
     "proofId": "erdos-163",
     "range": {
       "startLine": 183,
-      "endLine": 201
+      "endLine": 198
     },
     "type": "definition",
     "title": "Conjectured Optimal Bound (Open)",

--- a/src/data/proofs/erdos-166/annotations.json
+++ b/src/data/proofs/erdos-166/annotations.json
@@ -293,7 +293,7 @@
     "proofId": "erdos-166",
     "range": {
       "startLine": 266,
-      "endLine": 283
+      "endLine": 269
     },
     "type": "concept",
     "title": "Logarithmic Gap Analysis",

--- a/src/data/proofs/erdos-167/annotations.json
+++ b/src/data/proofs/erdos-167/annotations.json
@@ -290,7 +290,7 @@
     "proofId": "erdos-167",
     "range": {
       "startLine": 266,
-      "endLine": 289
+      "endLine": 275
     },
     "type": "concept",
     "title": "Summary and Status",

--- a/src/data/proofs/erdos-169/annotations.json
+++ b/src/data/proofs/erdos-169/annotations.json
@@ -204,7 +204,7 @@
     "proofId": "erdos-169",
     "range": {
       "startLine": 251,
-      "endLine": 291
+      "endLine": 279
     },
     "type": "concept",
     "title": "Problem Summary",

--- a/src/data/proofs/erdos-174/annotations.json
+++ b/src/data/proofs/erdos-174/annotations.json
@@ -141,7 +141,7 @@
     "proofId": "erdos-174",
     "range": {
       "startLine": 222,
-      "endLine": 256
+      "endLine": 247
     },
     "type": "concept",
     "title": "Summary Theorems",

--- a/src/data/proofs/erdos-175/annotations.json
+++ b/src/data/proofs/erdos-175/annotations.json
@@ -383,7 +383,7 @@
     "type": "concept",
     "range": {
       "startLine": 181,
-      "endLine": 188
+      "endLine": 182
     },
     "title": "Example: C(10,5) = 252 Not Squarefree",
     "content": "$\\binom{10}{5} = 252 = 2^2 \\times 3^2 \\times 7$ is divisible by both $4$ and $9$, hence not squarefree. This is the smallest case ($n = 5$), proved by `native_decide` and `norm_num`.",

--- a/src/data/proofs/erdos-176/annotations.json
+++ b/src/data/proofs/erdos-176/annotations.json
@@ -259,7 +259,7 @@
     "proofId": "erdos-176",
     "range": {
       "startLine": 278,
-      "endLine": 311
+      "endLine": 303
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-178/annotations.json
+++ b/src/data/proofs/erdos-178/annotations.json
@@ -309,7 +309,7 @@
     "type": "concept",
     "range": {
       "startLine": 165,
-      "endLine": 175
+      "endLine": 165
     },
     "title": "Main Theorem",
     "content": "**erdos_178:**\n\nComplete resolution of Problem #178:\n\n1. The answer is YES: bounded signing exists for any family (Beck 1981)\n2. Quantitative bound: discrepancy ≤ K · d^(4+ε) (Beck 2017)\n\n**Proof:** Combines beck_1981 and beck_2017 axioms.\n\nThis fully resolves what Erdős called a problem where \"it seems certain the answer is affirmative.\"",

--- a/src/data/proofs/erdos-18/annotations.json
+++ b/src/data/proofs/erdos-18/annotations.json
@@ -194,7 +194,7 @@
     "proofId": "erdos-18",
     "range": {
       "startLine": 177,
-      "endLine": 204
+      "endLine": 187
     },
     "type": "definition",
     "title": "The Main Conjectures ($250)",

--- a/src/data/proofs/erdos-184/annotations.json
+++ b/src/data/proofs/erdos-184/annotations.json
@@ -357,7 +357,7 @@
     "proofId": "erdos-184",
     "range": {
       "startLine": 225,
-      "endLine": 249
+      "endLine": 242
     },
     "type": "concept",
     "title": "Summary Theorem and $\\log^*$ Verification",

--- a/src/data/proofs/erdos-188/annotations.json
+++ b/src/data/proofs/erdos-188/annotations.json
@@ -305,7 +305,7 @@
     "proofId": "erdos-188",
     "range": {
       "startLine": 170,
-      "endLine": 201
+      "endLine": 188
     },
     "type": "definition",
     "title": "Problem Status and Formal Statement",

--- a/src/data/proofs/erdos-189/annotations.json
+++ b/src/data/proofs/erdos-189/annotations.json
@@ -175,7 +175,7 @@
     "proofId": "erdos-189",
     "range": {
       "startLine": 143,
-      "endLine": 159
+      "endLine": 145
     },
     "type": "concept",
     "title": "Historical Context",

--- a/src/data/proofs/erdos-19/annotations.json
+++ b/src/data/proofs/erdos-19/annotations.json
@@ -232,7 +232,7 @@
     "proofId": "erdos-19",
     "range": {
       "startLine": 252,
-      "endLine": 258
+      "endLine": 255
     },
     "type": "concept",
     "title": "Erdős-Füredi Generalization",

--- a/src/data/proofs/erdos-191/annotations.json
+++ b/src/data/proofs/erdos-191/annotations.json
@@ -516,7 +516,7 @@
     "proofId": "erdos-191",
     "range": {
       "startLine": 343,
-      "endLine": 364
+      "endLine": 357
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-192/annotations.json
+++ b/src/data/proofs/erdos-192/annotations.json
@@ -124,7 +124,7 @@
     "proofId": "erdos-192",
     "range": {
       "startLine": 87,
-      "endLine": 107
+      "endLine": 103
     },
     "type": "concept",
     "title": "Complete Classification: erdos_192",

--- a/src/data/proofs/erdos-194/annotations.json
+++ b/src/data/proofs/erdos-194/annotations.json
@@ -237,7 +237,7 @@
     "proofId": "erdos-194",
     "range": {
       "startLine": 289,
-      "endLine": 299
+      "endLine": 296
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-198/annotations.json
+++ b/src/data/proofs/erdos-198/annotations.json
@@ -175,7 +175,7 @@
     "proofId": "erdos-198",
     "range": {
       "startLine": 138,
-      "endLine": 157
+      "endLine": 151
     },
     "type": "concept",
     "title": "Verified Examples",

--- a/src/data/proofs/erdos-20/annotations.json
+++ b/src/data/proofs/erdos-20/annotations.json
@@ -474,7 +474,7 @@
     "proofId": "erdos-20",
     "range": {
       "startLine": 167,
-      "endLine": 174
+      "endLine": 168
     },
     "type": "concept",
     "title": "Applications of Sunflower Bounds",

--- a/src/data/proofs/erdos-204/annotations.json
+++ b/src/data/proofs/erdos-204/annotations.json
@@ -204,7 +204,7 @@
     "proofId": "erdos-204",
     "range": {
       "startLine": 180,
-      "endLine": 195
+      "endLine": 185
     },
     "type": "insight",
     "title": "Small Examples: n = 6 and n = 12",

--- a/src/data/proofs/erdos-206/annotations.json
+++ b/src/data/proofs/erdos-206/annotations.json
@@ -175,7 +175,7 @@
     "proofId": "erdos-206",
     "range": {
       "startLine": 184,
-      "endLine": 198
+      "endLine": 194
     },
     "type": "definition",
     "title": "Egyptian Fraction Existence and Sylvester's Algorithm",

--- a/src/data/proofs/erdos-209/annotations.json
+++ b/src/data/proofs/erdos-209/annotations.json
@@ -204,7 +204,7 @@
     "proofId": "erdos-209",
     "range": {
       "startLine": 228,
-      "endLine": 246
+      "endLine": 241
     },
     "type": "concept",
     "title": "Main Theorem",

--- a/src/data/proofs/erdos-21/annotations.json
+++ b/src/data/proofs/erdos-21/annotations.json
@@ -213,7 +213,7 @@
     "proofId": "erdos-21",
     "range": {
       "startLine": 265,
-      "endLine": 299
+      "endLine": 273
     },
     "type": "concept",
     "title": "Kahn's Resolution (1994) - Main Result",

--- a/src/data/proofs/erdos-210/annotations.json
+++ b/src/data/proofs/erdos-210/annotations.json
@@ -139,7 +139,7 @@
     "proofId": "erdos-210",
     "range": {
       "startLine": 183,
-      "endLine": 217
+      "endLine": 196
     },
     "type": "concept",
     "title": "Summary Theorems",

--- a/src/data/proofs/erdos-214/annotations.json
+++ b/src/data/proofs/erdos-214/annotations.json
@@ -205,7 +205,7 @@
     "proofId": "erdos-214",
     "range": {
       "startLine": 176,
-      "endLine": 198
+      "endLine": 197
     },
     "type": "definition",
     "title": "Examples: Scaled Lattice",

--- a/src/data/proofs/erdos-215/annotations.json
+++ b/src/data/proofs/erdos-215/annotations.json
@@ -149,7 +149,7 @@
     "proofId": "erdos-215",
     "range": {
       "startLine": 166,
-      "endLine": 192
+      "endLine": 187
     },
     "type": "definition",
     "title": "The Lattice Point Selector Function",

--- a/src/data/proofs/erdos-217/annotations.json
+++ b/src/data/proofs/erdos-217/annotations.json
@@ -221,7 +221,7 @@
     "proofId": "erdos-217",
     "range": {
       "startLine": 89,
-      "endLine": 100
+      "endLine": 91
     },
     "type": "concept",
     "title": "Main Theorem: Existence for n = 4 and n = 5",

--- a/src/data/proofs/erdos-22/annotations.json
+++ b/src/data/proofs/erdos-22/annotations.json
@@ -175,7 +175,7 @@
     "proofId": "erdos-22",
     "range": {
       "startLine": 169,
-      "endLine": 205
+      "endLine": 182
     },
     "type": "concept",
     "title": "Conjecture Resolution (Verified Proof)",

--- a/src/data/proofs/erdos-221/annotations.json
+++ b/src/data/proofs/erdos-221/annotations.json
@@ -434,7 +434,7 @@
     "proofId": "erdos-221",
     "range": {
       "startLine": 232,
-      "endLine": 274
+      "endLine": 239
     },
     "type": "concept",
     "title": "Summary and Main Theorems",

--- a/src/data/proofs/erdos-222/annotations.json
+++ b/src/data/proofs/erdos-222/annotations.json
@@ -246,7 +246,7 @@
     "proofId": "erdos-222",
     "range": {
       "startLine": 141,
-      "endLine": 163
+      "endLine": 147
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-223/annotations.json
+++ b/src/data/proofs/erdos-223/annotations.json
@@ -194,7 +194,7 @@
     "proofId": "erdos-223",
     "range": {
       "startLine": 188,
-      "endLine": 222
+      "endLine": 214
     },
     "type": "definition",
     "title": "Diameter Graph and Dimensional Structure",

--- a/src/data/proofs/erdos-226/annotations.json
+++ b/src/data/proofs/erdos-226/annotations.json
@@ -185,7 +185,7 @@
     "type": "concept",
     "range": {
       "startLine": 242,
-      "endLine": 289
+      "endLine": 268
     },
     "title": "Summary: Problem SOLVED",
     "content": "Three theorems wrap up the formalization:\n\n- `erdos_226_summary` (**proved**): `ErdosQuestion ∧ GeneralQuestion`\n- `erdos_226` := `erdos_question_affirmative` (alias)\n- `erdos_226_answer` (**proved**): $\\exists$ entire transcendental $f$ preserving rationality — the most explicit statement\n\n**Score**: 4 axioms (Barth-Schneider real/complex, monotone version, no-polynomial), 1 verified theorem (`rationals_countable_dense`), 3 derived theorems, 0 sorries.",

--- a/src/data/proofs/erdos-23/annotations.json
+++ b/src/data/proofs/erdos-23/annotations.json
@@ -236,7 +236,7 @@
     "proofId": "erdos-23",
     "range": {
       "startLine": 194,
-      "endLine": 221
+      "endLine": 216
     },
     "type": "concept",
     "title": "Generalized Conjecture (1992)",

--- a/src/data/proofs/erdos-230/annotations.json
+++ b/src/data/proofs/erdos-230/annotations.json
@@ -386,7 +386,7 @@
     "proofId": "erdos-230",
     "range": {
       "startLine": 230,
-      "endLine": 239
+      "endLine": 230
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-231/annotations.json
+++ b/src/data/proofs/erdos-231/annotations.json
@@ -300,7 +300,7 @@
     "proofId": "erdos-231",
     "range": {
       "startLine": 205,
-      "endLine": 214
+      "endLine": 213
     },
     "type": "concept",
     "title": "Example: abba",

--- a/src/data/proofs/erdos-233/annotations.json
+++ b/src/data/proofs/erdos-233/annotations.json
@@ -213,7 +213,7 @@
     "proofId": "erdos-233",
     "range": {
       "startLine": 144,
-      "endLine": 158
+      "endLine": 147
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-235/annotations.json
+++ b/src/data/proofs/erdos-235/annotations.json
@@ -464,7 +464,7 @@
     "proofId": "erdos-235",
     "range": {
       "startLine": 305,
-      "endLine": 335
+      "endLine": 329
     },
     "type": "concept",
     "title": "Summary and Final Theorems",

--- a/src/data/proofs/erdos-239/annotations.json
+++ b/src/data/proofs/erdos-239/annotations.json
@@ -318,7 +318,7 @@
     "proofId": "erdos-239",
     "range": {
       "startLine": 262,
-      "endLine": 287
+      "endLine": 275
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-24/annotations.json
+++ b/src/data/proofs/erdos-24/annotations.json
@@ -211,7 +211,7 @@
     "proofId": "erdos-24",
     "range": {
       "startLine": 230,
-      "endLine": 257
+      "endLine": 245
     },
     "type": "concept",
     "title": "Summary Theorems",

--- a/src/data/proofs/erdos-240/annotations.json
+++ b/src/data/proofs/erdos-240/annotations.json
@@ -305,7 +305,7 @@
     "proofId": "erdos-240",
     "range": {
       "startLine": 261,
-      "endLine": 278
+      "endLine": 264
     },
     "type": "concept",
     "title": "Summary of Results",

--- a/src/data/proofs/erdos-241/annotations.json
+++ b/src/data/proofs/erdos-241/annotations.json
@@ -147,7 +147,7 @@
     "type": "insight",
     "range": {
       "startLine": 123,
-      "endLine": 132
+      "endLine": 123
     },
     "title": "B₃ Examples and Trivial Bound",
     "content": "{1,5,14,30} is a B₃ set — all 20 ordered triple sums are distinct. Note: the set {1,2,4,8} is NOT B₃ since $1+1+4 = 2+2+2 = 6$. The trivial counting argument: the $\\binom{k+2}{3}$ distinct ordered sums from a $k$-element set must fit in {3,...,3N}, giving $k = O(N^{1/3})$.",

--- a/src/data/proofs/erdos-246/annotations.json
+++ b/src/data/proofs/erdos-246/annotations.json
@@ -183,7 +183,7 @@
     "type": "concept",
     "range": {
       "startLine": 182,
-      "endLine": 194
+      "endLine": 186
     },
     "title": "Non-Complete Sequences",
     "content": "**single_powers_not_complete:**\n\nFor a ≥ 3, the set {a^k : k ≥ 0} is NOT complete.\n\n**non_representable_density:**\n\nA positive proportion of integers cannot be represented as sums of distinct powers of a (for a ≥ 3).\n\nExample: Powers of 3 give gaps that form positive density.",

--- a/src/data/proofs/erdos-251/annotations.json
+++ b/src/data/proofs/erdos-251/annotations.json
@@ -211,7 +211,7 @@
     "proofId": "erdos-251",
     "range": {
       "startLine": 196,
-      "endLine": 209
+      "endLine": 201
     },
     "type": "concept",
     "title": "Explicit Partial Sums",

--- a/src/data/proofs/erdos-255/annotations.json
+++ b/src/data/proofs/erdos-255/annotations.json
@@ -99,7 +99,7 @@
     "proofId": "erdos-255",
     "range": {
       "startLine": 150,
-      "endLine": 172
+      "endLine": 163
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-258/annotations.json
+++ b/src/data/proofs/erdos-258/annotations.json
@@ -156,7 +156,7 @@
     "proofId": "erdos-258",
     "range": {
       "startLine": 105,
-      "endLine": 113
+      "endLine": 108
     },
     "type": "definition",
     "title": "The Open General Case",

--- a/src/data/proofs/erdos-26/annotations.json
+++ b/src/data/proofs/erdos-26/annotations.json
@@ -267,7 +267,7 @@
     "proofId": "erdos-26",
     "range": {
       "startLine": 180,
-      "endLine": 209
+      "endLine": 202
     },
     "type": "concept",
     "title": "Summary and References",

--- a/src/data/proofs/erdos-262/annotations.json
+++ b/src/data/proofs/erdos-262/annotations.json
@@ -120,7 +120,7 @@
     "proofId": "erdos-262",
     "range": {
       "startLine": 172,
-      "endLine": 199
+      "endLine": 177
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-264/annotations.json
+++ b/src/data/proofs/erdos-264/annotations.json
@@ -194,7 +194,7 @@
     "proofId": "erdos-264",
     "range": {
       "startLine": 137,
-      "endLine": 144
+      "endLine": 137
     },
     "type": "concept",
     "title": "Double Exponential Growth Rate",

--- a/src/data/proofs/erdos-267/annotations.json
+++ b/src/data/proofs/erdos-267/annotations.json
@@ -218,7 +218,7 @@
     "proofId": "erdos-267",
     "range": {
       "startLine": 218,
-      "endLine": 231
+      "endLine": 224
     },
     "type": "concept",
     "title": "Related Problems",

--- a/src/data/proofs/erdos-269/annotations.json
+++ b/src/data/proofs/erdos-269/annotations.json
@@ -176,7 +176,7 @@
     "proofId": "erdos-269",
     "range": {
       "startLine": 284,
-      "endLine": 306
+      "endLine": 287
     },
     "type": "concept",
     "title": "Distinct Terms Case (SOLVED)",

--- a/src/data/proofs/erdos-270/annotations.json
+++ b/src/data/proofs/erdos-270/annotations.json
@@ -206,7 +206,7 @@
     "proofId": "erdos-270",
     "range": {
       "startLine": 249,
-      "endLine": 272
+      "endLine": 254
     },
     "type": "concept",
     "title": "Summary",

--- a/src/data/proofs/erdos-271/annotations.json
+++ b/src/data/proofs/erdos-271/annotations.json
@@ -207,7 +207,7 @@
     "proofId": "erdos-271",
     "range": {
       "startLine": 314,
-      "endLine": 362
+      "endLine": 336
     },
     "type": "concept",
     "title": "Main Results and Open Status",

--- a/src/data/proofs/erdos-272/annotations.json
+++ b/src/data/proofs/erdos-272/annotations.json
@@ -119,7 +119,7 @@
     "proofId": "erdos-272",
     "range": {
       "startLine": 127,
-      "endLine": 149
+      "endLine": 135
     },
     "type": "concept",
     "title": "Szabó's Theorem and Refined Results",

--- a/src/data/proofs/erdos-274/annotations.json
+++ b/src/data/proofs/erdos-274/annotations.json
@@ -167,7 +167,7 @@
     "proofId": "erdos-274",
     "range": {
       "startLine": 121,
-      "endLine": 138
+      "endLine": 130
     },
     "type": "concept",
     "title": "Summary",

--- a/src/data/proofs/erdos-275/annotations.json
+++ b/src/data/proofs/erdos-275/annotations.json
@@ -269,7 +269,7 @@
     "proofId": "erdos-275",
     "range": {
       "startLine": 169,
-      "endLine": 179
+      "endLine": 172
     },
     "type": "concept",
     "title": "Summary Theorem: Main Result and Tightness",

--- a/src/data/proofs/erdos-278/annotations.json
+++ b/src/data/proofs/erdos-278/annotations.json
@@ -343,7 +343,7 @@
     "type": "concept",
     "range": {
       "startLine": 584,
-      "endLine": 646
+      "endLine": 644
     },
     "title": "Single Modulus Case",
     "content": "For a single modulus $n$, there is only one residue to choose, and the coverage density is exactly $1/n$ regardless of the choice. This is the trivial base case: max = min = $1/n$.",
@@ -458,7 +458,7 @@
     "proofId": "erdos-278",
     "range": {
       "startLine": 603,
-      "endLine": 646
+      "endLine": 644
     },
     "type": "theorem",
     "title": "Singleton and Single-Modulus Density Results",

--- a/src/data/proofs/erdos-280/annotations.json
+++ b/src/data/proofs/erdos-280/annotations.json
@@ -121,7 +121,7 @@
     "proofId": "erdos-280",
     "range": {
       "startLine": 113,
-      "endLine": 128
+      "endLine": 113
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-281/annotations.json
+++ b/src/data/proofs/erdos-281/annotations.json
@@ -188,7 +188,7 @@
     "type": "concept",
     "range": {
       "startLine": 245,
-      "endLine": 252
+      "endLine": 250
     },
     "title": "Problem 281 Resolved (Axiomatized)",
     "content": "The result holds: axiomatized as `erdos_281_proved`. The proof uses the Davenport–Erdős theorem (lower density = upper density for multiplicative functions) and Rogers' theorem from Halberstam–Roth to upgrade pointwise convergence to uniform convergence.",

--- a/src/data/proofs/erdos-283/annotations.json
+++ b/src/data/proofs/erdos-283/annotations.json
@@ -99,7 +99,7 @@
     "proofId": "erdos-283",
     "range": {
       "startLine": 156,
-      "endLine": 175
+      "endLine": 157
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-284/annotations.json
+++ b/src/data/proofs/erdos-284/annotations.json
@@ -97,7 +97,7 @@
     "proofId": "erdos-284",
     "range": {
       "startLine": 158,
-      "endLine": 194
+      "endLine": 183
     },
     "type": "concept",
     "title": "Summary Theorems",

--- a/src/data/proofs/erdos-286/annotations.json
+++ b/src/data/proofs/erdos-286/annotations.json
@@ -180,7 +180,7 @@
     "proofId": "erdos-286",
     "range": {
       "startLine": 198,
-      "endLine": 245
+      "endLine": 236
     },
     "type": "concept",
     "title": "Egyptian Fractions and the Fibonacci–Sylvester Algorithm",

--- a/src/data/proofs/erdos-287/annotations.json
+++ b/src/data/proofs/erdos-287/annotations.json
@@ -179,7 +179,7 @@
     "proofId": "erdos-287",
     "range": {
       "startLine": 76,
-      "endLine": 91
+      "endLine": 85
     },
     "type": "theorem",
     "title": "Main Theorem: Gap ≥ 2 (Proved in Lean)",
@@ -204,7 +204,7 @@
     "proofId": "erdos-287",
     "range": {
       "startLine": 1,
-      "endLine": 91
+      "endLine": 85
     },
     "type": "insight",
     "title": "Formalization Design: Axiomatized Partial Results",

--- a/src/data/proofs/erdos-290/annotations.json
+++ b/src/data/proofs/erdos-290/annotations.json
@@ -252,7 +252,7 @@
     "proofId": "erdos-290",
     "range": {
       "startLine": 230,
-      "endLine": 265
+      "endLine": 263
     },
     "type": "concept",
     "title": "Main Theorems and Summary",

--- a/src/data/proofs/erdos-292/annotations.json
+++ b/src/data/proofs/erdos-292/annotations.json
@@ -119,7 +119,7 @@
     "type": "concept",
     "range": {
       "startLine": 145,
-      "endLine": 155
+      "endLine": 150
     },
     "title": "Martin's Main Theorem",
     "content": "**martin_main_theorem:**\n\nThe set A has natural density 1.\n\n**Proof:** Martin (2000) proved that B has density ~ (log log x)/(log x), which tends to 0. Therefore A = ℕ \\ B has density 1.\n\nThis completely resolves the question: almost all integers are in A.",

--- a/src/data/proofs/erdos-293/annotations.json
+++ b/src/data/proofs/erdos-293/annotations.json
@@ -99,7 +99,7 @@
     "proofId": "erdos-293",
     "range": {
       "startLine": 107,
-      "endLine": 132
+      "endLine": 121
     },
     "type": "concept",
     "title": "Conjectures and Small Values",

--- a/src/data/proofs/erdos-294/annotations.json
+++ b/src/data/proofs/erdos-294/annotations.json
@@ -329,7 +329,7 @@
     "proofId": "erdos-294",
     "range": {
       "startLine": 297,
-      "endLine": 316
+      "endLine": 306
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-295/annotations.json
+++ b/src/data/proofs/erdos-295/annotations.json
@@ -229,7 +229,7 @@
     "proofId": "erdos-295",
     "range": {
       "startLine": 153,
-      "endLine": 162
+      "endLine": 153
     },
     "type": "concept",
     "title": "e - 1 is Positive",

--- a/src/data/proofs/erdos-296/annotations.json
+++ b/src/data/proofs/erdos-296/annotations.json
@@ -321,7 +321,7 @@
     "proofId": "erdos-296",
     "range": {
       "startLine": 154,
-      "endLine": 169
+      "endLine": 160
     },
     "type": "concept",
     "title": "Infinitely Often Large (PROVED)",

--- a/src/data/proofs/erdos-3/annotations.json
+++ b/src/data/proofs/erdos-3/annotations.json
@@ -291,7 +291,7 @@
     "proofId": "erdos-3",
     "range": {
       "startLine": 156,
-      "endLine": 171
+      "endLine": 163
     },
     "type": "concept",
     "title": "Green-Tao and the Prime Connection",

--- a/src/data/proofs/erdos-300/annotations.json
+++ b/src/data/proofs/erdos-300/annotations.json
@@ -143,7 +143,7 @@
     "proofId": "erdos-300",
     "range": {
       "startLine": 246,
-      "endLine": 280
+      "endLine": 265
     },
     "type": "concept",
     "title": "Main Result: erdos_300",

--- a/src/data/proofs/erdos-305/annotations.json
+++ b/src/data/proofs/erdos-305/annotations.json
@@ -267,7 +267,7 @@
     "proofId": "erdos-305",
     "range": {
       "startLine": 186,
-      "endLine": 189
+      "endLine": 186
     },
     "type": "concept",
     "title": "Solution",

--- a/src/data/proofs/erdos-309/annotations.json
+++ b/src/data/proofs/erdos-309/annotations.json
@@ -387,7 +387,7 @@
     "proofId": "erdos-309",
     "range": {
       "startLine": 328,
-      "endLine": 349
+      "endLine": 339
     },
     "type": "concept",
     "title": "Summary",

--- a/src/data/proofs/erdos-310/annotations.json
+++ b/src/data/proofs/erdos-310/annotations.json
@@ -299,7 +299,7 @@
     "proofId": "erdos-310",
     "range": {
       "startLine": 301,
-      "endLine": 312
+      "endLine": 308
     },
     "type": "concept",
     "title": "Croot's Theorem",

--- a/src/data/proofs/erdos-315/annotations.json
+++ b/src/data/proofs/erdos-315/annotations.json
@@ -447,7 +447,7 @@
     "proofId": "erdos-315",
     "range": {
       "startLine": 255,
-      "endLine": 264
+      "endLine": 258
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-322/annotations.json
+++ b/src/data/proofs/erdos-322/annotations.json
@@ -120,7 +120,7 @@
     "proofId": "erdos-322",
     "range": {
       "startLine": 159,
-      "endLine": 191
+      "endLine": 182
     },
     "type": "concept",
     "title": "Summary: Problem #322 is PARTIALLY SOLVED",

--- a/src/data/proofs/erdos-329/annotations.json
+++ b/src/data/proofs/erdos-329/annotations.json
@@ -328,7 +328,7 @@
     "proofId": "erdos-329",
     "range": {
       "startLine": 197,
-      "endLine": 213
+      "endLine": 198
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-331/annotations.json
+++ b/src/data/proofs/erdos-331/annotations.json
@@ -289,7 +289,7 @@
     "proofId": "erdos-331",
     "range": {
       "startLine": 215,
-      "endLine": 233
+      "endLine": 223
     },
     "type": "concept",
     "title": "Summary Docstring",

--- a/src/data/proofs/erdos-333/annotations.json
+++ b/src/data/proofs/erdos-333/annotations.json
@@ -345,7 +345,7 @@
     "proofId": "erdos-333",
     "range": {
       "startLine": 274,
-      "endLine": 314
+      "endLine": 286
     },
     "type": "concept",
     "title": "Summary",

--- a/src/data/proofs/erdos-336/annotations.json
+++ b/src/data/proofs/erdos-336/annotations.json
@@ -197,7 +197,7 @@
     "proofId": "erdos-336",
     "range": {
       "startLine": 160,
-      "endLine": 180
+      "endLine": 161
     },
     "type": "concept",
     "title": "Main Results",

--- a/src/data/proofs/erdos-339/annotations.json
+++ b/src/data/proofs/erdos-339/annotations.json
@@ -203,7 +203,7 @@
     "proofId": "erdos-339",
     "range": {
       "startLine": 206,
-      "endLine": 216
+      "endLine": 215
     },
     "type": "definition",
     "title": "Related: Sidon Sets and Bₕ Sets",

--- a/src/data/proofs/erdos-340-greedy-sidon/annotations.json
+++ b/src/data/proofs/erdos-340-greedy-sidon/annotations.json
@@ -262,7 +262,7 @@
     "proofId": "erdos-340-greedy-sidon",
     "range": {
       "startLine": 444,
-      "endLine": 506
+      "endLine": 505
     },
     "type": "insight",
     "title": "Growth Rate Bounds and Erdos's Conjecture (#340)",

--- a/src/data/proofs/erdos-344/annotations.json
+++ b/src/data/proofs/erdos-344/annotations.json
@@ -270,7 +270,7 @@
     "proofId": "erdos-344",
     "range": {
       "startLine": 202,
-      "endLine": 211
+      "endLine": 207
     },
     "type": "concept",
     "title": "Summary of Known Results",

--- a/src/data/proofs/erdos-346/annotations.json
+++ b/src/data/proofs/erdos-346/annotations.json
@@ -224,7 +224,7 @@
     "type": "concept",
     "range": {
       "startLine": 78,
-      "endLine": 87
+      "endLine": 80
     },
     "title": "Erdos Problem 346: Convergence to the Golden Ratio",
     "content": "The conjecture states: if a sequence is **lacunary**, **strongly complete**, and **fragile**, then a_{n+1}/a_n converges to **phi = (1 + sqrt(5))/2**. Formally, for every delta > 0, there exists n_0 such that |a_{n+1}/a_n - phi| < delta for all n >= n_0. This would mean that the golden ratio is the unique growth rate compatible with all three properties simultaneously.",

--- a/src/data/proofs/erdos-352/annotations.json
+++ b/src/data/proofs/erdos-352/annotations.json
@@ -270,7 +270,7 @@
     "proofId": "erdos-352",
     "range": {
       "startLine": 217,
-      "endLine": 240
+      "endLine": 235
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-360/annotations.json
+++ b/src/data/proofs/erdos-360/annotations.json
@@ -207,7 +207,7 @@
     "proofId": "erdos-360",
     "range": {
       "startLine": 166,
-      "endLine": 185
+      "endLine": 170
     },
     "type": "concept",
     "title": "Main Result: Problem Solved",

--- a/src/data/proofs/erdos-361/annotations.json
+++ b/src/data/proofs/erdos-361/annotations.json
@@ -27,7 +27,7 @@
     "type": "concept",
     "range": {
       "startLine": 95,
-      "endLine": 146
+      "endLine": 140
     },
     "title": "Non-Representation Proofs and Structural Properties",
     "content": "Proved theorems establishing key structural properties. `nonRepresenting_of_sum_lt`: if $\\sum A < n$, then no subset of $A$ sums to $n$ (since $\\sum B \\leq \\sum A < n$ for $B \\subseteq A$). `maxNonRepr_small_sum`: when the total $\\{1, \\ldots, \\lfloor cn \\rfloor\\}$ sums to less than $n$, the maximum non-representing set is the full range. The documentation notes this replaces an earlier incorrect asymptotic claim — the condition $\\sum < n$ only holds for finitely many $n$ since the sum grows as $\\Theta(c^2 n^2)$. Additional structural results on the relationship between density parameter $c$ and the non-representation threshold.",

--- a/src/data/proofs/erdos-365/annotations.json
+++ b/src/data/proofs/erdos-365/annotations.json
@@ -169,7 +169,7 @@
     "proofId": "erdos-365",
     "range": {
       "startLine": 165,
-      "endLine": 189
+      "endLine": 181
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-366/annotations.json
+++ b/src/data/proofs/erdos-366/annotations.json
@@ -158,7 +158,7 @@
     "proofId": "erdos-366",
     "range": {
       "startLine": 206,
-      "endLine": 218
+      "endLine": 209
     },
     "type": "concept",
     "title": "Structure of k-Full Numbers",

--- a/src/data/proofs/erdos-373/annotations.json
+++ b/src/data/proofs/erdos-373/annotations.json
@@ -271,7 +271,7 @@
     "proofId": "erdos-373",
     "range": {
       "startLine": 158,
-      "endLine": 170
+      "endLine": 168
     },
     "type": "concept",
     "title": "Suranyi's Conjecture",

--- a/src/data/proofs/erdos-377/annotations.json
+++ b/src/data/proofs/erdos-377/annotations.json
@@ -213,7 +213,7 @@
     "proofId": "erdos-377",
     "range": {
       "startLine": 129,
-      "endLine": 135
+      "endLine": 134
     },
     "type": "concept",
     "title": "Complementary Sums Lemma",

--- a/src/data/proofs/erdos-378/annotations.json
+++ b/src/data/proofs/erdos-378/annotations.json
@@ -291,7 +291,7 @@
     "proofId": "erdos-378",
     "range": {
       "startLine": 308,
-      "endLine": 328
+      "endLine": 325
     },
     "type": "concept",
     "title": "Erdos Problem #378: Main Result",

--- a/src/data/proofs/erdos-391/annotations.json
+++ b/src/data/proofs/erdos-391/annotations.json
@@ -139,7 +139,7 @@
     "proofId": "erdos-391",
     "range": {
       "startLine": 210,
-      "endLine": 247
+      "endLine": 227
     },
     "type": "concept",
     "title": "Summary Theorem: All Main Results Combined",

--- a/src/data/proofs/erdos-394/annotations.json
+++ b/src/data/proofs/erdos-394/annotations.json
@@ -174,7 +174,7 @@
     "proofId": "erdos-394",
     "range": {
       "startLine": 263,
-      "endLine": 327
+      "endLine": 290
     },
     "type": "concept",
     "title": "Summary and Main Results",

--- a/src/data/proofs/erdos-395/annotations.json
+++ b/src/data/proofs/erdos-395/annotations.json
@@ -119,7 +119,7 @@
     "proofId": "erdos-395",
     "range": {
       "startLine": 158,
-      "endLine": 195
+      "endLine": 186
     },
     "type": "concept",
     "title": "Complete Resolution of Erdős #395",

--- a/src/data/proofs/erdos-396/annotations.json
+++ b/src/data/proofs/erdos-396/annotations.json
@@ -158,7 +158,7 @@
     "proofId": "erdos-396",
     "range": {
       "startLine": 77,
-      "endLine": 79
+      "endLine": 78
     },
     "type": "concept",
     "title": "Smallest Witnesses and Computational Evidence",

--- a/src/data/proofs/erdos-399/annotations.json
+++ b/src/data/proofs/erdos-399/annotations.json
@@ -209,7 +209,7 @@
     "proofId": "erdos-399",
     "range": {
       "startLine": 118,
-      "endLine": 125
+      "endLine": 123
     },
     "type": "concept",
     "title": "GCD Analysis",

--- a/src/data/proofs/erdos-4/annotations.json
+++ b/src/data/proofs/erdos-4/annotations.json
@@ -561,7 +561,7 @@
     "proofId": "erdos-4",
     "range": {
       "startLine": 216,
-      "endLine": 243
+      "endLine": 219
     },
     "type": "concept",
     "title": "Summary: SOLVED Status and Open Questions",

--- a/src/data/proofs/erdos-403/annotations.json
+++ b/src/data/proofs/erdos-403/annotations.json
@@ -270,7 +270,7 @@
     "proofId": "erdos-403",
     "range": {
       "startLine": 311,
-      "endLine": 356
+      "endLine": 339
     },
     "type": "concept",
     "title": "Main Results: erdos_403 and Powers of Three",

--- a/src/data/proofs/erdos-407/annotations.json
+++ b/src/data/proofs/erdos-407/annotations.json
@@ -203,7 +203,7 @@
     "proofId": "erdos-407",
     "range": {
       "startLine": 210,
-      "endLine": 233
+      "endLine": 219
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-41/annotations.json
+++ b/src/data/proofs/erdos-41/annotations.json
@@ -194,7 +194,7 @@
     "proofId": "erdos-41",
     "range": {
       "startLine": 152,
-      "endLine": 170
+      "endLine": 164
     },
     "type": "concept",
     "title": "Summary of Known Results",

--- a/src/data/proofs/erdos-419/annotations.json
+++ b/src/data/proofs/erdos-419/annotations.json
@@ -227,7 +227,7 @@
     "type": "insight",
     "range": {
       "startLine": 157,
-      "endLine": 172
+      "endLine": 165
     },
     "title": "Concrete Examples",
     "content": "Four axioms for concrete cases: n+1 prime → ratio ≈ 2, n+1 = 2p → ratio ≈ 3/2, n+1 = 3p → ratio ≈ 4/3, n+1 smooth → ratio ≈ 1. These illustrate the full range of limit points and demonstrate how the structure of n+1 determines the ratio.",

--- a/src/data/proofs/erdos-426/annotations.json
+++ b/src/data/proofs/erdos-426/annotations.json
@@ -275,7 +275,7 @@
     "proofId": "erdos-426",
     "range": {
       "startLine": 255,
-      "endLine": 281
+      "endLine": 255
     },
     "type": "concept",
     "title": "Problem Summary",

--- a/src/data/proofs/erdos-431/annotations.json
+++ b/src/data/proofs/erdos-431/annotations.json
@@ -119,7 +119,7 @@
     "proofId": "erdos-431",
     "range": {
       "startLine": 175,
-      "endLine": 219
+      "endLine": 213
     },
     "type": "concept",
     "title": "Summary: Problem #431 is OPEN",

--- a/src/data/proofs/erdos-437/annotations.json
+++ b/src/data/proofs/erdos-437/annotations.json
@@ -412,7 +412,7 @@
     "proofId": "erdos-437",
     "range": {
       "startLine": 277,
-      "endLine": 294
+      "endLine": 284
     },
     "type": "concept",
     "title": "Summary",

--- a/src/data/proofs/erdos-439/annotations.json
+++ b/src/data/proofs/erdos-439/annotations.json
@@ -193,7 +193,7 @@
     "proofId": "erdos-439",
     "range": {
       "startLine": 215,
-      "endLine": 223
+      "endLine": 218
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-440/annotations.json
+++ b/src/data/proofs/erdos-440/annotations.json
@@ -377,7 +377,7 @@
     "proofId": "erdos-440",
     "range": {
       "startLine": 189,
-      "endLine": 209
+      "endLine": 200
     },
     "type": "concept",
     "title": "Main Result: Problem #440 Solved",

--- a/src/data/proofs/erdos-442/annotations.json
+++ b/src/data/proofs/erdos-442/annotations.json
@@ -268,7 +268,7 @@
     "proofId": "erdos-442",
     "range": {
       "startLine": 244,
-      "endLine": 263
+      "endLine": 255
     },
     "type": "concept",
     "title": "Historical Significance",

--- a/src/data/proofs/erdos-443/annotations.json
+++ b/src/data/proofs/erdos-443/annotations.json
@@ -126,7 +126,7 @@
     "proofId": "erdos-443",
     "range": {
       "startLine": 163,
-      "endLine": 186
+      "endLine": 181
     },
     "type": "concept",
     "title": "Quadratic Structure and Arithmetic Progressions",

--- a/src/data/proofs/erdos-444/annotations.json
+++ b/src/data/proofs/erdos-444/annotations.json
@@ -253,7 +253,7 @@
     "proofId": "erdos-444",
     "range": {
       "startLine": 132,
-      "endLine": 152
+      "endLine": 137
     },
     "type": "concept",
     "title": "Summary Docstring and erdos_444_summary Theorem",

--- a/src/data/proofs/erdos-446/annotations.json
+++ b/src/data/proofs/erdos-446/annotations.json
@@ -157,7 +157,7 @@
     "proofId": "erdos-446",
     "range": {
       "startLine": 131,
-      "endLine": 141
+      "endLine": 139
     },
     "type": "concept",
     "title": "Primes Avoid the Interval",

--- a/src/data/proofs/erdos-448/annotations.json
+++ b/src/data/proofs/erdos-448/annotations.json
@@ -277,7 +277,7 @@
     "proofId": "erdos-448",
     "range": {
       "startLine": 289,
-      "endLine": 317
+      "endLine": 307
     },
     "type": "concept",
     "title": "Summary",

--- a/src/data/proofs/erdos-449/annotations.json
+++ b/src/data/proofs/erdos-449/annotations.json
@@ -231,7 +231,7 @@
     "type": "concept",
     "range": {
       "startLine": 146,
-      "endLine": 158
+      "endLine": 154
     },
     "title": "Ford's Derivation from Problem 448",
     "content": "**ford_derivation:** Kevin Ford observed the disproof follows from combining Cauchy-Schwarz with Problem 448.\n\nThe chain: Problem 448 ⟹ τ(n)/τ⁺(n) ≥ K+1 on positive density ⟹ r(n) ≥ τ(n)²/τ⁺(n) - τ(n) ≥ K·τ(n) on positive density.",

--- a/src/data/proofs/erdos-455/annotations.json
+++ b/src/data/proofs/erdos-455/annotations.json
@@ -189,7 +189,7 @@
     "proofId": "erdos-455",
     "range": {
       "startLine": 139,
-      "endLine": 151
+      "endLine": 142
     },
     "type": "concept",
     "title": "Alternative Characterization of Non-Decreasing Gaps",

--- a/src/data/proofs/erdos-457/annotations.json
+++ b/src/data/proofs/erdos-457/annotations.json
@@ -174,7 +174,7 @@
     "proofId": "erdos-457",
     "range": {
       "startLine": 179,
-      "endLine": 187
+      "endLine": 181
     },
     "type": "definition",
     "title": "Smooth Numbers Connection",

--- a/src/data/proofs/erdos-458/annotations.json
+++ b/src/data/proofs/erdos-458/annotations.json
@@ -148,7 +148,7 @@
     "proofId": "erdos-458",
     "range": {
       "startLine": 137,
-      "endLine": 158
+      "endLine": 156
     },
     "type": "insight",
     "title": "Connection to Legendre's Conjecture",

--- a/src/data/proofs/erdos-46/annotations.json
+++ b/src/data/proofs/erdos-46/annotations.json
@@ -229,7 +229,7 @@
     "type": "concept",
     "range": {
       "startLine": 79,
-      "endLine": 91
+      "endLine": 84
     },
     "title": "Monochromaticity Properties and Cardinality Bound",
     "content": "**mono_one_colour**: any set is monochromatic under a 1-colouring ($r = 1$). **mono_subset**: subsets of monochromatic sets are monochromatic. **unitFractionRepr_card_ge_two**: representations have $|S| \\ge 2$ (axiomatized).",

--- a/src/data/proofs/erdos-465/annotations.json
+++ b/src/data/proofs/erdos-465/annotations.json
@@ -259,7 +259,7 @@
     "proofId": "erdos-465",
     "range": {
       "startLine": 243,
-      "endLine": 293
+      "endLine": 256
     },
     "type": "concept",
     "title": "Summary: erdos_465_solved and erdos_465_summary",

--- a/src/data/proofs/erdos-466/annotations.json
+++ b/src/data/proofs/erdos-466/annotations.json
@@ -143,7 +143,7 @@
     "proofId": "erdos-466",
     "range": {
       "startLine": 55,
-      "endLine": 95
+      "endLine": 79
     },
     "type": "concept",
     "title": "The 465-466 Duality: Upper and Lower Bounds",

--- a/src/data/proofs/erdos-471/annotations.json
+++ b/src/data/proofs/erdos-471/annotations.json
@@ -138,7 +138,7 @@
     "proofId": "erdos-471",
     "range": {
       "startLine": 272,
-      "endLine": 300
+      "endLine": 274
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-475/annotations.json
+++ b/src/data/proofs/erdos-475/annotations.json
@@ -301,7 +301,7 @@
     "proofId": "erdos-475",
     "range": {
       "startLine": 192,
-      "endLine": 207
+      "endLine": 195
     },
     "type": "concept",
     "title": "erdos_475_summary — Combined Result",

--- a/src/data/proofs/erdos-477/annotations.json
+++ b/src/data/proofs/erdos-477/annotations.json
@@ -271,7 +271,7 @@
     "type": "concept",
     "range": {
       "startLine": 244,
-      "endLine": 271
+      "endLine": 261
     },
     "title": "Erdős Problem 477 (Open)",
     "content": "The main conjecture in three forms: (1) no degree $\\geq 2$ polynomial has a perfect complement, (2) no monomial $x^k$ with $k \\geq 2$ has a perfect complement, and (3) the combined statement. The formalization also notes connections to the Coven-Meyerowitz conjecture on integer tilings.",

--- a/src/data/proofs/erdos-482/annotations.json
+++ b/src/data/proofs/erdos-482/annotations.json
@@ -119,7 +119,7 @@
     "proofId": "erdos-482",
     "range": {
       "startLine": 128,
-      "endLine": 159
+      "endLine": 128
     },
     "type": "concept",
     "title": "Main Result: erdos_482",

--- a/src/data/proofs/erdos-484/annotations.json
+++ b/src/data/proofs/erdos-484/annotations.json
@@ -257,7 +257,7 @@
     "proofId": "erdos-484",
     "range": {
       "startLine": 254,
-      "endLine": 265
+      "endLine": 261
     },
     "type": "concept",
     "title": "Hindman's Theorem (1974)",

--- a/src/data/proofs/erdos-485/annotations.json
+++ b/src/data/proofs/erdos-485/annotations.json
@@ -208,7 +208,7 @@
     "type": "definition",
     "range": {
       "startLine": 210,
-      "endLine": 228
+      "endLine": 226
     },
     "title": "Sparse Polynomials and Product Density",
     "content": "**isSparse(P, c):** termCount(P) ≤ c · log(deg(P) + 1). A polynomial is sparse when its term count is logarithmic in its degree.\n\n**sparse_product_density (axiom):** ∃ c > 0 such that for sparse P, Q: termCount(P·Q) ≥ termCount(P) + termCount(Q) - 1.",

--- a/src/data/proofs/erdos-486/annotations.json
+++ b/src/data/proofs/erdos-486/annotations.json
@@ -195,7 +195,7 @@
     "proofId": "erdos-486",
     "range": {
       "startLine": 105,
-      "endLine": 109
+      "endLine": 108
     },
     "type": "definition",
     "title": "Natural Density",

--- a/src/data/proofs/erdos-487/annotations.json
+++ b/src/data/proofs/erdos-487/annotations.json
@@ -318,7 +318,7 @@
     "proofId": "erdos-487",
     "range": {
       "startLine": 335,
-      "endLine": 368
+      "endLine": 350
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-489/annotations.json
+++ b/src/data/proofs/erdos-489/annotations.json
@@ -119,7 +119,7 @@
     "proofId": "erdos-489",
     "range": {
       "startLine": 169,
-      "endLine": 198
+      "endLine": 190
     },
     "type": "concept",
     "title": "Summary Theorems",

--- a/src/data/proofs/erdos-491/annotations.json
+++ b/src/data/proofs/erdos-491/annotations.json
@@ -171,7 +171,7 @@
     "proofId": "erdos-491",
     "range": {
       "startLine": 174,
-      "endLine": 190
+      "endLine": 182
     },
     "type": "concept",
     "title": "Connection to Prime Factorization",

--- a/src/data/proofs/erdos-495/annotations.json
+++ b/src/data/proofs/erdos-495/annotations.json
@@ -155,7 +155,7 @@
     "proofId": "erdos-495",
     "range": {
       "startLine": 165,
-      "endLine": 188
+      "endLine": 178
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-496/annotations.json
+++ b/src/data/proofs/erdos-496/annotations.json
@@ -181,7 +181,7 @@
     "proofId": "erdos-496",
     "range": {
       "startLine": 90,
-      "endLine": 96
+      "endLine": 94
     },
     "type": "concept",
     "title": "Davenport–Heilbronn (1946)",

--- a/src/data/proofs/erdos-497/annotations.json
+++ b/src/data/proofs/erdos-497/annotations.json
@@ -63,7 +63,7 @@
     "proofId": "erdos-497",
     "range": {
       "startLine": 50,
-      "endLine": 58
+      "endLine": 51
     },
     "type": "insight",
     "title": "Small Dedekind Numbers",

--- a/src/data/proofs/erdos-499/annotations.json
+++ b/src/data/proofs/erdos-499/annotations.json
@@ -206,7 +206,7 @@
     "proofId": "erdos-499",
     "range": {
       "startLine": 268,
-      "endLine": 288
+      "endLine": 284
     },
     "type": "concept",
     "title": "Problem Summary",

--- a/src/data/proofs/erdos-500/annotations.json
+++ b/src/data/proofs/erdos-500/annotations.json
@@ -143,7 +143,7 @@
     "type": "concept",
     "range": {
       "startLine": 45,
-      "endLine": 59
+      "endLine": 58
     },
     "title": "Stubs: Extremal Number, Density, Bounds, and Conjecture (Incomplete)",
     "content": "Lines 45-59 are section header comments and orphaned docstrings marking out the remaining formalization work:\n\n**Turán number** (stub at line 45): `ex3_K4 n` would return the maximum number of edges in a $K_4^{(3)}$-free hypergraph on $n$ vertices, axiomatized with existence (`ex3_K4_achievable`) and optimality (`ex3_K4_optimal`) properties.\n\n**Turán density** (stub at line 49): `turanDensityK4_3` would formalize $\\pi(K_4^{(3)}) = \\lim_{n\\to\\infty} \\text{ex}_3(n)/\\binom{n}{3}$, whose existence is guaranteed by the Katona–Nemetz–Simonovits theorem (1964).\n\n**Turán's lower bound** (stub at line 50): $\\pi \\geq 5/9$ from the 3-partition construction.\n\n**Razborov's upper bound** (stub at line 52): $\\pi \\leq 0.5612$ via flag algebras (2010).\n\n**Turán's conjecture** (stub at line 54): $\\pi = 5/9$ (OPEN since 1941).\n\n**Exact small values** (stub at line 56): $\\text{ex}_3(4) = 3$, $\\text{ex}_3(5) = 7$, $\\text{ex}_3(6) = 13$.",

--- a/src/data/proofs/erdos-504/annotations.json
+++ b/src/data/proofs/erdos-504/annotations.json
@@ -167,7 +167,7 @@
     "type": "concept",
     "range": {
       "startLine": 184,
-      "endLine": 219
+      "endLine": 217
     },
     "title": "Optimal Configurations and Convex Position",
     "content": "Regular n-gon vertices are defined via cos/sin on the unit circle. For N = 2^k, the regular polygon achieves the optimal (minimum) maximum angle (regularNGon_optimal). The isConvexPosition predicate (axiomatized) captures when all points are on the convex hull. Optimal configurations achieving α_N are always in convex position (optimal_is_convex).",

--- a/src/data/proofs/erdos-505/annotations.json
+++ b/src/data/proofs/erdos-505/annotations.json
@@ -138,7 +138,7 @@
     "type": "concept",
     "range": {
       "startLine": 59,
-      "endLine": 63
+      "endLine": 60
     },
     "title": "Low-Dimensional Positive Results",
     "content": "Axioms asserting Borsuk's conjecture for $n = 2$ (classical, due to Lenz and Hadwiger) and $n = 3$ (Eggleston 1955, also by Grünbaum and Heppes). For $n = 2$, the result follows from the fact that any planar set of diameter 1 can be covered by 3 strips. For $n = 3$, the proof uses the geometry of the Reuleaux triangle and its 3D analogues. The case $n = 1$ is trivial: any interval is already diameter $< 1$ after splitting into 2 parts.",

--- a/src/data/proofs/erdos-507/annotations.json
+++ b/src/data/proofs/erdos-507/annotations.json
@@ -207,7 +207,7 @@
     "type": "concept",
     "range": {
       "startLine": 83,
-      "endLine": 85
+      "endLine": 83
     },
     "title": "Cohen–Pohoata–Zakharov Upper Bound $\\alpha(n) \\ll n^{-7/6-o(1)}$",
     "content": "Cohen, Pohoata, and Zakharov (2024) achieved the current best upper bound $\\alpha(n) \\leq C/n^{7/6+o(1)}$, improving the KPS exponent from $8/7 \\approx 1.143$ to $7/6 \\approx 1.167$. Their breakthrough uses incidence geometry techniques—specifically point-line and point-curve incidence bounds—combined with the polynomial method. The $o(1)$ term in the exponent comes from a logarithmic correction.",

--- a/src/data/proofs/erdos-509/annotations.json
+++ b/src/data/proofs/erdos-509/annotations.json
@@ -119,7 +119,7 @@
     "proofId": "erdos-509",
     "range": {
       "startLine": 173,
-      "endLine": 201
+      "endLine": 199
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-51/annotations.json
+++ b/src/data/proofs/erdos-51/annotations.json
@@ -164,7 +164,7 @@
     "proofId": "erdos-51",
     "range": {
       "startLine": 63,
-      "endLine": 70
+      "endLine": 69
     },
     "type": "concept",
     "title": "Stubs: Preimage Structure and Growth Bounds (Unformalized)",

--- a/src/data/proofs/erdos-510/annotations.json
+++ b/src/data/proofs/erdos-510/annotations.json
@@ -139,7 +139,7 @@
     "proofId": "erdos-510",
     "range": {
       "startLine": 60,
-      "endLine": 66
+      "endLine": 64
     },
     "type": "concept",
     "title": "Sidon Set Optimality: √N Cannot Be Improved",

--- a/src/data/proofs/erdos-515/annotations.json
+++ b/src/data/proofs/erdos-515/annotations.json
@@ -157,7 +157,7 @@
     "proofId": "erdos-515",
     "range": {
       "startLine": 236,
-      "endLine": 290
+      "endLine": 286
     },
     "type": "concept",
     "title": "Summary and Main Theorems",

--- a/src/data/proofs/erdos-516/annotations.json
+++ b/src/data/proofs/erdos-516/annotations.json
@@ -281,7 +281,7 @@
     "proofId": "erdos-516",
     "range": {
       "startLine": 192,
-      "endLine": 205
+      "endLine": 196
     },
     "type": "concept",
     "title": "Macintyre's Counterexample (1952)",

--- a/src/data/proofs/erdos-522/annotations.json
+++ b/src/data/proofs/erdos-522/annotations.json
@@ -272,7 +272,7 @@
     "proofId": "erdos-522",
     "range": {
       "startLine": 257,
-      "endLine": 281
+      "endLine": 276
     },
     "type": "concept",
     "title": "Summary and Conclusions",

--- a/src/data/proofs/erdos-523/annotations.json
+++ b/src/data/proofs/erdos-523/annotations.json
@@ -291,7 +291,7 @@
     "type": "concept",
     "range": {
       "startLine": 238,
-      "endLine": 253
+      "endLine": 238
     },
     "title": "Summary: Complete Resolution",
     "content": "Four concluding theorems: `erdos_523` and `erdos_523_solved` both assert `ErdosQuestion523` (forwarding from `erdos_523_answer`). `erdos_523_constant` witnesses $C = 1$ explicitly. `erdos_523_main` packages `halasz_theorem`. The problem is completely solved: $\\max_{|z|=1} |\\sum \\varepsilon_k z^k| = (1 + o(1))\\sqrt{n \\log n}$ almost surely.",

--- a/src/data/proofs/erdos-525/annotations.json
+++ b/src/data/proofs/erdos-525/annotations.json
@@ -199,7 +199,7 @@
     "type": "concept",
     "range": {
       "startLine": 182,
-      "endLine": 226
+      "endLine": 202
     },
     "title": "Complete Solution Summary",
     "content": "Three summary theorems combine the key results: (1) Littlewood's conjecture is true (Kashin), (2) the correct exponent is -1/2 (Konyagin), and (3) the exact limiting distribution is e^{-ελ} (Cook-Nguyen). This completely resolves Erdős Problem #525.",

--- a/src/data/proofs/erdos-527/annotations.json
+++ b/src/data/proofs/erdos-527/annotations.json
@@ -138,7 +138,7 @@
     "proofId": "erdos-527",
     "range": {
       "startLine": 133,
-      "endLine": 162
+      "endLine": 136
     },
     "type": "concept",
     "title": "Summary Theorems",

--- a/src/data/proofs/erdos-529/annotations.json
+++ b/src/data/proofs/erdos-529/annotations.json
@@ -197,7 +197,7 @@
     "proofId": "erdos-529",
     "range": {
       "startLine": 304,
-      "endLine": 326
+      "endLine": 306
     },
     "type": "concept",
     "title": "Main Results Summary",

--- a/src/data/proofs/erdos-53/annotations.json
+++ b/src/data/proofs/erdos-53/annotations.json
@@ -182,7 +182,7 @@
     "type": "definition",
     "range": {
       "startLine": 115,
-      "endLine": 127
+      "endLine": 116
     },
     "title": "Individual Counting Functions",
     "content": "subsetSumCount and subsetProductCount separately count the distinct integers representable as subset sums and subset products. The axioms assert that the union count $|\\text{sumsOrProducts}(A)|$ is at least each individual count — a trivial consequence of $|X \\cup Y| \\geq \\max(|X|, |Y|)$ for finite sets, but formalized explicitly for convenience.",

--- a/src/data/proofs/erdos-532/annotations.json
+++ b/src/data/proofs/erdos-532/annotations.json
@@ -285,7 +285,7 @@
     "proofId": "erdos-532",
     "range": {
       "startLine": 299,
-      "endLine": 326
+      "endLine": 303
     },
     "type": "concept",
     "title": "Summary: Problem Solved",

--- a/src/data/proofs/erdos-534/annotations.json
+++ b/src/data/proofs/erdos-534/annotations.json
@@ -149,7 +149,7 @@
     "proofId": "erdos-534",
     "range": {
       "startLine": 122,
-      "endLine": 150
+      "endLine": 133
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-535/annotations.json
+++ b/src/data/proofs/erdos-535/annotations.json
@@ -260,7 +260,7 @@
     "proofId": "erdos-535",
     "range": {
       "startLine": 211,
-      "endLine": 219
+      "endLine": 211
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-536/annotations.json
+++ b/src/data/proofs/erdos-536/annotations.json
@@ -163,7 +163,7 @@
     "proofId": "erdos-536",
     "range": {
       "startLine": 82,
-      "endLine": 84
+      "endLine": 83
     },
     "type": "concept",
     "title": "LCM Divisibility Structure Lemma",

--- a/src/data/proofs/erdos-539/annotations.json
+++ b/src/data/proofs/erdos-539/annotations.json
@@ -444,7 +444,7 @@
     "proofId": "erdos-539",
     "range": {
       "startLine": 180,
-      "endLine": 193
+      "endLine": 188
     },
     "type": "concept",
     "title": "Granville-Roesler Geometric Reformulation",

--- a/src/data/proofs/erdos-54/annotations.json
+++ b/src/data/proofs/erdos-54/annotations.json
@@ -186,7 +186,7 @@
     "type": "definition",
     "range": {
       "startLine": 77,
-      "endLine": 85
+      "endLine": 78
     },
     "title": "Erdős Problem 54: Solved — Θ((log N)²)",
     "content": "**ErdosProblem54**: the conjunction of both bounds: $\\exists c > 0$ (lower) $\\wedge$ $\\exists A$ Ramsey 2-complete with $\\le C(\\log N)^2$ (upper). Together: the minimum growth rate is $\\Theta((\\log N)^2)$.",

--- a/src/data/proofs/erdos-542/annotations.json
+++ b/src/data/proofs/erdos-542/annotations.json
@@ -150,7 +150,7 @@
     "type": "concept",
     "range": {
       "startLine": 90,
-      "endLine": 106
+      "endLine": 97
     },
     "title": "Singleton Validity and Reciprocal Sum",
     "content": "`singleton_satisfies_lcm`: any singleton $\\{a\\}$ with $a \\in \\{1,\\ldots,n\\}$ and $a > 0$ satisfies the LCM condition vacuously (no distinct pairs). Proved by `Finset.mem_singleton` + `subst` + `absurd`. `reciprocal_sum_singleton`: $\\sum_{x \\in \\{a\\}} 1/x = 1/a$, proved by `simp`.",

--- a/src/data/proofs/erdos-549/annotations.json
+++ b/src/data/proofs/erdos-549/annotations.json
@@ -325,7 +325,7 @@
     "proofId": "erdos-549",
     "range": {
       "startLine": 226,
-      "endLine": 249
+      "endLine": 248
     },
     "type": "concept",
     "title": "Main Result: Conjecture Disproved",

--- a/src/data/proofs/erdos-55/annotations.json
+++ b/src/data/proofs/erdos-55/annotations.json
@@ -335,7 +335,7 @@
     "proofId": "erdos-55",
     "range": {
       "startLine": 174,
-      "endLine": 191
+      "endLine": 181
     },
     "type": "concept",
     "title": "Historical Notes and References",

--- a/src/data/proofs/erdos-550/annotations.json
+++ b/src/data/proofs/erdos-550/annotations.json
@@ -156,7 +156,7 @@
     "proofId": "erdos-550",
     "range": {
       "startLine": 198,
-      "endLine": 218
+      "endLine": 211
     },
     "type": "concept",
     "title": "Bounded Degree and Burr's Conjecture",

--- a/src/data/proofs/erdos-554/annotations.json
+++ b/src/data/proofs/erdos-554/annotations.json
@@ -137,7 +137,7 @@
     "proofId": "erdos-554",
     "range": {
       "startLine": 126,
-      "endLine": 141
+      "endLine": 128
     },
     "type": "concept",
     "title": "The Pentagon Case",

--- a/src/data/proofs/erdos-558/annotations.json
+++ b/src/data/proofs/erdos-558/annotations.json
@@ -165,7 +165,7 @@
     "proofId": "erdos-558",
     "range": {
       "startLine": 192,
-      "endLine": 209
+      "endLine": 194
     },
     "type": "concept",
     "title": "Erdos Problem #558 Main Theorem",

--- a/src/data/proofs/erdos-560/annotations.json
+++ b/src/data/proofs/erdos-560/annotations.json
@@ -231,7 +231,7 @@
     "proofId": "erdos-560",
     "range": {
       "startLine": 260,
-      "endLine": 291
+      "endLine": 265
     },
     "type": "concept",
     "title": "Main Results Summary",

--- a/src/data/proofs/erdos-561/annotations.json
+++ b/src/data/proofs/erdos-561/annotations.json
@@ -202,7 +202,7 @@
     "proofId": "erdos-561",
     "range": {
       "startLine": 219,
-      "endLine": 235
+      "endLine": 227
     },
     "type": "concept",
     "title": "Summary and Main Theorem",

--- a/src/data/proofs/erdos-562/annotations.json
+++ b/src/data/proofs/erdos-562/annotations.json
@@ -219,7 +219,7 @@
     "proofId": "erdos-562",
     "range": {
       "startLine": 84,
-      "endLine": 86
+      "endLine": 85
     },
     "type": "concept",
     "title": "General Lower Bound for r ≥ 3",

--- a/src/data/proofs/erdos-564/annotations.json
+++ b/src/data/proofs/erdos-564/annotations.json
@@ -214,7 +214,7 @@
     "proofId": "erdos-564",
     "range": {
       "startLine": 191,
-      "endLine": 212
+      "endLine": 207
     },
     "type": "concept",
     "title": "The 4-Colour Evidence",

--- a/src/data/proofs/erdos-565/annotations.json
+++ b/src/data/proofs/erdos-565/annotations.json
@@ -319,7 +319,7 @@
     "proofId": "erdos-565",
     "range": {
       "startLine": 275,
-      "endLine": 307
+      "endLine": 286
     },
     "type": "concept",
     "title": "Summary: Complete Resolution of Erdos Problem #565",

--- a/src/data/proofs/erdos-57/annotations.json
+++ b/src/data/proofs/erdos-57/annotations.json
@@ -146,7 +146,7 @@
     "proofId": "erdos-57",
     "range": {
       "startLine": 155,
-      "endLine": 167
+      "endLine": 166
     },
     "type": "concept",
     "title": "Historical Notes and Proof Technique Overview",

--- a/src/data/proofs/erdos-570/annotations.json
+++ b/src/data/proofs/erdos-570/annotations.json
@@ -115,7 +115,7 @@
     "proofId": "erdos-570",
     "range": {
       "startLine": 143,
-      "endLine": 156
+      "endLine": 148
     },
     "type": "concept",
     "title": "Complete Resolution",

--- a/src/data/proofs/erdos-571/annotations.json
+++ b/src/data/proofs/erdos-571/annotations.json
@@ -229,7 +229,7 @@
     "proofId": "erdos-571",
     "range": {
       "startLine": 160,
-      "endLine": 182
+      "endLine": 180
     },
     "type": "concept",
     "title": "Classical Upper Bounds: Kovari-Sos-Turan and Bondy-Simonovits",

--- a/src/data/proofs/erdos-573/annotations.json
+++ b/src/data/proofs/erdos-573/annotations.json
@@ -178,7 +178,7 @@
     "proofId": "erdos-573",
     "range": {
       "startLine": 174,
-      "endLine": 198
+      "endLine": 177
     },
     "type": "concept",
     "title": "Summary Theorems",

--- a/src/data/proofs/erdos-575/annotations.json
+++ b/src/data/proofs/erdos-575/annotations.json
@@ -164,7 +164,7 @@
     "proofId": "erdos-575",
     "range": {
       "startLine": 84,
-      "endLine": 90
+      "endLine": 89
     },
     "type": "concept",
     "title": "Monotonicity of Extremal Functions",

--- a/src/data/proofs/erdos-576/annotations.json
+++ b/src/data/proofs/erdos-576/annotations.json
@@ -417,7 +417,7 @@
     "proofId": "erdos-576",
     "range": {
       "startLine": 220,
-      "endLine": 224
+      "endLine": 223
     },
     "type": "concept",
     "title": "Hypercubes are Bipartite",

--- a/src/data/proofs/erdos-578/annotations.json
+++ b/src/data/proofs/erdos-578/annotations.json
@@ -207,7 +207,7 @@
     "proofId": "erdos-578",
     "range": {
       "startLine": 143,
-      "endLine": 158
+      "endLine": 151
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-58/annotations.json
+++ b/src/data/proofs/erdos-58/annotations.json
@@ -121,7 +121,7 @@
     "proofId": "erdos-58",
     "range": {
       "startLine": 131,
-      "endLine": 165
+      "endLine": 152
     },
     "type": "concept",
     "title": "Corollaries: χ ≥ 5 Forces Two Odd Lengths, Equality Implies Clique",

--- a/src/data/proofs/erdos-580/annotations.json
+++ b/src/data/proofs/erdos-580/annotations.json
@@ -246,7 +246,7 @@
     "proofId": "erdos-580",
     "range": {
       "startLine": 223,
-      "endLine": 237
+      "endLine": 236
     },
     "type": "concept",
     "title": "Tightness of the LKS Condition",

--- a/src/data/proofs/erdos-581/annotations.json
+++ b/src/data/proofs/erdos-581/annotations.json
@@ -184,7 +184,7 @@
     "proofId": "erdos-581",
     "range": {
       "startLine": 260,
-      "endLine": 281
+      "endLine": 261
     },
     "type": "concept",
     "title": "Main Results",

--- a/src/data/proofs/erdos-582/annotations.json
+++ b/src/data/proofs/erdos-582/annotations.json
@@ -208,7 +208,7 @@
     "proofId": "erdos-582",
     "range": {
       "startLine": 307,
-      "endLine": 320
+      "endLine": 317
     },
     "type": "concept",
     "title": "Main Results Summary",

--- a/src/data/proofs/erdos-583/annotations.json
+++ b/src/data/proofs/erdos-583/annotations.json
@@ -231,7 +231,7 @@
     "proofId": "erdos-583",
     "range": {
       "startLine": 228,
-      "endLine": 239
+      "endLine": 232
     },
     "type": "concept",
     "title": "Lower Bounds and Tightness Examples",

--- a/src/data/proofs/erdos-585/annotations.json
+++ b/src/data/proofs/erdos-585/annotations.json
@@ -142,7 +142,7 @@
     "proofId": "erdos-585",
     "range": {
       "startLine": 78,
-      "endLine": 89
+      "endLine": 80
     },
     "type": "insight",
     "title": "Combined Bounds — The Open Gap",

--- a/src/data/proofs/erdos-586/annotations.json
+++ b/src/data/proofs/erdos-586/annotations.json
@@ -163,7 +163,7 @@
     "proofId": "erdos-586",
     "range": {
       "startLine": 142,
-      "endLine": 172
+      "endLine": 165
     },
     "type": "concept",
     "title": "Summary: Three Key Results",

--- a/src/data/proofs/erdos-589/annotations.json
+++ b/src/data/proofs/erdos-589/annotations.json
@@ -221,7 +221,7 @@
     "proofId": "erdos-589",
     "range": {
       "startLine": 306,
-      "endLine": 342
+      "endLine": 339
     },
     "type": "concept",
     "title": "Problem Summary",

--- a/src/data/proofs/erdos-591/annotations.json
+++ b/src/data/proofs/erdos-591/annotations.json
@@ -229,7 +229,7 @@
     "proofId": "erdos-591",
     "range": {
       "startLine": 164,
-      "endLine": 182
+      "endLine": 175
     },
     "type": "concept",
     "title": "The Pattern Summary",

--- a/src/data/proofs/erdos-593/annotations.json
+++ b/src/data/proofs/erdos-593/annotations.json
@@ -119,7 +119,7 @@
     "proofId": "erdos-593",
     "range": {
       "startLine": 99,
-      "endLine": 111
+      "endLine": 110
     },
     "type": "concept",
     "title": "2-Colorable Hypergraphs Are Unavoidable",

--- a/src/data/proofs/erdos-594/annotations.json
+++ b/src/data/proofs/erdos-594/annotations.json
@@ -216,7 +216,7 @@
     "proofId": "erdos-594",
     "range": {
       "startLine": 238,
-      "endLine": 270
+      "endLine": 245
     },
     "type": "concept",
     "title": "Summary",

--- a/src/data/proofs/erdos-596/annotations.json
+++ b/src/data/proofs/erdos-596/annotations.json
@@ -146,7 +146,7 @@
     "type": "concept",
     "range": {
       "startLine": 129,
-      "endLine": 146
+      "endLine": 142
     },
     "title": "Summary",
     "content": "**erdos_596_summary** (proved): packages the known results as a conjunction — (C₄, C₆) satisfies the dichotomy AND at least one dichotomy pair exists. **dichotomy_pairs_exist** (proved): constructs the witness from c4_c6_dichotomy. The general characterization of all dichotomy pairs remains **OPEN**.",

--- a/src/data/proofs/erdos-597/annotations.json
+++ b/src/data/proofs/erdos-597/annotations.json
@@ -156,7 +156,7 @@
     "proofId": "erdos-597",
     "range": {
       "startLine": 173,
-      "endLine": 189
+      "endLine": 183
     },
     "type": "concept",
     "title": "Summary Theorem: Known Results Combined",

--- a/src/data/proofs/erdos-598/annotations.json
+++ b/src/data/proofs/erdos-598/annotations.json
@@ -166,7 +166,7 @@
     "proofId": "erdos-598",
     "range": {
       "startLine": 84,
-      "endLine": 96
+      "endLine": 84
     },
     "type": "concept",
     "title": "Monotonicity in Ground Set Size",

--- a/src/data/proofs/erdos-599/annotations.json
+++ b/src/data/proofs/erdos-599/annotations.json
@@ -223,7 +223,7 @@
     "proofId": "erdos-599",
     "range": {
       "startLine": 216,
-      "endLine": 245
+      "endLine": 230
     },
     "type": "concept",
     "title": "Summary and Status",

--- a/src/data/proofs/erdos-600/annotations.json
+++ b/src/data/proofs/erdos-600/annotations.json
@@ -121,7 +121,7 @@
     "proofId": "erdos-600",
     "range": {
       "startLine": 156,
-      "endLine": 179
+      "endLine": 167
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-605/annotations.json
+++ b/src/data/proofs/erdos-605/annotations.json
@@ -251,7 +251,7 @@
     "proofId": "erdos-605",
     "range": {
       "startLine": 247,
-      "endLine": 254
+      "endLine": 250
     },
     "type": "concept",
     "title": "Geometric Constructions",

--- a/src/data/proofs/erdos-606/annotations.json
+++ b/src/data/proofs/erdos-606/annotations.json
@@ -336,7 +336,7 @@
     "proofId": "erdos-606",
     "range": {
       "startLine": 229,
-      "endLine": 244
+      "endLine": 243
     },
     "type": "concept",
     "title": "Szemerédi-Trotter Incidence Bound",

--- a/src/data/proofs/erdos-609/annotations.json
+++ b/src/data/proofs/erdos-609/annotations.json
@@ -444,7 +444,7 @@
     "proofId": "erdos-609",
     "range": {
       "startLine": 217,
-      "endLine": 241
+      "endLine": 219
     },
     "type": "concept",
     "title": "Main Problem Statement and Asymptotics",

--- a/src/data/proofs/erdos-61/annotations.json
+++ b/src/data/proofs/erdos-61/annotations.json
@@ -157,7 +157,7 @@
     "proofId": "erdos-61",
     "range": {
       "startLine": 132,
-      "endLine": 148
+      "endLine": 137
     },
     "type": "concept",
     "title": "Concrete Example Graphs",

--- a/src/data/proofs/erdos-610/annotations.json
+++ b/src/data/proofs/erdos-610/annotations.json
@@ -289,7 +289,7 @@
     "proofId": "erdos-610",
     "range": {
       "startLine": 203,
-      "endLine": 223
+      "endLine": 222
     },
     "type": "concept",
     "title": "Main Result: erdos_610_known (OPEN)",

--- a/src/data/proofs/erdos-616/annotations.json
+++ b/src/data/proofs/erdos-616/annotations.json
@@ -336,7 +336,7 @@
     "proofId": "erdos-616",
     "range": {
       "startLine": 246,
-      "endLine": 286
+      "endLine": 281
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-617/annotations.json
+++ b/src/data/proofs/erdos-617/annotations.json
@@ -138,7 +138,7 @@
     "proofId": "erdos-617",
     "range": {
       "startLine": 180,
-      "endLine": 211
+      "endLine": 202
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-618/annotations.json
+++ b/src/data/proofs/erdos-618/annotations.json
@@ -137,7 +137,7 @@
     "proofId": "erdos-618",
     "range": {
       "startLine": 247,
-      "endLine": 276
+      "endLine": 250
     },
     "type": "concept",
     "title": "Complete Resolution",

--- a/src/data/proofs/erdos-619/annotations.json
+++ b/src/data/proofs/erdos-619/annotations.json
@@ -162,7 +162,7 @@
     "proofId": "erdos-619",
     "range": {
       "startLine": 191,
-      "endLine": 227
+      "endLine": 209
     },
     "type": "concept",
     "title": "Summary and Partial Results",

--- a/src/data/proofs/erdos-620/annotations.json
+++ b/src/data/proofs/erdos-620/annotations.json
@@ -446,7 +446,7 @@
     "proofId": "erdos-620",
     "range": {
       "startLine": 264,
-      "endLine": 314
+      "endLine": 283
     },
     "type": "insight",
     "title": "Open Status",

--- a/src/data/proofs/erdos-627/annotations.json
+++ b/src/data/proofs/erdos-627/annotations.json
@@ -486,7 +486,7 @@
     "proofId": "erdos-627",
     "range": {
       "startLine": 222,
-      "endLine": 237
+      "endLine": 236
     },
     "type": "concept",
     "title": "Main Status",

--- a/src/data/proofs/erdos-628/annotations.json
+++ b/src/data/proofs/erdos-628/annotations.json
@@ -250,7 +250,7 @@
     "proofId": "erdos-628",
     "range": {
       "startLine": 221,
-      "endLine": 254
+      "endLine": 246
     },
     "type": "concept",
     "title": "Main Problem Status",

--- a/src/data/proofs/erdos-63/annotations.json
+++ b/src/data/proofs/erdos-63/annotations.json
@@ -341,7 +341,7 @@
     "proofId": "erdos-63",
     "range": {
       "startLine": 211,
-      "endLine": 228
+      "endLine": 224
     },
     "type": "definition",
     "title": "Generalized Conjecture and Squares Case",

--- a/src/data/proofs/erdos-630/annotations.json
+++ b/src/data/proofs/erdos-630/annotations.json
@@ -232,7 +232,7 @@
     "proofId": "erdos-630",
     "range": {
       "startLine": 225,
-      "endLine": 254
+      "endLine": 246
     },
     "type": "concept",
     "title": "Main Problem Status",

--- a/src/data/proofs/erdos-631/annotations.json
+++ b/src/data/proofs/erdos-631/annotations.json
@@ -300,7 +300,7 @@
     "proofId": "erdos-631",
     "range": {
       "startLine": 245,
-      "endLine": 276
+      "endLine": 269
     },
     "type": "concept",
     "title": "Main Status: erdos_631_status",

--- a/src/data/proofs/erdos-632/annotations.json
+++ b/src/data/proofs/erdos-632/annotations.json
@@ -596,7 +596,7 @@
     "proofId": "erdos-632",
     "range": {
       "startLine": 254,
-      "endLine": 279
+      "endLine": 260
     },
     "type": "concept",
     "title": "Planar Graphs: m = 2 Case",

--- a/src/data/proofs/erdos-634/annotations.json
+++ b/src/data/proofs/erdos-634/annotations.json
@@ -650,7 +650,7 @@
     "proofId": "erdos-634",
     "range": {
       "startLine": 271,
-      "endLine": 299
+      "endLine": 298
     },
     "type": "concept",
     "title": "Erdős Problem #634 — Partial Answer",

--- a/src/data/proofs/erdos-636/annotations.json
+++ b/src/data/proofs/erdos-636/annotations.json
@@ -447,7 +447,7 @@
     "proofId": "erdos-636",
     "range": {
       "startLine": 240,
-      "endLine": 262
+      "endLine": 261
     },
     "type": "concept",
     "title": "Related Problems",

--- a/src/data/proofs/erdos-639/annotations.json
+++ b/src/data/proofs/erdos-639/annotations.json
@@ -273,7 +273,7 @@
     "proofId": "erdos-639",
     "range": {
       "startLine": 196,
-      "endLine": 208
+      "endLine": 202
     },
     "type": "concept",
     "title": "Pyber's Covering and Earlier Results",

--- a/src/data/proofs/erdos-642/annotations.json
+++ b/src/data/proofs/erdos-642/annotations.json
@@ -632,7 +632,7 @@
     "proofId": "erdos-642",
     "range": {
       "startLine": 260,
-      "endLine": 265
+      "endLine": 263
     },
     "type": "concept",
     "title": "Bounds Gap",

--- a/src/data/proofs/erdos-645/annotations.json
+++ b/src/data/proofs/erdos-645/annotations.json
@@ -214,7 +214,7 @@
     "proofId": "erdos-645",
     "range": {
       "startLine": 235,
-      "endLine": 259
+      "endLine": 251
     },
     "type": "definition",
     "title": "The Finite Version",

--- a/src/data/proofs/erdos-648/annotations.json
+++ b/src/data/proofs/erdos-648/annotations.json
@@ -519,7 +519,7 @@
     "proofId": "erdos-648",
     "range": {
       "startLine": 378,
-      "endLine": 384
+      "endLine": 378
     },
     "type": "concept",
     "title": "Main Result: Erdős #648 Solved",

--- a/src/data/proofs/erdos-652/annotations.json
+++ b/src/data/proofs/erdos-652/annotations.json
@@ -342,7 +342,7 @@
     "proofId": "erdos-652",
     "range": {
       "startLine": 174,
-      "endLine": 177
+      "endLine": 175
     },
     "type": "insight",
     "title": "Regular Polygon Example",

--- a/src/data/proofs/erdos-653/annotations.json
+++ b/src/data/proofs/erdos-653/annotations.json
@@ -139,7 +139,7 @@
     "proofId": "erdos-653",
     "range": {
       "startLine": 246,
-      "endLine": 274
+      "endLine": 253
     },
     "type": "concept",
     "title": "Summary Theorems",

--- a/src/data/proofs/erdos-656/annotations.json
+++ b/src/data/proofs/erdos-656/annotations.json
@@ -270,7 +270,7 @@
     "proofId": "erdos-656",
     "range": {
       "startLine": 185,
-      "endLine": 187
+      "endLine": 185
     },
     "type": "concept",
     "title": "Erdős Problem #172",

--- a/src/data/proofs/erdos-658/annotations.json
+++ b/src/data/proofs/erdos-658/annotations.json
@@ -232,7 +232,7 @@
     "proofId": "erdos-658",
     "range": {
       "startLine": 295,
-      "endLine": 331
+      "endLine": 299
     },
     "type": "concept",
     "title": "Summary",

--- a/src/data/proofs/erdos-66/annotations.json
+++ b/src/data/proofs/erdos-66/annotations.json
@@ -175,7 +175,7 @@
     "proofId": "erdos-66",
     "range": {
       "startLine": 182,
-      "endLine": 196
+      "endLine": 187
     },
     "type": "concept",
     "title": "Stronger Implies Original",

--- a/src/data/proofs/erdos-665/annotations.json
+++ b/src/data/proofs/erdos-665/annotations.json
@@ -135,7 +135,7 @@
     "proofId": "erdos-665",
     "range": {
       "startLine": 168,
-      "endLine": 195
+      "endLine": 170
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-666/annotations.json
+++ b/src/data/proofs/erdos-666/annotations.json
@@ -329,7 +329,7 @@
     "proofId": "erdos-666",
     "range": {
       "startLine": 259,
-      "endLine": 270
+      "endLine": 263
     },
     "type": "concept",
     "title": "Turán Number for C₄",

--- a/src/data/proofs/erdos-669/annotations.json
+++ b/src/data/proofs/erdos-669/annotations.json
@@ -113,7 +113,7 @@
     "proofId": "erdos-669",
     "range": {
       "startLine": 123,
-      "endLine": 130
+      "endLine": 128
     },
     "type": "concept",
     "title": "Optimal Configurations",

--- a/src/data/proofs/erdos-670/annotations.json
+++ b/src/data/proofs/erdos-670/annotations.json
@@ -129,7 +129,7 @@
     "proofId": "erdos-670",
     "range": {
       "startLine": 141,
-      "endLine": 164
+      "endLine": 157
     },
     "type": "concept",
     "title": "Higher Dimensions and Connections",

--- a/src/data/proofs/erdos-672/annotations.json
+++ b/src/data/proofs/erdos-672/annotations.json
@@ -156,7 +156,7 @@
     "proofId": "erdos-672",
     "range": {
       "startLine": 198,
-      "endLine": 219
+      "endLine": 214
     },
     "type": "concept",
     "title": "Known Cases Summary",

--- a/src/data/proofs/erdos-676/annotations.json
+++ b/src/data/proofs/erdos-676/annotations.json
@@ -242,7 +242,7 @@
     "proofId": "erdos-676",
     "range": {
       "startLine": 214,
-      "endLine": 228
+      "endLine": 225
     },
     "type": "concept",
     "title": "Problem Status",

--- a/src/data/proofs/erdos-683/annotations.json
+++ b/src/data/proofs/erdos-683/annotations.json
@@ -193,7 +193,7 @@
     "proofId": "erdos-683",
     "range": {
       "startLine": 253,
-      "endLine": 259
+      "endLine": 253
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-691/annotations.json
+++ b/src/data/proofs/erdos-691/annotations.json
@@ -334,7 +334,7 @@
     ],
     "range": {
       "startLine": 173,
-      "endLine": 178
+      "endLine": 173
     }
   }
 ]

--- a/src/data/proofs/erdos-692/annotations.json
+++ b/src/data/proofs/erdos-692/annotations.json
@@ -283,7 +283,7 @@
     "proofId": "erdos-692",
     "range": {
       "startLine": 277,
-      "endLine": 295
+      "endLine": 281
     },
     "type": "concept",
     "title": "Main Summary Theorems",

--- a/src/data/proofs/erdos-694/annotations.json
+++ b/src/data/proofs/erdos-694/annotations.json
@@ -156,7 +156,7 @@
     "proofId": "erdos-694",
     "range": {
       "startLine": 165,
-      "endLine": 189
+      "endLine": 171
     },
     "type": "concept",
     "title": "Non-Carmichael Proofs",

--- a/src/data/proofs/erdos-696/annotations.json
+++ b/src/data/proofs/erdos-696/annotations.json
@@ -243,7 +243,7 @@
     "proofId": "erdos-696",
     "range": {
       "startLine": 298,
-      "endLine": 340
+      "endLine": 310
     },
     "type": "concept",
     "title": "Summary",

--- a/src/data/proofs/erdos-697/annotations.json
+++ b/src/data/proofs/erdos-697/annotations.json
@@ -286,7 +286,7 @@
     "proofId": "erdos-697",
     "range": {
       "startLine": 218,
-      "endLine": 231
+      "endLine": 226
     },
     "type": "concept",
     "title": "Summary and Final Statement",

--- a/src/data/proofs/erdos-7/annotations.json
+++ b/src/data/proofs/erdos-7/annotations.json
@@ -221,7 +221,7 @@
     "proofId": "erdos-7",
     "range": {
       "startLine": 249,
-      "endLine": 276
+      "endLine": 274
     },
     "type": "concept",
     "title": "Problem Summary",

--- a/src/data/proofs/erdos-702/annotations.json
+++ b/src/data/proofs/erdos-702/annotations.json
@@ -173,7 +173,7 @@
     "proofId": "erdos-702",
     "range": {
       "startLine": 144,
-      "endLine": 178
+      "endLine": 155
     },
     "type": "concept",
     "title": "Main Theorem: erdos_702",

--- a/src/data/proofs/erdos-703/annotations.json
+++ b/src/data/proofs/erdos-703/annotations.json
@@ -382,7 +382,7 @@
     "content": "Combined statement: the main question is answered YES (via Frankl-Rödl) and T(n,0) = 2^{n-1}. The proof uses frankl_rodl_1987 for the main question and T_n_0 for the trivial case. This theorem ties together the entire formalization.",
     "range": {
       "startLine": 258,
-      "endLine": 266
+      "endLine": 259
     },
     "significance": "key",
     "mathContext": "The combined result packages the solution to Erdős #703 with the base case. The structure `mainQuestion ∧ (∀ n, n ≥ 1 → T n 0 = 2^{n-1})` shows that the formalization captures both the main theorem (Frankl-Rödl) and its starting point (the classical intersecting family bound). The final `erdos_703 : mainQuestion := frankl_rodl_1987` gives the clean statement.",

--- a/src/data/proofs/erdos-704/annotations.json
+++ b/src/data/proofs/erdos-704/annotations.json
@@ -188,7 +188,7 @@
     "proofId": "erdos-704",
     "range": {
       "startLine": 140,
-      "endLine": 155
+      "endLine": 154
     },
     "type": "concept",
     "title": "Proof Techniques",

--- a/src/data/proofs/erdos-706/annotations.json
+++ b/src/data/proofs/erdos-706/annotations.json
@@ -122,7 +122,7 @@
     "proofId": "erdos-706",
     "range": {
       "startLine": 69,
-      "endLine": 80
+      "endLine": 71
     },
     "type": "concept",
     "title": "Connections to Related Problems",

--- a/src/data/proofs/erdos-708/annotations.json
+++ b/src/data/proofs/erdos-708/annotations.json
@@ -140,7 +140,7 @@
     "proofId": "erdos-708",
     "range": {
       "startLine": 156,
-      "endLine": 190
+      "endLine": 184
     },
     "type": "concept",
     "title": "Summary Theorems",

--- a/src/data/proofs/erdos-709/annotations.json
+++ b/src/data/proofs/erdos-709/annotations.json
@@ -234,7 +234,7 @@
     "proofId": "erdos-709",
     "range": {
       "startLine": 202,
-      "endLine": 232
+      "endLine": 230
     },
     "type": "concept",
     "title": "Proof Techniques",

--- a/src/data/proofs/erdos-71/annotations.json
+++ b/src/data/proofs/erdos-71/annotations.json
@@ -298,7 +298,7 @@
     "proofId": "erdos-71",
     "range": {
       "startLine": 253,
-      "endLine": 272
+      "endLine": 258
     },
     "type": "concept",
     "title": "Summary and Status",

--- a/src/data/proofs/erdos-710/annotations.json
+++ b/src/data/proofs/erdos-710/annotations.json
@@ -247,7 +247,7 @@
     "proofId": "erdos-710",
     "range": {
       "startLine": 307,
-      "endLine": 341
+      "endLine": 320
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-711/annotations.json
+++ b/src/data/proofs/erdos-711/annotations.json
@@ -250,7 +250,7 @@
     "proofId": "erdos-711",
     "range": {
       "startLine": 296,
-      "endLine": 344
+      "endLine": 333
     },
     "type": "concept",
     "title": "Main Results Summary",

--- a/src/data/proofs/erdos-713/annotations.json
+++ b/src/data/proofs/erdos-713/annotations.json
@@ -137,7 +137,7 @@
     "proofId": "erdos-713",
     "range": {
       "startLine": 188,
-      "endLine": 212
+      "endLine": 195
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-714/annotations.json
+++ b/src/data/proofs/erdos-714/annotations.json
@@ -377,7 +377,7 @@
     "proofId": "erdos-714",
     "range": {
       "startLine": 249,
-      "endLine": 263
+      "endLine": 259
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-717/annotations.json
+++ b/src/data/proofs/erdos-717/annotations.json
@@ -347,7 +347,7 @@
     "proofId": "erdos-717",
     "range": {
       "startLine": 274,
-      "endLine": 292
+      "endLine": 289
     },
     "type": "concept",
     "title": "Bollobás-Catlin-Erdős Conjecture",

--- a/src/data/proofs/erdos-718/annotations.json
+++ b/src/data/proofs/erdos-718/annotations.json
@@ -133,7 +133,7 @@
     "proofId": "erdos-718",
     "range": {
       "startLine": 167,
-      "endLine": 199
+      "endLine": 177
     },
     "type": "concept",
     "title": "Main Results and Summary",

--- a/src/data/proofs/erdos-720/annotations.json
+++ b/src/data/proofs/erdos-720/annotations.json
@@ -190,7 +190,7 @@
     "proofId": "erdos-720",
     "range": {
       "startLine": 249,
-      "endLine": 267
+      "endLine": 257
     },
     "type": "concept",
     "title": "Main Results Summary",

--- a/src/data/proofs/erdos-722/annotations.json
+++ b/src/data/proofs/erdos-722/annotations.json
@@ -280,7 +280,7 @@
     "proofId": "erdos-722",
     "range": {
       "startLine": 297,
-      "endLine": 321
+      "endLine": 302
     },
     "type": "concept",
     "title": "Summary and Historical Note",

--- a/src/data/proofs/erdos-723/annotations.json
+++ b/src/data/proofs/erdos-723/annotations.json
@@ -299,7 +299,7 @@
     "proofId": "erdos-723",
     "range": {
       "startLine": 171,
-      "endLine": 187
+      "endLine": 174
     },
     "type": "concept",
     "title": "Bruck-Ryser Application: No Order-6 Plane (Verified)",

--- a/src/data/proofs/erdos-724/annotations.json
+++ b/src/data/proofs/erdos-724/annotations.json
@@ -280,7 +280,7 @@
     "proofId": "erdos-724",
     "range": {
       "startLine": 305,
-      "endLine": 310
+      "endLine": 309
     },
     "type": "concept",
     "title": "Summary of Known Results",

--- a/src/data/proofs/erdos-725/annotations.json
+++ b/src/data/proofs/erdos-725/annotations.json
@@ -195,7 +195,7 @@
     "proofId": "erdos-725",
     "range": {
       "startLine": 144,
-      "endLine": 154
+      "endLine": 150
     },
     "type": "definition",
     "title": "GeneralAsymptotic and ExtendedConjecture",

--- a/src/data/proofs/erdos-732/annotations.json
+++ b/src/data/proofs/erdos-732/annotations.json
@@ -242,7 +242,7 @@
     "proofId": "erdos-732",
     "range": {
       "startLine": 285,
-      "endLine": 327
+      "endLine": 316
     },
     "type": "concept",
     "title": "Summary Theorems",

--- a/src/data/proofs/erdos-733/annotations.json
+++ b/src/data/proofs/erdos-733/annotations.json
@@ -241,7 +241,7 @@
     "proofId": "erdos-733",
     "range": {
       "startLine": 259,
-      "endLine": 289
+      "endLine": 274
     },
     "type": "insight",
     "title": "Complete Summary",

--- a/src/data/proofs/erdos-734/annotations.json
+++ b/src/data/proofs/erdos-734/annotations.json
@@ -173,7 +173,7 @@
     "proofId": "erdos-734",
     "range": {
       "startLine": 206,
-      "endLine": 218
+      "endLine": 206
     },
     "type": "concept",
     "title": "Summary Theorem (Proved)",

--- a/src/data/proofs/erdos-735/annotations.json
+++ b/src/data/proofs/erdos-735/annotations.json
@@ -317,7 +317,7 @@
     "proofId": "erdos-735",
     "range": {
       "startLine": 207,
-      "endLine": 212
+      "endLine": 210
     },
     "type": "concept",
     "title": "Dimension Bound",

--- a/src/data/proofs/erdos-739/annotations.json
+++ b/src/data/proofs/erdos-739/annotations.json
@@ -170,7 +170,7 @@
     "proofId": "erdos-739",
     "range": {
       "startLine": 123,
-      "endLine": 139
+      "endLine": 129
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-74/annotations.json
+++ b/src/data/proofs/erdos-74/annotations.json
@@ -197,7 +197,7 @@
     "proofId": "erdos-74",
     "range": {
       "startLine": 239,
-      "endLine": 276
+      "endLine": 273
     },
     "type": "concept",
     "title": "Basic Bounds (Proved)",

--- a/src/data/proofs/erdos-742/annotations.json
+++ b/src/data/proofs/erdos-742/annotations.json
@@ -377,7 +377,7 @@
     "proofId": "erdos-742",
     "range": {
       "startLine": 204,
-      "endLine": 212
+      "endLine": 207
     },
     "type": "concept",
     "title": "Main Result: Erdős Problem #742",

--- a/src/data/proofs/erdos-743/annotations.json
+++ b/src/data/proofs/erdos-743/annotations.json
@@ -158,7 +158,7 @@
     "proofId": "erdos-743",
     "range": {
       "startLine": 159,
-      "endLine": 173
+      "endLine": 162
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-745/annotations.json
+++ b/src/data/proofs/erdos-745/annotations.json
@@ -245,23 +245,5 @@
     ],
     "mathContext": "See annotation content for formal details of summary and comparison",
     "prerequisites": []
-  },
-  {
-    "id": "ann-e745-answer",
-    "proofId": "erdos-745",
-    "range": {
-      "startLine": 299,
-      "endLine": 327
-    },
-    "type": "concept",
-    "title": "The Final Answer",
-    "content": "**erdos_745_answer:**\n\nErdős Problem #745 is SOLVED.\n\nThe second largest component of G(n, 1/n) has size **Θ(log n)** almost surely.\n\n**Historical significance:**\n- Erdős asked this question in the 1970s\n- He conjectured the answer was O(log n)\n- Komlós, Sulyok, and Szemerédi confirmed this in 1980\n- The result is now a cornerstone of random graph theory",
-    "significance": "key",
-    "relatedConcepts": [
-      "Solved problems",
-      "Random graph milestones"
-    ],
-    "mathContext": "See annotation content for formal details of the final answer",
-    "prerequisites": []
   }
 ]

--- a/src/data/proofs/erdos-747/annotations.json
+++ b/src/data/proofs/erdos-747/annotations.json
@@ -299,7 +299,7 @@
     "proofId": "erdos-747",
     "range": {
       "startLine": 297,
-      "endLine": 328
+      "endLine": 313
     },
     "type": "concept",
     "title": "Complete Summary",

--- a/src/data/proofs/erdos-751/annotations.json
+++ b/src/data/proofs/erdos-751/annotations.json
@@ -224,7 +224,7 @@
     "proofId": "erdos-751",
     "range": {
       "startLine": 220,
-      "endLine": 242
+      "endLine": 235
     },
     "type": "concept",
     "title": "Summary",

--- a/src/data/proofs/erdos-754/annotations.json
+++ b/src/data/proofs/erdos-754/annotations.json
@@ -282,7 +282,7 @@
     "proofId": "erdos-754",
     "range": {
       "startLine": 137,
-      "endLine": 151
+      "endLine": 140
     },
     "type": "concept",
     "title": "Summary Theorems",

--- a/src/data/proofs/erdos-755/annotations.json
+++ b/src/data/proofs/erdos-755/annotations.json
@@ -186,7 +186,7 @@
     "proofId": "erdos-755",
     "range": {
       "startLine": 250,
-      "endLine": 278
+      "endLine": 272
     },
     "type": "concept",
     "title": "Problem Summary",

--- a/src/data/proofs/erdos-756/annotations.json
+++ b/src/data/proofs/erdos-756/annotations.json
@@ -363,7 +363,7 @@
     "proofId": "erdos-756",
     "range": {
       "startLine": 262,
-      "endLine": 284
+      "endLine": 268
     },
     "type": "concept",
     "title": "Main Theorem",

--- a/src/data/proofs/erdos-759/annotations.json
+++ b/src/data/proofs/erdos-759/annotations.json
@@ -375,7 +375,7 @@
     "proofId": "erdos-759",
     "range": {
       "startLine": 284,
-      "endLine": 298
+      "endLine": 295
     },
     "type": "concept",
     "title": "Summary of Results",

--- a/src/data/proofs/erdos-762/annotations.json
+++ b/src/data/proofs/erdos-762/annotations.json
@@ -279,7 +279,7 @@
     "proofId": "erdos-762",
     "range": {
       "startLine": 236,
-      "endLine": 247
+      "endLine": 240
     },
     "type": "concept",
     "title": "Summary",

--- a/src/data/proofs/erdos-763/annotations.json
+++ b/src/data/proofs/erdos-763/annotations.json
@@ -335,7 +335,7 @@
     "proofId": "erdos-763",
     "range": {
       "startLine": 258,
-      "endLine": 276
+      "endLine": 271
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-765/annotations.json
+++ b/src/data/proofs/erdos-765/annotations.json
@@ -178,7 +178,7 @@
     "proofId": "erdos-765",
     "range": {
       "startLine": 196,
-      "endLine": 227
+      "endLine": 215
     },
     "type": "concept",
     "title": "Projective Plane Examples (4 PROVED)",

--- a/src/data/proofs/erdos-766/annotations.json
+++ b/src/data/proofs/erdos-766/annotations.json
@@ -290,7 +290,7 @@
     "proofId": "erdos-766",
     "range": {
       "startLine": 181,
-      "endLine": 186
+      "endLine": 181
     },
     "type": "concept",
     "title": "4-Cycle Anomaly",

--- a/src/data/proofs/erdos-767/annotations.json
+++ b/src/data/proofs/erdos-767/annotations.json
@@ -244,7 +244,7 @@
     "proofId": "erdos-767",
     "range": {
       "startLine": 176,
-      "endLine": 205
+      "endLine": 193
     },
     "type": "concept",
     "title": "Combined Main Statement",

--- a/src/data/proofs/erdos-769/annotations.json
+++ b/src/data/proofs/erdos-769/annotations.json
@@ -99,7 +99,7 @@
     "proofId": "erdos-769",
     "range": {
       "startLine": 97,
-      "endLine": 122
+      "endLine": 116
     },
     "type": "concept",
     "title": "Upper Bounds",

--- a/src/data/proofs/erdos-773/annotations.json
+++ b/src/data/proofs/erdos-773/annotations.json
@@ -185,7 +185,7 @@
     "proofId": "erdos-773",
     "range": {
       "startLine": 203,
-      "endLine": 250
+      "endLine": 236
     },
     "type": "concept",
     "title": "Open Questions and Summary",

--- a/src/data/proofs/erdos-774/annotations.json
+++ b/src/data/proofs/erdos-774/annotations.json
@@ -322,7 +322,7 @@
     "proofId": "erdos-774",
     "range": {
       "startLine": 211,
-      "endLine": 220
+      "endLine": 215
     },
     "type": "concept",
     "title": "nesetril_rodl_sales_theorem",

--- a/src/data/proofs/erdos-775/annotations.json
+++ b/src/data/proofs/erdos-775/annotations.json
@@ -438,7 +438,7 @@
     "proofId": "erdos-775",
     "range": {
       "startLine": 272,
-      "endLine": 291
+      "endLine": 281
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-777/annotations.json
+++ b/src/data/proofs/erdos-777/annotations.json
@@ -232,7 +232,7 @@
     "proofId": "erdos-777",
     "range": {
       "startLine": 323,
-      "endLine": 384
+      "endLine": 336
     },
     "type": "concept",
     "title": "Main Results Summary",

--- a/src/data/proofs/erdos-784/annotations.json
+++ b/src/data/proofs/erdos-784/annotations.json
@@ -399,7 +399,7 @@
     "type": "concept",
     "range": {
       "startLine": 240,
-      "endLine": 262
+      "endLine": 251
     },
     "title": "Main Problem Statement",
     "content": "**erdos_784_statement:**\n\nThe complete formalization combining all results:\n\n1. **C = 1:** H₁(x) ≍ x/log x (Ruzsa-Saias)\n2. **C > 1:** H_C(x) ≍ x^{e^{1-C}}/log x (Ruzsa-Weingartner)\n3. **C ≤ 1:** Answer is YES (polynomial-log bound exists)\n4. **C > 1:** Answer is NO (no such bound exists)\n\nThis theorem packages the entire solution.",

--- a/src/data/proofs/erdos-785/annotations.json
+++ b/src/data/proofs/erdos-785/annotations.json
@@ -242,7 +242,7 @@
     "proofId": "erdos-785",
     "range": {
       "startLine": 195,
-      "endLine": 203
+      "endLine": 199
     },
     "type": "concept",
     "title": "Average Representation",

--- a/src/data/proofs/erdos-786/annotations.json
+++ b/src/data/proofs/erdos-786/annotations.json
@@ -232,7 +232,7 @@
     "proofId": "erdos-786",
     "range": {
       "startLine": 160,
-      "endLine": 173
+      "endLine": 166
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-787/annotations.json
+++ b/src/data/proofs/erdos-787/annotations.json
@@ -99,7 +99,7 @@
     "proofId": "erdos-787",
     "range": {
       "startLine": 126,
-      "endLine": 149
+      "endLine": 138
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-788/annotations.json
+++ b/src/data/proofs/erdos-788/annotations.json
@@ -139,7 +139,7 @@
     "proofId": "erdos-788",
     "range": {
       "startLine": 146,
-      "endLine": 164
+      "endLine": 155
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-790/annotations.json
+++ b/src/data/proofs/erdos-790/annotations.json
@@ -137,7 +137,7 @@
     "proofId": "erdos-790",
     "range": {
       "startLine": 123,
-      "endLine": 133
+      "endLine": 129
     },
     "type": "concept",
     "title": "Combined CKS Bounds",

--- a/src/data/proofs/erdos-791/annotations.json
+++ b/src/data/proofs/erdos-791/annotations.json
@@ -116,7 +116,7 @@
     "proofId": "erdos-791",
     "range": {
       "startLine": 183,
-      "endLine": 215
+      "endLine": 205
     },
     "type": "concept",
     "title": "Main Results",

--- a/src/data/proofs/erdos-796/annotations.json
+++ b/src/data/proofs/erdos-796/annotations.json
@@ -244,7 +244,7 @@
     "proofId": "erdos-796",
     "range": {
       "startLine": 219,
-      "endLine": 241
+      "endLine": 221
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-797/annotations.json
+++ b/src/data/proofs/erdos-797/annotations.json
@@ -160,7 +160,7 @@
     "proofId": "erdos-797",
     "range": {
       "startLine": 152,
-      "endLine": 175
+      "endLine": 155
     },
     "type": "concept",
     "title": "Summary Theorem: erdos_797_summary",

--- a/src/data/proofs/erdos-799/annotations.json
+++ b/src/data/proofs/erdos-799/annotations.json
@@ -328,7 +328,7 @@
     "proofId": "erdos-799",
     "range": {
       "startLine": 178,
-      "endLine": 201
+      "endLine": 178
     },
     "type": "concept",
     "title": "Erdős 799: Main Theorem and Resolution",

--- a/src/data/proofs/erdos-802/annotations.json
+++ b/src/data/proofs/erdos-802/annotations.json
@@ -239,7 +239,7 @@
     "proofId": "erdos-802",
     "range": {
       "startLine": 165,
-      "endLine": 203
+      "endLine": 180
     },
     "type": "concept",
     "title": "Main Result: erdos_802",

--- a/src/data/proofs/erdos-803/annotations.json
+++ b/src/data/proofs/erdos-803/annotations.json
@@ -118,7 +118,7 @@
     "proofId": "erdos-803",
     "range": {
       "startLine": 130,
-      "endLine": 165
+      "endLine": 159
     },
     "type": "concept",
     "title": "Positive Results",

--- a/src/data/proofs/erdos-806/annotations.json
+++ b/src/data/proofs/erdos-806/annotations.json
@@ -250,7 +250,7 @@
     "proofId": "erdos-806",
     "range": {
       "startLine": 215,
-      "endLine": 232
+      "endLine": 219
     },
     "type": "concept",
     "title": "Summary",

--- a/src/data/proofs/erdos-81/annotations.json
+++ b/src/data/proofs/erdos-81/annotations.json
@@ -322,7 +322,7 @@
     "proofId": "erdos-81",
     "range": {
       "startLine": 288,
-      "endLine": 296
+      "endLine": 290
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-811/annotations.json
+++ b/src/data/proofs/erdos-811/annotations.json
@@ -285,7 +285,7 @@
     "proofId": "erdos-811",
     "range": {
       "startLine": 168,
-      "endLine": 193
+      "endLine": 169
     },
     "type": "concept",
     "title": "Main Theorem: erdos_811 (OPEN Problem Summary)",

--- a/src/data/proofs/erdos-813/annotations.json
+++ b/src/data/proofs/erdos-813/annotations.json
@@ -121,7 +121,7 @@
     "proofId": "erdos-813",
     "range": {
       "startLine": 112,
-      "endLine": 125
+      "endLine": 118
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-814/annotations.json
+++ b/src/data/proofs/erdos-814/annotations.json
@@ -232,7 +232,7 @@
     "proofId": "erdos-814",
     "range": {
       "startLine": 279,
-      "endLine": 319
+      "endLine": 292
     },
     "type": "concept",
     "title": "Main Results Summary",

--- a/src/data/proofs/erdos-816/annotations.json
+++ b/src/data/proofs/erdos-816/annotations.json
@@ -139,7 +139,7 @@
     "proofId": "erdos-816",
     "range": {
       "startLine": 206,
-      "endLine": 226
+      "endLine": 206
     },
     "type": "concept",
     "title": "Summary",

--- a/src/data/proofs/erdos-818/annotations.json
+++ b/src/data/proofs/erdos-818/annotations.json
@@ -229,7 +229,7 @@
     "proofId": "erdos-818",
     "range": {
       "startLine": 292,
-      "endLine": 325
+      "endLine": 294
     },
     "type": "concept",
     "title": "Summary",

--- a/src/data/proofs/erdos-819/annotations.json
+++ b/src/data/proofs/erdos-819/annotations.json
@@ -209,7 +209,7 @@
     "proofId": "erdos-819",
     "range": {
       "startLine": 255,
-      "endLine": 289
+      "endLine": 262
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-82/annotations.json
+++ b/src/data/proofs/erdos-82/annotations.json
@@ -195,7 +195,7 @@
     "type": "insight",
     "range": {
       "startLine": 320,
-      "endLine": 352
+      "endLine": 326
     },
     "title": "Bounds Summary",
     "content": "**erdos_82_bounds_summary** is a proved theorem combining both known bounds:\n1. F(n) ≥ (1/2)log₂(n) from Ramsey theory (F_ramsey_lower)\n2. F(n) ≤ C·√n·(log n)^{O(1)} from Alon-Krivelevich-Sudakov (aks_upper_bound)\n\nProof: `exact ⟨F_ramsey_lower, aks_upper_bound⟩`\n\nThe problem remains OPEN with a large gap between log(n) and √n.",

--- a/src/data/proofs/erdos-821/annotations.json
+++ b/src/data/proofs/erdos-821/annotations.json
@@ -118,7 +118,7 @@
     "proofId": "erdos-821",
     "range": {
       "startLine": 137,
-      "endLine": 163
+      "endLine": 142
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-822/annotations.json
+++ b/src/data/proofs/erdos-822/annotations.json
@@ -155,7 +155,7 @@
     "proofId": "erdos-822",
     "range": {
       "startLine": 110,
-      "endLine": 118
+      "endLine": 114
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-824/annotations.json
+++ b/src/data/proofs/erdos-824/annotations.json
@@ -134,7 +134,7 @@
     "proofId": "erdos-824",
     "range": {
       "startLine": 229,
-      "endLine": 251
+      "endLine": 238
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-829/annotations.json
+++ b/src/data/proofs/erdos-829/annotations.json
@@ -348,7 +348,7 @@
     "proofId": "erdos-829",
     "range": {
       "startLine": 193,
-      "endLine": 217
+      "endLine": 196
     },
     "type": "concept",
     "title": "Summary: State of Knowledge",

--- a/src/data/proofs/erdos-830/annotations.json
+++ b/src/data/proofs/erdos-830/annotations.json
@@ -222,7 +222,7 @@
     "proofId": "erdos-830",
     "range": {
       "startLine": 140,
-      "endLine": 147
+      "endLine": 142
     },
     "type": "concept",
     "title": "Paganini's Discovery (1866)",

--- a/src/data/proofs/erdos-832/annotations.json
+++ b/src/data/proofs/erdos-832/annotations.json
@@ -117,7 +117,7 @@
     "proofId": "erdos-832",
     "range": {
       "startLine": 132,
-      "endLine": 155
+      "endLine": 140
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-833/annotations.json
+++ b/src/data/proofs/erdos-833/annotations.json
@@ -253,7 +253,7 @@
     "proofId": "erdos-833",
     "range": {
       "startLine": 211,
-      "endLine": 222
+      "endLine": 215
     },
     "type": "concept",
     "title": "Proof Technique: Lovász Local Lemma Contrapositive",

--- a/src/data/proofs/erdos-835/annotations.json
+++ b/src/data/proofs/erdos-835/annotations.json
@@ -463,7 +463,7 @@
     "proofId": "erdos-835",
     "range": {
       "startLine": 171,
-      "endLine": 182
+      "endLine": 177
     },
     "type": "concept",
     "title": "Uniqueness of k = 2",

--- a/src/data/proofs/erdos-836/annotations.json
+++ b/src/data/proofs/erdos-836/annotations.json
@@ -138,7 +138,7 @@
     "proofId": "erdos-836",
     "range": {
       "startLine": 252,
-      "endLine": 279
+      "endLine": 270
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-838/annotations.json
+++ b/src/data/proofs/erdos-838/annotations.json
@@ -118,7 +118,7 @@
     "proofId": "erdos-838",
     "range": {
       "startLine": 135,
-      "endLine": 154
+      "endLine": 142
     },
     "type": "concept",
     "title": "Erdos-Szekeres and Triangle Bounds",

--- a/src/data/proofs/erdos-84/annotations.json
+++ b/src/data/proofs/erdos-84/annotations.json
@@ -244,7 +244,7 @@
     "proofId": "erdos-84",
     "range": {
       "startLine": 238,
-      "endLine": 279
+      "endLine": 268
     },
     "type": "concept",
     "title": "Summary Theorems",

--- a/src/data/proofs/erdos-841/annotations.json
+++ b/src/data/proofs/erdos-841/annotations.json
@@ -166,7 +166,7 @@
     "proofId": "erdos-841",
     "range": {
       "startLine": 155,
-      "endLine": 197
+      "endLine": 169
     },
     "type": "theorem",
     "title": "Summary Characterization: Erdős #841 Solved",

--- a/src/data/proofs/erdos-842/annotations.json
+++ b/src/data/proofs/erdos-842/annotations.json
@@ -118,7 +118,7 @@
     "proofId": "erdos-842",
     "range": {
       "startLine": 215,
-      "endLine": 234
+      "endLine": 227
     },
     "type": "concept",
     "title": "Complete Resolution",

--- a/src/data/proofs/erdos-843/annotations.json
+++ b/src/data/proofs/erdos-843/annotations.json
@@ -239,7 +239,7 @@
     "proofId": "erdos-843",
     "range": {
       "startLine": 245,
-      "endLine": 271
+      "endLine": 256
     },
     "type": "concept",
     "title": "Problem Summary",

--- a/src/data/proofs/erdos-845/annotations.json
+++ b/src/data/proofs/erdos-845/annotations.json
@@ -156,7 +156,7 @@
     "proofId": "erdos-845",
     "range": {
       "startLine": 170,
-      "endLine": 189
+      "endLine": 176
     },
     "type": "concept",
     "title": "Verified Examples",

--- a/src/data/proofs/erdos-849/annotations.json
+++ b/src/data/proofs/erdos-849/annotations.json
@@ -244,7 +244,7 @@
     "proofId": "erdos-849",
     "range": {
       "startLine": 185,
-      "endLine": 195
+      "endLine": 193
     },
     "type": "concept",
     "title": "OEIS Connections",

--- a/src/data/proofs/erdos-851/annotations.json
+++ b/src/data/proofs/erdos-851/annotations.json
@@ -329,7 +329,7 @@
     "proofId": "erdos-851",
     "range": {
       "startLine": 157,
-      "endLine": 172
+      "endLine": 163
     },
     "type": "concept",
     "title": "Connection to Covering Congruences",

--- a/src/data/proofs/erdos-855/annotations.json
+++ b/src/data/proofs/erdos-855/annotations.json
@@ -115,7 +115,7 @@
     "proofId": "erdos-855",
     "range": {
       "startLine": 155,
-      "endLine": 180
+      "endLine": 172
     },
     "type": "definition",
     "title": "Related Conjectures",

--- a/src/data/proofs/erdos-856/annotations.json
+++ b/src/data/proofs/erdos-856/annotations.json
@@ -297,7 +297,7 @@
     "proofId": "erdos-856",
     "range": {
       "startLine": 256,
-      "endLine": 274
+      "endLine": 260
     },
     "type": "definition",
     "title": "Open Problem and Gap Analysis",

--- a/src/data/proofs/erdos-857/annotations.json
+++ b/src/data/proofs/erdos-857/annotations.json
@@ -287,7 +287,7 @@
     "proofId": "erdos-857",
     "range": {
       "startLine": 277,
-      "endLine": 324
+      "endLine": 289
     },
     "type": "concept",
     "title": "Summary and Main Theorem",

--- a/src/data/proofs/erdos-858/annotations.json
+++ b/src/data/proofs/erdos-858/annotations.json
@@ -243,7 +243,7 @@
     "proofId": "erdos-858",
     "range": {
       "startLine": 327,
-      "endLine": 349
+      "endLine": 348
     },
     "type": "concept",
     "title": "Summary",

--- a/src/data/proofs/erdos-862/annotations.json
+++ b/src/data/proofs/erdos-862/annotations.json
@@ -122,7 +122,7 @@
     "type": "concept",
     "range": {
       "startLine": 119,
-      "endLine": 135
+      "endLine": 131
     },
     "title": "Main Result and Question Answers",
     "content": "The `counting_argument` axiom formalizes the key division: $A_1(N) \\geq A(N) / 2^{(1+\\varepsilon)\\sqrt{N}}$. Combining with the Saxton-Thomason lower bound gives `erdos_862_main`: $A_1(N) \\geq 2^{(0.16-\\varepsilon)\\sqrt{N}}$. Then `question2_positive` shows $A_1(N) > 2^{N^c}$ for $c < 1/2$ (since $0.16\\sqrt{N} = 0.16 N^{1/2} > N^c$ for $c < 1/2$), and `question1_negative` shows $A_1(N)$ is NOT $< 2^{o(\\sqrt{N})}$ (since $2^{0.16\\sqrt{N}}$ violates the universal quantifier at $c = 0.16$).",

--- a/src/data/proofs/erdos-869/annotations.json
+++ b/src/data/proofs/erdos-869/annotations.json
@@ -293,7 +293,7 @@
     "proofId": "erdos-869",
     "range": {
       "startLine": 278,
-      "endLine": 289
+      "endLine": 283
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-870/annotations.json
+++ b/src/data/proofs/erdos-870/annotations.json
@@ -380,7 +380,7 @@
     "proofId": "erdos-870",
     "range": {
       "startLine": 280,
-      "endLine": 322
+      "endLine": 303
     },
     "type": "concept",
     "title": "Summary",

--- a/src/data/proofs/erdos-876/annotations.json
+++ b/src/data/proofs/erdos-876/annotations.json
@@ -238,7 +238,7 @@
     "proofId": "erdos-876",
     "range": {
       "startLine": 249,
-      "endLine": 265
+      "endLine": 257
     },
     "type": "concept",
     "title": "Connections to Sidon Sets and $B_h$ Sequences",

--- a/src/data/proofs/erdos-878/annotations.json
+++ b/src/data/proofs/erdos-878/annotations.json
@@ -117,7 +117,7 @@
     "proofId": "erdos-878",
     "range": {
       "startLine": 182,
-      "endLine": 230
+      "endLine": 219
     },
     "type": "concept",
     "title": "Summary",

--- a/src/data/proofs/erdos-883/annotations.json
+++ b/src/data/proofs/erdos-883/annotations.json
@@ -178,7 +178,7 @@
     "type": "concept",
     "range": {
       "startLine": 195,
-      "endLine": 223
+      "endLine": 216
     },
     "title": "Coprime Graph Properties",
     "content": "coprime_graph_chromatic (axiom): placeholder for high chromatic number. isCoprimeCycle: a cycle where consecutive pairs are coprime. triangles_above_threshold (axiom): for n >= 10, above threshold guarantees a triangle.",

--- a/src/data/proofs/erdos-885/annotations.json
+++ b/src/data/proofs/erdos-885/annotations.json
@@ -220,7 +220,7 @@
     "proofId": "erdos-885",
     "range": {
       "startLine": 153,
-      "endLine": 180
+      "endLine": 165
     },
     "type": "concept",
     "title": "Verified Examples",

--- a/src/data/proofs/erdos-888/annotations.json
+++ b/src/data/proofs/erdos-888/annotations.json
@@ -176,7 +176,7 @@
     "proofId": "erdos-888",
     "range": {
       "startLine": 219,
-      "endLine": 233
+      "endLine": 228
     },
     "type": "definition",
     "title": "Problem Variants",

--- a/src/data/proofs/erdos-894/annotations.json
+++ b/src/data/proofs/erdos-894/annotations.json
@@ -139,7 +139,7 @@
     "proofId": "erdos-894",
     "range": {
       "startLine": 222,
-      "endLine": 233
+      "endLine": 225
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-897/annotations.json
+++ b/src/data/proofs/erdos-897/annotations.json
@@ -194,7 +194,7 @@
     "proofId": "erdos-897",
     "range": {
       "startLine": 129,
-      "endLine": 145
+      "endLine": 141
     },
     "type": "definition",
     "title": "Classical Examples",

--- a/src/data/proofs/erdos-902/annotations.json
+++ b/src/data/proofs/erdos-902/annotations.json
@@ -101,7 +101,7 @@
     "proofId": "erdos-902",
     "range": {
       "startLine": 138,
-      "endLine": 165
+      "endLine": 146
     },
     "type": "concept",
     "title": "Asymptotic Gap",

--- a/src/data/proofs/erdos-903/annotations.json
+++ b/src/data/proofs/erdos-903/annotations.json
@@ -429,7 +429,7 @@
     "proofId": "erdos-903",
     "range": {
       "startLine": 201,
-      "endLine": 227
+      "endLine": 211
     },
     "type": "concept",
     "title": "erdos_903_summary (Proved)",

--- a/src/data/proofs/erdos-904/annotations.json
+++ b/src/data/proofs/erdos-904/annotations.json
@@ -360,7 +360,7 @@
     "proofId": "erdos-904",
     "range": {
       "startLine": 170,
-      "endLine": 175
+      "endLine": 171
     },
     "type": "concept",
     "title": "degree_sum_tight: The Constant 3/2 is Optimal",

--- a/src/data/proofs/erdos-905/annotations.json
+++ b/src/data/proofs/erdos-905/annotations.json
@@ -204,7 +204,7 @@
     "type": "insight",
     "range": {
       "startLine": 188,
-      "endLine": 201
+      "endLine": 190
     },
     "title": "Triangle Count Lower Bound",
     "content": "triangle_count_lower_bound (axiom): T(G) ≥ (e(G) - n²/4) · n/6. Each excess edge above the Turán threshold contributes about n/6 triangles.",

--- a/src/data/proofs/erdos-906/annotations.json
+++ b/src/data/proofs/erdos-906/annotations.json
@@ -251,7 +251,7 @@
     "proofId": "erdos-906",
     "range": {
       "startLine": 165,
-      "endLine": 175
+      "endLine": 168
     },
     "type": "concept",
     "title": "Zero Set Properties",

--- a/src/data/proofs/erdos-909/annotations.json
+++ b/src/data/proofs/erdos-909/annotations.json
@@ -195,7 +195,7 @@
     "proofId": "erdos-909",
     "range": {
       "startLine": 111,
-      "endLine": 134
+      "endLine": 125
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-91/annotations.json
+++ b/src/data/proofs/erdos-91/annotations.json
@@ -187,7 +187,7 @@
     "proofId": "erdos-91",
     "range": {
       "startLine": 243,
-      "endLine": 277
+      "endLine": 276
     },
     "type": "concept",
     "title": "Problem Summary",

--- a/src/data/proofs/erdos-915/annotations.json
+++ b/src/data/proofs/erdos-915/annotations.json
@@ -302,7 +302,7 @@
     "proofId": "erdos-915",
     "range": {
       "startLine": 182,
-      "endLine": 195
+      "endLine": 186
     },
     "type": "concept",
     "title": "Mader (1973): General Disproof for m ≥ 6",

--- a/src/data/proofs/erdos-917/annotations.json
+++ b/src/data/proofs/erdos-917/annotations.json
@@ -139,7 +139,7 @@
     "proofId": "erdos-917",
     "range": {
       "startLine": 177,
-      "endLine": 206
+      "endLine": 181
     },
     "type": "concept",
     "title": "Main Summary Theorem",

--- a/src/data/proofs/erdos-918/annotations.json
+++ b/src/data/proofs/erdos-918/annotations.json
@@ -177,7 +177,7 @@
     "proofId": "erdos-918",
     "range": {
       "startLine": 134,
-      "endLine": 148
+      "endLine": 146
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-920/annotations.json
+++ b/src/data/proofs/erdos-920/annotations.json
@@ -375,7 +375,7 @@
     "proofId": "erdos-920",
     "range": {
       "startLine": 199,
-      "endLine": 207
+      "endLine": 203
     },
     "type": "concept",
     "title": "Mattheus-Verstraete Ramsey Bound R(4,m)",

--- a/src/data/proofs/erdos-921/annotations.json
+++ b/src/data/proofs/erdos-921/annotations.json
@@ -156,7 +156,7 @@
     "proofId": "erdos-921",
     "range": {
       "startLine": 158,
-      "endLine": 183
+      "endLine": 169
     },
     "type": "concept",
     "title": "Final Status: Problem Solved",

--- a/src/data/proofs/erdos-925/annotations.json
+++ b/src/data/proofs/erdos-925/annotations.json
@@ -121,7 +121,7 @@
     "proofId": "erdos-925",
     "range": {
       "startLine": 161,
-      "endLine": 177
+      "endLine": 166
     },
     "type": "concept",
     "title": "The Easy Lower Bound",

--- a/src/data/proofs/erdos-93/annotations.json
+++ b/src/data/proofs/erdos-93/annotations.json
@@ -117,7 +117,7 @@
     "proofId": "erdos-93",
     "range": {
       "startLine": 133,
-      "endLine": 155
+      "endLine": 146
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-930/annotations.json
+++ b/src/data/proofs/erdos-930/annotations.json
@@ -193,7 +193,7 @@
     "proofId": "erdos-930",
     "range": {
       "startLine": 143,
-      "endLine": 158
+      "endLine": 149
     },
     "type": "concept",
     "title": "Non-Power Examples",

--- a/src/data/proofs/erdos-936/annotations.json
+++ b/src/data/proofs/erdos-936/annotations.json
@@ -224,7 +224,7 @@
     "proofId": "erdos-936",
     "range": {
       "startLine": 313,
-      "endLine": 341
+      "endLine": 327
     },
     "type": "concept",
     "title": "Problem Summary",

--- a/src/data/proofs/erdos-939/annotations.json
+++ b/src/data/proofs/erdos-939/annotations.json
@@ -247,7 +247,7 @@
     "proofId": "erdos-939",
     "range": {
       "startLine": 212,
-      "endLine": 222
+      "endLine": 213
     },
     "type": "concept",
     "title": "Perfect Powers are r-Powerful",

--- a/src/data/proofs/erdos-942/annotations.json
+++ b/src/data/proofs/erdos-942/annotations.json
@@ -118,7 +118,7 @@
     "proofId": "erdos-942",
     "range": {
       "startLine": 140,
-      "endLine": 158
+      "endLine": 144
     },
     "type": "concept",
     "title": "Density of h(n) = l",

--- a/src/data/proofs/erdos-950/annotations.json
+++ b/src/data/proofs/erdos-950/annotations.json
@@ -124,7 +124,7 @@
     "type": "concept",
     "range": {
       "startLine": 219,
-      "endLine": 244
+      "endLine": 225
     },
     "title": "Weaker Conjecture and Implication",
     "content": "Erdős's weaker conjecture: ∀ ε > 0, large x has y < x with π(x) < π(y) + ε·π(x−y). If a strong version holds, then f(n) ≪ log log log n — an extremely slow growth bound.",

--- a/src/data/proofs/erdos-962/annotations.json
+++ b/src/data/proofs/erdos-962/annotations.json
@@ -114,7 +114,7 @@
     "proofId": "erdos-962",
     "range": {
       "startLine": 183,
-      "endLine": 224
+      "endLine": 192
     },
     "type": "concept",
     "title": "Summary Theorems",

--- a/src/data/proofs/erdos-966/annotations.json
+++ b/src/data/proofs/erdos-966/annotations.json
@@ -241,7 +241,7 @@
     "proofId": "erdos-966",
     "range": {
       "startLine": 287,
-      "endLine": 308
+      "endLine": 294
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-967/annotations.json
+++ b/src/data/proofs/erdos-967/annotations.json
@@ -361,23 +361,5 @@
       "convergence"
     ],
     "prerequisites": []
-  },
-  {
-    "id": "ann-e967-summary",
-    "proofId": "erdos-967",
-    "range": {
-      "startLine": 245,
-      "endLine": 252
-    },
-    "type": "concept",
-    "title": "Summary Theorem",
-    "content": "**Theorem erdos_967_summary:**\n\n1. The Erdős-Ingham conjecture (1964) is FALSE for infinite sequences\n2. Yip (2025) provided counterexamples for every nonzero t\n3. The finite sequence case remains OPEN\n4. The {2,3,5} case connects to the Four Exponentials conjecture",
-    "significance": "key",
-    "mathContext": "See annotation content for formal details of summary theorem",
-    "relatedConcepts": [
-      "Lean 4 formalization",
-      "mathematical proof"
-    ],
-    "prerequisites": []
   }
 ]

--- a/src/data/proofs/erdos-970/annotations.json
+++ b/src/data/proofs/erdos-970/annotations.json
@@ -222,7 +222,7 @@
     "proofId": "erdos-970",
     "range": {
       "startLine": 157,
-      "endLine": 161
+      "endLine": 157
     },
     "type": "concept",
     "title": "Small Values Consistency",

--- a/src/data/proofs/erdos-971/annotations.json
+++ b/src/data/proofs/erdos-971/annotations.json
@@ -137,7 +137,7 @@
     "proofId": "erdos-971",
     "range": {
       "startLine": 132,
-      "endLine": 155
+      "endLine": 143
     },
     "type": "concept",
     "title": "Verified Computational Examples",

--- a/src/data/proofs/erdos-973/annotations.json
+++ b/src/data/proofs/erdos-973/annotations.json
@@ -160,7 +160,7 @@
     "proofId": "erdos-973",
     "range": {
       "startLine": 171,
-      "endLine": 201
+      "endLine": 188
     },
     "type": "concept",
     "title": "Summary Theorems",

--- a/src/data/proofs/erdos-975/annotations.json
+++ b/src/data/proofs/erdos-975/annotations.json
@@ -190,7 +190,7 @@
     "proofId": "erdos-975",
     "range": {
       "startLine": 174,
-      "endLine": 198
+      "endLine": 183
     },
     "type": "concept",
     "title": "Verified Divisor Counts",

--- a/src/data/proofs/erdos-976/annotations.json
+++ b/src/data/proofs/erdos-976/annotations.json
@@ -195,7 +195,7 @@
     "proofId": "erdos-976",
     "range": {
       "startLine": 163,
-      "endLine": 188
+      "endLine": 175
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-978/annotations.json
+++ b/src/data/proofs/erdos-978/annotations.json
@@ -228,7 +228,7 @@
     "proofId": "erdos-978",
     "range": {
       "startLine": 255,
-      "endLine": 295
+      "endLine": 282
     },
     "type": "concept",
     "title": "Problem Summary",

--- a/src/data/proofs/erdos-979/annotations.json
+++ b/src/data/proofs/erdos-979/annotations.json
@@ -213,7 +213,7 @@
     "proofId": "erdos-979",
     "range": {
       "startLine": 149,
-      "endLine": 167
+      "endLine": 154
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-98/annotations.json
+++ b/src/data/proofs/erdos-98/annotations.json
@@ -119,7 +119,7 @@
     "proofId": "erdos-98",
     "range": {
       "startLine": 74,
-      "endLine": 82
+      "endLine": 75
     },
     "type": "definition",
     "title": "The Erdős Conjecture: $h(n)/n \\to \\infty$",

--- a/src/data/proofs/erdos-980/annotations.json
+++ b/src/data/proofs/erdos-980/annotations.json
@@ -352,7 +352,7 @@
     "proofId": "erdos-980",
     "range": {
       "startLine": 275,
-      "endLine": 277
+      "endLine": 276
     },
     "type": "concept",
     "title": "Polya-Vinogradov Connection",

--- a/src/data/proofs/erdos-981/annotations.json
+++ b/src/data/proofs/erdos-981/annotations.json
@@ -137,7 +137,7 @@
     "proofId": "erdos-981",
     "range": {
       "startLine": 173,
-      "endLine": 205
+      "endLine": 175
     },
     "type": "concept",
     "title": "Complete Resolution",

--- a/src/data/proofs/erdos-982/annotations.json
+++ b/src/data/proofs/erdos-982/annotations.json
@@ -398,7 +398,7 @@
     "proofId": "erdos-982",
     "range": {
       "startLine": 320,
-      "endLine": 341
+      "endLine": 333
     },
     "type": "concept",
     "title": "Problem Status Summary",

--- a/src/data/proofs/erdos-983/annotations.json
+++ b/src/data/proofs/erdos-983/annotations.json
@@ -120,7 +120,7 @@
     "proofId": "erdos-983",
     "range": {
       "startLine": 187,
-      "endLine": 207
+      "endLine": 206
     },
     "type": "definition",
     "title": "y-Smooth Numbers and Dickman Asymptotics",

--- a/src/data/proofs/erdos-984/annotations.json
+++ b/src/data/proofs/erdos-984/annotations.json
@@ -253,7 +253,7 @@
     "type": "concept",
     "range": {
       "startLine": 174,
-      "endLine": 192
+      "endLine": 177
     },
     "title": "Summary Theorem",
     "content": "erdos_984_summary packages the three main results into a single conjunction: (1) Hunter's 2-coloring with subpolynomial bound (the affirmative answer), (2) Spencer's 3-coloring with subpolynomial bound (the precedent), (3) Erdős's partial 2-coloring with polynomial bound (the intermediate result). The proof is a single line: exact ⟨hunter_theorem, spencer_1975, erdos_partial_construction⟩, reflecting that all three components are axiomatized.",

--- a/src/data/proofs/erdos-985/annotations.json
+++ b/src/data/proofs/erdos-985/annotations.json
@@ -258,7 +258,7 @@
     "proofId": "erdos-985",
     "range": {
       "startLine": 200,
-      "endLine": 229
+      "endLine": 223
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-986/annotations.json
+++ b/src/data/proofs/erdos-986/annotations.json
@@ -175,7 +175,7 @@
     "proofId": "erdos-986",
     "range": {
       "startLine": 216,
-      "endLine": 249
+      "endLine": 224
     },
     "type": "concept",
     "title": "Problem Summary",

--- a/src/data/proofs/erdos-987/annotations.json
+++ b/src/data/proofs/erdos-987/annotations.json
@@ -240,7 +240,7 @@
     "proofId": "erdos-987",
     "range": {
       "startLine": 239,
-      "endLine": 258
+      "endLine": 245
     },
     "type": "concept",
     "title": "Main Result: erdos_987",

--- a/src/data/proofs/erdos-989/annotations.json
+++ b/src/data/proofs/erdos-989/annotations.json
@@ -537,7 +537,7 @@
     "proofId": "erdos-989",
     "range": {
       "startLine": 321,
-      "endLine": 365
+      "endLine": 341
     },
     "type": "concept",
     "title": "Summary",

--- a/src/data/proofs/erdos-99/annotations.json
+++ b/src/data/proofs/erdos-99/annotations.json
@@ -140,7 +140,7 @@
     "proofId": "erdos-99",
     "range": {
       "startLine": 158,
-      "endLine": 184
+      "endLine": 179
     },
     "type": "concept",
     "title": "The Conjectures and Packing Density",

--- a/src/data/proofs/erdos-992/annotations.json
+++ b/src/data/proofs/erdos-992/annotations.json
@@ -117,7 +117,7 @@
     "proofId": "erdos-992",
     "range": {
       "startLine": 158,
-      "endLine": 179
+      "endLine": 162
     },
     "type": "concept",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-993/annotations.json
+++ b/src/data/proofs/erdos-993/annotations.json
@@ -157,7 +157,7 @@
     "proofId": "erdos-993",
     "range": {
       "startLine": 154,
-      "endLine": 168
+      "endLine": 164
     },
     "type": "definition",
     "title": "Independence Number and Peak Location",

--- a/src/data/proofs/erdos-995/annotations.json
+++ b/src/data/proofs/erdos-995/annotations.json
@@ -355,7 +355,7 @@
     "proofId": "erdos-995",
     "range": {
       "startLine": 209,
-      "endLine": 212
+      "endLine": 210
     },
     "type": "concept",
     "title": "erdos_995_statement (Proved)",

--- a/src/data/proofs/erdos-999/annotations.json
+++ b/src/data/proofs/erdos-999/annotations.json
@@ -119,7 +119,7 @@
     "proofId": "erdos-999",
     "range": {
       "startLine": 121,
-      "endLine": 148
+      "endLine": 147
     },
     "type": "concept",
     "title": "Consequences and Related Results",

--- a/src/data/proofs/fair-games-theorem/annotations.json
+++ b/src/data/proofs/fair-games-theorem/annotations.json
@@ -123,7 +123,7 @@
     "proofId": "fair-games-theorem",
     "range": {
       "startLine": 350,
-      "endLine": 428
+      "endLine": 417
     },
     "type": "concept",
     "title": "Applications Section (Placeholder Theorems)",

--- a/src/data/proofs/four-color-theorem-oq-02/annotations.json
+++ b/src/data/proofs/four-color-theorem-oq-02/annotations.json
@@ -100,7 +100,7 @@
     "proofId": "four-color-theorem-oq-02",
     "range": {
       "startLine": 67,
-      "endLine": 93
+      "endLine": 86
     },
     "type": "insight",
     "title": "The Open Question: Minimum Configuration Set",

--- a/src/data/proofs/hermite-lindemann/annotations.json
+++ b/src/data/proofs/hermite-lindemann/annotations.json
@@ -172,7 +172,7 @@
     "proofId": "hermite-lindemann",
     "range": {
       "startLine": 360,
-      "endLine": 397
+      "endLine": 390
     },
     "type": "concept",
     "title": "Auxiliary Polynomial Method (Pedagogical)",

--- a/src/data/proofs/hilbert-11/annotations.json
+++ b/src/data/proofs/hilbert-11/annotations.json
@@ -243,7 +243,7 @@
     "proofId": "hilbert-11",
     "range": {
       "startLine": 446,
-      "endLine": 497
+      "endLine": 494
     },
     "type": "concept",
     "title": "Problem Status Summary",

--- a/src/data/proofs/hilbert-17/annotations.json
+++ b/src/data/proofs/hilbert-17/annotations.json
@@ -219,7 +219,7 @@
     "proofId": "hilbert-17",
     "range": {
       "startLine": 543,
-      "endLine": 577
+      "endLine": 561
     },
     "type": "concept",
     "title": "Summary and Problem Status",

--- a/src/data/proofs/hilbert-19-oq-03/annotations.json
+++ b/src/data/proofs/hilbert-19-oq-03/annotations.json
@@ -183,7 +183,7 @@
     "proofId": "hilbert-19-oq-03",
     "range": {
       "startLine": 448,
-      "endLine": 458
+      "endLine": 454
     },
     "type": "insight",
     "title": "The Complete Regularity Chain: Evans-Krylov + Schauder = C-infinity",

--- a/src/data/proofs/hilbert-20/annotations.json
+++ b/src/data/proofs/hilbert-20/annotations.json
@@ -156,7 +156,7 @@
     "proofId": "hilbert-20",
     "range": {
       "startLine": 240,
-      "endLine": 252
+      "endLine": 244
     },
     "type": "concept",
     "title": "Lewy's Counterexample",

--- a/src/data/proofs/hilbert-21/annotations.json
+++ b/src/data/proofs/hilbert-21/annotations.json
@@ -223,7 +223,7 @@
     "proofId": "hilbert-21",
     "range": {
       "startLine": 348,
-      "endLine": 388
+      "endLine": 386
     },
     "type": "concept",
     "title": "Problem Status: SOLVED (with subtleties)",

--- a/src/data/proofs/hilbert-3/annotations.json
+++ b/src/data/proofs/hilbert-3/annotations.json
@@ -239,7 +239,7 @@
     "proofId": "hilbert-3",
     "range": {
       "startLine": 475,
-      "endLine": 515
+      "endLine": 514
     },
     "type": "concept",
     "title": "Historical Impact and K-Theory Connections",

--- a/src/data/proofs/hurwitz-theorem-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/hurwitz-theorem-oq-03-oq-01/annotations.json
@@ -100,7 +100,7 @@
     "proofId": "hurwitz-theorem-oq-03-oq-01",
     "range": {
       "startLine": 81,
-      "endLine": 115
+      "endLine": 113
     },
     "type": "insight",
     "title": "The Non-Commutative Sorry: Two Paths to Quaternion-Octonion Restriction",

--- a/src/data/proofs/kepler-conjecture/annotations.json
+++ b/src/data/proofs/kepler-conjecture/annotations.json
@@ -194,7 +194,7 @@
     "proofId": "kepler-conjecture",
     "range": {
       "startLine": 418,
-      "endLine": 431
+      "endLine": 430
     },
     "type": "concept",
     "title": "Exports and Summary",

--- a/src/data/proofs/kroneckers-jugendtraum/annotations.json
+++ b/src/data/proofs/kroneckers-jugendtraum/annotations.json
@@ -244,7 +244,7 @@
     "proofId": "kroneckers-jugendtraum",
     "range": {
       "startLine": 356,
-      "endLine": 392
+      "endLine": 387
     },
     "type": "concept",
     "title": "Problem Status Summary",

--- a/src/data/proofs/mathematical-induction-oq-01/annotations.json
+++ b/src/data/proofs/mathematical-induction-oq-01/annotations.json
@@ -98,7 +98,7 @@
     "proofId": "mathematical-induction-oq-01",
     "range": {
       "startLine": 149,
-      "endLine": 153
+      "endLine": 150
     },
     "type": "concept",
     "title": "Cantor Normal Form: Statement Stub",

--- a/src/data/proofs/mean-value-theorem/annotations.json
+++ b/src/data/proofs/mean-value-theorem/annotations.json
@@ -225,7 +225,7 @@
     "proofId": "mean-value-theorem",
     "range": {
       "startLine": 157,
-      "endLine": 164
+      "endLine": 163
     },
     "type": "concept",
     "title": "Type-Check Verification",

--- a/src/data/proofs/minkowski-fundamental-theorem-oq-04/annotations.json
+++ b/src/data/proofs/minkowski-fundamental-theorem-oq-04/annotations.json
@@ -231,7 +231,7 @@
     "proofId": "minkowski-fundamental-theorem-oq-04",
     "range": {
       "startLine": 185,
-      "endLine": 193
+      "endLine": 192
     },
     "type": "insight",
     "title": "Extensional Equality: Two Proof Routes Are Interchangeable",

--- a/src/data/proofs/picks-theorem/annotations.json
+++ b/src/data/proofs/picks-theorem/annotations.json
@@ -243,7 +243,7 @@
     "proofId": "picks-theorem",
     "range": {
       "startLine": 440,
-      "endLine": 489
+      "endLine": 484
     },
     "type": "definition",
     "title": "Applications and Lattice Width",

--- a/src/data/proofs/prime-number-theorem/annotations.json
+++ b/src/data/proofs/prime-number-theorem/annotations.json
@@ -568,7 +568,7 @@
     "proofId": "prime-number-theorem",
     "range": {
       "startLine": 430,
-      "endLine": 463
+      "endLine": 460
     },
     "type": "concept",
     "title": "Summary and API Surface",

--- a/src/data/proofs/ptolemys-theorem/annotations.json
+++ b/src/data/proofs/ptolemys-theorem/annotations.json
@@ -235,7 +235,7 @@
     "proofId": "ptolemys-theorem",
     "range": {
       "startLine": 237,
-      "endLine": 257
+      "endLine": 240
     },
     "title": "Historical Context: Chord Tables and the Almagest",
     "type": "concept",

--- a/src/data/proofs/pythagorean-triples/annotations.json
+++ b/src/data/proofs/pythagorean-triples/annotations.json
@@ -206,7 +206,7 @@
     "proofId": "pythagorean-triples",
     "range": {
       "startLine": 241,
-      "endLine": 268
+      "endLine": 260
     },
     "type": "concept",
     "title": "Scaling and Non-primitive Triples",

--- a/src/data/proofs/roth-theorem-k3/annotations.json
+++ b/src/data/proofs/roth-theorem-k3/annotations.json
@@ -165,7 +165,7 @@
     "proofId": "roth-theorem-k3",
     "range": {
       "startLine": 707,
-      "endLine": 1438
+      "endLine": 1401
     },
     "type": "concept",
     "title": "Density Increment via Dirichlet Approximation (732 lines)",

--- a/src/data/proofs/shannon-source-coding-oq-01/annotations.json
+++ b/src/data/proofs/shannon-source-coding-oq-01/annotations.json
@@ -159,7 +159,7 @@
     "proofId": "shannon-source-coding-oq-01",
     "range": {
       "startLine": 286,
-      "endLine": 297
+      "endLine": 292
     },
     "type": "concept",
     "title": "R(D) Convexity (Axiomatized)",

--- a/src/data/proofs/shannon-source-coding/annotations.json
+++ b/src/data/proofs/shannon-source-coding/annotations.json
@@ -84,7 +84,7 @@
     "proofId": "shannon-source-coding",
     "range": {
       "startLine": 28,
-      "endLine": 34
+      "endLine": 32
     },
     "type": "concept",
     "title": "Source Coding Achievability",

--- a/src/data/proofs/solution-of-cubic/annotations.json
+++ b/src/data/proofs/solution-of-cubic/annotations.json
@@ -215,7 +215,7 @@
     "proofId": "solution-of-cubic",
     "range": {
       "startLine": 269,
-      "endLine": 298
+      "endLine": 297
     },
     "type": "concept",
     "title": "Historical Significance and Connections",

--- a/src/data/proofs/sqrt2-minpoly-oq-02/annotations.json
+++ b/src/data/proofs/sqrt2-minpoly-oq-02/annotations.json
@@ -172,7 +172,7 @@
     "proofId": "sqrt2-minpoly-oq-02",
     "range": {
       "startLine": 174,
-      "endLine": 204
+      "endLine": 202
     },
     "type": "insight",
     "title": "Concrete Examples: ∛6, ∛10, ⁵√12, ∜30",

--- a/src/data/proofs/sylow-theorems/annotations.json
+++ b/src/data/proofs/sylow-theorems/annotations.json
@@ -271,7 +271,7 @@
     "proofId": "sylow-theorems",
     "range": {
       "startLine": 234,
-      "endLine": 247
+      "endLine": 246
     },
     "type": "concept",
     "title": "Verification via #check",

--- a/src/data/proofs/yang-mills/annotations.json
+++ b/src/data/proofs/yang-mills/annotations.json
@@ -418,7 +418,7 @@
     "proofId": "yang-mills",
     "range": {
       "startLine": 41,
-      "endLine": 49
+      "endLine": 48
     },
     "type": "concept",
     "title": "Summary: 50+ Theorems, 7 Axioms, and the Open Conjecture",


### PR DESCRIPTION
## Fix

Corrected 485 out-of-bounds annotation range values across 478 gallery proof entries.

## Evidence

**Before**: 483 annotations had `endLine` values exceeding actual Lean file length (by 1–48 lines). 2 annotations had `startLine` exceeding file length.

**After**: All annotation ranges are within file bounds:
- 483 annotations: `endLine` clamped to actual file line count
- 2 annotations removed entirely (startLine already past EOF):
  - `erdos-745`: `ann-e745-answer` (startLine=299 > 298 lines)
  - `erdos-967`: `ann-e967-summary` (startLine=245 > 240 lines)

**Root cause**: Annotations were generated against stale file length metadata after Lean files were modified/shortened.

**Validation**: Re-scan confirms 0 remaining OOB annotation issues. All 478 modified JSON files parse cleanly.

---
Automated fix by lean-mechanic agent.