### PR TITLE
enrichment: bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01 — historical context, keyInsights, openQuestions

### DIFF
--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -36,6 +36,18 @@
     "prerequisites": ["ring homomorphisms", "Ideal.mem_span_pair"]
   },
   {
+    "id": "ann-step2-overview",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 76, "endLine": 81 },
+    "type": "concept",
+    "title": "Step 2 Strategy: Why totalDegree_mul_of_isDomain?",
+    "content": "The docstring introduces the key challenge: to prove $I$ is not principal, we assume $I = \\langle f \\rangle$ and derive a contradiction. The contradiction comes in two substeps: (1) $f \\mid C 2$ forces $f$ to be a constant polynomial, and (2) $C c \\mid X_0$ with $c$ an integer forces $c = \\pm 1$, making $f$ a unit. The delicate point is why totalDegree_mul_of_isDomain (EXACT equality) is needed rather than just an inequality: we need $\\deg(f) + \\deg(g) = \\deg(fg) = 0$, which forces $\\deg(f) = 0$ over $\\mathbb{N}$. An inequality $\\deg(fg) \\leq \\deg(f) + \\deg(g) = 0$ would also suffice, but Lean's Mathlib provides the exact equality as a standalone lemma for domains.",
+    "mathContext": "In a general commutative ring, $\\deg_{\\text{tot}}(fg) \\leq \\deg_{\\text{tot}}(f) + \\deg_{\\text{tot}}(g)$ holds but can be strict (e.g., in $\\mathbb{Z}/4\\mathbb{Z}[X]$, $2X \\cdot 2X = 0$ has degree $-\\infty$ while $2X$ has degree 1). Over an integral domain (NoZeroDivisors), equality holds because the leading term of $fg$ is the product of the leading terms of $f$ and $g$, which is nonzero. The specific Mathlib lemma `MvPolynomial.totalDegree_mul_of_isDomain` encodes this for multivariate polynomials, and its EXACT equality form is essential to close the $\\mathbb{N}$-valued arithmetic with `omega`.",
+    "significance": "technical",
+    "relatedConcepts": ["totalDegree_mul_of_isDomain", "NoZeroDivisors", "integral domain", "leading term"],
+    "prerequisites": ["polynomial degree theory", "integral domains"]
+  },
+  {
     "id": "ann-degree-zero",
     "proofId": "bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01",
     "range": { "startLine": 82, "endLine": 103 },

--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -75,7 +75,7 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "The question of which polynomial rings are PIDs or PIRs is central to commutative algebra. Gauss (1801) proved ℤ is a UFD; Gauss's lemma gives UFD → R[X] is a UFD, so ℤ[X] is a UFD. However ℤ[X] is NOT a PID: the ideal (2, X) is not principal. For ℤ[X,Y], the same witness works. This is a foundational distinction: UFD is strictly weaker than PID. Noether (1920s) and Krull systematized this hierarchy: PID → UFD → GCD domain → integral domain. The proof here via the ring map ℤ[X,Y] → ℤ/2ℤ is the standard modern proof, credited to the general theory of maximal ideals and quotient rings.",
+    "historicalContext": "The distinction between principal ideal domains (PIDs) and unique factorization domains (UFDs) is one of the central organizing themes of nineteenth- and twentieth-century commutative algebra.\n\nThe story begins with Gauss. In his 1801 *Disquisitiones Arithmeticae*, Gauss proved that the integers ℤ form a UFD — every integer factors uniquely into primes. Gauss's lemma (*Recherches arithmétiques*, later formalized) states: if $R$ is a UFD, then $R[X]$ is a UFD. Iterated application gives that $\\mathbb{Z}[X], \\mathbb{Z}[X,Y],\\ldots$ are all UFDs.\n\nBut unique factorization is strictly weaker than having only principal ideals. Ernst Kummer (1840s) discovered that unique factorization fails in rings like $\\mathbb{Z}[\\sqrt{-5}]$: the element $6 = 2 \\cdot 3 = (1+\\sqrt{-5})(1-\\sqrt{-5})$ has two distinct factorizations into irreducibles. Kummer's remedy was 'ideal numbers' (later made precise by Dedekind as ideals), restoring unique factorization at the level of ideals. Dedekind showed that rings of integers of number fields are *Dedekind domains* — every nonzero ideal factors uniquely into prime ideals — and that those where every ideal is principal are exactly the PIDs.\n\nThe failure of $\\mathbb{Z}[X]$ to be a PID is classical: the ideal $(2, X) \\subset \\mathbb{Z}[X]$ is proper (any $2a + Xb$ has even constant term) and non-principal (a generator would have to divide both $2$ and $X$, but then degree and divisibility force it to be a unit, contradicting properness). The same ideal witnesses the failure for $\\mathbb{Z}[X,Y]$.\n\nEmmy Noether (1921) and Wolfgang Krull (1920s–30s) axiomatized this theory into the modern hierarchy: Field $\\subsetneq$ Euclidean domain $\\subsetneq$ PID $\\subsetneq$ UFD $\\subsetneq$ GCD domain $\\subsetneq$ Noetherian domain $\\subsetneq$ integral domain. Hilbert's basis theorem (1890) showed $R$ Noetherian implies $R[X]$ Noetherian, giving finitely-generated ideals throughout polynomial rings. The ideal $(2,X)$ itself is finitely generated — but not by a single element.\n\nFrom algebraic geometry, $\\mathbb{Z}[X,Y]$ is the coordinate ring of the arithmetic surface $\\text{Spec}\\,\\mathbb{Z}[X,Y]$, which has Krull dimension 3. The ideal $(2, X)$ defines a codimension-2 closed subscheme — a 'curve' in this arithmetic surface — that is not a principal divisor. This non-principality is an instance of non-trivial Chow groups, central to Grothendieck's development of $K$-theory and the Riemann-Roch theorem for arithmetic surfaces.",
     "problemStatement": "Is ℤ[X,Y] a principal ideal ring? (Answer: No.)",
     "text": "ℤ[X,Y] is NOT a principal ideal ring: the ideal (2, X) is a proper non-principal ideal.",
     "proofStrategy": "Witness I = (2, X₀). Step 1: I ≠ ⊤ via constantCoeff : ℤ[X,Y] → ℤ (evaluates all vars at 0): any element 2a + X₀b maps to 2·constantCoeff(a), which is even, so cannot equal 1. Step 2: I not principal: if I = (f), then f | C 2. Since f ≠ 0 and g := 2/f ≠ 0, totalDegree_mul_of_isDomain gives totalDegree(f) + totalDegree(g) = totalDegree(C 2) = 0, so totalDegree(f) = 0, hence f = C c with c | 2. Then C c | X₀, extracting the X₀-coefficient gives 1 = c · coeff(X₀, g), so c | 1, so c is a unit. Then C c is a unit (via IsUnit.map), so (C c) = ⊤, contradicting I ≠ ⊤.",
@@ -85,7 +85,9 @@
       "totalDegree_eq_zero_iff_eq_C converts degree 0 to f = C (constantCoeff f)",
       "Coefficient extraction: C c * g = X₀ → c * coeff(X₀, g) = 1, so c | 1 in ℤ, so IsUnit c",
       "IsUnit.map lifts units ℤ → ℤ[X,Y] via the ring hom C : ℤ →+* ℤ[X,Y]",
-      "Ideal.span_singleton_eq_top: ⟨u⟩ = ⊤ iff u is a unit"
+      "Ideal.span_singleton_eq_top: ⟨u⟩ = ⊤ iff u is a unit",
+      "**Two independent witnesses in one proof**: the ideal $(2, X_0)$ must simultaneously be proper (separating the PID-failure from the trivial case $I = \\top$) and non-principal. The ring hom witness (constantCoeff for properness) and the degree witness (totalDegree for non-principality) are logically independent — properness rules out the generator being a unit, while non-principality rules out a non-unit generator. This two-step structure is common in ideal-theoretic impossibility proofs.",
+      "**The Krull dimension chain**: $\\dim_{\\text{Krull}}(\\mathbb{Z}) = 1$, $\\dim_{\\text{Krull}}(\\mathbb{Z}[X]) = 2$, $\\dim_{\\text{Krull}}(\\mathbb{Z}[X,Y]) = 3$. A necessary condition for a Noetherian integral domain to be a PID is that $\\dim_{\\text{Krull}} \\leq 1$ (Dedekind domains are the maximal-dimensional case). Since $\\mathbb{Z}[X,Y]$ has dimension 3, it is 'too large' to be a PID — but the proof avoids dimension theory entirely, giving a direct combinatorial witness via the ideal $(2, X_0)$."
     ],
     "prerequisites": [
       "Principal ideal ring definition",
@@ -141,25 +143,38 @@
     {
       "targetId": "bezout-identity-oq-02-oq-01-oq-01-oq-01",
       "relationship": "parent",
-      "description": "ℤ[X,Y] is a UFD (the complementary positive result)"
+      "description": "ℤ[X,Y] is a UFD — the complementary positive result. Together, the two entries establish the strict containment PID ⊊ UFD witnessed by ℤ[X,Y]."
     },
     {
       "targetId": "bezout-identity-oq-02-oq-01-oq-01",
       "relationship": "grandparent",
-      "description": "ℤ[X] is a UFD (Gauss's lemma)"
+      "description": "ℤ[X] is a UFD (Gauss's lemma). The PID failure already occurs in ℤ[X]: the ideal (2, X) ⊂ ℤ[X] is non-principal by the same argument, establishing that the failure is not specific to two variables."
     },
     {
       "targetId": "bezout-identity",
       "relationship": "foundational",
-      "description": "Bézout's Identity"
+      "description": "Bézout's Identity — the classical characterization of PIDs via the property that every pair of elements (a,b) satisfies xa + yb = gcd(a,b). In ℤ[X,Y], this Bézout property fails: no single-generator witnesses gcd(2, X₀) ∈ (2, X₀)."
+    },
+    {
+      "targetId": "factor-remainder-nullstellensatz",
+      "relationship": "related",
+      "description": "The Factor-Remainder Theorem and its generalization toward Hilbert's Nullstellensatz — an adjacent part of the ideal theory of polynomial rings. The Nullstellensatz describes the maximal ideals of k[X₁,…,Xₙ]; by contrast, the ideal (2, X) ⊂ ℤ[X,Y] is a prime ideal (since ℤ[X,Y]/(2,X) ≅ 𝔽₂) but not principal — illustrating the richer structure of arithmetic polynomial rings over ℤ compared to geometric polynomial rings over fields."
+    },
+    {
+      "targetId": "bezout-identity-oq-02-oq-01-oq-02",
+      "relationship": "sibling",
+      "description": "A sibling sub-entry exploring further ideal-theoretic properties of polynomial rings. Cross-referencing the non-PID result establishes the landscape: which positive properties (GCD domain, Noetherian, etc.) ℤ[X,Y] retains versus what it lacks."
     }
   ],
   "conclusion": {
     "summary": "Complete proof that ℤ[X,Y] is not a PIR, with 0 sorries and 0 axioms, using the ideal (2,X) as witness.",
     "implications": "Establishes the strict inequality PID < UFD in the ring hierarchy. ℤ[X,Y] is the canonical example of a UFD that is not a PID.",
     "openQuestions": [
-      "Can we formalize the Nullstellensatz for ℤ[X,Y]?",
-      "Can we classify which polynomial rings R[X₁,...,Xₙ] are PIRs?"
+      "Can we formalize the Nullstellensatz for ℤ[X,Y]? Hilbert's Nullstellensatz over a field $k$ states: if $f$ vanishes on all common zeros of $f_1,\\ldots,f_r \\in k[X_1,\\ldots,X_n]$, then $f^m \\in (f_1,\\ldots,f_r)$ for some $m$. Over $\\mathbb{Z}$, the arithmetic Nullstellensatz (Schmidt 1985, Brownawell 1987) provides bounds but is substantially harder. Can Lean formalize even the weak form $\\sqrt{I} = \\bigcap_{\\mathfrak{p} \\supseteq I} \\mathfrak{p}$ (Jacobson radical equals intersection of prime ideals) for $\\mathbb{Z}[X,Y]$?",
+      "Can we classify which polynomial rings $R[X_1,\\ldots,X_n]$ are PIRs? The answer is known: $R[X_1,\\ldots,X_n]$ is a PIR if and only if $R$ is a finite product of fields when $n \\geq 1$ (since polynomial rings over fields are PIDs only for $n=1$; for $n \\geq 2$ even $k[X,Y]$ for a field $k$ is not a PID). Can this complete characterization be formalized in Lean?",
+      "What is the class number of $\\mathbb{Z}[\\sqrt{-5}]$, and can Lean formalize it? The failure of unique factorization in $\\mathbb{Z}[\\sqrt{-5}]$ (e.g., $6 = 2 \\cdot 3 = (1+\\sqrt{-5})(1-\\sqrt{-5})$) is measured by the *class group* $\\text{Cl}(\\mathbb{Z}[\\sqrt{-5}]) \\cong \\mathbb{Z}/2\\mathbb{Z}$ — the deviation from being a PID. While the gallery entry `bezout-identity-oq-02-oq-01-oq-01-oq-01` proves $\\mathbb{Z}[X,Y]$ is a UFD (so its class group is trivial), formalizing non-trivial class groups for rings of integers would be a major step toward arithmetic geometry in Lean.",
+      "**Bézout rings**: A commutative ring is a *Bézout ring* if every finitely-generated ideal is principal (a weakening of PID that does not require Noetherianness). The ring of integers of any algebraic number field is not Bézout when it is not a PID (class number $> 1$). In contrast, the ring of all algebraic integers is a Bézout domain but not a PID (it is not Noetherian). Can Lean formalize that $\\mathbb{Z}[X,Y]$ is not a Bézout ring either — since $(2, X)$ is already a finitely-generated non-principal ideal?",
+      "**Serre's theorem and projective modules**: Serre's theorem (1955, proved by Quillen and Suslin in 1976) states that finitely-generated projective modules over $k[X_1,\\ldots,X_n]$ (a polynomial ring over a field) are free. Over $\\mathbb{Z}[X_1,\\ldots,X_n]$, the analogous statement is also true (Swan 1968). The existence of non-principal ideals in $\\mathbb{Z}[X,Y]$ shows these ideals are projective but not free as $\\mathbb{Z}[X,Y]$-modules — but by Quillen-Suslin-Swan, every projective module over $\\mathbb{Z}[X,Y]$ IS free. This apparent paradox resolves because $(2,X)$ is not projective as a module (it is an ideal that is not invertible in the Picard group sense). Can Lean formalize the distinction between projective and invertible ideals in $\\mathbb{Z}[X,Y]$?"
     ]
   },
   "mainTheorems": [


### PR DESCRIPTION
## Enrichment Pass: ℤ[X,Y] is NOT a Principal Ideal Ring

Enrichment of `bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01` (untracked entry, 0 prior passes).

### Changes

**meta.json:**
- **historicalContext** expanded from 590 → ~2,000 chars: added Kummer's discovery of non-unique factorization in ℤ[√-5] and the origin of ideal theory, Noether-Krull hierarchy axiomatization (1920s-30s), algebraic geometry interpretation (Spec ℤ[X,Y] as arithmetic surface, Krull dimension 3, Chow groups)
- **keyInsights** expanded from 6 → 8: added insight on the independence of the two witnesses (constantCoeff for properness, totalDegree for non-principality), and the Krull dimension obstruction (dim ≤ 1 necessary for Noetherian PIDs)
- **openQuestions** expanded from 2 → 5: arithmetic Nullstellensatz over ℤ, complete PIR classification for R[X₁,...,Xₙ], class number formalization for ℤ[√-5], Bézout rings, Serre-Quillen-Suslin projective modules
- **crossReferences** expanded from 3 → 5: added factor-remainder-nullstellensatz (connection to polynomial ideal theory) and bezout-identity-oq-02-oq-01-oq-02 (sibling)

**annotations.json:**
- Added 9th annotation `ann-step2-overview` (lines 76-81): explains why `totalDegree_mul_of_isDomain` (exact equality) is needed over an integral domain vs. the weaker inequality available in general rings

### Axiom integrity
No change to axiomCount (0) or status (verified) — purely content enrichment.