### PR TITLE
fix(erdos-410): correct phantom originalContributions entries

### DIFF
--- a/src/data/proofs/erdos-410/meta.json
+++ b/src/data/proofs/erdos-410/meta.json
@@ -49,13 +49,11 @@
       "ErdosConjecture410 definition: growth rate → ∞",
       "conjecture_equiv theorem: super-exponential growth",
       "sigma_lower_bound theorem: σ(n) ≥ n + 1",
-      "sigma_upper_bound axiom: Robin's bound",
+      "robin_inequality axiom: Robin's bound (equivalent to RH)",
       "average_sigma axiom: average ≈ π²/6",
       "IsPerfect, IsAbundant, IsDeficient definitions",
       "aliquot definition: proper divisor sum",
-      "CatalanDicksonConjecture definition",
-      "sigma_multiplicative theorem",
-      "sigma_prime_pow theorem"
+      "sigma_multiplicative theorem"
     ],
     "axiomCount": 2,
     "lineCount": 371,


### PR DESCRIPTION
## Fix

Correct `meta.originalContributions` in `src/data/proofs/erdos-410/meta.json`:
- Rename `sigma_upper_bound` → `robin_inequality` (the actual axiom name in the Lean file)
- Remove `"CatalanDicksonConjecture definition"` (never declared)
- Remove `"sigma_prime_pow theorem"` (never declared)

## Evidence

**Before**: 3 phantom entries referencing non-existent declarations.

**After**: All entries reference declarations that exist in `proofs/Proofs/Erdos410Problem.lean`. `axiomCount: 2` unchanged (correct: `robin_inequality` + `average_sigma`).

Closes #13177

---
Automated fix by lean-mechanic agent.