### PR TITLE
enrich(batch): references, sections, prerequisites for 7 gallery entries (#12992)

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-03/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-03/meta.json
@@ -210,32 +210,39 @@
   ],
   "references": [
     {
-      "authors": "Stewart, Ian",
+      "authors": ["I. Stewart"],
       "title": "Galois Theory",
       "year": "2015",
       "venue": "CRC Press, 4th edition",
       "note": "Chapters 9-12: solvability by radicals, Galois's criterion, and the classical proof of Abel-Ruffini as a corollary"
     },
     {
-      "authors": "Cox, David A.",
+      "authors": ["D. A. Cox"],
       "title": "Galois Theory",
       "year": "2012",
       "venue": "Wiley, 2nd edition",
       "note": "Theorem 13.4.3 (Galois criterion), Theorem 13.1.1 (forward direction), Section 13.4 (Kummer theory for cyclic extensions)"
     },
     {
-      "authors": "Lang, Serge",
+      "authors": ["S. Lang"],
       "title": "Algebra",
       "year": "2002",
       "venue": "Graduate Texts in Mathematics 211, Springer, 3rd revised edition",
       "note": "Chapter VI §7-§9: Galois's solvability criterion, Kummer extensions, and the complete proof of both directions"
     },
     {
-      "authors": "Galois, Évariste",
+      "authors": ["É. Galois"],
       "title": "Mémoire sur les conditions de résolubilité des équations par radicaux",
       "year": "1846",
       "venue": "Journal de mathématiques pures et appliquées (posthumous, ed. Liouville), vol. 11, pp. 381-444",
       "note": "Original memoir presenting the criterion; written 1831, submitted to the Paris Academy, published posthumously 14 years after Galois's death"
+    },
+    {
+      "authors": ["The mathlib Community"],
+      "title": "Mathlib4: A Unified Library of Mathematics Formalized in Lean 4",
+      "year": "2024",
+      "venue": "https://github.com/leanprover-community/mathlib4",
+      "note": "Provides solvableByRad.isSolvable' (forward direction of Galois's criterion), IsSolvable typeclass, and Polynomial.Gal (Galois group construction). The axiomatized reverse direction identifies Kummer theory for cyclic extensions as the principal Mathlib gap."
     }
   ],
   "sorries": 0


### PR DESCRIPTION
Batch enrichment pass across 7 gallery entries (enricher-1 session).

## Entries enriched
1. **abel-ruffini-galois-extensions** — Split combined section into Parts III/IV/V
2. **cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-03** — Added references, prerequisites, expanded sections, annotation
3. **abel-ruffini-oq-04-oq-02-oq-02** — Expanded prerequisites, added section mathContext
4. **abel-ruffini-oq-04-oq-03** — Fixed references format, added Mathlib reference
5. **abel-ruffini-oq-04-oq-07** — Added references, prerequisites, header section
6. **algebraic-numbers-countable** — Fixed references format, added Mathlib reference
7. **algebraic-numbers-countable-oq-02** — Added references array, header section

## Common patterns
- Fixed `references[].authors` from strings to arrays (data consistency)
- Added missing Mathlib references
- Added header sections for entries where sections started mid-file
- Expanded thin `overview.prerequisites` arrays

Build verified: `pnpm build` passes.