### PR TITLE
fix(audit): sync leanFile.lineCount for hurwitz-oq-04 and lebesgue-oq-06

### DIFF
--- a/src/data/proofs/hurwitz-theorem-oq-04/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-04/meta.json
@@ -121,7 +121,7 @@
       "HurwitzTheorem"
     ],
     "namespace": "HurwitzTheoremOQ04",
-    "lineCount": 764,
+    "lineCount": 822,
     "axiomCount": 1,
     "theoremCount": 32,
     "definitionCount": 15,

--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -212,7 +212,7 @@
       "Mathlib"
     ],
     "namespace": "BanachTarski",
-    "lineCount": 783,
+    "lineCount": 1286,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 5,


### PR DESCRIPTION
## Fix

Syncs stale `leanFile.lineCount` fields in 2 gallery entries. The `meta.lineCount` was already correct in both cases.

## Evidence

| Proof | Field | Before | After |
|-------|-------|--------|-------|
| hurwitz-theorem-oq-04 | leanFile.lineCount | 764 | 822 |
| lebesgue-measure-oq-06 | leanFile.lineCount | 783 | 1286 |

**Verification**: `meta.lineCount` for both entries was already correct (822 and 1286 respectively). Only the `leanFile` sub-section was stale.

Sorry counts and axiom counts are unaffected.

---
Automated fix by lean-mechanic agent.