### PR TITLE
fix(audit): sync stale lineCount fields across 7 gallery entries (batch)

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-04/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-04/meta.json
@@ -21,7 +21,7 @@
         "dateAdded": "2026-04-24",
         "axiomCount": 0,
         "assumptions": "",
-        "lineCount": 255,
+        "lineCount": 234,
         "theoremCount": 9,
         "definitionCount": 3,
         "originalContributions": [

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -23,7 +23,7 @@
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
     "assumptions": "Four open sorries: (1) hook_length_formula (LGV approach: requires SYT↔NI bijection + det factorization), (2) ni_count_eq_syt_count (Fomin/Viennot/RSK correspondence), (3) lgv_det_factors_as_hook_quotient (det factorization identity), (4) hook_walk_identity ≥5-row case (GNW or RSK, ~300 lines; at-most-2-row, gHookYD, ≤2-col, exactly-3-row, exactly-4-row all proved). hook_length_formula_general is proved modulo hook_walk_identity via corner induction.",
-    "lineCount": 7274,
+    "lineCount": 10130,
     "theoremCount": 164,
     "definitionCount": 14,
     "originalContributions": [
@@ -89,7 +89,7 @@
       "LGV"
     ],
     "namespace": "HookLengthFormula",
-    "lineCount": 5882,
+    "lineCount": 10130,
     "axiomCount": 0,
     "sorries": 4,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",

--- a/src/data/proofs/erdos-1008-oq-04/meta.json
+++ b/src/data/proofs/erdos-1008-oq-04/meta.json
@@ -33,7 +33,7 @@
     ],
     "dateAdded": "2026-04-12",
     "axiomCount": 2,
-    "lineCount": 136,
+    "lineCount": 145,
     "prerequisites": [
       "Extremal graph theory",
       "Kővári-Sós-Turán theorem",
@@ -143,7 +143,7 @@
       "Finset"
     ],
     "namespace": "Erdos1008OQ04",
-    "lineCount": 136,
+    "lineCount": 145,
     "axiomCount": 2,
     "theoremCount": 1,
     "definitionCount": 1,

--- a/src/data/proofs/erdos-795/meta.json
+++ b/src/data/proofs/erdos-795/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/795",
     "erdosProblemStatus": "solved",
     "axiomCount": 0,
-    "lineCount": 500,
+    "lineCount": 496,
     "assumptions": "14 sorry(s).",
     "mathlib_version": "4.26.0"
   },
@@ -167,7 +167,7 @@
     ],
     "opens": [],
     "namespace": "Erdos795",
-    "lineCount": 500,
+    "lineCount": 496,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 7,

--- a/src/data/proofs/liouville-theorem-oq-04/meta.json
+++ b/src/data/proofs/liouville-theorem-oq-04/meta.json
@@ -174,7 +174,7 @@
     ],
     "opens": ["Polynomial"],
     "namespace": "LiouvilleTheoremOQ04",
-    "lineCount": 415,
+    "lineCount": 398,
     "axiomCount": 1,
     "theoremCount": 12,
     "definitionCount": 2,

--- a/src/data/proofs/sperner-ndim-oq-04/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-04/meta.json
@@ -42,7 +42,7 @@
     ],
     "dateAdded": "2026-04-22",
     "axiomCount": 0,
-    "lineCount": 764,
+    "lineCount": 892,
     "assumptions": "1 sorry in kuhn_path_existential Case 2 (B_fc = ∅): when all boundary doors are non-FC, needs walk-pairing involution on B-B pairs to show |B-B| even, then |B-nfc| odd − |B-B| even → |B-FC| odd ≥ 1 → ∃ walk from B_nfc reaching FC. Note: bdry_nfc_even (|B_nfc| always even) was removed — it is FALSE; |B_nfc| can be odd when B-FC walks exist. Requires kuhnWalkWithExit + walkTrace_reversal induction (~100 lines). 0 axiom declarations.",
     "mathlib_version": "4.26.0"
   },
@@ -247,7 +247,7 @@
       "BigOperators"
     ],
     "namespace": "SpernerNDimOQ04",
-    "lineCount": 764,
+    "lineCount": 892,
     "axiomCount": 0,
     "theoremCount": 20,
     "definitionCount": 8,

--- a/src/data/proofs/synthesis-curvature-ptolemy/meta.json
+++ b/src/data/proofs/synthesis-curvature-ptolemy/meta.json
@@ -52,7 +52,7 @@
     ],
     "dateAdded": "2026-04-26",
     "axiomCount": 0,
-    "lineCount": 210,
+    "lineCount": 270,
     "assumptions": "0 axioms. 0 sorries. All results are fully machine-verified. The hyperbolic Ptolemy theorem (K<0) is stated as a conjecture in comments only — it is NOT claimed as a theorem in this file.",
     "mathlib_version": "4.26.0",
     "parentProof": "ptolemys-theorem-oq-01-oq-02"


### PR DESCRIPTION
## Fix

Syncs stale `lineCount` fields in 7 gallery entries. Multiple research commits modified Lean files without updating `meta.lineCount` and/or `leanFile.lineCount`. Research commit #12780 (a large squashed commit) also reverted lineCount values to pre-update values in several proofs.

## Changes

| Proof | Field | Before | After |
|-------|-------|--------|-------|
| ballot-problem-oq-03-oq-01-oq-02 | meta.lineCount | 7274 | 10130 |
| ballot-problem-oq-03-oq-01-oq-02 | leanFile.lineCount | 5882 | 10130 |
| sperner-ndim-oq-04 | meta+leanFile.lineCount | 764 | 892 |
| synthesis-curvature-ptolemy | meta.lineCount | 210 | 270 |
| abel-ruffini-galois-extensions-oq-04 | meta.lineCount | 255 | 234 |
| liouville-theorem-oq-04 | meta+leanFile.lineCount | 415 | 398 |
| erdos-1008-oq-04 | meta+leanFile.lineCount | 136 | 145 |
| erdos-795 | meta+leanFile.lineCount | 500 | 496 |

Sorry counts and axiom counts are unaffected.

---
Automated fix by lean-mechanic agent.