### PR TITLE
Research: erdos-456 — document Mathlib.Data.Rat.Order import drift blocker

### DIFF
--- a/research/problems/erdos-456/knowledge.md
+++ b/research/problems/erdos-456/knowledge.md
@@ -64,7 +64,45 @@ Back to the problem
 
 ## Sessions
 
-(No research sessions yet)
+### Session 1 (2026-04-27) — Mathlib API Drift Confirmed (Build Blocked)
+
+**Mode**: REVISIT (claimed RICH, score 29)
+**Outcome**: BLOCKED — file does not build on `origin/main` due to a removed Mathlib module
+
+#### Build Verification
+Ran `LEAN_MEMORY_LIMIT=6144 ./proofs/scripts/docker-build.sh Proofs.Erdos456Problem`. The build fails before any Lean code in this repo is checked:
+
+```
+error: no such file or directory (error code: 2)
+  file: .lake/packages/mathlib/Mathlib/Data/Rat/Order.lean
+error: Proofs/Erdos456Problem.lean: bad import 'Mathlib.Data.Rat.Order'
+```
+
+`Mathlib.Data.Rat.Order` no longer exists in Mathlib (likely merged into `Mathlib.Data.Rat.Basic` or similar in the same 2026-04-26 upgrade cohort that broke `Erdos1151OQ04` and `AngleTrisectionOQ02OQ01OQ02Incomplete01`).
+
+Both files have the broken import:
+- `proofs/Proofs/Erdos456Problem.lean:38`
+- `proofs/Proofs/Erdos456Aristotle.lean:16`
+
+#### State of the Lean Code (when import is restored)
+A grep audit of both files shows **0 axiom declarations and 0 sorry instances** (excluding occurrences in comments/docstrings):
+
+- `Erdos456Problem.lean`: 272 lines, 15 theorems, 6 defs, 0 axioms, 0 sorries
+- `Erdos456Aristotle.lean`: 83 lines, 3 theorems, 2 defs, 0 axioms, 0 sorries
+
+Both `meta.json` and the `leanFiles` block in the problem JSON are roughly accurate on `axiomCount` and `sorries`, but the `progressSummary` says "2 deep axioms (linnik_bound, m_over_n_diverges)" — this is **stale**. Those axioms were eliminated in earlier sessions; the progressSummary needs updating to reflect that the file is fully verified except for the open conjectures (which are stated as `def Prop`, not as `axiom`).
+
+#### Why I Did Not Fix
+Per project memory `project_mathlib_api_drift_2026_04`, removing or renaming a Mathlib import is part of the same upgrade-cohort drift that researchers should not fix in research sessions. The right owner is the Mechanic agent. I have, however, refreshed the JSON metadata where it was clearly stale (separate from the import drift).
+
+#### Files Modified
+- `research/problems/erdos-456/knowledge.md` — this entry
+- `src/data/research/problems/erdos-456.json` — `progressSummary`, `currentState.blockers`, Session 1 insight
+
+#### Next Steps
+1. Mechanic should remove the `Mathlib.Data.Rat.Order` import (and verify nothing in the file depended uniquely on it; ℚ comparisons used in `AlmostAll` may need a replacement import like `Mathlib.Data.Rat.Defs` or the order content reaches via `Mathlib.NumberTheory.LSeries.PrimesInAP`)
+2. After build is green: SOLVED-style follow-up — generate strong open questions (e.g., unconditional `mₙ < pₙ` infinitely often via van Doorn for `n = 2^{2k+1}, k ≥ 1` using `3 ∣ 2^{2k+1}+1`, sharpening `part1_implies_infinitely_many` to drop the conjecture hypothesis)
+3. Refresh `progressSummary` to drop the stale "2 deep axioms" claim
 
 ---
 

--- a/src/data/research/problems/erdos-456.json
+++ b/src/data/research/problems/erdos-456.json
@@ -20,8 +20,10 @@
     "since": "2026-01-13T04:11:10.511Z",
     "iteration": 3,
     "focus": "All provable content proved. 2 deep axioms (Linnik, m/n divergence) remain — genuinely unprovable from Mathlib.",
-    "blockers": [],
-    "nextAction": "None — problem is complete.",
+    "blockers": [
+      "Mathlib API drift on origin/main: Mathlib.Data.Rat.Order module no longer exists. Affects both Erdos456Problem.lean (line 38) and Erdos456Aristotle.lean (line 16). Verified via Docker build 2026-04-27."
+    ],
+    "nextAction": "Wait for Mechanic to repair import drift; then SOLVED follow-up (van Doorn unconditional infinitely-many).",
     "attemptCounts": {
       "total": 3,
       "currentApproach": 1,
@@ -29,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: 0 sorries, 2 deep axioms (linnik_bound, m_over_n_diverges). 9 formerly-axiom properties proved from sInf + Dirichlet (Mathlib PrimesInAP). Gallery sections updated.",
+    "progressSummary": "BLOCKED (upstream): file fails to build on origin/main because Mathlib.Data.Rat.Order module no longer exists in Mathlib (verified by Docker build 2026-04-27). Once the import is repaired, the actual file state is 0 axioms / 0 sorries across both Erdos456Problem.lean and Erdos456Aristotle.lean (the prior progressSummary mentioning 2 deep axioms is stale — those were eliminated; only the conjectures Part1/Part2/Part3 remain unproved as open Props).",
     "builtItems": [
       "part2_implies_part1: SORRY FILLED — Part2 implies Part1 via C=2 argument",
       "part1_implies_infinitely_many: SORRY FILLED — using erdos_strict_inequality axiom",
@@ -60,7 +62,8 @@
       "part1_implies_infinitely_many: uses erdos_strict_inequality axiom directly (cleaner than density→counting conversion)",
       "All 3 sorries eliminated: file now has 4 axioms (all deep) and 0 sorries",
       "Eliminated erdos_strict_inequality axiom via pigeonhole: AlmostAll P → ∀ N, ∃ n ≥ N, P n (take ε=1/2, M=max(N₀,2N+1), contradiction on [N,M))",
-      "Eliminated dirichlet_primes_mod1 axiom: Mathlib PrimesInAP has Nat.forall_exists_prime_gt_and_modEq, converted via modEq_iff_dvd_prime"
+      "Eliminated dirichlet_primes_mod1 axiom: Mathlib PrimesInAP has Nat.forall_exists_prime_gt_and_modEq, converted via modEq_iff_dvd_prime",
+      "Session 1 (2026-04-27): Erdos456Problem.lean and Erdos456Aristotle.lean both fail to build on origin/main: import Mathlib.Data.Rat.Order is gone (module removed). Same 2026-04-26 Mathlib upgrade cohort as Erdos1151OQ04 and AngleTrisectionOQ02OQ01OQ02Incomplete01."
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -82,7 +85,7 @@
     "mathlib": []
   },
   "started": "2026-01-13T04:11:10.511Z",
-  "lastUpdate": "2026-03-28T11:57:00.000Z",
+  "lastUpdate": "2026-04-27T12:50:00Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [


### PR DESCRIPTION
## Summary
Documents an upstream blocker on `proofs/Proofs/Erdos456Problem.lean` and `proofs/Proofs/Erdos456Aristotle.lean`: both files fail to build on `origin/main` because `Mathlib.Data.Rat.Order` no longer exists.

This is the same 2026-04-26 Mathlib upgrade cohort as PR #13142 (researcher-7's `Erdos1151OQ04` blocker doc) and PR #13159 (researcher-1's `AngleTrisectionOQ02OQ01OQ02Incomplete01` blocker doc — also from this session). The drift here is a module removal rather than a renamed lemma.

## Findings
Verified by `LEAN_MEMORY_LIMIT=6144 ./proofs/scripts/docker-build.sh Proofs.Erdos456Problem`:

```
error: no such file or directory (error code: 2)
  file: .lake/packages/mathlib/Mathlib/Data/Rat/Order.lean
error: Proofs/Erdos456Problem.lean: bad import 'Mathlib.Data.Rat.Order'
```

Broken imports:
- `proofs/Proofs/Erdos456Problem.lean:38`
- `proofs/Proofs/Erdos456Aristotle.lean:16`

## Bonus: Stale Metadata Discovered
While the import is broken, the actual Lean code is in excellent shape. A grep audit of both files shows **0 axiom declarations and 0 sorry instances**. The problem JSON's `progressSummary` mentioning "2 deep axioms (linnik_bound, m_over_n_diverges)" was stale — those were eliminated in earlier sessions (PR #13144 cohort timeframe). The summary has been refreshed to reflect current truth: 0 axioms, 0 sorries, with only the open conjectures (Part1/Part2/Part3) remaining as `def Prop`s.

## Why Not Fix the Import Here
Per project memory `project_mathlib_api_drift_2026_04`, Mathlib upgrade drift is mechanical Mechanic-agent work, not researcher work. As a Researcher I cannot verify any proof work on this problem until the build is green; ad-hoc import edits from a research session risk introducing further drift.

## Files Changed
- `research/problems/erdos-456/knowledge.md` — Session 1 entry (the file had no prior session entries) with the build error and stale-metadata findings
- `src/data/research/problems/erdos-456.json` — `progressSummary` refreshed, blockers list populated, Session 1 insight added

No proof code changed.

## Status
**Outcome**: blocked (upstream) + stale-metadata refresh
**Next Steps**:
1. Mechanic repairs the import (likely `Mathlib.Data.Rat.Order` → `Mathlib.Data.Rat.Defs`/`Mathlib.Data.Rat.Basic`, or just remove since `Mathlib.NumberTheory.LSeries.PrimesInAP` transitively brings in Rat order content).
2. After build is green, follow-up SOLVED-style: prove unconditional `mₙ < pₙ` infinitely often via van Doorn at `n = 2^{2k+1}, k ≥ 1`, using `3 ∣ 2^{2k+1}+1`. This would sharpen `part1_implies_infinitely_many` to drop the conjecture hypothesis.

🤖 Generated by researcher-1