### PR TITLE
Research: hook walk identity proved for ≤2-row shapes (non-circular)

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean
@@ -4630,20 +4630,96 @@ theorem card_SYT_corner_step (μ : YoungDiagram) (hn : 0 < μ.card) :
     = (n-1)! * n = n!                             [hook_walk_identity]
 -/
 
+/-- hookProd is nonzero in ℚ. -/
+private lemma hookProdQ_ne_zero (μ : YoungDiagram) : (hookProd μ : ℚ) ≠ 0 :=
+  Nat.cast_ne_zero.mpr (hookProd_pos μ).ne'
+
+/-- Removing a corner from a ≤2-row diagram preserves the ≤2-row property.
+    Any corner c is in row 0 or row 1; removing it leaves rows 2+ unchanged (still empty). -/
+private lemma removeCorner_atMostTwoRows {μ : YoungDiagram} {c : ℕ × ℕ}
+    (h2 : μ.rowLen 2 = 0) (hc : isCorner μ c) :
+    (removeCorner μ c hc).rowLen 2 = 0 := by
+  -- If rowLen 2 > 0 then (2, 0) ∈ removeCorner, so (2, 0) ∈ μ, contradicting h2
+  rcases Nat.eq_zero_or_pos ((removeCorner μ c hc).rowLen 2) with h | hpos
+  · exact h
+  · exfalso
+    have hmem : (2, 0) ∈ removeCorner μ c hc := YoungDiagram.mem_iff_lt_rowLen.mpr hpos
+    obtain ⟨hmem2, _⟩ := (mem_removeCorner hc).mp hmem
+    have hlt := YoungDiagram.mem_iff_lt_rowLen.mp hmem2
+    omega
+
+/-- The hook walk identity for at-most-2-row Young diagrams.
+    **Non-circular proof**: hook_length_formula_atMostTwoRows was proved without this identity,
+    and removing a corner of a ≤2-row shape gives another ≤2-row shape.
+    Key algebraic identity:
+      HP / HPc = card(SYT(μ\c)) · HP / (N-1)!   [from HLF for μ\c]
+      Σ_c HP/HPc = HP/(N-1)! · Σ_c card(SYT(μ\c))
+               = HP/(N-1)! · card(SYT(μ))         [corner step]
+               = N!/(N-1)! = N                     [HLF for μ] -/
+private lemma hook_walk_identity_atMostTwoRows (μ : YoungDiagram) (h2 : μ.rowLen 2 = 0)
+    (hpos : 0 < μ.card) :
+    ∑ c ∈ (corners μ).attach,
+      ((hookProd μ : ℚ) / (hookProd (removeCorner μ c.val (mem_corners.mp c.prop)) : ℚ))
+    = (μ.card : ℚ) := by
+  have hHP : (hookProd μ : ℚ) ≠ 0 := hookProdQ_ne_zero μ
+  have hfact : ((μ.card - 1).factorial : ℚ) ≠ 0 :=
+    Nat.cast_ne_zero.mpr (Nat.factorial_pos _).ne'
+  -- HLF for μ over ℚ (proved independently, without hook_walk_identity)
+  have hμ : (Fintype.card (StandardYoungTableau μ) : ℚ) * hookProd μ = μ.card.factorial :=
+    by exact_mod_cast hook_length_formula_atMostTwoRows μ h2
+  -- HLF for each removeCorner (stays ≤2-row by removeCorner_atMostTwoRows)
+  have hμc : ∀ cx : { x // x ∈ corners μ },
+      (Fintype.card (StandardYoungTableau
+        (removeCorner μ cx.val (mem_corners.mp cx.prop))) : ℚ) *
+      (hookProd (removeCorner μ cx.val (mem_corners.mp cx.prop)) : ℚ) =
+      ((μ.card - 1).factorial : ℚ) := by
+    intro ⟨c, hcx⟩
+    have h2c := removeCorner_atMostTwoRows h2 (mem_corners.mp hcx)
+    have hlf := hook_length_formula_atMostTwoRows _ h2c
+    rw [removeCorner_card (mem_corners.mp hcx)] at hlf
+    exact_mod_cast hlf
+  -- Corner step over ℚ
+  have hstepQ : (Fintype.card (StandardYoungTableau μ) : ℚ) =
+      ∑ cx ∈ (corners μ).attach,
+        (Fintype.card (StandardYoungTableau
+          (removeCorner μ cx.val (mem_corners.mp cx.prop))) : ℚ) :=
+    by exact_mod_cast card_SYT_corner_step μ hpos
+  -- μ.card! = μ.card × (μ.card − 1)! as rationals
+  have hfact_succ : (μ.card.factorial : ℚ) = (μ.card : ℚ) * ((μ.card - 1).factorial : ℚ) := by
+    cases hcard : μ.card with
+    | zero => omega
+    | succ n =>
+      rw [show μ.card - 1 = n by omega, show μ.card = n + 1 from hcard, Nat.factorial_succ]
+      push_cast; ring
+  -- Each summand: HP/HPc = card(SYT(μ\c)) × (HP/(N-1)!)
+  have hterm : ∀ cx : { x // x ∈ corners μ },
+      (hookProd μ : ℚ) / (hookProd (removeCorner μ cx.val (mem_corners.mp cx.prop)) : ℚ) =
+      (Fintype.card (StandardYoungTableau
+        (removeCorner μ cx.val (mem_corners.mp cx.prop))) : ℚ) *
+      ((hookProd μ : ℚ) / ((μ.card - 1).factorial : ℚ)) := by
+    intro ⟨c, hcx⟩
+    have hHPc : (hookProd (removeCorner μ c (mem_corners.mp hcx)) : ℚ) ≠ 0 :=
+      hookProdQ_ne_zero _
+    have hIHc := hμc ⟨c, hcx⟩
+    rw [mul_div_assoc, div_eq_div_iff hHPc hfact]
+    linear_combination -(hookProd μ : ℚ) * hIHc
+  -- Assemble: rewrite summands, factor, apply corner step, use HLF and factorial identity
+  simp_rw [hterm]
+  rw [← Finset.sum_mul, ← hstepQ, mul_div_assoc, hμ, hfact_succ]
+  field_simp [hfact]
+
 /-- The hook walk identity: sum over corners c of hookProd(μ)/hookProd(μ\c) equals μ.card.
-    For each corner c = (i,j): removing c decreases each hook length in row i (left of c)
-    and col j (above c) by exactly 1. The sum of resulting ratios telescopes to μ.card.
-    Verified for: empty, 1-row, 1-col, 2-row, generalized hook shapes.
-    [OPEN: general proof requires hook walk combinatorics (~300 lines)] -/
+    Proved for at-most-2-row shapes via hook_walk_identity_atMostTwoRows (non-circular).
+    General (≥3-row) case: requires GNW probabilistic proof (~300 lines) or RSK (~500 lines). -/
 private lemma hook_walk_identity (μ : YoungDiagram) (hn : 0 < μ.card) :
     ∑ c ∈ (corners μ).attach,
       ((hookProd μ : ℚ) / (hookProd (removeCorner μ c.val (mem_corners.mp c.prop)) : ℚ))
     = (μ.card : ℚ) := by
-  sorry
-
-/-- hookProd is nonzero in ℚ. -/
-private lemma hookProdQ_ne_zero (μ : YoungDiagram) : (hookProd μ : ℚ) ≠ 0 :=
-  Nat.cast_ne_zero.mpr (hookProd_pos μ).ne'
+  by_cases h2 : μ.rowLen 2 = 0
+  · -- At-most-2-row case: proved non-circularly
+    exact hook_walk_identity_atMostTwoRows μ h2 hn
+  · -- ≥3-row case: requires hook walk combinatorics (GNW ~300 lines or RSK ~500 lines)
+    sorry
 
 /-- The general hook-length formula in ℚ, proved by well-founded recursion on μ.card.
     Uses card_SYT_corner_step (Part XIII) + hook_walk_identity. -/

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
@@ -6,26 +6,26 @@
   "tier": "A",
   "path": "full",
   "problemStatement": {
-    "formal": "theorem hook_length_formula (\u03bb : YoungDiagram) : Fintype.card (StandardYoungTableau \u03bb) = \u03bb.card.factorial / \u220f u : \u03bb, hookLength \u03bb u",
-    "plain": "Using the fully-proved n\u00d7n LGV lemma (BallotProblemOQ03OQ02.lean), formalize the hook-length formula f^\u03bb = n! / \u220f h(u) for standard Young tableaux of arbitrary shape. The two-row case is already proved numerically; the goal is a structural proof for general \u03bb.",
+    "formal": "theorem hook_length_formula (λ : YoungDiagram) : Fintype.card (StandardYoungTableau λ) = λ.card.factorial / ∏ u : λ, hookLength λ u",
+    "plain": "Using the fully-proved n×n LGV lemma (BallotProblemOQ03OQ02.lean), formalize the hook-length formula f^λ = n! / ∏ h(u) for standard Young tableaux of arbitrary shape. The two-row case is already proved numerically; the goal is a structural proof for general λ.",
     "whyMatters": [
-      "f^\u03bb counts the dimension of the Specht module S^\u03bb of S_n \u2014 connecting combinatorics to representation theory",
-      "The n\u00d7n LGV lemma (2315 lines, 0 sorries) provides the infrastructure; this closes the loop",
-      "No complete Lean 4 proof of the hook-length formula exists \u2014 genuine Mathlib contribution potential"
+      "f^λ counts the dimension of the Specht module S^λ of S_n — connecting combinatorics to representation theory",
+      "The n×n LGV lemma (2315 lines, 0 sorries) provides the infrastructure; this closes the loop",
+      "No complete Lean 4 proof of the hook-length formula exists — genuine Mathlib contribution potential"
     ]
   },
   "knownResults": {
     "proven": [
-      "2\u00d72 LGV lemma: lgv_lemma_2x2 in BallotProblemOQ03.lean (2879 lines, 0 sorries)",
-      "General n\u00d7n LGV lemma: lgv_lemma_rxr in BallotProblemOQ03OQ02.lean (2315 lines, 0 sorries)",
+      "2×2 LGV lemma: lgv_lemma_2x2 in BallotProblemOQ03.lean (2879 lines, 0 sorries)",
+      "General n×n LGV lemma: lgv_lemma_rxr in BallotProblemOQ03OQ02.lean (2315 lines, 0 sorries)",
       "2-row hook-length: hook_length_formula_two_row in BallotProblemOQ03OQ03.lean (C_m * (m+1)! * m! = (2m)!)",
       "Catalan/lattice path machinery: extensive in BallotProblemOQ03OQ02.lean"
     ],
     "open": [
       "hookLength function for YoungDiagram: h(i,j) = arm(i,j) + leg(i,j) + 1",
-      "LGV source/target encoding for arbitrary \u03bb",
-      "Determinant factorization: det[C(\u03bb\u2c7c - i + j + r - 1, \u03bb\u2c7c - i + j)] = \u220f h(u)",
-      "Connection StandardYoungTableau count \u2194 LGV non-intersecting path count",
+      "LGV source/target encoding for arbitrary λ",
+      "Determinant factorization: det[C(λⱼ - i + j + r - 1, λⱼ - i + j)] = ∏ h(u)",
+      "Connection StandardYoungTableau count ↔ LGV non-intersecting path count",
       "General hook_length_formula for arbitrary YoungDiagram"
     ],
     "goal": "Prove hook_length_formula using lgv_lemma_rxr from BallotProblemOQ03OQ02.lean, starting with rectangular shapes then generalizing"
@@ -47,54 +47,57 @@
     }
   },
   "knowledge": {
-    "progressSummary": "IN-PROGRESS: hook_walk_identity (line 4638) is sole remaining sorry for general HLF. Submitted to Aristotle (project 8a9026a1). All other infrastructure complete.",
+    "progressSummary": "IN-PROGRESS: hook_walk_identity proved for ≤2-row shapes (non-circular, compiles). Sorry restricted to ≥3-row shapes. General case needs GNW (~300L) or RSK (~500L).",
     "builtItems": [
       "instFintypeSYT: Fintype instance for StandardYoungTableau (BallotProblemOQ03OQ01OQ02.lean, Part IIIb)",
       "emptyTableau: unique SYT of shape bot (BallotProblemOQ03OQ01OQ02.lean, Part IIIc)",
       "hook_length_formula_bot: proved theorem for empty diagram (BallotProblemOQ03OQ01OQ02.lean:hook_length_formula_bot)",
       "hook_length_formula_from_chain: proved conditional theorem from two sorry lemmas (BallotProblemOQ03OQ01OQ02.lean:hook_length_formula_from_chain)",
       "oneRowYD, mem_oneRowYD, oneRowYD_card, rowLen_oneRowYD_zero, colLen_oneRowYD (PART VI infrastructure)",
-      "hookLength_oneRowYD, hookProd_oneRowYD \u2014 hook computations for single-row shape",
-      "oneRowSYT, entry_oneRow_eq, oneRowSYT_unique \u2014 SYT uniqueness machinery",
-      "hook_length_formula_one_row \u2014 verified instance of hook formula, 0 sorries",
+      "hookLength_oneRowYD, hookProd_oneRowYD — hook computations for single-row shape",
+      "oneRowSYT, entry_oneRow_eq, oneRowSYT_unique — SYT uniqueness machinery",
+      "hook_length_formula_one_row — verified instance of hook formula, 0 sorries",
       "hookProd_hookShapeYD: proved hookProd(m+1,1)=(m+2)*m! in BallotProblemOQ03OQ01OQ02.lean:775",
       "card_SYT_hookShapeYD: proved |SYT(m+1,1)|=m+1 via Equiv.ofBijective hookSYT in BallotProblemOQ03OQ01OQ02.lean:1062",
       "hook_length_formula_hook_shape: proved hook formula for hook shapes in BallotProblemOQ03OQ01OQ02.lean:1075",
       "Bool simp lemma fix: removed Bool.false_eq_false etc. from 5 locations in BallotProblemOQ03OQ02.lean (session 5, 2026-04-22)",
-      "sytBallotEquiv m : SYT(twoRectYD m) \u2243 {ballot m-subsets of Fin(2m)} (BallotProblemOQ03OQ01OQ02.lean:1503)",
+      "sytBallotEquiv m : SYT(twoRectYD m) ≃ {ballot m-subsets of Fin(2m)} (BallotProblemOQ03OQ01OQ02.lean:1503)",
       "lRefl m S k, firstAbove, badBarrier: Lindstrom reflection infrastructure (lines 1572-2616)",
       "ballot_finset_card: |ballot m-subsets| = Cn m proved (line 2620)",
       "card_SYT_twoRectYD: Fintype.card SYT(twoRectYD m) = Cn m proved 0 sorries (line 2708)",
       "hook_length_formula_two_rect: card * hookProd = (2m)! proved 0 sorries (line 2716)",
-      "sytBallotEquiv m : SYT(twoRectYD m) \u2243 ballot m-subsets of Fin(2m) (BallotProblemOQ03OQ01OQ02.lean:1503)",
+      "sytBallotEquiv m : SYT(twoRectYD m) ≃ ballot m-subsets of Fin(2m) (BallotProblemOQ03OQ01OQ02.lean:1503)",
       "lRefl/firstAbove/badBarrier: Lindstrom reflection infrastructure (lines 1572-2616)",
       "ballot_finset_card: |ballot m-subsets| = Cn m proved (line 2620)",
       "card_SYT_twoRectYD: card SYT(twoRectYD m) = Cn m proved 0 sorries (line 2708)",
       "hook_length_formula_two_rect: card * hookProd = (2m)! proved 0 sorries (line 2716)",
-      "hook_length_formula_atMostTwoRows in BallotProblemOQ03OQ01OQ02.lean:3578 (proved, 0 sorries): HLF for all \u22642-row shapes",
+      "hook_length_formula_atMostTwoRows in BallotProblemOQ03OQ01OQ02.lean:3578 (proved, 0 sorries): HLF for all ≤2-row shapes",
       "card_SYT_twoRowYD in BallotProblemOQ03OQ01OQ02.lean:3450 (proved, 0 sorries): WF induction on a+b",
       "hook_length_formula_two_row_gen in BallotProblemOQ03OQ01OQ02.lean:3527 (proved): HLF for general 2-row [a,b]",
       "card_SYT_corner_step in BallotProblemOQ03OQ01OQ02.lean:3802 (proved, 0 sorries): SYT corner recursion",
       "BallotProblemOQ03OQ01OQ02Aristotle.lean created with ni_count_eq_syt_count_Aristotle + lgv_det_factors_as_hook_quotient_Aristotle",
-      "hook_length_formula_atMostTwoRows in BallotProblemOQ03OQ01OQ02.lean:3578 (proved, 0 sorries): HLF for all \u22642-row shapes",
+      "hook_length_formula_atMostTwoRows in BallotProblemOQ03OQ01OQ02.lean:3578 (proved, 0 sorries): HLF for all ≤2-row shapes",
       "card_SYT_twoRowYD in BallotProblemOQ03OQ01OQ02.lean:3450 (proved, 0 sorries): WF induction on a+b",
       "hook_length_formula_two_row_gen in BallotProblemOQ03OQ01OQ02.lean:3527 (proved): HLF for general 2-row [a,b]",
       "card_SYT_corner_step in BallotProblemOQ03OQ01OQ02.lean:3802 (proved, 0 sorries): SYT corner recursion",
       "BallotProblemOQ03OQ01OQ02Aristotle.lean created with ni_count_eq_syt_count_Aristotle + lgv_det_factors_as_hook_quotient_Aristotle",
-      "hook_walk_identity_Aristotle in BallotProblemOQ03OQ01OQ02Aristotle.lean (submitted to Aristotle project 8a9026a1)"
+      "hook_walk_identity_Aristotle in BallotProblemOQ03OQ01OQ02Aristotle.lean (submitted to Aristotle project 8a9026a1)",
+      "removeCorner_atMostTwoRows (BallotProblemOQ03OQ01OQ02.lean:4639): removing corner from ≤2-row shape stays ≤2-row",
+      "hook_walk_identity_atMostTwoRows (BallotProblemOQ03OQ01OQ02.lean:4659): hook walk identity proved for all ≤2-row shapes, non-circular",
+      "hook_walk_identity (BallotProblemOQ03OQ01OQ02.lean:4714): case split — ≤2-row proved, ≥3-row sorry"
     ],
     "insights": [
       "lgv_lemma_rxr in BallotProblemOQ03OQ02.lean is the key building block (Gessel-Viennot involution proof)",
-      "hook_length_formula_two_row (BallotProblemOQ03OQ03.lean) proved C_m * (m+1)! * m! = (2m)! \u2014 numerical verification only",
-      "Approach: encode \u03bb = (\u03bb\u2081 \u2265 ... \u2265 \u03bb_r) via sources (0, r-i) and targets (\u03bb\u1d62 + r - i, 0)",
-      "instFintypeSYT: Fintype instance for SYT via injection into (\u03bc.cells \u2192 Fin (\u03bc.card+1)) \u2014 critical for Fintype.card to typecheck",
+      "hook_length_formula_two_row (BallotProblemOQ03OQ03.lean) proved C_m * (m+1)! * m! = (2m)! — numerical verification only",
+      "Approach: encode λ = (λ₁ ≥ ... ≥ λ_r) via sources (0, r-i) and targets (λᵢ + r - i, 0)",
+      "instFintypeSYT: Fintype instance for SYT via injection into (μ.cells → Fin (μ.card+1)) — critical for Fintype.card to typecheck",
       "hook_length_formula_bot: proved for empty diagram (base case, 1*1=0!=1)",
-      "hook_length_formula_from_chain: proves main theorem FROM ni_count_eq_syt_count AND lgv_det_factors_as_hook_quotient \u2014 logical chain complete",
+      "hook_length_formula_from_chain: proves main theorem FROM ni_count_eq_syt_count AND lgv_det_factors_as_hook_quotient — logical chain complete",
       "lgv_det_factors_as_hook_quotient reformulated as det*hookProd=n! (avoids integer division, cleaner than det=n!/hookProd)",
       "Two sorry lemmas remain: RSK bijection (ni_count_eq_syt_count, ~200 lines) and Vandermonde-type det identity (lgv_det_factors_as_hook_quotient, ~200 lines)",
       "Single-row hook formula proved directly without LGV: unique SYT entry(0,j)=j+1, hookProd=n!",
-      "oneRowYD n = YoungDiagram.ofRowLens [n] \u2014 ofRowLens is the right Mathlib constructor",
-      "hookLength_add_eq: hookLength \u03bc i j + 1 = rowLen i - j + colLen j \u2014 key computation lemma",
+      "oneRowYD n = YoungDiagram.ofRowLens [n] — ofRowLens is the right Mathlib constructor",
+      "hookLength_add_eq: hookLength μ i j + 1 = rowLen i - j + colLen j — key computation lemma",
       "Nat.descFactorial_self n proves hookProd = n! via descFactorial_eq_prod_range",
       "SYT uniqueness: lower bound by IH on row_strict, upper bound by chain to last cell",
       "if_neg (mt mem_oneRowYD.mpr hc) is the clean pattern for entry_zero proofs",
@@ -102,32 +105,36 @@
       "hookProd insert decomposition: use Finset.prod_insert to isolate j=0 arm, then handle row arm via descFactorial_eq_prod_range",
       "Hook-shape family fully formalized without LGV infrastructure - elementary bijection suffices",
       "Pre-existing build failures in BallotProblemOQ03OQ02.lean (Bool.false_eq_false removed from Lean4) are blocking full build verification but do not affect Part VIII work",
-      "Bool.false_eq_false, Bool.true_eq_false, Bool.false_eq_true, Bool.true_eq_true removed from modern Lean4/Mathlib \u2014 simp handles Bool equalities by kernel/definitional reduction",
-      "card_SYT_twoRectYD strategy: SYT(2\u00d7m) \u2194 ballot sequences \u2194 Dyck paths \u2194 Cn m via subset bijection (k \u2208 S iff k goes to row 1, ballot condition enforces ordering)",
-      "Lindstrom reflection principle: bad m-subsets \u2194 (m+1)-subsets gives ballot count = C(2m,m) - C(2m,m+1) = Cn m",
-      "Direct Finset bijection SYT(m,m) \u2194 ballot m-subsets cleaner than ballot-path approach: row-0 entries form ballot Finset naturally",
+      "Bool.false_eq_false, Bool.true_eq_false, Bool.false_eq_true, Bool.true_eq_true removed from modern Lean4/Mathlib — simp handles Bool equalities by kernel/definitional reduction",
+      "card_SYT_twoRectYD strategy: SYT(2×m) ↔ ballot sequences ↔ Dyck paths ↔ Cn m via subset bijection (k ∈ S iff k goes to row 1, ballot condition enforces ordering)",
+      "Lindstrom reflection principle: bad m-subsets ↔ (m+1)-subsets gives ballot count = C(2m,m) - C(2m,m+1) = Cn m",
+      "Direct Finset bijection SYT(m,m) ↔ ballot m-subsets cleaner than ballot-path approach: row-0 entries form ballot Finset naturally",
       "BallotProblemOQ03OQ02 nil case fix: List.countP_nil + subst needed for take_at_column_entry and take_east_count_within_column",
-      "Lindstrom reflection principle: bad m-subsets \u2194 (m+1)-subsets gives ballot count = C(2m,m) - C(2m,m+1) = Cn m",
-      "Direct Finset bijection SYT(m,m) \u2194 ballot m-subsets cleaner than ballot-path approach: row-0 entries form ballot Finset naturally",
+      "Lindstrom reflection principle: bad m-subsets ↔ (m+1)-subsets gives ballot count = C(2m,m) - C(2m,m+1) = Cn m",
+      "Direct Finset bijection SYT(m,m) ↔ ballot m-subsets cleaner than ballot-path approach: row-0 entries form ballot Finset naturally",
       "card_SYT_twoRowYD proved by WF induction on a+b: base b=0 (oneRowYD), step uses corner recursion + Pascal + catalan_eq_ballot",
       "hook_length_formula_two_row_gen proved: uses card_SYT_twoRowYD + two_row_hook_identity + hookProd_twoRowYD",
       "hook_length_formula_atMostTwoRows: any mu with rowLen(2)=0 is twoRowYD (rowLen 0) (rowLen 1); hook formula applies directly",
       "card_SYT_corner_step proved: card(SYT(mu)) = sum_c card(SYT(mu\\c)) for non-empty mu (via extendSYT/restrictSYT bijection)",
-      "General hook_length_formula via corner induction requires hook walk identity: sum_c hookProd(mu)/hookProd(mu\\c) = n \u2014 lives in Q not N",
+      "General hook_length_formula via corner induction requires hook walk identity: sum_c hookProd(mu)/hookProd(mu\\c) = n — lives in Q not N",
       "hook_walk_identity (line 4638) is the sole remaining sorry for general HLF via well-founded induction",
       "For each corner c=(r,s): hookProd(mu)/hookProd(mu\\c) = prod over same-row/col cells of h/(h-1), since corner has h=1",
-      "Identity is NOT provable by reducing to HLF (circular) \u2014 needs independent hook-walk/RSK argument"
+      "Identity is NOT provable by reducing to HLF (circular) — needs independent hook-walk/RSK argument",
+      "hook_walk_identity_atMostTwoRows is provable non-circularly: HLF for ≤2-row was proved without hook_walk_identity, and corners preserve ≤2-row property",
+      "Key algebraic chain for 2-row case: HP/HPc = card(SYT(μ\\c)) * HP/(N-1)! → sum = HP/(N-1)! * card(SYT(μ)) = N!/( N-1)! = N",
+      "div_eq_div_iff + linear_combination pattern handles the per-term ratio rewriting cleanly in ℚ",
+      "General (≥3-row) case still requires GNW probabilistic proof (~300 lines) or RSK (~500 lines) — not buildable in a single session"
     ],
     "mathlibGaps": [
-      "hookLength may not be defined in Mathlib.Combinatorics.YoungDiagram \u2014 check arm/leg availability",
-      "StandardYoungTableau enumeration \u2014 check Mathlib.Combinatorics.YoungTableaux"
+      "hookLength may not be defined in Mathlib.Combinatorics.YoungDiagram — check arm/leg availability",
+      "StandardYoungTableau enumeration — check Mathlib.Combinatorics.YoungTableaux"
     ],
     "nextSteps": [
-      "Prove ni_count_eq_syt_count: Fomin growth diagram bijection SYT(mu) <-> NI-paths in youngLGVConfig (~200 lines)",
-      "Prove lgv_det_factors_as_hook_quotient: det(pathMatrix) * hookProd = n! via Vandermonde-type identity (~200 lines)",
-      "Alternative: prove hook walk identity sum_c hookProd(mu)/hookProd(mu\\c) = n in Q, then derive HLF by induction",
-      "Retrieve Aristotle result for hook_walk_identity (project 8a9026a1-e4ec-40d3-81d4-bee5bec6e4b3)",
-      "If Aristotle proves hook_walk_identity, integrate into BallotProblemOQ03OQ01OQ02.lean:4638 and close hook_length_formula_Q"
+      "Implement GNW (Greene-Nijenhuis-Wilf 1979) probabilistic proof of hook_walk_identity for ≥3-row shapes (~300 lines)",
+      "Alternative: RSK correspondence approach (~500 lines) — import Mathlib RSK if available",
+      "Alternative: Jeu de taquin approach (JDT, ~500 lines)",
+      "Check Mathlib for RSK or GNW infrastructure before building from scratch",
+      "Aristotle job 8a9026a1 submitted for hook_walk_identity_Aristotle — check if completed"
     ]
   },
   "tags": [
@@ -149,6 +156,7 @@
     "ballot-problem-oq-03",
     "ballot-problem-oq-03-oq-01",
     "ballot-problem-oq-03-oq-01-oq-01",
+    "ballot-problem-oq-03-oq-01-oq-01-oq-01",
     "ballot-problem-oq-03-oq-01-oq-02",
     "ballot-problem-oq-03-oq-01-oq-04",
     "ballot-problem-oq-03-oq-02",
@@ -158,7 +166,7 @@
     "papers": [
       "Frame-Robinson-Thrall (1954): The hook graphs of the symmetric group",
       "Gessel-Viennot (1985): Binomial determinants, paths, and hook length formulae",
-      "Lindstr\u00f6m (1973): On the vector representations of induced matroids"
+      "Lindström (1973): On the vector representations of induced matroids"
     ],
     "urls": [],
     "mathlib": [
@@ -326,15 +334,37 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01.lean"
     },
     {
+      "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
+      "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
+      "lineCount": 273,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 2,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",
       "filename": "BallotProblemOQ03OQ01OQ02.lean",
-      "lineCount": 3585,
-      "theoremCount": 62,
+      "lineCount": 4726,
+      "theoremCount": 64,
       "axiomCount": 0,
       "defCount": 10,
-      "sorryCount": 9,
+      "sorryCount": 10,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BallotProblemOQ03OQ01OQ02Aristotle.lean",
+      "filename": "BallotProblemOQ03OQ01OQ02Aristotle.lean",
+      "lineCount": 114,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 4,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ02Aristotle.lean"
     },
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ04.lean",
@@ -369,5 +399,6 @@
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ03.lean"
     }
-  ]
+  ],
+  "iteration": 1
 }


### PR DESCRIPTION
## Summary

- Proves `hook_walk_identity` for all at-most-2-row Young diagrams without circularity
- Adds `removeCorner_atMostTwoRows`: removing a corner from a ≤2-row shape stays ≤2-row
- Adds `hook_walk_identity_atMostTwoRows`: key identity Σ_c HP/HPc = N for ≤2-row μ
- `hook_walk_identity` now case-splits: ≤2-row proved, ≥3-row still sorry

## Mathematical Content

**Problem**: `hook_walk_identity` (line 4714) is the sole remaining blocker for `hook_length_formula_general`.

**New non-circular proof for ≤2-row shapes**:
```
Σ_c hookProd(μ)/hookProd(μ\c)
= HP/(N-1)! · Σ_c card(SYT(μ\c))    [HP/HPc = card(SYT(μ\c))·HP/(N-1)! from HLF for μ\c]
= HP/(N-1)! · card(SYT(μ))           [corner step]
= N!/(N-1)! = N                       [HLF for μ]
```
Non-circular because `hook_length_formula_atMostTwoRows` was proved without this identity, and corners preserve the ≤2-row property.

**Remaining gap**: ≥3-row shapes require GNW probabilistic proof (~300 lines) or RSK correspondence (~500 lines).

## Files Modified

- `proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean`: +100 lines of new lemmas
- `src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json`: updated knowledge

## Test plan

- [x] Docker build succeeds (exit code 0)
- [x] `hook_walk_identity_atMostTwoRows` type-checks
- [x] `removeCorner_atMostTwoRows` type-checks
- [x] `hook_walk_identity` case-splits correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)