### PR TITLE
chore(audit): fix sorry count ballot-problem-oq-03-oq-01-oq-01-oq-01 (2 → 3)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "ballot-problem-oq-03-oq-01-oq-01-oq-01",
   "title": "Jacobi-Trudi Identity: Schur Polynomials as Determinants of Complete Homogeneous Symmetric Polynomials",
   "slug": "ballot-problem-oq-03-oq-01-oq-01-oq-01",
-  "description": "Defines Schur polynomials via the Jacobi-Trudi determinant formula and the SSYT generating function. Proves key properties (symmetry, base cases, two-row formula, hook-length evaluation, k=0,1 SSYT bijections). The k=2 SSYT equality (ssytSchurFin_two_row) is stated with sorry (jdt bijection ~200 lines); the general k\u22653 case is open (algebraic LGV + RSK ~300 lines).",
+  "description": "Defines Schur polynomials via the Jacobi-Trudi determinant formula and the SSYT generating function. Proves key properties (symmetry, base cases, two-row formula, hook-length evaluation, k=0,1 SSYT bijections). The k=2 SSYT equality (ssytSchurFin_two_row) is proved but relies on 2 sorry'd private helpers (jdt_weight_sum and ssytFin_two_row_eq_sum_colstrict, ~200 lines total); the general k\u22653 case is open (algebraic LGV + RSK ~300 lines).",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-24",
@@ -19,10 +19,10 @@
       "ssyt"
     ],
     "badge": "formalized",
-    "sorries": 2,
+    "sorries": 3,
     "dateAdded": "2026-04-23",
     "axiomCount": 0,
-    "assumptions": "2 sorries: (1) ssytSchurFin_two_row (k=2 case via jdt bijection ~200 lines); (2) jacobi_trudi_ssyt_eq k\u22653 via algebraic LGV + RSK (~300 lines). k=0 and k=1 cases proved explicitly.",
+    "assumptions": "3 sorries: (1) jdt_weight_sum (private: JDT involution weight sum for 2-row case); (2) ssytFin_two_row_eq_sum_colstrict (private: row decomposition bijection for k=2 SSYT, ~200 lines combined); (3) jacobi_trudi_ssyt_eq k\u22653 via algebraic LGV + RSK (~300 lines). Note: ssytSchurFin_two_row is proved but depends on these sorry'd helpers. k=0 and k=1 cases proved explicitly.",
     "lineCount": 405,
     "theoremCount": 11,
     "definitionCount": 5,
@@ -58,7 +58,7 @@
     ]
   },
   "conclusion": {
-    "summary": "Defines Schur polynomials via both Jacobi-Trudi formula and SSYT generating function. Proves symmetry, base cases (k=0,1 for both), two-row formula, hook-length evaluation, and k=1 SSYT bijection. 2 sorries: ssytSchurFin_two_row (k=2, jdt bijection) and jacobi_trudi_ssyt_eq k\u22653 (algebraic LGV + RSK).",
+    "summary": "Defines Schur polynomials via both Jacobi-Trudi formula and SSYT generating function. Proves symmetry, base cases (k=0,1 for both), two-row formula, hook-length evaluation, and k=1 SSYT bijection. 3 sorries: jdt_weight_sum and ssytFin_two_row_eq_sum_colstrict (private helpers for k=2 jdt bijection, ~200 lines) and jacobi_trudi_ssyt_eq k\u22653 (algebraic LGV + RSK, ~300 lines).",
     "implications": "This provides: (1) the first Lean 4 Jacobi-Trudi matrix definition, (2) the first Lean 4 SSYT type for arbitrary partition shapes with Fintype instance, (3) the first formal statement that det[h_{\u03bb\u1d62-i+j}] = \u03a3_T weight(T) as a meaningful theorem. The remaining sorry precisely identifies the RSK correspondence for k \u2265 2 (~300 lines) as the key missing ingredient. A completed formalization would unlock: the Pieri rule $s_\\lambda h_n = \\sum_\\mu s_\\mu$, the Murnaghan-Nakayama rule, and connections to Schubert calculus via the existing LGV infrastructure in the gallery.",
     "openQuestions": [
       "Prove jacobi_trudi_ssyt_eq (general case, k \u2265 2): RSK correspondence SSYT \u2194 NI lattice path tuples for the LGV configuration, then weight matching with hsymm products"
@@ -83,7 +83,7 @@
     "theoremCount": 11,
     "definitionCount": 5,
     "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
-    "sorries": 2
+    "sorries": 3
   },
   "crossReferences": [
     {
@@ -167,8 +167,8 @@
       "startLine": 160,
       "endLine": 272,
       "summary": "Defines SSYTFin (bounded SSYT type with Fintype instance), ssytSchurFin (SSYT generating function), proves ssytSchurFin_empty (k=0), proves ssytSchurFin_one_row (k=1, bijection via sorted multiset reps), and states jacobi_trudi_ssyt_eq (general, sorry for k \u2265 2).",
-      "mathContext": "SSYTFin n k sh = subtype of ((i:Fin k)\u00d7Fin(sh i)\u2192Fin n) satisfying row-weak (weakly increasing rows) and col-strict (strictly increasing columns). Fintype instance via Subtype.fintype (decidable predicates over finite types). ssytSchurFin = \u2211_T T.weight where T.weight = \u220f_p X(T p). k=0 proved by Unique (empty SSYT, both conditions vacuous) + IsEmpty (empty product = 1). k=1 proved via Fintype.sum_equiv with bijection \u03c8: SSYTFin n 1 \u2243 Sym (Fin n) m using List.sortedLE_ofFn_iff (Monotone \u2194 SortedLE). General case (k \u2265 2): RSK correspondence (~300 lines), 2 sorries remain (ssytSchurFin_two_row + jacobi_trudi_ssyt_eq k\u22653)."
+      "mathContext": "SSYTFin n k sh = subtype of ((i:Fin k)\u00d7Fin(sh i)\u2192Fin n) satisfying row-weak (weakly increasing rows) and col-strict (strictly increasing columns). Fintype instance via Subtype.fintype (decidable predicates over finite types). ssytSchurFin = \u2211_T T.weight where T.weight = \u220f_p X(T p). k=0 proved by Unique (empty SSYT, both conditions vacuous) + IsEmpty (empty product = 1). k=1 proved via Fintype.sum_equiv with bijection \u03c8: SSYTFin n 1 \u2243 Sym (Fin n) m using List.sortedLE_ofFn_iff (Monotone \u2194 SortedLE). k=2 case: ssytSchurFin_two_row is proved but depends on 2 sorry'd private helpers (jdt_weight_sum + ssytFin_two_row_eq_sum_colstrict). General case (k \u2265 3): RSK correspondence (~300 lines), 3 sorries total in file."
     }
   ],
-  "sorries": 2
+  "sorries": 3
 }


### PR DESCRIPTION
## Summary

- Corrects `sorries` field from 2 → 3 in `meta.json` for `ballot-problem-oq-03-oq-01-oq-01-oq-01`
- The Lean file `BallotProblemOQ03OQ01OQ01OQ01.lean` contains 3 `sorry` keywords (lines 342, 358, 455)
- meta.json incorrectly claimed 2 sorries

## Evidence

**Lean file shows 3 sorries:**
- Line 342: `jdt_weight_sum` (private helper — JDT involution weight sum)
- Line 358: `ssytFin_two_row_eq_sum_colstrict` (private helper — row decomposition bijection)
- Line 455: `jacobi_trudi_ssyt_eq` (main theorem, k≥3 case)

**Note**: `ssytSchurFin_two_row` (the theorem meta.json was listing as sorry'd) is actually proved — it depends on the two sorry'd private helpers above.

## Fields Updated

- `meta.sorries`: 2 → 3
- `leanFile.sorries`: 2 → 3
- Top-level `sorries`: 2 → 3
- `meta.assumptions`: Updated to list all 3 actual sorry'd items accurately
- `description`: Corrected to note ssytSchurFin_two_row is proved (not sorry'd), with 2 sorry'd helpers
- `conclusion.summary`: Updated sorry count and description
- `sections[sec-ssyt-definition].mathContext`: Updated to reflect 3 sorries

---
Discovered during gallery integrity audit.

Labels: enrichment