### PR TITLE
enrichment: synthesis-curvature-ptolemy — fix lineCount, add summary section

### DIFF
--- a/src/data/proofs/synthesis-curvature-ptolemy/annotations.json
+++ b/src/data/proofs/synthesis-curvature-ptolemy/annotations.json
@@ -106,5 +106,17 @@
     "significance": "supporting",
     "prerequisites": ["Poincaré disk model", "Möbius transformations", "hyperbolic geodesic distance", "conformal factors"],
     "relatedConcepts": ["hyperbolic geometry", "Poincaré disk", "curvatureSin (-1)", "Möbius group", "conformal geometry"]
+  },
+  {
+    "id": "ann-summary",
+    "proofId": "synthesis-curvature-ptolemy",
+    "range": { "startLine": 259, "endLine": 270 },
+    "type": "context",
+    "title": "Public API: Seven Exported Names",
+    "content": "The `#check` commands at the end of the file enumerate the seven names that constitute the public API of this module:\n\n- **`curvatureSin`**: the noncomputable definition, polymorphic over ℝ\n- **`curvatureSin_zero`**: simp lemma `curvatureSin 0 t = t`\n- **`curvatureSin_one`**: rewrite lemma `curvatureSin 1 t = sin t`\n- **`curvatureSin_neg_one`**: rewrite lemma `curvatureSin (-1) t = sinh t`\n- **`curvatureSin_zero_right`**: simp lemma `curvatureSin K 0 = 0`\n- **`spherical_ptolemy_eq_curvatureSin`**: the spherical Ptolemy equality, with concyclicity hypotheses\n- **`spherical_ptolemy_ineq_curvatureSin`**: the spherical Ptolemy inequality, unconditional\n\nThis minimal API is designed for importability: future files proving K-geometry results can `import Proofs.SynthesisCurvaturePtolemy` and immediately use `simp [curvatureSin_one]` to reduce K=1 statements to standard Mathlib `Real.sin` theorems.",
+    "mathContext": "In Lean 4, `#check` at the module level is a documentation and verification device — it confirms that each name is in scope, has the expected type, and is fully proved. The implicit argument `@` (as in `@curvatureSin`) forces display of all implicit arguments, making the types fully explicit. The 7 `#check` lines serve as a module interface specification: 1 definition + 4 special-case lemmas (K=0, K=1, K=-1, t=0) + 2 Ptolemy theorems (equality, inequality).",
+    "significance": "context",
+    "prerequisites": ["Lean 4 #check command", "implicit arguments", "noncomputable definitions"],
+    "relatedConcepts": ["module interface", "simp lemmas", "rewrite lemmas", "Lean 4 documentation"]
   }
 ]

--- a/src/data/proofs/synthesis-curvature-ptolemy/meta.json
+++ b/src/data/proofs/synthesis-curvature-ptolemy/meta.json
@@ -52,7 +52,7 @@
     ],
     "dateAdded": "2026-04-26",
     "axiomCount": 0,
-    "lineCount": 210,
+    "lineCount": 270,
     "assumptions": "0 axioms. 0 sorries. All results are fully machine-verified. The hyperbolic Ptolemy theorem (K<0) is stated as a conjecture in comments only — it is NOT claimed as a theorem in this file.",
     "mathlib_version": "4.26.0",
     "parentProof": "ptolemys-theorem-oq-01-oq-02"
@@ -87,12 +87,21 @@
     },
     {
       "title": "Spherical Ptolemy Inequality (New)",
-      "startLine": 178,
-      "endLine": 240,
+      "startLine": 167,
+      "endLine": 258,
       "description": "Proves the spherical Ptolemy INEQUALITY for any four unit-circle points in ℂ. No concyclicity assumption needed. Proof: chord-arc + complex Ptolemy inequality / 4.",
       "summary": "Spherical Ptolemy ≤ for all unit-circle points — unconditional inequality",
       "id": "spherical-inequality",
       "mathContext": "For any z₁,z₂,z₃,z₄ on the unit circle in ℂ (‖z_i‖=1), not necessarily concyclic: sin(d_ac/2)·sin(d_bd/2) ≤ sin(d_ab/2)·sin(d_cd/2) + sin(d_bc/2)·sin(d_ad/2). Proof: chord-arc gives ‖z_i-z_j‖ = 2·sin(d_ij/2), so sin(d_ij/2) = ‖z_i-z_j‖/2. The inequality becomes (‖z₁-z₃‖/2)·(‖z₂-z₄‖/2) ≤ ..., which is ptolemy_inequality divided by 4."
+    },
+    {
+      "title": "Summary: All Exported Names",
+      "startLine": 259,
+      "endLine": 270,
+      "description": "Lists all definitions and theorems exported from this file via #check: curvatureSin, curvatureSin_zero, curvatureSin_one, curvatureSin_neg_one, curvatureSin_zero_right, spherical_ptolemy_eq_curvatureSin, spherical_ptolemy_ineq_curvatureSin.",
+      "summary": "Public API: 1 def + 4 lemmas + 2 theorems",
+      "id": "summary",
+      "mathContext": "The 7 exported names form the curvatureSin API: the definition itself, four special-case lemmas (K=0, K=1, K=-1, t=0), and the two Ptolemy theorems (equality with concyclicity, inequality without). This compact API makes the file importable as a reusable layer in future constant-curvature geometry formalizations."
     }
   ],
   "overview": {
@@ -193,7 +202,7 @@
       "EuclideanGeometry"
     ],
     "namespace": null,
-    "lineCount": 210,
+    "lineCount": 270,
     "axiomCount": 0,
     "theoremCount": 7,
     "sorries": 0,


### PR DESCRIPTION
Enrichment pass for synthesis-curvature-ptolemy (supersedes #12594).

Built on top of the rich content already merged in PRs #12571 (full annotations) and #12584 (index.ts). Adds improvements not yet on `main`:

## Changes

- **Fixed `lineCount` 210→270** in both `meta.json` top-level and `leanFile` sub-object. The actual Lean source file is 270 lines; the earlier stale value caused confusion in audit tooling.
- **Corrected section range** for `spherical-inequality` (167–258, was 178–240) to include the theorem's full docstring and the hyperbolic conjecture comment block.
- **Added `summary` section** (lines 259–270): the `#check` public API block enumerating all 7 exported names: 1 definition + 4 special-case lemmas + 2 Ptolemy theorems.
- **Added `ann-summary` annotation** explaining the module's API design — the 7 exported names form a minimal importable layer for future constant-curvature geometry formalizations.
- **Carries forward `index.ts`** from PR #12584 in the standard named-export format (unchanged).

## Axiom Integrity

`status: "verified"`, `axiomCount: 0`, `sorries: 0` — confirmed against the 270-line Lean source. The hyperbolic Ptolemy theorem is stated in a comment section only (not as `theorem` or `axiom`), so it does not affect the axiom count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)