### PR TITLE
Fix: erdos-982 originalContributions and section summaries reference phantom declarations

### DIFF
--- a/src/data/proofs/erdos-982/meta.json
+++ b/src/data/proofs/erdos-982/meta.json
@@ -54,14 +54,11 @@
       "guaranteedDistinctDistances function f(n)",
       "erdos982Conjecture formal statement",
       "moser_bound axiom (1952 result)",
-      "erdos_fishburn_bound axiom (1994 result)",
-      "dumitrescu_bound axiom (2006 result)",
       "nppz_bound axiom (2013 result)",
-      "regular_polygon_distances optimality",
+      "regular_polygon_distances axiom (regular polygon optimality)",
       "triangle_case, quadrilateral_case, pentagon_case small examples",
       "strongerConjectureDisproved connecting to Problem #97",
-      "acute_triangle_counterexample for curve conjecture",
-      "barany_roldan_pensado weakened curve result",
+      "stronger_conjecture_is_false axiom",
       "currentGap analysis of known vs conjectured bounds",
       "erdos_982_status main theorem summarizing state of knowledge"
     ],
@@ -114,18 +111,18 @@
     {
       "id": "known-bounds",
       "title": "Known Bounds",
-      "summary": "moser_bound, erdos_fishburn_bound, dumitrescu_bound, nppz_bound axioms",
+      "summary": "moser_bound, nppz_bound axioms (Moser 1952, Nivasch et al. 2013)",
       "startLine": 126,
       "endLine": 169,
-      "mathContext": "Axiomatized: moser_bound, erdos_fishburn_bound, dumitrescu_bound, nppz_bound axioms"
+      "mathContext": "Axiomatized: moser_bound, nppz_bound axioms"
     },
     {
       "id": "regular-polygon",
       "title": "Regular Polygon Optimality",
-      "summary": "regular_polygon_distances, upper_bound_on_f axioms",
+      "summary": "regular_polygon_distances axiom (regular polygon optimality)",
       "startLine": 170,
       "endLine": 192,
-      "mathContext": "Axiomatized: regular_polygon_distances, upper_bound_on_f axioms"
+      "mathContext": "Axiomatized: regular_polygon_distances axiom"
     },
     {
       "id": "small-cases",
@@ -146,10 +143,10 @@
     {
       "id": "curve-generalization",
       "title": "Convex Curve Generalization",
-      "summary": "acute_triangle_counterexample, barany_roldan_pensado results",
-      "startLine": 262,
-      "endLine": 293,
-      "mathContext": "Mathematical content: acute_triangle_counterexample, barany_roldan_pensado results"
+      "summary": "Docstring context: Bárány-Roldán-Pensado (2013) curve conjecture counterexample discussion",
+      "startLine": 249,
+      "endLine": 262,
+      "mathContext": "Docstring context: convex curve generalization and its disproof (no Lean declarations)"
     },
     {
       "id": "gap-analysis",


### PR DESCRIPTION
## Fix

Remove phantom Lean declarations from `originalContributions` and section `summary`/`mathContext` fields in `src/data/proofs/erdos-982/meta.json`.

## Evidence

**Before**: `originalContributions` listed `erdos_fishburn_bound`, `dumitrescu_bound`, `acute_triangle_counterexample`, `barany_roldan_pensado` — none of which exist in `Erdos982Problem.lean`.

**After**: Only declarations that actually exist in the Lean file are referenced:
- `moser_bound`, `nppz_bound`, `regular_polygon_distances`, `stronger_conjecture_is_false` axioms
- Definitions and theorems that appear in the file
- Section summaries corrected: `known-bounds` now lists only `moser_bound, nppz_bound`; `regular-polygon` lists only `regular_polygon_distances`; `curve-generalization` updated to reflect docstring-only content

Fields `axiomCount: 4`, `sorries: 3`, `status: axiomatized`, and `badge: axiom` were already correct and unchanged.

Closes #13168

---
Automated fix by lean-mechanic agent.