### PR TITLE
Enrich synthesis-curvature-ptolemy: add 8 comprehensive annotations

### DIFF
--- a/src/data/proofs/synthesis-curvature-ptolemy/annotations.json
+++ b/src/data/proofs/synthesis-curvature-ptolemy/annotations.json
@@ -1,3 +1,68 @@
 {
-  "annotations": []
+  "annotations": [
+    {
+      "id": "scp-module-header",
+      "startLine": 1,
+      "endLine": 65,
+      "title": "Module Overview: Unifying Ptolemy Across Three Geometries",
+      "body": "This file introduces the `curvatureSin K` function, which is the unifying object behind Ptolemy-type theorems in all three constant-curvature geometries. The core observation is that the Ptolemy theorem — in spherical, Euclidean, and hyperbolic geometry — always has the same algebraic form, but with different transcendental functions replacing the ordinary chord lengths. By packaging these three functions into a single definition parametrized by the curvature K, the theorem becomes a schema: one statement with one proof outline, valid for all K.\n\nThe six results proved are numbered explicitly in the docstring (lines 33-40). Items 1-4 are basic properties of curvatureSin. Items 5-6 are the Ptolemy results: the EQUALITY (for concyclic points, K=1), and the INEQUALITY (for all unit-circle points in ℂ, K=1). The inequality is the key new contribution — it has no concyclicity condition.",
+      "mathContext": "In classical non-Euclidean geometry, the Ptolemy equality for constant curvature K takes the form: `sn_K(d(a,c)/2)·sn_K(d(b,d)/2) = sn_K(d(a,b)/2)·sn_K(d(c,d)/2) + sn_K(d(a,d)/2)·sn_K(d(b,c)/2)` where `sn_K` is the Jacobi sn function at curvature K. This file implements `sn_K` as `curvatureSin K`, restricted to the real line (no elliptic modulus). The Euclidean case (K=0) recovers ordinary Ptolemy: `(ac/2)·(bd/2) = (ab/2)·(cd/2) + (ad/2)·(bc/2)`, i.e., `ac·bd = ab·cd + ad·bc`, the standard chord form."
+    },
+    {
+      "id": "scp-curvaturesin-def",
+      "startLine": 75,
+      "endLine": 91,
+      "title": "curvatureSin K t: Three-Case Definition via If-Then-Else",
+      "body": "The definition uses nested `if-then-else` on the sign of K:\n\n```\ncurvatureSin K t :=\n  if K = 0 then t\n  else if 0 < K then sin(√K · t) / √K\n  else sinh(√(-K) · t) / √(-K)\n```\n\nThe `noncomputable` keyword is required because `Real.sin`, `Real.sinh`, and `Real.sqrt` are noncomputable in Lean 4's kernel. The three branches exactly match the classical `sn_K` function from constant-curvature geometry. Crucially, the K=0 branch returns `t` (the identity), which is the L'Hôpital limit of `sin(√K·t)/√K` as K→0 (both numerator and denominator → 0, ratio → t).",
+      "mathContext": "The continuity of K ↦ curvatureSin K t at K=0 is mathematically clear from L'Hôpital: `lim_{K→0} sin(√K·t)/√K = lim_{K→0} (cos(√K·t)·t/(2√K))/(1/(2√K)) = lim cos(√K·t)·t = t`. The Lean definition chooses the K=0 value explicitly rather than proving continuity. The argument `Real.sqrt K` for K>0 is the principal square root (always ≥ 0), and `Real.sqrt (-K)` for K<0 is well-defined because -K>0 in that branch."
+    },
+    {
+      "id": "scp-zero-identity",
+      "startLine": 96,
+      "endLine": 130,
+      "title": "Basic Properties: K=0 is the Identity, K=±1 Give sin and sinh",
+      "body": "Four key lemmas pin down the behavior of curvatureSin:\n\n1. `curvatureSin_zero`: The K=0 case is the identity — this is a `@[simp]` lemma, immediately dispatched by `simp [curvatureSin]`.\n2. `curvatureSin_one`: The K=1 case gives `Real.sin`. Proof: √1=1, 1·t=t, t/1=t. Done by `rw` + `div_one`.\n3. `curvatureSin_neg_one`: The K=-1 case gives `Real.sinh`. Proof: √(-(-1))=√1=1, then same reduction.\n4. `curvatureSin_zero_right`: For any K, curvatureSin K 0 = 0 — all three branches give 0 at t=0 (`sin 0 = 0`, `t = 0`, `sinh 0 = 0`).\n\nThe `curvatureSin_pos` and `curvatureSin_neg` helper lemmas (lines 102-110) rewrite the definition in the respective half-domains and are used internally to prove the two special-value theorems.",
+      "mathContext": "The vanishing at t=0 (`curvatureSin_zero_right`) and the normalization `(d/dt)(curvatureSin K t)|_{t=0} = 1` (not proved here) are characteristic of the sn_K function. The derivative is: for K>0, `d/dt[sin(√K·t)/√K] = cos(√K·t)`, which is 1 at t=0. For K<0, `d/dt[sinh(√(-K)·t)/√(-K)] = cosh(√(-K)·t)`, which is also 1 at t=0. This uniform normalization is why sn_K is the 'right' parametrization for comparing across geometries."
+    },
+    {
+      "id": "scp-spherical-equality",
+      "startLine": 138,
+      "endLine": 165,
+      "title": "Spherical Ptolemy Equality: Restatement in curvatureSin Language",
+      "body": "The theorem `spherical_ptolemy_eq_curvatureSin` re-expresses the spherical Ptolemy equality (already proved in `PtolemysTheoremOQ01OQ02.lean`) using curvatureSin 1 notation. The proof is essentially one line:\n\n```lean\nsimp only [curvatureSin_one]\nexact SphericalPtolemy.spherical_ptolemy h_cosph h_apc h_bpd ha hb hc hd\n```\n\nThe first line rewrites `curvatureSin 1` to `sin` everywhere, and the second line delegates to the existing spherical Ptolemy theorem. The hypotheses carry the full geometric data: `Cospherical` (all four points on a common sphere), two crossing-diagonal conditions (`∠ a p c = π`, `∠ b p d = π`), and four unit-norm conditions.\n\n**Key point**: This theorem requires concyclicity. Without it, only an inequality holds — proved next.",
+      "mathContext": "The hypotheses `∠ a p c = π` and `∠ b p d = π` encode that p lies on the geodesic arc from a to c and from b to d — i.e., p is the intersection of the two diagonals. This is the standard inscribed-quadrilateral condition in spherical geometry. `Cospherical` asserts that all four points lie on a common sphere (great circle or otherwise). Together, these are the direct analogues of the Euclidean 'concyclic' condition in `ptolemy_inequality`'s equality case."
+    },
+    {
+      "id": "scp-chord-arc-substitution",
+      "startLine": 199,
+      "endLine": 229,
+      "title": "Proof of the Inequality: Chord-Arc Substitution + Scaling",
+      "body": "The proof of `spherical_ptolemy_ineq_curvatureSin` is a four-step calculation:\n\n**Step 1** (lines 200-211): Apply `SphericalPtolemy.unit_sphere_chord_via_sin` to each of the six pairs. This gives six equations of the form `‖zᵢ - zⱼ‖ = 2·sin(arccos(⟪zᵢ,zⱼ⟫)/2)`.\n\n**Step 2** (lines 213-218): Solve each for the sin value: `sin(arccos(⟪zᵢ,zⱼ⟫)/2) = ‖zᵢ - zⱼ‖/2`. (Each follows by `linarith` from the previous step.)\n\n**Step 3** (line 220): Rewrite the goal using these six equations. The goal is now purely in terms of norm differences: `‖z₁-z₃‖/2·‖z₂-z₄‖/2 ≤ ‖z₁-z₂‖/2·‖z₃-z₄‖/2 + ‖z₂-z₃‖/2·‖z₁-z₄‖/2`.\n\n**Step 4** (lines 223-229): Apply `ptolemy_inequality` to get `‖z₁-z₃‖·‖z₂-z₄‖ ≤ ‖z₁-z₂‖·‖z₃-z₄‖ + ‖z₂-z₃‖·‖z₁-z₄‖`, then divide by 4 (encoded as `ring` rewriting + `linarith`).",
+      "mathContext": "The norm expression `‖z‖` for `z : ℂ` uses the complex norm, which equals `√(z.re² + z.im²)`. When z lies on the unit circle (‖z‖=1), the inner product `⟪zᵢ, zⱼ⟫_ℝ` is the real inner product of ℂ viewed as ℝ², which equals `(zᵢ·conj(zⱼ)).re = Re(zᵢ·conj(zⱼ))`. The chord-arc identity `‖zᵢ - zⱼ‖ = 2sin(d/2)` where d = arccos⟨zᵢ,zⱼ⟩ is the spherical analogue of the Euclidean chord-length formula `2R·sin(θ/2)` on a circle of radius R=1. The division by 4 at the end arises because the inequality is homogeneous of degree 2 in the norms, and 1/2·1/2 = 1/4."
+    },
+    {
+      "id": "scp-inequality-new-result",
+      "startLine": 171,
+      "endLine": 198,
+      "title": "spherical_ptolemy_ineq_curvatureSin: The Key New Contribution",
+      "body": "The theorem statement deserves careful reading:\n\n```lean\ntheorem spherical_ptolemy_ineq_curvatureSin (z₁ z₂ z₃ z₄ : ℂ)\n    (h1 : ‖z₁‖ = 1) (h2 : ‖z₂‖ = 1) (h3 : ‖z₃‖ = 1) (h4 : ‖z₄‖ = 1) :\n    curvatureSin 1 (arccos (⟪z₁, z₃⟫_ℝ) / 2) * curvatureSin 1 (arccos (⟪z₂, z₄⟫_ℝ) / 2) ≤\n    curvatureSin 1 (arccos (⟪z₁, z₂⟫_ℝ) / 2) * curvatureSin 1 (arccos (⟪z₃, z₄⟫_ℝ) / 2) +\n    curvatureSin 1 (arccos (⟪z₂, z₃⟫_ℝ) / 2) * curvatureSin 1 (arccos (⟪z₁, z₄⟫_ℝ) / 2)\n```\n\nThe only hypotheses are the four unit-norm conditions — there is no Cospherical hypothesis, no crossing-diagonal hypothesis, no concyclicity requirement whatsoever. This is the spherical Ptolemy INEQUALITY for arbitrary quadrilaterals on the unit circle in ℂ.\n\nThe equality case is governed by the four points being concyclic (inscribed in a common great circle in the appropriate ordering), which is when `spherical_ptolemy_eq_curvatureSin` applies.",
+      "mathContext": "The contrast with the Euclidean setting is instructive. In the Euclidean plane, `ptolemy_inequality` (from `PtolemysComplexProof.lean`) states `|z₁-z₃|·|z₂-z₄| ≤ |z₁-z₂|·|z₃-z₄| + |z₂-z₃|·|z₁-z₄|` for any four complex numbers — no unit-norm assumption needed. Here, the unit-norm assumption is required because `arccos(⟨z,w⟩/2)` is the spherical metric (geodesic arc distance) only between unit-norm points. For non-unit points, the expression `arccos(⟨z,w⟩)` may be undefined or meaningless geometrically. So the spherical inequality applies to the unit circle specifically, while the complex Ptolemy inequality is universal."
+    },
+    {
+      "id": "scp-hyperbolic-conjecture",
+      "startLine": 231,
+      "endLine": 257,
+      "title": "Hyperbolic Case: What Would Be Needed",
+      "body": "The file ends with a detailed comment explaining why the K=-1 case is not proved. The conjecture statement would be:\n\n`sinh(d_H(z₁,z₃)/2)·sinh(d_H(z₂,z₄)/2) = sinh(d_H(z₁,z₂)/2)·sinh(d_H(z₃,z₄)/2) + sinh(d_H(z₁,z₄)/2)·sinh(d_H(z₂,z₃)/2)`\n\nfor concyclic points in the Poincaré disk. The key identity needed is:\n\n`sinh(d_H(z,w)/2) = |z - w| / √((1-|z|²)(1-|w|²))`\n\nThe conformal factors `1-|z|²` appear in the hyperbolic chord-arc identity (unlike the spherical case where they cancel because `1-‖z‖² = 0` for ‖z‖=1). The three infrastructure gaps are quantified: ~300 lines for the Poincaré metric structure, ~400-500 for Möbius isometries, ~200 for circle-to-circle correspondence.\n\nThis honest accounting of what is proved vs. conjectured is a strength of the formalization approach.",
+      "mathContext": "The hyperbolic distance in the Poincaré disk model is `d_H(z,w) = 2·arctanh(|φ_z(w)|)` where `φ_z(w) = (w-z)/(1-z̄w)` is the Möbius automorphism moving z to the origin. The half-distance formula `sinh(d_H(z,w)/2) = |z-w|/√((1-|z|²)(1-|w|²))` arises from this. For concyclic hyperbolic points (points on a common hypercircle or horocircle), the conformal factors do NOT cancel as they do for the spherical unit circle — they require careful handling via the Möbius isometry framework. This is the technical obstruction that makes the K=-1 case genuinely harder than the K=1 case."
+    },
+    {
+      "id": "scp-import-architecture",
+      "startLine": 1,
+      "endLine": 5,
+      "title": "Import Structure: Building on Two Parent Proofs",
+      "body": "The five imports reveal the dependency structure:\n\n1. `Proofs.PtolemysComplexProof` — provides `ptolemy_inequality` (complex Ptolemy ≤)\n2. `Proofs.PtolemysTheoremOQ01OQ02` — provides `SphericalPtolemy.spherical_ptolemy` (equality) and `SphericalPtolemy.unit_sphere_chord_via_sin` (chord-arc)\n3. `Mathlib.Analysis.Complex.Trigonometric` — provides `Real.sinh` and complex trigonometry\n4. `Mathlib.Analysis.InnerProductSpace.Basic` — provides inner product `⟪·,·⟫_ℝ` for the real IPS structure on ℂ\n5. `Mathlib.Tactic` — standard tactic infrastructure\n\nThe proof is a synthesis of two gallery proofs (PtolemysComplexProof and PtolemysTheoremOQ01OQ02), demonstrating how gallery entries can serve as stepping stones for more general results.",
+      "mathContext": "The real inner product space structure on ℂ (from `InnerProductSpace.Basic`) treats ℂ as ℝ² with inner product `⟪z,w⟫_ℝ = Re(z·conj(w)) = z.re·w.re + z.im·w.im`. This is the correct inner product for `unit_sphere_chord_via_sin` to apply — the theorem is stated for a general real inner product space V with the standard norm, and ℂ with this inner product is exactly such a space (with the identification |z|² = ⟪z,z⟫_ℝ)."
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

- Writes 8 detailed annotations for `SynthesisCurvaturePtolemy.lean` (was empty)
- Covers: module overview, import architecture, curvatureSin definition (3-case if-then-else + L'Hôpital context), basic properties (K=0/1/-1 cases), spherical Ptolemy equality restatement, the new spherical Ptolemy inequality (key contribution), 4-step chord-arc substitution proof walkthrough, hyperbolic conjecture infrastructure analysis
- Each annotation includes `mathContext` with deeper mathematical connections

## Test plan

- [x] `pnpm build` passes (exit 0, 3m 16s)
- [x] Annotation JSON validates (no build errors)
- [x] 8 annotations × 2 fields (body + mathContext) each

🤖 Generated with [Claude Code](https://claude.ai/claude-code)