### PR TITLE
Seeker: select cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01 (Nonderogatory Cyclic Vector: All Fields)

### DIFF
--- a/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01/knowledge.md
+++ b/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01/literature/README.md
+++ b/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01/problem.md
+++ b/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01/problem.md
@@ -1,0 +1,143 @@
+# Problem: Complete Nonderogatory to Cyclic Vector: The General Case (All Fields)
+
+**Slug**: cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01
+**Created**: 2026-04-25
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\forall K \text{ field},\ \forall n \geq 1,\ \forall M \in M_n(K):\ \mu_M = \chi_M \Rightarrow \exists v \in K^n,\ \{v, Mv, \ldots, M^{n-1}v\}\ \text{spans}\ K^n
+$$
+
+```lean
+theorem nonderogatory_has_cyclic_vector_any_field
+    {K : Type*} [Field K] {n : ℕ} (hn : 0 < n)
+    (M : Matrix (Fin n) (Fin n) K)
+    (hnd : IsNonderogatory M) :
+    ∃ v : Fin n → K, IsCyclicVector M v
+```
+
+### Plain Language
+
+A matrix M is **nonderogatory** if its minimal polynomial equals its characteristic polynomial. A vector v is **cyclic** for M if iterating M on v (i.e., v, Mv, M²v, …) spans the whole space.
+
+The theorem: every nonderogatory matrix has a cyclic vector, over **any** field — including finite fields.
+
+Previous formalizations proved this for infinite fields (union avoidance) and for |K| > n. This problem closes the general case using a module-theoretic argument that avoids all cardinality conditions.
+
+### Why This Matters
+
+1. Completes the cyclic vector trilogy in the gallery (infinite → |K| > n → all fields)
+2. Demonstrates that the result is algebraic (module theory over PID K[X]), not combinatorial
+3. Isolates a concrete Mathlib gap: PID module structure theorem for K[X]-modules
+4. Natural Mathlib contribution target: the missing lemma `exists_cyclic_vector_module`
+
+## Known Results
+
+### What's Already Proven
+
+- `CayleyHamiltonMinpolyOQ05OQ01` — nonderogatory ↔ cyclic vector for infinite fields
+- `CayleyHamiltonMinpolyOQ05OQ01OQ01` — weakened to |K| > n
+- All 22 supporting lemmas in `CayleyHamiltonMinpolyOQ05OQ01OQ04.lean` are sorry-free:
+  - `aeval_conj`: conjugation commutes with polynomial evaluation
+  - `IsCyclicVector` and `IsNonderogatory` preserved under matrix similarity
+  - `krylov_independent_iff_cyclic`: Krylov span ↔ cyclic vector
+
+### What's Still Open
+
+- Main theorem `nonderogatory_has_cyclic_vector_any_field` — 1 sorry in WIP file
+- `exists_cyclic_vector_module`: if M nonderogatory then ∃ v generating K^n as K[X]-module
+
+### Our Goal
+
+Fill the single sorry in `CayleyHamiltonMinpolyOQ05OQ01OQ04.lean` (268 lines, 22 theorems)
+by proving `exists_cyclic_vector_module`, either via Mathlib's PID module structure or directly.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `cayley-hamilton` | Base theorem (charpoly annihilates M) | Polynomial evaluation |
+| `cayley-hamilton-minpoly` | Minimal polynomial reduction | Annihilator ideals |
+| `cayley-hamilton-minpoly-oq-05` | Nonderogatory ↔ cyclic (original) | Union avoidance |
+| `cayley-hamilton-minpoly-oq-05-oq-01` | Proof for infinite fields | Polynomial counting |
+| `cayley-hamilton-minpoly-oq-05-oq-01-oq-04` | Parent WIP file | Module theory over K[X] |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Module structure theorem** (preferred): K^n with M-action is f.g. over PID K[X]; nonderogatory forces rank-1 (single cyclic summand); generator is the cyclic vector.
+   - Why it might work: The module K[X]/(minpoly M) has rank 1, so its generator v satisfies ann(v) = (minpoly M), making v cyclic.
+   - Risk: Mathlib's PID module structure results may not apply to this K[X]-module setup.
+
+2. **Rational canonical form**: Nonderogatory → single companion matrix block → e₁ is cyclic.
+   - Why it might work: Concrete, avoids module theory abstraction.
+   - Risk: Rational canonical form may not be formalized in Mathlib for arbitrary fields.
+
+3. **Direct annihilator argument**: For nonderogatory M, show ∃ v with ann(v) = (minpoly M) using dimension counting over K.
+   - Why it might work: Reduces to linear algebra, avoids module theory.
+   - Risk: May still need module theory in disguise.
+
+### Key Difficulties
+
+- PID structure theorem for K[X]-modules not directly available in Mathlib
+- Rational canonical form not fully formalized in Mathlib (as of early 2026)
+- Translating between Matrix algebra and module-theoretic language in Lean 4
+
+### What Would a Proof Need?
+
+- Key lemma: `exists_cyclic_vector_module` — module generator is a cyclic vector
+- Mathlib search: `Module.Cyclic`, `Submodule.span_singleton_eq_top`, `Ideal.Quotient.mk_surjective`
+- Technical: `Polynomial.aeval_apply` and `Module.smul` compatibility
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- 22 supporting lemmas already proved; only 1 sorry remains
+- Proof strategy clearly laid out in the WIP file header comments
+- Primary obstacle: finding/building the right Mathlib lemma for cyclic K[X]-modules
+
+**Estimated Effort**:
+- Exploration: 1-2 days (Mathlib search for PID structure / rational canonical form)
+- If approach 1 works: 1-3 days of Lean formalization
+- If approach 2 works: 3-5 days (companion matrix results may need proving)
+
+## References
+
+### Papers
+- Hoffman & Kunze, *Linear Algebra*, Ch. 7 — Rational canonical form, cyclic decomposition
+
+### Mathlib
+- `Mathlib.LinearAlgebra.Matrix.Charpoly` — characteristic polynomial machinery
+- `Mathlib.RingTheory.PrincipalIdealDomain` — PID module structure
+- `Mathlib.LinearAlgebra.FreeModule.Basic` — free module rank results
+
+## Metadata
+
+```yaml
+tags:
+  - linear-algebra
+  - abstract-algebra
+  - minimal-polynomial
+  - cyclic-vector
+  - finite-fields
+  - module-theory
+  - wip
+  - seeker-selected
+related_proofs:
+  - cayley-hamilton
+  - cayley-hamilton-minpoly
+  - cayley-hamilton-minpoly-oq-05
+  - cayley-hamilton-minpoly-oq-05-oq-01
+  - cayley-hamilton-minpoly-oq-05-oq-01-oq-04
+difficulty: medium
+source: gallery-gap
+created: 2026-04-25
+```

--- a/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01/state.md
+++ b/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01/state.md
@@ -1,0 +1,33 @@
+# Research State: cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-04-25T10:49:29+02:00
+**Iteration**: 1
+
+## Current Focus
+The main theorem `nonderogatory_has_cyclic_vector_any_field` has exactly 1 sorry in the WIP
+lean file (`proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean`, 268 lines, 22 theorems).
+All supporting lemmas are proved. The sorry requires the structure theorem for f.g. modules
+over the PID K[X] — this is the key Mathlib gap to address.
+
+## Active Approach
+Module-theoretic: Give K^n the K[X]-module structure via M. Nonderogatory forces
+V ≅ K[X]/(minpoly(M)). The generator of this cyclic module is a cyclic vector for M.
+Secondary fallback: companion matrix / rational canonical form approach.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+- PID module structure theorem for K[X]-modules not directly available in Mathlib
+  for this specific application (as of 2026-04-25)
+- Rational canonical form not fully formalized in Mathlib for arbitrary fields
+
+## Next Action
+1. Search Mathlib for `Module.Cyclic`, `Submodule.span_singleton_eq_top`, PID module structure
+2. Check if rational canonical form (companion matrix approach) is available
+3. Attempt to fill `exists_cyclic_vector_module` sorry in the WIP file

--- a/research/registry.json
+++ b/research/registry.json
@@ -15771,6 +15771,13 @@
       "path": "full",
       "started": "2026-04-24T10:42:44+02:00",
       "status": "active"
+    },
+    {
+      "slug": "cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-25T10:49:30+02:00",
+      "status": "active"
     }
   ],
   "config": {


### PR DESCRIPTION
## Summary

- Selects **cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01** for research: completing the nonderogatory → cyclic vector theorem over arbitrary fields (including finite fields)
- Pool status: 37 available (above threshold of 15) — no replenishment needed
- Initializes research workspace with enriched `problem.md` and `state.md`

## Selected Problem

**ID**: cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01
**Name**: Complete Nonderogatory to Cyclic Vector: The General Case (All Fields)
**Tier**: A | **Significance**: 7/10 | **Tractability**: 6/10
**Knowledge Score**: 0 (EMPTY) | **Composite**: 76

## Selection Rationale

1. **EMPTY knowledge tier** (score 0) — highest priority class; no research started despite workspace being initialized
2. **WIP completion with concrete gap**: 22 supporting lemmas proved, exactly 1 sorry remains requiring PID module structure theorem for K[X]
3. **Domain diversity**: Linear algebra — distinct from recent sperner (topology) and Szemerédi (additive combinatorics) selections

## Quality Gate

- Not a near-duplicate of recent completions ✓
- Significance ≥ 3 ✓ (7/10)
- Not from same domain as last 3 selections ✓
- Has clear first step (search Mathlib for cyclic K[X]-module structure) ✓

## Labels

`research`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)