### PR TITLE
enrichment: angle-trisection-cos-20-gal-oq-03-oq-01 + amgm-oq-02-oq-03-oq-03 — new annotations

### DIFF
--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-03-oq-01/annotations.json
@@ -124,5 +124,30 @@
       "Polynomial.Gal.galActionHom_injective",
       "Polynomial.card_rootSet_eq_natDegree"
     ]
+  },
+  {
+    "id": "ann-at-cos72-gal-06-constructibility",
+    "proofId": "angle-trisection-cos-20-gal-oq-03-oq-01",
+    "range": {
+      "startLine": 436,
+      "endLine": 462
+    },
+    "type": "insight",
+    "title": "Constructibility of the Regular Pentagon: |Gal|=2 vs |Gal|=3",
+    "content": "The summary comment at lines 436-462 draws the key distinction between this entry and its sibling cubic cases. The degree-2 result |Gal|=2 has a direct geometric implication via Gauss's constructibility criterion (1801): a real algebraic number α is constructible by ruler and compass if and only if [ℚ(α):ℚ] is a power of 2. Since [ℚ(cos(72°)):ℚ] = 2 = 2¹, cos(72°) is constructible, and therefore the regular pentagon (5-gon) is constructible by compass and straightedge.\n\nIn contrast, the sibling entries in this family (AngleTrisectionCos20GalOQ03 for cos(40°), AngleTrisectionCos20GalOQ01 for cos(π/7)) give |Gal|=3, meaning [ℚ(cos):ℚ]=3 is NOT a power of 2. This is Wantzel's (1837) proof of the impossibility of angle trisection: to trisect 60°, one would need cos(20°) to be constructible, but [ℚ(cos(20°)):ℚ]=3.\n\nThe general pattern: |Gal(ℚ(cos(2π/p))/ℚ)| = (p−1)/2 for prime p. This equals a power of 2 exactly when (p−1)/2 = 2^k, i.e., p = 2^{k+1}+1 is a Fermat prime. The known Fermat primes are 3, 5, 17, 257, 65537 — and the corresponding regular polygons (triangle, pentagon, 17-gon, 257-gon, 65537-gon) are constructible.",
+    "mathContext": "Gauss's criterion (1801): A regular $n$-gon is constructible iff $\\phi(n) = 2^k$ for some $k$. For $n=p$ prime: $\\phi(p)=p-1$, so the $p$-gon is constructible iff $p-1$ is a power of 2, i.e., $p$ is a Fermat prime. The formalization gives $[\\mathbb{Q}(\\cos(2\\pi/5)):\\mathbb{Q}] = 2$, which is a power of 2. The comparison table: $p=5$: $|\\text{Gal}|=2$, constructible; $p=7$: $|\\text{Gal}|=3$, NOT constructible; $p=9$ (not prime, but $\\cos(40°)$): $|\\text{Gal}|=3$, NOT constructible.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Gauss constructibility criterion",
+      "Fermat primes",
+      "regular pentagon construction",
+      "Wantzel 1837",
+      "angle trisection impossibility"
+    ],
+    "prerequisites": [
+      "Gauss's constructibility criterion (Disquisitiones Arithmeticae §366)",
+      "Wantzel's impossibility theorem (1837)",
+      "cos72_gal_card (main theorem of this file)"
+    ]
   }
 ]

--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-03-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-03-oq-01/meta.json
@@ -4,7 +4,7 @@
   "slug": "angle-trisection-cos-20-gal-oq-03-oq-01",
   "description": "Proves that the Galois group of 4X²+2X−1 over ℚ has cardinality 2. This polynomial is the minimal polynomial of cos(72°) = cos(2π/5), with roots cos(72°) and cos(144°) = cos(4π/5). Irreducibility is established via Eisenstein's criterion on the shifted polynomial 4X²+10X+5 (Eisenstein at p=5). The splitting field equals ℚ(cos(72°)) since both roots lie in it, giving degree 2 and Galois group ℤ/2ℤ. This is the p=5 instance of |Gal(ℚ(cos(2π/p))/ℚ)| = (p−1)/2 for prime p.",
   "meta": {
-    "author": "researcher-5",
+    "author": "Lean Genius",
     "sourceUrl": "https://en.wikipedia.org/wiki/Minimal_polynomial_(field_theory)",
     "date": "2026",
     "status": "verified",


### PR DESCRIPTION
## Summary
- `amgm-inequality-oq-02-oq-03-oq-03`: Added 6th annotation on conditional proof architecture — axiom vs proved step, import substitution pattern in Lean 4
- `angle-trisection-cos-20-gal-oq-03-oq-01`: Added 6th annotation on constructibility of the regular pentagon via Gauss's criterion (|Gal|=2 → power of 2 → constructible), contrasting with |Gal|=3 cubic cases. Fixed author "researcher-5" → "Lean Genius"

🤖 Enricher-2