### PR TITLE
enrich(abel-ruffini): fix overlapping annotation ranges for Parts VI and VII

### DIFF
--- a/src/data/proofs/abel-ruffini/annotations.json
+++ b/src/data/proofs/abel-ruffini/annotations.json
@@ -345,7 +345,7 @@
     "proofId": "abel-ruffini",
     "range": {
       "startLine": 151,
-      "endLine": 183
+      "endLine": 163
     },
     "type": "insight",
     "title": "Part VI: Why Degree 5 Is the Exact Threshold",
@@ -372,8 +372,8 @@
     "id": "ann-part-vii-historical",
     "proofId": "abel-ruffini",
     "range": {
-      "startLine": 151,
-      "endLine": 183
+      "startLine": 164,
+      "endLine": 185
     },
     "type": "insight",
     "title": "Part VII: The Impossibility Paradigm and Historical Significance",


### PR DESCRIPTION
## Summary

- Fix duplicate annotation ranges in `abel-ruffini/annotations.json`
- `ann-part-vi-threshold` (Part VI: threshold analysis): endLine 183 → 163
- `ann-part-vii-historical` (Part VII: historical significance): startLine 151 → 164, endLine 183 → 185

Both annotations previously covered the identical range (lines 151–183), meaning the UI displayed both when hovering over any line in the combined comment block. Now each annotation maps to its own distinct section, matching the existing section boundaries in meta.json.

## Quality

Entry was already at quality 100 / 5 passes with all peer review items resolved. This is a targeted structural cleanup pass.