### PR TITLE
Fix: ballot-problem-oq-03-oq-01-oq-02 sorry count 4→5 (audit sync)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "ballot-problem-oq-03-oq-01-oq-02",
   "title": "Hook-Length Formula for Standard Young Tableaux via LGV",
   "slug": "ballot-problem-oq-03-oq-01-oq-02",
-  "description": "Formalizes the hook-length formula f^λ = n!/∏h(u) for Standard Young Tableaux. Fully proves the formula for single-row (1×n), single-column (n×1), hook-shape ((m+1,1)), 2-row rectangular (m×m), and general 2-row [a,b] families. General formula has 4 sorries via LGV approach (RSK bijection, det factorization, main theorem) or 1 sorry via corner induction (hook_walk_identity). hook_length_formula_general proved via corner induction modulo hook_walk_identity.",
+  "description": "Formalizes the hook-length formula f^λ = n!/∏h(u) for Standard Young Tableaux. Fully proves the formula for single-row (1×n), single-column (n×1), hook-shape ((m+1,1)), 2-row rectangular (m×m), and general 2-row [a,b] families. General formula has 5 sorries total: 3 via LGV approach (RSK bijection, det factorization, main theorem) + 2 for corner induction (hookProd_ratio_formula, hook_walk_identity ≥3-row case). hook_length_formula_general proved via corner induction modulo hook_walk_identity.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-21",
@@ -19,10 +19,10 @@
       "representation-theory"
     ],
     "badge": "wip",
-    "sorries": 4,
+    "sorries": 5,
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "assumptions": "Four open sorries: (1) hook_length_formula (LGV approach: requires SYT↔NI bijection + det factorization), (2) ni_count_eq_syt_count (Fomin/Viennot/RSK correspondence), (3) lgv_det_factors_as_hook_quotient (det factorization identity), (4) hook_walk_identity (corner induction: sum of hook-ratio over corners = n; general proof requires ~300 lines). hook_length_formula_general is proved modulo hook_walk_identity via Part XIV corner induction.",
+    "assumptions": "Five open sorries: (1) hook_length_formula (LGV approach: requires SYT↔NI bijection + det factorization), (2) ni_count_eq_syt_count (Fomin/Viennot/RSK correspondence), (3) lgv_det_factors_as_hook_quotient (det factorization identity), (4) hookProd_ratio_formula (corner induction prerequisite: product ratio identity over arm/leg cells, ~50 lines), (5) hook_walk_identity ≥3-row case (GNW or RSK, ~300 lines; at-most-2-row case proved). hook_length_formula_general is proved modulo hook_walk_identity via Part XIV corner induction.",
     "lineCount": 4801,
     "theoremCount": 162,
     "definitionCount": 14,
@@ -42,7 +42,8 @@
       "hook_length_formula_two_row_gen: formula for general 2-row [a,b] (1 sorry: card_SYT_twoRowYD)",
       "Numerical verification: hook-length formula proved for (2,1), (2,2), (3,1), (3,2), (3,2,1), (4,3,2,1), (3,3), (4,4) shapes",
       "hook_length_formula_gHookYD: HLF for all generalized hook shapes [a, 1^b] (card = C(a+b-1,b), proved via double induction + inline bijection, 0 sorries)",
-      "hook_walk_identity: sum over corners c of hookProd(μ)/hookProd(μ\\c) = μ.card — corner recursion key lemma (1 sorry, verified for all special cases)",
+      "hookProd_ratio_formula: hookProd(μ)/hookProd(μ\\c) equals product over arm × product over leg (1 sorry: ~50 lines Finset.prod_union decomposition)",
+      "hook_walk_identity: sum over corners c of hookProd(μ)/hookProd(μ\\c) = μ.card — at-most-2-row case proved; ≥3-row case has 1 sorry (~300 lines GNW/RSK)",
       "hook_length_formula_general: HLF for all Young diagrams via corner induction (proved modulo hook_walk_identity, 0 sorries in the theorem itself)"
     ]
   },
@@ -67,7 +68,7 @@
     ]
   },
   "conclusion": {
-    "summary": "Hook-length formula fully proved for five infinite families: 1×n (direct), n×1 (direct), hook-shape (m+1,1) (bijection), 2×m rect (Lindstrom reflection), and general 2-row [a,b] (conditional on ballot bijection, 1 sorry). hookProd for [a,b] = (a+1).descFactorial(b) × (a-b)! × b! proved with 0 sorries. Part XIV (commit c0dcbcf81a) adds hook_length_formula_general as the primary result, proved via corner induction modulo hook_walk_identity (1 sorry), reducing from 3 sorries in the LGV approach to 1. Total: 4 sorries (3 LGV path + 1 corner induction).",
+    "summary": "Hook-length formula fully proved for five infinite families: 1×n (direct), n×1 (direct), hook-shape (m+1,1) (bijection), 2×m rect (Lindstrom reflection), and general 2-row [a,b] (conditional on ballot bijection, 1 sorry). hookProd for [a,b] = (a+1).descFactorial(b) × (a-b)! × b! proved with 0 sorries. Part XIV adds hook_length_formula_general as the primary result, proved via corner induction modulo hook_walk_identity. Total: 5 sorries (3 LGV path + 2 corner induction: hookProd_ratio_formula + hook_walk_identity ≥3-row).",
     "implications": "A complete formalization would be the first Lean 4 proof of the hook-length formula, a milestone in formal combinatorics. The LGV approach connects our existing ballot problem proofs to representation theory via the Specht module dimension formula f^λ = dim S^λ.",
     "openQuestions": [
       "Formalize the SYT ↔ NI bijection via Fomin's growth diagrams or the RSK correspondence (~200 lines)",
@@ -88,7 +89,7 @@
     "namespace": "HookLengthFormula",
     "lineCount": 4801,
     "axiomCount": 0,
-    "sorries": 4,
+    "sorries": 5,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",
     "theoremCount": 100,
     "definitionCount": 14
@@ -169,9 +170,9 @@
       "title": "Part XIV: hook_length_formula_general via Corner Induction",
       "startLine": 4600,
       "endLine": 4725,
-      "summary": "Proves hook_length_formula_general by well-founded induction on μ.card, using card_SYT_corner_step (Part XIII) + hook_walk_identity (1 sorry). hook_length_formula_Q is the ℚ version proved by WF induction.",
+      "summary": "Proves hook_length_formula_general by well-founded induction on μ.card, using card_SYT_corner_step (Part XIII) + hook_walk_identity (2 sorries: hookProd_ratio_formula + ≥3-row case). hook_length_formula_Q is the ℚ version proved by WF induction.",
       "mathContext": "hook_walk_identity: Σ_c hookProd(μ)/hookProd(μ\\c) = μ.card. The main theorem reduces to hook_length_formula_Q via exact_mod_cast."
     }
   ],
-  "sorries": 4
+  "sorries": 5
 }


### PR DESCRIPTION
## Audit Fix

**Proof**: ballot-problem-oq-03-oq-01-oq-02
**Issue**: sorry count mismatch — meta.json claimed 4 sorries, Lean file has 5

## Evidence

**meta.json claimed**: 4 sorries
**Lean file actual**: 5 sorries at lines 219, 235, 245, 4966, 4977

The 5th sorry (`hookProd_ratio_formula`, line 4966) was missing from the count. This is a private lemma proving the arm/leg product ratio identity that feeds into `hook_walk_identity`. The original description only counted `hook_walk_identity` as a single sorry but missed its prerequisite lemma.

## Changes

- `meta.sorries`: 4 → 5
- `leanFile.sorries`: 4 → 5
- Top-level `sorries`: 4 → 5
- `meta.assumptions`: Updated from "Four open sorries" to "Five open sorries", naming `hookProd_ratio_formula` explicitly
- `description`, `conclusion.summary`, section summary: Updated to reflect 5 sorries

---
Discovered during gallery integrity audit.