### PR TITLE
feat(aristotle): Erdos901 companion — propertyB dichotomy + monochromatic probability

### DIFF
--- a/proofs/Proofs/Erdos901Aristotle.lean
+++ b/proofs/Proofs/Erdos901Aristotle.lean
@@ -1,0 +1,66 @@
+/-
+  Aristotle targets for Erdős Problem #901 (Property B and Hypergraph Coloring)
+  Routine supporting lemmas for automated proof search.
+  See Erdos901Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main open conjecture (Erdős-Lovász: m(n) = Θ(n · 2^n))
+  - propertyB_dichotomy: pure logical equivalence (∃/¬∀ duality), no math content
+  - monochromatic_probability: concrete power identity (2^(1-n) = 2/2^n), no sorry defs
+  - No axiom declarations
+  - No open conjectures
+-/
+import Mathlib.Combinatorics.SetFamily.Basic
+import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Fintype.Basic
+import Mathlib.Analysis.SpecialFunctions.Log.Basic
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Mathlib.Tactic
+
+namespace Erdos901Aristotle
+
+open Finset Real
+
+/-- A 2-coloring of vertices. -/
+def TwoColoring (V : Type*) := V → Fin 2
+
+/-- An edge is monochromatic under a coloring if all vertices have the same color. -/
+def IsMonochromatic {V : Type*} (c : TwoColoring V) (e : Finset V) : Prop :=
+  (∀ v ∈ e, c v = 0) ∨ (∀ v ∈ e, c v = 1)
+
+/-- An n-uniform hypergraph: a family of n-element subsets of a ground set. -/
+structure UniformHypergraph (V : Type*) [Fintype V] (n : ℕ) where
+  edges : Finset (Finset V)
+  uniform : ∀ e ∈ edges, e.card = n
+
+/-- Property B: there exists a 2-coloring with no monochromatic edge. -/
+def HasPropertyB {V : Type*} [Fintype V] [DecidableEq V] {n : ℕ}
+    (H : UniformHypergraph V n) : Prop :=
+  ∃ c : TwoColoring V, ∀ e ∈ H.edges, ¬IsMonochromatic c e
+
+/-- Without Property B: every 2-coloring has a monochromatic edge. -/
+def LacksPropertyB {V : Type*} [Fintype V] [DecidableEq V] {n : ℕ}
+    (H : UniformHypergraph V n) : Prop :=
+  ∀ c : TwoColoring V, ∃ e ∈ H.edges, IsMonochromatic c e
+
+/-- Aristotle target: HasPropertyB and LacksPropertyB are logical complements.
+
+    Key: HasPropertyB H = ∃ c, ∀ e ∈ H.edges, ¬M(c,e)
+         LacksPropertyB H = ∀ c, ∃ e ∈ H.edges, M(c,e)
+         ¬LacksPropertyB H = ∃ c, ∀ e ∈ H.edges, ¬M(c,e) = HasPropertyB H
+    Pure ∃/¬∀ duality — no mathematical content beyond propositional logic. -/
+theorem propertyB_dichotomy {V : Type*} [Fintype V] [DecidableEq V] {n : ℕ}
+    (H : UniformHypergraph V n) :
+    HasPropertyB H ↔ ¬LacksPropertyB H := by
+  sorry
+
+/-- Aristotle target: Probability a specific edge is monochromatic under random 2-coloring.
+
+    For an n-element edge, probability = 2 · (1/2)^n = 2 / 2^n = 2^(1-n).
+    Concretely: (2 : ℝ) ^ (1 - (n : ℤ)) = 2 / 2 ^ n
+    Proof: 2^(1-n) = 2^1 / 2^n = 2 / 2^n via zpow_sub₀. -/
+theorem monochromatic_probability (n : ℕ) (hn : n ≥ 1) :
+    (2 : ℝ) ^ (1 - (n : ℤ)) = 2 / 2 ^ n := by
+  sorry
+
+end Erdos901Aristotle


### PR DESCRIPTION
## Fix

Add `Erdos901Aristotle.lean` companion file with two Aristotle-suitable targets from `Erdos901Problem.lean`.

## Evidence

**Targets selected**:
1. `propertyB_dichotomy` — `HasPropertyB H ↔ ¬LacksPropertyB H`. Pure ∃/¬∀ logical duality. The definitions are complements by construction: one is `∃ c, ∀ e, ¬M` and the other is `∀ c, ∃ e, M`, so `push_neg` / `simp` suffices.

2. `monochromatic_probability` — `(2 : ℝ) ^ (1 - (n : ℤ)) = 2 / 2 ^ n` for `n ≥ 1`. Concrete power identity via `zpow_sub₀` and `zpow_natCast`.

**Pre-submission checklist**:
- [x] No `def ... := sorry`
- [x] No `axiom` declarations
- [x] No `theorem ... : True`
- [x] No `/-!` docstrings
- [x] No open conjectures

**Excluded sorries** (not Aristotle-suitable):
- `m_well_defined`, `m_mono`, `m_2_eq_3`, `m_3_eq_7`, `m_4_eq_23` — require number-theory constructions
- `erdos_lower_bound`, `beck_lower_bound`, `rs_lower_bound` — major research results
- `lll_property_b` — Lovász Local Lemma application

---
Automated fix by lean-mechanic agent.