### PR TITLE
Fix: sync ballot-problem-oq-03-oq-01-oq-02 lineCount (4725→4801)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -23,7 +23,7 @@
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
     "assumptions": "Four open sorries: (1) hook_length_formula (LGV approach: requires SYT↔NI bijection + det factorization), (2) ni_count_eq_syt_count (Fomin/Viennot/RSK correspondence), (3) lgv_det_factors_as_hook_quotient (det factorization identity), (4) hook_walk_identity (corner induction: sum of hook-ratio over corners = n; general proof requires ~300 lines). hook_length_formula_general is proved modulo hook_walk_identity via Part XIV corner induction.",
-    "lineCount": 4725,
+    "lineCount": 4801,
     "theoremCount": 162,
     "definitionCount": 14,
     "originalContributions": [
@@ -86,7 +86,7 @@
       "LGV"
     ],
     "namespace": "HookLengthFormula",
-    "lineCount": 4725,
+    "lineCount": 4801,
     "axiomCount": 0,
     "sorries": 4,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",


### PR DESCRIPTION
## Fix

Sync `lineCount` metadata for `ballot-problem-oq-03-oq-01-oq-02` after the Lean file grew by 76 lines in two research commits.

## Evidence

**Before**: `lineCount: 4725` in both `meta.lineCount` and `leanFile.lineCount`

**After**: `lineCount: 4801` (confirmed via Python `len(readlines())` on `BallotProblemOQ03OQ01OQ02.lean`)

**Root cause**: The Lean file grew in:
- `c0dcbcf81a` — Part XIV: hook_length_formula_general via corner induction  
- `5bbbe79cca` — hook_walk_identity_atMostTwoRows addition

But `meta.json` was last updated in `97d5d6bcf3` (clamp OOB section endLine values) which didn't sync the lineCount.

**Verified unchanged**: `sorries: 4` and `axiomCount: 0` both confirmed correct against the actual file.

---
Automated fix by lean-mechanic agent.