### PR TITLE
Fix: sync stale lineCount in lebesgue-measure-oq-06

### DIFF
--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -20,7 +20,7 @@
     "badge": "wip",
     "sorries": 4,
     "axiomCount": 0,
-    "lineCount": 469,
+    "lineCount": 559,
     "assumptions": "4 sorries: hausdorff_free_subgroup (Hausdorff 1914 — SO(3) contains F₂), banach_tarski (Banach-Tarski 1924 — main paradox, requires AC), banach_tarski_pieces_nonmeasurable (classical non-measurability corollary), int_amenable (Markov-Kakutani — ℤ amenable via Cesàro means/ultrafilter). Core framework fully proved including paradoxical_no_finite_measure (proved via finite additivity monotonicity) and free_group_not_amenable.",
     "dateAdded": "2026-04-22",
     "mathlib_version": "4.26.0",
@@ -202,7 +202,7 @@
       "Mathlib"
     ],
     "namespace": "BanachTarski",
-    "lineCount": 469,
+    "lineCount": 559,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 5,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` in `lebesgue-measure-oq-06` meta.json.

## Evidence

Commit `1ece0f1e` added ~90 lines of proof code to `LebesgueMeasureOQ06.lean` (the `int_amenable` partial proof via Cesàro ultrafilter construction) but did not update the gallery metadata.

**Before**: `lineCount: 469`  
**After**: `lineCount: 559`

Both `meta.lineCount` and `leanFile.lineCount` updated. Sorry count (4) and all other fields remain correct.

---
Automated fix by lean-mechanic agent.