### PR TITLE
fix(erdos-778): repair True stub, broken degree game defs, orphaned docstrings

### DIFF
--- a/proofs/Proofs/Erdos778Problem.lean
+++ b/proofs/Proofs/Erdos778Problem.lean
@@ -120,7 +120,8 @@ noncomputable def maxDegree (G : SimpleGraph (Fin n)) [DecidableRel G.Adj] : ℕ
 /-- Game 3 (Degree Game): Alice wins if max red degree > max blue degree -/
 def aliceWinsDegreeGame (n : ℕ) (state : GameState n) : Prop :=
   gameOver n state ∧
-  ∃ dr db : ℕ, dr > db  -- max red degree > max blue degree
+  @maxDegree n (redSubgraph n state) (Classical.decRel _) >
+  @maxDegree n (blueSubgraph n state) (Classical.decRel _)
 
 /- ## Part V: Strategies
 
@@ -147,29 +148,36 @@ def AliceHasWinningStrategy_CliqueGame (n : ℕ) : Prop :=
   ∃ τ : AliceStrategy n, ∀ σ : BobStrategy n,
     aliceWinsCliqueGame n (playGame n τ σ)
 
+/-- Alice has a winning strategy for the degree game on K_n -/
+def AliceHasWinningStrategy_DegreeGame (n : ℕ) : Prop :=
+  ∃ τ : AliceStrategy n, ∀ σ : BobStrategy n,
+    aliceWinsDegreeGame n (playGame n τ σ)
+
+/-- Bob has a winning strategy for the degree game on K_n -/
+def BobHasWinningStrategy_DegreeGame (n : ℕ) : Prop :=
+  ∃ σ : BobStrategy n, ∀ τ : AliceStrategy n,
+    ¬aliceWinsDegreeGame n (playGame n τ σ)
+
 /- ## Part VI: Erdős's Conjecture and Known Results -/
 
 /-- Erdős's Conjecture: Bob has winning strategy for all n ≥ 3 -/
 def ErdosConjecture : Prop :=
   ∀ n : ℕ, n ≥ 3 → BobHasWinningStrategy_CliqueGame n
 
-/-- Malekshahian-Spiro 2024: The set {n : Bob wins clique game} has
-    natural density ≥ 3/4 among natural numbers -/
-/-- Malekshahian-Spiro 2024: If Alice wins at n, Bob wins at n+1, n+2, n+3 -/
+/-- Malekshahian-Spiro 2024: If Alice wins clique game at n, Bob wins at n+1, n+2, n+3.
+    The set {n : Bob wins clique game} has natural density ≥ 3/4. -/
 axiom malekshahian_spiro_alice_n_bob_n123 :
   ∀ n : ℕ, AliceHasWinningStrategy_CliqueGame n →
     BobHasWinningStrategy_CliqueGame (n + 1) ∧
     BobHasWinningStrategy_CliqueGame (n + 2) ∧
     BobHasWinningStrategy_CliqueGame (n + 3)
 
-/-- Malekshahian-Spiro 2024: The set {n : Bob wins degree game} has
-    natural density ≥ 2/3 -/
-/-- Malekshahian-Spiro 2024: If Alice wins degree game at n,
-    Bob wins at n+1 and n+2 -/
-theorem malekshahian_spiro_alice_n_bob_n12_degree :
-  ∀ n : ℕ, True →  -- If Alice wins degree game at n
-    True  -- Then Bob wins degree game at n+1 and n+2
-  := fun _ _ => trivial
+/-- Malekshahian-Spiro 2024: If Alice wins degree game at n, Bob wins at n+1 and n+2.
+    The set {n : Bob wins degree game} has natural density ≥ 2/3. -/
+axiom malekshahian_spiro_alice_n_bob_n12_degree :
+  ∀ n : ℕ, AliceHasWinningStrategy_DegreeGame n →
+    BobHasWinningStrategy_DegreeGame (n + 1) ∧
+    BobHasWinningStrategy_DegreeGame (n + 2)
 
 /- ## Part VII: Consequences of Known Results -/
 
@@ -190,8 +198,6 @@ theorem alice_no_four_consecutive (n : ℕ) :
   -- Contradiction: σ beats all Alice strategies, but τ beats all Bob strategies
   exact hσ τ (hτ σ)
 
-/-- The game is determined: for each n, either Alice or Bob has
-    a winning strategy (by Zermelo's theorem for finite games) -/
 /- ## Part VIII: Summary
 
 Erdős Problem #778: OPEN

--- a/src/data/proofs/erdos-778/meta.json
+++ b/src/data/proofs/erdos-778/meta.json
@@ -57,9 +57,9 @@
       "game_determined: Zermelo's theorem axiomatized",
       "erdos_778_periodicity summary theorem"
     ],
-    "axiomCount": 2,
-    "lineCount": 219,
-    "assumptions": "2 axioms: playGame, malekshahian_spiro_alice_n_bob_n123. 0 sorries."
+    "axiomCount": 3,
+    "lineCount": 225,
+    "assumptions": "3 axioms: playGame, malekshahian_spiro_alice_n_bob_n123, malekshahian_spiro_alice_n_bob_n12_degree. 0 sorries."
   },
   "overview": {
     "historicalContext": "**Erd\u0151s Problem #778: Clique-Building Games on Complete Graphs**\n\nThis problem, posed by Erd\u0151s (referenced in Gu83), concerns competitive edge-coloring games on complete graphs \u2014 a topic at the intersection of combinatorial game theory and Ramsey theory.\n\n**Three Game Variants:**\nAlice and Bob alternate coloring edges of K_n red (Alice) and blue (Bob), with Alice going first. Variant 1 (Clique Game): Alice wins if her largest red clique exceeds Bob's largest blue clique. Variant 2 (Modified Game): Bob colors 2 edges per turn; he wins if his largest clique strictly exceeds Alice's. Variant 3 (Degree Game): Alice wins if the maximum degree in the red subgraph exceeds that of the blue.\n\n**Erd\u0151s's Belief:** Erd\u0151s conjectured that Bob should always have a winning strategy in the clique game for n \u2265 3, reflecting the general principle that the second player often has a structural advantage in such games.\n\n**Recent Progress:** Malekshahian and Spiro (arXiv:2410.18304, 2024) proved significant partial results. For the clique game, they showed Bob wins for a set of n with natural density at least 3/4, and that if Alice ever wins at some n, then Bob wins at the next three values n+1, n+2, n+3. For the degree game, Bob wins with density at least 2/3, with a similar recovery property over two consecutive values. These results strongly support Erd\u0151s's conjecture but the complete answer remains open.",
@@ -168,10 +168,10 @@
       "Finset"
     ],
     "namespace": "Erdos778",
-    "lineCount": 219,
-    "axiomCount": 2,
+    "lineCount": 225,
+    "axiomCount": 3,
     "theoremCount": 3,
-    "definitionCount": 16,
+    "definitionCount": 18,
     "path": "Proofs/Erdos778Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Minimal repair for gallery integrity issue #13065 (erdos-778: Clique-Building Games).

## Evidence

**Before**:
- `aliceWinsDegreeGame` used `∃ dr db : ℕ, dr > db` — trivially satisfiable, making the condition meaningless
- `malekshahian_spiro_alice_n_bob_n12_degree` was `True → True` stub with no mathematical content
- 3 orphaned `/-- ... -/` docstrings with no following declarations
- No `AliceHasWinningStrategy_DegreeGame` / `BobHasWinningStrategy_DegreeGame` definitions

**After**:
- `aliceWinsDegreeGame` correctly compares `maxDegree (redSubgraph n state) > maxDegree (blueSubgraph n state)` via `Classical.decRel`
- `AliceHasWinningStrategy_DegreeGame` and `BobHasWinningStrategy_DegreeGame` defined
- `malekshahian_spiro_alice_n_bob_n12_degree` is a proper `axiom` with correct Malekshahian-Spiro type
- Orphaned docstrings removed or consolidated
- `axiomCount` updated 2→3, `lineCount` 219→225, `definitionCount` 16→18

Note: supersedes conflicting PR #13074 which had accumulated unrelated changes.

Closes #13065

---
Automated fix by lean-mechanic agent.