### PR TITLE
Fix: sync ballot-problem-oq-03-oq-01-oq-02 lineCount 4725→4801 after Part XIV

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -23,7 +23,7 @@
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
     "assumptions": "Four open sorries: (1) hook_length_formula (LGV approach: requires SYT↔NI bijection + det factorization), (2) ni_count_eq_syt_count (Fomin/Viennot/RSK correspondence), (3) lgv_det_factors_as_hook_quotient (det factorization identity), (4) hook_walk_identity (corner induction: sum of hook-ratio over corners = n; general proof requires ~300 lines). hook_length_formula_general is proved modulo hook_walk_identity via Part XIV corner induction.",
-    "lineCount": 4725,
+    "lineCount": 4801,
     "theoremCount": 162,
     "definitionCount": 14,
     "originalContributions": [
@@ -86,7 +86,7 @@
       "LGV"
     ],
     "namespace": "HookLengthFormula",
-    "lineCount": 4725,
+    "lineCount": 4801,
     "axiomCount": 0,
     "sorries": 4,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",
@@ -168,7 +168,7 @@
       "id": "sec-corner-induction",
       "title": "Part XIV: hook_length_formula_general via Corner Induction",
       "startLine": 4600,
-      "endLine": 4725,
+      "endLine": 4801,
       "summary": "Proves hook_length_formula_general by well-founded induction on μ.card, using card_SYT_corner_step (Part XIII) + hook_walk_identity (1 sorry). hook_length_formula_Q is the ℚ version proved by WF induction.",
       "mathContext": "hook_walk_identity: Σ_c hookProd(μ)/hookProd(μ\\c) = μ.card. The main theorem reduces to hook_length_formula_Q via exact_mod_cast."
     }


### PR DESCRIPTION
## Fix

Synced stale `lineCount` and section `endLine` in `ballot-problem-oq-03-oq-01-oq-02` meta.json after Part XIV was added to the Lean file without updating gallery metadata.

## Evidence

**Cause**: Commit c0dcbcf81a (Part XIV: hook_length_formula_general via Corner Induction) added 77 lines to `BallotProblemOQ03OQ01OQ02.lean` but did not update the gallery metadata.

**Before**:
- `meta.lineCount`: 4725
- `leanFile.lineCount`: 4725
- `sec-corner-induction.endLine`: 4725

**After**:
- `meta.lineCount`: 4801
- `leanFile.lineCount`: 4801
- `sec-corner-induction.endLine`: 4801

Actual file line count (Python `split('\\n')` minus trailing empty): 4801

---
Automated fix by lean-mechanic agent.