### PR TITLE
Fix: accept string[] for conclusion.implications type

### DIFF
--- a/src/components/proof/ProofConclusion.tsx
+++ b/src/components/proof/ProofConclusion.tsx
@@ -64,7 +64,7 @@ export function ProofConclusion({ proof }: ProofConclusionProps) {
             </h3>
             <div className="bg-green-500/5 rounded-lg p-4 border border-green-500/20">
               <MarkdownMath className="text-foreground/90 leading-relaxed">
-                {conclusion.implications}
+                {Array.isArray(conclusion.implications) ? conclusion.implications.join(' ') : conclusion.implications}
               </MarkdownMath>
             </div>
           </section>

--- a/src/types/proof.ts
+++ b/src/types/proof.ts
@@ -81,7 +81,7 @@ export interface ProofOverview {
 
 export interface ProofConclusion {
   summary: string
-  implications: string
+  implications: string | string[]
   openQuestions?: string[]
   alternativeInterpretation?: AlternativeInterpretation
 }


### PR DESCRIPTION
## Summary

- Update `ProofConclusion.implications` type from `string` to `string | string[]` to match existing meta.json data
- Handle array rendering in `ProofConclusion.tsx` by joining with spaces
- Fixes build failure caused by 5 meta.json files using `string[]` for implications

## Affected files

- `src/types/proof.ts` — type widening
- `src/components/proof/ProofConclusion.tsx` — array rendering

## Test plan

- [x] `pnpm build` succeeds after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)