### PR TITLE
Fix: sync stale lineCount in 6 gallery entries

### DIFF
--- a/src/data/proofs/dissection-of-cubes-oq-04/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-04/meta.json
@@ -23,7 +23,7 @@
     "dateAdded": "2026-04-22",
     "axiomCount": 2,
     "assumptions": "2 axioms: 1. tmul_infinite_order_ne_zero (from OQ02OQ02): ℝ is flat over ℤ — needed to show nonzero tensor products. 2. icoAngle_irrational: arccos(-√5/3)/π is irrational (icosahedron dihedral angle) — proof requires Chebyshev arithmetic in ℤ[√5], deferred. All sorries are now proved (edge count scaling lemmas closed in research session).",
-    "lineCount": 437,
+    "lineCount": 432,
     "theoremCount": 15,
     "definitionCount": 4,
     "mathlibDependencies": [

--- a/src/data/proofs/erdos-1018-oq-04/meta.json
+++ b/src/data/proofs/erdos-1018-oq-04/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 2,
     "axiomCount": 4,
-    "lineCount": 308,
+    "lineCount": 307,
     "assumptions": "4 axioms: van Kampen-Flores theorem, embeddability of K₃ and K₄ in R², density-exceeds-Turán threshold. 2 sorries: isEmbeddable definition, turanNumber definition.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
@@ -190,7 +190,7 @@
       "Finset"
     ],
     "namespace": "Erdos1018OQ04",
-    "lineCount": 308,
+    "lineCount": 307,
     "axiomCount": 4,
     "theoremCount": 11,
     "definitionCount": 12,

--- a/src/data/proofs/erdos-512/meta.json
+++ b/src/data/proofs/erdos-512/meta.json
@@ -66,7 +66,7 @@
       "konyagin_equals_mps: logical equivalence of the two proofs"
     ],
     "axiomCount": 2,
-    "lineCount": 365,
+    "lineCount": 368,
     "assumptions": "2 axioms: konyagin_theorem, mcgehee_pigno_smith_theorem."
   },
   "overview": {
@@ -214,7 +214,7 @@
       "MeasureTheory"
     ],
     "namespace": "Erdos512",
-    "lineCount": 365,
+    "lineCount": 368,
     "axiomCount": 2,
     "theoremCount": 11,
     "definitionCount": 16,

--- a/src/data/proofs/erdos-ko-rado/meta.json
+++ b/src/data/proofs/erdos-ko-rado/meta.json
@@ -21,7 +21,7 @@
     "dateAdded": "2026-04-02",
     "axiomCount": 9,
     "assumptions": "9 axioms for the combinatorial double-counting lemmas and deep extension theorems: at_most_k_intersecting_cyclic_intervals (key lemma: at most k of n cyclic intervals are pairwise intersecting), double_counting_bound (the main Katona double-count giving |A|≤C(n-1,k-1)), frankl_t_intersecting (Frankl's theorem on t-intersecting families), hilton_milner (Hilton-Milner 1967: non-star bound), bollobas_set_pairs (Bollobás set-pairs inequality, now with correct hypotheses), pyber_cross_intersecting (Pyber 1986: cross-intersecting sum bound), ekr_for_permutations (Ellis-Friedgut-Pilpel 2011), sunflower_lemma (Erdős-Ko 1961 sunflower bound), coset_size (the permutation coset {σ : σ(i)=j} has exactly (n-1)! elements — replaces a degenerate 1+1=2 stub). Previously degenerate axioms (set_appears_in_cyclic_orders, improved_sunflower_lemma, cross_intersecting_bound) have been proved, and tstar_achieves_frankl_bound proved via bijection.",
-    "lineCount": 745,
+    "lineCount": 744,
     "theoremCount": 15,
     "definitionCount": 14,
     "originalContributions": [
@@ -65,7 +65,7 @@
   },
   "leanFile": {
     "namespace": "ErdosKoRado",
-    "lineCount": 745,
+    "lineCount": 744,
     "axiomCount": 9,
     "theoremCount": 15,
     "definitionCount": 14,

--- a/src/data/proofs/ptolemys-complex-proof/meta.json
+++ b/src/data/proofs/ptolemys-complex-proof/meta.json
@@ -38,7 +38,7 @@
     ],
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
-    "lineCount": 154,
+    "lineCount": 145,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
   },
   "overview": {
@@ -161,7 +161,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 154,
+    "lineCount": 145,
     "axiomCount": 0,
     "theoremCount": 6,
     "substantiveTheoremCount": 4,

--- a/src/data/proofs/ptolemys-theorem-oq-01/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01/meta.json
@@ -49,7 +49,7 @@
     ],
     "dateAdded": "2026-04-13",
     "axiomCount": 0,
-    "lineCount": 470,
+    "lineCount": 482,
     "assumptions": "None. All results fully verified from Mathlib with 0 sorries and 0 axioms.",
     "theoremCount": 8,
     "definitionCount": 2
@@ -148,7 +148,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 470,
+    "lineCount": 482,
     "axiomCount": 0,
     "theoremCount": 8,
     "substantiveTheoremCount": 5,


### PR DESCRIPTION
## Fix

Corrects stale `lineCount` values in 6 gallery meta.json files where the recorded line count no longer matches the actual Lean source file.

## Evidence

| Proof | Before | After | Diff |
|-------|--------|-------|------|
| ptolemys-theorem-oq-01 | 470 | 482 | +12 |
| ptolemys-complex-proof | 154 | 145 | -9 |
| dissection-of-cubes-oq-04 | 437 | 432 | -5 |
| erdos-512 | 365 | 368 | +3 |
| erdos-ko-rado | 745 | 744 | -1 |
| erdos-1018-oq-04 | 308 | 307 | -1 |

All other metadata (sorries, axiomCount, status, badge) remains unchanged.

---
Automated fix by lean-mechanic agent.