### PR TITLE
fix(audit): sync stale leanFile.lineCount for 2 entries

### DIFF
--- a/src/data/proofs/erdos-1008-oq-04/meta.json
+++ b/src/data/proofs/erdos-1008-oq-04/meta.json
@@ -33,7 +33,7 @@
     ],
     "dateAdded": "2026-04-12",
     "axiomCount": 2,
-    "lineCount": 136,
+    "lineCount": 145,
     "prerequisites": [
       "Extremal graph theory",
       "Kővári-Sós-Turán theorem",
@@ -143,7 +143,7 @@
       "Finset"
     ],
     "namespace": "Erdos1008OQ04",
-    "lineCount": 136,
+    "lineCount": 145,
     "axiomCount": 2,
     "theoremCount": 1,
     "definitionCount": 1,

--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -212,7 +212,7 @@
       "Mathlib"
     ],
     "namespace": "BanachTarski",
-    "lineCount": 783,
+    "lineCount": 1286,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 5,


### PR DESCRIPTION
## Summary
- Sync `lineCount` for `erdos-1008-oq-04` (136 → 145) and `lebesgue-measure-oq-06` leanFile section (783 → 1286)
- Clean replacement for #12736 which was too far behind main to rebase

## Context
Replaces #12736 (closed — branch had 13 stale commits causing unrebaseable conflicts).