### PR TITLE
Enrich synthesis-curvature-ptolemy: fix annotations format, correct section lines

### DIFF
--- a/src/data/proofs/synthesis-curvature-ptolemy/annotations.json
+++ b/src/data/proofs/synthesis-curvature-ptolemy/annotations.json
@@ -1,4 +1,5 @@
-[
+{
+  "annotations": [
   {
     "id": "ann-module-intro",
     "proofId": "synthesis-curvature-ptolemy",
@@ -246,4 +247,5 @@
       "Real.sinh"
     ]
   }
-]
+  ]
+}

--- a/src/data/proofs/synthesis-curvature-ptolemy/meta.json
+++ b/src/data/proofs/synthesis-curvature-ptolemy/meta.json
@@ -87,8 +87,8 @@
     },
     {
       "title": "Spherical Ptolemy Equality (curvatureSin 1)",
-      "startLine": 155,
-      "endLine": 175,
+      "startLine": 133,
+      "endLine": 165,
       "description": "Restates the spherical Ptolemy equality (from PtolemysTheoremOQ01OQ02.lean) using curvatureSin 1 for concyclic unit-sphere points.",
       "summary": "Spherical Ptolemy equality via curvatureSin 1 — requires concyclicity",
       "id": "spherical-equality",
@@ -96,7 +96,7 @@
     },
     {
       "title": "Spherical Ptolemy Inequality (New)",
-      "startLine": 171,
+      "startLine": 167,
       "endLine": 229,
       "description": "Proves the spherical Ptolemy INEQUALITY for any four unit-circle points in ℂ. No concyclicity assumption needed. Proof: (1) reduce curvatureSin 1 to sin; (2) six chord-arc applications; (3) algebraic rewrite; (4) ptolemy_inequality / 4 via linarith.",
       "summary": "Spherical Ptolemy ≤ for all unit-circle points — unconditional inequality (new result)",


### PR DESCRIPTION
## Enrichment pass for synthesis-curvature-ptolemy

**Quality before:** 38 (passes: 0 — previous enrichment never marked complete)

### Changes

**annotations.json** — fixed critical format bug:
- Was: bare array `[{...}]` — `index.ts` reads `annotationsJson.annotations` so the 10 existing annotations were hidden (property undefined at runtime)
- Now: `{"annotations": [{...}]}` — correctly matches `const annotationsData = annotationsJson as { annotations: Annotation[] }` in index.ts

The 10 annotations cover all major proof sections with LaTeX mathContext, significance, relatedConcepts, and prerequisites:
- Unified Ptolemy framework context and curvatureSin definition
- Special case identifications: K=1→sin, K=0→id, K=-1→sinh, zero normalization
- Spherical equality (requires concyclicity) and inequality (unconditional, new result)
- Chord-arc identity bridge and scaling-by-1/4 algebraic technique
- Hyperbolic conjecture: documented infrastructure blockers

**meta.json** — corrected section line numbers:
- `spherical-equality`: startLine 155 → 133 (actual theorem starts at line 138)
- `spherical-inequality`: startLine 171 → 167 (actual theorem starts at line 171)