### PR TITLE
Enrich erdos-1-wip-01: add index.ts, annotations, sections, cross-refs

### DIFF
--- a/src/data/proofs/erdos-1-wip-01/annotations.json
+++ b/src/data/proofs/erdos-1-wip-01/annotations.json
@@ -1,0 +1,198 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "erdos-1-wip-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 37
+    },
+    "type": "concept",
+    "title": "File Overview: Structural Theory of DSS",
+    "content": "This file builds the structural foundations for Erdős Problem #1 (Distinct Subset Sums). It provides:\n\n1. **Superincreasing extension lemma** — the combinatorial engine behind all known DSS constructions\n2. **Powers-of-2 DSS** — the canonical greedy construction by induction\n3. **DSS existence** — fills the `sorry` in OQ03's `minDSSBound` definition\n4. **Positivity constraint** — 0 cannot appear in a DSS set\n5. **Global sum lower bound** — `sum(A) ≥ 2^n − 1` for any n-element DSS set\n\nThe file imports `Proofs.Erdos1Problem` for the `hasDistinctSubsetSums` predicate, which states: for all subsets S, T ⊆ A, if sum(S) = sum(T) then S = T.",
+    "mathContext": "The Distinct Subset Sums (DSS) property for a finite set $A \\subseteq \\mathbb{N}$:\n$$\\text{hasDistinctSubsetSums}(A) \\iff \\forall S, T \\subseteq A,\\; \\sum_{s \\in S} s = \\sum_{t \\in T} t \\Rightarrow S = T$$\nThis forces all $2^{|A|}$ subset sums to be distinct. Erdős (1931, $\\$500$ prize) conjectured that any DSS set of size $n$ must have $\\max(A) \\geq c \\cdot 2^n$ for an absolute constant $c > 0$.",
+    "significance": "key",
+    "prerequisites": [
+      "Finset operations in Lean 4 / Mathlib",
+      "The hasDistinctSubsetSums definition from Erdos1Problem.lean",
+      "Subset sums and pigeonhole principle"
+    ],
+    "relatedConcepts": [
+      "Distinct subset sums",
+      "Erdős Problem #1",
+      "superincreasing sequences",
+      "additive combinatorics"
+    ]
+  },
+  {
+    "id": "ann-superincreasing-lemma",
+    "proofId": "erdos-1-wip-01",
+    "range": {
+      "startLine": 39,
+      "endLine": 118
+    },
+    "type": "theorem",
+    "title": "Superincreasing Extension Lemma",
+    "content": "`dss_superincreasing_extend` is the combinatorial core of this file. It states: if `A` has DSS and `b > sum(A)`, then `insert b A` also has DSS.\n\nThe proof proceeds by a four-way case split on whether `b` belongs to each of the two subsets `S` and `T` with equal sums:\n\n- **Case b ∈ S and b ∈ T**: Erase `b` from both sets. The sums remain equal after subtracting `b`. Apply DSS of `A` to the erased sets, then re-insert `b` to get `S = T`.\n\n- **Case b ∈ S but b ∉ T**: Since `b > sum(A) ≥ sum(T)` (as T ⊆ A), but `b ≤ sum(S)`, we get `sum(T) < b ≤ sum(S)`. This contradicts `sum(S) = sum(T)`.\n\n- **Case b ∉ S but b ∈ T**: Symmetric contradiction.\n\n- **Case b ∉ S and b ∉ T**: Both subsets lie in `A`. Apply DSS of `A` directly.\n\nThis lemma is what makes superincreasing sequences — sequences where each element exceeds the sum of all predecessors — automatically DSS.",
+    "mathContext": "A sequence $a_1 < a_2 < \\cdots < a_n$ is **superincreasing** if $a_k > \\sum_{i<k} a_i$ for each $k$. The lemma says: extending a DSS set by a superincreasing step preserves DSS.\n\nFormally: if $b > \\sum_{a \\in A} a$ and $b \\notin A$ and $A$ is DSS, then $A \\cup \\{b\\}$ is DSS.\n\nThe key insight is the **sum-disjointness** of the two cases: any subset containing $b$ has sum $\\geq b > \\sum(A)$, while any subset not containing $b$ has sum $\\leq \\sum(A)$. These ranges are disjoint, so the equal-sum condition forces both subsets to lie in the same case, reducing to DSS of $A$.",
+    "significance": "key",
+    "prerequisites": [
+      "Finset.erase and Finset.insert",
+      "Finset.sum_le_sum_of_subset_of_nonneg",
+      "Finset.single_le_sum",
+      "hasDistinctSubsetSums"
+    ],
+    "relatedConcepts": [
+      "superincreasing sequence",
+      "DSS property",
+      "case analysis on membership",
+      "pigeonhole principle"
+    ]
+  },
+  {
+    "id": "ann-geometric-sum",
+    "proofId": "erdos-1-wip-01",
+    "range": {
+      "startLine": 119,
+      "endLine": 138
+    },
+    "type": "technique",
+    "title": "Geometric Sum Bound for Powers of 2",
+    "content": "Two auxiliary lemmas establish the arithmetic needed for the powers-of-2 construction:\n\n- `sum_two_pow_range_add_one` (private): $\\sum_{i=0}^{n-1} 2^i + 1 = 2^n$, proved by induction on $n$.\n- `sum_two_pow_lt` (public): $\\sum_{i=0}^{n-1} 2^i < 2^n$, derived by `linarith` from the above.\n\nThese provide the crucial superincreasing property for powers of 2: $2^n > \\sum_{i=0}^{n-1} 2^i$, which is exactly the hypothesis of `dss_superincreasing_extend`.",
+    "mathContext": "The geometric sum identity: $\\sum_{i=0}^{n-1} 2^i = 2^n - 1$, or equivalently $\\sum_{i=0}^{n-1} 2^i + 1 = 2^n$.\n\nThis is the standard formula for the sum of a geometric series with ratio 2, proved here by induction:\n- Base: $\\sum_{i=0}^{-1} 2^i + 1 = 0 + 1 = 1 = 2^0$.\n- Step: $\\sum_{i=0}^{n} 2^i + 1 = (\\sum_{i=0}^{n-1} 2^i) + 2^n + 1 = (2^n) + 2^n = 2 \\cdot 2^n = 2^{n+1}$.",
+    "significance": "supporting",
+    "prerequisites": [
+      "Finset.sum_range_succ",
+      "pow_succ",
+      "induction on ℕ"
+    ],
+    "relatedConcepts": [
+      "geometric series",
+      "powers of 2",
+      "inductive proof"
+    ]
+  },
+  {
+    "id": "ann-powers-of-two",
+    "proofId": "erdos-1-wip-01",
+    "range": {
+      "startLine": 140,
+      "endLine": 176
+    },
+    "type": "theorem",
+    "title": "Powers-of-2 Set Has Distinct Subset Sums",
+    "content": "`powers_of_two_has_dss` proves that the set $\\{2^0, 2^1, \\ldots, 2^{n-1}\\} = \\{1, 2, 4, \\ldots, 2^{n-1}\\}$ has distinct subset sums for any $n$.\n\nThe proof is by induction on $n$:\n- **Base** ($n = 0$): The empty set trivially has DSS.\n- **Step** ($n \\to n+1$): The set for $n+1$ is obtained by inserting $2^n$ into the set for $n$. Since $2^n > \\sum_{i<n} 2^i$ (by `sum_two_pow_lt`), we apply `dss_superincreasing_extend`.\n\nA technical step verifies that the sum over the image set equals the sum over the range: $\\sum_{s \\in \\{2^i : i < n\\}} s = \\sum_{i < n} 2^i$, using injectivity of $i \\mapsto 2^i$ to apply `Finset.sum_image`.",
+    "mathContext": "In binary representation, the $2^n$ subsets of $\\{2^0, 2^1, \\ldots, 2^{n-1}\\}$ have sums $0, 1, 2, \\ldots, 2^n - 1$ — the $n$-bit binary numbers. This bijection with $\\{0, 1, \\ldots, 2^n - 1\\}$ is exactly the DSS property: every subset has a different sum.\n\nThe formal Lean set is $(\\text{Finset.range}\\,n).\\text{image}\\,(2^\\cdot : \\mathbb{N} \\to \\mathbb{N})$, i.e., $\\{2^0, 2^1, \\ldots, 2^{n-1}\\}$ as a Finset, using injectivity of $i \\mapsto 2^i$ to ensure correct cardinality.",
+    "significance": "key",
+    "prerequisites": [
+      "dss_superincreasing_extend",
+      "sum_two_pow_lt",
+      "Finset.sum_image",
+      "Nat.pow_right_injective"
+    ],
+    "relatedConcepts": [
+      "binary representation",
+      "superincreasing sequence",
+      "Finset.image",
+      "inductive proof"
+    ]
+  },
+  {
+    "id": "ann-dss-existence",
+    "proofId": "erdos-1-wip-01",
+    "range": {
+      "startLine": 177,
+      "endLine": 226
+    },
+    "type": "theorem",
+    "title": "DSS Existence for Any n",
+    "content": "Two existence theorems show DSS sets of any size can be constructed:\n\n**`dss_exists`**: For any $n$, there exists an $n$-element set $A$ with DSS and all elements $\\leq n \\cdot 2^n$.\n- Witness: $A = \\{2^0, 2^1, \\ldots, 2^{n-1}\\}$\n- Cardinality $n$: uses injectivity of $i \\mapsto 2^i$\n- Bound: $2^i \\leq 2^n \\leq n \\cdot 2^n$ for $i < n$\n- DSS: `powers_of_two_has_dss`\n\n**`dss_positive_exists`**: For any $n$, there exists an $n$-element DSS set of positive integers with all elements $\\leq 2^n$.\n- Same witness, but with a tighter bound: $2^i < 2^n$ for $i < n$.\n- Positivity: $2^i > 0$ by `positivity`.\n\nThese theorems fill the `sorry` gap in OQ03's `minDSSBound` definition, which needed an existential witness to define the minimum bound function.",
+    "mathContext": "The witness $A = \\{2^0, \\ldots, 2^{n-1}\\}$ satisfies:\n- $|A| = n$ (since $i \\mapsto 2^i$ is injective)\n- $\\forall a \\in A,\\; a \\leq 2^n$ (since $2^i < 2^n$ for $i < n$)\n- DSS (by `powers_of_two_has_dss`)\n\nOQ03's `minDSSBound n` is defined as `Nat.find h` where `h` is the existential $\\exists N, \\exists A, |A| = n \\land \\max(A) \\leq N \\land \\text{DSS}(A)$. Without a proof that this existential holds, `Nat.find` cannot be applied. `dss_exists` provides exactly this proof, replacing the `sorry`.",
+    "significance": "key",
+    "prerequisites": [
+      "powers_of_two_has_dss",
+      "Finset.card_image_of_injective",
+      "Nat.pow_right_injective",
+      "positivity tactic"
+    ],
+    "relatedConcepts": [
+      "Nat.find",
+      "minDSSBound (OQ03)",
+      "existential witness",
+      "powers of 2"
+    ]
+  },
+  {
+    "id": "ann-structural-properties",
+    "proofId": "erdos-1-wip-01",
+    "range": {
+      "startLine": 227,
+      "endLine": 259
+    },
+    "type": "insight",
+    "title": "Structural Constraints: Positivity, Monotonicity, Singletons",
+    "content": "Four elementary structural properties of DSS sets:\n\n**`not_dss_of_mem_zero`**: If $0 \\in A$, then $A$ does NOT have DSS. Proof: $\\emptyset$ and $\\{0\\}$ are distinct subsets with the same sum ($0$). So $A$ fails the injectivity requirement.\n\n**`dss_elements_pos`**: All elements of a nonempty DSS set are positive. Derived by contrapositive from `not_dss_of_mem_zero`: if $a = 0 \\in A$, then $A$ is not DSS.\n\n**`dss_subset`**: Any subset $B \\subseteq A$ of a DSS set $A$ also has DSS. This is immediate: if $S, T \\subseteq B \\subseteq A$ have equal sums, apply DSS of $A$.\n\n**`dss_singleton`**: Any singleton $\\{a\\}$ has DSS. Proof: the only subsets are $\\emptyset$ and $\\{a\\}$; they have sums $0$ and $a$, which are equal only if $a = 0$, but in that case we'd need $\\emptyset = \\{0\\}$, contradiction.",
+    "mathContext": "The monotone property (`dss_subset`) means DSS is a *downward-closed* or *hereditary* property with respect to subset containment: the family of DSS sets is closed under taking subsets. Equivalently, DSS is a **matroid-like** property in the sense that subsets of independent sets are independent.\n\nThe positivity constraint (`dss_elements_pos`) is not just a curiosity — it is essential for bounding arguments. The Erdős conjecture asks about $\\max(A)$ for DSS sets $A \\subseteq \\mathbb{N}_{>0}$; allowing $0$ would trivially violate DSS.",
+    "significance": "supporting",
+    "prerequisites": [
+      "Finset.subset_singleton_iff",
+      "not_dss_of_mem_zero",
+      "hasDistinctSubsetSums"
+    ],
+    "relatedConcepts": [
+      "hereditary set family",
+      "positivity constraint",
+      "Finset.singleton_subset_iff",
+      "matroid independence"
+    ]
+  },
+  {
+    "id": "ann-sum-lower-bound",
+    "proofId": "erdos-1-wip-01",
+    "range": {
+      "startLine": 261,
+      "endLine": 301
+    },
+    "type": "theorem",
+    "title": "Sum Lower Bound: sum(A) ≥ 2^n − 1",
+    "content": "`dss_sum_lower_bound` proves: for any $n$-element DSS set $A$, we have $2^n \\leq \\sum(A) + 1$ (equivalently, $\\sum(A) \\geq 2^n - 1$).\n\nThe proof is a clean pigeonhole argument:\n1. The subset-sum map $S \\mapsto \\sum(S)$ is injective on all $2^n$ subsets of $A$ (by DSS).\n2. All subset sums lie in $\\{0, 1, \\ldots, \\sum(A)\\}$ (a set of size $\\sum(A) + 1$).\n3. By pigeonhole (or Finset cardinality): $2^n \\leq \\sum(A) + 1$.\n\nThe Lean proof uses `Finset.card_image_of_injOn` to compute the image cardinality as $2^n$, then `Finset.card_le_card` to bound it by $\\text{range}(\\sum(A) + 1)$.\n\n`dss_sum_ge_pow_sub_one` is a direct corollary: $2^n - 1 \\leq \\sum(A)$, following from `linarith`.",
+    "mathContext": "The $2^n$ subsets of an $n$-element DSS set $A$ have pairwise distinct sums in $[0, \\sum(A)]$. By injectivity:\n$$2^n = |\\{\\text{sum}(S) : S \\subseteq A\\}| \\leq |\\{0, 1, \\ldots, \\sum(A)\\}| = \\sum(A) + 1$$\n\nThis global sum lower bound $\\sum(A) \\geq 2^n - 1$ is stronger than the per-element bound: since $\\sum(A) \\leq n \\cdot \\max(A)$, we get $\\max(A) \\geq (2^n - 1)/n$. The Erdős conjecture strengthens this to $\\max(A) \\geq c \\cdot 2^n$ for an absolute constant $c$.",
+    "significance": "key",
+    "prerequisites": [
+      "Finset.card_image_of_injOn",
+      "Finset.card_powerset",
+      "Finset.sum_le_sum_of_subset_of_nonneg",
+      "Set.InjOn"
+    ],
+    "relatedConcepts": [
+      "pigeonhole principle",
+      "injective cardinality bound",
+      "Erdős conjecture on DSS",
+      "counting lower bound"
+    ]
+  },
+  {
+    "id": "ann-mindssboundq-fix",
+    "proofId": "erdos-1-wip-01",
+    "range": {
+      "startLine": 303,
+      "endLine": 319
+    },
+    "type": "insight",
+    "title": "OQ03 Fix: minDSSBound Existence Witness",
+    "content": "`minDSS_witness` provides the existential witness that was previously `sorry` in OQ03's `minDSSBound` definition:\n\n$$\\text{minDSS\\_witness}(n) : \\exists N,\\; \\exists A,\\; |A| = n \\land (\\forall a \\in A, a \\leq N) \\land \\text{hasDistinctSubsetSums}(A)$$\n\nWitness: $N = n \\cdot 2^n$ and $A = \\{2^0, \\ldots, 2^{n-1}\\}$. The proof is a one-liner delegating to `dss_exists`.\n\nThis bridges `Erdos1WIP` to `Erdos1OQ03`: OQ03 uses `Nat.find h` to define the minimum bound function, but previously had a `sorry` for the existential `h`. Now `minDSS_witness n` fills that gap, making `minDSSBound` a complete definition.",
+    "mathContext": "OQ03 defines $f(n) = \\min\\{N : \\exists A \\subseteq [N], |A| = n, \\text{DSS}(A)\\}$ using Lean's `Nat.find`. The function `Nat.find : (∃ n, P n) → ℕ` requires an actual proof of the existential as input. Without `minDSS_witness`, OQ03 had a `sorry` blocking the `minDSSBound` definition.\n\nWith $N = n \\cdot 2^n$ as the witness bound, the minimum $f(n)$ satisfies $f(n) \\leq n \\cdot 2^n$. The Conway-Guy sequence (also in OQ03) gives a tighter upper bound; the Erdős conjecture asks for the sharp lower bound $f(n) \\geq c \\cdot 2^n$.",
+    "significance": "key",
+    "prerequisites": [
+      "dss_exists",
+      "Nat.find",
+      "minDSSBound (OQ03)"
+    ],
+    "relatedConcepts": [
+      "minDSSBound",
+      "Erdos1OQ03",
+      "sorry elimination",
+      "Conway-Guy sequence",
+      "Erdős Problem #1"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-1-wip-01/index.ts
+++ b/src/data/proofs/erdos-1-wip-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos1WIP01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos1Wip01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos1Wip01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos1Wip01Data: ProofData = {
+  proof: erdos1Wip01Proof,
+  annotations: erdos1Wip01Annotations,
+}

--- a/src/data/proofs/erdos-1-wip-01/meta.json
+++ b/src/data/proofs/erdos-1-wip-01/meta.json
@@ -19,7 +19,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "None. All results are fully proved in Lean 4.",
-    "lineCount": 220,
+    "lineCount": 319,
     "theoremCount": 12,
     "definitionCount": 0,
     "dateAdded": "2026-04-26",
@@ -50,6 +50,94 @@
       "Elementary number theory (powers of 2)"
     ]
   },
+  "sections": [
+    {
+      "id": "imports-header",
+      "title": "Imports and Header",
+      "startLine": 1,
+      "endLine": 37,
+      "summary": "File header describing the seven structural results, references to Erdős (1955), Dubroff-Fox-Xu (2021), Conway-Guy (1968), and OEIS A005318. Imports Proofs.Erdos1Problem (the hasDistinctSubsetSums predicate) and opens Finset namespace."
+    },
+    {
+      "id": "superincreasing-lemma",
+      "title": "Part I: Superincreasing Extension Lemma",
+      "startLine": 39,
+      "endLine": 118,
+      "summary": "dss_superincreasing_extend: if A has DSS and b > sum(A) with b ∉ A, then insert b A has DSS. Proved by four-way case split on b ∈ S, b ∈ T. The combinatorial core underlying all known DSS constructions."
+    },
+    {
+      "id": "geometric-sum",
+      "title": "Part II: Geometric Sum Bound",
+      "startLine": 119,
+      "endLine": 138,
+      "summary": "sum_two_pow_range_add_one (private): ∑_{i<n} 2^i + 1 = 2^n by induction. sum_two_pow_lt: ∑_{i<n} 2^i < 2^n by linarith. Provides the superincreasing property for powers of 2.",
+      "mathContext": "$\\sum_{i=0}^{n-1} 2^i = 2^n - 1$, proved by induction, providing the strict bound $2^n > \\sum_{i=0}^{n-1} 2^i$ needed for the superincreasing extension step."
+    },
+    {
+      "id": "powers-of-two-dss",
+      "title": "Part III: Powers of 2 Give DSS",
+      "startLine": 140,
+      "endLine": 176,
+      "summary": "powers_of_two_has_dss: {2^0, 2^1, …, 2^(n-1)} has distinct subset sums for any n. Proved by induction via dss_superincreasing_extend. Uses Finset.sum_image with injectivity of i ↦ 2^i.",
+      "mathContext": "The set $\\{1, 2, 4, \\ldots, 2^{n-1}\\}$ represents the $n$-bit binary numbers: its $2^n$ subsets have sums $0, 1, \\ldots, 2^n - 1$, all distinct."
+    },
+    {
+      "id": "dss-existence",
+      "title": "Part IV: DSS Existence for Any n",
+      "startLine": 177,
+      "endLine": 226,
+      "summary": "dss_exists: ∃ A with |A| = n, all elements ≤ n·2^n, and DSS. dss_positive_exists: ∃ A with |A| = n, all elements positive and ≤ 2^n, and DSS. Both use the powers-of-2 witness. Fills the sorry in OQ03's minDSSBound."
+    },
+    {
+      "id": "structural-properties",
+      "title": "Part V: Structural Properties",
+      "startLine": 227,
+      "endLine": 259,
+      "summary": "not_dss_of_mem_zero: 0 ∈ A destroys DSS (∅ and {0} have same sum). dss_elements_pos: all elements of a DSS set are positive. dss_subset: hereditary property — any subset of a DSS set has DSS. dss_singleton: any singleton has DSS."
+    },
+    {
+      "id": "sum-lower-bound",
+      "title": "Part VI: Sum Lower Bound",
+      "startLine": 261,
+      "endLine": 301,
+      "summary": "dss_sum_lower_bound: 2^n ≤ sum(A) + 1 for any n-element DSS set A (by pigeonhole on the 2^n distinct subset sums in [0, sum(A)]). dss_sum_ge_pow_sub_one: sum(A) ≥ 2^n − 1 as corollary.",
+      "mathContext": "The $2^n$ distinct subset sums lie in $\\{0, \\ldots, \\sum(A)\\}$, forcing $2^n \\leq \\sum(A) + 1$ by injectivity counting. This global bound implies $\\max(A) \\geq (2^n-1)/n$."
+    },
+    {
+      "id": "mindssboundq-fix",
+      "title": "Part VII: Connection to OQ03 minDSSBound",
+      "startLine": 303,
+      "endLine": 319,
+      "summary": "minDSS_witness: ∃ N, ∃ A, |A| = n ∧ (∀ a ∈ A, a ≤ N) ∧ DSS(A). One-liner delegating to dss_exists. Fills the sorry that blocked OQ03's Nat.find-based minDSSBound definition."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "erdos-1",
+      "relationship": "extends",
+      "description": "The main Erdős Problem #1 gallery entry — this WIP file provides structural foundations that support the OQ01–OQ04 sub-entries"
+    },
+    {
+      "targetId": "erdos-1-oq-01",
+      "relationship": "related",
+      "description": "OQ01 proves the counting lower bound max(A) ≥ 2^(n-1)/n via pigeonhole — the same argument that this file generalizes to the global sum lower bound sum(A) ≥ 2^n − 1"
+    },
+    {
+      "targetId": "erdos-1-oq-02",
+      "relationship": "related",
+      "description": "OQ02's DFX entropy framework (Dubroff-Fox-Xu 2021) uses information-theoretic methods to improve the constant in the lower bound — complementing this file's elementary pigeonhole approach"
+    },
+    {
+      "targetId": "erdos-1-oq-03",
+      "relationship": "foundational",
+      "description": "OQ03 defines minDSSBound using Nat.find, which requires the existential witness now provided by dss_exists / minDSS_witness in this file — directly filling OQ03's sorry"
+    },
+    {
+      "targetId": "erdos-1-oq-04",
+      "relationship": "related",
+      "description": "OQ04 studies extremal DSS sets (those achieving the minimum max element) — the structural constraints proved here (positivity, sum lower bound) are necessary conditions for extremality"
+    }
+  ],
   "conclusion": {
     "summary": "This file provides the structural foundations for Erdős Problem #1: the superincreasing extension lemma (the construction principle behind all known DSS sets), the powers-of-2 DSS construction (proved by induction), existence of DSS sets for any n (filling the sorry in OQ03), positivity of elements, and the global sum lower bound. All results have 0 sorries and 0 axioms.",
     "implications": "The superincreasing lemma gives a recursive DSS construction: start with A = {} and repeatedly add any element larger than the current sum. This shows DSS sets are not 'rare' — they can be built greedily. The powers-of-2 construction is the smallest such greedy sequence. The Conway-Guy sequence (OQ03) is a more efficient greedy strategy that nearly achieves the conjectured optimal constant c = 1/(2π^{1/2}) ≈ 0.28.",


### PR DESCRIPTION
First-pass enrichment for erdos-1-wip-01 (Erdős #1 Structural Theory).

**What was missing:**
- No `index.ts` — proof was invisible on the site ("proof not found")
- No `annotations.json`
- No `sections` array in meta.json
- Incorrect `lineCount` (220 vs actual 319)

**Changes:**
- Created `index.ts` to make proof discoverable on the gallery
- Created `annotations.json` with 7 annotations covering all 7 parts:
  - File header and DSS definition context (lines 1–37)
  - Superincreasing extension lemma with 4-way case analysis (lines 39–118)
  - Geometric sum bound for powers-of-2 (lines 119–138)
  - Powers-of-2 DSS by induction (lines 140–176)
  - DSS existence theorems filling OQ03 sorry (lines 177–226)
  - Structural properties: positivity, hereditary, singleton (lines 227–259)
  - Sum lower bound sum(A) ≥ 2^n−1 via pigeonhole (lines 261–301)
  - minDSS_witness connecting to OQ03 minDSSBound (lines 303–319)
- Added `sections` array (7 sections) to meta.json
- Added `crossReferences` to erdos-1 and OQ01–OQ04
- Fixed `lineCount`: 220 → 319