### PR TITLE
fix(meta): sync lineCount and sorries for erdos-1012-oq-03

### DIFF
--- a/src/data/proofs/erdos-1012-oq-03/meta.json
+++ b/src/data/proofs/erdos-1012-oq-03/meta.json
@@ -18,10 +18,10 @@
       "well-founded-recursion"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 4,
     "axiomCount": 1,
     "lineCount": 1884,
-    "assumptions": "1 axiom: gh_longest_cycle_is_hamiltonian (Ghouila-Houri path surgery: under GH degree conditions, the longest directed cycle in a SC digraph is Hamiltonian — standard result from Ghouila-Houri 1960, Diestel §10). 1 sorry. Rédei, Moon-Moser, directed_hamiltonian_threshold fully proved.",
+    "assumptions": "1 axiom: gh_longest_cycle_is_hamiltonian (Ghouila-Houri path surgery: under GH degree conditions, the longest directed cycle in a SC digraph is Hamiltonian — standard result from Ghouila-Houri 1960, Diestel §10). 4 sorries.",
     "dateAdded": "2026-03-30",
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Hamiltonian_path_problem#Directed_graphs",
@@ -258,10 +258,10 @@
     "namespace": "Erdos1012OQ03",
     "lineCount": 1884,
     "axiomCount": 1,
-    "sorries": 1,
+    "sorries": 4,
     "path": "Proofs/Erdos1012OQ03.lean",
     "theoremCount": 27,
     "definitionCount": 9
   },
-  "sorries": 1
+  "sorries": 4
 }

--- a/src/data/proofs/erdos-1012-oq-03/meta.json
+++ b/src/data/proofs/erdos-1012-oq-03/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 1,
     "axiomCount": 1,
-    "lineCount": 1827,
+    "lineCount": 1884,
     "assumptions": "1 axiom: gh_longest_cycle_is_hamiltonian (Ghouila-Houri path surgery: under GH degree conditions, the longest directed cycle in a SC digraph is Hamiltonian — standard result from Ghouila-Houri 1960, Diestel §10). 1 sorry. Rédei, Moon-Moser, directed_hamiltonian_threshold fully proved.",
     "dateAdded": "2026-03-30",
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
@@ -256,7 +256,7 @@
       "Finset"
     ],
     "namespace": "Erdos1012OQ03",
-    "lineCount": 1827,
+    "lineCount": 1884,
     "axiomCount": 1,
     "sorries": 1,
     "path": "Proofs/Erdos1012OQ03.lean",


### PR DESCRIPTION
## Fix

Two stale metadata fields in `erdos-1012-oq-03/meta.json`:
1. `lineCount` was 1827; actual file has 1884 lines (both `meta.lineCount` and `leanFile.lineCount`)
2. `sorries` was 1; actual file has 4 sorries (comment-stripped count)

## Evidence

| Field | Before | After |
|-------|--------|-------|
| `meta.lineCount` | 1827 | **1884** |
| `leanFile.lineCount` | 1827 | **1884** |
| `sorries` (all 3 fields) | 1 | **4** |

Ground truth: `wc -l proofs/Proofs/Erdos1012OQ03.lean` = 1884; `grep -c sorry` (comment-stripped) = 4.

---
Automated fix by lean-mechanic agent.