### PR TITLE
feat(shannon-source-coding-oq-04): prove type_class_size_le_entropy_pow and dominant_type_lower_bound

### DIFF
--- a/proofs/Proofs/ShannonSourceCodingOQ04.lean
+++ b/proofs/Proofs/ShannonSourceCodingOQ04.lean
@@ -1,5 +1,6 @@
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
 import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Mathlib.Combinatorics.Pigeonhole
 import Mathlib.Data.Nat.Choose.Multinomial
 import Mathlib.Data.Fintype.Card
 import Mathlib.Tactic
@@ -156,18 +157,74 @@ theorem log_typeProb_eq (n : ℕ) (hn : (n : ℝ) ≠ 0) (f : Fin k → ℕ)
       = ((n : ℝ) * ((f i : ℝ) / n)) * Real.log ((f i : ℝ) / n) := by rw [hkey]
     _ = (n : ℝ) * ((f i : ℝ) / n * Real.log ((f i : ℝ) / n)) := by ring
 
-/-- **Type Class Size Upper Bound**: |T_f| ≤ 2^{n H(f/n)}.
+/-- **Type Class Size Upper Bound**: |T_f| ≤ exp(n H(f/n)).
 
-    Proof: The sum over all sequences of probability under Q = f/n is at most 1.
-    Each sequence x ∈ T_f has p_Q(x) = ∏ Q_i^{f_i} = exp(-n H(Q)).
-    So |T_f| * exp(-n H(Q)) ≤ ∑_x p_Q(x) ≤ 1.
-    Therefore |T_f| ≤ exp(n H(Q)) = 2^{n H(Q) / log 2}.
-    [OPEN: ~30 lines using Finset.sum_le_card_nsmul] -/
+    Proof: Let Q = f/n be the empirical distribution (sums to 1).
+    For x ∈ T_f: ∏ j, Q(x_j) = ∏ i, Q(i)^{f_i} = typeProb = exp(-n H(Q)).
+    Sum over all sequences: ∑_x ∏ j, Q(x_j) = (∑ i, Q(i))^n = 1^n = 1.
+    So |T_f| * exp(-n H(Q)) ≤ ∑_x ∏ j, Q(x_j) = 1.
+    Therefore |T_f| ≤ exp(n H(Q)). -/
 theorem type_class_size_le_entropy_pow (n : ℕ) (hn : 0 < n) (f : Fin k → ℕ)
     (hf : ∑ i, f i = n) (hf_pos : ∀ i, 0 < f i) :
     ((typeClass n f hf).card : ℝ) ≤
     Real.exp ((n : ℝ) * empEntropy n (Nat.cast_pos.mpr hn).ne' f) := by
-  sorry
+  set hn' : (n : ℝ) ≠ 0 := (Nat.cast_pos.mpr hn).ne'
+  -- Q = empirical distribution f/n
+  let Q : Fin k → ℝ := fun i => (f i : ℝ) / n
+  -- Q sums to 1
+  have hQsum : ∑ i : Fin k, Q i = 1 := by
+    simp only [Q, ← Finset.sum_div, ← Nat.cast_sum, hf]
+    exact div_self hn'
+  -- Q i > 0 for all i
+  have hQpos : ∀ i, 0 < Q i := fun i =>
+    div_pos (Nat.cast_pos.mpr (hf_pos i)) (Nat.cast_pos.mpr hn)
+  -- typeProb n hn' f > 0 (product of positives)
+  have htypeProb_pos : 0 < typeProb n hn' f := by
+    simp only [typeProb]
+    exact Finset.prod_pos (fun i _ => pow_pos (hQpos i) _)
+  -- typeProb = exp(-(n * empEntropy))
+  have htypeProb_exp : typeProb n hn' f = Real.exp (-(n : ℝ) * empEntropy n hn' f) := by
+    rw [← log_typeProb_eq n hn' f (fun i => hQpos i), Real.exp_log htypeProb_pos]
+  -- For x ∈ T_f: ∏ j : Fin n, Q (x j) = typeProb
+  have hseqProb_const : ∀ x ∈ typeClass n f hf,
+      ∏ j : Fin n, Q (x j) = typeProb n hn' f := by
+    intro x hx
+    simp only [typeClass, Finset.mem_filter, Finset.mem_univ, true_and] at hx
+    -- hx : empDist n x = f
+    simp only [typeProb, Q]
+    -- Regroup positions by their alphabet value using prod_fiberwise'
+    rw [← Finset.prod_fiberwise' Finset.univ x (fun j => (f j : ℝ) / ↑n)]
+    apply Finset.prod_congr rfl
+    intro b _
+    -- ∏ a ∈ univ with x a = b, (f b / n) = (f b / n) ^ (f b)
+    rw [Finset.prod_const]
+    congr 1
+    -- (filter card) = f b; follows from empDist n x b = f b
+    change empDist n x b = f b
+    exact congr_fun hx b
+  -- ∑ x : Fin n → Fin k, ∏ j, Q (x j) = 1
+  have hsum_one : ∑ x : Fin n → Fin k, ∏ j : Fin n, Q (x j) = 1 := by
+    -- ∏ i : Fin n, ∑ j ∈ univ, Q j = ∑ x ∈ piFinset, ∏ i, Q (x i)
+    have h := Finset.prod_univ_sum (κ := fun _ : Fin n => Fin k)
+                 (fun _ => Finset.univ) (fun _ j => Q j)
+    simp only [hQsum, Finset.prod_const_one, Fintype.piFinset_univ] at h
+    simpa using h.symm
+  -- |T_f| * typeProb ≤ 1 by sum estimate
+  have h_key : ((typeClass n f hf).card : ℝ) * typeProb n hn' f ≤ 1 :=
+    calc ((typeClass n f hf).card : ℝ) * typeProb n hn' f
+        = ∑ _ ∈ typeClass n f hf, typeProb n hn' f := by
+          rw [Finset.sum_const, nsmul_eq_mul, mul_comm]
+      _ = ∑ x ∈ typeClass n f hf, ∏ j : Fin n, Q (x j) :=
+          Finset.sum_congr rfl (fun x hx => (hseqProb_const x hx).symm)
+      _ ≤ ∑ x : Fin n → Fin k, ∏ j : Fin n, Q (x j) :=
+          sum_le_univ_sum_of_nonneg (fun x =>
+            Finset.prod_nonneg (fun j _ => le_of_lt (hQpos (x j))))
+      _ = 1 := hsum_one
+  -- Conclude: |T_f| ≤ exp(n H(Q))
+  calc ((typeClass n f hf).card : ℝ)
+      ≤ 1 / typeProb n hn' f := (le_div_iff htypeProb_pos).mpr h_key
+    _ = Real.exp ((n : ℝ) * empEntropy n hn' f) := by
+        rw [htypeProb_exp, one_div, ← Real.exp_neg, neg_neg]
 
 /-- **Lower bound**: The dominant type class has size ≥ k^n / (n+1)^k.
     Since there are at most (n+1)^k distinct types and all sequences sum to k^n,
@@ -175,7 +232,55 @@ theorem type_class_size_le_entropy_pow (n : ℕ) (hn : 0 < n) (f : Fin k → ℕ
 theorem dominant_type_lower_bound (n : ℕ) :
     ∃ f : Fin k → ℕ, ∃ hf : ∑ i, f i = n,
     k ^ n / (n + 1) ^ k ≤ (typeClass n f hf).card := by
-  sorry
+  -- Trivial case: bound is 0, any type works
+  by_cases hm : k ^ n / (n + 1) ^ k = 0
+  · -- Exhibit the constant-zero sequence's type
+    let x₀ : Fin n → Fin k := fun _ => ⟨0, Nat.pos_of_ne_zero (NeZero.ne k)⟩
+    exact ⟨empDist n x₀, empDist_sum n x₀, hm ▸ Nat.zero_le _⟩
+  · -- Map sequences to Fin k → Fin (n+1) via bounded empDist
+    -- empDist n x i counts elements of Fin n, so ≤ n < n+1
+    have h_bound : ∀ (x : Fin n → Fin k) (i : Fin k), empDist n x i ≤ n := fun x i =>
+      (Finset.card_filter_le _ _).trans (by simp [Finset.card_univ, Fintype.card_fin])
+    -- Define the map F : sequences → (Fin k → Fin (n+1))
+    let F : (Fin n → Fin k) → (Fin k → Fin (n + 1)) :=
+      fun x i => ⟨empDist n x i, Nat.lt_succ_of_le (h_bound x i)⟩
+    -- Target Finset T = all functions Fin k → Fin (n+1), card = (n+1)^k
+    have hT_nonempty : (Finset.univ : Finset (Fin k → Fin (n + 1))).Nonempty :=
+      Finset.univ_nonempty
+    have hT_card : (Finset.univ : Finset (Fin k → Fin (n + 1))).card = (n + 1) ^ k := by
+      simp [Fintype.card_pi, Fintype.card_fin]
+    -- Domain card = k^n
+    have hS_card : (Finset.univ : Finset (Fin n → Fin k)).card = k ^ n := by
+      simp [Fintype.card_pi, Fintype.card_fin]
+    -- Pigeonhole bound: (n+1)^k * (k^n / (n+1)^k) ≤ k^n
+    have hpig : (Finset.univ : Finset (Fin k → Fin (n + 1))).card * (k ^ n / (n + 1) ^ k) ≤
+        (Finset.univ : Finset (Fin n → Fin k)).card := by
+      rw [hT_card, hS_card]
+      exact (mul_comm _ _).le.trans (Nat.div_mul_le_self _ _)
+    -- Apply pigeonhole: ∃ y : Fin k → Fin (n+1) with large fiber
+    obtain ⟨y, _, hy_card⟩ := Finset.exists_le_card_fiber_of_mul_le_card_of_maps_to
+      (f := F) (t := Finset.univ)
+      (fun _ _ => Finset.mem_univ _) hT_nonempty hpig
+    -- The fiber {x | F x = y} is nonempty (since bound > 0)
+    have h_pos : 0 < (Finset.univ.filter fun x : Fin n → Fin k => F x = y).card :=
+      (Nat.pos_of_ne_zero hm).trans_le hy_card
+    obtain ⟨x₀, hx₀⟩ := Finset.card_pos.mp h_pos
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hx₀
+    -- From F x₀ = y, extract: empDist n x₀ = Fin.val ∘ y
+    have h_empDist_eq : empDist n x₀ = fun i => (y i).val := by
+      funext i; exact (Fin.ext_iff.mp (congr_fun hx₀ i)).symm
+    -- So ∑ i, (Fin.val ∘ y) i = n
+    have hf₀ : ∑ i : Fin k, (y i).val = n := by
+      rw [← h_empDist_eq]; exact empDist_sum n x₀
+    -- The fiber equals the type class for f₀ = Fin.val ∘ y
+    have h_eq : Finset.univ.filter (fun x : Fin n → Fin k => F x = y) =
+        typeClass n (fun i => (y i).val) hf₀ := by
+      ext x
+      simp only [Finset.mem_filter, Finset.mem_univ, true_and, typeClass, F]
+      constructor
+      · intro h; funext i; exact (Fin.ext_iff.mp (congr_fun h i)).symm
+      · intro h; funext i; exact Fin.ext (congr_fun h i).symm
+    exact ⟨fun i => (y i).val, hf₀, h_eq ▸ hy_card⟩
 
 /-!
 ## Section 3: Source Coding via Method of Types

--- a/research/problems/shannon-source-coding-oq-04/knowledge.md
+++ b/research/problems/shannon-source-coding-oq-04/knowledge.md
@@ -6,16 +6,91 @@ Insights accumulated during research on this problem.
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+The method of types (Csiszár-Körner 1981) gives a combinatorial proof of Shannon's source
+coding theorem. Key objects:
+- `empDist n x i` = #{j : x j = i} (empirical distribution of sequence x)
+- `typeClass n f hf` = {x : Fin n → Fin k | empDist n x = f} (type class)
+- `shannonEntropy p` = -∑ p_i * log p_i (Shannon entropy)
+- `empEntropy n hn f` = shannonEntropy of (f i / n) (empirical entropy)
+- `typeProb n hn f` = ∏ i, (f i / n)^(f i) = exp(-n H(f/n)) (probability weight per sequence in type class)
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+### Proved Theorems (Session 2026-04-25)
+
+**`type_class_size_le_entropy_pow`**: |T_f| ≤ exp(n H(Q)) proved via probability argument:
+1. For x ∈ T_f, `∏ j, Q(x j) = typeProb n hn f` (proved via `Finset.prod_fiberwise'`)
+   - `prod_fiberwise'` rewrites `∏ j : Fin n, Q (x j)` into `∏ b : Fin k, Q b ^ (empDist n x b)`
+   - Since x ∈ T_f means empDist n x = f, this equals `∏ i, Q i ^ (f i) = typeProb`
+2. Total probability = 1: `∑ x : Fin n → Fin k, ∏ j, Q (x j) = 1` via `Finset.prod_univ_sum`
+   - `prod_univ_sum` gives: `∏ i, (∑ j, f i j) = ∑ x ∈ piFinset, ∏ i, f i (x i)`
+   - With f i j = Q j (constant in i): ∏ i, (∑ j, Q j) = ∏ i, 1 = 1
+   - `Fintype.piFinset_univ`: piFinset (fun _ => univ) = univ
+3. |T_f| * typeProb ≤ 1 via `sum_le_univ_sum_of_nonneg`
+4. |T_f| ≤ 1/typeProb = exp(n H(Q)) via `le_div_iff` + exp algebra
+
+**`dominant_type_lower_bound`**: ∃ f, |T_f| ≥ k^n / (n+1)^k proved via pigeonhole:
+1. Map sequences to Fin k → Fin (n+1) via empDist (values in {0,...,n})
+2. Apply `Finset.exists_le_card_fiber_of_mul_le_card_of_maps_to` (requires `import Mathlib.Combinatorics.Pigeonhole`)
+3. Convert fiber to type class using `empDist_sum` for sum constraint
+
+### Key Mathlib Lemmas
+
+- `Finset.prod_fiberwise'`: groups `∏ j ∈ s, f (g j)` by value of g — crucial for rewriting
+  sequence product as type-indexed product
+- `Finset.prod_univ_sum`: `∏ i, ∑ j, f i j = ∑ x ∈ piFinset, ∏ i, f i (x i)`
+  (product of sums = sum of products; multinomial expansion)
+- `Fintype.piFinset_univ`: `piFinset (fun _ => Finset.univ) = Finset.univ`
+  (converts piFinset form to Finset.univ for total probability sum)
+- `Finset.exists_le_card_fiber_of_mul_le_card_of_maps_to`: pigeonhole for cardinality
+  (requires `import Mathlib.Combinatorics.Pigeonhole` — not auto-imported via Mathlib.Tactic)
+- `sum_le_univ_sum_of_nonneg`: ∑ x ∈ s, f x ≤ ∑ x : α, f x when f ≥ 0
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+**Forward references**: Lean 4 does not allow forward references. `total_sequences_eq` (defined in Section 4)
+cannot be used in `dominant_type_lower_bound` (Section 2). Fix: inline the proof.
+
+**Missing import**: `Finset.exists_le_card_fiber_of_mul_le_card_of_maps_to` requires explicit
+`import Mathlib.Combinatorics.Pigeonhole` — not available via `Mathlib.Tactic` alone.
+
+---
+
+## Remaining Sorries
+
+1. **`type_class_size_eq_multinomial`** (HARD): |T_f| = n! / ∏(f i)! — requires explicit bijection
+   between type class and multiset arrangements. ~60 lines. Aristotle candidate.
+
+2. **`source_coding_achievability_mot`** (OPEN): Formal achievability at rate H(p) + ε.
+   Requires concentration inequalities and formal coding rate definition. Not tractable soon.
+
+---
+
+## Session 2026-04-25 (Session 1) — Proved 2 of 4 Sorries
+
+**Mode**: FRESH
+**Outcome**: PROGRESS — 4 → 2 sorries
+
+### What I Did
+
+1. Surveyed meta.json and existing Lean file structure
+2. Proved `type_class_size_le_entropy_pow` via probability argument
+3. Proved `dominant_type_lower_bound` via pigeonhole
+4. Added `import Mathlib.Combinatorics.Pigeonhole` to imports
+5. Fixed build errors: forward reference (inlined `total_sequences_eq`), missing import
+
+### Files Modified
+
+- `proofs/Proofs/ShannonSourceCodingOQ04.lean` (247 → 352 lines, 4 → 2 sorries)
+- `src/data/proofs/shannon-source-coding-oq-04/meta.json` (updated sorries, lineCount, contributions)
+- `research/problems/shannon-source-coding-oq-04/knowledge.md` (this file)
+
+### Next Steps
+
+1. Submit `type_class_size_eq_multinomial` to Aristotle (HARD — known bijection, ~60 lines)
+2. Leave `source_coding_achievability_mot` as OPEN (requires LLN/concentration infrastructure)
+3. Advance phase to ACT

--- a/src/data/proofs/shannon-source-coding-oq-04/meta.json
+++ b/src/data/proofs/shannon-source-coding-oq-04/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "wip",
-    "sorries": 4,
+    "sorries": 2,
     "mathlibDependencies": [
       {
         "theorem": "Real.log_pow",
@@ -34,6 +34,21 @@
         "theorem": "Nat.multinomial",
         "description": "Multinomial coefficients for type class size formula",
         "module": "Mathlib.Data.Nat.Choose.Multinomial"
+      },
+      {
+        "theorem": "Finset.exists_le_card_fiber_of_mul_le_card_of_maps_to",
+        "description": "Pigeonhole principle for fiber cardinality — used in dominant_type_lower_bound",
+        "module": "Mathlib.Combinatorics.Pigeonhole"
+      },
+      {
+        "theorem": "Finset.prod_univ_sum",
+        "description": "Product of sums equals sum of products over pi-type — used in type_class_size_le_entropy_pow",
+        "module": "Mathlib.Algebra.BigOperators.Pi"
+      },
+      {
+        "theorem": "Finset.prod_fiberwise'",
+        "description": "Regroups product by fiber value — used to show constant probability over type class",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset"
       }
     ],
     "originalContributions": [
@@ -42,13 +57,13 @@
       "count_types_le: at most (n+1)^k distinct empirical distributions (proved)",
       "total_sequences_eq: k^n total sequences over Fin k alphabet (proved)",
       "empEntropy_eq_shannonEntropy: empirical entropy matches Shannon entropy of normalized type (proved)",
-      "log_typeProb_eq: log-probability of type class weight equals -n * H(Q) (proved)"
+      "log_typeProb_eq: log-probability of type class weight equals -n * H(Q) (proved)",
+      "type_class_size_le_entropy_pow: |T_f| ≤ exp(n H(Q)) via probability argument (proved)",
+      "dominant_type_lower_bound: dominant type class ≥ k^n/(n+1)^k via pigeonhole (proved)"
     ],
     "assumptions": [
       "type_class_size_eq_multinomial: |T_f| = n!/∏(f_i)! (bijection proof omitted, ~60 lines)",
-      "type_class_size_le_entropy_pow: |T_f| ≤ exp(n H(Q)) (requires sum-of-products identity)",
-      "dominant_type_lower_bound: largest type class ≥ k^n/(n+1)^k (pigeonhole)",
-      "source_coding_achievability_mot: formal achievability proof (convergence argument)"
+      "source_coding_achievability_mot: formal achievability proof (requires concentration inequalities)"
     ],
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
@@ -98,10 +113,10 @@
     },
     {
       "id": "type-class-size-bound",
-      "title": "Type Class Size Upper Bound (sorry)",
+      "title": "Type Class Size Upper Bound (proved)",
       "startLine": 159,
-      "endLine": 195,
-      "summary": "type_class_size_le_entropy_pow: |T_f| ≤ exp(n H(Q)). Sorry: requires sum-of-products identity and ENNReal lifting. Also includes type_class_partition (proved).",
+      "endLine": 230,
+      "summary": "type_class_size_le_entropy_pow: |T_f| ≤ exp(n H(Q)) proved via prob_fiberwise' + prod_univ_sum. dominant_type_lower_bound: proved via Finset pigeonhole. type_class_partition: proved.",
       "mathContext": "$|T_f| \\cdot e^{-nH(Q)} \\leq \\sum_{x \\in T_f} Q^n(x) \\leq 1$ since probabilities sum to 1."
     },
     {
@@ -151,6 +166,7 @@
     "imports": [
       "Mathlib.Analysis.SpecialFunctions.Log.Basic",
       "Mathlib.Analysis.SpecialFunctions.Pow.Real",
+      "Mathlib.Combinatorics.Pigeonhole",
       "Mathlib.Data.Nat.Choose.Multinomial",
       "Mathlib.Data.Fintype.Card",
       "Mathlib.Tactic"
@@ -161,12 +177,12 @@
       "BigOperators"
     ],
     "namespace": "MethodOfTypes",
-    "lineCount": 247,
+    "lineCount": 352,
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 4,
     "path": "Proofs/ShannonSourceCodingOQ04.lean",
-    "sorries": 4
+    "sorries": 2
   },
   "references": [
     {
@@ -184,5 +200,5 @@
       "note": "Chapter 11 gives a clear exposition of the method of types"
     }
   ],
-  "sorries": 4
+  "sorries": 2
 }

--- a/src/data/research/problems/shannon-source-coding-oq-04.json
+++ b/src/data/research/problems/shannon-source-coding-oq-04.json
@@ -1,7 +1,7 @@
 {
   "slug": "shannon-source-coding-oq-04",
   "title": "Method of Types as Alternative Proof of Shannon Source Coding",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "C",
   "path": "full",
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-04-21T04:57:28-07:00",
-    "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "phase": "ACT",
+    "since": "2026-04-25T00:00:00-07:00",
+    "iteration": 2,
+    "focus": "Proved type_class_size_le_entropy_pow and dominant_type_lower_bound. 2 sorries remain.",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "Submit type_class_size_eq_multinomial to Aristotle for proof search.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,11 +29,24 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": [],
+    "progressSummary": "PROGRESS: Proved type_class_size_le_entropy_pow and dominant_type_lower_bound. 4→2 sorries.",
+    "builtItems": [
+      "type_class_size_le_entropy_pow: |T_f| ≤ exp(n H(Q)) proved via prod_fiberwise' + prod_univ_sum (ShannonSourceCodingOQ04.lean:166)",
+      "dominant_type_lower_bound: dominant type class ≥ k^n/(n+1)^k proved via Finset pigeonhole (ShannonSourceCodingOQ04.lean:175)"
+    ],
+    "insights": [
+      "prod_fiberwise' rewrites ∏ j:Fin n, Q(x j) as ∏ i:Fin k, Q(i)^(empDist n x i) for any x — key for equating sequence probability to type probability",
+      "prod_univ_sum (product of sums = sum over piFinset of products) gives total probability = 1 without EN NReal lifting",
+      "Finset.exists_le_card_fiber_of_mul_le_card_of_maps_to is in Mathlib.Combinatorics.Pigeonhole — NOT auto-imported via Mathlib.Tactic",
+      "Lean 4 forward reference issue: theorems defined later in file cannot be used earlier; must inline proofs"
+    ],
+    "mathlibGaps": [
+      "Fintype.card_fiber_eq_multinomial: if it exists, could prove type_class_size_eq_multinomial directly"
+    ],
+    "nextSteps": [
+      "Submit type_class_size_eq_multinomial to Aristotle — HARD sorry, explicit bijection ~60 lines",
+      "Leave source_coding_achievability_mot as OPEN (requires concentration inequalities)"
+    ],
     "markdown": "# Knowledge Base: shannon-source-coding-oq-04\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [
@@ -93,11 +106,11 @@
     {
       "path": "Proofs/ShannonSourceCodingOQ04.lean",
       "filename": "ShannonSourceCodingOQ04.lean",
-      "lineCount": 248,
-      "theoremCount": 11,
+      "lineCount": 352,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 4,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonSourceCodingOQ04.lean"
     },


### PR DESCRIPTION
## Summary

Reduces sorry count in `ShannonSourceCodingOQ04.lean` from **4 → 2** by proving the two core combinatorial results of the method of types.

### Proved Theorems

**`type_class_size_le_entropy_pow`**: |T_f| ≤ exp(n H(Q))
- Strategy: probability argument — each x ∈ T_f has the same probability typeProb under Q = f/n
- Key lemmas: `Finset.prod_fiberwise'` (rewrites sequence product as type-indexed product), `Finset.prod_univ_sum` (total probability = 1 without ENNReal lifting)
- Closes: sum-of-products identity gap noted in original meta.json

**`dominant_type_lower_bound`**: ∃ f, |T_f| ≥ k^n/(n+1)^k  
- Strategy: pigeonhole via `Finset.exists_le_card_fiber_of_mul_le_card_of_maps_to`
- Required adding `import Mathlib.Combinatorics.Pigeonhole` (not auto-imported via Mathlib.Tactic)
- Fixed forward reference issue (inlined `total_sequences_eq` proof)

### Remaining Sorries (2)
- `type_class_size_eq_multinomial`: bijection between type class and multinomial arrangements (~60 lines, Aristotle candidate)
- `source_coding_achievability_mot`: requires concentration inequalities and formal coding rate definition (OPEN)

## Files Changed
- `proofs/Proofs/ShannonSourceCodingOQ04.lean`: 247 → 352 lines, 4 → 2 sorries
- `src/data/proofs/shannon-source-coding-oq-04/meta.json`: updated sorry count, lineCount, contributions
- `research/problems/shannon-source-coding-oq-04/knowledge.md`: session notes and Mathlib lemma catalogue
- `src/data/research/problems/shannon-source-coding-oq-04.json`: phase OBSERVE→ACT, knowledge entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)