### PR TITLE
Research: hook_walk_identity for generalized hook shapes [a,1^b] (Session 19)

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean
@@ -5056,6 +5056,130 @@ private lemma hookProd_ratio_formula {μ : YoungDiagram} {c : ℕ × ℕ} (hc : 
   linear_combination key_Q
 
 
+-- ============================================================
+-- Hook walk identity for generalized hook shapes [a, 1^b] (PART XIVb)
+-- ============================================================
+
+/-- Any corner of gHookYD a b ha (with b ≥ 1) is either (0, a-1) with a ≥ 2, or (b, 0).
+    Proof: corners must be at row ends; row 0 ends at a-1, column 0 ends at b.
+    When a=1: (0,0) has leg neighbor (1,0), so only (b,0) is a corner. -/
+private lemma corners_gHookYD_cases (a b : ℕ) (ha : 0 < a) (hb : 0 < b) {c : ℕ × ℕ}
+    (hc : isCorner (gHookYD a b ha) c) :
+    (c = (0, a - 1) ∧ 1 < a) ∨ c = (b, 0) := by
+  obtain ⟨i, j⟩ := c
+  obtain ⟨hmem, hright, hbelow⟩ := hc
+  rcases mem_gHookYD.mp hmem with ⟨hi0, hj⟩ | ⟨hi1, hi2, hj0⟩
+  · -- (i, j) with i = 0, j < a
+    subst hi0
+    -- hright: (0, j+1) ∉ μ → j+1 ≥ a → j = a-1
+    have hja : j = a - 1 := by
+      have : ¬(j + 1 < a) := fun hlt =>
+        hright (mem_gHookYD.mpr (Or.inl ⟨rfl, hlt⟩))
+      omega
+    subst hja
+    left
+    refine ⟨rfl, ?_⟩
+    -- hbelow: (1, a-1) ∉ μ; but if a=1 then (1,0) ∈ μ (since b≥1), contradiction
+    by_contra hle
+    push_neg at hle
+    have ha1 : a = 1 := Nat.le_antisymm hle ha
+    subst ha1
+    -- a-1 = 0, so (0, 0) ∈ μ and (1, 0) ∈ μ (since b ≥ 1)
+    exact hbelow (mem_gHookYD.mpr (Or.inr ⟨Nat.one_pos, hb, rfl⟩))
+  · -- (i, j) with 1 ≤ i ≤ b, j = 0
+    subst hj0
+    right
+    -- hbelow: (i+1, 0) ∉ μ → i+1 > b → i = b
+    have hib : i = b := by
+      have : ¬(i + 1 ≤ b) := fun hle =>
+        hbelow (mem_gHookYD.mpr (Or.inr ⟨by omega, hle, rfl⟩))
+      omega
+    exact ⟨hib, rfl⟩
+
+/-- The hook walk identity for generalized hook shapes [a, 1^b] with b ≥ 1.
+    Non-circular proof: hook_length_formula_gHookYD is proved independently,
+    and removing a corner of gHookYD a b gives another gHookYD shape.
+    Extends hook_walk_identity_atMostTwoRows to cover ≥3-row hook shapes. -/
+private lemma hook_walk_identity_gHookYD (a b : ℕ) (ha : 0 < a) (hb : 0 < b) :
+    ∑ c ∈ (corners (gHookYD a b ha)).attach,
+      ((hookProd (gHookYD a b ha) : ℚ) /
+       (hookProd (removeCorner (gHookYD a b ha) c.val
+         (mem_corners.mp c.prop)) : ℚ))
+    = ((gHookYD a b ha).card : ℚ) := by
+  have hHP : (hookProd (gHookYD a b ha) : ℚ) ≠ 0 := hookProdQ_ne_zero _
+  have hN : (gHookYD a b ha).card = a + b := gHookYD_card a b ha
+  have hpos : 0 < (gHookYD a b ha).card := by rw [hN]; omega
+  have hfact : (((gHookYD a b ha).card - 1).factorial : ℚ) ≠ 0 :=
+    Nat.cast_ne_zero.mpr (Nat.factorial_pos _).ne'
+  -- HLF for μ (proved independently, without hook_walk_identity)
+  have hμ : (Fintype.card (StandardYoungTableau (gHookYD a b ha)) : ℚ) *
+      hookProd (gHookYD a b ha) = (gHookYD a b ha).card.factorial :=
+    by exact_mod_cast hook_length_formula_gHookYD a b ha
+  -- Corner step: card(SYT(μ)) = Σ_c card(SYT(μ\c))
+  have hstepQ : (Fintype.card (StandardYoungTableau (gHookYD a b ha)) : ℚ) =
+      ∑ cx ∈ (corners (gHookYD a b ha)).attach,
+        (Fintype.card (StandardYoungTableau
+          (removeCorner (gHookYD a b ha) cx.val (mem_corners.mp cx.prop))) : ℚ) :=
+    by exact_mod_cast card_SYT_corner_step (gHookYD a b ha) hpos
+  -- HLF for each removeCorner: a corner removal gives another gHookYD shape
+  have hμc : ∀ cx : { x // x ∈ corners (gHookYD a b ha) },
+      (Fintype.card (StandardYoungTableau
+        (removeCorner (gHookYD a b ha) cx.val (mem_corners.mp cx.prop))) : ℚ) *
+      (hookProd (removeCorner (gHookYD a b ha) cx.val (mem_corners.mp cx.prop)) : ℚ) =
+      (((gHookYD a b ha).card - 1).factorial : ℚ) := by
+    intro ⟨c, hcx⟩
+    have hcorner : isCorner (gHookYD a b ha) c := mem_corners.mp hcx
+    rcases corners_gHookYD_cases a b ha hb hcorner with ⟨hceq, ha2⟩ | hceq
+    · -- c = (0, a-1): removeCorner = gHookYD (a-1) b h'
+      subst hceq
+      rw [removeCorner_gHook_top a b ha ha2 hcorner]
+      have hlf : Fintype.card (StandardYoungTableau (gHookYD (a - 1) b (by omega))) *
+          hookProd (gHookYD (a - 1) b (by omega)) =
+          (gHookYD (a - 1) b (by omega)).card.factorial :=
+        hook_length_formula_gHookYD (a - 1) b (by omega)
+      rw [gHookYD_card] at hlf
+      have hfact_eq : a - 1 + b = (gHookYD a b ha).card - 1 := by rw [hN]; omega
+      rw [hfact_eq] at hlf
+      exact_mod_cast hlf
+    · -- c = (b, 0): removeCorner = gHookYD a (b-1) ha
+      subst hceq
+      rw [removeCorner_gHook_bot a b ha hb hcorner]
+      have hlf : Fintype.card (StandardYoungTableau (gHookYD a (b - 1) ha)) *
+          hookProd (gHookYD a (b - 1) ha) =
+          (gHookYD a (b - 1) ha).card.factorial :=
+        hook_length_formula_gHookYD a (b - 1) ha
+      rw [gHookYD_card] at hlf
+      have hfact_eq : a + (b - 1) = (gHookYD a b ha).card - 1 := by rw [hN]; omega
+      rw [hfact_eq] at hlf
+      exact_mod_cast hlf
+  -- μ.card! = μ.card × (μ.card-1)! as rationals
+  have hfact_succ : ((gHookYD a b ha).card.factorial : ℚ) =
+      ((gHookYD a b ha).card : ℚ) * (((gHookYD a b ha).card - 1).factorial : ℚ) := by
+    cases hcard : (gHookYD a b ha).card with
+    | zero => rw [hN] at hcard; omega
+    | succ n =>
+      rw [show (gHookYD a b ha).card - 1 = n by omega,
+          show (gHookYD a b ha).card = n + 1 from hcard, Nat.factorial_succ]
+      push_cast; ring
+  -- Each summand: HP/HPc = card(SYT(μ\c)) × HP/(N-1)!
+  have hterm : ∀ cx : { x // x ∈ corners (gHookYD a b ha) },
+      (hookProd (gHookYD a b ha) : ℚ) /
+      (hookProd (removeCorner (gHookYD a b ha) cx.val (mem_corners.mp cx.prop)) : ℚ) =
+      (Fintype.card (StandardYoungTableau
+        (removeCorner (gHookYD a b ha) cx.val (mem_corners.mp cx.prop))) : ℚ) *
+      ((hookProd (gHookYD a b ha) : ℚ) / (((gHookYD a b ha).card - 1).factorial : ℚ)) := by
+    intro ⟨c, hcx⟩
+    have hHPc :
+        (hookProd (removeCorner (gHookYD a b ha) c (mem_corners.mp hcx)) : ℚ) ≠ 0 :=
+      hookProdQ_ne_zero _
+    have hIHc := hμc ⟨c, hcx⟩
+    rw [mul_div_assoc, div_eq_div_iff hHPc hfact]
+    linear_combination -(hookProd (gHookYD a b ha) : ℚ) * hIHc
+  -- Assemble: same algebra as hook_walk_identity_atMostTwoRows
+  simp_rw [hterm]
+  rw [← Finset.sum_mul, ← hstepQ, mul_div_assoc, hμ, hfact_succ]
+  field_simp [hfact]
+
 private lemma hook_walk_identity (μ : YoungDiagram) (hn : 0 < μ.card) :
     ∑ c ∈ (corners μ).attach,
       ((hookProd μ : ℚ) / (hookProd (removeCorner μ c.val (mem_corners.mp c.prop)) : ℚ))
@@ -5063,8 +5187,12 @@ private lemma hook_walk_identity (μ : YoungDiagram) (hn : 0 < μ.card) :
   by_cases h2 : μ.rowLen 2 = 0
   · -- At-most-2-row case: proved non-circularly
     exact hook_walk_identity_atMostTwoRows μ h2 hn
-  · -- ≥3-row case: requires hook walk combinatorics (GNW ~300 lines or RSK ~500 lines)
-    sorry
+  · -- ≥3-row: check if μ is a generalized hook shape [a, 1^b]
+    by_cases hghook : ∃ (a b : ℕ) (ha : 0 < a) (hb : 0 < b), μ = gHookYD a b ha
+    · obtain ⟨a, b, ha, hb, rfl⟩ := hghook
+      exact hook_walk_identity_gHookYD a b ha hb
+    · -- General ≥3-row, non-gHookYD case: requires GNW hook walk (~300 lines)
+      sorry
 
 /-- The general hook-length formula in ℚ, proved by well-founded recursion on μ.card.
     Uses card_SYT_corner_step (Part XIII) + hook_walk_identity. -/

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/knowledge.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/knowledge.md
@@ -407,3 +407,50 @@ The sorry count increased by 1 (net) because:
    to HLF itself (circular without external proof). The `hookProd_ratio_formula` now provides the
    ratio factorization needed as input. The 2-row case is already proved in `hook_walk_identity_atMostTwoRows`.
 2. **Archive sessions**: knowledge.md is >500 lines; archive sessions 5-17 to sessions/ subdir.
+
+---
+
+## Session 2026-04-24 (Session 19) — Hook Walk Identity for Generalized Hook Shapes
+
+**Mode**: REVISIT (RICH knowledge tier, score 106)
+**Outcome**: PROGRESS — `hook_walk_identity_gHookYD` proved; sorry scope reduced
+
+### What I Did
+
+1. Identified the non-circular proof path: `hook_length_formula_gHookYD` (proved independently in
+   Session 14 via combinatorial formula) enables proving `hook_walk_identity_gHookYD` without
+   circularity — the same algebraic pattern as `hook_walk_identity_atMostTwoRows`.
+2. Added `corners_gHookYD_cases` (~40 lines): characterizes all corners of `gHookYD a b ha`
+   (with b ≥ 1) as either `(0, a-1)` with `a ≥ 2` (top-right), or `(b, 0)` (bottom-left).
+3. Added `hook_walk_identity_gHookYD` (~90 lines): non-circular proof of hook walk identity for
+   all `[a, 1^b]` shapes. Algebraic strategy mirrors `hook_walk_identity_atMostTwoRows`.
+4. Updated `hook_walk_identity` dispatcher: sorry now covers only ≥3-row non-gHookYD shapes.
+5. PR: rjwalters/lean-genius#12381
+
+### Key Findings
+
+- **Non-circular path via gHookYD**: `hook_length_formula_gHookYD` (session 14) is the independent
+  HLF source — no circularity with `hook_walk_identity`.
+- **a = 1 edge case**: When `a = 1`, `(0, 0)` has `(1, 0) ∈ gHookYD` (b ≥ 1), so NOT a top-right corner.
+- **Remaining sorry scope**: ≥3-row shapes that are NOT [a,1^b] — e.g., [3,2,1], [4,3,2] — require GNW.
+
+### Files Modified
+
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean` (5146 → 5274 lines, PART XIVb added)
+- `research/problems/ballot-problem-oq-03-oq-01-oq-02/knowledge.md` (this file)
+- `src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json` (knowledge updated)
+- `src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json` (lineCount 5274)
+- PR: rjwalters/lean-genius#12381
+
+### Sorry Count: 4 (unchanged count, reduced scope)
+
+- `hook_walk_identity` (PART XIV): sorry now covers only ≥3-row non-gHookYD shapes
+- `ni_count_eq_syt_count` (line 219): RSK bijection, FALSE as stated
+- `lgv_det_factors_as_hook_quotient` (line 235): det identity, FALSE as stated
+- `hook_length_formula` (line 245): depends on the two above (FALSE as stated)
+
+### Next Steps
+
+1. **GNW hook walk for ≥3-row non-gHookYD shapes**: ~200-300 Lean lines (probabilistic proof).
+2. **Simpler stepping stone**: prove `hook_walk_identity` for shapes with exactly 3 rows.
+3. **Archive sessions**: knowledge.md now >600 lines; archive sessions 5-18 to sessions/ subdir.

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "ballot-problem-oq-03-oq-01-oq-02",
   "title": "Hook-Length Formula for Standard Young Tableaux via LGV",
   "slug": "ballot-problem-oq-03-oq-01-oq-02",
-  "description": "Formalizes the hook-length formula f^λ = n!/∏h(u) for Standard Young Tableaux. Fully proves the formula for single-row (1×n), single-column (n×1), hook-shape ((m+1,1)), 2-row rectangular (m×m), and general 2-row [a,b] families. General formula has 4 sorries: 3 via LGV approach (RSK bijection, det factorization, main theorem) + 1 for corner induction (hook_walk_identity ≥3-row case). hookProd_ratio_formula now proved (session 18). hook_length_formula_general proved via corner induction modulo hook_walk_identity.",
+  "description": "Formalizes the hook-length formula f^λ = n!/∏h(u) for Standard Young Tableaux. Fully proves the formula for single-row (1×n), single-column (n×1), hook-shape ((m+1,1)), 2-row rectangular (m×m), general 2-row [a,b], and all generalized hook shapes [a,1^b]. General formula has 4 sorries: 3 via LGV approach (RSK bijection, det factorization, main theorem) + 1 for corner induction (hook_walk_identity ≥3-row non-gHookYD case). hook_walk_identity_gHookYD proved (session 19); scope reduced to non-hook ≥3-row shapes.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-21",
@@ -22,9 +22,9 @@
     "sorries": 4,
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "assumptions": "Four open sorries: (1) hook_length_formula (LGV approach: requires SYT↔NI bijection + det factorization), (2) ni_count_eq_syt_count (Fomin/Viennot/RSK correspondence), (3) lgv_det_factors_as_hook_quotient (det factorization identity), (4) hook_walk_identity ≥3-row case (GNW or RSK, ~300 lines; at-most-2-row case proved; hookProd_ratio_formula now fully proved session 18). hook_length_formula_general is proved modulo hook_walk_identity via Part XIV corner induction.",
-    "lineCount": 5146,
-    "theoremCount": 162,
+    "assumptions": "Four open sorries: (1) hook_length_formula (LGV approach: requires SYT↔NI bijection + det factorization), (2) ni_count_eq_syt_count (Fomin/Viennot/RSK correspondence), (3) lgv_det_factors_as_hook_quotient (det factorization identity), (4) hook_walk_identity ≥3-row non-gHookYD case (GNW or RSK, ~300 lines; at-most-2-row and all [a,1^b] cases proved; hookProd_ratio_formula fully proved session 18, hook_walk_identity_gHookYD proved session 19). hook_length_formula_general is proved modulo hook_walk_identity via Part XIV corner induction.",
+    "lineCount": 5274,
+    "theoremCount": 164,
     "definitionCount": 14,
     "originalContributions": [
       "hookLength: hook length at cell (i,j) = armLen + legLen + 1 using YoungDiagram.rowLen and colLen",
@@ -44,7 +44,9 @@
       "hook_length_formula_gHookYD: HLF for all generalized hook shapes [a, 1^b] (card = C(a+b-1,b), proved via double induction + inline bijection, 0 sorries)",
       "hookProd_ratio_formula: hookProd(μ)/hookProd(μ\\c) equals product over arm × product over leg (1 sorry: ~50 lines Finset.prod_union decomposition)",
       "hook_walk_identity: sum over corners c of hookProd(μ)/hookProd(μ\\c) = μ.card — at-most-2-row case proved; ≥3-row case has 1 sorry (~300 lines GNW/RSK)",
-      "hook_length_formula_general: HLF for all Young diagrams via corner induction (proved modulo hook_walk_identity, 0 sorries in the theorem itself)"
+      "hook_length_formula_general: HLF for all Young diagrams via corner induction (proved modulo hook_walk_identity, 0 sorries in the theorem itself)",
+      "corners_gHookYD_cases: characterizes all corners of [a,1^b] as either (0,a-1) with a≥2 or (b,0) (proved, 0 sorries, session 19)",
+      "hook_walk_identity_gHookYD: hook walk identity Σ_c hookProd/hookProd(μ\\c)=|μ| proved for all [a,1^b] with b≥1, non-circular via hook_length_formula_gHookYD (session 19)"
     ]
   },
   "overview": {
@@ -87,7 +89,7 @@
       "LGV"
     ],
     "namespace": "HookLengthFormula",
-    "lineCount": 5146,
+    "lineCount": 5274,
     "axiomCount": 0,
     "sorries": 4,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
@@ -47,7 +47,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: hookProd_ratio_formula proved (session 18); 4 sorries remain (hook_walk_identity ≥3-row + 3 legacy)",
+    "progressSummary": "PROGRESS: hook_walk_identity_gHookYD proved (session 19); sorry scope reduced to ≥3-row non-gHookYD shapes; 4 sorries remain",
     "builtItems": [
       "instFintypeSYT: Fintype instance for StandardYoungTableau (BallotProblemOQ03OQ01OQ02.lean, Part IIIb)",
       "emptyTableau: unique SYT of shape bot (BallotProblemOQ03OQ01OQ02.lean, Part IIIc)",
@@ -98,7 +98,9 @@
       "removeCorner_atMostTwoRows (BallotProblemOQ03OQ01OQ02.lean:4639): removing corner from ≤2-row shape stays ≤2-row",
       "hook_walk_identity_atMostTwoRows (BallotProblemOQ03OQ01OQ02.lean:4659): hook walk identity proved for all ≤2-row shapes, non-circular",
       "hook_walk_identity (BallotProblemOQ03OQ01OQ02.lean:4714): case split — ≤2-row proved, ≥3-row sorry",
-      "hookProd_ratio_formula: proved 0-sorry in BallotProblemOQ03OQ01OQ02.lean session 18"
+      "hookProd_ratio_formula: proved 0-sorry in BallotProblemOQ03OQ01OQ02.lean session 18",
+      "corners_gHookYD_cases (BallotProblemOQ03OQ01OQ02.lean:~5058): characterizes corners of gHookYD a b ha (b≥1) as (0,a-1) with a≥2 OR (b,0)",
+      "hook_walk_identity_gHookYD (BallotProblemOQ03OQ01OQ02.lean:~5100): hook walk identity proved for all [a,1^b] shapes with b≥1, non-circular proof via hook_length_formula_gHookYD"
     ],
     "insights": [
       "lgv_lemma_rxr in BallotProblemOQ03OQ02.lean is the key building block (Gessel-Viennot involution proof)",
@@ -151,16 +153,20 @@
       "General (≥3-row) case still requires GNW probabilistic proof (~300 lines) or RSK (~500 lines) — not buildable in a single session",
       "hookProd_ratio_formula proved using ℕ-equality-then-cast strategy: key_nat avoids division, then linear_combination key_Q closes after prod_div_distrib",
       "Finset.prod_image injectivity: .2 for (i,s) image, .1 for (r,j) image; Prod.ext h.symm rfl proves (i,x.2)=x from x.1=i",
-      "disjoint_sdiff_self_right proves Disjoint s (t\\s) for restCells=ν.cells\\(arm∪leg)"
+      "disjoint_sdiff_self_right proves Disjoint s (t\\s) for restCells=ν.cells\\(arm∪leg)",
+      "hook_walk_identity_gHookYD is provable non-circularly because hook_length_formula_gHookYD was independently proved in session 14 via combinatorial formula C(a+b-1,b)",
+      "a=1 edge case in corners_gHookYD: (0,0) is NOT a top-right corner when a=1 because (1,0)∈gHookYD (b≥1) prevents it from being a corner",
+      "hook_walk_identity sorry scope: now covers only ≥3-row shapes that are NOT gHookYD — shapes like [3,2,1], [4,3,2], etc. require GNW probabilistic proof"
     ],
     "mathlibGaps": [
       "hookLength may not be defined in Mathlib.Combinatorics.YoungDiagram — check arm/leg availability",
       "StandardYoungTableau enumeration — check Mathlib.Combinatorics.YoungTableaux"
     ],
     "nextSteps": [
-      "Prove hook_walk_identity ≥3-row case: needs GNW probabilistic hook walk (~200-300 lines)",
-      "Archive sessions 5-17 to sessions/ subdir (knowledge.md >500 lines)",
-      "Fix ni_count_eq_syt_count statement (RSK bijection, FALSE as stated)"
+      "Prove hook_walk_identity for ≥3-row non-gHookYD shapes via GNW probabilistic hook walk (~200-300 lines)",
+      "Simpler stepping stone: prove hook_walk_identity for shapes with exactly 3 rows",
+      "Fix ni_count_eq_syt_count statement (RSK bijection, FALSE as stated — needs hypothesis relating μ to LGV config)",
+      "Archive sessions 5-18 to sessions/ subdir (knowledge.md >700 lines)"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

- **Problem**: ballot-problem-oq-03-oq-01-oq-02 (Hook-Length Formula, Tier A, knowledge score 106)
- **Session 19** of ongoing HLF formalization work

### New Lemmas Added

**`corners_gHookYD_cases`** — Characterizes the corners of a generalized hook shape `[a, 1^b]` (with `b ≥ 1`). Any corner is either `(0, a-1)` with `a ≥ 2` (top-right), or `(b, 0)` (bottom-left). Proved by case-splitting on the `mem_gHookYD` characterization plus corner conditions (no right/below neighbors).

**`hook_walk_identity_gHookYD`** — Proves the hook walk identity
```
∑_{c ∈ corners(μ)} hookProd(μ) / hookProd(μ\c) = μ.card
```
for all generalized hook shapes `μ = gHookYD a b ha` with `b ≥ 1`.

This is a **non-circular proof** using `hook_length_formula_gHookYD` (proved independently in Session 14 via combinatorial formula) as the independent HLF source. The algebraic structure mirrors `hook_walk_identity_atMostTwoRows`.

**Updated `hook_walk_identity` dispatcher** — Added a `by_cases` on `∃ a b ha hb, μ = gHookYD a b ha` between the ≤2-row case and the final `sorry`. The sorry now covers only ≥3-row shapes that are NOT generalized hook shapes (e.g., [3,2,1], [4,3,2]).

### Proof Progress

| Scope | Before | After |
|-------|--------|-------|
| `hook_walk_identity` sorry covers | All ≥3-row shapes | Non-hook ≥3-row shapes only |
| Generalized hook shapes [a,1^b] | sorry | ✓ proved |

### Remaining Work

The final sorry covers shapes like `[3,2,1]`, `[4,3,2]`, `[n,n-1,...,2,1]`, etc. These require the full GNW probabilistic proof (~200-300 Lean lines) or an RSK-based approach (~500 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)