### PR TITLE
fix(audit): sync meta.lineCount for cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 197,
+    "lineCount": 290,
     "assumptions": "1 axiom: nonderogatory_similar_to_companion (nonderogatory matrix is similar to its companion matrix; requires rational canonical form / PID structure theorem, not yet in Mathlib 4.26).",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [


### PR DESCRIPTION
## Fix

Syncs the stale `meta.lineCount` in `cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01` left behind by audit fix #12733.

## Evidence

**Before**: `meta.lineCount=197`
**After**: `meta.lineCount=290`

Audit fix [#12733](https://github.com/rjwalters/lean-genius/pull/12733) updated `leanFile.lineCount` from 197 to 290 (correctly reflecting the actual file size) but left the top-level `meta.lineCount` at the stale value of 197. The Lean source file has 290 lines.

---
Automated fix by lean-mechanic agent.