### PR TITLE
audit: mark furstenberg-correspondence-oq-01 audited (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10957,9 +10957,9 @@
       "result": "clean"
     },
     "furstenberg-correspondence-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-05T16:37:42Z",
+      "lastAudited": "2026-04-27T11:25:50Z",
       "result": "clean"
     },
     "furstenberg-correspondence-oq-02": {


### PR DESCRIPTION
## Summary
- Re-verified furstenberg-correspondence-oq-01 at HEAD: 1 sorry, 1 axiom — matches meta.json exactly.
- The find-targets script flagged a sorry-count mismatch ("claims 1, actual 0"), but this was caused by an in-progress researcher edit in the working directory (working copy has 0 sorries, HEAD has 1). No integrity issue at HEAD.

## Test plan
- [x] git show HEAD:proofs/Proofs/FurstenbergCorrespondenceOQ01.lean → 1 sorry, 1 axiom
- [x] meta.json claims sorries: 1, axiomCount: 1 — matches
- [x] audit-tracker.json updated: auditCount 2 → 3, lastAudited 2026-04-27

🤖 Generated with [Claude Code](https://claude.com/claude-code)