### PR TITLE
fix(audit): sync meta sorry/lineCount/theoremCount for angle-trisection-oq-02-oq-01-oq-02-incomplete-01

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
@@ -17,10 +17,10 @@
     ],
     "proofRepoPath": "Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 1,
     "axiomCount": 0,
-    "theoremCount": 18,
-    "lineCount": 284,
+    "theoremCount": 16,
+    "lineCount": 306,
     "mathlibDependencies": [
       {
         "theorem": "Polynomial.irreducible_of_eisenstein_criterion",
@@ -136,12 +136,12 @@
   ],
   "leanFile": {
     "namespace": "AngleTrisectionOQ02OQ01OQ02Incomplete01",
-    "lineCount": 315,
+    "lineCount": 306,
     "axiomCount": 0,
-    "theoremCount": 18,
+    "theoremCount": 16,
     "definitionCount": 3,
     "path": "Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
-    "sorries": 2
+    "sorries": 1
   },
-  "sorries": 2
+  "sorries": 1
 }

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-02-incomplete-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-02-incomplete-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Tower sorry structured into 5-step proof (A-E), 2 targeted sub-sorries remain + wantzel out-of-scope",
+    "progressSummary": "CURRENT STATE (post-revert): 1 sorry (wantzel_galois_iff, FALSE under current IsConstructible def). Sessions 26-28 work was reverted. File is functionally complete for concrete impossibility results but IsConstructible definition is intentionally minimal (constructibles=rationals). wantzel_galois_iff needs IsConstructible redesign + ~500L Galois theory.",
     "builtItems": [
       "isConstructible_mem_range: all constructible numbers are rational (Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean:89)",
       "not_constructible_of_bad_degree: proved via rationality + minpoly.eq_X_sub_C (line 179)",
@@ -64,10 +64,10 @@
       "wantzel_galois_iff: requires full FTGT + 2-group structure, estimated 500+ lines — not in Mathlib"
     ],
     "nextSteps": [
-      "Prove hβ_dvd: set up Algebra (↥ℚ⟮a⟯) (↥ℚ⟮β⟯) from ha_le_β, apply tower law, bound [ℚ⟮β⟯:ℚ⟮a⟯] ≤ 2 via minpoly of β over ℚ⟮a⟯",
-      "Prove hjoin_dvd: needs stronger IH — reformulate isConstructible_algebraic_degree with stronger statement about extensions",
-      "Alternative for hjoin_dvd: convert to QuadraticTower approach from AngleTrisectionOQ02OQ04OQ01.lean",
-      "wantzel_galois_iff remains out-of-scope (500+ lines)"
+      "Option A: Create Incomplete02.lean re-applying Sessions 26-28 fix with hβ_dvd proved (~150L)",
+      "Option B: Prove sqrt2_constructible_tower in OQ04OQ01.lean (~25L, self-contained)",
+      "Accept current state as-is (1 sorry permanently out-of-scope under current def)",
+      "wantzel_galois_iff under current def: permanently out-of-scope"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

- The Lean source file `AngleTrisectionOQ02OQ01OQ02Incomplete01.lean` was reverted to a 1-sorry state in commit `0306317c8a8` (session 29 audit), but `meta.json` was not updated at the same time.
- This PR syncs all affected metadata fields to match the current HEAD state of the Lean file.

## Changes

| Field | Before | After |
|---|---|---|
| `meta.sorries` | 2 | 1 |
| `meta.theoremCount` | 18 | 16 |
| `meta.lineCount` | 284 | 306 |
| `leanFile.sorries` | 2 | 1 |
| `leanFile.theoremCount` | 18 | 16 |
| `leanFile.lineCount` | 315 | 306 |
| root `sorries` | 2 | 1 |

## Test plan

- [ ] Confirm `git show HEAD:proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean | wc -l` returns 306
- [ ] Confirm sorry count in that file is 1 (only `wantzel_galois_iff` at line 304)
- [ ] Confirm theorem count is 16 and definition count is 3
- [ ] Gallery build (`pnpm build`) passes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)