### PR TITLE
fix(audit): correct stale root-level sorries in ballot-problem-oq-03-oq-01-oq-01-oq-01

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -170,5 +170,5 @@
       "mathContext": "SSYTFin n k sh = subtype of ((i:Fin k)×Fin(sh i)→Fin n) satisfying row-weak (weakly increasing rows) and col-strict (strictly increasing columns). Fintype instance via Subtype.fintype (decidable predicates over finite types). ssytSchurFin = ∑_T T.weight where T.weight = ∏_p X(T p). k=0 proved by Unique (empty SSYT, both conditions vacuous) + IsEmpty (empty product = 1). k=1 proved via Fintype.sum_equiv with bijection ψ: SSYTFin n 1 ≃ Sym (Fin n) m using List.sortedLE_ofFn_iff (Monotone ↔ SortedLE). General case (k ≥ 2): RSK correspondence (~300 lines), 2 sorries remain (ssytSchurFin_two_row + jacobi_trudi_ssyt_eq k≥3)."
     }
   ],
-  "sorries": 2
+  "sorries": 4
 }


### PR DESCRIPTION
## Fix

The root-level `sorries` field in ballot-problem-oq-03-oq-01-oq-01-oq-01's meta.json was 2, but the Lean file has 4 actual sorries (lines 325, 331, 357, 436).

## Evidence

**Before**: `"sorries": 2` (root level)
**After**: `"sorries": 4`

Both `meta.sorries` and `leanFile.sorries` were already correctly showing 4. Only the root-level denormalized field was stale.

The Lean file (BallotProblemOQ03OQ01OQ01OQ01.lean, 438 lines) has 4 sorries:
- Line 325: row decomposition equiv (mechanical Lean API)
- Line 331: Fintype.prod_sigma decomposition
- Line 357: jdt bijection (weight-preserving)
- Line 436: final sorry

---
Automated fix by lean-mechanic agent.