### PR TITLE
fix(audit): sync sorry count/lineCount for angle-trisection-oq-02-oq-01-oq-02-incomplete-01

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
@@ -2,7 +2,7 @@
   "id": "angle-trisection-oq-02-oq-01-oq-02-incomplete-01",
   "title": "Completing the Wantzel-Galois Constructibility Proof",
   "slug": "angle-trisection-oq-02-oq-01-oq-02-incomplete-01",
-  "description": "Completes the parent Wantzel-Galois proof (angle-trisection-oq-02-oq-01-oq-02) by proving not_constructible_of_bad_degree via a redesigned IsConstructible inductive that enables proper induction. Reduces parent's 5 sorries to 2. All concrete impossibility results (angle trisection, cube doubling, regular 7-gon) are fully proved.",
+  "description": "Completes the parent Wantzel-Galois proof (angle-trisection-oq-02-oq-01-oq-02) by proving not_constructible_of_bad_degree via a redesigned IsConstructible inductive that enables proper induction. Reduces parent's 5 sorries to 1. All concrete impossibility results (angle trisection, cube doubling, regular 7-gon) are fully proved.",
   "meta": {
     "author": "Wantzel (1837), completion formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Straightedge_and_compass_construction",
@@ -17,10 +17,10 @@
     ],
     "proofRepoPath": "Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 1,
     "axiomCount": 0,
-    "theoremCount": 18,
-    "lineCount": 284,
+    "theoremCount": 16,
+    "lineCount": 306,
     "mathlibDependencies": [
       {
         "theorem": "Polynomial.irreducible_of_eisenstein_criterion",
@@ -103,7 +103,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Reduces the parent's 5 sorries to 2 by: (1) redesigning IsConstructible to enable induction, (2) proving not_constructible_of_bad_degree via the rationality argument, (3) proving Eisenstein irreducibility for X³-2, (4) computing all three polynomial degrees. The remaining sorry (wantzel_galois_iff) requires the full Galois correspondence and is out of scope.",
+    "summary": "Reduces the parent's 5 sorries to 1 by: (1) redesigning IsConstructible to enable induction, (2) proving not_constructible_of_bad_degree via the rationality argument, (3) proving Eisenstein irreducibility for X³-2, (4) computing all three polynomial degrees. The remaining sorry (wantzel_galois_iff) requires the full Galois correspondence and is out of scope.",
     "implications": "The three classical impossibility results — angle trisection, cube doubling, regular 7-gon — are now fully proved (0 axioms) in this file. The proof demonstrates that the IsConstructible definition choice is critical: existential vs explicit constructors has dramatic consequences for what can be proved by induction.",
     "openQuestions": [
       "Can wantzel_galois_iff be proved using Mathlib's IntermediateField.orderIsoOfGal and Sylow theory for 2-groups?",
@@ -136,12 +136,12 @@
   ],
   "leanFile": {
     "namespace": "AngleTrisectionOQ02OQ01OQ02Incomplete01",
-    "lineCount": 315,
+    "lineCount": 306,
     "axiomCount": 0,
-    "theoremCount": 18,
+    "theoremCount": 16,
     "definitionCount": 3,
     "path": "Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
-    "sorries": 2
+    "sorries": 1
   },
-  "sorries": 2
+  "sorries": 1
 }


### PR DESCRIPTION
## Summary

- Commit 72ed399 replaced the Lean file with a corrected 306-line, 1-sorry version but did not update `meta.json`
- All sorry/lineCount/theoremCount fields were stale by the time of this audit

## Changes

| Field | Before | After |
|-------|--------|-------|
| `meta.sorries` | 2 | 1 |
| `meta.lineCount` | 284 | 306 |
| `meta.theoremCount` | 18 | 16 |
| `leanFile.sorries` | 2 | 1 |
| `leanFile.lineCount` | 315 | 306 |
| `leanFile.theoremCount` | 18 | 16 |
| `sorries` (root) | 2 | 1 |
| description text | "reduces to 2" | "reduces to 1" |
| conclusion.summary | "5 sorries to 2" | "5 sorries to 1" |

## Verification

```
grep -n "sorry" proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean
# 14: comment (not code)
# 46: comment (not code)
# 304:   sorry   ← only real sorry (wantzel_galois_iff)

wc -l proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean
# 306

grep -c "^theorem \|^lemma " proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean
# 16
```

Discovered during gallery integrity audit.