### PR TITLE
fix(meta): correct theoremCount for dissection-of-cubes-oq-04 (15→25)

### DIFF
--- a/src/data/proofs/dissection-of-cubes-oq-04/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-04/meta.json
@@ -24,7 +24,7 @@
     "axiomCount": 0,
     "assumptions": "0 axioms. The previously listed axiom tmul_infinite_order_ne_zero is now a proved theorem in DissectionOfCubesOQ02OQ02.lean (status: verified, axiomCount: 0). icoAngle_irrational (arccos(-√5/3)/π irrational) was proved via Chebyshev integer sequence for arccos(1/9). DissectionOfCubesOQ04.lean has 0 axiom declarations, 0 sorries, and only imports fully-proved theorems from its dependencies.",
     "lineCount": 557,
-    "theoremCount": 15,
+    "theoremCount": 25,
     "definitionCount": 4,
     "mathlibDependencies": [
       {
@@ -178,7 +178,7 @@
   "leanFile": {
     "path": "Proofs/DissectionOfCubesOQ04.lean",
     "lineCount": 557,
-    "theoremCount": 15,
+    "theoremCount": 25,
     "definitionCount": 4,
     "axiomCount": 0,
     "sorries": 0


### PR DESCRIPTION
## Fix

Corrects stale `theoremCount` in `dissection-of-cubes-oq-04/meta.json`.

## Evidence

**Before**: `meta.theoremCount: 15`, `leanFile.theoremCount: 15`
**After**: `meta.theoremCount: 25`, `leanFile.theoremCount: 25`

The Lean file `DissectionOfCubesOQ04.lean` (557 lines) contains 25 proved theorems and lemmas (verified by regex scan after comment stripping). The previous count of 15 reflected an earlier version of the file before 10 additional theorems were added:
- `icoSeq_zero`, `icoSeq_one`, `icoSeq_succ`, `three_ndvd_icoSeq` (icosahedron Chebyshev sequence)
- `icoSeq_eq_cos`, `cos_two_icoAngle`, `arccos_one_ninth_eq`
- `icoAngle_irrational`, `icoAngle_infinite_order`, `ico_dehn_ne_zero`

All counts (sorries=0, axiomCount=0, lineCount=557, definitionCount=4) remain correct.

---
Automated fix by lean-mechanic agent.