### PR TITLE
Fix: correct top-level sorries=0 in erdos-512 meta.json

### DIFF
--- a/src/data/proofs/erdos-512/meta.json
+++ b/src/data/proofs/erdos-512/meta.json
@@ -238,5 +238,5 @@
       "description": "Related Erdős problem sharing themes: exponential-sums, harmonic-analysis"
     }
   ],
-  "sorries": 2
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

The top-level `sorries` field in `erdos-512/meta.json` was incorrectly set to 2. The Lean file (`Erdos512Problem.lean`) has 0 code sorries — only 2 `axiom` declarations (`konyagin_theorem`, `mcgehee_pigno_smith_theorem`). The axiom count is correctly recorded in `meta.axiomCount=2` and `leanFile.axiomCount=2`; the `meta.sorries` and `leanFile.sorries` sub-fields already showed 0 correctly.

## Evidence

**Before**: `"sorries": 2` (top-level field)
**After**: `"sorries": 0` (matches actual code and sub-fields)

**Verification**:
- `grep -n "sorry" proofs/Proofs/Erdos512Problem.lean` → only 2 `axiom` lines (no `sorry` keyword)
- `meta.sorries` = 0, `leanFile.sorries` = 0 (both already correct)

---
Automated fix by lean-mechanic agent.