### PR TITLE
fix(ballot-jt-oq01): correct sorry count 3→2 in meta.json

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "ballot-problem-oq-03-oq-01-oq-01-oq-01",
   "title": "Jacobi-Trudi Identity: Schur Polynomials as Determinants of Complete Homogeneous Symmetric Polynomials",
   "slug": "ballot-problem-oq-03-oq-01-oq-01-oq-01",
-  "description": "Defines Schur polynomials via the Jacobi-Trudi determinant formula and the SSYT generating function. Proves key properties (symmetry, base cases, two-row formula, hook-length evaluation, k=0,1 SSYT bijections). The k=2 SSYT equality (ssytSchurFin_two_row) is proved but relies on 2 sorry'd private helpers (jdt_weight_sum and ssytFin_two_row_eq_sum_colstrict, ~200 lines total); the general k\u22653 case is open (algebraic LGV + RSK ~300 lines).",
+  "description": "Defines Schur polynomials via the Jacobi-Trudi determinant formula and the SSYT generating function. Proves key properties (symmetry, base cases, two-row formula, hook-length evaluation, k=0,1 SSYT bijections). 2 sorries remain: ssytSchurFin_two_row (k=2 SSYT equality directly sorry'd, ~80 lines estimated) and jacobi_trudi_ssyt_eq k\u22653 (RSK correspondence, ~300-400 lines).",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-24",
@@ -19,10 +19,10 @@
       "ssyt"
     ],
     "badge": "formalized",
-    "sorries": 3,
+    "sorries": 2,
     "dateAdded": "2026-04-23",
     "axiomCount": 0,
-    "assumptions": "3 sorries: (1) jdt_weight_sum (private: JDT involution weight sum for 2-row case); (2) ssytFin_two_row_eq_sum_colstrict (private: row decomposition bijection for k=2 SSYT, ~200 lines combined); (3) jacobi_trudi_ssyt_eq k\u22653 via algebraic LGV + RSK (~300 lines). Note: ssytSchurFin_two_row is proved but depends on these sorry'd helpers. k=0 and k=1 cases proved explicitly.",
+    "assumptions": "2 sorries: (1) ssytSchurFin_two_row: 2-row SSYT sum = Bender-Knuth Jacobi-Trudi formula (~80 lines, estimated); (2) jacobi_trudi_ssyt_eq k\u22653: RSK correspondence SSYT \u2194 non-intersecting lattice paths (~300-400 lines). k=0 and k=1 cases proved explicitly.",
     "lineCount": 457,
     "theoremCount": 11,
     "definitionCount": 5,
@@ -58,7 +58,7 @@
     ]
   },
   "conclusion": {
-    "summary": "Defines Schur polynomials via both Jacobi-Trudi formula and SSYT generating function. Proves symmetry, base cases (k=0,1 for both), two-row formula, hook-length evaluation, and k=1 SSYT bijection. 3 sorries: jdt_weight_sum and ssytFin_two_row_eq_sum_colstrict (private helpers for k=2 jdt bijection, ~200 lines) and jacobi_trudi_ssyt_eq k\u22653 (algebraic LGV + RSK, ~300 lines).",
+    "summary": "Defines Schur polynomials via both Jacobi-Trudi formula and SSYT generating function. Proves symmetry, base cases (k=0,1 for both), two-row formula, hook-length evaluation, and k=1 SSYT bijection. 2 sorries: ssytSchurFin_two_row (k=2 SSYT equality directly sorry'd, ~80 lines) and jacobi_trudi_ssyt_eq k\u22653 (RSK correspondence, ~300-400 lines).",
     "implications": "This provides: (1) the first Lean 4 Jacobi-Trudi matrix definition, (2) the first Lean 4 SSYT type for arbitrary partition shapes with Fintype instance, (3) the first formal statement that det[h_{\u03bb\u1d62-i+j}] = \u03a3_T weight(T) as a meaningful theorem. The remaining sorry precisely identifies the RSK correspondence for k \u2265 2 (~300 lines) as the key missing ingredient. A completed formalization would unlock: the Pieri rule $s_\\lambda h_n = \\sum_\\mu s_\\mu$, the Murnaghan-Nakayama rule, and connections to Schubert calculus via the existing LGV infrastructure in the gallery.",
     "openQuestions": [
       "Prove jacobi_trudi_ssyt_eq (general case, k \u2265 2): RSK correspondence SSYT \u2194 NI lattice path tuples for the LGV configuration, then weight matching with hsymm products"
@@ -83,7 +83,7 @@
     "theoremCount": 11,
     "definitionCount": 5,
     "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
-    "sorries": 3
+    "sorries": 2
   },
   "crossReferences": [
     {
@@ -167,8 +167,8 @@
       "startLine": 160,
       "endLine": 272,
       "summary": "Defines SSYTFin (bounded SSYT type with Fintype instance), ssytSchurFin (SSYT generating function), proves ssytSchurFin_empty (k=0), proves ssytSchurFin_one_row (k=1, bijection via sorted multiset reps), and states jacobi_trudi_ssyt_eq (general, sorry for k \u2265 2).",
-      "mathContext": "SSYTFin n k sh = subtype of ((i:Fin k)\u00d7Fin(sh i)\u2192Fin n) satisfying row-weak (weakly increasing rows) and col-strict (strictly increasing columns). Fintype instance via Subtype.fintype (decidable predicates over finite types). ssytSchurFin = \u2211_T T.weight where T.weight = \u220f_p X(T p). k=0 proved by Unique (empty SSYT, both conditions vacuous) + IsEmpty (empty product = 1). k=1 proved via Fintype.sum_equiv with bijection \u03c8: SSYTFin n 1 \u2243 Sym (Fin n) m using List.sortedLE_ofFn_iff (Monotone \u2194 SortedLE). k=2 case: ssytSchurFin_two_row is proved but depends on 2 sorry'd private helpers (jdt_weight_sum + ssytFin_two_row_eq_sum_colstrict). General case (k \u2265 3): RSK correspondence (~300 lines), 3 sorries total in file."
+      "mathContext": "SSYTFin n k sh = subtype of ((i:Fin k)\u00d7Fin(sh i)\u2192Fin n) satisfying row-weak (weakly increasing rows) and col-strict (strictly increasing columns). Fintype instance via Subtype.fintype (decidable predicates over finite types). ssytSchurFin = \u2211_T T.weight where T.weight = \u220f_p X(T p). k=0 proved by Unique (empty SSYT, both conditions vacuous) + IsEmpty (empty product = 1). k=1 proved via Fintype.sum_equiv with bijection \u03c8: SSYTFin n 1 \u2243 Sym (Fin n) m using List.sortedLE_ofFn_iff (Monotone \u2194 SortedLE). k=2 case: ssytSchurFin_two_row is directly sorry'd (~80 lines estimated). General case (k \u2265 3): RSK correspondence (~300-400 lines). 2 sorries total in file."
     }
   ],
-  "sorries": 3
+  "sorries": 2
 }


### PR DESCRIPTION
## Summary

- `meta.json` for `ballot-problem-oq-03-oq-01-oq-01-oq-01` claimed `"sorries": 3` but the Lean source (`BallotProblemOQ03OQ01OQ01.lean`) has exactly **2** sorries confirmed by auditor
- The original meta assumed 2 private helper sorries (`jdt_weight_sum` + `ssytFin_two_row_eq_sum_colstrict`) plus one theorem sorry — those private helpers were merged into a direct sorry on `ssytSchurFin_two_row`

## Changes

Updated 6 locations in `meta.json`:
1. Top-level `"sorries": 3` → `"sorries": 2`
2. `meta.sorries: 3` → `meta.sorries: 2`
3. `leanFile.sorries: 3` → `leanFile.sorries: 2`
4. `description`: updated to reflect `ssytSchurFin_two_row` is directly sorry'd (not via 2 private helpers)
5. `meta.assumptions`: updated from 3-sorry to 2-sorry description — (1) `ssytSchurFin_two_row` ~80 lines, (2) `jacobi_trudi_ssyt_eq` k≥3 RSK ~300-400 lines
6. `conclusion.summary` and `sections[sec-ssyt-definition].mathContext`: updated sorry counts and descriptions

## Actual sorries in Lean file
- Line 330: `ssytSchurFin_two_row` — directly sorry'd
- Line 391: `jacobi_trudi_ssyt_eq` for k≥3 — RSK correspondence sorry

🤖 Generated with [Claude Code](https://claude.com/claude-code)