### PR TITLE
fix(area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02): correct theoremCount 13→18

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02/meta.json
@@ -20,9 +20,9 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "theoremCount": 13,
+    "theoremCount": 18,
     "lineCount": 210,
-    "assumptions": "None. Fully verified with 0 sorries and 0 axioms. All 13 theorems are proved from Mathlib using only pi_lt_d2 (π < 3.15), pi_gt_three (π > 3), Gamma_add_one, and rpow_pos_of_pos as numerical/analytic facts.",
+    "assumptions": "None. Fully verified with 0 sorries and 0 axioms. All 18 theorems are proved from Mathlib using only pi_lt_d2 (π < 3.15), pi_gt_three (π > 3), Gamma_add_one, and rpow_pos_of_pos as numerical/analytic facts.",
     "mathlibDependencies": [
       {
         "theorem": "Gamma_add_one",
@@ -122,7 +122,7 @@
     "namespace": "MaxBallVolume",
     "lineCount": 210,
     "axiomCount": 0,
-    "theoremCount": 13,
+    "theoremCount": 18,
     "definitionCount": 1,
     "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

- Corrects `theoremCount` from 13 to 18 in meta.json (both `meta` and `leanFile` sections)
- Updates `assumptions` text which also referenced the wrong count
- Proof integrity confirmed: 0 sorries, 0 axioms, `status: verified` is accurate

## Audit Findings

**Proof**: `area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02`

The Lean file `Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ02.lean` contains 18 theorems:
`omega_pos`, `omega_nonneg`, `omega_recurrence`, `omega_zero`, `omega_one`, `omega_two`, `omega_three`, `omega_four`, `omega_five`, `ratio_lt_one`, `omega_strict_decrease`, `omega_even_le_six`, `omega_odd_le_seven`, `omega_six_lt_five`, `omega_seven_lt_five`, `omega_five_is_max`, `omega_max_value`, `omega_five_unique_max`.

All integrity checks passed: 0 sorries, 0 True stubs, 0 axiom declarations, no Mathlib wrapper issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)