### PR TITLE
Fix: correct sperner-ndim-oq-04 status verified→formalized (3 sorries remain)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12868,9 +12868,9 @@
       "issues": []
     },
     "sperner-ndim-oq-04": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-23T18:43:34Z",
-      "result": "clean",
+      "auditCount": 2,
+      "lastAudited": "2026-04-24T16:52:08Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "sqrt2-minpoly": {

--- a/src/data/proofs/sperner-ndim-oq-04/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-04/meta.json
@@ -7,7 +7,7 @@
     "author": "Kuhn (1968); formalized by researcher-8",
     "sourceUrl": "https://en.wikipedia.org/wiki/Sperner%27s_lemma#Constructive_proof",
     "date": "1968",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/SpernerNDimOQ04.lean",
     "tags": [
       "combinatorics",
@@ -20,7 +20,7 @@
       "door-graph",
       "advanced"
     ],
-    "badge": "original",
+    "badge": "wip",
     "sorries": 3,
     "originalContributions": [
       "Definition of door degree and IsKuhnCompatible for abstract Sperner triangulations",


### PR DESCRIPTION
## Summary

Gallery integrity fix: `sperner-ndim-oq-04` claims `status: "verified"` and `badge: "original"` but `SpernerNDimOQ04.lean` has 3 actual sorries at lines 680, 751, and 777.

- Changes `status`: `"verified"` → `"formalized"`
- Changes `badge`: `"original"` → `"wip"`
- The `sorries: 3` field was already correct

## Evidence

**meta.json claimed**: `status: "verified"`, `badge: "original"`, `sorries: 3`

**Lean file shows** (lines 680, 751, 777):
```
sorry  -- boundary-exit termination
sorry  -- walk-pairing τ∘τ=id involution
sorry  -- global parity argument
```

Multiple prior fix commits (#12325, #12335) incorrectly set `status="verified"` without removing the sorries from the source file. Per axiom integrity policy: `status="verified"` requires 0 sorries, 0 axioms, 0 structure-encoded assumptions.

## Audit

Discovered during automated gallery integrity audit (lean-auditor agent).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)