### PR TITLE
fix(meta): add missing sorries and leanFile fields to 6 proofs

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-04/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-04/meta.json
@@ -122,5 +122,14 @@
       "relationship": "related",
       "description": "Sibling: Cantor's 1874 height function proof. Both the height function (for countability) and Baker's theorem (for transcendence) use degree-based measures of algebraic numbers."
     }
-  ]
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/AlgebraicNumbersCountableOQ04.lean",
+    "lineCount": 640,
+    "theoremCount": 12,
+    "definitionCount": 0,
+    "axiomCount": 4,
+    "sorries": 0
+  }
 }

--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -193,5 +193,14 @@
       "venue": "Oxford University Press, 2nd edition",
       "note": "Comprehensive modern reference for symmetric function theory including Newton-Girard identities, power sum symmetric functions, and their role in algebraic combinatorics"
     }
-  ]
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01OQ01.lean",
+    "lineCount": 133,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "axiomCount": 0,
+    "sorries": 0
+  }
 }

--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01/meta.json
@@ -153,5 +153,14 @@
       "year": "1707",
       "note": "Newton's identities relating power sums to elementary symmetric polynomials. The n=2 case p₂ = e₁² - 2e₂ and n=3 case p₃ = e₁p₂ - e₂p₁ + 3e₃ are proved explicitly here."
     }
-  ]
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01.lean",
+    "lineCount": 91,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "axiomCount": 0,
+    "sorries": 0
+  }
 }

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -142,5 +142,14 @@
       "relationship": "sibling",
       "description": "The multinomial distribution OQ-02 chain. This entry resolves a sub-question about Fintype infrastructure needed to formalize the full multinomial PMF in Lean 4."
     }
-  ]
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/BinomialTheoremOQ02OQ01OQ01OQ01.lean",
+    "lineCount": 185,
+    "theoremCount": 5,
+    "definitionCount": 3,
+    "axiomCount": 0,
+    "sorries": 0
+  }
 }

--- a/src/data/proofs/erdos-1-wip-01/meta.json
+++ b/src/data/proofs/erdos-1-wip-01/meta.json
@@ -196,5 +196,14 @@
       "year": "ongoing",
       "venue": "The On-Line Encyclopedia of Integer Sequences"
     }
-  ]
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/Erdos1WIP01.lean",
+    "lineCount": 319,
+    "theoremCount": 13,
+    "definitionCount": 0,
+    "axiomCount": 0,
+    "sorries": 0
+  }
 }

--- a/src/data/proofs/newton-inductive-step-oq-03/meta.json
+++ b/src/data/proofs/newton-inductive-step-oq-03/meta.json
@@ -144,5 +144,14 @@
       "relationship": "related",
       "description": "OQ-02 formalizes Newton's inequality for general symmetric polynomials; OQ-03 focuses on the q-analog setting"
     }
-  ]
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/NewtonInductiveStepOQ03.lean",
+    "lineCount": 231,
+    "theoremCount": 9,
+    "definitionCount": 2,
+    "axiomCount": 0,
+    "sorries": 0
+  }
 }


### PR DESCRIPTION
## Fix

Six proofs used the old metadata format with `sorries` nested inside `meta{}` but no top-level `sorries` field or `leanFile` section. All 6 are verified/axiomatized with 0 actual sorries in their Lean files.

## Evidence

**Before**: No top-level `sorries` field, no `leanFile` section.

**After**: `sorries: 0` at top level + `leanFile` section with lineCount, theoremCount, definitionCount, axiomCount, sorries.

## Proofs Updated

| Proof | Lines | Theorems | Axioms | Status |
|-------|-------|----------|--------|--------|
| amgm-inequality-oq-02-oq-01-oq-02-oq-01 | 91 | 3 | 0 | verified |
| newton-inductive-step-oq-03 | 231 | 9 | 0 | verified |
| binomial-theorem-oq-02-oq-01-oq-01-oq-01 | 185 | 5 | 0 | verified |
| algebraic-numbers-countable-oq-04 | 640 | 12 | 4 | axiomatized |
| erdos-1-wip-01 | 319 | 13 | 0 | verified |
| amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01 | 133 | 4 | 0 | verified |

## Validation

`pnpm build` passes without errors.

---
Automated fix by lean-mechanic agent.