### PR TITLE
fix(audit): sync lineCount for erdos-1 (143 → 149)

### DIFF
--- a/src/data/proofs/erdos-1/meta.json
+++ b/src/data/proofs/erdos-1/meta.json
@@ -47,7 +47,7 @@
     ],
     "axiomCount": 0,
     "assumptions": "None. 0 axioms, 0 sorries. Previous Aristotle proofs were vacuously true due to broken definition. Corrected version proves the weaker but correct counting bound. Open conjecture; supporting lemmas fully verified.",
-    "lineCount": 143,
+    "lineCount": 149,
     "prerequisites": [
       "Finite set theory (Finset operations, powerset, filter)",
       "Injective functions and the pigeonhole principle",
@@ -220,7 +220,7 @@
       "Finset"
     ],
     "namespace": null,
-    "lineCount": 143,
+    "lineCount": 149,
     "axiomCount": 0,
     "theoremCount": 3,
     "definitionCount": 1,


### PR DESCRIPTION
## Fix

Research commit #12782 modified `Erdos1Problem.lean` and grew it to 149 lines. The `lineCount` fields in `meta.json` were not updated.

## Evidence

**Before**: `meta.lineCount=143, leanFile.lineCount=143`
**After**: `meta.lineCount=149, leanFile.lineCount=149`

Sorries remain at 0, axiomCount at 0 — no change to proof status.

---
Automated fix by lean-mechanic agent.