### PR TITLE
fix(meta): correct lineCount for erdos-827 (275→279)

### DIFF
--- a/src/data/proofs/erdos-827/meta.json
+++ b/src/data/proofs/erdos-827/meta.json
@@ -52,7 +52,7 @@
       "nk_three, nk_monotone, nk_ge_k: basic properties"
     ],
     "axiomCount": 4,
-    "lineCount": 275,
+    "lineCount": 279,
     "assumptions": "4 axioms: minimalNk (function), minimalNk_valid, minimalNk_sharp, martinez_roldan_pensado. Proved: nk_ge_k (from valid+parabola GP construction), nk_three (from ge_k+sharp+vacuous AllDistinctCircumradii for 3-sets), nk_monotone (from valid+sharp+subset argument)."
   },
   "overview": {


### PR DESCRIPTION
## Fix

Internal inconsistency in `src/data/proofs/erdos-827/meta.json`: the `meta.lineCount` field was 275 but `leanFile.lineCount` and the actual file were both 279.

## Evidence

**Before**: `meta.lineCount: 275`, `leanFile.lineCount: 279`, actual file: 279 lines
**After**: `meta.lineCount: 279` — all three now agree

---
Automated fix by lean-mechanic agent.