### PR TITLE
fix(meta): correct section endLine OOB for 3 gallery entries

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-04/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-04/meta.json
@@ -115,7 +115,7 @@
             "id": "sec-main-theorem",
             "title": "Part V: Jordan-Hölder Theorem",
             "startLine": 229,
-            "endLine": 255,
+            "endLine": 234,
             "summary": "`jordan_holder_subgroups` and `jordan_holder_finite_groups`: one-line delegations to `CompositionSeries.jordan_holder` once the JordanHolderLattice instance is provided. `#check` statements verify the exported types. These theorems become available automatically — the entire power of the abstract Jordan-Hölder machinery applies to groups at no additional proof cost.",
             "mathContext": "Jordan-Hölder uniqueness: any two composition series of a finite group have the same length and the same multiset of simple composition factors up to permutation and isomorphism. For $S_5$: the unique series is $\\{e\\} \\triangleleft A_5 \\triangleleft S_5$ with factors $A_5$ (simple, order 60) and $\\mathbb{Z}/2\\mathbb{Z}$. Jordan-Hölder guarantees no alternative decomposition avoids the non-abelian $A_5$ factor, making the Abel-Ruffini degree-5 threshold absolute."
         }

--- a/src/data/proofs/erdos-638/meta.json
+++ b/src/data/proofs/erdos-638/meta.json
@@ -90,7 +90,7 @@
       "id": "classical-ramsey",
       "title": "Classical Ramsey Theorem",
       "startLine": 218,
-      "endLine": 243,
+      "endLine": 242,
       "summary": "Proves ramsey_triangle by induction: for every n ≥ 1, there exists N such that every n-colouring of K_N contains a monochromatic triangle. Bound: R(1) = 3, R(n+1) ≤ (n+1)·(R(n)-1) + 2. Derives complete_graphs_ramsey: the family of complete graphs forms a Ramsey family."
     }
   ],

--- a/src/data/proofs/erdos-795/meta.json
+++ b/src/data/proofs/erdos-795/meta.json
@@ -146,7 +146,7 @@
       "id": "sec-795-summary",
       "title": "Summary",
       "startLine": 491,
-      "endLine": 500,
+      "endLine": 496,
       "summary": "Closing documentation block summarizing the SOLVED status, the exact asymptotic g(n) = π(n) + π(√n) + Θ(π(∛n)), and the key insight about primes and prime powers forming optimal sets.",
       "mathContext": "Mathematical content: Closing documentation block summarizing the SOLVED status, the exact asymptotic g(n) = π(n) + π(√n) + Θ(π(∛n)), and the key insight about primes and prime powers forming optimal sets."
     }


### PR DESCRIPTION
## Fix

Three gallery entries had section `endLine` values exceeding the actual file `lineCount`, creating out-of-bounds section boundaries.

## Evidence

**abel-ruffini-galois-extensions-oq-04** (`sec-main-theorem`):
- Before: `endLine: 255`, lineCount: 234 (21 lines out of bounds)
- After: `endLine: 234` (matches actual file end)

**erdos-638** (`classical-ramsey`):
- Before: `endLine: 243`, lineCount: 242 (1 line out of bounds)
- After: `endLine: 242` (matches actual file end)

**erdos-795** (`sec-795-summary`):
- Before: `endLine: 500`, lineCount: 496 (4 lines out of bounds)
- After: `endLine: 496` (matches actual file end)

All verified by reading the actual Lean source files and confirmed via `pnpm build` (exit 0).

---
Automated fix by lean-mechanic agent.