### PR TITLE
fix(audit): sync meta.json counts for synthesis-curvature-ptolemy

### DIFF
--- a/src/data/proofs/synthesis-curvature-ptolemy/meta.json
+++ b/src/data/proofs/synthesis-curvature-ptolemy/meta.json
@@ -52,7 +52,7 @@
     ],
     "dateAdded": "2026-04-26",
     "axiomCount": 0,
-    "lineCount": 210,
+    "lineCount": 270,
     "assumptions": "0 axioms. 0 sorries. All results are fully machine-verified. The hyperbolic Ptolemy theorem (K<0) is stated as a conjecture in comments only — it is NOT claimed as a theorem in this file.",
     "mathlib_version": "4.26.0",
     "parentProof": "ptolemys-theorem-oq-01-oq-02"
@@ -165,7 +165,7 @@
     "namespace": null,
     "lineCount": 270,
     "axiomCount": 0,
-    "theoremCount": 7,
+    "theoremCount": 8,
     "sorries": 0,
     "path": "Proofs/SynthesisCurvaturePtolemy.lean"
   }


### PR DESCRIPTION
## Summary

- Corrects `lineCount` from 210 → 270 (actual file has 270 lines)
- Corrects `theoremCount` from 7 → 8 (6 curvatureSin lemmas + 2 Ptolemy theorems)

Integrity-critical fields unchanged: sorries (0), axiomCount (0), status/badge remain correct.

Discovered during automated gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)