### PR TITLE
Fix: sync stale lineCount for sperner-ndim-oq-04

### DIFF
--- a/src/data/proofs/sperner-ndim-oq-04/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-04/meta.json
@@ -42,7 +42,7 @@
     ],
     "dateAdded": "2026-04-22",
     "axiomCount": 1,
-    "lineCount": 779,
+    "lineCount": 734,
     "assumptions": "1 axiom declaration: kuhn_path_existential_ax encodes Kuhn's walk-pairing involution argument (τ∘τ=id via walk reversibility + non-revisiting = no fixed points). Non-revisiting is fully proved (kuhn_step_nonrevisit + WalkValid); walk reversibility is the remaining open formalization step. 0 sorries.",
     "mathlib_version": "4.26.0"
   },
@@ -247,7 +247,7 @@
       "BigOperators"
     ],
     "namespace": "SpernerNDimOQ04",
-    "lineCount": 779,
+    "lineCount": 734,
     "axiomCount": 1,
     "theoremCount": 20,
     "definitionCount": 8,


### PR DESCRIPTION
## Fix

Updated stale `lineCount` in `sperner-ndim-oq-04/meta.json` to match the actual committed Lean source.

## Evidence

**Before**: `meta.lineCount: 779`, `leanFile.lineCount: 779`
**After**: `meta.lineCount: 734`, `leanFile.lineCount: 734`

Verified: `git show HEAD:proofs/Proofs/SpernerNDimOQ04.lean | wc -l` → 734

All other integrity claims remain correct (sorries: 0, axiomCount: 1, status: axiomatized, badge: axiom).

Closes #12445

---
Automated fix by lean-mechanic agent.