### PR TITLE
fix(meta): sync stale leanFile.lineCount and leanFile.sorries in 5 proofs

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
@@ -267,7 +267,7 @@
       "Topology"
     ],
     "namespace": "IsoperimetricOQ",
-    "lineCount": 1938,
+    "lineCount": 1937,
     "axiomCount": 0,
     "theoremCount": 68,
     "definitionCount": 12,

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -91,9 +91,9 @@
       "LGV"
     ],
     "namespace": "HookLengthFormula",
-    "lineCount": 16029,
+    "lineCount": 16248,
     "axiomCount": 0,
-    "sorries": 4,
+    "sorries": 3,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",
     "theoremCount": 521,
     "definitionCount": 14
@@ -202,5 +202,5 @@
       "mathContext": "$h(\\mu,i,j) = h(\\mu^\\top,j,i)$ (arm↔leg under transpose). For N-row shapes: hook walk identity $\\sum_c \\text{hookProd}(\\mu)/\\text{hookProd}(\\mu\\setminus c) = \\sum_i a_i$ is a polynomial identity in $a_1,\\ldots,a_N$, verifiable by `ring` after computing each hook length as a linear combination of $a_i$."
     }
   ],
-  "sorries": 4
+  "sorries": 3
 }

--- a/src/data/proofs/erdos-60/meta.json
+++ b/src/data/proofs/erdos-60/meta.json
@@ -182,7 +182,7 @@
       "Finset"
     ],
     "namespace": "Erdos60",
-    "lineCount": 386,
+    "lineCount": 385,
     "axiomCount": 8,
     "theoremCount": 10,
     "definitionCount": 12,

--- a/src/data/proofs/hurwitz-theorem-oq-04/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-04/meta.json
@@ -137,11 +137,11 @@
       "HurwitzTheorem"
     ],
     "namespace": "HurwitzTheoremOQ04",
-    "lineCount": 1052,
+    "lineCount": 1104,
     "axiomCount": 0,
     "theoremCount": 40,
     "definitionCount": 15,
-    "sorries": 2,
+    "sorries": 1,
     "path": "Proofs/HurwitzTheoremOQ04.lean"
   },
   "crossReferences": [
@@ -156,5 +156,5 @@
       "description": "Sibling open question: n-square identities and normed division algebras"
     }
   ],
-  "sorries": 2
+  "sorries": 1
 }

--- a/src/data/proofs/navier-stokes/meta.json
+++ b/src/data/proofs/navier-stokes/meta.json
@@ -335,7 +335,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 21111,
+    "lineCount": 21110,
     "structureCount": 249,
     "axiomCount": 0,
     "theoremCount": 846,


### PR DESCRIPTION
## Fix

The recent fix commit (#13034) updated `meta.lineCount` and `meta.sorries` but left `leanFile.lineCount` and `leanFile.sorries` stale in the `leanFile` block of each `meta.json`. This PR syncs the `leanFile` block to match reality.

## Evidence

**Before / After:**

| Proof | Field | Before | After |
|-------|-------|--------|-------|
| ballot-problem-oq-03-oq-01-oq-02 | leanFile.lineCount | 16029 | 16248 |
| ballot-problem-oq-03-oq-01-oq-02 | leanFile.sorries | 4 | 3 |
| ballot-problem-oq-03-oq-01-oq-02 | sorries (top-level) | 4 | 3 |
| hurwitz-theorem-oq-04 | leanFile.lineCount | 1052 | 1104 |
| hurwitz-theorem-oq-04 | leanFile.sorries | 2 | 1 |
| hurwitz-theorem-oq-04 | sorries (top-level) | 2 | 1 |
| area-of-circle-oq-01-oq-03 | leanFile.lineCount | 1938 | 1937 |
| erdos-60 | leanFile.lineCount | 386 | 385 |
| navier-stokes | leanFile.lineCount | 21111 | 21110 |

All values verified against actual Lean files via Python scan using wc-l compatible counting.

The canonical `meta.sorries` field (read by the auditor) was already correct; only the `leanFile` block was stale.

---
Automated fix by lean-mechanic agent.