### PR TITLE
feat: Newton-Girard corollaries k=1,2,3 proved (0 sorries, 0 axioms)

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01.lean
+++ b/proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01.lean
@@ -9,15 +9,15 @@
   for all k ≥ 1.
 
   Mathlib provides MvPolynomial.psum_eq_mul_esymm_sub_sum which states:
-    pₙ = (-1)^(n+1) · n · eₙ - Σ_{i<n-1} (-1)^i · eᵢ₊₁ · pₙ₋₁₋ᵢ
+    pₙ = (-1)^(n+1) · n · eₙ − Σ_{a ∈ antidiag n, 0<a.1<n} (-1)^a.1 · e_{a.1} · p_{a.2}
 
   Corollaries (k = 1, 2, 3):
     p₁ = e₁
     p₂ = e₁² − 2·e₂
     p₃ = e₁·p₂ − e₂·p₁ + 3·e₃
 
-  Status: WIP — sorries remain for the explicit corollary derivations.
-  Axioms: 0, Sorries: 3
+  Status: PROVED — all three corollaries derived from psum_eq_mul_esymm_sub_sum.
+  Axioms: 0, Sorries: 0
   Tags: algebra, symmetric-functions, newton-girard, power-sums, mv-polynomial
 -/
 
@@ -25,34 +25,20 @@ import Mathlib
 
 namespace AMGMInequalityOQ02OQ01OQ02OQ01
 
-open MvPolynomial Finset BigOperators
+open MvPolynomial Finset BigOperators Set
 
 variable (σ : Type*) (R : Type*) [CommRing R] [Fintype σ]
-
--- ============================================================
--- Main Theorem: Newton-Girard Recurrence (via Mathlib)
--- ============================================================
-
-/-- **Newton-Girard Recurrence** (from Mathlib):
-    For n ≥ 1, the power sum pₙ satisfies:
-      pₙ = (-1)^(n+1) · n · eₙ − Σ_{0≤i<n-1} (-1)^i · eᵢ₊₁ · pₙ₋₁₋ᵢ
-
-    This is `MvPolynomial.psum_eq_mul_esymm_sub_sum` from Mathlib. -/
-theorem newton_girard_recurrence (n : ℕ) (hn : n ≠ 0) :
-    psum σ R n =
-      (-1) ^ (n + 1) * (n : R) * esymm σ R n -
-      ∑ i ∈ range (n - 1), (-1) ^ i * (esymm σ R (i + 1) * psum σ R (n - 1 - i)) :=
-  MvPolynomial.psum_eq_mul_esymm_sub_sum σ R n hn
 
 -- ============================================================
 -- Corollary 1: p₁ = e₁
 -- ============================================================
 
 /-- **Newton-Girard k=1**: The first power sum equals the first elementary symmetric polynomial:
-      p₁ = e₁ -/
+      p₁ = e₁
+    Proof: both equal ∑ i : σ, X i (from Mathlib's psum_one and esymm_one). -/
 theorem psum_one_eq_esymm_one :
-    psum σ R 1 = esymm σ R 1 := by
-  sorry
+    psum σ R 1 = esymm σ R 1 :=
+  (MvPolynomial.psum_one σ R).trans (MvPolynomial.esymm_one σ R).symm
 
 -- ============================================================
 -- Corollary 2: p₂ = e₁² − 2·e₂
@@ -60,20 +46,46 @@ theorem psum_one_eq_esymm_one :
 
 /-- **Newton-Girard k=2**: The second power sum satisfies:
       p₂ = e₁² − 2·e₂
-    Equivalently: Σ xᵢ² = (Σ xᵢ)² − 2·Σ_{i<j} xᵢxⱼ. -/
+    Equivalently: Σ xᵢ² = (Σ xᵢ)² − 2·Σ_{i<j} xᵢxⱼ.
+
+    Proof: Apply psum_eq_mul_esymm_sub_sum at k=2. The antidiagonal {a : a.1+a.2=2, 0<a.1<2}
+    = {(1,1)}, so psum 2 = (-1)³·2·e₂ − (-1)¹·e₁·p₁ = -2e₂ + e₁² = e₁² - 2e₂. -/
 theorem psum_two_eq :
     psum σ R 2 = esymm σ R 1 ^ 2 - 2 * esymm σ R 2 := by
-  sorry
+  have h1 : psum σ R 1 = esymm σ R 1 := psum_one_eq_esymm_one σ R
+  rw [MvPolynomial.psum_eq_mul_esymm_sub_sum σ R 2 two_pos]
+  have hfilt : (Finset.antidiagonal 2).filter (fun a : ℕ × ℕ => a.1 ∈ Ioo 0 2) =
+               {(1, 1)} := by
+    ext ⟨a, b⟩
+    simp only [Finset.mem_filter, Finset.Nat.mem_antidiagonal, mem_Ioo,
+               Finset.mem_singleton, Prod.mk.injEq]
+    omega
+  simp only [hfilt, Finset.sum_singleton, h1]
+  ring
 
 -- ============================================================
 -- Corollary 3: p₃ = e₁·p₂ − e₂·p₁ + 3·e₃
 -- ============================================================
 
 /-- **Newton-Girard k=3**: The third power sum satisfies:
-      p₃ = e₁·p₂ − e₂·p₁ + 3·e₃ -/
+      p₃ = e₁·p₂ − e₂·p₁ + 3·e₃
+
+    Proof: Apply psum_eq_mul_esymm_sub_sum at k=3. The antidiagonal {a : a.1+a.2=3, 0<a.1<3}
+    = {(1,2), (2,1)}, so:
+    psum 3 = (-1)⁴·3·e₃ − ((-1)¹·e₁·p₂ + (-1)²·e₂·p₁)
+           = 3e₃ + e₁·p₂ − e₂·p₁ = e₁·p₂ − e₂·p₁ + 3e₃. -/
 theorem psum_three_eq :
     psum σ R 3 =
       esymm σ R 1 * psum σ R 2 - esymm σ R 2 * psum σ R 1 + 3 * esymm σ R 3 := by
-  sorry
+  rw [MvPolynomial.psum_eq_mul_esymm_sub_sum σ R 3 (by norm_num)]
+  have hfilt : (Finset.antidiagonal 3).filter (fun a : ℕ × ℕ => a.1 ∈ Ioo 0 3) =
+               {(1, 2), (2, 1)} := by
+    ext ⟨a, b⟩
+    simp only [Finset.mem_filter, Finset.Nat.mem_antidiagonal, mem_Ioo,
+               Finset.mem_insert, Finset.mem_singleton, Prod.mk.injEq]
+    omega
+  simp only [hfilt, Finset.sum_insert (by decide : (1, 2) ∉ ({(2, 1)} : Finset (ℕ × ℕ))),
+             Finset.sum_singleton]
+  ring
 
 end AMGMInequalityOQ02OQ01OQ02OQ01

--- a/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01/knowledge.md
+++ b/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01/knowledge.md
@@ -1,0 +1,65 @@
+# Knowledge Base: amgm-inequality-oq-02-oq-01-oq-02-oq-01
+
+**Last Updated**: 2026-04-26
+
+---
+
+## Problem Understanding
+
+Prove the Newton-Girard recurrence corollaries connecting power sums and elementary
+symmetric polynomials. Key objects:
+- `psum σ R k` = Σᵢ Xᵢᵏ (k-th power sum polynomial)
+- `esymm σ R k` = Σ_{i₁<...<iₖ} Xᵢ₁·...·Xᵢₖ (k-th elementary symmetric polynomial)
+- `MvPolynomial.psum_eq_mul_esymm_sub_sum`: Newton's identity in Mathlib's antidiagonal form
+
+---
+
+## Session 2026-04-26 (Session 1) — All 3 Corollaries Proved
+
+**Mode**: FRESH
+**Outcome**: COMPLETED — 3 → 0 sorries
+
+### What I Did
+
+1. Surveyed Mathlib's `NewtonIdentities.lean` to understand `psum_eq_mul_esymm_sub_sum` signature
+2. Read `psum_one`, `esymm_one` from Mathlib Defs
+3. Removed incorrect `newton_girard_recurrence` wrapper (used `range` form vs actual `antidiagonal` form)
+4. Proved all three corollaries directly from `psum_eq_mul_esymm_sub_sum`
+
+### Key Findings
+
+**`psum_one_eq_esymm_one`**: Trivial — `psum_one.trans esymm_one.symm`. Both are `∑ i, X i`.
+
+**`psum_two_eq`** (p₂ = e₁² − 2·e₂):
+- Apply `psum_eq_mul_esymm_sub_sum` at k=2
+- `antidiagonal(2) ∩ Ioo 0 2 = {(1,1)}` (computed by `omega`)
+- `(-1)^3 * 2 * e₂ - (-1)^1 * e₁ * e₁ = e₁² - 2e₂` closes by `ring`
+
+**`psum_three_eq`** (p₃ = e₁·p₂ − e₂·p₁ + 3·e₃):
+- Apply `psum_eq_mul_esymm_sub_sum` at k=3
+- `antidiagonal(3) ∩ Ioo 0 3 = {(1,2),(2,1)}` (computed by `omega`)
+- `Finset.sum_insert (by decide)` separates the two elements
+- `(-1)^4 * 3 * e₃ - ((-1)^1 * e₁ * p₂ + (-1)^2 * e₂ * p₁) = e₁*p₂ - e₂*p₁ + 3*e₃` by `ring`
+
+### Reusable Pattern
+
+```lean
+have hfilt : (Finset.antidiagonal n).filter (fun a : ℕ × ℕ => a.1 ∈ Ioo 0 n) = {s} := by
+  ext ⟨a, b⟩
+  simp only [Finset.mem_filter, Finset.Nat.mem_antidiagonal, mem_Ioo,
+             Finset.mem_singleton, Prod.mk.injEq]
+  omega
+simp only [hfilt, Finset.sum_singleton, ...]
+ring
+```
+
+This pattern handles any concrete `k` by `omega`-deciding the filter and then `ring` for the algebra.
+
+### Files Modified
+
+- `proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01.lean` (0 sorries, 0 axioms)
+- `src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01/meta.json` (status → verified, sorries → 0)
+
+### PR
+
+PR #12569: feat: Newton-Girard corollaries k=1,2,3 proved (0 sorries, 0 axioms)

--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-25",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01.lean",
     "tags": [
       "algebra",
@@ -16,7 +16,7 @@
       "elementary-symmetric-polynomials",
       "mv-polynomial"
     ],
-    "badge": "wip",
+    "badge": "original",
     "mathlibDependencies": [
       {
         "theorem": "MvPolynomial.psum_eq_mul_esymm_sub_sum",
@@ -37,9 +37,9 @@
       "offDiag_prod_eq_two_mul_e2: specialization to products xᵢxⱼ"
     ],
     "dateAdded": "2026-04-25",
-    "assumptions": "Lean formalization created as WIP stub. Three corollary derivations (p₁=e₁, p₂, p₃) remain as sorries; the main recurrence wraps Mathlib MvPolynomial.psum_eq_mul_esymm_sub_sum.",
+    "assumptions": "None. All three corollaries (p₁=e₁, p₂=e₁²−2e₂, p₃=e₁p₂−e₂p₁+3e₃) proved from MvPolynomial.psum_eq_mul_esymm_sub_sum via antidiagonal filter computation and ring.",
     "mathlib_version": "4.26.0",
-    "sorries": 3,
+    "sorries": 0,
     "axiomCount": 0
   },
   "overview": {


### PR DESCRIPTION
## Summary

Proves the three Newton-Girard recurrence corollaries for symmetric polynomials:

- **psum_one_eq_esymm_one**: p₁ = e₁ — trivial via `psum_one.trans esymm_one.symm`
- **psum_two_eq**: p₂ = e₁² − 2·e₂ — antidiag(2) filter = {(1,1)}, then `ring`
- **psum_three_eq**: p₃ = e₁·p₂ − e₂·p₁ + 3·e₃ — antidiag(3) filter = {(1,2),(2,1)}, then `ring`

All three corollaries are derived directly from `MvPolynomial.psum_eq_mul_esymm_sub_sum` by computing the Finset antidiagonal filter using `omega` and closing with `ring`.

**Status**: 0 sorries, 0 axioms. Closes `amgm-inequality-oq-02-oq-01-oq-02-oq-01`.

## Key Technique

Filter set computation pattern:
```lean
have hfilt : (Finset.antidiagonal n).filter (fun a : ℕ × ℕ => a.1 ∈ Ioo 0 n) = {...} := by
  ext ⟨a, b⟩; simp only [..., Finset.Nat.mem_antidiagonal, mem_Ioo, ...]; omega
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)