### PR TITLE
research(erdos-935): document Mathlib v4.26 API drift, route to Mechanic

### DIFF
--- a/src/data/research/problems/erdos-935.json
+++ b/src/data/research/problems/erdos-935.json
@@ -16,12 +16,17 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "BLOCKED",
     "since": "2026-01-15T11:50:52.408Z",
     "iteration": 2,
-    "focus": "Initial exploration of the problem.",
-    "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "focus": "Build broken by Mathlib v4.26.0 API drift; needs Mechanic repair before further work.",
+    "blockers": [
+      "Mathlib v4.26.0 API drift: import 'Mathlib.Data.Rat.Basic' no longer exists (use Mathlib.Data.Rat.Defs).",
+      "powerfulPart_is_powerful: Finset.dvd_prod_of_mem dispatch fails — Finsupp.prod vs Finset.prod mismatch (need explicit Finsupp.prod unfold).",
+      "powerfulPart_mul: 'Finsupp.not_mem_support_iff' deprecated → 'Finsupp.notMem_support_iff' (warning, not blocker).",
+      "ErdosProblem935_part1: '(n : ℚ) ^ (2 + ε)' fails — no HPow ℚ ℚ ℚ instance. Needs ℝ + Real.rpow conversion."
+    ],
+    "nextAction": "Mechanic agent: repair file. Then resume research.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,7 +34,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: 4 theorems proved (powerfulPart_one, _dvd, _is_powerful, _mul), 0A, 0S. Fully constructive definition via Nat.factorization.",
+    "progressSummary": "BLOCKED (Mathlib v4.26 drift, 2026-04-27): Supporting infrastructure was complete (4 thms, 0A, 0S) as of original write, but file no longer compiles after Mathlib upgrade. Issues identified — see currentState.blockers for repair list.",
     "builtItems": [
       "Assessment: 5 of 6 axioms are for opaque powerfulPart — all eliminable by constructive def",
       "Proved powerfulPart_is_powerful: if p prime divides Q₂(n) then p² divides Q₂(n)",
@@ -41,12 +46,16 @@
       "5 axioms unused (powerfulPart properties + mahler_lower_bound) — removed (6→1A)",
       "powerfulPart_is_powerful proved via Prime.dvd_finsuppProd_iff witness decomposition",
       "powerfulPart_mul proved via Finsupp.support_add_eq + Finset.prod_union on disjoint coprime factorizations",
-      "Nat.support_factorization (rfl) bridges factorization.support and primeFactors seamlessly"
+      "Nat.support_factorization (rfl) bridges factorization.support and primeFactors seamlessly",
+      "2026-04-27 build attempt: file no longer compiles on Mathlib v4.26.0. Specific failures listed in currentState.blockers — most are mechanical fixes (import rename, deprecated lemma, Finsupp.prod unfold). Part 1's '(n:ℚ)^(2+ε:ℚ)' is the substantive issue — must convert to ℝ + Real.rpow."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Verify proofs compile with Docker build",
-      "Consider Aristotle companion file for any remaining sorries"
+      "Mechanic: fix import 'Mathlib.Data.Rat.Basic' → 'Mathlib.Data.Rat.Defs'.",
+      "Mechanic: fix Finset.dvd_prod_of_mem in powerfulPart_is_powerful (add Finsupp.prod unfold before simpa).",
+      "Mechanic: rename Finsupp.not_mem_support_iff → Finsupp.notMem_support_iff (2 occurrences in powerfulPart_mul).",
+      "Mechanic: convert ErdosProblem935_part1 to use ℝ and Real.rpow (import Mathlib.Analysis.SpecialFunctions.Pow.Real).",
+      "After repair: re-verify supporting lemmas, then continue researcher work on follow-up directions."
     ],
     "markdown": "# Erdős #935 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nFor any integer $n=\\prod p^{k_p}$ let $Q_2(n)$ be the powerful part of $n$, so that\\[Q_2(n) = \\prod_{\\substack{p\\\\ k_p\\geq 2}}p^{k_p}.\\]Is it true that, for every $\\epsilon>0$ and $\\ell\\geq 1$, if $n$ is sufficiently large then\\[Q_2(n(n+1)\\cdots(n+\\ell))<n^{2+\\epsilon}?\\]If $\\ell\\geq 2$ then is\\[\\limsup_{n\\to \\infty}\\frac{Q_2(n(n+1)\\cdots(n+\\ell))}{n^2}\\]infinite?\n\nIf $\\ell\\geq 2$ then is\\[\\lim_{n\\to \\infty}\\frac{Q_2(n(n+1)\\cdots(n+\\ell))}{n^{\\ell+1}}=0?\\]\n\n\n\nErd\\H{o}s \\cite{Er76d} writes that if this is true then it 'seems very difficult to prove'.\n\nA result of Mahler implies, for every $\\ell\\geq 1$,\\[\\limsup_{n\\to \\infty}\\frac{Q_2(n(n+1)\\cdots(n+\\ell))}{n^2}\\geq 1.\\]All these questions can be asked replacing $Q_2$ by $Q_r$ for $r>2$, only keeping those prime powers with exponent $\\geq r$.\n\n\n\n\nReferences\n\n\n[Er76d] Erd\\H{o}s, P., Problems and results on number theoretic properties of consecutive integers and related questions. Proceedings of the Fifth Manitoba Conference on Numerical Mathematics (Univ. Manitoba, Winnipeg, Man., 1975) (1976), 25-44.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #934\n- Problem #936\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er76d\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
@@ -64,7 +73,7 @@
     "mathlib": []
   },
   "started": "2026-01-15T11:50:52.409Z",
-  "lastUpdate": "2026-03-13T07:52:17.055Z",
+  "lastUpdate": "2026-04-27T17:00:00.000Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [


### PR DESCRIPTION
## Summary

`proofs/Proofs/Erdos935Problem.lean` no longer compiles on Mathlib v4.26.0. The original supporting infrastructure (4 theorems: `powerfulPart_one`, `_dvd`, `_is_powerful`, `_mul`; 0 axioms, 0 sorries) was correct when first written, but several Mathlib API changes have broken the build.

This PR is **metadata-only** — it does not touch the Lean file. Per CLAUDE.md and the researcher feedback memory, Mathlib API-drift repairs are not researcher work; the file is now flagged for the Mechanic.

## Build break details

Captured in `currentState.blockers` / `nextSteps` so the Mechanic has a concrete punch list:

- **Import broken**: `import Mathlib.Data.Rat.Basic` — that file no longer exists in v4.26. Use `Mathlib.Data.Rat.Defs` (or rely on `Mathlib.Tactic`).
- **`powerfulPart_is_powerful` (line ~98)**: `Finset.dvd_prod_of_mem` fails because the goal is a `Finsupp.prod`, not a `Finset.prod` directly. Need an explicit `simp only [Finsupp.prod]` before the `simpa`.
- **`powerfulPart_mul` (lines ~111, ~117)**: `Finsupp.not_mem_support_iff` is deprecated → `Finsupp.notMem_support_iff` (warning only, but should be cleaned).
- **`ErdosProblem935_part1` (line ~138)**: `(n : ℚ) ^ (2 + ε)` with `ε : ℚ` fails — there is no `HPow ℚ ℚ ℚ` instance. The substantive fix is to convert Part 1 (and arguably Part 3) to `ℝ` exponents using `Real.rpow` (`import Mathlib.Analysis.SpecialFunctions.Pow.Real`).

The first three are mechanical. The Part 1 fix is a small structural rewrite (change `ε : ℚ` → `ε : ℝ`, coerce `Q2consec` to `ℝ`).

## Changes

- `src/data/research/problems/erdos-935.json`:
  - `currentState.phase`: `ACT` → `BLOCKED`
  - `currentState.focus` / `nextAction`: reflect repair-pending state
  - `currentState.blockers`: lists the four build issues
  - `knowledge.progressSummary`: notes BLOCKED status with date
  - `knowledge.insights`: appends 2026-04-27 build attempt summary
  - `knowledge.nextSteps`: enumerates Mechanic repair tasks
  - `lastUpdate`: today

No Lean file touched. No claim should be made on this problem by another researcher until the Mechanic clears the blocker.

## Test plan

- [x] `python3 -c "import json; json.load(open(...))"` — JSON parses
- [x] Docker build of `Proofs.Erdos935Problem` confirmed broken on v4.26.0 (matches pattern from project_mathlib_api_drift_2026_04 memory note)
- [ ] Mechanic to repair, then re-claim for further research

🤖 Generated by researcher-6