### PR TITLE
fix(meta): correct sorries/status for hurwitz-oq-04 and szemeredi-gowers

### DIFF
--- a/src/data/proofs/hurwitz-theorem-oq-04/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-04/meta.json
@@ -156,5 +156,5 @@
       "description": "Sibling open question: n-square identities and normed division algebras"
     }
   ],
-  "sorries": 2
+  "sorries": 1
 }

--- a/src/data/proofs/szemeredi-hypergraph-core-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/szemeredi-hypergraph-core-oq-01-incomplete-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://arxiv.org/abs/math/0610762",
     "date": "2026",
-    "status": "verified",
+    "status": "formalized",
     "tags": [
       "combinatorics",
       "szemeredi",
@@ -19,7 +19,7 @@
     ],
     "proofRepoPath": "Proofs/SzemerediHypergraphGowers.lean",
     "badge": "infrastructure",
-    "sorries": 0,
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "Finset.inter_eq_left",
@@ -141,7 +141,7 @@
     "theoremCount": 14,
     "definitionCount": 6,
     "path": "Proofs/SzemerediHypergraphGowers.lean",
-    "sorries": 0
+    "sorries": 1
   },
   "references": [
     {
@@ -166,5 +166,5 @@
       "note": "First regularity lemma for k-uniform hypergraphs"
     }
   ],
-  "sorries": 0
+  "sorries": 1
 }


### PR DESCRIPTION
## Fix

Proactive sorry-count audit found 2 gallery metadata mismatches.

## Evidence

**hurwitz-theorem-oq-04**
- **Before**: `"sorries": 2` (top-level field)
- **After**: `"sorries": 1`
- `meta.sorries` and `leanFile.sorries` were already correct at 1; top-level was stale

**szemeredi-hypergraph-core-oq-01-incomplete-01**
- **Before**: `sorries: 0` (all three fields), `status: "verified"`
- **After**: `sorries: 1` (all three fields), `status: "formalized"`
- `SzemerediHypergraphGowers.lean` line 242: real sorry in `naive_implies_gowers` theorem
- Status `"verified"` requires 0 sorries per gallery policy

---
Automated fix by lean-mechanic agent.