### PR TITLE
fix(erdos-1043): prove 3 routine sorries (7→4)

### DIFF
--- a/proofs/Proofs/Erdos1043Problem.lean
+++ b/proofs/Proofs/Erdos1043Problem.lean
@@ -130,8 +130,8 @@ theorem EHP_conjecture_false : ¬EHP_Conjecture := by
   obtain ⟨f, hMonic, hDeg, hProj⟩ := pommerenke_counterexample
   obtain ⟨u, hu⟩ := h f hMonic hDeg
   have := hProj u
-  -- 2.386 > 2
-  sorry
+  -- 2.386 > 2 in ℝ≥0∞
+  exact absurd (this.trans hu) (by norm_num)
 
 /-- The Pommerenke constant: infimum over all polynomials of the min projection measure. -/
 noncomputable def pommerenkeConstant : ℝ≥0∞ :=
@@ -151,7 +151,8 @@ axiom pommerenke_upper_bound :
 /-- Corollary: The minimum projection measure is bounded by 3.3. -/
 theorem min_projection_bounded (f : Polynomial ℂ) (hMonic : f.Monic) (hDeg : f.natDegree ≥ 1) :
     minProjectionMeasure f ≤ 3.3 := by
-  sorry
+  obtain ⟨u, hu⟩ := pommerenke_upper_bound f hMonic hDeg
+  exact (iInf_le _ u).trans hu
 
 /- ## Part VII: Properties of Level Sets -/
 
@@ -185,7 +186,8 @@ noncomputable def maxWidth (S : Set ℂ) : ℝ≥0∞ :=
 /-- For convex sets, minWidth = diameter / (some constant related to shape). -/
 theorem convex_width_bounds (S : Set ℂ) (hConvex : Convex ℝ S) (hCompact : IsCompact S) :
     minWidth S ≤ maxWidth S := by
-  sorry
+  have hne : Nonempty Direction := ⟨⟨1, Complex.norm_one⟩⟩
+  exact (iInf_le (width S) hne.some).trans (le_iSup (width S) hne.some)
 
 /- ## Part IX: Lemniscates -/
 

--- a/src/data/proofs/erdos-1043/meta.json
+++ b/src/data/proofs/erdos-1043/meta.json
@@ -17,7 +17,7 @@
       "geometry"
     ],
     "badge": "axiom",
-    "sorries": 7,
+    "sorries": 4,
     "erdosNumber": 1043,
     "erdosUrl": "https://erdosproblems.com/1043",
     "erdosProblemStatus": "solved",
@@ -48,7 +48,7 @@
     ],
     "axiomCount": 2,
     "lineCount": 270,
-    "assumptions": "2 axioms: pommerenke_counterexample (Pommerenke — monic poly s.t. every projection of level set has measure ≥ 2.386), pommerenke_upper_bound (measure 3.3 is achievable as upper bound). 7 sorries in supporting lemmas."
+    "assumptions": "2 axioms: pommerenke_counterexample (Pommerenke — monic poly s.t. every projection of level set has measure ≥ 2.386), pommerenke_upper_bound (measure 3.3 is achievable as upper bound). 4 sorries remain in complex-analysis supporting lemmas (disk_projection_measure, monomial_projection, levelSet_connected_iff, levelSet_compact)."
   },
   "overview": {
     "historicalContext": "**Origins in Polynomial Geometry (1958)**\n\nErdős, Herzog, and Piranian posed this problem in their 1958 paper 'Metric properties of polynomials' (J. Analyse Math. 6, 125–148), studying how the level set $L_f = \\{z \\in \\mathbb{C} : |f(z)| \\le 1\\}$ of a monic polynomial spreads in the complex plane. For $f(z) = z^n$, the level set is the closed unit disk $\\overline{B}(0,1)$, whose projection onto any line has length exactly 2 (the diameter). They conjectured this measure of 2 might be universally achievable.\n\n**The Level Set Tradition**: These sets are **lemniscates**, named after the figure-eight curve $|z^2 - 1| = c$ studied by Jakob Bernoulli (1694). The arc length integral for Bernoulli's lemniscate was a catalyst for Euler's and Gauss's work on elliptic integrals. In potential theory, level sets of monic polynomials have logarithmic capacity 1, a normalization due to Fekete's transfinite diameter theorem (1923).\n\n**Pommerenke's Resolution (1961)**: Christian Pommerenke, in 'Über die analytische Kapazität' (Math. Ann. 144, 285–296), proved the conjecture **FALSE**: there exist monic polynomials where every projection has measure $\\ge 2.386$, so no direction achieves the disk's measure of 2. He also proved the positive result that every monic polynomial has some projection $\\le 3.3$. The exact value of the **Pommerenke constant** $\\mathcal{P} = \\sup_f \\inf_u \\mu(\\pi_u(L_f)) \\in [2.386, 3.3]$ remains unknown.",
@@ -255,8 +255,8 @@
     "axiomCount": 2,
     "theoremCount": 12,
     "definitionCount": 15,
-    "sorries": 7,
+    "sorries": 4,
     "path": "Proofs/Erdos1043Problem.lean"
   },
-  "sorries": 7
+  "sorries": 4
 }


### PR DESCRIPTION
## Fix

Proves 3 simple corollary sorries in Erdos1043Problem.lean that follow
directly from the axioms and standard Mathlib order lemmas.

## Evidence

**EHP_conjecture_false** (line 128):
- Before: `sorry` with comment `-- 2.386 > 2`
- After: `exact absurd (this.trans hu) (by norm_num)`
- Proof: `hProj u : 2.386 ≤ X` and `hu : X ≤ 2` give `2.386 ≤ 2`; `norm_num` closes the goal in `ℝ≥0∞`

**min_projection_bounded** (line 152):
- Before: `sorry`
- After: `exact (iInf_le _ u).trans hu`
- Proof: Obtain direction `u` from `pommerenke_upper_bound`; use `iInf_le` to bound minimum from above

**convex_width_bounds** (line 186):
- Before: `sorry`
- After: `(iInf_le (width S) hne.some).trans (le_iSup (width S) hne.some)`
- Proof: `Direction` is nonempty (witnessed by `⟨1, Complex.norm_one⟩`); infimum ≤ value ≤ supremum

**meta.json**: `sorries` updated from 7 to 4 in all three fields.

Remaining 4 sorries are complex-analysis results requiring measure theory:
- `disk_projection_measure`, `monomial_projection`
- `levelSet_connected_iff`, `levelSet_compact`

---
Automated fix by lean-mechanic agent.