### PR TITLE
fix(meta): sync hurwitz-theorem-oq-04 meta.json (2 sorries, 0 axioms, 1052 lines)

### DIFF
--- a/src/data/proofs/hurwitz-theorem-oq-04/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-04/meta.json
@@ -18,13 +18,13 @@
       "advanced"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 2,
     "dateAdded": "2026-04-24",
-    "axiomCount": 1,
-    "assumptions": "1 axiom: G2_der_dimension (finrank ℝ OctonionDerSubmodule = 14). Previous G2_is_octonion_aut (Nat.card OctonionAut = 14) was replaced: Nat.card of an infinite Lie group equals 0 in type theory, making it mathematically incorrect. G2_der_dimension targets the Lie algebra dimension directly. All supporting lemmas fully proved.",
-    "lineCount": 822,
-    "theoremCount": 35,
-    "definitionCount": 17,
+    "axiomCount": 0,
+    "assumptions": "0 axiom declarations; 2 sorries in private helper lemmas (derEval14_injective, derBasis14_linearIndependent). G2_der_dimension (finrank ℝ Der(𝕆) = 14) depends on these sorry'd lemmas.",
+    "lineCount": 1052,
+    "theoremCount": 27,
+    "definitionCount": 34,
     "originalContributions": [
       "OctonionAlgHom / OctonionAut: structures for octonion algebra homomorphisms and automorphisms",
       "alg_aut_preserves_norm: automorphisms preserve the norm (proved via polarization and imaginary decomposition)",
@@ -137,11 +137,11 @@
       "HurwitzTheorem"
     ],
     "namespace": "HurwitzTheoremOQ04",
-    "lineCount": 822,
-    "axiomCount": 1,
-    "theoremCount": 40,
-    "definitionCount": 15,
-    "sorries": 0,
+    "lineCount": 1052,
+    "axiomCount": 0,
+    "theoremCount": 27,
+    "definitionCount": 34,
+    "sorries": 2,
     "path": "Proofs/HurwitzTheoremOQ04.lean"
   },
   "crossReferences": [
@@ -156,5 +156,5 @@
       "description": "Sibling open question: n-square identities and normed division algebras"
     }
   ],
-  "sorries": 0
+  "sorries": 2
 }


### PR DESCRIPTION
## Summary

- Corrects stale metadata in `src/data/proofs/hurwitz-theorem-oq-04/meta.json` to match the actual Lean source at `proofs/Proofs/HurwitzTheoremOQ04.lean` (HEAD).
- `meta.sorries` and `leanFile.sorries`: 0 → 2 (two tactic `sorry`s in private lemmas `derEval14_injective` and `derBasis14_linearIndependent`)
- `meta.axiomCount` and `leanFile.axiomCount`: 1 → 0 (no `axiom` keyword declarations; `G2_der_dimension` is a theorem depending on sorry'd helpers, not an axiom)
- `meta.assumptions`: updated to accurately describe the 2 sorry'd helper lemmas
- `leanFile.lineCount`: 822 → 1052
- `leanFile.theoremCount`: 40 → 27
- `leanFile.definitionCount`: 15 → 34
- Top-level `sorries`: 0 → 2

## Test plan

- [ ] Verify `meta.sorries == leanFile.sorries == 2`
- [ ] Verify `meta.axiomCount == leanFile.axiomCount == 0`
- [ ] Verify `leanFile.lineCount == 1052`
- [ ] Confirm `status` remains `"axiomatized"` (sorries present) and `badge` remains `"axiom"` (both accurate given sorry'd helpers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)