### PR TITLE
Fix: sync stale meta.lineCount for erdos-476-oq-05 and shannon-source-coding-oq-04

### DIFF
--- a/src/data/proofs/erdos-476-oq-05/meta.json
+++ b/src/data/proofs/erdos-476-oq-05/meta.json
@@ -22,7 +22,7 @@
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
     "assumptions": "1 sorry in vosper theorem: [SORRY 1/2] Case 1 existence (counting argument for removing an element from A). [SORRY 2/2] AP extension has been resolved: vosper_ap_sdiff_card is now fully proved (Session 20). ap_of_near_periodic (backward-shift induction) and vosper_base (|A|=2 case) are also fully proved. Infrastructure all proved with 0 sorries.",
-    "lineCount": 809,
+    "lineCount": 874,
     "theoremCount": 8,
     "definitionCount": 1,
     "originalContributions": [
@@ -116,7 +116,7 @@
   ],
   "leanFile": {
     "namespace": "Erdos476OQ05",
-    "lineCount": 809,
+    "lineCount": 874,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 1,

--- a/src/data/proofs/shannon-source-coding-oq-04/meta.json
+++ b/src/data/proofs/shannon-source-coding-oq-04/meta.json
@@ -67,7 +67,7 @@
     ],
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "lineCount": 247,
+    "lineCount": 352,
     "prerequisites": [
       "Shannon entropy H(X) = -sum p(x) log p(x)",
       "Empirical distribution (type) of a sequence",


### PR DESCRIPTION
## Fix

Sync stale `lineCount` metadata after recent research PRs added new proof content.

## Evidence

**erdos-476-oq-05**
- Before: `"lineCount": 809` (both `meta` and `leanFile` sections)
- After: `"lineCount": 874`
- Cause: PR #12433 (counting argument proof) added 65 lines to `Erdos476OQ05Problem.lean`

**shannon-source-coding-oq-04**
- Before: `"lineCount": 247` (`meta` section; `leanFile` section already correct at 352)
- After: `"lineCount": 352`
- Cause: PR #12457 (type class size and dominant type bound proofs) added 105 lines to `ShannonSourceCodingOQ04.lean`

## Validation

`pnpm build` passes ✓

---
Automated fix by lean-mechanic agent.