### PR TITLE
research(angle-trisection-oq-02-oq-01-oq-02-incomplete-01): restore IsConstructible fix

### DIFF
--- a/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean
+++ b/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean
@@ -2,49 +2,46 @@
 Completing the Wantzel-Galois Constructibility Proof
 Open Question: angle-trisection-oq-02-oq-01-oq-02-incomplete-01
 
-The parent file AngleTrisectionOQ02OQ01OQ02.lean had 5 sorries:
-  1. not_constructible_of_bad_degree  — tower degree theory (PROVED HERE)
-  2. cube_root_2_minpoly_irred        — Eisenstein at p=2 (PROVED HERE)
-  3. cos20_minpoly_degree             — natDegree computation (PROVED HERE)
-  4. regular_7gon_impossible_degree   — degree ≠ 2^k (PROVED HERE)
-  5. wantzel_galois_iff               — full Galois correspondence (STILL SORRY)
+## Definition Fix (Session 26 — restored in Session 29)
 
-## Progress
+The original `sqrt_ext` constructor required `IsConstructible β` as a precondition,
+making constructible numbers exactly the rationals. This was mathematically wrong
+(√2 should be constructible) and made `wantzel_galois_iff` false.
 
-This file reduces to 1 sorry by:
-- Redesigning IsConstructible: making a and b explicit in sqrt_ext (enabling proper IH)
-- Proving `isConstructible_mem_range`: every constructible number is rational
-- Proving `not_constructible_of_bad_degree` via: constructible → rational → degree 1 → contradiction
-- Proving cube_root_2_minpoly_irred via Eisenstein at p = 2
-- Proving cos20_minpoly_degree and regular_7gon_poly_degree by direct computation
+**Fixed definition**: `sqrt_ext` no longer requires `IsConstructible β`. The square root β
+of a constructible number a is constructible (along with any b + β for constructible b).
 
-## Key Insight: Why the Original Definition Had Issues
+Under the fixed definition:
+- √2 IS constructible (a = 2 rational, b = 0, β = √2, β² = 2 ✓)
+- `isConstructible_mem_range` is no longer provable (correct!)
+- `wantzel_galois_iff` is now a TRUE statement (not false as before)
 
-The original `sqrt_ext` constructor hid `a` and `b` inside an existential:
-  `hα : ∃ a b : ℂ, IsConstructible a ∧ IsConstructible b ∧ β * β = a ∧ α = b + β`
-This prevented Lean from providing inductive hypotheses for `a` and `b`.
+## History
 
-The fix: make `a`, `b` explicit constructor parameters. The recursor then provides
-IHs for all three (β, a, b), enabling the proof of `isConstructible_mem_range`.
+This file reduces the parent (AngleTrisectionOQ02OQ01OQ02.lean, 5 sorries) to fewer.
 
-## Mathematical Content
+Sessions 26-27: Fixed IsConstructible definition + structured tower sorry.
+Session 28: Structured the single tower sorry into 5-step proof (Steps A-E).
+Session 29: Restored sessions 26-28 work (accidentally reverted in PR #12782).
+           Also improved not_constructible_of_bad_degree to use Dvd (not Eq).
 
-Under the redesigned definition, IsConstructible α holds only when α ∈ ℚ:
-- `rational` case: directly
-- `sqrt_ext β a b` case: α = b + β with β, b ∈ ℚ (by IH) → α ∈ ℚ
+## Remaining Sorries
 
-Therefore: if p is irreducible with p(α) = 0 and α constructible, then α ∈ ℚ,
-so p has a rational root, forcing deg(p) = 1 = 2^0. Contradicts ¬ DegreePowerOfTwo p.
+1. `hβ_dvd` (Step C): finrank ℚ ℚ⟮β⟯ ∣ 2^(j+1)
+   Proof plan: ℚ⟮a⟯ ≤ ℚ⟮β⟯, tower law gives finrank_β = [ℚ⟮β⟯:ℚ⟮a⟯] * 2^j.
+   β satisfies X²-a over ℚ⟮a⟯ → [ℚ⟮β⟯:ℚ⟮a⟯] ≤ 2 → [ℚ⟮β⟯:ℚ⟮a⟯] ∣ 2 → finrank_β ∣ 2^(j+1).
+   Needs: Algebra (↥ℚ⟮a⟯) (↥ℚ⟮β⟯) from ha_le_β, and simple extension fact
+   Module.finrank ↥ℚ⟮a⟯ ↥ℚ⟮β⟯ = natDegree (minpoly ↥ℚ⟮a⟯ β) (β generates ℚ⟮β⟯ over ℚ⟮a⟯).
 
-## Remaining Sorry
+2. `hjoin_dvd` (Step D): finrank ℚ (ℚ⟮b⟯ ⊔ ℚ⟮β⟯) ∣ 2^(j+k+1)
+   Proof plan: tower via ℚ⟮β⟯ gives finrank_join = [join:ℚ⟮β⟯] * finrank_β.
+   Need [join:ℚ⟮β⟯] ∣ 2^k. This requires STRONGER IH for b: not just finrank ℚ ℚ⟮b⟯ ∣ 2^k,
+   but "for any K/ℚ, finrank K K⟮b⟯ divides a power of 2". Current IH is too weak.
 
-5. wantzel_galois_iff: Requires full Galois correspondence + 2-group structure.
+3. `wantzel_galois_iff` (out-of-scope): Requires full Galois correspondence + 2-group structure.
    Estimated: 500+ lines of new Galois theory infrastructure. Out of scope.
 
-## Axioms and Sorries
-
-1 sorry (wantzel_galois_iff). 0 axioms.
-All concrete degree-based impossibility results are fully proved.
+## Status: 3 sorries (2 targeted tower + 1 out-of-scope Galois), 0 axioms
 -/
 
 import Mathlib.FieldTheory.Galois.Basic
@@ -52,6 +49,8 @@ import Mathlib.FieldTheory.Minpoly.Field
 import Mathlib.FieldTheory.IntermediateField.Adjoin.Basic
 import Mathlib.GroupTheory.SpecificGroups.Cyclic
 import Mathlib.RingTheory.Polynomial.Eisenstein.Basic
+import Mathlib.RingTheory.Algebraic.Basic
+import Mathlib.RingTheory.IntegralClosure.Algebra.Basic
 import Mathlib.Tactic
 
 open Polynomial IntermediateField
@@ -59,24 +58,25 @@ open Polynomial IntermediateField
 namespace AngleTrisectionOQ02OQ01OQ02Incomplete01
 
 -- ============================================================
--- PART 1: Constructible Number Framework (Redesigned)
+-- PART 1: Constructible Number Framework (Fixed Definition)
 -- ============================================================
 
-/-- An algebraic number α ∈ ℂ is **constructible** if it is reachable by a tower
-    of quadratic extensions of ℚ. Each step adds a square root.
+/-- An element of ℂ is **constructible** if reachable by a tower of quadratic
+    extensions starting from ℚ.
 
-    **Redesigned from parent**: `a` and `b` are now explicit parameters (not hidden
-    inside an ∃), enabling Lean to provide inductive hypotheses for all three
-    in the `sqrt_ext` case. This is essential for proving `isConstructible_mem_range`.
+    **Key design change from earlier version**: `sqrt_ext` no longer requires
+    `IsConstructible β`. Instead, β is any complex number satisfying β² = a
+    for some constructible a. This is the mathematically correct definition:
+    square roots of constructible numbers are constructible.
 
-    The constructible numbers under this definition are exactly the rationals
-    (see `isConstructible_mem_range` below for the proof). The `sqrt_ext` rule
-    only allows adding β to b where β, b are already constructible — starting from
-    rationals, no new elements are ever added. -/
+    Under the old definition (with `IsConstructible β` as a precondition),
+    all constructible numbers were rational — making `wantzel_galois_iff` false.
+    Under this corrected definition, e.g. √2 is constructible. -/
 inductive IsConstructible : ℂ → Prop where
   | rational : ∀ α : ℂ, α ∈ Set.range (algebraMap ℚ ℂ) → IsConstructible α
   | sqrt_ext : ∀ (β a b : ℂ),
-      IsConstructible β → IsConstructible a → IsConstructible b →
+      -- Note: NO IsConstructible β requirement (the key fix)
+      IsConstructible a → IsConstructible b →
       β * β = a → IsConstructible (b + β)
 
 /-- Rational numbers are constructible. -/
@@ -84,75 +84,137 @@ theorem isConstructible_rat (q : ℚ) : IsConstructible (algebraMap ℚ ℂ q) :
   IsConstructible.rational _ ⟨q, rfl⟩
 
 /-- 0 is constructible. -/
-theorem isConstructible_zero : IsConstructible (0 : ℂ) :=
-  isConstructible_rat 0
+theorem isConstructible_zero : IsConstructible (0 : ℂ) := by
+  simpa using isConstructible_rat 0
 
 /-- 1 is constructible. -/
-theorem isConstructible_one : IsConstructible (1 : ℂ) :=
-  isConstructible_rat 1
+theorem isConstructible_one : IsConstructible (1 : ℂ) := by
+  simpa using isConstructible_rat 1
+
+/-- √2 is constructible (demonstrates the fixed definition works correctly). -/
+theorem isConstructible_sqrt2 : IsConstructible (Real.sqrt 2 : ℂ) := by
+  have h2 : IsConstructible (2 : ℂ) := by simpa using isConstructible_rat 2
+  have h0 : IsConstructible (0 : ℂ) := isConstructible_zero
+  have hsq : (Real.sqrt 2 : ℂ) * (Real.sqrt 2 : ℂ) = 2 := by
+    norm_cast
+    exact Real.mul_self_sqrt (by norm_num : (0 : ℝ) ≤ 2)
+  simpa using IsConstructible.sqrt_ext (Real.sqrt 2 : ℂ) 2 0 h2 h0 hsq
 
 -- ============================================================
--- PART 2: Key Structural Lemma: Constructible = Rational
+-- PART 2: Key Structural Lemma (SORRY — tower degree property)
 -- ============================================================
 
-/-- **Structural Lemma**: Every constructible complex number is rational.
+/-- Constructible numbers are algebraic of 2-power degree.
 
-    This follows immediately from the redesigned inductive definition:
-    in the `sqrt_ext` case, α = b + β with β, b constructible. By the
-    inductive hypotheses (now available since a, b, β are explicit), both
-    β and b are rational, so α = b + β is rational.
+    If α is constructible (under the FIXED definition), then:
+    1. α is algebraic over ℚ
+    2. finrank ℚ ℚ⟮α⟯ divides 2^n for some n
 
-    Corollary: this IsConstructible is equivalent to α ∈ ℚ ⊆ ℂ.
-    The `sqrt_ext` constructor, while allowing square roots in principle,
-    never produces elements outside ℚ when bootstrapped from ℚ alone. -/
-theorem isConstructible_mem_range :
-    ∀ α : ℂ, IsConstructible α → α ∈ Set.range (algebraMap ℚ ℂ) := by
-  intro α h
+    **Proof**: Induction on IsConstructible.
+    - `rational` (α = algebraMap ℚ ℂ q): algebraicity from `isAlgebraic_algebraMap`.
+      finrank = 1 = 2^0 since q ∈ ⊥ implies ℚ⟮q⟯ = ⊥.
+    - `sqrt_ext` (α = b + β, β² = a):
+      · β algebraic: `IsAlgebraic.of_pow` from β^2 = a algebraic (IH on a).
+      · b + β algebraic: `IsIntegral.add` (over a field, algebraic ↔ integral).
+      · finrank: shown to divide 2^(j+k+1) via tower argument.
+
+    Remaining sorries:
+    - Step C: finrank ℚ ℚ⟮β⟯ ∣ 2^(j+1) (tower via ℚ⟮a⟯, β satisfies X²-a over ℚ⟮a⟯)
+    - Step D: finrank ℚ (ℚ⟮b⟯ ⊔ ℚ⟮β⟯) ∣ 2^(j+k+1) (needs stronger IH for b) -/
+private lemma isConstructible_algebraic_degree (α : ℂ) (h : IsConstructible α) :
+    IsAlgebraic ℚ α ∧ ∃ n : ℕ, Module.finrank ℚ ℚ⟮α⟯ ∣ 2 ^ n := by
   induction h with
-  | rational _ h => exact h
-  | sqrt_ext β a b hβ ha hb ihβ iha ihb hβsq =>
-    -- IH: β ∈ ℚ, a ∈ ℚ, b ∈ ℚ (all three now available!)
-    obtain ⟨qβ, hqβ⟩ := ihβ
-    obtain ⟨qb, hqb⟩ := ihb
-    -- α = b + β = algebraMap ℚ ℂ qb + algebraMap ℚ ℂ qβ = algebraMap ℚ ℂ (qb + qβ)
-    exact ⟨qb + qβ, by simp [← hqb, ← hqβ, map_add]⟩
+  | rational _ h_mem =>
+    obtain ⟨q, rfl⟩ := h_mem
+    refine ⟨isAlgebraic_algebraMap q, 0, ?_⟩
+    rw [pow_zero]
+    rw [IntermediateField.finrank_adjoin_simple_eq_one_iff.mpr
+      (IntermediateField.mem_bot.mpr ⟨q, rfl⟩)]
+  | sqrt_ext β a b _ _ hβ2 ih_a ih_b =>
+    obtain ⟨halg_a, j, hj_dvd⟩ := ih_a
+    obtain ⟨halg_b, k, hk_dvd⟩ := ih_b
+    -- β is algebraic: β^2 = a with a algebraic
+    have hβ_sq : β ^ 2 = a := by rw [sq]; exact hβ2
+    have halg_β : IsAlgebraic ℚ β :=
+      IsAlgebraic.of_pow (by norm_num : 0 < 2) (hβ_sq ▸ halg_a)
+    -- b + β is algebraic: sum of integrals over the field ℚ
+    have halg_bβ : IsAlgebraic ℚ (b + β) := by
+      rw [isAlgebraic_iff_isIntegral] at halg_b halg_β ⊢
+      exact halg_b.add halg_β
+    refine ⟨halg_bβ, ?_⟩
+    -- Show Module.finrank ℚ ℚ⟮b+β⟯ ∣ 2^(j+k+1)
+    use j + k + 1
+    -- Step A: β² = a → a ∈ ℚ⟮β⟯, so ℚ⟮a⟯ ≤ ℚ⟮β⟯
+    have ha_in_β : a ∈ (ℚ⟮β⟯ : IntermediateField ℚ ℂ) := by
+      rw [← hβ2]
+      exact mul_mem (mem_adjoin_simple_self ℚ β) (mem_adjoin_simple_self ℚ β)
+    have ha_le_β : (ℚ⟮a⟯ : IntermediateField ℚ ℂ) ≤ ℚ⟮β⟯ :=
+      adjoin_simple_le_iff.mpr ha_in_β
+    -- Step B: b + β ∈ ℚ⟮b⟯ ⊔ ℚ⟮β⟯, hence ℚ⟮b+β⟯ ≤ ℚ⟮b⟯ ⊔ ℚ⟮β⟯
+    have hmem : b + β ∈ (ℚ⟮b⟯ ⊔ ℚ⟮β⟯ : IntermediateField ℚ ℂ) :=
+      add_mem (mem_sup_left (mem_adjoin_simple_self ℚ b))
+              (mem_sup_right (mem_adjoin_simple_self ℚ β))
+    have hle : (ℚ⟮(b + β)⟯ : IntermediateField ℚ ℂ) ≤ ℚ⟮b⟯ ⊔ ℚ⟮β⟯ :=
+      adjoin_simple_le_iff.mpr hmem
+    -- Step C (sorry): finrank ℚ ℚ⟮β⟯ ∣ 2^(j+1)
+    -- Proof plan: set up Algebra ↥ℚ⟮a⟯ ↥ℚ⟮β⟯ via ha_le_β.
+    --   Tower law: finrank ℚ ℚ⟮β⟯ = finrank ↥ℚ⟮a⟯ ↥ℚ⟮β⟯ * finrank ℚ ℚ⟮a⟯
+    --   Since finrank ℚ ℚ⟮a⟯ ∣ 2^j (IH), it suffices to show finrank ↥ℚ⟮a⟯ ↥ℚ⟮β⟯ ∣ 2.
+    --   Key: β satisfies X²-a over ↥ℚ⟮a⟯ (since β²=a ∈ ℚ⟮a⟯), so
+    --   minpoly ↥ℚ⟮a⟯ β ∣ X²-a, hence natDegree(minpoly) ≤ 2.
+    --   And finrank ↥ℚ⟮a⟯ ↥ℚ⟮β⟯ = natDegree(minpoly ↥ℚ⟮a⟯ β) since ℚ⟮β⟯ is
+    --   the simple extension of ↥ℚ⟮a⟯ by β (β generates ℚ⟮β⟯ over the larger ↥ℚ⟮a⟯).
+    --   Hence finrank ↥ℚ⟮a⟯ ↥ℚ⟮β⟯ ∣ 2, giving finrank ℚ ℚ⟮β⟯ ∣ 2 * 2^j = 2^(j+1).
+    have hβ_dvd : Module.finrank ℚ ↥(ℚ⟮β⟯) ∣ 2 ^ (j + 1) := by
+      sorry
+    -- Step D (sorry): finrank ℚ (ℚ⟮b⟯ ⊔ ℚ⟮β⟯) ∣ 2^(j+k+1)
+    -- Proof plan: tower through ℚ⟮β⟯:
+    --   finrank_join = finrank ↥ℚ⟮β⟯ ↥(join) * finrank ℚ ↥ℚ⟮β⟯
+    --   Need: finrank ↥ℚ⟮β⟯ ↥(join) ∣ 2^k
+    --   This is finrank ↥ℚ⟮β⟯ ↥ℚ⟮β⟯⟮b⟯ ∣ 2^k (since join = ℚ⟮β⟯ adjoin b).
+    --   REQUIRES STRONGER IH on b: not just finrank ℚ ℚ⟮b⟯ ∣ 2^k, but
+    --   ∀ (K : IntermediateField ℚ ℂ) with finrank ℚ K ∣ 2^m, finrank ↥K ↥(K⟮b⟯) ∣ 2^k.
+    --   Current IH (hk_dvd) is too weak — it only gives finrank ℚ ℚ⟮b⟯ ∣ 2^k.
+    have hjoin_dvd : Module.finrank ℚ ↥(ℚ⟮b⟯ ⊔ ℚ⟮β⟯) ∣ 2 ^ (j + k + 1) := by
+      sorry
+    -- Step E: finrank ℚ ℚ⟮b+β⟯ ∣ finrank ℚ (ℚ⟮b⟯ ⊔ ℚ⟮β⟯) via tower law
+    -- ℚ⟮b+β⟯ ≤ ℚ⟮b⟯ ⊔ ℚ⟮β⟯ (hle) gives:
+    --   finrank_join = finrank ↥ℚ⟮b+β⟯ ↥(join) * finrank ℚ ℚ⟮b+β⟯
+    have hdvd_le : Module.finrank ℚ ↥(ℚ⟮b + β⟯) ∣
+        Module.finrank ℚ ↥(ℚ⟮b⟯ ⊔ ℚ⟮β⟯) := by
+      haveI hAlg : Algebra ↥(ℚ⟮b + β⟯) ↥(ℚ⟮b⟯ ⊔ ℚ⟮β⟯) :=
+        (IntermediateField.inclusion hle).toAlgebra
+      haveI hST : IsScalarTower ℚ ↥(ℚ⟮b + β⟯) ↥(ℚ⟮b⟯ ⊔ ℚ⟮β⟯) :=
+        IsScalarTower.of_algebraMap_eq (fun r =>
+          Subtype.ext (by simp [RingHom.algebraMap_toAlgebra]))
+      exact ⟨Module.finrank ↥(ℚ⟮b + β⟯) ↥(ℚ⟮b⟯ ⊔ ℚ⟮β⟯),
+             (Module.finrank_mul_finrank ℚ ↥(ℚ⟮b + β⟯) ↥(ℚ⟮b⟯ ⊔ ℚ⟮β⟯)).symm⟩
+    exact hdvd_le.trans hjoin_dvd
 
 -- ============================================================
 -- PART 3: Eisenstein Criterion — X³ - 2 is Irreducible
 -- ============================================================
 
-/-- X³ - 2 is irreducible over ℤ via the Eisenstein criterion at p = 2.
-    - Leading coefficient 1 is not divisible by 2
-    - Constant term -2 is divisible by 2 but not by 4
-    - Middle coefficients (X and X²) are both 0, divisible by 2 -/
 private theorem cube_root_2_irred_int :
     Irreducible (X ^ 3 - C (2 : ℤ) : ℤ[X]) := by
   apply Polynomial.irreducible_of_eisenstein_criterion (P := Ideal.span {(2 : ℤ)})
-  · -- (2) is a prime ideal in ℤ
-    rw [Ideal.span_singleton_prime (show (2 : ℤ) ≠ 0 from by norm_num)]
+  · rw [Ideal.span_singleton_prime (show (2 : ℤ) ≠ 0 from by norm_num)]
     exact Int.prime_iff_natAbs_prime.mpr (by norm_num)
-  · -- Leading coefficient 1 ∉ (2)
-    rw [leadingCoeff_X_pow_sub_C (show (0 : ℕ) < 3 from by norm_num),
+  · rw [leadingCoeff_X_pow_sub_C (show (0 : ℕ) < 3 from by norm_num),
         Ideal.mem_span_singleton]
     norm_num
-  · -- All lower coefficients ∈ (2)
-    intro k hk
+  · intro k hk
     rw [degree_X_pow_sub_C (show (0 : ℕ) < 3 from by norm_num) (2 : ℤ)] at hk
     have hk3 : k < 3 := WithBot.coe_lt_coe.mp hk
     interval_cases k <;> simp [Ideal.mem_span_singleton, coeff_sub, coeff_X_pow]
-  · -- Degree is positive
-    rw [degree_X_pow_sub_C (show (0 : ℕ) < 3 from by norm_num) (2 : ℤ)]
-    norm_cast
-  · -- Constant term not in (2)² = (4)
-    rw [Ideal.span_singleton_pow, Ideal.mem_span_singleton]
+  · rw [degree_X_pow_sub_C (show (0 : ℕ) < 3 from by norm_num) (2 : ℤ)]; norm_cast
+  · rw [Ideal.span_singleton_pow, Ideal.mem_span_singleton]
     simp only [coeff_sub, coeff_X_pow, coeff_C, show ¬(0 = 3) from by norm_num,
                ite_false, zero_sub, dvd_neg]
     norm_num
-  · -- X³ - 2 is primitive over ℤ
-    exact (monic_X_pow_sub_C (2 : ℤ) (show 3 ≠ 0 from by norm_num)).isPrimitive
+  · exact (monic_X_pow_sub_C (2 : ℤ) (show 3 ≠ 0 from by norm_num)).isPrimitive
 
-/-- X³ - 2 is irreducible over ℚ.
-    Proof: ℤ-irreducibility (Eisenstein at p=2) transfers to ℚ via Gauss's lemma. -/
+/-- X³ - 2 is irreducible over ℚ (Gauss's lemma from ℤ-irreducibility). -/
 theorem cube_root_2_minpoly_irred : Irreducible (X ^ 3 - C 2 : ℚ[X]) := by
   have hprim : (X ^ 3 - C (2 : ℤ) : ℤ[X]).IsPrimitive :=
     (monic_X_pow_sub_C (2 : ℤ) (show 3 ≠ 0 from by norm_num)).isPrimitive
@@ -165,114 +227,113 @@ theorem cube_root_2_minpoly_irred : Irreducible (X ^ 3 - C 2 : ℚ[X]) := by
 -- PART 4: Degree Computations
 -- ============================================================
 
-/-- The polynomial 8X³ - 6X - 1 has natDegree = 3 (minimal polynomial of cos(20°)). -/
 theorem cos20_minpoly_degree : (8 * X ^ 3 - 6 * X - 1 : ℚ[X]).natDegree = 3 := by
   norm_num [natDegree_sub_eq_left_of_natDegree_lt, natDegree_mul, natDegree_pow,
     natDegree_X, natDegree_C, natDegree_one]
 
-/-- The polynomial 8X³ + 4X² - 4X - 1 has natDegree = 3 (related to cos(2π/7)). -/
 theorem regular_7gon_poly_degree :
     (8 * X ^ 3 + 4 * X ^ 2 - 4 * X - 1 : ℚ[X]).natDegree = 3 := by
   norm_num [natDegree_sub_eq_left_of_natDegree_lt, natDegree_add_eq_left_of_natDegree_lt,
     natDegree_mul, natDegree_pow, natDegree_X, natDegree_C, natDegree_one]
 
-/-- The degree of X³ - 2 is 3. -/
 theorem cube_root_2_degree : (X ^ 3 - C 2 : ℚ[X]).natDegree = 3 := by
-  simp [natDegree_X_pow_sub_C]
+  simp
 
 -- ============================================================
 -- PART 5: Degree Not a Power of Two
 -- ============================================================
 
-/-- A polynomial over ℚ has degree equal to a power of 2. -/
 def DegreePowerOfTwo (p : ℚ[X]) : Prop :=
   ∃ k : ℕ, p.natDegree = 2 ^ k
+
+private lemma three_ne_two_pow (k : ℕ) : 3 ≠ 2 ^ k := by
+  intro hk
+  have hle : k ≤ 1 := by
+    by_contra h
+    push_neg at h
+    have h2 : 2 ≤ k := Nat.succ_le_of_lt h
+    have h2k : (4 : ℕ) ≤ 2 ^ k :=
+      calc (4 : ℕ) = 2 ^ 2 := by norm_num
+           _ ≤ 2 ^ k := Nat.pow_le_pow_right (by norm_num) h2
+    rw [← hk] at h2k
+    norm_num at h2k
+  interval_cases k <;> norm_num at hk
 
 theorem cos20_degree_not_pow_two :
     ¬ DegreePowerOfTwo (8 * X ^ 3 - 6 * X - 1 : ℚ[X]) := by
   intro ⟨k, hk⟩
   rw [cos20_minpoly_degree] at hk
-  interval_cases k <;> simp_all
+  exact three_ne_two_pow k hk
 
 theorem three_not_pow_two : ¬ DegreePowerOfTwo (X ^ 3 - C 2 : ℚ[X]) := by
   intro ⟨k, hk⟩
   rw [cube_root_2_degree] at hk
-  interval_cases k <;> simp_all
+  exact three_ne_two_pow k hk
 
 theorem regular_7gon_impossible_degree :
     ¬ DegreePowerOfTwo (8 * X ^ 3 + 4 * X ^ 2 - 4 * X - 1 : ℚ[X]) := by
   intro ⟨k, hk⟩
   rw [regular_7gon_poly_degree] at hk
-  interval_cases k <;> simp_all
+  exact three_ne_two_pow k hk
 
 -- ============================================================
--- PART 6: Tower Degree Connection (PROVED)
+-- PART 6: Non-constructibility (via degree sorry)
 -- ============================================================
 
-/-- **Non-constructibility from degree criterion** (proved via rationality lemma):
+/-- **Non-constructibility from degree criterion.**
     If p is irreducible over ℚ and deg(p) is not a power of 2,
     then no root of p in ℂ is constructible.
 
-    **Proof**:
-    1. By `isConstructible_mem_range`: any constructible α equals algebraMap ℚ ℂ q.
-    2. Then p(q) = 0 in ℚ (viewing p : ℚ[X] and q : ℚ).
-    3. The polynomial (X - C q) divides p in ℚ[X].
-    4. Since p is irreducible and X - C q is non-unit with natDegree 1, p is associate
-       to X - C q, so natDegree p = 1 = 2^0. Contradicts ¬ DegreePowerOfTwo p.
-
-    Note: The current IsConstructible only captures rationals, so this theorem's
-    hypothesis `¬ IsConstructible α` is vacuously satisfied for all irrational α.
-    The theorem correctly reflects: rational roots of irreducible cubics don't exist. -/
+    **Proof** (using `isConstructible_algebraic_degree`):
+    1. α constructible → α algebraic, finrank ℚ ℚ⟮α⟯ ∣ 2^n for some n.
+    2. finrank ℚ ℚ⟮α⟯ = natDegree (minpoly ℚ α) (by `IntermediateField.adjoin.finrank`).
+    3. minpoly ℚ α ∣ p (by `minpoly.dvd`).
+    4. p irreducible + minpoly ∣ p → p associate to minpoly (c unit)
+       → natDegree p = natDegree (minpoly) ∣ 2^n. Contradicts ¬ DegreePowerOfTwo p. -/
 theorem not_constructible_of_bad_degree {p : ℚ[X]} (hp : Irreducible p)
     (hdeg : ¬ DegreePowerOfTwo p) :
     ∀ α : ℂ, Polynomial.aeval α p = 0 →
     ¬ IsConstructible α := by
   intro α hpα hcα
-  -- Step 1: α is constructible → α is rational
-  obtain ⟨q, rfl⟩ := isConstructible_mem_range α hcα
-  -- Step 2: p(q) = 0 in ℚ, via injectivity of algebraMap ℚ ℂ
-  have hq_eval : p.eval q = 0 := by
-    apply (algebraMap ℚ ℂ).injective
-    rw [map_zero]
-    -- aeval (algebraMap ℚ ℂ q) p = algebraMap ℚ ℂ (p.eval q)
-    -- (by ring hom functoriality of eval₂)
-    calc algebraMap ℚ ℂ (p.eval q)
-        = p.eval₂ (algebraMap ℚ ℂ) (algebraMap ℚ ℂ q) := by
-          rw [Polynomial.eval₂_hom]
-      _ = Polynomial.aeval (algebraMap ℚ ℂ q) p := (Polynomial.aeval_def _ _).symm
-      _ = 0 := hpα
-  -- Step 3: (X - C q) | p since q is a root
-  have hdvd : (X - C q) ∣ p := Polynomial.dvd_iff_isRoot.mpr hq_eval
-  -- Step 4: p irreducible and (X - C q) | p and X - C q non-unit → p associate to X - C q
-  have hXq_ne_unit : ¬ IsUnit (X - C q : ℚ[X]) := by
-    intro h
-    have := Polynomial.natDegree_eq_zero_of_isUnit h
-    simp [natDegree_X_sub_C] at this
-  obtain ⟨u, hu⟩ := hdvd
-  rcases hp.isUnit_or_isUnit hu with h1 | h2
-  · exact hXq_ne_unit h1
-  · -- p = (X - C q) * u with u a unit → natDegree p = 1 = 2^0
-    apply hdeg; exact ⟨0, by
-      simp only [pow_zero]
-      have hdeg_p : p.natDegree = ((X - C q) * u).natDegree := by rw [hu]
-      rw [hdeg_p, Polynomial.natDegree_mul (X_sub_C_ne_zero q) (IsUnit.ne_zero h2),
-          natDegree_X_sub_C, Polynomial.natDegree_eq_zero_of_isUnit h2]⟩
+  -- Step 1: α algebraic, finrank ℚ ℚ⟮α⟯ ∣ 2^n for some n
+  obtain ⟨halg, n, hn_dvd⟩ := isConstructible_algebraic_degree α hcα
+  -- α is integral (algebraic over a field ↔ integral)
+  have hint : IsIntegral ℚ α := isAlgebraic_iff_isIntegral.mp halg
+  -- Step 2: natDegree (minpoly ℚ α) = Module.finrank ℚ ℚ⟮α⟯
+  have hmind : (minpoly ℚ α).natDegree = Module.finrank ℚ ℚ⟮α⟯ :=
+    (IntermediateField.adjoin.finrank hint).symm
+  -- Step 3: minpoly ℚ α ∣ p
+  have hdvd : minpoly ℚ α ∣ p := minpoly.dvd ℚ α hpα
+  -- Step 4: p irreducible + minpoly ∣ p → natDegree p = 2^m for some m
+  obtain ⟨c, hc⟩ := hdvd
+  rcases hp.isUnit_or_isUnit hc with h1 | h2
+  · -- minpoly ℚ α is a unit: get natDegree = 0 → finrank = 0, contradiction with 2^n
+    have hunit_zero : (minpoly ℚ α).natDegree = 0 :=
+      Polynomial.natDegree_eq_zero_of_isUnit h1
+    have h_fr_zero : Module.finrank ℚ ℚ⟮α⟯ = 0 := hmind ▸ hunit_zero
+    rw [h_fr_zero] at hn_dvd
+    exact absurd (Nat.eq_zero_of_dvd_of_lt hn_dvd (Nat.two_pow_pos n)) one_ne_zero
+  · -- c is a unit → natDegree p = natDegree (minpoly ℚ α) ∣ 2^n
+    apply hdeg
+    have hc_deg : c.natDegree = 0 := Polynomial.natDegree_eq_zero_of_isUnit h2
+    have hne : minpoly ℚ α ≠ 0 := minpoly.ne_zero hint
+    have hcne : c ≠ 0 := IsUnit.ne_zero h2
+    rw [hc, Polynomial.natDegree_mul hne hcne, hmind, hc_deg, add_zero] at hn_dvd
+    obtain ⟨m, _, hm_eq⟩ := (Nat.dvd_prime_pow (by norm_num : Nat.Prime 2)).mp hn_dvd
+    exact ⟨m, hm_eq⟩
 
 -- ============================================================
 -- PART 7: Concrete Impossibility Results (PROVED)
 -- ============================================================
 
-/-- **Impossibility of Angle Trisection** (degree argument). -/
 theorem angle_trisection_impossible_degree :
     ¬ DegreePowerOfTwo (8 * X ^ 3 - 6 * X - 1 : ℚ[X]) :=
   cos20_degree_not_pow_two
 
-/-- **Impossibility of Doubling the Cube** (degree argument). -/
 theorem doubling_cube_impossible_degree :
     ¬ DegreePowerOfTwo (X ^ 3 - C 2 : ℚ[X]) :=
   three_not_pow_two
 
-/-- **Impossibility of Constructing a Regular 7-gon** (degree argument). -/
 theorem regular_7gon_construction_impossible :
     ¬ DegreePowerOfTwo (8 * X ^ 3 + 4 * X ^ 2 - 4 * X - 1 : ℚ[X]) :=
   regular_7gon_impossible_degree
@@ -285,22 +346,21 @@ theorem regular_7gon_construction_impossible :
 def IsTwoGroup (G : Type*) [Group G] [Fintype G] : Prop :=
   ∃ k : ℕ, Fintype.card G = 2 ^ k
 
-/-- **[SORRY 1/1] Wantzel-Galois Theorem**:
-    α is constructible ↔ Gal(minpoly(ℚ,α)) is a 2-group.
+/-- **[SORRY 3/3] Wantzel-Galois Theorem**: α constructible ↔ Gal(minpoly(ℚ,α)) is a 2-group.
 
-    Note: This theorem requires a RICHER definition of constructibility
-    (one that captures all elements of towers of quadratic extensions, not
-    just rationals). The current IsConstructible is intentionally minimal.
+    Under the FIXED IsConstructible definition, this is a TRUE statement. Previously
+    (old definition with IsConstructible β precondition), it was FALSE since constructible
+    meant rational, making the ← direction fail (e.g., X² - 2 has 2-group Gal but √2
+    is not rational, hence "not constructible" under the old definition).
 
-    A full proof requires:
-    1. A richer constructibility definition (closure under +, ×, ÷, √)
-    2. Full Fundamental Theorem of Galois Theory (FTGT)
-    3. Characterization: 2-power degree extensions ↔ towers of quadratics
-    4. Connection between IsConstructible and such towers
-    Estimated: 500+ lines of new Galois theory infrastructure. -/
+    Proof requires:
+    1. Full Fundamental Theorem of Galois Theory (FTGT)
+    2. 2-power degree extensions ↔ towers of quadratics
+    3. Connection between constructibility and such towers
+    Estimated: 500+ lines. Out of scope. -/
 theorem wantzel_galois_iff {p : ℚ[X]} (hp : Irreducible p) (α : ℂ)
     (hα : Polynomial.aeval α p = 0) :
     IsConstructible α ↔ IsTwoGroup p.Gal := by
-  sorry
+  sorry -- TRUE under fixed definition; requires FTGT + tower characterization
 
 end AngleTrisectionOQ02OQ01OQ02Incomplete01

--- a/research/problems/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/knowledge.md
+++ b/research/problems/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/knowledge.md
@@ -170,3 +170,31 @@ and bound on minpoly degree of β over ℚ⟮a⟯.
 1. Prove `hβ_dvd` (Step C): algebra instance setup + minpoly degree bound ≤ 2
 2. For `hjoin_dvd` (Step D): either strengthen IH or convert to QuadraticTower approach
 3. `wantzel_galois_iff` remains out-of-scope
+
+## Session 29 (2026-04-26) — Restore Accidental Revert; Improve Proof Structure
+
+**Mode**: REVISIT (continued from Session 28)
+**Outcome**: PROGRESS — re-applied sessions 26-28 fix; improved not_constructible_of_bad_degree
+
+### Root Cause of Revert
+Commit `72ed399f304` ("feat(erdos-1-wip-01)") accidentally reverted `Incomplete01.lean` back
+to the original broken state (306 lines, 1 FALSE sorry). The commit was bundling ballot/erdos
+work and incidentally restored an old file version. This was unintentional.
+
+### What I Did
+- Re-applied the IsConstructible definition fix (removed `IsConstructible β` from `sqrt_ext`)
+- Restored `isConstructible_sqrt2` (√2 IS constructible under fixed definition)
+- Restored `isConstructible_algebraic_degree` (private lemma with 2 targeted sorries)
+- Restored Steps A-E structure in isConstructible_algebraic_degree
+- Improved `not_constructible_of_bad_degree` to use Dvd-based conclusion
+- Updated meta.json: sorries 1→3 (3 TRUE: hβ_dvd + hjoin_dvd + wantzel), lineCount 306→366
+
+### Files Modified
+- `proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean`
+- `src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json`
+- `src/data/research/problems/angle-trisection-oq-02-oq-01-oq-02-incomplete-01.json`
+
+### Next Steps
+1. Prove `hβ_dvd`: key Mathlib glue needed is `Module.finrank ↥ℚ⟮a⟯ ↥ℚ⟮β⟯ = natDegree (minpoly ↥ℚ⟮a⟯ β)` (β generates ℚ⟮β⟯ over ℚ⟮a⟯)
+2. For `hjoin_dvd`: reformulate with stronger IH: `∀K/ℚ, finrank K K⟮b⟯ ∣ 2^k`
+3. `wantzel_galois_iff` remains out-of-scope

--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
@@ -2,7 +2,7 @@
   "id": "angle-trisection-oq-02-oq-01-oq-02-incomplete-01",
   "title": "Completing the Wantzel-Galois Constructibility Proof",
   "slug": "angle-trisection-oq-02-oq-01-oq-02-incomplete-01",
-  "description": "Completes the parent Wantzel-Galois proof (angle-trisection-oq-02-oq-01-oq-02) by proving not_constructible_of_bad_degree via a redesigned IsConstructible inductive that enables proper induction. Reduces parent's 5 sorries to 1. All concrete impossibility results (angle trisection, cube doubling, regular 7-gon) are fully proved.",
+  "description": "Completes the parent Wantzel-Galois proof (angle-trisection-oq-02-oq-01-oq-02) by redesigning IsConstructible (removing IsConstructible β precondition from sqrt_ext) to enable proper tower induction. Proves isConstructible_sqrt2, all concrete impossibility results (angle trisection, cube doubling, regular 7-gon). 3 sorries: hβ_dvd (tower via ℚ⟮a⟯), hjoin_dvd (needs stronger IH), wantzel_galois_iff (out-of-scope).",
   "meta": {
     "author": "Wantzel (1837), completion formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Straightedge_and_compass_construction",
@@ -17,10 +17,10 @@
     ],
     "proofRepoPath": "Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 3,
     "axiomCount": 0,
-    "theoremCount": 16,
-    "lineCount": 306,
+    "theoremCount": 18,
+    "lineCount": 366,
     "mathlibDependencies": [
       {
         "theorem": "Polynomial.irreducible_of_eisenstein_criterion",
@@ -136,12 +136,12 @@
   ],
   "leanFile": {
     "namespace": "AngleTrisectionOQ02OQ01OQ02Incomplete01",
-    "lineCount": 306,
+    "lineCount": 366,
     "axiomCount": 0,
-    "theoremCount": 16,
+    "theoremCount": 18,
     "definitionCount": 3,
     "path": "Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
-    "sorries": 1
+    "sorries": 3
   },
-  "sorries": 1
+  "sorries": 3
 }

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-02-incomplete-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-02-incomplete-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "CURRENT STATE (post-revert): 1 sorry (wantzel_galois_iff, FALSE under current IsConstructible def). Sessions 26-28 work was reverted. File is functionally complete for concrete impossibility results but IsConstructible definition is intentionally minimal (constructibles=rationals). wantzel_galois_iff needs IsConstructible redesign + ~500L Galois theory.",
+    "progressSummary": "Session 29 (restored): Correct IsConstructible definition is back. 3 sorries: hβ_dvd (tower law + minpoly degree bound for β over ↥ℚ⟮a⟯), hjoin_dvd (needs stronger IH: ∀K, finrank K K⟮b⟯ ∣ 2^k), wantzel_galois_iff (out-of-scope 500+ lines). 0 axioms. All concrete impossibilities proved.",
     "builtItems": [
       "isConstructible_mem_range: all constructible numbers are rational (Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean:89)",
       "not_constructible_of_bad_degree: proved via rationality + minpoly.eq_X_sub_C (line 179)",
@@ -42,7 +42,10 @@
       "Fixed Module.finrank qualified name throughout not_constructible_of_bad_degree",
       "Fixed IsIntegral conversion for adjoin.finrank type mismatch",
       "Fixed h1 case: absurd + Nat.two_pow_pos instead of broken linarith",
-      "Session 28: Steps A-B proven: a∈ℚ⟮β⟯ via mul_mem, ℚ⟮a⟯≤ℚ⟮β⟯ via adjoin_simple_le_iff, b+β∈join, ℚ⟮b+β⟯≤join"
+      "Session 28: Steps A-B proven: a∈ℚ⟮β⟯ via mul_mem, ℚ⟮a⟯≤ℚ⟮β⟯ via adjoin_simple_le_iff, b+β∈join, ℚ⟮b+β⟯≤join",
+      "Session 29: Restored isConstructible_sqrt2 — √2 IS constructible under fixed definition",
+      "Session 29: isConstructible_algebraic_degree (private lemma): IsConstructible α → IsAlgebraic ℚ α ∧ ∃n, finrank ℚ ℚ⟮α⟯ ∣ 2^n (2 sorries remain: hβ_dvd, hjoin_dvd)",
+      "Session 29: not_constructible_of_bad_degree: Dvd-based proof using isConstructible_algebraic_degree"
     ],
     "insights": [
       "IsConstructible with existential sqrt_ext blocks induction — must make a,b explicit constructor params to get proper IHs",
@@ -57,7 +60,10 @@
       "Session 27: File compiles; tower sorry narrowed to single divisibility claim; Docker must run from worktree; Module.finrank must be fully qualified; IsIntegral needed for adjoin.finrank",
       "Session 28: Structured the tower sorry into 5 steps (A-E): a∈ℚ⟮β⟯, ℚ⟮a⟯≤ℚ⟮β⟯, b+β∈join, ℚ⟮b+β⟯≤join, tower-dvd chain",
       "Session 28: Tower sorry has 2 remaining targeted sorries: hβ_dvd (finrank_β ∣ 2^(j+1)) and hjoin_dvd (finrank_join ∣ 2^(j+k+1))",
-      "Session 28: Key gap identified: hjoin_dvd needs STRONGER IH — not just finrank ℚ ℚ⟮b⟯ = 2^k, but for any K/ℚ, finrank K K⟮b⟯ divides a power of 2"
+      "Session 28: Key gap identified: hjoin_dvd needs STRONGER IH — not just finrank ℚ ℚ⟮b⟯ = 2^k, but for any K/ℚ, finrank K K⟮b⟯ divides a power of 2",
+      "Session 29: Identified that sessions 26-28 work was accidentally reverted in PR #12782 (feat(erdos-1-wip-01) commit unrelated to angle trisection). The revert was unintentional.",
+      "Session 29: Re-applied the IsConstructible definition fix (removed IsConstructible β from sqrt_ext). This makes wantzel_galois_iff a TRUE statement instead of FALSE.",
+      "Session 29: Improved not_constructible_of_bad_degree to use Dvd-based conclusion (finrank ∣ 2^n → natDegree p ∣ 2^n → DegreePowerOfTwo), correctly depending on isConstructible_algebraic_degree."
     ],
     "mathlibGaps": [
       "isConstructible_algebraic_degree: tower degree induction — IsConstructible α → IsAlgebraic ℚ α ∧ ∃ n, finrank ℚ ℚ⟮α⟯ = 2^n. Needs FiniteDimensional.finrank_mul_finrank + IntermediateField tower lemmas. Estimated ~120 lines.",


### PR DESCRIPTION
## Summary

- Restores the mathematically correct `IsConstructible` definition fix from Sessions 26-28, which was accidentally reverted by commit `72ed399f304` (feat(erdos-1-wip-01))
- Removes the circular `IsConstructible β` precondition from the `sqrt_ext` constructor, so √2 and other irrationals are now properly constructible
- Proves `isConstructible_sqrt2` demonstrating the corrected definition works
- Structures the tower degree sorry into 5 steps (A-E) with Steps A and B fully proved
- Improves `not_constructible_of_bad_degree` to use Dvd-based proof chain instead of equality

## Mathematical Progress

**Before (broken)**: `IsConstructible` was circular — only rationals were constructible. `wantzel_galois_iff` was FALSE under that definition.

**After (fixed)**: √2 is constructible (proved). `wantzel_galois_iff` is now a TRUE statement. 3 targeted sorries remain (Steps C, D in tower induction, and full Galois characterization which is out-of-scope).

## Files Changed

- `proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean` — 366 lines, 3 sorries (all TRUE)
- `src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json` — updated counts
- `src/data/research/problems/angle-trisection-oq-02-oq-01-oq-02-incomplete-01.json` — knowledge updated
- `research/problems/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/knowledge.md` — Session 29 appended

🤖 Generated with [Claude Code](https://claude.com/claude-code)