### PR TITLE
fix(erdos-989): correct section descriptions claiming non-existent axioms

### DIFF
--- a/src/data/proofs/erdos-989/meta.json
+++ b/src/data/proofs/erdos-989/meta.json
@@ -159,10 +159,10 @@
     {
       "id": "proof-techniques",
       "title": "Proof Techniques",
-      "summary": "Formalizes the two proof techniques as axioms: fourier_analysis_lower_bound (for any A and r > 1, some circle has discrepancy \u2265 \u221ar/10) and probabilistic_upper_bound_construction (existence of sequence with local discrepancy O(\u221a(r log r))).",
+      "summary": "Documents the two proof techniques used by Beck: Fourier analysis with Bessel functions for the lower bound, and probabilistic lattice perturbation for the upper bound. This section contains only narrative documentation, not formal declarations.",
       "startLine": 209,
       "endLine": 239,
-      "mathContext": "Formalizes the two proof techniques as axioms: fourier_analysis_lower_bound (for any A and r > 1, some circle has discrepancy \u2265 \u221ar/10) and probabilistic_upper_bound_construction (existence of sequence with local discrepancy O(\u221a(r log r)))."
+      "mathContext": "Documents the two proof techniques used by Beck: Fourier analysis with Bessel functions for the lower bound, and probabilistic lattice perturbation for the upper bound. This section contains only narrative documentation, not formal declarations."
     },
     {
       "id": "open-questions",
@@ -175,10 +175,10 @@
     {
       "id": "related-results",
       "title": "Related Results",
-      "summary": "States Schmidt's classical box discrepancy theorem (D(N) \u2265 c log N for d=2) and Alexander's half-plane discrepancy theorem (D(N) \u2265 cN^{1/4}) as axioms, providing context for why circle discrepancy (\u221ar) is intermediate.",
+      "summary": "Documents Schmidt's classical box discrepancy theorem and Alexander's half-plane discrepancy theorem in docstrings, providing context for why circle discrepancy (\u221ar) is intermediate. These results are described but not formalized.",
       "startLine": 284,
       "endLine": 320,
-      "mathContext": "States Schmidt's classical box discrepancy theorem (D(N) \u2265 c log N for d=2) and Alexander's half-plane discrepancy theorem (D(N) \u2265 cN^{1/4}) as axioms, providing context for why circle discrepancy (\u221ar) is intermediate."
+      "mathContext": "Documents Schmidt's classical box discrepancy theorem and Alexander's half-plane discrepancy theorem in docstrings, providing context for why circle discrepancy (\u221ar) is intermediate. These results are described but not formalized."
     },
     {
       "id": "summary",


### PR DESCRIPTION
## Fix

Two section descriptions in `src/data/proofs/erdos-989/meta.json` falsely claimed that named axiom declarations existed in the Lean source file.

## Evidence

**Before (proof-techniques)**:
> "Formalizes the two proof techniques as axioms: fourier_analysis_lower_bound ... and probabilistic_upper_bound_construction ..."

**After (proof-techniques)**:
> "Documents the two proof techniques used by Beck: Fourier analysis with Bessel functions for the lower bound, and probabilistic lattice perturbation for the upper bound. This section contains only narrative documentation, not formal declarations."

**Before (related-results)**:
> "States Schmidt's classical box discrepancy theorem ... and Alexander's half-plane discrepancy theorem ... as axioms ..."

**After (related-results)**:
> "Documents Schmidt's classical box discrepancy theorem and Alexander's half-plane discrepancy theorem in docstrings ... These results are described but not formalized."

Verified against `Erdos989Problem.lean` lines 209-239 and 284-320: both ranges contain only `/-- ... -/` docstring comments with no `axiom`, `theorem`, or `def` declarations matching the claimed names. The actual axioms in the file are `beck_lower_bound` (line 88) and `beck_upper_bound` (line 130).

Closes #13104

---
Automated fix by lean-mechanic agent.