### PR TITLE
Enrich ptolemys-theorem-oq-01-oq-02: fix annotation schema, add header section

### DIFF
--- a/src/data/proofs/ptolemys-theorem-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01-oq-02/annotations.json
@@ -1,37 +1,167 @@
 [
   {
-    "id": "header",
-    "startLine": 1,
-    "endLine": 70,
-    "title": "Imports and Documentation",
-    "body": "Imports `Proofs.PtolemysTheorem` (the Euclidean Ptolemy theorem wrapping Mathlib), `InnerProductSpace.Basic` for `norm_sub_sq_real` and Cauchy-Schwarz, `Trigonometric.Inverse` for `Real.cos_arccos` and `arccos_nonneg`/`arccos_le_pi`, and `Trigonometric.Basic` for `Real.cos_two_mul` and `Real.sin_sq_add_cos_sq`. The module document explains the proof strategy: spherical Ptolemy = Euclidean Ptolemy ÷ 4 after chord-arc substitution."
+    "id": "ann-imports-header",
+    "proofId": "ptolemys-theorem-oq-01-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 63
+    },
+    "type": "concept",
+    "title": "Module Overview: Spherical Ptolemy via Chord-Arc Identity",
+    "content": "This file proves the spherical Ptolemy theorem by leveraging the Euclidean version already in Mathlib. The key architectural insight: instead of re-proving Ptolemy from scratch in spherical geometry, translate between the two settings using the **chord-arc identity** — a bridge formula relating Euclidean distances to spherical arc distances.\n\nThe proof imports four modules:\n- `Proofs.PtolemysTheorem`: The Euclidean Ptolemy theorem as a NormedAddTorsor wrapper around Mathlib's `mul_dist_add_mul_dist_eq_mul_dist_of_cospherical`\n- `InnerProductSpace.Basic`: For `norm_sub_sq_real` and Cauchy-Schwarz (`abs_real_inner_le_norm`)\n- `Trigonometric.Inverse`: For `Real.cos_arccos`, `Real.arccos_nonneg`, `Real.arccos_le_pi`\n- `Trigonometric.Basic`: For `Real.cos_two_mul`, `Real.sin_sq_add_cos_sq`\n\nThe three theorems are organized as: (1) `inner_unit_mem_Icc` — domain lemma for arccos; (2) `unit_sphere_chord_via_sin` — the chord-arc bridge; (3) `spherical_ptolemy` — the main result via Euclidean Ptolemy + chord-arc + linear_combination. Part 4 surveys the hyperbolic case and explains why it requires substantially more infrastructure.",
+    "mathContext": "The spherical Ptolemy theorem states: for $a, b, c, d$ on the unit sphere $S^{n-1} \\subset V$ (a real inner product space), lying on a common circle with diagonals crossing, the geodesic arc distances satisfy:\n$$\\sin\\frac{d(a,c)}{2}\\cdot\\sin\\frac{d(b,d)}{2} = \\sin\\frac{d(a,b)}{2}\\cdot\\sin\\frac{d(c,d)}{2} + \\sin\\frac{d(a,d)}{2}\\cdot\\sin\\frac{d(b,c)}{2}$$\nwhere $d(x,y) = \\arccos(\\langle x, y \\rangle)$ is the great-circle distance. The bridge to Euclidean Ptolemy is:\n$$\\|x - y\\| = 2\\sin\\left(\\frac{\\arccos(\\langle x, y \\rangle)}{2}\\right)$$\nfor unit vectors $x, y$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Euclidean Ptolemy theorem",
+      "spherical geometry",
+      "chord-arc identity",
+      "inner product space",
+      "NormedAddTorsor",
+      "great-circle distance"
+    ],
+    "prerequisites": [
+      "Real inner product spaces and their metric structure",
+      "Euclidean Ptolemy theorem (Mathlib)",
+      "Trigonometric functions: arccos, sin, and their properties",
+      "NormedAddTorsor: abstract affine spaces"
+    ]
   },
   {
-    "id": "cauchy-schwarz",
-    "startLine": 72,
-    "endLine": 80,
-    "title": "Cauchy-Schwarz for Unit Vectors",
-    "body": "For unit vectors $a, b$ with $\\|a\\| = \\|b\\| = 1$, `abs_real_inner_le_norm` gives $|\\langle a, b \\rangle| \\leq 1$, so $\\langle a, b \\rangle \\in [-1, 1]$. This is needed to apply `Real.cos_arccos : cos(arccos x) = x for x ∈ [-1,1]` and to ensure `arccos` lies in its proper domain."
+    "id": "ann-namespace-setup",
+    "proofId": "ptolemys-theorem-oq-01-oq-02",
+    "range": {
+      "startLine": 65,
+      "endLine": 71
+    },
+    "type": "technical",
+    "title": "Namespace and Variable Declarations",
+    "content": "The `SphericalPtolemy` namespace scopes all definitions. `open Real EuclideanGeometry` provides access to `Real.sin`, `Real.arccos`, `Real.cos_arccos`, etc. without full qualification, and to `Cospherical` and `ptolemys_theorem` from `EuclideanGeometry`.\n\nThe universe-polymorphic variable `V : Type*` with instances `[NormedAddCommGroup V] [InnerProductSpace ℝ V]` means all theorems apply to any real Hilbert space — $\\mathbb{R}^n$, $\\ell^2$, function spaces, etc. The `set_option linter.unusedVariables false` suppresses warnings about hypothesis variables introduced but not used directly (they are used by typeclass instances).",
+    "mathContext": "The inner product space structure on $V$ provides:\n- $\\langle \\cdot, \\cdot \\rangle : V \\times V \\to \\mathbb{R}$ (written `⟪a, b⟫_ℝ` in Lean)\n- $\\|\\cdot\\| : V \\to \\mathbb{R}_{\\geq 0}$ with $\\|v\\|^2 = \\langle v, v \\rangle$\n- Cauchy-Schwarz: $|\\langle a, b \\rangle| \\leq \\|a\\| \\cdot \\|b\\|$\n\nNote that Lean's `NormedAddCommGroup` plus `InnerProductSpace ℝ` together provide both the additive group structure and the inner product; the norm is derived from the inner product.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "InnerProductSpace",
+      "NormedAddCommGroup",
+      "open statement",
+      "variable declarations",
+      "Lean 4 namespace"
+    ],
+    "prerequisites": [
+      "Lean 4 type class system",
+      "Inner product spaces over ℝ",
+      "Lean 4 namespaces and open"
+    ]
   },
   {
-    "id": "chord-arc",
-    "startLine": 84,
-    "endLine": 152,
-    "title": "Chord-Arc Identity: ‖a−b‖ = 2·sin(arccos(⟨a,b⟩)/2)",
-    "body": "The core lemma connecting Euclidean chord length to spherical arc distance.\n\n**Setup**: `arccos(⟨a,b⟩) ∈ [0,π]` (from `arccos_nonneg`, `arccos_le_pi`), so `arccos/2 ∈ [0,π/2]` and `sin(arccos/2) ≥ 0`.\n\n**Left square**: `‖a−b‖² = ‖a‖² − 2⟨a,b⟩ + ‖b‖² = 2 − 2⟨a,b⟩` (using `norm_sub_sq_real` and `‖a‖=‖b‖=1`).\n\n**Right square calculation**:\n- `cos(arccos c) = 2cos²(arccos(c)/2) − 1` (double-angle: `cos_two_mul`)\n- Combined with `cos_arccos : cos(arccos c) = c`: `cos²(arccos(c)/2) = (1+c)/2`\n- Pythagorean identity: `sin²(arccos(c)/2) = 1 − (1+c)/2 = (1−c)/2`\n- So `(2sin(arccos(c)/2))² = 4·(1−c)/2 = 2−2c`\n\n**Conclusion**: Both sides non-negative, squares equal → equal, via `Real.sqrt_sq : √(x²) = x for x ≥ 0`."
+    "id": "ann-cauchy-schwarz",
+    "proofId": "ptolemys-theorem-oq-01-oq-02",
+    "range": {
+      "startLine": 73,
+      "endLine": 83
+    },
+    "type": "technique",
+    "title": "inner_unit_mem_Icc: Domain Lemma for arccos",
+    "content": "`inner_unit_mem_Icc` establishes that the inner product of two unit vectors lies in $[-1, 1]$, the domain of `Real.arccos`. This is a prerequisite for all uses of `Real.cos_arccos` (which requires its argument in $[-1, 1]$) in the chord-arc lemma.\n\nThe proof is a direct application of Cauchy-Schwarz: `abs_real_inner_le_norm a b` gives $|\\langle a, b \\rangle| \\leq \\|a\\| \\cdot \\|b\\| = 1 \\cdot 1 = 1$ after rewriting with `ha : ‖a‖ = 1` and `hb : ‖b‖ = 1`. The conjunction `(-1 ≤ ⟪a,b⟫_ℝ) ∧ (⟪a,b⟫_ℝ ≤ 1)` follows from `|x| ≤ 1 ↔ -1 ≤ x ∧ x ≤ 1`.\n\nThis lemma is `private` — it's a helper used only within the file. The `private` keyword prevents it from leaking into the `SphericalPtolemy` namespace.",
+    "mathContext": "For $a, b \\in V$ with $\\|a\\| = \\|b\\| = 1$:\n$$|\\langle a, b \\rangle| \\leq \\|a\\| \\cdot \\|b\\| = 1$$\nby Cauchy-Schwarz, so $\\langle a, b \\rangle \\in [-1, 1]$.\n\nThis ensures `Real.arccos (⟪a,b⟫_ℝ)` is defined and lies in $[0, \\pi]$:\n- `Real.arccos_nonneg`: $\\arccos(x) \\geq 0$ for $x \\in [-1,1]$\n- `Real.arccos_le_pi`: $\\arccos(x) \\leq \\pi$ for $x \\in [-1,1]$\n\nGeometrically: $\\langle a, b \\rangle = \\cos(\\theta)$ where $\\theta$ is the angle between $a$ and $b$, and angles are in $[0, \\pi]$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Cauchy-Schwarz inequality",
+      "abs_real_inner_le_norm",
+      "Real.arccos domain",
+      "unit vector",
+      "private lemma"
+    ],
+    "prerequisites": [
+      "Cauchy-Schwarz inequality in inner product spaces",
+      "absolute value and interval membership",
+      "arccos domain: [-1, 1]"
+    ]
   },
   {
-    "id": "spherical-ptolemy",
-    "startLine": 156,
-    "endLine": 220,
-    "title": "Spherical Ptolemy: Main Theorem",
-    "body": "For four unit-sphere points on a common circle:\n$$\\sin\\frac{d(a,c)}{2}\\cdot\\sin\\frac{d(b,d)}{2} = \\sin\\frac{d(a,b)}{2}\\cdot\\sin\\frac{d(c,d)}{2} + \\sin\\frac{d(a,d)}{2}\\cdot\\sin\\frac{d(b,c)}{2}$$\n\n**Key steps**:\n1. `ptolemys_theorem h_cosph h_apc h_bpd` : Euclidean Ptolemy gives $\\|a-b\\|\\cdot\\|c-d\\| + \\|b-c\\|\\cdot\\|a-d\\| = \\|a-c\\|\\cdot\\|b-d\\|$\n2. `dist_comm d a` : standardize to `dist a d`\n3. `simp [dist_eq_norm]` : convert `dist` to `‖·−·‖` in the self-torsor V\n4. `unit_sphere_chord_via_sin` applied 6 times: each `‖x−y‖ = 2·sin(d(x,y)/2)`\n5. `linear_combination -(1/4)·h_eucl` : the four 4s cancel, giving the spherical equality\n\nThe `linear_combination` tactic checks that `goal_lhs − goal_rhs = −(1/4)·(h_eucl_lhs − h_eucl_rhs)` using `ring`."
+    "id": "ann-chord-arc-identity",
+    "proofId": "ptolemys-theorem-oq-01-oq-02",
+    "range": {
+      "startLine": 84,
+      "endLine": 143
+    },
+    "type": "technique",
+    "title": "unit_sphere_chord_via_sin: The Bridge Formula",
+    "content": "`unit_sphere_chord_via_sin` is the mathematical heart of the proof: it establishes that for two points on the unit sphere, the Euclidean chord length equals twice the sine of half the geodesic arc length. This identity is the bridge between Euclidean and spherical Ptolemy.\n\n**Proof structure**: The proof works by showing both sides are non-negative and their squares are equal.\n\n**Non-negativity**: `norm_nonneg (a-b) ≥ 0` is immediate; `sin(arccos(c)/2) ≥ 0` requires `Real.sin_nonneg_of_nonneg_of_le_pi` with the observation that `arccos(c)/2 ∈ [0, π/2]`.\n\n**Square of left side**: `‖a-b‖² = ‖a‖² - 2⟨a,b⟩ + ‖b‖² = 1 - 2⟨a,b⟩ + 1 = 2 - 2⟨a,b⟩` (from `norm_sub_sq_real`).\n\n**Square of right side**: Using `cos(arccos c) = c` and the double-angle identity `cos(θ) = 2cos²(θ/2) - 1`:\n- Set `c = ⟨a,b⟩`, `θ = arccos(c)`: `c = 2cos²(θ/2) - 1`\n- So `cos²(θ/2) = (1+c)/2` and `sin²(θ/2) = 1 - (1+c)/2 = (1-c)/2`\n- Thus `(2sin(θ/2))² = 4·(1-c)/2 = 2 - 2c = 2 - 2⟨a,b⟩`\n\n**Conclusion**: Both squares equal `2 - 2⟨a,b⟩`, and since both sides are non-negative, `Real.sqrt_sq` completes the proof.",
+    "mathContext": "For $a, b \\in V$ with $\\|a\\| = \\|b\\| = 1$, let $c = \\langle a, b \\rangle$:\n\n$$\\|a-b\\|^2 = \\|a\\|^2 - 2\\langle a,b\\rangle + \\|b\\|^2 = 2 - 2c$$\n\n$$\\left(2\\sin\\frac{\\arccos c}{2}\\right)^2 = 4\\sin^2\\frac{\\arccos c}{2}$$\n\nFrom the double-angle identity $\\cos(\\theta) = 2\\cos^2(\\theta/2) - 1$ with $\\theta = \\arccos c$:\n$$\\cos^2\\frac{\\arccos c}{2} = \\frac{1+c}{2}, \\quad \\sin^2\\frac{\\arccos c}{2} = \\frac{1-c}{2}$$\n\nSo $(2\\sin(\\arccos c/2))^2 = 4 \\cdot \\frac{1-c}{2} = 2 - 2c$.\n\nSince both sides are non-negative and their squares agree:\n$$\\|a-b\\| = 2\\sin\\frac{\\arccos\\langle a,b\\rangle}{2} = 2\\sin\\frac{d_S(a,b)}{2}$$\nwhere $d_S(a,b) = \\arccos(\\langle a,b\\rangle)$ is the geodesic arc distance on $S^{n-1}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "chord-arc identity",
+      "half-angle formula",
+      "double-angle formula",
+      "cos_two_mul",
+      "Real.sqrt_sq",
+      "norm_sub_sq_real",
+      "spherical distance",
+      "geodesic"
+    ],
+    "prerequisites": [
+      "norm_sub_sq_real: ‖x-y‖² expansion",
+      "Real.cos_arccos: cos(arccos x) = x for x ∈ [-1,1]",
+      "Real.cos_two_mul: cos(2θ) = 2cos²θ - 1",
+      "Real.sin_sq_add_cos_sq: Pythagorean identity",
+      "Real.sqrt_sq: √(x²) = x for x ≥ 0",
+      "Real.sin_nonneg_of_nonneg_of_le_pi"
+    ]
   },
   {
-    "id": "hyperbolic-survey",
-    "startLine": 222,
-    "endLine": 265,
-    "title": "Hyperbolic Case: Mathematical Survey",
-    "body": "The Poincaré disk hyperbolic chord-arc identity is $\\sinh(d_H(a,b)/2) = |a−b|/\\sqrt{(1−|a|^2)(1−|b|^2)}$. Unlike the spherical case where $\\|a\\|=1$ makes the denominator 1 uniformly, the hyperbolic denominators depend on the point. For four interior points of D on a common hyperbolic circle, the factors $\\sqrt{(1−|x|^2)}$ do not cancel symmetrically, making the derivation more complex. Ideal boundary points ($|x|=1$) degenerate to Euclidean Ptolemy on the unit circle.\n\nThe unified curvature-$\\kappa$ framework: $\\text{sn}_\\kappa(t) = \\sin(\\sqrt{\\kappa}t)/\\sqrt{\\kappa}$ (spherical), $t$ (Euclidean), or $\\sinh(\\sqrt{|\\kappa|}t)/\\sqrt{|\\kappa|}$ (hyperbolic). This file proves the $\\kappa=1$ case. Infrastructure needed for $\\kappa=-1$: Poincaré metric, Möbius isometries, hyperbolic circles (~800-1200 lines)."
+    "id": "ann-spherical-ptolemy",
+    "proofId": "ptolemys-theorem-oq-01-oq-02",
+    "range": {
+      "startLine": 144,
+      "endLine": 204
+    },
+    "type": "theorem",
+    "title": "spherical_ptolemy: The Main Theorem",
+    "content": "`spherical_ptolemy` is the culmination: it combines the Euclidean Ptolemy theorem with the chord-arc identity to prove the spherical version. The proof is a six-step calculation:\n\n1. **Euclidean Ptolemy**: `ptolemys_theorem h_cosph h_apc h_bpd` gives `dist(a,b)·dist(c,d) + dist(b,c)·dist(d,a) = dist(a,c)·dist(b,d)` in the NormedAddTorsor sense\n2. **Symmetrize**: `rw [dist_comm d a]` standardizes to `dist a d` throughout\n3. **Unpack `dist`**: `simp only [dist_eq_norm]` converts to `‖·-·‖` norms\n4. **Apply chord-arc**: Six applications of `unit_sphere_chord_via_sin` replace each `‖x-y‖` with `2·sin(arccos(⟨x,y⟩)/2)`\n5. **Rewrite**: `rw [hab, hcd, hbc, had, hac, hbd] at h_eucl` substitutes all six into `h_eucl`\n6. **Divide by 4**: `linear_combination -(1/4 : ℝ) * h_eucl` closes the goal, since `h_eucl` after substitution is `4·(sin_ab·sin_cd + sin_bc·sin_ad) = 4·sin_ac·sin_bd`, and dividing by 4 gives the spherical equality\n\nThe `linear_combination` tactic is ideal here: it reduces the goal to checking a ring identity after multiplying `h_eucl` by `-(1/4)`, which `ring` handles automatically.",
+    "mathContext": "**Hypotheses**:\n- $a, b, c, d \\in V$ with $\\|a\\|=\\|b\\|=\\|c\\|=\\|d\\|=1$ (unit sphere)\n- `Cospherical ({a,b,c,d})`: they lie on a common circle of $V$\n- $\\angle apc = \\pi$ and $\\angle bpd = \\pi$: diagonals $ac$ and $bd$ cross at $p$\n\n**Euclidean Ptolemy** (from Mathlib via `PtolemysTheorem.lean`):\n$$\\|a-b\\|\\cdot\\|c-d\\| + \\|b-c\\|\\cdot\\|a-d\\| = \\|a-c\\|\\cdot\\|b-d\\|$$\n\n**After chord-arc substitution** (each $\\|x-y\\| = 2s_{xy}$ where $s_{xy} = \\sin(\\arccos\\langle x,y\\rangle/2)$):\n$$4s_{ab}s_{cd} + 4s_{bc}s_{ad} = 4s_{ac}s_{bd}$$\n\n**Divide by 4**:\n$$s_{ac}s_{bd} = s_{ab}s_{cd} + s_{ad}s_{bc}$$\n\nThe `linear_combination` check: `goal_lhs - goal_rhs = -(1/4)·(h_eucl_lhs - h_eucl_rhs)` is a ring identity in $\\mathbb{R}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Euclidean Ptolemy theorem",
+      "ptolemys_theorem",
+      "Cospherical",
+      "NormedAddTorsor",
+      "dist_eq_norm",
+      "linear_combination tactic",
+      "cyclic quadrilateral"
+    ],
+    "prerequisites": [
+      "Euclidean Ptolemy theorem (from Mathlib via PtolemysTheorem.lean)",
+      "unit_sphere_chord_via_sin (previous lemma)",
+      "dist_eq_norm in NormedAddTorsor",
+      "linear_combination tactic for ring identities"
+    ]
+  },
+  {
+    "id": "ann-hyperbolic-survey",
+    "proofId": "ptolemys-theorem-oq-01-oq-02",
+    "range": {
+      "startLine": 205,
+      "endLine": 270
+    },
+    "type": "context",
+    "title": "Hyperbolic Ptolemy: Why It's Harder and What's Needed",
+    "content": "Part 4 is a mathematical survey explaining why the proof strategy used for the spherical case does NOT immediately extend to the hyperbolic case, and what infrastructure would be required.\n\n**The key difference**: In the spherical case, $\\|a\\| = \\|b\\| = 1$ makes the chord-arc identity `‖a-b‖ = 2sin(d/2)` uniform — the factor of 2 is the same for all pairs of unit vectors. In the Poincaré disk, the hyperbolic chord-arc identity `sinh(d_H(a,b)/2) = |a-b|/√((1-|a|²)(1-|b|²))` has point-dependent denominators `(1-|x|²)` that do NOT cancel symmetrically for four interior points on a common hyperbolic circle.\n\n**What would work**: If all four points were on the ideal boundary $\\partial D$ (i.e., $|x| = 1$), the denominators become 1 and Euclidean Ptolemy on the unit circle applies directly. For interior points, the statement requires an explicit correction with conformal factors.\n\n**Infrastructure needed**: ~800-1200 lines including Poincaré disk metric, Möbius transformations as hyperbolic isometries, classification of hyperbolic circles (Euclidean circles inside $D$), and the `sinh` chord-arc identity.\n\n**Unified curvature-κ viewpoint**: The function $\\text{sn}_\\kappa(t)$ (spherical `sin`, Euclidean `t`, hyperbolic `sinh`) unifies all three Ptolemy theorems into one statement. The three `#check` statements at the end verify the types of the two proved theorems.",
+    "mathContext": "**Poincaré disk**: $D = \\{z \\in \\mathbb{C} : |z| < 1\\}$ with hyperbolic distance $d_H(a,b) = 2\\text{arctanh}(|\\varphi_a(b)|)$ where $\\varphi_a(b) = (b-a)/(1-\\bar{a}b)$.\n\n**Hyperbolic chord-arc identity**: $\\sinh(d_H(a,b)/2) = |a-b|/\\sqrt{(1-|a|^2)(1-|b|^2)}$\n\n**Why factors don't cancel**: For four points on a hyperbolic circle, the Euclidean Ptolemy equality gives:\n$$|a-b|\\cdot|c-d| + |b-c|\\cdot|a-d| = |a-c|\\cdot|b-d|$$\nSubstituting the chord-arc identity would give:\n$$\\frac{\\sinh(d_H(a,b)/2)\\cdot\\sinh(d_H(c,d)/2)}{\\sqrt{(1-|a|^2)(1-|b|^2)}\\cdot\\sqrt{(1-|c|^2)(1-|d|^2)}} + \\cdots$$\nThe denominators are products like $(1-|a|^2)^{1/2}(1-|b|^2)^{1/2}$, and these cannot be combined into a single factor since $|a|, |b|, |c|, |d|$ are all different.\n\n**Unified statement** (curvature $\\kappa$): $\\text{sn}_\\kappa(d(a,c)/2) \\cdot \\text{sn}_\\kappa(d(b,d)/2) = \\text{sn}_\\kappa(d(a,b)/2)\\cdot\\text{sn}_\\kappa(d(c,d)/2) + \\text{sn}_\\kappa(d(a,d)/2)\\cdot\\text{sn}_\\kappa(d(b,c)/2)$\nwhere $\\text{sn}_\\kappa(t) = \\sin(\\sqrt{\\kappa}\\,t)/\\sqrt{\\kappa}$ ($\\kappa>0$), $t$ ($\\kappa=0$), $\\sinh(\\sqrt{|\\kappa|}\\,t)/\\sqrt{|\\kappa|}$ ($\\kappa<0$).",
+    "significance": "context",
+    "relatedConcepts": [
+      "Poincaré disk model",
+      "hyperbolic geometry",
+      "Möbius transformations",
+      "conformal factor",
+      "sinh chord-arc identity",
+      "curvature-κ Ptolemy theorem",
+      "CAT(κ) spaces",
+      "ideal boundary"
+    ],
+    "prerequisites": [
+      "Poincaré disk metric and hyperbolic distance",
+      "Möbius transformations and hyperbolic isometries",
+      "Real.sinh and Real.arctanh",
+      "Curvature in Riemannian geometry"
+    ]
   }
 ]

--- a/src/data/proofs/ptolemys-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01-oq-02/meta.json
@@ -62,6 +62,15 @@
   },
   "sections": [
     {
+      "id": "imports-header",
+      "title": "Imports, Module Documentation, and Setup",
+      "startLine": 1,
+      "endLine": 71,
+      "summary": "Four imports: PtolemysTheorem (Euclidean Ptolemy wrapper), InnerProductSpace.Basic (norm_sub_sq_real, Cauchy-Schwarz), Trigonometric.Inverse (arccos), Trigonometric.Basic (cos_two_mul). Module docstring describes the proof strategy: spherical Ptolemy = Euclidean Ptolemy ÷ 4 after chord-arc substitution. Namespace SphericalPtolemy, variable V for real inner product space.",
+      "description": "Module documentation explaining the proof strategy (chord-arc bridge from Euclidean to spherical Ptolemy), imports, namespace, and the variable declaration for an arbitrary real inner product space V. The hyperbolic case survey is explained in the docstring.",
+      "mathContext": "The four imports provide the complete logical foundation: `Proofs.PtolemysTheorem` supplies `ptolemys_theorem` (Euclidean Ptolemy in NormedAddTorsor); `InnerProductSpace.Basic` provides `norm_sub_sq_real` ($\\|x-y\\|^2 = \\|x\\|^2 - 2\\langle x,y\\rangle + \\|y\\|^2$) and `abs_real_inner_le_norm` (Cauchy-Schwarz); `Trigonometric.Inverse` provides `cos_arccos`, `arccos_nonneg`, `arccos_le_pi`; `Trigonometric.Basic` provides `cos_two_mul` (double-angle) and `sin_sq_add_cos_sq` (Pythagorean). The variable $V$ ranges over all real Hilbert spaces."
+    },
+    {
       "title": "Cauchy-Schwarz Bound",
       "startLine": 72,
       "endLine": 80,
@@ -95,7 +104,9 @@
       "description": "Detailed mathematical survey of the hyperbolic Ptolemy theorem in the Poincaré disk model. Explains why the conformal factors don't cancel cleanly for interior points, and outlines the infrastructure needed (~800-1200 lines).",
       "summary": "Survey: hyperbolic Ptolemy via Poincaré disk, conformal factors, unified κ-geometry statement",
       "id": "hyperbolic-survey",
-      "mathContext": "In the Poincaré disk $D = \\{z \\in \\mathbb{C} : |z| < 1\\}$, the hyperbolic chord-arc identity is:\n$$\\sinh(d_H(a,b)/2) = \\frac{|a-b|}{\\sqrt{(1-|a|^2)(1-|b|^2)}}$$\n\nFor four points on a common **hyperbolic circle** (which is also a Euclidean circle inside $D$), the Euclidean Ptolemy theorem applies to the complex coordinates. However, the conformal factors $\\sqrt{(1-|x|^2)(1-|y|^2)}$ do **not** cancel uniformly — unlike the spherical case where $\\|a\\| = \\|b\\| = 1$ makes all factors equal to 1.\n\nThe unified curvature-$\\kappa$ Ptolemy theorem: define $\\text{sn}_\\kappa(t) = \\sin(\\sqrt{\\kappa}\\cdot t)/\\sqrt{\\kappa}$ (spherical), $t$ (Euclidean), or $\\sinh(\\sqrt{|\\kappa|}\\cdot t)/\\sqrt{|\\kappa|}$ (hyperbolic). Then for cyclic quadrilaterals in $\\kappa$-geometry: $\\text{sn}_\\kappa(d(a,c)/2)\\cdot\\text{sn}_\\kappa(d(b,d)/2) = \\text{sn}_\\kappa(d(a,b)/2)\\cdot\\text{sn}_\\kappa(d(c,d)/2) + \\text{sn}_\\kappa(d(a,d)/2)\\cdot\\text{sn}_\\kappa(d(b,c)/2)$."
+      "mathContext": "In the Poincaré disk $D = \\{z \\in \\mathbb{C} : |z| < 1\\}$, the hyperbolic chord-arc identity is:\n$$\\sinh(d_H(a,b)/2) = \\frac{|a-b|}{\\sqrt{(1-|a|^2)(1-|b|^2)}}$$\n\nFor four points on a common **hyperbolic circle** (which is also a Euclidean circle inside $D$), the Euclidean Ptolemy theorem applies to the complex coordinates. However, the conformal factors $\\sqrt{(1-|x|^2)(1-|y|^2)}$ do **not** cancel uniformly — unlike the spherical case where $\\|a\\| = \\|b\\| = 1$ makes all factors equal to 1.\n\nThe unified curvature-$\\kappa$ Ptolemy theorem: define $\\text{sn}_\\kappa(t) = \\sin(\\sqrt{\\kappa}\\cdot t)/\\sqrt{\\kappa}$ (spherical), $t$ (Euclidean), or $\\sinh(\\sqrt{|\\kappa|}\\cdot t)/\\sqrt{|\\kappa|}$ (hyperbolic). Then for cyclic quadrilaterals in $\\kappa$-geometry: $\\text{sn}_\\kappa(d(a,c)/2)\\cdot\\text{sn}_\\kappa(d(b,d)/2) = \\text{sn}_\\kappa(d(a,b)/2)\\cdot\\text{sn}_\\kappa(d(c,d)/2) + \\text{sn}_\\kappa(d(a,d)/2)\\cdot\\text{sn}_\\kappa(d(b,c)/2)$.",
+      "startLine": 222,
+      "endLine": 270
     }
   ],
   "overview": {
@@ -104,11 +115,14 @@
     "text": "The spherical Ptolemy theorem is an elegant consequence of the Euclidean version via the chord-arc identity. Four points on the unit sphere satisfying the cyclic condition satisfy a multiplicative sine equality for their pairwise arc distances — the spherical analogue of the product-of-chords equality.",
     "proofStrategy": "**Step 1** (Chord-Arc Identity): For unit sphere points a, b, ‖a−b‖ = 2·sin(arccos(⟨a,b⟩)/2).\n\nProve by squaring both sides and using:\n- ‖a−b‖² = 2 − 2⟨a,b⟩  (from norm_sub_sq_real)\n- (2sin(θ/2))² = 2(1−cosθ)  (from cos_two_mul with θ = arccos(⟨a,b⟩))\n- Both sides non-negative → equal (via Real.sqrt_sq)\n\n**Step 2** (Apply Euclidean Ptolemy): ptolemys_theorem gives ‖a-b‖·‖c-d‖ + ‖b-c‖·‖a-d‖ = ‖a-c‖·‖b-d‖.\n\n**Step 3** (Substitute and cancel): Replace each norm by 2·sin(arc/2), giving 4·(sin_ab·sin_cd + sin_bc·sin_ad) = 4·sin_ac·sin_bd. Divide by 4.",
     "keyInsights": [
-      "The chord-arc identity ‖a−b‖ = 2·sin(arccos(⟨a,b⟩)/2) is the bridge between Euclidean and spherical Ptolemy",
-      "The factor of 4 cancels cleanly because all points are on the UNIT sphere (‖x‖ = 1), unlike the hyperbolic case where conformal factors depend on the point",
-      "V as its own NormedAddTorsor (via SeminormedAddCommGroup.toNormedAddTorsor) lets us apply the abstract Euclidean Ptolemy theorem directly in the inner product space",
-      "linear_combination (-(1/4)·h_eucl) is the cleanest proof tactic for the division-by-4 step in a ring",
-      "The spherical Ptolemy theorem is the κ=1 case of the unified curvature-κ Ptolemy theorem; κ=0 (Euclidean) is in Mathlib; κ=-1 (hyperbolic) requires ~1000 lines of new infrastructure"
+      "The chord-arc identity ‖a−b‖ = 2·sin(arccos(⟨a,b⟩)/2) is the bridge between Euclidean and spherical Ptolemy — translating Euclidean distances into spherical arc distances through the sine half-angle",
+      "The factor of 4 cancels cleanly because all points are on the UNIT sphere (‖x‖ = 1), unlike the hyperbolic case where conformal factors 1/(1-|x|²) depend on the point and prevent uniform cancellation",
+      "V as its own NormedAddTorsor (via SeminormedAddCommGroup.toNormedAddTorsor) lets us apply the abstract Euclidean Ptolemy theorem directly in the inner product space, treating V as its own affine space where dist(x,y) = ‖x-y‖",
+      "linear_combination (-(1/4)·h_eucl) is the cleanest proof tactic for the division-by-4 step: it instructs Lean to verify that goal_lhs − goal_rhs = -(1/4)·(h_eucl_lhs − h_eucl_rhs) as a ring identity, eliminating the factor of 4 introduced by the chord-arc substitution",
+      "The spherical Ptolemy theorem is the κ=1 case of the unified curvature-κ Ptolemy theorem; κ=0 (Euclidean) is in Mathlib as mul_dist_add_mul_dist_eq_mul_dist_of_cospherical; κ=-1 (hyperbolic) requires ~1000 lines of new infrastructure",
+      "The proof strategy — reduce to Euclidean then substitute — mirrors how Ptolemy himself implicitly knew: ancient astronomers computed star positions on the celestial sphere by relating chord tables (Euclidean) to arc tables (spherical), the same 2sin(θ/2) identity, centuries before it was formalized",
+      "The squaring-and-sqrt technique (show x² = y², both non-negative, conclude x = y) recurs throughout the file: it converts multiplicative identities involving square roots or norms into polynomial ring identities that norm_num and linarith can handle — a foundational proof pattern in Lean formalization of metric geometry",
+      "The `Cospherical` hypothesis and the angle conditions `∠ a p c = π, ∠ b p d = π` are exactly what Mathlib's Euclidean Ptolemy theorem (`mul_dist_add_mul_dist_eq_mul_dist_of_cospherical`) requires. Importing these conditions verbatim from the Euclidean version means the spherical theorem is as general as the Euclidean one — no extra conditions needed beyond what characterizes a cyclic quadrilateral"
     ],
     "prerequisites": [
       "Real inner product spaces and their metric structure",


### PR DESCRIPTION
## Summary

First enrichment pass for `ptolemys-theorem-oq-01-oq-02` (Spherical Ptolemy theorem).

**Annotations schema fix**: The annotations.json was using `body` instead of `content` and was missing `proofId`, `type`, `significance`, `relatedConcepts`, and `prerequisites` fields. Rewrote all 6 annotations with the correct schema and rich mathematical content for each section.

**Annotation content improvements**:
- `ann-imports-header` (lines 1-63): Full module overview explaining proof strategy
- `ann-namespace-setup` (lines 65-71): Inner product space variable declarations
- `ann-cauchy-schwarz` (lines 73-83): Domain lemma for arccos, Cauchy-Schwarz application
- `ann-chord-arc-identity` (lines 84-143): Complete proof walk-through of the bridge formula with step-by-step LaTeX mathematics
- `ann-spherical-ptolemy` (lines 144-204): Six-step proof breakdown with `linear_combination` explanation
- `ann-hyperbolic-survey` (lines 205-270): Why conformal factors don't cancel and what infrastructure is needed

**meta.json improvements**:
- Added `imports-header` section covering lines 1-71 (previously uncovered)
- Fixed `hyperbolic-survey` section end line from 265 to 270 (covers full file)
- Expanded `keyInsights` from 5 to 8 entries, adding: squaring-and-sqrt proof pattern, ancient astronomical motivation for chord-arc identity, `linear_combination` mechanism details, and `Cospherical` hypothesis alignment with Euclidean Ptolemy