### PR TITLE
Enrich abel-ruffini-oq-04-oq-03: add inverse-galois and alternating solvability cross-references

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-03/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-03/meta.json
@@ -206,6 +206,16 @@
       "targetId": "abel-ruffini-oq-04-oq-07",
       "relationship": "complementary",
       "description": "Bring-Jerrard reduction and the Bring radical: the constructive complement to this criterion's impossibility. While Galois's criterion (this entry) establishes that quintics with non-solvable Galois groups cannot be solved by radicals, the Bring radical provides a constructive alternative — the Bring-Jerrard form $y^5 + py + q = 0$ is solvable using BR$(t)$, the unique real root of $x^5 + x + t = 0$. Together, this entry and `abel-ruffini-oq-04-oq-07` establish the complete picture: the quintic is not solvable in the class of radical expressions, but IS solvable in the larger class of Bring-radical expressions."
+    },
+    {
+      "targetId": "inverse-galois",
+      "relationship": "related",
+      "description": "The Inverse Galois problem — which finite groups occur as Galois groups over $\\mathbb{Q}$? — is the natural complement to Galois's solvability criterion. This entry characterizes when a polynomial has a solvable Galois group (and hence has radical roots); the inverse problem asks which solvable (and non-solvable) groups are actually realizable. Shafarevich's theorem (every finite solvable group is a Galois group over $\\mathbb{Q}$) is the complete positive answer: the solvable groups whose radical expressions this criterion licenses are exactly all finite solvable groups, which Shafarevich showed are all realizable."
+    },
+    {
+      "targetId": "abel-ruffini-oq-04-oq-02-oq-02",
+      "relationship": "complementary",
+      "description": "Proves that $A_n$ is solvable iff $n \\leq 4$ — a concrete instance of the solvability classification that drives this criterion. The threshold $n = 5$ is exactly where $A_5$ (the smallest non-abelian simple group) makes $S_5$ non-solvable, so Galois's criterion forbids radical formulas for quintics with Galois group $S_5$. Conversely, for $n \\leq 4$, all $A_n$ are solvable, which (via Galois's criterion applied to degree-$\\leq 4$ polynomials whose Galois groups embed in solvable $S_4$) explains why quadratic, cubic, and quartic formulas exist."
     }
   ],
   "references": [


### PR DESCRIPTION
## Summary

Enrichment pass for *Galois's Solvability Criterion* (`abel-ruffini-oq-04-oq-03`).

The entry already has rich annotations (10 annotations, 165 lines with correct line counts) and strong section coverage. This pass adds two cross-references that were mentioned in the open questions but absent from the reference network:

**`inverse-galois` (Inverse Galois Problem):** Galois's solvability criterion characterizes *when* polynomial roots are solvable by radicals via solvable Galois groups; the inverse Galois problem asks *which* finite groups are realizable as Galois groups over $\mathbb{Q}$. Shafarevich's theorem (every finite solvable group is a Galois group over $\mathbb{Q}$) is the complete positive answer — the solvable groups whose radical formulas this criterion licenses are exactly those that Shafarevich showed are all realizable.

**`abel-ruffini-oq-04-oq-02-oq-02` (Aₙ Solvable iff n ≤ 4):** The alternating group solvability classification is the concrete instance of the solvable/non-solvable boundary this criterion governs. The threshold $n = 5$ (where $A_5$ makes $S_5$ non-solvable) is exactly why radical formulas fail for degree-5 polynomials; for $n \leq 4$ all alternating/symmetric groups are solvable, explaining the existence of quadratic/cubic/quartic formulas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)