### PR TITLE
research: erdos-476-oq-05-wip-01 session 3 — blocked analysis

### DIFF
--- a/research/problems/erdos-476-oq-05-wip-01/knowledge.md
+++ b/research/problems/erdos-476-oq-05-wip-01/knowledge.md
@@ -1,7 +1,54 @@
 # Knowledge Base: erdos-476-oq-05-wip-01
 
-**Last Updated**: 2026-04-25
+**Last Updated**: 2026-04-26
 Insights accumulated during research on this problem.
+
+---
+
+## Session 2026-04-26 (Session 3) — B-All-Redundancy Analysis; |A|≥4,|B|≥3 Sorry Confirmed Blocked
+
+**Mode**: REVISIT
+**Outcome**: blocked (deeper analysis; no Lean code changes)
+
+### What I Did
+
+- Analyzed the remaining sorry at line 844 (`|A|≥4 or |B|≥4` all-redundancy case) in depth
+- Proved **B-all-redundancy from A-all-redundancy**: if every x ∈ A+B has ≥ 2 A-reps (hrep2),
+  then ∀ b ∈ B, A+(B\{b}) = A+B. Proof: if x ∉ A+(B\{b₀}), all reps of x use b₀ → at most 1 rep,
+  contradicting hrep2. (~10-15 lines in Lean, using hrep2 already proved at lines 782-804)
+- Attempted orbit argument via B-all-redundancy: for |A|=2, B is closed under a fixed shift d=a₁-a₀,
+  giving |B| ≥ p. But for |A| ≥ 3, the shift d varies with b — no fixed d.
+- Verified for |A|=4, |B|=3: hineq gives equality 12 = 2*6, so every element has EXACTLY rep = 2
+  (the counting is tight). Bipartite graph analysis shows no immediate contradiction from rep = 2.
+- Confirmed the Aristotle companion file (lines 258-265) acknowledges the same blocker.
+
+### Key Findings
+
+- **B-all-redundancy derivation** (elementary, ~15 Lean lines): From `hrep2` (rep_A(x) ≥ 2 for all
+  x ∈ A+B), B is also all-redundant: ∀ b ∈ B, A+(B\{b}) = A+B. The companion file already has
+  this at lines 145-162 via `non_redundant_b_gives_a`. Can be added to main file.
+- **Orbit argument barrier**: The |B|=2 orbit argument works because A is closed under the UNIQUE
+  nonzero difference d of B (forced by |B|=2). For |B|≥3 and |A|≥3, B-all-redundancy gives: ∀ b ∈ B,
+  ∃ d ∈ (A-A)\{0}: b+d ∈ B. But d varies with b — can't apply orbit argument.
+- **tight rep=2 case** (|A|=4, |B|=3): Counting is exactly tight: 4*3=12=2*6. So rep_A(x)=2 exactly
+  for all x. Bipartite graph is 3-regular (A-side) and 2-regular ((A+B)-side). No immediate
+  arithmetic contradiction found.
+- **Assessment: BLOCKED** — The sorry at line 844 requires either (1) Kneser's theorem ~200-300 lines,
+  (2) a polynomial/Fourier approach (~100+ lines), or (3) complete proof restructuring.
+
+### Files Modified
+
+- None (analysis only)
+
+### Next Steps
+
+1. **Build B-all-redundancy into main proof** (~15 lines, easy): Add `hredB_eq` after `hredA_eq`
+   in the sorry block. Gives more hypotheses for future attempts.
+2. **Kneser build**: For ZMod p, Kneser reduces to CD (trivial subgroups), but the STRUCTURAL
+   application differs. The "Kneser route" for Vosper is: use Kneser to show all-redundant A
+   forces A+B to be a coset (impossible in ZMod p with |A+B| < p). Estimated: ~200-300 lines.
+3. **Alternative: polynomial method** using combinatorial Nullstellensatz over ZMod p.
+4. **Flag as BLOCKED and move on** (3 sessions on this sorry with |A|≥4,|B|≥3 sub-case).
 
 ---
 
@@ -106,4 +153,12 @@ theorems. Recommend Aristotle submission as first approach.
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- **Counting argument for |A|≥4, |B|≥3**: Double counting gives hineq (|A|-2)(|B|-2) ≥ 2 which
+  HOLDS (not contradicted) for all such cases. The counting approach is exhausted.
+- **Orbit argument via B-all-redundancy**: B-all-redundancy gives ∀ b ∈ B, ∃ d ∈ (A-A)\{0}: b+d ∈ B.
+  But d varies with b (no fixed d), so the orbit/periodicity argument doesn't apply for |A| ≥ 3.
+- **Iterative element removal**: A being all-redundant (removing any a preserves A+B) does NOT imply
+  that A\{a} is also all-redundant. Cannot iterate removal to reach |A|=2.
+- **Inductive hypothesis (IH) application**: (A\{a₀}, B) with all-redundant A has |(A\{a₀})+B| =
+  |A|+|B|-1 > |A\{a₀}|+|B|-1, so Vosper equality condition fails. IH doesn't apply.
+- **IH via B-perspective**: Symmetric argument. (A, B\{b₀}) with B all-redundant has same issue.

--- a/src/data/research/problems/erdos-476-oq-05-wip-01.json
+++ b/src/data/research/problems/erdos-476-oq-05-wip-01.json
@@ -1,6 +1,6 @@
 {
   "slug": "erdos-476-oq-05-wip-01",
-  "title": "Erdős #476 OQ5 — Complete Vosper's Theorem Inductive Step",
+  "title": "Erd\u0151s #476 OQ5 \u2014 Complete Vosper's Theorem Inductive Step",
   "phase": "ACT",
   "status": "active",
   "tier": "A",
@@ -29,36 +29,40 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: |B|=2 and |A|=|B|=3 cases proved; 1 sorry for |A|>=4 or |B|>=4 (Kneser needed)",
+    "progressSummary": "BLOCKED: |B|=2 and |A|=|B|=3 cases proved; 1 sorry at line 844 (|A|>=4 or |B|>=4 all-redundant case) confirmed blocked \u2014 needs Kneser theorem or proof restructuring",
     "builtItems": [
       "case1_exists |B|=2 branch: fully proved via orbit argument (Erdos476OQ05Problem.lean ~550-609)",
-      "hredA_card lemma inline: ∀ a ∈ A, (A.erase a + B).card = A.card + B.card - 1 from CD + inclusion",
-      "hredA set equality inline: ∀ a ∈ A, A.erase a + B = A + B via Finset.eq_of_subset_of_card_le",
-      "horbit_nat by induction: a₀ + k*(b1-b2) ∈ A for all k : ℕ",
-      "hrep2 lemma: ∀ x ∈ A+B, 2 ≤ (A.filter (fun a => x-a ∈ B)).card — if r(x)=1, contradicts hredA (Erdos476OQ05Problem.lean ~781-803)",
-      "hsum_eq: ∑_x r(x) = |A|·|B| via sigma bijection (x,a) ↦ (a,x-a) (Erdos476OQ05Problem.lean ~806-829)",
-      "hineq: counting bound |A|·|B| ≥ 2(|A|+|B|-1) from hrep2 + hsum_eq (Erdos476OQ05Problem.lean ~835)",
-      "|A|=|B|=3 sub-case: 9 ≥ 10 contradiction via norm_num (Erdos476OQ05Problem.lean ~838-840)"
+      "hredA_card lemma inline: \u2200 a \u2208 A, (A.erase a + B).card = A.card + B.card - 1 from CD + inclusion",
+      "hredA set equality inline: \u2200 a \u2208 A, A.erase a + B = A + B via Finset.eq_of_subset_of_card_le",
+      "horbit_nat by induction: a\u2080 + k*(b1-b2) \u2208 A for all k : \u2115",
+      "hrep2 lemma: \u2200 x \u2208 A+B, 2 \u2264 (A.filter (fun a => x-a \u2208 B)).card \u2014 if r(x)=1, contradicts hredA (Erdos476OQ05Problem.lean ~781-803)",
+      "hsum_eq: \u2211_x r(x) = |A|\u00b7|B| via sigma bijection (x,a) \u21a6 (a,x-a) (Erdos476OQ05Problem.lean ~806-829)",
+      "hineq: counting bound |A|\u00b7|B| \u2265 2(|A|+|B|-1) from hrep2 + hsum_eq (Erdos476OQ05Problem.lean ~835)",
+      "|A|=|B|=3 sub-case: 9 \u2265 10 contradiction via norm_num (Erdos476OQ05Problem.lean ~838-840)"
     ],
     "insights": [
-      "case1_exists |B|=2 proved: orbit argument shows A closed under +(b1-b2) → |A| ≥ p (contradiction)",
+      "case1_exists |B|=2 proved: orbit argument shows A closed under +(b1-b2) \u2192 |A| \u2265 p (contradiction)",
       "Set equality A.erase(a)+B = A+B follows from: CD lower bound + inclusion upper bound + hall assumption",
       "Key pattern: Finset.eq_of_subset_of_card_le + cardinality from hredA_card proves set equality",
-      "For |B|≥3: all-redundant contradiction needs Freiman-Ruzsa or stabilizer structure theorem — genuinely hard",
-      "The orbit argument uses zmod_orbit_injective (Fin p → ZMod p injective when d≠0) already in file",
-      "r(x) ≥ 2 for all x ∈ A+B when A is all-redundant: if r(x)=1 with unique a₁, then x ∉ (A.erase a₁)+B, contradicting SET equality hredA a₁",
-      "Double counting identity: ∑_x |{a ∈ A : x-a ∈ B}| = |A|·|B| via Finset.card_bij bijection (x,a) ↦ (a,x-a)",
-      "Counting argument only closes |A|=|B|=3 (9 < 10); for |A|≥4 or |B|≥4, the bound (|A|-2)(|B|-2) ≥ 2 holds and Kneser is needed",
-      "Kneser theorem for ZMod p: NOT in Mathlib. Building it from scratch needs ~200-300 lines of additive combinatorics infrastructure"
+      "For |B|\u22653: all-redundant contradiction needs Freiman-Ruzsa or stabilizer structure theorem \u2014 genuinely hard",
+      "The orbit argument uses zmod_orbit_injective (Fin p \u2192 ZMod p injective when d\u22600) already in file",
+      "r(x) \u2265 2 for all x \u2208 A+B when A is all-redundant: if r(x)=1 with unique a\u2081, then x \u2209 (A.erase a\u2081)+B, contradicting SET equality hredA a\u2081",
+      "Double counting identity: \u2211_x |{a \u2208 A : x-a \u2208 B}| = |A|\u00b7|B| via Finset.card_bij bijection (x,a) \u21a6 (a,x-a)",
+      "Counting argument only closes |A|=|B|=3 (9 < 10); for |A|\u22654 or |B|\u22654, the bound (|A|-2)(|B|-2) \u2265 2 holds and Kneser is needed",
+      "Kneser theorem for ZMod p: NOT in Mathlib. Building it from scratch needs ~200-300 lines of additive combinatorics infrastructure",
+      "B-all-redundancy from A-all-redundancy (session 3 insight): if rep_A(x) >= 2 for all x in A+B (hrep2), then B is also all-redundant: forall b in B, A+(B\\{b})=A+B. Proof: if x not in A+(B\\{b0}), all reps use b0 -> at most 1 rep, contradicting hrep2",
+      "Orbit argument barrier (session 3): B-all-redundancy gives forall b in B, exists d in (A-A)\\{0}: b+d in B. But d varies with b for |A|>=3 \u2014 no fixed d, orbit argument fails",
+      "Tight rep=2 case (session 3): for |A|=4, |B|=3, every x in A+B has EXACTLY rep=2 (4*3=12=2*6). Bipartite graph is 3-regular/2-regular. No arithmetic contradiction found from rep=2 alone"
     ],
     "mathlibGaps": [
-      "Kneser theorem for abelian groups (needed for |A|>=4 or |B|>=4 all-redundant contradiction in Vosper induction)"
+      "Kneser theorem for abelian groups (needed for |A|>=4 or |B|>=4 all-redundant contradiction in Vosper induction)",
+      "B-all-redundancy derivation (elementary, ~15 lines): follows from hrep2 via contradiction \u2014 if x not in A+(B\\{b0}), all reps of x use b0 giving rep=1, contradicting hrep2>=2"
     ],
     "nextSteps": [
-      "Build Kneser theorem for ZMod p (~200-300 lines): since Stab(A+B) is trivial for prime order groups, |A+B| >= |A|+|B|-1 forces AP structure under full redundancy",
-      "Alternative: try elementary Freiman/Schur approach for the |A|>=4, |B|>=3 sub-case",
-      "Key constraint: for tight case |A|=4, |B|=3, each x in A+B has r(x)=2 exactly — may enable direct structural argument without Kneser",
-      "If 3+ sessions stuck on Kneser: flag as BLOCKED and release claim"
+      "B-all-redundancy can be added to main proof (~15 lines) using hrep2 already proved \u2014 easy win for future prover",
+      "Kneser build for ZMod p: since stabilizer must be {0} (prime order), Kneser reduces to CD. The structural argument needs ~200-300 lines",
+      "Alternative: polynomial method (combinatorial Nullstellensatz over ZMod p) \u2014 different infrastructure",
+      "Consider flagging as BLOCKED and moving on; 3 sessions with no progress on line 844 sorry"
     ],
     "markdown": "# Knowledge Base: erdos-476-oq-05-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

- Analyzed the remaining sorry at line 844 of `Erdos476OQ05Problem.lean` (all-redundant A with |A|≥4, |B|≥3 case)
- Proved B-all-redundancy follows from A-all-redundancy via `hrep2`: if every element has ≥2 A-reps, then B is also all-redundant
- Confirmed counting argument is exhausted (tight rep=2 for |A|=4,|B|=3; no contradiction)
- Documented dead ends: iterative removal, IH via smaller pair, orbit via B-all-redundancy
- The sorry requires Kneser's theorem (~200-300 lines) or proof restructuring

## Files changed
- `research/problems/erdos-476-oq-05-wip-01/knowledge.md` — session 3 session log, dead ends
- `src/data/research/problems/erdos-476-oq-05-wip-01.json` — updated insights, next steps, blocked status

🤖 Generated with [Claude Code](https://claude.ai/claude-code)