### PR TITLE
enrich(amgm-inequality-oq-04-oq-05): add preamble section (98→100)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-04-oq-05/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04-oq-05/meta.json
@@ -84,6 +84,14 @@
   ],
   "sections": [
     {
+      "id": "sec-preamble",
+      "title": "Preamble: Derivation Narrative and Proof Blueprint",
+      "startLine": 1,
+      "endLine": 65,
+      "summary": "Module docstring with full algebraic derivation (three ingredients → Brent-Salamin formula), imports, namespace declaration, and `open Real`. The §Status checklist tracks which steps are axiomatized vs. proved.",
+      "mathContext": "The derivation in the docstring reduces to three substitutions: $E = K(3/4 - S/2)$ into $2KE - K^2 = \\pi/2$ gives $K^2(1-2S) = \\pi$; $K = \\pi/(2M)$ gives $K^2 = \\pi^2/(4M^2)$; combining gives $\\pi = 4M^2/(1-2S)$. The E/K ratio derivation uses $E/K = 1 - \\sum_{n \\geq 0} 2^{n-1} c_n^2$: the $n=0$ term is $2^{-1} c_0^2 = 1/4$ (since $c_0^2 = a_0^2 - b_0^2 = 1 - 1/2 = 1/2$ after normalization), giving $E/K = 3/4 - S/2$."
+    },
+    {
       "id": "sec-setup",
       "title": "§ 1: Setup — AGM Sequences and Limit",
       "startLine": 67,


### PR DESCRIPTION
## Enrichment: amgm-inequality-oq-04-oq-05 (quality 98 → 100)

**Proof**: Brent-Salamin Formula: π via AGM and Legendre's Relation

### Change

- **§0 Preamble section** (lines 1-65): Adds the module docstring/derivation narrative as a formal section with `mathContext` explaining the E/K ratio computation: $c_0^2 = a_0^2 - b_0^2 = 1 - 1/2 = 1/2$; the $n=0$ term contributes $2^{-1} c_0^2 = 1/4$; the $n \geq 1$ terms contribute $S/2$; giving $E/K = 3/4 - S/2$.

This brings sections from 4 (8pts) to 5 (10pts), raising quality from 98 to 100.

---

### Also included (from previous commit in this branch)

- **cayley-hamilton-cyclic-vector-all-fields**: 5th keyInsight (Fin.elim0 n=0 dispatch) + §V Summary section (96→100)

### Labels
enrichment