### PR TITLE
Fix: correct section endLine out-of-bounds in 4 gallery entries

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-04/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-04/meta.json
@@ -122,7 +122,7 @@
             "id": "sec-main-theorem",
             "title": "Part V: Jordan-Hölder Theorem",
             "startLine": 229,
-            "endLine": 255,
+            "endLine": 234,
             "summary": "`jordan_holder_subgroups` and `jordan_holder_finite_groups`: one-line delegations to `CompositionSeries.jordan_holder` once the JordanHolderLattice instance is provided. `#check` statements verify the exported types. These theorems become available automatically — the entire power of the abstract Jordan-Hölder machinery applies to groups at no additional proof cost.",
             "mathContext": "Jordan-Hölder uniqueness: any two composition series of a finite group have the same length and the same multiset of simple composition factors up to permutation and isomorphism. For $S_5$: the unique series is $\\{e\\} \\triangleleft A_5 \\triangleleft S_5$ with factors $A_5$ (simple, order 60) and $\\mathbb{Z}/2\\mathbb{Z}$. Jordan-Hölder guarantees no alternative decomposition avoids the non-abelian $A_5$ factor, making the Abel-Ruffini degree-5 threshold absolute."
         }

--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -135,7 +135,7 @@
       "id": "sec-main",
       "title": "Main Theorems",
       "startLine": 152,
-      "endLine": 199,
+      "endLine": 192,
       "summary": "I_not_principal, not_isPrincipalIdealRing, exists_non_principal_ideal, ufd_not_pir_distinction."
     }
   ],

--- a/src/data/proofs/ptolemys-complex-proof/meta.json
+++ b/src/data/proofs/ptolemys-complex-proof/meta.json
@@ -113,7 +113,7 @@
       "id": "exports",
       "title": "Exported Theorems",
       "startLine": 145,
-      "endLine": 154,
+      "endLine": 145,
       "summary": "#check verification of all six exported theorems.",
       "mathContext": "Six theorems: ptolemy_algebraic_identity (CommRing), ptolemy_complex_identity (ℂ), ptolemy_inequality (norm), ptolemy_inequality_abs (Complex.abs), ptolemy_inequality_dist (dist), ptolemy_equality_of_proportional (equality characterization)."
     }

--- a/src/data/proofs/synthesis-curvature-ptolemy/meta.json
+++ b/src/data/proofs/synthesis-curvature-ptolemy/meta.json
@@ -110,7 +110,7 @@
       "id": "summary",
       "title": "Summary #check Statements",
       "startLine": 259,
-      "endLine": 271,
+      "endLine": 270,
       "summary": "Seven #check commands verifying all main declarations are well-typed: curvatureSin, curvatureSin_zero, curvatureSin_one, curvatureSin_neg_one, curvatureSin_zero_right, spherical_ptolemy_eq_curvatureSin, spherical_ptolemy_ineq_curvatureSin.",
       "mathContext": "The #check statements serve as a final type-checking sanity check, confirming all seven declarations compile without errors and their types are as expected."
     }


### PR DESCRIPTION
## Fix

Four `meta.json` files had `endLine` values in their `sections` arrays pointing beyond the actual Lean file length. This causes gallery rendering errors when the UI tries to display line ranges that don't exist.

## Evidence

| Entry | Section | Before | After | File Length |
|-------|---------|--------|-------|-------------|
| `abel-ruffini-galois-extensions-oq-04` | `sec-main-theorem` | 255 | 234 | 234 |
| `bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01` | `sec-main` | 199 | 192 | 192 |
| `ptolemys-complex-proof` | `exports` | 154 | 145 | 145 |
| `synthesis-curvature-ptolemy` | `summary` | 271 | 270 | 270 |

All `endLine` values corrected to match actual file length (last valid line).

---
Automated fix by lean-mechanic agent.