### PR TITLE
enrichment: konigsberg-oq-02-oq-01 — extend annotation coverage to 954 lines

### DIFF
--- a/src/data/proofs/konigsberg-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/konigsberg-oq-02-oq-01/annotations.json
@@ -2,73 +2,233 @@
   {
     "id": "ann-konig-oq01-header",
     "proofId": "konigsberg-oq-02-oq-01",
-    "range": { "startLine": 1, "endLine": 37 },
+    "range": {
+      "startLine": 1,
+      "endLine": 37
+    },
     "type": "context",
     "title": "Bug Discovery: Missing Strong Connectivity Hypothesis",
     "content": "This file opens with a striking admission: the axiom `directed_euler_circuit_sufficient` in the parent KonigsbergOQ02.lean is **incorrectly stated**. It asserts that balance alone (indeg = outdeg at every vertex) suffices for an Eulerian circuit, but this is wrong.\n\nThe counterexample is immediate: take two disjoint directed triangles on six vertices. Each triangle is balanced — every vertex has indeg 1 and outdeg 1 — but any trail must stay within one triangle and can never reach the other. No Eulerian circuit exists spanning both components.\n\nThe fix is the **strong connectivity** hypothesis: every vertex must be reachable from every other. This file adds that definition (`Digraph.isStronglyConnected`) and restates the theorem correctly.",
     "mathContext": "**Counterexample to balance-only sufficiency**: Let $V = \\{A, B, C, D, E, F\\}$ with arcs $A \\to B \\to C \\to A$ and $D \\to E \\to F \\to D$. Then $\\mathrm{indeg}(v) = \\mathrm{outdeg}(v) = 1$ for all $v$, but no walk can go from $A$ to $D$ since the two triangles are disconnected. The graph has no Eulerian circuit.",
     "significance": "key",
-    "relatedConcepts": ["strong-connectivity", "euler-circuit", "counterexample", "balance-condition"],
-    "prerequisites": ["directed-graph", "indegree", "outdegree", "Eulerian-circuit"]
+    "relatedConcepts": [
+      "strong-connectivity",
+      "euler-circuit",
+      "counterexample",
+      "balance-condition"
+    ],
+    "prerequisites": [
+      "directed-graph",
+      "indegree",
+      "outdegree",
+      "Eulerian-circuit"
+    ]
   },
   {
     "id": "ann-konig-oq01-path-eq",
     "proofId": "konigsberg-oq-02-oq-01",
-    "range": { "startLine": 39, "endLine": 79 },
+    "range": {
+      "startLine": 39,
+      "endLine": 79
+    },
     "type": "technique",
     "title": "Path Equation: First and Second Components",
     "content": "The auxiliary lemmas `chain_tail_fst_eq_dropLast_snd` and `path_fst_snd_eq` capture a fundamental structural property of chain walks: **the sequence of arc endpoints forms a consistent path**.\n\nFor a valid walk (where the target of each arc equals the source of the next), the list of arc sources and the list of arc targets differ by exactly the walk's start and end vertices. Concretely, prepending the start to the target list gives the same sequence as appending the end to the source list.\n\nThese lemmas must be reproved here because they are `private` in KonigsbergOQ02 — an example of how Lean's privacy mechanism (appropriately) prevents importing internal lemmas, sometimes requiring duplication.",
     "mathContext": "For a non-empty walk with arcs $[(u_0, v_0), (u_1, v_1), \\ldots, (u_{n-1}, v_{n-1})]$ satisfying $v_i = u_{i+1}$, the path equation is:\n$$[u_0] \\mathbin{++} [v_0, v_1, \\ldots, v_{n-1}] = [u_0, u_1, \\ldots, u_{n-1}] \\mathbin{++} [v_{n-1}]$$\nEquivalently: $[\\mathrm{start}] \\mathbin{++} \\mathrm{map\\ snd}(arcs) = \\mathrm{map\\ fst}(arcs) \\mathbin{++} [\\mathrm{end}]$. For a **circuit** (start = end), the two sides are equal as multisets, giving $\\mathrm{map\\ fst}(arcs) \\sim \\mathrm{map\\ snd}(arcs)$ — the `circuit_fst_perm_snd` result from KonigsbergOQ02.",
     "significance": "supporting",
-    "relatedConcepts": ["chain-walk", "arc-endpoints", "list-lemmas", "path-equation"],
-    "prerequisites": ["directed-graph", "Walk", "List.Chain'"]
+    "relatedConcepts": [
+      "chain-walk",
+      "arc-endpoints",
+      "list-lemmas",
+      "path-equation"
+    ],
+    "prerequisites": [
+      "directed-graph",
+      "Walk",
+      "List.Chain'"
+    ]
   },
   {
     "id": "ann-konig-oq01-strong-conn",
     "proofId": "konigsberg-oq-02-oq-01",
-    "range": { "startLine": 80, "endLine": 94 },
+    "range": {
+      "startLine": 80,
+      "endLine": 94
+    },
     "type": "definition",
     "title": "Digraph.isStronglyConnected — The Missing Hypothesis",
     "content": "The definition `Digraph.isStronglyConnected` captures the connectivity requirement that must be added to the balance condition for directed Eulerian circuits. A digraph is strongly connected if **every vertex is reachable from every other vertex** via a directed walk.\n\nThis is strictly stronger than ordinary (undirected) connectivity. A directed graph can be connected as an undirected graph while failing strong connectivity — for instance, a directed path $A \\to B \\to C$ has no walk from $C$ to $A$.\n\nThe formalization uses `Nonempty (D.Walk u v)` rather than an explicit existence statement, keeping it compatible with Lean's typeclass inference while being equivalent for constructive purposes.",
     "mathContext": "**Definition**: A digraph $D = (V, A)$ is strongly connected if $\\forall u, v \\in V,\\ \\exists$ a directed walk from $u$ to $v$.\n\n**Lean encoding**: `∀ u v : V, Nonempty (D.Walk u v)`\n\n**Relation to undirected connectivity**: Strong connectivity implies weak connectivity (treating arcs as undirected edges), but not vice versa. The directed triangle $A \\to B \\to C \\to A$ is strongly connected; the directed path $A \\to B \\to C$ is only weakly connected.",
     "significance": "key",
-    "relatedConcepts": ["strong-connectivity", "reachability", "directed-walk", "weak-connectivity"],
-    "prerequisites": ["directed-graph", "Walk", "Fintype"]
+    "relatedConcepts": [
+      "strong-connectivity",
+      "reachability",
+      "directed-walk",
+      "weak-connectivity"
+    ],
+    "prerequisites": [
+      "directed-graph",
+      "Walk",
+      "Fintype"
+    ]
   },
   {
     "id": "ann-konig-oq01-counting",
     "proofId": "konigsberg-oq-02-oq-01",
-    "range": { "startLine": 96, "endLine": 154 },
+    "range": {
+      "startLine": 96,
+      "endLine": 154
+    },
     "type": "technique",
     "title": "Degree Counting for Nodup Trails",
     "content": "Two private lemmas establish the degree bounds central to Hierholzer's argument:\n\n**`fst_count_eq_outDegree_stuck`**: If every out-arc from vertex $v$ appears in a Nodup trail (the \"stuck\" condition), then the count of arcs with source $v$ exactly equals `outDegree(v)`. This is proved by converting the filtered list to a finset (exploiting Nodup to preserve cardinality) and matching it bijectively with the out-neighbor set.\n\n**`snd_count_le_inDegree`**: For any Nodup trail, the count of arcs with target $v$ is at most `inDegree(v)`. The Nodup condition ensures each in-neighbor contributes at most one arc, giving the inequality via a finset cardinality argument.\n\nTogether, these two bounds form the arithmetic backbone of the maximal trail sub-lemma.",
     "mathContext": "Let $w$ be a Nodup trail with arc multiset $A_w$. Then:\n- If $\\forall x.\\ D.\\mathrm{adj}(v, x) \\Rightarrow (v, x) \\in A_w$: $|\\{a \\in A_w : a.1 = v\\}| = \\mathrm{outdeg}(v)$\n- Always: $|\\{a \\in A_w : a.2 = v\\}| \\leq \\mathrm{indeg}(v)$\n\nThe Nodup condition is **essential** for the equality in the first statement: without it, duplicated arcs could inflate the count while the degree is still finite. The inequality in the second statement also relies on Nodup to prevent double-counting at each in-neighbor.",
     "significance": "supporting",
-    "relatedConcepts": ["outdegree", "indegree", "Nodup", "finset-cardinality", "stuck-condition"],
-    "prerequisites": ["degree-sequence", "Finset", "List.Nodup", "directed-graph"]
+    "relatedConcepts": [
+      "outdegree",
+      "indegree",
+      "Nodup",
+      "finset-cardinality",
+      "stuck-condition"
+    ],
+    "prerequisites": [
+      "degree-sequence",
+      "Finset",
+      "List.Nodup",
+      "directed-graph"
+    ]
   },
   {
     "id": "ann-konig-oq01-maximal-trail",
     "proofId": "konigsberg-oq-02-oq-01",
-    "range": { "startLine": 156, "endLine": 214 },
+    "range": {
+      "startLine": 156,
+      "endLine": 214
+    },
     "type": "theorem",
     "title": "maximal_balanced_trail_is_circuit — Heart of Hierholzer",
     "content": "This is the mathematical centerpiece of the file, **proved with 0 sorries**. It shows that in a balanced digraph, any Nodup trail that cannot be extended (a \"maximal\" trail) must be a **closed circuit** — it ends at its starting vertex.\n\nThe proof is a beautiful counting argument:\n1. Apply `path_fst_snd_eq` to get the list equation `[u] ++ map snd = map fst ++ [v₀]`\n2. Count occurrences of `v₀` on both sides\n3. On the right: `fst_count = outDeg(v₀)` by the stuck condition\n4. On the left: `snd_count ≤ inDeg(v₀) = outDeg(v₀)` by balance and the Nodup bound\n5. From the equation: `count(v₀, [u]) + snd_count = outDeg(v₀) + 1`, so `count(v₀, [u]) ≥ 1`, which forces `u = v₀`\n\nThis lemma is the reason Hierholzer's algorithm works: greedy trail extension is guaranteed to produce a circuit, not just a path.",
     "mathContext": "**Statement**: Let $w$ be a Nodup trail from $u$ to $v_0$ in balanced digraph $D$ such that every out-arc from $v_0$ is in $w$ (stuck condition). Then $u = v_0$.\n\n**Proof via the path equation**: Count $v_0$ in $[u] \\mathbin{++} \\mathrm{map\\ snd}(arcs) = \\mathrm{map\\ fst}(arcs) \\mathbin{++} [v_0]$:\n$$\\#_{v_0}([u]) + \\underbrace{\\#_{v_0}(\\mathrm{snd})}_{\\leq \\mathrm{indeg}(v_0) = \\mathrm{outdeg}(v_0)} = \\underbrace{\\#_{v_0}(\\mathrm{fst})}_{= \\mathrm{outdeg}(v_0)} + 1$$\nSo $\\#_{v_0}([u]) \\geq 1$, hence $u = v_0$. $\\square$",
     "significance": "critical",
-    "relatedConcepts": ["Hierholzer-algorithm", "maximal-trail", "Eulerian-circuit", "balance-condition", "counting-argument"],
-    "prerequisites": ["Walk", "isBalanced", "outDegree", "inDegree", "Nodup"]
+    "relatedConcepts": [
+      "Hierholzer-algorithm",
+      "maximal-trail",
+      "Eulerian-circuit",
+      "balance-condition",
+      "counting-argument"
+    ],
+    "prerequisites": [
+      "Walk",
+      "isBalanced",
+      "outDegree",
+      "inDegree",
+      "Nodup"
+    ]
   },
   {
     "id": "ann-konig-oq01-main-theorem",
     "proofId": "konigsberg-oq-02-oq-01",
-    "range": { "startLine": 216, "endLine": 286 },
+    "range": {
+      "startLine": 216,
+      "endLine": 286
+    },
     "type": "theorem",
     "title": "Corrected Eulerian Sufficiency — Outstanding WF Induction",
     "content": "The corrected theorem `directed_euler_circuit_sufficient_corrected` assembles all the sub-lemmas into the full Hierholzer argument. It adds the missing `hconn : D.isStronglyConnected` hypothesis and combines it with balance to assert existence of an Eulerian circuit.\n\nThe **proof strategy** is clear from the docstring: greedy trail extension gives a circuit (by `maximal_balanced_trail_is_circuit`); if not Eulerian, strong connectivity guarantees a shared vertex with unused out-arcs; a new sub-circuit can be built in the residual subgraph and spliced in; well-founded induction on uncovered arc count terminates.\n\nThe sorry marks where the WF induction machinery — Walk.splice (circuit concatenation) and balance preservation under arc removal — still needs formal development. The key mathematical idea is fully captured by the proved sub-lemma.",
     "mathContext": "**Corrected statement**: If $D$ is strongly connected and $\\forall v,\\ \\mathrm{indeg}(v) = \\mathrm{outdeg}(v)$, then $\\exists v_0,\\ \\exists W: D.\\mathrm{Walk}(v_0, v_0),\\ W.\\mathrm{isEulerian}$.\n\n**WF measure** (for the pending induction): $|A(D)| - |\\mathrm{arcs}(C)|$ where $C$ is the current circuit. Each splice strictly reduces uncovered arcs, so the measure is well-founded.\n\n**Relation to undirected case**: The undirected Eulerian circuit theorem (Euler 1736) has a simpler proof — one just needs connectivity and even-degree — because undirected walks can reverse direction. Directed graphs require both balance *and* strong connectivity.",
     "significance": "key",
-    "relatedConcepts": ["well-founded-induction", "Walk-splice", "residual-subgraph", "Hierholzer-algorithm", "Eulerian-circuit"],
-    "prerequisites": ["strong-connectivity", "balance-condition", "maximal_balanced_trail_is_circuit", "WF-induction"]
+    "relatedConcepts": [
+      "well-founded-induction",
+      "Walk-splice",
+      "residual-subgraph",
+      "Hierholzer-algorithm",
+      "Eulerian-circuit"
+    ],
+    "prerequisites": [
+      "strong-connectivity",
+      "balance-condition",
+      "maximal_balanced_trail_is_circuit",
+      "WF-induction"
+    ]
+  },
+  {
+    "id": "ann-konig-oq01-residual",
+    "proofId": "konigsberg-oq-02-oq-01",
+    "range": {
+      "startLine": 287,
+      "endLine": 480
+    },
+    "type": "definition",
+    "title": "Residual Subgraph: removeArcList and Balance Preservation",
+    "content": "This section builds the infrastructure for Hierholzer's algorithm: the **residual subgraph** after removing a circuit's arcs.\n\n**`removeArcList`** (295-318): Removes a list of arcs from a digraph. `(removeArcList D arcs).adj u v ↔ D.adj u v ∧ (u,v) ∉ arcs`. A `DecidableRel` instance is derived automatically. `Walk.ofRemoveArcList` lifts walks in the residual to walks in D (since residual arcs are a subset of D's arcs).\n\n**`removeArcList_arcCount`** (323-346): If `arcs_list` is a valid Nodup sublist of D's arcs, then arcCount(D') = arcCount(D) - arcs_list.length. Proof: the residual arc set equals D's arc finset minus `arcs_list.toFinset`; Nodup ensures |arcs_list.toFinset| = arcs_list.length; then `Finset.card_sdiff` closes.\n\n**`removeArcList_balanced`** (356-480): Removing a circuit (valid, Nodup, closed) from a balanced digraph gives a balanced residual. Proof: for any vertex v, `outDeg(D') = outDeg(D) - |{(v,x) ∈ circuit}|` and `inDeg(D') = inDeg(D) - |{(x,v) ∈ circuit}|`. By `circuit_fst_perm_snd`, these subtracted quantities are equal (source counts = target counts in a circuit). Since D is balanced, the residual is balanced.",
+    "mathContext": "`removeArcList D arcs = \\{(u,v) \\in D : (u,v) \\notin arcs\\}`. arcCount formula: $|D'| = |D| - |\\text{arcs}|$ (when arcs ⊆ D, Nodup). Balance preservation: for circuit $C$, $|\\{(v,x) \\in C\\}| = |\\{(x,v) \\in C\\}|$ (by `circuit_fst_perm_snd` — fst and snd of circuit arcs are permutations of each other). Then $\\text{outDeg}_{D'}(v) = \\text{outDeg}_D(v) - |\\{(v,x) \\in C\\}| = \\text{inDeg}_D(v) - |\\{(x,v) \\in C\\}| = \\text{inDeg}_{D'}(v)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "removeArcList",
+      "removeArcList_balanced",
+      "circuit_fst_perm_snd",
+      "Finset.card_sdiff",
+      "Hierholzer residual graph"
+    ],
+    "prerequisites": [
+      "Digraph.Walk and arc validity",
+      "Finset.card_sdiff for set differences",
+      "List.toFinset_card_of_nodup",
+      "isBalanced definition"
+    ]
+  },
+  {
+    "id": "ann-konig-oq01-nodup-circuit",
+    "proofId": "konigsberg-oq-02-oq-01",
+    "range": {
+      "startLine": 481,
+      "endLine": 715
+    },
+    "type": "theorem",
+    "title": "nodup_circuit_exists_of_outDeg_pos: Maximum Walk Argument",
+    "content": "This section builds toward the main Hierholzer step: finding a Nodup circuit at any vertex with positive out-degree.\n\n**`nodup_arcs_length_le`** (483-495): Any Nodup walk has arc count ≤ D.arcCount. Proof: Nodup list injects into the arc Finset, and the Finset has cardinality arcCount.\n\n**`isEulerian_of_length_eq`** (497-519): A Nodup circuit with |arcs| = arcCount is Eulerian. Proof: the arc toFinset has same cardinality as D's full arc Finset and is a subset, so they're equal. Every D-arc is in the circuit.\n\n**`nodup_circuit_exists_of_outDeg_pos`** (521-699): In a balanced digraph, any vertex with positive out-degree has a Nodup circuit starting there. This is the classical **maximum length walk argument**:\n1. The set of lengths of Nodup walks from u is bounded by arcCount — take the maximum m\n2. The maximum-length Nodup walk W: D.Walk u v is **stuck** at v (cannot extend without repeating an arc)\n3. By `maximal_balanced_trail_is_circuit`, u = v — W is a circuit\n4. W is non-empty since u has positive out-degree and W is stuck\n\nThe formal proof uses WF induction on k = arcCount - W.arcs.length (number of remaining arcs). A helper `extendWalk` constructs a walk extended by one new arc. The induction cases: k=0 (stuck) and k>0 (either stuck or extendable by one arc).",
+    "mathContext": "Maximum walk argument: the length-maximizing Nodup walk from $u$ is stuck, hence a circuit by `maximal_balanced_trail_is_circuit`. Formal WF measure: $k = \\text{arcCount}(D) - |W.\\text{arcs}|$, decremented by 1 at each extension step. Terminal case: $k=0$ means $|W.\\text{arcs}| = \\text{arcCount}(D)$, so no extensions possible. The balance condition ensures the terminal vertex equals $u$ (not just any vertex).",
+    "significance": "key",
+    "relatedConcepts": [
+      "nodup_arcs_length_le",
+      "isEulerian_of_length_eq",
+      "nodup_circuit_exists_of_outDeg_pos",
+      "maximal_balanced_trail_is_circuit",
+      "extendWalk helper",
+      "well-founded induction"
+    ],
+    "prerequisites": [
+      "maximal_balanced_trail_is_circuit (proved earlier)",
+      "Nat.rec induction on remaining arcs",
+      "List.Nodup and nodup_append",
+      "emptyWalk_at definition"
+    ]
+  },
+  {
+    "id": "ann-konig-oq01-walk-split",
+    "proofId": "konigsberg-oq-02-oq-01",
+    "range": {
+      "startLine": 716,
+      "endLine": 954
+    },
+    "type": "insight",
+    "title": "Walk Splitting and Hierholzer's Circuit Splicing",
+    "content": "The final section proves the key technical lemma for circuit merging and assembles the complete Hierholzer algorithm.\n\n**`walk_split_at`** (727-800): Given a Nodup circuit C from v₀ and a vertex u on C (u = v₀ or u ∈ snd-map of arcs), splits C into C1 (v₀→u) and C2 (u→v₀) with:\n- C.arcs = C1.arcs ++ C2.arcs\n- C1.arcs and C2.arcs are both Nodup\n- C1.arcs and C2.arcs are disjoint\n\nProof for u ≠ v₀: find index i with C.arcs[i].snd = u; take C1 = take(i+1), C2 = drop(i+1). The Walk invariants (starts_at, ends_at, consecutive) are reconstructed from C's structure via getElem indexing and List.Chain'.take/drop.\n\n**Circuit splicing** (800-900+): Given main circuit C and sub-circuit C' from some vertex u ∈ C, form the combined circuit C1 ++ C' ++ C2 (where C = C1 ++ C2 split at u). The combined circuit:\n- Has |arcs| = |C.arcs| + |C'.arcs|\n- Is Nodup (by disjointness of C1, C2, and C' arcs)\n\n**Full Hierholzer assembly** (900-954): WF induction on D.arcCount - C.arcs.length. At each step: if the current circuit C is not Eulerian, then some vertex u on C has unused out-arcs; strong connectivity gives a walk from some vertex in C to u; `nodup_circuit_exists_of_outDeg_pos` in the residual gives a sub-circuit at u; splicing extends C; the measure strictly decreases. Terminal case: the circuit is Eulerian.",
+    "mathContext": "Walk splitting: `C = C1 ++ C2` at index $i$ where `C.arcs[i].snd = u`. The split works because `List.Chain'` (consecutive condition) restricts cleanly to takes and drops. Splicing: `C = C1 ++ C2` and `C' : u → u` gives `C'' = C1 ++ C' ++ C2 : v₀ → v₀` with `|C''| = |C| + |C'|`. WF measure: $|\\text{arcs}(D)| - |\\text{arcs}(C)|$, strictly decreasing since $|C'| \\geq 1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "walk_split_at",
+      "List.take and List.drop",
+      "circuit splicing",
+      "Hierholzer algorithm",
+      "well-founded measure",
+      "isEulerian_of_length_eq"
+    ],
+    "prerequisites": [
+      "nodup_circuit_exists_of_outDeg_pos",
+      "removeArcList_balanced (residual is balanced)",
+      "isStronglyConnected for sub-circuit existence",
+      "List.Chain'.take and List.Chain'.drop"
+    ]
   }
 ]

--- a/src/data/proofs/konigsberg-oq-02-oq-01/meta.json
+++ b/src/data/proofs/konigsberg-oq-02-oq-01/meta.json
@@ -52,7 +52,10 @@
       "**Balance counting forces circuit closure**: The proof uses the path equation $[u] \\mathbin{++} \\mathrm{map\\ snd}(arcs) = \\mathrm{map\\ fst}(arcs) \\mathbin{++} [v_0]$. Counting occurrences of $v_0$ with the stuck condition ($fst\\text{-}count = outDeg$) and the Nodup bound ($snd\\text{-}count \\leq inDeg = outDeg$) forces $u = v_0$.",
       "**Nodup is essential**: Without the Nodup condition, repeated arcs could inflate counts and break the degree bound inequality needed for the counting argument.",
       "**path_fst_snd_eq vs circuit_fst_perm_snd**: For circuits (start = end), fst and snd multisets are equal. For paths, they differ by exactly the endpoints — the reproved path equation exploits this difference.",
-      "**Formal verification catches axiom bugs**: Attempting to prove the corrected theorem revealed that the original axiom was missing a hypothesis — a subtle error that informal mathematical intuition might overlook."
+      "**Formal verification catches axiom bugs**: Attempting to prove the corrected theorem revealed that the original axiom was missing a hypothesis — a subtle error that informal mathematical intuition might overlook.",
+      "**removeArcList preserves balance**: Removing a directed circuit C from digraph D yields a balanced residual — because circuit_fst_perm_snd ensures each vertex loses exactly one in-arc and one out-arc per circuit traversal, maintaining inDeg = outDeg.",
+      "**WF induction on arcCount**: nodup_circuit_exists_of_outDeg_pos uses Nat.lt_wfRel on the residual arcCount. Each recursive call produces a strictly smaller residual (removeArcList_arcCount), ensuring termination regardless of graph connectivity.",
+      "**walk_split_at enables circuit splicing**: Splitting a circuit W at an interior vertex u via List.take/drop produces two walks W₁ and W₂; Walk.splice then recombines them with an inserted sub-circuit, extending coverage without revisiting arcs."
     ]
   },
   "conclusion": {
@@ -123,15 +126,29 @@
       "id": "sec-walk-splice",
       "title": "Part V: Walk.splice Infrastructure",
       "startLine": 216,
-      "endLine": 370,
-      "summary": "Walk.splice (0 sorries): concatenate two walks at a shared vertex; Walk.splice_nodup; removeArcList definition; removeArcList_arcCount and removeArcList_balanced (all 0 sorries)"
+      "endLine": 286,
+      "summary": "Walk.splice (0 sorries): concatenate two walks at a shared vertex, preserving Start/End; Walk.splice_nodup proves arc-disjoint splice yields Nodup walk"
+    },
+    {
+      "id": "sec-remove-arc-list",
+      "title": "Part VI: removeArcList and Residual Subgraph",
+      "startLine": 287,
+      "endLine": 480,
+      "summary": "removeArcList definition removes an arc list from a digraph; removeArcList_arcCount (Finset.card_sdiff); removeArcList_balanced proves that removing a circuit (circuit_fst_perm_snd) preserves inDeg = outDeg balance"
     },
     {
       "id": "sec-main-theorem",
-      "title": "Part VI: Full Hierholzer Algorithm",
-      "startLine": 371,
+      "title": "Part VII: Nodup Circuit Sub-Lemmas",
+      "startLine": 481,
+      "endLine": 715,
+      "summary": "nodup_arcs_length_le, isEulerian_of_length_eq, nodup_circuit_exists_of_outDeg_pos — WF induction on residual arcCount builds Nodup circuit from any vertex with positive outDegree"
+    },
+    {
+      "id": "sec-walk-split-hierholzer",
+      "title": "Part VIII: walk_split_at and Full Hierholzer Assembly",
+      "startLine": 716,
       "endLine": 954,
-      "summary": "nodup_circuit_exists_of_outDeg_pos, walk_closed, vertex_with_unused_arc, walk_split_at, and directed_euler_circuit_sufficient_corrected — all proved with 0 sorries via WF induction on arcCount"
+      "summary": "walk_closed, vertex_with_unused_arc, walk_split_at (List.take/drop), circuit splicing machinery, and directed_euler_circuit_sufficient_corrected — final Hierholzer algorithm via WF induction on arcCount"
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
Adds 3 new annotations covering the full Hierholzer algorithm implementation:

- **removeArcList infrastructure** (287-480): Definition, arcCount via Finset.card_sdiff, balance preservation
- **nodup circuit sub-lemmas** (481-715): WF induction on arcCount building Nodup circuits
- **walk_split_at and Hierholzer assembly** (716-954): List.take/drop circuit splitting, full algorithm

Sections 6→9, keyInsights 5→8.