### PR TITLE
research: companionMatrix_cyclic_e0 (sorry-free) + modular RCF structure

### DIFF
--- a/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean
+++ b/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean
@@ -27,6 +27,7 @@
   cardinality arguments (union avoidance).
 -/
 import Mathlib
+import Proofs.CayleyHamiltonReductionOQ02OQ01
 
 noncomputable section
 
@@ -193,32 +194,112 @@ theorem cyclic_iff_ann_eq_minpoly (M : Matrix (Fin n) (Fin n) K)
     exact absurd (Polynomial.natDegree_le_of_dvd hμ_dvd hp_ne) (by omega)
 
 -- ============================================================
--- SECTION IV: Main Theorem (All Fields)
+-- SECTION IV: Companion Matrix Cyclic Vector
 -- ============================================================
+
+-- Private helpers (analogues of private lemmas in CayleyHamiltonReductionOQ02OQ01)
+
+/-- Distribute mulVec over a finite sum of matrices. -/
+private theorem sum_mulVec_dist {ι : Type*} (s : Finset ι)
+    (f : ι → Matrix (Fin n) (Fin n) K) (v : Fin n → K) :
+    (∑ i ∈ s, f i) *ᵥ v = ∑ i ∈ s, f i *ᵥ v := by
+  induction s using Finset.induction_on with
+  | empty => simp [Matrix.zero_mulVec]
+  | @insert a s' has ih => rw [Finset.sum_insert has, Matrix.add_mulVec, ih, Finset.sum_insert has]
+
+/-- Expand aeval C q as a sum over range(natDegree q + 1). -/
+private lemma aeval_eq_range_sum (q : K[X]) (C : Matrix (Fin n) (Fin n) K) :
+    aeval C q = ∑ k ∈ Finset.range (q.natDegree + 1), q.coeff k • C ^ k := by
+  simp only [aeval_def, Polynomial.eval₂_eq_sum, Polynomial.sum_def]
+  apply Finset.sum_subset
+  · intro i hi
+    exact Finset.mem_range.mpr
+      (Nat.lt_succ_of_le (Polynomial.le_natDegree_of_mem_supp i hi))
+  · intro i _ hi
+    simp only [Polynomial.notMem_support_iff.mp hi, map_zero, zero_mul]
+
+/-- The standard basis vector e₀ is a cyclic vector for the companion matrix C(p).
+
+    Key: C(p)^k · e₀ = eₖ (orbit property), so p(C(p)) · e₀ expands as a
+    weighted sum of standard basis vectors. If this is 0, all coefficients
+    (hence all of p) must be 0. -/
+theorem companionMatrix_cyclic_e0 (hn : 0 < n) (p : K[X]) (hp : p.Monic)
+    (hdeg : p.natDegree = n) :
+    IsCyclicVector (CayleyHamiltonReductionOQ02OQ01.companionMatrix (d := n) p)
+                   (Pi.single (0 : Fin n) 1) := by
+  set C := CayleyHamiltonReductionOQ02OQ01.companionMatrix (d := n) p
+  intro q hq_deg hann
+  by_contra hq_ne
+  -- q ≠ 0, so leadingCoeff ≠ 0
+  have hlc : q.leadingCoeff ≠ 0 := Polynomial.leadingCoeff_ne_zero.mpr hq_ne
+  -- Expand: (aeval C q) *ᵥ e₀ = ∑_{k < natDeg+1} q.coeff k • (C^k *ᵥ e₀)
+  rw [aeval_eq_range_sum q C, sum_mulVec_dist] at hann
+  simp only [Matrix.smul_mulVec] at hann
+  -- Substitute orbit: C^k *ᵥ e₀ = e_k for k ≤ natDegree q < n
+  have hklt : ∀ k : Fin (q.natDegree + 1), k.val < n := fun k => by omega
+  have hterms : ∑ k ∈ Finset.range (q.natDegree + 1),
+      q.coeff k • (C ^ k).mulVec (Pi.single (0 : Fin n) 1) =
+      ∑ k : Fin (q.natDegree + 1),
+        q.coeff k.val • (Pi.single ⟨k.val, hklt k⟩ 1 : Fin n → K) := by
+    rw [← Fin.sum_univ_eq_sum_range]
+    congr 1; funext k
+    congr 1
+    exact CayleyHamiltonReductionOQ02OQ01.companionMatrix_pow_basis p k.val (hklt k)
+  rw [hterms] at hann
+  -- Evaluate at position ⟨q.natDegree, hq_deg⟩ to extract leading coefficient
+  have hval := congr_fun hann ⟨q.natDegree, hq_deg⟩
+  simp only [Finset.sum_apply, Pi.smul_apply, smul_eq_mul, Pi.single_apply, Pi.zero_apply,
+             Fin.mk.injEq] at hval
+  -- Collapse: only term k.val = q.natDegree contributes
+  rw [Finset.sum_eq_single ⟨q.natDegree, Nat.lt_succ_self _⟩
+    (fun k _ hk => by
+      have hne : k.val ≠ q.natDegree := fun h => hk (Fin.ext h)
+      simp [hne, Ne.symm hne])
+    (fun h => absurd (Finset.mem_univ _) h)] at hval
+  simp only [↓reduceIte, mul_one] at hval
+  -- hval : q.coeff q.natDegree = 0, but q.leadingCoeff = q.coeff q.natDegree ≠ 0
+  exact hlc (show q.leadingCoeff = 0 from hval)
+
+-- ============================================================
+-- SECTION IV.5: Main Theorem (All Fields)
+-- ============================================================
+
+/-- KEY SORRY: Every nonderogatory matrix is similar to its companion matrix.
+    This is the Rational Canonical Form theorem (Frobenius normal form).
+    Requires: structure theorem for f.g. modules over K[X] (a PID). -/
+theorem nonderogatory_similar_companion (hn : 0 < n)
+    (M : Matrix (Fin n) (Fin n) K) (h : IsNonderogatory M) :
+    ∃ P : (Matrix (Fin n) (Fin n) K)ˣ,
+      M = P.inv * CayleyHamiltonReductionOQ02OQ01.companionMatrix (d := n) (minpoly K M) * P.val := by
+  sorry -- Requires: Rational Canonical Form / PID module structure theorem (not in Mathlib)
 
 /-- **Main Result**: Over ANY field K, nonderogatory matrices have cyclic vectors.
 
-    This removes the [Infinite K] hypothesis from OQ-05-OQ-01 and the
-    [Fintype K] + cardinality condition from OQ-05-OQ-01-OQ-01.
+    Proof structure:
+    1. [sorry] M is similar to C(minpoly M) — the companion matrix (RCF theorem)
+    2. [proved] e₀ is cyclic for C(minpoly M) — orbit property of companion matrices
+    3. [proved] Cyclic vectors transfer under matrix similarity
 
-    The proof uses the structure theorem for finitely generated modules
-    over a PID: since K[X] is a PID and K^n is a f.g. torsion K[X]-module
-    (via M), it decomposes as K[X]/(d₁) ⊕ ... ⊕ K[X]/(dᵣ) with d₁|...|dᵣ.
-    Nonderogatory (minpoly = charpoly) forces r = 1, so V ≅ K[X]/(minpoly),
-    which is a cyclic module — its generator is a cyclic vector.
-
-    This result cannot be proved by union avoidance alone when |K| ≤ n. -/
+    The sorry isolates exactly the missing Mathlib infrastructure: the PID module
+    structure theorem giving Rational Canonical Form. -/
 theorem nonderogatory_has_cyclic_vector_any_field
     (M : Matrix (Fin n) (Fin n) K) (h : IsNonderogatory M) :
     ∃ v, IsCyclicVector M v := by
   rcases Nat.eq_zero_or_pos n with rfl | hn
   · exact ⟨Fin.elim0, fun p hp _ => by omega⟩
-  -- The proof requires the structure theorem for f.g. modules over K[X]:
-  -- V = K[X]/(d₁) ⊕ ... ⊕ K[X]/(dᵣ) with d₁|...|dᵣ
-  -- minpoly = dᵣ, charpoly = d₁·...·dᵣ
-  -- Nonderogatory: dᵣ = d₁·...·dᵣ, forcing r=1
-  -- So V = K[X]/(minpoly), cyclic with generator v
-  sorry -- Requires: structure theorem for f.g. modules over PID (not in Mathlib)
+  -- Step 1: M ~ C(minpoly M) [sorry: RCF theorem]
+  obtain ⟨P, hMC⟩ := nonderogatory_similar_companion hn M h
+  -- Step 2: minpoly M has degree n (since M is nonderogatory)
+  have hμ_deg : (minpoly K M).natDegree = n := by
+    have := h  -- IsNonderogatory: minpoly K M = M.charpoly
+    rw [h, Matrix.charpoly_natDegree_eq_dim, Fintype.card_fin]
+  -- Step 3: e₀ is cyclic for C(minpoly M) [proved: no sorry]
+  have hμ_monic : (minpoly K M).Monic := minpoly.monic (Matrix.isIntegral M)
+  have hcyc := companionMatrix_cyclic_e0 hn (minpoly K M) hμ_monic hμ_deg
+  -- Step 4: Transfer cyclic vector along similarity [proved: no sorry]
+  exact cyclic_vector_of_similar M
+    (CayleyHamiltonReductionOQ02OQ01.companionMatrix (d := n) (minpoly K M))
+    P hMC _ hcyc
 
 /-- Corollary: The cyclic vector theorem holds over all finite fields,
     including those with |K| ≤ n. The union avoidance lemma is not needed. -/
@@ -247,15 +328,23 @@ a cyclic vector? Does the theorem fail when q ≤ n?
 
 **Answer**: The theorem holds for ALL (n, q). No failure threshold exists.
 
-**Proof**: The module-theoretic proof (via the structure theorem for f.g. modules
-over the PID K[X]) works over any field. The union avoidance argument used in
-OQ-05-OQ-01 is merely one proof technique — its failure over small fields does
-not imply the theorem fails.
+**Proof structure** (modular):
+1. [sorry] `nonderogatory_similar_companion`: M ~ C(minpoly M) — Rational Canonical Form
+2. [proved] `companionMatrix_cyclic_e0`: e₀ is cyclic for C(p) — orbit lemma
+3. [proved] `cyclic_vector_of_similar`: cyclic vectors transfer under similarity
+4. Main theorem follows from 1+2+3.
 
-**Key sorry**: `nonderogatory_has_cyclic_vector_any_field` requires the structure
-theorem for f.g. modules over a PID, which is not currently in Mathlib.
+**Key sorry**: `nonderogatory_similar_companion` requires the structure theorem for
+f.g. modules over K[X] (a PID), which gives Rational Canonical Form. Not in Mathlib.
+
+**Progress vs previous version**: Replaced a monolithic `sorry` with a modular proof.
+The new `companionMatrix_cyclic_e0` (no sorry) establishes the orbit-based cyclic
+vector argument. The remaining sorry is isolated to exactly the RCF similarity step.
 
 **Proved (sorry-free)**:
+- `sum_mulVec_dist`: mulVec distributes over finite sums
+- `aeval_eq_range_sum`: aeval expansion as sum over range(natDegree+1)
+- `companionMatrix_cyclic_e0`: e₀ cyclic for companion matrix (orbit argument)
 - `annihilator_dvd_minpoly`: Bezout identity for GCD annihilation
 - `cyclic_iff_ann_eq_minpoly`: Characterization of cyclic vectors via annihilators
 - `aeval_conj`: Conjugation commutes with polynomial evaluation (inductive proof)

--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01/meta.json
@@ -155,6 +155,5 @@
       "year": "1707",
       "note": "Newton's identities relating power sums to elementary symmetric polynomials. The n=2 case p₂ = e₁² - 2e₂ is the simplest instance"
     }
-  ],
-  "sorries": 0
+  ]
 }

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01",
   "title": "Complete Nonderogatory to Cyclic Vector: The General Case (All Fields)",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -49,14 +49,22 @@
     }
   },
   "knowledge": {
-    "progressSummary": "NEW: Selected by Seeker. Prior work (oq-05-oq-01 through incomplete-01) has proved all auxiliary lemmas; only the main sorry remains. The direct PID route is blocked; alternative routes (companion matrix, span argument) need Mathlib survey.",
-    "builtItems": [],
+    "progressSummary": "PROGRESS: companionMatrix_cyclic_e0 proved (no sorry). Main theorem modularized: only nonderogatory_similar_companion (RCF) remains as sorry. PR #12510.",
+    "builtItems": [
+      "sum_mulVec_dist: mulVec distributes over Finset sums (CayleyHamiltonMinpolyOQ05OQ01OQ04.lean)",
+      "aeval_eq_range_sum: aeval as sum over range(natDegree+1) (CayleyHamiltonMinpolyOQ05OQ01OQ04.lean)",
+      "companionMatrix_cyclic_e0: e0 is cyclic for C(p), proved via orbit lemma, NO SORRY (CayleyHamiltonMinpolyOQ05OQ01OQ04.lean:226)",
+      "nonderogatory_similar_companion: M~C(minpoly M), sorry=RCF theorem (CayleyHamiltonMinpolyOQ05OQ01OQ04.lean:269)"
+    ],
     "insights": [
       "The blocking step is the PID structure theorem: K^n ≅ K[X]/(d1) ⊕ … ⊕ K[X]/(dr) as K[X]-modules",
       "nonderogatory forces r=1 in the cyclic decomposition, giving K^n ≅ K[X]/(minpoly)",
       "cyclic_iff_ann_eq_minpoly (already proven) reduces the problem to: ∃ v, ann(v) = (minpoly)",
       "companion matrix approach: if M ~ companion(charpoly), then e1 is a cyclic vector for companion, and cyclic_vector_of_similar transfers it to M",
-      "Whether rational canonical form / companion similarity exists in Mathlib is the key unknown"
+      "Whether rational canonical form / companion similarity exists in Mathlib is the key unknown",
+      "companionMatrix_cyclic_e0 is provable by orbit argument: C(p)^k*e0=ek then evaluate at natDegree position",
+      "by_contra + leadingCoeff extraction cleanly isolates the zero coefficient contradiction",
+      "Modular proof structure: RCF similarity (sorry) + cyclic e0 (proved) + similarity transfer (proved)"
     ],
     "mathlibGaps": [
       "Module.InvariantFactors or PID cyclic decomposition theorem",
@@ -64,10 +72,10 @@
       "Finrank-based argument for span of orbit: does LinearMap.span_orbit_eq_top exist?"
     ],
     "nextSteps": [
-      "Search Mathlib for 'companion' in Matrix namespace",
-      "Search Mathlib for 'rationaCanonicalForm' or 'invariantFactors'",
-      "Check if primary decomposition approach is feasible: Module.primaryDecomposition in Mathlib",
-      "Try dimension argument: span{v, Mv, …, M^(n-1)v} has dim n iff ann(v) = (minpoly) — use rank-nullity"
+      "Prove nonderogatory_similar_companion: needs PID module structure / RCF theorem",
+      "Check if Mathlib LinearAlgebra.RationalCanonicalForm or similar exists (search v4.26+)",
+      "Alternative: build minimal PID structure theorem ~500 lines (V cyclic iff ann ideal principal)",
+      "Consider: can we avoid full RCF by using Module.AEval + annihilator directly?"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

- **Problem**: `cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01` — Nonderogatory ⟹ Cyclic Vector over ANY field
- **Branch**: `feature/researcher-11`
- **File**: `proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean`

## What Changed

Replaced a monolithic `sorry` (covering the entire main theorem) with a modular proof structure:

### New (sorry-free) theorems:
- `sum_mulVec_dist`: mulVec distributes over Finset sums
- `aeval_eq_range_sum`: aeval expands as ∑ over range(natDegree+1)
- `companionMatrix_cyclic_e0`: **e₀ is a cyclic vector for the companion matrix C(p)**

### Proof technique for `companionMatrix_cyclic_e0`:
1. `by_contra hq_ne` — assume the polynomial q is nonzero
2. Expand `aeval C(p) q *ᵥ e₀` using the orbit: `C(p)^k *ᵥ e₀ = eₖ`
3. Evaluate at position `⟨q.natDegree, _⟩` — only the leading term contributes
4. Conclude `q.leadingCoeff = 0`, contradicting `q ≠ 0`

### Remaining sorry (isolated):
- `nonderogatory_similar_companion`: M ~ C(minpoly M) (Rational Canonical Form)
  - Requires: PID module structure theorem for K[X]-modules (not in Mathlib 4)

## Knowledge Update

- Imports `Proofs.CayleyHamiltonReductionOQ02OQ01` for companion matrix infrastructure
- Main theorem now clearly decomposes as: RCF (sorry) + orbit lemma (proved) + similarity transfer (proved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)