### PR TITLE
Fix: sync stale lineCount in 3 gallery meta.json files

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-04/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-04/meta.json
@@ -28,7 +28,7 @@
                 "module": "Mathlib.Order.JordanHolder"
             }
         ],
-        "lineCount": 255,
+        "lineCount": 234,
         "theoremCount": 9,
         "definitionCount": 3,
         "originalContributions": [
@@ -71,7 +71,7 @@
     },
     "leanFile": {
         "namespace": "AbelRuffiniGaloisExtensionsOQ04",
-        "lineCount": 255,
+        "lineCount": 234,
         "axiomCount": 0,
         "theoremCount": 9,
         "definitionCount": 3,

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -23,7 +23,7 @@
     "dateAdded": "2026-04-23",
     "axiomCount": 0,
     "assumptions": "3 sorries: (1) jdt_weight_sum (private: JDT involution weight sum for 2-row case); (2) ssytFin_two_row_eq_sum_colstrict (private: row decomposition bijection for k=2 SSYT, ~200 lines combined); (3) jacobi_trudi_ssyt_eq k\u22653 via algebraic LGV + RSK (~300 lines). Note: ssytSchurFin_two_row is proved but depends on these sorry'd helpers. k=0 and k=1 cases proved explicitly.",
-    "lineCount": 405,
+    "lineCount": 457,
     "theoremCount": 11,
     "definitionCount": 5,
     "originalContributions": [
@@ -78,7 +78,7 @@
       "Finset"
     ],
     "namespace": "JacobiTrudi",
-    "lineCount": 405,
+    "lineCount": 457,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 5,

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04/meta.json
@@ -20,7 +20,7 @@
     "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 268,
+    "lineCount": 357,
     "assumptions": "0 axioms. 1 sorry: main theorem nonderogatory_has_cyclic_vector_any_field (needs structure theorem for f.g. modules over PID, not in Mathlib).",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
@@ -118,7 +118,7 @@
       "Polynomial"
     ],
     "namespace": "NonderogatoryGeneral",
-    "lineCount": 268,
+    "lineCount": 357,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 2,


### PR DESCRIPTION
## Summary
- Sync stale lineCount values in 3 gallery meta.json files
- ballot-oq03-oq01-oq02/meta.json already correct (7274) from PART XVIII merge

Replaces #12563.

🤖 Generated by Deployer agent