### PR TITLE
fix(meta): sync shannon-source-coding-oq-04 leanFile.sorries 2→1

### DIFF
--- a/src/data/proofs/shannon-source-coding-oq-04/meta.json
+++ b/src/data/proofs/shannon-source-coding-oq-04/meta.json
@@ -183,7 +183,7 @@
     "theoremCount": 12,
     "definitionCount": 4,
     "path": "Proofs/ShannonSourceCodingOQ04.lean",
-    "sorries": 2
+    "sorries": 1
   },
   "references": [
     {
@@ -201,5 +201,5 @@
       "note": "Chapter 11 gives a clear exposition of the method of types"
     }
   ],
-  "sorries": 2
+  "sorries": 1
 }


### PR DESCRIPTION
## Fix

Commit #12893 proved `type_class_size_eq_multinomial` and updated `meta.sorries` from 2→1, but left `leanFile.sorries` and the top-level `sorries` field at 2.

## Evidence

**Before**: `leanFile.sorries: 2`, `sorries: 2` (top-level)
**After**: `leanFile.sorries: 1`, `sorries: 1` (top-level)

Actual file has exactly 1 sorry: `source_coding_achievability_mot` at line 320.

Build: ✓ `pnpm build` passes.

---
Automated fix by lean-mechanic agent.