### PR TITLE
shannon-source-coding-oq-04: update Aristotle companion for type_class_size_eq_multinomial

### DIFF
--- a/proofs/Proofs/ShannonSourceCodingOQ04Aristotle.lean
+++ b/proofs/Proofs/ShannonSourceCodingOQ04Aristotle.lean
@@ -3,16 +3,16 @@
   Routine supporting lemmas for automated proof search.
   See ShannonSourceCodingOQ04.lean for the main formalization.
 
-  Targets:
-  - empDist_sum: empirical distribution counts sum to block length n
-  - typeProb_pos: type probability is positive when all empirical counts are positive
-  - typeProb_eq_exp_neg: typeProb = exp(-n H_emp(Q)) via log identity
-  - type_class_size_le_entropy_pow: |T_f| ≤ exp(n H(f/n)) (method of types key bound)
-  - dominant_type_lower_bound: pigeonhole bound on largest type class size
+  PRIMARY TARGET (Session 2):
+  - type_class_size_eq_multinomial: |T_f| = n! / ∏(f i)! (multinomial counting fact)
+
+  Previously proved in main file (included here for context, no sorries):
+  - empDist_sum', typeProb_pos', log_typeProb_eq'
+  Note: type_class_size_le_entropy_pow and dominant_type_lower_bound
+  were proved in the main file (PR #12457); removed from this companion file.
 
   NOT included:
-  - type_class_size_eq_multinomial (requires ~60-line bijection argument)
-  - source_coding_achievability_mot (main theorem; assembles the above)
+  - source_coding_achievability_mot (OPEN: needs LLN/concentration inequalities)
 -/
 import Mathlib
 
@@ -115,41 +115,35 @@ theorem log_typeProb_eq' (n : ℕ) (hn : (n : ℝ) ≠ 0)
     _ = (n : ℝ) * ((f i : ℝ) / n * Real.log ((f i : ℝ) / n)) := by ring
 
 -- ============================================================
--- Target 4: Type class size ≤ exp(n H_emp(Q))
+-- PRIMARY TARGET: Type class size = multinomial coefficient
 -- ============================================================
 
-/-- **Type Class Size Upper Bound** (method of types key lemma).
+/-- **Type class size equals the multinomial coefficient**: |T_f| = n! / ∏(f i)!
 
-    For any type f with ∑ f i = n and all f i > 0:
-      |T_f| ≤ exp(n H(f/n))
+    This is the fundamental counting fact of the method of types (Csiszár-Körner 1981).
 
-    Proof sketch (probability argument):
-    1. Each x ∈ typeClass'(f) satisfies empDist' n x = f (by definition)
-    2. Assign Q-probability: prob(x) = ∏_i (f_i/n)^{f_i} = typeProb' (constant on T_f)
-    3. ∑_{x : Fin n → Fin k} prob(x) ≤ 1 (multinomial normalization)
-    4. ∑_{x ∈ T_f} prob(x) = |T_f| * typeProb' (sum of constant = card times value)
-    5. So |T_f| * typeProb' ≤ 1, hence |T_f| ≤ exp(n H(Q)) = 1/typeProb'. -/
-theorem type_class_size_le_entropy_pow' (n : ℕ) (hn : 0 < n) (f : Fin k → ℕ)
-    (hf : ∑ i, f i = n) (hf_pos : ∀ i, 0 < f i) :
-    ((typeClass' n f hf).card : ℝ) ≤
-    Real.exp ((n : ℝ) * empEntropy' n (Nat.cast_pos.mpr hn).ne' f) := by
-  sorry
+    Proof approach 1 (INDUCTION ON n):
+    - Base n=0: one empty function, multinomial = 0!/1 = 1. ✓
+    - Inductive step: partition T_f by the last element x(Fin.last n).
+      For v with f(v) > 0: {x ∈ T_f | x(n) = v} ≅ T_{f[v ↦ f(v)-1]}
+      via the bijection x ↦ x ∘ Fin.castSucc (drop last element).
+      Pascal identity: multinomial(f) = ∑_{v:f(v)>0} multinomial(f[v↦f(v)-1])
+      follows from: ∏(f i)! * multinomial(f) = n! (multinomial_spec) and
+      ∏(f i)! * multinomial(update f v (f(v)-1)) = f(v) * (n-1)!
+      (since ∏(update f v (f(v)-1) i)! = ∏(f i)! / f(v)).
 
--- ============================================================
--- Target 5: Dominant type class lower bound (pigeonhole)
--- ============================================================
+    Proof approach 2 (PERMUTATION QUOTIENT):
+    - Define canonical sequence C_f : Fin n → Fin k where position j maps to i
+      if ∑_{l<i} f l ≤ j < ∑_{l≤i} f l (sorted multiset arrangement).
+    - Map σ : Equiv.Perm (Fin n) ↦ C_f ∘ σ ∈ T_f.
+    - Fiber over each x ∈ T_f has size ∏(f i)! (permutations within each preimage block).
+    - Therefore |T_f| = n! / ∏(f i)! = multinomial (by multinomial_spec).
 
-/-- **Dominant Type Lower Bound** (pigeonhole principle).
-
-    There exists a type f with ∑ f i = n such that its type class satisfies
-      |T_f| ≥ k^n / (n+1)^k
-
-    Proof: There are k^n total sequences (Fintype.card (Fin n → Fin k) = k^n)
-    and at most (n+1)^k distinct types (each type maps Fin k to {0,...,n}).
-    By pigeonhole, some type class has size ≥ k^n / (n+1)^k. -/
-theorem dominant_type_lower_bound' (n : ℕ) :
-    ∃ f : Fin k → ℕ, ∃ hf : ∑ i, f i = n,
-    k ^ n / (n + 1) ^ k ≤ (typeClass' n f hf).card := by
+    Key lemmas:
+    - Nat.multinomial_spec: ∏(f i)! * multinomial univ f = (∑ f i)! = n!
+    - Fintype.card_perm: (Finset.univ : Finset (Equiv.Perm (Fin n))).card = n! -/
+theorem type_class_size_eq_multinomial (n : ℕ) (f : Fin k → ℕ) (hf : ∑ i, f i = n) :
+    (typeClass' n f hf).card = Nat.multinomial Finset.univ f := by
   sorry
 
 end ShannonSourceCodingOQ04Aristotle

--- a/research/problems/shannon-source-coding-oq-04/knowledge.md
+++ b/research/problems/shannon-source-coding-oq-04/knowledge.md
@@ -94,3 +94,43 @@ cannot be used in `dominant_type_lower_bound` (Section 2). Fix: inline the proof
 1. Submit `type_class_size_eq_multinomial` to Aristotle (HARD — known bijection, ~60 lines)
 2. Leave `source_coding_achievability_mot` as OPEN (requires LLN/concentration infrastructure)
 3. Advance phase to ACT
+
+---
+
+## Session 2026-04-25 (Session 2) — Companion File Updated for Aristotle
+
+**Mode**: REVISIT
+**Outcome**: INFRASTRUCTURE — Aristotle companion file updated with `type_class_size_eq_multinomial`
+
+### What I Did
+
+1. Rebased onto origin/main to incorporate session 1 changes (PR #12457)
+2. Updated `ShannonSourceCodingOQ04Aristotle.lean`: removed stale sorries, added new target
+3. Documented two complete proof strategies for `type_class_size_eq_multinomial`
+4. Attempted Aristotle submission — blocked by full disk (`/Users/rwalters/.cache/uv/` full)
+
+### Proof Strategies for type_class_size_eq_multinomial
+
+**Strategy 1: Induction on n**
+- Base n=0: unique empty function = 1 = multinomial(f)
+- Step: partition T_f by x(Fin.last n) = v. For fv > 0:
+  {x ∈ T_f | x(n) = v} ≅ T_{f[v↦fv-1]} via x ↦ x ∘ Fin.castSucc
+- Pascal identity: ∑_{v:fv>0} multinomial(f[v↦fv-1]) = multinomial(f)
+  Proof: ∏(f i)! * ∑ = ∑ fv * (n-1)! = n * (n-1)! = n! = ∏(f i)! * multinomial(f)
+
+**Strategy 2: Permutation quotient**
+- C_f: canonical sequence (sorted), positions ∑_{l<i} fl ... ∑_{l≤i} fl map to i
+- Surjection Perm(Fin n) → T_f via σ ↦ C_f ∘ σ
+- Fiber size = ∏(f i)! ⟹ |T_f| = n!/∏(f i)! = multinomial (by multinomial_spec)
+
+### Files Modified
+
+- `proofs/Proofs/ShannonSourceCodingOQ04Aristotle.lean` (companion file updated)
+- `research/problems/shannon-source-coding-oq-04/knowledge.md` (this file)
+
+### Next Steps
+
+1. Free disk space, then submit companion file to Aristotle:
+   `bash research/scripts/aristotle-submit.sh proofs/Proofs/ShannonSourceCodingOQ04Aristotle.lean shannon-source-coding-oq-04 "Session 2: type_class_size_eq_multinomial"`
+2. If Aristotle fails/unavailable: implement induction proof manually (~100 lines, see strategy above)
+3. `source_coding_achievability_mot` remains OPEN (needs LLN infrastructure)

--- a/src/data/proofs/erdos-476-oq-05/meta.json
+++ b/src/data/proofs/erdos-476-oq-05/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-476-oq-05",
   "title": "Erdős #476 OQ5: Vosper's Theorem — Equality Case of Cauchy-Davenport",
   "slug": "erdos-476-oq-05",
-  "description": "Vosper's theorem (1956): if |A+B| = |A|+|B|-1 in Z/pZ with |A|,|B|≥2 and |A+B|<p, then A and B are arithmetic progressions with the same common difference d. Infrastructure fully proved: IsArithmeticProgression definition, singleton/pair AP lemmas, translation invariance, ap_of_near_periodic (backward-shift induction), and vosper_base (|A|=2 case). Full Vosper induction (1 sorry) remains open.",
+  "description": "Vosper's theorem (1956): if |A+B| = |A|+|B|-1 in Z/pZ with |A|,|B|≥2 and |A+B|<p, then A and B are arithmetic progressions with the same common difference d. Fully proved: all infrastructure, vosper_base, vosper_ap_sdiff_card, and the |B|=2 and |A|=|B|=3 sub-cases of case1_exists. One sorry remains: the |A|≥4 or |B|≥4 all-redundant contradiction (requires Kneser's theorem, not in Mathlib).",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-21",
@@ -56,7 +56,7 @@
     ]
   },
   "conclusion": {
-    "summary": "Infrastructure for Vosper's theorem fully established and mostly proved: IsArithmeticProgression defined, basic AP lemmas proved (singleton, pair, shift, cardinality), ap_of_near_periodic proved (backward-shift induction), vosper_base proved (|A|=2 case), vosper_ap_sdiff_card proved (Session 20). One sorry remains in the full Vosper induction: Case 1 existence (counting/iterative removal).",
+    "summary": "Vosper's theorem nearly complete: IsArithmeticProgression, all AP lemmas, ap_of_near_periodic, vosper_base, vosper_ap_sdiff_card all proved (0 sorries). In the full induction, case1_exists is mostly proved — |B|=2 via orbit argument, |A|=|B|=3 via counting (9 < 10). One sorry remains: |B|≥3 and (|A|≥4 or |B|≥4) all-redundant contradiction, which requires Kneser's theorem (not yet in Mathlib).",
     "implications": "Once ap_of_near_periodic is formalized (the backward-shift induction), the full Vosper theorem follows from standard induction. Vosper's theorem would then complement ZMod.cauchy_davenport in Mathlib, completing the picture of additive structure in Z/pZ.",
     "openQuestions": [
       "Formalize ap_of_near_periodic: B is an AP if |B \\ (B+d)| = 1 (needs backward-shift induction on |B|)",

--- a/src/data/research/problems/erdos-476-oq-05-wip-01.json
+++ b/src/data/research/problems/erdos-476-oq-05-wip-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: |A|=|B|=3 all-redundant case proved via counting; 1 sorry remains for |A|≥4 or |B|≥4 (needs Kneser)",
+    "progressSummary": "PROGRESS: |B|=2 and |A|=|B|=3 cases proved; 1 sorry for |A|>=4 or |B|>=4 (Kneser needed)",
     "builtItems": [
       "case1_exists |B|=2 branch: fully proved via orbit argument (Erdos476OQ05Problem.lean ~550-609)",
       "hredA_card lemma inline: ∀ a ∈ A, (A.erase a + B).card = A.card + B.card - 1 from CD + inclusion",
@@ -51,10 +51,13 @@
       "Counting argument only closes |A|=|B|=3 (9 < 10); for |A|≥4 or |B|≥4, the bound (|A|-2)(|B|-2) ≥ 2 holds and Kneser is needed",
       "Kneser theorem for ZMod p: NOT in Mathlib. Building it from scratch needs ~200-300 lines of additive combinatorics infrastructure"
     ],
-    "mathlibGaps": [],
+    "mathlibGaps": [
+      "Kneser theorem for abelian groups (needed for |A|>=4 or |B|>=4 all-redundant contradiction in Vosper induction)"
+    ],
     "nextSteps": [
-      "Build Kneser theorem for ZMod p (~200-300 lines): Stab(A+B) is trivial for prime order groups, so |A+B| ≥ |A|+|B|-1 forces AP structure under full redundancy",
-      "Alternative: try elementary Freiman/Schur approach for the |A|≥4, |B|≥3 sub-case",
+      "Build Kneser theorem for ZMod p (~200-300 lines): since Stab(A+B) is trivial for prime order groups, |A+B| >= |A|+|B|-1 forces AP structure under full redundancy",
+      "Alternative: try elementary Freiman/Schur approach for the |A|>=4, |B|>=3 sub-case",
+      "Key constraint: for tight case |A|=4, |B|=3, each x in A+B has r(x)=2 exactly — may enable direct structural argument without Kneser",
       "If 3+ sessions stuck on Kneser: flag as BLOCKED and release claim"
     ],
     "markdown": "# Knowledge Base: erdos-476-oq-05-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"

--- a/src/data/research/problems/shannon-source-coding-oq-04.json
+++ b/src/data/research/problems/shannon-source-coding-oq-04.json
@@ -44,7 +44,8 @@
       "Fintype.card_fiber_eq_multinomial: if it exists, could prove type_class_size_eq_multinomial directly"
     ],
     "nextSteps": [
-      "Submit type_class_size_eq_multinomial to Aristotle — HARD sorry, explicit bijection ~60 lines",
+      "Free disk space + submit ShannonSourceCodingOQ04Aristotle.lean to Aristotle for type_class_size_eq_multinomial",
+      "If Aristotle unavailable: implement induction-on-n proof: partition T_f by x(Fin.last n), use Pascal identity",
       "Leave source_coding_achievability_mot as OPEN (requires concentration inequalities)"
     ],
     "markdown": "# Knowledge Base: shannon-source-coding-oq-04\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
@@ -117,11 +118,11 @@
     {
       "path": "Proofs/ShannonSourceCodingOQ04Aristotle.lean",
       "filename": "ShannonSourceCodingOQ04Aristotle.lean",
-      "lineCount": 156,
-      "theoremCount": 5,
+      "lineCount": 145,
+      "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonSourceCodingOQ04Aristotle.lean"
     }


### PR DESCRIPTION
## Summary

Session 2 progress on method-of-types formalization (OQ-04):

- Updates `ShannonSourceCodingOQ04Aristotle.lean` to reflect session 1 progress:
  - Removes stale sorries (proved in PR #12457): `type_class_size_le_entropy_pow'`, `dominant_type_lower_bound'`
  - Adds `type_class_size_eq_multinomial` as the sole remaining Aristotle target
- Documents two complete proof strategies for the sorry:
  1. **Induction on n** + Pascal identity: ∑_{v:f(v)>0} multinomial(f[v↦f(v)-1]) = multinomial(f)
  2. **Permutation quotient**: canonical sequence C_f, fiber size = ∏(f i)!, multinomial_spec
- Updates `knowledge.md` and `problem.json` with session 2 findings

## State

- Main file: 352 lines, **2 sorries remaining** (same as after session 1)
  - `type_class_size_eq_multinomial` (HARD, Aristotle target)
  - `source_coding_achievability_mot` (OPEN, needs LLN)
- Companion file: 145 lines, **1 sorry** (ready for Aristotle when disk space frees)

## Test plan

- [ ] Check companion file compiles (imports only, sorry doesn't block)
- [ ] Verify sorry count correct in companion (1 sorry for `type_class_size_eq_multinomial`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)