### PR TITLE
Enrich cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01: add 8 annotations, deepen historicalContext

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01/annotations.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01/annotations.json
@@ -1,1 +1,98 @@
-[]
+[
+  {
+    "id": "ann-setup-overview",
+    "proofId": "cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01",
+    "range": { "startLine": 1, "endLine": 36 },
+    "type": "context",
+    "title": "Module Overview: Decomposing a Vague Sorry",
+    "content": "The file header explains the intellectual contribution: a vague 'sorry — requires PID structure theorem' in the parent file is replaced by two precisely-separated pieces. The first piece (companion matrix orbit) is fully proved here. The second piece (nonderogatory ↔ similar to companion) is stated as a named axiom. This modular decomposition pattern — prove what you can, axiomatize the rest precisely — is a disciplined approach to incremental formalization in Lean 4.",
+    "mathContext": "The companion matrix $C(p)$ of a monic degree-$n$ polynomial $p$ has a canonical property: $C(p)^k e_0 = e_k$ for all $k < n$. This Krylov orbit property is the constructive core that can be proved without the PID structure theorem. The remaining gap, $M \\sim C(\\chi_M)$ for nonderogatory $M$, is exactly what needs rational canonical form.",
+    "significance": "context",
+    "relatedConcepts": ["rational canonical form", "PID structure theorem", "companion matrix", "incremental formalization"],
+    "prerequisites": ["linear algebra", "polynomial rings over fields", "Lean 4 / Mathlib basics"]
+  },
+  {
+    "id": "ann-definitions",
+    "proofId": "cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01",
+    "range": { "startLine": 40, "endLine": 46 },
+    "type": "definition",
+    "title": "IsCyclicVector and IsNonderogatory",
+    "content": "Two core definitions establish the vocabulary for the entire file. IsCyclicVector M v says that no nonzero polynomial of degree less than n kills v when evaluated at M — equivalently, the Krylov orbit {v, Mv, M²v, …, M^{n-1}v} spans K^n. IsNonderogatory M says the minimal polynomial equals the characteristic polynomial, the classical condition for a matrix to have a single invariant factor (i.e., for K^n to be a cyclic K[X]-module). These definitions are deliberately consistent with the parent OQ05OQ01OQ04 file to enable cross-referencing.",
+    "mathContext": "$v$ is cyclic for $M \\in M_n(K)$ iff $\\forall p \\in K[X],\\, \\deg p < n \\Rightarrow p(M)v \\neq 0$ (for $p \\neq 0$). Equivalently, $\\operatorname{span}\\{v, Mv, \\ldots, M^{n-1}v\\} = K^n$. $M$ is nonderogatory iff $\\mu_M = \\chi_M$ (both monic of degree $n$), which forces $K^n \\cong K[X]/(\\chi_M)$ as $K[X]$-modules.",
+    "significance": "key",
+    "relatedConcepts": ["Krylov subspace", "minimal polynomial", "characteristic polynomial", "cyclic K[X]-module", "invariant factors", "rational canonical form"],
+    "prerequisites": ["polynomial evaluation on matrices (aeval)", "matrix-vector products (mulVec)", "Mathlib.Algebra.Polynomial.Basic"]
+  },
+  {
+    "id": "ann-companion-matrix",
+    "proofId": "cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01",
+    "range": { "startLine": 52, "endLine": 93 },
+    "type": "definition",
+    "title": "Companion Matrix: Definition and Structural Lemmas",
+    "content": "The companion matrix companionMat p is defined pointwise: entry (i,j) is 1 if i = j+1 (subdiagonal), -(p.coeff i) if j+1 = n (last column), and 0 otherwise. Three structural lemmas (companionMat_subdiag, companionMat_last_col, companionMat_zero) establish the three cases explicitly — this verbose decomposition is necessary for Lean's definitional equality. The lemma companionMat_mulVec_basis then proves the key stepping stone: C * ej = e_{j+1} for j < n-1, which is the subdiagonal-shift property.",
+    "mathContext": "For $p = x^n + a_{n-1}x^{n-1} + \\cdots + a_0$, the companion matrix is $C(p)_{ij} = \\begin{cases} 1 & i = j+1 \\\\ -a_i & j = n-1 \\\\ 0 & \\text{otherwise} \\end{cases}$. The characteristic polynomial of $C(p)$ is $p$ itself. The subdiagonal-shift: $C(p) \\cdot e_j = e_{j+1}$ for $j < n-1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["companion matrix", "subdiagonal", "matrix multiplication", "standard basis", "shift operator"],
+    "prerequisites": ["Fin n (finite index type)", "Pi.single (standard basis vectors)", "Matrix.mulVec"]
+  },
+  {
+    "id": "ann-krylov-orbit",
+    "proofId": "cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01",
+    "range": { "startLine": 95, "endLine": 105 },
+    "type": "technique",
+    "title": "Krylov Orbit Theorem: C^k e0 = e_k",
+    "content": "The lemma companionMat_pow_e0 is proved by induction on k. The base case (k=0) is trivial. The inductive step uses companionMat_mulVec_basis: if C^m e0 = em by hypothesis, then C^{m+1} e0 = C * em = e_{m+1}. This gives the key structural fact: the k-th power of the companion matrix maps e0 to the k-th standard basis vector. The Krylov sequence {C^0 e0, C^1 e0, ..., C^{n-1} e0} = {e0, e1, ..., e_{n-1}} is the entire standard basis.",
+    "mathContext": "$C(p)^k e_0 = e_k$ for $0 \\leq k < n$ (proved by induction). This is the fundamental property of companion matrices: they act as a cyclic permutation on the standard basis. It implies $\\det[e_0 \\mid Ce_0 \\mid \\cdots \\mid C^{n-1}e_0] = \\det(I_n) = 1 \\neq 0$, so the Krylov vectors are linearly independent.",
+    "significance": "key",
+    "relatedConcepts": ["Krylov sequence", "mathematical induction", "matrix powers", "standard basis span", "cyclic basis"],
+    "prerequisites": ["companionMat_mulVec_basis", "pow_succ (Matrix.mul_mulVec)", "Fin arithmetic"]
+  },
+  {
+    "id": "ann-orbit-eval",
+    "proofId": "cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01",
+    "range": { "startLine": 111, "endLine": 157 },
+    "type": "technique",
+    "title": "Leading Coefficient Extraction: The Key Computation",
+    "content": "The lemma companion_orbit_eval is the technical heart of the proof. For a nonzero polynomial q with deg q < n, it shows that the natDegree(q)-th coordinate of q(C)e0 equals q's leading coefficient. The proof: (1) expand q(C) as a sum over the support of q using aeval_def; (2) distribute mulVec over the sum (sum_mulVec); (3) apply companionMat_pow_e0 to replace C^k e0 with e_k; (4) evaluate the sum at index natDegree(q) — only the k = natDegree(q) term survives. This is a coordinate-extraction argument that avoids any rank or determinant computation.",
+    "mathContext": "For $q = \\sum_{k \\in \\text{supp}(q)} a_k x^k$ with $\\deg q < n$: $(q(C)e_0)_{\\deg q} = \\sum_k a_k (C^k e_0)_{\\deg q} = \\sum_k a_k [e_k]_{\\deg q} = a_{\\deg q} = \\text{lc}(q)$, using $[e_k]_j = \\delta_{kj}$. The Kronecker delta collapse is exact because $k \\leq \\deg q < n$ for all $k$ in the support.",
+    "significance": "key",
+    "relatedConcepts": ["aeval expansion", "polynomial support", "Kronecker delta", "coordinate evaluation", "leading coefficient"],
+    "prerequisites": ["aeval_def (eval₂ as sum)", "Finset.sum_eq_single", "Pi.single_apply", "Polynomial.le_natDegree_of_mem_supp"]
+  },
+  {
+    "id": "ann-main-cyclic",
+    "proofId": "cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01",
+    "range": { "startLine": 163, "endLine": 180 },
+    "type": "insight",
+    "title": "Main Verified Theorem: e0 is Cyclic for Companion(p)",
+    "content": "companionMat_e0_cyclic is the central fully-verified result. Assume for contradiction that q ≠ 0 with deg q < n and q(C)e0 = 0. Then companion_orbit_eval gives leadingCoeff(q) = 0, but leadingCoeff of a nonzero polynomial is nonzero — contradiction. The proof is remarkably compact (two significant steps) because all the technical work was done in the prior lemmas. This is the companion matrix half of the main theorem, completely independent of rational canonical form.",
+    "mathContext": "Proof (contrapositive): Suppose $q \\neq 0$, $\\deg q < n$, $q(C)e_0 = 0$. Then $0 = [q(C)e_0]_{\\deg q} = \\text{lc}(q)$ by companion_orbit_eval. But $\\text{lc}(q) \\neq 0$ for $q \\neq 0$ (Polynomial.leadingCoeff_ne_zero). Contradiction. Therefore $e_0$ is cyclic for $C(p)$ whenever $p$ is monic of degree $n > 0$.",
+    "significance": "key",
+    "relatedConcepts": ["cyclic vector", "proof by contradiction", "leading coefficient", "companion matrix cyclic property", "Krylov basis"],
+    "prerequisites": ["companion_orbit_eval", "Polynomial.leadingCoeff_ne_zero", "IsCyclicVector definition"]
+  },
+  {
+    "id": "ann-similarity-transfer",
+    "proofId": "cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01",
+    "range": { "startLine": 186, "endLine": 233 },
+    "type": "technique",
+    "title": "Similarity Transfer: Conjugation Preserves Cyclicity",
+    "content": "cyclic_vector_similar_transfer proves that if M = P⁻¹NP and v is cyclic for N, then P⁻¹v is cyclic for M. The proof establishes the conjugation formula q(P⁻¹NP) = P⁻¹ q(N) P by induction on the structure of q (using Polynomial.induction_on'). The monomial case requires proving (P⁻¹NP)^m = P⁻¹ N^m P by another induction, using P·P⁻¹ = 1 to collapse the middle factors. Once the conjugation formula is established, the transfer is straightforward: q(M)(P⁻¹v) = P⁻¹(q(N)v) = 0 iff q(N)v = 0.",
+    "mathContext": "Conjugation formula: $q(P^{-1}NP) = P^{-1}q(N)P$ for all $q \\in K[X]$ (algebra homomorphism applied to the conjugation map). Proof: $(P^{-1}NP)^m = P^{-1}N^m P$ by induction (collapsing $P \\cdot P^{-1} = I$ at each step). Therefore $q(M)(P^{-1}v) = P^{-1}(q(N)v)$, and the transfer follows by left-multiplying by $P$.",
+    "significance": "supporting",
+    "relatedConcepts": ["matrix conjugation", "algebra homomorphism", "matrix units", "similarity invariance", "aeval_conj"],
+    "prerequisites": ["Polynomial.induction_on' (structural induction)", "Units.val_inv / Units.inv_val", "Matrix.mulVec_mulVec"]
+  },
+  {
+    "id": "ann-axiom-main",
+    "proofId": "cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01",
+    "range": { "startLine": 235, "endLine": 290 },
+    "type": "insight",
+    "title": "The Axiom and Final Assembly: Nonderogatory ⟹ Cyclic Vector",
+    "content": "The axiom nonderogatory_similar_to_companion states precisely that nonderogatory M is similar to its companion matrix — this is the classical theorem requiring the rational canonical form (equivalently: K^n ≅ K[X]/(χ_M) as K[X]-modules when minpoly = charpoly). The main theorem nonderogatory_has_cyclic_vector_any_field assembles all three pieces: e0 is cyclic for C(χ_M) (proved), M is similar to C(χ_M) (axiom), and similarity transfers cyclic vectors (proved). The corollary for finite fields follows immediately, removing the [Infinite K] restriction that hampered the parent file's approach.",
+    "mathContext": "Axiom: Nonderogatory $M$ is similar to $C(\\chi_M)$. This is equivalent to: $K^n \\cong K[X]/(\\chi_M)$ as $K[X]$-modules, which requires the structure theorem for f.g. modules over the PID $K[X]$. Once proved, the chain is complete: $e_0$ cyclic for $C(\\chi_M)$ (proved) $\\Rightarrow$ $P^{-1}e_0$ cyclic for $M$ (transfer) $\\Rightarrow$ nonderogatory $M$ has a cyclic vector. Holds over all fields (finite or infinite).",
+    "significance": "key",
+    "relatedConcepts": ["rational canonical form", "PID module structure theorem", "Mathlib gap (v4.26)", "nonderogatory matrix", "cyclic vector existence", "finite fields"],
+    "prerequisites": ["companionMat_e0_cyclic", "cyclic_vector_similar_transfer", "nonderogatory_similar_to_companion", "Matrix.charpoly_natDegree_eq_dim"]
+  }
+]

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01/meta.json
@@ -47,7 +47,7 @@
     ]
   },
   "overview": {
-    "historicalContext": "The parent file CayleyHamiltonMinpolyOQ05OQ01OQ04.lean proves the annihilator characterization (cyclic iff ann = (minpoly)) and the F2 counterexample to union avoidance, but its main theorem has a sorry requiring the full PID structure theorem. This WIP file takes a different approach: instead of the module-theoretic route (K^n as K[X]-module), it proves the companion matrix route directly. The companion matrix C(p) of a monic polynomial p has a well-known property: the standard basis vector e0 = (1,0,...,0) is a cyclic vector, because the Krylov orbit {e0, Ce0, C^2 e0, ...} produces the standard basis. This is a concrete, constructive result that can be fully verified in Lean 4.",
+    "historicalContext": "Companion matrices have been a cornerstone of linear algebra since the 19th century, appearing naturally in the theory of eigenvalues (Cayley, Weierstrass) and the rational canonical form (Frobenius, 1879). The nonderogatory property — that the minimal polynomial equals the characteristic polynomial — was identified as the condition for a matrix to have a single invariant factor, making K^n a cyclic module over K[X]. The equivalence 'nonderogatory ↔ similar to companion matrix' is the central theorem of rational canonical form theory, but its proof requires the structure theorem for finitely generated modules over K[X], a principal ideal domain. Unlike the Jordan canonical form (valid only over algebraically closed fields), the rational canonical form works over any field. Despite its classical status, the PID structure theorem for K[X]-modules had not been formalized in Mathlib as of version 4.26. The parent file CayleyHamiltonMinpolyOQ05OQ01OQ04.lean attempts the general theorem via the module-theoretic route but carries a sorry at the key step. This WIP file pursues a companion-matrix-first strategy: the Krylov orbit C^k e0 = e_k is a concrete, purely computational fact about matrix powers that can be verified without any abstract module theory, providing an unconditional proof of the companion matrix half.",
     "problemStatement": "Reduce the sorry in the general nonderogatory cyclic vector theorem to a precisely-stated axiom. The original sorry was vague ('requires PID structure theorem'). This file proves the companion matrix half and isolates the remaining gap as: 'nonderogatory M is similar to companion(charpoly M)'.",
     "proofStrategy": "Three-step decomposition: (1) PROVE that e0 is cyclic for companionMat(p) when p is monic of degree n, via the orbit argument: C^k e0 = e_k for k < n, so evaluating q(C)e0 at index natDegree(q) gives q.leadingCoeff, which is nonzero for q != 0. (2) STATE as axiom that nonderogatory M is similar to companionMat(charpoly M). (3) PROVE the similarity transfer theorem: if M = P^{-1}NP and v is cyclic for N, then P^{-1}v is cyclic for M. Combining (1)+(2)+(3) gives the main theorem.",
     "keyInsights": [
@@ -95,17 +95,17 @@
       "id": "similarity-transfer",
       "title": "V. Similarity Transfer",
       "startLine": 162,
-      "endLine": 200,
-      "summary": "Proves cyclic_vector_similar_transfer and states nonderogatory_similar_to_companion as an axiom.",
-      "mathContext": "If M = P^{-1}NP, then aeval M q = P^{-1} (aeval N q) P by the conjugation formula, so q(M)(P^{-1}v) = P^{-1}(q(N)v). The axiom states that nonderogatory M is similar to companion(charpoly M)."
+      "endLine": 233,
+      "summary": "Proves cyclic_vector_similar_transfer (conjugation formula q(P⁻¹NP) = P⁻¹q(N)P via polynomial induction) and states nonderogatory_similar_to_companion as an axiom.",
+      "mathContext": "If M = P^{-1}NP, then aeval M q = P^{-1} (aeval N q) P by the conjugation formula, so q(M)(P^{-1}v) = P^{-1}(q(N)v). The axiom states that nonderogatory M is similar to companion(charpoly M), capturing the rational canonical form gap."
     },
     {
       "id": "main-theorem",
-      "title": "VI. Main Theorem",
-      "startLine": 205,
-      "endLine": 233,
-      "summary": "Proves nonderogatory_has_cyclic_vector_any_field by combining the three pieces: companion cyclic vector (proved), similarity (axiom), and transfer (proved).",
-      "mathContext": "For n > 0: companionMat(charpoly M) has e0 as a cyclic vector (Section IV); M is similar to it (axiom); similarity transfers cyclic vectors (Section V). Therefore M has a cyclic vector."
+      "title": "VI. Main Theorem and Corollary",
+      "startLine": 248,
+      "endLine": 290,
+      "summary": "Proves nonderogatory_has_cyclic_vector_any_field (over any field) and the corollary for finite fields by combining: companion cyclic vector (proved), similarity (axiom), and transfer (proved).",
+      "mathContext": "For n > 0: companionMat(charpoly M) has e0 as a cyclic vector (Section IV); M is similar to it (axiom); similarity transfers cyclic vectors (Section V). Therefore M has a cyclic vector. The finite-field corollary removes the [Infinite K] hypothesis from the parent file's approach."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01 (Nonderogatory to Cyclic Vector: Companion Matrix Approach).

## Quality improvements

**annotations.json** (was empty → 8 annotations added):
- Setup/overview context: modular decomposition strategy explanation
- IsCyclicVector and IsNonderogatory definitions with LaTeX math
- Companion matrix definition and structural lemmas
- Krylov orbit theorem (C^k e0 = e_k) with induction proof walkthrough
- Leading coefficient extraction lemma (companion_orbit_eval) — the technical heart
- Main cyclic vector theorem (companionMat_e0_cyclic) with contrapositive argument
- Similarity transfer via polynomial induction / conjugation formula
- Axiom + final assembly + finite-field corollary

**meta.json** — enriched historicalContext:
- Added Frobenius rational canonical form history (1879)
- Added Weierstrass / Cayley context for companion matrices
- Explained relationship to PID structure theorem for K[X]-modules
- Contrasted with Jordan canonical form (algebraically closed fields only)
- Updated section VI endLine to 290 (actual file length; was 233)
- Extended section V to include the axiom statement (lines 162–233)

## Axiom integrity
Confirmed: `status: "axiomatized"`, `axiomCount: 1`, `badge: "axiom"` — correctly reflects the single `axiom nonderogatory_similar_to_companion` declaration. No structure-encoded assumptions found.