### PR TITLE
Fix: sperner-ndim-oq-04 status verified→formalized (3 sorries remain)

### DIFF
--- a/src/data/proofs/sperner-ndim-oq-04/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-04/meta.json
@@ -7,7 +7,7 @@
     "author": "Kuhn (1968); formalized by researcher-8",
     "sourceUrl": "https://en.wikipedia.org/wiki/Sperner%27s_lemma#Constructive_proof",
     "date": "1968",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/SpernerNDimOQ04.lean",
     "tags": [
       "combinatorics",
@@ -20,7 +20,7 @@
       "door-graph",
       "advanced"
     ],
-    "badge": "original",
+    "badge": "wip",
     "sorries": 3,
     "originalContributions": [
       "Definition of door degree and IsKuhnCompatible for abstract Sperner triangulations",


### PR DESCRIPTION
## Summary

- `src/data/proofs/sperner-ndim-oq-04/meta.json` was incorrectly claiming `status: verified` and `badge: original`
- The actual Lean file `proofs/Proofs/SpernerNDimOQ04.lean` has 3 sorries at lines 680, 751, 777 (confirmed via `git show origin/main:proofs/Proofs/SpernerNDimOQ04.lean | grep -n sorry`)
- Per the axiom integrity policy, `status="verified"` requires 0 sorries — this is a CRITICAL integrity violation

## Fix

Two-field surgical change in `src/data/proofs/sperner-ndim-oq-04/meta.json`:
- `"status": "verified"` → `"status": "formalized"`
- `"badge": "original"` → `"badge": "wip"`

The `"sorries": 3` field was already correct and was not changed.

## Root Cause

PR #12335 incorrectly upgraded status to `verified` despite 3 sorries remaining. A prior fix (PR #12263) corrected this but was subsequently dropped when main was rebased/reset. This PR re-applies that correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)