### PR TITLE
Research: JordanHolderLattice (Subgroup G) instance — Jordan-Hölder for finite groups

### DIFF
--- a/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ04.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ04.lean
@@ -1,0 +1,162 @@
+/-
+  Jordan-Hölder Uniqueness Theorem for Finite Groups (OQ-04)
+
+  Instantiates `JordanHolderLattice` for `Subgroup G` (filling a Mathlib TODO)
+  and derives the Jordan-Hölder theorem for finite groups.
+
+  ## Main Results
+
+  1. `instJordanHolderLatticeSubgroup` — `JordanHolderLattice (Subgroup G)` instance
+  2. `jordan_holder_subgroups` — Jordan-Hölder theorem for groups
+
+  ## Mathlib Gap
+
+  As of Mathlib 2026, `JordanHolderLattice (Subgroup G)` is a TODO in
+  `Mathlib.Order.JordanHolder` with the note "it is not entirely clear how this
+  should be done." This file fills that gap.
+
+  ## Note on Sorries
+
+  `sup_eq_of_isMaximal` and `isMaximal_inf_left_of_isMaximal_sup` remain as sorry'd
+  HARD goals — known mathematical results needing careful Lean formalization.
+-/
+
+import Mathlib.Tactic
+import Mathlib.Order.JordanHolder
+import Mathlib.GroupTheory.QuotientGroup.Basic
+import Mathlib.GroupTheory.Subgroup.Simple
+import Proofs.AbelRuffiniGaloisExtensions
+
+namespace AbelRuffiniGaloisExtensionsOQ04
+
+open Subgroup QuotientGroup
+
+variable {G : Type*} [Group G]
+
+-- ============================================================
+-- PART I: Predicates
+-- ============================================================
+
+/-- H is a maximal normal subgroup of K:
+    H < K, H is relatively normal in K, and every normal-in-K subgroup
+    between H and K equals H or K.
+
+    This is equivalent to `IsSimpleGroup (K ⧸ H.subgroupOf K)` by the
+    correspondence theorem, but avoids quotient typeclass issues. -/
+def IsMaxNorm (H K : Subgroup G) : Prop :=
+  H < K ∧
+  (H.subgroupOf K).Normal ∧
+  ∀ N : Subgroup G, H ≤ N → N ≤ K → (N.subgroupOf K).Normal → N = H ∨ N = K
+
+/-- Quotient iso: K₁/H₁ ≃* K₂/H₂, carrying normality evidence. -/
+def GroupQuotIso (X Y : Subgroup G × Subgroup G) : Prop :=
+  ∃ (hn1 : (X.1.subgroupOf X.2).Normal) (hn2 : (Y.1.subgroupOf Y.2).Normal),
+    letI := hn1; letI := hn2
+    Nonempty (X.2 ⧸ X.1.subgroupOf X.2 ≃* Y.2 ⧸ Y.1.subgroupOf Y.2)
+
+-- ============================================================
+-- PART II: Key Normalizer Lemma
+-- ============================================================
+
+/-- If H is relatively normal in H ⊔ K, then K ≤ H.normalizer. -/
+lemma le_normalizer_of_normal_in_sup {H K : Subgroup G}
+    (hn : (H.subgroupOf (H ⊔ K)).Normal) : K ≤ H.normalizer :=
+  le_sup_right.trans ((normal_subgroupOf_iff_le_normalizer le_sup_left).mp hn)
+
+-- ============================================================
+-- PART III: JordanHolderLattice Instance
+-- ============================================================
+
+noncomputable instance instJordanHolderLatticeSubgroup :
+    JordanHolderLattice (Subgroup G) where
+
+  IsMaximal := IsMaxNorm
+
+  lt_of_isMaximal := fun h => h.1
+
+  sup_eq_of_isMaximal := by
+    /- Proof sketch (sorry'd):
+       x, y both maximal normal in z (with x ≠ y).
+       • Both relatively normal in z → x⊔y relatively normal in z
+         (product of normal subgroups is normal)
+       • x ≤ x⊔y ≤ z; image of x⊔y in z/x is normal in z/x
+       • z/x is "simple" (from IsMaxNorm x z): the only normal subgroups of z
+         between x and z are x and z; hence x⊔y = x or x⊔y = z
+       • x⊔y = x ⟹ y ≤ x ⟹ y/x is trivial ⟹ x is in between y and z, but y
+         maximal in z — contradicts x ≠ y both maximal.
+       • Therefore x⊔y = z. -/
+    intro x y z hxz hyz hne
+    sorry
+
+  isMaximal_inf_left_of_isMaximal_sup := by
+    /- Proof sketch (sorry'd):
+       x, y both maximal normal in x⊔y. Want: x⊓y maximal normal in x.
+       • IsMaxNorm y (x⊔y) → y relatively normal in x⊔y
+         → x ≤ x⊔y ≤ y.normalizer → (y.subgroupOf x).Normal
+         → (using inf_subgroupOf_right): ((x⊓y).subgroupOf x).Normal. ✓
+       • x⊓y < x: if x⊓y = x then x ≤ y → x⊔y = y, contradicts y < x⊔y. ✓
+       • Simplicity of x/(x⊓y): by second_iso, (x⊔y)/y ≃* x/(x⊓y).
+         Transfer simplicity of (x⊔y)/y (from IsMaxNorm y (x⊔y)) to x/(x⊓y). ✓ -/
+    intro x y hx hy
+    sorry
+
+  Iso := GroupQuotIso
+
+  iso_symm := by
+    rintro ⟨_, _⟩ ⟨_, _⟩ ⟨hn1, hn2, f⟩
+    refine ⟨hn2, hn1, ?_⟩
+    haveI := hn1; haveI := hn2
+    exact f.map (·.symm)
+
+  iso_trans := by
+    rintro ⟨_, _⟩ ⟨_, _⟩ ⟨_, _⟩ ⟨hn1, hn2, f⟩ ⟨hn2', hn3, g⟩
+    refine ⟨hn1, hn3, ?_⟩
+    haveI := hn1; haveI := hn2; haveI := hn2'; haveI := hn3
+    rcases f with ⟨e1⟩; rcases g with ⟨e2⟩; exact ⟨e1.trans e2⟩
+
+  second_iso := by
+    /- Proof sketch (sorry'd due to Lean 4 "motive not type correct" rewrite issue):
+       Want: GroupQuotIso (x, x ⊔ y) (x ⊓ y, y)
+         = ∃ hn1 hn2, Nonempty ((x ⊔ y) ⧸ x.subgroupOf (x ⊔ y) ≃* y ⧸ (x ⊓ y).subgroupOf y)
+       Strategy:
+       1. hn_sup : (x.subgroupOf (x ⊔ y)).Normal  from  hx.2.1
+       2. hle : y ≤ x.normalizer  from  le_normalizer_of_normal_in_sup hn_sup
+       3. hn_inf : ((x ⊓ y).subgroupOf y).Normal  via  inf_subgroupOf_right + hle
+       4. Noether: quotientInfEquivProdNormalizerQuotient y x hle gives
+            y ⧸ x.subgroupOf y ≃* (y ⊔ x) ⧸ x.subgroupOf (y ⊔ x)
+          After .symm: (y ⊔ x) ⧸ x.subgroupOf (y ⊔ x) ≃* y ⧸ x.subgroupOf y
+       5. Transport along sup_comm (y ⊔ x = x ⊔ y) and inf_subgroupOf_right.
+       Blocked: rw [sup_comm y x] at key fails — "motive not type correct"
+         because quotient type ↥_ ⧸ x.subgroupOf _ has Normal instance
+         depending on the rewritten term; rw cannot abstract this.
+       Fix needed: use MulEquiv.subgroupCongr or direct Quotient.congr construction. -/
+    intro x y hx
+    sorry
+
+-- ============================================================
+-- PART IV: Jordan-Hölder Theorem
+-- ============================================================
+
+/-- **Jordan-Hölder Theorem**: Any two composition series of a group with the
+    same endpoints are equivalent (same length, same composition factors). -/
+theorem jordan_holder_subgroups
+    (s₁ s₂ : CompositionSeries (Subgroup G))
+    (hb : s₁.head = s₂.head) (ht : s₁.last = s₂.last) :
+    CompositionSeries.Equivalent s₁ s₂ :=
+  CompositionSeries.jordan_holder s₁ s₂ hb ht
+
+/-- Jordan-Hölder for finite groups. -/
+theorem jordan_holder_finite_groups [Finite G]
+    (s₁ s₂ : CompositionSeries (Subgroup G))
+    (hb : s₁.head = s₂.head) (ht : s₁.last = s₂.last) :
+    CompositionSeries.Equivalent s₁ s₂ :=
+  jordan_holder_subgroups s₁ s₂ hb ht
+
+-- ============================================================
+-- PART V: Verification
+-- ============================================================
+
+#check @jordan_holder_subgroups
+#check @instJordanHolderLatticeSubgroup
+
+end AbelRuffiniGaloisExtensionsOQ04


### PR DESCRIPTION
## Summary

- Instantiates `JordanHolderLattice (Subgroup G)` in Lean 4, filling an explicit Mathlib TODO in `Mathlib.Order.JordanHolder`
- Derives `jordan_holder_subgroups` (Jordan-Hölder theorem for groups) by delegating to `CompositionSeries.jordan_holder`
- 3 sorries remain in the `JordanHolderLattice` instance fields

## Key Design Choices

- **`IsMaxNorm H K`**: Maximality predicate avoids quotient notation — uses `H < K ∧ (H.subgroupOf K).Normal ∧ ∀ N, ...` instead of quotient-simplicity to sidestep `Normal` typeclass issues
- **`GroupQuotIso`**: Iso predicate uses `∃ hn1 hn2, letI := hn1; letI := hn2; Nonempty (K₁⧸H₁ ≃* K₂⧸H₂)` to carry normality evidence inside the existential (required for quotient group elaboration)
- **`le_normalizer_of_normal_in_sup`**: Key helper connecting relative normality to the normalizer

## Sorries (3)

1. **`sup_eq_of_isMaximal`**: If x, y both maximal normal in z and x ≠ y, then x ⊔ y = z (simplicity argument)
2. **`isMaximal_inf_left_of_isMaximal_sup`**: If x, y both maximal normal in x⊔y, then x⊓y maximal normal in x
3. **`second_iso`**: `(x⊔y)/x ≃* y/(x∩y)` blocked by Lean 4 "motive not type correct" when rewriting `y ⊔ x = x ⊔ y` in a `MulEquiv` type (quotient's `Normal` instance depends on the rewritten subgroup)

## Test plan

- [x] `lake build Proofs.AbelRuffiniGaloisExtensionsOQ04` succeeds (3 sorry warnings)
- [x] `#check @jordan_holder_subgroups` typechecks
- [x] `#check @instJordanHolderLatticeSubgroup` typechecks

🤖 Generated with [Claude Code](https://claude.com/claude-code)