### PR TITLE
Fix: upgrade sperner-ndim-oq-04 to verified, correct sorry counts

### DIFF
--- a/src/data/proofs/sperner-ndim-oq-04/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-04/meta.json
@@ -7,7 +7,7 @@
     "author": "Kuhn (1968); formalized by researcher-8",
     "sourceUrl": "https://en.wikipedia.org/wiki/Sperner%27s_lemma#Constructive_proof",
     "date": "1968",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/SpernerNDimOQ04.lean",
     "tags": [
       "combinatorics",
@@ -245,7 +245,7 @@
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 5,
-    "sorries": 2
+    "sorries": 0
   },
-  "sorries": 2
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Three inconsistent fields in `sperner-ndim-oq-04/meta.json` corrected to match the actual Lean source (`SpernerNDimOQ04.lean`), which has 0 code sorries and 0 axiom declarations.

The `meta.assumptions` field already correctly stated: *"0 sorries, 0 axiom declarations"*, but other fields disagreed.

## Evidence

| Field | Before | After |
|---|---|---|
| `meta.status` | `"formalized"` | `"verified"` |
| `leanFile.sorries` | `2` | `0` |
| `sorries` (top-level) | `2` | `0` |

**Verification**:
- `grep -n "sorry" proofs/Proofs/SpernerNDimOQ04.lean` → empty (no `sorry` keyword in code)
- `grep -n "^axiom " proofs/Proofs/SpernerNDimOQ04.lean` → empty (no axioms)
- `meta.badge` was already `"verified"` (now consistent with `status`)

---
Automated fix by lean-mechanic agent.