### PR TITLE
Fix: sync lebesgue-measure-oq-06 sorries 4→3, lineCount 559→741

### DIFF
--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -18,10 +18,10 @@
       "research"
     ],
     "badge": "wip",
-    "sorries": 4,
+    "sorries": 3,
     "axiomCount": 0,
-    "lineCount": 559,
-    "assumptions": "4 sorries: hausdorff_free_subgroup (Hausdorff 1914 — SO(3) contains F₂), banach_tarski (Banach-Tarski 1924 — main paradox, requires AC), banach_tarski_pieces_nonmeasurable (classical non-measurability corollary), int_amenable (Markov-Kakutani — ℤ amenable via Cesàro means/ultrafilter). Core framework fully proved including paradoxical_no_finite_measure (proved via finite additivity monotonicity) and free_group_not_amenable.",
+    "lineCount": 741,
+    "assumptions": "3 sorries: hausdorff_free_subgroup (Hausdorff 1914 — SO(3) contains F₂), banach_tarski (Banach-Tarski 1924 — main paradox, requires AC), banach_tarski_pieces_nonmeasurable (classical non-measurability corollary). Core framework fully proved including paradoxical_no_finite_measure (proved via finite additivity monotonicity), free_group_not_amenable, and int_amenable (ℤ amenable, proved via ultrafilter Cesàro mean with translation invariance via window-shift argument).",
     "dateAdded": "2026-04-22",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -102,12 +102,12 @@
       "title": "§VI: Amenability and the Group-Theoretic Source",
       "startLine": 249,
       "endLine": 295,
-      "summary": "Defines amenable groups. States int_amenable (ℤ is amenable via Cesàro means, sorry). Proves free_group_not_amenable (F₂ non-amenable via paradoxical decomposition — fully proved, no sorry). Closes the BanachTarski namespace.",
+      "summary": "Defines amenable groups. Proves int_amenable (ℤ is amenable via ultrafilter Cesàro mean — fully proved, no sorry) and free_group_not_amenable (F₂ non-amenable via paradoxical decomposition — fully proved, no sorry). Closes the BanachTarski namespace.",
       "mathContext": "A group $G$ is amenable iff $\\exists \\mu: 2^G \\to [0,\\infty]$ with $\\mu(G)=1$, $\\mu(A \\cup B) = \\mu(A) + \\mu(B)$ for disjoint $A, B$, and $\\mu(gA) = \\mu(A)$ for all $g \\in G$. Abelian groups are amenable (via Markov-Kakutani). $F_2$ is not amenable: $F_2 = W(a) \\sqcup aW(a^{-1})$ and $F_2 = W(b) \\sqcup bW(b^{-1})$ give two paradoxical coverings. `int_amenable` can likely be proved using Mathlib's Hahn-Banach (`NormedSpace.HahnBanach`) to construct a Banach limit extending the Cesàro mean on $\\ell^\\infty(\\mathbb{Z})$."
     }
   ],
   "conclusion": {
-    "summary": "The Banach-Tarski paradox is formalized with 4 sorries and 0 axioms. The abstract framework (equidecomposability, paradoxical sets, F₂ non-amenability) is fully proved — including complete machine-checked proofs of paradoxical_no_finite_measure (proved via finite additivity monotonicity) and free_group_not_amenable. The 4 remaining sorry theorems represent deep established results (Hausdorff 1914, Banach-Tarski 1924, Markov-Kakutani) whose Lean proofs require 150–800 lines each.",
+    "summary": "The Banach-Tarski paradox is formalized with 3 sorries and 0 axioms. The abstract framework (equidecomposability, paradoxical sets, F₂ non-amenability) is fully proved — including complete machine-checked proofs of paradoxical_no_finite_measure (proved via finite additivity monotonicity), free_group_not_amenable, and int_amenable (ℤ amenable via ultrafilter Cesàro mean). The 3 remaining sorry theorems represent deep established results (Hausdorff 1914, Banach-Tarski 1924) whose Lean proofs require 300–800 lines each.",
     "openQuestions": [
       "Can Hausdorff's free subgroup theorem be fully formalized in Lean? The proof requires showing that explicit 3×3 rotation matrices $\\varphi$ (rotation by $\\arccos(1/3)$ around the $z$-axis) and $\\psi$ (rotation by $\\arccos(1/3)$ around the $x$-axis) generate a free group of rank 2 in $\\text{SO}(3)$. The algebraic argument shows that nontrivial words $w(\\varphi, \\psi)$ applied to $e_1 = (1, 0, 0)$ produce vectors with coordinates in $\\mathbb{Z}[1/3, \\sqrt{2}/3]$ that are non-zero — requiring careful case analysis on the word structure and number-theoretic properties of $\\arccos(1/3)$ (specifically that it is not a rational multiple of $\\pi$).",
       "Can the full Banach-Tarski proof be formalized in Lean 4? The most likely modular path: (1) formalize the free subgroup freeness (the sorry in `hausdorff_free_subgroup`); (2) prove the paradoxical decomposition of $F_2$ acting on itself (purely algebraic, ~100 lines); (3) lift to $S^2 \\setminus D$ via the free group action (~150 lines); (4) handle the exceptional set $D$ via a rotation of infinite order (Hilbert hotel, ~100 lines); (5) extend from $S^2$ to $B^3$ by coning and handling the center (~100 lines). Estimated total: 800–1200 lines.",
@@ -202,12 +202,12 @@
       "Mathlib"
     ],
     "namespace": "BanachTarski",
-    "lineCount": 559,
+    "lineCount": 741,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 5,
     "path": "Proofs/LebesgueMeasureOQ06.lean",
-    "sorries": 4
+    "sorries": 3
   },
-  "sorries": 4
+  "sorries": 3
 }


### PR DESCRIPTION
## Fix

Sync lebesgue-measure-oq-06 meta.json after int_amenable was proved in commit e5fb59e7b2 (PR #12341) but meta.json was not updated.

## Evidence

**Before**:
- `sorries`: 4 (hausdorff_free_subgroup, banach_tarski, banach_tarski_pieces_nonmeasurable, int_amenable)
- `leanFile.lineCount`: 559

**After**:
- `sorries`: 3 (hausdorff_free_subgroup, banach_tarski, banach_tarski_pieces_nonmeasurable)  
- `leanFile.lineCount`: 741

**Root cause**: PR #12341 proved `int_amenable` translation invariance via window-shift argument (adding ~182 lines), but did not update meta.json. The actual file now has exactly 3 code sorries (verified by inspection at lines 184, 226, 239).

Updated fields: `meta.sorries`, `meta.lineCount`, `meta.assumptions`, `sections` (amenability summary), `conclusion.summary`, `leanFile.lineCount`, `leanFile.sorries`, and top-level `sorries`.

---
Automated fix by lean-mechanic agent.