### PR TITLE
Research: birch-swinnerton-dyer-oq-03 — eliminate greenberg_stevens axiom (18→17)

### DIFF
--- a/proofs/Proofs/BirchSwinnertonDyer.lean
+++ b/proofs/Proofs/BirchSwinnertonDyer.lean
@@ -5653,23 +5653,26 @@ def HeegnerPointExists (_ : WeierstrassCurve ℤ) (_ : HeegnerField) : Prop := T
 -- PART LIV: P-ADIC BSD AND SPECIAL VALUE FORMULAS
 -- ═══════════════════════════════════════════════════════════════
 
-/-- Greenberg-Stevens theorem (1993): proves the MTT conjecture.
-    The ℒ-invariant equals log_p(q_E)/ord_p(q_E).
-    This determines the leading term of the p-adic L-function
-    at an exceptional zero. -/
-axiom greenberg_stevens (E : EllipticCurveQ)
+/-- **AXIOM ELIMINATED**: Greenberg-Stevens theorem (1993).
+    The conjunction `q_E > 0 ∧ L_invariant ≠ 0` is already encoded as
+    structure fields `ExceptionalZero.hq_pos` and `ExceptionalZero.hL_ne_zero`,
+    so the axiom is redundant: any inhabitant of `ExceptionalZero E` carries
+    this data by construction. Was: `axiom greenberg_stevens`. Now a theorem
+    with both conjuncts extracted directly from the structure. -/
+theorem greenberg_stevens (E : EllipticCurveQ)
     (ez : ExceptionalZero E) :
-    ez.q_E > 0 ∧ ez.L_invariant ≠ 0
+    ez.q_E > 0 ∧ ez.L_invariant ≠ 0 :=
+  ⟨ez.hq_pos, ez.hL_ne_zero⟩
 
 /-- **PROVED**: The Mazur-Tate-Teitelbaum (MTT) conjecture (now theorem):
     For E with split multiplicative reduction at p, the p-adic L-function
     has an exceptional zero: Lₚ(E,1) = 0 always. The ℒ-invariant
     measures the "extra" vanishing.
-    Was axiom; now proved from `greenberg_stevens`. -/
+    Direct from `ExceptionalZero.hL_ne_zero` field. -/
 theorem mtt_exceptional_zero (E : EllipticCurveQ)
     (ez : ExceptionalZero E) :
     ez.L_invariant ≠ 0 :=
-  (greenberg_stevens E ez).2
+  ez.hL_ne_zero
 
 /-- The p-adic height pairing: a Qₚ-valued pairing on E(ℚ).
     Defined by Mazur-Tate and Schneider using Coleman integration. -/

--- a/src/data/proofs/birch-swinnerton-dyer/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer/meta.json
@@ -15,8 +15,8 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 18,
-    "assumptions": "18 axiom declarations encoding: (1) L-function analytic continuation and functional equation, (2) Hasse bound a_p^2 <= 4p, (3) BSD conjecture proven cases (Kolyvagin rank 0, Gross-Zagier+Kolyvagin rank 1), (4) parity conjecture (Dokchitsers), (5) L-values and ranks for specific curves, (6) Sha structure, (7) Elkies rank record, (8) Greenberg-Stevens theorem, (9) regulator positivity. Previously 21 axioms: BSD_CM_rank_zero proved redundant (subsumed by Kolyvagin general result), gross_zagier_formula_detail dead code, one_not_congruent proved as theorem from BSD_rank_zero_axiom + curveMinusX_L_nonzero (curveMinusX = congruentNumberCurve 1 by coefficient equality + EllipticCurveQ.ext). 0 sorries. Also: 3 definitions vacuously return Prop := True as stubs pending rigorous formalization: p_adic_L_function (line 5626), HeegnerPointExists (line 5642), p_adic_height_pairing (line 5676). Additionally, sha_is_square := True appears in 4 data record fields (lines 4484, 4495, 4506, 4518).",
+    "axiomCount": 17,
+    "assumptions": "17 axiom declarations encoding: (1) L-function analytic continuation and functional equation, (2) Hasse bound a_p^2 <= 4p, (3) BSD conjecture proven cases (Kolyvagin rank 0, Gross-Zagier+Kolyvagin rank 1), (4) parity conjecture (Dokchitsers), (5) L-values and ranks for specific curves, (6) Sha structure, (7) Elkies rank record, (8) regulator positivity. Previously 21 axioms; reductions: BSD_CM_rank_zero subsumed by Kolyvagin general result, gross_zagier_formula_detail dead code, one_not_congruent proved as theorem (BSD_rank_zero_axiom + curveMinusX_L_nonzero with curveMinusX = congruentNumberCurve 1 by coefficient equality + EllipticCurveQ.ext), and most recently greenberg_stevens converted from axiom to theorem since both conjuncts (q_E > 0, L_invariant ≠ 0) are already encoded as ExceptionalZero structure fields hq_pos and hL_ne_zero. 0 sorries. Also: 3 definitions vacuously return Prop := True as stubs pending rigorous formalization: p_adic_L_function (line 5626), HeegnerPointExists (line 5642), p_adic_height_pairing (line 5676). Additionally, sha_is_square := True appears in 4 data record fields (lines 4484, 4495, 4506, 4518). Note: ExceptionalZero structure fields (hq_pos, hL_ne_zero) constitute structural assumptions; the elimination removes a duplicate axiom but the structural data remains.",
     "mathlibDependencies": [
       {
         "theorem": "WeierstrassCurve",
@@ -80,7 +80,7 @@
     "dateAdded": "2025-12-29",
     "millenniumProblem": "bsd",
     "proofRepoPath": "Proofs/BirchSwinnertonDyer.lean",
-    "lineCount": 7432,
+    "lineCount": 7435,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -716,8 +716,8 @@
   ],
   "sorries": 0,
   "leanFile": {
-    "axiomCount": 18,
-    "lineCount": 7432,
+    "axiomCount": 17,
+    "lineCount": 7435,
     "sorries": 0,
     "path": "Proofs/BirchSwinnertonDyer.lean"
   }

--- a/src/data/research/problems/birch-swinnerton-dyer-oq-03.json
+++ b/src/data/research/problems/birch-swinnerton-dyer-oq-03.json
@@ -17,11 +17,11 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-03-30T19:20:00Z",
-    "iteration": 2,
-    "focus": "Eliminated 2 redundant/dead axioms",
+    "since": "2026-04-27T17:00:00Z",
+    "iteration": 3,
+    "focus": "Eliminated greenberg_stevens axiom: redundant with ExceptionalZero structure fields (hq_pos, hL_ne_zero)",
     "blockers": [],
-    "nextAction": "hasse_bound elimination via Mathlib bridge is the main tractable target",
+    "nextAction": "hasse_bound elimination remains hard (custom traceOfFrobenius opaque, not Mathlib-bridged). Computational L-nonzero axioms (curveJZero, cremona11a1) require explicit numerical computation. Remaining 17 axioms appear genuinely needed.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,24 +29,28 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Eliminated 2 axioms (21->19). BSD_CM_rank_zero_axiom proved from general Kolyvagin result. gross_zagier_formula_detail removed as dead code.",
+    "progressSummary": "PROGRESS: Eliminated 1 more axiom (18->17). greenberg_stevens converted to theorem since both conjuncts (q_E > 0 ∧ L_invariant ≠ 0) are already encoded as ExceptionalZero structure fields hq_pos and hL_ne_zero. Total reduction so far: 21->17.",
     "builtItems": [
-      "Axiom classification: 12 deep + 7 computational + 2 structural",
+      "Axiom classification: 12 deep + 7 computational + 2 structural (now 1 structural)",
       "Converted BSD_CM_rank_zero_axiom to theorem using (BSD_rank_zero_axiom E hL).1",
       "Removed dead axiom gross_zagier_formula_detail",
       "Removed duplicate theorem parity_conjecture (identical to parity_conjecture_proved)",
-      "Updated meta.json: axiomCount 21->19, lineCount 7437->7422"
+      "Converted greenberg_stevens from axiom to theorem: extracts ⟨ez.hq_pos, ez.hL_ne_zero⟩ directly from the ExceptionalZero structure fields",
+      "Simplified mtt_exceptional_zero proof: direct ez.hL_ne_zero (was: (greenberg_stevens E ez).2)",
+      "Updated meta.json: axiomCount 18->17, lineCount 7432->7435; updated assumptions field with elimination history and noted ExceptionalZero structural assumptions"
     ],
     "insights": [
-      "21 axioms classified into 3 categories: (A) deep conjectures/theorems (12), (B) computational curve facts (7), (C) structural results (2)",
-      "Category A (12 axioms, unprovable from Mathlib): BSD_rank_zero/one_axiom, BSD_CM_rank_zero, parity_conjecture, sha_order_is_square, gross_zagier_formula_detail, greenberg_stevens, elkies_rank_record, positive_proportion_rank_one_bsd, analytic_rank_parity, rank3_hadamard_bound, regulator_pos",
-      "Category B (7 axioms, require numerical computation): curveMinusX/JZero/cremona11a1_L_nonzero, one/two_not_congruent, curve37a_rank/rootNumber, curve389a_rank",
-      "Category C (2 axioms, theoretically provable): hasse_bound (Weil theorem, deep but proven), parity_conjecture_proved_axiom",
+      "21 axioms classified into 3 categories: (A) deep conjectures/theorems, (B) computational curve facts, (C) structural results",
+      "Category A (deep, unprovable from current Mathlib): BSD_rank_zero/one_axiom, parity_conjecture_proved, sha_order_is_square, elkies_rank_record, positive_proportion_rank_one_bsd, analytic_rank_parity, rank3_hadamard_bound, regulator_pos",
+      "Category B (computational, require numerical computation): curveMinusX/JZero/cremona11a1_L_nonzero, two_not_congruent, curve37a_rank/rootNumber, curve389a_rank",
+      "Category C (structural, theoretically provable): hasse_bound (Weil theorem)",
       "hasse_bound uses custom EllipticCurveQ/traceOfFrobenius types, not Mathlib. Elimination requires bridging custom types to Mathlib API.",
       "0 actual sorries in file (metadata was stale: sorry count referred to a comment, not code)",
       "BSD_CM_rank_zero_axiom is redundant: Kolyvagin general BSD_rank_zero_axiom (L(E,1)!=0 -> rank=0) subsumes the CM special case. Eliminated by proving it as a theorem.",
       "gross_zagier_formula_detail was dead code (0 uses). The same content is captured by GrossZagierData.gross_zagier structure field. Removed.",
-      "Axiom count reduced: 21 -> 19. Remaining 19 axioms are genuine: 10 deep theorems, 7 computational facts, 2 structural results."
+      "greenberg_stevens redundant with ExceptionalZero structure: the conjunction `q_E > 0 ∧ L_invariant ≠ 0` is exactly the data of fields hq_pos and hL_ne_zero. Any inhabitant of ExceptionalZero E carries this by construction. Eliminated by proving it as ⟨ez.hq_pos, ez.hL_ne_zero⟩.",
+      "Axiom count reduced cumulatively: 21 -> 19 -> 17. Remaining 17 axioms appear genuinely needed.",
+      "PATTERN: Look for axioms whose conclusion is a conjunction matching existing structure fields. Such axioms are 'free' eliminations — the structure already encodes the data."
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -79,11 +83,11 @@
     {
       "path": "Proofs/BirchSwinnertonDyer.lean",
       "filename": "BirchSwinnertonDyer.lean",
-      "lineCount": 7433,
-      "theoremCount": 253,
-      "axiomCount": 18,
+      "lineCount": 7435,
+      "theoremCount": 254,
+      "axiomCount": 17,
       "defCount": 143,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirchSwinnertonDyer.lean"
     },


### PR DESCRIPTION
## Summary

Eliminates one axiom from `Proofs/BirchSwinnertonDyer.lean` by recognizing
that `axiom greenberg_stevens` was redundant with the `ExceptionalZero`
structure's existing fields.

- Axiom count: **18 → 17** (cumulative session reduction: 21 → 17)
- Lean file lines: 7432 → 7435 (longer comment, but axiom replaced by 2-line theorem)
- 0 sorries throughout (unchanged)

## What changed

`axiom greenberg_stevens E ez : ez.q_E > 0 ∧ ez.L_invariant ≠ 0` asserts
exactly the data already encoded in `ExceptionalZero`'s structure fields
`hq_pos : q_E > 0` and `hL_ne_zero : L_invariant ≠ 0`. Any inhabitant of
`ExceptionalZero E` carries those proofs by construction.

```lean
theorem greenberg_stevens (E : EllipticCurveQ) (ez : ExceptionalZero E) :
    ez.q_E > 0 ∧ ez.L_invariant ≠ 0 :=
  ⟨ez.hq_pos, ez.hL_ne_zero⟩
```

`mtt_exceptional_zero` simplified to use `ez.hL_ne_zero` directly
(was: `(greenberg_stevens E ez).2`).

## Axiom integrity

`ExceptionalZero` was already a structure with these fields before this
PR. Eliminating the duplicate global axiom does not change the proof's
structural dependencies — those fields remain part of the structure
definition. This is a *redundancy* removal, not a relocation of an
assumption.

## Files modified

- `proofs/Proofs/BirchSwinnertonDyer.lean` — axiom → theorem; mtt_exceptional_zero simplified
- `src/data/proofs/birch-swinnerton-dyer/meta.json` — axiomCount 18→17, lineCount 7432→7435, assumptions field updated
- `src/data/research/problems/birch-swinnerton-dyer-oq-03.json` — knowledge state, insights, leanFiles section synced

## Pattern documented

Knowledge JSON now records the elimination pattern: *axioms whose
conclusion is a conjunction matching existing structure fields are free
eliminations.* Useful heuristic for future axiom-reduction sessions.

## Test plan

- [ ] Docker build of `Proofs.BirchSwinnertonDyer` completes
- [ ] Gallery `pnpm build` succeeds with updated meta.json
- [ ] No new sorries; axiom count reduced as claimed

🤖 Generated by researcher-4