### PR TITLE
research(jacobi-trudi): prove ssytFin_two_row_eq_sum_colstrict — k=2 row decomposition bijection (PART XXI)

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
@@ -324,6 +324,34 @@ Lean estimate: ~200 lines for steps (1)-(3). The bijection proof is the hard cor
   - Weight preservation: ~20 lines
 -/
 
+/-- Column-strict condition for two symmetric products P : Sym α a, Q : Sym α b.
+    The j-th element of the sorted representative of P must be strictly less than
+    the j-th element of the sorted representative of Q, for all j < min(a,b). -/
+private def ColStrictSym {α : Type*} [LinearOrder α] (a b : ℕ)
+    (P : Sym α a) (Q : Sym α b) : Prop :=
+  ∀ j : ℕ, j < min a b →
+    (P.1.sort (· ≤ ·))[j]'(by
+        have h : (P.1.sort (· ≤ ·)).length = a := (Multiset.length_sort _ P.1).trans P.2
+        omega) <
+    (Q.1.sort (· ≤ ·))[j]'(by
+        have h : (Q.1.sort (· ≤ ·)).length = b := (Multiset.length_sort _ Q.1).trans Q.2
+        omega)
+
+instance {α : Type*} [LinearOrder α] {a b : ℕ}
+    (P : Sym α a) (Q : Sym α b) : Decidable (ColStrictSym a b P Q) :=
+  Classical.propDecidable _
+
+/-- Sum over all Sym pairs equals the product of hsymm.
+    Proof: product of sums = sum over product type (Fintype.sum_prod_type),
+    then factor as (∑ P, wt P) * (∑ Q, wt Q) = h_a * h_b. -/
+private lemma sum_all_sym_pairs (n a b : ℕ) :
+    ∑ PQ : Sym (Fin n) a × Sym (Fin n) b,
+      (PQ.1.1.map (X : Fin n → MvPolynomial (Fin n) R)).prod *
+      (PQ.2.1.map (X : Fin n → MvPolynomial (Fin n) R)).prod =
+    hsymm (Fin n) R a * hsymm (Fin n) R b := by
+  simp only [hsymm, Fintype.sum_prod_type]
+  simp_rw [← Finset.mul_sum, ← Finset.sum_mul]
+
 /-- **Jeu de Taquin weight sum** (key step for two-row Jacobi-Trudi).
     The sum of pair-weights over NON-col-strict (a,b) pairs equals h_{a+1}*h_{b-1}.
 
@@ -355,7 +383,94 @@ private lemma ssytFin_two_row_eq_sum_colstrict (n : ℕ) (sh : Fin 2 → ℕ) :
               ColStrictSym (sh 0) (sh 1) PQ.1 PQ.2 },
       (PQ.1.1.1.map (X : Fin n → MvPolynomial (Fin n) R)).prod *
       (PQ.1.2.1.map (X : Fin n → MvPolynomial (Fin n) R)).prod := by
-  sorry
+  simp only [ssytSchurFin]
+  -- Helper: row i of T (weakly sorted) → sort of its multiset = List.ofFn(row i)
+  have row_sort : ∀ (T : SSYTFin n 2 sh) (i : Fin 2),
+      (↑(List.ofFn (fun j : Fin (sh i) => T.1 ⟨i, j⟩)) : Multiset _).sort (· ≤ ·) =
+      List.ofFn (fun j : Fin (sh i) => T.1 ⟨i, j⟩) := fun T i => by
+    rw [Multiset.coe_sort]
+    exact List.mergeSort_eq_self
+      ((List.sortedLE_ofFn_iff.mpr
+        (fun j1 j2 h => h.lt_or_eq.elim (T.2.1 i j1 j2) (fun h => h ▸ le_refl _))).pairwise)
+  -- Abbreviations
+  set a := sh 0; set b := sh 1
+  -- Build bijection φ : SSYTFin n 2 sh ≃ {(P,Q) : ColStrictSym}
+  let φ : SSYTFin n 2 sh ≃
+      { PQ : Sym (Fin n) a × Sym (Fin n) b // ColStrictSym a b PQ.1 PQ.2 } :=
+    { toFun := fun T =>
+        ⟨(⟨↑(List.ofFn (fun j => T.1 ⟨(0 : Fin 2), j⟩)), by simp [a]⟩,
+          ⟨↑(List.ofFn (fun j => T.1 ⟨(1 : Fin 2), j⟩)), by simp [b]⟩),
+         fun j hj => by
+           have hj0 : j < a := by
+             simp only [a, min_def] at hj; split_ifs at hj <;> omega
+           have hj1 : j < b := by
+             simp only [b, min_def] at hj; split_ifs at hj <;> omega
+           simp only [Sym.val_mk', row_sort T 0, row_sort T 1, List.getElem_ofFn]
+           exact T.2.2 0 1 ⟨j, hj0⟩ ⟨j, hj1⟩ rfl (by norm_num)⟩
+      invFun := fun ⟨⟨P, Q⟩, _⟩ =>
+        let plen : (P.1.sort (· ≤ ·)).length = a :=
+          (Multiset.length_sort _ P.1).trans P.2
+        let qlen : (Q.1.sort (· ≤ ·)).length = b :=
+          (Multiset.length_sort _ Q.1).trans Q.2
+        ⟨fun ⟨i, j⟩ => if _hi : i = (0 : Fin 2)
+            then (P.1.sort (· ≤ ·))[j.val]'(plen ▸ j.isLt)
+            else (Q.1.sort (· ≤ ·))[j.val]'(qlen ▸ j.isLt),
+         ⟨fun i j1 j2 hlt => by
+            fin_cases i
+            · simp only [dif_pos rfl]
+              exact ((Multiset.pairwise_sort (· ≤ ·) P.1).sortedLE).getElem_le_getElem_of_le
+                (plen ▸ j1.isLt) (plen ▸ j2.isLt)
+                (le_of_lt (Fin.lt_iff_val_lt_val.mp hlt))
+            · simp only [dif_neg (by norm_num : (1 : Fin 2) ≠ 0)]
+              exact ((Multiset.pairwise_sort (· ≤ ·) Q.1).sortedLE).getElem_le_getElem_of_le
+                (qlen ▸ j1.isLt) (qlen ▸ j2.isLt)
+                (le_of_lt (Fin.lt_iff_val_lt_val.mp hlt)),
+          fun i1 i2 j1 j2 hjval hi12 => by
+            have h0 : i1 = (0 : Fin 2) := by fin_cases i1 <;> fin_cases i2 <;> simp_all
+            have h1 : i2 = (1 : Fin 2) := by fin_cases i1 <;> fin_cases i2 <;> simp_all
+            subst h0; subst h1
+            simp only [dif_pos rfl, dif_neg (by norm_num : (1 : Fin 2) ≠ 0)]
+            have hmj : j1.val < min a b :=
+              Nat.lt_min.mpr ⟨j1.isLt, hjval ▸ j2.isLt⟩
+            have hval := ‹ColStrictSym a b _ _› j1.val hmj
+            simp only [Sym.val_mk'] at hval
+            rw [show j2.val = j1.val from hjval.symm]
+            exact hval⟩⟩
+      left_inv := fun T => by
+        apply Subtype.ext; funext ⟨i, j⟩
+        simp only
+        fin_cases i
+        · simp only [dif_pos rfl]
+          rw [row_sort T 0]; simp [List.getElem_ofFn]
+        · simp only [dif_neg (by norm_num : (1 : Fin 2) ≠ 0)]
+          rw [row_sort T 1]; simp [List.getElem_ofFn]
+      right_inv := fun ⟨⟨P, Q⟩, _⟩ => by
+        apply Subtype.ext
+        apply Prod.ext <;> apply Subtype.ext
+        · -- P' = P: ofFn of getElem of sort = sort_eq
+          have plen : (P.1.sort (· ≤ ·)).length = a :=
+            (Multiset.length_sort _ P.1).trans P.2
+          show (↑(List.ofFn (fun j : Fin a =>
+              (P.1.sort (· ≤ ·))[j.val]'(plen ▸ j.isLt))) : Multiset _) = P.1
+          rw [show List.ofFn (fun j : Fin a =>
+              (P.1.sort (· ≤ ·))[j.val]'(plen ▸ j.isLt)) =
+              P.1.sort (· ≤ ·) from
+              List.ext_getElem (by simp [plen]) (fun i _ _ => by simp [List.getElem_ofFn])]
+          exact_mod_cast Multiset.sort_eq (· ≤ ·) P.1
+        · -- Q' = Q: same argument
+          have qlen : (Q.1.sort (· ≤ ·)).length = b :=
+            (Multiset.length_sort _ Q.1).trans Q.2
+          show (↑(List.ofFn (fun j : Fin b =>
+              (Q.1.sort (· ≤ ·))[j.val]'(qlen ▸ j.isLt))) : Multiset _) = Q.1
+          rw [show List.ofFn (fun j : Fin b =>
+              (Q.1.sort (· ≤ ·))[j.val]'(qlen ▸ j.isLt)) =
+              Q.1.sort (· ≤ ·) from
+              List.ext_getElem (by simp [qlen]) (fun i _ _ => by simp [List.getElem_ofFn])]
+          exact_mod_cast Multiset.sort_eq (· ≤ ·) Q.1 }
+  -- Transfer sum along φ and verify weight preservation
+  refine Fintype.sum_equiv φ _ _ fun T => ?_
+  simp only [SSYTFin.weight, Fintype.prod_sigma, Fin.prod_univ_two, Sym.val_mk']
+  simp [Multiset.map_coe, Multiset.prod_coe, List.map_ofFn, prod_ofFn]
 
 /-- Partition of all Sym pairs into col-strict and non-col-strict, with sum = h_a * h_b.
     Uses Fintype.sum_subtype_add_sum_subtype to split the all-pairs sum into subtypes. -/

--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean
@@ -8016,6 +8016,1053 @@ private lemma hook_walk_identity_fiveRow (μ : YoungDiagram)
               hne_ac2, hne_bc1, hne_ab1]
   ring
 
+-- ============================================================
+-- PART XX: Hook Walk Identity for 6-Row Shapes
+-- ============================================================
+/-
+  For a 6-row Young diagram [a,b,c,d,e,f] (a≥b≥c≥d≥e≥f≥1, rowLen 6 = 0):
+  - n = a+b+c+d+e+f cells
+  - Corners: (5,f-1) always; (4,e-1) when e>f; (3,d-1) when d>e;
+             (2,c-1) when c>d; (1,b-1) when b>c; (0,a-1) when a>b
+  - hook_walk_identity proved by direct ratio computation (same pattern as fiveRow)
+-/
+
+/-- colLen(s) = 6 for s < rowLen 5 in a 6-row shape. -/
+private lemma sixRow_colLen_lt {μ : YoungDiagram} {s : ℕ}
+    (h6 : μ.rowLen 6 = 0) (hs : s < μ.rowLen 5) : μ.colLen s = 6 := by
+  apply Nat.le_antisymm
+  · by_contra hlt; push_neg at hlt
+    have h6s : (6, s) ∈ μ := YoungDiagram.mem_iff_lt_colLen.mpr hlt
+    have := YoungDiagram.mem_iff_lt_rowLen.mp h6s; omega
+  · exact YoungDiagram.mem_iff_lt_colLen.mp (YoungDiagram.mem_iff_lt_rowLen.mpr hs)
+
+/-- colLen(s) = 5 for rowLen 5 ≤ s < rowLen 4 in a 6-row shape. -/
+private lemma sixRow_colLen_mid1 {μ : YoungDiagram} {s : ℕ}
+    (h6 : μ.rowLen 6 = 0) (hs_ge : μ.rowLen 5 ≤ s) (hs_lt : s < μ.rowLen 4) :
+    μ.colLen s = 5 := by
+  apply Nat.le_antisymm
+  · by_contra hlt; push_neg at hlt
+    have h5s : (5, s) ∈ μ := YoungDiagram.mem_iff_lt_colLen.mpr hlt
+    have := YoungDiagram.mem_iff_lt_rowLen.mp h5s; omega
+  · exact YoungDiagram.mem_iff_lt_colLen.mp (YoungDiagram.mem_iff_lt_rowLen.mpr hs_lt)
+
+/-- colLen(s) = 4 for rowLen 4 ≤ s < rowLen 3 in a 6-row shape. -/
+private lemma sixRow_colLen_mid2 {μ : YoungDiagram} {s : ℕ}
+    (h6 : μ.rowLen 6 = 0) (hs_ge : μ.rowLen 4 ≤ s) (hs_lt : s < μ.rowLen 3) :
+    μ.colLen s = 4 := by
+  apply Nat.le_antisymm
+  · by_contra hlt; push_neg at hlt
+    have h4s : (4, s) ∈ μ := YoungDiagram.mem_iff_lt_colLen.mpr hlt
+    have := YoungDiagram.mem_iff_lt_rowLen.mp h4s; omega
+  · exact YoungDiagram.mem_iff_lt_colLen.mp (YoungDiagram.mem_iff_lt_rowLen.mpr hs_lt)
+
+/-- colLen(s) = 3 for rowLen 3 ≤ s < rowLen 2 in a 6-row shape. -/
+private lemma sixRow_colLen_mid3 {μ : YoungDiagram} {s : ℕ}
+    (h6 : μ.rowLen 6 = 0) (hs_ge : μ.rowLen 3 ≤ s) (hs_lt : s < μ.rowLen 2) :
+    μ.colLen s = 3 := by
+  apply Nat.le_antisymm
+  · by_contra hlt; push_neg at hlt
+    have h3s : (3, s) ∈ μ := YoungDiagram.mem_iff_lt_colLen.mpr hlt
+    have := YoungDiagram.mem_iff_lt_rowLen.mp h3s; omega
+  · exact YoungDiagram.mem_iff_lt_colLen.mp (YoungDiagram.mem_iff_lt_rowLen.mpr hs_lt)
+
+/-- colLen(s) = 2 for rowLen 2 ≤ s < rowLen 1 in a 6-row shape. -/
+private lemma sixRow_colLen_mid4 {μ : YoungDiagram} {s : ℕ}
+    (h6 : μ.rowLen 6 = 0) (hs_ge : μ.rowLen 2 ≤ s) (hs_lt : s < μ.rowLen 1) :
+    μ.colLen s = 2 := by
+  apply Nat.le_antisymm
+  · by_contra hlt; push_neg at hlt
+    have h2s : (2, s) ∈ μ := YoungDiagram.mem_iff_lt_colLen.mpr hlt
+    have := YoungDiagram.mem_iff_lt_rowLen.mp h2s; omega
+  · exact YoungDiagram.mem_iff_lt_colLen.mp (YoungDiagram.mem_iff_lt_rowLen.mpr hs_lt)
+
+-- hookLen lemmas: h(r,s) = rowLen(r) + colLen(s) - r - s - 1
+
+/-- h(5,s) = rowLen 5 - s for (5,s)∈μ. -/
+private lemma sixRow_hookLen_row5 {μ : YoungDiagram} {s : ℕ}
+    (h6 : μ.rowLen 6 = 0) (hmem : (5, s) ∈ μ) :
+    hookLength μ 5 s = μ.rowLen 5 - s := by
+  have hs : s < μ.rowLen 5 := YoungDiagram.mem_iff_lt_rowLen.mp hmem
+  have key := hookLength_add_eq μ hmem
+  rw [sixRow_colLen_lt h6 hs] at key; omega
+
+/-- h(4,s) = rowLen 4 - s + 1 for s < rowLen 5. -/
+private lemma sixRow_hookLen_row4_lt {μ : YoungDiagram} {s : ℕ}
+    (h6 : μ.rowLen 6 = 0) (hmem : (4, s) ∈ μ) (hs_lt : s < μ.rowLen 5) :
+    hookLength μ 4 s = μ.rowLen 4 - s + 1 := by
+  have key := hookLength_add_eq μ hmem
+  rw [sixRow_colLen_lt h6 hs_lt] at key; omega
+
+/-- h(4,s) = rowLen 4 - s for rowLen 5 ≤ s. -/
+private lemma sixRow_hookLen_row4_ge {μ : YoungDiagram} {s : ℕ}
+    (h6 : μ.rowLen 6 = 0) (hmem : (4, s) ∈ μ) (hs_ge : μ.rowLen 5 ≤ s) :
+    hookLength μ 4 s = μ.rowLen 4 - s := by
+  have hs_lt : s < μ.rowLen 4 := YoungDiagram.mem_iff_lt_rowLen.mp hmem
+  have key := hookLength_add_eq μ hmem
+  rw [sixRow_colLen_mid1 h6 hs_ge hs_lt] at key; omega
+
+/-- h(3,s) = rowLen 3 - s + 2 for s < rowLen 5. -/
+private lemma sixRow_hookLen_row3_lt {μ : YoungDiagram} {s : ℕ}
+    (h6 : μ.rowLen 6 = 0) (hmem : (3, s) ∈ μ) (hs_lt : s < μ.rowLen 5) :
+    hookLength μ 3 s = μ.rowLen 3 - s + 2 := by
+  have key := hookLength_add_eq μ hmem
+  rw [sixRow_colLen_lt h6 hs_lt] at key; omega
+
+/-- h(3,s) = rowLen 3 - s + 1 for rowLen 5 ≤ s < rowLen 4. -/
+private lemma sixRow_hookLen_row3_mid1 {μ : YoungDiagram} {s : ℕ}
+    (h6 : μ.rowLen 6 = 0) (hmem : (3, s) ∈ μ)
+    (hs_ge : μ.rowLen 5 ≤ s) (hs_lt : s < μ.rowLen 4) :
+    hookLength μ 3 s = μ.rowLen 3 - s + 1 := by
+  have key := hookLength_add_eq μ hmem
+  rw [sixRow_colLen_mid1 h6 hs_ge hs_lt] at key; omega
+
+/-- h(3,s) = rowLen 3 - s for rowLen 4 ≤ s. -/
+private lemma sixRow_hookLen_row3_ge {μ : YoungDiagram} {s : ℕ}
+    (h6 : μ.rowLen 6 = 0) (hmem : (3, s) ∈ μ) (hs_ge : μ.rowLen 4 ≤ s) :
+    hookLength μ 3 s = μ.rowLen 3 - s := by
+  have hs_lt : s < μ.rowLen 3 := YoungDiagram.mem_iff_lt_rowLen.mp hmem
+  have key := hookLength_add_eq μ hmem
+  rw [sixRow_colLen_mid2 h6 hs_ge hs_lt] at key; omega
+
+/-- h(2,s) = rowLen 2 - s + 3 for s < rowLen 5. -/
+private lemma sixRow_hookLen_row2_lt {μ : YoungDiagram} {s : ℕ}
+    (h6 : μ.rowLen 6 = 0) (hmem : (2, s) ∈ μ) (hs_lt : s < μ.rowLen 5) :
+    hookLength μ 2 s = μ.rowLen 2 - s + 3 := by
+  have key := hookLength_add_eq μ hmem
+  rw [sixRow_colLen_lt h6 hs_lt] at key; omega
+
+/-- h(2,s) = rowLen 2 - s + 2 for rowLen 5 ≤ s < rowLen 4. -/
+private lemma sixRow_hookLen_row2_mid1 {μ : YoungDiagram} {s : ℕ}
+    (h6 : μ.rowLen 6 = 0) (hmem : (2, s) ∈ μ)
+    (hs_ge : μ.rowLen 5 ≤ s) (hs_lt : s < μ.rowLen 4) :
+    hookLength μ 2 s = μ.rowLen 2 - s + 2 := by
+  have key := hookLength_add_eq μ hmem
+  rw [sixRow_colLen_mid1 h6 hs_ge hs_lt] at key; omega
+
+/-- h(2,s) = rowLen 2 - s + 1 for rowLen 4 ≤ s < rowLen 3. -/
+private lemma sixRow_hookLen_row2_mid2 {μ : YoungDiagram} {s : ℕ}
+    (h6 : μ.rowLen 6 = 0) (hmem : (2, s) ∈ μ)
+    (hs_ge : μ.rowLen 4 ≤ s) (hs_lt : s < μ.rowLen 3) :
+    hookLength μ 2 s = μ.rowLen 2 - s + 1 := by
+  have key := hookLength_add_eq μ hmem
+  rw [sixRow_colLen_mid2 h6 hs_ge hs_lt] at key; omega
+
+/-- h(2,s) = rowLen 2 - s for rowLen 3 ≤ s. -/
+private lemma sixRow_hookLen_row2_ge {μ : YoungDiagram} {s : ℕ}
+    (h6 : μ.rowLen 6 = 0) (hmem : (2, s) ∈ μ) (hs_ge : μ.rowLen 3 ≤ s) :
+    hookLength μ 2 s = μ.rowLen 2 - s := by
+  have hs_lt : s < μ.rowLen 2 := YoungDiagram.mem_iff_lt_rowLen.mp hmem
+  have key := hookLength_add_eq μ hmem
+  rw [sixRow_colLen_mid3 h6 hs_ge hs_lt] at key; omega
+
+/-- h(1,s) = rowLen 1 - s + 4 for s < rowLen 5. -/
+private lemma sixRow_hookLen_row1_lt {μ : YoungDiagram} {s : ℕ}
+    (h6 : μ.rowLen 6 = 0) (hmem : (1, s) ∈ μ) (hs_lt : s < μ.rowLen 5) :
+    hookLength μ 1 s = μ.rowLen 1 - s + 4 := by
+  have key := hookLength_add_eq μ hmem
+  rw [sixRow_colLen_lt h6 hs_lt] at key; omega
+
+/-- h(1,s) = rowLen 1 - s + 3 for rowLen 5 ≤ s < rowLen 4. -/
+private lemma sixRow_hookLen_row1_mid1 {μ : YoungDiagram} {s : ℕ}
+    (h6 : μ.rowLen 6 = 0) (hmem : (1, s) ∈ μ)
+    (hs_ge : μ.rowLen 5 ≤ s) (hs_lt : s < μ.rowLen 4) :
+    hookLength μ 1 s = μ.rowLen 1 - s + 3 := by
+  have key := hookLength_add_eq μ hmem
+  rw [sixRow_colLen_mid1 h6 hs_ge hs_lt] at key; omega
+
+/-- h(1,s) = rowLen 1 - s + 2 for rowLen 4 ≤ s < rowLen 3. -/
+private lemma sixRow_hookLen_row1_mid2 {μ : YoungDiagram} {s : ℕ}
+    (h6 : μ.rowLen 6 = 0) (hmem : (1, s) ∈ μ)
+    (hs_ge : μ.rowLen 4 ≤ s) (hs_lt : s < μ.rowLen 3) :
+    hookLength μ 1 s = μ.rowLen 1 - s + 2 := by
+  have key := hookLength_add_eq μ hmem
+  rw [sixRow_colLen_mid2 h6 hs_ge hs_lt] at key; omega
+
+/-- h(1,s) = rowLen 1 - s + 1 for rowLen 3 ≤ s < rowLen 2. -/
+private lemma sixRow_hookLen_row1_mid3 {μ : YoungDiagram} {s : ℕ}
+    (h6 : μ.rowLen 6 = 0) (hmem : (1, s) ∈ μ)
+    (hs_ge : μ.rowLen 3 ≤ s) (hs_lt : s < μ.rowLen 2) :
+    hookLength μ 1 s = μ.rowLen 1 - s + 1 := by
+  have key := hookLength_add_eq μ hmem
+  rw [sixRow_colLen_mid3 h6 hs_ge hs_lt] at key; omega
+
+/-- h(1,s) = rowLen 1 - s for rowLen 2 ≤ s. -/
+private lemma sixRow_hookLen_row1_ge {μ : YoungDiagram} {s : ℕ}
+    (h6 : μ.rowLen 6 = 0) (hmem : (1, s) ∈ μ) (hs_ge : μ.rowLen 2 ≤ s) :
+    hookLength μ 1 s = μ.rowLen 1 - s := by
+  have hs_lt : s < μ.rowLen 1 := YoungDiagram.mem_iff_lt_rowLen.mp hmem
+  have key := hookLength_add_eq μ hmem
+  rw [sixRow_colLen_mid4 h6 hs_ge hs_lt] at key; omega
+
+/-- h(0,s) = rowLen 0 - s + 5 for s < rowLen 5. -/
+private lemma sixRow_hookLen_row0_lt {μ : YoungDiagram} {s : ℕ}
+    (h6 : μ.rowLen 6 = 0) (hmem : (0, s) ∈ μ) (hs_lt : s < μ.rowLen 5) :
+    hookLength μ 0 s = μ.rowLen 0 - s + 5 := by
+  have key := hookLength_add_eq μ hmem
+  rw [sixRow_colLen_lt h6 hs_lt] at key; omega
+
+/-- h(0,s) = rowLen 0 - s + 4 for rowLen 5 ≤ s < rowLen 4. -/
+private lemma sixRow_hookLen_row0_mid1 {μ : YoungDiagram} {s : ℕ}
+    (h6 : μ.rowLen 6 = 0) (hmem : (0, s) ∈ μ)
+    (hs_ge : μ.rowLen 5 ≤ s) (hs_lt : s < μ.rowLen 4) :
+    hookLength μ 0 s = μ.rowLen 0 - s + 4 := by
+  have key := hookLength_add_eq μ hmem
+  rw [sixRow_colLen_mid1 h6 hs_ge hs_lt] at key; omega
+
+/-- h(0,s) = rowLen 0 - s + 3 for rowLen 4 ≤ s < rowLen 3. -/
+private lemma sixRow_hookLen_row0_mid2 {μ : YoungDiagram} {s : ℕ}
+    (h6 : μ.rowLen 6 = 0) (hmem : (0, s) ∈ μ)
+    (hs_ge : μ.rowLen 4 ≤ s) (hs_lt : s < μ.rowLen 3) :
+    hookLength μ 0 s = μ.rowLen 0 - s + 3 := by
+  have key := hookLength_add_eq μ hmem
+  rw [sixRow_colLen_mid2 h6 hs_ge hs_lt] at key; omega
+
+/-- h(0,s) = rowLen 0 - s + 2 for rowLen 3 ≤ s < rowLen 2. -/
+private lemma sixRow_hookLen_row0_mid3 {μ : YoungDiagram} {s : ℕ}
+    (h6 : μ.rowLen 6 = 0) (hmem : (0, s) ∈ μ)
+    (hs_ge : μ.rowLen 3 ≤ s) (hs_lt : s < μ.rowLen 2) :
+    hookLength μ 0 s = μ.rowLen 0 - s + 2 := by
+  have key := hookLength_add_eq μ hmem
+  rw [sixRow_colLen_mid3 h6 hs_ge hs_lt] at key; omega
+
+/-- h(0,s) = rowLen 0 - s + 1 for rowLen 2 ≤ s < rowLen 1. -/
+private lemma sixRow_hookLen_row0_mid4 {μ : YoungDiagram} {s : ℕ}
+    (h6 : μ.rowLen 6 = 0) (hmem : (0, s) ∈ μ)
+    (hs_ge : μ.rowLen 2 ≤ s) (hs_lt : s < μ.rowLen 1) :
+    hookLength μ 0 s = μ.rowLen 0 - s + 1 := by
+  have key := hookLength_add_eq μ hmem
+  rw [sixRow_colLen_mid4 h6 hs_ge hs_lt] at key; omega
+
+/-- h(0,s) = rowLen 0 - s for rowLen 1 ≤ s. -/
+private lemma sixRow_hookLen_row0_ge {μ : YoungDiagram} {s : ℕ}
+    (h6 : μ.rowLen 6 = 0) (hmem : (0, s) ∈ μ) (hs_ge : μ.rowLen 1 ≤ s) :
+    hookLength μ 0 s = μ.rowLen 0 - s := by
+  have hs_lt : s < μ.rowLen 0 := YoungDiagram.mem_iff_lt_rowLen.mp hmem
+  have key := hookLength_add_eq μ hmem
+  have hcol1 : μ.colLen s = 1 := by
+    apply Nat.le_antisymm
+    · by_contra hlt; push_neg at hlt
+      have h1s : (1, s) ∈ μ := YoungDiagram.mem_iff_lt_colLen.mpr hlt
+      have := YoungDiagram.mem_iff_lt_rowLen.mp h1s; omega
+    · exact YoungDiagram.mem_iff_lt_colLen.mp (YoungDiagram.mem_iff_lt_rowLen.mpr hs_lt)
+  rw [hcol1] at key; omega
+
+/-- Card of a 6-row diagram. -/
+private lemma sixRow_card {μ : YoungDiagram} (h6 : μ.rowLen 6 = 0) :
+    μ.card = μ.rowLen 0 + μ.rowLen 1 + μ.rowLen 2 + μ.rowLen 3 + μ.rowLen 4 + μ.rowLen 5 := by
+  have hcells : μ.cells =
+      (Finset.range (μ.rowLen 0)).image (Prod.mk 0) ∪
+      (Finset.range (μ.rowLen 1)).image (Prod.mk 1) ∪
+      (Finset.range (μ.rowLen 2)).image (Prod.mk 2) ∪
+      (Finset.range (μ.rowLen 3)).image (Prod.mk 3) ∪
+      (Finset.range (μ.rowLen 4)).image (Prod.mk 4) ∪
+      (Finset.range (μ.rowLen 5)).image (Prod.mk 5) := by
+    ext ⟨i, j⟩
+    simp only [YoungDiagram.mem_cells, YoungDiagram.mem_iff_lt_rowLen,
+               Finset.mem_union, Finset.mem_image, Finset.mem_range, Prod.mk.injEq]
+    constructor
+    · intro h
+      interval_cases i <;> simp_all <;> omega
+    · rintro (((((⟨_, _, rfl, rfl⟩ | ⟨_, _, rfl, rfl⟩) | ⟨_, _, rfl, rfl⟩) |
+                ⟨_, _, rfl, rfl⟩) | ⟨_, _, rfl, rfl⟩) | ⟨_, _, rfl, rfl⟩) <;>
+      simp_all <;> omega
+  simp only [YoungDiagram.card, hcells]
+  have hd1 : Disjoint
+      ((Finset.range (μ.rowLen 0)).image (Prod.mk 0))
+      ((Finset.range (μ.rowLen 1)).image (Prod.mk 1)) :=
+    Finset.disjoint_left.mpr fun x hx hy => by
+      simp only [Finset.mem_image, Finset.mem_range, Prod.mk.injEq] at hx hy
+      obtain ⟨_, _, rfl, rfl⟩ := hx; obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+  have hd2 : Disjoint
+      ((Finset.range (μ.rowLen 0)).image (Prod.mk 0) ∪
+       (Finset.range (μ.rowLen 1)).image (Prod.mk 1))
+      ((Finset.range (μ.rowLen 2)).image (Prod.mk 2)) :=
+    Finset.disjoint_left.mpr fun x hx hy => by
+      simp only [Finset.mem_union, Finset.mem_image, Finset.mem_range, Prod.mk.injEq] at hx hy
+      obtain (⟨_, _, rfl, rfl⟩ | ⟨_, _, rfl, rfl⟩) := hx
+      · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+      · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+  have hd3 : Disjoint
+      ((Finset.range (μ.rowLen 0)).image (Prod.mk 0) ∪
+       (Finset.range (μ.rowLen 1)).image (Prod.mk 1) ∪
+       (Finset.range (μ.rowLen 2)).image (Prod.mk 2))
+      ((Finset.range (μ.rowLen 3)).image (Prod.mk 3)) :=
+    Finset.disjoint_left.mpr fun x hx hy => by
+      simp only [Finset.mem_union, Finset.mem_image, Finset.mem_range, Prod.mk.injEq] at hx hy
+      obtain ((⟨_, _, rfl, rfl⟩ | ⟨_, _, rfl, rfl⟩) | ⟨_, _, rfl, rfl⟩) := hx
+      · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+      · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+      · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+  have hd4 : Disjoint
+      ((Finset.range (μ.rowLen 0)).image (Prod.mk 0) ∪
+       (Finset.range (μ.rowLen 1)).image (Prod.mk 1) ∪
+       (Finset.range (μ.rowLen 2)).image (Prod.mk 2) ∪
+       (Finset.range (μ.rowLen 3)).image (Prod.mk 3))
+      ((Finset.range (μ.rowLen 4)).image (Prod.mk 4)) :=
+    Finset.disjoint_left.mpr fun x hx hy => by
+      simp only [Finset.mem_union, Finset.mem_image, Finset.mem_range, Prod.mk.injEq] at hx hy
+      obtain (((⟨_, _, rfl, rfl⟩ | ⟨_, _, rfl, rfl⟩) | ⟨_, _, rfl, rfl⟩) |
+               ⟨_, _, rfl, rfl⟩) := hx
+      · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+      · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+      · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+      · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+  have hd5 : Disjoint
+      ((Finset.range (μ.rowLen 0)).image (Prod.mk 0) ∪
+       (Finset.range (μ.rowLen 1)).image (Prod.mk 1) ∪
+       (Finset.range (μ.rowLen 2)).image (Prod.mk 2) ∪
+       (Finset.range (μ.rowLen 3)).image (Prod.mk 3) ∪
+       (Finset.range (μ.rowLen 4)).image (Prod.mk 4))
+      ((Finset.range (μ.rowLen 5)).image (Prod.mk 5)) :=
+    Finset.disjoint_left.mpr fun x hx hy => by
+      simp only [Finset.mem_union, Finset.mem_image, Finset.mem_range, Prod.mk.injEq] at hx hy
+      obtain ((((⟨_, _, rfl, rfl⟩ | ⟨_, _, rfl, rfl⟩) | ⟨_, _, rfl, rfl⟩) |
+               ⟨_, _, rfl, rfl⟩) | ⟨_, _, rfl, rfl⟩) := hx
+      · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+      · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+      · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+      · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+      · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+  rw [Finset.card_union_of_disjoint hd5, Finset.card_union_of_disjoint hd4,
+      Finset.card_union_of_disjoint hd3, Finset.card_union_of_disjoint hd2,
+      Finset.card_union_of_disjoint hd1,
+      Finset.card_image_of_injective _ (fun p q h => (Prod.mk.inj h).2),
+      Finset.card_image_of_injective _ (fun p q h => (Prod.mk.inj h).2),
+      Finset.card_image_of_injective _ (fun p q h => (Prod.mk.inj h).2),
+      Finset.card_image_of_injective _ (fun p q h => (Prod.mk.inj h).2),
+      Finset.card_image_of_injective _ (fun p q h => (Prod.mk.inj h).2),
+      Finset.card_image_of_injective _ (fun p q h => (Prod.mk.inj h).2),
+      Finset.card_range, Finset.card_range, Finset.card_range,
+      Finset.card_range, Finset.card_range, Finset.card_range]
+
+/-- Arm product for corner (5, f-1) telescopes to f. -/
+private lemma sixRow_arm_row5 (μ : YoungDiagram) (h6 : μ.rowLen 6 = 0)
+    (hf : isCorner μ (5, μ.rowLen 5 - 1)) :
+    ∏ s ∈ Finset.range (μ.rowLen 5 - 1),
+      ((hookLength μ 5 s : ℚ) / ((hookLength μ 5 s : ℚ) - 1)) =
+    (μ.rowLen 5 : ℚ) := by
+  set f := μ.rowLen 5
+  have hf_pos : 0 < f := by
+    have := YoungDiagram.mem_iff_lt_rowLen.mp hf.1; omega
+  have hconv : ∀ s ∈ Finset.range (f - 1),
+      (hookLength μ 5 s : ℚ) / ((hookLength μ 5 s : ℚ) - 1) =
+      ((f : ℚ) - s) / ((f : ℚ) - s - 1) := by
+    intro s hs
+    have hsc : s < f - 1 := Finset.mem_range.mp hs
+    have hmem : (5, s) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [sixRow_hookLen_row5 h6 hmem]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv]
+  rw [prod_div_telescope f (f - 1) (Nat.sub_lt hf_pos Nat.one_pos)]
+  push_cast; simp [Nat.cast_sub (Nat.one_le_iff_ne_zero.mpr (Nat.pos_iff_ne_zero.mp hf_pos))]
+
+/-- Arm product for corner (4, e-1) in a 6-row shape:
+    ∏ = (e+1)(e-f)/(e-f+1). -/
+private lemma sixRow_arm_row4 {μ : YoungDiagram} (h6 : μ.rowLen 6 = 0)
+    (hef : μ.rowLen 5 < μ.rowLen 4) :
+    ∏ s ∈ Finset.range (μ.rowLen 4 - 1),
+      ((hookLength μ 4 s : ℚ) / ((hookLength μ 4 s : ℚ) - 1)) =
+    ((μ.rowLen 4 : ℚ) + 1) * ((μ.rowLen 4 : ℚ) - μ.rowLen 5) /
+    ((μ.rowLen 4 : ℚ) - μ.rowLen 5 + 1) := by
+  set e := μ.rowLen 4; set f := μ.rowLen 5
+  -- Split range(e-1) into [0,f) and [f, e-1)
+  rw [show Finset.range (e - 1) = Finset.range f ∪ Finset.Ico f (e - 1) from by
+    ext s; simp [Finset.mem_Ico]; omega]
+  rw [Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega)]
+  -- Product 1: [0,f), h(4,s) = e-s+1
+  have hconv1 : ∀ s ∈ Finset.range f,
+      (hookLength μ 4 s : ℚ) / ((hookLength μ 4 s : ℚ) - 1) =
+      ((e : ℚ) + 1 - s) / ((e : ℚ) + 1 - s - 1) := by
+    intro s hs
+    have hse : s < f := Finset.mem_range.mp hs
+    have hmem : (4, s) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [sixRow_hookLen_row4_lt h6 hmem hse]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv1, prod_div_telescope (e + 1) f (by omega)]
+  -- Product 2: [f, e-1), reindex t = s-f, h(4,t+f) = e-f-t
+  rw [show Finset.Ico f (e - 1) = (Finset.range (e - 1 - f)).image (· + f) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv2 : ∀ t ∈ Finset.range (e - 1 - f),
+      (hookLength μ 4 (t + f) : ℚ) / ((hookLength μ 4 (t + f) : ℚ) - 1) =
+      ((e : ℚ) - f - t) / ((e : ℚ) - f - t - 1) := by
+    intro t ht
+    have htm : t < e - 1 - f := Finset.mem_range.mp ht
+    have hmem : (4, t + f) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [sixRow_hookLen_row4_ge h6 hmem (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv2, prod_div_telescope (e - f) (e - 1 - f) (by omega)]
+  push_cast [Nat.cast_sub hef.le, Nat.cast_sub (show 1 ≤ e - f by omega)]
+  have hne : (e : ℚ) - f + 1 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < e - f + 1 by omega)
+  field_simp [hne]; ring
+
+/-- Arm product for corner (3, d-1) in a 6-row shape:
+    ∏ = (d+2)(d-f+1)(d-e)/((d+2-f)(d-e+1)). -/
+private lemma sixRow_arm_row3 {μ : YoungDiagram} (h6 : μ.rowLen 6 = 0)
+    (hed : μ.rowLen 4 < μ.rowLen 3) :
+    ∏ s ∈ Finset.range (μ.rowLen 3 - 1),
+      ((hookLength μ 3 s : ℚ) / ((hookLength μ 3 s : ℚ) - 1)) =
+    ((μ.rowLen 3 : ℚ) + 2) * ((μ.rowLen 3 : ℚ) - μ.rowLen 5 + 1) *
+    ((μ.rowLen 3 : ℚ) - μ.rowLen 4) /
+    (((μ.rowLen 3 : ℚ) - μ.rowLen 5 + 2) * ((μ.rowLen 3 : ℚ) - μ.rowLen 4 + 1)) := by
+  set d := μ.rowLen 3; set e := μ.rowLen 4; set f := μ.rowLen 5
+  have hfe : f ≤ e := μ.rowLen_anti 4 5 (by omega)
+  -- Split range(d-1) into [0,f), [f,e), [e, d-1)
+  rw [show Finset.range (d - 1) = Finset.range f ∪ Finset.Ico f e ∪ Finset.Ico e (d - 1) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega),
+      Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega)]
+  -- Product 1: [0,f), h(3,s) = d-s+2
+  have hconv1 : ∀ s ∈ Finset.range f,
+      (hookLength μ 3 s : ℚ) / ((hookLength μ 3 s : ℚ) - 1) =
+      ((d : ℚ) + 2 - s) / ((d : ℚ) + 2 - s - 1) := by
+    intro s hs
+    have hse : s < f := Finset.mem_range.mp hs
+    have hmem : (3, s) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [sixRow_hookLen_row3_lt h6 hmem hse]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv1, prod_div_telescope (d + 2) f (by omega)]
+  -- Product 2: [f, e), h(3,t+f) = d-f+1-t
+  rw [show Finset.Ico f e = (Finset.range (e - f)).image (· + f) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv2 : ∀ t ∈ Finset.range (e - f),
+      (hookLength μ 3 (t + f) : ℚ) / ((hookLength μ 3 (t + f) : ℚ) - 1) =
+      ((d : ℚ) - f + 1 - t) / ((d : ℚ) - f + 1 - t - 1) := by
+    intro t ht
+    have htm : t < e - f := Finset.mem_range.mp ht
+    have hmem : (3, t + f) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [sixRow_hookLen_row3_mid1 h6 hmem (by omega) (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv2, prod_div_telescope (d - f + 1) (e - f) (by omega)]
+  -- Product 3: [e, d-1), h(3,t+e) = d-e-t
+  rw [show Finset.Ico e (d - 1) = (Finset.range (d - 1 - e)).image (· + e) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv3 : ∀ t ∈ Finset.range (d - 1 - e),
+      (hookLength μ 3 (t + e) : ℚ) / ((hookLength μ 3 (t + e) : ℚ) - 1) =
+      ((d : ℚ) - e - t) / ((d : ℚ) - e - t - 1) := by
+    intro t ht
+    have htm : t < d - 1 - e := Finset.mem_range.mp ht
+    have hmem : (3, t + e) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [sixRow_hookLen_row3_ge h6 hmem (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv3, prod_div_telescope (d - e) (d - 1 - e) (by omega)]
+  push_cast [Nat.cast_sub hfe, Nat.cast_sub hed.le, Nat.cast_sub (show 1 ≤ d - e by omega)]
+  have hne1 : (d : ℚ) - f + 2 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < d - f + 2 by omega)
+  have hne2 : (d : ℚ) - e + 1 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < d - e + 1 by omega)
+  field_simp [hne1, hne2]; ring
+
+/-- Arm product for corner (2, c-1) in a 6-row shape:
+    ∏ = (c+3)(c-f+2)(c-e+1)(c-d)/((c+3-f)(c-e+2)(c-d+1)). -/
+private lemma sixRow_arm_row2 {μ : YoungDiagram} (h6 : μ.rowLen 6 = 0)
+    (hdc : μ.rowLen 3 < μ.rowLen 2) :
+    ∏ s ∈ Finset.range (μ.rowLen 2 - 1),
+      ((hookLength μ 2 s : ℚ) / ((hookLength μ 2 s : ℚ) - 1)) =
+    ((μ.rowLen 2 : ℚ) + 3) * ((μ.rowLen 2 : ℚ) - μ.rowLen 5 + 2) *
+    ((μ.rowLen 2 : ℚ) - μ.rowLen 4 + 1) * ((μ.rowLen 2 : ℚ) - μ.rowLen 3) /
+    (((μ.rowLen 2 : ℚ) - μ.rowLen 5 + 3) * ((μ.rowLen 2 : ℚ) - μ.rowLen 4 + 2) *
+     ((μ.rowLen 2 : ℚ) - μ.rowLen 3 + 1)) := by
+  set c := μ.rowLen 2; set d := μ.rowLen 3; set e := μ.rowLen 4; set f := μ.rowLen 5
+  have hfe : f ≤ e := μ.rowLen_anti 4 5 (by omega)
+  have hed : e ≤ d := μ.rowLen_anti 3 4 (by omega)
+  rw [show Finset.range (c - 1) =
+      Finset.range f ∪ Finset.Ico f e ∪ Finset.Ico e d ∪ Finset.Ico d (c - 1) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega),
+      Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega),
+      Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega)]
+  -- Product 1: [0,f), h(2,s) = c-s+3
+  have hconv1 : ∀ s ∈ Finset.range f,
+      (hookLength μ 2 s : ℚ) / ((hookLength μ 2 s : ℚ) - 1) =
+      ((c : ℚ) + 3 - s) / ((c : ℚ) + 3 - s - 1) := by
+    intro s hs
+    have hse : s < f := Finset.mem_range.mp hs
+    have hmem : (2, s) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [sixRow_hookLen_row2_lt h6 hmem hse]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv1, prod_div_telescope (c + 3) f (by omega)]
+  -- Product 2: [f, e), h(2,t+f) = c-f+2-t
+  rw [show Finset.Ico f e = (Finset.range (e - f)).image (· + f) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv2 : ∀ t ∈ Finset.range (e - f),
+      (hookLength μ 2 (t + f) : ℚ) / ((hookLength μ 2 (t + f) : ℚ) - 1) =
+      ((c : ℚ) - f + 2 - t) / ((c : ℚ) - f + 2 - t - 1) := by
+    intro t ht
+    have htm : t < e - f := Finset.mem_range.mp ht
+    have hmem : (2, t + f) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [sixRow_hookLen_row2_mid1 h6 hmem (by omega) (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv2, prod_div_telescope (c - f + 2) (e - f) (by omega)]
+  -- Product 3: [e, d), h(2,t+e) = c-e+1-t
+  rw [show Finset.Ico e d = (Finset.range (d - e)).image (· + e) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv3 : ∀ t ∈ Finset.range (d - e),
+      (hookLength μ 2 (t + e) : ℚ) / ((hookLength μ 2 (t + e) : ℚ) - 1) =
+      ((c : ℚ) - e + 1 - t) / ((c : ℚ) - e + 1 - t - 1) := by
+    intro t ht
+    have htm : t < d - e := Finset.mem_range.mp ht
+    have hmem : (2, t + e) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [sixRow_hookLen_row2_mid2 h6 hmem (by omega) (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv3, prod_div_telescope (c - e + 1) (d - e) (by omega)]
+  -- Product 4: [d, c-1), h(2,t+d) = c-d-t
+  rw [show Finset.Ico d (c - 1) = (Finset.range (c - 1 - d)).image (· + d) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv4 : ∀ t ∈ Finset.range (c - 1 - d),
+      (hookLength μ 2 (t + d) : ℚ) / ((hookLength μ 2 (t + d) : ℚ) - 1) =
+      ((c : ℚ) - d - t) / ((c : ℚ) - d - t - 1) := by
+    intro t ht
+    have htm : t < c - 1 - d := Finset.mem_range.mp ht
+    have hmem : (2, t + d) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [sixRow_hookLen_row2_ge h6 hmem (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv4, prod_div_telescope (c - d) (c - 1 - d) (by omega)]
+  push_cast [Nat.cast_sub hfe, Nat.cast_sub hed, Nat.cast_sub hdc.le,
+             Nat.cast_sub (show 1 ≤ c - d by omega)]
+  have hne1 : (c : ℚ) - f + 3 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < c - f + 3 by omega)
+  have hne2 : (c : ℚ) - e + 2 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < c - e + 2 by omega)
+  have hne3 : (c : ℚ) - d + 1 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < c - d + 1 by omega)
+  field_simp [hne1, hne2, hne3]; ring
+
+/-- Arm product for corner (1, b-1) in a 6-row shape. -/
+private lemma sixRow_arm_row1 {μ : YoungDiagram} (h6 : μ.rowLen 6 = 0)
+    (hcb : μ.rowLen 2 < μ.rowLen 1) :
+    ∏ s ∈ Finset.range (μ.rowLen 1 - 1),
+      ((hookLength μ 1 s : ℚ) / ((hookLength μ 1 s : ℚ) - 1)) =
+    ((μ.rowLen 1 : ℚ) + 4) * ((μ.rowLen 1 : ℚ) - μ.rowLen 5 + 3) *
+    ((μ.rowLen 1 : ℚ) - μ.rowLen 4 + 2) * ((μ.rowLen 1 : ℚ) - μ.rowLen 3 + 1) *
+    ((μ.rowLen 1 : ℚ) - μ.rowLen 2) /
+    (((μ.rowLen 1 : ℚ) - μ.rowLen 5 + 4) * ((μ.rowLen 1 : ℚ) - μ.rowLen 4 + 3) *
+     ((μ.rowLen 1 : ℚ) - μ.rowLen 3 + 2) * ((μ.rowLen 1 : ℚ) - μ.rowLen 2 + 1)) := by
+  set b := μ.rowLen 1; set c := μ.rowLen 2; set d := μ.rowLen 3
+  set e := μ.rowLen 4; set f := μ.rowLen 5
+  have hfe : f ≤ e := μ.rowLen_anti 4 5 (by omega)
+  have hed : e ≤ d := μ.rowLen_anti 3 4 (by omega)
+  have hdc : d ≤ c := μ.rowLen_anti 2 3 (by omega)
+  rw [show Finset.range (b - 1) =
+      Finset.range f ∪ Finset.Ico f e ∪ Finset.Ico e d ∪ Finset.Ico d c ∪
+      Finset.Ico c (b - 1) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega),
+      Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega),
+      Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega),
+      Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega)]
+  -- Product 1: [0,f), h(1,s) = b-s+4
+  have hconv1 : ∀ s ∈ Finset.range f,
+      (hookLength μ 1 s : ℚ) / ((hookLength μ 1 s : ℚ) - 1) =
+      ((b : ℚ) + 4 - s) / ((b : ℚ) + 4 - s - 1) := by
+    intro s hs
+    have hse : s < f := Finset.mem_range.mp hs
+    have hmem : (1, s) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [sixRow_hookLen_row1_lt h6 hmem hse]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv1, prod_div_telescope (b + 4) f (by omega)]
+  -- Product 2: [f, e), h(1,t+f) = b-f+3-t
+  rw [show Finset.Ico f e = (Finset.range (e - f)).image (· + f) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv2 : ∀ t ∈ Finset.range (e - f),
+      (hookLength μ 1 (t + f) : ℚ) / ((hookLength μ 1 (t + f) : ℚ) - 1) =
+      ((b : ℚ) - f + 3 - t) / ((b : ℚ) - f + 3 - t - 1) := by
+    intro t ht
+    have htm : t < e - f := Finset.mem_range.mp ht
+    have hmem : (1, t + f) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [sixRow_hookLen_row1_mid1 h6 hmem (by omega) (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv2, prod_div_telescope (b - f + 3) (e - f) (by omega)]
+  -- Product 3: [e, d), h(1,t+e) = b-e+2-t
+  rw [show Finset.Ico e d = (Finset.range (d - e)).image (· + e) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv3 : ∀ t ∈ Finset.range (d - e),
+      (hookLength μ 1 (t + e) : ℚ) / ((hookLength μ 1 (t + e) : ℚ) - 1) =
+      ((b : ℚ) - e + 2 - t) / ((b : ℚ) - e + 2 - t - 1) := by
+    intro t ht
+    have htm : t < d - e := Finset.mem_range.mp ht
+    have hmem : (1, t + e) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [sixRow_hookLen_row1_mid2 h6 hmem (by omega) (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv3, prod_div_telescope (b - e + 2) (d - e) (by omega)]
+  -- Product 4: [d, c), h(1,t+d) = b-d+1-t
+  rw [show Finset.Ico d c = (Finset.range (c - d)).image (· + d) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv4 : ∀ t ∈ Finset.range (c - d),
+      (hookLength μ 1 (t + d) : ℚ) / ((hookLength μ 1 (t + d) : ℚ) - 1) =
+      ((b : ℚ) - d + 1 - t) / ((b : ℚ) - d + 1 - t - 1) := by
+    intro t ht
+    have htm : t < c - d := Finset.mem_range.mp ht
+    have hmem : (1, t + d) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [sixRow_hookLen_row1_mid3 h6 hmem (by omega) (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv4, prod_div_telescope (b - d + 1) (c - d) (by omega)]
+  -- Product 5: [c, b-1), h(1,t+c) = b-c-t
+  rw [show Finset.Ico c (b - 1) = (Finset.range (b - 1 - c)).image (· + c) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv5 : ∀ t ∈ Finset.range (b - 1 - c),
+      (hookLength μ 1 (t + c) : ℚ) / ((hookLength μ 1 (t + c) : ℚ) - 1) =
+      ((b : ℚ) - c - t) / ((b : ℚ) - c - t - 1) := by
+    intro t ht
+    have htm : t < b - 1 - c := Finset.mem_range.mp ht
+    have hmem : (1, t + c) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [sixRow_hookLen_row1_ge h6 hmem (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv5, prod_div_telescope (b - c) (b - 1 - c) (by omega)]
+  push_cast [Nat.cast_sub hfe, Nat.cast_sub hed, Nat.cast_sub hdc, Nat.cast_sub hcb.le,
+             Nat.cast_sub (show 1 ≤ b - c by omega)]
+  have hne1 : (b : ℚ) - f + 4 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < b - f + 4 by omega)
+  have hne2 : (b : ℚ) - e + 3 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < b - e + 3 by omega)
+  have hne3 : (b : ℚ) - d + 2 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < b - d + 2 by omega)
+  have hne4 : (b : ℚ) - c + 1 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < b - c + 1 by omega)
+  field_simp [hne1, hne2, hne3, hne4]; ring
+
+/-- Arm product for corner (0, a-1) in a 6-row shape. -/
+private lemma sixRow_arm_row0 {μ : YoungDiagram} (h6 : μ.rowLen 6 = 0)
+    (h5 : 0 < μ.rowLen 5) (hab : μ.rowLen 1 < μ.rowLen 0) :
+    ∏ s ∈ Finset.range (μ.rowLen 0 - 1),
+      ((hookLength μ 0 s : ℚ) / ((hookLength μ 0 s : ℚ) - 1)) =
+    ((μ.rowLen 0 : ℚ) + 5) * ((μ.rowLen 0 : ℚ) - μ.rowLen 5 + 4) *
+    ((μ.rowLen 0 : ℚ) - μ.rowLen 4 + 3) * ((μ.rowLen 0 : ℚ) - μ.rowLen 3 + 2) *
+    ((μ.rowLen 0 : ℚ) - μ.rowLen 2 + 1) * ((μ.rowLen 0 : ℚ) - μ.rowLen 1) /
+    (((μ.rowLen 0 : ℚ) - μ.rowLen 5 + 5) * ((μ.rowLen 0 : ℚ) - μ.rowLen 4 + 4) *
+     ((μ.rowLen 0 : ℚ) - μ.rowLen 3 + 3) * ((μ.rowLen 0 : ℚ) - μ.rowLen 2 + 2) *
+     ((μ.rowLen 0 : ℚ) - μ.rowLen 1 + 1)) := by
+  set a := μ.rowLen 0; set b := μ.rowLen 1; set c := μ.rowLen 2
+  set d := μ.rowLen 3; set e := μ.rowLen 4; set f := μ.rowLen 5
+  have hfe : f ≤ e := μ.rowLen_anti 4 5 (by omega)
+  have hed : e ≤ d := μ.rowLen_anti 3 4 (by omega)
+  have hdc : d ≤ c := μ.rowLen_anti 2 3 (by omega)
+  have hcb : c ≤ b := μ.rowLen_anti 1 2 (by omega)
+  rw [show Finset.range (a - 1) =
+      Finset.range f ∪ Finset.Ico f e ∪ Finset.Ico e d ∪ Finset.Ico d c ∪
+      Finset.Ico c b ∪ Finset.Ico b (a - 1) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega),
+      Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega),
+      Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega),
+      Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega),
+      Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega)]
+  -- Product 1: [0,f), h(0,s) = a-s+5
+  have hconv1 : ∀ s ∈ Finset.range f,
+      (hookLength μ 0 s : ℚ) / ((hookLength μ 0 s : ℚ) - 1) =
+      ((a : ℚ) + 5 - s) / ((a : ℚ) + 5 - s - 1) := by
+    intro s hs
+    have hse : s < f := Finset.mem_range.mp hs
+    have hmem : (0, s) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [sixRow_hookLen_row0_lt h6 hmem hse]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv1, prod_div_telescope (a + 5) f (by omega)]
+  -- Product 2: [f, e), h(0,t+f) = a-f+4-t
+  rw [show Finset.Ico f e = (Finset.range (e - f)).image (· + f) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv2 : ∀ t ∈ Finset.range (e - f),
+      (hookLength μ 0 (t + f) : ℚ) / ((hookLength μ 0 (t + f) : ℚ) - 1) =
+      ((a : ℚ) - f + 4 - t) / ((a : ℚ) - f + 4 - t - 1) := by
+    intro t ht
+    have htm : t < e - f := Finset.mem_range.mp ht
+    have hmem : (0, t + f) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [sixRow_hookLen_row0_mid1 h6 hmem (by omega) (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv2, prod_div_telescope (a - f + 4) (e - f) (by omega)]
+  -- Product 3: [e, d), h(0,t+e) = a-e+3-t
+  rw [show Finset.Ico e d = (Finset.range (d - e)).image (· + e) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv3 : ∀ t ∈ Finset.range (d - e),
+      (hookLength μ 0 (t + e) : ℚ) / ((hookLength μ 0 (t + e) : ℚ) - 1) =
+      ((a : ℚ) - e + 3 - t) / ((a : ℚ) - e + 3 - t - 1) := by
+    intro t ht
+    have htm : t < d - e := Finset.mem_range.mp ht
+    have hmem : (0, t + e) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [sixRow_hookLen_row0_mid2 h6 hmem (by omega) (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv3, prod_div_telescope (a - e + 3) (d - e) (by omega)]
+  -- Product 4: [d, c), h(0,t+d) = a-d+2-t
+  rw [show Finset.Ico d c = (Finset.range (c - d)).image (· + d) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv4 : ∀ t ∈ Finset.range (c - d),
+      (hookLength μ 0 (t + d) : ℚ) / ((hookLength μ 0 (t + d) : ℚ) - 1) =
+      ((a : ℚ) - d + 2 - t) / ((a : ℚ) - d + 2 - t - 1) := by
+    intro t ht
+    have htm : t < c - d := Finset.mem_range.mp ht
+    have hmem : (0, t + d) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [sixRow_hookLen_row0_mid3 h6 hmem (by omega) (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv4, prod_div_telescope (a - d + 2) (c - d) (by omega)]
+  -- Product 5: [c, b), h(0,t+c) = a-c+1-t
+  rw [show Finset.Ico c b = (Finset.range (b - c)).image (· + c) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv5 : ∀ t ∈ Finset.range (b - c),
+      (hookLength μ 0 (t + c) : ℚ) / ((hookLength μ 0 (t + c) : ℚ) - 1) =
+      ((a : ℚ) - c + 1 - t) / ((a : ℚ) - c + 1 - t - 1) := by
+    intro t ht
+    have htm : t < b - c := Finset.mem_range.mp ht
+    have hmem : (0, t + c) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [sixRow_hookLen_row0_mid4 h6 hmem (by omega) (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv5, prod_div_telescope (a - c + 1) (b - c) (by omega)]
+  -- Product 6: [b, a-1), h(0,t+b) = a-b-t
+  rw [show Finset.Ico b (a - 1) = (Finset.range (a - 1 - b)).image (· + b) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv6 : ∀ t ∈ Finset.range (a - 1 - b),
+      (hookLength μ 0 (t + b) : ℚ) / ((hookLength μ 0 (t + b) : ℚ) - 1) =
+      ((a : ℚ) - b - t) / ((a : ℚ) - b - t - 1) := by
+    intro t ht
+    have htm : t < a - 1 - b := Finset.mem_range.mp ht
+    have hmem : (0, t + b) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [sixRow_hookLen_row0_ge h6 hmem (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv6, prod_div_telescope (a - b) (a - 1 - b) (by omega)]
+  push_cast [Nat.cast_sub hfe, Nat.cast_sub hed, Nat.cast_sub hdc, Nat.cast_sub hcb,
+             Nat.cast_sub hab.le, Nat.cast_sub (show 1 ≤ a - b by omega)]
+  have hne1 : (a : ℚ) - f + 5 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < a - f + 5 by omega)
+  have hne2 : (a : ℚ) - e + 4 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < a - e + 4 by omega)
+  have hne3 : (a : ℚ) - d + 3 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < a - d + 3 by omega)
+  have hne4 : (a : ℚ) - c + 2 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < a - c + 2 by omega)
+  have hne5 : (a : ℚ) - b + 1 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < a - b + 1 by omega)
+  field_simp [hne1, hne2, hne3, hne4, hne5]; ring
+
+/-- The hook walk identity for 6-row Young diagrams [a,b,c,d,e,f].
+    NON-CIRCULAR: proved directly via hookProd_ratio_formula. -/
+private lemma hook_walk_identity_sixRow (μ : YoungDiagram)
+    (h6 : μ.rowLen 6 = 0) (h5 : 0 < μ.rowLen 5) :
+    ∑ c ∈ (corners μ).attach,
+      ((hookProd μ : ℚ) / (hookProd (removeCorner μ c.val (mem_corners.mp c.prop)) : ℚ))
+    = (μ.card : ℚ) := by
+  set a := μ.rowLen 0; set b := μ.rowLen 1; set c := μ.rowLen 2
+  set d := μ.rowLen 3; set e := μ.rowLen 4; set f := μ.rowLen 5
+  have hfe : f ≤ e := μ.rowLen_anti 4 5 (by omega)
+  have hed : e ≤ d := μ.rowLen_anti 3 4 (by omega)
+  have hdc : d ≤ c := μ.rowLen_anti 2 3 (by omega)
+  have hcb : c ≤ b := μ.rowLen_anti 1 2 (by omega)
+  have hba : b ≤ a := μ.rowLen_anti 0 1 (by omega)
+  have hbot : isCorner μ (5, f - 1) := by
+    refine ⟨YoungDiagram.mem_iff_lt_rowLen.mpr (by omega), ?_, ?_⟩
+    · intro h; exact absurd (YoungDiagram.mem_iff_lt_rowLen.mp h) (by omega)
+    · intro h; exact absurd (YoungDiagram.mem_iff_lt_rowLen.mp h) (by omega)
+  have hcard : (μ.card : ℚ) = (a : ℚ) + b + c + d + e + f := by
+    exact_mod_cast sixRow_card h6
+  rw [hcard]
+  let ratio : ℕ × ℕ → ℚ := fun x =>
+    if hx : isCorner μ x then (hookProd μ : ℚ) / hookProd (removeCorner μ x hx) else 0
+  have hconvert : ∑ cc ∈ (corners μ).attach,
+        ((hookProd μ : ℚ) / hookProd (removeCorner μ cc.val (mem_corners.mp cc.prop))) =
+      ∑ x ∈ corners μ, ratio x := by
+    rw [← Finset.sum_attach (f := ratio)]
+    apply Finset.sum_congr rfl
+    intro cx _; exact dif_pos (mem_corners.mp cx.2)
+  -- Corners of a 6-row shape are a subset of {(5,f-1),(4,e-1),(3,d-1),(2,c-1),(1,b-1),(0,a-1)}
+  have hsub : corners μ ⊆
+      ({(5, f - 1), (4, e - 1), (3, d - 1), (2, c - 1), (1, b - 1), (0, a - 1)} :
+       Finset (ℕ × ℕ)) := by
+    intro x hx
+    have hxc := mem_corners.mp hx
+    simp only [Finset.mem_insert, Finset.mem_singleton]
+    obtain ⟨i, j⟩ := x
+    obtain ⟨hmem, hright, hbelow⟩ := hxc
+    have hi_lt : i < 6 := by
+      by_contra h6i; push_neg at h6i
+      have : (6, j) ∈ μ := by
+        calc (6, j) ≤ (i, j) := by constructor <;> omega
+          _ ∈ μ := hmem
+        |>.mp hmem
+      exact absurd (YoungDiagram.mem_iff_lt_rowLen.mp this) (by omega)
+    interval_cases i
+    · right; right; right; right; right
+      have hja : j = a - 1 := by
+        have : ¬(j + 1 < a) := fun hlt => hright (YoungDiagram.mem_iff_lt_rowLen.mpr (by omega))
+        omega
+      exact ⟨rfl, hja⟩
+    · right; right; right; right; left
+      have hjb : j = b - 1 := by
+        have : ¬(j + 1 < b) := fun hlt => hright (YoungDiagram.mem_iff_lt_rowLen.mpr (by omega))
+        omega
+      exact ⟨rfl, hjb⟩
+    · right; right; right; left
+      have hjc : j = c - 1 := by
+        have : ¬(j + 1 < c) := fun hlt => hright (YoungDiagram.mem_iff_lt_rowLen.mpr (by omega))
+        omega
+      exact ⟨rfl, hjc⟩
+    · right; right; left
+      have hjd : j = d - 1 := by
+        have : ¬(j + 1 < d) := fun hlt => hright (YoungDiagram.mem_iff_lt_rowLen.mpr (by omega))
+        omega
+      exact ⟨rfl, hjd⟩
+    · right; left
+      have hje : j = e - 1 := by
+        have : ¬(j + 1 < e) := fun hlt => hright (YoungDiagram.mem_iff_lt_rowLen.mpr (by omega))
+        omega
+      exact ⟨rfl, hje⟩
+    · left
+      have hjf : j = f - 1 := by
+        have : ¬(j + 1 < f) := fun hlt => hright (YoungDiagram.mem_iff_lt_rowLen.mpr (by omega))
+        omega
+      exact ⟨rfl, hjf⟩
+  have hext : ∑ x ∈ corners μ, ratio x =
+      ∑ x ∈ ({(5, f - 1), (4, e - 1), (3, d - 1), (2, c - 1), (1, b - 1), (0, a - 1)} :
+             Finset (ℕ × ℕ)), ratio x := by
+    apply Finset.sum_subset hsub
+    intro x _ hxnc; exact dif_neg (mt mem_corners.mpr hxnc)
+  -- Ratio for corner (5, f-1)
+  have hR5 : ratio (5, f - 1) =
+      (f : ℚ) * ((a : ℚ) - f + 6) / ((a : ℚ) - f + 5) *
+      ((b : ℚ) - f + 5) / ((b : ℚ) - f + 4) *
+      ((c : ℚ) - f + 4) / ((c : ℚ) - f + 3) *
+      ((d : ℚ) - f + 3) / ((d : ℚ) - f + 2) *
+      ((e : ℚ) - f + 2) / ((e : ℚ) - f + 1) := by
+    simp only [ratio, dif_pos hbot]
+    rw [hookProd_ratio_formula hbot]
+    simp only [Prod.fst, Prod.snd]
+    rw [sixRow_arm_row5 μ h6 hbot]
+    have hf1 : f - 1 < f := Nat.sub_lt h5 Nat.one_pos
+    have hmem0 : (0, f - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    have hmem1 : (1, f - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    have hmem2 : (2, f - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    have hmem3 : (3, f - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    have hmem4 : (4, f - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [show Finset.range 5 = {0, 1, 2, 3, 4} from by ext k; simp; omega]
+    rw [Finset.prod_insert (by simp), Finset.prod_insert (by simp),
+        Finset.prod_insert (by simp), Finset.prod_insert (by simp),
+        Finset.prod_singleton]
+    rw [sixRow_hookLen_row0_lt h6 hmem0 hf1,
+        sixRow_hookLen_row1_lt h6 hmem1 hf1,
+        sixRow_hookLen_row2_lt h6 hmem2 hf1,
+        sixRow_hookLen_row3_lt h6 hmem3 hf1,
+        sixRow_hookLen_row4_lt h6 hmem4 hf1]
+    push_cast [Nat.cast_sub (show 1 ≤ f from h5),
+               Nat.cast_sub (show f - 1 ≤ a by omega),
+               Nat.cast_sub (show f - 1 ≤ b by omega),
+               Nat.cast_sub (show f - 1 ≤ c by omega),
+               Nat.cast_sub (show f - 1 ≤ d by omega),
+               Nat.cast_sub (show f - 1 ≤ e by omega)]
+    ring
+  -- Ratio for corner (4, e-1) [when e > f]
+  have hR4 : ratio (4, e - 1) =
+      ((e : ℚ) + 1) * ((e : ℚ) - f) / ((e : ℚ) - f + 1) *
+      ((a : ℚ) - e + 5) / ((a : ℚ) - e + 4) *
+      ((b : ℚ) - e + 4) / ((b : ℚ) - e + 3) *
+      ((c : ℚ) - e + 3) / ((c : ℚ) - e + 2) *
+      ((d : ℚ) - e + 2) / ((d : ℚ) - e + 1) := by
+    by_cases hef : f < e
+    · have hmid : isCorner μ (4, e - 1) := by
+        refine ⟨YoungDiagram.mem_iff_lt_rowLen.mpr (by omega), ?_, ?_⟩
+        · intro h; exact absurd (YoungDiagram.mem_iff_lt_rowLen.mp h) (by omega)
+        · intro h; exact absurd (YoungDiagram.mem_iff_lt_rowLen.mp h) (by omega)
+      simp only [ratio, dif_pos hmid]
+      rw [hookProd_ratio_formula hmid]
+      simp only [Prod.fst, Prod.snd]
+      rw [sixRow_arm_row4 h6 hef]
+      have he1 : e - 1 < e := Nat.sub_lt (by omega) Nat.one_pos
+      have hef1 : f ≤ e - 1 := by omega
+      have hmem0 : (0, e - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+      have hmem1 : (1, e - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+      have hmem2 : (2, e - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+      have hmem3 : (3, e - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+      rw [show Finset.range 4 = {0, 1, 2, 3} from by ext k; simp; omega]
+      rw [Finset.prod_insert (by simp), Finset.prod_insert (by simp),
+          Finset.prod_insert (by simp), Finset.prod_singleton]
+      rw [sixRow_hookLen_row0_mid1 h6 hmem0 hef1 he1,
+          sixRow_hookLen_row1_mid1 h6 hmem1 hef1 he1,
+          sixRow_hookLen_row2_mid1 h6 hmem2 hef1 he1,
+          sixRow_hookLen_row3_mid1 h6 hmem3 hef1 he1]
+      push_cast [Nat.cast_sub (show 1 ≤ e from by omega),
+                 Nat.cast_sub hef.le,
+                 Nat.cast_sub (show e - 1 ≤ a by omega),
+                 Nat.cast_sub (show e - 1 ≤ b by omega),
+                 Nat.cast_sub (show e - 1 ≤ c by omega),
+                 Nat.cast_sub (show e - 1 ≤ d by omega)]
+      ring
+    · have hef_eq : e = f := Nat.le_antisymm (not_lt.mp hef) hfe
+      have hnotcorner : ¬ isCorner μ (4, e - 1) := by
+        intro ⟨_, _, hbelow⟩
+        exact hbelow (YoungDiagram.mem_iff_lt_rowLen.mpr (by omega))
+      simp only [ratio, dif_neg hnotcorner]
+      have : (e : ℚ) - f = 0 := by rw [hef_eq]; ring
+      rw [this]; ring
+  -- Ratio for corner (3, d-1) [when d > e]
+  have hR3 : ratio (3, d - 1) =
+      ((d : ℚ) + 2) * ((d : ℚ) - f + 1) * ((d : ℚ) - e) /
+      (((d : ℚ) - f + 2) * ((d : ℚ) - e + 1)) *
+      ((a : ℚ) - d + 4) / ((a : ℚ) - d + 3) *
+      ((b : ℚ) - d + 3) / ((b : ℚ) - d + 2) *
+      ((c : ℚ) - d + 2) / ((c : ℚ) - d + 1) := by
+    by_cases hde : e < d
+    · have hmid : isCorner μ (3, d - 1) := by
+        refine ⟨YoungDiagram.mem_iff_lt_rowLen.mpr (by omega), ?_, ?_⟩
+        · intro h; exact absurd (YoungDiagram.mem_iff_lt_rowLen.mp h) (by omega)
+        · intro h; exact absurd (YoungDiagram.mem_iff_lt_rowLen.mp h) (by omega)
+      simp only [ratio, dif_pos hmid]
+      rw [hookProd_ratio_formula hmid]
+      simp only [Prod.fst, Prod.snd]
+      rw [sixRow_arm_row3 h6 hde]
+      have hd1 : d - 1 < d := Nat.sub_lt (by omega) Nat.one_pos
+      have hed1 : e ≤ d - 1 := by omega
+      have hmem0 : (0, d - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+      have hmem1 : (1, d - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+      have hmem2 : (2, d - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+      rw [show Finset.range 3 = {0, 1, 2} from by ext k; simp; omega]
+      rw [Finset.prod_insert (by simp), Finset.prod_insert (by simp),
+          Finset.prod_singleton]
+      rw [sixRow_hookLen_row0_mid2 h6 hmem0 hed1 hd1,
+          sixRow_hookLen_row1_mid2 h6 hmem1 hed1 hd1,
+          sixRow_hookLen_row2_mid2 h6 hmem2 hed1 hd1]
+      push_cast [Nat.cast_sub (show 1 ≤ d from by omega),
+                 Nat.cast_sub hde.le,
+                 Nat.cast_sub hfe,
+                 Nat.cast_sub (show d - 1 ≤ a by omega),
+                 Nat.cast_sub (show d - 1 ≤ b by omega),
+                 Nat.cast_sub (show d - 1 ≤ c by omega)]
+      ring
+    · have hde_eq : d = e := Nat.le_antisymm (not_lt.mp hde) hed
+      have hnotcorner : ¬ isCorner μ (3, d - 1) := by
+        intro ⟨_, _, hbelow⟩
+        exact hbelow (YoungDiagram.mem_iff_lt_rowLen.mpr (by omega))
+      simp only [ratio, dif_neg hnotcorner]
+      have : (d : ℚ) - e = 0 := by rw [hde_eq]; ring
+      rw [this]; ring
+  -- Ratio for corner (2, c-1) [when c > d]
+  have hR2 : ratio (2, c - 1) =
+      ((c : ℚ) + 3) * ((c : ℚ) - f + 2) * ((c : ℚ) - e + 1) * ((c : ℚ) - d) /
+      (((c : ℚ) - f + 3) * ((c : ℚ) - e + 2) * ((c : ℚ) - d + 1)) *
+      ((a : ℚ) - c + 3) / ((a : ℚ) - c + 2) *
+      ((b : ℚ) - c + 2) / ((b : ℚ) - c + 1) := by
+    by_cases hcd : d < c
+    · have hmid : isCorner μ (2, c - 1) := by
+        refine ⟨YoungDiagram.mem_iff_lt_rowLen.mpr (by omega), ?_, ?_⟩
+        · intro h; exact absurd (YoungDiagram.mem_iff_lt_rowLen.mp h) (by omega)
+        · intro h; exact absurd (YoungDiagram.mem_iff_lt_rowLen.mp h) (by omega)
+      simp only [ratio, dif_pos hmid]
+      rw [hookProd_ratio_formula hmid]
+      simp only [Prod.fst, Prod.snd]
+      rw [sixRow_arm_row2 h6 hcd]
+      have hc1 : c - 1 < c := Nat.sub_lt (by omega) Nat.one_pos
+      have hdc1 : d ≤ c - 1 := by omega
+      have hmem0 : (0, c - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+      have hmem1 : (1, c - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+      rw [show Finset.range 2 = {0, 1} from by ext k; simp; omega]
+      rw [Finset.prod_insert (by simp), Finset.prod_singleton]
+      rw [sixRow_hookLen_row0_mid3 h6 hmem0 hdc1 hc1,
+          sixRow_hookLen_row1_mid3 h6 hmem1 hdc1 hc1]
+      push_cast [Nat.cast_sub (show 1 ≤ c from by omega),
+                 Nat.cast_sub hcd.le,
+                 Nat.cast_sub hed,
+                 Nat.cast_sub hfe,
+                 Nat.cast_sub (show c - 1 ≤ a by omega),
+                 Nat.cast_sub (show c - 1 ≤ b by omega)]
+      ring
+    · have hcd_eq : c = d := Nat.le_antisymm (not_lt.mp hcd) hdc
+      have hnotcorner : ¬ isCorner μ (2, c - 1) := by
+        intro ⟨_, _, hbelow⟩
+        exact hbelow (YoungDiagram.mem_iff_lt_rowLen.mpr (by omega))
+      simp only [ratio, dif_neg hnotcorner]
+      have : (c : ℚ) - d = 0 := by rw [hcd_eq]; ring
+      rw [this]; ring
+  -- Ratio for corner (1, b-1) [when b > c]
+  have hR1 : ratio (1, b - 1) =
+      ((b : ℚ) + 4) * ((b : ℚ) - f + 3) * ((b : ℚ) - e + 2) * ((b : ℚ) - d + 1) *
+      ((b : ℚ) - c) /
+      (((b : ℚ) - f + 4) * ((b : ℚ) - e + 3) * ((b : ℚ) - d + 2) *
+       ((b : ℚ) - c + 1)) *
+      ((a : ℚ) - b + 2) / ((a : ℚ) - b + 1) := by
+    by_cases hbc : c < b
+    · have hmid : isCorner μ (1, b - 1) := by
+        refine ⟨YoungDiagram.mem_iff_lt_rowLen.mpr (by omega), ?_, ?_⟩
+        · intro h; exact absurd (YoungDiagram.mem_iff_lt_rowLen.mp h) (by omega)
+        · intro h; exact absurd (YoungDiagram.mem_iff_lt_rowLen.mp h) (by omega)
+      simp only [ratio, dif_pos hmid]
+      rw [hookProd_ratio_formula hmid]
+      simp only [Prod.fst, Prod.snd]
+      rw [sixRow_arm_row1 h6 hbc]
+      have hb1 : b - 1 < b := Nat.sub_lt (by omega) Nat.one_pos
+      have hcb1 : c ≤ b - 1 := by omega
+      have hmem0 : (0, b - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+      rw [show Finset.range 1 = {0} from by ext k; simp; omega]
+      rw [Finset.prod_singleton]
+      rw [sixRow_hookLen_row0_mid4 h6 hmem0 hcb1 hb1]
+      push_cast [Nat.cast_sub (show 1 ≤ b from by omega),
+                 Nat.cast_sub hbc.le,
+                 Nat.cast_sub hdc,
+                 Nat.cast_sub hed,
+                 Nat.cast_sub hfe,
+                 Nat.cast_sub (show b - 1 ≤ a by omega)]
+      ring
+    · have hbc_eq : b = c := Nat.le_antisymm (not_lt.mp hbc) hcb
+      have hnotcorner : ¬ isCorner μ (1, b - 1) := by
+        intro ⟨_, _, hbelow⟩
+        exact hbelow (YoungDiagram.mem_iff_lt_rowLen.mpr (by omega))
+      simp only [ratio, dif_neg hnotcorner]
+      have : (b : ℚ) - c = 0 := by rw [hbc_eq]; ring
+      rw [this]; ring
+  -- Ratio for corner (0, a-1) [when a > b]
+  have hR0 : ratio (0, a - 1) =
+      ((a : ℚ) + 5) * ((a : ℚ) - f + 4) * ((a : ℚ) - e + 3) * ((a : ℚ) - d + 2) *
+      ((a : ℚ) - c + 1) * ((a : ℚ) - b) /
+      (((a : ℚ) - f + 5) * ((a : ℚ) - e + 4) * ((a : ℚ) - d + 3) *
+       ((a : ℚ) - c + 2) * ((a : ℚ) - b + 1)) := by
+    by_cases hab : b < a
+    · have htop : isCorner μ (0, a - 1) := by
+        refine ⟨YoungDiagram.mem_iff_lt_rowLen.mpr (by omega), ?_, ?_⟩
+        · intro h; exact absurd (YoungDiagram.mem_iff_lt_rowLen.mp h) (by omega)
+        · intro h; exact absurd (YoungDiagram.mem_iff_lt_rowLen.mp h) (by omega)
+      simp only [ratio, dif_pos htop]
+      rw [hookProd_ratio_formula htop]
+      simp only [Prod.fst, Prod.snd, Finset.prod_range_zero, mul_one]
+      rw [sixRow_arm_row0 h6 h5 hab]
+      ring
+    · have hab_eq : a = b := Nat.le_antisymm (not_lt.mp hab) hba
+      have hnotcorner : ¬ isCorner μ (0, a - 1) := by
+        intro ⟨_, _, hbelow⟩
+        exact hbelow (YoungDiagram.mem_iff_lt_rowLen.mpr (by omega))
+      simp only [ratio, dif_neg hnotcorner]
+      have : (a : ℚ) - b = 0 := by rw [hab_eq]; ring
+      rw [this]; ring
+  rw [hconvert, hext]
+  have hd1 : (5, f - 1) ∉ ({(4, e - 1), (3, d - 1), (2, c - 1), (1, b - 1), (0, a - 1)} :
+    Finset (ℕ × ℕ)) := by simp [Prod.mk.injEq]
+  have hd2 : (4, e - 1) ∉ ({(3, d - 1), (2, c - 1), (1, b - 1), (0, a - 1)} :
+    Finset (ℕ × ℕ)) := by simp [Prod.mk.injEq]
+  have hd3 : (3, d - 1) ∉ ({(2, c - 1), (1, b - 1), (0, a - 1)} : Finset (ℕ × ℕ)) := by
+    simp [Prod.mk.injEq]
+  have hd4 : (2, c - 1) ∉ ({(1, b - 1), (0, a - 1)} : Finset (ℕ × ℕ)) := by
+    simp [Prod.mk.injEq]
+  have hd5 : (1, b - 1) ∉ ({(0, a - 1)} : Finset (ℕ × ℕ)) := by simp [Prod.mk.injEq]
+  rw [show ({(5, f - 1), (4, e - 1), (3, d - 1), (2, c - 1), (1, b - 1), (0, a - 1)} :
+           Finset (ℕ × ℕ)) =
+      insert (5, f - 1) (insert (4, e - 1) (insert (3, d - 1) (insert (2, c - 1)
+        (insert (1, b - 1) {(0, a - 1)})))) from rfl,
+      Finset.sum_insert hd1, Finset.sum_insert hd2, Finset.sum_insert hd3,
+      Finset.sum_insert hd4, Finset.sum_insert hd5, Finset.sum_singleton,
+      hR5, hR4, hR3, hR2, hR1, hR0]
+  have hne_ef1 : (e : ℚ) - f + 1 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < e - f + 1 by omega)
+  have hne_de1 : (d : ℚ) - e + 1 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < d - e + 1 by omega)
+  have hne_df2 : (d : ℚ) - f + 2 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < d - f + 2 by omega)
+  have hne_cd1 : (c : ℚ) - d + 1 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < c - d + 1 by omega)
+  have hne_ce2 : (c : ℚ) - e + 2 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < c - e + 2 by omega)
+  have hne_cf3 : (c : ℚ) - f + 3 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < c - f + 3 by omega)
+  have hne_bc1 : (b : ℚ) - c + 1 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < b - c + 1 by omega)
+  have hne_bd2 : (b : ℚ) - d + 2 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < b - d + 2 by omega)
+  have hne_be3 : (b : ℚ) - e + 3 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < b - e + 3 by omega)
+  have hne_bf4 : (b : ℚ) - f + 4 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < b - f + 4 by omega)
+  have hne_ab1 : (a : ℚ) - b + 1 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < a - b + 1 by omega)
+  have hne_ac2 : (a : ℚ) - c + 2 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < a - c + 2 by omega)
+  have hne_ad3 : (a : ℚ) - d + 3 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < a - d + 3 by omega)
+  have hne_ae4 : (a : ℚ) - e + 4 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < a - e + 4 by omega)
+  have hne_af5 : (a : ℚ) - f + 5 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < a - f + 5 by omega)
+  push_cast [Nat.cast_sub hfe, Nat.cast_sub hed, Nat.cast_sub hdc, Nat.cast_sub hcb,
+             Nat.cast_sub hba,
+             Nat.cast_sub (show f ≤ d by omega), Nat.cast_sub (show f ≤ c by omega),
+             Nat.cast_sub (show f ≤ b by omega), Nat.cast_sub (show f ≤ a by omega),
+             Nat.cast_sub (show e ≤ c by omega), Nat.cast_sub (show e ≤ b by omega),
+             Nat.cast_sub (show e ≤ a by omega), Nat.cast_sub (show d ≤ b by omega),
+             Nat.cast_sub (show d ≤ a by omega), Nat.cast_sub (show c ≤ a by omega)]
+  field_simp [hne_ef1, hne_de1, hne_df2, hne_cd1, hne_ce2, hne_cf3,
+              hne_bc1, hne_bd2, hne_be3, hne_bf4,
+              hne_ab1, hne_ac2, hne_ad3, hne_ae4, hne_af5]
+  ring
+
 private lemma hook_walk_identity (μ : YoungDiagram) (hn : 0 < μ.card) :
     ∑ c ∈ (corners μ).attach,
       ((hookProd μ : ℚ) / (hookProd (removeCorner μ c.val (mem_corners.mp c.prop)) : ℚ))
@@ -8039,8 +9086,12 @@ private lemma hook_walk_identity (μ : YoungDiagram) (hn : 0 < μ.card) :
           by_cases h5 : μ.rowLen 5 = 0
           · -- Exactly 5 rows: use direct computation via hookProd_ratio_formula
             exact hook_walk_identity_fiveRow μ h5 (Nat.pos_of_ne_zero h4)
-          · -- 6+ rows: requires GNW hook walk (general case, still open)
-            sorry
+          · -- 6+ rows: check if exactly 6 rows
+            by_cases h6 : μ.rowLen 6 = 0
+            · -- Exactly 6 rows: use direct computation via hookProd_ratio_formula
+              exact hook_walk_identity_sixRow μ h6 (Nat.pos_of_ne_zero h5)
+            · -- 7+ rows: requires GNW hook walk (general case, still open)
+              sorry
 
 /-- The general hook-length formula in ℚ, proved by well-founded recursion on μ.card.
     Uses card_SYT_corner_step (Part XIII) + hook_walk_identity. -/

--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean
@@ -7172,6 +7172,7 @@ private lemma hook_walk_identity_fourRow (μ : YoungDiagram)
   field_simp [hne_ad3, hne_bd2, hne_cd1, hne_ac2, hne_bc1, hne_ab1]
   ring
 
+-- ============================================================
 -- PART XIX: Hook Walk Identity for 5-Row Shapes
 -- ============================================================
 /-
@@ -7179,7 +7180,7 @@ private lemma hook_walk_identity_fourRow (μ : YoungDiagram)
   - n = a+b+c+d+e cells
   - Corners: (4,e-1) always; (3,d-1) when d>e; (2,c-1) when c>d; (1,b-1) when b>c; (0,a-1) when a>b
   - hook_walk_identity proved by direct ratio computation via hookProd_ratio_formula
-  - Ratios close with field_simp; ring (same algebraic pattern as threeRow/fourRow)
+  - Ratios close with field_simp; ring (same algebraic pattern as fourRow)
 -/
 
 /-- colLen(s) = 5 for s < rowLen 4 in a 5-row shape (rowLen 5 = 0). -/
@@ -7235,111 +7236,120 @@ private lemma fiveRow_hookLen_row3_lt {μ : YoungDiagram} {s : ℕ}
     (h5 : μ.rowLen 5 = 0) (hmem : (3, s) ∈ μ) (hs : s < μ.rowLen 4) :
     hookLength μ 3 s = μ.rowLen 3 - s + 1 := by
   have key := hookLength_add_eq μ hmem
-  rw [fiveRow_colLen_lt h5 hs] at key; omega
+  rw [fiveRow_colLen_lt h5 hs] at key
+  have hs3 : s < μ.rowLen 3 := YoungDiagram.mem_iff_lt_rowLen.mp hmem; omega
 
-/-- hookLength μ 3 s = rowLen 3 − s for rowLen 4 ≤ s in a 5-row shape. -/
+/-- hookLength μ 3 s = rowLen 3 − s for rowLen 4 ≤ s < rowLen 3 in a 5-row shape. -/
 private lemma fiveRow_hookLen_row3_ge {μ : YoungDiagram} {s : ℕ}
     (h5 : μ.rowLen 5 = 0) (hmem : (3, s) ∈ μ) (hs : μ.rowLen 4 ≤ s) :
     hookLength μ 3 s = μ.rowLen 3 - s := by
-  have hs_lt : s < μ.rowLen 3 := YoungDiagram.mem_iff_lt_rowLen.mp hmem
+  have hs3 : s < μ.rowLen 3 := YoungDiagram.mem_iff_lt_rowLen.mp hmem
   have key := hookLength_add_eq μ hmem
-  rw [fiveRow_colLen_mid1 h5 hs hs_lt] at key; omega
+  rw [fiveRow_colLen_mid1 h5 hs hs3] at key; omega
 
 /-- hookLength μ 2 s = rowLen 2 − s + 2 for s < rowLen 4 in a 5-row shape. -/
 private lemma fiveRow_hookLen_row2_lt {μ : YoungDiagram} {s : ℕ}
     (h5 : μ.rowLen 5 = 0) (hmem : (2, s) ∈ μ) (hs : s < μ.rowLen 4) :
     hookLength μ 2 s = μ.rowLen 2 - s + 2 := by
   have key := hookLength_add_eq μ hmem
-  rw [fiveRow_colLen_lt h5 hs] at key; omega
+  rw [fiveRow_colLen_lt h5 hs] at key
+  have hs2 : s < μ.rowLen 2 := YoungDiagram.mem_iff_lt_rowLen.mp hmem; omega
 
 /-- hookLength μ 2 s = rowLen 2 − s + 1 for rowLen 4 ≤ s < rowLen 3 in a 5-row shape. -/
 private lemma fiveRow_hookLen_row2_mid1 {μ : YoungDiagram} {s : ℕ}
-    (h5 : μ.rowLen 5 = 0) (hmem : (2, s) ∈ μ) (hs_ge : μ.rowLen 4 ≤ s)
-    (hs_lt : s < μ.rowLen 3) : hookLength μ 2 s = μ.rowLen 2 - s + 1 := by
+    (h5 : μ.rowLen 5 = 0) (hmem : (2, s) ∈ μ) (hs_ge : μ.rowLen 4 ≤ s) (hs_lt : s < μ.rowLen 3) :
+    hookLength μ 2 s = μ.rowLen 2 - s + 1 := by
   have key := hookLength_add_eq μ hmem
-  rw [fiveRow_colLen_mid1 h5 hs_ge hs_lt] at key; omega
+  rw [fiveRow_colLen_mid1 h5 hs_ge hs_lt] at key
+  have hs2 : s < μ.rowLen 2 := YoungDiagram.mem_iff_lt_rowLen.mp hmem; omega
 
-/-- hookLength μ 2 s = rowLen 2 − s for rowLen 3 ≤ s in a 5-row shape. -/
+/-- hookLength μ 2 s = rowLen 2 − s for rowLen 3 ≤ s < rowLen 2 in a 5-row shape. -/
 private lemma fiveRow_hookLen_row2_ge {μ : YoungDiagram} {s : ℕ}
     (h5 : μ.rowLen 5 = 0) (hmem : (2, s) ∈ μ) (hs : μ.rowLen 3 ≤ s) :
     hookLength μ 2 s = μ.rowLen 2 - s := by
-  have hs_lt : s < μ.rowLen 2 := YoungDiagram.mem_iff_lt_rowLen.mp hmem
+  have hs2 : s < μ.rowLen 2 := YoungDiagram.mem_iff_lt_rowLen.mp hmem
   have key := hookLength_add_eq μ hmem
-  rw [fiveRow_colLen_mid2 h5 hs hs_lt] at key; omega
+  rw [fiveRow_colLen_mid2 h5 hs hs2] at key; omega
 
 /-- hookLength μ 1 s = rowLen 1 − s + 3 for s < rowLen 4 in a 5-row shape. -/
 private lemma fiveRow_hookLen_row1_lt {μ : YoungDiagram} {s : ℕ}
     (h5 : μ.rowLen 5 = 0) (hmem : (1, s) ∈ μ) (hs : s < μ.rowLen 4) :
     hookLength μ 1 s = μ.rowLen 1 - s + 3 := by
   have key := hookLength_add_eq μ hmem
-  rw [fiveRow_colLen_lt h5 hs] at key; omega
+  rw [fiveRow_colLen_lt h5 hs] at key
+  have hs1 : s < μ.rowLen 1 := YoungDiagram.mem_iff_lt_rowLen.mp hmem; omega
 
 /-- hookLength μ 1 s = rowLen 1 − s + 2 for rowLen 4 ≤ s < rowLen 3 in a 5-row shape. -/
 private lemma fiveRow_hookLen_row1_mid1 {μ : YoungDiagram} {s : ℕ}
-    (h5 : μ.rowLen 5 = 0) (hmem : (1, s) ∈ μ) (hs_ge : μ.rowLen 4 ≤ s)
-    (hs_lt : s < μ.rowLen 3) : hookLength μ 1 s = μ.rowLen 1 - s + 2 := by
+    (h5 : μ.rowLen 5 = 0) (hmem : (1, s) ∈ μ) (hs_ge : μ.rowLen 4 ≤ s) (hs_lt : s < μ.rowLen 3) :
+    hookLength μ 1 s = μ.rowLen 1 - s + 2 := by
   have key := hookLength_add_eq μ hmem
-  rw [fiveRow_colLen_mid1 h5 hs_ge hs_lt] at key; omega
+  rw [fiveRow_colLen_mid1 h5 hs_ge hs_lt] at key
+  have hs1 : s < μ.rowLen 1 := YoungDiagram.mem_iff_lt_rowLen.mp hmem; omega
 
 /-- hookLength μ 1 s = rowLen 1 − s + 1 for rowLen 3 ≤ s < rowLen 2 in a 5-row shape. -/
 private lemma fiveRow_hookLen_row1_mid2 {μ : YoungDiagram} {s : ℕ}
-    (h5 : μ.rowLen 5 = 0) (hmem : (1, s) ∈ μ) (hs_ge : μ.rowLen 3 ≤ s)
-    (hs_lt : s < μ.rowLen 2) : hookLength μ 1 s = μ.rowLen 1 - s + 1 := by
+    (h5 : μ.rowLen 5 = 0) (hmem : (1, s) ∈ μ) (hs_ge : μ.rowLen 3 ≤ s) (hs_lt : s < μ.rowLen 2) :
+    hookLength μ 1 s = μ.rowLen 1 - s + 1 := by
   have key := hookLength_add_eq μ hmem
-  rw [fiveRow_colLen_mid2 h5 hs_ge hs_lt] at key; omega
+  rw [fiveRow_colLen_mid2 h5 hs_ge hs_lt] at key
+  have hs1 : s < μ.rowLen 1 := YoungDiagram.mem_iff_lt_rowLen.mp hmem; omega
 
-/-- hookLength μ 1 s = rowLen 1 − s for rowLen 2 ≤ s in a 5-row shape. -/
+/-- hookLength μ 1 s = rowLen 1 − s for rowLen 2 ≤ s < rowLen 1 in a 5-row shape. -/
 private lemma fiveRow_hookLen_row1_ge {μ : YoungDiagram} {s : ℕ}
     (h5 : μ.rowLen 5 = 0) (hmem : (1, s) ∈ μ) (hs : μ.rowLen 2 ≤ s) :
     hookLength μ 1 s = μ.rowLen 1 - s := by
-  have hs_lt : s < μ.rowLen 1 := YoungDiagram.mem_iff_lt_rowLen.mp hmem
+  have hs1 : s < μ.rowLen 1 := YoungDiagram.mem_iff_lt_rowLen.mp hmem
   have key := hookLength_add_eq μ hmem
-  rw [fiveRow_colLen_mid3 h5 hs hs_lt] at key; omega
+  rw [fiveRow_colLen_mid3 h5 hs hs1] at key; omega
 
 /-- hookLength μ 0 s = rowLen 0 − s + 4 for s < rowLen 4 in a 5-row shape. -/
 private lemma fiveRow_hookLen_row0_lt {μ : YoungDiagram} {s : ℕ}
     (h5 : μ.rowLen 5 = 0) (hmem : (0, s) ∈ μ) (hs : s < μ.rowLen 4) :
     hookLength μ 0 s = μ.rowLen 0 - s + 4 := by
   have key := hookLength_add_eq μ hmem
-  rw [fiveRow_colLen_lt h5 hs] at key; omega
+  rw [fiveRow_colLen_lt h5 hs] at key
+  have hs0 : s < μ.rowLen 0 := YoungDiagram.mem_iff_lt_rowLen.mp hmem; omega
 
 /-- hookLength μ 0 s = rowLen 0 − s + 3 for rowLen 4 ≤ s < rowLen 3 in a 5-row shape. -/
 private lemma fiveRow_hookLen_row0_mid1 {μ : YoungDiagram} {s : ℕ}
-    (h5 : μ.rowLen 5 = 0) (hmem : (0, s) ∈ μ) (hs_ge : μ.rowLen 4 ≤ s)
-    (hs_lt : s < μ.rowLen 3) : hookLength μ 0 s = μ.rowLen 0 - s + 3 := by
+    (h5 : μ.rowLen 5 = 0) (hmem : (0, s) ∈ μ) (hs_ge : μ.rowLen 4 ≤ s) (hs_lt : s < μ.rowLen 3) :
+    hookLength μ 0 s = μ.rowLen 0 - s + 3 := by
   have key := hookLength_add_eq μ hmem
-  rw [fiveRow_colLen_mid1 h5 hs_ge hs_lt] at key; omega
+  rw [fiveRow_colLen_mid1 h5 hs_ge hs_lt] at key
+  have hs0 : s < μ.rowLen 0 := YoungDiagram.mem_iff_lt_rowLen.mp hmem; omega
 
 /-- hookLength μ 0 s = rowLen 0 − s + 2 for rowLen 3 ≤ s < rowLen 2 in a 5-row shape. -/
 private lemma fiveRow_hookLen_row0_mid2 {μ : YoungDiagram} {s : ℕ}
-    (h5 : μ.rowLen 5 = 0) (hmem : (0, s) ∈ μ) (hs_ge : μ.rowLen 3 ≤ s)
-    (hs_lt : s < μ.rowLen 2) : hookLength μ 0 s = μ.rowLen 0 - s + 2 := by
+    (h5 : μ.rowLen 5 = 0) (hmem : (0, s) ∈ μ) (hs_ge : μ.rowLen 3 ≤ s) (hs_lt : s < μ.rowLen 2) :
+    hookLength μ 0 s = μ.rowLen 0 - s + 2 := by
   have key := hookLength_add_eq μ hmem
-  rw [fiveRow_colLen_mid2 h5 hs_ge hs_lt] at key; omega
+  rw [fiveRow_colLen_mid2 h5 hs_ge hs_lt] at key
+  have hs0 : s < μ.rowLen 0 := YoungDiagram.mem_iff_lt_rowLen.mp hmem; omega
 
 /-- hookLength μ 0 s = rowLen 0 − s + 1 for rowLen 2 ≤ s < rowLen 1 in a 5-row shape. -/
 private lemma fiveRow_hookLen_row0_mid3 {μ : YoungDiagram} {s : ℕ}
-    (h5 : μ.rowLen 5 = 0) (hmem : (0, s) ∈ μ) (hs_ge : μ.rowLen 2 ≤ s)
-    (hs_lt : s < μ.rowLen 1) : hookLength μ 0 s = μ.rowLen 0 - s + 1 := by
+    (h5 : μ.rowLen 5 = 0) (hmem : (0, s) ∈ μ) (hs_ge : μ.rowLen 2 ≤ s) (hs_lt : s < μ.rowLen 1) :
+    hookLength μ 0 s = μ.rowLen 0 - s + 1 := by
   have key := hookLength_add_eq μ hmem
-  rw [fiveRow_colLen_mid3 h5 hs_ge hs_lt] at key; omega
+  rw [fiveRow_colLen_mid3 h5 hs_ge hs_lt] at key
+  have hs0 : s < μ.rowLen 0 := YoungDiagram.mem_iff_lt_rowLen.mp hmem; omega
 
-/-- hookLength μ 0 s = rowLen 0 − s for rowLen 1 ≤ s in a 5-row shape. -/
+/-- hookLength μ 0 s = rowLen 0 − s for rowLen 1 ≤ s < rowLen 0 in a 5-row shape. -/
 private lemma fiveRow_hookLen_row0_ge {μ : YoungDiagram} {s : ℕ}
     (h5 : μ.rowLen 5 = 0) (hmem : (0, s) ∈ μ) (hs : μ.rowLen 1 ≤ s) :
     hookLength μ 0 s = μ.rowLen 0 - s := by
-  have hs_lt : s < μ.rowLen 0 := YoungDiagram.mem_iff_lt_rowLen.mp hmem
+  have hs0 : s < μ.rowLen 0 := YoungDiagram.mem_iff_lt_rowLen.mp hmem
   have key := hookLength_add_eq μ hmem
-  -- colLen s = 1 since s ≥ rowLen 1 and s < rowLen 0
-  have hcol1 : μ.colLen s = 1 := by
+  have hcl : μ.colLen s = 1 := by
     apply Nat.le_antisymm
     · by_contra hlt; push_neg at hlt
       have h1s : (1, s) ∈ μ := YoungDiagram.mem_iff_lt_colLen.mpr hlt
-      exact absurd (YoungDiagram.mem_iff_lt_rowLen.mp h1s) (by omega)
-    · exact YoungDiagram.mem_iff_lt_colLen.mp (YoungDiagram.mem_iff_lt_rowLen.mpr hs_lt)
-  rw [hcol1] at key; omega
+      have := YoungDiagram.mem_iff_lt_rowLen.mp h1s; omega
+    · exact YoungDiagram.mem_iff_lt_colLen.mp (YoungDiagram.mem_iff_lt_rowLen.mpr hs0)
+  rw [hcl] at key; omega
 
-/-- The bottom-row corner (4, rowLen 4 - 1) always exists in a 5-row shape. -/
+/-- corner (4, e-1) always exists in a 5-row shape (rowLen 4 > 0, rowLen 5 = 0). -/
 private lemma fiveRow_corner_bot {μ : YoungDiagram} (h5 : μ.rowLen 5 = 0)
     (h4 : 0 < μ.rowLen 4) : isCorner μ (4, μ.rowLen 4 - 1) := by
   refine ⟨YoungDiagram.mem_iff_lt_rowLen.mpr (by omega),
@@ -7407,8 +7417,7 @@ private lemma fiveRow_card {μ : YoungDiagram} (h5 : μ.rowLen 5 = 0) :
       · left; left; right; exact ⟨j, hlt, rfl, rfl⟩
       · left; right; exact ⟨j, hlt, rfl, rfl⟩
       · right; exact ⟨j, hlt, rfl, rfl⟩
-    · rintro ((((⟨k, hk, rfl, rfl⟩ | ⟨k, hk, rfl, rfl⟩) | ⟨k, hk, rfl, rfl⟩) |
-               ⟨k, hk, rfl, rfl⟩) | ⟨k, hk, rfl, rfl⟩)
+    · rintro ((((⟨k, hk, rfl, rfl⟩ | ⟨k, hk, rfl, rfl⟩) | ⟨k, hk, rfl, rfl⟩) | ⟨k, hk, rfl, rfl⟩) | ⟨k, hk, rfl, rfl⟩)
       all_goals exact hk
   have hd1 : Disjoint ((Finset.range (μ.rowLen 0)).image (Prod.mk 0))
                        ((Finset.range (μ.rowLen 1)).image (Prod.mk 1)) :=
@@ -7443,8 +7452,7 @@ private lemma fiveRow_card {μ : YoungDiagram} (h5 : μ.rowLen 5 = 0) :
       ((Finset.range (μ.rowLen 4)).image (Prod.mk 4)) :=
     Finset.disjoint_left.mpr fun x hx hy => by
       simp only [Finset.mem_union, Finset.mem_image, Finset.mem_range, Prod.mk.injEq] at hx hy
-      obtain (((⟨_, _, rfl, rfl⟩ | ⟨_, _, rfl, rfl⟩) | ⟨_, _, rfl, rfl⟩) |
-               ⟨_, _, rfl, rfl⟩) := hx
+      obtain (((⟨_, _, rfl, rfl⟩ | ⟨_, _, rfl, rfl⟩) | ⟨_, _, rfl, rfl⟩) | ⟨_, _, rfl, rfl⟩) := hx
       · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
       · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
       · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
@@ -7456,8 +7464,8 @@ private lemma fiveRow_card {μ : YoungDiagram} (h5 : μ.rowLen 5 = 0) :
       Finset.card_image_of_injective _ (fun p q h => (Prod.mk.inj h).2),
       Finset.card_image_of_injective _ (fun p q h => (Prod.mk.inj h).2),
       Finset.card_image_of_injective _ (fun p q h => (Prod.mk.inj h).2),
-      Finset.card_range, Finset.card_range, Finset.card_range, Finset.card_range,
-      Finset.card_range]
+      Finset.card_range, Finset.card_range, Finset.card_range,
+      Finset.card_range, Finset.card_range]
 
 /-- Arm product for corner (4, e-1) telescopes to e.
     ∏_{s ∈ range(e-1)} h(4,s)/(h(4,s)-1) = e, where h(4,s) = e-s. -/
@@ -7481,7 +7489,7 @@ private lemma fiveRow_arm_row4 (μ : YoungDiagram) (h5 : μ.rowLen 5 = 0)
   push_cast; simp [Nat.cast_sub (Nat.one_le_iff_ne_zero.mpr (Nat.pos_iff_ne_zero.mp he_pos))]
 
 /-- Arm product for corner (3, d-1) in a 5-row shape:
-    ∏_{s=0}^{d-2} h(3,s)/(h(3,s)-1) = (d+1)(d-e)/(d-e+1). -/
+    ∏_{s=0}^{d-2} h(3,s)/(h(3,s)-1) = (d+1)(d-e)/((d-e+1)). -/
 private lemma fiveRow_arm_row3 {μ : YoungDiagram} (h5 : μ.rowLen 5 = 0)
     (hde : μ.rowLen 4 < μ.rowLen 3) :
     ∏ s ∈ Finset.range (μ.rowLen 3 - 1),
@@ -7493,25 +7501,26 @@ private lemma fiveRow_arm_row3 {μ : YoungDiagram} (h5 : μ.rowLen 5 = 0)
   rw [show Finset.range (d - 1) = Finset.range e ∪ Finset.Ico e (d - 1) from by
     ext s; simp [Finset.mem_Ico]; omega]
   rw [Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega)]
-  -- First product: s ∈ [0,e), h(3,s) = d-s+1 → (d+1-s)/(d+1-s-1)
+  -- First product: s ∈ [0,e), h(3,s) = d-s+1
   have hconv1 : ∀ s ∈ Finset.range e,
       (hookLength μ 3 s : ℚ) / ((hookLength μ 3 s : ℚ) - 1) =
       ((d : ℚ) + 1 - s) / ((d : ℚ) + 1 - s - 1) := by
     intro s hs
     have hse : s < e := Finset.mem_range.mp hs
     have hmem : (3, s) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
-    rw [fiveRow_hookLen_row3_lt h5 hmem hse]
+    rw [fiveRow_hookLen_row3_lt h5 hmem (by omega)]
     push_cast; congr 1 <;> push_cast <;> omega
   rw [Finset.prod_congr rfl hconv1, prod_div_telescope (d + 1) e (by omega)]
-  -- Second product: s ∈ [e, d-1), reindex t = s-e, h(3,t+e) = d-e-t
+  -- Second product: s ∈ [e, d-1), h(3,s) = d-s
   have hconv2 : ∀ s ∈ Finset.Ico e (d - 1),
       (hookLength μ 3 s : ℚ) / ((hookLength μ 3 s : ℚ) - 1) =
       ((d : ℚ) - s) / ((d : ℚ) - s - 1) := by
     intro s hs
     have ⟨hse, hsd⟩ := Finset.mem_Ico.mp hs
     have hmem : (3, s) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
-    rw [fiveRow_hookLen_row3_ge h5 hmem hse]
+    rw [fiveRow_hookLen_row3_ge h5 hmem (by omega)]
     push_cast; congr 1 <;> push_cast <;> omega
+  -- Reindex [e, d-1) to [0, d-e-1)
   rw [show Finset.Ico e (d - 1) = (Finset.range (d - 1 - e)).image (· + e) from by
     ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
   rw [Finset.prod_image (by intro x _ y _ h; omega)]
@@ -7524,14 +7533,15 @@ private lemma fiveRow_arm_row3 {μ : YoungDiagram} (h5 : μ.rowLen 5 = 0)
     rw [fiveRow_hookLen_row3_ge h5 hmem (by omega)]
     push_cast; congr 1 <;> push_cast <;> omega
   rw [Finset.prod_congr rfl hconv2', prod_div_telescope (d - e) (d - 1 - e) (by omega)]
+  -- Combine: (d+1)/(d-e+1) × (d-e)/1 = (d+1)(d-e)/(d-e+1)
   push_cast [Nat.cast_sub hde.le, Nat.cast_sub (show 1 ≤ d - e by omega)]
-  have hne : (d : ℚ) - e + 1 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < d - e + 1 by omega)
-  field_simp [hne]; ring
+  have hne1 : (d : ℚ) - e + 1 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < d - e + 1 by omega)
+  field_simp [hne1]; ring
 
 /-- Arm product for corner (2, c-1) in a 5-row shape:
     ∏_{s=0}^{c-2} h(2,s)/(h(2,s)-1) = (c+2)(c-e+1)(c-d)/((c-e+2)(c-d+1)). -/
 private lemma fiveRow_arm_row2 {μ : YoungDiagram} (h5 : μ.rowLen 5 = 0)
-    (hdc : μ.rowLen 3 < μ.rowLen 2) :
+    (hcd : μ.rowLen 3 < μ.rowLen 2) :
     ∏ s ∈ Finset.range (μ.rowLen 2 - 1),
       ((hookLength μ 2 s : ℚ) / ((hookLength μ 2 s : ℚ) - 1)) =
     ((μ.rowLen 2 : ℚ) + 2) * ((μ.rowLen 2 : ℚ) - μ.rowLen 4 + 1) *
@@ -7544,17 +7554,17 @@ private lemma fiveRow_arm_row2 {μ : YoungDiagram} (h5 : μ.rowLen 5 = 0)
     ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
   rw [Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega),
       Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega)]
-  -- Product 1: [0,e), h(2,s) = c-s+2 → (c+2-s)/(c+2-s-1)
+  -- Product 1: [0,e), h(2,s) = c-s+2
   have hconv1 : ∀ s ∈ Finset.range e,
       (hookLength μ 2 s : ℚ) / ((hookLength μ 2 s : ℚ) - 1) =
       ((c : ℚ) + 2 - s) / ((c : ℚ) + 2 - s - 1) := by
     intro s hs
     have hse : s < e := Finset.mem_range.mp hs
     have hmem : (2, s) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
-    rw [fiveRow_hookLen_row2_lt h5 hmem hse]
+    rw [fiveRow_hookLen_row2_lt h5 hmem (by omega)]
     push_cast; congr 1 <;> push_cast <;> omega
   rw [Finset.prod_congr rfl hconv1, prod_div_telescope (c + 2) e (by omega)]
-  -- Product 2: [e, d), h(2,t+e) = c-e+1-t → prod_div_telescope (c-e+1) (d-e)
+  -- Product 2: [e, d), h(2,s) = c-s+1
   rw [show Finset.Ico e d = (Finset.range (d - e)).image (· + e) from by
     ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
   rw [Finset.prod_image (by intro x _ y _ h; omega)]
@@ -7567,7 +7577,7 @@ private lemma fiveRow_arm_row2 {μ : YoungDiagram} (h5 : μ.rowLen 5 = 0)
     rw [fiveRow_hookLen_row2_mid1 h5 hmem (by omega) (by omega)]
     push_cast; congr 1 <;> push_cast <;> omega
   rw [Finset.prod_congr rfl hconv2, prod_div_telescope (c - e + 1) (d - e) (by omega)]
-  -- Product 3: [d, c-1), h(2,t+d) = c-d-t → prod_div_telescope (c-d) (c-1-d)
+  -- Product 3: [d, c-1), h(2,s) = c-s
   rw [show Finset.Ico d (c - 1) = (Finset.range (c - 1 - d)).image (· + d) from by
     ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
   rw [Finset.prod_image (by intro x _ y _ h; omega)]
@@ -7580,7 +7590,8 @@ private lemma fiveRow_arm_row2 {μ : YoungDiagram} (h5 : μ.rowLen 5 = 0)
     rw [fiveRow_hookLen_row2_ge h5 hmem (by omega)]
     push_cast; congr 1 <;> push_cast <;> omega
   rw [Finset.prod_congr rfl hconv3, prod_div_telescope (c - d) (c - 1 - d) (by omega)]
-  push_cast [Nat.cast_sub hed, Nat.cast_sub hdc.le, Nat.cast_sub (show 1 ≤ c - d by omega)]
+  -- Combine all three
+  push_cast [Nat.cast_sub hed, Nat.cast_sub hcd.le, Nat.cast_sub (show 1 ≤ c - d by omega)]
   have hne1 : (c : ℚ) - e + 2 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < c - e + 2 by omega)
   have hne2 : (c : ℚ) - d + 1 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < c - d + 1 by omega)
   field_simp [hne1, hne2]; ring
@@ -7588,7 +7599,7 @@ private lemma fiveRow_arm_row2 {μ : YoungDiagram} (h5 : μ.rowLen 5 = 0)
 /-- Arm product for corner (1, b-1) in a 5-row shape:
     ∏_{s=0}^{b-2} h(1,s)/(h(1,s)-1) = (b+3)(b-e+2)(b-d+1)(b-c)/((b-e+3)(b-d+2)(b-c+1)). -/
 private lemma fiveRow_arm_row1 {μ : YoungDiagram} (h5 : μ.rowLen 5 = 0)
-    (hcb : μ.rowLen 2 < μ.rowLen 1) :
+    (hbc : μ.rowLen 2 < μ.rowLen 1) :
     ∏ s ∈ Finset.range (μ.rowLen 1 - 1),
       ((hookLength μ 1 s : ℚ) / ((hookLength μ 1 s : ℚ) - 1)) =
     ((μ.rowLen 1 : ℚ) + 3) * ((μ.rowLen 1 : ℚ) - μ.rowLen 4 + 2) *
@@ -7598,7 +7609,7 @@ private lemma fiveRow_arm_row1 {μ : YoungDiagram} (h5 : μ.rowLen 5 = 0)
   set b := μ.rowLen 1; set c := μ.rowLen 2; set d := μ.rowLen 3; set e := μ.rowLen 4
   have hed : e ≤ d := μ.rowLen_anti 3 4 (by omega)
   have hdc : d ≤ c := μ.rowLen_anti 2 3 (by omega)
-  -- Split range(b-1) into [0,e), [e,d), [d,c), [c, b-1)
+  -- Split range(b-1) into [0,e), [e,d), [d,c), [c,b-1)
   rw [show Finset.range (b - 1) = Finset.range e ∪ Finset.Ico e d ∪
       Finset.Ico d c ∪ Finset.Ico c (b - 1) from by
     ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
@@ -7612,10 +7623,10 @@ private lemma fiveRow_arm_row1 {μ : YoungDiagram} (h5 : μ.rowLen 5 = 0)
     intro s hs
     have hse : s < e := Finset.mem_range.mp hs
     have hmem : (1, s) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
-    rw [fiveRow_hookLen_row1_lt h5 hmem hse]
+    rw [fiveRow_hookLen_row1_lt h5 hmem (by omega)]
     push_cast; congr 1 <;> push_cast <;> omega
   rw [Finset.prod_congr rfl hconv1, prod_div_telescope (b + 3) e (by omega)]
-  -- Product 2: [e, d), h(1,t+e) = b-e+2-t
+  -- Product 2: [e, d), h(1,s) = b-s+2
   rw [show Finset.Ico e d = (Finset.range (d - e)).image (· + e) from by
     ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
   rw [Finset.prod_image (by intro x _ y _ h; omega)]
@@ -7628,7 +7639,7 @@ private lemma fiveRow_arm_row1 {μ : YoungDiagram} (h5 : μ.rowLen 5 = 0)
     rw [fiveRow_hookLen_row1_mid1 h5 hmem (by omega) (by omega)]
     push_cast; congr 1 <;> push_cast <;> omega
   rw [Finset.prod_congr rfl hconv2, prod_div_telescope (b - e + 2) (d - e) (by omega)]
-  -- Product 3: [d, c), h(1,t+d) = b-d+1-t
+  -- Product 3: [d, c), h(1,s) = b-s+1
   rw [show Finset.Ico d c = (Finset.range (c - d)).image (· + d) from by
     ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
   rw [Finset.prod_image (by intro x _ y _ h; omega)]
@@ -7641,7 +7652,7 @@ private lemma fiveRow_arm_row1 {μ : YoungDiagram} (h5 : μ.rowLen 5 = 0)
     rw [fiveRow_hookLen_row1_mid2 h5 hmem (by omega) (by omega)]
     push_cast; congr 1 <;> push_cast <;> omega
   rw [Finset.prod_congr rfl hconv3, prod_div_telescope (b - d + 1) (c - d) (by omega)]
-  -- Product 4: [c, b-1), h(1,t+c) = b-c-t
+  -- Product 4: [c, b-1), h(1,s) = b-s
   rw [show Finset.Ico c (b - 1) = (Finset.range (b - 1 - c)).image (· + c) from by
     ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
   rw [Finset.prod_image (by intro x _ y _ h; omega)]
@@ -7654,7 +7665,8 @@ private lemma fiveRow_arm_row1 {μ : YoungDiagram} (h5 : μ.rowLen 5 = 0)
     rw [fiveRow_hookLen_row1_ge h5 hmem (by omega)]
     push_cast; congr 1 <;> push_cast <;> omega
   rw [Finset.prod_congr rfl hconv4, prod_div_telescope (b - c) (b - 1 - c) (by omega)]
-  push_cast [Nat.cast_sub hed, Nat.cast_sub hdc, Nat.cast_sub hcb.le,
+  -- Combine all four
+  push_cast [Nat.cast_sub hed, Nat.cast_sub hdc, Nat.cast_sub hbc.le,
              Nat.cast_sub (show 1 ≤ b - c by omega)]
   have hne1 : (b : ℚ) - e + 3 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < b - e + 3 by omega)
   have hne2 : (b : ℚ) - d + 2 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < b - d + 2 by omega)
@@ -7662,8 +7674,8 @@ private lemma fiveRow_arm_row1 {μ : YoungDiagram} (h5 : μ.rowLen 5 = 0)
   field_simp [hne1, hne2, hne3]; ring
 
 /-- Arm product for corner (0, a-1) in a 5-row shape:
-    ∏_{s=0}^{a-2} h(0,s)/(h(0,s)-1) = (a+4)(a-e+3)(a-d+2)(a-c+1)(a-b)/
-                                         ((a-e+4)(a-d+3)(a-c+2)(a-b+1)). -/
+    ∏_{s=0}^{a-2} h(0,s)/(h(0,s)-1) =
+    (a+4)(a-e+3)(a-d+2)(a-c+1)(a-b)/((a-e+4)(a-d+3)(a-c+2)(a-b+1)). -/
 private lemma fiveRow_arm_row0 {μ : YoungDiagram} (h5 : μ.rowLen 5 = 0)
     (h4 : 0 < μ.rowLen 4) (hab : μ.rowLen 1 < μ.rowLen 0) :
     ∏ s ∈ Finset.range (μ.rowLen 0 - 1),
@@ -7678,7 +7690,7 @@ private lemma fiveRow_arm_row0 {μ : YoungDiagram} (h5 : μ.rowLen 5 = 0)
   have hed : e ≤ d := μ.rowLen_anti 3 4 (by omega)
   have hdc : d ≤ c := μ.rowLen_anti 2 3 (by omega)
   have hcb : c ≤ b := μ.rowLen_anti 1 2 (by omega)
-  -- Split range(a-1) into [0,e), [e,d), [d,c), [c,b), [b, a-1)
+  -- Split range(a-1) into [0,e), [e,d), [d,c), [c,b), [b,a-1)
   rw [show Finset.range (a - 1) = Finset.range e ∪ Finset.Ico e d ∪
       Finset.Ico d c ∪ Finset.Ico c b ∪ Finset.Ico b (a - 1) from by
     ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
@@ -7691,12 +7703,11 @@ private lemma fiveRow_arm_row0 {μ : YoungDiagram} (h5 : μ.rowLen 5 = 0)
       (hookLength μ 0 s : ℚ) / ((hookLength μ 0 s : ℚ) - 1) =
       ((a : ℚ) + 4 - s) / ((a : ℚ) + 4 - s - 1) := by
     intro s hs
-    have hse : s < e := Finset.mem_range.mp hs
     have hmem : (0, s) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
-    rw [fiveRow_hookLen_row0_lt h5 hmem hse]
+    rw [fiveRow_hookLen_row0_lt h5 hmem (by exact_mod_cast Finset.mem_range.mp hs)]
     push_cast; congr 1 <;> push_cast <;> omega
   rw [Finset.prod_congr rfl hconv1, prod_div_telescope (a + 4) e (by omega)]
-  -- Product 2: [e, d), h(0,t+e) = a-e+3-t
+  -- Product 2: [e, d), h(0,s) = a-s+3
   rw [show Finset.Ico e d = (Finset.range (d - e)).image (· + e) from by
     ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
   rw [Finset.prod_image (by intro x _ y _ h; omega)]
@@ -7709,7 +7720,7 @@ private lemma fiveRow_arm_row0 {μ : YoungDiagram} (h5 : μ.rowLen 5 = 0)
     rw [fiveRow_hookLen_row0_mid1 h5 hmem (by omega) (by omega)]
     push_cast; congr 1 <;> push_cast <;> omega
   rw [Finset.prod_congr rfl hconv2, prod_div_telescope (a - e + 3) (d - e) (by omega)]
-  -- Product 3: [d, c), h(0,t+d) = a-d+2-t
+  -- Product 3: [d, c), h(0,s) = a-s+2
   rw [show Finset.Ico d c = (Finset.range (c - d)).image (· + d) from by
     ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
   rw [Finset.prod_image (by intro x _ y _ h; omega)]
@@ -7722,7 +7733,7 @@ private lemma fiveRow_arm_row0 {μ : YoungDiagram} (h5 : μ.rowLen 5 = 0)
     rw [fiveRow_hookLen_row0_mid2 h5 hmem (by omega) (by omega)]
     push_cast; congr 1 <;> push_cast <;> omega
   rw [Finset.prod_congr rfl hconv3, prod_div_telescope (a - d + 2) (c - d) (by omega)]
-  -- Product 4: [c, b), h(0,t+c) = a-c+1-t
+  -- Product 4: [c, b), h(0,s) = a-s+1
   rw [show Finset.Ico c b = (Finset.range (b - c)).image (· + c) from by
     ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
   rw [Finset.prod_image (by intro x _ y _ h; omega)]
@@ -7735,7 +7746,7 @@ private lemma fiveRow_arm_row0 {μ : YoungDiagram} (h5 : μ.rowLen 5 = 0)
     rw [fiveRow_hookLen_row0_mid3 h5 hmem (by omega) (by omega)]
     push_cast; congr 1 <;> push_cast <;> omega
   rw [Finset.prod_congr rfl hconv4, prod_div_telescope (a - c + 1) (b - c) (by omega)]
-  -- Product 5: [b, a-1), h(0,t+b) = a-b-t
+  -- Product 5: [b, a-1), h(0,s) = a-s
   rw [show Finset.Ico b (a - 1) = (Finset.range (a - 1 - b)).image (· + b) from by
     ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
   rw [Finset.prod_image (by intro x _ y _ h; omega)]
@@ -7787,28 +7798,28 @@ private lemma hook_walk_identity_fiveRow (μ : YoungDiagram)
     intro x hx
     simp only [Finset.mem_insert, Finset.mem_singleton]
     rcases fiveRow_corner_cases h5 h4 (mem_corners.mp hx) with
-      ⟨heq, _⟩ | ⟨heq, _⟩ | ⟨heq, _⟩ | ⟨heq, _⟩ | heq
+        ⟨heq, _⟩ | ⟨heq, _⟩ | ⟨heq, _⟩ | ⟨heq, _⟩ | heq
     · right; right; right; right; exact heq
     · right; right; right; left; exact heq
     · right; right; left; exact heq
     · right; left; exact heq
     · left; exact heq
   have hext : ∑ x ∈ corners μ, ratio x =
-      ∑ x ∈ ({(4, e - 1), (3, d - 1), (2, c - 1), (1, b - 1), (0, a - 1)} :
-              Finset (ℕ × ℕ)), ratio x := by
+      ∑ x ∈ ({(4, e - 1), (3, d - 1), (2, c - 1), (1, b - 1), (0, a - 1)} : Finset (ℕ × ℕ)),
+        ratio x := by
     apply Finset.sum_subset hsub
     intro x _ hxnc; exact dif_neg (mt mem_corners.mpr hxnc)
   -- Compute ratio for corner (4, e-1)
   have hR4 : ratio (4, e - 1) =
-      (e : ℚ) * ((d : ℚ) - e + 2) / ((d : ℚ) - e + 1) *
-      ((c : ℚ) - e + 3) / ((c : ℚ) - e + 2) *
+      (e : ℚ) * ((a : ℚ) - e + 5) / ((a : ℚ) - e + 4) *
       ((b : ℚ) - e + 4) / ((b : ℚ) - e + 3) *
-      ((a : ℚ) - e + 5) / ((a : ℚ) - e + 4) := by
+      ((c : ℚ) - e + 3) / ((c : ℚ) - e + 2) *
+      ((d : ℚ) - e + 2) / ((d : ℚ) - e + 1) := by
     simp only [ratio, dif_pos hbot]
     rw [hookProd_ratio_formula hbot]
     simp only [Prod.fst, Prod.snd]
     rw [fiveRow_arm_row4 μ h5 hbot]
-    -- Leg: rows 0,1,2,3 at column e-1 (zone s < e)
+    -- Leg: rows 0,1,2,3 at column e-1
     have he1 : e - 1 < e := Nat.sub_lt h4 Nat.one_pos
     have hmem0 : (0, e - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
     have hmem1 : (1, e - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
@@ -7830,9 +7841,9 @@ private lemma hook_walk_identity_fiveRow (μ : YoungDiagram)
   -- Compute ratio for corner (3, d-1) [when d > e]
   have hR3 : ratio (3, d - 1) =
       ((d : ℚ) + 1) * ((d : ℚ) - e) / ((d : ℚ) - e + 1) *
-      ((c : ℚ) - d + 2) / ((c : ℚ) - d + 1) *
+      ((a : ℚ) - d + 4) / ((a : ℚ) - d + 3) *
       ((b : ℚ) - d + 3) / ((b : ℚ) - d + 2) *
-      ((a : ℚ) - d + 4) / ((a : ℚ) - d + 3) := by
+      ((c : ℚ) - d + 2) / ((c : ℚ) - d + 1) := by
     by_cases hde : e < d
     · have hmid : isCorner μ (3, d - 1) := by
         refine ⟨YoungDiagram.mem_iff_lt_rowLen.mpr (by omega), ?_, ?_⟩
@@ -7853,7 +7864,7 @@ private lemma hook_walk_identity_fiveRow (μ : YoungDiagram)
       rw [fiveRow_hookLen_row0_mid1 h5 hmem0 hed1 (by omega),
           fiveRow_hookLen_row1_mid1 h5 hmem1 hed1 (by omega),
           fiveRow_hookLen_row2_mid1 h5 hmem2 hed1 (by omega)]
-      push_cast [Nat.cast_sub (show 1 ≤ d from by omega),
+      push_cast [Nat.cast_sub (show 1 ≤ d by omega),
                  Nat.cast_sub (show d - 1 ≤ a by omega),
                  Nat.cast_sub (show d - 1 ≤ b by omega),
                  Nat.cast_sub (show d - 1 ≤ c by omega),
@@ -7871,9 +7882,9 @@ private lemma hook_walk_identity_fiveRow (μ : YoungDiagram)
   have hR2 : ratio (2, c - 1) =
       ((c : ℚ) + 2) * ((c : ℚ) - e + 1) * ((c : ℚ) - d) /
       (((c : ℚ) - e + 2) * ((c : ℚ) - d + 1)) *
-      ((b : ℚ) - c + 2) / ((b : ℚ) - c + 1) *
-      ((a : ℚ) - c + 3) / ((a : ℚ) - c + 2) := by
-    by_cases hdc' : d < c
+      ((a : ℚ) - c + 3) / ((a : ℚ) - c + 2) *
+      ((b : ℚ) - c + 2) / ((b : ℚ) - c + 1) := by
+    by_cases hcd : d < c
     · have hmid : isCorner μ (2, c - 1) := by
         refine ⟨YoungDiagram.mem_iff_lt_rowLen.mpr (by omega), ?_, ?_⟩
         · intro h; exact absurd (YoungDiagram.mem_iff_lt_rowLen.mp h) (by omega)
@@ -7881,8 +7892,8 @@ private lemma hook_walk_identity_fiveRow (μ : YoungDiagram)
       simp only [ratio, dif_pos hmid]
       rw [hookProd_ratio_formula hmid]
       simp only [Prod.fst, Prod.snd]
-      rw [fiveRow_arm_row2 h5 hdc']
-      -- Leg: rows 0,1 at column c-1 (zone [d,c))
+      rw [fiveRow_arm_row2 h5 hcd]
+      -- Leg: rows 0 and 1 at column c-1 (zone [d, c))
       have hc1 : c - 1 < c := Nat.sub_lt (by omega) Nat.one_pos
       have hdc1 : d ≤ c - 1 := by omega
       have hmem0 : (0, c - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
@@ -7894,22 +7905,22 @@ private lemma hook_walk_identity_fiveRow (μ : YoungDiagram)
       push_cast [Nat.cast_sub (show 1 ≤ c by omega),
                  Nat.cast_sub (show c - 1 ≤ a by omega),
                  Nat.cast_sub (show c - 1 ≤ b by omega),
-                 Nat.cast_sub hdc'.le, Nat.cast_sub hed]
+                 Nat.cast_sub hcd.le, Nat.cast_sub (show e ≤ c by omega)]
       ring
     · -- c = d: corner (2, c-1) doesn't exist; ratio = 0
-      have hdc_eq : c = d := Nat.le_antisymm (not_lt.mp hdc') hdc
+      have hcd_eq : c = d := Nat.le_antisymm (not_lt.mp hcd) hdc
       have hnotcorner : ¬ isCorner μ (2, c - 1) := by
         intro ⟨_, _, hbelow⟩
         exact hbelow (YoungDiagram.mem_iff_lt_rowLen.mpr (by omega))
       simp only [ratio, dif_neg hnotcorner]
-      have : (c : ℚ) - d = 0 := by rw [hdc_eq]; ring
+      have : (c : ℚ) - d = 0 := by rw [hcd_eq]; ring
       rw [this]; ring
   -- Compute ratio for corner (1, b-1) [when b > c]
   have hR1 : ratio (1, b - 1) =
       ((b : ℚ) + 3) * ((b : ℚ) - e + 2) * ((b : ℚ) - d + 1) * ((b : ℚ) - c) /
       (((b : ℚ) - e + 3) * ((b : ℚ) - d + 2) * ((b : ℚ) - c + 1)) *
       ((a : ℚ) - b + 2) / ((a : ℚ) - b + 1) := by
-    by_cases hcb' : c < b
+    by_cases hbc : c < b
     · have hmid : isCorner μ (1, b - 1) := by
         refine ⟨YoungDiagram.mem_iff_lt_rowLen.mpr (by omega), ?_, ?_⟩
         · intro h; exact absurd (YoungDiagram.mem_iff_lt_rowLen.mp h) (by omega)
@@ -7917,17 +7928,17 @@ private lemma hook_walk_identity_fiveRow (μ : YoungDiagram)
       simp only [ratio, dif_pos hmid]
       rw [hookProd_ratio_formula hmid]
       simp only [Prod.fst, Prod.snd]
-      rw [fiveRow_arm_row1 h5 hcb']
-      -- Leg: row 0 at column b-1 (zone [c,b))
+      rw [fiveRow_arm_row1 h5 hbc]
+      -- Leg: row 0 at column b-1 (zone [c, b))
       have hmem0 : (0, b - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
       rw [Finset.prod_range_succ, Finset.prod_range_zero, one_mul]
       rw [fiveRow_hookLen_row0_mid3 h5 hmem0 (by omega) (by omega)]
       push_cast [Nat.cast_sub (show 1 ≤ b by omega),
                  Nat.cast_sub (show b - 1 ≤ a by omega),
-                 Nat.cast_sub hcb'.le, Nat.cast_sub hdc, Nat.cast_sub hed]
+                 Nat.cast_sub hbc.le, Nat.cast_sub (show d ≤ b by omega),
+                 Nat.cast_sub (show e ≤ b by omega)]
       ring
-    · -- b = c: corner (1, b-1) doesn't exist; ratio = 0
-      have hbc_eq : b = c := Nat.le_antisymm (not_lt.mp hcb') hcb
+    · have hbc_eq : b = c := Nat.le_antisymm (not_lt.mp hbc) hcb
       have hnotcorner : ¬ isCorner μ (1, b - 1) := by
         intro ⟨_, _, hbelow⟩
         exact hbelow (YoungDiagram.mem_iff_lt_rowLen.mpr (by omega))
@@ -7936,10 +7947,10 @@ private lemma hook_walk_identity_fiveRow (μ : YoungDiagram)
       rw [this]; ring
   -- Compute ratio for corner (0, a-1) [when a > b]
   have hR0 : ratio (0, a - 1) =
-      ((a : ℚ) + 4) * ((a : ℚ) - e + 3) * ((a : ℚ) - d + 2) * ((a : ℚ) - c + 1) *
-      ((a : ℚ) - b) /
-      (((a : ℚ) - e + 4) * ((a : ℚ) - d + 3) * ((a : ℚ) - c + 2) *
-       ((a : ℚ) - b + 1)) := by
+      ((a : ℚ) + 4) * ((a : ℚ) - e + 3) * ((a : ℚ) - d + 2) *
+      ((a : ℚ) - c + 1) * ((a : ℚ) - b) /
+      (((a : ℚ) - e + 4) * ((a : ℚ) - d + 3) *
+       ((a : ℚ) - c + 2) * ((a : ℚ) - b + 1)) := by
     by_cases hab : b < a
     · have htop : isCorner μ (0, a - 1) := by
         refine ⟨YoungDiagram.mem_iff_lt_rowLen.mpr (by omega), ?_, ?_⟩
@@ -7951,8 +7962,7 @@ private lemma hook_walk_identity_fiveRow (μ : YoungDiagram)
       rw [fiveRow_arm_row0 h5 h4 hab]
       push_cast [Nat.cast_sub hab.le, Nat.cast_sub hcb, Nat.cast_sub hdc, Nat.cast_sub hed]
       ring
-    · -- a = b: corner (0, a-1) doesn't exist; ratio = 0
-      have hab_eq : a = b := Nat.le_antisymm (not_lt.mp hab) hba
+    · have hab_eq : a = b := Nat.le_antisymm (not_lt.mp hab) hba
       have hnotcorner : ¬ isCorner μ (0, a - 1) := by
         intro ⟨_, _, hbelow⟩
         exact hbelow (YoungDiagram.mem_iff_lt_rowLen.mpr (by omega))
@@ -7961,46 +7971,49 @@ private lemma hook_walk_identity_fiveRow (μ : YoungDiagram)
       rw [this]; ring
   rw [hconvert, hext]
   -- Sum over 5 corners using distinctness
-  have hne43 : (4, e - 1) ∉ ({(3, d - 1), (2, c - 1), (1, b - 1), (0, a - 1)} :
-      Finset (ℕ × ℕ)) := by simp [Prod.mk.injEq]
+  have hne43 : (4, e - 1) ∉
+      ({(3, d - 1), (2, c - 1), (1, b - 1), (0, a - 1)} : Finset (ℕ × ℕ)) := by
+    simp [Prod.mk.injEq]
   have hne32 : (3, d - 1) ∉ ({(2, c - 1), (1, b - 1), (0, a - 1)} : Finset (ℕ × ℕ)) := by
     simp [Prod.mk.injEq]
   have hne21 : (2, c - 1) ∉ ({(1, b - 1), (0, a - 1)} : Finset (ℕ × ℕ)) := by
     simp [Prod.mk.injEq]
-  have hne10 : (1, b - 1) ∉ ({(0, a - 1)} : Finset (ℕ × ℕ)) := by simp [Prod.mk.injEq]
+  have hne10 : (1, b - 1) ∉ ({(0, a - 1)} : Finset (ℕ × ℕ)) := by
+    simp [Prod.mk.injEq]
   rw [show ({(4, e - 1), (3, d - 1), (2, c - 1), (1, b - 1), (0, a - 1)} : Finset (ℕ × ℕ)) =
-      insert (4, e - 1) (insert (3, d - 1) (insert (2, c - 1) (insert (1, b - 1)
-        {(0, a - 1)}))) from rfl,
+      insert (4, e - 1) (insert (3, d - 1) (insert (2, c - 1) (insert (1, b - 1) {(0, a - 1)})))
+      from rfl,
       Finset.sum_insert hne43, Finset.sum_insert hne32,
-      Finset.sum_insert hne21, Finset.sum_insert hne10, Finset.sum_singleton,
+      Finset.sum_insert hne21, Finset.sum_insert hne10,
+      Finset.sum_singleton,
       hR4, hR3, hR2, hR1, hR0]
-  -- Close with field_simp + ring
-  have hne_de1 : (d : ℚ) - e + 1 ≠ 0 := by
-    exact_mod_cast (show (0 : ℤ) < d - e + 1 by omega)
-  have hne_ce2 : (c : ℚ) - e + 2 ≠ 0 := by
-    exact_mod_cast (show (0 : ℤ) < c - e + 2 by omega)
-  have hne_be3 : (b : ℚ) - e + 3 ≠ 0 := by
-    exact_mod_cast (show (0 : ℤ) < b - e + 3 by omega)
+  -- Close with field_simp + ring using nonzero denominators
   have hne_ae4 : (a : ℚ) - e + 4 ≠ 0 := by
     exact_mod_cast (show (0 : ℤ) < a - e + 4 by omega)
-  have hne_cd1 : (c : ℚ) - d + 1 ≠ 0 := by
-    exact_mod_cast (show (0 : ℤ) < c - d + 1 by omega)
-  have hne_bd2 : (b : ℚ) - d + 2 ≠ 0 := by
-    exact_mod_cast (show (0 : ℤ) < b - d + 2 by omega)
+  have hne_be3 : (b : ℚ) - e + 3 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < b - e + 3 by omega)
+  have hne_ce2 : (c : ℚ) - e + 2 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < c - e + 2 by omega)
+  have hne_de1 : (d : ℚ) - e + 1 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < d - e + 1 by omega)
   have hne_ad3 : (a : ℚ) - d + 3 ≠ 0 := by
     exact_mod_cast (show (0 : ℤ) < a - d + 3 by omega)
-  have hne_bc1 : (b : ℚ) - c + 1 ≠ 0 := by
-    exact_mod_cast (show (0 : ℤ) < b - c + 1 by omega)
+  have hne_bd2 : (b : ℚ) - d + 2 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < b - d + 2 by omega)
+  have hne_cd1 : (c : ℚ) - d + 1 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < c - d + 1 by omega)
   have hne_ac2 : (a : ℚ) - c + 2 ≠ 0 := by
     exact_mod_cast (show (0 : ℤ) < a - c + 2 by omega)
+  have hne_bc1 : (b : ℚ) - c + 1 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < b - c + 1 by omega)
   have hne_ab1 : (a : ℚ) - b + 1 ≠ 0 := by
     exact_mod_cast (show (0 : ℤ) < a - b + 1 by omega)
   push_cast [Nat.cast_sub hed, Nat.cast_sub hdc, Nat.cast_sub hcb, Nat.cast_sub hba,
              Nat.cast_sub (show e ≤ c by omega), Nat.cast_sub (show e ≤ b by omega),
              Nat.cast_sub (show e ≤ a by omega), Nat.cast_sub (show d ≤ b by omega),
              Nat.cast_sub (show d ≤ a by omega), Nat.cast_sub (show c ≤ a by omega)]
-  field_simp [hne_de1, hne_ce2, hne_be3, hne_ae4, hne_cd1, hne_bd2,
-              hne_ad3, hne_bc1, hne_ac2, hne_ab1]
+  field_simp [hne_ae4, hne_be3, hne_ce2, hne_de1, hne_ad3, hne_bd2, hne_cd1,
+              hne_ac2, hne_bc1, hne_ab1]
   ring
 
 private lemma hook_walk_identity (μ : YoungDiagram) (hn : 0 < μ.card) :

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/knowledge.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/knowledge.md
@@ -1,8 +1,8 @@
 # Knowledge Base: LGV Lemma → Jacobi-Trudi Identity
 
 **Problem**: ballot-problem-oq-03-oq-01-oq-01-oq-01
-**Last Updated**: 2026-04-25
-**Knowledge Items**: 26
+**Last Updated**: 2026-04-26
+**Knowledge Items**: 34
 
 Insights accumulated during research on this problem.
 
@@ -17,6 +17,44 @@ symmetric polynomials: `s_λ = det[h_{λᵢ-i+j}]`. The proof route via SSYT and
   3. Biject SSYT ↔ non-intersecting lattice paths (RSK)
   4. Apply LGV: det[e(Aᵢ,Bⱼ)] = weighted NI-path count
   5. Identify the LGV matrix with the Jacobi-Trudi matrix
+
+---
+
+## Session 2026-04-26 (Session 9) — ssytFin_two_row_eq_sum_colstrict Proved (Full Bijection)
+
+**Mode**: REVISIT (RICH knowledge tier)
+**Outcome**: progress — `ssytFin_two_row_eq_sum_colstrict` proved with explicit `Equiv`; 3→2 sorries
+
+### What I Did
+
+1. Proved `ssytFin_two_row_eq_sum_colstrict` (~80 lines): explicit `Equiv` between `SSYTFin n 2 sh`
+   and `{ PQ : Sym (Fin n) a × Sym (Fin n) b // ColStrictSym a b PQ.1 PQ.2 }`
+2. `toFun`: pack rows 0,1 into Sym via `List.ofFn`; col-strict condition from SSYT `col_strict`
+3. `invFun`: unpack via `Multiset.sort` sorted representatives; `fin_cases i` for row-weak proof
+4. `left_inv`: roundtrip through `row_sort` (rows already sorted via `List.mergeSort_eq_self`)
+5. `right_inv`: `Multiset.sort_eq` reconstructs original multiset from sorted list
+6. Fixed `split_ifs` → `fin_cases i` in `invFun` row-weak direction (fin_cases substitutes i=0,1)
+
+### Key Findings
+
+- **Mathlib lemmas used**: `List.sortedLE_ofFn_iff`, `Multiset.pairwise_sort`, `Multiset.sort_eq`,
+  `List.mergeSort_eq_self`, `Fintype.sum_equiv`, `Fin.prod_univ_two`
+- **fin_cases vs split_ifs**: for dependent if-then-else `if _h : i = 0`, `fin_cases i` is better
+  than `split_ifs` because it substitutes into the type of `j1`, `j2 : Fin (sh i)`
+- **JDT non-injectivity**: naive "first violation, move Q[c] to P" bijection for `jdt_weight_sum`
+  is NOT injective. Counterexample: n=3, a=b=2: ({1,2},{0,1}) and ({0,2},{1,1}) both map to
+  the same image. The correct involution must preserve `P.1+Q.1` (like LGV intersecting-path swap)
+
+### Files Modified
+
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean` (457 → 572 lines, 3 → 2 sorries)
+- `src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json` (sorries 3→2, lineCount→572)
+
+### Next Steps
+
+- `jdt_weight_sum`: implement LGV-style involution that preserves `P.1+Q.1` combined multiset;
+  sign pairs by first violation position — this requires signed-path argument not simple greedy
+- General k≥3: RSK correspondence (~300 lines); long-term work
 
 ---
 

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -2,10 +2,10 @@
   "id": "ballot-problem-oq-03-oq-01-oq-01-oq-01",
   "title": "Jacobi-Trudi Identity: Schur Polynomials as Determinants of Complete Homogeneous Symmetric Polynomials",
   "slug": "ballot-problem-oq-03-oq-01-oq-01-oq-01",
-  "description": "Defines Schur polynomials via the Jacobi-Trudi determinant formula and the SSYT generating function. Proves key properties (symmetry, base cases, two-row formula, hook-length evaluation, k=0,1 SSYT bijections). The k=2 SSYT equality (ssytSchurFin_two_row) is proved but relies on 2 sorry'd private helpers (jdt_weight_sum and ssytFin_two_row_eq_sum_colstrict, ~200 lines total); the general k\u22653 case is open (algebraic LGV + RSK ~300 lines).",
+  "description": "Defines Schur polynomials via the Jacobi-Trudi determinant formula and the SSYT generating function. Proves key properties (symmetry, base cases, two-row formula, hook-length evaluation, k=0,1,2 SSYT cases). The k=2 SSYT equality (ssytSchurFin_two_row) is fully proved including the row-decomposition bijection; 2 sorries remain: jdt_weight_sum (JDT involution ~80 lines) and the general k≥3 case (algebraic LGV + RSK ~300 lines).",
   "meta": {
     "author": "Lean Genius",
-    "date": "2026-04-24",
+    "date": "2026-04-26",
     "status": "formalized",
     "proofRepoPath": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
     "tags": [
@@ -19,37 +19,37 @@
       "ssyt"
     ],
     "badge": "formalized",
-    "sorries": 3,
+    "sorries": 2,
     "dateAdded": "2026-04-23",
     "axiomCount": 0,
-    "assumptions": "3 sorries: (1) jdt_weight_sum (private: JDT involution weight sum for 2-row case); (2) ssytFin_two_row_eq_sum_colstrict (private: row decomposition bijection for k=2 SSYT, ~200 lines combined); (3) jacobi_trudi_ssyt_eq k\u22653 via algebraic LGV + RSK (~300 lines). Note: ssytSchurFin_two_row is proved but depends on these sorry'd helpers. k=0 and k=1 cases proved explicitly.",
-    "lineCount": 457,
+    "assumptions": "2 sorries: (1) jdt_weight_sum (private: JDT involution weight sum for 2-row case, ~80 lines); (2) jacobi_trudi_ssyt_eq k≥3 via algebraic LGV + RSK (~300 lines). Note: ssytSchurFin_two_row is fully proved including row-decomp bijection ssytFin_two_row_eq_sum_colstrict.",
+    "lineCount": 572,
     "theoremCount": 11,
     "definitionCount": 5,
     "originalContributions": [
-      "jacobiTrudiMatrix: the k\u00d7k matrix with entries h_{sh_i + j - i} (or 0 for negative index) \u2014 first Lean 4 Jacobi-Trudi matrix definition",
+      "jacobiTrudiMatrix: the k×k matrix with entries h_{sh_i + j - i} (or 0 for negative index) — first Lean 4 Jacobi-Trudi matrix definition",
       "schurPolynomial: det(jacobiTrudiMatrix) as the primary definition of Schur polynomials in Lean 4",
-      "schurPolynomial_empty: Schur polynomial of empty partition = 1 (det of 0\u00d70 matrix)",
-      "schurPolynomial_one_row: Schur([n]) = hsymm \u03c3 R n (the n-th complete homogeneous symmetric polynomial)",
+      "schurPolynomial_empty: Schur polynomial of empty partition = 1 (det of 0×0 matrix)",
+      "schurPolynomial_one_row: Schur([n]) = hsymm σ R n (the n-th complete homogeneous symmetric polynomial)",
       "jacobiTrudiMatrix_entry_isSymmetric: each entry h_{sh_i+j-i} is individually symmetric",
       "schurPolynomial_isSymmetric: Schur polynomials are symmetric via AlgHom.map_det + rename_hsymm",
       "schurPolynomial_two_row: explicit 2-row formula h_a*h_b - h_{a+1}*(h_{b-1} or 0)",
-      "SSYTFin n k sh: first Lean 4 SSYT definition using sigma-type encoding (i:Fin k)\u00d7Fin(sh i) \u2192 Fin n with decidable row-weak and col-strict conditions; Fintype instance via Subtype.fintype",
-      "ssytSchurFin: SSYT generating function \u2014 canonical tableau-sum definition of Schur polynomial",
+      "SSYTFin n k sh: first Lean 4 SSYT definition using sigma-type encoding (i:Fin k)×Fin(sh i) → Fin n with decidable row-weak and col-strict conditions; Fintype instance via Subtype.fintype",
+      "ssytSchurFin: SSYT generating function — canonical tableau-sum definition of Schur polynomial",
       "ssytSchurFin_empty: k=0 case proved via Unique (empty SSYT) + IsEmpty (empty sigma-type product)"
     ]
   },
   "overview": {
-    "historicalContext": "Carl Gustav Jacob Jacobi stated the identity bearing his name in 1841, and Nicola Trudi independently rediscovered it in 1864. The formula $s_\\lambda = \\det[h_{\\lambda_i - i + j}]$ expresses Schur polynomials as determinants of complete homogeneous symmetric polynomials $h_n$. Issai Schur (1901\u20131911) developed the systematic theory connecting these polynomials to the representation theory of GL(n): each $s_\\lambda$ is the character of the irreducible polynomial representation indexed by partition $\\lambda$. This dual algebraic/combinatorial nature \u2014 both a ring-theoretic determinant formula and a character \u2014 makes the Jacobi-Trudi identity central to modern algebraic combinatorics. The combinatorial proof via the Lindstr\u00f6m-Gessel-Viennot (LGV) lemma was developed by Gessel and Viennot in 1985, completing the picture by showing semistandard Young tableaux (SSYT) biject with non-intersecting lattice path systems. Macdonald's 1979 book 'Symmetric Functions and Hall Polynomials' systematized these connections and remains the standard reference.",
+    "historicalContext": "Carl Gustav Jacob Jacobi stated the identity bearing his name in 1841, and Nicola Trudi independently rediscovered it in 1864. The formula $s_\\lambda = \\det[h_{\\lambda_i - i + j}]$ expresses Schur polynomials as determinants of complete homogeneous symmetric polynomials $h_n$. Issai Schur (1901–1911) developed the systematic theory connecting these polynomials to the representation theory of GL(n): each $s_\\lambda$ is the character of the irreducible polynomial representation indexed by partition $\\lambda$. This dual algebraic/combinatorial nature — both a ring-theoretic determinant formula and a character — makes the Jacobi-Trudi identity central to modern algebraic combinatorics. The combinatorial proof via the Lindström-Gessel-Viennot (LGV) lemma was developed by Gessel and Viennot in 1985, completing the picture by showing semistandard Young tableaux (SSYT) biject with non-intersecting lattice path systems. Macdonald's 1979 book 'Symmetric Functions and Hall Polynomials' systematized these connections and remains the standard reference.",
     "problemStatement": "Formalize the definition of Schur polynomials via the Jacobi-Trudi determinant formula and prove their key properties: symmetry, base cases, and the connection to the LGV lemma infrastructure already formalized in the parent gallery proofs.",
-    "text": "The key insight is that Mathlib's complete homogeneous symmetric polynomials hsymm \u03c3 R n provide exactly the building blocks for the Jacobi-Trudi matrix. The entry at position (i,j) is h_{sh_i + j - i} when i \u2264 sh_i + j (else 0 to handle the h_n = 0 for n < 0 convention using \u2115 subtraction). Symmetry of the Schur polynomial then follows from: (1) each matrix entry is symmetric (using hsymm_isSymmetric + rename_hsymm), and (2) AlgHom.map_det lets us push rename through the determinant.",
-    "proofStrategy": "For symmetry: AlgHom.map_det gives (rename e)(det M) = det((rename e).mapMatrix M), then show each entry (rename e)(h_{sh_i+j-i}) = h_{sh_i+j-i} using rename_hsymm. For base cases: det_fin_zero = 1, det_fin_one simplifies 1\u00d71 determinant. The LGV connection (SSYT \u2194 NI paths via RSK) requires ~400 lines of additional formalization.",
+    "text": "The key insight is that Mathlib's complete homogeneous symmetric polynomials hsymm σ R n provide exactly the building blocks for the Jacobi-Trudi matrix. The entry at position (i,j) is h_{sh_i + j - i} when i ≤ sh_i + j (else 0 to handle the h_n = 0 for n < 0 convention using ℕ subtraction). Symmetry of the Schur polynomial then follows from: (1) each matrix entry is symmetric (using hsymm_isSymmetric + rename_hsymm), and (2) AlgHom.map_det lets us push rename through the determinant.",
+    "proofStrategy": "For symmetry: AlgHom.map_det gives (rename e)(det M) = det((rename e).mapMatrix M), then show each entry (rename e)(h_{sh_i+j-i}) = h_{sh_i+j-i} using rename_hsymm. For base cases: det_fin_zero = 1, det_fin_one simplifies 1×1 determinant. The LGV connection (SSYT ↔ NI paths via RSK) requires ~400 lines of additional formalization.",
     "keyInsights": [
-      "Mathlib's hsymm \u03c3 R n is precisely the h_n in the Jacobi-Trudi formula \u2014 no additional definitions needed, the whole matrix is built from Mathlib primitives",
-      "\u2115 subtraction handles the h_n = 0 for n < 0 convention cleanly: checking i \u2264 sh_i + j before computing sh_i + j - i avoids the need for integers or a custom 'truncated subtraction' type",
-      "AlgHom.map_det lifts any R-algebra homomorphism through det, reducing symmetry of s_\u03bb to symmetry of each h_n \u2014 a single Mathlib lemma carries the whole argument",
-      "The 0-indexed Lean representation (Fin k) shifts the matrix entry formula: standard 1-indexed M_{ij} = h_{\u03bb\u1d62+j-i} becomes 0-indexed h_{sh_i+j-i} with conditional on i.val \u2264 sh_i + j.val",
-      "The LGV connection (SSYT \u2194 NI paths via RSK) requires ~400 lines and is the key missing piece: once formalized, it gives a purely combinatorial proof that the determinant formula equals the tableau-sum definition"
+      "Mathlib's hsymm σ R n is precisely the h_n in the Jacobi-Trudi formula — no additional definitions needed, the whole matrix is built from Mathlib primitives",
+      "ℕ subtraction handles the h_n = 0 for n < 0 convention cleanly: checking i ≤ sh_i + j before computing sh_i + j - i avoids the need for integers or a custom 'truncated subtraction' type",
+      "AlgHom.map_det lifts any R-algebra homomorphism through det, reducing symmetry of s_λ to symmetry of each h_n — a single Mathlib lemma carries the whole argument",
+      "The 0-indexed Lean representation (Fin k) shifts the matrix entry formula: standard 1-indexed M_{ij} = h_{λᵢ+j-i} becomes 0-indexed h_{sh_i+j-i} with conditional on i.val ≤ sh_i + j.val",
+      "The LGV connection (SSYT ↔ NI paths via RSK) requires ~400 lines and is the key missing piece: once formalized, it gives a purely combinatorial proof that the determinant formula equals the tableau-sum definition"
     ],
     "prerequisites": [
       "Mathlib.RingTheory.MvPolynomial.Symmetric.Defs: hsymm, IsSymmetric, rename_hsymm, hsymm_isSymmetric",
@@ -58,10 +58,10 @@
     ]
   },
   "conclusion": {
-    "summary": "Defines Schur polynomials via both Jacobi-Trudi formula and SSYT generating function. Proves symmetry, base cases (k=0,1 for both), two-row formula, hook-length evaluation, and k=1 SSYT bijection. 3 sorries: jdt_weight_sum and ssytFin_two_row_eq_sum_colstrict (private helpers for k=2 jdt bijection, ~200 lines) and jacobi_trudi_ssyt_eq k\u22653 (algebraic LGV + RSK, ~300 lines).",
-    "implications": "This provides: (1) the first Lean 4 Jacobi-Trudi matrix definition, (2) the first Lean 4 SSYT type for arbitrary partition shapes with Fintype instance, (3) the first formal statement that det[h_{\u03bb\u1d62-i+j}] = \u03a3_T weight(T) as a meaningful theorem. The remaining sorry precisely identifies the RSK correspondence for k \u2265 2 (~300 lines) as the key missing ingredient. A completed formalization would unlock: the Pieri rule $s_\\lambda h_n = \\sum_\\mu s_\\mu$, the Murnaghan-Nakayama rule, and connections to Schubert calculus via the existing LGV infrastructure in the gallery.",
+    "summary": "Defines Schur polynomials via both Jacobi-Trudi formula and SSYT generating function. Proves symmetry, base cases (k=0,1 for both), two-row formula, hook-length evaluation, k=1 SSYT bijection, and k=2 SSYT equality (ssytSchurFin_two_row proved with full row-decomposition bijection ssytFin_two_row_eq_sum_colstrict). 2 sorries: jdt_weight_sum (JDT involution for 2-row, ~80 lines) and jacobi_trudi_ssyt_eq k≥3 (algebraic LGV + RSK, ~300 lines).",
+    "implications": "This provides: (1) the first Lean 4 Jacobi-Trudi matrix definition, (2) the first Lean 4 SSYT type for arbitrary partition shapes with Fintype instance, (3) the first formal statement that det[h_{λᵢ-i+j}] = Σ_T weight(T) as a meaningful theorem. The remaining sorry precisely identifies the RSK correspondence for k ≥ 2 (~300 lines) as the key missing ingredient. A completed formalization would unlock: the Pieri rule $s_\\lambda h_n = \\sum_\\mu s_\\mu$, the Murnaghan-Nakayama rule, and connections to Schubert calculus via the existing LGV infrastructure in the gallery.",
     "openQuestions": [
-      "Prove jacobi_trudi_ssyt_eq (general case, k \u2265 2): RSK correspondence SSYT \u2194 NI lattice path tuples for the LGV configuration, then weight matching with hsymm products"
+      "Prove jacobi_trudi_ssyt_eq (general case, k ≥ 2): RSK correspondence SSYT ↔ NI lattice path tuples for the LGV configuration, then weight matching with hsymm products"
     ]
   },
   "leanFile": {
@@ -78,12 +78,12 @@
       "Finset"
     ],
     "namespace": "JacobiTrudi",
-    "lineCount": 457,
+    "lineCount": 572,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 5,
     "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
-    "sorries": 3
+    "sorries": 2
   },
   "crossReferences": [
     {
@@ -94,22 +94,22 @@
     {
       "targetId": "ballot-problem-oq-03-oq-01-oq-02",
       "relationship": "sibling",
-      "description": "Hook-Length Formula via LGV \u2014 another application of the same parent LGV machinery. While Jacobi-Trudi computes $s_\\lambda$ as a determinant of $h_n$'s, the hook-length formula counts Standard Young Tableaux (SYT) of shape $\\lambda$ \u2014 both are consequences of the LGV combinatorial framework."
+      "description": "Hook-Length Formula via LGV — another application of the same parent LGV machinery. While Jacobi-Trudi computes $s_\\lambda$ as a determinant of $h_n$'s, the hook-length formula counts Standard Young Tableaux (SYT) of shape $\\lambda$ — both are consequences of the LGV combinatorial framework."
     },
     {
       "targetId": "ballot-problem-oq-03-oq-02",
       "relationship": "foundational",
-      "description": "Full n\u00d7n LGV Lemma formalization that the LGV connection proof strategy ultimately relies upon. The LGV lemma equates a determinant of path-counting polynomials to a signed sum over non-intersecting path systems, which Jacobi-Trudi applies to prove $s_\\lambda = \\det[h_{\\lambda_i - i + j}]$."
+      "description": "Full n×n LGV Lemma formalization that the LGV connection proof strategy ultimately relies upon. The LGV lemma equates a determinant of path-counting polynomials to a signed sum over non-intersecting path systems, which Jacobi-Trudi applies to prove $s_\\lambda = \\det[h_{\\lambda_i - i + j}]$."
     },
     {
       "targetId": "ballot-problem-oq-03-oq-01-oq-04",
       "relationship": "sibling",
-      "description": "Catalan Recurrence via LGV \u2014 a third application of the same LGV machinery from the parent entry, computing Catalan numbers as a determinant. The shared infrastructure (LGV + ballot paths) connects Catalan numbers, hook-length formula, and Jacobi-Trudi as three faces of the same determinant-path correspondence."
+      "description": "Catalan Recurrence via LGV — a third application of the same LGV machinery from the parent entry, computing Catalan numbers as a determinant. The shared infrastructure (LGV + ballot paths) connects Catalan numbers, hook-length formula, and Jacobi-Trudi as three faces of the same determinant-path correspondence."
     },
     {
       "targetId": "binomial-theorem",
       "relationship": "related",
-      "description": "The binomial theorem $\\binom{n+k-1}{k-1} = h_n(1,\\ldots,1)$ connects Jacobi-Trudi to combinatorial identities: evaluating $s_\\lambda$ at all-ones gives the number of SSYT of shape $\\lambda$ in $k$ variables, which equals the dimension of the corresponding GL(k) representation \u2014 computed via the hook-length formula. The stars-and-bars formula $\\binom{n+k-1}{k-1}$ for $h_n(1^k)$ is a direct binomial coefficient identity."
+      "description": "The binomial theorem $\\binom{n+k-1}{k-1} = h_n(1,\\ldots,1)$ connects Jacobi-Trudi to combinatorial identities: evaluating $s_\\lambda$ at all-ones gives the number of SSYT of shape $\\lambda$ in $k$ variables, which equals the dimension of the corresponding GL(k) representation — computed via the hook-length formula. The stars-and-bars formula $\\binom{n+k-1}{k-1}$ for $h_n(1^k)$ is a direct binomial coefficient identity."
     }
   ],
   "sections": [
@@ -119,22 +119,22 @@
       "startLine": 1,
       "endLine": 29,
       "summary": "File header, Mathlib imports (Symmetric.Defs, Determinant.Basic, parent proof), opens (MvPolynomial, Matrix, Finset), namespace, and variable declarations for the abstract commutative ring setting.",
-      "mathContext": "Works over `{\u03c3 R : Type*} [CommRing R] [Fintype \u03c3] [DecidableEq \u03c3]` \u2014 fully abstract in both the variable set \u03c3 and coefficient ring R. The parent import `Proofs.BallotProblemOQ03OQ01OQ01` supplies the LGV infrastructure."
+      "mathContext": "Works over `{σ R : Type*} [CommRing R] [Fintype σ] [DecidableEq σ]` — fully abstract in both the variable set σ and coefficient ring R. The parent import `Proofs.BallotProblemOQ03OQ01OQ01` supplies the LGV infrastructure."
     },
     {
       "id": "sec-definitions",
       "title": "Part I: Definitions",
       "startLine": 35,
       "endLine": 47,
-      "summary": "Defines jacobiTrudiMatrix (k\u00d7k matrix with entries h_{sh_i+j-i} or 0) and schurPolynomial (its determinant). Both are noncomputable due to classical choice in hsymm.",
-      "mathContext": "`jacobiTrudiMatrix k sh : Matrix (Fin k) (Fin k) (MvPolynomial \u03c3 R)`. `schurPolynomial k sh = Matrix.det (jacobiTrudiMatrix k sh)`. Uses \u2115 subtraction with conditional `if i.val \u2264 sh i + j.val` to handle the $h_n = 0$ for $n < 0$ convention."
+      "summary": "Defines jacobiTrudiMatrix (k×k matrix with entries h_{sh_i+j-i} or 0) and schurPolynomial (its determinant). Both are noncomputable due to classical choice in hsymm.",
+      "mathContext": "`jacobiTrudiMatrix k sh : Matrix (Fin k) (Fin k) (MvPolynomial σ R)`. `schurPolynomial k sh = Matrix.det (jacobiTrudiMatrix k sh)`. Uses ℕ subtraction with conditional `if i.val ≤ sh i + j.val` to handle the $h_n = 0$ for $n < 0$ convention."
     },
     {
       "id": "sec-base-cases",
       "title": "Part II: Base Cases",
       "startLine": 53,
       "endLine": 61,
-      "summary": "schurPolynomial_empty: s_() = 1 (0\u00d70 det via det_fin_zero). schurPolynomial_one_row: s_[n] = h_n (1\u00d71 det via det_fin_one). Both proved with simp.",
+      "summary": "schurPolynomial_empty: s_() = 1 (0×0 det via det_fin_zero). schurPolynomial_one_row: s_[n] = h_n (1×1 det via det_fin_one). Both proved with simp.",
       "mathContext": "`Matrix.det_fin_zero`: the determinant of the unique $0 \\times 0$ matrix is $1$. `Matrix.det_fin_one`: the $1 \\times 1$ determinant reduces to the single entry. These are boundary sanity checks for the Jacobi-Trudi definition."
     },
     {
@@ -143,7 +143,7 @@
       "startLine": 63,
       "endLine": 77,
       "summary": "Two theorems: entry-level symmetry (each h_n invariant under variable rename, proved via split_ifs + hsymm_isSymmetric) and full Schur polynomial symmetry via AlgHom.map_det (proved).",
-      "mathContext": "`IsSymmetric \u03c6` means `\u2200 e : Equiv.Perm \u03c3, rename e \u03c6 = \u03c6`. Strategy: `AlgHom.map_det` gives `rename e (det M) = det (Matrix.mapMatrix (rename e) M)`. Each entry satisfies `rename e (h_n) = h_n` by `rename_hsymm`, so the mapped matrix equals the original."
+      "mathContext": "`IsSymmetric φ` means `∀ e : Equiv.Perm σ, rename e φ = φ`. Strategy: `AlgHom.map_det` gives `rename e (det M) = det (Matrix.mapMatrix (rename e) M)`. Each entry satisfies `rename e (h_n) = h_n` by `rename_hsymm`, so the mapped matrix equals the original."
     },
     {
       "id": "sec-two-row",
@@ -166,9 +166,9 @@
       "title": "Part VI: SSYT Definition and Jacobi-Trudi Equality",
       "startLine": 160,
       "endLine": 272,
-      "summary": "Defines SSYTFin (bounded SSYT type with Fintype instance), ssytSchurFin (SSYT generating function), proves ssytSchurFin_empty (k=0), proves ssytSchurFin_one_row (k=1, bijection via sorted multiset reps), and states jacobi_trudi_ssyt_eq (general, sorry for k \u2265 2).",
-      "mathContext": "SSYTFin n k sh = subtype of ((i:Fin k)\u00d7Fin(sh i)\u2192Fin n) satisfying row-weak (weakly increasing rows) and col-strict (strictly increasing columns). Fintype instance via Subtype.fintype (decidable predicates over finite types). ssytSchurFin = \u2211_T T.weight where T.weight = \u220f_p X(T p). k=0 proved by Unique (empty SSYT, both conditions vacuous) + IsEmpty (empty product = 1). k=1 proved via Fintype.sum_equiv with bijection \u03c8: SSYTFin n 1 \u2243 Sym (Fin n) m using List.sortedLE_ofFn_iff (Monotone \u2194 SortedLE). k=2 case: ssytSchurFin_two_row is proved but depends on 2 sorry'd private helpers (jdt_weight_sum + ssytFin_two_row_eq_sum_colstrict). General case (k \u2265 3): RSK correspondence (~300 lines), 3 sorries total in file."
+      "summary": "Defines SSYTFin (bounded SSYT type with Fintype instance), ssytSchurFin (SSYT generating function), proves ssytSchurFin_empty (k=0), proves ssytSchurFin_one_row (k=1, bijection via sorted multiset reps), and states jacobi_trudi_ssyt_eq (general, sorry for k ≥ 2).",
+      "mathContext": "SSYTFin n k sh = subtype of ((i:Fin k)×Fin(sh i)→Fin n) satisfying row-weak (weakly increasing rows) and col-strict (strictly increasing columns). Fintype instance via Subtype.fintype (decidable predicates over finite types). ssytSchurFin = ∑_T T.weight where T.weight = ∏_p X(T p). k=0 proved by Unique (empty SSYT, both conditions vacuous) + IsEmpty (empty product = 1). k=1 proved via Fintype.sum_equiv with bijection ψ: SSYTFin n 1 ≃ Sym (Fin n) m using List.sortedLE_ofFn_iff (Monotone ↔ SortedLE). k=2 case: ssytSchurFin_two_row is proved but depends on 2 sorry'd private helpers (jdt_weight_sum + ssytFin_two_row_eq_sum_colstrict). General case (k ≥ 3): RSK correspondence (~300 lines), 3 sorries total in file."
     }
   ],
-  "sorries": 3
+  "sorries": 2
 }

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: ssytSchurFin_two_row assembly proved (eq_sub_of_add_eq + JDT + partition). 3 sorries remain: jdt_weight_sum (~80 lines), ssytFin_two_row_eq_sum_colstrict (~60 lines), k≥3 (algebraic LGV).",
+    "progressSummary": "PROGRESS: ssytFin_two_row_eq_sum_colstrict proved (full bijection Equiv); 2 sorries remain: jdt_weight_sum (~80 lines LGV involution) and k≥3 (algebraic LGV + RSK ~300 lines)",
     "builtItems": [
       "jacobiTrudiMatrix: Matrix (Fin k) (Fin k) (MvPolynomial σ R) — entry (i,j) = hsymm (sh_i + j - i) or 0",
       "schurPolynomial: MvPolynomial σ R = det(jacobiTrudiMatrix) — the Jacobi-Trudi formula as definition",
@@ -58,7 +58,8 @@
       "sym_pair_sum_partition: proved (Fintype.sum_subtype_add_sum_subtype splits full pair-sum into col-strict + non-col-strict = h_a * h_b)",
       "ssytSchurFin_two_row: assembly proof complete (eq_sub_of_add_eq + jdt_weight_sum + sym_pair_sum_partition); 2 focused sorries remain",
       "jdt_weight_sum: stated (sorry) — JDT bijection gives ∑_{non-col-strict} weight = h_{a+1} * h_{b-1}",
-      "ssytFin_two_row_eq_sum_colstrict: stated (sorry) — SSYT k=2 bijects to col-strict pair sum"
+      "ssytFin_two_row_eq_sum_colstrict: stated (sorry) — SSYT k=2 bijects to col-strict pair sum",
+      "ssytFin_two_row_eq_sum_colstrict: proved (not sorry) — explicit Equiv with toFun/invFun using Multiset.sort + List.getElem_ofFn + Multiset.sort_eq"
     ],
     "insights": [
       "Mathlib has hsymm σ R n (complete homogeneous symmetric polynomials) in RingTheory.MvPolynomial.Symmetric.Defs — directly usable for Jacobi-Trudi matrix entries",
@@ -88,7 +89,8 @@
       "jeu de taquin bijection for k=2: insert Q[c] into P at first-violation column c, remove from Q; ~100 lines standalone",
       "Fintype.sum_subtype_add_sum_subtype splits ∑ f over a type into ∑_{p x} f + ∑_{¬p x} f = ∑ f — key for partition identity",
       "eq_sub_of_add_eq (ring lemma: a + b = c → a = c - b) enables assembling ssytSchurFin_two_row from partition + JDT identities",
-      "ColStrictSym: column-strict on Sym pairs defined via sorted representatives (Finset.sort); avoids SSYT structural noise for the JDT step"
+      "ColStrictSym: column-strict on Sym pairs defined via sorted representatives (Finset.sort); avoids SSYT structural noise for the JDT step",
+      "ssytFin_two_row_eq_sum_colstrict proved (Session 9): full ~80-line bijection Equiv between SSYTFin n 2 sh and col-strict Sym pairs, using fin_cases i for row-weak inv direction"
     ],
     "mathlibGaps": [
       "No Mathlib SchurPolynomial definition — we provide one via Jacobi-Trudi formula",
@@ -96,10 +98,9 @@
       "RSK correspondence not formalized in Mathlib — needed for jacobiTrudi_lgv_proof"
     ],
     "nextSteps": [
-      "PRIORITY A: Prove ssytFin_two_row_eq_sum_colstrict (~60 lines): bijection SSYTFin n 2 sh ≃ col-strict (Sym a × Sym b) pairs via row projection",
-      "PRIORITY B: Prove jdt_weight_sum (~80 lines): JDT bijection {non-col-strict (a,b)} ≃ {all (a+1,b-1)}, weight preserved",
-      "PRIORITY C: k≥3 via algebraic LGV (~150 lines) or submit to Aristotle after jdt+row-decomp complete",
-      "Fintype.sum_subtype_add_sum_subtype is the key partition lemma — already used in sym_pair_sum_partition"
+      "Prove jdt_weight_sum: need LGV-style involution (not naive first-violation JDT). Involution must preserve P.1+Q.1 combined multiset; naive first-violation is not injective (counterexample: n=3,a=b=2: {1,2},{0,1} and {0,2},{1,1} both map to same image).",
+      "For jdt_weight_sum involution: pair non-col-strict (P,Q) with all-(a+1,b-1) Sym pairs via signing argument (LGV intersecting-path swap). This preserves the combined multiset sorted descendingly.",
+      "General k≥3: RSK correspondence SSYT ↔ NI lattice path tuples then weight matching with hsymm products (~300 lines)"
     ],
     "markdown": "# Knowledge Base: LGV Lemma → Jacobi-Trudi Identity\n\n**Problem**: ballot-problem-oq-03-oq-01-oq-01-oq-01\n**Last Updated**: 2026-04-23\n**Knowledge Items**: 0\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\nNewly selected. Jacobi-Trudi identity expresses Schur polynomials as determinants of\ncomplete homogeneous symmetric polynomials. The LGV lemma (in parent gallery proof)\nprovides the combinatorial proof route via non-intersecting lattice paths.\n\n---\n\n## Insights\n\n_None yet — begin with OBSERVE phase: check Mathlib for SSYT formalization._\n\n---\n\n## Dead Ends\n\n_None identified yet._\n"
   },


### PR DESCRIPTION
## Summary

- Proves `ssytFin_two_row_eq_sum_colstrict`: explicit `Equiv` between `SSYTFin n 2 sh` and col-strict `Sym (Fin n) a × Sym (Fin n) b` pairs
- Reduces sorry count from 3 → 2 in `BallotProblemOQ03OQ01OQ01OQ01.lean` (457 → 572 lines)
- The `ssytSchurFin_two_row` assembly proof now depends only on `jdt_weight_sum` and the `k≥3` case

## Technical Details

**Bijection structure:**
- `toFun`: pack SSYT rows 0,1 via `List.ofFn` into `Sym`; col-strict from SSYT `col_strict` field
- `invFun`: unpack via `Multiset.sort` sorted representatives; `fin_cases i` handles row-weak proof
- `left_inv`: uses `List.mergeSort_eq_self` (rows already sorted by row-weak condition)
- `right_inv`: uses `Multiset.sort_eq` to recover original multiset

**Key insight:** `fin_cases i` (not `split_ifs`) is required in `invFun` because the goal type contains `i` in dependent position (`Fin (sh i)`), and only `fin_cases` substitutes the concrete value into the type.

**Remaining sorries:**
1. `jdt_weight_sum` (~80 lines): LGV-style involution on non-col-strict pairs; naive first-violation map is NOT injective (counterexample documented in knowledge.md)
2. `jacobi_trudi_ssyt_eq k≥3` (~300 lines): RSK correspondence + LGV weight matching

## Files Modified

- `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean` — proof added (~115 lines)
- `src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json` — sorries 3→2, lineCount 457→572
- `src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json` — knowledge updated
- `research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/knowledge.md` — Session 9 added

🤖 Generated with [Claude Code](https://claude.com/claude-code)