### PR TITLE
Fix: sync ballot-problem-oq-03-oq-01-oq-01-oq-01 sorries 2→1

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "ballot-problem-oq-03-oq-01-oq-01-oq-01",
   "title": "Jacobi-Trudi Identity: Schur Polynomials as Determinants of Complete Homogeneous Symmetric Polynomials",
   "slug": "ballot-problem-oq-03-oq-01-oq-01-oq-01",
-  "description": "Defines Schur polynomials via the Jacobi-Trudi determinant formula and the SSYT generating function. Proves key properties (symmetry, base cases, two-row formula, hook-length evaluation) and defines the SSYT type SSYTFin with k=0 base case proved. The general Jacobi-Trudi = SSYT equality and k=1 case remain open (RSK correspondence, ~300 lines).",
+  "description": "Defines Schur polynomials via the Jacobi-Trudi determinant formula and the SSYT generating function. Proves key properties (symmetry, base cases, two-row formula, hook-length evaluation, k=1 SSYT bijection) and defines the SSYT type SSYTFin with k=0 and k=1 base cases proved. The general Jacobi-Trudi = SSYT equality remains open for k ≥ 2 (RSK correspondence, ~300 lines).",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-24",
@@ -19,11 +19,11 @@
       "ssyt"
     ],
     "badge": "formalized",
-    "sorries": 2,
+    "sorries": 1,
     "dateAdded": "2026-04-23",
     "axiomCount": 0,
-    "assumptions": "2 sorries for open cases: (1) ssytSchurFin_one_row: k=1 case requires bijection SSYTFin n 1 (fun _ => m) ≃ Sym (Fin n) m via sorted multiset representatives (List.sortedLE_ofFn_iff: Monotone ↔ SortedLE); (2) jacobi_trudi_ssyt_eq: general Jacobi-Trudi equality schurPolynomial = ssytSchurFin via RSK correspondence (~300 lines). All other theorems proved: symmetry (AlgHom.map_det), base cases, two-row formula, hook-length evaluation, SSYT k=0 base case (unique empty SSYT, empty product = 1).",
-    "lineCount": 272,
+    "assumptions": "1 sorry for the open case: jacobi_trudi_ssyt_eq: general Jacobi-Trudi equality schurPolynomial = ssytSchurFin via RSK correspondence (~300 lines) for k ≥ 2. All other theorems proved: symmetry (AlgHom.map_det), base cases, two-row formula, hook-length evaluation, SSYT k=0 base case (unique empty SSYT, empty product = 1), SSYT k=1 case (bijection SSYTFin n 1 (fun _ => m) ≃ Sym (Fin n) m via sorted multiset representatives).",
+    "lineCount": 313,
     "theoremCount": 10,
     "definitionCount": 5,
     "originalContributions": [
@@ -58,11 +58,10 @@
     ]
   },
   "conclusion": {
-    "summary": "Defines Schur polynomials via both Jacobi-Trudi formula and SSYT generating function. Proves symmetry, base cases (k=0,1 for both definitions), two-row formula, and hook-length evaluation. 2 sorries: ssytSchurFin_one_row (k=1 bijection via sorted multisets) and jacobi_trudi_ssyt_eq (general RSK proof).",
-    "implications": "This provides: (1) the first Lean 4 Jacobi-Trudi matrix definition, (2) the first Lean 4 SSYT type for arbitrary partition shapes with Fintype instance, (3) the first formal statement that det[h_{λᵢ-i+j}] = Σ_T weight(T) as a meaningful theorem. The 2 open sorries precisely identify the RSK correspondence (~300 lines) as the key missing ingredient. A completed formalization would unlock: the Pieri rule $s_\\lambda h_n = \\sum_\\mu s_\\mu$, the Murnaghan-Nakayama rule, and connections to Schubert calculus via the existing LGV infrastructure in the gallery.",
+    "summary": "Defines Schur polynomials via both Jacobi-Trudi formula and SSYT generating function. Proves symmetry, base cases (k=0,1 for both definitions), two-row formula, hook-length evaluation, and the k=1 SSYT bijection. 1 sorry: jacobi_trudi_ssyt_eq (general RSK proof for k ≥ 2).",
+    "implications": "This provides: (1) the first Lean 4 Jacobi-Trudi matrix definition, (2) the first Lean 4 SSYT type for arbitrary partition shapes with Fintype instance, (3) the first formal statement that det[h_{λᵢ-i+j}] = Σ_T weight(T) as a meaningful theorem. The remaining sorry precisely identifies the RSK correspondence for k ≥ 2 (~300 lines) as the key missing ingredient. A completed formalization would unlock: the Pieri rule $s_\\lambda h_n = \\sum_\\mu s_\\mu$, the Murnaghan-Nakayama rule, and connections to Schubert calculus via the existing LGV infrastructure in the gallery.",
     "openQuestions": [
-      "Prove ssytSchurFin_one_row: bijection SSYTFin n 1 (fun _ => m) ≃ Sym (Fin n) m via Multiset.sort and List.sortedLE_ofFn_iff (Monotone ↔ SortedLE)",
-      "Prove jacobi_trudi_ssyt_eq (general case): RSK correspondence SSYT ↔ NI lattice path tuples for the LGV configuration, then weight matching with hsymm products"
+      "Prove jacobi_trudi_ssyt_eq (general case, k ≥ 2): RSK correspondence SSYT ↔ NI lattice path tuples for the LGV configuration, then weight matching with hsymm products"
     ]
   },
   "leanFile": {
@@ -79,12 +78,12 @@
       "Finset"
     ],
     "namespace": "JacobiTrudi",
-    "lineCount": 272,
+    "lineCount": 313,
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 5,
     "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
-    "sorries": 2
+    "sorries": 1
   },
   "crossReferences": [
     {
@@ -167,9 +166,9 @@
       "title": "Part VI: SSYT Definition and Jacobi-Trudi Equality",
       "startLine": 160,
       "endLine": 272,
-      "summary": "Defines SSYTFin (bounded SSYT type with Fintype instance), ssytSchurFin (SSYT generating function), proves ssytSchurFin_empty (k=0), states ssytSchurFin_one_row (k=1, sorry) and jacobi_trudi_ssyt_eq (general, sorry).",
-      "mathContext": "SSYTFin n k sh = subtype of ((i:Fin k)×Fin(sh i)→Fin n) satisfying row-weak (weakly increasing rows) and col-strict (strictly increasing columns). Fintype instance via Subtype.fintype (decidable predicates over finite types). ssytSchurFin = ∑_T T.weight where T.weight = ∏_p X(T p). k=0 proved by Unique (empty SSYT, both conditions vacuous) + IsEmpty (empty product = 1). k=1 requires bijection with Sym (Fin n) m via List.sortedLE_ofFn_iff. General case: RSK correspondence (~300 lines)."
+      "summary": "Defines SSYTFin (bounded SSYT type with Fintype instance), ssytSchurFin (SSYT generating function), proves ssytSchurFin_empty (k=0), proves ssytSchurFin_one_row (k=1, bijection via sorted multiset reps), and states jacobi_trudi_ssyt_eq (general, sorry for k ≥ 2).",
+      "mathContext": "SSYTFin n k sh = subtype of ((i:Fin k)×Fin(sh i)→Fin n) satisfying row-weak (weakly increasing rows) and col-strict (strictly increasing columns). Fintype instance via Subtype.fintype (decidable predicates over finite types). ssytSchurFin = ∑_T T.weight where T.weight = ∏_p X(T p). k=0 proved by Unique (empty SSYT, both conditions vacuous) + IsEmpty (empty product = 1). k=1 proved via Fintype.sum_equiv with bijection ψ: SSYTFin n 1 ≃ Sym (Fin n) m using List.sortedLE_ofFn_iff (Monotone ↔ SortedLE). General case (k ≥ 2): RSK correspondence (~300 lines), 1 sorry remains."
     }
   ],
-  "sorries": 2
+  "sorries": 1
 }


### PR DESCRIPTION
## Summary

- `ssytSchurFin_one_row` (k=1 SSYT bijection via sorted multiset representatives) was fully proved in the Lean file but meta.json still listed it as an open sorry
- Corrects `sorries: 2 → 1` and updates all related description/assumption/conclusion text
- Syncs `lineCount: 272 → 313` to match actual file length

## Evidence

**meta.json claimed**: 2 sorries (ssytSchurFin_one_row + jacobi_trudi_ssyt_eq)
**Lean file shows**: 1 sorry (only jacobi_trudi_ssyt_eq at line 311)

`ssytSchurFin_one_row` is proved at lines 239–291 via `Fintype.sum_equiv` with an explicit bijection `ψ : SSYTFin n 1 ≃ Sym (Fin n) m` using `List.sortedLE_ofFn_iff`.

## Test plan
- [x] `grep -c sorry proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean` returns 1
- [x] All `"sorries"` fields in meta.json now read 1
- [x] Assumptions and descriptions updated to reflect the proved k=1 case

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)