### PR TITLE
fix(meta): correct leanFile.axiomCount for 7 entries (issue #12561 follow-up)

### DIFF
--- a/src/data/proofs/greens-theorem-oq-04/meta.json
+++ b/src/data/proofs/greens-theorem-oq-04/meta.json
@@ -241,7 +241,7 @@
     ],
     "namespace": "GreensTheoremOQ04",
     "lineCount": 587,
-    "axiomCount": 2,
+    "axiomCount": 0,
     "theoremCount": 23,
     "definitionCount": 14,
     "path": "Proofs/GreensTheoremOQ04.lean",

--- a/src/data/proofs/inverse-galois-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-oq-01/meta.json
@@ -303,7 +303,7 @@
   "leanFile": {
     "path": "Proofs/InverseGaloisOQ01.lean",
     "lineCount": 723,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "sorries": 1,
     "theoremCount": 46,
     "definitionCount": 1,

--- a/src/data/proofs/inverse-galois/meta.json
+++ b/src/data/proofs/inverse-galois/meta.json
@@ -303,7 +303,7 @@
   "leanFile": {
     "path": "Proofs/InverseGalois.lean",
     "lineCount": 1882,
-    "axiomCount": 5,
+    "axiomCount": 4,
     "sorries": 0,
     "theoremCount": 105,
     "definitionCount": 1,

--- a/src/data/proofs/yang-mills-2d/meta.json
+++ b/src/data/proofs/yang-mills-2d/meta.json
@@ -175,7 +175,7 @@
   "leanFile": {
     "lineCount": 28075,
     "structureCount": 365,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 1787,
     "lemmaCount": 0,
     "defCount": 641,

--- a/src/data/proofs/yang-mills-lattice/meta.json
+++ b/src/data/proofs/yang-mills-lattice/meta.json
@@ -148,7 +148,7 @@
   "leanFile": {
     "lineCount": 28075,
     "structureCount": 365,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 1787,
     "lemmaCount": 0,
     "defCount": 641,

--- a/src/data/proofs/yang-mills-transfer-matrix/meta.json
+++ b/src/data/proofs/yang-mills-transfer-matrix/meta.json
@@ -138,7 +138,7 @@
   "leanFile": {
     "lineCount": 28075,
     "structureCount": 365,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 1787,
     "lemmaCount": 0,
     "defCount": 641,

--- a/src/data/proofs/yang-mills/meta.json
+++ b/src/data/proofs/yang-mills/meta.json
@@ -203,7 +203,7 @@
     ],
     "namespace": "YangMillsMassGap",
     "lineCount": 48,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 1806,
     "definitionCount": 260,
     "path": "Proofs/YangMillsMassGap.lean",


### PR DESCRIPTION
## Fix

Complete the remaining fixes from issue #12561 — 7 entries where `leanFile.axiomCount` counted inherited/structure-encoded axioms instead of actual `^axiom` declarations in the file itself.

## Evidence

**Before**: `leanFile.axiomCount` inflated by counting axioms from imported parent files or structure-encoded assumptions.

**After**: `leanFile.axiomCount` = count of `^axiom` declarations in THAT file only (per `find-targets.ts` design).

| Slug | Before | After | Reason |
|------|--------|-------|--------|
| yang-mills | 1 | 0 | gaugeTransform is in YangMills/Classical.lean, not YangMillsMassGap.lean |
| yang-mills-2d | 1 | 0 | Exploration.lean has 0 axiom decls |
| yang-mills-lattice | 1 | 0 | Exploration.lean has 0 axiom decls |
| yang-mills-transfer-matrix | 1 | 0 | Exploration.lean has 0 axiom decls |
| inverse-galois-oq-01 | 1 | 0 | three_dvd_gal_card is in InverseGaloisA5.lean, not InverseGaloisOQ01.lean |
| inverse-galois | 5 | 4 | 4 confirmed axiom decls; 5th was inherited from InverseGaloisA5.lean |
| greens-theorem-oq-04 | 2 | 0 | axioms are in GreensTheoremOQ03.lean, not OQ04 |

Note: `meta.axiomCount` is unchanged — it correctly counts ALL semantic assumptions (both direct and inherited). Only `leanFile.axiomCount` (the tooling field) is fixed here.

Related: Issue #12561 (4 entries fixed in that PR; these 7 were not yet addressed when the issue was closed).

---
Automated fix by lean-mechanic agent.