### PR TITLE
enrich(abel-ruffini-oq-04-oq-02-oq-02): fix section ranges, add cross-refs

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02/annotations.json
@@ -90,7 +90,9 @@
     "relatedConcepts": [
       "Equiv.Perm.not_solvable",
       "proof by contradiction",
-      "A₅ simplicity"
+      "A₅ simplicity",
+      "abel-ruffini-oq-04-oq-02",
+      "abel-ruffini-galois-extensions-oq-04"
     ],
     "prerequisites": [
       "sn_solvable_of_an_solvable",

--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02/meta.json
@@ -88,40 +88,40 @@
       "id": "header",
       "title": "Documentation and Imports",
       "startLine": 1,
-      "endLine": 44,
-      "summary": "Module docstring with classification table, key argument, and references. Imports Mathlib.GroupTheory.Solvable and Mathlib.GroupTheory.SpecificGroups.Alternating."
+      "endLine": 53,
+      "summary": "Module docstring with classification table, key argument, and references. Imports Mathlib.GroupTheory.Solvable and Mathlib.GroupTheory.SpecificGroups.Alternating. set_option linter flags, open Equiv, and namespace declaration."
     },
     {
       "id": "small-cases",
       "title": "Small Alternating Groups Are Solvable (n ≤ 4)",
-      "startLine": 52,
-      "endLine": 77,
-      "summary": "Proves A₀ through A₄ are solvable. A₀, A₁, A₂ by inferInstance; A₃ by isSolvable_of_comm + decide; A₄ by subgroup solvability from S₄.",
-      "mathContext": "$A_3 \\cong \\mathbb{Z}/3\\mathbb{Z}$ (abelian). $A_4 \\leq S_4$ and $S_4$ is solvable."
+      "startLine": 55,
+      "endLine": 80,
+      "summary": "Proves A₀ through A₄ are solvable. A₀, A₁, A₂ by inferInstance; A₃ by isSolvable_of_comm + decide; A₄ by subgroup solvability from S₄ (derived length 3 via native_decide).",
+      "mathContext": "$A_3 \\cong \\mathbb{Z}/3\\mathbb{Z}$ (abelian). $A_4 \\leq S_4$ and $S_4$ is solvable (derived length 3: $S_4^{(3)} = \\{e\\}$ verified by native_decide)."
     },
     {
       "id": "large-cases",
       "title": "Large Alternating Groups Are Not Solvable (n ≥ 5)",
-      "startLine": 79,
-      "endLine": 103,
-      "summary": "Proves A_n not solvable for n ≥ 5 via the exact sequence argument: solvable A_n → solvable S_n → contradiction with Equiv.Perm.not_solvable.",
-      "mathContext": "Exact sequence $1 \\to A_n \\to S_n \\to \\mathbb{Z}^\\times \\to 1$ and solvability extension."
+      "startLine": 82,
+      "endLine": 109,
+      "summary": "Proves A_n not solvable for n ≥ 5. Private lemma sn_solvable_of_an_solvable uses the sign exact sequence 1 → Aₙ → Sₙ → ℤˣ → 1 and solvable_of_ker_le_range. Private lemma sn_not_solvable delegates to Equiv.Perm.not_solvable. Public theorem an_not_solvable_of_ge_five combines them by contradiction.",
+      "mathContext": "Exact sequence $1 \\to A_n \\to S_n \\xrightarrow{\\text{sign}} \\{\\pm 1\\} \\to 1$ and solvability extension. If $A_n$ solvable and $\\{\\pm 1\\} \\cong \\mathbb{Z}/2\\mathbb{Z}$ solvable, then $S_n$ solvable — but $S_n$ is not solvable for $n \\geq 5$."
     },
     {
       "id": "classification",
       "title": "The Complete Classification",
-      "startLine": 105,
-      "endLine": 125,
-      "summary": "alternating_solvable_iff: IsSolvable (alternatingGroup (Fin n)) ↔ n ≤ 4. Complete bidirectional proof.",
-      "mathContext": "$A_n$ solvable $\\iff n \\leq 4$."
+      "startLine": 111,
+      "endLine": 138,
+      "summary": "alternating_solvable_iff: IsSolvable (alternatingGroup (Fin n)) ↔ n ≤ 4. Forward direction: contradiction via an_not_solvable_of_ge_five. Backward direction: interval_cases n enumerates 0–4, each discharged by the small-case theorems.",
+      "mathContext": "$A_n$ solvable $\\iff n \\leq 4$. Proof by interval_cases (backward) and by_contra + omega (forward)."
     },
     {
       "id": "corollaries",
       "title": "Corollaries and Sharp Threshold",
-      "startLine": 127,
-      "endLine": 155,
-      "summary": "Named instances for A₅ and A₆ non-solvability. Convenience lemmas alternating_solvable_of_le_four and alternating_not_solvable_of_ge_five. sharp_threshold witnesses that A₄ is solvable but A₅ is not.",
-      "mathContext": "The exact threshold: $A_4$ solvable, $A_5$ not."
+      "startLine": 140,
+      "endLine": 167,
+      "summary": "Named instances for A₅ and A₆ non-solvability. Convenience lemmas alternating_solvable_of_le_four and alternating_not_solvable_of_ge_five. sharp_threshold witnesses that A₄ is solvable but A₅ is not. Closes namespace AbelRuffiniOQ04OQ02OQ02.",
+      "mathContext": "The exact threshold: $A_4$ solvable (via Klein four-group chain $\\{e\\} \\trianglelefteq V_4 \\trianglelefteq A_4$), $A_5$ not (simplest non-abelian simple group, order 60)."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -133,7 +133,7 @@
       "id": "sec-main",
       "title": "Main Theorems",
       "startLine": 152,
-      "endLine": 199,
+      "endLine": 192,
       "summary": "I_not_principal, not_isPrincipalIdealRing, exists_non_principal_ideal, ufd_not_pir_distinction."
     }
   ],
@@ -141,17 +141,17 @@
     {
       "targetId": "bezout-identity-oq-02-oq-01-oq-01-oq-01",
       "relationship": "parent",
-      "description": "ℤ[X,Y] is a UFD (the complementary positive result)"
+      "description": "The complementary positive result: ℤ[X,Y] IS a UFD (by Gauss's lemma applied inductively). This entry establishes the other half: UFD does NOT imply PID. Together they witness the strict inclusion PID ⊊ UFD."
     },
     {
       "targetId": "bezout-identity-oq-02-oq-01-oq-01",
       "relationship": "grandparent",
-      "description": "ℤ[X] is a UFD (Gauss's lemma)"
+      "description": "ℤ[X] is a UFD via Gauss's lemma (R UFD → R[X] UFD). The same ideal (2,X) that witnesses ℤ[X] is not a PID is reused here for ℤ[X,Y], demonstrating the same PID failure persists under variable extension."
     },
     {
       "targetId": "bezout-identity",
       "relationship": "foundational",
-      "description": "Bézout's Identity"
+      "description": "Bézout's Identity holds in all PIDs: gcd(a,b) = sa + tb for integers s,t. The failure of ℤ[X,Y] to be a PID means Bézout's identity does NOT hold for general polynomial pairs — specifically, gcd(2, X) = 1 but no polynomial combination 2f + Xg = 1 exists in ℤ[X,Y]."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for abel-ruffini-oq-04-oq-02-oq-02 (Alternating Groups: Aₙ Solvable iff n ≤ 4).

## Changes

**Section range corrections** — all 5 sections had boundaries that cut mid-theorem or started mid-docstring:
- `header`: endLine 44 → 53 (now includes set_option, open Equiv, namespace declaration)
- `small-cases`: startLine 52 → 55, endLine 77 → 80 (starts at PART 1 comment, ends at complete a4_solvable)
- `large-cases`: startLine 79 → 82, endLine 103 → 109 (starts at PART 2 comment, includes full an_not_solvable_of_ge_five)
- `classification`: startLine 105 → 111, endLine 125 → 138 (starts at PART 3 comment, ends at complete alternating_solvable_iff)
- `corollaries`: startLine 127 → 140, endLine 155 → 167 (starts at PART 4 comment, ends at namespace close)

**Section summary and mathContext improvements** for corrected boundaries.

**Cross-references** added to `ann-alt-grp-nonsolvable`:
- `abel-ruffini-oq-04-oq-02` (parent: symmetric group Sₙ classification, same technique)
- `abel-ruffini-galois-extensions-oq-04` (Jordan-Hölder uniqueness theorem)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)