### PR TITLE
feat(amgm-inequality-oq-02-oq-01-oq-02-oq-01): prove Newton-Girard k=1,2,3 corollaries

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01.lean
+++ b/proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01.lean
@@ -3,21 +3,21 @@
 
   Open Question (amgm-inequality-oq-02-oq-01-oq-02-oq-01):
   Prove the general Newton-Girard recurrence connecting power sums
-    pₖ = Σ xᵢᵏ
+    pk = Sigma x_i^k
   and elementary symmetric polynomials
-    eₖ = Σ_{i₁<...<iₖ} xᵢ₁...xᵢₖ
-  for all k ≥ 1.
+    ek = Sigma_{i1<...<ik} x_{i1}...x_{ik}
+  for all k >= 1.
 
   Mathlib provides MvPolynomial.psum_eq_mul_esymm_sub_sum which states:
-    pₙ = (-1)^(n+1) · n · eₙ - Σ_{i<n-1} (-1)^i · eᵢ₊₁ · pₙ₋₁₋ᵢ
+    pn = (-1)^(n+1) * n * en - Sigma_{0<i<n} (-1)^i * e_i * p_{n-i}
 
   Corollaries (k = 1, 2, 3):
-    p₁ = e₁
-    p₂ = e₁² − 2·e₂
-    p₃ = e₁·p₂ − e₂·p₁ + 3·e₃
+    p1 = e1
+    p2 = e1^2 - 2*e2
+    p3 = e1*p2 - e2*p1 + 3*e3
 
-  Status: WIP — sorries remain for the explicit corollary derivations.
-  Axioms: 0, Sorries: 3
+  Status: Verified -- all corollaries proved via Mathlib's Newton identities.
+  Axioms: 0, Sorries: 0
   Tags: algebra, symmetric-functions, newton-girard, power-sums, mv-polynomial
 -/
 
@@ -34,46 +34,90 @@ variable (σ : Type*) (R : Type*) [CommRing R] [Fintype σ]
 -- ============================================================
 
 /-- **Newton-Girard Recurrence** (from Mathlib):
-    For n ≥ 1, the power sum pₙ satisfies:
-      pₙ = (-1)^(n+1) · n · eₙ − Σ_{0≤i<n-1} (-1)^i · eᵢ₊₁ · pₙ₋₁₋ᵢ
+    For n >= 1, the power sum pn satisfies:
+      pn = (-1)^(n+1) * n * en - Sigma_{0<a<n} (-1)^a * e_a * p_{n-a}
 
     This is `MvPolynomial.psum_eq_mul_esymm_sub_sum` from Mathlib. -/
-theorem newton_girard_recurrence (n : ℕ) (hn : n ≠ 0) :
-    psum σ R n =
-      (-1) ^ (n + 1) * (n : R) * esymm σ R n -
-      ∑ i ∈ range (n - 1), (-1) ^ i * (esymm σ R (i + 1) * psum σ R (n - 1 - i)) :=
+theorem newton_girard_recurrence (n : ℕ) (hn : 0 < n) :
+    psum σ R n = (-1) ^ (n + 1) * (n : MvPolynomial σ R) * esymm σ R n -
+      ∑ a ∈ antidiagonal n with a.1 ∈ Set.Ioo 0 n,
+        (-1) ^ a.fst * esymm σ R a.1 * psum σ R a.2 :=
   MvPolynomial.psum_eq_mul_esymm_sub_sum σ R n hn
 
 -- ============================================================
--- Corollary 1: p₁ = e₁
+-- Helper: antidiagonal filter evaluations
+-- ============================================================
+
+/-- For k=1, there is no natural number strictly between 0 and 1,
+    so the antidiagonal filter is empty. -/
+private lemma antidiag_filter_one :
+    (antidiagonal 1).filter (fun a => a.1 ∈ Set.Ioo 0 1) = ∅ := by
+  ext ⟨a, b⟩
+  simp only [mem_filter, mem_antidiagonal, Set.mem_Ioo, Finset.notMem_empty, iff_false, not_and]
+  omega
+
+/-- For k=2, the only pair (a,b) with a+b=2 and 0 < a < 2 is (1,1). -/
+private lemma antidiag_filter_two :
+    (antidiagonal 2).filter (fun a => a.1 ∈ Set.Ioo 0 2) = {(1, 1)} := by
+  ext ⟨a, b⟩
+  simp only [mem_filter, mem_antidiagonal, Set.mem_Ioo, mem_singleton, Prod.mk.injEq]
+  constructor
+  · rintro ⟨hab, ha_pos, ha_lt⟩; omega
+  · rintro ⟨rfl, rfl⟩; omega
+
+/-- For k=3, the pairs (a,b) with a+b=3 and 0 < a < 3 are (1,2) and (2,1). -/
+private lemma antidiag_filter_three :
+    (antidiagonal 3).filter (fun a => a.1 ∈ Set.Ioo 0 3) = {(1, 2), (2, 1)} := by
+  ext ⟨a, b⟩
+  simp only [mem_filter, mem_antidiagonal, Set.mem_Ioo, mem_insert, mem_singleton, Prod.mk.injEq]
+  constructor
+  · rintro ⟨hab, ha_pos, ha_lt⟩; omega
+  · rintro (⟨rfl, rfl⟩ | ⟨rfl, rfl⟩) <;> omega
+
+-- ============================================================
+-- Corollary 1: p1 = e1
 -- ============================================================
 
 /-- **Newton-Girard k=1**: The first power sum equals the first elementary symmetric polynomial:
-      p₁ = e₁ -/
+      p1 = e1 -/
 theorem psum_one_eq_esymm_one :
     psum σ R 1 = esymm σ R 1 := by
-  sorry
+  have h := MvPolynomial.psum_eq_mul_esymm_sub_sum σ R 1 (by omega)
+  rw [antidiag_filter_one, sum_empty, sub_zero] at h
+  linear_combination h
 
 -- ============================================================
--- Corollary 2: p₂ = e₁² − 2·e₂
+-- Corollary 2: p2 = e1^2 - 2*e2
 -- ============================================================
 
 /-- **Newton-Girard k=2**: The second power sum satisfies:
-      p₂ = e₁² − 2·e₂
-    Equivalently: Σ xᵢ² = (Σ xᵢ)² − 2·Σ_{i<j} xᵢxⱼ. -/
+      p2 = e1^2 - 2*e2
+    Equivalently: Sigma x_i^2 = (Sigma x_i)^2 - 2*Sigma_{i<j} x_i*x_j. -/
 theorem psum_two_eq :
     psum σ R 2 = esymm σ R 1 ^ 2 - 2 * esymm σ R 2 := by
-  sorry
+  have h₁ := psum_one_eq_esymm_one σ R
+  have h := MvPolynomial.psum_eq_mul_esymm_sub_sum σ R 2 (by omega)
+  rw [antidiag_filter_two, sum_singleton] at h
+  -- h : psum 2 = (-1)^3 * 2 * esymm 2 - (-1)^1 * esymm 1 * psum 1
+  -- h1 : psum 1 = esymm 1
+  -- Goal: psum 2 = esymm 1 ^ 2 - 2 * esymm 2
+  linear_combination h + esymm σ R 1 * h₁
 
 -- ============================================================
--- Corollary 3: p₃ = e₁·p₂ − e₂·p₁ + 3·e₃
+-- Corollary 3: p3 = e1*p2 - e2*p1 + 3*e3
 -- ============================================================
 
 /-- **Newton-Girard k=3**: The third power sum satisfies:
-      p₃ = e₁·p₂ − e₂·p₁ + 3·e₃ -/
+      p3 = e1*p2 - e2*p1 + 3*e3 -/
 theorem psum_three_eq :
     psum σ R 3 =
       esymm σ R 1 * psum σ R 2 - esymm σ R 2 * psum σ R 1 + 3 * esymm σ R 3 := by
-  sorry
+  have h := MvPolynomial.psum_eq_mul_esymm_sub_sum σ R 3 (by omega)
+  rw [antidiag_filter_three] at h
+  rw [sum_insert (show (1, 2) ∉ ({(2, 1)} : Finset _) by decide), sum_singleton] at h
+  -- h : psum 3 = (-1)^4 * 3 * esymm 3
+  --     - ((-1)^1 * esymm 1 * psum 2 + (-1)^2 * esymm 2 * psum 1)
+  -- = 3*e3 + e1*p2 - e2*p1
+  linear_combination h
 
 end AMGMInequalityOQ02OQ01OQ02OQ01

--- a/proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean
+++ b/proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean
@@ -1,44 +1,10 @@
 /-
   Aristotle targets for amgm-inequality-oq-02-oq-01-oq-02-oq-01
-  Newton-Girard corollaries k=1,2,3 for automated proof search.
+  Newton-Girard corollaries k=1,2,3.
   See AmgmInequalityOQ02OQ01OQ02OQ01.lean for the main formalization.
 
-  The 3 sorries in the main file are Newton-Girard corollaries for
-  MvPolynomial power sums and elementary symmetric polynomials.
-
-  ## Proof Strategies
-
-  TARGET 1 (psum_one_eq_esymm_one):
-    Apply psum_eq_mul_esymm_sub_sum at n=1:
-      psum σ R 1 = (-1)^2 * 1 * esymm σ R 1 - (empty sum over antidiag 1 filtered by 0<a<1)
-      = 1 * esymm σ R 1 - 0 = esymm σ R 1
-    The sum is empty because no a satisfies 0 < a < 1 for natural numbers.
-    Strategy: have h := MvPolynomial.psum_eq_mul_esymm_sub_sum σ R 1 one_ne_zero
-              simp [Finset.antidiagonal, Set.Ioo] at h; linarith
-
-  TARGET 2 (psum_two_eq):
-    Apply psum_eq_mul_esymm_sub_sum at n=2.
-    antidiag(2) filtered by 0<a<2 = {(1,1)}, so:
-      psum σ R 2 = (-1)^3 * 2 * esymm σ R 2 - (-1)^1 * esymm σ R 1 * psum σ R 1
-               = -2*esymm 2 + esymm 1 * psum 1
-               = -2*esymm 2 + esymm 1 * esymm 1   (using psum 1 = esymm 1)
-               = esymm 1 ^ 2 - 2 * esymm 2
-    Strategy: rw [psum_one_eq_esymm_one]
-              have h := MvPolynomial.psum_eq_mul_esymm_sub_sum σ R 2 (by norm_num)
-              simp [Finset.antidiagonal, Set.Ioo] at h
-              ring_nf at h ⊢; exact h
-
-  TARGET 3 (psum_three_eq):
-    Apply psum_eq_mul_esymm_sub_sum at n=3.
-    antidiag(3) filtered by 0<a<3 = {(1,2), (2,1)}, so:
-      psum σ R 3 = (-1)^4 * 3 * esymm σ R 3
-                - (-1)^1 * esymm σ R 1 * psum σ R 2
-                - (-1)^2 * esymm σ R 2 * psum σ R 1
-               = 3*esymm 3 + esymm 1 * psum 2 - esymm 2 * psum 1
-    Strategy: rw [psum_one_eq_esymm_one]
-              have h := MvPolynomial.psum_eq_mul_esymm_sub_sum σ R 3 (by norm_num)
-              simp [Finset.antidiagonal, Set.Ioo] at h
-              ring_nf at h ⊢; exact h
+  All 3 targets now proved via MvPolynomial.psum_eq_mul_esymm_sub_sum
+  with antidiagonal filter evaluation and linear_combination.
 -/
 import Mathlib
 
@@ -48,43 +14,47 @@ namespace AmgmInequalityOQ02OQ01OQ02OQ01Aristotle
 
 variable (σ : Type*) (R : Type*) [CommRing R] [Fintype σ]
 
-/-
-TARGET 1: Newton-Girard k=1 — the first power sum equals the first
-elementary symmetric polynomial.
+private lemma antidiag_filter_one :
+    (antidiagonal 1).filter (fun a => a.1 ∈ Ioo 0 1) = ∅ := by
+  ext ⟨a, b⟩
+  simp only [mem_filter, mem_antidiagonal, mem_Ioo, Finset.notMem_empty, iff_false, not_and]
+  omega
 
-psum σ R 1 = Σ_{i : σ} X i = esymm σ R 1
--/
+private lemma antidiag_filter_two :
+    (antidiagonal 2).filter (fun a => a.1 ∈ Ioo 0 2) = {(1, 1)} := by
+  ext ⟨a, b⟩
+  simp only [mem_filter, mem_antidiagonal, mem_Ioo, mem_singleton, Prod.mk.injEq]
+  constructor
+  · rintro ⟨hab, ha_pos, ha_lt⟩; omega
+  · rintro ⟨rfl, rfl⟩; omega
+
+private lemma antidiag_filter_three :
+    (antidiagonal 3).filter (fun a => a.1 ∈ Ioo 0 3) = {(1, 2), (2, 1)} := by
+  ext ⟨a, b⟩
+  simp only [mem_filter, mem_antidiagonal, mem_Ioo, mem_insert, mem_singleton, Prod.mk.injEq]
+  constructor
+  · rintro ⟨hab, ha_pos, ha_lt⟩; omega
+  · rintro (⟨rfl, rfl⟩ | ⟨rfl, rfl⟩) <;> omega
+
 theorem psum_one_eq_esymm_one :
     psum σ R 1 = esymm σ R 1 := by
-  sorry
+  have h := MvPolynomial.psum_eq_mul_esymm_sub_sum σ R 1 (by omega)
+  rw [antidiag_filter_one, sum_empty, sub_zero] at h
+  linear_combination h
 
-/-
-TARGET 2: Newton-Girard k=2 — power sum in terms of elementary symmetric polynomials.
-
-p₂ = e₁² − 2·e₂
-
-Derivation via psum_eq_mul_esymm_sub_sum at n=2:
-  antidiag(2) ∩ {0<a<2} = {(1,1)}, so the sum has one term:
-  psum 2 = -2·esymm 2 - (-1)·esymm 1·psum 1 = e₁² - 2·e₂
--/
 theorem psum_two_eq :
     psum σ R 2 = esymm σ R 1 ^ 2 - 2 * esymm σ R 2 := by
-  sorry
+  have h₁ := psum_one_eq_esymm_one σ R
+  have h := MvPolynomial.psum_eq_mul_esymm_sub_sum σ R 2 (by omega)
+  rw [antidiag_filter_two, sum_singleton] at h
+  linear_combination h + esymm σ R 1 * h₁
 
-/-
-TARGET 3: Newton-Girard k=3 — power sum in terms of lower-degree power sums.
-
-p₃ = e₁·p₂ − e₂·p₁ + 3·e₃
-
-Derivation via psum_eq_mul_esymm_sub_sum at n=3:
-  antidiag(3) ∩ {0<a<3} = {(1,2), (2,1)}, so the sum has two terms:
-  psum 3 = 3·esymm 3 - (-1)·esymm 1·psum 2 - 1·esymm 2·psum 1
-         = 3·e₃ + e₁·p₂ - e₂·p₁
-         = e₁·p₂ - e₂·p₁ + 3·e₃
--/
 theorem psum_three_eq :
     psum σ R 3 =
       esymm σ R 1 * psum σ R 2 - esymm σ R 2 * psum σ R 1 + 3 * esymm σ R 3 := by
-  sorry
+  have h := MvPolynomial.psum_eq_mul_esymm_sub_sum σ R 3 (by omega)
+  rw [antidiag_filter_three] at h
+  rw [sum_insert (show (1, 2) ∉ ({(2, 1)} : Finset _) by decide), sum_singleton] at h
+  linear_combination h
 
 end AmgmInequalityOQ02OQ01OQ02OQ01Aristotle

--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-25",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01.lean",
     "tags": [
       "algebra",
@@ -16,7 +16,7 @@
       "elementary-symmetric-polynomials",
       "mv-polynomial"
     ],
-    "badge": "wip",
+    "badge": "original",
     "mathlibDependencies": [
       {
         "theorem": "MvPolynomial.psum_eq_mul_esymm_sub_sum",
@@ -37,9 +37,9 @@
       "offDiag_prod_eq_two_mul_e2: specialization to products xᵢxⱼ"
     ],
     "dateAdded": "2026-04-25",
-    "assumptions": "Lean formalization created as WIP stub. Three corollary derivations (p₁=e₁, p₂, p₃) remain as sorries; the main recurrence wraps Mathlib MvPolynomial.psum_eq_mul_esymm_sub_sum.",
+    "assumptions": "None. All three Newton-Girard corollaries (p1=e1, p2=e1^2-2e2, p3=e1*p2-e2*p1+3e3) proved directly from Mathlib MvPolynomial.psum_eq_mul_esymm_sub_sum via antidiagonal filter evaluation and linear_combination.",
     "mathlib_version": "4.26.0",
-    "sorries": 3,
+    "sorries": 0,
     "axiomCount": 0
   },
   "overview": {
@@ -53,7 +53,7 @@
       "The proof works for any CommRing, not just ℝ — the symmetry identity is purely algebraic",
       "Finset.sum_image handles the reindexing step cleanly: swap is injective, so the sum transforms correctly",
       "The `calc` block in `sum_lower_eq_sum_upper` makes the three-step proof readable: symmetry → reindexing → image identity. This proof structure (rewrite f(p) → sum_image → image identity) is a reusable template for any double-counting argument involving symmetric functions over finsets.",
-      "**WIP context**: 3 sorries remain in corollary derivations (p₁=e₁, p₂, p₃ as corollaries of `MvPolynomial.psum_eq_mul_esymm_sub_sum`). The main off-diagonal symmetry proof is complete; the remaining sorries are in converting the abstract Mathlib recurrence to concrete small-k specializations. These are expected to be closable by `ring`/`simp` after correctly handling the `Fin`-indexed Mathlib multivariate polynomial conventions.",
+      "All three corollaries (k=1,2,3) are proved by evaluating the antidiagonal filter for each k (yielding empty, {(1,1)}, or {(1,2),(2,1)}), then closing the resulting algebra with `linear_combination`. No `ring`/`simp` suffices alone because the expressions involve `(-1)^n` exponents and `Nat.cast` coefficients in `MvPolynomial sigma R`.",
       "**Change-of-basis significance**: Newton-Girard is the change-of-basis matrix between the power sum basis $\\{p_k\\}$ and the elementary symmetric basis $\\{e_k\\}$ of the ring of symmetric functions $\\Lambda$. The matrix entries are given by the recurrence coefficients, which are integers — making Newton-Girard a statement about the integrality of this change of basis. This integrality is fundamental: it means that every symmetric polynomial with integer coefficients in $e_k$ has integer $p_k$-coefficients, and vice versa (up to division by k!)."
     ],
     "prerequisites": [
@@ -113,10 +113,9 @@
     }
   ],
   "conclusion": {
-    "summary": "Gallery entry for a planned Newton-Girard recurrence proof. Status: formalized (wip) — the Lean file has not yet been written. The off-diagonal symmetry identity is proved in the parent entry (amgm-inequality-oq-02-oq-01-oq-02). This entry tracks the open task of extending that proof to the full Newton-Girard recurrence for all k ≥ 1.",
+    "summary": "Verified Newton-Girard recurrence corollaries for k=1,2,3. All three power-sum/elementary-symmetric identities (p1=e1, p2=e1^2-2e2, p3=e1*p2-e2*p1+3e3) are proved directly from Mathlib's psum_eq_mul_esymm_sub_sum via antidiagonal filter evaluation and linear_combination. The main recurrence wrapper is also provided.",
     "implications": "**For Newton-Girard**: Combined with the parent's diagonal/off-diagonal decomposition, this gives the complete n=2 Newton-Girard identity: (Σxᵢ)² = Σxᵢ² + 2·e₂.\n\n**For Symmetric Functions**: The identity is the fundamental connection between the power sum p₂ and the elementary symmetric polynomial e₂, forming the base case for the full Newton-Girard recurrence.\n\n**For Mathlib**: Demonstrates clean use of Finset.offDiag, sum_image, and Prod.swap for combinatorial double-counting arguments.",
     "openQuestions": [
-      "Close the 3 remaining sorries in the corollary derivations (p₁=e₁, p₂, p₃) by correctly instantiating `MvPolynomial.psum_eq_mul_esymm_sub_sum` for small k and converting the abstract `MvPolynomial` statement to the concrete `Finset.sum` form used in the parent entries. The main challenge is matching the `Fin n`-indexed Mathlib multivariate polynomials with the user-facing finset-indexed power sums.",
       "Prove the full Newton-Girard recurrence for all k: $p_k = \\sum_{i=1}^k (-1)^{i-1} e_i p_{k-i}$ — using `MvPolynomial.psum_eq_mul_esymm_sub_sum` as the core, but setting up a clean inductive framework so all k cases follow uniformly.",
       "Formalize the change-of-basis between the power sum and elementary symmetric bases of $\\Lambda_n$ (the ring of symmetric polynomials in n variables): express $e_k$ in terms of $p_1, \\ldots, p_k$ and vice versa, showing the transition matrix is integral with determinant $\\pm 1$ (over $\\mathbb{Q}$, not $\\mathbb{Z}$, due to the $k!$ denominators in the $e_k \\to p$ direction).",
       "Formalize Schur positivity: the Schur functions $s_\\lambda$ (another basis of $\\Lambda$) can be written as non-negative integer combinations of products of elementary symmetric polynomials $e_\\lambda$. Newton-Girard connects this to the representation theory of $GL(n)$ — the Schur function $s_\\lambda$ is the character of the irreducible $GL(n)$-representation $V_\\lambda$, and $e_k = s_{(1^k)}$ is the character of the $k$-th exterior power.",


### PR DESCRIPTION
## Summary

- Prove all 3 sorry'd Newton-Girard corollaries (p1=e1, p2=e1^2-2e2, p3=e1*p2-e2*p1+3e3) by applying `MvPolynomial.psum_eq_mul_esymm_sub_sum` directly from Mathlib
- Fix pre-existing type errors in the `newton_girard_recurrence` wrapper (wrong argument type, wrong coefficient cast, wrong sum formulation)
- Update meta.json: status formalized -> verified, badge wip -> original, sorries 3 -> 0
- Update Aristotle companion file with the same proofs

## Proof approach

Each corollary is proved in three steps:
1. Instantiate `psum_eq_mul_esymm_sub_sum` at the concrete k value
2. Evaluate the antidiagonal filter via `ext`/`simp`/`omega` helper lemmas
3. Close the resulting ring equality with `linear_combination`

The antidiagonal filters evaluate to:
- k=1: empty set (no natural number strictly between 0 and 1)
- k=2: {(1,1)}
- k=3: {(1,2), (2,1)}

## Docker build verification

```
Build completed successfully (7743 jobs).
=== Build succeeded ===
```

No warnings, no errors, 0 sorries.

## Test plan

- [x] `docker-build.sh Proofs.AmgmInequalityOQ02OQ01OQ02OQ01` succeeds with 0 sorries
- [x] No deprecation warnings
- [x] meta.json updated to reflect verified status