### PR TITLE
enrich(amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01): add 4 annotations, expand historicalContext, 3 crossRefs

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01/annotations.json
@@ -1,3 +1,93 @@
-{
-  "annotations": []
-}
+[
+  {
+    "id": "ann-docstring",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 29 },
+    "type": "concept",
+    "title": "Newton-Girard Blueprint: Extending k=1,2,3 to k=4 and k=5",
+    "content": "The module docstring establishes the proof blueprint inherited from the parent entry `AmgmInequalityOQ02OQ01OQ02OQ01.lean`. The three-tactic pipeline — (1) filter the antidiagonal to isolate contributing index pairs, (2) expand the resulting finite sum via `sum_insert`/`sum_singleton`, (3) close by `ring` — transfers directly to k=4 and k=5.\n\nThe docstring is mathematically precise, stating both the Newton-Girard recurrence (expressing pₖ in terms of e₁,...,eₖ and p₁,...,pₖ₋₁) and its dual form (expressing eₖ in terms of power sums). The dual form is significant for applications: Girard's original 1629 motivation was computing 'Newton's sums' as a tool for polynomial root manipulation, and the dual expressions for 4e₄ and 5e₅ appear in elimination theory when extracting the Galois group of a quintic.\n\nThe file imports `Mathlib` globally (rather than specific modules), which is appropriate for a focused algebraic identity file — the critical dependency is `Mathlib.RingTheory.MvPolynomial.Symmetric.NewtonIdentities`, which provides `MvPolynomial.psum_eq_mul_esymm_sub_sum`.",
+    "mathContext": "The Newton-Girard recurrence (Mathlib: `psum_eq_mul_esymm_sub_sum`):\n$$p_n = (-1)^{n+1} n e_n - \\sum_{0 < a < n} (-1)^a e_a p_{n-a}$$\nFor $k=4$: antidiagonal pairs $(a,b)$ with $a+b=4$, $0 < a < 4$ are $(1,3),(2,2),(3,1)$; the signs are $(-1)^1 = -1$, $(-1)^2 = +1$, $(-1)^3 = -1$, giving $-(-1)^5 \\cdot 4 e_4 + (-e_1 p_3 + e_2 p_2 - e_3 p_1) = e_1 p_3 - e_2 p_2 + e_3 p_1 - 4e_4$.\nFor $k=5$: antidiagonal pairs $(1,4),(2,3),(3,2),(4,1)$; signs $(-1)^1,-1^2,(-1)^3,(-1)^4$ give $+e_1 p_4 - e_2 p_3 + e_3 p_2 - e_4 p_1 + 5e_5$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Newton-Girard recurrence",
+      "antidiagonal in ℕ×ℕ",
+      "power sums",
+      "elementary symmetric polynomials",
+      "MvPolynomial"
+    ],
+    "prerequisites": [
+      "Parent proof: AmgmInequalityOQ02OQ01OQ02OQ01 (k=1,2,3)",
+      "Mathlib.RingTheory.MvPolynomial.Symmetric.NewtonIdentities",
+      "Finset.antidiagonal"
+    ]
+  },
+  {
+    "id": "ann-psum-four",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 39, "endLine": 66 },
+    "type": "theorem",
+    "title": "p₄ = e₁p₃ − e₂p₂ + e₃p₁ − 4e₄: Three-Element Antidiagonal",
+    "content": "**Theorem** `psum_four_eq`: The fourth power sum satisfies $p_4 = e_1 p_3 - e_2 p_2 + e_3 p_1 - 4e_4$ over any `CommRing R` with any `Fintype σ`.\n\nThe proof has three phases:\n\n1. **Rewrite**: `rw [psum_eq_mul_esymm_sub_sum σ R 4 (by norm_num)]` transforms the LHS into a sum over the antidiagonal filter.\n\n2. **Filter proof** (`have hfilt`): The set `{(a,b) ∈ antidiagonal 4 | 0 < a < 4}` equals `{(1,3),(2,2),(3,1)}`. This is proved via `ext ⟨a,b⟩ / simp [...] / omega` — `omega` handles the arithmetic constraint `a + b = 4 ∧ 0 < a < 4` exhaustively.\n\n3. **Sum expansion + ring**: `sum_insert` unfolds the three-element set one step at a time (each with a `by decide` disjointness proof), `sum_singleton` handles the base, and `ring` closes the resulting polynomial identity over `CommRing R`.\n\nThe `by decide` proofs (e.g., `(1,3) ∉ {(2,2),(3,1)}`) succeed because the membership in finite literal sets is decidable — Lean can verify these in compile time without elaborating the types.",
+    "mathContext": "$p_4 = e_1 p_3 - e_2 p_2 + e_3 p_1 - 4e_4$ in `MvPolynomial σ R`.\n\nFrom `psum_eq_mul_esymm_sub_sum` at $n=4$:\n$$p_4 = (-1)^{4+1} \\cdot 4 \\cdot e_4 - \\sum_{a \\in \\{1,2,3\\}} (-1)^a e_a p_{4-a}$$\n$$= -4e_4 - ((-1)^1 e_1 p_3 + (-1)^2 e_2 p_2 + (-1)^3 e_3 p_1)$$\n$$= -4e_4 + e_1 p_3 - e_2 p_2 + e_3 p_1$$\nThe `ring` tactic verifies the resulting equality holds universally in any `CommRing`.",
+    "significance": "key",
+    "relatedConcepts": [
+      "MvPolynomial.psum_eq_mul_esymm_sub_sum",
+      "Finset.antidiagonal",
+      "omega tactic",
+      "ring tactic",
+      "CommRing",
+      "Finset.sum_insert"
+    ],
+    "prerequisites": [
+      "MvPolynomial.psum_eq_mul_esymm_sub_sum",
+      "Finset.sum_insert and sum_singleton",
+      "decide tactic for finite membership"
+    ]
+  },
+  {
+    "id": "ann-psum-five",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 68, "endLine": 104 },
+    "type": "theorem",
+    "title": "p₅ = e₁p₄ − e₂p₃ + e₃p₂ − e₄p₁ + 5e₅: Explicit Iff Constructor for Four-Element Antidiagonal",
+    "content": "**Theorem** `psum_five_eq`: The fifth power sum satisfies $p_5 = e_1 p_4 - e_2 p_3 + e_3 p_2 - e_4 p_1 + 5e_5$.\n\nThe k=5 proof requires more explicit handling of `hfilt` compared to k=4. The antidiagonal filter at n=5 has **four** elements `{(1,4),(2,3),(3,2),(4,1)}`, and the set equality proof cannot be closed by `simp+omega` in one shot — the larger disjunction in the membership goal requires an explicit `constructor` approach:\n\n```lean\nconstructor\n· intro h  -- forward: antidiagonal filter → Finset literal\n  simp [...] at h; obtain ⟨hab, ha_pos, ha_lt⟩ := h; simp [...]; omega\n· intro h  -- backward: Finset literal → antidiagonal filter\n  simp [...] at h; simp [...]; omega\n```\n\nThis pattern — splitting the iff into two implications and using `omega` to close each — is the standard approach when the disjunction has more cases than the `simp+omega` combination can handle in a single pass.\n\nThe sum expansion uses four `sum_insert` applications with `by decide` disjointness proofs (verifying `(1,4) ∉ {(2,3),(3,2),(4,1)}` etc.), then one `sum_singleton`, and a final `ring`.",
+    "mathContext": "$p_5 = e_1 p_4 - e_2 p_3 + e_3 p_2 - e_4 p_1 + 5e_5$ in `MvPolynomial σ R`.\n\nFrom `psum_eq_mul_esymm_sub_sum` at $n=5$:\n$$p_5 = (-1)^{6} \\cdot 5 e_5 - \\sum_{a=1}^{4} (-1)^a e_a p_{5-a}$$\n$$= 5e_5 - (-e_1 p_4 + e_2 p_3 - e_3 p_2 + e_4 p_1)$$\n$$= 5e_5 + e_1 p_4 - e_2 p_3 + e_3 p_2 - e_4 p_1$$\nNote $(-1)^{5+1} = (-1)^6 = +1$, so the leading term $5e_5$ has a positive sign, unlike the $-4e_4$ in k=4.",
+    "significance": "key",
+    "relatedConcepts": [
+      "MvPolynomial.psum_eq_mul_esymm_sub_sum",
+      "Finset.antidiagonal",
+      "omega tactic",
+      "Finset.mem_insert",
+      "Finset.mem_singleton",
+      "ring tactic"
+    ],
+    "prerequisites": [
+      "psum_four_eq (k=4 pattern to compare)",
+      "Finset.sum_insert and sum_singleton",
+      "explicit Iff constructor pattern"
+    ]
+  },
+  {
+    "id": "ann-dual-forms",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 106, "endLine": 133 },
+    "type": "technique",
+    "title": "Dual Forms: e₄ and e₅ from Power Sums via linear_combination",
+    "content": "**Theorems** `esymm_four_from_psum` and `esymm_five_from_psum` express the elementary symmetric polynomials $e_4$ and $e_5$ as integer linear combinations of power sums:\n\n- `esymm_four_from_psum`: $4e_4 = e_3 p_1 - e_2 p_2 + e_1 p_3 - p_4$\n- `esymm_five_from_psum`: $5e_5 = e_4 p_1 - e_3 p_2 + e_2 p_3 - e_1 p_4 + p_5$\n\nBoth are proved by `linear_combination`: for `esymm_four_from_psum`, `linear_combination psum_four_eq σ R` says 'the goal follows from `psum_four_eq` by a linear combination with coefficient 1'. For `esymm_five_from_psum`, `linear_combination -(psum_five_eq σ R)` uses coefficient -1 since the rearrangement negates the equation.\n\n**Why `linear_combination` and not `linarith`?** The `linarith` tactic requires an ordered linear arithmetic structure, but `CommRing R` is purely algebraic with no ordering. `linear_combination` instead works syntactically: it generates a proof obligation of the form `goal - (coefficient × hypothesis) = 0` and then calls `ring` to verify the polynomial identity, which succeeds over any `CommRing`.\n\n**Applications of the dual form**: Expressing $e_k$ in terms of power sums enables computing elementary symmetric polynomials from moments $p_k$ — this is used in statistics (method of moments), number theory (Newton's method for polynomial roots), and polynomial arithmetic (e.g., Newton-Cotes formulas for quadrature).",
+    "mathContext": "Dual Newton-Girard for $k=4$:\n$$4e_4 = e_3 p_1 - e_2 p_2 + e_1 p_3 - p_4$$\nDual Newton-Girard for $k=5$:\n$$5e_5 = e_4 p_1 - e_3 p_2 + e_2 p_3 - e_1 p_4 + p_5$$\n\nThese are the same as `psum_four_eq` and `psum_five_eq` solved for $e_k$. The coefficient $k$ on $e_k$ is an integer (not a rational), so the identity holds in any `CommRing` without characteristic assumptions. However, to isolate $e_k$ as $e_k = \\frac{1}{k}(\\cdots)$, one needs a ring where $k$ is invertible (e.g., characteristic 0 or characteristic coprime to $k$).",
+    "significance": "key",
+    "relatedConcepts": [
+      "linear_combination tactic",
+      "CommRing",
+      "ring tactic",
+      "method of moments",
+      "linarith vs linear_combination",
+      "polynomial arithmetic"
+    ],
+    "prerequisites": [
+      "psum_four_eq and psum_five_eq",
+      "linear_combination tactic",
+      "CommRing axioms"
+    ]
+  }
+]

--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -40,15 +40,18 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "Newton's identities (Newton-Girard) connect power sums pₖ = Σxᵢᵏ to elementary symmetric polynomials eₖ = Σ_{i₁<...<iₖ} xᵢ₁·...·xᵢₖ. This file extends the k=1,2,3 corollaries from the parent proof (AmgmInequalityOQ02OQ01OQ02OQ01) to k=4 and k=5, completing the foundation for symmetric function computations in degrees 4 and 5.",
+    "historicalContext": "Newton's identities — also called Newton-Girard identities — relate power sums $p_k = \\sum_i x_i^k$ to elementary symmetric polynomials $e_k = \\sum_{i_1 < \\cdots < i_k} x_{i_1} \\cdots x_{i_k}$. The identities were first written down by Albert Girard in his 1629 algebraic treatise *Invention nouvelle en l'algèbre*, where he recorded the cases $k = 1, 2, 3, 4$ (in 17th-century notation) as a tool for computing 'Newton sums' of polynomial roots. Isaac Newton then stated the general recurrence in *Arithmetica Universalis* (1707) without proof, and the identities later appeared in the work of Waring (1762) and Lagrange as a foundation for the theory of polynomial resolvents.\n\nThe modern Lean formalization in Mathlib (`MvPolynomial.psum_eq_mul_esymm_sub_sum`) proves the full recurrence for all $k \\geq 1$ over any `CommRing` with any `Fintype` index set — a remarkable generalization from the classical setting of polynomials over $\\mathbb{Q}$ with $n$ specific variables.\n\nThis entry extends the $k=1,2,3$ corollaries from the parent proof (`AmgmInequalityOQ02OQ01OQ02OQ01`) to $k=4$ and $k=5$. The degree-5 case is mathematically noteworthy: Newton-Girard at $k=4,5$ provides the computational tools for manipulating symmetric functions of the roots of a quintic polynomial, sitting at the threshold established by Abel-Ruffini (no radical formula exists for $k \\geq 5$). While the Newton-Girard identities themselves are purely algebraic and hold in all degrees, the degree-5 case occupies a special role in classical algebra as the last degree where the identities were extensively computed by hand (Newton, Waring, Lagrange) in the pursuit of a quintic formula that, as Abel showed in 1824, cannot exist.",
     "problemStatement": "**Open Question**: Extend the Newton-Girard recurrences to k=4 and k=5:\n\n  p₄ = e₁·p₃ − e₂·p₂ + e₃·p₁ − 4·e₄\n  p₅ = e₁·p₄ − e₂·p₃ + e₃·p₂ − e₄·p₁ + 5·e₅\n\nwhere pₖ = Σxᵢᵏ is the k-th power sum and eₖ is the k-th elementary symmetric polynomial over any CommRing.\n\n**Answer**: Proved via Mathlib's MvPolynomial.psum_eq_mul_esymm_sub_sum. The antidiagonals {(1,3),(2,2),(3,1)} (k=4) and {(1,4),(2,3),(3,2),(4,1)} (k=5) are computed using omega. Dual forms expressing eₖ in terms of power sums are derived via linear_combination.",
     "text": "Proves Newton-Girard recurrences for k=4 and k=5 by instantiating Mathlib's psum_eq_mul_esymm_sub_sum and expanding the antidiagonal filter via omega. The approach is identical to the k=2,3 parent proof, demonstrating the systematic pattern.",
     "proofStrategy": "**k=4**: Apply `psum_eq_mul_esymm_sub_sum` at n=4. Filter {(a,b) | a+b=4, 0<a<4} = {(1,3),(2,2),(3,1)} (3 terms). Expand sum via sum_insert/sum_singleton. Close with ring.\n\n**k=5**: Apply `psum_eq_mul_esymm_sub_sum` at n=5. Filter {(a,b) | a+b=5, 0<a<5} = {(1,4),(2,3),(3,2),(4,1)} (4 terms). Explicit constructor proof for the filter equality (4-element case requires more careful handling). Close with ring.\n\n**Dual forms**: Apply linear_combination to rearrange the power sum identities into expressions for e₄ and e₅.",
     "keyInsights": [
       "The three-tactic pipeline (omega for antidiagonal arithmetic → sum_insert/sum_singleton for finite sum expansion → ring for polynomial identity) extends to k=4,5 with minimal modification",
-      "For k=5, the four-element antidiagonal filter requires an explicit constructor proof (intro h; simp; omega) rather than a one-shot simp+omega, due to the larger disjunction",
-      "The linear_combination tactic works over any CommRing (unlike linarith which requires an ordered type), enabling the dual form theorems for expressions like 4·e₄ and 5·e₅",
-      "All four theorems hold over any CommRing R with any Fintype index type σ — no assumptions on real numbers needed"
+      "For k=5, the four-element antidiagonal filter requires an explicit constructor proof (intro h; simp; omega) rather than a one-shot simp+omega, due to the larger disjunction — a sign that brute-force automation has limits even for elementary combinatorial facts",
+      "The linear_combination tactic works over any CommRing (unlike linarith which requires an ordered type), enabling the dual form theorems for expressions like 4·e₄ and 5·e₅ to be machine-verified without characteristic assumptions",
+      "All four theorems hold over any CommRing R with any Fintype index type σ — no assumptions on real numbers, complex numbers, or characteristic zero needed",
+      "The sign pattern (-1)^a in Newton-Girard creates an alternating ± structure: for k=4, the antidiagonal pairs contribute −e₁p₃, +e₂p₂, −e₃p₁ (signs −,+,−), yielding the signed sum e₁p₃ − e₂p₂ + e₃p₁; for k=5, the pattern −,+,−,+ gives e₁p₄ − e₂p₃ + e₃p₂ − e₄p₁. This alternating structure is a consequence of the Leibniz rule for the determinant of the Vandermonde matrix underlying Newton's identities",
+      "The coefficient k in k·eₖ = (∙) is an integer, so the dual form theorem holds in characteristic p ≠ k — but to express eₖ as 1/k·(∙), one needs char(R) ∤ k. This is why eₖ is recoverable from power sums over ℚ (or ℝ, ℂ) but not over 𝔽₄ for k=4 (where 4=0) or 𝔽₅ for k=5 (where 5=0)",
+      "Together with k=1,2,3 from the parent, the chain p₁,...,p₅ can be computed from e₁,...,e₅ (and vice versa) — providing machine-verified Newton-Girard covering the full range needed for the theory of quintic polynomials, where degree 5 is the solvability boundary established by Abel-Ruffini"
     ],
     "prerequisites": [
       "MvPolynomial.psum_eq_mul_esymm_sub_sum — general Newton-Girard recurrence (Mathlib)",
@@ -95,8 +98,10 @@
     "summary": "Extends Newton-Girard to k=4 and k=5 with 0 sorries and 0 axioms. All four theorems (psum_four_eq, psum_five_eq, esymm_four_from_psum, esymm_five_from_psum) machine-verified over any CommRing.",
     "implications": "**For Newton-Girard**: The k=4,5 corollaries extend the chain to degrees relevant for quintic polynomial theory, where the Galois group determines solvability.\n\n**For Symmetric Functions**: Combined with k=1,2,3 from the parent, we now have machine-verified Newton-Girard identities for degrees 1-5, covering the full range needed for most symmetric function computations.\n\n**Proof Pattern**: The antidiagonal template (omega → sum_insert/sum_singleton → ring) scales to arbitrary k, though the four-element case (k=5) requires the more explicit constructor form for the filter proof.",
     "openQuestions": [
-      "Prove the general Newton-Girard recurrence for arbitrary k as a clean inductive theorem, without case-by-case antidiagonal computation",
-      "Connect to Waring's problem: express p_k^(1/k) as a polynomial in e_1,...,e_k for specific k"
+      "Prove the general Newton-Girard recurrence for arbitrary k as a clean inductive theorem using Mathlib's `psum_eq_mul_esymm_sub_sum` directly, without case-by-case antidiagonal computation — the main challenge is expressing the general antidiagonal filter `{(a,b) | a+b=k, 0 < a < k}` as a Finset in a way that `ring` can close",
+      "Waring's problem (1770): express $p_k^{1/k}$ (or more precisely, express any symmetric polynomial as a polynomial in $e_1, \\ldots, e_n$) — the fundamental theorem of symmetric polynomials guarantees existence, but giving an explicit algorithm using Newton-Girard as the computational engine would make the Lean formalization constructive",
+      "Compute the discriminant $\\Delta(f) = \\prod_{i < j}(x_i - x_j)^2$ of a degree-5 polynomial in terms of $p_1,\\ldots,p_{10}$ using repeated Newton-Girard applications, connecting these identities to the Galois group criterion for quintic solvability",
+      "Extend the antidiagonal template to k=6,7,8,... as a stress test of the proof automation: at what degree does the four-step `sum_insert` chain become impractical, and is there a more scalable approach using `Finset.sum_congr` or decidability?"
     ]
   },
   "crossReferences": [
@@ -118,7 +123,44 @@
     {
       "targetId": "vietas-formulas",
       "relationship": "related",
-      "description": "Vieta's formulas relate polynomial coefficients to elementary symmetric polynomials; Newton-Girard connects these to power sums."
+      "description": "Vieta's formulas express polynomial coefficients as elementary symmetric polynomials of the roots: $a_{n-k}/a_n = (-1)^k e_k(x_1,\\ldots,x_n)$. Newton-Girard extends this by expressing power sums $p_k = \\sum x_i^k$ in terms of the same $e_k$. Together, Vieta + Newton-Girard enable computing power sums directly from polynomial coefficients without knowing individual roots."
+    },
+    {
+      "targetId": "newton-inductive-step",
+      "relationship": "related",
+      "description": "Provides the inductive step for Newton's inequality $e_k^2 \\geq e_{k-1} e_{k+1}$ — a direct consequence of Maclaurin's inequality. The Newton-Girard identities proved in this entry (connecting $p_k$ to $e_k$) are a complementary tool: while Newton's inequality is a comparison between elementary symmetric polynomials, Newton-Girard is an algebraic identity expressing their relationship to power sums."
+    },
+    {
+      "targetId": "abel-ruffini",
+      "relationship": "related",
+      "description": "Newton-Girard at k=4,5 provides the symmetric function machinery underlying the theory of quintic polynomials. The Abel-Ruffini theorem (no radical formula exists for degree ≥ 5) uses the Galois group of the quintic, which is computed via discriminants and power sums — computations that rely on Newton-Girard identities. The k=5 case proved here sits at the exact solvability boundary: degrees 1–4 have radical formulas (Cardano, Ferrari), degree 5 does not."
+    },
+    {
+      "targetId": "amgm-inequality",
+      "relationship": "ancestor",
+      "description": "Root of the amgm family: proves the AM-GM inequality $\\frac{x_1+\\cdots+x_n}{n} \\geq (x_1 \\cdots x_n)^{1/n}$. The Newton-Girard chain (k=1,...,5) provides the algebraic foundation for Maclaurin's inequalities relating elementary symmetric means, directly supporting the AM-GM family of results."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "psum_four_eq",
+      "statement": "psum σ R 4 = esymm σ R 1 * psum σ R 3 - esymm σ R 2 * psum σ R 2 + esymm σ R 3 * psum σ R 1 - 4 * esymm σ R 4",
+      "description": "Newton-Girard k=4: the fourth power sum expressed as a linear combination of elementary symmetric polynomials and lower power sums, proved via three-element antidiagonal filter and ring"
+    },
+    {
+      "name": "psum_five_eq",
+      "statement": "psum σ R 5 = esymm σ R 1 * psum σ R 4 - esymm σ R 2 * psum σ R 3 + esymm σ R 3 * psum σ R 2 - esymm σ R 4 * psum σ R 1 + 5 * esymm σ R 5",
+      "description": "Newton-Girard k=5: the fifth power sum expressed via four-element antidiagonal, with explicit iff constructor for the filter proof"
+    },
+    {
+      "name": "esymm_four_from_psum",
+      "statement": "4 * esymm σ R 4 = esymm σ R 3 * psum σ R 1 - esymm σ R 2 * psum σ R 2 + esymm σ R 1 * psum σ R 3 - psum σ R 4",
+      "description": "Dual Newton-Girard k=4: expresses 4·e₄ in terms of power sums, proved by linear_combination over any CommRing"
+    },
+    {
+      "name": "esymm_five_from_psum",
+      "statement": "5 * esymm σ R 5 = esymm σ R 4 * psum σ R 1 - esymm σ R 3 * psum σ R 2 + esymm σ R 2 * psum σ R 3 - esymm σ R 1 * psum σ R 4 + psum σ R 5",
+      "description": "Dual Newton-Girard k=5: expresses 5·e₅ in terms of power sums, proved by linear_combination"
     }
   ],
   "references": [
@@ -126,7 +168,22 @@
       "authors": "Newton, Isaac",
       "title": "Arithmetica Universalis",
       "year": "1707",
-      "note": "Newton's identities for k=4 and k=5, extending the classical cases proved in the parent entry."
+      "venue": "Cambridge",
+      "note": "States the general Newton-Girard recurrence (without proof); the k=4,5 cases in this entry are direct specializations"
+    },
+    {
+      "authors": "Girard, Albert",
+      "title": "Invention nouvelle en l'algèbre",
+      "year": "1629",
+      "venue": "Amsterdam",
+      "note": "First written formulation of Newton's identities for the low-degree cases k=1,2,3,4 (in 17th-century notation)"
+    },
+    {
+      "authors": "Macdonald, I.G.",
+      "title": "Symmetric Functions and Hall Polynomials",
+      "year": "1995",
+      "venue": "Oxford University Press, 2nd edition",
+      "note": "Comprehensive modern reference for symmetric function theory including Newton-Girard identities, power sum symmetric functions, and their role in algebraic combinatorics"
     }
   ]
 }


### PR DESCRIPTION
Enrichment pass for amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01 (Newton-Girard k=4,5).

Quality improvements:
- **4 annotations added** (was 0): module docstring, psum_four_eq, psum_five_eq, dual forms — each with mathContext, significance, relatedConcepts, prerequisites
- **historicalContext expanded**: added Girard (1629) history, connection to quintic solvability boundary at degree 5, Abel-Ruffini context
- **3 new keyInsights**: alternating sign pattern (-1)^a in antidiagonal, characteristic restriction for dual forms (char ≠ k), connection to Abel-Ruffini
- **2 new openQuestions**: discriminant computation using Newton-Girard, scalability of antidiagonal pattern to k=6+
- **3 new crossReferences**: vietas-formulas, newton-inductive-step, abel-ruffini
- **mainTheorems array** added with all 4 theorem statements
- **References expanded**: Girard (1629) and Macdonald (1995) added