### PR TITLE
Fix: ptolemys-theorem-oq-01-oq-02 badge original→mathlib

### DIFF
--- a/src/data/proofs/ptolemys-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01-oq-02/meta.json
@@ -18,7 +18,7 @@
       "inner-product-space",
       "chord-arc-formula"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -56,7 +56,7 @@
     "dateAdded": "2026-04-24",
     "axiomCount": 0,
     "lineCount": 270,
-    "assumptions": "0 axioms. 0 sorries. Assumes: Cospherical condition (points on common circle), angle conditions for diagonal crossing, unit sphere (‖a‖=‖b‖=‖c‖=‖d‖=1).",
+    "assumptions": "0 axioms. 0 sorries (core result via Mathlib bridge). Relies on Mathlib's EuclideanGeometry.mul_dist_add_mul_dist_eq_mul_dist_of_cospherical for the Euclidean Ptolemy step. Assumes: Cospherical condition (points on common circle), angle conditions for diagonal crossing, unit sphere (‖a‖=‖b‖=‖c‖=‖d‖=1).",
     "mathlib_version": "4.26.0",
     "parentProof": "ptolemys-theorem-oq-01"
   },


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: ptolemys-theorem-oq-01-oq-02
**Severity**: MEDIUM

## Issue

`badge` was set to `"original"` but this proof is **Tier B** — the core step in `spherical_ptolemy` calls `ptolemys_theorem`, which is a thin wrapper around Mathlib's `EuclideanGeometry.mul_dist_add_mul_dist_eq_mul_dist_of_cospherical`. Per gallery integrity rules, Tier B proofs must use badge `"mathlib"`.

## Evidence

**meta.json claimed**: `"badge": "original"`

**Lean file shows**:
```lean
have h_eucl : dist a b * dist c d + dist b c * dist d a = dist a c * dist b d :=
  ptolemys_theorem h_cosph h_apc h_bpd
```

And in `PtolemysTheorem.lean`:
```lean
theorem ptolemys_theorem ... :=
  mul_dist_add_mul_dist_eq_mul_dist_of_cospherical h hapc hbpd
```

## What IS original

- `unit_sphere_chord_via_sin`: chord-arc identity for unit sphere points (original)
- The substitution argument connecting Euclidean to spherical Ptolemy (original strategy)

## Fix

- `badge`: `"original"` → `"mathlib"`
- `assumptions`: Added "core result via Mathlib bridge" note

---
Discovered during gallery integrity audit (auditor-agent).