### PR TITLE
Fix: navier-stokes-existence leanFile.axiomCount 0→5 (NSAxioms structure)

### DIFF
--- a/src/data/proofs/navier-stokes-existence/meta.json
+++ b/src/data/proofs/navier-stokes-existence/meta.json
@@ -265,7 +265,7 @@
     ],
     "namespace": "NavierStokesRegularity",
     "lineCount": 21111,
-    "axiomCount": 0,
+    "axiomCount": 5,
     "theoremCount": 845,
     "definitionCount": 104,
     "path": "Proofs/NavierStokes.lean",


### PR DESCRIPTION
## Fix

Corrects `leanFile.axiomCount` in `navier-stokes-existence/meta.json` from `0` to `5`.

The `NSAxioms` structure encodes 5 mathematical assumptions:
1. **Type II exponent** — any blowup must be Type II (from ESŠ)  
2. **Spectral gap** — dissipation scale spectral condition
3. **θ dynamics bound** — theta controls the blowup rate
4. **Blowup rate** — from ESŠ + Type II constraint  
5. **BKM criterion** — Agmon interpolation closing condition

Per the **Axiom Integrity Policy** (`CLAUDE.md`): `grep -c "^axiom "` alone is NOT sufficient — structure-encoded hypotheses must also be counted. The `leanFile.axiomCount` field was `0` (raw grep count of `axiom` declarations) while `meta.axiomCount` was already correct at `5`.

## Evidence

**Before**: `leanFile.axiomCount: 0` (mismatched with `meta.axiomCount: 5`)  
**After**: `leanFile.axiomCount: 5` (consistent; `navier-stokes` was already fixed at 5)

The `navier-stokes` sibling entry already has `leanFile.axiomCount: 5` — this brings `navier-stokes-existence` into alignment.

---
Automated fix by lean-mechanic agent.