### PR TITLE
enrichment: add Baker's theorem cross-refs to transcendence theory cluster

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable/meta.json
@@ -202,6 +202,11 @@
       "targetId": "cantor-diagonalization-oq-02",
       "relationship": "related",
       "description": "Studies the cardinality of \u03c9\u2081, the first uncountable ordinal: |\u03c9\u2081| = \u2135\u2081. Countability of algebraic numbers (this entry) contributes to the Cantor cardinal hierarchy: \u2135\u2080 = |\u2115| = |\u211a| = |Alg(\u211d)| < |\u211d| = 2^\u2135\u2080. Whether \u2135\u2081 = 2^\u2135\u2080 (the Continuum Hypothesis, independent of ZFC) is the central question connecting this entry's strict countability result to the ordinal cardinality studied in OQ-02."
+    },
+    {
+      "targetId": "algebraic-numbers-countable-oq-04",
+      "relationship": "extended-by",
+      "description": "Baker's theorem: if log \u03b1\u2081, ..., log \u03b1\u2099 are linearly independent over \u211a (where \u03b1\u1d62 are nonzero algebraic), they are linearly independent over \u211a\u0305. This is the deepest result about transcendence of logarithms of algebraic numbers, extending from the cardinality argument here (which shows transcendentals are 'most' reals but constructs none) to specific \u211a\u0305-linear independence statements. Baker's 1966 proof earned the Fields Medal and enabled effective Diophantine bounds unobtainable from mere cardinality arguments."
     }
   ],
   "references": [

--- a/src/data/proofs/gelfond-schneider/meta.json
+++ b/src/data/proofs/gelfond-schneider/meta.json
@@ -200,6 +200,11 @@
       "targetId": "liouville-theorem",
       "relationship": "foundational",
       "description": "Liouville's Diophantine approximation theorem (1844) gave the first transcendence results. Gelfond-Schneider uses a different technique (auxiliary functions) but both exploit algebraic vs transcendental approximation gaps"
+    },
+    {
+      "targetId": "algebraic-numbers-countable-oq-04",
+      "relationship": "extended-by",
+      "description": "Baker's theorem (1966, Fields Medal) is the vast generalization of Gelfond-Schneider: if log α₁, ..., log αₙ are linearly independent over ℚ, they remain linearly independent over Q̄. Gelfond-Schneider handles n=2: log(α^β)/log α = β (algebraic irrational) is the Q̄-linear dependence that Baker's theorem forbids. Baker's proof uses auxiliary function methods pioneered by Gelfond-Schneider but extended to multiple logarithms simultaneously, enabling effective Diophantine bounds with applications to Catalan's conjecture and class number problems."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/hermite-lindemann/meta.json
+++ b/src/data/proofs/hermite-lindemann/meta.json
@@ -177,6 +177,11 @@
       "targetId": "sqrt2-irrational",
       "relationship": "foundational",
       "description": "Irrationality of √2 is the simplest expressibility barrier. The hierarchy is: √2 ∉ ℚ (irrational) → quintic roots ∉ radical extensions (Abel-Ruffini) → e,π ∉ algebraic numbers (Hermite-Lindemann)"
+    },
+    {
+      "targetId": "algebraic-numbers-countable-oq-04",
+      "relationship": "extended-by",
+      "description": "Baker's theorem (1966) is the multi-logarithm generalization of Hermite-Lindemann: if log α₁, ..., log αₙ are Q-linearly independent, they are Q̄-linearly independent. Hermite-Lindemann is the n=1 case: a single non-zero log α (for algebraic α≠1) is Q̄-linearly independent of 1, i.e., it is transcendental. Baker's proof builds on Hermite's auxiliary polynomial technique but must handle simultaneous approximation of multiple logarithms, requiring a much more delicate zero-counting argument via Siegel's lemma."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
Enrichment pass for the transcendence theory cluster. `algebraic-numbers-countable-oq-04` (Baker's theorem) was added recently but not referenced by any related entry.

**Changes: 3 files modified**

- **gelfond-schneider**: add Baker as "extended-by" — Baker's theorem (1966) vastly generalizes Gelfond-Schneider from 2 logs to linear forms in n logarithms; explains the auxiliary function connection
- **hermite-lindemann**: add Baker as "extended-by" — Hermite-Lindemann is the n=1 case; Baker's generalization to simultaneous independence of n logarithms required Siegel's lemma and zero-counting
- **algebraic-numbers-countable**: add Baker as "extended-by" — deepest transcendence result in the OQ tree; contrasts with cardinality arguments (existence) via effective Diophantine bounds

Build: ✓ `pnpm build` passes