### PR TITLE
enrichment: add synthesis-curvature-ptolemy cross-refs to 4 Ptolemy/geometry entries

### DIFF
--- a/src/data/proofs/law-of-cosines/meta.json
+++ b/src/data/proofs/law-of-cosines/meta.json
@@ -163,6 +163,11 @@
       "targetId": "euler-identity",
       "relationship": "related",
       "description": "Euler's formula $e^{i\\theta} = \\cos\\theta + i\\sin\\theta$ provides the connection between the inner product $\\langle v, w \\rangle = \\|v\\|\\|w\\|\\cos\\theta$ used in the Law of Cosines and the complex exponential — the cosine function that appears in $c^2 = a^2 + b^2 - 2ab\\cos C$ is the real part of $e^{iC}$"
+    },
+    {
+      "targetId": "synthesis-curvature-ptolemy",
+      "relationship": "related",
+      "description": "synthesis-curvature-ptolemy introduces curvatureSin K as the constant-curvature generalization of the distance function, which simultaneously generalizes the law of cosines. The Euclidean law of cosines $c^2 = a^2 + b^2 - 2ab\\cos C$ is the K=0 case: curvatureSin 0(d) = d, so the curvature-parametrized Ptolemy equality reduces to the Euclidean identity. For K>0, curvatureSin K(d) = sin(√K·d)/√K gives the spherical law of cosines; for K<0, it gives the hyperbolic version. The synthesis framework thus unifies all three constant-curvature laws of cosines alongside Ptolemy's theorem."
     }
   ],
   "leanFile": {

--- a/src/data/proofs/ptolemys-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01-oq-02/meta.json
@@ -180,6 +180,11 @@
       "targetId": "ptolemys-theorem-oq-01-oq-01",
       "relationship": "sibling",
       "description": "Ptolemy Converse for unit-circle points: equality characterizes cyclic order. The spherical Ptolemy theorem proved here extends the forward direction (cyclic → Ptolemy equality) to the sphere; this OQ-01-OQ-01 sibling entry proves the converse (Ptolemy equality → cyclic order) for S¹ ⊂ S². Together they characterize concyclicity on the sphere: the Ptolemy equality holds if and only if the four points lie on a common great circle arc in a given order."
+    },
+    {
+      "targetId": "synthesis-curvature-ptolemy",
+      "relationship": "related",
+      "description": "synthesis-curvature-ptolemy proves spherical Ptolemy via the curvatureSin K unification framework with K=1, while this entry proves the same result via the chord-arc identity ‖u-v‖ = 2·sin(d_S(u,v)/2) in the unit sphere S² embedded in ℝ³. Both handle K=1 (spherical); synthesis-curvature-ptolemy additionally conjectures the K=-1 (hyperbolic) case via cosh identities. The synthesis survey in this entry's hyperbolic section directly motivates synthesis-curvature-ptolemy's curvatureSin K = sn_κ abstraction."
     }
   ],
   "references": [

--- a/src/data/proofs/ptolemys-theorem/meta.json
+++ b/src/data/proofs/ptolemys-theorem/meta.json
@@ -144,6 +144,11 @@
       "targetId": "triangle-angle-sum",
       "relationship": "related",
       "description": "The inscribed angle theorem, closely related to the triangle angle sum, underpins the proof that opposite angles in a cyclic quadrilateral sum to 180 degrees."
+    },
+    {
+      "targetId": "synthesis-curvature-ptolemy",
+      "relationship": "extended-by",
+      "description": "synthesis-curvature-ptolemy extends Ptolemy's theorem to all constant-curvature geometries using the unified curvatureSin K function. The Euclidean theorem proved here is the K=0 special case: as K→0, curvatureSin K(d) → d and the curvature-parametrized Ptolemy equality reduces to AC·BD = AB·CD + BC·DA. The synthesis proof covers K>0 (spherical) and conjectures K<0 (hyperbolic), providing a single framework that subsumes both Euclidean and non-Euclidean versions."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/spherical-law-of-cosines/meta.json
+++ b/src/data/proofs/spherical-law-of-cosines/meta.json
@@ -135,6 +135,11 @@
       "targetId": "law-of-sines-oq-06",
       "relationship": "related",
       "description": "The planar law of sines formalized via InnerProductGeometry.angle — the Euclidean counterpart to the spherical law of sines, which together with the spherical law of cosines forms the complete spherical triangle toolkit"
+    },
+    {
+      "targetId": "synthesis-curvature-ptolemy",
+      "relationship": "related",
+      "description": "synthesis-curvature-ptolemy introduces curvatureSin K as the constant-curvature generalization of the sine function, satisfying the ODE d²y/dx² + K·y = 0. At K=1, curvatureSin 1(d) = sin(d) — the same sine function appearing in the spherical law of cosines cos(c) = cos(a)cos(b) + sin(a)sin(b)cos(C). Both proofs use the inner-product distance formula ⟨u,v⟩ = cos(d_S(u,v)) for unit vectors and the chord-arc identity connecting Euclidean chords to spherical arc lengths. The curvatureSin framework directly generalizes the spherical law of cosines to all constant-curvature geometries."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
Enrichment pass for the Ptolemy theorem cluster. `synthesis-curvature-ptolemy` was added in #12500 but was not referenced by any existing gallery entry despite being a key curvature-unification result.

**Changes: 4 files modified**

- **ptolemys-theorem**: add `synthesis-curvature-ptolemy` as "extended-by" — the Euclidean theorem here is the K=0 special case of the general curvatureSin K framework
- **ptolemys-theorem-oq-01-oq-02**: add as "related" — parallel spherical proof via chord-arc identity; synthesis uses the same result via different route, and also surveys the K=-1 hyperbolic case
- **spherical-law-of-cosines**: add as "related" — shared curvatureSin K / inner-product infrastructure; curvatureSin 1(d) = sin(d) is the same sine appearing in cos(c) = cos(a)cos(b) + sin(a)sin(b)cos(C)
- **law-of-cosines**: add as "related" — K→0 limit of curvatureSin K recovers the Euclidean law; synthesis unifies all three constant-curvature laws of cosines alongside Ptolemy

Build: ✓ `pnpm build` passes