### PR TITLE
fix: sync lineCount for 42 gallery entries + prove Erdos660 two_point_one_distance

### DIFF
--- a/proofs/Proofs/Erdos660Aristotle.lean
+++ b/proofs/Proofs/Erdos660Aristotle.lean
@@ -151,7 +151,32 @@ lemma distinctDistances_empty :
 /-- A two-point set has exactly 1 distinct distance -/
 lemma two_point_one_distance (p q : Point3D) (hne : p ≠ q) :
     distinctDistances {p, q} = 1 := by
-  sorry
+  unfold distinctDistances pairwiseDistances
+  have hpq : 0 < dist p q := dist_pos.mpr hne
+  have h1 : (({p, q} : Finset Point3D).product {p, q}).image
+      (fun pq => dist pq.1 pq.2) = {0, dist p q} := by
+    ext d
+    simp only [Finset.mem_image, Finset.mem_product, Finset.mem_insert, Finset.mem_singleton]
+    constructor
+    · rintro ⟨⟨a, b⟩, ⟨ha | ha, hb | hb⟩, rfl⟩
+      · subst ha; subst hb; exact Or.inl (dist_self p)
+      · subst ha; subst hb; exact Or.inr rfl
+      · subst ha; subst hb; exact Or.inr (dist_comm q p)
+      · subst ha; subst hb; exact Or.inl (dist_self q)
+    · rintro (rfl | rfl)
+      · exact ⟨(p, p), ⟨Or.inl rfl, Or.inl rfl⟩, dist_self p⟩
+      · exact ⟨(p, q), ⟨Or.inl rfl, Or.inr rfl⟩, rfl⟩
+  rw [h1]
+  have h2 : ({0, dist p q} : Finset ℝ).filter (· > 0) = {dist p q} := by
+    ext d
+    simp only [Finset.mem_filter, Finset.mem_insert, Finset.mem_singleton, gt_iff_lt]
+    constructor
+    · rintro ⟨rfl | rfl, hd⟩
+      · exact absurd hd (lt_irrefl 0)
+      · rfl
+    · rintro rfl
+      exact ⟨Or.inr rfl, hpq⟩
+  rw [h2, Finset.card_singleton]
 
 /-
   ## Section 6: Finset and Cardinality Helpers

--- a/research/aristotle-jobs.json
+++ b/research/aristotle-jobs.json
@@ -3079,8 +3079,8 @@
         "pairwiseDistances_singleton",
         "distinctDistances_singleton"
       ],
-      "notes": "Companion file for distinct distances lower bounds. 10 routine lemmas: distance positivity, finset helpers, pairwiseDistances membership, trivial lower bound, and simple constructions.",
-      "status": "pending"
+      "notes": "Companion file for distinct distances lower bounds. 10 routine lemmas: distance positivity, finset helpers, pairwiseDistances membership, trivial lower bound, and simple constructions. RESOLVED MANUALLY: two_point_one_distance proved directly via Finset.ext argument.",
+      "status": "resolved_manually"
     },
     {
       "project_id": "1e5da4a3-3520-4d2b-9856-c2fddbcf1a68",

--- a/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
@@ -56,7 +56,7 @@
     ],
     "dateAdded": "2026-02-24",
     "axiomCount": 0,
-    "lineCount": 1937,
+    "lineCount": 1938,
     "assumptions": "0 sorries. The IBP formula fourierCoeffOn_deriv_periodic is now proved via import from AreaOfCircleOQ01OQ02OQ02.lean.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -91,7 +91,7 @@
       "LGV"
     ],
     "namespace": "HookLengthFormula",
-    "lineCount": 16029,
+    "lineCount": 16248,
     "axiomCount": 0,
     "sorries": 4,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",

--- a/src/data/proofs/cauchy-schwarz-integral/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral/meta.json
@@ -43,7 +43,7 @@
     ],
     "dateAdded": "2026-02-11",
     "axiomCount": 0,
-    "lineCount": 117,
+    "lineCount": 118,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0"
   },
@@ -187,7 +187,7 @@
       "MeasureTheory"
     ],
     "namespace": "BunyakovskySchwarz",
-    "lineCount": 117,
+    "lineCount": 118,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 0,

--- a/src/data/proofs/erdos-1028/meta.json
+++ b/src/data/proofs/erdos-1028/meta.json
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "solved",
     "relatedProblems": [],
     "axiomCount": 2,
-    "lineCount": 310,
+    "lineCount": 311,
     "assumptions": "2 axioms: erdos_upper, erdos_spencer_lower. 0 sorries.",
     "mathlib_version": "4.26.0"
   },
@@ -238,7 +238,7 @@
       "Finset"
     ],
     "namespace": "Erdos1028",
-    "lineCount": 310,
+    "lineCount": 311,
     "axiomCount": 2,
     "theoremCount": 8,
     "definitionCount": 10,

--- a/src/data/proofs/erdos-1034/meta.json
+++ b/src/data/proofs/erdos-1034/meta.json
@@ -26,7 +26,7 @@
       "erdos-1033"
     ],
     "axiomCount": 1,
-    "lineCount": 778,
+    "lineCount": 779,
     "assumptions": "1 axiom: maTang_counterexample. 3 sorries.",
     "mathlib_version": "4.26.0"
   },
@@ -273,7 +273,7 @@
       "Finset"
     ],
     "namespace": "Erdos1034",
-    "lineCount": 778,
+    "lineCount": 779,
     "axiomCount": 1,
     "theoremCount": 17,
     "definitionCount": 22,

--- a/src/data/proofs/erdos-108/meta.json
+++ b/src/data/proofs/erdos-108/meta.json
@@ -46,7 +46,7 @@
       "Special case extraction for R\u00f6dl's r=4 theorem"
     ],
     "axiomCount": 1,
-    "lineCount": 141,
+    "lineCount": 142,
     "assumptions": "1 axiom: erdos_hajnal_rodl_theorem. See Lean source for the complete statement."
   },
   "overview": {
@@ -225,7 +225,7 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos108",
-    "lineCount": 141,
+    "lineCount": 142,
     "axiomCount": 1,
     "theoremCount": 2,
     "definitionCount": 0,

--- a/src/data/proofs/erdos-109/meta.json
+++ b/src/data/proofs/erdos-109/meta.json
@@ -49,7 +49,7 @@
       "Verified example for even numbers"
     ],
     "axiomCount": 1,
-    "lineCount": 437,
+    "lineCount": 438,
     "assumptions": "1 axiom: moreira_richter_robertson. See Lean source for the complete statement."
   },
   "overview": {
@@ -242,7 +242,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos109",
-    "lineCount": 437,
+    "lineCount": 438,
     "axiomCount": 1,
     "theoremCount": 13,
     "definitionCount": 9,

--- a/src/data/proofs/erdos-1161/meta.json
+++ b/src/data/proofs/erdos-1161/meta.json
@@ -54,7 +54,7 @@
       "Small cases: explicit counts for S_1, S_2, S_3"
     ],
     "axiomCount": 0,
-    "lineCount": 323,
+    "lineCount": 324,
     "assumptions": "0 axioms, 0 sorries. All results proved from Lean primitives."
   },
   "overview": {
@@ -143,7 +143,7 @@
       "Nat"
     ],
     "namespace": null,
-    "lineCount": 323,
+    "lineCount": 324,
     "axiomCount": 0,
     "theoremCount": 15,
     "definitionCount": 3,

--- a/src/data/proofs/erdos-123/meta.json
+++ b/src/data/proofs/erdos-123/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/123",
     "erdosProblemStatus": "open",
     "axiomCount": 3,
-    "lineCount": 317,
+    "lineCount": 318,
     "assumptions": "3 axiom(s): powers23_repr, erdos_123_conjecture, erdos_lewin_357. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
@@ -116,7 +116,7 @@
       "Pointwise"
     ],
     "namespace": "Erdos123",
-    "lineCount": 317,
+    "lineCount": 318,
     "axiomCount": 3,
     "theoremCount": 22,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-139/meta.json
+++ b/src/data/proofs/erdos-139/meta.json
@@ -30,7 +30,7 @@
       "Szemerédi regularity lemma (for understanding the proof chain)",
       "Roth's theorem and the corners theorem (k=3 case)"
     ],
-    "lineCount": 260,
+    "lineCount": 261,
     "assumptions": "4 axioms: kelley_meka_bound (r₃(N) ≤ N·exp(−c(log N)^(1/12)), Kelley-Meka 2023), gowers_bound (r_k(N) ≤ N/(log log N)^c for k≥4, Gowers 2001), behrend_lower_bound (r₃(N) ≥ N·exp(−c√(log N)), Behrend 1946), szemeredi_theorem (sets with positive density contain k-APs for all k). 1 sorry: main density-to-zero proof.",
     "mathlib_version": "4.26.0"
   },
@@ -113,7 +113,7 @@
       "Topology"
     ],
     "namespace": "Erdos139",
-    "lineCount": 260,
+    "lineCount": 261,
     "axiomCount": 4,
     "theoremCount": 8,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-143/meta.json
+++ b/src/data/proofs/erdos-143/meta.json
@@ -46,7 +46,7 @@
       "Formalized the KLL 2025 partial resolution"
     ],
     "axiomCount": 3,
-    "lineCount": 119,
+    "lineCount": 120,
     "assumptions": "3 axiom(s): kll_theorem, well_separated_integers_primitive, erdos_1935_primitive. See Lean source for complete statements."
   },
   "overview": {
@@ -219,7 +219,7 @@
       "Topology"
     ],
     "namespace": "Erdos143",
-    "lineCount": 119,
+    "lineCount": 120,
     "axiomCount": 3,
     "theoremCount": 1,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-157/meta.json
+++ b/src/data/proofs/erdos-157/meta.json
@@ -59,7 +59,7 @@
       "Verified theorem: powers_of_two_sidon"
     ],
     "axiomCount": 3,
-    "lineCount": 535,
+    "lineCount": 536,
     "assumptions": "3 axioms: (1) pilatte_existence — the Pilatte 2023 existence result (infinite Sidon set that is an asymptotic basis of order 3); (2) sidon_counting_bound — counting bound for Sidon sets; (3) basis_counting_lower — lower bound for basis counting. 0 sorries (previously 1 sorry for pilatte_existence was axiomatized; sidon_counting_contradiction proved by Aristotle)."
   },
   "overview": {
@@ -159,7 +159,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos157",
-    "lineCount": 535,
+    "lineCount": 536,
     "axiomCount": 3,
     "theoremCount": 7,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-167/meta.json
+++ b/src/data/proofs/erdos-167/meta.json
@@ -28,7 +28,7 @@
       "extremal combinatorics",
       "linear programming relaxation"
     ],
-    "lineCount": 274,
+    "lineCount": 275,
     "assumptions": "1 axiom: IsPlanar. 0 sorries.",
     "mathlib_version": "4.26.0"
   },
@@ -136,7 +136,7 @@
       "Set"
     ],
     "namespace": "Erdos167",
-    "lineCount": 274,
+    "lineCount": 275,
     "axiomCount": 1,
     "theoremCount": 4,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-168/meta.json
+++ b/src/data/proofs/erdos-168/meta.json
@@ -55,7 +55,7 @@
       "Formalized the irrationality question"
     ],
     "axiomCount": 2,
-    "lineCount": 180,
+    "lineCount": 181,
     "assumptions": "2 axioms: gsw_limit_exists, better_construction. 0 sorries."
   },
   "overview": {
@@ -141,7 +141,7 @@
       "Finset"
     ],
     "namespace": "Erdos168",
-    "lineCount": 180,
+    "lineCount": 181,
     "axiomCount": 2,
     "theoremCount": 4,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-171/meta.json
+++ b/src/data/proofs/erdos-171/meta.json
@@ -56,7 +56,7 @@
       "Aristotle-verified: no_4_clique (no tetrahedron in ℝ²)"
     ],
     "axiomCount": 2,
-    "lineCount": 302,
+    "lineCount": 303,
     "references": [
       {
         "title": "The chromatic number of the plane is at least 5",
@@ -197,7 +197,7 @@
       "Metric"
     ],
     "namespace": "Erdos171",
-    "lineCount": 302,
+    "lineCount": 303,
     "axiomCount": 2,
     "theoremCount": 16,
     "definitionCount": 4,

--- a/src/data/proofs/erdos-172/meta.json
+++ b/src/data/proofs/erdos-172/meta.json
@@ -46,7 +46,7 @@
       "Explicit connection between finite and infinite versions"
     ],
     "axiomCount": 3,
-    "lineCount": 144,
+    "lineCount": 145,
     "references": [
       {
         "title": "Monochromatic sums and products in ℕ",
@@ -155,7 +155,7 @@
       "Finset"
     ],
     "namespace": "Erdos172",
-    "lineCount": 144,
+    "lineCount": 145,
     "axiomCount": 3,
     "theoremCount": 4,
     "definitionCount": 6,

--- a/src/data/proofs/erdos-202/meta.json
+++ b/src/data/proofs/erdos-202/meta.json
@@ -53,7 +53,7 @@
       "Multiple theorems proved by Aristotle including f_mono, f_le_N, L_mono, L_subpolynomial"
     ],
     "axiomCount": 0,
-    "lineCount": 859,
+    "lineCount": 860,
     "assumptions": "3 sorry(s). No axioms."
   },
   "overview": {
@@ -175,7 +175,7 @@
       "Classical"
     ],
     "namespace": "Erdos202",
-    "lineCount": 859,
+    "lineCount": 860,
     "axiomCount": 0,
     "theoremCount": 40,
     "definitionCount": 19,

--- a/src/data/proofs/erdos-29/meta.json
+++ b/src/data/proofs/erdos-29/meta.json
@@ -22,7 +22,7 @@
     "erdosProblemStatus": "solved",
     "erdosPrizeValue": "$100",
     "axiomCount": 5,
-    "lineCount": 523,
+    "lineCount": 524,
     "assumptions": "5 axioms: JPSZ_set (explicit construction), JPSZ_is_basis, JPSZ_representation_bound, JPSZ_explicit, JPSZ_size_optimal. JPSZ_is_economical and JPSZ_density_zero fully proved as consequences (not independent axioms): economical follows from representation bound via exp(C√(log n) - ε·log n) → -∞, density zero follows from size optimal via squeeze with C·√(log N/N) → 0. 0 sorries.",
     "prerequisites": [
       "Additive bases and Waring's problem",
@@ -171,7 +171,7 @@
       "Filter"
     ],
     "namespace": "Erdos29",
-    "lineCount": 523,
+    "lineCount": 524,
     "axiomCount": 5,
     "theoremCount": 12,
     "definitionCount": 12,

--- a/src/data/proofs/erdos-299/meta.json
+++ b/src/data/proofs/erdos-299/meta.json
@@ -54,7 +54,7 @@
       "Proof that powers of 2 have unbounded gaps"
     ],
     "axiomCount": 1,
-    "lineCount": 386,
+    "lineCount": 387,
     "assumptions": "1 axiom (bloom_theorem: Bloom's 2021 result on positive density sets). 0 sorries."
   },
   "overview": {
@@ -170,7 +170,7 @@
       "Finset"
     ],
     "namespace": "Erdos299",
-    "lineCount": 386,
+    "lineCount": 387,
     "axiomCount": 1,
     "theoremCount": 10,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-303/meta.json
+++ b/src/data/proofs/erdos-303/meta.json
@@ -54,7 +54,7 @@
       "Connection to density version (Erd\u0151s #302)"
     ],
     "axiomCount": 2,
-    "lineCount": 258,
+    "lineCount": 259,
     "assumptions": "2 axioms: brownRodl_theorem, erdos303_true. See Lean source for complete statements."
   },
   "overview": {
@@ -144,7 +144,7 @@
       "Set"
     ],
     "namespace": "Erdos303",
-    "lineCount": 258,
+    "lineCount": 259,
     "axiomCount": 2,
     "theoremCount": 8,
     "definitionCount": 8,

--- a/src/data/proofs/erdos-355/meta.json
+++ b/src/data/proofs/erdos-355/meta.json
@@ -48,7 +48,7 @@
       "Fibonacci-like sequence example with ratio approximately \u03c6"
     ],
     "axiomCount": 2,
-    "lineCount": 391,
+    "lineCount": 392,
     "assumptions": "2 axiom(s) and 0 sorry(s). See the Lean source for details."
   },
   "overview": {
@@ -147,7 +147,7 @@
       "Set"
     ],
     "namespace": "Erdos355",
-    "lineCount": 391,
+    "lineCount": 392,
     "axiomCount": 2,
     "theoremCount": 15,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-37/meta.json
+++ b/src/data/proofs/erdos-37/meta.json
@@ -80,7 +80,7 @@
       "Classical axioms: schnirelmann_theorem, mann_theorem"
     ],
     "axiomCount": 6,
-    "lineCount": 367,
+    "lineCount": 368,
     "prerequisites": [
       "Essential components in additive number theory",
       "Lacunary sequences and their properties",
@@ -225,7 +225,7 @@
       "Filter"
     ],
     "namespace": "Erdos37",
-    "lineCount": 367,
+    "lineCount": 368,
     "axiomCount": 6,
     "theoremCount": 6,
     "definitionCount": 10,

--- a/src/data/proofs/erdos-370/meta.json
+++ b/src/data/proofs/erdos-370/meta.json
@@ -64,12 +64,12 @@
       "erdos_370: injective-function encoding of infinitude (sorry'd)"
     ],
     "axiomCount": 2,
-    "lineCount": 284,
+    "lineCount": 285,
     "assumptions": "2 axioms (gpf_mul_le, dickman_density) and 2 sorries. gpf function and 7 properties now proved from Mathlib."
   },
   "leanFile": {
     "path": "Proofs/Erdos370Problem.lean",
-    "lineCount": 284,
+    "lineCount": 285,
     "namespace": "Erdos370",
     "imports": [
       "Mathlib"

--- a/src/data/proofs/erdos-402/meta.json
+++ b/src/data/proofs/erdos-402/meta.json
@@ -60,7 +60,7 @@
       "erdos_402_contains_one: conjecture proved when 1 \u2208 A"
     ],
     "axiomCount": 0,
-    "lineCount": 693,
+    "lineCount": 694,
     "assumptions": "1 sorry: erdos_402_graham_conjecture (main conjecture, requires Balasubramanian-Soundararajan sieve argument). Quadruple case fully proved."
   },
   "overview": {
@@ -177,7 +177,7 @@
       "Finset"
     ],
     "namespace": "Erdos402",
-    "lineCount": 693,
+    "lineCount": 694,
     "axiomCount": 0,
     "theoremCount": 25,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-45/meta.json
+++ b/src/data/proofs/erdos-45/meta.json
@@ -40,7 +40,7 @@
       }
     ],
     "axiomCount": 3,
-    "lineCount": 141,
+    "lineCount": 142,
     "prerequisites": [
       "Egyptian fractions and unit fraction decompositions",
       "Ramsey theory and monochromatic structures",
@@ -133,7 +133,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos45",
-    "lineCount": 141,
+    "lineCount": 142,
     "axiomCount": 3,
     "theoremCount": 3,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-485/meta.json
+++ b/src/data/proofs/erdos-485/meta.json
@@ -23,7 +23,7 @@
     "erdosUrl": "https://erdosproblems.com/485",
     "erdosProblemStatus": "solved",
     "axiomCount": 1,
-    "lineCount": 225,
+    "lineCount": 226,
     "assumptions": "1 axiom: schinzel_zannier_improved (Schinzel-Zannier 2009: f(k) ≫ log k). This deep algebraic result is not yet in Mathlib.",
     "mathlib_version": "4.26.0"
   },
@@ -115,7 +115,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos485",
-    "lineCount": 225,
+    "lineCount": 226,
     "axiomCount": 1,
     "theoremCount": 3,
     "definitionCount": 6,

--- a/src/data/proofs/erdos-517/meta.json
+++ b/src/data/proofs/erdos-517/meta.json
@@ -51,7 +51,7 @@
       "Verified example showing exponential sequences have Fej\u00e9r gaps"
     ],
     "dateAdded": "2025-12-22",
-    "lineCount": 175,
+    "lineCount": 176,
     "prerequisites": [
       "Complex analysis: entire functions, power series",
       "Lacunary (gap) series and Fabry/Fej\u00e9r gap conditions",
@@ -145,7 +145,7 @@
       "Topology"
     ],
     "namespace": "Erdos517",
-    "lineCount": 175,
+    "lineCount": 176,
     "axiomCount": 1,
     "theoremCount": 3,
     "definitionCount": 3,

--- a/src/data/proofs/erdos-551/meta.json
+++ b/src/data/proofs/erdos-551/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/551",
     "erdosProblemStatus": "solved",
     "axiomCount": 0,
-    "lineCount": 603,
+    "lineCount": 604,
     "assumptions": "No axioms. 22 sorry(s) remain in the formalization.",
     "mathlib_version": "4.26.0"
   },
@@ -175,7 +175,7 @@
       "Finset"
     ],
     "namespace": "Erdos551",
-    "lineCount": 603,
+    "lineCount": 604,
     "axiomCount": 0,
     "theoremCount": 26,
     "definitionCount": 14,

--- a/src/data/proofs/erdos-60/meta.json
+++ b/src/data/proofs/erdos-60/meta.json
@@ -51,7 +51,7 @@
       "conjecture_implies_two_copies: Aristotle-proved implication"
     ],
     "axiomCount": 8,
-    "lineCount": 385,
+    "lineCount": 386,
     "prerequisites": [
       "Extremal graph theory (Tur\u00e1n-type problems)",
       "4-cycles (C\u2084) in graphs",

--- a/src/data/proofs/erdos-604/meta.json
+++ b/src/data/proofs/erdos-604/meta.json
@@ -59,7 +59,7 @@
       "Crossing number inequality",
       "Number theory (sums of two squares, Landau's theorem)"
     ],
-    "lineCount": 223,
+    "lineCount": 224,
     "assumptions": "No axioms. 1 sorry remaining: integerLattice_pinnedDistances (deep constructive existence). maxPinnedDistances and pinnedDistance_le are now sorry-free.",
     "mathlib_version": "4.26.0"
   },
@@ -184,7 +184,7 @@
       "Set"
     ],
     "namespace": null,
-    "lineCount": 223,
+    "lineCount": 224,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 11,

--- a/src/data/proofs/erdos-624/meta.json
+++ b/src/data/proofs/erdos-624/meta.json
@@ -57,7 +57,7 @@
     ],
     "dateAdded": "2025-12-27",
     "axiomCount": 5,
-    "lineCount": 218,
+    "lineCount": 219,
     "assumptions": "5 axioms: erdos_hajnal_upper_bound, erdos_624_open, weaker_conjecture_open, and 2 more. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
@@ -172,7 +172,7 @@
       "Set"
     ],
     "namespace": "Erdos624",
-    "lineCount": 218,
+    "lineCount": 219,
     "axiomCount": 5,
     "theoremCount": 4,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-629/meta.json
+++ b/src/data/proofs/erdos-629/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/629",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "lineCount": 911,
+    "lineCount": 912,
     "assumptions": "7 sorry(s). No axioms.",
     "mathlib_version": "4.26.0"
   },
@@ -175,7 +175,7 @@
       "Finset"
     ],
     "namespace": "Erdos629",
-    "lineCount": 911,
+    "lineCount": 912,
     "axiomCount": 0,
     "theoremCount": 37,
     "definitionCount": 14,

--- a/src/data/proofs/erdos-643/meta.json
+++ b/src/data/proofs/erdos-643/meta.json
@@ -49,7 +49,7 @@
       "Statement of Erd\u0151s-Rado Sunflower Lemma connection"
     ],
     "axiomCount": 3,
-    "lineCount": 1402,
+    "lineCount": 1403,
     "assumptions": "3 axiom(s) and 1 sorry(s). See the Lean source for details."
   },
   "overview": {
@@ -186,7 +186,7 @@
       "Classical"
     ],
     "namespace": "Harmonic.GeneralizeProofs",
-    "lineCount": 1402,
+    "lineCount": 1403,
     "axiomCount": 3,
     "theoremCount": 42,
     "definitionCount": 15,

--- a/src/data/proofs/erdos-69/meta.json
+++ b/src/data/proofs/erdos-69/meta.json
@@ -45,7 +45,7 @@
       "Structure connecting Problem 69 to Problem 257"
     ],
     "axiomCount": 1,
-    "lineCount": 188,
+    "lineCount": 189,
     "prerequisites": [
       "Arithmetic functions (\u03c9, d, \u03a9) and prime factorization",
       "Infinite series, absolute convergence, and summation interchange",
@@ -194,7 +194,7 @@
       "Finset"
     ],
     "namespace": "Erdos69",
-    "lineCount": 188,
+    "lineCount": 189,
     "axiomCount": 1,
     "theoremCount": 5,
     "definitionCount": 2,

--- a/src/data/proofs/erdos-795/meta.json
+++ b/src/data/proofs/erdos-795/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/795",
     "erdosProblemStatus": "solved",
     "axiomCount": 0,
-    "lineCount": 495,
+    "lineCount": 496,
     "assumptions": "14 sorry(s).",
     "mathlib_version": "4.26.0"
   },
@@ -167,7 +167,7 @@
     ],
     "opens": [],
     "namespace": "Erdos795",
-    "lineCount": 495,
+    "lineCount": 496,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-866/meta.json
+++ b/src/data/proofs/erdos-866/meta.json
@@ -54,7 +54,7 @@
       "Four open problems formalized as Lean propositions"
     ],
     "axiomCount": 0,
-    "lineCount": 84,
+    "lineCount": 85,
     "assumptions": "0 axioms. 0 sorries. All results formalized without axioms."
   },
   "overview": {
@@ -142,7 +142,7 @@
       "Real"
     ],
     "namespace": "Erdos866",
-    "lineCount": 84,
+    "lineCount": 85,
     "axiomCount": 0,
     "theoremCount": 3,
     "definitionCount": 10,

--- a/src/data/proofs/erdos-941/meta.json
+++ b/src/data/proofs/erdos-941/meta.json
@@ -58,7 +58,7 @@
       "generalizedQuestion: Problem #1107 connection"
     ],
     "axiomCount": 4,
-    "lineCount": 323,
+    "lineCount": 324,
     "assumptions": "4 axiom(s) and 0 sorry(s)."
   },
   "overview": {
@@ -178,7 +178,7 @@
       "Nat"
     ],
     "namespace": "Erdos941",
-    "lineCount": 323,
+    "lineCount": 324,
     "axiomCount": 4,
     "theoremCount": 11,
     "definitionCount": 13,

--- a/src/data/proofs/hurwitz-theorem-oq-04/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-04/meta.json
@@ -137,7 +137,7 @@
       "HurwitzTheorem"
     ],
     "namespace": "HurwitzTheoremOQ04",
-    "lineCount": 1052,
+    "lineCount": 1104,
     "axiomCount": 0,
     "theoremCount": 40,
     "definitionCount": 15,

--- a/src/data/proofs/navier-stokes-existence/meta.json
+++ b/src/data/proofs/navier-stokes-existence/meta.json
@@ -63,7 +63,7 @@
     ],
     "dateAdded": "2026-03-14",
     "relatedProblems": [],
-    "lineCount": 21110,
+    "lineCount": 21111,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -264,7 +264,7 @@
       "TwoDimensionalGlobal"
     ],
     "namespace": "NavierStokesRegularity",
-    "lineCount": 21110,
+    "lineCount": 21111,
     "axiomCount": 0,
     "theoremCount": 846,
     "definitionCount": 104,

--- a/src/data/proofs/navier-stokes-oq-01/meta.json
+++ b/src/data/proofs/navier-stokes-oq-01/meta.json
@@ -60,7 +60,7 @@
       "Theorem total_dissipation_bound: \u222b\u2080\u1d40 2\u03bdP(t) dt \u2264 E(0), total dissipation bounded by initial enstrophy"
     ],
     "dateAdded": "2026-02-26",
-    "lineCount": 21110,
+    "lineCount": 21111,
     "assumptions": "None. Formalized with 0 axioms and 0 sorries remain.",
     "relatedProblems": [
       {
@@ -181,7 +181,7 @@
       "TwoDimensionalGlobal"
     ],
     "namespace": "NavierStokesRegularity",
-    "lineCount": 21110,
+    "lineCount": 21111,
     "axiomCount": 0,
     "theoremCount": 846,
     "definitionCount": 104,

--- a/src/data/proofs/navier-stokes-oq-02/meta.json
+++ b/src/data/proofs/navier-stokes-oq-02/meta.json
@@ -59,7 +59,7 @@
       "Theorem continuous_dependence_2d: for any \u03b5 > 0, threshold \u03b4 = \u03b5\u00b7exp(-C\u00b7E(0)\u00b7T) gives W(0) \u2264 \u03b4 implies W(t) \u2264 \u03b5, establishing Hadamard well-posedness"
     ],
     "dateAdded": "2026-02-28",
-    "lineCount": 21110,
+    "lineCount": 21111,
     "assumptions": "1 structure-encoded assumption: NSSolutionPair2D.stability_estimate (Ladyzhenskaya stability estimate W'(t) \u2264 C\u00b7E(t)\u00b7W(t), the core PDE estimate \u2014 mathematically known but not formalized in this file)",
     "mathlib_version": "4.26.0"
   },
@@ -202,7 +202,7 @@
       "TwoDimensionalGlobal"
     ],
     "namespace": "NavierStokesRegularity",
-    "lineCount": 21110,
+    "lineCount": 21111,
     "axiomCount": 0,
     "theoremCount": 846,
     "definitionCount": 104,

--- a/src/data/proofs/navier-stokes/meta.json
+++ b/src/data/proofs/navier-stokes/meta.json
@@ -73,7 +73,7 @@
     "millenniumProblem": "navier-stokes",
     "proofRepoPath": "Proofs/NavierStokes.lean",
     "mathlib_version": "4.26.0",
-    "lineCount": 21110
+    "lineCount": 21111
   },
   "objection": {
     "verdict": "CONDITIONAL 3D + PROVEN 2D",


### PR DESCRIPTION
## Summary

### Metadata Fixes (42 files)
- Corrects `lineCount` fields in `meta.json` for 42 proof entries where the stored value did not match the actual Lean source line count
- 40 entries were off by exactly 1 (Python iterator counts lines including a final line without a trailing newline; stored values matched `wc -l` convention instead)
- `hurwitz-theorem-oq-04`: off by 52 (file extended since last sync)
- `ballot-problem-oq-03-oq-01-oq-02`: off by 219 (file extended since last sync)
- Both `meta.lineCount` and `leanFile.lineCount` fields updated where present
- Changes are surgical (regex replacement only touching the lineCount number, no JSON reformatting)

### Aristotle Companion Fix (Erdos660)
- Replaces `sorry` in `two_point_one_distance` with a direct proof that a 2-point set `{p,q}` (p≠q) has exactly 1 distinct positive pairwise distance
- Proof: show `pairwiseDistances {p,q} = {0, dist p q}` via `Finset.ext`, filter for `> 0` gives `{dist p q}`, `Finset.card_singleton` closes
- Updates `research/aristotle-jobs.json` to mark `erdos-660` job as `resolved_manually`

## Test plan

- [ ] Re-run auditor mismatch scan to confirm 0 remaining lineCount mismatches
- [ ] Verify Erdos660Aristotle.lean builds with 0 sorries (run docker-build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)