### PR TITLE
feat: Aristotle companion for Erdős #1196 Markov chain normalization

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -827,6 +827,7 @@ import Proofs.Erdos1181Problem
 import Proofs.Erdos1182Problem
 import Proofs.Erdos1183Problem
 import Proofs.Erdos118Problem
+import Proofs.Erdos1196Aristotle
 import Proofs.Erdos1196Problem
 import Proofs.Erdos119Problem
 import Proofs.Erdos11Problem

--- a/proofs/Proofs/Erdos1196Aristotle.lean
+++ b/proofs/Proofs/Erdos1196Aristotle.lean
@@ -1,0 +1,43 @@
+/-
+  Aristotle targets for Erdos1196Problem
+  Routine supporting lemmas for automated proof search.
+  See Erdos1196Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main open conjectures or deep analytic results (axiomatized separately)
+  - Routine algebraic/sum manipulations that follow from standard Mathlib lemmas
+  - No definition sorries
+  - No axioms
+
+  Included targets (2):
+  - vonMangoldt_sum_eq_log_comp: ∑ d in filter (· ∣ n) (range (n+1)), Λ d = log n
+    (restatement of Mathlib's vonMangoldt_sum using the filter form)
+  - transition_sum_eq_one_comp: transition probabilities sum to 1
+    (follows from vonMangoldt_sum_eq_log_comp by division by log n)
+-/
+import Mathlib
+
+open Real Nat ArithmeticFunction
+
+namespace Erdos1196Aristotle
+
+/-- The transition probability from n to n/q in the downward divisibility chain. -/
+noncomputable def transitionProb (n q : ℕ) : ℝ :=
+  if q ∣ n ∧ 2 ≤ n then (vonMangoldt q : ℝ) / log (n : ℝ) else 0
+
+-- Routine: the von Mangoldt sum over divisors of n equals log n.
+-- Follows from Mathlib's vonMangoldt_sum (which uses n.divisors) by showing
+-- filter (· ∣ n) (range (n+1)) = n.divisors for n ≥ 1 (since 0 ∤ n for n ≥ 2).
+theorem vonMangoldt_sum_eq_log_comp (n : ℕ) (hn : 2 ≤ n) :
+    (Finset.filter (· ∣ n) (Finset.range (n + 1))).sum
+      (fun d => (vonMangoldt d : ℝ)) = log (n : ℝ) := by
+  sorry
+
+-- Routine: the transition probabilities from state n sum to 1.
+-- The sum ∑_{q | n} (Λ(q) / log n) = (∑_{q | n} Λ(q)) / log n = log n / log n = 1.
+theorem transition_sum_eq_one_comp (n : ℕ) (hn : 2 ≤ n) :
+    (Finset.filter (· ∣ n) (Finset.range (n + 1))).sum
+      (fun q => transitionProb n q) = 1 := by
+  sorry
+
+end Erdos1196Aristotle


### PR DESCRIPTION
## Fix

Adds an Aristotle companion file (`Erdos1196Aristotle.lean`) for the Erdős #1196 (Primitive Sets / Erdős-Sarkozy-Szemeredi Conjecture) formalization.

## Evidence

**Before**: `Erdos1196Problem.lean` has 1 sorry in `transition_sum_eq_one` (the Markov chain normalization theorem). No Aristotle companion existed.

**After**: `Erdos1196Aristotle.lean` exposes 2 Aristotle targets:
- `vonMangoldt_sum_eq_log_comp`: the von Mangoldt divisor sum equals log n — provable via Mathlib's `ArithmeticFunction.vonMangoldt_sum` (same identity, different `Finset` representation)
- `transition_sum_eq_one_comp`: transition probabilities sum to 1 — follows by factoring out `1/log n` from the sum and applying the von Mangoldt identity

The `vonMangoldt_sum` in Mathlib uses `n.divisors` while the main file uses `filter (· ∣ n) (range (n+1))`; these are equal for n ≥ 1 since 0 ∤ n.

**Pre-submission checklist**:
- [x] No `def ... := sorry`
- [x] No `axiom` declarations
- [x] No `theorem ... : True` placeholders
- [x] No `/-!` docstring sections
- [x] No open conjectures (main theorem and axioms are in the parent file)
- [x] `pnpm build` passes

---
Automated fix by lean-mechanic agent.