### PR TITLE
fix(audit): correct stale leanFile.axiomCount in 16 gallery entries

### DIFF
--- a/src/data/proofs/buffons-needle-oq-02-oq-02/meta.json
+++ b/src/data/proofs/buffons-needle-oq-02-oq-02/meta.json
@@ -228,7 +228,7 @@
     ],
     "namespace": "BuffonsNeedleOQ02OQ02",
     "lineCount": 376,
-    "axiomCount": 1,
+    "axiomCount": 2,
     "theoremCount": 15,
     "definitionCount": 4,
     "path": "Proofs/BuffonsNeedleOQ02OQ02.lean",

--- a/src/data/proofs/erdos-1012-oq-03/meta.json
+++ b/src/data/proofs/erdos-1012-oq-03/meta.json
@@ -257,7 +257,7 @@
     ],
     "namespace": "Erdos1012OQ03",
     "lineCount": 1827,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "sorries": 1,
     "path": "Proofs/Erdos1012OQ03.lean",
     "theoremCount": 9,

--- a/src/data/proofs/erdos-1126-oq-01/meta.json
+++ b/src/data/proofs/erdos-1126-oq-01/meta.json
@@ -185,7 +185,7 @@
     "path": "Proofs/Erdos1126OQ01Problem.lean",
     "filename": "Erdos1126OQ01Problem.lean",
     "lineCount": 472,
-    "axiomCount": 5,
+    "axiomCount": 7,
     "sorries": 0
   },
   "sorries": 0

--- a/src/data/proofs/erdos-2-oq-01/meta.json
+++ b/src/data/proofs/erdos-2-oq-01/meta.json
@@ -137,7 +137,7 @@
   "leanFile": {
     "lineCount": 232,
     "path": "Proofs/Erdos2OQ01.lean",
-    "axiomCount": 0,
+    "axiomCount": 3,
     "sorries": 0
   },
   "sorries": 0

--- a/src/data/proofs/erdos-504/meta.json
+++ b/src/data/proofs/erdos-504/meta.json
@@ -16,7 +16,7 @@
     ],
     "namespace": "Erdos504",
     "lineCount": 217,
-    "axiomCount": 4,
+    "axiomCount": 5,
     "theoremCount": 1,
     "definitionCount": 5,
     "path": "Proofs/Erdos504Problem.lean",

--- a/src/data/proofs/erdos-529/meta.json
+++ b/src/data/proofs/erdos-529/meta.json
@@ -225,7 +225,7 @@
     ],
     "namespace": "Erdos529",
     "lineCount": 306,
-    "axiomCount": 5,
+    "axiomCount": 7,
     "theoremCount": 6,
     "definitionCount": 5,
     "path": "Proofs/Erdos529Problem.lean",

--- a/src/data/proofs/erdos-756/meta.json
+++ b/src/data/proofs/erdos-756/meta.json
@@ -223,7 +223,7 @@
     ],
     "namespace": "Erdos756",
     "lineCount": 268,
-    "axiomCount": 2,
+    "axiomCount": 5,
     "theoremCount": 8,
     "definitionCount": 15,
     "path": "Proofs/Erdos756Problem.lean",

--- a/src/data/proofs/erdos-96/meta.json
+++ b/src/data/proofs/erdos-96/meta.json
@@ -150,7 +150,7 @@
     ],
     "namespace": "Erdos96",
     "lineCount": 285,
-    "axiomCount": 2,
+    "axiomCount": 3,
     "theoremCount": 2,
     "definitionCount": 10,
     "path": "Proofs/Erdos96Problem.lean",

--- a/src/data/proofs/greens-theorem-oq-04/meta.json
+++ b/src/data/proofs/greens-theorem-oq-04/meta.json
@@ -241,7 +241,7 @@
     ],
     "namespace": "GreensTheoremOQ04",
     "lineCount": 587,
-    "axiomCount": 0,
+    "axiomCount": 2,
     "theoremCount": 23,
     "definitionCount": 14,
     "path": "Proofs/GreensTheoremOQ04.lean",

--- a/src/data/proofs/hilbert-21/meta.json
+++ b/src/data/proofs/hilbert-21/meta.json
@@ -150,7 +150,7 @@
     "opens": [],
     "namespace": "Hilbert21",
     "lineCount": 386,
-    "axiomCount": 3,
+    "axiomCount": 4,
     "theoremCount": 4,
     "definitionCount": 5,
     "path": "Proofs/Hilbert21RiemannHilbert.lean",

--- a/src/data/proofs/inverse-galois-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-oq-01/meta.json
@@ -303,7 +303,7 @@
   "leanFile": {
     "path": "Proofs/InverseGaloisOQ01.lean",
     "lineCount": 723,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "sorries": 1,
     "theoremCount": 46,
     "definitionCount": 1,

--- a/src/data/proofs/inverse-galois/meta.json
+++ b/src/data/proofs/inverse-galois/meta.json
@@ -303,7 +303,7 @@
   "leanFile": {
     "path": "Proofs/InverseGalois.lean",
     "lineCount": 1882,
-    "axiomCount": 4,
+    "axiomCount": 5,
     "sorries": 0,
     "theoremCount": 105,
     "definitionCount": 1,

--- a/src/data/proofs/yang-mills-2d/meta.json
+++ b/src/data/proofs/yang-mills-2d/meta.json
@@ -175,7 +175,7 @@
   "leanFile": {
     "lineCount": 28075,
     "structureCount": 365,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 1787,
     "lemmaCount": 0,
     "defCount": 641,

--- a/src/data/proofs/yang-mills-lattice/meta.json
+++ b/src/data/proofs/yang-mills-lattice/meta.json
@@ -148,7 +148,7 @@
   "leanFile": {
     "lineCount": 28075,
     "structureCount": 365,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 1787,
     "lemmaCount": 0,
     "defCount": 641,

--- a/src/data/proofs/yang-mills-transfer-matrix/meta.json
+++ b/src/data/proofs/yang-mills-transfer-matrix/meta.json
@@ -138,7 +138,7 @@
   "leanFile": {
     "lineCount": 28075,
     "structureCount": 365,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 1787,
     "lemmaCount": 0,
     "defCount": 641,

--- a/src/data/proofs/yang-mills/meta.json
+++ b/src/data/proofs/yang-mills/meta.json
@@ -203,7 +203,7 @@
     ],
     "namespace": "YangMillsMassGap",
     "lineCount": 48,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 1806,
     "definitionCount": 260,
     "path": "Proofs/YangMillsMassGap.lean",


### PR DESCRIPTION
## Summary

- 16 gallery `meta.json` files had stale `leanFile.axiomCount` values that were lower than the actual `^axiom` declaration count in the corresponding Lean source files
- The `find-targets.ts` auditor uses this field to detect axiom undercounts, causing false-positive alerts for all 16 entries
- `meta.axiomCount` was already correct in all cases — only `leanFile.axiomCount` needed updating

## Entries fixed

| slug | old | new |
|------|-----|-----|
| yang-mills | 0 | 1 |
| yang-mills-transfer-matrix | 0 | 1 |
| yang-mills-lattice | 0 | 1 |
| yang-mills-2d | 0 | 1 |
| inverse-galois-oq-01 | 0 | 1 |
| inverse-galois | 4 | 5 |
| greens-theorem-oq-04 | 0 | 2 |
| erdos-2-oq-01 | 0 | 3 |
| hilbert-21 | 3 | 4 |
| erdos-96 | 2 | 3 |
| erdos-756 | 2 | 5 |
| erdos-529 | 5 | 7 |
| buffons-needle-oq-02-oq-02 | 1 | 2 |
| erdos-504 | 4 | 5 |
| erdos-1126-oq-01 | 5 | 7 |
| erdos-1012-oq-03 | 0 | 1 |

## Test plan

- [ ] Run `npx tsx scripts/auditor/find-targets.ts --issues` and confirm the 16 axiom-undercount false positives are no longer reported
- [ ] Each diff is exactly 2 lines (one removal, one addition) — no collateral formatting changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)