### PR TITLE
enrich(cayley-hamilton-cyclic-vector-all-fields): expand historicalContext, add mainTheorems, 2 annotations, 2 crossRefs

### DIFF
--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields/annotations.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields/annotations.json
@@ -1,5 +1,28 @@
 [
   {
+    "id": "ann-chcvaf-header",
+    "proofId": "cayley-hamilton-cyclic-vector-all-fields",
+    "range": {
+      "startLine": 1,
+      "endLine": 47
+    },
+    "type": "concept",
+    "title": "Module Header: Three-Step Proof Architecture and Mathlib Gap",
+    "content": "The module docstring lays out the full proof architecture before any Lean code appears. It names three building blocks: (1) the axiom `nonderogatory_similar_companion` (M ~ C(minpoly M), stated but not proved — the Mathlib gap); (2) `companionMatrix_cyclic_e0` (e₀ is cyclic for C(p), proved in CayleyHamiltonMinpolyOQ05OQ01OQ04 via the orbit C(p)^k · e₀ = eₖ); and (3) `cyclic_vector_of_similar` (cyclic vectors transfer under similarity, proved in the same file). The fourth point is the main theorem combining all three. This upfront blueprint is a design pattern for axiomatized formalizations: declare all assumptions explicitly, prove what you can, and clearly demarcate the boundary between verified and assumed content. The `Status: axiomatized (1 axiom, 0 sorries)` tag in the docstring directly matches the gallery's `badge: axiom` classification.",
+    "mathContext": "The proof architecture encodes the logical dependency graph: main theorem depends on (1) + (2) + (3); (2) and (3) depend only on Mathlib; (1) depends on the PID structure theorem for $K[X]$-modules (the Mathlib gap). This layering means any future Mathlib addition of the PID structure theorem would allow replacing the axiom with a proof, upgrading the entry from `axiomatized` to `verified` without any other changes. The imports (lines 41-49) show the two proof files this depends on: `CayleyHamiltonReductionOQ02OQ01` for companion matrix definitions and `CayleyHamiltonMinpolyOQ05OQ01OQ04` for the proved supporting lemmas.",
+    "significance": "context",
+    "relatedConcepts": [
+      "axiomatized proof architecture",
+      "companion matrix orbit C(p)^k · e₀ = eₖ",
+      "cyclic vector transfer under similarity",
+      "Mathlib gap: PID structure theorem"
+    ],
+    "prerequisites": [
+      "rational canonical form overview",
+      "Lean 4 module docstrings and imports"
+    ]
+  },
+  {
     "id": "ann-chcvaf-rcf-axiom",
     "proofId": "cayley-hamilton-cyclic-vector-all-fields",
     "range": {
@@ -68,6 +91,30 @@
     "prerequisites": [
       "nonderogatory_has_cyclic_vector",
       "companion matrix orbit property"
+    ]
+  },
+  {
+    "id": "ann-chcvaf-cyclic-characterization",
+    "proofId": "cayley-hamilton-cyclic-vector-all-fields",
+    "range": {
+      "startLine": 155,
+      "endLine": 169
+    },
+    "type": "insight",
+    "title": "Polynomial Annihilator Characterization of Cyclic Vectors",
+    "content": "`cyclic_iff_not_killed_below_degree` gives the polynomial annihilator characterization: v is cyclic for M iff no nonzero polynomial p of degree < n kills v under M (i.e., `(aeval M p).mulVec v ≠ 0`). The proof is purely logical — it unfolds `IsCyclicVector` and `CyclicVectorArbitrary.IsCyclicVector` via `simp only`, then splits into two implications closed by direct application of the hypothesis. No matrix computation is needed, because this is essentially unfolding the definition: `IsCyclicVector` IS the annihilator condition, and the corollary just restates it using the `aeval M` notation. The nonderogatory hypothesis `h : IsNonderogatory M` appears in the signature but is not used in the proof body — it is present to make the intended context (nonderogatory matrices) explicit to the reader.",
+    "mathContext": "Formally: $v$ is cyclic for $M$ iff $\\ker(p(M) \\cdot -) \\not\\ni v$ for all nonzero $p$ with $\\deg(p) < n$. Since $M$ is nonderogatory, $\\deg(\\mathrm{minpoly}) = n$, so the bound $\\deg(p) < n$ is exactly the bound needed to avoid the minimal polynomial. Any linear dependence $\\sum_{k < n} c_k M^k v = 0$ would give such a polynomial $p = \\sum c_k X^k$ with $p(M)v = 0$, so the condition is equivalent to $\\{v, Mv, \\ldots, M^{n-1}v\\}$ being linearly independent — i.e., a basis of $K^n$ (by dimension count).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "aeval (polynomial evaluation at a matrix)",
+      "mulVec (matrix-vector multiplication)",
+      "annihilator ideal",
+      "CyclicVectorArbitrary.IsCyclicVector"
+    ],
+    "prerequisites": [
+      "polynomial evaluation in Lean 4 via aeval",
+      "K[X]-module structure on K^n",
+      "linear independence via dimension"
     ]
   },
   {

--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields/meta.json
@@ -51,7 +51,7 @@
     "dateAdded": "2026-04-26"
   },
   "overview": {
-    "historicalContext": "The cyclic vector theorem is a cornerstone of the theory of rational canonical forms, established by Ferdinand Georg Frobenius in his 1878 paper 'Über lineare Substitutionen und bilineare Formen'. A matrix $M \\in M_n(K)$ is **nonderogatory** when its minimal polynomial equals its characteristic polynomial (both monic of degree $n$); a vector $v$ is **cyclic** for $M$ when $\\{v, Mv, M^2v, \\ldots, M^{n-1}v\\}$ forms a basis for $K^n$. The connection is bilateral: cyclic implies nonderogatory (proved in `cayley-hamilton-minpoly-oq-05-oq-01`), and nonderogatory implies cyclic (this result). The theorem holds over ALL fields — unlike the simpler union avoidance argument, which requires $|K| > n$ and breaks down over small finite fields such as $\\mathbb{F}_2$. The module-theoretic proof (via the structure theorem for f.g. modules over the PID $K[X]$) is field-independent: nonderogatory forces $K^n \\cong K[X]/(\\mathrm{minpoly}\\, M)$ as $K[X]$-modules, so $K^n$ is cyclic by definition. This formalization captures the key mathematical content via an explicit axiom for the one missing piece (the PID structure theorem) and proves the main theorem from it with full verification.",
+    "historicalContext": "The cyclic vector theorem lies at the intersection of two major 19th-century programs: the canonical form theory for linear operators and the module theory of rings. **Camille Jordan** (1870) established the Jordan normal form, decomposing complex matrices into Jordan blocks — a decomposition that requires all eigenvalues to lie in the base field. Jordan's theory was restricted to algebraically closed fields like $\\mathbb{C}$. **Ferdinand Georg Frobenius** (1878), in his landmark paper *Über lineare Substitutionen und bilineare Formen*, overcame this restriction by introducing the **rational canonical form** (now also called Frobenius normal form): every matrix over an arbitrary field is similar to a block-diagonal matrix of companion matrices $\\mathrm{diag}(C(d_1), \\ldots, C(d_r))$, where $d_1 \\mid \\cdots \\mid d_r$ are the **invariant factors** — computed from the matrix's characteristic polynomial via the PID $K[X]$ without reference to eigenvalues. This makes the theory valid over $\\mathbb{Q}$, $\\mathbb{F}_p$, and any field.\n\nA matrix $M \\in M_n(K)$ is **nonderogatory** when its minimal polynomial equals its characteristic polynomial; a vector $v$ is **cyclic** for $M$ when $\\{v, Mv, \\ldots, M^{n-1}v\\}$ is a basis. The cyclic vector theorem — nonderogatory $\\Rightarrow$ cyclic — holds over ALL fields. The modern module-theoretic proof, developed through **Emmy Noether's** 1929 work on the structure theorem for finitely generated modules over PIDs, shows that nonderogatory forces $K^n \\cong K[X]/(\\mathrm{minpoly}\\, M)$ as a $K[X]$-module, making cyclicity immediate. **H.J.S. Smith** (1861) gave the first constructive approach via Smith normal form for polynomial matrices, providing an algorithm for computing invariant factors. This formalization captures the theory via an explicit axiom for the PID structure theorem — the single Mathlib gap — and fully verifies the main theorem from it.",
     "problemStatement": "For any field $K$ and any nonderogatory matrix $M \\in M_n(K)$, prove there exists a cyclic vector $v \\in K^n$ — a vector such that $\\{v, Mv, \\ldots, M^{n-1}v\\}$ is a basis for $K^n$.",
     "proofStrategy": "The proof uses three building blocks: (1) the RCF similarity axiom states that every nonderogatory $M$ is similar to its companion matrix $C(\\mathrm{minpoly}\\, M)$, i.e., $M = P^{-1} C P$ for some invertible $P$; (2) the orbit lemma (proved in `CayleyHamiltonMinpolyOQ05OQ01OQ04`) shows $e_0$ is cyclic for $C(p)$ because $C(p)^k \\cdot e_0 = e_k$ for all $k < n$; (3) the similarity invariance lemma (also proved) transfers the cyclic vector: if $w$ is cyclic for $N$ and $M = P^{-1}NP$, then $P^{-1}w$ is cyclic for $M$. Combining: $M \\sim C(\\mathrm{minpoly}\\, M)$ via $P$, $e_0$ is cyclic for $C$, so $P^{-1} e_0$ is cyclic for $M$. The proof never invokes field cardinality, working over arbitrary $K$.",
     "keyInsights": [
@@ -129,17 +129,44 @@
     {
       "targetId": "cayley-hamilton-minpoly-oq-05-oq-01",
       "relationship": "extends",
-      "description": "Converse: nonderogatory ← cyclic (proved for infinite fields). This file proves the opposite direction for ALL fields."
+      "description": "Converse: nonderogatory ← cyclic (proved for infinite fields using union avoidance). This file proves the opposite direction for ALL fields via the RCF similarity axiom, bypassing cardinality arguments entirely."
     },
     {
       "targetId": "cayley-hamilton-minpoly-oq-05-oq-01-oq-04",
       "relationship": "companion",
-      "description": "Alternative approach using module theory with sorry. This file uses the axiom approach, giving 0 sorries and explicit axiom declaration."
+      "description": "Alternative approach using module theory with sorry. This file uses the axiom approach, giving 0 sorries and explicit axiom declaration — contrasting proof architectures for the same theorem."
     },
     {
       "targetId": "cayley-hamilton-reduction-oq-02-oq-01",
       "relationship": "uses",
       "description": "Companion matrix definition and orbit lemma C(p)^k · e₀ = eₖ. The two proved supporting lemmas live in CayleyHamiltonMinpolyOQ05OQ01OQ04 which imports this file."
+    },
+    {
+      "targetId": "cayley-hamilton",
+      "relationship": "related",
+      "description": "The Cayley-Hamilton theorem (M satisfies its own characteristic polynomial) is the starting point of the entire series. This file builds on the charpoly infrastructure (Matrix.charpoly_natDegree_eq_dim) established there."
+    },
+    {
+      "targetId": "cayley-hamilton-minpoly-oq-05",
+      "relationship": "part-of",
+      "description": "The parent open question series on the minimal polynomial characterization of nonderogatory matrices. This All-Fields result completes the series by removing the |K| > n restriction from OQ-01."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "CayleyHamiltonCyclicVectorAllFields.nonderogatory_has_cyclic_vector",
+      "statement": "∀ (M : Matrix (Fin n) (Fin n) K), IsNonderogatory M → ∃ v, IsCyclicVector M v",
+      "description": "Main theorem: every nonderogatory matrix over ANY field has a cyclic vector. Uses 1 axiom (RCF similarity), 0 sorries."
+    },
+    {
+      "name": "CayleyHamiltonCyclicVectorAllFields.nonderogatory_has_cyclic_vector_finite",
+      "statement": "∀ [Fintype K] (M : Matrix (Fin n) (Fin n) K), IsNonderogatory M → ∃ v, IsCyclicVector M v",
+      "description": "Specializes to finite fields F_q where q ≤ n, covering the regime where union avoidance fails."
+    },
+    {
+      "name": "CayleyHamiltonCyclicVectorAllFields.cyclic_iff_not_killed_below_degree",
+      "statement": "IsNonderogatory M → (IsCyclicVector M v ↔ ∀ p : K[X], p ≠ 0 → p.natDegree < n → ¬(aeval M p).mulVec v = 0)",
+      "description": "Polynomial annihilator characterization: cyclic iff not killed by any nonzero polynomial of degree < n."
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Enrichment: cayley-hamilton-cyclic-vector-all-fields

**Proof**: Nonderogatory → Cyclic Vector: All Fields (Axiomatized RCF)

### Changes

- **historicalContext** expanded from ~900→~1500 chars: Jordan 1870 normal form (restricted to algebraically closed fields), Frobenius 1878 rational canonical form over arbitrary fields, Emmy Noether's 1929 PID structure theorem, H.J.S. Smith's 1861 constructive Smith normal form approach
- **mainTheorems** array added (was entirely missing): 3 theorems with Lean statements — `nonderogatory_has_cyclic_vector`, `nonderogatory_has_cyclic_vector_finite`, `cyclic_iff_not_killed_below_degree`
- **crossReferences**: 2 new refs — `cayley-hamilton` (main CH theorem, uses charpoly infrastructure) and `cayley-hamilton-minpoly-oq-05` (parent OQ series). Improved description for `oq-05-oq-01` to clarify that union avoidance is bypassed entirely.
- **annotation** `ann-chcvaf-header` (lines 1-47): documents the module docstring's role as a proof architecture blueprint and how it encodes the axiom/verified boundary. Explains the upgrade path from axiomatized → verified.
- **annotation** `ann-chcvaf-cyclic-characterization` (lines 155-169): explains the `cyclic_iff_not_killed_below_degree` corollary — why the nonderogatory hypothesis appears in the signature but isn't used in the proof body, and the equivalence with linear independence via dimension.

### Labels
enrichment