### PR TITLE
fix(meta): sync leanFile.sorries + lineCount for hurwitz-oq-04 and ballot-hlf

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
@@ -267,7 +267,7 @@
       "Topology"
     ],
     "namespace": "IsoperimetricOQ",
-    "lineCount": 1938,
+    "lineCount": 1937,
     "axiomCount": 0,
     "theoremCount": 68,
     "definitionCount": 12,

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -91,9 +91,9 @@
       "LGV"
     ],
     "namespace": "HookLengthFormula",
-    "lineCount": 16029,
+    "lineCount": 16248,
     "axiomCount": 0,
-    "sorries": 4,
+    "sorries": 3,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",
     "theoremCount": 521,
     "definitionCount": 14
@@ -202,5 +202,5 @@
       "mathContext": "$h(\\mu,i,j) = h(\\mu^\\top,j,i)$ (arm↔leg under transpose). For N-row shapes: hook walk identity $\\sum_c \\text{hookProd}(\\mu)/\\text{hookProd}(\\mu\\setminus c) = \\sum_i a_i$ is a polynomial identity in $a_1,\\ldots,a_N$, verifiable by `ring` after computing each hook length as a linear combination of $a_i$."
     }
   ],
-  "sorries": 4
+  "sorries": 3
 }

--- a/src/data/proofs/erdos-60/meta.json
+++ b/src/data/proofs/erdos-60/meta.json
@@ -182,7 +182,7 @@
       "Finset"
     ],
     "namespace": "Erdos60",
-    "lineCount": 386,
+    "lineCount": 385,
     "axiomCount": 8,
     "theoremCount": 10,
     "definitionCount": 12,

--- a/src/data/proofs/hurwitz-theorem-oq-04/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-04/meta.json
@@ -137,11 +137,11 @@
       "HurwitzTheorem"
     ],
     "namespace": "HurwitzTheoremOQ04",
-    "lineCount": 1052,
+    "lineCount": 1104,
     "axiomCount": 0,
     "theoremCount": 40,
     "definitionCount": 15,
-    "sorries": 2,
+    "sorries": 1,
     "path": "Proofs/HurwitzTheoremOQ04.lean"
   },
   "crossReferences": [
@@ -156,5 +156,5 @@
       "description": "Sibling open question: n-square identities and normed division algebras"
     }
   ],
-  "sorries": 2
+  "sorries": 1
 }

--- a/src/data/proofs/navier-stokes/meta.json
+++ b/src/data/proofs/navier-stokes/meta.json
@@ -335,7 +335,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 21111,
+    "lineCount": 21110,
     "structureCount": 249,
     "axiomCount": 0,
     "theoremCount": 846,


### PR DESCRIPTION
## Fix

PR #13034 updated \`meta.lineCount\` and \`meta.sorries\` for several proofs, but left corresponding \`leanFile.lineCount\`, \`leanFile.sorries\`, and top-level \`sorries\` fields stale.

## Evidence

**hurwitz-theorem-oq-04** (leanFile fields stale after #13034):
- Before: \`leanFile.sorries: 2\`, \`leanFile.lineCount: 1052\`, top-level \`sorries: 2\`
- After: \`leanFile.sorries: 1\`, \`leanFile.lineCount: 1104\`, top-level \`sorries: 1\`

**ballot-problem-oq-03-oq-01-oq-02** (leanFile fields stale after #13034):
- Before: \`leanFile.sorries: 4\`, \`leanFile.lineCount: 16029\`, top-level \`sorries: 4\`
- After: \`leanFile.sorries: 3\`, \`leanFile.lineCount: 16248\`, top-level \`sorries: 3\`

**area-of-circle-oq-01-oq-03** (leanFile.lineCount stale after #13034):
- Before: \`leanFile.lineCount: 1938\` | After: 1937

**erdos-60** (leanFile.lineCount stale after #13034):
- Before: \`leanFile.lineCount: 386\` | After: 385

**navier-stokes** (leanFile.lineCount stale after #13034):
- Before: \`leanFile.lineCount: 21111\` | After: 21110

All verified against current Lean source files.

Supersedes conflicting PRs #13044 and #13040.

---
Automated fix by lean-mechanic agent.