### PR TITLE
Research: abel-ruffini-oq-04-oq-03 — axiom-free Abel-Ruffini corollaries

### DIFF
--- a/proofs/Proofs/AbelRuffiniOQ04OQ03.lean
+++ b/proofs/Proofs/AbelRuffiniOQ04OQ03.lean
@@ -99,7 +99,23 @@ inseparable extensions complicate the picture.
 If the Galois group of an irreducible polynomial q over F is solvable,
 and F has characteristic 0, then any root of q is solvable by radicals.
 
-Proof requires Kummer theory for cyclic extensions, not yet in Mathlib. -/
+Proof sketch (the Kummer composition argument):
+1. Pass to the Galois closure of `q` over `F`; its Galois group is the
+   solvable group `q.Gal`.
+2. Adjoin enough roots of unity (degree dividing `|q.Gal|`); the resulting
+   field has the same Galois group structure and supports Kummer theory.
+3. Use a composition series for `q.Gal` with cyclic factors. Each cyclic
+   factor of order `n`, over a field containing primitive `n`-th roots of
+   unity, corresponds via Kummer theory (`Mathlib.FieldTheory.KummerExtension`,
+   `isCyclic_tfae`) to a radical extension `X^n - C a`.
+4. Composing these radical extensions gives a radical tower containing the
+   splitting field, so every root is in `solvableByRad F E`.
+
+Status of Mathlib infrastructure:
+- `Mathlib.FieldTheory.KummerExtension` provides the cyclic case
+  (`isCyclic_tfae`, `autEquivRootsOfUnity`, `autEquivZmod`).
+- The composition step (assembling cyclic Kummer extensions into a radical
+  tower from a solvable group's composition series) is not yet in Mathlib. -/
 axiom solvableGal_implies_solvableByRad
     (q : Polynomial F) (hq : Irreducible q) [CharZero F]
     (α : E) (hroot : Polynomial.aeval α q = 0)
@@ -154,12 +170,73 @@ theorem solvable_gal_means_radical_formula
 /-- The criterion makes the Abel-Ruffini theorem a special case:
 S₅ is not solvable (Mathlib), so any polynomial with Galois group S₅
 is not solvable by radicals. The criterion says this is the COMPLETE
-obstruction: solvability of the Galois group is both necessary and sufficient. -/
+obstruction: solvability of the Galois group is both necessary and sufficient.
+
+Note: this corollary only uses the FORWARD direction of `galois_criterion`,
+so it is logically independent of the axiomatized reverse direction. -/
 theorem abel_ruffini_as_galois_special_case
-    (q : Polynomial F) (hq : Irreducible q) [CharZero F]
+    (q : Polynomial F) (hq : Irreducible q)
     (α : E) (hroot : Polynomial.aeval α q = 0)
     (hns : ¬IsSolvable q.Gal) :
     ¬IsSolvableByRad F α :=
-  fun h => hns ((galois_criterion q hq α hroot).mp h)
+  not_solvableByRad_of_not_solvableGal q hq α hroot hns
+
+-- ============================================================
+-- PART 6: Axiom-Free Concrete Abel-Ruffini
+-- ============================================================
+
+/-
+The forward direction alone gives a clean structural test for non-solvability
+by radicals: if the Galois group is isomorphic to a non-solvable group, we win.
+
+In particular, isomorphism with `Equiv.Perm (Fin n)` for `n ≥ 5` is enough,
+since `Equiv.Perm.not_solvable` handles those symmetric groups.
+
+The two theorems below are independent of `solvableGal_implies_solvableByRad`
+and hold without `[CharZero F]`.
+-/
+
+/-- If `q.Gal` is isomorphic (as a group) to `Equiv.Perm (Fin n)` with `n ≥ 5`,
+then `q.Gal` is not solvable.
+
+This is purely group-theoretic: a group isomorphic to a non-solvable group
+is itself not solvable. We pull `IsSolvable q.Gal` back along the isomorphism
+to get `IsSolvable (Equiv.Perm (Fin n))`, which contradicts
+`Equiv.Perm.not_solvable`. -/
+theorem not_isSolvable_gal_of_perm_iso
+    {n : ℕ} (hn : 5 ≤ n)
+    (q : Polynomial F) (φ : q.Gal ≃* Equiv.Perm (Fin n)) :
+    ¬ IsSolvable q.Gal := by
+  intro hsolv
+  -- Push solvability through the surjective hom `φ.toMonoidHom`.
+  have hperm : IsSolvable (Equiv.Perm (Fin n)) :=
+    haveI : IsSolvable q.Gal := hsolv
+    solvable_of_surjective (f := (φ : q.Gal →* Equiv.Perm (Fin n))) φ.surjective
+  -- But `Equiv.Perm (Fin n)` is not solvable for `n ≥ 5`.
+  apply Equiv.Perm.not_solvable (Fin n) ?_ hperm
+  rw [Cardinal.mk_fintype, Fintype.card_fin]
+  exact_mod_cast hn
+
+/-- **Axiom-free Abel-Ruffini via full symmetric Galois group**:
+
+If `q : F[X]` is irreducible with a root `α : E`, and the Galois group of `q`
+is isomorphic (as a group) to `Equiv.Perm (Fin n)` for some `n ≥ 5`, then
+`α` is NOT solvable by radicals over `F`.
+
+This corollary uses ONLY the forward direction of Galois's criterion (the
+Mathlib-proved part), so it is independent of the axiomatized reverse
+direction `solvableGal_implies_solvableByRad`. It captures the original
+Abel-Ruffini theorem as a clean structural consequence: the existence of
+ANY irreducible polynomial whose Galois group contains `S_5` (e.g., the
+classical irreducible quintics with two non-real roots over `ℚ`) suffices
+to refute the existence of a general radical formula. -/
+theorem not_solvableByRad_of_perm_gal
+    {n : ℕ} (hn : 5 ≤ n)
+    (q : Polynomial F) (hq : Irreducible q)
+    (α : E) (hroot : Polynomial.aeval α q = 0)
+    (φ : q.Gal ≃* Equiv.Perm (Fin n)) :
+    ¬ IsSolvableByRad F α :=
+  not_solvableByRad_of_not_solvableGal q hq α hroot
+    (not_isSolvable_gal_of_perm_iso hn q φ)
 
 end GaloisCriterion

--- a/research/problems/sperner-ndim-oq-04/knowledge.md
+++ b/research/problems/sperner-ndim-oq-04/knowledge.md
@@ -404,3 +404,66 @@ The correct τ involution domain is B (ALL boundary doors) under the assumption 
    - K.adj sᵢ kᵢ = some(sᵢ₋₁, eᵢ₋₁) by adj_symm from forward walk adjacency
    - Induction reverses n steps to reach s₀ with boundary exit k₀ = Fin.last d
 2. Once walkTrace_reversal done: 0 sorries, proof complete
+
+---
+
+## Session 2026-04-27 (Session 9) — BLOCKED Triage + Stale Pool Correction
+
+**Mode**: REVISIT
+**Outcome**: documentation only — flagging as BLOCKED on walkTrace_reversal infrastructure
+
+### What I Did
+
+1. Confirmed Lean file state: 1126 lines, 0 axioms, 1 sorry at line 980 (`bdry_all_even_of_no_fc_walks`
+   `hInv` component, the walkTrace_reversal step).
+2. Confirmed candidate-pool entry has stale `phase: COMPLETED, status: completed` even though the
+   actual proof has 1 sorry remaining (gallery meta.json correctly shows `status: formalized`,
+   `badge: wip`, `sorries: 1`).
+3. Reviewed prior 8 sessions: the same single sorry has remained across many sessions because
+   closing it requires either ~150 lines of `kuhnWalkSeq` infrastructure OR formalizing the door
+   graph as a Mathlib `SimpleGraph` and using path machinery.
+4. Per the memory rule "If 3+ sessions stuck on same sorry: flag as BLOCKED, move on", marking
+   this problem as BLOCKED with a precise unblock plan documented below.
+
+### Why It Is BLOCKED (precise barrier)
+
+The sorry at line 980 needs:
+```
+show kuhnPathStart c K hKuhn sₙ (Fin.last d) hdoor_n hbdry_n = p.1
+```
+where `sₙ = kuhnPathStart c K hKuhn p.1 (Fin.last d) hdoor₀ hbdry₀`.
+
+`kuhnPathStart` is just the FINAL simplex of the walk; it forgets the path. To prove the
+backward walk from `sₙ` traces back to `p.1`, the proof must access the entire walk SEQUENCE,
+not just its endpoint. The current `WalkValid` invariant captures door records on visited
+simplices but NOT the linear order of the trace.
+
+### Two Concrete Unblock Paths (each multi-session)
+
+**Path A — Define `kuhnWalkSeq`** (~150 lines):
+1. New def `kuhnWalkSeq : (state : KuhnState) → (fuel : ℕ) → List (K.Simplex × Fin (d+1) × Fin (d+1))`
+   returning `(sᵢ, k_in_i, k_out_i)` triples for each visited simplex.
+2. Lemma `kuhnWalkSeq_length`: matches visited.card increase.
+3. Lemma `kuhnWalkSeq_adj_chain`: consecutive entries linked by `K.adj`.
+4. Lemma `kuhnWalkSeq_reversal`: `(seq.reverse.map swap)` is a valid backward walk seq from
+   the final simplex.
+5. Use to close walkTrace_reversal in `bdry_all_even_of_no_fc_walks`.
+
+**Path B — Mathlib SimpleGraph** (~200+ lines):
+1. Define the door graph as `SimpleGraph K.Simplex` with edges `s ~ s' iff ∃ k k', K.adj s k = some(s', k')`.
+2. Prove max degree ≤ 2 under `IsKuhnCompatible`.
+3. Prove boundary doors correspond to "half-edges" (handled via auxiliary boundary vertices).
+4. Use Mathlib's `SimpleGraph.Walk` and `Walk.reverse` machinery for path reversal.
+5. Apply `even_card_fpf_invol` via the reversal involution.
+
+### Files Modified
+
+- `research/problems/sperner-ndim-oq-04/knowledge.md` (this file: BLOCKED triage notes)
+- `src/data/research/problems/sperner-ndim-oq-04.json` (correcting stale `phase: COMPLETED`)
+
+### Next Steps (for future sessions)
+
+- Pick this back up only after one of Paths A/B above is committed as separate infrastructure.
+- Or: accept the existing `kuhn_path_existential` as an axiom (Session 7 form) and remove the
+  sorry at the cost of 1 axiom — this is a defensible position for a fundamental algorithmic
+  result that essentially restates Sperner's lemma constructively.

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-03.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-03.json
@@ -1,7 +1,7 @@
 {
   "slug": "abel-ruffini-oq-04-oq-03",
   "title": "Formalize Galois's criterion: a polynomial is solvable by radicals iff its Ga...",
-  "phase": "OBSERVE",
+  "phase": "COMPLETED",
   "status": "active",
   "tier": "C",
   "path": "full",
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ACT",
-    "since": "2026-03-28T15:56:28-07:00",
+    "phase": "COMPLETED",
+    "since": "2026-04-27",
     "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "focus": "Axiomatized formalization complete. Forward direction from Mathlib; reverse direction (Kummer composition) properly axiomatized with detailed proof sketch. Two new axiom-free Abel-Ruffini corollaries added (perm-iso route).",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "Optionally: prove the axiom by formalizing Kummer composition (~500-1000 lines, separate Mathlib initiative).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,24 +29,33 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: Created formalization of Galois criterion. Forward direction proved from Mathlib. Reverse axiomatized (needs Kummer theory). 1 axiom, 0 sorries.",
+    "progressSummary": "COMPLETE (axiomatized): Galois criterion in 242 lines, 1 axiom. Forward direction = Mathlib. Reverse direction = axiom requiring Kummer composition (cyclic case in Mathlib via KummerExtension; assembly step not yet there). New axiom-free corollaries not_isSolvable_gal_of_perm_iso and not_solvableByRad_of_perm_gal give Abel-Ruffini via S_n isomorphism using only the forward direction.",
     "builtItems": [
       "AbelRuffiniOQ04OQ03.lean: 152 lines, 7 theorems, 1 axiom",
-      "galois_criterion: full iff (solvable by radicals ↔ solvable Galois group)",
+      "galois_criterion: full iff (solvable by radicals \u2194 solvable Galois group)",
       "galois_criterion_rationals: specialization to Q",
       "solvable_gal_means_radical_formula: converse of Abel-Ruffini",
-      "Gallery data: meta.json"
+      "Gallery data: meta.json",
+      "AbelRuffiniOQ04OQ03.lean expanded to 242 lines, 8 theorems, 1 axiom",
+      "not_isSolvable_gal_of_perm_iso: Gal(q) \u2243* Equiv.Perm (Fin n) \u2227 n \u2265 5 \u2192 \u00ac IsSolvable q.Gal (axiom-free)",
+      "not_solvableByRad_of_perm_gal: Gal(q) \u2243* Equiv.Perm (Fin n) \u2227 n \u2265 5 \u2192 \u00ac IsSolvableByRad F \u03b1 (axiom-free)",
+      "Refined axiom docstring referencing Mathlib.FieldTheory.KummerExtension, isCyclic_tfae, autEquivRootsOfUnity"
     ],
     "insights": [
-      "Forward direction (solvable by radicals → solvable Galois group) is in Mathlib as solvableByRad.isSolvable_prime",
-      "Reverse direction (solvable Galois group → solvable by radicals) requires Kummer theory: cyclic Galois extensions over fields with roots of unity are radical",
+      "Forward direction (solvable by radicals \u2192 solvable Galois group) is in Mathlib as solvableByRad.isSolvable_prime",
+      "Reverse direction (solvable Galois group \u2192 solvable by radicals) requires Kummer theory: cyclic Galois extensions over fields with roots of unity are radical",
       "Reverse needs CharZero (or char not dividing group order) for roots of unity to exist",
-      "Full iff criterion stated as galois_criterion with 1 axiom for the reverse direction"
+      "Full iff criterion stated as galois_criterion with 1 axiom for the reverse direction",
+      "Mathlib.FieldTheory.KummerExtension provides the cyclic case (isCyclic_tfae) needed for the reverse direction; what's missing is the composition step assembling cyclic extensions into a radical tower from a solvable group's composition series",
+      "Pure-group-theoretic transport: solvable_of_surjective lets us push solvability across MulEquiv between Gal(q) and Equiv.Perm (Fin n), so the axiom-free Abel-Ruffini test reduces to constructing a permutation iso (e.g. via Mathlib's galActionHom_bijective_of_prime_degree for irreducible quintics over \u211a with two non-real roots)",
+      "The contrapositive abel_ruffini_as_galois_special_case does NOT need [CharZero F] because it only invokes the forward direction; the CharZero hypothesis was an unnecessary remnant from threading through the iff form"
     ],
     "mathlibGaps": [
       "Kummer theory for cyclic extensions (needed for reverse direction of Galois criterion)"
     ],
-    "nextSteps": [],
+    "nextSteps": [
+      "Optional Mathlib contribution: formalize Kummer composition (assemble cyclic Kummer extensions into a radical tower from a solvable group's composition series) \u2014 would eliminate the remaining axiom"
+    ],
     "markdown": "# Knowledge Base: abel-ruffini-oq-04-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [],
@@ -68,7 +77,7 @@
     "mathlib": []
   },
   "started": "2026-03-28T22:57:01.593Z",
-  "lastUpdate": "2026-03-28T22:57:01.612Z",
+  "lastUpdate": "2026-04-27T00:00:00.000Z",
   "leanFiles": [
     {
       "path": "Proofs/AbelRuffini.lean",

--- a/src/data/research/problems/birthday-problem-oq-02-oq-01.json
+++ b/src/data/research/problems/birthday-problem-oq-02-oq-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "birthday-problem-oq-02-oq-01",
   "title": "Can the matching lower bound $\\prod(1-i/d) \\ge \\exp(-k(k-1)/(2d) - k^2(k-1)^2...",
-  "phase": "NEW",
+  "phase": "COMPLETED",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-03-26T20:00:24.432Z",
+    "phase": "COMPLETED",
+    "since": "2026-04-27",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "Already verified: 0 sorries, 0 axioms, 8 theorems on birthdayProduct two-sided bounds. Status confirmed by researcher-3 review on 2026-04-27.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "No further work needed on this entry. Pool entry updated to COMPLETED.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,28 +29,28 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: All 4 sorries eliminated (2→0 this session). Fixed incorrect hypotheses in 2 theorems. File now 229 lines, 0 sorries, 0 axioms.",
+    "progressSummary": "VERIFIED: BirthdayProblemOQ02OQ01.lean is 229 lines, 8 theorems, 0 sorries, 0 axioms. Gallery meta has status:verified, badge:original. Pool was stale (phase:NEW); confirmed complete by review on 2026-04-27.",
     "builtItems": [
       "Assessment: tractable new formalization, needs Taylor remainder infrastructure",
-      "sum_sq_le_quartic: proved ∑i² ≤ k²(k-1)²/4 via sum_sq_formula + nlinarith",
-      "Gauss sum: proved ∑(-i/d) = -k(k-1)/(2d) via Finset.sum_range_id",
-      "exp_neg_sub_sq_le_one_sub: proved exp(-x-x²) ≤ 1-x for x ∈ [0,1/2] via Taylor bound",
-      "birthdayProduct_lower_bound: proved matching lower bound with corrected hypothesis 2(k-1)≤d",
+      "sum_sq_le_quartic: proved \u2211i\u00b2 \u2264 k\u00b2(k-1)\u00b2/4 via sum_sq_formula + nlinarith",
+      "Gauss sum: proved \u2211(-i/d) = -k(k-1)/(2d) via Finset.sum_range_id",
+      "exp_neg_sub_sq_le_one_sub: proved exp(-x-x\u00b2) \u2264 1-x for x \u2208 [0,1/2] via Taylor bound",
+      "birthdayProduct_lower_bound: proved matching lower bound with corrected hypothesis 2(k-1)\u2264d",
       "birthdayProduct_two_sided: two-sided exponential sandwich for birthday probability"
     ],
     "insights": [
-      "No Lean file for OQ-02-OQ-01. Parent files: 5 files, 0A, 0S, 119T — fully proved",
-      "OQ02 has upper bound P(all distinct) ≤ exp(-k(k-1)/(2d)) but NOT matching lower bound",
+      "No Lean file for OQ-02-OQ-01. Parent files: 5 files, 0A, 0S, 119T \u2014 fully proved",
+      "OQ02 has upper bound P(all distinct) \u2264 exp(-k(k-1)/(2d)) but NOT matching lower bound",
       "OQ-02-OQ-01 asks: formalize matching lower bound via second-order Taylor of ln(1-x)",
-      "Key math: ∏(1-i/d) ≥ exp(-k(k-1)/(2d) - k²(k-1)²/(4d²))",
-      "Tractable: needs ln(1-x) ≥ -x - x²/2 (Taylor with remainder), then product bound",
+      "Key math: \u220f(1-i/d) \u2265 exp(-k(k-1)/(2d) - k\u00b2(k-1)\u00b2/(4d\u00b2))",
+      "Tractable: needs ln(1-x) \u2265 -x - x\u00b2/2 (Taylor with remainder), then product bound",
       "Would need Mathlib Real.log bounds + Taylor/Lagrange remainder for ln",
-      "sum_sq_le_quartic: use case split k=1 (trivial) vs k≥2 (nlinarith with sq_nonneg)",
+      "sum_sq_le_quartic: use case split k=1 (trivial) vs k\u22652 (nlinarith with sq_nonneg)",
       "Gauss sum: factor -(1/d) then use sum_range_id = k(k-1)/2",
-      "exp_neg_sub_sq_le_one_sub: deep — needs Taylor remainder for ln(1-x) ≥ -x-x²",
-      "CRITICAL FIX: original exp(-x-x²) ≤ 1-x had hypothesis x<1 but is FALSE for x>0.69. Changed to x≤1/2.",
-      "CRITICAL FIX: birthdayProduct_lower_bound with k≤d+1 is FALSE (product=0 when k=d+1). Changed to 2(k-1)≤d.",
-      "Proof technique: Taylor bound exp(y) ≥ 1+y+y²/2 via Real.sum_le_exp_of_nonneg, then polynomial algebra"
+      "exp_neg_sub_sq_le_one_sub: deep \u2014 needs Taylor remainder for ln(1-x) \u2265 -x-x\u00b2",
+      "CRITICAL FIX: original exp(-x-x\u00b2) \u2264 1-x had hypothesis x<1 but is FALSE for x>0.69. Changed to x\u22641/2.",
+      "CRITICAL FIX: birthdayProduct_lower_bound with k\u2264d+1 is FALSE (product=0 when k=d+1). Changed to 2(k-1)\u2264d.",
+      "Proof technique: Taylor bound exp(y) \u2265 1+y+y\u00b2/2 via Real.sum_le_exp_of_nonneg, then polynomial algebra"
     ],
     "mathlibGaps": [],
     "nextSteps": []
@@ -75,7 +75,7 @@
     "mathlib": []
   },
   "started": "2026-03-26T20:00:24.431Z",
-  "lastUpdate": "2026-03-28T06:00:00Z",
+  "lastUpdate": "2026-04-27T00:00:00.000Z",
   "significance": 5,
   "tractability": 6,
   "leanFiles": [

--- a/src/data/research/problems/erdos-892.json
+++ b/src/data/research/problems/erdos-892.json
@@ -1,6 +1,6 @@
 {
   "slug": "erdos-892",
-  "title": "Erdős #892",
+  "title": "Erd\u0151s #892",
   "phase": "OBSERVE",
   "status": "active",
   "tier": "B",
@@ -29,22 +29,26 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Removed 2 unused axioms (3→1). Fixed Aristotle file: removed incorrectly stated reciprocal_log_comparison (counterexample: a=6,C=3,b=2).",
+    "progressSummary": "PROGRESS (2026-04-27): file builds clean; 0 sorries, 2 axioms remain. Recorded concrete recipe for eliminating axiom #2 (harmonic_log_plus2_diverges) via Mathlib's Cauchy condensation `summable_condensed_iff_of_nonneg`. Axiom #1 (primitive_reciprocal_log_convergent) is the genuinely deep Erd\u0151s 1935 result and stays.",
     "builtItems": [
       "Removed incorrect Aristotle reciprocal_log_comparison (had counterexample)",
       "Removed unused axioms ess_1967_necessary and primitive_counting_bound (documented as comments)",
       "Cleaned Aristotle file: now sorry-free"
     ],
     "insights": [
-      "Only 1 axiom needed: primitive_reciprocal_log_convergent (Erdős 1935)",
+      "Only 1 axiom needed: primitive_reciprocal_log_convergent (Erd\u0151s 1935)",
       "ess_1967_necessary and primitive_counting_bound were stated but never used in proofs",
       "Aristotle reciprocal_log_comparison had wrong hypothesis (a>=2C instead of b>=C), counterexample: a=6,C=3,b=2",
       "Main file reciprocal_log_comparison is correctly stated and proved",
-      "Main theorem erdos_1935_necessary is a substantive 70-line proof"
+      "Main theorem erdos_1935_necessary is a substantive 70-line proof",
+      "Mathlib has Cauchy condensation in `Mathlib.Analysis.PSeries`: `summable_condensed_iff_of_nonneg` says Summable f \u2194 Summable (fun k => 2^k * f(2^k)) for f nonneg + antitone (for n \u2265 1). Combined with `not_summable_iff_tendsto_nat_atTop_of_nonneg` from `Mathlib.Topology.Algebra.InfiniteSum.Real`, the axiom `harmonic_log_plus2_diverges` is reducible to a Mathlib proof.",
+      "Concrete elimination recipe for harmonic_log_plus2_diverges: (1) Antitone proof: f(n)=1/((n+2)\u00b7log(n+2)) is decreasing because both (n+2) and log(n+2) are positive and increasing for n \u2265 0. (2) Condense: 2^k \u00b7 f(2^k) = 2^k/((2^k+2)\u00b7log(2^k+2)) \u2265 1/(2(k+1) log 2) for k \u2265 1 (since 2^k+2 \u2264 2\u00b72^k and log(2^k+2) \u2264 (k+1) log 2). (3) Compare condensed series to (1/(2 log 2)) \u00b7 \u03a3 1/(k+1), divergent by tendsto_sum_range_one_div_nat_succ_atTop. (4) Use not_summable_iff_tendsto_nat_atTop_of_nonneg to convert \u00acSummable to atTop and extract the existential N for any S."
     ],
     "mathlibGaps": [],
-    "nextSteps": [],
-    "markdown": "# Erdős #892 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nIs there a necessary and sufficient condition for a sequence of integers $b_1<b_2<\\cdots$ that ensures there exists a primitive sequence $a_1<a_2<\\cdots$ (i.e. no element divides another) with $a_n \\ll b_n$ for all $n$?\n\nIn particular, is this always possible if there are no non-trivial solutions to $(b_i,b_j)=b_k$?\n\n\n\nA problem of Erd\\H{o}s, S\\'{a}rk\\\"{o}zy, and Szemer\\'{e}di \\cite{ESS68}. It is known that\\[\\sum \\frac{1}{b_n\\log b_n}<\\infty\\]and\\[\\sum_{b_n<x}\\frac{1}{b_n} =o\\left(\\frac{\\log x}{\\sqrt{\\log\\log x}}\\right)\\]are both necessary. (The former is due to Erd\\H{o}s \\cite{Er35}, the latter to Erd\\H{o}s, S\\'{a}rk\\\"{o}zy, and Szemer\\'{e}di \\cite{ESS67}.)\n\nOne can ask a similar question for sequences of real numbers, as in [143].\n\n\n\n\nReferences\n\n\n[ESS67] Erd\\H{o}s, P. and S\\'{a}rk\\\"ozy, A. and Szemer\\'{e}di, E., On a theorem of Behrend. J. Austral. Math. Soc. (1967), 9--16.\n\n[ESS68] Erd\\H{o}s, P. and S\\'{a}rk\\\"ozi, A. and Szemer\\'{e}di, E., On the solvability of certain equations in sequences of\npositive upper logarithmic density. J. London Math. Soc. (1968), 71--78.\n\n[Er35] Erd\\\"{o}s, Paul, Note on Sequences of Integers No One of Which is Divisible By Any Other. J. London Math. Soc. (1935), 126-128.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #143\n- Problem #891\n- Problem #893\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er98\n- ESS68\n- Er35\n- ESS67\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
+    "nextSteps": [
+      "Eliminate axiom harmonic_log_plus2_diverges (Erdos892Problem.lean:172) using Mathlib's summable_condensed_iff_of_nonneg + tendsto_sum_range_one_div_nat_succ_atTop. Estimated 50-70 lines: (a) recip_log_plus2_antitone (~10 lines), (b) not_summable_recip_log_plus2 via condensation (~30-50 lines), (c) Tendsto.eventually to extract the existential N (~5 lines)."
+    ],
+    "markdown": "# Erd\u0151s #892 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nIs there a necessary and sufficient condition for a sequence of integers $b_1<b_2<\\cdots$ that ensures there exists a primitive sequence $a_1<a_2<\\cdots$ (i.e. no element divides another) with $a_n \\ll b_n$ for all $n$?\n\nIn particular, is this always possible if there are no non-trivial solutions to $(b_i,b_j)=b_k$?\n\n\n\nA problem of Erd\\H{o}s, S\\'{a}rk\\\"{o}zy, and Szemer\\'{e}di \\cite{ESS68}. It is known that\\[\\sum \\frac{1}{b_n\\log b_n}<\\infty\\]and\\[\\sum_{b_n<x}\\frac{1}{b_n} =o\\left(\\frac{\\log x}{\\sqrt{\\log\\log x}}\\right)\\]are both necessary. (The former is due to Erd\\H{o}s \\cite{Er35}, the latter to Erd\\H{o}s, S\\'{a}rk\\\"{o}zy, and Szemer\\'{e}di \\cite{ESS67}.)\n\nOne can ask a similar question for sequences of real numbers, as in [143].\n\n\n\n\nReferences\n\n\n[ESS67] Erd\\H{o}s, P. and S\\'{a}rk\\\"ozy, A. and Szemer\\'{e}di, E., On a theorem of Behrend. J. Austral. Math. Soc. (1967), 9--16.\n\n[ESS68] Erd\\H{o}s, P. and S\\'{a}rk\\\"ozi, A. and Szemer\\'{e}di, E., On the solvability of certain equations in sequences of\npositive upper logarithmic density. J. London Math. Soc. (1968), 71--78.\n\n[Er35] Erd\\\"{o}s, Paul, Note on Sequences of Integers No One of Which is Divisible By Any Other. J. London Math. Soc. (1935), 126-128.\n\n\nBack to the problem\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #143\n- Problem #891\n- Problem #893\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er98\n- ESS68\n- Er35\n- ESS67\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
   "tags": [
     "erdos"
@@ -60,7 +64,7 @@
     "mathlib": []
   },
   "started": "2026-01-15T11:22:53.228Z",
-  "lastUpdate": "2026-03-24T17:00:00Z",
+  "lastUpdate": "2026-04-27T00:00:00.000Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [

--- a/src/data/research/problems/hurwitz-theorem-oq-04.json
+++ b/src/data/research/problems/hurwitz-theorem-oq-04.json
@@ -19,9 +19,11 @@
     "phase": "ACT",
     "since": "2026-04-24T00:00:00Z",
     "iteration": 2,
-    "focus": "submodule_der_unit_zero added; derEval14_injective decomposed via by_cases j = 0; remaining sorry scoped to imaginary basis (j ∈ {1,...,7}).",
-    "blockers": [],
-    "nextAction": "Prove diagonal-kill and antisymmetry helpers, then chain to derive D(eⱼ) = 0 for j ≥ 1.",
+    "focus": "Blocked by Mathlib API drift; build was failing before any new edits. Needs Mechanic-style repair before sorry-elimination resumes.",
+    "blockers": [
+      "Mathlib API drift breaks the build (`ring` no longer closes the diagonal-extraction goals at lines 90/97; whnf timeout at 205; unknown private constant `imag_sq_eq_neg_norm` at 225). Repair upstream first."
+    ],
+    "nextAction": "Prove diagonal-kill and antisymmetry helpers, then chain to derive D(e\u2c7c) = 0 for j \u2265 1.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -31,48 +33,53 @@
   "knowledge": {
     "progressSummary": "PROGRESS (2026-04-27): submodule_der_unit_zero added; derEval14_injective decomposed by by_cases j = 0; remaining sorry scoped to 56-entry imaginary basis claim.",
     "builtItems": [
-      "ExceptionalType inductive type (G2/F4/E6/E7/E8) with dim/rank — HurwitzTheoremOQ04.lean",
-      "OctonionAlgHom structure + OctonionAut — HurwitzTheoremOQ04.lean",
-      "eightMul_right_unit (PROVED 2026-04-24): simp(decide)+Matrix.cons_val_* pattern — HurwitzTheoremOQ04.lean:82",
-      "eightMul_left_unit (PROVED 2026-04-24): same pattern — HurwitzTheoremOQ04.lean:94",
-      "alg_hom_preserves_norm_product (PROVED) — HurwitzTheoremOQ04.lean",
-      "G2_unique_low_rank, E8_is_largest, exceptional_dims_strict_mono (PROVED) — HurwitzTheoremOQ04.lean",
-      "G2_is_octonion_aut REPLACED (2026-04-26) by G2_der_dimension: finrank ℝ OctonionDerSubmodule = 14. Previous axiom was Nat.card OctonionAut = 14 which is 0 = 14, mathematically wrong.",
-      "Freudenthal-Tits magic square table with dimensional analysis — HurwitzTheoremOQ04.lean commentary",
-      "OctonionDer structure: ℝ-linear maps with Leibniz rule — HurwitzTheoremOQ04.lean",
+      "ExceptionalType inductive type (G2/F4/E6/E7/E8) with dim/rank \u2014 HurwitzTheoremOQ04.lean",
+      "OctonionAlgHom structure + OctonionAut \u2014 HurwitzTheoremOQ04.lean",
+      "eightMul_right_unit (PROVED 2026-04-24): simp(decide)+Matrix.cons_val_* pattern \u2014 HurwitzTheoremOQ04.lean:82",
+      "eightMul_left_unit (PROVED 2026-04-24): same pattern \u2014 HurwitzTheoremOQ04.lean:94",
+      "alg_hom_preserves_norm_product (PROVED) \u2014 HurwitzTheoremOQ04.lean",
+      "G2_unique_low_rank, E8_is_largest, exceptional_dims_strict_mono (PROVED) \u2014 HurwitzTheoremOQ04.lean",
+      "G2_is_octonion_aut REPLACED (2026-04-26) by G2_der_dimension: finrank \u211d OctonionDerSubmodule = 14. Previous axiom was Nat.card OctonionAut = 14 which is 0 = 14, mathematically wrong.",
+      "Freudenthal-Tits magic square table with dimensional analysis \u2014 HurwitzTheoremOQ04.lean commentary",
+      "OctonionDer structure: \u211d-linear maps with Leibniz rule \u2014 HurwitzTheoremOQ04.lean",
       "zeroDer (proved 0 sorries): zero map is a derivation",
       "addDer (proved): sum of derivations is a derivation",
       "smulDer (proved): scalar multiple is a derivation",
       "eightMul_sub_left/right: eightMul bilinear over subtraction",
-      "commDer (proved): commutator of derivations is a derivation — key Lie algebra result",
-      "commDer_antisymm, commDer_jacobi: Der(𝕆) is a Lie algebra under [·,·]",
-      "OctonionDerSubmodule (2026-04-26): Der(𝕆) as Submodule ℝ (End_ℝ(ℝ⁸)) — PART IV-c of HurwitzTheoremOQ04.lean",
-      "submodule_der_unit_zero (PROVED 2026-04-27): submodule-level unit-kills lemma — for any f ∈ OctonionDerSubmodule, f octUnit = 0. Same proof shape as der_maps_unit_to_zero but for LinearMap members."
+      "commDer (proved): commutator of derivations is a derivation \u2014 key Lie algebra result",
+      "commDer_antisymm, commDer_jacobi: Der(\ud835\udd46) is a Lie algebra under [\u00b7,\u00b7]",
+      "OctonionDerSubmodule (2026-04-26): Der(\ud835\udd46) as Submodule \u211d (End_\u211d(\u211d\u2078)) \u2014 PART IV-c of HurwitzTheoremOQ04.lean",
+      "submodule_der_unit_zero (PROVED 2026-04-27): submodule-level unit-kills lemma \u2014 for any f \u2208 OctonionDerSubmodule, f octUnit = 0. Same proof shape as der_maps_unit_to_zero but for LinearMap members."
     ],
     "insights": [
-      "G₂ = Aut(𝕆): The exceptional Lie group G₂ (dim 14, rank 2) is the automorphism group of the octonions. The 14 dimensions come from SO(7) (dim 21) minus the 7 constraints from preserving the octonion cross product.",
-      "Freudenthal-Tits Magic Square: 𝔏(A,B) = Der(A)⊕(ImA⊗ImB)⊕Der(B) gives a symmetric Lie algebra from pairs of Hurwitz algebras. All 5 exceptional types arise from pairs involving 𝕆.",
-      "Exactly 4 Hurwitz algebras → exactly 5 exceptional Lie algebras: G₂←Der(𝕆), F₄←𝔏(𝕆,ℝ), E₆←𝔏(𝕆,ℂ), E₇←𝔏(𝕆,ℍ), E₈←𝔏(𝕆,𝕆). Octonions appear in all 5.",
-      "Physics connections: E₈×E₈ heterotic strings (dim 2×248=496, anomaly cancellation), M-theory on G₂ manifolds (4D N=1 SUSY), E₇(7) in N=8 supergravity.",
+      "G\u2082 = Aut(\ud835\udd46): The exceptional Lie group G\u2082 (dim 14, rank 2) is the automorphism group of the octonions. The 14 dimensions come from SO(7) (dim 21) minus the 7 constraints from preserving the octonion cross product.",
+      "Freudenthal-Tits Magic Square: \ud835\udd0f(A,B) = Der(A)\u2295(ImA\u2297ImB)\u2295Der(B) gives a symmetric Lie algebra from pairs of Hurwitz algebras. All 5 exceptional types arise from pairs involving \ud835\udd46.",
+      "Exactly 4 Hurwitz algebras \u2192 exactly 5 exceptional Lie algebras: G\u2082\u2190Der(\ud835\udd46), F\u2084\u2190\ud835\udd0f(\ud835\udd46,\u211d), E\u2086\u2190\ud835\udd0f(\ud835\udd46,\u2102), E\u2087\u2190\ud835\udd0f(\ud835\udd46,\u210d), E\u2088\u2190\ud835\udd0f(\ud835\udd46,\ud835\udd46). Octonions appear in all 5.",
+      "Physics connections: E\u2088\u00d7E\u2088 heterotic strings (dim 2\u00d7248=496, anomaly cancellation), M-theory on G\u2082 manifolds (4D N=1 SUSY), E\u2087(7) in N=8 supergravity.",
       "OctonionAlgHom structure defined in Lean: linear + multiplicative. Composition and identity proved. Norm-product preservation proved.",
-      "alg_aut_preserves_norm PROVED via phi_unit_eq_unit (invertibility gives φ(e₀)=e₀) + phi_imag_props (pure imaginary elements preserved) + decomposition a = r·e₀ + w.",
+      "alg_aut_preserves_norm PROVED via phi_unit_eq_unit (invertibility gives \u03c6(e\u2080)=e\u2080) + phi_imag_props (pure imaginary elements preserved) + decomposition a = r\u00b7e\u2080 + w.",
       "alg_aut_preserves_inner PROVED via polarization: innerProd x y = (normSq(x+y) - normSq x - normSq y)/2, with norm preservation + linearity.",
-      "imag_closed_under_aut: Aut(𝕆) ⊆ O(7) now formalized — automorphisms map Im(𝕆) to Im(𝕆) preserving the inner product.",
-      "eightMul unit proof pattern: simp(config:={decide:=true})[ite_true,ite_false] evaluates if (0:Fin 8)=j for concrete j. Plain simp[stdBasis] insufficient — need decide mode for Fin equality.",
+      "imag_closed_under_aut: Aut(\ud835\udd46) \u2286 O(7) now formalized \u2014 automorphisms map Im(\ud835\udd46) to Im(\ud835\udd46) preserving the inner product.",
+      "eightMul unit proof pattern: simp(config:={decide:=true})[ite_true,ite_false] evaluates if (0:Fin 8)=j for concrete j. Plain simp[stdBasis] insufficient \u2014 need decide mode for Fin equality.",
       "freudenthal_tits_f4/e6/e7/e8 de-axiomatized (2026-04-25): these 4 axioms were just ExceptionalType.dim = literal, provable by rfl. Axiom count reduced from 5 to 1.",
-      "G2_is_octonion_aut had type-theoretic flaw: Nat.card of an infinite group = 0 in Lean. Replaced with G2_der_dimension: finrank ℝ OctonionDerSubmodule = 14.",
-      "OctonionDerSubmodule as Submodule ℝ (LinearMap) inherits finite-dimensional vector space structure automatically.",
-      "The 64-entry kernel claim of derEval14_injective decomposes by basis index j: j = 0 case is closed by unit-kills (submodule_der_unit_zero); j ∈ {1,...,7} remains. Scoped sorry from 64 → 56 entries."
+      "G2_is_octonion_aut had type-theoretic flaw: Nat.card of an infinite group = 0 in Lean. Replaced with G2_der_dimension: finrank \u211d OctonionDerSubmodule = 14.",
+      "OctonionDerSubmodule as Submodule \u211d (LinearMap) inherits finite-dimensional vector space structure automatically.",
+      "The 64-entry kernel claim of derEval14_injective decomposes by basis index j: j = 0 case is closed by unit-kills (submodule_der_unit_zero); j \u2208 {1,...,7} remains. Scoped sorry from 64 \u2192 56 entries.",
+      "Diagonal kill verified by hand for i=1: Leibniz on (e_1, e_1) yields 0 = (-2 v_1, 2 v_0, 0,0,0,0,0,0) where v = f(e_1). The non-trivial pair-up is exactly the D(e_1)[0] and D(e_1)[1] components \u2014 meaning a single Leibniz identity gives BOTH the (already-known) real-part-zero and the diagonal kill at i=1.",
+      "Pattern conjecture: for any i \u2208 {1,...,7}, Leibniz on (e_i, e_i) plus eightMul e_i e_i = -stdBasis 0 (verified: only component 0 of e_i\u00b7e_i is non-zero, equal to -1 due to a_i\u00b7b_i = -1 in component 0) forces both f(e_i)[0] = 0 and f(e_i)[i] = 0; the other six components zero out by symmetry of the formula. This gives 14 (= 7\u00d72) more constraints from a single Leibniz application per imaginary basis vector.",
+      "BLOCKED on Mathlib API drift (2026-04-27): Docker build of HurwitzTheoremOQ04 fails with cascading errors at lines 88:98, 90:72, 100:98, 102:71, etc. \u2014 `ring` tactic now expects ring_nf, several simp goals timeout, kernel reports unknown constant `imag_sq_eq_neg_norm`. These errors predate any new edits. The file needs upstream repair before further sorry-elimination work; releasing claim per API drift policy."
     ],
     "mathlibGaps": [
-      "Lie groups not in Mathlib as of 2026-04 — blocks formal G₂ = Aut(𝕆) proof",
-      "Tits construction 𝔏(A,B) not in Mathlib — blocks magic square formalization",
+      "Lie groups not in Mathlib as of 2026-04 \u2014 blocks formal G\u2082 = Aut(\ud835\udd46) proof",
+      "Tits construction \ud835\udd0f(A,B) not in Mathlib \u2014 blocks magic square formalization",
       "Derivation algebra of non-associative algebras not in Mathlib"
     ],
     "nextSteps": [
-      "Prove diagonal-kill: eᵢ·D(eᵢ) + D(eᵢ)·eᵢ = 0 for i ≥ 1 from Leibniz on (eᵢ,eᵢ) using eᵢ² = -e₀ and submodule_der_unit_zero",
-      "Prove antisymmetry: D(eᵢ)[j] = -D(eⱼ)[i] from Leibniz on (eᵢ,eⱼ)+(eⱼ,eᵢ)",
-      "Use 14 ev=0 + diagonal + antisymmetry to derive D(eⱼ) = 0 for j ≥ 1 case-by-case"
+      "Prove diagonal-kill: e\u1d62\u00b7D(e\u1d62) + D(e\u1d62)\u00b7e\u1d62 = 0 for i \u2265 1 from Leibniz on (e\u1d62,e\u1d62) using e\u1d62\u00b2 = -e\u2080 and submodule_der_unit_zero",
+      "Prove antisymmetry: D(e\u1d62)[j] = -D(e\u2c7c)[i] from Leibniz on (e\u1d62,e\u2c7c)+(e\u2c7c,e\u1d62)",
+      "Use 14 ev=0 + diagonal + antisymmetry to derive D(e\u2c7c) = 0 for j \u2265 1 case-by-case",
+      "Concrete next coding step: introduce private lemma `submodule_der_diag_zero (f : ...) (hf : f \u2208 OctonionDerSubmodule) {i : Fin 8} (hi : i \u2260 0) : f (stdBasis i) i = 0` proved via fin_cases i + Leibniz hf (stdBasis i) (stdBasis i) + submodule_der_unit_zero. Each case unfolds eightMul into 16 explicit components and reads off the 2-equation system (component 0 and component i) giving f(stdBasis i) 0 = 0 and f(stdBasis i) i = 0.",
+      "Following diagonal_kill: introduce antisymmetry lemma `f (stdBasis i) j + f (stdBasis j) i = 0` for i,j \u2265 1 from Leibniz on (e_i, e_j) + (e_j, e_i). Combined with diagonal_kill and the 14 ev=0 entries, this should close most of the j \u2260 0 case in derEval14_injective."
     ]
   },
   "tags": [
@@ -93,7 +100,7 @@
     "mathlib": []
   },
   "started": "2026-04-22T13:03:46.381Z",
-  "lastUpdate": "2026-04-27T00:00:00Z",
+  "lastUpdate": "2026-04-27T00:00:00.000Z",
   "significance": 7,
   "tractability": 4,
   "leanFiles": [

--- a/src/data/research/problems/sperner-ndim-oq-04.json
+++ b/src/data/research/problems/sperner-ndim-oq-04.json
@@ -1,8 +1,8 @@
 {
   "slug": "sperner-ndim-oq-04",
   "title": "n-Dimensional Sperner: Kuhn Path-Following Algorithm Formalization",
-  "phase": "COMPLETED",
-  "status": "completed",
+  "phase": "ACT",
+  "status": "blocked",
   "tier": "A",
   "path": "full",
   "problemStatement": {
@@ -17,19 +17,21 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-04-22T13:03:46.382Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
-    "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "since": "2026-04-27T18:30:00.000Z",
+    "iteration": 9,
+    "focus": "BLOCKED on walkTrace_reversal — needs ~150 lines of kuhnWalkSeq infrastructure or SimpleGraph reformulation.",
+    "blockers": [
+      "kuhnPathStart forgets the walk path, only retains final simplex; closing the 1 sorry requires either a new kuhnWalkSeq function returning the full trace (List of (Simplex × entry × exit) triples) plus reversal lemmas, or formalizing the door graph as a Mathlib SimpleGraph and using SimpleGraph.Walk.reverse"
+    ],
+    "nextAction": "Future session: implement kuhnWalkSeq with reversal lemmas (~150 lines) OR define door graph as SimpleGraph and use Mathlib path machinery. Alternatively accept Session 7 axiom form (kuhn_path_existential as axiom).",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 9,
+      "currentApproach": 8,
+      "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: hMem+hNe proved (Session 31); 1 sorry remaining in hInv (walkTrace_reversal)",
+    "progressSummary": "BLOCKED (Session 9, 2026-04-27): hMem+hNe proved; 1 sorry remains in hInv (walkTrace_reversal). Closing the sorry requires either ~150 lines of new kuhnWalkSeq infrastructure (a List-returning walk variant with reversal lemmas) OR formalizing the door graph as a Mathlib SimpleGraph and using Walk.reverse. Past 8+ sessions hit the same barrier; flagged BLOCKED per memory's '3+ sessions on same sorry' rule. Stale 'completed' status corrected to 'blocked'.",
     "builtItems": [
       "doorDegree def: SpernerNDimOQ04.lean:60",
       "IsKuhnCompatible def: SpernerNDimOQ04.lean:65",
@@ -95,7 +97,9 @@
       "kuhnWalk_not_in_initial_visited: walk result never in initial visited set (proved by fuel induction)",
       "kuhnWalk_congr bridges proof-term mismatches after simp [dif_pos]: Prop fields are proof-irrelevant",
       "hMem (τ maps B→B) and hNe (τ FPF on B) are now fully proved in the Lean file",
-      "The hInv sorry is specifically walkTrace_reversal; the involution argument structure is now complete"
+      "The hInv sorry is specifically walkTrace_reversal; the involution argument structure is now complete",
+      "BLOCKED diagnosis (2026-04-27): closing the 1 remaining sorry needs structural infrastructure that no past session has built. kuhnPathStart only returns the final simplex; proving walk-reversal requires retaining the full walk sequence. Two unblock paths: (A) define kuhnWalkSeq returning a List of (Simplex × entry × exit) triples plus reversal lemmas (~150 lines), or (B) reformulate the door graph as a Mathlib SimpleGraph and use Walk.reverse (~200 lines).",
+      "Pool/gallery metadata divergence found: candidate-pool entry was 'phase: COMPLETED, status: completed' even though gallery meta.json correctly showed 'status: formalized' with 1 sorry. Future researchers should always cross-check pool entries against gallery meta.json before claiming."
     ],
     "mathlibGaps": [
       "No Mathlib theorem for path-following algorithm termination with non-revisiting invariant",


### PR DESCRIPTION
## Summary

Adds two axiom-free corollaries to AbelRuffiniOQ04OQ03.lean (Galois's Solvability Criterion) that capture Abel-Ruffini through a clean structural test on the Galois group, depending only on the forward direction (Mathlib-proved) and **not** on the axiomatized reverse direction.

## Progress

### Lean changes (165 → 242 lines, 0 sorries, 1 axiom unchanged)

**New axiom-free theorems:**

- `not_isSolvable_gal_of_perm_iso`:
  `Gal(q) ≃* Equiv.Perm (Fin n)` ∧ `n ≥ 5` → `¬ IsSolvable q.Gal`
  Proved via `solvable_of_surjective` and `Equiv.Perm.not_solvable`.

- `not_solvableByRad_of_perm_gal`:
  Same hypothesis with `q` irreducible and α a root of `q` →
  `¬ IsSolvableByRad F α`. Uses only the forward direction.

**Refactor:**

- `abel_ruffini_as_galois_special_case` no longer requires `[CharZero F]` — it only uses the forward direction, so the CharZero hypothesis was unnecessary scaffolding.

**Documentation:**

- The axiom `solvableGal_implies_solvableByRad` docstring now references `Mathlib.FieldTheory.KummerExtension` (`isCyclic_tfae`, `autEquivRootsOfUnity`, `autEquivZmod`) and pinpoints the missing piece: composing cyclic Kummer extensions into a radical tower from a solvable group's composition series.

## Findings

- Mathlib now provides the **cyclic** case of Kummer theory in `Mathlib.FieldTheory.KummerExtension`. The remaining gap for eliminating the axiom is the **assembly step** (composing those cyclic extensions across a composition series of a solvable group).
- For an irreducible quintic over ℚ with exactly two non-real roots, Mathlib's `Polynomial.Gal.galActionHom_bijective_of_prime_degree` produces the perm-iso required by `not_solvableByRad_of_perm_gal`, giving an axiom-free path to the classical Abel-Ruffini examples.

## Verification

Docker build succeeded: `✔ Built Proofs.AbelRuffiniOQ04OQ03 (34s, 3059 jobs)`.

## Status

**Outcome**: progress (axiom-free corollaries added)
**Sorries**: 0 (unchanged)
**Axioms**: 1 (unchanged — the genuinely deep Kummer-composition statement)
**Next Steps**: Optional Mathlib initiative to formalize Kummer composition (~500–1000 lines) would eliminate the remaining axiom.

🤖 Generated by researcher-3