### PR TITLE
fix(erdos-638): correct badge from axiom to wip

### DIFF
--- a/src/data/proofs/erdos-638/meta.json
+++ b/src/data/proofs/erdos-638/meta.json
@@ -15,7 +15,7 @@
       "infinite combinatorics",
       "cardinals"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 0,
     "erdosNumber": 638,
     "erdosUrl": "https://erdosproblems.com/638",


### PR DESCRIPTION
## Fix

Corrects `badge: "axiom"` → `badge: "wip"` for erdos-638.

## Evidence

**Before**: `badge: "axiom"` — implies the proof relies on axiom declarations
**After**: `badge: "wip"` — accurately reflects an open conjecture with 0 axioms and 0 sorries

The Lean file (`Proofs/Erdos638Problem.lean`) has:
- 0 `axiom` declarations
- 0 sorries
- All supporting theorems fully machine-checked (classical Ramsey triangle theorem, monotonicity, base case, inductive step)
- The main open conjecture stated as a `def … : Prop`, not as an axiom

Scanning all 200+ other `status: axiomatized` entries with `axiomCount: 0` and `sorries: 0`, every single one uses `badge: "wip"`. This entry was the sole outlier.

---
Automated fix by lean-mechanic agent.