### PR TITLE
fix(hurwitz-theorem-oq-04): sync sorries 2→1, lineCount 1053→1094

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11350,9 +11350,9 @@
       "result": "clean"
     },
     "hurwitz-theorem-oq-04": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-26T19:41:48Z",
+      "lastAudited": "2026-04-27T11:16:51Z",
       "result": "issues-fixed"
     },
     "inclusion-exclusion": {

--- a/src/data/proofs/hurwitz-theorem-oq-04/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-04/meta.json
@@ -18,11 +18,11 @@
       "advanced"
     ],
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 1,
     "dateAdded": "2026-04-24",
     "axiomCount": 0,
-    "assumptions": "2 sorries in G2_der_dimension proof chain: (1) derEval14_injective — extracting basis vector agreement from evaluation equality (~50 lines of Leibniz constraint applications), (2) derBasis14_linearIndependent — showing 14×14 evaluation matrix has nonzero determinant. The Aut(𝕆) ⊆ O(7) portion is fully proved with 0 sorries.",
-    "lineCount": 1053,
+    "assumptions": "1 sorry in G2_der_dimension proof chain: derEval14_injective — extracting basis vector agreement from evaluation equality (~50 lines of Leibniz constraint applications). The companion lemma derBasis14_linearIndependent (14×14 evaluation matrix linear independence) was proved in PR #13121 via Fin 14 case analysis with nlinarith on the 7 independent 2×2 blocks. The Aut(𝕆) ⊆ O(7) portion is fully proved with 0 sorries.",
+    "lineCount": 1094,
     "theoremCount": 35,
     "definitionCount": 17,
     "originalContributions": [
@@ -41,7 +41,7 @@
   "overview": {
     "historicalContext": "Hurwitz's theorem (1898) establishes that normed division algebras over ℝ exist only in dimensions 1, 2, 4, and 8 — corresponding to ℝ, ℂ, ℍ, and 𝕆. This result has profound implications beyond algebra: the four normed division algebras are intimately connected to the five exceptional simple Lie algebras through the Freudenthal-Tits magic square (1954–1966). The connection was suspected by Élie Cartan as early as 1914, when he identified G₂ as the automorphism group of the octonions. Hans Freudenthal (1954) and Jacques Tits (1966) systematized this into a unified construction: from any two normed division algebras A, B, one builds a Lie algebra 𝔏(A, B) = Der(A) ⊕ (Im A ⊗ Im B) ⊕ Der(B), and the resulting 4×4 table (the 'magic square') produces all five exceptional simple Lie algebras: G₂, F₄, E₆, E₇, E₈. The word 'magic' refers to the surprising symmetry 𝔏(A, B) ≅ 𝔏(B, A), despite the construction not obviously being symmetric.",
     "problemStatement": "Show that Aut(𝕆) ⊆ O(7) — the automorphism group of the octonions acts by isometries on the 7-dimensional imaginary subspace Im(𝕆) — and axiomatize the identification G₂ = Aut(𝕆) along with the four exceptional Lie algebras F₄, E₆, E₇, E₈ arising from the Freudenthal-Tits magic square.",
-    "text": "Formalizes the connection between the four normed division algebras and the five exceptional Lie algebras. Proves Aut(𝕆) ⊆ O(7) (fully proved, 0 sorries). G2_der_dimension (finrank Der(𝕆) = 14) is proved modulo 2 sorries for basis evaluation extraction and linear independence.",
+    "text": "Formalizes the connection between the four normed division algebras and the five exceptional Lie algebras. Proves Aut(𝕆) ⊆ O(7) (fully proved, 0 sorries). G2_der_dimension (finrank Der(𝕆) = 14) is proved modulo 1 remaining sorry for basis evaluation extraction (derEval14_injective); the companion linear-independence lemma is now proved.",
     "proofStrategy": "The formalization introduces OctonionAlgHom and OctonionAut structures for algebra homomorphisms and invertible automorphisms. Key lemmas proved: (1) any automorphism φ fixes the unit element e₀ (via the left-identity uniqueness argument); (2) pure imaginary elements y (y[0]=0) satisfy y² = −normSq(y)·e₀; (3) phi_imag_props: automorphisms preserve imaginary elements and their norms; (4) alg_aut_preserves_norm follows by decomposing x = r·e₀ + w (pure imaginary w) and using orthogonality; (5) polarization gives inner product preservation. The exceptional Lie algebra part uses an ExceptionalType inductive type with dimension and rank functions, and proves structural properties (strict ordering, G₂ uniqueness, E₈ maximality) by decidability.",
     "keyInsights": [
       "**φ fixes e₀**: Any algebra automorphism must fix the unit element. The elegant proof: φ(e₀) acts as a left identity for all y (since φ is surjective and e₀ is a left identity), and a left identity in an algebra with a right identity must equal the right identity.",
@@ -66,7 +66,7 @@
       "title": "Preamble: Context and Contents",
       "startLine": 1,
       "endLine": 63,
-      "summary": "Module documentation places the formalization in context: Hurwitz's theorem (1898) gives 4 normed division algebras, and the Freudenthal-Tits magic square (1954–1966) connects them to 5 exceptional Lie algebras. The contents table distinguishes proved results from in-progress ones (2 sorries for Der(𝕆) dimension proof). References: Baez 'The Octonions' (2002), Freudenthal (1964), Tits (1966).",
+      "summary": "Module documentation places the formalization in context: Hurwitz's theorem (1898) gives 4 normed division algebras, and the Freudenthal-Tits magic square (1954–1966) connects them to 5 exceptional Lie algebras. The contents table distinguishes proved results from in-progress ones (1 remaining sorry for the Der(𝕆) dimension proof — basis evaluation extraction). References: Baez 'The Octonions' (2002), Freudenthal (1964), Tits (1966).",
       "mathContext": "The magic square table: rows and columns indexed by {ℝ,ℂ,ℍ,𝕆}. Entries: 𝔏(𝕆,ℝ)=F₄, 𝔏(𝕆,ℂ)=E₆, 𝔏(𝕆,ℍ)=E₇, 𝔏(𝕆,𝕆)=E₈, plus G₂=Der(𝕆). The 'magic': 𝔏(A,B)≅𝔏(B,A) despite the definition not being visibly symmetric."
     },
     {
@@ -106,7 +106,7 @@
       "title": "§IV-c to V: Derivation Algebra as Submodule + Freudenthal-Tits Axioms",
       "startLine": 558,
       "endLine": 697,
-      "summary": "Defines OctonionDerSubmodule as a Submodule of End_ℝ(ℝ⁸) to give Der(𝕆) an inherited vector space structure. Proves G2_der_dimension (finrank = 14) via upper bound (injective evaluation map) and lower bound (14 linearly independent derivations), with 2 sorries for the algebraic extraction steps. Proves derivation structural properties: der_maps_unit_to_zero, der_maps_real_part_to_zero, toLinearMap, mem_der_submodule. Then states the Freudenthal-Tits magic square: freudenthal_tits_f4/e6/e7/e8 (dimension facts, 52/78/133/248).",
+      "summary": "Defines OctonionDerSubmodule as a Submodule of End_ℝ(ℝ⁸) to give Der(𝕆) an inherited vector space structure. Proves G2_der_dimension (finrank = 14) via upper bound (injective evaluation map) and lower bound (14 linearly independent derivations); derBasis14_linearIndependent is now fully proved, leaving 1 sorry in derEval14_injective (basis evaluation extraction). Proves derivation structural properties: der_maps_unit_to_zero, der_maps_real_part_to_zero, toLinearMap, mem_der_submodule. Then states the Freudenthal-Tits magic square: freudenthal_tits_f4/e6/e7/e8 (dimension facts, 52/78/133/248).",
       "mathContext": "Der(𝕆) as a Submodule of $\\text{End}_\\mathbb{R}(\\mathbb{R}^8)$: the set of $\\mathbb{R}$-linear maps $D: \\mathbb{R}^8 \\to \\mathbb{R}^8$ satisfying the Leibniz rule $D(ab) = D(a)\\cdot b + a\\cdot D(b)$ for octonion multiplication. Axiom `G2_der_dimension`: $\\text{finrank}_\\mathbb{R}(\\text{Der}(\\mathbb{O})) = 14$ (the dimension of $\\mathfrak{g}_2$). Tits construction: $\\mathfrak{L}(A,B) = \\mathfrak{der}(A) \\oplus (\\text{Im}A \\otimes \\text{Im}B) \\oplus \\mathfrak{der}(B)$ with $\\dim\\mathfrak{L}(\\mathbb{O},\\mathbb{O}) = 14 + 49 + 14 + \\text{extra} = 248$."
     },
     {
@@ -119,7 +119,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization establishes the bridge between Hurwitz's four normed division algebras and the five exceptional Lie algebras. The key proved result is that Aut(𝕆) ⊆ O(7): octonion automorphisms preserve norms, real parts, inner products, and the imaginary subspace — all proved without sorries using algebraic decomposition. G2_der_dimension (finrank Der(𝕆) = 14) has 2 remaining sorries for basis evaluation extraction and linear independence. The five exceptional Lie algebras (G₂, F₄, E₆, E₇, E₈) are connected via the Freudenthal-Tits magic square, with structural properties proved by decidability.",
+    "summary": "This formalization establishes the bridge between Hurwitz's four normed division algebras and the five exceptional Lie algebras. The key proved result is that Aut(𝕆) ⊆ O(7): octonion automorphisms preserve norms, real parts, inner products, and the imaginary subspace — all proved without sorries using algebraic decomposition. G2_der_dimension (finrank Der(𝕆) = 14) has 1 remaining sorry for basis evaluation extraction (derEval14_injective); the linear-independence companion lemma is now fully proved. The five exceptional Lie algebras (G₂, F₄, E₆, E₇, E₈) are connected via the Freudenthal-Tits magic square, with structural properties proved by decidability.",
     "implications": "The formalization demonstrates that Hurwitz's theorem (n∈{1,2,4,8}) constrains not just composition algebras but the entire exceptional structure of simple Lie algebras: the 4 normed division algebras yield exactly 5 exceptional types. Removing the 16-dimensional case eliminates the possibility of a 6th exceptional Lie algebra. Physical applications include E₈×E₈ heterotic string theory (anomaly cancellation: dim=2×248=496) and M-theory compactification on G₂ manifolds.",
     "openQuestions": [
       "Prove G₂ ≅ Aut(𝕆) formally in Lean: requires Lie group theory (compact simple groups, root systems) not yet in Mathlib as of 2026-04.",
@@ -137,11 +137,11 @@
       "HurwitzTheorem"
     ],
     "namespace": "HurwitzTheoremOQ04",
-    "lineCount": 1053,
+    "lineCount": 1094,
     "axiomCount": 0,
     "theoremCount": 40,
     "definitionCount": 15,
-    "sorries": 2,
+    "sorries": 1,
     "path": "Proofs/HurwitzTheoremOQ04.lean"
   },
   "crossReferences": [


### PR DESCRIPTION
## Summary
- Re-audit found `meta.sorries=2` but actual file has 1 sorry (PR #13121 proved `derBasis14_linearIndependent`)
- `lineCount=1053` but file is 1094 lines
- Update `meta.{sorries,lineCount}`, `leanFile.{sorries,lineCount}`, plus narrative fields (`assumptions`, `meta.text`, `module-overview` summary, `derivation-submodule-magic-square` summary, `conclusion.summary`) to reflect that only `derEval14_injective` remains as a sorry

## Why
The auditor found this gallery entry overstating the remaining work. After PR #13121, only one of the two stated sorries remains. Keeping the meta accurate is required by the audit integrity policy (status `formalized`/badge `wip` is correct since 1 sorry > 0).

## Test plan
- [x] `python3 -c "import json; json.load(open('src/data/proofs/hurwitz-theorem-oq-04/meta.json'))"` — JSON validates
- [x] `git show HEAD:proofs/Proofs/HurwitzTheoremOQ04.lean | wc -l` → 1094
- [x] One actual `sorry` token in the Lean file (line 787); other matches are inside comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)