### PR TITLE
docs(sperner-ndim-oq-05): document SpernerGrid mathematical error + Mathlib PR readiness

### DIFF
--- a/proofs/Proofs/DissectionOfCubesOQ02OQ02.lean
+++ b/proofs/Proofs/DissectionOfCubesOQ02OQ02.lean
@@ -203,14 +203,50 @@ theorem tetAngle_infinite_order :
   have hn_ne : (n : ℝ) ≠ 0 := Int.cast_ne_zero.mpr hn
   exact ⟨(m : ℚ) / (n : ℚ), by push_cast; field_simp; linarith⟩
 
-/-- **Flatness axiom**: In ℝ ⊗_ℤ (ℝ/πℤ), if [θ] has infinite order
+/-- **Flatness theorem**: In ℝ ⊗_ℤ (ℝ/πℤ), if [θ] has infinite order
 then r ⊗ [θ] ≠ 0 for r ≠ 0.
 
-Justified by: ℝ is flat over ℤ (torsion-free over PID).
-The injection ℤ ↪ ℝ/πℤ via n ↦ n·[θ] tensors to ℝ ≅ ℝ⊗ℤ ↪ ℝ⊗(ℝ/πℤ). -/
-axiom tmul_infinite_order_ne_zero (r : ℝ) (x : AngleQuot) (hr : r ≠ 0)
+Proof: ℝ is flat over ℤ (torsion-free over a Bezout domain). The map
+n ↦ n·[θ] is an injective ℤ-linear map ℤ ↪ ℝ/πℤ (from infinite order).
+Flatness of ℝ over ℤ implies id ⊗ f : ℝ ⊗ ℤ ↪ ℝ ⊗ (ℝ/πℤ) is injective.
+Under the isomorphism ℝ ⊗ ℤ ≅ ℝ, the element r ⊗ 1 maps to r ≠ 0,
+hence r ⊗ x = (id ⊗ f)(r ⊗ 1) ≠ 0.
+
+Module.Flat ℤ ℝ: ℤ is a Bezout domain (EuclideanDomain → PID → IsBezout) and
+ℝ is torsion-free over ℤ (CharZero ℝ → IsAddTorsionFree ℝ → NoZeroSMulDivisors ℤ ℝ),
+so by flat_iff_torsion_eq_bot_of_isBezout, ℝ is flat over ℤ. -/
+theorem tmul_infinite_order_ne_zero (r : ℝ) (x : AngleQuot) (hr : r ≠ 0)
     (hx : ∀ n : ℤ, n ≠ 0 → n • x ≠ 0) :
-    TensorProduct.tmul ℤ r x ≠ (0 : DehnGroup)
+    TensorProduct.tmul ℤ r x ≠ (0 : DehnGroup) := by
+  -- Module.Flat ℤ ℝ: ℤ is Bezout (PID) and ℝ is torsion-free (CharZero)
+  haveI hflat : Module.Flat ℤ ℝ :=
+    Module.Flat.flat_iff_torsion_eq_bot_of_isBezout.mpr
+      (Submodule.noZeroSMulDivisors_iff_torsion_eq_bot.mp inferInstance)
+  -- Injective ℤ-linear map f : ℤ →ₗ[ℤ] AngleQuot, n ↦ n • x
+  let f : ℤ →ₗ[ℤ] AngleQuot :=
+    { toFun := fun n => n • x
+      map_add' := fun m n => by rw [add_smul]
+      map_smul' := fun c n => by rw [mul_smul] }
+  have hf_inj : Function.Injective f := by
+    intro m n hmn
+    simp only [f, LinearMap.coe_mk, AddHom.coe_mk] at hmn
+    by_contra hne
+    exact hx (m - n) (sub_ne_zero.mpr hne) (by rw [sub_smul, hmn, sub_self])
+  -- By flatness, id ⊗ f : ℝ ⊗[ℤ] ℤ → ℝ ⊗[ℤ] AngleQuot is injective
+  have hlTensor : Function.Injective (f.lTensor ℝ) :=
+    Module.Flat.lTensor_preserves_injective_linearMap f hf_inj
+  -- (f.lTensor ℝ)(r ⊗ₜ 1) = r ⊗ₜ f(1) = r ⊗ₜ (1 • x) = r ⊗ₜ x
+  have hkey : (f.lTensor ℝ) (r ⊗ₜ[ℤ] (1 : ℤ)) = TensorProduct.tmul ℤ r x := by
+    simp [LinearMap.lTensor_tmul, f, one_smul]
+  -- If r ⊗ₜ x = 0, then r ⊗ₜ 1 = 0 by injectivity
+  intro heq
+  have h1 : r ⊗ₜ[ℤ] (1 : ℤ) = (0 : ℝ ⊗[ℤ] ℤ) :=
+    hlTensor (by rw [hkey, heq, map_zero])
+  -- But (TensorProduct.rid ℤ ℝ)(r ⊗ₜ 1) = (1 : ℤ) • r = r ≠ 0
+  have h2 : (TensorProduct.rid ℤ ℝ) (r ⊗ₜ[ℤ] (1 : ℤ)) = r := by
+    rw [TensorProduct.rid_tmul]; exact one_smul ℤ r
+  rw [h1, map_zero] at h2
+  exact hr h2.symm
 
 -- ========================================================================
 -- Part VII: Tetrahedron Dehn Invariant is Nonzero (PROVED)
@@ -379,13 +415,14 @@ theorem dehn_zero_of_rational_angles (angles : List (ℝ × ℝ))
 /-
 ## Axiom Budget
 
-This formalization uses 1 axiom (reduced from 6):
-
-1. `tmul_infinite_order_ne_zero` — ℝ is flat over ℤ
-   Status: Standard algebra (torsion-free over PID ⟹ flat)
+This formalization uses 0 axioms (reduced from 6, then from 1):
 
 ### Previously Axiomatized, Now Proved
 
+- `tmul_infinite_order_ne_zero` — proved via Module.Flat ℤ ℝ
+  (EuclideanDomain ℤ → IsBezout ℤ; CharZero ℝ → NoZeroSMulDivisors ℤ ℝ;
+   flat_iff_torsion_eq_bot_of_isBezout gives Module.Flat ℤ ℝ;
+   then lTensor_preserves_injective_linearMap + TensorProduct.rid argument)
 - `niven_arccos_third` — Cross-referenced from DissectionOfCubesOQ02.lean
 - `arccos_neg_third` — Proved via Mathlib's `Real.arccos_neg`
 - `dehn_preserved_by_scissors` — Proved (placeholder: `True → d₁ = d₁`)

--- a/proofs/Proofs/DissectionOfCubesOQ04.lean
+++ b/proofs/Proofs/DissectionOfCubesOQ04.lean
@@ -520,10 +520,11 @@ theorem cube_unique_zero_dehn (a : ℝ) (ha : a > 0) :
 ### New axioms introduced in this file: 0
 (icoAngle_irrational is now PROVED via Chebyshev sequence for arccos(1/9))
 
-### Inherited axioms (from OQ02OQ02): 1
-1. `tmul_infinite_order_ne_zero` — ℝ flat over ℤ
+### Inherited axioms (from OQ02OQ02): 0
+- `tmul_infinite_order_ne_zero` is now a proved theorem in OQ02OQ02
+  (Module.Flat ℤ ℝ via Bezout + torsion-free, then lTensor injectivity)
 
-### Total axiom count: 1 (reduced from 2)
+### Total axiom count: 0
 
 ### New theorems proved (0 sorries):
 - `icoSeq` + `three_ndvd_icoSeq` + `icoSeq_eq_cos` — Chebyshev for arccos(1/9)

--- a/proofs/Proofs/SpernerNDimOQ04.lean
+++ b/proofs/Proofs/SpernerNDimOQ04.lean
@@ -52,6 +52,10 @@ the unique other door (if any), repeating until reaching an FC simplex.
 12. `kuhnPathStart_is_fc_of_fc_start` — Walk finds FC immediately if starting simplex is FC
 13. `kuhnPathStart_finds_fc_existential` — ∃ boundary door whose walk finds FC (axiomatized)
 
+### Proved (Section XI — Termination Dichotomy)
+13. `all_visited_forces_bdry` — When all simplices visited, non-FC exit must be boundary
+14. `kuhnWalk_fc_or_bdry` — With |K.Simplex| fuel, walk terminates at FC or boundary door
+
 ### Axiomatized
 - `bdry_nfc_even` (sorry) — Walk-reversal involution τ∘τ=id pending; non-revisiting proved
 - `kuhn_path_existential` — Proved from bdry_nfc_even; replaces the former axiom
@@ -690,7 +694,126 @@ theorem kuhnPathStart_is_fc_of_fc_start {c : Coloring d N} {K : SpernerTriangula
   kuhnWalk_fc_if_started_fc hKuhn _ _ hfc₀
 
 -- ============================================================
--- SECTION XI: Walk Pairing Parity and Main Existential
+-- SECTION XI: Termination Dichotomy
+-- ============================================================
+
+/-- When all simplices except current are visited, any non-FC exit must be a boundary door.
+    The exit door can't lead to a new simplex (none left), so K.adj = none. -/
+private lemma all_visited_forces_bdry {c : Coloring d N} {K : SpernerTriangulation d N}
+    {hKuhn : IsKuhnCompatible c K} {state : KuhnState d N c K}
+    {rec : DoorRecord d N K} {pred : Option K.Simplex}
+    (hvalid : WalkValid hKuhn state rec pred)
+    (hfull : state.visited.card + 1 = Fintype.card K.Simplex)
+    (hnonfc : ¬IsFC c K state.current) :
+    ∃ k_out, isDoorAt c K state.current k_out ∧ K.adj state.current k_out = none := by
+  -- Get the unique exit door k_out ≠ state.entry
+  obtain ⟨k_out, ⟨hne, hdoor_out⟩, _⟩ :=
+    nonfc_with_door_has_unique_exit hKuhn state.current hnonfc state.entry state.entry_is_door
+  refine ⟨k_out, hdoor_out, ?_⟩
+  -- If K.adj = some (s', k'), then s' must be new, but all simplices are visited ∪ {current}
+  cases hadj : K.adj state.current k_out with
+  | none => rfl
+  | some sk =>
+    obtain ⟨s', k'⟩ := sk
+    exfalso
+    -- s' ∉ visited ∪ {current} by non-revisiting
+    have hs'_not := kuhn_step_nonrevisit hvalid hne hdoor_out hadj
+    -- but visited ∪ {current} covers all simplices
+    have huniv : state.visited ∪ {state.current} = Finset.univ := by
+      apply Finset.eq_univ_of_card
+      have hdisj : Disjoint state.visited {state.current} := by
+        simp [Finset.disjoint_left, state.current_not_visited]
+      rw [Finset.card_union_of_disjoint hdisj, Finset.card_singleton]
+      exact hfull
+    exact hs'_not (huniv ▸ Finset.mem_univ s')
+
+/-- kuhnWalk is proof-irrelevant in the KuhnState Prop fields: only current, entry, visited matter.
+    Proof: reduce to KuhnState equality, then use proof_irrel for the two Prop fields. -/
+private lemma kuhnWalk_congr {c : Coloring d N} {K : SpernerTriangulation d N}
+    (hKuhn : IsKuhnCompatible c K) (fuel : ℕ) (s₁ s₂ : KuhnState d N c K)
+    (hcur : s₁.current = s₂.current) (hent : s₁.entry = s₂.entry) (hvis : s₁.visited = s₂.visited) :
+    kuhnWalk c K hKuhn fuel s₁ = kuhnWalk c K hKuhn fuel s₂ := by
+  suffices h : s₁ = s₂ from congrArg (kuhnWalk c K hKuhn fuel) h
+  obtain ⟨cur₁, ent₁, ed₁, vis₁, cnv₁⟩ := s₁
+  obtain ⟨cur₂, ent₂, ed₂, vis₂, cnv₂⟩ := s₂
+  -- hcur, hent, hvis are now field equalities after obtain
+  simp only at hcur hent hvis
+  subst hcur; subst hent; subst hvis
+  -- ed₁ ed₂ : isDoorAt c K cur₁ ent₁ (same type); cnv₁ cnv₂ : cur₁ ∉ vis₁ (same type)
+  have h1 : ed₁ = ed₂ := proof_irrel _ _
+  have h2 : cnv₁ = cnv₂ := proof_irrel _ _
+  rw [h1, h2]
+
+/-- With fuel = (Fintype.card K.Simplex - visited.card), kuhnWalk terminates at FC or boundary.
+    Proof: by induction on fuel. Non-revisiting ensures each step visits a fresh simplex;
+    when all simplices are claimed, the exit must be a boundary door. -/
+theorem kuhnWalk_fc_or_bdry {c : Coloring d N} {K : SpernerTriangulation d N}
+    {hKuhn : IsKuhnCompatible c K} (fuel : ℕ) :
+    ∀ (state : KuhnState d N c K) (rec : DoorRecord d N K) (pred : Option K.Simplex),
+      WalkValid hKuhn state rec pred →
+      fuel + state.visited.card = Fintype.card K.Simplex →
+      IsFC c K (kuhnWalk c K hKuhn fuel state) ∨
+      ∃ k, isDoorAt c K (kuhnWalk c K hKuhn fuel state) k ∧
+           K.adj (kuhnWalk c K hKuhn fuel state) k = none := by
+  induction fuel with
+  | zero =>
+    intro state rec pred hvalid hn
+    -- fuel = 0 ⟹ visited.card = |K.Simplex|, but current ∉ visited — impossible
+    exfalso
+    simp only [Nat.zero_add] at hn
+    have hdisj : Disjoint state.visited {state.current} := by
+      rw [Finset.disjoint_left]; intro x hx hmem
+      exact state.current_not_visited (Finset.mem_singleton.mp hmem ▸ hx)
+    have hcard : (state.visited ∪ {state.current}).card = state.visited.card + 1 := by
+      rw [Finset.card_union_of_disjoint hdisj, Finset.card_singleton]
+    linarith [Finset.card_le_univ (state.visited ∪ {state.current})]
+  | succ n ih =>
+    intro state rec pred hvalid hn
+    by_cases hfc : IsFC c K state.current
+    · -- FC: walk returns current immediately
+      left; rw [kuhnWalk_succ_eq_current_of_fc hKuhn n state hfc]; exact hfc
+    · -- Non-FC: take one step
+      -- Use kuhnStep to identify the exit door and next simplex
+      set exit_doors := Finset.univ.filter (fun k => isDoorAt c K state.current k ∧ k ≠ state.entry)
+      -- Exit doors are nonempty (non-FC with entry door has a unique other door)
+      have hnonempty : exit_doors.Nonempty := by
+        obtain ⟨k_u, ⟨hne_u, hdoor_u⟩, _⟩ :=
+          nonfc_with_door_has_unique_exit hKuhn state.current hfc state.entry state.entry_is_door
+        exact ⟨k_u, Finset.mem_filter.mpr ⟨Finset.mem_univ _, hdoor_u, hne_u⟩⟩
+      set k_out := exit_doors.min' hnonempty
+      have hk_prop := (Finset.mem_filter.mp (Finset.min'_mem exit_doors hnonempty)).2
+      -- Non-revisiting: the next simplex (if any) is fresh
+      cases hadj : K.adj state.current k_out with
+      | none =>
+        -- Boundary exit
+        have heq : kuhnWalk c K hKuhn (n + 1) state = state.current := by
+          simp only [kuhnWalk, if_neg hfc, dif_pos hnonempty, hadj]
+        rw [heq]; right; exact ⟨k_out, hk_prop.1, hadj⟩
+      | some sk =>
+        obtain ⟨s', k'⟩ := sk
+        have hs'_fresh := kuhn_step_nonrevisit hvalid hk_prop.2 hk_prop.1 hadj
+        -- Walk steps to s' (the hs' guard never triggers)
+        -- LHS: unfold kuhnWalk (n+1) with all guards discharged
+        -- RHS: kuhnWalk n with explicitly-named proof terms
+        -- After unfolding, both states have same data fields; kuhnWalk_congr handles Prop fields.
+        have heq : kuhnWalk c K hKuhn (n + 1) state =
+            kuhnWalk c K hKuhn n
+              { current := s', entry := k', entry_is_door := (door_transfer hadj).mp hk_prop.1,
+                visited := state.visited ∪ {state.current},
+                current_not_visited := hs'_fresh } := by
+          conv_lhs => simp only [kuhnWalk, if_neg hfc, dif_pos hnonempty, hadj, dif_neg hs'_fresh]
+          apply kuhnWalk_congr <;> rfl
+        rw [heq]
+        have hvalid_new := walkValid_step hvalid hk_prop.2 hk_prop.1 hadj hs'_fresh
+        have hn_new : n + (state.visited ∪ {state.current}).card = Fintype.card K.Simplex := by
+          have hdisj : Disjoint state.visited {state.current} := by
+            rw [Finset.disjoint_left]; intro x hx hmem
+            exact state.current_not_visited (Finset.mem_singleton.mp hmem ▸ hx)
+          rw [Finset.card_union_of_disjoint hdisj, Finset.card_singleton]; omega
+        exact ih _ _ _ hvalid_new hn_new
+
+-- ============================================================
+-- SECTION XII: Walk Pairing Parity and Main Existential
 -- ============================================================
 
 /-- The non-FC boundary doors have even cardinality.
@@ -711,7 +834,8 @@ theorem kuhnPathStart_is_fc_of_fc_start {c : Coloring d N} {K : SpernerTriangula
         contradicting kuhn_step_nonrevisit + WalkValid (non-revisiting is FULLY PROVED)
 
     **Proved ingredients**: nonfc_with_door_has_unique_exit ✓, WalkValid ✓,
-    kuhn_step_nonrevisit ✓, adj_symm ✓, even_card_fpf_invol ✓.
+    kuhn_step_nonrevisit ✓, adj_symm ✓, even_card_fpf_invol ✓,
+    kuhnWalk_fc_or_bdry ✓ (termination dichotomy).
     **Pending (this sorry)**: kuhnWalkWithExit definition + walkTrace_reversal induction. -/
 private lemma bdry_nfc_even {c : Coloring d N} {K : SpernerTriangulation d N}
     (hKuhn : IsKuhnCompatible c K) (hc : IsSperner c) :
@@ -801,7 +925,8 @@ theorem kuhn_path_existential {c : Coloring d N} {K : SpernerTriangulation d N}
     boundary door set B_fc has odd cardinality ≥ 1.
 
     Proved: non-revisiting (kuhn_step_nonrevisit + WalkValid), unique exit
-    (nonfc_with_door_has_unique_exit), parity structure, main theorem body.
+    (nonfc_with_door_has_unique_exit), parity structure, main theorem body,
+    termination dichotomy (kuhnWalk_fc_or_bdry).
     Pending (bdry_nfc_even sorry): walk reversal τ∘τ=id via walkTrace_reversal induction. -/
 theorem kuhnPathStart_finds_fc_existential {c : Coloring d N} {K : SpernerTriangulation d N}
     (hKuhn : IsKuhnCompatible c K)

--- a/research/problems/sperner-ndim-oq-05/knowledge.md
+++ b/research/problems/sperner-ndim-oq-05/knowledge.md
@@ -310,8 +310,56 @@ so avoids elaboration overhead.
 
 ---
 
+## Session 2026-04-26 (Session 11) - Mathlib Files Audit + SpernerGrid Mathematical Error
+
+**Mode**: REVISIT
+**Outcome**: Critical finding — SpernerGrid.lean sorries are unprovable; Mathlib PR files are fully ready
+
+### Key Finding: Actual File State (far ahead of session 5 records)
+
+- `SpernerMathlib4.lean` (732 lines): 0 sorries, `maxHeartbeats 200000` ✅ (Mathlib default)
+- `SpernerSimplicialInstance.lean` (1003 lines): 0 sorries, `maxHeartbeats 200000` ✅
+- Both files have granular imports (no `import Mathlib`)
+- Recent PRs: #11316, #11470 (heartbeat reduction), #11521 (adjFn optimization), #11625 (granular imports)
+
+### Key Finding: boundary_verts_on_face is MATHEMATICALLY WRONG
+
+The theorem claims: when `gridAdj d N s k = none` (k.val < d), then `(s.verts j).coords k = 0` for all j ≠ k.
+
+**Counterexample**: d=1, N=2, S1 = {verts(0)=(1,1), verts(1)=(2,0)}, miss=1, incDir(0)=0:
+- `gridAdj(S1, 0) = none` (boundary, last_v.coords(miss=1) = 0 ✓)
+- k=0, j=1: claim `(2,0).coords(0) = 0` but it equals 2. FALSE.
+
+**Root cause**: GridSimplex includes BOTH orientations of each geometric simplex.
+For d=1 N=2, gridComplex has 4 cells; each geometric edge appears twice.
+Boundary door count = 2 (EVEN), so `boundary_doors_odd` is also FALSE as stated.
+
+**What IS true**: With canonical-only simplices (miss = ⟨d, _⟩, last coordinate):
+- Each geometric simplex appears exactly once
+- Boundary door count = 1 for d=1 N=2 (ODD ✓)
+- `boundary_doors_odd` would be true with this restriction
+- Correct proof requires induction on d, not the current shortcut
+
+### Mathlib PR Status (2026-04-26): FULLY READY
+
+Both Part 1 and Part 2 are Mathlib-ready. All remaining work is USER ACTION:
+1. Refresh `rjwalters/mathlib4:sperner-abstract-parity` with current files
+2. Submit PR to mathlib4 with `SpernerMathlib4.lean` (Part 1)
+3. Comment on mathlib4#25231 pointing to `SpernerSimplicialInstance.lean` (Part 2)
+
+### Next Steps
+
+1. **[USER ACTION]** Refresh Mathlib fork + submit Part 1 PR to mathlib4
+2. **[USER ACTION]** Comment on mathlib4#25231 pointing to Part 2
+3. **[NEW RESEARCH PROBLEM]** Fix SpernerGrid.lean: restrict to canonical orientations
+   (miss = ⟨d, _⟩) and redesign boundary_doors_odd proof via induction on d (~300-500L)
+
+---
+
 ## Dead Ends
 
 - `FixedPointFree.lean` (GroupTheory) — about group automorphisms, not Finsets
 - `SimpleGraph.IsMatching.even_card` — about graph matching, too much overhead
 - No direct `Finset.even_card_of_involutive` exists in Mathlib
+- `boundary_verts_on_face` proof attempt: theorem is FALSE (counterexample: d=1 N=2, S1)
+- `no_boundary_doors_face_lt` (proved): also mathematically wrong, uses unprovable sorry

--- a/src/data/proofs/dissection-of-cubes-oq-02-oq-02/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-02-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Dehn (1900), Sydler (1965), Jessen (1968)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Dehn%E2%80%93Sydler_theorem",
     "date": "1965",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/DissectionOfCubesOQ02OQ02.lean",
     "tags": [
       "geometry",
@@ -18,9 +18,9 @@
       "wiedijk-100",
       "research"
     ],
-    "badge": "axiom",
+    "badge": "original",
     "sorries": 0,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "dateAdded": "2026-03-25",
     "mathlibDependencies": [
       {
@@ -55,7 +55,7 @@
       "Dehn-Sydler completeness theorem statement"
     ],
     "lineCount": 413,
-    "assumptions": "1 axiom: tmul_infinite_order_ne_zero (flatness of ℝ over ℤ — torsion-free over PID implies flat). Previously 6 axioms; 5 eliminated: niven_arccos_third (cross-referenced from parent file), arccos_neg_third (proved via Real.arccos_neg), and 3 placeholder axioms (dehn_preserved_by_scissors, volume_preserved_by_scissors, dehn_sydler_theorem).",
+    "assumptions": "0 axioms. tmul_infinite_order_ne_zero is now a proved theorem using Module.Flat ℤ ℝ (flatness from IsBezout ℤ via EuclideanDomain and NoZeroSMulDivisors ℤ ℝ via CharZero). Previously reduced from 6 axioms to 1 (5 eliminated); final axiom now proved via lTensor injectivity under flatness.",
     "mathlib_version": "4.26.0",
     "wiedijkNumber": 37,
     "relatedProblems": [

--- a/src/data/proofs/dissection-of-cubes-oq-04/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-04/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius",
     "sourceUrl": "https://en.wikipedia.org/wiki/Dehn_invariant",
     "date": "1900",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/DissectionOfCubesOQ04.lean",
     "tags": [
       "geometry",
@@ -18,14 +18,14 @@
       "scissors-congruence",
       "irrational-angles"
     ],
-    "badge": "axiom",
+    "badge": "original",
     "sorries": 0,
     "dateAdded": "2026-04-22",
-    "axiomCount": 1,
-    "assumptions": "1 axiom: tmul_infinite_order_ne_zero (from OQ02OQ02): \u211d is flat over \u2124 \u2014 needed to show nonzero tensor products. Previously axiomatized icoAngle_irrational (arccos(-\u221a5/3)/\u03c0 irrational) is now PROVED via Chebyshev integer sequence for arccos(1/9).",
-    "lineCount": 557,
-    "theoremCount": 15,
-    "definitionCount": 4,
+    "axiomCount": 0,
+    "assumptions": "0 axioms. All previously axiomatized results are now proved: icoAngle_irrational via coupled Chebyshev sequences over ℤ[√5], tmul_infinite_order_ne_zero via Module.Flat ℤ ℝ (proved in OQ02OQ02).",
+    "lineCount": 581,
+    "theoremCount": 22,
+    "definitionCount": 5,
     "mathlibDependencies": [
       {
         "theorem": "Real.arccos_le_pi_div_two",

--- a/src/data/research/problems/sperner-ndim-oq-04.json
+++ b/src/data/research/problems/sperner-ndim-oq-04.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "AXIOMATIZED: 0 sorries, 1 axiom (kuhn_path_existential_ax). Session 5: removed 2 false theorems (kuhn_walk_reaches_fc, kuhnPathStart_is_fc); axiomatized kuhnPathStart_finds_fc_existential (true but requires walk reversibility τ∘τ=id). Non-revisiting FULLY PROVED (Session 4, kuhn_step_nonrevisit + WalkValid). Walk reversibility remains as mathematical gap in axiom.",
+    "progressSummary": "AXIOMATIZED: 1 sorry (bdry_nfc_even), 0 axioms. Session 10: proved termination dichotomy (kuhnWalk_fc_or_bdry, all_visited_forces_bdry, kuhnWalk_congr). Session 5: proved parity structure (kuhn_path_existential from bdry_nfc_even). Non-revisiting FULLY PROVED. Remaining: walk reversal τ∘τ=id in bdry_nfc_even.",
     "builtItems": [
       "doorDegree def: SpernerNDimOQ04.lean:60",
       "IsKuhnCompatible def: SpernerNDimOQ04.lean:65",
@@ -53,8 +53,12 @@
       "walkValid_init (PROVED): initial boundary-door state satisfies WalkValid — SpernerNDimOQ04.lean:420",
       "kuhn_step_nonrevisit (PROVED): KEY non-revisiting theorem — under WalkValid, walk never revisits any simplex — SpernerNDimOQ04.lean:447",
       "walkValid_step (PROVED): WalkValid preserved by one Kuhn step — SpernerNDimOQ04.lean:529",
-      "kuhn_path_existential_ax (AXIOM, Session 5): Kuhn walk finds FC from some boundary door — SpernerNDimOQ04.lean:708",
-      "kuhnPathStart_finds_fc_existential (PROVED from axiom, Session 5): eliminates sorry, uses kuhn_path_existential_ax — SpernerNDimOQ04.lean:724",
+      "all_visited_forces_bdry (PROVED, Session 10): when all simplices visited, non-FC exit must be boundary door",
+      "kuhnWalk_congr (PROVED, Session 10): kuhnWalk proof-irrelevant in KuhnState Prop fields via proof_irrel",
+      "kuhnWalk_fc_or_bdry (PROVED, Session 10): with fuel=|K.Simplex|, walk terminates at FC or boundary door",
+      "bdry_nfc_even (SORRY): non-FC boundary doors have even cardinality via walk-pairing involution",
+      "kuhn_path_existential (PROVED from bdry_nfc_even, Session 5): parity argument gives ∃ FC boundary door",
+      "kuhnPathStart_finds_fc_existential (PROVED = kuhn_path_existential): eliminates former axiom",
       "REMOVED kuhn_walk_reaches_fc (Session 5): theorem was FALSE — universal walk correctness is false for some paths",
       "REMOVED kuhnPathStart_is_fc (Session 5): theorem was FALSE — not all boundary doors reach FC"
     ],
@@ -77,7 +81,10 @@
       "Non-revisiting proof structure: for visited s, use (1) kuhnWalk_no_immediate_back for predecessor case; (2) 3-door contradiction (kuhn_three_doors_contradiction) for non-predecessor case; distinctness from adj_unique_facet + current ∉ visited",
       "WalkValid invariant: tracks (k_in, k_out) per visited simplex + predecessor identification. exit_to_chain splits into predecessor-case and non-predecessor-case. This enables adj_unique_facet to fire correctly for both k_back ≠ k_out_s and k_back ≠ k_in_s",
       "walk-pairing argument for kuhnPathStart_finds_fc_existential: define τ on non-FC-terminating boundary doors. τ is fixed-point-free involution (walk reversibility). even_card_fpf_invol gives |non-FC bdry doors| even. Odd - even = odd ≥ 1 FC bdry door. Uses non-revisiting (now proved) + walk reversibility (pending)",
-      "kuhnPathStart_is_fc (universal) is FALSE: walk can terminate at non-FC boundary exit. Correct statement is existential: kuhnPathStart_finds_fc_existential"
+      "kuhnPathStart_is_fc (universal) is FALSE: walk can terminate at non-FC boundary exit. Correct statement is existential: kuhnPathStart_finds_fc_existential",
+      "kuhnWalk_congr needs proof_irrel: KuhnState Prop fields (entry_is_door, current_not_visited) are propositionally but not definitionally equal between kuhnWalk internal computation and explicit proofs",
+      "kuhnWalk_fc_or_bdry base case: fuel=0 with visited.card=|K.Simplex| is impossible because current not-in-visited contradicts full coverage",
+      "Walk reversal (τ∘τ=id): at each step of reverse walk, adj_symm forces the unique exit door to match the previous forward step, retracing the path in reverse"
     ],
     "mathlibGaps": [
       "No Mathlib theorem for path-following algorithm termination with non-revisiting invariant",
@@ -85,8 +92,7 @@
       "SpernerTriangulation lacks an adjacent-simplices-share-unique-facet axiom needed for the non-revisiting proof"
     ],
     "nextSteps": [
-      "If walk reversibility is later formalized: prove τ∘τ=id by tracking the full walk sequence (sₙ path + unique exit at each non-FC simplex) and showing reversed walk retraces forward walk",
-      "Once walk reversibility is proved, replace kuhn_path_existential_ax with a full proof using even_card_fpf_invol",
+      "Prove kuhnWalk_reversal: if walk from (s0,k0) exits at (sn,kn) boundary, then walk from (sn,kn) exits at (s0,k0); induction on path length using adj_symm — this is the ONLY remaining sorry (bdry_nfc_even)",
       "Consider contributing adj_unique_facet + Kuhn algorithm formalization to Mathlib as standalone combinatorics contribution"
     ]
   },

--- a/src/data/research/problems/sperner-ndim-oq-05.json
+++ b/src/data/research/problems/sperner-ndim-oq-05.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (session 5): Proved gridAdj_ne in SpernerGrid.lean (6 → 5 sorries). gridAdj_symm and gridAdj_vertex remain (require involutivity proofs).",
+    "progressSummary": "PROGRESS (session 11): Mathlib PR files READY (maxHeartbeats 200000, 0 sorries, granular imports). SpernerGrid.lean BLOCKED: boundary_verts_on_face and boundary_doors_odd are FALSE as stated (oriented simplices give even door count). Fix requires canonical orientation restriction.",
     "builtItems": [
       "SpernerMathlib4Opt.lean: optimized proof proposal for even_card_of_fpf_invol using sum_involution (research/problems/sperner-ndim-oq-05/lean/)",
       "even_card_of_fpf_invol: 53-line strongInduction proof replaced with 11-line sum_involution proof in SpernerMathlib4.lean",
@@ -58,15 +58,22 @@
       "SpernerGrid.lean: 11 → 6 sorries after proving all four step_same cases",
       "split_ifs auto-closes h:none=some contradictions — only 1 bullet needed per split_ifs in helper lemmas",
       "j_step.castSucc.val syntactically ≠ j_step.val even though equal — need simp [Fin.castSucc] before omega in hlv proofs",
-      "gridAdj_ne proved via 3-case split: boundary cases use verts_injective; interior case uses inc_injective + interiorFlip_incDir_kprev"
+      "gridAdj_ne proved via 3-case split: boundary cases use verts_injective; interior case uses inc_injective + interiorFlip_incDir_kprev",
+      "boundary_verts_on_face is MATHEMATICALLY WRONG: counterexample d=1 N=2, S1={verts(0)=(1,1),verts(1)=(2,0)}, gridAdj(k=0)=none but (2,0).coords(0)=2≠0",
+      "Root cause: GridSimplex includes both orientations of each geometric simplex. gridComplex d=1 N=2 has 4 cells (each edge twice). Boundary door count=2 (EVEN), not odd.",
+      "boundary_doors_odd is FALSE for oriented gridComplex — needs canonical orientations (miss=⟨d,_⟩) restriction to give odd count",
+      "no_boundary_doors_face_lt (proved) is also wrong: uses sorry-based boundary_verts_on_face. (S1,0) IS a door at k=0<d with adj=none.",
+      "Fix: restrict GridSimplex to canonical orientations (miss=⟨d,_⟩). With canonical simplices each geometric simplex appears once and boundary door count is ODD.",
+      "Mathlib PR files are FULLY READY: SpernerMathlib4.lean (0 sorries, maxHeartbeats 200000, granular imports) + SpernerSimplicialInstance.lean (0 sorries, maxHeartbeats 200000) — PRs #11316 #11470 #11521 #11625 completed this work"
     ],
-    "mathlibGaps": [],
+    "mathlibGaps": [
+      "GridSimplex structure admits both orientations of each geometric simplex — needs canonical orientation constraint (miss=⟨d,_⟩) for SpernerGrid parity argument to work"
+    ],
     "nextSteps": [
-      "[USER ACTION] Post comment on mathlib4#25231 pointing Dillies to SpernerSimplicialInstance.lean as Part 2",
-      "Test granular imports via Docker build for SpernerMathlib4.lean",
-      "Profile SpernerSimplicialInstance.lean with set_option profiler true to find expensive proofs",
-      "Reduce SpernerSimplicialInstance heartbeats to ≤ 800000 for Mathlib PR",
-      "Submit Part 1 (SpernerMathlib4) PR to mathlib4 as initial contribution, Part 2 as follow-up"
+      "[USER ACTION] Refresh rjwalters/mathlib4:sperner-abstract-parity with current SpernerMathlib4.lean (200K heartbeats, granular imports)",
+      "[USER ACTION] Submit Part 1 PR to mathlib4 (SpernerMathlib4.lean, 732 lines, 0 sorries)",
+      "[USER ACTION] Comment on mathlib4#25231 pointing Dillies to SpernerSimplicialInstance.lean as Part 2",
+      "NEW RESEARCH: Fix SpernerGrid.lean by restricting to canonical orientations (miss=⟨d,_⟩) and redesigning boundary_doors_odd proof via induction on d (~300-500 lines)"
     ],
     "markdown": "# Knowledge Base: sperner-ndim-oq-05\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Session 11 research findings for sperner-ndim-oq-05 (Sperner Mathlib contribution):

**Critical Finding**: `boundary_verts_on_face` in `SpernerGrid.lean` is mathematically wrong.

- **Counterexample**: d=1, N=2, S1={verts(0)=(1,1), verts(1)=(2,0)}, miss=1, incDir(0)=0. Then `gridAdj(S1, 0) = none` but `(S1.verts 1).coords 0 = 2 ≠ 0`. The theorem claims this should be 0.
- **Root cause**: `GridSimplex d N` includes both orientations of each geometric simplex. For d=1 N=2, `gridComplex` has 4 cells (each geometric edge twice). Boundary door count = 2 (EVEN), so `boundary_doors_odd` is also false as stated.
- **Fix**: Restrict `GridSimplex` to canonical orientations (`miss = ⟨d, _⟩`). This is a new research problem (~300-500 lines).

**Positive Finding**: Mathlib PR files are fully ready:
- `SpernerMathlib4.lean`: 0 sorries, `maxHeartbeats 200000`, granular imports ✅
- `SpernerSimplicialInstance.lean`: 0 sorries, `maxHeartbeats 200000` ✅
- All remaining work is user action (refresh fork + submit PR to mathlib4)

## Labels

`research`