### PR TITLE
fix(audit): sync theoremCount for sophie-germain-oq-01 (22→24)

### DIFF
--- a/src/data/proofs/sophie-germain-oq-01/meta.json
+++ b/src/data/proofs/sophie-germain-oq-01/meta.json
@@ -20,7 +20,7 @@
     "sorries": 0,
     "axiomCount": 1,
     "lineCount": 196,
-    "theoremCount": 22,
+    "theoremCount": 24,
     "definitionCount": 1,
     "assumptions": "1 axiom: `sophie_germain_conjecture` (inherited from parent, states the unproved Sophie Germain prime conjecture).",
     "dateAdded": "2026-04-26",
@@ -205,7 +205,7 @@
     "namespace": "SophieGermainOQ01",
     "lineCount": 196,
     "axiomCount": 1,
-    "theoremCount": 22,
+    "theoremCount": 24,
     "definitionCount": 1,
     "sorries": 0,
     "path": "Proofs/SophieGermainOQ01.lean"


### PR DESCRIPTION
## Summary

- Corrects `theoremCount` in `src/data/proofs/sophie-germain-oq-01/meta.json` from 22 to 24 in both locations (`meta` object and `leanFile` object)
- Discrepancy found during gallery integrity audit: `grep -c "^theorem "` on `proofs/Proofs/SophieGermainOQ01.lean` returns 24, but metadata claimed 22

## Changes

- `meta.theoremCount`: 22 → 24
- `leanFile.theoremCount`: 22 → 24

No Lean source changes; metadata sync only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)