### PR TITLE
fix(meta): sync ballot-problem-oq-03-oq-01-oq-02 lineCount after PART XXIV

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -23,7 +23,7 @@
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
     "assumptions": "Four open sorries: (1) hook_length_formula (LGV approach: requires SYT↔NI bijection + det factorization), (2) ni_count_eq_syt_count (Fomin/Viennot/RSK correspondence), (3) lgv_det_factors_as_hook_quotient (det factorization identity), (4) hook_walk_identity ≥9-row non-gHookYD ≥3-col case (GNW probabilistic proof; at-most-2-row, gHookYD, ≤2-col, exactly-3-row, exactly-4-row, exactly-5-row, exactly-6-row, exactly-7-row, exactly-9-row ALL proved). hook_length_formula_general is proved modulo hook_walk_identity via corner induction.",
-    "lineCount": 13638,
+    "lineCount": 13784,
     "theoremCount": 464,
     "definitionCount": 14,
     "originalContributions": [
@@ -91,7 +91,7 @@
       "LGV"
     ],
     "namespace": "HookLengthFormula",
-    "lineCount": 13638,
+    "lineCount": 13784,
     "axiomCount": 0,
     "sorries": 4,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",


### PR DESCRIPTION
## Summary

- Syncs `leanFile.lineCount` and `meta.lineCount` from 13638 → 13784 in ballot-problem-oq-03-oq-01-oq-02/meta.json
- PART XXIV (transpose duality, #12925) added 146 lines but meta.json was not updated
- Sorry count (4) and axiom count (0) are already correct

## Audit Result

- **Sorry count**: 4 (matches meta)
- **Axiom count**: 0 (matches meta)  
- **Status**: `formalized` / badge `wip` (appropriate — has sorries)
- **True stubs**: None
- **Issue**: Only lineCount was stale

---
Discovered during gallery integrity audit.