### PR TITLE
Research: ballot-problem-oq-03-oq-01-oq-01-oq-01 — Session 11 b=1 recipe

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
@@ -382,9 +382,42 @@ private lemma jdt_weight_sum (n a b : ℕ) (hba : b ≤ a) :
     -- Need: weight-preserving bijection
     --   {non-col-strict (a,b) pairs} ≃ {all (a+1, b-1) pairs}
     -- Forward map: find first violation c in ColStrictSym, let v = Q.sort[c],
-    --   then P' = Sym.cons v P, Q' = Sym.erase Q v
+    --   then P' = Sym.cons v P, Q' = Sym.erase Q v (need v ∈ Q.1)
     -- Inverse map: find the "seam" element in P'.sort to move back to Q'
     -- Weight preserved by Multiset.prod_cons + Multiset.prod_erase
+    --
+    -- ============================================================================
+    -- DETAILED RECIPE FOR b = 1 BASE CASE (helper for next session)
+    -- ============================================================================
+    -- When b = 1, ColStrictSym a 1 P Q says P.sort[0] < Q.sort[0]; ¬cs gives the
+    -- opposite. Q has size 1, so by Sym.oneEquiv we have Q = oneEquiv q for some
+    -- q : Fin n, with q = Q.sort[0] (only element). Goal becomes:
+    --
+    --   ∑_{(P, q): q ≤ P.sort[0]} wt(P) * X q = h_{a+1}
+    --
+    -- BIJECTION ψ : {(P, q) : q ≤ P.sort[0]} ≃ Sym (Fin n) (a+1)
+    --   forward (P, q) ↦ q ::ₛ P            -- Sym.cons; coe = q ::ₘ P.1
+    --   inverse P' ↦ ((P'.erase q', oneEquiv q')) where
+    --     q' := (P'.1.sort (· ≤ ·)).head    -- smallest element
+    --     proof q' ∈ P'.1: q' is the head of (length a+1) sorted list
+    --     proof q' ≤ (P'.erase q').sort[0]: erase preserves sortedness; q' was min
+    --   weight preservation:
+    --     wt(P) * X q
+    --     = (P.1.map X).prod * X q
+    --     = ((q ::ₘ P.1).map X).prod          -- by Multiset.prod_cons + map_cons
+    --     = wt(q ::ₛ P)
+    -- KEY LEMMAS:
+    --   * Multiset.sort_cons (∀ b ∈ s, r a b) : sort(a ::ₘ s) = a :: sort(s)
+    --     applied with: q ≤ P.sort[0] implies q ≤ all elements of P (sortedness)
+    --   * Sym.cons_erase : a ::ₛ s.erase a h = s  (closes left_inv)
+    --   * Sym.erase_cons_head : (a ::ₛ s).erase a _ = s  (closes right_inv direction)
+    -- ESTIMATE: ~80-100 lines for jdt_weight_sum_b_one as a separate helper.
+    -- ============================================================================
+    --
+    -- For b ≥ 2, the bijection generalizes: insert Q.sort[c] into P at position c,
+    -- where c is the first violation index. The inverse map is the JDT seam
+    -- algorithm (find c such that P'.sort[c] came from Q's c-th violation column).
+    -- This is genuinely intricate; ~150-200 lines of focused Lean work.
     sorry
   · -- b = 0: ColStrictSym a 0 P Q is vacuously true (quantifies over Fin (min a 0) = Fin 0)
     -- So ¬ColStrictSym = False, the subtype is empty, and the sum equals 0

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/knowledge.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/knowledge.md
@@ -491,6 +491,72 @@ symmetric polynomials: `s_λ = det[h_{λᵢ-i+j}]`. The proof route via SSYT and
 
 ---
 
+## Session 2026-04-27 (Session 11) — Concrete b=1 Recipe Documented
+
+**Mode**: REVISIT (RICH, score 73)
+**Outcome**: SURVEY+ — added actionable b=1 proof recipe to file; no sorry count change
+
+### What I Did
+
+Confirmed the file's two open sorries are stable (jdt_weight_sum b≥1, jacobi_trudi_ssyt_eq k≥3).
+Investigated relevant Mathlib API:
+
+- **`Sym.oneEquiv : α ≃ Sym α 1`** (Mathlib.Data.Sym.Basic:477) — provides clean
+  Sym n 1 ↔ Fin n conversion: `oneEquiv a = ⟨{a}, _⟩`.
+- **`Sym.cons : α → Sym α n → Sym α (n+1)`** (denoted `::ₛ`, line 106). Coercion
+  is `(a ::ₛ s : Multiset) = a ::ₘ s.1`.
+- **`Sym.erase [DecidableEq α] : Sym α (n+1) → α → (a ∈ s) → Sym α n`** (line 203).
+- **`Sym.cons_erase : a ::ₛ s.erase a h = s`** (line 219) — left-inverse closer.
+- **`Sym.erase_cons_head : (a ::ₛ s).erase a _ = s`** (line 223) — round-trip.
+- **`Multiset.sort_cons : (∀ b ∈ s, r a b) → sort (a ::ₘ s) r = a :: sort s r`**
+  (Multiset/Sort.lean:69) — KEY for showing that consing the min preserves sort head.
+
+Added an explicit recipe block to `BallotProblemOQ03OQ01OQ01OQ01.lean` at the b≥1
+branch of `jdt_weight_sum` describing the b=1 bijection construction in concrete
+Lean terms. This makes the next session's implementation mechanical.
+
+### Concrete b=1 Recipe (already documented in file, recorded here for posterity)
+
+```text
+-- LHS for b=1 (after Sym.oneEquiv reparameterization):
+--   ∑_{(P : Sym n a, q : Fin n) // q ≤ P.sort[0]} wt(P) * X q
+-- RHS: h_{a+1} = ∑_{P' : Sym n (a+1)} wt(P').
+
+-- Bijection ψ:
+--   forward (P, q, h) ↦ q ::ₛ P
+--   inverse P' ↦ ((P'.erase q', oneEquiv q'), proof) where q' = P'.sort.head
+--   left_inv: erase_cons_head (q is the head we just consed)
+--   right_inv: cons_erase (after extracting min, consing it back gives P')
+-- Weight preservation (single line):
+--   wt(P) * X q = ((q ::ₘ P.1).map X).prod = wt(q ::ₛ P)
+-- via Multiset.prod_cons + Multiset.map_cons.
+```
+
+### Why I Didn't Implement
+
+Without local docker build feedback, attempting an 80-100 line bijection proof
+risks breaking compilation in subtle ways (Fin coercions, sort.head pos proofs,
+etc.). The recipe captures the math precisely so a session with build access
+can implement directly.
+
+### Files Modified
+
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean` (~30 lines of detailed
+  recipe added in `jdt_weight_sum` b≥1 branch comment)
+- `research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/knowledge.md` (this file)
+
+### Sorry Count: 2 (unchanged)
+
+### Next Session Owner
+
+Implement `jdt_weight_sum_b_one` as a separate `private lemma` using the
+documented recipe. Estimated 60-90 lines focused work given the API references
+are now explicit. Then refactor `jdt_weight_sum` to dispatch on b ∈ {0, 1, ≥2}.
+The b≥2 case remains the JDT seam construction (~150 lines) and is the
+real frontier.
+
+---
+
 ## Session 2026-04-27 (Session 10) — Survey only; no code changes
 
 **Mode**: REVISIT (RICH, score 72)

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
@@ -18,10 +18,10 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-04-23T12:58:12+02:00",
-    "iteration": 2,
+    "iteration": 3,
     "focus": "Building Jacobi-Trudi determinant formula in Lean 4 using Mathlib hsymm",
     "blockers": [],
-    "nextAction": "Targeted JDT bijection session: define forward map (P plus Q.sort[c], Q minus Q.sort[c]) and inverse (seam in Pprime), prove Equiv plus Multiset.prod_cons/prod_erase weight preservation. ~120 focused lines for jdt_weight_sum alone.",
+    "nextAction": "Implement jdt_weight_sum_b_one using documented recipe (Sym.oneEquiv + Sym.cons + Multiset.sort_cons + Multiset.prod_cons).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: jdt_weight_sum b=0 case proved (vacuously true). 2 sorries remain: jdt_weight_sum b>=1 (JDT bijection ~100 lines) + jacobi_trudi_ssyt_eq k>=3 (LGV+RSK ~300 lines).",
+    "progressSummary": "PROGRESS: Session 11 (2026-04-27) added actionable b=1 proof recipe to file; 2 sorries remain (jdt_weight_sum b≥1 with concrete recipe, jacobi_trudi_ssyt_eq k≥3).",
     "builtItems": [
       "jacobiTrudiMatrix: Matrix (Fin k) (Fin k) (MvPolynomial σ R) — entry (i,j) = hsymm (sh_i + j - i) or 0",
       "schurPolynomial: MvPolynomial σ R = det(jacobiTrudiMatrix) — the Jacobi-Trudi formula as definition",
@@ -98,7 +98,8 @@
       "ssytSchurFin_two_row proof pattern: cs = total - ncs; Fintype.sum_subtype_add_sum_subtype splits into cs+ncs=total; eq_sub_of_add_eq closes after substituting rowPair_sum_weight and nonColStrict_sum_weight",
       "ssytFin_two_row_eq_sum_colstrict proved via explicit SSYTFin ≃ colstrict-pair Equiv; uses ssytFin_row_sort_eq_ofFn helper that shows sort of sorted row = same row via mergeSort_eq_self",
       "ColStrictSym definition: P.sort[j] < Q.sort[j] for all j < min(a,b); Decidable via Fintype.decidableForallFintype; key for separating SSYT contributions by column-strict pairs",
-      "Session 10 (2026-04-27, survey only): both remaining sorries (jdt_weight_sum, jacobi_trudi_ssyt_eq k>=3) are correctly stated as of session 9. No fast fixes available; each is a focused 100-300 line proof body. Released for an agent with budget for sustained work."
+      "Session 10 (2026-04-27, survey only): both remaining sorries (jdt_weight_sum, jacobi_trudi_ssyt_eq k>=3) are correctly stated as of session 9. No fast fixes available; each is a focused 100-300 line proof body. Released for an agent with budget for sustained work.",
+      "Session 11 (2026-04-27): documented concrete b=1 recipe using Sym.oneEquiv (alpha ≃ Sym alpha 1, Mathlib.Data.Sym.Basic:477), Sym.cons/cons_erase/erase_cons_head, and Multiset.sort_cons. Recipe lives in jdt_weight_sum b≥1 branch comment as actionable Lean plan. Next session can implement jdt_weight_sum_b_one directly without re-discovering API."
     ],
     "mathlibGaps": [
       "No Mathlib SchurPolynomial definition — we provide one via Jacobi-Trudi formula",
@@ -106,10 +107,10 @@
       "RSK correspondence not formalized in Mathlib — needed for jacobiTrudi_lgv_proof"
     ],
     "nextSteps": [
-      "Submit twoRow_equiv and twoRow_equiv_weight to Aristotle (mechanical sorries)",
-      "Implement nonColStrict_sum_weight via jdt bijection: define jdtForward (insert Q[c] into P at violation c), prove it is an Equiv to RowPair (a+1)(b-1), show weight-preserving, apply rowPair_sum_weight",
-      "Once nonColStrict_sum_weight proved, ssytSchurFin_two_row has 0 sorries — only k>=3 remains",
-      "Prove jdt_weight_sum: construct explicit weight-preserving bijection {non-col-strict (a,b)} ≃ {all (a+1,b-1)} via multiset insert/erase; inverse is the seam-finding operation"
+      "Implement jdt_weight_sum_b_one (~60-90 lines) using documented recipe: bijection {(P, q): q ≤ P.sort[0]} ≃ Sym n (a+1) via cons/erase, with weight preserved by prod_cons + map_cons",
+      "Refactor jdt_weight_sum to dispatch on b ∈ {0, 1, ≥2} cases, eliminating the b=1 sorry",
+      "Tackle b≥2 JDT seam construction (~150 lines) — the genuine frontier",
+      "Alternative: build algebraic LGV in BallotProblemOQ03AlgebraicLGV.lean for k≥3 case (~150 lines)"
     ],
     "markdown": "# Knowledge Base: LGV Lemma → Jacobi-Trudi Identity\n\n**Problem**: ballot-problem-oq-03-oq-01-oq-01-oq-01\n**Last Updated**: 2026-04-23\n**Knowledge Items**: 0\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\nNewly selected. Jacobi-Trudi identity expresses Schur polynomials as determinants of\ncomplete homogeneous symmetric polynomials. The LGV lemma (in parent gallery proof)\nprovides the combinatorial proof route via non-intersecting lattice paths.\n\n---\n\n## Insights\n\n_None yet — begin with OBSERVE phase: check Mathlib for SSYT formalization._\n\n---\n\n## Dead Ends\n\n_None identified yet._\n"
   },
@@ -143,7 +144,7 @@
     "mathlib": []
   },
   "started": "2026-04-23T11:05:51.190Z",
-  "lastUpdate": "2026-04-26T00:00:00.000Z",
+  "lastUpdate": "2026-04-27T00:00:00.000Z",
   "leanFiles": [
     {
       "path": "Proofs/BallotProblem.lean",


### PR DESCRIPTION
## Summary
Session 11 research iteration on `ballot-problem-oq-03-oq-01-oq-01-oq-01` (LGV → Jacobi-Trudi).

Documented a concrete, actionable Lean recipe for the b=1 case of `jdt_weight_sum`, based on a Mathlib API audit. Recipe lives in the file's b≥1 branch comment (~30 lines) so the next focused session can implement directly.

## Progress
- Audited Mathlib `Sym`/`Multiset` API: identified `Sym.oneEquiv`, `Sym.cons`/`cons_erase`/`erase_cons_head`, `Multiset.sort_cons`, `Multiset.prod_cons` as the building blocks
- Added a step-by-step recipe block inside `jdt_weight_sum` documenting:
  - Reparameterization via `Sym.oneEquiv: Fin n ≃ Sym (Fin n) 1`
  - Forward/inverse bijection construction `(P, q) ↔ q ::ₛ P`
  - Weight preservation via `Multiset.prod_cons + map_cons`
- Updated `knowledge.md` with Session 11 entry (concrete recipe + next-step guidance)
- Updated `src/data/research/problems/<slug>.json` insights and nextSteps

## Files Modified
- `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean` (633 → 666 lines; comment-only changes)
- `research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/knowledge.md`
- `src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json`

## Honesty Note
**Sorry count unchanged (2).** This iteration is infrastructure-only — it converts a generic "use JDT bijection" comment into a step-by-step Lean recipe with named lemmas and proof tactics. The next session that has docker-build feedback can implement `jdt_weight_sum_b_one` (~60-90 lines) directly from the recipe.

This is more substantive than Session 10 (pure text survey) but still falls short of changing the sorry count. The b=1 base case is genuinely tractable; the b≥2 case (JDT seam construction, ~150 lines) remains the real frontier.

## Status
**Outcome**: surveyed (recipe documented, no proof attempted)
**Next Steps**:
1. Implement `jdt_weight_sum_b_one` using documented recipe (~60-90 lines)
2. Refactor `jdt_weight_sum` to dispatch on b ∈ {0, 1, ≥2}
3. Tackle b≥2 JDT seam construction or pivot to algebraic LGV for k≥3

🤖 Generated by researcher-3