### PR TITLE
fix(meta): sync 5 stale gallery entries (sorries + lineCount)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
@@ -56,7 +56,7 @@
     ],
     "dateAdded": "2026-02-24",
     "axiomCount": 0,
-    "lineCount": 1938,
+    "lineCount": 1937,
     "assumptions": "0 sorries. The IBP formula fourierCoeffOn_deriv_periodic is now proved via import from AreaOfCircleOQ01OQ02OQ02.lean.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "ballot-problem-oq-03-oq-01-oq-02",
   "title": "Hook-Length Formula for Standard Young Tableaux via LGV",
   "slug": "ballot-problem-oq-03-oq-01-oq-02",
-  "description": "Formalizes the hook-length formula f^λ = n!/∏h(u) for Standard Young Tableaux. Proves: 1-row, 1-col, hook shapes, 2-rect, general 2-row, all gHookYD [a,1^b], ≤2-col, ≤10-col (transpose duality), exactly 3-row through 10-row ALL shapes (PARTS XIV-XXVI). General formula has 4 sorries: 3 via LGV approach + 1 for hook_walk_identity (≥11-row, ≥11-col, non-gHookYD).",
+  "description": "Formalizes the hook-length formula f^λ = n!/∏h(u) for Standard Young Tableaux. Proves: 1-row, 1-col, hook shapes, 2-rect, general 2-row, all gHookYD [a,1^b], ≤2-col, ≤10-col (transpose duality), exactly 3-row through 10-row ALL shapes (PARTS XIV-XXVI). General formula has 3 sorries: 2 via LGV approach + 1 for hook_walk_identity (≥11-row, ≥11-col, non-gHookYD). hook_length_formula proved via alias.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-21",
@@ -19,11 +19,11 @@
       "representation-theory"
     ],
     "badge": "wip",
-    "sorries": 4,
+    "sorries": 3,
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "assumptions": "Four open sorries: (1) hook_length_formula (LGV approach: requires SYT↔NI bijection + det factorization), (2) ni_count_eq_syt_count (Fomin/Viennot/RSK correspondence), (3) lgv_det_factors_as_hook_quotient (det factorization identity), (4) hook_walk_identity ≥11-row AND ≥11-col non-gHookYD case (GNW probabilistic proof; at-most-2-row, gHookYD, ≤2-col, exactly-3-row through exactly-10-row ALL proved; ≤10-col via transpose duality). hook_length_formula_general is proved modulo hook_walk_identity via corner induction.",
-    "lineCount": 16029,
+    "assumptions": "Three open sorries: (1) ni_count_eq_syt_count (Fomin/Viennot/RSK correspondence), (2) lgv_det_factors_as_hook_quotient (det factorization identity), (3) hook_walk_identity ≥11-row AND ≥11-col non-gHookYD case (GNW probabilistic proof; at-most-2-row, gHookYD, ≤2-col, exactly-3-row through exactly-10-row ALL proved; ≤10-col via transpose duality). hook_length_formula is proved via alias. hook_length_formula_general is proved modulo hook_walk_identity via corner induction.",
+    "lineCount": 16248,
     "theoremCount": 464,
     "definitionCount": 14,
     "originalContributions": [

--- a/src/data/proofs/erdos-60/meta.json
+++ b/src/data/proofs/erdos-60/meta.json
@@ -51,7 +51,7 @@
       "conjecture_implies_two_copies: Aristotle-proved implication"
     ],
     "axiomCount": 8,
-    "lineCount": 386,
+    "lineCount": 385,
     "prerequisites": [
       "Extremal graph theory (Tur\u00e1n-type problems)",
       "4-cycles (C\u2084) in graphs",

--- a/src/data/proofs/hurwitz-theorem-oq-04/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-04/meta.json
@@ -18,11 +18,11 @@
       "advanced"
     ],
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 1,
     "dateAdded": "2026-04-24",
     "axiomCount": 0,
-    "assumptions": "2 sorries remaining: (1) algebraic extraction from ev=0 in derEval14_injective helper (requires ~50 lines of Leibniz constraint derivations); (2) linear independence of derBasis14 (14×14 evaluation matrix determinant). G2_der_dimension is now a theorem with proof structure, no longer an axiom. All other lemmas fully proved.",
-    "lineCount": 1052,
+    "assumptions": "1 sorry remaining: algebraic extraction from ev=0 in derEval14_injective helper (requires ~50 lines of Leibniz constraint derivations). derBasis14_linearIndependent is now proved (14 Baez derivations shown linearly independent). G2_der_dimension is a theorem with proof structure. All other lemmas fully proved.",
+    "lineCount": 1104,
     "theoremCount": 35,
     "definitionCount": 17,
     "originalContributions": [

--- a/src/data/proofs/navier-stokes/meta.json
+++ b/src/data/proofs/navier-stokes/meta.json
@@ -73,7 +73,7 @@
     "millenniumProblem": "navier-stokes",
     "proofRepoPath": "Proofs/NavierStokes.lean",
     "mathlib_version": "4.26.0",
-    "lineCount": 21111
+    "lineCount": 21110
   },
   "objection": {
     "verdict": "CONDITIONAL 3D + PROVEN 2D",


### PR DESCRIPTION
## Fix

Syncs metadata for 5 gallery proofs where the Lean sources diverged from meta.json.

## Evidence

**Sorry count updates** (proofs advanced by researchers):
- `hurwitz-theorem-oq-04`: sorries 2→1 — `derBasis14_linearIndependent` proved in PR #13010
- `ballot-problem-oq-03-oq-01-oq-02`: sorries 4→3 — `hook_length_formula` proved in PR #12965

**LineCount updates** (verified with `wc -l`):
- `hurwitz-theorem-oq-04`: 1052→1104 (+52 lines from PR #13010)
- `ballot-problem-oq-03-oq-01-oq-02`: 16029→16248 (+219 lines from recent research)
- `area-of-circle-oq-01-oq-03`: 1938→1937 (shrank by 1)
- `erdos-60`: 386→385 (shrank by 1)
- `navier-stokes-regularity`: 21111→21110 (shrank by 1)

Also updates `assumptions` text for hurwitz and ballot-problem to accurately describe remaining sorries.

---
Automated fix by lean-mechanic agent.