### PR TITLE
fix: remove phantom originalContributions from erdos-419, erdos-870, erdos-283

### DIFF
--- a/src/data/proofs/erdos-283/meta.json
+++ b/src/data/proofs/erdos-283/meta.json
@@ -47,8 +47,6 @@
       "ErdosCondition and erdos_283_conjecture formal statements",
       "graham_theorem and alekseyev_theorem axioms",
       "Verified examples: egyptian_example_236, egyptian_example_2_4_6_12, alekseyev_example via native_decide",
-      "van_doorn_linear and van_doorn_quadratic axioms",
-      "cassels_theorem axiom (without Egyptian constraint)",
       "trivial_egyptian proved for {1}",
       "erdos_283_summary: two-part conjunction of Graham and Alekseyev"
     ],

--- a/src/data/proofs/erdos-419/meta.json
+++ b/src/data/proofs/erdos-419/meta.json
@@ -64,7 +64,6 @@
       "factorialDivisorRatio definition",
       "padicValFactorial for Legendre's formula",
       "limitPointSet definition: {1} ∪ {1 + 1/k : k ≥ 1}",
-      "ratio_product_formula axiom",
       "small_primes_contribution and large_prime_valuation analysis",
       "sawhney_characterization proved theorem (iff characterization)",
       "limit_set_properties proved theorem",

--- a/src/data/proofs/erdos-870/meta.json
+++ b/src/data/proofs/erdos-870/meta.json
@@ -53,7 +53,6 @@
       "ErdosConjecture870 main conjecture",
       "hartter_nathanson_existence axiom",
       "erdos_nathanson_k2 axiom",
-      "waring_theorem axiom",
       "IsSidonSet definition"
     ],
     "axiomCount": 2,


### PR DESCRIPTION
## Fix

Batch removal of non-existent axiom claims from `originalContributions` in 3 gallery entries.

## Changes

**erdos-419**: Remove `"ratio_product_formula axiom"` — not declared in `proofs/Proofs/Erdos419Problem.lean`. Actual axioms: `one_is_limit_point`, `one_plus_reciprocal_is_limit_point`, `only_these_limit_points`.

**erdos-870**: Remove `"waring_theorem axiom"` — not declared in `proofs/Proofs/Erdos870Problem.lean`. Actual axioms: `hartter_nathanson_existence`, `erdos_nathanson_k2`.

**erdos-283**: Remove `"van_doorn_linear and van_doorn_quadratic axioms"` and `"cassels_theorem axiom"` — none declared in `proofs/Proofs/Erdos283Problem.lean`. Actual axioms: `graham_theorem`, `alekseyev_theorem`.

All `axiomCount` values are correct and unchanged.

Closes #13186
Closes #13187
Closes #13188

---
Automated fix by lean-mechanic agent.