### PR TITLE
fix(meta): correct lineCount off-by-one for 3 proofs (audit batch 6)

### DIFF
--- a/src/data/proofs/erdos-1028/meta.json
+++ b/src/data/proofs/erdos-1028/meta.json
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "solved",
     "relatedProblems": [],
     "axiomCount": 2,
-    "lineCount": 311,
+    "lineCount": 310,
     "assumptions": "2 axioms: erdos_upper, erdos_spencer_lower. 0 sorries.",
     "mathlib_version": "4.26.0"
   },
@@ -238,7 +238,7 @@
       "Finset"
     ],
     "namespace": "Erdos1028",
-    "lineCount": 311,
+    "lineCount": 310,
     "axiomCount": 2,
     "theoremCount": 8,
     "definitionCount": 10,

--- a/src/data/proofs/erdos-1034/meta.json
+++ b/src/data/proofs/erdos-1034/meta.json
@@ -26,7 +26,7 @@
       "erdos-1033"
     ],
     "axiomCount": 1,
-    "lineCount": 779,
+    "lineCount": 778,
     "assumptions": "1 axiom: maTang_counterexample. 3 sorries.",
     "mathlib_version": "4.26.0"
   },
@@ -273,7 +273,7 @@
       "Finset"
     ],
     "namespace": "Erdos1034",
-    "lineCount": 779,
+    "lineCount": 778,
     "axiomCount": 1,
     "theoremCount": 17,
     "definitionCount": 22,

--- a/src/data/proofs/erdos-1161/meta.json
+++ b/src/data/proofs/erdos-1161/meta.json
@@ -54,7 +54,7 @@
       "Small cases: explicit counts for S_1, S_2, S_3"
     ],
     "axiomCount": 0,
-    "lineCount": 324,
+    "lineCount": 323,
     "assumptions": "0 axioms, 0 sorries. All results proved from Lean primitives."
   },
   "overview": {
@@ -143,7 +143,7 @@
       "Nat"
     ],
     "namespace": null,
-    "lineCount": 324,
+    "lineCount": 323,
     "axiomCount": 0,
     "theoremCount": 15,
     "definitionCount": 3,


### PR DESCRIPTION
## Summary

Fixes from gallery integrity audit (2026-04-26):
- `erdos-1028`: 311 → 310
- `erdos-1034`: 779 → 778
- `erdos-1161`: 324 → 323

All verified with `wc -l`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)