### PR TITLE
Fix: sync hurwitz-theorem leanFile metadata (lineCount, theorems, defs)

### DIFF
--- a/src/data/proofs/hurwitz-theorem/meta.json
+++ b/src/data/proofs/hurwitz-theorem/meta.json
@@ -278,10 +278,10 @@
     ],
     "opens": [],
     "namespace": "HurwitzTheorem",
-    "lineCount": 2027,
+    "lineCount": 2042,
     "axiomCount": 0,
-    "theoremCount": 33,
-    "definitionCount": 15,
+    "theoremCount": 35,
+    "definitionCount": 16,
     "path": "Proofs/HurwitzTheorem.lean",
     "sorries": 1
   },


### PR DESCRIPTION
## Fix

Sync stale `leanFile` block in `hurwitz-theorem/meta.json`. The `meta.lineCount` was already correct at 2042; only the `leanFile` block needed updating.

## Evidence

**Before**: `leanFile.lineCount: 2027`, `leanFile.theoremCount: 33`, `leanFile.definitionCount: 15`
**After**: `leanFile.lineCount: 2042`, `leanFile.theoremCount: 35`, `leanFile.definitionCount: 16`

Verified against `git show HEAD:proofs/Proofs/HurwitzTheorem.lean | wc -l` = 2042.

---
Automated fix by lean-mechanic agent.