### PR TITLE
audit: fix erdos-982 originalContributions to match Lean source

### DIFF
--- a/src/data/proofs/erdos-982/meta.json
+++ b/src/data/proofs/erdos-982/meta.json
@@ -52,18 +52,15 @@
       "maxDistinctDistances function for maximum over all vertices",
       "InConvexPosition predicate for convex polygon vertices",
       "guaranteedDistinctDistances function f(n)",
-      "erdos982Conjecture formal statement",
+      "erdos982Conjecture and erdos982Conjecture' formal statements",
       "moser_bound axiom (1952 result)",
-      "erdos_fishburn_bound axiom (1994 result)",
-      "dumitrescu_bound axiom (2006 result)",
       "nppz_bound axiom (2013 result)",
-      "regular_polygon_distances optimality",
+      "regular_polygon_distances axiom (upper-bound construction)",
       "triangle_case, quadrilateral_case, pentagon_case small examples",
-      "strongerConjectureDisproved connecting to Problem #97",
-      "acute_triangle_counterexample for curve conjecture",
-      "barany_roldan_pensado weakened curve result",
-      "currentGap analysis of known vs conjectured bounds",
-      "erdos_982_status main theorem summarizing state of knowledge"
+      "strongerConjectureDisproved predicate connecting to Problem #97",
+      "stronger_conjecture_is_false axiom",
+      "currentGap definition and gap_value theorem",
+      "erdos_982_status and erdos_982_summary main theorems"
     ],
     "axiomCount": 4,
     "lineCount": 333,
@@ -114,18 +111,18 @@
     {
       "id": "known-bounds",
       "title": "Known Bounds",
-      "summary": "moser_bound, erdos_fishburn_bound, dumitrescu_bound, nppz_bound axioms",
+      "summary": "moser_bound and nppz_bound axioms (Erdos-Fishburn and Dumitrescu noted in docstrings only)",
       "startLine": 126,
       "endLine": 169,
-      "mathContext": "Axiomatized: moser_bound, erdos_fishburn_bound, dumitrescu_bound, nppz_bound axioms"
+      "mathContext": "Axiomatized: moser_bound, nppz_bound axioms"
     },
     {
       "id": "regular-polygon",
       "title": "Regular Polygon Optimality",
-      "summary": "regular_polygon_distances, upper_bound_on_f axioms",
+      "summary": "regular_polygon_distances axiom",
       "startLine": 170,
       "endLine": 192,
-      "mathContext": "Axiomatized: regular_polygon_distances, upper_bound_on_f axioms"
+      "mathContext": "Axiomatized: regular_polygon_distances axiom"
     },
     {
       "id": "small-cases",


### PR DESCRIPTION
## Summary

The \`originalContributions\` field for **erdos-982** listed four phantom items that exist only as docstring comments in the Lean file (no corresponding \`axiom\`/\`theorem\`/\`def\` declaration):

- \`erdos_fishburn_bound\` axiom — only a \`/-- ... -/\` docstring, no declaration
- \`dumitrescu_bound\` axiom — only a docstring, no declaration
- \`acute_triangle_counterexample\` for curve conjecture — no declaration
- \`barany_roldan_pensado\` weakened curve result — no declaration

The \"known-bounds\" and \"regular-polygon\" section summaries also referenced these phantom axioms (and a non-existent \`upper_bound_on_f\`).

## Verification

\`\`\`
$ grep -E '^(axiom|theorem|def|noncomputable def)\s' proofs/Proofs/Erdos982Problem.lean
def distinctDistancesFrom ...
def maxDistinctDistances ...
def InConvexPosition ...
noncomputable def guaranteedDistinctDistances ...
def erdos982Conjecture ...
def erdos982Conjecture' ...
axiom moser_bound ...
axiom nppz_bound ...
axiom regular_polygon_distances ...
theorem triangle_case ...
theorem quadrilateral_case ...
theorem pentagon_case ...
def strongerConjectureDisproved ...
axiom stronger_conjecture_is_false ...
def currentGap ...
theorem gap_value ...
theorem erdos_982_status ...
theorem erdos_982_summary ...
\`\`\`

Actual axioms: 4 (matches \`axiomCount: 4\`). Phantom contributions removed; real ones (\`erdos982Conjecture'\`, \`stronger_conjecture_is_false\`, \`gap_value\`, \`erdos_982_summary\`) added.

\`axiomCount\`, \`sorries\`, \`badge\`, \`status\`, and the \`assumptions\` field were already correct; this is purely a contributions-list integrity fix.

## Test plan

- [x] \`python3 -c \"import json; json.load(open('src/data/proofs/erdos-982/meta.json'))\"\` — JSON valid
- [x] All listed contributions correspond to declarations actually present in \`Erdos982Problem.lean\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)