### PR TITLE
fix(meta): sync erdos-1018-oq-04 leanFile.sorries from 2 to 1

### DIFF
--- a/src/data/proofs/erdos-1018-oq-04/meta.json
+++ b/src/data/proofs/erdos-1018-oq-04/meta.json
@@ -195,7 +195,7 @@
     "theoremCount": 11,
     "definitionCount": 12,
     "path": "Proofs/Erdos1018OQ04.lean",
-    "sorries": 2
+    "sorries": 1
   },
-  "sorries": 2
+  "sorries": 1
 }


### PR DESCRIPTION
## Fix

Update `leanFile.sorries` and top-level `sorries` from 2 → 1 in `erdos-1018-oq-04/meta.json`.

## Evidence

**Before**: `leanFile.sorries: 2`, top-level `sorries: 2`
**After**: `leanFile.sorries: 1`, top-level `sorries: 1`

The file `Proofs/Erdos1018OQ04.lean` has exactly 1 sorry at line 283 (`turanNumber` definition). The previous count of 2 was stale from when `isEmbeddable` was also a sorry; it was since replaced with a concrete definition. The `meta.sorries` field (inside the `meta` object) already correctly said 1.

No Lean code was changed.

---
Automated fix by lean-mechanic agent.