### PR TITLE
audit(szemeredi-gowers): sync meta.json — file is sorry-free

### DIFF
--- a/src/data/proofs/szemeredi-hypergraph-core-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/szemeredi-hypergraph-core-oq-01-incomplete-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://arxiv.org/abs/math/0610762",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "tags": [
       "combinatorics",
       "szemeredi",
@@ -19,7 +19,7 @@
     ],
     "proofRepoPath": "Proofs/SzemerediHypergraphGowers.lean",
     "badge": "infrastructure",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Finset.inter_eq_left",
@@ -44,7 +44,7 @@
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
     "lineCount": 322,
-    "assumptions": "Infrastructure file: 1 sorry (naive_implies_gowers: bridging naive and Gowers regularity requires reformulation), 0 axioms. Provides definitions (SimplicialComplex, completeComplex, topCliques, relativeKDensity, IsGowersRegular, globalDensity) and supporting lemmas. The naive_implies_gowers theorem requires additional structural hypothesis on C'; the obstruction is documented in-file (Part VII).",
+    "assumptions": "Infrastructure file: 0 sorries, 0 axioms. Provides definitions (SimplicialComplex, completeComplex, topCliques, relativeKDensity, IsGowersRegular, globalDensity) and supporting lemmas. A previously-attempted naive_implies_gowers theorem was removed; the obstruction (sub-complex topCliques are not generally transversals of vertex sub-parts) is documented in-file (Part VII), and three provable surrogates are supplied instead (relativeKDensity_eq_of_topCliques_eq, isGowersRegular_self, isGowersRegular_empty).",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -109,7 +109,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Gowers hypergraph regularity infrastructure: 1 structure (SimplicialComplex), 6 definitions (completeComplex, IsSubComplex, topCliques, relativeKDensity, IsGowersRegular, globalDensity), and supporting proved theorems. 1 sorry (naive_implies_gowers, pending reformulation with structural hypothesis on C'), 0 axioms. The key consistency result relativeKDensity_completeComplex shows relative density w.r.t. the complete complex equals global density. The naive_implies_gowers theorem requires either partition-induced sub-complexes or a partition-respecting hypothesis; the obstruction is documented in Part VII of the file.",
+    "summary": "Gowers hypergraph regularity infrastructure: 1 structure (SimplicialComplex), 6 definitions (completeComplex, IsSubComplex, topCliques, relativeKDensity, IsGowersRegular, globalDensity), and 14 supporting proved theorems. 0 sorries, 0 axioms. The key consistency result relativeKDensity_completeComplex shows relative density w.r.t. the complete complex equals global density. A previously-attempted naive_implies_gowers theorem was removed in favor of three provable surrogates (relativeKDensity_eq_of_topCliques_eq, isGowersRegular_self, isGowersRegular_empty); the obstruction to a direct naive → Gowers reduction is documented in Part VII of the file.",
     "implications": "**Theoretical**: This infrastructure is the foundation for formalizing the hypergraph counting lemma (Nagle-Rödl-Schacht 2006) and the multidimensional Szemerédi theorem (Gowers 2007). The stratified SimplicialComplex design makes dimension-level conditions explicit, which is essential for the inductive structure of the counting lemma proof.\n\n**For the gallery**: The Gowers regularity infrastructure completes the theoretical framework started in SzemerediHypergraphCore.lean (naive regularity) and SzemerediHypergraphCoreOQ01.lean (flat simplicial complex). Together, these files provide a comprehensive formalization of hypergraph regularity foundations.",
     "openQuestions": [
       "Can a partition-respecting variant of naive regularity be defined that genuinely implies Gowers regularity?",
@@ -141,7 +141,7 @@
     "theoremCount": 14,
     "definitionCount": 6,
     "path": "Proofs/SzemerediHypergraphGowers.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "references": [
     {
@@ -166,5 +166,5 @@
       "note": "First regularity lemma for k-uniform hypergraphs"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Summary

The Lean file `proofs/Proofs/SzemerediHypergraphGowers.lean` on `main` has **0 sorries** and **0 axioms**, but `meta.json` still claims `sorries: 1` / `status: formalized`.

PR #13176 (ported in #13227) eliminated the only sorry by removing the attempted `naive_implies_gowers` theorem and replacing it with three provable surrogates (`relativeKDensity_eq_of_topCliques_eq`, `isGowersRegular_self`, `isGowersRegular_empty`); the obstruction is documented in Part VII of the file.

Two follow-up meta-fix PRs (#13231, #13241) inverted the correction and regressed the meta back to `sorries: 1 / status: formalized`. This PR restores the meta to match the actual Lean file.

### Changes
- `meta.sorries`, `leanFile.sorries`, top-level `sorries`: `1 → 0`
- `meta.status`: `formalized → verified`
- `meta.assumptions` and `conclusion.summary`: rewritten to reflect the 0-sorry state and the surrogate strategy

### Verification

Stripped block/line comments from the Lean file and counted `\bsorry\b`:

```
sorries: 0
axioms: 0
theorems: 14, definitions: 6, structures: 1
```

Surfaces from `find-targets.ts --issues` flagged `sorry mismatch: claims 1, actual 0`. After this PR, the target should resolve cleanly.

## Test plan

- [ ] CI passes
- [ ] `npx tsx scripts/auditor/find-targets.ts --issues` no longer lists `szemeredi-hypergraph-core-oq-01-incomplete-01`

🤖 Discovered during gallery integrity audit.