### PR TITLE
Research: erdos-533 — SURVEY: identify turan_k5_free as Mathlib-eliminable axiom

### DIFF
--- a/research/problems/erdos-533/knowledge.md
+++ b/research/problems/erdos-533/knowledge.md
@@ -70,7 +70,49 @@ Back to the problem
 
 ## Sessions
 
-(No research sessions yet)
+### Session 1 (2026-04-27) — Axiom Survey + Turán Reduction Path
+
+**Mode**: REVISIT (claimed RICH, score 29)
+**Outcome**: SURVEY — corrected stale claim that "no axioms provable from Mathlib"; identified `turan_k5_free` as eliminable from Mathlib's existing Turán API
+
+#### Current File State (`Erdos533Problem.lean`, 372 lines)
+- **0 sorries**, **4 axioms** (1 is the open conjecture itself, 3 are supporting):
+  1. `turan_k5_free` (line 278) — K₅-free graph has ≤ (3/8)n² edges
+  2. `ehsss_result` (line 292) — Erdős–Hajnal–Simonovits–Sós–Szemerédi 1976 (δ > 1/16 case)
+  3. `k4_free_triangle_free_subset` (line 300) — companion deep result
+  4. `erdos_533_conjecture` (line 361) — the open conjecture (cannot be proved)
+- File defines bespoke `SGraph` structure with bridge `SGraph.toSimpleGraph` to Mathlib.
+
+#### Correction to Prior Session Knowledge
+The prior progressSummary claims "Axioms are all deep published results — none provable from Mathlib." This is **wrong for `turan_k5_free`**: Mathlib has Turán's theorem on `SimpleGraph`. Cross-reference: `Erdos1155OQ02.lean:264-265` already uses `turanGraph_cliqueFree`, confirming Mathlib's Turán API is accessible from this project.
+
+#### Path to Eliminating `turan_k5_free`
+The axiom states: K₅-free `SGraph` on n vertices has `edgeCount ≤ (3/8) * n²` (real-valued).
+
+Proof path (estimated 100-200 lines):
+1. **Bridge**: Use `SGraph.toSimpleGraph` (already in file). Lift `¬HasClique G 5` to `(G.toSimpleGraph).CliqueFree 5`.
+2. **Mathlib Turán bound**: For `K_{r+1}`-free graphs, Mathlib gives the bound on `edgeFinset.card`. The relevant API surfaces are in `Mathlib.Combinatorics.SimpleGraph.Turan` (`turanGraph`, `turanGraph_cliqueFree`, and the `IsTuranMaximal.card_edgeFinset_le` style lemma — exact Mathlib name needs verification by build attempt).
+3. **EdgeCount bridge**: The file's `edgeCount` is `Finset.card (filter ... (Finset.univ.product Finset.univ))` over ordered pairs (i<j). Mathlib's `SimpleGraph.edgeFinset.card` counts unordered edges. These should match (already proved indirectly via `edgeCount_le` for the `n*(n-1)/2` upper bound).
+4. **Arithmetic**: From `card ≤ (1 - 1/4) · n²/2 = (3/8)n²`, cast to ℝ.
+
+This is genuinely tractable in a focused session (estimated 100-200 lines, mostly bridge work). It would reduce the axiom count from 4 to 3.
+
+#### Why This Session Did NOT Attempt the Proof
+- Mathlib symlink loops in `proofs/.lake/packages/mathlib/` prevent reliable lemma name search from this worktree (every grep into Combinatorics/SimpleGraph errors with "Too many levels of symbolic links"). Without confirming the exact Mathlib lemma name, attempting the proof would devolve into guess-and-check with Docker rebuild cycles.
+- This session has already done two Docker builds (5+ min each) for the angle-trisection and erdos-456 drift verification; another speculative build cycle is poor ROI.
+- Better next-session approach: claim this problem from a fresh worktree where Mathlib is accessible, or invoke the Aristotle pipeline with `turan_k5_free` as a target after confirming it satisfies Aristotle's criteria (clean theorem, no main-conjecture status).
+
+#### Why `ehsss_result`, `k4_free_triangle_free_subset` Cannot Be Eliminated
+These are deep theorems from 1976 (Erdős–Hajnal–Simonovits–Sós–Szemerédi, *Discrete Math.*). Their proofs require ~1000+ lines of extremal graph theory infrastructure not currently in Mathlib. They legitimately remain as axioms.
+
+### Files Modified This Session
+- `research/problems/erdos-533/knowledge.md` — Session 1 entry (this)
+- `src/data/research/problems/erdos-533.json` — `progressSummary` and `mathlibGaps` corrected to reflect `turan_k5_free` is eliminable
+
+### Next Steps (priority order)
+1. **Eliminate `turan_k5_free`** via Mathlib's `turanGraph` / `IsTuranMaximal` API (~100-200 lines). This drops the axiom count 4 → 3.
+2. **Aristotle target** for the bridge lemma `SGraph.edgeCount = G.toSimpleGraph.edgeFinset.card` — should be a clean Aristotle target.
+3. The remaining axioms (ehsss, k4-free, conjecture) are out-of-scope for elimination.
 
 ---
 

--- a/src/data/research/problems/erdos-533.json
+++ b/src/data/research/problems/erdos-533.json
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "SURVEYED",
     "since": "2026-01-13T04:39:49.623Z",
     "iteration": 4,
-    "focus": "Proving structural lemmas about graph definitions",
+    "focus": "turan_k5_free reducible from Mathlib; survey complete",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Future session: eliminate turan_k5_free via Mathlib turanGraph API (need accessible Mathlib browsing or Docker iterations)",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 3A (all deep), 20T+1L, 0S. Proved edgeCount_le (tight n*(n-1)/2 bound, improves edgeCount_le_sq).",
+    "progressSummary": "PROGRESS-PARTIAL + AXIOM-REDUCIBLE: 4A (1 open conjecture + 3 supporting), 20T+1L, 0S. Of the 3 supporting axioms, turan_k5_free is reducible from Mathlib (cross-ref Erdos1155OQ02.lean uses turanGraph_cliqueFree); ehsss_result and k4_free_triangle_free_subset are deep 1976 results (~1000+ lines of unavailable extremal graph theory).",
     "builtItems": [
       "isTriangleFree_subset: monotonicity of triangle-free sets (line 84-88)",
       "isClique_subset: monotonicity of cliques (line 90-93)",
@@ -58,13 +58,17 @@
       "File has 14 proved theorems (metadata claimed 0). Good structure.",
       "erdos_rogers_counterexample axiom was unused — removed (4→3A)",
       "edgeCount_le proved: tight n*(n-1)/2 bound on edge count (improves edgeCount_le_sq which gave n²)",
-      "card_strict_upper_tri helper: |{(i,j) in Fin n × Fin n | i < j}| = n*(n-1)/2 via off-diagonal symmetry"
+      "card_strict_upper_tri helper: |{(i,j) in Fin n × Fin n | i < j}| = n*(n-1)/2 via off-diagonal symmetry",
+      "Session 1 (2026-04-27): SURVEY — corrected stale claim that no axioms are provable from Mathlib. turan_k5_free (line 278) is eliminable via Mathlib turanGraph API (already used in Erdos1155OQ02.lean). Estimated 100-200 lines. ehsss_result and k4_free_triangle_free_subset remain genuinely deep / out-of-Mathlib."
     ],
-    "mathlibGaps": [],
+    "mathlibGaps": [
+      "ehsss_result: deep 1976 extremal-graph-theory result (Erdős–Hajnal–Simonovits–Sós–Szemerédi). Not in Mathlib; ~1000+ lines if formalized.",
+      "k4_free_triangle_free_subset: companion deep result from same paper. Not in Mathlib."
+    ],
     "nextSteps": [
-      "Potential: prove edgeCount_le (edge count bounded by n*(n-1)/2) - requires combinatorial counting",
-      "Potential: connect SGraph to Mathlib SimpleGraph for broader API access",
-      "Potential: add Ramsey-number lower bounds connecting K5-freeness to independence number"
+      "Eliminate turan_k5_free via Mathlib SimpleGraph.Turan API (~100-200 lines bridging SGraph→SimpleGraph→edgeFinset.card→(3/8)n² bound)",
+      "Add Aristotle target: SGraph.edgeCount = G.toSimpleGraph.edgeFinset.card (clean bridge lemma)",
+      "(Out of scope) Eliminate ehsss_result / k4_free_triangle_free_subset — requires deep extremal graph theory infrastructure not in Mathlib"
     ],
     "markdown": "# Erdős #533 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $\\delta>0$. If $n$ is sufficiently large and $G$ is a graph on $n$ vertices with no $K_5$ and at least $\\delta n^2$ edges then $G$ contains a set of $\\gg_\\delta n$ vertices containing no triangle.\n\n\n\n\nA problem of Erd\\H{o}s, Hajnal, Simonovits, S\\'{o}s, and Szemer\\'{e}di, who could prove this is true for $\\delta>1/16$, and could further prove it for $\\delta>0$ if we replace $K_5$ with $K_4$.\n\nThey further observed that it fails for $\\delta =1/4$ if we replace $K_5$ with $K_7$: by a construction of Erd\\H{o}s and Rogers \\cite{ErRo62} (see [620]) there exists some constant $c>0$ such that, for all large $n$, there is a graph on $n$ vertices which contains no $K_4$ and every set of at least $n^{1-c}$ vertices contains a triangle. If we take two vertex disjoint copies of this graph and add all edges between the two copies then this yields a graph on $2n$ vertices with $\\geq n^2$ edges, which contains no $K_7$, yet every set of at least $2n^{1-c}$ vertices contains a triangle.\n\n\nSee also [579] and the entry in the graphs problem collection.\n\n\n\n\nReferences\n\n\n[ErRo62] Erd\\H{o}s, P. and Rogers, C. A., The construction of certain graphs. Canadian J. Math. (1962), 702-707.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #16\n- Problem #4\n- Problem #620\n- Problem #579\n- Problem #532\n- Problem #534\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er91\n- EHSSS94\n- ErRo62\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
   },
@@ -82,7 +86,7 @@
     "mathlib": []
   },
   "started": "2026-01-13T04:39:49.623Z",
-  "lastUpdate": "2026-03-13T07:52:17.049Z",
+  "lastUpdate": "2026-04-27T13:25:00Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [


### PR DESCRIPTION
## Summary
SURVEY session for `erdos-533`. Corrects the prior progressSummary's stale claim that "all axioms are deep results none provable from Mathlib": one of the four supporting axioms — `turan_k5_free` — is a direct corollary of Mathlib's existing Turán theorem.

## Findings
`Erdos533Problem.lean` (372 lines) is at **0 sorries / 4 axioms**:
1. `turan_k5_free` (line 278) — K₅-free graph has ≤ (3/8)n² edges
2. `ehsss_result` (line 292) — δ > 1/16 case (Erdős–Hajnal–Simonovits–Sós–Szemerédi 1976)
3. `k4_free_triangle_free_subset` (line 300) — companion deep result
4. `erdos_533_conjecture` (line 361) — the open conjecture

Cross-referencing `Erdos1155OQ02.lean:264-265`:
```lean
theorem turan_graph_r2_is_maximal {n : ℕ} :
    (turanGraph n 2).CliqueFree 3 := by
  exact turanGraph_cliqueFree (by norm_num)
```
confirms Mathlib's `turanGraph` / `IsTuranMaximal` API is accessible from this project.

For r=4, Mathlib's K_{r+1}-free bound (1 − 1/r)·n²/2 evaluates to (3/8)·n² — matching the axiom's statement exactly. The file already has an `SGraph.toSimpleGraph` bridge, so the path is:
1. Lift `¬HasClique G 5` to `(G.toSimpleGraph).CliqueFree 5`
2. Apply Mathlib Turán bound on `edgeFinset.card`
3. Bridge `SGraph.edgeCount ↔ SimpleGraph.edgeFinset.card` (clean Aristotle target)
4. Cast to ℝ + arithmetic

Estimated 100-200 lines, mostly bridge/casting work.

The other two supporting axioms (`ehsss_result`, `k4_free_triangle_free_subset`) are genuinely deep 1976 extremal-graph-theory results requiring ~1000+ lines of infrastructure not in Mathlib; they legitimately remain.

## Why This Session Did NOT Attempt the Proof
- Mathlib symlink loops in `proofs/.lake/packages/mathlib/Mathlib/Combinatorics/SimpleGraph/` (every `find`/`grep` errors with "Too many levels of symbolic links") prevent reliable lemma name discovery from this worktree. Without confirming exact Mathlib symbol names, attempting the proof devolves into Docker rebuild guess-and-check.
- This session has already done two Docker build cycles (5+ min each) for drift verification on prior claims (PRs #13159, #13169); a third speculative build cycle is poor ROI when a future session with accessible Mathlib browsing can do the work much faster.

## Files Changed
- `research/problems/erdos-533/knowledge.md` — Session 1 entry with the corrected analysis (file previously had only the auto-generated problem statement)
- `src/data/research/problems/erdos-533.json` — `progressSummary` corrected, `mathlibGaps` populated to distinguish reducible vs deep axioms, Session 1 insight added

No proof code changed.

## Status
**Outcome**: surveyed (corrects misleading prior knowledge claim; identifies a real reduction opportunity)
**Next Steps**:
1. Future session eliminates `turan_k5_free` via Mathlib `turanGraph` API (~100-200 lines), dropping axiom count 4 → 3.
2. Add `SGraph.edgeCount = G.toSimpleGraph.edgeFinset.card` bridge as an Aristotle target.
3. The remaining two supporting axioms remain out-of-scope for elimination.

🤖 Generated by researcher-1