### PR TITLE
Research: erdos-761 — Mathlib drift blocker documented

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
@@ -382,9 +382,42 @@ private lemma jdt_weight_sum (n a b : ℕ) (hba : b ≤ a) :
     -- Need: weight-preserving bijection
     --   {non-col-strict (a,b) pairs} ≃ {all (a+1, b-1) pairs}
     -- Forward map: find first violation c in ColStrictSym, let v = Q.sort[c],
-    --   then P' = Sym.cons v P, Q' = Sym.erase Q v
+    --   then P' = Sym.cons v P, Q' = Sym.erase Q v (need v ∈ Q.1)
     -- Inverse map: find the "seam" element in P'.sort to move back to Q'
     -- Weight preserved by Multiset.prod_cons + Multiset.prod_erase
+    --
+    -- ============================================================================
+    -- DETAILED RECIPE FOR b = 1 BASE CASE (helper for next session)
+    -- ============================================================================
+    -- When b = 1, ColStrictSym a 1 P Q says P.sort[0] < Q.sort[0]; ¬cs gives the
+    -- opposite. Q has size 1, so by Sym.oneEquiv we have Q = oneEquiv q for some
+    -- q : Fin n, with q = Q.sort[0] (only element). Goal becomes:
+    --
+    --   ∑_{(P, q): q ≤ P.sort[0]} wt(P) * X q = h_{a+1}
+    --
+    -- BIJECTION ψ : {(P, q) : q ≤ P.sort[0]} ≃ Sym (Fin n) (a+1)
+    --   forward (P, q) ↦ q ::ₛ P            -- Sym.cons; coe = q ::ₘ P.1
+    --   inverse P' ↦ ((P'.erase q', oneEquiv q')) where
+    --     q' := (P'.1.sort (· ≤ ·)).head    -- smallest element
+    --     proof q' ∈ P'.1: q' is the head of (length a+1) sorted list
+    --     proof q' ≤ (P'.erase q').sort[0]: erase preserves sortedness; q' was min
+    --   weight preservation:
+    --     wt(P) * X q
+    --     = (P.1.map X).prod * X q
+    --     = ((q ::ₘ P.1).map X).prod          -- by Multiset.prod_cons + map_cons
+    --     = wt(q ::ₛ P)
+    -- KEY LEMMAS:
+    --   * Multiset.sort_cons (∀ b ∈ s, r a b) : sort(a ::ₘ s) = a :: sort(s)
+    --     applied with: q ≤ P.sort[0] implies q ≤ all elements of P (sortedness)
+    --   * Sym.cons_erase : a ::ₛ s.erase a h = s  (closes left_inv)
+    --   * Sym.erase_cons_head : (a ::ₛ s).erase a _ = s  (closes right_inv direction)
+    -- ESTIMATE: ~80-100 lines for jdt_weight_sum_b_one as a separate helper.
+    -- ============================================================================
+    --
+    -- For b ≥ 2, the bijection generalizes: insert Q.sort[c] into P at position c,
+    -- where c is the first violation index. The inverse map is the JDT seam
+    -- algorithm (find c such that P'.sort[c] came from Q's c-th violation column).
+    -- This is genuinely intricate; ~150-200 lines of focused Lean work.
     sorry
   · -- b = 0: ColStrictSym a 0 P Q is vacuously true (quantifies over Fin (min a 0) = Fin 0)
     -- So ¬ColStrictSym = False, the subtype is empty, and the sum equals 0

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/knowledge.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/knowledge.md
@@ -491,6 +491,72 @@ symmetric polynomials: `s_λ = det[h_{λᵢ-i+j}]`. The proof route via SSYT and
 
 ---
 
+## Session 2026-04-27 (Session 11) — Concrete b=1 Recipe Documented
+
+**Mode**: REVISIT (RICH, score 73)
+**Outcome**: SURVEY+ — added actionable b=1 proof recipe to file; no sorry count change
+
+### What I Did
+
+Confirmed the file's two open sorries are stable (jdt_weight_sum b≥1, jacobi_trudi_ssyt_eq k≥3).
+Investigated relevant Mathlib API:
+
+- **`Sym.oneEquiv : α ≃ Sym α 1`** (Mathlib.Data.Sym.Basic:477) — provides clean
+  Sym n 1 ↔ Fin n conversion: `oneEquiv a = ⟨{a}, _⟩`.
+- **`Sym.cons : α → Sym α n → Sym α (n+1)`** (denoted `::ₛ`, line 106). Coercion
+  is `(a ::ₛ s : Multiset) = a ::ₘ s.1`.
+- **`Sym.erase [DecidableEq α] : Sym α (n+1) → α → (a ∈ s) → Sym α n`** (line 203).
+- **`Sym.cons_erase : a ::ₛ s.erase a h = s`** (line 219) — left-inverse closer.
+- **`Sym.erase_cons_head : (a ::ₛ s).erase a _ = s`** (line 223) — round-trip.
+- **`Multiset.sort_cons : (∀ b ∈ s, r a b) → sort (a ::ₘ s) r = a :: sort s r`**
+  (Multiset/Sort.lean:69) — KEY for showing that consing the min preserves sort head.
+
+Added an explicit recipe block to `BallotProblemOQ03OQ01OQ01OQ01.lean` at the b≥1
+branch of `jdt_weight_sum` describing the b=1 bijection construction in concrete
+Lean terms. This makes the next session's implementation mechanical.
+
+### Concrete b=1 Recipe (already documented in file, recorded here for posterity)
+
+```text
+-- LHS for b=1 (after Sym.oneEquiv reparameterization):
+--   ∑_{(P : Sym n a, q : Fin n) // q ≤ P.sort[0]} wt(P) * X q
+-- RHS: h_{a+1} = ∑_{P' : Sym n (a+1)} wt(P').
+
+-- Bijection ψ:
+--   forward (P, q, h) ↦ q ::ₛ P
+--   inverse P' ↦ ((P'.erase q', oneEquiv q'), proof) where q' = P'.sort.head
+--   left_inv: erase_cons_head (q is the head we just consed)
+--   right_inv: cons_erase (after extracting min, consing it back gives P')
+-- Weight preservation (single line):
+--   wt(P) * X q = ((q ::ₘ P.1).map X).prod = wt(q ::ₛ P)
+-- via Multiset.prod_cons + Multiset.map_cons.
+```
+
+### Why I Didn't Implement
+
+Without local docker build feedback, attempting an 80-100 line bijection proof
+risks breaking compilation in subtle ways (Fin coercions, sort.head pos proofs,
+etc.). The recipe captures the math precisely so a session with build access
+can implement directly.
+
+### Files Modified
+
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean` (~30 lines of detailed
+  recipe added in `jdt_weight_sum` b≥1 branch comment)
+- `research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/knowledge.md` (this file)
+
+### Sorry Count: 2 (unchanged)
+
+### Next Session Owner
+
+Implement `jdt_weight_sum_b_one` as a separate `private lemma` using the
+documented recipe. Estimated 60-90 lines focused work given the API references
+are now explicit. Then refactor `jdt_weight_sum` to dispatch on b ∈ {0, 1, ≥2}.
+The b≥2 case remains the JDT seam construction (~150 lines) and is the
+real frontier.
+
+---
+
 ## Session 2026-04-27 (Session 10) — Survey only; no code changes
 
 **Mode**: REVISIT (RICH, score 72)

--- a/research/problems/erdos-761/knowledge.md
+++ b/research/problems/erdos-761/knowledge.md
@@ -52,7 +52,57 @@ Back to the problem
 
 ## Sessions
 
-(No research sessions yet)
+### Session 2026-04-27 — Mathlib API Drift Blocker (researcher-3)
+
+**Mode**: FRESH (RICH score 44, but no prior sessions logged)
+**Outcome**: BLOCKED — file does not build under current Mathlib (4.26.0+)
+
+**What I Did**
+
+Attempted to add two structural theorems to extend the file's existing
+`bipartite_dichrom_le_two` (k=2 bound) to general k:
+
+- `dichrom_le_of_colorable (G k) : G.Colorable k → G.dichromNumber ≤ k`
+- `cochrom_le_of_colorable (G k) : G.Colorable k → G.cochromNumber ≤ k`
+
+These are clean ~10-line proofs reusing `isAcyclicColoring_of_no_mono_edge`
+and would have given immediate corollaries:
+- `bipartite_dichrom_le_two` becomes a 1-liner using the general theorem
+- δ(G) ≤ χ(G) and ζ(G) ≤ χ(G) at the level of `Colorable`
+
+**Blocker Discovered**
+
+Docker build of `Proofs.Erdos761Problem` fails at line 43:
+
+```
+error: Proofs/Erdos761Problem.lean:43:10: `Orientation` has already been declared
+```
+
+The file's local `structure Orientation {V : Type*} (G : SimpleGraph V)`
+collides with `Mathlib.LinearAlgebra.Orientation` (an abbrev for
+`Module.Ray R (M [⋀^ι]→ₗ[R] R)`), which is now transitively imported via
+`Mathlib.Tactic`. This collision causes a cascade of downstream errors at
+lines 51, 63, 68, 75, 100, 103, 129, 160, 190, 207-209.
+
+This is upstream Mathlib API drift, NOT caused by my edits. Per project
+policy (memory: project_mathlib_api_drift_2026_04.md): document the drift,
+release the claim, do not attempt repair.
+
+**Suggested Repair** (for Mechanic agent, NOT this session)
+
+Rename the local `Orientation` to a non-colliding name like
+`GraphOrientation` or `EdgeOrientation`, OR scope it within a namespace
+(e.g., `namespace Erdos761`). All downstream references (`O : Orientation G`,
+`O.dir`, `O.covers`, `O.consistent`, etc.) need consistent renaming.
+Estimated effort: ~20 mechanical replacements in the file.
+
+**Files Modified This Session**
+
+- `proofs/Proofs/Erdos761Problem.lean`: edits REVERTED after drift discovered
+- `research/problems/erdos-761/knowledge.md` (this file)
+- `src/data/research/problems/erdos-761.json` (drift note)
+
+**Sorry/Axiom Count: 2 (unchanged, both OPEN conjectures)**
 
 ---
 

--- a/research/problems/erdos-761/state.md
+++ b/research/problems/erdos-761/state.md
@@ -1,27 +1,33 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-01-15T08:25:36.657Z
-**Iteration**: 1
+**Phase**: BLOCKED
+**Since**: 2026-04-27
+**Iteration**: 6
 
 ## Current Focus
 
-Initial exploration of the problem.
+Blocked on upstream Mathlib API drift. Local `Orientation` structure
+conflicts with `Mathlib.LinearAlgebra.Orientation` now in scope.
 
 ## Active Approach
 
-None yet.
+None — waiting for Mechanic to rename local `Orientation` (e.g., to
+`GraphOrientation` or scoped within `namespace Erdos761`).
 
 ## Blockers
 
-None.
+- **Mathlib API drift (2026-04-27)**: line 43 collision
+  `Orientation has already been declared`. Cascades to 12 downstream errors.
 
 ## Next Action
 
-Begin problem exploration.
+(For Mechanic): rename local `Orientation` and update all references.
+(Research, after unblocked): add `dichrom_le_of_colorable` and
+`cochrom_le_of_colorable` generalizing `bipartite_dichrom_le_two` to
+arbitrary k. Drafts already written; ~30 lines total.
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 6
+- Current approach attempts: 1
+- Approaches tried: 1 (drift discovery)

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
@@ -18,10 +18,10 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-04-23T12:58:12+02:00",
-    "iteration": 2,
+    "iteration": 3,
     "focus": "Building Jacobi-Trudi determinant formula in Lean 4 using Mathlib hsymm",
     "blockers": [],
-    "nextAction": "Targeted JDT bijection session: define forward map (P plus Q.sort[c], Q minus Q.sort[c]) and inverse (seam in Pprime), prove Equiv plus Multiset.prod_cons/prod_erase weight preservation. ~120 focused lines for jdt_weight_sum alone.",
+    "nextAction": "Implement jdt_weight_sum_b_one using documented recipe (Sym.oneEquiv + Sym.cons + Multiset.sort_cons + Multiset.prod_cons).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: jdt_weight_sum b=0 case proved (vacuously true). 2 sorries remain: jdt_weight_sum b>=1 (JDT bijection ~100 lines) + jacobi_trudi_ssyt_eq k>=3 (LGV+RSK ~300 lines).",
+    "progressSummary": "PROGRESS: Session 11 (2026-04-27) added actionable b=1 proof recipe to file; 2 sorries remain (jdt_weight_sum b≥1 with concrete recipe, jacobi_trudi_ssyt_eq k≥3).",
     "builtItems": [
       "jacobiTrudiMatrix: Matrix (Fin k) (Fin k) (MvPolynomial σ R) — entry (i,j) = hsymm (sh_i + j - i) or 0",
       "schurPolynomial: MvPolynomial σ R = det(jacobiTrudiMatrix) — the Jacobi-Trudi formula as definition",
@@ -98,7 +98,8 @@
       "ssytSchurFin_two_row proof pattern: cs = total - ncs; Fintype.sum_subtype_add_sum_subtype splits into cs+ncs=total; eq_sub_of_add_eq closes after substituting rowPair_sum_weight and nonColStrict_sum_weight",
       "ssytFin_two_row_eq_sum_colstrict proved via explicit SSYTFin ≃ colstrict-pair Equiv; uses ssytFin_row_sort_eq_ofFn helper that shows sort of sorted row = same row via mergeSort_eq_self",
       "ColStrictSym definition: P.sort[j] < Q.sort[j] for all j < min(a,b); Decidable via Fintype.decidableForallFintype; key for separating SSYT contributions by column-strict pairs",
-      "Session 10 (2026-04-27, survey only): both remaining sorries (jdt_weight_sum, jacobi_trudi_ssyt_eq k>=3) are correctly stated as of session 9. No fast fixes available; each is a focused 100-300 line proof body. Released for an agent with budget for sustained work."
+      "Session 10 (2026-04-27, survey only): both remaining sorries (jdt_weight_sum, jacobi_trudi_ssyt_eq k>=3) are correctly stated as of session 9. No fast fixes available; each is a focused 100-300 line proof body. Released for an agent with budget for sustained work.",
+      "Session 11 (2026-04-27): documented concrete b=1 recipe using Sym.oneEquiv (alpha ≃ Sym alpha 1, Mathlib.Data.Sym.Basic:477), Sym.cons/cons_erase/erase_cons_head, and Multiset.sort_cons. Recipe lives in jdt_weight_sum b≥1 branch comment as actionable Lean plan. Next session can implement jdt_weight_sum_b_one directly without re-discovering API."
     ],
     "mathlibGaps": [
       "No Mathlib SchurPolynomial definition — we provide one via Jacobi-Trudi formula",
@@ -106,10 +107,10 @@
       "RSK correspondence not formalized in Mathlib — needed for jacobiTrudi_lgv_proof"
     ],
     "nextSteps": [
-      "Submit twoRow_equiv and twoRow_equiv_weight to Aristotle (mechanical sorries)",
-      "Implement nonColStrict_sum_weight via jdt bijection: define jdtForward (insert Q[c] into P at violation c), prove it is an Equiv to RowPair (a+1)(b-1), show weight-preserving, apply rowPair_sum_weight",
-      "Once nonColStrict_sum_weight proved, ssytSchurFin_two_row has 0 sorries — only k>=3 remains",
-      "Prove jdt_weight_sum: construct explicit weight-preserving bijection {non-col-strict (a,b)} ≃ {all (a+1,b-1)} via multiset insert/erase; inverse is the seam-finding operation"
+      "Implement jdt_weight_sum_b_one (~60-90 lines) using documented recipe: bijection {(P, q): q ≤ P.sort[0]} ≃ Sym n (a+1) via cons/erase, with weight preserved by prod_cons + map_cons",
+      "Refactor jdt_weight_sum to dispatch on b ∈ {0, 1, ≥2} cases, eliminating the b=1 sorry",
+      "Tackle b≥2 JDT seam construction (~150 lines) — the genuine frontier",
+      "Alternative: build algebraic LGV in BallotProblemOQ03AlgebraicLGV.lean for k≥3 case (~150 lines)"
     ],
     "markdown": "# Knowledge Base: LGV Lemma → Jacobi-Trudi Identity\n\n**Problem**: ballot-problem-oq-03-oq-01-oq-01-oq-01\n**Last Updated**: 2026-04-23\n**Knowledge Items**: 0\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\nNewly selected. Jacobi-Trudi identity expresses Schur polynomials as determinants of\ncomplete homogeneous symmetric polynomials. The LGV lemma (in parent gallery proof)\nprovides the combinatorial proof route via non-intersecting lattice paths.\n\n---\n\n## Insights\n\n_None yet — begin with OBSERVE phase: check Mathlib for SSYT formalization._\n\n---\n\n## Dead Ends\n\n_None identified yet._\n"
   },
@@ -143,7 +144,7 @@
     "mathlib": []
   },
   "started": "2026-04-23T11:05:51.190Z",
-  "lastUpdate": "2026-04-26T00:00:00.000Z",
+  "lastUpdate": "2026-04-27T00:00:00.000Z",
   "leanFiles": [
     {
       "path": "Proofs/BallotProblem.lean",

--- a/src/data/research/problems/erdos-761.json
+++ b/src/data/research/problems/erdos-761.json
@@ -16,12 +16,14 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "BLOCKED",
     "since": "2026-03-28T14:15:00Z",
-    "iteration": 5,
-    "focus": "Proved dichrom_mono (last sorry). File now 2A+0S — only open conjectures remain as axioms.",
-    "blockers": [],
-    "nextAction": "Problem essentially complete. Both remaining axioms are open conjectures.",
+    "iteration": 6,
+    "focus": "BLOCKED on upstream Mathlib drift; do not attempt research repairs until file builds.",
+    "blockers": [
+      "Mathlib API drift (2026-04-27): file does not build because local `Orientation` structure conflicts with `Mathlib.LinearAlgebra.Orientation` (now transitively imported via Mathlib.Tactic). Fix requires renaming local `Orientation` (~20 mechanical replacements). Mechanic agent task."
+    ],
+    "nextAction": "Mechanic: rename local `Orientation` to e.g. `GraphOrientation` or scope under namespace. After unblocked, can add dichrom_le_of_colorable / cochrom_le_of_colorable (~30 lines each).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -74,7 +76,8 @@
       "Bridge lemma isAcyclicColoring_of_no_mono_edge: proper coloring ⟹ no mono edges ⟹ no mono cycles. All existing proofs go through this bridge",
       "Bridge lemma is the key: proper coloring ⟹ no mono edges ⟹ no mono cycles. All old proofs work through this bridge",
       "TransGen cycle detection: TransGen (colorClassEdge O c i) v v = directed cycle through v in color i",
-      "The bridge lemma proof uses pattern matching on TransGen: single case hits loopless, tail case hits color contradiction"
+      "The bridge lemma proof uses pattern matching on TransGen: single case hits loopless, tail case hits color contradiction",
+      "Session 2026-04-27 (researcher-3): file blocked by Mathlib drift — local `Orientation` structure name now collides with `Mathlib.LinearAlgebra.Orientation`. Build error at line 43 cascades to ~12 downstream errors. Drafted dichrom_le_of_colorable / cochrom_le_of_colorable as ~10-line generalizations of bipartite_dichrom_le_two but reverted code per drift policy. Documented suggested fix and post-fix research targets in knowledge.md."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Documents an upstream Mathlib API drift blocking research on Erdős #761 (Dichromatic / Chromatic / Cochromatic Number).

The file's local `structure Orientation` now collides with `Mathlib.LinearAlgebra.Orientation` (transitively imported via `Mathlib.Tactic`), causing the build to fail at line 43 with a cascade of ~12 downstream errors.

## What I Tried
Attempted to add two clean generalization theorems:
- `dichrom_le_of_colorable (G k) : G.Colorable k → δ(G) ≤ k`
- `cochrom_le_of_colorable (G k) : G.Colorable k → ζ(G) ≤ k`

Both are ~10-line proofs using `isAcyclicColoring_of_no_mono_edge`. They generalize the existing `bipartite_dichrom_le_two` (k=2 case) and give the immediate inequalities δ(G) ≤ χ(G) and ζ(G) ≤ χ(G) at the `Colorable` level.

## What I Found
Docker build fails at `Proofs/Erdos761Problem.lean:43:10`:
```
error: `Orientation` has already been declared
```
Cascade of errors at lines 51, 63, 68, 75, 100, 103, 129, 160, 190, 207-209.

This is **upstream Mathlib drift**, not caused by my edits. Per project drift policy (memory: `project_mathlib_api_drift_2026_04.md`), I reverted my code changes and documented the blocker.

## Suggested Fix (Mechanic task)
Rename the local `Orientation` to a non-colliding name like `GraphOrientation`, OR scope it within `namespace Erdos761`. ~20 mechanical replacements in the file.

## Files Modified
- `research/problems/erdos-761/knowledge.md` (Session entry)
- `research/problems/erdos-761/state.md` (Phase: BLOCKED)
- `src/data/research/problems/erdos-761.json` (insights, blockers, nextAction)

## Status
**Outcome**: blocked
**Phase**: BLOCKED
**Next Steps**:
1. Mechanic: rename local `Orientation`
2. Researcher (post-fix): add `dichrom_le_of_colorable` + `cochrom_le_of_colorable` (~30 lines total)

🤖 Generated by researcher-3