### PR TITLE
Research: erdos-931 — Mathlib drift + latent proof bug blocker

### DIFF
--- a/research/problems/erdos-931/knowledge.md
+++ b/research/problems/erdos-931/knowledge.md
@@ -66,7 +66,86 @@ Back to the problem
 
 ## Sessions
 
-(No research sessions yet)
+### Session (2026-04-27, researcher-1) — DRIFT + LATENT BUG BLOCKER
+
+**Outcome**: BLOCKED — Mathlib API drift (line 269) plus a latent proof
+bug (lines 485–487) keep `Erdos931Problem.lean` from building under
+Lean 4.26 / current Mathlib.
+
+Docker build of the unmodified file fails with:
+
+```
+error: Proofs/Erdos931Problem.lean:269:63: Invalid field `mp`:
+  The environment does not contain `Function.mp`
+error: Proofs/Erdos931Problem.lean:269:9: Tactic `rcases` failed:
+  `x✝ : ?m.47` is not an inductive datatype
+error: Proofs/Erdos931Problem.lean:486:41: omega could not prove the goal
+error: Proofs/Erdos931Problem.lean:487:60: Application type mismatch:
+  `hp` has type `Nat.Prime p`
+  but is expected to have type `Nat.Prime (n₁ + p)`
+```
+
+#### Issue 1 — Mathlib API drift on `Prime.dvd_finset_prod_iff`
+
+Line 269 in `exists_prime_between_of_large_prime_factor`:
+
+```lean
+obtain ⟨j, hj_mem, hq_dvd_j⟩ := hq.prime.dvd_finset_prod_iff.mp hq_dvd
+```
+
+In the current Mathlib, `Prime.dvd_finset_prod_iff` takes the product
+function `f` as an explicit argument before producing the iff. The
+existing call leaves `f` implicit and then tries `.mp` on what is now
+a function, hence the `Function.mp` error.
+
+Likely fix: `(hq.prime.dvd_finset_prod_iff _).mp hq_dvd` (or pass the
+explicit `fun i => n₂ + i`). Same drift family as the April 26–27 wave
+documented in `project_mathlib_api_drift_2026_04`.
+
+#### Issue 2 — Latent proof bug at lines 485–487
+
+`hard_case_no_prime_in_first_block` takes a prime `p ∈ (n₁, n₁+k₁]`
+and calls
+
+```lean
+have hp_in : p ∈ Finset.Icc 1 k₁ := by
+  rw [Finset.mem_Icc]; constructor <;> omega
+exact hard_case_first_block_composite n₁ k₁ h₅ h₇ p hp_in hp
+```
+
+This passes the *prime* `p` as the Finset.Icc *index* — but `p` can be
+much larger than `k₁` (e.g. `p = n₁ + k₁` when `n₁ ≥ 1`). The omega
+cannot establish `p ≤ k₁`, and the application type-checks the prime
+hypothesis `hp : p.Prime` against the target's expected
+`(n₁ + p).Prime` from `hard_case_first_block_composite`.
+
+The intended index is `i := p - n₁ ∈ [1, k₁]`. Quick fix sketch:
+
+```lean
+set i := p - n₁
+have hi_eq : p = n₁ + i := by omega
+have hi_mem : i ∈ Finset.Icc 1 k₁ := by
+  rw [Finset.mem_Icc]; refine ⟨?_, ?_⟩ <;> omega
+have hi_prime : (n₁ + i).Prime := hi_eq ▸ hp
+exact hard_case_first_block_composite n₁ k₁ h₅ h₇ i hi_mem hi_prime
+```
+
+This bug is latent: `Erdos931Problem.lean` was last touched in PR
+#10735 (commit `783f005c6d9`, generic research dispatcher) and has
+not been re-built against the current Mathlib until this session, so
+the fault was not caught earlier.
+
+#### Status of native_decide proofs
+
+The four `native_decide` proofs in this file
+(`consecutiveProduct_*`, `*_same_factors`, `tijdeman_same_factors`,
+`hard_case_vacuous_k3_n30`) should be unaffected by the drift, but
+cannot be verified until issues 1 and 2 are repaired.
+
+#### Routing
+
+Mechanic territory. Researcher releases the claim with status
+`in-progress` per `project_mathlib_api_drift_2026_04`.
 
 ---
 

--- a/src/data/research/problems/erdos-931.json
+++ b/src/data/research/problems/erdos-931.json
@@ -16,14 +16,16 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "OBSERVE",
     "since": "2026-03-30T21:44:17.000Z",
     "iteration": 3,
-    "focus": "0 axioms, 2 sorries (both deep Størmer-style number theory). File now Aristotle-eligible.",
+    "focus": "Mathlib drift + latent proof bug — release for Mechanic",
     "blockers": [
-      "Størmer's theorem not in Mathlib — needed to fully eliminate exists_prime_between_blocks axiom"
+      "Størmer's theorem not in Mathlib — needed to fully eliminate exists_prime_between_blocks axiom",
+      "Mathlib API drift: Prime.dvd_finset_prod_iff at line 269",
+      "Latent proof bug: hard_case_no_prime_in_first_block at lines 485-487"
     ],
-    "nextAction": "Try to prove exists_prime_between_blocks_hard for k₁=k₂=3 via contradiction",
+    "nextAction": "Mechanic: (1) update line 269 to provide the prod function explicitly to Prime.dvd_finset_prod_iff; (2) fix lines 485-487 to use i = p - n₁ as the Finset.Icc index. Then re-verify all 4 native_decide proofs build cleanly.",
     "attemptCounts": {
       "total": 2,
       "currentApproach": 1,
@@ -59,7 +61,11 @@
       "The hard case forces BOTH blocks to be n₁-smooth, making it likely vacuously true by Størmer — the SamePrimeFactors hypothesis cannot be satisfied when blocks are far apart and smooth",
       "In hard case, first block is entirely composite (no prime), so next prime > n₁+k₁",
       "Hard case hypotheses (h₅, h₆, h₇, SamePrimeFactors) are computationally verified to be mutually inconsistent for n₁ ≤ 30 with k₁=k₂=3",
-      "The SamePrimeFactors constraint is extremely restrictive: second block must use EXACTLY the same primes as first block, which is impossible when blocks are in different ranges"
+      "The SamePrimeFactors constraint is extremely restrictive: second block must use EXACTLY the same primes as first block, which is impossible when blocks are in different ranges",
+      "DRIFT BLOCKER (2026-04-27, researcher-1): docker build of unmodified Erdos931Problem.lean fails with 4 errors. Two distinct issues: (a) Mathlib API drift on Prime.dvd_finset_prod_iff at line 269 — hq.prime.dvd_finset_prod_iff.mp hq_dvd no longer type-checks; the iff now takes the prod function f as an explicit argument, e.g. (hq.prime.dvd_finset_prod_iff _).mp hq_dvd. (b) Pre-existing proof bug at lines 485-487 in hard_case_no_prime_in_first_block: p (a prime in (n₁, n₁+k₁]) is passed as the Finset.Icc index to hard_case_first_block_composite, but the index should be i = p - n₁ ∈ [1, k₁] and the prime hypothesis should be (n₁ + i).Prime reconstructed from p = n₁ + (p - n₁).",
+      "Quick fix sketch for line 485-487: introduce i := p - n₁, prove i ∈ Finset.Icc 1 k₁ from n₁ < p ∧ p ≤ n₁ + k₁, rewrite hp : p.Prime to (n₁ + i).Prime, then call hard_case_first_block_composite n₁ k₁ h₅ h₇ i hi_mem hi_prime.",
+      "Build infrastructure: native_decide proofs (hard_case_vacuous_k3_n30, samePrimeFactors counterexamples) likely unaffected by the drift but cannot be re-verified until lines 269 and 485 are fixed.",
+      "Last touch: only commit was 783f005c6d9 from PR #10735 (research dispatch). The bug at 485 may have been latent and never caught because the file had not been built on the current Mathlib until now."
     ],
     "mathlibGaps": [
       "Størmer's theorem on consecutive smooth numbers — would fully resolve exists_prime_between_blocks"
@@ -81,7 +87,7 @@
     "mathlib": []
   },
   "started": "2026-01-15T11:43:50.650Z",
-  "lastUpdate": "2026-04-27T00:00:00Z",
+  "lastUpdate": "2026-04-27T00:00:00.000Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [


### PR DESCRIPTION
## Summary

Research session for Erdős #931 (same prime factors in products of consecutive integers). Docker build of the unmodified `proofs/Proofs/Erdos931Problem.lean` fails with **two distinct issues** that together block any further proof work on the file.

## Build errors

```
error: Proofs/Erdos931Problem.lean:269:63: Invalid field `mp`:
  The environment does not contain `Function.mp`
error: Proofs/Erdos931Problem.lean:269:9: Tactic `rcases` failed:
  `x✝ : ?m.47` is not an inductive datatype
error: Proofs/Erdos931Problem.lean:486:41: omega could not prove the goal
error: Proofs/Erdos931Problem.lean:487:60: Application type mismatch:
  `hp` has type `Nat.Prime p`
  but is expected to have type `Nat.Prime (n₁ + p)`
```

## Issue 1 — Mathlib API drift (line 269)

In `exists_prime_between_of_large_prime_factor`:

```lean
obtain ⟨j, hj_mem, hq_dvd_j⟩ := hq.prime.dvd_finset_prod_iff.mp hq_dvd
```

In current Mathlib, `Prime.dvd_finset_prod_iff` takes the product function `f` as an *explicit* argument before yielding the iff. The existing call leaves `f` implicit and then tries `.mp` on a function value, hence `Function.mp` is being looked up.

**Likely fix:** `(hq.prime.dvd_finset_prod_iff _).mp hq_dvd` (or pass `(fun i => n₂ + i)` explicitly).

This matches the April 26–27 drift wave documented in `project_mathlib_api_drift_2026_04` (sibling drift PRs: #13120, #13195, #13216, #13223, #13225).

## Issue 2 — Latent proof bug (lines 485–487)

`hard_case_no_prime_in_first_block` takes a prime `p ∈ (n₁, n₁+k₁]` and tries to apply `hard_case_first_block_composite`:

```lean
have hp_in : p ∈ Finset.Icc 1 k₁ := by
  rw [Finset.mem_Icc]; constructor <;> omega
exact hard_case_first_block_composite n₁ k₁ h₅ h₇ p hp_in hp
```

This is wrong on two counts:
- `p` (the *prime*) is being used as the Finset.Icc *index*, but for typical inputs `p ≥ n₁ + 1 > k₁`, so `p ≤ k₁` cannot hold and `omega` rightly fails.
- `hard_case_first_block_composite` returns `¬ (n₁ + i).Prime`, so the application after partial argument list expects `Nat.Prime (n₁ + p)`, not the local `hp : p.Prime`.

The intended index is `i := p - n₁ ∈ [1, k₁]`. Suggested fix:

```lean
set i := p - n₁
have hi_eq : p = n₁ + i := by omega
have hi_mem : i ∈ Finset.Icc 1 k₁ := by
  rw [Finset.mem_Icc]; refine ⟨?_, ?_⟩ <;> omega
have hi_prime : (n₁ + i).Prime := hi_eq ▸ hp
exact hard_case_first_block_composite n₁ k₁ h₅ h₇ i hi_mem hi_prime
```

This bug is **latent**: `Erdos931Problem.lean` was last touched in PR #10735 (commit `783f005c6d9`, generic research dispatcher) and has not been re-built against current Mathlib until this session.

## Files changed in this PR

- `research/problems/erdos-931/knowledge.md` — full session report with reproduction and fix sketches
- `src/data/research/problems/erdos-931.json` — `currentState.blockers`, `nextAction`, and insights updated

No Lean files modified.

## Status

**Outcome**: blocked-by-drift + latent-bug (releasing claim, in-progress)
**Next steps**: Mechanic to apply the two fixes above, then re-verify the four `native_decide` proofs (`hard_case_vacuous_k3_n30` and the counterexample lemmas) build cleanly.

## Test plan

- [x] Verified docker build of unmodified file reproduces all four errors
- [x] Knowledge JSON `currentState.blockers` lists both root causes
- [x] No Lean source modified, so no build regression introduced

🤖 Generated by researcher-1