### PR TITLE
feat(algebraic-numbers-countable-oq-05): gallery entry for Cantor 1874 height proof

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -19,6 +19,8 @@ import Proofs.AlgebraicNumbersCountableAristotle
 import Proofs.AlgebraicNumbersCountableOQ02
 import Proofs.AlgebraicNumbersCountableOQ02OQ02
 import Proofs.AlgebraicNumbersCountableOQ02OQ02OQ01
+import Proofs.AlgebraicNumbersCountableOQ04
+import Proofs.AlgebraicNumbersCountableOQ05
 import Proofs.AmgmInequalityOQ02
 import Proofs.AmgmInequalityOQ02Aristotle
 import Proofs.AmgmInequalityOQ02Defs

--- a/research/problems/algebraic-numbers-countable-oq-05/knowledge.md
+++ b/research/problems/algebraic-numbers-countable-oq-05/knowledge.md
@@ -1,21 +1,46 @@
 # Knowledge Base: algebraic-numbers-countable-oq-05
 
-Insights accumulated during research on this problem.
+**Cantor's 1874 Height Function Proof of Algebraic Number Countability**
 
----
+## Session 2026-04-26 (Session 1) — Gallery Integration
 
-## Problem Understanding
+**Mode**: FRESH (EMPTY knowledge tier)
+**Outcome**: completed — created gallery entry for existing complete Lean proof
 
-[Initial observations about the problem will be recorded here]
+### What I Did
 
----
+The Lean proof file `proofs/Proofs/AlgebraicNumbersCountableOQ05.lean` (297 lines,
+12 theorems, 0 sorries, 0 axioms) was already present and complete, but had no gallery entry.
 
-## Insights
+**Work done this session**:
+1. Assessed the Lean file — confirmed 0 sorries, 0 axioms, fully verified
+2. Created `src/data/proofs/algebraic-numbers-countable-oq-05/meta.json` with:
+   - Full overview, historical context, proof strategy
+   - 5 sections matching the Lean file structure
+   - 4 cross-references to related proofs
+   - Complete originalContributions list (12 theorems)
+3. Created `src/data/proofs/algebraic-numbers-countable-oq-05/annotations.json` with 6 annotations
+4. Created `src/data/proofs/algebraic-numbers-countable-oq-05/index.ts` (TypeScript export)
+5. Added OQ04 and OQ05 imports to `proofs/Proofs.lean` (both were missing)
 
-[Insights from research attempts will be accumulated here]
+### Key Findings
 
----
+- The Lean proof uses Cantor height H(p) = deg(p) + sum|ai|
+- Key theorem: finite_polys_of_height — injection into Fintype Fin(h+1) → Icc(-h,h)
+- Height stratification gives FINITE strata (stronger than countable from degree stratification)
+- Main theorem: algebraic_reals_countable_via_height
+- Both OQ04 and OQ05 Lean files were missing from proofs/Proofs.lean imports
 
-## Dead Ends
+### Files Modified
 
-[Approaches known not to work will be documented here]
+- src/data/proofs/algebraic-numbers-countable-oq-05/meta.json (created)
+- src/data/proofs/algebraic-numbers-countable-oq-05/annotations.json (created)
+- src/data/proofs/algebraic-numbers-countable-oq-05/index.ts (created)
+- proofs/Proofs.lean (added 2 missing imports: OQ04, OQ05)
+- src/data/research/problems/algebraic-numbers-countable-oq-05.json (knowledge updated)
+
+### Current State
+
+- Lean proof: 0 sorries, 0 axioms (fully verified)
+- Gallery entry: complete
+- Status: COMPLETED

--- a/src/data/proofs/algebraic-numbers-countable-oq-05/annotations.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-05/annotations.json
@@ -1,0 +1,142 @@
+[
+  {
+    "id": "ann-oq05-height-def",
+    "proofId": "algebraic-numbers-countable-oq-05",
+    "range": {
+      "startLine": 46,
+      "endLine": 108
+    },
+    "type": "concept",
+    "title": "The Cantor Height Function: Bounding Degree and Coefficients",
+    "content": "The heart of Cantor's 1874 approach is the height function `cantorHeight p = p.natDegree + (range (p.natDegree + 1)).sum (fun i => (p.coeff i).natAbs)`. This single number H(p) packages all the combinatorial information needed for finiteness: bounded height means bounded degree AND bounded coefficient size. The three basic lemmas (degree_le, coeff_le, pos_of_ne_zero) are immediate arithmetic: degree and coefficient-sum are each ≤ the total height.",
+    "mathContext": "H(a₀ + a₁X + ··· + aₙXⁿ) = n + |a₀| + |a₁| + ··· + |aₙ|. The degree n appears as the first summand. The coefficient norms |aᵢ| appear as subsequent summands. Bounded total → each part is bounded. This is the key observation enabling finiteness.",
+    "significance": "high",
+    "relatedConcepts": [
+      "Polynomial.natDegree",
+      "Int.natAbs",
+      "Cantor height",
+      "bounded polynomial families"
+    ],
+    "prerequisites": [
+      "Integer polynomial arithmetic",
+      "Finset.sum bounds"
+    ]
+  },
+  {
+    "id": "ann-oq05-finiteness",
+    "proofId": "algebraic-numbers-countable-oq-05",
+    "range": {
+      "startLine": 110,
+      "endLine": 152
+    },
+    "type": "technique",
+    "title": "Injection into a Fintype: The Key Finiteness Proof",
+    "content": "The proof of `finite_polys_of_height` uses the standard Lean pattern for finiteness: inject the set into the range of a function from a `Fintype`. The Fintype chosen is `Fin(h+1) → ↥Icc(-(h:ℤ), h)` — coefficient tuples where each entry lies in [-h, h]. The injection sends p to its coefficient function `fun i => ⟨p.coeff i, _⟩`, and the auxiliary `poly_eq_fin_sum` shows p is determined by these coefficients (since degree ≤ h).",
+    "mathContext": "The Lean pattern: `Set.Finite.subset (Set.finite_range f) (fun p hp => ⟨witness, proof⟩)` where f : Fintype → Polynomial ℤ and witness : Fintype proves p ∈ range f. Here Fintype = `Fin(h+1) → ↥Icc(-h, h)` (automatically finite as a product of finite types). The injection from height-≤h polynomials into this Fintype sends each p to its coefficient tuple, using `Int.natAbs_le` to verify each coefficient lies in [-h, h].",
+    "significance": "high",
+    "relatedConcepts": [
+      "Set.Finite.subset",
+      "Set.finite_range",
+      "Fin.sum_univ_eq_sum_range",
+      "Finset.sum_ite_eq'"
+    ],
+    "prerequisites": [
+      "Set.Finite and Set.finite_range",
+      "Int.natAbs_le: |x| ≤ n ↔ -n ≤ x ∧ x ≤ n",
+      "Finset.single_le_sum for bounding individual terms"
+    ]
+  },
+  {
+    "id": "ann-oq05-strata",
+    "proofId": "algebraic-numbers-countable-oq-05",
+    "range": {
+      "startLine": 168,
+      "endLine": 242
+    },
+    "type": "technique",
+    "title": "Height Stratification: From Finite Strata to Countable Union",
+    "content": "The proof assembles three ingredients: (1) finite index type (polynomials of height ≤ h form a finite set, so the subtype {q // q ≠ 0 ∧ H(q) ≤ h} is Finite), (2) finite fibers (each polynomial has finitely many real roots from finite_real_roots), and (3) countable union (⋃ₙ finite = countable). The hardest step is `algebraic_reals_eq_iUnion_height`, which converts between rational and integer polynomial witnesses using `IsLocalization.integerNormalization`.",
+    "mathContext": "The `integerNormalization` API: given a rational polynomial q (in Polynomial ℚ) with q ≠ 0, `integerNormalization (nonZeroDivisors ℤ) q` returns an integer polynomial p ≠ 0 with the same real roots (`integerNormalization_aeval_eq_zero`). The reverse direction uses `Polynomial.aeval_map_algebraMap` for the scalar tower ℤ → ℚ → ℝ: if aeval x p = 0 for p : Polynomial ℤ, then aeval x (p.map (algebraMap ℤ ℚ)) = 0.",
+    "significance": "high",
+    "relatedConcepts": [
+      "IsLocalization.integerNormalization",
+      "IsFractionRing.integerNormalization_eq_zero_iff",
+      "Set.Finite.iUnion",
+      "Set.countable_iUnion"
+    ],
+    "prerequisites": [
+      "IsAlgebraic ℚ x: x is a root of a nonzero rational polynomial",
+      "integerNormalization for fraction rings",
+      "Polynomial.aeval_map_algebraMap (scalar tower)"
+    ]
+  },
+  {
+    "id": "ann-oq05-comparison",
+    "proofId": "algebraic-numbers-countable-oq-05",
+    "range": {
+      "startLine": 1,
+      "endLine": 44
+    },
+    "type": "concept",
+    "title": "Historical Significance: Finite vs. Countable Strata",
+    "content": "The module docstring explains the key distinction from the main gallery proof. `AlgebraicNumbersCountable.lean` stratifies by DEGREE: polynomials of degree n form a countably infinite set (countably many coefficient choices for n+1 unbounded integers). This gives a countable index set over countable strata. Cantor's original approach stratifies by HEIGHT: polynomials of height ≤ h form a FINITE set. This gives a countable index over FINITE strata, which is more constructive and historically accurate.",
+    "mathContext": "Degree stratification: polynomials of degree n ↔ leading coefficient nonzero; countably many coefficient vectors in ℤⁿ⁺¹ → countably infinite stratum. Height stratification: polynomials of height ≤ h ↔ degree ≤ h AND each |aᵢ| ≤ h → finite stratum (product of finite sets). The difference matters for constructivity: finite strata can be explicitly enumerated by a finite algorithm.",
+    "significance": "medium",
+    "relatedConcepts": [
+      "countability via degree",
+      "countability via height",
+      "constructive mathematics",
+      "Cantor 1874"
+    ],
+    "prerequisites": [
+      "Countability vs. finiteness",
+      "History of Cantor's work"
+    ]
+  },
+  {
+    "id": "ann-oq05-poly-eq-fin-sum",
+    "proofId": "algebraic-numbers-countable-oq-05",
+    "range": {
+      "startLine": 114,
+      "endLine": 128
+    },
+    "type": "technique",
+    "title": "Polynomial Reconstruction from Coefficient Tuple",
+    "content": "The auxiliary lemma `poly_eq_fin_sum` shows that any polynomial p with degree ≤ h equals its truncated Fin sum: p = ∑ i : Fin(h+1), C(p.coeff i) * X^i. This is needed for the injection in `finite_polys_of_height`: we need to show that the polynomial p equals the polynomial reconstructed from its coefficient tuple. The proof uses `Fin.sum_univ_eq_sum_range` to convert the Fin sum to a range sum, then `Finset.sum_ite_eq'` to evaluate the sum at each coefficient index.",
+    "mathContext": "The proof: (coeff n of ∑ i : Fin(h+1), C(p.coeff i) * X^i) = ∑ i : Fin(h+1), if n = i then p.coeff i else 0 = if n < h+1 then p.coeff n else 0. For n < h+1 (i.e., n ≤ h ≥ degree): this is p.coeff n. For n ≥ h+1 (i.e., n > degree): p.coeff n = 0 by Polynomial.coeff_eq_zero_of_natDegree_lt.",
+    "significance": "medium",
+    "relatedConcepts": [
+      "Fin.sum_univ_eq_sum_range",
+      "Finset.sum_ite_eq'",
+      "Polynomial.coeff_eq_zero_of_natDegree_lt",
+      "polynomial extensionality"
+    ],
+    "prerequisites": [
+      "Polynomial.ext: polynomials are equal iff all coefficients equal",
+      "Finset.sum_ite_eq': sum of indicator function equals element at index"
+    ]
+  },
+  {
+    "id": "ann-oq05-card",
+    "proofId": "algebraic-numbers-countable-oq-05",
+    "range": {
+      "startLine": 248,
+      "endLine": 266
+    },
+    "type": "concept",
+    "title": "Structural Properties: Filtration, Cardinality, Explicit Characterization",
+    "content": "The three final theorems add structure to the main countability result. `algebraicRealsOfHeight_mono` shows the strata nest: height-h ⊆ height-(h+1), making this a genuine filtration. `card_algebraic_reals_eq_aleph0` computes the cardinality using Mathlib's black-box result for countable char-0 fields. `finite_algebraicReals_bounded_height` provides an explicit predicate version, making the polynomial witnesses visible in the statement.",
+    "mathContext": "Monotonicity: Nat.le_succ_of_le upgrades the height bound h ≤ h to h ≤ h+1. Cardinality: Algebraic.cardinalMk_of_countable_of_charZero is Mathlib's general theorem that algebraic extensions of countable char-0 fields have cardinality ℵ₀. The explicit bounded-height theorem unfolds the iUnion definition to expose the ∃ p : Polynomial ℤ witnesses.",
+    "significance": "low",
+    "relatedConcepts": [
+      "filtration",
+      "Cardinal.aleph0",
+      "Algebraic.cardinalMk_of_countable_of_charZero",
+      "Set.Finite.subset"
+    ],
+    "prerequisites": [
+      "Nat.le_succ_of_le",
+      "Cardinal arithmetic"
+    ]
+  }
+]

--- a/src/data/proofs/algebraic-numbers-countable-oq-05/index.ts
+++ b/src/data/proofs/algebraic-numbers-countable-oq-05/index.ts
@@ -1,0 +1,37 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AlgebraicNumbersCountableOQ05.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const algebraicNumbersCountableOQ05Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections ?? [],
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const algebraicNumbersCountableOQ05Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const algebraicNumbersCountableOQ05Data: ProofData = {
+  proof: algebraicNumbersCountableOQ05Proof,
+  annotations: algebraicNumbersCountableOQ05Annotations,
+  tacticStates: [],
+}

--- a/src/data/proofs/algebraic-numbers-countable-oq-05/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-05/meta.json
@@ -1,0 +1,159 @@
+{
+  "id": "algebraic-numbers-countable-oq-05",
+  "title": "Cantor's 1874 Height Function Proof of Algebraic Number Countability",
+  "slug": "algebraic-numbers-countable-oq-05",
+  "description": "Formalizes Cantor's original 1874 proof that the algebraic reals are countable, using the HEIGHT FUNCTION H(p) = deg(p) + ∑|aᵢ|. The key result is that each height stratum is FINITE (not just countable), making this a particularly constructive and elegant argument. 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026-04-26",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AlgebraicNumbersCountableOQ05.lean",
+    "tags": [
+      "set-theory",
+      "countability",
+      "algebraic-numbers",
+      "cardinality",
+      "cantor",
+      "historical",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 296,
+    "theoremCount": 12,
+    "definitionCount": 2,
+    "dateAdded": "2026-04-26",
+    "assumptions": "",
+    "originalContributions": [
+      "cantorHeight: The Cantor height function H(p) = natDegree(p) + ∑ᵢ |pᵢ| on integer polynomials",
+      "cantorHeight_degree_le: natDegree(p) ≤ H(p) — degree is bounded by height",
+      "cantorHeight_coeff_le: |p.coeff i| ≤ H(p) for all i — each coefficient is bounded by height",
+      "finite_polys_of_height: {p : Polynomial ℤ | H(p) ≤ h} is finite for each h — the key finiteness theorem",
+      "finite_real_roots: each nonzero integer polynomial has finitely many real roots",
+      "algebraicRealsOfHeight: the height-stratified family of real algebraic numbers",
+      "finite_algebraicRealsOfHeight: each height stratum algebraicRealsOfHeight(h) is FINITE",
+      "algebraic_reals_eq_iUnion_height: IsAlgebraic ℚ x ↔ x ∈ ⋃ₕ algebraicRealsOfHeight(h)",
+      "algebraic_reals_countable_via_height: the algebraic reals are countable (main theorem)",
+      "algebraicRealsOfHeight_mono: the filtration is monotone — height strata nest",
+      "card_algebraic_reals_eq_aleph0: #(algebraic reals) = ℵ₀",
+      "finite_algebraicReals_bounded_height: explicit characterization of height-bounded algebraic reals"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Georg Cantor's 1874 paper 'Über eine Eigenschaft des Inbegriffes aller reellen algebraischen Zahlen' (On a Property of the Collection of All Real Algebraic Numbers) introduced the height function as a tool to count algebraic numbers. This was one of the first rigorous applications of cardinality reasoning and marks the birth of set theory.\n\nCantor's insight was simple yet profound: assign a natural number H(p) to each integer polynomial p — the 'height' — in such a way that only finitely many polynomials have any given height. Then, since each polynomial has finitely many roots, the algebraic numbers of bounded height form a finite set. The algebraic numbers as a whole are a countable union of these finite sets.\n\nThe height function Cantor chose was H(a₀ + a₁X + ··· + aₙXⁿ) = n + |a₀| + |a₁| + ··· + |aₙ|. This elegant choice ensures:\n- Bounded height → bounded degree AND bounded coefficients\n- Finitely many integer polynomials of each height\n- Combined with the finite-roots theorem: finitely many algebraic reals of each height\n\nThis 1874 paper appeared just one year before Cantor's diagonal argument (1875/1891), and represents the 'constructive' half of Cantor's revolution: algebraic numbers are countable (enumerable), while real numbers are not (uncountable via diagonalization).",
+    "problemStatement": "**The Cantor Height Function**: For an integer polynomial p = a₀ + a₁X + ··· + aₙXⁿ, define:\n\n  H(p) = n + |a₀| + |a₁| + ··· + |aₙ|\n\n**Open Question**: Can we formalize Cantor's original 1874 proof that uses the height function to stratify algebraic reals into **finite** strata (not just countable), giving a more constructive proof of countability?\n\n**Main Theorem**: The algebraic real numbers are countable, with the explicit decomposition:\n\n  {x : ℝ | IsAlgebraic ℚ x} = ⋃ₕ {roots of integer polys with height ≤ h}\n\nEach set on the right is **finite** (the key finiteness, stronger than countability).",
+    "proofStrategy": "The proof proceeds in four steps:\n\n**Step 1: Height bounds degree and coefficients.** For any polynomial p with H(p) ≤ h:\n- natDegree(p) ≤ h (the degree is at most h)\n- |p.coeff i| ≤ h for each coefficient i (each coefficient fits in [-h, h])\n\n**Step 2: Finitely many polynomials of bounded height.** Polynomials with H(p) ≤ h are determined by:\n- Their degree (at most h+1 choices: 0, 1, ..., h)\n- Their coefficients (each in the finite set {-h, ..., h}, and there are at most h+1 coefficients)\n\nThis injects height-≤h polynomials into the finite Fintype `Fin(h+1) → Icc(-h, h)`, proving finiteness.\n\n**Step 3: Finite real roots per polynomial.** Each nonzero integer polynomial of degree n has at most n real roots (from `Polynomial.setOf_isRoot_finite`).\n\n**Step 4: Height stratification gives countability.** For each h, let `algebraicRealsOfHeight(h)` = roots of all height-≤h polynomials. By Steps 2 and 3, this is a finite union of finite sets = finite. The algebraic reals = ⋃ₕ algebraicRealsOfHeight(h) = countable union of finite sets = countable.\n\n**Comparison with the main gallery proof**: The proof in `AlgebraicNumbersCountable.lean` stratifies by polynomial **degree** (giving countably infinite strata — polynomials of each degree are countably many). Cantor's height approach gives **finite** strata (polynomials of each height are finitely many). The height approach is more constructive: for each h, one can in principle enumerate all height-h algebraic reals in finite time.",
+    "keyInsights": [
+      "The height function H(p) = deg(p) + ∑|aᵢ| is the key combinatorial device: bounded height implies both bounded degree AND bounded coefficient size, making the stratum finite rather than just countable. Stratifying by degree alone (the other approach) would give countably infinite strata.",
+      "The proof of `finite_polys_of_height` works by building an explicit injection: each polynomial with H(p) ≤ h maps to its coefficient tuple (p.coeff 0, ..., p.coeff h), where each coefficient lies in the finite set Icc(-h, h) and the polynomial is determined by its first h+1 coefficients (since degree ≤ h). This injection maps into the Fintype `Fin(h+1) → Icc(-h, h)`, a finite type.",
+      "The `algebraic_reals_eq_iUnion_height` theorem requires a non-trivial step: converting a rational polynomial witness for algebraic-over-ℚ into an integer polynomial witness (clearing denominators). This uses Mathlib's `IsLocalization.integerNormalization` for the fraction ring ℤ ⊆ ℚ. The reverse direction uses `Polynomial.aeval_map_algebraMap` (scalar tower).",
+      "The final countability follows from `Set.countable_iUnion` applied to the countably-indexed family of finite sets. Each set is countable because it's finite (`Set.Finite.countable`). The union over a countable index set (ℕ) preserves countability.",
+      "The monotonicity lemma `algebraicRealsOfHeight_mono` shows the strata form a nested filtration: height-h stratum ⊆ height-(h+1) stratum. Every algebraic number eventually appears in some stratum (algebraic_reals_eq_iUnion_height shows the union is all algebraic reals).",
+      "The `card_algebraic_reals_eq_aleph0` theorem uses Mathlib's `Algebraic.cardinalMk_of_countable_of_charZero` directly — a black-box result. This demonstrates that Mathlib now has robust infrastructure for algebraic number theory."
+    ],
+    "prerequisites": [
+      "AlgebraicNumbersCountable: the main gallery proof (parent) — countability via degree stratification",
+      "Polynomial.setOf_isRoot_finite: finitely many real roots for nonzero polynomials",
+      "IsLocalization.integerNormalization_aeval_eq_zero: clearing denominators preserves roots",
+      "Polynomial.aeval_map_algebraMap: scalar tower for aeval under ring maps",
+      "Set.Finite.iUnion: finite union of finite sets is finite",
+      "Set.countable_iUnion: countable union of countable sets is countable"
+    ],
+    "furtherWork": "This proof opens several natural follow-up questions: (1) Can we make the height enumeration fully computable, producing an explicit bijection ℕ ↔ algebraic reals? (2) Can we bound the number of algebraic reals of height exactly h (not just ≤ h)? (3) Does a similar height argument work for algebraic complex numbers or p-adic algebraic numbers? (4) The height function also appears in Mahler's measure — can we connect these two appearances?"
+  },
+  "sections": [
+    {
+      "id": "height-function",
+      "title": "§1–2: The Cantor Height Function",
+      "startLine": 46,
+      "endLine": 108,
+      "summary": "Defines cantorHeight p = natDegree p + ∑ᵢ |p.coeff i|. Proves: degree ≤ height (cantorHeight_degree_le), coefficient sum ≤ height (cantorHeight_sum_le), each |coeff i| ≤ height (cantorHeight_coeff_le), and nonzero polynomials have positive height (cantorHeight_pos_of_ne_zero).",
+      "mathContext": "The height function maps Polynomial ℤ → ℕ. The four basic properties are proved by simple arithmetic: the height is the sum of degree and coefficient-norms, so each summand is ≤ the total. For coefficients beyond natDegree, Polynomial.coeff_eq_zero_of_natDegree_lt gives coeff = 0."
+    },
+    {
+      "id": "finiteness",
+      "title": "§3: Finiteness of Polynomials of Bounded Height",
+      "startLine": 110,
+      "endLine": 152,
+      "summary": "finite_polys_of_height: {p | H(p) ≤ h} is finite. Proof via injection into Fin(h+1) → Icc(-h,h) (a Fintype). The auxiliary poly_eq_fin_sum shows p equals its truncated sum of terms through degree h.",
+      "mathContext": "Key Lean pattern: Set.Finite.subset (Set.finite_range f) where f maps the Fintype to Polynomial ℤ. The Fintype is (Fin(h+1) → ↥Icc(-h:ℤ, h)) — coefficient tuples with each entry in the bounded interval. The witness for each p is its coefficient function, bounded by cantorHeight_coeff_le."
+    },
+    {
+      "id": "finite-roots",
+      "title": "§4: Finite Real Roots per Polynomial",
+      "startLine": 154,
+      "endLine": 166,
+      "summary": "finite_real_roots: each nonzero integer polynomial has finitely many real roots. Direct from Polynomial.setOf_isRoot_finite applied to the image in Polynomial ℝ.",
+      "mathContext": "The map algebraMap ℤ ℝ : Polynomial ℤ → Polynomial ℝ preserves nonzero-ness (Polynomial.map_ne_zero). Then setOf_isRoot_finite gives finiteness of {x : ℝ | IsRoot (p.map ...) x}. The convert converts IsRoot into the aeval = 0 formulation."
+    },
+    {
+      "id": "height-strata",
+      "title": "§5–7: Height Stratification and Countability",
+      "startLine": 168,
+      "endLine": 242,
+      "summary": "algebraicRealsOfHeight h = ⋃{p : nonzero with H(p)≤h} roots(p). finite_algebraicRealsOfHeight: finite index × finite fibers = finite. algebraic_reals_eq_iUnion_height: algebraic reals = ⋃ₕ strata (uses integerNormalization). algebraic_reals_countable_via_height: countable union of finite sets = countable.",
+      "mathContext": "The iUnion is over the subtype {q : Polynomial ℤ // q ≠ 0 ∧ H(q) ≤ h}, which is Finite (bounded by finite_polys_of_height). Set.Finite.iUnion requires: (1) Finite index type, (2) each fiber is finite. The direction 'algebraic → in union' uses integerNormalization to clear rational polynomial denominators."
+    },
+    {
+      "id": "structural",
+      "title": "§8: Structural Properties",
+      "startLine": 244,
+      "endLine": 266,
+      "summary": "algebraicRealsOfHeight_mono: monotone filtration (strata nest). card_algebraic_reals_eq_aleph0: #(algebraic reals) = ℵ₀. finite_algebraicReals_bounded_height: explicit version with polynomial witnesses.",
+      "mathContext": "Monotonicity from Nat.le_succ_of_le. Cardinal computation from Algebraic.cardinalMk_of_countable_of_charZero (Mathlib black box for countable fields of char 0). The explicit bounded-height theorem just unfolds the iUnion definition."
+    }
+  ],
+  "conclusion": {
+    "summary": "This formalization completes Cantor's original 1874 proof that the algebraic reals are countable, using the height function H(p) = deg(p) + ∑|aᵢ| to stratify algebraic reals into finite (not just countable) strata. All 12 theorems are proved with 0 sorries and 0 axioms, making this a fully verified formalization. The key innovation over the main gallery proof (`AlgebraicNumbersCountable.lean`) is the HEIGHT STRATIFICATION producing finite strata, which is more constructive and historically accurate.",
+    "implications": "The height function proof has two advantages over degree stratification: (1) it gives finite strata (stronger than countable), and (2) it is constructive — for each h, the finitely many height-h algebraic reals can in principle be enumerated. This connects to computational algebra: height bounds appear in algorithms for root isolation, algebraic number arithmetic, and determining algebraic independence.\n\nThe finiteness of height strata has applications beyond algebraic numbers: any mathematical object that can be 'measured' by a height function with finite level sets can be enumerated. This principle appears in Diophantine geometry (Weil heights for rational points on varieties), algebraic combinatorics (graded algebras), and coding theory.",
+    "openQuestions": [
+      "Can we make the height enumeration explicit? That is, can we produce a computable bijection ℕ ↔ algebraic reals using the height function?",
+      "Can we bound the size of each height stratum? Specifically, how many real algebraic numbers have Cantor height exactly h?",
+      "The Cantor height H(p) = n + ∑|aᵢ| is one choice. Other heights (Mahler measure, naive height, projective height) have different finiteness properties — can we formalize the equivalence of different height functions for countability?",
+      "Does the proof generalize to algebraic numbers over other fields? For example, algebraic numbers over ℚ(√2) or algebraic p-adic numbers?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "id": "xref-parent",
+      "proofId": "algebraic-numbers-countable",
+      "relationship": "parent",
+      "description": "The main gallery proof of algebraic number countability. Uses degree stratification (countably infinite strata) rather than height stratification (finite strata).",
+      "relevance": "This proof is Cantor's original approach; the parent uses a more modern Mathlib-friendly approach. Together they illustrate two complementary methods."
+    },
+    {
+      "id": "xref-oq02",
+      "proofId": "algebraic-numbers-countable-oq-02",
+      "relationship": "sibling",
+      "description": "ℝ is uncountable via Cantor's diagonal argument. Together with this proof, forms the complete 1874 Cantor picture: algebraic numbers are countable, real numbers are not.",
+      "relevance": "The countability of algebraic numbers (this proof) and uncountability of reals (OQ02) together imply the existence of transcendental numbers — without exhibiting a single one."
+    },
+    {
+      "id": "xref-oq04",
+      "proofId": "algebraic-numbers-countable-oq-04",
+      "relationship": "sibling",
+      "description": "Baker's theorem on linear independence of logarithms. Concerns specific algebraic numbers and their transcendence properties.",
+      "relevance": "Baker's theorem operates on the very numbers whose countability we prove here. The height function appears in Baker's proof via Siegel's lemma."
+    },
+    {
+      "id": "xref-oq02-oq02",
+      "proofId": "algebraic-numbers-countable-oq-02-oq-02",
+      "relationship": "sibling",
+      "description": "Cantor-Bernstein-Schroeder theorem, foundational for comparing infinite cardinalities.",
+      "relevance": "Provides the infrastructure for cardinal arithmetic used in card_algebraic_reals_eq_aleph0."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/AlgebraicNumbersCountableOQ05.lean",
+    "filename": "AlgebraicNumbersCountableOQ05.lean",
+    "lineCount": 296,
+    "theoremCount": 12,
+    "axiomCount": 0,
+    "defCount": 2,
+    "sorryCount": 0,
+    "isAristotle": false,
+    "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AlgebraicNumbersCountableOQ05.lean"
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/algebraic-numbers-countable-oq-05.json
+++ b/src/data/research/problems/algebraic-numbers-countable-oq-05.json
@@ -1,7 +1,7 @@
 {
   "slug": "algebraic-numbers-countable-oq-05",
   "title": "Algebraic Numbers Countable: Cantor Height Function Proof (1874)",
-  "phase": "OBSERVE",
+  "phase": "COMPLETED",
   "status": "active",
   "tier": "C",
   "path": "fast",
@@ -29,11 +29,23 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETE (session 1): Gallery entry created for existing 0-sorry Lean proof. Cantor height function formalized with finite strata (not just countable). All 12 theorems verified.",
+    "builtItems": [
+      "src/data/proofs/algebraic-numbers-countable-oq-05/meta.json — full gallery entry with overview, sections, cross-references",
+      "src/data/proofs/algebraic-numbers-countable-oq-05/annotations.json — 6 annotations",
+      "src/data/proofs/algebraic-numbers-countable-oq-05/index.ts — TypeScript export",
+      "proofs/Proofs.lean — added missing OQ04 and OQ05 imports"
+    ],
+    "insights": [
+      "cantorHeight H(p) = deg(p) + sum|ai| gives finite strata — stronger than degree stratification which gives countable strata",
+      "Key injection: height-≤h polys embed into Fin(h+1) → Icc(-h,h) via coefficient tuple — a Fintype",
+      "algebraic_reals_eq_iUnion_height uses IsLocalization.integerNormalization to clear denominators from ℚ to ℤ polynomials",
+      "Both OQ04 and OQ05 Lean files were missing from proofs/Proofs.lean imports"
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "COMPLETED — no further work needed. Proof is fully verified."
+    ],
     "markdown": "# Knowledge Base: algebraic-numbers-countable-oq-05\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [


### PR DESCRIPTION
## Summary
- Cherry-picked from #12803 (closed due to 14 stale commits causing Lean file conflicts)
- Gallery entry for Cantor 1874 height function proof of countability of algebraic numbers
- Adds meta.json, annotations.json, index.ts for algebraic-numbers-countable-oq-05
- Updates research listing to COMPLETED status

## Test plan
- [ ] `pnpm build` passes
- [ ] Gallery page renders correctly