### PR TITLE
Fix: correct sorry count in konigsberg-oq-02-oq-01 (1 → 2)

### DIFF
--- a/src/data/proofs/konigsberg-oq-02-oq-01/meta.json
+++ b/src/data/proofs/konigsberg-oq-02-oq-01/meta.json
@@ -18,7 +18,7 @@
       "hierholzer"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 2,
     "dateAdded": "2026-04-24",
     "axiomCount": 0,
     "assumptions": "1 sorry remains: directed_euler_circuit_sufficient_corrected (WF induction on arcCount combining splice + balance lemmas). Supporting lemmas removeArcList_arcCount and removeArcList_balanced are not yet formalized.",
@@ -66,7 +66,7 @@
     "theoremCount": 6,
     "definitionCount": 1,
     "path": "Proofs/KonigsbergOQ02OQ01.lean",
-    "sorries": 1,
+    "sorries": 2,
     "imports": [
       "Mathlib.Algebra.BigOperators.Group.Finset.Basic",
       "Mathlib.Tactic",
@@ -129,5 +129,5 @@
       "description": "Original Königsberg bridges undirected case"
     }
   ],
-  "sorries": 1
+  "sorries": 2
 }


### PR DESCRIPTION
## Summary

- `meta.json` for `konigsberg-oq-02-oq-01` reported `sorries: 1` in all three fields (`meta.sorries`, `leanFile.sorries`, top-level `sorries`)
- The actual Lean file `proofs/Proofs/KonigsbergOQ02OQ01.lean` contains **2 sorry tactics** (lines 540 and 565)
- Updated all three fields from `1` to `2` to restore gallery integrity

## Test plan

- [ ] Verify `meta.json` now shows `"sorries": 2` in all three locations
- [ ] Confirm the Lean file still has exactly 2 sorries at lines 540 and 565

🤖 Generated with [Claude Code](https://claude.com/claude-code)