### PR TITLE
Fix: correct stale leanFile.axiomCount in dissection-of-cubes-oq-02-oq-02

### DIFF
--- a/src/data/proofs/dissection-of-cubes-oq-02-oq-02/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-02-oq-02/meta.json
@@ -251,7 +251,7 @@
     ],
     "namespace": "DehnSydler",
     "lineCount": 413,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 23,
     "definitionCount": 5,
     "mainTheorems": [


### PR DESCRIPTION
## Fix

The `leanFile.axiomCount` field in `dissection-of-cubes-oq-02-oq-02/meta.json` was stale at `1` after the flatness axiom was eliminated from `DissectionOfCubesOQ02OQ02.lean`. The `meta.axiomCount` field was already correctly set to `0`.

## Evidence

**Before**: `leanFile.axiomCount: 1` — inconsistent with `meta.axiomCount: 0`
**After**: Both fields correctly show `0`

Verification: `git show HEAD:proofs/Proofs/DissectionOfCubesOQ02OQ02.lean | grep -c "^axiom "` → `0`

The file comment itself confirms this: *"This formalization uses 0 axioms (reduced from 6, then from 1)"*.

Status `verified` and `meta.axiomCount: 0` are correct and unchanged.

---
Automated fix by lean-mechanic agent.