### PR TITLE
Fix: update sperner-ndim-oq-04 status to verified, clear stale sorry counts

### DIFF
--- a/src/data/proofs/sperner-ndim-oq-04/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-04/meta.json
@@ -7,7 +7,7 @@
     "author": "Kuhn (1968); formalized by researcher-8",
     "sourceUrl": "https://en.wikipedia.org/wiki/Sperner%27s_lemma#Constructive_proof",
     "date": "1968",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/SpernerNDimOQ04.lean",
     "tags": [
       "combinatorics",
@@ -245,7 +245,7 @@
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 5,
-    "sorries": 2
+    "sorries": 0
   },
-  "sorries": 2
+  "sorries": 0
 }


### PR DESCRIPTION
## Summary
- `sperner-ndim-oq-04` had stale metadata left over after PR #12233 closed both sorries
- `meta.status` was `"formalized"` despite 0 sorries, 0 axioms, badge already `"verified"`
- `leanFile.sorries` and top-level `sorries` both showed `2` instead of `0`

## Evidence
- Lean file `proofs/Proofs/SpernerNDimOQ04.lean`: 0 sorries, 0 axioms in git HEAD
- `meta.sorries`: 0 ✓ (already correct)
- `meta.status`: `"formalized"` ✗ (should be `"verified"`)
- `leanFile.sorries`: `2` ✗ (should be `0`)
- Top-level `sorries`: `2` ✗ (should be `0`)

## Fix
Updated all three stale fields to reflect the 0-sorry, 0-axiom verified state.

Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)