### PR TITLE
fix(shannon-source-coding-oq-04): correct stale sorry count 1→2 and lineCount 414→352

### DIFF
--- a/src/data/proofs/shannon-source-coding-oq-04/meta.json
+++ b/src/data/proofs/shannon-source-coding-oq-04/meta.json
@@ -177,12 +177,12 @@
       "BigOperators"
     ],
     "namespace": "MethodOfTypes",
-    "lineCount": 414,
+    "lineCount": 352,
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 4,
     "path": "Proofs/ShannonSourceCodingOQ04.lean",
-    "sorries": 1
+    "sorries": 2
   },
   "references": [
     {


### PR DESCRIPTION
## Integrity Fix

**Proof**: shannon-source-coding-oq-04
**Issue**: meta.json leanFile.sorries and lineCount don't match the actual Lean file.

## Evidence

**meta.json claims** (after commit #12645):
- `leanFile.sorries: 1`
- `leanFile.lineCount: 414`

**Lean file (ShannonSourceCodingOQ04.lean) shows**:
- 2 sorries (lines 91 and 309)
- 352 lines

## Root Cause

Commit #12645 updated meta.json to claim Aristotle had proved `type_class_size_eq_multinomial`, but **the Lean file was never modified** in that commit. The sorry at line 91 is still present in the source.

## Fix

Reverts `leanFile.sorries` to 2 and `leanFile.lineCount` to 352 to match the actual Lean source.

---
Discovered during gallery integrity audit.