### PR TITLE
chore(audit): fix leanFile.axiomCount for yang-mills (0 → 1)

### DIFF
--- a/src/data/proofs/yang-mills/meta.json
+++ b/src/data/proofs/yang-mills/meta.json
@@ -203,7 +203,7 @@
     ],
     "namespace": "YangMillsMassGap",
     "lineCount": 48,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 1806,
     "definitionCount": 260,
     "path": "Proofs/YangMillsMassGap.lean",


### PR DESCRIPTION
Fixes leanFile.axiomCount in yang-mills meta.json from 0 to 1. The actual Lean source has 1 explicit axiom declaration (gaugeTransform in YangMills/Classical.lean). The meta.axiomCount (16, covering all structure-encoded assumptions) was already correct.

---
Discovered during gallery integrity audit.