### PR TITLE
fix(angle-trisection-oq-02-oq-01-oq-02-incomplete-01): correct sorry count 1→2 in meta.json

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
@@ -2,7 +2,7 @@
   "id": "angle-trisection-oq-02-oq-01-oq-02-incomplete-01",
   "title": "Completing the Wantzel-Galois Constructibility Proof",
   "slug": "angle-trisection-oq-02-oq-01-oq-02-incomplete-01",
-  "description": "Completes the parent Wantzel-Galois proof (angle-trisection-oq-02-oq-01-oq-02) by proving not_constructible_of_bad_degree via a redesigned IsConstructible inductive that enables proper induction. Reduces parent's 5 sorries to 1. All concrete impossibility results (angle trisection, cube doubling, regular 7-gon) are fully proved.",
+  "description": "Completes the parent Wantzel-Galois proof (angle-trisection-oq-02-oq-01-oq-02) by proving not_constructible_of_bad_degree via a redesigned IsConstructible inductive that enables proper induction. Reduces parent's 5 sorries to 2. All concrete impossibility results (angle trisection, cube doubling, regular 7-gon) are fully proved.",
   "meta": {
     "author": "Wantzel (1837), completion formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Straightedge_and_compass_construction",
@@ -17,7 +17,7 @@
     ],
     "proofRepoPath": "Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 2,
     "axiomCount": 0,
     "theoremCount": 18,
     "lineCount": 260,
@@ -103,7 +103,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Reduces the parent's 5 sorries to 1 by: (1) redesigning IsConstructible to enable induction, (2) proving not_constructible_of_bad_degree via the rationality argument, (3) proving Eisenstein irreducibility for X³-2, (4) computing all three polynomial degrees. The remaining sorry (wantzel_galois_iff) requires the full Galois correspondence and is out of scope.",
+    "summary": "Reduces the parent's 5 sorries to 2 by: (1) redesigning IsConstructible to enable induction, (2) proving not_constructible_of_bad_degree via the rationality argument, (3) proving Eisenstein irreducibility for X³-2, (4) computing all three polynomial degrees. The remaining sorry (wantzel_galois_iff) requires the full Galois correspondence and is out of scope.",
     "implications": "The three classical impossibility results — angle trisection, cube doubling, regular 7-gon — are now fully proved (0 axioms) in this file. The proof demonstrates that the IsConstructible definition choice is critical: existential vs explicit constructors has dramatic consequences for what can be proved by induction.",
     "openQuestions": [
       "Can wantzel_galois_iff be proved using Mathlib's IntermediateField.orderIsoOfGal and Sylow theory for 2-groups?",
@@ -141,7 +141,7 @@
     "theoremCount": 18,
     "definitionCount": 3,
     "path": "Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
-    "sorries": 1
+    "sorries": 2
   },
-  "sorries": 1
+  "sorries": 2
 }


### PR DESCRIPTION
PR #12653 fixed the `IsConstructible` definition and added a second sorry (`isConstructible_algebraic_degree` at line 282), but `meta.json` was not updated to reflect this.

**Changes:**
- Top-level `sorries`: 1 → 2
- `leanFile.sorries`: 1 → 2
- `description`: "Reduces parent's 5 sorries to 1" → "...to 2"
- `conclusion.summary`: "Reduces the parent's 5 sorries to 1 by:" → "...to 2 by:"

🤖 Generated with [Claude Code](https://claude.com/claude-code)