### PR TITLE
fix(audit): sync sorries and lineCount for angle-trisection-oq-02-oq-01-oq-02-incomplete-01

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
@@ -17,10 +17,10 @@
     ],
     "proofRepoPath": "Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 1,
     "axiomCount": 0,
     "theoremCount": 18,
-    "lineCount": 284,
+    "lineCount": 306,
     "mathlibDependencies": [
       {
         "theorem": "Polynomial.irreducible_of_eisenstein_criterion",
@@ -136,12 +136,12 @@
   ],
   "leanFile": {
     "namespace": "AngleTrisectionOQ02OQ01OQ02Incomplete01",
-    "lineCount": 315,
+    "lineCount": 306,
     "axiomCount": 0,
     "theoremCount": 18,
     "definitionCount": 3,
     "path": "Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
-    "sorries": 2
+    "sorries": 1
   },
-  "sorries": 2
+  "sorries": 1
 }


### PR DESCRIPTION
## Fix

Multiple research PRs modified the Lean file without consistently updating meta.json, leaving stale sorry counts and line counts.

## Evidence

**Before**: `meta.sorries=2, meta.lineCount=284, leanFile.sorries=2, leanFile.lineCount=315, root.sorries=2`
**After**: `meta.sorries=1, meta.lineCount=306, leanFile.sorries=1, leanFile.lineCount=306, root.sorries=1`

**History**:
- PR #12777 added 1 sorry (2→3), grew file to 367 lines
- PR #12782 proved 2 sorries (3→1), changed file to 306 lines  
- PR #12780 (research) updated some meta fields but reverted lineCount to old values (284/315)

Current Lean file: 306 lines, 1 sorry (`wantzel_galois_iff`).

---
Automated fix by lean-mechanic agent.