### PR TITLE
chore(audit): re-audit 160 proofs clean — 2026-04-26 batches 3-5

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5998,63 +5998,63 @@
       "result": "issues-fixed"
     },
     "erdos-530": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T17:02:03Z",
+      "lastAudited": "2026-04-26T08:22:20Z",
       "result": "clean"
     },
     "erdos-531": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
+      "result": "clean"
     },
     "erdos-532": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
+      "result": "clean"
     },
     "erdos-533": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:26:00Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
       "result": "clean"
     },
     "erdos-534": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:26:01Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
       "result": "clean"
     },
     "erdos-535": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
+      "result": "clean"
     },
     "erdos-536": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-26T08:22:20Z",
+      "result": "clean"
     },
     "erdos-537": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T17:39:08Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-26T08:22:20Z",
       "result": "clean"
     },
     "erdos-538": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:25:59Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
       "result": "clean"
     },
     "erdos-539": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:25:58Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
       "result": "clean"
     },
     "erdos-54": {
@@ -6065,62 +6065,62 @@
     },
     "erdos-540": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
+      "result": "clean"
     },
     "erdos-541": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
+      "result": "clean"
     },
     "erdos-542": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:59:40Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-26T08:22:20Z",
+      "result": "clean"
     },
     "erdos-543": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:25:56Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
       "result": "clean"
     },
     "erdos-544": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:25:57Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
       "result": "clean"
     },
     "erdos-545": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:25:51Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
       "result": "clean"
     },
     "erdos-546": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:25:54Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
       "result": "clean"
     },
     "erdos-547": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
+      "result": "clean"
     },
     "erdos-548": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:25:52Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
       "result": "clean"
     },
     "erdos-549": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:25:55Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
       "result": "clean"
     },
     "erdos-55": {
@@ -6131,62 +6131,62 @@
     },
     "erdos-550": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:25:46Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
       "result": "clean"
     },
     "erdos-551": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:25:47Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
       "result": "clean"
     },
     "erdos-552": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:25:49Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
       "result": "clean"
     },
     "erdos-553": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:25:50Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
       "result": "clean"
     },
     "erdos-554": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T11:47:18Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-26T08:22:20Z",
+      "result": "clean"
     },
     "erdos-555": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:59:40Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-26T08:22:20Z",
+      "result": "clean"
     },
     "erdos-556": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:25:44Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
       "result": "clean"
     },
     "erdos-557": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:25:43Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
       "result": "clean"
     },
     "erdos-558": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:25:45Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
       "result": "clean"
     },
     "erdos-559": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:25:38Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
       "result": "clean"
     },
     "erdos-56": {
@@ -6197,63 +6197,63 @@
     },
     "erdos-560": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:25:39Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
       "result": "clean"
     },
     "erdos-561": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:25:37Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
       "result": "clean"
     },
     "erdos-562": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
+      "result": "clean"
     },
     "erdos-563": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:25:41Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
       "result": "clean"
     },
     "erdos-564": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
+      "result": "clean"
     },
     "erdos-565": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
+      "result": "clean"
     },
     "erdos-566": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:59:41Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-26T08:22:20Z",
+      "result": "clean"
     },
     "erdos-567": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T22:17:30Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-26T08:22:20Z",
+      "result": "clean"
     },
     "erdos-568": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:25:34Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
       "result": "clean"
     },
     "erdos-569": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
+      "result": "clean"
     },
     "erdos-57": {
       "agentId": "auditor-cycle-20-batch",
@@ -6263,63 +6263,63 @@
     },
     "erdos-570": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
+      "result": "clean"
     },
     "erdos-571": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
+      "result": "clean"
     },
     "erdos-572": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:25:33Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
       "result": "clean"
     },
     "erdos-573": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
+      "result": "clean"
     },
     "erdos-574": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:59:41Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-26T08:22:20Z",
+      "result": "clean"
     },
     "erdos-575": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:59:41Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-26T08:22:20Z",
+      "result": "clean"
     },
     "erdos-576": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:25:32Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
       "result": "clean"
     },
     "erdos-577": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
+      "result": "clean"
     },
     "erdos-578": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
+      "result": "clean"
     },
     "erdos-579": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:59:41Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-26T08:22:20Z",
+      "result": "clean"
     },
     "erdos-58": {
       "agentId": "auditor-cycle-20-batch",
@@ -6329,62 +6329,62 @@
     },
     "erdos-580": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
+      "result": "clean"
     },
     "erdos-581": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:25:29Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
       "result": "clean"
     },
     "erdos-582": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
+      "result": "clean"
     },
     "erdos-583": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
+      "result": "clean"
     },
     "erdos-584": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:25:30Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
       "result": "clean"
     },
     "erdos-585": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:59:41Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-26T08:22:20Z",
+      "result": "clean"
     },
     "erdos-586": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
+      "result": "clean"
     },
     "erdos-587": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:25:18Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
       "result": "clean"
     },
     "erdos-588": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
+      "result": "clean"
     },
     "erdos-589": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:25:28Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
       "result": "clean"
     },
     "erdos-59": {
@@ -6395,63 +6395,63 @@
     },
     "erdos-590": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:25:17Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
       "result": "clean"
     },
     "erdos-591": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
+      "result": "clean"
     },
     "erdos-592": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:25:15Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
       "result": "clean"
     },
     "erdos-593": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:59:41Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-26T08:22:20Z",
+      "result": "clean"
     },
     "erdos-594": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
+      "result": "clean"
     },
     "erdos-595": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:25:16Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
       "result": "clean"
     },
     "erdos-596": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
+      "result": "clean"
     },
     "erdos-597": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
+      "result": "clean"
     },
     "erdos-598": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:59:41Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-26T08:22:20Z",
+      "result": "clean"
     },
     "erdos-599": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
+      "result": "clean"
     },
     "erdos-6": {
       "agentId": "auditor-cycle-20-batch",
@@ -6467,44 +6467,44 @@
     },
     "erdos-600": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
+      "result": "clean"
     },
     "erdos-601": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T17:39:07Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-26T08:22:20Z",
       "result": "clean"
     },
     "erdos-602": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:25:12Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
       "result": "clean"
     },
     "erdos-603": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:25:11Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
       "result": "clean"
     },
     "erdos-604": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:25:13Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
       "result": "clean"
     },
     "erdos-605": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:25:09Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
       "result": "clean"
     },
     "erdos-606": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:25:07Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
       "result": "clean"
     },
     "erdos-606-oq-03": {
@@ -6517,20 +6517,20 @@
     },
     "erdos-607": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:25:05Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
       "result": "clean"
     },
     "erdos-608": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:25:06Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
       "result": "clean"
     },
     "erdos-609": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:25:10Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:22:20Z",
       "result": "clean"
     },
     "erdos-61": {

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6541,63 +6541,63 @@
     },
     "erdos-610": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:25:00Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean"
     },
     "erdos-611": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:25:01Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean"
     },
     "erdos-612": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:25:04Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean"
     },
     "erdos-613": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:25:03Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean"
     },
     "erdos-614": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:24:58Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean"
     },
     "erdos-615": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:24:59Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean"
     },
     "erdos-616": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
+      "result": "clean"
     },
     "erdos-617": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:24:57Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean"
     },
     "erdos-618": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
+      "result": "clean"
     },
     "erdos-619": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
+      "result": "clean"
     },
     "erdos-62": {
       "agentId": "auditor-cycle-20-batch",
@@ -6607,64 +6607,64 @@
     },
     "erdos-620": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:24:53Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean"
     },
     "erdos-621": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:24:37Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean"
     },
     "erdos-622": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:24:19Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean"
     },
     "erdos-623": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:24:15Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean"
     },
     "erdos-624": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:24:16Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean"
     },
     "erdos-625": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:24:17Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean"
     },
     "erdos-626": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:24:18Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean"
     },
     "erdos-627": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:24:27Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean"
     },
     "erdos-628": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [
         "sorry mismatch corrected in meta.json"
       ],
-      "lastAudited": "2026-04-05T23:11:31Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-26T08:21:27Z",
+      "result": "clean"
     },
     "erdos-629": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:24:14Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean"
     },
     "erdos-63": {
@@ -6675,63 +6675,63 @@
     },
     "erdos-630": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:24:09Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean"
     },
     "erdos-631": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:24:11Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean"
     },
     "erdos-632": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:24:12Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean"
     },
     "erdos-633": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:24:13Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean"
     },
     "erdos-634": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:24:04Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean"
     },
     "erdos-635": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:24:05Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean"
     },
     "erdos-636": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
+      "result": "clean"
     },
     "erdos-637": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:24:08Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean"
     },
     "erdos-638": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:24:06Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean"
     },
     "erdos-639": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
+      "result": "clean"
     },
     "erdos-64": {
       "agentId": "auditor-cycle-20-batch",
@@ -6741,63 +6741,63 @@
     },
     "erdos-640": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:24:02Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean"
     },
     "erdos-641": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:24:03Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean"
     },
     "erdos-642": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
+      "result": "clean"
     },
     "erdos-643": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:23:52Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean"
     },
     "erdos-644": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:23:48Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean"
     },
     "erdos-645": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
+      "result": "clean"
     },
     "erdos-646": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:23:49Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean"
     },
     "erdos-647": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:23:51Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean"
     },
     "erdos-648": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:23:43Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean"
     },
     "erdos-649": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
+      "result": "clean"
     },
     "erdos-65": {
       "agentId": "auditor-cycle-20-batch",
@@ -6807,64 +6807,64 @@
     },
     "erdos-650": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:23:44Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean"
     },
     "erdos-651": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:23:46Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean"
     },
     "erdos-652": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:23:47Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean"
     },
     "erdos-653": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
+      "result": "clean"
     },
     "erdos-654": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:59:41Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-26T08:21:27Z",
+      "result": "clean"
     },
     "erdos-655": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:59:41Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-26T08:21:27Z",
+      "result": "clean"
     },
     "erdos-656": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:23:42Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean"
     },
     "erdos-657": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 7,
-      "lastAudited": "2026-04-04T23:23:29Z",
+      "auditCount": 8,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean",
       "issues": []
     },
     "erdos-658": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:23:40Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean"
     },
     "erdos-659": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
+      "result": "clean"
     },
     "erdos-66": {
       "agentId": "auditor-cycle-20-batch",
@@ -6874,63 +6874,63 @@
     },
     "erdos-660": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:23:39Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean"
     },
     "erdos-661": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:59:41Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-26T08:21:27Z",
+      "result": "clean"
     },
     "erdos-662": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:23:36Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean"
     },
     "erdos-663": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:23:37Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean"
     },
     "erdos-664": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:23:38Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean"
     },
     "erdos-665": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
+      "result": "clean"
     },
     "erdos-666": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-26T08:21:27Z",
+      "result": "clean"
     },
     "erdos-667": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:23:35Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean"
     },
     "erdos-668": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:23:34Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
       "result": "clean"
     },
     "erdos-669": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:21:27Z",
+      "result": "clean"
     },
     "erdos-67": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6940,63 +6940,63 @@
     },
     "erdos-670": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:18:42Z",
+      "result": "clean"
     },
     "erdos-671": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-04T23:23:29Z",
+      "auditCount": 5,
+      "lastAudited": "2026-04-26T08:18:42Z",
       "result": "clean",
       "issues": []
     },
     "erdos-672": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:23:31Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:18:42Z",
       "result": "clean"
     },
     "erdos-673": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T17:38:28Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-26T08:18:42Z",
       "result": "clean"
     },
     "erdos-674": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:23:33Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:18:42Z",
       "result": "clean"
     },
     "erdos-675": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:23:28Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:18:42Z",
       "result": "clean"
     },
     "erdos-676": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:18:42Z",
+      "result": "clean"
     },
     "erdos-677": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:23:29Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:18:42Z",
       "result": "clean"
     },
     "erdos-678": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-04T09:27:51Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-04-26T08:18:42Z",
+      "result": "clean"
     },
     "erdos-679": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T17:01:06Z",
+      "lastAudited": "2026-04-26T08:18:42Z",
       "result": "clean"
     },
     "erdos-68": {
@@ -7006,63 +7006,63 @@
       "result": "clean"
     },
     "erdos-680": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T17:04:45Z",
+      "lastAudited": "2026-04-26T08:18:42Z",
       "result": "clean"
     },
     "erdos-681": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:23:22Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:18:42Z",
       "result": "clean"
     },
     "erdos-682": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:23:21Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:18:42Z",
       "result": "clean"
     },
     "erdos-683": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:23:24Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:18:42Z",
       "result": "clean"
     },
     "erdos-684": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:18:42Z",
+      "result": "clean"
     },
     "erdos-685": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:59:41Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-26T08:18:42Z",
+      "result": "clean"
     },
     "erdos-686": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:23:17Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:18:42Z",
       "result": "clean"
     },
     "erdos-687": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:23:18Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:18:42Z",
       "result": "clean"
     },
     "erdos-688": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:59:41Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-26T08:18:42Z",
+      "result": "clean"
     },
     "erdos-689": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:23:19Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:18:42Z",
       "result": "clean"
     },
     "erdos-69": {
@@ -7073,62 +7073,62 @@
     },
     "erdos-690": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:23:16Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:18:42Z",
       "result": "clean"
     },
     "erdos-691": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:59:41Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-26T08:18:42Z",
+      "result": "clean"
     },
     "erdos-692": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:18:42Z",
+      "result": "clean"
     },
     "erdos-693": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:23:12Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:18:42Z",
       "result": "clean"
     },
     "erdos-694": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:23:13Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:18:42Z",
       "result": "clean"
     },
     "erdos-695": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:18:42Z",
+      "result": "clean"
     },
     "erdos-696": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:23:10Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:18:42Z",
       "result": "clean"
     },
     "erdos-697": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:18:42Z",
+      "result": "clean"
     },
     "erdos-698": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:18:42Z",
+      "result": "clean"
     },
     "erdos-699": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:23:11Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:18:42Z",
       "result": "clean"
     },
     "erdos-7": {
@@ -7151,62 +7151,62 @@
     },
     "erdos-700": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T21:59:41Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-26T08:18:42Z",
+      "result": "clean"
     },
     "erdos-701": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:23:06Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:18:42Z",
       "result": "clean"
     },
     "erdos-702": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:18:42Z",
+      "result": "clean"
     },
     "erdos-703": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:23:08Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:18:42Z",
       "result": "clean"
     },
     "erdos-704": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:18:42Z",
+      "result": "clean"
     },
     "erdos-705": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:23:05Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:18:42Z",
       "result": "clean"
     },
     "erdos-706": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:18:42Z",
+      "result": "clean"
     },
     "erdos-707": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:22:56Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:18:42Z",
       "result": "clean"
     },
     "erdos-708": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:22:30Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:18:42Z",
       "result": "clean"
     },
     "erdos-709": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:22:46Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T08:18:42Z",
       "result": "clean"
     },
     "erdos-71": {


### PR DESCRIPTION
## Summary

Re-audit pass covering 160 proofs (erdos-815 through erdos-670), last checked 2026-04-03 (23 days ago).

**Checks**: sorry count vs `meta.sorries`, axiom count vs `meta.axiomCount`, line count vs `meta.lineCount`.

**Key findings**:
- Improved axiom counting to include `noncomputable axiom` declarations (erdos-756 has 5 axioms: 2 plain + 3 noncomputable — meta was already correct)
- Several apparent sorry mismatches confirmed as comment text only (erdos-761, erdos-809, erdos-866)
- No real integrity issues found

All 160: ✅ clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)