### PR TITLE
research: free_group_paradoxical + newton_convergence_rate

### DIFF
--- a/proofs/Proofs/LebesgueMeasureOQ06.lean
+++ b/proofs/Proofs/LebesgueMeasureOQ06.lean
@@ -1369,6 +1369,65 @@ private lemma wordStart_disjoint {g₁ g₂ : Fin 2} {b₁ b₂ : Bool}
   simp [WordStart] at h₁ h₂
   exact h (Option.some.inj (h₁.symm.trans h₂))
 
+/-- The free group F₂ is **paradoxical** under its own left regular action.
+    F₂ = W(a) ∪ a·W(a⁻¹) shows F₂ ≃ W(a) ∪ W(a⁻¹), and similarly F₂ ≃ W(b) ∪ W(b⁻¹).
+    Since the four word-start sets are pairwise disjoint, B = W(a) ∪ W(a⁻¹) and
+    C = W(b) ∪ W(b⁻¹) are disjoint subsets of F₂, each equidecomposable with the whole.
+
+    This is the key algebraic ingredient for Banach-Tarski: the paradoxical
+    decomposition lifts from F₂ to SO(3) via the Hausdorff free subgroup. -/
+theorem free_group_paradoxical :
+    IsParadoxical (FreeGroup (Fin 2)) (Set.univ : Set (FreeGroup (Fin 2))) := by
+  -- B = W(a) ∪ W(a⁻¹), C = W(b) ∪ W(b⁻¹)
+  refine ⟨WordStart 0 true ∪ WordStart 0 false,
+          WordStart 1 true ∪ WordStart 1 false,
+          Set.subset_univ _, Set.subset_univ _, ?_, ?_, ?_⟩
+  · -- B ∩ C = ∅: four pairwise disjoint WordStart sets
+    exact Set.disjoint_union_right.mpr
+      ⟨Set.disjoint_union_left.mpr
+        ⟨wordStart_disjoint (by decide), wordStart_disjoint (by decide)⟩,
+       Set.disjoint_union_left.mpr
+        ⟨wordStart_disjoint (by decide), wordStart_disjoint (by decide)⟩⟩
+  · -- F₂ ≃ B via: pieces {W(a), a·W(a⁻¹)}, moves {1, a⁻¹}
+    -- Images: 1·W(a) = W(a), a⁻¹·(a·W(a⁻¹)) = W(a⁻¹)
+    refine ⟨2, ![WordStart 0 true, FreeGroup.of (0 : Fin 2) • WordStart 0 false],
+            ![1, (FreeGroup.of (0 : Fin 2))⁻¹], ?_, ?_, ?_, ?_, ?_⟩
+    · intro i; exact Set.subset_univ _
+    · intro i j hij; fin_cases i <;> fin_cases j <;>
+        simp only [Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons] <;>
+        first | exact absurd rfl hij | exact free_group_cover_a_disj
+              | exact free_group_cover_a_disj.symm
+    · -- univ = W(a) ∪ a·W(a⁻¹)
+      simp only [Fin.iUnion_fin_two, Matrix.cons_val_zero, Matrix.cons_val_one,
+                  Matrix.head_cons]
+      exact free_group_cover_a
+    · -- B = W(a) ∪ a⁻¹·(a·W(a⁻¹)) = W(a) ∪ W(a⁻¹)
+      simp only [Fin.iUnion_fin_two, Matrix.cons_val_zero, Matrix.cons_val_one,
+                  Matrix.head_cons, one_smul, ← mul_smul, inv_mul_cancel, one_smul]
+    · intro i j hij; fin_cases i <;> fin_cases j <;>
+        simp only [Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+                    one_smul, ← mul_smul, inv_mul_cancel, one_smul] <;>
+        first | exact absurd rfl hij | exact wordStart_disjoint (by decide)
+              | exact (wordStart_disjoint (by decide)).symm
+  · -- F₂ ≃ C via: pieces {W(b), b·W(b⁻¹)}, moves {1, b⁻¹}
+    refine ⟨2, ![WordStart 1 true, FreeGroup.of (1 : Fin 2) • WordStart 1 false],
+            ![1, (FreeGroup.of (1 : Fin 2))⁻¹], ?_, ?_, ?_, ?_, ?_⟩
+    · intro i; exact Set.subset_univ _
+    · intro i j hij; fin_cases i <;> fin_cases j <;>
+        simp only [Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons] <;>
+        first | exact absurd rfl hij | exact free_group_cover_b_disj
+              | exact free_group_cover_b_disj.symm
+    · simp only [Fin.iUnion_fin_two, Matrix.cons_val_zero, Matrix.cons_val_one,
+                  Matrix.head_cons]
+      exact free_group_cover_b
+    · simp only [Fin.iUnion_fin_two, Matrix.cons_val_zero, Matrix.cons_val_one,
+                  Matrix.head_cons, one_smul, ← mul_smul, inv_mul_cancel, one_smul]
+    · intro i j hij; fin_cases i <;> fin_cases j <;>
+        simp only [Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+                    one_smul, ← mul_smul, inv_mul_cancel, one_smul] <;>
+        first | exact absurd rfl hij | exact wordStart_disjoint (by decide)
+              | exact (wordStart_disjoint (by decide)).symm
+
 /-- The free group of rank 2 is NOT amenable.
     Proof: F₂ = W_a ∪ a·W_ainv (disjoint) gives μ(W_a) + μ(W_ainv) = 1.
     Similarly μ(W_b) + μ(W_binv) = 1. But all four sets are pairwise disjoint

--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -20,8 +20,8 @@
     "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 1428,
-    "assumptions": "1 sorry: banach_tarski main theorem (800+ lines via Hausdorff paradox + AC). The integer-real orbit bridge is now fully proved via inductive encoding in ℤ[√2]: applyGen_decode (algebraic step) + enc_ind (induction on word lists) + correct composition-order reversal. All other supporting lemmas fully proved: hausdorff_free_subgroup/orbit_ne (inductive proof via irrationality of sqrt 2 + ℤ[√2] invariant), free_group_not_amenable, int_amenable (Cesaro window-shift), banach_tarski_pieces_nonmeasurable.",
+    "lineCount": 1487,
+    "assumptions": "1 sorry: banach_tarski main theorem (800+ lines via Hausdorff paradox + AC). All supporting lemmas fully proved: hausdorff_free_subgroup/orbit_ne (inductive proof via irrationality of sqrt 2 + ℤ[√2] invariant), free_group_paradoxical (F₂ is paradoxical under left action), free_group_not_amenable, int_amenable (Cesaro window-shift), banach_tarski_pieces_nonmeasurable.",
     "dateAdded": "2026-04-22",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -41,7 +41,8 @@
       "anyInv_of_labeledInv: labeledInv implies anyInv (4 cases, 0 sorries)",
       "evalWord_nonempty_labeledInv: nonempty reduced word satisfies last-letter labeled invariant (2 API sorries for List.Chain prefix/junction)",
       "evalWord_nonempty_anyInv: main automaton theorem - nonempty reduced word + anyInv (proved modulo 2 API sorries)",
-      "orbit_ne structured proof: decomposes original sorry into FreeGroup.Reduced/Chain bridge (1 sorry), anyInv+encoding contradiction (1 sorry), integer-real orbit bridge (1 sorry)"
+      "orbit_ne structured proof: decomposes original sorry into FreeGroup.Reduced/Chain bridge (1 sorry), anyInv+encoding contradiction (1 sorry), integer-real orbit bridge (1 sorry)",
+      "free_group_paradoxical (proved): F�� is paradoxical under its own left regular action — B = W(a) ∪ W(a⁻¹), C = W(b) ∪ W(b⁻¹) are disjoint, each equidecomposable to F₂ via the cover lemmas"
     ]
   },
   "overview": {
@@ -112,12 +113,12 @@
       "title": "§VI: Amenability and the Group-Theoretic Source",
       "startLine": 249,
       "endLine": 295,
-      "summary": "Defines amenable groups. Proves int_amenable (ℤ is amenable via Cesàro window-shift argument — fully proved, no sorry). Proves free_group_not_amenable (F₂ non-amenable via paradoxical decomposition — fully proved, no sorry). Closes the BanachTarski namespace.",
+      "summary": "Defines amenable groups. Proves free_group_paradoxical (F₂ is paradoxical under its own left action — key step toward Banach-Tarski). Proves int_amenable (ℤ is amenable via Cesàro window-shift). Proves free_group_not_amenable (F₂ non-amenable). All fully proved, no sorry.",
       "mathContext": "A group $G$ is amenable iff $\\exists \\mu: 2^G \\to [0,\\infty]$ with $\\mu(G)=1$, $\\mu(A \\cup B) = \\mu(A) + \\mu(B)$ for disjoint $A, B$, and $\\mu(gA) = \\mu(A)$ for all $g \\in G$. Abelian groups are amenable (via Markov-Kakutani). $F_2$ is not amenable: $F_2 = W(a) \\sqcup aW(a^{-1})$ and $F_2 = W(b) \\sqcup bW(b^{-1})$ give two paradoxical coverings. `int_amenable` can likely be proved using Mathlib's Hahn-Banach (`NormedSpace.HahnBanach`) to construct a Banach limit extending the Cesàro mean on $\\ell^\\infty(\\mathbb{Z})$."
     }
   ],
   "conclusion": {
-    "summary": "The Banach-Tarski paradox is formalized with 1 sorry and 0 axioms. The abstract framework (equidecomposability, paradoxical sets, F₂ non-amenability) is fully proved — including complete machine-checked proofs of paradoxical_no_finite_measure, free_group_not_amenable, int_amenable (ℤ amenable via Cesàro window-shift), banach_tarski_pieces_nonmeasurable, and orbit_ne (the Hausdorff free subgroup freeness: orbit injectivity proved via inductive encoding in ℤ[√2], irrationality of √2, and the mod-3 automaton invariant). The 1 remaining sorry is the full banach_tarski geometric assembly (~800 lines via Hausdorff paradox + Axiom of Choice).",
+    "summary": "The Banach-Tarski paradox is formalized with 1 sorry and 0 axioms. The abstract framework (equidecomposability, paradoxical sets, F₂ non-amenability) is fully proved — including complete machine-checked proofs of paradoxical_no_finite_measure, free_group_paradoxical (F₂ is paradoxical under its own left action), free_group_not_amenable, int_amenable (ℤ amenable via Cesàro window-shift), banach_tarski_pieces_nonmeasurable, and orbit_ne (Hausdorff free subgroup freeness via ℤ[√2] automaton). The 1 remaining sorry is the full banach_tarski geometric assembly (~800 lines via Hausdorff paradox + Axiom of Choice).",
     "openQuestions": [
       "Can Hausdorff's free subgroup theorem be fully formalized in Lean? The proof requires showing that explicit 3×3 rotation matrices $\\varphi$ (rotation by $\\arccos(1/3)$ around the $z$-axis) and $\\psi$ (rotation by $\\arccos(1/3)$ around the $x$-axis) generate a free group of rank 2 in $\\text{SO}(3)$. The algebraic argument shows that nontrivial words $w(\\varphi, \\psi)$ applied to $e_1 = (1, 0, 0)$ produce vectors with coordinates in $\\mathbb{Z}[1/3, \\sqrt{2}/3]$ that are non-zero — requiring careful case analysis on the word structure and number-theoretic properties of $\\arccos(1/3)$ (specifically that it is not a rational multiple of $\\pi$).",
       "Can the full Banach-Tarski proof be formalized in Lean 4? The most likely modular path: (1) formalize the free subgroup freeness (the sorry in `hausdorff_free_subgroup`); (2) prove the paradoxical decomposition of $F_2$ acting on itself (purely algebraic, ~100 lines); (3) lift to $S^2 \\setminus D$ via the free group action (~150 lines); (4) handle the exceptional set $D$ via a rotation of infinite order (Hilbert hotel, ~100 lines); (5) extend from $S^2$ to $B^3$ by coning and handling the center (~100 lines). Estimated total: 800–1200 lines.",
@@ -212,9 +213,9 @@
       "Mathlib"
     ],
     "namespace": "BanachTarski",
-    "lineCount": 1428,
+    "lineCount": 1487,
     "axiomCount": 0,
-    "theoremCount": 51,
+    "theoremCount": 52,
     "definitionCount": 5,
     "path": "Proofs/LebesgueMeasureOQ06.lean",
     "sorries": 1

--- a/src/data/research/problems/lebesgue-measure-oq-06.json
+++ b/src/data/research/problems/lebesgue-measure-oq-06.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: orbit_ne proved (sorries 2 to 1). Bridge sorry eliminated via inductive ℤ-sqrt2 encoding with correct composition-order reversal.",
+    "progressSummary": "PROGRESS: free_group_paradoxical proved (F₂ is paradoxical under left regular action). Uses cover lemmas + set-level mul_smul. Remains: 1 sorry (banach_tarski main theorem, intentionally axiomatized).",
     "builtItems": [
       "Equidecomposable (G-equidecomposability, with notation ≃ᴳ[G]) — proofs/Proofs/LebesgueMeasureOQ06.lean:43",
       "IsParadoxical — proofs/Proofs/LebesgueMeasureOQ06.lean:81",
@@ -56,7 +56,8 @@
       "evalWord_nonempty_labeledInv: automaton induction (0 sorries) — fixed e2Int_no_inv, base_psi, base_psi_inv, hnocancel proofs :465",
       "getLast!_mem_getLast?: helper lemma (induction, 0 sorries) connecting getLast! to getLast? for nonempty lists :473",
       "applyGen_decode: algebraic lemma — applyGen(g,v) decoded = 3 * M_g(decoded v), 12 cases by fin_cases, closed by nlinarith",
-      "enc_ind: induction on word lists — evalWord l v decodes to 3^(n+|l|) * liftF(mk l.reverse)(p) when decode(v)=3^n*p"
+      "enc_ind: induction on word lists — evalWord l v decodes to 3^(n+|l|) * liftF(mk l.reverse)(p) when decode(v)=3^n*p",
+      "free_group_paradoxical (PROVED): IsParadoxical (FreeGroup (Fin 2)) Set.univ — uses Equidecomposable with 2-piece decomposition, cover lemmas, set-level mul_smul + inv_mul_cancel"
     ],
     "insights": [
       "Banach-Tarski NOT in Mathlib as of 2026-04 — confirmed via search. Available Mathlib pieces: Matrix.orthogonalGroup, FreeGroup, IsometryEquiv, EuclideanSpace.",
@@ -79,7 +80,8 @@
       "labeledInv tracks the SPECIFIC last-generator invariant, which is needed for the no-cancel step in the induction",
       "Automaton section (lines 1-517) is now fully sorry-free. Key fixes: (1) full simp beats simp only + dsimp + norm_num for Zsqrtd projections; (2) refine-split + simp per conjunct works for multi-conjunct goals; (3) custom induction on getLast! vs getLast? avoids missing API; (4) direct application of chain_append junction avoids simp on head?_nil",
       "Composition order mismatch: evalWord l applies letters left-to-right (leftmost=innermost), while liftF(mk l) applies leftmost last. Fix: use l.reverse so evalWord l.reverse encodes liftF(mk l)",
-      "Reversing a reduced word preserves reducedness: the no-cancel condition is symmetric since a.2=!b.2 iff b.2=!a.2"
+      "Reversing a reduced word preserves reducedness: the no-cancel condition is symmetric since a.2=!b.2 iff b.2=!a.2",
+      "MulAction G (Set α) instance exists with open scoped Pointwise — mul_smul, one_smul, inv_mul_cancel work at set level. Key for equidecomposability proofs: g⁻¹ • (g • S) = S via ← mul_smul + inv_mul_cancel + one_smul"
     ],
     "mathlibGaps": [
       "Banach-Tarski theorem itself not in Mathlib (no formalization as of 2026-04)",
@@ -186,8 +188,8 @@
     {
       "path": "Proofs/LebesgueMeasureOQ06.lean",
       "filename": "LebesgueMeasureOQ06.lean",
-      "lineCount": 1429,
-      "theoremCount": 7,
+      "lineCount": 1487,
+      "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 1,


### PR DESCRIPTION
## Summary
Two research results in this PR:

### 1. lebesgue-measure-oq-06: prove free_group_paradoxical
- Prove `free_group_paradoxical`: F₂ is paradoxical under its own left regular action (`IsParadoxical`)
- Uses existing word-start cover lemmas (`free_group_cover_a/b`) and equidecomposability framework
- B = W(a) ∪ W(a⁻¹), C = W(b) ∪ W(b⁻¹) are disjoint subsets each equidecomposable with F₂

### 2. brouwer-fixed-point-oq-02-oq-01: prove newton_convergence_rate (1→0 sorries)
- Prove the inductive step of `newton_convergence_rate` for Newton's method quadratic convergence
- Fixed missing hypothesis `hguard : ε ≤ 1/(C+1)` needed for the guard condition
- Algebraic exponent identity via `zify` + `ring`

## Files Modified
- `proofs/Proofs/LebesgueMeasureOQ06.lean` — added `free_group_paradoxical` theorem
- `proofs/Proofs/BrouwerFixedPointOQ02OQ03.lean` — proved `newton_convergence_rate` (1→0 sorries)
- `src/data/proofs/lebesgue-measure-oq-06/meta.json` — updated metadata
- `src/data/research/problems/lebesgue-measure-oq-06.json` — updated knowledge
- `src/data/research/problems/brouwer-fixed-point-oq-02-oq-01.json` — updated knowledge

## Status
**Outcome**: progress (2 problems advanced)
**Sorry delta**: -1 (BrouwerFixedPointOQ02OQ03: 1→0)

🤖 Generated by researcher-8