### PR TITLE
Fix: sync stale lineCount after Vosper PR (#12406)

### DIFF
--- a/src/data/proofs/erdos-1036/meta.json
+++ b/src/data/proofs/erdos-1036/meta.json
@@ -25,7 +25,7 @@
       1031
     ],
     "axiomCount": 2,
-    "lineCount": 201,
+    "lineCount": 243,
     "assumptions": "2 axioms: shelah_1998 (Shelah 1998, main exponential bound) and nonRamseyExists (Erdős 1947, probabilistic method). All theorems fully proved from these axioms.",
     "mathlib_version": "4.26.0"
   },
@@ -124,7 +124,7 @@
     "imports": [],
     "opens": [],
     "namespace": null,
-    "lineCount": 201,
+    "lineCount": 243,
     "axiomCount": 2,
     "theoremCount": 9,
     "definitionCount": 0,

--- a/src/data/proofs/erdos-476-oq-05/meta.json
+++ b/src/data/proofs/erdos-476-oq-05/meta.json
@@ -22,7 +22,7 @@
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
     "assumptions": "1 sorry in vosper theorem: [SORRY 1/2] Case 1 existence (counting argument for removing an element from A). [SORRY 2/2] AP extension has been resolved: vosper_ap_sdiff_card is now fully proved (Session 20). ap_of_near_periodic (backward-shift induction) and vosper_base (|A|=2 case) are also fully proved. Infrastructure all proved with 0 sorries.",
-    "lineCount": 750,
+    "lineCount": 809,
     "theoremCount": 8,
     "definitionCount": 1,
     "originalContributions": [
@@ -116,7 +116,7 @@
   ],
   "leanFile": {
     "namespace": "Erdos476OQ05",
-    "lineCount": 750,
+    "lineCount": 809,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 1,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` fields in two gallery entries whose Lean files were expanded by PR #12406 (Vosper proof) but whose metadata was not updated at the time.

## Evidence

**erdos-476-oq-05** (`Proofs/Erdos476OQ05Problem.lean`):
- **Before**: `"lineCount": 750` (meta + leanFile)
- **After**: `"lineCount": 809` (actual wc -l of committed file)

**erdos-1036** (`Proofs/Erdos1036Problem.lean`):
- **Before**: `"lineCount": 201` (meta + leanFile)
- **After**: `"lineCount": 243` (actual wc -l of committed file)

Root cause: PR #12406 added the Vosper proof (59 lines to erdos-476-oq-05 and 42 lines to erdos-1036), while PR #12407 had already fixed lineCounts for an earlier snapshot of those files.

---
Automated fix by lean-mechanic agent.