### PR TITLE
Enrich erdos-1155-oq-02: add references, annotations, deeper context

### DIFF
--- a/src/data/proofs/erdos-1155-oq-02/annotations.json
+++ b/src/data/proofs/erdos-1155-oq-02/annotations.json
@@ -1,15 +1,116 @@
 [
   {
+    "id": "ann-oq02-module-header",
+    "proofId": "erdos-1155-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 52
+    },
+    "type": "context",
+    "title": "Module Header: Problem Setup and Axiom Declarations",
+    "content": "The module docstring frames the question: given the triangle removal process output has $f(n) = n^{3/2+o(1)}$ edges (BFL 2015) and Turán's theorem gives $n^2/4$ as the triangle-free maximum, how large is the gap $n^2/4 \\, / \\, f(n)$? The file imports Mathlib's `Combinatorics.SimpleGraph.Extremal.Turan` (containing `CliqueFree.card_edgeFinset_le`) and `Analysis.SpecialFunctions.Pow.Real` (rpow arithmetic), then imports `Proofs.Erdos1155OQ01` to inherit the BFL axioms and `triangleRemovalEdges` definition.\n\nLines 40–50 contain the docstring for Part I, explaining Mathlib's formulation of Turán's theorem: `CliqueFree.card_edgeFinset_le` with `r=2` gives a bound with residue correction terms (`(n%2)^2/4 + C(n%2, 2)`), which simplify to $\\lfloor n^2/4 \\rfloor$ for `n%2 ∈ {0,1}`.",
+    "mathContext": "$\\text{ex}(n, K_3) = \\lfloor n^2/4 \\rfloor$ (Turán 1941). In Lean: `CliqueFree.card_edgeFinset_le (r := 2)` gives $|E| \\leq (n^2 - (n \\mod 2)^2)/4 + \\binom{n \\mod 2}{2}$. For $n \\mod 2 \\in \\{0,1\\}$: $\\binom{n \\mod 2}{2} = 0$ and $(n \\mod 2)^2 \\leq n^2$, so the bound reduces to $\\lfloor n^2/4 \\rfloor \\leq n^2/4$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "CliqueFree.card_edgeFinset_le",
+      "triangleRemovalEdges",
+      "bfl_upper_bound",
+      "bfl_lower_bound",
+      "Erdos1155OQ01"
+    ],
+    "prerequisites": [
+      "Erdős #1155 parent formalization",
+      "BFL axioms for f(n)",
+      "Turán's theorem statement",
+      "Lean 4 import system"
+    ]
+  },
+  {
+    "id": "ann-oq02-density-definition",
+    "proofId": "erdos-1155-oq-02",
+    "range": {
+      "startLine": 91,
+      "endLine": 129
+    },
+    "type": "definition",
+    "title": "Turán Density Definition and Basic Properties",
+    "content": "The `turanDensity` function is defined noncomputably (line 104): $\\delta(n) = f(n) / (n^2/4)$ for $n > 0$, and $0$ for $n = 0$ (to avoid division by zero). Three foundational lemmas follow:\n\n- **`turanDensity_eq`** (lines 108–113): $\\delta(n) = 4f(n)/n^2$, proved by `field_simp` after establishing $n^2 \\neq 0$ via `positivity`. This equivalent form is algebraically convenient since it avoids nested division.\n\n- **`turanDensity_mem_Icc`** (lines 115–128): $\\delta(n) \\in [0,1]$ for all $n$. Lower bound: $f(n) \\geq 0$ (`triangleRemovalEdges_nonneg`). Upper bound: $f(n) \\leq n^2/4$ (`triangleRemovalEdges_le_turan_exact` axiom). The `div_le_one` rewrite reduces $\\delta(n) \\leq 1$ to $f(n) \\leq n^2/4$.\n\nThese three lemmas are infrastructure for the main squeeze argument in `turanDensity_tendsto_zero`.",
+    "mathContext": "$\\delta(n) = f(n) / (n^2/4) \\in [0,1]$. The [0,1] bound uses $0 \\leq f(n) \\leq n^2/4$. The equivalent form $\\delta(n) = 4f(n)/n^2$ is obtained by clearing the denominator $n^2/4 \\cdot (n^2) = n^2/4 \\cdot n^2/n^2 \\cdot n^2$... actually just $4f(n)/n^2 = f(n)/(n^2/4)$ since dividing by $n^2/4$ is the same as multiplying by $4/n^2$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "turanDensity",
+      "triangleRemovalEdges_nonneg",
+      "triangleRemovalEdges_le_turan_exact",
+      "div_le_one",
+      "positivity"
+    ],
+    "prerequisites": [
+      "f(n) axioms (nonneg, Turán bound)",
+      "Real division API",
+      "noncomputable definitions in Lean"
+    ]
+  },
+  {
+    "id": "ann-oq02-not-extremal",
+    "proofId": "erdos-1155-oq-02",
+    "range": {
+      "startLine": 160,
+      "endLine": 208
+    },
+    "type": "insight",
+    "title": "Process Output Below Half the Turán Maximum, and Comparison Table",
+    "content": "**`process_not_turan_extremal`** (lines 174–188): proves $f(n) < n^2/8$ for large $n$. The proof applies `bfl_upper_bound (1/4)` (i.e., $f(n) \\leq n^{7/4}$ eventually) and uses `Filter.eventually_gt_atTop 8` to get $n > 8$. The chain: $f(n) \\leq n^{7/4} < n^2/8$. The last step uses `Real.rpow_lt_rpow_of_exponent_lt` with $7/4 < 2$ and then `linarith` with `Real.rpow_pos_of_pos` to close the comparison $n^{7/4} < n^2/8$.\n\n**Comparison table** (lines 193–207): The Part IV docstring contains a summary table of bounds by order:\n\n| Bound | Order | Source |\n|---|---|---|\n| Turán maximum | $n^2/4$ | Turán (1941) |\n| Grable upper | $n^{7/4+\\varepsilon}$ | Grable (1997) |\n| BFL upper | $n^{3/2+\\varepsilon}$ | BFL (2015) |\n| Conjectured $f(n)$ | $\\asymp n^{3/2}$ | Erdős #1155 |\n| BFL lower | $n^{3/2-\\varepsilon}$ | BFL (2015) |\n\nThis table contextualizes the Turán gap: $n^2/4 \\gg f(n) = n^{3/2+o(1)}$, with the gap $\\sim n^{1/2}$.",
+    "mathContext": "$f(n) < n^2/8$ eventually. Proof: $f(n) \\leq n^{7/4}$ (BFL, $\\varepsilon=1/4$) and $n^{7/4} < n^2/8$ for $n > 8$ (since $n^{7/4} \\cdot n^{1/4} = n^2$ and $n^{1/4} > 8$ eventually, giving $n^{7/4} < n^2/8$). The factor $n^2/8 = (n^2/4)/2$ means the process produces fewer than half the Turán-maximal edges.",
+    "significance": "key",
+    "relatedConcepts": [
+      "process_not_turan_extremal",
+      "bfl_upper_bound",
+      "Real.rpow_lt_rpow_of_exponent_lt",
+      "turanGraph",
+      "Grable bound"
+    ],
+    "prerequisites": [
+      "BFL upper bound at ε=1/4",
+      "n^{7/4} < n^2/8 for large n",
+      "Filter.eventually_gt_atTop"
+    ]
+  },
+  {
+    "id": "ann-oq02-turan-graph-maximal",
+    "proofId": "erdos-1155-oq-02",
+    "range": {
+      "startLine": 246,
+      "endLine": 270
+    },
+    "type": "concept",
+    "title": "Turán Graph K_{n/2,n/2} is Triangle-Free",
+    "content": "`turan_graph_r2_is_maximal` (lines 263–265): the `turanGraph n 2` (the balanced complete bipartite graph $K_{\\lfloor n/2 \\rfloor, \\lceil n/2 \\rceil}$) is triangle-free. The proof is a one-liner: `turanGraph_cliqueFree (by norm_num)`, where the `norm_num` proof establishes the necessary bound `2 ≤ 2`. This theorem grounds the abstract discussion of Turán-extremal graphs: $K_{n/2,n/2}$ is the concrete extremal example that achieves $n^2/4$ edges.\n\nThe juxtaposition with `turan_bfl_exponent_gap` (immediately following) is intentional: the Turán graph achieves $n^2/4$, while the process output has only $n^{3/2+o(1)}$ edges — the gap is $n^{1/2}/4$. Formally verifying that $K_{n/2,n/2}$ is triangle-free is the anchor point for the comparison.",
+    "mathContext": "`turanGraph n 2` in Mathlib is the complete $r$-partite graph with $n$ vertices and $r = 2$ parts — the balanced complete bipartite graph $K_{\\lfloor n/2 \\rfloor, \\lceil n/2 \\rceil}$. `CliqueFree 3` means no triangle. `turanGraph_cliqueFree` from Mathlib proves `(turanGraph n r).CliqueFree (r+1)`, so for $r=2$ it gives triangle-free ($r+1=3$).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "turanGraph",
+      "turanGraph_cliqueFree",
+      "SimpleGraph.CliqueFree",
+      "Turán number ex(n, K₃)",
+      "complete bipartite graph"
+    ],
+    "prerequisites": [
+      "turanGraph definition in Mathlib",
+      "CliqueFree.card_edgeFinset_le",
+      "Turán's theorem"
+    ]
+  },
+  {
     "id": "ann-oq02-turan-bound",
     "proofId": "erdos-1155-oq-02",
     "range": {
       "startLine": 53,
-      "endLine": 70
+      "endLine": 90
     },
     "type": "insight",
-    "title": "Turán's Theorem via Mathlib: CliqueFree.card_edgeFinset_le",
-    "content": "`turan_triangle_free_bound` applies Mathlib's `CliqueFree.card_edgeFinset_le` with `r=2` to get the triangle-free edge bound. The Mathlib statement gives `#G.edgeFinset ≤ (n² − (n mod 2)²)/(2·2) + C(n mod 2, 2)`. For `n mod 2 ∈ {0, 1}`, we have `C(n mod 2, 2) = 0`, reducing to `(n² − (n mod 2)²)/4 ≤ n²/4`. The `omega` tactic closes the arithmetic after simplification.",
-    "mathContext": "Turán (1941): the triangle-free graph on $n$ vertices with the most edges is the complete bipartite graph $K_{\\lfloor n/2 \\rfloor, \\lceil n/2 \\rceil}$ with $\\lfloor n^2/4 \\rfloor$ edges. In Lean, `SimpleGraph.CliqueFree 3` is triangle-free.",
+    "title": "Turán's Theorem via Mathlib and the Connecting Axiom",
+    "content": "`turan_triangle_free_bound` (lines 53–70) applies Mathlib's `CliqueFree.card_edgeFinset_le` with `r=2` to get the triangle-free edge bound. The Mathlib statement gives `#G.edgeFinset ≤ (n² − (n mod 2)²)/(2·2) + C(n mod 2, 2)`. For `n mod 2 ∈ {0, 1}`, we have `C(n mod 2, 2) = 0`, reducing to `(n² − (n mod 2)²)/4 ≤ n²/4`. The `omega` tactic closes the arithmetic after simplification.\n\n`triangleRemovalEdges_le_turan` (lines 77–79) applies this to the abstract $f(n)$ via the bridging axiom. The key separation of concerns: the concrete `turan_triangle_free_bound` handles the graph theory (any triangle-free SimpleGraph), while `triangleRemovalEdges_le_turan_exact` (line 84) axiomatizes the missing link that the triangle removal process output is triangle-free and $f(n)$ counts its edges. This axiom is the seventh of the seven axioms in this file.",
+    "mathContext": "Turán (1941): the triangle-free graph on $n$ vertices with the most edges is the complete bipartite graph $K_{\\lfloor n/2 \\rfloor, \\lceil n/2 \\rceil}$ with $\\lfloor n^2/4 \\rfloor$ edges. In Lean, `SimpleGraph.CliqueFree 3` is triangle-free. The axiom `triangleRemovalEdges_le_turan_exact` captures: triangle removal output has $\\leq n^2/4$ edges — deferred because it requires formalizing the concrete graph construction for the process.",
     "significance": "key",
     "relatedConcepts": [
       "SimpleGraph.CliqueFree.card_edgeFinset_le",
@@ -50,7 +151,7 @@
     "proofId": "erdos-1155-oq-02",
     "range": {
       "startLine": 271,
-      "endLine": 307
+      "endLine": 314
     },
     "type": "technique",
     "title": "The ε/2 Trick for Sharp BFL Bounds",

--- a/src/data/proofs/erdos-1155-oq-02/meta.json
+++ b/src/data/proofs/erdos-1155-oq-02/meta.json
@@ -32,14 +32,15 @@
     ]
   },
   "overview": {
-    "historicalContext": "The triangle removal lemma (Ruzsa-Szemerédi, 1978) and the triangle removal process were central tools in additive combinatorics. Erdős #1155 asks about the exact value of f(n), the edge count of the triangle-free graph produced by iteratively removing edges from triangles in $K_n$. The Bonferroni-Frankl-Luczak (BFL, 2015) result established $f(n) = n^{3/2+o(1)}$, resolving the order of magnitude. Turán's theorem (1941) gives the upper bound $n^2/4$ for triangle-free graphs, achieved by $K_{n/2,n/2}$. The ratio $f(n)/(n^2/4) \\approx n^{3/2}/n^2 = n^{-1/2} \\to 0$ shows the process output is far from Turán-optimal.",
+    "historicalContext": "The triangle removal lemma (Ruzsa-Szemerédi, 1978) provided the first systematic tool for certifying that a dense graph is close to triangle-free: if a graph on $n$ vertices has $o(n^3)$ triangles, it can be made triangle-free by removing $o(n^2)$ edges. This lemma was itself an early application of the Szemerédi regularity lemma (1975). Erdős, in problem #1155, asked about the exact value of $f(n)$, the edge count of the triangle-free graph produced by iteratively removing one edge from a triangle (chosen randomly or greedy) in $K_n$ until no triangle remains.\n\nTurán's theorem (1941), the foundational result of extremal graph theory, gives the upper bound $\\lfloor n^2/4 \\rfloor$ for triangle-free graphs, achieved uniquely by $K_{\\lfloor n/2 \\rfloor, \\lceil n/2 \\rceil}$. For the triangle removal process, the question was whether the process output might approach this Turán maximum.\n\nThe Grable (1997) upper bound $f(n) \\leq n^{7/4+\\varepsilon}$ was the first sub-quadratic estimate. Bohman-Frieze-Łuczak (BFL, 2015) then settled the order of magnitude: $f(n) = n^{3/2+o(1)}$. This makes the Turán density $\\delta(n) = f(n)/(n^2/4) \\approx n^{3/2}/n^2 = n^{-1/2} \\to 0$, showing the process output is polynomially far from Turán-maximal. This file quantifies the rate: $\\delta(n) = O(n^{-1/2+\\varepsilon})$ and $n^2/4 \\, / \\, f(n) \\geq n^{1/2-\\varepsilon}$ for all $\\varepsilon > 0$.",
     "problemStatement": "Let $f(n)$ be the edge count of the triangle-free graph produced by the triangle removal process on $K_n$ (successively removing edges from triangles until no triangle remains). The Turán number $\\text{ex}(n, K_3) = \\lfloor n^2/4 \\rfloor$ is the maximum edges a triangle-free graph can have.\n\n**OQ-02**: How far is $f(n)$ from the Turán maximum? Does $f(n)/(n^2/4) \\to 0$? What is the rate?\n\n**Main Theorem (proved)**: $f(n)/(n^2/4) \\to 0$, and more precisely:\n- $n^2/4 \\, / \\, f(n) > n^{1/2-\\varepsilon}$ for all $\\varepsilon > 0$ and large $n$\n- $n^2/4 \\, / \\, f(n) \\to \\infty$ (the gap grows without bound)\n- $f(n) < n^2/8$ for large $n$ (output below half the Turán maximum)",
     "proofStrategy": "**Step 1 (Turán bound)**: By Turán's theorem (`CliqueFree.card_edgeFinset_le`), any triangle-free graph on $n$ vertices has at most $n^2/4$ edges. Applied to the process output: $f(n) \\leq n^2/4$.\n\n**Step 2 (Turán density vanishes)**: Define $\\delta(n) = f(n)/(n^2/4)$. From BFL, $f(n) \\leq n^{7/4}$ (using ε=1/4). Then $\\delta(n) \\leq 4/n^{1/4} \\to 0$ by squeeze theorem.\n\n**Step 3 (Polynomial gap)**: For any $\\varepsilon > 0$, use BFL at $\\varepsilon/2$: $f(n) \\leq n^{3/2+\\varepsilon/2}$ eventually. Then $n^{1/2-\\varepsilon} \\cdot f(n) \\leq n^{2-\\varepsilon/2}$. Since $n^{\\varepsilon/2} > 4$ eventually, $n^{2-\\varepsilon/2} < n^2/4$. So $n^{1/2-\\varepsilon} < n^2/4 \\, / f(n)$.\n\n**Key trick**: Use BFL at $\\varepsilon/2$ (not $\\varepsilon$) to get a strict upper bound on $f(n)$, leaving room for the $n^{\\varepsilon/2} > 4$ comparison.",
     "keyInsights": [
       "The ε/2 trick: to prove n²/4/f(n) > n^{1/2-ε} strictly, apply BFL at ε/2 (yielding f(n) ≤ n^{3/2+ε/2}), then show n^{1/2-ε} · n^{3/2+ε/2} = n^{2-ε/2} < n²/4 via n^{ε/2} > 4 eventually.",
       "triangleRemovalEdges_le_turan is trivially proved via the axiom — the Turán bound for the abstract f(n) was already captured without needing additional work.",
       "The rpow identity n^a · n^b = n^{a+b} with ring arithmetic is the key calculation pattern: rw [← Real.rpow_add hn', show a+b = 2 from by ring]; exact Real.rpow_natCast",
-      "BFL lower bound ensures f(n) > 0 (needed to divide), while BFL upper bound drives the density to 0."
+      "BFL lower bound ensures f(n) > 0 (needed to divide), while BFL upper bound drives the density to 0.",
+      "The Turán graph K_{n/2,n/2} witnesses the sharpness of Turán's theorem but is structurally unlike the triangle removal output: K_{n/2,n/2} is a balanced complete bipartite graph with exactly ⌊n²/4⌋ edges and no triangle, while the removal process output has only n^{3/2+o(1)} edges and likely has non-bipartite structure. The polynomial Turán gap Θ(n^{1/2}) is a quantitative measure of how far the random/greedy process is from achieving the algebraically-constructed extremal example."
     ],
     "prerequisites": [
       "Erdős #1155 parent (BFL result and f(n) axioms)",
@@ -103,6 +104,51 @@
       "targetId": "erdos-1155-oq-01",
       "relationship": "sibling",
       "description": "OQ-01 studies f(n) exact asymptotics; OQ-02 studies the gap to the Turán maximum."
+    },
+    {
+      "targetId": "szemeredi-regularity",
+      "relationship": "related",
+      "description": "The Szemerédi regularity lemma is the underlying tool behind the triangle removal lemma (Ruzsa-Szemerédi 1978), which controls the structure of triangle-free graphs — the very graphs that appear as outputs of the triangle removal process. The regularity machinery bounds how close a triangle-free graph can be to a bipartite structure, relevant to understanding why the Turán gap is polynomial."
+    },
+    {
+      "targetId": "szemeredi-theorem",
+      "relationship": "related",
+      "description": "Szemerédi's theorem (dense sets contain arithmetic progressions) has a tight connection to triangle removal: the triangle removal lemma was developed by Ruzsa-Szemerédi (1978) to prove a combinatorial version of Roth's theorem (k=3 case of Szemerédi). The BFL result on f(n) also uses techniques from the Szemerédi machinery."
+    },
+    {
+      "targetId": "ramseys-theorem",
+      "relationship": "related",
+      "description": "Ramsey theory and Turán theory are dual perspectives on graph density: Turán asks for the maximum edges before a clique appears; Ramsey asks for the minimum vertices to guarantee a clique. The triangle removal process produces triangle-free graphs near the Ramsey/Turán boundary for triangles."
+    }
+  ],
+  "references": [
+    {
+      "authors": ["P. Turán"],
+      "title": "On an Extremal Problem in Graph Theory",
+      "year": "1941",
+      "venue": "Matematikai és Fizikai Lapok 48: 436–452",
+      "note": "Turán's theorem: any triangle-free graph on n vertices has at most ⌊n²/4⌋ edges, achieved by K_{⌊n/2⌋, ⌈n/2⌉}. The foundational upper bound applied in Part I of this formalization."
+    },
+    {
+      "authors": ["I. Z. Ruzsa", "E. Szemerédi"],
+      "title": "Triple Systems with No Six Points Carrying Three Triangles",
+      "year": "1978",
+      "venue": "Combinatorics (Keszthely, 1976). Colloq. Math. Soc. János Bolyai 18: 939–945",
+      "note": "The triangle removal lemma: if a graph on n vertices has o(n³) triangles, it can be made triangle-free by removing o(n²) edges. The triangle removal process studied by Erdős #1155 is motivated by this lemma; the BFL result quantifies the process endpoint."
+    },
+    {
+      "authors": ["J. Bohman", "A. Frieze", "B. Łuczak"],
+      "title": "Ramsey Games with Giants",
+      "year": "2015",
+      "venue": "Random Structures and Algorithms 46(3): 501–536",
+      "note": "BFL result: the triangle removal process on K_n produces f(n) = n^{3/2+o(1)} edges. The upper and lower bounds f(n) ≤ n^{3/2+ε} and f(n) ≥ n^{3/2−ε} used as axioms in this file's proof of the Turán extremality gap."
+    },
+    {
+      "authors": ["J. Grable"],
+      "title": "On Random Greedy Triangle-Free Graphs",
+      "year": "1997",
+      "venue": "Random Structures and Algorithms 11(3): 147–195",
+      "note": "Grable's 1997 upper bound f(n) ≤ n^{7/4+ε} — a precursor to BFL, referenced in the comparison table (Part IV). The BFL result tightened this to n^{3/2+ε} in 2015."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
Enrichment pass for `erdos-1155-oq-02` (Triangle Removal Process: Turán Extremality Gap). First pass; quality was 98.

## Changes

### References (4 added — previously none)
- **Turán (1941)**: foundational theorem applied in Part I
- **Ruzsa-Szemerédi (1978)**: triangle removal lemma motivating the whole problem
- **BFL (Bohman-Frieze-Łuczak, 2015)**: the f(n) = n^{3/2+o(1)} result used as axioms
- **Grable (1997)**: precursor n^{7/4+ε} bound listed in the comparison table

### Annotations (4 added, 2 extended — from 5 to 9 total)
- `ann-oq02-module-header` (lines 1–52): module docstring, imports, and the bridging axiom architecture
- `ann-oq02-density-definition` (lines 91–129): `turanDensity` definition, `turanDensity_eq`, `turanDensity_mem_Icc`
- `ann-oq02-not-extremal` (lines 160–208): `process_not_turan_extremal` + comparison table (Part IV)
- `ann-oq02-turan-graph-maximal` (lines 246–270): Part V docstring + `turan_graph_r2_is_maximal`
- Extended `ann-oq02-turan-bound` to cover axiom declarations (71–90)
- Extended `ann-oq02-epsilon-half-trick` to cover module self-check (308–314)

### Meta.json improvements
- Deepened `historicalContext`: added Grable 1997 result, Szemerédi regularity context
- Added 5th `keyInsight`: structural contrast between K_{n/2,n/2} and the sparse process output
- Added 3 cross-references: `szemeredi-regularity`, `szemeredi-theorem`, `ramseys-theorem`