### PR TITLE
Fix: sync enrichment-tracker quality scores (1,872 stale entries)

### DIFF
--- a/src/data/proofs/enrichment-tracker.json
+++ b/src/data/proofs/enrichment-tracker.json
@@ -791,17 +791,17 @@
     "minkowski-theorem": {
       "passes": 1,
       "lastEnriched": "2026-03-26T08:51:43Z",
-      "quality": 95
+      "quality": 100
     },
     "product-of-segments-of-chords": {
       "passes": 1,
       "lastEnriched": "2026-03-26T09:06:31.409Z",
-      "quality": 95
+      "quality": 100
     },
     "mean-value-theorem": {
       "passes": 1,
       "lastEnriched": "2026-03-26T10:00:00Z",
-      "quality": 95,
+      "quality": 100,
       "lastEnricher": "enricher"
     },
     "taylor-sincos-convergence-oq-03": {
@@ -856,7 +856,7 @@
     "konigsberg-oq-03": {
       "passes": 1,
       "lastEnriched": "2026-04-03T07:18:03Z",
-      "quality": 0
+      "quality": 100
     },
     "erdos-1012-oq-03": {
       "passes": 2,
@@ -871,7 +871,7 @@
     "erdos-606-oq-03": {
       "passes": 1,
       "lastEnriched": "2026-04-03T07:18:07Z",
-      "quality": 98
+      "quality": 100
     },
     "randomized-maxcut-oq-02": {
       "passes": 1,
@@ -881,7 +881,7 @@
     "erdos-1118-oq-02": {
       "passes": 1,
       "lastEnriched": "2026-04-03T07:18:08Z",
-      "quality": 98
+      "quality": 100
     },
     "denumerability-rationals-oq-04": {
       "passes": 1,
@@ -912,7 +912,7 @@
     "elementary-quadratic-reciprocity-oq-03-oq-02-oq-01": {
       "passes": 2,
       "lastEnriched": "2026-04-05T11:31:54Z",
-      "quality": 98
+      "quality": 100
     },
     "erdos-1015-oq-05": {
       "passes": 2,
@@ -948,7 +948,7 @@
     "angle-trisection-oq-02-oq-04": {
       "passes": 4,
       "lastEnriched": "2026-04-04T04:11:43Z",
-      "quality": 98
+      "quality": 100
     },
     "angle-trisection-oq-02-oq-02": {
       "passes": 2,
@@ -960,7 +960,7 @@
     "lagrange-theorem-oq-05": {
       "passes": 1,
       "lastEnriched": "2026-04-04T04:12:07Z",
-      "quality": 98
+      "quality": 100
     },
     "hurwitz-theorem-oq-03": {
       "passes": 2,
@@ -1047,7 +1047,7 @@
     "binomial-theorem-oq-02-oq-02": {
       "passes": 1,
       "lastEnriched": "2026-04-05T03:54:40Z",
-      "quality": 95
+      "quality": 100
     },
     "abel-ruffini-oq-04-oq-02-oq-03": {
       "passes": 2,
@@ -1057,7 +1057,7 @@
     "ptolemys-complex-proof-oq-01": {
       "passes": 20,
       "lastEnriched": "2026-04-05T05:35:00Z",
-      "quality": 90
+      "quality": 100
     },
     "erdos-1005": {
       "passes": 11,
@@ -1162,12 +1162,12 @@
     "erdos-330": {
       "passes": 1,
       "lastEnriched": "2026-04-05T12:16:08Z",
-      "quality": 96
+      "quality": 100
     },
     "erdos-508": {
       "passes": 1,
       "lastEnriched": "2026-04-05T12:16:08Z",
-      "quality": 96
+      "quality": 100
     },
     "bertrands-postulate-oq-03-oq-04": {
       "passes": 2,
@@ -1179,12 +1179,12 @@
     "erdos-563": {
       "passes": 1,
       "lastEnriched": "2026-04-05T12:33:31Z",
-      "quality": 93
+      "quality": 100
     },
     "erdos-547": {
       "passes": 1,
       "lastEnriched": "2026-04-05T12:28:09Z",
-      "quality": 96
+      "quality": 100
     },
     "arithmetic-series-oq-02-oq-02-oq-03-oq-01": {
       "passes": 2,
@@ -1246,12 +1246,12 @@
     "erdos-1215": {
       "passes": 2,
       "lastEnriched": "2026-04-21T13:14:01Z",
-      "quality": 92
+      "quality": 100
     },
     "erdos-1216": {
       "passes": 2,
       "lastEnriched": "2026-04-21T13:16:15Z",
-      "quality": 92
+      "quality": 100
     },
     "erdos-1212": {
       "passes": 2,
@@ -1280,7 +1280,7 @@
     "bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03": {
       "passes": 1,
       "lastEnriched": "2026-04-21T13:20:54Z",
-      "quality": 97
+      "quality": 100
     },
     "abel-ruffini-galois-extensions": {
       "passes": 4,
@@ -1532,6 +1532,5568 @@
     "abel-ruffini-oq-04-oq-02": {
       "passes": 1,
       "lastEnriched": "2026-04-24T15:30:00Z",
+      "quality": 100
+    },
+    "abel-ruffini-oq-04-oq-02-oq-02": {
+      "quality": 100
+    },
+    "abel-ruffini-oq-04-oq-03": {
+      "quality": 100
+    },
+    "abel-ruffini-oq-04-oq-07": {
+      "quality": 100
+    },
+    "algebraic-numbers-countable": {
+      "quality": 100
+    },
+    "algebraic-numbers-countable-oq-02": {
+      "quality": 100
+    },
+    "algebraic-numbers-countable-oq-02-oq-02": {
+      "quality": 100
+    },
+    "amgm-inequality-oq-02-oq-01": {
+      "quality": 100
+    },
+    "amgm-inequality-oq-02-oq-01-oq-02": {
+      "quality": 100
+    },
+    "amgm-inequality-oq-02-oq-03": {
+      "quality": 100
+    },
+    "amgm-inequality-oq-02-oq-03-oq-03": {
+      "quality": 100
+    },
+    "amgm-inequality-oq-03-oq-02": {
+      "quality": 100
+    },
+    "amgm-inequality-oq-03-oq-02-oq-01": {
+      "quality": 100
+    },
+    "amgm-inequality-oq-03-oq-02-oq-04": {
+      "quality": 100
+    },
+    "amgm-inequality-oq-03-oq-03": {
+      "quality": 100
+    },
+    "amgm-inequality-oq-03-oq-03-oq-01": {
+      "quality": 100
+    },
+    "amgm-inequality-oq-03-oq-04": {
+      "quality": 100
+    },
+    "amgm-inequality-oq-04": {
+      "quality": 100
+    },
+    "angle-trisection-cos-20-gal": {
+      "quality": 100
+    },
+    "angle-trisection-cos-20-gal-oq-01": {
+      "quality": 100
+    },
+    "angle-trisection-cos-20-gal-oq-01-oq-01": {
+      "quality": 100
+    },
+    "angle-trisection-cos-20-gal-oq-03": {
+      "quality": 100
+    },
+    "angle-trisection-cos-20-gal-oq-03-oq-01": {
+      "quality": 100
+    },
+    "angle-trisection-oq-01": {
+      "quality": 100
+    },
+    "angle-trisection-oq-02": {
+      "quality": 100
+    },
+    "angle-trisection-oq-02-oq-01": {
+      "quality": 100
+    },
+    "angle-trisection-oq-02-oq-01-oq-01": {
+      "quality": 100
+    },
+    "angle-trisection-oq-02-oq-01-oq-02": {
+      "quality": 100
+    },
+    "angle-trisection-oq-02-oq-03": {
+      "quality": 100
+    },
+    "angle-trisection-oq-02-oq-03-oq-01": {
+      "quality": 100
+    },
+    "angle-trisection-oq-03": {
+      "quality": 100
+    },
+    "angle-trisection-oq-05": {
+      "quality": 100
+    },
+    "angle-trisection-oq-05-oq-01": {
+      "quality": 100
+    },
+    "area-of-circle": {
+      "quality": 100
+    },
+    "area-of-circle-oq-01-oq-02-oq-01-oq-01": {
+      "quality": 100
+    },
+    "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01": {
+      "quality": 100
+    },
+    "area-of-circle-oq-01-oq-02-oq-01-oq-03": {
+      "quality": 100
+    },
+    "area-of-circle-oq-01-oq-02-oq-03": {
+      "quality": 100
+    },
+    "area-of-circle-oq-01-oq-02-oq-03-oq-03": {
+      "quality": 100
+    },
+    "area-of-circle-oq-01-oq-03": {
+      "quality": 100
+    },
+    "area-of-circle-oq-01-oq-03-oq-01": {
+      "quality": 100
+    },
+    "area-of-circle-oq-02": {
+      "quality": 100
+    },
+    "area-of-circle-oq-02-oq-01": {
+      "quality": 100
+    },
+    "area-of-circle-oq-02-oq-04": {
+      "quality": 100
+    },
+    "area-of-circle-oq-03-oq-02": {
+      "quality": 100
+    },
+    "area-of-circle-oq-03-oq-02-oq-02-oq-01": {
+      "quality": 100
+    },
+    "area-of-circle-oq-03-oq-03": {
+      "quality": 100
+    },
+    "area-of-circle-oq-03-oq-03-oq-02": {
+      "quality": 100
+    },
+    "area-of-circle-oq-05": {
+      "quality": 100
+    },
+    "area-of-circle-oq-05-oq-01": {
+      "quality": 100
+    },
+    "area-of-circle-oq-05-oq-02": {
+      "quality": 100
+    },
+    "arithmetic-series-oq-00": {
+      "quality": 100
+    },
+    "arithmetic-series-oq-02": {
+      "quality": 100
+    },
+    "arithmetic-series-oq-02-oq-01": {
+      "quality": 100
+    },
+    "arithmetic-series-oq-02-oq-02": {
+      "quality": 100
+    },
+    "arithmetic-series-oq-02-oq-03": {
+      "quality": 100
+    },
+    "arithmetic-series-oq-02-oq-04": {
+      "quality": 100
+    },
+    "arithmetic-series-oq-02-oq-04-oq-01": {
+      "quality": 100
+    },
+    "arithmetic-series-oq-02-oq-04-oq-01-oq-03": {
+      "quality": 100
+    },
+    "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02": {
+      "quality": 100
+    },
+    "arithmetic-series-oq-04": {
+      "quality": 100
+    },
+    "arithmetic-series-oq-04-oq-01": {
+      "quality": 100
+    },
+    "ballot-problem-oq-01": {
+      "quality": 100
+    },
+    "ballot-problem-oq-01-oq-02": {
+      "quality": 100
+    },
+    "ballot-problem-oq-01-oq-02-oq-01": {
+      "quality": 100
+    },
+    "ballot-problem-oq-01-oq-02-oq-04": {
+      "quality": 100
+    },
+    "ballot-problem-oq-01-oq-04": {
+      "quality": 100
+    },
+    "ballot-problem-oq-02": {
+      "quality": 100
+    },
+    "ballot-problem-oq-03": {
+      "quality": 100
+    },
+    "ballot-problem-oq-03-oq-01": {
+      "quality": 100
+    },
+    "ballot-problem-oq-03-oq-01-oq-01": {
+      "quality": 100
+    },
+    "ballot-problem-oq-03-oq-01-oq-01-oq-01": {
+      "quality": 100
+    },
+    "ballot-problem-oq-03-oq-01-oq-02": {
+      "quality": 100
+    },
+    "ballot-problem-oq-03-oq-01-oq-04": {
+      "quality": 100
+    },
+    "basel-problem": {
+      "quality": 100
+    },
+    "basel-problem-oq-01": {
+      "quality": 100
+    },
+    "basel-problem-oq-01-oq-01": {
+      "quality": 100
+    },
+    "basel-problem-oq-01-oq-01-oq-02": {
+      "quality": 100
+    },
+    "basel-problem-oq-01-oq-03": {
+      "quality": 100
+    },
+    "basel-problem-oq-02": {
+      "quality": 100
+    },
+    "basel-problem-oq-04": {
+      "quality": 100
+    },
+    "basel-problem-oq-05": {
+      "quality": 100
+    },
+    "bertrands-postulate-oq-03": {
+      "quality": 100
+    },
+    "bertrands-postulate-oq-03-oq-04-oq-03": {
+      "quality": 100
+    },
+    "bezout-identity-oq-01": {
+      "quality": 100
+    },
+    "bezout-identity-oq-02": {
+      "quality": 100
+    },
+    "bezout-identity-oq-02-oq-01": {
+      "quality": 100
+    },
+    "bezout-identity-oq-02-oq-01-oq-01": {
+      "quality": 100
+    },
+    "bezout-identity-oq-02-oq-01-oq-01-oq-01": {
+      "quality": 100
+    },
+    "bezout-identity-oq-02-oq-02": {
+      "quality": 100
+    },
+    "bezout-identity-oq-02-oq-02-oq-01-oq-01": {
+      "quality": 100
+    },
+    "bezout-identity-oq-03-oq-01": {
+      "quality": 100
+    },
+    "bezout-identity-oq-03-oq-01-oq-01": {
+      "quality": 100
+    },
+    "bezout-identity-oq-03-oq-01-oq-01-oq-01": {
+      "quality": 100
+    },
+    "bezout-identity-oq-03-oq-01-oq-02": {
+      "quality": 100
+    },
+    "bezout-identity-oq-03-oq-04-oq-01": {
+      "quality": 100
+    },
+    "bezout-identity-oq-04": {
+      "quality": 100
+    },
+    "bezout-identity-oq-04-oq-01": {
+      "quality": 100
+    },
+    "bezout-identity-oq-04-oq-02": {
+      "quality": 100
+    },
+    "binary-gcd": {
+      "quality": 100
+    },
+    "binary-gcd-oq-01-oq-04": {
+      "quality": 100
+    },
+    "binary-gcd-oq-03": {
+      "quality": 100
+    },
+    "binomial-theorem": {
+      "quality": 100
+    },
+    "binomial-theorem-oq-01": {
+      "quality": 100
+    },
+    "binomial-theorem-oq-01-oq-01": {
+      "quality": 100
+    },
+    "binomial-theorem-oq-02": {
+      "quality": 100
+    },
+    "binomial-theorem-oq-02-oq-01": {
+      "quality": 100
+    },
+    "binomial-theorem-oq-02-oq-01-oq-01": {
+      "quality": 100
+    },
+    "binomial-theorem-oq-02-oq-01-oq-03": {
+      "quality": 100
+    },
+    "binomial-theorem-oq-02-oq-03": {
+      "quality": 100
+    },
+    "binomial-theorem-oq-02-oq-04": {
+      "quality": 100
+    },
+    "binomial-theorem-oq-03": {
+      "quality": 100
+    },
+    "binomial-theorem-oq-03-oq-02": {
+      "quality": 100
+    },
+    "binomial-theorem-oq-03-oq-02-oq-03": {
+      "quality": 100
+    },
+    "binomial-theorem-oq-04": {
+      "quality": 100
+    },
+    "binomial-theorem-oq-04-oq-01": {
+      "quality": 100
+    },
+    "binomial-theorem-oq-04-oq-02": {
+      "quality": 100
+    },
+    "binomial-theorem-oq-04-oq-02-oq-01": {
+      "quality": 100
+    },
+    "birch-swinnerton-dyer": {
+      "quality": 100
+    },
+    "birch-swinnerton-dyer-oq-06": {
+      "quality": 100
+    },
+    "birthday-problem": {
+      "quality": 100
+    },
+    "birthday-problem-oq-02": {
+      "quality": 100
+    },
+    "birthday-problem-oq-02-oq-01": {
+      "quality": 100
+    },
+    "birthday-problem-oq-03": {
+      "quality": 100
+    },
+    "birthday-problem-oq-03-oq-01": {
+      "quality": 100
+    },
+    "birthday-problem-oq-03-oq-01-oq-01": {
+      "quality": 100
+    },
+    "birthday-problem-oq-03-oq-01-oq-02": {
+      "quality": 100
+    },
+    "birthday-problem-oq-03-oq-03": {
+      "quality": 100
+    },
+    "borsuk-ulam-oq-02": {
+      "quality": 100
+    },
+    "borsuk-ulam-oq-02-oq-01": {
+      "quality": 100
+    },
+    "borsuk-ulam-oq-02-oq-01-oq-01": {
+      "quality": 100
+    },
+    "borsuk-ulam-oq-02-oq-01-oq-03": {
+      "quality": 100
+    },
+    "borsuk-ulam-oq-02-oq-01-oq-04": {
+      "quality": 100
+    },
+    "borsuk-ulam-oq-02-oq-02": {
+      "quality": 100
+    },
+    "borsuk-ulam-oq-02-oq-03": {
+      "quality": 100
+    },
+    "borsuk-ulam-oq-03": {
+      "quality": 100
+    },
+    "borsuk-ulam-oq-03-oq-01": {
+      "quality": 100
+    },
+    "borsuk-ulam-oq-03-oq-01-oq-01": {
+      "quality": 100
+    },
+    "borsuk-ulam-oq-03-oq-03": {
+      "quality": 100
+    },
+    "borsuk-ulam-oq-04": {
+      "quality": 100
+    },
+    "bounded-prime-gaps-oq-01": {
+      "quality": 100
+    },
+    "bounded-prime-gaps-oq-03": {
+      "quality": 100
+    },
+    "bounded-prime-gaps-oq-03-oq-01": {
+      "quality": 100
+    },
+    "bounded-prime-gaps-oq-03-oq-01-oq-04": {
+      "quality": 100
+    },
+    "bounded-prime-gaps-oq-04": {
+      "quality": 100
+    },
+    "bounded-prime-gaps-oq-04-oq-01": {
+      "quality": 100
+    },
+    "brouwer-fixed-point": {
+      "quality": 100
+    },
+    "brouwer-fixed-point-oq-01-oq-02": {
+      "quality": 100
+    },
+    "brouwer-fixed-point-oq-01-oq-03": {
+      "quality": 100
+    },
+    "brouwer-fixed-point-oq-02": {
+      "quality": 100
+    },
+    "brouwer-fixed-point-oq-02-oq-02": {
+      "quality": 100
+    },
+    "brouwer-fixed-point-oq-04": {
+      "quality": 100
+    },
+    "brouwer-fixed-point-oq-04-oq-02": {
+      "quality": 100
+    },
+    "brouwer-fixed-point-oq-04-oq-03": {
+      "quality": 100
+    },
+    "brouwer-fixed-point-oq-04-oq-04": {
+      "quality": 100
+    },
+    "buffons-needle": {
+      "quality": 100
+    },
+    "buffons-needle-oq-01": {
+      "quality": 100
+    },
+    "buffons-needle-oq-01-oq-01": {
+      "quality": 100
+    },
+    "buffons-needle-oq-01-oq-01-oq-01": {
+      "quality": 100
+    },
+    "buffons-needle-oq-01-oq-01-oq-04": {
+      "quality": 100
+    },
+    "buffons-needle-oq-01-oq-02": {
+      "quality": 100
+    },
+    "buffons-needle-oq-02": {
+      "quality": 100
+    },
+    "buffons-needle-oq-02-oq-01": {
+      "quality": 100
+    },
+    "buffons-needle-oq-02-oq-02": {
+      "quality": 100
+    },
+    "burnside-counting": {
+      "quality": 100
+    },
+    "burnside-counting-oq-03": {
+      "quality": 100
+    },
+    "cantor-diagonalization-oq-01": {
+      "quality": 100
+    },
+    "cantor-diagonalization-oq-01-oq-01": {
+      "quality": 100
+    },
+    "cantor-diagonalization-oq-01-oq-01-oq-02": {
+      "quality": 100
+    },
+    "cantor-diagonalization-oq-01-oq-01-oq-02-oq-03": {
+      "quality": 100
+    },
+    "cantor-diagonalization-oq-02-oq-01": {
+      "quality": 100
+    },
+    "cantor-diagonalization-oq-02-oq-03": {
+      "quality": 100
+    },
+    "cantor-diagonalization-oq-02-oq-03-oq-02": {
+      "quality": 100
+    },
+    "cantor-diagonalization-oq-03": {
+      "quality": 100
+    },
+    "cantor-diagonalization-oq-03-oq-01-oq-01": {
+      "quality": 100
+    },
+    "cantor-diagonalization-oq-03-oq-01-oq-03": {
+      "quality": 100
+    },
+    "cantor-diagonalization-oq-04": {
+      "quality": 100
+    },
+    "cantor-diagonalization-oq-04-oq-03": {
+      "quality": 100
+    },
+    "cantors-theorem": {
+      "quality": 100
+    },
+    "cantors-theorem-oq-01": {
+      "quality": 100
+    },
+    "cantors-theorem-oq-01-oq-01": {
+      "quality": 100
+    },
+    "cantors-theorem-oq-02": {
+      "quality": 100
+    },
+    "cantors-theorem-oq-03": {
+      "quality": 100
+    },
+    "cauchy-schwarz-integral": {
+      "quality": 100
+    },
+    "cauchy-schwarz-integral-oq-01": {
+      "quality": 100
+    },
+    "cauchy-schwarz-integral-oq-01-oq-01": {
+      "quality": 100
+    },
+    "cauchy-schwarz-integral-oq-01-oq-01-oq-01": {
+      "quality": 100
+    },
+    "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02": {
+      "quality": 100
+    },
+    "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01": {
+      "quality": 100
+    },
+    "cauchy-schwarz-integral-oq-01-oq-01-oq-02": {
+      "quality": 100
+    },
+    "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01": {
+      "quality": 100
+    },
+    "cauchy-schwarz-integral-oq-01-oq-02": {
+      "quality": 100
+    },
+    "cauchy-schwarz-integral-oq-01-oq-03": {
+      "quality": 100
+    },
+    "cauchy-schwarz-integral-oq-01-oq-03-oq-01": {
+      "quality": 100
+    },
+    "cauchy-schwarz-integral-oq-02": {
+      "quality": 100
+    },
+    "cauchy-schwarz-integral-oq-02-oq-02": {
+      "quality": 100
+    },
+    "cauchy-schwarz-integral-oq-02-oq-02-oq-01": {
+      "quality": 100
+    },
+    "cauchy-schwarz-integral-oq-03": {
+      "quality": 100
+    },
+    "cauchy-schwarz-oq-01": {
+      "quality": 100
+    },
+    "cauchy-schwarz-oq-01-oq-01": {
+      "quality": 100
+    },
+    "cauchy-schwarz-oq-01-oq-01-oq-01": {
+      "quality": 100
+    },
+    "cauchy-schwarz-oq-01-oq-02": {
+      "quality": 100
+    },
+    "cauchy-schwarz-oq-01-oq-03": {
+      "quality": 100
+    },
+    "cauchy-schwarz-oq-01-oq-04": {
+      "quality": 100
+    },
+    "cauchy-schwarz-oq-02": {
+      "quality": 100
+    },
+    "cauchy-schwarz-oq-02-oq-01": {
+      "quality": 100
+    },
+    "cauchy-schwarz-oq-03-oq-01": {
+      "quality": 100
+    },
+    "cauchy-schwarz-oq-03-oq-02": {
+      "quality": 100
+    },
+    "cauchy-schwarz-oq-04": {
+      "quality": 100
+    },
+    "cauchy-schwarz-oq-04-oq-01": {
+      "quality": 100
+    },
+    "cayley-hamilton": {
+      "quality": 100
+    },
+    "cayley-hamilton-minpoly": {
+      "quality": 100
+    },
+    "cayley-hamilton-minpoly-oq-01": {
+      "quality": 100
+    },
+    "cayley-hamilton-minpoly-oq-02": {
+      "quality": 100
+    },
+    "cayley-hamilton-minpoly-oq-02-oq-01": {
+      "quality": 100
+    },
+    "cayley-hamilton-minpoly-oq-02-oq-01-oq-01": {
+      "quality": 100
+    },
+    "cayley-hamilton-minpoly-oq-02-oq-02": {
+      "quality": 100
+    },
+    "cayley-hamilton-minpoly-oq-02-oq-03": {
+      "quality": 100
+    },
+    "cayley-hamilton-minpoly-oq-03": {
+      "quality": 100
+    },
+    "cayley-hamilton-minpoly-oq-03-oq-01": {
+      "quality": 100
+    },
+    "cayley-hamilton-minpoly-oq-04": {
+      "quality": 100
+    },
+    "cayley-hamilton-minpoly-oq-05-oq-01": {
+      "quality": 100
+    },
+    "cayley-hamilton-minpoly-oq-05-oq-01-oq-01": {
+      "quality": 100
+    },
+    "cayley-hamilton-minpoly-oq-05-oq-01-oq-02": {
+      "quality": 100
+    },
+    "cayley-hamilton-minpoly-oq-05-oq-01-oq-03": {
+      "quality": 100
+    },
+    "cayley-hamilton-minpoly-oq-05-oq-01-oq-04": {
+      "quality": 100
+    },
+    "cayley-hamilton-minpoly-oq-05-oq-02": {
+      "quality": 100
+    },
+    "cayley-hamilton-oq-01": {
+      "quality": 100
+    },
+    "cayley-hamilton-oq-02": {
+      "quality": 100
+    },
+    "cayley-hamilton-reduction": {
+      "quality": 100
+    },
+    "cayley-hamilton-reduction-oq-01": {
+      "quality": 100
+    },
+    "cayley-hamilton-reduction-oq-01-oq-02": {
+      "quality": 100
+    },
+    "cayley-hamilton-reduction-oq-02": {
+      "quality": 100
+    },
+    "cayley-hamilton-reduction-oq-02-oq-01": {
+      "quality": 100
+    },
+    "central-limit-theorem": {
+      "quality": 100
+    },
+    "central-limit-theorem-oq-01": {
+      "quality": 100
+    },
+    "central-limit-theorem-oq-01-oq-01": {
+      "quality": 100
+    },
+    "central-limit-theorem-oq-01-oq-02": {
+      "quality": 100
+    },
+    "central-limit-theorem-oq-01-oq-02-oq-01": {
+      "quality": 100
+    },
+    "central-limit-theorem-oq-01-oq-02-oq-01-oq-01": {
+      "quality": 100
+    },
+    "central-limit-theorem-oq-01-oq-03": {
+      "quality": 100
+    },
+    "central-limit-theorem-oq-02": {
+      "quality": 100
+    },
+    "central-limit-theorem-oq-03": {
+      "quality": 100
+    },
+    "central-limit-theorem-oq-04": {
+      "quality": 100
+    },
+    "cevas-theorem": {
+      "quality": 100
+    },
+    "cevas-theorem-non-euclidean": {
+      "quality": 100
+    },
+    "cevas-theorem-non-euclidean-oq-02": {
+      "quality": 100
+    },
+    "cevas-theorem-oq-01": {
+      "quality": 100
+    },
+    "cevas-theorem-oq-02": {
+      "quality": 100
+    },
+    "cevas-theorem-oq-02-oq-01-oq-02": {
+      "quality": 100
+    },
+    "cevas-theorem-oq-02-oq-01-oq-03": {
+      "quality": 100
+    },
+    "cevas-theorem-oq-02-oq-02": {
+      "quality": 100
+    },
+    "cevas-theorem-oq-04": {
+      "quality": 100
+    },
+    "chebyshev-pnt-bridge": {
+      "quality": 100
+    },
+    "chebyshev-pnt-bridge-oq-01": {
+      "quality": 100
+    },
+    "chebyshev-pnt-bridge-oq-01-oq-02": {
+      "quality": 100
+    },
+    "chebyshev-pnt-bridge-oq-02": {
+      "quality": 100
+    },
+    "chinese-remainder-constructive": {
+      "quality": 100
+    },
+    "chinese-remainder-constructive-oq-03": {
+      "quality": 100
+    },
+    "chinese-remainder-constructive-oq-04": {
+      "quality": 100
+    },
+    "chinese-remainder-constructive-oq-04-oq-03": {
+      "quality": 100
+    },
+    "chinese-remainder-non-coprime": {
+      "quality": 100
+    },
+    "chinese-remainder-non-coprime-oq-01": {
+      "quality": 100
+    },
+    "chinese-remainder-non-coprime-oq-01-oq-01": {
+      "quality": 100
+    },
+    "chinese-remainder-non-coprime-oq-02": {
+      "quality": 100
+    },
+    "chinese-remainder-non-coprime-oq-03": {
+      "quality": 100
+    },
+    "chinese-remainder-non-coprime-oq-03-oq-02": {
+      "quality": 100
+    },
+    "chinese-remainder-non-coprime-oq-04": {
+      "quality": 100
+    },
+    "collatz-cycles": {
+      "quality": 100
+    },
+    "collatz-cycles-oq-04": {
+      "quality": 100
+    },
+    "collatz-structured": {
+      "quality": 100
+    },
+    "collatz-structured-oq-02": {
+      "quality": 100
+    },
+    "collatz-structured-oq-02-oq-01": {
+      "quality": 100
+    },
+    "combinations-formula": {
+      "quality": 100
+    },
+    "combinations-formula-oq-01": {
+      "quality": 100
+    },
+    "combinations-formula-oq-02": {
+      "quality": 100
+    },
+    "continuum-hypothesis-oq-01": {
+      "quality": 100
+    },
+    "continuum-hypothesis-oq-02": {
+      "quality": 100
+    },
+    "cramers-rule-oq-01": {
+      "quality": 100
+    },
+    "cramers-rule-oq-01-oq-02": {
+      "quality": 100
+    },
+    "cramers-rule-oq-01-oq-03": {
+      "quality": 100
+    },
+    "cramers-rule-oq-02": {
+      "quality": 100
+    },
+    "cramers-rule-oq-03": {
+      "quality": 100
+    },
+    "cramers-rule-oq-04": {
+      "quality": 100
+    },
+    "cube-root-2-irrational": {
+      "quality": 100
+    },
+    "cube-root-3-irrational": {
+      "quality": 100
+    },
+    "cube-root-3-irrational-oq-02": {
+      "quality": 100
+    },
+    "de-moivre-oq-01": {
+      "quality": 100
+    },
+    "de-moivre-oq-03": {
+      "quality": 100
+    },
+    "de-moivre-oq-03-oq-01": {
+      "quality": 100
+    },
+    "denumerability-rationals-oq-01": {
+      "quality": 100
+    },
+    "denumerability-rationals-oq-02": {
+      "quality": 100
+    },
+    "denumerability-rationals-oq-02-oq-02": {
+      "quality": 100
+    },
+    "denumerability-rationals-oq-03": {
+      "quality": 100
+    },
+    "derangements-convergence": {
+      "quality": 100
+    },
+    "derangements-convergence-oq-01": {
+      "quality": 100
+    },
+    "derangements-oq-02": {
+      "quality": 100
+    },
+    "derangements-oq-02-oq-01": {
+      "quality": 100
+    },
+    "derangements-oq-02-oq-02": {
+      "quality": 100
+    },
+    "derangements-oq-03": {
+      "quality": 100
+    },
+    "derangements-oq-03-oq-01": {
+      "quality": 100
+    },
+    "derangements-oq-03-oq-01-oq-02": {
+      "quality": 100
+    },
+    "derangements-oq-03-oq-02": {
+      "quality": 100
+    },
+    "desargues-theorem": {
+      "quality": 100
+    },
+    "desargues-theorem-oq-01": {
+      "quality": 100
+    },
+    "desargues-theorem-oq-02": {
+      "quality": 100
+    },
+    "desargues-theorem-oq-04": {
+      "quality": 100
+    },
+    "descartes-rule-of-signs": {
+      "quality": 100
+    },
+    "descartes-rule-of-signs-oq-01": {
+      "quality": 100
+    },
+    "descartes-rule-of-signs-oq-01-oq-01": {
+      "quality": 100
+    },
+    "descartes-rule-of-signs-oq-01-oq-02": {
+      "quality": 100
+    },
+    "descartes-rule-of-signs-oq-02": {
+      "quality": 100
+    },
+    "descartes-rule-of-signs-oq-03": {
+      "quality": 100
+    },
+    "descartes-rule-of-signs-oq-04": {
+      "quality": 100
+    },
+    "dirichlets-theorem": {
+      "quality": 100
+    },
+    "dirichlets-theorem-oq-01": {
+      "quality": 100
+    },
+    "dirichlets-theorem-oq-02": {
+      "quality": 100
+    },
+    "dirichlets-theorem-oq-02-oq-01": {
+      "quality": 100
+    },
+    "dirichlets-theorem-oq-03": {
+      "quality": 100
+    },
+    "dissection-of-cubes": {
+      "quality": 100
+    },
+    "dissection-of-cubes-oq-01": {
+      "quality": 100
+    },
+    "dissection-of-cubes-oq-01-oq-01": {
+      "quality": 100
+    },
+    "dissection-of-cubes-oq-02": {
+      "quality": 100
+    },
+    "dissection-of-cubes-oq-02-oq-02": {
+      "quality": 100
+    },
+    "dissection-of-cubes-oq-03": {
+      "quality": 100
+    },
+    "dissection-of-cubes-oq-04": {
+      "quality": 100
+    },
+    "divisibility-by-3": {
+      "quality": 100
+    },
+    "divisibility-by-3-oq-01": {
+      "quality": 100
+    },
+    "divisibility-by-3-oq-03": {
+      "quality": 100
+    },
+    "divisibility-by-3-oq-03-oq-02": {
+      "quality": 100
+    },
+    "divisibility-by-3-oq-04": {
+      "quality": 100
+    },
+    "divisibility-by-3-oq-04-oq-02": {
+      "quality": 100
+    },
+    "divisibility-by-three-oq-01": {
+      "quality": 100
+    },
+    "divisibility-by-three-oq-01-oq-02": {
+      "quality": 100
+    },
+    "divisibility-by-three-oq-02": {
+      "quality": 100
+    },
+    "divisibility-rules": {
+      "quality": 100
+    },
+    "divisibility-rules-oq-01": {
+      "quality": 100
+    },
+    "divisibility-rules-oq-01-oq-01": {
+      "quality": 100
+    },
+    "divisibility-rules-oq-01-oq-01-oq-01": {
+      "quality": 100
+    },
+    "divisibility-truncation-general": {
+      "quality": 100
+    },
+    "divisibility-truncation-general-oq-01": {
+      "quality": 100
+    },
+    "e-transcendental": {
+      "quality": 100
+    },
+    "e-transcendental-oq-01": {
+      "quality": 100
+    },
+    "elementary-quadratic-reciprocity": {
+      "quality": 100
+    },
+    "elementary-quadratic-reciprocity-oq-01": {
+      "quality": 100
+    },
+    "elementary-quadratic-reciprocity-oq-01-oq-01": {
+      "quality": 100
+    },
+    "elementary-quadratic-reciprocity-oq-02": {
+      "quality": 100
+    },
+    "elementary-quadratic-reciprocity-oq-03": {
+      "quality": 100
+    },
+    "elementary-quadratic-reciprocity-oq-03-oq-01": {
+      "quality": 100
+    },
+    "elementary-quadratic-reciprocity-oq-03-oq-02": {
+      "quality": 100
+    },
+    "erdos-1": {
+      "quality": 100
+    },
+    "erdos-1-oq-03": {
+      "quality": 100
+    },
+    "erdos-10": {
+      "quality": 100
+    },
+    "erdos-100": {
+      "quality": 100
+    },
+    "erdos-100-oq-02": {
+      "quality": 100
+    },
+    "erdos-100-oq-02-oq-02": {
+      "quality": 100
+    },
+    "erdos-1000": {
+      "quality": 100
+    },
+    "erdos-1001": {
+      "quality": 100
+    },
+    "erdos-1001-oq-03": {
+      "quality": 100
+    },
+    "erdos-1002": {
+      "quality": 100
+    },
+    "erdos-1002-oq-01": {
+      "quality": 100
+    },
+    "erdos-1002-oq-01-oq-01": {
+      "quality": 100
+    },
+    "erdos-1003": {
+      "quality": 100
+    },
+    "erdos-1006-oq-01": {
+      "quality": 100
+    },
+    "erdos-1006-oq-02": {
+      "quality": 100
+    },
+    "erdos-1006-oq-02-oq-03": {
+      "quality": 100
+    },
+    "erdos-1007": {
+      "quality": 100
+    },
+    "erdos-1007-oq-01": {
+      "quality": 100
+    },
+    "erdos-1007-oq-01-oq-01": {
+      "quality": 100
+    },
+    "erdos-1007-oq-05": {
+      "quality": 100
+    },
+    "erdos-1008-oq-01": {
+      "quality": 100
+    },
+    "erdos-1008-oq-04": {
+      "quality": 100
+    },
+    "erdos-1009": {
+      "quality": 100
+    },
+    "erdos-1009-oq-02": {
+      "quality": 100
+    },
+    "erdos-101": {
+      "quality": 100
+    },
+    "erdos-1010": {
+      "quality": 100
+    },
+    "erdos-1011": {
+      "quality": 100
+    },
+    "erdos-1012": {
+      "quality": 100
+    },
+    "erdos-1012-oq-01": {
+      "quality": 100
+    },
+    "erdos-1012-oq-02": {
+      "quality": 100
+    },
+    "erdos-1013": {
+      "quality": 100
+    },
+    "erdos-1014": {
+      "quality": 100
+    },
+    "erdos-1014-oq-01": {
+      "quality": 100
+    },
+    "erdos-1014-oq-02": {
+      "quality": 100
+    },
+    "erdos-1015": {
+      "quality": 100
+    },
+    "erdos-1015-oq-01": {
+      "quality": 100
+    },
+    "erdos-1016": {
+      "quality": 100
+    },
+    "erdos-1017-oq-01": {
+      "quality": 100
+    },
+    "erdos-1018": {
+      "quality": 100
+    },
+    "erdos-1018-oq-04": {
+      "quality": 100
+    },
+    "erdos-1018-oq-04-incomplete-01": {
+      "quality": 100
+    },
+    "erdos-1019": {
+      "quality": 100
+    },
+    "erdos-102": {
+      "quality": 100
+    },
+    "erdos-1020": {
+      "quality": 100
+    },
+    "erdos-1021": {
+      "quality": 100
+    },
+    "erdos-1021-oq-01": {
+      "quality": 100
+    },
+    "erdos-1023": {
+      "quality": 100
+    },
+    "erdos-1023-oq-01": {
+      "quality": 100
+    },
+    "erdos-1024": {
+      "quality": 100
+    },
+    "erdos-1025": {
+      "quality": 100
+    },
+    "erdos-1026": {
+      "quality": 100
+    },
+    "erdos-1027-oq-01": {
+      "quality": 100
+    },
+    "erdos-1027-oq-03": {
+      "quality": 100
+    },
+    "erdos-1028": {
+      "quality": 100
+    },
+    "erdos-1029": {
+      "quality": 100
+    },
+    "erdos-103": {
+      "quality": 100
+    },
+    "erdos-103-oq-01": {
+      "quality": 100
+    },
+    "erdos-1030": {
+      "quality": 100
+    },
+    "erdos-1031": {
+      "quality": 100
+    },
+    "erdos-1032": {
+      "quality": 100
+    },
+    "erdos-1033": {
+      "quality": 100
+    },
+    "erdos-1034": {
+      "quality": 100
+    },
+    "erdos-1035": {
+      "quality": 100
+    },
+    "erdos-1037": {
+      "quality": 100
+    },
+    "erdos-1038": {
+      "quality": 100
+    },
+    "erdos-1039": {
+      "quality": 100
+    },
+    "erdos-104": {
+      "quality": 100
+    },
+    "erdos-1041": {
+      "quality": 100
+    },
+    "erdos-1042": {
+      "quality": 100
+    },
+    "erdos-1043": {
+      "quality": 100
+    },
+    "erdos-1044": {
+      "quality": 100
+    },
+    "erdos-1045": {
+      "quality": 100
+    },
+    "erdos-1046": {
+      "quality": 100
+    },
+    "erdos-1047": {
+      "quality": 100
+    },
+    "erdos-105": {
+      "quality": 100
+    },
+    "erdos-105-oq-02": {
+      "quality": 100
+    },
+    "erdos-105-oq-05": {
+      "quality": 100
+    },
+    "erdos-1051": {
+      "quality": 100
+    },
+    "erdos-1052": {
+      "quality": 100
+    },
+    "erdos-1054": {
+      "quality": 100
+    },
+    "erdos-1054-oq-01": {
+      "quality": 100
+    },
+    "erdos-1056": {
+      "quality": 100
+    },
+    "erdos-1059-oq-01": {
+      "quality": 100
+    },
+    "erdos-1059-oq-01-oq-01": {
+      "quality": 100
+    },
+    "erdos-1059-oq-02": {
+      "quality": 100
+    },
+    "erdos-1059-oq-02-oq-01": {
+      "quality": 100
+    },
+    "erdos-1059-oq-03": {
+      "quality": 100
+    },
+    "erdos-1059-oq-05": {
+      "quality": 100
+    },
+    "erdos-106-oq-02": {
+      "quality": 100
+    },
+    "erdos-1061": {
+      "quality": 100
+    },
+    "erdos-1062": {
+      "quality": 100
+    },
+    "erdos-1063": {
+      "quality": 100
+    },
+    "erdos-1064": {
+      "quality": 100
+    },
+    "erdos-1065-oq-05": {
+      "quality": 100
+    },
+    "erdos-1066": {
+      "quality": 100
+    },
+    "erdos-1066-oq-04": {
+      "quality": 100
+    },
+    "erdos-1067": {
+      "quality": 100
+    },
+    "erdos-1068": {
+      "quality": 100
+    },
+    "erdos-1069": {
+      "quality": 100
+    },
+    "erdos-107": {
+      "quality": 100
+    },
+    "erdos-1070": {
+      "quality": 100
+    },
+    "erdos-1071": {
+      "quality": 100
+    },
+    "erdos-1072": {
+      "quality": 100
+    },
+    "erdos-1073": {
+      "quality": 100
+    },
+    "erdos-1074": {
+      "quality": 100
+    },
+    "erdos-1075": {
+      "quality": 100
+    },
+    "erdos-1076": {
+      "quality": 100
+    },
+    "erdos-1077": {
+      "quality": 100
+    },
+    "erdos-1078": {
+      "quality": 100
+    },
+    "erdos-1079": {
+      "quality": 100
+    },
+    "erdos-108": {
+      "quality": 100
+    },
+    "erdos-1080": {
+      "quality": 100
+    },
+    "erdos-1081": {
+      "quality": 100
+    },
+    "erdos-1082": {
+      "quality": 100
+    },
+    "erdos-1083": {
+      "quality": 100
+    },
+    "erdos-1083-oq-02": {
+      "quality": 100
+    },
+    "erdos-1085": {
+      "quality": 100
+    },
+    "erdos-1086": {
+      "quality": 100
+    },
+    "erdos-1087": {
+      "quality": 100
+    },
+    "erdos-1088": {
+      "quality": 100
+    },
+    "erdos-109": {
+      "quality": 100
+    },
+    "erdos-109-oq-01": {
+      "quality": 100
+    },
+    "erdos-1090": {
+      "quality": 100
+    },
+    "erdos-1091": {
+      "quality": 100
+    },
+    "erdos-1092": {
+      "quality": 100
+    },
+    "erdos-1093": {
+      "quality": 100
+    },
+    "erdos-1094": {
+      "quality": 100
+    },
+    "erdos-1095-oq-01": {
+      "quality": 100
+    },
+    "erdos-1096": {
+      "quality": 100
+    },
+    "erdos-1098": {
+      "quality": 100
+    },
+    "erdos-1098-oq-01-oq-01": {
+      "quality": 100
+    },
+    "erdos-1098-oq-04": {
+      "quality": 100
+    },
+    "erdos-1099": {
+      "quality": 100
+    },
+    "erdos-11": {
+      "quality": 100
+    },
+    "erdos-110": {
+      "quality": 100
+    },
+    "erdos-1100": {
+      "quality": 100
+    },
+    "erdos-1101": {
+      "quality": 100
+    },
+    "erdos-1102": {
+      "quality": 100
+    },
+    "erdos-1104": {
+      "quality": 100
+    },
+    "erdos-1105": {
+      "quality": 100
+    },
+    "erdos-1106": {
+      "quality": 100
+    },
+    "erdos-1107": {
+      "quality": 100
+    },
+    "erdos-1107-oq-02": {
+      "quality": 100
+    },
+    "erdos-1108": {
+      "quality": 100
+    },
+    "erdos-1109": {
+      "quality": 100
+    },
+    "erdos-111": {
+      "quality": 100
+    },
+    "erdos-1110": {
+      "quality": 100
+    },
+    "erdos-1111": {
+      "quality": 100
+    },
+    "erdos-1112": {
+      "quality": 100
+    },
+    "erdos-1113": {
+      "quality": 100
+    },
+    "erdos-1114": {
+      "quality": 100
+    },
+    "erdos-1115": {
+      "quality": 100
+    },
+    "erdos-1116": {
+      "quality": 100
+    },
+    "erdos-1117": {
+      "quality": 100
+    },
+    "erdos-1118": {
+      "quality": 100
+    },
+    "erdos-1119": {
+      "quality": 100
+    },
+    "erdos-112": {
+      "quality": 100
+    },
+    "erdos-1120": {
+      "quality": 100
+    },
+    "erdos-1121": {
+      "quality": 100
+    },
+    "erdos-1122": {
+      "quality": 100
+    },
+    "erdos-1123": {
+      "quality": 100
+    },
+    "erdos-1124": {
+      "quality": 100
+    },
+    "erdos-1124-oq-01": {
+      "quality": 100
+    },
+    "erdos-1125": {
+      "quality": 100
+    },
+    "erdos-1126": {
+      "quality": 100
+    },
+    "erdos-1126-oq-01": {
+      "quality": 100
+    },
+    "erdos-1128": {
+      "quality": 100
+    },
+    "erdos-1129": {
+      "quality": 100
+    },
+    "erdos-1129-oq-02": {
+      "quality": 100
+    },
+    "erdos-113": {
+      "quality": 100
+    },
+    "erdos-1131": {
+      "quality": 100
+    },
+    "erdos-1131-oq-01": {
+      "quality": 100
+    },
+    "erdos-1132": {
+      "quality": 100
+    },
+    "erdos-1133": {
+      "quality": 100
+    },
+    "erdos-1134": {
+      "quality": 100
+    },
+    "erdos-1135": {
+      "quality": 100
+    },
+    "erdos-1136": {
+      "quality": 100
+    },
+    "erdos-1137": {
+      "quality": 100
+    },
+    "erdos-1138": {
+      "quality": 100
+    },
+    "erdos-1138-oq-03": {
+      "quality": 100
+    },
+    "erdos-1139": {
+      "quality": 100
+    },
+    "erdos-114": {
+      "quality": 100
+    },
+    "erdos-114-oq-01": {
+      "quality": 100
+    },
+    "erdos-114-oq-04": {
+      "quality": 100
+    },
+    "erdos-1140": {
+      "quality": 100
+    },
+    "erdos-1141": {
+      "quality": 100
+    },
+    "erdos-1142": {
+      "quality": 100
+    },
+    "erdos-1143": {
+      "quality": 100
+    },
+    "erdos-1144": {
+      "quality": 100
+    },
+    "erdos-1145": {
+      "quality": 100
+    },
+    "erdos-1146": {
+      "quality": 100
+    },
+    "erdos-1147": {
+      "quality": 100
+    },
+    "erdos-1148": {
+      "quality": 100
+    },
+    "erdos-1149": {
+      "quality": 100
+    },
+    "erdos-115": {
+      "quality": 100
+    },
+    "erdos-1150": {
+      "quality": 100
+    },
+    "erdos-1151": {
+      "quality": 100
+    },
+    "erdos-1153": {
+      "quality": 100
+    },
+    "erdos-1155": {
+      "quality": 100
+    },
+    "erdos-1155-oq-01-oq-01": {
+      "quality": 100
+    },
+    "erdos-1155-oq-01-oq-07": {
+      "quality": 100
+    },
+    "erdos-1155-oq-02": {
+      "quality": 100
+    },
+    "erdos-1156": {
+      "quality": 100
+    },
+    "erdos-1157": {
+      "quality": 100
+    },
+    "erdos-1158": {
+      "quality": 100
+    },
+    "erdos-1159": {
+      "quality": 100
+    },
+    "erdos-116": {
+      "quality": 100
+    },
+    "erdos-1160": {
+      "quality": 100
+    },
+    "erdos-1165": {
+      "quality": 100
+    },
+    "erdos-1166": {
+      "quality": 100
+    },
+    "erdos-1167": {
+      "quality": 100
+    },
+    "erdos-1168": {
+      "quality": 100
+    },
+    "erdos-1169": {
+      "quality": 100
+    },
+    "erdos-117-oq-01": {
+      "quality": 100
+    },
+    "erdos-1170": {
+      "quality": 100
+    },
+    "erdos-1171": {
+      "quality": 100
+    },
+    "erdos-1172": {
+      "quality": 100
+    },
+    "erdos-1173": {
+      "quality": 100
+    },
+    "erdos-1174": {
+      "quality": 100
+    },
+    "erdos-1175": {
+      "quality": 100
+    },
+    "erdos-1176": {
+      "quality": 100
+    },
+    "erdos-1177": {
+      "quality": 100
+    },
+    "erdos-1178": {
+      "quality": 100
+    },
+    "erdos-1179": {
+      "quality": 100
+    },
+    "erdos-1179-oq-01": {
+      "quality": 100
+    },
+    "erdos-118": {
+      "quality": 100
+    },
+    "erdos-1181": {
+      "quality": 100
+    },
+    "erdos-1182": {
+      "quality": 100
+    },
+    "erdos-1183": {
+      "quality": 100
+    },
+    "erdos-119": {
+      "quality": 100
+    },
+    "erdos-1196": {
+      "quality": 100
+    },
+    "erdos-12": {
+      "quality": 100
+    },
+    "erdos-120": {
+      "quality": 100
+    },
+    "erdos-121": {
+      "quality": 100
+    },
+    "erdos-122": {
+      "quality": 100
+    },
+    "erdos-123": {
+      "quality": 100
+    },
+    "erdos-124": {
+      "quality": 100
+    },
+    "erdos-124-complete-sequences": {
+      "quality": 100
+    },
+    "erdos-125": {
+      "quality": 100
+    },
+    "erdos-126": {
+      "quality": 100
+    },
+    "erdos-127": {
+      "quality": 100
+    },
+    "erdos-128": {
+      "quality": 100
+    },
+    "erdos-129": {
+      "quality": 100
+    },
+    "erdos-13": {
+      "quality": 100
+    },
+    "erdos-130": {
+      "quality": 100
+    },
+    "erdos-130-wip-01": {
+      "quality": 100
+    },
+    "erdos-131": {
+      "quality": 100
+    },
+    "erdos-131-oq-01": {
+      "quality": 100
+    },
+    "erdos-132": {
+      "quality": 100
+    },
+    "erdos-133": {
+      "quality": 100
+    },
+    "erdos-134": {
+      "quality": 100
+    },
+    "erdos-135": {
+      "quality": 100
+    },
+    "erdos-136": {
+      "quality": 100
+    },
+    "erdos-137": {
+      "quality": 100
+    },
+    "erdos-138": {
+      "quality": 100
+    },
+    "erdos-139": {
+      "quality": 100
+    },
+    "erdos-14": {
+      "quality": 100
+    },
+    "erdos-14-unique-sums": {
+      "quality": 100
+    },
+    "erdos-140": {
+      "quality": 100
+    },
+    "erdos-141": {
+      "quality": 100
+    },
+    "erdos-142": {
+      "quality": 100
+    },
+    "erdos-143": {
+      "quality": 100
+    },
+    "erdos-144": {
+      "quality": 100
+    },
+    "erdos-145": {
+      "quality": 100
+    },
+    "erdos-146": {
+      "quality": 100
+    },
+    "erdos-147": {
+      "quality": 100
+    },
+    "erdos-148": {
+      "quality": 100
+    },
+    "erdos-149": {
+      "quality": 100
+    },
+    "erdos-15": {
+      "quality": 100
+    },
+    "erdos-150": {
+      "quality": 100
+    },
+    "erdos-152": {
+      "quality": 100
+    },
+    "erdos-152-oq-01": {
+      "quality": 100
+    },
+    "erdos-153": {
+      "quality": 100
+    },
+    "erdos-154": {
+      "quality": 100
+    },
+    "erdos-155": {
+      "quality": 100
+    },
+    "erdos-156": {
+      "quality": 100
+    },
+    "erdos-157": {
+      "quality": 100
+    },
+    "erdos-158": {
+      "quality": 100
+    },
+    "erdos-159": {
+      "quality": 100
+    },
+    "erdos-16": {
+      "quality": 100
+    },
+    "erdos-160": {
+      "quality": 100
+    },
+    "erdos-161": {
+      "quality": 100
+    },
+    "erdos-162": {
+      "quality": 100
+    },
+    "erdos-163": {
+      "quality": 100
+    },
+    "erdos-164": {
+      "quality": 100
+    },
+    "erdos-165": {
+      "quality": 100
+    },
+    "erdos-166": {
+      "quality": 100
+    },
+    "erdos-167": {
+      "quality": 100
+    },
+    "erdos-168": {
+      "quality": 100
+    },
+    "erdos-169": {
+      "quality": 100
+    },
+    "erdos-17": {
+      "quality": 100
+    },
+    "erdos-170": {
+      "quality": 100
+    },
+    "erdos-171": {
+      "quality": 100
+    },
+    "erdos-172": {
+      "quality": 100
+    },
+    "erdos-173": {
+      "quality": 100
+    },
+    "erdos-174": {
+      "quality": 100
+    },
+    "erdos-175": {
+      "quality": 100
+    },
+    "erdos-176": {
+      "quality": 100
+    },
+    "erdos-177": {
+      "quality": 100
+    },
+    "erdos-177-oq-04": {
+      "quality": 100
+    },
+    "erdos-178": {
+      "quality": 100
+    },
+    "erdos-179": {
+      "quality": 100
+    },
+    "erdos-18": {
+      "quality": 100
+    },
+    "erdos-180": {
+      "quality": 100
+    },
+    "erdos-181-oq-01": {
+      "quality": 100
+    },
+    "erdos-182": {
+      "quality": 100
+    },
+    "erdos-183": {
+      "quality": 100
+    },
+    "erdos-184": {
+      "quality": 100
+    },
+    "erdos-185": {
+      "quality": 100
+    },
+    "erdos-186": {
+      "quality": 100
+    },
+    "erdos-188": {
+      "quality": 100
+    },
+    "erdos-189": {
+      "quality": 100
+    },
+    "erdos-19": {
+      "quality": 100
+    },
+    "erdos-190": {
+      "quality": 100
+    },
+    "erdos-191": {
+      "quality": 100
+    },
+    "erdos-192": {
+      "quality": 100
+    },
+    "erdos-193": {
+      "quality": 100
+    },
+    "erdos-194": {
+      "quality": 100
+    },
+    "erdos-195": {
+      "quality": 100
+    },
+    "erdos-196": {
+      "quality": 100
+    },
+    "erdos-197": {
+      "quality": 100
+    },
+    "erdos-198": {
+      "quality": 100
+    },
+    "erdos-199": {
+      "quality": 100
+    },
+    "erdos-2": {
+      "quality": 100
+    },
+    "erdos-2-oq-01": {
+      "quality": 100
+    },
+    "erdos-20": {
+      "quality": 100
+    },
+    "erdos-200": {
+      "quality": 100
+    },
+    "erdos-201": {
+      "quality": 100
+    },
+    "erdos-202": {
+      "quality": 100
+    },
+    "erdos-203": {
+      "quality": 100
+    },
+    "erdos-204": {
+      "quality": 100
+    },
+    "erdos-205": {
+      "quality": 100
+    },
+    "erdos-206": {
+      "quality": 100
+    },
+    "erdos-207": {
+      "quality": 100
+    },
+    "erdos-208": {
+      "quality": 100
+    },
+    "erdos-209": {
+      "quality": 100
+    },
+    "erdos-21": {
+      "quality": 100
+    },
+    "erdos-210": {
+      "quality": 100
+    },
+    "erdos-211": {
+      "quality": 100
+    },
+    "erdos-212": {
+      "quality": 100
+    },
+    "erdos-213": {
+      "quality": 100
+    },
+    "erdos-214": {
+      "quality": 100
+    },
+    "erdos-215": {
+      "quality": 100
+    },
+    "erdos-218": {
+      "quality": 100
+    },
+    "erdos-219": {
+      "quality": 100
+    },
+    "erdos-22": {
+      "quality": 100
+    },
+    "erdos-221": {
+      "quality": 100
+    },
+    "erdos-222": {
+      "quality": 100
+    },
+    "erdos-223": {
+      "quality": 100
+    },
+    "erdos-224": {
+      "quality": 100
+    },
+    "erdos-225": {
+      "quality": 100
+    },
+    "erdos-226": {
+      "quality": 100
+    },
+    "erdos-228": {
+      "quality": 100
+    },
+    "erdos-229": {
+      "quality": 100
+    },
+    "erdos-23": {
+      "quality": 100
+    },
+    "erdos-230": {
+      "quality": 100
+    },
+    "erdos-231": {
+      "quality": 100
+    },
+    "erdos-232": {
+      "quality": 100
+    },
+    "erdos-233": {
+      "quality": 100
+    },
+    "erdos-235": {
+      "quality": 100
+    },
+    "erdos-236": {
+      "quality": 100
+    },
+    "erdos-238": {
+      "quality": 100
+    },
+    "erdos-239": {
+      "quality": 100
+    },
+    "erdos-24": {
+      "quality": 100
+    },
+    "erdos-240": {
+      "quality": 100
+    },
+    "erdos-241": {
+      "quality": 100
+    },
+    "erdos-242": {
+      "quality": 100
+    },
+    "erdos-243": {
+      "quality": 100
+    },
+    "erdos-244": {
+      "quality": 100
+    },
+    "erdos-245": {
+      "quality": 100
+    },
+    "erdos-246": {
+      "quality": 100
+    },
+    "erdos-247-oq-01": {
+      "quality": 100
+    },
+    "erdos-248": {
+      "quality": 100
+    },
+    "erdos-249": {
+      "quality": 100
+    },
+    "erdos-249-oq-01": {
+      "quality": 100
+    },
+    "erdos-25": {
+      "quality": 100
+    },
+    "erdos-250": {
+      "quality": 100
+    },
+    "erdos-251": {
+      "quality": 100
+    },
+    "erdos-252": {
+      "quality": 100
+    },
+    "erdos-253": {
+      "quality": 100
+    },
+    "erdos-254": {
+      "quality": 100
+    },
+    "erdos-255": {
+      "quality": 100
+    },
+    "erdos-256": {
+      "quality": 100
+    },
+    "erdos-257": {
+      "quality": 100
+    },
+    "erdos-258": {
+      "quality": 100
+    },
+    "erdos-259": {
+      "quality": 100
+    },
+    "erdos-26": {
+      "quality": 100
+    },
+    "erdos-261": {
+      "quality": 100
+    },
+    "erdos-262": {
+      "quality": 100
+    },
+    "erdos-264": {
+      "quality": 100
+    },
+    "erdos-265": {
+      "quality": 100
+    },
+    "erdos-266": {
+      "quality": 100
+    },
+    "erdos-267": {
+      "quality": 100
+    },
+    "erdos-269": {
+      "quality": 100
+    },
+    "erdos-27": {
+      "quality": 100
+    },
+    "erdos-270": {
+      "quality": 100
+    },
+    "erdos-271": {
+      "quality": 100
+    },
+    "erdos-272": {
+      "quality": 100
+    },
+    "erdos-274": {
+      "quality": 100
+    },
+    "erdos-275": {
+      "quality": 100
+    },
+    "erdos-276": {
+      "quality": 100
+    },
+    "erdos-279": {
+      "quality": 100
+    },
+    "erdos-28-additive-bases": {
+      "quality": 100
+    },
+    "erdos-280": {
+      "quality": 100
+    },
+    "erdos-281": {
+      "quality": 100
+    },
+    "erdos-282": {
+      "quality": 100
+    },
+    "erdos-283": {
+      "quality": 100
+    },
+    "erdos-284": {
+      "quality": 100
+    },
+    "erdos-285": {
+      "quality": 100
+    },
+    "erdos-286": {
+      "quality": 100
+    },
+    "erdos-288": {
+      "quality": 100
+    },
+    "erdos-29": {
+      "quality": 100
+    },
+    "erdos-29-oq-02": {
+      "quality": 100
+    },
+    "erdos-290": {
+      "quality": 100
+    },
+    "erdos-291": {
+      "quality": 100
+    },
+    "erdos-292": {
+      "quality": 100
+    },
+    "erdos-293": {
+      "quality": 100
+    },
+    "erdos-295": {
+      "quality": 100
+    },
+    "erdos-296": {
+      "quality": 100
+    },
+    "erdos-297": {
+      "quality": 100
+    },
+    "erdos-298": {
+      "quality": 100
+    },
+    "erdos-299": {
+      "quality": 100
+    },
+    "erdos-3": {
+      "quality": 100
+    },
+    "erdos-30": {
+      "quality": 100
+    },
+    "erdos-300": {
+      "quality": 100
+    },
+    "erdos-301": {
+      "quality": 100
+    },
+    "erdos-302": {
+      "quality": 100
+    },
+    "erdos-303": {
+      "quality": 100
+    },
+    "erdos-304": {
+      "quality": 100
+    },
+    "erdos-305": {
+      "quality": 100
+    },
+    "erdos-306": {
+      "quality": 100
+    },
+    "erdos-307": {
+      "quality": 100
+    },
+    "erdos-308": {
+      "quality": 100
+    },
+    "erdos-309": {
+      "quality": 100
+    },
+    "erdos-31": {
+      "quality": 100
+    },
+    "erdos-310": {
+      "quality": 100
+    },
+    "erdos-312": {
+      "quality": 100
+    },
+    "erdos-313": {
+      "quality": 100
+    },
+    "erdos-314": {
+      "quality": 100
+    },
+    "erdos-315": {
+      "quality": 100
+    },
+    "erdos-316": {
+      "quality": 100
+    },
+    "erdos-317": {
+      "quality": 100
+    },
+    "erdos-318": {
+      "quality": 100
+    },
+    "erdos-32": {
+      "quality": 100
+    },
+    "erdos-320": {
+      "quality": 100
+    },
+    "erdos-322": {
+      "quality": 100
+    },
+    "erdos-323": {
+      "quality": 100
+    },
+    "erdos-325": {
+      "quality": 100
+    },
+    "erdos-326": {
+      "quality": 100
+    },
+    "erdos-327": {
+      "quality": 100
+    },
+    "erdos-327-oq-01": {
+      "quality": 100
+    },
+    "erdos-327-oq-01-oq-04": {
+      "quality": 100
+    },
+    "erdos-328": {
+      "quality": 100
+    },
+    "erdos-329": {
+      "quality": 100
+    },
+    "erdos-33": {
+      "quality": 100
+    },
+    "erdos-333": {
+      "quality": 100
+    },
+    "erdos-334": {
+      "quality": 100
+    },
+    "erdos-335": {
+      "quality": 100
+    },
+    "erdos-336": {
+      "quality": 100
+    },
+    "erdos-337": {
+      "quality": 100
+    },
+    "erdos-338": {
+      "quality": 100
+    },
+    "erdos-339": {
+      "quality": 100
+    },
+    "erdos-34": {
+      "quality": 100
+    },
+    "erdos-340-greedy-sidon": {
+      "quality": 100
+    },
+    "erdos-342": {
+      "quality": 100
+    },
+    "erdos-343": {
+      "quality": 100
+    },
+    "erdos-344": {
+      "quality": 100
+    },
+    "erdos-345": {
+      "quality": 100
+    },
+    "erdos-346": {
+      "quality": 100
+    },
+    "erdos-348": {
+      "quality": 100
+    },
+    "erdos-349": {
+      "quality": 100
+    },
+    "erdos-35": {
+      "quality": 100
+    },
+    "erdos-350": {
+      "quality": 100
+    },
+    "erdos-351": {
+      "quality": 100
+    },
+    "erdos-352": {
+      "quality": 100
+    },
+    "erdos-353": {
+      "quality": 100
+    },
+    "erdos-354": {
+      "quality": 100
+    },
+    "erdos-355": {
+      "quality": 100
+    },
+    "erdos-356": {
+      "quality": 100
+    },
+    "erdos-358": {
+      "quality": 100
+    },
+    "erdos-359": {
+      "quality": 100
+    },
+    "erdos-360": {
+      "quality": 100
+    },
+    "erdos-363": {
+      "quality": 100
+    },
+    "erdos-364": {
+      "quality": 100
+    },
+    "erdos-365": {
+      "quality": 100
+    },
+    "erdos-366": {
+      "quality": 100
+    },
+    "erdos-367": {
+      "quality": 100
+    },
+    "erdos-368": {
+      "quality": 100
+    },
+    "erdos-37": {
+      "quality": 100
+    },
+    "erdos-370": {
+      "quality": 100
+    },
+    "erdos-371": {
+      "quality": 100
+    },
+    "erdos-372": {
+      "quality": 100
+    },
+    "erdos-373": {
+      "quality": 100
+    },
+    "erdos-374": {
+      "quality": 100
+    },
+    "erdos-375": {
+      "quality": 100
+    },
+    "erdos-376": {
+      "quality": 100
+    },
+    "erdos-377": {
+      "quality": 100
+    },
+    "erdos-378": {
+      "quality": 100
+    },
+    "erdos-38": {
+      "quality": 100
+    },
+    "erdos-380": {
+      "quality": 100
+    },
+    "erdos-381": {
+      "quality": 100
+    },
+    "erdos-382": {
+      "quality": 100
+    },
+    "erdos-383": {
+      "quality": 100
+    },
+    "erdos-384": {
+      "quality": 100
+    },
+    "erdos-385": {
+      "quality": 100
+    },
+    "erdos-386": {
+      "quality": 100
+    },
+    "erdos-387": {
+      "quality": 100
+    },
+    "erdos-388": {
+      "quality": 100
+    },
+    "erdos-39": {
+      "quality": 100
+    },
+    "erdos-390": {
+      "quality": 100
+    },
+    "erdos-391": {
+      "quality": 100
+    },
+    "erdos-392": {
+      "quality": 100
+    },
+    "erdos-393": {
+      "quality": 100
+    },
+    "erdos-394": {
+      "quality": 100
+    },
+    "erdos-395": {
+      "quality": 100
+    },
+    "erdos-395-oq-01": {
+      "quality": 100
+    },
+    "erdos-396": {
+      "quality": 100
+    },
+    "erdos-397": {
+      "quality": 100
+    },
+    "erdos-398": {
+      "quality": 100
+    },
+    "erdos-399": {
+      "quality": 100
+    },
+    "erdos-400": {
+      "quality": 100
+    },
+    "erdos-401": {
+      "quality": 100
+    },
+    "erdos-402": {
+      "quality": 100
+    },
+    "erdos-404": {
+      "quality": 100
+    },
+    "erdos-405": {
+      "quality": 100
+    },
+    "erdos-406": {
+      "quality": 100
+    },
+    "erdos-407": {
+      "quality": 100
+    },
+    "erdos-408": {
+      "quality": 100
+    },
+    "erdos-41": {
+      "quality": 100
+    },
+    "erdos-410": {
+      "quality": 100
+    },
+    "erdos-411": {
+      "quality": 100
+    },
+    "erdos-412": {
+      "quality": 100
+    },
+    "erdos-413": {
+      "quality": 100
+    },
+    "erdos-415": {
+      "quality": 100
+    },
+    "erdos-416": {
+      "quality": 100
+    },
+    "erdos-417": {
+      "quality": 100
+    },
+    "erdos-418": {
+      "quality": 100
+    },
+    "erdos-419": {
+      "quality": 100
+    },
+    "erdos-42": {
+      "quality": 100
+    },
+    "erdos-420": {
+      "quality": 100
+    },
+    "erdos-421": {
+      "quality": 100
+    },
+    "erdos-423": {
+      "quality": 100
+    },
+    "erdos-424": {
+      "quality": 100
+    },
+    "erdos-425": {
+      "quality": 100
+    },
+    "erdos-426": {
+      "quality": 100
+    },
+    "erdos-427": {
+      "quality": 100
+    },
+    "erdos-428": {
+      "quality": 100
+    },
+    "erdos-429": {
+      "quality": 100
+    },
+    "erdos-43": {
+      "quality": 100
+    },
+    "erdos-431": {
+      "quality": 100
+    },
+    "erdos-433": {
+      "quality": 100
+    },
+    "erdos-434": {
+      "quality": 100
+    },
+    "erdos-435": {
+      "quality": 100
+    },
+    "erdos-437": {
+      "quality": 100
+    },
+    "erdos-438": {
+      "quality": 100
+    },
+    "erdos-439": {
+      "quality": 100
+    },
+    "erdos-44": {
+      "quality": 100
+    },
+    "erdos-440": {
+      "quality": 100
+    },
+    "erdos-441": {
+      "quality": 100
+    },
+    "erdos-442": {
+      "quality": 100
+    },
+    "erdos-443": {
+      "quality": 100
+    },
+    "erdos-445": {
+      "quality": 100
+    },
+    "erdos-446": {
+      "quality": 100
+    },
+    "erdos-447": {
+      "quality": 100
+    },
+    "erdos-448": {
+      "quality": 100
+    },
+    "erdos-449": {
+      "quality": 100
+    },
+    "erdos-45": {
+      "quality": 100
+    },
+    "erdos-450": {
+      "quality": 100
+    },
+    "erdos-451": {
+      "quality": 100
+    },
+    "erdos-452": {
+      "quality": 100
+    },
+    "erdos-453": {
+      "quality": 100
+    },
+    "erdos-453-oq-02": {
+      "quality": 100
+    },
+    "erdos-454": {
+      "quality": 100
+    },
+    "erdos-455": {
+      "quality": 100
+    },
+    "erdos-456": {
+      "quality": 100
+    },
+    "erdos-457": {
+      "quality": 100
+    },
+    "erdos-458": {
+      "quality": 100
+    },
+    "erdos-459": {
+      "quality": 100
+    },
+    "erdos-46": {
+      "quality": 100
+    },
+    "erdos-460": {
+      "quality": 100
+    },
+    "erdos-461": {
+      "quality": 100
+    },
+    "erdos-463": {
+      "quality": 100
+    },
+    "erdos-464": {
+      "quality": 100
+    },
+    "erdos-465": {
+      "quality": 100
+    },
+    "erdos-467": {
+      "quality": 100
+    },
+    "erdos-468": {
+      "quality": 100
+    },
+    "erdos-469": {
+      "quality": 100
+    },
+    "erdos-470": {
+      "quality": 100
+    },
+    "erdos-471": {
+      "quality": 100
+    },
+    "erdos-472": {
+      "quality": 100
+    },
+    "erdos-473": {
+      "quality": 100
+    },
+    "erdos-474": {
+      "quality": 100
+    },
+    "erdos-475": {
+      "quality": 100
+    },
+    "erdos-476": {
+      "quality": 100
+    },
+    "erdos-476-oq-05": {
+      "quality": 100
+    },
+    "erdos-477": {
+      "quality": 100
+    },
+    "erdos-478": {
+      "quality": 100
+    },
+    "erdos-479": {
+      "quality": 100
+    },
+    "erdos-48": {
+      "quality": 100
+    },
+    "erdos-480": {
+      "quality": 100
+    },
+    "erdos-481": {
+      "quality": 100
+    },
+    "erdos-482": {
+      "quality": 100
+    },
+    "erdos-483": {
+      "quality": 100
+    },
+    "erdos-484": {
+      "quality": 100
+    },
+    "erdos-485": {
+      "quality": 100
+    },
+    "erdos-485-oq-01": {
+      "quality": 100
+    },
+    "erdos-485-oq-02": {
+      "quality": 100
+    },
+    "erdos-486": {
+      "quality": 100
+    },
+    "erdos-487": {
+      "quality": 100
+    },
+    "erdos-488": {
+      "quality": 100
+    },
+    "erdos-489": {
+      "quality": 100
+    },
+    "erdos-49": {
+      "quality": 100
+    },
+    "erdos-490": {
+      "quality": 100
+    },
+    "erdos-490-oq-01": {
+      "quality": 100
+    },
+    "erdos-491": {
+      "quality": 100
+    },
+    "erdos-492": {
+      "quality": 100
+    },
+    "erdos-493": {
+      "quality": 100
+    },
+    "erdos-494": {
+      "quality": 100
+    },
+    "erdos-495": {
+      "quality": 100
+    },
+    "erdos-496": {
+      "quality": 100
+    },
+    "erdos-498": {
+      "quality": 100
+    },
+    "erdos-499": {
+      "quality": 100
+    },
+    "erdos-5": {
+      "quality": 100
+    },
+    "erdos-5-prime-gaps": {
+      "quality": 100
+    },
+    "erdos-50": {
+      "quality": 100
+    },
+    "erdos-500": {
+      "quality": 100
+    },
+    "erdos-501": {
+      "quality": 100
+    },
+    "erdos-502": {
+      "quality": 100
+    },
+    "erdos-503": {
+      "quality": 100
+    },
+    "erdos-504": {
+      "quality": 100
+    },
+    "erdos-505": {
+      "quality": 100
+    },
+    "erdos-506": {
+      "quality": 100
+    },
+    "erdos-507": {
+      "quality": 100
+    },
+    "erdos-509": {
+      "quality": 100
+    },
+    "erdos-51": {
+      "quality": 100
+    },
+    "erdos-510": {
+      "quality": 100
+    },
+    "erdos-511": {
+      "quality": 100
+    },
+    "erdos-512": {
+      "quality": 100
+    },
+    "erdos-513": {
+      "quality": 100
+    },
+    "erdos-514": {
+      "quality": 100
+    },
+    "erdos-515": {
+      "quality": 100
+    },
+    "erdos-516": {
+      "quality": 100
+    },
+    "erdos-517": {
+      "quality": 100
+    },
+    "erdos-52": {
+      "quality": 100
+    },
+    "erdos-520": {
+      "quality": 100
+    },
+    "erdos-521": {
+      "quality": 100
+    },
+    "erdos-522": {
+      "quality": 100
+    },
+    "erdos-523": {
+      "quality": 100
+    },
+    "erdos-524": {
+      "quality": 100
+    },
+    "erdos-525": {
+      "quality": 100
+    },
+    "erdos-527": {
+      "quality": 100
+    },
+    "erdos-528": {
+      "quality": 100
+    },
+    "erdos-529": {
+      "quality": 100
+    },
+    "erdos-53": {
+      "quality": 100
+    },
+    "erdos-530": {
+      "quality": 100
+    },
+    "erdos-531": {
+      "quality": 100
+    },
+    "erdos-532": {
+      "quality": 100
+    },
+    "erdos-533": {
+      "quality": 100
+    },
+    "erdos-534": {
+      "quality": 100
+    },
+    "erdos-535": {
+      "quality": 100
+    },
+    "erdos-536": {
+      "quality": 100
+    },
+    "erdos-537": {
+      "quality": 100
+    },
+    "erdos-538": {
+      "quality": 100
+    },
+    "erdos-54": {
+      "quality": 100
+    },
+    "erdos-540": {
+      "quality": 100
+    },
+    "erdos-541": {
+      "quality": 100
+    },
+    "erdos-542": {
+      "quality": 100
+    },
+    "erdos-543": {
+      "quality": 100
+    },
+    "erdos-544": {
+      "quality": 100
+    },
+    "erdos-545": {
+      "quality": 100
+    },
+    "erdos-546": {
+      "quality": 100
+    },
+    "erdos-548": {
+      "quality": 100
+    },
+    "erdos-549": {
+      "quality": 100
+    },
+    "erdos-55": {
+      "quality": 100
+    },
+    "erdos-550": {
+      "quality": 100
+    },
+    "erdos-551": {
+      "quality": 100
+    },
+    "erdos-552": {
+      "quality": 100
+    },
+    "erdos-553": {
+      "quality": 100
+    },
+    "erdos-554": {
+      "quality": 100
+    },
+    "erdos-555": {
+      "quality": 100
+    },
+    "erdos-556": {
+      "quality": 100
+    },
+    "erdos-557": {
+      "quality": 100
+    },
+    "erdos-558": {
+      "quality": 100
+    },
+    "erdos-559": {
+      "quality": 100
+    },
+    "erdos-56": {
+      "quality": 100
+    },
+    "erdos-560": {
+      "quality": 100
+    },
+    "erdos-561": {
+      "quality": 100
+    },
+    "erdos-562": {
+      "quality": 100
+    },
+    "erdos-564": {
+      "quality": 100
+    },
+    "erdos-565": {
+      "quality": 100
+    },
+    "erdos-566": {
+      "quality": 100
+    },
+    "erdos-567": {
+      "quality": 100
+    },
+    "erdos-568": {
+      "quality": 100
+    },
+    "erdos-569": {
+      "quality": 100
+    },
+    "erdos-57": {
+      "quality": 100
+    },
+    "erdos-570": {
+      "quality": 100
+    },
+    "erdos-571": {
+      "quality": 100
+    },
+    "erdos-572": {
+      "quality": 100
+    },
+    "erdos-573": {
+      "quality": 100
+    },
+    "erdos-574": {
+      "quality": 100
+    },
+    "erdos-575": {
+      "quality": 100
+    },
+    "erdos-576": {
+      "quality": 100
+    },
+    "erdos-577": {
+      "quality": 100
+    },
+    "erdos-578": {
+      "quality": 100
+    },
+    "erdos-579": {
+      "quality": 100
+    },
+    "erdos-58": {
+      "quality": 100
+    },
+    "erdos-580": {
+      "quality": 100
+    },
+    "erdos-581": {
+      "quality": 100
+    },
+    "erdos-582": {
+      "quality": 100
+    },
+    "erdos-583": {
+      "quality": 100
+    },
+    "erdos-584": {
+      "quality": 100
+    },
+    "erdos-585": {
+      "quality": 100
+    },
+    "erdos-586": {
+      "quality": 100
+    },
+    "erdos-587": {
+      "quality": 100
+    },
+    "erdos-588": {
+      "quality": 100
+    },
+    "erdos-589": {
+      "quality": 100
+    },
+    "erdos-59": {
+      "quality": 100
+    },
+    "erdos-590": {
+      "quality": 100
+    },
+    "erdos-591": {
+      "quality": 100
+    },
+    "erdos-592": {
+      "quality": 100
+    },
+    "erdos-593": {
+      "quality": 100
+    },
+    "erdos-594": {
+      "quality": 100
+    },
+    "erdos-595": {
+      "quality": 100
+    },
+    "erdos-596": {
+      "quality": 100
+    },
+    "erdos-597": {
+      "quality": 100
+    },
+    "erdos-598": {
+      "quality": 100
+    },
+    "erdos-599": {
+      "quality": 100
+    },
+    "erdos-6": {
+      "quality": 100
+    },
+    "erdos-60": {
+      "quality": 100
+    },
+    "erdos-600": {
+      "quality": 100
+    },
+    "erdos-601": {
+      "quality": 100
+    },
+    "erdos-602": {
+      "quality": 100
+    },
+    "erdos-603": {
+      "quality": 100
+    },
+    "erdos-604": {
+      "quality": 100
+    },
+    "erdos-605": {
+      "quality": 100
+    },
+    "erdos-606": {
+      "quality": 100
+    },
+    "erdos-606-oq-03-oq-03": {
+      "quality": 100
+    },
+    "erdos-607": {
+      "quality": 100
+    },
+    "erdos-608": {
+      "quality": 100
+    },
+    "erdos-609": {
+      "quality": 100
+    },
+    "erdos-61": {
+      "quality": 100
+    },
+    "erdos-610": {
+      "quality": 100
+    },
+    "erdos-611": {
+      "quality": 100
+    },
+    "erdos-612": {
+      "quality": 100
+    },
+    "erdos-614": {
+      "quality": 100
+    },
+    "erdos-615": {
+      "quality": 100
+    },
+    "erdos-617": {
+      "quality": 100
+    },
+    "erdos-618": {
+      "quality": 100
+    },
+    "erdos-619": {
+      "quality": 100
+    },
+    "erdos-62": {
+      "quality": 100
+    },
+    "erdos-621": {
+      "quality": 100
+    },
+    "erdos-622": {
+      "quality": 100
+    },
+    "erdos-622-oq-04": {
+      "quality": 100
+    },
+    "erdos-624": {
+      "quality": 100
+    },
+    "erdos-627": {
+      "quality": 100
+    },
+    "erdos-628": {
+      "quality": 100
+    },
+    "erdos-629": {
+      "quality": 100
+    },
+    "erdos-63": {
+      "quality": 100
+    },
+    "erdos-630": {
+      "quality": 100
+    },
+    "erdos-631": {
+      "quality": 100
+    },
+    "erdos-635": {
+      "quality": 100
+    },
+    "erdos-637": {
+      "quality": 100
+    },
+    "erdos-638": {
+      "quality": 100
+    },
+    "erdos-639": {
+      "quality": 100
+    },
+    "erdos-64": {
+      "quality": 100
+    },
+    "erdos-640": {
+      "quality": 100
+    },
+    "erdos-641": {
+      "quality": 100
+    },
+    "erdos-642": {
+      "quality": 100
+    },
+    "erdos-643": {
+      "quality": 100
+    },
+    "erdos-645": {
+      "quality": 100
+    },
+    "erdos-646": {
+      "quality": 100
+    },
+    "erdos-647": {
+      "quality": 100
+    },
+    "erdos-648": {
+      "quality": 100
+    },
+    "erdos-649": {
+      "quality": 100
+    },
+    "erdos-65": {
+      "quality": 100
+    },
+    "erdos-65-oq-03": {
+      "quality": 100
+    },
+    "erdos-650": {
+      "quality": 100
+    },
+    "erdos-651": {
+      "quality": 100
+    },
+    "erdos-652": {
+      "quality": 100
+    },
+    "erdos-653": {
+      "quality": 100
+    },
+    "erdos-654": {
+      "quality": 100
+    },
+    "erdos-655": {
+      "quality": 100
+    },
+    "erdos-656": {
+      "quality": 100
+    },
+    "erdos-657": {
+      "quality": 100
+    },
+    "erdos-658": {
+      "quality": 100
+    },
+    "erdos-659": {
+      "quality": 100
+    },
+    "erdos-66": {
+      "quality": 100
+    },
+    "erdos-661": {
+      "quality": 100
+    },
+    "erdos-662": {
+      "quality": 100
+    },
+    "erdos-663": {
+      "quality": 100
+    },
+    "erdos-664": {
+      "quality": 100
+    },
+    "erdos-665": {
+      "quality": 100
+    },
+    "erdos-666": {
+      "quality": 100
+    },
+    "erdos-667": {
+      "quality": 100
+    },
+    "erdos-668": {
+      "quality": 100
+    },
+    "erdos-669": {
+      "quality": 100
+    },
+    "erdos-67": {
+      "quality": 100
+    },
+    "erdos-670": {
+      "quality": 100
+    },
+    "erdos-672": {
+      "quality": 100
+    },
+    "erdos-673": {
+      "quality": 100
+    },
+    "erdos-674": {
+      "quality": 100
+    },
+    "erdos-675": {
+      "quality": 100
+    },
+    "erdos-676": {
+      "quality": 100
+    },
+    "erdos-679": {
+      "quality": 100
+    },
+    "erdos-68": {
+      "quality": 100
+    },
+    "erdos-680": {
+      "quality": 100
+    },
+    "erdos-681": {
+      "quality": 100
+    },
+    "erdos-682": {
+      "quality": 100
+    },
+    "erdos-683": {
+      "quality": 100
+    },
+    "erdos-684": {
+      "quality": 100
+    },
+    "erdos-685": {
+      "quality": 100
+    },
+    "erdos-686": {
+      "quality": 100
+    },
+    "erdos-687": {
+      "quality": 100
+    },
+    "erdos-688": {
+      "quality": 100
+    },
+    "erdos-689": {
+      "quality": 100
+    },
+    "erdos-69": {
+      "quality": 100
+    },
+    "erdos-690": {
+      "quality": 100
+    },
+    "erdos-691": {
+      "quality": 100
+    },
+    "erdos-692": {
+      "quality": 100
+    },
+    "erdos-693": {
+      "quality": 100
+    },
+    "erdos-694": {
+      "quality": 100
+    },
+    "erdos-695": {
+      "quality": 100
+    },
+    "erdos-696": {
+      "quality": 100
+    },
+    "erdos-697": {
+      "quality": 100
+    },
+    "erdos-698": {
+      "quality": 100
+    },
+    "erdos-699": {
+      "quality": 100
+    },
+    "erdos-7": {
+      "quality": 100
+    },
+    "erdos-70": {
+      "quality": 100
+    },
+    "erdos-70-oq-01": {
+      "quality": 100
+    },
+    "erdos-700": {
+      "quality": 100
+    },
+    "erdos-701": {
+      "quality": 100
+    },
+    "erdos-702": {
+      "quality": 100
+    },
+    "erdos-703": {
+      "quality": 100
+    },
+    "erdos-704": {
+      "quality": 100
+    },
+    "erdos-705": {
+      "quality": 100
+    },
+    "erdos-706": {
+      "quality": 100
+    },
+    "erdos-707": {
+      "quality": 100
+    },
+    "erdos-708": {
+      "quality": 100
+    },
+    "erdos-709": {
+      "quality": 100
+    },
+    "erdos-71": {
+      "quality": 100
+    },
+    "erdos-710": {
+      "quality": 100
+    },
+    "erdos-711": {
+      "quality": 100
+    },
+    "erdos-712": {
+      "quality": 100
+    },
+    "erdos-713": {
+      "quality": 100
+    },
+    "erdos-714": {
+      "quality": 100
+    },
+    "erdos-715": {
+      "quality": 100
+    },
+    "erdos-717": {
+      "quality": 100
+    },
+    "erdos-718": {
+      "quality": 100
+    },
+    "erdos-719": {
+      "quality": 100
+    },
+    "erdos-72": {
+      "quality": 100
+    },
+    "erdos-720": {
+      "quality": 100
+    },
+    "erdos-721": {
+      "quality": 100
+    },
+    "erdos-722": {
+      "quality": 100
+    },
+    "erdos-723": {
+      "quality": 100
+    },
+    "erdos-724": {
+      "quality": 100
+    },
+    "erdos-725": {
+      "quality": 100
+    },
+    "erdos-726": {
+      "quality": 100
+    },
+    "erdos-727": {
+      "quality": 100
+    },
+    "erdos-728": {
+      "quality": 100
+    },
+    "erdos-728-factorial-divisibility": {
+      "quality": 100
+    },
+    "erdos-729": {
+      "quality": 100
+    },
+    "erdos-73": {
+      "quality": 100
+    },
+    "erdos-730": {
+      "quality": 100
+    },
+    "erdos-731": {
+      "quality": 100
+    },
+    "erdos-732": {
+      "quality": 100
+    },
+    "erdos-733": {
+      "quality": 100
+    },
+    "erdos-734": {
+      "quality": 100
+    },
+    "erdos-735": {
+      "quality": 100
+    },
+    "erdos-737": {
+      "quality": 100
+    },
+    "erdos-738": {
+      "quality": 100
+    },
+    "erdos-739": {
+      "quality": 100
+    },
+    "erdos-74": {
+      "quality": 100
+    },
+    "erdos-740": {
+      "quality": 100
+    },
+    "erdos-741": {
+      "quality": 100
+    },
+    "erdos-742": {
+      "quality": 100
+    },
+    "erdos-743": {
+      "quality": 100
+    },
+    "erdos-744": {
+      "quality": 100
+    },
+    "erdos-745": {
+      "quality": 100
+    },
+    "erdos-746": {
+      "quality": 100
+    },
+    "erdos-747": {
+      "quality": 100
+    },
+    "erdos-748": {
+      "quality": 100
+    },
+    "erdos-749": {
+      "quality": 100
+    },
+    "erdos-75": {
+      "quality": 100
+    },
+    "erdos-750": {
+      "quality": 100
+    },
+    "erdos-751": {
+      "quality": 100
+    },
+    "erdos-752": {
+      "quality": 100
+    },
+    "erdos-753": {
+      "quality": 100
+    },
+    "erdos-754": {
+      "quality": 100
+    },
+    "erdos-755": {
+      "quality": 100
+    },
+    "erdos-756": {
+      "quality": 100
+    },
+    "erdos-757": {
+      "quality": 100
+    },
+    "erdos-758": {
+      "quality": 100
+    },
+    "erdos-759": {
+      "quality": 100
+    },
+    "erdos-76": {
+      "quality": 100
+    },
+    "erdos-760": {
+      "quality": 100
+    },
+    "erdos-761": {
+      "quality": 100
+    },
+    "erdos-762": {
+      "quality": 100
+    },
+    "erdos-763": {
+      "quality": 100
+    },
+    "erdos-764": {
+      "quality": 100
+    },
+    "erdos-765": {
+      "quality": 100
+    },
+    "erdos-766": {
+      "quality": 100
+    },
+    "erdos-767": {
+      "quality": 100
+    },
+    "erdos-768": {
+      "quality": 100
+    },
+    "erdos-769": {
+      "quality": 100
+    },
+    "erdos-77": {
+      "quality": 100
+    },
+    "erdos-770": {
+      "quality": 100
+    },
+    "erdos-771": {
+      "quality": 100
+    },
+    "erdos-772": {
+      "quality": 100
+    },
+    "erdos-773": {
+      "quality": 100
+    },
+    "erdos-774": {
+      "quality": 100
+    },
+    "erdos-775": {
+      "quality": 100
+    },
+    "erdos-776": {
+      "quality": 100
+    },
+    "erdos-777": {
+      "quality": 100
+    },
+    "erdos-778": {
+      "quality": 100
+    },
+    "erdos-779": {
+      "quality": 100
+    },
+    "erdos-78": {
+      "quality": 100
+    },
+    "erdos-782": {
+      "quality": 100
+    },
+    "erdos-783": {
+      "quality": 100
+    },
+    "erdos-784": {
+      "quality": 100
+    },
+    "erdos-785": {
+      "quality": 100
+    },
+    "erdos-786": {
+      "quality": 100
+    },
+    "erdos-787": {
+      "quality": 100
+    },
+    "erdos-788": {
+      "quality": 100
+    },
+    "erdos-789": {
+      "quality": 100
+    },
+    "erdos-79": {
+      "quality": 100
+    },
+    "erdos-790": {
+      "quality": 100
+    },
+    "erdos-791": {
+      "quality": 100
+    },
+    "erdos-792": {
+      "quality": 100
+    },
+    "erdos-793": {
+      "quality": 100
+    },
+    "erdos-794": {
+      "quality": 100
+    },
+    "erdos-795": {
+      "quality": 100
+    },
+    "erdos-796": {
+      "quality": 100
+    },
+    "erdos-797": {
+      "quality": 100
+    },
+    "erdos-798": {
+      "quality": 100
+    },
+    "erdos-799": {
+      "quality": 100
+    },
+    "erdos-8": {
+      "quality": 100
+    },
+    "erdos-80": {
+      "quality": 100
+    },
+    "erdos-800": {
+      "quality": 100
+    },
+    "erdos-801": {
+      "quality": 100
+    },
+    "erdos-802": {
+      "quality": 100
+    },
+    "erdos-803": {
+      "quality": 100
+    },
+    "erdos-804": {
+      "quality": 100
+    },
+    "erdos-805": {
+      "quality": 100
+    },
+    "erdos-806": {
+      "quality": 100
+    },
+    "erdos-807": {
+      "quality": 100
+    },
+    "erdos-809": {
+      "quality": 100
+    },
+    "erdos-81": {
+      "quality": 100
+    },
+    "erdos-810": {
+      "quality": 100
+    },
+    "erdos-811": {
+      "quality": 100
+    },
+    "erdos-812": {
+      "quality": 100
+    },
+    "erdos-813": {
+      "quality": 100
+    },
+    "erdos-814": {
+      "quality": 100
+    },
+    "erdos-815": {
+      "quality": 100
+    },
+    "erdos-816": {
+      "quality": 100
+    },
+    "erdos-817": {
+      "quality": 100
+    },
+    "erdos-818": {
+      "quality": 100
+    },
+    "erdos-819": {
+      "quality": 100
+    },
+    "erdos-82": {
+      "quality": 100
+    },
+    "erdos-820": {
+      "quality": 100
+    },
+    "erdos-821": {
+      "quality": 100
+    },
+    "erdos-822": {
+      "quality": 100
+    },
+    "erdos-823": {
+      "quality": 100
+    },
+    "erdos-824": {
+      "quality": 100
+    },
+    "erdos-826": {
+      "quality": 100
+    },
+    "erdos-827": {
+      "quality": 100
+    },
+    "erdos-828": {
+      "quality": 100
+    },
+    "erdos-829": {
+      "quality": 100
+    },
+    "erdos-83": {
+      "quality": 100
+    },
+    "erdos-830": {
+      "quality": 100
+    },
+    "erdos-831": {
+      "quality": 100
+    },
+    "erdos-832": {
+      "quality": 100
+    },
+    "erdos-833": {
+      "quality": 100
+    },
+    "erdos-834": {
+      "quality": 100
+    },
+    "erdos-835": {
+      "quality": 100
+    },
+    "erdos-836": {
+      "quality": 100
+    },
+    "erdos-837": {
+      "quality": 100
+    },
+    "erdos-837-oq-05": {
+      "quality": 100
+    },
+    "erdos-838": {
+      "quality": 100
+    },
+    "erdos-839": {
+      "quality": 100
+    },
+    "erdos-84": {
+      "quality": 100
+    },
+    "erdos-841": {
+      "quality": 100
+    },
+    "erdos-842": {
+      "quality": 100
+    },
+    "erdos-843": {
+      "quality": 100
+    },
+    "erdos-844": {
+      "quality": 100
+    },
+    "erdos-845": {
+      "quality": 100
+    },
+    "erdos-846": {
+      "quality": 100
+    },
+    "erdos-847": {
+      "quality": 100
+    },
+    "erdos-848-oq-01": {
+      "quality": 100
+    },
+    "erdos-849": {
+      "quality": 100
+    },
+    "erdos-85": {
+      "quality": 100
+    },
+    "erdos-850": {
+      "quality": 100
+    },
+    "erdos-851": {
+      "quality": 100
+    },
+    "erdos-852": {
+      "quality": 100
+    },
+    "erdos-853": {
+      "quality": 100
+    },
+    "erdos-854": {
+      "quality": 100
+    },
+    "erdos-855": {
+      "quality": 100
+    },
+    "erdos-856": {
+      "quality": 100
+    },
+    "erdos-857": {
+      "quality": 100
+    },
+    "erdos-858": {
+      "quality": 100
+    },
+    "erdos-859": {
+      "quality": 100
+    },
+    "erdos-86": {
+      "quality": 100
+    },
+    "erdos-860": {
+      "quality": 100
+    },
+    "erdos-862": {
+      "quality": 100
+    },
+    "erdos-863": {
+      "quality": 100
+    },
+    "erdos-864": {
+      "quality": 100
+    },
+    "erdos-865": {
+      "quality": 100
+    },
+    "erdos-866": {
+      "quality": 100
+    },
+    "erdos-868": {
+      "quality": 100
+    },
+    "erdos-869": {
+      "quality": 100
+    },
+    "erdos-87": {
+      "quality": 100
+    },
+    "erdos-870": {
+      "quality": 100
+    },
+    "erdos-871": {
+      "quality": 100
+    },
+    "erdos-872": {
+      "quality": 100
+    },
+    "erdos-873": {
+      "quality": 100
+    },
+    "erdos-874": {
+      "quality": 100
+    },
+    "erdos-875": {
+      "quality": 100
+    },
+    "erdos-876": {
+      "quality": 100
+    },
+    "erdos-877": {
+      "quality": 100
+    },
+    "erdos-878": {
+      "quality": 100
+    },
+    "erdos-879": {
+      "quality": 100
+    },
+    "erdos-88": {
+      "quality": 100
+    },
+    "erdos-880": {
+      "quality": 100
+    },
+    "erdos-881": {
+      "quality": 100
+    },
+    "erdos-882": {
+      "quality": 100
+    },
+    "erdos-883": {
+      "quality": 100
+    },
+    "erdos-884": {
+      "quality": 100
+    },
+    "erdos-885": {
+      "quality": 100
+    },
+    "erdos-886": {
+      "quality": 100
+    },
+    "erdos-887": {
+      "quality": 100
+    },
+    "erdos-888": {
+      "quality": 100
+    },
+    "erdos-889": {
+      "quality": 100
+    },
+    "erdos-89": {
+      "quality": 100
+    },
+    "erdos-890": {
+      "quality": 100
+    },
+    "erdos-891": {
+      "quality": 100
+    },
+    "erdos-892": {
+      "quality": 100
+    },
+    "erdos-893": {
+      "quality": 100
+    },
+    "erdos-894": {
+      "quality": 100
+    },
+    "erdos-895": {
+      "quality": 100
+    },
+    "erdos-896": {
+      "quality": 100
+    },
+    "erdos-897": {
+      "quality": 100
+    },
+    "erdos-898": {
+      "quality": 100
+    },
+    "erdos-899": {
+      "quality": 100
+    },
+    "erdos-9": {
+      "quality": 100
+    },
+    "erdos-90": {
+      "quality": 100
+    },
+    "erdos-900": {
+      "quality": 100
+    },
+    "erdos-901": {
+      "quality": 100
+    },
+    "erdos-902": {
+      "quality": 100
+    },
+    "erdos-903": {
+      "quality": 100
+    },
+    "erdos-904": {
+      "quality": 100
+    },
+    "erdos-905": {
+      "quality": 100
+    },
+    "erdos-906": {
+      "quality": 100
+    },
+    "erdos-907": {
+      "quality": 100
+    },
+    "erdos-908": {
+      "quality": 100
+    },
+    "erdos-909": {
+      "quality": 100
+    },
+    "erdos-909-oq-01": {
+      "quality": 100
+    },
+    "erdos-91": {
+      "quality": 100
+    },
+    "erdos-910": {
+      "quality": 100
+    },
+    "erdos-911": {
+      "quality": 100
+    },
+    "erdos-912": {
+      "quality": 100
+    },
+    "erdos-913": {
+      "quality": 100
+    },
+    "erdos-914": {
+      "quality": 100
+    },
+    "erdos-915": {
+      "quality": 100
+    },
+    "erdos-916": {
+      "quality": 100
+    },
+    "erdos-917": {
+      "quality": 100
+    },
+    "erdos-918": {
+      "quality": 100
+    },
+    "erdos-919": {
+      "quality": 100
+    },
+    "erdos-92": {
+      "quality": 100
+    },
+    "erdos-920": {
+      "quality": 100
+    },
+    "erdos-921": {
+      "quality": 100
+    },
+    "erdos-922": {
+      "quality": 100
+    },
+    "erdos-923": {
+      "quality": 100
+    },
+    "erdos-924": {
+      "quality": 100
+    },
+    "erdos-925": {
+      "quality": 100
+    },
+    "erdos-926": {
+      "quality": 100
+    },
+    "erdos-927": {
+      "quality": 100
+    },
+    "erdos-929": {
+      "quality": 100
+    },
+    "erdos-93": {
+      "quality": 100
+    },
+    "erdos-930": {
+      "quality": 100
+    },
+    "erdos-931": {
+      "quality": 100
+    },
+    "erdos-932": {
+      "quality": 100
+    },
+    "erdos-933": {
+      "quality": 100
+    },
+    "erdos-934": {
+      "quality": 100
+    },
+    "erdos-935": {
+      "quality": 100
+    },
+    "erdos-936": {
+      "quality": 100
+    },
+    "erdos-937": {
+      "quality": 100
+    },
+    "erdos-938": {
+      "quality": 100
+    },
+    "erdos-939": {
+      "quality": 100
+    },
+    "erdos-94": {
+      "quality": 100
+    },
+    "erdos-94-oq-02": {
+      "quality": 100
+    },
+    "erdos-940": {
+      "quality": 100
+    },
+    "erdos-941": {
+      "quality": 100
+    },
+    "erdos-942": {
+      "quality": 100
+    },
+    "erdos-943": {
+      "quality": 100
+    },
+    "erdos-944": {
+      "quality": 100
+    },
+    "erdos-945": {
+      "quality": 100
+    },
+    "erdos-946": {
+      "quality": 100
+    },
+    "erdos-947": {
+      "quality": 100
+    },
+    "erdos-948": {
+      "quality": 100
+    },
+    "erdos-949": {
+      "quality": 100
+    },
+    "erdos-95": {
+      "quality": 100
+    },
+    "erdos-950": {
+      "quality": 100
+    },
+    "erdos-951": {
+      "quality": 100
+    },
+    "erdos-952": {
+      "quality": 100
+    },
+    "erdos-953": {
+      "quality": 100
+    },
+    "erdos-954": {
+      "quality": 100
+    },
+    "erdos-957": {
+      "quality": 100
+    },
+    "erdos-958": {
+      "quality": 100
+    },
+    "erdos-959": {
+      "quality": 100
+    },
+    "erdos-96": {
+      "quality": 100
+    },
+    "erdos-960": {
+      "quality": 100
+    },
+    "erdos-961": {
+      "quality": 100
+    },
+    "erdos-962": {
+      "quality": 100
+    },
+    "erdos-963": {
+      "quality": 100
+    },
+    "erdos-964": {
+      "quality": 100
+    },
+    "erdos-965": {
+      "quality": 100
+    },
+    "erdos-966": {
+      "quality": 100
+    },
+    "erdos-967": {
+      "quality": 100
+    },
+    "erdos-968": {
+      "quality": 100
+    },
+    "erdos-969": {
+      "quality": 100
+    },
+    "erdos-97": {
+      "quality": 100
+    },
+    "erdos-971": {
+      "quality": 100
+    },
+    "erdos-972": {
+      "quality": 100
+    },
+    "erdos-973": {
+      "quality": 100
+    },
+    "erdos-974": {
+      "quality": 100
+    },
+    "erdos-975": {
+      "quality": 100
+    },
+    "erdos-976": {
+      "quality": 100
+    },
+    "erdos-978": {
+      "quality": 100
+    },
+    "erdos-979": {
+      "quality": 100
+    },
+    "erdos-98": {
+      "quality": 100
+    },
+    "erdos-980": {
+      "quality": 100
+    },
+    "erdos-981": {
+      "quality": 100
+    },
+    "erdos-982": {
+      "quality": 100
+    },
+    "erdos-983": {
+      "quality": 100
+    },
+    "erdos-984": {
+      "quality": 100
+    },
+    "erdos-985": {
+      "quality": 100
+    },
+    "erdos-986": {
+      "quality": 100
+    },
+    "erdos-987": {
+      "quality": 100
+    },
+    "erdos-988": {
+      "quality": 100
+    },
+    "erdos-989": {
+      "quality": 100
+    },
+    "erdos-99": {
+      "quality": 100
+    },
+    "erdos-990": {
+      "quality": 100
+    },
+    "erdos-991": {
+      "quality": 100
+    },
+    "erdos-992": {
+      "quality": 100
+    },
+    "erdos-993": {
+      "quality": 100
+    },
+    "erdos-994": {
+      "quality": 100
+    },
+    "erdos-995": {
+      "quality": 100
+    },
+    "erdos-996": {
+      "quality": 100
+    },
+    "erdos-997": {
+      "quality": 100
+    },
+    "erdos-998": {
+      "quality": 100
+    },
+    "erdos-999": {
+      "quality": 100
+    },
+    "erdos-ko-rado": {
+      "quality": 100
+    },
+    "euler-identity": {
+      "quality": 100
+    },
+    "euler-identity-oq-01": {
+      "quality": 100
+    },
+    "euler-identity-oq-01-oq-01": {
+      "quality": 100
+    },
+    "euler-polyhedral-formula": {
+      "quality": 100
+    },
+    "euler-polyhedral-formula-oq-01": {
+      "quality": 100
+    },
+    "euler-polyhedral-formula-oq-01-oq-01": {
+      "quality": 100
+    },
+    "euler-polyhedral-formula-oq-02": {
+      "quality": 100
+    },
+    "euler-polyhedral-formula-oq-02-oq-01": {
+      "quality": 100
+    },
+    "euler-totient-oq-02": {
+      "quality": 100
+    },
+    "euler-totient-oq-02-oq-01": {
+      "quality": 100
+    },
+    "euler-totient-oq-03": {
+      "quality": 100
+    },
+    "euler-totient-oq-04": {
+      "quality": 100
+    },
+    "factor-remainder-nullstellensatz": {
+      "quality": 100
+    },
+    "factor-remainder-nullstellensatz-oq-01": {
+      "quality": 100
+    },
+    "factor-remainder-nullstellensatz-oq-02": {
+      "quality": 100
+    },
+    "factor-remainder-theorem": {
+      "quality": 100
+    },
+    "fair-games-theorem-oq-01": {
+      "quality": 100
+    },
+    "fair-games-theorem-oq-02": {
+      "quality": 100
+    },
+    "fair-games-theorem-oq-02-oq-01": {
+      "quality": 100
+    },
+    "fair-games-theorem-oq-02-oq-04": {
+      "quality": 100
+    },
+    "fair-games-theorem-oq-03": {
+      "quality": 100
+    },
+    "fermat-two-squares": {
+      "quality": 100
+    },
+    "fermat-two-squares-oq-01": {
+      "quality": 100
+    },
+    "fermats-last-theorem": {
+      "quality": 100
+    },
+    "fermats-last-theorem-oq-03": {
+      "quality": 100
+    },
+    "feuerbachs-theorem": {
+      "quality": 100
+    },
+    "feuerbachs-theorem-defs": {
+      "quality": 100
+    },
+    "feuerbachs-theorem-defs-oq-04": {
+      "quality": 100
+    },
+    "feuerbachs-theorem-oq-01": {
+      "quality": 100
+    },
+    "feuerbachs-theorem-oq-02": {
+      "quality": 100
+    },
+    "feuerbachs-theorem-oq-05": {
+      "quality": 100
+    },
+    "four-color-theorem": {
+      "quality": 100
+    },
+    "four-color-theorem-oq-01": {
+      "quality": 100
+    },
+    "four-color-theorem-oq-02": {
+      "quality": 100
+    },
+    "fourier-series": {
+      "quality": 100
+    },
+    "fourier-series-oq-01": {
+      "quality": 100
+    },
+    "fourier-series-oq-02": {
+      "quality": 100
+    },
+    "fourier-series-oq-02-incomplete-01": {
+      "quality": 100
+    },
+    "fourier-series-oq-02-oq-01": {
+      "quality": 100
+    },
+    "fourier-series-oq-02-oq-02": {
+      "quality": 100
+    },
+    "fourier-series-oq-02-oq-03": {
+      "quality": 100
+    },
+    "fourier-series-oq-03": {
+      "quality": 100
+    },
+    "fourier-series-oq-04": {
+      "quality": 100
+    },
+    "friendship-theorem": {
+      "quality": 100
+    },
+    "friendship-theorem-oq-01": {
+      "quality": 100
+    },
+    "friendship-theorem-oq-03": {
+      "quality": 100
+    },
+    "fundamental-arithmetic-oq-01": {
+      "quality": 100
+    },
+    "fundamental-arithmetic-oq-02": {
+      "quality": 100
+    },
+    "fundamental-theorem-algebra-oq-04": {
+      "quality": 100
+    },
+    "fundamental-theorem-calculus-oq-01": {
+      "quality": 100
+    },
+    "fundamental-theorem-calculus-oq-02": {
+      "quality": 100
+    },
+    "furstenberg-correspondence": {
+      "quality": 100
+    },
+    "furstenberg-correspondence-oq-01": {
+      "quality": 100
+    },
+    "gcd-algorithm": {
+      "quality": 100
+    },
+    "gcd-algorithm-oq-01": {
+      "quality": 100
+    },
+    "gcd-algorithm-oq-01-oq-03": {
+      "quality": 100
+    },
+    "gcd-algorithm-oq-04": {
+      "quality": 100
+    },
+    "gelfond-schneider": {
+      "quality": 100
+    },
+    "general-quartic": {
+      "quality": 100
+    },
+    "geometric-series": {
+      "quality": 100
+    },
+    "geometric-series-oq-01": {
+      "quality": 100
+    },
+    "geometric-series-oq-02": {
+      "quality": 100
+    },
+    "geometric-series-oq-02-oq-03": {
+      "quality": 100
+    },
+    "geometric-series-oq-02-oq-05": {
+      "quality": 100
+    },
+    "geometric-series-oq-03": {
+      "quality": 100
+    },
+    "godel-first-incompleteness-oq01": {
+      "quality": 100
+    },
+    "godel-second-incompleteness-oq02": {
+      "quality": 100
+    },
+    "greens-theorem": {
+      "quality": 100
+    },
+    "greens-theorem-oq-01": {
+      "quality": 100
+    },
+    "greens-theorem-oq-02": {
+      "quality": 100
+    },
+    "greens-theorem-oq-03": {
+      "quality": 100
+    },
+    "greens-theorem-oq-04": {
+      "quality": 100
+    },
+    "halting-problem": {
+      "quality": 100
+    },
+    "harmonic-divergence": {
+      "quality": 100
+    },
+    "harmonic-divergence-oq-02": {
+      "quality": 100
+    },
+    "harmonic-divergence-oq-04": {
+      "quality": 100
+    },
+    "hermite-lindemann": {
+      "quality": 100
+    },
+    "herons-formula-oq-03": {
+      "quality": 100
+    },
+    "herons-formula-oq-04": {
+      "quality": 100
+    },
+    "hilbert-10": {
+      "quality": 100
+    },
+    "hilbert-10-oq-01": {
+      "quality": 100
+    },
+    "hilbert-11": {
+      "quality": 100
+    },
+    "hilbert-13": {
+      "quality": 100
+    },
+    "hilbert-13-oq-04": {
+      "quality": 100
+    },
+    "hilbert-14": {
+      "quality": 100
+    },
+    "hilbert-15-oq-02": {
+      "quality": 100
+    },
+    "hilbert-16": {
+      "quality": 100
+    },
+    "hilbert-17": {
+      "quality": 100
+    },
+    "hilbert-17-oq-01": {
+      "quality": 100
+    },
+    "hilbert-19": {
+      "quality": 100
+    },
+    "hilbert-19-oq-03": {
+      "quality": 100
+    },
+    "hilbert-20": {
+      "quality": 100
+    },
+    "hilbert-20-oq-01-oq-03": {
+      "quality": 100
+    },
+    "hilbert-21": {
+      "quality": 100
+    },
+    "hilbert-22": {
+      "quality": 100
+    },
+    "hilbert-22-oq-01": {
+      "quality": 100
+    },
+    "hilbert-23": {
+      "quality": 100
+    },
+    "hilbert-3": {
+      "quality": 100
+    },
+    "hilbert-5": {
+      "quality": 100
+    },
+    "hilbert-6": {
+      "quality": 100
+    },
+    "hilbert-9-reciprocity": {
+      "quality": 100
+    },
+    "hodge-conjecture": {
+      "quality": 100
+    },
+    "hurwitz-theorem": {
+      "quality": 100
+    },
+    "hurwitz-theorem-oq-03-oq-01": {
+      "quality": 100
+    },
+    "inclusion-exclusion": {
+      "quality": 100
+    },
+    "inclusion-exclusion-oq-01": {
+      "quality": 100
+    },
+    "infinitude-primes": {
+      "quality": 100
+    },
+    "infinitude-primes-4k1": {
+      "quality": 100
+    },
+    "intermediate-value-theorem": {
+      "quality": 100
+    },
+    "intermediate-value-theorem-oq-01": {
+      "quality": 100
+    },
+    "intermediate-value-theorem-oq-02": {
+      "quality": 100
+    },
+    "inverse-galois": {
+      "quality": 100
+    },
+    "inverse-galois-oq-01": {
+      "quality": 100
+    },
+    "inverse-galois-oq-02": {
+      "quality": 100
+    },
+    "inverse-galois-oq-06": {
+      "quality": 100
+    },
+    "isoperimetric-theorem": {
+      "quality": 100
+    },
+    "isoperimetric-theorem-oq-01": {
+      "quality": 100
+    },
+    "isosceles-triangle-oq-01": {
+      "quality": 100
+    },
+    "kepler-conjecture": {
+      "quality": 100
+    },
+    "knights-tour-oblique": {
+      "quality": 100
+    },
+    "knights-tour-oblique-oq-01": {
+      "quality": 100
+    },
+    "konigsberg": {
+      "quality": 100
+    },
+    "konigsberg-oq-02": {
+      "quality": 100
+    },
+    "konigsberg-oq-02-oq-01": {
+      "quality": 100
+    },
+    "konigsberg-oq-03-oq-02": {
+      "quality": 100
+    },
+    "konigsberg-oq-04": {
+      "quality": 100
+    },
+    "kummer-theorem": {
+      "quality": 100
+    },
+    "kummer-theorem-oq-01": {
+      "quality": 100
+    },
+    "kummer-theorem-oq-01-oq-01": {
+      "quality": 100
+    },
+    "kummer-theorem-oq-02": {
+      "quality": 100
+    },
+    "kummer-theorem-oq-03": {
+      "quality": 100
+    },
+    "lagrange-four-squares-oq-01": {
+      "quality": 100
+    },
+    "lagrange-four-squares-oq-04": {
+      "quality": 100
+    },
+    "lagrange-theorem-oq-01": {
+      "quality": 100
+    },
+    "lagrange-theorem-oq-03": {
+      "quality": 100
+    },
+    "law-of-cosines": {
+      "quality": 100
+    },
+    "law-of-cosines-oq-01": {
+      "quality": 100
+    },
+    "law-of-cosines-oq-01-oq-05": {
+      "quality": 100
+    },
+    "law-of-cosines-oq-04": {
+      "quality": 100
+    },
+    "law-of-sines-oq-06": {
+      "quality": 100
+    },
+    "laws-of-large-numbers": {
+      "quality": 100
+    },
+    "laws-of-large-numbers-oq-01": {
+      "quality": 100
+    },
+    "laws-of-large-numbers-oq-03": {
+      "quality": 100
+    },
+    "laws-of-large-numbers-oq-04": {
+      "quality": 100
+    },
+    "lebesgue-measure-oq-01": {
+      "quality": 100
+    },
+    "lebesgue-measure-oq-01-oq-01": {
+      "quality": 100
+    },
+    "lebesgue-measure-oq-03-oq-01": {
+      "quality": 100
+    },
+    "lebesgue-measure-oq-06": {
+      "quality": 100
+    },
+    "legendre-partial": {
+      "quality": 100
+    },
+    "leibniz-pi": {
+      "quality": 100
+    },
+    "leibniz-pi-oq-01": {
+      "quality": 100
+    },
+    "leibniz-pi-oq-01-oq-01": {
+      "quality": 100
+    },
+    "leibniz-pi-oq-02": {
+      "quality": 100
+    },
+    "leibniz-pi-oq-03": {
+      "quality": 100
+    },
+    "lhopital": {
+      "quality": 100
+    },
+    "lhopital-oq-01": {
+      "quality": 100
+    },
+    "lhopital-oq-02": {
+      "quality": 100
+    },
+    "lovasz-local-lemma": {
+      "quality": 100
+    },
+    "lovasz-local-lemma-oq-02": {
+      "quality": 100
+    },
+    "mathematical-induction": {
+      "quality": 100
+    },
+    "mathematical-induction-oq-01": {
+      "quality": 100
+    },
+    "mean-value-theorem-oq-02": {
+      "quality": 100
+    },
+    "mean-value-theorem-oq-03": {
+      "quality": 100
+    },
+    "minkowski-fundamental-theorem": {
+      "quality": 100
+    },
+    "minkowski-fundamental-theorem-oq-02": {
+      "quality": 100
+    },
+    "minkowski-theorem-oq-02": {
+      "quality": 100
+    },
+    "morleys-theorem": {
+      "quality": 100
+    },
+    "morleys-theorem-oq-01": {
+      "quality": 100
+    },
+    "motivic-flag-maps": {
+      "quality": 100
+    },
+    "motivic-flag-maps-oq-02": {
+      "quality": 100
+    },
+    "napoleons-theorem": {
+      "quality": 100
+    },
+    "napoleons-theorem-oq-02": {
+      "quality": 100
+    },
+    "navier-stokes": {
+      "quality": 100
+    },
+    "navier-stokes-existence": {
+      "quality": 100
+    },
+    "navier-stokes-oq-01": {
+      "quality": 100
+    },
+    "newton-inductive-step": {
+      "quality": 100
+    },
+    "newton-inductive-step-oq-01": {
+      "quality": 100
+    },
+    "nth-root-irrational": {
+      "quality": 100
+    },
+    "nth-root-irrational-oq-01": {
+      "quality": 100
+    },
+    "p-vs-np": {
+      "quality": 100
+    },
+    "pac-learning-bounds": {
+      "quality": 100
+    },
+    "parallel-postulate-independence": {
+      "quality": 100
+    },
+    "parallel-postulate-independence-oq-02": {
+      "quality": 100
+    },
+    "partition-theorem": {
+      "quality": 100
+    },
+    "partition-theorem-oq-01": {
+      "quality": 100
+    },
+    "partition-theorem-oq-01-oq-01": {
+      "quality": 100
+    },
+    "partition-theorem-oq-03": {
+      "quality": 100
+    },
+    "pascals-hexagon": {
+      "quality": 100
+    },
+    "pell-equation": {
+      "quality": 100
+    },
+    "perfect-numbers": {
+      "quality": 100
+    },
+    "pi-transcendental": {
+      "quality": 100
+    },
+    "picks-theorem": {
+      "quality": 100
+    },
+    "picks-theorem-oq-01": {
+      "quality": 100
+    },
+    "picks-theorem-oq-03": {
+      "quality": 100
+    },
+    "platonic-solids-oq-01": {
+      "quality": 100
+    },
+    "platonic-solids-oq-02": {
+      "quality": 100
+    },
+    "poincare-conjecture": {
+      "quality": 100
+    },
+    "prime-gap-bounds": {
+      "quality": 100
+    },
+    "prime-gap-bounds-oq-01": {
+      "quality": 100
+    },
+    "prime-number-theorem": {
+      "quality": 100
+    },
+    "prime-reciprocal-divergence": {
+      "quality": 100
+    },
+    "primitive-roots": {
+      "quality": 100
+    },
+    "primitive-roots-oq-02": {
+      "quality": 100
+    },
+    "prob-method-alteration": {
+      "quality": 100
+    },
+    "prob-method-applications": {
+      "quality": 100
+    },
+    "prob-method-expectation": {
+      "quality": 100
+    },
+    "prob-method-lovasz-local": {
+      "quality": 100
+    },
+    "prob-method-second-moment": {
+      "quality": 100
+    },
+    "prob-method-second-moment-oq-01": {
+      "quality": 100
+    },
+    "product-of-segments-of-chords-oq-01": {
+      "quality": 100
+    },
+    "ptolemys-complex-proof": {
+      "quality": 100
+    },
+    "ptolemys-complex-proof-oq-02": {
+      "quality": 100
+    },
+    "ptolemys-theorem-oq-01": {
+      "quality": 100
+    },
+    "ptolemys-theorem-oq-01-incomplete-01": {
+      "quality": 100
+    },
+    "ptolemys-theorem-oq-01-oq-01": {
+      "quality": 100
+    },
+    "ptolemys-theorem-oq-01-oq-02": {
+      "quality": 100
+    },
+    "puiseux-theorem": {
+      "quality": 100
+    },
+    "pythagorean-theorem": {
+      "quality": 100
+    },
+    "pythagorean-theorem-oq-03": {
+      "quality": 100
+    },
+    "pythagorean-triples": {
+      "quality": 100
+    },
+    "pythagorean-triples-oq-01": {
+      "quality": 100
+    },
+    "pythagorean-triples-oq-02": {
+      "quality": 100
+    },
+    "quadratic-reciprocity": {
+      "quality": 100
+    },
+    "quadratic-reciprocity-algorithm-oq-01": {
+      "quality": 100
+    },
+    "ramanujan-sum-fallacy": {
+      "quality": 100
+    },
+    "ramsey-r4k-extensions": {
+      "quality": 100
+    },
+    "ramseys-theorem": {
+      "quality": 100
+    },
+    "ramseys-theorem-oq-04": {
+      "quality": 100
+    },
+    "randomized-maxcut": {
+      "quality": 100
+    },
+    "randomized-maxcut-oq-01": {
+      "quality": 100
+    },
+    "randomized-maxcut-oq-04": {
+      "quality": 100
+    },
+    "rh-consequences": {
+      "quality": 100
+    },
+    "roth-theorem-k3": {
+      "quality": 100
+    },
+    "roth-theorem-k3-oq-01": {
+      "quality": 100
+    },
+    "russell-1-plus-1": {
+      "quality": 100
+    },
+    "schauder-fixed-point": {
+      "quality": 100
+    },
+    "schauder-fixed-point-oq-01": {
+      "quality": 100
+    },
+    "schauder-fixed-point-oq-03": {
+      "quality": 100
+    },
+    "schauder-fixed-point-oq-03-oq-01": {
+      "quality": 100
+    },
+    "schroeder-bernstein": {
+      "quality": 100
+    },
+    "schroeder-bernstein-oq-02": {
+      "quality": 100
+    },
+    "schroeder-bernstein-oq-03": {
+      "quality": 100
+    },
+    "schroeder-bernstein-oq-04": {
+      "quality": 100
+    },
+    "shannon-channel-coding": {
+      "quality": 100
+    },
+    "shannon-channel-coding-oq-02": {
+      "quality": 100
+    },
+    "shannon-channel-coding-oq-02-oq-01": {
+      "quality": 100
+    },
+    "shannon-channel-coding-oq-02-oq-04": {
+      "quality": 100
+    },
+    "shannon-channel-coding-oq-03": {
+      "quality": 100
+    },
+    "shannon-channel-coding-oq-04": {
+      "quality": 100
+    },
+    "shannon-channel-coding-oq-04-oq-01": {
+      "quality": 100
+    },
+    "shannon-channel-coding-oq-04-oq-01-oq-01": {
+      "quality": 100
+    },
+    "shannon-entropy": {
+      "quality": 100
+    },
+    "shannon-entropy-oq-01": {
+      "quality": 100
+    },
+    "shannon-entropy-oq-02": {
+      "quality": 100
+    },
+    "shannon-entropy-oq-03": {
+      "quality": 100
+    },
+    "shannon-source-coding": {
+      "quality": 100
+    },
+    "shannon-source-coding-oq-01": {
+      "quality": 100
+    },
+    "shannon-source-coding-oq-02": {
+      "quality": 100
+    },
+    "shannon-source-coding-oq-04": {
+      "quality": 100
+    },
+    "shapley-folkman": {
+      "quality": 100
+    },
+    "shapley-folkman-oq-03": {
+      "quality": 100
+    },
+    "solution-of-cubic": {
+      "quality": 100
+    },
+    "solution-of-cubic-oq-03": {
+      "quality": 100
+    },
+    "solution-of-cubic-oq-03-oq-01": {
+      "quality": 100
+    },
+    "solution-of-cubic-oq-03-oq-02": {
+      "quality": 100
+    },
+    "solution-of-cubic-oq-03-oq-03": {
+      "quality": 100
+    },
+    "solution-of-cubic-oq-05": {
+      "quality": 100
+    },
+    "sophie-germain": {
+      "quality": 100
+    },
+    "sophie-germain-oq-02": {
+      "quality": 100
+    },
+    "sperner-ndim": {
+      "quality": 100
+    },
+    "sperner-ndim-oq-01": {
+      "quality": 100
+    },
+    "sperner-ndim-oq-03": {
+      "quality": 100
+    },
+    "sperner-ndim-oq-03-oq-01": {
+      "quality": 100
+    },
+    "sperner-ndim-oq-04": {
+      "quality": 100
+    },
+    "spherical-law-of-cosines": {
+      "quality": 100
+    },
+    "spherical-law-of-sines": {
+      "quality": 100
+    },
+    "sqrt2-examples": {
+      "quality": 100
+    },
+    "sqrt2-examples-oq-01": {
+      "quality": 100
+    },
+    "sqrt2-from-axioms": {
+      "quality": 100
+    },
+    "sqrt2-from-axioms-oq-01": {
+      "quality": 100
+    },
+    "sqrt2-irrational": {
+      "quality": 100
+    },
+    "sqrt2-minpoly": {
+      "quality": 100
+    },
+    "sqrt2-minpoly-oq-01": {
+      "quality": 100
+    },
+    "sqrt2-minpoly-oq-02": {
+      "quality": 100
+    },
+    "sqrt2-plus-sqrt3-irrational-oq-03": {
+      "quality": 100
+    },
+    "stirling-formula": {
+      "quality": 100
+    },
+    "stirling-formula-oq-01": {
+      "quality": 100
+    },
+    "stirling-formula-oq-02": {
+      "quality": 100
+    },
+    "subset-count": {
+      "quality": 100
+    },
+    "subset-count-multiset": {
+      "quality": 100
+    },
+    "subset-count-multiset-oq-01": {
+      "quality": 100
+    },
+    "subset-count-oq-02": {
+      "quality": 100
+    },
+    "subset-count-oq-02-oq-01": {
+      "quality": 100
+    },
+    "sum-of-divisors": {
+      "quality": 100
+    },
+    "sum-of-kth-powers": {
+      "quality": 100
+    },
+    "sum-of-kth-powers-oq-01": {
+      "quality": 100
+    },
+    "sum-of-kth-powers-oq-02": {
+      "quality": 100
+    },
+    "sum-of-kth-powers-oq-04": {
+      "quality": 100
+    },
+    "sylow-theorem": {
+      "quality": 100
+    },
+    "sylow-theorem-oq-01": {
+      "quality": 100
+    },
+    "sylow-theorem-oq-02": {
+      "quality": 100
+    },
+    "sylow-theorems": {
+      "quality": 100
+    },
+    "sylow-theorems-oq-01": {
+      "quality": 100
+    },
+    "sylow-theorems-oq-02": {
+      "quality": 100
+    },
+    "sylow-theorems-oq-04": {
+      "quality": 100
+    },
+    "szemeredi-core": {
+      "quality": 100
+    },
+    "szemeredi-counting": {
+      "quality": 100
+    },
+    "szemeredi-full": {
+      "quality": 100
+    },
+    "szemeredi-hypergraph-core": {
+      "quality": 100
+    },
+    "szemeredi-hypergraph-core-oq-01-incomplete-01": {
+      "quality": 100
+    },
+    "szemeredi-regularity": {
+      "quality": 100
+    },
+    "szemeredi-theorem": {
+      "quality": 100
+    },
+    "taylor-sincos-convergence": {
+      "quality": 100
+    },
+    "taylor-sincos-convergence-oq-01": {
+      "quality": 100
+    },
+    "taylor-sincos-convergence-oq-02": {
+      "quality": 100
+    },
+    "taylor-sincos-convergence-oq-04": {
+      "quality": 100
+    },
+    "taylor-theorem": {
+      "quality": 100
+    },
+    "taylor-theorem-oq-02": {
+      "quality": 100
+    },
+    "taylor-theorem-oq-03": {
+      "quality": 100
+    },
+    "three-place-identity": {
+      "quality": 100
+    },
+    "three-place-identity-oq-02": {
+      "quality": 100
+    },
+    "tractatus-ontology": {
+      "quality": 100
+    },
+    "triangle-angle-sum": {
+      "quality": 100
+    },
+    "triangle-angle-sum-oq-01": {
+      "quality": 100
+    },
+    "triangle-angle-sum-oq-02": {
+      "quality": 100
+    },
+    "triangle-angle-sum-oq-03": {
+      "quality": 100
+    },
+    "triangle-inequality": {
+      "quality": 100
+    },
+    "triangle-inequality-oq-03": {
+      "quality": 100
+    },
+    "triangle-inequality-oq-04": {
+      "quality": 100
+    },
+    "triangular-reciprocals-oq-01": {
+      "quality": 100
+    },
+    "triangular-reciprocals-oq-03": {
+      "quality": 100
+    },
+    "triangular-reciprocals-oq-03-oq-02": {
+      "quality": 100
+    },
+    "twin-primes-special": {
+      "quality": 100
+    },
+    "unit-distance-independence": {
+      "quality": 100
+    },
+    "vietas-formulas-oq-02": {
+      "quality": 100
+    },
+    "vietas-formulas-oq-03": {
+      "quality": 100
+    },
+    "vietas-formulas-oq-03-oq-01": {
+      "quality": 100
+    },
+    "vietas-formulas-oq-03-oq-05": {
+      "quality": 100
+    },
+    "weak-goldbach": {
+      "quality": 100
+    },
+    "wilsons-theorem": {
+      "quality": 100
+    },
+    "wilsons-theorem-oq-01": {
+      "quality": 100
+    },
+    "wilsons-theorem-oq-02": {
+      "quality": 100
+    },
+    "wilsons-theorem-oq-03": {
+      "quality": 100
+    },
+    "wilsons-theorem-oq-04": {
+      "quality": 100
+    },
+    "wolstenholme-theorem-oq-01": {
+      "quality": 100
+    },
+    "wolstenholme-theorem-oq-02": {
+      "quality": 100
+    },
+    "wolstenholme-theorem-oq-03": {
+      "quality": 100
+    },
+    "yang-mills-2d": {
+      "quality": 100
+    },
+    "yang-mills-2d-oq-01": {
+      "quality": 100
+    },
+    "yang-mills-2d-oq-02": {
+      "quality": 100
+    },
+    "yang-mills-lattice": {
+      "quality": 100
+    },
+    "yang-mills-lattice-oq-01": {
+      "quality": 100
+    },
+    "yang-mills-transfer-matrix": {
+      "quality": 100
+    },
+    "yang-mills-transfer-matrix-oq-01": {
       "quality": 100
     }
   },


### PR DESCRIPTION
## Summary

- Fixes 1,872 stale `quality` values in `src/data/proofs/enrichment-tracker.json`
- All stale entries had quality=0 or quality<100 in the tracker but actually compute to quality=100 via the scoring algorithm
- The divergence occurred because entries were created/enriched before the quality scorer reached its current algorithm, or before quality was tracked per-entry

## Impact

The `claim-next` script uses priority = `(1/(passes+1)) * (100 - quality)` to select targets. With stale quality values (e.g., quality=0), fully-enriched entries got high priority and were repeatedly re-selected, wasting enricher cycles. After this fix, all quality-100 entries have priority=0, ensuring the enricher pool focuses on genuinely lower-quality entries.

## Verification

- JSON validity checked: `python3 -c "import json; json.load(...)"`
- After fix: 0 entries with quality < 100 in tracker
- `find-targets.ts` already computed quality=100 for all 2,150 affected entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)