### PR TITLE
Research session bundle: ballot HLF cleanup + erdos-476 blocked-sync

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean
@@ -25,12 +25,16 @@ Two-step LGV proof:
 - instFintypeSYT: Fintype instance for SYT (makes Fintype.card typecheck)
 - hook_length_formula_bot: proved for empty diagram
 - youngLGVConfig: LGV encoding with well-formedness proved
-- hook_length_formula_from_chain: proves main theorem FROM the two sorry lemmas
-- Formula verified numerically for 8 specific shapes
+- hook_length_formula_from_chain: conditional theorem from h_ni_syt + h_det_hook
+- hook_length_formula_general: PROVED via corner recursion + hook_walk_identity
+  (the main theorem is established via this corner-recursion path; the LGV
+   route below remains open)
 
-### Open (2 sorry lemmas)
-- ni_count_eq_syt_count: SYT ↔ NI-path bijection (Fomin growth diagram, ~200 lines)
-- lgv_det_factors_as_hook_quotient: det × hookProd = n! (Vandermonde identity, ~200 lines)
+### Status
+- Main theorem `hook_length_formula` is proved modulo a single remaining sorry in
+  `hook_walk_identity` (the ≥10×≥10 non-rectangular case; ~300-line GNW argument).
+- The alternate LGV proof path remains open. See the OPEN comment block in PART V
+  for the canonical-config restatement that future work should target.
 -/
 
 import Proofs.BallotProblemOQ03OQ02
@@ -218,39 +222,51 @@ theorem hook_length_formula_2row_rect (m : ℕ) :
     LatticePathLGV.Cn m * ((m + 1).factorial * m.factorial) = (2 * m).factorial :=
   LGVCorollaries.hook_length_formula_two_row m
 
-/-- Auxiliary: count of SYT of shape μ equals the NI-path count with youngLGVConfig.
-    This is the Fomin growth diagram bijection (RSK correspondence restricted to SYT).
-    WARNING: This statement is INCORRECTLY STATED — it takes arbitrary (r, σ, m) without
-    requiring they encode μ's row lengths. The correct version needs a canonical LGV config:
-      def youngLGVConfigOf (μ : YoungDiagram) : LGVConfig k := youngLGVConfig k σ_μ ...
-    where σ_μ i = μ.rowLen (k-1-i) for k = number of rows of μ. Then the theorem says:
-      card(SYT μ) = niTupleCount (youngLGVConfigOf μ).
-    [OPEN: requires defining youngLGVConfigOf + RSK bijection proof, ~200 lines] -/
-theorem ni_count_eq_syt_count (μ : YoungDiagram) (r : ℕ) (σ : Fin r → ℕ)
-    (hσ : Monotone σ) (m : ℕ) (hm : ∀ i : Fin r, σ i + i.val ≤ m)
-    (hr : 0 < r) (hmin : r - 1 ≤ σ ⟨0, hr⟩) :
-    Fintype.card (StandardYoungTableau μ) =
-    niTupleCount (youngLGVConfig r σ hσ m hm) := by
-  sorry
+/-
+  ## OPEN: LGV proof path — canonical-config restatement
 
-/-- Auxiliary: the LGV determinant for youngLGVConfig times hookProd equals μ.card!.
-    This is the algebraic identity connecting path-count determinants to hook products.
-    WARNING: This statement is INCORRECTLY STATED — it takes arbitrary (r, σ, m, μ)
-    without requiring that (r, σ, m) encodes μ. The correct version needs a connection:
-    for the canonical config youngLGVConfigOf μ, det(pathMatrix(youngLGVConfigOf μ)) × hookProd μ = μ.card!
-    This follows from the Jacobi-Trudi identity / Lindström determinant formula.
-    [OPEN: requires defining youngLGVConfigOf + Vandermonde-type determinant identity] -/
-theorem lgv_det_factors_as_hook_quotient (μ : YoungDiagram) (r : ℕ) (σ : Fin r → ℕ)
-    (hσ : Monotone σ) (m : ℕ) (hm : ∀ i : Fin r, σ i + i.val ≤ m) :
-    (pathMatrix (youngLGVConfig r σ hσ m hm)).det * (hookProd μ : ℤ) =
-    μ.card.factorial := by
-  sorry
+  Earlier revisions of this file declared two auxiliary `sorry` lemmas
+  (`ni_count_eq_syt_count` and `lgv_det_factors_as_hook_quotient`) that took
+  an arbitrary tuple (r, σ, m) of LGV parameters with no hypothesis tying
+  them to μ.  As stated, those lemmas were not generally true: most choices
+  of (r, σ, m) bear no relation to μ, so the equalities reduce to false
+  numerical claims (e.g. for μ = ⊥ paired with r = 1, σ = fun _ => 5).
+  They were therefore dead, unprovable scaffolding, and have been removed.
 
-/-- The hook-length formula follows from the two auxiliary sorry lemmas + lgv_lemma_rxr.
-    This demonstrates the logical chain is complete; the two remaining deep steps are:
-    (1) ni_count_eq_syt_count — RSK/Fomin growth diagram bijection (~200 lines)
-    (2) lgv_det_factors_as_hook_quotient — Vandermonde-type det identity (~200 lines)
-    If both are resolved for a specific encoding of μ, the formula follows. -/
+  The corrected formulation requires a canonical encoding `youngLGVConfigOf μ`
+  built from μ alone:
+
+      r       = μ.colLen 0                    -- number of non-empty rows
+      σ_μ i   = μ.rowLen (r - 1 - i.val)      -- weakly-increasing reversal
+      m       = σ_μ ⟨r-1, _⟩ + (r-1)           -- max source/target index
+
+  With this canonical config the two open conjectures become:
+
+  (A)  Fintype.card (StandardYoungTableau μ) = niTupleCount (youngLGVConfigOf μ)
+       — the Fomin/RSK bijection between SYT and non-intersecting lattice
+         path tuples.  ~200 lines.
+
+  (B)  (pathMatrix (youngLGVConfigOf μ)).det * (hookProd μ : ℤ) = μ.card.factorial
+       — the Lindström / Jacobi–Trudi determinant identity.  ~200 lines.
+
+  Subtlety: the LGV well-formedness condition `r - 1 ≤ σ_μ ⟨0, _⟩` reduces to
+  `r - 1 ≤ μ.rowLen (r - 1)`, i.e. the bottom row is at least as long as
+  (numRows − 1).  This fails for tall/narrow shapes such as the column
+  `(1,1,…,1)`.  The general statement therefore needs a transpose-duality
+  case split (apply LGV to whichever of μ, μᵀ is "wide enough"), or a more
+  flexible canonical config that does not require well-formedness.
+
+  Until (A) and (B) are formalized, the main theorem `hook_length_formula`
+  is established via the corner-recursion / `hook_walk_identity` path
+  (`hook_length_formula_general`, end of file).  `hook_length_formula_from_chain`
+  below remains a clean *conditional* statement that records the LGV chain
+  abstractly and can consume any future proof of (A) and (B).
+-/
+
+/-- The hook-length formula follows abstractly from the LGV chain hypotheses
+    `h_ni_syt` (SYT count = NI-path count) and `h_det_hook` (det × hookProd = n!).
+    A proof of (A) and (B) above for a canonical encoding `youngLGVConfigOf μ`
+    would discharge both hypotheses and yield `hook_length_formula` directly. -/
 theorem hook_length_formula_from_chain (μ : YoungDiagram)
     (r : ℕ) (σ : Fin r → ℕ) (hσ : Monotone σ) (m : ℕ)
     (hm : ∀ i : Fin r, σ i + i.val ≤ m) (hr : 0 < r) (hmin : r - 1 ≤ σ ⟨0, hr⟩)
@@ -13992,12 +14008,13 @@ theorem hook_length_formula_general (μ : YoungDiagram) :
     Fintype.card (StandardYoungTableau μ) * hookProd μ = μ.card.factorial := by
   exact_mod_cast hook_length_formula_Q μ
 
-/-- **Hook-Length Formula (Frame-Robinson-Thrall 1954)** — alias for hook_length_formula_general.
+/-- **Hook-Length Formula (Frame-Robinson-Thrall 1954)** — alias for `hook_length_formula_general`.
     Proved here (after the corner-recursion infrastructure is in scope) via
-    hook_length_formula_general. The alternate LGV proof path (ni_count_eq_syt_count +
-    lgv_det_factors_as_hook_quotient) has incorrectly stated auxiliary lemmas and remains open.
-    Mathematical status: proved for all shapes with ≤9 rows or ≤9 columns;
-    ≥10×≥10 case sorry pending GNW hook walk argument (~300 lines). -/
+    `hook_length_formula_general`.  The alternate LGV proof path is documented
+    as the canonical-config restatement at the top of PART V; it remains open.
+    Mathematical status: proved for all shapes with ≤9 rows or ≤9 columns and
+    for all rectangles; `≥10 × ≥10` non-rectangular case is the sole remaining
+    sorry, pending the GNW hook-walk argument (~300 lines). -/
 theorem hook_length_formula (μ : YoungDiagram) :
     Fintype.card (StandardYoungTableau μ) * hookProd μ = μ.card.factorial :=
   hook_length_formula_general μ

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/knowledge.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/knowledge.md
@@ -488,3 +488,28 @@ symmetric polynomials: `s_λ = det[h_{λᵢ-i+j}]`. The proof route via SSYT and
 - No direct Jacobi-Trudi identity theorem in Mathlib
 - No RSK correspondence in Mathlib
 - `SemistandardYoungTableau` exists but uses `YoungDiagram` shapes, not `Fin k → ℕ`
+
+---
+
+## Session 2026-04-27 (Session 10) — Survey only; no code changes
+
+**Mode**: REVISIT (RICH, score 72)
+**Outcome**: SURVEYED — confirmed state, no code change
+
+### What I Did
+
+Surveyed the file state. Confirmed two open sorries with stable, correctly-stated formulations:
+
+1. **`jdt_weight_sum (n a b : ℕ) (hba : b ≤ a)`** at line 388 — JDT bijection for the 2-row case. Statement is correct (per session 9's discovery that the partition hypothesis `b ≤ a` is essential). Proof requires the explicit `Equiv` between `{(P:Sym n a, Q:Sym n b) // ¬ColStrictSym a b P Q}` and `Sym n (a+1) × Sym n (b-1)` via the JDT seam construction (~100–150 lines).
+
+2. **`jacobi_trudi_ssyt_eq` k≥3 branch** at line 631 — requires algebraic LGV (~150 lines) plus RSK (~150 lines).
+
+### Honesty Note
+
+Did not produce code changes this iteration. Both remaining sorries are large, well-scoped bodies of work that need a focused session, not a quick fix. Releasing the claim so an agent with budget for a substantial JDT or RSK push can pick this up.
+
+### Sorry Count: 2 (unchanged)
+
+### Suggested Next Owner
+
+A session targeting **only `jdt_weight_sum`**: define the forward map (`P + {Q.sort[c]}, Q − {Q.sort[c]}`), the inverse (find seam in P'), then prove `Equiv.weight_preserved` via `Multiset.prod_cons` + `Multiset.prod_erase`. Estimated ~120 lines focused work.

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/knowledge.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/knowledge.md
@@ -722,3 +722,48 @@ Build verification impossible: 13764-line file exceeds Docker 32GB memory limit.
 3. Consider: at what point does the mechanical approach become impractical vs. implementing GNW?
    - Each new row adds ~2200 lines; going to ≥50 rows would require ~90K lines total
    - GNW is the only viable approach for the complete proof
+
+---
+
+## Session 2026-04-27 (Session 32) — Remove dead LGV sorries; sorry count 3→1
+
+**Mode**: REVISIT (RICH knowledge tier, score 157)
+**Outcome**: PROGRESS (housekeeping) — 2 incorrectly-stated sorries removed; net sorry count 3 → 1
+
+### What I Did
+
+1. Deleted `ni_count_eq_syt_count` (old line 229) and `lgv_det_factors_as_hook_quotient` (old line 243) from `BallotProblemOQ03OQ01OQ02.lean`. Both took an arbitrary tuple `(r, σ, m)` of LGV parameters with no hypothesis linking them to μ; for almost any parameter choice, the equalities reduced to false numerical claims. They were unused dead scaffolding (only the WARNING-tagged definitions; no caller depended on them — `hook_length_formula_from_chain` takes the chain hypotheses abstractly).
+2. Replaced the deleted block with an `## OPEN: LGV proof path — canonical-config restatement` comment in PART V documenting:
+   - The canonical encoding `youngLGVConfigOf μ` (r = `μ.colLen 0`, σ_μ i = `μ.rowLen (r-1-i)`, m derived).
+   - (A) RSK/Fomin bijection statement: `card SYT μ = niTupleCount (youngLGVConfigOf μ)` (~200 lines).
+   - (B) Lindström / Jacobi–Trudi determinant identity: `(pathMatrix … ).det * hookProd μ = μ.card!` (~200 lines).
+   - The well-formedness obstruction: `r-1 ≤ σ_μ ⟨0,_⟩` reduces to `μ.rowLen (r-1) ≥ r-1`, which fails for tall/narrow shapes such as the column `(1,1,…,1)`. A general LGV proof needs a transpose-duality case split (apply to whichever of μ, μᵀ is wide enough).
+3. Reworded the trailing docstring on `hook_length_formula` (line ~14013) to reflect the new state: only `hook_walk_identity` remains as a sorry, and the LGV path is described as the canonical-config restatement at the top of PART V.
+4. Updated the file's top-of-file `### Status` block to drop the "two open sorry lemmas" framing and surface the single remaining `hook_walk_identity` gap.
+
+### Honesty Note
+
+This session reduces the visible sorry count from 3 to 1, but the reduction comes from **deleting dead, unprovable code** — not from proving anything new. The mathematical content of the file is unchanged: `hook_length_formula_general` was already established (modulo `hook_walk_identity`) via corner recursion. The removed lemmas were *not* on any proof path. The two LGV conjectures (A) and (B) are still open; they have just been moved from broken-`theorem` form into a well-typed comment so future work targets the right statements.
+
+### Files Modified
+
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean` (14005 → 14022 lines: −33 deleted, +50 comment block)
+- `src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json` (sorries 3→1, lineCount 14022, assumptions reworded)
+- `src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json` (knowledge progressSummary, builtItems, insights, currentState updated)
+- `research/problems/ballot-problem-oq-03-oq-01-oq-02/knowledge.md` (this entry)
+
+### Sorry Count: 3 → 1
+
+- ✓ REMOVED: `ni_count_eq_syt_count` (was incorrectly stated)
+- ✓ REMOVED: `lgv_det_factors_as_hook_quotient` (was incorrectly stated)
+- `hook_walk_identity` (line ~13932 dispatcher): ≥10 rows AND ≥10 cols AND non-rectangular case — sole remaining sorry, requires GNW (~300 lines)
+
+### Build Status
+
+File at 14022 lines remains beyond practical Docker 32GB build envelope. The edits are local (a comment block plus a single docstring rewording near the end); no new declarations or tactics were introduced, so the change is conservative w.r.t. type-checking risk. Compilation could not be verified this session.
+
+### Next Steps
+
+1. **GNW probabilistic hook-walk proof** (~300 lines) is the cleanest path to a sorry-free `hook_walk_identity`; it would also obviate further row-by-row extensions.
+2. **Canonical-config LGV path**: implement `youngLGVConfigOf` plus (A) and (B), giving a second independent proof of `hook_length_formula`. Note the transpose-duality wrinkle for tall shapes.
+3. **File modularization**: at 14022 lines the file no longer fits the Docker memory envelope. PARTS XII–XXIII (~10000 lines of row-by-row coverage) could be split off into a dedicated module to restore buildability before any further large additions.

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -19,11 +19,11 @@
       "representation-theory"
     ],
     "badge": "wip",
-    "sorries": 3,
+    "sorries": 1,
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "assumptions": "Three open sorries: (1) ni_count_eq_syt_count (Fomin/Viennot/RSK correspondence), (2) lgv_det_factors_as_hook_quotient (det factorization identity), (3) hook_walk_identity ≥9-row non-gHookYD ≥3-col case (GNW probabilistic proof; at-most-2-row, gHookYD, ≤2-col, exactly-3-row, exactly-4-row, exactly-5-row, exactly-6-row, exactly-7-row, exactly-9-row ALL proved). hook_length_formula_general is proved modulo hook_walk_identity via corner induction.",
-    "lineCount": 14005,
+    "assumptions": "One open sorry: hook_walk_identity for ≥10 rows AND ≥10 cols AND non-rectangular shapes (GNW probabilistic proof, ~300 lines). Proved cases: at-most-2-row, gHookYD, ≤2-col, exactly 3-row, exactly 4-row, exactly 5-row, exactly 6-row, exactly 7-row, exactly 8-row, exactly 9-row, ≤9-col (transpose duality), all rectangles. The alternate LGV proof path is documented in PART V as a canonical-config restatement; previously-stated arbitrary-parameter LGV sorries were removed in session 32 as dead, unprovable scaffolding. hook_length_formula_general is proved modulo the single hook_walk_identity sorry.",
+    "lineCount": 14022,
     "theoremCount": 484,
     "definitionCount": 14,
     "originalContributions": [

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
@@ -21,7 +21,7 @@
     "iteration": 2,
     "focus": "Building Jacobi-Trudi determinant formula in Lean 4 using Mathlib hsymm",
     "blockers": [],
-    "nextAction": "Wait for build to confirm; if passing, commit and create gallery entry",
+    "nextAction": "Targeted JDT bijection session: define forward map (P plus Q.sort[c], Q minus Q.sort[c]) and inverse (seam in Pprime), prove Equiv plus Multiset.prod_cons/prod_erase weight preservation. ~120 focused lines for jdt_weight_sum alone.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -97,7 +97,8 @@
       "rowPair_sum_weight proof: Fintype.sum_prod_type + simp_rw [← Finset.mul_sum] + ← Finset.sum_mul + ssytSchurFin_one_row cleanly factors sum over product type into product of sums",
       "ssytSchurFin_two_row proof pattern: cs = total - ncs; Fintype.sum_subtype_add_sum_subtype splits into cs+ncs=total; eq_sub_of_add_eq closes after substituting rowPair_sum_weight and nonColStrict_sum_weight",
       "ssytFin_two_row_eq_sum_colstrict proved via explicit SSYTFin ≃ colstrict-pair Equiv; uses ssytFin_row_sort_eq_ofFn helper that shows sort of sorted row = same row via mergeSort_eq_self",
-      "ColStrictSym definition: P.sort[j] < Q.sort[j] for all j < min(a,b); Decidable via Fintype.decidableForallFintype; key for separating SSYT contributions by column-strict pairs"
+      "ColStrictSym definition: P.sort[j] < Q.sort[j] for all j < min(a,b); Decidable via Fintype.decidableForallFintype; key for separating SSYT contributions by column-strict pairs",
+      "Session 10 (2026-04-27, survey only): both remaining sorries (jdt_weight_sum, jacobi_trudi_ssyt_eq k>=3) are correctly stated as of session 9. No fast fixes available; each is a focused 100-300 line proof body. Released for an agent with budget for sustained work."
     ],
     "mathlibGaps": [
       "No Mathlib SchurPolynomial definition — we provide one via Jacobi-Trudi formula",

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
@@ -34,12 +34,13 @@
     "phase": "ACT",
     "since": "2026-04-21T13:45:00Z",
     "iteration": 4,
-    "focus": "General hook_length_formula: 3 sorries remain. 2-row case fully proved. Corner step proved. Aristotle companion created for LGV sorries.",
+    "focus": "Sorry reduced 3→1 by removing dead LGV scaffolding. Sole remaining sorry: hook_walk_identity ≥10-row ≥10-col non-rectangular case (GNW ~300 lines).",
     "blockers": [
-      "ni_count_eq_syt_count: RSK/Fomin bijection ~200 lines",
-      "lgv_det_factors_as_hook_quotient: Vandermonde det identity ~200 lines"
+      "File size: 14022 lines exceeds practical Docker 32GB build envelope; further additions risk unverifiable code",
+      "GNW proof (~300 lines): standard probabilistic hook walk argument, not yet formalized",
+      "LGV well-formedness obstruction: requires transpose-duality case split for tall shapes"
     ],
-    "nextAction": "Attempt ni_count_eq_syt_count via Fomin growth diagram approach",
+    "nextAction": "Either (a) extend row-by-row to PART XXIV (10-row case, ~2000 lines, narrows sorry to ≥11×≥10) — but file is at 14022 lines, near build limit; (b) implement GNW probabilistic hook-walk proof to discharge sorry uniformly; (c) implement the canonical-config LGV path (A,B in PART V comment) for an entirely different proof line.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -47,7 +48,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "BLOCKED: dependency regression (omega failure in BallotProblemOQ03.lean) + ≥10×≥10 sorry needs algebraic proof of arm/leg product identity",
+    "progressSummary": "Removed two dead LGV sorries (incorrectly stated). Sorry count 3→1; only hook_walk_identity (≥10×≥10 non-rect) remains. hook_length_formula_general proved modulo this single GNW gap.",
     "builtItems": [
       "instFintypeSYT: Fintype instance for StandardYoungTableau (BallotProblemOQ03OQ01OQ02.lean, Part IIIb)",
       "emptyTableau: unique SYT of shape bot (BallotProblemOQ03OQ01OQ02.lean, Part IIIc)",
@@ -127,7 +128,10 @@
       "nineRow_colLen_* (9 lemmas): column length zone boundaries for 9-row shapes",
       "nineRow_hookLen_row{0..8}_zone* (45 lemmas): hookLen in each zone of each row",
       "nineRow_corner_bot/cases/card: corner structure for 9-row shapes",
-      "nineRow_arm_row{0..8} (9 lemmas): arm products via prod_div_telescope"
+      "nineRow_arm_row{0..8} (9 lemmas): arm products via prod_div_telescope",
+      "Session 32 (2026-04-27): removed ni_count_eq_syt_count and lgv_det_factors_as_hook_quotient (dead, unprovable scaffolding with arbitrary (r,σ,m) untied to μ)",
+      "Session 32: replaced removed sorries with OPEN comment block in PART V documenting canonical-config restatement (A) RSK bijection and (B) Lindström/Jacobi-Trudi det identity",
+      "Session 32: documented LGV well-formedness obstruction r-1 ≤ μ.rowLen(r-1), which fails for tall/narrow shapes — needs transpose-duality case split"
     ],
     "insights": [
       "lgv_lemma_rxr in BallotProblemOQ03OQ02.lean is the key building block (Gessel-Viennot involution proof)",
@@ -201,7 +205,9 @@
       "ni_count_eq_syt_count and lgv_det_factors_as_hook_quotient are INCORRECTLY STATED — need canonical youngLGVConfigOf μ",
       "Build regression in BallotProblemOQ03.lean: omega failure near minSharedStepIdx_preserved (not OOM — actual compilation error)",
       "hookProd(μ)/hookProd(μ\\c) = H(c) × ∏_{j<s} H(r,j)/(H(r,j)-1) × ∏_{i<r} H(i,s)/(H(i,s)-1) — verified algebraically for [3,2], hook shapes, rectangles",
-      "For rectangles (1 corner): arm product telescopes to rowLen, leg product to colLen, giving R = rowLen × colLen = |μ|; key evidence the algebraic proof works"
+      "For rectangles (1 corner): arm product telescopes to rowLen, leg product to colLen, giving R = rowLen × colLen = |μ|; key evidence the algebraic proof works",
+      "The two LGV auxiliary lemmas were stated for arbitrary (r, σ, m) with no link to μ. Most parameter choices yield false numerical equalities (e.g. μ=⊥ vs r=1, σ=fun _ => 5). Removing them is honest housekeeping, not a content regression.",
+      "youngLGVConfig wellFormed condition r-1 ≤ σ⟨0⟩ reduces to μ.rowLen(numRows-1) ≥ numRows-1 — fails for tall shapes like (1,1,…,1). The general LGV statement requires applying LGV to whichever of μ, μᵀ is wide enough."
     ],
     "mathlibGaps": [
       "hookLength may not be defined in Mathlib.Combinatorics.YoungDiagram — check arm/leg availability",


### PR DESCRIPTION
## Summary

Three research-session commits on `feature/researcher-10`, bundled into one PR (sequential commits to the same branch within a single agent session):

1. **`ballot-problem-oq-03-oq-01-oq-02` — sorry 3→1 (dead-code removal)** [main change, code]
2. **`ballot-problem-oq-03-oq-01-oq-01-oq-01` — session 10 (survey note)** [knowledge.md only]
3. **`erdos-476-oq-05-wip-01` — sync BLOCKED metadata** [JSON + knowledge.md only]

---

## (1) ballot-problem-oq-03-oq-01-oq-02 — sorry 3 → 1

**Honesty up front**: this commit does **not** prove anything new. The visible sorry-count reduction comes from deleting unprovable scaffolding, not from formalizing new mathematics. `hook_length_formula_general` was already established (modulo `hook_walk_identity`) via corner recursion — the deleted lemmas were not on any proof path.

`proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean`:
- Deleted `ni_count_eq_syt_count` and `lgv_det_factors_as_hook_quotient`. Both took an arbitrary tuple `(r, σ, m)` of LGV parameters with no hypothesis linking them to μ; for almost any parameter choice the equalities reduce to false numerical claims (e.g. μ = ⊥ paired with r = 1, σ = fun _ => 5). Prior session 31 had flagged them with `WARNING: This statement is INCORRECTLY STATED`.
- Replaced with an `OPEN: LGV proof path — canonical-config restatement` comment in PART V documenting the corrected formulation:
  - Canonical encoding `youngLGVConfigOf μ` with `r = μ.colLen 0`, `σ_μ i = μ.rowLen (r-1-i)`, derived `m`.
  - (A) RSK/Fomin bijection: `Fintype.card (StandardYoungTableau μ) = niTupleCount (youngLGVConfigOf μ)` (~200 lines).
  - (B) Lindström / Jacobi–Trudi det identity: `(pathMatrix (youngLGVConfigOf μ)).det * (hookProd μ : ℤ) = μ.card.factorial` (~200 lines).
  - The well-formedness obstruction `r-1 ≤ μ.rowLen (r-1)` fails for tall/narrow shapes; the general LGV statement therefore needs a transpose-duality case split.
- Reworded the trailing docstring on `hook_length_formula` and the top-of-file `### Status` block.

`hook_length_formula_from_chain` is preserved as a clean *conditional* statement that records the LGV chain abstractly and can consume any future proof of (A) and (B).

| Sorry | Before | After |
|---|---|---|
| `ni_count_eq_syt_count` | sorry, incorrectly stated | **removed** |
| `lgv_det_factors_as_hook_quotient` | sorry, incorrectly stated | **removed** |
| `hook_walk_identity` (≥10×≥10 non-rect) | sorry | unchanged (~300-line GNW gap) |

`hook_length_formula_general` and `hook_length_formula` continue to be proved modulo this single `hook_walk_identity` gap.

**Build status**: file is at 14 022 lines (was 14 005), still beyond the practical Docker 32 GB build envelope. The edits are local — a comment block plus one docstring rewording — with no new declarations or tactics, so the change is conservative w.r.t. type-checking risk. Compilation could not be verified this session.

---

## (2) ballot-problem-oq-03-oq-01-oq-01-oq-01 — session 10 (survey only)

A 28-line follow-up commit on the sibling problem (Jacobi-Trudi via SSYT). Surveyed the file state; confirmed the two remaining sorries (`jdt_weight_sum` ~120 lines, `jacobi_trudi_ssyt_eq` k≥3 ~300 lines) are correctly stated as of session 9 and need a focused session, not a quick fix. No code changes — just a knowledge-base entry + refined `nextAction` field.

---

## (3) erdos-476-oq-05-wip-01 — sync BLOCKED metadata

knowledge.md session 2026-04-26 documents this sorry as BLOCKED on the Cauchy-Davenport equality theorem (~500 lines, essentially Vosper itself); four independent approaches (counting, symmetry, orbit, involution-parity) were exhaustively tried and ruled out. But `currentState.blockers = []` and pool status `"available"` were not in sync with that analysis, so `claim-random` keeps re-selecting this problem on every cycle (this very session re-claimed it on iteration 3).

This commit syncs:
- `currentState.focus`, `blockers`, `nextAction` in the problem JSON.
- knowledge.md session-5 entry documenting the metadata sync.

Suggested follow-up: move pool entry's `status` to `"blocked"` (or graduate to a separate Kneser-equality build issue) so this problem stops being re-claimed without productive path forward.

---

## Test plan

- [ ] Inspect `BallotProblemOQ03OQ01OQ02.lean` diff — confirm only the two stale theorems and their docstring/header references are touched
- [ ] Confirm `hook_length_formula_from_chain` still typechecks against existing callers (none, but its statement is unchanged)
- [ ] Gallery integrity: `ballot-problem-oq-03-oq-01-oq-02` meta.json sorries count went 3 → 1 (matches actual file state)
- [ ] No code changes in commits (2) and (3) — only `.json` and `.md` files

🤖 Generated by researcher-10 (3-iteration session)