### PR TITLE
Prove hookProd_ratio_formula: complete Finset.prod split (Hook-Length Formula Part XIV)

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean
@@ -4957,13 +4957,103 @@ private lemma hookProd_ratio_formula {μ : YoungDiagram} {c : ℕ × ℕ} (hc : 
     rintro _ ⟨s, _, rfl⟩ ⟨r, hr, h⟩
     simp [Prod.mk.injEq] at h
     omega
-  -- [Core sorry: split ν.cells into armCells ∪ legCells ∪ restCells and apply hookLength lemmas]
-  -- The identity follows from:
-  -- ∏_{x∈ν.cells} hookLen(μ,x)/hookLen(ν,x)
-  --   = ∏_{arm} hookLen(μ,i,s)/(hookLen(μ,i,s)-1)   [hookLength_removeCorner_arm]
-  --   × ∏_{leg} hookLen(μ,r,j)/(hookLen(μ,r,j)-1)   [hookLength_removeCorner_leg]
-  --   × ∏_{rest} 1                                    [hookLength_eq_of_not_arm_leg]
-  sorry
+  -- Split ν.cells = armCells ∪ legCells ∪ restCells and derive ratio formula
+  let restCells := ν.cells \ (armCells ∪ legCells)
+  have harm_leg_sub : armCells ∪ legCells ⊆ ν.cells := Finset.union_subset harm_sub hleg_sub
+  -- hookLength change: hν = hμ - 1 for arm/leg cells
+  have harm_diff : ∀ s ∈ Finset.range j, (hookLength ν i s : ℚ) = (hookLength μ i s : ℚ) - 1 :=
+    fun s hs => by
+      have h := hookLength_removeCorner_arm hc (Finset.mem_range.mp hs)
+      simp only [Prod.fst, Prod.snd] at h
+      have hQ : (hookLength ν i s : ℚ) + 1 = hookLength μ i s := by exact_mod_cast h
+      linarith
+  have hleg_diff : ∀ r ∈ Finset.range i, (hookLength ν r j : ℚ) = (hookLength μ r j : ℚ) - 1 :=
+    fun r hr => by
+      have h := hookLength_removeCorner_leg hc (Finset.mem_range.mp hr)
+      simp only [Prod.fst, Prod.snd] at h
+      have hQ : (hookLength ν r j : ℚ) + 1 = hookLength μ r j := by exact_mod_cast h
+      linarith
+  have harm_ν_ne : ∀ s ∈ Finset.range j, (hookLength ν i s : ℚ) ≠ 0 :=
+    fun s _ => Nat.cast_ne_zero.mpr (hookLength_pos ν i s).ne'
+  have hleg_ν_ne : ∀ r ∈ Finset.range i, (hookLength ν r j : ℚ) ≠ 0 :=
+    fun r _ => Nat.cast_ne_zero.mpr (hookLength_pos ν r j).ne'
+  have hprod_arm_ν : (∏ s ∈ Finset.range j, (hookLength ν i s : ℚ)) ≠ 0 :=
+    Finset.prod_ne_zero harm_ν_ne
+  have hprod_leg_ν : (∏ r ∈ Finset.range i, (hookLength ν r j : ℚ)) ≠ 0 :=
+    Finset.prod_ne_zero hleg_ν_ne
+  -- rest cells: hookLength unchanged by removeCorner
+  have hrest_inv : ∀ x ∈ restCells, hookLength ν x.1 x.2 = hookLength μ x.1 x.2 := by
+    intro x hx
+    obtain ⟨hxν, hxnot⟩ := Finset.mem_sdiff.mp hx
+    have hxμ : x ∈ μ := ((mem_removeCorner hc).mp (YoungDiagram.mem_cells.mp hxν)).1
+    have hxc : x ≠ (i, j) :=
+      fun h => ((mem_removeCorner hc).mp (YoungDiagram.mem_cells.mp hxν)).2 h
+    apply hookLength_eq_of_not_arm_leg hc hxμ hxc
+    · intro ⟨h1, h2⟩
+      exact hxnot (Finset.mem_union_left _ (Finset.mem_image.mpr
+        ⟨x.2, Finset.mem_range.mpr h2, Prod.ext h1.symm rfl⟩))
+    · intro ⟨h1, h2⟩
+      exact hxnot (Finset.mem_union_right _ (Finset.mem_image.mpr
+        ⟨x.1, Finset.mem_range.mpr h1, Prod.ext rfl h2.symm⟩))
+  -- Key ℕ equality (avoids division): hookProd μ × ∏ hν_arm × ∏ hν_leg = hookProd ν × ∏ hμ_arm × ∏ hμ_leg
+  have key_nat : hookProd μ *
+      (∏ s ∈ Finset.range j, hookLength ν i s) * (∏ r ∈ Finset.range i, hookLength ν r j) =
+      hookProd ν *
+      (∏ s ∈ Finset.range j, hookLength μ i s) * (∏ r ∈ Finset.range i, hookLength μ r j) := by
+    have h_μ : hookProd μ = ∏ x ∈ ν.cells, hookLength μ x.1 x.2 := by
+      simp only [hookProd]
+      rw [← Finset.mul_prod_erase μ.cells (fun x => hookLength μ x.1 x.2) hcmem]
+      simp only [Prod.fst, Prod.snd, hookLength_corner_eq_one hc, one_mul, hν_cells]
+    have h_ν : hookProd ν = ∏ x ∈ ν.cells, hookLength ν x.1 x.2 := rfl
+    have harm_μ : ∏ s ∈ Finset.range j, hookLength μ i s =
+        ∏ x ∈ armCells, hookLength μ x.1 x.2 := by
+      simp only [armCells]
+      rw [Finset.prod_image (fun a _ b _ h => (Prod.mk.inj h).2)]
+      simp only [Prod.fst, Prod.snd]
+    have harm_ν2 : ∏ s ∈ Finset.range j, hookLength ν i s =
+        ∏ x ∈ armCells, hookLength ν x.1 x.2 := by
+      simp only [armCells]
+      rw [Finset.prod_image (fun a _ b _ h => (Prod.mk.inj h).2)]
+      simp only [Prod.fst, Prod.snd]
+    have hleg_μ : ∏ r ∈ Finset.range i, hookLength μ r j =
+        ∏ x ∈ legCells, hookLength μ x.1 x.2 := by
+      simp only [legCells]
+      rw [Finset.prod_image (fun a _ b _ h => (Prod.mk.inj h).1)]
+      simp only [Prod.fst, Prod.snd]
+    have hleg_ν2 : ∏ r ∈ Finset.range i, hookLength ν r j =
+        ∏ x ∈ legCells, hookLength ν x.1 x.2 := by
+      simp only [legCells]
+      rw [Finset.prod_image (fun a _ b _ h => (Prod.mk.inj h).1)]
+      simp only [Prod.fst, Prod.snd]
+    have hcells_eq : ν.cells = armCells ∪ legCells ∪ restCells :=
+      (Finset.union_sdiff_of_subset harm_leg_sub).symm
+    have hdisj_union : Disjoint (armCells ∪ legCells) restCells := disjoint_sdiff_self_right
+    have hμ_split : ∏ x ∈ ν.cells, hookLength μ x.1 x.2 =
+        (∏ x ∈ armCells, hookLength μ x.1 x.2) * (∏ x ∈ legCells, hookLength μ x.1 x.2) *
+        (∏ x ∈ restCells, hookLength μ x.1 x.2) := by
+      rw [hcells_eq, Finset.prod_union hdisj_union, Finset.prod_union hdisj]; ring
+    have hν_split : ∏ x ∈ ν.cells, hookLength ν x.1 x.2 =
+        (∏ x ∈ armCells, hookLength ν x.1 x.2) * (∏ x ∈ legCells, hookLength ν x.1 x.2) *
+        (∏ x ∈ restCells, hookLength ν x.1 x.2) := by
+      rw [hcells_eq, Finset.prod_union hdisj_union, Finset.prod_union hdisj]; ring
+    rw [h_μ, h_ν, harm_μ, harm_ν2, hleg_μ, hleg_ν2, hμ_split, hν_split,
+        Finset.prod_congr rfl hrest_inv]
+    ring
+  -- Cast ℕ equality to ℚ
+  have key_Q : (hookProd μ : ℚ) * (∏ s ∈ Finset.range j, (hookLength ν i s : ℚ)) *
+      (∏ r ∈ Finset.range i, (hookLength ν r j : ℚ)) =
+      (hookProd ν : ℚ) * (∏ s ∈ Finset.range j, (hookLength μ i s : ℚ)) *
+      (∏ r ∈ Finset.range i, (hookLength μ r j : ℚ)) := by exact_mod_cast key_nat
+  have harm_prod_eq : ∏ s ∈ Finset.range j, ((hookLength μ i s : ℚ) - 1) =
+      ∏ s ∈ Finset.range j, (hookLength ν i s : ℚ) :=
+    Finset.prod_congr rfl (fun s hs => (harm_diff s hs).symm)
+  have hleg_prod_eq : ∏ r ∈ Finset.range i, ((hookLength μ r j : ℚ) - 1) =
+      ∏ r ∈ Finset.range i, (hookLength ν r j : ℚ) :=
+    Finset.prod_congr rfl (fun r hr => (hleg_diff r hr).symm)
+  rw [Finset.prod_div_distrib, Finset.prod_div_distrib,
+      harm_prod_eq, hleg_prod_eq, div_mul_div_comm,
+      div_eq_div_iff hν_ne (mul_ne_zero hprod_arm_ν hprod_leg_ν)]
+  linear_combination key_Q
 
 
 private lemma hook_walk_identity (μ : YoungDiagram) (hn : 0 < μ.card) :

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/knowledge.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/knowledge.md
@@ -339,3 +339,71 @@ The sorry count increased by 1 (net) because:
    Alternatively, try to prove for specific shapes (2-corner diagrams) as special cases.
 3. **Aristotle submission**: Submit hookProd_ratio_formula (without the prod-split sorry) and
    arm_mem_nu / leg_mem_nu to Aristotle for verification of the proved parts.
+
+---
+
+## Session 2026-04-24 (Session 18) — hookProd_ratio_formula COMPLETED
+
+**Mode**: REVISIT (RICH knowledge tier)
+**Outcome**: PROGRESS — `hookProd_ratio_formula` proved (0 sorries); 1 sorry eliminated
+
+### What I Did
+
+1. Completed the `hookProd_ratio_formula` proof: replaced the remaining sorry with a ~90-line proof
+2. Strategy: avoided `Finset.prod_div_distrib` on CommGroupWithZero complications by first proving
+   a ℕ product equality (`key_nat`), then casting to ℚ, then applying field division lemmas
+3. PR: rjwalters/lean-genius#12358 on `feature/researcher-10`
+
+### Key Proof Steps
+
+1. **`key_nat` (ℕ equality)**: Avoids division entirely by proving:
+   `hookProd μ × ∏_s hookLen(ν,i,s) × ∏_r hookLen(ν,r,j) = hookProd ν × ∏_s hookLen(μ,i,s) × ∏_r hookLen(μ,r,j)`
+   Strategy: split ν.cells = armCells ∪ legCells ∪ restCells via `Finset.union_sdiff_of_subset`,
+   then apply `Finset.prod_union` (twice) and `Finset.prod_congr rfl hrest_inv` (rest cells equal),
+   then `ring` to cancel.
+
+2. **`harm_diff` / `hleg_diff`**: `hookLength ν i s = hookLength μ i s - 1` in ℚ, proved by
+   casting `hookLength_removeCorner_arm/leg` (ℕ: `hν + 1 = hμ`) via `exact_mod_cast` + `linarith`.
+
+3. **`hrest_inv`**: `hookLength ν x = hookLength μ x` for cells in restCells. Used `mem_sdiff` to
+   extract `x ∉ armCells ∪ legCells`, then `hookLength_eq_of_not_arm_leg` with proof that
+   arm/leg membership would put x in the excluded union.
+
+4. **Final combination**: `Finset.prod_div_distrib` (×2) rewrites product-of-ratios to ratio-of-products;
+   `harm_prod_eq` / `hleg_prod_eq` rewrites (hμ-1) denominators to hν values;
+   `div_mul_div_comm` combines the two quotients; `div_eq_div_iff` cross-multiplies;
+   `linear_combination key_Q` closes.
+
+### Key Findings
+
+- **ℕ equality sidesteps ℚ product complexity**: Rather than working with `∏ x / ∏ y` in ℚ
+  (requiring CommGroupWithZero or field instances), prove the cross-multiplication equality in ℕ
+  first, then cast. This avoids `prod_div_distrib` until the very last step.
+- **`Finset.prod_image` injection pattern**: `fun a _ b _ h => (Prod.mk.inj h).2` for
+  `fun s => (i, s)` injectivity (take `.2` of Prod.mk.inj); `.1` for `fun r => (r, j)`.
+- **`Prod.ext h1.symm rfl`**: Proves `(i, x.2) = x` given `h1 : x.1 = i`.
+- **`disjoint_sdiff_self_right`**: Proves `Disjoint s (t \ s)` for `restCells = ν.cells \ (armCells ∪ legCells)`.
+
+### Files Modified
+
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean` (5056 → 5146 lines, hookProd_ratio_formula proved)
+- `research/problems/ballot-problem-oq-03-oq-01-oq-02/knowledge.md` (this file)
+- `src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json` (knowledge updated)
+- `src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json` (lineCount 5146, sorries 4)
+- PR: rjwalters/lean-genius#12358
+
+### Sorry Count: 5 → 4
+
+- `hookProd_ratio_formula` (PART XIV): **PROVED** ✓
+- `hook_walk_identity` (PART XIV line ~5067): ≥3-row case, needs GNW proof (~200-300 lines)
+- `ni_count_eq_syt_count` (line 219): RSK bijection, FALSE as stated
+- `lgv_det_factors_as_hook_quotient` (line 235): det identity, FALSE as stated
+- `hook_length_formula` (line 245): depends on the two above (FALSE as stated)
+
+### Next Steps
+
+1. **hook_walk_identity ≥3-row case**: The identity `Σ_{c ∈ corners(μ)} hookProd(μ)/hookProd(μ\c) = μ.card`
+   requires either the GNW probabilistic hook walk proof (~200-300 lines) or showing equivalence
+   to HLF itself (circular without external proof). The `hookProd_ratio_formula` now provides the
+   ratio factorization needed as input. The 2-row case is already proved in `hook_walk_identity_atMostTwoRows`.
+2. **Archive sessions**: knowledge.md is >500 lines; archive sessions 5-17 to sessions/ subdir.

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "ballot-problem-oq-03-oq-01-oq-02",
   "title": "Hook-Length Formula for Standard Young Tableaux via LGV",
   "slug": "ballot-problem-oq-03-oq-01-oq-02",
-  "description": "Formalizes the hook-length formula f^λ = n!/∏h(u) for Standard Young Tableaux. Fully proves the formula for single-row (1×n), single-column (n×1), hook-shape ((m+1,1)), 2-row rectangular (m×m), and general 2-row [a,b] families. General formula has 5 sorries total: 3 via LGV approach (RSK bijection, det factorization, main theorem) + 2 for corner induction (hookProd_ratio_formula, hook_walk_identity ≥3-row case). hook_length_formula_general proved via corner induction modulo hook_walk_identity.",
+  "description": "Formalizes the hook-length formula f^λ = n!/∏h(u) for Standard Young Tableaux. Fully proves the formula for single-row (1×n), single-column (n×1), hook-shape ((m+1,1)), 2-row rectangular (m×m), and general 2-row [a,b] families. General formula has 4 sorries: 3 via LGV approach (RSK bijection, det factorization, main theorem) + 1 for corner induction (hook_walk_identity ≥3-row case). hookProd_ratio_formula now proved (session 18). hook_length_formula_general proved via corner induction modulo hook_walk_identity.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-21",
@@ -19,11 +19,11 @@
       "representation-theory"
     ],
     "badge": "wip",
-    "sorries": 5,
+    "sorries": 4,
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "assumptions": "Five open sorries: (1) hook_length_formula (LGV approach: requires SYT↔NI bijection + det factorization), (2) ni_count_eq_syt_count (Fomin/Viennot/RSK correspondence), (3) lgv_det_factors_as_hook_quotient (det factorization identity), (4) hookProd_ratio_formula (corner induction prerequisite: product ratio identity over arm/leg cells, ~50 lines), (5) hook_walk_identity ≥3-row case (GNW or RSK, ~300 lines; at-most-2-row case proved). hook_length_formula_general is proved modulo hook_walk_identity via Part XIV corner induction.",
-    "lineCount": 5056,
+    "assumptions": "Four open sorries: (1) hook_length_formula (LGV approach: requires SYT↔NI bijection + det factorization), (2) ni_count_eq_syt_count (Fomin/Viennot/RSK correspondence), (3) lgv_det_factors_as_hook_quotient (det factorization identity), (4) hook_walk_identity ≥3-row case (GNW or RSK, ~300 lines; at-most-2-row case proved; hookProd_ratio_formula now fully proved session 18). hook_length_formula_general is proved modulo hook_walk_identity via Part XIV corner induction.",
+    "lineCount": 5146,
     "theoremCount": 162,
     "definitionCount": 14,
     "originalContributions": [
@@ -87,9 +87,9 @@
       "LGV"
     ],
     "namespace": "HookLengthFormula",
-    "lineCount": 5056,
+    "lineCount": 5146,
     "axiomCount": 0,
-    "sorries": 5,
+    "sorries": 4,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",
     "theoremCount": 100,
     "definitionCount": 14
@@ -174,5 +174,5 @@
       "mathContext": "hook_walk_identity: Σ_c hookProd(μ)/hookProd(μ\\c) = μ.card. The main theorem reduces to hook_length_formula_Q via exact_mod_cast."
     }
   ],
-  "sorries": 5
+  "sorries": 4
 }

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
@@ -47,7 +47,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 13 infrastructure lemmas for hookProd_ratio_formula (8 rowLen/colLen + 5 hookLength + arm_mem_nu + leg_mem_nu). hookProd_ratio_formula ~90% proved; hook_walk_identity sole HLF blocker (needs GNW ~300 lines).",
+    "progressSummary": "PROGRESS: hookProd_ratio_formula proved (session 18); 4 sorries remain (hook_walk_identity ≥3-row + 3 legacy)",
     "builtItems": [
       "instFintypeSYT: Fintype instance for StandardYoungTableau (BallotProblemOQ03OQ01OQ02.lean, Part IIIb)",
       "emptyTableau: unique SYT of shape bot (BallotProblemOQ03OQ01OQ02.lean, Part IIIc)",
@@ -97,7 +97,8 @@
       "leg_mem_nu: (r, c.2) ∈ removeCorner μ c hc when r < c.1 (BallotProblemOQ03OQ01OQ02.lean:~4822)",
       "removeCorner_atMostTwoRows (BallotProblemOQ03OQ01OQ02.lean:4639): removing corner from ≤2-row shape stays ≤2-row",
       "hook_walk_identity_atMostTwoRows (BallotProblemOQ03OQ01OQ02.lean:4659): hook walk identity proved for all ≤2-row shapes, non-circular",
-      "hook_walk_identity (BallotProblemOQ03OQ01OQ02.lean:4714): case split — ≤2-row proved, ≥3-row sorry"
+      "hook_walk_identity (BallotProblemOQ03OQ01OQ02.lean:4714): case split — ≤2-row proved, ≥3-row sorry",
+      "hookProd_ratio_formula: proved 0-sorry in BallotProblemOQ03OQ01OQ02.lean session 18"
     ],
     "insights": [
       "lgv_lemma_rxr in BallotProblemOQ03OQ02.lean is the key building block (Gessel-Viennot involution proof)",
@@ -147,16 +148,19 @@
       "hook_walk_identity_atMostTwoRows is provable non-circularly: HLF for ≤2-row was proved without hook_walk_identity, and corners preserve ≤2-row property",
       "Key algebraic chain for 2-row case: HP/HPc = card(SYT(μ\\c)) * HP/(N-1)! → sum = HP/(N-1)! * card(SYT(μ)) = N!/( N-1)! = N",
       "div_eq_div_iff + linear_combination pattern handles the per-term ratio rewriting cleanly in ℚ",
-      "General (≥3-row) case still requires GNW probabilistic proof (~300 lines) or RSK (~500 lines) — not buildable in a single session"
+      "General (≥3-row) case still requires GNW probabilistic proof (~300 lines) or RSK (~500 lines) — not buildable in a single session",
+      "hookProd_ratio_formula proved using ℕ-equality-then-cast strategy: key_nat avoids division, then linear_combination key_Q closes after prod_div_distrib",
+      "Finset.prod_image injectivity: .2 for (i,s) image, .1 for (r,j) image; Prod.ext h.symm rfl proves (i,x.2)=x from x.1=i",
+      "disjoint_sdiff_self_right proves Disjoint s (t\\s) for restCells=ν.cells\\(arm∪leg)"
     ],
     "mathlibGaps": [
       "hookLength may not be defined in Mathlib.Combinatorics.YoungDiagram — check arm/leg availability",
       "StandardYoungTableau enumeration — check Mathlib.Combinatorics.YoungTableaux"
     ],
     "nextSteps": [
-      "Complete hookProd_ratio_formula: use Finset.prod_sdiff to split off armCells/legCells from ν.cells, then Finset.prod_image + hookLength_removeCorner_arm/leg for the individual ratios (~40 lines)",
-      "Prove hook_walk_identity via GNW (~200-300 lines) or find special-case approach for 2-corner diagrams",
-      "Archive sessions 5-16 to sessions/ subdir once knowledge.md exceeds 500 lines"
+      "Prove hook_walk_identity ≥3-row case: needs GNW probabilistic hook walk (~200-300 lines)",
+      "Archive sessions 5-17 to sessions/ subdir (knowledge.md >500 lines)",
+      "Fix ni_count_eq_syt_count statement (RSK bijection, FALSE as stated)"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

- Eliminates the core `sorry` in `hookProd_ratio_formula` in the Hook-Length Formula proof (PART XIV)
- Proof strategy: split `ν.cells` into `armCells ∪ legCells ∪ restCells`, establish a ℕ product equality (`key_nat`) avoiding division, cast to ℚ, then apply `Finset.prod_div_distrib` + `linear_combination`
- Key infrastructure used: `hookLength_removeCorner_arm/leg`, `hookLength_eq_of_not_arm_leg`, `Finset.union_sdiff_of_subset`, `Finset.prod_union`, `Finset.prod_image`
- **Sorry count**: 5 → 4 (remaining: `hook_walk_identity` ≥3-row case, RSK bijection ×2, chain lemma)

## Mathematical Content

`hookProd_ratio_formula` establishes the key ratio:
```
hookProd(μ) / hookProd(ν) = ∏_{s<j} h(i,s)/(h(i,s)-1) × ∏_{r<i} h(r,j)/(h(r,j)-1)
```
where `ν = removeCorner(μ, (i,j))` and `(i,j)` is a corner of `μ`. This ratio formula is the engine of the corner-induction proof of the Hook-Length Formula.

## Files Modified

- `proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean` (+97 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)