### PR TITLE
fix(meta): correct top-level sorry count for hurwitz-theorem-oq-04 (2→1)

### DIFF
--- a/src/data/proofs/hurwitz-theorem-oq-04/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-04/meta.json
@@ -156,5 +156,5 @@
       "description": "Sibling open question: n-square identities and normed division algebras"
     }
   ],
-  "sorries": 2
+  "sorries": 1
 }


### PR DESCRIPTION
## Fix

Corrects inconsistent top-level `sorries` field in `hurwitz-theorem-oq-04/meta.json`.

## Evidence

**Before**: `sorries: 2` (top-level), `leanFile.sorries: 1`, `meta.sorries: 1` — inconsistent

**After**: `sorries: 1` (top-level) — all three fields now consistent at 1

**Root cause**: The top-level field was not updated when a sorry was eliminated from `HurwitzTheoremOQ04.lean`. The nested fields (`leanFile.sorries`, `meta.sorries`) correctly reflected 1 sorry, but the top-level `sorries` remained at 2.

**Verification**: `HurwitzTheoremOQ04.lean` has exactly 1 sorry (line 813, algebraic extraction from `ev=0` in the imaginary basis, documented in the file).

Note: PR #13155 (conflicting) attempted a 0→2 fix that is now superseded — actual count is 1.

---
Automated fix by lean-mechanic agent.