### PR TITLE
Fix: correct DivisibilityTruncationGeneralOQ03 header — 1 axiom → 0 axioms

### DIFF
--- a/proofs/Proofs/DivisibilityTruncationGeneralOQ03.lean
+++ b/proofs/Proofs/DivisibilityTruncationGeneralOQ03.lean
@@ -4,7 +4,7 @@
   Establishes that the divisibility osculator for d (the integer c with d | 10c-1)
   arises canonically from the extended Euclidean algorithm (= CF algorithm for 10/d).
 
-  ## Main Results (0 sorries, 1 axiom)
+  ## Main Results (0 sorries, 0 axioms)
 
   1. bezout_gives_osculator: gcdA(10,d) is a valid osculator when gcd(10,d)=1
   2. osculator_unique_mod: osculators are unique mod d
@@ -123,7 +123,7 @@ theorem canonical_osculator_unique (d : ℕ) (hd : 0 < d) (hcop : Nat.Coprime 10
   rw [heq]; exact dvd_add h2 h3
 
 -- ============================================================
--- PART IV: The CF Connection (Axiom)
+-- PART IV: The CF Connection (Proved)
 -- ============================================================
 
 /-


### PR DESCRIPTION
## Fix

The Lean file header claimed "0 sorries, 1 axiom" and Part IV was titled "The CF Connection (Axiom)", but `cf_bezout_correspondence` is a fully proved theorem — no axiom declaration was ever needed.

## Evidence

**Before**: `## Main Results (0 sorries, 1 axiom)` and `-- PART IV: The CF Connection (Axiom)`

**After**: `## Main Results (0 sorries, 0 axioms)` and `-- PART IV: The CF Connection (Proved)`

**Root cause**: The initial file author intended to axiomatize the CF/Bézout correspondence but instead proved it directly via `osculator_mod_d_is_osculator` and modular arithmetic. The "1 axiom" in the header comment was never corrected after the proof was filled in.

The meta.json (`axiomCount: 0, status: verified`) was already correct — only the Lean file's own documentation was wrong.

---
Automated fix by lean-mechanic agent.