### PR TITLE
Fix: correct definitionCount for 8 Erdős problems (0→actual)

### DIFF
--- a/src/data/proofs/erdos-1017/meta.json
+++ b/src/data/proofs/erdos-1017/meta.json
@@ -190,7 +190,7 @@
     "lineCount": 696,
     "axiomCount": 3,
     "theoremCount": 37,
-    "definitionCount": 0,
+    "definitionCount": 6,
     "path": "Proofs/Erdos1017OQ01.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-1036/meta.json
+++ b/src/data/proofs/erdos-1036/meta.json
@@ -127,7 +127,7 @@
     "lineCount": 201,
     "axiomCount": 2,
     "theoremCount": 9,
-    "definitionCount": 0,
+    "definitionCount": 6,
     "path": "Proofs/Erdos1036Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-220/meta.json
+++ b/src/data/proofs/erdos-220/meta.json
@@ -140,7 +140,7 @@
     "lineCount": 227,
     "axiomCount": 4,
     "theoremCount": 3,
-    "definitionCount": 0,
+    "definitionCount": 14,
     "path": "Proofs/Erdos220Problem.lean",
     "sorries": 2
   },

--- a/src/data/proofs/erdos-330/meta.json
+++ b/src/data/proofs/erdos-330/meta.json
@@ -120,7 +120,7 @@
     "lineCount": 65,
     "axiomCount": 1,
     "theoremCount": 0,
-    "definitionCount": 0,
+    "definitionCount": 5,
     "path": "Proofs/Erdos330Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-633/meta.json
+++ b/src/data/proofs/erdos-633/meta.json
@@ -152,7 +152,7 @@
     "lineCount": 236,
     "axiomCount": 0,
     "theoremCount": 11,
-    "definitionCount": 0,
+    "definitionCount": 12,
     "sorries": 8,
     "path": "Proofs/Erdos633Problem.lean"
   },

--- a/src/data/proofs/erdos-644/meta.json
+++ b/src/data/proofs/erdos-644/meta.json
@@ -149,7 +149,7 @@
     "lineCount": 277,
     "axiomCount": 3,
     "theoremCount": 19,
-    "definitionCount": 0,
+    "definitionCount": 14,
     "sorries": 16,
     "path": "Proofs/Erdos644Problem.lean"
   },

--- a/src/data/proofs/erdos-660/meta.json
+++ b/src/data/proofs/erdos-660/meta.json
@@ -139,7 +139,7 @@
     "lineCount": 179,
     "axiomCount": 0,
     "theoremCount": 10,
-    "definitionCount": 0,
+    "definitionCount": 8,
     "sorries": 10,
     "path": "Proofs/Erdos660Problem.lean"
   },

--- a/src/data/proofs/erdos-840/meta.json
+++ b/src/data/proofs/erdos-840/meta.json
@@ -104,7 +104,7 @@
     "lineCount": 237,
     "axiomCount": 8,
     "theoremCount": 9,
-    "definitionCount": 0,
+    "definitionCount": 11,
     "sorries": 0,
     "path": "Proofs/Erdos840Problem.lean"
   },


### PR DESCRIPTION
## Fix

Eight gallery proof entries had `leanFile.definitionCount: 0` in their `meta.json`
files despite having actual `def` declarations in their Lean source files.

## Evidence

| Proof | File | Claimed | Actual |
|-------|------|---------|--------|
| erdos-220 | Erdos220Problem.lean | 0 | 14 |
| erdos-330 | Erdos330Problem.lean | 0 | 5 |
| erdos-633 | Erdos633Problem.lean | 0 | 12 |
| erdos-644 | Erdos644Problem.lean | 0 | 14 |
| erdos-660 | Erdos660Problem.lean | 0 | 8 |
| erdos-840 | Erdos840Problem.lean | 0 | 11 |
| erdos-1017 | Erdos1017OQ01.lean | 0 | 6 |
| erdos-1036 | Erdos1036Problem.lean | 0 | 6 |

**Verification method**: grep for `^def`, `^noncomputable def`, `^private def` on each Lean file.

## Validation

`pnpm build` passes after these changes.

---
Automated fix by lean-mechanic agent.