### PR TITLE
feat(newton-oq-03): gallery entry for log-concavity of Gaussian binomial coefficients

### DIFF
--- a/src/data/proofs/newton-inductive-step-oq-03/annotations.json
+++ b/src/data/proofs/newton-inductive-step-oq-03/annotations.json
@@ -1,0 +1,145 @@
+[
+  {
+    "id": "ann-newton-oq03-overview",
+    "proofId": "newton-inductive-step-oq-03",
+    "range": {
+      "startLine": 1,
+      "endLine": 41
+    },
+    "type": "concept",
+    "title": "Log-Concavity of Gaussian Binomial Coefficients",
+    "content": "**Gaussian binomial coefficients** $\\binom{n}{k}_q$ are q-analogs of ordinary binomial coefficients, counting k-dimensional subspaces of an n-dimensional vector space over $\\mathbb{F}_q$. For $q \\in (0,1)$, they satisfy the **log-concavity** inequality: $\\binom{n}{k+1}_q^2 \\geq \\binom{n}{k}_q \\cdot \\binom{n}{k+2}_q$. This file gives a complete Lean 4 proof with **0 sorries and 0 axioms**, using a ratio recurrence and a key q-power monotonicity inequality.",
+    "mathContext": "At $q \\to 1$, the Gaussian binomial $\\binom{n}{k}_q \\to \\binom{n}{k}$ (ordinary binomial). Log-concavity of binomial coefficients ($\\binom{n}{k}^2 \\geq \\binom{n}{k-1}\\binom{n}{k+1}$) is a classical result. The q-analog for Gaussian binomials is proved here by a direct ratio argument. The key identity: the consecutive ratio $\\binom{n}{k+1}_q / \\binom{n}{k}_q = (1-q^{n-k})/(1-q^{k+1})$ is antitone in k for $q \\in (0,1)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Gaussian binomial coefficients",
+      "q-Pochhammer products",
+      "log-concavity",
+      "unimodal sequences",
+      "finite vector space subspace counting"
+    ],
+    "prerequisites": [
+      "Ordinary binomial coefficients",
+      "q-analogs in combinatorics",
+      "Monotonicity of q^n for q ∈ (0,1)"
+    ]
+  },
+  {
+    "id": "ann-newton-oq03-gaussbinom-def",
+    "proofId": "newton-inductive-step-oq-03",
+    "range": {
+      "startLine": 56,
+      "endLine": 63
+    },
+    "type": "definition",
+    "title": "qPoch and gaussBinom: q-Pochhammer and Gaussian Binomial",
+    "content": "**qPoch n q** = $\\prod_{i=1}^n (1 - q^i)$ is the q-Pochhammer product (q-analog of $n!$). **gaussBinom n k q** = $\\frac{\\prod_{i=0}^{k-1}(1-q^{n-i})}{\\text{qPoch}\\,k\\,q}$ is the Gaussian binomial coefficient. Both are `noncomputable` since they produce real numbers. The definition uses `Finset.range k` as the index set.",
+    "mathContext": "The q-Pochhammer product $[n]_q! = (1-q)(1-q^2)\\cdots(1-q^n)$ satisfies $[0]_q! = 1$ (empty product). The Gaussian binomial numerator $\\prod_{i=0}^{k-1}(1-q^{n-i})$ counts from the top: $(1-q^n)(1-q^{n-1})\\cdots(1-q^{n-k+1})$. At $q=0$: gaussBinom $n$ $k$ $0 = 1$ for all $k \\leq n$. At $q \\to 1$: recovers $\\binom{n}{k}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "q-Pochhammer product",
+      "q-factorial",
+      "Finset.prod in Lean 4",
+      "noncomputable for ℝ"
+    ],
+    "prerequisites": [
+      "Finset.range in Lean 4",
+      "Finset.prod",
+      "Real number arithmetic"
+    ]
+  },
+  {
+    "id": "ann-newton-oq03-positivity",
+    "proofId": "newton-inductive-step-oq-03",
+    "range": {
+      "startLine": 65,
+      "endLine": 83
+    },
+    "type": "technique",
+    "title": "Positivity via Finset.prod_pos",
+    "content": "**gaussBinom_pos** establishes $\\binom{n}{k}_q > 0$ for $q \\in (0,1)$ and $k \\leq n$. The proof uses `Finset.prod_pos` to show each factor $1 - q^m > 0$ for $m \\geq 1$ (since $q^m < 1$). Positivity of the denominator qPoch and numerator follows identically. The lemma `one_sub_pow_pos` is the key local helper.",
+    "mathContext": "For $q \\in (0,1)$ and $m \\geq 1$: $q^m < q^0 = 1$ by `pow_lt_one`, so $1 - q^m > 0$. The q-Pochhammer product qPoch $n$ $q = \\prod_{i=1}^n(1-q^i)$ is a product of positive terms, hence positive. The numerator of gaussBinom is similarly a product of positive terms when $k \\leq n$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Finset.prod_pos",
+      "pow_lt_one for q ∈ (0,1)",
+      "div_pos"
+    ],
+    "prerequisites": [
+      "Finset.prod_pos in Mathlib",
+      "pow_lt_one",
+      "Real.div_pos"
+    ]
+  },
+  {
+    "id": "ann-newton-oq03-ratio-recurrence",
+    "proofId": "newton-inductive-step-oq-03",
+    "range": {
+      "startLine": 89,
+      "endLine": 101
+    },
+    "type": "technique",
+    "title": "Ratio Recurrence via prod_range_succ + field_simp",
+    "content": "**gaussBinom_ratio_mul** proves $G(k+1) \\cdot (1-q^{k+1}) = G(k) \\cdot (1-q^{n-k})$ by unfolding both Finset products using `Finset.prod_range_succ`, then using `field_simp + ring` to cancel the common factor qPoch $k$ $q > 0$. This is the multiplication form of the ratio formula $\\binom{n}{k+1}_q / \\binom{n}{k}_q = (1-q^{n-k})/(1-q^{k+1})$.",
+    "mathContext": "The ratio recurrence is the q-analog of $\\binom{n}{k+1} / \\binom{n}{k} = (n-k)/(k+1)$. It expresses the key structure: the numerator gains a factor $(1-q^{n-k})$ while the denominator gains $(1-q^{k+1})$. Unfolding `Finset.prod_range_succ` on both sides simultaneously reveals the common qPoch $k$ $q$ factor which `field_simp` can cancel.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.prod_range_succ",
+      "field_simp for division cancellation",
+      "q-binomial ratio formula"
+    ],
+    "prerequisites": [
+      "Finset.prod_range_succ",
+      "field_simp",
+      "positivity of qPoch"
+    ]
+  },
+  {
+    "id": "ann-newton-oq03-key-ineq",
+    "proofId": "newton-inductive-step-oq-03",
+    "range": {
+      "startLine": 107,
+      "endLine": 117
+    },
+    "type": "technique",
+    "title": "Key q-Power Inequality: Two Applications of pow_le_pow_of_le_one",
+    "content": "**q_pow_key_ineq** proves $q^{n-k} + q^k \\geq q^n + q^{n+1}$ for $q \\in (0,1)$ and $k \\leq n$. The proof applies `pow_le_pow_of_le_one` twice: $q^{n-k} \\geq q^n$ (since $n-k \\leq n$) and $q^k \\geq q^{n+1}$ (since $k \\leq n < n+1$). Then `add_le_add` combines them. This is the arithmetically essential inequality for the log-concavity proof.",
+    "mathContext": "The inequality says: summing the two 'extreme' exponents $n-k$ and $k$ (which average to $n/2$) dominates summing $n$ and $n+1$ (which are both $\\geq n/2$ when $k \\leq n/2$, and one is ≥ and one is equal). The Chebyshev-rearrangement perspective: $q^a + q^b \\geq q^c + q^d$ when $\\{a,b\\}$ is 'more spread' than $\\{c,d\\}$ and $a+b = c+d$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "pow_le_pow_of_le_one for q ∈ (0,1)",
+      "add_le_add",
+      "monotone decrease of geometric sequences"
+    ],
+    "prerequisites": [
+      "pow_le_pow_of_le_one in Mathlib",
+      "Nat.sub_le",
+      "omega for natural number arithmetic"
+    ]
+  },
+  {
+    "id": "ann-newton-oq03-log-concave",
+    "proofId": "newton-inductive-step-oq-03",
+    "range": {
+      "startLine": 154,
+      "endLine": 208
+    },
+    "type": "proof",
+    "title": "Log-Concavity via linear_combination + ratio recurrences",
+    "content": "**gaussBinom_log_concave** (the main theorem) proves $G(k+1)^2 \\geq G(k) \\cdot G(k+2)$ by: (1) applying two ratio recurrences to get $G_1 D_1 = G_0 N_0$ and $G_2 D_2 = G_1 N_1$; (2) computing via `linear_combination` that $G_1^2 D_1 D_2 - G_0 G_2 D_1 D_2 = G_0 G_1 (N_0 D_2 - N_1 D_1)$; (3) using `ratio_ineq` to get $N_1 D_1 \\leq N_0 D_2$; (4) dividing by $D_1 D_2 > 0$.",
+    "mathContext": "The algebraic core: $G_1^2 D_1 D_2 - G_0 G_2 D_1 D_2 = G_0 G_1(N_0 D_2 - N_1 D_1)$ follows from substituting the ratio recurrences. This is proved by `linear_combination G1 * D2 * hrec1 - G0 * D1 * hrec2` — a single linear combination tactic. The final step divides by $D_1 D_2 > 0$ using `field_simp` after establishing the nonnegativity of the right side.",
+    "significance": "breakthrough",
+    "relatedConcepts": [
+      "linear_combination tactic in Lean 4",
+      "ratio recurrence for Gaussian binomials",
+      "ratio_ineq (antitone step)",
+      "div_pos for final conclusion"
+    ],
+    "prerequisites": [
+      "gaussBinom_ratio_mul (two applications)",
+      "ratio_ineq (the antitone step)",
+      "gaussBinom_pos (positivity)",
+      "linear_combination tactic"
+    ]
+  }
+]

--- a/src/data/proofs/newton-inductive-step-oq-03/index.ts
+++ b/src/data/proofs/newton-inductive-step-oq-03/index.ts
@@ -1,0 +1,46 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+// Type assertion for JSON import
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+// Import the Lean source file
+const leanSource = () => import('../../../../proofs/Proofs/NewtonInductiveStepOQ03.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '', // Loaded dynamically
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const proofData: ProofData = {
+  proof,
+  annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/newton-inductive-step-oq-03/meta.json
+++ b/src/data/proofs/newton-inductive-step-oq-03/meta.json
@@ -1,0 +1,141 @@
+{
+  "id": "newton-inductive-step-oq-03",
+  "title": "Log-Concavity of Gaussian Binomial Coefficients",
+  "slug": "newton-inductive-step-oq-03",
+  "description": "Formalizes log-concavity of Gaussian binomial coefficients (q-analogs of C(n,k)): gaussBinom n (k+1) q² ≥ gaussBinom n k q · gaussBinom n (k+2) q for q ∈ (0,1) and k+2 ≤ n. Proved via a ratio recurrence and a key q-power inequality.",
+  "meta": {
+    "author": "Formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Gaussian_binomial_coefficient",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/NewtonInductiveStepOQ03.lean",
+    "tags": [
+      "combinatorics",
+      "q-analogs",
+      "log-concavity",
+      "gaussian-binomial",
+      "newton-inequality",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 231,
+    "dateAdded": "2026-04-25",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.prod_pos",
+        "description": "Positivity of finite products",
+        "module": "Mathlib.Algebra.BigOperators.Order"
+      },
+      {
+        "theorem": "pow_le_pow_of_le_one",
+        "description": "Monotone decrease of q^n for q ∈ (0,1)",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      },
+      {
+        "theorem": "Finset.prod_range_succ",
+        "description": "Unfolding a product over range n+1",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset"
+      }
+    ],
+    "originalContributions": [
+      "Definition of qPoch (q-Pochhammer product) and gaussBinom (Gaussian binomial coefficient)",
+      "gaussBinom_pos: Gaussian binomial coefficients are positive for q ∈ (0,1)",
+      "gaussBinom_ratio_mul: ratio recurrence G(k+1)·(1-q^{k+1}) = G(k)·(1-q^{n-k})",
+      "q_pow_key_ineq: q^{n-k} + q^k ≥ q^n + q^{n+1} for q ∈ (0,1), k ≤ n",
+      "ratio_ineq: (1-q^{n-k})(1-q^k) ≤ (1-q^{n-k+1})(1-q^{k+1}) (ratio antitone in k)",
+      "gaussBinom_log_concave: G(k+1)² ≥ G(k)·G(k+2) — the main log-concavity theorem"
+    ],
+    "assumptions": "0 axiom declarations, 0 sorries. Fully machine-checked.",
+    "prerequisites": [
+      "Gaussian binomial coefficients and their recurrence",
+      "q-Pochhammer products",
+      "Monotonicity of q^n for q ∈ (0,1)",
+      "Finset products in Lean 4"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Gaussian binomial coefficients (also called q-binomial coefficients) were introduced by Gauss in the context of counting k-dimensional subspaces of an n-dimensional vector space over a field with q elements. They arise in the theory of q-analogs, quantum groups, and combinatorics of finite fields.\n\nLog-concavity of Gaussian binomial coefficients was established by various authors and is a q-analog of the classical log-concavity of ordinary binomial coefficients C(n,k). The result states that the sequence gaussBinom n k q (for k=0,1,...,n) forms a log-concave sequence for fixed n and q ∈ (0,1).",
+    "problemStatement": "For $q \\in (0,1)$ and natural numbers $k, n$ with $k+2 \\leq n$, define the Gaussian binomial coefficient:\n\n$$\\binom{n}{k}_q = \\frac{\\prod_{i=0}^{k-1}(1-q^{n-i})}{\\prod_{i=1}^{k}(1-q^i)}$$\n\nProve the log-concavity inequality:\n\n$$\\binom{n}{k+1}_q^2 \\geq \\binom{n}{k}_q \\cdot \\binom{n}{k+2}_q$$",
+    "text": "Formalizes log-concavity of Gaussian binomial coefficients for q ∈ (0,1). The proof proceeds via a ratio recurrence relating consecutive Gaussian binomial coefficients and a key monotonicity inequality for q-powers.",
+    "proofStrategy": "1. **Define qPoch and gaussBinom** using Finset.prod over ranges\n2. **Prove positivity** (gaussBinom_pos) via Finset.prod_pos and 1-q^m > 0 for m ≥ 1\n3. **Prove the ratio recurrence** (gaussBinom_ratio_mul): G(k+1)·(1-q^{k+1}) = G(k)·(1-q^{n-k}) via prod_range_succ + field_simp\n4. **Prove the key q-power inequality** (q_pow_key_ineq): q^{n-k}+q^k ≥ q^n+q^{n+1} using pow_le_pow_of_le_one twice\n5. **Prove ratio antitone** (ratio_ineq): expand (1-Aq)(1-Bq)-(1-A)(1-B) = (1-q)(A+B-AB-ABq) by ring, then apply key_ineq\n6. **Prove log-concavity** (gaussBinom_log_concave): use both ratio recurrences to express G1²-G0·G2 as G0·G1·(N0·D2-N1·D1) ≥ 0"
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Gaussian Binomial Coefficients",
+      "startLine": 52,
+      "endLine": 63,
+      "summary": "Definition of qPoch (q-Pochhammer product) and gaussBinom (Gaussian binomial coefficient) using Finset.prod.",
+      "mathContext": "The q-Pochhammer product $[n]_q! = \\prod_{i=1}^n (1-q^i)$ and the Gaussian binomial $\\binom{n}{k}_q = \\prod_{i=0}^{k-1}(1-q^{n-i}) / [k]_q!$ are the q-analogs of factorial and binomial coefficient."
+    },
+    {
+      "id": "positivity",
+      "title": "Positivity for q ∈ (0,1)",
+      "startLine": 65,
+      "endLine": 83,
+      "summary": "Proves gaussBinom n k q > 0 for q ∈ (0,1) and k ≤ n via positivity of each factor 1-q^m.",
+      "mathContext": "For q ∈ (0,1) and m ≥ 1: 1-q^m > 0 since q^m < 1. The product qPoch n q > 0 and the numerator product > 0, so their ratio gaussBinom n k q > 0."
+    },
+    {
+      "id": "ratio-recurrence",
+      "title": "Ratio Recurrence",
+      "startLine": 85,
+      "endLine": 101,
+      "summary": "Proves G(k+1)·(1-q^{k+1}) = G(k)·(1-q^{n-k}) — the multiplication form of G(k+1)/G(k) = (1-q^{n-k})/(1-q^{k+1}).",
+      "mathContext": "The Gaussian binomial satisfies $\\binom{n}{k+1}_q / \\binom{n}{k}_q = (1-q^{n-k}) / (1-q^{k+1})$. This is the q-analog of $(k+1)\\binom{n}{k+1} = (n-k)\\binom{n}{k}$. Proved by unfolding Finset.prod_range_succ and applying field_simp."
+    },
+    {
+      "id": "key-inequality",
+      "title": "Key q-Power Inequality",
+      "startLine": 103,
+      "endLine": 117,
+      "summary": "Proves q^{n-k} + q^k ≥ q^n + q^{n+1} for q ∈ (0,1) and k ≤ n using monotonicity of q^a.",
+      "mathContext": "Since q ∈ (0,1), q^a is decreasing: q^{n-k} ≥ q^n (as n-k ≤ n) and q^k ≥ q^{n+1} (as k ≤ n < n+1). Adding gives the inequality. This is the arithmetically critical step enabling log-concavity."
+    },
+    {
+      "id": "ratio-antitone",
+      "title": "Ratio Antitone",
+      "startLine": 119,
+      "endLine": 148,
+      "summary": "Proves (1-q^{n-k})(1-q^k) ≤ (1-q^{n-k+1})(1-q^{k+1}) — the ratio G(k+1)/G(k) is decreasing in k.",
+      "mathContext": "The algebraic identity (1-Aq)(1-Bq)-(1-A)(1-B) = (1-q)(A+B-AB-ABq) reduces ratio antitone to q_pow_key_ineq with A=q^{n-k}, B=q^k, giving AB = q^n and ABq = q^{n+1}."
+    },
+    {
+      "id": "log-concavity",
+      "title": "Log-Concavity Main Theorem",
+      "startLine": 150,
+      "endLine": 208,
+      "summary": "Main result: G(k+1)² ≥ G(k)·G(k+2) for q ∈ (0,1) and k+2 ≤ n.",
+      "mathContext": "Using ratio recurrences G1·D1 = G0·N0 and G2·D2 = G1·N1, we compute G1²·D1·D2 - G0·G2·D1·D2 = G0·G1·(N0·D2 - N1·D1) ≥ 0 by ratio_ineq. Dividing by D1·D2 > 0 gives G1² ≥ G0·G2. The key step uses linear_combination."
+    }
+  ],
+  "conclusion": {
+    "summary": "We give a complete Lean 4 formalization of log-concavity of Gaussian binomial coefficients with 0 sorries and 0 axioms. The proof formalizes the ratio recurrence, a key q-power monotonicity inequality, and uses linear_combination to close the main algebraic identity.",
+    "implications": "Gaussian binomial coefficients appear in the combinatorics of finite vector spaces (counting k-dimensional subspaces of F_q^n), quantum groups, and q-series identities. The log-concavity property has applications in unimodality of q-analog sequences and the study of symmetric Macdonald polynomials.",
+    "openQuestions": [
+      "Ultra-log-concavity: is the sequence C(n,k)_q · k! / (k!)_q log-concave in a stronger sense?",
+      "Generalize to quantum group q-binomials where q is a root of unity",
+      "Log-concavity of q-Stirling numbers by analogous ratio arguments"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "newton-inductive-step",
+      "relationship": "extends",
+      "description": "q-analog extension: replaces ordinary binomial C(n,k) with Gaussian binomial coefficients; the log-concavity proof strategy parallels the classical Newton inequality"
+    },
+    {
+      "targetId": "newton-inductive-step-oq-01",
+      "relationship": "related",
+      "description": "OQ-01 proves log-concavity of elementary symmetric means; OQ-03 proves the q-analog for Gaussian binomials — both use ratio recurrences and algebraic identities"
+    },
+    {
+      "targetId": "newton-inductive-step-oq-02",
+      "relationship": "related",
+      "description": "OQ-02 formalizes Newton's inequality for general symmetric polynomials; OQ-03 focuses on the q-analog setting"
+    }
+  ]
+}

--- a/src/data/research/problems/newton-inductive-step-oq-03.json
+++ b/src/data/research/problems/newton-inductive-step-oq-03.json
@@ -1,8 +1,8 @@
 {
   "slug": "newton-inductive-step-oq-03",
   "title": "Newton's Identity: Extension to q-Binomial and Log-Concavity",
-  "phase": "NEW",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {
@@ -16,8 +16,8 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-04-22T13:03:46.506Z",
+    "phase": "COMPLETED",
+    "since": "2026-04-25T10:00:00Z",
     "iteration": 1,
     "focus": "Initial exploration of the problem.",
     "blockers": [],
@@ -29,9 +29,24 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETE: 0 sorries, 0 axioms. Log-concavity of Gaussian binomials proved. Gallery entry created.",
+    "builtItems": [
+      "NewtonInductiveStepOQ03.lean: gaussBinom_pos (positivity for q∈(0,1))",
+      "NewtonInductiveStepOQ03.lean: gaussBinom_ratio_mul (ratio recurrence)",
+      "NewtonInductiveStepOQ03.lean: q_pow_key_ineq (key q-power monotonicity)",
+      "NewtonInductiveStepOQ03.lean: ratio_ineq (ratio antitone in k)",
+      "NewtonInductiveStepOQ03.lean: gaussBinom_log_concave (main log-concavity theorem)",
+      "src/data/proofs/newton-inductive-step-oq-03/meta.json (gallery entry created)",
+      "src/data/proofs/newton-inductive-step-oq-03/annotations.json (6 annotations)",
+      "src/data/proofs/newton-inductive-step-oq-03/index.ts (TypeScript export)"
+    ],
+    "insights": [
+      "gaussBinom_log_concave proved via ratio recurrence + linear_combination tactic",
+      "Key step: G1^2*D1*D2 - G0*G2*D1*D2 = G0*G1*(N0*D2-N1*D1) closes by linear_combination",
+      "q_pow_key_ineq (q^{n-k}+q^k >= q^n+q^{n+1}) uses pow_le_pow_of_le_one twice",
+      "ratio_ineq (ratio antitone) follows from algebraic identity (1-Aq)(1-Bq)-(1-A)(1-B) = (1-q)(A+B-AB-ABq)",
+      "Lean file was already complete (0 sorries) — gallery entry was the missing piece"
+    ],
     "mathlibGaps": [],
     "nextSteps": []
   },


### PR DESCRIPTION
## Summary

- Creates gallery entry for `NewtonInductiveStepOQ03.lean` — a **complete Lean 4 proof** (0 sorries, 0 axioms) of log-concavity of Gaussian binomial coefficients
- Updates `src/data/research/problems/newton-inductive-step-oq-03.json` to completed status

## Mathematical Content

**Theorem**: For $q \in (0,1)$ and $k+2 \leq n$:
$$\binom{n}{k+1}_q^2 \geq \binom{n}{k}_q \cdot \binom{n}{k+2}_q$$

where $\binom{n}{k}_q$ is the Gaussian binomial coefficient (q-analog of $C(n,k)$, counting $k$-dim subspaces of $\mathbb{F}_q^n$).

**Key theorems formalized**:
- `gaussBinom_pos`: positivity for $q \in (0,1)$
- `gaussBinom_ratio_mul`: ratio recurrence $G(k+1) \cdot (1-q^{k+1}) = G(k) \cdot (1-q^{n-k})$
- `q_pow_key_ineq`: $q^{n-k} + q^k \geq q^n + q^{n+1}$ for $q \in (0,1)$, $k \leq n$
- `ratio_ineq`: $(1-q^{n-k})(1-q^k) \leq (1-q^{n-k+1})(1-q^{k+1})$ (ratio antitone)
- `gaussBinom_log_concave`: main log-concavity theorem via `linear_combination`

## Files Added

- `src/data/proofs/newton-inductive-step-oq-03/meta.json` — 6 sections, 6 original contributions
- `src/data/proofs/newton-inductive-step-oq-03/annotations.json` — 6 annotations
- `src/data/proofs/newton-inductive-step-oq-03/index.ts` — TypeScript export

## Test plan

- [ ] Gallery entry renders correctly on the website
- [ ] `pnpm build` succeeds (listings.json auto-regenerated)
- [ ] Lean file path in meta.json matches `proofs/Proofs/NewtonInductiveStepOQ03.lean`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)