### PR TITLE
research(angle-trisection): structure tower divisibility sorry into 5-step skeleton

### DIFF
--- a/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean
+++ b/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean
@@ -16,25 +16,39 @@ Under the fixed definition:
 - `isConstructible_mem_range` is no longer provable (correct!)
 - `wantzel_galois_iff` is now a TRUE statement (not false as before)
 
-## Progress: 1 false sorry → 2 true sorries
+## Progress: 1 false sorry → 3 true sorries (2 targeted + 1 out-of-scope)
 
-1. `isConstructible_algebraic_degree` — tower degree property (TRUE, needs ~120 lines)
-2. `wantzel_galois_iff`               — full Galois correspondence (TRUE, needs 500+ lines)
+Session update: The single sorry in `isConstructible_algebraic_degree` has been replaced
+with a structured proof skeleton (Steps A–E) that:
+1. Proves a ∈ ℚ⟮β⟯ and ℚ⟮a⟯ ≤ ℚ⟮β⟯ (Step A)
+2. Proves b+β ∈ ℚ⟮b⟯ ⊔ ℚ⟮β⟯ and ℚ⟮b+β⟯ ≤ ℚ⟮b⟯ ⊔ ℚ⟮β⟯ (Step B)
+3. Reduces the finrank ∣ 2^(j+k+1) claim to two targeted sorries (Steps C, D)
+4. Attempts to prove finrank ℚ⟮b+β⟯ ∣ finrank (join) via algebra instances (Step E)
 
 ## Remaining Sorries
 
-1. `isConstructible_algebraic_degree`: IsConstructible α → IsAlgebraic ℚ α ∧ ∃ n, finrank ℚ ℚ⟮α⟯ = 2^n
-   Proof sketch: Induction on IsConstructible.
-   - rational case: algebraic (minpoly = X - C q), finrank = 1 = 2^0
-   - sqrt_ext case: β² = a, a constructible (IH: finrank ℚ ℚ⟮a⟯ = 2^j), b constructible
-     (IH: finrank ℚ ℚ⟮b⟯ = 2^k). β satisfies X² - a over ℚ(a), so [ℚ(β):ℚ(a)] ≤ 2.
-     Tower law: finrank ℚ ℚ⟮b+β⟯ | finrank ℚ ℚ(b,β) ≤ finrank ℚ ℚ⟮b⟯ * finrank ℚ ℚ⟮β⟯ | 2^(k+j+1).
-   Estimated: ~120 lines. Needs tower law lemmas from Mathlib.
+1. `hβ_dvd` (line ~162): finrank ℚ ℚ⟮β⟯ ∣ 2^(j+1)
+   Proof plan: ℚ⟮a⟯ ≤ ℚ⟮β⟯, tower law gives finrank_β = [ℚ⟮β⟯:ℚ⟮a⟯] * 2^j.
+   β satisfies X²-a over ℚ⟮a⟯ → [ℚ⟮β⟯:ℚ⟮a⟯] ≤ 2 → [ℚ⟮β⟯:ℚ⟮a⟯] ∣ 2 → finrank_β ∣ 2^(j+1).
+   Needs: Algebra (↥ℚ⟮a⟯) (↥ℚ⟮β⟯) instance from ha_le_β, bound on [ℚ⟮β⟯:ℚ⟮a⟯] via minpoly.
 
-2. `wantzel_galois_iff`: Requires full Galois correspondence + 2-group structure.
+2. `hjoin_dvd` (line ~169): finrank ℚ (ℚ⟮b⟯ ⊔ ℚ⟮β⟯) ∣ 2^(j+k+1)
+   Proof plan: tower via ℚ⟮β⟯ gives finrank_join = [join:ℚ⟮β⟯] * finrank_β.
+   Need [join:ℚ⟮β⟯] ∣ 2^k. This requires STRONGER IH for b: not just finrank ℚ ℚ⟮b⟯ = 2^k,
+   but "for any K/ℚ, finrank K K⟮b⟯ divides a power of 2". Current IH is too weak.
+   Alternative: reformulate `isConstructible_algebraic_degree` with stronger induction.
+
+3. `wantzel_galois_iff` (out-of-scope): Requires full Galois correspondence + 2-group structure.
    Estimated: 500+ lines of new Galois theory infrastructure. Out of scope.
 
-## Status: 2 sorries (both TRUE), 0 axioms
+## Key Mathematical Gap
+
+The `hjoin_dvd` sorry reveals that the induction in `isConstructible_algebraic_degree` is
+too weak. The statement "finrank ℚ ℚ⟮b⟯ = 2^k" does not imply that b's degree over any
+extension of ℚ divides a power of 2. A STRONGER induction is needed, e.g.:
+  "For all IsConstructible b and for any K/ℚ with 2-power degree, finrank K K⟮b⟯ ∣ 2^k"
+
+## Status: 3 sorries (2 targeted tower + 1 out-of-scope Galois), 0 axioms
 -/
 
 import Mathlib.FieldTheory.Galois.Basic
@@ -139,8 +153,46 @@ private lemma isConstructible_algebraic_degree (α : ℂ) (h : IsConstructible �
     suffices hdvd : Module.finrank ℚ ℚ⟮(b + β)⟯ ∣ 2 ^ (j + k + 1) by
       obtain ⟨m, _, hm⟩ := (Nat.dvd_prime_pow (by norm_num : Nat.Prime 2)).mp hdvd
       exact ⟨m, hm⟩
-    -- [SORRY] Tower: ℚ⟮b+β⟯ ⊆ (ℚ⟮a⟯ ⊔ ℚ⟮β⟯) ⊔ ℚ⟮b⟯ with finrank | 2^j * 2 * 2^k
-    sorry
+    -- Tower argument: show finrank ℚ ℚ⟮b+β⟯ ∣ 2^(j+k+1)
+    --
+    -- Step A: β² = a ∈ ℚ⟮a⟯ ⟹ a ∈ ℚ⟮β⟯ (close under ·), so ℚ⟮a⟯ ≤ ℚ⟮β⟯
+    have ha_in_β : a ∈ (ℚ⟮β⟯ : IntermediateField ℚ ℂ) := by
+      rw [← hβ2]
+      exact mul_mem (mem_adjoin_simple_self ℚ β) (mem_adjoin_simple_self ℚ β)
+    have ha_le_β : (ℚ⟮a⟯ : IntermediateField ℚ ℂ) ≤ ℚ⟮β⟯ :=
+      adjoin_simple_le_iff.mpr ha_in_β
+    -- Step B: b + β ∈ ℚ⟮b⟯ ⊔ ℚ⟮β⟯, hence ℚ⟮b+β⟯ ≤ ℚ⟮b⟯ ⊔ ℚ⟮β⟯
+    have hmem : b + β ∈ (ℚ⟮b⟯ ⊔ ℚ⟮β⟯ : IntermediateField ℚ ℂ) :=
+      add_mem (mem_sup_left (mem_adjoin_simple_self ℚ b))
+              (mem_sup_right (mem_adjoin_simple_self ℚ β))
+    have hle : (ℚ⟮(b + β)⟯ : IntermediateField ℚ ℂ) ≤ ℚ⟮b⟯ ⊔ ℚ⟮β⟯ :=
+      adjoin_simple_le_iff.mpr hmem
+    -- Step C: finrank ℚ ℚ⟮β⟯ ∣ 2^(j+1)
+    -- Proof: ℚ⟮a⟯ ≤ ℚ⟮β⟯ gives tower law
+    --   finrank ℚ ℚ⟮β⟯ = [ℚ⟮β⟯:ℚ⟮a⟯] * finrank ℚ ℚ⟮a⟯ = [ℚ⟮β⟯:ℚ⟮a⟯] * 2^j
+    -- β satisfies X² - a over ℚ⟮a⟯ (since a = β² ∈ ℚ⟮a⟯), so [ℚ⟮β⟯:ℚ⟮a⟯] ≤ 2
+    -- Therefore [ℚ⟮β⟯:ℚ⟮a⟯] ∣ 2, giving finrank ℚ ℚ⟮β⟯ ∣ 2 * 2^j = 2^(j+1)
+    have hβ_dvd : Module.finrank ℚ ↥(ℚ⟮β⟯) ∣ 2 ^ (j + 1) := by
+      sorry -- tower via ℚ⟮a⟯: [ℚ⟮β⟯:ℚ⟮a⟯] ≤ 2 from β²=a, [ℚ⟮β⟯:ℚ⟮a⟯] ∣ 2, finrank_β = [ℚ⟮β⟯:ℚ⟮a⟯] * 2^j
+    -- Step D: finrank ℚ (ℚ⟮b⟯ ⊔ ℚ⟮β⟯) ∣ 2^(j+k+1)
+    -- Proof: tower through ℚ⟮β⟯
+    --   finrank_join = [join:ℚ⟮β⟯] * finrank_β ∣ 2^k * 2^(j+1) = 2^(j+k+1)
+    -- where [join:ℚ⟮β⟯] ∣ 2^k because b has 2^k-power degree over ℚ
+    -- (this uses the stronger IH: for any K/ℚ, finrank K K⟮b⟯ divides a power of 2)
+    have hjoin_dvd : Module.finrank ℚ ↥(ℚ⟮b⟯ ⊔ ℚ⟮β⟯) ∣ 2 ^ (j + k + 1) := by
+      sorry -- tower via ℚ⟮β⟯: [join:ℚ⟮β⟯] ∣ 2^k (needs stronger IH on b), finrank_β ∣ 2^(j+1)
+    -- Step E: finrank ℚ⟮b+β⟯ ∣ finrank (ℚ⟮b⟯ ⊔ ℚ⟮β⟯) via hle (tower law for inclusions)
+    -- ℚ⟮b+β⟯ ≤ ℚ⟮b⟯ ⊔ ℚ⟮β⟯ gives: finrank_join = [join:ℚ⟮b+β⟯] * finrank_{b+β}
+    have hdvd_le : Module.finrank ℚ ↥(ℚ⟮b + β⟯) ∣
+        Module.finrank ℚ ↥(ℚ⟮b⟯ ⊔ ℚ⟮β⟯) := by
+      haveI hAlg : Algebra ↥(ℚ⟮b + β⟯) ↥(ℚ⟮b⟯ ⊔ ℚ⟮β⟯) :=
+        (IntermediateField.inclusion hle).toAlgebra
+      haveI hST : IsScalarTower ℚ ↥(ℚ⟮b + β⟯) ↥(ℚ⟮b⟯ ⊔ ℚ⟮β⟯) :=
+        IsScalarTower.of_algebraMap_eq (fun r =>
+          Subtype.ext (by simp [RingHom.algebraMap_toAlgebra]))
+      exact ⟨Module.finrank ↥(ℚ⟮b + β⟯) ↥(ℚ⟮b⟯ ⊔ ℚ⟮β⟯),
+             (Module.finrank_mul_finrank ℚ ↥(ℚ⟮b + β⟯) ↥(ℚ⟮b⟯ ⊔ ℚ⟮β⟯)).symm⟩
+    exact hdvd_le.trans hjoin_dvd
 
 -- ============================================================
 -- PART 3: Eisenstein Criterion — X³ - 2 is Irreducible

--- a/proofs/Proofs/HurwitzTheoremOQ04.lean
+++ b/proofs/Proofs/HurwitzTheoremOQ04.lean
@@ -44,6 +44,10 @@ These four algebras are deeply connected to the exceptional Lie groups through:
   - `commDer`: commutator of two derivations is a derivation
   - `commDer_antisymm`, `commDer_jacobi`: Der(𝕆) is a Lie algebra
   - `OctonionDerSubmodule`: Der(𝕆) as a Submodule of End_ℝ(ℝ⁸)
+  - `der_maps_unit_to_zero`: D(e₀) = 0 for every derivation D
+  - `der_maps_real_part_to_zero`: D kills the real part r·e₀
+  - `OctonionDer.toLinearMap`: bridge from OctonionDer to LinearMap
+  - `OctonionDer.mem_der_submodule`: every OctonionDer lies in OctonionDerSubmodule
   - `freudenthal_tits_f4/e6/e7/e8`: ExceptionalType dims match definitions (proved by rfl)
   - All exceptional type dimension computations
   - `G2_unique_low_rank`: G₂ is the only exceptional Lie algebra of rank < 4
@@ -587,6 +591,55 @@ axiom G2_der_dimension :
     FiniteDimensional.finrank ℝ OctonionDerSubmodule = ExceptionalType.G2.dim
 
 -- ============================================================
+-- PART IV-d: Structural Properties of Derivations
+-- ============================================================
+
+/-!
+### Key Structural Facts About Der(𝕆)
+
+These results hold for any derivation, independently of the dimension axiom.
+
+**Unit kills**: Every derivation maps e₀ to zero. Proof: applying Leibniz to e₀·e₀ = e₀ gives
+D(e₀) = D(e₀) + D(e₀), so D(e₀) = 0.
+
+**Submodule bridge**: OctonionDer and OctonionDerSubmodule are two representations
+of the same Lie algebra — the former as a structure, the latter as a Submodule of End_ℝ(ℝ⁸).
+-/
+
+/-- Any derivation of the octonion algebra maps the unit element e₀ to zero.
+    Proof: Applying Leibniz to e₀·e₀ = e₀ gives D(e₀) = D(e₀)·e₀ + e₀·D(e₀) = 2·D(e₀),
+    hence D(e₀) = 0 component-wise. -/
+theorem der_maps_unit_to_zero (D : OctonionDer) : D.map octUnit = 0 := by
+  have h := D.leibniz octUnit octUnit
+  simp only [eightMul_right_unit, eightMul_left_unit] at h
+  funext i
+  have hi := congr_fun h i
+  simp only [Pi.add_apply] at hi
+  linarith
+
+/-- Any derivation kills the real part of 𝕆: D(r·e₀) = r·D(e₀) = 0. -/
+theorem der_maps_real_part_to_zero (D : OctonionDer) (r : ℝ) :
+    D.map (r • octUnit) = 0 := by
+  rw [D.map_smul, der_maps_unit_to_zero D, smul_zero]
+
+/-- Convert an OctonionDer structure to an ℝ-linear map. -/
+def OctonionDer.toLinearMap (D : OctonionDer) : (Fin 8 → ℝ) →ₗ[ℝ] (Fin 8 → ℝ) where
+  toFun := D.map
+  map_add' := D.map_add
+  map_smul' := D.map_smul
+
+/-- Every OctonionDer defines an element of OctonionDerSubmodule (satisfies the
+    Leibniz rule as a linear map). This bridges the two representations of Der(𝕆). -/
+theorem OctonionDer.mem_der_submodule (D : OctonionDer) :
+    D.toLinearMap ∈ OctonionDerSubmodule := by
+  intro a b
+  exact D.leibniz a b
+
+/-- Lift an OctonionDer to a certified member of OctonionDerSubmodule. -/
+def OctonionDer.toSubmoduleMem (D : OctonionDer) : OctonionDerSubmodule :=
+  ⟨D.toLinearMap, D.mem_der_submodule⟩
+
+-- ============================================================
 -- PART V: The Freudenthal-Tits Magic Square
 -- ============================================================
 
@@ -756,6 +809,11 @@ were admissible, there would be a 6th exceptional type.
 #check @commDer_jacobi
 #check @OctonionDerSubmodule
 #check @G2_der_dimension
+#check @der_maps_unit_to_zero
+#check @der_maps_real_part_to_zero
+#check @OctonionDer.toLinearMap
+#check @OctonionDer.mem_der_submodule
+#check @OctonionDer.toSubmoduleMem
 #check @freudenthal_tits_f4
 #check @freudenthal_tits_e6
 #check @freudenthal_tits_e7

--- a/research/problems/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/knowledge.md
+++ b/research/problems/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/knowledge.md
@@ -128,3 +128,45 @@ Now:
 ### Next Steps
 1. Prove the tower divisibility sorry: `Module.finrank ℚ ℚ⟮b+β⟯ ∣ 2^(j+k+1)`
    - Key: ℚ⟮b+β⟯ ≤ ℚ⟮a,β,b⟯; each adjoin step multiplies finrank by ≤ 2^k
+
+## Session 28 (2026-04-26) — Tower Sorry Structured (5-Step Proof Skeleton)
+
+**Mode**: REVISIT (continued from Session 27)
+**Outcome**: PROGRESS — single opaque sorry replaced with 5-step structured proof skeleton
+
+### What I Did
+- Replaced the single `sorry` for `Module.finrank ℚ ℚ⟮(b + β)⟯ ∣ 2 ^ (j + k + 1)` with
+  a structured 5-step proof (Steps A–E):
+  - **Step A** (proved): `a ∈ ℚ⟮β⟯` via `mul_mem` from β*β=a and β∈ℚ⟮β⟯
+  - **Step A** (proved): `ℚ⟮a⟯ ≤ ℚ⟮β⟯` via `adjoin_simple_le_iff.mpr`
+  - **Step B** (proved): `b + β ∈ ℚ⟮b⟯ ⊔ ℚ⟮β⟯` via `add_mem` + `mem_sup_left/right`
+  - **Step B** (proved): `ℚ⟮b+β⟯ ≤ ℚ⟮b⟯ ⊔ ℚ⟮β⟯` via `adjoin_simple_le_iff.mpr`
+  - **Step C** (sorry): `finrank ℚ ℚ⟮β⟯ ∣ 2^(j+1)` — tower via ℚ⟮a⟯
+  - **Step D** (sorry): `finrank ℚ (ℚ⟮b⟯ ⊔ ℚ⟮β⟯) ∣ 2^(j+k+1)` — needs stronger IH on b
+  - **Step E** (attempted): `finrank ℚ⟮b+β⟯ ∣ finrank (join)` via algebra instances + tower law
+
+### Key Insight: Stronger IH Needed for hjoin_dvd
+The proof gap in Step D: showing `[ℚ⟮b⟯⊔ℚ⟮β⟯:ℚ⟮β⟯] ∣ 2^k` requires knowing that b's
+degree over ℚ⟮β⟯ divides 2^k. This does NOT follow from `finrank ℚ ℚ⟮b⟯ = 2^k` alone.
+A **stronger IH** is needed: "for all IsConstructible b, for any K/ℚ, finrank K K⟮b⟯
+divides a power of 2." This would require reformulating `isConstructible_algebraic_degree`
+or using the `QuadraticTower` approach from `AngleTrisectionOQ02OQ04OQ01.lean`.
+
+### Key Insight: Step C (hβ_dvd) is Provable
+The bound `finrank ℚ ℚ⟮β⟯ ∣ 2^(j+1)` follows from:
+1. `ℚ⟮a⟯ ≤ ℚ⟮β⟯` (Step A)
+2. Tower law: `finrank_β = [ℚ⟮β⟯:ℚ⟮a⟯] * 2^j`
+3. β satisfies X² - a over ℚ⟮a⟯ → `[ℚ⟮β⟯:ℚ⟮a⟯] ≤ 2`
+4. `[ℚ⟮β⟯:ℚ⟮a⟯] ∣ 2` (since it's 1 or 2), so `finrank_β ∣ 2^(j+1)`
+Needs: `Algebra (↥ℚ⟮a⟯) (↥ℚ⟮β⟯)` from `(IntermediateField.inclusion ha_le_β).toAlgebra`
+and bound on minpoly degree of β over ℚ⟮a⟯.
+
+### Files Modified
+- `proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean` — structured sorry replacement
+- `src/data/proofs/.../meta.json` — lineCount 284→367, sorries 2→3 (targeted)
+- `src/data/research/problems/...json` — knowledge update
+
+### Next Steps
+1. Prove `hβ_dvd` (Step C): algebra instance setup + minpoly degree bound ≤ 2
+2. For `hjoin_dvd` (Step D): either strengthen IH or convert to QuadraticTower approach
+3. `wantzel_galois_iff` remains out-of-scope

--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
@@ -17,10 +17,10 @@
     ],
     "proofRepoPath": "Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 3,
     "axiomCount": 0,
     "theoremCount": 18,
-    "lineCount": 284,
+    "lineCount": 367,
     "mathlibDependencies": [
       {
         "theorem": "Polynomial.irreducible_of_eisenstein_criterion",

--- a/src/data/proofs/hurwitz-theorem-oq-04/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-04/meta.json
@@ -121,10 +121,10 @@
       "HurwitzTheorem"
     ],
     "namespace": "HurwitzTheoremOQ04",
-    "lineCount": 764,
+    "lineCount": 822,
     "axiomCount": 1,
-    "theoremCount": 32,
-    "definitionCount": 15,
+    "theoremCount": 35,
+    "definitionCount": 17,
     "sorries": 0,
     "path": "Proofs/HurwitzTheoremOQ04.lean"
   },

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-02-incomplete-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-02-incomplete-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: File compiles; 2 sorries remain (tower divisibility + Galois characterization)",
+    "progressSummary": "PROGRESS: Tower sorry structured into 5-step proof (A-E), 2 targeted sub-sorries remain + wantzel out-of-scope",
     "builtItems": [
       "isConstructible_mem_range: all constructible numbers are rational (Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean:89)",
       "not_constructible_of_bad_degree: proved via rationality + minpoly.eq_X_sub_C (line 179)",
@@ -41,7 +41,8 @@
       "Fixed isConstructible_sqrt2 (norm_cast + Real.mul_self_sqrt)",
       "Fixed Module.finrank qualified name throughout not_constructible_of_bad_degree",
       "Fixed IsIntegral conversion for adjoin.finrank type mismatch",
-      "Fixed h1 case: absurd + Nat.two_pow_pos instead of broken linarith"
+      "Fixed h1 case: absurd + Nat.two_pow_pos instead of broken linarith",
+      "Session 28: Steps A-B proven: a∈ℚ⟮β⟯ via mul_mem, ℚ⟮a⟯≤ℚ⟮β⟯ via adjoin_simple_le_iff, b+β∈join, ℚ⟮b+β⟯≤join"
     ],
     "insights": [
       "IsConstructible with existential sqrt_ext blocks induction — must make a,b explicit constructor params to get proper IHs",
@@ -53,16 +54,20 @@
       "Session 26: Fixed definition removes IsConstructible β → √2 is now constructible (proved isConstructible_sqrt2)",
       "Session 26: wantzel_galois_iff was FALSE under old definition (→ direction fails: √2 has 2-group Gal but was not 'constructible'). Now TRUE under fixed definition.",
       "Session 26: not_constructible_of_bad_degree now uses isConstructible_algebraic_degree sorry + IntermediateField.adjoin.finrank for degree connection",
-      "Session 27: File compiles; tower sorry narrowed to single divisibility claim; Docker must run from worktree; Module.finrank must be fully qualified; IsIntegral needed for adjoin.finrank"
+      "Session 27: File compiles; tower sorry narrowed to single divisibility claim; Docker must run from worktree; Module.finrank must be fully qualified; IsIntegral needed for adjoin.finrank",
+      "Session 28: Structured the tower sorry into 5 steps (A-E): a∈ℚ⟮β⟯, ℚ⟮a⟯≤ℚ⟮β⟯, b+β∈join, ℚ⟮b+β⟯≤join, tower-dvd chain",
+      "Session 28: Tower sorry has 2 remaining targeted sorries: hβ_dvd (finrank_β ∣ 2^(j+1)) and hjoin_dvd (finrank_join ∣ 2^(j+k+1))",
+      "Session 28: Key gap identified: hjoin_dvd needs STRONGER IH — not just finrank ℚ ℚ⟮b⟯ = 2^k, but for any K/ℚ, finrank K K⟮b⟯ divides a power of 2"
     ],
     "mathlibGaps": [
       "isConstructible_algebraic_degree: tower degree induction — IsConstructible α → IsAlgebraic ℚ α ∧ ∃ n, finrank ℚ ℚ⟮α⟯ = 2^n. Needs FiniteDimensional.finrank_mul_finrank + IntermediateField tower lemmas. Estimated ~120 lines.",
       "wantzel_galois_iff: requires full FTGT + 2-group structure, estimated 500+ lines — not in Mathlib"
     ],
     "nextSteps": [
-      "Prove tower divisibility: Module.finrank ℚ ℚ⟮b+β⟯ ∣ 2^(j+k+1)",
-      "Key lemmas: IntermediateField.adjoin.finrank, finrank of degree-2 adjoin",
-      "wantzel_galois_iff is out-of-scope (500+ lines)"
+      "Prove hβ_dvd: set up Algebra (↥ℚ⟮a⟯) (↥ℚ⟮β⟯) from ha_le_β, apply tower law, bound [ℚ⟮β⟯:ℚ⟮a⟯] ≤ 2 via minpoly of β over ℚ⟮a⟯",
+      "Prove hjoin_dvd: needs stronger IH — reformulate isConstructible_algebraic_degree with stronger statement about extensions",
+      "Alternative for hjoin_dvd: convert to QuadraticTower approach from AngleTrisectionOQ02OQ04OQ01.lean",
+      "wantzel_galois_iff remains out-of-scope (500+ lines)"
     ]
   },
   "tags": [

--- a/src/data/research/problems/hurwitz-theorem-oq-04.json
+++ b/src/data/research/problems/hurwitz-theorem-oq-04.json
@@ -109,11 +109,11 @@
     {
       "path": "Proofs/HurwitzTheoremOQ04.lean",
       "filename": "HurwitzTheoremOQ04.lean",
-      "lineCount": 737,
+      "lineCount": 765,
       "theoremCount": 23,
       "axiomCount": 1,
-      "defCount": 12,
-      "sorryCount": 3,
+      "defCount": 13,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/HurwitzTheoremOQ04.lean"
     }


### PR DESCRIPTION
## Summary

- Replaces the single opaque `sorry` for `finrank ℚ ℚ⟮b+β⟯ ∣ 2^(j+k+1)` in `isConstructible_algebraic_degree` with a structured 5-step proof skeleton (Steps A–E)
- Steps A–B (proved): membership and inclusion facts (`a∈ℚ⟮β⟯`, `ℚ⟮a⟯≤ℚ⟮β⟯`, `b+β∈join`, `ℚ⟮b+β⟯≤join`)
- Steps C–E: two targeted sorries with clear mathematical statements + an algebra-instance attempt for the dvd-from-inclusion step
- Documents the key mathematical gap: Step D (`hjoin_dvd`) needs a stronger induction hypothesis

## Key Mathematical Insight

The `hjoin_dvd` sorry reveals that `isConstructible_algebraic_degree` needs a stronger IH. The statement `finrank ℚ ℚ⟮b⟯ = 2^k` alone does not imply that `[ℚ⟮b⟯⊔K:K] ∣ 2^k` for an arbitrary extension `K/ℚ`. The correct proof requires: *for any K/ℚ, finrank K K⟮b⟯ divides a power of 2*. This can be proved via the QuadraticTower approach from `AngleTrisectionOQ02OQ04OQ01.lean`.

## Test plan

- [ ] File still has the same 3 sorries (hβ_dvd, hjoin_dvd, wantzel_galois_iff) — no new sorry regressions
- [ ] Steps A–B (4 have statements) are proved without sorry
- [ ] Mathematical comments in Steps C, D explain exactly what each sorry needs

🤖 Generated with [Claude Code](https://claude.com/claude-code)