### PR TITLE
Fix: replace True stub with honest axiom in erdos-1008-oq-04

### DIFF
--- a/proofs/Proofs/Erdos1008OQ04.lean
+++ b/proofs/Proofs/Erdos1008OQ04.lean
@@ -24,6 +24,7 @@ a K_{s,t}-free subgraph with Ω(m^{1-1/s}) edges (for s ≤ t)?
 -/
 
 import Mathlib.Combinatorics.SimpleGraph.Basic
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
 import Mathlib.Tactic
 
 namespace Erdos1008OQ04
@@ -71,14 +72,22 @@ axiom kst_subgraph_theorem (s t : ℕ) (hs : 1 ≤ s) (hst : s ≤ t) :
 
 /-- **Optimality**: The exponent 1-1/s is best possible.
 
-    The Zarankiewicz construction (random bipartite graphs or algebraic
-    constructions) shows that for n = t^s, the complete bipartite graph
-    K_{n^{1/s}, n} has Θ(n^{2-1/s}) edges and every subgraph with
-    Ω(n^{2-1/s+ε}) edges contains K_{s,t} for any ε > 0.
+    Zarankiewicz's algebraic construction (incidence graphs of finite projective
+    planes) yields K_{s,s}-free graphs with Ω(n^{2-1/s}) edges, matching the
+    Kővári-Sós-Turán upper bound. For prime power q with s = q+1, the point-line
+    incidence graph of PG(2,q) is K_{s,s}-free with q²+q+1 vertices and
+    Θ(n^{2-1/s}) edges. Formalizing this requires finite geometry infrastructure
+    not yet available in Mathlib.
 
-    This shows the CFS exponent cannot be improved. -/
-theorem kst_exponent_optimal (s : ℕ) (hs : 2 ≤ s) :
-    True := trivial -- placeholder: the exponent 1-1/s cannot be improved
+    Axiomatized since the Zarankiewicz construction requires algebraic combinatorics
+    (projective planes over finite fields) not yet formalized in Mathlib. -/
+axiom kst_exponent_optimal (s : ℕ) (hs : 2 ≤ s) :
+    ∃ c : ℝ, 0 < c ∧
+      ∀ n : ℕ, 0 < n →
+        ∃ (G : SimpleGraph (Fin n)) (E : Finset (Sym2 (Fin n))),
+          (E : Set (Sym2 (Fin n))) ⊆ G.edgeSet ∧
+          IsKstFree G s s ∧
+          c * (n : ℝ) ^ ((2 : ℝ) - 1 / (s : ℝ)) ≤ (E.card : ℝ)
 
 -- ============================================================
 -- Part III: Recovery of Parent Result
@@ -112,11 +121,11 @@ theorem c4_from_kst :
 /-
 ## Summary
 
-### Axioms (1)
+### Axioms (2)
 1. `kst_subgraph_theorem` - K_{s,t}-free subgraphs with Ω(m^{1-1/s}) edges exist
+2. `kst_exponent_optimal` - The exponent 1-1/s is optimal (Zarankiewicz construction)
 
-### Proved (2)
-- `kst_exponent_optimal` - The exponent 1-1/s is best possible (vacuous placeholder)
+### Proved (1)
 - `c4_from_kst` - C₄ case as corollary of K_{2,2}
 
 ### Key Insight
@@ -125,9 +134,9 @@ The K_{s,t} generalization reveals the role of the Kővári-Sós-Turán exponent
 The full CFS result uses a more refined "degeneracy" parameter that gives
 better exponents for specific graphs (like 2/3 for C₄ instead of 1/2).
 
-### Axiom Count: 1
-The axiom requires probabilistic method infrastructure (random sampling,
-expectation bounds) not available in Mathlib.
+### Axiom Count: 2
+- kst_subgraph_theorem: requires probabilistic method infrastructure
+- kst_exponent_optimal: requires algebraic geometry (finite projective planes)
 -/
 
 #check @kst_subgraph_theorem

--- a/src/data/proofs/erdos-1008-oq-04/meta.json
+++ b/src/data/proofs/erdos-1008-oq-04/meta.json
@@ -28,10 +28,11 @@
     "originalContributions": [
       "IsKstFree: K_{s,t}-freeness definition",
       "kst_subgraph_theorem: CFS generalization (AXIOM)",
+      "kst_exponent_optimal: exponent optimality via Zarankiewicz construction (AXIOM)",
       "c4_from_kst: C4 case as K_{2,2} corollary (PROVED)"
     ],
     "dateAdded": "2026-04-12",
-    "axiomCount": 1,
+    "axiomCount": 2,
     "lineCount": 136,
     "prerequisites": [
       "Extremal graph theory",
@@ -39,7 +40,7 @@
       "Complete bipartite graphs",
       "Probabilistic method (for proof)"
     ],
-    "assumptions": "1 axiom: kst_subgraph_theorem (K_{s,t}-free subgraph existence with Ω(m^{1-1/s}) edges, Conlon-Fox-Sudakov 2014, requiring the probabilistic method).",
+    "assumptions": "2 axioms: kst_subgraph_theorem (K_{s,t}-free subgraph existence with Ω(m^{1-1/s}) edges, Conlon-Fox-Sudakov 2014) and kst_exponent_optimal (exponent 1-1/s is tight via Zarankiewicz construction, finite projective plane incidence graphs).",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -88,7 +89,7 @@
       "title": "Exponent Optimality",
       "startLine": 72,
       "endLine": 81,
-      "summary": "Axiomatizes that the exponent $1 - 1/s$ is optimal via Zarankiewicz-type constructions. Currently a placeholder (`True`), noting that algebraic constructions in finite geometry provide matching lower bounds."
+      "summary": "Axiomatizes that the exponent 1 − 1/s is optimal via Zarankiewicz algebraic constructions (incidence graphs of finite projective planes). Formally states existence of dense K_{s,s}-free graphs with Ω(n^{2-1/s}) edges."
     },
     {
       "id": "c4-corollary",
@@ -123,7 +124,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Formalizes the $K_{s,t}$ generalization of Erdős 1008 with 2 axioms (CFS existence theorem and exponent optimality) and 1 proved corollary recovering the $C_4 = K_{2,2}$ case. The formalization highlights the subtle exponent discrepancy between the general $K_{s,t}$ bound ($1 - 1/s$) and the specific $C_4$ bound ($2/3$), which arises from the CFS degeneracy refinement.",
+    "summary": "Formalizes the K_{s,t} generalization of Erdős 1008 with 2 axioms (CFS existence theorem and exponent optimality via Zarankiewicz) and 1 proved corollary recovering the C₄ = K_{2,2} case. The formalization highlights the subtle exponent discrepancy between the general K_{s,t} bound (1 − 1/s) and the specific C₄ bound (2/3), which arises from the CFS degeneracy refinement.",
     "implications": "Reveals that the Kővári-Sós-Turán exponent $1/s$ governs a fundamental dichotomy in extremal graph theory: it determines both the maximum edge density of $K_{s,t}$-free graphs (the Zarankiewicz problem) and the minimum size of $K_{s,t}$-free subgraphs in arbitrary dense graphs. The gap between $1 - 1/s$ and the refined degeneracy exponent suggests further structural invariants beyond bipartite completeness are at play.",
     "openQuestions": [
       "Can the $K_{s,t}$ result be extended to non-bipartite forbidden subgraphs $H$, with exponent depending on the Turán exponent of $H$?",
@@ -143,7 +144,7 @@
     ],
     "namespace": "Erdos1008OQ04",
     "lineCount": 136,
-    "axiomCount": 1,
+    "axiomCount": 2,
     "theoremCount": 1,
     "definitionCount": 1,
     "path": "Proofs/Erdos1008OQ04.lean",
@@ -171,6 +172,11 @@
       "name": "kst_subgraph_theorem",
       "type": "axiom",
       "description": "K_{s,t}-free subgraph with Ω(m^{1-1/s}) edges exists"
+    },
+    {
+      "name": "kst_exponent_optimal",
+      "type": "axiom",
+      "description": "Exponent 1-1/s is tight: dense K_{s,s}-free graphs exist via Zarankiewicz construction"
     },
     {
       "name": "c4_from_kst",


### PR DESCRIPTION
## Fix

Replace the `kst_exponent_optimal` True stub with a proper axiom capturing the Zarankiewicz lower bound that shows the CFS exponent 1-1/s cannot be improved.

## Evidence

**Before**:
```lean
theorem kst_exponent_optimal (s : ℕ) (hs : 2 ≤ s) :
    True := trivial -- placeholder: the exponent 1-1/s cannot be improved
```
This creates a false impression that exponent optimality has been formalized, when `True := trivial` proves nothing mathematical.

**After**:
```lean
axiom kst_exponent_optimal (s : ℕ) (hs : 2 ≤ s) :
    ∃ c : ℝ, 0 < c ∧
      ∀ n : ℕ, 0 < n →
        ∃ (G : SimpleGraph (Fin n)) (E : Finset (Sym2 (Fin n))),
          (E : Set (Sym2 (Fin n))) ⊆ G.edgeSet ∧
          IsKstFree G s s ∧
          c * (n : ℝ) ^ ((2 : ℝ) - 1 / (s : ℝ)) ≤ (E.card : ℝ)
```

The axiom honestly captures the Zarankiewicz construction: K_{s,s}-free graphs exist with Ω(n^{2-1/s}) edges. Also adds `import Mathlib.Analysis.SpecialFunctions.Pow.Real` for `Real.rpow`.

**meta.json**: `axiomCount` 1→2, `assumptions` updated, `mainTheorems` updated.

The proof status remains `axiomatized` (correct); `sorries: 0` unchanged (axioms don't add sorries).

Closes #12697

---
Automated fix by lean-mechanic agent.