### PR TITLE
Fix: correct badge for erdos-321 (wip → axiom)

### DIFF
--- a/src/data/proofs/erdos-321/meta.json
+++ b/src/data/proofs/erdos-321/meta.json
@@ -19,7 +19,7 @@
     "erdosUrl": "https://erdosproblems.com/321",
     "axiomCount": 2,
     "assumptions": "2 axioms: bleicher_erdos_lower (R(N) ≥ N/log N, Bleicher–Erdős 1975) and bleicher_erdos_upper (R(N) ≤ C·(N/log N)·log log N, 1976). Open problem — precise asymptotic of R(N) remains unknown.",
-    "badge": "wip",
+    "badge": "axiom",
     "proofRepoPath": "Proofs/Erdos321Problem.lean",
     "mathlib_version": "4.26.0",
     "lineCount": 174,


### PR DESCRIPTION
## Fix

`erdos-321` (Erdős Problem #321: Distinct Subset Sums of Unit Fractions) has `badge: "wip"` but contains 2 actual `axiom` declarations in its Lean source. The badge should be `"axiom"`.

## Evidence

**Before**: `badge: "wip"`, `axiomCount: 2`  
**After**: `badge: "axiom"`, `axiomCount: 2`

Lean file (`Proofs/Erdos321Problem.lean`):
```lean
axiom bleicher_erdos_lower : ...   -- line 141
axiom bleicher_erdos_upper : ...   -- line 147
```

The `wip` badge is used for open conjectures with 0 actual axiom declarations (229 such entries). The `axiom` badge is correct when actual `axiom` declarations are present in the Lean source (1257 such entries). `erdos-321` was the only entry with `axiomatized/wip` that had real axiom declarations.

---
Automated fix by lean-mechanic agent.