### PR TITLE
Enrich abel-ruffini-galois-extensions-oq-04: fix line counts, annotation ranges, add cross-reference

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-04/annotations.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-04/annotations.json
@@ -110,7 +110,7 @@
   {
     "id": "ann-second-iso",
     "proofId": "abel-ruffini-galois-extensions-oq-04",
-    "range": { "startLine": 183, "endLine": 227 },
+    "range": { "startLine": 183, "endLine": 206 },
     "type": "technique",
     "title": "second_iso: Noether's Second Isomorphism via Direct Map Construction",
     "content": "The second isomorphism theorem in this context states: if x is maximal normal in x⊔y, then (x⊔y)/x ≃* y/(x⊓y). The proof constructs a direct map φ : y →* (x⊔y)/x by composing inclusion le_sup_right with the quotient map mk'. The kernel of φ is computed to be (x⊓y).subgroupOf y (by a membership calculation), and surjectivity follows by decomposing any element of x⊔y as a product from x and y, then showing the x-part is in the kernel. The first isomorphism theorem `quotientKerEquivOfSurjective` then gives the isomorphism. This avoids `rw [sup_comm y x]` which fails with 'motive not type correct' due to Normal typeclass dependency on the rewritten term.",
@@ -122,7 +122,7 @@
   {
     "id": "ann-jordan-holder",
     "proofId": "abel-ruffini-galois-extensions-oq-04",
-    "range": { "startLine": 233, "endLine": 247 },
+    "range": { "startLine": 208, "endLine": 225 },
     "type": "insight",
     "title": "Jordan-Hölder Theorem: One-Line Delegation",
     "content": "With the JordanHolderLattice instance in place, the Jordan-Hölder theorem for groups reduces to a single call to `CompositionSeries.jordan_holder` from Mathlib. This demonstrates the power of the typeclass abstraction: once the three axioms are verified for (Subgroup G), the full Jordan-Hölder machinery — which works for any JordanHolderLattice — applies automatically. The `jordan_holder_finite_groups` variant specializes to finite groups (the hypotheses require finite G implicitly through CompositionSeries termination), delegating immediately to the general version.",

--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-04/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-04/meta.json
@@ -21,7 +21,7 @@
         "dateAdded": "2026-04-24",
         "axiomCount": 0,
         "assumptions": "",
-        "lineCount": 255,
+        "lineCount": 234,
         "theoremCount": 9,
         "definitionCount": 3,
         "originalContributions": [
@@ -107,15 +107,15 @@
             "id": "sec-inf-and-iso",
             "title": "Part IV: Axioms 2–3 — isMaximal_inf and second_iso",
             "startLine": 105,
-            "endLine": 227,
+            "endLine": 207,
             "summary": "`isMaximal_inf_left_of_isMaximal_sup` (lines 105–167): if x and y are both maximal normal in x⊔y, then x⊓y is maximal normal in x — three goals (strict containment, relative normality, maximality); maximality case uses element-wise Subgroup.mem_sup decomposition. `iso_symm` and `iso_trans` (lines 169–181): GroupQuotIso is symmetric and transitive. `second_iso` (lines 183–227): (x⊔y)/x ≃* y/(x⊓y) via first isomorphism theorem, constructing φ: y →* (x⊔y)/x directly to bypass sup_comm rewrite failure.",
             "mathContext": "The element-wise argument: for $a \\in x$, write $a = nb$ with $n \\in N, b \\in y$ (Subgroup.mem_sup); then $b = n^{-1}a \\in x \\cap y \\leq N$, so $a \\in N$. The `rw [sup_comm y x]` failure occurs because the Normal typeclass instance for the quotient type depends syntactically on the rewritten term — a systematic issue in Lean 4 with typeclass-dependent rewriting that requires constructing the map directly rather than rewriting."
         },
         {
             "id": "sec-main-theorem",
             "title": "Part V: Jordan-Hölder Theorem",
-            "startLine": 229,
-            "endLine": 255,
+            "startLine": 208,
+            "endLine": 234,
             "summary": "`jordan_holder_subgroups` and `jordan_holder_finite_groups`: one-line delegations to `CompositionSeries.jordan_holder` once the JordanHolderLattice instance is provided. `#check` statements verify the exported types. These theorems become available automatically — the entire power of the abstract Jordan-Hölder machinery applies to groups at no additional proof cost.",
             "mathContext": "Jordan-Hölder uniqueness: any two composition series of a finite group have the same length and the same multiset of simple composition factors up to permutation and isomorphism. For $S_5$: the unique series is $\\{e\\} \\triangleleft A_5 \\triangleleft S_5$ with factors $A_5$ (simple, order 60) and $\\mathbb{Z}/2\\mathbb{Z}$. Jordan-Hölder guarantees no alternative decomposition avoids the non-abelian $A_5$ factor, making the Abel-Ruffini degree-5 threshold absolute."
         }
@@ -155,6 +155,11 @@
             "id": "abel-ruffini-oq-04-oq-02-oq-03",
             "relationship": "complementary",
             "description": "Proves all finite groups of order $< 60$ are solvable. $A_5$ (order 60) is the minimal non-solvable group — equivalently, the first group to have a non-cyclic composition factor. Jordan-Hölder makes this precise: the 59 groups of smaller order all have composition series with only cyclic factors"
+        },
+        {
+            "id": "abel-ruffini-oq-04-oq-02-oq-02",
+            "relationship": "complementary",
+            "description": "Proves the complete solvability classification for alternating groups: $A_n$ is solvable if and only if $n \\leq 4$. Jordan-Hölder certifies this by making composition factors intrinsic invariants: for $n \\geq 5$, the non-abelian simple group $A_n$ appears as an inescapable composition factor in the Jordan-Hölder series of $A_n$ itself, while for $n \\leq 4$ all composition factors are cyclic. This entry and the present one together show the full picture: $A_n$'s solvability classification and the uniqueness of the series witnessing it"
         }
     ],
     "sorries": 0


### PR DESCRIPTION
## Summary

Enrichment pass for the Jordan-Hölder JordanHolderLattice gallery entry (`abel-ruffini-galois-extensions-oq-04`).

**Bug fixes (metadata inconsistencies):**
- `meta.lineCount`: 255 → 234 (Lean file has 234 lines, not 255)
- `sections[sec-inf-and-iso].endLine`: 227 → 207 (second_iso proof ends at line 206; section was incorrectly including the Jordan-Hölder theorem declarations at 208–225)
- `sections[sec-main-theorem]`: startLine 229 → 208, endLine 255 → 234 (section now correctly spans the PART IV: Jordan-Hölder Theorem block through the namespace end)
- `annotations[ann-second-iso].range.endLine`: 227 → 206 (annotation range was overrunning into Jordan-Hölder theorem lines)
- `annotations[ann-jordan-holder].range`: `{startLine: 233, endLine: 247}` → `{startLine: 208, endLine: 225}` (annotation was pointing past the file's end; corrected to the actual Jordan-Hölder theorem declarations)

**Enrichment:**
- Added cross-reference to `abel-ruffini-oq-04-oq-02-oq-02` (*Alternating Groups: Aₙ Solvable iff n ≤ 4*): Jordan-Hölder certifies that Aₙ's composition factors are intrinsic invariants — for n ≥ 5, the non-abelian simple Aₙ appears as an inescapable factor, while for n ≤ 4 all factors are cyclic. Together the two entries cover both the uniqueness of the composition series and the solvability classification it encodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)