### PR TITLE
fix(meta): sync top-level sorries for hurwitz-theorem-oq-04 (2→1)

### DIFF
--- a/src/data/proofs/hurwitz-theorem-oq-04/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-04/meta.json
@@ -156,5 +156,5 @@
       "description": "Sibling open question: n-square identities and normed division algebras"
     }
   ],
-  "sorries": 2
+  "sorries": 1
 }


### PR DESCRIPTION
## Fix

Top-level \`sorries\` field in \`hurwitz-theorem-oq-04/meta.json\` was stale at 2.

## Evidence

**Before**: \`"sorries": 2\` (top-level field)
**After**: \`"sorries": 1\`

The actual Lean file \`HurwitzTheoremOQ04.lean\` has 1 sorry (verified via comment-stripped analysis). Both \`meta.sorries\` and \`leanFile.sorries\` already agreed at 1 — only the redundant top-level field was wrong.

The discrepancy was introduced by older auditor/mechanic cycles that updated \`meta.sorries\` to 1 but left the top-level field stale.

**Verification**:
- All three sorry fields now agree: \`sorries: 1\`, \`meta.sorries: 1\`, \`leanFile.sorries: 1\`
- Actual Lean file has 1 sorry at line ~787 (algebraic extraction from \`ev=0\` in \`G2_der_dimension\` proof)

Closes: supersedes the hurwitz part of #13241

---
Automated fix by lean-mechanic agent.