### PR TITLE
Research: erdos-353-incomplete-01 — document upstream build blocker (orphan docstrings + HSMul Set drift)

### DIFF
--- a/research/problems/erdos-353-incomplete-01/knowledge.md
+++ b/research/problems/erdos-353-incomplete-01/knowledge.md
@@ -2,13 +2,130 @@
 
 ## Research Notes
 
-*No research conducted yet. See problem.md for context.*
+Erdős Problem #353 (Geometric Configurations in Sets of Infinite Measure):
+recently solved by Koizumi (2025) for isosceles trapezoids, isosceles
+triangles, and right triangles, plus Kovač–Predojević (2024) for cyclic
+quadrilaterals. The Lean formalization keeps each solved result as an
+`axiom` (since the underlying proofs are recent Mathlib-external research)
+and proves the natural scaling consequences from those axioms.
 
 ## Known Facts
 
-- Lean file: `proofs/Proofs/`
-- Sorries: see problem.md
+- `proofs/Proofs/Erdos353Problem.lean` — main file (446 lines, 11 thms,
+  4 axioms encoding cited published results, 0 sorries on disk)
+- `proofs/Proofs/Erdos353Aristotle.lean` — companion (40 lines, 1 thm,
+  scaling-of-Lebesgue-measure helper)
 
 ## Approaches Tried
 
-*None yet.*
+### Prior session — scaling argument from Koizumi (status snapshot)
+
+Earlier work proved the scaling consequence:
+`scaling_property : HasInfiniteMeasure A → ∀ t > 0, HasIsoscelesTriangleWithArea A t`,
+reducing the per-area question to Koizumi's area-1 axiom by rescaling
+the set by `1/√t`. Companion-file `volume_preimage_smul_eq_top`
+provides the Haar-scaling glue. As recorded, the file had 0 sorries.
+
+## Session 2 (2026-04-27) — Build Blocked
+
+**Mode**: REVISIT (claimed MODERATE problem, knowledge score 12)
+**Outcome**: BLOCKED — both files fail to build on `origin/master`.
+This is adjacent in time to the `project_mathlib_api_drift_2026_04`
+cohort but a different breakage pattern (pointwise `Set` smul +
+stricter docstring parsing).
+
+### Build Verification
+
+Ran `./proofs/scripts/docker-build.sh Proofs.Erdos353Problem` and
+`./proofs/scripts/docker-build.sh Proofs.Erdos353Aristotle` from a
+clean `origin/master` snapshot (commit `70a28e942bd`). Both fail.
+
+### Errors (Erdos353Problem.lean)
+
+Two distinct categories:
+
+**Category A — Lean 4.26 stricter docstring parsing.**
+Lines 226, 233, 251, 260 each open a `/-- ... -/` doc-comment that is
+*not* attached to a following declaration (the file has free-floating
+docstrings for Kovač's Trapezoid theorem (line 222), Kovač's
+Parallelogram counterexample (line 227), Kovač–Predojević Congruent
+Sides counterexample (line 247), and Finite Measure Fails (line 256),
+none of which have a paired `axiom`/`theorem`/`lemma`):
+
+```
+error: Proofs/Erdos353Problem.lean:226:2: unexpected token '/--'; expected 'lemma'
+error: Proofs/Erdos353Problem.lean:233:2: unexpected token '/--'; expected 'lemma'
+error: Proofs/Erdos353Problem.lean:251:2: unexpected token '/--'; expected 'lemma'
+error: Proofs/Erdos353Problem.lean:260:2: unexpected token '/--'; expected 'lemma'
+```
+
+These probably parsed in an older Lean release. Fix: convert each
+orphan `/-- ... -/` to a regular block comment `/- ... -/`, or attach
+each to a stub axiom.
+
+**Category B — `HSMul ℝ (Set _)` instance no longer synthesized.**
+Lines 274, 285, 347, 350 use `c⁻¹ • A` where
+`A : Set (EuclideanSpace ℝ (Fin 2))`. Lean fails to synthesize
+`HSMul ℝ (Set (EuclideanSpace ℝ (Fin 2))) ?m`, suggesting the
+pointwise smul instance on `Set` is no longer in scope:
+
+```
+error: Proofs/Erdos353Problem.lean:274:4: failed to synthesize
+  HSMul ℝ (Set (EuclideanSpace ℝ (Fin 2))) ?m.19
+```
+
+Likely fix: `open Pointwise` (the Mathlib convention to enable
+`c • A` for sets), or import the module that now carries
+`Set.smul_set`.
+
+There are also cascading errors at lines 296 (parser), 320 (`simp`
+made no progress) that may resolve once `HSMul` resolution is
+restored.
+
+### Errors (Erdos353Aristotle.lean)
+
+Single instance error from the same root cause:
+
+```
+error: Proofs/Erdos353Aristotle.lean:29:66: failed to synthesize
+  HSMul ℝ (Set (EuclideanSpace ℝ (Fin 2))) ?m.53
+```
+
+Likely fix: same `open Pointwise` / Mathlib import adjustment as the
+main file.
+
+### Why I Did Not Fix
+
+Per project memory `project_mathlib_api_drift_2026_04`, repair work
+on upstream-induced breakage is Mechanic-owned. While Category A
+(orphan docstrings) is locally repairable, Category B is genuine
+Mathlib API drift on the pointwise scalar action and should be
+batched with other affected files. A scoped researcher fix would
+risk diverging from a future Mechanic batch repair.
+
+### Next Steps
+
+1. **Mechanic**:
+   - Convert orphan `/-- ... -/` docstrings on lines 222, 227, 247,
+     256 of Erdos353Problem.lean to regular block comments
+     `/- ... -/`. This unblocks Category A.
+   - Add `open Pointwise` to both `Erdos353Problem.lean` and
+     `Erdos353Aristotle.lean` (or import the module that re-exposes
+     `Set.smul_set`). This unblocks Category B.
+   - Re-run Docker build to confirm green state.
+2. **Researcher (after repair)**: extend `scaling_property` to right
+   triangles, isosceles trapezoids, and cyclic quadrilaterals. All
+   four are structurally identical uses of `addHaar_smul` on the
+   corresponding base axiom — a direct parallel of the existing
+   `scaling_property` for isosceles triangles. This rounds out the
+   gallery's "any positive area" coverage of the Erdős #353
+   configuration list.
+
+### Files Modified This Session
+
+- `research/problems/erdos-353-incomplete-01/knowledge.md` (this
+  file) — Session 2 entry: build verification + drift diagnosis
+- `src/data/research/problems/erdos-353-incomplete-01.json` —
+  `progressSummary`, `currentState`, `nextSteps`
+
+No proof code changed.

--- a/src/data/research/problems/erdos-353-incomplete-01.json
+++ b/src/data/research/problems/erdos-353-incomplete-01.json
@@ -16,12 +16,15 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-04-03T08:28:28Z",
-    "iteration": 1,
-    "focus": "",
-    "blockers": [],
-    "nextAction": "",
+    "phase": "ACT",
+    "since": "2026-04-27T14:10:00Z",
+    "iteration": 2,
+    "focus": "Blocked: orphan docstrings + HSMul Set drift",
+    "blockers": [
+      "Lean 4.26 strict docstring parsing on lines 226/233/251/260",
+      "Mathlib pointwise Set smul instance not synthesized — needs `open Pointwise` in both Erdos353Problem.lean and Erdos353Aristotle.lean"
+    ],
+    "nextAction": "Mechanic: orphan docstring conversion + open Pointwise. Researcher (post-repair): extend scaling_property to right triangles, trapezoids, cyclic quadrilaterals.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,7 +32,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: Proved companion file sorry. Fixed meta.json (0 sorries, 4 deep axioms). All Lean files sorry-free.",
+    "progressSummary": "BLOCKED on upstream breakage. Docker build of both Proofs.Erdos353Problem and Proofs.Erdos353Aristotle fails on origin/master. Two categories: (A) Lean 4.26 strict docstring parsing — orphan `/-- ... -/` doc-comments on lines 222/227/247/256 of main file; (B) Mathlib drift — `HSMul ℝ (Set _)` instance no longer synthesized for `c • A` set scaling (likely needs `open Pointwise`). Mechanic-owned per project_mathlib_api_drift_2026_04 policy. See knowledge.md Session 2 for fix recipe.",
     "builtItems": [
       "Proved scaling_property modulo measure scaling sorry in Erdos353Problem.lean",
       "Created Erdos353Aristotle.lean companion file for remaining sorry",
@@ -47,7 +50,13 @@
       "Companion file sorry was already solved by technique in main file — direct proof via addHaar_smul"
     ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Mechanic: convert orphan docstrings on lines 222/227/247/256 of Erdos353Problem.lean to block comments",
+      "Mechanic: add `open Pointwise` to both Erdos353Problem.lean and Erdos353Aristotle.lean",
+      "Researcher (post-repair): scaling_property_right (axiom: koizumi_right_triangle)",
+      "Researcher (post-repair): scaling_property_trapezoid (axiom: koizumi_isosceles_trapezoid)",
+      "Researcher (post-repair): scaling_property_cyclic (axiom: kovac_predojevic_cyclic)"
+    ],
     "markdown": "# Knowledge: erdos-353-incomplete-01\n\n## Research Notes\n\n*No research conducted yet. See problem.md for context.*\n\n## Known Facts\n\n- Lean file: `proofs/Proofs/`\n- Sorries: see problem.md\n\n## Approaches Tried\n\n*None yet.*\n"
   },
   "tags": [],


### PR DESCRIPTION
## Summary

Documents another casualty of recent upstream changes in the 2026-04-26/27 cohort. Both `Proofs.Erdos353Problem` and `Proofs.Erdos353Aristotle` fail to build on `origin/master`.

- **Build verification**: clean Docker builds of both files fail. Cache pulls 7727 Mathlib oleans cleanly; only the project files fail.
- **Two distinct breakage categories**, both upstream.
- **No proof code changed.** Per project memory `project_mathlib_api_drift_2026_04`, Mechanic owns these repairs. Same pattern as PR #13142 (Erdos1151OQ04), PR #13159 (AngleTrisectionOQ02OQ01OQ02Incomplete01), and PR #13216 (cevas-theorem-non-euclidean-oq-02, just filed).

## Errors

### Category A — Lean 4.26 stricter docstring parsing

```
error: Proofs/Erdos353Problem.lean:226:2: unexpected token '/--'; expected 'lemma'
error: Proofs/Erdos353Problem.lean:233:2: unexpected token '/--'; expected 'lemma'
error: Proofs/Erdos353Problem.lean:251:2: unexpected token '/--'; expected 'lemma'
error: Proofs/Erdos353Problem.lean:260:2: unexpected token '/--'; expected 'lemma'
```

Orphan `/-- ... -/` doc-comments at lines 222 (Kovač's Trapezoid), 227 (Kovač's Parallelogram counterexample), 247 (Kovač–Predojević Congruent Sides counterexample), and 256 (Finite Measure Fails) — none have an attached declaration. Probably parsed in older Lean. Fix: convert each to a block comment `/- ... -/` or attach a stub axiom.

### Category B — Mathlib pointwise Set smul

```
error: Proofs/Erdos353Problem.lean:274:4: failed to synthesize
  HSMul ℝ (Set (EuclideanSpace ℝ (Fin 2))) ?m.19
error: Proofs/Erdos353Aristotle.lean:29:66: failed to synthesize
  HSMul ℝ (Set (EuclideanSpace ℝ (Fin 2))) ?m.53
```

`c • A` for set scaling no longer resolves. Likely fix: `open Pointwise` (Mathlib's standard convention for set-scaling notation) in both files. Cascading errors at L296 (parser), L320 (`simp` no progress) probably resolve once `HSMul` synthesizes again.

## Fix recipe (for Mechanic)

1. Convert orphan `/-- ... -/` on lines 222/227/247/256 of `Erdos353Problem.lean` to `/- ... -/`.
2. Add `open Pointwise` to `Erdos353Problem.lean` and `Erdos353Aristotle.lean`.
3. Re-run `./proofs/scripts/docker-build.sh Proofs.Erdos353Problem` and `Proofs.Erdos353Aristotle`.

## Post-repair researcher plan

The existing `scaling_property` proves the per-area extension for **isosceles triangles** (Koizumi axiom). Once the build is green, the same `addHaar_smul`-based pattern transfers to:

- `scaling_property_right` — from `koizumi_right_triangle`
- `scaling_property_trapezoid` — from `koizumi_isosceles_trapezoid`
- `scaling_property_cyclic` — from `kovac_predojevic_cyclic`

This rounds out the gallery's "any positive area" coverage of the Erdős #353 configuration list.

## Files Modified

- `research/problems/erdos-353-incomplete-01/knowledge.md` — Session 2 entry: build verification, drift diagnosis, fix recipe, post-repair plan
- `src/data/research/problems/erdos-353-incomplete-01.json` — `progressSummary`, `currentState.blockers`, `nextSteps`

## Status

**Outcome**: blocked-upstream
**Next Steps**: Mechanic batches Category A + B fixes; researcher resumes with the four parallel scaling theorems.

🤖 Generated by researcher-5