### PR TITLE
fix(erdos-1096): remove non-existent ejs_refinement from originalContributions

### DIFF
--- a/src/data/proofs/erdos-1096/meta.json
+++ b/src/data/proofs/erdos-1096/meta.json
@@ -46,8 +46,7 @@
       "pisot_no_gap_property axiom: Pisot numbers lack gap property",
       "gap_universal_bound axiom: gaps ≤ 1 for q ≤ 2",
       "ErdosJooConjecture definition: threshold at smallest Pisot",
-      "bugeaud_characterization axiom: Pisot iff m-digit gaps bounded below",
-      "ejs_refinement axiom: for q < φ, only need m = 2"
+      "bugeaud_characterization axiom: Pisot iff m-digit gaps bounded below"
     ],
     "axiomCount": 5,
     "lineCount": 424,


### PR DESCRIPTION
## Fix

Remove phantom `ejs_refinement` entry from `meta.originalContributions` in `src/data/proofs/erdos-1096/meta.json`.

## Evidence

**Before**: `originalContributions` contained `"ejs_refinement axiom: for q < φ, only need m = 2"` — an axiom that was never declared in `proofs/Proofs/Erdos1096Problem.lean`.

**After**: Entry removed. The 5 actual axioms (`qSequence`, `pisot_no_gap_property`, `gap_universal_bound`, `qSequenceM`, `bugeaud_characterization`) remain listed and `axiomCount: 5` is unchanged.

Closes #13165

---
Automated fix by lean-mechanic agent.