### PR TITLE
Audit: re-verify 11 proofs clean (fourier-series-oq-04, feuerbachs-theorem-oq-02, and 9 more)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -208,12 +208,12 @@
       "result": "clean"
     },
     "area-of-circle-oq-01-oq-03": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
         "https://github.com/rjwalters/lean-genius/pull/8651"
       ],
-      "lastAudited": "2026-04-03T05:20:33Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-24T18:53:24Z",
+      "result": "clean"
     },
     "area-of-circle-oq-02": {
       "auditCount": 2,
@@ -307,9 +307,9 @@
       "result": "clean"
     },
     "ballot-problem-oq-01-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-24T18:52:03Z",
       "result": "clean"
     },
     "ballot-problem-oq-01-oq-04": {
@@ -331,9 +331,9 @@
       "result": "clean"
     },
     "ballot-problem-oq-03-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-24T18:51:28Z",
       "result": "clean"
     },
     "ballot-problem-oq-03-oq-02": {
@@ -764,9 +764,9 @@
       "result": "clean"
     },
     "burnside-counting": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-24T18:50:47Z",
       "result": "clean"
     },
     "cantor-diagonalization": {
@@ -950,9 +950,9 @@
       "result": "clean"
     },
     "cauchy-schwarz-oq-01-oq-04": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-24T18:50:09Z",
       "result": "clean"
     },
     "cauchy-schwarz-oq-03": {
@@ -1466,9 +1466,9 @@
       "result": "clean"
     },
     "descartes-rule-of-signs-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-24T18:49:46Z",
       "result": "clean"
     },
     "descartes-rule-of-signs-oq-04": {
@@ -1923,9 +1923,9 @@
       "result": "clean"
     },
     "erdos-1018-oq-04": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-24T18:48:57Z",
       "result": "clean"
     },
     "erdos-1019": {
@@ -2223,9 +2223,9 @@
       "result": "clean"
     },
     "erdos-1059-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-24T18:47:44Z",
       "result": "clean"
     },
     "erdos-1059-oq-05": {
@@ -9245,9 +9245,9 @@
       "result": "clean"
     },
     "factor-remainder-nullstellensatz-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-24T18:47:12Z",
       "result": "clean"
     },
     "factor-remainder-theorem": {
@@ -9293,9 +9293,9 @@
       "result": "clean"
     },
     "fermats-last-theorem-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-24T18:46:40Z",
       "result": "clean"
     },
     "feuerbachs-theorem": {
@@ -9317,9 +9317,9 @@
       "result": "clean"
     },
     "feuerbachs-theorem-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-24T18:46:01Z",
       "result": "clean"
     },
     "four-color-theorem": {
@@ -9379,9 +9379,9 @@
       "result": "clean"
     },
     "fourier-series-oq-04": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-24T18:45:21Z",
       "result": "clean"
     },
     "friendship-theorem": {
@@ -10896,8 +10896,8 @@
       "result": "clean"
     },
     "unit-distance-independence": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-03T05:24:38Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-24T18:54:30Z",
       "result": "clean"
     },
     "vietas-formulas": {
@@ -10935,8 +10935,8 @@
       "result": "clean"
     },
     "wilsons-theorem-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-03T05:24:38Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-24T18:53:59Z",
       "result": "clean"
     },
     "wilsons-theorem-oq-04": {


### PR DESCRIPTION
## Audit Tracker Update

Re-verified 11 proofs are clean (no integrity issues found):

- fourier-series-oq-04 (scaffold, badge=wip, 0 sorries, 0 axioms — transparent)
- feuerbachs-theorem-oq-02 (axiomatized, 5 sorries, 3 axioms — all match)
- fermats-last-theorem-oq-03 (axiomatized, 0 sorries, 1 axiom — matches)
- factor-remainder-nullstellensatz-oq-01 (verified/mathlib, 0 sorries — clean)
- erdos-1059-oq-03 (verified/original, 0 sorries — clean)
- erdos-1018-oq-04 (axiomatized, 2 sorries, 4 axioms — all match)
- descartes-rule-of-signs-oq-03 (verified/mathlib, 0 sorries — clean)
- cauchy-schwarz-oq-01-oq-04 (verified/mathlib, 0 sorries — clean)
- burnside-counting (axiomatized, 0 sorries, 5 axioms — all match)
- ballot-problem-oq-03-oq-01 (verified/original, 0 sorries — clean)
- ballot-problem-oq-01-oq-02 (verified/mathlib, 0 sorries — clean)
- area-of-circle-oq-01-oq-03 (verified/mathlib — "trivially" in comment was false positive)
- wilsons-theorem-oq-02 (verified/original, 0 sorries — clean)
- unit-distance-independence (axiomatized, 0 sorries, 2 axioms — clean)

All sorry counts, axiom counts, status, and badge fields verified against `git show HEAD:<file>`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)