### PR TITLE
Fix: change cube-root-2-irrational badge from 'original' to 'mathlib'

### DIFF
--- a/src/data/proofs/cube-root-2-irrational/meta.json
+++ b/src/data/proofs/cube-root-2-irrational/meta.json
@@ -14,7 +14,7 @@
       "number-theory",
       "cube-roots"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-04-02",
     "axiomCount": 0,


### PR DESCRIPTION
## Summary

- The `cube-root-2-irrational` gallery entry had `"badge": "original"` in its `meta.json`
- The main theorem `irrational_cbrt2` obtains its result by calling Mathlib's `irrational_nrt_of_notint_nrt`, making this a Tier B (mathlib) entry per gallery tier rules
- The description and conclusion text already honestly acknowledged the Mathlib dependency; only the `badge` field needed correction

## Change

- `src/data/proofs/cube-root-2-irrational/meta.json`: `"badge": "original"` → `"badge": "mathlib"`

## Test plan

- [ ] Verify `meta.json` badge field reads `"mathlib"`
- [ ] Confirm gallery build renders the mathlib badge on the cube-root-2-irrational proof page

🤖 Generated with [Claude Code](https://claude.com/claude-code)