### PR TITLE
feat(hurwitz-oq-04): fix incorrect axiom, add OctonionDerSubmodule

### DIFF
--- a/proofs/Proofs/HurwitzTheoremOQ04.lean
+++ b/proofs/Proofs/HurwitzTheoremOQ04.lean
@@ -40,21 +40,17 @@ These four algebras are deeply connected to the exceptional Lie groups through:
   - `alg_aut_preserves_inner`: Aut(𝕆) preserves the inner product (by polarization)
   - `imag_closed_under_aut`: Aut(𝕆) maps Im(𝕆) to Im(𝕆) — Aut(𝕆) ⊆ O(7)
   - `OctonionDer`: structure of octonion derivations (Leibniz rule)
-  - `zeroDer`, `addDer`, `smulDer`: Der(𝕆) is a vector space
+  - `zeroDer`, `addDer`, `smulDer`: Der(𝕆) operations
   - `commDer`: commutator of two derivations is a derivation
   - `commDer_antisymm`, `commDer_jacobi`: Der(𝕆) is a Lie algebra
+  - `OctonionDerSubmodule`: Der(𝕆) as a Submodule of End_ℝ(ℝ⁸)
   - `freudenthal_tits_f4/e6/e7/e8`: ExceptionalType dims match definitions (proved by rfl)
   - All exceptional type dimension computations
   - `G2_unique_low_rank`: G₂ is the only exceptional Lie algebra of rank < 4
   - `E8_is_largest`: E₈ has the highest dimension (248)
 
-- **Computational (sorry, provable by ring)**:
-  - `eightMul_right_unit`: e₀ is the right identity
-  - `eightMul_left_unit`: e₀ is the left identity
-  - `normSq_octUnit_mul`: normSq norm-product identity with octUnit
-
 - **Axiomatized** (1 genuinely deep result):
-  - `G2_is_octonion_aut`: G₂ = Aut(𝕆) (requires Lie group theory not in Mathlib)
+  - `G2_der_dimension`: finrank ℝ Der(𝕆) = 14 (requires 14 lin. indep. derivations)
 
 ## References
 - John Baez, "The Octonions", Bull. AMS 39 (2002) — comprehensive survey
@@ -415,13 +411,9 @@ def ExceptionalType.rank : ExceptionalType → ℕ
   | .E7 => 7
   | .E8 => 8
 
-/-- **G₂ is the automorphism group of the octonions.**
-
-    Axiomatized: the formal proof requires Lie group theory and an explicit
-    identification of the automorphism group with the 14-dimensional compact
-    simple Lie group of type G₂. -/
-axiom G2_is_octonion_aut :
-    ExceptionalType.G2.dim = Nat.card (OctonionAut)
+/-! **G₂ and the derivation algebra**: At the Lie algebra level, 𝔤₂ ≅ Der(𝕆):
+    the derivation algebra of the octonions has dimension 14.
+    Formalized in PART IV-c as `G2_der_dimension`. -/
 
 -- ============================================================
 -- PART IV-b: Derivation Algebra of the Octonions
@@ -559,6 +551,40 @@ theorem commDer_jacobi (D₁ D₂ D₃ : OctonionDer) (x : Fin 8 → ℝ) :
     (commDer (commDer D₃ D₁) D₂).map x = 0 := by
   simp only [commDer, Pi.sub_apply]
   ring
+
+-- ============================================================
+-- PART IV-c: Der(𝕆) as a Vector Subspace — Dimension Axiom
+-- ============================================================
+
+/-!
+### Der(𝕆) as a Submodule of End_ℝ(ℝ⁸)
+
+The derivation algebra Der(𝕆) is a subspace of the space of ℝ-linear endomorphisms
+of ℝ⁸. This formulation gives Der(𝕆) an inherited vector space structure and enables
+`FiniteDimensional.finrank` to measure its dimension.
+-/
+
+private lemma eightMul_zero_left (b : Fin 8 → ℝ) : eightMul (0 : Fin 8 → ℝ) b = 0 := by
+  have h := eightMul_smul_left (0 : ℝ) b b; simp at h; simpa using h
+
+private lemma eightMul_zero_right (a : Fin 8 → ℝ) : eightMul a (0 : Fin 8 → ℝ) = 0 := by
+  have h := eightMul_smul_right (0 : ℝ) a a; simp at h; simpa using h
+
+/-- Der(𝕆) as a submodule of End_ℝ(ℝ⁸): ℝ-linear maps satisfying the Leibniz rule.
+    Inherits the vector space structure from the ambient finite-dimensional space. -/
+def OctonionDerSubmodule : Submodule ℝ ((Fin 8 → ℝ) →ₗ[ℝ] (Fin 8 → ℝ)) where
+  carrier := {f | ∀ a b, f (eightMul a b) = eightMul (f a) b + eightMul a (f b)}
+  zero_mem' a b := by simp [eightMul_zero_left, eightMul_zero_right]
+  add_mem' {f g} hf hg a b := by
+    simp only [LinearMap.add_apply, hf a b, hg a b, eightMul_add_left, eightMul_add_right]; abel
+  smul_mem' r f hf a b := by
+    simp only [LinearMap.smul_apply, hf a b, smul_add, eightMul_smul_left, eightMul_smul_right]
+
+/-- **Der(𝕆) has dimension 14** over ℝ — identifying the Lie algebra 𝔤₂ ≅ Der(𝕆).
+    Axiomatized: a complete proof requires exhibiting 14 linearly independent derivations
+    D_{ij} for pairs 1 ≤ i < j ≤ 7 of imaginary octonion basis elements. -/
+axiom G2_der_dimension :
+    FiniteDimensional.finrank ℝ OctonionDerSubmodule = ExceptionalType.G2.dim
 
 -- ============================================================
 -- PART V: The Freudenthal-Tits Magic Square
@@ -728,6 +754,8 @@ were admissible, there would be a 6th exceptional type.
 #check @commDer_self_eq_zero
 #check @commDer_antisymm
 #check @commDer_jacobi
+#check @OctonionDerSubmodule
+#check @G2_der_dimension
 #check @freudenthal_tits_f4
 #check @freudenthal_tits_e6
 #check @freudenthal_tits_e7

--- a/research/problems/hurwitz-theorem-oq-04/knowledge.md
+++ b/research/problems/hurwitz-theorem-oq-04/knowledge.md
@@ -139,3 +139,45 @@ For a true proof:
 2. **Archive sessions 1-3**: Move to sessions/ subdirectory (knowledge.md now >100 lines).
 3. **G2_is_octonion_aut**: Still axiom. Proving it formally requires Lie group theory not in Mathlib.
    Could reformulate it as a dim(Der(𝕆)) = 14 statement once explicit derivations are exhibited.
+
+---
+
+## Session 2026-04-26 (Session 5) — Axiom Correction + OctonionDerSubmodule
+
+**Mode**: REVISIT (RICH knowledge tier, score 31)
+**Outcome**: PROGRESS — axiom replaced with mathematically correct formulation
+
+### What I Did
+
+1. **Fixed mathematically incorrect axiom**: `G2_is_octonion_aut : G2.dim = Nat.card OctonionAut`
+   asserts `14 = Nat.card OctonionAut`. Since OctonionAut is infinite (G₂ is a continuous
+   Lie group), `Nat.card OctonionAut = 0` in Lean. The axiom was effectively `14 = 0`.
+   Replaced with `G2_der_dimension : finrank ℝ OctonionDerSubmodule = G2.dim` — mathematically
+   correct statement about the Lie ALGEBRA dimension.
+
+2. **Added PART IV-c: OctonionDerSubmodule** (~30 lines, 0 sorries):
+   - `eightMul_zero_left/right`: zero · b = 0 and a · 0 = 0 (private lemmas)
+   - `OctonionDerSubmodule`: Der(𝕆) as a `Submodule ℝ ((Fin 8 → ℝ) →ₗ[ℝ] (Fin 8 → ℝ))`
+   - Membership: zero_mem (trivial), add_mem (bilinearity + abel), smul_mem (bilinearity)
+   - `G2_der_dimension`: axiom finrank ℝ OctonionDerSubmodule = 14
+
+### Key Findings
+
+- **Nat.card vs finrank**: `Nat.card` of an infinite type returns 0. `FiniteDimensional.finrank`
+  is the right tool for Lie algebra dimension, requiring Module + FiniteDimensional instances.
+- **Submodule approach**: Der(𝕆) as a `Submodule ℝ (LinMap)` automatically inherits all
+  module structure from the ambient finite-dimensional End_ℝ(ℝ⁸) (dim 64).
+- **Previous formulation was inconsistent**: If Lean ever proves `Infinite OctonionAut`,
+  the old axiom `14 = 0` would give `False`. The new axiom avoids this.
+
+### Files Modified
+
+- `proofs/Proofs/HurwitzTheoremOQ04.lean` (736 → 764 lines; PART IV-c added, axiom fixed)
+- `src/data/research/problems/hurwitz-theorem-oq-04.json` (knowledge updated)
+- `src/data/proofs/hurwitz-theorem-oq-04/meta.json` (lineCount, theoremCount, assumptions)
+
+### Next Steps
+
+1. **Exhibit 14 derivations**: D_{ij}(x) for 1 ≤ i < j ≤ 7 to PROVE G2_der_dimension
+2. **Linear independence**: 14×14 matrix argument (decide-based)
+3. **Archive sessions 1-4** to sessions/ directory

--- a/src/data/proofs/hurwitz-theorem-oq-04/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-04/meta.json
@@ -21,10 +21,10 @@
     "sorries": 0,
     "dateAdded": "2026-04-24",
     "axiomCount": 1,
-    "assumptions": "1 axiom: G2_is_octonion_aut (G₂ ≅ Aut(𝕆), requires Lie group theory not yet in Mathlib). The 4 Freudenthal-Tits dimension statements (freudenthal_tits_f4/e6/e7/e8) were de-axiomatized: they are definitional equalities proved by rfl. All supporting lemmas (norm preservation, real-part preservation, imaginary-subspace closure, derivation algebra) are fully proved.",
-    "lineCount": 730,
-    "theoremCount": 31,
-    "definitionCount": 14,
+    "assumptions": "1 axiom: G2_der_dimension (finrank ℝ OctonionDerSubmodule = 14). Previous G2_is_octonion_aut (Nat.card OctonionAut = 14) was replaced: Nat.card of an infinite Lie group equals 0 in type theory, making it mathematically incorrect. G2_der_dimension targets the Lie algebra dimension directly. All supporting lemmas fully proved.",
+    "lineCount": 764,
+    "theoremCount": 32,
+    "definitionCount": 15,
     "originalContributions": [
       "OctonionAlgHom / OctonionAut: structures for octonion algebra homomorphisms and automorphisms",
       "alg_aut_preserves_norm: automorphisms preserve the norm (proved via polarization and imaginary decomposition)",
@@ -121,10 +121,10 @@
       "HurwitzTheorem"
     ],
     "namespace": "HurwitzTheoremOQ04",
-    "lineCount": 736,
+    "lineCount": 764,
     "axiomCount": 1,
-    "theoremCount": 31,
-    "definitionCount": 14,
+    "theoremCount": 32,
+    "definitionCount": 15,
     "sorries": 0,
     "path": "Proofs/HurwitzTheoremOQ04.lean"
   },

--- a/src/data/research/problems/hurwitz-theorem-oq-04.json
+++ b/src/data/research/problems/hurwitz-theorem-oq-04.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 0 sorries, 1 axiom (was 5). OctonionDer Lie algebra structure added (Session 4). commDer_jacobi proves Der(𝕆) satisfies Jacobi identity.",
+    "progressSummary": "PROGRESS: 0 sorries, 1 axiom (corrected from Nat.card to finrank). OctonionDerSubmodule added.",
     "builtItems": [
       "ExceptionalType inductive type (G2/F4/E6/E7/E8) with dim/rank — HurwitzTheoremOQ04.lean",
       "OctonionAlgHom structure + OctonionAut — HurwitzTheoremOQ04.lean",
@@ -37,7 +37,7 @@
       "eightMul_left_unit (PROVED 2026-04-24): same pattern — HurwitzTheoremOQ04.lean:94",
       "alg_hom_preserves_norm_product (PROVED) — HurwitzTheoremOQ04.lean",
       "G2_unique_low_rank, E8_is_largest, exceptional_dims_strict_mono (PROVED) — HurwitzTheoremOQ04.lean",
-      "G2_is_octonion_aut, freudenthal_tits_f4/e6/e7/e8 (axioms) — HurwitzTheoremOQ04.lean",
+      "G2_is_octonion_aut REPLACED (2026-04-26) by G2_der_dimension: finrank ℝ OctonionDerSubmodule = 14. Previous axiom was Nat.card OctonionAut = 14 which is 0 = 14, mathematically wrong.",
       "Freudenthal-Tits magic square table with dimensional analysis — HurwitzTheoremOQ04.lean commentary",
       "OctonionDer structure: ℝ-linear maps with Leibniz rule — HurwitzTheoremOQ04.lean",
       "zeroDer (proved 0 sorries): zero map is a derivation",
@@ -45,7 +45,8 @@
       "smulDer (proved): scalar multiple is a derivation",
       "eightMul_sub_left/right: eightMul bilinear over subtraction",
       "commDer (proved): commutator of derivations is a derivation — key Lie algebra result",
-      "commDer_antisymm, commDer_jacobi: Der(𝕆) is a Lie algebra under [·,·]"
+      "commDer_antisymm, commDer_jacobi: Der(𝕆) is a Lie algebra under [·,·]",
+      "OctonionDerSubmodule (2026-04-26): Der(𝕆) as Submodule ℝ (End_ℝ(ℝ⁸)) — PART IV-c of HurwitzTheoremOQ04.lean"
     ],
     "insights": [
       "G₂ = Aut(𝕆): The exceptional Lie group G₂ (dim 14, rank 2) is the automorphism group of the octonions. The 14 dimensions come from SO(7) (dim 21) minus the 7 constraints from preserving the octonion cross product.",
@@ -57,7 +58,9 @@
       "alg_aut_preserves_inner PROVED via polarization: innerProd x y = (normSq(x+y) - normSq x - normSq y)/2, with norm preservation + linearity.",
       "imag_closed_under_aut: Aut(𝕆) ⊆ O(7) now formalized — automorphisms map Im(𝕆) to Im(𝕆) preserving the inner product.",
       "eightMul unit proof pattern: simp(config:={decide:=true})[ite_true,ite_false] evaluates if (0:Fin 8)=j for concrete j. Plain simp[stdBasis] insufficient — need decide mode for Fin equality.",
-      "freudenthal_tits_f4/e6/e7/e8 de-axiomatized (2026-04-25): these 4 axioms were just ExceptionalType.dim = literal, provable by rfl. Axiom count reduced from 5 to 1."
+      "freudenthal_tits_f4/e6/e7/e8 de-axiomatized (2026-04-25): these 4 axioms were just ExceptionalType.dim = literal, provable by rfl. Axiom count reduced from 5 to 1.",
+      "G2_is_octonion_aut had type-theoretic flaw: Nat.card of an infinite group = 0 in Lean. Replaced with G2_der_dimension: finrank ℝ OctonionDerSubmodule = 14.",
+      "OctonionDerSubmodule as Submodule ℝ (LinearMap) inherits finite-dimensional vector space structure automatically."
     ],
     "mathlibGaps": [
       "Lie groups not in Mathlib as of 2026-04 — blocks formal G₂ = Aut(𝕆) proof",
@@ -65,9 +68,9 @@
       "Derivation algebra of non-associative algebras not in Mathlib"
     ],
     "nextSteps": [
-      "Attempt to bound dim(Der(𝕆)) = 14 by exhibiting 14 explicit derivations (would strengthen G2_is_octonion_aut)",
-      "Prove that every Aut(𝕆) element near identity gives a derivation via tangent space (requires smooth structures)",
-      "Archive sessions 1-3 to sessions/ directory"
+      "Exhibit 14 explicit derivations D_{ij} for 1<=i<j<=7 to PROVE G2_der_dimension",
+      "Prove linear independence via 14x14 matrix computation",
+      "Archive old sessions"
     ]
   },
   "tags": [
@@ -88,7 +91,7 @@
     "mathlib": []
   },
   "started": "2026-04-22T13:03:46.381Z",
-  "lastUpdate": "2026-04-22T13:03:46.381Z",
+  "lastUpdate": "2026-04-26T00:00:00Z",
   "significance": 7,
   "tractability": 4,
   "leanFiles": [


### PR DESCRIPTION
## Summary

- **Fixes mathematically incorrect axiom**: `G2_is_octonion_aut : G2.dim = Nat.card OctonionAut` claimed `14 = Nat.card OctonionAut`. Since `OctonionAut` (the Lie group G₂) is infinite, `Nat.card` returns 0, making this axiom assert `14 = 0` — effectively inconsistent with any proof that G₂ is infinite.
- **Replaces with correct axiom**: `G2_der_dimension : finrank ℝ OctonionDerSubmodule = G2.dim` targets the Lie *algebra* dimension, which is 14. This is both mathematically correct and well-typed.
- **Adds `OctonionDerSubmodule`**: Der(𝕆) as a `Submodule ℝ ((Fin 8 → ℝ) →ₗ[ℝ] (Fin 8 → ℝ))`, inheriting finite-dimensional vector space structure from End_ℝ(ℝ⁸).

## Mathematical Significance

The previous axiom was using `Nat.card` to capture the "dimension" of a Lie group, which is a category error in type theory: `Nat.card` counts discrete elements and returns 0 for infinite types. The correct tool for Lie algebra dimension is `FiniteDimensional.finrank`. `OctonionDerSubmodule` provides the natural ambient module structure for this measurement.

## Files Changed

- `proofs/Proofs/HurwitzTheoremOQ04.lean`: +28 lines (PART IV-c), -7 lines (old axiom removed), preamble and #check updated
- `src/data/proofs/hurwitz-theorem-oq-04/meta.json`: updated axiom description, line/theorem/definition counts
- `src/data/research/problems/hurwitz-theorem-oq-04.json`: knowledge updated
- `research/problems/hurwitz-theorem-oq-04/knowledge.md`: Session 5 added

## Test plan

- [ ] Docker build verification (pending — docker not available in this session)
- [ ] All existing proofs unchanged (0 sorries still holds)
- [ ] Axiom count remains 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)