### PR TITLE
Research: erdos-513 — replace axiom maxModulus with concrete def (6 → 4 axioms)

### DIFF
--- a/proofs/Proofs/Erdos513Problem.lean
+++ b/proofs/Proofs/Erdos513Problem.lean
@@ -37,13 +37,21 @@ theorem maxTerm_nonneg (a : ℕ → ℂ) (r : ℝ) (hr : 0 ≤ r) :
     0 ≤ maxTerm a r :=
   le_max_left 0 _
 
-/-- The maximum modulus M(r, f) = sup_{|z|=r} |f(z)| for the entire
-    function defined by `a`. Axiomatized. -/
-axiom maxModulus (a : ℕ → ℂ) (r : ℝ) : ℝ
+/-- The entire function defined by a power series with coefficients `a`.
+    For coefficients defining a non-summable series at `z`, `tsum` returns 0. -/
+noncomputable def powerSeriesFun (a : ℕ → ℂ) (z : ℂ) : ℂ := ∑' n, a n * z ^ n
 
-/-- maxModulus is nonneg for r ≥ 0. -/
-axiom maxModulus_nonneg (a : ℕ → ℂ) (r : ℝ) (hr : 0 ≤ r) :
-  0 ≤ maxModulus a r
+/-- The maximum modulus M(r, f) = sup_{|z|=r} |f(z)| for the entire
+    function defined by `a`. Wraps with `max 0` to guarantee nonnegativity
+    (the iSup over the sphere is already nonneg, but this avoids needing
+    boundedness assumptions on `a`). -/
+noncomputable def maxModulus (a : ℕ → ℂ) (r : ℝ) : ℝ :=
+  max 0 (⨆ z ∈ Metric.sphere (0 : ℂ) r, ‖powerSeriesFun a z‖)
+
+/-- maxModulus is nonneg for r ≥ 0 (in fact for all r, by definition). -/
+theorem maxModulus_nonneg (a : ℕ → ℂ) (r : ℝ) (hr : 0 ≤ r) :
+    0 ≤ maxModulus a r :=
+  le_max_left 0 _
 
 /-- The ratio μ(r)/M(r). Returns 0 if M(r) = 0. -/
 noncomputable def termModulusRatio (a : ℕ → ℂ) (r : ℝ) : ℝ :=

--- a/research/problems/erdos-513/knowledge.md
+++ b/research/problems/erdos-513/knowledge.md
@@ -64,7 +64,39 @@ Back to the problem
 
 ## Sessions
 
-(No research sessions yet)
+### 2026-04-27 (researcher-7) - Replace `axiom maxModulus` with concrete `iSup` definition
+
+**Mode**: REVISIT (prior session marked maxModulus concretization "too complex")
+**Outcome**: PROGRESS — eliminated 2 axioms from `Erdos513Problem.lean` (6 → 4)
+
+**What I Did**
+
+1. Audited file: 6 axioms total (`maxModulus`, `maxModulus_nonneg`, `maxTerm_le_maxModulus`, `kovari_lower_bound`, `clunie_hayman_upper_bound`, `erdos_513_exact_value`)
+2. Replaced `axiom maxModulus a r : ℝ` with a concrete `noncomputable def` using `iSup` over `Metric.sphere (0 : ℂ) r` of `‖powerSeriesFun a z‖`, where `powerSeriesFun a z := ∑' n, a n * z^n`.
+3. Replaced `axiom maxModulus_nonneg` with a one-line theorem (`le_max_left 0 _`) since the definition wraps with `max 0 (...)`.
+4. Verified via Docker build (23s, exit 0) — only minor unused-variable warnings remain.
+
+**Key Insight: `tsum` returns 0 for non-summable cases**
+
+Lean's `tsum` (`∑' n, ...`) is defined to return 0 when the family is not summable. This means `powerSeriesFun a z` is always well-defined, even for sequences `a` that don't define an entire function. The `max 0 (...)` wrapper in the iSup also handles unbounded suprema (which return their default in `ℝ`), so `maxModulus_nonneg` follows trivially.
+
+For transcendental entire functions (the only case the downstream axioms apply to), the series is summable, so the definition agrees with the classical max modulus.
+
+**Remaining Axioms (4)**
+
+1. `maxTerm_le_maxModulus` — μ(r) ≤ M(r). Classical Cauchy estimate result; provable but requires Cauchy's integral formula (substantial Mathlib API).
+2. `kovari_lower_bound` — research-level (Kövári unpublished); not provable here.
+3. `clunie_hayman_upper_bound` — research-level (Clunie–Hayman 1964); not provable here.
+4. `erdos_513_exact_value` — the OPEN conjecture itself.
+
+**Files Modified**
+
+- `proofs/Proofs/Erdos513Problem.lean` (lines 41-56; +12 lines, -8 lines)
+
+**Next Steps**
+
+1. Update `axiomCount` in meta.json (if it exists for this entry; `src/data/research/problems/erdos-513.json` has `axiomCount: 6` to update to 4)
+2. Consider tackling `maxTerm_le_maxModulus` — would require Cauchy estimate; large effort but axiom-eliminating
 
 ---
 

--- a/src/data/research/problems/erdos-513.json
+++ b/src/data/research/problems/erdos-513.json
@@ -29,17 +29,22 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: Assessed and marked complete.",
+    "progressSummary": "PROGRESS (researcher-7, 2026-04-27): Erdos513Problem.lean axiomCount 6 → 4. Replaced axiom maxModulus with concrete def (iSup over Metric.sphere of powerSeriesFun via tsum); axiom maxModulus_nonneg now provable from le_max_left.",
     "builtItems": [
       "Concretized maxTerm definition (Erdos513Problem.lean:31-33)",
       "Proved maxTerm_nonneg from concrete def (Erdos513Problem.lean:36-37)",
-      "Fixed half_lt_two_div_pi using nlinarith cross-multiplication (Erdos513Problem.lean:116-123)"
+      "Fixed half_lt_two_div_pi using nlinarith cross-multiplication (Erdos513Problem.lean:116-123)",
+      "powerSeriesFun: noncomputable def for entire function ∑' n, a n * z^n (Erdos513Problem.lean:31-32)",
+      "maxModulus: replaced axiom with noncomputable def via iSup over Metric.sphere (Erdos513Problem.lean:35-40)",
+      "maxModulus_nonneg: replaced axiom with theorem (le_max_left 0 _) (Erdos513Problem.lean:43-44)"
     ],
     "insights": [
       "maxTerm can be concretized as max 0 (iSup n, ‖a n‖ * r^n) - eliminates definition axiom + nonneg axiom",
       "half_lt_two_div_pi proof needed cross-multiplication via field_simp + nlinarith (div_lt_div_iff was renamed)",
       "Real.pi_lt_four is the correct Mathlib constant for π < 4 (not pi_lt_315 or pi_lt_3141593)",
-      "maxModulus concretization requires tsum over circles - too complex for this session"
+      "maxModulus concretization requires tsum over circles - too complex for this session",
+      "Lean's tsum returns 0 for non-summable families — safe to use ∑' n, a n * z^n unconditionally as definition of entire function (returns 0 outside disk of convergence for non-entire a)",
+      "max 0 (iSup ...) handles unbounded iSup (which returns 0 default in ℝ) — gives free maxModulus_nonneg without needing summability hypothesis"
     ],
     "mathlibGaps": [],
     "nextSteps": [],
@@ -59,17 +64,17 @@
     "mathlib": []
   },
   "started": "2026-01-13T04:39:49.622Z",
-  "lastUpdate": "2026-03-13T07:52:17.049Z",
+  "lastUpdate": "2026-04-27T16:30:00-07:00",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/Erdos513Problem.lean",
       "filename": "Erdos513Problem.lean",
-      "lineCount": 160,
-      "theoremCount": 10,
-      "axiomCount": 6,
-      "defCount": 3,
+      "lineCount": 167,
+      "theoremCount": 11,
+      "axiomCount": 4,
+      "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos513Problem.lean"


### PR DESCRIPTION
## Summary

Research session for `erdos-513` (Erdős #513: maximum-term-to-max-modulus ratio for transcendental entire functions; OPEN). Reduced axiom count from **6 → 4**.

## Progress

- Added `noncomputable def powerSeriesFun (a : ℕ → ℂ) (z : ℂ) : ℂ := ∑' n, a n * z^n` — the entire function defined by coefficient sequence `a`.
- Replaced `axiom maxModulus a r : ℝ` with concrete `noncomputable def`:
  ```lean
  noncomputable def maxModulus (a : ℕ → ℂ) (r : ℝ) : ℝ :=
    max 0 (⨆ z ∈ Metric.sphere (0 : ℂ) r, ‖powerSeriesFun a z‖)
  ```
- Replaced `axiom maxModulus_nonneg` with one-line theorem (`le_max_left 0 _`).

## Findings

- **`tsum` semantics make this clean**: Lean's `tsum` returns 0 for non-summable families, so `powerSeriesFun` is well-defined for arbitrary `a`. The downstream axioms (Kövári, Clunie–Hayman) only apply to transcendental entire functions where the series is summable, so the new definition agrees with the classical max modulus on the relevant domain.
- **`max 0 (...)` wrapper handles unbounded iSup**: `iSup` in `ℝ` returns 0 when not bounded above, so the wrapper guarantees nonnegativity without needing boundedness hypotheses.
- **Prior session note ("too complex") was overcautious**: The earlier session marked maxModulus concretization as "too complex for this session". With `tsum` + `max 0`, it's a 6-line definition.

## Remaining Axioms (4)

| Axiom | Type | Tractable? |
|-------|------|------------|
| `maxTerm_le_maxModulus` | Classical (Cauchy estimate) | Provable but requires Cauchy integral formula API |
| `kovari_lower_bound` | Research-level (Kövári unpublished) | Not provable |
| `clunie_hayman_upper_bound` | Research-level (Clunie–Hayman 1964) | Not provable |
| `erdos_513_exact_value` | The OPEN conjecture | Not provable |

## Verification

- Docker build: `./proofs/scripts/docker-build.sh Proofs.Erdos513Problem` — **succeeded** (23s, exit 0). Two unused-variable lints for `hr` parameter (the new `maxModulus_nonneg` doesn't need it; pre-existing on `maxTerm_nonneg`).

## Status

**Outcome**: progress (axiom elimination)
**Next Steps**: Tackling `maxTerm_le_maxModulus` would require Cauchy's integral formula via Mathlib's complex analysis — a substantial but valuable next step.

🤖 Generated by researcher-7