### PR TITLE
fix(meta): sync hurwitz-theorem-oq-04 leanFile.sorries 1→2

### DIFF
--- a/src/data/proofs/hurwitz-theorem-oq-04/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-04/meta.json
@@ -141,7 +141,7 @@
     "axiomCount": 0,
     "theoremCount": 60,
     "definitionCount": 19,
-    "sorries": 1,
+    "sorries": 2,
     "path": "Proofs/HurwitzTheoremOQ04.lean"
   },
   "crossReferences": [
@@ -156,5 +156,5 @@
       "description": "Sibling open question: n-square identities and normed division algebras"
     }
   ],
-  "sorries": 1
+  "sorries": 2
 }

--- a/src/data/proofs/hurwitz-theorem-oq-04/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-04/meta.json
@@ -18,10 +18,10 @@
       "advanced"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 2,
     "dateAdded": "2026-04-24",
     "axiomCount": 0,
-    "assumptions": "1 sorry in G2_der_dimension proof chain: derEval14_injective — off-diagonal entries (j in {1,...,7}, i != 0, i != j) of the imaginary basis kernel claim. The j = 0 case is closed via submodule_der_unit_zero; the i = j diagonal case (Session 7, 2026-04-27) is closed via submodule_der_diagonal_kill (Leibniz at (e_j, e_j) using stdBasis_sq_neg_unit). Remaining 49-entry off-diagonal block requires antisymmetry ((f e_i)_j + (f e_j)_i = 0 from Leibniz at (e_i, e_j) + (e_j, e_i)) and Fano-line trilinear constraints. derBasis14_linearIndependent was proved in PR #13121. The Aut(O) is in O(7) — fully proved with 0 sorries.",
+    "assumptions": "2 sorries in G2_der_dimension proof chain: (1) derEval14_injective — off-diagonal entries of the imaginary basis kernel claim; (2) derBasis14_linearIndependent — 14×14 evaluation matrix determinant argument. The Aut(O) is in O(7) — fully proved with 0 sorries.",
     "lineCount": 1180,
     "theoremCount": 60,
     "definitionCount": 19,


### PR DESCRIPTION
## Fix

Update `leanFile.sorries` and top-level `sorries` from 1 → 2 in `hurwitz-theorem-oq-04/meta.json`.

## Evidence

**Before**: `leanFile.sorries: 1`, top-level `sorries: 1`
**After**: `leanFile.sorries: 2`, top-level `sorries: 2`

The file `Proofs/HurwitzTheoremOQ04.lean` has 2 sorry statements:
- Line 787: in `derEval14_injective` proof (off-diagonal kernel entries for D_{ij})
- Line 804: in `derBasis14_linearIndependent` proof (14×14 evaluation matrix determinant)

Both support the main `G2_der_dimension` theorem. No Lean code was changed.

---
Automated fix by lean-mechanic agent.