### PR TITLE
fix(meta): correct lineCount off-by-one for 6 proofs (audit batch 3)

### DIFF
--- a/src/data/proofs/erdos-624/meta.json
+++ b/src/data/proofs/erdos-624/meta.json
@@ -57,7 +57,7 @@
     ],
     "dateAdded": "2025-12-27",
     "axiomCount": 5,
-    "lineCount": 219,
+    "lineCount": 218,
     "assumptions": "5 axioms: erdos_hajnal_upper_bound, erdos_624_open, weaker_conjecture_open, and 2 more. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
@@ -172,7 +172,7 @@
       "Set"
     ],
     "namespace": "Erdos624",
-    "lineCount": 219,
+    "lineCount": 218,
     "axiomCount": 5,
     "theoremCount": 4,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-629/meta.json
+++ b/src/data/proofs/erdos-629/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/629",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "lineCount": 912,
+    "lineCount": 911,
     "assumptions": "7 sorry(s). No axioms.",
     "mathlib_version": "4.26.0"
   },
@@ -175,7 +175,7 @@
       "Finset"
     ],
     "namespace": "Erdos629",
-    "lineCount": 912,
+    "lineCount": 911,
     "axiomCount": 0,
     "theoremCount": 37,
     "definitionCount": 14,

--- a/src/data/proofs/erdos-643/meta.json
+++ b/src/data/proofs/erdos-643/meta.json
@@ -49,7 +49,7 @@
       "Statement of Erd\u0151s-Rado Sunflower Lemma connection"
     ],
     "axiomCount": 3,
-    "lineCount": 1403,
+    "lineCount": 1402,
     "assumptions": "3 axiom(s) and 1 sorry(s). See the Lean source for details."
   },
   "overview": {
@@ -186,7 +186,7 @@
       "Classical"
     ],
     "namespace": "Harmonic.GeneralizeProofs",
-    "lineCount": 1403,
+    "lineCount": 1402,
     "axiomCount": 3,
     "theoremCount": 42,
     "definitionCount": 15,

--- a/src/data/proofs/erdos-69/meta.json
+++ b/src/data/proofs/erdos-69/meta.json
@@ -45,7 +45,7 @@
       "Structure connecting Problem 69 to Problem 257"
     ],
     "axiomCount": 1,
-    "lineCount": 189,
+    "lineCount": 188,
     "prerequisites": [
       "Arithmetic functions (\u03c9, d, \u03a9) and prime factorization",
       "Infinite series, absolute convergence, and summation interchange",
@@ -194,7 +194,7 @@
       "Finset"
     ],
     "namespace": "Erdos69",
-    "lineCount": 189,
+    "lineCount": 188,
     "axiomCount": 1,
     "theoremCount": 5,
     "definitionCount": 2,

--- a/src/data/proofs/erdos-795/meta.json
+++ b/src/data/proofs/erdos-795/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/795",
     "erdosProblemStatus": "solved",
     "axiomCount": 0,
-    "lineCount": 496,
+    "lineCount": 495,
     "assumptions": "14 sorry(s).",
     "mathlib_version": "4.26.0"
   },
@@ -167,7 +167,7 @@
     ],
     "opens": [],
     "namespace": "Erdos795",
-    "lineCount": 496,
+    "lineCount": 495,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-941/meta.json
+++ b/src/data/proofs/erdos-941/meta.json
@@ -58,7 +58,7 @@
       "generalizedQuestion: Problem #1107 connection"
     ],
     "axiomCount": 4,
-    "lineCount": 324,
+    "lineCount": 323,
     "assumptions": "4 axiom(s) and 0 sorry(s)."
   },
   "overview": {
@@ -178,7 +178,7 @@
       "Nat"
     ],
     "namespace": "Erdos941",
-    "lineCount": 324,
+    "lineCount": 323,
     "axiomCount": 4,
     "theoremCount": 11,
     "definitionCount": 13,


### PR DESCRIPTION
## Summary

Fixes discovered during gallery integrity audit (2026-04-26):
- `erdos-624`: 219 → 218
- `erdos-629`: 912 → 911
- `erdos-643`: 1403 → 1402
- `erdos-69`: 189 → 188
- `erdos-795`: 496 → 495
- `erdos-941`: 324 → 323

All verified with `wc -l`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)