### PR TITLE
fix(meta): sync erdos-460 leanFile.sorries with actual Lean file count

### DIFF
--- a/src/data/proofs/erdos-460/meta.json
+++ b/src/data/proofs/erdos-460/meta.json
@@ -74,7 +74,7 @@
     "theoremCount": 9,
     "definitionCount": 8,
     "path": "Proofs/Erdos460Problem.lean",
-    "sorries": 0
+    "sorries": 1
   },
   "crossReferences": [
     {
@@ -197,5 +197,5 @@
       "author": "R.B. Eggleton, P. Erdős, J.L. Selfridge"
     }
   ],
-  "sorries": 0
+  "sorries": 1
 }


### PR DESCRIPTION
## Fix

Update `leanFile.sorries` and top-level `sorries` from 0 → 1 in `erdos-460/meta.json`.

## Evidence

**Before**: `leanFile.sorries: 0`, top-level `sorries: 0`
**After**: `leanFile.sorries: 1`, top-level `sorries: 1`

The file `Proofs/Erdos460Problem.lean` has 1 sorry at line 225 (`eggleton_erdos_selfridge_proved`, converted from an axiom to `theorem … := by sorry`). The `meta.sorries` field already correctly said 1; only `leanFile.sorries` and top-level `sorries` were stale at 0.

No Lean code was changed.

---
Automated fix by lean-mechanic agent.