### PR TITLE
Fix: sync stale lineCount for ballot-problem and hurwitz-theorem-oq-04

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -89,7 +89,7 @@
       "LGV"
     ],
     "namespace": "HookLengthFormula",
-    "lineCount": 5274,
+    "lineCount": 5452,
     "axiomCount": 0,
     "sorries": 4,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",

--- a/src/data/proofs/hurwitz-theorem-oq-04/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-04/meta.json
@@ -121,7 +121,7 @@
       "HurwitzTheorem"
     ],
     "namespace": "HurwitzTheoremOQ04",
-    "lineCount": 730,
+    "lineCount": 736,
     "axiomCount": 1,
     "theoremCount": 31,
     "definitionCount": 14,


### PR DESCRIPTION
## Fix

Two gallery meta.json files have stale `lineCount` values after recent research PRs grew their Lean source files without updating gallery metadata.

## Evidence

**ballot-problem-oq-03-oq-01-oq-02**:
- `leanFile.lineCount`: 5274 → 5452 (+178 lines)
- Hook-length formula PRs (#12426, #12381, #12358, #12309) added significant content

**hurwitz-theorem-oq-04**:
- `leanFile.lineCount`: 730 → 736 (+6 lines)
- PR #12420 (de-axiomatize 4 trivial axioms + add Der(𝕆) Lie algebra) added 6 lines

All other metadata (sorries, axiomCount, status, badge) remains correct.

---
Automated fix by lean-mechanic agent.