### PR TITLE
Research: Vosper hpos proof (erdos-476-oq-05 Session 20) + hook_walk_identity_gHookYD (Session 19)

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean
@@ -5056,6 +5056,130 @@ private lemma hookProd_ratio_formula {μ : YoungDiagram} {c : ℕ × ℕ} (hc : 
   linear_combination key_Q
 
 
+-- ============================================================
+-- Hook walk identity for generalized hook shapes [a, 1^b] (PART XIVb)
+-- ============================================================
+
+/-- Any corner of gHookYD a b ha (with b ≥ 1) is either (0, a-1) with a ≥ 2, or (b, 0).
+    Proof: corners must be at row ends; row 0 ends at a-1, column 0 ends at b.
+    When a=1: (0,0) has leg neighbor (1,0), so only (b,0) is a corner. -/
+private lemma corners_gHookYD_cases (a b : ℕ) (ha : 0 < a) (hb : 0 < b) {c : ℕ × ℕ}
+    (hc : isCorner (gHookYD a b ha) c) :
+    (c = (0, a - 1) ∧ 1 < a) ∨ c = (b, 0) := by
+  obtain ⟨i, j⟩ := c
+  obtain ⟨hmem, hright, hbelow⟩ := hc
+  rcases mem_gHookYD.mp hmem with ⟨hi0, hj⟩ | ⟨hi1, hi2, hj0⟩
+  · -- (i, j) with i = 0, j < a
+    subst hi0
+    -- hright: (0, j+1) ∉ μ → j+1 ≥ a → j = a-1
+    have hja : j = a - 1 := by
+      have : ¬(j + 1 < a) := fun hlt =>
+        hright (mem_gHookYD.mpr (Or.inl ⟨rfl, hlt⟩))
+      omega
+    subst hja
+    left
+    refine ⟨rfl, ?_⟩
+    -- hbelow: (1, a-1) ∉ μ; but if a=1 then (1,0) ∈ μ (since b≥1), contradiction
+    by_contra hle
+    push_neg at hle
+    have ha1 : a = 1 := Nat.le_antisymm hle ha
+    subst ha1
+    -- a-1 = 0, so (0, 0) ∈ μ and (1, 0) ∈ μ (since b ≥ 1)
+    exact hbelow (mem_gHookYD.mpr (Or.inr ⟨Nat.one_pos, hb, rfl⟩))
+  · -- (i, j) with 1 ≤ i ≤ b, j = 0
+    subst hj0
+    right
+    -- hbelow: (i+1, 0) ∉ μ → i+1 > b → i = b
+    have hib : i = b := by
+      have : ¬(i + 1 ≤ b) := fun hle =>
+        hbelow (mem_gHookYD.mpr (Or.inr ⟨by omega, hle, rfl⟩))
+      omega
+    exact ⟨hib, rfl⟩
+
+/-- The hook walk identity for generalized hook shapes [a, 1^b] with b ≥ 1.
+    Non-circular proof: hook_length_formula_gHookYD is proved independently,
+    and removing a corner of gHookYD a b gives another gHookYD shape.
+    Extends hook_walk_identity_atMostTwoRows to cover ≥3-row hook shapes. -/
+private lemma hook_walk_identity_gHookYD (a b : ℕ) (ha : 0 < a) (hb : 0 < b) :
+    ∑ c ∈ (corners (gHookYD a b ha)).attach,
+      ((hookProd (gHookYD a b ha) : ℚ) /
+       (hookProd (removeCorner (gHookYD a b ha) c.val
+         (mem_corners.mp c.prop)) : ℚ))
+    = ((gHookYD a b ha).card : ℚ) := by
+  have hHP : (hookProd (gHookYD a b ha) : ℚ) ≠ 0 := hookProdQ_ne_zero _
+  have hN : (gHookYD a b ha).card = a + b := gHookYD_card a b ha
+  have hpos : 0 < (gHookYD a b ha).card := by rw [hN]; omega
+  have hfact : (((gHookYD a b ha).card - 1).factorial : ℚ) ≠ 0 :=
+    Nat.cast_ne_zero.mpr (Nat.factorial_pos _).ne'
+  -- HLF for μ (proved independently, without hook_walk_identity)
+  have hμ : (Fintype.card (StandardYoungTableau (gHookYD a b ha)) : ℚ) *
+      hookProd (gHookYD a b ha) = (gHookYD a b ha).card.factorial :=
+    by exact_mod_cast hook_length_formula_gHookYD a b ha
+  -- Corner step: card(SYT(μ)) = Σ_c card(SYT(μ\c))
+  have hstepQ : (Fintype.card (StandardYoungTableau (gHookYD a b ha)) : ℚ) =
+      ∑ cx ∈ (corners (gHookYD a b ha)).attach,
+        (Fintype.card (StandardYoungTableau
+          (removeCorner (gHookYD a b ha) cx.val (mem_corners.mp cx.prop))) : ℚ) :=
+    by exact_mod_cast card_SYT_corner_step (gHookYD a b ha) hpos
+  -- HLF for each removeCorner: a corner removal gives another gHookYD shape
+  have hμc : ∀ cx : { x // x ∈ corners (gHookYD a b ha) },
+      (Fintype.card (StandardYoungTableau
+        (removeCorner (gHookYD a b ha) cx.val (mem_corners.mp cx.prop))) : ℚ) *
+      (hookProd (removeCorner (gHookYD a b ha) cx.val (mem_corners.mp cx.prop)) : ℚ) =
+      (((gHookYD a b ha).card - 1).factorial : ℚ) := by
+    intro ⟨c, hcx⟩
+    have hcorner : isCorner (gHookYD a b ha) c := mem_corners.mp hcx
+    rcases corners_gHookYD_cases a b ha hb hcorner with ⟨hceq, ha2⟩ | hceq
+    · -- c = (0, a-1): removeCorner = gHookYD (a-1) b h'
+      subst hceq
+      rw [removeCorner_gHook_top a b ha ha2 hcorner]
+      have hlf : Fintype.card (StandardYoungTableau (gHookYD (a - 1) b (by omega))) *
+          hookProd (gHookYD (a - 1) b (by omega)) =
+          (gHookYD (a - 1) b (by omega)).card.factorial :=
+        hook_length_formula_gHookYD (a - 1) b (by omega)
+      rw [gHookYD_card] at hlf
+      have hfact_eq : a - 1 + b = (gHookYD a b ha).card - 1 := by rw [hN]; omega
+      rw [hfact_eq] at hlf
+      exact_mod_cast hlf
+    · -- c = (b, 0): removeCorner = gHookYD a (b-1) ha
+      subst hceq
+      rw [removeCorner_gHook_bot a b ha hb hcorner]
+      have hlf : Fintype.card (StandardYoungTableau (gHookYD a (b - 1) ha)) *
+          hookProd (gHookYD a (b - 1) ha) =
+          (gHookYD a (b - 1) ha).card.factorial :=
+        hook_length_formula_gHookYD a (b - 1) ha
+      rw [gHookYD_card] at hlf
+      have hfact_eq : a + (b - 1) = (gHookYD a b ha).card - 1 := by rw [hN]; omega
+      rw [hfact_eq] at hlf
+      exact_mod_cast hlf
+  -- μ.card! = μ.card × (μ.card-1)! as rationals
+  have hfact_succ : ((gHookYD a b ha).card.factorial : ℚ) =
+      ((gHookYD a b ha).card : ℚ) * (((gHookYD a b ha).card - 1).factorial : ℚ) := by
+    cases hcard : (gHookYD a b ha).card with
+    | zero => rw [hN] at hcard; omega
+    | succ n =>
+      rw [show (gHookYD a b ha).card - 1 = n by omega,
+          show (gHookYD a b ha).card = n + 1 from hcard, Nat.factorial_succ]
+      push_cast; ring
+  -- Each summand: HP/HPc = card(SYT(μ\c)) × HP/(N-1)!
+  have hterm : ∀ cx : { x // x ∈ corners (gHookYD a b ha) },
+      (hookProd (gHookYD a b ha) : ℚ) /
+      (hookProd (removeCorner (gHookYD a b ha) cx.val (mem_corners.mp cx.prop)) : ℚ) =
+      (Fintype.card (StandardYoungTableau
+        (removeCorner (gHookYD a b ha) cx.val (mem_corners.mp cx.prop))) : ℚ) *
+      ((hookProd (gHookYD a b ha) : ℚ) / (((gHookYD a b ha).card - 1).factorial : ℚ)) := by
+    intro ⟨c, hcx⟩
+    have hHPc :
+        (hookProd (removeCorner (gHookYD a b ha) c (mem_corners.mp hcx)) : ℚ) ≠ 0 :=
+      hookProdQ_ne_zero _
+    have hIHc := hμc ⟨c, hcx⟩
+    rw [mul_div_assoc, div_eq_div_iff hHPc hfact]
+    linear_combination -(hookProd (gHookYD a b ha) : ℚ) * hIHc
+  -- Assemble: same algebra as hook_walk_identity_atMostTwoRows
+  simp_rw [hterm]
+  rw [← Finset.sum_mul, ← hstepQ, mul_div_assoc, hμ, hfact_succ]
+  field_simp [hfact]
+
 private lemma hook_walk_identity (μ : YoungDiagram) (hn : 0 < μ.card) :
     ∑ c ∈ (corners μ).attach,
       ((hookProd μ : ℚ) / (hookProd (removeCorner μ c.val (mem_corners.mp c.prop)) : ℚ))
@@ -5063,8 +5187,12 @@ private lemma hook_walk_identity (μ : YoungDiagram) (hn : 0 < μ.card) :
   by_cases h2 : μ.rowLen 2 = 0
   · -- At-most-2-row case: proved non-circularly
     exact hook_walk_identity_atMostTwoRows μ h2 hn
-  · -- ≥3-row case: requires hook walk combinatorics (GNW ~300 lines or RSK ~500 lines)
-    sorry
+  · -- ≥3-row: check if μ is a generalized hook shape [a, 1^b]
+    by_cases hghook : ∃ (a b : ℕ) (ha : 0 < a) (hb : 0 < b), μ = gHookYD a b ha
+    · obtain ⟨a, b, ha, hb, rfl⟩ := hghook
+      exact hook_walk_identity_gHookYD a b ha hb
+    · -- General ≥3-row, non-gHookYD case: requires GNW hook walk (~300 lines)
+      sorry
 
 /-- The general hook-length formula in ℚ, proved by well-founded recursion on μ.card.
     Uses card_SYT_corner_step (Part XIII) + hook_walk_identity. -/

--- a/proofs/Proofs/Erdos476OQ05Problem.lean
+++ b/proofs/Proofs/Erdos476OQ05Problem.lean
@@ -3,8 +3,8 @@ Erdős Problem #476, Open Question 5: Vosper's Theorem (1956)
 
 Source: Follow-up to erdos-476 (Erdős-Heilbronn conjecture)
 Status: PARTIAL — ap_of_near_periodic proved (orbit-cardinality argument);
-                   vosper_base proved; vosper_ap_sdiff_card structured (hpos sorry);
-                   isAP_sdiff_card proved; vosper_case1_exists sorryed
+                   vosper_base proved; vosper_ap_sdiff_card proved (hpos proved, Session 20);
+                   isAP_sdiff_card proved; vosper_case1_exists sorryed [1 sorry remains]
 
 Statement (Vosper 1956):
 Let p be prime, A, B ⊆ Z/pZ with |A|, |B| ≥ 2.
@@ -245,7 +245,174 @@ private lemma vosper_ap_sdiff_card
     omega
   -- Position analysis: a₀ is a₁-d (predecessor) or a₁+|A'|*d (successor)
   have hpos : a₀ = a₁ - d ∨ a₀ = a₁ + ((A.erase a₀).card : ZMod p) * d := by
-    sorry -- HARD: position analysis from |{a₀}+B \ (A'+B)| = 1, both APs with diff d
+    -- Unfold AP definitions to use index-set representation
+    unfold IsArithmeticProgression at hAP_a₀B hAP_A'B
+    rw [hcard_a₀B] at hAP_a₀B
+    -- Bounds needed for injectivity of nat-cast
+    have hBlt : B.card < p := by omega
+    have hn₂lt : (A.erase a₀).card + B.card - 1 < p := by rw [hA'card]; omega
+    -- The AP₁ map i ↦ a₀+b₀+i*d is injective on range(B.card)
+    have hAP₁_inj : ∀ i j : ℕ, i < B.card → j < B.card →
+        a₀ + b₀ + (i : ZMod p) * d = a₀ + b₀ + (j : ZMod p) * d → i = j := by
+      intro i j hi hj heq
+      have h1 : (i : ZMod p) = (j : ZMod p) := mul_right_cancel₀ hd (add_left_cancel heq)
+      have h2 := congrArg ZMod.val h1
+      simp only [ZMod.val_natCast, Nat.mod_eq_of_lt (Nat.lt_trans hi hBlt),
+                 Nat.mod_eq_of_lt (Nat.lt_trans hj hBlt)] at h2
+      omega
+    -- The AP₂ map j ↦ a₁+b₀+j*d is injective on range(n₂)
+    have hAP₂_inj : ∀ i j : ℕ, i < (A.erase a₀).card + B.card - 1 →
+        j < (A.erase a₀).card + B.card - 1 →
+        a₁ + b₀ + (i : ZMod p) * d = a₁ + b₀ + (j : ZMod p) * d → i = j := by
+      intro i j hi hj heq
+      have h1 : (i : ZMod p) = (j : ZMod p) := mul_right_cancel₀ hd (add_left_cancel heq)
+      have h2 := congrArg ZMod.val h1
+      simp only [ZMod.val_natCast, Nat.mod_eq_of_lt (Nat.lt_trans hi hn₂lt),
+                 Nat.mod_eq_of_lt (Nat.lt_trans hj hn₂lt)] at h2
+      omega
+    -- Extract the unique missing element y
+    obtain ⟨y, hy⟩ := Finset.card_eq_one.mp h_sdiff_one
+    have hy_AP₁ : y ∈ ({a₀} + B : Finset _) :=
+      Finset.mem_of_mem_sdiff (hy ▸ Finset.mem_singleton_self y)
+    have hy_notAP₂ : y ∉ (A.erase a₀) + B :=
+      (Finset.mem_sdiff.mp (hy ▸ Finset.mem_singleton_self y)).2
+    -- All other elements of AP₁ are in AP₂
+    have hothers : ∀ z ∈ ({a₀} + B : Finset _), z ≠ y → z ∈ (A.erase a₀) + B := by
+      intro z hz hne
+      by_contra hznot
+      exact hne (Finset.mem_singleton.mp (hy ▸ Finset.mem_sdiff.mpr ⟨hz, hznot⟩))
+    -- y = a₀+b₀+m*d for some m < B.card
+    rw [hAP_a₀B] at hy_AP₁
+    obtain ⟨m, hm_range, hm_eq⟩ := Finset.mem_image.mp hy_AP₁
+    rw [Finset.mem_range] at hm_range
+    -- Helper: AP₂ membership gives explicit index
+    have inAP₂ : ∀ z ∈ (A.erase a₀) + B, ∃ j < (A.erase a₀).card + B.card - 1,
+        z = a₁ + b₀ + (j : ZMod p) * d := by
+      intro z hz
+      rw [hAP_A'B] at hz
+      obtain ⟨j, hj, hje⟩ := Finset.mem_image.mp hz
+      exact ⟨j, Finset.mem_range.mp hj, hje.symm⟩
+    -- Helper: y ∉ AP₂ means a₁+b₀+j*d ≠ a₀+b₀+m*d for all j < n₂
+    have hy_notAP₂_idx : ∀ j < (A.erase a₀).card + B.card - 1,
+        a₁ + b₀ + (j : ZMod p) * d ≠ y := by
+      intro j hj heq
+      exact hy_notAP₂ (by rw [hAP_A'B]; exact Finset.mem_image.mpr ⟨j, Finset.mem_range.mpr hj, heq.symm⟩)
+    -- Case split: m = 0, m = B.card-1, or interior
+    rcases Nat.lt_or_eq_of_le (Nat.zero_le m) with hm_pos | rfl
+    · -- m ≥ 1 case
+      rcases Nat.lt_or_eq_of_le (Nat.lt_succ_iff.mp hm_range) with hm_int | rfl
+      · -- 0 < m < B.card-1: INTERIOR CASE → contradiction
+        -- (proof: both (m-1) and (m+1) are non-missing indices, giving j=n₂-1 and k=0,
+        --  then linear combination yields (|A'|+|B|)*d = 0, contradicting n₂+1 < p and d≠0)
+        exfalso
+        -- index m-1 not missing → a₀+b₀+(m-1)*d ∈ AP₂ at some j with j = n₂-1
+        have hpred_ne : a₀ + b₀ + ((m - 1 : ℕ) : ZMod p) * d ≠ y := by
+          intro heq
+          exact absurd (hAP₁_inj _ _ (by omega) hm_range heq.symm) (by omega)
+        have hpred_AP₁ : a₀ + b₀ + ((m - 1 : ℕ) : ZMod p) * d ∈ ({a₀} + B : Finset _) := by
+          rw [hAP_a₀B]; exact Finset.mem_image.mpr ⟨m - 1, Finset.mem_range.mpr (by omega), rfl⟩
+        obtain ⟨j, hj_lt, hj_eq⟩ := inAP₂ _ (hothers _ hpred_AP₁ hpred_ne)
+        -- j must be n₂-1 (otherwise a₀+b₀+m*d would be in AP₂ via index j+1)
+        have hj_max : j = (A.erase a₀).card + B.card - 2 := by
+          by_contra hj_ne
+          have hj_lt' : j + 1 < (A.erase a₀).card + B.card - 1 := by omega
+          have hym_eq : a₁ + b₀ + ((j + 1 : ℕ) : ZMod p) * d = y := by
+            rw [← hm_eq]
+            have hcast : ((j + 1 : ℕ) : ZMod p) = (j : ZMod p) + 1 := by push_cast; ring
+            have hm_cast : (m : ZMod p) = ((m - 1 : ℕ) : ZMod p) + 1 := by
+              push_cast [Nat.sub_add_cancel hm_pos]; ring
+            linear_combination hj_eq + hm_cast * d - hcast * d
+          exact hy_notAP₂_idx _ hj_lt' hym_eq
+        -- index m+1 not missing → a₀+b₀+(m+1)*d ∈ AP₂ at some k with k = 0
+        have hsucc_ne : a₀ + b₀ + ((m + 1 : ℕ) : ZMod p) * d ≠ y := by
+          intro heq
+          exact absurd (hAP₁_inj _ _ (by omega) hm_range heq.symm) (by omega)
+        have hsucc_AP₁ : a₀ + b₀ + ((m + 1 : ℕ) : ZMod p) * d ∈ ({a₀} + B : Finset _) := by
+          rw [hAP_a₀B]; exact Finset.mem_image.mpr ⟨m + 1, Finset.mem_range.mpr (by omega), by push_cast; ring⟩
+        obtain ⟨k, hk_lt, hk_eq⟩ := inAP₂ _ (hothers _ hsucc_AP₁ hsucc_ne)
+        -- k must be 0 (otherwise a₀+b₀+m*d would be in AP₂ via index k-1)
+        have hk_zero : k = 0 := by
+          by_contra hk_ne
+          have hym_eq2 : a₁ + b₀ + ((k - 1 : ℕ) : ZMod p) * d = y := by
+            rw [← hm_eq]
+            have hcast : ((k - 1 : ℕ) : ZMod p) = (k : ZMod p) - 1 := by
+              push_cast [Nat.sub_add_cancel (Nat.pos_of_ne_zero hk_ne)]; ring
+            have hm_cast : (m : ZMod p) = ((m + 1 : ℕ) : ZMod p) - 1 := by push_cast; ring
+            linear_combination hk_eq + hm_cast * d - hcast * d
+          exact hy_notAP₂_idx _ (by omega) hym_eq2
+        -- From j = n₂-1 and k = 0: derive (|A'|+|B|)*d = 0
+        rw [hj_max] at hj_eq; rw [hk_zero] at hk_eq
+        -- hj_eq : a₁+b₀+((n₂-1):ZMod p)*d = a₀+b₀+((m-1):ℕ)*d
+        -- hk_eq : a₁+b₀+(0:ZMod p)*d = a₀+b₀+((m+1):ℕ)*d
+        have hderiv : ((A.erase a₀).card + B.card : ZMod p) * d = 0 := by
+          have hcast_n₂ : ((A.erase a₀).card + B.card - 2 : ℕ) + 2 = (A.erase a₀).card + B.card := by
+            rw [hA'card]; omega
+          have : ((A.erase a₀).card + B.card - 2 + 2 : ℕ) = (A.erase a₀).card + B.card := hcast_n₂
+          have hcast_sum : ((A.erase a₀).card + B.card : ZMod p) =
+              ((A.erase a₀).card + B.card - 2 : ℕ) + (2 : ZMod p) := by
+            push_cast [← hcast_n₂]; ring
+          rw [hcast_sum]
+          linear_combination hj_eq - hk_eq
+        -- (|A'|+|B|)*d = 0 with d≠0 implies p ∣ (|A'|+|B|), but |A'|+|B| < p
+        have hlt' : (A.erase a₀).card + B.card < p := by rw [hA'card]; omega
+        have hne : ((A.erase a₀).card + B.card : ZMod p) ≠ 0 := by
+          rw [ZMod.natCast_zmod_eq_zero_iff_dvd]
+          intro hdvd
+          have := Nat.le_of_dvd (by omega) hdvd
+          omega
+        exact hne (mul_right_cancel₀ hd (by rw [hderiv, zero_mul]))
+      · -- m = B.card-1: LAST ELEMENT missing → a₀ = a₁+|A'|*d
+        right
+        -- index m-1 = B.card-2 not missing (since m = B.card-1 and B.card ≥ 2)
+        have hpred_ne : a₀ + b₀ + ((B.card - 2 : ℕ) : ZMod p) * d ≠ y := by
+          intro heq
+          exact absurd (hAP₁_inj _ _ (by omega) hm_range heq.symm) (by omega)
+        have hpred_AP₁ : a₀ + b₀ + ((B.card - 2 : ℕ) : ZMod p) * d ∈ ({a₀} + B : Finset _) := by
+          rw [hAP_a₀B]
+          exact Finset.mem_image.mpr ⟨B.card - 2, Finset.mem_range.mpr (by omega), rfl⟩
+        obtain ⟨j, hj_lt, hj_eq⟩ := inAP₂ _ (hothers _ hpred_AP₁ hpred_ne)
+        -- j = n₂-1 (otherwise a₀+b₀+(B.card-1)*d = y would be in AP₂ via index j+1)
+        have hj_max : j = (A.erase a₀).card + B.card - 2 := by
+          by_contra hj_ne
+          have hj_lt' : j + 1 < (A.erase a₀).card + B.card - 1 := by omega
+          have hym_eq : a₁ + b₀ + ((j + 1 : ℕ) : ZMod p) * d = y := by
+            rw [← hm_eq]
+            have hcast_j : ((j + 1 : ℕ) : ZMod p) = (j : ZMod p) + 1 := by push_cast; ring
+            have hcast_m : (B.card - 1 : ZMod p) = ((B.card - 2 : ℕ) : ZMod p) + 1 := by
+              push_cast [Nat.sub_add_cancel (by omega : 2 ≤ B.card)]; ring
+            linear_combination hj_eq + hcast_m * d - hcast_j * d
+          exact hy_notAP₂_idx _ hj_lt' hym_eq
+        -- From hj_eq with j = n₂-1: a₀+b₀+(B.card-2)*d = a₁+b₀+(|A'|+|B|-2)*d
+        rw [hj_max] at hj_eq
+        -- Conclusion: a₀ = a₁+|A'|*d
+        have hcast_n : (A.erase a₀).card + B.card - 2 = (A.erase a₀).card + (B.card - 2) := by omega
+        linear_combination hj_eq
+    · -- m = 0: FIRST ELEMENT missing → a₀ = a₁-d
+      left
+      -- index 1 is not missing (B.card ≥ 2)
+      have h1_ne : a₀ + b₀ + (1 : ZMod p) * d ≠ y := by
+        rw [← hm_eq]
+        simp only [Nat.cast_zero, zero_mul, add_zero, one_mul]
+        intro h; exact hd (add_left_cancel h)
+      have h1_AP₁ : a₀ + b₀ + (1 : ZMod p) * d ∈ ({a₀} + B : Finset _) := by
+        rw [hAP_a₀B]
+        exact Finset.mem_image.mpr ⟨1, Finset.mem_range.mpr (by omega), by push_cast; ring⟩
+      obtain ⟨j, hj_lt, hj_eq⟩ := inAP₂ _ (hothers _ h1_AP₁ h1_ne)
+      rcases Nat.eq_zero_or_pos j with rfl | hj_pos
+      · -- j = 0: a₁+b₀ = a₀+b₀+d → a₀ = a₁-d
+        simp only [Nat.cast_zero, zero_mul, add_zero] at hj_eq
+        linear_combination -hj_eq
+      · -- j ≥ 1: a₁+b₀+(j-1)*d = a₀+b₀ ∈ AP₂, contradicting a₀+b₀ ∉ AP₂
+        exfalso
+        -- a₀+b₀ = y (since m = 0, y = a₀+b₀+0*d = a₀+b₀)
+        have hy_val : y = a₀ + b₀ := by rw [← hm_eq]; simp
+        -- a₁+b₀+(j-1)*d = a₀+b₀ = y
+        have hpred_eq_y : a₁ + b₀ + ((j - 1 : ℕ) : ZMod p) * d = y := by
+          rw [hy_val]
+          have hcast_j : ((j - 1 : ℕ) : ZMod p) = (j : ZMod p) - 1 := by
+            push_cast [Nat.sub_add_cancel hj_pos]; ring
+          linear_combination hj_eq - hcast_j * d
+        exact hy_notAP₂_idx _ (by omega) hpred_eq_y
   -- In each case A is an AP with diff d, so |A \ A.image(·+d)| = 1 by isAP_sdiff_card
   rcases hpos with ha₀_pred | ha₀_succ
   · -- Case: a₀ = a₁ - d (predecessor of AP A'); A = AP(a₀, d, |A|)

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/knowledge.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/knowledge.md
@@ -407,3 +407,50 @@ The sorry count increased by 1 (net) because:
    to HLF itself (circular without external proof). The `hookProd_ratio_formula` now provides the
    ratio factorization needed as input. The 2-row case is already proved in `hook_walk_identity_atMostTwoRows`.
 2. **Archive sessions**: knowledge.md is >500 lines; archive sessions 5-17 to sessions/ subdir.
+
+---
+
+## Session 2026-04-24 (Session 19) — Hook Walk Identity for Generalized Hook Shapes
+
+**Mode**: REVISIT (RICH knowledge tier, score 106)
+**Outcome**: PROGRESS — `hook_walk_identity_gHookYD` proved; sorry scope reduced
+
+### What I Did
+
+1. Identified the non-circular proof path: `hook_length_formula_gHookYD` (proved independently in
+   Session 14 via combinatorial formula) enables proving `hook_walk_identity_gHookYD` without
+   circularity — the same algebraic pattern as `hook_walk_identity_atMostTwoRows`.
+2. Added `corners_gHookYD_cases` (~40 lines): characterizes all corners of `gHookYD a b ha`
+   (with b ≥ 1) as either `(0, a-1)` with `a ≥ 2` (top-right), or `(b, 0)` (bottom-left).
+3. Added `hook_walk_identity_gHookYD` (~90 lines): non-circular proof of hook walk identity for
+   all `[a, 1^b]` shapes. Algebraic strategy mirrors `hook_walk_identity_atMostTwoRows`.
+4. Updated `hook_walk_identity` dispatcher: sorry now covers only ≥3-row non-gHookYD shapes.
+5. PR: rjwalters/lean-genius#12381
+
+### Key Findings
+
+- **Non-circular path via gHookYD**: `hook_length_formula_gHookYD` (session 14) is the independent
+  HLF source — no circularity with `hook_walk_identity`.
+- **a = 1 edge case**: When `a = 1`, `(0, 0)` has `(1, 0) ∈ gHookYD` (b ≥ 1), so NOT a top-right corner.
+- **Remaining sorry scope**: ≥3-row shapes that are NOT [a,1^b] — e.g., [3,2,1], [4,3,2] — require GNW.
+
+### Files Modified
+
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean` (5146 → 5274 lines, PART XIVb added)
+- `research/problems/ballot-problem-oq-03-oq-01-oq-02/knowledge.md` (this file)
+- `src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json` (knowledge updated)
+- `src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json` (lineCount 5274)
+- PR: rjwalters/lean-genius#12381
+
+### Sorry Count: 4 (unchanged count, reduced scope)
+
+- `hook_walk_identity` (PART XIV): sorry now covers only ≥3-row non-gHookYD shapes
+- `ni_count_eq_syt_count` (line 219): RSK bijection, FALSE as stated
+- `lgv_det_factors_as_hook_quotient` (line 235): det identity, FALSE as stated
+- `hook_length_formula` (line 245): depends on the two above (FALSE as stated)
+
+### Next Steps
+
+1. **GNW hook walk for ≥3-row non-gHookYD shapes**: ~200-300 Lean lines (probabilistic proof).
+2. **Simpler stepping stone**: prove `hook_walk_identity` for shapes with exactly 3 rows.
+3. **Archive sessions**: knowledge.md now >600 lines; archive sessions 5-18 to sessions/ subdir.

--- a/research/problems/erdos-476-oq-05/knowledge.md
+++ b/research/problems/erdos-476-oq-05/knowledge.md
@@ -133,3 +133,35 @@ Key Mathlib lemma available: `Finset.card_eq_sum_card_fiberwise` (BigOperators/G
 1. Check Aristotle results for project a5594e66 in next session
 2. If Aristotle succeeds: integrate solution into main file
 3. If Aristotle fails: implement the |A|=|B|=3 counting argument (provable via card_eq_sum_card_fiberwise) and leave |A|≥3,|B|≥4 and |A|≥4,|B|≥3 for future sessions
+
+## Session 2026-04-24 (Session 20) — Prove hpos in vosper_ap_sdiff_card
+
+**Mode**: REVISIT (continuing from Session 4)
+**Outcome**: Progress — hpos proved, 1→1 sorry (only case1_exists remains)
+
+### What I Did
+- Proved `hpos` sorry inside `vosper_ap_sdiff_card` (line 248 → replaced with ~170 lines of proof)
+- hpos states: `a₀ = a₁ - d ∨ a₀ = a₁ + |A'| * d` — the unique missing element is at an endpoint
+- Committed as Session 20 to feature/researcher-6, PR #12392
+
+### Key Mathematical Argument
+
+**Three-way case split on missing index m ∈ {0,...,|B|-1}:**
+
+1. **Interior (0 < m < |B|-1):** Get AP₂ indices from (m-1) and (m+1) not missing; `linear_combination` gives `(|A'|+|B|)·d = 0` in ZMod p. But `|A'|+|B| = A.card+B.card-1 < p` via `hlt`, so `ZMod.natCast_zmod_eq_zero_iff_dvd` + `Nat.le_of_dvd` gives contradiction.
+2. **First (m=0):** Index 0 in AP₂ gives j=0 not missing, `linear_combination -hj_eq` shows `a₀ = a₁ - d`.
+3. **Last (m=|B|-1):** Index n₂-1 in AP₂ gives j=n₂-1 not missing, `linear_combination hj_eq` shows `a₀ = a₁ + |A'|·d`.
+
+**Key tools:** `ZMod.val_natCast`, `Nat.mod_eq_of_lt` (for injectivity), `ZMod.natCast_zmod_eq_zero_iff_dvd`, `Nat.le_of_dvd`, `linear_combination`.
+
+### Files Modified
+- `proofs/Proofs/Erdos476OQ05Problem.lean`: hpos proved (583→750 lines, 2→1 sorry)
+
+### Current State
+- Main file: 1 sorry remaining (Case 1 existence, `vosper_case1_exists`, line 720)
+- Aristotle job still running: a5594e66-6409-47ed-89d8-eea7d709f12a
+
+### Next Steps
+1. Check Aristotle results for project a5594e66
+2. If Aristotle succeeds on case1_exists: integrate, then 0 sorries
+3. If Aristotle fails: attempt double-counting argument (|A|=|B|=3 case is provable)

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "ballot-problem-oq-03-oq-01-oq-02",
   "title": "Hook-Length Formula for Standard Young Tableaux via LGV",
   "slug": "ballot-problem-oq-03-oq-01-oq-02",
-  "description": "Formalizes the hook-length formula f^λ = n!/∏h(u) for Standard Young Tableaux. Fully proves the formula for single-row (1×n), single-column (n×1), hook-shape ((m+1,1)), 2-row rectangular (m×m), and general 2-row [a,b] families. General formula has 4 sorries: 3 via LGV approach (RSK bijection, det factorization, main theorem) + 1 for corner induction (hook_walk_identity ≥3-row case). hookProd_ratio_formula now proved (session 18). hook_length_formula_general proved via corner induction modulo hook_walk_identity.",
+  "description": "Formalizes the hook-length formula f^λ = n!/∏h(u) for Standard Young Tableaux. Fully proves the formula for single-row (1×n), single-column (n×1), hook-shape ((m+1,1)), 2-row rectangular (m×m), general 2-row [a,b], and all generalized hook shapes [a,1^b]. General formula has 4 sorries: 3 via LGV approach (RSK bijection, det factorization, main theorem) + 1 for corner induction (hook_walk_identity ≥3-row non-gHookYD case). hook_walk_identity_gHookYD proved (session 19); scope reduced to non-hook ≥3-row shapes.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-21",
@@ -22,9 +22,9 @@
     "sorries": 4,
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "assumptions": "Four open sorries: (1) hook_length_formula (LGV approach: requires SYT↔NI bijection + det factorization), (2) ni_count_eq_syt_count (Fomin/Viennot/RSK correspondence), (3) lgv_det_factors_as_hook_quotient (det factorization identity), (4) hook_walk_identity ≥3-row case (GNW or RSK, ~300 lines; at-most-2-row case proved; hookProd_ratio_formula now fully proved session 18). hook_length_formula_general is proved modulo hook_walk_identity via Part XIV corner induction.",
-    "lineCount": 5146,
-    "theoremCount": 162,
+    "assumptions": "Four open sorries: (1) hook_length_formula (LGV approach: requires SYT↔NI bijection + det factorization), (2) ni_count_eq_syt_count (Fomin/Viennot/RSK correspondence), (3) lgv_det_factors_as_hook_quotient (det factorization identity), (4) hook_walk_identity ≥3-row non-gHookYD case (GNW or RSK, ~300 lines; at-most-2-row and all [a,1^b] cases proved; hookProd_ratio_formula fully proved session 18, hook_walk_identity_gHookYD proved session 19). hook_length_formula_general is proved modulo hook_walk_identity via Part XIV corner induction.",
+    "lineCount": 5274,
+    "theoremCount": 164,
     "definitionCount": 14,
     "originalContributions": [
       "hookLength: hook length at cell (i,j) = armLen + legLen + 1 using YoungDiagram.rowLen and colLen",
@@ -44,7 +44,9 @@
       "hook_length_formula_gHookYD: HLF for all generalized hook shapes [a, 1^b] (card = C(a+b-1,b), proved via double induction + inline bijection, 0 sorries)",
       "hookProd_ratio_formula: hookProd(μ)/hookProd(μ\\c) equals product over arm × product over leg (1 sorry: ~50 lines Finset.prod_union decomposition)",
       "hook_walk_identity: sum over corners c of hookProd(μ)/hookProd(μ\\c) = μ.card — at-most-2-row case proved; ≥3-row case has 1 sorry (~300 lines GNW/RSK)",
-      "hook_length_formula_general: HLF for all Young diagrams via corner induction (proved modulo hook_walk_identity, 0 sorries in the theorem itself)"
+      "hook_length_formula_general: HLF for all Young diagrams via corner induction (proved modulo hook_walk_identity, 0 sorries in the theorem itself)",
+      "corners_gHookYD_cases: characterizes all corners of [a,1^b] as either (0,a-1) with a≥2 or (b,0) (proved, 0 sorries, session 19)",
+      "hook_walk_identity_gHookYD: hook walk identity Σ_c hookProd/hookProd(μ\\c)=|μ| proved for all [a,1^b] with b≥1, non-circular via hook_length_formula_gHookYD (session 19)"
     ]
   },
   "overview": {
@@ -87,7 +89,7 @@
       "LGV"
     ],
     "namespace": "HookLengthFormula",
-    "lineCount": 5146,
+    "lineCount": 5274,
     "axiomCount": 0,
     "sorries": 4,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
@@ -47,7 +47,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: hookProd_ratio_formula proved (session 18); 4 sorries remain (hook_walk_identity ≥3-row + 3 legacy)",
+    "progressSummary": "PROGRESS: hook_walk_identity_gHookYD proved (session 19); sorry scope reduced to ≥3-row non-gHookYD shapes; 4 sorries remain",
     "builtItems": [
       "instFintypeSYT: Fintype instance for StandardYoungTableau (BallotProblemOQ03OQ01OQ02.lean, Part IIIb)",
       "emptyTableau: unique SYT of shape bot (BallotProblemOQ03OQ01OQ02.lean, Part IIIc)",
@@ -98,7 +98,9 @@
       "removeCorner_atMostTwoRows (BallotProblemOQ03OQ01OQ02.lean:4639): removing corner from ≤2-row shape stays ≤2-row",
       "hook_walk_identity_atMostTwoRows (BallotProblemOQ03OQ01OQ02.lean:4659): hook walk identity proved for all ≤2-row shapes, non-circular",
       "hook_walk_identity (BallotProblemOQ03OQ01OQ02.lean:4714): case split — ≤2-row proved, ≥3-row sorry",
-      "hookProd_ratio_formula: proved 0-sorry in BallotProblemOQ03OQ01OQ02.lean session 18"
+      "hookProd_ratio_formula: proved 0-sorry in BallotProblemOQ03OQ01OQ02.lean session 18",
+      "corners_gHookYD_cases (BallotProblemOQ03OQ01OQ02.lean:~5058): characterizes corners of gHookYD a b ha (b≥1) as (0,a-1) with a≥2 OR (b,0)",
+      "hook_walk_identity_gHookYD (BallotProblemOQ03OQ01OQ02.lean:~5100): hook walk identity proved for all [a,1^b] shapes with b≥1, non-circular proof via hook_length_formula_gHookYD"
     ],
     "insights": [
       "lgv_lemma_rxr in BallotProblemOQ03OQ02.lean is the key building block (Gessel-Viennot involution proof)",
@@ -151,16 +153,20 @@
       "General (≥3-row) case still requires GNW probabilistic proof (~300 lines) or RSK (~500 lines) — not buildable in a single session",
       "hookProd_ratio_formula proved using ℕ-equality-then-cast strategy: key_nat avoids division, then linear_combination key_Q closes after prod_div_distrib",
       "Finset.prod_image injectivity: .2 for (i,s) image, .1 for (r,j) image; Prod.ext h.symm rfl proves (i,x.2)=x from x.1=i",
-      "disjoint_sdiff_self_right proves Disjoint s (t\\s) for restCells=ν.cells\\(arm∪leg)"
+      "disjoint_sdiff_self_right proves Disjoint s (t\\s) for restCells=ν.cells\\(arm∪leg)",
+      "hook_walk_identity_gHookYD is provable non-circularly because hook_length_formula_gHookYD was independently proved in session 14 via combinatorial formula C(a+b-1,b)",
+      "a=1 edge case in corners_gHookYD: (0,0) is NOT a top-right corner when a=1 because (1,0)∈gHookYD (b≥1) prevents it from being a corner",
+      "hook_walk_identity sorry scope: now covers only ≥3-row shapes that are NOT gHookYD — shapes like [3,2,1], [4,3,2], etc. require GNW probabilistic proof"
     ],
     "mathlibGaps": [
       "hookLength may not be defined in Mathlib.Combinatorics.YoungDiagram — check arm/leg availability",
       "StandardYoungTableau enumeration — check Mathlib.Combinatorics.YoungTableaux"
     ],
     "nextSteps": [
-      "Prove hook_walk_identity ≥3-row case: needs GNW probabilistic hook walk (~200-300 lines)",
-      "Archive sessions 5-17 to sessions/ subdir (knowledge.md >500 lines)",
-      "Fix ni_count_eq_syt_count statement (RSK bijection, FALSE as stated)"
+      "Prove hook_walk_identity for ≥3-row non-gHookYD shapes via GNW probabilistic hook walk (~200-300 lines)",
+      "Simpler stepping stone: prove hook_walk_identity for shapes with exactly 3 rows",
+      "Fix ni_count_eq_syt_count statement (RSK bijection, FALSE as stated — needs hypothesis relating μ to LGV config)",
+      "Archive sessions 5-18 to sessions/ subdir (knowledge.md >700 lines)"
     ]
   },
   "tags": [

--- a/src/data/research/problems/erdos-476-oq-05.json
+++ b/src/data/research/problems/erdos-476-oq-05.json
@@ -1,13 +1,13 @@
 {
   "slug": "erdos-476-oq-05",
-  "title": "Erd\u0151s #476: Structure of Cauchy-Davenport Extremal Sets (Vosper's Theorem)",
+  "title": "Erdős #476: Structure of Cauchy-Davenport Extremal Sets (Vosper's Theorem)",
   "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
   "problemStatement": {
-    "formal": "theorem vosper (p : \u2115) [hp : Fact (Nat.Prime p)] (A B : Finset (ZMod p)) (hA : 2 \u2264 A.card) (hB : 2 \u2264 B.card) (h : (A + B).card = A.card + B.card - 1) (hlt : A.card + B.card - 1 < p) : \u2203 (d : ZMod p) (a b : ZMod p), IsArithmeticProgression A a d \u2227 IsArithmeticProgression B b d",
-    "plain": "Vosper's theorem (1956): if equality holds in the Cauchy-Davenport bound |A+B| = |A|+|B|-1 for non-trivial A,B \u2286 Z/pZ, then A and B are arithmetic progressions with the same common difference d.",
+    "formal": "theorem vosper (p : ℕ) [hp : Fact (Nat.Prime p)] (A B : Finset (ZMod p)) (hA : 2 ≤ A.card) (hB : 2 ≤ B.card) (h : (A + B).card = A.card + B.card - 1) (hlt : A.card + B.card - 1 < p) : ∃ (d : ZMod p) (a b : ZMod p), IsArithmeticProgression A a d ∧ IsArithmeticProgression B b d",
+    "plain": "Vosper's theorem (1956): if equality holds in the Cauchy-Davenport bound |A+B| = |A|+|B|-1 for non-trivial A,B ⊆ Z/pZ, then A and B are arithmetic progressions with the same common difference d.",
     "whyMatters": [
       "Completes the Cauchy-Davenport theorem with a structural characterization of extremizers",
       "Cornerstone of additive combinatorics: characterizes when sumsets are minimally small",
@@ -16,7 +16,7 @@
   },
   "knownResults": {
     "proven": [
-      "erdos-476: Cauchy-Davenport lower bound |A+B| \u2265 min(p, |A|+|B|-1) (verified, 0 sorries)"
+      "erdos-476: Cauchy-Davenport lower bound |A+B| ≥ min(p, |A|+|B|-1) (verified, 0 sorries)"
     ],
     "open": [
       "Vosper's theorem: equality case structure",
@@ -38,42 +38,44 @@
     }
   },
   "knowledge": {
-    "progressSummary": "IN-PROGRESS: 2 sorries remain (hpos, vosper_case1_exists). Both formulated as standalone lemmas in Aristotle companion and submitted for overnight processing.",
+    "progressSummary": "IN-PROGRESS: 1 sorry remains (vosper_case1_exists, Case 1 existence). hpos proved in Session 20 via 3-way case split + ZMod arithmetic. Aristotle job a5594e66 running on case1_exists.",
     "builtItems": [
-      "isAP_sdiff_card: proved A\\A.image(\u00b7+d)={a} for AP(a,d) with d\u22600, |A|<p \u2014 key: start a has no predecessor (Erdos476OQ05Problem.lean:153)",
-      "vosper_ap_sdiff_card: structured proof using isAP_sdiff_card, hunion, h_sdiff_one \u2014 only hpos (position analysis) remains (Erdos476OQ05Problem.lean:207)",
-      "vosper_base: fully proved \u2014 base case |A|=2 using card arithmetic and Finset.card_inter_add_card_sdiff",
-      "ap_of_near_periodic: proved \u2014 B\\B.image(\u00b7+d)={b} and d\u22600 implies B is AP starting at b",
-      "hpos position analysis (vosper_ap_sdiff_card): predecessor/successor case analysis \u2014 proofs/Proofs/Erdos476OQ05Problem.lean:248-450",
+      "isAP_sdiff_card: proved A\\A.image(·+d)={a} for AP(a,d) with d≠0, |A|<p — key: start a has no predecessor (Erdos476OQ05Problem.lean:153)",
+      "vosper_ap_sdiff_card: structured proof using isAP_sdiff_card, hunion, h_sdiff_one — only hpos (position analysis) remains (Erdos476OQ05Problem.lean:207)",
+      "vosper_base: fully proved — base case |A|=2 using card arithmetic and Finset.card_inter_add_card_sdiff",
+      "ap_of_near_periodic: proved — B\\B.image(·+d)={b} and d≠0 implies B is AP starting at b",
+      "hpos position analysis (vosper_ap_sdiff_card): predecessor/successor case analysis — proofs/Proofs/Erdos476OQ05Problem.lean:248-450",
       "Erdos476OQ05Aristotle.lean: ap_sdiff_endpoint lemma (sorry, submitted to Aristotle)",
-      "Erdos476OQ05Aristotle.lean: case1_exists lemma (sorry with partial proof sketch, submitted to Aristotle)"
+      "Erdos476OQ05Aristotle.lean: case1_exists lemma (sorry with partial proof sketch, submitted to Aristotle)",
+      "hpos proved: a₀=a₁-d OR a₀=a₁+|A'|·d, via 3-way case split on missing AP index (Erdos476OQ05Problem.lean:248-420, Session 20)"
     ],
     "insights": [
-      "Vosper 1956: equality |A+B|=|A|+|B|-1 (with |A|,|B|\u22652, |A|+|B|\u2264p) \u2194 A,B are APs with same common difference",
+      "Vosper 1956: equality |A+B|=|A|+|B|-1 (with |A|,|B|≥2, |A|+|B|≤p) ↔ A,B are APs with same common difference",
       "Edge cases: |A|=1 or |B|=1 give trivial equality with no structure constraint",
       "Proof structure: induction on |A|, removing one element and applying CD to smaller set",
-      "AP in Z/pZ: set {a, a+d, a+2d, ..., a+(k-1)d} mod p; d\u22600 since p is prime",
+      "AP in Z/pZ: set {a, a+d, a+2d, ..., a+(k-1)d} mod p; d≠0 since p is prime",
       "Recursive theorem with termination_by A.card works cleanly for vosper induction",
       "Case 1 existence proved by contradiction: if all a in A give Case 2, counting gives |A|*|B| >= 2(|A|+|B|-1) which fails for small sizes",
       "AP extension: |{a0}+B minus A-prime+B|=1 forces a0 to be adjacent to A-prime (predecessor or successor)",
-      "isAP_sdiff_card key insight: in AP(a,d), start a has no d-predecessor; any predecessor y=a+(j:ZMod p)*d would require (j+1)*d=0, but j+1<=|A|<p so p\u2224j+1",
-      "Finset.card_inter_add_card_sdiff (not card_sdiff_add_card_inter) is the correct Mathlib lemma: (s\u2229t).card+(s\\t).card=s.card",
-      "subst ha where ha:a=a\u2080 in Lean 4 eliminates a\u2080 from context, not a \u2014 use rw [ha] instead when a\u2080 is needed downstream",
-      "Docker lean-mathlib-cache has stale oleans causing ring/push_cast/linear_combination to fail as unknown tactic \u2014 pre-existing environment issue",
-      "hpos (position analysis in vosper_ap_sdiff_card) proved via linear_combination \u2014 ZMod p ring algebra, not linarith",
+      "isAP_sdiff_card key insight: in AP(a,d), start a has no d-predecessor; any predecessor y=a+(j:ZMod p)*d would require (j+1)*d=0, but j+1<=|A|<p so p∤j+1",
+      "Finset.card_inter_add_card_sdiff (not card_sdiff_add_card_inter) is the correct Mathlib lemma: (s∩t).card+(s\\t).card=s.card",
+      "subst ha where ha:a=a₀ in Lean 4 eliminates a₀ from context, not a — use rw [ha] instead when a₀ is needed downstream",
+      "Docker lean-mathlib-cache has stale oleans causing ring/push_cast/linear_combination to fail as unknown tactic — pre-existing environment issue",
+      "hpos (position analysis in vosper_ap_sdiff_card) proved via linear_combination — ZMod p ring algebra, not linarith",
       "linarith is inapplicable in ZMod p (not ordered ring); linear_combination (CommRing tactic) works in any ring",
       "Set.InjOn is the correct Lean 4 Mathlib name (not Function.InjOn) for set injectivity",
       "import Mathlib.Tactic required for linear_combination and push_cast; Mathlib.Tactic.IntervalCases insufficient",
       "ap_sdiff_endpoint lemma formulated: two APs with same diff, |AP1\\AP2|=1 forces start1=start2-d or start1=start2+(m-n+1)*d",
       "vosper_case1_exists: counting argument shows (|A|-2)(|B|-2)>=2 when all elements redundant; fails for |A|=3,|B|<=3 but not |B|>=4; ZMod prime structure needed for general case",
-      "Submitted ap_sdiff_endpoint and case1_exists to Aristotle companion for overnight processing"
+      "Submitted ap_sdiff_endpoint and case1_exists to Aristotle companion for overnight processing",
+      "Interior contradiction: (|A'|+|B|)·d=0 in ZMod p refuted since |A'|+|B|<p via ZMod.natCast_zmod_eq_zero_iff_dvd+Nat.le_of_dvd",
+      "AP map injectivity via ZMod.val_natCast+Nat.mod_eq_of_lt: need val_cast+cast_inj chain for ZMod index uniqueness"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Retrieve ap_sdiff_endpoint proof from Aristotle when complete",
-      "Retrieve case1_exists proof from Aristotle when complete",
-      "After both proofs retrieved, integrate into vosper_ap_sdiff_card and vosper theorems",
-      "Build full proof of vosper main theorem once sorries resolved"
+      "Check Aristotle job a5594e66 for case1_exists result",
+      "If Aristotle fails: double-counting argument proves |A|=|B|=3 case (card_eq_sum_card_fiberwise)",
+      "Larger |A|,|B|: shifting/compression methods needed (not in Mathlib)"
     ]
   },
   "tags": [
@@ -94,7 +96,7 @@
   "references": {
     "papers": [
       "Vosper, A.G. (1956): The fraction of subsets of integers summing to a given value",
-      "Nathanson, M.B. Additive Number Theory: Inverse Problems, \u00a72.4"
+      "Nathanson, M.B. Additive Number Theory: Inverse Problems, §2.4"
     ],
     "urls": [],
     "mathlib": [


### PR DESCRIPTION
## Summary

- **Session 20 (Vosper's theorem)**: Proves `hpos` in `vosper_ap_sdiff_card`, eliminating 1 sorry from Vosper's theorem formalization. 1 sorry remains (`case1_exists`).
- **Session 19 (Hook-length formula)**: Proves `hook_walk_identity_gHookYD` and `corners_gHookYD_cases` for generalized hook shapes [a,1^b], extending the hook walk identity coverage.

## Mathematical Content

### hpos (Vosper's theorem, erdos-476-oq-05)

The `hpos` lemma proves that the unique element missing from `{a₀}+B \ (A'+B)` when both are APs with common difference `d` must be the first or last element:

```
hpos : a₀ = a₁ - d ∨ a₀ = a₁ + |A'| * d
```

Proof strategy:
- Injectivity of AP maps via `ZMod.val_natCast` + `Nat.mod_eq_of_lt`
- Three-way case split on missing index `m`
- Interior contradiction: `(|A'|+|B|)·d = 0` in `ZMod p`, refuted since `|A'|+|B| < p` via `ZMod.natCast_zmod_eq_zero_iff_dvd` + `Nat.le_of_dvd`
- Endpoint cases closed by `linear_combination`

### hook_walk_identity_gHookYD (ballot-problem-oq-03-oq-01-oq-02)

Proves the hook walk identity `Σ_c hookProd(μ)/hookProd(μ\c) = μ.card` for all generalized hook shapes [a,1^b] via a non-circular path using `hook_length_formula_gHookYD` (proved independently in Session 14).

## Files Modified

- `proofs/Proofs/Erdos476OQ05Problem.lean` (583→750 lines, 2→1 sorry)
- `proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean` (5146→5274 lines, +corners_gHookYD_cases, hook_walk_identity_gHookYD)
- `src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json` (metadata update)
- `src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json` (lineCount, theoremCount update)
- `research/problems/ballot-problem-oq-03-oq-01-oq-02/knowledge.md` (Session 19 documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)