### PR TITLE
fix(erdos-533): sync leanFile.axiomCount and lineCount after axiom→def conversion

### DIFF
--- a/src/data/proofs/erdos-533/meta.json
+++ b/src/data/proofs/erdos-533/meta.json
@@ -21,8 +21,8 @@
     "erdosUrl": "https://erdosproblems.com/533",
     "erdosProblemStatus": "open",
     "axiomCount": 3,
-    "lineCount": 372,
-    "assumptions": "4 axioms: ehsss_result (EHSSS partial result for delta>1/16), k4_free_triangle_free_subset (K4-free case for all delta>0), turan_k5_free (Turán bound: K5-free has ≤ 3n²/8 edges), erdos_533_conjecture (OPEN). Neighborhood structure and K4-free neighborhood lemma proved. erdos_533_conjecture converted from axiom to def (open conjecture should not be axiom-asserted).",
+    "lineCount": 371,
+    "assumptions": "3 axioms: ehsss_result (EHSSS partial result for delta>1/16), k4_free_triangle_free_subset (K4-free case for all delta>0), turan_k5_free (Turán bound: K5-free has ≤ 3n²/8 edges). erdos_533_conjecture converted from axiom to def (open conjecture should not be axiom-asserted). Neighborhood structure and K4-free neighborhood lemma proved.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -143,8 +143,8 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 366,
-    "axiomCount": 4,
+    "lineCount": 371,
+    "axiomCount": 3,
     "theoremCount": 27,
     "definitionCount": 5,
     "path": "Proofs/Erdos533Problem.lean",


### PR DESCRIPTION
## Fix

Syncs `leanFile.axiomCount` and `leanFile.lineCount` in `erdos-533/meta.json` after a previous commit (c53be39) converted `erdos_533_conjecture` from `axiom` to `def` but only partially updated the metadata.

## Evidence

**Before**:
- `leanFile.axiomCount: 4` (stale — axiom→def reduced count to 3)
- `leanFile.lineCount: 366` (stale — file grew to 371 lines)
- `meta.lineCount: 372` (off by 1)
- `meta.assumptions`: started with "4 axioms: ..." listing erdos_533_conjecture

**After**:
- `leanFile.axiomCount: 3` (matches actual 3 axiom declarations in file)
- `leanFile.lineCount: 371` (matches `wc -l`)
- `meta.lineCount: 371`
- `meta.assumptions`: "3 axioms: ..." with erdos_533_conjecture removed from axiom list

The `meta.axiomCount` field was already correctly updated to 3 by c53be39; this PR fixes the fields that were missed.

---
Automated fix by lean-mechanic agent.