### PR TITLE
Fix: port missing derangements-convergence-oq-03 gallery entry to main

### DIFF
--- a/src/data/proofs/derangements-convergence-oq-03/annotations.json
+++ b/src/data/proofs/derangements-convergence-oq-03/annotations.json
@@ -1,0 +1,49 @@
+[
+  {
+    "id": "ann-dcoq03-helper",
+    "proofId": "derangements-convergence-oq-03",
+    "range": {
+      "startLine": 37,
+      "endLine": 42
+    },
+    "type": "concept",
+    "title": "Helper: n! · (1/(n+1)!) = 1/(n+1)",
+    "content": "The private lemma `factorial_mul_one_div_factorial_succ` computes n! · (1/(n+1)!) = 1/(n+1). This is the arithmetic bridge between the rate bound |D(n) - x| ≤ n! · (1/(n+1)!) (from multiplying the convergence rate by n!) and the clean upper bound 1/(n+1). The proof rewrites with Nat.factorial_succ to expand (n+1)! = (n+1)·n!, then uses push_cast, field_simp, ring.",
+    "mathContext": "$n! \\cdot \\frac{1}{(n+1)!} = n! \\cdot \\frac{1}{(n+1) \\cdot n!} = \\frac{1}{n+1}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.factorial_succ",
+      "field_simp",
+      "factorial arithmetic"
+    ],
+    "prerequisites": [
+      "Nat.factorial_succ: (n+1)! = (n+1) · n!",
+      "real number field arithmetic"
+    ]
+  },
+  {
+    "id": "ann-dcoq03-main",
+    "proofId": "derangements-convergence-oq-03",
+    "range": {
+      "startLine": 44,
+      "endLine": 88
+    },
+    "type": "theorem",
+    "title": "derangements_eq_round: D(n) = round(n!/e) for n ≥ 2",
+    "content": "The main theorem proves (numDerangements n : ℤ) = round(n! · rexp(-1)) for n ≥ 2. The proof has two phases:\n\n**Phase 1 (lines 54-72)**: Establish |D(n) − x| < 1/2 where x = n!/e. (1) Apply `derangements_convergence_rate n` to get |D(n)/n! − e⁻¹| ≤ 1/(n+1)!. (2) Rewrite the left side as |D(n) − x|/n! via field manipulation (abs_div, abs_of_pos). (3) Use div_le_iff to multiply both sides by n!, getting |D(n) − x| ≤ n!/(n+1)! = 1/(n+1) via the helper lemma. (4) From n ≥ 2: n+1 > 2, so 1/(n+1) < 1/2 via one_div_lt_one_div_of_lt.\n\n**Phase 2 (lines 74-86)**: Conclude D(n) = round(x). (1) Rewrite with round_eq: round x = ⌊x + 1/2⌋. (2) Apply floor_eq_iff: ⌊r⌋ = z ↔ z ≤ r ∧ r < z + 1. (3) Use abs_lt to split |D − x| < 1/2 into D − x < 1/2 and -(1/2) < D − x. (4) Both halves close with push_cast + linarith.",
+    "mathContext": "Let $x = n!/e$. Step 1: $|D(n)/n! - e^{-1}| \\leq 1/(n+1)!$, so $|D(n) - x| \\leq 1/(n+1) < 1/2$ for $n \\geq 2$. Step 2: Since $D(n) \\in \\mathbb{Z}$ and $|D(n) - x| < 1/2$, we have $\\lfloor x + 1/2 \\rfloor = D(n)$, i.e., $\\text{round}(x) = D(n)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "derangements_convergence_rate",
+      "round_eq",
+      "floor_eq_iff",
+      "abs_lt",
+      "one_div_lt_one_div_of_lt"
+    ],
+    "prerequisites": [
+      "derangements_convergence_rate from DerangementsConvergence.lean",
+      "Mathlib round and floor API",
+      "absolute value arithmetic in Lean 4"
+    ]
+  }
+]

--- a/src/data/proofs/derangements-convergence-oq-03/index.ts
+++ b/src/data/proofs/derangements-convergence-oq-03/index.ts
@@ -1,0 +1,8 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/DerangementsConvergenceOQ03.lean?raw'
+const meta = metaJson as unknown as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+export const derangementsConvergenceOq03Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections ?? [], source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
+export const derangementsConvergenceOq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+export const derangementsConvergenceOq03Data: ProofData = { proof: derangementsConvergenceOq03Proof, annotations: derangementsConvergenceOq03Annotations, tacticStates: [] }

--- a/src/data/proofs/derangements-convergence-oq-03/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-03/meta.json
@@ -1,0 +1,154 @@
+{
+  "id": "derangements-convergence-oq-03",
+  "title": "Derangements = round(n!/e)",
+  "slug": "derangements-convergence-oq-03",
+  "description": "Proves that the number of derangements of n elements equals the nearest integer to n!/e for all n ≥ 2. Uses the alternating-series rate bound |D(n)/n! − e⁻¹| ≤ 1/(n+1)! to show |D(n) − n!/e| ≤ 1/(n+1) < 1/2, which characterises D(n) as the unique integer nearest to n!/e.",
+  "meta": {
+    "author": "researcher",
+    "date": "2026-04-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DerangementsConvergenceOQ03.lean",
+    "tags": [
+      "combinatorics",
+      "derangements",
+      "rounding",
+      "exponential",
+      "number-theory",
+      "analysis",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "No assumptions. The theorem is fully machine-checked. The proof delegates the rate bound to derangements_convergence_rate from DerangementsConvergence.lean, which establishes |D(n)/n! - e⁻¹| ≤ 1/(n+1)! via the alternating series estimation theorem.",
+    "dateAdded": "2026-04-24",
+    "lineCount": 88,
+    "theoremCount": 1,
+    "definitionCount": 0,
+    "originalContributions": [
+      "derangements_eq_round (PROVED): For n ≥ 2, (numDerangements n : ℤ) = round(n! · rexp(-1))",
+      "factorial_mul_one_div_factorial_succ (helper): n! · (1/(n+1)!) = 1/(n+1), bridging the rate bound to the 1/(n+1) upper bound"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "derangements_convergence_rate",
+        "description": "Rate bound |D(n)/n! - e⁻¹| ≤ 1/(n+1)! from alternating series estimation",
+        "module": "Proofs.DerangementsConvergence"
+      },
+      {
+        "theorem": "round_eq",
+        "description": "round x = ⌊x + 1/2⌋ — used to reduce round characterisation to floor",
+        "module": "Mathlib.Algebra.Order.Round"
+      },
+      {
+        "theorem": "floor_eq_iff",
+        "description": "⌊r⌋ = z ↔ z ≤ r ∧ r < z + 1 — key for the final integer characterisation",
+        "module": "Mathlib.Algebra.Order.Floor"
+      },
+      {
+        "theorem": "abs_lt",
+        "description": "|a - b| < c ↔ b - c < a ∧ a < b + c — unpacks the absolute value bound",
+        "module": "Mathlib.Algebra.Abs"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The derangement number D(n) counts permutations with no fixed points. The classical formula D(n) = n! · Σ_{k=0}^n (−1)^k/k! leads immediately to D(n)/n! → e⁻¹ as n → ∞ (Montmort 1708, Euler 1751). A sharper consequence: since n!/e is never an integer (e is transcendental), the nearest integer to n!/e is uniquely determined, and it equals D(n) for all n ≥ 2. This elegant rounding characterisation is a standard result in combinatorics.",
+    "problemStatement": "**OQ-03 of derangements-convergence**\n\nProve that for n ≥ 2, the number of derangements D(n) equals the nearest integer to n!/e:\n\n  D(n) = round(n! · e⁻¹)\n\nEquivalently: |D(n) − n!/e| < 1/2 for all n ≥ 2.",
+    "text": "For n ≥ 2, (numDerangements n : ℤ) = round((n! : ℝ) · rexp(-1)).",
+    "proofStrategy": "**Three steps:**\n1. **Rate bound**: From `derangements_convergence_rate` (DerangementsConvergence.lean): |D(n)/n! − e⁻¹| ≤ 1/(n+1)!. Multiply both sides by n! to get |D(n) − n!/e| ≤ 1/(n+1).\n2. **Strict bound**: For n ≥ 2: n+1 ≥ 3 > 2, so 1/(n+1) < 1/2. Therefore |D(n) − n!/e| < 1/2.\n3. **Rounding characterisation**: D(n) is an integer with |D(n) − x| < 1/2 where x = n!/e, so D(n) = round(x). The proof uses `round_eq` (round x = ⌊x + 1/2⌋) and `floor_eq_iff` to reduce to two linear inequalities, closed by `linarith`.",
+    "keyInsights": [
+      "The multiplication n! × (1/(n+1)!) = 1/(n+1) is the key computation — the helper lemma factorial_mul_one_div_factorial_succ provides this in a form that linarith can use",
+      "The condition n ≥ 2 is tight: at n=1, D(1)=0 and 1!/e ≈ 0.368, and round(0.368) = 0, so the result holds — but the bound 1/(n+1) = 1/2 is not strict. The proof uses n+1 > 2 to get strict inequality.",
+      "The rounding characterisation bypasses the need to compute round(n!/e) explicitly: knowing |D(n) − n!/e| < 1/2 and D(n) ∈ ℤ uniquely determines D(n) = round(n!/e)",
+      "Using abs_lt to split |D − x| < 1/2 into two half-open intervals, then linarith closes both halves independently"
+    ],
+    "prerequisites": [
+      "derangements_convergence_rate from DerangementsConvergence.lean",
+      "round_eq and floor_eq_iff from Mathlib",
+      "Basic real arithmetic and factorial identities"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-helper",
+      "title": "Helper Lemma: Factorial Simplification",
+      "startLine": 37,
+      "endLine": 42,
+      "summary": "Private lemma factorial_mul_one_div_factorial_succ: n! · (1/(n+1)!) = 1/(n+1). Proof by rewriting with Nat.factorial_succ, push_cast, field_simp, ring.",
+      "mathContext": "$n! \\cdot \\frac{1}{(n+1)!} = \\frac{n!}{(n+1) \\cdot n!} = \\frac{1}{n+1}$."
+    },
+    {
+      "id": "sec-main",
+      "title": "Main Theorem: derangements_eq_round",
+      "startLine": 44,
+      "endLine": 88,
+      "summary": "For n ≥ 2, (numDerangements n : ℤ) = round(n! · rexp(-1)). Proof: (1) establish |D(n) − n!/e| < 1/2 using derangements_convergence_rate and the helper lemma; (2) apply round_eq + floor_eq_iff + abs_lt to reduce to two linarith goals.",
+      "mathContext": "Let $x = n! \\cdot e^{-1}$. The alternating-series bound gives $|D(n)/n! - e^{-1}| \\leq 1/(n+1)!$, so $|D(n) - x| \\leq n!/(n+1)! = 1/(n+1) < 1/2$ for $n \\geq 2$. Since $D(n) \\in \\mathbb{Z}$ with $|D(n) - x| < 1/2$, it follows $D(n) = \\text{round}(x)$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "derangements-convergence",
+      "relationship": "uses",
+      "description": "Imports derangements_convergence_rate: |D(n)/n! - e⁻¹| ≤ 1/(n+1)! via alternating series estimation"
+    },
+    {
+      "targetId": "derangements-convergence-oq-01",
+      "relationship": "sibling",
+      "description": "Sibling: proves P(X_n = k) → e⁻¹/k! (Poisson(1) marginals); this file proves the rounding characterisation of D(n)"
+    },
+    {
+      "targetId": "derangements",
+      "relationship": "related",
+      "description": "Root: basic derangement definitions D(n) = n! Σ(-1)^k/k! and inclusion-exclusion formula"
+    }
+  ],
+  "conclusion": {
+    "summary": "Machine-verified: for all n ≥ 2, D(n) = round(n!/e). The proof extracts a strict rounding bound from the alternating-series rate estimate, showing |D(n) − n!/e| < 1/2, which uniquely characterises D(n) as the nearest integer. Zero sorries, zero axioms.",
+    "implications": "**Computational convenience**: This gives a simple formula for D(n): compute n!/e and round to the nearest integer. For large n, floating-point arithmetic with sufficient precision gives D(n) exactly.\\n\\n**Tightness**: The bound 1/(n+1) approaches 1/2 from above as the bound deteriorates for n → 1 (at n = 2: 1/3, at n = 1: 1/2 exactly). The condition n ≥ 2 is tight for the strict inequality.\\n\\n**Connection to transcendence**: The rounding never ties (D(n) is never a half-integer offset from n!/e) because e is transcendental, so n!/e is never a half-integer.",
+    "openQuestions": [
+      "Prove the analogous result for subfactorials: D(n) = ⌊n!/e + 1/2⌋ (equivalent formulation via floor)",
+      "Extend to generalised derangements: D_k(n) (permutations with no k-cycles of a fixed type) — does a similar rounding characterisation hold?"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "derangements_eq_round",
+      "type": "core",
+      "description": "For n ≥ 2: (numDerangements n : ℤ) = round((n! : ℝ) · rexp(-1))",
+      "leanType": "(n : ℕ) → 2 ≤ n → (numDerangements n : ℤ) = round ((n.factorial : ℝ) * rexp (-1))"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.DerangementsConvergence"
+    ],
+    "opens": ["Nat", "Real", "Filter", "Topology"],
+    "namespace": "DerangementsConvergenceOQ03",
+    "lineCount": 88,
+    "axiomCount": 0,
+    "theoremCount": 1,
+    "substantiveTheoremCount": 1,
+    "duplicateTheorems": 0,
+    "definitionCount": 0,
+    "path": "Proofs/DerangementsConvergenceOQ03.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Pierre de Montmort",
+      "title": "Essay d'analyse sur les jeux de hazard",
+      "year": "1708",
+      "note": "First derivation of the derangement formula"
+    },
+    {
+      "authors": "Leonhard Euler",
+      "title": "Calcul de la probabilité dans le jeu de rencontre",
+      "year": "1751",
+      "note": "Standard reference for D(n)/n! → e⁻¹"
+    }
+  ]
+}


### PR DESCRIPTION
## Fix

Port the missing gallery entry for derangements-convergence-oq-03 from master to main.

## Evidence

**Before**: The Lean proof `DerangementsConvergenceOQ03.lean` exists in main (commit e5ca35dd09, PR #12294) but the gallery entry (meta.json, annotations.json, index.ts) was merged only to `master` in PR #12308. The gallery directory `src/data/proofs/derangements-convergence-oq-03/` is absent from `main`.

**After**: Gallery data present in main, derangements-convergence-oq-03 will appear in the gallery when built from main.

---
Automated fix by lean-mechanic agent.