### PR TITLE
fix(meta): correct sorry count and status for szemeredi-hypergraph-core-oq-01-incomplete-01

### DIFF
--- a/src/data/proofs/szemeredi-hypergraph-core-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/szemeredi-hypergraph-core-oq-01-incomplete-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://arxiv.org/abs/math/0610762",
     "date": "2026",
-    "status": "verified",
+    "status": "formalized",
     "tags": [
       "combinatorics",
       "szemeredi",
@@ -19,7 +19,7 @@
     ],
     "proofRepoPath": "Proofs/SzemerediHypergraphGowers.lean",
     "badge": "infrastructure",
-    "sorries": 0,
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "Finset.inter_eq_left",
@@ -44,7 +44,7 @@
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
     "lineCount": 322,
-    "assumptions": "Infrastructure file: 0 sorries, 0 axioms. Provides definitions (SimplicialComplex, completeComplex, topCliques, relativeKDensity, IsGowersRegular, globalDensity) and 14 supporting lemmas. The previously-conjectured naive_implies_gowers theorem was found to be false as stated; the obstruction is documented in-file (Part VII).",
+    "assumptions": "Infrastructure file: 1 sorry (naive_implies_gowers: bridging naive and Gowers regularity requires reformulation), 0 axioms. Provides definitions (SimplicialComplex, completeComplex, topCliques, relativeKDensity, IsGowersRegular, globalDensity) and supporting lemmas. The naive_implies_gowers theorem requires additional structural hypothesis on C'; the obstruction is documented in-file (Part VII).",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -109,7 +109,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Gowers hypergraph regularity infrastructure: 1 structure (SimplicialComplex), 6 definitions (completeComplex, IsSubComplex, topCliques, relativeKDensity, IsGowersRegular, globalDensity), and 14 proved theorems. 0 sorries, 0 axioms. The key consistency result relativeKDensity_completeComplex shows relative density w.r.t. the complete complex equals global density. A previously-conjectured naive_implies_gowers theorem was found to be false as stated and is replaced by three provable surrogates (relativeKDensity_eq_of_topCliques_eq, isGowersRegular_self, isGowersRegular_empty); the obstruction is documented in Part VII of the file.",
+    "summary": "Gowers hypergraph regularity infrastructure: 1 structure (SimplicialComplex), 6 definitions (completeComplex, IsSubComplex, topCliques, relativeKDensity, IsGowersRegular, globalDensity), and supporting proved theorems. 1 sorry (naive_implies_gowers, pending reformulation with structural hypothesis on C'), 0 axioms. The key consistency result relativeKDensity_completeComplex shows relative density w.r.t. the complete complex equals global density. The naive_implies_gowers theorem requires either partition-induced sub-complexes or a partition-respecting hypothesis; the obstruction is documented in Part VII of the file.",
     "implications": "**Theoretical**: This infrastructure is the foundation for formalizing the hypergraph counting lemma (Nagle-Rödl-Schacht 2006) and the multidimensional Szemerédi theorem (Gowers 2007). The stratified SimplicialComplex design makes dimension-level conditions explicit, which is essential for the inductive structure of the counting lemma proof.\n\n**For the gallery**: The Gowers regularity infrastructure completes the theoretical framework started in SzemerediHypergraphCore.lean (naive regularity) and SzemerediHypergraphCoreOQ01.lean (flat simplicial complex). Together, these files provide a comprehensive formalization of hypergraph regularity foundations.",
     "openQuestions": [
       "Can a partition-respecting variant of naive regularity be defined that genuinely implies Gowers regularity?",
@@ -141,7 +141,7 @@
     "theoremCount": 14,
     "definitionCount": 6,
     "path": "Proofs/SzemerediHypergraphGowers.lean",
-    "sorries": 0
+    "sorries": 1
   },
   "references": [
     {
@@ -166,5 +166,5 @@
       "note": "First regularity lemma for k-uniform hypergraphs"
     }
   ],
-  "sorries": 0
+  "sorries": 1
 }


### PR DESCRIPTION
## Fix

Corrects stale metadata in `szemeredi-hypergraph-core-oq-01-incomplete-01/meta.json`.

## Evidence

**Before**:
- `status: "verified"`, `sorries: 0` (all three fields)
- `assumptions`: claimed "0 sorries, 0 axioms"
- `conclusion.summary`: claimed "0 sorries, 0 axioms"

**After**:
- `status: "formalized"`, `sorries: 1` (all three fields)
- Updated `assumptions` and `conclusion.summary` to reflect the 1 remaining sorry

**Root cause**: `SzemerediHypergraphGowers.lean` contains 1 sorry at line 242 in `naive_implies_gowers` — bridging naive regularity (sub-vertex-parts) to Gowers regularity (sub-complexes) requires a structural hypothesis not present in the current theorem statement. The comment documents the obstruction in Part VII of the file.

**Verification**: `grep -c "sorry"` (excluding comments) in `SzemerediHypergraphGowers.lean` = 1.

---
Automated fix by lean-mechanic agent.