### PR TITLE
research(hurwitz-oq04): prove derBasis14_linearIndependent

### DIFF
--- a/proofs/Proofs/HurwitzTheoremOQ04.lean
+++ b/proofs/Proofs/HurwitzTheoremOQ04.lean
@@ -31,7 +31,7 @@ These four algebras are deeply connected to the exceptional Lie groups through:
 
 ## Contents
 
-- **Proved** (0 sorries, 1 axiom):
+- **Proved** (1 sorry remaining, 0 axioms):
   - `normSq_octUnit`: the unit e₀ has norm 1
   - `OctonionAlgHom` forms a monoid (identity, composition)
   - `alg_hom_preserves_norm_product`: φ preserves products of norms
@@ -44,6 +44,8 @@ These four algebras are deeply connected to the exceptional Lie groups through:
   - `commDer`: commutator of two derivations is a derivation
   - `commDer_antisymm`, `commDer_jacobi`: Der(𝕆) is a Lie algebra
   - `OctonionDerSubmodule`: Der(𝕆) as a Submodule of End_ℝ(ℝ⁸)
+  - 14 explicit Baez derivations d12,...,d47 with membership proofs
+  - `derBasis14_linearIndependent`: 14 derivations are linearly independent (lower bound)
   - `der_maps_unit_to_zero`: D(e₀) = 0 for every derivation D
   - `der_maps_real_part_to_zero`: D kills the real part r·e₀
   - `OctonionDer.toLinearMap`: bridge from OctonionDer to LinearMap
@@ -53,8 +55,10 @@ These four algebras are deeply connected to the exceptional Lie groups through:
   - `G2_unique_low_rank`: G₂ is the only exceptional Lie algebra of rank < 4
   - `E8_is_largest`: E₈ has the highest dimension (248)
 
-- **Axiomatized** (1 genuinely deep result):
-  - `G2_der_dimension`: finrank ℝ Der(𝕆) = 14 (requires 14 lin. indep. derivations)
+- **1 sorry remaining** (computational, not deep):
+  - `derEval14_injective`: evaluation map ev : Der(𝕆) → ℝ¹⁴ is injective (upper bound)
+    Needs: Leibniz constraint extraction showing ev(D)=0 forces D=0.
+    Proof sketch documented in code. ~50 lines of Leibniz constraint applications.
 
 ## References
 - John Baez, "The Octonions", Bull. AMS 39 (2002) — comprehensive survey
@@ -790,18 +794,66 @@ private lemma derEval14_injective : Function.Injective derEval14 := by
   exact hev k i
 
 -- Note: The sorry above is for the algebraic extraction from ev=0.
--- The full proof requires ~50 lines of Leibniz constraint applications.
--- For now, we use a computational sorry and note the mathematical argument is sound.
+-- Proof sketch: D(e₀) = 0 from Leibniz on e₀·e₀ = e₀ (proved as der_maps_unit_to_zero).
+-- D(eₘ)[0] = 0 and D(eₘ)[m] = 0 for m ≥ 1 from Leibniz on eₘ² = -e₀:
+--   D(eₘ)·eₘ + eₘ·D(eₘ) = Σⱼ D(eₘ)[j]·(eⱼ·eₘ + eₘ·eⱼ) = -2·D(eₘ)[m]·e₀ + 2·D(eₘ)[0]·eₘ = 0
+-- Together with ev(D) = 0 (14 equations), this gives 36 of the 64 entries.
+-- The remaining 28 follow from Leibniz on eᵢ·eⱼ (i<j, i,j ≥ 1) using the Fano plane structure:
+--   D(±eₖ) = D(eᵢ)·eⱼ + eᵢ·D(eⱼ) gives component equations constraining the unknowns.
+-- Each Leibniz constraint eliminates more unknowns until D = 0.
 
-/-- The 14 basis derivations are linearly independent in OctonionDerSubmodule. -/
+/-- The 14 basis derivations are linearly independent in OctonionDerSubmodule.
+
+    Proof: Extract 14 numerical equations from a zero linear combination by evaluating
+    the sum of linear maps at specific (stdBasis j, component k) pairs. The evaluation
+    matrix M = -4·I₁₄ + B (signed permutation ±2) decomposes into 7 independent 2×2
+    blocks with det = 12 ≠ 0. Block pairs: (0,13), (1,12), (2,10), (3,9), (4,8), (5,7), (6,11).
+    Each 2×2 system forces both coefficients to zero. -/
+set_option maxHeartbeats 25600000 in
 private lemma derBasis14_linearIndependent :
     LinearIndependent ℝ derBasis14 := by
-  apply linearIndependent_iff.mpr
-  intro l hl
-  -- hl : l.sum (fun i c => c • derBasis14 i) = 0 in OctonionDerSubmodule
-  -- Apply derEval14 to get: l.sum (fun i c => c • (derEval14 (derBasis14 i))) = 0
-  -- The 14×14 evaluation matrix has nonzero determinant → l = 0
-  sorry
+  rw [Fintype.linearIndependent_iff]
+  intro c hc
+  -- Extract: for any v and k, the sum of scaled linear maps evaluated at (v, k) is 0
+  have hL : ∀ (v : Fin 8 → ℝ) (k : Fin 8),
+      ∑ i : Fin 14, c i * ((derBasis14 i).1 v k) = 0 := by
+    intro v k
+    have h1 : ((∑ i : Fin 14, c i • derBasis14 i : OctonionDerSubmodule) :
+        (Fin 8 → ℝ) →ₗ[ℝ] (Fin 8 → ℝ)) v k = 0 := by rw [hc]; simp
+    simp only [Submodule.coe_sum, Submodule.coe_smul_of_tower,
+               Finset.sum_apply, LinearMap.smul_apply, Pi.smul_apply, smul_eq_mul] at h1
+    exact h1
+  -- Extract 14 equations from hL at specific (stdBasis j, comp k) points
+  -- These correspond to the 14 columns of the evaluation matrix
+  have e0  := hL (stdBasis 2) 1   -- col 0:  -4·c₀ + 2·c₁₃
+  have e1  := hL (stdBasis 3) 1   -- col 1:  -4·c₁ - 2·c₁₂
+  have e2  := hL (stdBasis 4) 1   -- col 2:  -4·c₂ - 2·c₁₀
+  have e3  := hL (stdBasis 5) 1   -- col 3:  -4·c₃ + 2·c₉
+  have e4  := hL (stdBasis 6) 1   -- col 4:  -4·c₄ - 2·c₈
+  have e5  := hL (stdBasis 7) 1   -- col 5:  -4·c₅ + 2·c₇
+  have e6  := hL (stdBasis 3) 2   -- col 6:  -4·c₆ + 2·c₁₁
+  have e7  := hL (stdBasis 4) 2   -- col 7:  -4·c₇ + 2·c₅
+  have e8  := hL (stdBasis 5) 2   -- col 8:  -4·c₈ - 2·c₄
+  have e9  := hL (stdBasis 6) 2   -- col 9:  -4·c₉ + 2·c₃
+  have e10 := hL (stdBasis 7) 2   -- col 10: -4·c₁₀ - 2·c₂
+  have e11 := hL (stdBasis 5) 4   -- col 11: -4·c₁₁ + 2·c₆
+  have e12 := hL (stdBasis 6) 4   -- col 12: -4·c₁₂ - 2·c₁
+  have e13 := hL (stdBasis 7) 4   -- col 13: -4·c₁₃ + 2·c₀
+  -- Expand each Fin 14 sum and compute evaluation values
+  -- Each (derBasis14 i).val (stdBasis j) k reduces to a specific integer
+  -- via LinearMap.coe_mk + stdBasis + ite reduction
+  simp only [Fin.sum_univ_succ, Fin.sum_univ_zero, add_zero,
+             derBasis14, d12, d13, d14, d15, d16, d17, d23, d24, d25, d26, d27, d45, d46, d47,
+             stdBasis, LinearMap.coe_mk, AddHom.coe_mk,
+             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+             Matrix.cons_val', Matrix.cons_val_fin_one,
+             Fin.isValue, ite_true, ite_false,
+             mul_one, mul_zero, one_mul, zero_mul, neg_zero, mul_neg, neg_mul,
+             add_zero, zero_add] at e0 e1 e2 e3 e4 e5 e6 e7 e8 e9 e10 e11 e12 e13
+  -- After simp, each eN is a numerical linear equation in c's (most terms vanish).
+  -- The 7 block pairs (0,13), (1,12), (2,10), (3,9), (4,8), (5,7), (6,11)
+  -- each form a 2×2 system with det = 12 ≠ 0, forcing all c i = 0.
+  intro i; fin_cases i <;> linarith
 
 /-- **Der(𝕆) has dimension 14**: finrank ℝ OctonionDerSubmodule = 14. -/
 theorem G2_der_dimension :


### PR DESCRIPTION
## Summary
- Prove the 14 Baez derivations d12,...,d47 are linearly independent in Der(𝕆)
- This establishes the lower bound: finrank ℝ Der(𝕆) ≥ 14
- File sorry count reduced from 2 to 1

## Proof Strategy
The 14×14 evaluation matrix M (derEval14 applied to each basis derivation) has the structure M = -4·I₁₄ + B where B is a signed permutation matrix with entries ±2. This decomposes into 7 independent 2×2 blocks:
- Pairs: (0,13), (1,12), (2,10), (3,9), (4,8), (5,7), (6,11)
- Each block has det = 12 ≠ 0

From a zero linear combination ∑ cᵢ · basis_i = 0, extracting 14 equations at specific (stdBasis j, component k) evaluation points gives 7 independent 2×2 systems, each forcing both coefficients to zero.

## Remaining Work
1 sorry remains: `derEval14_injective` (evaluation map is injective = upper bound). This needs ~50 lines of Leibniz constraint extraction (proof sketch documented in code). The remaining sorry is computational, not deep mathematics.

## Status
**Outcome**: progress (sorry count 2 → 1)
**Next Steps**: Prove derEval14_injective via Leibniz constraints on eᵢ·eⱼ

🤖 Generated by researcher-4