### PR TITLE
fix(meta): sync leanFile.theoremCount for 18 gallery entries

### DIFF
--- a/.loom/tokens
+++ b/.loom/tokens
@@ -1,0 +1,1 @@
+/Users/rwalters/GitHub/lean-genius/.loom/tokens

--- a/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01/meta.json
@@ -189,7 +189,7 @@
     "namespace": "PowerMeanCrossZero",
     "lineCount": 225,
     "axiomCount": 0,
-    "theoremCount": 4,
+    "theoremCount": 9,
     "definitionCount": 0,
     "sorries": 0,
     "path": "Proofs/PowerMeanCrossZeroOQ.lean"

--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-01/meta.json
@@ -24,7 +24,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "theoremCount": 27,
+    "theoremCount": 30,
     "defCount": 5,
     "lineCount": 507,
     "mathlib_version": "4.26.0",
@@ -201,7 +201,7 @@
     "namespace": "PolyaEnumeration",
     "lineCount": 507,
     "axiomCount": 0,
-    "theoremCount": 27,
+    "theoremCount": 30,
     "definitionCount": 5,
     "sorries": 0,
     "path": "Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean"

--- a/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json
@@ -179,7 +179,7 @@
     "namespace": "CayleyHamiltonReductionOQ02OQ01",
     "lineCount": 396,
     "axiomCount": 0,
-    "theoremCount": 12,
+    "theoremCount": 18,
     "definitionCount": 1,
     "sorries": 0,
     "path": "Proofs/CayleyHamiltonReductionOQ02OQ01.lean"

--- a/src/data/proofs/chebyshev-bounds/meta.json
+++ b/src/data/proofs/chebyshev-bounds/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified.",
     "lineCount": 439,
-    "theoremCount": 18,
+    "theoremCount": 15,
     "definitionCount": 3,
     "originalContributions": [
       "Definition of the first Chebyshev function θ(n) = Σ_{p ≤ n} log p and proof that θ(n) ≤ n·log(4)",
@@ -137,7 +137,7 @@
     "lineCount": 439,
     "path": "Proofs/ChebyshevBounds.lean",
     "axiomCount": 0,
-    "theoremCount": 18,
+    "theoremCount": 15,
     "definitionCount": 3,
     "sorries": 0,
     "imports": [

--- a/src/data/proofs/combinations-formula-oq-02/meta.json
+++ b/src/data/proofs/combinations-formula-oq-02/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 0,
     "assumptions": "",
     "lineCount": 312,
-    "theoremCount": 25,
+    "theoremCount": 22,
     "definitionCount": 2,
     "originalContributions": [
       "catalan: C_n = C(2n,n) - C(2n,n+1)",
@@ -102,7 +102,7 @@
     "namespace": "CatalanNumbers",
     "lineCount": 312,
     "axiomCount": 0,
-    "theoremCount": 25,
+    "theoremCount": 22,
     "definitionCount": 2,
     "path": "Proofs/CombinationsFormulaOQ02.lean",
     "sorries": 0

--- a/src/data/proofs/dissection-of-cubes-oq-01-oq-01/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01-oq-01/meta.json
@@ -143,7 +143,7 @@
     "namespace": "DissectionOfCubesOQ01OQ01",
     "lineCount": 328,
     "axiomCount": 0,
-    "theoremCount": 26,
+    "theoremCount": 29,
     "definitionCount": 5,
     "path": "Proofs/DissectionOfCubesOQ01OQ01.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-470/meta.json
+++ b/src/data/proofs/erdos-470/meta.json
@@ -163,7 +163,7 @@
     "namespace": "Erdos470",
     "lineCount": 593,
     "axiomCount": 3,
-    "theoremCount": 46,
+    "theoremCount": 42,
     "definitionCount": 14,
     "path": "Proofs/Erdos470Problem.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-643/meta.json
+++ b/src/data/proofs/erdos-643/meta.json
@@ -188,7 +188,7 @@
     "namespace": "Harmonic.GeneralizeProofs",
     "lineCount": 1403,
     "axiomCount": 3,
-    "theoremCount": 45,
+    "theoremCount": 42,
     "definitionCount": 15,
     "path": "Proofs/Erdos643Problem.lean",
     "sorries": 1

--- a/src/data/proofs/erdos-848-oq-01/meta.json
+++ b/src/data/proofs/erdos-848-oq-01/meta.json
@@ -22,7 +22,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 160,
-    "theoremCount": 11,
+    "theoremCount": 15,
     "defCount": 1,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0"
@@ -138,7 +138,7 @@
     "namespace": "Erdos848OQ01",
     "lineCount": 160,
     "axiomCount": 0,
-    "theoremCount": 11,
+    "theoremCount": 15,
     "definitionCount": 1,
     "path": "Proofs/Erdos848ProblemOQ01.lean",
     "sorries": 0

--- a/src/data/proofs/hurwitz-theorem-oq-04/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-04/meta.json
@@ -139,7 +139,7 @@
     "namespace": "HurwitzTheoremOQ04",
     "lineCount": 822,
     "axiomCount": 1,
-    "theoremCount": 32,
+    "theoremCount": 40,
     "definitionCount": 15,
     "sorries": 0,
     "path": "Proofs/HurwitzTheoremOQ04.lean"

--- a/src/data/proofs/konigsberg-oq-04/meta.json
+++ b/src/data/proofs/konigsberg-oq-04/meta.json
@@ -116,7 +116,7 @@
     "namespace": "KonigsbergOQ04",
     "lineCount": 338,
     "axiomCount": 1,
-    "theoremCount": 12,
+    "theoremCount": 9,
     "definitionCount": 8,
     "path": "Proofs/KonigsbergOQ04.lean",
     "sorries": 0

--- a/src/data/proofs/kummer-theorem-oq-02/meta.json
+++ b/src/data/proofs/kummer-theorem-oq-02/meta.json
@@ -181,7 +181,7 @@
     "namespace": "KummerTheoremOQ02",
     "lineCount": 412,
     "axiomCount": 0,
-    "theoremCount": 16,
+    "theoremCount": 21,
     "definitionCount": 4,
     "path": "Proofs/KummerTheoremOQ02.lean",
     "sorries": 0

--- a/src/data/proofs/lhopital-oq-01/meta.json
+++ b/src/data/proofs/lhopital-oq-01/meta.json
@@ -157,7 +157,7 @@
     "namespace": "LHopitalFailure",
     "lineCount": 142,
     "axiomCount": 0,
-    "theoremCount": 11,
+    "theoremCount": 8,
     "definitionCount": 0,
     "path": "Proofs/LHopitalOQ01.lean",
     "sorries": 0

--- a/src/data/proofs/ptolemys-complex-proof-oq-02/meta.json
+++ b/src/data/proofs/ptolemys-complex-proof-oq-02/meta.json
@@ -158,7 +158,7 @@
     "namespace": "PtolemysComplexProofOQ02",
     "lineCount": 351,
     "axiomCount": 0,
-    "theoremCount": 6,
+    "theoremCount": 11,
     "substantiveTheoremCount": 1,
     "duplicateTheorems": 0,
     "definitionCount": 0,

--- a/src/data/proofs/ptolemys-theorem-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01-incomplete-01/meta.json
@@ -159,7 +159,7 @@
     "namespace": "PtolemysTheoremOQ01Incomplete01",
     "lineCount": 489,
     "axiomCount": 0,
-    "theoremCount": 2,
+    "theoremCount": 7,
     "definitionCount": 0,
     "sorries": 0,
     "path": "Proofs/PtolemysTheoremOQ01Incomplete01.lean"

--- a/src/data/proofs/ptolemys-theorem-oq-01/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01/meta.json
@@ -51,7 +51,7 @@
     "axiomCount": 0,
     "lineCount": 482,
     "assumptions": "None. All results fully verified from Mathlib with 0 sorries and 0 axioms.",
-    "theoremCount": 8,
+    "theoremCount": 13,
     "definitionCount": 2
   },
   "overview": {
@@ -150,7 +150,7 @@
     "namespace": null,
     "lineCount": 482,
     "axiomCount": 0,
-    "theoremCount": 8,
+    "theoremCount": 13,
     "substantiveTheoremCount": 5,
     "duplicateTheorems": 0,
     "definitionCount": 2,

--- a/src/data/proofs/randomized-maxcut-oq-04/meta.json
+++ b/src/data/proofs/randomized-maxcut-oq-04/meta.json
@@ -149,7 +149,7 @@
     "namespace": "MaxCutDerandomization",
     "lineCount": 401,
     "axiomCount": 0,
-    "theoremCount": 10,
+    "theoremCount": 15,
     "definitionCount": 4,
     "path": "Proofs/RandomizedMaxcutOQ04.lean",
     "sorries": 0

--- a/src/data/proofs/sqrt2-minpoly-oq-01/meta.json
+++ b/src/data/proofs/sqrt2-minpoly-oq-01/meta.json
@@ -183,7 +183,7 @@
     "namespace": "Sqrt2MinpolyOQ01",
     "lineCount": 252,
     "axiomCount": 0,
-    "theoremCount": 17,
+    "theoremCount": 20,
     "definitionCount": 0,
     "sorries": 0,
     "path": "Proofs/Sqrt2MinpolyOQ01.lean"


### PR DESCRIPTION
## Fix

Corrects stale `leanFile.theoremCount` values in 18 meta.json files where the Lean source grew (or was initially set inaccurately) through subsequent research and enrichment activity.

## Evidence

**Method**: Grep for top-level `theorem`, `lemma`, `private theorem`, `private lemma`, `protected theorem`, `protected lemma`, and `@[attr] theorem/lemma` declarations in each Lean file, then compare against `leanFile.theoremCount` in meta.json.

**Changes (reported→actual)**:
- amgm-inequality-oq-03-oq-02-oq-01: 4→9
- arithmetic-series-oq-02-oq-02-oq-03-oq-01: 27→30
- cayley-hamilton-reduction-oq-02-oq-01: 12→18 (private lemmas were uncounted)
- chebyshev-bounds: 18→15
- combinations-formula-oq-02: 25→22
- dissection-of-cubes-oq-01-oq-01: 26→29
- erdos-470: 46→42
- erdos-643: 45→42
- erdos-848-oq-01: 11→15
- hurwitz-theorem-oq-04: 32→40 (private lemmas were uncounted)
- konigsberg-oq-04: 12→9
- kummer-theorem-oq-02: 16→21
- lhopital-oq-01: 11→8
- ptolemys-complex-proof-oq-02: 6→11
- ptolemys-theorem-oq-01: 8→13
- ptolemys-theorem-oq-01-incomplete-01: 2→7
- randomized-maxcut-oq-04: 10→15
- sqrt2-minpoly-oq-01: 17→20

---
Automated fix by lean-mechanic agent.