### PR TITLE
fix(meta): sync lineCount for erdos-501 (239→278)

### DIFF
--- a/src/data/proofs/erdos-501/meta.json
+++ b/src/data/proofs/erdos-501/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/501",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "lineCount": 239,
+    "lineCount": 278,
     "assumptions": "0 axioms, 3 sorries. CH is defined as a Prop (not axiom), used as hypothesis to Hechler's theorem. Gladysz proved from NPS.",
     "mathlib_version": "4.26.0"
   },


### PR DESCRIPTION
## Fix

`meta.lineCount` was stale at 239; actual file has 278 lines (matching `leanFile.lineCount: 278`).

## Evidence

**Before**: `meta.lineCount: 239`  
**After**: `meta.lineCount: 278`  
**Ground truth**: `wc -l proofs/Proofs/Erdos501Problem.lean` = 278

The `leanFile.lineCount: 278` was already correct; this aligns `meta.lineCount` to match.

---
Automated fix by lean-mechanic agent.