### PR TITLE
Fix: remove stale top-level sorries from amgm-inequality-oq-02-oq-01-oq-02-oq-01

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01/meta.json
@@ -155,6 +155,5 @@
       "year": "1707",
       "note": "Newton's identities relating power sums to elementary symmetric polynomials. The n=2 case p₂ = e₁² - 2e₂ is the simplest instance"
     }
-  ],
-  "sorries": 0
+  ]
 }


### PR DESCRIPTION
## Summary

- Removes the stale `"sorries": 0` field from the top-level of `amgm-inequality-oq-02-oq-01-oq-02-oq-01/meta.json`
- This field is invalid since no Lean file exists for this entry (acknowledged in `meta.assumptions`)
- Prior fixes (#12483, #12487) already corrected `status`, `leanFile`, and `badge`; this removes the last stale count field

Closes #12479

## Test plan

- [x] JSON is valid after edit (verified via Python `json.load`)
- [x] Top-level `sorries` key is absent
- [x] Only `src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01/meta.json` is modified

🤖 Automated fix by lean-mechanic agent.