### PR TITLE
enrichment: area-of-circle-oq-02 — Gamma dichotomy annotation

### DIFF
--- a/src/data/proofs/area-of-circle-oq-02/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-02/annotations.json
@@ -118,5 +118,30 @@
       "Mathlib.MeasureTheory.Measure.Lebesgue.VolumeOfBalls",
       "Complex.instMeasurableSpace"
     ]
+  },
+  {
+    "id": "ann-even-odd-dichotomy",
+    "proofId": "area-of-circle-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 30
+    },
+    "type": "insight",
+    "title": "Even vs Odd Dimensions: The Γ(1/2) = √π Dichotomy",
+    "content": "The module header summarizes the unified formula $V_n = \\pi^{n/2}/\\Gamma(n/2+1)$, but conceals a fundamental dichotomy between even and odd dimensions that appears in the Gamma function evaluations.\n\n**Even dimensions** (n=2k): $\\Gamma(k+1) = k!$ (integer factorial), giving $V_{2k} = \\pi^k/k!$. Clean closed forms: $V_0=1$, $V_2=\\pi$, $V_4=\\pi^2/2$, $V_6=\\pi^3/6$, ... These are the coefficients of $e^\\pi = \\sum \\pi^k/k!$.\n\n**Odd dimensions** (n=2k+1): $\\Gamma((2k+3)/2)$ involves $\\Gamma(1/2) = \\sqrt{\\pi}$ (Leibniz 1675/Euler 1729). The private lemma `gamma_three_div_two: Γ(3/2) = √π/2` is the bridging computation: $V_3 = \\pi^{3/2}/\\Gamma(5/2) = \\pi^{3/2}/(3\\sqrt{\\pi}/4) = 4\\pi/3$. General odd: $V_{2k+1} = 2^{k+1}\\pi^k/(2k+1)!!$ where $(2k+1)!! = 1 \\cdot 3 \\cdot 5 \\cdots (2k+1)$.\n\nThe recurrence $V_n = V_{n-2} \\cdot 2\\pi/n$ proved by `unitBallVolume_recurrence` is the Lean-efficient way to traverse both families without recomputing Gamma values from scratch at each step.",
+    "mathContext": "The key identity: $\\Gamma(1/2) = \\sqrt{\\pi}$ (first proved by Euler, 1729). From this: $\\Gamma(3/2) = (1/2)\\cdot\\Gamma(1/2) = \\sqrt{\\pi}/2$; $\\Gamma(5/2) = (3/2)\\cdot\\Gamma(3/2) = 3\\sqrt{\\pi}/4$. The odd-dimension formula: $V_{2k+1} = \\pi^{k+1/2}/\\Gamma(k+3/2) = \\pi^{k+1/2} \\cdot 2^{k+1}/(3\\cdot5\\cdots(2k+1)\\sqrt{\\pi}) = 2^{k+1}\\pi^k/(2k+1)!!$. The even/odd dichotomy is the reason the volume sequence does not factor uniformly — $V_1, V_3, V_5, \\ldots$ and $V_0, V_2, V_4, \\ldots$ are two separate monotone-then-decreasing sequences, each decreasing to 0.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Gamma(1/2) = sqrt(pi)",
+      "double factorial",
+      "even/odd dimension dichotomy",
+      "gamma_three_div_two",
+      "Gamma_one_half_eq"
+    ],
+    "prerequisites": [
+      "Real.Gamma_one_half_eq: Γ(1/2) = √π (Mathlib)",
+      "Real.Gamma_add_one: Γ(x+1) = x·Γ(x) (Mathlib)",
+      "unitBallVolume definition"
+    ]
   }
 ]

--- a/src/data/proofs/area-of-circle-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-02/meta.json
@@ -123,6 +123,16 @@
       "targetId": "area-of-circle-oq-05",
       "relationship": "related",
       "description": "OQ-05 connects Gaussian integral to circle area; the n-ball volume formula involves the same π via Gamma function"
+    },
+    {
+      "targetId": "area-of-circle-oq-02-oq-01",
+      "relationship": "child",
+      "description": "Child entry: proves the nball_volume_scaling axiom from this file by establishing the EuclideanSpace/PiLp measure isomorphism — converting this conditional result to a fully verified theorem"
+    },
+    {
+      "targetId": "area-of-circle-oq-02-oq-04",
+      "relationship": "child",
+      "description": "Child entry: proves Vol(Bⁿ) → 0 as n → ∞ using Stirling's approximation — the asymptotic counterpart to the finite-n computations here"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Summary
- `area-of-circle-oq-02`: Added 6th annotation `ann-even-odd-dichotomy` explaining the even/odd dimension dichotomy in the Gamma function formula: V_{2k} = π^k/k! vs odd V_{2k+1} involving √π (Γ(1/2)=√π), with the recurrence as the efficient bridge. Also added cross-references to child entries that complete the open questions.

🤖 Enricher-2