### PR TITLE
prove(dissection-oq-04): eliminate last axiom via Module.Flat — OQ02OQ02 and OQ04 now verified

### DIFF
--- a/proofs/Proofs/DissectionOfCubesOQ02.lean
+++ b/proofs/Proofs/DissectionOfCubesOQ02.lean
@@ -149,10 +149,10 @@ theorem nivenSeq_eq_cos (k : ℕ) :
   induction n with
   | zero =>
     refine ⟨by simp [nivenSeq, Real.cos_zero], ?_⟩
-    simp only [nivenSeq_one, Nat.cast_one, pow_one]
-    rw [show (1 : ℝ) * Real.arccos (1/3) = Real.arccos (1/3) from one_mul _,
+    have h1 : (nivenSeq 1 : ℝ) = 2 := by norm_num [nivenSeq]
+    simp only [Nat.zero_add, pow_one, Nat.cast_one, one_mul, h1,
       Real.cos_arccos (by norm_num : (-1 : ℝ) ≤ 1/3) (by norm_num : (1/3 : ℝ) ≤ 1)]
-    push_cast; ring
+    norm_num
   | succ m ih =>
     refine ⟨ih.2, ?_⟩
     have hrec : (nivenSeq (m + 2) : ℝ) =

--- a/proofs/Proofs/DissectionOfCubesOQ02OQ02.lean
+++ b/proofs/Proofs/DissectionOfCubesOQ02OQ02.lean
@@ -18,7 +18,7 @@
   • Rational angle vanishing: r ⊗ [qπ] = 0 for all q ∈ ℚ (PROVED)
     — uses divisibility of ℝ as a ℤ-module
   • Cube has zero Dehn invariant (PROVED)
-  • Tetrahedron has nonzero Dehn invariant (PROVED modulo flatness axiom)
+  • Tetrahedron has nonzero Dehn invariant (PROVED)
   • Hilbert's Third Problem: cube ≇ tetrahedron (PROVED)
   • Dehn-Sydler completeness theorem (STATED)
 
@@ -203,14 +203,53 @@ theorem tetAngle_infinite_order :
   have hn_ne : (n : ℝ) ≠ 0 := Int.cast_ne_zero.mpr hn
   exact ⟨(m : ℚ) / (n : ℚ), by push_cast; field_simp; linarith⟩
 
-/-- **Flatness axiom**: In ℝ ⊗_ℤ (ℝ/πℤ), if [θ] has infinite order
+/-- **Flatness theorem**: In ℝ ⊗_ℤ (ℝ/πℤ), if [θ] has infinite order
 then r ⊗ [θ] ≠ 0 for r ≠ 0.
 
-Justified by: ℝ is flat over ℤ (torsion-free over PID).
-The injection ℤ ↪ ℝ/πℤ via n ↦ n·[θ] tensors to ℝ ≅ ℝ⊗ℤ ↪ ℝ⊗(ℝ/πℤ). -/
-axiom tmul_infinite_order_ne_zero (r : ℝ) (x : AngleQuot) (hr : r ≠ 0)
+Proof: ℝ is flat over ℤ (torsion-free module over Bézout domain ℤ).
+The map f : ℤ →ₗ[ℤ] AngleQuot, n ↦ n·[θ] is injective (infinite order).
+By flatness, id_ℝ ⊗ f : ℝ ⊗_ℤ ℤ → ℝ ⊗_ℤ AngleQuot is injective.
+Under TensorProduct.rid : ℝ ⊗_ℤ ℤ ≅ ℝ, the element r ⊗ 1 maps to r ≠ 0.
+Hence r ⊗ [θ] = (id_ℝ ⊗ f)(r ⊗ 1) ≠ 0. -/
+theorem tmul_infinite_order_ne_zero (r : ℝ) (x : AngleQuot) (hr : r ≠ 0)
     (hx : ∀ n : ℤ, n ≠ 0 → n • x ≠ 0) :
-    TensorProduct.tmul ℤ r x ≠ (0 : DehnGroup)
+    TensorProduct.tmul ℤ r x ≠ (0 : DehnGroup) := by
+  -- ℝ is flat over ℤ: NoZeroSMulDivisors ℤ ℝ ↔ torsion ℤ ℝ = ⊥ ↔ Flat ℤ ℝ (Bézout)
+  haveI : Module.Flat ℤ ℝ := by
+    rw [Module.Flat.flat_iff_torsion_eq_bot_of_isBezout,
+        ← Submodule.noZeroSMulDivisors_iff_torsion_eq_bot]
+    exact NoZeroSMulDivisors.iff_algebraMap_injective.mpr Int.cast_injective
+  -- The injective ℤ-linear map f : ℤ →ₗ[ℤ] AngleQuot, n ↦ n • x
+  let f : ℤ →ₗ[ℤ] AngleQuot :=
+    { toFun    := fun n => n • x
+      map_add' := fun a b => add_smul a b x
+      map_smul' := fun m n => mul_smul m n x }
+  -- f is injective: n • x = 0 → n = 0 (infinite order condition)
+  have hf : Function.Injective f := fun a b hab => by
+    -- f is definitionally the map n ↦ n • x
+    have ha : f a = a • x := rfl
+    have hb : f b = b • x := rfl
+    rw [ha, hb] at hab
+    -- hab : a • x = b • x, so (a - b) • x = 0
+    by_contra hne
+    exact absurd (show (a - b) • x = 0 by rw [sub_smul, hab, sub_self])
+      (hx (a - b) (sub_ne_zero.mpr hne))
+  -- By flatness of ℝ, lTensor ℝ f : ℝ ⊗_ℤ ℤ → ℝ ⊗_ℤ AngleQuot is injective
+  have hinj := Module.Flat.lTensor_preserves_injective_linearMap (M := ℝ) f hf
+  -- r ⊗ 1 ≠ 0 in ℝ ⊗_ℤ ℤ: TensorProduct.rid maps it to r ≠ 0
+  have hr1 : TensorProduct.tmul ℤ r (1 : ℤ) ≠ 0 := fun h => hr <| by
+    have heq : (TensorProduct.rid ℤ ℝ) (TensorProduct.tmul ℤ r (1 : ℤ)) = r := by
+      rw [TensorProduct.rid_tmul]; exact one_smul ℤ r
+    rw [h, map_zero] at heq
+    exact heq.symm
+  -- lTensor ℝ f maps r ⊗ 1 to r ⊗ f(1) = r ⊗ (1 • x) = r ⊗ x
+  have hfact : (f.lTensor ℝ) (TensorProduct.tmul ℤ r (1 : ℤ)) =
+      TensorProduct.tmul ℤ r x := by
+    have h1 : f 1 = x := show (1 : ℤ) • x = x from one_smul ℤ x
+    rw [LinearMap.lTensor_tmul, h1]
+  -- Conclude: r ⊗ x ≠ 0 (if it were 0, then r ⊗ 1 = 0 by injectivity, contradiction)
+  intro h
+  exact hr1 (hinj ((hfact.trans h).trans (map_zero _).symm))
 
 -- ========================================================================
 -- Part VII: Tetrahedron Dehn Invariant is Nonzero (PROVED)
@@ -255,7 +294,9 @@ noncomputable def octAngle : ℝ := Real.arccos (-1/3)
 /-- arccos(-1/3) = π - arccos(1/3). Standard identity for arccos.
 Proved via Mathlib's `Real.arccos_neg`. -/
 theorem arccos_neg_third : octAngle = Real.pi - tetAngle := by
-  unfold octAngle tetAngle; exact Real.arccos_neg (1/3)
+  unfold octAngle tetAngle
+  have h : (-1 : ℝ) / 3 = -(1 / 3) := by norm_num
+  rw [h]; exact Real.arccos_neg (1/3)
 
 /-- [arccos(-1/3)] = -[arccos(1/3)] in ℝ/πℤ, since [π] = 0. -/
 theorem octAngle_class : angleClass octAngle = -angleClass tetAngle := by
@@ -321,7 +362,7 @@ theorem dehn_preserved_by_scissors (d₁ d₂ : DehnGroup) :
 theorem volume_preserved_by_scissors (v₁ v₂ : ℝ) :
     True → v₁ = v₁ := fun _ => rfl
 
-/-- **The Dehn-Sydler Theorem (Sydler 1965, simplified by Jessen 1968)**
+/- **The Dehn-Sydler Theorem (Sydler 1965, simplified by Jessen 1968)**
 
 Two polyhedra in ℝ³ are scissors congruent if and only if they have
 equal volume AND equal Dehn invariant.
@@ -379,13 +420,13 @@ theorem dehn_zero_of_rational_angles (angles : List (ℝ × ℝ))
 /-
 ## Axiom Budget
 
-This formalization uses 1 axiom (reduced from 6):
-
-1. `tmul_infinite_order_ne_zero` — ℝ is flat over ℤ
-   Status: Standard algebra (torsion-free over PID ⟹ flat)
+This formalization uses 0 axioms (reduced from 6):
 
 ### Previously Axiomatized, Now Proved
 
+- `tmul_infinite_order_ne_zero` — ℝ is flat over ℤ (torsion-free over Bézout domain)
+  Proved via: Module.Flat.flat_iff_torsion_eq_bot_of_isBezout +
+              NoZeroSMulDivisors.iff_algebraMap_injective + Int.cast_injective
 - `niven_arccos_third` — Cross-referenced from DissectionOfCubesOQ02.lean
 - `arccos_neg_third` — Proved via Mathlib's `Real.arccos_neg`
 - `dehn_preserved_by_scissors` — Proved (placeholder: `True → d₁ = d₁`)

--- a/proofs/Proofs/DissectionOfCubesOQ04.lean
+++ b/proofs/Proofs/DissectionOfCubesOQ04.lean
@@ -23,9 +23,9 @@
 
   ## Axiom Budget
 
-  1. `tmul_infinite_order_ne_zero` (from OQ02OQ02) — ℝ flat over ℤ
-  2. `icoAngle_irrational` — arccos(-√5/3)/π irrational (icosahedron)
-     [Proof requires Chebyshev arithmetic in ℤ[√5]; deferred]
+  0 axioms (fully proved):
+  - `tmul_infinite_order_ne_zero` (OQ02OQ02): PROVED via ℝ flat over ℤ (Bézout + torsion-free)
+  - `icoAngle_irrational`: PROVED via Chebyshev sequence for arccos(1/9)
 
   ## Classification Table (among Platonic solids)
 
@@ -545,10 +545,10 @@ theorem cube_unique_zero_dehn (a : ℝ) (ha : a > 0) :
 ### New axioms introduced in this file: 0
 - `icoAngle_irrational` is now a proved theorem (Chebyshev ℤ[√5] argument).
 
-### Inherited axioms (from OQ02OQ02): 1
-1. `tmul_infinite_order_ne_zero` — ℝ flat over ℤ
+### Inherited axioms (from OQ02OQ02): 0
+(tmul_infinite_order_ne_zero is now PROVED via ℝ flat over ℤ — Bézout domain + NoZeroSMulDivisors)
 
-### Total axiom count: 1
+### Total axiom count: 0 (reduced from 2)
 
 ### New theorems proved (0 sorries):
 - `five_ndvd_cosThreeFifthsSeq` — 5 ∤ d_n for the new sequence

--- a/research/problems/dissection-of-cubes-oq-04/knowledge.md
+++ b/research/problems/dissection-of-cubes-oq-04/knowledge.md
@@ -85,6 +85,41 @@ Dihedral angles:
 
 ---
 
+## Session 9 (2026-04-26)
+
+**Mode**: REVISIT
+**Outcome**: COMPLETED — proved `tmul_infinite_order_ne_zero`, eliminating last axiom; axiomCount 1→0, status→verified
+
+### What I Did
+
+1. Proved `tmul_infinite_order_ne_zero` in `DissectionOfCubesOQ02OQ02.lean` using `Module.Flat` infrastructure
+2. Key insight: ℝ is flat over ℤ because it is torsion-free over the Bézout domain ℤ
+   - Used `Module.Flat.flat_iff_torsion_eq_bot_of_isBezout`
+   - Used `Submodule.noZeroSMulDivisors_iff_torsion_eq_bot`
+   - Used `NoZeroSMulDivisors.iff_algebraMap_injective.mpr Int.cast_injective`
+3. Constructed injective linear map `f : ℤ →ₗ[ℤ] AngleQuot, n ↦ n•x`
+4. By flatness, `lTensor ℝ f` is injective — maps `r⊗1` to `r⊗x`
+5. `r⊗1 ≠ 0` via `TensorProduct.rid ℤ ℝ` (maps to r ≠ 0)
+6. Hence `r⊗x ≠ 0`
+7. Also fixed pre-existing bugs: OQ02 `simp` timeout (Nat.zero_add) and OQ02OQ02 `/--` doc comment syntax error and `arccos_neg_third` heartbeat timeout (`(-1:ℝ)/3 ≠ -(1/3)` syntactically)
+
+### Files Modified
+
+- `proofs/Proofs/DissectionOfCubesOQ02OQ02.lean` (413 → 454 lines)
+  - Replaced `axiom tmul_infinite_order_ne_zero` with full 40-line proof
+  - Fixed `/--` doc comment at line 363
+  - Fixed `arccos_neg_third` via `norm_num` preprocessing
+- `proofs/Proofs/DissectionOfCubesOQ02.lean`
+  - Fixed pre-existing `simp` timeout via `Nat.zero_add` + explicit `cos_arccos`
+- Both meta.json files updated: axiomCount 1→0, status→verified, badge→verified
+
+### Outcome
+
+- `dissection-of-cubes-oq-02-oq-02`: VERIFIED (0 axioms, 0 sorries)
+- `dissection-of-cubes-oq-04`: VERIFIED (0 axioms, 0 sorries) — depends on OQ02OQ02 which is now axiom-free
+
+---
+
 ## Dead Ends
 
 - Direct `norm_num` for mod-3 invariant inductive step — doesn't handle the symbolic case.

--- a/src/data/proofs/dissection-of-cubes-oq-02-oq-02/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-02-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Dehn (1900), Sydler (1965), Jessen (1968)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Dehn%E2%80%93Sydler_theorem",
     "date": "1965",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/DissectionOfCubesOQ02OQ02.lean",
     "tags": [
       "geometry",
@@ -18,9 +18,9 @@
       "wiedijk-100",
       "research"
     ],
-    "badge": "axiom",
+    "badge": "verified",
     "sorries": 0,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "dateAdded": "2026-03-25",
     "mathlibDependencies": [
       {
@@ -52,10 +52,11 @@
       "tet_dehn_ne_zero: tetrahedron Dehn invariant is nonzero (arccos(1/3)/π irrational)",
       "hilbert_third_problem: D(cube) ≠ D(tetrahedron)",
       "octAngle_class: [arccos(-1/3)] = -[arccos(1/3)] in ℝ/πℤ",
-      "Dehn-Sydler completeness theorem statement"
+      "Dehn-Sydler completeness theorem statement",
+      "tmul_infinite_order_ne_zero: proved via Module.Flat (ℝ flat over ℤ as Bézout + NoZeroSMulDivisors) — lTensor ℝ f injective for injective f : ℤ →ₗ AngleQuot"
     ],
-    "lineCount": 413,
-    "assumptions": "1 axiom: tmul_infinite_order_ne_zero (flatness of ℝ over ℤ — torsion-free over PID implies flat). Previously 6 axioms; 5 eliminated: niven_arccos_third (cross-referenced from parent file), arccos_neg_third (proved via Real.arccos_neg), and 3 placeholder axioms (dehn_preserved_by_scissors, volume_preserved_by_scissors, dehn_sydler_theorem).",
+    "lineCount": 454,
+    "assumptions": "0 axioms. All assumptions eliminated. tmul_infinite_order_ne_zero proved via Module.Flat: ℝ is flat over ℤ (Bézout domain + NoZeroSMulDivisors ℤ ℝ), so lTensor ℝ f is injective for any injective f : ℤ →ₗ[ℤ] AngleQuot, giving r⊗x≠0 when r≠0 and x has infinite order. Previously 6 axioms; all eliminated across sessions.",
     "mathlib_version": "4.26.0",
     "wiedijkNumber": 37,
     "relatedProblems": [
@@ -193,10 +194,9 @@
     "summary": "This formalization constructs the proper algebraic Dehn invariant $D(P) \\in \\mathbb{R} \\otimes_{\\mathbb{Z}} (\\mathbb{R}/\\pi\\mathbb{Z})$ using Mathlib's tensor product infrastructure. The central algebraic insight — that $\\mathbb{R}$ is divisible over $\\mathbb{Z}$, so torsion elements of $\\mathbb{R}/\\pi\\mathbb{Z}$ are killed in the tensor product — gives a clean proof that rational-angle polyhedra have $D = 0$. Combined with Niven's theorem ($\\arccos(1/3)/\\pi \\notin \\mathbb{Q}$), this resolves Hilbert's Third Problem: $D(\\text{cube}) = 0 \\neq D(\\text{tet})$. The Dehn-Sydler completeness theorem is stated as an axiom.",
     "implications": "The tensor product formulation of the Dehn invariant automatically handles the rational-angle vanishing that must be argued case-by-case in elementary treatments. This algebraic perspective generalizes: scissors congruence in higher dimensions connects to algebraic K-theory (Dupont, Sah), where the Dehn invariant lives in $K_3(\\mathbb{C})$. The formalization demonstrates that Mathlib's tensor product API is mature enough for non-trivial applications in geometric algebra.",
     "openQuestions": [
-      "Can the flatness axiom (tmul_infinite_order_ne_zero) be proved in Lean using Mathlib's flatness theory for torsion-free modules over PIDs?",
+      "RESOLVED: The flatness axiom (tmul_infinite_order_ne_zero) was proved in Lean using Module.Flat, Module.Flat.flat_iff_torsion_eq_bot_of_isBezout, and NoZeroSMulDivisors.iff_algebraMap_injective.",
       "Can Sydler's sufficiency proof (same volume + same D implies scissors congruent) be formalized, completing the Dehn-Sydler theorem?",
-      "What are the complete scissors congruence invariants in $\\mathbb{R}^n$ for $n \\geq 4$? Jessen and Thorup (1978) showed that volume and Dehn invariant do NOT suffice in dimension 4.",
-      "The arccos_neg_third axiom has been proved via Mathlib's Real.arccos_neg. Can the remaining flatness axiom (tmul_infinite_order_ne_zero) be proved using Mathlib's Module.Flat theory?"
+      "What are the complete scissors congruence invariants in $\\mathbb{R}^n$ for $n \\geq 4$? Jessen and Thorup (1978) showed that volume and Dehn invariant do NOT suffice in dimension 4."
     ]
   },
   "crossReferences": [
@@ -250,8 +250,8 @@
       "Real"
     ],
     "namespace": "DehnSydler",
-    "lineCount": 413,
-    "axiomCount": 1,
+    "lineCount": 454,
+    "axiomCount": 0,
     "theoremCount": 23,
     "definitionCount": 5,
     "mainTheorems": [

--- a/src/data/proofs/dissection-of-cubes-oq-04/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-04/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius",
     "sourceUrl": "https://en.wikipedia.org/wiki/Dehn_invariant",
     "date": "1900",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/DissectionOfCubesOQ04.lean",
     "tags": [
       "geometry",
@@ -18,11 +18,11 @@
       "scissors-congruence",
       "irrational-angles"
     ],
-    "badge": "axiom",
+    "badge": "verified",
     "sorries": 0,
     "dateAdded": "2026-04-22",
-    "axiomCount": 1,
-    "assumptions": "1 axiom: tmul_infinite_order_ne_zero (from OQ02OQ02): ℝ is flat over ℤ — needed to show nonzero tensor products. icoAngle_irrational is now a proved theorem (Chebyshev ℤ[√5] argument), reducing the axiom count from 2 to 1.",
+    "axiomCount": 0,
+    "assumptions": "0 axioms. tmul_infinite_order_ne_zero (flatness of ℝ over ℤ) was proved in DissectionOfCubesOQ02OQ02.lean via Module.Flat infrastructure. icoAngle_irrational (arccos(-√5/3)/π irrational) was proved in a prior session via Chebyshev integer sequence for arccos(1/9).",
     "lineCount": 581,
     "theoremCount": 22,
     "definitionCount": 5,
@@ -150,8 +150,8 @@
     "summary": "Among the five Platonic solids, the cube is uniquely characterized by having zero Dehn invariant. This extends Hilbert's Third Problem from the single pair (cube, tetrahedron) to the complete classification of all Platonic solids under scissors congruence.",
     "implications": "The complete classification shows that the cube is the unique Platonic solid that can potentially be scissors congruent to a non-Platonic polyhedron of equal volume. All other four Platonic solids have D ≠ 0 and so cannot be dissected and reassembled into any shape with D = 0 (in particular, not into a cube). The new irrationality result arccos(1/√5)/π ∉ ℚ is itself a contribution to the theory of irrational angles, extending the Niven-style Chebyshev technique to a new cosine value.",
     "openQuestions": [
-      "Can the remaining axiom (tmul_infinite_order_ne_zero — flatness of ℝ over ℤ) be proved using Mathlib's Module.Flat infrastructure?",
-      "Can icoAngle_irrational be proved by extending the Chebyshev argument to ℤ[√5], completing the proof for all five Platonic solids with 0 axioms?"
+      "RESOLVED: The flatness axiom (tmul_infinite_order_ne_zero) was proved in DissectionOfCubesOQ02OQ02.lean using Module.Flat and NoZeroSMulDivisors.",
+      "Can this technique be applied to prove irrationality results for other dihedral angles arising in higher-dimensional polytopes?"
     ]
   },
   "crossReferences": [

--- a/src/data/research/problems/dissection-of-cubes-oq-04.json
+++ b/src/data/research/problems/dissection-of-cubes-oq-04.json
@@ -29,36 +29,39 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: axiomCount 2\u21921. icoAngle_irrational proved via coupled \u2124[\u221a5] Chebyshev sequences. Only tmul_infinite_order_ne_zero (\u211d flat over \u2124) remains.",
+    "progressSummary": "COMPLETE: 0 axioms, 0 sorries. tmul_infinite_order_ne_zero proved via Module.Flat. All Platonic solid Dehn invariants computed and verified.",
     "builtItems": [
-      "cube_unique_zero_dehn (PROVED, 0 sorries) \u2014 DissectionOfCubesOQ04.lean",
-      "cube_isolated_dehn_invariant (PROVED) \u2014 cube D=0, all others D\u22600",
-      "five_ndvd_cosThreeFifthsSeq (PROVED) \u2014 5 \u2224 d_n for cosThreeFifths sequence",
-      "arccos_three_fifths_irrational (PROVED) \u2014 arccos(3/5)/\u03c0 \u2209 \u211a",
-      "dodAngle_irrational (PROVED) \u2014 arccos(-1/\u221a5)/\u03c0 \u2209 \u211a via chain",
-      "dod_dehn_ne_zero (PROVED) \u2014 dodecahedron D \u2260 0",
-      "icoSeqAB : \u2115 \u2192 \u2124 \u00d7 \u2124 \u2014 coupled integer sequence A_n + B_n\u221a5 = 3^n\u00b72cos(n\u00b7icoAngle) (DissectionOfCubesOQ04.lean:305)",
-      "icoSeqAB_ndvd \u2014 mod-3 invariant \u00ac3|A_{2k} \u2227 \u00ac3|B_{2k+1} (DissectionOfCubesOQ04.lean:319)",
-      "icoSeqAB_eq_cos \u2014 Chebyshev connection theorem (DissectionOfCubesOQ04.lean:360)",
-      "icoAngle_irrational \u2014 proved theorem (was axiom) via \u2124[\u221a5] argument (DissectionOfCubesOQ04.lean:394)",
-      "DissectionOfCubesOQ04Aristotle.lean \u2014 all 3 sorries closed with tmul_infinite_order_ne_zero pattern"
+      "cube_unique_zero_dehn (PROVED, 0 sorries) — DissectionOfCubesOQ04.lean",
+      "cube_isolated_dehn_invariant (PROVED) — cube D=0, all others D≠0",
+      "five_ndvd_cosThreeFifthsSeq (PROVED) — 5 ∤ d_n for cosThreeFifths sequence",
+      "arccos_three_fifths_irrational (PROVED) — arccos(3/5)/π ∉ ℚ",
+      "dodAngle_irrational (PROVED) — arccos(-1/√5)/π ∉ ℚ via chain",
+      "dod_dehn_ne_zero (PROVED) — dodecahedron D ≠ 0",
+      "icoSeqAB : ℕ → ℤ × ℤ — coupled integer sequence A_n + B_n√5 = 3^n·2cos(n·icoAngle) (DissectionOfCubesOQ04.lean:305)",
+      "icoSeqAB_ndvd — mod-3 invariant ¬3|A_{2k} ∧ ¬3|B_{2k+1} (DissectionOfCubesOQ04.lean:319)",
+      "icoSeqAB_eq_cos — Chebyshev connection theorem (DissectionOfCubesOQ04.lean:360)",
+      "icoAngle_irrational — proved theorem (was axiom) via ℤ[√5] argument (DissectionOfCubesOQ04.lean:394)",
+      "DissectionOfCubesOQ04Aristotle.lean — all 3 sorries closed with tmul_infinite_order_ne_zero pattern",
+      "tmul_infinite_order_ne_zero proof in DissectionOfCubesOQ02OQ02.lean:214-252 (40 lines, Module.Flat approach)"
     ],
     "insights": [
       "DissectionOfCubesOQ04.lean already fully drafted with substantial proof",
-      "Chebyshev \u2124[\u221a5] approach: f_n = A_n + B_n\u221a5 = 3^n\u00b72cos(n\u00b7icoAngle) with mod-3 invariant",
+      "Chebyshev ℤ[√5] approach: f_n = A_n + B_n√5 = 3^n·2cos(n·icoAngle) with mod-3 invariant",
       "IsCoprime.dvd_of_dvd_mul_left is the key Mathlib lemma for coprime-factor divisibility",
       "Simultaneous induction on (n, n+1) pairs avoids needing n-2 explicitly",
-      "linear_combination with sq_sqrt closes ring identities involving \u221a5^2=5",
-      "Nat.Prime.irrational_sqrt proves \u221a5 irrational without extra imports",
+      "linear_combination with sq_sqrt closes ring identities involving √5^2=5",
+      "Nat.Prime.irrational_sqrt proves √5 irrational without extra imports",
       "Nat.even_or_odd handles parity case split for the final contradiction",
-      "In paired induction, prove first component as intermediate `have` before `refine \u27e8?, ?\u27e9`"
+      "In paired induction, prove first component as intermediate `have` before `refine ⟨?, ?⟩`",
+      "tmul_infinite_order_ne_zero proved in OQ02OQ02 via Module.Flat: ℝ flat over ℤ (Bézout + NoZeroSMulDivisors), lTensor injective → r⊗x≠0",
+      "OQ02OQ02 arccos_neg_third timeout fixed: (-1:ℝ)/3 is not syntactically -(1/3), need norm_num preprocessing before Real.arccos_neg",
+      "Both OQ02OQ02 and OQ04 now have 0 axioms; status upgraded to verified"
     ],
     "mathlibGaps": [
-      "\u211d flat over \u2124 (tmul_infinite_order_ne_zero) \u2014 still axiomatized"
+      "ℝ flat over ℤ (tmul_infinite_order_ne_zero) — still axiomatized"
     ],
     "nextSteps": [
-      "Prove tmul_infinite_order_ne_zero using Module.Flat in Mathlib (would achieve 0 axioms)",
-      "Cross-solid comparison: D(tetrahedron) \u2260 D(icosahedron) directly?"
+      "COMPLETED — no further work needed; all axioms eliminated"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

- Proves `tmul_infinite_order_ne_zero` in `DissectionOfCubesOQ02OQ02.lean` using Mathlib's `Module.Flat` infrastructure — ℝ is flat over ℤ (Bézout domain + `NoZeroSMulDivisors ℤ ℝ`), so `lTensor ℝ f` is injective for any injective `f : ℤ →ₗ[ℤ] AngleQuot`
- Reduces `dissection-of-cubes-oq-02-oq-02` and `dissection-of-cubes-oq-04` from `axiomCount: 1` → `axiomCount: 0`, upgrading both to `status: verified`
- Fixes three pre-existing bugs: OQ02 `simp` timeout (`Nat.zero_add`), OQ02OQ02 `/--` doc comment syntax error, OQ02OQ02 `arccos_neg_third` heartbeat timeout

## Mathematical Content

The key lemma `tmul_infinite_order_ne_zero` states: if `r ≠ 0` and `x ∈ ℝ/πℤ` has infinite order, then `r ⊗ x ≠ 0` in `ℝ ⊗_ℤ (ℝ/πℤ)`.

**Proof**: ℝ flat over ℤ → `lTensor ℝ f` injective for injective `f`. Construct `f : n ↦ n•x` (injective by infinite-order hypothesis). Under `TensorProduct.rid`, `r⊗1 ↦ r ≠ 0`. Then `lTensor ℝ f (r⊗1) = r⊗x`, so `r⊗x ≠ 0`.

## Test plan

- [x] `./proofs/scripts/docker-build.sh Proofs.DissectionOfCubesOQ02OQ02` — builds clean (87s, warnings only)
- [x] 0 `axiom` declarations in both files
- [x] 0 `sorry` in both files
- [x] meta.json updated: `axiomCount: 0`, `status: verified`, `badge: verified`

🤖 Generated with [Claude Code](https://claude.com/claude-code)