### PR TITLE
Fix: abel-ruffini-galois-extensions-oq-04 badge should be mathlib not verified

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-04/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-04/meta.json
@@ -16,11 +16,18 @@
             "finite-groups",
             "abel-ruffini"
         ],
-        "badge": "verified",
+        "badge": "mathlib",
         "sorries": 0,
         "dateAdded": "2026-04-24",
         "axiomCount": 0,
         "assumptions": "",
+        "mathlibDependencies": [
+            {
+                "theorem": "CompositionSeries.jordan_holder",
+                "description": "Jordan-Hölder uniqueness: any two composition series have the same length and isomorphic factors",
+                "module": "Mathlib.Order.JordanHolder"
+            }
+        ],
         "lineCount": 255,
         "theoremCount": 9,
         "definitionCount": 3,


### PR DESCRIPTION
## Fix

Corrects the badge classification for `abel-ruffini-galois-extensions-oq-04` from `verified` (Tier A — independent formalization) to `mathlib` (Tier B — Mathlib bridge proof).

## Evidence

**Before**: `meta.badge: "verified"`, `meta.mathlibDependencies: null`
**After**: `meta.badge: "mathlib"`, `meta.mathlibDependencies: [{ theorem: "CompositionSeries.jordan_holder", ... }]`

The named theorems `jordan_holder_subgroups` and `jordan_holder_finite_groups` are one-line delegations to Mathlib's `CompositionSeries.jordan_holder`. The primary original contribution is `instJordanHolderLatticeSubgroup` (filling a Mathlib TODO), but the main theorem itself is a Mathlib derivation — making this Tier B.

The `status: "verified"` and `axiomCount: 0` are correct (0 sorries, 0 axioms) and are unchanged.

Closes #12530

---
Automated fix by lean-mechanic agent.