### PR TITLE
audit: re-verify erdos-1098-oq-01-oq-01 and erdos-1098-oq-04 (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11306,8 +11306,8 @@
       "issues": []
     },
     "erdos-1098-oq-04": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-03T09:33:04Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-26T11:43:10Z",
       "result": "clean",
       "issues": []
     },
@@ -12173,7 +12173,7 @@
       "lastAudited": "2026-04-26T13:00:00Z",
       "result": "clean",
       "issues": [],
-      "notes": "Untracked gallery entry (not in git); Lean file missing from git but PR #12837 is open — marked clean"
+      "notes": "Untracked gallery entry (not in git); Lean file missing from git but PR #12837 is open \u2014 marked clean"
     },
     "angle-trisection-cos-20-gal-oq-03": {
       "auditCount": 1,


### PR DESCRIPTION
## Summary
- Re-audited `erdos-1098-oq-01-oq-01`: 0 sorries, 2 axioms, badge `axiom` — all claims verified clean
- Re-audited `erdos-1098-oq-04`: 0 sorries, 0 axioms, badge `wip` — all claims verified clean
- Gallery remains at 2169 audited proofs, 0 open issues

## Checks Performed
- Sorry count vs meta.json ✓
- Axiom count (explicit + structure-encoded) vs meta.json ✓
- True stub detection ✓
- Badge appropriateness ✓
- Mathlib delegation opacity ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)