### PR TITLE
fix(meta): correct erdos-99 section line ranges and add Summary section

### DIFF
--- a/src/data/proofs/erdos-99/meta.json
+++ b/src/data/proofs/erdos-99/meta.json
@@ -105,32 +105,40 @@
       "title": "The Triangular Lattice",
       "summary": "triangularLatticePoint, TriangularLattice definitions; lattice properties described in docstrings only",
       "startLine": 98,
-      "endLine": 128,
+      "endLine": 116,
       "mathContext": "Mathematical content: triangularLatticePoint, TriangularLattice definitions; lattice properties described informally in docstrings only (no axiom declarations)"
     },
     {
       "id": "thue-theorem",
       "title": "Thue's Theorem and Lattice Structure",
       "summary": "Thue's diameter consequence described in docstring only; no Lean declaration",
-      "startLine": 129,
-      "endLine": 141,
+      "startLine": 117,
+      "endLine": 124,
       "mathContext": "Informal sketch only: Thue's diameter consequence described in docstring; no Lean declaration exists"
     },
     {
       "id": "small-cases",
       "title": "Small Cases",
       "summary": "case_n4_no_equilateral axiom (only); case_n3 is a docstring comment",
-      "startLine": 142,
-      "endLine": 157,
+      "startLine": 125,
+      "endLine": 136,
       "mathContext": "Axiomatized: case_n4_no_equilateral axiom only; case_n3 is a docstring comment with no corresponding Lean declaration"
     },
     {
       "id": "main-conjecture",
       "title": "The Main Conjecture (OPEN)",
       "summary": "Erdos99Conjecture, StrongerConjecture, triangularPackingDensity",
-      "startLine": 158,
-      "endLine": 179,
+      "startLine": 137,
+      "endLine": 164,
       "mathContext": "Mathematical content: Erdos99Conjecture, StrongerConjecture, triangularPackingDensity"
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "summary": "erdos_99_summary theorem packaging the n=4 counterexample as the concrete result",
+      "startLine": 165,
+      "endLine": 179,
+      "mathContext": "Mathematical content: erdos_99_summary theorem proved by direct application of the case_n4_no_equilateral axiom"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

- Section line ranges in `src/data/proofs/erdos-99/meta.json` were misaligned with the Lean source by ~12 lines, causing the section descriptions to falsely describe content at the wrong locations.
- The Part VIII Summary section (containing the `erdos_99_summary` theorem) was missing entirely.

## Evidence

The `proofs/Proofs/Erdos99Problem.lean` file has Part headers at:

| Part | Lean line | meta startLine (before) | meta startLine (after) |
|------|-----------|------------------------|-----------------------|
| IV   Triangular Lattice    |  98 |  98 |  98 |
| V    Thue's Theorem        | 117 | 129 | 117 |
| VI   Small Cases           | 125 | 142 | 125 |
| VII  Main Conjecture       | 137 | 158 | 137 |
| VIII Summary               | 165 |  —  | 165 |

Concrete misclaims under the old ranges:

- `thue-theorem` (lines 129–141) claimed "no Lean declaration", but the `case_n4_no_equilateral` axiom (line 133) was inside that range.
- `small-cases` (lines 142–157) claimed `case_n4_no_equilateral axiom (only)`, but that axiom is at line 133 and the 142–157 range actually contains `Erdos99Conjecture` (144), `StrongerConjecture` (153), and `triangularPackingDensity` (162).

## Fix

Re-aligned section ranges to the Part headers and added a Summary section for Part VIII.

## Test plan

- [x] All sections cover contiguous, non-overlapping line ranges (39-179).
- [x] Section descriptions match the declarations in their stated line ranges.
- [x] No Lean source changes.

Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)