### PR TITLE
fix(meta): correct lineCount for erdos-37 (368→367) and erdos-172 (145→144)

### DIFF
--- a/src/data/proofs/erdos-172/meta.json
+++ b/src/data/proofs/erdos-172/meta.json
@@ -46,7 +46,7 @@
       "Explicit connection between finite and infinite versions"
     ],
     "axiomCount": 3,
-    "lineCount": 145,
+    "lineCount": 144,
     "references": [
       {
         "title": "Monochromatic sums and products in ℕ",
@@ -155,7 +155,7 @@
       "Finset"
     ],
     "namespace": "Erdos172",
-    "lineCount": 145,
+    "lineCount": 144,
     "axiomCount": 3,
     "theoremCount": 4,
     "definitionCount": 6,

--- a/src/data/proofs/erdos-37/meta.json
+++ b/src/data/proofs/erdos-37/meta.json
@@ -80,7 +80,7 @@
       "Classical axioms: schnirelmann_theorem, mann_theorem"
     ],
     "axiomCount": 6,
-    "lineCount": 368,
+    "lineCount": 367,
     "prerequisites": [
       "Essential components in additive number theory",
       "Lacunary sequences and their properties",
@@ -225,7 +225,7 @@
       "Filter"
     ],
     "namespace": "Erdos37",
-    "lineCount": 368,
+    "lineCount": 367,
     "axiomCount": 6,
     "theoremCount": 6,
     "definitionCount": 10,


### PR DESCRIPTION
## Summary
- Fix `lineCount` off-by-one in `erdos-37/meta.json`: 368 → 367
- Fix `lineCount` off-by-one in `erdos-172/meta.json`: 145 → 144

Discovered during gallery integrity audit. Verified with `wc -l`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)