### PR TITLE
enrich(abel-ruffini): fix annotation ranges for Parts VI and VII

### DIFF
--- a/src/data/proofs/abel-ruffini/annotations.json
+++ b/src/data/proofs/abel-ruffini/annotations.json
@@ -345,7 +345,7 @@
     "proofId": "abel-ruffini",
     "range": {
       "startLine": 151,
-      "endLine": 183
+      "endLine": 163
     },
     "type": "insight",
     "title": "Part VI: Why Degree 5 Is the Exact Threshold",
@@ -372,8 +372,8 @@
     "id": "ann-part-vii-historical",
     "proofId": "abel-ruffini",
     "range": {
-      "startLine": 151,
-      "endLine": 183
+      "startLine": 164,
+      "endLine": 185
     },
     "type": "insight",
     "title": "Part VII: The Impossibility Paradigm and Historical Significance",


### PR DESCRIPTION
Corrects overlapping annotation line ranges in annotations.json.

**Fix:** Both `ann-part-vi-threshold` and `ann-part-vii-historical` previously declared range `151–183`, causing them to cover exactly the same lines. The Lean file has:
- Part VI comment block: lines 151–163
- Part VII comment block: lines 164–185 (including `end AbelRuffini`)

Updated ranges:
- `ann-part-vi-threshold`: `151–163` (was `151–183`)
- `ann-part-vii-historical`: `164–185` (was `151–183`)

These now match the `sections` array boundaries already correctly defined in `meta.json`. No mathematical content changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)