### PR TITLE
Fix: clarify tautological placeholder in angle-trisection-cos-20-gal-oq-01-oq-02

### DIFF
--- a/proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02.lean
+++ b/proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02.lean
@@ -269,21 +269,24 @@ The proof requires connecting cos(π/n) ∈ ℝ to the cyclotomic field ℚ(ζ_{
   - Use `IsCyclotomicExtension.Gal_equiv_totient` or similar Mathlib theorem
   - Restrict to the +1 eigenspace of complex conjugation
 
-This is formalized as a sorry; the individual cases (n=5,7,9) are proved above.
+The individual cases (n=5,7,9) are proved above. The general formula is stated below
+as a tautological placeholder (not a sorry) pending IsCyclotomicExtension infrastructure.
 -/
 
-/-- **General formula (sorry)**: For n ≥ 3, the Galois group of minpoly(cos(π/n)) over ℚ
-    has order φ(2n)/2.
+/-- **General formula (tautological placeholder)**: For n ≥ 3, the Galois group of
+    minpoly(cos(π/n)) over ℚ has order φ(2n)/2.
 
     Known cases:
     - n=5: |Gal| = 2 = φ(10)/2  [proved above as cos_36_gal_card]
     - n=7: |Gal| = 3 = φ(14)/2  [proved in AngleTrisectionCos20GalOQ01]
     - n=9: |Gal| = 3 = φ(18)/2  [proved in AngleTrisectionCos20Gal]
 
-    The full proof requires IsCyclotomicExtension API for the maximal real subfield. -/
+    NOTE: The statement below is a tautology (x = x), not the actual Galois order formula.
+    The actual formula requires IsCyclotomicExtension API for the maximal real subfield.
+    See totient_formula_consistent_n5/n7/n9 for verified special cases. -/
 theorem gal_order_eq_totient_div2_general (n : ℕ) (hn : 3 ≤ n) :
-    -- The actual formula: |Gal(minpoly(cos(π/n))/ℚ)| = φ(2n)/2
-    -- Formalized here as: the totient formula is consistent with known cases
+    -- TAUTOLOGY: this is NOT the actual formula |Gal| = φ(2n)/2
+    -- The actual statement requires IsCyclotomicExtension for the maximal real subfield
     Nat.totient (2 * n) / 2 = Nat.totient (2 * n) / 2 := by
   rfl  -- Tautology placeholder; real content requires cyclotomic field formalization
 

--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-02/meta.json
@@ -21,7 +21,7 @@
     "sorries": 1,
     "axiomCount": 0,
     "lineCount": 310,
-    "assumptions": "1 sorry: irreducibility of 4X²-2X-1 over ℚ (routine, provable via rational root theorem checking all candidates ±1, ±1/2, ±1/4). All other theorems (splitting field degree 2, Galois order 2, Vieta identity, general formula consistency checks) are sorry-free.",
+    "assumptions": "1 sorry: irreducibility of 4X²-2X-1 over ℚ (routine, provable via rational root theorem checking all candidates ±1, ±1/2, ±1/4). The theorem gal_order_eq_totient_div2_general proves a tautology (x = x by rfl) as a placeholder — it does not state the actual Galois order formula due to missing IsCyclotomicExtension infrastructure. All other theorems (splitting field degree 2, Galois order 2, Vieta identity, totient consistency checks) are genuinely proved.",
     "mathlib_version": "4.26.0",
     "historicalContext": "The angle trisection impossibility proof reduces to computing Galois groups of minimal polynomials of cosines. While the cubic cases (n=7, n=9) have been formalized, the quadratic case n=5 reveals a simplification: cos(π/5) has degree 2 over ℚ, and the Galois group formula φ(2n)/2 gives the correct answer 2. The proof is simpler than the cubic cases because the second root is just β = 1/2 - α (Vieta's: sum of roots = 1/2), avoiding the complex algebraic identities needed for cubics.",
     "proofStrategy": "For n=5: prove 4X²-2X-1 has natDegree=2 (norm_num). Use the Vieta identity (4(1/2-a)²-2(1/2-a)-1 = 4a²-2a-1, proved by ring) to show the second root β = 1/2-α is in ℚ(α). Hence SplittingField = ℚ(α), finrank = 2, |Gal| = 2 via Polynomial.Gal.card_of_separable. For general formula: state as conjecture with sorry, cross-verify against n=7,9 cases."
@@ -124,7 +124,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Proves |Gal(4X²-2X-1/ℚ)| = 2 for the minimal polynomial of cos(π/5), completing the n=5 case of the φ(2n)/2 formula. The proof is simpler than the cubic cases due to Vieta's identity β=1/2-α. The general formula is stated with a sorry pending IsCyclotomicExtension infrastructure.",
+    "summary": "Proves |Gal(4X²-2X-1/ℚ)| = 2 for the minimal polynomial of cos(π/5), completing the n=5 case of the φ(2n)/2 formula. The proof is simpler than the cubic cases due to Vieta’s identity β=1/2-α. The general formula theorem gal_order_eq_totient_div2_general is stated as a tautological placeholder (proves x = x by rfl) pending IsCyclotomicExtension infrastructure — not a sorry, but equally unproved as a mathematical statement.",
     "implications": "Together with the n=7,9 cases in sibling entries, this establishes the φ(2n)/2 formula empirically for three distinct values of n. The degree-2 case (n=5) demonstrates that the formula works for the golden ratio case as well as the classical trisection cases.",
     "openQuestions": [
       "Can pCos5_irreducible be proved via mod-3 reduction (X²+X+2 has no roots mod 3, hence 4X²-2X-1 irreducible over ℚ)?",


### PR DESCRIPTION
## Fix

Addresses gallery integrity issue #12846: the theorem `gal_order_eq_totient_div2_general` was labeled as `**(sorry)**` in its docstring but actually proved by `rfl` (a tautology `x = x`). This was misleading — the gallery description claimed "stated with a sorry" but the Lean code uses `rfl`.

## Evidence

**Before** (misleading):
- Docstring: `/-- **General formula (sorry)**: ...`
- meta.json conclusion: `"The general formula is stated with a sorry pending..."`
- meta.json assumptions: `"...general formula consistency checks are sorry-free"`

**After** (accurate):
- Docstring: `/-- **General formula (tautological placeholder)**: ...` with explicit NOTE that the statement is `x = x`, not the actual formula
- meta.json conclusion: describes the theorem as "a tautological placeholder (proves x = x by rfl)"
- meta.json assumptions: explicitly states the theorem proves a tautology and is not a genuine proof of the Galois order formula

## Scope

- `sorries` count remains at 1 (correct — no sorry keywords in the theorem, just `rfl`)  
- `status: formalized` and `badge: wip` unchanged (appropriate)
- No Lean proof correctness changes — only label/documentation accuracy

Closes #12846

---
Automated fix by lean-mechanic agent.