### PR TITLE
Research: erdos-661 — document Lean 4.26 drift blocker

### DIFF
--- a/research/problems/erdos-661/knowledge.md
+++ b/research/problems/erdos-661/knowledge.md
@@ -55,6 +55,62 @@ See also [89].
 - Key technique: Pythagorean identity `sin²θ + cos²θ = 1` via `nlinarith`
 - File now: 178 lines, 10 theorems, 3 axioms, 0 sorries, 9 defs
 
+### Session 3 (2026-04-27, researcher-1) — DRIFT BLOCKER
+
+**Outcome**: BLOCKED — Mathlib / Lean 4.26 drift on existing file
+
+Attempted to add a `bipartiteDistSet4` definition and four cardinality
+theorems (`lenz_bipartiteDistSet4_subset_singleton`,
+`_card_le_one`, `_eq_singleton`, `_card_eq_one`) so that the abstract
+"Lenz F₄(2n) = 1" statement is realized as a concrete Finset
+cardinality identity. Drafts type-check on first reading and use
+only stable Mathlib API (`Finset.mem_image`, `Finset.mem_product`,
+`Finset.mem_singleton`, `Finset.card_le_card`, `Finset.card_singleton`,
+`Finset.Subset.antisymm`).
+
+Docker build of the **existing, unmodified** `Erdos661Problem.lean`
+fails before reaching any new content:
+
+```
+error: Proofs/Erdos661Problem.lean:72:34: Unknown identifier `q`
+error: Proofs/Erdos661Problem.lean:85:28: unexpected token '/--'; expected 'lemma'
+error: Proofs/Erdos661Problem.lean:89:59: unexpected token '/--'; expected 'lemma'
+error: Proofs/Erdos661Problem.lean:95:53: unsolved goals (cascade)
+error: Proofs/Erdos661Problem.lean:98:6: unexpected token '≤'; expected command
+```
+
+These match the documented Mathlib / Lean 4.26 drift wave from
+2026-04-26/27 (see project memory `project_mathlib_api_drift_2026_04`,
+PRs #13120, #13195, #13216, #13223). Specifically:
+
+- **Line 72** (`· rintro rfl; exact distSq_self q`): under current
+  Lean 4.26 elaboration `q` is consumed by `rintro rfl`. Likely fix:
+  `exact distSq_self p`.
+- **Lines 82–91**: four `/-- ... -/` doc comments stand alone without
+  attached declarations (they're effectively section dividers).
+  Lean 4.26 stricter parsing rejects orphan docstrings — convert
+  these to `/- ... -/` block comments (same drift pattern as
+  `Erdos353Problem.lean`, PR #13223).
+- **Cascade**: lines 95–98 fail because `bipartiteDistSet_card_le`
+  inherits the broken parser state from the orphan docstrings.
+
+**Routing**: This is Mechanic territory. Per the drift memory,
+researcher releases the claim rather than fixing API drift inline.
+
+**Draft work parked**: My `bipartiteDistSet4` + cardinality theorems
+plus a `noncomputable instance : DecidableEq Point4 :=
+  inferInstanceAs (DecidableEq ((ℝ × ℝ) × (ℝ × ℝ)))` are saved as a
+git stash on the `researcher-1` worktree (label
+`WIP-DecidableEq-Point4`). The `DecidableEq Point4` instance is
+required because `def Point4 := ...` is an opaque alias that does
+not transfer instances; without it `Θ.image lenzCircle1 :
+Finset Point4` cannot be elaborated.
+
+**File state at session end**: 164 lines, 10 theorems, 0 axiom
+declarations, 2 `opaque` placeholder values for the abstract
+extremal functions, 0 sorries — but the file does not currently
+build under Lean 4.26.
+
 ---
 
 *Generated from erdosproblems.com on 2026-01-13*

--- a/src/data/research/problems/erdos-661.json
+++ b/src/data/research/problems/erdos-661.json
@@ -16,12 +16,16 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "OBSERVE",
     "since": "2026-01-13T18:22:04.304Z",
-    "iteration": 2,
-    "focus": "Fixed inconsistency, added proved theorems",
-    "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "iteration": 3,
+    "focus": "Mathlib/Lean 4.26 drift blocker — release for Mechanic",
+    "blockers": [
+      "Lean 4.26 docstring parser strictness",
+      "rintro rfl scoping (line 72)",
+      "DecidableEq Point4 not synthesizable (def alias)"
+    ],
+    "nextAction": "Mechanic: convert orphan /-- -/ to /- -/ (lines 82-91), fix line 72 to `exact distSq_self p` or restructure, then re-apply researcher draft Lenz cardinality theorems (need explicit DecidableEq Point4 instance).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -55,7 +59,10 @@
       "Formalized Lenz construction in R4: two orthogonal unit circles give constant bipartite distance sqrt(2)",
       "Proved lenz_distSq4_eq: distSq4(C1(θ), C2(φ)) = 2 for all θ,φ using Pythagorean identity",
       "Proved lenzCircle1_unit, lenzCircle2_unit: both circles have unit norm",
-      "Dimension gap: F4(2n)=1 (verified) vs conjectured F2(2n)=o(n/sqrt(log n)) in R2"
+      "Dimension gap: F4(2n)=1 (verified) vs conjectured F2(2n)=o(n/sqrt(log n)) in R2",
+      "DRIFT BLOCKER (2026-04-27): docker build fails on the existing file with 5+ Lean 4.26 errors before reaching new content. Per memory project_mathlib_api_drift_2026_04, this matches the documented April 26-27 Mathlib/Lean drift wave; release claim and route to Mechanic.",
+      "Specific drift errors in current Erdos661Problem.lean: (1) Line 72 `· rintro rfl; exact distSq_self q` fails with `Unknown identifier q` — after rintro rfl the variable q is no longer in scope under current Lean 4.26 elaboration. (2) Lines 85, 89: orphan `/-- ... -/` doc comments before `/- ## ... -/` block headers raise `unexpected token /--; expected lemma` — Lean 4.26 stricter docstring parsing. Cascade then breaks lines 95-98.",
+      "Planned but not committed work: bipartiteDistSet4 + 4 Lenz F_4(2n)=1 cardinality theorems (lenz_bipartiteDistSet4_subset_singleton, _card_le_one, _eq_singleton, _card_eq_one) plus a noncomputable DecidableEq Point4 instance. Drafts saved in git stash WIP-DecidableEq-Point4 on this worktree; can be re-applied once Mechanic restores the existing file."
     ],
     "mathlibGaps": [],
     "nextSteps": [],
@@ -75,7 +82,7 @@
     "mathlib": []
   },
   "started": "2026-01-13T18:22:04.304Z",
-  "lastUpdate": "2026-03-13T07:52:17.050Z",
+  "lastUpdate": "2026-04-27T00:00:00.000Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [


### PR DESCRIPTION
## Summary

Research session for Erdős #661 (bipartite distinct distances). Attempted to add concrete `bipartiteDistSet4` cardinality theorems realizing $F_4(2n) = 1$ as a verified Finset cardinality identity, but the existing `proofs/Proofs/Erdos661Problem.lean` does not build under Lean 4.26.

## Drift findings

Docker build of the **unmodified** file fails with:

```
error: Proofs/Erdos661Problem.lean:72:34: Unknown identifier `q`
error: Proofs/Erdos661Problem.lean:85:28: unexpected token '/--'; expected 'lemma'
error: Proofs/Erdos661Problem.lean:89:59: unexpected token '/--'; expected 'lemma'
error: Proofs/Erdos661Problem.lean:95:53: unsolved goals (cascade)
error: Proofs/Erdos661Problem.lean:98:6: unexpected token '≤'; expected command
```

This matches the documented April 26–27 Mathlib / Lean 4.26 drift wave (sibling drift PRs: #13120, #13195, #13216, #13223).

Specific issues:

1. **Line 72** — `· rintro rfl; exact distSq_self q`: `q` is consumed by `rintro rfl` under current Lean 4.26 elaboration. Likely fix: `exact distSq_self p`.
2. **Lines 82–91** — four orphan `/-- ... -/` doc comments stand alone without an attached declaration (used as section dividers). Lean 4.26 stricter parsing rejects them. Convert to `/- ... -/` block comments (same fix as `Erdos353Problem.lean` PR #13223).
3. **Lines 95–98** — cascading parser-state failure from the orphan docstrings.

## Researcher draft (parked)

Designed and drafted (proofs check on first reading; not committed):

- `noncomputable instance : DecidableEq Point4 := inferInstanceAs (DecidableEq ((ℝ × ℝ) × (ℝ × ℝ)))` — required because `def Point4 := ...` is an opaque alias that does not transfer instances; without it `Θ.image lenzCircle1 : Finset Point4` cannot be elaborated.
- `bipartiteDistSet4 : Finset Point4 → Finset Point4 → Finset ℝ` (noncomputable).
- `lenz_bipartiteDistSet4_subset_singleton`: distance set ⊆ {2}.
- `lenz_bipartiteDistSet4_card_le_one`: cardinality ≤ 1.
- `lenz_bipartiteDistSet4_eq_singleton` (with non-emptiness): set = {2}.
- `lenz_bipartiteDistSet4_card_eq_one`: cardinality = 1 — concretely realizes $F_4(2n) \le 1$ for every $n \ge 1$.

Parked in a `WIP-DecidableEq-Point4` git stash on the `researcher-1` worktree; can be re-applied verbatim once Mechanic restores the file.

## Files changed in this PR

- `research/problems/erdos-661/knowledge.md` — Session 3 entry with full drift report
- `src/data/research/problems/erdos-661.json` — `currentState.blockers`, `nextAction`, and insights updated

No Lean files modified.

## Status

**Outcome**: blocked-by-drift (releasing claim, in-progress)
**Next steps**: Mechanic to apply the small fixes listed above, then a future researcher (or me) re-applies the parked Lenz cardinality draft.

## Test plan

- [x] Verified docker build of unmodified file reproduces the 5+ errors above
- [x] Knowledge JSON `currentState.blockers` reflects the three drift causes
- [x] No Lean source modified, so no build regression introduced

🤖 Generated by researcher-1