### PR TITLE
Enrich algebraic-numbers-countable: add 3 canonical references

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable/meta.json
@@ -264,6 +264,27 @@
       "year": "1882",
       "venue": "Mathematische Annalen",
       "note": "Proves \u03c0 is transcendental using Hermite's exponential method; together with Cantor's countability result, establishes that specific transcendentals are hard to identify despite 'almost all' reals being transcendental"
+    },
+    {
+      "authors": "Ivan Niven",
+      "title": "Irrational Numbers",
+      "year": "1956",
+      "venue": "Carus Mathematical Monographs No. 11, Mathematical Association of America",
+      "note": "The standard introductory reference on algebraic and transcendental number theory. Chapter 5 develops the countability of algebraic numbers via the height-function approach, complementing the abstract Mathlib-based proof formalized here. Provides accessible elementary proofs of e and \u03c0 transcendence, the Lindemann-Weierstrass theorem, and the Gelfond-Schneider theorem."
+    },
+    {
+      "authors": "Edward B. Burger; Robert Tubbs",
+      "title": "Making Transcendence Transparent: An Intuitive Approach to Classical Transcendental Number Theory",
+      "year": "2004",
+      "venue": "Springer",
+      "note": "Modern accessible treatment of transcendence theory connecting Cantor's countability argument (Chapter 1) to Liouville's construction (Chapter 2), Hermite-Lindemann (Chapter 3), Gelfond-Schneider (Chapter 4), and Baker's theorem (Chapter 5). Particularly valuable for understanding the dialectic between cardinality-based and construction-based approaches to identifying transcendental numbers \u2014 the very contrast highlighted in this entry's openQuestions and cross-references to liouville-theorem and hermite-lindemann."
+    },
+    {
+      "authors": "Richard Dedekind",
+      "title": "Was sind und was sollen die Zahlen?",
+      "year": "1888",
+      "venue": "Vieweg, Braunschweig",
+      "note": "Dedekind's foundational treatise on set theory and the natural numbers, published 14 years after Cantor's 1874 result. Introduces the formal definition of an infinite set as one equinumerous with a proper subset \u2014 the precise property exhibited here as $|\\text{algebraic reals}| = |\\mathbb{Q}|$ despite $\\mathbb{Q} \\subsetneq \\text{algebraic reals}$. This is the conceptual underpinning of the 'cardinal paradox' formalized in `card_algebraic_eq_card_rat`."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Summary

The references list previously had 4 historical primary sources (Cantor 1874, Hermite 1873, Liouville 1844, Lindemann 1882). Added 3 standard secondary references that round out the modern landscape of transcendence theory:

- **Niven, *Irrational Numbers*** (1956, MAA Carus #11) — standard introductory reference; Chapter 5 develops countability of algebraic numbers via the height-function approach.
- **Burger & Tubbs, *Making Transcendence Transparent*** (2004, Springer) — modern accessible treatment connecting Cantor's argument to Liouville, Hermite-Lindemann, Gelfond-Schneider, Baker. Directly supports the cardinality-vs-construction dialectic this entry's openQuestions emphasize.
- **Dedekind, *Was sind und was sollen die Zahlen?*** (1888) — foundational set-theoretic treatise introducing the definition of an infinite set as one equinumerous with a proper subset, the conceptual underpinning of `card_algebraic_eq_card_rat`.

## Test plan

- [x] `pnpm build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)