### PR TITLE
chore(audit): batch re-audit 82 proofs clean (2026-04-26)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9116,15 +9116,15 @@
     },
     "erdos-784": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:59Z",
+      "result": "clean"
     },
     "erdos-785": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:59Z",
+      "result": "clean"
     },
     "erdos-786": {
       "agentId": "auditor-cycle-20-batch",
@@ -9140,27 +9140,27 @@
     },
     "erdos-788": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:58Z",
+      "result": "clean"
     },
     "erdos-789": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:59Z",
+      "result": "clean"
     },
     "erdos-79": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:59Z",
+      "result": "clean"
     },
     "erdos-790": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:59Z",
+      "result": "clean"
     },
     "erdos-791": {
       "agentId": "auditor-cycle-20-batch",
@@ -9194,9 +9194,9 @@
     },
     "erdos-796": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:58Z",
+      "result": "clean"
     },
     "erdos-797": {
       "agentId": "auditor-cycle-20-batch",
@@ -9242,15 +9242,15 @@
     },
     "erdos-802": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:42Z",
+      "result": "clean"
     },
     "erdos-803": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:57Z",
+      "result": "clean"
     },
     "erdos-804": {
       "agentId": "auditor-cycle-20-batch",
@@ -9266,9 +9266,9 @@
     },
     "erdos-806": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:58Z",
+      "result": "clean"
     },
     "erdos-807": {
       "agentId": "auditor-cycle-20-batch",
@@ -9278,9 +9278,9 @@
     },
     "erdos-808": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:58Z",
+      "result": "clean"
     },
     "erdos-809": {
       "auditCount": 4,
@@ -9302,39 +9302,39 @@
     },
     "erdos-811": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:41Z",
+      "result": "clean"
     },
     "erdos-812": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:41Z",
+      "result": "clean"
     },
     "erdos-813": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:42Z",
+      "result": "clean"
     },
     "erdos-814": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:42Z",
+      "result": "clean"
     },
     "erdos-815": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:42Z",
+      "result": "clean"
     },
     "erdos-816": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:41Z",
+      "result": "clean"
     },
     "erdos-817": {
       "agentId": "auditor-cycle-20-batch",
@@ -9350,15 +9350,15 @@
     },
     "erdos-819": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:41Z",
+      "result": "clean"
     },
     "erdos-82": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:30Z",
+      "result": "clean"
     },
     "erdos-820": {
       "agentId": "auditor-cycle-20-batch",
@@ -9368,27 +9368,27 @@
     },
     "erdos-821": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:30Z",
+      "result": "clean"
     },
     "erdos-822": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:30Z",
+      "result": "clean"
     },
     "erdos-823": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:41Z",
+      "result": "clean"
     },
     "erdos-824": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:41Z",
+      "result": "clean"
     },
     "erdos-825": {
       "agentId": "auditor-cycle-20-batch",
@@ -9416,9 +9416,9 @@
     },
     "erdos-829": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:30Z",
+      "result": "clean"
     },
     "erdos-83": {
       "agentId": "auditor-cycle-20-batch",
@@ -9440,9 +9440,9 @@
     },
     "erdos-832": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:30Z",
+      "result": "clean"
     },
     "erdos-833": {
       "agentId": "auditor-cycle-20-batch",
@@ -9458,15 +9458,15 @@
     },
     "erdos-835": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:30Z",
+      "result": "clean"
     },
     "erdos-836": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:30Z",
+      "result": "clean"
     },
     "erdos-837": {
       "agentId": "auditor-cycle-20-batch",
@@ -9488,15 +9488,15 @@
     },
     "erdos-839": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-26T20:48:29Z",
+      "result": "clean"
     },
     "erdos-84": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:30Z",
+      "result": "clean"
     },
     "erdos-840": {
       "agentId": "auditor-cycle-20-batch",
@@ -9507,21 +9507,21 @@
     },
     "erdos-841": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:17Z",
+      "result": "clean"
     },
     "erdos-842": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:17Z",
+      "result": "clean"
     },
     "erdos-843": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:17Z",
+      "result": "clean"
     },
     "erdos-844": {
       "agentId": "auditor-cycle-20-batch",
@@ -9543,9 +9543,9 @@
     },
     "erdos-847": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:29Z",
+      "result": "clean"
     },
     "erdos-848": {
       "agentId": "auditor-cycle-20-batch",
@@ -9603,9 +9603,9 @@
     },
     "erdos-855": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:17Z",
+      "result": "clean"
     },
     "erdos-856": {
       "agentId": "auditor-cycle-20-batch",
@@ -9621,21 +9621,21 @@
     },
     "erdos-858": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:17Z",
+      "result": "clean"
     },
     "erdos-859": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:17Z",
+      "result": "clean"
     },
     "erdos-86": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-26T20:48:17Z",
+      "result": "clean"
     },
     "erdos-860": {
       "agentId": "auditor-cycle-20-batch",
@@ -9645,9 +9645,9 @@
     },
     "erdos-861": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:17Z",
+      "result": "clean"
     },
     "erdos-862": {
       "agentId": "auditor-cycle-20-batch",
@@ -9687,27 +9687,27 @@
     },
     "erdos-868": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:04Z",
+      "result": "clean"
     },
     "erdos-869": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:04Z",
+      "result": "clean"
     },
     "erdos-87": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:16Z",
+      "result": "clean"
     },
     "erdos-870": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:16Z",
+      "result": "clean"
     },
     "erdos-871": {
       "agentId": "auditor-cycle-20-batch",
@@ -9747,15 +9747,15 @@
     },
     "erdos-877": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:04Z",
+      "result": "clean"
     },
     "erdos-878": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:04Z",
+      "result": "clean"
     },
     "erdos-879": {
       "agentId": "auditor-cycle-20-batch",
@@ -9765,9 +9765,9 @@
     },
     "erdos-88": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:04Z",
+      "result": "clean"
     },
     "erdos-880": {
       "agentId": "auditor-cycle-20-batch",
@@ -9807,9 +9807,9 @@
     },
     "erdos-886": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:04Z",
+      "result": "clean"
     },
     "erdos-887": {
       "agentId": "auditor-cycle-20-batch",
@@ -9825,9 +9825,9 @@
     },
     "erdos-889": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:04Z",
+      "result": "clean"
     },
     "erdos-89": {
       "agentId": "auditor-cycle-20-batch",
@@ -9861,9 +9861,9 @@
     },
     "erdos-894": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:04Z",
+      "result": "clean"
     },
     "erdos-895": {
       "agentId": "auditor-cycle-20-batch",
@@ -9897,9 +9897,9 @@
     },
     "erdos-9": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:47:51Z",
+      "result": "clean"
     },
     "erdos-90": {
       "agentId": "auditor-cycle-20-batch",
@@ -9927,21 +9927,21 @@
     },
     "erdos-903": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:03Z",
+      "result": "clean"
     },
     "erdos-904": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:48:03Z",
+      "result": "clean"
     },
     "erdos-905": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:47:51Z",
+      "result": "clean"
     },
     "erdos-906": {
       "agentId": "auditor-cycle-20-batch",
@@ -9963,9 +9963,9 @@
     },
     "erdos-909": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:47:51Z",
+      "result": "clean"
     },
     "erdos-909-oq-01": {
       "auditCount": 2,
@@ -9993,9 +9993,9 @@
     },
     "erdos-912": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:47:50Z",
+      "result": "clean"
     },
     "erdos-913": {
       "agentId": "auditor-cycle-20-batch",
@@ -10023,15 +10023,15 @@
     },
     "erdos-917": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:47:50Z",
+      "result": "clean"
     },
     "erdos-918": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:47:50Z",
+      "result": "clean"
     },
     "erdos-919": {
       "agentId": "auditor-cycle-20-batch",
@@ -10041,9 +10041,9 @@
     },
     "erdos-92": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:47:50Z",
+      "result": "clean"
     },
     "erdos-920": {
       "agentId": "auditor-cycle-20-batch",
@@ -10053,33 +10053,33 @@
     },
     "erdos-921": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:47:36Z",
+      "result": "clean"
     },
     "erdos-922": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:47:36Z",
+      "result": "clean"
     },
     "erdos-923": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:47:36Z",
+      "result": "clean"
     },
     "erdos-924": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:47:50Z",
+      "result": "clean"
     },
     "erdos-925": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:47:50Z",
+      "result": "clean"
     },
     "erdos-926": {
       "agentId": "auditor-cycle-20-batch",
@@ -10089,9 +10089,9 @@
     },
     "erdos-927": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:47:50Z",
+      "result": "clean"
     },
     "erdos-928": {
       "agentId": "auditor-cycle-20-batch",
@@ -10113,9 +10113,9 @@
     },
     "erdos-930": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:47:36Z",
+      "result": "clean"
     },
     "erdos-931": {
       "agentId": "auditor-cycle-20-batch",
@@ -10131,15 +10131,15 @@
     },
     "erdos-933": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-26T20:47:36Z",
+      "result": "clean"
     },
     "erdos-934": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:47:36Z",
+      "result": "clean"
     },
     "erdos-935": {
       "agentId": "auditor-cycle-20-batch",
@@ -10155,9 +10155,9 @@
     },
     "erdos-937": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:47:36Z",
+      "result": "clean"
     },
     "erdos-938": {
       "auditCount": 3,
@@ -10167,9 +10167,9 @@
     },
     "erdos-939": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:47:35Z",
+      "result": "clean"
     },
     "erdos-94": {
       "agentId": "auditor-cycle-20-batch",
@@ -10178,10 +10178,10 @@
       "result": "clean"
     },
     "erdos-94-oq-02": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-26T20:47:35Z",
+      "result": "clean"
     },
     "erdos-940": {
       "agentId": "auditor-cycle-20-batch",
@@ -10197,15 +10197,15 @@
     },
     "erdos-942": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:47:22Z",
+      "result": "clean"
     },
     "erdos-943": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:47:22Z",
+      "result": "clean"
     },
     "erdos-944": {
       "agentId": "auditor-cycle-20-batch",
@@ -10227,15 +10227,15 @@
     },
     "erdos-947": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:47:22Z",
+      "result": "clean"
     },
     "erdos-948": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:47:35Z",
+      "result": "clean"
     },
     "erdos-949": {
       "agentId": "auditor-cycle-20-batch",
@@ -10251,9 +10251,9 @@
     },
     "erdos-950": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:47:22Z",
+      "result": "clean"
     },
     "erdos-951": {
       "agentId": "auditor-cycle-20-batch",
@@ -10287,9 +10287,9 @@
     },
     "erdos-956": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:47:22Z",
+      "result": "clean"
     },
     "erdos-957": {
       "agentId": "auditor-cycle-20-batch",
@@ -10341,9 +10341,9 @@
     },
     "erdos-964": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:47:21Z",
+      "result": "clean"
     },
     "erdos-965": {
       "agentId": "auditor-cycle-20-batch",
@@ -10353,27 +10353,27 @@
     },
     "erdos-966": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:47:21Z",
+      "result": "clean"
     },
     "erdos-967": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:47:21Z",
+      "result": "clean"
     },
     "erdos-968": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:46:57Z",
+      "result": "clean"
     },
     "erdos-969": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:47:21Z",
+      "result": "clean"
     },
     "erdos-97": {
       "agentId": "auditor-cycle-20-batch",
@@ -10383,9 +10383,9 @@
     },
     "erdos-970": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:47:22Z",
+      "result": "clean"
     },
     "erdos-971": {
       "agentId": "auditor-cycle-20-batch",
@@ -10407,9 +10407,9 @@
     },
     "erdos-974": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:46:57Z",
+      "result": "clean"
     },
     "erdos-975": {
       "agentId": "auditor-cycle-20-batch",
@@ -10419,9 +10419,9 @@
     },
     "erdos-976": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:46:57Z",
+      "result": "clean"
     },
     "erdos-977": {
       "agentId": "auditor-cycle-20-batch",
@@ -10432,9 +10432,9 @@
     },
     "erdos-978": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:46:57Z",
+      "result": "clean"
     },
     "erdos-979": {
       "agentId": "auditor-cycle-20-batch",
@@ -10456,15 +10456,15 @@
     },
     "erdos-981": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:46:57Z",
+      "result": "clean"
     },
     "erdos-982": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:46:57Z",
+      "result": "clean"
     },
     "erdos-983": {
       "agentId": "auditor-cycle-20-batch",
@@ -10474,15 +10474,15 @@
     },
     "erdos-984": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:46:57Z",
+      "result": "clean"
     },
     "erdos-985": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:46:57Z",
+      "result": "clean"
     },
     "erdos-986": {
       "agentId": "auditor-cycle-20-batch",
@@ -10504,15 +10504,15 @@
     },
     "erdos-989": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:45:17Z",
+      "result": "clean"
     },
     "erdos-99": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-26T20:45:36Z",
+      "result": "clean"
     },
     "erdos-990": {
       "agentId": "auditor-cycle-20-batch",
@@ -13178,6 +13178,12 @@
     "cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-04": {
       "auditCount": 1,
       "lastAudited": "2026-04-26T16:11:50Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-803 erdos-806 erdos-808 erdos-796 erdos-788 erdos-789 erdos-79 erdos-790 erdos-784 erdos-785 ": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-26T20:48:50Z",
       "result": "clean",
       "issues": []
     }


### PR DESCRIPTION
## Summary

- Re-audited 82 proofs in the erdos-800s to erdos-980s range plus erdos-989 and erdos-99
- All verified against git HEAD: axiomCount, sorries, lineCount, badges all match
- No integrity issues found — all proofs marked clean

## Proofs Audited

All proofs confirmed clean: axiom counts, sorry counts, line counts, and True-stub checks all match meta.json claims.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)