### PR TITLE
enrichment: erdos-1-wip-01 — 5-section structure, quality 100/100

### DIFF
--- a/src/data/proofs/erdos-1-wip-01/annotations.json
+++ b/src/data/proofs/erdos-1-wip-01/annotations.json
@@ -38,7 +38,7 @@
   {
     "id": "ann-erdos-1-wip-01-pow2-sum-inj-both",
     "proofId": "erdos-1-wip-01",
-    "range": { "startLine": 60, "endLine": 96 },
+    "range": { "startLine": 60, "endLine": 106 },
     "type": "insight",
     "title": "Binary Uniqueness by Strong Induction: Four-Case Analysis",
     "content": "This is the mathematical heart of the proof. `pow2_sum_inj` establishes that if $S, T \\subseteq \\{0,\\ldots,n-1\\}$ satisfy $\\sum_{i \\in S} 2^i = \\sum_{i \\in T} 2^i$, then $S = T$. The proof proceeds by strong induction on $n$, splitting on whether $n-1$ belongs to $S$ and $T$ independently.\n\n**Case (both contain $n-1$)**: `Finset.add_sum_erase` separates out the $2^{n-1}$ contribution from each sum. Canceling it gives equal sums over $S \\setminus \\{n-1\\}$ and $T \\setminus \\{n-1\\}$, and the IH closes.\n\n**Case ($n-1 \\in S$, $n-1 \\notin T$)**: `Finset.single_le_sum` gives $\\sum_S 2^i \\geq 2^{n-1}$, while `sum_pow2_lt_of_subset_range` gives $\\sum_T 2^i < 2^{n-1}$ — contradiction by `omega`.\n\n**Case ($n-1 \\notin S$, $n-1 \\in T$)**: symmetric.\n\n**Case (neither contains $n-1$)**: `subset_range_pred` shrinks both to $\\{0,\\ldots,n-2\\}$ and IH closes directly.",

--- a/src/data/proofs/erdos-1-wip-01/meta.json
+++ b/src/data/proofs/erdos-1-wip-01/meta.json
@@ -40,6 +40,10 @@
       {
         "id": "erdos-1-oq-03",
         "relationship": "Fills the sorry in minDSSBound — this theorem is used as the Nat.find witness"
+      },
+      {
+        "id": "erdos-1-oq-02",
+        "relationship": "Contrasts: Dubroff–Fox–Xu achieves the near-optimal lower bound N ≥ √(2/π)·2ⁿ/√n, demonstrating how far the n·2ⁿ existence bound falls from the conjectured threshold"
       }
     ],
     "mathlibDependencies": [
@@ -132,6 +136,11 @@
       "targetId": "erdos-1-oq-03",
       "relationship": "fills-gap",
       "description": "dss_existence fills the sorry in minDSSBound (Nat.find witness), making the minimum DSS bound function well-defined"
+    },
+    {
+      "targetId": "erdos-1-oq-02",
+      "relationship": "contrasts",
+      "description": "Dubroff–Fox–Xu proves N ≥ √(2/π)·2ⁿ/√n (asymptotically tight lower bound), dwarfing the n·2ⁿ existence bound here — together they span the gap between existence and optimality"
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-1-wip-01/meta.json
+++ b/src/data/proofs/erdos-1-wip-01/meta.json
@@ -82,28 +82,44 @@
   },
   "sections": [
     {
-      "id": "auxiliary-lemmas",
-      "title": "Auxiliary Lemmas for Binary Injectivity",
+      "id": "imports-setup",
+      "title": "Part I: Imports and Module Setup",
+      "startLine": 1,
+      "endLine": 31,
+      "summary": "Imports Proofs.Erdos1Problem (hasDistinctSubsetSums definition) and Mathlib; opens Finset namespace; declares namespace Erdos1Wip01.",
+      "mathContext": "`hasDistinctSubsetSums A` defined in Erdos1Problem: $\\forall S, T \\subseteq A,\\ \\text{sum}(S) = \\text{sum}(T) \\Rightarrow S = T$"
+    },
+    {
+      "id": "quantitative-lemmas",
+      "title": "Part II: Quantitative Lemmas (Geometric Sum and Subset Bound)",
       "startLine": 33,
+      "endLine": 58,
+      "summary": "Three lemmas: geom_sum_pow2 (∑_{i<n} 2^i + 1 = 2^n), sum_pow2_lt_of_subset_range (any subset has sum < 2^n), and subset_range_pred (bookkeeping for range shrinkage).",
+      "mathContext": "$\\sum_{i<n} 2^i + 1 = 2^n$; $S \\subseteq \\{0,\\ldots,n-1\\} \\Rightarrow \\sum_{i \\in S} 2^i < 2^n$; $n \\notin S, S \\subseteq \\{0,\\ldots,n\\} \\Rightarrow S \\subseteq \\{0,\\ldots,n-1\\}$"
+    },
+    {
+      "id": "binary-uniqueness",
+      "title": "Part III: Binary Representation Uniqueness (pow2_sum_inj)",
+      "startLine": 59,
       "endLine": 106,
-      "summary": "Three supporting lemmas: geometric sum identity, subset sum bound, and binary representation uniqueness by strong induction.",
-      "mathContext": "$\\sum_{i<n} 2^i + 1 = 2^n$; any $S \\subseteq \\{0,\\ldots,n-1\\}$ has $\\sum_{i \\in S} 2^i < 2^n$; $S, T \\subseteq \\{0,\\ldots,n-1\\}$, $\\sum_S 2^i = \\sum_T 2^i \\Rightarrow S = T$"
+      "summary": "Proves pow2_sum_inj by strong induction: if S, T ⊆ {0,...,n-1} have equal power-of-2 sums, then S = T. Four-case split on membership of n-1.",
+      "mathContext": "$S, T \\subseteq \\{0,\\ldots,n-1\\},\\ \\sum_S 2^i = \\sum_T 2^i \\Rightarrow S = T$ — the Lean proof of binary numeral uniqueness"
     },
     {
       "id": "dss-powers",
-      "title": "The DSS Property of Powers of Two",
+      "title": "Part IV: DSS Property of Powers of Two",
       "startLine": 107,
       "endLine": 156,
-      "summary": "Proves that {2^i : i < n} has distinct subset sums using the preimage index trick and binary uniqueness.",
-      "mathContext": "$\\forall S, T \\subseteq \\{2^0,\\ldots,2^{n-1}\\},\\ \\sum S = \\sum T \\Rightarrow S = T$"
+      "summary": "Proves powersOfTwo_hasDistinctSubsetSums: {2^i : i < n} has distinct subset sums using the preimage index trick and binary uniqueness.",
+      "mathContext": "$\\forall S, T \\subseteq \\{2^0,\\ldots,2^{n-1}\\},\\ \\sum S = \\sum T \\Rightarrow S = T$ — bridge from index level to value level via Finset.sum_image"
     },
     {
       "id": "dss-existence",
-      "title": "Existence of n-Element DSS Sets (Main Theorem)",
-      "startLine": 158,
+      "title": "Part V: Existence of n-Element DSS Sets (Main Theorem)",
+      "startLine": 157,
       "endLine": 187,
-      "summary": "For any n, constructs an n-element set with all elements ≤ n·2^n and distinct subset sums. Used as Nat.find witness in minDSSBound.",
-      "mathContext": "$\\forall n,\\ \\exists A,\\ |A|=n \\wedge (\\forall a \\in A,\\ a \\leq n \\cdot 2^n) \\wedge \\text{DSS}(A)$"
+      "summary": "For any n, constructs an n-element set with all elements ≤ n·2^n and distinct subset sums. Used as Nat.find witness in minDSSBound (Erdos1OQ03.lean).",
+      "mathContext": "$\\forall n,\\ \\exists A : \\text{Finset}\\,\\mathbb{N},\\ |A| = n \\wedge (\\forall a \\in A,\\ a \\leq n \\cdot 2^n) \\wedge \\text{DSS}(A)$"
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
## Summary

- Expands erdos-1-wip-01 from 3 sections → 5 sections matching the Lean file's logical structure
- Achieves quality score 100/100 in find-targets.ts scoring

## Sections Added

| ID | Title | Lines |
|---|---|---|
| imports-setup | Part I: Imports and Module Setup | 1–31 |
| quantitative-lemmas | Part II: Quantitative Lemmas (geometric sum, subset bound, range shrinkage) | 33–58 |
| binary-uniqueness | Part III: Binary Uniqueness — pow2_sum_inj four-case induction | 59–106 |
| dss-powers | Part IV: DSS Property (preimage trick) | 107–156 |
| dss-existence | Part V: Existence Theorem — Nat.find witness | 157–187 |

Previously at 3 sections (6 pts), now 5 sections (10 pts). Combined with the 7 keyInsights, 8 annotations, and references from PR #12606, this achieves the maximum 100/100 quality score.

## Test plan

- [x] `pnpm build` passes (✓ built in 2m 1s)
- [x] find-targets.ts reports quality 100 for erdos-1-wip-01

🤖 Generated with [Claude Code](https://claude.com/claude-code)