### PR TITLE
Add Aristotle companion for Erdős #552 (Ramsey R(C₄, Sₙ))

### DIFF
--- a/proofs/Proofs/Erdos552Aristotle.lean
+++ b/proofs/Proofs/Erdos552Aristotle.lean
@@ -1,0 +1,117 @@
+/-
+  Aristotle targets for Erdős Problem #552: Ramsey Number R(C₄, Sₙ)
+  Supporting lemmas for automated proof search.
+  See Erdos552Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - Known mathematical results with existing literature proofs (HARD tier)
+  - NOT the main open Erdős question (ErdosQuestion, ErdosConjecture — open)
+  - NOT theorems depending on other sorry-defined functions
+    (asymptotic_bounds depends on parsons + befrs; c4_star_extremal depends on parsons)
+  - No axiom declarations, no def sorries, no open conjectures
+  - polarityGraph (def sorry): Aristotle skips definitions
+
+  Included targets (all HARD tier, known results):
+  - parsons_upper_bound: R(C₄, Sₙ) ≤ n + ⌈√n⌉ + 1  [Parsons 1975]
+  - befrs_lower_bound: R(C₄, Sₙ) ≥ n + √n − 6n^{11/40}  [BEFRS 1989]
+  - exact_value_q2_plus_1: R(C₄, S_{q²+1}) = q²+1+q  [Parsons 1975]
+  - exact_value_q2: R(C₄, S_{q²}) = q²+q+1  [Parsons 1975]
+  - exact_value_q2_minus_t: R(C₄, S_{q²−t}) = q²−t+q+1  [Parsons 1975]
+  - parsons_construction: Projective-plane graph witnesses the lower bound
+  - c4_minimum_degree: Min degree ≥ n/2 ⟹ G contains C₄  [known]
+
+  Excluded (open or dependent on open):
+  - ErdosQuestion, ErdosConjecture — the main unsolved problem
+  - asymptotic_bounds — depends on parsons_upper_bound and befrs_lower_bound (both sorry'd)
+  - c4_star_extremal — depends on parsons_upper_bound (sorry'd)
+  - f_eventually_increasing — R(C₄,Sₙ) is constant at n=q², n=q²+1; eventual strict
+    monotonicity requires delicate analysis
+  - cramer_implies_better_bound — involves CramerConjecture as hypothesis (unproved)
+-/
+import Mathlib
+import Proofs.Erdos552Problem
+
+namespace Erdos552Aristotle
+
+open Erdos552 SimpleGraph Finset
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART I: Parsons Upper Bound (1975)
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- Parsons (1975): R(C₄, Sₙ) ≤ n + ⌈√n⌉ + 1 for n ≥ 1.
+
+    Proof uses the polarity graph of PG(2,q): for n between consecutive
+    prime-power squares, a polarity graph construction shows no C₄ and
+    no large star exist simultaneously in a graph on n + ⌈√n⌉ + 1 vertices.
+    See [Pa75] for the full argument. -/
+theorem parsons_upper_bound_ari (n : ℕ) (hn : n ≥ 1) :
+    R_C4_Sn n ≤ n + Nat.ceil (Real.sqrt n) + 1 := by
+  sorry
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART II: BEFRS Lower Bound (1989)
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- Burr-Erdős-Faudree-Rousseau-Schelp (1989): asymptotic lower bound.
+
+    For all sufficiently large n:
+      R(C₄, Sₙ) ≥ n + √n − 6·n^{11/40}
+
+    See [BEFRS89] for the full probabilistic/algebraic argument. -/
+theorem befrs_lower_bound_ari :
+    ∀ᶠ n in Filter.atTop,
+      (R_C4_Sn n : ℝ) ≥ n + Real.sqrt n - 6 * (n : ℝ) ^ (11/40 : ℝ) := by
+  sorry
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART III: Exact Values at Prime Powers (Parsons 1975)
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- For n = q² + 1 (q prime power): R(C₄, Sₙ) = n + ⌈√n⌉ = q² + 1 + q.
+
+    Uses the polarity graph of PG(2,q): a q²+q+1-vertex graph that is
+    C₄-free and whose complement contains no K_{1,q²+1}. -/
+theorem exact_value_q2_plus_1_ari (q : ℕ) (hq : Nat.Prime q ∨ ∃ p k, Nat.Prime p ∧ q = p ^ k) :
+    R_C4_Sn (q ^ 2 + 1) = q ^ 2 + 1 + q := by
+  sorry
+
+/-- For n = q² (q prime power): R(C₄, Sₙ) = n + ⌈√n⌉ + 1 = q² + q + 1. -/
+theorem exact_value_q2_ari (q : ℕ) (hq : Nat.Prime q ∨ ∃ p k, Nat.Prime p ∧ q = p ^ k) :
+    R_C4_Sn (q ^ 2) = q ^ 2 + q + 1 := by
+  sorry
+
+/-- For n = q² − t where 0 ≤ t ≤ q: R(C₄, Sₙ) = n + ⌈√n⌉ + 1 = q² − t + q + 1. -/
+theorem exact_value_q2_minus_t_ari (q t : ℕ) (ht : t ≤ q)
+    (hq : Nat.Prime q ∨ ∃ p k, Nat.Prime p ∧ q = p ^ k) :
+    R_C4_Sn (q ^ 2 - t) = q ^ 2 - t + q + 1 := by
+  sorry
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART IV: Projective Plane Construction (Parsons 1975)
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- The polarity graph of PG(2,q) provides the C₄-free lower bound witness.
+
+    For prime q, there exists a graph H on q²+q+1 vertices such that
+    H is C₄-free and the complement of H contains no S_{q²}. -/
+theorem parsons_construction_ari (q : ℕ) (hq : Nat.Prime q) :
+    ∃ G : SimpleGraph (Fin (q ^ 2 + q + 1)),
+      ¬ContainsSubgraph G C4 ∧ ¬ContainsSubgraph (complement G) (starGraph (q ^ 2)) := by
+  sorry
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART V: Minimum Degree and C₄
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- The minimum degree condition for C₄: if every vertex of G has
+    degree ≥ n/2 in a graph on n ≥ 4 vertices, then G contains C₄ as a subgraph.
+
+    Proof sketch: Any two vertices u, v of high degree share ≥ 2 common
+    neighbors by pigeonhole (degrees sum to ≥ n, so intersection ≥ 2), giving
+    a 4-cycle u—w₁—v—w₂—u. -/
+theorem c4_minimum_degree_ari (n : ℕ) (G : SimpleGraph (Fin n)) (hn : n ≥ 4) :
+    (∀ v : Fin n, G.degree v ≥ n / 2) → ContainsSubgraph G C4 := by
+  sorry
+
+end Erdos552Aristotle


### PR DESCRIPTION
## Fix

Creates `Erdos552Aristotle.lean` — an Aristotle companion file for Erdős Problem #552 on the Ramsey number R(C₄, Sₙ).

This proof (12 sorry'd theorems) was one of 4 sorry-heavy proofs in the gallery without an Aristotle companion file.

## What's Included

7 HARD-tier theorem targets for automated proof search:

| Theorem | Source | Tier |
|---------|--------|------|
| `parsons_upper_bound_ari` | Parsons (1975) | HARD |
| `befrs_lower_bound_ari` | Burr-Erdős-Faudree-Rousseau-Schelp (1989) | HARD |
| `exact_value_q2_plus_1_ari` | Parsons (1975) | HARD |
| `exact_value_q2_ari` | Parsons (1975) | HARD |
| `exact_value_q2_minus_t_ari` | Parsons (1975) | HARD |
| `parsons_construction_ari` | Parsons (1975) | HARD |
| `c4_minimum_degree_ari` | standard graph theory | HARD |

## What's Excluded

- `ErdosQuestion` / `ErdosConjecture` — the main unsolved Erdős question
- `asymptotic_bounds`, `c4_star_extremal` — depend on other sorry'd theorems
- `f_eventually_increasing` — R(C₄,Sₙ) is constant for consecutive values at prime powers
- `cramer_implies_better_bound` — involves unproved Cramér conjecture as hypothesis
- `polarityGraph` — def sorry (Aristotle skips definitions)

## Pre-submission Checklist

- [x] No `def ... := sorry`
- [x] No `axiom` declarations
- [x] No `theorem ... : True` placeholders
- [x] No `/-!` docstring sections
- [x] No open conjectures as targets

---
Automated fix by lean-mechanic agent.