### PR TITLE
Fix: sync stale lineCount in 3 gallery entries after research merges

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -23,7 +23,7 @@
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
     "assumptions": "Five open sorries: (1) hook_length_formula (LGV approach: requires SYT↔NI bijection + det factorization), (2) ni_count_eq_syt_count (Fomin/Viennot/RSK correspondence), (3) lgv_det_factors_as_hook_quotient (det factorization identity), (4) hookProd_ratio_formula (corner induction prerequisite: product ratio identity over arm/leg cells, ~50 lines), (5) hook_walk_identity ≥3-row case (GNW or RSK, ~300 lines; at-most-2-row case proved). hook_length_formula_general is proved modulo hook_walk_identity via Part XIV corner induction.",
-    "lineCount": 4801,
+    "lineCount": 5056,
     "theoremCount": 162,
     "definitionCount": 14,
     "originalContributions": [
@@ -87,7 +87,7 @@
       "LGV"
     ],
     "namespace": "HookLengthFormula",
-    "lineCount": 4801,
+    "lineCount": 5056,
     "axiomCount": 0,
     "sorries": 5,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",

--- a/src/data/proofs/konigsberg-oq-02-oq-01/meta.json
+++ b/src/data/proofs/konigsberg-oq-02-oq-01/meta.json
@@ -22,7 +22,7 @@
     "dateAdded": "2026-04-24",
     "axiomCount": 0,
     "assumptions": "0 sorries. Proof complete: Hierholzer WF induction, nodup_circuit_exists + vertex_with_unused_arc fully proved. Awaiting Docker build verification.",
-    "lineCount": 954,
+    "lineCount": 992,
     "theoremCount": 6,
     "definitionCount": 1,
     "originalContributions": [
@@ -61,7 +61,7 @@
   },
   "leanFile": {
     "namespace": "KonigsbergOQ02OQ01",
-    "lineCount": 954,
+    "lineCount": 992,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 1,

--- a/src/data/proofs/sperner-ndim-oq-04/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-04/meta.json
@@ -36,7 +36,7 @@
     ],
     "dateAdded": "2026-04-22",
     "axiomCount": 0,
-    "lineCount": 507,
+    "lineCount": 480,
     "assumptions": "0 sorries (down from 3: all proved). 0 Lean axiom declarations. Proof is conditional on: (1) IsKuhnCompatible hypothesis (door degree ≤ 2 per simplex — not all triangulations satisfy this), (2) SpernerTriangulation abstract axioms (adj_symm, adj_vertices, adj_unique_facet, boundary_face), (3) IsSperner coloring hypothesis, (4) odd boundary door count (hbdry_odd). Open mathematical question: constructive FC-termination (that kuhnPathStart actually reaches an FC simplex) is documented but not encoded as a sorry.",
     "mathlib_version": "4.26.0"
   },
@@ -241,7 +241,7 @@
       "BigOperators"
     ],
     "namespace": "SpernerNDimOQ04",
-    "lineCount": 507,
+    "lineCount": 480,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 6,


### PR DESCRIPTION
## Fix

Sync stale lineCount metadata after recent research PRs extended these Lean files.

## Evidence

| Proof | Before | After |
|-------|--------|-------|
| ballot-problem-oq-03-oq-01-oq-02 | 4801 | 5056 |
| konigsberg-oq-02-oq-01 | 954 | 992 |
| sperner-ndim-oq-04 | 507 | 480 |

Caused by:
- **ballot**: PR #12309 added Hook-length formula infrastructure (+255 lines)
- **konigsberg**: PR #12301 completed Hierholzer proof (+38 lines)
- **sperner-ndim**: PR #12325 removed sorry placeholders (-27 lines)

---
Automated fix by lean-mechanic agent.