### PR TITLE
enrich(arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02): add 2 annotations and upgrade header

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02/annotations.json
@@ -10,18 +10,32 @@
     "title": "Multiset Vandermonde: Problem Setup and Three Proof Perspectives",
     "content": "The module docstring frames the problem: prove the multiset Vandermonde identity C^ms(m+n,r) = Σ_{j=0}^{r} C^ms(m,j)·C^ms(n,r-j), where C^ms(n,k) = Nat.multichoose n k counts multisets of size k from a set of n elements. The relation multichoose n k = C(n+k-1, k) connects multiset coefficients to standard binomials. The proof strategy is double induction on m and r, driven by the Pascal-like recurrence multichoose(n+1)(k+1) = multichoose n (k+1) + multichoose(n+1) k.\n\nThree equivalent proof perspectives, only one formalized:\n1. **Inductive** (formalized): double induction on m and r using the Pascal recurrence — the combinatorial translation of the formal power series argument\n2. **Generating function** (conceptual): coefficient of x^r in (1-x)^{-m}·(1-x)^{-n} = (1-x)^{-(m+n)} gives the identity immediately — this is the 'obvious' proof but requires formalizing formal power series\n3. **Combinatorial** (bijective): count multisets of size r from m+n elements by partition into 'first m' and 'last n' contributions — the bijection proof, requiring multiset combinatorics infrastructure",
     "mathContext": "The multiset coefficient satisfies $\\binom{n+k-1}{k} = \\text{mc}(n,k)$ (stars and bars). Three perspectives: (1) **Generating function**: $\\frac{1}{(1-x)^{m+n}} = \\frac{1}{(1-x)^m} \\cdot \\frac{1}{(1-x)^n}$ and $[x^r]\\frac{1}{(1-x)^n} = \\text{mc}(n,r)$; Cauchy product gives the convolution. (2) **Negative binomial**: $\\text{mc}(n,k) = (-1)^k\\binom{-n}{k}$ (extended binomial coefficient with negative top), so the identity follows from the ordinary Vandermonde convolution with negative parameters. (3) **Pascal recurrence**: $\\text{mc}(n+1)(k+1) = \\text{mc}(n)(k+1) + \\text{mc}(n+1)(k)$ mirrors $\\binom{n}{k} = \\binom{n-1}{k-1} + \\binom{n-1}{k}$, making the double induction a direct analogue of the classical Vandermonde proof via Pascal's triangle.",
-    "significance": "supporting",
+    "significance": "key",
     "relatedConcepts": [
       "multiset coefficient",
       "Vandermonde identity",
       "Pascal recurrence",
-      "stars and bars"
+      "stars and bars",
+      "negative binomial distribution",
+      "generating functions"
     ],
     "prerequisites": [
       "Nat.multichoose",
       "Nat.multichoose_succ_succ",
       "Mathlib.Data.Nat.Choose.Basic"
     ]
+  },
+  {
+    "id": "ann-section-docstrings",
+    "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02",
+    "range": { "startLine": 33, "endLine": 59 },
+    "type": "context",
+    "title": "Section Headers and Lemma Documentation",
+    "content": "The proof is organized into three sections with explicit headers. Section 1 (lines 33-35) groups the base case lemma `sum_zero_left`. Section 2 (lines 48-59) introduces `sum_succ_left` with an inline docstring explaining the proof strategy: (a) apply `sum_range_succ'` to split j=0 terms from both sides; (b) note the j=0 terms cancel (both equal mc(n,r+1)); (c) for j≥1, expand mc(m+1)(j+1) via the Pascal recurrence; (d) separate the resulting sums via `sum_add_distrib`. The documentation correctly identifies that the index alignment issue (`r+1-(j+1) = r-j`) must be resolved before the Pascal recurrence expansion — foreshadowing the `have hsub + simp_rw` tactic sequence in the proof body.",
+    "mathContext": "`sum_zero_left n r`: $\\sum_{j=0}^r \\text{mc}(0,j)\\cdot\\text{mc}(n,r-j) = \\text{mc}(n,r)$. `sum_succ_left m n r`: $\\sum_{j=0}^{r+1} \\text{mc}(m+1,j)\\cdot\\text{mc}(n,r+1-j) = \\sum_{j=0}^{r+1} \\text{mc}(m,j)\\cdot\\text{mc}(n,r+1-j) + \\sum_{j=0}^r \\text{mc}(m+1,j)\\cdot\\text{mc}(n,r-j)$.",
+    "significance": "context",
+    "relatedConcepts": ["proof organization", "sum_range_succ'", "Pascal recurrence", "index alignment"],
+    "prerequisites": ["Nat.multichoose_zero_right", "Nat.multichoose_succ_succ", "Finset.sum_range_succ'"]
   },
   {
     "id": "ann-sum-zero-left",
@@ -45,6 +59,18 @@
       "Nat.multichoose_zero_succ",
       "Finset.sum_range_succ'"
     ]
+  },
+  {
+    "id": "ann-hsum-trick",
+    "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02",
+    "range": { "startLine": 79, "endLine": 116 },
+    "type": "technique",
+    "title": "hsum Ring Lemma: Bridging m+1+n and (m+n)+1 for multichoose_succ_succ",
+    "content": "A subtle but critical Lean 4 detail in the main inductive step (lines 106-116): the have `hsum : m + 1 + n = (m + n) + 1 := by ring`. This rewrite is needed because `Nat.multichoose_succ_succ` has signature `multichoose (n+1) (k+1) = multichoose n (k+1) + multichoose (n+1) k`, which expects `(m+n)+1` as first argument. But the goal has `m+1+n` (from the induction variable arrangement). The `rw [hsum, Nat.multichoose_succ_succ]` transforms the LHS, then `rw [ih_m (r+1)]` and `rw [← hsum]; rw [ih_r]` carefully restore the original variable order for applying the IHs, and `rw [← sum_succ_left m n r]` reassembles using the decomposition lemma in reverse.\n\nThe proof `theorem multiset_vandermonde` has 0 sorries and closes in 28 lines. The `induction m generalizing r` pattern is essential: without `generalizing r`, the inner IH `ih_r` would only apply at the specific `r` value fixed by the outer induction, not at `r` for arbitrary `m`. Lean 4's `induction` tactic respects the context — variables not in `generalizing` become fixed.",
+    "mathContext": "The identity `m + 1 + n = (m + n) + 1` holds in $\\mathbb{N}$ by commutativity and associativity of addition. In Lean 4, `ring` closes such goals. `Nat.multichoose_succ_succ n k : Nat.multichoose (n+1) (k+1) = Nat.multichoose n (k+1) + Nat.multichoose (n+1) k` — the Pascal-like identity. Applied at $n = m+n$ and $k = r$: $\\text{mc}(m+n+1)(r+1) = \\text{mc}(m+n)(r+1) + \\text{mc}(m+n+1)(r)$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.multichoose_succ_succ", "induction generalizing", "ring tactic", "rw rewrite"],
+    "prerequisites": ["sum_zero_left", "sum_succ_left", "Nat.multichoose_succ_succ", "induction generalizing"]
   },
   {
     "id": "ann-sum-zero-right",


### PR DESCRIPTION
Enrichment pass for `arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02` (Multiset Vandermonde Identity). Quality was 88/100.

## Changes

### annotations.json
- Added `ann-section-docstrings` (33–59): section headers and the sum_succ_left proof plan in the docstring
- Added `ann-hsum-trick` (79–116): the `have hsum : m + 1 + n = (m + n) + 1 := by ring` technique and `induction ... generalizing` pattern
- Upgraded `ann-mvandermonde-header` significance: `supporting` → `key` (it's the conceptual overview with 3 proof perspectives)
- Extended `relatedConcepts` in header to include negative binomial distribution and generating functions

Total annotations: 7 (up from 5). All have `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.

## Build
`pnpm build` passes cleanly.