### PR TITLE
fix(meta): correct erdos-991 originalContributions — brauchart_bound is commentary, not axiom

### DIFF
--- a/src/data/proofs/erdos-991/meta.json
+++ b/src/data/proofs/erdos-991/meta.json
@@ -56,7 +56,7 @@
       "normalizedCapArea: cap area normalized to [0,1]",
       "capCount: count of points in a cap",
       "HasSmallDiscrepancy: o(n) discrepancy property",
-      "brauchart_bound axiom: O(n^{3/4}) discrepancy bound",
+      "Brauchart (2008) O(n^{3/4}) bound documented in comments (not formalized as axiom)",
       "marzo_mas_bound axiom: improved O(n^{2/3}) bound",
       "erdos_991 theorem: main qualitative result",
       "FeketePoints: optimal configurations for n points",
@@ -122,10 +122,10 @@
     {
       "id": "brauchart-bound",
       "title": "Brauchart's Bound (2008)",
-      "summary": "brauchart_bound axiom: O(n^{3/4}) discrepancy",
+      "summary": "Brauchart (2008) O(n^{3/4}) discrepancy bound (documented in comments)",
       "startLine": 140,
       "endLine": 160,
-      "mathContext": "brauchart_bound axiom: $O(n^{3/4})$ discrepancy"
+      "mathContext": "Brauchart (2008) $O(n^{3/4})$ discrepancy bound — documented in comments, not formalized as axiom"
     },
     {
       "id": "marzo-mas-bound",


### PR DESCRIPTION
## Fix

Remove false claim that `brauchart_bound` is an axiom in the Lean source for `erdos-991`.

## Evidence

**Before**: `originalContributions` listed `"brauchart_bound axiom: O(n^{3/4}) discrepancy bound"` implying an `axiom brauchart_bound` declaration exists.

**After**: Entry updated to `"Brauchart (2008) O(n^{3/4}) bound documented in comments (not formalized as axiom)"`.

**Lean file reality**: The Brauchart (2008) section (lines 140–160 of `Proofs/Erdos991Problem.lean`) contains only comment blocks — no `axiom brauchart_bound` declaration. The file has exactly one axiom: `marzo_mas_bound` at line 168. The `leanFile.axiomCount: 1` was already correct.

Also updated the `brauchart-bound` section `summary` and `mathContext` to clarify it is commentary only.

Closes #12982

---
Automated fix by lean-mechanic agent.