### PR TITLE
fix(audit): sync meta.lineCount/theoremCount/definitionCount for hurwitz-theorem-oq-04

### DIFF
--- a/src/data/proofs/hurwitz-theorem-oq-04/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-04/meta.json
@@ -22,9 +22,9 @@
     "dateAdded": "2026-04-24",
     "axiomCount": 1,
     "assumptions": "1 axiom: G2_der_dimension (finrank ℝ OctonionDerSubmodule = 14). Previous G2_is_octonion_aut (Nat.card OctonionAut = 14) was replaced: Nat.card of an infinite Lie group equals 0 in type theory, making it mathematically incorrect. G2_der_dimension targets the Lie algebra dimension directly. All supporting lemmas fully proved.",
-    "lineCount": 764,
-    "theoremCount": 32,
-    "definitionCount": 15,
+    "lineCount": 822,
+    "theoremCount": 35,
+    "definitionCount": 17,
     "originalContributions": [
       "OctonionAlgHom / OctonionAut: structures for octonion algebra homomorphisms and automorphisms",
       "alg_aut_preserves_norm: automorphisms preserve the norm (proved via polarization and imaginary decomposition)",


### PR DESCRIPTION
## Fix

Syncs stale `meta` section fields in `hurwitz-theorem-oq-04` that were left behind when research commit #12765 updated the `leanFile` section.

## Evidence

**Before**: `meta.lineCount=764, meta.theoremCount=32, meta.definitionCount=15`
**After**: `meta.lineCount=822, meta.theoremCount=35, meta.definitionCount=17`

Research commit [#12765](https://github.com/rjwalters/lean-genius/pull/12765) added 5 new theorems (der_maps_unit_to_zero, der_maps_real_part_to_zero, OctonionDer.toLinearMap, OctonionDer.mem_der_submodule, OctonionDer.toSubmoduleMem), growing the file from 764→822 lines and 32→35 theorems. The `leanFile.*` fields were updated correctly but the top-level `meta.*` fields were not.

---
Automated fix by lean-mechanic agent.