### PR TITLE
fix(erdos-637): add missing [Nonempty V] to regular_one_degree

### DIFF
--- a/proofs/Proofs/Erdos637Problem.lean
+++ b/proofs/Proofs/Erdos637Problem.lean
@@ -158,8 +158,8 @@ noncomputable def degreeSequence (G : SimpleGraph V) : List ℕ :=
 def IsRegular (G : SimpleGraph V) (k : ℕ) : Prop :=
   ∀ v : V, vertexDegree G v = k
 
-/-- Regular graphs have 1 distinct degree. -/
-theorem regular_one_degree (G : SimpleGraph V) (k : ℕ) (h : IsRegular G k) :
+/-- Regular graphs have 1 distinct degree (requires nonempty vertex set). -/
+theorem regular_one_degree (G : SimpleGraph V) (k : ℕ) [Nonempty V] (h : IsRegular G k) :
     numDistinctDegrees G = 1 := by
   sorry
 


### PR DESCRIPTION
## Fix

Added missing `[Nonempty V]` typeclass instance to `regular_one_degree` in `Erdos637Problem.lean`.

## Evidence

**Before**: `theorem regular_one_degree (G : SimpleGraph V) (k : ℕ) (h : IsRegular G k) : numDistinctDegrees G = 1`

**After**: `theorem regular_one_degree (G : SimpleGraph V) (k : ℕ) [Nonempty V] (h : IsRegular G k) : numDistinctDegrees G = 1`

**Why it was wrong**: For empty `V` (e.g. `Fin 0`):
- `IsRegular G k` holds vacuously (universal quantification over empty type)
- `distinctDegrees G = Finset.image (vertexDegree G) Finset.univ = Finset.image _ ∅ = ∅`
- Therefore `numDistinctDegrees G = 0 ≠ 1`
- The theorem was **false** as stated

**Why the fix is correct**: With `[Nonempty V]`, `Finset.univ` is nonempty. Since `IsRegular G k` forces every vertex to have degree `k`, the image `distinctDegrees G = {k}` has cardinality 1.

No meta.json changes needed — the theorem body remains `sorry` (unprovable without a full proof), but the statement is now a correct claim that a proof could eventually fill.

---
Automated fix by lean-mechanic agent.