### PR TITLE
feat(aristotle): add Aristotle companion for UnitDistanceHN7

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2565,6 +2565,7 @@ import Proofs.TriangularReciprocalGeneralized
 import Proofs.TriangularReciprocalsFigurate
 import Proofs.TwinPrimes
 import Proofs.UnitDistanceHN7
+import Proofs.UnitDistanceHN7Aristotle
 import Proofs.UnitDistanceIndependence
 import Proofs.VietasFormulas
 import Proofs.VietasFormulasOQ02

--- a/proofs/Proofs/UnitDistanceHN7Aristotle.lean
+++ b/proofs/Proofs/UnitDistanceHN7Aristotle.lean
@@ -1,0 +1,70 @@
+/-
+  Aristotle targets for UnitDistanceHN7
+  Routine supporting lemmas for automated proof search.
+  See UnitDistanceHN7.lean for the main Hadwiger-Nelson upper bound (χ(ℝ²) ≤ 7).
+
+  The main file has 3 sorries that are candidates for automated proof:
+  1. hexCenter_dist_sq — algebraic distance formula for A₂ lattice centers
+  2. covering_radius — Voronoi covering radius ≤ s for the hexagonal lattice
+  3. hexColor_eq_implies_mod — mod condition from hexColor equality
+
+  Criteria for inclusion:
+  - NOT the main Hadwiger-Nelson theorem (follows from the 3 sorries above)
+  - Standalone theorems (sorries at theorem level, not buried in proofs)
+  - No definition sorries, no axiom declarations, no open conjectures
+  - No /-! docstring sections (use /- instead)
+-/
+import Proofs.UnitDistanceHN7
+import Mathlib
+
+open EuclideanSpace Real
+
+namespace UnitDistanceHN7Aristotle
+
+/-
+## Target 1: Algebraic Distance Formula for Hex Centers
+
+The A₂ lattice with basis e₁ = (s√3, 0), e₂ = (s√3/2, 3s/2) has center-to-center
+squared distance equal to 3s²·(Δa² + Δa·Δb + Δb²) where s = hexSideLength.
+
+Proof: Let da = a₁ - a₂, db = b₁ - b₂.
+  Δx = s√3·(da + db/2), Δy = 3s/2·db
+  Δx² + Δy² = 3s²·da² + 3s²·da·db + 3s²/4·db² + 9s²/4·db²
+             = 3s²·(da² + da·db + db²)
+-/
+
+/-- Algebraic identity: squared distance between A₂ hex centers equals 3s²·Q(Δa,Δb). -/
+theorem hexCenter_dist_sq_ari (a₁ b₁ a₂ b₂ : ℤ) :
+    dist (hexCenter a₁ b₁) (hexCenter a₂ b₂) ^ 2 =
+    3 * hexSideLength ^ 2 *
+      (((a₁ : ℝ) - a₂) ^ 2 + ((a₁ : ℝ) - a₂) * ((b₁ : ℝ) - b₂) +
+       ((b₁ : ℝ) - b₂) ^ 2) := by
+  sorry
+
+/-
+## Target 2: Hex Color Equality Implies Lattice Mod Condition
+
+The hexColor function assigns color (3q + r) mod 7 to lattice coordinates (q, r).
+If two lattice cells have the same color, then 3·(q₁-q₂) + (r₁-r₂) ≡ 0 (mod 7).
+-/
+
+/-- If two points have the same hexColor, their hexCoord satisfy the mod 7 condition. -/
+theorem hexColor_eq_implies_mod_ari (p q : Plane)
+    (hcolor : hexColor p = hexColor q) :
+    (3 * ((hexCoord p).1 - (hexCoord q).1) + ((hexCoord p).2 - (hexCoord q).2)) % 7 = 0 := by
+  sorry
+
+/-
+## Target 3: Covering Radius of A₂ Lattice
+
+Every point of the plane lies within distance s = hexSideLength of the center
+of its assigned Voronoi hex cell. The cube-coordinate rounding algorithm in
+hexCoord assigns each point to the nearest lattice site.
+-/
+
+/-- Every point is within distance hexSideLength of its assigned hex center. -/
+theorem covering_radius_ari (p : Plane) :
+    dist p (hexCenter (hexCoord p).1 (hexCoord p).2) ≤ hexSideLength := by
+  sorry
+
+end UnitDistanceHN7Aristotle


### PR DESCRIPTION
## Fix

Add Aristotle companion file for the Hadwiger-Nelson upper bound proof (χ(ℝ²) ≤ 7).

## Evidence

**Before**: `UnitDistanceHN7.lean` had 3 standalone sorry-bearing theorems with no Aristotle companion file.

**After**: `UnitDistanceHN7Aristotle.lean` provides the 3 routine lemmas as Aristotle targets:
1. `hexCenter_dist_sq_ari` — algebraic expansion: dist²(center(a₁,b₁), center(a₂,b₂)) = 3s²·Q(Δa,Δb)
2. `hexColor_eq_implies_mod_ari` — mod-7 condition implied by hexColor equality
3. `covering_radius_ari` — every point lies within distance s of its Voronoi hex center

Once Aristotle proves these, `hadwiger_nelson_7coloring` follows automatically (it's fully proved in the main file conditioned on these 3 lemmas).

---
Automated fix by lean-mechanic agent.