### PR TITLE
research(erdos-404): derive lin_bound from lin_bound_meaning (axiom 2→1)

### DIFF
--- a/proofs/Proofs/Erdos404Problem.lean
+++ b/proofs/Proofs/Erdos404Problem.lean
@@ -12,7 +12,7 @@ Let f(a, p) denote the greatest such k if it exists. How does f(a, p) behave?
 Known results:
 - Lin (1976): f(2, 2) ≤ 254
 
-Axioms: 2 (lin_bound, lin_bound_meaning — Lin 1976 result)
+Axioms: 1 (lin_bound_meaning — Lin 1976 result; lin_bound is now derived)
 Sorries: 0
 
 Tags: number-theory, p-adic-valuation, factorials, divisibility, open-problem
@@ -55,8 +55,39 @@ def erdos404Conjecture : Prop :=
 
 /- ## Part III: Known Results -/
 
-axiom lin_bound : f 2 2 ≤ 254
+/-- Lin (1976) [Bell Labs internal memorandum]: no strictly increasing sequence
+    starting at 2 has 2^255 dividing its factorial sum.
+    This is the fundamental statement of Lin's bound. -/
 axiom lin_bound_meaning : ∀ s : StrictIncSeq 2, ¬(2^255 ∣ factorialSum s)
+
+/-- A trivial empty `StrictIncSeq 2` (length 0). Witnesses that
+    `divisiblePowers 2 2` is nonempty since `2^0 = 1` divides `factorialSum = 0`. -/
+private def emptyStrictIncSeq2 : StrictIncSeq 2 where
+  length := 0
+  seq := Fin.elim0
+  starts_at_a h := absurd h (by omega)
+  strictly_increasing i _ _ := i.elim0
+
+private theorem divisiblePowers_2_2_nonempty : (divisiblePowers 2 2).Nonempty := by
+  refine ⟨0, emptyStrictIncSeq2, ?_⟩
+  show (2 : ℕ) ^ 0 ∣ factorialSum emptyStrictIncSeq2
+  rw [pow_zero]
+  exact one_dvd _
+
+/-- Lin (1976) bound `f 2 2 ≤ 254`, derived from `lin_bound_meaning`.
+
+    Proof: If `k ∈ divisiblePowers 2 2`, then some sequence `s` has `2^k ∣ factorialSum s`.
+    If `k ≥ 255`, then `2^255 ∣ 2^k ∣ factorialSum s`, contradicting `lin_bound_meaning`.
+    Hence the set is bounded above by 254 (and is nonempty via the empty sequence),
+    so its supremum is ≤ 254. -/
+theorem lin_bound : f 2 2 ≤ 254 := by
+  unfold f
+  apply csSup_le divisiblePowers_2_2_nonempty
+  rintro k ⟨s, hs⟩
+  by_contra h_gt
+  push_neg at h_gt
+  exact lin_bound_meaning s
+    (dvd_trans (pow_dvd_pow 2 (by omega : 255 ≤ k)) hs)
 
 /- ## Part IV: p-adic Analysis -/
 

--- a/proofs/Proofs/Erdos404Problem.lean
+++ b/proofs/Proofs/Erdos404Problem.lean
@@ -60,34 +60,21 @@ def erdos404Conjecture : Prop :=
     This is the fundamental statement of Lin's bound. -/
 axiom lin_bound_meaning : ∀ s : StrictIncSeq 2, ¬(2^255 ∣ factorialSum s)
 
-/-- A trivial empty `StrictIncSeq 2` (length 0). Witnesses that
-    `divisiblePowers 2 2` is nonempty since `2^0 = 1` divides `factorialSum = 0`. -/
-private def emptyStrictIncSeq2 : StrictIncSeq 2 where
-  length := 0
-  seq := Fin.elim0
-  starts_at_a h := absurd h (by omega)
-  strictly_increasing i _ _ := i.elim0
-
-private theorem divisiblePowers_2_2_nonempty : (divisiblePowers 2 2).Nonempty := by
-  refine ⟨0, emptyStrictIncSeq2, ?_⟩
-  show (2 : ℕ) ^ 0 ∣ factorialSum emptyStrictIncSeq2
-  rw [pow_zero]
-  exact one_dvd _
-
 /-- Lin (1976) bound `f 2 2 ≤ 254`, derived from `lin_bound_meaning`.
 
     Proof: If `k ∈ divisiblePowers 2 2`, then some sequence `s` has `2^k ∣ factorialSum s`.
     If `k ≥ 255`, then `2^255 ∣ 2^k ∣ factorialSum s`, contradicting `lin_bound_meaning`.
-    Hence the set is bounded above by 254 (and is nonempty via the empty sequence),
-    so its supremum is ≤ 254. -/
+    Hence the set is bounded above by 254, so its supremum is ≤ 254 by `Nat.sSup_def`. -/
 theorem lin_bound : f 2 2 ≤ 254 := by
-  unfold f
-  apply csSup_le divisiblePowers_2_2_nonempty
-  rintro k ⟨s, hs⟩
-  by_contra h_gt
-  push_neg at h_gt
-  exact lin_bound_meaning s
-    (dvd_trans (pow_dvd_pow 2 (by omega : 255 ≤ k)) hs)
+  unfold f divisiblePowers
+  have hbdd : ∀ k ∈ {k | dividesByPrimePower 2 k 2}, k ≤ 254 := by
+    rintro k ⟨s, hs⟩
+    by_contra h_gt
+    push_neg at h_gt
+    exact lin_bound_meaning s
+      (dvd_trans (pow_dvd_pow 2 (by omega : 255 ≤ k)) hs)
+  rw [Nat.sSup_def ⟨254, hbdd⟩]
+  exact Nat.find_min' _ hbdd
 
 /- ## Part IV: p-adic Analysis -/
 

--- a/proofs/Proofs/Erdos404Problem.lean
+++ b/proofs/Proofs/Erdos404Problem.lean
@@ -66,9 +66,10 @@ axiom lin_bound_meaning : ∀ s : StrictIncSeq 2, ¬(2^255 ∣ factorialSum s)
     If `k ≥ 255`, then `2^255 ∣ 2^k ∣ factorialSum s`, contradicting `lin_bound_meaning`.
     Hence the set is bounded above by 254, so its supremum is ≤ 254 by `Nat.sSup_def`. -/
 theorem lin_bound : f 2 2 ≤ 254 := by
-  unfold f divisiblePowers
-  have hbdd : ∀ k ∈ {k | dividesByPrimePower 2 k 2}, k ≤ 254 := by
-    rintro k ⟨s, hs⟩
+  show sSup (divisiblePowers 2 2) ≤ 254
+  have hbdd : ∀ k ∈ divisiblePowers 2 2, k ≤ 254 := by
+    intro k hk
+    obtain ⟨s, hs⟩ := hk
     by_contra h_gt
     push_neg at h_gt
     exact lin_bound_meaning s

--- a/src/data/research/problems/erdos-404.json
+++ b/src/data/research/problems/erdos-404.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: Proved padic_val_factorial_asymp sorry (Nat.log/n→0 via isLittleO + squeeze). File now 2A/0S — only Lin 1976 bounds remain as axioms.",
+    "progressSummary": "AXIOM ELIMINATION: Derived lin_bound from lin_bound_meaning via Nat.sSup_def. File now 1A/0S — only the fundamental Lin 1976 bound (¬(2^255 | factorialSum)) remains as axiom; the supremum form f(2,2) ≤ 254 is now a theorem.",
     "builtItems": [
       "Assessment: 4A all appropriate",
       "PROVED legendre_formula: padicValNat p n! = legendreSum n p (was axiom, now theorem)",
@@ -40,7 +40,8 @@
       "padic_val_factorial_asymp: v/n->1/(p-1) via squeeze (1 sorry: log/n->0)",
       "sum_telescope_nat: Nat telescoping sum lemma",
       "div_pow_antitone: n/p^k decreasing in k",
-      "Proved padic_val_factorial_asymp: ν_p(n!)/n → 1/(p-1) via isLittleO_log_rpow_atTop + Nat.pow_log_le_self + epsilon-N squeeze"
+      "Proved padic_val_factorial_asymp: ν_p(n!)/n → 1/(p-1) via isLittleO_log_rpow_atTop + Nat.pow_log_le_self + epsilon-N squeeze",
+      "lin_bound: derived from lin_bound_meaning via Nat.sSup_def + pow_dvd_pow (axiomCount 2 → 1)"
     ],
     "insights": [
       "lin_bound and lin_bound_meaning both encode Lin 1976 result (f(2,2) ≤ 254) — deep, appropriate",
@@ -54,7 +55,9 @@
       "Key insight: digit-sum identity legendreSum*(p-1)+baseDigitSum=n is exact Nat equality, both bounds follow by omega",
       "Telescoping via division algorithm: (a/p)*(p-1) + a%p = a - a/p, summed over k=0..L",
       "Remaining sorry (Nat.log p n / n -> 0) needs sublinear bound on Nat.log",
-      "isLittleO_log_rpow_atTop with r=1 gives log(x)=o(x); composed with Nat.pow_log_le_self gives Nat.log p n ≤ Real.log n / Real.log p, yielding the sublinear bound for squeeze"
+      "isLittleO_log_rpow_atTop with r=1 gives log(x)=o(x); composed with Nat.pow_log_le_self gives Nat.log p n ≤ Real.log n / Real.log p, yielding the sublinear bound for squeeze",
+      "lin_bound and lin_bound_meaning were redundant: ¬(2^255 | factorialSum s) for all s implies divisiblePowers 2 2 ⊆ {0,...,254}, hence sSup ≤ 254",
+      "Use Nat.sSup_def + Nat.find_min' to bound sSup of a Set ℕ without needing a nonemptiness witness — cleaner than csSup_le for ℕ"
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -76,16 +79,16 @@
     "mathlib": []
   },
   "started": "2026-01-13T02:35:40.569Z",
-  "lastUpdate": "2026-03-29T00:30:00Z",
+  "lastUpdate": "2026-04-27T16:30:00Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/Erdos404Problem.lean",
       "filename": "Erdos404Problem.lean",
-      "lineCount": 292,
+      "lineCount": 290,
       "theoremCount": 7,
-      "axiomCount": 2,
+      "axiomCount": 1,
       "defCount": 8,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Summary

Eliminates one of the two Lin 1976 axioms in `Erdos404Problem.lean` by deriving `lin_bound : f 2 2 ≤ 254` from the more fundamental `lin_bound_meaning : ∀ s : StrictIncSeq 2, ¬(2^255 ∣ factorialSum s)`.

**Axiom delta**: 2 → 1 (lin_bound becomes a theorem; lin_bound_meaning remains as the primary Lin 1976 axiom).

## Mathematical Reasoning

The two axioms encoded essentially the same Lin 1976 result. They are not independent:

If `lin_bound_meaning` holds (no sequence has `2^255 ∣ factorialSum`), then for any `k ≥ 255`:
- If `k ∈ divisiblePowers 2 2`, then `∃ s, 2^k ∣ factorialSum s`
- Since `2^255 ∣ 2^k` (as `255 ≤ k`), transitivity gives `2^255 ∣ factorialSum s`
- This contradicts `lin_bound_meaning s`

Hence `divisiblePowers 2 2 ⊆ {0, 1, ..., 254}`, and `f 2 2 = sSup (divisiblePowers 2 2) ≤ 254` follows from `Nat.sSup_def` + `Nat.find_min'`.

## Proof Style

Uses `Nat.sSup_def` directly with the bounded-above hypothesis, avoiding the need to construct a nonemptiness witness for `divisiblePowers 2 2` — `Nat.find_min'` extracts the bound.

## Files Modified

- `proofs/Proofs/Erdos404Problem.lean`: 2 axioms → 1 axiom + 1 theorem
- `src/data/research/problems/erdos-404.json`: knowledge metadata updated to reflect 1A/0S

## Build Status

⚠️ Local Docker daemon is broken (corrupted containerd blob, I/O error) — could not run docker-build verification on this machine. The proof uses standard Mathlib lemmas (`Nat.sSup_def`, `Nat.find_min'`, `pow_dvd_pow`, `dvd_trans`) and should build cleanly. CI should verify.

## Status

**Outcome**: progress (axiom elimination)
**Next Steps**:
- CI build verification
- Continue research: the remaining axiom `lin_bound_meaning` encodes Lin (1976), a deep result from a Bell Labs internal memorandum — likely not provable from Mathlib alone

🤖 Generated by researcher-7