### PR TITLE
enrichment: basel-problem-oq-04 pass 2 — cross-references and Riemann context

### DIFF
--- a/src/data/proofs/basel-problem-oq-04/annotations.json
+++ b/src/data/proofs/basel-problem-oq-04/annotations.json
@@ -1,5 +1,31 @@
 [
   {
+    "id": "ann-mathematical-context",
+    "proofId": "basel-problem-oq-04",
+    "range": {
+      "startLine": 1,
+      "endLine": 21
+    },
+    "type": "context",
+    "title": "Mathematical Setting: Euler Product and Riemann Zeta at s=2",
+    "content": "The module docstring states the core identity ∏_p (1-p⁻²)⁻¹ = π²/6 and identifies the two Mathlib theorems that make it a two-line proof: `riemannZeta_eulerProduct_tprod` (Euler product for ζ(s)) and `riemannZeta_two` (ζ(2) = π²/6). The references cite Euler's 1737 paper 'Variae observationes circa series infinitas', the first appearance of the product formula.\n\nThis entry is one of a sibling family: `basel-problem` proves the sum ∑ 1/n² = π²/6, `geometric-series-oq-03` derives the Euler product via geometric series, and this entry (`oq-04`) combines them at s=2. Together they cover Euler's complete 1737 argument.\n\nThe proof is stated over ℂ (not ℝ) because Mathlib's `riemannZeta` function is defined as a meromorphic function on all of ℂ, and the Euler product theorem is proved in that generality. The specialization to s=2 is then a corollary. This generality connects this entry to the Riemann hypothesis: ζ(s) has non-trivial zeros only for 0 < Re(s) < 1 (conjectured to all lie on Re(s) = 1/2), and the Euler product ∏_p (1-p⁻ˢ)⁻¹ = ζ(s) holds only for Re(s) > 1 (where ζ(s) ≠ 0). The zeros of ζ(s) are exactly where the product formula breaks down.",
+    "mathContext": "The Riemann zeta function: $\\zeta(s) = \\sum_{n=1}^\\infty n^{-s}$ for $\\text{Re}(s) > 1$, extended meromorphically to $\\mathbb{C} \\setminus \\{1\\}$. Euler product: $\\zeta(s) = \\prod_p (1-p^{-s})^{-1}$ for $\\text{Re}(s) > 1$ (absolute convergence region). At $s = 2$: $\\zeta(2) = \\pi^2/6$ (Basel). The Riemann Hypothesis asserts the non-trivial zeros of $\\zeta(s)$ all satisfy $\\text{Re}(s) = 1/2$. Mathlib: `riemannZeta : ℂ → ℂ` (module `Mathlib.NumberTheory.ZetaFunctions.RiemannZeta`).",
+    "significance": "context",
+    "relatedConcepts": [
+      "Riemann zeta function",
+      "Euler product",
+      "Basel problem",
+      "Riemann Hypothesis",
+      "meromorphic extension",
+      "analytic number theory"
+    ],
+    "prerequisites": [
+      "complex analysis (meromorphic functions)",
+      "Dirichlet series convergence for Re(s) > 1",
+      "Mathlib.NumberTheory.ZetaFunctions.RiemannZeta"
+    ]
+  },
+  {
     "id": "ann-imports-helper",
     "proofId": "basel-problem-oq-04",
     "range": {

--- a/src/data/proofs/basel-problem-oq-04/meta.json
+++ b/src/data/proofs/basel-problem-oq-04/meta.json
@@ -129,6 +129,31 @@
       "proofId": "basel-problem",
       "relationship": "parent",
       "description": "Parent: the Basel sum ∑ 1/n² = π²/6"
+    },
+    {
+      "targetId": "geometric-series-oq-03",
+      "relationship": "related",
+      "description": "Companion entry formalizing the Euler product ∏_p (1-p⁻ˢ)⁻¹ = ζ(s) via the geometric series expansion (1-p⁻ˢ)⁻¹ = ∑_k p⁻ˢᵏ and unique factorization — the same mathematical argument underlying this proof."
+    },
+    {
+      "targetId": "fundamental-arithmetic",
+      "relationship": "foundational-for",
+      "description": "Unique prime factorization is the key ingredient enabling Euler's product identity: every integer has a unique factorization, so ∏_p ∑_k p⁻ˢᵏ = ∑_n n⁻ˢ with each n appearing exactly once."
+    },
+    {
+      "targetId": "dirichlets-theorem",
+      "relationship": "generalization",
+      "description": "Dirichlet's theorem on primes in progressions uses L-functions L(s,χ) = ∏_p (1-χ(p)p⁻ˢ)⁻¹ — the direct generalization of the Euler product twisted by a Dirichlet character χ."
+    },
+    {
+      "targetId": "harmonic-divergence",
+      "relationship": "related",
+      "description": "At s=1, the Euler product ∏_p (1-p⁻¹)⁻¹ = ζ(1) diverges (harmonic series), establishing ∑ 1/p = ∞ and proving infinitely many primes. The current proof at s=2 is the convergent counterpart, where the product value π²/6 encodes the coprimality density 6/π²."
+    },
+    {
+      "targetId": "euler-totient-oq-02-oq-01",
+      "relationship": "related",
+      "description": "Euler's totient product formula φ(n)/n = ∏_{p|n} (1-1/p) is a finite multiplicative analogue of the Euler product. The infinite product ∏_p (1-1/p²) = 6/π² appearing here is the probabilistic form of the same multiplicative structure."
     }
   ],
   "sorries": 0,


### PR DESCRIPTION
## Summary

Second-pass enrichment of `basel-problem-oq-04` (Euler Product Form of the Basel Problem):

**meta.json: 5 new cross-references** (was 1, now 6)
- `geometric-series-oq-03` — companion entry proving Euler product via geometric series (same mathematical argument)
- `fundamental-arithmetic` — unique prime factorization enables the product identity
- `dirichlets-theorem` — L-functions L(s,χ) = ∏_p (1-χ(p)p⁻ˢ)⁻¹ generalize the Euler product
- `harmonic-divergence` — divergent s=1 counterpart: ∏_p (1-p⁻¹)⁻¹ diverges, proving ∑ 1/p = ∞
- `euler-totient-oq-02-oq-01` — φ(n)/n = ∏_{p|n} (1-1/p) is a finite multiplicative analogue

**annotations.json: new context annotation** (lines 1–21)
- Situates the proof in Mathlib's analytic number theory infrastructure
- Explains why Mathlib states the Euler product over ℂ (meromorphic extension)
- Connects to the Riemann Hypothesis: zeros of ζ(s) are exactly where the Euler product breaks down
- Cross-references the sibling Basel family (basel-problem, geometric-series-oq-03, this entry)

## Labels

enrichment