### PR TITLE
Fix: sync stale lineCount in erdos-476-oq-05 and lebesgue-measure-oq-06

### DIFF
--- a/src/data/proofs/erdos-476-oq-05/meta.json
+++ b/src/data/proofs/erdos-476-oq-05/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-476-oq-05",
   "title": "Erdős #476 OQ5: Vosper's Theorem — Equality Case of Cauchy-Davenport",
   "slug": "erdos-476-oq-05",
-  "description": "Vosper's theorem (1956): if |A+B| = |A|+|B|-1 in Z/pZ with |A|,|B|≥2 and |A+B|<p, then A and B are arithmetic progressions with the same common difference d. Infrastructure fully proved: IsArithmeticProgression definition, singleton/pair AP lemmas, translation invariance, ap_of_near_periodic (backward-shift induction), and vosper_base (|A|=2 case). Full Vosper induction (2 sorries) remains open.",
+  "description": "Vosper's theorem (1956): if |A+B| = |A|+|B|-1 in Z/pZ with |A|,|B|≥2 and |A+B|<p, then A and B are arithmetic progressions with the same common difference d. Infrastructure fully proved: IsArithmeticProgression definition, singleton/pair AP lemmas, translation invariance, ap_of_near_periodic (backward-shift induction), and vosper_base (|A|=2 case). Full Vosper induction (1 sorry) remains open.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-21",
@@ -18,11 +18,11 @@
       "zmod"
     ],
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 1,
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "assumptions": "2 sorries in vosper theorem: [SORRY 1/2] Case 1 existence (counting argument for removing an element from A) and [SORRY 2/2] AP extension (a₀ adjacent to A' implies A is AP with same difference d). Both ap_of_near_periodic (backward-shift induction) and vosper_base (|A|=2 case) are fully proved. Infrastructure all proved with 0 sorries.",
-    "lineCount": 583,
+    "assumptions": "1 sorry in vosper theorem: [SORRY 1/2] Case 1 existence (counting argument for removing an element from A). [SORRY 2/2] AP extension has been resolved: vosper_ap_sdiff_card is now fully proved (Session 20). ap_of_near_periodic (backward-shift induction) and vosper_base (|A|=2 case) are also fully proved. Infrastructure all proved with 0 sorries.",
+    "lineCount": 750,
     "theoremCount": 8,
     "definitionCount": 1,
     "originalContributions": [
@@ -33,7 +33,7 @@
       "shift_card_eq: |B.image (·+d)| = |B| via add_right_injective (proved, 0 sorries)",
       "ap_of_near_periodic: B is AP if |B\\(B+d)|=1 (proved — backward-shift induction)",
       "vosper_base: Vosper for |A|=2 (proved — uses ap_of_near_periodic)",
-      "vosper: full Vosper theorem (2 sorries — Case 1 existence and AP extension in induction on |A|)"
+      "vosper: full Vosper theorem (1 sorry — Case 1 existence in induction on |A|; AP extension proved via vosper_ap_sdiff_card in Session 20)"
     ]
   },
   "overview": {
@@ -56,7 +56,7 @@
     ]
   },
   "conclusion": {
-    "summary": "Infrastructure for Vosper's theorem fully established and mostly proved: IsArithmeticProgression defined, basic AP lemmas proved (singleton, pair, shift, cardinality), ap_of_near_periodic proved (backward-shift induction), vosper_base proved (|A|=2 case). Two sorries remain in the full Vosper induction: Case 1 existence (counting/iterative removal) and AP extension (a₀ adjacent to A' forces A to be AP).",
+    "summary": "Infrastructure for Vosper's theorem fully established and mostly proved: IsArithmeticProgression defined, basic AP lemmas proved (singleton, pair, shift, cardinality), ap_of_near_periodic proved (backward-shift induction), vosper_base proved (|A|=2 case), vosper_ap_sdiff_card proved (Session 20). One sorry remains in the full Vosper induction: Case 1 existence (counting/iterative removal).",
     "implications": "Once ap_of_near_periodic is formalized (the backward-shift induction), the full Vosper theorem follows from standard induction. Vosper's theorem would then complement ZMod.cauchy_davenport in Mathlib, completing the picture of additive structure in Z/pZ.",
     "openQuestions": [
       "Formalize ap_of_near_periodic: B is an AP if |B \\ (B+d)| = 1 (needs backward-shift induction on |B|)",
@@ -111,17 +111,17 @@
       "title": "Vosper's Theorem: Base Case and Full Induction",
       "startLine": 128,
       "endLine": 165,
-      "summary": "vosper_base (|A|=2, inclusion-exclusion → ap_of_near_periodic, fully proved), vosper (strong induction on |A|, 2 sorries: Case 1 existence and AP extension). vosper_base now proved; two specific sub-goals in the induction remain open."
+      "summary": "vosper_base (|A|=2, inclusion-exclusion → ap_of_near_periodic, fully proved), vosper_ap_sdiff_card (AP extension, fully proved — Session 20), vosper (strong induction on |A|, 1 sorry: Case 1 existence). vosper_base and vosper_ap_sdiff_card now proved; one specific sub-goal in the induction remains open."
     }
   ],
   "leanFile": {
     "namespace": "Erdos476OQ05",
-    "lineCount": 583,
+    "lineCount": 750,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 1,
     "path": "Proofs/Erdos476OQ05Problem.lean",
-    "sorries": 2
+    "sorries": 1
   },
-  "sorries": 2
+  "sorries": 1
 }

--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -20,7 +20,7 @@
     "badge": "wip",
     "sorries": 3,
     "axiomCount": 0,
-    "lineCount": 741,
+    "lineCount": 735,
     "assumptions": "3 sorries: hausdorff_free_subgroup (Hausdorff 1914 — SO(3) contains F₂), banach_tarski (Banach-Tarski 1924 — main paradox, requires AC), banach_tarski_pieces_nonmeasurable (classical non-measurability corollary). Core framework fully proved including paradoxical_no_finite_measure, free_group_not_amenable, and int_amenable (ℤ amenable via Cesàro window-shift argument — fully proved).",
     "dateAdded": "2026-04-22",
     "mathlib_version": "4.26.0",
@@ -203,7 +203,7 @@
       "Mathlib"
     ],
     "namespace": "BanachTarski",
-    "lineCount": 741,
+    "lineCount": 735,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 5,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` metadata in two gallery entries discovered during self-audit.

## Evidence

**erdos-476-oq-05** (`Proofs/Erdos476OQ05Problem.lean`):
- **Before**: `lineCount: 583` in both `meta` and `leanFile` blocks; `sorries: 2`
- **After**: `lineCount: 750`; `sorries: 1`
- **Why**: File grew by 167 lines across Sessions 19–20. Session 20 proved `vosper_ap_sdiff_card` (sorry 2/2), reducing the remaining sorry count to 1.

**lebesgue-measure-oq-06** (`Proofs/LebesgueMeasureOQ06.lean`):
- **Before**: `lineCount: 741` in both `meta` and `leanFile` blocks
- **After**: `lineCount: 735`
- **Why**: File shrank by 6 lines (minor cleanup).

Both fixes verified by counting actual lines in the Lean files.

---
Automated fix by lean-mechanic agent.