### PR TITLE
fix(meta): sync hurwitz-theorem-oq-04 lineCount (822→1052)

### DIFF
--- a/src/data/proofs/hurwitz-theorem-oq-04/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-04/meta.json
@@ -22,7 +22,7 @@
     "dateAdded": "2026-04-24",
     "axiomCount": 0,
     "assumptions": "2 sorries remaining: (1) algebraic extraction from ev=0 in derEval14_injective helper (requires ~50 lines of Leibniz constraint derivations); (2) linear independence of derBasis14 (14×14 evaluation matrix determinant). G2_der_dimension is now a theorem with proof structure, no longer an axiom. All other lemmas fully proved.",
-    "lineCount": 822,
+    "lineCount": 1052,
     "theoremCount": 35,
     "definitionCount": 17,
     "originalContributions": [
@@ -137,7 +137,7 @@
       "HurwitzTheorem"
     ],
     "namespace": "HurwitzTheoremOQ04",
-    "lineCount": 822,
+    "lineCount": 1052,
     "axiomCount": 0,
     "theoremCount": 40,
     "definitionCount": 15,


### PR DESCRIPTION
## Fix

Sync `lineCount` in `hurwitz-theorem-oq-04/meta.json` from 822 to 1052.

## Evidence

**Before**: `"lineCount": 822` in both `meta` and `leanFile` sections

**After**: `"lineCount": 1052` in both sections

**Root cause**: Commit 7263d98b831 (PR #12984, "replace axiom G2_der_dimension with proof structure") added ~230 lines to `HurwitzTheoremOQ04.lean` (14 explicit derivation definitions, member lemmas, evaluation infrastructure). PR #12994 synced `sorries` and `axiomCount` from that commit but did not update `lineCount`.

**Verification**: `wc -l proofs/Proofs/HurwitzTheoremOQ04.lean` → 1052

---
Automated fix by lean-mechanic agent.