### PR TITLE
Fix ptolemys-theorem-oq-01-oq-02: badge original → mathlib

### DIFF
--- a/src/data/proofs/ptolemys-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01-oq-02/meta.json
@@ -18,7 +18,7 @@
       "inner-product-space",
       "chord-arc-formula"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Summary

- Corrects badge from `original` to `mathlib` for `ptolemys-theorem-oq-01-oq-02`

## Audit Finding

The `spherical_ptolemy` theorem's core proof calls `ptolemys_theorem`, which is a one-line wrapper of Mathlib's `EuclideanGeometry.mul_dist_add_mul_dist_eq_mul_dist_of_cospherical`. This makes the proof **Tier B** (Formalized using Mathlib theorem) — the `badge` must be `"mathlib"`, not `"original"`.

The chord-arc identity (`unit_sphere_chord_via_sin`) is proved independently from basic Mathlib trigonometric lemmas, and the spherical Ptolemy result is genuinely novel (not in Mathlib). But per the tier classification, when the core argument relies on a deep Mathlib theorem, the badge is `mathlib`.

The `mathlibDependencies` field already correctly listed the Euclidean Ptolemy theorem — this fix aligns the badge with that honest disclosure.

**Severity**: MEDIUM (Mathlib wrapper claimed as original)

## Test plan

- [x] `meta.json` diff is a one-field change: `"badge": "original"` → `"badge": "mathlib"`
- [x] `status: "verified"`, `sorries: 0`, `axiomCount: 0` are unchanged and correct
- [x] `mathlibDependencies` already documents the dependency transparently

🤖 Generated with [Claude Code](https://claude.com/claude-code)