### PR TITLE
feat: prove OmegaContinuous.monotone (Cantor OQ04OQ03, 0 sorries)

### DIFF
--- a/proofs/Proofs/CantorDiagonalizationOQ04OQ03.lean
+++ b/proofs/Proofs/CantorDiagonalizationOQ04OQ03.lean
@@ -122,9 +122,25 @@ def OmegaContinuous [CompleteLattice α] (f : α → α) : Prop :=
 theorem OmegaContinuous.monotone [CompleteLattice α] {f : α → α}
     (hf : OmegaContinuous f) : Monotone f := by
   intro a b hab
-  have hc : ∀ n : ℕ, (fun _ : ℕ => a) n ≤ (fun n => if n = 0 then a else b) (n + 1) := by
-    intro n; simp; exact hab
-  sorry -- Derivable but needs careful chain construction; not the main result
+  -- Construct the chain: c 0 = a, c (n+1) = b
+  let c : ℕ → α := fun n => if n = 0 then a else b
+  -- Chain is ascending
+  have hc_asc : ∀ n, c n ≤ c (n + 1) := fun n => by
+    simp only [c, Nat.succ_ne_zero, ↓reduceIte]
+    split_ifs with h
+    · exact hab
+    · exact le_refl b
+  -- Supremum of chain is b
+  have hc_sup : ⨆ n, c n = b := le_antisymm
+    (iSup_le fun n => by simp only [c]; split_ifs <;> [exact hab; exact le_refl b])
+    (le_iSup c 1)
+  -- Apply ω-continuity: f b = ⊔ₙ f(c n)
+  have hcont := hf c hc_asc
+  rw [hc_sup] at hcont
+  -- f a = f (c 0) ≤ ⊔ₙ f(c n) = f b
+  have hfa : f a = f (c 0) := by simp [c]
+  rw [hfa, hcont]
+  exact le_iSup _ 0
 
 /-- The Kleene fixed point: the supremum of the Kleene chain. -/
 noncomputable def kleeneFix [CompleteLattice α] (f : α → α) : α :=

--- a/src/data/proofs/cantor-diagonalization-oq-04-oq-03/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-04-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Lawvere (1969), Scott (1972), formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Kleene_fixed-point_theorem",
     "date": "1969/1972",
-    "status": "formalized",
+    "status": "verified",
     "tags": [
       "logic",
       "category-theory",
@@ -16,8 +16,8 @@
       "order-theory"
     ],
     "proofRepoPath": "Proofs/CantorDiagonalizationOQ04OQ03.lean",
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "original",
+    "sorries": 0,
     "axiomCount": 0,
     "theoremCount": 10,
     "mathlibDependencies": [
@@ -33,7 +33,7 @@
       }
     ],
     "lineCount": 283,
-    "assumptions": []
+    "assumptions": "None. OmegaContinuous.monotone proved via chain construction: c 0 = a, c (n+1) = b gives f(a) ≤ ⊔ₙ f(cₙ) = f(b) by ω-continuity."
   },
   "parent": "cantor-diagonalization-oq-04",
   "openQuestion": "How does Lawvere's categorical fixed-point theorem connect to domain-theoretic fixed points (Kleene chain, Scott's theorem, Y combinator)?",


### PR DESCRIPTION
## Summary

Closes the last sorry in `CantorDiagonalizationOQ04OQ03.lean` (Lawvere-Kleene domain theory connection).

**Proved**: `OmegaContinuous.monotone` — ω-continuous implies monotone.

**Proof**: Construct the two-element ascending chain `c 0 = a, c (n+1) = b`:
- Chain is ascending: `a ≤ b` at step 0, `b ≤ b` for n ≥ 1
- Supremum is `b` (reached at step 1)
- ω-continuity gives `f(b) = ⊔ₙ f(cₙ) ≥ f(c₀) = f(a)`

**Status**: 0 sorries, 0 axioms. Gallery entry updated to `verified`.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)