### PR TITLE
chore(auditor): sync audit tracker — 14 proofs re-audited clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8976,9 +8976,9 @@
     },
     "erdos-970": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T06:24:46Z",
+      "result": "clean"
     },
     "erdos-971": {
       "agentId": "auditor-cycle-20-batch",
@@ -9012,9 +9012,9 @@
     },
     "erdos-976": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T06:24:46Z",
+      "result": "clean"
     },
     "erdos-977": {
       "agentId": "auditor-cycle-20-batch",
@@ -9025,9 +9025,9 @@
     },
     "erdos-978": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T06:24:46Z",
+      "result": "clean"
     },
     "erdos-979": {
       "agentId": "auditor-cycle-20-batch",
@@ -9049,15 +9049,15 @@
     },
     "erdos-981": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T06:24:45Z",
+      "result": "clean"
     },
     "erdos-982": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T06:24:45Z",
+      "result": "clean"
     },
     "erdos-983": {
       "agentId": "auditor-cycle-20-batch",
@@ -9067,15 +9067,15 @@
     },
     "erdos-984": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T06:24:45Z",
+      "result": "clean"
     },
     "erdos-985": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T06:24:45Z",
+      "result": "clean"
     },
     "erdos-986": {
       "agentId": "auditor-cycle-20-batch",
@@ -9097,15 +9097,15 @@
     },
     "erdos-989": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T06:24:45Z",
+      "result": "clean"
     },
     "erdos-99": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T06:24:45Z",
+      "result": "clean"
     },
     "erdos-990": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Re-audited 14 gallery proofs against git HEAD: sorry counts, axiom counts, True stubs
- Validated 29 'verified/original' proofs flagged by automated scan — all clean (sorry mentions were only in documentation comments)
- Confirmed integrity of enrichment PRs merged since last sync: abel-ruffini-*, konigsberg-oq-02-oq-01, ramsey-r4k-extensions

## Proofs Audited

| Proof | Result |
|-------|--------|
| erdos-994 | clean |
| erdos-476-oq-05 | clean |
| angle-trisection-oq-02-oq-01-oq-02-incomplete-01 | clean |
| ballot-problem-oq-03-oq-01-oq-01-oq-01 | clean |
| lebesgue-measure-oq-06 | clean |
| erdos-989, erdos-99, erdos-984, erdos-985 | clean |
| erdos-981, erdos-982, erdos-976, erdos-978, erdos-970 | clean |

No integrity issues found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)