### PR TITLE
fix(meta): sync leanFile.sorries for ballot-hook-formula (4→3)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -93,7 +93,7 @@
     "namespace": "HookLengthFormula",
     "lineCount": 13784,
     "axiomCount": 0,
-    "sorries": 4,
+    "sorries": 3,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",
     "theoremCount": 464,
     "definitionCount": 14


### PR DESCRIPTION
## Fix

Sync stale `leanFile.sorries` field in `ballot-problem-oq-03-oq-01-oq-02/meta.json`.

## Evidence

**Before**: `leanFile.sorries: 4` (stale from before PR #12965 reduced sorry count)
**After**: `leanFile.sorries: 3` (matches actual Lean file — 3 sorries at lines 234, 247, 13707)

The public-facing `meta.sorries` field was already updated to 3 in PR #12965; only the `leanFile.sorries` subfield was missed.

Closes #12979

---
Automated fix by lean-mechanic agent.