### PR TITLE
Enrich 3 gallery entries: Gödel, Borsuk-Ulam, Nonderogatory

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-03/annotations.json
+++ b/src/data/proofs/borsuk-ulam-oq-03/annotations.json
@@ -136,6 +136,81 @@
     ]
   },
   {
+    "id": "ann-bu-oq03-08-tucker-signed",
+    "proofId": "borsuk-ulam-oq-03",
+    "range": {
+      "startLine": 518,
+      "endLine": 570
+    },
+    "type": "technique",
+    "title": "Tucker's 1D Signed Lemma via Boolean Reduction",
+    "content": "The integer-labeled Tucker lemma states: if vertices of a 1D simplicial complex are labeled with nonzero integers such that boundary labels are complementary ($L(0) + L(n+1) = 0$), then some adjacent pair has opposite signs. The proof reduces to the Boolean Tucker lemma by taking the sign of each label ($S(i) = (0 < L(i))$). The complementary boundary condition forces $S(0) \\neq S(n+1)$ (since $L(0)$ and $L(n+1)$ have opposite signs), so the Boolean version gives an adjacent sign-change, which translates back to integer labels with opposite signs.",
+    "mathContext": "Tucker (integer version): $L: \\{0,\\ldots,n+1\\} \\to \\mathbb{Z} \\setminus \\{0\\}$, $L(0) + L(n+1) = 0 \\Rightarrow \\exists i: L(i) \\cdot L(i+1) < 0$. Reduction: $S = \\text{sign}(L)$ satisfies Boolean Tucker's hypothesis.",
+    "significance": "key",
+    "relatedConcepts": ["Tucker's lemma", "complementary labeling", "sign function", "simplicial complex"],
+    "prerequisites": ["tucker_1d_sign_change", "decide predicate in Lean 4"]
+  },
+  {
+    "id": "ann-bu-oq03-09-parity-lemma",
+    "proofId": "borsuk-ulam-oq-03",
+    "range": {
+      "startLine": 1055,
+      "endLine": 1080
+    },
+    "type": "insight",
+    "title": "Tucker's Parity Lemma: Sign Changes as Topological Invariant",
+    "content": "The parity lemma strengthens Tucker: not only does a sign change exist, but the NUMBER of sign changes has the same parity as the endpoint comparison. When endpoints differ ($s(0) \\neq s(n)$), the transition count is odd — hence at least 1. This is the combinatorial analog of the topological fact that the degree of the antipodal map on $S^0$ is odd. The proof uses induction on $n$ with exhaustive Boolean case analysis (8 cases for $a, b, c \\in \\{\\text{true}, \\text{false}\\}$) handled by Lean's `decide` tactic.",
+    "mathContext": "$\\#\\{i : s(i) \\neq s(i+1)\\} \\equiv \\begin{cases} 0 \\pmod{2} & \\text{if } s(0) = s(n) \\\\ 1 \\pmod{2} & \\text{if } s(0) \\neq s(n) \\end{cases}$",
+    "significance": "key",
+    "relatedConcepts": ["topological degree", "parity argument", "Fin.induction", "combinatorial topology"],
+    "prerequisites": ["countTransitions", "Nat.add_mod", "Boolean case analysis"]
+  },
+  {
+    "id": "ann-bu-oq03-10-bu-brouwer-equiv",
+    "proofId": "borsuk-ulam-oq-03",
+    "range": {
+      "startLine": 2006,
+      "endLine": 2049
+    },
+    "type": "insight",
+    "title": "BU ↔ Brouwer FP Equivalence in 1D",
+    "content": "The logical equivalence of Borsuk-Ulam and Brouwer's Fixed Point theorem in 1D is proved in both directions. BU → Brouwer: given $f: [-1,1] \\to [-1,1]$, define $h(x) = f(x) - x$. Then $h(-1) \\geq 0$ (since $f(-1) \\geq -1$) and $h(1) \\leq 0$ (since $f(1) \\leq 1$), so IVT gives a zero $x_0$ with $f(x_0) = x_0$. Brouwer → BU: in 1D both reduce to IVT, so the reverse direction is immediate. In higher dimensions, the equivalence passes through the no-retraction theorem, forming a cycle BU → no-retraction → Brouwer FP → BU.",
+    "mathContext": "BU$_1 \\Leftrightarrow$ Brouwer$_1$: both are IVT. For $n \\geq 2$: BU$_n \\Rightarrow$ no-retraction$_n \\Rightarrow$ Brouwer$_n$ and Brouwer$_n \\Rightarrow$ no-retraction$_n \\Rightarrow$ BU$_n$.",
+    "significance": "key",
+    "relatedConcepts": ["logical equivalence", "theorem reduction", "intermediate value theorem", "no-retraction theorem"],
+    "prerequisites": ["borsuk_ulam_interval", "intermediate_value_Icc'", "ContinuousOn.sub"]
+  },
+  {
+    "id": "ann-bu-oq03-11-no-retraction",
+    "proofId": "borsuk-ulam-oq-03",
+    "range": {
+      "startLine": 2050,
+      "endLine": 2079
+    },
+    "type": "technique",
+    "title": "No-Retraction Theorem in 1D via IVT",
+    "content": "There is no continuous retraction $r: [-1,1] \\to \\{-1,1\\}$ that fixes the boundary ($r(-1) = -1$, $r(1) = 1$). The proof is by IVT: since $r(-1) = -1 \\leq 0 \\leq 1 = r(1)$ and $r$ is continuous, there exists $x_0 \\in [-1,1]$ with $r(x_0) = 0$. But $r$ only takes values in $\\{-1, 1\\}$, so $r(x_0) \\in \\{-1,1\\}$ contradicts $r(x_0) = 0$. This is the 1D instance of the general theorem that $B^{n+1}$ does not retract onto $S^n$, which in higher dimensions requires algebraic topology (Brouwer degree or homology).",
+    "mathContext": "No retraction $r: B^1 \\to S^0$ with $r|_{S^0} = \\text{id}$. IVT: $r(-1) = -1$, $r(1) = 1$, $r$ continuous $\\Rightarrow \\exists x_0: r(x_0) = 0 \\notin \\{\\pm 1\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["retraction", "connectedness", "Brouwer degree", "homology"],
+    "prerequisites": ["intermediate_value_Icc", "Continuous.continuousOn"]
+  },
+  {
+    "id": "ann-bu-oq03-12-ray-sphere",
+    "proofId": "borsuk-ulam-oq-03",
+    "range": {
+      "startLine": 3552,
+      "endLine": 3578
+    },
+    "type": "technique",
+    "title": "Ray-Sphere Intersection: No-Retraction → Brouwer FP Architecture",
+    "content": "The proof that no-retraction implies Brouwer FP uses the ray-sphere intersection technique: given $f: B^{n+1} \\to B^{n+1}$ with no fixed point, define the ray from $f(x)$ through $x$ and intersect it with $S^n$. This gives a retraction $r: B^{n+1} \\to S^n$ that fixes $S^n$ (since on the sphere, the retraction parameter $t = 1$ makes $r(x) = f(x) + 1 \\cdot (x - f(x)) = x$). The construction uses the quadratic formula for ray-sphere intersection: solve $|f(x) + t(x - f(x))|^2 = 1$ for $t$ via the discriminant $\\Delta = (A + B)^2 \\geq 0$ where $A = |x - f(x)|^2$ and $B = \\langle f(x), x - f(x) \\rangle$.",
+    "mathContext": "Retraction: $r(x) = f(x) + t_+(x) \\cdot (x - f(x))$ where $t_+ = \\frac{-B + \\sqrt{B^2 - AC}}{A}$, $A = |d|^2$, $B = \\langle a, d \\rangle$, $C = |a|^2 - 1$, $a = f(x)$, $d = x - f(x)$.",
+    "significance": "key",
+    "relatedConcepts": ["ray-sphere intersection", "quadratic formula", "ball projection", "continuous retraction"],
+    "prerequisites": ["nsq (norm squared)", "ip (inner product)", "Real.sqrt", "div_eq_iff"]
+  },
+  {
     "id": "ann-bu-oq03-07-structural-properties",
     "proofId": "borsuk-ulam-oq-03",
     "range": {

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-03/annotations.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-03/annotations.json
@@ -24,6 +24,18 @@
     "prerequisites": ["field theory", "polynomial rings", "matrix algebra", "unique factorization"]
   },
   {
+    "id": "ann-wip03-setup",
+    "proofId": "cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-03",
+    "range": { "startLine": 33, "endLine": 44 },
+    "type": "context",
+    "title": "Imports and Environment Setup",
+    "content": "The file imports the full Mathlib library, opens the `Matrix` and `Polynomial` namespaces for concise notation, and declares `noncomputable section` since `Field K` instances are generally noncomputable in Lean 4. The `Classical.propDecidable` attribute enables classical reasoning (`by_contra`, decidable equality on propositions) throughout the file. The field `K` and dimension `n` are introduced as universe-polymorphic implicit variables, allowing the results to apply to any field and matrix size.",
+    "mathContext": "The `noncomputable` declaration is necessary because field operations and polynomial evaluation in Lean 4 are defined noncomputably via classical axioms. The `open Matrix Polynomial` allows writing `mulVec`, `aeval`, `natDegree`, etc. without module prefixes.",
+    "significance": "context",
+    "relatedConcepts": ["Lean 4 noncomputable", "classical logic", "universe polymorphism"],
+    "prerequisites": ["Lean 4 module system", "Mathlib library structure"]
+  },
+  {
     "id": "ann-wip03-cyclic-def",
     "proofId": "cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-03",
     "range": { "startLine": 49, "endLine": 51 },

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-03/meta.json
@@ -69,12 +69,12 @@
   },
   "sections": [
     {
-      "id": "preamble",
-      "title": "Preamble and Setup",
+      "id": "imports",
+      "title": "Imports and Setup",
       "startLine": 1,
       "endLine": 44,
-      "summary": "File documentation, Mathlib import, namespace declaration, and type-class variable setup. Uses Classical.propDecidable for decidability in the coprimality/Bézout arguments.",
-      "mathContext": "The proof is parametric in a field $K$ and dimension $n : \\mathbb{N}$, with all matrices in $K^{n \\times n}$ (Fin n → Fin n → K)."
+      "summary": "Module docstring describing the prime power cyclic vector theorem, its proof strategy (induction on exponent e), and relationship to WIP01/WIP02. Imports `Mathlib`, opens `Matrix` and `Polynomial`, declares `noncomputable section` and `Classical.propDecidable`, and introduces universe-polymorphic field variables `K` and dimension `n`.",
+      "mathContext": "The docstring outlines the key new lemma `pow_irred_dvd_of_annihilated` and its inductive proof structure. The `noncomputable section` is needed because `Field K` instances are generally noncomputable in Lean 4, and `Classical.propDecidable` enables classical reasoning (by_contra, by_cases) throughout the file."
     },
     {
       "id": "definitions",
@@ -109,12 +109,12 @@
       "mathContext": "Pick v with p^(e-1)(M)v ≠ 0 (possible since deg(p^(e-1)) < n = deg(minpoly) implies p^(e-1)(M) ≠ 0). Then p^e(M)v = 0. For any r with r(M)v = 0 and deg(r) < n: pow_irred_dvd_of_annihilated gives p^e | r, so deg(r) ≥ e·deg(p) = n, contradicting deg(r) < n. Hence r = 0."
     },
     {
-      "id": "corollary",
-      "title": "V. Corollary — Finite Fields",
+      "id": "finite-corollary",
+      "title": "V. Finite Field Corollary",
       "startLine": 240,
       "endLine": 253,
-      "summary": "States the finite field specialization as a separate theorem, emphasizing that the prime power cyclic vector theorem holds for all finite fields with no cardinality restriction on |K| relative to n.",
-      "mathContext": "For any finite field $\\mathbb{F}_q$ and nonderogatory $M \\in \\mathbb{F}_q^{n \\times n}$ with $\\mu_M = p^e$, there exists a cyclic vector — no restriction $q > n$ needed."
+      "summary": "Corollary `nonderogatory_pw_has_cyclic_vector_finite` makes explicit that the main theorem holds for all finite fields with no cardinality restriction, then closes the namespace and section.",
+      "mathContext": "The theorem holds for $\\mathbb{F}_q$ for any prime power $q$, unlike earlier results (e.g., OQ-05-OQ-01-OQ-01) that required $|K| > n$. The proof is a direct delegation to the main theorem since no infinite-field-specific arguments were used."
     }
   ],
   "conclusion": {
@@ -142,6 +142,43 @@
     "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP03.lean",
     "sorries": 0
   },
+  "references": [
+    {
+      "authors": "Frobenius, Ferdinand Georg",
+      "title": "Ueber lineare Substitutionen und bilineare Formen",
+      "year": "1878",
+      "venue": "Journal für die reine und angewandte Mathematik (Crelle's Journal), vol. 84, pp. 1–63",
+      "note": "Foundational paper on the rational canonical form and elementary divisors of matrices over polynomial rings — the original context for the cyclic vector theorem"
+    },
+    {
+      "authors": "Hoffman, Kenneth; Kunze, Ray",
+      "title": "Linear Algebra",
+      "year": "1971",
+      "venue": "Prentice-Hall, 2nd edition",
+      "note": "Standard reference for the cyclic decomposition theorem and nonderogatory matrices. Chapter 7 develops the theory of cyclic vectors and rational canonical form via the PID structure theorem"
+    },
+    {
+      "authors": "Horn, Roger A.; Johnson, Charles R.",
+      "title": "Matrix Analysis",
+      "year": "2013",
+      "venue": "Cambridge University Press, 2nd edition",
+      "note": "Section 3.2 covers nonderogatory matrices and their characterization via cyclic vectors. Theorem 3.2.4 proves the equivalence: M is nonderogatory iff M has a cyclic vector"
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "nonderogatory_pw_has_cyclic_vector",
+      "type": "core",
+      "description": "For nonderogatory M with minpoly = p^e (p monic irreducible, e ≥ 1), M has a cyclic vector over any field K",
+      "leanType": "(M : Matrix (Fin n) (Fin n) K) → IsNonderogatory M → (p : K[X]) → (e : ℕ) → Irreducible p → p.Monic → 0 < e → minpoly K M = p ^ e → ∃ v, IsCyclicVector M v"
+    },
+    {
+      "name": "pow_irred_dvd_of_annihilated",
+      "type": "key",
+      "description": "If p is irreducible, p^e(M)v ≠ 0, p^(e+1)(M)v = 0, and r(M)v = 0, then p^(e+1) divides r",
+      "leanType": "Irreducible p → ∀ (e : ℕ) (v : Fin n → K), (aeval M (p^e)).mulVec v ≠ 0 → (aeval M (p^(e+1))).mulVec v = 0 → ∀ r, (aeval M r).mulVec v = 0 → p^(e+1) ∣ r"
+    }
+  ],
   "crossReferences": [
     {
       "targetId": "cayley-hamilton-minpoly-oq-05-oq-01-oq-04",

--- a/src/data/proofs/godel-incompleteness/annotations.json
+++ b/src/data/proofs/godel-incompleteness/annotations.json
@@ -9,6 +9,7 @@
     "type": "concept",
     "title": "The Theorem That Changed Everything",
     "content": "Gödel's 1931 paper is one of the most important in the history of mathematics and logic. It proved that Hilbert's dream of a complete, consistent formal foundation for mathematics was impossible.\n\nThe theorem states that any formal system $F$ capable of expressing basic arithmetic must be **incomplete**: there exist true statements that $F$ cannot prove. This isn't a flaw in our axioms—it's a fundamental limitation of formal reasoning itself.\n\nThis formalization presents the key conceptual components. A complete proof would require thousands of lines defining syntax, proof systems, and primitive recursive functions.",
+    "mathContext": "For any consistent, recursively axiomatizable theory $F \\supseteq Q$ (Robinson arithmetic): $\\exists \\varphi \\in \\mathcal{L}_F$ such that $F \\nvdash \\varphi$ and $F \\nvdash \\neg\\varphi$.",
     "significance": "key",
     "relatedConcepts": [
       "Hilbert's Program",
@@ -26,6 +27,7 @@
     "type": "definition",
     "title": "The Formula Type",
     "content": "We axiomatize `Formula` as an abstract type representing well-formed formulas in our formal system. In a full formalization, this would be an inductive type defining the syntax of first-order arithmetic:\n\n- Variables: $x, y, z, \\ldots$\n- Constants: $0, 1, 2, \\ldots$\n- Functions: $+, \\times, S$ (successor)\n- Relations: $=, <$\n- Logical connectives: $\\land, \\lor, \\neg, \\rightarrow$\n- Quantifiers: $\\forall, \\exists$\n\nEvery formula in Peano Arithmetic can be built from these primitives.",
+    "mathContext": "The language $\\mathcal{L}_{\\text{PA}} = \\{0, S, +, \\times, =, <, \\neg, \\land, \\lor, \\to, \\forall, \\exists\\}$. Each well-formed formula $\\varphi$ is a finite string over this alphabet built by inductive grammar rules.",
     "significance": "key",
     "relatedConcepts": [
       "formal syntax",
@@ -79,6 +81,7 @@
     "type": "insight",
     "title": "Injectivity of Encoding",
     "content": "The Gödel numbering must be **injective**: different formulas get different numbers. This ensures we can uniquely identify formulas by their codes.\n\nGödel used prime factorization for his encoding. For instance, a sequence of symbols $(a_1, a_2, \\ldots, a_n)$ might be encoded as $2^{a_1} \\cdot 3^{a_2} \\cdot 5^{a_3} \\cdots p_n^{a_n}$ where $p_i$ is the $i$th prime. The fundamental theorem of arithmetic guarantees unique decoding.",
+    "mathContext": "The Gödel numbering $\\ulcorner \\cdot \\urcorner : \\text{Formula} \\to \\mathbb{N}$ is injective: $\\ulcorner \\varphi \\urcorner = \\ulcorner \\psi \\urcorner \\Rightarrow \\varphi = \\psi$. Gödel's encoding: $\\ulcorner (a_1, \\ldots, a_n) \\urcorner = \\prod_{i=1}^n p_i^{a_i}$.",
     "significance": "supporting",
     "prerequisites": [
       "ann-godel-numbering"
@@ -220,6 +223,7 @@
     "type": "concept",
     "title": "Death of Hilbert's Program",
     "content": "David Hilbert had proposed that:\n1. All mathematics could be formalized in a complete, consistent system\n2. The consistency of this system could be proved by \"finitary\" means\n\nGödel's First Incompleteness Theorem killed (1): no complete system exists. His Second Incompleteness Theorem killed (2): no consistent system can prove its own consistency.\n\nThis was a shock to the mathematical community. The dream of absolute certainty in mathematics was over.",
+    "mathContext": "Hilbert's Program (1920s): Find $F$ such that (1) $F$ is complete ($\\forall \\varphi, F \\vdash \\varphi$ or $F \\vdash \\neg\\varphi$), (2) $F$ is consistent, and (3) $\\text{Con}(F)$ is provable by finitary means. Gödel showed (1) and (3) are impossible for any $F \\supseteq Q$.",
     "significance": "key",
     "relatedConcepts": [
       "Hilbert",
@@ -237,6 +241,7 @@
     "type": "insight",
     "title": "The Inexhaustibility of Mathematics",
     "content": "Gödel's theorem reveals something profound: mathematical truth is inexhaustible. No matter how many axioms we add, there will always be truths beyond our reach.\n\nWe can always add $G$ as a new axiom—then the system proves what it couldn't before. But immediately, a new Gödel sentence $G'$ emerges that the expanded system cannot prove. It's turtles all the way down.",
+    "mathContext": "For any consistent $F$, define $F_1 = F + G_F$. Then $F_1$ is consistent but has its own Gödel sentence $G_{F_1}$ unprovable in $F_1$. Iterating: $F_\\alpha$ for any recursive ordinal $\\alpha$ still has undecidable sentences.",
     "significance": "key",
     "relatedConcepts": [
       "axiom extension",
@@ -254,6 +259,7 @@
     "type": "concept",
     "title": "Mind vs. Machine",
     "content": "Some philosophers (notably Roger Penrose and J.R. Lucas) have argued that Gödel's theorem shows human minds are not machines—we can \"see\" that $G$ is true even though no formal system can prove it.\n\nThis interpretation is controversial. Critics argue that humans are also subject to limitations, and our \"seeing\" the truth of $G$ depends on assumptions (like consistency) that we cannot verify.\n\nThe debate continues: does mathematical intuition transcend computation, or are we also bounded by our own version of incompleteness?",
+    "mathContext": "Lucas-Penrose argument: if the mind is a Turing machine $T$, then $T$ is consistent, so $G_T$ is true but $T$ cannot prove it — yet we can 'see' $G_T$ is true. Conclusion: mind $\\neq$ Turing machine. Putnam's objection: the argument assumes we can verify $\\text{Con}(T)$.",
     "significance": "supporting",
     "relatedConcepts": [
       "mechanism",

--- a/src/data/proofs/godel-incompleteness/annotations.source.json
+++ b/src/data/proofs/godel-incompleteness/annotations.source.json
@@ -8,6 +8,7 @@
     "type": "concept",
     "title": "The Theorem That Changed Everything",
     "content": "Gödel's 1931 paper is one of the most important in the history of mathematics and logic. It proved that Hilbert's dream of a complete, consistent formal foundation for mathematics was impossible.\n\nThe theorem states that any formal system $F$ capable of expressing basic arithmetic must be **incomplete**: there exist true statements that $F$ cannot prove. This isn't a flaw in our axioms—it's a fundamental limitation of formal reasoning itself.\n\nThis formalization presents the key conceptual components. A complete proof would require thousands of lines defining syntax, proof systems, and primitive recursive functions.",
+    "mathContext": "For any consistent, recursively axiomatizable theory $F \\supseteq Q$ (Robinson arithmetic): $\\exists \\varphi \\in \\mathcal{L}_F$ such that $F \\nvdash \\varphi$ and $F \\nvdash \\neg\\varphi$.",
     "significance": "key",
     "relatedConcepts": [
       "Hilbert's Program",
@@ -25,6 +26,7 @@
     "type": "definition",
     "title": "The Formula Type",
     "content": "We axiomatize `Formula` as an abstract type representing well-formed formulas in our formal system. In a full formalization, this would be an inductive type defining the syntax of first-order arithmetic:\n\n- Variables: $x, y, z, \\ldots$\n- Constants: $0, 1, 2, \\ldots$\n- Functions: $+, \\times, S$ (successor)\n- Relations: $=, <$\n- Logical connectives: $\\land, \\lor, \\neg, \\rightarrow$\n- Quantifiers: $\\forall, \\exists$\n\nEvery formula in Peano Arithmetic can be built from these primitives.",
+    "mathContext": "The language $\\mathcal{L}_{\\text{PA}} = \\{0, S, +, \\times, =, <, \\neg, \\land, \\lor, \\to, \\forall, \\exists\\}$. Each well-formed formula $\\varphi$ is a finite string over this alphabet built by inductive grammar rules.",
     "significance": "key",
     "relatedConcepts": [
       "formal syntax",
@@ -79,6 +81,7 @@
     "type": "insight",
     "title": "Injectivity of Encoding",
     "content": "The Gödel numbering must be **injective**: different formulas get different numbers. This ensures we can uniquely identify formulas by their codes.\n\nGödel used prime factorization for his encoding. For instance, a sequence of symbols $(a_1, a_2, \\ldots, a_n)$ might be encoded as $2^{a_1} \\cdot 3^{a_2} \\cdot 5^{a_3} \\cdots p_n^{a_n}$ where $p_i$ is the $i$th prime. The fundamental theorem of arithmetic guarantees unique decoding.",
+    "mathContext": "The Gödel numbering $\\ulcorner \\cdot \\urcorner : \\text{Formula} \\to \\mathbb{N}$ is injective: $\\ulcorner \\varphi \\urcorner = \\ulcorner \\psi \\urcorner \\Rightarrow \\varphi = \\psi$. Gödel's encoding: $\\ulcorner (a_1, \\ldots, a_n) \\urcorner = \\prod_{i=1}^n p_i^{a_i}$.",
     "significance": "supporting",
     "prerequisites": [
       "ann-godel-numbering"
@@ -243,6 +246,7 @@
     "type": "concept",
     "title": "Death of Hilbert's Program",
     "content": "David Hilbert had proposed that:\n1. All mathematics could be formalized in a complete, consistent system\n2. The consistency of this system could be proved by \"finitary\" means\n\nGödel's First Incompleteness Theorem killed (1): no complete system exists. His Second Incompleteness Theorem killed (2): no consistent system can prove its own consistency.\n\nThis was a shock to the mathematical community. The dream of absolute certainty in mathematics was over.",
+    "mathContext": "Hilbert's Program (1920s): Find $F$ such that (1) $F$ is complete ($\\forall \\varphi, F \\vdash \\varphi$ or $F \\vdash \\neg\\varphi$), (2) $F$ is consistent, and (3) $\\text{Con}(F)$ is provable by finitary means. Gödel showed (1) and (3) are impossible for any $F \\supseteq Q$.",
     "significance": "key",
     "relatedConcepts": [
       "Hilbert",
@@ -261,6 +265,7 @@
     "type": "insight",
     "title": "The Inexhaustibility of Mathematics",
     "content": "Gödel's theorem reveals something profound: mathematical truth is inexhaustible. No matter how many axioms we add, there will always be truths beyond our reach.\n\nWe can always add $G$ as a new axiom—then the system proves what it couldn't before. But immediately, a new Gödel sentence $G'$ emerges that the expanded system cannot prove. It's turtles all the way down.",
+    "mathContext": "For any consistent $F$, define $F_1 = F + G_F$. Then $F_1$ is consistent but has its own Gödel sentence $G_{F_1}$ unprovable in $F_1$. Iterating: $F_\\alpha$ for any recursive ordinal $\\alpha$ still has undecidable sentences.",
     "significance": "key",
     "relatedConcepts": [
       "axiom extension",
@@ -278,6 +283,7 @@
     "type": "concept",
     "title": "Mind vs. Machine",
     "content": "Some philosophers (notably Roger Penrose and J.R. Lucas) have argued that Gödel's theorem shows human minds are not machines—we can \"see\" that $G$ is true even though no formal system can prove it.\n\nThis interpretation is controversial. Critics argue that humans are also subject to limitations, and our \"seeing\" the truth of $G$ depends on assumptions (like consistency) that we cannot verify.\n\nThe debate continues: does mathematical intuition transcend computation, or are we also bounded by our own version of incompleteness?",
+    "mathContext": "Lucas-Penrose argument: if the mind is a Turing machine $T$, then $T$ is consistent, so $G_T$ is true but $T$ cannot prove it — yet we can 'see' $G_T$ is true. Conclusion: mind $\\neq$ Turing machine. Putnam's objection: the argument assumes we can verify $\\text{Con}(T)$.",
     "significance": "supporting",
     "relatedConcepts": [
       "mechanism",


### PR DESCRIPTION
## Summary
- Cherry-picked enrichments from stale PRs #13094 and #13095 (closed due to branch divergence)
- **Gödel's Incompleteness**: add mathContext to 6 annotations (all 14 now have LaTeX formulas)
- **Borsuk-Ulam OQ03**: add 5 annotations covering Tucker signed/parity lemmas, BU-Brouwer FP, no-retraction, ray-sphere architecture
- **Nonderogatory Prime Power WIP03**: add imports/finite-corollary sections, references (Frobenius 1878, Hoffman-Kunze, Horn-Johnson), annotations

## Test plan
- [ ] pnpm build succeeds
- [ ] Affected proof pages render correctly in gallery