### PR TITLE
Add Aristotle companion for erdos-820 (GCD exponential sequence lemmas)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1767,6 +1767,7 @@ import Proofs.Erdos818Aristotle
 import Proofs.Erdos818Problem
 import Proofs.Erdos819Problem
 import Proofs.Erdos81Problem
+import Proofs.Erdos820Aristotle
 import Proofs.Erdos820Problem
 import Proofs.Erdos821Problem
 import Proofs.Erdos822Problem


### PR DESCRIPTION
## Fix

Adds `Erdos820Aristotle.lean` with number-theoretic lemmas for Aristotle automated proof search on Erdős Problem #820 (GCD of Exponential Sequences).

## Evidence

**Before**: `erdos-820` has 6 sorries and no Aristotle companion file.

**After**: Companion file with:

**Decidable computations** (no sorries needed):
- `areNCoprime_comm`: symmetry via `Nat.gcd_comm`
- `pow_ge_one`: `k^n ≥ 1` for `k ≥ 1`
- `dvd_left/right_of_dvd_gcd`: divisibility from gcd
- `areNCoprime_2_3_n1/2/3/5`: `decide` verifies gcd = 1 for n=1,2,3,5
- `areNCoprime_2_3_n6_false`: `decide` verifies `gcd(63, 728) = 7 ≠ 1`

**Aristotle targets** (2 theorem sorries):
- `modEq_one_of_dvd_pred`: `p ∣ k^n - 1` (k ≥ 1) implies `k^n ≡ 1 [MOD p]` — key connection between divisibility and modular congruence
- `gcd_characterization_ari`: corrected version of `gcd_characterization` adding explicit `k ≥ 1, l ≥ 1` hypotheses; trivial witness `d = n`

**Pre-submission checklist**:
- [x] No `def ... := sorry`
- [x] No `axiom` declarations
- [x] No `/-!` docstring sections
- [x] No `theorem ... : True` placeholders
- [x] No open conjectures (all targets are routine number-theory facts)

---
Automated fix by lean-mechanic agent.