### PR TITLE
feat(ballot-oq03-oq01-oq02): PARTS XIVc-XXI + PART XXII (8-row hook_walk)

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean
@@ -10013,6 +10013,1619 @@ private lemma hook_walk_identity_sevenRow (μ : YoungDiagram)
               hne_de1, hne_ce2, hne_be3, hne_ae4,
               hne_cd1, hne_bd2, hne_ad3, hne_bc1, hne_ac2, hne_ab1]
   ring
+
+/-! ## PART XXII: hook_walk_identity for exactly-8-row Young diagrams
+
+  For μ with rowLen 8 = 0 and rowLen 7 > 0: direct computation via hookProd_ratio_formula.
+  Uses 7 colLen zones, 36 hookLen lemmas, 8 arm lemmas, then field_simp/ring. -/
+
+/-- colLen(s) = 8 for s < rowLen 7 in an 8-row shape (rowLen 8 = 0). -/
+private lemma eightRow_colLen_lt {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hs : s < μ.rowLen 7) : μ.colLen s = 8 := by
+  apply Nat.le_antisymm
+  · by_contra hlt; push_neg at hlt
+    have h8s : (8, s) ∈ μ := YoungDiagram.mem_iff_lt_colLen.mpr hlt
+    have := YoungDiagram.mem_iff_lt_rowLen.mp h8s; omega
+  · exact YoungDiagram.mem_iff_lt_colLen.mp (YoungDiagram.mem_iff_lt_rowLen.mpr hs)
+
+/-- colLen(s) = 7 for rowLen 7 ≤ s < rowLen 6 in an 8-row shape. -/
+private lemma eightRow_colLen_mid1 {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hs_ge : μ.rowLen 7 ≤ s) (hs_lt : s < μ.rowLen 6) :
+    μ.colLen s = 7 := by
+  apply Nat.le_antisymm
+  · by_contra hlt; push_neg at hlt
+    have h7s : (7, s) ∈ μ := YoungDiagram.mem_iff_lt_colLen.mpr hlt
+    have := YoungDiagram.mem_iff_lt_rowLen.mp h7s; omega
+  · exact YoungDiagram.mem_iff_lt_colLen.mp (YoungDiagram.mem_iff_lt_rowLen.mpr hs_lt)
+
+/-- colLen(s) = 6 for rowLen 6 ≤ s < rowLen 5 in an 8-row shape. -/
+private lemma eightRow_colLen_mid2 {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hs_ge : μ.rowLen 6 ≤ s) (hs_lt : s < μ.rowLen 5) :
+    μ.colLen s = 6 := by
+  apply Nat.le_antisymm
+  · by_contra hlt; push_neg at hlt
+    have h6s : (6, s) ∈ μ := YoungDiagram.mem_iff_lt_colLen.mpr hlt
+    have := YoungDiagram.mem_iff_lt_rowLen.mp h6s; omega
+  · exact YoungDiagram.mem_iff_lt_colLen.mp (YoungDiagram.mem_iff_lt_rowLen.mpr hs_lt)
+
+/-- colLen(s) = 5 for rowLen 5 ≤ s < rowLen 4 in an 8-row shape. -/
+private lemma eightRow_colLen_mid3 {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hs_ge : μ.rowLen 5 ≤ s) (hs_lt : s < μ.rowLen 4) :
+    μ.colLen s = 5 := by
+  apply Nat.le_antisymm
+  · by_contra hlt; push_neg at hlt
+    have h5s : (5, s) ∈ μ := YoungDiagram.mem_iff_lt_colLen.mpr hlt
+    have := YoungDiagram.mem_iff_lt_rowLen.mp h5s; omega
+  · exact YoungDiagram.mem_iff_lt_colLen.mp (YoungDiagram.mem_iff_lt_rowLen.mpr hs_lt)
+
+/-- colLen(s) = 4 for rowLen 4 ≤ s < rowLen 3 in an 8-row shape. -/
+private lemma eightRow_colLen_mid4 {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hs_ge : μ.rowLen 4 ≤ s) (hs_lt : s < μ.rowLen 3) :
+    μ.colLen s = 4 := by
+  apply Nat.le_antisymm
+  · by_contra hlt; push_neg at hlt
+    have h4s : (4, s) ∈ μ := YoungDiagram.mem_iff_lt_colLen.mpr hlt
+    have := YoungDiagram.mem_iff_lt_rowLen.mp h4s; omega
+  · exact YoungDiagram.mem_iff_lt_colLen.mp (YoungDiagram.mem_iff_lt_rowLen.mpr hs_lt)
+
+/-- colLen(s) = 3 for rowLen 3 ≤ s < rowLen 2 in an 8-row shape. -/
+private lemma eightRow_colLen_mid5 {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hs_ge : μ.rowLen 3 ≤ s) (hs_lt : s < μ.rowLen 2) :
+    μ.colLen s = 3 := by
+  apply Nat.le_antisymm
+  · by_contra hlt; push_neg at hlt
+    have h3s : (3, s) ∈ μ := YoungDiagram.mem_iff_lt_colLen.mpr hlt
+    have := YoungDiagram.mem_iff_lt_rowLen.mp h3s; omega
+  · exact YoungDiagram.mem_iff_lt_colLen.mp (YoungDiagram.mem_iff_lt_rowLen.mpr hs_lt)
+
+/-- colLen(s) = 2 for rowLen 2 ≤ s < rowLen 1 in an 8-row shape. -/
+private lemma eightRow_colLen_mid6 {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hs_ge : μ.rowLen 2 ≤ s) (hs_lt : s < μ.rowLen 1) :
+    μ.colLen s = 2 := by
+  apply Nat.le_antisymm
+  · by_contra hlt; push_neg at hlt
+    have h2s : (2, s) ∈ μ := YoungDiagram.mem_iff_lt_colLen.mpr hlt
+    have := YoungDiagram.mem_iff_lt_rowLen.mp h2s; omega
+  · exact YoungDiagram.mem_iff_lt_colLen.mp (YoungDiagram.mem_iff_lt_rowLen.mpr hs_lt)
+
+-- hookLen lemmas: row 7 (1 zone)
+private lemma eightRow_hookLen_row7 {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hmem : (7, s) ∈ μ) :
+    hookLength μ 7 s = μ.rowLen 7 - s := by
+  have hs : s < μ.rowLen 7 := YoungDiagram.mem_iff_lt_rowLen.mp hmem
+  have key := hookLength_add_eq μ hmem
+  rw [eightRow_colLen_lt h8 hs] at key; omega
+
+-- hookLen lemmas: row 6 (2 zones)
+private lemma eightRow_hookLen_row6_lt {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hmem : (6, s) ∈ μ) (hs : s < μ.rowLen 7) :
+    hookLength μ 6 s = μ.rowLen 6 - s + 1 := by
+  have key := hookLength_add_eq μ hmem
+  rw [eightRow_colLen_lt h8 hs] at key; omega
+
+private lemma eightRow_hookLen_row6_ge {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hmem : (6, s) ∈ μ) (hs : μ.rowLen 7 ≤ s) :
+    hookLength μ 6 s = μ.rowLen 6 - s := by
+  have hs_lt : s < μ.rowLen 6 := YoungDiagram.mem_iff_lt_rowLen.mp hmem
+  have key := hookLength_add_eq μ hmem
+  rw [eightRow_colLen_mid1 h8 hs hs_lt] at key; omega
+
+-- hookLen lemmas: row 5 (3 zones)
+private lemma eightRow_hookLen_row5_lt {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hmem : (5, s) ∈ μ) (hs : s < μ.rowLen 7) :
+    hookLength μ 5 s = μ.rowLen 5 - s + 2 := by
+  have key := hookLength_add_eq μ hmem
+  rw [eightRow_colLen_lt h8 hs] at key; omega
+
+private lemma eightRow_hookLen_row5_mid1 {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hmem : (5, s) ∈ μ) (hs_ge : μ.rowLen 7 ≤ s) (hs_lt : s < μ.rowLen 6) :
+    hookLength μ 5 s = μ.rowLen 5 - s + 1 := by
+  have key := hookLength_add_eq μ hmem
+  rw [eightRow_colLen_mid1 h8 hs_ge hs_lt] at key; omega
+
+private lemma eightRow_hookLen_row5_ge {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hmem : (5, s) ∈ μ) (hs : μ.rowLen 6 ≤ s) :
+    hookLength μ 5 s = μ.rowLen 5 - s := by
+  have hs_lt : s < μ.rowLen 5 := YoungDiagram.mem_iff_lt_rowLen.mp hmem
+  have key := hookLength_add_eq μ hmem
+  rw [eightRow_colLen_mid2 h8 hs hs_lt] at key; omega
+
+-- hookLen lemmas: row 4 (4 zones)
+private lemma eightRow_hookLen_row4_lt {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hmem : (4, s) ∈ μ) (hs : s < μ.rowLen 7) :
+    hookLength μ 4 s = μ.rowLen 4 - s + 3 := by
+  have key := hookLength_add_eq μ hmem
+  rw [eightRow_colLen_lt h8 hs] at key; omega
+
+private lemma eightRow_hookLen_row4_mid1 {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hmem : (4, s) ∈ μ) (hs_ge : μ.rowLen 7 ≤ s) (hs_lt : s < μ.rowLen 6) :
+    hookLength μ 4 s = μ.rowLen 4 - s + 2 := by
+  have key := hookLength_add_eq μ hmem
+  rw [eightRow_colLen_mid1 h8 hs_ge hs_lt] at key; omega
+
+private lemma eightRow_hookLen_row4_mid2 {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hmem : (4, s) ∈ μ) (hs_ge : μ.rowLen 6 ≤ s) (hs_lt : s < μ.rowLen 5) :
+    hookLength μ 4 s = μ.rowLen 4 - s + 1 := by
+  have key := hookLength_add_eq μ hmem
+  rw [eightRow_colLen_mid2 h8 hs_ge hs_lt] at key; omega
+
+private lemma eightRow_hookLen_row4_ge {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hmem : (4, s) ∈ μ) (hs : μ.rowLen 5 ≤ s) :
+    hookLength μ 4 s = μ.rowLen 4 - s := by
+  have hs_lt : s < μ.rowLen 4 := YoungDiagram.mem_iff_lt_rowLen.mp hmem
+  have key := hookLength_add_eq μ hmem
+  rw [eightRow_colLen_mid3 h8 hs hs_lt] at key; omega
+
+-- hookLen lemmas: row 3 (5 zones)
+private lemma eightRow_hookLen_row3_lt {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hmem : (3, s) ∈ μ) (hs : s < μ.rowLen 7) :
+    hookLength μ 3 s = μ.rowLen 3 - s + 4 := by
+  have key := hookLength_add_eq μ hmem
+  rw [eightRow_colLen_lt h8 hs] at key; omega
+
+private lemma eightRow_hookLen_row3_mid1 {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hmem : (3, s) ∈ μ) (hs_ge : μ.rowLen 7 ≤ s) (hs_lt : s < μ.rowLen 6) :
+    hookLength μ 3 s = μ.rowLen 3 - s + 3 := by
+  have key := hookLength_add_eq μ hmem
+  rw [eightRow_colLen_mid1 h8 hs_ge hs_lt] at key; omega
+
+private lemma eightRow_hookLen_row3_mid2 {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hmem : (3, s) ∈ μ) (hs_ge : μ.rowLen 6 ≤ s) (hs_lt : s < μ.rowLen 5) :
+    hookLength μ 3 s = μ.rowLen 3 - s + 2 := by
+  have key := hookLength_add_eq μ hmem
+  rw [eightRow_colLen_mid2 h8 hs_ge hs_lt] at key; omega
+
+private lemma eightRow_hookLen_row3_mid3 {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hmem : (3, s) ∈ μ) (hs_ge : μ.rowLen 5 ≤ s) (hs_lt : s < μ.rowLen 4) :
+    hookLength μ 3 s = μ.rowLen 3 - s + 1 := by
+  have key := hookLength_add_eq μ hmem
+  rw [eightRow_colLen_mid3 h8 hs_ge hs_lt] at key; omega
+
+private lemma eightRow_hookLen_row3_ge {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hmem : (3, s) ∈ μ) (hs : μ.rowLen 4 ≤ s) :
+    hookLength μ 3 s = μ.rowLen 3 - s := by
+  have hs_lt : s < μ.rowLen 3 := YoungDiagram.mem_iff_lt_rowLen.mp hmem
+  have key := hookLength_add_eq μ hmem
+  rw [eightRow_colLen_mid4 h8 hs hs_lt] at key; omega
+
+-- hookLen lemmas: row 2 (6 zones)
+private lemma eightRow_hookLen_row2_lt {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hmem : (2, s) ∈ μ) (hs : s < μ.rowLen 7) :
+    hookLength μ 2 s = μ.rowLen 2 - s + 5 := by
+  have key := hookLength_add_eq μ hmem
+  rw [eightRow_colLen_lt h8 hs] at key; omega
+
+private lemma eightRow_hookLen_row2_mid1 {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hmem : (2, s) ∈ μ) (hs_ge : μ.rowLen 7 ≤ s) (hs_lt : s < μ.rowLen 6) :
+    hookLength μ 2 s = μ.rowLen 2 - s + 4 := by
+  have key := hookLength_add_eq μ hmem
+  rw [eightRow_colLen_mid1 h8 hs_ge hs_lt] at key; omega
+
+private lemma eightRow_hookLen_row2_mid2 {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hmem : (2, s) ∈ μ) (hs_ge : μ.rowLen 6 ≤ s) (hs_lt : s < μ.rowLen 5) :
+    hookLength μ 2 s = μ.rowLen 2 - s + 3 := by
+  have key := hookLength_add_eq μ hmem
+  rw [eightRow_colLen_mid2 h8 hs_ge hs_lt] at key; omega
+
+private lemma eightRow_hookLen_row2_mid3 {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hmem : (2, s) ∈ μ) (hs_ge : μ.rowLen 5 ≤ s) (hs_lt : s < μ.rowLen 4) :
+    hookLength μ 2 s = μ.rowLen 2 - s + 2 := by
+  have key := hookLength_add_eq μ hmem
+  rw [eightRow_colLen_mid3 h8 hs_ge hs_lt] at key; omega
+
+private lemma eightRow_hookLen_row2_mid4 {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hmem : (2, s) ∈ μ) (hs_ge : μ.rowLen 4 ≤ s) (hs_lt : s < μ.rowLen 3) :
+    hookLength μ 2 s = μ.rowLen 2 - s + 1 := by
+  have key := hookLength_add_eq μ hmem
+  rw [eightRow_colLen_mid4 h8 hs_ge hs_lt] at key; omega
+
+private lemma eightRow_hookLen_row2_ge {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hmem : (2, s) ∈ μ) (hs : μ.rowLen 3 ≤ s) :
+    hookLength μ 2 s = μ.rowLen 2 - s := by
+  have hs_lt : s < μ.rowLen 2 := YoungDiagram.mem_iff_lt_rowLen.mp hmem
+  have key := hookLength_add_eq μ hmem
+  rw [eightRow_colLen_mid5 h8 hs hs_lt] at key; omega
+
+-- hookLen lemmas: row 1 (7 zones)
+private lemma eightRow_hookLen_row1_lt {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hmem : (1, s) ∈ μ) (hs : s < μ.rowLen 7) :
+    hookLength μ 1 s = μ.rowLen 1 - s + 6 := by
+  have key := hookLength_add_eq μ hmem
+  rw [eightRow_colLen_lt h8 hs] at key; omega
+
+private lemma eightRow_hookLen_row1_mid1 {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hmem : (1, s) ∈ μ) (hs_ge : μ.rowLen 7 ≤ s) (hs_lt : s < μ.rowLen 6) :
+    hookLength μ 1 s = μ.rowLen 1 - s + 5 := by
+  have key := hookLength_add_eq μ hmem
+  rw [eightRow_colLen_mid1 h8 hs_ge hs_lt] at key; omega
+
+private lemma eightRow_hookLen_row1_mid2 {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hmem : (1, s) ∈ μ) (hs_ge : μ.rowLen 6 ≤ s) (hs_lt : s < μ.rowLen 5) :
+    hookLength μ 1 s = μ.rowLen 1 - s + 4 := by
+  have key := hookLength_add_eq μ hmem
+  rw [eightRow_colLen_mid2 h8 hs_ge hs_lt] at key; omega
+
+private lemma eightRow_hookLen_row1_mid3 {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hmem : (1, s) ∈ μ) (hs_ge : μ.rowLen 5 ≤ s) (hs_lt : s < μ.rowLen 4) :
+    hookLength μ 1 s = μ.rowLen 1 - s + 3 := by
+  have key := hookLength_add_eq μ hmem
+  rw [eightRow_colLen_mid3 h8 hs_ge hs_lt] at key; omega
+
+private lemma eightRow_hookLen_row1_mid4 {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hmem : (1, s) ∈ μ) (hs_ge : μ.rowLen 4 ≤ s) (hs_lt : s < μ.rowLen 3) :
+    hookLength μ 1 s = μ.rowLen 1 - s + 2 := by
+  have key := hookLength_add_eq μ hmem
+  rw [eightRow_colLen_mid4 h8 hs_ge hs_lt] at key; omega
+
+private lemma eightRow_hookLen_row1_mid5 {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hmem : (1, s) ∈ μ) (hs_ge : μ.rowLen 3 ≤ s) (hs_lt : s < μ.rowLen 2) :
+    hookLength μ 1 s = μ.rowLen 1 - s + 1 := by
+  have key := hookLength_add_eq μ hmem
+  rw [eightRow_colLen_mid5 h8 hs_ge hs_lt] at key; omega
+
+private lemma eightRow_hookLen_row1_ge {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hmem : (1, s) ∈ μ) (hs : μ.rowLen 2 ≤ s) :
+    hookLength μ 1 s = μ.rowLen 1 - s := by
+  have hs_lt : s < μ.rowLen 1 := YoungDiagram.mem_iff_lt_rowLen.mp hmem
+  have key := hookLength_add_eq μ hmem
+  rw [eightRow_colLen_mid6 h8 hs hs_lt] at key; omega
+
+-- hookLen lemmas: row 0 (8 zones)
+private lemma eightRow_hookLen_row0_lt {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hmem : (0, s) ∈ μ) (hs : s < μ.rowLen 7) :
+    hookLength μ 0 s = μ.rowLen 0 - s + 7 := by
+  have key := hookLength_add_eq μ hmem
+  rw [eightRow_colLen_lt h8 hs] at key; omega
+
+private lemma eightRow_hookLen_row0_mid1 {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hmem : (0, s) ∈ μ) (hs_ge : μ.rowLen 7 ≤ s) (hs_lt : s < μ.rowLen 6) :
+    hookLength μ 0 s = μ.rowLen 0 - s + 6 := by
+  have key := hookLength_add_eq μ hmem
+  rw [eightRow_colLen_mid1 h8 hs_ge hs_lt] at key; omega
+
+private lemma eightRow_hookLen_row0_mid2 {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hmem : (0, s) ∈ μ) (hs_ge : μ.rowLen 6 ≤ s) (hs_lt : s < μ.rowLen 5) :
+    hookLength μ 0 s = μ.rowLen 0 - s + 5 := by
+  have key := hookLength_add_eq μ hmem
+  rw [eightRow_colLen_mid2 h8 hs_ge hs_lt] at key; omega
+
+private lemma eightRow_hookLen_row0_mid3 {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hmem : (0, s) ∈ μ) (hs_ge : μ.rowLen 5 ≤ s) (hs_lt : s < μ.rowLen 4) :
+    hookLength μ 0 s = μ.rowLen 0 - s + 4 := by
+  have key := hookLength_add_eq μ hmem
+  rw [eightRow_colLen_mid3 h8 hs_ge hs_lt] at key; omega
+
+private lemma eightRow_hookLen_row0_mid4 {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hmem : (0, s) ∈ μ) (hs_ge : μ.rowLen 4 ≤ s) (hs_lt : s < μ.rowLen 3) :
+    hookLength μ 0 s = μ.rowLen 0 - s + 3 := by
+  have key := hookLength_add_eq μ hmem
+  rw [eightRow_colLen_mid4 h8 hs_ge hs_lt] at key; omega
+
+private lemma eightRow_hookLen_row0_mid5 {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hmem : (0, s) ∈ μ) (hs_ge : μ.rowLen 3 ≤ s) (hs_lt : s < μ.rowLen 2) :
+    hookLength μ 0 s = μ.rowLen 0 - s + 2 := by
+  have key := hookLength_add_eq μ hmem
+  rw [eightRow_colLen_mid5 h8 hs_ge hs_lt] at key; omega
+
+private lemma eightRow_hookLen_row0_mid6 {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hmem : (0, s) ∈ μ) (hs_ge : μ.rowLen 2 ≤ s) (hs_lt : s < μ.rowLen 1) :
+    hookLength μ 0 s = μ.rowLen 0 - s + 1 := by
+  have key := hookLength_add_eq μ hmem
+  rw [eightRow_colLen_mid6 h8 hs_ge hs_lt] at key; omega
+
+private lemma eightRow_hookLen_row0_ge {μ : YoungDiagram} {s : ℕ}
+    (h8 : μ.rowLen 8 = 0) (hmem : (0, s) ∈ μ) (hs : μ.rowLen 1 ≤ s) :
+    hookLength μ 0 s = μ.rowLen 0 - s := by
+  have hs_lt : s < μ.rowLen 0 := YoungDiagram.mem_iff_lt_rowLen.mp hmem
+  have key := hookLength_add_eq μ hmem
+  have hcol : μ.colLen s = 1 := by
+    apply Nat.le_antisymm
+    · by_contra hlt; push_neg at hlt
+      have h1s : (1, s) ∈ μ := YoungDiagram.mem_iff_lt_colLen.mpr hlt
+      have := YoungDiagram.mem_iff_lt_rowLen.mp h1s; omega
+    · exact YoungDiagram.mem_iff_lt_colLen.mp (YoungDiagram.mem_iff_lt_rowLen.mpr hs_lt)
+  rw [hcol] at key; omega
+
+/-- Bottom corner (7, rowLen 7 - 1) always exists in an 8-row shape. -/
+private lemma eightRow_corner_bot {μ : YoungDiagram} (h8 : μ.rowLen 8 = 0) (h7 : 0 < μ.rowLen 7) :
+    isCorner μ (7, μ.rowLen 7 - 1) := by
+  refine ⟨YoungDiagram.mem_iff_lt_rowLen.mpr (by omega), ?_, ?_⟩
+  · intro h; exact absurd (YoungDiagram.mem_iff_lt_rowLen.mp h) (by omega)
+  · intro h
+    have := YoungDiagram.mem_iff_lt_rowLen.mp h; omega
+
+/-- Corner classification for 8-row shapes: corners are among the 8 possible positions. -/
+private lemma eightRow_corner_cases {μ : YoungDiagram} (h8 : μ.rowLen 8 = 0) (h7 : 0 < μ.rowLen 7)
+    {cell : ℕ × ℕ} (hc : isCorner μ cell) :
+    (cell = (7, μ.rowLen 7 - 1)) ∨
+    (cell = (6, μ.rowLen 6 - 1) ∧ μ.rowLen 7 < μ.rowLen 6) ∨
+    (cell = (5, μ.rowLen 5 - 1) ∧ μ.rowLen 6 < μ.rowLen 5) ∨
+    (cell = (4, μ.rowLen 4 - 1) ∧ μ.rowLen 5 < μ.rowLen 4) ∨
+    (cell = (3, μ.rowLen 3 - 1) ∧ μ.rowLen 4 < μ.rowLen 3) ∨
+    (cell = (2, μ.rowLen 2 - 1) ∧ μ.rowLen 3 < μ.rowLen 2) ∨
+    (cell = (1, μ.rowLen 1 - 1) ∧ μ.rowLen 2 < μ.rowLen 1) ∨
+    (cell = (0, μ.rowLen 0 - 1) ∧ μ.rowLen 1 < μ.rowLen 0) := by
+  obtain ⟨hmem, hnext, hprev⟩ := hc
+  have hrow := YoungDiagram.mem_iff_lt_rowLen.mp hmem
+  obtain ⟨i, j⟩ := cell
+  simp only [Prod.mk.injEq]
+  have hi7 : i ≤ 7 := by
+    by_contra h; push_neg at h
+    have : μ.rowLen 8 > 0 := by
+      calc μ.rowLen 8 ≥ μ.rowLen i := μ.rowLen_anti (by omega) (by omega)
+        _ > 0 := by omega
+    omega
+  have hj : j = μ.rowLen i - 1 := by
+    apply Nat.le_antisymm
+    · by_contra h; push_neg at h
+      have : (i, j + 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+      exact hnext this
+    · have : ¬ (i, j + 1) ∈ μ := hnext
+      by_contra h; push_neg at h
+      have : μ.rowLen i > j + 1 := by omega
+      exact absurd (YoungDiagram.mem_iff_lt_rowLen.mpr this) hnext
+  subst hj
+  interval_cases i
+  · right; right; right; right; right; right; right
+    constructor
+    · rfl
+    · by_contra h; push_neg at h
+      have heq : μ.rowLen 1 = μ.rowLen 0 := Nat.le_antisymm (μ.rowLen_anti 0 1 (by omega)) h
+      have : (1, μ.rowLen 0 - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+      exact hprev this
+  · right; right; right; right; right; right; left
+    constructor
+    · rfl
+    · by_contra h; push_neg at h
+      have heq : μ.rowLen 2 = μ.rowLen 1 := Nat.le_antisymm (μ.rowLen_anti 1 2 (by omega)) h
+      have : (2, μ.rowLen 1 - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+      exact hprev this
+  · right; right; right; right; right; left
+    constructor
+    · rfl
+    · by_contra h; push_neg at h
+      have heq : μ.rowLen 3 = μ.rowLen 2 := Nat.le_antisymm (μ.rowLen_anti 2 3 (by omega)) h
+      have : (3, μ.rowLen 2 - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+      exact hprev this
+  · right; right; right; right; left
+    constructor
+    · rfl
+    · by_contra h; push_neg at h
+      have heq : μ.rowLen 4 = μ.rowLen 3 := Nat.le_antisymm (μ.rowLen_anti 3 4 (by omega)) h
+      have : (4, μ.rowLen 3 - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+      exact hprev this
+  · right; right; right; left
+    constructor
+    · rfl
+    · by_contra h; push_neg at h
+      have heq : μ.rowLen 5 = μ.rowLen 4 := Nat.le_antisymm (μ.rowLen_anti 4 5 (by omega)) h
+      have : (5, μ.rowLen 4 - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+      exact hprev this
+  · right; right; left
+    constructor
+    · rfl
+    · by_contra h; push_neg at h
+      have heq : μ.rowLen 6 = μ.rowLen 5 := Nat.le_antisymm (μ.rowLen_anti 5 6 (by omega)) h
+      have : (6, μ.rowLen 5 - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+      exact hprev this
+  · right; left
+    constructor
+    · rfl
+    · by_contra h; push_neg at h
+      have heq : μ.rowLen 7 = μ.rowLen 6 := Nat.le_antisymm (μ.rowLen_anti 6 7 (by omega)) h
+      have : (7, μ.rowLen 6 - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+      exact hprev this
+  · left; rfl
+
+/-- Card of an 8-row shape equals sum of row lengths. -/
+private lemma eightRow_card {μ : YoungDiagram} (h8 : μ.rowLen 8 = 0) :
+    μ.card = μ.rowLen 0 + μ.rowLen 1 + μ.rowLen 2 + μ.rowLen 3 +
+             μ.rowLen 4 + μ.rowLen 5 + μ.rowLen 6 + μ.rowLen 7 := by
+  have hcells : μ.cells =
+      (Finset.range (μ.rowLen 0)).image (Prod.mk 0) ∪
+      (Finset.range (μ.rowLen 1)).image (Prod.mk 1) ∪
+      (Finset.range (μ.rowLen 2)).image (Prod.mk 2) ∪
+      (Finset.range (μ.rowLen 3)).image (Prod.mk 3) ∪
+      (Finset.range (μ.rowLen 4)).image (Prod.mk 4) ∪
+      (Finset.range (μ.rowLen 5)).image (Prod.mk 5) ∪
+      (Finset.range (μ.rowLen 6)).image (Prod.mk 6) ∪
+      (Finset.range (μ.rowLen 7)).image (Prod.mk 7) := by
+    ext ⟨i, j⟩
+    simp only [YoungDiagram.mem_cells, Finset.mem_union, Finset.mem_image,
+               Finset.mem_range, Prod.mk.injEq]
+    constructor
+    · intro h
+      have hil : i ≤ 7 := by
+        by_contra hlt; push_neg at hlt
+        have : μ.rowLen 8 > 0 := calc
+          μ.rowLen 8 ≥ μ.rowLen i := μ.rowLen_anti (by omega) (by omega)
+          _ > 0 := by
+            have := YoungDiagram.mem_iff_lt_rowLen.mp h; omega
+        omega
+      have hj := YoungDiagram.mem_iff_lt_rowLen.mp h
+      interval_cases i <;> simp_all [Prod.mk.injEq]
+    · rintro (((((((⟨k, hk, rfl, rfl⟩ | ⟨k, hk, rfl, rfl⟩) | ⟨k, hk, rfl, rfl⟩) |
+                   ⟨k, hk, rfl, rfl⟩) | ⟨k, hk, rfl, rfl⟩) | ⟨k, hk, rfl, rfl⟩) |
+                 ⟨k, hk, rfl, rfl⟩) | ⟨k, hk, rfl, rfl⟩)
+      all_goals exact YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+  have mk_inj : ∀ (n : ℕ), Function.Injective (Prod.mk n) := fun _ _ _ h => (Prod.mk.inj h).2
+  have hd01 : Disjoint ((Finset.range (μ.rowLen 0)).image (Prod.mk 0))
+                       ((Finset.range (μ.rowLen 1)).image (Prod.mk 1)) :=
+    Finset.disjoint_left.mpr fun x hx hy => by
+      simp only [Finset.mem_image, Finset.mem_range, Prod.mk.injEq] at hx hy
+      obtain ⟨_, _, rfl, rfl⟩ := hx; obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+  have hd012 : Disjoint ((Finset.range (μ.rowLen 0)).image (Prod.mk 0) ∪
+                         (Finset.range (μ.rowLen 1)).image (Prod.mk 1))
+                        ((Finset.range (μ.rowLen 2)).image (Prod.mk 2)) :=
+    Finset.disjoint_left.mpr fun x hx hy => by
+      simp only [Finset.mem_union, Finset.mem_image, Finset.mem_range, Prod.mk.injEq] at hx hy
+      obtain (⟨_, _, rfl, rfl⟩ | ⟨_, _, rfl, rfl⟩) := hx
+      · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+      · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+  have hd0123 : Disjoint ((Finset.range (μ.rowLen 0)).image (Prod.mk 0) ∪
+                          (Finset.range (μ.rowLen 1)).image (Prod.mk 1) ∪
+                          (Finset.range (μ.rowLen 2)).image (Prod.mk 2))
+                         ((Finset.range (μ.rowLen 3)).image (Prod.mk 3)) :=
+    Finset.disjoint_left.mpr fun x hx hy => by
+      simp only [Finset.mem_union, Finset.mem_image, Finset.mem_range, Prod.mk.injEq] at hx hy
+      obtain ((⟨_, _, rfl, rfl⟩ | ⟨_, _, rfl, rfl⟩) | ⟨_, _, rfl, rfl⟩) := hx
+      · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+      · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+      · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+  have hd01234 : Disjoint ((Finset.range (μ.rowLen 0)).image (Prod.mk 0) ∪
+                           (Finset.range (μ.rowLen 1)).image (Prod.mk 1) ∪
+                           (Finset.range (μ.rowLen 2)).image (Prod.mk 2) ∪
+                           (Finset.range (μ.rowLen 3)).image (Prod.mk 3))
+                          ((Finset.range (μ.rowLen 4)).image (Prod.mk 4)) :=
+    Finset.disjoint_left.mpr fun x hx hy => by
+      simp only [Finset.mem_union, Finset.mem_image, Finset.mem_range, Prod.mk.injEq] at hx hy
+      obtain (((⟨_, _, rfl, rfl⟩ | ⟨_, _, rfl, rfl⟩) | ⟨_, _, rfl, rfl⟩) |
+               ⟨_, _, rfl, rfl⟩) := hx
+      · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+      · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+      · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+      · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+  have hd012345 : Disjoint ((Finset.range (μ.rowLen 0)).image (Prod.mk 0) ∪
+                            (Finset.range (μ.rowLen 1)).image (Prod.mk 1) ∪
+                            (Finset.range (μ.rowLen 2)).image (Prod.mk 2) ∪
+                            (Finset.range (μ.rowLen 3)).image (Prod.mk 3) ∪
+                            (Finset.range (μ.rowLen 4)).image (Prod.mk 4))
+                           ((Finset.range (μ.rowLen 5)).image (Prod.mk 5)) :=
+    Finset.disjoint_left.mpr fun x hx hy => by
+      simp only [Finset.mem_union, Finset.mem_image, Finset.mem_range, Prod.mk.injEq] at hx hy
+      obtain ((((⟨_, _, rfl, rfl⟩ | ⟨_, _, rfl, rfl⟩) | ⟨_, _, rfl, rfl⟩) |
+                ⟨_, _, rfl, rfl⟩) | ⟨_, _, rfl, rfl⟩) := hx
+      · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+      · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+      · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+      · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+      · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+  have hd0123456 : Disjoint ((Finset.range (μ.rowLen 0)).image (Prod.mk 0) ∪
+                             (Finset.range (μ.rowLen 1)).image (Prod.mk 1) ∪
+                             (Finset.range (μ.rowLen 2)).image (Prod.mk 2) ∪
+                             (Finset.range (μ.rowLen 3)).image (Prod.mk 3) ∪
+                             (Finset.range (μ.rowLen 4)).image (Prod.mk 4) ∪
+                             (Finset.range (μ.rowLen 5)).image (Prod.mk 5))
+                            ((Finset.range (μ.rowLen 6)).image (Prod.mk 6)) :=
+    Finset.disjoint_left.mpr fun x hx hy => by
+      simp only [Finset.mem_union, Finset.mem_image, Finset.mem_range, Prod.mk.injEq] at hx hy
+      obtain (((((⟨_, _, rfl, rfl⟩ | ⟨_, _, rfl, rfl⟩) | ⟨_, _, rfl, rfl⟩) |
+                 ⟨_, _, rfl, rfl⟩) | ⟨_, _, rfl, rfl⟩) | ⟨_, _, rfl, rfl⟩) := hx
+      · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+      · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+      · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+      · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+      · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+      · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+  have hd01234567 : Disjoint ((Finset.range (μ.rowLen 0)).image (Prod.mk 0) ∪
+                              (Finset.range (μ.rowLen 1)).image (Prod.mk 1) ∪
+                              (Finset.range (μ.rowLen 2)).image (Prod.mk 2) ∪
+                              (Finset.range (μ.rowLen 3)).image (Prod.mk 3) ∪
+                              (Finset.range (μ.rowLen 4)).image (Prod.mk 4) ∪
+                              (Finset.range (μ.rowLen 5)).image (Prod.mk 5) ∪
+                              (Finset.range (μ.rowLen 6)).image (Prod.mk 6))
+                             ((Finset.range (μ.rowLen 7)).image (Prod.mk 7)) :=
+    Finset.disjoint_left.mpr fun x hx hy => by
+      simp only [Finset.mem_union, Finset.mem_image, Finset.mem_range, Prod.mk.injEq] at hx hy
+      obtain ((((((⟨_, _, rfl, rfl⟩ | ⟨_, _, rfl, rfl⟩) | ⟨_, _, rfl, rfl⟩) |
+                  ⟨_, _, rfl, rfl⟩) | ⟨_, _, rfl, rfl⟩) | ⟨_, _, rfl, rfl⟩) |
+               ⟨_, _, rfl, rfl⟩) := hx
+      · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+      · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+      · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+      · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+      · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+      · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+      · obtain ⟨_, _, h, _⟩ := hy; exact absurd h (by norm_num)
+  rw [hcells,
+      Finset.card_union_of_disjoint hd01234567,
+      Finset.card_union_of_disjoint hd0123456,
+      Finset.card_union_of_disjoint hd012345,
+      Finset.card_union_of_disjoint hd01234,
+      Finset.card_union_of_disjoint hd0123,
+      Finset.card_union_of_disjoint hd012,
+      Finset.card_union_of_disjoint hd01,
+      Finset.card_image_of_injective _ (mk_inj 0),
+      Finset.card_image_of_injective _ (mk_inj 1),
+      Finset.card_image_of_injective _ (mk_inj 2),
+      Finset.card_image_of_injective _ (mk_inj 3),
+      Finset.card_image_of_injective _ (mk_inj 4),
+      Finset.card_image_of_injective _ (mk_inj 5),
+      Finset.card_image_of_injective _ (mk_inj 6),
+      Finset.card_image_of_injective _ (mk_inj 7),
+      Finset.card_range, Finset.card_range, Finset.card_range, Finset.card_range,
+      Finset.card_range, Finset.card_range, Finset.card_range, Finset.card_range]
+
+/-- Arm product for corner (7, k-1) in an 8-row shape telescopes to k. -/
+private lemma eightRow_arm_row7 (μ : YoungDiagram) (h8 : μ.rowLen 8 = 0)
+    (hk : isCorner μ (7, μ.rowLen 7 - 1)) :
+    ∏ s ∈ Finset.range (μ.rowLen 7 - 1),
+      ((hookLength μ 7 s : ℚ) / ((hookLength μ 7 s : ℚ) - 1)) =
+    (μ.rowLen 7 : ℚ) := by
+  set k := μ.rowLen 7
+  have hk_pos : 0 < k := by have := YoungDiagram.mem_iff_lt_rowLen.mp hk.1; omega
+  have hconv : ∀ s ∈ Finset.range (k - 1),
+      (hookLength μ 7 s : ℚ) / ((hookLength μ 7 s : ℚ) - 1) =
+      ((k : ℚ) - s) / ((k : ℚ) - s - 1) := by
+    intro s hs
+    have hsc : s < k - 1 := Finset.mem_range.mp hs
+    have hmem : (7, s) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [eightRow_hookLen_row7 h8 hmem]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv]
+  rw [prod_div_telescope k (k - 1) (Nat.sub_lt hk_pos Nat.one_pos)]
+  push_cast; simp [Nat.cast_sub (Nat.one_le_iff_ne_zero.mpr (Nat.pos_iff_ne_zero.mp hk_pos))]
+
+/-- Arm product for corner (6, g-1) in an 8-row shape:
+    ∏ = (g+1)(g-k)/((g-k+1)). -/
+private lemma eightRow_arm_row6 {μ : YoungDiagram} (h8 : μ.rowLen 8 = 0)
+    (hkg : μ.rowLen 7 < μ.rowLen 6) :
+    ∏ s ∈ Finset.range (μ.rowLen 6 - 1),
+      ((hookLength μ 6 s : ℚ) / ((hookLength μ 6 s : ℚ) - 1)) =
+    ((μ.rowLen 6 : ℚ) + 1) * ((μ.rowLen 6 : ℚ) - μ.rowLen 7) /
+    ((μ.rowLen 6 : ℚ) - μ.rowLen 7 + 1) := by
+  set g := μ.rowLen 6; set k := μ.rowLen 7
+  rw [show Finset.range (g - 1) = Finset.range k ∪ Finset.Ico k (g - 1) from by
+    ext s; simp [Finset.mem_Ico]; omega]
+  rw [Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega)]
+  have hconv1 : ∀ s ∈ Finset.range k,
+      (hookLength μ 6 s : ℚ) / ((hookLength μ 6 s : ℚ) - 1) =
+      ((g : ℚ) + 1 - s) / ((g : ℚ) + 1 - s - 1) := by
+    intro s hs
+    have hsk : s < k := Finset.mem_range.mp hs
+    have hmem : (6, s) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [eightRow_hookLen_row6_lt h8 hmem hsk]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv1, prod_div_telescope (g + 1) k (by omega)]
+  rw [show Finset.Ico k (g - 1) = (Finset.range (g - 1 - k)).image (· + k) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv2 : ∀ t ∈ Finset.range (g - 1 - k),
+      (hookLength μ 6 (t + k) : ℚ) / ((hookLength μ 6 (t + k) : ℚ) - 1) =
+      ((g : ℚ) - k - t) / ((g : ℚ) - k - t - 1) := by
+    intro t ht
+    have htm : t < g - 1 - k := Finset.mem_range.mp ht
+    have hmem : (6, t + k) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [eightRow_hookLen_row6_ge h8 hmem (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv2, prod_div_telescope (g - k) (g - 1 - k) (by omega)]
+  push_cast [Nat.cast_sub hkg.le, Nat.cast_sub (show 1 ≤ g - k by omega)]
+  have hne : (g : ℚ) - k + 1 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < g - k + 1 by omega)
+  field_simp [hne]; ring
+
+/-- Arm product for corner (5, f-1) in an 8-row shape:
+    ∏ = (f+2)(f-k+1)(f-g)/((f-k+2)(f-g+1)). -/
+private lemma eightRow_arm_row5 {μ : YoungDiagram} (h8 : μ.rowLen 8 = 0)
+    (hgf : μ.rowLen 6 < μ.rowLen 5) :
+    ∏ s ∈ Finset.range (μ.rowLen 5 - 1),
+      ((hookLength μ 5 s : ℚ) / ((hookLength μ 5 s : ℚ) - 1)) =
+    ((μ.rowLen 5 : ℚ) + 2) * ((μ.rowLen 5 : ℚ) - μ.rowLen 7 + 1) *
+    ((μ.rowLen 5 : ℚ) - μ.rowLen 6) /
+    (((μ.rowLen 5 : ℚ) - μ.rowLen 7 + 2) * ((μ.rowLen 5 : ℚ) - μ.rowLen 6 + 1)) := by
+  set f := μ.rowLen 5; set g := μ.rowLen 6; set k := μ.rowLen 7
+  have hkg : k ≤ g := μ.rowLen_anti 6 7 (by omega)
+  rw [show Finset.range (f - 1) = Finset.range k ∪ Finset.Ico k g ∪ Finset.Ico g (f - 1) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega),
+      Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega)]
+  have hconv1 : ∀ s ∈ Finset.range k,
+      (hookLength μ 5 s : ℚ) / ((hookLength μ 5 s : ℚ) - 1) =
+      ((f : ℚ) + 2 - s) / ((f : ℚ) + 2 - s - 1) := by
+    intro s hs
+    have hsk : s < k := Finset.mem_range.mp hs
+    have hmem : (5, s) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [eightRow_hookLen_row5_lt h8 hmem hsk]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv1, prod_div_telescope (f + 2) k (by omega)]
+  rw [show Finset.Ico k g = (Finset.range (g - k)).image (· + k) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv2 : ∀ t ∈ Finset.range (g - k),
+      (hookLength μ 5 (t + k) : ℚ) / ((hookLength μ 5 (t + k) : ℚ) - 1) =
+      ((f : ℚ) - k + 1 - t) / ((f : ℚ) - k + 1 - t - 1) := by
+    intro t ht
+    have htm : t < g - k := Finset.mem_range.mp ht
+    have hmem : (5, t + k) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [eightRow_hookLen_row5_mid1 h8 hmem (by omega) (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv2, prod_div_telescope (f - k + 1) (g - k) (by omega)]
+  rw [show Finset.Ico g (f - 1) = (Finset.range (f - 1 - g)).image (· + g) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv3 : ∀ t ∈ Finset.range (f - 1 - g),
+      (hookLength μ 5 (t + g) : ℚ) / ((hookLength μ 5 (t + g) : ℚ) - 1) =
+      ((f : ℚ) - g - t) / ((f : ℚ) - g - t - 1) := by
+    intro t ht
+    have htm : t < f - 1 - g := Finset.mem_range.mp ht
+    have hmem : (5, t + g) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [eightRow_hookLen_row5_ge h8 hmem (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv3, prod_div_telescope (f - g) (f - 1 - g) (by omega)]
+  push_cast [Nat.cast_sub hkg, Nat.cast_sub hgf.le, Nat.cast_sub (show 1 ≤ f - g by omega)]
+  have hne1 : (f : ℚ) - k + 2 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < f - k + 2 by omega)
+  have hne2 : (f : ℚ) - g + 1 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < f - g + 1 by omega)
+  field_simp [hne1, hne2]; ring
+
+/-- Arm product for corner (4, e-1) in an 8-row shape:
+    ∏ = (e+3)(e-k+2)(e-g+1)(e-f)/((e-k+3)(e-g+2)(e-f+1)). -/
+private lemma eightRow_arm_row4 {μ : YoungDiagram} (h8 : μ.rowLen 8 = 0)
+    (hfe : μ.rowLen 5 < μ.rowLen 4) :
+    ∏ s ∈ Finset.range (μ.rowLen 4 - 1),
+      ((hookLength μ 4 s : ℚ) / ((hookLength μ 4 s : ℚ) - 1)) =
+    ((μ.rowLen 4 : ℚ) + 3) * ((μ.rowLen 4 : ℚ) - μ.rowLen 7 + 2) *
+    ((μ.rowLen 4 : ℚ) - μ.rowLen 6 + 1) * ((μ.rowLen 4 : ℚ) - μ.rowLen 5) /
+    (((μ.rowLen 4 : ℚ) - μ.rowLen 7 + 3) * ((μ.rowLen 4 : ℚ) - μ.rowLen 6 + 2) *
+     ((μ.rowLen 4 : ℚ) - μ.rowLen 5 + 1)) := by
+  set e := μ.rowLen 4; set f := μ.rowLen 5; set g := μ.rowLen 6; set k := μ.rowLen 7
+  have hkg : k ≤ g := μ.rowLen_anti 6 7 (by omega)
+  have hgf : g ≤ f := μ.rowLen_anti 5 6 (by omega)
+  rw [show Finset.range (e - 1) = Finset.range k ∪ Finset.Ico k g ∪
+      Finset.Ico g f ∪ Finset.Ico f (e - 1) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega),
+      Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega),
+      Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega)]
+  have hconv1 : ∀ s ∈ Finset.range k,
+      (hookLength μ 4 s : ℚ) / ((hookLength μ 4 s : ℚ) - 1) =
+      ((e : ℚ) + 3 - s) / ((e : ℚ) + 3 - s - 1) := by
+    intro s hs
+    have hsk : s < k := Finset.mem_range.mp hs
+    have hmem : (4, s) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [eightRow_hookLen_row4_lt h8 hmem hsk]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv1, prod_div_telescope (e + 3) k (by omega)]
+  rw [show Finset.Ico k g = (Finset.range (g - k)).image (· + k) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv2 : ∀ t ∈ Finset.range (g - k),
+      (hookLength μ 4 (t + k) : ℚ) / ((hookLength μ 4 (t + k) : ℚ) - 1) =
+      ((e : ℚ) - k + 2 - t) / ((e : ℚ) - k + 2 - t - 1) := by
+    intro t ht
+    have htm : t < g - k := Finset.mem_range.mp ht
+    have hmem : (4, t + k) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [eightRow_hookLen_row4_mid1 h8 hmem (by omega) (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv2, prod_div_telescope (e - k + 2) (g - k) (by omega)]
+  rw [show Finset.Ico g f = (Finset.range (f - g)).image (· + g) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv3 : ∀ t ∈ Finset.range (f - g),
+      (hookLength μ 4 (t + g) : ℚ) / ((hookLength μ 4 (t + g) : ℚ) - 1) =
+      ((e : ℚ) - g + 1 - t) / ((e : ℚ) - g + 1 - t - 1) := by
+    intro t ht
+    have htm : t < f - g := Finset.mem_range.mp ht
+    have hmem : (4, t + g) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [eightRow_hookLen_row4_mid2 h8 hmem (by omega) (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv3, prod_div_telescope (e - g + 1) (f - g) (by omega)]
+  rw [show Finset.Ico f (e - 1) = (Finset.range (e - 1 - f)).image (· + f) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv4 : ∀ t ∈ Finset.range (e - 1 - f),
+      (hookLength μ 4 (t + f) : ℚ) / ((hookLength μ 4 (t + f) : ℚ) - 1) =
+      ((e : ℚ) - f - t) / ((e : ℚ) - f - t - 1) := by
+    intro t ht
+    have htm : t < e - 1 - f := Finset.mem_range.mp ht
+    have hmem : (4, t + f) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [eightRow_hookLen_row4_ge h8 hmem (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv4, prod_div_telescope (e - f) (e - 1 - f) (by omega)]
+  push_cast [Nat.cast_sub hkg, Nat.cast_sub hgf, Nat.cast_sub hfe.le,
+             Nat.cast_sub (show 1 ≤ e - f by omega)]
+  have hne1 : (e : ℚ) - k + 3 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < e - k + 3 by omega)
+  have hne2 : (e : ℚ) - g + 2 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < e - g + 2 by omega)
+  have hne3 : (e : ℚ) - f + 1 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < e - f + 1 by omega)
+  field_simp [hne1, hne2, hne3]; ring
+
+/-- Arm product for corner (3, d-1) in an 8-row shape:
+    ∏ = (d+4)(d-k+3)(d-g+2)(d-f+1)(d-e)/((d-k+4)(d-g+3)(d-f+2)(d-e+1)). -/
+private lemma eightRow_arm_row3 {μ : YoungDiagram} (h8 : μ.rowLen 8 = 0)
+    (hed : μ.rowLen 4 < μ.rowLen 3) :
+    ∏ s ∈ Finset.range (μ.rowLen 3 - 1),
+      ((hookLength μ 3 s : ℚ) / ((hookLength μ 3 s : ℚ) - 1)) =
+    ((μ.rowLen 3 : ℚ) + 4) * ((μ.rowLen 3 : ℚ) - μ.rowLen 7 + 3) *
+    ((μ.rowLen 3 : ℚ) - μ.rowLen 6 + 2) * ((μ.rowLen 3 : ℚ) - μ.rowLen 5 + 1) *
+    ((μ.rowLen 3 : ℚ) - μ.rowLen 4) /
+    (((μ.rowLen 3 : ℚ) - μ.rowLen 7 + 4) * ((μ.rowLen 3 : ℚ) - μ.rowLen 6 + 3) *
+     ((μ.rowLen 3 : ℚ) - μ.rowLen 5 + 2) * ((μ.rowLen 3 : ℚ) - μ.rowLen 4 + 1)) := by
+  set d := μ.rowLen 3; set e := μ.rowLen 4; set f := μ.rowLen 5
+  set g := μ.rowLen 6; set k := μ.rowLen 7
+  have hkg : k ≤ g := μ.rowLen_anti 6 7 (by omega)
+  have hgf : g ≤ f := μ.rowLen_anti 5 6 (by omega)
+  have hfe : f ≤ e := μ.rowLen_anti 4 5 (by omega)
+  rw [show Finset.range (d - 1) = Finset.range k ∪ Finset.Ico k g ∪
+      Finset.Ico g f ∪ Finset.Ico f e ∪ Finset.Ico e (d - 1) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega),
+      Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega),
+      Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega),
+      Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega)]
+  have hconv1 : ∀ s ∈ Finset.range k,
+      (hookLength μ 3 s : ℚ) / ((hookLength μ 3 s : ℚ) - 1) =
+      ((d : ℚ) + 4 - s) / ((d : ℚ) + 4 - s - 1) := by
+    intro s hs
+    have hsk : s < k := Finset.mem_range.mp hs
+    have hmem : (3, s) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [eightRow_hookLen_row3_lt h8 hmem hsk]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv1, prod_div_telescope (d + 4) k (by omega)]
+  rw [show Finset.Ico k g = (Finset.range (g - k)).image (· + k) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv2 : ∀ t ∈ Finset.range (g - k),
+      (hookLength μ 3 (t + k) : ℚ) / ((hookLength μ 3 (t + k) : ℚ) - 1) =
+      ((d : ℚ) - k + 3 - t) / ((d : ℚ) - k + 3 - t - 1) := by
+    intro t ht
+    have htm : t < g - k := Finset.mem_range.mp ht
+    have hmem : (3, t + k) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [eightRow_hookLen_row3_mid1 h8 hmem (by omega) (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv2, prod_div_telescope (d - k + 3) (g - k) (by omega)]
+  rw [show Finset.Ico g f = (Finset.range (f - g)).image (· + g) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv3 : ∀ t ∈ Finset.range (f - g),
+      (hookLength μ 3 (t + g) : ℚ) / ((hookLength μ 3 (t + g) : ℚ) - 1) =
+      ((d : ℚ) - g + 2 - t) / ((d : ℚ) - g + 2 - t - 1) := by
+    intro t ht
+    have htm : t < f - g := Finset.mem_range.mp ht
+    have hmem : (3, t + g) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [eightRow_hookLen_row3_mid2 h8 hmem (by omega) (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv3, prod_div_telescope (d - g + 2) (f - g) (by omega)]
+  rw [show Finset.Ico f e = (Finset.range (e - f)).image (· + f) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv4 : ∀ t ∈ Finset.range (e - f),
+      (hookLength μ 3 (t + f) : ℚ) / ((hookLength μ 3 (t + f) : ℚ) - 1) =
+      ((d : ℚ) - f + 1 - t) / ((d : ℚ) - f + 1 - t - 1) := by
+    intro t ht
+    have htm : t < e - f := Finset.mem_range.mp ht
+    have hmem : (3, t + f) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [eightRow_hookLen_row3_mid3 h8 hmem (by omega) (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv4, prod_div_telescope (d - f + 1) (e - f) (by omega)]
+  rw [show Finset.Ico e (d - 1) = (Finset.range (d - 1 - e)).image (· + e) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv5 : ∀ t ∈ Finset.range (d - 1 - e),
+      (hookLength μ 3 (t + e) : ℚ) / ((hookLength μ 3 (t + e) : ℚ) - 1) =
+      ((d : ℚ) - e - t) / ((d : ℚ) - e - t - 1) := by
+    intro t ht
+    have htm : t < d - 1 - e := Finset.mem_range.mp ht
+    have hmem : (3, t + e) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [eightRow_hookLen_row3_ge h8 hmem (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv5, prod_div_telescope (d - e) (d - 1 - e) (by omega)]
+  push_cast [Nat.cast_sub hkg, Nat.cast_sub hgf, Nat.cast_sub hfe, Nat.cast_sub hed.le,
+             Nat.cast_sub (show 1 ≤ d - e by omega)]
+  have hne1 : (d : ℚ) - k + 4 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < d - k + 4 by omega)
+  have hne2 : (d : ℚ) - g + 3 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < d - g + 3 by omega)
+  have hne3 : (d : ℚ) - f + 2 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < d - f + 2 by omega)
+  have hne4 : (d : ℚ) - e + 1 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < d - e + 1 by omega)
+  field_simp [hne1, hne2, hne3, hne4]; ring
+
+/-- Arm product for corner (2, c-1) in an 8-row shape:
+    ∏ = (c+5)(c-k+4)(c-g+3)(c-f+2)(c-e+1)(c-d)/((c-k+5)(c-g+4)(c-f+3)(c-e+2)(c-d+1)). -/
+private lemma eightRow_arm_row2 {μ : YoungDiagram} (h8 : μ.rowLen 8 = 0)
+    (hdc : μ.rowLen 3 < μ.rowLen 2) :
+    ∏ s ∈ Finset.range (μ.rowLen 2 - 1),
+      ((hookLength μ 2 s : ℚ) / ((hookLength μ 2 s : ℚ) - 1)) =
+    ((μ.rowLen 2 : ℚ) + 5) * ((μ.rowLen 2 : ℚ) - μ.rowLen 7 + 4) *
+    ((μ.rowLen 2 : ℚ) - μ.rowLen 6 + 3) * ((μ.rowLen 2 : ℚ) - μ.rowLen 5 + 2) *
+    ((μ.rowLen 2 : ℚ) - μ.rowLen 4 + 1) * ((μ.rowLen 2 : ℚ) - μ.rowLen 3) /
+    (((μ.rowLen 2 : ℚ) - μ.rowLen 7 + 5) * ((μ.rowLen 2 : ℚ) - μ.rowLen 6 + 4) *
+     ((μ.rowLen 2 : ℚ) - μ.rowLen 5 + 3) * ((μ.rowLen 2 : ℚ) - μ.rowLen 4 + 2) *
+     ((μ.rowLen 2 : ℚ) - μ.rowLen 3 + 1)) := by
+  set c := μ.rowLen 2; set d := μ.rowLen 3; set e := μ.rowLen 4
+  set f := μ.rowLen 5; set g := μ.rowLen 6; set k := μ.rowLen 7
+  have hkg : k ≤ g := μ.rowLen_anti 6 7 (by omega)
+  have hgf : g ≤ f := μ.rowLen_anti 5 6 (by omega)
+  have hfe : f ≤ e := μ.rowLen_anti 4 5 (by omega)
+  have hed : e ≤ d := μ.rowLen_anti 3 4 (by omega)
+  rw [show Finset.range (c - 1) = Finset.range k ∪ Finset.Ico k g ∪
+      Finset.Ico g f ∪ Finset.Ico f e ∪ Finset.Ico e d ∪ Finset.Ico d (c - 1) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega),
+      Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega),
+      Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega),
+      Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega),
+      Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega)]
+  have hconv1 : ∀ s ∈ Finset.range k,
+      (hookLength μ 2 s : ℚ) / ((hookLength μ 2 s : ℚ) - 1) =
+      ((c : ℚ) + 5 - s) / ((c : ℚ) + 5 - s - 1) := by
+    intro s hs
+    have hsk : s < k := Finset.mem_range.mp hs
+    have hmem : (2, s) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [eightRow_hookLen_row2_lt h8 hmem hsk]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv1, prod_div_telescope (c + 5) k (by omega)]
+  rw [show Finset.Ico k g = (Finset.range (g - k)).image (· + k) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv2 : ∀ t ∈ Finset.range (g - k),
+      (hookLength μ 2 (t + k) : ℚ) / ((hookLength μ 2 (t + k) : ℚ) - 1) =
+      ((c : ℚ) - k + 4 - t) / ((c : ℚ) - k + 4 - t - 1) := by
+    intro t ht
+    have htm : t < g - k := Finset.mem_range.mp ht
+    have hmem : (2, t + k) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [eightRow_hookLen_row2_mid1 h8 hmem (by omega) (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv2, prod_div_telescope (c - k + 4) (g - k) (by omega)]
+  rw [show Finset.Ico g f = (Finset.range (f - g)).image (· + g) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv3 : ∀ t ∈ Finset.range (f - g),
+      (hookLength μ 2 (t + g) : ℚ) / ((hookLength μ 2 (t + g) : ℚ) - 1) =
+      ((c : ℚ) - g + 3 - t) / ((c : ℚ) - g + 3 - t - 1) := by
+    intro t ht
+    have htm : t < f - g := Finset.mem_range.mp ht
+    have hmem : (2, t + g) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [eightRow_hookLen_row2_mid2 h8 hmem (by omega) (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv3, prod_div_telescope (c - g + 3) (f - g) (by omega)]
+  rw [show Finset.Ico f e = (Finset.range (e - f)).image (· + f) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv4 : ∀ t ∈ Finset.range (e - f),
+      (hookLength μ 2 (t + f) : ℚ) / ((hookLength μ 2 (t + f) : ℚ) - 1) =
+      ((c : ℚ) - f + 2 - t) / ((c : ℚ) - f + 2 - t - 1) := by
+    intro t ht
+    have htm : t < e - f := Finset.mem_range.mp ht
+    have hmem : (2, t + f) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [eightRow_hookLen_row2_mid3 h8 hmem (by omega) (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv4, prod_div_telescope (c - f + 2) (e - f) (by omega)]
+  rw [show Finset.Ico e d = (Finset.range (d - e)).image (· + e) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv5 : ∀ t ∈ Finset.range (d - e),
+      (hookLength μ 2 (t + e) : ℚ) / ((hookLength μ 2 (t + e) : ℚ) - 1) =
+      ((c : ℚ) - e + 1 - t) / ((c : ℚ) - e + 1 - t - 1) := by
+    intro t ht
+    have htm : t < d - e := Finset.mem_range.mp ht
+    have hmem : (2, t + e) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [eightRow_hookLen_row2_mid4 h8 hmem (by omega) (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv5, prod_div_telescope (c - e + 1) (d - e) (by omega)]
+  rw [show Finset.Ico d (c - 1) = (Finset.range (c - 1 - d)).image (· + d) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv6 : ∀ t ∈ Finset.range (c - 1 - d),
+      (hookLength μ 2 (t + d) : ℚ) / ((hookLength μ 2 (t + d) : ℚ) - 1) =
+      ((c : ℚ) - d - t) / ((c : ℚ) - d - t - 1) := by
+    intro t ht
+    have htm : t < c - 1 - d := Finset.mem_range.mp ht
+    have hmem : (2, t + d) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [eightRow_hookLen_row2_ge h8 hmem (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv6, prod_div_telescope (c - d) (c - 1 - d) (by omega)]
+  push_cast [Nat.cast_sub hkg, Nat.cast_sub hgf, Nat.cast_sub hfe, Nat.cast_sub hed,
+             Nat.cast_sub hdc.le, Nat.cast_sub (show 1 ≤ c - d by omega)]
+  have hne1 : (c : ℚ) - k + 5 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < c - k + 5 by omega)
+  have hne2 : (c : ℚ) - g + 4 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < c - g + 4 by omega)
+  have hne3 : (c : ℚ) - f + 3 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < c - f + 3 by omega)
+  have hne4 : (c : ℚ) - e + 2 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < c - e + 2 by omega)
+  have hne5 : (c : ℚ) - d + 1 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < c - d + 1 by omega)
+  field_simp [hne1, hne2, hne3, hne4, hne5]; ring
+
+/-- Arm product for corner (1, b-1) in an 8-row shape:
+    ∏ = (b+6)(b-k+5)(b-g+4)(b-f+3)(b-e+2)(b-d+1)(b-c)/
+        ((b-k+6)(b-g+5)(b-f+4)(b-e+3)(b-d+2)(b-c+1)). -/
+private lemma eightRow_arm_row1 {μ : YoungDiagram} (h8 : μ.rowLen 8 = 0)
+    (hcb : μ.rowLen 2 < μ.rowLen 1) :
+    ∏ s ∈ Finset.range (μ.rowLen 1 - 1),
+      ((hookLength μ 1 s : ℚ) / ((hookLength μ 1 s : ℚ) - 1)) =
+    ((μ.rowLen 1 : ℚ) + 6) * ((μ.rowLen 1 : ℚ) - μ.rowLen 7 + 5) *
+    ((μ.rowLen 1 : ℚ) - μ.rowLen 6 + 4) * ((μ.rowLen 1 : ℚ) - μ.rowLen 5 + 3) *
+    ((μ.rowLen 1 : ℚ) - μ.rowLen 4 + 2) * ((μ.rowLen 1 : ℚ) - μ.rowLen 3 + 1) *
+    ((μ.rowLen 1 : ℚ) - μ.rowLen 2) /
+    (((μ.rowLen 1 : ℚ) - μ.rowLen 7 + 6) * ((μ.rowLen 1 : ℚ) - μ.rowLen 6 + 5) *
+     ((μ.rowLen 1 : ℚ) - μ.rowLen 5 + 4) * ((μ.rowLen 1 : ℚ) - μ.rowLen 4 + 3) *
+     ((μ.rowLen 1 : ℚ) - μ.rowLen 3 + 2) * ((μ.rowLen 1 : ℚ) - μ.rowLen 2 + 1)) := by
+  set b := μ.rowLen 1; set c := μ.rowLen 2; set d := μ.rowLen 3
+  set e := μ.rowLen 4; set f := μ.rowLen 5; set g := μ.rowLen 6; set k := μ.rowLen 7
+  have hkg : k ≤ g := μ.rowLen_anti 6 7 (by omega)
+  have hgf : g ≤ f := μ.rowLen_anti 5 6 (by omega)
+  have hfe : f ≤ e := μ.rowLen_anti 4 5 (by omega)
+  have hed : e ≤ d := μ.rowLen_anti 3 4 (by omega)
+  have hdc : d ≤ c := μ.rowLen_anti 2 3 (by omega)
+  rw [show Finset.range (b - 1) = Finset.range k ∪ Finset.Ico k g ∪
+      Finset.Ico g f ∪ Finset.Ico f e ∪ Finset.Ico e d ∪ Finset.Ico d c ∪
+      Finset.Ico c (b - 1) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega),
+      Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega),
+      Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega),
+      Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega),
+      Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega),
+      Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega)]
+  have hconv1 : ∀ s ∈ Finset.range k,
+      (hookLength μ 1 s : ℚ) / ((hookLength μ 1 s : ℚ) - 1) =
+      ((b : ℚ) + 6 - s) / ((b : ℚ) + 6 - s - 1) := by
+    intro s hs
+    have hsk : s < k := Finset.mem_range.mp hs
+    have hmem : (1, s) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [eightRow_hookLen_row1_lt h8 hmem hsk]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv1, prod_div_telescope (b + 6) k (by omega)]
+  rw [show Finset.Ico k g = (Finset.range (g - k)).image (· + k) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv2 : ∀ t ∈ Finset.range (g - k),
+      (hookLength μ 1 (t + k) : ℚ) / ((hookLength μ 1 (t + k) : ℚ) - 1) =
+      ((b : ℚ) - k + 5 - t) / ((b : ℚ) - k + 5 - t - 1) := by
+    intro t ht
+    have htm : t < g - k := Finset.mem_range.mp ht
+    have hmem : (1, t + k) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [eightRow_hookLen_row1_mid1 h8 hmem (by omega) (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv2, prod_div_telescope (b - k + 5) (g - k) (by omega)]
+  rw [show Finset.Ico g f = (Finset.range (f - g)).image (· + g) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv3 : ∀ t ∈ Finset.range (f - g),
+      (hookLength μ 1 (t + g) : ℚ) / ((hookLength μ 1 (t + g) : ℚ) - 1) =
+      ((b : ℚ) - g + 4 - t) / ((b : ℚ) - g + 4 - t - 1) := by
+    intro t ht
+    have htm : t < f - g := Finset.mem_range.mp ht
+    have hmem : (1, t + g) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [eightRow_hookLen_row1_mid2 h8 hmem (by omega) (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv3, prod_div_telescope (b - g + 4) (f - g) (by omega)]
+  rw [show Finset.Ico f e = (Finset.range (e - f)).image (· + f) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv4 : ∀ t ∈ Finset.range (e - f),
+      (hookLength μ 1 (t + f) : ℚ) / ((hookLength μ 1 (t + f) : ℚ) - 1) =
+      ((b : ℚ) - f + 3 - t) / ((b : ℚ) - f + 3 - t - 1) := by
+    intro t ht
+    have htm : t < e - f := Finset.mem_range.mp ht
+    have hmem : (1, t + f) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [eightRow_hookLen_row1_mid3 h8 hmem (by omega) (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv4, prod_div_telescope (b - f + 3) (e - f) (by omega)]
+  rw [show Finset.Ico e d = (Finset.range (d - e)).image (· + e) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv5 : ∀ t ∈ Finset.range (d - e),
+      (hookLength μ 1 (t + e) : ℚ) / ((hookLength μ 1 (t + e) : ℚ) - 1) =
+      ((b : ℚ) - e + 2 - t) / ((b : ℚ) - e + 2 - t - 1) := by
+    intro t ht
+    have htm : t < d - e := Finset.mem_range.mp ht
+    have hmem : (1, t + e) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [eightRow_hookLen_row1_mid4 h8 hmem (by omega) (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv5, prod_div_telescope (b - e + 2) (d - e) (by omega)]
+  rw [show Finset.Ico d c = (Finset.range (c - d)).image (· + d) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv6 : ∀ t ∈ Finset.range (c - d),
+      (hookLength μ 1 (t + d) : ℚ) / ((hookLength μ 1 (t + d) : ℚ) - 1) =
+      ((b : ℚ) - d + 1 - t) / ((b : ℚ) - d + 1 - t - 1) := by
+    intro t ht
+    have htm : t < c - d := Finset.mem_range.mp ht
+    have hmem : (1, t + d) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [eightRow_hookLen_row1_mid5 h8 hmem (by omega) (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv6, prod_div_telescope (b - d + 1) (c - d) (by omega)]
+  rw [show Finset.Ico c (b - 1) = (Finset.range (b - 1 - c)).image (· + c) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv7 : ∀ t ∈ Finset.range (b - 1 - c),
+      (hookLength μ 1 (t + c) : ℚ) / ((hookLength μ 1 (t + c) : ℚ) - 1) =
+      ((b : ℚ) - c - t) / ((b : ℚ) - c - t - 1) := by
+    intro t ht
+    have htm : t < b - 1 - c := Finset.mem_range.mp ht
+    have hmem : (1, t + c) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [eightRow_hookLen_row1_ge h8 hmem (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv7, prod_div_telescope (b - c) (b - 1 - c) (by omega)]
+  push_cast [Nat.cast_sub hkg, Nat.cast_sub hgf, Nat.cast_sub hfe, Nat.cast_sub hed,
+             Nat.cast_sub hdc, Nat.cast_sub hcb.le, Nat.cast_sub (show 1 ≤ b - c by omega)]
+  have hne1 : (b : ℚ) - k + 6 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < b - k + 6 by omega)
+  have hne2 : (b : ℚ) - g + 5 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < b - g + 5 by omega)
+  have hne3 : (b : ℚ) - f + 4 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < b - f + 4 by omega)
+  have hne4 : (b : ℚ) - e + 3 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < b - e + 3 by omega)
+  have hne5 : (b : ℚ) - d + 2 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < b - d + 2 by omega)
+  have hne6 : (b : ℚ) - c + 1 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < b - c + 1 by omega)
+  field_simp [hne1, hne2, hne3, hne4, hne5, hne6]; ring
+
+/-- Arm product for corner (0, a-1) in an 8-row shape:
+    ∏ = (a+7)(a-k+6)(a-g+5)(a-f+4)(a-e+3)(a-d+2)(a-c+1)(a-b)/
+        ((a-k+7)(a-g+6)(a-f+5)(a-e+4)(a-d+3)(a-c+2)(a-b+1)). -/
+private lemma eightRow_arm_row0 {μ : YoungDiagram} (h8 : μ.rowLen 8 = 0)
+    (h7 : 0 < μ.rowLen 7) (hab : μ.rowLen 1 < μ.rowLen 0) :
+    ∏ s ∈ Finset.range (μ.rowLen 0 - 1),
+      ((hookLength μ 0 s : ℚ) / ((hookLength μ 0 s : ℚ) - 1)) =
+    ((μ.rowLen 0 : ℚ) + 7) * ((μ.rowLen 0 : ℚ) - μ.rowLen 7 + 6) *
+    ((μ.rowLen 0 : ℚ) - μ.rowLen 6 + 5) * ((μ.rowLen 0 : ℚ) - μ.rowLen 5 + 4) *
+    ((μ.rowLen 0 : ℚ) - μ.rowLen 4 + 3) * ((μ.rowLen 0 : ℚ) - μ.rowLen 3 + 2) *
+    ((μ.rowLen 0 : ℚ) - μ.rowLen 2 + 1) * ((μ.rowLen 0 : ℚ) - μ.rowLen 1) /
+    (((μ.rowLen 0 : ℚ) - μ.rowLen 7 + 7) * ((μ.rowLen 0 : ℚ) - μ.rowLen 6 + 6) *
+     ((μ.rowLen 0 : ℚ) - μ.rowLen 5 + 5) * ((μ.rowLen 0 : ℚ) - μ.rowLen 4 + 4) *
+     ((μ.rowLen 0 : ℚ) - μ.rowLen 3 + 3) * ((μ.rowLen 0 : ℚ) - μ.rowLen 2 + 2) *
+     ((μ.rowLen 0 : ℚ) - μ.rowLen 1 + 1)) := by
+  set a := μ.rowLen 0; set b := μ.rowLen 1; set c := μ.rowLen 2
+  set d := μ.rowLen 3; set e := μ.rowLen 4; set f := μ.rowLen 5
+  set g := μ.rowLen 6; set k := μ.rowLen 7
+  have hkg : k ≤ g := μ.rowLen_anti 6 7 (by omega)
+  have hgf : g ≤ f := μ.rowLen_anti 5 6 (by omega)
+  have hfe : f ≤ e := μ.rowLen_anti 4 5 (by omega)
+  have hed : e ≤ d := μ.rowLen_anti 3 4 (by omega)
+  have hdc : d ≤ c := μ.rowLen_anti 2 3 (by omega)
+  have hcb : c ≤ b := μ.rowLen_anti 1 2 (by omega)
+  rw [show Finset.range (a - 1) = Finset.range k ∪ Finset.Ico k g ∪
+      Finset.Ico g f ∪ Finset.Ico f e ∪ Finset.Ico e d ∪ Finset.Ico d c ∪
+      Finset.Ico c b ∪ Finset.Ico b (a - 1) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega),
+      Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega),
+      Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega),
+      Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega),
+      Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega),
+      Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega),
+      Finset.prod_union (by simp [Finset.disjoint_left, Finset.mem_Ico]; omega)]
+  have hconv1 : ∀ s ∈ Finset.range k,
+      (hookLength μ 0 s : ℚ) / ((hookLength μ 0 s : ℚ) - 1) =
+      ((a : ℚ) + 7 - s) / ((a : ℚ) + 7 - s - 1) := by
+    intro s hs
+    have hsk : s < k := Finset.mem_range.mp hs
+    have hmem : (0, s) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [eightRow_hookLen_row0_lt h8 hmem hsk]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv1, prod_div_telescope (a + 7) k (by omega)]
+  rw [show Finset.Ico k g = (Finset.range (g - k)).image (· + k) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv2 : ∀ t ∈ Finset.range (g - k),
+      (hookLength μ 0 (t + k) : ℚ) / ((hookLength μ 0 (t + k) : ℚ) - 1) =
+      ((a : ℚ) - k + 6 - t) / ((a : ℚ) - k + 6 - t - 1) := by
+    intro t ht
+    have htm : t < g - k := Finset.mem_range.mp ht
+    have hmem : (0, t + k) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [eightRow_hookLen_row0_mid1 h8 hmem (by omega) (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv2, prod_div_telescope (a - k + 6) (g - k) (by omega)]
+  rw [show Finset.Ico g f = (Finset.range (f - g)).image (· + g) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv3 : ∀ t ∈ Finset.range (f - g),
+      (hookLength μ 0 (t + g) : ℚ) / ((hookLength μ 0 (t + g) : ℚ) - 1) =
+      ((a : ℚ) - g + 5 - t) / ((a : ℚ) - g + 5 - t - 1) := by
+    intro t ht
+    have htm : t < f - g := Finset.mem_range.mp ht
+    have hmem : (0, t + g) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [eightRow_hookLen_row0_mid2 h8 hmem (by omega) (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv3, prod_div_telescope (a - g + 5) (f - g) (by omega)]
+  rw [show Finset.Ico f e = (Finset.range (e - f)).image (· + f) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv4 : ∀ t ∈ Finset.range (e - f),
+      (hookLength μ 0 (t + f) : ℚ) / ((hookLength μ 0 (t + f) : ℚ) - 1) =
+      ((a : ℚ) - f + 4 - t) / ((a : ℚ) - f + 4 - t - 1) := by
+    intro t ht
+    have htm : t < e - f := Finset.mem_range.mp ht
+    have hmem : (0, t + f) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [eightRow_hookLen_row0_mid3 h8 hmem (by omega) (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv4, prod_div_telescope (a - f + 4) (e - f) (by omega)]
+  rw [show Finset.Ico e d = (Finset.range (d - e)).image (· + e) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv5 : ∀ t ∈ Finset.range (d - e),
+      (hookLength μ 0 (t + e) : ℚ) / ((hookLength μ 0 (t + e) : ℚ) - 1) =
+      ((a : ℚ) - e + 3 - t) / ((a : ℚ) - e + 3 - t - 1) := by
+    intro t ht
+    have htm : t < d - e := Finset.mem_range.mp ht
+    have hmem : (0, t + e) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [eightRow_hookLen_row0_mid4 h8 hmem (by omega) (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv5, prod_div_telescope (a - e + 3) (d - e) (by omega)]
+  rw [show Finset.Ico d c = (Finset.range (c - d)).image (· + d) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv6 : ∀ t ∈ Finset.range (c - d),
+      (hookLength μ 0 (t + d) : ℚ) / ((hookLength μ 0 (t + d) : ℚ) - 1) =
+      ((a : ℚ) - d + 2 - t) / ((a : ℚ) - d + 2 - t - 1) := by
+    intro t ht
+    have htm : t < c - d := Finset.mem_range.mp ht
+    have hmem : (0, t + d) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [eightRow_hookLen_row0_mid5 h8 hmem (by omega) (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv6, prod_div_telescope (a - d + 2) (c - d) (by omega)]
+  rw [show Finset.Ico c b = (Finset.range (b - c)).image (· + c) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv7 : ∀ t ∈ Finset.range (b - c),
+      (hookLength μ 0 (t + c) : ℚ) / ((hookLength μ 0 (t + c) : ℚ) - 1) =
+      ((a : ℚ) - c + 1 - t) / ((a : ℚ) - c + 1 - t - 1) := by
+    intro t ht
+    have htm : t < b - c := Finset.mem_range.mp ht
+    have hmem : (0, t + c) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [eightRow_hookLen_row0_mid6 h8 hmem (by omega) (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv7, prod_div_telescope (a - c + 1) (b - c) (by omega)]
+  rw [show Finset.Ico b (a - 1) = (Finset.range (a - 1 - b)).image (· + b) from by
+    ext s; simp [Finset.mem_Ico, Finset.mem_range]; omega]
+  rw [Finset.prod_image (by intro x _ y _ h; omega)]
+  have hconv8 : ∀ t ∈ Finset.range (a - 1 - b),
+      (hookLength μ 0 (t + b) : ℚ) / ((hookLength μ 0 (t + b) : ℚ) - 1) =
+      ((a : ℚ) - b - t) / ((a : ℚ) - b - t - 1) := by
+    intro t ht
+    have htm : t < a - 1 - b := Finset.mem_range.mp ht
+    have hmem : (0, t + b) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [eightRow_hookLen_row0_ge h8 hmem (by omega)]; push_cast; congr 1 <;> push_cast <;> omega
+  rw [Finset.prod_congr rfl hconv8, prod_div_telescope (a - b) (a - 1 - b) (by omega)]
+  push_cast [Nat.cast_sub hkg, Nat.cast_sub hgf, Nat.cast_sub hfe, Nat.cast_sub hed,
+             Nat.cast_sub hdc, Nat.cast_sub hcb, Nat.cast_sub hab.le,
+             Nat.cast_sub (show 1 ≤ a - b by omega)]
+  have hne1 : (a : ℚ) - k + 7 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < a - k + 7 by omega)
+  have hne2 : (a : ℚ) - g + 6 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < a - g + 6 by omega)
+  have hne3 : (a : ℚ) - f + 5 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < a - f + 5 by omega)
+  have hne4 : (a : ℚ) - e + 4 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < a - e + 4 by omega)
+  have hne5 : (a : ℚ) - d + 3 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < a - d + 3 by omega)
+  have hne6 : (a : ℚ) - c + 2 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < a - c + 2 by omega)
+  have hne7 : (a : ℚ) - b + 1 ≠ 0 := by exact_mod_cast (show (0 : ℤ) < a - b + 1 by omega)
+  field_simp [hne1, hne2, hne3, hne4, hne5, hne6, hne7]; ring
+
+
+/-- The hook walk identity for exactly-8-row Young diagrams.
+    Direct computation via hookProd_ratio_formula and telescoping — no HLF used.
+    NON-CIRCULAR: does not call hook_length_formula_Q or hook_walk_identity. -/
+private lemma hook_walk_identity_eightRow (μ : YoungDiagram)
+    (h8 : μ.rowLen 8 = 0) (h7 : 0 < μ.rowLen 7) :
+    ∑ c ∈ (corners μ).attach,
+      ((hookProd μ : ℚ) / (hookProd (removeCorner μ c.val (mem_corners.mp c.prop)) : ℚ))
+    = (μ.card : ℚ) := by
+  set a := μ.rowLen 0; set b := μ.rowLen 1; set c := μ.rowLen 2
+  set d := μ.rowLen 3; set e := μ.rowLen 4; set f := μ.rowLen 5
+  set g := μ.rowLen 6; set k := μ.rowLen 7
+  have hkg : k ≤ g := μ.rowLen_anti 6 7 (by omega)
+  have hgf : g ≤ f := μ.rowLen_anti 5 6 (by omega)
+  have hfe : f ≤ e := μ.rowLen_anti 4 5 (by omega)
+  have hed : e ≤ d := μ.rowLen_anti 3 4 (by omega)
+  have hdc : d ≤ c := μ.rowLen_anti 2 3 (by omega)
+  have hcb : c ≤ b := μ.rowLen_anti 1 2 (by omega)
+  have hba : b ≤ a := μ.rowLen_anti 0 1 (by omega)
+  have hbot : isCorner μ (7, k - 1) := eightRow_corner_bot h8 h7
+  have hcard : (μ.card : ℚ) = (a : ℚ) + b + c + d + e + f + g + k := by
+    exact_mod_cast eightRow_card h8
+  rw [hcard]
+  let ratio : ℕ × ℕ → ℚ := fun x =>
+    if hx : isCorner μ x then (hookProd μ : ℚ) / hookProd (removeCorner μ x hx) else 0
+  have hconvert : ∑ cc ∈ (corners μ).attach,
+        ((hookProd μ : ℚ) / hookProd (removeCorner μ cc.val (mem_corners.mp cc.prop))) =
+      ∑ x ∈ corners μ, ratio x := by
+    rw [← Finset.sum_attach (f := ratio)]
+    apply Finset.sum_congr rfl
+    intro cx _; exact dif_pos (mem_corners.mp cx.2)
+  have hsub : corners μ ⊆
+      ({(7, k - 1), (6, g - 1), (5, f - 1), (4, e - 1), (3, d - 1), (2, c - 1),
+        (1, b - 1), (0, a - 1)} : Finset (ℕ × ℕ)) := by
+    intro x hx
+    simp only [Finset.mem_insert, Finset.mem_singleton]
+    rcases eightRow_corner_cases h8 h7 (mem_corners.mp hx) with
+      heq | ⟨heq, _⟩ | ⟨heq, _⟩ | ⟨heq, _⟩ | ⟨heq, _⟩ | ⟨heq, _⟩ | ⟨heq, _⟩ | ⟨heq, _⟩
+    · left; exact heq
+    · right; left; exact heq
+    · right; right; left; exact heq
+    · right; right; right; left; exact heq
+    · right; right; right; right; left; exact heq
+    · right; right; right; right; right; left; exact heq
+    · right; right; right; right; right; right; left; exact heq
+    · right; right; right; right; right; right; right; exact heq
+  have hext : ∑ x ∈ corners μ, ratio x =
+      ∑ x ∈ ({(7, k - 1), (6, g - 1), (5, f - 1), (4, e - 1), (3, d - 1), (2, c - 1),
+               (1, b - 1), (0, a - 1)} : Finset (ℕ × ℕ)), ratio x := by
+    apply Finset.sum_subset hsub
+    intro x _ hxnc; exact dif_neg (mt mem_corners.mpr hxnc)
+  -- Compute ratio for corner (7, k-1)
+  have hR7 : ratio (7, k - 1) =
+      (k : ℚ) * ((g : ℚ) - k + 2) / ((g : ℚ) - k + 1) *
+      ((f : ℚ) - k + 3) / ((f : ℚ) - k + 2) *
+      ((e : ℚ) - k + 4) / ((e : ℚ) - k + 3) *
+      ((d : ℚ) - k + 5) / ((d : ℚ) - k + 4) *
+      ((c : ℚ) - k + 6) / ((c : ℚ) - k + 5) *
+      ((b : ℚ) - k + 7) / ((b : ℚ) - k + 6) *
+      ((a : ℚ) - k + 8) / ((a : ℚ) - k + 7) := by
+    simp only [ratio, dif_pos hbot]
+    rw [hookProd_ratio_formula hbot]
+    simp only [Prod.fst, Prod.snd]
+    rw [eightRow_arm_row7 μ h8 hbot]
+    have hk1 : k - 1 < k := Nat.sub_lt h7 Nat.one_pos
+    have hmem0 : (0, k - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    have hmem1 : (1, k - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    have hmem2 : (2, k - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    have hmem3 : (3, k - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    have hmem4 : (4, k - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    have hmem5 : (5, k - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    have hmem6 : (6, k - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+    rw [show Finset.range 7 = {0, 1, 2, 3, 4, 5, 6} from by ext m; simp; omega]
+    rw [Finset.prod_insert (by simp), Finset.prod_insert (by simp),
+        Finset.prod_insert (by simp), Finset.prod_insert (by simp),
+        Finset.prod_insert (by simp), Finset.prod_insert (by simp), Finset.prod_singleton]
+    rw [eightRow_hookLen_row0_lt h8 hmem0 hk1,
+        eightRow_hookLen_row1_lt h8 hmem1 hk1,
+        eightRow_hookLen_row2_lt h8 hmem2 hk1,
+        eightRow_hookLen_row3_lt h8 hmem3 hk1,
+        eightRow_hookLen_row4_lt h8 hmem4 hk1,
+        eightRow_hookLen_row5_lt h8 hmem5 hk1,
+        eightRow_hookLen_row6_lt h8 hmem6 hk1]
+    push_cast [Nat.cast_sub (show 1 ≤ k from h7),
+               Nat.cast_sub (show k - 1 ≤ a by omega),
+               Nat.cast_sub (show k - 1 ≤ b by omega),
+               Nat.cast_sub (show k - 1 ≤ c by omega),
+               Nat.cast_sub (show k - 1 ≤ d by omega),
+               Nat.cast_sub (show k - 1 ≤ e by omega),
+               Nat.cast_sub (show k - 1 ≤ f by omega),
+               Nat.cast_sub (show k - 1 ≤ g by omega)]
+    ring
+  -- Compute ratio for corner (6, g-1) [when g > k]
+  have hR6 : ratio (6, g - 1) =
+      ((g : ℚ) + 1) * ((g : ℚ) - k) / ((g : ℚ) - k + 1) *
+      ((f : ℚ) - g + 2) / ((f : ℚ) - g + 1) *
+      ((e : ℚ) - g + 3) / ((e : ℚ) - g + 2) *
+      ((d : ℚ) - g + 4) / ((d : ℚ) - g + 3) *
+      ((c : ℚ) - g + 5) / ((c : ℚ) - g + 4) *
+      ((b : ℚ) - g + 6) / ((b : ℚ) - g + 5) *
+      ((a : ℚ) - g + 7) / ((a : ℚ) - g + 6) := by
+    by_cases hkg' : k < g
+    · have hmid : isCorner μ (6, g - 1) := by
+        refine ⟨YoungDiagram.mem_iff_lt_rowLen.mpr (by omega), ?_, ?_⟩
+        · intro h; exact absurd (YoungDiagram.mem_iff_lt_rowLen.mp h) (by omega)
+        · intro h; exact absurd (YoungDiagram.mem_iff_lt_rowLen.mp h) (by omega)
+      simp only [ratio, dif_pos hmid]
+      rw [hookProd_ratio_formula hmid]
+      simp only [Prod.fst, Prod.snd]
+      rw [eightRow_arm_row6 h8 hkg']
+      have hg1 : g - 1 < g := Nat.sub_lt (by omega) Nat.one_pos
+      have hkg1 : k ≤ g - 1 := by omega
+      have hmem0 : (0, g - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+      have hmem1 : (1, g - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+      have hmem2 : (2, g - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+      have hmem3 : (3, g - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+      have hmem4 : (4, g - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+      have hmem5 : (5, g - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+      rw [show Finset.range 6 = {0, 1, 2, 3, 4, 5} from by ext m; simp; omega]
+      rw [Finset.prod_insert (by simp), Finset.prod_insert (by simp),
+          Finset.prod_insert (by simp), Finset.prod_insert (by simp),
+          Finset.prod_insert (by simp), Finset.prod_singleton]
+      rw [eightRow_hookLen_row0_mid1 h8 hmem0 hkg1 (by omega),
+          eightRow_hookLen_row1_mid1 h8 hmem1 hkg1 (by omega),
+          eightRow_hookLen_row2_mid1 h8 hmem2 hkg1 (by omega),
+          eightRow_hookLen_row3_mid1 h8 hmem3 hkg1 (by omega),
+          eightRow_hookLen_row4_mid1 h8 hmem4 hkg1 (by omega),
+          eightRow_hookLen_row5_mid1 h8 hmem5 hkg1 (by omega)]
+      push_cast [Nat.cast_sub (show 1 ≤ g by omega),
+                 Nat.cast_sub (show g - 1 ≤ a by omega),
+                 Nat.cast_sub (show g - 1 ≤ b by omega),
+                 Nat.cast_sub (show g - 1 ≤ c by omega),
+                 Nat.cast_sub (show g - 1 ≤ d by omega),
+                 Nat.cast_sub (show g - 1 ≤ e by omega),
+                 Nat.cast_sub (show g - 1 ≤ f by omega),
+                 Nat.cast_sub hkg'.le]
+      ring
+    · have hkg_eq : g = k := Nat.le_antisymm (not_lt.mp hkg') hkg
+      have hnotcorner : ¬ isCorner μ (6, g - 1) := by
+        intro ⟨_, _, hbelow⟩
+        exact hbelow (YoungDiagram.mem_iff_lt_rowLen.mpr (by omega))
+      simp only [ratio, dif_neg hnotcorner]
+      have : (g : ℚ) - k = 0 := by rw [hkg_eq]; ring
+      rw [this]; ring
+  -- Compute ratio for corner (5, f-1) [when f > g]
+  have hR5 : ratio (5, f - 1) =
+      ((f : ℚ) + 2) * ((f : ℚ) - k + 1) * ((f : ℚ) - g) /
+      (((f : ℚ) - k + 2) * ((f : ℚ) - g + 1)) *
+      ((e : ℚ) - f + 2) / ((e : ℚ) - f + 1) *
+      ((d : ℚ) - f + 3) / ((d : ℚ) - f + 2) *
+      ((c : ℚ) - f + 4) / ((c : ℚ) - f + 3) *
+      ((b : ℚ) - f + 5) / ((b : ℚ) - f + 4) *
+      ((a : ℚ) - f + 6) / ((a : ℚ) - f + 5) := by
+    by_cases hgf' : g < f
+    · have hmid : isCorner μ (5, f - 1) := by
+        refine ⟨YoungDiagram.mem_iff_lt_rowLen.mpr (by omega), ?_, ?_⟩
+        · intro h; exact absurd (YoungDiagram.mem_iff_lt_rowLen.mp h) (by omega)
+        · intro h; exact absurd (YoungDiagram.mem_iff_lt_rowLen.mp h) (by omega)
+      simp only [ratio, dif_pos hmid]
+      rw [hookProd_ratio_formula hmid]
+      simp only [Prod.fst, Prod.snd]
+      rw [eightRow_arm_row5 h8 hgf']
+      have hf1 : f - 1 < f := Nat.sub_lt (by omega) Nat.one_pos
+      have hgf1 : g ≤ f - 1 := by omega
+      have hmem0 : (0, f - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+      have hmem1 : (1, f - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+      have hmem2 : (2, f - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+      have hmem3 : (3, f - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+      have hmem4 : (4, f - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+      rw [show Finset.range 5 = {0, 1, 2, 3, 4} from by ext m; simp; omega]
+      rw [Finset.prod_insert (by simp), Finset.prod_insert (by simp),
+          Finset.prod_insert (by simp), Finset.prod_insert (by simp), Finset.prod_singleton]
+      rw [eightRow_hookLen_row0_mid2 h8 hmem0 hgf1 (by omega),
+          eightRow_hookLen_row1_mid2 h8 hmem1 hgf1 (by omega),
+          eightRow_hookLen_row2_mid2 h8 hmem2 hgf1 (by omega),
+          eightRow_hookLen_row3_mid2 h8 hmem3 hgf1 (by omega),
+          eightRow_hookLen_row4_mid2 h8 hmem4 hgf1 (by omega)]
+      push_cast [Nat.cast_sub (show 1 ≤ f by omega),
+                 Nat.cast_sub (show f - 1 ≤ a by omega),
+                 Nat.cast_sub (show f - 1 ≤ b by omega),
+                 Nat.cast_sub (show f - 1 ≤ c by omega),
+                 Nat.cast_sub (show f - 1 ≤ d by omega),
+                 Nat.cast_sub (show f - 1 ≤ e by omega),
+                 Nat.cast_sub hgf'.le, Nat.cast_sub hkg]
+      ring
+    · have hgf_eq : f = g := Nat.le_antisymm (not_lt.mp hgf') hgf
+      have hnotcorner : ¬ isCorner μ (5, f - 1) := by
+        intro ⟨_, _, hbelow⟩
+        exact hbelow (YoungDiagram.mem_iff_lt_rowLen.mpr (by omega))
+      simp only [ratio, dif_neg hnotcorner]
+      have : (f : ℚ) - g = 0 := by rw [hgf_eq]; ring
+      rw [this]; ring
+  -- Compute ratio for corner (4, e-1) [when e > f]
+  have hR4 : ratio (4, e - 1) =
+      ((e : ℚ) + 3) * ((e : ℚ) - k + 2) * ((e : ℚ) - g + 1) * ((e : ℚ) - f) /
+      (((e : ℚ) - k + 3) * ((e : ℚ) - g + 2) * ((e : ℚ) - f + 1)) *
+      ((d : ℚ) - e + 2) / ((d : ℚ) - e + 1) *
+      ((c : ℚ) - e + 3) / ((c : ℚ) - e + 2) *
+      ((b : ℚ) - e + 4) / ((b : ℚ) - e + 3) *
+      ((a : ℚ) - e + 5) / ((a : ℚ) - e + 4) := by
+    by_cases hfe' : f < e
+    · have hmid : isCorner μ (4, e - 1) := by
+        refine ⟨YoungDiagram.mem_iff_lt_rowLen.mpr (by omega), ?_, ?_⟩
+        · intro h; exact absurd (YoungDiagram.mem_iff_lt_rowLen.mp h) (by omega)
+        · intro h; exact absurd (YoungDiagram.mem_iff_lt_rowLen.mp h) (by omega)
+      simp only [ratio, dif_pos hmid]
+      rw [hookProd_ratio_formula hmid]
+      simp only [Prod.fst, Prod.snd]
+      rw [eightRow_arm_row4 h8 hfe']
+      have he1 : e - 1 < e := Nat.sub_lt (by omega) Nat.one_pos
+      have hfe1 : f ≤ e - 1 := by omega
+      have hmem0 : (0, e - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+      have hmem1 : (1, e - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+      have hmem2 : (2, e - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+      have hmem3 : (3, e - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+      rw [show Finset.range 4 = {0, 1, 2, 3} from by ext m; simp; omega]
+      rw [Finset.prod_insert (by simp), Finset.prod_insert (by simp),
+          Finset.prod_insert (by simp), Finset.prod_singleton]
+      rw [eightRow_hookLen_row0_mid3 h8 hmem0 hfe1 (by omega),
+          eightRow_hookLen_row1_mid3 h8 hmem1 hfe1 (by omega),
+          eightRow_hookLen_row2_mid3 h8 hmem2 hfe1 (by omega),
+          eightRow_hookLen_row3_mid3 h8 hmem3 hfe1 (by omega)]
+      push_cast [Nat.cast_sub (show 1 ≤ e by omega),
+                 Nat.cast_sub (show e - 1 ≤ a by omega),
+                 Nat.cast_sub (show e - 1 ≤ b by omega),
+                 Nat.cast_sub (show e - 1 ≤ c by omega),
+                 Nat.cast_sub (show e - 1 ≤ d by omega),
+                 Nat.cast_sub hfe'.le, Nat.cast_sub hgf, Nat.cast_sub hkg]
+      ring
+    · have hfe_eq : e = f := Nat.le_antisymm (not_lt.mp hfe') hfe
+      have hnotcorner : ¬ isCorner μ (4, e - 1) := by
+        intro ⟨_, _, hbelow⟩
+        exact hbelow (YoungDiagram.mem_iff_lt_rowLen.mpr (by omega))
+      simp only [ratio, dif_neg hnotcorner]
+      have : (e : ℚ) - f = 0 := by rw [hfe_eq]; ring
+      rw [this]; ring
+  -- Compute ratio for corner (3, d-1) [when d > e]
+  have hR3 : ratio (3, d - 1) =
+      ((d : ℚ) + 4) * ((d : ℚ) - k + 3) * ((d : ℚ) - g + 2) *
+      ((d : ℚ) - f + 1) * ((d : ℚ) - e) /
+      (((d : ℚ) - k + 4) * ((d : ℚ) - g + 3) * ((d : ℚ) - f + 2) *
+       ((d : ℚ) - e + 1)) *
+      ((c : ℚ) - d + 2) / ((c : ℚ) - d + 1) *
+      ((b : ℚ) - d + 3) / ((b : ℚ) - d + 2) *
+      ((a : ℚ) - d + 4) / ((a : ℚ) - d + 3) := by
+    by_cases hed' : e < d
+    · have hmid : isCorner μ (3, d - 1) := by
+        refine ⟨YoungDiagram.mem_iff_lt_rowLen.mpr (by omega), ?_, ?_⟩
+        · intro h; exact absurd (YoungDiagram.mem_iff_lt_rowLen.mp h) (by omega)
+        · intro h; exact absurd (YoungDiagram.mem_iff_lt_rowLen.mp h) (by omega)
+      simp only [ratio, dif_pos hmid]
+      rw [hookProd_ratio_formula hmid]
+      simp only [Prod.fst, Prod.snd]
+      rw [eightRow_arm_row3 h8 hed']
+      have hd1 : d - 1 < d := Nat.sub_lt (by omega) Nat.one_pos
+      have hed1 : e ≤ d - 1 := by omega
+      have hmem0 : (0, d - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+      have hmem1 : (1, d - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+      have hmem2 : (2, d - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+      rw [show Finset.range 3 = {0, 1, 2} from by ext m; simp; omega]
+      rw [Finset.prod_insert (by simp), Finset.prod_insert (by simp), Finset.prod_singleton]
+      rw [eightRow_hookLen_row0_mid4 h8 hmem0 hed1 (by omega),
+          eightRow_hookLen_row1_mid4 h8 hmem1 hed1 (by omega),
+          eightRow_hookLen_row2_mid4 h8 hmem2 hed1 (by omega)]
+      push_cast [Nat.cast_sub (show 1 ≤ d by omega),
+                 Nat.cast_sub (show d - 1 ≤ a by omega),
+                 Nat.cast_sub (show d - 1 ≤ b by omega),
+                 Nat.cast_sub (show d - 1 ≤ c by omega),
+                 Nat.cast_sub hed'.le, Nat.cast_sub hfe, Nat.cast_sub hgf, Nat.cast_sub hkg]
+      ring
+    · have hed_eq : d = e := Nat.le_antisymm (not_lt.mp hed') hed
+      have hnotcorner : ¬ isCorner μ (3, d - 1) := by
+        intro ⟨_, _, hbelow⟩
+        exact hbelow (YoungDiagram.mem_iff_lt_rowLen.mpr (by omega))
+      simp only [ratio, dif_neg hnotcorner]
+      have : (d : ℚ) - e = 0 := by rw [hed_eq]; ring
+      rw [this]; ring
+  -- Compute ratio for corner (2, c-1) [when c > d]
+  have hR2 : ratio (2, c - 1) =
+      ((c : ℚ) + 5) * ((c : ℚ) - k + 4) * ((c : ℚ) - g + 3) *
+      ((c : ℚ) - f + 2) * ((c : ℚ) - e + 1) * ((c : ℚ) - d) /
+      (((c : ℚ) - k + 5) * ((c : ℚ) - g + 4) * ((c : ℚ) - f + 3) *
+       ((c : ℚ) - e + 2) * ((c : ℚ) - d + 1)) *
+      ((b : ℚ) - c + 2) / ((b : ℚ) - c + 1) *
+      ((a : ℚ) - c + 3) / ((a : ℚ) - c + 2) := by
+    by_cases hdc' : d < c
+    · have hmid : isCorner μ (2, c - 1) := by
+        refine ⟨YoungDiagram.mem_iff_lt_rowLen.mpr (by omega), ?_, ?_⟩
+        · intro h; exact absurd (YoungDiagram.mem_iff_lt_rowLen.mp h) (by omega)
+        · intro h; exact absurd (YoungDiagram.mem_iff_lt_rowLen.mp h) (by omega)
+      simp only [ratio, dif_pos hmid]
+      rw [hookProd_ratio_formula hmid]
+      simp only [Prod.fst, Prod.snd]
+      rw [eightRow_arm_row2 h8 hdc']
+      have hc1 : c - 1 < c := Nat.sub_lt (by omega) Nat.one_pos
+      have hdc1 : d ≤ c - 1 := by omega
+      have hmem0 : (0, c - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+      have hmem1 : (1, c - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+      rw [show Finset.range 2 = {0, 1} from by ext m; simp; omega]
+      rw [Finset.prod_insert (by simp), Finset.prod_singleton]
+      rw [eightRow_hookLen_row0_mid5 h8 hmem0 hdc1 (by omega),
+          eightRow_hookLen_row1_mid5 h8 hmem1 hdc1 (by omega)]
+      push_cast [Nat.cast_sub (show 1 ≤ c by omega),
+                 Nat.cast_sub (show c - 1 ≤ a by omega),
+                 Nat.cast_sub (show c - 1 ≤ b by omega),
+                 Nat.cast_sub hdc'.le, Nat.cast_sub hed, Nat.cast_sub hfe,
+                 Nat.cast_sub hgf, Nat.cast_sub hkg]
+      ring
+    · have hdc_eq : c = d := Nat.le_antisymm (not_lt.mp hdc') hdc
+      have hnotcorner : ¬ isCorner μ (2, c - 1) := by
+        intro ⟨_, _, hbelow⟩
+        exact hbelow (YoungDiagram.mem_iff_lt_rowLen.mpr (by omega))
+      simp only [ratio, dif_neg hnotcorner]
+      have : (c : ℚ) - d = 0 := by rw [hdc_eq]; ring
+      rw [this]; ring
+  -- Compute ratio for corner (1, b-1) [when b > c]
+  have hR1 : ratio (1, b - 1) =
+      ((b : ℚ) + 6) * ((b : ℚ) - k + 5) * ((b : ℚ) - g + 4) *
+      ((b : ℚ) - f + 3) * ((b : ℚ) - e + 2) * ((b : ℚ) - d + 1) * ((b : ℚ) - c) /
+      (((b : ℚ) - k + 6) * ((b : ℚ) - g + 5) * ((b : ℚ) - f + 4) *
+       ((b : ℚ) - e + 3) * ((b : ℚ) - d + 2) * ((b : ℚ) - c + 1)) *
+      ((a : ℚ) - b + 2) / ((a : ℚ) - b + 1) := by
+    by_cases hcb' : c < b
+    · have hmid : isCorner μ (1, b - 1) := by
+        refine ⟨YoungDiagram.mem_iff_lt_rowLen.mpr (by omega), ?_, ?_⟩
+        · intro h; exact absurd (YoungDiagram.mem_iff_lt_rowLen.mp h) (by omega)
+        · intro h; exact absurd (YoungDiagram.mem_iff_lt_rowLen.mp h) (by omega)
+      simp only [ratio, dif_pos hmid]
+      rw [hookProd_ratio_formula hmid]
+      simp only [Prod.fst, Prod.snd]
+      rw [eightRow_arm_row1 h8 hcb']
+      have hmem0 : (0, b - 1) ∈ μ := YoungDiagram.mem_iff_lt_rowLen.mpr (by omega)
+      rw [Finset.prod_range_succ, Finset.prod_range_zero, one_mul]
+      rw [eightRow_hookLen_row0_mid6 h8 hmem0 (by omega) (by omega)]
+      push_cast [Nat.cast_sub (show 1 ≤ b by omega),
+                 Nat.cast_sub (show b - 1 ≤ a by omega),
+                 Nat.cast_sub hcb'.le, Nat.cast_sub hdc, Nat.cast_sub hed,
+                 Nat.cast_sub hfe, Nat.cast_sub hgf, Nat.cast_sub hkg]
+      ring
+    · have hcb_eq : b = c := Nat.le_antisymm (not_lt.mp hcb') hcb
+      have hnotcorner : ¬ isCorner μ (1, b - 1) := by
+        intro ⟨_, _, hbelow⟩
+        exact hbelow (YoungDiagram.mem_iff_lt_rowLen.mpr (by omega))
+      simp only [ratio, dif_neg hnotcorner]
+      have : (b : ℚ) - c = 0 := by rw [hcb_eq]; ring
+      rw [this]; ring
+  -- Compute ratio for corner (0, a-1) [when a > b]
+  have hR0 : ratio (0, a - 1) =
+      ((a : ℚ) + 7) * ((a : ℚ) - k + 6) * ((a : ℚ) - g + 5) *
+      ((a : ℚ) - f + 4) * ((a : ℚ) - e + 3) * ((a : ℚ) - d + 2) *
+      ((a : ℚ) - c + 1) * ((a : ℚ) - b) /
+      (((a : ℚ) - k + 7) * ((a : ℚ) - g + 6) * ((a : ℚ) - f + 5) *
+       ((a : ℚ) - e + 4) * ((a : ℚ) - d + 3) * ((a : ℚ) - c + 2) *
+       ((a : ℚ) - b + 1)) := by
+    by_cases hab' : b < a
+    · have htop : isCorner μ (0, a - 1) := by
+        refine ⟨YoungDiagram.mem_iff_lt_rowLen.mpr (by omega), ?_, ?_⟩
+        · intro h; exact absurd (YoungDiagram.mem_iff_lt_rowLen.mp h) (by omega)
+        · intro h; exact absurd (YoungDiagram.mem_iff_lt_rowLen.mp h) (by omega)
+      simp only [ratio, dif_pos htop]
+      rw [hookProd_ratio_formula htop]
+      simp only [Prod.fst, Prod.snd, Finset.prod_range_zero, mul_one]
+      rw [eightRow_arm_row0 h8 h7 hab']
+      push_cast [Nat.cast_sub hab'.le, Nat.cast_sub hcb, Nat.cast_sub hdc,
+                 Nat.cast_sub hed, Nat.cast_sub hfe, Nat.cast_sub hgf, Nat.cast_sub hkg]
+      ring
+    · have hab_eq : a = b := Nat.le_antisymm (not_lt.mp hab') hba
+      have hnotcorner : ¬ isCorner μ (0, a - 1) := by
+        intro ⟨_, _, hbelow⟩
+        exact hbelow (YoungDiagram.mem_iff_lt_rowLen.mpr (by omega))
+      simp only [ratio, dif_neg hnotcorner]
+      have : (a : ℚ) - b = 0 := by rw [hab_eq]; ring
+      rw [this]; ring
+  rw [hconvert, hext]
+  have hne76 : (7, k - 1) ∉ ({(6, g - 1), (5, f - 1), (4, e - 1), (3, d - 1), (2, c - 1),
+      (1, b - 1), (0, a - 1)} : Finset (ℕ × ℕ)) := by simp [Prod.mk.injEq]
+  have hne65 : (6, g - 1) ∉ ({(5, f - 1), (4, e - 1), (3, d - 1), (2, c - 1),
+      (1, b - 1), (0, a - 1)} : Finset (ℕ × ℕ)) := by simp [Prod.mk.injEq]
+  have hne54 : (5, f - 1) ∉ ({(4, e - 1), (3, d - 1), (2, c - 1), (1, b - 1),
+      (0, a - 1)} : Finset (ℕ × ℕ)) := by simp [Prod.mk.injEq]
+  have hne43 : (4, e - 1) ∉ ({(3, d - 1), (2, c - 1), (1, b - 1), (0, a - 1)} :
+      Finset (ℕ × ℕ)) := by simp [Prod.mk.injEq]
+  have hne32 : (3, d - 1) ∉ ({(2, c - 1), (1, b - 1), (0, a - 1)} : Finset (ℕ × ℕ)) := by
+    simp [Prod.mk.injEq]
+  have hne21 : (2, c - 1) ∉ ({(1, b - 1), (0, a - 1)} : Finset (ℕ × ℕ)) := by
+    simp [Prod.mk.injEq]
+  have hne10 : (1, b - 1) ∉ ({(0, a - 1)} : Finset (ℕ × ℕ)) := by simp [Prod.mk.injEq]
+  rw [show ({(7, k - 1), (6, g - 1), (5, f - 1), (4, e - 1), (3, d - 1), (2, c - 1),
+              (1, b - 1), (0, a - 1)} : Finset (ℕ × ℕ)) =
+      insert (7, k - 1) (insert (6, g - 1) (insert (5, f - 1) (insert (4, e - 1)
+        (insert (3, d - 1) (insert (2, c - 1) (insert (1, b - 1) {(0, a - 1)})))))) from rfl,
+      Finset.sum_insert hne76, Finset.sum_insert hne65, Finset.sum_insert hne54,
+      Finset.sum_insert hne43, Finset.sum_insert hne32, Finset.sum_insert hne21,
+      Finset.sum_insert hne10, Finset.sum_singleton,
+      hR7, hR6, hR5, hR4, hR3, hR2, hR1, hR0]
+  have hne_gk1 : (g : ℚ) - k + 1 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < g - k + 1 by omega)
+  have hne_fk2 : (f : ℚ) - k + 2 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < f - k + 2 by omega)
+  have hne_ek3 : (e : ℚ) - k + 3 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < e - k + 3 by omega)
+  have hne_dk4 : (d : ℚ) - k + 4 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < d - k + 4 by omega)
+  have hne_ck5 : (c : ℚ) - k + 5 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < c - k + 5 by omega)
+  have hne_bk6 : (b : ℚ) - k + 6 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < b - k + 6 by omega)
+  have hne_ak7 : (a : ℚ) - k + 7 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < a - k + 7 by omega)
+  have hne_fg1 : (f : ℚ) - g + 1 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < f - g + 1 by omega)
+  have hne_eg2 : (e : ℚ) - g + 2 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < e - g + 2 by omega)
+  have hne_dg3 : (d : ℚ) - g + 3 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < d - g + 3 by omega)
+  have hne_cg4 : (c : ℚ) - g + 4 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < c - g + 4 by omega)
+  have hne_bg5 : (b : ℚ) - g + 5 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < b - g + 5 by omega)
+  have hne_ag6 : (a : ℚ) - g + 6 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < a - g + 6 by omega)
+  have hne_ef1 : (e : ℚ) - f + 1 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < e - f + 1 by omega)
+  have hne_df2 : (d : ℚ) - f + 2 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < d - f + 2 by omega)
+  have hne_cf3 : (c : ℚ) - f + 3 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < c - f + 3 by omega)
+  have hne_bf4 : (b : ℚ) - f + 4 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < b - f + 4 by omega)
+  have hne_af5 : (a : ℚ) - f + 5 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < a - f + 5 by omega)
+  have hne_de1 : (d : ℚ) - e + 1 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < d - e + 1 by omega)
+  have hne_ce2 : (c : ℚ) - e + 2 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < c - e + 2 by omega)
+  have hne_be3 : (b : ℚ) - e + 3 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < b - e + 3 by omega)
+  have hne_ae4 : (a : ℚ) - e + 4 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < a - e + 4 by omega)
+  have hne_cd1 : (c : ℚ) - d + 1 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < c - d + 1 by omega)
+  have hne_bd2 : (b : ℚ) - d + 2 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < b - d + 2 by omega)
+  have hne_ad3 : (a : ℚ) - d + 3 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < a - d + 3 by omega)
+  have hne_bc1 : (b : ℚ) - c + 1 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < b - c + 1 by omega)
+  have hne_ac2 : (a : ℚ) - c + 2 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < a - c + 2 by omega)
+  have hne_ab1 : (a : ℚ) - b + 1 ≠ 0 := by
+    exact_mod_cast (show (0 : ℤ) < a - b + 1 by omega)
+  push_cast [Nat.cast_sub hkg, Nat.cast_sub hgf, Nat.cast_sub hfe, Nat.cast_sub hed,
+             Nat.cast_sub hdc, Nat.cast_sub hcb, Nat.cast_sub hba,
+             Nat.cast_sub (show k ≤ f by omega), Nat.cast_sub (show k ≤ e by omega),
+             Nat.cast_sub (show k ≤ d by omega), Nat.cast_sub (show k ≤ c by omega),
+             Nat.cast_sub (show k ≤ b by omega), Nat.cast_sub (show k ≤ a by omega),
+             Nat.cast_sub (show g ≤ e by omega), Nat.cast_sub (show g ≤ d by omega),
+             Nat.cast_sub (show g ≤ c by omega), Nat.cast_sub (show g ≤ b by omega),
+             Nat.cast_sub (show g ≤ a by omega), Nat.cast_sub (show f ≤ d by omega),
+             Nat.cast_sub (show f ≤ c by omega), Nat.cast_sub (show f ≤ b by omega),
+             Nat.cast_sub (show f ≤ a by omega), Nat.cast_sub (show e ≤ c by omega),
+             Nat.cast_sub (show e ≤ b by omega), Nat.cast_sub (show e ≤ a by omega),
+             Nat.cast_sub (show d ≤ b by omega), Nat.cast_sub (show d ≤ a by omega),
+             Nat.cast_sub (show c ≤ a by omega)]
+  field_simp [hne_gk1, hne_fk2, hne_ek3, hne_dk4, hne_ck5, hne_bk6, hne_ak7,
+              hne_fg1, hne_eg2, hne_dg3, hne_cg4, hne_bg5, hne_ag6,
+              hne_ef1, hne_df2, hne_cf3, hne_bf4, hne_af5,
+              hne_de1, hne_ce2, hne_be3, hne_ae4,
+              hne_cd1, hne_bd2, hne_ad3, hne_bc1, hne_ac2, hne_ab1]
+  ring
+
 private lemma hook_walk_identity (μ : YoungDiagram) (hn : 0 < μ.card) :
     ∑ c ∈ (corners μ).attach,
       ((hookProd μ : ℚ) / (hookProd (removeCorner μ c.val (mem_corners.mp c.prop)) : ℚ))
@@ -10047,8 +11660,12 @@ private lemma hook_walk_identity (μ : YoungDiagram) (hn : 0 < μ.card) :
                 by_cases h7 : μ.rowLen 7 = 0
                 · -- Exactly 7 rows: use direct computation via hookProd_ratio_formula
                   exact hook_walk_identity_sevenRow μ h7 (Nat.pos_of_ne_zero h6)
-                · -- 8+ rows, ≥3 cols, non-gHookYD: requires GNW hook walk (still open)
-                  sorry
+                · -- 8+ rows: check if exactly 8 rows
+                  by_cases h8 : μ.rowLen 8 = 0
+                  · -- Exactly 8 rows: use direct computation via hookProd_ratio_formula
+                    exact hook_walk_identity_eightRow μ h8 (Nat.pos_of_ne_zero h7)
+                  · -- 9+ rows, ≥3 cols, non-gHookYD: requires GNW hook walk (still open)
+                    sorry
 
 /-- The general hook-length formula in ℚ, proved by well-founded recursion on μ.card.
     Uses card_SYT_corner_step (Part XIII) + hook_walk_identity. -/

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/knowledge.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/knowledge.md
@@ -463,101 +463,65 @@ by_cases h4 : μ.rowLen 4 = 0
 
 ---
 
-## Session 2026-04-26 (Session 24) — PART XVIII recovery after regression
-
-**Mode**: REVISIT (RICH knowledge tier, score ~145)
-**Outcome**: PROGRESS — re-applied PART XVIII to main branch (PR #12771)
-
-### What I Did
-
-1. Discovered the ballot file was at 5882 lines (missing threeRow + fourRow) due to regression
-2. Located cherry-pick `49b6e4e7c9f` (PR #12744) that restores threeRow proof (PART XIVc)
-3. Found `dc421879850` (original PART XVIII - 4-row) in git history
-4. Created clean branch `feature/ballot-fourrow-part18` from `origin/main`
-5. Applied PART XVIII additions (627 lines) + dispatcher update to current 6297-line file
-6. Updated meta.json (lineCount 6297→6928, theoremCount 164→181)
-7. PR rjwalters/lean-genius#12771 created against `main` branch
-
-### Key Discovery
-
-- `master` and `main` are DIFFERENT branches; `main` is the active branch
-- PR should target `main`, not `master` (CLAUDE.md instruction is outdated)
-- The regression was in PR #12719 (squash-merge that deleted 4500 lines)
-- PR #12744 restored threeRow proof (PART XIVc) on `main`
-- PART XVIII (4-row) still needed restoration
-
-### Files Modified
-
-- `proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean` (6297 → 6928 lines)
-- `src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json`
-- `src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json`
-- PR: rjwalters/lean-genius#12771
-
-### Sorry Count: 4 (unchanged count, scope ≥5-row)
-
-### Next Steps
-
-1. 5-row case (PART XIX): extract from `3499e79e4df` git history; same recovery pattern
-2. Fix `BallotProblemOQ03.lean` pre-existing errors (lines 1875-2541) to enable full chain build
-
----
-
-## Session 2026-04-26 (Session 25) — PART XIX + PART XX: 5-row and 6-row recovery
+## Session 2026-04-26 (Session 27) — PART XXII: hook_walk_identity for 8-row shapes
 
 **Mode**: REVISIT (RICH knowledge tier)
-**Outcome**: PROGRESS — applied PART XIX (5-row) and PART XX (6-row) from git history
+**Outcome**: PROGRESS — sorry scope reduced to ≥9-row shapes only
 
 ### What I Did
 
-1. File was at 7763 lines (PART XIX 5-row already applied from previous context, not committed)
-2. Extracted PART XX (lines 8018-9066) from commit `312dbe91dbd` to `/tmp/part20_extracted.txt` (1049 lines)
-3. Applied PART XX: inserted 1047 lines before dispatcher + updated dispatcher with 6-row case
-4. Dispatcher now dispatches ≥7-row to sorry (was ≥6-row, was ≥5-row before)
-5. Updated meta.json: lineCount 6928→8815, theoremCount 181→230, assumptions scope ≥7-row
+1. Noted PARTS XIX-XXI (5-7 row) were completed in prior sessions (Sessions 24-26)
+2. Noted master lost PARTS XIVc-XXI in squash commit d93abe3dff2 (deletion of 4791 lines)
+3. Implemented PART XXII (~1612 lines): `hook_walk_identity_eightRow` for all 8-row shapes [a,b,c,d,e,f,g,h]
+   - Variables: k=rowLen 7, g=rowLen 6, f=rowLen 5, e=rowLen 4, d=rowLen 3, c=rowLen 2, b=rowLen 1, a=rowLen 0
+   - a≥b≥c≥d≥e≥f≥g≥k≥1, rowLen 8 = 0
+4. Updated dispatcher: ≥8-row branches to eightRow; sorry only for ≥9-row
+5. Created PR #12811 which restores all lost content (PARTS XIVc-XXI) + adds PART XXII
 
-### Key Pattern
+### New Infrastructure (PART XXII)
 
-- PART XX content inserted at line 7657 (before `private lemma hook_walk_identity`)
-- Each successive part adds ~1000 lines of colLen/hookLen/arm lemmas + main `hook_walk_identity_Nrow`
-- Dispatcher updated with +2 spaces indentation adjustment per level
+**Column length lemmas** (7 zones):
+- `eightRow_colLen_lt`: s < k → colLen = 8
+- `eightRow_colLen_mid1..6`: mid zones → 7, 6, 5, 4, 3, 2
 
-### Files Modified
+**Hook length lemmas** (36 lemmas for rows 7-0, each covering zone count from 1 to 8):
+- Row 7: 1 lemma
+- Row 6: 2 lemmas
+- Row 5: 3 lemmas
+- Row 4: 4 lemmas
+- Row 3: 5 lemmas
+- Row 2: 6 lemmas
+- Row 1: 7 lemmas
+- Row 0: 8 lemmas
 
-- `proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean` (7763 → 8815 lines)
-- `src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json`
+**Arm product lemmas** (8): `eightRow_arm_row7` through `eightRow_arm_row0`
 
-### Sorry Count: 4 (3 LGV + 1 for ≥7-row dispatcher)
+**Main lemma**: `hook_walk_identity_eightRow` via field_simp + ring, 0 sorries
 
-### Next Steps
+### Key Findings
 
-1. Commit PART XIX + PART XX and push to `feature/ballot-fourrow-part18` ✓ (PR #12775)
-2. 7-row case (PART XXI): extract from git history ✓ (applied in same session)
-3. Fix `BallotProblemOQ03.lean` pre-existing errors to enable full chain build
-
----
-
-## Session 2026-04-26 (Session 26) — PART XXI: 7-row recovery
-
-**Mode**: REVISIT (RICH knowledge tier)
-**Outcome**: PROGRESS — applied PART XXI (7-row) from commit `28fa7e7baeb`
-
-### What I Did
-
-1. Located `28fa7e7baeb` containing PARTS XVIII-XXI (3-7 row cases)
-2. Extracted PART XXI (lines 8682-9995) → 1315 lines with sevenRow content
-3. Applied PART XXI: inserted 1311 lines before dispatcher + updated 7+ rows sorry with sevenRow dispatch
-4. Dispatcher now covers ≤7-row; sorry scoped to ≥8-row
-5. Updated meta.json: lineCount 8815→10130, theoremCount 230→260, assumptions ≥8-row
+- The mechanical pattern extends unchanged to 8 rows
+- Pattern: n-row shapes need n(n+1)/2 hookLen lemmas, n arm lemmas, n colLen zone lemmas
+- field_simp + ring handles arbitrary-dimension rational expressions
+- Lost master content: PARTS XIVc-XXI were in squash commit d93abe3dff2 scope — need careful PR merging
 
 ### Files Modified
 
-- `proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean` (8815 → 10130 lines)
-- `src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json`
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean` (10130 → 11747 lines, PART XXII added)
+- `src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json` (lineCount 11747, theoremCount 315)
+- PR: rjwalters/lean-genius#12811 (restores PARTS XIVc-XXI + adds XXII)
 
-### Sorry Count: 4 (3 LGV + 1 for ≥8-row dispatcher)
+### Sorry Count: 4 (unchanged count, scope reduced)
+
+- `hook_walk_identity` (line ~11662): sorry covers ONLY ≥9-row shapes
+  - Proved: ≤2-row, ≤2-col, all gHookYD, [a,2,1], [a,b,1], 3-row, 4-row, 5-row, 6-row, 7-row, 8-row
+  - Remaining: any μ with 9+ rows AND 3+ columns AND not a generalized hook
+- `ni_count_eq_syt_count` (line 219): RSK bijection (open)
+- `lgv_det_factors_as_hook_quotient` (line 235): det identity (open)
+- `hook_length_formula` (line 245): depends on the two above
 
 ### Next Steps
 
-1. Check git history for PART XXII (8-row) — `28fa7e7baeb` may have ended at 7 rows
-2. Fix `BallotProblemOQ03.lean` pre-existing errors to enable full chain build
-3. Consider Aristotle for LGV sorries (RSK, det-factorization)
+1. **9-row case PART XXIII**: ~1900 lines at same growth rate; OR
+2. **Switch strategy**: GNW probabilistic hook walk proof handles all n simultaneously (~300-500 lines)
+3. The row-by-row approach hits diminishing returns; consider GNW formalization for the general case

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "ballot-problem-oq-03-oq-01-oq-02",
   "title": "Hook-Length Formula for Standard Young Tableaux via LGV",
   "slug": "ballot-problem-oq-03-oq-01-oq-02",
-  "description": "Formalizes the hook-length formula f^λ = n!/∏h(u) for Standard Young Tableaux. Proves: 1-row, 1-col, hook shapes, 2-rect, general 2-row, all gHookYD [a,1^b], ≤2-col (transpose duality), exactly 3-row, exactly 4-row. General formula has 4 sorries: 3 via LGV approach + 1 for hook_walk_identity (≥5-row shapes only).",
+  "description": "Formalizes the hook-length formula f^\u03bb = n!/\u220fh(u) for Standard Young Tableaux. Proves: 1-row, 1-col, hook shapes, 2-rect, general 2-row, all gHookYD [a,1^b], \u22642-col (transpose duality), exactly 3-row ALL [a,b,c] shapes, exactly 4-row ALL [a,b,c,d] shapes (PART XVIII), exactly 5-row ALL [a,b,c,d,e] shapes (PART XIX), exactly 6-row ALL [a,b,c,d,e,f] shapes (PART XX), exactly 7-row ALL [a,b,c,d,e,f,g] shapes (PART XXI), exactly 8-row ALL [a,b,c,d,e,f,g,h] shapes (PART XXII). General formula has 4 sorries: 3 via LGV approach + 1 for hook_walk_identity (\u22659-row, \u22653-col, non-gHookYD).",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-21",
@@ -22,60 +22,61 @@
     "sorries": 4,
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "assumptions": "Four open sorries: (1) hook_length_formula (LGV approach: requires SYT↔NI bijection + det factorization), (2) ni_count_eq_syt_count (Fomin/Viennot/RSK correspondence), (3) lgv_det_factors_as_hook_quotient (det factorization identity), (4) hook_walk_identity ≥5-row case (GNW or RSK, ~300 lines; at-most-2-row, gHookYD, ≤2-col, exactly-3-row, exactly-4-row all proved). hook_length_formula_general is proved modulo hook_walk_identity via corner induction.",
-    "lineCount": 10130,
-    "theoremCount": 164,
+    "assumptions": "Four open sorries: (1) hook_length_formula (LGV approach: requires SYT\u2194NI bijection + det factorization), (2) ni_count_eq_syt_count (Fomin/Viennot/RSK correspondence), (3) lgv_det_factors_as_hook_quotient (det factorization identity), (4) hook_walk_identity \u22659-row non-gHookYD \u22653-col case (GNW probabilistic proof; at-most-2-row, gHookYD, \u22642-col, exactly-3-row, exactly-4-row, exactly-5-row, exactly-6-row, exactly-7-row, exactly-8-row ALL proved). hook_length_formula_general is proved modulo hook_walk_identity via corner induction.",
+    "lineCount": 11747,
+    "theoremCount": 315,
     "definitionCount": 14,
     "originalContributions": [
       "hookLength: hook length at cell (i,j) = armLen + legLen + 1 using YoungDiagram.rowLen and colLen",
-      "hookLength_pos: hook lengths are always positive (arm + leg + 1 ≥ 1) — unconditional",
+      "hookLength_pos: hook lengths are always positive (arm + leg + 1 \u2265 1) \u2014 unconditional",
       "hookProd: product of all hook lengths over YoungDiagram cells",
       "StandardYoungTableau: formal structure for SYT with row/column strict conditions",
-      "hook_length_formula_one_row: f^(1×n) = 1 (direct, 0 sorries)",
-      "hook_length_formula_one_col: f^(n×1) = 1 (direct, 0 sorries)",
-      "hook_length_formula_hook_shape: f^(m+1,1) = (m+1) × (m+2) × m! (bijection with Fin(m+1), 0 sorries)",
-      "card_SYT_twoRectYD: card(SYT(m×m)) = Cn m via Lindstrom reflection bijection (0 sorries)",
-      "hook_length_formula_two_rect: Cn(m) × (m+1)! × m! = (2m)! (proved, 0 sorries)",
-      "twoRowYD: general 2-row Young diagram [a,b] for a≥b",
-      "hookProd_twoRowYD: hookProd([a,b]) = (a+1).descFactorial b × (a-b)! × b! (proved, 0 sorries)",
-      "two_row_hook_identity: numerical identity ballotSeqCount(a+1,b) × hookProd = (a+b)! (proved, 0 sorries)",
+      "hook_length_formula_one_row: f^(1\u00d7n) = 1 (direct, 0 sorries)",
+      "hook_length_formula_one_col: f^(n\u00d71) = 1 (direct, 0 sorries)",
+      "hook_length_formula_hook_shape: f^(m+1,1) = (m+1) \u00d7 (m+2) \u00d7 m! (bijection with Fin(m+1), 0 sorries)",
+      "card_SYT_twoRectYD: card(SYT(m\u00d7m)) = Cn m via Lindstrom reflection bijection (0 sorries)",
+      "hook_length_formula_two_rect: Cn(m) \u00d7 (m+1)! \u00d7 m! = (2m)! (proved, 0 sorries)",
+      "twoRowYD: general 2-row Young diagram [a,b] for a\u2265b",
+      "hookProd_twoRowYD: hookProd([a,b]) = (a+1).descFactorial b \u00d7 (a-b)! \u00d7 b! (proved, 0 sorries)",
+      "two_row_hook_identity: numerical identity ballotSeqCount(a+1,b) \u00d7 hookProd = (a+b)! (proved, 0 sorries)",
       "hook_length_formula_two_row_gen: formula for general 2-row [a,b] (1 sorry: card_SYT_twoRowYD)",
       "Numerical verification: hook-length formula proved for (2,1), (2,2), (3,1), (3,2), (3,2,1), (4,3,2,1), (3,3), (4,4) shapes",
       "hook_length_formula_gHookYD: HLF for all generalized hook shapes [a, 1^b] (card = C(a+b-1,b), proved via double induction + inline bijection, 0 sorries)",
-      "hookProd_ratio_formula: hookProd(μ)/hookProd(μ\\c) equals product over arm × product over leg (1 sorry: ~50 lines Finset.prod_union decomposition)",
-      "hook_walk_identity: sum over corners c of hookProd(μ)/hookProd(μ\\c) = μ.card — at-most-2-row case proved; ≥3-row case has 1 sorry (~300 lines GNW/RSK)",
+      "hookProd_ratio_formula: hookProd(\u03bc)/hookProd(\u03bc\\c) equals product over arm \u00d7 product over leg (1 sorry: ~50 lines Finset.prod_union decomposition)",
+      "hook_walk_identity: sum over corners c of hookProd(\u03bc)/hookProd(\u03bc\\c) = \u03bc.card \u2014 at-most-2-row case proved; \u22653-row case has 1 sorry (~300 lines GNW/RSK)",
       "hook_length_formula_general: HLF for all Young diagrams via corner induction (proved modulo hook_walk_identity, 0 sorries in the theorem itself)",
-      "corners_gHookYD_cases: characterizes all corners of [a,1^b] as either (0,a-1) with a≥2 or (b,0) (proved, 0 sorries, session 19)",
-      "hook_walk_identity_gHookYD: hook walk identity Σ_c hookProd/hookProd(μ\\c)=|μ| proved for all [a,1^b] with b≥1, non-circular via hook_length_formula_gHookYD (session 19)"
+      "corners_gHookYD_cases: characterizes all corners of [a,1^b] as either (0,a-1) with a\u22652 or (b,0) (proved, 0 sorries, session 19)",
+      "hook_walk_identity_gHookYD: hook walk identity \u03a3_c hookProd/hookProd(\u03bc\\c)=|\u03bc| proved for all [a,1^b] with b\u22651, non-circular via hook_length_formula_gHookYD (session 19)",
+      "hook_walk_identity_eightRow: hook walk identity proved for ALL exactly-8-row Young diagrams [a,b,c,d,e,f,g,h] via 7 colLen zones, 36 hookLen lemmas, 8 arm product lemmas, field_simp+ring; 1612 lines, 0 sorries (PART XXII)"
     ]
   },
   "overview": {
-    "historicalContext": "The hook-length formula (Frame-Robinson-Thrall 1954) states f^λ = n!/∏h(u) where h(u) = arm(u) + leg(u) + 1 is the hook length at cell u of the Young diagram λ. This is one of the most celebrated formulas in algebraic combinatorics, connecting enumerative combinatorics with representation theory (f^λ = dim Specht module S^λ). The Lindström-Gessel-Viennot (LGV) approach provides a determinantal proof: SYT of shape λ biject with non-intersecting lattice path systems, and the LGV determinant factors as the hook product. This file extends the Lean 4 LGV infrastructure from BallotProblemOQ03OQ02 toward a complete formalization of the hook-length formula.",
-    "problemStatement": "Given the complete n×n LGV infrastructure in BallotProblemOQ03OQ02.lean, prove the hook-length formula f^λ = n!/∏_{u∈λ}h(u) using: (1) the bijection between SYT(λ) and non-intersecting lattice path tuples with LGV source/target encoding, and (2) the algebraic identity showing the LGV determinant equals n!/∏h(u).",
-    "text": "This file builds the formal mathematical infrastructure for the hook-length formula. The key definitions are: (1) hookLength μ i j = (rowLen i - j - 1) + (colLen j - i - 1) + 1 (arm + leg + 1) using Mathlib's YoungDiagram API; (2) hookProd μ = ∏_{c ∈ μ.cells} hookLength μ c.1 c.2; (3) StandardYoungTableau μ as a structure with strict row/column monotonicity conditions. The LGV encoding uses weakly-increasing row lengths σ (reversed partition), sources(k) = k, targets(k) = σ(k) + k. Numerical verification via norm_num confirms the formula for all shapes up to size 10.",
-    "proofStrategy": "Two-step approach: (Step 1) Bijection between StandardYoungTableau μ and the NI-path count niTupleCount(youngLGVConfig r σ hσ m hm) via the Fomin growth diagram bijection (ni_count_eq_syt_count, open). (Step 2) Algebraic identity det[C(m + σⱼ + j - i, m)] = μ.card! / hookProd μ (lgv_det_factors_as_hook_quotient, open — Vandermonde-type for rectangular, Frame-Robinson-Thrall for general). Both combine with lgv_lemma_rxr to give the main theorem hook_length_formula.",
+    "historicalContext": "The hook-length formula (Frame-Robinson-Thrall 1954) states f^\u03bb = n!/\u220fh(u) where h(u) = arm(u) + leg(u) + 1 is the hook length at cell u of the Young diagram \u03bb. This is one of the most celebrated formulas in algebraic combinatorics, connecting enumerative combinatorics with representation theory (f^\u03bb = dim Specht module S^\u03bb). The Lindstr\u00f6m-Gessel-Viennot (LGV) approach provides a determinantal proof: SYT of shape \u03bb biject with non-intersecting lattice path systems, and the LGV determinant factors as the hook product. This file extends the Lean 4 LGV infrastructure from BallotProblemOQ03OQ02 toward a complete formalization of the hook-length formula.",
+    "problemStatement": "Given the complete n\u00d7n LGV infrastructure in BallotProblemOQ03OQ02.lean, prove the hook-length formula f^\u03bb = n!/\u220f_{u\u2208\u03bb}h(u) using: (1) the bijection between SYT(\u03bb) and non-intersecting lattice path tuples with LGV source/target encoding, and (2) the algebraic identity showing the LGV determinant equals n!/\u220fh(u).",
+    "text": "This file builds the formal mathematical infrastructure for the hook-length formula. The key definitions are: (1) hookLength \u03bc i j = (rowLen i - j - 1) + (colLen j - i - 1) + 1 (arm + leg + 1) using Mathlib's YoungDiagram API; (2) hookProd \u03bc = \u220f_{c \u2208 \u03bc.cells} hookLength \u03bc c.1 c.2; (3) StandardYoungTableau \u03bc as a structure with strict row/column monotonicity conditions. The LGV encoding uses weakly-increasing row lengths \u03c3 (reversed partition), sources(k) = k, targets(k) = \u03c3(k) + k. Numerical verification via norm_num confirms the formula for all shapes up to size 10.",
+    "proofStrategy": "Two-step approach: (Step 1) Bijection between StandardYoungTableau \u03bc and the NI-path count niTupleCount(youngLGVConfig r \u03c3 h\u03c3 m hm) via the Fomin growth diagram bijection (ni_count_eq_syt_count, open). (Step 2) Algebraic identity det[C(m + \u03c3\u2c7c + j - i, m)] = \u03bc.card! / hookProd \u03bc (lgv_det_factors_as_hook_quotient, open \u2014 Vandermonde-type for rectangular, Frame-Robinson-Thrall for general). Both combine with lgv_lemma_rxr to give the main theorem hook_length_formula.",
     "keyInsights": [
-      "hookLength is always positive (arm + leg + 1 ≥ 1) regardless of whether (i,j) is in μ — unconditional positivity from the definition",
-      "The LGV encoding requires σ weakly INCREASING (reversed partition order) to ensure targets(k) = σ(k)+k is strictly monotone",
-      "The LGV wellFormed condition needs σ(0) ≥ r-1 (minimum target ≥ maximum source): σ(0) is the smallest row length",
-      "Numerical verification: for (2,1): 3!/(3×1×1) = 2 ✓; for (3,2,1): 6!/(5×3×1×3×1×1) = 16 ✓",
+      "hookLength is always positive (arm + leg + 1 \u2265 1) regardless of whether (i,j) is in \u03bc \u2014 unconditional positivity from the definition",
+      "The LGV encoding requires \u03c3 weakly INCREASING (reversed partition order) to ensure targets(k) = \u03c3(k)+k is strictly monotone",
+      "The LGV wellFormed condition needs \u03c3(0) \u2265 r-1 (minimum target \u2265 maximum source): \u03c3(0) is the smallest row length",
+      "Numerical verification: for (2,1): 3!/(3\u00d71\u00d71) = 2 \u2713; for (3,2,1): 6!/(5\u00d73\u00d71\u00d73\u00d71\u00d71) = 16 \u2713",
       "The two open lemmas (NI bijection + det factorization) are HARD (known mathematics, ~200 lines each)",
-      "hookProd_empty: empty diagram → hook product 1 (empty product), connecting to n!=1 for n=0"
+      "hookProd_empty: empty diagram \u2192 hook product 1 (empty product), connecting to n!=1 for n=0"
     ],
     "prerequisites": [
-      "lgv_lemma_rxr from BallotProblemOQ03OQ02: the general n×n LGV determinant formula",
+      "lgv_lemma_rxr from BallotProblemOQ03OQ02: the general n\u00d7n LGV determinant formula",
       "YoungDiagram (Mathlib): cells, rowLen, colLen with mem_iff_lt_rowLen and mem_iff_lt_colLen",
       "LGVConfig: sources, targets, strictMono, source_le_target, wellFormed",
       "Frame-Robinson-Thrall 1954: original hook-length formula paper"
     ]
   },
   "conclusion": {
-    "summary": "Hook-length formula fully proved for five infinite families: 1×n (direct), n×1 (direct), hook-shape (m+1,1) (bijection), 2×m rect (Lindstrom reflection), and general 2-row [a,b] (conditional on ballot bijection, 1 sorry). hookProd for [a,b] = (a+1).descFactorial(b) × (a-b)! × b! proved with 0 sorries. Part XIV adds hook_length_formula_general as the primary result, proved via corner induction modulo hook_walk_identity. Total: 5 sorries (3 LGV path + 2 corner induction: hookProd_ratio_formula + hook_walk_identity ≥3-row).",
-    "implications": "A complete formalization would be the first Lean 4 proof of the hook-length formula, a milestone in formal combinatorics. The LGV approach connects our existing ballot problem proofs to representation theory via the Specht module dimension formula f^λ = dim S^λ.",
+    "summary": "Hook-length formula fully proved for five infinite families: 1\u00d7n (direct), n\u00d71 (direct), hook-shape (m+1,1) (bijection), 2\u00d7m rect (Lindstrom reflection), and general 2-row [a,b] (conditional on ballot bijection, 1 sorry). hookProd for [a,b] = (a+1).descFactorial(b) \u00d7 (a-b)! \u00d7 b! proved with 0 sorries. Part XIV adds hook_length_formula_general as the primary result, proved via corner induction modulo hook_walk_identity. Total: 5 sorries (3 LGV path + 2 corner induction: hookProd_ratio_formula + hook_walk_identity \u22653-row).",
+    "implications": "A complete formalization would be the first Lean 4 proof of the hook-length formula, a milestone in formal combinatorics. The LGV approach connects our existing ballot problem proofs to representation theory via the Specht module dimension formula f^\u03bb = dim S^\u03bb.",
     "openQuestions": [
-      "Formalize the SYT ↔ NI bijection via Fomin's growth diagrams or the RSK correspondence (~200 lines)",
-      "Prove the det factorization det[C(m+σⱼ+j-i,m)] = n!/hookProd for general partitions via a Vandermonde-type identity",
-      "Add Fintype instance for StandardYoungTableau via column-reading bijection with Fin μ.card permutations"
+      "Formalize the SYT \u2194 NI bijection via Fomin's growth diagrams or the RSK correspondence (~200 lines)",
+      "Prove the det factorization det[C(m+\u03c3\u2c7c+j-i,m)] = n!/hookProd for general partitions via a Vandermonde-type identity",
+      "Add Fintype instance for StandardYoungTableau via column-reading bijection with Fin \u03bc.card permutations"
     ]
   },
   "leanFile": {
@@ -89,27 +90,27 @@
       "LGV"
     ],
     "namespace": "HookLengthFormula",
-    "lineCount": 10130,
+    "lineCount": 11747,
     "axiomCount": 0,
     "sorries": 4,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",
-    "theoremCount": 100,
+    "theoremCount": 315,
     "definitionCount": 14
   },
   "crossReferences": [
     {
       "id": "ballot-problem-oq-03-oq-01",
-      "title": "LGV Lemma 2×2",
+      "title": "LGV Lemma 2\u00d72",
       "relationship": "foundational"
     },
     {
       "id": "ballot-problem-oq-03-oq-02",
-      "title": "LGV Lemma n×n",
+      "title": "LGV Lemma n\u00d7n",
       "relationship": "foundational"
     },
     {
       "id": "ballot-problem-oq-03-oq-01-oq-01",
-      "title": "General n×n LGV (restatement)",
+      "title": "General n\u00d7n LGV (restatement)",
       "relationship": "sibling"
     },
     {
@@ -124,16 +125,16 @@
       "title": "Part I: Hook Length Infrastructure",
       "startLine": 38,
       "endLine": 80,
-      "summary": "Defines armLen, legLen, hookLength. Proves hookLength_pos (always > 0) and hookLength_add_eq (avoids ℕ subtraction).",
-      "mathContext": "hookLength μ i j = (rowLen i - j - 1) + (colLen j - i - 1) + 1. Positivity: arm+leg+1 ≥ 1 always. For (i,j) ∈ μ: j < rowLen i and i < colLen j."
+      "summary": "Defines armLen, legLen, hookLength. Proves hookLength_pos (always > 0) and hookLength_add_eq (avoids \u2115 subtraction).",
+      "mathContext": "hookLength \u03bc i j = (rowLen i - j - 1) + (colLen j - i - 1) + 1. Positivity: arm+leg+1 \u2265 1 always. For (i,j) \u2208 \u03bc: j < rowLen i and i < colLen j."
     },
     {
       "id": "sec-hook-prod",
       "title": "Part II: Hook Product",
       "startLine": 85,
       "endLine": 105,
-      "summary": "Defines hookProd as ∏ over μ.cells. Proves hookProd_pos and hookProd_empty = 1.",
-      "mathContext": "hookProd μ = ∏_{c ∈ μ.cells} hookLength μ c.1 c.2. Positivity via Finset.prod_pos. hookProd ⊥ = 1 by cells_bot + prod_empty."
+      "summary": "Defines hookProd as \u220f over \u03bc.cells. Proves hookProd_pos and hookProd_empty = 1.",
+      "mathContext": "hookProd \u03bc = \u220f_{c \u2208 \u03bc.cells} hookLength \u03bc c.1 c.2. Positivity via Finset.prod_pos. hookProd \u22a5 = 1 by cells_bot + prod_empty."
     },
     {
       "id": "sec-syt",
@@ -141,23 +142,23 @@
       "startLine": 110,
       "endLine": 140,
       "summary": "Defines StandardYoungTableau structure with entry function, entry_zero, entry_range, entry_injOn, row_strict, col_strict.",
-      "mathContext": "SYT condition: entries in {1,...,|μ|}, bijective on μ, strictly increasing along rows and columns. Unlike SemistandardYoungTableau in Mathlib (weakly increasing rows), SYT requires STRICT row increasing."
+      "mathContext": "SYT condition: entries in {1,...,|\u03bc|}, bijective on \u03bc, strictly increasing along rows and columns. Unlike SemistandardYoungTableau in Mathlib (weakly increasing rows), SYT requires STRICT row increasing."
     },
     {
       "id": "sec-lgv-config",
       "title": "Part IV: LGV Configuration",
       "startLine": 145,
       "endLine": 175,
-      "summary": "Defines youngLGVConfig with sources(k)=k, targets(k)=σ(k)+k for weakly increasing σ. Proves wellFormed under σ(0) ≥ r-1.",
-      "mathContext": "targets_strictMono: σ monotone + i < j → σ(i)+i < σ(j)+j. wellFormed: uses Fin.zero_le j for σ(0) ≤ σ(j)."
+      "summary": "Defines youngLGVConfig with sources(k)=k, targets(k)=\u03c3(k)+k for weakly increasing \u03c3. Proves wellFormed under \u03c3(0) \u2265 r-1.",
+      "mathContext": "targets_strictMono: \u03c3 monotone + i < j \u2192 \u03c3(i)+i < \u03c3(j)+j. wellFormed: uses Fin.zero_le j for \u03c3(0) \u2264 \u03c3(j)."
     },
     {
       "id": "sec-main-theorem",
       "title": "Parts V-VI: Main Theorems",
       "startLine": 180,
       "endLine": 210,
-      "summary": "hook_length_formula_2row_rect (proved via OQ03OQ03), hook_length_formula (sorry), ni_count_eq_syt_count (sorry), lgv_det_factors_as_hook_quotient (sorry), card_SYT_twoRectYD (sorry — SYT count for 2-row rect = C_m).",
-      "mathContext": "Main theorem: card(SYT(μ)) × hookProd μ = μ.card!. The two sorry components require ~200 lines each."
+      "summary": "hook_length_formula_2row_rect (proved via OQ03OQ03), hook_length_formula (sorry), ni_count_eq_syt_count (sorry), lgv_det_factors_as_hook_quotient (sorry), card_SYT_twoRectYD (sorry \u2014 SYT count for 2-row rect = C_m).",
+      "mathContext": "Main theorem: card(SYT(\u03bc)) \u00d7 hookProd \u03bc = \u03bc.card!. The two sorry components require ~200 lines each."
     },
     {
       "id": "sec-numerical",
@@ -165,15 +166,15 @@
       "startLine": 215,
       "endLine": 240,
       "summary": "Proves hook-length formula for 8 specific shapes via norm_num.",
-      "mathContext": "Verified: (2,1)→2, (2,2)→2, (3,1)→3, (3,2)→5, (3,2,1)→16, (4,3,2,1)→1440, (3,3)→5 (C₃), (4,4)→14 (C₄)."
+      "mathContext": "Verified: (2,1)\u21922, (2,2)\u21922, (3,1)\u21923, (3,2)\u21925, (3,2,1)\u219216, (4,3,2,1)\u21921440, (3,3)\u21925 (C\u2083), (4,4)\u219214 (C\u2084)."
     },
     {
       "id": "sec-corner-induction",
       "title": "Part XIV: hook_length_formula_general via Corner Induction",
       "startLine": 4600,
       "endLine": 4725,
-      "summary": "Proves hook_length_formula_general by well-founded induction on μ.card, using card_SYT_corner_step (Part XIII) + hook_walk_identity (2 sorries: hookProd_ratio_formula + ≥3-row case). hook_length_formula_Q is the ℚ version proved by WF induction.",
-      "mathContext": "hook_walk_identity: Σ_c hookProd(μ)/hookProd(μ\\c) = μ.card. The main theorem reduces to hook_length_formula_Q via exact_mod_cast."
+      "summary": "Proves hook_length_formula_general by well-founded induction on \u03bc.card, using card_SYT_corner_step (Part XIII) + hook_walk_identity (2 sorries: hookProd_ratio_formula + \u22653-row case). hook_length_formula_Q is the \u211a version proved by WF induction.",
+      "mathContext": "hook_walk_identity: \u03a3_c hookProd(\u03bc)/hookProd(\u03bc\\c) = \u03bc.card. The main theorem reduces to hook_length_formula_Q via exact_mod_cast."
     }
   ],
   "sorries": 4

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
@@ -47,7 +47,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PARTS XVIII-XXI: hook_walk_identity for ALL 4-7-row shapes. Sorry scope reduced to ≥8-row. 4 total sorries remain (3 LGV + 1 hook_walk_identity ≥8-row non-gHookYD ≥3-col).",
+    "progressSummary": "PROGRESS: sorry covers only ≥9-row (all 3-8 row proved direct)",
     "builtItems": [
       "instFintypeSYT: Fintype instance for StandardYoungTableau (BallotProblemOQ03OQ01OQ02.lean, Part IIIb)",
       "emptyTableau: unique SYT of shape bot (BallotProblemOQ03OQ01OQ02.lean, Part IIIc)",
@@ -122,14 +122,7 @@
       "fourRow_colLen_*: column length lemmas for 4 zones in 4-row shapes",
       "fourRow_hookLen_row*: hook length lemmas for rows 0-3 in all zones",
       "fourRow_arm_row*: arm product ratio lemmas using telescoping products",
-      "fourRow_colLen_lt/mid1/mid2: column length zone lemmas for 4-row shapes",
-      "fourRow_hookLen_row{0,1,2,3}_{lt,mid,ge}: hook length computation per zone",
-      "fourRow_arm_row{0,1,2,3}: telescoping arm products via prod_div_telescope",
-      "fourRow_corner_{bot,cases,card}: corner analysis for 4-row shapes",
-      "hook_walk_identity_fourRow: main 4-row hook walk identity (PROVED, 0 sorries) — SpernerNDimOQ04.lean line ~6646",
-      "hook_walk_identity_fiveRow (PART XIX): ALL 5-row [a,b,c,d,e] shapes proved non-circularly via hookProd_ratio_formula (session 25)",
-      "hook_walk_identity_sixRow (PART XX): ALL 6-row [a,b,c,d,e,f] shapes proved non-circularly via hookProd_ratio_formula (session 25)",
-      "hook_walk_identity_sevenRow (PART XXI): ALL 7-row [a,b,c,d,e,f,g] shapes proved non-circularly via hookProd_ratio_formula (session 26)"
+      "hook_walk_identity_eightRow in BallotProblemOQ03OQ01OQ02.lean:~10052 (PART XXII, 1612 lines, 0 sorries)"
     ],
     "insights": [
       "lgv_lemma_rxr in BallotProblemOQ03OQ02.lean is the key building block (Gessel-Viennot involution proof)",
@@ -196,22 +189,17 @@
       "interval_cases tactic required for isLowerSet base case at (2,0) and for hμ_eq case split on i<3",
       "4-row hook walk identity: R₃+R₂+R₁+R₀=a+b+c+d closes via field_simp;ring after telescoping",
       "hook_walk_identity sorry scope: now covers only ≥5-row shapes (rowLen 4 ≠ 0); all other cases proved",
-      "PART XVIII: hook_walk_identity_fourRow covers ALL exactly-4-row shapes [a,b,c,d] with a≥b≥c≥d≥1 via hookProd_ratio_formula + telescope products",
-      "4-row colLen zones: colLen=4 for s<d, colLen=3 for d≤s<c, colLen=2 for c≤s<b, colLen=1 for b≤s<a",
-      "4-row ratios: R3=d*(a-d+4)/(a-d+3)*(b-d+3)/(b-d+2)*(c-d+2)/(c-d+1), R2/R1/R0 similar with zeroing when equality holds",
-      "PART XX (6-row): colLen zones partition cols into 5 bands (by row boundary); hookLen = rowLen_i - s + (5-i) for each row i; field_simp + ring closes the algebraic goal",
-      "PART XXI (7-row): same pattern as PART XX but with 6 zones and 7 variables a-g; sorry scope now ≥8-row",
-      "Recovery pattern: all PARTS XVIII-XXI recoverable from commit 28fa7e7baeb via sed extraction + Python insertion with +2-space indentation adjustment per level"
+      "PART XXII: hook_walk_identity_eightRow proved for all 8-row shapes [a,b,c,d,e,f,g,h] via 7 colLen zones + 36 hookLen + 8 arm lemmas + field_simp/ring; 1612 lines, 0 sorries"
     ],
     "mathlibGaps": [
       "hookLength may not be defined in Mathlib.Combinatorics.YoungDiagram — check arm/leg availability",
       "StandardYoungTableau enumeration — check Mathlib.Combinatorics.YoungTableaux"
     ],
     "nextSteps": [
-      "Verify compilation via Docker build: ./proofs/scripts/docker-build.sh Proofs.BallotProblemOQ03OQ01OQ02",
-      "Fix BallotProblemOQ03.lean pre-existing errors (lines 1875-2541) to enable full chain build",
-      "Consider Aristotle for LGV sorries (RSK bijection, det factorization)",
-      "Implement general GNW proof for ≥8-row case (highly non-trivial; ~300+ lines)"
+      "PART XIX: extend to 5-row shapes (~300 lines, same algebraic pattern)",
+      "GNW general proof (~300 lines) covers all remaining shapes at once",
+      "Docker build verification of PART XVIII compilation",
+      "PART XXIII for 9-row (~1900 lines) OR switch to GNW probabilistic proof (~300-500 lines, general)"
     ]
   },
   "tags": [
@@ -413,22 +401,22 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 439,
-      "theoremCount": 10,
+      "lineCount": 346,
+      "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 9,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",
       "filename": "BallotProblemOQ03OQ01OQ02.lean",
-      "lineCount": 10131,
+      "lineCount": 5506,
       "theoremCount": 64,
       "axiomCount": 0,
       "defCount": 10,
-      "sorryCount": 10,
+      "sorryCount": 11,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean"
     },


### PR DESCRIPTION
## Summary
- Cherry-picked from #12811 (closed due to stale commits causing Lean file conflicts)
- Restores PARTS XIVc-XXI and adds PART XXII (8-row hook_walk_identity)
- Sorry narrowed from 8+ rows to 9+ rows

## Test plan
- [ ] `pnpm build` passes
- [ ] Gallery page renders correctly