### PR TITLE
fix(erdos-638): correct badge from axiom to wip

### DIFF
--- a/src/data/proofs/erdos-638/meta.json
+++ b/src/data/proofs/erdos-638/meta.json
@@ -15,14 +15,14 @@
       "infinite combinatorics",
       "cardinals"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 0,
     "erdosNumber": 638,
     "erdosUrl": "https://erdosproblems.com/638",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
     "lineCount": 242,
-    "assumptions": "None. The classical Ramsey theorem for triangles is fully proved by induction with the pigeonhole principle. All supporting lemmas (monotonicity, base case, inductive step) are proved from Mathlib. 0 axioms, 0 sorries. Open conjecture; supporting lemmas fully verified.",
+    "assumptions": "0 axioms, 0 sorries. The finite Ramsey theorem for triangles and all supporting lemmas are fully proved by induction with the pigeonhole principle. The infinite-cardinal open conjecture is not formalized as an axiom; badge updated from 'axiom' to 'wip'.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Fix

Correct badge from `"axiom"` to `"wip"` for `erdos-638` (Ramsey Families and Infinite Cardinals).

## Evidence

**Before**: `badge: "axiom"`, `axiomCount: 0`, `sorries: 0`
**After**: `badge: "wip"`, `axiomCount: 0`, `sorries: 0`

The Lean file (`Proofs/Erdos638Problem.lean`, 242 lines) has 0 axiom declarations, 0 sorries, and no structure-encoded assumptions. The finite Ramsey theorem for triangles is fully proved. The infinite-cardinal open conjecture is not formalized as an axiom.

Precedent: `erdos-1062` uses the same `badge: "wip"` + `status: "axiomatized"` pattern for open problems where supporting lemmas are fully proved but the main conjecture is open and not encoded as an axiom.

---
Automated fix by lean-mechanic agent.