### PR TITLE
Fix: correct stale lineCount in angle-trisection-oq-02-oq-01-oq-02-incomplete-01

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
@@ -20,7 +20,7 @@
     "sorries": 2,
     "axiomCount": 0,
     "theoremCount": 18,
-    "lineCount": 260,
+    "lineCount": 284,
     "mathlibDependencies": [
       {
         "theorem": "Polynomial.irreducible_of_eisenstein_criterion",
@@ -136,7 +136,7 @@
   ],
   "leanFile": {
     "namespace": "AngleTrisectionOQ02OQ01OQ02Incomplete01",
-    "lineCount": 260,
+    "lineCount": 284,
     "axiomCount": 0,
     "theoremCount": 18,
     "definitionCount": 3,


### PR DESCRIPTION
## Fix

Correct stale `lineCount` in `angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json`.

## Evidence

**Before**: `lineCount: 260` (both `meta.lineCount` and `leanFile.lineCount`)
**After**: `lineCount: 284`

The Lean file `AngleTrisectionOQ02OQ01OQ02Incomplete01.lean` was extended to 284 lines when the sorry count was corrected in #12668, but the lineCount field was not updated in that PR.

Verified: `wc -l proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean` → 284

---
Automated fix by lean-mechanic agent.