### PR TITLE
audit: erdos-982 (clean) + erdos-985 (issues-found, see #13292)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10480,9 +10480,9 @@
     },
     "erdos-985": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-27T16:49:09Z",
+      "result": "issues-found"
     },
     "erdos-986": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10462,9 +10462,9 @@
     },
     "erdos-982": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-27T16:45:04Z",
+      "result": "clean"
     },
     "erdos-983": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Gallery integrity audit covering two proofs.

## erdos-982 (Distinct Distances from Convex Polygon Vertices) — CLEAN

- **Sorries**: 3 (lines 197, 210, 331) ✓ matches `meta.json`
- **Axioms**: 4 (`moser_bound`, `nppz_bound`, `regular_polygon_distances`, `stronger_conjecture_is_false`) ✓ matches `axiomCount: 4`
- **Status**: `axiomatized` / **Badge**: `axiom` — correct for open problem
- **Tier C** (axiomatized scaffold) — appropriate
- **No True stubs**, lineCount 333 ✓

Result: clean.

## erdos-985 (Prime Primitive Roots) — ISSUES FOUND

- **Sorries**: 0 ✓ / **Axioms**: 2 (`heath_brown_theorem`, `erdos_985_conjecture`) ✓
- **Status / Badge**: `axiomatized` / `axiom` — correct
- **Theorem / definition counts** match (18 / 3)

**Issue**: `artin_implies_erdos_985` (lines 185–192) is listed in `originalContributions` as a "connection theorem" linking Artin's conjecture to Erdős 985, but its proof body ignores the `h_artin` hypothesis and calls `erdos_985_conjecture` (the axiom asserting the conclusion) directly. The theorem is therefore vacuous and overstates the formalization.

Filed: #13292

## Tracker Updates

- `erdos-982`: auditCount 2 → 3, result `clean`
- `erdos-985`: auditCount 2 → 3, result `issues-found`

🤖 Gallery integrity audit cycle (auditor agent).