### PR TITLE
fix(meta): add missing leanFile fields to 4 more proofs

### DIFF
--- a/src/data/proofs/area-of-circle-oq-05-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-02/meta.json
@@ -117,5 +117,13 @@
       "Can the result be extended to the complex case (Hermitian positive-definite matrices over ℂ)?"
     ]
   },
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/AreaOfCircleOQ05OQ02.lean",
+    "lineCount": 189,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "axiomCount": 0,
+    "sorries": 0
+  }
 }

--- a/src/data/proofs/dissection-of-cubes-oq-04/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-04/meta.json
@@ -174,5 +174,13 @@
       "description": "The Platonic solids gallery entry provides context on Euler's formula V-E+F=2 and the classification of regular polyhedra."
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/DissectionOfCubesOQ04.lean",
+    "lineCount": 557,
+    "theoremCount": 15,
+    "definitionCount": 4,
+    "axiomCount": 1,
+    "sorries": 0
+  }
 }

--- a/src/data/proofs/fair-games-theorem-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/fair-games-theorem-oq-02-oq-01-oq-01/meta.json
@@ -173,5 +173,13 @@
       "description": "Random walk and martingale theory. The zero-mean corollary here (wald_zero_mean_gives_zero_drift) is the total-drift companion to the OST's terminal-value result."
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/FairGamesTheoremOQ02OQ01OQ01.lean",
+    "lineCount": 361,
+    "theoremCount": 10,
+    "definitionCount": 1,
+    "axiomCount": 0,
+    "sorries": 0
+  }
 }

--- a/src/data/proofs/minkowski-fundamental-theorem-oq-04/meta.json
+++ b/src/data/proofs/minkowski-fundamental-theorem-oq-04/meta.json
@@ -151,5 +151,13 @@
       "description": "The classical Minkowski's theorem (convex body theorem). Both proofs use lattice geometry but at different levels of abstraction."
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/MinkowskiFundamentalTheoremOQ04.lean",
+    "lineCount": 192,
+    "theoremCount": 10,
+    "definitionCount": 3,
+    "axiomCount": 0,
+    "sorries": 0
+  }
 }


### PR DESCRIPTION
## Fix

Four proofs were using the old metadata format with `leanFile` data embedded inside `meta{}` but no top-level `leanFile` section.

## Evidence

**Before**: `leanFile` field absent.
**After**: `leanFile` section added to each with path, lineCount, theoremCount, definitionCount, axiomCount, and sorries — all verified against the actual Lean source files.

Companion to #12974 which fixed 6 proofs with the same pattern.

---
Automated fix by lean-mechanic agent.