### PR TITLE
Fix: correct definitionCount for weak-goldbach (0→15) and erdos-1006-oq-01 (0→12)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13028,6 +13028,12 @@
       "lastAudited": "2026-04-24T20:39:10Z",
       "result": "clean",
       "issues": []
+    },
+    "bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-24T20:50:40Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {

--- a/src/data/proofs/erdos-1006-oq-01/meta.json
+++ b/src/data/proofs/erdos-1006-oq-01/meta.json
@@ -23,7 +23,7 @@
     "assumptions": "3 axioms: cover_graph_characterization (Pretzel-Brightwell 1985: G admits robustly acyclic orientation ↔ G is a cover graph of some poset), chromatic_lt_girth_implies_robust (Fisher-Fraughnaugh-Langley-West 1997: χ(G) < girth(G) → G has robust orientation), nesetril_rodl_counterexample (Nešetřil-Rödl 1978: for every girth g≥3, there exists a graph with girth g that does NOT have a robust orientation).",
     "lineCount": 277,
     "theoremCount": 6,
-    "definitionCount": 0,
+    "definitionCount": 12,
     "originalContributions": [
       "admitsRobustAcyclicOrientation: predicate — G has an orientation that stays acyclic under any single edge reversal",
       "isCoverGraph / isCoverGraphOf: G is a cover graph of a poset P if G = Hasse diagram of P",
@@ -116,7 +116,7 @@
     "lineCount": 277,
     "axiomCount": 3,
     "theoremCount": 6,
-    "definitionCount": 0,
+    "definitionCount": 12,
     "path": "Proofs/Erdos1006OQ01.lean",
     "sorries": 0
   },

--- a/src/data/proofs/weak-goldbach/meta.json
+++ b/src/data/proofs/weak-goldbach/meta.json
@@ -22,7 +22,7 @@
     "assumptions": "9 axioms for deep analytic number theory results: vinogradov_ternary_goldbach (Vinogradov 1937: every sufficiently large odd number is sum of 3 primes), helfgott_weak_goldbach (Helfgott 2013: proved unconditionally for all odd n>5), circle_method_asymptotic (circle method asymptotic formula for ternary representations), schnirelmann_basis_theorem (every dense enough set is an additive basis), ramare_six_primes (Ramare 1995: every even n > 1 is sum of ≤ 6 primes), tao_five_primes (Tao 2012: every odd n > 1 is sum of ≤ 5 primes), chen_theorem (Chen 1973: every sufficiently large even n = p + P₂), binary_goldbach_verified (verified for n ≤ 4·10¹⁸), helfgott_explicit_bound (Helfgott's explicit bound). Also: 2 theorem-level True stubs (vinogradov_minor_arc_bound, linnik_goldbach_representations) — placeholder theorems proving True pending formalization of analytic bounds.",
     "lineCount": 480,
     "theoremCount": 24,
-    "definitionCount": 0,
+    "definitionCount": 15,
     "originalContributions": [
       "WeakGoldbachConjecture: formal statement — ∀ n odd, n > 5 → ∃ p q r prime, n = p+q+r",
       "BinaryGoldbachConjecture: ∀ n even, n > 2 → ∃ p q prime, n = p+q",
@@ -151,7 +151,7 @@
     "lineCount": 480,
     "axiomCount": 9,
     "theoremCount": 24,
-    "definitionCount": 0,
+    "definitionCount": 15,
     "path": "Proofs/WeakGoldbach.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Correct `definitionCount` metadata field for two gallery entries that claimed 0 definitions but had multiple top-level `def` declarations in their Lean files.

## Evidence

**weak-goldbach** (`WeakGoldbach.lean`):
- **Before**: `definitionCount: 0` in `meta` and `leanFile` sections
- **After**: `definitionCount: 15`
- **Defs**: `IsSumOfThreePrimes`, `WeakGoldbachConjecture`, `IsSumOfTwoPrimes`, `BinaryGoldbachConjecture`, `checkThreePrimes`, `isSumOfThreePrimesDecide`, `checkTwoPrimes`, `isSumOfTwoPrimesDecide`, `exponentialSumOverPrimes`, `representationCount`, `schnirelmannDensity`, `IsAdditiveBasis`, `IsP2`, `twinPrimeConstant`, `LevyConjecture`

**erdos-1006-oq-01** (`Erdos1006OQ01.lean`):
- **Before**: `definitionCount: 0` in `meta` and `leanFile` sections
- **After**: `definitionCount: 12`
- **Defs**: `GraphOrientation.isAcyclic`, `GraphOrientation.hasDependentArc`, `GraphOrientation.isRobustlyAcyclic`, `admitsRobustAcyclicOrientation`, `emptyOrientation`, `linearOrientation`, `isCoverGraphOf`, `coverOrientation`, `posetRank`, `isBipartite'`, `bipartiteOrientation`, `isCoverGraph`

**Severity**: LOW — does not affect `status`, `sorries`, `axiomCount`, or `badge`. Core claims are accurate.

---
Automated fix by lean-mechanic agent.