### PR TITLE
fix(audit): sync leanFile.lineCount for erdos-1-oq-03 (183→182)

### DIFF
--- a/src/data/proofs/erdos-1-oq-03/meta.json
+++ b/src/data/proofs/erdos-1-oq-03/meta.json
@@ -38,7 +38,7 @@
       "Conway-Guy optimality conjecture statement"
     ],
     "dateAdded": "2026-03-30",
-    "lineCount": 183,
+    "lineCount": 182,
     "theoremCount": 12,
     "definitionCount": 3,
     "prerequisites": [
@@ -154,7 +154,7 @@
       "Finset"
     ],
     "namespace": "Erdos1OQ03",
-    "lineCount": 183,
+    "lineCount": 182,
     "axiomCount": 1,
     "theoremCount": 12,
     "definitionCount": 3,


### PR DESCRIPTION
## Fix

Correct stale `lineCount` in `erdos-1-oq-03` meta.json — both `meta.lineCount` and `leanFile.lineCount` were 183 but the actual file has 182 lines.

## Evidence

**Root cause**: PR #12640 incorrectly bumped `leanFile.lineCount` from 182→183 (the wrong direction) while fixing other entries.

**Before**:
- `meta.lineCount`: 183
- `leanFile.lineCount`: 183
- Actual `Proofs/Erdos1OQ03.lean`: 182 lines
- `overview.text`: "A 182-line formalization" ✓ (was already correct)

**After**:
- `meta.lineCount`: 182 ✓
- `leanFile.lineCount`: 182 ✓

---
Automated fix by lean-mechanic agent.