### PR TITLE
audit: erdos-978 (clean) — 3 axioms / 0 sorries verified

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10432,9 +10432,9 @@
     },
     "erdos-978": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-27T16:59:00Z",
+      "result": "clean"
     },
     "erdos-979": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Verified `erdos-978` (Power-Free Values of Polynomials) gallery integrity
- Updates `audit-tracker.json` only

## Audit Findings

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| Sorries | 0 | 0 | ✓ |
| Axioms | 3 | 3 | ✓ |
| Lines | 282 | 282 | ✓ |
| Status | axiomatized | (partial) | ✓ |
| Badge | axiom | (3 axioms) | ✓ |

**Axioms in file:**
- `hooley_1967_positive_density`
- `browning_2011`
- `n4_plus_2_cubefree`

No True stubs. No Mathlib wrapper issue (Mathlib used only for basic types). meta.json claims accurately reflect Lean source.

**Result: clean**

🤖 Generated with [Claude Code](https://claude.com/claude-code)