### PR TITLE
Fix: sync stale lineCount and section summary for abel-ruffini-galois-extensions-oq-04

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-04/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-04/meta.json
@@ -21,7 +21,7 @@
         "dateAdded": "2026-04-24",
         "axiomCount": 0,
         "assumptions": "",
-        "lineCount": 241,
+        "lineCount": 255,
         "theoremCount": 9,
         "definitionCount": 3,
         "originalContributions": [
@@ -62,7 +62,7 @@
     },
     "leanFile": {
         "namespace": "AbelRuffiniGaloisExtensionsOQ04",
-        "lineCount": 241,
+        "lineCount": 255,
         "axiomCount": 0,
         "theoremCount": 9,
         "definitionCount": 3,
@@ -89,13 +89,13 @@
             "title": "Part II: JordanHolderLattice Instance",
             "startLine": 70,
             "endLine": 210,
-            "summary": "instJordanHolderLatticeSubgroup — fills Mathlib TODO. sup_eq_of_isMaximal proved; isMaximal_inf_left_of_isMaximal_sup 2/3 proved (1 sorry); iso_symm, iso_trans, second_iso all proved"
+            "summary": "instJordanHolderLatticeSubgroup — fills Mathlib TODO. All 3 axioms proved: sup_eq_of_isMaximal, isMaximal_inf_left_of_isMaximal_sup (element-wise Subgroup.mem_sup argument), iso_symm, iso_trans, second_iso. 0 sorries."
         },
         {
             "id": "sec-main-theorem",
             "title": "Part III: Jordan-Hölder Theorem",
             "startLine": 211,
-            "endLine": 241,
+            "endLine": 255,
             "summary": "jordan_holder_subgroups and jordan_holder_finite_groups — delegates to CompositionSeries.jordan_holder once instance is provided"
         }
     ],


### PR DESCRIPTION
## Summary

- `lineCount` was 241 in both `meta` and `leanFile` fields; actual file is 255 lines (grew when the `isMaximal_inf_left_of_isMaximal_sup` sorry was resolved in #12416)
- `sec-instance` section summary still said "2/3 proved (1 sorry)" — all 3 JordanHolderLattice axioms are now proved, 0 sorries
- `sec-main-theorem.endLine` updated from 241 → 255 to match actual file length

## Audit context

Discovered during gallery integrity audit. The primary sorry/status fix was applied in #12416; this PR syncs the remaining stale metadata fields.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)