### PR TITLE
fix(meta): correct leanFile.axiomCount to include resolved import/additionalFiles axioms

### DIFF
--- a/src/data/proofs/greens-theorem-oq-04/meta.json
+++ b/src/data/proofs/greens-theorem-oq-04/meta.json
@@ -241,7 +241,7 @@
     ],
     "namespace": "GreensTheoremOQ04",
     "lineCount": 587,
-    "axiomCount": 0,
+    "axiomCount": 2,
     "theoremCount": 23,
     "definitionCount": 14,
     "path": "Proofs/GreensTheoremOQ04.lean",

--- a/src/data/proofs/inverse-galois-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-oq-01/meta.json
@@ -303,7 +303,7 @@
   "leanFile": {
     "path": "Proofs/InverseGaloisOQ01.lean",
     "lineCount": 723,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "sorries": 1,
     "theoremCount": 46,
     "definitionCount": 1,

--- a/src/data/proofs/inverse-galois/meta.json
+++ b/src/data/proofs/inverse-galois/meta.json
@@ -303,7 +303,7 @@
   "leanFile": {
     "path": "Proofs/InverseGalois.lean",
     "lineCount": 1882,
-    "axiomCount": 4,
+    "axiomCount": 5,
     "sorries": 0,
     "theoremCount": 105,
     "definitionCount": 1,

--- a/src/data/proofs/yang-mills-2d/meta.json
+++ b/src/data/proofs/yang-mills-2d/meta.json
@@ -175,7 +175,7 @@
   "leanFile": {
     "lineCount": 28075,
     "structureCount": 365,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 1787,
     "lemmaCount": 0,
     "defCount": 641,

--- a/src/data/proofs/yang-mills-lattice/meta.json
+++ b/src/data/proofs/yang-mills-lattice/meta.json
@@ -148,7 +148,7 @@
   "leanFile": {
     "lineCount": 28075,
     "structureCount": 365,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 1787,
     "lemmaCount": 0,
     "defCount": 641,

--- a/src/data/proofs/yang-mills-transfer-matrix/meta.json
+++ b/src/data/proofs/yang-mills-transfer-matrix/meta.json
@@ -138,7 +138,7 @@
   "leanFile": {
     "lineCount": 28075,
     "structureCount": 365,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 1787,
     "lemmaCount": 0,
     "defCount": 641,

--- a/src/data/proofs/yang-mills/meta.json
+++ b/src/data/proofs/yang-mills/meta.json
@@ -203,7 +203,7 @@
     ],
     "namespace": "YangMillsMassGap",
     "lineCount": 48,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 1806,
     "definitionCount": 260,
     "path": "Proofs/YangMillsMassGap.lean",


### PR DESCRIPTION
## Summary

7 gallery entries were flagged as issues by `find-targets.ts --issues` because `leanFile.axiomCount` only counted axioms declared directly in the main Lean file. The auditor script resolves the full import chain (including `additionalFiles` and submodule imports) and compares against the total.

Changes to `leanFile.axiomCount` only — `meta.axiomCount` (the semantic assumption count) is unchanged:

| Entry | Old | New | Reason |
|-------|-----|-----|--------|
| `yang-mills` | 0 | 1 | `gaugeTransform` axiom in `YangMills/Classical.lean` (resolved via import chain from `YangMillsMassGap.lean`) |
| `yang-mills-transfer-matrix` | 0 | 1 | `Exploration.lean` imports `Classical.lean` which has 1 axiom |
| `yang-mills-lattice` | 0 | 1 | Same as above |
| `yang-mills-2d` | 0 | 1 | Same as above |
| `inverse-galois` | 4 | 5 | `three_dvd_gal_card` in `InverseGaloisA5.lean` (an `additionalFile`) |
| `inverse-galois-oq-01` | 0 | 1 | Same axiom; `InverseGaloisA5.lean` is an `additionalFile` |
| `greens-theorem-oq-04` | 0 | 2 | `greens_theorem_typeI` + `disk_area_eq_pi` in `GreensTheoremOQ03.lean` (an `additionalFile`) |

## Test plan

- [x] `npx tsx scripts/auditor/find-targets.ts --issues` shows **0 issues** from the worktree (was 7)
- [x] `meta.axiomCount` is unchanged in all 7 files (semantic assumptions unaffected)
- [x] Only `leanFile.axiomCount` changed, which reflects raw Lean declaration counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)