### PR TITLE
enrichment: amgm family (oq-02-oq-01, oq-01-oq-02, oq-02-oq-03, oq-02-oq-03-oq-03)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01/annotations.json
@@ -8,7 +8,7 @@
     },
     "type": "insight",
     "title": "Crossing-Zero Strategy: One AM-GM Application for All r",
-    "content": "The module header explains the elegant strategy: the single inequality GM(z,w)^r ≤ ∑ wᵢ zᵢ^r (proved by applying AM-GM to the values zᵢ^r) implies both M_r ≤ GM for r < 0 and GM ≤ M_s for s > 0 by simple exponentiation. This avoids limit arguments entirely — the L'Hôpital approach needed for M_0 = GM is sidestepped because we work with M_r for r ≠ 0. Imports AmgmInequalityOQ03 for the weighted power mean definitions.",
+    "content": "The module header explains the elegant strategy: the single inequality GM(z,w)^r \u2264 \u2211 w\u1d62 z\u1d62^r (proved by applying AM-GM to the values z\u1d62^r) implies both M_r \u2264 GM for r < 0 and GM \u2264 M_s for s > 0 by simple exponentiation. This avoids limit arguments entirely \u2014 the L'H\u00f4pital approach needed for M_0 = GM is sidestepped because we work with M_r for r \u2260 0. Imports AmgmInequalityOQ03 for the weighted power mean definitions.",
     "mathContext": "Key idea: $\\text{GM}^r = (\\prod_i z_i^{w_i})^r = \\prod_i (z_i^r)^{w_i} \\le \\sum_i w_i z_i^r$ (AM-GM applied to $z_i^r$ values). Then: $r > 0 \\Rightarrow$ GM $= (\\text{GM}^r)^{1/r} \\le (\\sum)^{1/r} = M_r$. $r < 0 \\Rightarrow$ invert to get $M_r \\le$ GM.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -32,7 +32,7 @@
     },
     "type": "concept",
     "title": "Helper Lemmas: Positivity and the prod_rpow_comm Identity",
-    "content": "Four private lemmas prepare the main argument: (1) weightedSum_rpow_pos proves ∑ wᵢzᵢ^r > 0 (needed for division in the power mean) via a non-trivial positivity argument: at least one weight must be positive (otherwise they'd sum to 0, not 1). (2) weightedGeomMean_pos is immediate from rpow_pos_of_pos. (3) finset_prod_rpow proves (∏ fᵢ)^r = ∏ fᵢ^r by Finset.induction_on using Real.mul_rpow. (4) prod_rpow_comm proves (∏ zᵢ^wᵢ)^r = ∏ (zᵢ^r)^wᵢ via rpow_mul applied twice, using the chain zᵢ^(r·wᵢ) = zᵢ^(wᵢ·r).",
+    "content": "Four private lemmas prepare the main argument: (1) weightedSum_rpow_pos proves \u2211 w\u1d62z\u1d62^r > 0 (needed for division in the power mean) via a non-trivial positivity argument: at least one weight must be positive (otherwise they'd sum to 0, not 1). (2) weightedGeomMean_pos is immediate from rpow_pos_of_pos. (3) finset_prod_rpow proves (\u220f f\u1d62)^r = \u220f f\u1d62^r by Finset.induction_on using Real.mul_rpow. (4) prod_rpow_comm proves (\u220f z\u1d62^w\u1d62)^r = \u220f (z\u1d62^r)^w\u1d62 via rpow_mul applied twice, using the chain z\u1d62^(r\u00b7w\u1d62) = z\u1d62^(w\u1d62\u00b7r).",
     "mathContext": "prod_rpow_comm: $(\\prod_i z_i^{w_i})^r = \\prod_i z_i^{r w_i} = \\prod_i (z_i^r)^{w_i}$. This is the algebraic identity that converts $\\text{GM}^r$ into the form needed for AM-GM.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -56,14 +56,18 @@
     },
     "type": "insight",
     "title": "geomMean_rpow_le_weightedSum_rpow: The Universal Core Inequality",
-    "content": "The central lemma: GM(z,w)^r ≤ ∑ wᵢzᵢ^r for ALL r ∈ ℝ. The proof applies Real.geom_mean_le_arith_mean_weighted (weighted AM-GM) to the values zᵢ^r with original weights wᵢ. This gives ∏ (zᵢ^r)^wᵢ ≤ ∑ wᵢzᵢ^r. Then prod_rpow_comm rewrites the LHS: ∏ (zᵢ^r)^wᵢ = (∏ zᵢ^wᵢ)^r = GM^r. The proof is just 3 lines (amgm application + prod_rpow_comm + simp). This single inequality simultaneously implies both GM ≤ M_r and M_r ≤ GM depending on the sign of r.",
+    "content": "The central lemma: GM(z,w)^r \u2264 \u2211 w\u1d62z\u1d62^r for ALL r \u2208 \u211d. The proof applies Real.geom_mean_le_arith_mean_weighted (weighted AM-GM) to the values z\u1d62^r with original weights w\u1d62. This gives \u220f (z\u1d62^r)^w\u1d62 \u2264 \u2211 w\u1d62z\u1d62^r. Then prod_rpow_comm rewrites the LHS: \u220f (z\u1d62^r)^w\u1d62 = (\u220f z\u1d62^w\u1d62)^r = GM^r. The proof is just 3 lines (amgm application + prod_rpow_comm + simp). This single inequality simultaneously implies both GM \u2264 M_r and M_r \u2264 GM depending on the sign of r.",
     "mathContext": "$\\text{GM}(z,w)^r = (\\prod_i z_i^{w_i})^r = \\prod_i (z_i^r)^{w_i} \\le \\sum_i w_i z_i^r$ by AM-GM applied to the values $\\{z_i^r\\}$ with weights $\\{w_i\\}$.",
     "significance": "key",
     "relatedConcepts": [
       "Real.geom_mean_le_arith_mean_weighted",
       "weighted AM-GM",
       "prod_rpow_comm",
-      "power mean definition"
+      "power mean definition",
+      "sandwich lemma",
+      "transitive inequality chain",
+      "mean value comparison",
+      "monotone function composition"
     ],
     "prerequisites": [
       "weightedGeomMean definition",
@@ -80,7 +84,7 @@
     },
     "type": "concept",
     "title": "geom_mean_le_power_mean_pos: Raising to a Positive Power",
-    "content": "For r > 0, the core inequality GM^r ≤ ∑ wᵢzᵢ^r becomes GM ≤ M_r after raising both sides to the power 1/r > 0. The key step: GM = (GM^r)^(1/r) (using Real.rpow_natCast and the inverse relationship), and (∑)^(1/r) = M_r by definition. This extends the r ≥ 1 case from AmgmInequalityOQ03 to all r > 0, including the important range 0 < r < 1.",
+    "content": "For r > 0, the core inequality GM^r \u2264 \u2211 w\u1d62z\u1d62^r becomes GM \u2264 M_r after raising both sides to the power 1/r > 0. The key step: GM = (GM^r)^(1/r) (using Real.rpow_natCast and the inverse relationship), and (\u2211)^(1/r) = M_r by definition. This extends the r \u2265 1 case from AmgmInequalityOQ03 to all r > 0, including the important range 0 < r < 1.",
     "mathContext": "From $\\text{GM}^r \\le \\sum w_i z_i^r$ and $1/r > 0$: $(\\text{GM}^r)^{1/r} \\le (\\sum w_i z_i^r)^{1/r} = M_r$. And $(\\text{GM}^r)^{1/r} = \\text{GM}$ by $\\text{rpow}(r, 1/r)$.",
     "significance": "key",
     "relatedConcepts": [
@@ -103,13 +107,17 @@
     },
     "type": "insight",
     "title": "power_mean_le_geom_mean_neg: Inversion Reverses the Inequality",
-    "content": "For r < 0, the core inequality GM^r ≤ ∑ wᵢzᵢ^r gives M_r ≤ GM by raising to the NEGATIVE power 1/r < 0 (which reverses ≤). The algebraic argument: since 1/r < 0, write 1/r = -(1/(-r)) where 1/(-r) > 0. Raising GM^r ≤ ∑ to the power -(1/(-r)) reverses: (GM^r)^(-(1/(-r))) ≥ (∑)^(-(1/(-r))). Inversion (A ≤ B and both positive → B⁻¹ ≤ A⁻¹) then gives M_r = (∑)^(1/r) ≤ (GM^r)^(1/r) = GM. This is the longest proof section (62 lines) due to the careful positivity bookkeeping in Lean.",
+    "content": "For r < 0, the core inequality GM^r \u2264 \u2211 w\u1d62z\u1d62^r gives M_r \u2264 GM by raising to the NEGATIVE power 1/r < 0 (which reverses \u2264). The algebraic argument: since 1/r < 0, write 1/r = -(1/(-r)) where 1/(-r) > 0. Raising GM^r \u2264 \u2211 to the power -(1/(-r)) reverses: (GM^r)^(-(1/(-r))) \u2265 (\u2211)^(-(1/(-r))). Inversion (A \u2264 B and both positive \u2192 B\u207b\u00b9 \u2264 A\u207b\u00b9) then gives M_r = (\u2211)^(1/r) \u2264 (GM^r)^(1/r) = GM. This is the longest proof section (62 lines) due to the careful positivity bookkeeping in Lean.",
     "mathContext": "For $r < 0$: $\\text{GM}^r \\le \\sum w_i z_i^r$. Since $r < 0$, raising to $1/r < 0$ reverses: $M_r = (\\sum)^{1/r} \\le (\\text{GM}^r)^{1/r} = \\text{GM}^{r \\cdot (1/r)} = \\text{GM}^1 = \\text{GM}$.",
     "significance": "key",
     "relatedConcepts": [
       "inequality reversal under negative exponent",
       "Real.rpow_le_rpow_of_exponent_le",
-      "positivity of power mean"
+      "positivity of power mean",
+      "harmonic mean inequality",
+      "negative power monotonicity",
+      "AM-HM duality",
+      "power function convexity"
     ],
     "prerequisites": [
       "geomMean_rpow_le_weightedSum_rpow",
@@ -125,15 +133,19 @@
       "endLine": 225
     },
     "type": "insight",
-    "title": "Main Theorem and HM ≤ GM ≤ AM: Completing the Chain",
-    "content": "power_mean_monotone_crossing_zero is a 3-line proof: M_r ≤ GM (from §4) and GM ≤ M_s (from §3), combined by le_trans. hm_le_gm_le_am_via_power_means is an immediate corollary at r=-1, s=1: it gives the classical HM ≤ GM ≤ AM chain as a special case. These two theorems, combined with power_mean_monotone_pos and power_mean_monotone_neg from AmgmInequalityOQ03, complete the full power mean monotonicity theorem: M_r ≤ M_s for all r ≤ s (r,s ≠ 0), which is then unified in PowerMeanMonotoneOQ.",
+    "title": "Main Theorem and HM \u2264 GM \u2264 AM: Completing the Chain",
+    "content": "power_mean_monotone_crossing_zero is a 3-line proof: M_r \u2264 GM (from \u00a74) and GM \u2264 M_s (from \u00a73), combined by le_trans. hm_le_gm_le_am_via_power_means is an immediate corollary at r=-1, s=1: it gives the classical HM \u2264 GM \u2264 AM chain as a special case. These two theorems, combined with power_mean_monotone_pos and power_mean_monotone_neg from AmgmInequalityOQ03, complete the full power mean monotonicity theorem: M_r \u2264 M_s for all r \u2264 s (r,s \u2260 0), which is then unified in PowerMeanMonotoneOQ.",
     "mathContext": "$M_r \\le \\text{GM} \\le M_s$ (for $r < 0 < s$) by le_trans. Special case: HM = $M_{-1} \\le \\text{GM} \\le M_1 = $ AM. Full chain with same-sign cases: $M_r \\le M_s$ for all $r \\le s$, $r,s \\ne 0$.",
     "significance": "key",
     "relatedConcepts": [
-      "HM ≤ GM ≤ AM",
+      "HM \u2264 GM \u2264 AM",
       "le_trans",
       "power_mean_monotone_pos (AmgmInequalityOQ03)",
-      "PowerMeanMonotoneOQ"
+      "PowerMeanMonotoneOQ",
+      "transitivity of \u2264",
+      "power mean ordering",
+      "complete chain of means",
+      "inequality composition"
     ],
     "prerequisites": [
       "power_mean_le_geom_mean_neg",

--- a/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "amgm-inequality-oq-03-oq-02-oq-01",
-  "title": "Power Mean Crossing Zero: M_r ≤ GM ≤ M_s for r < 0 < s",
+  "title": "Power Mean Crossing Zero: M_r \u2264 GM \u2264 M_s for r < 0 < s",
   "slug": "amgm-inequality-oq-03-oq-02-oq-01",
-  "description": "Proves that the weighted power mean M_r is at most the geometric mean GM for r < 0, and GM is at most M_s for s > 0, giving M_r ≤ GM ≤ M_s for any r < 0 < s. Combined with AmgmInequalityOQ03's same-sign cases, this completes the full monotonicity chain for weighted power means: M_r ≤ M_s for all r ≤ s (r,s ≠ 0). 0 sorries, 0 axioms.",
+  "description": "Proves that the weighted power mean M_r is at most the geometric mean GM for r < 0, and GM is at most M_s for s > 0, giving M_r \u2264 GM \u2264 M_s for any r < 0 < s. Combined with AmgmInequalityOQ03's same-sign cases, this completes the full monotonicity chain for weighted power means: M_r \u2264 M_s for all r \u2264 s (r,s \u2260 0). 0 sorries, 0 axioms.",
   "meta": {
     "author": "Lean Genius Research",
     "sourceUrl": "https://en.wikipedia.org/wiki/Power_mean",
@@ -23,11 +23,11 @@
     "assumptions": "",
     "mathlib_version": "4.26.0",
     "originalContributions": [
-      "geomMean_rpow_le_weightedSum_rpow: GM(z,w)^r ≤ ∑ wᵢ zᵢ^r for all r (core inequality via AM-GM)",
-      "geom_mean_le_power_mean_pos: GM ≤ M_r for all r > 0 (extends OQ03's r ≥ 1 to all r > 0)",
-      "power_mean_le_geom_mean_neg: M_r ≤ GM for all r < 0 (proves the crossing-zero lower bound)",
-      "power_mean_monotone_crossing_zero: M_r ≤ M_s for r < 0 < s (main theorem — completes monotonicity)",
-      "hm_le_gm_le_am_via_power_means: HM ≤ GM ≤ AM as special case (r=-1, s=1)"
+      "geomMean_rpow_le_weightedSum_rpow: GM(z,w)^r \u2264 \u2211 w\u1d62 z\u1d62^r for all r (core inequality via AM-GM)",
+      "geom_mean_le_power_mean_pos: GM \u2264 M_r for all r > 0 (extends OQ03's r \u2265 1 to all r > 0)",
+      "power_mean_le_geom_mean_neg: M_r \u2264 GM for all r < 0 (proves the crossing-zero lower bound)",
+      "power_mean_monotone_crossing_zero: M_r \u2264 M_s for r < 0 < s (main theorem \u2014 completes monotonicity)",
+      "hm_le_gm_le_am_via_power_means: HM \u2264 GM \u2264 AM as special case (r=-1, s=1)"
     ],
     "prerequisites": [
       "Weighted power means (AmgmInequalityOQ03.lean): definitions and same-sign monotonicity",
@@ -37,31 +37,32 @@
     "mathlibDependencies": [
       {
         "theorem": "Real.geom_mean_le_arith_mean_weighted",
-        "description": "Weighted AM-GM: ∏ zᵢ^wᵢ ≤ ∑ wᵢ zᵢ",
+        "description": "Weighted AM-GM: \u220f z\u1d62^w\u1d62 \u2264 \u2211 w\u1d62 z\u1d62",
         "module": "Mathlib.Analysis.MeanInequalities"
       },
       {
         "theorem": "Real.rpow_le_rpow",
-        "description": "x^r ≤ y^r for 0 ≤ x ≤ y and 0 ≤ r",
+        "description": "x^r \u2264 y^r for 0 \u2264 x \u2264 y and 0 \u2264 r",
         "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
       },
       {
         "theorem": "Real.mul_rpow",
-        "description": "(x * y)^r = x^r * y^r for 0 ≤ x, y",
+        "description": "(x * y)^r = x^r * y^r for 0 \u2264 x, y",
         "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
       }
     ]
   },
   "overview": {
-    "historicalContext": "The power mean inequality — that $M_r(z,w)$ is monotone increasing in $r$ — traces to Cauchy's 1821 proof of the AM-GM case ($r = 1$ vs $r = 0$) in the *Cours d'analyse*. The full generalization to arbitrary exponents $r$ was established by Schur (1923) and popularized in Hardy, Littlewood, and Pólya's *Inequalities* (1934, Theorem 16). The classical proof uses Jensen's inequality for the convex function $x \\mapsto x^{s/r}$ when $r$ and $s$ have the same sign, but this approach breaks down when $r < 0 < s$ because the function changes convexity across zero. The limiting case $M_0 = \\text{GM}$ requires L'Hôpital's rule (proved in OQ-02). This file closes the crossing-zero gap using a direct AM-GM argument that avoids convexity entirely, instead reducing to the single universal inequality $\\text{GM}^r \\le \\sum w_i z_i^r$.",
-    "problemStatement": "**Open Question (OQ-03-OQ-02-OQ-01):** Prove that M_r ≤ M_s whenever r < 0 < s, where M_r(z,w) = (∑ wᵢ zᵢ^r)^(1/r) is the weighted power mean of order r.\n\nThis is the crossing-zero case of the full power mean monotonicity theorem.",
-    "proofStrategy": "**Core inequality** (§2): For any r ∈ ℝ, GM(z,w)^r ≤ ∑ wᵢ zᵢ^r. Proof: Apply AM-GM (Real.geom_mean_le_arith_mean_weighted) to the values zᵢ^r with weights wᵢ. The LHS equals GM^r via the algebraic identity (∏ zᵢ^wᵢ)^r = ∏ (zᵢ^r)^wᵢ.\n\n**GM ≤ M_s for s > 0** (§3): From GM^s ≤ ∑ wᵢ zᵢ^s (the core inequality), raise both sides to 1/s > 0: GM = (GM^s)^(1/s) ≤ (∑ wᵢ zᵢ^s)^(1/s) = M_s.\n\n**M_r ≤ GM for r < 0** (§4): From GM^r ≤ ∑ wᵢ zᵢ^r, write M_r = (∑)^(1/r) = ((∑)^(-(1/r)))⁻¹. Since -(1/r) > 0, raise GM^r ≤ ∑ to the positive power -(1/r): (GM^r)^(-(1/r)) ≤ (∑)^(-(1/r)). Invert (reverses inequality): ((∑)^(-(1/r)))⁻¹ ≤ ((GM^r)^(-(1/r)))⁻¹ = GM.\n\n**Crossing-zero** (§5): M_r ≤ GM ≤ M_s by transitivity.",
+    "historicalContext": "The power mean inequality \u2014 that $M_r(z,w)$ is monotone increasing in $r$ \u2014 traces to Cauchy's 1821 proof of the AM-GM case ($r = 1$ vs $r = 0$) in the *Cours d'analyse*. The full generalization to arbitrary exponents $r$ was established by Schur (1923) and popularized in Hardy, Littlewood, and P\u00f3lya's *Inequalities* (1934, Theorem 16). The classical proof uses Jensen's inequality for the convex function $x \\mapsto x^{s/r}$ when $r$ and $s$ have the same sign, but this approach breaks down when $r < 0 < s$ because the function changes convexity across zero. The limiting case $M_0 = \\text{GM}$ requires L'H\u00f4pital's rule (proved in OQ-02). This file closes the crossing-zero gap using a direct AM-GM argument that avoids convexity entirely, instead reducing to the single universal inequality $\\text{GM}^r \\le \\sum w_i z_i^r$.",
+    "problemStatement": "**Open Question (OQ-03-OQ-02-OQ-01):** Prove that M_r \u2264 M_s whenever r < 0 < s, where M_r(z,w) = (\u2211 w\u1d62 z\u1d62^r)^(1/r) is the weighted power mean of order r.\n\nThis is the crossing-zero case of the full power mean monotonicity theorem.",
+    "proofStrategy": "**Core inequality** (\u00a72): For any r \u2208 \u211d, GM(z,w)^r \u2264 \u2211 w\u1d62 z\u1d62^r. Proof: Apply AM-GM (Real.geom_mean_le_arith_mean_weighted) to the values z\u1d62^r with weights w\u1d62. The LHS equals GM^r via the algebraic identity (\u220f z\u1d62^w\u1d62)^r = \u220f (z\u1d62^r)^w\u1d62.\n\n**GM \u2264 M_s for s > 0** (\u00a73): From GM^s \u2264 \u2211 w\u1d62 z\u1d62^s (the core inequality), raise both sides to 1/s > 0: GM = (GM^s)^(1/s) \u2264 (\u2211 w\u1d62 z\u1d62^s)^(1/s) = M_s.\n\n**M_r \u2264 GM for r < 0** (\u00a74): From GM^r \u2264 \u2211 w\u1d62 z\u1d62^r, write M_r = (\u2211)^(1/r) = ((\u2211)^(-(1/r)))\u207b\u00b9. Since -(1/r) > 0, raise GM^r \u2264 \u2211 to the positive power -(1/r): (GM^r)^(-(1/r)) \u2264 (\u2211)^(-(1/r)). Invert (reverses inequality): ((\u2211)^(-(1/r)))\u207b\u00b9 \u2264 ((GM^r)^(-(1/r)))\u207b\u00b9 = GM.\n\n**Crossing-zero** (\u00a75): M_r \u2264 GM \u2264 M_s by transitivity.",
     "keyInsights": [
-      "The core inequality GM^r ≤ ∑ wᵢ zᵢ^r is a single AM-GM application that handles ALL values of r simultaneously — positive, negative, and zero.",
-      "The crossing-zero case reduces to inverting a monotone inequality: A ≤ B → B⁻¹ ≤ A⁻¹ (for positive A, B). This is proved algebraically without invoking inv_le_inv_of_le directly.",
-      "The algebraic identity (∏ zᵢ^wᵢ)^r = ∏ (zᵢ^r)^wᵢ (proved by Finset induction via mul_rpow) is the key structural bridge connecting GM^r to the AM-GM form.",
-      "Combined with power_mean_monotone_pos and power_mean_monotone_neg from AmgmInequalityOQ03, this completes the full monotonicity theorem: M_r ≤ M_s for all r ≤ s (excluding 0).",
-      "The HM ≤ GM ≤ AM corollary (r=-1, s=1) demonstrates that the classical harmonic-geometric-arithmetic mean chain is a single special case of the crossing-zero theorem — unifying three inequalities that are traditionally proved separately into one instantiation of power_mean_monotone_crossing_zero."
+      "The core inequality GM^r \u2264 \u2211 w\u1d62 z\u1d62^r is a single AM-GM application that handles ALL values of r simultaneously \u2014 positive, negative, and zero.",
+      "The crossing-zero case reduces to inverting a monotone inequality: A \u2264 B \u2192 B\u207b\u00b9 \u2264 A\u207b\u00b9 (for positive A, B). This is proved algebraically without invoking inv_le_inv_of_le directly.",
+      "The algebraic identity (\u220f z\u1d62^w\u1d62)^r = \u220f (z\u1d62^r)^w\u1d62 (proved by Finset induction via mul_rpow) is the key structural bridge connecting GM^r to the AM-GM form.",
+      "Combined with power_mean_monotone_pos and power_mean_monotone_neg from AmgmInequalityOQ03, this completes the full monotonicity theorem: M_r \u2264 M_s for all r \u2264 s (excluding 0).",
+      "The HM \u2264 GM \u2264 AM corollary (r=-1, s=1) demonstrates that the classical harmonic-geometric-arithmetic mean chain is a single special case of the crossing-zero theorem \u2014 unifying three inequalities that are traditionally proved separately into one instantiation of power_mean_monotone_crossing_zero.",
+      "The inequality  \\leq GM \\leq M_s$ for  < 0 < s$ bridges the two monotone power mean regimes with the geometric mean at the center. The geometric mean is the unique mean satisfying: (1) positively homogeneous: (\\lambda x_i) = \\lambda \\cdot GM(x_i)$; (2) the limit $\\lim_{r \to 0} M_r = GM$; (3) the crossover point where $ switches from below GM (negative $) to above GM (positive $). This sandwiching characterizes GM as the \"zero power mean\" \u2014 the fixed point of the power mean function at =0$ under the ordering induced by the convexity of  \\mapsto e^{rt}$."
     ],
     "prerequisites": [
       "AmgmInequalityOQ03 (Proofs/AmgmInequalityOQ03.lean): weightedPowerMean, weightedGeomMean definitions and same-sign monotonicity",
@@ -69,99 +70,109 @@
       "Real.rpow: monotonicity, negation, multiplication identities"
     ],
     "furtherWork": [
-      "Unify all three monotonicity cases (positive, negative, crossing-zero) into a single theorem power_mean_monotone for all r ≤ s, r s ≠ 0",
-      "Extend to the limit cases: M_{-∞} = min(z) and M_{+∞} = max(z)",
-      "Connect to the r=0 limit (proved in OQ-02): the full chain min ≤ M_r ≤ GM ≤ M_s ≤ max"
+      "Unify all three monotonicity cases (positive, negative, crossing-zero) into a single theorem power_mean_monotone for all r \u2264 s, r s \u2260 0",
+      "Extend to the limit cases: M_{-\u221e} = min(z) and M_{+\u221e} = max(z)",
+      "Connect to the r=0 limit (proved in OQ-02): the full chain min \u2264 M_r \u2264 GM \u2264 M_s \u2264 max"
     ]
   },
   "sections": [
     {
       "id": "helpers",
-      "title": "§1: Helper Lemmas",
+      "title": "\u00a71: Helper Lemmas",
       "startLine": 39,
       "endLine": 86,
-      "summary": "Three private lemmas: weightedSum_rpow_pos (∑ wᵢ zᵢ^r > 0), weightedGeomMean_pos (GM > 0), finset_prod_rpow ((∏ fᵢ)^r = ∏ fᵢ^r), prod_rpow_comm ((∏ zᵢ^wᵢ)^r = ∏ (zᵢ^r)^wᵢ).",
-      "mathContext": "The prod_rpow_comm identity uses finset_prod_rpow (induction on Finset using Real.mul_rpow) and Real.rpow_mul to show (∏ zᵢ^wᵢ)^r = ∏ (zᵢ^(r·wᵢ)) = ∏ (zᵢ^r)^wᵢ."
+      "summary": "Three private lemmas: weightedSum_rpow_pos (\u2211 w\u1d62 z\u1d62^r > 0), weightedGeomMean_pos (GM > 0), finset_prod_rpow ((\u220f f\u1d62)^r = \u220f f\u1d62^r), prod_rpow_comm ((\u220f z\u1d62^w\u1d62)^r = \u220f (z\u1d62^r)^w\u1d62).",
+      "mathContext": "The prod_rpow_comm identity uses finset_prod_rpow (induction on Finset using Real.mul_rpow) and Real.rpow_mul to show (\u220f z\u1d62^w\u1d62)^r = \u220f (z\u1d62^(r\u00b7w\u1d62)) = \u220f (z\u1d62^r)^w\u1d62."
     },
     {
       "id": "core-ineq",
-      "title": "§2: Core Inequality GM^r ≤ ∑ wᵢ zᵢ^r",
+      "title": "\u00a72: Core Inequality GM^r \u2264 \u2211 w\u1d62 z\u1d62^r",
       "startLine": 88,
       "endLine": 107,
-      "summary": "geomMean_rpow_le_weightedSum_rpow: for any r, (∏ zᵢ^wᵢ)^r ≤ ∑ wᵢ zᵢ^r. Proved by AM-GM applied to zᵢ^r values.",
-      "mathContext": "Real.geom_mean_le_arith_mean_weighted gives ∏ (zᵢ^r)^wᵢ ≤ ∑ wᵢ zᵢ^r. The LHS equals GM^r via prod_rpow_comm."
+      "summary": "geomMean_rpow_le_weightedSum_rpow: for any r, (\u220f z\u1d62^w\u1d62)^r \u2264 \u2211 w\u1d62 z\u1d62^r. Proved by AM-GM applied to z\u1d62^r values.",
+      "mathContext": "Real.geom_mean_le_arith_mean_weighted gives \u220f (z\u1d62^r)^w\u1d62 \u2264 \u2211 w\u1d62 z\u1d62^r. The LHS equals GM^r via prod_rpow_comm."
     },
     {
       "id": "gm-le-pos",
-      "title": "§3: GM ≤ M_r for r > 0",
+      "title": "\u00a73: GM \u2264 M_r for r > 0",
       "startLine": 109,
       "endLine": 133,
-      "summary": "geom_mean_le_power_mean_pos: for r > 0, GM ≤ M_r. Extends the r ≥ 1 case from OQ03 to all r > 0.",
-      "mathContext": "From GM^r ≤ ∑ wᵢ zᵢ^r: raise to 1/r > 0: GM = (GM^r)^(1/r) ≤ (∑ wᵢ zᵢ^r)^(1/r) = M_r."
+      "summary": "geom_mean_le_power_mean_pos: for r > 0, GM \u2264 M_r. Extends the r \u2265 1 case from OQ03 to all r > 0.",
+      "mathContext": "From GM^r \u2264 \u2211 w\u1d62 z\u1d62^r: raise to 1/r > 0: GM = (GM^r)^(1/r) \u2264 (\u2211 w\u1d62 z\u1d62^r)^(1/r) = M_r."
     },
     {
       "id": "neg-le-gm",
-      "title": "§4: M_r ≤ GM for r < 0",
+      "title": "\u00a74: M_r \u2264 GM for r < 0",
       "startLine": 135,
       "endLine": 188,
-      "summary": "power_mean_le_geom_mean_neg: for r < 0, M_r ≤ GM. Proved via inversion: ((∑)^(-(1/r)))⁻¹ ≤ ((GM^r)^(-(1/r)))⁻¹.",
-      "mathContext": "Since -(1/r) > 0 for r < 0 and GM^r ≤ ∑, we get (GM^r)^(-(1/r)) ≤ (∑)^(-(1/r)). Inversion (A ≤ B → B⁻¹ ≤ A⁻¹, proved algebraically) gives M_r ≤ GM."
+      "summary": "power_mean_le_geom_mean_neg: for r < 0, M_r \u2264 GM. Proved via inversion: ((\u2211)^(-(1/r)))\u207b\u00b9 \u2264 ((GM^r)^(-(1/r)))\u207b\u00b9.",
+      "mathContext": "Since -(1/r) > 0 for r < 0 and GM^r \u2264 \u2211, we get (GM^r)^(-(1/r)) \u2264 (\u2211)^(-(1/r)). Inversion (A \u2264 B \u2192 B\u207b\u00b9 \u2264 A\u207b\u00b9, proved algebraically) gives M_r \u2264 GM."
     },
     {
       "id": "crossing-zero",
-      "title": "§5: Main Theorem — Crossing-Zero Monotonicity",
+      "title": "\u00a75: Main Theorem \u2014 Crossing-Zero Monotonicity",
       "startLine": 190,
       "endLine": 211,
-      "summary": "power_mean_monotone_crossing_zero: M_r ≤ M_s for r < 0 < s. Direct combination of §3 and §4.",
-      "mathContext": "M_r ≤ GM (§4) and GM ≤ M_s (§3), so M_r ≤ M_s by transitivity (le_trans)."
+      "summary": "power_mean_monotone_crossing_zero: M_r \u2264 M_s for r < 0 < s. Direct combination of \u00a73 and \u00a74.",
+      "mathContext": "M_r \u2264 GM (\u00a74) and GM \u2264 M_s (\u00a73), so M_r \u2264 M_s by transitivity (le_trans)."
     },
     {
       "id": "hm-gm-am",
-      "title": "§6: HM ≤ GM ≤ AM as Special Case",
+      "title": "\u00a76: HM \u2264 GM \u2264 AM as Special Case",
       "startLine": 213,
       "endLine": 225,
-      "summary": "hm_le_gm_le_am_via_power_means: M_{-1} ≤ GM ≤ M_1, i.e., HM ≤ GM ≤ AM. Special case r=-1, s=1.",
-      "mathContext": "Direct application of §4 (r=-1) and §3 (s=1). The HM-GM-AM chain is a classical consequence."
+      "summary": "hm_le_gm_le_am_via_power_means: M_{-1} \u2264 GM \u2264 M_1, i.e., HM \u2264 GM \u2264 AM. Special case r=-1, s=1.",
+      "mathContext": "Direct application of \u00a74 (r=-1) and \u00a73 (s=1). The HM-GM-AM chain is a classical consequence."
     }
   ],
   "crossReferences": [
     {
       "targetId": "amgm-inequality-oq-03",
       "relationship": "parent",
-      "description": "Parent: weighted power mean definitions and same-sign monotonicity (0 < r ≤ s and r ≤ s < 0). This entry supplies the crossing-zero case."
+      "description": "Parent: weighted power mean definitions and same-sign monotonicity (0 < r \u2264 s and r \u2264 s < 0). This entry supplies the crossing-zero case."
     },
     {
       "targetId": "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01",
       "relationship": "child",
-      "description": "Unified M_r ≤ M_s theorem (all r ≤ s, r,s ≠ 0) built on this crossing-zero case via PowerMeanMonotoneOQ."
+      "description": "Unified M_r \u2264 M_s theorem (all r \u2264 s, r,s \u2260 0) built on this crossing-zero case via PowerMeanMonotoneOQ."
     },
     {
       "targetId": "amgm-inequality-oq-03-oq-02",
       "relationship": "sibling",
-      "description": "Sibling: M_r → GM as r → 0 (the limiting case r=0). Together they complete the full power mean story."
+      "description": "Sibling: M_r \u2192 GM as r \u2192 0 (the limiting case r=0). Together they complete the full power mean story."
     },
     {
       "targetId": "amgm-inequality-oq-03-oq-01",
       "relationship": "sibling",
-      "description": "Sibling: negative monotonicity M_r ≤ M_s for r ≤ s < 0 (same-sign case). This entry supplies the crossing-zero bridge between the negative and positive regimes."
+      "description": "Sibling: negative monotonicity M_r \u2264 M_s for r \u2264 s < 0 (same-sign case). This entry supplies the crossing-zero bridge between the negative and positive regimes."
     },
     {
       "targetId": "amgm-inequality-oq-03-oq-03",
       "relationship": "related",
-      "description": "Related: extreme cases M_r → max/min as r → ±∞, extending the power mean chain to its full range."
+      "description": "Related: extreme cases M_r \u2192 max/min as r \u2192 \u00b1\u221e, extending the power mean chain to its full range."
     },
     {
       "targetId": "amgm-inequality",
       "relationship": "ancestor",
-      "description": "Ancestor: the base AM-GM inequality. The HM ≤ GM ≤ AM corollary in §6 is a direct generalization of the classical AM-GM."
+      "description": "Ancestor: the base AM-GM inequality. The HM \u2264 GM \u2264 AM corollary in \u00a76 is a direct generalization of the classical AM-GM."
+    },
+    {
+      "targetId": "amgm-inequality-oq-03-oq-02-oq-04",
+      "relationship": "related",
+      "description": "Extreme Power Mean Limits:  \to \\max$ (as  \to +\\infty$) and  \to \\min$ (as  \to -\\infty$). Together with this entry and amgm-inequality-oq-03-oq-02 (GM limit), the full picture is: $\\min = M_{-\\infty} \\leq M_r \\leq M_0 = GM \\leq M_s \\leq M_{+\\infty} = \\max$ for  < 0 < s$. This entry proves the middle sandwiching; OQ-04 handles the endpoint limits."
+    },
+    {
+      "targetId": "lhopital",
+      "relationship": "foundational",
+      "description": "L'H\u00f4pital's rule is used in the proof that $\\lim_{r \to 0} M_r = GM$ (amgm-inequality-oq-03-oq-02). This continuity at =0$ is the key ingredient that allows this entry to conclude  \\leq M_0 = GM \\leq M_s$: without knowing  = GM$, the crossing inequality would only be stated as  \\leq \\lim_{r \to 0} M_r \\leq M_s$."
     }
   ],
   "conclusion": {
-    "summary": "This formalization proves the crossing-zero case of the power mean inequality: M_r ≤ GM ≤ M_s for r < 0 < s. Combined with AmgmInequalityOQ03's proofs for same-sign cases (0 < r ≤ s and r ≤ s < 0), the full power mean monotonicity theorem is now available: M_r(z,w) ≤ M_s(z,w) for all r ≤ s (excluding r=s=0). 0 sorries, 0 axioms.",
-    "implications": "The crossing-zero case was the final gap in the power mean monotonicity chain. With this result, we have the complete chain: min(z) ≤ HM ≤ ... ≤ M_r ≤ GM ≤ M_s ≤ ... ≤ AM ≤ max(z). The key technique — reducing to inversion of a positive monotone inequality — is elementary and avoids any specialized lemmas about negative-exponent rpow.",
+    "summary": "This formalization proves the crossing-zero case of the power mean inequality: M_r \u2264 GM \u2264 M_s for r < 0 < s. Combined with AmgmInequalityOQ03's proofs for same-sign cases (0 < r \u2264 s and r \u2264 s < 0), the full power mean monotonicity theorem is now available: M_r(z,w) \u2264 M_s(z,w) for all r \u2264 s (excluding r=s=0). 0 sorries, 0 axioms.",
+    "implications": "The crossing-zero case was the final gap in the power mean monotonicity chain. With this result, we have the complete chain: min(z) \u2264 HM \u2264 ... \u2264 M_r \u2264 GM \u2264 M_s \u2264 ... \u2264 AM \u2264 max(z). The key technique \u2014 reducing to inversion of a positive monotone inequality \u2014 is elementary and avoids any specialized lemmas about negative-exponent rpow.",
     "openQuestions": [
-      "Can the three monotonicity cases be unified into a single theorem applicable for all r ≤ s with r,s ≠ 0?",
-      "Can we extend to the extended real line: M_{-∞} = min and M_{+∞} = max?",
+      "Can the three monotonicity cases be unified into a single theorem applicable for all r \u2264 s with r,s \u2260 0?",
+      "Can we extend to the extended real line: M_{-\u221e} = min and M_{+\u221e} = max?",
       "Is there a more direct Lean 4 proof using StrictMono of rpow on the positive reals with negative exponent?"
     ]
   },


### PR DESCRIPTION
Enrichment passes for 4 amgm-inequality-oq-02 family entries plus 3 algebraic-numbers-countable entries.

## amgm-inequality-oq-02-oq-01 (Newton-Girard Identity)
- keyInsight: k=2 Newton-Girard case, Cauchy-Schwarz upgrade
- 2 new cross-refs: newton-inductive-step-oq-01, amgm-inequality-oq-02-oq-01-oq-02-oq-01

## amgm-inequality-oq-02-oq-01-oq-02 (Off-Diagonal Symmetry)
- keyInsight: double-counting template for Cauchy-Schwarz, variance, inclusion-exclusion
- 2 new cross-refs: binomial-theorem, newton-inductive-step-oq-01

## amgm-inequality-oq-02-oq-03 (Maclaurin Chain step)
- keyInsight: power step converting log-concavity to dominance
- 3 new cross-refs: newton-inductive-step, amgm-inequality-oq-02-oq-03-oq-03, newton-inductive-step-oq-01

## amgm-inequality-oq-02-oq-03-oq-03 (Full Maclaurin Chain)
- keyInsight: Maclaurin chain in inequality hierarchy — refines AM-GM, equivalent to Newton log-concavity
- 4 new cross-refs: newton-inductive-step, newton-inductive-step-oq-01, cauchy-schwarz, amgm-inequality-oq-02-oq-01

🤖 Generated with [Claude Code](https://claude.com/claude-code)