### PR TITLE
Fix abel-ruffini annotation ranges: separate Part VI and Part VII

### DIFF
--- a/src/data/proofs/abel-ruffini/annotations.json
+++ b/src/data/proofs/abel-ruffini/annotations.json
@@ -345,7 +345,7 @@
     "proofId": "abel-ruffini",
     "range": {
       "startLine": 151,
-      "endLine": 183
+      "endLine": 163
     },
     "type": "insight",
     "title": "Part VI: Why Degree 5 Is the Exact Threshold",
@@ -372,8 +372,8 @@
     "id": "ann-part-vii-historical",
     "proofId": "abel-ruffini",
     "range": {
-      "startLine": 151,
-      "endLine": 183
+      "startLine": 164,
+      "endLine": 185
     },
     "type": "insight",
     "title": "Part VII: The Impossibility Paradigm and Historical Significance",


### PR DESCRIPTION
Annotation range fix for `abel-ruffini` gallery entry.

## Problem

`ann-part-vi-threshold` and `ann-part-vii-historical` both had the same range `(151-183)`, causing both annotations to appear on the same code section in the gallery viewer — doubling up on the same lines rather than covering distinct sections.

## Fix

Corrected ranges to match the actual Lean file structure (185 lines):
- `ann-part-vi-threshold`: lines 151–163 (Part VI text about degree-5 threshold)
- `ann-part-vii-historical`: lines 164–185 (Part VII text + `end AbelRuffini`)

These now match the section boundaries already defined in `meta.json` (`threshold: 151-163`, `historical-significance: 164-185`).

## Note

This is a structural fix (no content added/removed). The entry was already at quality 100 with all peer review items resolved.