### PR TITLE
fix(meta): sync leanFile stats for shannon-oq-04 and cayley-hamilton-cyclic

### DIFF
--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields/meta.json
@@ -21,7 +21,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 213,
+    "lineCount": 201,
     "assumptions": "1 axiom: nonderogatory_similar_companion (RCF similarity theorem — every nonderogatory matrix is similar to its companion matrix). Requires the structure theorem for f.g. modules over K[X], not yet in Mathlib 4. All other lemmas are fully proved.",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
@@ -127,9 +127,9 @@
     ],
     "opens": ["Matrix", "Polynomial"],
     "namespace": "CayleyHamiltonCyclicVectorAllFields",
-    "lineCount": 213,
+    "lineCount": 201,
     "axiomCount": 1,
-    "theoremCount": 5,
+    "theoremCount": 3,
     "definitionCount": 2,
     "path": "Proofs/CayleyHamiltonCyclicVectorAllFields.lean",
     "sorries": 0

--- a/src/data/proofs/shannon-source-coding-oq-04/meta.json
+++ b/src/data/proofs/shannon-source-coding-oq-04/meta.json
@@ -68,7 +68,7 @@
     ],
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "lineCount": 352,
+    "lineCount": 429,
     "prerequisites": [
       "Shannon entropy H(X) = -sum p(x) log p(x)",
       "Empirical distribution (type) of a sequence",
@@ -178,10 +178,10 @@
       "BigOperators"
     ],
     "namespace": "MethodOfTypes",
-    "lineCount": 352,
+    "lineCount": 429,
     "axiomCount": 0,
-    "theoremCount": 12,
-    "definitionCount": 4,
+    "theoremCount": 11,
+    "definitionCount": 5,
     "path": "Proofs/ShannonSourceCodingOQ04.lean",
     "sorries": 1
   },


### PR DESCRIPTION
## Fix

Corrects stale `leanFile` metadata in two gallery entries where the Lean source files diverged from the recorded statistics.

## Evidence

**shannon-source-coding-oq-04**:
- `lineCount`: 352 → 429 (+77 lines added when `type_class_size_eq_multinomial` was proved in #12893)
- `theoremCount`: 12 → 11 (was incorrect from earlier edits)
- `definitionCount`: 4 → 5 (file has 5 `def`/`noncomputable def` declarations)

**cayley-hamilton-cyclic-vector-all-fields**:
- `lineCount`: 213 → 201 (was miscounted at entry creation in #12897)
- `theoremCount`: 5 → 3 (file has exactly 3 `theorem` declarations; `definitionCount: 2` stays correct for the 2 `abbrev` aliases)

Both `meta.lineCount` and `leanFile.lineCount` are updated in each entry.

---
Automated fix by lean-mechanic agent.