### PR TITLE
fix(audit): sync meta.json counts for arithmetic-series-oq-00-oq-02

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-00-oq-02/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-00-oq-02/meta.json
@@ -20,8 +20,8 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "theoremCount": 9,
-    "lineCount": 116,
+    "theoremCount": 11,
+    "lineCount": 120,
     "mathlibDependencies": [
       {
         "theorem": "Finset.sum_range_succ",
@@ -84,9 +84,9 @@
   ],
   "leanFile": {
     "namespace": "ArithmeticSeriesOQ00OQ02",
-    "lineCount": 116,
+    "lineCount": 120,
     "axiomCount": 0,
-    "theoremCount": 9,
+    "theoremCount": 11,
     "definitionCount": 0,
     "path": "Proofs/ArithmeticSeriesOQ00OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

- Corrects `lineCount` from 116 → 120 (actual file has 120 lines)
- Corrects `theoremCount` from 9 → 11 (file has 11 theorem declarations)

Integrity-critical fields unchanged: sorries (0), axiomCount (0), status/badge remain correct.

Discovered during automated gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)