### PR TITLE
Enrich algebraic-numbers-countable: Galois orbit keyInsight + 2 refs

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable/meta.json
@@ -2,7 +2,7 @@
   "id": "algebraic-numbers-countable",
   "title": "Countability of Algebraic Numbers",
   "slug": "algebraic-numbers-countable",
-  "description": "A formalization of Cantor's 1874 theorem that the algebraic numbers are countable. Proves countability and cardinality \u2135\u2080 for algebraic reals and complex numbers, stratification by minimal polynomial degree, the countable union decomposition, and cardinality equality between algebraic numbers and \u211a.",
+  "description": "A formalization of Cantor's 1874 theorem that the algebraic numbers are countable. Proves countability and cardinality ℵ₀ for algebraic reals and complex numbers, stratification by minimal polynomial degree, the countable union decomposition, and cardinality equality between algebraic numbers and ℚ.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-04",
@@ -65,41 +65,42 @@
       }
     ],
     "originalContributions": [
-      "algebraicRealsOfBoundedDegree and algebraicComplexOfBoundedDegree: sets of algebraic numbers with minimal polynomial degree \u2264 d",
+      "algebraicRealsOfBoundedDegree and algebraicComplexOfBoundedDegree: sets of algebraic numbers with minimal polynomial degree ≤ d",
       "algebraicRealsOfDegree and algebraicComplexOfDegree: stratification by exact minimal polynomial degree",
       "Countability of each degree stratum: algebraicRealsOfBoundedDegree_countable and algebraicRealsOfDegree_countable",
-      "Degree stratification decomposition: algebraic_reals_eq_iUnion_degree \u2014 algebraic reals as countable union of degree strata",
+      "Degree stratification decomposition: algebraic_reals_eq_iUnion_degree — algebraic reals as countable union of degree strata",
       "Alternative countability proof via degree stratification: algebraic_reals_countable_via_strata",
-      "Cardinality equality: card_algebraic_eq_card_rat shows algebraic numbers and \u211a have the same cardinality \u2135\u2080",
-      "Monotone chain: bounded_degree_monotone \u2014 the degree-bounded sets form an increasing filtration",
+      "Cardinality equality: card_algebraic_eq_card_rat shows algebraic numbers and ℚ have the same cardinality ℵ₀",
+      "Monotone chain: bounded_degree_monotone — the degree-bounded sets form an increasing filtration",
       "Exhaustive filtration: algebraic_reals_eq_iUnion_bounded"
     ]
   },
   "overview": {
-    "historicalContext": "Georg Cantor proved the countability of algebraic numbers in 1874, in his landmark paper '\u00dcber eine Eigenschaft des Inbegriffes aller reellen algebraischen Zahlen' (On a Property of the Collection of All Real Algebraic Numbers). This is the very same paper where he proved that the real numbers are uncountable \u2014 the first result of its kind, establishing that there are different 'sizes' of infinity.\n\nThe pair of results \u2014 algebraic numbers are countable (\u2135\u2080), real numbers are uncountable (2^\u2135\u2080) \u2014 had a profound philosophical consequence: almost all real numbers (in the sense of cardinality) are transcendental. Yet at the time Cantor wrote, only e (Hermite, 1873) was known to be transcendental. The existence of 'most' real numbers being transcendental was established before any systematic method for identifying them.\n\nCantor's original proof used an elegant 'height' function for polynomials: h(a\u2080 + a\u2081x + ... + a\u2099x\u207f) = n + |a\u2080| + |a\u2081| + ... + |a\u2099| (total of degree and absolute values of coefficients). For each height H, there are finitely many polynomials, each with finitely many roots. Ordering by height and enumerating roots within each height gives a bijection to \u2115.\n\nThe modern proof uses the equivalent degree stratification: for each degree d, there are countably many polynomials over \u211a of degree d (since \u211a^{d+1} is countable), each with at most d roots. The union over all d \u2208 \u2115 is countable by the countable union of countable sets theorem.",
-    "problemStatement": "An **algebraic number** (over \u211a) is a complex number that is a root of some nonzero polynomial with rational coefficients. The **degree** of an algebraic number is the degree of its minimal polynomial over \u211a.\n\n**Theorem** (Cantor, 1874): The set of algebraic real numbers {x \u2208 \u211d | IsAlgebraic \u211a x} is countable and has cardinality \u2135\u2080.\n\nThe formalization also proves: (1) countability of algebraic complex numbers, (2) countability of each degree stratum separately, (3) cardinality equality |algebraic reals| = |\u211a| = \u2135\u2080 despite algebraic \u228b \u211a.",
+    "historicalContext": "Georg Cantor proved the countability of algebraic numbers in 1874, in his landmark paper 'Über eine Eigenschaft des Inbegriffes aller reellen algebraischen Zahlen' (On a Property of the Collection of All Real Algebraic Numbers). This is the very same paper where he proved that the real numbers are uncountable — the first result of its kind, establishing that there are different 'sizes' of infinity.\n\nThe pair of results — algebraic numbers are countable (ℵ₀), real numbers are uncountable (2^ℵ₀) — had a profound philosophical consequence: almost all real numbers (in the sense of cardinality) are transcendental. Yet at the time Cantor wrote, only e (Hermite, 1873) was known to be transcendental. The existence of 'most' real numbers being transcendental was established before any systematic method for identifying them.\n\nCantor's original proof used an elegant 'height' function for polynomials: h(a₀ + a₁x + ... + aₙxⁿ) = n + |a₀| + |a₁| + ... + |aₙ| (total of degree and absolute values of coefficients). For each height H, there are finitely many polynomials, each with finitely many roots. Ordering by height and enumerating roots within each height gives a bijection to ℕ.\n\nThe modern proof uses the equivalent degree stratification: for each degree d, there are countably many polynomials over ℚ of degree d (since ℚ^{d+1} is countable), each with at most d roots. The union over all d ∈ ℕ is countable by the countable union of countable sets theorem.",
+    "problemStatement": "An **algebraic number** (over ℚ) is a complex number that is a root of some nonzero polynomial with rational coefficients. The **degree** of an algebraic number is the degree of its minimal polynomial over ℚ.\n\n**Theorem** (Cantor, 1874): The set of algebraic real numbers {x ∈ ℝ | IsAlgebraic ℚ x} is countable and has cardinality ℵ₀.\n\nThe formalization also proves: (1) countability of algebraic complex numbers, (2) countability of each degree stratum separately, (3) cardinality equality |algebraic reals| = |ℚ| = ℵ₀ despite algebraic ⊋ ℚ.",
     "text": "A 254-line formalization of Cantor's 1874 countability theorem for algebraic numbers, comprising 18 theorems and 4 definitions with zero sorries and zero axioms. The core results delegate to Mathlib: `algebraic_reals_countable` applies `Algebraic.countable` in one line, and `card_algebraic_reals_eq_aleph0` applies `cardinalMk_of_countable_of_charZero` for the exact cardinality $\\aleph_0$. The original contributions build a degree stratification: `algebraicRealsOfBoundedDegree d` (degree $\\leq d$) and `algebraicRealsOfDegree d` (degree $= d$) define two nested families, each proved countable via `Set.Countable.mono`. The decomposition `algebraic_reals_eq_iUnion_degree` writes $\\{x \\in \\mathbb{R} \\mid \\text{IsAlgebraic}\\,\\mathbb{Q}\\,x\\} = \\bigcup_d \\text{algebraicRealsOfDegree}\\,d$, and `algebraic_reals_countable_via_strata` applies `Set.countable_iUnion` to give an alternative proof. Structural results include `rat_algebraic_degree_one` (rationals embed as degree-1 via `isAlgebraic_algebraMap`), `bounded_degree_monotone` (filtration $B_0 \\subseteq B_1 \\subseteq \\cdots$), and `card_algebraic_eq_card_rat` ($|\\text{algebraic reals}| = |\\mathbb{Q}|$, both $\\aleph_0$).",
-    "proofStrategy": "The formalization proceeds in two ways:\n\n1. **Direct (Mathlib delegation)**: Apply `Algebraic.countable \u211a \u211d` \u2014 Mathlib proves that algebraic elements over any countable commutative ring form a countable set. Since \u211a is countable (it is `Denumerable`, meaning it has a bijection with \u2115), this gives algebraic_reals_countable in one line. The cardinality \u2135\u2080 follows from `Algebraic.cardinalMk_of_countable_of_charZero \u211a \u211d`.\n\n2. **Via degree stratification (original)**: Define `algebraicRealsOfDegree d = {x | IsAlgebraic \u211a x \u2227 natDegree(minpoly \u211a x) = d}`. Each stratum is a subset of all algebraic numbers (which are countable), so it is countable. Use `algebraic_reals_eq_iUnion_degree` to write the algebraic numbers as \u22c3 d, algebraicRealsOfDegree d, and `Set.countable_iUnion algebraicRealsOfDegree_countable` (countable union of countable sets) to conclude.\n\nThe stratification also provides two nested structures: `algebraicRealsOfBoundedDegree d = {x | IsAlgebraic \u211a x \u2227 natDegree \u2264 d}` (inclusive up to d) and `algebraicRealsOfDegree d` (exactly d). These form a filtration: algebraicRealsOfBoundedDegree d \u2286 algebraicRealsOfBoundedDegree (d+1) and \u22c3 algebraicRealsOfBoundedDegree d = all algebraic numbers.",
+    "proofStrategy": "The formalization proceeds in two ways:\n\n1. **Direct (Mathlib delegation)**: Apply `Algebraic.countable ℚ ℝ` — Mathlib proves that algebraic elements over any countable commutative ring form a countable set. Since ℚ is countable (it is `Denumerable`, meaning it has a bijection with ℕ), this gives algebraic_reals_countable in one line. The cardinality ℵ₀ follows from `Algebraic.cardinalMk_of_countable_of_charZero ℚ ℝ`.\n\n2. **Via degree stratification (original)**: Define `algebraicRealsOfDegree d = {x | IsAlgebraic ℚ x ∧ natDegree(minpoly ℚ x) = d}`. Each stratum is a subset of all algebraic numbers (which are countable), so it is countable. Use `algebraic_reals_eq_iUnion_degree` to write the algebraic numbers as ⋃ d, algebraicRealsOfDegree d, and `Set.countable_iUnion algebraicRealsOfDegree_countable` (countable union of countable sets) to conclude.\n\nThe stratification also provides two nested structures: `algebraicRealsOfBoundedDegree d = {x | IsAlgebraic ℚ x ∧ natDegree ≤ d}` (inclusive up to d) and `algebraicRealsOfDegree d` (exactly d). These form a filtration: algebraicRealsOfBoundedDegree d ⊆ algebraicRealsOfBoundedDegree (d+1) and ⋃ algebraicRealsOfBoundedDegree d = all algebraic numbers.",
     "keyInsights": [
-      "The degree stratification reveals the internal structure: algebraic numbers are a countable union of countable layers, each determined by minimal polynomial degree. The full set decomposes as \u22c3_{d\u2208\u2115} {x | IsAlgebraic \u211a x \u2227 natDegree(minpoly \u211a x) = d}, and Set.countable_iUnion applies since each layer is a subset of all algebraic numbers.",
-      "Despite algebraic numbers forming a proper superset of \u211a (they include \u221a2, \u221b3, (1+\u221a5)/2, and uncountably many algebraic irrationals), both sets have the same cardinality \u2135\u2080. This is formalized as: Cardinal.mk {x : \u211d // IsAlgebraic \u211a x} = Cardinal.mk \u211a, proved by both equaling aleph0 via Mathlib's cardinalMk_of_countable_of_charZero and mk_denumerable.",
-      "The bounded-degree sets form a monotone filtration: algebraicRealsOfBoundedDegree d \u2286 algebraicRealsOfBoundedDegree (d+1) (by Nat.le_succ_of_le), and their union equals all algebraic numbers. This is the Lean analogue of Cantor's 'height' ordering \u2014 controlling complexity by bounding the degree.",
-      "The complement \u2014 transcendental reals \u2014 is uncountable: \u211d is uncountable (Cantor's 1874 diagonal argument) while algebraic reals are countable, so the set difference is uncountable. 'Almost all' real numbers (in the sense of cardinality) are transcendental, even though constructing specific transcendentals is hard.",
-      "Degree 1 = \u211a via algebraMap: rationals embed as algebraic reals of degree 1 by `isAlgebraic_algebraMap`. The minimal polynomial of q \u2208 \u211a over \u211a is X \u2212 q (linear), so natDegree = 1. This proves the bottom stratum algebraicRealsOfDegree 1 \u2287 image(\u211a \u2192 \u211d), connecting the stratification to the well-known denumerability of \u211a.",
-      "Cantor's 1874 argument is non-constructive: it shows transcendentals exist by cardinality without exhibiting any. Liouville (1844) used a complementary constructive approach: numbers that are 'too well approximated' by rationals (e.g., \u03a3 10^{-k!}) cannot be algebraic, because algebraic numbers satisfy algebraic approximation bounds. These are dual perspectives \u2014 set-cardinality vs. Diophantine approximation \u2014 and the Lean formalization takes Cantor's route via Mathlib's Algebraic.countable, bypassing the constructive theory.",
-      "The algebraic numbers form an algebraically closed field (\u211a\u0305, the algebraic closure of \u211a) but are NOT metrically complete: Cauchy sequences of algebraic numbers can converge to transcendentals. Conversely, \u211d is metrically complete but not algebraically closed (no square root of \u22121). This algebraic-closure vs. metric-completion duality explains why \u2102 = algebraic closure of \u211d is needed to get both properties simultaneously, and why the 'natural' number systems form a strict hierarchy: \u211a \u2282 \u211a\u0305 \u2229 \u211d \u2282 \u211d \u2282 \u2102 = \u211a\u0305."
+      "The degree stratification reveals the internal structure: algebraic numbers are a countable union of countable layers, each determined by minimal polynomial degree. The full set decomposes as ⋃_{d∈ℕ} {x | IsAlgebraic ℚ x ∧ natDegree(minpoly ℚ x) = d}, and Set.countable_iUnion applies since each layer is a subset of all algebraic numbers.",
+      "Despite algebraic numbers forming a proper superset of ℚ (they include √2, ∛3, (1+√5)/2, and uncountably many algebraic irrationals), both sets have the same cardinality ℵ₀. This is formalized as: Cardinal.mk {x : ℝ // IsAlgebraic ℚ x} = Cardinal.mk ℚ, proved by both equaling aleph0 via Mathlib's cardinalMk_of_countable_of_charZero and mk_denumerable.",
+      "The bounded-degree sets form a monotone filtration: algebraicRealsOfBoundedDegree d ⊆ algebraicRealsOfBoundedDegree (d+1) (by Nat.le_succ_of_le), and their union equals all algebraic numbers. This is the Lean analogue of Cantor's 'height' ordering — controlling complexity by bounding the degree.",
+      "The complement — transcendental reals — is uncountable: ℝ is uncountable (Cantor's 1874 diagonal argument) while algebraic reals are countable, so the set difference is uncountable. 'Almost all' real numbers (in the sense of cardinality) are transcendental, even though constructing specific transcendentals is hard.",
+      "Degree 1 = ℚ via algebraMap: rationals embed as algebraic reals of degree 1 by `isAlgebraic_algebraMap`. The minimal polynomial of q ∈ ℚ over ℚ is X − q (linear), so natDegree = 1. This proves the bottom stratum algebraicRealsOfDegree 1 ⊇ image(ℚ → ℝ), connecting the stratification to the well-known denumerability of ℚ.",
+      "Cantor's 1874 argument is non-constructive: it shows transcendentals exist by cardinality without exhibiting any. Liouville (1844) used a complementary constructive approach: numbers that are 'too well approximated' by rationals (e.g., Σ 10^{-k!}) cannot be algebraic, because algebraic numbers satisfy algebraic approximation bounds. These are dual perspectives — set-cardinality vs. Diophantine approximation — and the Lean formalization takes Cantor's route via Mathlib's Algebraic.countable, bypassing the constructive theory.",
+      "The algebraic numbers form an algebraically closed field (ℚ̅, the algebraic closure of ℚ) but are NOT metrically complete: Cauchy sequences of algebraic numbers can converge to transcendentals. Conversely, ℝ is metrically complete but not algebraically closed (no square root of −1). This algebraic-closure vs. metric-completion duality explains why ℂ = algebraic closure of ℝ is needed to get both properties simultaneously, and why the 'natural' number systems form a strict hierarchy: ℚ ⊂ ℚ̅ ∩ ℝ ⊂ ℝ ⊂ ℂ = ℚ̅.",
+      "The countable set of algebraic numbers is not just a set but a $\\text{Gal}(\\overline{\\mathbb{Q}}/\\mathbb{Q})$-set: the absolute Galois group of $\\mathbb{Q}$ acts on $\\overline{\\mathbb{Q}}$ by field automorphisms, and the orbits are precisely the sets of conjugates (roots of the same minimal polynomial). Within each degree-$d$ stratum $\\text{alg}_d(\\mathbb{C})$, the action partitions the stratum into Galois orbits each of size dividing $d!$ (the order of $S_d$, the maximal Galois group of an irreducible degree-$d$ polynomial). The countability of algebraic numbers thus refines to a finer count: $|\\overline{\\mathbb{Q}}| = \\aleph_0 = \\sum_{d \\geq 1} (\\text{number of monic irreducible degree-}d\\text{ polynomials over }\\mathbb{Q}) \\cdot d$. The absolute Galois group $\\text{Gal}(\\overline{\\mathbb{Q}}/\\mathbb{Q})$ itself, by contrast, has cardinality $2^{\\aleph_0}$ (uncountable, profinite topology) — so the action is by an enormous group on a countable set, with each orbit of finite size."
     ],
     "prerequisites": [
-      "Set theory (countability, cardinality, \u2135\u2080)",
+      "Set theory (countability, cardinality, ℵ₀)",
       "Algebra (minimal polynomials, field extensions)",
       "Cardinal arithmetic in Lean 4 / Mathlib"
     ]
   },
   "conclusion": {
-    "summary": "This formalization verifies Cantor's 1874 theorem that algebraic numbers form a countable set with cardinality \u2135\u2080, matching that of \u211a. The degree stratification provides additional structural insight: the algebraic numbers decompose as a countable union of countable strata, each indexed by minimal polynomial degree.",
+    "summary": "This formalization verifies Cantor's 1874 theorem that algebraic numbers form a countable set with cardinality ℵ₀, matching that of ℚ. The degree stratification provides additional structural insight: the algebraic numbers decompose as a countable union of countable strata, each indexed by minimal polynomial degree.",
     "implications": "The countability of algebraic numbers directly implies that almost all real numbers (in the sense of cardinality) are transcendental. This is Cantor's original motivation: transcendental numbers exist and are, in a precise sense, the 'typical' real number. The result also underpins the theory of transcendence: to show a number is transcendental, it suffices to show it is not algebraic.",
     "openQuestions": [
-      "**[Addressed in `hermite-lindemann`]** Formalize the Lindemann-Weierstrass theorem: if $\\alpha_1, \\ldots, \\alpha_n$ are distinct algebraic numbers, then $e^{\\alpha_1}, \\ldots, e^{\\alpha_n}$ are linearly independent over $\\mathbb{Q}$. This implies both $e$ and $\\pi$ are transcendental \u2014 Hermite (1873) proved $e$, Lindemann (1882) proved $\\pi$ using the same method.",
+      "**[Addressed in `hermite-lindemann`]** Formalize the Lindemann-Weierstrass theorem: if $\\alpha_1, \\ldots, \\alpha_n$ are distinct algebraic numbers, then $e^{\\alpha_1}, \\ldots, e^{\\alpha_n}$ are linearly independent over $\\mathbb{Q}$. This implies both $e$ and $\\pi$ are transcendental — Hermite (1873) proved $e$, Lindemann (1882) proved $\\pi$ using the same method.",
       "**[Addressed in `algebraic-numbers-countable-oq-02`]** Prove in Lean 4 that $\\mathbb{R}$ is uncountable, completing the 1874 paper. The companion entry `algebraic-numbers-countable-oq-02` formalizes the diagonal argument ($|\\mathbb{R}| = 2^{\\aleph_0} > \\aleph_0$); `algebraic-numbers-countable-oq-02-oq-02` provides Cantor's original nested intervals proof from the same paper.",
       "**[Addressed in `gelfond-schneider`]** Formalize the Gelfond-Schneider theorem: if $\\alpha$ is algebraic ($\\alpha \\neq 0, 1$) and $\\beta$ is irrational algebraic, then $\\alpha^\\beta$ is transcendental. This implies $2^{\\sqrt{2}}$ is transcendental (Hilbert's seventh problem, solved 1934). The companion entry `gelfond-schneider` formalizes this result, proving $2^{\\sqrt{2}}$ is transcendental as a direct application.",
       "Formalize Baker's theorem (1966): if $\\log \\alpha_1, \\ldots, \\log \\alpha_n$ are linearly independent over $\\mathbb{Q}$ for nonzero algebraic $\\alpha_i$, then they are linearly independent over $\\overline{\\mathbb{Q}}$. Baker's theorem is the most powerful tool in transcendence theory, implying effective lower bounds for linear forms in logarithms.",
@@ -112,55 +113,55 @@
       "title": "Header: Module Documentation, Degree Examples, and Historical Context",
       "startLine": 1,
       "endLine": 68,
-      "description": "Module header explaining the 6 key results (algebraic reals/complex countable, bounded degree countable, cardinality \u2135\u2080, exact degree countable, degree stratification). Three proof approach sections: Foundation (Mathlib's Algebraic.countable and cardinalMk), Original Contributions (degree stratification), Proof Techniques. Mathematical background defining algebraic numbers and degree, with examples by degree (degree 1: rationals; degree 2: \u221a2, (1+\u221a5)/2; degree 3: \u221b2; degree n: roots of irreducible n-polys). Historical note on Cantor 1874. Connection to denumerability of \u211a: all these sets (\u211a, degree \u2264 d, all algebraic) have cardinality \u2135\u2080. Opens namespace AlgebraicNumbersCountable.",
+      "description": "Module header explaining the 6 key results (algebraic reals/complex countable, bounded degree countable, cardinality ℵ₀, exact degree countable, degree stratification). Three proof approach sections: Foundation (Mathlib's Algebraic.countable and cardinalMk), Original Contributions (degree stratification), Proof Techniques. Mathematical background defining algebraic numbers and degree, with examples by degree (degree 1: rationals; degree 2: √2, (1+√5)/2; degree 3: ∛2; degree n: roots of irreducible n-polys). Historical note on Cantor 1874. Connection to denumerability of ℚ: all these sets (ℚ, degree ≤ d, all algebraic) have cardinality ℵ₀. Opens namespace AlgebraicNumbersCountable.",
       "mathContext": "Cantor's 1874 height function: $H(a_0 + a_1 x + \\cdots + a_n x^n) = n + |a_0| + |a_1| + \\cdots + |a_n|$ orders integer polynomials by total complexity. For each height $H$, there are finitely many polynomials (since the coefficient sum is bounded) each with $\\leq H$ roots, giving a well-defined enumeration $\\mathbb{N} \\to \\overline{\\mathbb{Q}} \\cap \\mathbb{R}$. The modern Lean proof uses the equivalent degree stratification via Mathlib's $\\texttt{Algebraic.countable}$, bypassing explicit bijection in favor of abstract countability. The examples by degree illustrate the size of each stratum: degree 2 already contains infinitely many numbers ($\\sqrt{2}, \\sqrt{3}, \\sqrt{5}, (1+\\sqrt{5})/2, \\ldots$) yet the union over all degrees is still only $\\aleph_0$."
     },
     {
       "id": "sec-algebraic-core",
-      "title": "\u00a71. Core Countability and Cardinality Results",
+      "title": "§1. Core Countability and Cardinality Results",
       "startLine": 72,
       "endLine": 101,
-      "description": "Four one-line theorems delegating to Mathlib: `algebraic_reals_countable` (Algebraic.countable \u211a \u211d), `algebraic_complex_countable` (Algebraic.countable \u211a \u2102), `card_algebraic_reals_eq_aleph0` (cardinalMk_of_countable_of_charZero \u211a \u211d), `card_algebraic_complex_eq_aleph0` (cardinalMk_of_countable_of_charZero \u211a \u2102). The cardinality results are strictly stronger than countability: they prove |algebraic reals| = \u2135\u2080 (countably infinite), ruling out finite algebraic number sets. The char_zero condition on \u211d and \u2102 ensures the field is of characteristic 0, needed for Mathlib's API.",
+      "description": "Four one-line theorems delegating to Mathlib: `algebraic_reals_countable` (Algebraic.countable ℚ ℝ), `algebraic_complex_countable` (Algebraic.countable ℚ ℂ), `card_algebraic_reals_eq_aleph0` (cardinalMk_of_countable_of_charZero ℚ ℝ), `card_algebraic_complex_eq_aleph0` (cardinalMk_of_countable_of_charZero ℚ ℂ). The cardinality results are strictly stronger than countability: they prove |algebraic reals| = ℵ₀ (countably infinite), ruling out finite algebraic number sets. The char_zero condition on ℝ and ℂ ensures the field is of characteristic 0, needed for Mathlib's API.",
       "mathContext": "$\\texttt{Algebraic.countable}\\ \\mathbb{Q}\\ \\mathbb{R}$: Mathlib's general theorem that algebraic elements over a countable commutative ring form a countable set. Here $\\mathbb{Q}$ is $\\texttt{Denumerable}$ — has an explicit bijection with $\\mathbb{N}$ — which makes it countable as a ring. $\\texttt{cardinalMk\\_of\\_countable\\_of\\_charZero}\\ \\mathbb{Q}\\ \\mathbb{R}$: strengthens countable to the exact cardinality $\\aleph_0$ (ruling out finite algebraic sets). The $\\texttt{CharZero}$ typeclass on $\\mathbb{R}$ and $\\mathbb{C}$ ensures $\\operatorname{char}(\\mathbb{R}) = 0$, preventing pathological behavior in the cardinality computation (e.g., finite fields in characteristic $p$ have finite algebraic closures)."
     },
     {
       "id": "sec-algebraic-bounded",
-      "title": "\u00a72. Algebraic Numbers of Bounded Degree",
+      "title": "§2. Algebraic Numbers of Bounded Degree",
       "startLine": 103,
       "endLine": 135,
-      "description": "Defines `algebraicRealsOfBoundedDegree d` = {x : \u211d | IsAlgebraic \u211a x \u2227 (minpoly \u211a x).natDegree \u2264 d} and `algebraicComplexOfBoundedDegree d` (analogous for \u2102). Both are noncomputable (because minpoly is noncomputable). Proves `bounded_degree_subset_algebraic_reals`: the bounded-degree set \u2286 all algebraic numbers (fun _ hx => hx.1 extracts the IsAlgebraic component from the conjunction). Proves countability of both sets via Set.Countable.mono \u2014 subsets of countable sets are countable.",
+      "description": "Defines `algebraicRealsOfBoundedDegree d` = {x : ℝ | IsAlgebraic ℚ x ∧ (minpoly ℚ x).natDegree ≤ d} and `algebraicComplexOfBoundedDegree d` (analogous for ℂ). Both are noncomputable (because minpoly is noncomputable). Proves `bounded_degree_subset_algebraic_reals`: the bounded-degree set ⊆ all algebraic numbers (fun _ hx => hx.1 extracts the IsAlgebraic component from the conjunction). Proves countability of both sets via Set.Countable.mono — subsets of countable sets are countable.",
       "mathContext": "$\\texttt{algebraicRealsOfBoundedDegree}\\ d = \\{x : \\mathbb{R} \\mid \\texttt{IsAlgebraic}\\ \\mathbb{Q}\\ x \\wedge (\\texttt{minpoly}\\ \\mathbb{Q}\\ x).\\texttt{natDegree} \\leq d\\}$. The minimal polynomial $\\texttt{minpoly}\\ \\mathbb{Q}\\ x$ is the unique monic irreducible polynomial over $\\mathbb{Q}$ with $x$ as a root; $\\texttt{natDegree}$ gives its degree. These bounded sets grow as $\\mathbb{Q} = \\text{BoundedDeg}_1 \\subsetneq \\text{BoundedDeg}_2 \\subsetneq \\cdots$ (strictly, since $\\sqrt[d+1]{2} \\in \\text{BoundedDeg}_{d+1} \\setminus \\text{BoundedDeg}_d$). Countability follows from $\\texttt{Set.Countable.mono}$: a subset of a countable set is countable."
     },
     {
       "id": "sec-algebraic-exact",
-      "title": "\u00a73. Algebraic Numbers of Exact Degree",
+      "title": "§3. Algebraic Numbers of Exact Degree",
       "startLine": 137,
       "endLine": 165,
-      "description": "Defines `algebraicRealsOfDegree d` = {x : \u211d | IsAlgebraic \u211a x \u2227 (minpoly \u211a x).natDegree = d} and `algebraicComplexOfDegree d`. Proves `exact_degree_subset_bounded`: exact-degree d \u2286 bounded-degree d (le_of_eq converts equality to \u2264). Proves `algebraicRealsOfDegree_countable`: via two-step subset chain exact \u2192 bounded \u2192 all algebraic. For complex: uses apply Set.Countable.mono with explicit lambda to convert the exact-degree condition to bounded-degree. This establishes that each horizontal slice of the degree stratification is individually countable.",
+      "description": "Defines `algebraicRealsOfDegree d` = {x : ℝ | IsAlgebraic ℚ x ∧ (minpoly ℚ x).natDegree = d} and `algebraicComplexOfDegree d`. Proves `exact_degree_subset_bounded`: exact-degree d ⊆ bounded-degree d (le_of_eq converts equality to ≤). Proves `algebraicRealsOfDegree_countable`: via two-step subset chain exact → bounded → all algebraic. For complex: uses apply Set.Countable.mono with explicit lambda to convert the exact-degree condition to bounded-degree. This establishes that each horizontal slice of the degree stratification is individually countable.",
       "mathContext": "The degree strata: $\\texttt{algebraicRealsOfDegree}\\ d$ partitions algebraic reals by exact minimal polynomial degree. Degree 1: $\\mathbb{Q}$ (minimal polynomial $X - q$). Degree 2: $\\mathbb{Q}(\\sqrt{n})$ for squarefree $n > 1$ (minimal polynomial $X^2 - n$). Degree 3: $\\mathbb{Q}(\\sqrt[3]{2})$ (minimal polynomial $X^3 - 2$, irreducible by Eisenstein at $p = 2$). Each stratum is countable (subset of countable algebraic numbers); countability of the union follows from $\\texttt{Set.countable\\_iUnion}$. The partition $\\text{Alg}(\\mathbb{R}) = \\bigsqcup_{d \\geq 1} \\text{alg}_d(\\mathbb{R})$ is disjoint since minimal polynomial degree is unique."
     },
     {
       "id": "sec-algebraic-stratification",
-      "title": "\u00a74. Degree Stratification and Alternative Countability Proof",
+      "title": "§4. Degree Stratification and Alternative Countability Proof",
       "startLine": 167,
       "endLine": 201,
-      "description": "Proves `algebraic_reals_eq_iUnion_degree`: {x : \u211d | IsAlgebraic \u211a x} = \u22c3 d : \u2115, algebraicRealsOfDegree d. Proof by ext x, simp, constructor: (\u2192) given IsAlgebraic x, use d = natDegree(minpoly \u211a x) and rfl; (\u2190) extract IsAlgebraic from the existential. Analogous for complex numbers. `algebraic_reals_countable_via_strata`: alternative proof by rewriting via the union and applying Set.countable_iUnion algebraicRealsOfDegree_countable (countable union of countable sets). This demonstrates the stratification is not just a structural description but a valid proof technique.",
+      "description": "Proves `algebraic_reals_eq_iUnion_degree`: {x : ℝ | IsAlgebraic ℚ x} = ⋃ d : ℕ, algebraicRealsOfDegree d. Proof by ext x, simp, constructor: (→) given IsAlgebraic x, use d = natDegree(minpoly ℚ x) and rfl; (←) extract IsAlgebraic from the existential. Analogous for complex numbers. `algebraic_reals_countable_via_strata`: alternative proof by rewriting via the union and applying Set.countable_iUnion algebraicRealsOfDegree_countable (countable union of countable sets). This demonstrates the stratification is not just a structural description but a valid proof technique.",
       "mathContext": "$\\texttt{algebraic\\_reals\\_eq\\_iUnion\\_degree}$: $\\text{Alg}(\\mathbb{R}) = \\bigcup_{d \\in \\mathbb{N}} \\texttt{algebraicRealsOfDegree}\\ d$. The witness for each $x$ is $d := (\\texttt{minpoly}\\ \\mathbb{Q}\\ x).\\texttt{natDegree}$ with $\\texttt{rfl}$. $\\texttt{Set.countable\\_iUnion}$: a $\\mathbb{N}$-indexed union of countable sets is countable — this is the Lean encoding of $|\\mathbb{N} \\times \\mathbb{N}| = |\\mathbb{N}|$ (Cantor pairing function). The alternative proof $\\texttt{algebraic\\_reals\\_countable\\_via\\_strata}$ demonstrates that the stratification is mathematically substantive: it gives an independent route to the same conclusion, bypassing the direct Mathlib delegation in $\\S1$."
     },
     {
       "id": "sec-algebraic-degree1",
-      "title": "\u00a75. Degree 1 = Rationals and Monotone Filtration",
+      "title": "§5. Degree 1 = Rationals and Monotone Filtration",
       "startLine": 203,
       "endLine": 217,
-      "description": "Two theorems: `rat_algebraic_degree_one`: every q \u2208 \u211a is algebraic (isAlgebraic_algebraMap q \u2014 elements mapped from the base field are algebraic, with minimal polynomial X \u2212 q of degree 1). `bounded_degree_monotone`: algebraicRealsOfBoundedDegree d \u2286 algebraicRealsOfBoundedDegree (d+1), proved by Nat.le_succ_of_le on the degree bound. These establish the filtration structure: \u211a \u2286 deg\u22641 \u2286 deg\u22642 \u2286 ... \u2286 all algebraic, each inclusion strict (e.g., \u221a2 \u2208 deg\u22642 but \u221a2 \u2209 \u211a).",
+      "description": "Two theorems: `rat_algebraic_degree_one`: every q ∈ ℚ is algebraic (isAlgebraic_algebraMap q — elements mapped from the base field are algebraic, with minimal polynomial X − q of degree 1). `bounded_degree_monotone`: algebraicRealsOfBoundedDegree d ⊆ algebraicRealsOfBoundedDegree (d+1), proved by Nat.le_succ_of_le on the degree bound. These establish the filtration structure: ℚ ⊆ deg≤1 ⊆ deg≤2 ⊆ ... ⊆ all algebraic, each inclusion strict (e.g., √2 ∈ deg≤2 but √2 ∉ ℚ).",
       "mathContext": "$\\texttt{isAlgebraic\\_algebraMap}$: for $q \\in \\mathbb{Q}$, the image of $q$ in $\\mathbb{R}$ satisfies $q$ as a root of $X - q \\in \\mathbb{Q}[X]$ (a monic linear polynomial), so $\\texttt{minpoly}\\ \\mathbb{Q}\\ q = X - q$ and $\\texttt{natDegree} = 1$. $\\texttt{bounded\\_degree\\_monotone}$: $\\text{BoundedDeg}_d \\subseteq \\text{BoundedDeg}_{d+1}$ by $\\texttt{Nat.le\\_succ\\_of\\_le}$ on the degree inequality. The inclusions are strict: $\\sqrt[d+1]{2}$ has minimal polynomial $X^{d+1} - 2$ (irreducible by Eisenstein at $p=2$), giving degree $d+1$, so $\\sqrt[d+1]{2} \\in \\text{BoundedDeg}_{d+1} \\setminus \\text{BoundedDeg}_d$."
     },
     {
       "id": "sec-algebraic-cardinality",
-      "title": "\u00a76\u20137. Cardinality Comparisons and Exhaustive Filtration",
+      "title": "§6–7. Cardinality Comparisons and Exhaustive Filtration",
       "startLine": 219,
       "endLine": 254,
-      "description": "Section 6: `card_algebraic_eq_card_rat` proves |{x : \u211d // IsAlgebraic \u211a x}| = |\u211a| by rewriting both via aleph0 (card_algebraic_reals_eq_aleph0 and Cardinal.mk_denumerable). `card_algebraic_eq_card_nat` proves the same equals |\u2115|. Both illustrate the 'paradox' that a proper superset has the same cardinality. Section 7: `algebraic_reals_eq_iUnion_bounded` proves {x : \u211d | IsAlgebraic \u211a x} = \u22c3 d, algebraicRealsOfBoundedDegree d, using d = natDegree(minpoly x) and le_refl. This is the bounded-degree version of the exact-degree stratification. Ends with end AlgebraicNumbersCountable.",
+      "description": "Section 6: `card_algebraic_eq_card_rat` proves |{x : ℝ // IsAlgebraic ℚ x}| = |ℚ| by rewriting both via aleph0 (card_algebraic_reals_eq_aleph0 and Cardinal.mk_denumerable). `card_algebraic_eq_card_nat` proves the same equals |ℕ|. Both illustrate the 'paradox' that a proper superset has the same cardinality. Section 7: `algebraic_reals_eq_iUnion_bounded` proves {x : ℝ | IsAlgebraic ℚ x} = ⋃ d, algebraicRealsOfBoundedDegree d, using d = natDegree(minpoly x) and le_refl. This is the bounded-degree version of the exact-degree stratification. Ends with end AlgebraicNumbersCountable.",
       "mathContext": "$\\texttt{card\\_algebraic\\_eq\\_card\\_rat}$: $|\\{x : \\mathbb{R} \\mid \\texttt{IsAlgebraic}\\ \\mathbb{Q}\\ x\\}| = |\\mathbb{Q}|$, proved via the chain $= \\aleph_0 = |\\mathbb{Q}|$ using $\\texttt{mk\\_denumerable}$ ($\\mathbb{Q}$ is countably infinite). The 'paradox': $\\text{Alg}(\\mathbb{R}) \\supsetneq \\mathbb{Q}$ (containing $\\sqrt{2}, \\sqrt[3]{2}, (1+\\sqrt{5})/2, \\ldots$) yet $|\\text{Alg}(\\mathbb{R})| = |\\mathbb{Q}| = |\\mathbb{N}| = \\aleph_0$. This is Dedekind's definition of infinite sets: a set is infinite iff it is equinumerous with a proper subset. $\\texttt{algebraic\\_reals\\_eq\\_iUnion\\_bounded}$: $\\text{Alg}(\\mathbb{R}) = \\bigcup_d \\text{BoundedDeg}_d$ uses $d = (\\texttt{minpoly}\\ \\mathbb{Q}\\ x).\\texttt{natDegree}$ and $\\texttt{le\\_refl}$ as the witness and membership proof."
     }
   ],
@@ -168,27 +169,27 @@
     {
       "targetId": "algebraic-numbers-countable-oq-02",
       "relationship": "companion",
-      "description": "Proves \u211d is uncountable via Cantor's diagonal argument \u2014 the complementary result from Cantor's 1874 paper. Together these two results establish: algebraic numbers are countable (\u2135\u2080) while reals are uncountable (2^\u2135\u2080), implying almost all real numbers are transcendental."
+      "description": "Proves ℝ is uncountable via Cantor's diagonal argument — the complementary result from Cantor's 1874 paper. Together these two results establish: algebraic numbers are countable (ℵ₀) while reals are uncountable (2^ℵ₀), implying almost all real numbers are transcendental."
     },
     {
       "targetId": "cantor-diagonalization",
       "relationship": "related",
-      "description": "Cantor's diagonal argument that \u211d is uncountable \u2014 the other half of the 1874 paper. The countability of algebraic numbers and uncountability of \u211d together imply transcendental numbers are 'most' real numbers."
+      "description": "Cantor's diagonal argument that ℝ is uncountable — the other half of the 1874 paper. The countability of algebraic numbers and uncountability of ℝ together imply transcendental numbers are 'most' real numbers."
     },
     {
       "targetId": "cayley-hamilton-minpoly",
       "relationship": "related",
-      "description": "The Cayley-Hamilton theorem and minimal polynomial theory (minpoly) are central to both proofs. algebraic-numbers-countable uses minpoly \u211a x extensively for the degree stratification; Cayley-Hamilton proves A satisfies its own minpoly in a matrix algebra context."
+      "description": "The Cayley-Hamilton theorem and minimal polynomial theory (minpoly) are central to both proofs. algebraic-numbers-countable uses minpoly ℚ x extensively for the degree stratification; Cayley-Hamilton proves A satisfies its own minpoly in a matrix algebra context."
     },
     {
       "targetId": "algebraic-numbers-countable-oq-02-oq-02",
       "relationship": "related",
-      "description": "Formalizes Cantor's original 1874 nested intervals proof that \u211d is uncountable, complementing the diagonal argument in algebraic-numbers-countable-oq-02. Both entries complete the two-part result from Cantor's landmark paper: algebraic numbers are countable (this entry) and \u211d is uncountable (oq-02 / oq-02-oq-02)."
+      "description": "Formalizes Cantor's original 1874 nested intervals proof that ℝ is uncountable, complementing the diagonal argument in algebraic-numbers-countable-oq-02. Both entries complete the two-part result from Cantor's landmark paper: algebraic numbers are countable (this entry) and ℝ is uncountable (oq-02 / oq-02-oq-02)."
     },
     {
       "targetId": "hermite-lindemann",
       "relationship": "implication",
-      "description": "Addresses the first open question: formalizes the Lindemann-Weierstrass theorem proving $e$ and $\\pi$ are transcendental. This is the most concrete consequence of algebraic number countability \u2014 identifying specific members of the uncountable transcendental complement."
+      "description": "Addresses the first open question: formalizes the Lindemann-Weierstrass theorem proving $e$ and $\\pi$ are transcendental. This is the most concrete consequence of algebraic number countability — identifying specific members of the uncountable transcendental complement."
     },
     {
       "targetId": "cantors-theorem",
@@ -203,17 +204,17 @@
     {
       "targetId": "liouville-theorem",
       "relationship": "complementary",
-      "description": "Liouville's Theorem on Transcendental Numbers \u2014 the constructive complement to Cantor's cardinality argument. Liouville (1844) showed that algebraic numbers of degree $d$ cannot be approximated by rationals to better than order $1/q^d$; numbers violating this bound (like $\\sum_{k=1}^{\\infty} 10^{-k!}$) must be transcendental. This gives explicit examples, whereas Cantor's 1874 argument (formalized here) proves transcendentals are cardinality-'most' of $\\mathbb{R}$ without constructing any. The two approaches are dual: the Lean formalization here uses Mathlib's `Algebraic.countable` to bypass constructive enumeration, while `liouville-theorem` formalizes the Diophantine approximation criterion. Together they represent the two founding strategies of transcendence theory \u2014 counting vs. construction."
+      "description": "Liouville's Theorem on Transcendental Numbers — the constructive complement to Cantor's cardinality argument. Liouville (1844) showed that algebraic numbers of degree $d$ cannot be approximated by rationals to better than order $1/q^d$; numbers violating this bound (like $\\sum_{k=1}^{\\infty} 10^{-k!}$) must be transcendental. This gives explicit examples, whereas Cantor's 1874 argument (formalized here) proves transcendentals are cardinality-'most' of $\\mathbb{R}$ without constructing any. The two approaches are dual: the Lean formalization here uses Mathlib's `Algebraic.countable` to bypass constructive enumeration, while `liouville-theorem` formalizes the Diophantine approximation criterion. Together they represent the two founding strategies of transcendence theory — counting vs. construction."
     },
     {
       "targetId": "e-transcendental",
       "relationship": "implication",
-      "description": "Transcendence of $e$ \u2014 the first concrete member of the uncountable transcendental complement. Hermite (1873), one year before Cantor's 1874 paper, proved $e$ is transcendental by showing it is not a root of any nonzero rational polynomial. This entry proves that transcendentals are cardinality-'most' reals; `e-transcendental` proves $e$ specifically lies in that complement. The contrast is instructive: Cantor's argument establishes the transcendental complement is uncountable without naming a single element, while Hermite's proof identifies $e$ without using cardinality. Both results were needed to understand the landscape: existence, prevalence, and specific examples."
+      "description": "Transcendence of $e$ — the first concrete member of the uncountable transcendental complement. Hermite (1873), one year before Cantor's 1874 paper, proved $e$ is transcendental by showing it is not a root of any nonzero rational polynomial. This entry proves that transcendentals are cardinality-'most' reals; `e-transcendental` proves $e$ specifically lies in that complement. The contrast is instructive: Cantor's argument establishes the transcendental complement is uncountable without naming a single element, while Hermite's proof identifies $e$ without using cardinality. Both results were needed to understand the landscape: existence, prevalence, and specific examples."
     },
     {
       "targetId": "pi-transcendental",
       "relationship": "implication",
-      "description": "Transcendence of $\\pi$ \u2014 Lindemann (1882) applied Hermite's exponential method to prove $\\pi$ transcendental, settling the ancient question of circle squaring. The Lindemann-Weierstrass theorem generalizes both: if $\\alpha_1, \\ldots, \\alpha_n$ are distinct algebraic numbers, then $e^{\\alpha_1}, \\ldots, e^{\\alpha_n}$ are linearly independent over $\\mathbb{Q}$. Since $e^{i\\pi} = -1$ (Euler's identity) and $-1$ is algebraic, $i\\pi$ cannot be algebraic \u2014 hence $\\pi$ is transcendental. Together with this entry's proof that algebraic numbers are countable and $\\mathbb{R}$ is uncountable, `pi-transcendental` shows that $\\pi$ is among the uncountable majority."
+      "description": "Transcendence of $\\pi$ — Lindemann (1882) applied Hermite's exponential method to prove $\\pi$ transcendental, settling the ancient question of circle squaring. The Lindemann-Weierstrass theorem generalizes both: if $\\alpha_1, \\ldots, \\alpha_n$ are distinct algebraic numbers, then $e^{\\alpha_1}, \\ldots, e^{\\alpha_n}$ are linearly independent over $\\mathbb{Q}$. Since $e^{i\\pi} = -1$ (Euler's identity) and $-1$ is algebraic, $i\\pi$ cannot be algebraic — hence $\\pi$ is transcendental. Together with this entry's proof that algebraic numbers are countable and $\\mathbb{R}$ is uncountable, `pi-transcendental` shows that $\\pi$ is among the uncountable majority."
     },
     {
       "targetId": "gelfond-schneider",
@@ -239,52 +240,66 @@
   "references": [
     {
       "authors": "Georg Cantor",
-      "title": "\u00dcber eine Eigenschaft des Inbegriffes aller reellen algebraischen Zahlen",
+      "title": "Über eine Eigenschaft des Inbegriffes aller reellen algebraischen Zahlen",
       "year": "1874",
-      "venue": "Journal f\u00fcr die reine und angewandte Mathematik (Crelle's Journal)",
+      "venue": "Journal für die reine und angewandte Mathematik (Crelle's Journal)",
       "note": "Original proof that algebraic numbers are countable; the same paper contains the first uncountability proof of the reals via the nested-intervals argument"
     },
     {
       "authors": "Charles Hermite",
       "title": "Sur la fonction exponentielle",
       "year": "1873",
-      "venue": "Comptes rendus de l'Acad\u00e9mie des Sciences",
-      "note": "First proof that e is transcendental; the method was extended by Lindemann (1882) to prove \u03c0 transcendental and generalized to the Lindemann-Weierstrass theorem"
+      "venue": "Comptes rendus de l'Académie des Sciences",
+      "note": "First proof that e is transcendental; the method was extended by Lindemann (1882) to prove π transcendental and generalized to the Lindemann-Weierstrass theorem"
     },
     {
       "authors": "Joseph Liouville",
-      "title": "Sur des classes tr\u00e8s \u00e9tendues de quantit\u00e9s dont la valeur n'est ni alg\u00e9brique, ni m\u00eame r\u00e9ductible \u00e0 des irrationnelles alg\u00e9briques",
+      "title": "Sur des classes très étendues de quantités dont la valeur n'est ni algébrique, ni même réductible à des irrationnelles algébriques",
       "year": "1844",
-      "venue": "Journal de Math\u00e9matiques Pures et Appliqu\u00e9es",
+      "venue": "Journal de Mathématiques Pures et Appliquées",
       "note": "First constructive existence proof of transcendental numbers via Diophantine approximation bounds; complements Cantor's cardinality argument by giving explicit examples"
     },
     {
       "authors": "Ferdinand von Lindemann",
-      "title": "\u00dcber die Zahl \u03c0",
+      "title": "Über die Zahl π",
       "year": "1882",
       "venue": "Mathematische Annalen",
-      "note": "Proves \u03c0 is transcendental using Hermite's exponential method; together with Cantor's countability result, establishes that specific transcendentals are hard to identify despite 'almost all' reals being transcendental"
+      "note": "Proves π is transcendental using Hermite's exponential method; together with Cantor's countability result, establishes that specific transcendentals are hard to identify despite 'almost all' reals being transcendental"
     },
     {
       "authors": "Ivan Niven",
       "title": "Irrational Numbers",
       "year": "1956",
       "venue": "Carus Mathematical Monographs No. 11, Mathematical Association of America",
-      "note": "The standard introductory reference on algebraic and transcendental number theory. Chapter 5 develops the countability of algebraic numbers via the height-function approach, complementing the abstract Mathlib-based proof formalized here. Provides accessible elementary proofs of e and \u03c0 transcendence, the Lindemann-Weierstrass theorem, and the Gelfond-Schneider theorem."
+      "note": "The standard introductory reference on algebraic and transcendental number theory. Chapter 5 develops the countability of algebraic numbers via the height-function approach, complementing the abstract Mathlib-based proof formalized here. Provides accessible elementary proofs of e and π transcendence, the Lindemann-Weierstrass theorem, and the Gelfond-Schneider theorem."
     },
     {
       "authors": "Edward B. Burger; Robert Tubbs",
       "title": "Making Transcendence Transparent: An Intuitive Approach to Classical Transcendental Number Theory",
       "year": "2004",
       "venue": "Springer",
-      "note": "Modern accessible treatment of transcendence theory connecting Cantor's countability argument (Chapter 1) to Liouville's construction (Chapter 2), Hermite-Lindemann (Chapter 3), Gelfond-Schneider (Chapter 4), and Baker's theorem (Chapter 5). Particularly valuable for understanding the dialectic between cardinality-based and construction-based approaches to identifying transcendental numbers \u2014 the very contrast highlighted in this entry's openQuestions and cross-references to liouville-theorem and hermite-lindemann."
+      "note": "Modern accessible treatment of transcendence theory connecting Cantor's countability argument (Chapter 1) to Liouville's construction (Chapter 2), Hermite-Lindemann (Chapter 3), Gelfond-Schneider (Chapter 4), and Baker's theorem (Chapter 5). Particularly valuable for understanding the dialectic between cardinality-based and construction-based approaches to identifying transcendental numbers — the very contrast highlighted in this entry's openQuestions and cross-references to liouville-theorem and hermite-lindemann."
     },
     {
       "authors": "Richard Dedekind",
       "title": "Was sind und was sollen die Zahlen?",
       "year": "1888",
       "venue": "Vieweg, Braunschweig",
-      "note": "Dedekind's foundational treatise on set theory and the natural numbers, published 14 years after Cantor's 1874 result. Introduces the formal definition of an infinite set as one equinumerous with a proper subset \u2014 the precise property exhibited here as $|\\text{algebraic reals}| = |\\mathbb{Q}|$ despite $\\mathbb{Q} \\subsetneq \\text{algebraic reals}$. This is the conceptual underpinning of the 'cardinal paradox' formalized in `card_algebraic_eq_card_rat`."
+      "note": "Dedekind's foundational treatise on set theory and the natural numbers, published 14 years after Cantor's 1874 result. Introduces the formal definition of an infinite set as one equinumerous with a proper subset — the precise property exhibited here as $|\\text{algebraic reals}| = |\\mathbb{Q}|$ despite $\\mathbb{Q} \\subsetneq \\text{algebraic reals}$. This is the conceptual underpinning of the 'cardinal paradox' formalized in `card_algebraic_eq_card_rat`."
+    },
+    {
+      "authors": "Jean-Pierre Serre",
+      "title": "Topics in Galois Theory",
+      "year": "2008",
+      "venue": "A K Peters/CRC Press, 2nd edition",
+      "note": "Standard modern reference for the absolute Galois group $\\text{Gal}(\\overline{\\mathbb{Q}}/\\mathbb{Q})$ and its action on algebraic numbers; treats orbit decomposition by minimal polynomial and connects to the inverse Galois problem"
+    },
+    {
+      "authors": "Alan Baker",
+      "title": "Transcendental Number Theory",
+      "year": "1975",
+      "venue": "Cambridge University Press",
+      "note": "Comprehensive monograph on transcendence; chapter 1 reviews Cantor's countability argument and Liouville's construction; later chapters cover Baker's theorem on linear forms in logarithms (Fields Medal 1970), the most powerful effective transcendence tool"
     }
   ],
   "leanFile": {
@@ -298,7 +313,10 @@
       "Mathlib.SetTheory.Cardinal.Basic",
       "Mathlib.Tactic"
     ],
-    "opens": ["Polynomial", "Cardinal"],
+    "opens": [
+      "Polynomial",
+      "Cardinal"
+    ],
     "namespace": "AlgebraicNumbersCountable",
     "lineCount": 254,
     "path": "Proofs/AlgebraicNumbersCountable.lean",
@@ -312,37 +330,37 @@
         "name": "algebraic_reals_countable",
         "type": "delegation",
         "description": "The algebraic real numbers are countable",
-        "leanType": "Set.Countable {x : \u211d | IsAlgebraic \u211a x}"
+        "leanType": "Set.Countable {x : ℝ | IsAlgebraic ℚ x}"
       },
       {
         "name": "card_algebraic_reals_eq_aleph0",
         "type": "delegation",
         "description": "Cardinality of algebraic reals equals aleph0",
-        "leanType": "Cardinal.mk {x : \u211d // IsAlgebraic \u211a x} = Cardinal.aleph0"
+        "leanType": "Cardinal.mk {x : ℝ // IsAlgebraic ℚ x} = Cardinal.aleph0"
       },
       {
         "name": "algebraic_reals_eq_iUnion_degree",
         "type": "original",
         "description": "Algebraic reals decompose as union of degree strata",
-        "leanType": "{x : \u211d | IsAlgebraic \u211a x} = \u22c3 d : \u2115, algebraicRealsOfDegree d"
+        "leanType": "{x : ℝ | IsAlgebraic ℚ x} = ⋃ d : ℕ, algebraicRealsOfDegree d"
       },
       {
         "name": "algebraic_reals_countable_via_strata",
         "type": "original",
         "description": "Alternative countability proof via degree stratification",
-        "leanType": "Set.Countable {x : \u211d | IsAlgebraic \u211a x}"
+        "leanType": "Set.Countable {x : ℝ | IsAlgebraic ℚ x}"
       },
       {
         "name": "card_algebraic_eq_card_rat",
         "type": "original",
         "description": "Algebraic reals and rationals have the same cardinality",
-        "leanType": "Cardinal.mk {x : \u211d // IsAlgebraic \u211a x} = Cardinal.mk \u211a"
+        "leanType": "Cardinal.mk {x : ℝ // IsAlgebraic ℚ x} = Cardinal.mk ℚ"
       },
       {
         "name": "algebraic_reals_eq_iUnion_bounded",
         "type": "original",
         "description": "Algebraic reals are the exhaustive union of bounded-degree sets",
-        "leanType": "{x : \u211d | IsAlgebraic \u211a x} = \u22c3 d : \u2115, algebraicRealsOfBoundedDegree d"
+        "leanType": "{x : ℝ | IsAlgebraic ℚ x} = ⋃ d : ℕ, algebraicRealsOfBoundedDegree d"
       }
     ],
     "sorries": 0
@@ -351,20 +369,20 @@
     {
       "name": "algebraic_reals_countable",
       "type": "core",
-      "description": "The set of algebraic real numbers {x : \u211d | IsAlgebraic \u211a x} is countable (Cantor 1874)",
-      "leanType": "Set.Countable {x : \u211d | IsAlgebraic \u211a x}"
+      "description": "The set of algebraic real numbers {x : ℝ | IsAlgebraic ℚ x} is countable (Cantor 1874)",
+      "leanType": "Set.Countable {x : ℝ | IsAlgebraic ℚ x}"
     },
     {
       "name": "card_algebraic_reals_eq_aleph0",
       "type": "core",
       "description": "The algebraic reals have cardinality exactly aleph0 (countably infinite, not finite)",
-      "leanType": "Cardinal.mk {x : \u211d // IsAlgebraic \u211a x} = Cardinal.aleph0"
+      "leanType": "Cardinal.mk {x : ℝ // IsAlgebraic ℚ x} = Cardinal.aleph0"
     },
     {
       "name": "algebraic_reals_eq_iUnion_degree",
       "type": "key",
       "description": "Algebraic reals decompose as countable union of degree strata",
-      "leanType": "{x : \u211d | IsAlgebraic \u211a x} = \u22c3 d : \u2115, algebraicRealsOfDegree d"
+      "leanType": "{x : ℝ | IsAlgebraic ℚ x} = ⋃ d : ℕ, algebraicRealsOfDegree d"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Summary

Targeted enrichment for `algebraic-numbers-countable` (Cantor 1874 countability of algebraic numbers). The entry was already very polished (7 keyInsights, 14 cross-refs, sections+annotations comprehensive), so this is a focused single-angle addition.

## Changes

- **New 8th `keyInsight`**: the Galois group action on $\overline{\mathbb{Q}}$. Connects the cardinality result to structural Galois theory: the countable algebraic numbers carry a $\text{Gal}(\overline{\mathbb{Q}}/\mathbb{Q})$ action with finite orbits (conjugates by minimal polynomial), while $\text{Gal}(\overline{\mathbb{Q}}/\mathbb{Q})$ itself is uncountable ($2^{\aleph_0}$, profinite). This perspective was absent from the existing insights, which covered cardinality, filtration, transcendence, and algebraic-vs-metric duality but not Galois orbit decomposition.
- **2 new references**: Serre, *Topics in Galois Theory* (canonical modern reference for the absolute Galois group); Baker, *Transcendental Number Theory* (Fields Medalist's monograph covering Cantor's argument and effective transcendence).

## Test Plan

- [x] `pnpm build` passes
- [x] JSON validates
- [x] No edits to Lean source, annotations, or other entries