### PR TITLE
Fix: ballot-problem-oq-03-oq-01-oq-02 sorry count 4→5 (gallery integrity)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "ballot-problem-oq-03-oq-01-oq-02",
   "title": "Hook-Length Formula for Standard Young Tableaux via LGV",
   "slug": "ballot-problem-oq-03-oq-01-oq-02",
-  "description": "Formalizes the hook-length formula f^λ = n!/∏h(u) for Standard Young Tableaux. Fully proves the formula for single-row (1×n), single-column (n×1), hook-shape ((m+1,1)), 2-row rectangular (m×m), and general 2-row [a,b] families. General formula has 4 sorries: 3 via LGV approach (RSK bijection, det factorization, main theorem) + 1 for corner induction (hook_walk_identity ≥3-row case). hookProd_ratio_formula now proved (session 18). hook_length_formula_general proved via corner induction modulo hook_walk_identity.",
+  "description": "Formalizes the hook-length formula f^λ = n!/∏h(u) for Standard Young Tableaux. Fully proves the formula for single-row (1×n), single-column (n×1), hook-shape ((m+1,1)), 2-row rectangular (m×m), and general 2-row [a,b] families. General formula has 5 sorries: 3 via LGV approach (RSK bijection, det factorization, main theorem) + 2 for hook walk identity (3-row case + ≥4-row case). hookProd_ratio_formula now proved (session 18). hook_length_formula_general proved via corner induction modulo hook_walk_identity.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-21",
@@ -19,10 +19,10 @@
       "representation-theory"
     ],
     "badge": "wip",
-    "sorries": 4,
+    "sorries": 5,
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "assumptions": "Four open sorries: (1) hook_length_formula (LGV approach: requires SYT↔NI bijection + det factorization), (2) ni_count_eq_syt_count (Fomin/Viennot/RSK correspondence), (3) lgv_det_factors_as_hook_quotient (det factorization identity), (4) hook_walk_identity ≥3-row case (GNW or RSK, ~300 lines; at-most-2-row case proved; hookProd_ratio_formula now fully proved session 18). hook_length_formula_general is proved modulo hook_walk_identity via Part XIV corner induction.",
+    "assumptions": "Five open sorries: (1) hook_length_formula (LGV approach: requires SYT↔NI bijection + det factorization), (2) ni_count_eq_syt_count (Fomin/Viennot/RSK correspondence), (3) lgv_det_factors_as_hook_quotient (det factorization identity), (4) hook_walk_identity_threeRow (exactly-3-row case, private lemma), (5) hook_walk_identity ≥4-row case (GNW or RSK, ~300 lines; at-most-2-row case proved; gHookYD case proved session 19; hookProd_ratio_formula now fully proved session 18). hook_length_formula_general is proved modulo hook_walk_identity via Part XIV corner induction.",
     "lineCount": 5146,
     "theoremCount": 162,
     "definitionCount": 14,
@@ -42,8 +42,8 @@
       "hook_length_formula_two_row_gen: formula for general 2-row [a,b] (1 sorry: card_SYT_twoRowYD)",
       "Numerical verification: hook-length formula proved for (2,1), (2,2), (3,1), (3,2), (3,2,1), (4,3,2,1), (3,3), (4,4) shapes",
       "hook_length_formula_gHookYD: HLF for all generalized hook shapes [a, 1^b] (card = C(a+b-1,b), proved via double induction + inline bijection, 0 sorries)",
-      "hookProd_ratio_formula: hookProd(μ)/hookProd(μ\\c) equals product over arm × product over leg (1 sorry: ~50 lines Finset.prod_union decomposition)",
-      "hook_walk_identity: sum over corners c of hookProd(μ)/hookProd(μ\\c) = μ.card — at-most-2-row case proved; ≥3-row case has 1 sorry (~300 lines GNW/RSK)",
+      "hookProd_ratio_formula: hookProd(μ)/hookProd(μ\\c) equals product over arm × product over leg (proved, 0 sorries)",
+      "hook_walk_identity: sum over corners c of hookProd(μ)/hookProd(μ\\c) = μ.card — at-most-2-row case proved; gHookYD case proved (session 19); 3-row case has 1 sorry; ≥4-row case has 1 sorry (~300 lines GNW/RSK)",
       "hook_length_formula_general: HLF for all Young diagrams via corner induction (proved modulo hook_walk_identity, 0 sorries in the theorem itself)"
     ]
   },
@@ -68,7 +68,7 @@
     ]
   },
   "conclusion": {
-    "summary": "Hook-length formula fully proved for five infinite families: 1×n (direct), n×1 (direct), hook-shape (m+1,1) (bijection), 2×m rect (Lindstrom reflection), and general 2-row [a,b] (conditional on ballot bijection, 1 sorry). hookProd for [a,b] = (a+1).descFactorial(b) × (a-b)! × b! proved with 0 sorries. Part XIV adds hook_length_formula_general as the primary result, proved via corner induction modulo hook_walk_identity. Total: 5 sorries (3 LGV path + 2 corner induction: hookProd_ratio_formula + hook_walk_identity ≥3-row).",
+    "summary": "Hook-length formula fully proved for five infinite families: 1×n (direct), n×1 (direct), hook-shape (m+1,1) (bijection), 2×m rect (Lindstrom reflection), and general 2-row [a,b] (conditional on ballot bijection, 1 sorry). hookProd for [a,b] = (a+1).descFactorial(b) × (a-b)! × b! proved with 0 sorries. Part XIV adds hook_length_formula_general as the primary result, proved via corner induction modulo hook_walk_identity. Total: 5 sorries (3 LGV path + 2 hook_walk_identity: 3-row case + ≥4-row case).",
     "implications": "A complete formalization would be the first Lean 4 proof of the hook-length formula, a milestone in formal combinatorics. The LGV approach connects our existing ballot problem proofs to representation theory via the Specht module dimension formula f^λ = dim S^λ.",
     "openQuestions": [
       "Formalize the SYT ↔ NI bijection via Fomin's growth diagrams or the RSK correspondence (~200 lines)",
@@ -89,7 +89,7 @@
     "namespace": "HookLengthFormula",
     "lineCount": 5146,
     "axiomCount": 0,
-    "sorries": 4,
+    "sorries": 5,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",
     "theoremCount": 100,
     "definitionCount": 14
@@ -170,9 +170,9 @@
       "title": "Part XIV: hook_length_formula_general via Corner Induction",
       "startLine": 4600,
       "endLine": 4725,
-      "summary": "Proves hook_length_formula_general by well-founded induction on μ.card, using card_SYT_corner_step (Part XIII) + hook_walk_identity (2 sorries: hookProd_ratio_formula + ≥3-row case). hook_length_formula_Q is the ℚ version proved by WF induction.",
+      "summary": "Proves hook_length_formula_general by well-founded induction on μ.card, using card_SYT_corner_step (Part XIII) + hook_walk_identity (2 sorries: 3-row case + ≥4-row case). hook_length_formula_Q is the ℚ version proved by WF induction.",
       "mathContext": "hook_walk_identity: Σ_c hookProd(μ)/hookProd(μ\\c) = μ.card. The main theorem reduces to hook_length_formula_Q via exact_mod_cast."
     }
   ],
-  "sorries": 4
+  "sorries": 5
 }


### PR DESCRIPTION
## Summary

- **Auditor-detected integrity fix**: the Lean file `Proofs/BallotProblemOQ03OQ01OQ02.lean` has 5 actual sorry statements, but `meta.json` claimed 4
- The 5th sorry is `hook_walk_identity_threeRow` (private lemma for exactly-3-row case at line 5408)
- Also corrects `hookProd_ratio_formula` status from "(1 sorry)" to "(proved, 0 sorries)" since it was fully proved in session 18
- Updates `hook_walk_identity` description to reflect the 3-row / >=4-row split instead of the stale ">=3-row case has 1 sorry"

## Changes to `src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json`

1. `meta.sorries`: 4 -> 5
2. `leanFile.sorries`: 4 -> 5
3. Top-level `sorries`: 4 -> 5
4. `description`: updated sorry count and breakdown text
5. `assumptions`: updated from "Four open sorries" to "Five open sorries" with correct enumeration
6. `originalContributions.hookProd_ratio_formula`: "(1 sorry: ~50 lines ...)" -> "(proved, 0 sorries)"
7. `originalContributions.hook_walk_identity`: updated to reflect gHookYD proved + 3-row/>=4-row split
8. `conclusion.summary`: corrected sorry breakdown
9. `sections.sec-corner-induction.summary`: corrected sorry breakdown

## Test plan

- [x] JSON is valid (verified with `python3 -m json.tool`)
- [x] All three `sorries` fields consistently show 5
- [x] No other files modified

Generated with [Claude Code](https://claude.com/claude-code)