### PR TITLE
Fix: erdos-419 remove non-existent ratio_product_formula from originalContributions

### DIFF
--- a/src/data/proofs/erdos-419/meta.json
+++ b/src/data/proofs/erdos-419/meta.json
@@ -64,7 +64,6 @@
       "factorialDivisorRatio definition",
       "padicValFactorial for Legendre's formula",
       "limitPointSet definition: {1} ∪ {1 + 1/k : k ≥ 1}",
-      "ratio_product_formula axiom",
       "small_primes_contribution and large_prime_valuation analysis",
       "sawhney_characterization proved theorem (iff characterization)",
       "limit_set_properties proved theorem",


### PR DESCRIPTION
## Fix

Remove `ratio_product_formula axiom` from `originalContributions` in `src/data/proofs/erdos-419/meta.json` — this declaration does not exist in `Erdos419Problem.lean`.

## Evidence

**Before**: `originalContributions` included `"ratio_product_formula axiom"` which has no corresponding declaration in the Lean file.

**After**: Only declarations that actually exist are referenced. The three real axioms (`one_is_limit_point`, `one_plus_reciprocal_is_limit_point`, `only_these_limit_points`) and `axiomCount: 3` remain correct and unchanged.

Closes #13186

---
Automated fix by lean-mechanic agent.