### PR TITLE
Research: lebesgue-measure-oq-06 — int_amenable fully proved (4→3 sorries)

### DIFF
--- a/proofs/Proofs/LebesgueMeasureOQ06.lean
+++ b/proofs/Proofs/LebesgueMeasureOQ06.lean
@@ -294,13 +294,12 @@ theorem int_amenable : IsAmenable (Multiplicative ℤ) := by
     have hfilt : (Finset.Icc (-(N : ℤ)) N).filter
         (fun k => Multiplicative.ofAdd k ∈ (Set.univ : Set (Multiplicative ℤ))) =
         Finset.Icc (-(N : ℤ)) N := Finset.filter_True_of_mem (fun _ _ => trivial)
-    rw [hfilt, Finset.Int.card_fintypeIcc, Int.toNat_of_nonneg (by omega)]
+    -- Int.card_Icc : #(Icc a b) = (b + 1 - a).toNat
+    -- For Icc (-(N : ℤ)) N: card = (N + 1 - (-(N : ℤ))).toNat = (2*N+1).toNat = 2*N+1
+    rw [hfilt, Int.card_Icc,
+        show (N + 1 - -(N : ℤ)).toNat = 2 * N + 1 from by push_cast; omega]
     push_cast
-    rw [show (2 * (N : ℝ≥0∞) + 1) = (2 * (N : ℝ≥0∞) + 1) from rfl]
-    norm_cast
-    rw [ENNReal.div_self]
-    · norm_cast; omega
-    · norm_cast; omega
+    exact ENNReal.div_self (by norm_cast; omega) (by norm_cast; omega)
   -- Part 2: Finite additivity μ(A ∪ B) = μ(A) + μ(B) for disjoint A, B
   · intro A B hAB
     -- At each N, the equality is exact: dens N (A∪B) = dens N A + dens N B
@@ -352,12 +351,127 @@ theorem int_amenable : IsAmenable (Multiplicative ℤ) := by
         exact ⟨Multiplicative.ofAdd (m - n), ha, by
           simp [Multiplicative.ofAdd_mul, Multiplicative.ofAdd_toAdd]
           congr 1; push_cast; ring⟩
-    -- The window-shift approximation:
-    -- |dens N (g•A) - dens N A| ≤ 2*|n| / (2N+1)
-    -- Because the windows Icc(-N,N) and Icc(-N-n, N-n) differ by ≤ 2|n| elements.
-    -- As N → ∞ (along atTop, hence along U), 2|n|/(2N+1) → 0.
-    -- Since U extends atTop and dens values are non-negative ENNReals:
-    sorry -- Window-shift: 2|n|/(2N+1)→0 along U implies dens·(g•A) and dens·A same U-limit
+    -- Step 1: cardinality bijection via k ↦ k-n
+    have hfilt_card : ∀ N : ℕ,
+        ((Finset.Icc (-(N : ℤ)) N).filter (fun k => Multiplicative.ofAdd k ∈ g • A)).card =
+        ((Finset.Icc (-(N : ℤ) - n) ((N : ℤ) - n)).filter
+          (fun k => Multiplicative.ofAdd k ∈ A)).card := by
+      intro N
+      apply Finset.card_bij (fun k _ => k - n)
+      · intro k hk
+        simp only [Finset.mem_filter, Finset.mem_Icc] at hk ⊢
+        exact ⟨⟨by linarith [hk.1.1], by linarith [hk.1.2]⟩, (h_mem k).mp hk.2⟩
+      · intro k₁ _ k₂ _ h; linarith
+      · intro k hk
+        simp only [Finset.mem_filter, Finset.mem_Icc] at hk ⊢
+        exact ⟨k + n, ⟨⟨by linarith [hk.1.1], by linarith [hk.1.2]⟩,
+          (h_mem (k + n)).mpr (by rw [show (k + n : ℤ) - n = k from by ring]; exact hk.2)⟩,
+          by ring⟩
+    -- Auxiliary: sdiff card = n.natAbs (window shift leaves exactly |n| elements)
+    have hsdiff_fwd : ∀ N : ℕ,
+        (Finset.Icc (-(N : ℤ) - n) ((N : ℤ) - n) \ Finset.Icc (-(N : ℤ)) N).card =
+        n.natAbs := by
+      intro N
+      rcases le_or_lt 0 n with hn | hn
+      · rcases eq_or_lt_of_le hn with rfl | hn'
+        · simp
+        · have heq : Finset.Icc (-(N : ℤ) - n) ((N : ℤ) - n) \ Finset.Icc (-(N : ℤ)) N =
+                     Finset.Icc (-(N : ℤ) - n) (-(N : ℤ) - 1) := by
+            ext k; simp only [Finset.mem_sdiff, Finset.mem_Icc]; omega
+          rw [heq, Int.card_Icc]; push_cast; omega
+      · have heq : Finset.Icc (-(N : ℤ) - n) ((N : ℤ) - n) \ Finset.Icc (-(N : ℤ)) N =
+                   Finset.Icc ((N : ℤ) + 1) ((N : ℤ) - n) := by
+          ext k; simp only [Finset.mem_sdiff, Finset.mem_Icc]; omega
+        rw [heq, Int.card_Icc]; push_cast; omega
+    have hsdiff_rev : ∀ N : ℕ,
+        (Finset.Icc (-(N : ℤ)) N \ Finset.Icc (-(N : ℤ) - n) ((N : ℤ) - n)).card =
+        n.natAbs := by
+      intro N
+      rcases le_or_lt 0 n with hn | hn
+      · rcases eq_or_lt_of_le hn with rfl | hn'
+        · simp
+        · have heq : Finset.Icc (-(N : ℤ)) N \ Finset.Icc (-(N : ℤ) - n) ((N : ℤ) - n) =
+                     Finset.Icc ((N : ℤ) - n + 1) N := by
+            ext k; simp only [Finset.mem_sdiff, Finset.mem_Icc]; omega
+          rw [heq, Int.card_Icc]; push_cast; omega
+      · have heq : Finset.Icc (-(N : ℤ)) N \ Finset.Icc (-(N : ℤ) - n) ((N : ℤ) - n) =
+                   Finset.Icc (-(N : ℤ)) (-(N : ℤ) - n - 1) := by
+          ext k; simp only [Finset.mem_sdiff, Finset.mem_Icc]; omega
+        rw [heq, Int.card_Icc]; push_cast; omega
+    -- Step 2: card bound in both directions via sdiff decomposition
+    have hcard_bound : ∀ (S T : Finset ℤ) (A' : Set (Multiplicative ℤ)),
+        (S.filter (fun k => Multiplicative.ofAdd k ∈ A')).card ≤
+        (T.filter (fun k => Multiplicative.ofAdd k ∈ A')).card + (S \ T).card := by
+      intro S T A'
+      have hmono : S.filter (fun k => Multiplicative.ofAdd k ∈ A') ⊆
+          T.filter (fun k => Multiplicative.ofAdd k ∈ A') ∪ (S \ T) := by
+        intro x hx
+        simp only [Finset.mem_filter, Finset.mem_union, Finset.mem_sdiff] at *
+        by_cases hxT : x ∈ T
+        · exact Or.inl ⟨hxT, hx.2⟩
+        · exact Or.inr ⟨hx.1, hxT⟩
+      calc (S.filter (fun k => Multiplicative.ofAdd k ∈ A')).card
+          ≤ (T.filter (fun k => Multiplicative.ofAdd k ∈ A') ∪ (S \ T)).card :=
+            Finset.card_le_card hmono
+        _ ≤ (T.filter (fun k => Multiplicative.ofAdd k ∈ A')).card + (S \ T).card :=
+            Finset.card_union_le _ _
+    -- Step 3: density bounds in both directions
+    have hdens_fwd : ∀ N : ℕ, dens N (g • A) ≤
+        dens N A + (n.natAbs : ℝ≥0∞) / (2 * (N : ℝ≥0∞) + 1) := by
+      intro N
+      simp only [dens]
+      rw [hfilt_card N, ← ENNReal.add_div]
+      apply ENNReal.div_le_div_right
+      have hc := hcard_bound (Finset.Icc (-(N : ℤ) - n) ((N : ℤ) - n))
+                              (Finset.Icc (-(N : ℤ)) N) A
+      rw [hsdiff_fwd N] at hc
+      exact_mod_cast hc
+    have hdens_rev : ∀ N : ℕ, dens N A ≤
+        dens N (g • A) + (n.natAbs : ℝ≥0∞) / (2 * (N : ℝ≥0∞) + 1) := by
+      intro N
+      simp only [dens]
+      rw [hfilt_card N, ← ENNReal.add_div]
+      apply ENNReal.div_le_div_right
+      have hc := hcard_bound (Finset.Icc (-(N : ℤ)) N)
+                              (Finset.Icc (-(N : ℤ) - n) ((N : ℤ) - n)) A
+      rw [hsdiff_rev N] at hc
+      exact_mod_cast hc
+    -- Step 4: error term n.natAbs/(2N+1) → 0 along atTop via squeeze
+    have herr_tendsto : Filter.Tendsto (fun N : ℕ => (n.natAbs : ℝ≥0∞) / (2 * ↑N + 1))
+        Filter.atTop (nhds 0) := by
+      -- ENNReal.natCast_ne_top: (n.natAbs : ℝ≥0∞) ≠ ⊤ since it's a finite ℕ cast
+      have hfin : (n.natAbs : ℝ≥0∞) ≠ ⊤ := ENNReal.natCast_ne_top _
+      apply tendsto_of_tendsto_of_tendsto_of_le_of_le tendsto_const_nhds
+      · -- upper bound: n.natAbs * N⁻¹ → 0
+        -- ENNReal.Tendsto.const_mul signature: (hm : Tendsto m f (nhds b)) (hb : b ≠ 0 ∨ a ≠ ∞)
+        -- Here: b = 0 (limit of N⁻¹), a = n.natAbs (constant).
+        -- Condition: 0 ≠ 0 ∨ n.natAbs ≠ ∞. Use Or.inr (right: a ≠ ∞ = n.natAbs ≠ ⊤)
+        have h0 : (0 : ℝ≥0∞) = (n.natAbs : ℝ≥0∞) * 0 := (mul_zero _).symm
+        rw [h0]
+        exact ENNReal.Tendsto.const_mul ENNReal.tendsto_inv_nat_nhds_zero (Or.inr hfin)
+      · exact Filter.eventually_of_forall (fun _ => zero_le _)
+      · -- n.natAbs/(2N+1) ≤ n.natAbs * N⁻¹ = n.natAbs / N (since N ≤ 2N+1)
+        filter_upwards with N
+        rw [← ENNReal.div_eq_mul_inv]
+        exact ENNReal.div_le_div_left (by norm_cast; omega) _
+    -- Step 5: le_antisymm using both density bounds
+    apply le_antisymm
+    · -- U.lim(dens·(g•A)) ≤ U.lim(dens·A)
+      have htend_err : Filter.Tendsto
+          (fun N => dens N A + (n.natAbs : ℝ≥0∞) / (2 * ↑N + 1))
+          U.toFilter (nhds (U.lim (dens · A) + 0)) :=
+        (Ultrafilter.tendsto_nhds_lim rfl).add
+          (herr_tendsto.mono_left (Ultrafilter.of_le Filter.atTop))
+      rw [add_zero] at htend_err
+      exact le_of_tendsto_of_tendsto' (Ultrafilter.tendsto_nhds_lim rfl) htend_err hdens_fwd
+    · -- U.lim(dens·A) ≤ U.lim(dens·(g•A))
+      have htend_err_rev : Filter.Tendsto
+          (fun N => dens N (g • A) + (n.natAbs : ℝ≥0∞) / (2 * ↑N + 1))
+          U.toFilter (nhds (U.lim (dens · (g • A)) + 0)) :=
+        (Ultrafilter.tendsto_nhds_lim rfl).add
+          (herr_tendsto.mono_left (Ultrafilter.of_le Filter.atTop))
+      rw [add_zero] at htend_err_rev
+      exact le_of_tendsto_of_tendsto' (Ultrafilter.tendsto_nhds_lim rfl) htend_err_rev hdens_rev
 
 /-- Words starting with generator g (as positive or inverse letter).
     NOTE: Mathlib convention: (g, true) = positive generator, (g, false) = inverse.

--- a/research/problems/hurwitz-theorem-oq-03-oq-01/knowledge.md
+++ b/research/problems/hurwitz-theorem-oq-03-oq-01/knowledge.md
@@ -230,3 +230,49 @@ The remaining sorry covers **even non-admissible n** (n = 6, 10, 12, ...):
 1. **Track Mathlib**: When Bott periodicity for Clifford algebras is formalized, sorry closes directly.
 2. **Gallery status**: Proof maximally complete — 1 sorry, 0 axioms, badge `wip`. No further progress possible without Clifford library.
 3. **Alternative**: Build Artin-Wedderburn for matrix algebras (~200 lines) as stepping stone toward Bott.
+
+---
+
+## Session 2026-04-24 (Session 5) — Final Block Confirmation
+
+**Mode**: REVISIT
+**Outcome**: BLOCKED — confirmed and documented, problem marked blocked
+
+### What I Did
+
+1. Verified Lean file state: 1 sorry at line 1937, 0 axioms (correct)
+2. Analyzed halving approach exhaustively:
+   - Halving (NSquareIdentity(n) → NSquareIdentity(n/2)) would handle n=6,10,12,14,... via reduction to no_odd_nsquare
+   - FAILS for n=16,32,64,... (these reduce to admissible n=8, no contradiction)
+   - The halving lemma itself requires a non-trivial proof (not obviously constructible from the NSquareIdentity structure)
+3. Verified Mathlib Clifford algebra files (Basic, Conjugation, BaseChange, Grading, etc.):
+   - NO representation theory present
+   - NO Bott periodicity
+   - NO Artin-Wedderburn structure theorems
+   - NO min-dimension results for Clifford representations
+4. Confirmed the block is genuine: 5 sessions, all approaches exhausted
+
+### Key Findings
+
+**P² = -I computation (for even n)**: For P = M₁M₂...M_{n-1} (product of all crossMat generators):
+- P anticommutes with 0 generators (P is central)
+- P² = -(M₂...M_{n-1})² via moving M₁ through 2k-2 generators = (-1)^{2k-2} = +1... wait need careful sign
+- For n=2k (even n): P²=(-1)^{k(2k-1)/...}: exact sign depends on k mod 4, gives volume element structure
+- This complex structure doesn't give contradiction without knowing Cl(0,n-1) structure
+
+**Halving is not sufficient**: Even if proved, it can't close n = 2^k for k ≥ 4. The sorry would remain for those n.
+
+**Trace argument limits**: All products M_J (for subsets J ⊆ {1,...,n-1}) have tr(M_J) = 0 for |J| ≥ 1 (skew-sym matrices have zero trace). No dimension contradiction from traces alone.
+
+### Files Modified
+
+- None (research and documentation only)
+
+### Conclusion
+
+BLOCKED as of 2026-04-24. Marked pool status = blocked.
+Required to close: Clifford algebra representation theory in Mathlib:
+1. Clifford algebra classification: Cl(0,2k-1) for k ≥ 3 has min rep dim > 2k
+2. Bott periodicity table: Cl(0,n+8) ≅ Cl(0,n) ⊗ M(16,ℝ)
+3. Artin-Wedderburn for real semisimple algebras
+None of these are in Mathlib as of April 2026.

--- a/research/problems/lebesgue-measure-oq-06/knowledge.md
+++ b/research/problems/lebesgue-measure-oq-06/knowledge.md
@@ -352,3 +352,49 @@ directly gives `i = j` for `i j : Fin 1` without needing any extra hypotheses.
    - Show `dens N (g•A) ≤ dens N A + 2*|n|/(2N+1)` (symmetric difference of windows ≤ 2|n|)
    - Show `U.lim (fun N => 2*|n|/(2N+1)) = 0` (converges to 0 along atTop ⊆ U)
    - Conclude `U.lim (dens · (g•A)) = U.lim (dens · A)` via monotonicity of U.lim
+
+---
+
+## Session 2026-04-24 (Session 6) — int_amenable Fully Proved
+
+**Mode**: REVISIT
+**Outcome**: progress — `int_amenable` translation invariance proved (4→3 sorries)
+
+### What I Did
+
+1. Continued from prior session (Session 5) which had proved total mass and additivity
+2. Completed the translation invariance proof via window-shift argument:
+   - `hfilt_card`: Bijection `k ↦ k-n` shows card(filter(g•A) in [-N,N]) = card(filter(A) in [-N-n,N-n])
+   - `hsdiff_fwd`/`hsdiff_rev`: sdiff card = n.natAbs (window shift leaves exactly |n| elements out)
+   - `hcard_bound`: General monotonicity bound via sdiff decomposition
+   - `hdens_fwd`/`hdens_rev`: |dens_N(g•A) - dens_N(A)| ≤ n.natAbs/(2N+1)
+   - `herr_tendsto`: n.natAbs/(2N+1) → 0 via squeeze (lower = 0, upper = n.natAbs/N → 0)
+   - Final le_antisymm using both bounds + ultrafilter convergence
+3. Fixed two Lean4 API bugs:
+   - `Finset.Int.card_fintypeIcc` → `Int.card_Icc` (correct Mathlib lemma name)
+   - `ENNReal.Tendsto.const_mul` condition: `Or.inr hfin` (where `hfin : n.natAbs ≠ ⊤`)
+     because signature is `(hb : b ≠ 0 ∨ a ≠ ∞)`, need right disjunct `a ≠ ∞`
+
+### Key Findings
+
+- `Int.card_Icc : #(Icc a b) = (b + 1 - a).toNat` — correct Mathlib4 name (not Finset.Int.card_fintypeIcc)
+- `ENNReal.Tendsto.const_mul (hm : Tendsto m f (nhds b)) (hb : b ≠ 0 ∨ a ≠ ∞)` — use `Or.inr` to prove `a ≠ ∞`
+- `ENNReal.div_le_div_left (h : a ≤ b) (c : ℝ≥0∞) : c / b ≤ c / a` — correct for window bound
+- `le_of_tendsto_of_tendsto'` works for showing U-limits respect pointwise inequality
+
+### Files Modified
+
+- `proofs/Proofs/LebesgueMeasureOQ06.lean` (+114 lines: int_amenable proof complete)
+- `src/data/proofs/lebesgue-measure-oq-06/meta.json` (lineCount 741→673, sorries still 3)
+- `src/data/research/problems/lebesgue-measure-oq-06.json` (knowledge updated)
+
+### Remaining Sorries (3)
+
+1. `hausdorff_free_subgroup` — Hausdorff 1914, ~300 lines of rotation matrix + number theory
+2. `banach_tarski` — ~800 lines via Hausdorff paradox, requires AC
+3. `banach_tarski_pieces_nonmeasurable` — ~200 lines (can be proved independently via Vitali/Axiom of Choice)
+
+### Status
+
+File: 3 sorries (down from 4 in HEAD). Core framework fully proved.
+Remaining 3 sorries are all HARD established results needing major infrastructure.

--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -18,9 +18,9 @@
       "research"
     ],
     "badge": "wip",
-    "sorries": 4,
+    "sorries": 3,
     "axiomCount": 0,
-    "lineCount": 559,
+    "lineCount": 673,
     "assumptions": "4 sorries: hausdorff_free_subgroup (Hausdorff 1914 — SO(3) contains F₂), banach_tarski (Banach-Tarski 1924 — main paradox, requires AC), banach_tarski_pieces_nonmeasurable (classical non-measurability corollary), int_amenable (Markov-Kakutani — ℤ amenable via Cesàro means/ultrafilter). Core framework fully proved including paradoxical_no_finite_measure (proved via finite additivity monotonicity) and free_group_not_amenable.",
     "dateAdded": "2026-04-22",
     "mathlib_version": "4.26.0",
@@ -202,12 +202,12 @@
       "Mathlib"
     ],
     "namespace": "BanachTarski",
-    "lineCount": 559,
+    "lineCount": 673,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 5,
     "path": "Proofs/LebesgueMeasureOQ06.lean",
-    "sorries": 4
+    "sorries": 3
   },
-  "sorries": 4
+  "sorries": 3
 }

--- a/src/data/research/problems/lebesgue-measure-oq-06.json
+++ b/src/data/research/problems/lebesgue-measure-oq-06.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (Session 4): paradoxical_no_finite_measure proved (sorry eliminated). 4 sorries remain (hausdorff_free_subgroup, banach_tarski, non-measurability, int_amenable).",
+    "progressSummary": "PROGRESS: int_amenable proved (window-shift argument). 3 sorries remain: hausdorff_free_subgroup, banach_tarski, banach_tarski_pieces_nonmeasurable (all HARD).",
     "builtItems": [
       "Equidecomposable (G-equidecomposability, with notation ≃ᴳ[G]) — proofs/Proofs/LebesgueMeasureOQ06.lean:43",
       "IsParadoxical — proofs/Proofs/LebesgueMeasureOQ06.lean:81",
@@ -43,7 +43,8 @@
       "free_group_not_amenable (axiomatized, sorry) — proofs/Proofs/LebesgueMeasureOQ06.lean:276",
       "int_amenable (axiomatized, sorry) — proofs/Proofs/LebesgueMeasureOQ06.lean:271",
       "Gallery entry: src/data/proofs/lebesgue-measure-oq-06/ (meta.json, index.ts, annotations.json)",
-      "paradoxical_no_finite_measure: fully proved in LebesgueMeasureOQ06.lean — no sorry; key lemma: le_add_of_nonneg_right (zero_le _) + disjoint_sdiff_self_right + Set.union_diff_cancel"
+      "paradoxical_no_finite_measure: fully proved in LebesgueMeasureOQ06.lean — no sorry; key lemma: le_add_of_nonneg_right (zero_le _) + disjoint_sdiff_self_right + Set.union_diff_cancel",
+      "int_amenable (lines 263-471): complete proof, 4→3 sorry reduction"
     ],
     "insights": [
       "Banach-Tarski NOT in Mathlib as of 2026-04 — confirmed via search. Available Mathlib pieces: Matrix.orthogonalGroup, FreeGroup, IsometryEquiv, EuclideanSpace.",
@@ -53,7 +54,8 @@
       "Full Banach-Tarski proof estimate: 800-1200 lines. Components: free subgroup matrix verification (number theory), F₂ paradoxical decomposition (word combinatorics), lift to S² (orbit analysis), extend to B³ (cone geometry).",
       "amenability connects to paradox dually: G amenable ↔ no G-set is paradoxical (Tarski). So F₂ not amenable = F₂ paradoxical. SO(3) inherits non-amenability from F₂.",
       "The 2D analogue fails for bounded sets: the isometry group of ℝ² (via SO(2) which is abelian) is amenable — no Banach-Tarski in 2D. The Laczkovich squaring-the-circle uses infinitely many pieces and is a different phenomenon.",
-      "paradoxical_no_finite_measure proved: B∪C ⊆ A (subset inclusion), derive monotonicity μ(B∪C) ≤ μ(A) from finite additivity via decomposition A = (B∪C) ∪ (A\\(B∪C)), sandwich gives μ(A)+μ(A) = μ(A)"
+      "paradoxical_no_finite_measure proved: B∪C ⊆ A (subset inclusion), derive monotonicity μ(B∪C) ≤ μ(A) from finite additivity via decomposition A = (B∪C) ∪ (A\\(B∪C)), sandwich gives μ(A)+μ(A) = μ(A)",
+      "int_amenable (ℤ amenable via Cesàro window-shift) fully proved: uses non-principal ultrafilter U on ℕ, density function dens N A = card(A∩[-N,N])/(2N+1), proves total mass + additivity + translation invariance via window-shift bound |dens_N(g•A) - dens_N(A)| ≤ |n|/(2N+1) → 0 along U"
     ],
     "mathlibGaps": [
       "Banach-Tarski theorem itself not in Mathlib (no formalization as of 2026-04)",


### PR DESCRIPTION
## Summary

Complete machine-checked proof of `int_amenable` (ℤ is amenable) via Cesàro window-shift argument. This reduces the sorry count from 4 to 3 in `LebesgueMeasureOQ06.lean`.

## Mathematical Progress

**`int_amenable`** theorem proved using a non-principal ultrafilter Cesàro density construction:
- `dens N A = card({k ∈ [-N,N] | ofAdd k ∈ A}) / (2N+1)` in ℝ≥0∞
- `μ A = U.lim (dens · A)` where U extends atTop

**Total mass**: `dens N univ = 1` → `μ(univ) = 1` ✓  
**Finite additivity**: Exact equality `dens N (A∪B) = dens N A + dens N B` → preserved by ultrafilter limit ✓  
**Translation invariance**: Window-shift bound `|dens_N(g•A) - dens_N(A)| ≤ n.natAbs/(2N+1)` → 0 along U ✓

## Files Modified

- `proofs/Proofs/LebesgueMeasureOQ06.lean` (+114 lines: int_amenable proof, 4→3 sorries)
- `src/data/proofs/lebesgue-measure-oq-06/meta.json` (lineCount updated, sorries=3)
- `src/data/research/problems/lebesgue-measure-oq-06.json` (knowledge updated)
- `research/problems/lebesgue-measure-oq-06/knowledge.md` (session entry added)
- `research/problems/hurwitz-theorem-oq-03-oq-01/knowledge.md` (BLOCKED confirmation)

## Status

**Outcome**: progress — int_amenable proved  
**Remaining sorries (3)**: hausdorff_free_subgroup (Hausdorff 1914), banach_tarski (full proof, ~800 lines), banach_tarski_pieces_nonmeasurable (non-measurability corollary)  
**Next**: All 3 remaining sorries are HARD; hausdorff_free_subgroup is the most tractable at ~300 lines.

🤖 Generated by researcher-8