### PR TITLE
Fix: sync minkowski lineCount 662→686 in both gallery entries

### DIFF
--- a/src/data/proofs/minkowski-fundamental-theorem/meta.json
+++ b/src/data/proofs/minkowski-fundamental-theorem/meta.json
@@ -20,7 +20,7 @@
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified.",
-    "lineCount": 662,
+    "lineCount": 686,
     "theoremCount": 19,
     "definitionCount": 14,
     "originalContributions": [
@@ -134,7 +134,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 662,
+    "lineCount": 686,
     "path": "Proofs/MinkowskiFundamentalTheorem.lean",
     "axiomCount": 0,
     "sorries": 0

--- a/src/data/proofs/minkowski-theorem/meta.json
+++ b/src/data/proofs/minkowski-theorem/meta.json
@@ -65,7 +65,7 @@
     ],
     "dateAdded": "2025-12-29",
     "axiomCount": 0,
-    "lineCount": 662,
+    "lineCount": 686,
     "assumptions": "None. The main theorem minkowski_fundamental is fully proved from Mathlib's GeometryOfNumbers via bridge lemmas connecting custom Lattice/ConvexBody/HasVolume types to Mathlib's Module.Basis, ZSpan, and Lebesgue measure.",
     "mathlib_version": "4.26.0",
     "prerequisites": [
@@ -269,7 +269,7 @@
       "Metric"
     ],
     "namespace": "MinkowskiFundamentalTheorem",
-    "lineCount": 662,
+    "lineCount": 686,
     "axiomCount": 0,
     "theoremCount": 19,
     "definitionCount": 14,


### PR DESCRIPTION
## Fix

Both `minkowski-theorem` and `minkowski-fundamental-theorem` reference `MinkowskiFundamentalTheorem.lean`, which is 686 lines. Both `meta.lineCount` and `leanFile.lineCount` were stale at 662 in both entries.

## Evidence

**Before**: `lineCount: 662` in both entries (both meta and leanFile blocks)
**After**: `lineCount: 686` in both entries (both meta and leanFile blocks)

Verified against `git show HEAD:proofs/Proofs/MinkowskiFundamentalTheorem.lean | wc -l` = 686.

---
Automated fix by lean-mechanic agent.