### PR TITLE
fix(audit): sync leanFile.lineCount for 3 proofs after Lean file expansions

### DIFF
--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-02/meta.json
@@ -20,7 +20,7 @@
     "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 310,
+    "lineCount": 326,
     "assumptions": "1 sorry: irreducibility of 4X²-2X-1 over ℚ (routine, provable via rational root theorem checking all candidates ±1, ±1/2, ±1/4). The theorem gal_order_eq_totient_div2_general proves a tautology (x = x by rfl) as a placeholder — it does not state the actual Galois order formula due to missing IsCyclotomicExtension infrastructure. All other theorems (splitting field degree 2, Galois order 2, Vieta identity, totient consistency checks) are genuinely proved.",
     "mathlib_version": "4.26.0",
     "historicalContext": "The angle trisection impossibility proof reduces to computing Galois groups of minimal polynomials of cosines. While the cubic cases (n=7, n=9) have been formalized, the quadratic case n=5 reveals a simplification: cos(π/5) has degree 2 over ℚ, and the Galois group formula φ(2n)/2 gives the correct answer 2. The proof is simpler than the cubic cases because the second root is just β = 1/2 - α (Vieta's: sum of roots = 1/2), avoiding the complex algebraic identities needed for cubics.",
@@ -93,7 +93,7 @@
       "Proofs.AngleTrisectionCos20GalOQ01"
     ],
     "namespace": "AngleTrisectionCos20GalOQ01OQ02",
-    "lineCount": 310,
+    "lineCount": 326,
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 2,

--- a/src/data/proofs/furstenberg-correspondence-oq-01/meta.json
+++ b/src/data/proofs/furstenberg-correspondence-oq-01/meta.json
@@ -54,7 +54,7 @@
       "Ergodic theory concepts"
     ],
     "mathlib_version": "4.26.0",
-    "lineCount": 285,
+    "lineCount": 528,
     "relatedProblems": [
       {
         "id": "furstenberg-correspondence",
@@ -148,7 +148,7 @@
   "leanFile": {
     "path": "Proofs/FurstenbergCorrespondenceOQ01.lean",
     "filename": "FurstenbergCorrespondenceOQ01.lean",
-    "lineCount": 285,
+    "lineCount": 528,
     "axiomCount": 1,
     "sorries": 0
   },

--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -20,7 +20,7 @@
     "badge": "wip",
     "sorries": 2,
     "axiomCount": 0,
-    "lineCount": 1286,
+    "lineCount": 1342,
     "assumptions": "2 sorries: (1) integer-real orbit bridge (evalWord toWord encodes 3^n * liftF, ~60 lines induction via irrationality of sqrt 2); (2) banach_tarski main theorem (800+ lines via Hausdorff paradox + AC). All other supporting lemmas fully proved: evalWord_nonempty_labeledInv, FreeGroup.Reduced/Chain bridge, anyInv+encoding contradiction, free_group_not_amenable, int_amenable (Cesaro window-shift), banach_tarski_pieces_nonmeasurable.",
     "dateAdded": "2026-04-22",
     "mathlib_version": "4.26.0",
@@ -212,7 +212,7 @@
       "Mathlib"
     ],
     "namespace": "BanachTarski",
-    "lineCount": 1286,
+    "lineCount": 1342,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 5,


### PR DESCRIPTION
## Summary

Corrects stale `lineCount` in `meta.json` / `leanFile.lineCount` for three gallery proofs whose Lean source files were extended by recent PRs but whose metadata was not updated.

| Proof | Old lineCount | Actual | Difference | Lean file extended by |
|-------|--------------|--------|-----------|----------------------|
| furstenberg-correspondence-oq-01 | 285 | 528 | +243 | #12847 (Cesàro measure infrastructure) |
| lebesgue-measure-oq-06 | 1286 | 1342 | +56 | #12839 (automaton infrastructure fixes) |
| angle-trisection-cos-20-gal-oq-01-oq-02 | 310 | 326 | +16 | #12854 (tautological label fix) |

No sorry counts, axiom counts, status, or badge fields were changed — only `lineCount` at both `meta.lineCount` and `leanFile.lineCount` locations in each file.

## Test plan
- [x] `pnpm build` passes cleanly
- [x] `wc -l` confirmed actual line counts match new values
- [x] Verified sorry/axiom counts remain correct in all three files