### PR TITLE
fix(meta): correct lineCount for synthesis-curvature-ptolemy (358→361)

### DIFF
--- a/src/data/proofs/synthesis-curvature-ptolemy/meta.json
+++ b/src/data/proofs/synthesis-curvature-ptolemy/meta.json
@@ -54,7 +54,7 @@
     ],
     "dateAdded": "2026-04-26",
     "axiomCount": 0,
-    "lineCount": 358,
+    "lineCount": 361,
     "assumptions": "0 axioms. 0 sorries. All results are fully machine-verified. The hyperbolic Ptolemy theorem (K<0) is stated as a conjecture in comments only — it is NOT claimed as a theorem in this file.",
     "mathlib_version": "4.26.0",
     "parentProof": "ptolemys-theorem-oq-01-oq-02"
@@ -201,7 +201,7 @@
       "EuclideanGeometry"
     ],
     "namespace": null,
-    "lineCount": 358,
+    "lineCount": 361,
     "axiomCount": 0,
     "theoremCount": 11,
     "sorries": 0,


### PR DESCRIPTION
## Fix

**Before**: `meta.lineCount = 358`, `leanFile.lineCount = 358`
**After**: `meta.lineCount = 361`, `leanFile.lineCount = 361`

The Lean file (`proofs/Proofs/SynthesisCurvaturePtolemy.lean`) grew by 3 lines since meta.json was last updated. Sorry count (0) and axiom count (0) are correct.

---
Automated fix by lean-mechanic agent.