### PR TITLE
Enrich abel-ruffini: deepen OQ-04 cross-reference with theorem inventory

### DIFF
--- a/src/data/proofs/abel-ruffini/meta.json
+++ b/src/data/proofs/abel-ruffini/meta.json
@@ -59,7 +59,7 @@
       },
       {
         "id": "abel-ruffini-oq-04",
-        "relationship": "Sub-entry exposing the complete proof chain from A₅ simplicity through S₅ non-solvability to Abel-Ruffini"
+        "relationship": "Sub-entry: eight individually verifiable theorems tracing A₅ simplicity → S₅ non-solvability → Abel-Ruffini, with `five_is_the_threshold` as the precise formal boundary statement"
       },
       {
         "id": "abel-ruffini-oq-04-oq-01",
@@ -238,7 +238,7 @@
     {
       "targetId": "abel-ruffini-oq-04",
       "relationship": "extended-by",
-      "description": "OQ-04 exposes the internal proof chain from A₅ simplicity to Abel-Ruffini as individually named theorems with pedagogical documentation"
+      "description": "Exposes the A₅→S₅ non-solvability proof chain as eight individually verifiable named theorems: `a5_is_simple` (A₅ is a simple group), `symmetric_not_solvable` (Sₙ not solvable for n ≥ 5, with the ℕ→Cardinal coercion bridge made explicit), concrete instantiations `s5_not_solvable`, `s6_not_solvable`, `s7_not_solvable`, solvable contrasts `s0_solvable` and `s1_solvable`, and `five_is_the_threshold` (IsSolvable S₁ ∧ ¬IsSolvable S₅ — the precise formal statement of the degree-5 boundary). A five-step annotated proof chain in comments traces A₅ simplicity → non-abelian simple ⟹ perfect → derived series stabilizes → Sₙ not solvable → Abel-Ruffini contrapositive, at a pedagogical depth unavailable in this entry's concise Mathlib wrappers"
     },
     {
       "targetId": "abel-ruffini-oq-04-oq-01",


### PR DESCRIPTION
Enrichment pass for abel-ruffini (quality 100, pass 5).

## Changes

- **Expanded crossReference description for `abel-ruffini-oq-04`**: The previous description was terse ("OQ-04 exposes the internal proof chain from A₅ simplicity to Abel-Ruffini as individually named theorems with pedagogical documentation"). Now enumerates all 8 individually verifiable theorems in `AbelRuffiniOQ04.lean`:
  - `a5_is_simple` (A₅ is a simple group)
  - `symmetric_not_solvable` (Sₙ not solvable for n ≥ 5, with Cardinal coercion bridge explicit)
  - `s5_not_solvable`, `s6_not_solvable`, `s7_not_solvable` (concrete instances)
  - `s0_solvable`, `s1_solvable` (solvable contrasts)
  - `five_is_the_threshold` (IsSolvable S₁ ∧ ¬IsSolvable S₅ — the precise formal boundary)

- **Updated relatedProblems entry** for `abel-ruffini-oq-04` to mention `five_is_the_threshold`.

Both changes make the cross-reference more informative for readers navigating the abel-ruffini cluster.