### PR TITLE
fix(deploy): prevent DNS failures during wrangler upload

### DIFF
--- a/scripts/deploy/sync-and-deploy.sh
+++ b/scripts/deploy/sync-and-deploy.sh
@@ -652,7 +652,9 @@ deploy_website() {
     safe_commit_msg=$(git log -1 --format="%s" 2>/dev/null | LC_ALL=C tr -cd '[:print:]' | cut -c1-100 || echo "deploy $commit_hash")
 
     print_info "Running wrangler pages deploy (commit: $commit_hash)..."
-    if wrangler pages deploy dist --project-name=lean-genius --branch=main --commit-dirty=true --commit-hash="$commit_hash" --commit-message="$safe_commit_msg" 2>&1 | tail -10; then
+    # UV_THREADPOOL_SIZE=32 prevents DNS resolution failures (ENOTFOUND) during
+    # parallel bulk uploads on macOS with Node 25 + wrangler 4.x
+    if UV_THREADPOOL_SIZE=32 wrangler pages deploy dist --project-name=lean-genius --branch=main --commit-dirty=true --commit-hash="$commit_hash" --commit-message="$safe_commit_msg" 2>&1 | tail -10; then
         print_success "Deployment completed"
 
         # Prune old deployments, keeping only the latest N


### PR DESCRIPTION
## Summary
- Set `UV_THREADPOOL_SIZE=32` before `wrangler pages deploy` to prevent intermittent `ENOTFOUND api.cloudflare.com` errors
- Root cause: Node 25's default libuv threadpool (size 4) gets exhausted by wrangler's parallel bulk upload of ~5000+ files, causing DNS resolution failures
- Discovered during deploy cycle where PR #12474 was merged and build succeeded but deploy failed 3 times before applying this fix

## Test plan
- [x] Verified fix works: successful deploy of 1285 files (5240 total) after applying `UV_THREADPOOL_SIZE=32`
- [x] Production site verified: HTTP 200 at lean-genious.pages.dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)