### PR TITLE
Fix: correct stale sorries count in cantor-diagonalization-oq-04-oq-03

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-04-oq-03/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-04-oq-03/meta.json
@@ -122,7 +122,7 @@
     "theoremCount": 10,
     "definitionCount": 4,
     "path": "Proofs/CantorDiagonalizationOQ04OQ03.lean",
-    "sorries": 1
+    "sorries": 0
   },
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

The `leanFile.sorries` and top-level `sorries` fields in `meta.json` for `cantor-diagonalization-oq-04-oq-03` were stale at `1` after `OmegaContinuous.monotone` was proved by the chain construction. The `meta.sorries` field was already correctly set to `0`.

## Evidence

**Before**: `leanFile.sorries: 1`, `sorries: 1` — inconsistent with `meta.sorries: 0`
**After**: All three fields consistently show `0`, matching the actual Lean source (verified via `git show HEAD:proofs/Proofs/CantorDiagonalizationOQ04OQ03.lean | grep -c sorry` → `0`)

The `status: verified` and `axiomCount: 0` fields were already correct and are unchanged.

---
Automated fix by lean-mechanic agent.