### PR TITLE
Enrich abel-ruffini: add Jordan-Hölder cross-reference

### DIFF
--- a/src/data/proofs/abel-ruffini/meta.json
+++ b/src/data/proofs/abel-ruffini/meta.json
@@ -88,6 +88,10 @@
       {
         "id": "inverse-galois-oq-06",
         "relationship": "Proves A₅ ≅ Gal(x⁵-5x⁴+10x³-10x²+25x-5/ℚ) — an alternative concrete non-radical quintic witness via A₅ realizability, complementing the S₅ witness in abel-ruffini-oq-04-oq-01"
+      },
+      {
+        "id": "abel-ruffini-galois-extensions-oq-04",
+        "relationship": "Jordan-Hölder Uniqueness Theorem via JordanHolderLattice — formalizes the uniqueness guarantee cited in keyInsights: any two composition series of a finite group have the same multiset of simple quotients (0 sorries, 0 axioms), making the S₅ obstruction in Abel-Ruffini absolute and independent of the choice of decomposition"
       }
     ],
     "lineCount": 185,


### PR DESCRIPTION
Enrichment pass for abel-ruffini.

## Changes

- Added `abel-ruffini-galois-extensions-oq-04` (Jordan-Hölder Uniqueness Theorem via JordanHolderLattice) to `relatedProblems` in meta.json.

The `keyInsights` array already cites the Jordan-Hölder theorem ("**Jordan-Hölder Guarantees Completeness:**...") but the corresponding gallery entry was missing from `relatedProblems`. The new entry formalizes exactly the uniqueness guarantee cited: that any two composition series of a finite group have the same multiset of simple quotients (0 sorries, 0 axioms), making the S₅ obstruction in Abel-Ruffini absolute.

Build: passes `pnpm build`.