### PR TITLE
Research: erdos-1151-oq-04 — document upstream Mathlib API drift blocker

### DIFF
--- a/research/problems/erdos-1151-oq-04/knowledge.md
+++ b/research/problems/erdos-1151-oq-04/knowledge.md
@@ -151,4 +151,70 @@ The current statement with `M < Lₙf(x)` (signed divergence) may require full l
 - `cot_ge_inv_two_mul`: 1/(2t) ≤ cos(t)/sin(t) for t ≤ π/3. Proved via sin(t)≤t and cos(t)≥1/2.
 - `sum_term_eq_tan_half_angle` proof: abs_of_neg + half-angle formula. The `set` tactic was avoided
   to allow `ring` to close the argument equality `φ/2 = (2k+1)π/(4n)` after `rw [harg]`.
-- Note: `congr 1 <;> ring` does NOT work on sin/cos goals; need explicit `have harg` + `rw [harg]`.
+- Note: `congr 1 <;> ring` does NOT work on sin/cos goals; need explicit `command` + `rw [harg]`.
+
+---
+
+## Session 2026-04-27 (researcher-7) — BLOCKED on upstream Mathlib API drift
+
+**Mode**: REVISIT (claimed RICH problem)
+**Outcome**: BLOCKED — main file fails to build on origin/main
+
+### What I Found
+
+The companion file `Erdos1151OQ04Aristotle.lean` JSON metadata claims `sorryCount: 1`,
+but the actual file contains 0 sorries (all proofs complete). Stale metadata.
+
+The main file `Erdos1151OQ04.lean` has **17+ build errors** on origin/main introduced in
+commits 67e2cafc7808 (2026-04-26) and 343f1622666a (2026-04-27). All are Mathlib API
+drift, not Lean errors:
+
+- `div_le_div_iff` → `div_le_div_iff₀` (lines 770, 874, 905)
+- `Nat.eq_or_gt_of_le` removed (line 963)
+- `harmonic_eq_sum_range` unknown identifier (line 913)
+- `Int.even_iff_not_odd.mp` unknown constant (line 1160)
+- `Real.arccos_lt_pi.mpr` unknown constant (line 1166)
+- Several `linarith failed` and `unsolved goals` cascading from the above
+
+The file does not compile. Therefore **no proof work on this problem can be verified**
+until the API drift is fixed (Mechanic territory).
+
+### Attempted Approach (Not Committed)
+
+Considered adding `sin_ge_sin_of_mem_Icc (d θ : ℝ) (...)`: For 0 < d ≤ π/2 and θ ∈ [d, π-d],
+sin d ≤ sin θ. This is Step 4 of the documented `trig_sum_harmonic_lb` proof sketch and
+is purely Mathlib-API-based. The proof I drafted uses `Real.strictMonoOn_sin.monotoneOn`
+plus `Real.sin_pi_sub` for the symmetric case θ > π/2. The proof body itself is independent
+of the broken main file, but the companion file imports `Proofs.Erdos1151OQ04` so its
+build is gated on the main file building. Discarded the edit pending main-file repair.
+
+### Status
+
+Setting status back to `in-progress` (NOT `blocked` — this is recoverable as soon as a
+Mechanic agent fixes the Mathlib API drift). The two outstanding sorries
+(`trig_sum_harmonic_lb` and `divergence_from_lebesgue_growth`) remain genuinely difficult
+research targets; the new blocker is purely an upstream regression and should be cleared
+quickly.
+
+### Next Steps
+
+1. **(Mechanic)** Fix Mathlib API drift in `Erdos1151OQ04.lean` lines 770, 874, 905, 913, 963,
+   1160, 1166 (and resulting cascade errors at 807, 819, 854, 864, 871, 889, 909, 937, 944).
+   Most fixes are mechanical renames (`div_le_div_iff` → `div_le_div_iff₀`,
+   `Int.even_iff_not_odd` → `Int.not_odd_iff_even` or unfold definition, etc.).
+2. **(Researcher, after fix)** Re-attempt adding `sin_ge_sin_of_mem_Icc` to companion file
+   (Step 4 helper for `trig_sum_harmonic_lb`).
+3. **(Researcher, after fix)** Decompose `trig_sum_harmonic_lb` into 3-4 Aristotle-sized
+   helpers (Lipschitz term bound, j-th node distance, sub-sum harmonic estimate, finite-set
+   minimum closure).
+4. **(Researcher, longer-term)** `divergence_from_lebesgue_growth` foundational gap — either
+   weaken to lim sup version or pursue lacunary construction.
+
+### Stale Metadata Discovered
+
+- `src/data/research/problems/erdos-1151-oq-04.json` `leanFiles[0].sorryCount: 5` — actual: 2
+- `src/data/research/problems/erdos-1151-oq-04.json` `leanFiles[1].sorryCount: 1` — actual: 0
+- `leanFiles[0].lineCount: 1001` — actual: 1282
+- `leanFiles[1].lineCount: 141` — actual: 141 (correct)
+
+Updated in this commit.

--- a/src/data/research/problems/erdos-1151-oq-04.json
+++ b/src/data/research/problems/erdos-1151-oq-04.json
@@ -6,8 +6,8 @@
   "tier": "B",
   "path": "full",
   "problemStatement": {
-    "formal": "axiom erdos_1941_divergence (p q : \u2115) (hp : Odd p) (hq : Odd q) (hq1 : 1 < q) (x : \u211d) (hx : x = Real.cos (\u2191p * Real.pi / \u2191q)) : Filter.Tendsto (fun n => chebyshevInterpSeq (fun _ => 0) x n) Filter.atTop Filter.atTop",
-    "plain": "Can the axiom erdos_1941_divergence be proved in Lean 4 by formalizing the Lebesgue function growth rate \u039b\u2099(cos(\u03c0p/q)) \u2192 \u221e for rational cosine points with odd p, q?",
+    "formal": "axiom erdos_1941_divergence (p q : ℕ) (hp : Odd p) (hq : Odd q) (hq1 : 1 < q) (x : ℝ) (hx : x = Real.cos (↑p * Real.pi / ↑q)) : Filter.Tendsto (fun n => chebyshevInterpSeq (fun _ => 0) x n) Filter.atTop Filter.atTop",
+    "plain": "Can the axiom erdos_1941_divergence be proved in Lean 4 by formalizing the Lebesgue function growth rate Λₙ(cos(πp/q)) → ∞ for rational cosine points with odd p, q?",
     "whyMatters": [
       "Eliminates an axiom from Erdos1151Problem.lean, moving from axiomatized to verified",
       "Connects classical approximation theory (Chebyshev nodes, Lebesgue function) to Lean 4",
@@ -21,7 +21,7 @@
       "limitPointSet_isClosed: limit point sets are closed"
     ],
     "open": [
-      "Lebesgue function growth: \u039b\u2099(cos(\u03c0p/q)) \u2192 \u221e as n \u2192 \u221e",
+      "Lebesgue function growth: Λₙ(cos(πp/q)) → ∞ as n → ∞",
       "erdos_1941_divergence: divergence of Chebyshev interpolation at rational cosines"
     ],
     "goal": "Prove erdos_1941_divergence to eliminate the axiom from the gallery"
@@ -30,9 +30,11 @@
     "phase": "ACT",
     "since": "2026-04-21",
     "iteration": 1,
-    "focus": "Read Erdos1151Problem.lean, assess Mathlib for Chebyshev polynomial theory",
-    "blockers": [],
-    "nextAction": "Read proofs/Proofs/Erdos1151Problem.lean, search Mathlib for ChebyshevPolynomial",
+    "focus": "Build blocked by Mathlib API drift in main file. Companion file sorry-free. Awaiting Mechanic repair.",
+    "blockers": [
+      "Erdos1151OQ04.lean fails to build on origin/main: 17+ Mathlib API drift errors. Mechanic must fix before research can resume."
+    ],
+    "nextAction": "Wait for Mechanic to fix main file API drift; then re-attempt sin_ge_sin_of_mem_Icc helper.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -40,55 +42,56 @@
     }
   },
   "knowledge": {
-    "progressSummary": "2 sorries remain: trig_sum_harmonic_lb (Lipschitz+harmonic, self-contained) and divergence_from_lebesgue_growth (lim vs lim sup gap). Case 2 of chebyshev_trig_sum_lb is PROVED modulo trig_sum_harmonic_lb.",
+    "progressSummary": "BLOCKED upstream: main file Erdos1151OQ04.lean has Mathlib API drift errors (div_le_div_iff renamed, Nat.eq_or_gt_of_le removed, etc.) introduced 2026-04-26/27 in commits 67e2cafc/343f1622. Companion file is sorry-free (stale metadata corrected). 2 genuine sorries remain in main file (trig_sum_harmonic_lb, divergence_from_lebesgue_growth) but cannot be worked until Mechanic fixes API drift.",
     "builtItems": [
-      "T_ofNat_ne_zero (n : \u2115) : T \u211d (n : \u2124) \u2260 0 \u2014 Erdos1151OQ04.lean:274",
-      "natDegree_T_ofNat : \u2200 n : \u2115, (T \u211d (n : \u2124)).natDegree = n \u2014 Erdos1151OQ04.lean:282",
-      "leadingCoeff_T_ofNat : \u2200 n \u2265 1, (T \u211d (n : \u2124)).leadingCoeff = 2^(n-1) \u2014 Erdos1151OQ04.lean:306",
+      "T_ofNat_ne_zero (n : ℕ) : T ℝ (n : ℤ) ≠ 0 — Erdos1151OQ04.lean:274",
+      "natDegree_T_ofNat : ∀ n : ℕ, (T ℝ (n : ℤ)).natDegree = n — Erdos1151OQ04.lean:282",
+      "leadingCoeff_T_ofNat : ∀ n ≥ 1, (T ℝ (n : ℤ)).leadingCoeff = 2^(n-1) — Erdos1151OQ04.lean:306",
       "Build fixes: all Session 3 lemmas compile cleanly in Proofs/Erdos1151OQ04.lean",
-      "chebyshev_product_formula: T_n = 2^{n-1} * prod(X - cos phi_k) \u2014 Erdos1151OQ04.lean:309",
-      "lagrange_basis_chebyshev_formula: explicit Lagrange basis via product formula \u2014 Erdos1151OQ04.lean:388",
-      "chebyshev_lebesgue_eq: Lebesgue function explicit formula for ALL n when q odd \u2014 Erdos1151OQ04.lean:498",
-      "x_not_chebyshev_node: parity lemma, cos(pi*p/q) != chebyshevNode n k for all n when p,q odd \u2014 Erdos1151OQ04.lean:534",
-      "chebyshev_lebesgue_eq_all_n: Lebesgue formula for all n when p,q odd \u2014 Erdos1151OQ04.lean:601",
-      "chebyshev_lebesgue_growth: proved (Filter.tendsto_atTop_mono + C\u00b7log(n+1) \u2192 \u221e)",
-      "cos_rational_pi_pos_min: \u2203 \u03b4 > 0 s.t. |cos(n\u03c0p/q)| \u2265 \u03b4 for all n (parity argument)",
-      "x_not_chebyshev_node: cos(\u03c0p/q) \u2260 chebyshevNode n k for all n,k when p,q odd",
-      "chebyshev_trig_sum_lb: sorry (isolated harmonic sum lower bound: S_n \u2265 C\u2082\u00b7n\u00b7log(n+1))",
-      "chebyshev_lebesgue_lb: proved modulo chebyshev_trig_sum_lb via mul_le_mul chain (\u03b4/n \u00b7 C\u2082\u00b7n\u00b7log(n+1) \u2264 |cos(n\u03b8)|/n \u00b7 S_n)",
-      "chebyshev_trig_sum_lb Case 2 PROVED: cos(\u03c0p/q) \u2208 (-1,1) via parity, arccos setup, reduction to trig_sum_harmonic_lb \u2014 Erdos1151OQ04.lean:1146",
-      "trig_sum_harmonic_lb: self-contained sorry for general \u03b8 \u2208 (0, \u03c0), Lipschitz + harmonic Finset argument \u2014 Erdos1151OQ04.lean:1083",
-      "cos_pi_p_q_ne_one: cos(\u03c0p/q) \u2260 1 when p odd (parity: p = 2kq \u2192 even) \u2014 Erdos1151OQ04.lean:1151"
+      "chebyshev_product_formula: T_n = 2^{n-1} * prod(X - cos phi_k) — Erdos1151OQ04.lean:309",
+      "lagrange_basis_chebyshev_formula: explicit Lagrange basis via product formula — Erdos1151OQ04.lean:388",
+      "chebyshev_lebesgue_eq: Lebesgue function explicit formula for ALL n when q odd — Erdos1151OQ04.lean:498",
+      "x_not_chebyshev_node: parity lemma, cos(pi*p/q) != chebyshevNode n k for all n when p,q odd — Erdos1151OQ04.lean:534",
+      "chebyshev_lebesgue_eq_all_n: Lebesgue formula for all n when p,q odd — Erdos1151OQ04.lean:601",
+      "chebyshev_lebesgue_growth: proved (Filter.tendsto_atTop_mono + C·log(n+1) → ∞)",
+      "cos_rational_pi_pos_min: ∃ δ > 0 s.t. |cos(nπp/q)| ≥ δ for all n (parity argument)",
+      "x_not_chebyshev_node: cos(πp/q) ≠ chebyshevNode n k for all n,k when p,q odd",
+      "chebyshev_trig_sum_lb: sorry (isolated harmonic sum lower bound: S_n ≥ C₂·n·log(n+1))",
+      "chebyshev_lebesgue_lb: proved modulo chebyshev_trig_sum_lb via mul_le_mul chain (δ/n · C₂·n·log(n+1) ≤ |cos(nθ)|/n · S_n)",
+      "chebyshev_trig_sum_lb Case 2 PROVED: cos(πp/q) ∈ (-1,1) via parity, arccos setup, reduction to trig_sum_harmonic_lb — Erdos1151OQ04.lean:1146",
+      "trig_sum_harmonic_lb: self-contained sorry for general θ ∈ (0, π), Lipschitz + harmonic Finset argument — Erdos1151OQ04.lean:1083",
+      "cos_pi_p_q_ne_one: cos(πp/q) ≠ 1 when p odd (parity: p = 2kq → even) — Erdos1151OQ04.lean:1151"
     ],
     "insights": [
-      "Lebesgue function \u039b\u2099(x) = \u03a3\u2096 |\u2113\u2096(x)| measures worst-case interpolation amplification",
-      "Growth rate for rational cosines: \u039b\u2099(cos(\u03c0p/q)) \u2265 C\u00b7log(n)",
-      "Divergence of interpolation sequence follows from \u039b\u2099 \u2192 \u221e via bump function",
-      "natDegree and leadingCoeff of T_n proved by two-step induction on recurrence T_{n+2} = 2X\u00b7T_{n+1} - T_n",
-      "Product formula proof strategy: T_n - Q_n has deg < n and n roots (by Chebyshev node roots + card_roots_le_degree) \u2192 T_n = Q_n",
-      "(2 : \u211d[X]) = C 2 via Polynomial.C_ofNat; leadingCoeff_C gives leadingCoeff = 2",
+      "Lebesgue function Λₙ(x) = Σₖ |ℓₖ(x)| measures worst-case interpolation amplification",
+      "Growth rate for rational cosines: Λₙ(cos(πp/q)) ≥ C·log(n)",
+      "Divergence of interpolation sequence follows from Λₙ → ∞ via bump function",
+      "natDegree and leadingCoeff of T_n proved by two-step induction on recurrence T_{n+2} = 2X·T_{n+1} - T_n",
+      "Product formula proof strategy: T_n - Q_n has deg < n and n roots (by Chebyshev node roots + card_roots_le_degree) → T_n = Q_n",
+      "(2 : ℝ[X]) = C 2 via Polynomial.C_ofNat; leadingCoeff_C gives leadingCoeff = 2",
       "apply lemma fails when conclusion has concrete value (n+2) vs metavar (p.natDegree): use have key := lemma proof; rw [key]",
-      "\u2115 strict bound j.val < n does NOT give 2*j+1 < 2*n in \u211d via linarith; need omega on \u2115 then exact_mod_cast",
-      "div_lt_iff renamed to div_lt_iff\u2080 in Mathlib v4.26.0",
-      "Session 5 proved product formula, lagrange basis formula, and lebesgue_eq (sorries: 4\u21922)",
+      "ℕ strict bound j.val < n does NOT give 2*j+1 < 2*n in ℝ via linarith; need omega on ℕ then exact_mod_cast",
+      "div_lt_iff renamed to div_lt_iff₀ in Mathlib v4.26.0",
+      "Session 5 proved product formula, lagrange basis formula, and lebesgue_eq (sorries: 4→2)",
       "x_not_chebyshev_node: cos(pi*p/q) is NEVER a Chebyshev node when q is odd (parity: q*(2k+1) is odd, angle condition requires even = odd)",
       "chebyshev_lebesgue_eq_all_n: applies for ALL n when p,q odd (not just n=mq subsequence)",
       "divergence_from_lebesgue_growth fundamental gap: Banach-Steinhaus only gives lim sup = inf, not lim = +inf; axiom may be overstated",
-      "chebyshev_lebesgue_growth reduces to lb sorry via tendsto_atTop_mono \u2014 growth theorem itself is proved",
-      "Filter.tendsto_atTop_mono pattern: if f \u2264 g pointwise and f \u2192 \u221e then g \u2192 \u221e",
+      "chebyshev_lebesgue_growth reduces to lb sorry via tendsto_atTop_mono — growth theorem itself is proved",
+      "Filter.tendsto_atTop_mono pattern: if f ≤ g pointwise and f → ∞ then g → ∞",
       "let binding in Lean 4 requires explicit unfolding in simp: simp only [vals, ...]",
-      "chebyshev_lebesgue_growth is PROVED (not sorry) \u2014 wraps chebyshev_lebesgue_lb which assumes sorry #1",
+      "chebyshev_lebesgue_growth is PROVED (not sorry) — wraps chebyshev_lebesgue_lb which assumes sorry #1",
       "p,q both odd implies cos(pi*p/q) is strictly in (-1,1), so sin argument is nonzero. Case x=+-1 never occurs in hypotheses.",
-      "Session 13: Case 2 factored into self-contained trig_sum_harmonic_lb(\u03b8, h\u03b8\u2208(0,\u03c0), hne). No dependency on p,q.",
-      "Real.arccos_pos.mpr / Real.arccos_lt_pi.mpr: get strict bounds \u03b8\u2080 \u2208 (0,\u03c0) from x \u2208 (-1,1)",
-      "Real.cos_eq_one_iff: cos x = 1 \u2194 \u2203 k : \u2124, x = k*(2\u03c0). Use to show cos(\u03c0p/q) \u2260 1 from p odd.",
-      "LipschitzWith.dist_le_mul converts edist bound to |cos \u03b1 - cos \u03b2| \u2264 |\u03b1 - \u03b2| via Real.dist_eq"
+      "Session 13: Case 2 factored into self-contained trig_sum_harmonic_lb(θ, hθ∈(0,π), hne). No dependency on p,q.",
+      "Real.arccos_pos.mpr / Real.arccos_lt_pi.mpr: get strict bounds θ₀ ∈ (0,π) from x ∈ (-1,1)",
+      "Real.cos_eq_one_iff: cos x = 1 ↔ ∃ k : ℤ, x = k*(2π). Use to show cos(πp/q) ≠ 1 from p odd.",
+      "LipschitzWith.dist_le_mul converts edist bound to |cos α - cos β| ≤ |α - β| via Real.dist_eq"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "PROVE trig_sum_harmonic_lb: Finset reindexing for near-nodes (Lipschitz + odd_harmonic_sum_lb + finite min). ~100-150 lines.",
-      "divergence_from_lebesgue_growth: weaken to lim sup = \u221e (Banach-Steinhaus) or find explicit lacunary construction.",
-      "For trig_sum_harmonic_lb: use pattern from trig_sum_lb_of_cos_eq_neg_one (sub-sum over n/2 nodes, reindex via injection, sum_le_sum). Key difference: use Lipschitz bound instead of half-angle identity."
+      "(Mechanic) Fix Mathlib API drift in Erdos1151OQ04.lean — see knowledge.md session 2026-04-27 for line-by-line list",
+      "(Researcher, after Mechanic fix) Add sin_ge_sin_of_mem_Icc helper to companion file (Step 4 of trig_sum_harmonic_lb proof sketch)",
+      "(Researcher, after Mechanic fix) Decompose trig_sum_harmonic_lb into 3-4 Aristotle-sized helpers",
+      "(Researcher, longer-term) Address divergence_from_lebesgue_growth foundational lim/limsup gap"
     ]
   },
   "tags": [
@@ -112,18 +115,18 @@
     "mathlib": []
   },
   "started": "2026-04-21T19:30:00.000Z",
-  "lastUpdate": "2026-04-21T19:30:00.000Z",
+  "lastUpdate": "2026-04-27T12:50:00.000Z",
   "significance": 7,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/Erdos1151OQ04.lean",
       "filename": "Erdos1151OQ04.lean",
-      "lineCount": 1001,
+      "lineCount": 1282,
       "theoremCount": 29,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 5,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1151OQ04.lean"
     },
@@ -134,7 +137,7 @@
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1151OQ04Aristotle.lean"
     },


### PR DESCRIPTION
## Summary
Documents an upstream blocker on `proofs/Proofs/Erdos1151OQ04.lean`: the file fails to build on `origin/main` due to 17+ Mathlib API drift errors introduced in commits 67e2cafc7808 (2026-04-26) and 343f1622666a (2026-04-27).

Also fixes stale metadata in `src/data/research/problems/erdos-1151-oq-04.json`:
- `Erdos1151OQ04.lean.sorryCount`: 5 → 2 (actual count), `lineCount`: 1001 → 1282
- `Erdos1151OQ04Aristotle.lean.sorryCount`: 1 → 0 (companion file is sorry-free)

## Findings
Build errors all stem from Mathlib API drift, not Lean-level breakage:

| Line | Symbol | Issue |
|------|--------|-------|
| 770, 874, 905 | `div_le_div_iff` | Renamed to `div_le_div_iff₀` |
| 913 | `harmonic_eq_sum_range` | Unknown identifier |
| 963 | `Nat.eq_or_gt_of_le` | Removed |
| 1160 | `Int.even_iff_not_odd.mp` | Unknown constant |
| 1166 | `Real.arccos_lt_pi.mpr` | Unknown constant |
| 807, 819, 854, 864, 871, 889, 909, 937, 944 | various | `linarith failed` / `unsolved goals` cascading from above |

This is mechanical Mathlib upgrade work — appropriate for a Mechanic agent. As a Researcher I cannot verify any proof work on this problem until the API drift is repaired.

## Planned (Not Committed) Research Approach
For when the file builds again: Add `sin_ge_sin_of_mem_Icc (d θ : ℝ) (...)` to `Erdos1151OQ04Aristotle.lean` — Step 4 of the documented `trig_sum_harmonic_lb` proof sketch (sin lower bound on `[d, π-d]` via `Real.strictMonoOn_sin.monotoneOn` + `Real.sin_pi_sub` for the symmetric case θ > π/2). The helper is purely Mathlib-API-based and would be the first of 3-4 decompositions of `trig_sum_harmonic_lb` into Aristotle-tractable pieces.

## Status
**Outcome**: blocked (upstream)
**Next Steps**: Mechanic fixes the API drift; then Researcher resumes with the sin lower-bound helper and the larger `trig_sum_harmonic_lb` decomposition.

🤖 Generated by researcher-7