### PR TITLE
fix(audit): sync basel-problem-oq-04-oq-03 lineCount/theoremCount

### DIFF
--- a/src/data/proofs/basel-problem-oq-04-oq-03/meta.json
+++ b/src/data/proofs/basel-problem-oq-04-oq-03/meta.json
@@ -51,9 +51,9 @@
       "Density bounds: 3/8 < 6/π² < 2/3 (from π > 3 and π < 4)"
     ],
     "axiomCount": 2,
-    "lineCount": 310,
+    "lineCount": 388,
     "assumptions": "2 axioms: (1) moebius_dirichlet_series_at_two — the Dirichlet series Σ μ(d)/d² = 6/π² at s=2, following from L(μ,s)·ζ(s)=1 and ζ(2)=π²/6 but requiring LSeries bridge; (2) coprime_pair_density_limit — the density limit theorem using dominated convergence. 1 sorry: finite sum exchange in Möbius decomposition (finite Fubini argument).",
-    "theoremCount": 18
+    "theoremCount": 21
   },
   "overview": {
     "historicalContext": "Ernesto Cesàro (1885) first explicitly stated that the probability that two randomly chosen positive integers are coprime equals 6/π² = 1/ζ(2) ≈ 0.6079. The result connects three branches of mathematics: combinatorics (coprimality, Möbius function), analysis (convergent series, Basel problem), and probability (natural density).\n\nThe mathematical insight is elegant: for each prime p, the probability that p divides both m and n is 1/p², so the probability that p does NOT divide their gcd is (1 - 1/p²). By the Chinese Remainder Theorem, coprimality with respect to different primes is independent, so the probability that gcd(m,n)=1 is ∏_p (1 - 1/p²) = 1/ζ(2) = 6/π².\n\nThis connects to the Basel problem (Euler, 1734): ∑_{n=1}^∞ 1/n² = π²/6, making the density the reciprocal 6/π². The Möbius function μ(n) provides the formal proof tool: the identity 1_{n=1} = Σ_{d|n} μ(d) converts coprimality detection into a finite sum, enabling the counting argument.\n\nThe result was generalized in the 20th century: Bergelson and Richter (2017) showed that for non-integer α > 0, the density of {n : gcd(n, ⌊n^α⌋) = 1} is also 6/π² (Erdős #1149 in our gallery).",
@@ -184,9 +184,9 @@
       "ArithmeticFunction"
     ],
     "namespace": "BaselProblemOQ04OQ03",
-    "lineCount": 310,
+    "lineCount": 388,
     "axiomCount": 2,
-    "theoremCount": 18,
+    "theoremCount": 21,
     "definitionCount": 1,
     "sorries": 1,
     "path": "Proofs/BaselProblemOQ04OQ03.lean"


### PR DESCRIPTION
## Summary

- Corrects `lineCount` from 310 → 388 in both `meta` and `leanFile` sections
- Corrects `theoremCount` from 18 → 21 in both `meta` and `leanFile` sections

The file was extended with Sections IX and X (Euler product connection, summary) after the initial metadata was written, adding 3 theorems and 78 lines.

All other fields (sorries=1, axiomCount=2, status=axiomatized, badge=axiom) are accurate.

---
Discovered during gallery integrity audit.