### PR TITLE
fix(audit): sync sorry count for dirichlets-theorem-oq-03 (3 → 2)

### DIFF
--- a/src/data/proofs/dirichlets-theorem-oq-03/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-03/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 2,
     "axiomCount": 2,
     "lineCount": 139,
     "theoremCount": 8,
@@ -79,7 +79,7 @@
       }
     ],
     "path": "Proofs/DirichletsTheoremOQ03.lean",
-    "sorries": 3
+    "sorries": 2
   },
   "overview": {
     "historicalContext": "Dirichlet proved in 1837 that there are infinitely many primes p ≡ a (mod q) for any coprime pair (a, q). The *quantitative* question — how large is the *first* such prime p(a, q)? — was answered by Linnik in 1944: p(a, q) ≤ c · q^L for absolute constants c and L. This L is the 'Linnik constant'. The history of bounding L spans decades: Pan Cheng-tung (1957) gave L ≤ 10000, Elliott-Halberstam (1966) reduced it to L ≤ 40, then Jutila (L ≤ 20), Chen (L ≤ 13.5), Wang (L ≤ 8), Heath-Brown (L ≤ 5.5, 1992), and finally Xylouris (L ≤ 5, 2011). Under the Generalized Riemann Hypothesis, L ≤ 2 + ε for any ε > 0. The unconditional conjecture is L = 1 + ε, or equivalently, linnikConstant = 1.",
@@ -167,5 +167,5 @@
       "Is the gap from L* ≤ 2+ε (GRH) to L* = 1 (optimal) resolvable by any known technique? Current evidence suggests L* = 1 may be harder than GRH itself — it appears to require both a zero-free region and a precise understanding of low-lying zeros of Dirichlet L-functions."
     ]
   },
-  "sorries": 3
+  "sorries": 2
 }


### PR DESCRIPTION
## Fix

The `dirichlets-theorem-oq-03` meta.json reports 3 sorries but the Lean file only has 2.

## Evidence

**Before**: `sorries=3`
**After**: `sorries=2`

The Lean file (line 34) has `⟨sorry, sorry⟩` filling an existential proof `∃ p, p.Prime ∧ p ≡ a [MOD q]` — 2 sorry tokens. A third sorry was previously proved but the metadata was not updated.

---
Automated fix by lean-mechanic agent.