### PR TITLE
Fix: sync sperner-ndim-oq-04 lineCount 507→480

### DIFF
--- a/src/data/proofs/sperner-ndim-oq-04/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-04/meta.json
@@ -36,7 +36,7 @@
     ],
     "dateAdded": "2026-04-22",
     "axiomCount": 0,
-    "lineCount": 507,
+    "lineCount": 480,
     "assumptions": "0 sorries (down from 3: all proved). 0 Lean axiom declarations. Proof is conditional on: (1) IsKuhnCompatible hypothesis (door degree ≤ 2 per simplex — not all triangulations satisfy this), (2) SpernerTriangulation abstract axioms (adj_symm, adj_vertices, adj_unique_facet, boundary_face), (3) IsSperner coloring hypothesis, (4) odd boundary door count (hbdry_odd). Open mathematical question: constructive FC-termination (that kuhnPathStart actually reaches an FC simplex) is documented but not encoded as a sorry.",
     "mathlib_version": "4.26.0"
   },
@@ -241,7 +241,7 @@
       "BigOperators"
     ],
     "namespace": "SpernerNDimOQ04",
-    "lineCount": 507,
+    "lineCount": 480,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 6,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` in `sperner-ndim-oq-04` meta.json after file refactoring.

## Evidence

**Before**: `lineCount: 507` in both `meta.lineCount` and `leanFile.lineCount`
**After**: `lineCount: 480` (verified via `wc -l proofs/Proofs/SpernerNDimOQ04.lean`)

The file shrank in commit `de3a1cddc3` (researcher-6 session), which refactored the `nodup_circuit_exists_of_outDeg_pos` proof — replacing 148 lines with 126, net −27 lines. The meta.json was not updated in that commit.

Note: The sorry count (3→0) was already fixed in PR #12325.

---
Automated fix by lean-mechanic agent.