### PR TITLE
Fix: leanFile.axiomCount semantic inflation in 11 entries

### DIFF
--- a/src/data/proofs/greens-theorem-oq-04/meta.json
+++ b/src/data/proofs/greens-theorem-oq-04/meta.json
@@ -241,7 +241,7 @@
     ],
     "namespace": "GreensTheoremOQ04",
     "lineCount": 587,
-    "axiomCount": 2,
+    "axiomCount": 0,
     "theoremCount": 23,
     "definitionCount": 14,
     "path": "Proofs/GreensTheoremOQ04.lean",

--- a/src/data/proofs/hilbert-14-oq-01/meta.json
+++ b/src/data/proofs/hilbert-14-oq-01/meta.json
@@ -178,7 +178,7 @@
     ],
     "namespace": "Hilbert14.NonReductive",
     "lineCount": 323,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 5,
     "path": "Proofs/Hilbert14NonReductive.lean",

--- a/src/data/proofs/inverse-galois-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-oq-01/meta.json
@@ -303,7 +303,7 @@
   "leanFile": {
     "path": "Proofs/InverseGaloisOQ01.lean",
     "lineCount": 723,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "sorries": 1,
     "theoremCount": 46,
     "definitionCount": 1,

--- a/src/data/proofs/inverse-galois/meta.json
+++ b/src/data/proofs/inverse-galois/meta.json
@@ -303,7 +303,7 @@
   "leanFile": {
     "path": "Proofs/InverseGalois.lean",
     "lineCount": 1882,
-    "axiomCount": 5,
+    "axiomCount": 4,
     "sorries": 0,
     "theoremCount": 105,
     "definitionCount": 1,

--- a/src/data/proofs/kroneckers-jugendtraum/meta.json
+++ b/src/data/proofs/kroneckers-jugendtraum/meta.json
@@ -270,7 +270,7 @@
     ],
     "namespace": "KroneckersJugendtraum",
     "lineCount": 387,
-    "axiomCount": 4,
+    "axiomCount": 0,
     "sorries": 0
   },
   "mainTheorems": [

--- a/src/data/proofs/law-of-cosines-oq-03/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-03/meta.json
@@ -60,7 +60,7 @@
   "leanFile": {
     "namespace": "HyperbolicLawOfCosines",
     "lineCount": 192,
-    "axiomCount": 3,
+    "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 2,
     "path": "Proofs/LawOfCosinesOQ03.lean",

--- a/src/data/proofs/navier-stokes-oq-02/meta.json
+++ b/src/data/proofs/navier-stokes-oq-02/meta.json
@@ -203,7 +203,7 @@
     ],
     "namespace": "NavierStokesRegularity",
     "lineCount": 21111,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 845,
     "definitionCount": 104,
     "path": "Proofs/NavierStokes.lean",

--- a/src/data/proofs/yang-mills-2d/meta.json
+++ b/src/data/proofs/yang-mills-2d/meta.json
@@ -175,7 +175,7 @@
   "leanFile": {
     "lineCount": 28075,
     "structureCount": 365,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 1787,
     "lemmaCount": 0,
     "defCount": 641,

--- a/src/data/proofs/yang-mills-lattice/meta.json
+++ b/src/data/proofs/yang-mills-lattice/meta.json
@@ -148,7 +148,7 @@
   "leanFile": {
     "lineCount": 28075,
     "structureCount": 365,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 1787,
     "lemmaCount": 0,
     "defCount": 641,

--- a/src/data/proofs/yang-mills-transfer-matrix/meta.json
+++ b/src/data/proofs/yang-mills-transfer-matrix/meta.json
@@ -138,7 +138,7 @@
   "leanFile": {
     "lineCount": 28075,
     "structureCount": 365,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 1787,
     "lemmaCount": 0,
     "defCount": 641,

--- a/src/data/proofs/yang-mills/meta.json
+++ b/src/data/proofs/yang-mills/meta.json
@@ -203,7 +203,7 @@
     ],
     "namespace": "YangMillsMassGap",
     "lineCount": 48,
-    "axiomCount": 16,
+    "axiomCount": 0,
     "theoremCount": 1806,
     "definitionCount": 260,
     "path": "Proofs/YangMillsMassGap.lean",


### PR DESCRIPTION
## Fix

Set `leanFile.axiomCount` to the actual `^axiom` declaration count in each Lean file, replacing semantic counts that included inherited/structure-encoded assumptions.

## Evidence

**Before**: `leanFile.axiomCount` reflected semantic counts (structure-encoded + inherited axioms), causing false-positive audit alerts from `find-targets.ts`

**After**: `leanFile.axiomCount` reflects only `^axiom` declarations in the specific Lean file

| Slug | Before | After |
|------|--------|-------|
| yang-mills | 16 | 0 |
| yang-mills-2d | 1 | 0 |
| yang-mills-lattice | 1 | 0 |
| yang-mills-transfer-matrix | 1 | 0 |
| navier-stokes-oq-02 | 1 | 0 |
| law-of-cosines-oq-03 | 3 | 0 |
| kroneckers-jugendtraum | 4 | 0 |
| inverse-galois-oq-01 | 1 | 0 |
| inverse-galois | 5 | 4 |
| hilbert-14-oq-01 | 1 | 0 |
| greens-theorem-oq-04 | 2 | 0 |

Note: Public `meta.axiomCount` values (semantic counts) are unchanged and remain correct.

Closes #12561

---
Automated fix by lean-mechanic agent.