### PR TITLE
Audit: 22 proofs re-audited, all clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -101,8 +101,8 @@
       "result": "clean"
     },
     "angle-trisection-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T05:30:43Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-24T19:51:34Z",
       "result": "clean"
     },
     "angle-trisection-oq-02": {
@@ -228,8 +228,8 @@
       "result": "clean"
     },
     "area-of-circle-oq-03-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-03T05:24:38Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-24T19:48:49Z",
       "result": "clean"
     },
     "area-of-circle-oq-03-oq-02": {
@@ -1028,8 +1028,8 @@
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-04": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-03T05:24:38Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-24T19:48:48Z",
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-05": {
@@ -1152,8 +1152,8 @@
       "result": "clean"
     },
     "cevas-theorem-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-03T05:24:38Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-24T19:48:46Z",
       "result": "clean"
     },
     "cevas-theorem-oq-02": {
@@ -1169,8 +1169,8 @@
       "result": "clean"
     },
     "cevas-theorem-oq-02-oq-01-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-03T05:24:38Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-24T19:48:44Z",
       "result": "clean"
     },
     "cevas-theorem-oq-02-oq-02": {
@@ -1222,13 +1222,13 @@
       "result": "clean"
     },
     "chinese-remainder-non-coprime-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-03T05:24:38Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-24T19:48:42Z",
       "result": "clean"
     },
     "chinese-remainder-non-coprime-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-03T05:24:38Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-24T19:48:41Z",
       "result": "clean"
     },
     "chinese-remainder-non-coprime-oq-04": {
@@ -1262,8 +1262,8 @@
       "result": "clean"
     },
     "combinations-formula-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-03T05:24:38Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-24T19:48:38Z",
       "result": "clean"
     },
     "continuum-hypothesis": {
@@ -1357,9 +1357,9 @@
       "result": "clean"
     },
     "denumerability-rationals-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T05:36:02Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-24T19:51:34Z",
+      "result": "clean"
     },
     "denumerability-rationals-oq-03": {
       "auditCount": 2,
@@ -4248,8 +4248,8 @@
       "result": "clean"
     },
     "erdos-28-additive-bases": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-03T05:24:38Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-24T19:48:36Z",
       "result": "clean"
     },
     "erdos-280": {
@@ -5778,8 +5778,8 @@
       "result": "clean"
     },
     "erdos-5-prime-gaps": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-03T05:24:38Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-24T19:48:34Z",
       "result": "clean"
     },
     "erdos-50": {
@@ -9162,8 +9162,8 @@
       "result": "clean"
     },
     "erdos-ko-rado": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-03T05:24:38Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-24T19:48:33Z",
       "result": "clean"
     },
     "erdos-szekeres": {
@@ -9883,8 +9883,8 @@
       "result": "clean"
     },
     "konigsberg-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-03T05:24:38Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-24T19:45:40Z",
       "result": "clean"
     },
     "konigsberg-oq-02": {
@@ -9930,8 +9930,8 @@
       "result": "clean"
     },
     "lagrange-four-squares-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-03T05:24:38Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-24T19:45:19Z",
       "result": "clean"
     },
     "lagrange-theorem": {
@@ -11003,26 +11003,26 @@
       "result": "clean"
     },
     "abel-ruffini-galois-extensions": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-03T05:50:08Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-24T19:51:34Z",
       "result": "clean",
       "issues": []
     },
     "abel-ruffini-oq-04-oq-02-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-03T05:50:30Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-24T19:51:34Z",
       "result": "clean",
       "issues": []
     },
     "arithmetic-series-oq-02-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-03T05:50:49Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-24T19:51:34Z",
       "result": "clean",
       "issues": []
     },
     "arithmetic-series-oq-02-oq-02-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-03T05:51:09Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-24T19:51:34Z",
       "result": "clean",
       "issues": []
     },
@@ -11135,26 +11135,26 @@
       "issues": []
     },
     "infinitude-primes-4k1": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-03T05:51:42Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-24T19:51:34Z",
       "result": "clean",
       "issues": []
     },
     "infinitude-primes-4k3": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-03T05:51:42Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-24T19:51:34Z",
       "result": "clean",
       "issues": []
     },
     "intermediate-value-theorem-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-03T05:51:42Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-24T19:51:34Z",
       "result": "clean",
       "issues": []
     },
     "sqrt2-plus-sqrt3-irrational": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-03T05:51:43Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-24T19:51:34Z",
       "result": "clean",
       "issues": []
     },


### PR DESCRIPTION
## Audit Results

Gallery integrity audit pass — 22 proofs re-audited, all clean.

**Proofs audited:**
- lagrange-four-squares-oq-02, konigsberg-oq-01, erdos-ko-rado
- erdos-5-prime-gaps, erdos-28-additive-bases, combinations-formula-oq-01
- chinese-remainder-non-coprime-oq-02/03, cevas-theorem-oq-01/02
- cayley-hamilton-minpoly-oq-04, area-of-circle-oq-03-oq-01
- angle-trisection-oq-01, denumerability-rationals-oq-02
- abel-ruffini-galois-extensions, abel-ruffini-oq-04-oq-02-oq-03
- arithmetic-series-oq-02-oq-01/02, sqrt2-plus-sqrt3-irrational
- intermediate-value-theorem-oq-02, infinitude-primes-4k1/4k3

**Checks performed per proof:**
- Sorry count vs meta.json `sorries` field
- Axiom count vs meta.json `axiomCount` field (including structure-encoded assumptions)
- True-stub detection (`: True :=` / `:= trivial`)
- Mathlib delegation opacity check (badge correctness)

**Result:** All 22 entries pass. No integrity issues detected.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)