### PR TITLE
Audit: fix badge for lagrange-four-squares-oq-01 (original→mathlib)

### DIFF
--- a/src/data/proofs/lagrange-four-squares-oq-01/meta.json
+++ b/src/data/proofs/lagrange-four-squares-oq-01/meta.json
@@ -15,11 +15,12 @@
       "quadratic-forms",
       "sums-of-squares"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified.",
+    "mathlibDependencies": [{"theorem": "Nat.sum_four_squares", "description": "Every natural number is a sum of four squares — used as foundation for four_square_exists_bounded", "module": "Mathlib.NumberTheory.SumFourSquares"}],
+    "assumptions": "Core existential result (four_square_exists_bounded) uses Mathlib's Nat.sum_four_squares. Algorithm, bounds, and verification proofs are independently proved.",
     "lineCount": 395,
     "theoremCount": 71,
     "definitionCount": 9,
@@ -31,7 +32,7 @@
       "Representation uniqueness analysis: 1, 2, 3, 5, 6, 7, 8 have unique sorted representations; first multiply-represented numbers identified",
       "isExcludedForm and excluded_form_check_50: detection of the 4^a(8b+7) form (Legendre's three-square theorem criterion)",
       "largest_component_bounds: \u221a(n/4) \u2264 a \u2264 \u221an for sorted representations",
-      "four_square_exists_bounded: Lagrange's theorem with all \u221an component bounds simultaneously"
+      "four_square_exists_bounded: derived from Mathlib's Nat.sum_four_squares, adds \u221an component bounds simultaneously"
     ]
   },
   "overview": {


### PR DESCRIPTION
## Summary

- Corrects `badge` from `"original"` to `"mathlib"` in `lagrange-four-squares-oq-01/meta.json`
- `four_square_exists_bounded` (line 278–281 of `LagrangeFourSquaresOQ01.lean`) calls `Nat.sum_four_squares` from `Mathlib.NumberTheory.SumFourSquares` for its core existential result — not an original proof
- Adds `mathlibDependencies` field documenting `Nat.sum_four_squares`
- Updates `assumptions` to accurately describe what is independently proved vs. what relies on Mathlib
- Updates `originalContributions` entry for `four_square_exists_bounded` to reflect Mathlib dependency

## Test plan

- [ ] Verify `badge` field is `"mathlib"` in updated meta.json
- [ ] Verify `mathlibDependencies` lists `Nat.sum_four_squares` from `Mathlib.NumberTheory.SumFourSquares`
- [ ] Verify `assumptions` accurately describes the Mathlib dependency
- [ ] Confirm gallery build (`pnpm build`) succeeds with updated meta

🤖 Generated with [Claude Code](https://claude.com/claude-code)