### PR TITLE
Fix: downgrade sperner-ndim-oq-04 from verified to formalized (3 sorries)

### DIFF
--- a/src/data/proofs/sperner-ndim-oq-04/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-04/meta.json
@@ -7,7 +7,7 @@
     "author": "Kuhn (1968); formalized by researcher-8",
     "sourceUrl": "https://en.wikipedia.org/wiki/Sperner%27s_lemma#Constructive_proof",
     "date": "1968",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/SpernerNDimOQ04.lean",
     "tags": [
       "combinatorics",
@@ -20,8 +20,8 @@
       "door-graph",
       "advanced"
     ],
-    "badge": "verified",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 3,
     "originalContributions": [
       "Definition of door degree and IsKuhnCompatible for abstract Sperner triangulations",
       "Proof that FC simplices have exactly 1 door under Kuhn compatibility",
@@ -37,7 +37,7 @@
     "dateAdded": "2026-04-22",
     "axiomCount": 0,
     "lineCount": 480,
-    "assumptions": "0 sorries, 0 axiom declarations. Proved: fc_door_count_eq_one, nonfc_door_count_zero_or_two, nonfc_with_door_has_unique_exit, kuhn_path_terminates (FC existence via sperner_ndim), kuhn_walk_result_not_in_visited (walk never revisits). Open: proving kuhnPathStart returns FC (not merely non-visited) requires door-graph cycle-freeness — an 'adj_unique_facet' axiom in SpernerTriangulation plus per-simplex door history in KuhnState.",
+    "assumptions": "3 sorries remaining (kuhnWalk non-revisiting, walk pairing existential, kuhnPathStart universal). 0 axiom declarations.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -245,7 +245,7 @@
     "axiomCount": 0,
     "theoremCount": 9,
     "definitionCount": 5,
-    "sorries": 0
+    "sorries": 3
   },
-  "sorries": 0
+  "sorries": 3
 }


### PR DESCRIPTION
## Summary

- Corrects stale metadata in `src/data/proofs/sperner-ndim-oq-04/meta.json`
- Status was set to `verified` (badge: `verified`, sorries: 0) in commit a202e1029e when the file had 0 sorries
- Commit af2baa982a subsequently added 3 new lemmas with sorry tactics at lines 416, 479, and 505, but meta.json was not updated

## Changes

- `meta.status`: `"verified"` → `"formalized"`
- `meta.badge`: `"verified"` → `"wip"`
- `meta.sorries`: `0` → `3`
- `meta.assumptions`: updated to reflect 3 remaining sorries (kuhnWalk non-revisiting, walk pairing existential, kuhnPathStart universal)
- `leanFile.sorries`: `0` → `3`
- top-level `sorries`: `0` → `3`

## Test plan

- [ ] Verify `src/data/proofs/sperner-ndim-oq-04/meta.json` now has `status: "formalized"`, `badge: "wip"`, all three sorry counts set to 3
- [ ] Confirm gallery build (`pnpm build`) passes with updated metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)