### PR TITLE
fix(meta): correct sorries/lineCount for ballot-oq-01-oq-02-oq-01 and hurwitz-oq-04

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01/meta.json
@@ -15,7 +15,7 @@
     ],
     "proofRepoPath": "Proofs/BallotProblemOQ01OQ02OQ01.lean",
     "badge": "wip",
-    "sorries": 3,
+    "sorries": 1,
     "originalContributions": [
       "multiCountedSequence_eq_biUnion: multi-candidate sequences = disjoint union of fibers",
       "multiProjectionFiber_pairwise_disjoint: fibers over distinct targets are disjoint",
@@ -25,7 +25,7 @@
     "dateAdded": "2026-04-12",
     "axiomCount": 0,
     "lineCount": 208,
-    "assumptions": "3 sorries: ncard additivity for disjoint unions (2) and final uniformOn assembly (1). All are Mathlib API navigation, not mathematical gaps."
+    "assumptions": "1 sorry: final ncard/ENNReal assembly for uniformOn_fiber_transfer' (Mathlib API navigation, not a mathematical gap)."
   },
   "overview": {
     "historicalContext": "The ballot problem originates with Joseph Bertrand (1887), who asked for the probability that a winning candidate leads throughout the count. The classical formula $(a-b)/(a+b)$ was proved elegantly by Désiré André using the reflection principle. The multi-candidate generalization asks: when one candidate faces $m-1$ opponents, does the same formula apply? The answer is yes, because only the total opponent vote count matters, not its distribution among opponents. The parent file (BallotProblemOQ01OQ02) established this reduction via a projection-and-fiber argument, proving that all fibers have equal cardinality through an explicit fiberSwap bijection. However, a gap remained: translating the combinatorial fact $|\\text{fiber}(t_1)| = |\\text{fiber}(t_2)|$ into the measure-theoretic statement $\\text{uniformOn}(\\text{MCS}, \\text{MSP}) = \\text{uniformOn}(\\text{CS}, \\text{SP})$. This file provides that bridge, requiring infrastructure for disjoint union cardinality in Mathlib's Set.ncard framework and ratio cancellation in ENNReal arithmetic.",
@@ -53,7 +53,7 @@
       "title": "Part I: Abstract Uniform Fiber Counting",
       "startLine": 37,
       "endLine": 60,
-      "summary": "General lemma: ncard of a disjoint union with uniform fiber sizes = k times number of fibers. Has 2 sorries for Mathlib ncard_biUnion API.",
+      "summary": "General lemma: ncard of a disjoint union with uniform fiber sizes = k times number of fibers.",
       "mathContext": "If $\\{S_i\\}_{i \\in I}$ are pairwise disjoint finite sets each with $|S_i| = k$, then $|\\bigcup_{i \\in I} S_i| = k \\cdot |I|$."
     },
     {
@@ -77,7 +77,7 @@
       "title": "Part IV: Main Theorem",
       "startLine": 129,
       "endLine": 176,
-      "summary": "uniformOn_fiber_transfer': the main theorem connecting all components. Has 1 sorry for the final assembly step (ncard computation + ENNReal division).",
+      "summary": "uniformOn_fiber_transfer': the main theorem connecting all components. Has the remaining sorry for the final assembly step (ncard computation + ENNReal division).",
       "mathContext": "The uniform probability over multi-candidate sequences equals the classical ballot probability: $\\text{uniformOn}(\\text{MCS}, \\text{MSP}) = \\text{uniformOn}(\\text{CS}, \\text{SP})$."
     },
     {
@@ -112,8 +112,8 @@
     }
   ],
   "conclusion": {
-    "summary": "Establishes the structural infrastructure for proving uniformOn_fiber_transfer. The fiber partition (3 lemmas fully proved: decomposition, disjointness, positive decomposition), ENNReal ratio cancellation (fully proved), and a general uniform-fiber counting lemma are all formalized. 3 sorries remain for Mathlib API navigation (ncard additivity for disjoint unions and the final uniformOn assembly). 0 axioms, 208 lines.",
-    "implications": "Completing the 3 remaining sorries (which are pure Mathlib API issues, not mathematical gaps) would eliminate the sole axiom in BallotProblemOQ01OQ02.lean, making the entire multi-candidate ballot theorem chain fully verified from Bertrand's original result through the m-candidate generalization. The uniform fiber transfer pattern itself is reusable: any surjection with equal-sized fibers preserves uniformOn probabilities, which could simplify other combinatorial probability arguments in the gallery.",
+    "summary": "Establishes the structural infrastructure for proving uniformOn_fiber_transfer. The fiber partition (3 lemmas fully proved: decomposition, disjointness, positive decomposition), ENNReal ratio cancellation (fully proved), and a general uniform-fiber counting lemma are all formalized. 1 sorry remains for the final ncard/ENNReal assembly step (Mathlib API navigation, not a mathematical gap). 0 axioms, 208 lines.",
+    "implications": "Completing the remaining sorry (a pure Mathlib API issue, not a mathematical gap) would eliminate the sole axiom in BallotProblemOQ01OQ02.lean, making the entire multi-candidate ballot theorem chain fully verified from Bertrand's original result through the m-candidate generalization. The uniform fiber transfer pattern itself is reusable: any surjection with equal-sized fibers preserves uniformOn probabilities, which could simplify other combinatorial probability arguments in the gallery.",
     "openQuestions": [
       "Can the ncard_biUnion_eq_of_uniform lemma be proved using Set.ncard_biUnion from Mathlib directly, or does it need a custom Finset-based approach via Finset.sum_const?",
       "What is the exact definition of ProbabilityTheory.uniformOn used in Mathlib's Wiedijk #30 ballot theorem — is it condCount or a custom definition? This determines the final assembly strategy.",
@@ -130,7 +130,7 @@
     "theoremCount": 7,
     "definitionCount": 0,
     "path": "Proofs/BallotProblemOQ01OQ02OQ01.lean",
-    "sorries": 3,
+    "sorries": 1,
     "opens": [
       "Ballot",
       "ProbabilityTheory",
@@ -151,8 +151,8 @@
     {
       "name": "uniformOn_fiber_transfer'",
       "type": "core",
-      "description": "Uniform fibers preserve uniformOn probability (3 sorries for API)"
+      "description": "Uniform fibers preserve uniformOn probability (1 sorry for API)"
     }
   ],
-  "sorries": 3
+  "sorries": 1
 }

--- a/src/data/proofs/hurwitz-theorem-oq-04/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-04/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-24",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/HurwitzTheoremOQ04.lean",
     "tags": [
       "algebra",
@@ -17,12 +17,12 @@
       "freudenthal-tits",
       "advanced"
     ],
-    "badge": "axiom",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 2,
     "dateAdded": "2026-04-24",
-    "axiomCount": 1,
-    "assumptions": "G2_der_dimension is axiomatized: a complete proof requires exhibiting 14 linearly independent derivations D_{ij}. The Aut(𝕆) ⊆ O(7) portion is fully proved with 0 sorries.",
-    "lineCount": 822,
+    "axiomCount": 0,
+    "assumptions": "2 sorries in G2_der_dimension proof chain: (1) derEval14_injective — extracting basis vector agreement from evaluation equality (~50 lines of Leibniz constraint applications), (2) derBasis14_linearIndependent — showing 14×14 evaluation matrix has nonzero determinant. The Aut(𝕆) ⊆ O(7) portion is fully proved with 0 sorries.",
+    "lineCount": 1053,
     "theoremCount": 35,
     "definitionCount": 17,
     "originalContributions": [
@@ -41,7 +41,7 @@
   "overview": {
     "historicalContext": "Hurwitz's theorem (1898) establishes that normed division algebras over ℝ exist only in dimensions 1, 2, 4, and 8 — corresponding to ℝ, ℂ, ℍ, and 𝕆. This result has profound implications beyond algebra: the four normed division algebras are intimately connected to the five exceptional simple Lie algebras through the Freudenthal-Tits magic square (1954–1966). The connection was suspected by Élie Cartan as early as 1914, when he identified G₂ as the automorphism group of the octonions. Hans Freudenthal (1954) and Jacques Tits (1966) systematized this into a unified construction: from any two normed division algebras A, B, one builds a Lie algebra 𝔏(A, B) = Der(A) ⊕ (Im A ⊗ Im B) ⊕ Der(B), and the resulting 4×4 table (the 'magic square') produces all five exceptional simple Lie algebras: G₂, F₄, E₆, E₇, E₈. The word 'magic' refers to the surprising symmetry 𝔏(A, B) ≅ 𝔏(B, A), despite the construction not obviously being symmetric.",
     "problemStatement": "Show that Aut(𝕆) ⊆ O(7) — the automorphism group of the octonions acts by isometries on the 7-dimensional imaginary subspace Im(𝕆) — and axiomatize the identification G₂ = Aut(𝕆) along with the four exceptional Lie algebras F₄, E₆, E₇, E₈ arising from the Freudenthal-Tits magic square.",
-    "text": "Formalizes the connection between the four normed division algebras and the five exceptional Lie algebras. Proves Aut(𝕆) ⊆ O(7) (fully proved, 0 sorries), and axiomatizes G₂ = Aut(𝕆) and the magic square exceptional types F₄, E₆, E₇, E₈ via G2_der_dimension axiom.",
+    "text": "Formalizes the connection between the four normed division algebras and the five exceptional Lie algebras. Proves Aut(𝕆) ⊆ O(7) (fully proved, 0 sorries). G2_der_dimension (finrank Der(𝕆) = 14) is proved modulo 2 sorries for basis evaluation extraction and linear independence.",
     "proofStrategy": "The formalization introduces OctonionAlgHom and OctonionAut structures for algebra homomorphisms and invertible automorphisms. Key lemmas proved: (1) any automorphism φ fixes the unit element e₀ (via the left-identity uniqueness argument); (2) pure imaginary elements y (y[0]=0) satisfy y² = −normSq(y)·e₀; (3) phi_imag_props: automorphisms preserve imaginary elements and their norms; (4) alg_aut_preserves_norm follows by decomposing x = r·e₀ + w (pure imaginary w) and using orthogonality; (5) polarization gives inner product preservation. The exceptional Lie algebra part uses an ExceptionalType inductive type with dimension and rank functions, and proves structural properties (strict ordering, G₂ uniqueness, E₈ maximality) by decidability.",
     "keyInsights": [
       "**φ fixes e₀**: Any algebra automorphism must fix the unit element. The elegant proof: φ(e₀) acts as a left identity for all y (since φ is surjective and e₀ is a left identity), and a left identity in an algebra with a right identity must equal the right identity.",
@@ -66,7 +66,7 @@
       "title": "Preamble: Context and Contents",
       "startLine": 1,
       "endLine": 63,
-      "summary": "Module documentation places the formalization in context: Hurwitz's theorem (1898) gives 4 normed division algebras, and the Freudenthal-Tits magic square (1954–1966) connects them to 5 exceptional Lie algebras. The contents table distinguishes proved results (0 sorries) from axiomatized ones (deep Lie group results not yet in Mathlib). References: Baez 'The Octonions' (2002), Freudenthal (1964), Tits (1966).",
+      "summary": "Module documentation places the formalization in context: Hurwitz's theorem (1898) gives 4 normed division algebras, and the Freudenthal-Tits magic square (1954–1966) connects them to 5 exceptional Lie algebras. The contents table distinguishes proved results from in-progress ones (2 sorries for Der(𝕆) dimension proof). References: Baez 'The Octonions' (2002), Freudenthal (1964), Tits (1966).",
       "mathContext": "The magic square table: rows and columns indexed by {ℝ,ℂ,ℍ,𝕆}. Entries: 𝔏(𝕆,ℝ)=F₄, 𝔏(𝕆,ℂ)=E₆, 𝔏(𝕆,ℍ)=E₇, 𝔏(𝕆,𝕆)=E₈, plus G₂=Der(𝕆). The 'magic': 𝔏(A,B)≅𝔏(B,A) despite the definition not being visibly symmetric."
     },
     {
@@ -106,7 +106,7 @@
       "title": "§IV-c to V: Derivation Algebra as Submodule + Freudenthal-Tits Axioms",
       "startLine": 558,
       "endLine": 697,
-      "summary": "Defines OctonionDerSubmodule as a Submodule of End_ℝ(ℝ⁸) to give Der(𝕆) an inherited vector space structure. Axiomatizes G2_der_dimension (finrank = 14) as an axiom declaration. Proves derivation structural properties: der_maps_unit_to_zero, der_maps_real_part_to_zero, toLinearMap, mem_der_submodule. Then states the Freudenthal-Tits magic square: freudenthal_tits_f4/e6/e7/e8 (dimension facts, 52/78/133/248).",
+      "summary": "Defines OctonionDerSubmodule as a Submodule of End_ℝ(ℝ⁸) to give Der(𝕆) an inherited vector space structure. Proves G2_der_dimension (finrank = 14) via upper bound (injective evaluation map) and lower bound (14 linearly independent derivations), with 2 sorries for the algebraic extraction steps. Proves derivation structural properties: der_maps_unit_to_zero, der_maps_real_part_to_zero, toLinearMap, mem_der_submodule. Then states the Freudenthal-Tits magic square: freudenthal_tits_f4/e6/e7/e8 (dimension facts, 52/78/133/248).",
       "mathContext": "Der(𝕆) as a Submodule of $\\text{End}_\\mathbb{R}(\\mathbb{R}^8)$: the set of $\\mathbb{R}$-linear maps $D: \\mathbb{R}^8 \\to \\mathbb{R}^8$ satisfying the Leibniz rule $D(ab) = D(a)\\cdot b + a\\cdot D(b)$ for octonion multiplication. Axiom `G2_der_dimension`: $\\text{finrank}_\\mathbb{R}(\\text{Der}(\\mathbb{O})) = 14$ (the dimension of $\\mathfrak{g}_2$). Tits construction: $\\mathfrak{L}(A,B) = \\mathfrak{der}(A) \\oplus (\\text{Im}A \\otimes \\text{Im}B) \\oplus \\mathfrak{der}(B)$ with $\\dim\\mathfrak{L}(\\mathbb{O},\\mathbb{O}) = 14 + 49 + 14 + \\text{extra} = 248$."
     },
     {
@@ -119,7 +119,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization establishes the bridge between Hurwitz's four normed division algebras and the five exceptional Lie algebras. The key proved result is that Aut(𝕆) ⊆ O(7): octonion automorphisms preserve norms, real parts, inner products, and the imaginary subspace — all proved without sorries using algebraic decomposition. The five exceptional Lie algebras (G₂, F₄, E₆, E₇, E₈) are axiomatized via G₂=Aut(𝕆) and the Freudenthal-Tits magic square, with structural properties proved by decidability.",
+    "summary": "This formalization establishes the bridge between Hurwitz's four normed division algebras and the five exceptional Lie algebras. The key proved result is that Aut(𝕆) ⊆ O(7): octonion automorphisms preserve norms, real parts, inner products, and the imaginary subspace — all proved without sorries using algebraic decomposition. G2_der_dimension (finrank Der(𝕆) = 14) has 2 remaining sorries for basis evaluation extraction and linear independence. The five exceptional Lie algebras (G₂, F₄, E₆, E₇, E₈) are connected via the Freudenthal-Tits magic square, with structural properties proved by decidability.",
     "implications": "The formalization demonstrates that Hurwitz's theorem (n∈{1,2,4,8}) constrains not just composition algebras but the entire exceptional structure of simple Lie algebras: the 4 normed division algebras yield exactly 5 exceptional types. Removing the 16-dimensional case eliminates the possibility of a 6th exceptional Lie algebra. Physical applications include E₈×E₈ heterotic string theory (anomaly cancellation: dim=2×248=496) and M-theory compactification on G₂ manifolds.",
     "openQuestions": [
       "Prove G₂ ≅ Aut(𝕆) formally in Lean: requires Lie group theory (compact simple groups, root systems) not yet in Mathlib as of 2026-04.",
@@ -137,11 +137,11 @@
       "HurwitzTheorem"
     ],
     "namespace": "HurwitzTheoremOQ04",
-    "lineCount": 822,
-    "axiomCount": 1,
+    "lineCount": 1053,
+    "axiomCount": 0,
     "theoremCount": 40,
     "definitionCount": 15,
-    "sorries": 0,
+    "sorries": 2,
     "path": "Proofs/HurwitzTheoremOQ04.lean"
   },
   "crossReferences": [
@@ -156,5 +156,5 @@
       "description": "Sibling open question: n-square identities and normed division algebras"
     }
   ],
-  "sorries": 0
+  "sorries": 2
 }


### PR DESCRIPTION
## Summary

- **ballot-problem-oq-01-oq-02-oq-01**: sorries 3→1 (only 1 `sorry` in code at line 174; prior count of 3 included comment mentions)
- **hurwitz-theorem-oq-04**: `G2_der_dimension` was refactored from `axiom` to `theorem` with 2 proof sorries. Updates: axiomCount 1→0, sorries 0→2, lineCount 822→1053, status axiomatized→formalized, badge axiom→wip

## Evidence

### ballot-problem-oq-01-oq-02-oq-01
- `grep -c sorry` on committed source finds 3 matches, but 2 are inside block comments (lines 188, 201)
- Stripping comments leaves 1 actual `sorry` at line 174 (ncard/ENNReal assembly)

### hurwitz-theorem-oq-04
- Zero `axiom` declarations in file (G2_der_dimension is now a `theorem`)
- 2 sorries: line 787 (derEval14_injective) and line 804 (derBasis14_linearIndependent)
- File grew from 822 to 1053 lines

## Test plan

- [x] Both meta.json files are valid JSON
- [ ] `pnpm build` passes with updated metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)