### PR TITLE
fix(audit): sync leanFile metadata for angle-trisection-oq-02-oq-01-oq-02-incomplete-01

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
@@ -136,12 +136,12 @@
   ],
   "leanFile": {
     "namespace": "AngleTrisectionOQ02OQ01OQ02Incomplete01",
-    "lineCount": 315,
+    "lineCount": 367,
     "axiomCount": 0,
     "theoremCount": 18,
-    "definitionCount": 3,
+    "definitionCount": 2,
     "path": "Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
-    "sorries": 2
+    "sorries": 3
   },
-  "sorries": 2
+  "sorries": 3
 }


### PR DESCRIPTION
## Fix

Sync stale `leanFile` metadata fields after research commit #12777 expanded the Lean file from 284→367 lines and added a sorry (2→3 sorries).

## Evidence

**Before** (stale after #12777):
- `leanFile.sorries` = 2 (stale)
- `leanFile.lineCount` = 315 (stale, even older than #12777)
- `leanFile.definitionCount` = 3 (pre-existing inaccuracy)
- root-level `sorries` = 2 (stale)

**After** (matches actual Lean file):
- `leanFile.sorries` = 3 ✓
- `leanFile.lineCount` = 367 ✓
- `leanFile.definitionCount` = 2 ✓ (only `DegreePowerOfTwo` and `IsTwoGroup` defined)
- root-level `sorries` = 3 ✓
- `meta.sorries` was already correct at 3 (updated by #12777)

**Verified**: `wc -l` → 367 lines; grep for sorry tactics → 3; grep for top-level defs → 2.

---
Automated fix by lean-mechanic agent.