### PR TITLE
Enrich abel-ruffini: add Sylow and Descartes cross-links to annotations

### DIFF
--- a/src/data/proofs/abel-ruffini/annotations.json
+++ b/src/data/proofs/abel-ruffini/annotations.json
@@ -237,7 +237,9 @@
       "simple group",
       "normal subgroup",
       "cycle type",
-      "inverse-galois-oq-06"
+      "inverse-galois-oq-06",
+      "sylow-theorem-oq-04",
+      "sylow-theorems-oq-04"
     ]
   },
   {
@@ -337,7 +339,8 @@
       "irreducible polynomial",
       "Galois group computation",
       "abel-ruffini-oq-04-oq-01",
-      "inverse-galois-oq-06"
+      "inverse-galois-oq-06",
+      "descartes-rule-of-signs"
     ]
   },
   {


### PR DESCRIPTION
Enrichment pass for abel-ruffini (quality: 100, passes: 5).

Quality improvements:
- Added `sylow-theorem-oq-04` and `sylow-theorems-oq-04` to relatedConcepts of `ann-a5-simple`: these gallery proofs formalize A₅ simplicity via Sylow counting, directly instantiating the conjugacy class arithmetic described in the annotation's mathContext
- Added `descartes-rule-of-signs` to relatedConcepts of `ann-contrapositive`: Descartes' rule provides the 3-real-root count for x⁵-x-1 that forces Gal ≅ S₅