### PR TITLE
fix(meta): correct lineCount for erdos-167 (275→274) and erdos-168 (181→180)

### DIFF
--- a/src/data/proofs/erdos-167/meta.json
+++ b/src/data/proofs/erdos-167/meta.json
@@ -28,7 +28,7 @@
       "extremal combinatorics",
       "linear programming relaxation"
     ],
-    "lineCount": 275,
+    "lineCount": 274,
     "assumptions": "1 axiom: IsPlanar. 0 sorries.",
     "mathlib_version": "4.26.0"
   },
@@ -136,7 +136,7 @@
       "Set"
     ],
     "namespace": "Erdos167",
-    "lineCount": 275,
+    "lineCount": 274,
     "axiomCount": 1,
     "theoremCount": 4,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-168/meta.json
+++ b/src/data/proofs/erdos-168/meta.json
@@ -55,7 +55,7 @@
       "Formalized the irrationality question"
     ],
     "axiomCount": 2,
-    "lineCount": 181,
+    "lineCount": 180,
     "assumptions": "2 axioms: gsw_limit_exists, better_construction. 0 sorries."
   },
   "overview": {
@@ -141,7 +141,7 @@
       "Finset"
     ],
     "namespace": "Erdos168",
-    "lineCount": 181,
+    "lineCount": 180,
     "axiomCount": 2,
     "theoremCount": 4,
     "definitionCount": 7,


### PR DESCRIPTION
## Summary

- Fix `lineCount` off-by-one in `erdos-167/meta.json`: 275 → 274
- Fix `lineCount` off-by-one in `erdos-168/meta.json`: 181 → 180

Both mismatches discovered during gallery integrity audit. Actual `wc -l` counts are 274 and 180 respectively.

## Test plan
- [ ] Verify `wc -l proofs/Proofs/Erdos167Problem.lean` = 274
- [ ] Verify `wc -l proofs/Proofs/Erdos168Problem.lean` = 180

🤖 Generated with [Claude Code](https://claude.com/claude-code)