### PR TITLE
Fix: inclusion-exclusion-oq-01 definitionCount 0→5

### DIFF
--- a/src/data/proofs/inclusion-exclusion-oq-01/meta.json
+++ b/src/data/proofs/inclusion-exclusion-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "inclusion-exclusion-oq-01",
   "title": "Inclusion-Exclusion: Applications to Number Theory and Combinatorics",
   "slug": "inclusion-exclusion-oq-01",
-  "description": "Applies the inclusion-exclusion principle to connect combinatorics and number theory. Proves sieve formulas (2-set and 3-set), Euler's totient via IE sieve (φ(pq)=(p-1)(q-1)), surjection counting (|Surj(n,k)| = Σ (-1)^j C(k,j)(k-j)^n), derangement formula (D(n) = Σ (-1)^k C(n,k)(n-k)!), derangement recurrence, divisor-totient identity (Σ_{d|n} φ(d) = n), and alternating binomial sum. 41 theorems, 0 definitions, 0 axioms.",
+  "description": "Applies the inclusion-exclusion principle to connect combinatorics and number theory. Proves sieve formulas (2-set and 3-set), Euler's totient via IE sieve (φ(pq)=(p-1)(q-1)), surjection counting (|Surj(n,k)| = Σ (-1)^j C(k,j)(k-j)^n), derangement formula (D(n) = Σ (-1)^k C(n,k)(n-k)!), derangement recurrence, divisor-totient identity (Σ_{d|n} φ(d) = n), and alternating binomial sum. 41 theorems, 5 definitions, 0 axioms.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-02-15",
@@ -22,7 +22,7 @@
     "assumptions": "None. Fully machine-verified using Mathlib's Nat.totient and Finset.card lemmas.",
     "lineCount": 382,
     "theoremCount": 41,
-    "definitionCount": 0,
+    "definitionCount": 5,
     "originalContributions": [
       "sieve_two / sieve_three: |U \\ (A ∪ B)| and three-set inclusion-exclusion",
       "totient_prime_product: φ(pq) = (p-1)(q-1) for distinct primes via IE sieve",
@@ -66,7 +66,7 @@
     "lineCount": 382,
     "axiomCount": 0,
     "theoremCount": 41,
-    "definitionCount": 0,
+    "definitionCount": 5,
     "path": "Proofs/InclusionExclusionOQ01.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Correct the `definitionCount` metadata field for `inclusion-exclusion-oq-01` from 0 to 5.

## Evidence

**Before**: `definitionCount: 0` in both `meta` and `leanFile` sections; description said "0 definitions"

**After**: `definitionCount: 5` in both sections; description says "5 definitions"

The Lean file contains 5 `def` declarations:
- Line 134: `def surjectionCount`
- Line 180: `def derangements`
- Line 252: `def altBinomSum`
- Line 309: `def stirling2`
- Line 334: `def bellNumber`

Core claims (status: verified, 0 axioms, 0 sorries) are unaffected.

Closes #12380

---
Automated fix by lean-mechanic agent.