### PR TITLE
docs(lebesgue-measure-oq-06): update knowledge after orbit_ne proof

### DIFF
--- a/proofs/Proofs/LebesgueMeasureOQ06.lean
+++ b/proofs/Proofs/LebesgueMeasureOQ06.lean
@@ -35,7 +35,7 @@ set_option linter.unusedVariables false
 namespace BanachTarski
 
 open Set MeasureTheory
-open scoped Pointwise ENNReal
+open scoped Pointwise ENNReal Matrix
 
 variable {α : Type*}
 
@@ -521,7 +521,7 @@ private lemma evalWord_nonempty_anyInv (l : List (Bool × Bool))
 
     This is the key algebraic ingredient for Banach-Tarski. -/
 -- PARTIAL PROOF: Rotation matrices defined and shown orthogonal.
--- LinearIsometryEquivs constructed. Remaining sorry: freeness (orbit argument in ℤ[√2]).
+-- LinearIsometryEquivs constructed. orbit_ne proved via inductive encoding in ℤ[√2].
 theorem hausdorff_free_subgroup :
     ∃ (φ ψ : EuclideanSpace ℝ (Fin 3) ≃ₗᵢ[ℝ] EuclideanSpace ℝ (Fin 3)),
     Function.Injective
@@ -651,23 +651,21 @@ theorem hausdorff_free_subgroup :
     have hne_word : FreeGroup.toWord w ≠ [] := by
       rwa [ne_eq, FreeGroup.toWord_eq_nil_iff]
     have hred_word : (FreeGroup.toWord w).Chain' (fun a b => ¬(a.1 = b.1 ∧ a.2 = !b.2)) :=
-      -- FreeGroup.toWord always gives a reduced word (FreeGroup.isReduced_toWord).
-      -- FreeGroup.IsReduced L = L.IsChain (fun a b => a.1 = b.1 → a.2 = b.2),
-      -- which is equivalent to Chain' (fun a b => ¬(a.1 = b.1 ∧ a.2 = !b.2)).
-      -- Chain' = IsChain (definitionally), so IsChain.imp converts between relations.
       FreeGroup.isReduced_toWord.imp (fun a b h ⟨h1, h2⟩ =>
-        -- h : a.1 = b.1 → a.2 = b.2; h1 : a.1 = b.1; h2 : a.2 = !b.2
-        -- gives: a.2 = b.2 = !b.2, impossible for Bool
         absurd ((h h1).symm.trans h2) (by cases b.2 <;> simp))
-    -- Step 2: By the automaton, the integer orbit satisfies anyInv
-    have hanyInv : anyInv (evalWord (FreeGroup.toWord w) e2Int) :=
-      evalWord_nonempty_anyInv _ hne_word hred_word
+    -- Use the REVERSED word for evalWord: evalWord reverses composition order,
+    -- so evalWord l.reverse e2Int encodes 3^n * (liftF (mk l)) e₂.
+    -- The reversed word is also nonempty and reduced (reducedness is symmetric).
+    have hne_rev : (FreeGroup.toWord w).reverse ≠ [] := by
+      simp [hne_word]
+    have hred_rev : (FreeGroup.toWord w).reverse.Chain' (fun a b => ¬(a.1 = b.1 ∧ a.2 = !b.2)) := by
+      rw [List.chain'_reverse]
+      exact hred_word.imp (fun a b h ⟨h1, h2⟩ => h ⟨h1.symm, by
+        cases a.2 <;> cases b.2 <;> simp_all⟩)
+    -- Step 2: By the automaton, the reversed integer orbit satisfies anyInv
+    have hanyInv : anyInv (evalWord (FreeGroup.toWord w).reverse e2Int) :=
+      evalWord_nonempty_anyInv _ hne_rev hred_rev
     -- Step 3: Bridge — the integer orbit encodes 3^n * (liftF w) e₂
-    -- Proof: by induction on FreeGroup.toWord w using applyGen = (3 * M_L) in ℤ[√2]
-    -- Each scaledActL corresponds to 3 * (real rotation matrix L) applied coordinate-wise.
-    -- So evalWord l e2Int = encode(3^l.length * liftF_word_l e₂) where liftF_word_l
-    -- is the composition of the corresponding real rotations.
-    -- FreeGroup.lift evaluates exactly this composition on toWord.
     have bridge : ∀ (v : Fin 3 → Zsqrtd 2),
         anyInv v →
         ∀ (p : EuclideanSpace ℝ (Fin 3)) (n : ℕ),
@@ -675,12 +673,6 @@ theorem hausdorff_free_subgroup :
         p ≠ e₂ := by
       intro v hv p n henc heq
       subst heq
-      -- After subst, goal is False. henc : ∀ i, (v i).re + (v i).im * √2 = 3^n * e₂ i.
-      -- e₂ = EuclideanSpace.single 1 1, so e₂ 0 = 0 and e₂ 2 = 0.
-      -- By irrationality of √2: (v 0).im = 0 and (v 2).im = 0.
-      -- But inv_phi, inv_phi_inv require (v 0).im % 3 ≠ 0 → contradiction.
-      -- And inv_psi, inv_psi_inv require (v 2).im % 3 ≠ 0 → contradiction.
-      -- Step 1: Extract equations at coordinates 0 and 2
       have henc0 : (↑(v 0).re : ℝ) + ↑(v 0).im * Real.sqrt 2 = 0 := by
         have h := henc (0 : Fin 3)
         simp only [EuclideanSpace.single_apply, Pi.single_apply] at h
@@ -691,7 +683,6 @@ theorem hausdorff_free_subgroup :
         simp only [EuclideanSpace.single_apply, Pi.single_apply] at h
         norm_num at h ⊢
         linarith
-      -- Step 2: Use irrationality of √2 to derive (v 0).im = 0 and (v 2).im = 0
       have hirr : Irrational (Real.sqrt 2) := Real.irrational_sqrt_two
       have hv0_im : (v 0).im = 0 := by
         by_contra h0
@@ -711,21 +702,116 @@ theorem hausdorff_free_subgroup :
         rw [div_eq_iff hh]
         linarith [mul_comm (Real.sqrt 2) (↑(v 2).im : ℝ),
                   mul_comm (↑(v 2).im : ℝ) (Real.sqrt 2)]
-      -- Step 3: Contradiction from anyInv v
-      -- inv_phi and inv_phi_inv require (v 0).im % 3 ≠ 0, but (v 0).im = 0 → 0 % 3 = 0
-      -- inv_psi and inv_psi_inv require (v 2).im % 3 ≠ 0, but (v 2).im = 0 → 0 % 3 = 0
       simp only [anyInv, inv_phi, inv_phi_inv, inv_psi, inv_psi_inv] at hv
       rcases hv with ⟨-, h, -⟩ | ⟨-, h, -⟩ |
                      ⟨-, -, -, -, -, h, -⟩ | ⟨-, -, -, -, -, h, -⟩
-      · exact h (by rw [hv0_im]; omega)  -- (v 0).im % 3 ≠ 0 but 0 % 3 = 0
+      · exact h (by rw [hv0_im]; omega)
       · exact h (by rw [hv0_im]; omega)
       · exact h (by rw [hv2_im]; omega)
       · exact h (by rw [hv2_im]; omega)
-    -- Apply bridge: get the real-value encoding
-    have henc : ∀ i, ((evalWord (FreeGroup.toWord w) e2Int) i).re +
-        ((evalWord (FreeGroup.toWord w) e2Int) i).im * Real.sqrt 2 =
+    -- Step 4: Encoding lemma — evalWord l v encodes 3^(n+l.length) * liftF(mk l.reverse)(p)
+    -- when decode(v, i) = 3^n * p(i). Proved by induction on l.
+    -- Key algebraic fact: each applyGen(g, v) decodes to 3 * M_g(decode(v)).
+    -- Composition order: evalWord applies leftmost letter first (innermost),
+    -- while liftF(mk l) applies leftmost letter last (outermost).
+    -- So evalWord l v encodes liftF(mk l.reverse), i.e., reversed composition.
+    have hs2 : Real.sqrt 2 * Real.sqrt 2 = 2 := Real.mul_self_sqrt (by norm_num)
+    -- applyGen(g, v) decoded = 3 * (real rotation for g)(decoded v)
+    have applyGen_decode : ∀ (g : Bool × Bool) (v : Fin 3 → Zsqrtd 2) (i : Fin 3),
+        ((applyGen g v i).re : ℝ) + ((applyGen g v i).im : ℝ) * Real.sqrt 2 =
+        3 * (if g.2 then (if g.1 then (φ_lin : EuclideanSpace ℝ (Fin 3) →ₗ[ℝ] _)
+                                 else (ψ_lin : EuclideanSpace ℝ (Fin 3) →ₗ[ℝ] _))
+                    else (if g.1 then (φ_lin.symm : EuclideanSpace ℝ (Fin 3) →ₗ[ℝ] _)
+                                 else (ψ_lin.symm : EuclideanSpace ℝ (Fin 3) →ₗ[ℝ] _)))
+            (fun j => ((v j).re : ℝ) + ((v j).im : ℝ) * Real.sqrt 2) i := by
+      rcases g with ⟨b, s⟩
+      fin_cases b <;> fin_cases s <;> fin_cases i <;>
+        simp only [applyGen, Bool.true_eq_false, Bool.false_eq_true, ite_true, ite_false,
+                   scaledActPhi_0, scaledActPhi_1, scaledActPhi_2,
+                   scaledActPhiInv_0, scaledActPhiInv_1, scaledActPhiInv_2,
+                   scaledActPsi_0, scaledActPsi_1, scaledActPsi_2,
+                   scaledActPsiInv_0, scaledActPsiInv_1, scaledActPsiInv_2,
+                   Zsqrtd.mul_re, Zsqrtd.mul_im, Zsqrtd.add_re, Zsqrtd.add_im,
+                   φ_lin, ψ_lin, LinearEquiv.ofLinear_apply, LinearEquiv.ofLinear_symm_apply,
+                   Matrix.toEuclideanLin_apply, WithLp.ofLp_toLp,
+                   Matrix.mulVec, Matrix.dotProduct, Fin.sum_univ_three] <;>
+        unfold_let Mφ Mψ <;>
+        simp only [Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+                   Matrix.head_fin_const, Matrix.cons_val_fin_one,
+                   Matrix.transpose_apply, Matrix.of_apply] <;>
+        push_cast <;>
+        nlinarith [hs2, Real.sqrt_nonneg 2,
+                   mul_comm (Real.sqrt 2) ((v 0).im : ℝ),
+                   mul_comm (Real.sqrt 2) ((v 1).im : ℝ),
+                   mul_comm (Real.sqrt 2) ((v 2).im : ℝ)]
+    -- General encoding induction:
+    -- evalWord l v decodes to 3^(n+l.length) * liftF(mk l.reverse) p
+    -- when decode(v) = 3^n * p component-wise.
+    have enc_ind : ∀ (l : List (Bool × Bool)) (v : Fin 3 → Zsqrtd 2)
+        (p : EuclideanSpace ℝ (Fin 3)) (n : ℕ),
+        (∀ i, ((v i).re : ℝ) + ((v i).im : ℝ) * Real.sqrt 2 = 3^n * p i) →
+        ∀ i, ((evalWord l v i).re : ℝ) + ((evalWord l v i).im : ℝ) * Real.sqrt 2 =
+        3^(n + l.length) * (liftF (FreeGroup.mk l.reverse)) p i := by
+      intro l
+      induction l with
+      | nil =>
+        intro v p n hv i
+        simp only [evalWord, List.length_nil, Nat.add_zero, List.reverse_nil,
+                   FreeGroup.lift_mk, List.map_nil, List.prod_nil, map_one,
+                   LinearEquiv.one_apply]
+        exact hv i
+      | cons a as ih =>
+        intro v p n hv i
+        simp only [evalWord, List.length_cons, List.reverse_cons]
+        -- The linear map for generator a
+        let Ma : EuclideanSpace ℝ (Fin 3) →ₗ[ℝ] EuclideanSpace ℝ (Fin 3) :=
+          if a.2 then (if a.1 then (φ_lin : EuclideanSpace ℝ (Fin 3) →ₗ[ℝ] _)
+                               else (ψ_lin : EuclideanSpace ℝ (Fin 3) →ₗ[ℝ] _))
+                 else (if a.1 then (φ_lin.symm : EuclideanSpace ℝ (Fin 3) →ₗ[ℝ] _)
+                               else (ψ_lin.symm : EuclideanSpace ℝ (Fin 3) →ₗ[ℝ] _))
+        -- decode(applyGen a v) = 3^(n+1) * Ma(p) component-wise
+        have hv' : ∀ j, ((applyGen a v j).re : ℝ) + ((applyGen a v j).im : ℝ) * Real.sqrt 2 =
+            3^(n + 1) * Ma p j := by
+          intro j
+          rw [applyGen_decode a v j]
+          -- applyGen_decode gives: 3 * Ma(decode v) j
+          -- decode v = 3^n * p by hv
+          -- Ma is linear: Ma(3^n * p) = 3^n * Ma(p)
+          have hdec : (fun k => ((v k).re : ℝ) + ((v k).im : ℝ) * Real.sqrt 2) = 3^n • p := by
+            funext k; rw [Pi.smul_apply, smul_eq_mul]; exact hv k
+          rw [hdec]
+          simp only [LinearMap.map_smul_of_tower, Pi.smul_apply, smul_eq_mul,
+                     pow_succ]
+          ring
+        -- Apply induction hypothesis for the tail
+        have step := ih (applyGen a v) (Ma p) (n + 1) hv' i
+        rw [step]
+        -- Connect liftF(mk (as.reverse ++ [a])) to Ma ∘ liftF(mk as.reverse)
+        congr 1
+        · -- Exponents: (n+1) + |as| = n + (|as|+1)
+          omega
+        · -- liftF(mk (as.reverse ++ [a])) p = liftF(mk as.reverse) (Ma p)
+          rw [← FreeGroup.mul_mk, map_mul]
+          simp only [FreeGroup.lift_mk, List.map_singleton, List.prod_singleton]
+          simp only [Ma]
+          rcases a with ⟨b, s⟩
+          fin_cases b <;> fin_cases s <;>
+            simp [cond, LinearEquiv.mul_apply]
+    -- Apply enc_ind with l = (toWord w).reverse, n = 0, p = e₂, v = e2Int
+    have henc : ∀ i, ((evalWord (FreeGroup.toWord w).reverse e2Int i).re : ℝ) +
+        ((evalWord (FreeGroup.toWord w).reverse e2Int i).im : ℝ) * Real.sqrt 2 =
         (3 : ℝ)^(FreeGroup.toWord w).length * ((liftF w) e₂ i) := by
-      sorry -- bridge connection: integer orbit ↔ real orbit scaled by 3^n
+      have hmk : liftF w = liftF (FreeGroup.mk (FreeGroup.toWord w)) :=
+        by rw [FreeGroup.mk_toWord]
+      rw [hmk]
+      have hbase : ∀ i, ((e2Int i).re : ℝ) + ((e2Int i).im : ℝ) * Real.sqrt 2 = 3^0 * e₂ i := by
+        intro i
+        fin_cases i <;>
+          simp [e2Int, e₂, EuclideanSpace.single_apply, Pi.single_apply,
+                Zsqrtd.re, Zsqrtd.im]
+      have step := enc_ind (FreeGroup.toWord w).reverse e2Int e₂ 0 hbase
+      simp only [Nat.zero_add, List.length_reverse, List.reverse_reverse] at step
+      exact step
     exact bridge _ hanyInv _ _ henc
   -- Injectivity from the orbit witness
   intro w₁ w₂ hw

--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -18,10 +18,10 @@
       "research"
     ],
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 1342,
-    "assumptions": "2 sorries: (1) integer-real orbit bridge (evalWord toWord encodes 3^n * liftF, ~60 lines induction via irrationality of sqrt 2); (2) banach_tarski main theorem (800+ lines via Hausdorff paradox + AC). All other supporting lemmas fully proved: evalWord_nonempty_labeledInv, FreeGroup.Reduced/Chain bridge, anyInv+encoding contradiction, free_group_not_amenable, int_amenable (Cesaro window-shift), banach_tarski_pieces_nonmeasurable.",
+    "lineCount": 1428,
+    "assumptions": "1 sorry: banach_tarski main theorem (800+ lines via Hausdorff paradox + AC). The integer-real orbit bridge is now fully proved via inductive encoding in ℤ[√2]: applyGen_decode (algebraic step) + enc_ind (induction on word lists) + correct composition-order reversal. All other supporting lemmas fully proved: hausdorff_free_subgroup/orbit_ne (inductive proof via irrationality of sqrt 2 + ℤ[√2] invariant), free_group_not_amenable, int_amenable (Cesaro window-shift), banach_tarski_pieces_nonmeasurable.",
     "dateAdded": "2026-04-22",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -117,7 +117,7 @@
     }
   ],
   "conclusion": {
-    "summary": "The Banach-Tarski paradox is formalized with 2 sorries and 0 axioms. The abstract framework (equidecomposability, paradoxical sets, F₂ non-amenability) is fully proved — including complete machine-checked proofs of paradoxical_no_finite_measure, free_group_not_amenable, int_amenable (ℤ amenable via Cesàro window-shift), and banach_tarski_pieces_nonmeasurable (proved via cardinality contradiction: Borel σ-algebra has ≤ 𝔠 Borel sets while unitBall3 has 2^𝔠 subsets). The 2 remaining sorry theorems are deep established results (Hausdorff 1914 free subgroup, Banach-Tarski 1924 main paradox) whose Lean proofs require 150–800 lines each.",
+    "summary": "The Banach-Tarski paradox is formalized with 1 sorry and 0 axioms. The abstract framework (equidecomposability, paradoxical sets, F₂ non-amenability) is fully proved — including complete machine-checked proofs of paradoxical_no_finite_measure, free_group_not_amenable, int_amenable (ℤ amenable via Cesàro window-shift), banach_tarski_pieces_nonmeasurable, and orbit_ne (the Hausdorff free subgroup freeness: orbit injectivity proved via inductive encoding in ℤ[√2], irrationality of √2, and the mod-3 automaton invariant). The 1 remaining sorry is the full banach_tarski geometric assembly (~800 lines via Hausdorff paradox + Axiom of Choice).",
     "openQuestions": [
       "Can Hausdorff's free subgroup theorem be fully formalized in Lean? The proof requires showing that explicit 3×3 rotation matrices $\\varphi$ (rotation by $\\arccos(1/3)$ around the $z$-axis) and $\\psi$ (rotation by $\\arccos(1/3)$ around the $x$-axis) generate a free group of rank 2 in $\\text{SO}(3)$. The algebraic argument shows that nontrivial words $w(\\varphi, \\psi)$ applied to $e_1 = (1, 0, 0)$ produce vectors with coordinates in $\\mathbb{Z}[1/3, \\sqrt{2}/3]$ that are non-zero — requiring careful case analysis on the word structure and number-theoretic properties of $\\arccos(1/3)$ (specifically that it is not a rational multiple of $\\pi$).",
       "Can the full Banach-Tarski proof be formalized in Lean 4? The most likely modular path: (1) formalize the free subgroup freeness (the sorry in `hausdorff_free_subgroup`); (2) prove the paradoxical decomposition of $F_2$ acting on itself (purely algebraic, ~100 lines); (3) lift to $S^2 \\setminus D$ via the free group action (~150 lines); (4) handle the exceptional set $D$ via a rotation of infinite order (Hilbert hotel, ~100 lines); (5) extend from $S^2$ to $B^3$ by coning and handling the center (~100 lines). Estimated total: 800–1200 lines.",
@@ -212,12 +212,12 @@
       "Mathlib"
     ],
     "namespace": "BanachTarski",
-    "lineCount": 1342,
+    "lineCount": 1428,
     "axiomCount": 0,
     "theoremCount": 51,
     "definitionCount": 5,
     "path": "Proofs/LebesgueMeasureOQ06.lean",
-    "sorries": 2
+    "sorries": 1
   },
-  "sorries": 2
+  "sorries": 1
 }

--- a/src/data/research/problems/lebesgue-measure-oq-06.json
+++ b/src/data/research/problems/lebesgue-measure-oq-06.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ACT: Automaton infrastructure fully compiled (0 sorries in lines 1-517). Remaining: bridge lemma (line 728) + banach_tarski axiomatized (line 785).",
+    "progressSummary": "PROGRESS: orbit_ne proved (sorries 2 to 1). Bridge sorry eliminated via inductive ℤ-sqrt2 encoding with correct composition-order reversal.",
     "builtItems": [
       "Equidecomposable (G-equidecomposability, with notation ≃ᴳ[G]) — proofs/Proofs/LebesgueMeasureOQ06.lean:43",
       "IsParadoxical — proofs/Proofs/LebesgueMeasureOQ06.lean:81",
@@ -54,7 +54,9 @@
       "evalWord_nonempty_anyInv: main automaton theorem :499",
       "orbit_ne: structured proof replacing big sorry :639",
       "evalWord_nonempty_labeledInv: automaton induction (0 sorries) — fixed e2Int_no_inv, base_psi, base_psi_inv, hnocancel proofs :465",
-      "getLast!_mem_getLast?: helper lemma (induction, 0 sorries) connecting getLast! to getLast? for nonempty lists :473"
+      "getLast!_mem_getLast?: helper lemma (induction, 0 sorries) connecting getLast! to getLast? for nonempty lists :473",
+      "applyGen_decode: algebraic lemma — applyGen(g,v) decoded = 3 * M_g(decoded v), 12 cases by fin_cases, closed by nlinarith",
+      "enc_ind: induction on word lists — evalWord l v decodes to 3^(n+|l|) * liftF(mk l.reverse)(p) when decode(v)=3^n*p"
     ],
     "insights": [
       "Banach-Tarski NOT in Mathlib as of 2026-04 — confirmed via search. Available Mathlib pieces: Matrix.orthogonalGroup, FreeGroup, IsometryEquiv, EuclideanSpace.",
@@ -75,7 +77,9 @@
       "Automaton invariant (anyInv) is preserved by all 12 valid transitions and violated by e2Int, giving the orbit separation",
       "The orbit_ne sorry decomposes into 3 sub-sorries: (a) FreeGroup.Reduced->Chain trivial, (b) anyInv+encoding contradiction ~20 lines via sqrt2 irrationality, (c) integer-real bridge ~60 lines induction on toWord",
       "labeledInv tracks the SPECIFIC last-generator invariant, which is needed for the no-cancel step in the induction",
-      "Automaton section (lines 1-517) is now fully sorry-free. Key fixes: (1) full simp beats simp only + dsimp + norm_num for Zsqrtd projections; (2) refine-split + simp per conjunct works for multi-conjunct goals; (3) custom induction on getLast! vs getLast? avoids missing API; (4) direct application of chain_append junction avoids simp on head?_nil"
+      "Automaton section (lines 1-517) is now fully sorry-free. Key fixes: (1) full simp beats simp only + dsimp + norm_num for Zsqrtd projections; (2) refine-split + simp per conjunct works for multi-conjunct goals; (3) custom induction on getLast! vs getLast? avoids missing API; (4) direct application of chain_append junction avoids simp on head?_nil",
+      "Composition order mismatch: evalWord l applies letters left-to-right (leftmost=innermost), while liftF(mk l) applies leftmost last. Fix: use l.reverse so evalWord l.reverse encodes liftF(mk l)",
+      "Reversing a reduced word preserves reducedness: the no-cancel condition is symmetric since a.2=!b.2 iff b.2=!a.2"
     ],
     "mathlibGaps": [
       "Banach-Tarski theorem itself not in Mathlib (no formalization as of 2026-04)",
@@ -84,9 +88,7 @@
       "Amenability for infinite groups not in Mathlib (FolnerCondition exists but Cesaro mean construction not)"
     ],
     "nextSteps": [
-      "Prove bridge sorry (line 728): evalWord (toWord w) e2Int scaled by 3^n = liftF w applied to e2 — induction on toWord length with scaledAct = 3 * M_L",
-      "Prove hred_word (sorry in orbit_ne): FreeGroup.toWord_reduced gives Reduced, convert to Chain",
-      "banach_tarski (line 785) remains axiomatized — full proof requires F2 paradoxical decomposition + SO(3) orbit lift"
+      "Only remaining sorry: banach_tarski main theorem (~800 lines via Hausdorff paradox + AC — intentionally axiomatized)"
     ]
   },
   "tags": [
@@ -184,11 +186,11 @@
     {
       "path": "Proofs/LebesgueMeasureOQ06.lean",
       "filename": "LebesgueMeasureOQ06.lean",
-      "lineCount": 1287,
+      "lineCount": 1429,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 7,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LebesgueMeasureOQ06.lean"
     },


### PR DESCRIPTION
## Summary

- Updates knowledge.json progressSummary to reflect orbit_ne proved (sorries 2→1)
- Records applyGen_decode and enc_ind as built items
- Documents composition-order reversal insight and reducedness symmetry

Follows from #12953 (proof commit, already merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)