### PR TITLE
enrichment: shapley-folkman — full annotation coverage

### DIFF
--- a/src/data/proofs/shapley-folkman/annotations.json
+++ b/src/data/proofs/shapley-folkman/annotations.json
@@ -109,5 +109,81 @@
       "core convergence",
       "convex relaxation"
     ]
+  },
+  {
+    "id": "ann-infra-depth",
+    "proofId": "shapley-folkman",
+    "range": {
+      "startLine": 161,
+      "endLine": 361
+    },
+    "type": "concept",
+    "title": "minCaraDepth: The Well-Founded Measure Driving the Induction",
+    "content": "The infrastructure section (161-361) establishes the well-founded measure `minCaraDepth` that makes the main induction terminate. Key components:\n\n1. `linearDependent_coefficients`: for affinely dependent points in ℝ^d, extracts explicit coefficients (∑λ_i·p_i = 0, ∑λ_i = 0, not-all-zero) via `not_affineIndependent_iff`.\n\n2. `exists_decomposition`: any element of conv(S) has a Caratheodory representation as a convex combination of ≤ d+1 points from S.\n\n3. `binary_repr_of_mem_convexHull_not_mem`: when x ∈ conv(S) \\ S, there exists a convex representation with ≥ 2 non-zero weights.\n\n4. `minCaraDepth` (sInf-based): the minimum number of points needed to represent x ∈ conv(S) as a convex combination of points from S. This is the induction measure.\n\n5. `minCaraDepth_le_of_repr`, `minCaraDepth_ge_two`: bounds on the depth. The `binary_repr_depth` lemma is crucial — it shows that for excess indices, we can produce a representation where the 'remainder' after perturbation has strictly smaller minCaraDepth, giving the well-foundedness needed for the main proof.",
+    "mathContext": "`minCaraDepth(x, S) = inf{n : ∃ p_1,...,p_n ∈ S, ∃ w_1,...,w_n ≥ 0 with ∑w_i=1 and ∑w_i·p_i = x}`. For x ∈ conv(S) \\ S, this is ≥ 2. The Caratheodory bound gives depth ≤ dim+1. The key property: if we perturb a representation using a linear dependence relation, at least one weight hits zero, strictly reducing the depth. This descent argument is what makes `reduce_excess_by_one` work.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "minCaraDepth",
+      "Caratheodory representation",
+      "affine dependence",
+      "well-founded induction",
+      "convex combination"
+    ],
+    "prerequisites": [
+      "AffineIndependent in Mathlib",
+      "convexHull membership",
+      "sInf as infimum in ℕ"
+    ]
+  },
+  {
+    "id": "ann-reduction-step",
+    "proofId": "shapley-folkman",
+    "range": {
+      "startLine": 362,
+      "endLine": 1130
+    },
+    "type": "insight",
+    "title": "reduce_excess_by_one: The 770-Line Core Reduction",
+    "content": "`reduce_excess_by_one` is the heart of the proof (770 lines). Given a decomposition with k > d excess indices, it produces a new decomposition with k-1 excess indices.\n\n**Proof architecture** (5 phases):\n\n1. **Binary representations** (362-450): For each excess index i, invoke `binary_repr_of_mem_convexHull_not_mem` to get a convex representation with ≥ 2 non-zero weights. Bundle these into a finite family.\n\n2. **Dimension argument** (451-600): The excess indices give > d vectors in ℝ^d. By `not_affineIndependent_iff`, extract explicit affine dependence coefficients λ_i with ∑λ_i·f_i = 0 and ∑λ_i = 0 (not-all-zero). Here f_i are the 'extra' points from each excess index's representation.\n\n3. **ε computation** (601-750): For each excess index, the representation has weights w_i ≥ 0 summing to 1. The perturbation δ_i = ε·λ_i·(shifted vector) must keep all weights non-negative. Compute ε = min over boundary constraints (smallest ratio w_i/|λ_i| where λ_i ≠ 0).\n\n4. **Perturbation** (751-900): Perturb each excess index's representation by ε·λ. The key identity: since ∑λ_i·(affine terms) = 0, the sum ∑x_i is preserved. The total sum equals x.\n\n5. **Case split** (901-1130): After perturbation, **Case A**: at least one previously-excess index now has a 1-point representation (weight on a single point = 1), moving it into its original set. **Cases B1/B2**: an excess index reduces its minCaraDepth by at least 1. Either way, total 'depth budget' decreases. Recursive application terminates.\n\nThe 770-line length reflects exhaustive case analysis on which index achieves the minimum ε and whether it resolves completely.",
+    "mathContext": "The sum-preservation identity: $\\sum_i x_i + \\epsilon \\sum_i \\lambda_i \\delta_i = \\sum_i x_i$ because $\\sum_i \\lambda_i = 0$ (affine dependence condition). The ε-choice ensures $w_{ij} - \\epsilon \\lambda_i \\geq 0$ for all weights, while $\\min_j(w_{ij}/\\lambda_i)$ achieves 0 for at least one $(i,j)$, reducing representation size. Total induction measure: $M = \\sum_{i \\in \\text{excess}} \\text{minCaraDepth}(x_i, S_i)$. Each application of `reduce_excess_by_one` either decreases $|\\text{excess}|$ by 1 (Case A) or decreases $M$ (Cases B1/B2). Since both are bounded below by 0, termination follows.",
+    "significance": "key",
+    "relatedConcepts": [
+      "reduce_excess_by_one",
+      "affine dependence perturbation",
+      "epsilon computation",
+      "minCaraDepth descent",
+      "sum preservation"
+    ],
+    "prerequisites": [
+      "minCaraDepth infrastructure",
+      "linearDependent_coefficients",
+      "binary_repr_of_mem_convexHull_not_mem",
+      "Finset.sum preservation under zero-sum perturbation"
+    ]
+  },
+  {
+    "id": "ann-main-and-corollaries",
+    "proofId": "shapley-folkman",
+    "range": {
+      "startLine": 1131,
+      "endLine": 1238
+    },
+    "type": "theorem",
+    "title": "shapley_folkman + Corollaries: Assembling the Final Theorems",
+    "content": "The final 108 lines assemble the main theorem and two corollaries from `reduce_excess_by_one`.\n\n**`shapley_folkman`** (1131-1180): Simple induction on excess count. If a decomposition has k > d excess indices, apply `reduce_excess_by_one` to get k-1. By induction, reach k ≤ d. Lean proof: structural induction on a natural number bound, applying the reduction each step.\n\n**`sum_close_to_convexHull`** (1181-1210): Given N sets S_i and x ∈ conv(∑S_i), there exist x_i ∈ conv(S_i) with ∑x_i = x and |excessIndices| ≤ finrank(ℝ, E). This is the direct statement of Shapley-Folkman.\n\n**`repeated_sum_nearly_convex`** (1211-1238): For a single set S and x ∈ conv(n·S) = n·conv(S), there exist f_1,...,f_n ∈ conv(S) with ∑f_i = x and |{i : f_i ∉ S}| ≤ finrank(ℝ, E). This is the economics corollary: as n grows, the fraction d/n of 'non-convex' agents vanishes.\n\nThe main theorem's Lean proof is remarkably short given the 1130-line setup — the heavy lifting is entirely in `reduce_excess_by_one`. The induction is clean because the reduction is a clean function from decomposition to decomposition.",
+    "mathContext": "The induction scheme: define $M(D) = \\max(0, |\\text{excessIndices}(D)| - d)$. When $M(D) > 0$, apply `reduce_excess_by_one` to get $D'$ with $M(D') < M(D)$. Terminal condition $M(D) = 0$ means $|\\text{excessIndices}(D)| \\leq d = \\text{finrank}(\\mathbb{R}, E)$. For `repeated_sum_nearly_convex`: $\\text{conv}(nS) = n \\cdot \\text{conv}(S)$ is used to reduce to the general theorem with $N = n$ identical sets, each equal to $S$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "shapley_folkman",
+      "sum_close_to_convexHull",
+      "repeated_sum_nearly_convex",
+      "Module.finrank",
+      "Decomposition.excessIndices"
+    ],
+    "prerequisites": [
+      "reduce_excess_by_one",
+      "Induction on natural number bound",
+      "conv(nS) = n·conv(S) identity"
+    ]
   }
 ]

--- a/src/data/proofs/shapley-folkman/meta.json
+++ b/src/data/proofs/shapley-folkman/meta.json
@@ -90,7 +90,10 @@
       "**Same technique as Caratheodory**: The proof is a direct generalization of Caratheodory's 'reduce affine dependence' argument, applied across multiple sets simultaneously rather than within a single convex hull.",
       "**Minimality + affine dependence = powerful combination**: Choosing the minimal-vertex decomposition and deriving a contradiction from excess is a clean proof pattern reusable in many convex geometry results.",
       "**Economic interpretation**: In an economy with $N$ agents in $\\mathbb{R}^d$, each agent's preferred bundle may not be convex (indivisible goods). But the aggregate allocation (Minkowski sum) is nearly convex: at most $d$ agents need 'fractional' allocations. As $N \\to \\infty$, the fraction of agents requiring convexification goes to 0.",
-      "**Quantitative refinement (Starr)**: The Shapley-Folkman-Starr theorem adds a Hausdorff distance bound: $d_H(\\sum S_i, \\text{conv}(\\sum S_i)) \\leq \\sqrt{\\sum_{\\text{top } d} r(S_i)^2}$ where $r(S_i)$ is the inner radius. This makes the 'nearly convex' intuition precise."
+      "**Quantitative refinement (Starr)**: The Shapley-Folkman-Starr theorem adds a Hausdorff distance bound: $d_H(\\sum S_i, \\text{conv}(\\sum S_i)) \\leq \\sqrt{\\sum_{\\text{top } d} r(S_i)^2}$ where $r(S_i)$ is the inner radius. This makes the 'nearly convex' intuition precise.",
+      "minCaraDepth (sInf over representation sizes) is the well-founded descent measure — each application of reduce_excess_by_one strictly decreases either the excess count or the total depth budget",
+      "The sum ∑x_i is preserved under affine-dependence perturbations because ∑λ_i = 0 (the affine condition) makes the perturbation sum zero",
+      "The 770-line reduce_excess_by_one dominates the proof length — the main theorem is just clean induction once this reduction is established"
     ],
     "prerequisites": [
       "Convex sets and convex hulls",
@@ -139,6 +142,27 @@
       "endLine": 158,
       "summary": "Two corollaries: (1) the qualitative Shapley-Folkman-Starr form for points in conv(sum Si); (2) the economic application for n-fold sums of a single set, showing that large averages are nearly convex regardless of n.",
       "mathContext": "Corollary 1: $x \\in \\text{conv}(\\sum S_i) \\Rightarrow x = \\sum f_i$ with at most $d$ non-original terms. Corollary 2: For $x \\in \\text{conv}(nS)$, at most $d$ of the $n$ terms need convexification. As $n \\to \\infty$, fraction $d/n \\to 0$."
+    },
+    {
+      "id": "cara-infrastructure",
+      "title": "Caratheodory Infrastructure and minCaraDepth",
+      "startLine": 159,
+      "endLine": 361,
+      "summary": "Establishes the well-founded induction measure `minCaraDepth` (sInf over representation sizes) and supporting lemmas: `linearDependent_coefficients` (explicit affine dependence coefficients via not_affineIndependent_iff), `exists_decomposition` (Caratheodory bound d+1), `binary_repr_of_mem_convexHull_not_mem` (≥2 nonzero weights for excess points), and `binary_repr_depth` (perturbation strictly reduces depth). These provide the termination guarantee for the main reduction."
+    },
+    {
+      "id": "reduce-excess",
+      "title": "Core Reduction: reduce_excess_by_one",
+      "startLine": 362,
+      "endLine": 1130,
+      "summary": "The 770-line proof that any decomposition with k > d excess indices can be reduced to one with k-1 excess indices. Phases: (1) binary representations for excess points, (2) affine dependence extraction from d+1 points in ℝ^d, (3) ε computation (min over boundary constraints), (4) sum-preserving perturbation (∑λ_i=0 ensures total preserved), (5) case analysis showing either an index joins its original set or its minCaraDepth strictly decreases. The induction measure M = max(0, |excess| - d) + Σ minCaraDepth is strictly decreasing."
+    },
+    {
+      "id": "main-assembly",
+      "title": "Main Theorem and Corollaries",
+      "startLine": 1131,
+      "endLine": 1238,
+      "summary": "Three final results assembled by induction on reduce_excess_by_one: `shapley_folkman` (the core lemma, induction on excess count), `sum_close_to_convexHull` (the standard statement: ∃ decomposition with |excess| ≤ finrank(ℝ,E)), and `repeated_sum_nearly_convex` (for n copies of S: at most d agents need fractional allocations, ratio d/n→0). The main theorem's proof is short because all complexity is in reduce_excess_by_one."
     }
   ],
   "references": [


### PR DESCRIPTION
## Summary

- Adds 3 new annotations to `shapley-folkman/annotations.json` (5→8 total), covering lines 161-1238 of `ShapleyFolkman.lean`
- Extends `meta.json` sections (5→8) and keyInsights (5→8) for complete file coverage
- New annotations: `ann-infra-depth` (minCaraDepth measure), `ann-reduction-step` (reduce_excess_by_one core), `ann-main-and-corollaries` (final assembly)

## Coverage

| Lines | Content |
|-------|---------|
| 161-361 | Caratheodory infrastructure: minCaraDepth, linearDependent_coefficients, binary_repr_depth |
| 362-1130 | reduce_excess_by_one: 5-phase 770-line core reduction |
| 1131-1238 | shapley_folkman, sum_close_to_convexHull, repeated_sum_nearly_convex |

🤖 Generated with [Claude Code](https://claude.com/claude-code)