### PR TITLE
Fix: correct stale lineCount in 6 gallery entries

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-04-oq-03/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-04-oq-03/meta.json
@@ -32,7 +32,7 @@
         "module": "Mathlib.Order.CompleteLattice"
       }
     ],
-    "lineCount": 283,
+    "lineCount": 299,
     "assumptions": "None. OmegaContinuous.monotone proved via chain construction: c 0 = a, c (n+1) = b gives f(a) ≤ ⊔ₙ f(cₙ) = f(b) by ω-continuity."
   },
   "parent": "cantor-diagonalization-oq-04",
@@ -117,7 +117,7 @@
   ],
   "leanFile": {
     "namespace": "CantorDiagonalizationOQ04OQ03",
-    "lineCount": 283,
+    "lineCount": 299,
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 4,

--- a/src/data/proofs/dissection-of-cubes-oq-02-oq-02/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-02-oq-02/meta.json
@@ -54,7 +54,7 @@
       "octAngle_class: [arccos(-1/3)] = -[arccos(1/3)] in ℝ/πℤ",
       "Dehn-Sydler completeness theorem statement"
     ],
-    "lineCount": 413,
+    "lineCount": 450,
     "assumptions": "0 axioms. tmul_infinite_order_ne_zero is now a proved theorem using Module.Flat ℤ ℝ (flatness from IsBezout ℤ via EuclideanDomain and NoZeroSMulDivisors ℤ ℝ via CharZero). Previously reduced from 6 axioms to 1 (5 eliminated); final axiom now proved via lTensor injectivity under flatness.",
     "mathlib_version": "4.26.0",
     "wiedijkNumber": 37,
@@ -250,7 +250,7 @@
       "Real"
     ],
     "namespace": "DehnSydler",
-    "lineCount": 413,
+    "lineCount": 450,
     "axiomCount": 0,
     "theoremCount": 23,
     "definitionCount": 5,

--- a/src/data/proofs/dissection-of-cubes-oq-04/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-04/meta.json
@@ -23,7 +23,7 @@
     "dateAdded": "2026-04-22",
     "axiomCount": 0,
     "assumptions": "0 axioms. All previously axiomatized results are now proved: icoAngle_irrational via coupled Chebyshev sequences over ℤ[√5], tmul_infinite_order_ne_zero via Module.Flat ℤ ℝ (proved in OQ02OQ02).",
-    "lineCount": 581,
+    "lineCount": 558,
     "theoremCount": 22,
     "definitionCount": 5,
     "mathlibDependencies": [

--- a/src/data/proofs/erdos-1-oq-03/meta.json
+++ b/src/data/proofs/erdos-1-oq-03/meta.json
@@ -38,7 +38,7 @@
       "Conway-Guy optimality conjecture statement"
     ],
     "dateAdded": "2026-03-30",
-    "lineCount": 184,
+    "lineCount": 183,
     "theoremCount": 12,
     "definitionCount": 3,
     "prerequisites": [
@@ -154,7 +154,7 @@
       "Finset"
     ],
     "namespace": "Erdos1OQ03",
-    "lineCount": 182,
+    "lineCount": 183,
     "axiomCount": 1,
     "theoremCount": 12,
     "definitionCount": 3,

--- a/src/data/proofs/sperner-ndim-oq-04/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-04/meta.json
@@ -42,7 +42,7 @@
     ],
     "dateAdded": "2026-04-22",
     "axiomCount": 1,
-    "lineCount": 878,
+    "lineCount": 877,
     "assumptions": "1 axiom: kuhn_path_existential — Kuhn's cross-path parity argument that a walk from some boundary door reaches an FC simplex. The walk-reversal involution τ∘τ=id (which would promote this to a theorem) requires kuhnWalkWithExit + walkTrace_reversal induction, not yet formalized. All other supporting lemmas are proved: non-revisiting (kuhn_step_nonrevisit + WalkValid), unique exit (nonfc_with_door_has_unique_exit), door counts, termination dichotomy. 0 sorries.",
     "mathlib_version": "4.26.0"
   },
@@ -247,7 +247,7 @@
       "BigOperators"
     ],
     "namespace": "SpernerNDimOQ04",
-    "lineCount": 878,
+    "lineCount": 877,
     "axiomCount": 1,
     "theoremCount": 20,
     "definitionCount": 8,

--- a/src/data/proofs/synthesis-curvature-ptolemy/meta.json
+++ b/src/data/proofs/synthesis-curvature-ptolemy/meta.json
@@ -52,7 +52,7 @@
     ],
     "dateAdded": "2026-04-26",
     "axiomCount": 0,
-    "lineCount": 271,
+    "lineCount": 270,
     "assumptions": "0 axioms. 0 sorries. All results are fully machine-verified. The hyperbolic Ptolemy theorem (K<0) is stated as a conjecture in comments only — it is NOT claimed as a theorem in this file.",
     "mathlib_version": "4.26.0",
     "parentProof": "ptolemys-theorem-oq-01-oq-02"
@@ -202,7 +202,7 @@
       "EuclideanGeometry"
     ],
     "namespace": null,
-    "lineCount": 271,
+    "lineCount": 270,
     "axiomCount": 0,
     "theoremCount": 7,
     "sorries": 0,


### PR DESCRIPTION
## Fix

Six `meta.json` files had `lineCount` values that no longer matched the actual Lean source file lengths. Stale line counts cause gallery display issues and fail auditor integrity checks.

## Evidence

| Entry | Field | Before | After |
|-------|-------|--------|-------|
| `dissection-of-cubes-oq-02-oq-02` | meta + leanFile | 413 | 450 |
| `dissection-of-cubes-oq-04` | meta | 581 | 558 |
| `cantor-diagonalization-oq-04-oq-03` | meta + leanFile | 283 | 299 |
| `erdos-1-oq-03` | meta | 184 | 183 |
| `erdos-1-oq-03` | leanFile | 182 | 183 |
| `sperner-ndim-oq-04` | meta + leanFile | 878 | 877 |
| `synthesis-curvature-ptolemy` | meta + leanFile | 271 | 270 |

All values verified against `wc -l` on the respective Lean files.

---
Automated fix by lean-mechanic agent.