### PR TITLE
Enrich hurwitz-theorem-oq-04: add 2 sections for full 5-section coverage

### DIFF
--- a/src/data/proofs/hurwitz-theorem-oq-04/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-04/meta.json
@@ -62,6 +62,14 @@
   },
   "sections": [
     {
+      "id": "module-overview",
+      "title": "Preamble: Context and Contents",
+      "startLine": 1,
+      "endLine": 63,
+      "summary": "Module documentation places the formalization in context: Hurwitz's theorem (1898) gives 4 normed division algebras, and the Freudenthal-Tits magic square (1954–1966) connects them to 5 exceptional Lie algebras. The contents table distinguishes proved results (0 sorries) from axiomatized ones (deep Lie group results not yet in Mathlib). References: Baez 'The Octonions' (2002), Freudenthal (1964), Tits (1966).",
+      "mathContext": "The magic square table: rows and columns indexed by {ℝ,ℂ,ℍ,𝕆}. Entries: 𝔏(𝕆,ℝ)=F₄, 𝔏(𝕆,ℂ)=E₆, 𝔏(𝕆,ℍ)=E₇, 𝔏(𝕆,𝕆)=E₈, plus G₂=Der(𝕆). The 'magic': 𝔏(A,B)≅𝔏(B,A) despite the definition not being visibly symmetric."
+    },
+    {
       "id": "octonion-automorphisms",
       "title": "§I-II: Octonion Unit and Automorphism Structures",
       "startLine": 64,
@@ -70,19 +78,27 @@
       "mathContext": "An octonion algebra homomorphism φ: 𝕆 → 𝕆 satisfies φ(a+b)=φ(a)+φ(b), φ(r·a)=r·φ(a), and φ(a·b)=φ(a)·φ(b). An automorphism also has a two-sided inverse. The unit element e₀ satisfies e₀·a = a·e₀ = a for all a ∈ 𝕆."
     },
     {
-      "id": "norm-preservation",
-      "title": "§III: Norm and Inner Product Preservation",
+      "id": "norm-preservation-core",
+      "title": "§III-a: Automorphisms Fix e₀ and Preserve Im(𝕆)",
       "startLine": 166,
-      "endLine": 360,
-      "summary": "Proves the core structural results: phi_unit_eq_unit (φ(e₀)=e₀), imag_sq_eq_neg_norm (y²=−normSq(y)·e₀ for pure imaginary y), phi_imag_props (φ maps Im(𝕆) to Im(𝕆) with norm preservation), alg_aut_preserves_norm (φ preserves all norms), real_part_preserved (Re(φ(x))=Re(x)), alg_aut_preserves_inner (φ preserves the inner product). These show Aut(𝕆) ⊆ O(7).",
-      "mathContext": "The key chain: (1) φ(e₀)=e₀ by left-identity uniqueness; (2) for y with y[0]=0: y²=−|y|²e₀ (direct computation); (3) φ(y)²=−|y|²e₀ (applying φ and using (1)); (4) |φ(y)|²=|y|² from component 0; (5) φ(y)[0]=0 from 2·(φ(y)[0])²=0; (6) norm preservation for all x by decomposition x=r·e₀+w; (7) inner product preservation by polarization |φ(x)+φ(y)|²=|x+y|²."
+      "endLine": 291,
+      "summary": "Private helper lemmas and the core norm result: phi_unit_eq_unit (φ(e₀)=e₀ by surjectivity argument), imag_sq_eq_neg_norm (y²=−‖y‖²e₀ for pure imaginary y), phi_imag_props (φ maps Im(𝕆) to Im(𝕆) isometrically), alg_aut_preserves_norm (φ preserves all norms via real-imaginary decomposition).",
+      "mathContext": "Proof chain: $\\varphi(e_0)=e_0$ (left-identity uniqueness) → $\\varphi(y)^2 = -\\|y\\|^2 e_0$ for $y_0=0$ → $\\|\\varphi(y)\\| = \\|y\\|$ and $\\varphi(y)_0=0$ → $\\|\\varphi(a)\\| = \\|a\\|$ for all $a$ (decompose $a = r e_0 + w$, use orthogonality)."
+    },
+    {
+      "id": "real-part-inner-product",
+      "title": "§III-b: Real Part, Conjugation, and Aut(𝕆) ⊆ O(7)",
+      "startLine": 292,
+      "endLine": 358,
+      "summary": "Defines realPart, imagPart, octConj. Proves real_part_preserved (Re(φ(x))=Re(x)) and alg_aut_preserves_inner (φ preserves the inner product by polarization). Together: Aut(𝕆) fixes e₀, maps Im(𝕆)=ℝ⁷ to itself, and acts isometrically — so Aut(𝕆) ⊆ O(7).",
+      "mathContext": "Polarization: $\\langle \\varphi(x), \\varphi(y) \\rangle = \\frac{1}{2}(\\|\\varphi(x+y)\\|^2 - \\|\\varphi(x)\\|^2 - \\|\\varphi(y)\\|^2) = \\langle x, y \\rangle$. Combined with $\\mathrm{Re}(\\varphi(x))=\\mathrm{Re}(x)$ (real part invariance), we get $\\mathrm{Aut}(\\mathbb{O}) \\subseteq \\mathrm{O}(7)$."
     },
     {
       "id": "exceptional-lie-algebras",
-      "title": "§IV-VI: G₂ and the Exceptional Lie Algebras",
+      "title": "§IV-VI: G₂, Magic Square, and Structural Consequences",
       "startLine": 359,
       "endLine": 583,
-      "summary": "Introduces ExceptionalType inductive type for G₂,F₄,E₆,E₇,E₈ with dimensions (14,52,78,133,248) and ranks (2,4,6,7,8). Axiomatizes G2_is_octonion_aut (G₂=Aut(𝕆)) and the four Freudenthal-Tits magic square exceptional types. Proves exceptional_dims_strict_mono, G2_unique_low_rank, E8_is_largest, magic_square_corners_distinct, exceptional_chain by decidability.",
+      "summary": "Introduces ExceptionalType inductive type for G₂,F₄,E₆,E₇,E₈ with dimensions (14,52,78,133,248) and ranks (2,4,6,7,8). Axiomatizes G2_is_octonion_aut (G₂=Aut(𝕆)) and freudenthal_tits_f4/e6/e7/e8. Proves exceptional_dims_strict_mono, G2_unique_low_rank, E8_is_largest, magic_square_corners_distinct, exceptional_chain by decidability. Closes with the Hurwitz-exceptional correspondence explaining why exactly 5 exceptional types exist.",
       "mathContext": "G₂ has dimension 14 = dim(SO(7)) − 7 = 21 − 7 (Aut(𝕆) acts on Im(𝕆)≅ℝ⁷ and is constrained by the cross-product structure). The Freudenthal-Tits magic square: 𝔏(A,B) = Der(A) ⊕ (ImA⊗ImB) ⊕ Der(B). Corners: 𝔏(𝕆,ℝ)=F₄(52), 𝔏(𝕆,ℂ)=E₆(78), 𝔏(𝕆,ℍ)=E₇(133), 𝔏(𝕆,𝕆)=E₈(248)."
     }
   ],


### PR DESCRIPTION
Second enrichment pass for `hurwitz-theorem-oq-04`.

## Changes

- **Added 2 new sections** to `meta.json` (was 3, now 5):
  - **Preamble** (lines 1-63): Module documentation context, references (Baez, Freudenthal, Tits), contents table
  - **§III-b** (lines 292-358): Split from §III — real part, conjugation, polarization, Aut(𝕆) ⊆ O(7) conclusion
  - §III now renamed **§III-a** (lines 166-291): The norm-preservation core (phi_unit_eq_unit, phi_imag_props, alg_aut_preserves_norm)

## Quality Impact

Before: quality 96 (sections: 6/10 — only 3 sections)
After: quality 100 (sections: 10/10 — 5 sections covering all 583 lines)

All 5 sections include `mathContext` with LaTeX formulas.