### PR TITLE
fix(meta): sync bounded-prime-gaps-oq-04 lineCount and theoremCount

### DIFF
--- a/src/data/proofs/bounded-prime-gaps-oq-04/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-04/meta.json
@@ -55,7 +55,7 @@
       "PolyaVinogradovHolds: key prerequisite statement",
       "BVPrerequisiteLayer: concrete 4-layer roadmap with estimates"
     ],
-    "lineCount": 366,
+    "lineCount": 416,
     "erdosUrl": null,
     "dateAdded": "2026-03-27"
   },
@@ -190,9 +190,9 @@
       "Filter"
     ],
     "namespace": "BoundedPrimeGapsOQ04",
-    "lineCount": 366,
+    "lineCount": 416,
     "axiomCount": 1,
-    "theoremCount": 12,
+    "theoremCount": 14,
     "definitionCount": 10,
     "path": "Proofs/BoundedPrimeGapsOQ04.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync `bounded-prime-gaps-oq-04/meta.json` with the current state of `BoundedPrimeGapsOQ04.lean`.

## Evidence

**Before**: `meta.lineCount=366`, `leanFile.lineCount=366`, `leanFile.theoremCount=12`
**After**: `meta.lineCount=416`, `leanFile.lineCount=416`, `leanFile.theoremCount=14`

The Lean file grew by 50 lines since the metadata was last set — `pv_uniform_bound` (a new theorem) and `LargeSieveHolds` (a new definition) were added. Two theorems (`pv_uniform_bound` and `total_effort_estimate`) were not counted. `definitionCount` (10) and `axiomCount` (1) remain correct.

---
Automated fix by lean-mechanic agent.