### PR TITLE
erdos-476-oq-05: counting argument proves |A|=|B|=3 sub-case in Vosper

### DIFF
--- a/proofs/Proofs/Erdos476OQ05Problem.lean
+++ b/proofs/Proofs/Erdos476OQ05Problem.lean
@@ -4,7 +4,8 @@ Erdős Problem #476, Open Question 5: Vosper's Theorem (1956)
 Source: Follow-up to erdos-476 (Erdős-Heilbronn conjecture)
 Status: PARTIAL — ap_of_near_periodic proved (orbit-cardinality argument);
                    vosper_base proved; vosper_ap_sdiff_card proved (hpos proved, Session 20);
-                   isAP_sdiff_card proved; vosper_case1_exists sorryed [1 sorry remains]
+                   isAP_sdiff_card proved; vosper_case1_exists sorryed [1 sorry remains];
+                   counting argument proves |A|=|B|=3 sub-case; Kneser needed for |A|≥4 or |B|≥4
 
 Statement (Vosper 1956):
 Let p be prime, A, B ⊆ Z/pZ with |A|, |B| ≥ 2.
@@ -774,9 +775,73 @@ theorem vosper (A B : Finset (ZMod p)) (hA : 2 ≤ A.card) (hB : 2 ≤ B.card)
             a₀ + (k : ZMod p) * (b₁ - b₂))) ⊆ A :=
           fun _ hx => by obtain ⟨j, _, rfl⟩ := Finset.mem_image.mp hx; exact horbit j
         linarith [Finset.card_le_card himg_sub]
-      · -- |B| ≥ 3: requires additive structure theory (period/Freiman/stabilizer)
+      · -- |B| ≥ 3: counting argument handles |A|=|B|=3; general case needs Kneser
         have hB3 : 3 ≤ B.card := by omega
-        sorry -- [HARD] |B| ≥ 3 all-redundant contradiction requires Freiman-Ruzsa or stabilizer theory
+        -- If all of A is redundant, every x ∈ A+B has ≥ 2 A-representations.
+        -- Proof: if r(x) = 1 with unique a₁, then x ∉ (A.erase a₁)+B, contradicting hredA a₁.
+        have hrep2 : ∀ x ∈ A + B, 2 ≤ (A.filter (fun a => x - a ∈ B)).card := by
+          intro x hx
+          by_contra hlt2
+          push_neg at hlt2
+          have hpos : 0 < (A.filter (fun a => x - a ∈ B)).card := by
+            obtain ⟨a, haA, b, hbB, hxab⟩ := Finset.mem_add.mp hx
+            apply Finset.card_pos.mpr
+            exact ⟨a, Finset.mem_filter.mpr ⟨haA, show x - a ∈ B by
+              have : x - a = b := (eq_sub_of_add_eq hxab).symm
+              rw [this]; exact hbB⟩⟩
+          have hcard1 : (A.filter (fun a => x - a ∈ B)).card = 1 := by omega
+          obtain ⟨a₁, ha₁⟩ := Finset.card_eq_one.mp hcard1
+          have ha₁A : a₁ ∈ A :=
+            (Finset.mem_filter.mp (ha₁ ▸ Finset.mem_singleton_self a₁)).1
+          have hxnotin : x ∉ A.erase a₁ + B := by
+            intro hcontra
+            obtain ⟨a', ha'er, b', hb'B, hsum'⟩ := Finset.mem_add.mp hcontra
+            rw [Finset.mem_erase] at ha'er
+            have ha'filt : a' ∈ A.filter (fun a => x - a ∈ B) :=
+              Finset.mem_filter.mpr ⟨ha'er.2, (eq_sub_of_add_eq hsum') ▸ hb'B⟩
+            rw [ha₁] at ha'filt
+            exact ha'er.1 (Finset.mem_singleton.mp ha'filt)
+          exact hxnotin (hredA a₁ ha₁A ▸ hx)
+        -- Double counting: ∑_{x ∈ A+B} r(x) = |A| · |B|
+        -- Because the map (x, a) ↦ (a, x-a) bijects the sigma with A×B.
+        have hsum_eq : ∑ x ∈ A + B, (A.filter (fun a => x - a ∈ B)).card = A.card * B.card := by
+          rw [← Finset.card_sigma, ← Finset.card_product]
+          apply Finset.card_bij (fun xa _ => (xa.2, xa.1 - xa.2))
+          · intro ⟨x, a⟩ hmem
+            simp only [Finset.mem_sigma, Finset.mem_filter] at hmem
+            exact Finset.mem_product.mpr ⟨hmem.2.1, hmem.2.2⟩
+          · intro ⟨x₁, a₁⟩ _ ⟨x₂, a₂⟩ _ heq
+            simp only [Prod.mk.injEq] at heq
+            obtain ⟨ha, hd⟩ := heq
+            obtain rfl := ha  -- unify a₁ = a₂
+            -- hd : x₁ - a₁ = x₂ - a₁; need ⟨x₁, a₁⟩ = ⟨x₂, a₁⟩
+            have h1 : x₁ = x₂ := by
+              have := congr_arg (· + a₁) hd
+              simp only [sub_add_cancel] at this
+              exact this
+            simp [h1]
+          · intro (a, b) hmem
+            rw [Finset.mem_product] at hmem
+            obtain ⟨haA, hbB⟩ := hmem
+            exact ⟨⟨a + b, a⟩,
+              Finset.mem_sigma.mpr ⟨Finset.mem_add.mpr ⟨a, haA, b, hbB, rfl⟩,
+                Finset.mem_filter.mpr ⟨haA, show a + b - a ∈ B by
+                  convert hbB using 1; ring⟩⟩,
+              Prod.ext rfl (show a + b - a = b by ring)⟩
+        -- From hrep2: ∑_x r(x) ≥ 2 · |A+B| = 2 · (|A| + |B| - 1)
+        have hlb : 2 * (A + B).card ≤ ∑ x ∈ A + B, (A.filter (fun a => x - a ∈ B)).card :=
+          calc 2 * (A + B).card = ∑ _ ∈ A + B, 2 := by simp [Finset.sum_const, mul_comm]
+            _ ≤ _ := Finset.sum_le_sum hrep2
+        -- Combining: |A| · |B| ≥ 2 · (|A| + |B| - 1), i.e., (|A|-2)(|B|-2) ≥ 2
+        have hineq : 2 * (A.card + B.card - 1) ≤ A.card * B.card := by
+          have := hsum_eq ▸ h ▸ hlb; omega
+        -- For |A|=3, |B|=3: 2*(3+3-1)=10 ≤ 3*3=9 is false → contradiction
+        by_cases hAB3 : A.card = 3 ∧ B.card = 3
+        · obtain ⟨hA3eq, hB3eq⟩ := hAB3
+          rw [hA3eq, hB3eq] at hineq; norm_num at hineq
+        · -- |A| ≥ 4 or |B| ≥ 4: (|A|-2)(|B|-2) ≥ 2 holds, but Kneser's theorem is needed
+          -- to derive that A and B must be APs (not available in Mathlib)
+          sorry -- [HARD] Requires Kneser's theorem (not in Mathlib) for |A|≥4 or |B|≥4
     -- Step 2: Apply IH recursively to A' = A.erase a₀ and B.
     have hA'card : (A.erase a₀).card = A.card - 1 := Finset.card_erase_of_mem ha₀A
     have hA'2 : 2 ≤ (A.erase a₀).card := by omega

--- a/research/problems/erdos-476-oq-05-wip-01/knowledge.md
+++ b/research/problems/erdos-476-oq-05-wip-01/knowledge.md
@@ -1,12 +1,50 @@
 # Knowledge Base: erdos-476-oq-05-wip-01
 
+**Last Updated**: 2026-04-25
 Insights accumulated during research on this problem.
+
+---
+
+## Session 2026-04-25 (Session 2) — Counting Argument: |A|=|B|=3 Sub-case Proved
+
+**Mode**: REVISIT
+**Outcome**: progress
+
+### What I Did
+
+- Proved the `|A|=|B|=3` sub-case of the all-redundant contradiction in `Erdos476OQ05Problem.lean`
+- Implemented the counting argument: if all of A is redundant (∀ a, A.erase a + B = A + B), then
+  every x ∈ A+B has ≥ 2 distinct A-representations (r(x) ≥ 2). Double counting gives
+  |A|·|B| ≥ 2·|A+B| = 2(|A|+|B|-1). For |A|=|B|=3: 9 ≥ 10, contradiction.
+- Added `hrep2` (r(x) ≥ 2 for x ∈ A+B), `hsum_eq` (sigma bijection double counting), `hlb` (sum lower bound), `hineq` (counting bound)
+- The sorry now covers only `|A|≥4 or |B|≥4` (not all of `|B|≥3`)
+- Documented that Kneser's theorem is needed for the general case
+
+### Key Findings
+
+- **r(x) ≥ 2 proof**: If only a₁ ∈ A satisfies x-a₁ ∈ B, then x ∉ (A.erase a₁)+B, contradicting the SET equality hredA. Uses `Finset.card_eq_one` + contraposition.
+- **Double counting via sigma bijection**: `(A+B).sigma (fun x => A.filter (fun a => x-a ∈ B))` bijects to `A.product B` via `(x, a) ↦ (a, x-a)`. Used `Finset.card_bij` + `Finset.card_sigma` + `Finset.card_product`.
+- **Kneser barrier for general case**: For |A|≥4 or |B|≥4, the counting bound (|A|-2)(|B|-2) ≥ 2 is SATISFIED (not contradicted), so the counting argument gives no contradiction. Kneser's theorem is needed to derive that full redundancy forces a periodic structure — Kneser is NOT in Mathlib.
+- **Key Lean tactics**: `eq_sub_of_add_eq`, `sub_add_cancel`, `obtain rfl :=`, `congr_arg`
+
+### Files Modified
+
+- `proofs/Proofs/Erdos476OQ05Problem.lean` (809 → 874 lines)
+  - Lines 777-843: replaced single sorry with counting argument (~65 lines)
+  - `|A|=|B|=3` sub-case proved
+  - Still 1 sorry at line 843 for `|A|≥4 or |B|≥4`
+
+### Next Steps
+
+1. **Kneser's theorem**: The remaining sorry needs Kneser. Not in Mathlib. Would require ~200-300 lines of infrastructure. Assessment: BUILD is feasible but high-effort.
+2. **Alternative approach (Schur-like)**: Try Freiman's theorem for the case |A+B|=|A|+|B|-1. May have a more elementary proof path.
+3. **Submit `case1_exists` to Aristotle**: The Aristotle companion has a cleaner version of this lemma. Aristotle might fill in the counting argument part if the infrastructure is right.
 
 ---
 
 ## Problem Understanding
 
-**Goal**: Fill 2 sorries in `Erdos476OQ05Problem.lean` to complete Vosper's theorem.
+**Goal**: Fill the remaining sorry in `Erdos476OQ05Problem.lean` to complete Vosper's theorem.
 
 ### The Two Sorries
 

--- a/src/data/research/problems/erdos-476-oq-05-wip-01.json
+++ b/src/data/research/problems/erdos-476-oq-05-wip-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-476-oq-05-wip-01",
   "title": "Erdős #476 OQ5 — Complete Vosper's Theorem Inductive Step",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -16,7 +16,7 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "ACT",
     "since": "2026-04-22T15:58:45+02:00",
     "iteration": 1,
     "focus": "Initial problem understanding. Read problem.md and gather context.",
@@ -29,25 +29,33 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: case1_exists proved for |B|=2 via orbit argument; |B|≥3 branch sorryed as HARD",
+    "progressSummary": "PROGRESS: |A|=|B|=3 all-redundant case proved via counting; 1 sorry remains for |A|≥4 or |B|≥4 (needs Kneser)",
     "builtItems": [
       "case1_exists |B|=2 branch: fully proved via orbit argument (Erdos476OQ05Problem.lean ~550-609)",
       "hredA_card lemma inline: ∀ a ∈ A, (A.erase a + B).card = A.card + B.card - 1 from CD + inclusion",
       "hredA set equality inline: ∀ a ∈ A, A.erase a + B = A + B via Finset.eq_of_subset_of_card_le",
-      "horbit_nat by induction: a₀ + k*(b1-b2) ∈ A for all k : ℕ"
+      "horbit_nat by induction: a₀ + k*(b1-b2) ∈ A for all k : ℕ",
+      "hrep2 lemma: ∀ x ∈ A+B, 2 ≤ (A.filter (fun a => x-a ∈ B)).card — if r(x)=1, contradicts hredA (Erdos476OQ05Problem.lean ~781-803)",
+      "hsum_eq: ∑_x r(x) = |A|·|B| via sigma bijection (x,a) ↦ (a,x-a) (Erdos476OQ05Problem.lean ~806-829)",
+      "hineq: counting bound |A|·|B| ≥ 2(|A|+|B|-1) from hrep2 + hsum_eq (Erdos476OQ05Problem.lean ~835)",
+      "|A|=|B|=3 sub-case: 9 ≥ 10 contradiction via norm_num (Erdos476OQ05Problem.lean ~838-840)"
     ],
     "insights": [
       "case1_exists |B|=2 proved: orbit argument shows A closed under +(b1-b2) → |A| ≥ p (contradiction)",
       "Set equality A.erase(a)+B = A+B follows from: CD lower bound + inclusion upper bound + hall assumption",
       "Key pattern: Finset.eq_of_subset_of_card_le + cardinality from hredA_card proves set equality",
       "For |B|≥3: all-redundant contradiction needs Freiman-Ruzsa or stabilizer structure theorem — genuinely hard",
-      "The orbit argument uses zmod_orbit_injective (Fin p → ZMod p injective when d≠0) already in file"
+      "The orbit argument uses zmod_orbit_injective (Fin p → ZMod p injective when d≠0) already in file",
+      "r(x) ≥ 2 for all x ∈ A+B when A is all-redundant: if r(x)=1 with unique a₁, then x ∉ (A.erase a₁)+B, contradicting SET equality hredA a₁",
+      "Double counting identity: ∑_x |{a ∈ A : x-a ∈ B}| = |A|·|B| via Finset.card_bij bijection (x,a) ↦ (a,x-a)",
+      "Counting argument only closes |A|=|B|=3 (9 < 10); for |A|≥4 or |B|≥4, the bound (|A|-2)(|B|-2) ≥ 2 holds and Kneser is needed",
+      "Kneser theorem for ZMod p: NOT in Mathlib. Building it from scratch needs ~200-300 lines of additive combinatorics infrastructure"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove |B|≥3 all-redundant contradiction — requires period structure / Freiman-Ruzsa theory",
-      "Alternative: build stabilizer theorem (if |A+B|=|A+H| for subgroup H, then A+B = A+H) for ZMod p (trivial: H = {0} or ZMod p)",
-      "Vosper is complete modulo this one sorry — consider submitting |B|≥3 branch to Aristotle"
+      "Build Kneser theorem for ZMod p (~200-300 lines): Stab(A+B) is trivial for prime order groups, so |A+B| ≥ |A|+|B|-1 forces AP structure under full redundancy",
+      "Alternative: try elementary Freiman/Schur approach for the |A|≥4, |B|≥3 sub-case",
+      "If 3+ sessions stuck on Kneser: flag as BLOCKED and release claim"
     ],
     "markdown": "# Knowledge Base: erdos-476-oq-05-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

- Implements the double-counting argument for the all-redundant contradiction in Vosper's theorem (Erdős #476 OQ5)
- Proves `hrep2`: if all of A is redundant, every x ∈ A+B has ≥ 2 distinct A-representations
- Proves `hsum_eq`: ∑_{x∈A+B} r(x) = |A|·|B| via sigma bijection (x,a) ↦ (a,x-a)
- Closes the |A|=|B|=3 sub-case: counting gives 9 ≥ 10 (contradiction)
- The remaining sorry (line 843) now covers only |A|≥4 or |B|≥4, which requires Kneser's theorem (not in Mathlib)
- Also includes ballot-problem session 5 documentation from previous session

## Test plan

- [ ] Verify `proofs/Proofs/Erdos476OQ05Problem.lean` compiles with Docker: `./proofs/scripts/docker-build.sh Proofs.Erdos476OQ05Problem`
- [ ] Confirm 1 sorry remains at line ~843 (Kneser case)
- [ ] Check knowledge.md accurately reflects mathematical state

🤖 Generated with [Claude Code](https://claude.com/claude-code)