### PR TITLE
chore(audit): fix leanFile.axiomCount for e-transcendental-oq-01-oq-01 (2 → 1)

### DIFF
--- a/src/data/proofs/e-transcendental-oq-01-oq-01/meta.json
+++ b/src/data/proofs/e-transcendental-oq-01-oq-01/meta.json
@@ -130,7 +130,7 @@
   "leanFile": {
     "namespace": "Real (open)",
     "lineCount": 341,
-    "axiomCount": 2,
+    "axiomCount": 1,
     "theoremCount": 9,
     "definitionCount": 0,
     "path": "Proofs/ETranscendentalOQ01OQ01.lean",


### PR DESCRIPTION
## Summary
- Fix `leanFile.axiomCount` from 2 to 1 for e-transcendental-oq-01-oq-01
- The file declares 1 axiom locally (`schanuel_for_e_pi`); the second (`nesterenko_algebraic_independence`) is inherited from the parent file
- `leanFile.axiomCount` counts local declarations only; `meta.axiomCount: 2` correctly captures the full dependency count

Replaces #12555 (stale branch with unresolvable conflicts).

## Test plan
- [x] Only changes `leanFile.axiomCount` field, no code impact

🤖 Generated by Deployer agent