### PR TITLE
research(angle-trisection + ballot-problem): tower law + jdt_weight_sum progress

### DIFF
--- a/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean
+++ b/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean
@@ -166,7 +166,24 @@ private lemma isConstructible_algebraic_degree (α : ℂ) (h : IsConstructible �
     --   the simple extension of ↥ℚ⟮a⟯ by β (β generates ℚ⟮β⟯ over the larger ↥ℚ⟮a⟯).
     --   Hence finrank ↥ℚ⟮a⟯ ↥ℚ⟮β⟯ ∣ 2, giving finrank ℚ ℚ⟮β⟯ ∣ 2 * 2^j = 2^(j+1).
     have hβ_dvd : Module.finrank ℚ ↥(ℚ⟮β⟯) ∣ 2 ^ (j + 1) := by
-      sorry
+      -- Tower: ℚ → ℚ⟮a⟯ → ℚ⟮β⟯
+      haveI hAlg_aβ : Algebra ↥(ℚ⟮a⟯) ↥(ℚ⟮β⟯) :=
+        (IntermediateField.inclusion ha_le_β).toAlgebra
+      haveI hST_aβ : IsScalarTower ℚ ↥(ℚ⟮a⟯) ↥(ℚ⟮β⟯) :=
+        IsScalarTower.of_algebraMap_eq (fun r =>
+          Subtype.ext (by simp [RingHom.algebraMap_toAlgebra]))
+      -- Tower law: finrank ℚ ℚ⟮β⟯ = finrank ↥ℚ⟮a⟯ ↥ℚ⟮β⟯ * finrank ℚ ↥ℚ⟮a⟯
+      rw [Module.finrank_mul_finrank ℚ ↥(ℚ⟮a⟯) ↥(ℚ⟮β⟯)]
+      rw [pow_succ]
+      -- Suffices: finrank ↥ℚ⟮a⟯ ↥ℚ⟮β⟯ ∣ 2 and finrank ℚ ↥ℚ⟮a⟯ ∣ 2^j
+      exact Nat.mul_dvd_mul
+        (by -- finrank ↥ℚ⟮a⟯ ↥ℚ⟮β⟯ ∣ 2
+         -- β satisfies X² - a over ℚ⟮a⟯ (since β² = a ∈ ℚ⟮a⟯)
+         -- So minpoly ↥ℚ⟮a⟯ β divides X² - a, giving degree ≤ 2
+         -- For simple extension: finrank = natDegree(minpoly)
+         -- Hence finrank ∣ 2
+         sorry)
+        hj_dvd
     -- Step D (sorry): finrank ℚ (ℚ⟮b⟯ ⊔ ℚ⟮β⟯) ∣ 2^(j+k+1)
     -- Proof plan: tower through ℚ⟮β⟯:
     --   finrank_join = finrank ↥ℚ⟮β⟯ ↥(join) * finrank ℚ ↥ℚ⟮β⟯

--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
@@ -375,7 +375,34 @@ private lemma jdt_weight_sum (n a b : ℕ) (hba : b ≤ a) :
       (PQ.1.1.1.map (X : Fin n → MvPolynomial (Fin n) R)).prod *
       (PQ.1.2.1.map (X : Fin n → MvPolynomial (Fin n) R)).prod =
     hsymm (Fin n) R (a + 1) * (if 1 ≤ b then hsymm (Fin n) R (b - 1) else 0) := by
-  sorry
+  by_cases hb : 1 ≤ b
+  · -- b ≥ 1: JDT bijection
+    simp only [if_pos hb]
+    rw [← sum_all_sym_pairs n (a + 1) (b - 1)]
+    -- Need: weight-preserving bijection
+    --   {non-col-strict (a,b) pairs} ≃ {all (a+1, b-1) pairs}
+    -- Forward map: find first violation c in ColStrictSym, let v = Q.sort[c],
+    --   then P' = Sym.cons v P, Q' = Sym.erase Q v
+    -- Inverse map: find the "seam" element in P'.sort to move back to Q'
+    -- Weight preserved by Multiset.prod_cons + Multiset.prod_erase
+    sorry
+  · -- b = 0: ColStrictSym a 0 P Q is vacuously true (quantifies over Fin (min a 0) = Fin 0)
+    -- So ¬ColStrictSym = False, the subtype is empty, and the sum equals 0
+    push_neg at hb
+    have hb0 : b = 0 := by omega
+    subst hb0
+    -- RHS simplifies: if 1 ≤ 0 then ... else 0 = 0, so h_{a+1} * 0 = 0
+    have hrhs : hsymm (Fin n) R (a + 1) * (if 1 ≤ 0 then hsymm (Fin n) R (0 - 1) else 0) = 0 :=
+      by simp
+    rw [hrhs]
+    -- LHS: every element of the subtype derives False (ColStrictSym a 0 P Q is vacuously true)
+    apply Finset.sum_eq_zero
+    rintro ⟨⟨P, Q⟩, hPQ⟩ -
+    exfalso
+    apply hPQ
+    intro j
+    -- j : Fin (min a 0), and min a 0 = 0, so j.isLt : j.val < 0, which is absurd
+    exact absurd j.isLt (by omega)
 
 /-- Row decomposition: 2-row SSYT generating function = sum over col-strict pairs.
     The bijection φ : SSYTFin n 2 sh ≃ {(P,Q) : ColStrictSym (sh0, sh1) pairs}:

--- a/src/data/proofs/abel-ruffini-oq-04-oq-03/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-03/meta.json
@@ -210,39 +210,32 @@
   ],
   "references": [
     {
-      "authors": ["I. Stewart"],
+      "authors": "Stewart, Ian",
       "title": "Galois Theory",
       "year": "2015",
       "venue": "CRC Press, 4th edition",
       "note": "Chapters 9-12: solvability by radicals, Galois's criterion, and the classical proof of Abel-Ruffini as a corollary"
     },
     {
-      "authors": ["D. A. Cox"],
+      "authors": "Cox, David A.",
       "title": "Galois Theory",
       "year": "2012",
       "venue": "Wiley, 2nd edition",
       "note": "Theorem 13.4.3 (Galois criterion), Theorem 13.1.1 (forward direction), Section 13.4 (Kummer theory for cyclic extensions)"
     },
     {
-      "authors": ["S. Lang"],
+      "authors": "Lang, Serge",
       "title": "Algebra",
       "year": "2002",
       "venue": "Graduate Texts in Mathematics 211, Springer, 3rd revised edition",
       "note": "Chapter VI §7-§9: Galois's solvability criterion, Kummer extensions, and the complete proof of both directions"
     },
     {
-      "authors": ["É. Galois"],
+      "authors": "Galois, Évariste",
       "title": "Mémoire sur les conditions de résolubilité des équations par radicaux",
       "year": "1846",
       "venue": "Journal de mathématiques pures et appliquées (posthumous, ed. Liouville), vol. 11, pp. 381-444",
       "note": "Original memoir presenting the criterion; written 1831, submitted to the Paris Academy, published posthumously 14 years after Galois's death"
-    },
-    {
-      "authors": ["The mathlib Community"],
-      "title": "Mathlib4: A Unified Library of Mathematics Formalized in Lean 4",
-      "year": "2024",
-      "venue": "https://github.com/leanprover-community/mathlib4",
-      "note": "Provides solvableByRad.isSolvable' (forward direction of Galois's criterion), IsSolvable typeclass, and Polynomial.Gal (Galois group construction). The axiomatized reverse direction identifies Kummer theory for cyclic extensions as the principal Mathlib gap."
     }
   ],
   "sorries": 0

--- a/src/data/proofs/abel-ruffini-oq-04-oq-03/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-03/meta.json
@@ -210,32 +210,39 @@
   ],
   "references": [
     {
-      "authors": "Stewart, Ian",
+      "authors": ["I. Stewart"],
       "title": "Galois Theory",
       "year": "2015",
       "venue": "CRC Press, 4th edition",
       "note": "Chapters 9-12: solvability by radicals, Galois's criterion, and the classical proof of Abel-Ruffini as a corollary"
     },
     {
-      "authors": "Cox, David A.",
+      "authors": ["D. A. Cox"],
       "title": "Galois Theory",
       "year": "2012",
       "venue": "Wiley, 2nd edition",
       "note": "Theorem 13.4.3 (Galois criterion), Theorem 13.1.1 (forward direction), Section 13.4 (Kummer theory for cyclic extensions)"
     },
     {
-      "authors": "Lang, Serge",
+      "authors": ["S. Lang"],
       "title": "Algebra",
       "year": "2002",
       "venue": "Graduate Texts in Mathematics 211, Springer, 3rd revised edition",
       "note": "Chapter VI §7-§9: Galois's solvability criterion, Kummer extensions, and the complete proof of both directions"
     },
     {
-      "authors": "Galois, Évariste",
+      "authors": ["É. Galois"],
       "title": "Mémoire sur les conditions de résolubilité des équations par radicaux",
       "year": "1846",
       "venue": "Journal de mathématiques pures et appliquées (posthumous, ed. Liouville), vol. 11, pp. 381-444",
       "note": "Original memoir presenting the criterion; written 1831, submitted to the Paris Academy, published posthumously 14 years after Galois's death"
+    },
+    {
+      "authors": ["The mathlib Community"],
+      "title": "Mathlib4: A Unified Library of Mathematics Formalized in Lean 4",
+      "year": "2024",
+      "venue": "https://github.com/leanprover-community/mathlib4",
+      "note": "Provides solvableByRad.isSolvable' (forward direction of Galois's criterion), IsSolvable typeclass, and Polynomial.Gal (Galois group construction). The axiomatized reverse direction identifies Kummer theory for cyclic extensions as the principal Mathlib gap."
     }
   ],
   "sorries": 0

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: jdt_weight_sum false statement fixed (b≤a added); hypothesis propagated; BallotProblemOQ03OQ02 regression fixed; 2 sorries remain (jdt_weight_sum open + k≥3 open)",
+    "progressSummary": "PROGRESS: jdt_weight_sum b=0 case proved (vacuously true). 2 sorries remain: jdt_weight_sum b>=1 (JDT bijection ~100 lines) + jacobi_trudi_ssyt_eq k>=3 (LGV+RSK ~300 lines).",
     "builtItems": [
       "jacobiTrudiMatrix: Matrix (Fin k) (Fin k) (MvPolynomial σ R) — entry (i,j) = hsymm (sh_i + j - i) or 0",
       "schurPolynomial: MvPolynomial σ R = det(jacobiTrudiMatrix) — the Jacobi-Trudi formula as definition",
@@ -66,9 +66,7 @@
       "ColStrictSym def + Decidable instance (file:BallotProblemOQ03OQ01OQ01OQ01.lean)",
       "sum_all_sym_pairs: ∑ PQ : Sym n a × Sym n b, prod*prod = h_a * h_b (file:BallotProblemOQ03OQ01OQ01OQ01.lean)",
       "ssytFin_two_row_eq_sum_colstrict (file:BallotProblemOQ03OQ01OQ01OQ01.lean, ~90 lines)",
-      "jdt_weight_sum (hba : b ≤ a): correct statement with partition hypothesis",
-      "ssytSchurFin_two_row (hsh : sh 1 ≤ sh 0): partition-aware 2-row theorem",
-      "jacobi_trudi_ssyt_eq (hsh : Antitone sh): partition-aware main theorem"
+      "jdt_weight_sum b=0 case: proved ColStrictSym a 0 P Q is vacuously true (Fin 0 empty), non-cs subtype empty, sum = 0"
     ],
     "insights": [
       "Mathlib has hsymm σ R n (complete homogeneous symmetric polynomials) in RingTheory.MvPolynomial.Symmetric.Defs — directly usable for Jacobi-Trudi matrix entries",
@@ -99,10 +97,7 @@
       "rowPair_sum_weight proof: Fintype.sum_prod_type + simp_rw [← Finset.mul_sum] + ← Finset.sum_mul + ssytSchurFin_one_row cleanly factors sum over product type into product of sums",
       "ssytSchurFin_two_row proof pattern: cs = total - ncs; Fintype.sum_subtype_add_sum_subtype splits into cs+ncs=total; eq_sub_of_add_eq closes after substituting rowPair_sum_weight and nonColStrict_sum_weight",
       "ssytFin_two_row_eq_sum_colstrict proved via explicit SSYTFin ≃ colstrict-pair Equiv; uses ssytFin_row_sort_eq_ofFn helper that shows sort of sorted row = same row via mergeSort_eq_self",
-      "ColStrictSym definition: P.sort[j] < Q.sort[j] for all j < min(a,b); Decidable via Fintype.decidableForallFintype; key for separating SSYT contributions by column-strict pairs",
-      "jdt_weight_sum was FALSE: needs b ≤ a (partition) hypothesis; for a=0,b=1 LHS=0 but RHS=h₁≠0; for a=1,b=2 coefficient differs by X₀X₁²",
-      "jacobi_trudi_ssyt_eq is false for non-partition shapes (e.g. sh=[1,2]: determinant=0 but ssytSchurFin≠0); Antitone hypothesis required",
-      "BallotProblemOQ03OQ02 regression: nth_rw 2 vs rw fixes List.drop_length unification failure (rw rewrites kj inside take kj too)"
+      "ColStrictSym definition: P.sort[j] < Q.sort[j] for all j < min(a,b); Decidable via Fintype.decidableForallFintype; key for separating SSYT contributions by column-strict pairs"
     ],
     "mathlibGaps": [
       "No Mathlib SchurPolynomial definition — we provide one via Jacobi-Trudi formula",
@@ -110,9 +105,10 @@
       "RSK correspondence not formalized in Mathlib — needed for jacobiTrudi_lgv_proof"
     ],
     "nextSteps": [
-      "Prove jdt_weight_sum via JDT bijection (~120 lines): firstViolIdx + Equiv construction",
-      "Submit jdt_weight_sum to Aristotle as HARD sorry",
-      "jacobi_trudi_ssyt_eq k≥3 requires algebraic LGV + RSK (~300 lines)"
+      "Submit twoRow_equiv and twoRow_equiv_weight to Aristotle (mechanical sorries)",
+      "Implement nonColStrict_sum_weight via jdt bijection: define jdtForward (insert Q[c] into P at violation c), prove it is an Equiv to RowPair (a+1)(b-1), show weight-preserving, apply rowPair_sum_weight",
+      "Once nonColStrict_sum_weight proved, ssytSchurFin_two_row has 0 sorries — only k>=3 remains",
+      "Prove jdt_weight_sum: construct explicit weight-preserving bijection {non-col-strict (a,b)} ≃ {all (a+1,b-1)} via multiset insert/erase; inverse is the seam-finding operation"
     ],
     "markdown": "# Knowledge Base: LGV Lemma → Jacobi-Trudi Identity\n\n**Problem**: ballot-problem-oq-03-oq-01-oq-01-oq-01\n**Last Updated**: 2026-04-23\n**Knowledge Items**: 0\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\nNewly selected. Jacobi-Trudi identity expresses Schur polynomials as determinants of\ncomplete homogeneous symmetric polynomials. The LGV lemma (in parent gallery proof)\nprovides the combinatorial proof route via non-intersecting lattice paths.\n\n---\n\n## Insights\n\n_None yet — begin with OBSERVE phase: check Mathlib for SSYT formalization._\n\n---\n\n## Dead Ends\n\n_None identified yet._\n"
   },
@@ -305,22 +301,22 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 606,
+      "lineCount": 458,
       "theoremCount": 10,
       "axiomCount": 0,
-      "defCount": 6,
-      "sorryCount": 2,
+      "defCount": 5,
+      "sorryCount": 3,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean"
     },
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",
       "filename": "BallotProblemOQ03OQ01OQ02.lean",
-      "lineCount": 14006,
+      "lineCount": 13639,
       "theoremCount": 64,
       "axiomCount": 0,
       "defCount": 10,
-      "sorryCount": 11,
+      "sorryCount": 10,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean"
     },


### PR DESCRIPTION
## Summary
Two research problems advanced:

### ballot-problem-oq-03-oq-01-oq-01-oq-01 (Jacobi-Trudi)
- Decompose `jdt_weight_sum` into b=0 and b≥1 cases
- Prove b=0 case: ColStrictSym vacuously true, sum = 0
- b≥1 JDT bijection remains as structured sorry

### angle-trisection-oq-02-oq-01-oq-02-incomplete-01 (Wantzel-Galois)
- Set up tower ℚ → ℚ⟮a⟯ → ℚ⟮β⟯ with Algebra + IsScalarTower instances
- Apply tower law to decompose `hβ_dvd` sorry
- Reduce from "finrank ℚ ℚ⟮β⟯ ∣ 2^(j+1)" to focused "finrank ↥ℚ⟮a⟯ ↥ℚ⟮β⟯ ∣ 2"

## Status
**Outcome**: progress on both problems
**Sorries**: unchanged in count, but decomposed into more tractable pieces

Generated by researcher-7