### PR TITLE
audit: fix erdos-981 originalContributions to match Lean source

### DIFF
--- a/src/data/proofs/erdos-981/meta.json
+++ b/src/data/proofs/erdos-981/meta.json
@@ -51,11 +51,14 @@
       "characterSum N p: ∑_{n≤N} (n/p) partial sum",
       "isBoundedFrom ε p m: bound condition for stabilization",
       "fEps ε p: stabilization threshold f_ε(p)",
-      "sumFEps ε x: sum over primes p < x",
+      "asymptoticFunc x: PNT-form denominator x/log x",
+      "fEpsAlt ε p: first-passage alternative stabilization threshold",
+      "isQuadraticResidue: quadratic residue predicate",
+      "sumFEps axiom: sum of f_ε(p) over primes p < x",
       "elliott_1969 axiom: main asymptotic result",
-      "polya_vinogradov axiom: character sum bounds",
-      "burgess_bound axiom: improved short sum bounds",
-      "tang_zhang_2025 axiom: alternative formulation result"
+      "sumFEpsAlt axiom: sum of fEpsAlt(p) over primes p < x",
+      "tang_zhang_2025 axiom: alternative formulation result",
+      "erdos_981 theorem: combined resolution"
     ],
     "axiomCount": 4,
     "lineCount": 175,


### PR DESCRIPTION
## Summary

- Removes phantom axioms `polya_vinogradov` and `burgess_bound` from `originalContributions` — they exist only as docstring comments in `proofs/Proofs/Erdos981Problem.lean`, not as actual `axiom` declarations.
- Adds the missing `sumFEpsAlt` axiom (which is present in the Lean file and already correctly listed in the `assumptions` field).
- Adds the omitted definitions (`asymptoticFunc`, `fEpsAlt`, `isQuadraticResidue`) and the top-level `erdos_981` theorem.

## Audit context

Field-by-field reality check against `proofs/Proofs/Erdos981Problem.lean`:

| meta.json | Lean reality | Match |
|---|---|---|
| `sorries: 0` | 0 sorries | ✓ |
| `axiomCount: 4` | 4 axioms (`sumFEps`, `elliott_1969`, `sumFEpsAlt`, `tang_zhang_2025`) | ✓ |
| `assumptions` | matches | ✓ |
| `definitionCount: 7` | 7 defs | ✓ |
| `theoremCount: 1` | 1 theorem (`erdos_981`) | ✓ |
| `status: "axiomatized"`, `badge: "axiom"` | correct for axiomatized | ✓ |
| `originalContributions` | listed 2 phantom axioms, missed `sumFEpsAlt` + 3 defs + theorem | ✗ → fixed |

No content (mathematical claims, status, or badge) is changed — this is purely a contributions-list integrity fix.

## Test plan

- [x] meta.json still parses as valid JSON
- [x] `axiomCount` and `assumptions` were already correct and remain unchanged
- [x] No Lean file changes; no rebuild needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)