### PR TITLE
fix(meta): correct sorry count for ballot-problem-oq-03-oq-01-oq-02 (3→1)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "ballot-problem-oq-03-oq-01-oq-02",
   "title": "Hook-Length Formula for Standard Young Tableaux via LGV",
   "slug": "ballot-problem-oq-03-oq-01-oq-02",
-  "description": "Formalizes the hook-length formula f^λ = n!/∏h(u) for Standard Young Tableaux. Proves: 1-row, 1-col, hook shapes, 2-rect, general 2-row, all gHookYD [a,1^b], ≤2-col (transpose duality), exactly 3-row ALL [a,b,c] shapes, exactly 4-row ALL [a,b,c,d] shapes (PART XVIII), exactly 5-row ALL [a,b,c,d,e] shapes (PART XIX), exactly 6-row ALL [a,b,c,d,e,f] shapes (PART XX), exactly 7-row ALL [a,b,c,d,e,f,g] shapes (PART XXI), exactly 8-row ALL [a,b,c,d,e,f,g,h] shapes (PART XXII), exactly 9-row ALL [a,b,c,d,e,f,g,h,i] shapes (PART XXIII). General formula has 3 sorries: 2 via LGV approach + 1 for hook_walk_identity (≥10-row, ≥3-col, non-gHookYD).",
+  "description": "Formalizes the hook-length formula f^λ = n!/∏h(u) for Standard Young Tableaux. Proves: 1-row, 1-col, hook shapes, 2-rect, general 2-row, all gHookYD [a,1^b], ≤2-col (transpose duality), exactly 3-row ALL [a,b,c] shapes, exactly 4-row ALL [a,b,c,d] shapes (PART XVIII), exactly 5-row ALL [a,b,c,d,e] shapes (PART XIX), exactly 6-row ALL [a,b,c,d,e,f] shapes (PART XX), exactly 7-row ALL [a,b,c,d,e,f,g] shapes (PART XXI), exactly 8-row ALL [a,b,c,d,e,f,g,h] shapes (PART XXII), exactly 9-row ALL [a,b,c,d,e,f,g,h,i] shapes (PART XXIII). General formula has 1 remaining sorry: hook_walk_identity for ≥10-row, ≥10-col, non-rectangular shapes (GNW probabilistic argument, ~300 lines). The 2 previously-stated LGV sorries were dead scaffolding and have been removed.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-21",
@@ -93,7 +93,7 @@
     "namespace": "HookLengthFormula",
     "lineCount": 14005,
     "axiomCount": 0,
-    "sorries": 3,
+    "sorries": 1,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",
     "theoremCount": 484,
     "definitionCount": 14
@@ -202,5 +202,5 @@
       "mathContext": "$h(\\mu,i,j) = h(\\mu^\\top,j,i)$ (arm↔leg under transpose). For N-row shapes: hook walk identity $\\sum_c \\text{hookProd}(\\mu)/\\text{hookProd}(\\mu\\setminus c) = \\sum_i a_i$ is a polynomial identity in $a_1,\\ldots,a_N$, verifiable by `ring` after computing each hook length as a linear combination of $a_i$."
     }
   ],
-  "sorries": 3
+  "sorries": 1
 }


### PR DESCRIPTION
## Fix

Corrects stale sorry count in `ballot-problem-oq-03-oq-01-oq-02/meta.json` from 3 to 1.

## Evidence

**Before**: `leanFile.sorries: 3`, top-level `sorries: 3`, description claiming "3 sorries: 2 via LGV approach + 1 for hook_walk_identity"

**After**: All three fields set to `1`, description updated to reflect the single remaining sorry (hook_walk_identity for ≥10×≥10 non-rectangular shapes)

**Root cause**: The two LGV-approach sorries (`ni_count_eq_syt_count` and `lgv_det_factors_as_hook_quotient`) were identified as dead, unprovable scaffolding and removed from the Lean file in session 32 (documented at line 228 of `BallotProblemOQ03OQ01OQ02.lean`). The metadata was never updated to reflect the removal.

**Verification**: Actual sorry count in `BallotProblemOQ03OQ01OQ02.lean` (excluding comments): 1 — at line 13932 (≥10×≥10 non-rectangular case, pending GNW hook-walk argument).

---
Automated fix by lean-mechanic agent.