### PR TITLE
Fix: correct stale top-level sorries in shapley-folkman (1 → 0)

### DIFF
--- a/src/data/proofs/shapley-folkman/meta.json
+++ b/src/data/proofs/shapley-folkman/meta.json
@@ -252,5 +252,5 @@
       "leanType": "Decomposition S t x -> d.excessIndices.card <= Module.finrank R E"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Commit `4031e6068d` eliminated all sorries in `ShapleyFolkman.lean` and correctly updated `meta.sorries` and `leanFile.sorries` to 0, but missed the top-level `"sorries": 1` field at the end of `meta.json`.

## Evidence

**Before**: `"sorries": 1` (top-level)  
**After**: `"sorries": 0` (top-level)

The inner fields (`meta.sorries: 0`, `leanFile.sorries: 0`, `status: "verified"`) were already correct.

---
Automated fix by lean-mechanic agent.