### PR TITLE
Research(erdos-269): add pow_isPSmooth structural lemma

### DIFF
--- a/proofs/Proofs/Erdos269Problem.lean
+++ b/proofs/Proofs/Erdos269Problem.lean
@@ -74,6 +74,22 @@ theorem isPSmooth_mul {P : Set ℕ} {m n : ℕ} (hm : IsPSmooth P m) (hn : IsPSm
     · exact hm.2 p hp h
     · exact hn.2 p hp h
 
+/-- Powers of a prime in P are P-smooth: if p ∈ P is prime and k ≥ 1, then p^k is P-smooth.
+
+This is the structural building block for the "P infinite ⇒ {a_n} infinite" argument:
+if any prime p lies in P, then the powers p, p², p³, ... give infinitely many P-smooth
+numbers, so the smoothSeq sequence is well-defined for all indices. -/
+theorem pow_isPSmooth {P : Set ℕ} {p : ℕ} (hp : p.Prime) (hpP : p ∈ P)
+    {k : ℕ} (hk : 1 ≤ k) : IsPSmooth P (p ^ k) := by
+  refine ⟨Nat.pos_pow_of_pos k hp.pos, ?_⟩
+  intro q hq hdiv
+  -- q is prime and q ∣ p^k, so q ∣ p
+  have hqp : q ∣ p := hq.dvd_of_dvd_pow hdiv
+  -- q is prime divisor of prime p, so q = p
+  have heq : q = p :=
+    (Nat.Prime.eq_one_or_self_of_dvd hp q hqp).resolve_left hq.ne_one
+  rwa [heq]
+
 /- ## Part II: The Sequence of P-smooth Numbers -/
 
 /--

--- a/src/data/proofs/erdos-269/meta.json
+++ b/src/data/proofs/erdos-269/meta.json
@@ -62,10 +62,11 @@
       "erdos_269_distinct axiom: distinct-term series is irrational",
       "twoThreeSmooth example: P = {2,3}",
       "lcmPadicVal definition: p-adic valuation of L_n",
-      "distinctLcmSeries definition: series without duplicate terms"
+      "distinctLcmSeries definition: series without duplicate terms",
+      "pow_isPSmooth: p^k is P-smooth for prime p ∈ P, k ≥ 1 (structural building block for P infinite ⇒ {a_n} infinite)"
     ],
     "axiomCount": 3,
-    "lineCount": 287,
+    "lineCount": 303,
     "assumptions": "3 axiom(s): erdos_269 (main conjecture, OPEN), erdos_269_infinite (infinite P case), erdos_269_distinct (distinct LCM case). Former axiom smoothSeq_zero now proved."
   },
   "overview": {
@@ -201,9 +202,9 @@
       "Finset"
     ],
     "namespace": "Erdos269",
-    "lineCount": 287,
+    "lineCount": 303,
     "axiomCount": 3,
-    "theoremCount": 14,
+    "theoremCount": 15,
     "definitionCount": 9,
     "path": "Proofs/Erdos269Problem.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-269.json
+++ b/src/data/research/problems/erdos-269.json
@@ -18,10 +18,10 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-01-12T22:30:27.389Z",
-    "iteration": 2,
-    "focus": "Axiom elimination + Mathlib compatibility fixes",
+    "iteration": 3,
+    "focus": "Surveyed; problem essentially complete with appropriate axiomatization. Added one routine structural lemma.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Move to other problems. Future deep work: formalize the infinite-P case using irrationality criterion + p-adic estimates (substantial multi-session effort).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,13 +29,14 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: 3A appropriate, 14T proved (+2 structural: partialLcm_dvd_succ, smoothSeq_dvd_partialLcm), 0S. Fixed meta.json stale originalContributions and lineCount.",
+    "progressSummary": "ROUTINE: Added pow_isPSmooth structural lemma. Total: 15T, 3A (all appropriate), 0S, 303 lines. No further axiom elimination possible — the three remaining axioms (erdos_269 finite OPEN, erdos_269_infinite, erdos_269_distinct) require deep analytic infrastructure beyond Mathlib.",
     "builtItems": [
       "theorem smoothSeq_zero (Nat.nth_count proof, 8 lines)",
       "Fixed one_isPSmooth (2 lines, simpler proof)",
       "Fixed partialLcm_succ, erdos_269_equivalent, lcmPadicVal",
       "partialLcm_dvd_succ: L_n | L_{n+1} (Nat.dvd_lcm_left)",
-      "smoothSeq_dvd_partialLcm: a_k | L_n for k < n (Finset.dvd_lcm)"
+      "smoothSeq_dvd_partialLcm: a_k | L_n for k < n (Finset.dvd_lcm)",
+      "pow_isPSmooth (Erdos269Problem.lean:~78): p^k is P-smooth for prime p ∈ P and k ≥ 1 (structural building block for P infinite ⇒ {a_n} infinite). Adds 1 theorem (14→15), 16 lines (287→303). Axiom count unchanged (3) — no further reduction possible per prior session."
     ],
     "insights": [
       "smoothSeq_zero provable: 1 is min P-smooth number (count 1 = 0 since IsPSmooth P 0 fails)",
@@ -70,7 +71,7 @@
     "mathlib": []
   },
   "started": "2026-01-12T22:30:27.390Z",
-  "lastUpdate": "2026-03-29T18:10:00.000Z",
+  "lastUpdate": "2026-04-27T17:15:00Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [


### PR DESCRIPTION
## Summary

Adds one routine structural lemma `pow_isPSmooth`: for prime p ∈ P with k ≥ 1, p^k is P-smooth.

This is the building block for the "infinite P ⇒ infinite smoothSeq witnesses" argument.

## Progress

- **Erdos269Problem.lean** (287 → 303 lines, theoremCount 14 → 15)
- **meta.json**, **research-problem JSON**: counts synced

## Honest status

The problem is essentially complete from an axiomatization perspective:
- 3 appropriate axioms (`erdos_269` open conjecture, `erdos_269_infinite` and
  `erdos_269_distinct` proved by Erdős but require deep analytic infrastructure)
- 0 sorries
- 15 theorems
- No further axiom reduction is possible per prior session analysis

This PR adds incremental structural value but does not advance the open problem.

## Status

**Outcome**: routine (small structural lemma added; no axiom elimination)

**Next Steps**: Future work would require formalizing the infinite-P irrationality argument (uses irrationality criterion + p-adic estimates) — substantial multi-session effort beyond the scope of single-iteration research.

🤖 Generated by researcher-9