### PR TITLE
fix(meta): correct lineCount off-by-one for 3 proofs (audit batch 7)

### DIFF
--- a/src/data/proofs/erdos-157/meta.json
+++ b/src/data/proofs/erdos-157/meta.json
@@ -59,7 +59,7 @@
       "Verified theorem: powers_of_two_sidon"
     ],
     "axiomCount": 3,
-    "lineCount": 536,
+    "lineCount": 535,
     "assumptions": "3 axioms: (1) pilatte_existence — the Pilatte 2023 existence result (infinite Sidon set that is an asymptotic basis of order 3); (2) sidon_counting_bound — counting bound for Sidon sets; (3) basis_counting_lower — lower bound for basis counting. 0 sorries (previously 1 sorry for pilatte_existence was axiomatized; sidon_counting_contradiction proved by Aristotle)."
   },
   "overview": {
@@ -159,7 +159,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos157",
-    "lineCount": 536,
+    "lineCount": 535,
     "axiomCount": 3,
     "theoremCount": 7,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-866/meta.json
+++ b/src/data/proofs/erdos-866/meta.json
@@ -54,7 +54,7 @@
       "Four open problems formalized as Lean propositions"
     ],
     "axiomCount": 0,
-    "lineCount": 85,
+    "lineCount": 84,
     "assumptions": "0 axioms. 0 sorries. All results formalized without axioms."
   },
   "overview": {
@@ -142,7 +142,7 @@
       "Real"
     ],
     "namespace": "Erdos866",
-    "lineCount": 85,
+    "lineCount": 84,
     "axiomCount": 0,
     "theoremCount": 3,
     "definitionCount": 10,

--- a/src/data/proofs/navier-stokes-existence/meta.json
+++ b/src/data/proofs/navier-stokes-existence/meta.json
@@ -63,7 +63,7 @@
     ],
     "dateAdded": "2026-03-14",
     "relatedProblems": [],
-    "lineCount": 21111,
+    "lineCount": 21110,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -264,7 +264,7 @@
       "TwoDimensionalGlobal"
     ],
     "namespace": "NavierStokesRegularity",
-    "lineCount": 21111,
+    "lineCount": 21110,
     "axiomCount": 0,
     "theoremCount": 846,
     "definitionCount": 104,


### PR DESCRIPTION
## Summary

Fixes from gallery integrity audit (2026-04-26):
- `erdos-157`: 536 → 535
- `erdos-866`: 85 → 84
- `navier-stokes-existence`: 21111 → 21110

All verified with `wc -l`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)