### PR TITLE
enrichment: abel-ruffini — align Part VI/VII annotation ranges with section boundaries

### DIFF
--- a/src/data/proofs/abel-ruffini/annotations.json
+++ b/src/data/proofs/abel-ruffini/annotations.json
@@ -345,7 +345,7 @@
     "proofId": "abel-ruffini",
     "range": {
       "startLine": 151,
-      "endLine": 183
+      "endLine": 163
     },
     "type": "insight",
     "title": "Part VI: Why Degree 5 Is the Exact Threshold",
@@ -372,8 +372,8 @@
     "id": "ann-part-vii-historical",
     "proofId": "abel-ruffini",
     "range": {
-      "startLine": 151,
-      "endLine": 183
+      "startLine": 164,
+      "endLine": 185
     },
     "type": "insight",
     "title": "Part VII: The Impossibility Paradigm and Historical Significance",


### PR DESCRIPTION
Enrichment pass for abel-ruffini. Entry is already at quality 100 with 5 passes; this pass makes a minor structural accuracy fix.

## Changes

- `ann-part-vi-threshold`: range updated from `151–183` → `151–163` (covers only Part VI content)
- `ann-part-vii-historical`: range updated from `151–183` → `164–185` (covers only Part VII content)

Both annotations previously had identical overlapping ranges covering the entire Parts VI–VII docstring block (lines 151–183). The sections in `meta.json` correctly defined the boundary at line 163/164 (where `## Part VII: Historical Significance` begins in the Lean file), but the annotation ranges didn't reflect this split. This aligns annotations with sections for consistency.

No content changes — only range metadata corrected.