### PR TITLE
Fix: sync sperner-ndim-oq-04 meta.json — 0 sorries, 1 axiom, axiomatized

### DIFF
--- a/src/data/proofs/sperner-ndim-oq-04/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-04/meta.json
@@ -7,7 +7,7 @@
     "author": "Kuhn (1968); formalized by researcher-8",
     "sourceUrl": "https://en.wikipedia.org/wiki/Sperner%27s_lemma#Constructive_proof",
     "date": "1968",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/SpernerNDimOQ04.lean",
     "tags": [
       "combinatorics",
@@ -20,8 +20,8 @@
       "door-graph",
       "advanced"
     ],
-    "badge": "wip",
-    "sorries": 3,
+    "badge": "axiom",
+    "sorries": 0,
     "originalContributions": [
       "Definition of door degree and IsKuhnCompatible for abstract Sperner triangulations",
       "Proof that FC simplices have exactly 1 door under Kuhn compatibility",
@@ -41,9 +41,9 @@
       "Proof of walkValid_step: WalkValid is preserved by one Kuhn step"
     ],
     "dateAdded": "2026-04-22",
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 779,
-    "assumptions": "3 sorries remaining: (1) kuhn_walk_reaches_fc: boundary-exit ruling-out only (non-revisiting part now proved); (2) kuhnPathStart_finds_fc_existential: walk-pairing \u03c4\u2218\u03c4=id involution; (3) kuhnPathStart_is_fc: acknowledged false as universal (documented). 0 axiom declarations.",
+    "assumptions": "1 axiom declaration: kuhn_path_existential_ax encodes Kuhn's walk-pairing involution argument (τ∘τ=id via walk reversibility + non-revisiting = no fixed points). Non-revisiting is fully proved (kuhn_step_nonrevisit + WalkValid); walk reversibility is the remaining open formalization step. 0 sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -173,7 +173,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization establishes the infrastructure for Kuhn's constructive proof of n-dimensional Sperner's lemma. Fully proved (Session 4): door counting, FC existence (kuhn_path_terminates via parity), and the non-revisiting invariant (kuhn_step_nonrevisit + WalkValid: walk never revisits any simplex). The WalkValid invariant (5 fields) enables adj_unique_facet to fire in both the predecessor and non-predecessor cases. 3 sorries remain: (1) kuhn_walk_reaches_fc: only boundary-exit ruling-out (parity/involution); (2) kuhnPathStart_finds_fc_existential: walk-pairing \u03c4\u2218\u03c4=id; (3) kuhnPathStart_is_fc: false as universal, documented. The hard combinatorial core (non-revisiting) is complete.",
+    "summary": "This formalization establishes the infrastructure for Kuhn's constructive proof of n-dimensional Sperner's lemma. Fully proved: door counting, FC existence (kuhn_path_terminates via parity), and the non-revisiting invariant (kuhn_step_nonrevisit + WalkValid: walk never revisits any simplex). 0 sorries remain; the existential walk-pairing theorem (kuhnPathStart_finds_fc_existential) is proved modulo 1 axiom: kuhn_path_existential_ax encodes Kuhn's τ∘τ=id involution argument (walk reversibility). The hard combinatorial core (non-revisiting) is complete.",
     "implications": "Kuhn's 1968 result is historically significant as the first polynomial-time algorithm for finding a fully-colored simplex. Path-following algorithms descended from Kuhn's work underlie Scarf's algorithm for computing approximate fixed points, the Lemke-Howson algorithm for Nash equilibrium computation, and the entire field of complementary pivot algorithms. The door-graph framework is essentially the same as the directed graph implicit in the PPAD complexity class (Papadimitriou 1994): a source vertex (boundary door) of in-degree 0 and out-degree 1, with all other vertices having in-degree = out-degree = 1. The abstract formulation using IsKuhnCompatible applies to any Sperner triangulation satisfying the degree bound, including Freudenthal triangulations and simplicial complexes arising in topological data analysis (TDA). In TDA, Sperner-colored subdivisions appear in persistent homology computations, where fully-colored simplices correspond to birth/death pairs in the barcode. The non-revisiting invariant proved here (paths in the door graph contain no cycles involving boundary vertices) is also the key property that makes all these pivot algorithms run in polynomial time.",
     "openQuestions": [
       "Can the non-revisiting invariant (the door graph component containing a boundary door is a path) be proved in Lean 4 using graph theory from Mathlib?",
@@ -248,10 +248,10 @@
     ],
     "namespace": "SpernerNDimOQ04",
     "lineCount": 779,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 20,
     "definitionCount": 8,
-    "sorries": 3
+    "sorries": 0
   },
-  "sorries": 3
+  "sorries": 0
 }


### PR DESCRIPTION
## Summary

- `SpernerNDimOQ04.lean` was updated to replace 3 sorries with `axiom kuhn_path_existential_ax`, but `meta.json` was never synced
- Fixes **sorry mismatch** (claimed 3, actual 0) and **axiom undercount** (claimed 0, actual 1)

## Changes

| Field | Before | After |
|-------|--------|-------|
| `status` | `"formalized"` | `"axiomatized"` |
| `badge` | `"wip"` | `"axiom"` |
| `sorries` | `3` | `0` |
| `axiomCount` | `0` | `1` |
| `assumptions` | "3 sorries remaining..." | Describes `kuhn_path_existential_ax` |
| `conclusion.summary` | "3 sorries remain..." | Updated to reflect 0 sorries |

## Integrity Verification

```
$ git show HEAD:proofs/Proofs/SpernerNDimOQ04.lean | grep -c "sorry"   # → 0
$ git show HEAD:proofs/Proofs/SpernerNDimOQ04.lean | grep "^axiom "    # → axiom kuhn_path_existential_ax
```

Discovered during gallery integrity audit (loom-auditor).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)