### PR TITLE
fix(auditor): correct stale metadata — ballot lineCount 457→393, lebesgue sorries 2→4

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -23,7 +23,7 @@
     "dateAdded": "2026-04-23",
     "axiomCount": 0,
     "assumptions": "2 sorries: (1) ssytSchurFin_two_row: 2-row SSYT sum = Bender-Knuth Jacobi-Trudi formula (~80 lines, estimated); (2) jacobi_trudi_ssyt_eq k\u22653: RSK correspondence SSYT \u2194 non-intersecting lattice paths (~300-400 lines). k=0 and k=1 cases proved explicitly.",
-    "lineCount": 457,
+    "lineCount": 393,
     "theoremCount": 11,
     "definitionCount": 5,
     "originalContributions": [
@@ -78,7 +78,7 @@
       "Finset"
     ],
     "namespace": "JacobiTrudi",
-    "lineCount": 457,
+    "lineCount": 393,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 5,

--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -18,10 +18,10 @@
       "research"
     ],
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 4,
     "axiomCount": 0,
-    "lineCount": 1136,
-    "assumptions": "2 sorries: orbit_ne (Hausdorff 1914 orbit connection bridge — reduced from full freeness sorry to a targeted connection between integer ℤ[√2]³ orbit and real SO(3) action), banach_tarski (Banach-Tarski 1924 — main paradox, requires AC). Core framework fully proved. New session (17): added complete orbit invariant infrastructure for Hausdorff freeness — 4 scaled integer actions (scaledActPhi/PhiInv/Psi/PsiInv) in ℤ[√2]³, 4 mod-3 invariant predicates (inv_phi/phi_inv/psi/psi_inv), 12 valid transition lemmas (all by simp+omega), 4 base cases, e2Int_no_inv, injectivity argument from orbit_ne.",
+    "lineCount": 563,
+    "assumptions": "4 sorries: (1) hausdorff_free_subgroup (Hausdorff 1914 free subgroup F₂ ↪ SO(3)); (2) banach_tarski (Banach-Tarski 1924 main paradox, requires AC); (3) banach_tarski_pieces_nonmeasurable (non-measurability of decomposition pieces); (4) int_amenable (ℤ amenable via Cesàro mean). Note: a previous version of this file (1136 lines) had proofs for banach_tarski_pieces_nonmeasurable and int_amenable; the current file regressed to 4 sorries after a sync operation.",
     "dateAdded": "2026-04-22",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -108,7 +108,7 @@
     }
   ],
   "conclusion": {
-    "summary": "The Banach-Tarski paradox is formalized with 2 sorries and 0 axioms. The abstract framework (equidecomposability, paradoxical sets, F₂ non-amenability) is fully proved — including complete machine-checked proofs of paradoxical_no_finite_measure, free_group_not_amenable, int_amenable (ℤ amenable via Cesàro window-shift), and banach_tarski_pieces_nonmeasurable (proved via cardinality contradiction: Borel σ-algebra has ≤ 𝔠 Borel sets while unitBall3 has 2^𝔠 subsets). The 2 remaining sorry theorems are deep established results (Hausdorff 1914 free subgroup, Banach-Tarski 1924 main paradox) whose Lean proofs require 150–800 lines each.",
+    "summary": "The Banach-Tarski paradox is formalized with 4 sorries and 0 axioms. The abstract framework (equidecomposability, paradoxical sets, F₂ non-amenability) is partially proved — including complete machine-checked proofs of paradoxical_no_finite_measure and free_group_not_amenable. Four theorems remain sorry'd: hausdorff_free_subgroup, banach_tarski, banach_tarski_pieces_nonmeasurable, and int_amenable. Note: a prior version of this file had machine-checked proofs for banach_tarski_pieces_nonmeasurable and int_amenable; the file regressed to 4 sorries after a sync operation (see PR #12658).",
     "openQuestions": [
       "Can Hausdorff's free subgroup theorem be fully formalized in Lean? The proof requires showing that explicit 3×3 rotation matrices $\\varphi$ (rotation by $\\arccos(1/3)$ around the $z$-axis) and $\\psi$ (rotation by $\\arccos(1/3)$ around the $x$-axis) generate a free group of rank 2 in $\\text{SO}(3)$. The algebraic argument shows that nontrivial words $w(\\varphi, \\psi)$ applied to $e_1 = (1, 0, 0)$ produce vectors with coordinates in $\\mathbb{Z}[1/3, \\sqrt{2}/3]$ that are non-zero — requiring careful case analysis on the word structure and number-theoretic properties of $\\arccos(1/3)$ (specifically that it is not a rational multiple of $\\pi$).",
       "Can the full Banach-Tarski proof be formalized in Lean 4? The most likely modular path: (1) formalize the free subgroup freeness (the sorry in `hausdorff_free_subgroup`); (2) prove the paradoxical decomposition of $F_2$ acting on itself (purely algebraic, ~100 lines); (3) lift to $S^2 \\setminus D$ via the free group action (~150 lines); (4) handle the exceptional set $D$ via a rotation of infinite order (Hilbert hotel, ~100 lines); (5) extend from $S^2$ to $B^3$ by coning and handling the center (~100 lines). Estimated total: 800–1200 lines.",
@@ -203,12 +203,12 @@
       "Mathlib"
     ],
     "namespace": "BanachTarski",
-    "lineCount": 1136,
+    "lineCount": 563,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 9,
     "path": "Proofs/LebesgueMeasureOQ06.lean",
-    "sorries": 2
+    "sorries": 4
   },
-  "sorries": 2
+  "sorries": 4
 }


### PR DESCRIPTION
## Integrity Fix

Two gallery entries with stale metadata discovered during audit.

### ballot-problem-oq-03-oq-01-oq-01-oq-01

**Problem**: `lineCount` is stale after Lean file was refactored in #12646.
- meta.json claimed: `lineCount: 457`
- Lean file actual: 393 lines
- Fix: `lineCount: 457 → 393`

### lebesgue-measure-oq-06

**Problem**: `sorries` and `lineCount` don't match the current Lean file. The "chore: sync" commit #12658 replaced the Lean file (1136 → 563 lines) but did not update meta.json. Additionally, the replacement regressed two previously-proved theorems back to `sorry`:
- `banach_tarski_pieces_nonmeasurable` — had a machine-checked proof via cardinality contradiction
- `int_amenable` — had a machine-checked proof via Cesàro window-shift

**Evidence**:
- meta.json claimed: `sorries: 2`, `lineCount: 1136`
- Lean file actual: 4 proof-term sorries, 563 lines
- Pre-sync file (commit `fd9993d274f`): 1136 lines, 2 proof-term sorries ✓

**Fix**: Updated `sorries: 2→4`, `lineCount: 1136→563`, and narrative text to reflect current state.

> **Note**: A separate issue should investigate whether the sync commit #12658 accidentally replaced a more complete version of `LebesgueMeasureOQ06.lean`. The pre-sync file had machine-checked proofs for `banach_tarski_pieces_nonmeasurable` and `int_amenable` that the current file lacks.

---
Discovered during gallery integrity audit.