### PR TITLE
Fix: correct stale lineCount in 2 gallery entries

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
@@ -20,7 +20,7 @@
     "sorries": 1,
     "axiomCount": 0,
     "theoremCount": 18,
-    "lineCount": 257,
+    "lineCount": 260,
     "mathlibDependencies": [
       {
         "theorem": "Polynomial.irreducible_of_eisenstein_criterion",

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -23,7 +23,7 @@
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
     "assumptions": "Four open sorries: (1) hook_length_formula (LGV approach: requires SYT↔NI bijection + det factorization), (2) ni_count_eq_syt_count (Fomin/Viennot/RSK correspondence), (3) lgv_det_factors_as_hook_quotient (det factorization identity), (4) hook_walk_identity for 6+ rows (GNW or RSK, ~300 lines; 3-row case proved via hook_walk_identity_threeRow; 4-row case proved via hook_walk_identity_fourRow; 5-row case proved via hook_walk_identity_fiveRow; gHookYD case proved). hook_length_formula_general is proved modulo hook_walk_identity via Part XIV corner induction.",
-    "lineCount": 8109,
+    "lineCount": 9173,
     "theoremCount": 164,
     "definitionCount": 14,
     "originalContributions": [
@@ -94,7 +94,7 @@
       "LGV"
     ],
     "namespace": "HookLengthFormula",
-    "lineCount": 8109,
+    "lineCount": 9173,
     "axiomCount": 0,
     "sorries": 4,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",


### PR DESCRIPTION
## Fix

Two gallery entries had stale `lineCount` values that no longer matched their Lean source files.

## Evidence

**ballot-problem-oq-03-oq-01-oq-02**:
- Before: `meta.lineCount = 8109`, `leanFile.lineCount = 8109`
- After: `meta.lineCount = 9173`, `leanFile.lineCount = 9173`
- Actual `BallotProblemOQ03OQ01OQ02.lean` line count: 9173

**angle-trisection-oq-02-oq-01-oq-02-incomplete-01**:
- Before: `meta.lineCount = 257`
- After: `meta.lineCount = 260`
- Actual `AngleTrisectionOQ02OQ01OQ02Incomplete01.lean` line count: 260
- Note: `leanFile.lineCount` was already 260 (correct); only `meta.lineCount` was stale

---
Automated fix by lean-mechanic agent.