### PR TITLE
Fix: remove false theorem sidon_implies_distinct_products in Erdos795Problem.lean

### DIFF
--- a/proofs/Proofs/Erdos795Problem.lean
+++ b/proofs/Proofs/Erdos795Problem.lean
@@ -366,32 +366,28 @@ unexpected end of input; expected ','-/
 def IsMultiplicativeSidon (A : Finset ℕ) : Prop :=
   ∀ a b c d ∈ A, a * b = c * d → ({a, b} : Finset ℕ) = {c, d}
 
-/-- Multiplicative Sidon implies distinct subset products -/
-theorem sidon_implies_distinct_products (A : Finset ℕ)
-    (hSidon : IsMultiplicativeSidon A) :
-    HasDistinctSubsetProducts A := by
-  sorry
+/- NOTE: The theorem `sidon_implies_distinct_products` (Sidon → DSP) was REMOVED
+   because it is MATHEMATICALLY FALSE.
 
-/- Aristotle failed to load this code into its environment. Double check that the syntax is correct.
+   Counterexample: A = {2, 3, 6} is a multiplicative Sidon set (all products of
+   pairs from A are distinct: 4, 6, 9, 12, 18, 36 — no two pairs give the same
+   product). However, A does NOT have distinct subset products: {2, 3} and {6} are
+   different subsets of A, but both have product 6.
 
-Function expected at
-  HasDistinctSubsetProducts
-but this term has type
-  ?m.1
+   The correct direction is: DSP → Sidon (for 2-element subsets), not Sidon → DSP.
+   See theorem `dsp_implies_sidon` (not yet formalized) for the correct statement.
+-/
 
-Note: Expected a function because this term is being applied to the argument
-  A
-Function expected at
-  IsMultiplicativeSidon
-but this term has type
-  ?m.2
-
-Note: Expected a function because this term is being applied to the argument
-  A-/
-/-- But distinct products is weaker than Sidon -/
+/-- Distinct subset products does NOT imply multiplicative Sidon.
+    The implication goes the other way for 2-element subsets (DSP → Sidon).
+    Counterexample: A = {2, 6, 18} has distinct subset products (products:
+    2, 6, 18, 12, 36, 108, 216, all distinct) but is not Sidon: 6*6 = 36 = 2*18,
+    while {6} ≠ {2, 18} as Finsets. -/
 theorem distinct_products_not_sidon :
     ∃ A : Finset ℕ, HasDistinctSubsetProducts A ∧ ¬IsMultiplicativeSidon A := by
-  -- Example: {2, 3, 4} has distinct products but 2·4 = 4·2 relates elements
+  -- Witness: A = {2, 6, 18}
+  -- DSP: subset products are 2, 6, 18, 12, 36, 108, 216, all distinct.
+  -- Not Sidon: 6*6 = 36 = 2*18, but {6,6} = {6} ≠ {2,18} as Finsets.
   sorry
 
 /- ## Related: Problem #786 -/

--- a/src/data/proofs/erdos-795/meta.json
+++ b/src/data/proofs/erdos-795/meta.json
@@ -17,13 +17,13 @@
       "distinct-products"
     ],
     "badge": "wip",
-    "sorries": 15,
+    "sorries": 14,
     "erdosNumber": 795,
     "erdosUrl": "https://erdosproblems.com/795",
     "erdosProblemStatus": "solved",
     "axiomCount": 0,
     "lineCount": 500,
-    "assumptions": "15 sorry(s).",
+    "assumptions": "14 sorry(s).",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -172,7 +172,7 @@
     "theoremCount": 14,
     "definitionCount": 7,
     "path": "Proofs/Erdos795Problem.lean",
-    "sorries": 15
+    "sorries": 14
   },
   "crossReferences": [
     {
@@ -191,5 +191,5 @@
       "description": "Related Erdős problem sharing themes: combinatorics, number-theory"
     }
   ],
-  "sorries": 15
+  "sorries": 14
 }


### PR DESCRIPTION
## Fix

Removed the false theorem `sidon_implies_distinct_products` from `Erdos795Problem.lean` and updated the sorry count in `meta.json` from 15 to 14.

## Evidence

**Before**: The file contained a theorem claiming every multiplicative Sidon set has distinct subset products (Sidon → DSP), with a `sorry` placeholder.

**After**: The false theorem is removed and replaced with a clear comment explaining why it cannot be proved, with an explicit counterexample.

## Mathematical Analysis

The theorem `sidon_implies_distinct_products` was:
```lean
theorem sidon_implies_distinct_products (A : Finset ℕ)
    (hSidon : IsMultiplicativeSidon A) :
    HasDistinctSubsetProducts A := by
  sorry
```

This is **mathematically false**. Counterexample:

**A = {2, 3, 6}** is a multiplicative Sidon set:
- All pairwise products from A: 4, 6, 9, 12, 18, 36 — all distinct
- No two different unordered pairs from A share a product → Sidon ✓

But **A does NOT have distinct subset products**:
- Subset {2, 3}: product = 6
- Subset {6}: product = 6
- Same product, different subsets → NOT DSP ✗

The correct relationship: `distinct_products_not_sidon` (also in the file) claims `∃ A, DSP(A) ∧ ¬Sidon(A)` — the companion proof with updated example `{2, 6, 18}` (where `6*6 = 36 = 2*18` violates Sidon).

## Scope
- `proofs/Proofs/Erdos795Problem.lean`: removed 1 false sorry, updated comment
- `src/data/proofs/erdos-795/meta.json`: `sorries` 15 → 14 (all 3 occurrences)

---
Automated fix by lean-mechanic agent.