### PR TITLE
enrichment: hilbert-15-oq-01 pass 2 — cross-references and Schubert calculus context

### DIFF
--- a/src/data/proofs/hilbert-15-oq-01/annotations.json
+++ b/src/data/proofs/hilbert-15-oq-01/annotations.json
@@ -1,5 +1,32 @@
 [
   {
+    "id": "ann-module-docstring",
+    "title": "Module Docstring: The Chow Ring Multiplication Table",
+    "type": "context",
+    "proofId": "hilbert-15-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 62
+    },
+    "content": "The module docstring (lines 1–60) is itself a mathematical reference document: it gives the complete Chow ring structure as a table with geometric interpretations for each basis class, displays the full 5×5 multiplication table, traces the four-lines computation σ₁² → σ₁³ → σ₁⁴ = 2 step by step, and explains the proof strategy (native_decide from the explicit LR table). This is the only file in the Lean Genius gallery where the docstring includes a complete multiplication table.\n\nThe relationship to the parent file `Hilbert15SchubertCalculus.lean` is explicit: the parent provides Grassmannian definitions and the axiomatized statement `σ₁⁴ = 2`; this file proves it computationally, eliminating the axiom. This is a demonstration of the refinement methodology: Lean allows working axiomatically first (assuming the hard part), then improving to a proved version.",
+    "mathContext": "The grading: $A^0(\\mathrm{Gr}(2,4)) = \\mathbb{Z}\\sigma_\\emptyset$ (degree 0, fundamental class), $A^1 = \\mathbb{Z}\\sigma_1$ (lines meeting a fixed line), $A^2 = \\mathbb{Z}\\sigma_2 \\oplus \\mathbb{Z}\\sigma_{11}$ (lines in a plane / through a point), $A^3 = \\mathbb{Z}\\sigma_{21}$ (lines in a plane through a point), $A^4 = \\mathbb{Z}\\sigma_{22}$ (a specific line, the 'point class'). The product $\\sigma_1 \\cdot \\sigma_{22} = 0$ (no line meets 4 fixed lines + 1 point class in general position) reflects the dimension count: $1 + 4 > 4 = \\dim A^*(\\mathrm{Gr}(2,4))$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Chow ring grading",
+      "Schubert calculus",
+      "Grassmannian Gr(2,4)",
+      "Littlewood-Richardson multiplication table",
+      "native_decide proof strategy",
+      "axiom elimination"
+    ],
+    "prerequisites": [
+      "algebraic cycles",
+      "rational equivalence",
+      "graded ring theory",
+      "projective 3-space geometry"
+    ]
+  },
+  {
     "id": "ann-schubert-overview",
     "title": "Schubert Calculus on Gr(2,4): Explicit Computation Approach",
     "type": "concept",

--- a/src/data/proofs/hilbert-15-oq-01/meta.json
+++ b/src/data/proofs/hilbert-15-oq-01/meta.json
@@ -128,6 +128,31 @@
       "targetId": "hilbert-15",
       "relationship": "extends",
       "description": "Parent: Hilbert's 15th problem with axiomatized four lines theorem. This file proves it computationally with 0 axioms."
+    },
+    {
+      "targetId": "hilbert-15-oq-02",
+      "relationship": "related",
+      "description": "Sibling: studies the computational complexity of Littlewood–Richardson coefficients — the same LR rule used to build the multiplication table here, and verifies the Gr(2,4) structure constants computationally."
+    },
+    {
+      "targetId": "ballot-problem-oq-03-oq-01-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Schur polynomials represent Schubert classes in the cohomology of Grassmannians: σ_λ corresponds to the Schur polynomial s_λ(x₁,...,xₖ) under the characteristic map. The Jacobi-Trudi determinants formalize this correspondence."
+    },
+    {
+      "targetId": "ballot-problem-oq-03-oq-01-oq-02",
+      "relationship": "related",
+      "description": "The hook-length formula counts standard Young tableaux, which appear as the building blocks of Littlewood–Richardson tableaux: LR coefficients c^μ_{λ,ν} count LR tableaux whose content is a Young tableau."
+    },
+    {
+      "targetId": "amgm-inequality-oq-02-oq-01-oq-02-oq-01",
+      "relationship": "related",
+      "description": "Newton-Girard identities convert between power sums {pₖ} and elementary symmetric polynomials {eₖ}, which represent Chern roots. In K-theory, Chern characters are expressed in terms of power sums of Chern roots, while Schubert classes correspond to Chern polynomials — connecting Schubert calculus to symmetric function theory."
+    },
+    {
+      "targetId": "motivic-flag-maps-oq-02",
+      "relationship": "generalization",
+      "description": "Grassmannians Gr(k,n) are special cases of partial flag varieties. The motivic Euler characteristic framework extends Schubert calculus to motivic cohomology, generalizing the intersection numbers computed here."
     }
   ],
   "references": [


### PR DESCRIPTION
## Summary

Second-pass enrichment of `hilbert-15-oq-01` (Chow Ring of Gr(2,4): Schubert Calculus):

**meta.json: 5 new cross-references** (was 1, now 6)
- `hilbert-15-oq-02` — sibling entry on LR coefficient complexity (same structure constants)
- `ballot-problem-oq-03-oq-01-oq-01-oq-01` — Schur polynomials represent Schubert classes via Jacobi-Trudi
- `ballot-problem-oq-03-oq-01-oq-02` — hook-length formula connects to LR tableaux construction
- `amgm-inequality-oq-02-oq-01-oq-02-oq-01` — Newton-Girard: power sums as Chern roots in K-theory
- `motivic-flag-maps-oq-02` — Grassmannians as special case of partial flag varieties

**annotations.json: new context annotation** (lines 1–62)
- Documents the complete multiplication table structure and degree grading
- Geometric interpretation of each Schubert basis class (lines = codim 1 constraints)
- Explains the `native_decide` proof strategy and axiom elimination methodology
- Notes this is the only gallery file whose docstring contains a full multiplication table