### PR TITLE
fix(meta): sync lineCount/sections for cayley-wip04 and erdos-1-oq-03

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-04/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-04/meta.json
@@ -21,7 +21,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 421,
+    "lineCount": 359,
     "assumptions": "None. Axiom-free proof using CRT/Bezout projections and prime power divisibility by induction.",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
@@ -111,17 +111,9 @@
       "id": "main-theorem",
       "title": "V. Main Theorem",
       "startLine": 207,
-      "endLine": 394,
+      "endLine": 327,
       "summary": "Proves nonderogatory_bipow_has_cyclic_vector: the main binary prime power cyclic vector theorem. Constructs v1, v2 in primary components, shows v1+v2 is cyclic via CRT projections and prime power divisibility.",
       "mathContext": "For minpoly = p^a * q^b with p, q coprime irreducibles: (1) lift coprimality to powers; (2) construct primary vectors v1, v2 with correct annihilation properties; (3) show v1+v2 is cyclic by extracting r(M)*vi = 0 via CRT projections, then applying prime power divisibility to get p^a | r and q^b | r, giving p^a*q^b | r and a degree contradiction."
-    },
-    {
-      "id": "corollary-finite",
-      "title": "VI. Corollary: Finite Field Specialization",
-      "startLine": 404,
-      "endLine": 417,
-      "summary": "Explicit corollary adding [Fintype K] to highlight that the proof works over all finite fields, including GF(2). This is a direct application of the main theorem with no additional argument.",
-      "mathContext": "The corollary nonderogatory_bipow_has_cyclic_vector_finite adds the Fintype K instance, emphasizing that no infinite-field assumption is needed — unlike the classical union-avoidance approach."
     }
   ],
   "conclusion": {
@@ -142,7 +134,7 @@
       "Polynomial"
     ],
     "namespace": "BinaryPrimePowerCyclicVector",
-    "lineCount": 421,
+    "lineCount": 359,
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 2,

--- a/src/data/proofs/erdos-1-oq-03/meta.json
+++ b/src/data/proofs/erdos-1-oq-03/meta.json
@@ -38,7 +38,7 @@
       "Conway-Guy optimality conjecture statement"
     ],
     "dateAdded": "2026-03-30",
-    "lineCount": 182,
+    "lineCount": 249,
     "theoremCount": 12,
     "definitionCount": 3,
     "prerequisites": [
@@ -107,8 +107,8 @@
     {
       "id": "growth-rate",
       "title": "Growth Rate Properties",
-      "startLine": 172,
-      "endLine": 182,
+      "startLine": 232,
+      "endLine": 249,
       "summary": "Strict monotonicity and at-most-doubles bound for the sequence.",
       "mathContext": "$a_k < a_{k+1} \\leq 2 a_k$"
     }
@@ -154,7 +154,7 @@
       "Finset"
     ],
     "namespace": "Erdos1OQ03",
-    "lineCount": 240,
+    "lineCount": 249,
     "axiomCount": 0,
     "theoremCount": 17,
     "definitionCount": 3,


### PR DESCRIPTION
## Fix

Syncs stale `lineCount` and section line ranges in two gallery entries. These were previously in closed PRs #13081 and #13082 (closed as mega-PRs by the deployer).

## Evidence

### cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-04

**Before**:
- `lineCount: 421` (both `meta` and `leanFile`)
- Section V (main-theorem) `endLine: 394` — out-of-bounds (file has 359 lines)
- Section VI (corollary-finite) `startLine: 404, endLine: 417` — OOB, corollary was removed

**After**:
- `lineCount: 359` — matches actual file
- Section V `endLine: 327` — last line of theorem code (before commentary block)
- Section VI removed — no longer exists in the file

### erdos-1-oq-03

**Before**:
- `meta.lineCount: 182`, `leanFile.lineCount: 240`
- growth-rate section `startLine: 172, endLine: 182` — overlapping with optimality section

**After**:
- Both lineCount fields: `249` — matches actual file (9 new theorems added)
- growth-rate section: `startLine: 232, endLine: 249` — correct range for conwayGuy_exponential_bound, conwayGuy_strictMono, conwayGuy_at_most_doubles

---
Automated fix by lean-mechanic agent.