### PR TITLE
Fix: ballot-problem-oq-03-oq-01-oq-02 stale sorry count (5→4) and lineCount

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -22,7 +22,7 @@
     "sorries": 4,
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "assumptions": "Four open sorries: (1) hook_length_formula (LGV approach: requires SYT↔NI bijection + det factorization), (2) ni_count_eq_syt_count (Fomin/Viennot/RSK correspondence), (3) lgv_det_factors_as_hook_quotient (det factorization identity), (4) hook_walk_identity ≥6-row case (GNW or RSK; at-most-2-row, gHookYD, ≤2-col, exactly-3-row, exactly-4-row, exactly-5-row all proved). hook_length_formula_general is proved modulo hook_walk_identity via corner induction.",
+    "assumptions": "Four open sorries: (1) hook_length_formula (LGV approach: requires SYT↔NI bijection + det factorization), (2) ni_count_eq_syt_count (Fomin/Viennot/RSK correspondence), (3) lgv_det_factors_as_hook_quotient (det factorization identity), (4) hook_walk_identity for 6+ rows (GNW or RSK, ~300 lines; 3-row case proved via hook_walk_identity_threeRow; 4-row case proved via hook_walk_identity_fourRow; 5-row case proved via hook_walk_identity_fiveRow; gHookYD case proved). hook_length_formula_general is proved modulo hook_walk_identity via Part XIV corner induction.",
     "lineCount": 8109,
     "theoremCount": 164,
     "definitionCount": 14,


### PR DESCRIPTION
## Summary

- Discovered during gallery integrity audit: `meta.assumptions` was missing the specific named lemmas for proved hook walk identity cases
- The Lean source (`proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean`) grew from 5146 to 8109 lines as the researcher proved the 3-row, 4-row, and 5-row cases
- `hook_walk_identity_threeRow`, `hook_walk_identity_fourRow`, `hook_walk_identity_fiveRow`, and the gHookYD case are now fully proved; only ≥6-row shapes remain (1 sorry)
- Prior commits had already corrected the numeric fields (`sorries: 4`, `lineCount: 8109`, description, conclusion.summary); this commit adds lemma-level detail to the `assumptions` field to match the actual Lean source state

## Changes

- `meta.assumptions`: expanded to name the proved helper lemmas and add `~300 lines` estimate for the remaining ≥6-row sorry; reference `Part XIV corner induction` for `hook_length_formula_general`

## Test plan

- [ ] Verify `meta.json` parses as valid JSON
- [ ] Confirm `sorries: 4` matches the 4 actual sorry statements in `proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean` at HEAD
- [ ] Confirm `lineCount: 8109` matches `wc -l` on the Lean source

🤖 Generated with [Claude Code](https://claude.com/claude-code)