### PR TITLE
Enrich Jordan-Hölder (galois-extensions-oq-04): fix section alignment

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-04/annotations.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-04/annotations.json
@@ -130,5 +130,29 @@
     "significance": "key",
     "relatedConcepts": ["CompositionSeries", "CompositionSeries.jordan_holder", "composition factors", "Schreier refinement theorem"],
     "prerequisites": ["composition series", "normal series", "Jordan-Hölder theorem statement"]
+  },
+  {
+    "id": "ann-namespace-setup",
+    "proofId": "abel-ruffini-galois-extensions-oq-04",
+    "range": { "startLine": 32, "endLine": 37 },
+    "type": "context",
+    "title": "Namespace, Open Declarations, and Universe-Polymorphic Variable",
+    "content": "The `namespace AbelRuffiniGaloisExtensionsOQ04` scopes all definitions and theorems to avoid name collisions with Mathlib or other proof files. `open Subgroup QuotientGroup` brings key operations (e.g., `mem_sup`, `mk'`, `subgroupOf`, `quotientKerEquivOfSurjective`) into scope without qualification. The `variable {G : Type*} [Group G]` declaration makes all subsequent definitions universe-polymorphic: the JordanHolderLattice instance and Jordan-Hölder theorem apply to any group in any Lean universe, not just `Type` or `Type 0`. The implicit `{G}` means Lean infers the group from context at each use site.",
+    "mathContext": "Universe polymorphism ensures the instance works uniformly for groups of any cardinality: finite groups in `Type` (like $S_5$), countable groups in `Type 0` (like free groups), and larger groups in higher universes. The `[Group G]` typeclass constraint is the only requirement — no finiteness, commutativity, or other structure is assumed. This generality is essential for a Mathlib-ready instance.",
+    "significance": "context",
+    "relatedConcepts": ["universe polymorphism", "typeclass system", "namespace scoping", "implicit variables"],
+    "prerequisites": ["Lean 4 universe system", "typeclass resolution"]
+  },
+  {
+    "id": "ann-verification",
+    "proofId": "abel-ruffini-galois-extensions-oq-04",
+    "range": { "startLine": 227, "endLine": 234 },
+    "type": "context",
+    "title": "Type Verification and Namespace Closure",
+    "content": "The `#check @jordan_holder_subgroups` command asks Lean to display the full type signature of the theorem, confirming it has the expected form: given two composition series with matching endpoints, they are equivalent. `#check @instJordanHolderLatticeSubgroup` verifies the JordanHolderLattice instance is registered — any downstream file importing this module can use `CompositionSeries.jordan_holder` for groups without additional setup. The `end` command closes the namespace, making all definitions accessible as `AbelRuffiniGaloisExtensionsOQ04.jordan_holder_subgroups` etc.",
+    "mathContext": "The `#check` commands are a standard Lean 4 verification pattern: they produce no runtime code but confirm at elaboration time that the typeclass instance is correctly registered and the theorem has the intended type. For the JordanHolderLattice instance, successful `#check` confirms that Lean's typeclass resolution can find `JordanHolderLattice (Subgroup G)` when needed — the critical property that makes `CompositionSeries.jordan_holder` available for groups.",
+    "significance": "context",
+    "relatedConcepts": ["#check command", "typeclass resolution", "instance registration", "namespace system"],
+    "prerequisites": ["Lean 4 elaboration", "typeclass system"]
   }
 ]

--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-04/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-04/meta.json
@@ -81,43 +81,67 @@
     "sections": [
         {
             "id": "sec-header",
-            "title": "Part I: Module Header and Imports",
+            "title": "Module Header, Imports, and Setup",
             "startLine": 1,
-            "endLine": 35,
-            "summary": "Module docstring documenting the mathematical goal (JordanHolderLattice instantiation), the Mathlib TODO being filled, and a technical note about a formerly sorry-carrying lemma (isMaximal_inf_left_of_isMaximal_sup) that was subsequently resolved by the element-wise argument. Imports: JordanHolder, QuotientGroup.Basic, Subgroup.Simple, and the parent AbelRuffiniGaloisExtensions file.",
-            "mathContext": "The Mathlib TODO comment in `Mathlib.Order.JordanHolder` says: 'TODO: add `JordanHolderLattice (Subgroup G)` instance'. This file provides it. The JordanHolderLattice typeclass abstracts the three axioms needed for Jordan-Hölder uniqueness, making the abstract theorem `CompositionSeries.jordan_holder` available for any instantiation including groups and modules."
+            "endLine": 37,
+            "summary": "Module docstring documenting the mathematical goal (JordanHolderLattice instantiation for Subgroup G), the Mathlib TODO being filled, and proof status (all 3 axioms fully proved, 0 sorries). Imports: JordanHolder (abstract typeclass + CompositionSeries), QuotientGroup.Basic (quotient construction + first isomorphism), Subgroup.Simple (simple group definition), and the parent AbelRuffiniGaloisExtensions file. Opens the `Subgroup` and `QuotientGroup` namespaces and introduces the universe-polymorphic group variable `{G : Type*} [Group G]`.",
+            "mathContext": "The Mathlib TODO in `Mathlib.Order.JordanHolder` says: 'TODO: add `JordanHolderLattice (Subgroup G)` instance.' This file provides it. The `JordanHolderLattice` typeclass abstracts the three axioms needed for Jordan-Hölder uniqueness, making the abstract theorem `CompositionSeries.jordan_holder` available for any concrete instantiation. The `variable {G : Type*} [Group G]` declaration makes all subsequent definitions and theorems universe-polymorphic — they apply to any group, not just groups in a fixed universe."
         },
         {
             "id": "sec-predicates",
-            "title": "Part II: Core Predicates",
-            "startLine": 36,
-            "endLine": 68,
-            "summary": "`IsMaxNorm H K`: H is a maximal normal subgroup of K (strict containment + relative normality + no intermediate normal-in-K subgroups). `GroupQuotIso`: quotient isomorphism K₁/H₁ ≃* K₂/H₂ packaged with explicit Normal witnesses. `le_normalizer_of_normal_in_sup`: if H is relatively normal in H⊔K, then K ≤ H.normalizer — a bridge lemma used in multiple axiom proofs.",
-            "mathContext": "`IsMaxNorm` avoids `IsSimpleGroup (K ⧸ H)` to sidestep typeclass dependency issues with quotient types. `GroupQuotIso` packages Normal evidence explicitly as existential witnesses, enabling `haveI` introduction before constructing `MulEquiv`. The normalizer lemma uses `normal_subgroupOf_iff_le_normalizer` to convert relative normality into the normalizer containment $K \\leq N_G(H)$."
+            "title": "Part I: Core Predicates and Normalizer Lemma",
+            "startLine": 38,
+            "endLine": 66,
+            "summary": "Three building blocks for the JordanHolderLattice instance. `IsMaxNorm H K` (lines 48–51): H is a maximal normal subgroup of K — strict containment, relative normality via `subgroupOf`, and no intermediate normal-in-K subgroups. `GroupQuotIso` (lines 54–57): quotient isomorphism K₁/H₁ ≃* K₂/H₂ packaged with explicit Normal witnesses to avoid typeclass synthesis failures. `le_normalizer_of_normal_in_sup` (lines 64–66): bridge lemma — if H is relatively normal in H⊔K then K ≤ H.normalizer — used in both isMaximal_inf and second_iso proofs.",
+            "mathContext": "`IsMaxNorm` avoids `IsSimpleGroup (K ⧸ H)` to sidestep the typeclass dependency where the `Normal` instance for the quotient depends on the syntactic form of the subgroup expression. `GroupQuotIso` packages Normal evidence as existential witnesses `hn1, hn2`, enabling `haveI` introduction before constructing `MulEquiv`. The normalizer lemma chains `le_sup_right : K \\leq H \\vee K` with `normal_subgroupOf_iff_le_normalizer` to convert relative normality $H \\trianglelefteq_{H \\vee K}$ into the normalizer containment $K \\leq N_G(H)$."
         },
         {
-            "id": "sec-sup-eq",
-            "title": "Part III: Axiom 1 — sup_eq_of_isMaximal",
-            "startLine": 70,
-            "endLine": 103,
-            "summary": "Instance declaration filling the Mathlib TODO (`IsMaximal := IsMaxNorm`, `Iso := GroupQuotIso`), followed by `sup_eq_of_isMaximal`: if x and y are both maximal normal in z with x ≠ y, then x ⊔ y = z. Proof: x ⊔ y is relatively normal in z via `subgroupOf_sup`; maximality of x applied to x ≤ x⊔y ≤ z yields x⊔y = z or contradiction.",
-            "mathContext": "The diamond lemma: if $x, y \\trianglelefteq_{\\max} z$ and $x \\neq y$, then $x \\vee y = z$. The key Mathlib lemma `subgroupOf_sup` gives $(A \\vee B)/_{C} = (A/_{C}) \\vee (B/_{C})$, showing a join of two relatively normal subgroups is relatively normal. Applying x's maximality to the chain $x \\leq x \\vee y \\leq z$ gives $x \\vee y = x$ (impossible since $y \\not\\leq x$ by x's maximality applied to y) or $x \\vee y = z$."
+            "id": "sec-instance-sup",
+            "title": "Part III: Instance Declaration and Axiom 1 — sup_eq_of_isMaximal",
+            "startLine": 68,
+            "endLine": 96,
+            "summary": "The `noncomputable instance instJordanHolderLatticeSubgroup` declaration (lines 72–78) fills the Mathlib TODO, setting `IsMaximal := IsMaxNorm` and `Iso := GroupQuotIso`. The first axiom `sup_eq_of_isMaximal` (lines 79–96): if x and y are both maximal normal in z with x ≠ y, then x ⊔ y = z. Proof: show x⊔y is relatively normal in z via `subgroupOf_sup` (join of normal subgroups is normal); apply x's maximality to the chain x ≤ x⊔y ≤ z; the case x⊔y = x implies y ≤ x, then y's maximality applied to x gives y = x (contradiction) or x = z (contradiction).",
+            "mathContext": "The diamond lemma for maximal normal subgroups: if $x, y \\trianglelefteq_{\\max} z$ and $x \\neq y$, then $x \\vee y = z$. The key Mathlib lemma `subgroupOf_sup` gives $(A \\vee B)/_{C} = (A/_{C}) \\vee (B/_{C})$, reflecting the lattice homomorphism property of `subgroupOf`. This combined with the fact that a supremum of normal subgroups is normal yields the normality of $x \\vee y$ in $z$. The `noncomputable` annotation is required because the instance uses classical existence reasoning via `quotientKerEquivOfSurjective`."
         },
         {
-            "id": "sec-inf-and-iso",
-            "title": "Part IV: Axioms 2–3 — isMaximal_inf and second_iso",
-            "startLine": 105,
-            "endLine": 227,
-            "summary": "`isMaximal_inf_left_of_isMaximal_sup` (lines 105–167): if x and y are both maximal normal in x⊔y, then x⊓y is maximal normal in x — three goals (strict containment, relative normality, maximality); maximality case uses element-wise Subgroup.mem_sup decomposition. `iso_symm` and `iso_trans` (lines 169–181): GroupQuotIso is symmetric and transitive. `second_iso` (lines 183–227): (x⊔y)/x ≃* y/(x⊓y) via first isomorphism theorem, constructing φ: y →* (x⊔y)/x directly to bypass sup_comm rewrite failure.",
-            "mathContext": "The element-wise argument: for $a \\in x$, write $a = nb$ with $n \\in N, b \\in y$ (Subgroup.mem_sup); then $b = n^{-1}a \\in x \\cap y \\leq N$, so $a \\in N$. The `rw [sup_comm y x]` failure occurs because the Normal typeclass instance for the quotient type depends syntactically on the rewritten term — a systematic issue in Lean 4 with typeclass-dependent rewriting that requires constructing the map directly rather than rewriting."
+            "id": "sec-inf-max",
+            "title": "Axiom 2 — isMaximal_inf_left_of_isMaximal_sup",
+            "startLine": 98,
+            "endLine": 156,
+            "summary": "The longest and most technically demanding axiom proof. If x and y are both maximal normal in x⊔y, then x⊓y is maximal normal in x. The proof establishes three goals: (1) x⊓y < x: if equality held, x ≤ y, making x⊔y = y, contradicting y < x⊔y. (2) (x⊓y).subgroupOf x is Normal: y normalizes x (since y is normal in x⊔y), so `inf_subgroupOf_right` converts to normality of the intersection. (3) Maximality: for N with x⊓y ≤ N ≤ x normal in x, consider N⊔y; apply y's maximality to get N⊔y = y (forcing N ≤ y, hence N = x⊓y) or N⊔y = x⊔y (element-wise argument: every a ∈ x is n·b with n ∈ N, b ∈ y∩x ≤ N, so a ∈ N, giving N = x).",
+            "mathContext": "The element-wise argument is the proof's centerpiece: given $N \\vee y = x \\vee y$ and $a \\in x$, use `Subgroup.mem_sup` to write $a = nb$ with $n \\in N, b \\in y$. Since $n \\in N \\leq x$, we get $b = n^{-1}a \\in x$. Also $b \\in y$, so $b \\in x \\wedge y \\leq N$. Therefore $a = nb \\in N$, proving $x \\leq N$. This avoids transferring simplicity through the second isomorphism theorem — a direct membership argument suffices where an isomorphism argument would require navigating quotient type dependencies."
         },
         {
-            "id": "sec-main-theorem",
-            "title": "Part V: Jordan-Hölder Theorem",
-            "startLine": 229,
+            "id": "sec-iso-rel",
+            "title": "Iso Relation Properties — iso_symm and iso_trans",
+            "startLine": 158,
+            "endLine": 170,
+            "summary": "`GroupQuotIso` must be an equivalence relation for the JordanHolderLattice axioms. `iso_symm` (lines 160–164): reverses K₁/H₁ ≃* K₂/H₂ using `MulEquiv.symm` lifted through `Nonempty.map`, swapping the Normal witnesses. `iso_trans` (lines 166–170): composes two isomorphisms using `MulEquiv.trans`, with careful `haveI` placement to introduce all four Normal instances before destructing the `Nonempty` witnesses with `rcases`.",
+            "mathContext": "These proofs verify that the composition factor isomorphism relation $\\simeq_*$ on quotient pairs is symmetric and transitive. For `iso_trans`: given $K_1/H_1 \\simeq_* K_2/H_2$ and $K_2/H_2 \\simeq_* K_3/H_3$, produce $K_1/H_1 \\simeq_* K_3/H_3$ by `MulEquiv.trans`. The `Nonempty` wrapping requires extracting witnesses with `rcases ⟨e1⟩` before composing. The four `haveI` invocations ensure all Normal instances are in scope for the final `MulEquiv.trans` construction."
+        },
+        {
+            "id": "sec-second-iso",
+            "title": "Axiom 3 — second_iso via First Isomorphism Theorem",
+            "startLine": 172,
+            "endLine": 206,
+            "summary": "The second isomorphism theorem in JordanHolderLattice form: if x is maximal normal in x⊔y, then (x⊔y)/x ≃* y/(x⊓y). The proof constructs φ : y →* (x⊔y)/x directly as `mk' ∘ inclusion le_sup_right`, avoiding the `rw [sup_comm]` that fails due to Normal typeclass dependency on the rewritten term. Kernel computation: ker φ = (x⊓y).subgroupOf y (membership calculation). Surjectivity: decompose any element of x⊔y via `Subgroup.mem_sup`, then show the x-component maps to the identity in the quotient. Apply `quotientKerEquivOfSurjective` to get the isomorphism.",
+            "mathContext": "Noether's second isomorphism theorem: for $H, K \\leq G$ with $K \\leq N_G(H)$, $(H \\vee K)/H \\simeq_* K/(H \\wedge K)$. The direct construction $\\varphi: y \\to (x \\vee y)/x$, $\\varphi(b) = b \\cdot x$, has $\\ker\\varphi = \\{b \\in y : b \\in x\\} = x \\wedge y$. The `rw [sup_comm y x]` failure is a systematic Lean 4 issue: the Normal typeclass instance for the quotient type `(y ⊔ x) ⧸ y.subgroupOf (y ⊔ x)` depends syntactically on the join expression, so rewriting `y ⊔ x` to `x ⊔ y` breaks the typeclass dependency chain with 'motive not type correct.'"
+        },
+        {
+            "id": "sec-jordan-holder",
+            "title": "Part IV: Jordan-Hölder Uniqueness Theorem",
+            "startLine": 208,
+            "endLine": 225,
+            "summary": "`jordan_holder_subgroups` and `jordan_holder_finite_groups`: one-line delegations to `CompositionSeries.jordan_holder` from Mathlib. With the JordanHolderLattice instance in place, the full Jordan-Hölder uniqueness theorem is immediate — any two composition series of a group with the same endpoints are equivalent (same length, same composition factors up to permutation and isomorphism). The `[Finite G]` variant makes the finiteness requirement explicit.",
+            "mathContext": "Jordan-Hölder uniqueness: any two composition series $1 = H_0 \\trianglelefteq \\cdots \\trianglelefteq H_n = G$ and $1 = K_0 \\trianglelefteq \\cdots \\trianglelefteq K_m = G$ satisfy $n = m$ and there is a permutation $\\sigma$ with $H_{i+1}/H_i \\simeq K_{\\sigma(i)+1}/K_{\\sigma(i)}$. For $S_5$: the unique composition series is $\\{e\\} \\triangleleft A_5 \\triangleleft S_5$ with factors $A_5$ (simple, order 60) and $\\mathbb{Z}/2\\mathbb{Z}$. Jordan-Hölder guarantees no alternative decomposition avoids the non-abelian $A_5$ factor, making the Abel-Ruffini degree-5 threshold absolute."
+        },
+        {
+            "id": "sec-verification",
+            "title": "Part V: Type Verification",
+            "startLine": 227,
             "endLine": 234,
-            "summary": "`jordan_holder_subgroups` and `jordan_holder_finite_groups`: one-line delegations to `CompositionSeries.jordan_holder` once the JordanHolderLattice instance is provided. `#check` statements verify the exported types. These theorems become available automatically — the entire power of the abstract Jordan-Hölder machinery applies to groups at no additional proof cost.",
-            "mathContext": "Jordan-Hölder uniqueness: any two composition series of a finite group have the same length and the same multiset of simple composition factors up to permutation and isomorphism. For $S_5$: the unique series is $\\{e\\} \\triangleleft A_5 \\triangleleft S_5$ with factors $A_5$ (simple, order 60) and $\\mathbb{Z}/2\\mathbb{Z}$. Jordan-Hölder guarantees no alternative decomposition avoids the non-abelian $A_5$ factor, making the Abel-Ruffini degree-5 threshold absolute."
+            "summary": "`#check @jordan_holder_subgroups` and `#check @instJordanHolderLatticeSubgroup` verify that the theorem and instance have the expected types, confirming the instance is correctly registered in Lean's typeclass system and that `CompositionSeries.jordan_holder` successfully resolves the `JordanHolderLattice (Subgroup G)` instance. Closes the `AbelRuffiniGaloisExtensionsOQ04` namespace.",
+            "mathContext": "The `#check` commands serve as lightweight verification that Lean's elaborator accepts the instance and the derived theorem. `@instJordanHolderLatticeSubgroup` confirms the instance is available for typeclass resolution — any later file importing this module can use `CompositionSeries.jordan_holder` for groups without additional setup."
         }
     ],
     "crossReferences": [


### PR DESCRIPTION
Enrichment pass for abel-ruffini-galois-extensions-oq-04.

**Quality improvements:**
- Split oversized section (122 lines spanning 4 logical parts) into 4 focused sections
- Fixed section line ranges to match actual Lean file structure (Parts I–V)
- Added 2 annotations for previously uncovered code sections (namespace/variable setup, verification)
- Sections: 5 → 8; Annotations: 11 → 13; Full line coverage achieved

🤖 Generated with [Claude Code](https://claude.com/claude-code)