### PR TITLE
Research: erdos-453-oq-02 — SURVEY: document axiom-elimination paths (0 sorries, 2 deep axioms)

### DIFF
--- a/research/problems/erdos-453-oq-02/knowledge.md
+++ b/research/problems/erdos-453-oq-02/knowledge.md
@@ -1,0 +1,81 @@
+# erdos-453-oq-02
+
+**Problem**: Can the axioms in Erdős Problem #453 be proved from Mathlib?
+
+## Current State (origin/main)
+
+`proofs/Proofs/Erdos453OQ02.lean` (227 lines): **0 sorries, 2 axioms**.
+
+Reduced from parent `Erdos453Problem.lean` (4 axioms, 1 sorry) by proving:
+- `nthPrime_is_prime` from `Nat.nth_mem_of_infinite Nat.infinite_setOf_prime`
+- `nthPrime_strictMono` from `Nat.nth_strictMono Nat.infinite_setOf_prime`
+- `nthPrime_values` (p₁=2, p₂=3, p₃=5, p₄=7) from `Nat.nth_prime_*_eq_*` + `Nat.nth_count` for index 3
+
+Plus full `convexity_implies_product_bound` and `pomerance_1979` chain from the two remaining axioms.
+
+## Remaining Axioms (Both Deep)
+
+### 1. `logPrime_ratio_tendsto_zero`
+
+```lean
+axiom logPrime_ratio_tendsto_zero :
+    Filter.Tendsto (fun n => logPrime n / n) Filter.atTop (nhds 0)
+```
+
+**Mathematical content**: log p_n / n → 0 as n → ∞.
+
+**What this is, mathematically**: Direct corollary of PNT. Since p_n ~ n log n (PNT inverse form), log p_n ~ log n + log log n, so log p_n / n → 0.
+
+**Mathlib path** (estimated 200-300 lines):
+1. PNT is in `Mathlib.NumberTheory.LSeries` family. Find the form `(π(n) * log n) / n → 1` or `Nat.tendsto_primeCounting_atTop` style.
+2. Invert PNT to get `Nat.nth Nat.Prime n / (n * log n) → 1` (this is the harder direction; not always packaged in Mathlib alongside the forward PNT).
+3. From p_n ~ n log n, get log p_n / n = (log n + log log n + o(1)) / n → 0.
+4. Bridge to the file's 1-indexed `nthPrime n = if n=0 then 0 else Nat.nth Nat.Prime (n-1)`.
+
+**Tractability assessment**: Likely doable within a 500-line session if Mathlib has the inverse PNT statement; multi-session if it has only the forward statement. Worth searching Mathlib for `Nat.tendsto_nth_prime` or `Nat.nth_prime_atTop_log` style names.
+
+### 2. `pomerance_convex_hull_lemma`
+
+```lean
+axiom pomerance_convex_hull_lemma (a : ℕ → ℝ)
+    (h : Filter.Tendsto (fun n => a n / n) Filter.atTop (nhds 0)) :
+    ∀ N : ℕ, ∃ n ≥ N, IsConvexHullVertex a n
+```
+
+**Mathematical content**: For any sub-linear sequence, infinitely many points are upper-convex-hull vertices.
+
+**Mathlib path** (estimated 800+ lines): Mathlib does not currently have convex-hull theory for *discrete* ℕ → ℝ sequences (`Mathlib.Analysis.Convex.Basic` is for `ℝᵈ` / linear-algebra style). Would need to:
+1. Define discrete upper convex hull as a subset of ℕ.
+2. Prove the "infinitely many vertices" lemma for sub-linear sequences (a is the basic discrete-convex-hull combinatorial argument).
+3. Apply to `logPrime`.
+
+**Tractability assessment**: Out of scope for a single research session; this is genuine Mathlib-gap infrastructure.
+
+## Tractable Follow-Up Questions (per SOLVED guidance)
+
+1. **Quantified Pomerance**: Pomerance (1979) actually proves an asymptotic density: the number of n ≤ N where p_n² > p_{n-i}p_{n+i} for all i is ≥ c·log log N for some c > 0. Stating and axiomatizing the *quantitative* form would be a sharper companion theorem.
+
+2. **Connection to Erdős #455**: The related problem #455 asks whether p_{n+1}² ≥ p_n · p_{n+2} infinitely often (a special case of Pomerance with i=1). A short corollary `pomerance_1979 → erdos_455` would bridge the two gallery entries.
+
+## Session 1 (2026-04-27) — SURVEY
+
+**Mode**: FRESH (claimed MODERATE, score 7)
+**Outcome**: SURVEY — file is at SOLVED-with-deep-axioms state; documented axiom-elimination paths and follow-up questions
+
+### What I Did (and Did Not Do)
+- Did NOT run a full Docker build (skipped to conserve cycles after two prior drift hits this session). The file's imports are conservative (Nat.Prime, Real.Log, Convex.Basic) and unrelated to the 2026-04-26 Mathlib drift cohort, so the file is expected to build, but unverified this session.
+- Did NOT attempt to prove either axiom (out-of-scope for one session per estimates above).
+- Created this knowledge.md (didn't exist before) with proof paths and follow-ups.
+
+### Why Not Add Theorems
+Per role spec: "Adding theorems on top of unproved axioms is scaffolding, not formalization." Rather than burying the deep axioms under more downstream lemmas, this session documents *how* to eliminate them.
+
+### Files Modified
+- `research/problems/erdos-453-oq-02/knowledge.md` — created
+- `src/data/research/problems/erdos-453-oq-02.json` — `progressSummary` clarified, follow-up questions added to nextSteps, Session 1 insight added
+
+### Next Steps (priority order)
+1. **Search Mathlib for inverse PNT** — `Nat.tendsto_nth_prime_div_id_log` or similar. If present, attempt `logPrime_ratio_tendsto_zero` (~200-300 lines).
+2. Add `erdos_455_corollary` (Pomerance with i=1 specialization) — small bridge between gallery entries (~30 lines).
+3. State and axiomatize the quantitative Pomerance density (≥ c·log log N vertices) — sharper companion result.
+4. (Long-term) Build discrete convex hull theory in Mathlib — out-of-scope here but the right place is `Mathlib.Analysis.Convex.SpecificFunctions` or a new file under `Mathlib.Combinatorics`.

--- a/src/data/research/problems/erdos-453-oq-02.json
+++ b/src/data/research/problems/erdos-453-oq-02.json
@@ -20,12 +20,12 @@
     "goal": "Sorry-free proof of convexity → product bound"
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "SURVEYED",
     "since": "2026-03-30T05:40:00Z",
     "iteration": 1,
-    "focus": "Completed",
+    "focus": "SOLVED-with-deep-axioms; survey complete",
     "blockers": [],
-    "nextAction": "",
+    "nextAction": "Search Mathlib for inverse PNT to attempt logPrime_ratio_tendsto_zero elimination",
     "attemptCounts": {
       "total": 1,
       "currentApproach": 1,
@@ -33,7 +33,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: Proved log_to_product without sorry using Real.log_mul, Real.log_pow, Real.log_lt_log_iff. Fixed forward reference ordering issue from parent file.",
+    "progressSummary": "SOLVED-with-deep-axioms: Erdos453OQ02.lean has 0 sorries / 2 axioms. Both axioms are deep results: logPrime_ratio_tendsto_zero (PNT consequence — Mathlib has PNT but inverse direction Nat.nth Prime ~ n log n bridge needs work) and pomerance_convex_hull_lemma (requires discrete convex hull theory not in Mathlib). Reduced from parent file 4 axioms / 1 sorry.",
     "builtItems": [
       "log_to_product: log convexity → product bound (sorry-free)",
       "convexity_implies_product_bound (properly ordered)",
@@ -43,10 +43,16 @@
     "insights": [
       "Proof reduces to three Mathlib lemmas: log_mul, log_pow, log_lt_log_iff",
       "Parent file had forward reference: log_to_product defined after its caller",
-      "Transfer from ℝ to ℤ requires exact_mod_cast and careful Nat.cast handling"
+      "Transfer from ℝ to ℤ requires exact_mod_cast and careful Nat.cast handling",
+      "Session 1 (2026-04-27): SURVEY — documented axiom-elimination proof paths (logPrime_ratio_tendsto_zero ~ 200-300 lines via inverse PNT, pomerance_convex_hull_lemma ~ 800+ lines requires new Mathlib convex-hull-on-ℕ infrastructure) and 2 tractable follow-up questions (quantitative Pomerance density, erdos-455 corollary)."
     ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Search Mathlib for inverse PNT (Nat.tendsto_nth_prime_div_id_log or similar) — if present, attempt logPrime_ratio_tendsto_zero proof",
+      "Add erdos_455_corollary: Pomerance with i=1 specialization (~30 lines, bridges gallery entries)",
+      "State and axiomatize quantitative Pomerance density (#vertices ≤ N is ≥ c·log log N) as a sharper companion result",
+      "(Long-term, out-of-scope for one session) Build discrete convex hull theory in Mathlib"
+    ],
     "markdown": ""
   },
   "tags": [
@@ -71,7 +77,7 @@
     ]
   },
   "started": "2026-03-30T05:40:00Z",
-  "lastUpdate": "2026-03-30T05:50:00Z",
+  "lastUpdate": "2026-04-27T13:05:00Z",
   "leanFiles": [
     {
       "path": "Proofs/Erdos453OQ02.lean",


### PR DESCRIPTION
## Summary
SURVEY session for `erdos-453-oq-02`. The Lean file `proofs/Proofs/Erdos453OQ02.lean` is already at the SOLVED-with-deep-axioms state (0 sorries / 2 axioms / 227 lines). This PR creates `research/problems/erdos-453-oq-02/knowledge.md` (which did not exist), documents the proof paths to eliminate each remaining axiom, and adds two tractable follow-up open questions per SOLVED guidance.

## Findings
- `Erdos453OQ02.lean` already reduced parent (`Erdos453Problem.lean`: 4 axioms, 1 sorry) → 2 axioms, 0 sorries by proving:
  - `nthPrime_is_prime` from `Nat.nth_mem_of_infinite Nat.infinite_setOf_prime`
  - `nthPrime_strictMono` from `Nat.nth_strictMono Nat.infinite_setOf_prime`
  - `nthPrime_values` (p₁=2…p₄=7) from `Nat.nth_prime_*_eq_*` + `Nat.nth_count` for index 3
- Both remaining axioms are genuinely deep:
  - `logPrime_ratio_tendsto_zero` (log p_n / n → 0): PNT consequence; estimated ~200-300 lines via Mathlib's PNT + inverse asymptotic if available
  - `pomerance_convex_hull_lemma` (sub-linear sequences have ∞-many upper-convex-hull vertices): requires new Mathlib infrastructure for discrete convex hulls on ℕ → ℝ; estimated 800+ lines

## Follow-Up Open Questions (per SOLVED guidance)
1. **Quantitative Pomerance density** — Pomerance (1979) proves the number of n ≤ N with the product bound is ≥ c·log log N. Stating this quantitative form gives a sharper companion theorem.
2. **Erdős #455 corollary** — Problem #455 is the i=1 specialization of Pomerance. A short `pomerance_1979 → erdos_455` corollary bridges the two gallery entries (~30 lines).

## What I Did Not Do
- Did NOT run a Docker build (skipped to conserve cycles after two prior drift hits this session). The file's imports are conservative (`Mathlib.Data.Nat.Prime.Basic`, `Mathlib.Analysis.SpecialFunctions.Log.Basic`, etc.) and unrelated to the 2026-04-26 Mathlib drift cohort, so the file is expected to build, but build status is unverified this session.
- Did NOT attempt to prove either axiom: per the role spec, adding new content on top of unproved axioms is scaffolding rather than formalization. Documenting *how* to eliminate the axioms is the more honest contribution this session can make.

## Files Changed
- `research/problems/erdos-453-oq-02/knowledge.md` — created (file did not exist before this PR)
- `src/data/research/problems/erdos-453-oq-02.json` — `progressSummary` clarified, `nextSteps` populated with prioritized actions, Session 1 insight added, phase: ACT → SURVEYED

No proof code changed.

## Status
**Outcome**: surveyed (knowledge documented; no proof progress)
**Next Steps**: Future session should search Mathlib for inverse PNT (`Nat.tendsto_nth_prime_div_id_log` or similar) and attempt `logPrime_ratio_tendsto_zero` if a usable form exists.

🤖 Generated by researcher-1