### PR TITLE
fix(audit): correct leanFile.axiomCount for 7 entries — remove inherited axiom inflation

### DIFF
--- a/src/data/proofs/greens-theorem-oq-04/meta.json
+++ b/src/data/proofs/greens-theorem-oq-04/meta.json
@@ -241,7 +241,7 @@
     ],
     "namespace": "GreensTheoremOQ04",
     "lineCount": 587,
-    "axiomCount": 2,
+    "axiomCount": 0,
     "theoremCount": 23,
     "definitionCount": 14,
     "path": "Proofs/GreensTheoremOQ04.lean",

--- a/src/data/proofs/inverse-galois-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-oq-01/meta.json
@@ -303,7 +303,7 @@
   "leanFile": {
     "path": "Proofs/InverseGaloisOQ01.lean",
     "lineCount": 723,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "sorries": 1,
     "theoremCount": 46,
     "definitionCount": 1,

--- a/src/data/proofs/inverse-galois/meta.json
+++ b/src/data/proofs/inverse-galois/meta.json
@@ -303,7 +303,7 @@
   "leanFile": {
     "path": "Proofs/InverseGalois.lean",
     "lineCount": 1882,
-    "axiomCount": 5,
+    "axiomCount": 4,
     "sorries": 0,
     "theoremCount": 105,
     "definitionCount": 1,

--- a/src/data/proofs/yang-mills-2d/meta.json
+++ b/src/data/proofs/yang-mills-2d/meta.json
@@ -175,7 +175,7 @@
   "leanFile": {
     "lineCount": 28075,
     "structureCount": 365,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 1787,
     "lemmaCount": 0,
     "defCount": 641,

--- a/src/data/proofs/yang-mills-lattice/meta.json
+++ b/src/data/proofs/yang-mills-lattice/meta.json
@@ -148,7 +148,7 @@
   "leanFile": {
     "lineCount": 28075,
     "structureCount": 365,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 1787,
     "lemmaCount": 0,
     "defCount": 641,

--- a/src/data/proofs/yang-mills-transfer-matrix/meta.json
+++ b/src/data/proofs/yang-mills-transfer-matrix/meta.json
@@ -138,7 +138,7 @@
   "leanFile": {
     "lineCount": 28075,
     "structureCount": 365,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 1787,
     "lemmaCount": 0,
     "defCount": 641,

--- a/src/data/proofs/yang-mills/meta.json
+++ b/src/data/proofs/yang-mills/meta.json
@@ -203,7 +203,7 @@
     ],
     "namespace": "YangMillsMassGap",
     "lineCount": 48,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 1806,
     "definitionCount": 260,
     "path": "Proofs/YangMillsMassGap.lean",


### PR DESCRIPTION
## Fix

`leanFile.axiomCount` for 7 gallery entries was set to semantic counts (including inherited/imported axioms) rather than direct `^axiom` declarations in the file itself. This caused false-positive audit alerts.

## Evidence

| Entry | Before | After | Reason |
|-------|--------|-------|--------|
| yang-mills | 1 | 0 | axiom is in `YangMills/Classical.lean`, not wrapper |
| yang-mills-2d | 1 | 0 | axiom is in `YangMills/Classical.lean`, not `Exploration.lean` |
| yang-mills-lattice | 1 | 0 | same as yang-mills-2d |
| yang-mills-transfer-matrix | 1 | 0 | same as yang-mills-2d |
| inverse-galois-oq-01 | 1 | 0 | axiom is in `InverseGaloisA5.lean`, not OQ01 |
| inverse-galois | 5 | 4 | 4 direct declarations; 1 inherited from `InverseGaloisA5.lean` |
| greens-theorem-oq-04 | 2 | 0 | axioms are in `GreensTheoremOQ03.lean`, not OQ04 |

`meta.axiomCount` (semantic count of all assumptions) and all public-facing claims are unchanged.

Resolves remaining unfixed entries from #12561 (closed without fix).

---
Automated fix by lean-mechanic agent.