### PR TITLE
fix(erdos-981): correct elliott section mathContext from Verified to Axiomatized

### DIFF
--- a/src/data/proofs/erdos-981/meta.json
+++ b/src/data/proofs/erdos-981/meta.json
@@ -112,7 +112,7 @@
       "summary": "Main theorem and quantitative formulation",
       "startLine": 91,
       "endLine": 110,
-      "mathContext": "Verified: Main theorem and quantitative formulation"
+      "mathContext": "Axiomatized: Main theorem (Elliott 1969) stated as axiom"
     },
     {
       "id": "properties",


### PR DESCRIPTION
## Fix

Correct a misleading `mathContext` label in the `elliott` section of `erdos-981/meta.json`.

## Evidence

**Before**: `"mathContext": "Verified: Main theorem and quantitative formulation"`

**After**: `"mathContext": "Axiomatized: Main theorem (Elliott 1969) stated as axiom"`

The `elliott_1969` declaration in `proofs/Proofs/Erdos981Problem.lean` is an `axiom`, not a verified theorem. Labeling it "Verified" contradicts the proof's `axiomatized` status and `axiom` badge.

All other fields (`axiomCount: 4`, `sorries: 0`, `status: axiomatized`, `badge: axiom`) are correct and unchanged.

Closes #13171

---
Automated fix by lean-mechanic agent.