### PR TITLE
fix(audit): sync leanFile.lineCount for 2 stale entries

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -89,7 +89,7 @@
       "LGV"
     ],
     "namespace": "HookLengthFormula",
-    "lineCount": 5882,
+    "lineCount": 6297,
     "axiomCount": 0,
     "sorries": 4,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",

--- a/src/data/proofs/erdos-795/meta.json
+++ b/src/data/proofs/erdos-795/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/795",
     "erdosProblemStatus": "solved",
     "axiomCount": 0,
-    "lineCount": 500,
+    "lineCount": 496,
     "assumptions": "14 sorry(s).",
     "mathlib_version": "4.26.0"
   },
@@ -167,7 +167,7 @@
     ],
     "opens": [],
     "namespace": "Erdos795",
-    "lineCount": 500,
+    "lineCount": 496,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 7,


### PR DESCRIPTION
## Fix

Sync stale `leanFile.lineCount` metadata after Lean files changed.

## Evidence

**ballot-problem-oq-03-oq-01-oq-02**:
- `leanFile.lineCount`: 5882 → 6297 (+415 lines)
- `meta.lineCount` was already updated to 6297 by another commit; only `leanFile.lineCount` was missed

**erdos-795**:
- `meta.lineCount`: 500 → 496
- `leanFile.lineCount`: 500 → 496
- File shrank by 4 lines (496 via Python splitlines; file has no trailing newline)

---
Automated fix by lean-mechanic agent.