### PR TITLE
Fix: revert sperner-ndim-oq-04 to formalized (3 sorries added post-verification)

### DIFF
--- a/src/data/proofs/sperner-ndim-oq-04/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-04/meta.json
@@ -7,7 +7,7 @@
     "author": "Kuhn (1968); formalized by researcher-8",
     "sourceUrl": "https://en.wikipedia.org/wiki/Sperner%27s_lemma#Constructive_proof",
     "date": "1968",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/SpernerNDimOQ04.lean",
     "tags": [
       "combinatorics",
@@ -20,8 +20,8 @@
       "door-graph",
       "advanced"
     ],
-    "badge": "verified",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 3,
     "originalContributions": [
       "Definition of door degree and IsKuhnCompatible for abstract Sperner triangulations",
       "Proof that FC simplices have exactly 1 door under Kuhn compatibility",
@@ -36,8 +36,8 @@
     ],
     "dateAdded": "2026-04-22",
     "axiomCount": 0,
-    "lineCount": 480,
-    "assumptions": "0 sorries, 0 axiom declarations. Proved: fc_door_count_eq_one, nonfc_door_count_zero_or_two, nonfc_with_door_has_unique_exit, kuhn_path_terminates (FC existence via sperner_ndim), kuhn_walk_result_not_in_visited (walk never revisits). Open: proving kuhnPathStart returns FC (not merely non-visited) requires door-graph cycle-freeness — an 'adj_unique_facet' axiom in SpernerTriangulation plus per-simplex door history in KuhnState.",
+    "lineCount": 507,
+    "assumptions": "3 sorries, 0 axiom declarations. Proved: fc_door_count_eq_one, nonfc_door_count_zero_or_two, nonfc_with_door_has_unique_exit, kuhn_path_terminates (FC existence via sperner_ndim), kuhn_walk_result_not_in_visited (walk never revisits), kuhnWalk_no_immediate_back, kuhnWalk_first_exit_interior. Open sorries: kuhn_walk_reaches_fc (needs general non-revisiting with per-simplex door history + boundary-exit parity argument), kuhnPathStart_finds_fc_existential (needs walk-pairing argument), kuhnPathStart_is_fc (universal form may be false for some starting boundary doors; existential form is the correct statement).",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -241,11 +241,11 @@
       "BigOperators"
     ],
     "namespace": "SpernerNDimOQ04",
-    "lineCount": 480,
+    "lineCount": 507,
     "axiomCount": 0,
-    "theoremCount": 9,
+    "theoremCount": 14,
     "definitionCount": 5,
-    "sorries": 0
+    "sorries": 3
   },
-  "sorries": 0
+  "sorries": 3
 }


### PR DESCRIPTION
## Fix

Corrects stale metadata in `sperner-ndim-oq-04` after PR #12245 added 3 new theorems with sorries.

## Evidence

**Before** (after PRs #12249/#12253): `status: verified`, `badge: verified`, `sorries: 0`
**After** (current Lean file): 3 actual sorries, 14 theorems, 507 lines

## Root Cause

PRs #12249 and #12253 correctly set the metadata to `verified` when `SpernerNDimOQ04.lean` had 0 sorries. PR #12245 then added 3 new incomplete theorems to the file:

1. `kuhn_walk_reaches_fc` — needs general non-revisiting proof + boundary-exit ruling-out
2. `kuhnPathStart_finds_fc_existential` — needs walk-pairing argument
3. `kuhnPathStart_is_fc` — file comment: "this theorem as stated may be FALSE for some starting boundary doors"

The metadata was not updated when #12245 merged.

## Changes

- `meta.status`: verified → formalized
- `meta.badge`: verified → wip
- `meta.sorries`: 0 → 3
- `meta.lineCount`: 480 → 507
- `meta.assumptions`: updated to list open sorries and proved ingredients
- `leanFile.sorries`: 0 → 3
- `leanFile.lineCount`: 480 → 507
- `leanFile.theoremCount`: 9 → 14
- `sorries` (root): 0 → 3

Discovered by auditor: sorry mismatch: claims 0, actual 3; status "verified" but has 3 sorries.

---
Automated fix by lean-mechanic agent.