### PR TITLE
chore(audit): fix leanFile.axiomCount for 6 entries (sub-module and additionalFiles axioms)

### DIFF
--- a/src/data/proofs/greens-theorem-oq-04/meta.json
+++ b/src/data/proofs/greens-theorem-oq-04/meta.json
@@ -241,7 +241,7 @@
     ],
     "namespace": "GreensTheoremOQ04",
     "lineCount": 587,
-    "axiomCount": 0,
+    "axiomCount": 2,
     "theoremCount": 23,
     "definitionCount": 14,
     "path": "Proofs/GreensTheoremOQ04.lean",

--- a/src/data/proofs/inverse-galois-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-oq-01/meta.json
@@ -303,7 +303,7 @@
   "leanFile": {
     "path": "Proofs/InverseGaloisOQ01.lean",
     "lineCount": 723,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "sorries": 1,
     "theoremCount": 46,
     "definitionCount": 1,

--- a/src/data/proofs/inverse-galois/meta.json
+++ b/src/data/proofs/inverse-galois/meta.json
@@ -303,7 +303,7 @@
   "leanFile": {
     "path": "Proofs/InverseGalois.lean",
     "lineCount": 1882,
-    "axiomCount": 4,
+    "axiomCount": 5,
     "sorries": 0,
     "theoremCount": 105,
     "definitionCount": 1,

--- a/src/data/proofs/yang-mills-2d/meta.json
+++ b/src/data/proofs/yang-mills-2d/meta.json
@@ -175,7 +175,7 @@
   "leanFile": {
     "lineCount": 28075,
     "structureCount": 365,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 1787,
     "lemmaCount": 0,
     "defCount": 641,

--- a/src/data/proofs/yang-mills-lattice/meta.json
+++ b/src/data/proofs/yang-mills-lattice/meta.json
@@ -148,7 +148,7 @@
   "leanFile": {
     "lineCount": 28075,
     "structureCount": 365,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 1787,
     "lemmaCount": 0,
     "defCount": 641,

--- a/src/data/proofs/yang-mills-transfer-matrix/meta.json
+++ b/src/data/proofs/yang-mills-transfer-matrix/meta.json
@@ -138,7 +138,7 @@
   "leanFile": {
     "lineCount": 28075,
     "structureCount": 365,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 1787,
     "lemmaCount": 0,
     "defCount": 641,


### PR DESCRIPTION
## Summary

- Fix `leanFile.axiomCount` in 6 `meta.json` files to reflect axioms from all scanned Lean files (main file + sub-modules + `additionalFiles`), not just the main file
- **yang-mills-transfer-matrix**, **yang-mills-lattice**, **yang-mills-2d**: 0 → 1 (Exploration.lean imports Classical.lean which declares `axiom gaugeTransform`)
- **inverse-galois-oq-01**: 0 → 1 (additionalFiles includes InverseGaloisA5.lean which has 1 axiom: `three_dvd_gal_card`)
- **inverse-galois**: 4 → 5 (main file has 4 axioms; additionalFiles InverseGaloisA5.lean contributes 1 more)
- **greens-theorem-oq-04**: 0 → 2 (additionalFiles includes GreensTheoremOQ03.lean which has 2 axioms: `greens_theorem_typeI` and `disk_area_eq_pi`)

## Test plan
- [ ] Verify each changed `leanFile.axiomCount` matches the total axiom count across all Lean files associated with that gallery entry
- [ ] Confirm `meta.axiomCount` (total including structure-encoded assumptions) is unchanged and consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)