### PR TITLE
Fix: correct stale lineCount in 2 gallery entries

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -23,7 +23,7 @@
     "dateAdded": "2026-04-23",
     "axiomCount": 0,
     "assumptions": "2 sorries: (1) ssytSchurFin_two_row: 2-row SSYT sum = Bender-Knuth Jacobi-Trudi formula (~80 lines, estimated); (2) jacobi_trudi_ssyt_eq k\u22653: RSK correspondence SSYT \u2194 non-intersecting lattice paths (~300-400 lines). k=0 and k=1 cases proved explicitly.",
-    "lineCount": 457,
+    "lineCount": 393,
     "theoremCount": 11,
     "definitionCount": 5,
     "originalContributions": [
@@ -78,7 +78,7 @@
       "Finset"
     ],
     "namespace": "JacobiTrudi",
-    "lineCount": 457,
+    "lineCount": 393,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 5,

--- a/src/data/proofs/shannon-source-coding-oq-04/meta.json
+++ b/src/data/proofs/shannon-source-coding-oq-04/meta.json
@@ -177,12 +177,12 @@
       "BigOperators"
     ],
     "namespace": "MethodOfTypes",
-    "lineCount": 414,
+    "lineCount": 352,
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 4,
     "path": "Proofs/ShannonSourceCodingOQ04.lean",
-    "sorries": 1
+    "sorries": 2
   },
   "references": [
     {


### PR DESCRIPTION
## Fix

Corrects stale `lineCount` and `sorries` metadata in two gallery entries found via full-gallery lineCount scan (2162 entries checked).

## Evidence

**ballot-problem-oq-03-oq-01-oq-01-oq-01**:
- `meta.lineCount`: 457 → 393
- `leanFile.lineCount`: 457 → 393
- `BallotProblemOQ03OQ01OQ01OQ01.lean`: 393 actual lines

**shannon-source-coding-oq-04**:
- `leanFile.lineCount`: 414 → 352
- `leanFile.sorries`: 1 → 2
- `ShannonSourceCodingOQ04.lean`: 352 actual lines, 2 `sorry` statements (lines 91 and 309)

---
Automated fix by lean-mechanic agent.