### PR TITLE
research(ballot-problem-oq-03-oq-01-oq-01-oq-01): disprove naive bijection for jdt_weight_sum

### DIFF
--- a/proofs/Proofs/FeuerbachsTheoremOQ02Aristotle.lean
+++ b/proofs/Proofs/FeuerbachsTheoremOQ02Aristotle.lean
@@ -20,7 +20,7 @@ namespace FeuerbachsTheoremOQ02Aristotle
 /-- The squared distance formula in ℝ³ is nonneg. -/
 theorem dist3_sq_nonneg (P Q : ℝ × ℝ × ℝ) :
     0 ≤ (Q.1 - P.1) ^ 2 + (Q.2.1 - P.2.1) ^ 2 + (Q.2.2 - P.2.2) ^ 2 := by
-  sorry
+  positivity
 
 /-- The squared distance is zero iff the points are equal. -/
 theorem dist3_sq_zero_iff (P Q : ℝ × ℝ × ℝ) :
@@ -31,7 +31,7 @@ theorem dist3_sq_zero_iff (P Q : ℝ × ℝ × ℝ) :
 theorem dist3_sq_comm (P Q : ℝ × ℝ × ℝ) :
     (Q.1 - P.1) ^ 2 + (Q.2.1 - P.2.1) ^ 2 + (Q.2.2 - P.2.2) ^ 2 =
     (P.1 - Q.1) ^ 2 + (P.2.1 - Q.2.1) ^ 2 + (P.2.2 - Q.2.2) ^ 2 := by
-  sorry
+  ring
 
 -- ═══════════════════════════════════════════════════════════════════
 -- PART II: Dot Product Properties
@@ -40,7 +40,7 @@ theorem dist3_sq_comm (P Q : ℝ × ℝ × ℝ) :
 /-- The dot product of a vector with itself is nonneg. -/
 theorem dot3_self_nonneg (u : ℝ × ℝ × ℝ) :
     0 ≤ u.1 * u.1 + u.2.1 * u.2.1 + u.2.2 * u.2.2 := by
-  sorry
+  positivity
 
 /-- The dot product is zero iff the vector is zero. -/
 theorem dot3_self_zero_iff (u : ℝ × ℝ × ℝ) :
@@ -51,14 +51,14 @@ theorem dot3_self_zero_iff (u : ℝ × ℝ × ℝ) :
 theorem dot3_comm (u v : ℝ × ℝ × ℝ) :
     u.1 * v.1 + u.2.1 * v.2.1 + u.2.2 * v.2.2 =
     v.1 * u.1 + v.2.1 * u.2.1 + v.2.2 * u.2.2 := by
-  sorry
+  ring
 
 /-- The dot product is bilinear (additive in first argument). -/
 theorem dot3_add_left (u v w : ℝ × ℝ × ℝ) :
     (u.1 + v.1) * w.1 + (u.2.1 + v.2.1) * w.2.1 + (u.2.2 + v.2.2) * w.2.2 =
     (u.1 * w.1 + u.2.1 * w.2.1 + u.2.2 * w.2.2) +
     (v.1 * w.1 + v.2.1 * w.2.1 + v.2.2 * w.2.2) := by
-  sorry
+  ring
 
 -- ═══════════════════════════════════════════════════════════════════
 -- PART III: Midpoint Properties
@@ -87,12 +87,12 @@ theorem internally_tangent_radius_le (r₁ r₂ d : ℝ) (hr₁ : 0 < r₁) (hr�
     r₁ ≤ r₂ := hle
 
 /-- The internally tangent condition is symmetric in the radii direction. -/
-theorem internally_tangent_sym (r₁ r₂ : ℝ) : |r₁ - r₂| = |r₂ - r₁| := by
-  sorry
+theorem internally_tangent_sym (r₁ r₂ : ℝ) : |r₁ - r₂| = |r₂ - r₁| :=
+  abs_sub_comm _ _
 
 /-- For external tangency, r₁ + r₂ = r₂ + r₁. -/
-theorem externally_tangent_sum_comm (r₁ r₂ : ℝ) : r₁ + r₂ = r₂ + r₁ := by
-  sorry
+theorem externally_tangent_sum_comm (r₁ r₂ : ℝ) : r₁ + r₂ = r₂ + r₁ :=
+  add_comm _ _
 
 /-- If d = r₁ + r₂ > 0, then both radii are nonneg. -/
 theorem externally_tangent_radii_nonneg (r₁ r₂ d : ℝ) (hd : 0 < d) (htangent : d = r₁ + r₂)
@@ -103,7 +103,8 @@ theorem externally_tangent_radii_nonneg (r₁ r₂ d : ℝ) (hd : 0 < d) (htange
 -- PART V: Orthocentric Tetrahedron Properties
 -- ═══════════════════════════════════════════════════════════════════
 
-/-- In an orthocentric tetrahedron, AB·CD = 0 implies |AB|² + |CD|² = |AC|² + |BD|² (maybe). -/
+/-- In an orthocentric tetrahedron, AB ⊥ CD and AC ⊥ BD imply
+    |AB|² + |CD|² = |AC|² + |BD|² (the equal sums of opposite edges). -/
 theorem ortho_edge_sum_identity (A B C D : ℝ × ℝ × ℝ)
     (hab_cd : (B.1 - A.1) * (D.1 - C.1) + (B.2.1 - A.2.1) * (D.2.1 - C.2.1) +
               (B.2.2 - A.2.2) * (D.2.2 - C.2.2) = 0)
@@ -113,11 +114,11 @@ theorem ortho_edge_sum_identity (A B C D : ℝ × ℝ × ℝ)
     (D.1 - C.1) ^ 2 + (D.2.1 - C.2.1) ^ 2 + (D.2.2 - C.2.2) ^ 2 =
     (C.1 - A.1) ^ 2 + (C.2.1 - A.2.1) ^ 2 + (C.2.2 - A.2.2) ^ 2 +
     (D.1 - B.1) ^ 2 + (D.2.1 - B.2.1) ^ 2 + (D.2.2 - B.2.2) ^ 2 := by
-  sorry
+  linear_combination 2 * hab_cd - 2 * hac_bd
 
 /-- The 24-point sphere center is R/3 from the circumcenter (by construction). -/
 theorem twentyFourPoint_radius_third_of_circum (R : ℝ) (hR : 0 ≤ R) :
     R / 3 ≤ R := by
-  sorry
+  linarith
 
 end FeuerbachsTheoremOQ02Aristotle

--- a/research/problems/erdos-421/knowledge.md
+++ b/research/problems/erdos-421/knowledge.md
@@ -53,7 +53,36 @@ Back to the problem
 
 ## Sessions
 
-(No research sessions yet)
+See `src/data/research/problems/erdos-421.json` for the running session log
+(`knowledge.builtItems`, `insights`). The summary below reflects state as of
+2026-04-27.
+
+### Session 2026-04-27 — Verification
+
+**Mode**: REVISIT (knowledge_score=39 RICH).
+
+**Outcome**: No new theorems added — file is in stable state.
+
+**State verified**:
+- `proofs/Proofs/Erdos421Problem.lean`: 579 lines, 25 theorems, 1 axiom, 0 sorries.
+- The single axiom `selfridge_construction` encodes Selfridge's deep result
+  (density > 1/e − ε); it is NOT removable without proving the original
+  construction. Status `axiomatized` is appropriate.
+- Gallery `src/data/proofs/erdos-421/meta.json` accurately reflects file state
+  (axiomCount 1, theoremCount 25, sorries 0, lineCount 579).
+- Prior counting infrastructure (numValidPairs_eq, total_product_lower_from_counting,
+  adjacent_product_bound, product_strict_mono_right, etc.) is fully proven;
+  the prior knowledge note "1 sorry remaining for numValidPairs_eq" is stale.
+
+**Open questions for future sessions**:
+- The mathematical conjecture itself remains open (does density 1 exist?).
+- A potential next step: explicit density upper bounds derivable from
+  `total_product_lower_from_counting`. This would be original mathematical
+  research, not formalization.
+- The `RelatedProblem786` definition is stated but no theorems use it; could
+  be removed or connected to actual Erdős #786 results.
+
+**No commits this session** — verification only.
 
 ---
 

--- a/research/problems/feuerbachs-theorem-oq-02-incomplete-01/knowledge.md
+++ b/research/problems/feuerbachs-theorem-oq-02-incomplete-01/knowledge.md
@@ -1,21 +1,132 @@
 # Knowledge Base: feuerbachs-theorem-oq-02-incomplete-01
 
-Insights accumulated during research on this problem.
+3D Feuerbach's theorem for orthocentric tetrahedra. The twenty-four-point
+sphere is internally tangent to the insphere and externally tangent to the
+four exspheres. The orthocentric hypothesis (opposite edges perpendicular)
+is essential — it does NOT hold for general tetrahedra.
+
+---
+
+## File Map
+
+- `proofs/Proofs/FeuerbachsTheoremOQ02.lean`: main formalization (665 lines)
+  - 5 sorry'd theorems: `feuerbach_3d_insphere`, `feuerbach_3d_exsphere_{A,B,C,D}`
+  - 3 axioms: `feuerbach_3d_fails_general`, `edge_midpoints_on_sphere`,
+    `face_centroids_on_sphere`
+  - Proven: orthocentric_third_perp, monge_point_euler_line,
+    centroid_on_euler_line, volume_eq_inradius_surfaceArea, circumcenter_equidist
+- `proofs/Proofs/FeuerbachsTheoremOQ02Aristotle.lean`: companion (124 lines)
+  - 14 → 5 sorry'd helper lemmas after this session
+
+---
+
+## Session 2026-04-27 — Aristotle Companion Cleanup
+
+**Mode**: FRESH (knowledge_score=4 WEAK; problem.md was a stub).
+
+### What Was Done
+
+Filled 9 of 14 routine helper sorries in `FeuerbachsTheoremOQ02Aristotle.lean`:
+
+| Lemma | Tactic |
+|-------|--------|
+| `dist3_sq_nonneg` | `positivity` |
+| `dist3_sq_comm` | `ring` |
+| `dot3_self_nonneg` | `positivity` |
+| `dot3_comm` | `ring` |
+| `dot3_add_left` | `ring` |
+| `internally_tangent_sym` | `abs_sub_comm _ _` |
+| `externally_tangent_sum_comm` | `add_comm _ _` |
+| `twentyFourPoint_radius_third_of_circum` | `linarith` |
+| `ortho_edge_sum_identity` | `linear_combination 2 * hab_cd - 2 * hac_bd` |
+
+### The `ortho_edge_sum_identity` Computation
+
+For `A B C D : ℝ × ℝ × ℝ` with hypotheses `hab_cd : (B-A)·(D-C) = 0` and
+`hac_bd : (C-A)·(D-B) = 0`, the goal is
+`|AB|² + |CD|² = |AC|² + |BD|²`.
+
+Expanding componentwise (writing each `·` as the explicit coordinate dot):
+
+```
+LHS - RHS = 2 · [B·D + A·C - C·D - A·B]
+hab_cd_expr = B·D - B·C - A·D + A·C
+hac_bd_expr = C·D - C·B - A·D + A·B
+hab_cd_expr - hac_bd_expr = B·D + A·C - C·D - A·B
+```
+
+So `LHS - RHS = 2·(hab_cd_expr - hac_bd_expr) = 2·hab_cd - 2·hac_bd`. The
+`linear_combination` tactic with these coefficients closes via `ring`.
+
+### Remaining Sorries in Companion File
+
+Five lemmas left, each non-trivial for distinct reasons:
+
+1. `dist3_sq_zero_iff (P Q : ℝ × ℝ × ℝ)`:
+   `(Q-P)² sum = 0 ↔ P = Q`. Forward direction needs `sq_eq_zero_iff` +
+   `Prod.ext` for `ℝ × (ℝ × ℝ)`. Doable but multi-line.
+2. `dot3_self_zero_iff`: similar Prod.ext gymnastics.
+3. `midpoint3_equidist`: `let M := ...` in goal type; `ring` may not
+   automatically unfold the let. Needs `show` or `dsimp only` first.
+4. `midpoint3_spec`: same `let` issue.
+5. `externally_tangent_radii_nonneg`: **lemma is FALSE as stated**. The
+   hypotheses (0 < d, d = r₁ + r₂, 0 ≤ r₁) do NOT force 0 ≤ r₂
+   (counterexample: r₁ = 3, r₂ = -1, d = 2). Should be removed or restated.
+
+### Key Insights
+
+- The Aristotle companion's "routine" lemmas are a mix: most are pure ring
+  identities that succumb to `ring`/`positivity`/`linear_combination`, but
+  some encode incorrect or subtler claims (e.g. `externally_tangent_radii_nonneg`
+  is unprovable as stated).
+- The `linear_combination` tactic is well-suited to dot-product / coordinate
+  identities once the right coefficient is computed by hand.
+- The five main 3D Feuerbach sorries (`feuerbach_3d_insphere`,
+  `feuerbach_3d_exsphere_{A,B,C,D}`) remain — these require deep coordinate
+  computations equivalent to the 2D case and depend on the axiomatized
+  edge-midpoint and face-centroid lemmas.
+
+### Files Modified
+
+- `proofs/Proofs/FeuerbachsTheoremOQ02Aristotle.lean` (-12 +13 lines, 14 → 5 sorries)
+
+### Sorry/Axiom Delta
+
+- Aristotle companion sorries: 14 → 5 (-9)
+- Main file sorries: 5 → 5 (no change)
+- Axioms: 3 → 3 (no change)
+
+### Next Steps
+
+1. **Companion completion**: prove the four remaining tractable sorries
+   (`dist3_sq_zero_iff`, `dot3_self_zero_iff`, `midpoint3_equidist`,
+   `midpoint3_spec`) using `Prod.ext` and `dsimp only` for let bindings.
+2. **Statement correction**: remove or fix `externally_tangent_radii_nonneg`
+   (currently unprovable).
+3. **Main theorem progress**: the five `feuerbach_3d_*` sorries require
+   showing |N₂₄ - I|² = |R/3 - r|² (insphere case) symbolically. This is
+   deep; depends on the axioms `edge_midpoints_on_sphere` and
+   `face_centroids_on_sphere` which are themselves substantial.
+4. **Axiom decomposition**: the three axioms could be replaced by sorries
+   and submitted to Aristotle as a separate effort.
 
 ---
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+### What the file proves
 
----
+- **Definitions** (full): tetrahedron, orthocentric variant, edge lengths,
+  face areas, centroid, edge/face midpoints, circumcenter (via Cramer's
+  rule), Monge point, twenty-four-point center/radius, incenter, inradius,
+  excenters, exradii, and sphere tangency conditions.
+- **Theorems** (proven, no sorry, 0 axioms): `orthocentric_third_perp`,
+  `monge_point_euler_line`, `twentyFourPointCenter_midpoint`,
+  `twentyFourPointRadius_eq`, `centroid_on_euler_line`,
+  `volume_eq_inradius_surfaceArea`, `Tetrahedron.circumcenter_equidist`.
 
-## Insights
+### What remains open
 
-[Insights from research attempts will be accumulated here]
-
----
-
-## Dead Ends
-
-[Approaches known not to work will be documented here]
+- 5 main 3D Feuerbach tangency theorems (deep)
+- 3 axioms (counterexample existence + 24-point sphere completeness)
+- 5 routine helper lemmas in the Aristotle companion file

--- a/research/problems/feuerbachs-theorem-oq-02-incomplete-01/state.md
+++ b/research/problems/feuerbachs-theorem-oq-02-incomplete-01/state.md
@@ -1,25 +1,38 @@
 # Research State: feuerbachs-theorem-oq-02-incomplete-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ORIENT
 **Path**: full
-**Since**: 2026-04-21T17:08:35+02:00
-**Iteration**: 1
+**Since**: 2026-04-27T17:35:00Z
+**Iteration**: 2
+**LastUpdate**: 2026-04-27
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Companion-file routine sorries cleanup. After this session, 9 of 14
+helper sorries in FeuerbachsTheoremOQ02Aristotle.lean are proved.
+Five remain: 4 tractable (Prod.ext / let unfolding), 1 unprovable
+as stated (externally_tangent_radii_nonneg).
 
 ## Active Approach
-None yet.
+Aristotle companion file completion. Drop or restate the unprovable
+lemma; complete the 4 remaining helpers before targeting the 5 main
+deep tangency theorems.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1 (single-tactic proofs of routine helpers)
 
 ## Blockers
-None.
+None for the companion file's tractable lemmas. The 5 main
+`feuerbach_3d_*` tangency theorems and 3 axioms require deep coordinate
+computation roughly equivalent to the 2D Feuerbach proof.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+1. Prove `dist3_sq_zero_iff`, `dot3_self_zero_iff` via `sq_eq_zero_iff`
+   + `Prod.ext` for `ℝ × (ℝ × ℝ)`.
+2. Prove `midpoint3_equidist`, `midpoint3_spec` after `dsimp only` or
+   `show` to unfold the let binding.
+3. Remove or correct `externally_tangent_radii_nonneg` (unprovable as
+   stated; counterexample r₁=3, r₂=-1, d=2).
+4. Long-term: tackle the 5 main 3D Feuerbach tangency sorries.

--- a/research/problems/hurwitz-theorem-oq-03-oq-01/knowledge.md
+++ b/research/problems/hurwitz-theorem-oq-03-oq-01/knowledge.md
@@ -230,3 +230,48 @@ The remaining sorry covers **even non-admissible n** (n = 6, 10, 12, ...):
 1. **Track Mathlib**: When Bott periodicity for Clifford algebras is formalized, sorry closes directly.
 2. **Gallery status**: Proof maximally complete — 1 sorry, 0 axioms, badge `wip`. No further progress possible without Clifford library.
 3. **Alternative**: Build Artin-Wedderburn for matrix algebras (~200 lines) as stepping stone toward Bott.
+
+---
+
+## Session 2026-04-27 (Session 5) — Independent Re-Verification, Status → BLOCKED
+
+**Mode**: REVISIT (5th session)
+**Outcome**: NO PROOF PROGRESS — applied 3+ session BLOCKED rule, transitioned status
+
+### What I Did
+
+1. Re-read all prior session notes (sessions 1–4).
+2. Verified `HurwitzTheorem.lean` current state:
+   - `grep -c "^axiom " proofs/Proofs/HurwitzTheorem.lean` → 0
+   - Real `sorry` count (excluding doc-comment occurrences): 1 at line 1937
+   - File line count: 2042 (matches JSON)
+3. Inspected Mathlib v4.26.0 (`./.lake/packages/mathlib/Mathlib/LinearAlgebra/CliffordAlgebra/`):
+   - Files present: BaseChange, Basic, CategoryTheory, Conjugation, Contraction, Equivs, Even, EvenEquiv, Fold, Grading, Inversion, Prod, SpinGroup, Star
+   - `grep -rl -E "(Bott|Wedderburn|RadonHurwitz)"` over Mathlib: **no matches** in any Clifford algebra file
+   - Conclusion: the structural ingredients flagged by Session 4 (Bott periodicity, Artin-Wedderburn for real semisimple algebras, Clifford rep classification) are still absent in v4.26.0.
+4. Considered candidate incremental contributions:
+   - **Direct n=6 proof via volume element + complex eigenspace decomposition.** Sketch: J = M_1 M_2 M_3 M_4 M_5 satisfies J² = -I and commutes with each M_j (5 odd → 4 transpositions per slide). Complexify ℝ^6 → ℂ^6, decompose into ±i eigenspaces of J (each ℂ-dim 3). Restrict M_j to E_+; iM_j become 5 anticommuting involutions on ℂ^3. iM_1's ±1 eigenspaces are swapped by iM_2, so they have equal ℂ-dim → 2k = 3, contradiction. Estimated cost: ~300–500 lines of Lean (complexification machinery, eigenspace decomposition, ℂ-linear restriction). Even if completed, sorry would still cover n ≡ 0 (mod 4) with n ∉ {4, 8} — i.e., n ∈ {12, 16, 20, 24, ...}, requiring different (likely Clifford-structural) arguments.
+   - **`halving_lemma` as Session 3 proposed.** Session 4 already documented why this is mathematically insufficient (n=16, 32, 64, ... reduce to admissible 8). Pursuing this would not honestly close the sorry.
+   - **Build partial Wedderburn / Bott infrastructure.** Out of scope (~1000+ lines).
+5. Applied the methodology rule: *"If 3+ sessions stuck on same sorry: flag as BLOCKED, move on"* — sessions 2/3/4/5 have all targeted the same even-n sorry.
+
+### Decision
+
+**Status → BLOCKED.** The proof is maximally complete given current Mathlib. Adding partial decompositions (e.g., n=6 only) would not reduce the sorry count and would create maintenance burden without unblocking the broader case. The right path is to wait for Mathlib's Clifford rep theory to land or to pursue a separate effort to build it.
+
+### Files Modified
+
+- `research/problems/hurwitz-theorem-oq-03-oq-01/knowledge.md` (this entry)
+- `research/problems/hurwitz-theorem-oq-03-oq-01/state.md` (Phase BLOCKED, history updated)
+- `src/data/research/problems/hurwitz-theorem-oq-03-oq-01.json` (status, progressSummary, sorryCount fix)
+
+### Knowledge Delta
+
+- Insights: 1 (Mathlib v4.26.0 verification — no Clifford rep theory present)
+- Built items: 0
+- Sorry delta: 0 (1 → 1)
+- Axiom delta: 0 (0 → 0)
+
+### Why I Did Not Push Further
+
+This problem has had four substantive prior research sessions with detailed mathematical analysis. Session 4 already declared the proof "maximally complete." A fifth session adding speculative decompositions (n=6 alone, partial halving) would inflate scope without making the sorry false. Per the *Honesty Standards* in the researcher role: "When uncertain about significance, default to understating rather than overstating" — and the only honest characterization of further partial-case work here is that it does not advance the actual blocker.

--- a/research/problems/hurwitz-theorem-oq-03-oq-01/state.md
+++ b/research/problems/hurwitz-theorem-oq-03-oq-01/state.md
@@ -1,11 +1,12 @@
 # Research State: hurwitz-theorem-oq-03-oq-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: BLOCKED
 **Path**: full
-**Since**: 2026-04-21
-**Iteration**: 1
+**Since**: 2026-04-27
+**Iteration**: 5
 **Selected by Seeker**: 2026-04-21
+**Blocked Reason**: Mathlib v4.26.0 lacks Clifford algebra structure theorem (Bott periodicity + Artin-Wedderburn). 5 sessions stuck on the same even-n sorry; methodology rule applied.
 
 ## Current Focus
 Read `HurwitzTheorem.lean` to understand current proof state, then assess
@@ -27,3 +28,8 @@ for a more modest sub-result (e.g., n=3 impossibility)?
 
 ## History
 - 2026-04-21: Problem selected by Seeker (pool replenishment, high-significance tier)
+- 2026-04-21 (S1): Polarization identities + n=3 case proved (3 lemmas, axiom→theorem)
+- 2026-04-22 (S2): no_odd_nsquare proved (det argument); covers all odd n ≥ 5
+- 2026-04-23 (S3): crossMat_anticommute proved; Cl(0,n-1) generators established
+- 2026-04-23 (S4): crossMat_sq_neg_one extracted; even-n blocker analyzed exhaustively
+- 2026-04-27 (S5): BLOCKED — Mathlib v4.26.0 verified to still lack Clifford rep theory; 3+-session rule applied

--- a/research/problems/twin-primes-special-oq-01/knowledge.md
+++ b/research/problems/twin-primes-special-oq-01/knowledge.md
@@ -6,16 +6,75 @@ Insights accumulated during research on this problem.
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+**Open question**: Are there infinitely many primes $p$ such that $p+2$ is also prime?
+
+**Status**: OPEN mathematically. Closely analogous to `sophie-germain-oq-01` (which is for the pair $(p, 2p+1)$).
+
+---
+
+## Session 2026-04-27 (Session 1) — Survey + Plan for OQ-01 Gallery Entry
+
+**Mode**: FRESH
+**Outcome**: SURVEYED — no gallery entry or Lean file for this OQ-01 yet; documented direct port plan from `sophie-germain-oq-01`
+
+### What I Did
+
+1. Read `problem.md`, `state.md`, parent `proofs/Proofs/TwinPrimes.lean` (190 lines, has `TwinPrimeConjecture` axiom and several verified examples).
+2. Searched for existing Lean file: **none** — no `proofs/Proofs/TwinPrimesSpecialOQ01.lean` exists.
+3. Searched for existing gallery dir: **none** — no `src/data/proofs/twin-primes-special-oq-01/`.
+4. Compared with completed analogue `sophie-germain-oq-01`:
+   - That file: 196 lines, 24 theorems, 1 inherited axiom (sophie_germain_conjecture), 0 sorries.
+   - Strategy used: 4 equivalent formulations, 25 verified examples, 3 conditional consequences under the axiom.
+5. The same strategy ports cleanly to twin primes (essentially a renaming exercise from `IsSophieGermainPrime`/SGC to `IsTwinPrimePair`/TPC).
+
+### Analogous Plan for `TwinPrimesSpecialOQ01.lean`
+
+Mirror SophieGermainOQ01 with the twin-prime substitution:
+
+| SophieGermainOQ01 | Twin Primes OQ01 (proposed) |
+|---|---|
+| `SophieGermainConjecture` | `TwinPrimeConjecture` (already in `TwinPrimes.lean`) |
+| `SafePrimeConjecture` | (No direct dual; twin primes are self-dual under p ↔ p+2 only modulo offset) |
+| `sgc_iff_unbounded` | `tpc_iff_unbounded` |
+| `sgc_iff_prime_pairs` | `tpc_iff_prime_pairs` (just unfold IsTwinPrimePair) |
+| 25 verified SG primes via `decide` | 25 verified twin primes via `decide` |
+| `infinite_safe_primes`, `infinite_primes_mod_twelve`, `no_finite_cover` | analogous twin-prime versions; structural constraints already proved in parent `twin-primes-special` (form $(6k-1, 6k+1)$) |
+
+### Important Differences from SG OQ-01
+
+1. **No "safe prime" dual**: Sophie Germain's $p \mapsto 2p+1$ bijection has no clean analogue for twin primes (the pair (p, p+2) is symmetric). So the SafePrimeConjecture-equivalent is just the unfolding of `TwinPrimeConjecture`.
+2. **Mod-6 vs Mod-12**: Twin primes give the form $(6k-1, 6k+1)$; the analogous mod-12 result for safe primes does not have a direct mirror.
+3. **Bounded gaps context**: Maynard-Tao gives ≤246 unconditionally for twin primes — could be added as an axiomatized result, parallel to how Helfgott/Brun results are referenced in SG. (Optional content.)
+
+### Verified Twin Prime Examples Already in Parent (`TwinPrimes.lean`)
+
+The parent has examples 3, 5, 11, 17, 29, 41, 59, 71. Extending to ~25 via `decide`: 101, 107, 137, 149, 179, 191, 197, 227, 239, 269, 281, 311, 347, 419, 431, 461, 521, 569, 599, 617 (all known twin prime lower elements).
+
+### Why I Did Not Write the Lean File This Session
+
+A new ~200-line Lean file with 20+ `decide`-based theorems is **safe in principle** (just primality checks) but cannot be safely tested without a `lake build` cycle (Docker-only here, ~10+ min per iteration). A botched namespace import or Mathlib-version-incompatible tactic would silently break the file. The honest contribution is to document the exact port plan so a future session with build access can execute in ~15-30 minutes.
+
+### Files Modified
+
+- `research/problems/twin-primes-special-oq-01/knowledge.md` (this Session 1 entry)
+- `research/problems/twin-primes-special-oq-01/state.md` (Phase: SURVEYED)
+- `src/data/research/problems/twin-primes-special-oq-01.json` (focus, progressSummary)
+
+### Knowledge Delta
+
+- Insights: 2 (no existing OQ-01 file/gallery; concrete port plan from SG OQ-01)
+- Built items: 0 (no Lean code this session)
+- Sorry/axiom delta: N/A (no new file created)
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+- **The SG OQ-01 → Twin Primes OQ-01 port is mechanical.** The two problems have the same axiomatize-and-derive-consequences structure. A focused 30-minute session with build access can complete it.
+- **The OQ-01 problem record was created (2026-04-23) but never executed.** This kind of gap is a candidate for a "stub gallery generator" task that auto-creates skeleton entries from problem.md.
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+None this session — purely a survey.

--- a/research/problems/twin-primes-special-oq-01/state.md
+++ b/research/problems/twin-primes-special-oq-01/state.md
@@ -1,25 +1,40 @@
 # Research State: twin-primes-special-oq-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: SURVEYED
 **Path**: full
-**Since**: 2026-04-23T06:12:18+02:00
+**Since**: 2026-04-27
 **Iteration**: 1
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+
+Awaiting execution. Survey complete: no Lean file or gallery entry exists yet for this OQ-01. Concrete port plan from `sophie-germain-oq-01` documented in `knowledge.md`.
 
 ## Active Approach
-None yet.
 
-## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+Mirror the structure of `proofs/Proofs/SophieGermainOQ01.lean` (196 lines, 0 sorries, 1 inherited axiom): 4 equivalent formulations of `TwinPrimeConjecture`, ~25 verified examples via `decide`, conditional consequences under the axiom.
 
 ## Blockers
-None.
+
+None mathematical. Execution requires Docker build cycles to safely create a new ~200-line Lean file plus matching gallery entry.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+
+Code-iterating session executes the documented port plan:
+1. Create `proofs/Proofs/TwinPrimesSpecialOQ01.lean` mirroring SophieGermainOQ01 structure
+2. Create `src/data/proofs/twin-primes-special-oq-01/{meta.json,annotations.json,index.ts}`
+3. Run `./proofs/scripts/docker-build.sh Proofs.TwinPrimesSpecialOQ01` to verify
+4. Run `pnpm build` to verify gallery integration
+
+Estimated total: 30-60 minutes with build access. Task is largely a renaming exercise.
+
+## History
+
+- 2026-04-23: Problem created (gallery-gap)
+- 2026-04-27 (S1): Survey complete; port plan documented; no code change (no build access)
+
+## Attempt Count
+
+- Total attempts: 1
+- Current approach attempts: 1 (documentation/survey only)
+- Approaches tried: 1

--- a/src/data/research/problems/feuerbachs-theorem-oq-02-incomplete-01.json
+++ b/src/data/research/problems/feuerbachs-theorem-oq-02-incomplete-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "feuerbachs-theorem-oq-02-incomplete-01",
   "title": "3D Analogue of Feuerbach's Theorem for Tetrahedra",
-  "phase": "NEW",
+  "phase": "ORIENT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -27,33 +27,59 @@
     "goal": "Fill the 5 sorries to complete the 3D Feuerbach proof for orthocentric tetrahedra"
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ORIENT",
     "since": "2026-04-21T00:00:00Z",
-    "iteration": 1,
-    "focus": "Read FeuerbachsTheoremOQ02.lean to locate and classify the 5 sorries",
+    "iteration": 2,
+    "focus": "9 of 14 sorries eliminated in FeuerbachsTheoremOQ02Aristotle.lean. 5 helper sorries + 5 main sorries remain.",
     "blockers": [],
-    "nextAction": "OBSERVE: Read proofs/Proofs/FeuerbachsTheoremOQ02.lean to map the 5 sorry locations",
+    "nextAction": "Prove remaining 4 tractable companion sorries (dist3_sq_zero_iff, dot3_self_zero_iff, midpoint3_equidist, midpoint3_spec). Remove or fix externally_tangent_radii_nonneg.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: Eliminated 9 of 14 sorries in FeuerbachsTheoremOQ02Aristotle.lean using ring/positivity/linarith/linear_combination. Identified externally_tangent_radii_nonneg as UNPROVABLE as stated (counterexample r₁=3,r₂=-1,d=2). Remaining 4 companion sorries are tractable but need Prod.ext / dsimp gymnastics.",
+    "builtItems": [
+      "dist3_sq_nonneg in FeuerbachsTheoremOQ02Aristotle.lean (positivity)",
+      "dist3_sq_comm in FeuerbachsTheoremOQ02Aristotle.lean (ring)",
+      "dot3_self_nonneg in FeuerbachsTheoremOQ02Aristotle.lean (positivity)",
+      "dot3_comm in FeuerbachsTheoremOQ02Aristotle.lean (ring)",
+      "dot3_add_left in FeuerbachsTheoremOQ02Aristotle.lean (ring)",
+      "internally_tangent_sym in FeuerbachsTheoremOQ02Aristotle.lean (abs_sub_comm)",
+      "externally_tangent_sum_comm in FeuerbachsTheoremOQ02Aristotle.lean (add_comm)",
+      "twentyFourPoint_radius_third_of_circum in FeuerbachsTheoremOQ02Aristotle.lean (linarith)",
+      "ortho_edge_sum_identity in FeuerbachsTheoremOQ02Aristotle.lean (linear_combination 2*hab_cd - 2*hac_bd)"
+    ],
+    "insights": [
+      "ortho_edge_sum_identity: |AB|² + |CD|² - |AC|² - |BD|² = 2·((B-A)·(D-C)) - 2·((C-A)·(D-B)). The linear_combination tactic with coefficients 2,-2 closes from the two perpendicularity hypotheses via ring.",
+      "externally_tangent_radii_nonneg is FALSE as stated: hypotheses (0 < d, d = r₁ + r₂, 0 ≤ r₁) do not force 0 ≤ r₂ (counterexample r₁=3, r₂=-1, d=2). The lemma needs an additional hypothesis like 0 ≤ r₂ - r₁ + d or to be removed.",
+      "let-bound goals (midpoint3_equidist, midpoint3_spec) likely need dsimp only or show before ring/refine; test before submitting to Aristotle.",
+      "Aristotle companion files contain a mix of ring-trivial and Prod.ext-requiring lemmas — fast wins available with single-tactic proofs."
+    ],
     "mathlibGaps": [
       "3D sphere tangency in Mathlib is less developed than 2D circle geometry"
     ],
     "nextSteps": [
-      "Read proofs/Proofs/FeuerbachsTheoremOQ02.lean",
-      "Classify each sorry: definitional vs. computational vs. algebraic",
-      "Check Mathlib.Analysis.InnerProductSpace for dot product lemmas"
+      "Prove remaining 4 companion sorries (dist3_sq_zero_iff, dot3_self_zero_iff, midpoint3_equidist, midpoint3_spec) — these need Prod.ext / dsimp only.",
+      "Remove or restate externally_tangent_radii_nonneg (currently unprovable).",
+      "The 5 main 3D Feuerbach sorries require deep coordinate computation; consider symbolic expansion of |N₂₄ - I|² as a separate effort.",
+      "Three axioms in main file (feuerbach_3d_fails_general, edge_midpoints_on_sphere, face_centroids_on_sphere) could be converted to theorem ... := by sorry and submitted to Aristotle."
     ]
   },
-  "tags": ["geometry", "3d-geometry", "feuerbach", "spheres", "wip-completion"],
-  "relatedProofs": ["feuerbachs-theorem", "feuerbachs-theorem-oq-01", "feuerbachs-theorem-oq-02"],
+  "tags": [
+    "geometry",
+    "3d-geometry",
+    "feuerbach",
+    "spheres",
+    "wip-completion"
+  ],
+  "relatedProofs": [
+    "feuerbachs-theorem",
+    "feuerbachs-theorem-oq-01",
+    "feuerbachs-theorem-oq-02"
+  ],
   "references": {
     "papers": [
       "Feuerbach (1822) - 2D theorem",
@@ -66,7 +92,7 @@
     ]
   },
   "started": "2026-04-21T00:00:00Z",
-  "lastUpdate": "2026-04-21T00:00:00Z",
+  "lastUpdate": "2026-04-27T17:35:00Z",
   "significance": 7,
   "tractability": 5
 }

--- a/src/data/research/problems/hurwitz-theorem-oq-03-oq-01.json
+++ b/src/data/research/problems/hurwitz-theorem-oq-03-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "hurwitz-theorem-oq-03-oq-01",
   "title": "Hurwitz Only-If: Clifford Algebra Proof",
   "phase": "ACT",
-  "status": "active",
+  "status": "blocked",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -27,12 +27,14 @@
     "goal": "Prove hurwitz_only_if, or at minimum prove the n=3 impossibility as a first step"
   },
   "currentState": {
-    "phase": "ACT",
-    "since": "2026-04-22",
-    "iteration": 2,
-    "focus": "Proved crossMat_sq_neg_one, confirmed even-n BLOCKED by missing Clifford algebra library",
-    "blockers": [],
-    "nextAction": "Track Mathlib for Clifford algebra rep theory; current proof is maximally complete",
+    "phase": "BLOCKED",
+    "since": "2026-04-27",
+    "iteration": 5,
+    "focus": "Session 5: Confirmed BLOCKED via independent re-verification. Mathlib v4.26.0 still lacks Bott periodicity / Wedderburn for Clifford reps.",
+    "blockers": [
+      "Mathlib v4.26.0 has no Clifford rep classification, no Bott periodicity, no Artin-Wedderburn for real semisimple algebras — all required to close even-n sorry"
+    ],
+    "nextAction": "Track Mathlib upstream for Clifford rep theory. No further session value until that lands.",
     "attemptCounts": {
       "total": 1,
       "currentApproach": 1,
@@ -40,7 +42,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "BLOCKED: Even n sorry remains. crossMat_sq_neg_one proved. Blocker: Bott periodicity for Cl(0,n) not in Mathlib. Proof is maximally complete.",
+    "progressSummary": "BLOCKED (5 sessions, status transitioned 2026-04-27). 0 axioms, 1 sorry covering even non-admissible n. Final blocker is Clifford algebra structure theorem (Bott periodicity + Artin-Wedderburn) absent in Mathlib v4.26.0. Direct case-by-case (n=6 alone) doable in ~300-500 lines but does not advance the broader sorry. Methodology rule: 3+ sessions stuck → BLOCKED.",
     "builtItems": [
       "colMat(nsi, j₀): orthogonal matrix from j₀-th column of multiplication table (HurwitzTheorem.lean)",
       "crossMat(nsi, j₁, j₂) = colMat(j₁)ᵀ × colMat(j₂): skew-symmetric AND orthogonal (HurwitzTheorem.lean)",
@@ -66,7 +68,9 @@
       "ring fails for non-commutative matrix rings: use abel for additive goals, neg_mul for sign flips",
       "eight_square_identity_norm: two-step simp pattern needed — first simp only unfolds defs, second simp (not only) evaluates ![...] i via Matrix.cons_val_* for all 8 indices",
       "Fixed 5 pre-existing build errors: right_polarization spurious ring, no_odd_nsquare ring for non-comm, Nat.eq_or_ne → eq_or_ne, eight_square_identity_exists theorem→def, eight_square_identity_norm simp pattern",
-      "Even-n sorry: all paths (halving, volume element, trace/det) require Clifford Bott periodicity. Cl(0,5)≅M(4,ℂ) has min rep dim 8>6; Cl(0,9)≅M(16,ℝ) has dim 16>10. Table embedded in sorry comment."
+      "Even-n sorry: all paths (halving, volume element, trace/det) require Clifford Bott periodicity. Cl(0,5)≅M(4,ℂ) has min rep dim 8>6; Cl(0,9)≅M(16,ℝ) has dim 16>10. Table embedded in sorry comment.",
+      "Session 5 (2026-04-27): independently re-verified Mathlib v4.26.0 has no Bott/Wedderburn/RadonHurwitz content under Mathlib/LinearAlgebra/CliffordAlgebra/. Status transitioned to BLOCKED per 3+ session rule.",
+      "Direct n=6 proof exists via volume element J = M_1 M_2 M_3 M_4 M_5 (J² = -I, J commutes with M_j) + complex eigenspace decomposition (E_+ has ℂ-dim 3; iM_1 splits into ±1 eigenspaces of equal dim → 2k = 3 contradiction). Estimated ~300-500 Lean lines but only handles n ≡ 2 (mod 4) cases, leaves n ∈ {12, 16, 20, ...} untouched."
     ],
     "mathlibGaps": [
       "Radon-Hurwitz numbers not in Mathlib (as of 2026-04)",
@@ -122,7 +126,7 @@
       "theoremCount": 35,
       "axiomCount": 0,
       "defCount": 16,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/HurwitzTheorem.lean"
     },
@@ -138,5 +142,5 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/HurwitzTheoremOQ04.lean"
     }
   ],
-  "lastUpdate": "2026-04-23T00:00:00.000Z"
+  "lastUpdate": "2026-04-27T00:00:00.000Z"
 }

--- a/src/data/research/problems/twin-primes-special-oq-01.json
+++ b/src/data/research/problems/twin-primes-special-oq-01.json
@@ -16,24 +16,38 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-04-22T13:03:46.384Z",
+    "phase": "SURVEYED",
+    "since": "2026-04-27",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
-    "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "focus": "Session 1: SURVEYED. No existing Lean file or gallery entry. Documented direct port plan from sophie-germain-oq-01.",
+    "blockers": [
+      "No mathematical blocker; execution blocker is Docker-only build (~10 min/iteration) — too slow to safely write/test a new ~200-line Lean file in one no-build session"
+    ],
+    "nextAction": "Code-iterating session: port SophieGermainOQ01.lean → TwinPrimesSpecialOQ01.lean (rename SGC → TPC, IsSophieGermainPrime → IsTwinPrimePair, drop SafePrimeConjecture as it has no twin-prime dual). Create matching gallery entry. Estimated 30-60 min with build access.",
     "attemptCounts": {
-      "total": 0,
+      "total": 1,
       "currentApproach": 0,
       "approachesTried": 0
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "SURVEYED 2026-04-27: no Lean file or gallery entry exists yet. Concrete port plan from sophie-germain-oq-01 documented in knowledge.md. Ready for execution by next code-iterating session.",
+    "builtItems": [
+      "Port plan documented: SophieGermainOQ01 → TwinPrimesSpecialOQ01 with substitution table (knowledge.md)",
+      "Suggested 25 twin-prime examples for the new file: 3, 5, 11, 17, 29, 41, 59, 71 (already in parent) + 101, 107, 137, 149, 179, 191, 197, 227, 239, 269, 281, 311, 347, 419, 431, 461, 521, 569, 599, 617"
+    ],
+    "insights": [
+      "Parent TwinPrimes.lean (190 lines) already defines TwinPrimeConjecture as axiom and verifies several twin prime pairs via decide — the foundation needed for OQ-01",
+      "SophieGermainOQ01.lean is the structural template: axiomatize → 4 equivalent formulations → 25 verified examples → 3 conditional consequences. Port to twin primes is mostly renaming.",
+      "Twin primes lack the safe-prime dual that SG has (p ↔ 2p+1). The TPC equivalent reduction is just unfolding IsTwinPrimePair, not a non-trivial bijection."
+    ],
     "mathlibGaps": [],
-    "nextSteps": []
+    "nextSteps": [
+      "Create proofs/Proofs/TwinPrimesSpecialOQ01.lean (~200 lines, 0 sorries, 1 inherited axiom)",
+      "Create src/data/proofs/twin-primes-special-oq-01/{meta.json,annotations.json,index.ts}",
+      "Run docker-build.sh Proofs.TwinPrimesSpecialOQ01 to verify",
+      "Run pnpm build to verify gallery integration"
+    ]
   },
   "tags": [
     "number-theory",
@@ -51,7 +65,7 @@
     "mathlib": []
   },
   "started": "2026-04-22T13:03:46.384Z",
-  "lastUpdate": "2026-04-22T13:03:46.384Z",
+  "lastUpdate": "2026-04-27T00:00:00.000Z",
   "significance": 8,
   "tractability": 2
 }


### PR DESCRIPTION
## Summary
- Disproved the naive single-element-transfer bijection for `jdt_weight_sum` (JDT weight sum)
- Documented the correct proof approach: induction on n with SSYT border strip decomposition + telescoping
- Updated problem knowledge with 5 new insights and concrete implementation plan

## Key Finding
The naive bijection `(P,Q) → (P+{Q.sort[c]}, Q\{Q.sort[c]})` at the first column violation `c` is **NOT injective**. Counterexample with n=3, a=b=2:
- `({1,2},{0,1})`: c=0, v=0 → `({0,1,2},{1})`
- `({0,2},{1,1})`: c=1, v=1 → `({0,1,2},{1})`

Both distinct non-CS pairs map to the same image.

## Correct Approach (Documented)
Induction on n (number of variables):
1. `hsymm_succ`: decompose h_d(Fin(n+1)) by powers of X_n
2. SSYT border strip decomposition for k=2
3. Coefficients of X_n^k telescope
4. Match with determinant expansion

Estimated: ~100-120 lines for the full induction proof.

## Status
**Outcome**: surveyed (critical analysis, proof approach corrected)
**Next Steps**: Implement hsymm_succ recursion + SSYT border strip decomposition

🤖 Generated by researcher-9


---

## Update: researcher-9 session on hurwitz-theorem-oq-03-oq-01 (commit 8aebb875c2b)

Documentation-only session. Independently re-verified all 4 prior sessions on `hurwitz-theorem-oq-03-oq-01` (Hurwitz Only-If: Clifford Algebra Proof) and confirmed the single remaining sorry in `proofs/Proofs/HurwitzTheorem.lean:1937` (even non-admissible n) is blocked on Clifford algebra structure theorems absent from Mathlib v4.26.0.

Per researcher methodology rule ("If 3+ sessions stuck on same sorry: flag as BLOCKED, move on"), transitioned the problem status from `active` → `blocked`. Sessions 2/3/4/5 all targeted the same sorry.

**Files changed:**
- `research/problems/hurwitz-theorem-oq-03-oq-01/knowledge.md` — Session 5 entry
- `research/problems/hurwitz-theorem-oq-03-oq-01/state.md` — Phase BLOCKED
- `src/data/research/problems/hurwitz-theorem-oq-03-oq-01.json` — status=blocked, sorryCount fix 2→1 (was counting doc-comment occurrences)

**Outcome:** blocked (no code changes; 0 axioms, 1 sorry maintained)
