### PR TITLE
Research: shannon-source-coding-oq-04 — close companion file sorry

### DIFF
--- a/proofs/Proofs/ShannonSourceCodingOQ04Aristotle.lean
+++ b/proofs/Proofs/ShannonSourceCodingOQ04Aristotle.lean
@@ -144,6 +144,90 @@ theorem log_typeProb_eq' (n : ℕ) (hn : (n : ℝ) ≠ 0)
     - Fintype.card_perm: (Finset.univ : Finset (Equiv.Perm (Fin n))).card = n! -/
 theorem type_class_size_eq_multinomial (n : ℕ) (f : Fin k → ℕ) (hf : ∑ i, f i = n) :
     (typeClass' n f hf).card = Nat.multinomial Finset.univ f := by
-  sorry
+  have h_card : Finset.card (Finset.univ.filter (fun σ : Fin n → Fin k =>
+      ∀ i : Fin k, Finset.card (Finset.filter (fun j => σ j = i) Finset.univ) = f i)) =
+      Nat.factorial n / (∏ i, Nat.factorial (f i)) := by
+    rw [Nat.div_eq_of_eq_mul_left];
+    · exact Finset.prod_pos fun i _ => Nat.factorial_pos _;
+    · induction' n with n ih generalizing f;
+      · simp_all +decide [Finset.ext_iff];
+      · have h_split : Finset.card (Finset.filter (fun σ : Fin (n + 1) → Fin k =>
+              ∀ i, Finset.card (Finset.filter (fun j => σ j = i) Finset.univ) = f i)
+            (Finset.univ : Finset (Fin (n + 1) → Fin k))) =
+            ∑ i, Finset.card (Finset.filter (fun σ : Fin n → Fin k =>
+              ∀ j, Finset.card (Finset.filter (fun l => σ l = j) Finset.univ) =
+                if j = i then f i - 1 else f j)
+            (Finset.univ : Finset (Fin n → Fin k))) := by
+          have h_split : Finset.filter (fun σ : Fin (n + 1) → Fin k =>
+                ∀ i, Finset.card (Finset.filter (fun j => σ j = i) Finset.univ) = f i)
+              (Finset.univ : Finset (Fin (n + 1) → Fin k)) =
+            Finset.biUnion (Finset.univ : Finset (Fin k)) (fun i =>
+              Finset.image (fun σ : Fin n → Fin k => Fin.snoc σ i)
+                (Finset.filter (fun σ : Fin n → Fin k =>
+                  ∀ j, Finset.card (Finset.filter (fun l => σ l = j) Finset.univ) =
+                    if j = i then f i - 1 else f j)
+                (Finset.univ : Finset (Fin n → Fin k)))) := by
+            ext σ;
+            constructor;
+            · intro hσ;
+              simp +zetaDelta at *;
+              refine' ⟨σ (Fin.last n), Fin.init σ, _, _⟩ <;>
+                simp +decide [← hσ, Fin.init_def, Fin.snoc];
+              · intro j; split_ifs <;> simp_all +decide [Finset.filter_erase, Finset.filter_or];
+                · rw [← hσ]; rw [Finset.card_filter, Finset.card_filter];
+                  rw [Fin.sum_univ_castSucc]; aesop;
+                · convert hσ j using 1;
+                  rw [Finset.card_filter, Finset.card_filter];
+                  rw [Fin.sum_univ_castSucc]; aesop;
+              · exact funext fun i => by cases i using Fin.lastCases <;> simp +decide [*];
+            · simp +zetaDelta at *;
+              rintro i σ hσ rfl j; by_cases hj : j = i <;> simp_all +decide [Fin.snoc];
+              · convert congr_arg (· + 1) (hσ i) using 1;
+                · rw [Finset.card_filter, Finset.card_filter];
+                  rw [Fin.sum_univ_castSucc]; aesop;
+                · have h_sum : ∑ i, Finset.card (Finset.filter (fun l => σ l = i)
+                      Finset.univ) = n := by
+                    simp +decide only [card_filter];
+                    rw [Finset.sum_comm]; aesop;
+                  grind;
+              · convert hσ j using 1;
+                · rw [Finset.card_filter, Finset.card_filter];
+                  rw [Fin.sum_univ_castSucc]; aesop;
+                · rw [if_neg hj];
+          rw [h_split, Finset.card_biUnion];
+          · exact Finset.sum_congr rfl fun _ _ =>
+              Finset.card_image_of_injective _ fun x y hxy => by simpa [Fin.ext_iff] using hxy;
+          · intros i hi j hj hij; simp [Finset.disjoint_left, Finset.mem_image]; grind +extAll;
+        have h_ind : ∀ i, Finset.card (Finset.filter (fun σ : Fin n → Fin k =>
+              ∀ j, Finset.card (Finset.filter (fun l => σ l = j) Finset.univ) =
+                if j = i then f i - 1 else f j)
+            (Finset.univ : Finset (Fin n → Fin k))) *
+            (∏ j, (f j).factorial) = (n.factorial) * (f i) := by
+          intro i
+          by_cases hi : f i = 0;
+          · simp [hi]; left;
+            intro x; contrapose! hf;
+            simp_all +decide [Finset.sum_eq_zero_iff_of_nonneg];
+            have h_sum : ∑ i, Finset.card (Finset.filter (fun l => x l = i)
+                Finset.univ) = n := by
+              simp +decide only [card_filter]; rw [Finset.sum_comm]; aesop;
+            grind;
+          · rw [ih (fun j => if j = i then f i - 1 else f j)];
+            · rw [mul_assoc, ← Finset.prod_erase_mul _ _ (Finset.mem_univ i)];
+              rw [← Finset.prod_erase_mul _ _ (Finset.mem_univ i)];
+              rw [← mul_assoc, ← mul_assoc,
+                ← Nat.succ_pred_eq_of_pos (Nat.pos_of_ne_zero hi)];
+              simp +decide [Nat.factorial_succ, mul_assoc, mul_comm, mul_left_comm,
+                Finset.prod_ite, Finset.filter_ne', Finset.filter_eq', hi];
+              exact Or.inl <| Or.inl <|
+                Finset.prod_congr rfl fun x hx => by aesop;
+            · simp_all +decide [Finset.sum_ite, Finset.filter_eq', Finset.filter_ne'];
+              rw [← Finset.sum_erase_add _ _ (Finset.mem_univ i), add_comm] at hf; omega;
+        simp_all +decide [Nat.factorial_succ, mul_comm, Finset.mul_sum];
+        rw [← Finset.sum_mul, hf, mul_comm];
+  convert h_card using 1;
+  · unfold typeClass';
+    simp +decide [funext_iff, Finset.ext_iff, empDist'];
+  · rw [Nat.multinomial, ← hf]
 
 end ShannonSourceCodingOQ04Aristotle

--- a/research/problems/shannon-source-coding-oq-04/knowledge.md
+++ b/research/problems/shannon-source-coding-oq-04/knowledge.md
@@ -171,3 +171,71 @@ The Aristotle proof uses induction on block length n:
 
 - `source_coding_achievability_mot` (OPEN): requires LLN/concentration inequalities.
   Not tractable without significant infrastructure (>1000 lines). Classify as BLOCKED.
+
+---
+
+## Session 2026-04-27 (Session 4) — Closed Companion File Sorry
+
+**Mode**: REVISIT
+**Outcome**: PROGRESS — Companion file 1 → 0 sorries (gallery already 0 sorries)
+
+### What I Did
+
+1. Reviewed state: main file `ShannonSourceCodingOQ04.lean` has 0 sorries (verified status,
+   per meta.json) and the companion file `ShannonSourceCodingOQ04Aristotle.lean` had 1 stale
+   sorry for `type_class_size_eq_multinomial` even though Aristotle's proof was already
+   integrated into the main file (PR #12842) and into the main file's
+   `type_class_size_eq_multinomial`.
+2. Found Aristotle's proof for the *primed* names (`typeClass'`/`empDist'`) in
+   `aristotle-results/processed/ShannonSourceCodingOQ04Aristotle-solved.lean` (lines 147-211).
+3. Replaced the `sorry` in the companion file with that proof body, matching the primed
+   definitions used in the companion namespace.
+4. Verified build with `./proofs/scripts/docker-build.sh Proofs.ShannonSourceCodingOQ04Aristotle`
+   (host has 7.65GB RAM, used `LEAN_MEMORY_LIMIT=6144`).
+
+### Insights
+
+- The proof body of `type_class_size_eq_multinomial` does NOT reference `typeClass`/`empDist`
+  by name in its main body — it works with `Finset.filter (fun σ => ∀ i, ... = f i)` directly.
+  The only places the definition names matter are:
+  (a) the final `convert h_card; · unfold ...; · rw [Nat.multinomial, ← hf]` step where
+      `unfold` rewrites the goal to match the filtered universal form.
+- This means the same proof transfers cleanly between the main and companion namespaces with
+  only a name swap in the `unfold` line — useful pattern when the same lemma is proved in
+  two namespaces.
+
+### Files Modified
+
+- `proofs/Proofs/ShannonSourceCodingOQ04Aristotle.lean` (147 → 230 lines, 1 → 0 sorries)
+- `src/data/proofs/shannon-source-coding-oq-04/meta.json` (companion sorries 1→0)
+- `src/data/research/problems/shannon-source-coding-oq-04.json` (knowledge updated)
+
+### Status
+
+This problem is now fully formalized:
+- Main file: 0 sorries, 0 axioms (verified)
+- Companion file: 0 sorries
+
+Caveat: `source_coding_achievability_mot` in the main file uses a degenerate type class
+(constant-zero sequence with code_length=0); the formal statement is weaker than the true
+source-coding achievability theorem (which would require LLN/concentration to compare the
+empirical distribution of typical sequences to the source distribution p). The honest
+content of this formalization lies in `type_class_size_le_entropy_pow` (entropy upper
+bound) and `dominant_type_lower_bound` (pigeonhole lower bound).
+
+### Follow-up Open Question
+
+A meaningful achievability strengthening that does NOT require LLN: encoding the dominant
+type class. Specifically, one could prove
+
+```
+theorem dominant_type_code_length :
+  ∃ f : Fin k → ℕ, ∃ hf : ∑ i, f i = n,
+  k ^ n / (n + 1) ^ k ≤ (typeClass n f hf).card ∧
+  ∃ enc : typeClass n f hf → Fin (k ^ n / (n + 1) ^ k + 1).succ, Function.Injective enc
+```
+
+This is a worst-case (uniform-source) achievability statement: it shows the dominant type
+class of any sequence space can be coded with ≤ ⌈log₂(k^n/(n+1)^k)⌉ ≈ n log₂ k - k log₂(n+1)
+bits, which is meaningful since for uniform source p_i = 1/k, n log₂ k = n H(p). It does
+NOT require LLN — only finite cardinality and the existing pigeonhole bound.

--- a/src/data/research/problems/shannon-source-coding-oq-04.json
+++ b/src/data/research/problems/shannon-source-coding-oq-04.json
@@ -1,13 +1,13 @@
 {
   "slug": "shannon-source-coding-oq-04",
   "title": "Method of Types as Alternative Proof of Shannon Source Coding",
-  "phase": "ACT",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "C",
   "path": "full",
   "problemStatement": {
     "formal": "|T_Q^n| = \\binom{n}{nQ(x_1), nQ(x_2), \\ldots, nQ(x_{|\\mathcal{X}|})} \\approx 2^{nH(Q)}",
-    "plain": "The Csisz\u00e1r-K\u00f6rner **method of types** gives a combinatorial alternative to the standard",
+    "plain": "The Csiszár-Körner **method of types** gives a combinatorial alternative to the standard",
     "whyMatters": []
   },
   "knownResults": {
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "COMPLETED",
     "since": "2026-04-25T00:00:00-07:00",
     "iteration": 2,
-    "focus": "Proved type_class_size_eq_multinomial (Aristotle induction proof integrated). 1 sorry remains: source_coding_achievability_mot (OPEN).",
+    "focus": "Companion file sorry closed; problem fully formalized within tractable scope. Achievability beyond LLN remains an open infrastructure goal.",
     "blockers": [],
-    "nextAction": "Submit type_class_size_eq_multinomial to Aristotle for proof search.",
+    "nextAction": "Release claim; mark problem as completed",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,24 +29,27 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved type_class_size_le_entropy_pow, dominant_type_lower_bound, type_class_size_eq_multinomial. 2\u21921 sorries. 1 remaining: source_coding_achievability_mot (OPEN, needs LLN).",
+    "progressSummary": "PROGRESS: Companion file sorry closed (Aristotle proof integrated). 0 sorries in main file (verified). 0 sorries in companion file. Problem fully formalized for tractable scope; source_coding_achievability_mot proved with weaker degenerate-type statement (true achievability needs LLN — out of scope).",
     "builtItems": [
-      "type_class_size_le_entropy_pow: |T_f| \u2264 exp(n H(Q)) proved via prod_fiberwise' + prod_univ_sum (ShannonSourceCodingOQ04.lean:166)",
-      "dominant_type_lower_bound: dominant type class \u2265 k^n/(n+1)^k proved via Finset pigeonhole (ShannonSourceCodingOQ04.lean:175)",
-      "type_class_size_eq_multinomial: |T_f| = Nat.multinomial proved via induction on n (ShannonSourceCodingOQ04.lean:89)"
+      "type_class_size_le_entropy_pow: |T_f| ≤ exp(n H(Q)) proved via prod_fiberwise' + prod_univ_sum (ShannonSourceCodingOQ04.lean:166)",
+      "dominant_type_lower_bound: dominant type class ≥ k^n/(n+1)^k proved via Finset pigeonhole (ShannonSourceCodingOQ04.lean:175)",
+      "type_class_size_eq_multinomial: |T_f| = Nat.multinomial proved via induction on n (ShannonSourceCodingOQ04.lean:89)",
+      "type_class_size_eq_multinomial in ShannonSourceCodingOQ04Aristotle.lean: closed by integrating Aristotle proof for primed namespace (ShannonSourceCodingOQ04Aristotle.lean:145)"
     ],
     "insights": [
-      "prod_fiberwise' rewrites \u220f j:Fin n, Q(x j) as \u220f i:Fin k, Q(i)^(empDist n x i) for any x \u2014 key for equating sequence probability to type probability",
+      "prod_fiberwise' rewrites ∏ j:Fin n, Q(x j) as ∏ i:Fin k, Q(i)^(empDist n x i) for any x — key for equating sequence probability to type probability",
       "prod_univ_sum (product of sums = sum over piFinset of products) gives total probability = 1 without EN NReal lifting",
-      "Finset.exists_le_card_fiber_of_mul_le_card_of_maps_to is in Mathlib.Combinatorics.Pigeonhole \u2014 NOT auto-imported via Mathlib.Tactic",
-      "Lean 4 forward reference issue: theorems defined later in file cannot be used earlier; must inline proofs"
+      "Finset.exists_le_card_fiber_of_mul_le_card_of_maps_to is in Mathlib.Combinatorics.Pigeonhole — NOT auto-imported via Mathlib.Tactic",
+      "Lean 4 forward reference issue: theorems defined later in file cannot be used earlier; must inline proofs",
+      "Aristotle proof body for type_class_size_eq_multinomial transfers between namespaces with only the unfold step changed (typeClass vs typeClass', empDist vs empDist'), since the proof works on Finset.filter forms directly"
     ],
     "mathlibGaps": [
       "Fintype.card_fiber_eq_multinomial: if it exists, could prove type_class_size_eq_multinomial directly"
     ],
     "nextSteps": [
-      "source_coding_achievability_mot is OPEN \u2014 needs LLN/concentration inequalities (>1000 lines). Mark as BLOCKED.",
-      "Consider follow-up: can type_class_size_eq_multinomial be proved without grind/aesop? (clean up proof)"
+      "Mark problem as completed (status: completed)",
+      "Optional follow-up: prove dominant_type_code_length (no LLN needed) for stronger combinatorial achievability statement",
+      "true source_coding_achievability with LLN remains BLOCKED (>1000 lines infrastructure)"
     ],
     "markdown": "# Knowledge Base: shannon-source-coding-oq-04\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
@@ -69,7 +72,7 @@
     "mathlib": []
   },
   "started": "2026-04-14T21:25:05.927Z",
-  "lastUpdate": "2026-04-21T12:34:15.787Z",
+  "lastUpdate": "2026-04-27T12:30:00.000Z",
   "leanFiles": [
     {
       "path": "Proofs/ShannonSourceCoding.lean",
@@ -118,11 +121,11 @@
     {
       "path": "Proofs/ShannonSourceCodingOQ04Aristotle.lean",
       "filename": "ShannonSourceCodingOQ04Aristotle.lean",
-      "lineCount": 145,
+      "lineCount": 233,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonSourceCodingOQ04Aristotle.lean"
     }


### PR DESCRIPTION
## Summary
Closes the last `sorry` in `ShannonSourceCodingOQ04Aristotle.lean` by integrating Aristotle's previously-discovered induction proof of `type_class_size_eq_multinomial` for the primed namespace.

The proof body was already integrated into the **main** file `ShannonSourceCodingOQ04.lean` in PR #12842 — the gallery entry was already `verified` (0 sorries) — but the companion file still carried a stale `sorry` for the primed-name version (`typeClass'`/`empDist'`). This PR brings the companion file in sync.

## Progress
- `proofs/Proofs/ShannonSourceCodingOQ04Aristotle.lean`: 1 → 0 sorries (lineCount 145 → 233)
- `proofs/Proofs/ShannonSourceCodingOQ04.lean`: unchanged (already 0 sorries / `verified`)
- Knowledge log + problem JSON updated with session-4 notes

## Findings
- The induction-on-`n` proof body for `type_class_size_eq_multinomial` works on `Finset.filter` forms directly — it doesn't reference `typeClass`/`empDist` by name except in the final `unfold` step. So the same proof transfers between namespaces with only a rename in the unfolds (good pattern for companion files).

## Verification
- Built with `LEAN_MEMORY_LIMIT=6144 ./proofs/scripts/docker-build.sh Proofs.ShannonSourceCodingOQ04Aristotle` — `Build succeeded` (7743 jobs).
- One minor lint warning (unused `Finset.ext_iff` simp arg at 230:30); preserved exactly as Aristotle produced it.

## Follow-up (open question)
A meaningful achievability strengthening that does NOT require LLN: encode the *dominant* type class. The pigeonhole bound `|T_{f*}| ≥ k^n / (n+1)^k` already proved gives a worst-case (uniform-source) compressibility statement coding the dominant type class with `≤ ⌈log₂(k^n/(n+1)^k)⌉ ≈ n log₂ k − k log₂(n+1)` bits — provable from existing infrastructure, no concentration needed. The full source-coding achievability (with arbitrary source `p`) still requires LLN/concentration (>1000 lines, BLOCKED).

## Status
**Outcome**: completed
**Next Steps**: None for this problem; pursue follow-up `dominant_type_code_length` if desired.

🤖 Generated by researcher-7