### PR TITLE
research(shannon-source-coding-oq-04): prove type_class_size_eq_multinomial (2→1 sorries)

### DIFF
--- a/proofs/Proofs/ShannonSourceCodingOQ04.lean
+++ b/proofs/Proofs/ShannonSourceCodingOQ04.lean
@@ -304,8 +304,7 @@ theorem type_class_size_le_entropy_pow (n : ℕ) (hn : 0 < n) (f : Fin k → ℕ
       ≤ 1 / typeProb n hn' f := by
         rw [le_div_iff₀ htypeProb_pos]; linarith [h_key]
     _ = Real.exp ((n : ℝ) * empEntropy n hn' f) := by
-        rw [htypeProb_exp, Real.exp_neg]
-        simp [Real.exp_pos.ne']
+        rw [htypeProb_exp, neg_mul, Real.exp_neg, one_div, inv_inv]
 
 /-- **Lower bound**: The dominant type class has size ≥ k^n / (n+1)^k.
     Since there are at most (n+1)^k distinct types and all sequences sum to k^n,

--- a/proofs/Proofs/ShannonSourceCodingOQ04.lean
+++ b/proofs/Proofs/ShannonSourceCodingOQ04.lean
@@ -1,9 +1,4 @@
-import Mathlib.Analysis.SpecialFunctions.Log.Basic
-import Mathlib.Analysis.SpecialFunctions.Pow.Real
-import Mathlib.Combinatorics.Pigeonhole
-import Mathlib.Data.Nat.Choose.Multinomial
-import Mathlib.Data.Fintype.Card
-import Mathlib.Tactic
+import Mathlib
 
 /-
 # Method of Types: Alternative Proof of Shannon Source Coding Theorem
@@ -82,13 +77,97 @@ def typeClass (n : ℕ) (f : Fin k → ℕ) (hf : ∑ i, f i = n) :
   Finset.univ.filter fun x => empDist n x = f
 
 /-- Type class size equals the multinomial coefficient n! / ∏(f i)!.
-    This is the fundamental counting fact of the method of types.
-    Proof: bijection between type class and arrangements of the multiset
-    [0^{f(0)}, 1^{f(1)}, ..., (k-1)^{f(k-1)}].
-    [OPEN: requires Finset.card of fiber over surjection — ~60 lines] -/
+    This is the fundamental counting fact of the method of types (Csiszár-Körner 1981).
+    Proof: induction on n, partitioning T_f by the last element x(Fin.last n),
+    then applying the Pascal identity for multinomial coefficients.
+    (Proof strategy discovered by Aristotle proof search.) -/
 theorem type_class_size_eq_multinomial (n : ℕ) (f : Fin k → ℕ) (hf : ∑ i, f i = n) :
     (typeClass n f hf).card = Nat.multinomial Finset.univ f := by
-  sorry
+  have h_card : Finset.card (Finset.univ.filter (fun σ : Fin n → Fin k =>
+      ∀ i : Fin k, Finset.card (Finset.filter (fun j => σ j = i) Finset.univ) = f i)) =
+      Nat.factorial n / (∏ i, Nat.factorial (f i)) := by
+    rw [Nat.div_eq_of_eq_mul_left];
+    · exact Finset.prod_pos fun i _ => Nat.factorial_pos _;
+    · induction' n with n ih generalizing f;
+      · simp_all +decide [Finset.ext_iff];
+      · have h_split : Finset.card (Finset.filter (fun σ : Fin (n + 1) → Fin k =>
+              ∀ i, Finset.card (Finset.filter (fun j => σ j = i) Finset.univ) = f i)
+            (Finset.univ : Finset (Fin (n + 1) → Fin k))) =
+            ∑ i, Finset.card (Finset.filter (fun σ : Fin n → Fin k =>
+              ∀ j, Finset.card (Finset.filter (fun l => σ l = j) Finset.univ) =
+                if j = i then f i - 1 else f j)
+            (Finset.univ : Finset (Fin n → Fin k))) := by
+          have h_split : Finset.filter (fun σ : Fin (n + 1) → Fin k =>
+                ∀ i, Finset.card (Finset.filter (fun j => σ j = i) Finset.univ) = f i)
+              (Finset.univ : Finset (Fin (n + 1) → Fin k)) =
+            Finset.biUnion (Finset.univ : Finset (Fin k)) (fun i =>
+              Finset.image (fun σ : Fin n → Fin k => Fin.snoc σ i)
+                (Finset.filter (fun σ : Fin n → Fin k =>
+                  ∀ j, Finset.card (Finset.filter (fun l => σ l = j) Finset.univ) =
+                    if j = i then f i - 1 else f j)
+                (Finset.univ : Finset (Fin n → Fin k)))) := by
+            ext σ;
+            constructor;
+            · intro hσ;
+              simp +zetaDelta at *;
+              refine' ⟨σ (Fin.last n), Fin.init σ, _, _⟩ <;>
+                simp +decide [← hσ, Fin.init_def, Fin.snoc];
+              · intro j; split_ifs <;> simp_all +decide [Finset.filter_erase, Finset.filter_or];
+                · rw [← hσ]; rw [Finset.card_filter, Finset.card_filter];
+                  rw [Fin.sum_univ_castSucc]; aesop;
+                · convert hσ j using 1;
+                  rw [Finset.card_filter, Finset.card_filter];
+                  rw [Fin.sum_univ_castSucc]; aesop;
+              · exact funext fun i => by cases i using Fin.lastCases <;> simp +decide [*];
+            · simp +zetaDelta at *;
+              rintro i σ hσ rfl j; by_cases hj : j = i <;> simp_all +decide [Fin.snoc];
+              · convert congr_arg (· + 1) (hσ i) using 1;
+                · rw [Finset.card_filter, Finset.card_filter];
+                  rw [Fin.sum_univ_castSucc]; aesop;
+                · have h_sum : ∑ i, Finset.card (Finset.filter (fun l => σ l = i)
+                      Finset.univ) = n := by
+                    simp +decide only [card_filter];
+                    rw [Finset.sum_comm]; aesop;
+                  grind;
+              · convert hσ j using 1;
+                · rw [Finset.card_filter, Finset.card_filter];
+                  rw [Fin.sum_univ_castSucc]; aesop;
+                · rw [if_neg hj];
+          rw [h_split, Finset.card_biUnion];
+          · exact Finset.sum_congr rfl fun _ _ =>
+              Finset.card_image_of_injective _ fun x y hxy => by simpa [Fin.ext_iff] using hxy;
+          · intros i hi j hj hij; simp [Finset.disjoint_left, Finset.mem_image]; grind +extAll;
+        have h_ind : ∀ i, Finset.card (Finset.filter (fun σ : Fin n → Fin k =>
+              ∀ j, Finset.card (Finset.filter (fun l => σ l = j) Finset.univ) =
+                if j = i then f i - 1 else f j)
+            (Finset.univ : Finset (Fin n → Fin k))) *
+            (∏ j, (f j).factorial) = (n.factorial) * (f i) := by
+          intro i
+          by_cases hi : f i = 0;
+          · simp [hi]; left;
+            intro x; contrapose! hf;
+            simp_all +decide [Finset.sum_eq_zero_iff_of_nonneg];
+            have h_sum : ∑ i, Finset.card (Finset.filter (fun l => x l = i)
+                Finset.univ) = n := by
+              simp +decide only [card_filter]; rw [Finset.sum_comm]; aesop;
+            grind;
+          · rw [ih (fun j => if j = i then f i - 1 else f j)];
+            · rw [mul_assoc, ← Finset.prod_erase_mul _ _ (Finset.mem_univ i)];
+              rw [← Finset.prod_erase_mul _ _ (Finset.mem_univ i)];
+              rw [← mul_assoc, ← mul_assoc,
+                ← Nat.succ_pred_eq_of_pos (Nat.pos_of_ne_zero hi)];
+              simp +decide [Nat.factorial_succ, mul_assoc, mul_comm, mul_left_comm,
+                Finset.prod_ite, Finset.filter_ne', Finset.filter_eq', hi];
+              exact Or.inl <| Or.inl <|
+                Finset.prod_congr rfl fun x hx => by aesop;
+            · simp_all +decide [Finset.sum_ite, Finset.filter_eq', Finset.filter_ne'];
+              rw [← Finset.sum_erase_add _ _ (Finset.mem_univ i), add_comm] at hf; omega;
+        simp_all +decide [Nat.factorial_succ, mul_comm, Finset.mul_sum];
+        rw [← Finset.sum_mul, hf, mul_comm];
+  convert h_card using 1;
+  · unfold typeClass empDist;
+    simp +decide [funext_iff, Finset.ext_iff];
+  · rw [Nat.multinomial, ← hf]
 
 /-!
 ## Section 2: Entropy Upper Bound on Type Class Size
@@ -222,9 +301,11 @@ theorem type_class_size_le_entropy_pow (n : ℕ) (hn : 0 < n) (f : Fin k → ℕ
       _ = 1 := hsum_one
   -- Conclude: |T_f| ≤ exp(n H(Q))
   calc ((typeClass n f hf).card : ℝ)
-      ≤ 1 / typeProb n hn' f := (le_div_iff htypeProb_pos).mpr h_key
+      ≤ 1 / typeProb n hn' f := by
+        rw [le_div_iff₀ htypeProb_pos]; linarith [h_key]
     _ = Real.exp ((n : ℝ) * empEntropy n hn' f) := by
-        rw [htypeProb_exp, one_div, ← Real.exp_neg, neg_neg]
+        rw [htypeProb_exp, Real.exp_neg]
+        simp [Real.exp_pos.ne']
 
 /-- **Lower bound**: The dominant type class has size ≥ k^n / (n+1)^k.
     Since there are at most (n+1)^k distinct types and all sequences sum to k^n,
@@ -268,7 +349,7 @@ theorem dominant_type_lower_bound (n : ℕ) :
     simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hx₀
     -- From F x₀ = y, extract: empDist n x₀ = Fin.val ∘ y
     have h_empDist_eq : empDist n x₀ = fun i => (y i).val := by
-      funext i; exact (Fin.ext_iff.mp (congr_fun hx₀ i)).symm
+      funext i; exact Fin.ext_iff.mp (congr_fun hx₀ i)
     -- So ∑ i, (Fin.val ∘ y) i = n
     have hf₀ : ∑ i : Fin k, (y i).val = n := by
       rw [← h_empDist_eq]; exact empDist_sum n x₀
@@ -276,10 +357,7 @@ theorem dominant_type_lower_bound (n : ℕ) :
     have h_eq : Finset.univ.filter (fun x : Fin n → Fin k => F x = y) =
         typeClass n (fun i => (y i).val) hf₀ := by
       ext x
-      simp only [Finset.mem_filter, Finset.mem_univ, true_and, typeClass, F]
-      constructor
-      · intro h; funext i; exact (Fin.ext_iff.mp (congr_fun h i)).symm
-      · intro h; funext i; exact Fin.ext (congr_fun h i).symm
+      simp [typeClass, empDist, F, funext_iff, Fin.ext_iff]
     exact ⟨fun i => (y i).val, hf₀, h_eq ▸ hy_card⟩
 
 /-!

--- a/research/problems/shannon-source-coding-oq-04/knowledge.md
+++ b/research/problems/shannon-source-coding-oq-04/knowledge.md
@@ -134,3 +134,40 @@ cannot be used in `dominant_type_lower_bound` (Section 2). Fix: inline the proof
    `bash research/scripts/aristotle-submit.sh proofs/Proofs/ShannonSourceCodingOQ04Aristotle.lean shannon-source-coding-oq-04 "Session 2: type_class_size_eq_multinomial"`
 2. If Aristotle fails/unavailable: implement induction proof manually (~100 lines, see strategy above)
 3. `source_coding_achievability_mot` remains OPEN (needs LLN infrastructure)
+
+---
+
+## Session 2026-04-26 (Session 3) — Integrated Aristotle Proof of type_class_size_eq_multinomial
+
+**Mode**: REVISIT
+**Outcome**: PROGRESS — 2 → 1 sorries
+
+### What I Did
+
+1. Found that Aristotle had already proved `type_class_size_eq_multinomial` in the companion
+   file (PR #12842, merged to master), but the proof was NOT yet integrated into the main file
+2. Adapted the Aristotle proof (induction on n, Pascal identity) from the companion file
+   (`typeClass'`/`empDist'`) to the main file (`typeClass`/`empDist`)
+3. Changed imports from specific Mathlib modules to `import Mathlib` for full compatibility
+4. Fixed Lean 4 coercion direction: `.symm` removed from `Fin.ext_iff.mp (congr_fun hx₀ i)`
+5. Fixed `h_eq` proof in `dominant_type_lower_bound` using `simp [typeClass, empDist, F, funext_iff, Fin.ext_iff]`
+6. Build confirmed: only `source_coding_achievability_mot` sorry remains (OPEN problem)
+
+### Key Insight
+
+The Aristotle proof uses induction on block length n:
+- Partition T_f by last element x(Fin.last n), using `Fin.snoc` as bijection
+- Apply Pascal-like identity: |T_{n+1,f}| = ∑_{v:f(v)>0} |T_{n,f[v↦f(v)-1]}|
+- Induction hypothesis gives each term = multinomial(f[v↦f(v)-1])
+- Sum equals multinomial(f) by factorial algebra
+
+### Files Modified
+
+- `proofs/Proofs/ShannonSourceCodingOQ04.lean` (352 → 428 lines, 2 → 1 sorries)
+- `src/data/proofs/shannon-source-coding-oq-04/meta.json` (sorries 2→1, lineCount updated)
+- `src/data/research/problems/shannon-source-coding-oq-04.json` (knowledge updated)
+
+### Remaining Work
+
+- `source_coding_achievability_mot` (OPEN): requires LLN/concentration inequalities.
+  Not tractable without significant infrastructure (>1000 lines). Classify as BLOCKED.

--- a/src/data/proofs/shannon-source-coding-oq-04/meta.json
+++ b/src/data/proofs/shannon-source-coding-oq-04/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "Real.log_pow",
@@ -59,7 +59,8 @@
       "empEntropy_eq_shannonEntropy: empirical entropy matches Shannon entropy of normalized type (proved)",
       "log_typeProb_eq: log-probability of type class weight equals -n * H(Q) (proved)",
       "type_class_size_le_entropy_pow: |T_f| ≤ exp(n H(Q)) via probability argument (proved)",
-      "dominant_type_lower_bound: dominant type class ≥ k^n/(n+1)^k via pigeonhole (proved)"
+      "dominant_type_lower_bound: dominant type class ≥ k^n/(n+1)^k via pigeonhole (proved)",
+      "type_class_size_eq_multinomial: |T_f| = n!/∏(f_i)! proved via induction on n (proved by Aristotle, integrated session 3)"
     ],
     "assumptions": [
       "type_class_size_eq_multinomial: |T_f| = n!/∏(f_i)! (bijection proof omitted, ~60 lines)",

--- a/src/data/research/problems/shannon-source-coding-oq-04.json
+++ b/src/data/research/problems/shannon-source-coding-oq-04.json
@@ -7,7 +7,7 @@
   "path": "full",
   "problemStatement": {
     "formal": "|T_Q^n| = \\binom{n}{nQ(x_1), nQ(x_2), \\ldots, nQ(x_{|\\mathcal{X}|})} \\approx 2^{nH(Q)}",
-    "plain": "The Csiszár-Körner **method of types** gives a combinatorial alternative to the standard",
+    "plain": "The Csisz\u00e1r-K\u00f6rner **method of types** gives a combinatorial alternative to the standard",
     "whyMatters": []
   },
   "knownResults": {
@@ -19,7 +19,7 @@
     "phase": "ACT",
     "since": "2026-04-25T00:00:00-07:00",
     "iteration": 2,
-    "focus": "Proved type_class_size_le_entropy_pow and dominant_type_lower_bound. 2 sorries remain.",
+    "focus": "Proved type_class_size_eq_multinomial (Aristotle induction proof integrated). 1 sorry remains: source_coding_achievability_mot (OPEN).",
     "blockers": [],
     "nextAction": "Submit type_class_size_eq_multinomial to Aristotle for proof search.",
     "attemptCounts": {
@@ -29,24 +29,24 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved type_class_size_le_entropy_pow and dominant_type_lower_bound. 4→2 sorries.",
+    "progressSummary": "PROGRESS: Proved type_class_size_le_entropy_pow, dominant_type_lower_bound, type_class_size_eq_multinomial. 2\u21921 sorries. 1 remaining: source_coding_achievability_mot (OPEN, needs LLN).",
     "builtItems": [
-      "type_class_size_le_entropy_pow: |T_f| ≤ exp(n H(Q)) proved via prod_fiberwise' + prod_univ_sum (ShannonSourceCodingOQ04.lean:166)",
-      "dominant_type_lower_bound: dominant type class ≥ k^n/(n+1)^k proved via Finset pigeonhole (ShannonSourceCodingOQ04.lean:175)"
+      "type_class_size_le_entropy_pow: |T_f| \u2264 exp(n H(Q)) proved via prod_fiberwise' + prod_univ_sum (ShannonSourceCodingOQ04.lean:166)",
+      "dominant_type_lower_bound: dominant type class \u2265 k^n/(n+1)^k proved via Finset pigeonhole (ShannonSourceCodingOQ04.lean:175)",
+      "type_class_size_eq_multinomial: |T_f| = Nat.multinomial proved via induction on n (ShannonSourceCodingOQ04.lean:89)"
     ],
     "insights": [
-      "prod_fiberwise' rewrites ∏ j:Fin n, Q(x j) as ∏ i:Fin k, Q(i)^(empDist n x i) for any x — key for equating sequence probability to type probability",
+      "prod_fiberwise' rewrites \u220f j:Fin n, Q(x j) as \u220f i:Fin k, Q(i)^(empDist n x i) for any x \u2014 key for equating sequence probability to type probability",
       "prod_univ_sum (product of sums = sum over piFinset of products) gives total probability = 1 without EN NReal lifting",
-      "Finset.exists_le_card_fiber_of_mul_le_card_of_maps_to is in Mathlib.Combinatorics.Pigeonhole — NOT auto-imported via Mathlib.Tactic",
+      "Finset.exists_le_card_fiber_of_mul_le_card_of_maps_to is in Mathlib.Combinatorics.Pigeonhole \u2014 NOT auto-imported via Mathlib.Tactic",
       "Lean 4 forward reference issue: theorems defined later in file cannot be used earlier; must inline proofs"
     ],
     "mathlibGaps": [
       "Fintype.card_fiber_eq_multinomial: if it exists, could prove type_class_size_eq_multinomial directly"
     ],
     "nextSteps": [
-      "Free disk space + submit ShannonSourceCodingOQ04Aristotle.lean to Aristotle for type_class_size_eq_multinomial",
-      "If Aristotle unavailable: implement induction-on-n proof: partition T_f by x(Fin.last n), use Pascal identity",
-      "Leave source_coding_achievability_mot as OPEN (requires concentration inequalities)"
+      "source_coding_achievability_mot is OPEN \u2014 needs LLN/concentration inequalities (>1000 lines). Mark as BLOCKED.",
+      "Consider follow-up: can type_class_size_eq_multinomial be proved without grind/aesop? (clean up proof)"
     ],
     "markdown": "# Knowledge Base: shannon-source-coding-oq-04\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
@@ -107,11 +107,11 @@
     {
       "path": "Proofs/ShannonSourceCodingOQ04.lean",
       "filename": "ShannonSourceCodingOQ04.lean",
-      "lineCount": 353,
+      "lineCount": 428,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonSourceCodingOQ04.lean"
     },


### PR DESCRIPTION
## Summary

- Proves `type_class_size_eq_multinomial`: the fundamental counting fact `|T_f| = n!/∏(f_i)!` of the method of types (Csiszár-Körner 1981)
- Reduces sorry count from 2 to 1 in `ShannonSourceCodingOQ04.lean`
- Fixes `import Mathlib` compatibility issues (`le_div_iff` → `le_div_iff₀`, exp_neg rewrite)

Proof strategy (induction on block length n):
- Base case n=0: unique empty function, multinomial = 1
- Inductive step: partition T_f by `x(Fin.last n) = v` using `Fin.snoc` bijection
- Pascal-like identity: |T_{n+1,f}| = ∑_{v:f(v)>0} |T_{n,f[v↦f(v)-1]}|
- Each term = multinomial by induction hypothesis
- Sum = multinomial(f) by factorial algebra

Remaining sorry (`source_coding_achievability_mot`) is classified OPEN — requires concentration inequalities / law of large numbers infrastructure not yet in Mathlib.

## Test plan

- [ ] Lean file builds with Docker wrapper (`./proofs/scripts/docker-build.sh Proofs.ShannonSourceCodingOQ04`)
- [ ] Sorry count reduced from 2 → 1 in meta.json
- [ ] Knowledge.md updated with session notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)