### PR TITLE
Fix: sync stale lineCount in 4 gallery meta.json files

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-04/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-04/meta.json
@@ -28,7 +28,7 @@
                 "module": "Mathlib.Order.JordanHolder"
             }
         ],
-        "lineCount": 255,
+        "lineCount": 234,
         "theoremCount": 9,
         "definitionCount": 3,
         "originalContributions": [
@@ -71,7 +71,7 @@
     },
     "leanFile": {
         "namespace": "AbelRuffiniGaloisExtensionsOQ04",
-        "lineCount": 255,
+        "lineCount": 234,
         "axiomCount": 0,
         "theoremCount": 9,
         "definitionCount": 3,

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -23,7 +23,7 @@
     "dateAdded": "2026-04-23",
     "axiomCount": 0,
     "assumptions": "3 sorries: (1) jdt_weight_sum (private: JDT involution weight sum for 2-row case); (2) ssytFin_two_row_eq_sum_colstrict (private: row decomposition bijection for k=2 SSYT, ~200 lines combined); (3) jacobi_trudi_ssyt_eq k\u22653 via algebraic LGV + RSK (~300 lines). Note: ssytSchurFin_two_row is proved but depends on these sorry'd helpers. k=0 and k=1 cases proved explicitly.",
-    "lineCount": 405,
+    "lineCount": 457,
     "theoremCount": 11,
     "definitionCount": 5,
     "originalContributions": [
@@ -78,7 +78,7 @@
       "Finset"
     ],
     "namespace": "JacobiTrudi",
-    "lineCount": 405,
+    "lineCount": 457,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 5,

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -23,7 +23,7 @@
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
     "assumptions": "Four open sorries: (1) hook_length_formula (LGV approach: requires SYT↔NI bijection + det factorization), (2) ni_count_eq_syt_count (Fomin/Viennot/RSK correspondence), (3) lgv_det_factors_as_hook_quotient (det factorization identity), (4) hook_walk_identity ≥3-row non-gHookYD case (GNW or RSK, ~300 lines; at-most-2-row and all [a,1^b] cases proved; hookProd_ratio_formula fully proved session 18, hook_walk_identity_gHookYD proved session 19). hook_length_formula_general is proved modulo hook_walk_identity via Part XIV corner induction.",
-    "lineCount": 5274,
+    "lineCount": 6643,
     "theoremCount": 164,
     "definitionCount": 14,
     "originalContributions": [
@@ -89,7 +89,7 @@
       "LGV"
     ],
     "namespace": "HookLengthFormula",
-    "lineCount": 5452,
+    "lineCount": 6643,
     "axiomCount": 0,
     "sorries": 4,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04/meta.json
@@ -20,7 +20,7 @@
     "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 268,
+    "lineCount": 357,
     "assumptions": "0 axioms. 1 sorry: main theorem nonderogatory_has_cyclic_vector_any_field (needs structure theorem for f.g. modules over PID, not in Mathlib).",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
@@ -118,7 +118,7 @@
       "Polynomial"
     ],
     "namespace": "NonderogatoryGeneral",
-    "lineCount": 268,
+    "lineCount": 357,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 2,


### PR DESCRIPTION
## Fix

Corrected stale `lineCount` fields in 4 gallery meta.json files where the Lean source files grew from recent research PRs but the metadata was not updated.

## Evidence

| Proof | Before (meta) | Before (leanFile) | Actual | Root cause |
|-------|-------------|----------------|--------|------------|
| ballot-problem-oq-03-oq-01-oq-02 | 5274 | 5452 | **6643** | Hook-length formula PRs #12471, #12472 (+1369 lines) |
| ballot-problem-oq-03-oq-01-oq-01-oq-01 | 405 | 405 | **457** | PR #12525 ssytSchurFin_two_row assembly (+52 lines) |
| cayley-hamilton-minpoly-oq-05-oq-01-oq-04 | 268 | 268 | **357** | PR #12510 companionMatrix_cyclic_e0 (+89 lines) |
| abel-ruffini-galois-extensions-oq-04 | 255 | 255 | **234** | PR #12441 removed stale sorry claims (-21 lines) |

All other metadata (sorries, axiomCount, status, badge) remains correct. Build verified: `pnpm build` succeeds.

---
Automated fix by lean-mechanic agent.