### PR TITLE
feat(aristotle): integrate type_class_size_eq_multinomial proof

### DIFF
--- a/proofs/Proofs/ShannonSourceCodingOQ04Aristotle.lean
+++ b/proofs/Proofs/ShannonSourceCodingOQ04Aristotle.lean
@@ -114,11 +114,12 @@ theorem log_typeProb_eq' (n : ℕ) (hn : (n : ℝ) ≠ 0)
       = ((n : ℝ) * ((f i : ℝ) / n)) * Real.log ((f i : ℝ) / n) := by rw [hkey]
     _ = (n : ℝ) * ((f i : ℝ) / n * Real.log ((f i : ℝ) / n)) := by ring
 
--- ============================================================
--- PRIMARY TARGET: Type class size = multinomial coefficient
--- ============================================================
+/-
+============================================================
+PRIMARY TARGET: Type class size = multinomial coefficient
+============================================================
 
-/-- **Type class size equals the multinomial coefficient**: |T_f| = n! / ∏(f i)!
+**Type class size equals the multinomial coefficient**: |T_f| = n! / ∏(f i)!
 
     This is the fundamental counting fact of the method of types (Csiszár-Körner 1981).
 
@@ -141,9 +142,72 @@ theorem log_typeProb_eq' (n : ℕ) (hn : (n : ℝ) ≠ 0)
 
     Key lemmas:
     - Nat.multinomial_spec: ∏(f i)! * multinomial univ f = (∑ f i)! = n!
-    - Fintype.card_perm: (Finset.univ : Finset (Equiv.Perm (Fin n))).card = n! -/
+    - Fintype.card_perm: (Finset.univ : Finset (Equiv.Perm (Fin n))).card = n!
+-/
 theorem type_class_size_eq_multinomial (n : ℕ) (f : Fin k → ℕ) (hf : ∑ i, f i = n) :
     (typeClass' n f hf).card = Nat.multinomial Finset.univ f := by
-  sorry
+  -- The number of such permutations is exactly $\frac{n!}{\prod_{i=0}^{k-1} f_i!}$.
+  have h_card : Finset.card (Finset.univ.filter (fun σ : Fin n → Fin k => ∀ i : Fin k, Finset.card (Finset.filter (fun j => σ j = i) Finset.univ) = f i)) = Nat.factorial n / (∏ i, Nat.factorial (f i)) := by
+    rw [ Nat.div_eq_of_eq_mul_left ];
+    · exact Finset.prod_pos fun i _ => Nat.factorial_pos _;
+    · induction' n with n ih generalizing f;
+      · simp_all +decide [ Finset.ext_iff ];
+      · -- Consider the set of sequences where the last element is $i$.
+        have h_split : Finset.card (Finset.filter (fun σ : Fin (n + 1) → Fin k => ∀ i, Finset.card (Finset.filter (fun j => σ j = i) Finset.univ) = f i) (Finset.univ : Finset (Fin (n + 1) → Fin k))) = ∑ i, Finset.card (Finset.filter (fun σ : Fin n → Fin k => ∀ j, Finset.card (Finset.filter (fun l => σ l = j) Finset.univ) = if j = i then f i - 1 else f j) (Finset.univ : Finset (Fin n → Fin k))) := by
+          have h_split : Finset.filter (fun σ : Fin (n + 1) → Fin k => ∀ i, Finset.card (Finset.filter (fun j => σ j = i) Finset.univ) = f i) (Finset.univ : Finset (Fin (n + 1) → Fin k)) = Finset.biUnion (Finset.univ : Finset (Fin k)) (fun i => Finset.image (fun σ : Fin n → Fin k => Fin.snoc σ i) (Finset.filter (fun σ : Fin n → Fin k => ∀ j, Finset.card (Finset.filter (fun l => σ l = j) Finset.univ) = if j = i then f i - 1 else f j) (Finset.univ : Finset (Fin n → Fin k)))) := by
+            ext σ;
+            constructor;
+            · intro hσ;
+              simp +zetaDelta at *;
+              refine' ⟨ σ ( Fin.last n ), Fin.init σ, _, _ ⟩ <;> simp +decide [ ← hσ, Fin.init_def, Fin.snoc ];
+              · intro j; split_ifs <;> simp_all +decide [ Finset.filter_erase, Finset.filter_or ] ;
+                · rw [ ← hσ ];
+                  rw [ Finset.card_filter, Finset.card_filter ];
+                  rw [ Fin.sum_univ_castSucc ] ; aesop;
+                · convert hσ j using 1;
+                  rw [ Finset.card_filter, Finset.card_filter ];
+                  rw [ Fin.sum_univ_castSucc ] ; aesop;
+              · exact funext fun i => by cases i using Fin.lastCases <;> simp +decide [ * ] ;
+            · simp +zetaDelta at *;
+              rintro i σ hσ rfl j; by_cases hj : j = i <;> simp_all +decide [ Fin.snoc ] ;
+              · convert congr_arg ( · + 1 ) ( hσ i ) using 1;
+                · rw [ Finset.card_filter, Finset.card_filter ];
+                  rw [ Fin.sum_univ_castSucc ] ; aesop;
+                · have h_sum : ∑ i, Finset.card (Finset.filter (fun l => σ l = i) Finset.univ) = n := by
+                    simp +decide only [card_filter];
+                    rw [ Finset.sum_comm ] ; aesop;
+                  grind;
+              · convert hσ j using 1;
+                · rw [ Finset.card_filter, Finset.card_filter ];
+                  rw [ Fin.sum_univ_castSucc ] ; aesop;
+                · rw [ if_neg hj ];
+          rw [ h_split, Finset.card_biUnion ];
+          · exact Finset.sum_congr rfl fun _ _ => Finset.card_image_of_injective _ fun x y hxy => by simpa [ Fin.ext_iff ] using hxy;
+          · intros i hi j hj hij; simp [Finset.disjoint_left, Finset.mem_image];
+            grind +extAll;
+        -- Apply the induction hypothesis to each term in the sum.
+        have h_ind : ∀ i, Finset.card (Finset.filter (fun σ : Fin n → Fin k => ∀ j, Finset.card (Finset.filter (fun l => σ l = j) Finset.univ) = if j = i then f i - 1 else f j) (Finset.univ : Finset (Fin n → Fin k))) * (∏ j, (f j).factorial) = (n.factorial) * (f i) := by
+          intro i
+          by_cases hi : f i = 0;
+          · simp [hi];
+            left;
+            intro x; contrapose! hf; simp_all +decide [ Finset.sum_eq_zero_iff_of_nonneg ] ;
+            have h_sum : ∑ i, Finset.card (Finset.filter (fun l => x l = i) Finset.univ) = n := by
+              simp +decide only [card_filter];
+              rw [ Finset.sum_comm ] ; aesop;
+            grind;
+          · rw [ ih ( fun j => if j = i then f i - 1 else f j ) ];
+            · rw [ mul_assoc, ← Finset.prod_erase_mul _ _ ( Finset.mem_univ i ) ];
+              rw [ ← Finset.prod_erase_mul _ _ ( Finset.mem_univ i ) ];
+              rw [ ← mul_assoc, ← mul_assoc, ← Nat.succ_pred_eq_of_pos ( Nat.pos_of_ne_zero hi ) ] ; simp +decide [ Nat.factorial_succ, mul_assoc, mul_comm, mul_left_comm, Finset.prod_ite, Finset.filter_ne', Finset.filter_eq', hi ];
+              exact Or.inl <| Or.inl <| Finset.prod_congr rfl fun x hx => by aesop;
+            · simp_all +decide [ Finset.sum_ite, Finset.filter_eq', Finset.filter_ne' ];
+              rw [ ← Finset.sum_erase_add _ _ ( Finset.mem_univ i ), add_comm ] at hf ; omega;
+        simp_all +decide [ Nat.factorial_succ, mul_comm, Finset.mul_sum _ _ _ ];
+        rw [ ← Finset.sum_mul _ _ _, hf, mul_comm ];
+  convert h_card using 1;
+  · unfold typeClass';
+    simp +decide [ funext_iff, Finset.ext_iff, empDist' ];
+  · rw [ Nat.multinomial, ← hf ]
 
 end ShannonSourceCodingOQ04Aristotle

--- a/research/aristotle-jobs.json
+++ b/research/aristotle-jobs.json
@@ -78,9 +78,9 @@
       "problem_id": "erdos-166",
       "submitted": "2026-01-15T08:27:18Z",
       "sorries": [
-        "theorem ramsey_one_left (t : \u2115) (ht : t \u2265 1) : R(1, t) = 1 := by",
-        "theorem ramsey_symmetric (s t : \u2115) : R(s, t) = R(t, s) := by",
-        "theorem ramsey_two_left (t : \u2115) (ht : t \u2265 2) : R(2, t) = t := by"
+        "theorem ramsey_one_left (t : ℕ) (ht : t ≥ 1) : R(1, t) = 1 := by",
+        "theorem ramsey_symmetric (s t : ℕ) : R(s, t) = R(t, s) := by",
+        "theorem ramsey_two_left (t : ℕ) (ht : t ≥ 2) : R(2, t) = t := by"
       ],
       "notes": "Ramsey R(4,k) lower bound - Mattheus-Verstraete 2023",
       "status": "integrated",
@@ -94,8 +94,8 @@
       "problem_id": "erdos-167",
       "submitted": "2026-01-15T08:27:20Z",
       "sorries": [
-        "theorem k4_tight : \u2203 (G : SimpleGraph (Fin 4)),",
-        "theorem k5_tight : \u2203 (G : SimpleGraph (Fin 5)),",
+        "theorem k4_tight : ∃ (G : SimpleGraph (Fin 4)),",
+        "theorem k5_tight : ∃ (G : SimpleGraph (Fin 5)),",
         "theorem trivial_bound (G : SimpleGraph V) :"
       ],
       "notes": "Tuza triangle covering conjecture",
@@ -110,10 +110,10 @@
       "problem_id": "erdos-168",
       "submitted": "2026-01-15T08:27:30Z",
       "sorries": [
-        "theorem better_construction (N : \u2115) :",
-        "theorem density_bounded (N : \u2115) (hN : N \u2265 1) :",
-        "theorem F_monotone (N : \u2115) : F N \u2264 F (N + 1) := by",
-        "theorem simple_lower_bound (N : \u2115) (hN : N \u2265 1) :"
+        "theorem better_construction (N : ℕ) :",
+        "theorem density_bounded (N : ℕ) (hN : N ≥ 1) :",
+        "theorem F_monotone (N : ℕ) : F N ≤ F (N + 1) := by",
+        "theorem simple_lower_bound (N : ℕ) (hN : N ≥ 1) :"
       ],
       "notes": "n 2n 3n free sets - GSW 1977",
       "status": "integrated",
@@ -128,7 +128,7 @@
       "submitted": "2026-01-15T08:27:35Z",
       "sorries": [
         "theorem chromatic_ge_clique {V : Type*} [Fintype V] (G : SimpleGraph V) :",
-        "theorem trivial_upper (n : \u2115) : maxChromaticSegments n \u2264 n := by"
+        "theorem trivial_upper (n : ℕ) : maxChromaticSegments n ≤ n := by"
       ],
       "notes": "Segment intersection chromatic - Pawlik 2014",
       "status": "integrated",
@@ -208,7 +208,7 @@
       "sorries": [
         ""
       ],
-      "notes": "Chromatic subgraphs - R\u00f6dl 1977",
+      "notes": "Chromatic subgraphs - Rödl 1977",
       "status": "integrated",
       "last_check": null,
       "integrated": "2026-01-16"
@@ -312,7 +312,7 @@
         "squarefree_double_odd",
         "squarefree_one"
       ],
-      "notes": "REVISIT: 9 axioms. Main conjectures OPEN. Supporting axioms HARD (Filaseta-Trifonov 1992, Pandey 2024, Erd\u0151s 1951, Granville 1998). Build verified.",
+      "notes": "REVISIT: 9 axioms. Main conjectures OPEN. Supporting axioms HARD (Filaseta-Trifonov 1992, Pandey 2024, Erdős 1951, Granville 1998). Build verified.",
       "status": "failed",
       "last_check": null,
       "outcome": "Aristotle failed to load environment. All sorries converted to axioms. No theorems proved.",
@@ -333,7 +333,7 @@
         "liu_montgomery",
         "penman_uncountable"
       ],
-      "notes": "REVISIT: 8 axioms. SOLVED (Liu-Montgomery 2020). Axioms include de Bruijn-Erd\u0151s, Bondy-Simonovits, high degree cycle results. Build verified.",
+      "notes": "REVISIT: 8 axioms. SOLVED (Liu-Montgomery 2020). Axioms include de Bruijn-Erdős, Bondy-Simonovits, high degree cycle results. Build verified.",
       "status": "failed",
       "last_check": null,
       "outcome": "Aristotle failed to load environment. Unexpected axioms added. No theorems proved.",
@@ -354,7 +354,7 @@
         "harborth_five",
         "kreisel_kurz_seven"
       ],
-      "notes": "REVISIT: 8 axioms. OPEN for general case, n=7 best known. Axioms include Anning-Erd\u0151s, Harborth n=5, Kreisel-Kurz n=7, GIP sparsity. Build verified.",
+      "notes": "REVISIT: 8 axioms. OPEN for general case, n=7 best known. Axioms include Anning-Erdős, Harborth n=5, Kreisel-Kurz n=7, GIP sparsity. Build verified.",
       "status": "failed",
       "last_check": null,
       "outcome": "Aristotle failed to load environment. No theorems proved - all axiomatized.",
@@ -368,8 +368,8 @@
       "sorries": [
         "kovac_tao_all_rationals",
         "stolarsky_conjecture_false",
-        "theorem harmonic_diverges : \u00acSummable (fun n : \u2115 => (1 : \u211d) / (n + 1)) := by",
-        "theorem sum_reciprocal_squares_summable : Summable (fun n : \u2115 => (1 : \u211d) / (n + 1)^2) := by"
+        "theorem harmonic_diverges : ¬Summable (fun n : ℕ => (1 : ℝ) / (n + 1)) := by",
+        "theorem sum_reciprocal_squares_summable : Summable (fun n : ℕ => (1 : ℝ) / (n + 1)^2) := by"
       ],
       "notes": "Standard convergence/divergence results for series",
       "status": "failed",
@@ -391,8 +391,8 @@
         "suk_bound",
         "theorem f_3_value : f 3 = 3 := by",
         "theorem f_4_lb : 4 < f 4 := by",
-        "theorem f_4_ub : f 4 \u2264 5 := by",
-        "theorem f_finite (n : \u2115) (hn : 3 \u2264 n) : (CardSet n).Nonempty := by",
+        "theorem f_4_ub : f 4 ≤ 5 := by",
+        "theorem f_finite (n : ℕ) (hn : 3 ≤ n) : (CardSet n).Nonempty := by",
         "theorem f_three_eq : f 3 = 3 := by"
       ],
       "notes": "5 sorries: Happy Ending Problem - f_3_value, f_4_lb, f_4_ub, f_finite, f_three_eq",
@@ -430,9 +430,9 @@
         "theorem example_binomial_square :",
         "theorem example_trinomial_square :",
         "theorem f_one : f 1 = 1 := by",
-        "theorem f_pos (k : \u2115) (hk : k \u2265 1) : f k \u2265 1 := by",
+        "theorem f_pos (k : ℕ) (hk : k ≥ 1) : f k ≥ 1 := by",
         "theorem f_two : f 2 = 3 := by",
-        "theorem general_divergence (n : \u2115) (hn : n \u2265 1) :",
+        "theorem general_divergence (n : ℕ) (hn : n ≥ 1) :",
         "theorem schinzel_lower_bound :",
         "theorem schinzel_zannier_improved :"
       ],
@@ -450,10 +450,10 @@
         "brownRodl_theorem",
         "erdos303_true",
         "theorem infinitely_many_solutions :",
-        "theorem monochromatic_iff_alt (\ud835\udcd2 : \u2124 \u2192 \u03b1) (a b c : \u2124) :",
-        "theorem unitFractionEq_iff_alt (a b c : \u2124) (ha : a \u2260 0) (hb : b \u2260 0) (hc : c \u2260 0) :"
+        "theorem monochromatic_iff_alt (𝓒 : ℤ → α) (a b c : ℤ) :",
+        "theorem unitFractionEq_iff_alt (a b c : ℤ) (ha : a ≠ 0) (hb : b ≠ 0) (hc : c ≠ 0) :"
       ],
-      "notes": "Monochromatic Unit Fraction Solutions - SOLVED (Brown-R\u00f6dl 1991)",
+      "notes": "Monochromatic Unit Fraction Solutions - SOLVED (Brown-Rödl 1991)",
       "status": "integrated",
       "last_check": null,
       "integrated": "2026-01-19",
@@ -532,7 +532,7 @@
       "status": "integrated",
       "original_sorries": 5,
       "solved_sorries": 3,
-      "notes": "Integrated from batch - 5\u21923 sorries"
+      "notes": "Integrated from batch - 5→3 sorries"
     },
     {
       "project_id": "e8c7f151-cf4a-4257-9ee1-cc564571ebff",
@@ -543,7 +543,7 @@
       "status": "integrated",
       "original_sorries": 3,
       "solved_sorries": 2,
-      "notes": "Integrated from batch - 3\u21922 sorries"
+      "notes": "Integrated from batch - 3→2 sorries"
     },
     {
       "project_id": "463fd6f9-3344-4387-82fe-0c9a02da0dec",
@@ -554,7 +554,7 @@
       "status": "integrated",
       "original_sorries": 2,
       "solved_sorries": 1,
-      "notes": "Integrated from batch - 2\u21921 sorries"
+      "notes": "Integrated from batch - 2→1 sorries"
     },
     {
       "project_id": "4d4f46e7-8d9e-49a3-8943-4c97ee8a241f",
@@ -565,7 +565,7 @@
       "status": "integrated",
       "original_sorries": 5,
       "solved_sorries": 1,
-      "notes": "Integrated from batch - 5\u21921 sorries"
+      "notes": "Integrated from batch - 5→1 sorries"
     },
     {
       "project_id": "254112df-e7b4-495b-8be3-2d2617d6d9e6",
@@ -576,7 +576,7 @@
       "status": "integrated",
       "original_sorries": 2,
       "solved_sorries": 1,
-      "notes": "Integrated from batch - 2\u21921 sorries"
+      "notes": "Integrated from batch - 2→1 sorries"
     },
     {
       "project_id": "a906ad36-22fc-4cc3-9c05-75bb1642dce8",
@@ -587,7 +587,7 @@
       "status": "integrated",
       "original_sorries": 3,
       "solved_sorries": 1,
-      "notes": "Integrated from batch - 3\u21921 sorries"
+      "notes": "Integrated from batch - 3→1 sorries"
     },
     {
       "project_id": "f5d0f273-819d-49bf-9021-01842b19bafa",
@@ -598,7 +598,7 @@
       "status": "integrated",
       "original_sorries": 5,
       "solved_sorries": 1,
-      "notes": "Integrated from batch - 5\u21921 sorries"
+      "notes": "Integrated from batch - 5→1 sorries"
     },
     {
       "project_id": "ca6f73f6-7352-477a-9749-0820bcfd35b4",
@@ -609,7 +609,7 @@
       "status": "integrated",
       "original_sorries": 3,
       "solved_sorries": 1,
-      "notes": "Integrated from batch - 3\u21921 sorries"
+      "notes": "Integrated from batch - 3→1 sorries"
     },
     {
       "project_id": "b01a17b8-e26e-43e4-be75-3aed52544d5f",
@@ -620,7 +620,7 @@
       "status": "integrated",
       "original_sorries": 4,
       "solved_sorries": 1,
-      "notes": "Integrated from batch - 4\u21921 sorries"
+      "notes": "Integrated from batch - 4→1 sorries"
     },
     {
       "project_id": "8942450f-e396-4846-97d7-20d51ef5dc57",
@@ -631,7 +631,7 @@
       "status": "integrated",
       "original_sorries": 3,
       "solved_sorries": 1,
-      "notes": "Integrated from batch - 3\u21921 sorries"
+      "notes": "Integrated from batch - 3→1 sorries"
     },
     {
       "project_id": "74278ca0-5769-438b-99fa-24efaa3f8ab9",
@@ -642,7 +642,7 @@
       "status": "integrated",
       "original_sorries": 4,
       "solved_sorries": 1,
-      "notes": "Integrated from batch - 4\u21921 sorries"
+      "notes": "Integrated from batch - 4→1 sorries"
     },
     {
       "project_id": "fc551401-f8db-40d2-9c00-d35b6708cb8e",
@@ -653,7 +653,7 @@
       "status": "integrated",
       "original_sorries": 3,
       "solved_sorries": 1,
-      "notes": "Integrated from batch - 3\u21921 sorries"
+      "notes": "Integrated from batch - 3→1 sorries"
     },
     {
       "project_id": "0981c660-3812-4596-b582-37bcd8147b2f",
@@ -664,7 +664,7 @@
       "status": "integrated",
       "original_sorries": 3,
       "solved_sorries": 1,
-      "notes": "Integrated from batch - 3\u21921 sorries"
+      "notes": "Integrated from batch - 3→1 sorries"
     },
     {
       "project_id": "07534fa5-cea1-4211-ac2e-66e3b86304f3",
@@ -675,7 +675,7 @@
       "status": "integrated",
       "original_sorries": 7,
       "solved_sorries": 1,
-      "notes": "Integrated from batch - 7\u21921 sorries"
+      "notes": "Integrated from batch - 7→1 sorries"
     },
     {
       "project_id": "b68219bf-f6f6-468d-aaf9-dee153ed25e4",
@@ -686,7 +686,7 @@
       "status": "integrated",
       "original_sorries": 3,
       "solved_sorries": 1,
-      "notes": "Integrated from batch - 3\u21921 sorries"
+      "notes": "Integrated from batch - 3→1 sorries"
     },
     {
       "project_id": "2c0deff5-83dc-45bd-a8dc-7d900c102ea5",
@@ -697,7 +697,7 @@
       "status": "integrated",
       "original_sorries": 3,
       "solved_sorries": 2,
-      "notes": "Integrated from batch - 3\u21922 sorries"
+      "notes": "Integrated from batch - 3→2 sorries"
     },
     {
       "project_id": "53ad8a5a-cb79-424d-a474-eb6a05318d2c",
@@ -708,7 +708,7 @@
       "status": "integrated",
       "original_sorries": 2,
       "solved_sorries": 1,
-      "notes": "Integrated from batch - 2\u21921 sorries"
+      "notes": "Integrated from batch - 2→1 sorries"
     },
     {
       "project_id": "ecfa895b-88ce-4432-aa19-9f0b5db1f88c",
@@ -719,7 +719,7 @@
       "status": "integrated",
       "original_sorries": 11,
       "solved_sorries": 6,
-      "notes": "Integrated from batch - 11\u21926 sorries"
+      "notes": "Integrated from batch - 11→6 sorries"
     },
     {
       "project_id": "5e879a4b-c313-4d93-ada9-41f2dcf2407c",
@@ -730,7 +730,7 @@
       "status": "integrated",
       "original_sorries": 1,
       "solved_sorries": 0,
-      "notes": "Integrated from batch - 1\u21920 sorries"
+      "notes": "Integrated from batch - 1→0 sorries"
     },
     {
       "project_id": "6bcac25f-2091-4639-a3d8-7ff2d53963c1",
@@ -2454,7 +2454,7 @@
       "preprocessing_log": null,
       "companion_file": true,
       "notes": "Companion file submission (T1)",
-      "outcome": "0 sorries remaining (companion file \u2014 merge into Erdos247Problem.lean)",
+      "outcome": "0 sorries remaining (companion file — merge into Erdos247Problem.lean)",
       "theorems_proved": 0
     },
     {
@@ -2989,7 +2989,7 @@
       "preprocessing_log": null,
       "companion_file": true,
       "notes": "Companion file submission (T1)",
-      "outcome": "1 sorries remaining (companion file \u2014 merge into Erdos1040Problem.lean)",
+      "outcome": "1 sorries remaining (companion file — merge into Erdos1040Problem.lean)",
       "theorems_proved": 3
     },
     {
@@ -3002,7 +3002,7 @@
       "preprocessing_log": null,
       "companion_file": true,
       "notes": "Companion file submission (T1)",
-      "outcome": "0 sorries remaining (companion file \u2014 merge into Erdos1OQ03Problem.lean)",
+      "outcome": "0 sorries remaining (companion file — merge into Erdos1OQ03Problem.lean)",
       "theorems_proved": 1
     },
     {
@@ -3122,7 +3122,7 @@
       "sorries": [
         ""
       ],
-      "notes": "End of session: energy_increment_packaging_ari sorry \u2014 Finset.sum_union decomposition for block energy comparison",
+      "notes": "End of session: energy_increment_packaging_ari sorry — Finset.sum_union decomposition for block energy comparison",
       "status": "integrated",
       "last_check": null,
       "outcome": "Already had 0 sorries",
@@ -3316,77 +3316,77 @@
       "project_id": "4bb3ac2d-d948-48ca-8b43-67eb8baecefc",
       "file": null,
       "status": "failed",
-      "notes": "Server COMPLETE but file:null \u2014 unrecoverable, size mismatch on retrieval",
+      "notes": "Server COMPLETE but file:null — unrecoverable, size mismatch on retrieval",
       "submitted": "2026-04-13"
     },
     {
       "project_id": "80f6ff5c-54d1-4d86-844f-c02aa76203d9",
       "file": null,
       "status": "failed",
-      "notes": "Server COMPLETE but file:null \u2014 unrecoverable, size mismatch on retrieval",
+      "notes": "Server COMPLETE but file:null — unrecoverable, size mismatch on retrieval",
       "submitted": "2026-04-13"
     },
     {
       "project_id": "54926dfe-de0f-4200-95ba-7fe50531e284",
       "file": null,
       "status": "failed",
-      "notes": "Server COMPLETE but file:null \u2014 unrecoverable, size mismatch on retrieval",
+      "notes": "Server COMPLETE but file:null — unrecoverable, size mismatch on retrieval",
       "submitted": "2026-04-13"
     },
     {
       "project_id": "1f53b403-353f-45ae-b7e9-2dc77d62de96",
       "file": null,
       "status": "failed",
-      "notes": "Server COMPLETE but file:null \u2014 unrecoverable, size mismatch on retrieval",
+      "notes": "Server COMPLETE but file:null — unrecoverable, size mismatch on retrieval",
       "submitted": "2026-04-13"
     },
     {
       "project_id": "a7d46ece-d317-4e4d-8a7b-f1ce92e6f28e",
       "file": null,
       "status": "failed",
-      "notes": "Server COMPLETE but file:null \u2014 unrecoverable, size mismatch on retrieval",
+      "notes": "Server COMPLETE but file:null — unrecoverable, size mismatch on retrieval",
       "submitted": "2026-04-13"
     },
     {
       "project_id": "7a4c7e49-034a-494c-96e3-c0dcc985cc9b",
       "file": null,
       "status": "failed",
-      "notes": "Server COMPLETE but file:null \u2014 unrecoverable, size mismatch on retrieval",
+      "notes": "Server COMPLETE but file:null — unrecoverable, size mismatch on retrieval",
       "submitted": "2026-04-13"
     },
     {
       "project_id": "5bdd79ee-bc17-4a53-a0d1-2391d47d8bb5",
       "file": null,
       "status": "failed",
-      "notes": "Server COMPLETE but file:null \u2014 unrecoverable, size mismatch on retrieval",
+      "notes": "Server COMPLETE but file:null — unrecoverable, size mismatch on retrieval",
       "submitted": "2026-04-13"
     },
     {
       "project_id": "77a39615-643b-4965-bf77-f7382175da9e",
       "file": null,
       "status": "failed",
-      "notes": "Server COMPLETE but file:null \u2014 unrecoverable, size mismatch on retrieval",
+      "notes": "Server COMPLETE but file:null — unrecoverable, size mismatch on retrieval",
       "submitted": "2026-04-13"
     },
     {
       "project_id": "3328cc74-9e64-4799-9fee-9f4f727e0890",
       "file": null,
       "status": "failed",
-      "notes": "Server COMPLETE but file:null \u2014 unrecoverable, size mismatch on retrieval",
+      "notes": "Server COMPLETE but file:null — unrecoverable, size mismatch on retrieval",
       "submitted": "2026-04-13"
     },
     {
       "project_id": "2a611ba5-5e4a-442b-8770-565631eccd03",
       "file": null,
       "status": "failed",
-      "notes": "Server COMPLETE but file:null \u2014 unrecoverable, size mismatch on retrieval",
+      "notes": "Server COMPLETE but file:null — unrecoverable, size mismatch on retrieval",
       "submitted": "2026-04-13"
     },
     {
       "project_id": "d326ce8e-8706-408b-9f0e-4d1e8cb85b4d",
       "file": null,
       "status": "failed",
-      "notes": "Server COMPLETE but file:null \u2014 unrecoverable, size mismatch on retrieval",
+      "notes": "Server COMPLETE but file:null — unrecoverable, size mismatch on retrieval",
       "submitted": "2026-04-13"
     },
     {
@@ -3445,7 +3445,7 @@
         "vosper_case1_exists",
         "ap_of_near_periodic"
       ],
-      "notes": "Case 1 existence: find a\u2080\u2208A with |(A\\{a\u2080})+B|=|A|+|B|-2. Hard counting argument. ap_of_near_periodic is restated for context (proved in main file).",
+      "notes": "Case 1 existence: find a₀∈A with |(A\\{a₀})+B|=|A|+|B|-2. Hard counting argument. ap_of_near_periodic is restated for context (proved in main file).",
       "outcome": "0 sorries remaining",
       "theorems_proved": 2
     },
@@ -3603,10 +3603,30 @@
       "project_id": "1476ea38-a421-41dc-9a8d-a79ba7e007a8",
       "problem_id": "erdos-476-oq-05",
       "file": "proofs/Proofs/Erdos476OQ05Aristotle.lean",
-      "status": "submitted",
+      "status": "completed",
       "created": "2026-04-24T12:53:06.658888",
       "description": "Prove ap_sdiff_endpoint and case1_exists for Vosper theorem",
-      "sorry_count": 2
+      "sorry_count": 2,
+      "outcome": "2 sorries remaining"
+    },
+    {
+      "project_id": "7303fc7f-3d89-4237-834f-372d9026a17d",
+      "file": "proofs/Proofs/ShannonSourceCodingOQ04Aristotle.lean",
+      "problem_id": "shannonsourcecodingoq04",
+      "submitted": "unknown",
+      "status": "integrated",
+      "outcome": "1 theorems proved via server recovery",
+      "theorems_proved": 1,
+      "notes": "Recovered and integrated from server at 2026-04-26T11:02:50Z"
+    },
+    {
+      "project_id": "5a02b98d-61de-4cf8-aacf-f2b31de9f7d8",
+      "file": "proofs/Proofs/AbelRuffiniGaloisExtensions.lean",
+      "problem_id": "abelruffinigaloisextensions",
+      "submitted": "unknown",
+      "status": "completed",
+      "outcome": "No improvement (recovered from server)",
+      "notes": "Recovered from server at 2026-04-26T11:03:09Z. No sorry reduction."
     }
   ]
 }


### PR DESCRIPTION
## Fix

Integrates Aristotle's completed proof of `type_class_size_eq_multinomial` in `ShannonSourceCodingOQ04Aristotle.lean`.

## Evidence

**Before**: Companion file had 1 sorry (`type_class_size_eq_multinomial`)
**After**: Companion file has 0 sorries — fully proven by Aristotle (Harmonic)

## Theorem Proved

```
theorem type_class_size_eq_multinomial (n : ℕ) (f : Fin k → ℕ) (hf : ∑ i, f i = n) :
    (typeClass' n f hf).card = Nat.multinomial Finset.univ f
```

This is the fundamental counting fact of the method of types: the number of sequences of block length n with empirical distribution f equals the multinomial coefficient n!/∏(f i)!

**Proof strategy** (Aristotle): induction on n, splitting the type class by the last element x(Fin.last n), using a Pascal-like identity for multinomial coefficients.

## Files Changed

- `proofs/Proofs/ShannonSourceCodingOQ04Aristotle.lean` — sorry replaced with Aristotle's full inductive proof
- `research/aristotle-jobs.json` — job 7303fc7f-... marked as integrated (1 theorem proved)

---
Automated integration by lean-mechanic agent.
Co-Authored-By: Aristotle (Harmonic) <aristotle-harmonic@harmonic.fun>