### PR TITLE
enrichment: amgm OQ tree — add parent→child cross-references for Maclaurin chain and power mean OQs

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03/meta.json
@@ -118,6 +118,11 @@
       "targetId": "cauchy-schwarz",
       "relationship": "related",
       "description": "Cauchy-Schwarz can be seen as a special case of Maclaurin's inequalities ($M_1 \\geq M_2$ for specific inputs), connecting the two fundamental inequalities of analysis"
+    },
+    {
+      "targetId": "amgm-inequality-oq-02-oq-03-oq-03",
+      "relationship": "extended-by",
+      "description": "Completes the Maclaurin chain: proves M_j ≥ M_k for all j ≤ k by induction on the gap (k - j), using `maclaurin_step` from this entry as the inductive step. Where this entry proves the one-step inequality M_j ≥ M_{j+1}, OQ-03-OQ-03 bootstraps it into the full transitive chain M₁ ≥ M₂ ≥ ... ≥ Mₙ via a `Nat.rec` induction."
     }
   ],
   "leanFile": {

--- a/src/data/proofs/amgm-inequality-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02/meta.json
@@ -160,6 +160,11 @@
       "targetId": "inclusion-exclusion",
       "relationship": "related",
       "description": "The powersetCard decomposition in elemSymm (summing over all $k$-element subsets) is a combinatorial cousin of inclusion-exclusion — both systematically enumerate subsets by cardinality. The elemSymm recurrence $e_{k+1}(n+1) = e_{k+1}(n) + x_{n+1} \\cdot e_k(n)$ parallels the inclusion-exclusion identity for subsets containing vs not containing a fixed element"
+    },
+    {
+      "targetId": "amgm-inequality-oq-02-oq-03-oq-03",
+      "relationship": "extended-by",
+      "description": "Full Maclaurin Chain (OQ-03-OQ-03) completes what this entry begins: once `maclaurin_step` Mₖ ≥ Mₖ₊₁ is available (proved by OQ-03), OQ-03-OQ-03 bootstraps it into the full transitive chain M_j ≥ M_k for all j ≤ k by induction on the gap (k - j). The `maclaurin_chain` theorem in this entry is axiomatized — OQ-03-OQ-03 proves it."
     }
   ],
   "overview": {

--- a/src/data/proofs/amgm-inequality-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03/meta.json
@@ -111,6 +111,21 @@
       "targetId": "sum-of-kth-powers",
       "relationship": "related",
       "description": "Power sums p_k = ∑ xᵢ^k are the unnormalized building blocks of power means: M_k = (∑ wᵢzᵢ^k)^(1/k) = (p_k/n)^(1/k) for equal weights. Power sum identities (Newton-Girard) relate p_k to elementary symmetric polynomials, connecting this power mean formalization to the Maclaurin chain in amgm-inequality-oq-02"
+    },
+    {
+      "targetId": "amgm-inequality-oq-03-oq-02-oq-01-oq-01",
+      "relationship": "extended-by",
+      "description": "Extended Power Mean Monotonicity (OQ-03-OQ-02-OQ-01-OQ-01) unifies the three separate cases proved here — same-sign positive (M_r ≤ M_s for 0 < r ≤ s), same-sign negative (M_r ≤ M_s for r ≤ s < 0 via duality), and the HM ≤ GM crossing — into a single theorem `power_mean_monotone_unified`. This entry proves the cases individually; OQ-03-OQ-02-OQ-01-OQ-01 assembles them into one statement covering all r ≤ s."
+    },
+    {
+      "targetId": "amgm-inequality-oq-03-oq-03-oq-01",
+      "relationship": "extended-by",
+      "description": "Power Mean Limits (OQ-03-OQ-03-OQ-01) proves the extreme cases of the power mean chain left open here: lim_{r→+∞} M_r = max(z) and lim_{r→-∞} M_r = min(z) via `Filter.Tendsto`. This formalizes the endpoints of the interpolation HM ≤ GM ≤ AM ≤ ... ≤ max that this entry begins, completing the picture from minimum to maximum."
+    },
+    {
+      "targetId": "amgm-inequality-oq-03-oq-04",
+      "relationship": "extended-by",
+      "description": "Rényi Entropy and Power Mean Monotonicity (OQ-03-OQ-04) proves the equivalence between power mean monotonicity M_r ≤ M_s and Rényi entropy monotonicity H_β ≤ H_α (α ≤ β). The connection sketched in the shannon-entropy cross-reference here is made precise: H_α = (1/(1-α)) log M_{α-1}(p), so power mean monotonicity is information-theoretic monotonicity in disguise. OQ-03-OQ-04 bridges the inequality and entropy libraries."
     }
   ],
   "overview": {


### PR DESCRIPTION
## Summary

Adds 5 missing parent→child cross-references in the AMgm OQ tree, where parent entries lacked links to children added after their creation:

- **amgm-inequality-oq-02-oq-03** → `amgm-inequality-oq-02-oq-03-oq-03` (Full Maclaurin Chain, extended-by)
- **amgm-inequality-oq-02** → `amgm-inequality-oq-02-oq-03-oq-03` (maclaurin_chain axiom elimination, extended-by)
- **amgm-inequality-oq-03** → `amgm-inequality-oq-03-oq-02-oq-01-oq-01` (unified power mean monotonicity, extended-by)
- **amgm-inequality-oq-03** → `amgm-inequality-oq-03-oq-03-oq-01` (power mean limits via Filter.Tendsto, extended-by)
- **amgm-inequality-oq-03** → `amgm-inequality-oq-03-oq-04` (Rényi entropy/power mean equivalence, extended-by)

## Test plan
- [x] JSON validated (`python3 -m json.tool`) for all 3 files
- [x] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)