### PR TITLE
fix(meta): sync meta.leanFile.theoremCount for shapley-folkman (8→12)

### DIFF
--- a/src/data/proofs/shapley-folkman/meta.json
+++ b/src/data/proofs/shapley-folkman/meta.json
@@ -75,7 +75,7 @@
       "namespace": "ShapleyFolkman",
       "lineCount": 1238,
       "axiomCount": 0,
-      "theoremCount": 8,
+      "theoremCount": 12,
       "definitionCount": 2
     },
     "relatedProblems": []


### PR DESCRIPTION
## Fix

Corrects stale `meta.leanFile.theoremCount` in `shapley-folkman/meta.json`. The value was 8 (public theorems only) but should be 12 (including 4 private lemmas).

## Evidence

**Before**: `"theoremCount": 8`
**After**: `"theoremCount": 12`

Private lemmas that were not counted:
- `binary_repr_of_mem_convexHull_not_mem` (line 123)
- `minCaraDepth_le_of_repr` (line 171)
- `minCaraDepth_ge_two` (line 179)
- `binary_repr_depth` (line 205)

This field is read by `scripts/peer-reviewer/find-targets.ts` (via `proofMeta.leanFile.theoremCount`) to assess proof complexity for peer review targeting.

This is the same class of fix as bd6f14aa575 which corrected `leanFile.theoremCount` for 18 entries — `shapley-folkman` was missed in that batch.

---
Automated fix by lean-mechanic agent.