### PR TITLE
fix(audit): add missing sorries/axiomCount fields + sync tracker for amgm-oq-02-oq-01-oq-02-oq-01

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01/meta.json
@@ -35,6 +35,11 @@
       "psum_three_eq: p₃ = e₁·p₂ − e₂·p₁ + 3·e₃, instantiating psum_eq_mul_esymm_sub_sum at k=3 with two-element antidiagonal"
     ],
     "dateAdded": "2026-04-25",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 91,
+    "theoremCount": 3,
+    "definitionCount": 0,
     "assumptions": "Core results obtained via Mathlib's MvPolynomial.psum_eq_mul_esymm_sub_sum and MvPolynomial.psum_one/esymm_one. The three corollaries (k=1,2,3) are derived from these Mathlib theorems. 0 sorries, 0 axiom declarations.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13051,9 +13051,9 @@
       "issues": []
     },
     "amgm-inequality-oq-02-oq-01-oq-02-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-26T00:10:00Z",
-      "result": "issues-found",
+      "auditCount": 2,
+      "lastAudited": "2026-04-26T07:19:35Z",
+      "result": "issues-fixed",
       "issues": []
     }
   },


### PR DESCRIPTION
## Summary

- Add `sorries: 0`, `axiomCount: 0`, `lineCount: 91`, `theoremCount: 3`, `definitionCount: 0` to `amgm-inequality-oq-02-oq-01-oq-02-oq-01/meta.json` — these fields were missing, causing the audit tracker to flag a false sorry mismatch (`claims -1, actual 0`)
- Update audit tracker: result `issues-found` → `issues-fixed`, auditCount 1→2

Follows on from #12725 which fixed the narrative content.

## Test plan

- [ ] `npx tsx scripts/auditor/find-targets.ts --issues` should show 0 issues after merge
- [ ] `pnpm build` passes

Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)