### PR TITLE
Enrichment pass: synthesis-curvature-ptolemy + amgm-inequality-oq-02-oq-01-oq-02-oq-01

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01/annotations.json
@@ -14,14 +14,14 @@
   {
     "id": "ann-ng-setup",
     "proofId": "amgm-inequality-oq-02-oq-01-oq-02-oq-01",
-    "range": { "startLine": 19, "endLine": 28 },
+    "range": { "startLine": 24, "endLine": 30 },
     "type": "concept",
-    "title": "Generality: Any CommRing over Any Fintype",
-    "content": "The variable declaration fixes a CommRing R and a Fintype σ, giving the Newton-Girard corollaries in full algebraic generality. All three theorems hold over any commutative ring — not just ℝ or ℚ — with coefficients indexed by any finite type σ. This is more general than the classical statement (which usually specializes to ℝ[x₁,...,xₙ]) and is directly applicable in Mathlib's MvPolynomial framework. The ring tactic closes each final algebraic step because the arithmetic identities are pure commutative ring equations.",
-    "mathContext": "$R$ is any commutative ring, $\\sigma$ is any finite type (index set). The power sum $p_k = \\sum_{i : \\sigma} X_i^k \\in \\text{MvPolynomial}(\\sigma, R)$ and $e_k = \\text{esymm}(\\sigma, R, k)$ are elements of `MvPolynomial σ R`. The identity $p_2 = e_1^2 - 2e_2$ is a polynomial identity with integer coefficients, hence valid over any ring.",
+    "title": "Namespace, Opens, and Variable: Full Algebraic Generality",
+    "content": "Lines 24-30 set up the ambient context for all three theorems:\n\n- `namespace AMGMInequalityOQ02OQ01OQ02OQ01` — scopes the theorems to avoid name conflicts\n- `open MvPolynomial Finset BigOperators Set` — brings `psum`, `esymm`, `∑`, `antidiagonal`, `Ioo` into scope without qualification\n- `variable (σ : Type*) (R : Type*) [CommRing R] [Fintype σ]` — universally quantifies over any commutative ring R and any finite index type σ\n\nThe `variable` declaration makes all three Newton-Girard corollaries hold over any commutative ring — not just ℝ or ℚ — with coefficients indexed by any finite type σ. This is more general than the classical statement (usually specialized to ℝ[x₁,...,xₙ]) and directly applicable in Mathlib's MvPolynomial framework. The `ring` tactic closes each final step because the arithmetic identities are polynomial identities with integer coefficients, valid over any ring.",
+    "mathContext": "$R$ is any commutative ring, $\\sigma$ is any finite type (index set). The power sum $p_k = \\sum_{i : \\sigma} X_i^k \\in \\text{MvPolynomial}(\\sigma, R)$ and $e_k = \\text{esymm}(\\sigma, R, k)$ are elements of `MvPolynomial σ R`. The identity $p_2 = e_1^2 - 2e_2$ is a polynomial identity with integer coefficients (in $\\mathbb{Z}[e_1, e_2]$), hence valid over any commutative ring by base change. `BigOperators` enables the $\\sum$ notation.",
     "significance": "supporting",
-    "relatedConcepts": ["CommRing", "Fintype", "MvPolynomial", "type class generality"],
-    "prerequisites": ["Lean 4 type classes", "MvPolynomial σ R"]
+    "relatedConcepts": ["CommRing", "Fintype", "MvPolynomial", "type-class-generality", "namespace", "open-statement", "BigOperators"],
+    "prerequisites": ["Lean 4 type classes", "MvPolynomial σ R", "namespace keyword", "open keyword", "variable keyword"]
   },
   {
     "id": "ann-ng-k1",

--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01/meta.json
@@ -53,7 +53,8 @@
       "The antidiagonal filter computation uses omega to verify membership conditions, making the combinatorial bookkeeping fully automatic",
       "psum_one_eq_esymm_one bridges two Mathlib lemmas (psum_one and esymm_one) that each separately state p₁ = Σ X i = e₁",
       "All three corollaries work over any CommRing, not just ℝ — the algebraic structure is the only requirement",
-      "The ring tactic closes each corollary after the antidiagonal is fully expanded, separating the combinatorial filtering from the algebraic simplification"
+      "The ring tactic closes each corollary after the antidiagonal is fully expanded, separating the combinatorial filtering from the algebraic simplification",
+      "The three-tactic pipeline — omega for antidiagonal arithmetic, sum_insert/sum_singleton for finite sum expansion, ring for polynomial identity — is a separable and composable proof strategy: each tactic handles exactly one layer of the proof (number theory → combinatorics → algebra)"
     ],
     "prerequisites": [
       "MvPolynomial.psum_eq_mul_esymm_sub_sum — general Newton-Girard recurrence (Mathlib)",


### PR DESCRIPTION
Two-entry enrichment pass.

## 1. synthesis-curvature-ptolemy (quality 38 → significant improvement)

### Annotations (critical structural fix)
- Fixed schema: all 8 annotations had wrong field names (`body`→`content`, flat `startLine`→`range:{startLine,endLine}`) and were missing `proofId`, `type`, `significance`
- Added 2 new annotations: IPS variable declaration (lines 136-137) and #check summary section (lines 259-270)
- Added to all: `significance`, `relatedConcepts`, `prerequisites`
- Total: 10 annotations, full schema compliance

### meta.json
- Expanded `historicalContext`: 256→822 chars; traces from Ptolemy's *Almagest* (~150 CE) through Al-Battani, Regiomontanus, Bolyai/Lobachevsky/Gauss, to Beardon-Minda (2007)
- Added 5th keyInsight: factor-of-4 scaling from chord-arc identity on unit circle
- Sections: 4→8 (full file coverage, including module header, IPS variable, hyperbolic conjecture, #check summary)

---

## 2. amgm-inequality-oq-02-oq-01-oq-02-oq-01 (quality 98, minor improvements)

- Fixed `ann-ng-setup` range: lines 19-28 (inside docstring) → 24-30 (actual namespace/open/variable). Updated content to explain namespace scoping, open statements, and `variable` keyword
- Added 6th keyInsight: omega→sum_insert→ring as a separable, composable proof strategy

## Build
`pnpm build` passes (exit code 0).