### PR TITLE
Enrich abel-ruffini: align Parts VI/VII annotation ranges with their sections

### DIFF
--- a/src/data/proofs/abel-ruffini/annotations.json
+++ b/src/data/proofs/abel-ruffini/annotations.json
@@ -353,7 +353,7 @@
     "proofId": "abel-ruffini",
     "range": {
       "startLine": 151,
-      "endLine": 183
+      "endLine": 163
     },
     "type": "insight",
     "title": "Part VI: Why Degree 5 Is the Exact Threshold",


### PR DESCRIPTION
## Summary

Two annotations in `src/data/proofs/abel-ruffini/annotations.json` covered the merged range 151-183 even though they describe logically distinct Lean docstring sections:

- `ann-part-vi-threshold` (Part VI: degree-5 threshold)
- `ann-part-vii-historical` (Part VII: impossibility paradigm)

Aligned each annotation to the lines its content actually describes:

- `ann-part-vi-threshold` → 151-163 (Part VI threshold docstring only)
- `ann-part-vii-historical` → 165-185 (Part VII historical docstring only)

Also corrected an off-by-2 line reference inside the Part VII annotation: the closing `end AbelRuffini` is on line 187, not 185.

## Test plan

- [x] `pnpm build` succeeds — JSON validates, Vite bundle builds cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)