### PR TITLE
research(amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01): prove Newton-Girard k=4,5

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01OQ01.lean
+++ b/proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01OQ01.lean
@@ -1,0 +1,133 @@
+/-
+  Newton-Girard Recurrence: k=4 and k=5 Extensions
+  Open Question (amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01):
+  Extend the k=1,2,3 Newton-Girard corollaries to k=4 and k=5.
+
+  Parent proof (AmgmInequalityOQ02OQ01OQ02OQ01.lean) established:
+    p₁ = e₁
+    p₂ = e₁² − 2·e₂
+    p₃ = e₁·p₂ − e₂·p₁ + 3·e₃
+
+  This file extends to:
+    k=4: p₄ = e₁·p₃ − e₂·p₂ + e₃·p₁ − 4·e₄
+    k=5: p₅ = e₁·p₄ − e₂·p₃ + e₃·p₂ − e₄·p₁ + 5·e₅
+
+  Both follow from Mathlib's MvPolynomial.psum_eq_mul_esymm_sub_sum:
+    pₙ = (-1)^(n+1)·n·eₙ − ∑_{0<a<n} (-1)^a · eₐ · pₙ₋ₐ
+
+  The antidiagonals:
+    k=4: {(a,b) | a+b=4, 0<a<4} = {(1,3),(2,2),(3,1)}
+    k=5: {(a,b) | a+b=5, 0<a<5} = {(1,4),(2,3),(3,2),(4,1)}
+
+  Dual expressions (eₖ in terms of power sums):
+    4·e₄ = e₃·p₁ − e₂·p₂ + e₁·p₃ − p₄
+    5·e₅ = e₄·p₁ − e₃·p₂ + e₂·p₃ − e₁·p₄ + p₅
+
+  Status: PROVED — k=4 and k=5 via antidiagonal template + ring
+  Axioms: 0, Sorries: 0
+  Tags: algebra, symmetric-functions, newton-girard, power-sums, mv-polynomial
+-/
+
+import Mathlib
+
+namespace AmgmInequalityOQ02OQ01OQ02OQ01OQ01
+
+open MvPolynomial Finset BigOperators Set
+
+variable (σ : Type*) (R : Type*) [CommRing R] [Fintype σ]
+
+-- ============================================================
+-- Corollary 4: p₄ = e₁·p₃ − e₂·p₂ + e₃·p₁ − 4·e₄
+-- ============================================================
+
+/-- **Newton-Girard k=4**: The fourth power sum satisfies:
+      p₄ = e₁·p₃ − e₂·p₂ + e₃·p₁ − 4·e₄
+
+    Proof: Apply `psum_eq_mul_esymm_sub_sum` at k=4.
+    The antidiagonal {(a,b) | a+b=4, 0<a<4} = {(1,3),(2,2),(3,1)}.
+    This gives:
+      p₄ = (-1)⁵·4·e₄ − ((-1)¹·e₁·p₃ + (-1)²·e₂·p₂ + (-1)³·e₃·p₁)
+         = −4e₄ + e₁p₃ − e₂p₂ + e₃p₁
+    Closed by ring. -/
+theorem psum_four_eq :
+    psum σ R 4 = esymm σ R 1 * psum σ R 3 - esymm σ R 2 * psum σ R 2 +
+                esymm σ R 3 * psum σ R 1 - 4 * esymm σ R 4 := by
+  rw [MvPolynomial.psum_eq_mul_esymm_sub_sum σ R 4 (by norm_num)]
+  have hfilt : (Finset.antidiagonal 4).filter (fun a : ℕ × ℕ => a.1 ∈ Set.Ioo 0 4) =
+               {(1, 3), (2, 2), (3, 1)} := by
+    ext ⟨a, b⟩
+    simp only [Finset.mem_filter, Finset.mem_antidiagonal, Set.mem_Ioo,
+               Finset.mem_insert, Finset.mem_singleton, Prod.mk.injEq]
+    omega
+  simp only [hfilt,
+             Finset.sum_insert (by decide : (1, 3) ∉ ({(2, 2), (3, 1)} : Finset (ℕ × ℕ))),
+             Finset.sum_insert (by decide : (2, 2) ∉ ({(3, 1)} : Finset (ℕ × ℕ))),
+             Finset.sum_singleton]
+  ring
+
+-- ============================================================
+-- Corollary 5: p₅ = e₁·p₄ − e₂·p₃ + e₃·p₂ − e₄·p₁ + 5·e₅
+-- ============================================================
+
+/-- **Newton-Girard k=5**: The fifth power sum satisfies:
+      p₅ = e₁·p₄ − e₂·p₃ + e₃·p₂ − e₄·p₁ + 5·e₅
+
+    Proof: Apply `psum_eq_mul_esymm_sub_sum` at k=5.
+    The antidiagonal {(a,b) | a+b=5, 0<a<5} = {(1,4),(2,3),(3,2),(4,1)}.
+    This gives:
+      p₅ = (-1)⁶·5·e₅ − ((-1)¹·e₁·p₄ + (-1)²·e₂·p₃ + (-1)³·e₃·p₂ + (-1)⁴·e₄·p₁)
+         = 5e₅ + e₁p₄ − e₂p₃ + e₃p₂ − e₄p₁
+    Closed by ring. -/
+theorem psum_five_eq :
+    psum σ R 5 = esymm σ R 1 * psum σ R 4 - esymm σ R 2 * psum σ R 3 +
+                esymm σ R 3 * psum σ R 2 - esymm σ R 4 * psum σ R 1 +
+                5 * esymm σ R 5 := by
+  rw [MvPolynomial.psum_eq_mul_esymm_sub_sum σ R 5 (by norm_num)]
+  have hfilt : (Finset.antidiagonal 5).filter (fun a : ℕ × ℕ => a.1 ∈ Set.Ioo 0 5) =
+               {(1, 4), (2, 3), (3, 2), (4, 1)} := by
+    ext ⟨a, b⟩
+    constructor
+    · intro h
+      simp only [Finset.mem_filter, Finset.mem_antidiagonal, Set.mem_Ioo] at h
+      obtain ⟨hab, ha_pos, ha_lt⟩ := h
+      simp only [Finset.mem_insert, Finset.mem_singleton, Prod.mk.injEq]
+      omega
+    · intro h
+      simp only [Finset.mem_insert, Finset.mem_singleton, Prod.mk.injEq] at h
+      simp only [Finset.mem_filter, Finset.mem_antidiagonal, Set.mem_Ioo]
+      omega
+  simp only [hfilt,
+             Finset.sum_insert (by decide : (1, 4) ∉ ({(2, 3), (3, 2), (4, 1)} : Finset (ℕ × ℕ))),
+             Finset.sum_insert (by decide : (2, 3) ∉ ({(3, 2), (4, 1)} : Finset (ℕ × ℕ))),
+             Finset.sum_insert (by decide : (3, 2) ∉ ({(4, 1)} : Finset (ℕ × ℕ))),
+             Finset.sum_singleton]
+  ring
+
+-- ============================================================
+-- Dual forms: expressing eₖ in terms of power sums
+-- ============================================================
+
+/-- **Newton-Girard dual k=4**: The fourth elementary symmetric polynomial
+    expressed via power sums:
+      4·e₄ = e₃·p₁ − e₂·p₂ + e₁·p₃ − p₄
+
+    This is the dual form of Newton-Girard k=4, obtained by rearranging
+    psum_four_eq. Works over any CommRing. -/
+theorem esymm_four_from_psum :
+    4 * esymm σ R 4 = esymm σ R 3 * psum σ R 1 - esymm σ R 2 * psum σ R 2 +
+                     esymm σ R 1 * psum σ R 3 - psum σ R 4 := by
+  linear_combination psum_four_eq σ R
+
+/-- **Newton-Girard dual k=5**: The fifth elementary symmetric polynomial
+    expressed via power sums:
+      5·e₅ = e₄·p₁ − e₃·p₂ + e₂·p₃ − e₁·p₄ + p₅
+
+    This is the dual form of Newton-Girard k=5, obtained by rearranging
+    psum_five_eq. Works over any CommRing. -/
+theorem esymm_five_from_psum :
+    5 * esymm σ R 5 = esymm σ R 4 * psum σ R 1 - esymm σ R 3 * psum σ R 2 +
+                     esymm σ R 2 * psum σ R 3 - esymm σ R 1 * psum σ R 4 +
+                     psum σ R 5 := by
+  linear_combination -(psum_five_eq σ R)
+
+end AmgmInequalityOQ02OQ01OQ02OQ01OQ01

--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01/annotations.json
@@ -1,0 +1,3 @@
+{
+  "annotations": []
+}

--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01/index.ts
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01/index.ts
@@ -1,0 +1,2 @@
+export { default as meta } from './meta.json';
+export { default as annotations } from './annotations.json';

--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -1,0 +1,132 @@
+{
+  "id": "amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01",
+  "title": "Newton-Girard for k=4 and k=5",
+  "slug": "amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01",
+  "description": "Extends the Newton-Girard recurrence to k=4 and k=5, continuing the chain from the parent proof (k=1,2,3). Proves p₄ = e₁p₃ − e₂p₂ + e₃p₁ − 4e₄ and p₅ = e₁p₄ − e₂p₃ + e₃p₂ − e₄p₁ + 5e₅ using the antidiagonal template established in the parent. Also derives the dual forms expressing e₄ and e₅ in terms of power sums.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-04-26",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01OQ01.lean",
+    "tags": [
+      "algebra",
+      "symmetric-functions",
+      "newton-girard",
+      "power-sums",
+      "elementary-symmetric-polynomials",
+      "mv-polynomial"
+    ],
+    "badge": "mathlib",
+    "mathlibDependencies": [
+      {
+        "theorem": "MvPolynomial.psum_eq_mul_esymm_sub_sum",
+        "description": "Newton-Girard recurrence: pₖ = (-1)^(k+1)·k·eₖ − Σ_{0<j<k} (-1)^j·eⱼ·pₖ₋ⱼ",
+        "module": "Mathlib.RingTheory.MvPolynomial.Symmetric.NewtonIdentities"
+      }
+    ],
+    "originalContributions": [
+      "psum_four_eq: p₄ = e₁p₃ − e₂p₂ + e₃p₁ − 4e₄, instantiating psum_eq_mul_esymm_sub_sum at k=4 with three-element antidiagonal {(1,3),(2,2),(3,1)}",
+      "psum_five_eq: p₅ = e₁p₄ − e₂p₃ + e₃p₂ − e₄p₁ + 5e₅, instantiating psum_eq_mul_esymm_sub_sum at k=5 with four-element antidiagonal {(1,4),(2,3),(3,2),(4,1)}",
+      "esymm_four_from_psum: 4e₄ = e₃p₁ − e₂p₂ + e₁p₃ − p₄, dual form via linear_combination",
+      "esymm_five_from_psum: 5e₅ = e₄p₁ − e₃p₂ + e₂p₃ − e₁p₄ + p₅, dual form via linear_combination"
+    ],
+    "dateAdded": "2026-04-26",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 133,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "assumptions": "All results derived from Mathlib's MvPolynomial.psum_eq_mul_esymm_sub_sum. 0 sorries, 0 axiom declarations.",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Newton's identities (Newton-Girard) connect power sums pₖ = Σxᵢᵏ to elementary symmetric polynomials eₖ = Σ_{i₁<...<iₖ} xᵢ₁·...·xᵢₖ. This file extends the k=1,2,3 corollaries from the parent proof (AmgmInequalityOQ02OQ01OQ02OQ01) to k=4 and k=5, completing the foundation for symmetric function computations in degrees 4 and 5.",
+    "problemStatement": "**Open Question**: Extend the Newton-Girard recurrences to k=4 and k=5:\n\n  p₄ = e₁·p₃ − e₂·p₂ + e₃·p₁ − 4·e₄\n  p₅ = e₁·p₄ − e₂·p₃ + e₃·p₂ − e₄·p₁ + 5·e₅\n\nwhere pₖ = Σxᵢᵏ is the k-th power sum and eₖ is the k-th elementary symmetric polynomial over any CommRing.\n\n**Answer**: Proved via Mathlib's MvPolynomial.psum_eq_mul_esymm_sub_sum. The antidiagonals {(1,3),(2,2),(3,1)} (k=4) and {(1,4),(2,3),(3,2),(4,1)} (k=5) are computed using omega. Dual forms expressing eₖ in terms of power sums are derived via linear_combination.",
+    "text": "Proves Newton-Girard recurrences for k=4 and k=5 by instantiating Mathlib's psum_eq_mul_esymm_sub_sum and expanding the antidiagonal filter via omega. The approach is identical to the k=2,3 parent proof, demonstrating the systematic pattern.",
+    "proofStrategy": "**k=4**: Apply `psum_eq_mul_esymm_sub_sum` at n=4. Filter {(a,b) | a+b=4, 0<a<4} = {(1,3),(2,2),(3,1)} (3 terms). Expand sum via sum_insert/sum_singleton. Close with ring.\n\n**k=5**: Apply `psum_eq_mul_esymm_sub_sum` at n=5. Filter {(a,b) | a+b=5, 0<a<5} = {(1,4),(2,3),(3,2),(4,1)} (4 terms). Explicit constructor proof for the filter equality (4-element case requires more careful handling). Close with ring.\n\n**Dual forms**: Apply linear_combination to rearrange the power sum identities into expressions for e₄ and e₅.",
+    "keyInsights": [
+      "The three-tactic pipeline (omega for antidiagonal arithmetic → sum_insert/sum_singleton for finite sum expansion → ring for polynomial identity) extends to k=4,5 with minimal modification",
+      "For k=5, the four-element antidiagonal filter requires an explicit constructor proof (intro h; simp; omega) rather than a one-shot simp+omega, due to the larger disjunction",
+      "The linear_combination tactic works over any CommRing (unlike linarith which requires an ordered type), enabling the dual form theorems for expressions like 4·e₄ and 5·e₅",
+      "All four theorems hold over any CommRing R with any Fintype index type σ — no assumptions on real numbers needed"
+    ],
+    "prerequisites": [
+      "MvPolynomial.psum_eq_mul_esymm_sub_sum — general Newton-Girard recurrence (Mathlib)",
+      "Parent proof: AmgmInequalityOQ02OQ01OQ02OQ01 (k=1,2,3 corollaries)",
+      "Finset.mem_antidiagonal — antidiagonal membership (Mathlib)",
+      "linear_combination tactic — proves ring identities from hypotheses"
+    ]
+  },
+  "sections": [
+    {
+      "id": "module-docstring",
+      "title": "Module Docstring: Newton-Girard k=4,5 Overview",
+      "startLine": 1,
+      "endLine": 27,
+      "summary": "Documents the open question (extend to k=4,5), the antidiagonal structure, and proof status (0 sorries, 0 axioms).",
+      "mathContext": "Newton-Girard recurrence $p_k = (-1)^{k+1} k e_k - \\sum_{0 < a < k} (-1)^a e_a p_{k-a}$. Antidiagonals: $k=4$: $\\{(1,3),(2,2),(3,1)\\}$; $k=5$: $\\{(1,4),(2,3),(3,2),(4,1)\\}$."
+    },
+    {
+      "id": "psum-four",
+      "title": "Corollary 4: p₄ = e₁p₃ − e₂p₂ + e₃p₁ − 4e₄",
+      "startLine": 36,
+      "endLine": 60,
+      "summary": "psum_four_eq: applies psum_eq_mul_esymm_sub_sum at k=4. Three-element antidiagonal {(1,3),(2,2),(3,1)} computed via omega. Sum expanded via sum_insert/sum_singleton. Closed by ring.",
+      "mathContext": "$p_4 = e_1 p_3 - e_2 p_2 + e_3 p_1 - 4e_4$."
+    },
+    {
+      "id": "psum-five",
+      "title": "Corollary 5: p₅ = e₁p₄ − e₂p₃ + e₃p₂ − e₄p₁ + 5e₅",
+      "startLine": 64,
+      "endLine": 108,
+      "summary": "psum_five_eq: applies psum_eq_mul_esymm_sub_sum at k=5. Four-element antidiagonal {(1,4),(2,3),(3,2),(4,1)} proved via explicit constructor with omega. Sum expanded via sum_insert/sum_singleton. Closed by ring.",
+      "mathContext": "$p_5 = e_1 p_4 - e_2 p_3 + e_3 p_2 - e_4 p_1 + 5e_5$."
+    },
+    {
+      "id": "dual-forms",
+      "title": "Dual Forms: e₄ and e₅ from Power Sums",
+      "startLine": 112,
+      "endLine": 133,
+      "summary": "esymm_four_from_psum and esymm_five_from_psum: rearrange the power sum identities to express the elementary symmetric polynomials in terms of power sums. Proved via linear_combination (works over any CommRing).",
+      "mathContext": "$4e_4 = e_3 p_1 - e_2 p_2 + e_1 p_3 - p_4$ and $5e_5 = e_4 p_1 - e_3 p_2 + e_2 p_3 - e_1 p_4 + p_5$."
+    }
+  ],
+  "conclusion": {
+    "summary": "Extends Newton-Girard to k=4 and k=5 with 0 sorries and 0 axioms. All four theorems (psum_four_eq, psum_five_eq, esymm_four_from_psum, esymm_five_from_psum) machine-verified over any CommRing.",
+    "implications": "**For Newton-Girard**: The k=4,5 corollaries extend the chain to degrees relevant for quintic polynomial theory, where the Galois group determines solvability.\n\n**For Symmetric Functions**: Combined with k=1,2,3 from the parent, we now have machine-verified Newton-Girard identities for degrees 1-5, covering the full range needed for most symmetric function computations.\n\n**Proof Pattern**: The antidiagonal template (omega → sum_insert/sum_singleton → ring) scales to arbitrary k, though the four-element case (k=5) requires the more explicit constructor form for the filter proof.",
+    "openQuestions": [
+      "Prove the general Newton-Girard recurrence for arbitrary k as a clean inductive theorem, without case-by-case antidiagonal computation",
+      "Connect to Waring's problem: express p_k^(1/k) as a polynomial in e_1,...,e_k for specific k"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "amgm-inequality-oq-02-oq-01-oq-02-oq-01",
+      "relationship": "parent",
+      "description": "Direct parent: proves Newton-Girard for k=1,2,3 using the same antidiagonal template. This entry extends to k=4,5."
+    },
+    {
+      "targetId": "amgm-inequality-oq-02-oq-01-oq-02",
+      "relationship": "ancestor",
+      "description": "Grandparent: proves the off-diagonal symmetry Σ_{i≠j} x_i x_j = 2·e₂."
+    },
+    {
+      "targetId": "amgm-inequality-oq-02",
+      "relationship": "ancestor",
+      "description": "Root: Maclaurin inequalities via elementary symmetric polynomials."
+    },
+    {
+      "targetId": "vietas-formulas",
+      "relationship": "related",
+      "description": "Vieta's formulas relate polynomial coefficients to elementary symmetric polynomials; Newton-Girard connects these to power sums."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Newton, Isaac",
+      "title": "Arithmetica Universalis",
+      "year": "1707",
+      "note": "Newton's identities for k=4 and k=5, extending the classical cases proved in the parent entry."
+    }
+  ]
+}

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01.json
@@ -29,11 +29,25 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETE: k=4,5 Newton-Girard proved (0 sorries, 0 axioms). Dual forms also derived. Gallery entry created at src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01/",
+    "builtItems": [
+      "psum_four_eq in AmgmInequalityOQ02OQ01OQ02OQ01OQ01.lean: p₄ = e₁p₃ − e₂p₂ + e₃p₁ − 4e₄",
+      "psum_five_eq in AmgmInequalityOQ02OQ01OQ02OQ01OQ01.lean: p₅ = e₁p₄ − e₂p₃ + e₃p₂ − e₄p₁ + 5e₅",
+      "esymm_four_from_psum: 4e₄ = e₃p₁ − e₂p₂ + e₁p₃ − p₄ (dual form)",
+      "esymm_five_from_psum: 5e₅ = e₄p₁ − e₃p₂ + e₂p₃ − e₁p₄ + p₅ (dual form)"
+    ],
+    "insights": [
+      "Newton-Girard k=4: p₄ = e₁p₃ − e₂p₂ + e₃p₁ − 4e₄, proved via antidiagonal {(1,3),(2,2),(3,1)} + ring",
+      "Newton-Girard k=5: p₅ = e₁p₄ − e₂p₃ + e₃p₂ − e₄p₁ + 5e₅, proved via antidiagonal {(1,4),(2,3),(3,2),(4,1)} + ring",
+      "Dual forms: 4e₄ and 5e₅ expressible in power sums via linear_combination (works over any CommRing)",
+      "k=5 filter proof requires explicit constructor for 4-element antidiagonal",
+      "Antidiagonal template scales to any k; pattern: apply psum_eq_mul_esymm_sub_sum, filter via omega, expand via sum_insert, close with ring"
+    ],
     "mathlibGaps": [],
-    "nextSteps": []
+    "nextSteps": [
+      "Prove general Newton-Girard for all k as inductive theorem (each k currently requires separate antidiagonal computation)",
+      "Connect Newton-Girard to MacMahon symmetric functions and plethystic substitution"
+    ]
   },
   "tags": [
     "challenging",


### PR DESCRIPTION
## Summary

Extends the Newton-Girard recurrence chain to k=4 and k=5, following the open question from the parent proof (amgm-inequality-oq-02-oq-01-oq-02-oq-01).

**Four theorems proved, 0 sorries, 0 axioms, over any CommRing:**

- `psum_four_eq`: p₄ = e₁p₃ − e₂p₂ + e₃p₁ − 4e₄
- `psum_five_eq`: p₅ = e₁p₄ − e₂p₃ + e₃p₂ − e₄p₁ + 5e₅  
- `esymm_four_from_psum`: 4e₄ = e₃p₁ − e₂p₂ + e₁p₃ − p₄ (dual form)
- `esymm_five_from_psum`: 5e₅ = e₄p₁ − e₃p₂ + e₂p₃ − e₁p₄ + p₅ (dual form)

**Proof strategy** (antidiagonal template from parent):
1. Apply `MvPolynomial.psum_eq_mul_esymm_sub_sum` at k=4 or k=5
2. Filter antidiagonal: `{(1,3),(2,2),(3,1)}` (k=4) or `{(1,4),(2,3),(3,2),(4,1)}` (k=5) via omega
3. Expand finite sum via `sum_insert`/`sum_singleton`
4. Close with `ring`

**Key technique:** `linear_combination` for dual forms (unlike `linarith`, works over any CommRing without ordering).

**Note:** k=5 requires an explicit `constructor` proof for the 4-element antidiagonal filter (4-element case requires more care than the 3-element k=4 case).

## Files

- `proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01OQ01.lean` — 133 lines, 4 theorems, 0 sorries, 0 axioms
- `src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01/` — gallery entry with meta.json

Labels: `research`