### PR TITLE
fix(meta): correct axiomCount for shannon-channel-coding-oq-02-oq-01

### DIFF
--- a/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
@@ -37,9 +37,9 @@
       "Root cause analysis of ShannonEntropy.lean line 811 failure (sum order mismatch in strong_subadditivity)",
       "Proposed fix: normalize ∑ y ∑ z ∑ x sum order before linarith using Finset.sum_comm"
     ],
-    "assumptions": "2 axioms: (1) fano_inequality — declared locally to represent the target axiom in ShannonChannelCoding.lean that this file aims to eliminate; (2) import_shannon_entropy_blocked — placeholder for ShannonEntropy.lean compilation blocker. 0 sorries. Both axioms will be eliminatable once ShannonEntropy.lean's strong_subadditivity proof is fixed.",
+    "assumptions": "1 axiom: import_shannon_entropy_blocked — placeholder for ShannonEntropy.lean compilation blocker. 0 sorries. The axiom will be eliminatable once ShannonEntropy.lean's strong_subadditivity proof is fixed. (Note: fano_inequality appears only inside a block comment illustrating the target axiom in ShannonChannelCoding.lean, not as a real axiom declaration.)",
     "dateAdded": "2026-04-04",
-    "axiomCount": 2,
+    "axiomCount": 1,
     "lineCount": 168,
     "prerequisites": [
       "Fano's inequality (OQ-03): H(X|Y) ≤ h(P_e) + P_e·log(|X|-1)",


### PR DESCRIPTION
## Fix

`meta.axiomCount` was 2 but only 1 real axiom exists in the Lean file.

## Evidence

**Before**: `"axiomCount": 2` — counting `fano_inequality` as a real axiom  
**After**: `"axiomCount": 1` — only `import_shannon_entropy_blocked` is a real axiom

**Root cause**: `fano_inequality` at line 81 of `ShannonChannelCodingOQ02OQ01.lean` appears inside a block comment (`/-...-/` spanning lines 75–107) as a code example showing what the target axiom looks like in `ShannonChannelCoding.lean`. It is **not** a Lean axiom declaration. The `leanFile.axiomCount: 1` sub-field was already correct; this PR aligns `meta.axiomCount` to match.

---
Automated fix by lean-mechanic agent.