### PR TITLE
research(erdos-1151-oq-04): prove Case 2 setup + factor trig_sum_harmonic_lb

### DIFF
--- a/proofs/Proofs/Erdos1151OQ04.lean
+++ b/proofs/Proofs/Erdos1151OQ04.lean
@@ -13,7 +13,7 @@ Prove `erdos_1941_divergence` by formalizing the connection between:
 The main theorem `erdos_1941_divergence_from_growth` is FULLY PROVED
 (i.e., is a valid mathematical deduction), assuming two sorry lemmas:
 
-  `chebyshev_trig_sum_lb` [SORRY: Case 2 only (x ∈ (-1,1)), harmonic sum via Lipschitz]
+  `trig_sum_harmonic_lb` [SORRY: Lipschitz + harmonic sum for general θ ∈ (0, π)]
   `divergence_from_lebesgue_growth` [SORRY: lacunary series construction]
 
 The non-sorry results proved here:
@@ -31,18 +31,19 @@ The non-sorry results proved here:
   - `cos_rational_pi_mod`: periodicity with period 2q [Session 7]
   - `cos_rational_pi_pos_min`: ∃ δ > 0, |cos(nπp/q)| ≥ δ for all n [Session 7]
   - `chebyshev_lebesgue_growth`: Λₙ → ∞ proved modulo chebyshev_lebesgue_lb [Session 11]
-  - `trig_sum_lb_of_cos_eq_neg_one`: S_n ≥ (1/(2π))·n·log(n+1) for x = -1 [Session 12, NEW]
-  - `chebyshev_trig_sum_lb` Case 1 (x = -1): via trig_sum_lb_of_cos_eq_neg_one [Session 12, NEW]
-  - `tan_eq_cot_complement`: complementary angle cotangent bound [Session 12, NEW]
-  - `odd_harmonic_sum_lb`: ∑ 1/(2j+1) ≥ (1/2)·log(m+1) [Session 12, NEW]
-  - `half_log_le_log_half_add_one`: (1/2)·log(n+1) ≤ log(n/2+1) [Session 12, NEW]
+  - `trig_sum_lb_of_cos_eq_neg_one`: S_n ≥ (1/(2π))·n·log(n+1) for x = -1 [Session 12]
+  - `chebyshev_trig_sum_lb` Case 1 (x = -1): via trig_sum_lb_of_cos_eq_neg_one [Session 12]
+  - `chebyshev_trig_sum_lb` Case 2 (x ∈ (-1,1)): reduced to trig_sum_harmonic_lb [Session 13]
+  - `tan_eq_cot_complement`: complementary angle cotangent bound [Session 12]
+  - `odd_harmonic_sum_lb`: ∑ 1/(2j+1) ≥ (1/2)·log(m+1) [Session 12]
+  - `half_log_le_log_half_add_one`: (1/2)·log(n+1) ≤ log(n/2+1) [Session 12]
 
-## Sorry 1: chebyshev_trig_sum_lb (Case 2 only)
-CASE 1 (x = -1) IS PROVED. Remaining sorry is Case 2 (x ∈ (-1, 1)):
-  - Need: ∃ C₂ > 0, C₂·n·log(n+1) ≤ ∑ sin(φ_k)/|cos(πp/q) - cos(φ_k)| when cos(πp/q) ≠ -1
-  - Strategy: Lipschitz bound |cos θ - cos φ| ≤ |θ-φ|, then harmonic sum of near-nodes
-  - Key tools: sin(πp/q) > 0 gives a constant depending on p,q; node spacing π/n
-  - Estimated difficulty: ~80 lines of careful Finset + trig arithmetic
+## Sorry 1: trig_sum_harmonic_lb (was: chebyshev_trig_sum_lb Case 2)
+Now factored as a SELF-CONTAINED lemma for general θ ∈ (0, π):
+  - Statement: ∃ C > 0, C·n·log(n+1) ≤ Σ sin(φₖ)/|cos θ - cos φₖ| for all n ≥ 1
+  - Depends only on θ ∈ (0, π) and cos θ ≠ any Chebyshev node (no p, q dependency)
+  - Case 2 of chebyshev_trig_sum_lb is PROVED modulo this lemma
+  - Proof approach: Lipschitz + Finset harmonic sum over near-nodes + finite min for small n
 
 ## Sorry 2: divergence_from_lebesgue_growth
 Proof requires:
@@ -1067,6 +1068,35 @@ private lemma trig_sum_lb_of_cos_eq_neg_one (n : ℕ) (hn : 0 < n) :
       _ ≤ ∑ k : Fin n, Real.sin ((2 * k.val + 1 : ℝ) * Real.pi / (4 * n)) /
             Real.cos ((2 * k.val + 1 : ℝ) * Real.pi / (4 * n)) := hsub_le_full
 
+/-! ## Harmonic Trig Sum Lower Bound (General x ∈ (-1, 1)) -/
+
+/-- **[SORRY] Harmonic trig sum lower bound for general θ ∈ (0, π).**
+
+    For any θ ∈ (0, π) with cos θ not a Chebyshev node for any n, the sum
+    S_n = Σₖ sin(φₖ)/|cos θ - cos φₖ| grows at least as fast as n · log(n+1).
+
+    Proof sketch: Let d = min(θ, π-θ) > 0.
+    1. By Lipschitz (|cos α - cos β| ≤ |α - β|): each term ≥ sin(φₖ)/|θ - φₖ|.
+    2. Nearest node k₀ satisfies |θ - φ_{k₀}| ≤ π/(2n).
+    3. For the j-th nearest node beyond k₀ (j = 0,...,m-1 with m = ⌊nd/(4π)⌋):
+       - |θ - φ_{k₀+j+1}| ≤ (2j+3)π/(2n)
+       - sin(φ_{k₀+j+1}) ≥ sin(d/2) ≥ d/π  (since node is in (d/2, π-d/2))
+       - Term ≥ (d/π) · 2n/((2j+3)π) = 2dn/(π²(2j+3))
+    4. Sub-sum ≥ (2dn/π²) · Σ_{j=0}^{m-1} 1/(2j+3) ≥ (2dn/π²) · ((1/2)·log(m+2) - 1)
+    5. For n ≥ N₀(d), this gives ≥ C · n · log(n+1) where C depends on d.
+    6. For 1 ≤ n < N₀, each S_n > 0 and n·log(n+1) > 0, so min ratio over
+       the finite set {1,...,N₀-1} is positive (Finset.min' argument).
+    7. Take C₂ = min of the large-n constant and the finite-set minimum. -/
+private lemma trig_sum_harmonic_lb (θ : ℝ) (hθ_pos : 0 < θ) (hθ_lt : θ < Real.pi)
+    (hne : ∀ (n : ℕ) (_ : 0 < n) (k : Fin n), Real.cos θ ≠ chebyshevNode n k) :
+    ∃ C : ℝ, 0 < C ∧ ∀ n : ℕ, 1 ≤ n →
+      C * ((↑n : ℝ) * Real.log ((↑n : ℝ) + 1)) ≤
+        ∑ k : Fin n, Real.sin ((2 * k.val + 1 : ℝ) * Real.pi / (2 * n)) /
+                     |Real.cos θ - chebyshevNode n k| := by
+  -- Core technical lemma: Lipschitz + harmonic sum over near-nodes + finite minimum.
+  -- See docstring for full proof sketch.
+  sorry
+
 /-! ## Key Lemmas with Sorry -/
 
 /-- **[SORRY] Harmonic sum lower bound for Chebyshev trig sum.**
@@ -1113,10 +1143,49 @@ private lemma chebyshev_trig_sum_lb (p q : ℕ) (hp : Odd p) (hq : Odd q) (hq_po
           |(-1 : ℝ) - Real.cos ((2 * k.val + 1 : ℝ) * Real.pi / (2 * n))| from
       Finset.sum_congr rfl (fun k _ => hrewrite k)]
     exact trig_sum_lb_of_cos_eq_neg_one n hn
-  · -- Case 2: x = cos(πp/q) ∈ (-1, 1), i.e., sin(πp/q) ≠ 0
-    -- Strategy: use Lipschitz bound |cos θ - cos φ| ≤ |θ - φ| and harmonic sum
-    -- of nodes near x to get S_n ≥ C·n·log(n+1) where C depends on sin(πp/q)
-    sorry  -- Case 2: x ∈ (-1, 1), Lipschitz + harmonic sum argument
+  · -- Case 2: x = cos(πp/q) ∈ (-1, 1), Lipschitz + harmonic sum
+    -- Step 1: cos(πp/q) ∈ (-1, 1)
+    have hx_gt : -1 < Real.cos ((↑p : ℝ) * Real.pi / ↑q) := by
+      by_contra h; push_neg at h
+      exact hx_neg1 (le_antisymm h (neg_one_le_cos _))
+    have hx_lt : Real.cos ((↑p : ℝ) * Real.pi / ↑q) < 1 := by
+      by_contra h; push_neg at h
+      have heq : Real.cos ((↑p : ℝ) * Real.pi / ↑q) = 1 :=
+        le_antisymm (Real.cos_le_one _) h
+      rw [Real.cos_eq_one_iff] at heq
+      obtain ⟨k, hk⟩ := heq
+      have hq_ne : (q : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hq_pos.ne'
+      have hpR : (p : ℝ) = k * (2 * q) := by field_simp at hk; linarith
+      have hpZ : (p : ℤ) = k * (2 * q) := by exact_mod_cast hpR
+      exact (Int.even_iff_not_odd.mp ⟨k * q, by linarith⟩) (by exact_mod_cast hp)
+    -- Step 2: arccos gives canonical angle θ₀ ∈ (0, π) with cos θ₀ = cos(πp/q)
+    set x := Real.cos ((↑p : ℝ) * Real.pi / ↑q) with hx_def
+    set θ₀ := Real.arccos x with hθ₀_def
+    have hcos_eq : Real.cos θ₀ = x := Real.cos_arccos (neg_one_le_cos _) (Real.cos_le_one _)
+    have hθ₀_pos : 0 < θ₀ := Real.arccos_pos.mpr hx_lt
+    have hθ₀_lt_pi : θ₀ < Real.pi := Real.arccos_lt_pi.mpr hx_gt
+    -- Step 3: Each sum term is positive
+    have hterm_pos : ∀ (n : ℕ) (hn : 0 < n) (k : Fin n),
+        0 < Real.sin ((2 * k.val + 1 : ℝ) * Real.pi / (2 * n)) /
+            |x - chebyshevNode n k| := by
+      intro n hn k
+      exact div_pos (chebyshevAngle_sin_pos n hn k)
+        (abs_pos.mpr (sub_ne_zero.mpr (x_not_chebyshev_node p q hp hq hq_pos n hn k)))
+    -- Step 4: Reduce to cos θ₀ form
+    suffices h_main : ∃ C₂ : ℝ, 0 < C₂ ∧ ∀ n : ℕ, 1 ≤ n →
+        C₂ * ((↑n : ℝ) * Real.log ((↑n : ℝ) + 1)) ≤
+          ∑ k : Fin n, Real.sin ((2 * k.val + 1 : ℝ) * Real.pi / (2 * n)) /
+                       |Real.cos θ₀ - chebyshevNode n k| by
+      obtain ⟨C₂, hC₂, hbound⟩ := h_main
+      refine ⟨C₂, hC₂, fun n hn => ?_⟩
+      have : x = Real.cos θ₀ := hcos_eq.symm
+      rw [this]; exact hbound n hn
+    -- Step 5: Apply trig_sum_harmonic_lb with θ₀ and the node-avoidance property
+    have hne : ∀ (n : ℕ) (_ : 0 < n) (k : Fin n), Real.cos θ₀ ≠ chebyshevNode n k := by
+      intro n hn k
+      rw [hcos_eq]
+      exact x_not_chebyshev_node p q hp hq hq_pos n hn k
+    exact trig_sum_harmonic_lb θ₀ hθ₀_pos hθ₀_lt_pi hne
 
 /-- **Logarithmic lower bound on the Lebesgue function** (proved modulo `chebyshev_trig_sum_lb`).
 

--- a/src/data/research/problems/erdos-1151-oq-04.json
+++ b/src/data/research/problems/erdos-1151-oq-04.json
@@ -6,8 +6,8 @@
   "tier": "B",
   "path": "full",
   "problemStatement": {
-    "formal": "axiom erdos_1941_divergence (p q : ℕ) (hp : Odd p) (hq : Odd q) (hq1 : 1 < q) (x : ℝ) (hx : x = Real.cos (↑p * Real.pi / ↑q)) : Filter.Tendsto (fun n => chebyshevInterpSeq (fun _ => 0) x n) Filter.atTop Filter.atTop",
-    "plain": "Can the axiom erdos_1941_divergence be proved in Lean 4 by formalizing the Lebesgue function growth rate Λₙ(cos(πp/q)) → ∞ for rational cosine points with odd p, q?",
+    "formal": "axiom erdos_1941_divergence (p q : \u2115) (hp : Odd p) (hq : Odd q) (hq1 : 1 < q) (x : \u211d) (hx : x = Real.cos (\u2191p * Real.pi / \u2191q)) : Filter.Tendsto (fun n => chebyshevInterpSeq (fun _ => 0) x n) Filter.atTop Filter.atTop",
+    "plain": "Can the axiom erdos_1941_divergence be proved in Lean 4 by formalizing the Lebesgue function growth rate \u039b\u2099(cos(\u03c0p/q)) \u2192 \u221e for rational cosine points with odd p, q?",
     "whyMatters": [
       "Eliminates an axiom from Erdos1151Problem.lean, moving from axiomatized to verified",
       "Connects classical approximation theory (Chebyshev nodes, Lebesgue function) to Lean 4",
@@ -21,7 +21,7 @@
       "limitPointSet_isClosed: limit point sets are closed"
     ],
     "open": [
-      "Lebesgue function growth: Λₙ(cos(πp/q)) → ∞ as n → ∞",
+      "Lebesgue function growth: \u039b\u2099(cos(\u03c0p/q)) \u2192 \u221e as n \u2192 \u221e",
       "erdos_1941_divergence: divergence of Chebyshev interpolation at rational cosines"
     ],
     "goal": "Prove erdos_1941_divergence to eliminate the axiom from the gallery"
@@ -40,49 +40,55 @@
     }
   },
   "knowledge": {
-    "progressSummary": "2 sorries remain: chebyshev_trig_sum_lb (tractable, ~200 lines) and divergence_from_lebesgue_growth (fundamental gap: lim vs lim sup)",
+    "progressSummary": "2 sorries remain: trig_sum_harmonic_lb (Lipschitz+harmonic, self-contained) and divergence_from_lebesgue_growth (lim vs lim sup gap). Case 2 of chebyshev_trig_sum_lb is PROVED modulo trig_sum_harmonic_lb.",
     "builtItems": [
-      "T_ofNat_ne_zero (n : ℕ) : T ℝ (n : ℤ) ≠ 0 — Erdos1151OQ04.lean:274",
-      "natDegree_T_ofNat : ∀ n : ℕ, (T ℝ (n : ℤ)).natDegree = n — Erdos1151OQ04.lean:282",
-      "leadingCoeff_T_ofNat : ∀ n ≥ 1, (T ℝ (n : ℤ)).leadingCoeff = 2^(n-1) — Erdos1151OQ04.lean:306",
+      "T_ofNat_ne_zero (n : \u2115) : T \u211d (n : \u2124) \u2260 0 \u2014 Erdos1151OQ04.lean:274",
+      "natDegree_T_ofNat : \u2200 n : \u2115, (T \u211d (n : \u2124)).natDegree = n \u2014 Erdos1151OQ04.lean:282",
+      "leadingCoeff_T_ofNat : \u2200 n \u2265 1, (T \u211d (n : \u2124)).leadingCoeff = 2^(n-1) \u2014 Erdos1151OQ04.lean:306",
       "Build fixes: all Session 3 lemmas compile cleanly in Proofs/Erdos1151OQ04.lean",
-      "chebyshev_product_formula: T_n = 2^{n-1} * prod(X - cos phi_k) — Erdos1151OQ04.lean:309",
-      "lagrange_basis_chebyshev_formula: explicit Lagrange basis via product formula — Erdos1151OQ04.lean:388",
-      "chebyshev_lebesgue_eq: Lebesgue function explicit formula for ALL n when q odd — Erdos1151OQ04.lean:498",
-      "x_not_chebyshev_node: parity lemma, cos(pi*p/q) != chebyshevNode n k for all n when p,q odd — Erdos1151OQ04.lean:534",
-      "chebyshev_lebesgue_eq_all_n: Lebesgue formula for all n when p,q odd — Erdos1151OQ04.lean:601",
-      "chebyshev_lebesgue_growth: proved (Filter.tendsto_atTop_mono + C·log(n+1) → ∞)",
-      "cos_rational_pi_pos_min: ∃ δ > 0 s.t. |cos(nπp/q)| ≥ δ for all n (parity argument)",
-      "x_not_chebyshev_node: cos(πp/q) ≠ chebyshevNode n k for all n,k when p,q odd",
-      "chebyshev_trig_sum_lb: sorry (isolated harmonic sum lower bound: S_n ≥ C₂·n·log(n+1))",
-      "chebyshev_lebesgue_lb: proved modulo chebyshev_trig_sum_lb via mul_le_mul chain (δ/n · C₂·n·log(n+1) ≤ |cos(nθ)|/n · S_n)"
+      "chebyshev_product_formula: T_n = 2^{n-1} * prod(X - cos phi_k) \u2014 Erdos1151OQ04.lean:309",
+      "lagrange_basis_chebyshev_formula: explicit Lagrange basis via product formula \u2014 Erdos1151OQ04.lean:388",
+      "chebyshev_lebesgue_eq: Lebesgue function explicit formula for ALL n when q odd \u2014 Erdos1151OQ04.lean:498",
+      "x_not_chebyshev_node: parity lemma, cos(pi*p/q) != chebyshevNode n k for all n when p,q odd \u2014 Erdos1151OQ04.lean:534",
+      "chebyshev_lebesgue_eq_all_n: Lebesgue formula for all n when p,q odd \u2014 Erdos1151OQ04.lean:601",
+      "chebyshev_lebesgue_growth: proved (Filter.tendsto_atTop_mono + C\u00b7log(n+1) \u2192 \u221e)",
+      "cos_rational_pi_pos_min: \u2203 \u03b4 > 0 s.t. |cos(n\u03c0p/q)| \u2265 \u03b4 for all n (parity argument)",
+      "x_not_chebyshev_node: cos(\u03c0p/q) \u2260 chebyshevNode n k for all n,k when p,q odd",
+      "chebyshev_trig_sum_lb: sorry (isolated harmonic sum lower bound: S_n \u2265 C\u2082\u00b7n\u00b7log(n+1))",
+      "chebyshev_lebesgue_lb: proved modulo chebyshev_trig_sum_lb via mul_le_mul chain (\u03b4/n \u00b7 C\u2082\u00b7n\u00b7log(n+1) \u2264 |cos(n\u03b8)|/n \u00b7 S_n)",
+      "chebyshev_trig_sum_lb Case 2 PROVED: cos(\u03c0p/q) \u2208 (-1,1) via parity, arccos setup, reduction to trig_sum_harmonic_lb \u2014 Erdos1151OQ04.lean:1146",
+      "trig_sum_harmonic_lb: self-contained sorry for general \u03b8 \u2208 (0, \u03c0), Lipschitz + harmonic Finset argument \u2014 Erdos1151OQ04.lean:1083",
+      "cos_pi_p_q_ne_one: cos(\u03c0p/q) \u2260 1 when p odd (parity: p = 2kq \u2192 even) \u2014 Erdos1151OQ04.lean:1151"
     ],
     "insights": [
-      "Lebesgue function Λₙ(x) = Σₖ |ℓₖ(x)| measures worst-case interpolation amplification",
-      "Growth rate for rational cosines: Λₙ(cos(πp/q)) ≥ C·log(n)",
-      "Divergence of interpolation sequence follows from Λₙ → ∞ via bump function",
-      "natDegree and leadingCoeff of T_n proved by two-step induction on recurrence T_{n+2} = 2X·T_{n+1} - T_n",
-      "Product formula proof strategy: T_n - Q_n has deg < n and n roots (by Chebyshev node roots + card_roots_le_degree) → T_n = Q_n",
-      "(2 : ℝ[X]) = C 2 via Polynomial.C_ofNat; leadingCoeff_C gives leadingCoeff = 2",
+      "Lebesgue function \u039b\u2099(x) = \u03a3\u2096 |\u2113\u2096(x)| measures worst-case interpolation amplification",
+      "Growth rate for rational cosines: \u039b\u2099(cos(\u03c0p/q)) \u2265 C\u00b7log(n)",
+      "Divergence of interpolation sequence follows from \u039b\u2099 \u2192 \u221e via bump function",
+      "natDegree and leadingCoeff of T_n proved by two-step induction on recurrence T_{n+2} = 2X\u00b7T_{n+1} - T_n",
+      "Product formula proof strategy: T_n - Q_n has deg < n and n roots (by Chebyshev node roots + card_roots_le_degree) \u2192 T_n = Q_n",
+      "(2 : \u211d[X]) = C 2 via Polynomial.C_ofNat; leadingCoeff_C gives leadingCoeff = 2",
       "apply lemma fails when conclusion has concrete value (n+2) vs metavar (p.natDegree): use have key := lemma proof; rw [key]",
-      "ℕ strict bound j.val < n does NOT give 2*j+1 < 2*n in ℝ via linarith; need omega on ℕ then exact_mod_cast",
-      "div_lt_iff renamed to div_lt_iff₀ in Mathlib v4.26.0",
-      "Session 5 proved product formula, lagrange basis formula, and lebesgue_eq (sorries: 4→2)",
+      "\u2115 strict bound j.val < n does NOT give 2*j+1 < 2*n in \u211d via linarith; need omega on \u2115 then exact_mod_cast",
+      "div_lt_iff renamed to div_lt_iff\u2080 in Mathlib v4.26.0",
+      "Session 5 proved product formula, lagrange basis formula, and lebesgue_eq (sorries: 4\u21922)",
       "x_not_chebyshev_node: cos(pi*p/q) is NEVER a Chebyshev node when q is odd (parity: q*(2k+1) is odd, angle condition requires even = odd)",
       "chebyshev_lebesgue_eq_all_n: applies for ALL n when p,q odd (not just n=mq subsequence)",
       "divergence_from_lebesgue_growth fundamental gap: Banach-Steinhaus only gives lim sup = inf, not lim = +inf; axiom may be overstated",
-      "chebyshev_lebesgue_growth reduces to lb sorry via tendsto_atTop_mono — growth theorem itself is proved",
-      "Filter.tendsto_atTop_mono pattern: if f ≤ g pointwise and f → ∞ then g → ∞",
+      "chebyshev_lebesgue_growth reduces to lb sorry via tendsto_atTop_mono \u2014 growth theorem itself is proved",
+      "Filter.tendsto_atTop_mono pattern: if f \u2264 g pointwise and f \u2192 \u221e then g \u2192 \u221e",
       "let binding in Lean 4 requires explicit unfolding in simp: simp only [vals, ...]",
-      "chebyshev_lebesgue_growth is PROVED (not sorry) — wraps chebyshev_lebesgue_lb which assumes sorry #1",
-      "p,q both odd implies cos(pi*p/q) is strictly in (-1,1), so sin argument is nonzero. Case x=+-1 never occurs in hypotheses."
+      "chebyshev_lebesgue_growth is PROVED (not sorry) \u2014 wraps chebyshev_lebesgue_lb which assumes sorry #1",
+      "p,q both odd implies cos(pi*p/q) is strictly in (-1,1), so sin argument is nonzero. Case x=+-1 never occurs in hypotheses.",
+      "Session 13: Case 2 factored into self-contained trig_sum_harmonic_lb(\u03b8, h\u03b8\u2208(0,\u03c0), hne). No dependency on p,q.",
+      "Real.arccos_pos.mpr / Real.arccos_lt_pi.mpr: get strict bounds \u03b8\u2080 \u2208 (0,\u03c0) from x \u2208 (-1,1)",
+      "Real.cos_eq_one_iff: cos x = 1 \u2194 \u2203 k : \u2124, x = k*(2\u03c0). Use to show cos(\u03c0p/q) \u2260 1 from p odd.",
+      "LipschitzWith.dist_le_mul converts edist bound to |cos \u03b1 - cos \u03b2| \u2264 |\u03b1 - \u03b2| via Real.dist_eq"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "chebyshev_lebesgue_lb: harmonic sum lower bound for S_n = Σ sin(φₖ)/|cos θ - cos φₖ| ≥ C·n·log(n+1)",
-      "divergence_from_lebesgue_growth: weaken to lim sup = ∞ (Banach-Steinhaus) or find explicit construction",
-      "Attempt chebyshev_trig_sum_lb: Lipschitz + harmonic sum proof (~200 lines). sin(pi*p/q) > 0 from p,q odd ensures x in (-1,1). Nearest node k0, bound denominator via node spacing pi/n, sum j=1..n/4 terms gives (n*sin(theta)/(2pi))*log(n/4+1).",
-      "Sorry #2 gap documented: UBP/Banach-Steinhaus gives lim sup not lim. Consider weakening divergence_from_lebesgue_growth to lim sup = inf version."
+      "PROVE trig_sum_harmonic_lb: Finset reindexing for near-nodes (Lipschitz + odd_harmonic_sum_lb + finite min). ~100-150 lines.",
+      "divergence_from_lebesgue_growth: weaken to lim sup = \u221e (Banach-Steinhaus) or find explicit lacunary construction.",
+      "For trig_sum_harmonic_lb: use pattern from trig_sum_lb_of_cos_eq_neg_one (sub-sum over n/2 nodes, reindex via injection, sum_le_sum). Key difference: use Lipschitz bound instead of half-angle identity."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary
- Proved `chebyshev_trig_sum_lb` Case 2 (x ∈ (-1,1)) modulo new self-contained sorry `trig_sum_harmonic_lb`
- Factored the remaining sorry into a clean, self-contained lemma with no dependency on p, q
- Updated problem knowledge with session insights and next steps

## Progress
**Case 2 of `chebyshev_trig_sum_lb` is now PROVED** (modulo `trig_sum_harmonic_lb`):
1. cos(πp/q) ∈ (-1,1): parity argument (cos=1 → p=2kq even, contradicts p odd)
2. arccos setup: θ₀ ∈ (0,π) with cos(θ₀) = cos(πp/q)
3. suffices reduction: rewrites x as cos(θ₀) to decouple from p,q
4. Applies `trig_sum_harmonic_lb` with node-avoidance from `x_not_chebyshev_node`

**New factored sorry: `trig_sum_harmonic_lb`**
- Self-contained: depends only on θ ∈ (0,π) and cos θ ≠ any Chebyshev node
- Proof approach: Lipschitz + harmonic Finset sum over near-nodes + finite min for small n

## Files Modified
- `proofs/Proofs/Erdos1151OQ04.lean`: Case 2 proof + new lemma
- `src/data/research/problems/erdos-1151-oq-04.json`: knowledge update

## Status
**Outcome**: progress
**Sorries**: 2 (trig_sum_harmonic_lb + divergence_from_lebesgue_growth)
**Next Steps**: Prove trig_sum_harmonic_lb via Finset reindexing (~100-150 lines)

🤖 Generated by researcher-3