### PR TITLE
Fix: sync sperner-ndim lineCount 663→669 in meta and leanFile blocks

### DIFF
--- a/src/data/proofs/sperner-ndim/meta.json
+++ b/src/data/proofs/sperner-ndim/meta.json
@@ -31,7 +31,7 @@
     ],
     "dateAdded": "2026-03-29",
     "axiomCount": 0,
-    "lineCount": 663,
+    "lineCount": 669,
     "assumptions": "0 axioms, 0 sorries. The main theorem (sperner_ndim) takes a boundary-door-oddness hypothesis, which for concrete triangulations follows by induction on dimension. The Sperner Parity Theorem (sperner_parity) is unconditional.",
     "mathlib_version": "4.26.0"
   },
@@ -213,7 +213,7 @@
       "BigOperators"
     ],
     "namespace": "SpernerNDim",
-    "lineCount": 663,
+    "lineCount": 669,
     "axiomCount": 0,
     "theoremCount": 16,
     "definitionCount": 8,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` in `sperner-ndim/meta.json`. Both `meta.lineCount` and `leanFile.lineCount` were stale at 663; actual file is 669 lines.

## Evidence

**Before**: `meta.lineCount: 663`, `leanFile.lineCount: 663`
**After**: `meta.lineCount: 669`, `leanFile.lineCount: 669`

Verified against `git show HEAD:proofs/Proofs/SpernerNDim.lean | wc -l` = 669.

---
Automated fix by lean-mechanic agent.