### PR TITLE
Research: axiom-integrity + sorry-def fixes (erdos-501, erdos-533, erdos-1018-oq-04)

### DIFF
--- a/proofs/Proofs/Erdos501ProblemProvable.lean
+++ b/proofs/Proofs/Erdos501ProblemProvable.lean
@@ -27,6 +27,7 @@ import Mathlib.MeasureTheory.Measure.Lebesgue.Basic
 import Mathlib.MeasureTheory.Measure.OuterMeasure.Basic
 import Mathlib.Topology.MetricSpace.Basic
 import Mathlib.Data.Set.Finite
+import Mathlib.SetTheory.Cardinal.Continuum
 import Mathlib.Tactic
 
 namespace Erdos501Provable
@@ -109,10 +110,19 @@ theorem independent_pair_exists (A : SetFamily) (hA : BoundedOuterMeasureFamily 
     This is stated as a conditional: CH implies the negation of the
     infinite independence property for some family.
 -/
-/-- The Continuum Hypothesis: every uncountable subset of ℝ has cardinality |ℝ|.
-    Defined as a `Prop` (not axiom) since this is the provable version of the file. -/
+/-- The Continuum Hypothesis: ℵ₁ = 𝔠 (the first uncountable cardinal equals the
+    cardinality of the continuum). This is independent of ZFC.
+
+    Defined as a `Prop` (not axiom) so this file is fully axiom-free.
+
+    Note: A previous version defined CH as
+    `∀ S ⊆ ℝ uncountable, ∃ f : ℝ → S, Function.Surjective f`,
+    but that statement is *trivially provable* in ZFC: pick any s₀ ∈ S and define
+    `f x := if x ∈ S then x else s₀`. This is surjective because every y ∈ S is
+    its own preimage. So that "CH" carried no content. The cardinal-equality form
+    used here matches `Erdos501Problem.lean` and the gallery's `ContinuumHypothesis.lean`. -/
 def continuum_hypothesis : Prop :=
-  ∀ (S : Set ℝ), ¬S.Countable → ∃ f : ℝ → S, Function.Surjective f
+  Cardinal.aleph 1 = Cardinal.continuum
 
 theorem hechler_under_CH (hCH : continuum_hypothesis) :
     ∃ A : SetFamily, BoundedOuterMeasureFamily A ∧ ¬HasInfiniteIndependent A := by

--- a/proofs/Proofs/Erdos533Problem.lean
+++ b/proofs/Proofs/Erdos533Problem.lean
@@ -357,8 +357,13 @@ theorem degree_le {n : ℕ} (G : SGraph n) (v : Fin n) : degree G v ≤ n - 1 :=
 
 /-- Erdős Problem #533: For every δ > 0, any K₅-free graph on n vertices
     with at least δn² edges must contain a triangle-free induced subgraph
-    on ≫_δ n vertices. -/
-axiom erdos_533_conjecture (δ : ℝ) (hδ : 0 < δ) :
+    on ≫_δ n vertices.
+
+    This is the open conjecture; it should be a `Prop`, not an `axiom`,
+    since asserting it via `axiom` would amount to assuming the conjecture
+    is true (which is unknown). The full conjecture is
+    `∀ δ > 0, erdos_533_conjecture δ _`. -/
+def erdos_533_conjecture (δ : ℝ) (_hδ : 0 < δ) : Prop :=
   ∃ c : ℝ, 0 < c ∧ ∀ (n : ℕ) (hn : 1 ≤ n)
     (G : SGraph n) (hK5 : ¬HasClique G 5)
     (hEdges : δ * n ^ 2 ≤ (edgeCount G : ℝ)),

--- a/src/data/proofs/erdos-533/meta.json
+++ b/src/data/proofs/erdos-533/meta.json
@@ -20,9 +20,9 @@
     "erdosNumber": 533,
     "erdosUrl": "https://erdosproblems.com/533",
     "erdosProblemStatus": "open",
-    "axiomCount": 4,
-    "lineCount": 366,
-    "assumptions": "4 axioms: ehsss_result (EHSSS partial result for delta>1/16), k4_free_triangle_free_subset (K4-free case for all delta>0), turan_k5_free (Turán bound: K5-free has ≤ 3n²/8 edges), erdos_533_conjecture (OPEN). Neighborhood structure and K4-free neighborhood lemma proved.",
+    "axiomCount": 3,
+    "lineCount": 372,
+    "assumptions": "4 axioms: ehsss_result (EHSSS partial result for delta>1/16), k4_free_triangle_free_subset (K4-free case for all delta>0), turan_k5_free (Turán bound: K5-free has ≤ 3n²/8 edges), erdos_533_conjecture (OPEN). Neighborhood structure and K4-free neighborhood lemma proved. erdos_533_conjecture converted from axiom to def (open conjecture should not be axiom-asserted).",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/research/problems/erdos-501-incomplete-01.json
+++ b/src/data/research/problems/erdos-501-incomplete-01.json
@@ -18,10 +18,10 @@
   "currentState": {
     "phase": "ORIENT",
     "since": "2026-03-28T20:57:10.258Z",
-    "iteration": 5,
-    "focus": "Decomposed erdos_hajnal_finite. Remaining sorry is product measure existence lemma for n>=2.",
+    "iteration": 6,
+    "focus": "CH-def bug fixed in Provable file. 3 deep sorries remain across both files (Erdos-Hajnal n>=2, Hechler under CH, NPS closed).",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Either eliminate file duplication (provable now mirrors main exactly), or break Mathlib gap with outer-measure Fubini lemma.",
     "attemptCounts": {
       "total": 1,
       "currentApproach": 0,
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Decomposed erdos_hajnal_finite into exists_independent_tuple (sorry for n>=2) + proved combinatorial reduction. 0 axioms, 3 sorries remain (exists_independent_tuple n>=2, hechler_under_CH, nps_closed_infinite).",
+    "progressSummary": "PROGRESS: Fixed CH definition bug in Erdos501ProblemProvable.lean — old def `∀ S ⊆ ℝ uncountable, ∃ surjection ℝ → S` is trivially provable in ZFC (carries no content). Replaced with `Cardinal.aleph 1 = Cardinal.continuum` matching main file. 0 axioms, 3 sorries remain (exists_independent_tuple n>=2, hechler_under_CH, nps_closed_infinite).",
     "builtItems": [
       "Proved max_size_infinite in Erdos501Problem.lean (by_contra + le_iSup₂ + omega)",
       "Proved max_size_infinite in Erdos501ProblemProvable.lean (same proof)",
@@ -40,7 +40,8 @@
       "Created Erdos501Aristotle.lean with bounded_empty, bounded_subset, bounded_inter_Icc, bounded_union, outerMeasure_mono, outerMeasure_inter_le, outerMeasure_union_le, exists_not_mem_of_outerMeasure_lt_Icc (sorry), isClosed_measurableSet, closed_outerMeasure_eq_measure, measure_compl_Icc_pos (sorry), independent_size_zero, independent_size_one",
       "Decomposed erdos_hajnal_finite into exists_independent_tuple + combinatorial reduction",
       "Proved erdos_hajnal_finite from exists_independent_tuple (Finset.image + card_image_of_injective)",
-      "Proved exists_independent_tuple base cases n=0 (Fin.elim0) and n=1 (Subsingleton)"
+      "Proved exists_independent_tuple base cases n=0 (Fin.elim0) and n=1 (Subsingleton)",
+      "Fixed continuum_hypothesis bug in Erdos501ProblemProvable.lean: replaced trivially-true surjection-based def with Cardinal.aleph 1 = Cardinal.continuum"
     ],
     "insights": [
       "Answer depends on set-theoretic axioms (CH): NO under CH (Hechler 1972), YES for closed sets (NPS 1987)",
@@ -61,13 +62,15 @@
       "Key proof analysis: gladysz_pairs and erdos_hajnal_finite both require Fubini-type arguments with measurability of the product graph {(x,y) : x ∈ A_y}. For general families, this graph may be non-measurable. For closed families, measurability of multifunction y ↦ A_y is not automatic.",
       "Product measure proof of Erdos-Hajnal: conflict set C_{ij}={f in [0,L]^n: f(i) in A(f(j))} has measure < L^{n-1} by Fubini section bound. Total < n(n-1)*L^{n-1} < L^n for L > n(n-1), so conflict-free injective tuples exist.",
       "Backward avoidance (x_i not in A_z) cannot be proved by deterministic construction -- requires product measure / counting argument. This is the fundamental difficulty.",
-      "Base cases n=0,1 of exists_independent_tuple proved. Combinatorial reduction (tuple to Finset) fully proved."
+      "Base cases n=0,1 of exists_independent_tuple proved. Combinatorial reduction (tuple to Finset) fully proved.",
+      "BUG (fixed): Provable file had `∀ S ⊆ ℝ uncountable, ∃ f : ℝ → S, Function.Surjective f` as CH. This is trivially True in ZFC: for non-empty S pick s₀ ∈ S and define f(x) := if x ∈ S then x else s₀; every y ∈ S has preimage y. So that def carried no CH content."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove exists_independent_tuple for n>=2: needs outer measure Tonelli/Cavalieri inequality on product spaces",
-      "Alternative: formalize product outer measure bound as Mathlib-compatible lemma, then reduce to it",
-      "Consider whether MeasureTheory.Measure.prod_fubini can handle outer measure bounds for non-measurable sets"
+      "Prove exists_independent_tuple for n>=2: requires outer-measure Tonelli/Cavalieri inequality on product spaces",
+      "Consider proof via measurable cover + Mathlib Fubini, then transfer back to outer measure",
+      "Hechler 1972 (under CH) and NPS 1987 (closed sets) require independent deep formalization efforts (transfinite induction / descriptive set theory)",
+      "Consider unifying main file and Provable file — both now use the same CH def, so structural duplication is closer to elimination"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Three related axiom/sorry-def integrity fixes for Erdős problem stubs.

### erdos-501-incomplete-01 (commit ea3f52087c8): trivially-True CH definition

`Erdos501ProblemProvable.lean` previously defined CH as

```lean
∀ (S : Set ℝ), ¬S.Countable → ∃ f : ℝ → S, Function.Surjective f
```

which is **trivially provable in ZFC** (carries no CH content). For any non-empty
`S`, `f x := if x ∈ S then x else s₀` makes every `y ∈ S` its own preimage. So the
"CH" hypothesis was empty.

**Fix**: Replace with `Cardinal.aleph 1 = Cardinal.continuum`, matching
`Erdos501Problem.lean` and the gallery's canonical `ContinuumHypothesis.lean`.

### erdos-533 (commit d0611322706): open conjecture as axiom

`Erdos533Problem.lean` declared the open conjecture as
`axiom erdos_533_conjecture (δ) (hδ) : ...`. This violates axiom-integrity: an
unknown statement asserted as an axiom assumes it's true and would poison any
downstream proof.

**Fix**: Convert to `def erdos_533_conjecture (δ : ℝ) (_hδ : 0 < δ) : Prop := ...`.
Reduces axiom count 4 → 3. The remaining 3 axioms (Turán k5-free, EHSSS, K4-free
triangle-free subset) are deep but TRUE results not yet in Mathlib — legitimate
axiomatizations.

### erdos-1018-oq-04 (commit a526a05b302): isEmbeddable sorry-def

`Erdos1018OQ04.lean` defined the central embeddability predicate as a sorry-def:

```lean
def isEmbeddable {r : ℕ} (_H : Hypergraph V r) (_d : ℕ) : Prop :=
  sorry
```

A sorry-def is worse than an axiom — it makes the resulting Prop opaque so no
downstream proof can reason through it. The companion file `Erdos1018OQ04Incomplete01`
worked around it by introducing a separate `isEmbeddableConc`, but couldn't
connect back (one of its sorries is exactly that connection).

**Fix**: Replace with the standard "almost-embedding" definition:

```lean
def isEmbeddable {r : ℕ} (H : Hypergraph V r) (d : ℕ) : Prop :=
  ∃ φ : V → Fin d → ℝ, Function.Injective φ ∧
    ∀ e₁ ∈ H.edges, ∀ e₂ ∈ H.edges, e₁ ≠ e₂ →
      convexHull ℝ (Set.image φ e₁) ∩ convexHull ℝ (Set.image φ e₂) ⊆
      convexHull ℝ (Set.image φ (e₁ ∩ e₂ : Finset V))
```

This matches the body of the child's `isEmbeddableConc` exactly, so the two are
now definitionally equal — the child's `r2_implies_main_r2` sorry can be filled
in a follow-up by leveraging this defeq.

## Sorry / axiom delta

| Problem | Before | After | Change |
|---------|--------|-------|--------|
| erdos-501-incomplete-01 (Provable) | 0 ax / 3 sorries | 0 ax / 3 sorries | CH def replaced (was trivially True) |
| erdos-533 | 4 ax / 0 sorries | 3 ax / 0 sorries | Open-conjecture axiom → def |
| erdos-1018-oq-04 (parent) | 4 ax / 2 sorry-defs | 4 ax / 1 sorry-def | isEmbeddable now concrete |

## Test plan

- [ ] CI builds `Proofs.Erdos501ProblemProvable`, `Proofs.Erdos533Problem`,
      and `Proofs.Erdos1018OQ04`
- [ ] Downstream consumers verified: `continuum_hypothesis` and
      `erdos_533_conjecture` only appear as Prop hypotheses (no destructuring);
      `isEmbeddable` consumers (`isNonEmbeddable`, `vanKampen_Flores`,
      `triangle_planar`, `K4_planar`, `hasSmallNonEmbeddable`) statements remain
      well-typed since the new def has the same signature.
- [ ] Gallery meta.json axiomCount/sorries fields updated for affected problems.

🤖 Generated by researcher-11