### PR TITLE
audit(szemeredi-gowers): port Lean fix from #13176 to main

### DIFF
--- a/proofs/Proofs/SzemerediHypergraphGowers.lean
+++ b/proofs/Proofs/SzemerediHypergraphGowers.lean
@@ -186,7 +186,7 @@ theorem IsGowersRegular.mono_delta {k : ℕ} (hk : 1 < k)
     (le_trans (mul_le_mul_of_nonneg_right hdd (by exact_mod_cast Nat.zero_le _)) hden)
 
 -- ═══════════════════════════════════════════════════════════════════
--- PART V: NAIVE IMPLIES GOWERS
+-- PART V: GLOBAL DENSITY AND COMPLETE COMPLEX
 -- ═══════════════════════════════════════════════════════════════════
 
 /-- The global edge density (fraction of all k-subsets that are edges) -/
@@ -222,23 +222,101 @@ theorem relativeKDensity_completeComplex {k : ℕ} (hk : 1 < k)
     -- Step 3: intersection with a superset is the set itself
     rw [Finset.inter_eq_left.mpr hsub]
 
-/-- Naive ε-regularity (with all-V parts) implies Gowers (ε, δ)-regularity
-    for any δ ∈ (0, 1] relative to the complete complex. -/
-theorem naive_implies_gowers {k : ℕ} (hk : 1 < k)
-    (H : UHypergraph V k) (ε δ : ℚ) (hε : 0 < ε) (hδ : 0 < δ) :
-    IsHypergraphRegular H ε (List.replicate k (Finset.univ (α := V))) →
-    IsGowersRegular hk H ε δ (completeComplex V (k - 1)) := by
-  intro hreg
+-- ═══════════════════════════════════════════════════════════════════
+-- PART VI: STRUCTURAL PROPERTIES OF GOWERS REGULARITY
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- Relative density depends only on the topCliques set: complexes with
+    identical topCliques give identical relative densities for every H. -/
+theorem relativeKDensity_eq_of_topCliques_eq {k : ℕ} (hk : 1 < k)
+    (H : UHypergraph V k) (C₁ C₂ : SimplicialComplex V (k - 1))
+    (h : topCliques (by omega : 0 < k - 1) C₁ =
+         topCliques (by omega : 0 < k - 1) C₂) :
+    relativeKDensity hk H C₁ = relativeKDensity hk H C₂ := by
+  unfold relativeKDensity
+  rw [h]
+
+/-- **Trivial Gowers regularity**: every k-graph H is (0, 1)-Gowers-regular
+    relative to any complex C.
+
+    With δ = 1, the constraint `|topCliques(C)| ≤ |topCliques(C')|` combined
+    with `topCliques_mono` (which gives `topCliques(C') ⊆ topCliques(C)`)
+    forces equality of topCliques as Finsets. Equal topCliques give equal
+    relative densities (via `relativeKDensity_eq_of_topCliques_eq`), hence
+    the difference is 0 ≤ 0. -/
+theorem isGowersRegular_self {k : ℕ} (hk : 1 < k)
+    (H : UHypergraph V k) (C : SimplicialComplex V (k - 1)) :
+    IsGowersRegular hk H 0 1 C := by
   intro C' hsub hden
-  -- HARD: The two density notions are not directly comparable.
-  -- naive regularity: density over V'₁ × ... × V'ₖ transversals (sub-vertex-sets)
-  -- Gowers regularity: density over topCliques(C') (sub-complex topological condition)
-  -- To bridge: given C' with dense topCliques, we would need sub-vertex-sets V'ᵢ such
-  -- that transversals of V' ≈ topCliques(C'). But sub-complex topCliques are NOT
-  -- generally expressible as transversals of vertex sub-parts.
-  -- A direct reduction from naive to Gowers requires the sub-complex to induce
-  -- a product structure on the clique sets, which does not hold for general C'.
-  -- Status: requires reformulation or additional structural hypothesis on C'.
-  sorry
+  -- δ = 1 + topCliques_mono force topCliques to be equal Finsets
+  have hsubD : topCliques (by omega : 0 < k - 1) C' ⊆
+               topCliques (by omega : 0 < k - 1) C :=
+    topCliques_mono _ hsub
+  have hcard1 : (topCliques (by omega : 0 < k - 1) C).card ≤
+                (topCliques (by omega : 0 < k - 1) C').card := by
+    have h1 := hden
+    rw [one_mul] at h1
+    exact_mod_cast h1
+  have hDeq : topCliques (by omega : 0 < k - 1) C' =
+              topCliques (by omega : 0 < k - 1) C :=
+    Finset.eq_of_subset_of_card_le hsubD hcard1
+  -- Equal topCliques imply equal relative densities
+  rw [relativeKDensity_eq_of_topCliques_eq hk H C' C hDeq, sub_self, abs_zero]
+  exact le_refl 0
+
+/-- **Empty hypergraph is Gowers-regular**: the empty k-graph has zero
+    relative density on every sub-complex, hence is (0, δ)-regular for
+    every ε ≥ 0 and every δ. -/
+theorem isGowersRegular_empty {k : ℕ} (hk : 1 < k)
+    (δ : ℚ) (C : SimplicialComplex V (k - 1)) :
+    IsGowersRegular hk (UHypergraph.empty V k) 0 δ C := by
+  intro C' _ _
+  rw [relativeKDensity_empty hk C', relativeKDensity_empty hk C, sub_self, abs_zero]
+  exact le_refl 0
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART VII: OBSTRUCTION TO NAIVE → GOWERS
+-- ═══════════════════════════════════════════════════════════════════
+
+/-
+  ## Why a direct `naive_implies_gowers` does not hold (as previously stated)
+
+  A previous session conjectured: with `parts = [univ × k]`,
+  `IsHypergraphRegular H ε parts → IsGowersRegular hk H ε δ (completeComplex …)`.
+
+  The hypothesis is degenerate. With `parts = [univ × k]` (k ≥ 2), the comparison
+  density `kPartiteDensity H parts = 0`, because `transversals parts` requires
+  every transversal `s` to satisfy `(s ∩ univ).card = 1`; but `s ∩ univ = s` and
+  `s.card = parts.length = k ≥ 2`, contradiction. Hence `transversals parts = ∅`.
+
+  So the hypothesis only constrains `|kPartiteDensity H parts' - 0| ≤ ε`, i.e.
+  bounds the density on every k-tuple of "large" subsets via the transversal
+  notion. But the transversal density only sees vertex-partitioned product
+  structure, while Gowers regularity quantifies over arbitrary sub-complexes
+  whose top-cliques need not arise from any vertex partition.
+
+  Concretely: a sub-complex `C' ⊆ completeComplex` may concentrate its top-cliques
+  on a small region of the k-set lattice that no transversal partition can hit.
+  Therefore `relativeKDensity H C'` can deviate from `globalDensity H` even when
+  the naive transversal-based hypothesis holds.
+
+  ## What CAN be proven (provable surrogates)
+
+  - `isGowersRegular_self`     — every H is (0, 1)-regular w.r.t. any C (above).
+  - `isGowersRegular_empty`    — the empty hypergraph is (0, δ)-regular (above).
+  - `IsGowersRegular.mono_eps` / `IsGowersRegular.mono_delta` — monotonicity
+    in the regularity parameters.
+
+  ## What would be needed to bridge naive → Gowers properly
+
+  Either (a) restrict to sub-complexes that arise from vertex partitions (so
+  topCliques become genuine transversals), or (b) replace the naive hypothesis
+  with a partition-respecting hypothesis (e.g., density of every sub-complex,
+  not every transversal). Both directions are research-level work.
+
+  Reference: Gowers (2007), §4 distinguishes "weak" (transversal-based) and
+  "strong" (relative-to-complex) regularity precisely because the former
+  does not imply the latter without additional structural input.
+-/
 
 end Szemeredi.Hypergraph


### PR DESCRIPTION
## Summary

Gallery integrity fix. The deploy branch (`main`) had inconsistent state:

- **meta.json** (via PR #13212): `status=verified`, `sorries=0`, `lineCount=322`, `badge=infrastructure`
- **Lean file**: still the old 244-line version with `naive_implies_gowers : ... := sorry` on line 242

PR #13212 assumed PR #13176 had landed on `main`, but #13176 was merged to `master` only. This PR ports the Lean file from `origin/master` so the file matches the meta.json claims.

## What changed

The Lean file `SzemerediHypergraphGowers.lean` is replaced with the version from `origin/master`:

- `naive_implies_gowers` theorem removed (it was unprovable as stated)
- Replaced by 3 provable surrogates: `relativeKDensity_eq_of_topCliques_eq`, `isGowersRegular_self`, `isGowersRegular_empty`
- Part VII docblock documents why a direct naive→Gowers reduction does not hold
- 244 → 322 lines, 1 → 0 sorries, 0 axioms

## Verification

After this PR, both the Lean file and meta.json agree:

- 0 sorries ✅
- 0 axioms ✅
- 322 lines ✅
- `status=verified`, `badge=infrastructure` is now accurate (Tier D toolkit)

## Test plan

- [ ] CI builds pass
- [ ] `grep -c "sorry$" proofs/Proofs/SzemerediHypergraphGowers.lean` returns 0
- [ ] `wc -l proofs/Proofs/SzemerediHypergraphGowers.lean` returns 322

---
Discovered during gallery integrity audit (auditor agent, 2026-04-27).

🤖 Generated with [Claude Code](https://claude.com/claude-code)