### PR TITLE
docs(sperner-ndim-oq-04): document Session 12 — Case A proved

### DIFF
--- a/research/problems/sperner-ndim-oq-04/knowledge.md
+++ b/research/problems/sperner-ndim-oq-04/knowledge.md
@@ -4,7 +4,7 @@
 
 Formalize Kuhn's (1968) constructive proof of Sperner's lemma via path-following in the door adjacency graph. Key goal: starting from a boundary door, follow the unique path to reach a fully-colored simplex.
 
-**Status**: SORRY — 0 axioms, 1 sorry (bdry_nfc_even on walk reversal τ∘τ=id). Session 6: axiom replaced with theorem kuhn_path_existential; proof structure complete, only walk reversal formalization pending.
+**Status**: SORRY — 0 axioms, 1 sorry (Case B of kuhn_path_existential: walk-reversal involution). Session 12: Case A proved; Case B pending.
 **Gallery entry**: `src/data/proofs/sperner-ndim-oq-04/`
 **Lean file**: `proofs/Proofs/SpernerNDimOQ04.lean`
 
@@ -302,3 +302,57 @@ Formalize Kuhn's (1968) constructive proof of Sperner's lemma via path-following
    and τ is FPF, ≥1 element reaches FC. The Lean gap is defining kuhnWalkWithExit properly.
 2. Alternative strategy: instead of involution on B_nfc, directly apply sperner_ndim's
    parity result to deduce FC existence, bypassing the walk argument. This may be simpler.
+
+---
+
+## Session 2026-04-26 (Session 12) — Case A of kuhn_path_existential Proved
+
+**Mode**: REVISIT
+**Outcome**: progress — Case A proved; sorry reduced to Case B only
+
+### What I Did
+
+1. Applied the "alternative strategy" from Session 11: use `sperner_ndim` directly to obtain
+   an FC simplex `t`, then case-split on whether `t`'s unique door is boundary or interior.
+2. Proved Case A (FC simplex has boundary door):
+   - Obtain FC simplex `t` from `sperner_ndim c K hc hbdry_odd`
+   - Extract unique door `k_t` via `fc_door_count_eq_one` + `Finset.card_eq_one`
+   - Case split: `K.adj t k_t = none` (boundary) vs interior
+   - When boundary: `kuhnPathStart_is_fc_of_fc_start` immediately gives the witness
+3. Case B (FC simplex has interior door) remains as sorry:
+   - When `K.adj t k_t = some(s', k')`, the walk-reversal involution argument is needed
+   - The walk from the boundary must reach `t` via some boundary door; formalizing this
+     requires `kuhnWalkWithExit` + `walkTrace_reversal` (~150 lines)
+4. Updated file header comment: `kuhn_path_existential` now documented as "partial sorry"
+
+### Key Findings
+
+- **Direct parity approach works for Case A**: Instead of the complex involution on boundary
+  doors, simply obtain an FC simplex from `sperner_ndim` and check if its door is on the
+  boundary. This completely avoids the bdry_nfc_even question for this case.
+- **Case B is the genuine hard case**: When the FC simplex's unique door is interior, we
+  cannot directly construct the boundary-door witness. Need to show that some boundary door's
+  walk reaches this FC simplex, which requires walk-reversal (tracing the path backwards
+  from the FC simplex to a boundary door).
+- **Lean file grew from 734 to 776 lines**: +21 lines net for the Case A proof body
+
+### Files Modified
+
+- `proofs/Proofs/SpernerNDimOQ04.lean` (+21 lines net: Case A proof in kuhn_path_existential)
+- `research/problems/sperner-ndim-oq-04/knowledge.md` (this session)
+- `src/data/research/problems/sperner-ndim-oq-04.json` (progressSummary, insights, nextSteps)
+
+### Proved This Session
+
+10. Case A of `kuhn_path_existential` — When FC simplex's unique door is on the boundary,
+    directly construct witness using `kuhnPathStart_is_fc_of_fc_start`
+
+### Remaining Sorries (1)
+
+1. Case B of `kuhn_path_existential` — FC simplex's unique door is interior; requires
+   walk-reversal involution to find a boundary door whose walk reaches the FC simplex
+
+### Next Steps
+
+1. Define `kuhnWalkWithExit` and prove `walkTrace_reversal` to fill Case B sorry (~150 lines)
+2. Then proof is complete (0 axioms, 0 sorries)

--- a/src/data/research/problems/sperner-ndim-oq-04.json
+++ b/src/data/research/problems/sperner-ndim-oq-04.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: bdry_nfc_even falsity discovered and removed; kuhn_path_existential restructured with correct proof strategy (sorry). 0 axioms, 1 sorry.",
+    "progressSummary": "PROGRESS: Case A of kuhn_path_existential proved (FC simplex with boundary door). Case B (interior door, walk-reversal involution) remains as sorry. 0 axioms, 1 sorry.",
     "builtItems": [
       "doorDegree def: SpernerNDimOQ04.lean:60",
       "IsKuhnCompatible def: SpernerNDimOQ04.lean:65",
@@ -56,7 +56,9 @@
       "kuhn_path_existential_ax (AXIOM, Session 5): Kuhn walk finds FC from some boundary door — SpernerNDimOQ04.lean:708",
       "kuhnPathStart_finds_fc_existential (PROVED from axiom, Session 5): eliminates sorry, uses kuhn_path_existential_ax — SpernerNDimOQ04.lean:724",
       "REMOVED kuhn_walk_reaches_fc (Session 5): theorem was FALSE — universal walk correctness is false for some paths",
-      "REMOVED kuhnPathStart_is_fc (Session 5): theorem was FALSE — not all boundary doors reach FC"
+      "REMOVED kuhnPathStart_is_fc (Session 5): theorem was FALSE — not all boundary doors reach FC",
+      "kuhn_path_existential Case A (PROVED, Session 12): FC simplex with boundary door — direct witness via kuhnPathStart_is_fc_of_fc_start",
+      "kuhn_path_existential Case B (sorry, Session 12): FC simplex with interior door — walk-reversal involution pending"
     ],
     "insights": [
       "IsKuhnCompatible (door degree ≤ 2) combined with abstract_door_parity gives exact door counts: 1 for FC, 0 or 2 for non-FC",
@@ -82,7 +84,9 @@
       "Proof sketch for τ∘τ=id: reversed walk retraces forward walk via IsKuhnCompatible unique-exit + adj_unique_facet symmetry",
       "FPF (no fixed points) part of involution is FULLY PROVED via kuhn_step_nonrevisit + WalkValid",
       "bdry_nfc_even (|B_nfc| even) is FALSE: counterexample d=1 N=2 gives |B_nfc|=1 (odd). The involution must apply to all of B, not just B_nfc.",
-      "Correct strategy: case split B_fc=∅ vs B_fc≠∅. When B_fc≠∅ use directly. When B_fc=∅, τ on B_nfc is FPF involution; odd |B| forces ≥1 element reaching FC."
+      "Correct strategy: case split B_fc=∅ vs B_fc≠∅. When B_fc≠∅ use directly. When B_fc=∅, τ on B_nfc is FPF involution; odd |B| forces ≥1 element reaching FC.",
+      "Direct parity approach (Session 12): obtain FC simplex from sperner_ndim, case-split on boundary vs interior door. Case A (boundary) uses kuhnPathStart_is_fc_of_fc_start directly. This avoids the bdry_nfc_even question entirely for Case A.",
+      "Case B is the genuine hard case: FC simplex with interior door requires walk-reversal to find a boundary door whose walk reaches it"
     ],
     "mathlibGaps": [
       "No Mathlib theorem for path-following algorithm termination with non-revisiting invariant",
@@ -90,8 +94,8 @@
       "SpernerTriangulation lacks an adjacent-simplices-share-unique-facet axiom needed for the non-revisiting proof"
     ],
     "nextSteps": [
-      "Implement kuhnWalkWithExit + walkTrace_reversal induction to formalize τ∘τ=id (~150 lines)",
-      "Alternative: apply sperner_ndim parity directly to bypass walk argument"
+      "Prove Case B of kuhn_path_existential: define kuhnWalkWithExit + walkTrace_reversal for FC simplex with interior door (~150 lines)",
+      "Then proof is complete (0 axioms, 0 sorries)"
     ]
   },
   "tags": [
@@ -111,18 +115,18 @@
     "mathlib": []
   },
   "started": "2026-04-22T13:03:46.382Z",
-  "lastUpdate": "2026-04-24T00:00:00.000Z",
+  "lastUpdate": "2026-04-26T00:00:00.000Z",
   "significance": 8,
   "tractability": 6,
   "leanFiles": [
     {
       "path": "Proofs/SpernerNDimOQ04.lean",
       "filename": "SpernerNDimOQ04.lean",
-      "lineCount": 734,
+      "lineCount": 776,
       "theoremCount": 13,
-      "axiomCount": 1,
+      "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 0,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SpernerNDimOQ04.lean"
     }


### PR DESCRIPTION
## Summary

- Document Session 12 findings in `knowledge.md`: Case A of `kuhn_path_existential` proved by obtaining FC simplex from `sperner_ndim` and checking if its unique door is on the boundary
- Update `sperner-ndim-oq-04.json` with new insights, corrected `leanFiles` metadata (0 axioms, 1 sorry, 776 lines), and updated `nextSteps`
- Case B (FC simplex with interior door, requiring walk-reversal involution) remains as the sole sorry

## Files changed

- `research/problems/sperner-ndim-oq-04/knowledge.md` — Session 12 notes
- `src/data/research/problems/sperner-ndim-oq-04.json` — Updated progressSummary, insights, nextSteps, leanFiles