### PR TITLE
fix(meta): correct sorry/axiom counts for 2 gallery proofs

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01/meta.json
@@ -15,8 +15,9 @@
     ],
     "proofRepoPath": "Proofs/BallotProblemOQ01OQ02OQ01.lean",
     "badge": "wip",
-    "sorries": 3,
+    "sorries": 1,
     "originalContributions": [
+      "ncard_biUnion_eq_of_uniform: ncard of uniform-fiber disjoint union = k × number of fibers (fully proved)",
       "multiCountedSequence_eq_biUnion: multi-candidate sequences = disjoint union of fibers",
       "multiProjectionFiber_pairwise_disjoint: fibers over distinct targets are disjoint",
       "multiStaysPositive_eq_biUnion: positive intersection = union of fibers over positive targets",
@@ -25,7 +26,7 @@
     "dateAdded": "2026-04-12",
     "axiomCount": 0,
     "lineCount": 208,
-    "assumptions": "3 sorries: ncard additivity for disjoint unions (2) and final uniformOn assembly (1). All are Mathlib API navigation, not mathematical gaps."
+    "assumptions": "1 sorry: final uniformOn assembly step connecting ncard computation to ENNReal division. Pure Mathlib API navigation, not a mathematical gap."
   },
   "overview": {
     "historicalContext": "The ballot problem originates with Joseph Bertrand (1887), who asked for the probability that a winning candidate leads throughout the count. The classical formula $(a-b)/(a+b)$ was proved elegantly by Désiré André using the reflection principle. The multi-candidate generalization asks: when one candidate faces $m-1$ opponents, does the same formula apply? The answer is yes, because only the total opponent vote count matters, not its distribution among opponents. The parent file (BallotProblemOQ01OQ02) established this reduction via a projection-and-fiber argument, proving that all fibers have equal cardinality through an explicit fiberSwap bijection. However, a gap remained: translating the combinatorial fact $|\\text{fiber}(t_1)| = |\\text{fiber}(t_2)|$ into the measure-theoretic statement $\\text{uniformOn}(\\text{MCS}, \\text{MSP}) = \\text{uniformOn}(\\text{CS}, \\text{SP})$. This file provides that bridge, requiring infrastructure for disjoint union cardinality in Mathlib's Set.ncard framework and ratio cancellation in ENNReal arithmetic.",
@@ -53,7 +54,7 @@
       "title": "Part I: Abstract Uniform Fiber Counting",
       "startLine": 37,
       "endLine": 60,
-      "summary": "General lemma: ncard of a disjoint union with uniform fiber sizes = k times number of fibers. Has 2 sorries for Mathlib ncard_biUnion API.",
+      "summary": "General lemma: ncard of a disjoint union with uniform fiber sizes = k times number of fibers. Fully proved using Set.ncard_biUnion and Finset.sum_const.",
       "mathContext": "If $\\{S_i\\}_{i \\in I}$ are pairwise disjoint finite sets each with $|S_i| = k$, then $|\\bigcup_{i \\in I} S_i| = k \\cdot |I|$."
     },
     {
@@ -112,8 +113,8 @@
     }
   ],
   "conclusion": {
-    "summary": "Establishes the structural infrastructure for proving uniformOn_fiber_transfer. The fiber partition (3 lemmas fully proved: decomposition, disjointness, positive decomposition), ENNReal ratio cancellation (fully proved), and a general uniform-fiber counting lemma are all formalized. 3 sorries remain for Mathlib API navigation (ncard additivity for disjoint unions and the final uniformOn assembly). 0 axioms, 208 lines.",
-    "implications": "Completing the 3 remaining sorries (which are pure Mathlib API issues, not mathematical gaps) would eliminate the sole axiom in BallotProblemOQ01OQ02.lean, making the entire multi-candidate ballot theorem chain fully verified from Bertrand's original result through the m-candidate generalization. The uniform fiber transfer pattern itself is reusable: any surjection with equal-sized fibers preserves uniformOn probabilities, which could simplify other combinatorial probability arguments in the gallery.",
+    "summary": "Establishes the structural infrastructure for proving uniformOn_fiber_transfer. The fiber partition (3 lemmas fully proved: decomposition, disjointness, positive decomposition), ENNReal ratio cancellation (fully proved), ncard_biUnion_eq_of_uniform (fully proved), and the main theorem are formalized. 1 sorry remains for the final uniformOn assembly step. 0 axioms, 208 lines.",
+    "implications": "Completing the 1 remaining sorry (the final uniformOn assembly, a pure Mathlib API issue, not a mathematical gap) would eliminate the sole axiom in BallotProblemOQ01OQ02.lean, making the entire multi-candidate ballot theorem chain fully verified from Bertrand's original result through the m-candidate generalization. The uniform fiber transfer pattern itself is reusable: any surjection with equal-sized fibers preserves uniformOn probabilities, which could simplify other combinatorial probability arguments in the gallery.",
     "openQuestions": [
       "Can the ncard_biUnion_eq_of_uniform lemma be proved using Set.ncard_biUnion from Mathlib directly, or does it need a custom Finset-based approach via Finset.sum_const?",
       "What is the exact definition of ProbabilityTheory.uniformOn used in Mathlib's Wiedijk #30 ballot theorem — is it condCount or a custom definition? This determines the final assembly strategy.",
@@ -130,7 +131,7 @@
     "theoremCount": 7,
     "definitionCount": 0,
     "path": "Proofs/BallotProblemOQ01OQ02OQ01.lean",
-    "sorries": 3,
+    "sorries": 1,
     "opens": [
       "Ballot",
       "ProbabilityTheory",
@@ -151,8 +152,8 @@
     {
       "name": "uniformOn_fiber_transfer'",
       "type": "core",
-      "description": "Uniform fibers preserve uniformOn probability (3 sorries for API)"
+      "description": "Uniform fibers preserve uniformOn probability (1 sorry for final assembly)"
     }
   ],
-  "sorries": 3
+  "sorries": 1
 }

--- a/src/data/proofs/hurwitz-theorem-oq-04/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-04/meta.json
@@ -2,11 +2,11 @@
   "id": "hurwitz-theorem-oq-04",
   "title": "Hurwitz's Theorem: Connection to Exceptional Lie Groups",
   "slug": "hurwitz-theorem-oq-04",
-  "description": "Formalizes the deep connection between the four normed division algebras (ℝ, ℂ, ℍ, 𝕆) and the five exceptional Lie algebras (G₂, F₄, E₆, E₇, E₈) via the Freudenthal-Tits magic square. Proves that Aut(𝕆) ⊆ O(7) (automorphisms preserve the imaginary subspace and inner product), and axiomatizes G₂ = Aut(𝕆) and the four exceptional types F₄, E₆, E₇, E₈ arising from the magic square construction.",
+  "description": "Formalizes the deep connection between the four normed division algebras (ℝ, ℂ, ℍ, 𝕆) and the five exceptional Lie algebras (G₂, F₄, E₆, E₇, E₈) via the Freudenthal-Tits magic square. Proves that Aut(𝕆) ⊆ O(7) (fully proved, 0 sorries), and proves G2_der_dimension (finrank Der(𝕆) = 14) with 2 computational sorries for the linear independence argument. Exceptional type structural properties proved by decidability.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-24",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/HurwitzTheoremOQ04.lean",
     "tags": [
       "algebra",
@@ -17,12 +17,12 @@
       "freudenthal-tits",
       "advanced"
     ],
-    "badge": "axiom",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 2,
     "dateAdded": "2026-04-24",
-    "axiomCount": 1,
-    "assumptions": "G2_der_dimension is axiomatized: a complete proof requires exhibiting 14 linearly independent derivations D_{ij}. The Aut(𝕆) ⊆ O(7) portion is fully proved with 0 sorries.",
-    "lineCount": 822,
+    "axiomCount": 0,
+    "assumptions": "2 computational sorries in the G2_der_dimension proof chain: (1) algebraic extraction from ev=0 in derEval14_injective, (2) linear independence of 14 derivation basis vectors via evaluation matrix. The Aut(𝕆) ⊆ O(7) portion and all exceptional type structural properties are fully proved.",
+    "lineCount": 1052,
     "theoremCount": 35,
     "definitionCount": 17,
     "originalContributions": [
@@ -41,7 +41,7 @@
   "overview": {
     "historicalContext": "Hurwitz's theorem (1898) establishes that normed division algebras over ℝ exist only in dimensions 1, 2, 4, and 8 — corresponding to ℝ, ℂ, ℍ, and 𝕆. This result has profound implications beyond algebra: the four normed division algebras are intimately connected to the five exceptional simple Lie algebras through the Freudenthal-Tits magic square (1954–1966). The connection was suspected by Élie Cartan as early as 1914, when he identified G₂ as the automorphism group of the octonions. Hans Freudenthal (1954) and Jacques Tits (1966) systematized this into a unified construction: from any two normed division algebras A, B, one builds a Lie algebra 𝔏(A, B) = Der(A) ⊕ (Im A ⊗ Im B) ⊕ Der(B), and the resulting 4×4 table (the 'magic square') produces all five exceptional simple Lie algebras: G₂, F₄, E₆, E₇, E₈. The word 'magic' refers to the surprising symmetry 𝔏(A, B) ≅ 𝔏(B, A), despite the construction not obviously being symmetric.",
     "problemStatement": "Show that Aut(𝕆) ⊆ O(7) — the automorphism group of the octonions acts by isometries on the 7-dimensional imaginary subspace Im(𝕆) — and axiomatize the identification G₂ = Aut(𝕆) along with the four exceptional Lie algebras F₄, E₆, E₇, E₈ arising from the Freudenthal-Tits magic square.",
-    "text": "Formalizes the connection between the four normed division algebras and the five exceptional Lie algebras. Proves Aut(𝕆) ⊆ O(7) (fully proved, 0 sorries), and axiomatizes G₂ = Aut(𝕆) and the magic square exceptional types F₄, E₆, E₇, E₈ via G2_der_dimension axiom.",
+    "text": "Formalizes the connection between the four normed division algebras and the five exceptional Lie algebras. Proves Aut(𝕆) ⊆ O(7) (fully proved, 0 sorries). G2_der_dimension (finrank Der(𝕆) = 14) is proved modulo 2 computational sorries for the linear independence argument. Magic square exceptional types F₄, E₆, E₇, E₈ are proved by decidability.",
     "proofStrategy": "The formalization introduces OctonionAlgHom and OctonionAut structures for algebra homomorphisms and invertible automorphisms. Key lemmas proved: (1) any automorphism φ fixes the unit element e₀ (via the left-identity uniqueness argument); (2) pure imaginary elements y (y[0]=0) satisfy y² = −normSq(y)·e₀; (3) phi_imag_props: automorphisms preserve imaginary elements and their norms; (4) alg_aut_preserves_norm follows by decomposing x = r·e₀ + w (pure imaginary w) and using orthogonality; (5) polarization gives inner product preservation. The exceptional Lie algebra part uses an ExceptionalType inductive type with dimension and rank functions, and proves structural properties (strict ordering, G₂ uniqueness, E₈ maximality) by decidability.",
     "keyInsights": [
       "**φ fixes e₀**: Any algebra automorphism must fix the unit element. The elegant proof: φ(e₀) acts as a left identity for all y (since φ is surjective and e₀ is a left identity), and a left identity in an algebra with a right identity must equal the right identity.",
@@ -106,20 +106,20 @@
       "title": "§IV-c to V: Derivation Algebra as Submodule + Freudenthal-Tits Axioms",
       "startLine": 558,
       "endLine": 697,
-      "summary": "Defines OctonionDerSubmodule as a Submodule of End_ℝ(ℝ⁸) to give Der(𝕆) an inherited vector space structure. Axiomatizes G2_der_dimension (finrank = 14) as an axiom declaration. Proves derivation structural properties: der_maps_unit_to_zero, der_maps_real_part_to_zero, toLinearMap, mem_der_submodule. Then states the Freudenthal-Tits magic square: freudenthal_tits_f4/e6/e7/e8 (dimension facts, 52/78/133/248).",
-      "mathContext": "Der(𝕆) as a Submodule of $\\text{End}_\\mathbb{R}(\\mathbb{R}^8)$: the set of $\\mathbb{R}$-linear maps $D: \\mathbb{R}^8 \\to \\mathbb{R}^8$ satisfying the Leibniz rule $D(ab) = D(a)\\cdot b + a\\cdot D(b)$ for octonion multiplication. Axiom `G2_der_dimension`: $\\text{finrank}_\\mathbb{R}(\\text{Der}(\\mathbb{O})) = 14$ (the dimension of $\\mathfrak{g}_2$). Tits construction: $\\mathfrak{L}(A,B) = \\mathfrak{der}(A) \\oplus (\\text{Im}A \\otimes \\text{Im}B) \\oplus \\mathfrak{der}(B)$ with $\\dim\\mathfrak{L}(\\mathbb{O},\\mathbb{O}) = 14 + 49 + 14 + \\text{extra} = 248$."
+      "summary": "Defines OctonionDerSubmodule as a Submodule of End_ℝ(ℝ⁸) to give Der(𝕆) an inherited vector space structure. Proves G2_der_dimension (finrank = 14) as a theorem via upper bound (injective evaluation map to ℝ¹⁴) and lower bound (14 linearly independent derivations), with 2 computational sorries remaining. Proves derivation structural properties: der_maps_unit_to_zero, der_maps_real_part_to_zero, toLinearMap, mem_der_submodule. Then states the Freudenthal-Tits magic square: freudenthal_tits_f4/e6/e7/e8 (dimension facts, 52/78/133/248, proved by rfl).",
+      "mathContext": "Der(𝕆) as a Submodule of $\\text{End}_\\mathbb{R}(\\mathbb{R}^8)$: the set of $\\mathbb{R}$-linear maps $D: \\mathbb{R}^8 \\to \\mathbb{R}^8$ satisfying the Leibniz rule $D(ab) = D(a)\\cdot b + a\\cdot D(b)$ for octonion multiplication. Theorem `G2_der_dimension`: $\\text{finrank}_\\mathbb{R}(\\text{Der}(\\mathbb{O})) = 14$ (the dimension of $\\mathfrak{g}_2$), proved via upper and lower bounds with 2 computational sorries. Tits construction: $\\mathfrak{L}(A,B) = \\mathfrak{der}(A) \\oplus (\\text{Im}A \\otimes \\text{Im}B) \\oplus \\mathfrak{der}(B)$ with $\\dim\\mathfrak{L}(\\mathbb{O},\\mathbb{O}) = 14 + 49 + 14 + \\text{extra} = 248$."
     },
     {
       "id": "physical-applications-summary",
       "title": "§VII: Hurwitz-Exceptional Correspondence and Physical Applications",
       "startLine": 750,
-      "endLine": 822,
+      "endLine": 1052,
       "summary": "Docstring explaining why Hurwitz's 4 normed division algebras yield exactly 5 exceptional Lie algebras: G₂=Der(𝕆), F₄=𝔏(𝕆,ℝ), E₆=𝔏(𝕆,ℂ), E₇=𝔏(𝕆,ℍ), E₈=𝔏(𝕆,𝕆). Physical applications: E₈×E₈ heterotic string theory (anomaly cancellation, dim=496), M-theory compactification on G₂ manifolds, E₇(7) symmetry of N=8 supergravity. #check summary of all 30 public declarations.",
       "mathContext": "E₈×E₈ heterotic string theory: the unique anomaly-free 10D string theory requires $\\text{dim}(G) = 496$ — satisfied by $E_8 \\times E_8$ with $2 \\times 248 = 496$ and $\\text{SO}(32)$ with $\\frac{32\\cdot 31}{2} = 496$. G₂ holonomy: a Riemannian 7-manifold $(M^7, g)$ with holonomy $G_2$ (i.e., the holonomy group $\\subseteq G_2 \\subset \\text{SO}(7)$) admits a parallel spinor, giving $N=1$ supersymmetry in 4D M-theory compactification. These physical applications arise precisely because $G_2 = \\text{Aut}(\\mathbb{O}) \\subseteq \\text{O}(7)$, proved in this file."
     }
   ],
   "conclusion": {
-    "summary": "This formalization establishes the bridge between Hurwitz's four normed division algebras and the five exceptional Lie algebras. The key proved result is that Aut(𝕆) ⊆ O(7): octonion automorphisms preserve norms, real parts, inner products, and the imaginary subspace — all proved without sorries using algebraic decomposition. The five exceptional Lie algebras (G₂, F₄, E₆, E₇, E₈) are axiomatized via G₂=Aut(𝕆) and the Freudenthal-Tits magic square, with structural properties proved by decidability.",
+    "summary": "This formalization establishes the bridge between Hurwitz's four normed division algebras and the five exceptional Lie algebras. The key proved result is that Aut(𝕆) ⊆ O(7): octonion automorphisms preserve norms, real parts, inner products, and the imaginary subspace — all proved without sorries using algebraic decomposition. G2_der_dimension (finrank Der(𝕆) = 14) is proved as a theorem with 2 computational sorries for the linear independence argument. The five exceptional Lie algebra structural properties (dimensions, ordering, uniqueness) are proved by decidability. 0 axioms, 2 sorries, 1052 lines.",
     "implications": "The formalization demonstrates that Hurwitz's theorem (n∈{1,2,4,8}) constrains not just composition algebras but the entire exceptional structure of simple Lie algebras: the 4 normed division algebras yield exactly 5 exceptional types. Removing the 16-dimensional case eliminates the possibility of a 6th exceptional Lie algebra. Physical applications include E₈×E₈ heterotic string theory (anomaly cancellation: dim=2×248=496) and M-theory compactification on G₂ manifolds.",
     "openQuestions": [
       "Prove G₂ ≅ Aut(𝕆) formally in Lean: requires Lie group theory (compact simple groups, root systems) not yet in Mathlib as of 2026-04.",
@@ -137,11 +137,11 @@
       "HurwitzTheorem"
     ],
     "namespace": "HurwitzTheoremOQ04",
-    "lineCount": 822,
-    "axiomCount": 1,
+    "lineCount": 1052,
+    "axiomCount": 0,
     "theoremCount": 40,
     "definitionCount": 15,
-    "sorries": 0,
+    "sorries": 2,
     "path": "Proofs/HurwitzTheoremOQ04.lean"
   },
   "crossReferences": [
@@ -156,5 +156,5 @@
       "description": "Sibling open question: n-square identities and normed division algebras"
     }
   ],
-  "sorries": 0
+  "sorries": 2
 }


### PR DESCRIPTION
## Summary

- **ballot-problem-oq-01-oq-02-oq-01**: sorry count 3→1. `ncard_biUnion_eq_of_uniform` was completed (fully proved via `Set.ncard_biUnion` + `Finset.sum_const`), leaving only the `uniformOn_fiber_transfer'` assembly sorry. Updated assumptions text, section summaries, and conclusion.
- **hurwitz-theorem-oq-04**: sorry 0→2, axiomCount 1→0, lineCount 822→1052, status `axiomatized`→`formalized`, badge `axiom`→`wip`. `G2_der_dimension` was converted from an `axiom` declaration to a `theorem` with 2 computational sorries (derEval14_injective extraction + derBasis14 linear independence). Updated description, overview, section summaries, conclusion, and leanFile metadata.

## Evidence

Verified by stripping block/line comments from Lean source and counting `sorry` keywords:
- `BallotProblemOQ01OQ02OQ01.lean`: 1 sorry (line ~125)
- `HurwitzTheoremOQ04.lean`: 2 sorries (lines ~787, ~804), 0 axiom declarations, 1052 lines

## Test plan

- [ ] `pnpm build` passes with updated meta.json
- [ ] Audit tracker `find-targets.ts --issues` shows 0 issues after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)