### PR TITLE
Enrich Nonderogatory Prime Power Cyclic Vector: sections, annotation, reference

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-03/annotations.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-03/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-wip03-lean-setup",
+    "proofId": "cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-03",
+    "range": { "startLine": 33, "endLine": 44 },
+    "type": "context",
+    "title": "Lean 4 Technical Setup",
+    "content": "The file imports all of Mathlib (for access to polynomial algebra, matrix theory, and UFD machinery), marks the section as `noncomputable` (since polynomial decidability and classical logic are used), and opens the `Matrix` and `Polynomial` namespaces. The `Classical.propDecidable` instance enables decidable equality for propositions — essential for the `by_contra` and case-splitting tactics used throughout the Bézout argument. The proof is parametric in a field $K$ and dimension $n$, with no finiteness or cardinality constraints on $K$.",
+    "mathContext": "Variables: $K$ a field, $n : \\mathbb{N}$, matrices in $\\text{Matrix}(\\text{Fin}\\, n)(\\text{Fin}\\, n)\\, K$. The `noncomputable` annotation is needed because `K[X]` division (used in Bézout's identity) requires classical choice.",
+    "significance": "context",
+    "relatedConcepts": ["noncomputable definitions", "classical logic", "type-class inference", "universe polymorphism"],
+    "prerequisites": ["Lean 4 syntax", "Mathlib conventions"]
+  },
+  {
     "id": "ann-wip03-docstring",
     "proofId": "cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-03",
     "range": { "startLine": 1, "endLine": 32 },

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-03/meta.json
@@ -69,6 +69,14 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Preamble and Setup",
+      "startLine": 1,
+      "endLine": 44,
+      "summary": "File documentation, Mathlib import, namespace declaration, and type-class variable setup. Uses Classical.propDecidable for decidability in the coprimality/Bézout arguments.",
+      "mathContext": "The proof is parametric in a field $K$ and dimension $n : \\mathbb{N}$, with all matrices in $K^{n \\times n}$ (Fin n → Fin n → K)."
+    },
+    {
       "id": "definitions",
       "title": "I. Definitions",
       "startLine": 46,
@@ -99,6 +107,14 @@
       "endLine": 235,
       "summary": "Proves nonderogatory_pw_has_cyclic_vector: for nonderogatory M with minpoly = p^e (p monic irreducible, e ≥ 1), M has a cyclic vector over any field K.",
       "mathContext": "Pick v with p^(e-1)(M)v ≠ 0 (possible since deg(p^(e-1)) < n = deg(minpoly) implies p^(e-1)(M) ≠ 0). Then p^e(M)v = 0. For any r with r(M)v = 0 and deg(r) < n: pow_irred_dvd_of_annihilated gives p^e | r, so deg(r) ≥ e·deg(p) = n, contradicting deg(r) < n. Hence r = 0."
+    },
+    {
+      "id": "corollary",
+      "title": "V. Corollary — Finite Fields",
+      "startLine": 240,
+      "endLine": 253,
+      "summary": "States the finite field specialization as a separate theorem, emphasizing that the prime power cyclic vector theorem holds for all finite fields with no cardinality restriction on |K| relative to n.",
+      "mathContext": "For any finite field $\\mathbb{F}_q$ and nonderogatory $M \\in \\mathbb{F}_q^{n \\times n}$ with $\\mu_M = p^e$, there exists a cyclic vector — no restriction $q > n$ needed."
     }
   ],
   "conclusion": {
@@ -196,6 +212,13 @@
       "year": "1971",
       "venue": "Prentice-Hall, 2nd edition",
       "note": "Chapter 7 develops the primary decomposition theorem and rational canonical form via the PID structure theorem. The prime power case proved here corresponds to the single-block case in their decomposition, but avoids the module-theoretic machinery entirely."
+    },
+    {
+      "authors": "Lancaster, Peter; Tismenetsky, Miron",
+      "title": "The Theory of Matrices",
+      "year": "1985",
+      "venue": "Academic Press, 2nd edition",
+      "note": "Chapter 6 treats the cyclic decomposition theorem with explicit construction of cyclic vectors via prime power factorization of the minimal polynomial. The 'level-shifting' technique in their proof (applying p(M) to descend one level) is the same strategy formalized here as the inductive step of pow_irred_dvd_of_annihilated."
     }
   ],
   "sorries": 0


### PR DESCRIPTION
Enrichment pass for cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-03.

**Improvements:**
- Added preamble section (lines 1-44) and corollary section (lines 240-253) for full Lean file coverage in sections array
- Added annotation for Lean 4 technical setup explaining `noncomputable section`, `Classical.propDecidable`, and import strategy
- Added Lancaster & Tismenetsky (1985) reference — their cyclic decomposition treatment uses the same level-shifting technique formalized here