### PR TITLE
Enrichment: double-counting template annotation for amgm-inequality-oq-02-oq-01-oq-02

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02/annotations.json
@@ -107,6 +107,33 @@
     ]
   },
   {
+    "id": "ann-double-counting-template",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-02",
+    "range": {
+      "startLine": 71,
+      "endLine": 117
+    },
+    "type": "insight",
+    "title": "Double-Counting Template: Rewrite → sum_image → Set Identity",
+    "content": "The proof of `sum_lower_eq_sum_upper` + `sum_offDiag_eq_two_mul_sum_upper` encodes a reusable **double-counting pattern** for symmetric functions over finsets in Lean. The pattern has four steps:\n\n1. **Decompose** the target set into two halves (here: upper and lower triangular parts) via a membership argument using `LinearOrder`.\n2. **Exhibit the bijection** between the halves as a `Finset.image` operation on an involution (here: `Prod.swap`).\n3. **Reindex the sum**: rewrite the summand to factor through the bijection, then apply `Finset.sum_image` with an injectivity proof.\n4. **Combine** via `Finset.sum_union` (disjointness required) and `two_mul`.\n\nThis template applies whenever: (a) the index set has a natural involution, (b) the summand is invariant under the involution. Common instances beyond this proof: the handshaking lemma (edges counted twice by summing degrees), symmetry of multinomial coefficients, counting involutions in permutation groups.",
+    "mathContext": "General pattern: if $S = A \\sqcup B$ with bijection $\\sigma: A \\to B$ and $f(\\sigma(x)) = f(x)$ for all $x \\in A$, then $\\sum_{x \\in S} f(x) = 2 \\sum_{x \\in A} f(x)$. Lean encoding: `Finset.sum_union` + `Finset.sum_image` + `sum_congr`.",
+    "significance": "key",
+    "relatedConcepts": [
+      "double-counting",
+      "Finset.sum_image",
+      "Finset.sum_union",
+      "involution",
+      "Prod.swap",
+      "handshaking-lemma",
+      "symmetry"
+    ],
+    "prerequisites": [
+      "Finset.sum_image (Mathlib)",
+      "Finset.sum_union (Mathlib)",
+      "involution injectivity"
+    ]
+  },
+  {
     "id": "ann-application",
     "proofId": "amgm-inequality-oq-02-oq-01-oq-02",
     "range": {

--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02/meta.json
@@ -4,8 +4,8 @@
   "slug": "amgm-inequality-oq-02-oq-01-oq-02",
   "description": "Proves the off-diagonal symmetry identity: for a symmetric function f(i,j) = f(j,i), the sum over off-diagonal pairs Σ_{i≠j} f(i,j) = 2·Σ_{i<j} f(i,j). Applied to products xᵢxⱼ, this gives Σ_{i≠j} xᵢxⱼ = 2·e₂ where e₂ = Σ_{i<j} xᵢxⱼ is the second elementary symmetric polynomial, completing the Newton-Girard decomposition (Σxᵢ)² = Σxᵢ² + 2·e₂.",
   "meta": {
-    "author": "Formalized here",
-    "date": "2026",
+    "author": "Lean Genius",
+    "date": "2026-04-13",
     "status": "verified",
     "proofRepoPath": "Proofs/AmgmInequalityOQ02OQ01OQ02.lean",
     "tags": [
@@ -141,6 +141,11 @@
     "sorries": 0
   },
   "crossReferences": [
+    {
+      "targetId": "amgm-inequality-oq-02-oq-01-oq-02-oq-01",
+      "relationship": "child",
+      "description": "Planned extension: Full Newton-Girard recurrence $p_k = \\sum_{i=1}^k (-1)^{i-1} e_i p_{k-i}$ for all $k \\geq 1$. This entry proves the $k=2$ base case $\\sum_{i \\neq j} x_i x_j = 2e_2$; the child tracks generalization to all $k$ using Mathlib's `MvPolynomial.psum_eq_mul_esymm_sub_sum` (Zeilberger's combinatorial proof of Newton's identities)."
+    },
     {
       "targetId": "amgm-inequality-oq-02-oq-01",
       "relationship": "extends",


### PR DESCRIPTION
## Summary

- Adds 6th annotation to `amgm-inequality-oq-02-oq-01-oq-02` (Off-Diagonal Symmetry) documenting the reusable double-counting template: Decompose → Bijection → `sum_image` → Combine
- Documents applicability to handshaking lemma, multinomial symmetry, and permutation group counting
- Adds cross-reference to child entry `amgm-inequality-oq-02-oq-01-oq-02-oq-01` (Newton-Girard recurrence generalization)
- Fixes author/date metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)