### PR TITLE
fix(audit): sync leanFile.axiomCount to direct ^axiom declarations — 54 entries

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03/meta.json
@@ -117,7 +117,7 @@
   "leanFile": {
     "namespace": "AmgmInequalityOQ02OQ03OQ03",
     "lineCount": 66,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 3,
     "definitionCount": 0,
     "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",

--- a/src/data/proofs/amgm-inequality-oq-02-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03/meta.json
@@ -137,7 +137,7 @@
     ],
     "namespace": "AmgmInequalityOQ02OQ03",
     "lineCount": 226,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 1,
     "path": "Proofs/AmgmInequalityOQ02OQ03.lean",

--- a/src/data/proofs/angle-trisection/meta.json
+++ b/src/data/proofs/angle-trisection/meta.json
@@ -99,7 +99,7 @@
     "namespace": "AngleTrisection",
     "lineCount": 383,
     "structureCount": 0,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 23,
     "lemmaCount": 0,
     "defCount": 6,

--- a/src/data/proofs/area-of-circle-oq-02-oq-04/meta.json
+++ b/src/data/proofs/area-of-circle-oq-02-oq-04/meta.json
@@ -102,7 +102,7 @@
   "leanFile": {
     "namespace": "BishopGromov",
     "lineCount": 272,
-    "axiomCount": 3,
+    "axiomCount": 0,
     "theoremCount": 18,
     "definitionCount": 3,
     "path": "Proofs/AreaOfCircleOQ02OQ04.lean",

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-04/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-04/meta.json
@@ -160,7 +160,7 @@
     }
   ],
   "leanFile": {
-    "axiomCount": 4,
+    "axiomCount": 0,
     "lineCount": 251,
     "path": "Proofs/BorsukUlamOQ02OQ01OQ04.lean",
     "sorries": 0

--- a/src/data/proofs/borsuk-ulam-oq-04/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-04/meta.json
@@ -138,7 +138,7 @@
     "opens": [],
     "namespace": "BorsukUlamOQ04",
     "lineCount": 300,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 11,
     "path": "Proofs/BorsukUlamOQ04.lean",

--- a/src/data/proofs/bounded-prime-gaps-oq-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-01/meta.json
@@ -69,7 +69,7 @@
   "leanFile": {
     "namespace": "BoundedPrimeGapsOQ01",
     "lineCount": 438,
-    "axiomCount": 3,
+    "axiomCount": 0,
     "theoremCount": 26,
     "definitionCount": 5,
     "path": "Proofs/BoundedPrimeGapsOQ01.lean",

--- a/src/data/proofs/brouwer-fixed-point-oq-04-oq-02/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-04-oq-02/meta.json
@@ -147,7 +147,7 @@
     ],
     "namespace": "NashBrouwer",
     "lineCount": 519,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "sorries": 0,
     "path": "Proofs/BrouwerFixedPointOQ04OQ02.lean"
   },

--- a/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04/meta.json
@@ -105,7 +105,7 @@
   "leanFile": {
     "namespace": "CauchyCrofton",
     "lineCount": 332,
-    "axiomCount": 2,
+    "axiomCount": 0,
     "theoremCount": 19,
     "definitionCount": 5,
     "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04.lean",

--- a/src/data/proofs/buffons-needle-oq-02-oq-02/meta.json
+++ b/src/data/proofs/buffons-needle-oq-02-oq-02/meta.json
@@ -228,7 +228,7 @@
     ],
     "namespace": "BuffonsNeedleOQ02OQ02",
     "lineCount": 376,
-    "axiomCount": 2,
+    "axiomCount": 1,
     "theoremCount": 15,
     "definitionCount": 4,
     "path": "Proofs/BuffonsNeedleOQ02OQ02.lean",

--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-02/meta.json
@@ -131,7 +131,7 @@
   "leanFile": {
     "namespace": "CantorDiagonalizationOQ03OQ01OQ02",
     "lineCount": 275,
-    "axiomCount": 2,
+    "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 4,
     "path": "Proofs/CantorDiagonalizationOQ03OQ01OQ02.lean",

--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-03/meta.json
@@ -129,7 +129,7 @@
   "leanFile": {
     "namespace": "CantorDiagonalizationOQ03OQ01OQ03",
     "lineCount": 256,
-    "axiomCount": 5,
+    "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 5,
     "path": "Proofs/CantorDiagonalizationOQ03OQ01OQ03.lean",

--- a/src/data/proofs/dissection-of-cubes-oq-01-oq-01/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01-oq-01/meta.json
@@ -142,7 +142,7 @@
     ],
     "namespace": "DissectionOfCubesOQ01OQ01",
     "lineCount": 328,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 26,
     "definitionCount": 5,
     "path": "Proofs/DissectionOfCubesOQ01OQ01.lean",

--- a/src/data/proofs/dissection-of-cubes-oq-01/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01/meta.json
@@ -140,7 +140,7 @@
     ],
     "namespace": "DissectionOfCubesOQ01",
     "lineCount": 274,
-    "axiomCount": 2,
+    "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 4,
     "path": "Proofs/DissectionOfCubesOQ01.lean",

--- a/src/data/proofs/dissection-of-cubes-oq-02/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-02/meta.json
@@ -177,7 +177,7 @@
     ],
     "namespace": "DissectionOfCubesOQ02",
     "lineCount": 379,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 18,
     "definitionCount": 5,
     "opens": [

--- a/src/data/proofs/dissection-of-cubes-oq-03/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-03/meta.json
@@ -165,7 +165,7 @@
   "leanFile": {
     "namespace": "(builds on DissectionOfCubes namespace)",
     "lineCount": 599,
-    "axiomCount": 2,
+    "axiomCount": 0,
     "theoremCount": 17,
     "definitionCount": 13,
     "path": "Proofs/DissectionOfCubesOQ03.lean",

--- a/src/data/proofs/erdos-100-oq-02/meta.json
+++ b/src/data/proofs/erdos-100-oq-02/meta.json
@@ -114,7 +114,7 @@
     ],
     "namespace": "Erdos100OQ02",
     "lineCount": 60,
-    "axiomCount": 2,
+    "axiomCount": 0,
     "theoremCount": 2,
     "definitionCount": 0,
     "path": "Proofs/Erdos100OQ02.lean",

--- a/src/data/proofs/erdos-1007-oq-05/meta.json
+++ b/src/data/proofs/erdos-1007-oq-05/meta.json
@@ -133,7 +133,7 @@
     ],
     "namespace": "Erdos1007OQ05",
     "lineCount": 141,
-    "axiomCount": 4,
+    "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 0,
     "path": "Proofs/Erdos1007OQ05.lean",

--- a/src/data/proofs/erdos-1012-oq-03/meta.json
+++ b/src/data/proofs/erdos-1012-oq-03/meta.json
@@ -257,7 +257,7 @@
     ],
     "namespace": "Erdos1012OQ03",
     "lineCount": 1827,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "sorries": 1,
     "path": "Proofs/Erdos1012OQ03.lean",
     "theoremCount": 9,

--- a/src/data/proofs/erdos-1014-oq-02/meta.json
+++ b/src/data/proofs/erdos-1014-oq-02/meta.json
@@ -141,7 +141,7 @@
     ],
     "namespace": "Erdos1014OQ02",
     "lineCount": 186,
-    "axiomCount": 12,
+    "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 0,
     "substantiveTheoremCount": 4,

--- a/src/data/proofs/erdos-105-oq-05/meta.json
+++ b/src/data/proofs/erdos-105-oq-05/meta.json
@@ -184,7 +184,7 @@
     ],
     "namespace": "Erdos105OQ05",
     "lineCount": 206,
-    "axiomCount": 3,
+    "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 9,
     "path": "Proofs/Erdos105OQ05.lean",

--- a/src/data/proofs/erdos-1059-oq-04/meta.json
+++ b/src/data/proofs/erdos-1059-oq-04/meta.json
@@ -64,7 +64,7 @@
   },
   "leanFile": {
     "lineCount": 147,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "note": "axiomCount=0 reflects declarations in this file only; meta.axiomCount=1 counts the inherited axiom from Proofs.Erdos1059OQ01 (density_one_conjecture)",
     "sorries": 0,
     "path": "Proofs/Erdos1059OQ04.lean"

--- a/src/data/proofs/erdos-1126-oq-01/meta.json
+++ b/src/data/proofs/erdos-1126-oq-01/meta.json
@@ -185,7 +185,7 @@
     "path": "Proofs/Erdos1126OQ01Problem.lean",
     "filename": "Erdos1126OQ01Problem.lean",
     "lineCount": 472,
-    "axiomCount": 7,
+    "axiomCount": 5,
     "sorries": 0
   },
   "sorries": 0

--- a/src/data/proofs/erdos-114-oq-04/meta.json
+++ b/src/data/proofs/erdos-114-oq-04/meta.json
@@ -126,7 +126,7 @@
     ],
     "namespace": "Erdos114OQ04",
     "lineCount": 177,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 5,
     "path": "Proofs/Erdos114OQ04Problem.lean",

--- a/src/data/proofs/erdos-1155-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-1155-oq-01-oq-01/meta.json
@@ -181,7 +181,7 @@
   "leanFile": {
     "lineCount": 296,
     "path": "Proofs/Erdos1155OQ01OQ01.lean",
-    "axiomCount": 6,
+    "axiomCount": 0,
     "sorries": 0
   },
   "sorries": 0

--- a/src/data/proofs/erdos-1155-oq-01/meta.json
+++ b/src/data/proofs/erdos-1155-oq-01/meta.json
@@ -338,7 +338,7 @@
   "leanFile": {
     "lineCount": 411,
     "structureCount": 0,
-    "axiomCount": 6,
+    "axiomCount": 0,
     "theoremCount": 18,
     "lemmaCount": 0,
     "defCount": 3,

--- a/src/data/proofs/erdos-1155-oq-02/meta.json
+++ b/src/data/proofs/erdos-1155-oq-02/meta.json
@@ -154,7 +154,7 @@
   "leanFile": {
     "lineCount": 314,
     "path": "Proofs/Erdos1155OQ02.lean",
-    "axiomCount": 7,
+    "axiomCount": 1,
     "sorries": 0
   },
   "sorries": 0

--- a/src/data/proofs/erdos-2-oq-01/meta.json
+++ b/src/data/proofs/erdos-2-oq-01/meta.json
@@ -137,7 +137,7 @@
   "leanFile": {
     "lineCount": 232,
     "path": "Proofs/Erdos2OQ01.lean",
-    "axiomCount": 3,
+    "axiomCount": 0,
     "sorries": 0
   },
   "sorries": 0

--- a/src/data/proofs/erdos-25/meta.json
+++ b/src/data/proofs/erdos-25/meta.json
@@ -150,7 +150,7 @@
     ],
     "namespace": null,
     "lineCount": 166,
-    "axiomCount": 3,
+    "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 6,
     "path": "Proofs/Erdos25Problem.lean",

--- a/src/data/proofs/erdos-504/meta.json
+++ b/src/data/proofs/erdos-504/meta.json
@@ -16,7 +16,7 @@
     ],
     "namespace": "Erdos504",
     "lineCount": 217,
-    "axiomCount": 5,
+    "axiomCount": 4,
     "theoremCount": 1,
     "definitionCount": 5,
     "path": "Proofs/Erdos504Problem.lean",

--- a/src/data/proofs/erdos-525-oq-02/meta.json
+++ b/src/data/proofs/erdos-525-oq-02/meta.json
@@ -110,7 +110,7 @@
     ],
     "namespace": "Erdos525OQ02",
     "lineCount": 144,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 4,
     "path": "Proofs/Erdos525OQ02.lean",

--- a/src/data/proofs/erdos-529/meta.json
+++ b/src/data/proofs/erdos-529/meta.json
@@ -225,7 +225,7 @@
     ],
     "namespace": "Erdos529",
     "lineCount": 306,
-    "axiomCount": 7,
+    "axiomCount": 5,
     "theoremCount": 6,
     "definitionCount": 5,
     "path": "Proofs/Erdos529Problem.lean",

--- a/src/data/proofs/erdos-756/meta.json
+++ b/src/data/proofs/erdos-756/meta.json
@@ -223,7 +223,7 @@
     ],
     "namespace": "Erdos756",
     "lineCount": 268,
-    "axiomCount": 5,
+    "axiomCount": 2,
     "theoremCount": 8,
     "definitionCount": 15,
     "path": "Proofs/Erdos756Problem.lean",

--- a/src/data/proofs/erdos-96/meta.json
+++ b/src/data/proofs/erdos-96/meta.json
@@ -150,7 +150,7 @@
     ],
     "namespace": "Erdos96",
     "lineCount": 285,
-    "axiomCount": 3,
+    "axiomCount": 2,
     "theoremCount": 2,
     "definitionCount": 10,
     "path": "Proofs/Erdos96Problem.lean",

--- a/src/data/proofs/euler-polyhedral-formula-oq-02-oq-01/meta.json
+++ b/src/data/proofs/euler-polyhedral-formula-oq-02-oq-01/meta.json
@@ -238,7 +238,7 @@
     ],
     "namespace": "SmoothGaussBonnet",
     "lineCount": 786,
-    "axiomCount": 10,
+    "axiomCount": 0,
     "theoremCount": 60,
     "definitionCount": 4,
     "path": "Proofs/EulerPolyhedralOQ02OQ01.lean",

--- a/src/data/proofs/four-color-theorem-oq-02/meta.json
+++ b/src/data/proofs/four-color-theorem-oq-02/meta.json
@@ -94,7 +94,7 @@
     ]
   },
   "leanFile": {
-    "axiomCount": 2,
+    "axiomCount": 0,
     "lineCount": 86,
     "path": "Proofs/FourColorTheoremOQ02.lean",
     "sorries": 0

--- a/src/data/proofs/godel-second-incompleteness-oq02/meta.json
+++ b/src/data/proofs/godel-second-incompleteness-oq02/meta.json
@@ -160,7 +160,7 @@
   ],
   "sorries": 0,
   "leanFile": {
-    "axiomCount": 6,
+    "axiomCount": 1,
     "lineCount": 258,
     "sorries": 0,
     "path": "Proofs/GodelSecondIncompletenessOQ02.lean"

--- a/src/data/proofs/greens-theorem-oq-04/meta.json
+++ b/src/data/proofs/greens-theorem-oq-04/meta.json
@@ -241,7 +241,7 @@
     ],
     "namespace": "GreensTheoremOQ04",
     "lineCount": 587,
-    "axiomCount": 2,
+    "axiomCount": 0,
     "theoremCount": 23,
     "definitionCount": 14,
     "path": "Proofs/GreensTheoremOQ04.lean",

--- a/src/data/proofs/hilbert-15-oq-02/meta.json
+++ b/src/data/proofs/hilbert-15-oq-02/meta.json
@@ -103,7 +103,7 @@
     "opens": [],
     "namespace": "LRComplexity",
     "lineCount": 506,
-    "axiomCount": 3,
+    "axiomCount": 0,
     "theoremCount": 17,
     "definitionCount": 3,
     "path": "Proofs/Hilbert15OQ02.lean",

--- a/src/data/proofs/hilbert-21/meta.json
+++ b/src/data/proofs/hilbert-21/meta.json
@@ -150,7 +150,7 @@
     "opens": [],
     "namespace": "Hilbert21",
     "lineCount": 386,
-    "axiomCount": 4,
+    "axiomCount": 3,
     "theoremCount": 4,
     "definitionCount": 5,
     "path": "Proofs/Hilbert21RiemannHilbert.lean",

--- a/src/data/proofs/hilbert-22/meta.json
+++ b/src/data/proofs/hilbert-22/meta.json
@@ -135,7 +135,7 @@
     "opens": [],
     "namespace": "Hilbert22Uniformization",
     "lineCount": 305,
-    "axiomCount": 2,
+    "axiomCount": 0,
     "sorries": 0,
     "theoremCount": 5,
     "definitionCount": 6,

--- a/src/data/proofs/hilbert-23/meta.json
+++ b/src/data/proofs/hilbert-23/meta.json
@@ -138,7 +138,7 @@
   "leanFile": {
     "path": "Proofs/Hilbert23CalculusVariations.lean",
     "lineCount": 328,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "sorries": 0,
     "theoremCount": 1,
     "definitionCount": 4

--- a/src/data/proofs/inverse-galois-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-oq-01/meta.json
@@ -303,7 +303,7 @@
   "leanFile": {
     "path": "Proofs/InverseGaloisOQ01.lean",
     "lineCount": 723,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "sorries": 1,
     "theoremCount": 46,
     "definitionCount": 1,

--- a/src/data/proofs/inverse-galois/meta.json
+++ b/src/data/proofs/inverse-galois/meta.json
@@ -303,7 +303,7 @@
   "leanFile": {
     "path": "Proofs/InverseGalois.lean",
     "lineCount": 1882,
-    "axiomCount": 5,
+    "axiomCount": 4,
     "sorries": 0,
     "theoremCount": 105,
     "definitionCount": 1,

--- a/src/data/proofs/navier-stokes-existence/meta.json
+++ b/src/data/proofs/navier-stokes-existence/meta.json
@@ -265,7 +265,7 @@
     ],
     "namespace": "NavierStokesRegularity",
     "lineCount": 21111,
-    "axiomCount": 5,
+    "axiomCount": 0,
     "theoremCount": 845,
     "definitionCount": 104,
     "path": "Proofs/NavierStokes.lean",

--- a/src/data/proofs/navier-stokes/meta.json
+++ b/src/data/proofs/navier-stokes/meta.json
@@ -337,7 +337,7 @@
   "leanFile": {
     "lineCount": 21111,
     "structureCount": 249,
-    "axiomCount": 5,
+    "axiomCount": 0,
     "theoremCount": 845,
     "lemmaCount": 14,
     "defCount": 104,

--- a/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
@@ -148,7 +148,7 @@
     ],
     "namespace": "FanoFromConditionalEntropy",
     "lineCount": 168,
-    "axiomCount": 2,
+    "axiomCount": 1,
     "sorries": 0,
     "path": "Proofs/ShannonChannelCodingOQ02OQ01.lean",
     "theoremCount": 3,

--- a/src/data/proofs/shannon-channel-coding-oq-02-oq-04/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02-oq-04/meta.json
@@ -142,7 +142,7 @@
   "leanFile": {
     "namespace": "InformationTheory.ChannelCoding.SymmetricCapacity",
     "lineCount": 248,
-    "axiomCount": 4,
+    "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 1,
     "path": "Proofs/ShannonChannelCodingOQ02OQ04.lean",

--- a/src/data/proofs/shannon-channel-coding-oq-02/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02/meta.json
@@ -174,7 +174,7 @@
     }
   ],
   "leanFile": {
-    "axiomCount": 4,
+    "axiomCount": 0,
     "lineCount": 297,
     "path": "Proofs/ShannonChannelCodingOQ02.lean",
     "sorries": 0

--- a/src/data/proofs/triangle-angle-sum-oq-02/meta.json
+++ b/src/data/proofs/triangle-angle-sum-oq-02/meta.json
@@ -138,7 +138,7 @@
     ],
     "namespace": "TriangleAngleSumGaussBonnet",
     "lineCount": 382,
-    "axiomCount": 3,
+    "axiomCount": 0,
     "sorries": 0,
     "path": "Proofs/TriangleAngleSumOQ02.lean",
     "theoremCount": 22,

--- a/src/data/proofs/yang-mills-2d/meta.json
+++ b/src/data/proofs/yang-mills-2d/meta.json
@@ -175,7 +175,7 @@
   "leanFile": {
     "lineCount": 28075,
     "structureCount": 365,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 1787,
     "lemmaCount": 0,
     "defCount": 641,

--- a/src/data/proofs/yang-mills-lattice/meta.json
+++ b/src/data/proofs/yang-mills-lattice/meta.json
@@ -148,7 +148,7 @@
   "leanFile": {
     "lineCount": 28075,
     "structureCount": 365,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 1787,
     "lemmaCount": 0,
     "defCount": 641,

--- a/src/data/proofs/yang-mills-transfer-matrix/meta.json
+++ b/src/data/proofs/yang-mills-transfer-matrix/meta.json
@@ -138,7 +138,7 @@
   "leanFile": {
     "lineCount": 28075,
     "structureCount": 365,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 1787,
     "lemmaCount": 0,
     "defCount": 641,

--- a/src/data/proofs/yang-mills/meta.json
+++ b/src/data/proofs/yang-mills/meta.json
@@ -203,7 +203,7 @@
     ],
     "namespace": "YangMillsMassGap",
     "lineCount": 48,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 1806,
     "definitionCount": 260,
     "path": "Proofs/YangMillsMassGap.lean",


### PR DESCRIPTION
## Fix

`leanFile.axiomCount` in 54 gallery entries was set to semantic counts (including inherited or structure-encoded assumptions) instead of direct `^axiom` declarations in each file. The auditor's `find-targets.ts` compares this field against grep counts, causing false-positive integrity alerts.

## Approach

Set `leanFile.axiomCount` = count of `^axiom` declarations in that file only. The public-facing `meta.axiomCount` (semantic full count) is unchanged.

## Pattern Breakdown

- **43 entries → 0**: All assumptions are structure-encoded fields or inherited from parent imports
- **11 entries → partial correction**: Mix of direct + inherited declarations

Examples:
- `navier-stokes`: 5 → 0 (5 structure-encoded in `NSAxioms`, no `^axiom` in file)
- `euler-polyhedral-formula-oq-02-oq-01`: 10 → 0 (all inherited from parent)
- `erdos-1155-oq-02`: 7 → 1 (1 direct, 6 inherited from parent chain)
- `erdos-756`: 5 → 2 (2 direct declarations; 3 structure-encoded)

## Notes

This overlaps with PR #12727 (7 entries) — those entries are included here for completeness. If #12727 merges first, the 7 overlapping files will be no-ops in this PR.

Follows pattern from issue #12561.

---
Automated fix by lean-mechanic agent.