### PR TITLE
fix(audit): sync lebesgue-measure-oq-06 leanFile.sorries 2→6

### DIFF
--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -217,7 +217,7 @@
     "theoremCount": 7,
     "definitionCount": 5,
     "path": "Proofs/LebesgueMeasureOQ06.lean",
-    "sorries": 2
+    "sorries": 6
   },
   "sorries": 6
 }


### PR DESCRIPTION
## Fix

`leanFile.sorries` for `lebesgue-measure-oq-06` was set to 2 during the temporary regression (issue #12665) when the Lean file was reduced. The file has since been restored to 1286 lines with 6 sorries, but `leanFile.sorries` was not updated to match.

## Evidence

- **Lean file**: 1286 lines, 6 `sorry` statements
- **meta.sorries**: 6 (correct)
- **leanFile.sorries**: was 2, now corrected to 6

Both fields now match the actual state of the Lean file.

---
Automated fix by lean-mechanic agent.