### PR TITLE
fix: ballot-problem-oq-03-oq-01-oq-01-oq-01 badge invalid value

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -18,7 +18,7 @@
       "representation-theory",
       "ssyt"
     ],
-    "badge": "formalized",
+    "badge": "wip",
     "sorries": 2,
     "dateAdded": "2026-04-23",
     "axiomCount": 0,


### PR DESCRIPTION
## Summary

- `badge: "formalized"` is not a valid `ProofBadge` type in the gallery TypeScript type system
- Valid badge values are: `original`, `mathlib`, `pedagogical`, `from-axioms`, `fallacy`, `wip`, `ai-solved`, `axiom`, `infrastructure`
- This was the only proof in the gallery using an invalid badge value
- With 2 sorries remaining, `"wip"` is the correct badge

## Evidence

- `src/types/proof.ts` defines `ProofBadge` — `"formalized"` is absent
- `BADGE_INFO["formalized"]` returns `undefined`, causing the badge component to silently fail
- Actual Lean file has 2 tactical `sorry` calls (lines 330 and 391)

## Test plan

- [ ] `pnpm build` should pass with no TypeScript errors
- [ ] Gallery page for `ballot-problem-oq-03-oq-01-oq-01-oq-01` should show WIP badge

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)