### PR TITLE
Enrich abel-ruffini-galois-extensions: fix annotation overlap, add 2 references

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions/annotations.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions/annotations.json
@@ -351,28 +351,27 @@
     "proofId": "abel-ruffini-galois-extensions",
     "range": {
       "startLine": 219,
-      "endLine": 248
+      "endLine": 235
     },
     "type": "insight",
-    "title": "Galois Group Order = Extension Degree, and Subgroup Solvability",
-    "content": "Two foundational results linking abstract Galois theory to concrete computation. (1) `galois_group_order`: for a finite Galois extension $E/F$, the order of the automorphism group $|\\text{Aut}(E/F)|$ equals the extension degree $[E:F]$. This is `IsGalois.card_aut_eq_finrank` — the fundamental theorem of Galois theory in numerical form. In the context of Abel-Ruffini, it means that a quintic with Galois group $S_5$ necessarily generates a degree-120 extension (since $|S_5| = 120$), which cannot be built from a radical tower (each step of which is a prime-degree extension). (2) `subgroup_solvable_of_solvable`: subgroups of solvable groups are solvable, proved trivially by `inferInstance` — Mathlib's typeclass system automatically derives `IsSolvable H` from `IsSolvable G` whenever $H \\leq G$. This closure property is essential: to conclude the Galois group of a subextension is solvable, one only needs to know the top group is solvable.",
-    "mathContext": "$|\\text{Gal}(E/F)| = [E:F]$ for finite Galois extensions (fundamental theorem). Subgroup inheritance: $H \\leq G$, $G$ solvable $\\Rightarrow H$ solvable (the derived series of $H$ is contained in the derived series of $G$: $H^{(k)} \\leq G^{(k)}$). Consequence: if $\\text{Gal}(E/F)$ is solvable, every intermediate subextension $E/K/F$ has solvable Galois group $\\text{Gal}(E/K) \\leq \\text{Gal}(E/F)$.",
+    "title": "Galois Group Order Equals Extension Degree",
+    "content": "The `GaloisProperties` section (Part V, lines 221–235) establishes the fundamental numerical form of Galois theory. `galois_group_order`: for a finite Galois extension $E/F$, the order of the automorphism group $|\\text{Aut}(E/F)|$ equals the extension degree $[E:F]$. This is `IsGalois.card_aut_eq_finrank` — the fundamental theorem of Galois theory stated numerically. In the Abel-Ruffini context, it means that a quintic with Galois group $S_5$ necessarily generates a degree-120 extension (since $|S_5| = 120$), which cannot be built from a radical tower (each step of which multiplies the degree by a prime). The theorem requires both `FiniteDimensional F E` (the extension has finite degree) and `IsGalois F E` (the extension is normal and separable) — both are necessary for the order equality. The numerical form enables computing Galois group orders from extension degrees: if $[E:\\mathbb{Q}] = 120$ and $E/\\mathbb{Q}$ is Galois, then $|\\text{Gal}(E/\\mathbb{Q})| = 120$. Combined with the classification that $S_n$ is not solvable for $n \\geq 5$ (and $|S_5| = 120$), this provides the arithmetic bridge from the degree of a polynomial to the solvability of its Galois group.",
+    "mathContext": "$|\\text{Gal}(E/F)| = [E:F]$ for finite Galois extensions. Equivalently: `Nat.card (E ≃ₐ[F] E) = Module.finrank F E`. Consequence: for a degree-$n$ irreducible polynomial $f$ with splitting field $E$ and Galois extension $E/\\mathbb{Q}$, the Galois group $\\text{Gal}(f/\\mathbb{Q}) \\leq S_n$ has order dividing $n!$. If the extension degree equals $n!$ (e.g., $120 = 5!$ for the companion quintic $x^5 - 4x + 2$), the Galois group is all of $S_n$.",
     "significance": "supporting",
     "relatedConcepts": [
       "Galois group",
       "extension degree",
       "IsGalois",
-      "IsSolvable",
-      "subgroup solvability",
-      "Galois correspondence",
-      "card_aut_eq_finrank"
+      "card_aut_eq_finrank",
+      "radical tower",
+      "fundamental theorem of Galois theory"
     ],
     "prerequisites": [
       "Galois extensions",
       "field extensions",
       "automorphism groups",
-      "solvable groups",
-      "typeclass inference in Lean"
+      "Module.finrank",
+      "IsGalois typeclass"
     ]
   },
   {

--- a/src/data/proofs/abel-ruffini-galois-extensions/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions/meta.json
@@ -199,6 +199,25 @@
       "year": "1995",
       "venue": "Springer GTM 148, 4th edition",
       "note": "Chapter 5: solvable groups, composition series, Jordan-Hölder theorem — the algebraic foundation for this formalization"
+    },
+    {
+      "authors": [
+        "F. Klein"
+      ],
+      "title": "Vorlesungen über das Ikosaeder und die Auflösung der Gleichungen vom fünften Grade",
+      "year": "1884",
+      "venue": "Teubner, Leipzig",
+      "note": "Klein's icosahedral theory: A₅ ≅ PSL(2,5) ≅ I (icosahedral rotation group) and the reduction of the quintic to icosahedral geometry. The geometric face of A₅'s simplicity referenced in this file's keyInsights."
+    },
+    {
+      "authors": [
+        "W. Feit",
+        "J. G. Thompson"
+      ],
+      "title": "Solvability of Groups of Odd Order",
+      "year": "1963",
+      "venue": "Pacific Journal of Mathematics 13(3): 775–1029",
+      "note": "Every finite group of odd order is solvable — directly constrains the classification: A₅ (order 60, even) is the smallest non-solvable group, consistent with Feit-Thompson since all odd-order groups are solvable. Referenced in the conclusion implications."
     }
   ],
   "sections": [


### PR DESCRIPTION
Enrichment pass for abel-ruffini-galois-extensions. Quality improvements:

**Annotation fix:**
- Fixed `arg-galois-order-subgroup` range overlap with `arg-subgroup-solvability` (both previously covered lines 237-248). Adjusted `arg-galois-order-subgroup` end from 248 → 235, scoping it to Part V (GaloisProperties) only. Updated content to focus on `card_aut_eq_finrank` and its arithmetic implication: a quintic with Galois group S₅ generates a degree-120 extension.

**New references:**
- Added Felix Klein (1884) *Vorlesungen über das Ikosaeder* — the icosahedral geometry of quintic solvability (A₅ ≅ I), cited in keyInsights
- Added Feit-Thompson (1963) *Solvability of Groups of Odd Order* (Pacific J. Math.) — cited in conclusion implications for odd-order constraint on non-solvable groups

🤖 Generated with [Claude Code](https://claude.com/claude-code)