### PR TITLE
fix(meta): correct lineCount off-by-one for 6 proofs (audit batch 4)

### DIFF
--- a/src/data/proofs/erdos-355/meta.json
+++ b/src/data/proofs/erdos-355/meta.json
@@ -48,7 +48,7 @@
       "Fibonacci-like sequence example with ratio approximately \u03c6"
     ],
     "axiomCount": 2,
-    "lineCount": 392,
+    "lineCount": 391,
     "assumptions": "2 axiom(s) and 0 sorry(s). See the Lean source for details."
   },
   "overview": {
@@ -147,7 +147,7 @@
       "Set"
     ],
     "namespace": "Erdos355",
-    "lineCount": 392,
+    "lineCount": 391,
     "axiomCount": 2,
     "theoremCount": 15,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-370/meta.json
+++ b/src/data/proofs/erdos-370/meta.json
@@ -64,12 +64,12 @@
       "erdos_370: injective-function encoding of infinitude (sorry'd)"
     ],
     "axiomCount": 2,
-    "lineCount": 285,
+    "lineCount": 284,
     "assumptions": "2 axioms (gpf_mul_le, dickman_density) and 2 sorries. gpf function and 7 properties now proved from Mathlib."
   },
   "leanFile": {
     "path": "Proofs/Erdos370Problem.lean",
-    "lineCount": 285,
+    "lineCount": 284,
     "namespace": "Erdos370",
     "imports": [
       "Mathlib"

--- a/src/data/proofs/erdos-45/meta.json
+++ b/src/data/proofs/erdos-45/meta.json
@@ -40,7 +40,7 @@
       }
     ],
     "axiomCount": 3,
-    "lineCount": 142,
+    "lineCount": 141,
     "prerequisites": [
       "Egyptian fractions and unit fraction decompositions",
       "Ramsey theory and monochromatic structures",
@@ -133,7 +133,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos45",
-    "lineCount": 142,
+    "lineCount": 141,
     "axiomCount": 3,
     "theoremCount": 3,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-517/meta.json
+++ b/src/data/proofs/erdos-517/meta.json
@@ -51,7 +51,7 @@
       "Verified example showing exponential sequences have Fej\u00e9r gaps"
     ],
     "dateAdded": "2025-12-22",
-    "lineCount": 176,
+    "lineCount": 175,
     "prerequisites": [
       "Complex analysis: entire functions, power series",
       "Lacunary (gap) series and Fabry/Fej\u00e9r gap conditions",
@@ -145,7 +145,7 @@
       "Topology"
     ],
     "namespace": "Erdos517",
-    "lineCount": 176,
+    "lineCount": 175,
     "axiomCount": 1,
     "theoremCount": 3,
     "definitionCount": 3,

--- a/src/data/proofs/erdos-551/meta.json
+++ b/src/data/proofs/erdos-551/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/551",
     "erdosProblemStatus": "solved",
     "axiomCount": 0,
-    "lineCount": 604,
+    "lineCount": 603,
     "assumptions": "No axioms. 22 sorry(s) remain in the formalization.",
     "mathlib_version": "4.26.0"
   },
@@ -175,7 +175,7 @@
       "Finset"
     ],
     "namespace": "Erdos551",
-    "lineCount": 604,
+    "lineCount": 603,
     "axiomCount": 0,
     "theoremCount": 26,
     "definitionCount": 14,

--- a/src/data/proofs/erdos-604/meta.json
+++ b/src/data/proofs/erdos-604/meta.json
@@ -59,7 +59,7 @@
       "Crossing number inequality",
       "Number theory (sums of two squares, Landau's theorem)"
     ],
-    "lineCount": 224,
+    "lineCount": 223,
     "assumptions": "No axioms. 1 sorry remaining: integerLattice_pinnedDistances (deep constructive existence). maxPinnedDistances and pinnedDistance_le are now sorry-free.",
     "mathlib_version": "4.26.0"
   },
@@ -184,7 +184,7 @@
       "Set"
     ],
     "namespace": null,
-    "lineCount": 224,
+    "lineCount": 223,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 11,


### PR DESCRIPTION
## Summary

Fixes from gallery integrity audit (2026-04-26):
- `erdos-45`: 142 → 141
- `erdos-355`: 392 → 391
- `erdos-370`: 285 → 284
- `erdos-517`: 176 → 175
- `erdos-551`: 604 → 603
- `erdos-604`: 224 → 223

All verified with `wc -l`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)