### PR TITLE
Enrichment: binary-gcd, angle-trisection-cos-20-gal-oq-03, arithmetic-series-oq-02-oq-04-oq-01

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01/annotations.json
@@ -114,5 +114,31 @@
       "choose_descFactorial",
       "Nat.descFactorial recursion"
     ]
+  },
+  {
+    "id": "ann-asoq01-polynomial-basis",
+    "proofId": "arithmetic-series-oq-02-oq-04-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 28
+    },
+    "type": "insight",
+    "title": "Falling Factorials as a Polynomial Basis: Umbral Calculus and Discrete Derivatives",
+    "content": "The falling factorial identity $\\binom{n}{k} \\cdot k! = n^{\\underline{k}}$ sits at the intersection of combinatorics and discrete calculus. In umbral calculus (Rota-Taylor, 1994), the falling factorial polynomials $\\{n^{\\underline{0}}, n^{\\underline{1}}, n^{\\underline{2}}, \\ldots\\}$ play the same role as the monomial basis $\\{1, n, n^2, \\ldots\\}$ in ordinary calculus — but they are the natural basis for **ℤ-valued polynomials on ℤ**: every function $f: \\mathbb{N} \\to \\mathbb{Z}$ that is a polynomial of degree $d$ has a unique representation $f(n) = \\sum_{k=0}^d c_k \\binom{n}{k}$ with $c_k \\in \\mathbb{Z}$.\n\nThe **discrete derivative** $\\Delta f(n) = f(n+1) - f(n)$ satisfies $\\Delta(n^{\\underline{k}}) = k \\cdot n^{\\underline{k-1}}$, the exact discrete analog of $\\frac{d}{dn}(n^k) = k \\cdot n^{k-1}$. This connects the descending factorial identity to the umbral calculus framework: the main theorem `choose_descFactorial` is the integrality certificate, while the divisibility theorem `factorial_dvd_descFactorial` states that $k! \\mid n^{\\underline{k}}$ — exactly that each basis polynomial $\\binom{n}{k} = n^{\\underline{k}}/k!$ takes integer values on integers.",
+    "mathContext": "The falling factorial basis: every polynomial $f \\in \\mathbb{Z}[n]$ has a unique representation $f(n) = \\sum_k c_k \\binom{n}{k}$ with $c_k = \\Delta^k f(0) \\in \\mathbb{Z}$, where $\\Delta^k$ is the $k$-th iterated forward difference. The key formula $\\Delta(n^{\\underline{k}}) = k \\cdot n^{\\underline{k-1}}$ and the integral formula $\\sum_{j=0}^{n-1} j^{\\underline{k}} = \\frac{n^{\\underline{k+1}}}{k+1}$ are the discrete analogs of differentiation and integration.",
+    "significance": "key",
+    "relatedConcepts": [
+      "umbral calculus",
+      "discrete derivative",
+      "falling factorial polynomial basis",
+      "integer-valued polynomials",
+      "Rota-Taylor umbral calculus",
+      "Vandermonde convolution"
+    ],
+    "prerequisites": [
+      "choose_descFactorial (main identity)",
+      "factorial_dvd_descFactorial (integrality)",
+      "discrete calculus basics"
+    ]
   }
 ]

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01/meta.json
@@ -107,6 +107,16 @@
   },
   "crossReferences": [
     {
+      "targetId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03",
+      "relationship": "child",
+      "description": "Vandermonde's convolution in falling factorial form: $\\sum_{j=0}^{k} \\binom{m}{j}\\binom{n}{k-j} = \\binom{m+n}{k}$. The open question in this entry was to prove this identity; the child entry delivers it."
+    },
+    {
+      "targetId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02",
+      "relationship": "child",
+      "description": "Multiset Vandermonde identity: extends Vandermonde convolution to multiset coefficients $\\binom{n+k-1}{k}$, the analog for unordered selection with repetition."
+    },
+    {
       "targetId": "arithmetic-series-oq-02-oq-04",
       "relationship": "extends",
       "description": "Parent: ascending factorial identity C(n+k,k)*k! = ascFactorial(n+1,k)"


### PR DESCRIPTION
## Summary

**binary-gcd** (Stein's Algorithm):
- Fixes `crossReferences` to use `targetId` (schema correction)
- Adds "properties-for-free" annotation: `binaryGcd_eq_gcd` transfers all `Nat.gcd` properties

**angle-trisection-cos-20-gal-oq-03** (cos(40°) Galois group):
- Adds annotation: |Gal|=3 → Gal ≅ ℤ/3ℤ (prime order = cyclic) and Wantzel non-constructibility
- Adds cross-reference to cos(72°) sibling (|Gal|=2, constructible)
- Fixes date metadata

**arithmetic-series-oq-02-oq-04-oq-01** (Descending Factorial Identity):
- Adds annotation on falling factorials as polynomial basis for ℤ-valued functions (umbral calculus connection)
- Adds cross-references to child entries: Vandermonde identity (oq-03) and Multiset Vandermonde (oq-03-oq-02)

🤖 Generated with [Claude Code](https://claude.com/claude-code)