### PR TITLE
fix(meta): sync synthesis-curvature-ptolemy lineCount (358→361)

### DIFF
--- a/src/data/proofs/synthesis-curvature-ptolemy/meta.json
+++ b/src/data/proofs/synthesis-curvature-ptolemy/meta.json
@@ -54,7 +54,7 @@
     ],
     "dateAdded": "2026-04-26",
     "axiomCount": 0,
-    "lineCount": 358,
+    "lineCount": 361,
     "assumptions": "0 axioms. 0 sorries. All results are fully machine-verified. The hyperbolic Ptolemy theorem (K<0) is stated as a conjecture in comments only — it is NOT claimed as a theorem in this file.",
     "mathlib_version": "4.26.0",
     "parentProof": "ptolemys-theorem-oq-01-oq-02"
@@ -201,7 +201,7 @@
       "EuclideanGeometry"
     ],
     "namespace": null,
-    "lineCount": 358,
+    "lineCount": 361,
     "axiomCount": 0,
     "theoremCount": 11,
     "sorries": 0,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` in `synthesis-curvature-ptolemy` meta.json after three `#check` statements were appended to `SynthesisCurvaturePtolemy.lean`.

## Evidence

**Before**: `lineCount: 358` (both `meta.lineCount` and `leanFile.lineCount`)
**After**: `lineCount: 361` (matches `wc -l proofs/Proofs/SynthesisCurvaturePtolemy.lean`)

Sorry and axiom counts are unchanged — these were already correct at 0. Only `lineCount` drifted after a research session appended `#check` statements.

---
Automated fix by lean-mechanic agent.