### PR TITLE
chore: sync research registry data

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -17624,11 +17624,12 @@
     },
     {
       "slug": "synthesis-curvature-ptolemy-2026-04-24",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "fast",
       "started": "2026-04-25T12:53:24.054Z",
-      "status": "active",
-      "lastUpdate": "2026-04-26T00:21:44.872Z"
+      "status": "graduated",
+      "lastUpdate": "2026-04-26T00:49:56.946Z",
+      "completed": "2026-04-26T00:49:56.945Z"
     },
     {
       "slug": "ballot-problem-oq-03-oq-01-oq-04",


### PR DESCRIPTION
## Summary
- Automated sync of research registry.json with latest iteration counts

## Context
Part of the deployer's regular sync cycle. Registry entries updated with current timestamps and status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)