### PR TITLE
feat(aristotle): add companion + prove cochromatic_coloring_exists_ari for Erdős #625

### DIFF
--- a/proofs/Proofs/Erdos625ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos625ProblemAristotle.lean
@@ -1,0 +1,125 @@
+/-
+  Aristotle targets for Erdős Problem #625: Chromatic vs Cochromatic Numbers of Random Graphs
+  Routine supporting lemmas for automated proof search.
+  See Erdos625Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main open question (MainQuestion, HeckelConjecture — both axiomatized)
+  - NOT the deep analysis results (Bollobás 1988, Heckel 2024, Steiner 2024)
+  - AlmostSurely-based theorems (AlmostSurely unfolds to ∀ ε > 0, ∃ N, ∀ n ≥ N, True — trivial)
+  - Logical implication and structural theorems
+  - No axioms, no definition sorries, no open conjectures
+  - No /-! docstring sections (use /- instead)
+-/
+import Proofs.Erdos625Problem
+import Mathlib
+
+namespace Erdos625Aristotle
+
+open Erdos625 SimpleGraph
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+/-
+## Section 1: AlmostSurely Placeholder Theorems
+
+AlmostSurely is defined as a placeholder:
+  AlmostSurely P = ∀ ε > 0, ∃ N, ∀ n ≥ N, True
+
+Since the body is True, all AlmostSurely statements are trivially satisfiable.
+These match the sorry-bearing theorems in Erdos625Problem.lean.
+-/
+
+/-- Lower bound on cochromatic number holds a.s. (AlmostSurely placeholder is trivially True). -/
+theorem cochromatic_lower_bound_ari :
+    AlmostSurely (fun n G => (cochromaticNumber G.graph : ℝ) ≥ n / (2 * Real.log n / Real.log 2)) := by
+  intro ε hε
+  exact ⟨0, fun n _ => trivial⟩
+
+/-- Bollobás upper bound holds a.s. (AlmostSurely placeholder is trivially True). -/
+theorem bollobas_upper_bound_ari :
+    ∀ ε > 0, AlmostSurely (fun n G =>
+      (chromaticNumber G.graph : ℝ) ≤ (1 + ε) * n / (2 * Real.log n / Real.log 2)) := by
+  intro ε hε ε' hε'
+  exact ⟨0, fun n _ => trivial⟩
+
+/-- The chromatic-cochromatic sandwich holds a.s. (AlmostSurely placeholder is trivially True). -/
+theorem chromatic_cochromatic_sandwich_ari :
+    AlmostSurely (fun n G =>
+      (cochromaticNumber G.graph : ℝ) ≤ chromaticNumber G.graph ∧
+      (chromaticNumber G.graph : ℝ) ≤ (1.01) * n / (2 * Real.log n / Real.log 2)) := by
+  intro ε hε
+  exact ⟨0, fun n _ => trivial⟩
+
+/-- Heckel-Steiner: difference is unbounded w.h.p. (AlmostSurely placeholder is trivially True). -/
+theorem heckel_steiner_unbounded_ari :
+    ∀ M : ℕ, AlmostSurely (fun n G =>
+      chromaticNumber G.graph - cochromaticNumber G.graph ≥ M) := by
+  intro M ε hε
+  exact ⟨0, fun n _ => trivial⟩
+
+/-- Difference lower bound a.s. (AlmostSurely placeholder is trivially True). -/
+theorem difference_lower_bound_ari :
+    ∀ ε > 0, ∃ f : ℕ → ℕ, StrictMono f ∧
+      AlmostSurely (fun n G =>
+        (chromaticNumber G.graph - cochromaticNumber G.graph : ℝ) ≥ n^(1/2 - ε)) := by
+  intro ε hε
+  exact ⟨id, strictMono_id, fun ε' hε' => ⟨0, fun n _ => trivial⟩⟩
+
+/-- Heckel conjecture implies the main question (both are AlmostSurely placeholders). -/
+theorem heckel_implies_main_ari (h : HeckelConjecture) : MainQuestion := by
+  intro ε hε
+  exact ⟨0, fun n _ => trivial⟩
+
+/-- Clique and independence number bound a.s. (AlmostSurely placeholder is trivially True). -/
+theorem clique_independence_bound_ari :
+    AlmostSurely (fun n G =>
+      (cliqueNumber G.graph : ℝ) ≤ 2.1 * Real.log n / Real.log 2 ∧
+      (independenceNumber G.graph : ℝ) ≤ 2.1 * Real.log n / Real.log 2) := by
+  intro ε hε
+  exact ⟨0, fun n _ => trivial⟩
+
+/-- Chromatic number concentration a.s. (AlmostSurely placeholder is trivially True). -/
+theorem chromatic_concentration_ari :
+    AlmostSurely (fun n G =>
+      ∃ χ₀ : ℕ, |chromaticNumber G.graph - χ₀| ≤ n / (Real.log n)^2) := by
+  intro ε hε
+  exact ⟨0, fun n _ => trivial⟩
+
+/-- Cochromatic number concentration a.s. (AlmostSurely placeholder is trivially True). -/
+theorem cochromatic_concentration_ari :
+    AlmostSurely (fun n G =>
+      ∃ ζ₀ : ℕ, |cochromaticNumber G.graph - ζ₀| ≤ n / Real.log n) := by
+  intro ε hε
+  exact ⟨0, fun n _ => trivial⟩
+
+/-
+## Section 2: Basic Inequality Lemmas
+-/
+
+/-- The difference χ - ζ is bounded above by χ for all graphs. -/
+theorem difference_le_chromatic_ari (G : SimpleGraph V) :
+    chromaticNumber G - cochromaticNumber G ≤ chromaticNumber G := by
+  omega
+
+/-
+## Section 3: Cochromatic Existence
+
+A cochromatic coloring always exists: use one color per vertex (singleton classes are trivially
+cochromatic since the cochromatic condition is vacuous for singletons).
+-/
+
+/-- The singleton set {v} is cochromatic: vacuously satisfies the empty/clique condition. -/
+theorem singleton_is_cochromatic_ari (G : SimpleGraph V) (v : V) :
+    IsCochromaticClass G {w | w = v} := by
+  right
+  intro u w hu hv huv
+  simp at hu hv
+  exact absurd (hu ▸ hv) huv
+
+/-- A cochromatic coloring with |V| colors always exists for any graph. -/
+theorem cochromatic_coloring_exists_ari (G : SimpleGraph V) :
+    Nonempty (CochromaticColoring G (Fintype.card V)) := by
+  sorry
+
+end Erdos625Aristotle

--- a/proofs/Proofs/Erdos625ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos625ProblemAristotle.lean
@@ -120,6 +120,12 @@ theorem singleton_is_cochromatic_ari (G : SimpleGraph V) (v : V) :
 /-- A cochromatic coloring with |V| colors always exists for any graph. -/
 theorem cochromatic_coloring_exists_ari (G : SimpleGraph V) :
     Nonempty (CochromaticColoring G (Fintype.card V)) := by
-  sorry
+  -- Assign each vertex a unique color via the canonical bijection V ≃ Fin (Fintype.card V).
+  -- Each color class is a singleton, so cochromatic vacuously (no two distinct elements).
+  refine ⟨⟨Fintype.equivFin V, fun c => ?_⟩⟩
+  right
+  intro u v hu hv huv
+  simp only [Set.mem_setOf_eq] at hu hv
+  exact absurd ((Fintype.equivFin V).injective (hu.trans hv.symm)) huv
 
 end Erdos625Aristotle


### PR DESCRIPTION
## Fix

Two commits for Erdős #625 (Chromatic vs Cochromatic Number):

### Commit 1: Aristotle companion file

Adds `Erdos625ProblemAristotle.lean` with Aristotle targets — routine lemmas supporting the chromatic vs cochromatic number formalization.

### Commit 2: Prove `cochromatic_coloring_exists_ari`

Proved by assigning each vertex a unique color via the canonical bijection `V ≃ Fin (Fintype.card V)`. Each singleton color class is cochromatic vacuously (no two distinct vertices share the same color), so the right disjunct holds trivially via injectivity.

---
Automated fix by lean-mechanic agent.