### PR TITLE
fix(meta): sync leanFile.theoremCount for 11 gallery entries

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01/meta.json
@@ -127,7 +127,7 @@
     "namespace": "BallotFiberTransfer",
     "lineCount": 208,
     "axiomCount": 0,
-    "theoremCount": 6,
+    "theoremCount": 7,
     "definitionCount": 0,
     "path": "Proofs/BallotProblemOQ01OQ02OQ01.lean",
     "sorries": 3,

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-04/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-04/meta.json
@@ -173,7 +173,7 @@
     "namespace": "BallotProblemOQ03OQ01OQ04",
     "lineCount": 182,
     "axiomCount": 0,
-    "theoremCount": 3,
+    "theoremCount": 10,
     "definitionCount": 0,
     "path": "Proofs/BallotProblemOQ03OQ01OQ04.lean",
     "sorries": 0

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-02/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-02/meta.json
@@ -148,7 +148,7 @@
     "namespace": "ChebyshevPNTBridgeOQ02",
     "lineCount": 173,
     "axiomCount": 0,
-    "theoremCount": 4,
+    "theoremCount": 5,
     "substantiveTheoremCount": 4,
     "duplicateTheorems": 0,
     "definitionCount": 0,

--- a/src/data/proofs/dissection-of-cubes-oq-02-oq-02/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-02-oq-02/meta.json
@@ -252,7 +252,7 @@
     "namespace": "DehnSydler",
     "lineCount": 454,
     "axiomCount": 0,
-    "theoremCount": 23,
+    "theoremCount": 24,
     "definitionCount": 5,
     "mainTheorems": [
       {

--- a/src/data/proofs/divisibility-rules-oq-02/meta.json
+++ b/src/data/proofs/divisibility-rules-oq-02/meta.json
@@ -52,7 +52,7 @@
     "namespace": "DivisibilityRulesOQ02",
     "lineCount": 142,
     "axiomCount": 0,
-    "theoremCount": 8,
+    "theoremCount": 9,
     "definitionCount": 0,
     "path": "Proofs/DivisibilityRulesOQ02.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-105-oq-02/meta.json
+++ b/src/data/proofs/erdos-105-oq-02/meta.json
@@ -158,7 +158,7 @@
     "namespace": "Erdos105OQ02",
     "lineCount": 288,
     "axiomCount": 3,
-    "theoremCount": 15,
+    "theoremCount": 20,
     "definitionCount": 6,
     "path": "Proofs/Erdos105OQ02.lean",
     "sorries": 0

--- a/src/data/proofs/greens-theorem-oq-02/meta.json
+++ b/src/data/proofs/greens-theorem-oq-02/meta.json
@@ -215,7 +215,7 @@
     "namespace": "GreensTheoremOQ02",
     "lineCount": 507,
     "axiomCount": 1,
-    "theoremCount": 19,
+    "theoremCount": 21,
     "definitionCount": 4,
     "path": "Proofs/GreensTheoremOQ02.lean",
     "sorries": 0

--- a/src/data/proofs/napoleons-theorem-oq-02/meta.json
+++ b/src/data/proofs/napoleons-theorem-oq-02/meta.json
@@ -183,7 +183,7 @@
     "namespace": "NapoleonsTheoremOQ02",
     "lineCount": 346,
     "axiomCount": 0,
-    "theoremCount": 9,
+    "theoremCount": 10,
     "sorries": 0,
     "path": "Proofs/NapoleonsTheoremOQ02.lean"
   }

--- a/src/data/proofs/solution-of-cubic-oq-05/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-05/meta.json
@@ -103,7 +103,7 @@
     "namespace": "SolutionOfCubicOQ05",
     "lineCount": 183,
     "axiomCount": 0,
-    "theoremCount": 8,
+    "theoremCount": 9,
     "definitionCount": 3,
     "path": "Proofs/SolutionOfCubicOQ05.lean",
     "sorries": 0

--- a/src/data/proofs/taylor-sincos-convergence-oq-04/meta.json
+++ b/src/data/proofs/taylor-sincos-convergence-oq-04/meta.json
@@ -209,7 +209,7 @@
     "namespace": "TaylorBoundedDerivConvergence",
     "lineCount": 324,
     "axiomCount": 0,
-    "theoremCount": 16,
+    "theoremCount": 18,
     "definitionCount": 1,
     "path": "Proofs/TaylorSinCosConvergenceOQ04.lean",
     "sorries": 0

--- a/src/data/proofs/tractatus-ontology/meta.json
+++ b/src/data/proofs/tractatus-ontology/meta.json
@@ -256,7 +256,7 @@
     "namespace": "Tractatus",
     "lineCount": 1230,
     "axiomCount": 1,
-    "theoremCount": 37,
+    "theoremCount": 40,
     "definitionCount": 29,
     "path": "Proofs/TractatusOntology.lean",
     "sorries": 0,


### PR DESCRIPTION
## Fix

Corrects stale `leanFile.theoremCount` values in 11 meta.json files where Lean source files grew through research/enrichment activity but gallery metadata was not updated.

## Evidence

**Before**: theoremCount values reflected the count at time of initial gallery entry creation.
**After**: values reflect current Lean source files using the canonical counting method (`^(theorem|lemma) ` lines).

| Entry | Before | After | Growth |
|-------|--------|-------|--------|
| ballot-problem-oq-01-oq-02-oq-01 | 6 | 7 | +1 |
| ballot-problem-oq-03-oq-01-oq-04 | 3 | 10 | +7 (Catalan recurrence proofs) |
| chebyshev-pnt-bridge-oq-02 | 4 | 5 | +1 |
| dissection-of-cubes-oq-02-oq-02 | 23 | 24 | +1 |
| divisibility-rules-oq-02 | 8 | 9 | +1 |
| erdos-105-oq-02 | 15 | 20 | +5 |
| greens-theorem-oq-02 | 19 | 21 | +2 |
| napoleons-theorem-oq-02 | 9 | 10 | +1 |
| solution-of-cubic-oq-05 | 8 | 9 | +1 |
| taylor-sincos-convergence-oq-04 | 16 | 18 | +2 |
| tractatus-ontology | 37 | 40 | +3 |

Follows up on #12914 which fixed 129 entries. Same counting method: lines beginning with `^(theorem|lemma) `.

---
Automated fix by lean-mechanic agent.