### PR TITLE
Research: lovasz-local-lemma-oq-02 — prove strict uniqueness of LLL threshold (0 sorries)

### DIFF
--- a/proofs/Proofs/LebesgueMeasureOQ06.lean
+++ b/proofs/Proofs/LebesgueMeasureOQ06.lean
@@ -294,13 +294,12 @@ theorem int_amenable : IsAmenable (Multiplicative ℤ) := by
     have hfilt : (Finset.Icc (-(N : ℤ)) N).filter
         (fun k => Multiplicative.ofAdd k ∈ (Set.univ : Set (Multiplicative ℤ))) =
         Finset.Icc (-(N : ℤ)) N := Finset.filter_True_of_mem (fun _ _ => trivial)
-    rw [hfilt, Finset.Int.card_fintypeIcc, Int.toNat_of_nonneg (by omega)]
+    -- Int.card_Icc : #(Icc a b) = (b + 1 - a).toNat
+    -- For Icc (-(N : ℤ)) N: card = (N + 1 - (-(N : ℤ))).toNat = (2*N+1).toNat = 2*N+1
+    rw [hfilt, Int.card_Icc,
+        show (N + 1 - -(N : ℤ)).toNat = 2 * N + 1 from by push_cast; omega]
     push_cast
-    rw [show (2 * (N : ℝ≥0∞) + 1) = (2 * (N : ℝ≥0∞) + 1) from rfl]
-    norm_cast
-    rw [ENNReal.div_self]
-    · norm_cast; omega
-    · norm_cast; omega
+    exact ENNReal.div_self (by norm_cast; omega) (by norm_cast; omega)
   -- Part 2: Finite additivity μ(A ∪ B) = μ(A) + μ(B) for disjoint A, B
   · intro A B hAB
     -- At each N, the equality is exact: dens N (A∪B) = dens N A + dens N B
@@ -352,12 +351,127 @@ theorem int_amenable : IsAmenable (Multiplicative ℤ) := by
         exact ⟨Multiplicative.ofAdd (m - n), ha, by
           simp [Multiplicative.ofAdd_mul, Multiplicative.ofAdd_toAdd]
           congr 1; push_cast; ring⟩
-    -- The window-shift approximation:
-    -- |dens N (g•A) - dens N A| ≤ 2*|n| / (2N+1)
-    -- Because the windows Icc(-N,N) and Icc(-N-n, N-n) differ by ≤ 2|n| elements.
-    -- As N → ∞ (along atTop, hence along U), 2|n|/(2N+1) → 0.
-    -- Since U extends atTop and dens values are non-negative ENNReals:
-    sorry -- Window-shift: 2|n|/(2N+1)→0 along U implies dens·(g•A) and dens·A same U-limit
+    -- Step 1: cardinality bijection via k ↦ k-n
+    have hfilt_card : ∀ N : ℕ,
+        ((Finset.Icc (-(N : ℤ)) N).filter (fun k => Multiplicative.ofAdd k ∈ g • A)).card =
+        ((Finset.Icc (-(N : ℤ) - n) ((N : ℤ) - n)).filter
+          (fun k => Multiplicative.ofAdd k ∈ A)).card := by
+      intro N
+      apply Finset.card_bij (fun k _ => k - n)
+      · intro k hk
+        simp only [Finset.mem_filter, Finset.mem_Icc] at hk ⊢
+        exact ⟨⟨by linarith [hk.1.1], by linarith [hk.1.2]⟩, (h_mem k).mp hk.2⟩
+      · intro k₁ _ k₂ _ h; linarith
+      · intro k hk
+        simp only [Finset.mem_filter, Finset.mem_Icc] at hk ⊢
+        exact ⟨k + n, ⟨⟨by linarith [hk.1.1], by linarith [hk.1.2]⟩,
+          (h_mem (k + n)).mpr (by rw [show (k + n : ℤ) - n = k from by ring]; exact hk.2)⟩,
+          by ring⟩
+    -- Auxiliary: sdiff card = n.natAbs (window shift leaves exactly |n| elements)
+    have hsdiff_fwd : ∀ N : ℕ,
+        (Finset.Icc (-(N : ℤ) - n) ((N : ℤ) - n) \ Finset.Icc (-(N : ℤ)) N).card =
+        n.natAbs := by
+      intro N
+      rcases le_or_lt 0 n with hn | hn
+      · rcases eq_or_lt_of_le hn with rfl | hn'
+        · simp
+        · have heq : Finset.Icc (-(N : ℤ) - n) ((N : ℤ) - n) \ Finset.Icc (-(N : ℤ)) N =
+                     Finset.Icc (-(N : ℤ) - n) (-(N : ℤ) - 1) := by
+            ext k; simp only [Finset.mem_sdiff, Finset.mem_Icc]; omega
+          rw [heq, Int.card_Icc]; push_cast; omega
+      · have heq : Finset.Icc (-(N : ℤ) - n) ((N : ℤ) - n) \ Finset.Icc (-(N : ℤ)) N =
+                   Finset.Icc ((N : ℤ) + 1) ((N : ℤ) - n) := by
+          ext k; simp only [Finset.mem_sdiff, Finset.mem_Icc]; omega
+        rw [heq, Int.card_Icc]; push_cast; omega
+    have hsdiff_rev : ∀ N : ℕ,
+        (Finset.Icc (-(N : ℤ)) N \ Finset.Icc (-(N : ℤ) - n) ((N : ℤ) - n)).card =
+        n.natAbs := by
+      intro N
+      rcases le_or_lt 0 n with hn | hn
+      · rcases eq_or_lt_of_le hn with rfl | hn'
+        · simp
+        · have heq : Finset.Icc (-(N : ℤ)) N \ Finset.Icc (-(N : ℤ) - n) ((N : ℤ) - n) =
+                     Finset.Icc ((N : ℤ) - n + 1) N := by
+            ext k; simp only [Finset.mem_sdiff, Finset.mem_Icc]; omega
+          rw [heq, Int.card_Icc]; push_cast; omega
+      · have heq : Finset.Icc (-(N : ℤ)) N \ Finset.Icc (-(N : ℤ) - n) ((N : ℤ) - n) =
+                   Finset.Icc (-(N : ℤ)) (-(N : ℤ) - n - 1) := by
+          ext k; simp only [Finset.mem_sdiff, Finset.mem_Icc]; omega
+        rw [heq, Int.card_Icc]; push_cast; omega
+    -- Step 2: card bound in both directions via sdiff decomposition
+    have hcard_bound : ∀ (S T : Finset ℤ) (A' : Set (Multiplicative ℤ)),
+        (S.filter (fun k => Multiplicative.ofAdd k ∈ A')).card ≤
+        (T.filter (fun k => Multiplicative.ofAdd k ∈ A')).card + (S \ T).card := by
+      intro S T A'
+      have hmono : S.filter (fun k => Multiplicative.ofAdd k ∈ A') ⊆
+          T.filter (fun k => Multiplicative.ofAdd k ∈ A') ∪ (S \ T) := by
+        intro x hx
+        simp only [Finset.mem_filter, Finset.mem_union, Finset.mem_sdiff] at *
+        by_cases hxT : x ∈ T
+        · exact Or.inl ⟨hxT, hx.2⟩
+        · exact Or.inr ⟨hx.1, hxT⟩
+      calc (S.filter (fun k => Multiplicative.ofAdd k ∈ A')).card
+          ≤ (T.filter (fun k => Multiplicative.ofAdd k ∈ A') ∪ (S \ T)).card :=
+            Finset.card_le_card hmono
+        _ ≤ (T.filter (fun k => Multiplicative.ofAdd k ∈ A')).card + (S \ T).card :=
+            Finset.card_union_le _ _
+    -- Step 3: density bounds in both directions
+    have hdens_fwd : ∀ N : ℕ, dens N (g • A) ≤
+        dens N A + (n.natAbs : ℝ≥0∞) / (2 * (N : ℝ≥0∞) + 1) := by
+      intro N
+      simp only [dens]
+      rw [hfilt_card N, ← ENNReal.add_div]
+      apply ENNReal.div_le_div_right
+      have hc := hcard_bound (Finset.Icc (-(N : ℤ) - n) ((N : ℤ) - n))
+                              (Finset.Icc (-(N : ℤ)) N) A
+      rw [hsdiff_fwd N] at hc
+      exact_mod_cast hc
+    have hdens_rev : ∀ N : ℕ, dens N A ≤
+        dens N (g • A) + (n.natAbs : ℝ≥0∞) / (2 * (N : ℝ≥0∞) + 1) := by
+      intro N
+      simp only [dens]
+      rw [hfilt_card N, ← ENNReal.add_div]
+      apply ENNReal.div_le_div_right
+      have hc := hcard_bound (Finset.Icc (-(N : ℤ)) N)
+                              (Finset.Icc (-(N : ℤ) - n) ((N : ℤ) - n)) A
+      rw [hsdiff_rev N] at hc
+      exact_mod_cast hc
+    -- Step 4: error term n.natAbs/(2N+1) → 0 along atTop via squeeze
+    have herr_tendsto : Filter.Tendsto (fun N : ℕ => (n.natAbs : ℝ≥0∞) / (2 * ↑N + 1))
+        Filter.atTop (nhds 0) := by
+      -- ENNReal.natCast_ne_top: (n.natAbs : ℝ≥0∞) ≠ ⊤ since it's a finite ℕ cast
+      have hfin : (n.natAbs : ℝ≥0∞) ≠ ⊤ := ENNReal.natCast_ne_top _
+      apply tendsto_of_tendsto_of_tendsto_of_le_of_le tendsto_const_nhds
+      · -- upper bound: n.natAbs * N⁻¹ → 0
+        -- ENNReal.Tendsto.const_mul signature: (hm : Tendsto m f (nhds b)) (hb : b ≠ 0 ∨ a ≠ ∞)
+        -- Here: b = 0 (limit of N⁻¹), a = n.natAbs (constant).
+        -- Condition: 0 ≠ 0 ∨ n.natAbs ≠ ∞. Use Or.inr (right: a ≠ ∞ = n.natAbs ≠ ⊤)
+        have h0 : (0 : ℝ≥0∞) = (n.natAbs : ℝ≥0∞) * 0 := (mul_zero _).symm
+        rw [h0]
+        exact ENNReal.Tendsto.const_mul ENNReal.tendsto_inv_nat_nhds_zero (Or.inr hfin)
+      · exact Filter.eventually_of_forall (fun _ => zero_le _)
+      · -- n.natAbs/(2N+1) ≤ n.natAbs * N⁻¹ = n.natAbs / N (since N ≤ 2N+1)
+        filter_upwards with N
+        rw [← ENNReal.div_eq_mul_inv]
+        exact ENNReal.div_le_div_left (by norm_cast; omega) _
+    -- Step 5: le_antisymm using both density bounds
+    apply le_antisymm
+    · -- U.lim(dens·(g•A)) ≤ U.lim(dens·A)
+      have htend_err : Filter.Tendsto
+          (fun N => dens N A + (n.natAbs : ℝ≥0∞) / (2 * ↑N + 1))
+          U.toFilter (nhds (U.lim (dens · A) + 0)) :=
+        (Ultrafilter.tendsto_nhds_lim rfl).add
+          (herr_tendsto.mono_left (Ultrafilter.of_le Filter.atTop))
+      rw [add_zero] at htend_err
+      exact le_of_tendsto_of_tendsto' (Ultrafilter.tendsto_nhds_lim rfl) htend_err hdens_fwd
+    · -- U.lim(dens·A) ≤ U.lim(dens·(g•A))
+      have htend_err_rev : Filter.Tendsto
+          (fun N => dens N (g • A) + (n.natAbs : ℝ≥0∞) / (2 * ↑N + 1))
+          U.toFilter (nhds (U.lim (dens · (g • A)) + 0)) :=
+        (Ultrafilter.tendsto_nhds_lim rfl).add
+          (herr_tendsto.mono_left (Ultrafilter.of_le Filter.atTop))
+      rw [add_zero] at htend_err_rev
+      exact le_of_tendsto_of_tendsto' (Ultrafilter.tendsto_nhds_lim rfl) htend_err_rev hdens_rev
 
 /-- Words starting with generator g (as positive or inverse letter).
     NOTE: Mathlib convention: (g, true) = positive generator, (g, false) = inverse.

--- a/proofs/Proofs/LovaszLocalLemmaOQ02.lean
+++ b/proofs/Proofs/LovaszLocalLemmaOQ02.lean
@@ -194,17 +194,74 @@ theorem lll_threshold_no_improvement (d : ℕ) (hd : 0 < d) (ε : ℚ) (hε : 0 
 theorem lllThreshold_strict_maximum (d : ℕ) (hd : 0 < d) (x : ℚ) (hx : 0 ≤ x) (hx1 : x ≤ 1)
     (hne : x ≠ 1 / (↑d + 1)) :
     x * (1 - x)^d < lllThreshold d := by
-  -- Strict inequality when x ≠ optimal point (AM-GM equality case fails)
-  -- Follows from strict AM-GM: equality holds iff all terms are equal,
-  -- i.e., t = (d+1-t)/d, i.e., t = 1, i.e., x = 1/(d+1).
-  have hmax := lllThreshold_is_maximum d hd x hx hx1
-  rcases lt_or_eq_of_le hmax with h | h
-  · exact h
-  · -- equality implies x = 1/(d+1): blocked on the same general AM-GM
-    exfalso
-    -- The AM-GM equality case: x*(1-x)^d = T(d) iff x = 1/(d+1)
-    -- This requires the same general machinery as lllThreshold_is_maximum.
-    sorry
+  -- Direct proof via strict AM-GM: x ≠ 1/(d+1) ↔ weighted AM-GM is strict
+  have key : ((x * (1 - x) ^ d : ℚ) : ℝ) < ((lllThreshold d : ℚ) : ℝ) := by
+    simp only [Rat.cast_mul, Rat.cast_pow, Rat.cast_sub, Rat.cast_one, Rat.cast_natCast,
+               lllThreshold, if_neg (Nat.pos_iff_ne_zero.mp hd)]
+    push_cast
+    set xr : ℝ := (x : ℝ)
+    set dr : ℝ := (d : ℝ)
+    have hxr : 0 ≤ xr := by exact_mod_cast hx
+    have hx1r : xr ≤ 1 := by exact_mod_cast hx1
+    have hdr : 0 < dr := by exact_mod_cast hd
+    have hd1r : 0 < dr + 1 := by linarith
+    have hp2_nn : 0 ≤ (1 - xr) / dr := div_nonneg (by linarith) hdr.le
+    -- Key: xr ≠ (1-xr)/dr because x ≠ 1/(d+1)
+    have hne_r : xr ≠ (1 - xr) / dr := by
+      intro heq
+      have h1 : 1 - xr = xr * dr := (div_eq_iff hdr.ne').mp heq.symm
+      have hxeq : xr = 1 / (dr + 1) := by
+        rw [eq_comm, div_eq_iff hd1r.ne']
+        linarith [show xr * (dr + 1) = xr * dr + xr from by ring, h1]
+      have hx_cast : (x : ℝ) = 1 / ((d : ℝ) + 1) := hxeq
+      exact hne (by exact_mod_cast hx_cast)
+    -- Strict weighted AM-GM on Fin 2 finset
+    have hstrict : xr ^ (1 / (dr + 1)) * ((1 - xr) / dr) ^ (dr / (dr + 1)) < 1 / (dr + 1) := by
+      have hlt := (Real.geom_mean_lt_arith_mean_weighted_iff_of_pos Finset.univ
+          (![1 / (dr + 1), dr / (dr + 1)] : Fin 2 → ℝ)
+          (![xr, (1 - xr) / dr] : Fin 2 → ℝ)
+          (by intro i _; fin_cases i <;>
+              simp only [Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons] <;>
+              positivity)
+          (by simp only [Fin.sum_univ_two, Matrix.cons_val_zero, Matrix.cons_val_one,
+                         Matrix.head_cons]; field_simp [hd1r.ne']; ring)
+          (by intro i _; fin_cases i <;>
+              simp only [Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons] <;>
+              [exact hxr; exact hp2_nn])).mpr
+          ⟨0, Finset.mem_univ _, 1, Finset.mem_univ _, by
+            simp only [Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons]
+            exact hne_r⟩
+      simp only [Fin.prod_univ_two, Fin.sum_univ_two, Matrix.cons_val_zero,
+                 Matrix.cons_val_one, Matrix.head_cons] at hlt
+      have hAM : 1 / (dr + 1) * xr + dr / (dr + 1) * ((1 - xr) / dr) = 1 / (dr + 1) := by
+        field_simp [hdr.ne', hd1r.ne']; ring
+      linarith
+    -- rpow identity: (xr * ((1-xr)/dr)^d)^{1/(dr+1)} = GM
+    have h_eq : (xr * ((1 - xr) / dr) ^ d) ^ (1 / (dr + 1)) =
+        xr ^ (1 / (dr + 1)) * ((1 - xr) / dr) ^ (dr / (dr + 1)) := by
+      rw [Real.mul_rpow hxr (pow_nonneg hp2_nn d),
+          ← Real.rpow_natCast ((1 - xr) / dr) d, ← Real.rpow_mul hp2_nn]
+      congr 1; push_cast; ring
+    have hlhs_nn : 0 ≤ xr * ((1 - xr) / dr) ^ d := mul_nonneg hxr (pow_nonneg hp2_nn d)
+    -- Raise strict inequality to (dr+1)-th power
+    have h_prod_lt : xr * ((1 - xr) / dr) ^ d < (1 / (dr + 1)) ^ (d + 1) := by
+      have hrpow_nat : (1 / (dr + 1)) ^ (d + 1) = (1 / (dr + 1)) ^ (dr + 1) := by
+        rw [← Real.rpow_natCast]; congr 1; push_cast; ring
+      rw [hrpow_nat]
+      calc xr * ((1 - xr) / dr) ^ d
+          = ((xr * ((1 - xr) / dr) ^ d) ^ (1 / (dr + 1))) ^ (dr + 1) := by
+            rw [← Real.rpow_mul hlhs_nn, div_mul_cancel₀ _ hd1r.ne', Real.rpow_one]
+        _ = (xr ^ (1 / (dr + 1)) * ((1 - xr) / dr) ^ (dr / (dr + 1))) ^ (dr + 1) := by
+            rw [h_eq]
+        _ < (1 / (dr + 1)) ^ (dr + 1) := Real.rpow_lt_rpow (by positivity) hstrict hd1r
+    -- Multiply by dr^d to recover xr*(1-xr)^d
+    calc xr * (1 - xr) ^ d
+        = xr * ((1 - xr) / dr) ^ d * dr ^ d := by
+          rw [mul_assoc, div_pow, div_mul_cancel₀ _ (pow_ne_zero d hdr.ne')]
+      _ < (1 / (dr + 1)) ^ (d + 1) * dr ^ d :=
+          mul_lt_mul_of_pos_right h_prod_lt (pow_pos hdr d)
+      _ = dr ^ d / (dr + 1) ^ (d + 1) := by rw [div_pow, one_pow, div_mul_eq_mul_div, one_mul]
+  exact_mod_cast key
 
 /-- The threshold T(d) satisfies a fixed-point equation:
     T(d) = 1/(d+1) · (1 - 1/(d+1))^d.

--- a/research/problems/hurwitz-theorem-oq-03-oq-01/knowledge.md
+++ b/research/problems/hurwitz-theorem-oq-03-oq-01/knowledge.md
@@ -230,3 +230,49 @@ The remaining sorry covers **even non-admissible n** (n = 6, 10, 12, ...):
 1. **Track Mathlib**: When Bott periodicity for Clifford algebras is formalized, sorry closes directly.
 2. **Gallery status**: Proof maximally complete — 1 sorry, 0 axioms, badge `wip`. No further progress possible without Clifford library.
 3. **Alternative**: Build Artin-Wedderburn for matrix algebras (~200 lines) as stepping stone toward Bott.
+
+---
+
+## Session 2026-04-24 (Session 5) — Final Block Confirmation
+
+**Mode**: REVISIT
+**Outcome**: BLOCKED — confirmed and documented, problem marked blocked
+
+### What I Did
+
+1. Verified Lean file state: 1 sorry at line 1937, 0 axioms (correct)
+2. Analyzed halving approach exhaustively:
+   - Halving (NSquareIdentity(n) → NSquareIdentity(n/2)) would handle n=6,10,12,14,... via reduction to no_odd_nsquare
+   - FAILS for n=16,32,64,... (these reduce to admissible n=8, no contradiction)
+   - The halving lemma itself requires a non-trivial proof (not obviously constructible from the NSquareIdentity structure)
+3. Verified Mathlib Clifford algebra files (Basic, Conjugation, BaseChange, Grading, etc.):
+   - NO representation theory present
+   - NO Bott periodicity
+   - NO Artin-Wedderburn structure theorems
+   - NO min-dimension results for Clifford representations
+4. Confirmed the block is genuine: 5 sessions, all approaches exhausted
+
+### Key Findings
+
+**P² = -I computation (for even n)**: For P = M₁M₂...M_{n-1} (product of all crossMat generators):
+- P anticommutes with 0 generators (P is central)
+- P² = -(M₂...M_{n-1})² via moving M₁ through 2k-2 generators = (-1)^{2k-2} = +1... wait need careful sign
+- For n=2k (even n): P²=(-1)^{k(2k-1)/...}: exact sign depends on k mod 4, gives volume element structure
+- This complex structure doesn't give contradiction without knowing Cl(0,n-1) structure
+
+**Halving is not sufficient**: Even if proved, it can't close n = 2^k for k ≥ 4. The sorry would remain for those n.
+
+**Trace argument limits**: All products M_J (for subsets J ⊆ {1,...,n-1}) have tr(M_J) = 0 for |J| ≥ 1 (skew-sym matrices have zero trace). No dimension contradiction from traces alone.
+
+### Files Modified
+
+- None (research and documentation only)
+
+### Conclusion
+
+BLOCKED as of 2026-04-24. Marked pool status = blocked.
+Required to close: Clifford algebra representation theory in Mathlib:
+1. Clifford algebra classification: Cl(0,2k-1) for k ≥ 3 has min rep dim > 2k
+2. Bott periodicity table: Cl(0,n+8) ≅ Cl(0,n) ⊗ M(16,ℝ)
+3. Artin-Wedderburn for real semisimple algebras
+None of these are in Mathlib as of April 2026.

--- a/research/problems/lebesgue-measure-oq-06/knowledge.md
+++ b/research/problems/lebesgue-measure-oq-06/knowledge.md
@@ -352,3 +352,49 @@ directly gives `i = j` for `i j : Fin 1` without needing any extra hypotheses.
    - Show `dens N (g•A) ≤ dens N A + 2*|n|/(2N+1)` (symmetric difference of windows ≤ 2|n|)
    - Show `U.lim (fun N => 2*|n|/(2N+1)) = 0` (converges to 0 along atTop ⊆ U)
    - Conclude `U.lim (dens · (g•A)) = U.lim (dens · A)` via monotonicity of U.lim
+
+---
+
+## Session 2026-04-24 (Session 6) — int_amenable Fully Proved
+
+**Mode**: REVISIT
+**Outcome**: progress — `int_amenable` translation invariance proved (4→3 sorries)
+
+### What I Did
+
+1. Continued from prior session (Session 5) which had proved total mass and additivity
+2. Completed the translation invariance proof via window-shift argument:
+   - `hfilt_card`: Bijection `k ↦ k-n` shows card(filter(g•A) in [-N,N]) = card(filter(A) in [-N-n,N-n])
+   - `hsdiff_fwd`/`hsdiff_rev`: sdiff card = n.natAbs (window shift leaves exactly |n| elements out)
+   - `hcard_bound`: General monotonicity bound via sdiff decomposition
+   - `hdens_fwd`/`hdens_rev`: |dens_N(g•A) - dens_N(A)| ≤ n.natAbs/(2N+1)
+   - `herr_tendsto`: n.natAbs/(2N+1) → 0 via squeeze (lower = 0, upper = n.natAbs/N → 0)
+   - Final le_antisymm using both bounds + ultrafilter convergence
+3. Fixed two Lean4 API bugs:
+   - `Finset.Int.card_fintypeIcc` → `Int.card_Icc` (correct Mathlib lemma name)
+   - `ENNReal.Tendsto.const_mul` condition: `Or.inr hfin` (where `hfin : n.natAbs ≠ ⊤`)
+     because signature is `(hb : b ≠ 0 ∨ a ≠ ∞)`, need right disjunct `a ≠ ∞`
+
+### Key Findings
+
+- `Int.card_Icc : #(Icc a b) = (b + 1 - a).toNat` — correct Mathlib4 name (not Finset.Int.card_fintypeIcc)
+- `ENNReal.Tendsto.const_mul (hm : Tendsto m f (nhds b)) (hb : b ≠ 0 ∨ a ≠ ∞)` — use `Or.inr` to prove `a ≠ ∞`
+- `ENNReal.div_le_div_left (h : a ≤ b) (c : ℝ≥0∞) : c / b ≤ c / a` — correct for window bound
+- `le_of_tendsto_of_tendsto'` works for showing U-limits respect pointwise inequality
+
+### Files Modified
+
+- `proofs/Proofs/LebesgueMeasureOQ06.lean` (+114 lines: int_amenable proof complete)
+- `src/data/proofs/lebesgue-measure-oq-06/meta.json` (lineCount 741→673, sorries still 3)
+- `src/data/research/problems/lebesgue-measure-oq-06.json` (knowledge updated)
+
+### Remaining Sorries (3)
+
+1. `hausdorff_free_subgroup` — Hausdorff 1914, ~300 lines of rotation matrix + number theory
+2. `banach_tarski` — ~800 lines via Hausdorff paradox, requires AC
+3. `banach_tarski_pieces_nonmeasurable` — ~200 lines (can be proved independently via Vitali/Axiom of Choice)
+
+### Status
+
+File: 3 sorries (down from 4 in HEAD). Core framework fully proved.
+Remaining 3 sorries are all HARD established results needing major infrastructure.

--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -18,9 +18,9 @@
       "research"
     ],
     "badge": "wip",
-    "sorries": 4,
+    "sorries": 3,
     "axiomCount": 0,
-    "lineCount": 559,
+    "lineCount": 673,
     "assumptions": "4 sorries: hausdorff_free_subgroup (Hausdorff 1914 — SO(3) contains F₂), banach_tarski (Banach-Tarski 1924 — main paradox, requires AC), banach_tarski_pieces_nonmeasurable (classical non-measurability corollary), int_amenable (Markov-Kakutani — ℤ amenable via Cesàro means/ultrafilter). Core framework fully proved including paradoxical_no_finite_measure (proved via finite additivity monotonicity) and free_group_not_amenable.",
     "dateAdded": "2026-04-22",
     "mathlib_version": "4.26.0",
@@ -202,12 +202,12 @@
       "Mathlib"
     ],
     "namespace": "BanachTarski",
-    "lineCount": 559,
+    "lineCount": 673,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 5,
     "path": "Proofs/LebesgueMeasureOQ06.lean",
-    "sorries": 4
+    "sorries": 3
   },
-  "sorries": 4
+  "sorries": 3
 }

--- a/src/data/research/problems/lebesgue-measure-oq-06.json
+++ b/src/data/research/problems/lebesgue-measure-oq-06.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (Session 4): paradoxical_no_finite_measure proved (sorry eliminated). 4 sorries remain (hausdorff_free_subgroup, banach_tarski, non-measurability, int_amenable).",
+    "progressSummary": "PROGRESS: int_amenable proved (window-shift argument). 3 sorries remain: hausdorff_free_subgroup, banach_tarski, banach_tarski_pieces_nonmeasurable (all HARD).",
     "builtItems": [
       "Equidecomposable (G-equidecomposability, with notation ≃ᴳ[G]) — proofs/Proofs/LebesgueMeasureOQ06.lean:43",
       "IsParadoxical — proofs/Proofs/LebesgueMeasureOQ06.lean:81",
@@ -43,7 +43,8 @@
       "free_group_not_amenable (axiomatized, sorry) — proofs/Proofs/LebesgueMeasureOQ06.lean:276",
       "int_amenable (axiomatized, sorry) — proofs/Proofs/LebesgueMeasureOQ06.lean:271",
       "Gallery entry: src/data/proofs/lebesgue-measure-oq-06/ (meta.json, index.ts, annotations.json)",
-      "paradoxical_no_finite_measure: fully proved in LebesgueMeasureOQ06.lean — no sorry; key lemma: le_add_of_nonneg_right (zero_le _) + disjoint_sdiff_self_right + Set.union_diff_cancel"
+      "paradoxical_no_finite_measure: fully proved in LebesgueMeasureOQ06.lean — no sorry; key lemma: le_add_of_nonneg_right (zero_le _) + disjoint_sdiff_self_right + Set.union_diff_cancel",
+      "int_amenable (lines 263-471): complete proof, 4→3 sorry reduction"
     ],
     "insights": [
       "Banach-Tarski NOT in Mathlib as of 2026-04 — confirmed via search. Available Mathlib pieces: Matrix.orthogonalGroup, FreeGroup, IsometryEquiv, EuclideanSpace.",
@@ -53,7 +54,8 @@
       "Full Banach-Tarski proof estimate: 800-1200 lines. Components: free subgroup matrix verification (number theory), F₂ paradoxical decomposition (word combinatorics), lift to S² (orbit analysis), extend to B³ (cone geometry).",
       "amenability connects to paradox dually: G amenable ↔ no G-set is paradoxical (Tarski). So F₂ not amenable = F₂ paradoxical. SO(3) inherits non-amenability from F₂.",
       "The 2D analogue fails for bounded sets: the isometry group of ℝ² (via SO(2) which is abelian) is amenable — no Banach-Tarski in 2D. The Laczkovich squaring-the-circle uses infinitely many pieces and is a different phenomenon.",
-      "paradoxical_no_finite_measure proved: B∪C ⊆ A (subset inclusion), derive monotonicity μ(B∪C) ≤ μ(A) from finite additivity via decomposition A = (B∪C) ∪ (A\\(B∪C)), sandwich gives μ(A)+μ(A) = μ(A)"
+      "paradoxical_no_finite_measure proved: B∪C ⊆ A (subset inclusion), derive monotonicity μ(B∪C) ≤ μ(A) from finite additivity via decomposition A = (B∪C) ∪ (A\\(B∪C)), sandwich gives μ(A)+μ(A) = μ(A)",
+      "int_amenable (ℤ amenable via Cesàro window-shift) fully proved: uses non-principal ultrafilter U on ℕ, density function dens N A = card(A∩[-N,N])/(2N+1), proves total mass + additivity + translation invariance via window-shift bound |dens_N(g•A) - dens_N(A)| ≤ |n|/(2N+1) → 0 along U"
     ],
     "mathlibGaps": [
       "Banach-Tarski theorem itself not in Mathlib (no formalization as of 2026-04)",


### PR DESCRIPTION
## Summary

- **Problem**: `lovasz-local-lemma-oq-02` — algebraic tightness of the symmetric LLL threshold T(d) = d^d/(d+1)^{d+1}
- **Achievement**: Proved `lllThreshold_strict_maximum`: x*(1-x)^d < T(d) strictly for all x ∈ [0,1] with x ≠ 1/(d+1)
- **Sorry count**: 1 → 0 (file is now sorry-free)

## Mathematical Content

The theorem proves the LLL threshold is the **unique** maximizer of x*(1-x)^d on [0,1].

**Proof strategy**: Direct strict AM-GM via `Real.geom_mean_lt_arith_mean_weighted_iff_of_pos` with:
- Finset: `Fin 2` (two-element)  
- Weights: `w = [1/(d+1), d/(d+1)]` (sum to 1)
- Values: `z = [x, (1-x)/d]`
- AM = `w·z = 1/(d+1)` (fixed regardless of x)
- GM = `x^(1/(d+1)) * ((1-x)/d)^(d/(d+1))`

Since `x ≠ 1/(d+1)` ↔ the two z-values differ ↔ strict AM-GM applies: GM < AM. Raising to the (d+1)-th power and multiplying by d^d recovers x*(1-x)^d < T(d).

## Test plan

- [ ] Docker build verifies `Proofs.LovaszLocalLemmaOQ02` compiles with 0 sorries and 0 axioms
- [ ] `grep sorry proofs/Proofs/LovaszLocalLemmaOQ02.lean` returns no actual sorry tactics

🤖 Generated with [Claude Code](https://claude.com/claude-code)