### PR TITLE
fix(audit): sync leanFile.lineCount for 5 entries — stale after file updates

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-04/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-04/meta.json
@@ -64,7 +64,7 @@
     },
     "leanFile": {
         "namespace": "AbelRuffiniGaloisExtensionsOQ04",
-        "lineCount": 255,
+        "lineCount": 234,
         "axiomCount": 0,
         "theoremCount": 9,
         "definitionCount": 3,

--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
@@ -136,7 +136,7 @@
   ],
   "leanFile": {
     "namespace": "AngleTrisectionOQ02OQ01OQ02Incomplete01",
-    "lineCount": 284,
+    "lineCount": 315,
     "axiomCount": 0,
     "theoremCount": 18,
     "definitionCount": 3,

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -89,7 +89,7 @@
       "LGV"
     ],
     "namespace": "HookLengthFormula",
-    "lineCount": 5452,
+    "lineCount": 5882,
     "axiomCount": 0,
     "sorries": 4,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01/meta.json
@@ -127,7 +127,7 @@
       "BigOperators"
     ],
     "namespace": "CompanionCyclicVector",
-    "lineCount": 197,
+    "lineCount": 290,
     "axiomCount": 1,
     "theoremCount": 5,
     "definitionCount": 2,

--- a/src/data/proofs/synthesis-curvature-ptolemy/meta.json
+++ b/src/data/proofs/synthesis-curvature-ptolemy/meta.json
@@ -163,7 +163,7 @@
       "EuclideanGeometry"
     ],
     "namespace": null,
-    "lineCount": 210,
+    "lineCount": 270,
     "axiomCount": 0,
     "theoremCount": 7,
     "sorries": 0,


### PR DESCRIPTION
## Fix

`leanFile.lineCount` was stale in 5 entries after their Lean files were updated.

## Changes

| Entry | Before | After | Change |
|-------|--------|-------|--------|
| ballot-problem-oq-03-oq-01-oq-02 | 5452 | 5882 | +430 lines |
| cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01 | 197 | 290 | +93 lines |
| synthesis-curvature-ptolemy | 210 | 270 | +60 lines |
| angle-trisection-oq-02-oq-01-oq-02-incomplete-01 | 284 | 315 | +31 lines |
| abel-ruffini-galois-extensions-oq-04 | 255 | 234 | -21 lines |

Note: `lebesgue-measure-oq-06` lineCount is fixed in PR #12731.

---
Automated fix by lean-mechanic agent.