### PR TITLE
fix(meta): sync hurwitz-theorem-oq-04 leanFile counts with current file

### DIFF
--- a/src/data/proofs/hurwitz-theorem-oq-04/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-04/meta.json
@@ -23,8 +23,8 @@
     "axiomCount": 0,
     "assumptions": "1 sorry in G2_der_dimension proof chain: derEval14_injective — off-diagonal entries (j in {1,...,7}, i != 0, i != j) of the imaginary basis kernel claim. The j = 0 case is closed via submodule_der_unit_zero; the i = j diagonal case (Session 7, 2026-04-27) is closed via submodule_der_diagonal_kill (Leibniz at (e_j, e_j) using stdBasis_sq_neg_unit). Remaining 49-entry off-diagonal block requires antisymmetry ((f e_i)_j + (f e_j)_i = 0 from Leibniz at (e_i, e_j) + (e_j, e_i)) and Fano-line trilinear constraints. derBasis14_linearIndependent was proved in PR #13121. The Aut(O) is in O(7) — fully proved with 0 sorries.",
     "lineCount": 1180,
-    "theoremCount": 38,
-    "definitionCount": 17,
+    "theoremCount": 60,
+    "definitionCount": 19,
     "originalContributions": [
       "OctonionAlgHom / OctonionAut: structures for octonion algebra homomorphisms and automorphisms",
       "alg_aut_preserves_norm: automorphisms preserve the norm (proved via polarization and imaginary decomposition)",
@@ -137,10 +137,10 @@
       "HurwitzTheorem"
     ],
     "namespace": "HurwitzTheoremOQ04",
-    "lineCount": 1094,
+    "lineCount": 1180,
     "axiomCount": 0,
-    "theoremCount": 40,
-    "definitionCount": 15,
+    "theoremCount": 60,
+    "definitionCount": 19,
     "sorries": 1,
     "path": "Proofs/HurwitzTheoremOQ04.lean"
   },


### PR DESCRIPTION
## Fix

Sync `hurwitz-theorem-oq-04/meta.json` with the current state of `HurwitzTheoremOQ04.lean`.

## Evidence

The `leanFile` section was stale — someone had updated `meta.lineCount` to 1180 but forgot to sync `leanFile.lineCount` and the theorem/definition counts:

| Field | Before | After |
|-------|--------|-------|
| `meta.theoremCount` | 38 | 60 |
| `meta.definitionCount` | 17 | 19 |
| `leanFile.lineCount` | 1094 | 1180 |
| `leanFile.theoremCount` | 40 | 60 |
| `leanFile.definitionCount` | 15 | 19 |

The file grew by 86 lines as research sessions added derivation submodule infrastructure (`OctonionDerSubmodule`, `OctonionDer.toLinearMap`, `OctonionDer.toSubmoduleMem`) and Freudenthal-Tits axiom machinery. Counts verified via grep on the Lean file.

`sorries` (1), `axiomCount` (0), and `meta.lineCount` (1180) remain unchanged and are correct.

---
Automated fix by lean-mechanic agent.