### PR TITLE
audit: re-audit 40 proofs, all clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -305,9 +305,9 @@
       "result": "clean"
     },
     "angle-trisection-oq-02-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T09:33:04Z",
+      "lastAudited": "2026-04-26T17:39:26Z",
       "result": "clean"
     },
     "angle-trisection-oq-02-oq-03": {
@@ -10071,9 +10071,9 @@
     },
     "erdos-924": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T17:43:52Z",
+      "result": "clean"
     },
     "erdos-925": {
       "agentId": "auditor-cycle-20-batch",
@@ -10113,9 +10113,9 @@
     },
     "erdos-930": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T17:43:52Z",
+      "result": "clean"
     },
     "erdos-931": {
       "agentId": "auditor-cycle-20-batch",
@@ -10131,15 +10131,15 @@
     },
     "erdos-933": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-26T17:43:52Z",
+      "result": "clean"
     },
     "erdos-934": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T17:43:52Z",
+      "result": "clean"
     },
     "erdos-935": {
       "agentId": "auditor-cycle-20-batch",
@@ -10155,9 +10155,9 @@
     },
     "erdos-937": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T17:43:52Z",
+      "result": "clean"
     },
     "erdos-938": {
       "auditCount": 3,
@@ -10167,9 +10167,9 @@
     },
     "erdos-939": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T17:43:52Z",
+      "result": "clean"
     },
     "erdos-94": {
       "agentId": "auditor-cycle-20-batch",
@@ -10178,10 +10178,10 @@
       "result": "clean"
     },
     "erdos-94-oq-02": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-26T17:43:52Z",
+      "result": "clean"
     },
     "erdos-940": {
       "agentId": "auditor-cycle-20-batch",
@@ -10197,15 +10197,15 @@
     },
     "erdos-942": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T17:43:52Z",
+      "result": "clean"
     },
     "erdos-943": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T17:43:52Z",
+      "result": "clean"
     },
     "erdos-944": {
       "agentId": "auditor-cycle-20-batch",
@@ -10227,15 +10227,15 @@
     },
     "erdos-947": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T17:43:52Z",
+      "result": "clean"
     },
     "erdos-948": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T17:43:33Z",
+      "result": "clean"
     },
     "erdos-949": {
       "agentId": "auditor-cycle-20-batch",
@@ -10251,9 +10251,9 @@
     },
     "erdos-950": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T17:43:34Z",
+      "result": "clean"
     },
     "erdos-951": {
       "agentId": "auditor-cycle-20-batch",
@@ -10287,9 +10287,9 @@
     },
     "erdos-956": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T17:43:33Z",
+      "result": "clean"
     },
     "erdos-957": {
       "agentId": "auditor-cycle-20-batch",
@@ -10341,9 +10341,9 @@
     },
     "erdos-964": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T17:43:33Z",
+      "result": "clean"
     },
     "erdos-965": {
       "agentId": "auditor-cycle-20-batch",
@@ -10353,27 +10353,27 @@
     },
     "erdos-966": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T17:43:33Z",
+      "result": "clean"
     },
     "erdos-967": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T17:43:33Z",
+      "result": "clean"
     },
     "erdos-968": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T17:43:33Z",
+      "result": "clean"
     },
     "erdos-969": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T17:43:33Z",
+      "result": "clean"
     },
     "erdos-97": {
       "agentId": "auditor-cycle-20-batch",
@@ -10383,9 +10383,9 @@
     },
     "erdos-970": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T17:43:33Z",
+      "result": "clean"
     },
     "erdos-971": {
       "agentId": "auditor-cycle-20-batch",
@@ -10407,9 +10407,9 @@
     },
     "erdos-974": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T17:43:33Z",
+      "result": "clean"
     },
     "erdos-975": {
       "agentId": "auditor-cycle-20-batch",
@@ -10419,22 +10419,22 @@
     },
     "erdos-976": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T17:43:12Z",
+      "result": "clean"
     },
     "erdos-977": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-04T23:23:29Z",
+      "lastAudited": "2026-04-26T17:43:12Z",
       "result": "clean"
     },
     "erdos-978": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T17:42:37Z",
+      "result": "clean"
     },
     "erdos-979": {
       "agentId": "auditor-cycle-20-batch",
@@ -10456,33 +10456,33 @@
     },
     "erdos-981": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T17:43:15Z",
+      "result": "clean"
     },
     "erdos-982": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T17:43:12Z",
+      "result": "clean"
     },
     "erdos-983": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:19:29Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T17:43:12Z",
       "result": "clean"
     },
     "erdos-984": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T17:42:14Z",
+      "result": "clean"
     },
     "erdos-985": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T17:42:22Z",
+      "result": "clean"
     },
     "erdos-986": {
       "agentId": "auditor-cycle-20-batch",
@@ -10504,15 +10504,15 @@
     },
     "erdos-989": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T17:41:34Z",
+      "result": "clean"
     },
     "erdos-99": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T17:41:58Z",
+      "result": "clean"
     },
     "erdos-990": {
       "agentId": "auditor-cycle-20-batch",
@@ -10522,39 +10522,39 @@
     },
     "erdos-991": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T17:41:42Z",
+      "result": "clean"
     },
     "erdos-992": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T17:42:06Z",
+      "result": "clean"
     },
     "erdos-993": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T17:41:17Z",
+      "result": "clean"
     },
     "erdos-994": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T17:40:47Z",
+      "result": "clean"
     },
     "erdos-995": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T17:41:26Z",
+      "result": "clean"
     },
     "erdos-996": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T17:41:00Z",
+      "result": "clean"
     },
     "erdos-997": {
       "agentId": "auditor-cycle-20-batch",
@@ -10564,9 +10564,9 @@
     },
     "erdos-998": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T17:41:10Z",
+      "result": "clean"
     },
     "erdos-999": {
       "agentId": "auditor-cycle-20-batch",
@@ -11450,10 +11450,10 @@
       "result": "clean"
     },
     "isoperimetric-theorem-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-26T17:40:34Z",
+      "result": "clean"
     },
     "isosceles-triangle": {
       "agentId": "auditor-cycle-20-batch",
@@ -11777,9 +11777,9 @@
     },
     "liouville-theorem": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T17:40:21Z",
+      "result": "clean"
     },
     "liouville-theorem-oq-04": {
       "auditCount": 1,
@@ -11995,10 +11995,10 @@
       "result": "clean"
     },
     "partition-theorem-oq-03": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-26T17:40:09Z",
+      "result": "clean"
     },
     "pascals-hexagon": {
       "auditCount": 3,


### PR DESCRIPTION
## Summary
- Re-audited 40 proofs (angle-trisection, partition-theorem, liouville-theorem, isoperimetric, erdős-900s series)
- All 40 passed integrity checks: sorry count, axiom count, True stubs, status/badge alignment
- Audit tracker updated with fresh timestamps

## Checks Performed
- Sorry count: meta.json vs actual Lean source (via `git show HEAD`)
- Axiom count: `^axiom ` declarations in source
- True stubs: `:= trivial` / `: True :=` patterns
- Status/badge consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)