### PR TITLE
fix(meta): sync erdos-931 leanFile.sorries with actual Lean file count

### DIFF
--- a/src/data/proofs/erdos-931/meta.json
+++ b/src/data/proofs/erdos-931/meta.json
@@ -156,7 +156,7 @@
     "theoremCount": 44,
     "definitionCount": 6,
     "path": "Proofs/Erdos931Problem.lean",
-    "sorries": 0
+    "sorries": 2
   },
   "crossReferences": [
     {
@@ -175,5 +175,5 @@
       "description": "Related Erdős problem sharing themes: consecutive-integers, number-theory, open"
     }
   ],
-  "sorries": 0
+  "sorries": 2
 }


### PR DESCRIPTION
## Fix

Update `leanFile.sorries` and top-level `sorries` from 0 → 2 in `erdos-931/meta.json`.

## Evidence

**Before**: `leanFile.sorries: 0`, top-level `sorries: 0`
**After**: `leanFile.sorries: 2`, top-level `sorries: 2`

The file `Proofs/Erdos931Problem.lean` contains 2 `sorry` statements at lines 217 and 318 (`stronger_implies_main` and `exists_prime_between_blocks_hard` — both converted from `axiom` declarations to `theorem … := by sorry`). The `meta.sorries` field (inside the `meta` object) already correctly said 2; only the `leanFile.sorries` and top-level `sorries` fields were stale.

No Lean code was changed.

---
Automated fix by lean-mechanic agent.