### PR TITLE
fix(meta): correct lineCount off-by-one for 7 proofs (audit batch 5)

### DIFF
--- a/src/data/proofs/erdos-29/meta.json
+++ b/src/data/proofs/erdos-29/meta.json
@@ -22,7 +22,7 @@
     "erdosProblemStatus": "solved",
     "erdosPrizeValue": "$100",
     "axiomCount": 5,
-    "lineCount": 524,
+    "lineCount": 523,
     "assumptions": "5 axioms: JPSZ_set (explicit construction), JPSZ_is_basis, JPSZ_representation_bound, JPSZ_explicit, JPSZ_size_optimal. JPSZ_is_economical and JPSZ_density_zero fully proved as consequences (not independent axioms): economical follows from representation bound via exp(C√(log n) - ε·log n) → -∞, density zero follows from size optimal via squeeze with C·√(log N/N) → 0. 0 sorries.",
     "prerequisites": [
       "Additive bases and Waring's problem",
@@ -171,7 +171,7 @@
       "Filter"
     ],
     "namespace": "Erdos29",
-    "lineCount": 524,
+    "lineCount": 523,
     "axiomCount": 5,
     "theoremCount": 12,
     "definitionCount": 12,

--- a/src/data/proofs/erdos-299/meta.json
+++ b/src/data/proofs/erdos-299/meta.json
@@ -54,7 +54,7 @@
       "Proof that powers of 2 have unbounded gaps"
     ],
     "axiomCount": 1,
-    "lineCount": 387,
+    "lineCount": 386,
     "assumptions": "1 axiom (bloom_theorem: Bloom's 2021 result on positive density sets). 0 sorries."
   },
   "overview": {
@@ -170,7 +170,7 @@
       "Finset"
     ],
     "namespace": "Erdos299",
-    "lineCount": 387,
+    "lineCount": 386,
     "axiomCount": 1,
     "theoremCount": 10,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-303/meta.json
+++ b/src/data/proofs/erdos-303/meta.json
@@ -54,7 +54,7 @@
       "Connection to density version (Erd\u0151s #302)"
     ],
     "axiomCount": 2,
-    "lineCount": 259,
+    "lineCount": 258,
     "assumptions": "2 axioms: brownRodl_theorem, erdos303_true. See Lean source for complete statements."
   },
   "overview": {
@@ -144,7 +144,7 @@
       "Set"
     ],
     "namespace": "Erdos303",
-    "lineCount": 259,
+    "lineCount": 258,
     "axiomCount": 2,
     "theoremCount": 8,
     "definitionCount": 8,

--- a/src/data/proofs/erdos-402/meta.json
+++ b/src/data/proofs/erdos-402/meta.json
@@ -60,7 +60,7 @@
       "erdos_402_contains_one: conjecture proved when 1 \u2208 A"
     ],
     "axiomCount": 0,
-    "lineCount": 694,
+    "lineCount": 693,
     "assumptions": "1 sorry: erdos_402_graham_conjecture (main conjecture, requires Balasubramanian-Soundararajan sieve argument). Quadruple case fully proved."
   },
   "overview": {
@@ -177,7 +177,7 @@
       "Finset"
     ],
     "namespace": "Erdos402",
-    "lineCount": 694,
+    "lineCount": 693,
     "axiomCount": 0,
     "theoremCount": 25,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-485/meta.json
+++ b/src/data/proofs/erdos-485/meta.json
@@ -23,7 +23,7 @@
     "erdosUrl": "https://erdosproblems.com/485",
     "erdosProblemStatus": "solved",
     "axiomCount": 1,
-    "lineCount": 226,
+    "lineCount": 225,
     "assumptions": "1 axiom: schinzel_zannier_improved (Schinzel-Zannier 2009: f(k) ≫ log k). This deep algebraic result is not yet in Mathlib.",
     "mathlib_version": "4.26.0"
   },
@@ -115,7 +115,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos485",
-    "lineCount": 226,
+    "lineCount": 225,
     "axiomCount": 1,
     "theoremCount": 3,
     "definitionCount": 6,

--- a/src/data/proofs/navier-stokes-oq-01/meta.json
+++ b/src/data/proofs/navier-stokes-oq-01/meta.json
@@ -60,7 +60,7 @@
       "Theorem total_dissipation_bound: \u222b\u2080\u1d40 2\u03bdP(t) dt \u2264 E(0), total dissipation bounded by initial enstrophy"
     ],
     "dateAdded": "2026-02-26",
-    "lineCount": 21111,
+    "lineCount": 21110,
     "assumptions": "None. Formalized with 0 axioms and 0 sorries remain.",
     "relatedProblems": [
       {
@@ -181,7 +181,7 @@
       "TwoDimensionalGlobal"
     ],
     "namespace": "NavierStokesRegularity",
-    "lineCount": 21111,
+    "lineCount": 21110,
     "axiomCount": 0,
     "theoremCount": 846,
     "definitionCount": 104,

--- a/src/data/proofs/navier-stokes-oq-02/meta.json
+++ b/src/data/proofs/navier-stokes-oq-02/meta.json
@@ -59,7 +59,7 @@
       "Theorem continuous_dependence_2d: for any \u03b5 > 0, threshold \u03b4 = \u03b5\u00b7exp(-C\u00b7E(0)\u00b7T) gives W(0) \u2264 \u03b4 implies W(t) \u2264 \u03b5, establishing Hadamard well-posedness"
     ],
     "dateAdded": "2026-02-28",
-    "lineCount": 21111,
+    "lineCount": 21110,
     "assumptions": "1 structure-encoded assumption: NSSolutionPair2D.stability_estimate (Ladyzhenskaya stability estimate W'(t) \u2264 C\u00b7E(t)\u00b7W(t), the core PDE estimate \u2014 mathematically known but not formalized in this file)",
     "mathlib_version": "4.26.0"
   },
@@ -202,7 +202,7 @@
       "TwoDimensionalGlobal"
     ],
     "namespace": "NavierStokesRegularity",
-    "lineCount": 21111,
+    "lineCount": 21110,
     "axiomCount": 0,
     "theoremCount": 846,
     "definitionCount": 104,


### PR DESCRIPTION
## Summary

Fixes from gallery integrity audit (2026-04-26):
- `erdos-29`: 524 → 523
- `erdos-299`: 387 → 386
- `erdos-303`: 259 → 258
- `erdos-402`: 694 → 693
- `erdos-485`: 226 → 225
- `navier-stokes-oq-01`: 21111 → 21110
- `navier-stokes-oq-02`: 21111 → 21110

All verified with `wc -l`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)