### PR TITLE
feat(shannon-source-coding-oq-04): prove type_class_size_eq_multinomial via Aristotle (2→1 sorries)

### DIFF
--- a/src/data/proofs/shannon-source-coding-oq-04/meta.json
+++ b/src/data/proofs/shannon-source-coding-oq-04/meta.json
@@ -177,12 +177,12 @@
       "BigOperators"
     ],
     "namespace": "MethodOfTypes",
-    "lineCount": 352,
+    "lineCount": 414,
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 4,
     "path": "Proofs/ShannonSourceCodingOQ04.lean",
-    "sorries": 2
+    "sorries": 1
   },
   "references": [
     {


### PR DESCRIPTION
## Summary

- Integrates Aristotle's proof of `type_class_size_eq_multinomial`: |T_f| = n!/∏(f i)!
- Proof is by induction on n, splitting the type class by last element value (Pascal-style recursion)
- Reduces sorry count from 2 to 1

## Mathematical Content

`type_class_size_eq_multinomial` states that the number of sequences of length n over alphabet `Fin k` with empirical distribution f equals the multinomial coefficient n!/(f(0)! · f(1)! · … · f(k-1)!). This is the fundamental counting fact of the method of types.

## Remaining Sorry

`source_coding_achievability_mot` requires the Law of Large Numbers for discrete distributions, not currently in Mathlib. This sorry is OPEN and documented as out-of-scope.

## Test plan
- [ ] Docker build: `./proofs/scripts/docker-build.sh Proofs.ShannonSourceCodingOQ04`
- [ ] Verify sorry count = 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)