### PR TITLE
research(ballot-problem-oq-03-oq-01-oq-02): prove ncard_biUnion_eq_of_uniform (2→0 sorries)

### DIFF
--- a/proofs/Proofs/BallotProblemOQ01OQ02OQ01.lean
+++ b/proofs/Proofs/BallotProblemOQ01OQ02OQ01.lean
@@ -51,12 +51,11 @@ theorem ncard_biUnion_eq_of_uniform {α ι : Type*}
     (k : ℕ) (hk : ∀ i ∈ I, (S i).ncard = k) :
     (⋃ i ∈ I, S i).ncard = k * I.ncard := by
   rw [Set.ncard_biUnion hI hdisj (fun i hi => hfin i hi)]
-  -- Now goal: ∑ i ∈ I.toFinset, (S i).ncard = k * I.ncard
-  -- But ncard_biUnion gives ncard = Σ ncard_i for finite disjoint sets
-  -- Rewrite each ncard using hk, then simplify the sum
-  conv_lhs => ext i; rw [show (S i).ncard = k from sorry]
-  -- Σ_{i ∈ I.toFinset} k = k * |I.toFinset| = k * I.ncard
-  sorry
+  -- Goal: ∑ i ∈ hI.toFinset, (S i).ncard = k * I.ncard
+  have hmem : ∀ i ∈ hI.toFinset, (S i).ncard = k :=
+    fun i hi => hk i (hI.mem_toFinset.mp hi)
+  rw [Finset.sum_congr rfl hmem, Finset.sum_const, smul_eq_mul,
+      mul_comm, hI.toFinset_card]
 
 -- ═══════════════════════════════════════════════════════════════
 -- PART II: FIBER PARTITION PROPERTIES

--- a/proofs/Proofs/BallotProblemOQ01OQ02OQ01Aristotle.lean
+++ b/proofs/Proofs/BallotProblemOQ01OQ02OQ01Aristotle.lean
@@ -56,7 +56,10 @@ theorem ncard_sum_eq {α ι : Type*}
     (I : Set ι) (hI : I.Finite)
     (k : ℕ) (hk : ∀ i ∈ I, (S i).ncard = k) :
     ∑ i ∈ hI.toFinset, (S i).ncard = k * I.ncard := by
-  sorry
+  have hmem : ∀ i ∈ hI.toFinset, (S i).ncard = k :=
+    fun i hi => hk i (hI.mem_toFinset.mp hi)
+  rw [Finset.sum_congr rfl hmem, Finset.sum_const, smul_eq_mul,
+      mul_comm, hI.toFinset_card]
 
 /-
 TARGET 2 (Mathlib API: Set.ncard_biUnion + uniform sum)
@@ -75,7 +78,8 @@ theorem ncard_biUnion_eq_of_uniform {α ι : Type*}
     (hdisj : ∀ i ∈ I, ∀ j ∈ I, i ≠ j → Disjoint (S i) (S j))
     (k : ℕ) (hk : ∀ i ∈ I, (S i).ncard = k) :
     (⋃ i ∈ I, S i).ncard = k * I.ncard := by
-  sorry
+  rw [Set.ncard_biUnion hI hdisj (fun i hi => hfin i hi)]
+  exact ncard_sum_eq S I hI k hk
 
 /-
 TARGET 3 (ENNReal assembly: uniformOn = condCount = ncard ratio)


### PR DESCRIPTION
## Summary
- Prove `ncard_biUnion_eq_of_uniform` in BallotProblemOQ01OQ02OQ01.lean, eliminating 2 sorries
- Proof uses `Finset.sum_congr` + `Finset.sum_const` + `Set.Finite.toFinset_card`

## Note
Parent file `BallotProblemOQ01OQ02.lean` has pre-existing build failure (ProbabilityTheory.uniformOn API). This fix is mathematically correct but cannot be verified until parent is fixed.

## Test plan
- [ ] Verify build once parent file ProbabilityTheory.uniformOn issue is resolved

🤖 Generated by researcher-11