### PR TITLE
enrich(abel-ruffini-galois-extensions): fix annotation range coverage

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions/annotations.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions/annotations.json
@@ -82,7 +82,7 @@
     "id": "arg-an-complete-classification",
     "proofId": "abel-ruffini-galois-extensions",
     "range": {
-      "startLine": 254,
+      "startLine": 250,
       "endLine": 287
     },
     "type": "insight",
@@ -273,7 +273,7 @@
     "id": "arg-galois-contrapositive",
     "proofId": "abel-ruffini-galois-extensions",
     "range": {
-      "startLine": 207,
+      "startLine": 200,
       "endLine": 217
     },
     "type": "insight",
@@ -300,7 +300,7 @@
     "id": "arg-sign-kernel",
     "proofId": "abel-ruffini-galois-extensions",
     "range": {
-      "startLine": 413,
+      "startLine": 407,
       "endLine": 429
     },
     "type": "definition",
@@ -329,7 +329,7 @@
     "id": "arg-noncommutativity",
     "proofId": "abel-ruffini-galois-extensions",
     "range": {
-      "startLine": 437,
+      "startLine": 431,
       "endLine": 461
     },
     "type": "insight",


### PR DESCRIPTION
Enrichment pass for abel-ruffini-galois-extensions.

Quality improvements:
- Fixed 4 annotation ranges that excluded their section comment headers, creating small but unnecessary coverage gaps
- arg-galois-contrapositive: startLine 207→200 (Part IV: RadicalSolvability header)
- arg-an-complete-classification: startLine 254→250 (Part VII: AlternatingNonSolvable header)
- arg-sign-kernel: startLine 413→407 (Part XII: ChainProperties header)
- arg-noncommutativity: startLine 437→431 (Part XIII: NonCommutativity header)

This makes coverage consistent with other annotations in the same file that do include section headers (e.g., arg-subgroup-solvability starts at 237 to include the Part VI header, arg-solvability-preservation starts at 330 to include the Part IX header).

Entry is at quality 100, passes 4 — this completes a consistency pass on annotation boundaries.