### PR TITLE
Fix: correct sylow-theorem-oq-02 badge original→mathlib

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13004,6 +13004,18 @@
       "lastAudited": "2026-04-24T15:01:30Z",
       "result": "clean",
       "issues": []
+    },
+    "erdos-1155-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-24T18:09:13Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "sylow-theorem-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-24T18:12:09Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {

--- a/src/data/proofs/sylow-theorem-oq-02/meta.json
+++ b/src/data/proofs/sylow-theorem-oq-02/meta.json
@@ -15,11 +15,11 @@
       "finite-groups",
       "orbit-stabilizer"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-04-24",
     "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified.",
+    "assumptions": "None. Fully machine-verified via Mathlib's Sylow API (Sylow.orbit_eq_top, Sylow.card_eq_index_normalizer, Sylow.equivQuotientNormalizer, card_sylow_modEq_one).",
     "lineCount": 204,
     "theoremCount": 9,
     "definitionCount": 2,


### PR DESCRIPTION
## Integrity Fix

**Proof**: sylow-theorem-oq-02 (Orbit Enumeration of Sylow p-Subgroups: n_p = [G : N_G(P)])
**Problem**: Badge was `original` but all theorems are thin Mathlib wrappers

## Evidence

All 9 theorems in `SylowTheoremOQ02Orbit.lean` are one-liner calls to Mathlib functions:

| Theorem | Mathlib backing |
|---------|----------------|
| sylow_orbit_is_all | `Sylow.orbit_eq_top P` |
| exists_conj_eq | `Sylow.exists_smul_eq G P Q` |
| stabilizer_eq_normalizer | `Sylow.stabilizer_eq_normalizer P` |
| sylow_count_eq_normalizer_index | `Sylow.card_eq_index_normalizer P` |
| sylowEquivQuotientNormalizer | `Sylow.equivQuotientNormalizer P` |
| sylow_count_dvd_index | `Sylow.card_dvd_index P` |
| sylow_count_congr_one | `card_sylow_modEq_one p G` |
| smul_eq_of_normal | `Sylow.smul_eq_of_normal` |

This is Failure Mode #5 ("0 sorries with hidden imports"): 0 sorries but core results obtained via Mathlib bridge. Gallery Tier B → badge must be `mathlib`, not `original`. The file's own summary table lists the Mathlib backing for every result.

## Fix

- Changed `"badge": "original"` → `"badge": "mathlib"`
- Clarified `assumptions` field to name the specific Mathlib API used

The `verified` status is retained (0 sorries, 0 axioms — the Lean kernel did verify everything).

---
Discovered during gallery integrity audit.