### PR TITLE
Research: pac-learning-bounds-oq-01 — VC dim of thresholds on ℕ = 1

### DIFF
--- a/proofs/Proofs/PACLearningOQ01.lean
+++ b/proofs/Proofs/PACLearningOQ01.lean
@@ -1,0 +1,94 @@
+/-
+  PAC Learning OQ-01: VC Dimension of Specific Hypothesis Classes
+
+  Concrete VC dimension calculations for tractable hypothesis classes,
+  advancing pac-learning-bounds-oq-01.
+
+  - Part I: Shatters definition (Set-based, matching standard formulation).
+  - Part II: Threshold classifiers on ℕ have VC dim ≥ 1 (shatter singletons).
+  - Part III: Threshold classifiers on ℕ do NOT shatter any pair (VC dim ≤ 1).
+  - Together: VC dim of thresholds on ℕ equals 1.
+
+  Vapnik-Chervonenkis (1971).
+-/
+import Mathlib
+
+namespace LearningTheory.VCDimension
+
+open Finset
+
+/-- A hypothesis class `H ⊆ Set α` shatters a finite set `S ⊆ α` if every
+    subset `T ⊆ S` can be realized as `h ∩ S` for some `h ∈ H`. -/
+def Shatters {α : Type*} (H : Set (Set α)) (S : Finset α) : Prop :=
+  ∀ T : Finset α, T ⊆ S → ∃ h ∈ H, ∀ x ∈ S, (x ∈ h ↔ x ∈ T)
+
+/-- Threshold classifiers on `ℕ`: `h_t = { x | x < t }`. -/
+def thresholdClassifiers : Set (Set ℕ) :=
+  { h | ∃ t : ℕ, h = { x | x < t } }
+
+/-- Thresholds shatter every singleton: pick `t = a + 1` to include `a`,
+    `t = 0` to exclude `a`. Hence VC dim of thresholds is at least 1. -/
+theorem threshold_shatters_singleton (a : ℕ) :
+    Shatters thresholdClassifiers ({a} : Finset ℕ) := by
+  intro T _
+  by_cases ha : a ∈ T
+  · -- Include a: use threshold a + 1.
+    refine ⟨{x | x < a + 1}, ⟨a + 1, rfl⟩, ?_⟩
+    intro x hx
+    rw [Finset.mem_singleton] at hx
+    subst hx
+    refine ⟨fun _ => ha, fun _ => ?_⟩
+    exact Nat.lt_succ_self x
+  · -- Exclude a: use threshold 0.
+    refine ⟨{x | x < 0}, ⟨0, rfl⟩, ?_⟩
+    intro x hx
+    rw [Finset.mem_singleton] at hx
+    subst hx
+    refine ⟨fun h => ?_, fun h => ?_⟩
+    · exact absurd h (Nat.not_lt_zero x)
+    · exact absurd h ha
+
+/-- Thresholds cannot shatter any 2-element set. Suppose `a < b`; the labeling
+    that selects only `b` (i.e. `T = {b}`) demands a threshold `t` with
+    `t ≤ a` (to exclude a) and `b < t` (to include b), contradicting `a < b`. -/
+theorem threshold_not_shatters_pair (a b : ℕ) (hab : a < b) :
+    ¬ Shatters thresholdClassifiers ({a, b} : Finset ℕ) := by
+  intro hShatter
+  -- The witness labeling: T = {b}.
+  have hSub : ({b} : Finset ℕ) ⊆ ({a, b} : Finset ℕ) := by
+    intro x hx
+    rw [Finset.mem_singleton] at hx
+    subst hx
+    simp
+  obtain ⟨h, ⟨t, ht⟩, hh⟩ := hShatter ({b} : Finset ℕ) hSub
+  subst ht
+  have ha_mem : a ∈ ({a, b} : Finset ℕ) := by simp
+  have hb_mem : b ∈ ({a, b} : Finset ℕ) := by simp
+  have ha := hh a ha_mem
+  have hb := hh b hb_mem
+  -- ha : a < t ↔ a ∈ {b}
+  -- hb : b < t ↔ b ∈ {b}
+  have ha' : ¬ (a < t) := by
+    intro h
+    have hmem : a ∈ ({b} : Finset ℕ) := ha.mp h
+    rw [Finset.mem_singleton] at hmem
+    omega
+  have hb' : b < t := hb.mpr (by simp)
+  omega
+
+/-- Combined: VC dim of threshold classifiers on `ℕ` is exactly 1
+    (no 2-element set is shattered, but every singleton is). -/
+theorem threshold_vcdim_bounds :
+    (∀ a : ℕ, Shatters thresholdClassifiers ({a} : Finset ℕ)) ∧
+    (∀ a b : ℕ, a ≠ b → ¬ Shatters thresholdClassifiers ({a, b} : Finset ℕ)) := by
+  refine ⟨threshold_shatters_singleton, ?_⟩
+  intro a b hab hShatter
+  rcases lt_or_gt_of_ne hab with hlt | hgt
+  · exact threshold_not_shatters_pair a b hlt hShatter
+  · -- {a, b} = {b, a}; reuse with arguments swapped.
+    have heq : ({a, b} : Finset ℕ) = ({b, a} : Finset ℕ) := by
+      ext x; simp [Or.comm]
+    rw [heq] at hShatter
+    exact threshold_not_shatters_pair b a hgt hShatter
+
+end LearningTheory.VCDimension

--- a/src/data/proofs/pac-learning-bounds-oq-01/annotations.json
+++ b/src/data/proofs/pac-learning-bounds-oq-01/annotations.json
@@ -1,0 +1,107 @@
+[
+  {
+    "id": "ann-shatters-def",
+    "proofId": "pac-learning-bounds-oq-01",
+    "range": {
+      "startLine": 22,
+      "endLine": 23
+    },
+    "type": "concept",
+    "title": "Shatters Predicate",
+    "content": "A hypothesis class $H \\subseteq \\mathcal{P}(\\alpha)$ shatters a finite set $S$ if every subset $T \\subseteq S$ is exactly $h \\cap S$ for some $h \\in H$. Equivalently, $H$ produces all $2^{|S|}$ possible labelings of $S$. We use a Finset-valued $T$ for cleaner reasoning over finite traces, and quantify over $T \\subseteq S$ via Finset subset.",
+    "mathContext": "$H$ shatters $S$ $\\iff$ $\\forall T \\subseteq S, \\exists h \\in H : \\forall x \\in S, (x \\in h \\iff x \\in T)$.",
+    "significance": "core",
+    "relatedConcepts": [
+      "VC dimension",
+      "growth function"
+    ],
+    "prerequisites": [
+      "Finite subsets",
+      "Set operations"
+    ]
+  },
+  {
+    "id": "ann-threshold-class",
+    "proofId": "pac-learning-bounds-oq-01",
+    "range": {
+      "startLine": 26,
+      "endLine": 27
+    },
+    "type": "concept",
+    "title": "Threshold Hypothesis Class",
+    "content": "$H_{thr} = \\{ \\{x : x < t\\} : t \\in \\mathbb{N} \\}$ — the family of half-lines below a threshold. Each hypothesis is parameterized by a single natural number $t$ and includes exactly the points strictly below $t$. This is the simplest nontrivial hypothesis class: monotone, ordered, and parameterized by one degree of freedom.",
+    "mathContext": "$h_t(x) = [\\![ x < t ]\\!]$, indicator of the half-line.",
+    "significance": "core",
+    "relatedConcepts": [
+      "monotone hypothesis class",
+      "concept class"
+    ],
+    "prerequisites": [
+      "Set comprehension"
+    ]
+  },
+  {
+    "id": "ann-singleton-shatters",
+    "proofId": "pac-learning-bounds-oq-01",
+    "range": {
+      "startLine": 31,
+      "endLine": 51
+    },
+    "type": "theorem",
+    "title": "Lower Bound: Singletons Are Shattered",
+    "content": "To shatter $\\{a\\}$ we must realize both labelings $\\emptyset$ and $\\{a\\}$. Two threshold witnesses suffice: $t = a + 1$ produces $h_t = \\{x : x < a + 1\\}$ which contains $a$, and $t = 0$ produces $h_t = \\{x : x < 0\\} = \\emptyset$ which excludes $a$. The proof case-splits on whether $a \\in T$ and supplies the appropriate $t$.",
+    "mathContext": "Witnesses: $t = a + 1$ for the labeling $T = \\{a\\}$; $t = 0$ for the labeling $T = \\emptyset$.",
+    "significance": "core",
+    "relatedConcepts": [
+      "case analysis",
+      "Finset.mem_singleton",
+      "Nat.lt_succ_self"
+    ],
+    "prerequisites": [
+      "Shatters definition",
+      "Threshold hypothesis class"
+    ]
+  },
+  {
+    "id": "ann-not-shatters-pair",
+    "proofId": "pac-learning-bounds-oq-01",
+    "range": {
+      "startLine": 54,
+      "endLine": 79
+    },
+    "type": "theorem",
+    "title": "Upper Bound: No Pair Is Shattered",
+    "content": "For $a < b$, consider the labeling $T = \\{b\\}$ (only $b$ included). If realized by $h_t$, then $a \\notin h_t$ forces $\\neg(a < t)$, i.e., $t \\leq a$. Simultaneously $b \\in h_t$ forces $b < t$. Combined: $b < t \\leq a$, contradicting $a < b$. The argument is purely order-theoretic: monotone classifiers cannot selectively include the larger of two ordered points without also including the smaller.",
+    "mathContext": "$T = \\{b\\}$ requires both $a \\notin h_t \\Rightarrow t \\leq a$ and $b \\in h_t \\Rightarrow b < t$, an impossibility under $a < b$.",
+    "significance": "core",
+    "relatedConcepts": [
+      "monotonicity obstruction",
+      "Finset.mem_singleton"
+    ],
+    "prerequisites": [
+      "Threshold hypothesis class",
+      "Linear order on ℕ"
+    ]
+  },
+  {
+    "id": "ann-vcdim-bounds",
+    "proofId": "pac-learning-bounds-oq-01",
+    "range": {
+      "startLine": 81,
+      "endLine": 93
+    },
+    "type": "concept",
+    "title": "Combined Bound: VC dim = 1",
+    "content": "Packaging the singleton lower bound and the pair upper bound: every singleton is shattered, and no two-point set is. The pair theorem is stated for $a < b$ and lifted to arbitrary distinct pairs via $\\{a, b\\} = \\{b, a\\}$ (Finset extensionality, `Or.comm`). Together these constraints pin VC dim of thresholds at exactly 1 — though we do not formally introduce a `vcDim` function here.",
+    "mathContext": "$\\operatorname{VCdim}(H_{thr}) = 1$.",
+    "significance": "core",
+    "relatedConcepts": [
+      "VC dimension definition",
+      "Finset extensionality"
+    ],
+    "prerequisites": [
+      "Lower bound theorem",
+      "Upper bound theorem"
+    ]
+  }
+]

--- a/src/data/proofs/pac-learning-bounds-oq-01/index.ts
+++ b/src/data/proofs/pac-learning-bounds-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/PACLearningOQ01.lean?raw'
+
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const pacLearningBoundsOq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const pacLearningBoundsOq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const pacLearningBoundsOq01Data: ProofData = {
+  proof: pacLearningBoundsOq01Proof,
+  annotations: pacLearningBoundsOq01Annotations,
+}

--- a/src/data/proofs/pac-learning-bounds-oq-01/meta.json
+++ b/src/data/proofs/pac-learning-bounds-oq-01/meta.json
@@ -1,0 +1,165 @@
+{
+  "id": "pac-learning-bounds-oq-01",
+  "title": "VC Dimension of Threshold Classifiers on ℕ",
+  "slug": "pac-learning-bounds-oq-01",
+  "description": "Concrete VC dimension calculation: threshold classifiers on ℕ have VC dimension exactly 1. Shows every singleton is shattered (lower bound) and no two-point set is shattered (upper bound). Direct contribution to pac-learning-bounds open question OQ-01: 'Can the VC dimension of specific hypothesis classes be computed in Lean?'",
+  "meta": {
+    "author": "Vapnik-Chervonenkis (1971), formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Vapnik%E2%80%93Chervonenkis_dimension",
+    "date": "1971",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PACLearningOQ01.lean",
+    "tags": [
+      "learning-theory",
+      "combinatorics",
+      "vc-dimension",
+      "cs-math-bridge"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "0 axioms, 0 sorries, 0 structure-encoded assumptions. The Shatters predicate and thresholdClassifiers family are concrete definitions over ℕ. All three theorems (singleton-shatters, pair-doesn't-shatter, combined bound) are fully proved using standard arithmetic and Finset reasoning.",
+    "dateAdded": "2026-04-27",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.mem_singleton",
+        "description": "Membership in a Finset singleton",
+        "module": "Mathlib.Data.Finset.Basic"
+      },
+      {
+        "theorem": "Nat.lt_succ_self",
+        "description": "n < n + 1 for natural numbers",
+        "module": "Mathlib.Data.Nat.Defs"
+      },
+      {
+        "theorem": "Nat.not_lt_zero",
+        "description": "No natural number is less than 0",
+        "module": "Mathlib.Data.Nat.Defs"
+      }
+    ],
+    "originalContributions": [
+      "Shatters: standard set-based shattering predicate (every subset T ⊆ S is realized as h ∩ S for some h ∈ H)",
+      "thresholdClassifiers: explicit family { x ↦ x < t : t ∈ ℕ }",
+      "threshold_shatters_singleton: every singleton {a} is shattered, witnessed by t = a+1 (include) or t = 0 (exclude)",
+      "threshold_not_shatters_pair: for a < b, the labeling T = {b} cannot be realized — would require t ≤ a (to exclude a) and t > b (to include b), contradicting a < b",
+      "threshold_vcdim_bounds: combines the two bounds — VC dim of thresholds is exactly 1"
+    ],
+    "prerequisites": [
+      "VC dimension and shattering",
+      "Basic Finset operations in Mathlib"
+    ],
+    "mathlib_version": "4.26.0",
+    "lineCount": 86,
+    "relatedProblems": [
+      {
+        "id": "pac-learning-bounds",
+        "relationship": "Answers a specific instance of OQ-01: computes VC dimension of a concrete hypothesis class"
+      }
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "pac-learning-bounds",
+      "relationship": "extends",
+      "description": "Concrete computation answering the parent's open question OQ-01 about VC dimension of specific hypothesis classes"
+    }
+  ],
+  "overview": {
+    "historicalContext": "The Vapnik-Chervonenkis (VC) dimension, introduced by Vapnik and Chervonenkis in 1971, measures the combinatorial richness of a hypothesis class by the size of the largest set it can shatter. Computing VC dimension for concrete classes is essential for applying PAC learning bounds: thresholds are the simplest nontrivial example.\n\nThe parent gallery entry pac-learning-bounds formalizes the Sauer-Shelah polynomial bound and lists as open question OQ-01 whether VC dimension can be computed in Lean for specific hypothesis classes. This entry answers that question for thresholds: the answer is yes, and the proof is short.",
+    "problemStatement": "Define the threshold hypothesis class on ℕ as $H_{thr} = \\{x \\mapsto x < t : t \\in \\mathbb{N}\\}$. Compute its VC dimension.\n\nShow:\n1. (Lower bound) Every singleton $\\{a\\}$ is shattered by $H_{thr}$.\n2. (Upper bound) No two-point set $\\{a, b\\}$ with $a \\neq b$ is shattered.\n\nTogether these establish $\\operatorname{VCdim}(H_{thr}) = 1$.",
+    "text": "Threshold classifiers on ℕ have VC dimension exactly 1. Verified in Lean 4 with three theorems (one definitional plus two bounds).",
+    "proofStrategy": "1. **Lower bound (singleton shattering):** Given any target labeling of $\\{a\\}$, we either include $a$ (use $t = a+1$, so $a < t$ holds) or exclude $a$ (use $t = 0$, so $a < 0$ fails). Both witnesses lie in $H_{thr}$.\n\n2. **Upper bound (no pair shattered):** Suppose $a < b$ and the labeling $T = \\{b\\}$ (only $b$ included) is realized by some $h_t \\in H_{thr}$. Then $a \\notin h_t$ forces $t \\leq a$, while $b \\in h_t$ forces $b < t$. Combined: $b < t \\leq a$, contradicting $a < b$.",
+    "keyInsights": [
+      "Thresholds are the simplest nontrivial hypothesis class: monotone in the parameter t. Their order-preserving structure both gives them shattering power on singletons and constrains them from shattering pairs.",
+      "The upper-bound argument is the standard 'monotonicity obstruction': if h_t treats a single point both ways, t can shift; but to selectively include only the larger of two points, t must straddle them, which the < ordering forbids.",
+      "Symmetry handling: the not-shatters-pair theorem is stated for a < b, then lifted to all distinct pairs using Finset extensionality (a, b ↦ b, a)."
+    ],
+    "prerequisites": [
+      "VC dimension and shattering",
+      "Basic Finset operations in Mathlib"
+    ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Definitions: Shatters and Threshold Classifiers",
+      "startLine": 17,
+      "endLine": 31,
+      "summary": "Sets up the standard set-based shattering predicate and defines the threshold hypothesis class on ℕ as { x ↦ x < t : t ∈ ℕ }.",
+      "mathContext": "$H$ shatters $S$ iff $\\forall T \\subseteq S, \\exists h \\in H : h \\cap S = T$."
+    },
+    {
+      "id": "lower-bound",
+      "title": "Singleton Shattering (VC dim ≥ 1)",
+      "startLine": 33,
+      "endLine": 51,
+      "summary": "Every singleton {a} is shattered by thresholds: t = a+1 includes a, t = 0 excludes a.",
+      "mathContext": "$\\forall a \\in \\mathbb{N}: H_{thr}$ shatters $\\{a\\}$."
+    },
+    {
+      "id": "upper-bound",
+      "title": "No Pair Shattered (VC dim ≤ 1)",
+      "startLine": 53,
+      "endLine": 76,
+      "summary": "For a < b, labeling T = {b} is unrealizable: would need t ≤ a (exclude a) and t > b (include b), contradicting a < b.",
+      "mathContext": "$\\forall a < b: \\neg H_{thr}$ shatters $\\{a, b\\}$."
+    },
+    {
+      "id": "combined",
+      "title": "Combined Bound (VC dim = 1)",
+      "startLine": 78,
+      "endLine": 86,
+      "summary": "Together: every singleton is shattered, and no two-point set is. Symmetric pairs handled via Finset extensionality.",
+      "mathContext": "$\\operatorname{VCdim}(H_{thr}) = 1$."
+    }
+  ],
+  "conclusion": {
+    "summary": "Threshold classifiers on ℕ have VC dimension exactly 1. The proof is short, uses only Finset and arithmetic from Mathlib, and demonstrates that concrete VC dimension computations (parent OQ-01) are tractable.",
+    "implications": "Provides a worked template for computing VC dimension of other simple hypothesis classes. Natural next steps: intervals on ℕ (VC dim = 2 via convexity obstruction), half-spaces in ℝ (VC dim = 2), axis-aligned rectangles in ℝ² (VC dim = 4). Each becomes a gallery entry advancing OQ-01.",
+    "openQuestions": [
+      "Compute VC dim of interval classifiers on ℕ (expected: 2). Would require a 'no triple shattered' lemma using interval convexity.",
+      "Compute VC dim of half-space classifiers on ℝᵈ (expected: d+1). Requires linear algebra and general position arguments.",
+      "Define vcDim as a Lean function (sup of cardinalities of shattered Finsets) and prove vcDim H_thr = 1 directly, not just via the two bounds."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Vapnik, V. N.; Chervonenkis, A. Ya.",
+      "title": "On the uniform convergence of relative frequencies of events to their probabilities",
+      "year": "1971",
+      "venue": "Theory of Probability and Its Applications, 16(2), 264–280",
+      "note": "Original definition of VC dimension."
+    },
+    {
+      "authors": "Shalev-Shwartz, Shai; Ben-David, Shai",
+      "title": "Understanding Machine Learning: From Theory to Algorithms",
+      "year": "2014",
+      "venue": "Cambridge University Press",
+      "note": "Chapter 6 discusses VC dimension of threshold and interval classifiers."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "threshold_vcdim_bounds",
+      "type": "core",
+      "description": "VC dimension of thresholds on ℕ equals 1: every singleton is shattered, and no two-point set is shattered.",
+      "leanType": "(∀ a, Shatters thresholdClassifiers {a}) ∧ (∀ a b, a ≠ b → ¬ Shatters thresholdClassifiers {a, b})"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "LearningTheory.VCDimension",
+    "lineCount": 86,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 2,
+    "path": "Proofs/PACLearningOQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/pac-learning-bounds-oq-01.json
+++ b/src/data/research/problems/pac-learning-bounds-oq-01.json
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "COMPLETED",
     "since": "2026-03-30T01:04:30.789Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "iteration": 2,
+    "focus": "VC dim of thresholds on ℕ formalized as VC dim = 1; gallery entry created",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Move to interval classifiers (oq-01 follow-up)",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,30 +29,26 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: VCDimension.lean restored and extended to 8 theorems, 0 sorries, 0 axioms. New: interval_not_shatters_triple proving VCDim(intervals)=2 via convexity argument. Gallery entry created.",
+    "progressSummary": "PROGRESS: VC dim of threshold classifiers on ℕ proved exactly = 1. Created Proofs/PACLearningOQ01.lean (3 theorems, 2 defs, 0 sorries, 0 axioms). Gallery entry created: src/data/proofs/pac-learning-bounds-oq-01/. Sets a working template for further VC-dim instance computations (intervals, half-spaces) toward parent OQ-01.",
     "builtItems": [
-      "VCDimension.lean: Shatters, vcDim, HypothesisClass, powerset, thresholdClassifiers, intervalClassifiers definitions",
-      "powerset_shatters: powerset shatters every finite set",
-      "threshold_shatters_singleton: threshold classifiers shatter singletons",
-      "threshold_not_shatters_pair: threshold classifiers cannot shatter pairs (key monotonicity argument)",
-      "interval_shatters_pair: interval classifiers shatter pairs via 4 explicit intervals",
-      "Gallery entry: src/data/proofs/pac-learning-bounds-oq-01/",
-      "VCDimension.lean restored and extended: interval_convex + interval_not_shatters_triple (new)",
-      "Gallery entry: src/data/proofs/pac-learning-bounds-oq-01/ with meta.json, index.ts, annotations.json"
+      "Proofs/PACLearningOQ01.lean: Shatters, thresholdClassifiers definitions",
+      "threshold_shatters_singleton: every {a} shattered (witnesses t=a+1, t=0)",
+      "threshold_not_shatters_pair: ∀ a<b, {a,b} not shattered (T={b} unrealizable)",
+      "threshold_vcdim_bounds: combined statement, VC dim of thresholds on ℕ = 1",
+      "Gallery entry: src/data/proofs/pac-learning-bounds-oq-01/{meta,annotations,index}"
     ],
     "insights": [
-      "Threshold monotonicity: {n<t} with b in implies a in when a<b, preventing {b} realization",
-      "Intervals break monotonicity: [b,b+1) contains b but excludes a<b",
-      "Powerset shatters trivially: use h=T for any T",
-      "Finset-based shattering is cleaner than Set-based for computational reasoning",
-      "Interval convexity is the key obstruction: if a,c in [lo,hi) with a<b<c, then b in [lo,hi)",
-      "VCDimension.lean was lost from main (commit cb629eaf69 on orphan branch) - restored and extended"
+      "Set-based Shatters predicate (∀ T ⊆ S, ∃ h ∈ H, ∀ x ∈ S, x ∈ h ↔ x ∈ T) compiles cleanly with Finset T",
+      "Order-theoretic obstruction for non-shattering: monotone classifier (x < t) cannot include only the larger of two ordered points",
+      "Symmetric pair handling: lift a<b case to all a≠b via {a,b} = {b,a} Finset extensionality + Or.comm",
+      "Set membership x ∈ {y | P y} = P x is definitional but rw doesn't apply through it; use ha.mp directly on the iff",
+      "Build of single Lean file via docker takes ~3 min after Mathlib cache hit"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove interval VCDim exactly 2 (triple non-shattering)",
-      "VCDim for halfspace classifiers in R^d (d+1)",
-      "Formalize Fundamental Theorem: finite VCDim iff PAC learnable"
+      "Compute VC dim of interval classifiers on ℕ (expected 2): need triple-shattering obstruction via convexity",
+      "Compute VC dim of half-spaces in ℝᵈ (expected d+1)",
+      "Define vcDim function (sup of cardinalities of shattered Finsets) and prove vcDim_thresholds = 1 directly"
     ]
   },
   "tags": [
@@ -63,7 +59,8 @@
     "seeker-selected"
   ],
   "relatedProofs": [
-    "pac-learning-bounds"
+    "pac-learning-bounds",
+    "pac-learning-bounds-oq-01"
   ],
   "references": {
     "papers": [],
@@ -71,7 +68,7 @@
     "mathlib": []
   },
   "started": "2026-03-30T01:04:30.789Z",
-  "lastUpdate": "2026-03-29T20:30:00Z",
+  "lastUpdate": "2026-04-27T16:30:00Z",
   "significance": 8,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary

Concrete VC dimension calculation answering a specific instance of the parent gallery's open question OQ-01: *"Can the VC dimension of specific hypothesis classes be computed in Lean?"*

Result: **VC dim of threshold classifiers on ℕ equals 1.**

## Files

- `proofs/Proofs/PACLearningOQ01.lean` (94 lines, 0 sorries, 0 axioms)
- `src/data/proofs/pac-learning-bounds-oq-01/{meta.json, annotations.json, index.ts}` (gallery entry)
- `src/data/research/problems/pac-learning-bounds-oq-01.json` (knowledge update)

## Theorems

| Theorem | Statement |
|---------|-----------|
| `threshold_shatters_singleton` | $\forall a, H_{thr}$ shatters $\{a\}$ |
| `threshold_not_shatters_pair` | $\forall a < b, \neg H_{thr}$ shatters $\{a, b\}$ |
| `threshold_vcdim_bounds` | combined bound — VC dim = 1 |

## Proof sketches

- **Lower bound:** $t = a+1$ realizes $\{a\}$, $t = 0$ realizes $\emptyset$.
- **Upper bound:** the labeling $T = \{b\}$ requires $t \leq a$ (exclude $a$) and $b < t$ (include $b$), contradicting $a < b$.
- **Symmetric pairs:** lift $a < b$ case to all distinct pairs via Finset extensionality.

## Verification

Built successfully via `./proofs/scripts/docker-build.sh Proofs.PACLearningOQ01` against Mathlib v4.26.0.

`pnpm annotations:build` succeeds with all 5 annotations validated against the Lean source.

## Notes

The prior pool metadata claimed a VCDimension.lean restoration that did not exist on any branch (referenced an orphan commit). This session creates the file fresh under a clean OQ-01-suffixed name (`PACLearningOQ01.lean`) and ties it to the parent problem via `crossReferences` in the gallery entry.

## Status

- **Outcome**: completed
- **Next steps**: extend to interval classifiers (VC dim 2 via convexity) and half-spaces in $\mathbb{R}^d$ (VC dim $d+1$); define `vcDim` as a Lean function.

## Test plan

- [x] Docker build succeeds for `Proofs.PACLearningOQ01`
- [x] `pnpm annotations:build` validates all annotations
- [ ] Gallery page renders correctly (manual verification)

🤖 Generated by researcher-9