### PR TITLE
Research: binary-gcd-oq-02 — survey + path forward (Int extension)

### DIFF
--- a/research/problems/binary-gcd-oq-02/knowledge.md
+++ b/research/problems/binary-gcd-oq-02/knowledge.md
@@ -1,0 +1,91 @@
+# binary-gcd-oq-02: Binary GCD Algorithm for Integers or Bignums
+
+## Problem Summary
+
+**Open Question**: Can the binary GCD algorithm (Stein 1967) be extended to:
+1. **Integers** (handling negative inputs)?
+2. **Bignums** (multi-precision arithmetic)?
+
+The Nat version is already formalized in `Proofs/GcdAlgorithmOQ02.lean:74` as
+`binaryGcd : ℕ → ℕ → ℕ`.
+
+## Session 2026-04-27 (Session 1) - SURVEY
+
+**Mode**: FRESH
+**Outcome**: surveyed — identified path forward, no Lean code added
+
+### What I Did
+- Audited the binary-gcd family of files: BinaryGcdOQ01, OQ01OQ03, OQ01OQ04,
+  OQ03, OQ03OQ01 (5 files, all 0 sorries / 0 axioms / many theorems).
+- Located the canonical `binaryGcd : ℕ → ℕ → ℕ` definition at
+  `Proofs/GcdAlgorithmOQ02.lean:74`.
+- Confirmed `Int.gcd` exists in Mathlib (`Mathlib.Data.Int.GCD`), giving a
+  reference target.
+- Identified that no `BinaryGcdOQ02.lean` file currently exists.
+
+### Path Forward (Integer Extension)
+
+The cleanest formalization route:
+
+```lean
+namespace BinaryGcdOQ02
+
+/-- Binary GCD on integers: take absolute values, delegate to ℕ binary GCD,
+    cast back to ℕ (since gcd ≥ 0 always). -/
+def binaryGcdInt (a b : ℤ) : ℕ := binaryGcd a.natAbs b.natAbs
+
+/-- Correctness: matches Mathlib's Int.gcd. -/
+theorem binaryGcdInt_eq_intGcd (a b : ℤ) :
+    binaryGcdInt a b = Int.gcd a b := by
+  -- Int.gcd is defined as a.natAbs.gcd b.natAbs (Mathlib).
+  -- binaryGcd a.natAbs b.natAbs = Nat.gcd a.natAbs b.natAbs (from
+  -- the existing binaryGcd_correct proof in GcdAlgorithmOQ02 or family).
+  sorry
+
+end BinaryGcdOQ02
+```
+
+**Estimated size**: ~50-80 lines including imports, namespace, sign handling
+edge cases, and the correctness proof (which reduces to existing
+`binaryGcd_correct` once the `natAbs` reduction is in place).
+
+### Path Forward (Bignum Extension)
+
+This is more open-ended. Mathlib does not expose a "bignum" type per se;
+`Nat` is unbounded. The interesting question is whether the *implementation*
+of binary GCD on Mathlib's `Nat` (via the Lean kernel's GMP-backed `Nat`)
+matches the algorithm spec — which is more about computational efficiency
+than mathematical content.
+
+A formalization-friendly proxy: extend `binaryGcd` to operate on bit
+sequences directly (via `Nat.bits` or `Nat.digits 2`) and prove equivalence.
+This is significantly more work (~200+ lines) and is more of a project than
+a single research session.
+
+### Key Findings
+
+- The integer extension is **mechanical and tractable** (~50 lines).
+- The bignum extension is **research-level / project-scale** unless we
+  redirect toward bit-sequence formalization.
+- No new Mathlib lemmas needed for the integer case beyond `Int.gcd_natAbs_left`
+  (or its equivalent) and existing `binaryGcd_correct`.
+
+### Files Surveyed
+- `proofs/Proofs/GcdAlgorithmOQ02.lean` (defines `binaryGcd : ℕ → ℕ → ℕ`)
+- `proofs/Proofs/BinaryGcdOQ01.lean` (step-count comparison)
+- `proofs/Proofs/BinaryGcdOQ01OQ03.lean`, `BinaryGcdOQ01OQ04.lean`,
+  `BinaryGcdOQ03.lean`, `BinaryGcdOQ03OQ01.lean` (related properties)
+
+### Next Steps
+1. Create `proofs/Proofs/BinaryGcdOQ02.lean` with the integer extension and
+   correctness theorem. Verify via Docker build.
+2. Document the bignum question as a separate (deferred) sub-problem
+   given its larger scope.
+3. Add gallery entry data (`src/data/proofs/binary-gcd-oq-02/meta.json`)
+   when the proof is verified.
+
+### Why a Survey Outcome (Not Implementation)
+This session lacked Docker access for build verification. Submitting
+unverified Int-extension code with `sorry`s is lower-value than a clear
+survey + path. Future researcher sessions can complete the formalization
+with a single Docker-verified PR (~50 lines).

--- a/research/problems/binary-gcd-oq-02/state.md
+++ b/research/problems/binary-gcd-oq-02/state.md
@@ -1,27 +1,32 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-04-03T12:03:52.282Z
+**Phase**: ORIENT
+**Since**: 2026-04-27
 **Iteration**: 1
 
 ## Current Focus
 
-Initial exploration of the problem.
+Survey complete. Identified path: extend `binaryGcd : ℕ → ℕ → ℕ`
+(`Proofs/GcdAlgorithmOQ02.lean:74`) to `binaryGcdInt : ℤ → ℤ → ℕ` via
+`natAbs` reduction. Bignum extension deferred (project-scale).
 
 ## Active Approach
 
-None yet.
+Integer extension via `binaryGcdInt a b := binaryGcd a.natAbs b.natAbs`,
+with correctness proved against Mathlib's `Int.gcd`.
 
 ## Blockers
 
-None.
+- Docker not available this session — implementation deferred to next
+  session for build verification.
 
 ## Next Action
 
-Begin problem exploration.
+Create `proofs/Proofs/BinaryGcdOQ02.lean` with integer extension.
+Estimated 50-80 lines. Verify via `./proofs/scripts/docker-build.sh`.
 
 ## Attempt Counts
 
-- Total attempts: 0
+- Total attempts: 1 (survey)
 - Current approach attempts: 0
 - Approaches tried: 0

--- a/src/data/research/problems/binary-gcd-oq-02.json
+++ b/src/data/research/problems/binary-gcd-oq-02.json
@@ -1,7 +1,7 @@
 {
   "slug": "binary-gcd-oq-02",
   "title": "Binary GCD Algorithm for Integers or Bignums",
-  "phase": "NEW",
+  "phase": "ORIENT",
   "status": "active",
   "tier": "B",
   "path": "fast",
@@ -16,24 +16,36 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-04-03T12:03:52.282Z",
+    "phase": "ORIENT",
+    "since": "2026-04-27",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "Survey complete. Path: extend Nat binaryGcd to Int via natAbs reduction; defer bignum extension.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Create proofs/Proofs/BinaryGcdOQ02.lean (~50-80 lines) with Docker verification.",
     "attemptCounts": {
-      "total": 0,
+      "total": 1,
       "currentApproach": 0,
       "approachesTried": 0
     }
   },
   "knowledge": {
-    "progressSummary": "",
+    "progressSummary": "SURVEYED: Located binaryGcd:ℕ→ℕ→ℕ at GcdAlgorithmOQ02.lean:74. Identified clean path: binaryGcdInt a b := binaryGcd a.natAbs b.natAbs, prove = Int.gcd (~50 lines). Bignum extension is project-scale, deferred.",
     "builtItems": [],
-    "insights": [],
+    "insights": [
+      "binaryGcd:ℕ→ℕ→ℕ already defined at proofs/Proofs/GcdAlgorithmOQ02.lean:74 (with both-even/one-even/both-odd cases)",
+      "Mathlib has Int.gcd a b := a.natAbs.gcd b.natAbs — correct comparison target for integer extension",
+      "Integer extension is mechanical: binaryGcdInt a b := binaryGcd a.natAbs b.natAbs, prove correct via existing binaryGcd_correct + Int.gcd unfold (~50 lines)",
+      "Bignum extension is project-scale: would require formalizing bit-sequence representations (Nat.bits / Nat.digits 2) since Lean Nat is already unbounded — ~200+ lines for non-trivial reformulation",
+      "5 sibling files (BinaryGcdOQ01, OQ01OQ03, OQ01OQ04, OQ03, OQ03OQ01) all 0 sorries / 0 axioms — established formalization style available",
+      "Did not create OQ02 file this session due to no Docker availability — submitting unverified Int extension with surrogate sorry would be lower-value than a clear survey"
+    ],
     "mathlibGaps": [],
-    "nextSteps": []
+    "nextSteps": [
+      "Create proofs/Proofs/BinaryGcdOQ02.lean defining binaryGcdInt and proving binaryGcdInt_eq_intGcd",
+      "Verify via ./proofs/scripts/docker-build.sh Proofs.BinaryGcdOQ02",
+      "Add gallery meta.json once verified",
+      "Document bignum question as deferred sub-problem (project-scale)"
+    ]
   },
   "tags": [
     "algorithm",
@@ -53,7 +65,7 @@
     "mathlib": []
   },
   "started": "2026-04-03T12:03:52.282Z",
-  "lastUpdate": "2026-04-03T12:03:52.282Z",
+  "lastUpdate": "2026-04-27T00:00:00Z",
   "significance": 5,
   "tractability": 7,
   "leanFiles": [


### PR DESCRIPTION
## Summary
Session 1 (FRESH) on binary-gcd-oq-02. Survey-only outcome documenting the formalization path; no Lean code added because local Docker was unavailable.

## Progress
- Surveyed the binary-gcd family of files (5 siblings, all 0-sorry / 0-axiom)
- Located the canonical `binaryGcd : ℕ → ℕ → ℕ` definition at `Proofs/GcdAlgorithmOQ02.lean:74`
- Confirmed `Int.gcd a b := a.natAbs.gcd b.natAbs` in Mathlib as the correctness target
- Phase advanced **NEW → ORIENT**

## Findings
- **Integer extension is mechanical** (~50 lines): define `binaryGcdInt a b := binaryGcd a.natAbs b.natAbs`, prove `binaryGcdInt = Int.gcd` via `binaryGcd_correct` + `Int.gcd` unfold.
- **Bignum extension is project-scale**: Lean's `Nat` is already unbounded; meaningful reformulation requires bit-sequence representation (`Nat.bits` / `Nat.digits 2`), ~200+ lines.

## Why a Survey (Not Implementation)
Submitting unverified Int-extension code with `sorry`s is lower-value than a clear survey + path. Future sessions can complete the formalization with a single Docker-verified PR (~50 lines).

## Status
**Outcome**: surveyed
**Next Steps**:
1. Create `proofs/Proofs/BinaryGcdOQ02.lean` with `binaryGcdInt` and correctness theorem
2. Verify via `./proofs/scripts/docker-build.sh Proofs.BinaryGcdOQ02`
3. Add gallery `meta.json` once verified
4. Document bignum question as deferred sub-problem

## Files Changed
- `research/problems/binary-gcd-oq-02/knowledge.md` (new)
- `research/problems/binary-gcd-oq-02/state.md` (NEW → ORIENT)
- `src/data/research/problems/binary-gcd-oq-02.json` (phase + insights)

🤖 Generated by researcher-4