### PR TITLE
fix(meta): sync leanFile.theoremCount for 21 gallery entries

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-04/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-04/meta.json
@@ -22,7 +22,7 @@
         "axiomCount": 0,
         "assumptions": "",
         "lineCount": 234,
-        "theoremCount": 9,
+        "theoremCount": 3,
         "definitionCount": 3,
         "originalContributions": [
             "IsMaxNorm: predicate for maximal normal subgroup H in K (relative normality + maximality)",
@@ -66,7 +66,7 @@
         "namespace": "AbelRuffiniGaloisExtensionsOQ04",
         "lineCount": 234,
         "axiomCount": 0,
-        "theoremCount": 9,
+        "theoremCount": 3,
         "definitionCount": 3,
         "path": "Proofs/AbelRuffiniGaloisExtensionsOQ04.lean",
         "sorries": 0,

--- a/src/data/proofs/amgm-inequality-oq-03-oq-03-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-03-oq-01/meta.json
@@ -121,7 +121,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
-    "theoremCount": 8,
+    "theoremCount": 19,
     "definitionCount": 4
   },
   "sorries": 0

--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-02/meta.json
@@ -96,7 +96,7 @@
     "namespace": "AngleTrisectionCos20GalOQ01OQ02",
     "lineCount": 326,
     "axiomCount": 0,
-    "theoremCount": 12,
+    "theoremCount": 27,
     "definitionCount": 2,
     "path": "Proofs/AngleTrisectionCos20GalOQ01OQ02.lean",
     "sorries": 1

--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-01/meta.json
@@ -160,7 +160,7 @@
     "namespace": "AngleTrisectionCos20GalOQ01",
     "lineCount": 416,
     "axiomCount": 0,
-    "theoremCount": 5,
+    "theoremCount": 32,
     "definitionCount": 0,
     "sorries": 0,
     "path": "Proofs/AngleTrisectionCos20GalOQ01.lean"

--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-03-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-03-oq-01/meta.json
@@ -235,7 +235,7 @@
     "namespace": "AngleTrisectionCos20GalOQ03OQ01",
     "lineCount": 462,
     "axiomCount": 0,
-    "theoremCount": 5,
+    "theoremCount": 28,
     "definitionCount": 0,
     "sorries": 0,
     "path": "Proofs/AngleTrisectionCos20GalOQ03OQ01.lean"

--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-03/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-03/meta.json
@@ -139,7 +139,7 @@
     "namespace": "AngleTrisectionCos20GalOQ03",
     "lineCount": 434,
     "axiomCount": 0,
-    "theoremCount": 18,
+    "theoremCount": 32,
     "definitionCount": 4,
     "path": "Proofs/AngleTrisectionCos20GalOQ03.lean",
     "sorries": 0

--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02/meta.json
@@ -182,7 +182,7 @@
     "namespace": "AperyZetaThree",
     "lineCount": 952,
     "axiomCount": 5,
-    "theoremCount": 25,
+    "theoremCount": 52,
     "definitionCount": 4,
     "path": "Proofs/BaselProblemOQ01OQ01OQ02.lean",
     "sorries": 0,

--- a/src/data/proofs/binomial-theorem-oq-04-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-04-oq-03/meta.json
@@ -123,7 +123,7 @@
     "namespace": "BinomialTheoremOQ04OQ03",
     "lineCount": 190,
     "axiomCount": 0,
-    "theoremCount": 17,
+    "theoremCount": 9,
     "substantiveTheoremCount": 11,
     "duplicateTheorems": 0,
     "definitionCount": 4,

--- a/src/data/proofs/derangements-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/derangements-oq-03-oq-01-oq-02/meta.json
@@ -172,7 +172,7 @@
     "namespace": "DerangementsOQ03OQ01OQ02",
     "lineCount": 412,
     "axiomCount": 0,
-    "theoremCount": 10,
+    "theoremCount": 24,
     "definitionCount": 1,
     "mainTheorems": [
       {

--- a/src/data/proofs/erdos-1012-oq-03/meta.json
+++ b/src/data/proofs/erdos-1012-oq-03/meta.json
@@ -260,7 +260,7 @@
     "axiomCount": 1,
     "sorries": 1,
     "path": "Proofs/Erdos1012OQ03.lean",
-    "theoremCount": 9,
+    "theoremCount": 27,
     "definitionCount": 9
   },
   "sorries": 1

--- a/src/data/proofs/erdos-1033/meta.json
+++ b/src/data/proofs/erdos-1033/meta.json
@@ -305,7 +305,7 @@
     "namespace": "Erdos1033",
     "lineCount": 1018,
     "axiomCount": 3,
-    "theoremCount": 16,
+    "theoremCount": 28,
     "definitionCount": 17,
     "sorries": 0,
     "path": "Proofs/Erdos1033Problem.lean"

--- a/src/data/proofs/erdos-1131/meta.json
+++ b/src/data/proofs/erdos-1131/meta.json
@@ -24,7 +24,7 @@
     "erdosUrl": "https://erdosproblems.com/1131",
     "erdosProblemStatus": "open",
     "axiomCount": 1,
-    "theoremCount": 14,
+    "theoremCount": 31,
     "lineCount": 1076,
     "assumptions": "1 axiom: erdos_1131_conjecture (OPEN). 0 sorries — all supporting lemmas fully proved: chebyshev_interp, chebyshev_sq_expansion, dct_offdiag, integral_cos_substitution, integral_chebyshev_sq, chebyshev_integral_trace.",
     "mathlib_version": "4.26.0"
@@ -201,7 +201,7 @@
     "namespace": "Erdos1131",
     "lineCount": 1076,
     "axiomCount": 1,
-    "theoremCount": 14,
+    "theoremCount": 31,
     "definitionCount": 6,
     "sorries": 0,
     "path": "Proofs/Erdos1131Problem.lean"

--- a/src/data/proofs/erdos-1179-oq-01/meta.json
+++ b/src/data/proofs/erdos-1179-oq-01/meta.json
@@ -21,7 +21,7 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "theoremCount": 23,
+    "theoremCount": 28,
     "definitionCount": 7,
     "lineCount": 709,
     "erdosNumber": 1179,
@@ -225,7 +225,7 @@
     "namespace": "Erdos1179OQ01",
     "lineCount": 709,
     "axiomCount": 0,
-    "theoremCount": 11,
+    "theoremCount": 28,
     "definitionCount": 5,
     "sorries": 0,
     "path": "Proofs/Erdos1179OQ01.lean"

--- a/src/data/proofs/erdos-263/meta.json
+++ b/src/data/proofs/erdos-263/meta.json
@@ -161,7 +161,7 @@
     "namespace": "Erdos263",
     "lineCount": 792,
     "axiomCount": 0,
-    "theoremCount": 19,
+    "theoremCount": 31,
     "definitionCount": 19,
     "path": "Proofs/Erdos263Problem.lean",
     "sorries": 4

--- a/src/data/proofs/erdos-268/meta.json
+++ b/src/data/proofs/erdos-268/meta.json
@@ -209,7 +209,7 @@
     "namespace": "Erdos268",
     "lineCount": 951,
     "axiomCount": 2,
-    "theoremCount": 15,
+    "theoremCount": 32,
     "definitionCount": 14,
     "sorries": 0,
     "path": "Proofs/Erdos268Problem.lean"

--- a/src/data/proofs/erdos-840/meta.json
+++ b/src/data/proofs/erdos-840/meta.json
@@ -103,7 +103,7 @@
     "namespace": null,
     "lineCount": 237,
     "axiomCount": 8,
-    "theoremCount": 9,
+    "theoremCount": 4,
     "definitionCount": 11,
     "sorries": 0,
     "path": "Proofs/Erdos840Problem.lean"

--- a/src/data/proofs/hurwitz-theorem-oq-03/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-03/meta.json
@@ -23,7 +23,7 @@
     "axiomCount": 0,
     "assumptions": "1 sorry: hurwitz_only_if — if an n-square identity exists, then n ∈ {1,2,4,8} (n=3 case proved; n∉{1,2,3,4,8} cases pending Clifford/Radon-Hurwitz argument). The converse (identities exist for n ∈ {1,2,4,8}) is fully proved. No axiom declarations.",
     "lineCount": 2042,
-    "theoremCount": 32,
+    "theoremCount": 45,
     "definitionCount": 15,
     "originalContributions": [
       "NSquareIdentity: structure for bilinear n-square composition identities",
@@ -69,7 +69,7 @@
     "namespace": "HurwitzTheorem",
     "lineCount": 2042,
     "axiomCount": 0,
-    "theoremCount": 33,
+    "theoremCount": 45,
     "definitionCount": 15,
     "path": "Proofs/HurwitzTheorem.lean",
     "sorries": 1

--- a/src/data/proofs/inverse-galois-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-oq-01/meta.json
@@ -305,7 +305,7 @@
     "lineCount": 723,
     "axiomCount": 0,
     "sorries": 1,
-    "theoremCount": 46,
+    "theoremCount": 40,
     "definitionCount": 1,
     "imports": [
       "Mathlib",

--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -214,7 +214,7 @@
     "namespace": "BanachTarski",
     "lineCount": 1342,
     "axiomCount": 0,
-    "theoremCount": 7,
+    "theoremCount": 51,
     "definitionCount": 5,
     "path": "Proofs/LebesgueMeasureOQ06.lean",
     "sorries": 2

--- a/src/data/proofs/pascals-hexagon/meta.json
+++ b/src/data/proofs/pascals-hexagon/meta.json
@@ -227,7 +227,7 @@
     "namespace": null,
     "lineCount": 1278,
     "axiomCount": 1,
-    "theoremCount": 21,
+    "theoremCount": 46,
     "definitionCount": 24,
     "path": "Proofs/PascalsHexagon.lean",
     "sorries": 1

--- a/src/data/proofs/poincare-conjecture/meta.json
+++ b/src/data/proofs/poincare-conjecture/meta.json
@@ -345,7 +345,7 @@
     "lineCount": 17675,
     "axiomCount": 32,
     "sorries": 0,
-    "theoremCount": 897,
+    "theoremCount": 943,
     "definitionCount": 365,
     "lemmaCount": 0
   }


### PR DESCRIPTION
## Fix

Corrects stale `leanFile.theoremCount` values in 21 meta.json files. These files grew through subsequent research/enrichment activity but metadata was not updated.

## Method

Counting: comprehensive regex matching `theorem`/`lemma` with optional attributes (`@[simp]` etc.), `private`/`protected`/`noncomputable` modifiers, and indentation — matching the method used when original counts were set.

## Evidence

**Undercounted** (file has more theorems than reported):
| Entry | Before | After |
|-------|--------|-------|
| poincare-conjecture | 897 | 943 |
| lebesgue-measure-oq-06 | 7 | 51 |
| basel-problem-oq-01-oq-01-oq-02 | 25 | 52 |
| angle-trisection-cos-20-gal-oq-01 | 5 | 32 |
| pascals-hexagon | 21 | 46 |
| angle-trisection-cos-20-gal-oq-03-oq-01 | 5 | 28 |
| erdos-1012-oq-03 | 9 | 27 |
| erdos-268 | 15 | 32 |
| erdos-1179-oq-01 | 11 | 28 |
| erdos-1131 | 14 | 31 |
| angle-trisection-cos-20-gal-oq-01-oq-02 | 12 | 27 |
| derangements-oq-03-oq-01-oq-02 | 10 | 24 |
| angle-trisection-cos-20-gal-oq-03 | 18 | 32 |
| hurwitz-theorem-oq-03 | 33 | 45 |
| erdos-263 | 19 | 31 |
| erdos-1033 | 16 | 28 |
| amgm-inequality-oq-03-oq-03-oq-01 | 8 | 19 |

**Overcounted** (theorems removed/refactored since last sync):
| Entry | Before | After |
|-------|--------|-------|
| binomial-theorem-oq-04-oq-03 | 17 | 9 |
| inverse-galois-oq-01 | 46 | 40 |
| abel-ruffini-galois-extensions-oq-04 | 9 | 3 |
| erdos-840 | 9 | 4 |

Build: ✓ `pnpm build` passes with no new errors.

---
Automated fix by lean-mechanic agent.