### PR TITLE
fix(meta): sync stale lineCount in 4 gallery proofs

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-incomplete-01/meta.json
@@ -20,7 +20,7 @@
     "sorries": 3,
     "axiomCount": 0,
     "theoremCount": 18,
-    "lineCount": 366,
+    "lineCount": 383,
     "mathlibDependencies": [
       {
         "theorem": "Polynomial.irreducible_of_eisenstein_criterion",
@@ -136,7 +136,7 @@
   ],
   "leanFile": {
     "namespace": "AngleTrisectionOQ02OQ01OQ02Incomplete01",
-    "lineCount": 366,
+    "lineCount": 383,
     "axiomCount": 0,
     "theoremCount": 19,
     "definitionCount": 3,

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -23,7 +23,7 @@
     "dateAdded": "2026-04-23",
     "axiomCount": 0,
     "assumptions": "2 sorries remain: (1) jdt_weight_sum — weight-preserving JDT bijection {non-col-strict (a,b)} ≃ {all (a+1,b-1)} (~80 lines); (2) jacobi_trudi_ssyt_eq k≥3 — algebraic LGV + RSK (~300 lines). ssytFin_two_row_eq_sum_colstrict proved (row-decomp bijection, no sorry). ssytSchurFin_two_row main theorem proved. k=0,1,2 proved.",
-    "lineCount": 605,
+    "lineCount": 633,
     "theoremCount": 14,
     "definitionCount": 8,
     "originalContributions": [
@@ -78,7 +78,7 @@
       "Finset"
     ],
     "namespace": "JacobiTrudi",
-    "lineCount": 605,
+    "lineCount": 633,
     "axiomCount": 0,
     "theoremCount": 16,
     "definitionCount": 9,

--- a/src/data/proofs/erdos-1-oq-03/meta.json
+++ b/src/data/proofs/erdos-1-oq-03/meta.json
@@ -38,7 +38,7 @@
       "Conway-Guy optimality conjecture statement"
     ],
     "dateAdded": "2026-03-30",
-    "lineCount": 182,
+    "lineCount": 249,
     "theoremCount": 12,
     "definitionCount": 3,
     "prerequisites": [
@@ -154,7 +154,7 @@
       "Finset"
     ],
     "namespace": "Erdos1OQ03",
-    "lineCount": 240,
+    "lineCount": 249,
     "axiomCount": 0,
     "theoremCount": 17,
     "definitionCount": 3,

--- a/src/data/proofs/sperner-ndim-oq-04/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-04/meta.json
@@ -42,7 +42,7 @@
     ],
     "dateAdded": "2026-04-22",
     "axiomCount": 0,
-    "lineCount": 892,
+    "lineCount": 1126,
     "assumptions": "1 sorry in kuhn_path_existential Case 2 (B_fc = ∅): when all boundary doors are non-FC, needs walk-pairing involution on B-B pairs to show |B-B| even, then |B-nfc| odd − |B-B| even → |B-FC| odd ≥ 1 → ∃ walk from B_nfc reaching FC. Note: bdry_nfc_even (|B_nfc| always even) was removed — it is FALSE; |B_nfc| can be odd when B-FC walks exist. Requires kuhnWalkWithExit + walkTrace_reversal induction (~100 lines). 0 axiom declarations.",
     "mathlib_version": "4.26.0"
   },
@@ -247,7 +247,7 @@
       "BigOperators"
     ],
     "namespace": "SpernerNDimOQ04",
-    "lineCount": 892,
+    "lineCount": 1126,
     "axiomCount": 0,
     "theoremCount": 20,
     "definitionCount": 8,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` values in 4 gallery meta.json files where Lean source files were extended by research commits but the metadata wasn't updated.

## Evidence

| Proof | Field | Before | After |
|-------|-------|--------|-------|
| sperner-ndim-oq-04 | meta.lineCount + leanFile.lineCount | 892 | 1126 |
| erdos-1-oq-03 | meta.lineCount | 182 | 249 |
| erdos-1-oq-03 | leanFile.lineCount | 240 | 249 |
| ballot-problem-oq-03-oq-01-oq-01-oq-01 | both | 605 | 633 |
| angle-trisection-oq-02-oq-01-oq-02-incomplete-01 | both | 366 | 383 |

**Sorry and axiom counts are unchanged** — these were already correct. Only `lineCount` drifted after research sessions extended the files.

Verified with `wc -l` on each Lean source file.

---
Automated fix by lean-mechanic agent.