### PR TITLE
fix(meta): correct lineCount off-by-one for 32 proofs (audit batch 2026-04-27)

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral/meta.json
@@ -43,7 +43,7 @@
     ],
     "dateAdded": "2026-02-11",
     "axiomCount": 0,
-    "lineCount": 117,
+    "lineCount": 118,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-1028/meta.json
+++ b/src/data/proofs/erdos-1028/meta.json
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "solved",
     "relatedProblems": [],
     "axiomCount": 2,
-    "lineCount": 310,
+    "lineCount": 311,
     "assumptions": "2 axioms: erdos_upper, erdos_spencer_lower. 0 sorries.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-1034/meta.json
+++ b/src/data/proofs/erdos-1034/meta.json
@@ -26,7 +26,7 @@
       "erdos-1033"
     ],
     "axiomCount": 1,
-    "lineCount": 778,
+    "lineCount": 779,
     "assumptions": "1 axiom: maTang_counterexample. 3 sorries.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-108/meta.json
+++ b/src/data/proofs/erdos-108/meta.json
@@ -46,7 +46,7 @@
       "Special case extraction for R\u00f6dl's r=4 theorem"
     ],
     "axiomCount": 1,
-    "lineCount": 141,
+    "lineCount": 142,
     "assumptions": "1 axiom: erdos_hajnal_rodl_theorem. See Lean source for the complete statement."
   },
   "overview": {

--- a/src/data/proofs/erdos-109/meta.json
+++ b/src/data/proofs/erdos-109/meta.json
@@ -49,7 +49,7 @@
       "Verified example for even numbers"
     ],
     "axiomCount": 1,
-    "lineCount": 437,
+    "lineCount": 438,
     "assumptions": "1 axiom: moreira_richter_robertson. See Lean source for the complete statement."
   },
   "overview": {

--- a/src/data/proofs/erdos-1161/meta.json
+++ b/src/data/proofs/erdos-1161/meta.json
@@ -54,7 +54,7 @@
       "Small cases: explicit counts for S_1, S_2, S_3"
     ],
     "axiomCount": 0,
-    "lineCount": 323,
+    "lineCount": 324,
     "assumptions": "0 axioms, 0 sorries. All results proved from Lean primitives."
   },
   "overview": {

--- a/src/data/proofs/erdos-123/meta.json
+++ b/src/data/proofs/erdos-123/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/123",
     "erdosProblemStatus": "open",
     "axiomCount": 3,
-    "lineCount": 317,
+    "lineCount": 318,
     "assumptions": "3 axiom(s): powers23_repr, erdos_123_conjecture, erdos_lewin_357. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-139/meta.json
+++ b/src/data/proofs/erdos-139/meta.json
@@ -30,7 +30,7 @@
       "Szemerédi regularity lemma (for understanding the proof chain)",
       "Roth's theorem and the corners theorem (k=3 case)"
     ],
-    "lineCount": 260,
+    "lineCount": 261,
     "assumptions": "4 axioms: kelley_meka_bound (r₃(N) ≤ N·exp(−c(log N)^(1/12)), Kelley-Meka 2023), gowers_bound (r_k(N) ≤ N/(log log N)^c for k≥4, Gowers 2001), behrend_lower_bound (r₃(N) ≥ N·exp(−c√(log N)), Behrend 1946), szemeredi_theorem (sets with positive density contain k-APs for all k). 1 sorry: main density-to-zero proof.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-143/meta.json
+++ b/src/data/proofs/erdos-143/meta.json
@@ -46,7 +46,7 @@
       "Formalized the KLL 2025 partial resolution"
     ],
     "axiomCount": 3,
-    "lineCount": 119,
+    "lineCount": 120,
     "assumptions": "3 axiom(s): kll_theorem, well_separated_integers_primitive, erdos_1935_primitive. See Lean source for complete statements."
   },
   "overview": {

--- a/src/data/proofs/erdos-157/meta.json
+++ b/src/data/proofs/erdos-157/meta.json
@@ -59,7 +59,7 @@
       "Verified theorem: powers_of_two_sidon"
     ],
     "axiomCount": 3,
-    "lineCount": 535,
+    "lineCount": 536,
     "assumptions": "3 axioms: (1) pilatte_existence — the Pilatte 2023 existence result (infinite Sidon set that is an asymptotic basis of order 3); (2) sidon_counting_bound — counting bound for Sidon sets; (3) basis_counting_lower — lower bound for basis counting. 0 sorries (previously 1 sorry for pilatte_existence was axiomatized; sidon_counting_contradiction proved by Aristotle)."
   },
   "overview": {

--- a/src/data/proofs/erdos-167/meta.json
+++ b/src/data/proofs/erdos-167/meta.json
@@ -28,7 +28,7 @@
       "extremal combinatorics",
       "linear programming relaxation"
     ],
-    "lineCount": 274,
+    "lineCount": 275,
     "assumptions": "1 axiom: IsPlanar. 0 sorries.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-168/meta.json
+++ b/src/data/proofs/erdos-168/meta.json
@@ -55,7 +55,7 @@
       "Formalized the irrationality question"
     ],
     "axiomCount": 2,
-    "lineCount": 180,
+    "lineCount": 181,
     "assumptions": "2 axioms: gsw_limit_exists, better_construction. 0 sorries."
   },
   "overview": {

--- a/src/data/proofs/erdos-171/meta.json
+++ b/src/data/proofs/erdos-171/meta.json
@@ -56,7 +56,7 @@
       "Aristotle-verified: no_4_clique (no tetrahedron in ℝ²)"
     ],
     "axiomCount": 2,
-    "lineCount": 302,
+    "lineCount": 303,
     "references": [
       {
         "title": "The chromatic number of the plane is at least 5",

--- a/src/data/proofs/erdos-172/meta.json
+++ b/src/data/proofs/erdos-172/meta.json
@@ -46,7 +46,7 @@
       "Explicit connection between finite and infinite versions"
     ],
     "axiomCount": 3,
-    "lineCount": 144,
+    "lineCount": 145,
     "references": [
       {
         "title": "Monochromatic sums and products in ℕ",

--- a/src/data/proofs/erdos-202/meta.json
+++ b/src/data/proofs/erdos-202/meta.json
@@ -53,7 +53,7 @@
       "Multiple theorems proved by Aristotle including f_mono, f_le_N, L_mono, L_subpolynomial"
     ],
     "axiomCount": 0,
-    "lineCount": 859,
+    "lineCount": 860,
     "assumptions": "3 sorry(s). No axioms."
   },
   "overview": {

--- a/src/data/proofs/erdos-29/meta.json
+++ b/src/data/proofs/erdos-29/meta.json
@@ -22,7 +22,7 @@
     "erdosProblemStatus": "solved",
     "erdosPrizeValue": "$100",
     "axiomCount": 5,
-    "lineCount": 523,
+    "lineCount": 524,
     "assumptions": "5 axioms: JPSZ_set (explicit construction), JPSZ_is_basis, JPSZ_representation_bound, JPSZ_explicit, JPSZ_size_optimal. JPSZ_is_economical and JPSZ_density_zero fully proved as consequences (not independent axioms): economical follows from representation bound via exp(C√(log n) - ε·log n) → -∞, density zero follows from size optimal via squeeze with C·√(log N/N) → 0. 0 sorries.",
     "prerequisites": [
       "Additive bases and Waring's problem",

--- a/src/data/proofs/erdos-299/meta.json
+++ b/src/data/proofs/erdos-299/meta.json
@@ -54,7 +54,7 @@
       "Proof that powers of 2 have unbounded gaps"
     ],
     "axiomCount": 1,
-    "lineCount": 386,
+    "lineCount": 387,
     "assumptions": "1 axiom (bloom_theorem: Bloom's 2021 result on positive density sets). 0 sorries."
   },
   "overview": {

--- a/src/data/proofs/erdos-303/meta.json
+++ b/src/data/proofs/erdos-303/meta.json
@@ -54,7 +54,7 @@
       "Connection to density version (Erd\u0151s #302)"
     ],
     "axiomCount": 2,
-    "lineCount": 258,
+    "lineCount": 259,
     "assumptions": "2 axioms: brownRodl_theorem, erdos303_true. See Lean source for complete statements."
   },
   "overview": {

--- a/src/data/proofs/erdos-355/meta.json
+++ b/src/data/proofs/erdos-355/meta.json
@@ -48,7 +48,7 @@
       "Fibonacci-like sequence example with ratio approximately \u03c6"
     ],
     "axiomCount": 2,
-    "lineCount": 391,
+    "lineCount": 392,
     "assumptions": "2 axiom(s) and 0 sorry(s). See the Lean source for details."
   },
   "overview": {

--- a/src/data/proofs/erdos-37/meta.json
+++ b/src/data/proofs/erdos-37/meta.json
@@ -80,7 +80,7 @@
       "Classical axioms: schnirelmann_theorem, mann_theorem"
     ],
     "axiomCount": 6,
-    "lineCount": 367,
+    "lineCount": 368,
     "prerequisites": [
       "Essential components in additive number theory",
       "Lacunary sequences and their properties",

--- a/src/data/proofs/erdos-370/meta.json
+++ b/src/data/proofs/erdos-370/meta.json
@@ -64,7 +64,7 @@
       "erdos_370: injective-function encoding of infinitude (sorry'd)"
     ],
     "axiomCount": 2,
-    "lineCount": 284,
+    "lineCount": 285,
     "assumptions": "2 axioms (gpf_mul_le, dickman_density) and 2 sorries. gpf function and 7 properties now proved from Mathlib."
   },
   "leanFile": {

--- a/src/data/proofs/erdos-45/meta.json
+++ b/src/data/proofs/erdos-45/meta.json
@@ -40,7 +40,7 @@
       }
     ],
     "axiomCount": 3,
-    "lineCount": 141,
+    "lineCount": 142,
     "prerequisites": [
       "Egyptian fractions and unit fraction decompositions",
       "Ramsey theory and monochromatic structures",

--- a/src/data/proofs/erdos-485/meta.json
+++ b/src/data/proofs/erdos-485/meta.json
@@ -23,7 +23,7 @@
     "erdosUrl": "https://erdosproblems.com/485",
     "erdosProblemStatus": "solved",
     "axiomCount": 1,
-    "lineCount": 225,
+    "lineCount": 226,
     "assumptions": "1 axiom: schinzel_zannier_improved (Schinzel-Zannier 2009: f(k) ≫ log k). This deep algebraic result is not yet in Mathlib.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-517/meta.json
+++ b/src/data/proofs/erdos-517/meta.json
@@ -51,7 +51,7 @@
       "Verified example showing exponential sequences have Fej\u00e9r gaps"
     ],
     "dateAdded": "2025-12-22",
-    "lineCount": 175,
+    "lineCount": 176,
     "prerequisites": [
       "Complex analysis: entire functions, power series",
       "Lacunary (gap) series and Fabry/Fej\u00e9r gap conditions",

--- a/src/data/proofs/erdos-551/meta.json
+++ b/src/data/proofs/erdos-551/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/551",
     "erdosProblemStatus": "solved",
     "axiomCount": 0,
-    "lineCount": 603,
+    "lineCount": 604,
     "assumptions": "No axioms. 22 sorry(s) remain in the formalization.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-604/meta.json
+++ b/src/data/proofs/erdos-604/meta.json
@@ -59,7 +59,7 @@
       "Crossing number inequality",
       "Number theory (sums of two squares, Landau's theorem)"
     ],
-    "lineCount": 223,
+    "lineCount": 224,
     "assumptions": "No axioms. 1 sorry remaining: integerLattice_pinnedDistances (deep constructive existence). maxPinnedDistances and pinnedDistance_le are now sorry-free.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-624/meta.json
+++ b/src/data/proofs/erdos-624/meta.json
@@ -57,7 +57,7 @@
     ],
     "dateAdded": "2025-12-27",
     "axiomCount": 5,
-    "lineCount": 218,
+    "lineCount": 219,
     "assumptions": "5 axioms: erdos_hajnal_upper_bound, erdos_624_open, weaker_conjecture_open, and 2 more. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-629/meta.json
+++ b/src/data/proofs/erdos-629/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/629",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "lineCount": 911,
+    "lineCount": 912,
     "assumptions": "7 sorry(s). No axioms.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-643/meta.json
+++ b/src/data/proofs/erdos-643/meta.json
@@ -49,7 +49,7 @@
       "Statement of Erd\u0151s-Rado Sunflower Lemma connection"
     ],
     "axiomCount": 3,
-    "lineCount": 1402,
+    "lineCount": 1403,
     "assumptions": "3 axiom(s) and 1 sorry(s). See the Lean source for details."
   },
   "overview": {

--- a/src/data/proofs/erdos-69/meta.json
+++ b/src/data/proofs/erdos-69/meta.json
@@ -45,7 +45,7 @@
       "Structure connecting Problem 69 to Problem 257"
     ],
     "axiomCount": 1,
-    "lineCount": 188,
+    "lineCount": 189,
     "prerequisites": [
       "Arithmetic functions (\u03c9, d, \u03a9) and prime factorization",
       "Infinite series, absolute convergence, and summation interchange",

--- a/src/data/proofs/erdos-795/meta.json
+++ b/src/data/proofs/erdos-795/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/795",
     "erdosProblemStatus": "solved",
     "axiomCount": 0,
-    "lineCount": 495,
+    "lineCount": 496,
     "assumptions": "14 sorry(s).",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-941/meta.json
+++ b/src/data/proofs/erdos-941/meta.json
@@ -58,7 +58,7 @@
       "generalizedQuestion: Problem #1107 connection"
     ],
     "axiomCount": 4,
-    "lineCount": 323,
+    "lineCount": 324,
     "assumptions": "4 axiom(s) and 0 sorry(s)."
   },
   "overview": {


### PR DESCRIPTION
## Fix

Syncs `lineCount` in 32 gallery meta.json files where the Lean sources grew by one line since last sync.

## Evidence

**Before**: Each of 32 proofs had `lineCount` stale by exactly +1 (meta says N, actual file has N+1 lines).

**After**: All 32 `lineCount` values match actual Lean file lengths. Sorry counts verified unchanged.

All proofs affected:
cauchy-schwarz-integral (117→118), erdos-1028 (310→311), erdos-1034 (778→779), erdos-108 (141→142), erdos-109 (437→438), erdos-1161 (323→324), erdos-123 (317→318), erdos-139 (260→261), erdos-143 (119→120), erdos-157 (535→536), erdos-167 (274→275), erdos-168 (180→181), erdos-171 (302→303), erdos-172 (144→145), erdos-202 (859→860), erdos-29 (523→524), erdos-299 (386→387), erdos-303 (258→259), erdos-355 (391→392), erdos-37 (367→368), erdos-370 (284→285), erdos-45 (141→142), erdos-485 (225→226), erdos-517 (175→176), erdos-551 (603→604), erdos-604 (223→224), erdos-624 (218→219), erdos-629 (911→912), erdos-643 (1402→1403), erdos-69 (188→189), erdos-795 (495→496), erdos-941 (323→324).

---
Automated fix by lean-mechanic agent.