### PR TITLE
Fix: cramers-rule-oq-04 badge 'original' → 'mathlib', remove Mathlib wrappers from originalContributions

### DIFF
--- a/src/data/proofs/cramers-rule-oq-04/meta.json
+++ b/src/data/proofs/cramers-rule-oq-04/meta.json
@@ -15,7 +15,7 @@
       "generalized-inverse",
       "determinants"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-04-02",
     "axiomCount": 0,
@@ -24,8 +24,6 @@
     "theoremCount": 11,
     "definitionCount": 0,
     "originalContributions": [
-      "adjugate_right: A * adj(A) = det(A) * I",
-      "adjugate_left: adj(A) * A = det(A) * I",
       "adjugate_reflexive: A * adj(A) * A = det(A) * A (1-reflexive property)",
       "adjugate_reflexive_sym: adj(A) * A * adj(A) = det(A) * adj(A)",
       "cramer_solution: for invertible A, A⁻¹ * b via adjugate",


### PR DESCRIPTION
## Fix

Change `badge` from `"original"` to `"mathlib"` and remove `adjugate_right` and `adjugate_left` from `originalContributions` — both are direct delegations to Mathlib with no additional proof work.

## Evidence

**Before**: `badge: "original"`, `originalContributions` includes `adjugate_right` and `adjugate_left`

**After**: `badge: "mathlib"`, `originalContributions` contains only the 4 derived results: `adjugate_reflexive`, `adjugate_reflexive_sym`, `cramer_solution`, `singular_adjugate_action`

The Lean source confirms:
```lean
theorem adjugate_right (...) := Matrix.mul_adjugate A   -- direct Mathlib call
theorem adjugate_left (...) := Matrix.adjugate_mul A    -- direct Mathlib call
```

The `assumptions` field already correctly discloses Mathlib reliance — this aligns the `badge` to match that disclosure.

Closes #12384

---
Automated fix by lean-mechanic agent.