### PR TITLE
Fix: correct erdos-1155-oq-02 badge from original to axiom

### DIFF
--- a/src/data/proofs/erdos-1155-oq-02/meta.json
+++ b/src/data/proofs/erdos-1155-oq-02/meta.json
@@ -16,7 +16,7 @@
       "erdos-problems",
       "bfl"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-24",
     "axiomCount": 7,


### PR DESCRIPTION
## Fix

Corrects an inconsistent `badge` field in `erdos-1155-oq-02/meta.json`: the entry had `status: "axiomatized"` but `badge: "original"`. Per gallery tier conventions, axiomatized proofs must use `badge: "axiom"`.

## Evidence

**Before**: `"badge": "original"` (inconsistent — original implies no axioms)
**After**: `"badge": "axiom"` (correct — 7 axioms inherited from parent BFL formalization)

The entry has 7 axioms (6 inherited from the BFL formalization, 1 direct axiom connecting f(n) to the Turán bound), making `status: "axiomatized"` correct. The `badge` field was simply out of sync.

---
Automated fix by lean-mechanic agent.