### PR TITLE
enrich(abel-ruffini-galois-extensions): fix definitionCount and annotation range

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions/annotations.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions/annotations.json
@@ -187,7 +187,7 @@
     "proofId": "abel-ruffini-galois-extensions",
     "range": {
       "startLine": 143,
-      "endLine": 158
+      "endLine": 152
     },
     "type": "concept",
     "title": "S₄ Solvability via Exact Sequence 1 → A₄ → S₄ → ℤˣ → 1",

--- a/src/data/proofs/abel-ruffini-galois-extensions/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions/meta.json
@@ -2,7 +2,7 @@
   "id": "abel-ruffini-galois-extensions",
   "title": "Abel-Ruffini Galois Theory Extensions",
   "slug": "abel-ruffini-galois-extensions",
-  "description": "Extends the Abel-Ruffini formalization with the complete solvability classification of symmetric groups. Proves S₀–S₄ are solvable, S_n is solvable if and only if n ≤ 4, A₅ is simple (the key obstruction), and non-commutativity witnesses for S₃, S₄, S₅, A₄, A₅. Verifies group orders |S₇|=5040, |A₈|=20160. 59 theorems, 0 definitions, 0 axioms.",
+  "description": "Extends the Abel-Ruffini formalization with the complete solvability classification of symmetric groups. Proves S₀–S₄ are solvable, S_n is solvable if and only if n ≤ 4, A₅ is simple (the key obstruction), and non-commutativity witnesses for S₃, S₄, S₅, A₄, A₅. Verifies group orders |S₇|=5040, |A₈|=20160. 59 theorems, 1 definition, 0 axioms.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-02-15",
@@ -22,7 +22,7 @@
     "assumptions": "None. Fully machine-verified using Mathlib's solvability infrastructure.",
     "lineCount": 534,
     "theoremCount": 59,
-    "definitionCount": 0,
+    "definitionCount": 1,
     "mathlibDependencies": [
       {
         "theorem": "Equiv.Perm.not_solvable",
@@ -92,7 +92,7 @@
     "lineCount": 534,
     "axiomCount": 0,
     "theoremCount": 59,
-    "definitionCount": 0,
+    "definitionCount": 1,
     "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Enrichment pass for abel-ruffini-galois-extensions

Accuracy fixes on 5th enrichment pass:

- **Fix `definitionCount`**: Changed from 0 to 1 in both `meta` and `leanFile` sections — the file has `private def klein_four` at line 107
- **Fix description**: Updated "0 definitions" to "1 definition" 
- **Fix annotation range**: `arg-s4-solvable` range narrowed from 143-158 to 143-152 (S₄ proof ends at line 151, section closes at 152; lines 154-158 are Part II header)