### PR TITLE
Fix gallery badge: ptolemys-theorem-oq-01-oq-02 should be mathlib not original

### DIFF
--- a/src/data/proofs/ptolemys-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01-oq-02/meta.json
@@ -18,7 +18,7 @@
       "inner-product-space",
       "chord-arc-formula"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -48,15 +48,15 @@
       }
     ],
     "originalContributions": [
-      "unit_sphere_chord_via_sin: ‖a−b‖ = 2·sin(arccos(⟨a,b⟩)/2) for unit sphere points in inner product space",
-      "spherical_ptolemy: sin(d_s(a,c)/2)·sin(d_s(b,d)/2) = sin(d_s(a,b)/2)·sin(d_s(c,d)/2) + sin(d_s(a,d)/2)·sin(d_s(b,c)/2)",
-      "Proof strategy: Euclidean Ptolemy → chord-arc substitution → divide by 4",
+      "unit_sphere_chord_via_sin: ‖a−b‖ = 2·sin(arccos(⟨a,b⟩)/2) for unit sphere points in inner product space (independently proved using basic Mathlib utilities)",
+      "spherical_ptolemy: derived from Mathlib's EuclideanGeometry.mul_dist_add_mul_dist_eq_mul_dist_of_cospherical via chord-arc substitution — new theorem not in Mathlib, but relies on Mathlib for the Euclidean Ptolemy core",
+      "Bridge infrastructure: chord-arc substitution + algebraic cancellation (linear_combination -(1/4)·h_eucl) connecting Euclidean and spherical Ptolemy",
       "Detailed survey of the hyperbolic case: conformal factor structure in the Poincaré disk"
     ],
     "dateAdded": "2026-04-24",
     "axiomCount": 0,
     "lineCount": 270,
-    "assumptions": "0 axioms. 0 sorries. Assumes: Cospherical condition (points on common circle), angle conditions for diagonal crossing, unit sphere (‖a‖=‖b‖=‖c‖=‖d‖=1).",
+    "assumptions": "0 axioms. 0 sorries (core result via Mathlib bridge: EuclideanGeometry.mul_dist_add_mul_dist_eq_mul_dist_of_cospherical). Assumes: Cospherical condition (points on common circle), angle conditions for diagonal crossing, unit sphere (‖a‖=‖b‖=‖c‖=‖d‖=1).",
     "mathlib_version": "4.26.0",
     "parentProof": "ptolemys-theorem-oq-01"
   },


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: `ptolemys-theorem-oq-01-oq-02`  
**Issue**: `badge: "original"` overstates the proof tier

## Evidence

**meta.json claimed**: `badge: "original"` (Tier A — no deep Mathlib imports doing core work)

**Reality**: The main theorem `spherical_ptolemy` is derived directly from Mathlib's `EuclideanGeometry.mul_dist_add_mul_dist_eq_mul_dist_of_cospherical` (the Euclidean Ptolemy theorem), accessed via `PtolemysTheorem.lean`. The parent proof `ptolemys-theorem` correctly carries `badge: "mathlib"`. This file is one further step in the same chain and must also be `mathlib`.

The chord-arc identity `unit_sphere_chord_via_sin` is independently proved, but the main result `spherical_ptolemy` is a Tier B result: derived via Mathlib's core theorem.

## Changes

- `badge`: `"original"` → `"mathlib"`
- `assumptions`: Added note: "0 sorries (core result via Mathlib bridge: EuclideanGeometry.mul_dist_add_mul_dist_eq_mul_dist_of_cospherical)"
- `originalContributions`: Clarified which work is independent (chord-arc identity) vs. derived (spherical_ptolemy bridge)

No Lean source changes — the Lean proof is correct; only the gallery metadata was overstating the tier.

---
Discovered during gallery integrity audit (loom:auditor).