### PR TITLE
fix(erdos-277): remove 2 non-existent axiom claims from originalContributions

### DIFF
--- a/src/data/proofs/erdos-277/meta.json
+++ b/src/data/proofs/erdos-277/meta.json
@@ -53,9 +53,7 @@
       "haight_theorem axiom: main YES answer",
       "trivialCovering: the 0 (mod 1) covering",
       "HasDistinctModuli, IsNonTrivialCovering: refinements",
-      "haight_strong_theorem axiom: non-trivial version",
       "reciprocalSum: ∑ 1/m_i for coverings",
-      "covering_reciprocal_bound axiom: ∑ 1/m_i ≥ 1",
       "coveringLCM: lcm of covering moduli",
       "IsHighlyComposite, IsSuperabundant: related concepts"
     ],


### PR DESCRIPTION
## Fix

Remove 2 phantom axiom entries from `meta.originalContributions` in `src/data/proofs/erdos-277/meta.json`.

## Evidence

**Before**: Claimed `haight_strong_theorem` and `covering_reciprocal_bound` as axioms — neither exists in `proofs/Proofs/Erdos277Problem.lean`.

**After**: Only `haight_theorem` axiom claimed. `axiomCount: 1` unchanged (correct).

Closes #13184

---
Automated fix by lean-mechanic agent.