### PR TITLE
fix(meta): sync leanFile fields for ballot-problem-oq-03-oq-01-oq-02

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -91,9 +91,9 @@
       "LGV"
     ],
     "namespace": "HookLengthFormula",
-    "lineCount": 13784,
+    "lineCount": 13796,
     "axiomCount": 0,
-    "sorries": 4,
+    "sorries": 3,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",
     "theoremCount": 464,
     "definitionCount": 14


### PR DESCRIPTION
## Summary

Stale metadata fix for `ballot-problem-oq-03-oq-01-oq-02/meta.json`.

PR #12965 reduced the sorry count from 4→3 by proving `hook_length_formula` via alias, and updated `meta.sorries` and the Lean file accordingly. However, the `leanFile` sub-section was not synced at the same time.

Changes:
- `leanFile.sorries`: 4 → 3 (matches `meta.sorries` and actual Lean file)
- `leanFile.lineCount`: 13784 → 13796 (matches current line count of `proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean` at HEAD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)