### PR TITLE
research(ballot-jt): fix false jdt_weight_sum + OQ03OQ02 regression

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
@@ -370,7 +370,7 @@ Lean estimate: ~200 lines for steps (1)-(3). The bijection proof is the hard cor
       Q' := Q.underlying - {Q.sort[c]}  (multiset-erase)
     Weight-preserved: wt(P)*wt(Q) = wt(P+{v})*wt(Q-{v}) by Multiset.prod_erase.
     Surjective: every (P', Q') has a unique preimage (find the "seam" element in P'.sort). -/
-private lemma jdt_weight_sum (n a b : ℕ) :
+private lemma jdt_weight_sum (n a b : ℕ) (hba : b ≤ a) :
     ∑ PQ : { PQ : Sym (Fin n) a × Sym (Fin n) b // ¬ColStrictSym a b PQ.1 PQ.2 },
       (PQ.1.1.1.map (X : Fin n → MvPolynomial (Fin n) R)).prod *
       (PQ.1.2.1.map (X : Fin n → MvPolynomial (Fin n) R)).prod =
@@ -529,7 +529,7 @@ private lemma sym_pair_sum_partition (n a b : ℕ) :
     2. ∑_{col-strict} + ∑_{¬col-strict} = h_a*h_b  [sym_pair_sum_partition]
     3. ∑_{¬col-strict} = h_{a+1}*h_{b-1}         [jdt_weight_sum]
     4. ∑_{col-strict} = h_a*h_b - h_{a+1}*h_{b-1} = schurPolynomial 2 sh [algebra] -/
-theorem ssytSchurFin_two_row (n : ℕ) (sh : Fin 2 → ℕ) :
+theorem ssytSchurFin_two_row (n : ℕ) (sh : Fin 2 → ℕ) (hsh : sh 1 ≤ sh 0) :
     ssytSchurFin (R := R) n 2 sh =
     schurPolynomial (σ := Fin n) (R := R) 2 sh := by
   set a := sh 0 with ha
@@ -549,7 +549,7 @@ theorem ssytSchurFin_two_row (n : ℕ) (sh : Fin 2 → ℕ) :
   -- jdt_weight_sum:         ∑_{¬col-strict} = h_{a+1} * (if 1 ≤ b then h_{b-1} else 0)
   -- Therefore:              ∑_{col-strict} = h_a * h_b - h_{a+1} * ...
   exact eq_sub_of_add_eq
-    (jdt_weight_sum (R := R) n a b ▸ sym_pair_sum_partition (R := R) n a b)
+    (jdt_weight_sum (R := R) n a b hsh ▸ sym_pair_sum_partition (R := R) n a b)
 
 /-
 ### Main Theorem: Jacobi-Trudi = SSYT Sum (Open for k ≥ 3)
@@ -567,26 +567,27 @@ theorem ssytSchurFin_two_row (n : ℕ) (sh : Fin 2 → ℕ) :
         (1) algebraic_lgv: for ring-valued weighted DAG, det(weight_matrix) = ∑_NI ∏ weights
         (2) RSK: SSYTFin n k sh ↔ NI tuples of 1-row SSYTs (the Jacobi-Trudi LGV config)
         (3) Weight match: SSYT weight = NI-tuple weight -/
-theorem jacobi_trudi_ssyt_eq (n k : ℕ) (sh : Fin k → ℕ) :
+theorem jacobi_trudi_ssyt_eq (n k : ℕ) (sh : Fin k → ℕ) (hsh : Antitone sh) :
     JacobiTrudi.schurPolynomial (σ := Fin n) (R := R) k sh =
     ssytSchurFin (R := R) n k sh := by
   cases k with
   | zero =>
     -- k = 0: empty partition; both sides = 1.
-    have hsh : sh = Fin.elim0 := funext (fun i => i.elim0)
-    rw [hsh, schurPolynomial_empty, ssytSchurFin_empty]
+    have hsh0 : sh = Fin.elim0 := funext (fun i => i.elim0)
+    rw [hsh0, schurPolynomial_empty, ssytSchurFin_empty]
   | succ k =>
     cases k with
     | zero =>
       -- k = 1: one-row partition.
-      have hsh : sh = fun _ => sh ⟨0, Nat.lt_succ_self 0⟩ :=
+      have hsh1 : sh = fun _ => sh ⟨0, Nat.lt_succ_self 0⟩ :=
         funext (fun i => by fin_cases i <;> rfl)
-      rw [hsh, schurPolynomial_one_row, ssytSchurFin_one_row]
+      rw [hsh1, schurPolynomial_one_row, ssytSchurFin_one_row]
     | succ k =>
       cases k with
       | zero =>
         -- k = 2: two-row case, proved by jdt bijection.
-        exact (ssytSchurFin_two_row n sh).symm
+        -- hsh : Antitone sh gives sh 1 ≤ sh 0 (the partition condition).
+        exact (ssytSchurFin_two_row n sh (hsh (by decide : (0 : Fin 2) ≤ 1))).symm
       | succ k =>
         -- k ≥ 3: requires algebraic LGV + RSK (~300 lines).
         --

--- a/proofs/Proofs/BallotProblemOQ03OQ02.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ02.lean
@@ -2367,7 +2367,7 @@ private theorem gvCanon_self_inverse {r : ℕ} (cfg : LGVConfig r) (hwf : cfg.we
       have h2 : ((t.2 cj).val.take kj ++ (t.2 ci).val.drop ki).drop kj =
                 (t.2 ci).val.drop ki := by
         have hkj_drop : ((t.2 cj).val.take kj).drop kj = [] := by
-          rw [← List.length_take_of_le hkj_le]; exact List.drop_length
+          nth_rw 2 [← List.length_take_of_le hkj_le]; exact List.drop_length
         rw [List.drop_append, List.length_take_of_le hkj_le, Nat.sub_self,
             List.drop_zero, hkj_drop, List.nil_append]
       rw [h1, h2, List.take_append_drop]
@@ -2383,7 +2383,7 @@ private theorem gvCanon_self_inverse {r : ℕ} (cfg : LGVConfig r) (hwf : cfg.we
         have h2 : ((t.2 ci).val.take ki ++ (t.2 cj).val.drop kj).drop ki =
                   (t.2 cj).val.drop kj := by
           have hki_drop : ((t.2 ci).val.take ki).drop ki = [] := by
-            rw [← List.length_take_of_le hki_le]; exact List.drop_length
+            nth_rw 2 [← List.length_take_of_le hki_le]; exact List.drop_length
           rw [List.drop_append, List.length_take_of_le hki_le, Nat.sub_self,
               List.drop_zero, hki_drop, List.nil_append]
         rw [h1, h2, List.take_append_drop]

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/knowledge.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/knowledge.md
@@ -8,6 +8,62 @@ Insights accumulated during research on this problem.
 
 ---
 
+## Session 2026-04-26 (Session 9) — jdt_weight_sum Bug Fix + Hypothesis Propagation
+
+**Mode**: REVISIT (RICH knowledge tier, score 71)
+**Outcome**: PROGRESS — false statement corrected; hypothesis `b ≤ a` added; BallotProblemOQ03OQ02 regression fixed
+
+### What I Did
+
+1. **Discovered `jdt_weight_sum` is FALSE as stated**: The lemma claimed
+   `∑_{non-cs (P:a, Q:b)} wt = h_{a+1} * h_{b-1}` for ANY `a, b`. Counterexample:
+   - a=0, b=1: LHS = 0 (no non-cs pairs since min(a,b)=0 makes col-strict vacuous), RHS = h₁ ≠ 0
+   - a=1, b=2: LHS = X₀³ + 2X₀²X₁ + X₀X₁² + X₁³, RHS = h₂h₁ = X₀³ + 2X₀²X₁ + **2**X₀X₁² + X₁³ ✗
+   - a=2, b=1 (partition case): LHS = RHS = h₃ ✓
+
+2. **Added `(hba : b ≤ a)` to `jdt_weight_sum`**: The JDT bijection is only valid for
+   partition shapes (a ≥ b). Without this condition, the forward map doesn't cover all
+   (a+1, b-1) pairs.
+
+3. **Propagated hypothesis**:
+   - `ssytSchurFin_two_row`: added `(hsh : sh 1 ≤ sh 0)`, passes to `jdt_weight_sum`
+   - `jacobi_trudi_ssyt_eq`: added `(hsh : Antitone sh)`, passes `hsh (by decide : (0:Fin 2) ≤ 1)` for k=2 case
+   - Renamed local `hsh` in k=0, k=1 branches to `hsh0`, `hsh1` to avoid shadowing
+
+4. **Fixed `BallotProblemOQ03OQ02.lean` regression** (lines 2370, 2386):
+   - Old: `rw [← List.length_take_of_le h_le]; exact List.drop_length`
+   - Bug: `rw` rewrote `kj` inside `take kj` too, making `List.drop_length` fail to unify
+   - Fix: `nth_rw 2 [← List.length_take_of_le h_le]; exact List.drop_length`
+   - Effect: only rewrites the count argument of `drop`, leaving the `take` argument unchanged
+
+### Key Findings
+
+- **`jdt_weight_sum` needs partition hypothesis**: The JDT bijection {non-cs (P:a, Q:b)} ≃ {all (P':a+1, Q':b-1)} only works when a ≥ b. For a < b, the non-cs set maps to a PROPER SUBSET of all (a+1, b-1) pairs.
+- **`jacobi_trudi_ssyt_eq` is only true for partitions**: For k=2 with sh=[1,2] (non-partition), the Jacobi-Trudi determinant = 0 but ssytSchurFin n 2 [1,2] ≠ 0 (e.g., for n=2: X₀X₁²). Adding `Antitone sh` fixes this.
+- **OQ03OQ02 regression**: `nth_rw` vs `rw` difference in Lean 4 Mathlib — when a variable appears multiple times, `rw` replaces ALL occurrences while `nth_rw N` replaces only the N-th.
+
+### Files Modified
+
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean` (605 → 606 lines; hypothesis fixes)
+- `proofs/Proofs/BallotProblemOQ03OQ02.lean` (lines 2370, 2386; regression fix)
+
+### Sorry Count: 2 (unchanged — jdt_weight_sum still open, but now CORRECTLY stated)
+
+- `jdt_weight_sum (hba : b ≤ a)`: correct statement, JDT bijection proof pending (~100-150 lines)
+- `jacobi_trudi_ssyt_eq k≥3`: algebraic LGV + RSK (~300 lines) (OPEN)
+
+### Next Steps
+
+1. **Prove `jdt_weight_sum` via JDT bijection**: implement explicit `Equiv` between:
+   - `{(P:Sym n a, Q:Sym n b) // ¬ColStrictSym a b P Q}` ≃ `Sym n (a+1) × Sym n (b-1)`
+   - Forward: find firstViolIdx c; P' = P + {Q.sort[c]}, Q' = Q - {Q.sort[c]}
+   - Inverse: find the "seam" element in P' to move back to Q'
+   - ~120 lines estimated
+2. **Submit to Aristotle**: `jdt_weight_sum` with `hba` is now a HARD sorry; Aristotle may handle it
+3. **`jacobi_trudi_ssyt_eq k≥3`**: needs RSK bijection + LGV, ~300 lines
+
+---
+
 ## Session 2026-04-26 (Session 8) — ssytFin_two_row_eq_sum_colstrict Proved + Missing Defs Added
 
 **Mode**: REVISIT (RICH knowledge tier, score 64)

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: k=0,1,2 SSYT equality proved. 2 sorries: jdt_weight_sum (JDT bijection) + jacobi_trudi_ssyt_eq k≥3 (LGV+RSK)",
+    "progressSummary": "PROGRESS: jdt_weight_sum false statement fixed (b≤a added); hypothesis propagated; BallotProblemOQ03OQ02 regression fixed; 2 sorries remain (jdt_weight_sum open + k≥3 open)",
     "builtItems": [
       "jacobiTrudiMatrix: Matrix (Fin k) (Fin k) (MvPolynomial σ R) — entry (i,j) = hsymm (sh_i + j - i) or 0",
       "schurPolynomial: MvPolynomial σ R = det(jacobiTrudiMatrix) — the Jacobi-Trudi formula as definition",
@@ -65,7 +65,10 @@
       "ssytFin_row_sort_eq_ofFn: sort of ↑(ofFn T.rowi) = ofFn T.rowi when row is monotone (file:BallotProblemOQ03OQ01OQ01OQ01.lean, ~10 lines)",
       "ColStrictSym def + Decidable instance (file:BallotProblemOQ03OQ01OQ01OQ01.lean)",
       "sum_all_sym_pairs: ∑ PQ : Sym n a × Sym n b, prod*prod = h_a * h_b (file:BallotProblemOQ03OQ01OQ01OQ01.lean)",
-      "ssytFin_two_row_eq_sum_colstrict (file:BallotProblemOQ03OQ01OQ01OQ01.lean, ~90 lines)"
+      "ssytFin_two_row_eq_sum_colstrict (file:BallotProblemOQ03OQ01OQ01OQ01.lean, ~90 lines)",
+      "jdt_weight_sum (hba : b ≤ a): correct statement with partition hypothesis",
+      "ssytSchurFin_two_row (hsh : sh 1 ≤ sh 0): partition-aware 2-row theorem",
+      "jacobi_trudi_ssyt_eq (hsh : Antitone sh): partition-aware main theorem"
     ],
     "insights": [
       "Mathlib has hsymm σ R n (complete homogeneous symmetric polynomials) in RingTheory.MvPolynomial.Symmetric.Defs — directly usable for Jacobi-Trudi matrix entries",
@@ -96,7 +99,10 @@
       "rowPair_sum_weight proof: Fintype.sum_prod_type + simp_rw [← Finset.mul_sum] + ← Finset.sum_mul + ssytSchurFin_one_row cleanly factors sum over product type into product of sums",
       "ssytSchurFin_two_row proof pattern: cs = total - ncs; Fintype.sum_subtype_add_sum_subtype splits into cs+ncs=total; eq_sub_of_add_eq closes after substituting rowPair_sum_weight and nonColStrict_sum_weight",
       "ssytFin_two_row_eq_sum_colstrict proved via explicit SSYTFin ≃ colstrict-pair Equiv; uses ssytFin_row_sort_eq_ofFn helper that shows sort of sorted row = same row via mergeSort_eq_self",
-      "ColStrictSym definition: P.sort[j] < Q.sort[j] for all j < min(a,b); Decidable via Fintype.decidableForallFintype; key for separating SSYT contributions by column-strict pairs"
+      "ColStrictSym definition: P.sort[j] < Q.sort[j] for all j < min(a,b); Decidable via Fintype.decidableForallFintype; key for separating SSYT contributions by column-strict pairs",
+      "jdt_weight_sum was FALSE: needs b ≤ a (partition) hypothesis; for a=0,b=1 LHS=0 but RHS=h₁≠0; for a=1,b=2 coefficient differs by X₀X₁²",
+      "jacobi_trudi_ssyt_eq is false for non-partition shapes (e.g. sh=[1,2]: determinant=0 but ssytSchurFin≠0); Antitone hypothesis required",
+      "BallotProblemOQ03OQ02 regression: nth_rw 2 vs rw fixes List.drop_length unification failure (rw rewrites kj inside take kj too)"
     ],
     "mathlibGaps": [
       "No Mathlib SchurPolynomial definition — we provide one via Jacobi-Trudi formula",
@@ -104,10 +110,9 @@
       "RSK correspondence not formalized in Mathlib — needed for jacobiTrudi_lgv_proof"
     ],
     "nextSteps": [
-      "Submit twoRow_equiv and twoRow_equiv_weight to Aristotle (mechanical sorries)",
-      "Implement nonColStrict_sum_weight via jdt bijection: define jdtForward (insert Q[c] into P at violation c), prove it is an Equiv to RowPair (a+1)(b-1), show weight-preserving, apply rowPair_sum_weight",
-      "Once nonColStrict_sum_weight proved, ssytSchurFin_two_row has 0 sorries — only k>=3 remains",
-      "Prove jdt_weight_sum: construct explicit weight-preserving bijection {non-col-strict (a,b)} ≃ {all (a+1,b-1)} via multiset insert/erase; inverse is the seam-finding operation"
+      "Prove jdt_weight_sum via JDT bijection (~120 lines): firstViolIdx + Equiv construction",
+      "Submit jdt_weight_sum to Aristotle as HARD sorry",
+      "jacobi_trudi_ssyt_eq k≥3 requires algebraic LGV + RSK (~300 lines)"
     ],
     "markdown": "# Knowledge Base: LGV Lemma → Jacobi-Trudi Identity\n\n**Problem**: ballot-problem-oq-03-oq-01-oq-01-oq-01\n**Last Updated**: 2026-04-23\n**Knowledge Items**: 0\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\nNewly selected. Jacobi-Trudi identity expresses Schur polynomials as determinants of\ncomplete homogeneous symmetric polynomials. The LGV lemma (in parent gallery proof)\nprovides the combinatorial proof route via non-intersecting lattice paths.\n\n---\n\n## Insights\n\n_None yet — begin with OBSERVE phase: check Mathlib for SSYT formalization._\n\n---\n\n## Dead Ends\n\n_None identified yet._\n"
   },
@@ -300,22 +305,22 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 458,
+      "lineCount": 606,
       "theoremCount": 10,
       "axiomCount": 0,
-      "defCount": 5,
-      "sorryCount": 3,
+      "defCount": 6,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",
       "filename": "BallotProblemOQ03OQ01OQ02.lean",
-      "lineCount": 13639,
+      "lineCount": 14006,
       "theoremCount": 64,
       "axiomCount": 0,
       "defCount": 10,
-      "sorryCount": 10,
+      "sorryCount": 11,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean"
     },


### PR DESCRIPTION
## Summary

- **Bug fix**: `jdt_weight_sum` was stated without the required partition hypothesis `b ≤ a`, making the lemma false for e.g. `a=0,b=1` (LHS=0 but RHS=h₁≠0) and `a=1,b=2` (coefficient mismatch)
- **Hypothesis propagation**: Added `Antitone sh` to `jacobi_trudi_ssyt_eq` and `sh 1 ≤ sh 0` to `ssytSchurFin_two_row`; the Jacobi-Trudi identity only holds for partition shapes
- **Regression fix**: `BallotProblemOQ03OQ02.lean` lines 2370/2386 — changed `rw` to `nth_rw 2` to prevent rewriting `kj` inside `take kj` which caused `List.drop_length` unification failure in Lean 4.26

## Test plan

- [ ] Docker build `Proofs.BallotProblemOQ03OQ01OQ01OQ01` passes (pending)
- [ ] `jdt_weight_sum` sorry still present but now correctly stated with `(hba : b ≤ a)`
- [ ] `jacobi_trudi_ssyt_eq` and `ssytSchurFin_two_row` have correct partition hypothesis

🤖 Generated with [Claude Code](https://claude.com/claude-code)