### PR TITLE
enrichment: synthesis-curvature-ptolemy — add index.ts so proof page loads

### DIFF
--- a/src/data/proofs/synthesis-curvature-ptolemy/index.ts
+++ b/src/data/proofs/synthesis-curvature-ptolemy/index.ts
@@ -1,0 +1,38 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/SynthesisCurvaturePtolemy.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const synthesisCurvaturePtolemyProof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const synthesisCurvaturePtolemyAnnotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const synthesisCurvaturePtolemyData: ProofData = {
+  proof: synthesisCurvaturePtolemyProof,
+  annotations: synthesisCurvaturePtolemyAnnotations,
+}
+
+export default synthesisCurvaturePtolemyData


### PR DESCRIPTION
Quick fix for `synthesis-curvature-ptolemy`: the proof page was returning "proof not found" on the live site because `index.ts` was missing. Without this file, Vite's `import.meta.glob` cannot discover the proof.

The entry was already richly enriched (9 annotations with full mathContext, 7 keyInsights, 7 cross-references, 5 open questions in conclusion) — this PR only adds the missing `index.ts` loader.