### PR TITLE
audit(erdos-1059-oq-01): remove phantom 5209/5573 witnesses, add Selberg theorems

### DIFF
--- a/src/data/proofs/erdos-1059-oq-01/meta.json
+++ b/src/data/proofs/erdos-1059-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-1059-oq-01",
   "title": "Density of Factorial-Avoiding Primes (Erdős 1059, OQ-01)",
   "slug": "erdos-1059-oq-01",
-  "description": "Formalizes the natural density question for Erdős Problem #1059: What fraction of all primes p satisfy AllFactorialSubtractionsComposite(p)? Provides a decidable instance, six new witnesses (461, 557, 673 at level 5; 769 at level 6; 5209, 5573 at level 7), a proved logarithmic bound on check counts, exact interval formula, counting functions C(x) and π(x), density gap (C(x) < π(x) for x ≥ 3) and density sandwich (0 < C(x) < π(x) for x ≥ 101), and axiomatizes the density-1 conjecture. 0 sorries, 1 axiom.",
+  "description": "Formalizes the natural density question for Erdős Problem #1059: What fraction of all primes p satisfy AllFactorialSubtractionsComposite(p)? Provides a decidable instance, four new witnesses (461, 557, 673 at level 5; 769 at level 6) extending the existing two (101, 211), a proved logarithmic bound on check counts, exact interval formula, counting functions C(x) and π(x), density gap (C(x) < π(x) for x ≥ 3), density sandwich (0 < C(x) < π(x) for x ≥ 101), infinitude of qualifying primes (imported from OQ-02 Selberg framework), and the Selberg lower bound C((N+3)!) ≥ N. Axiomatizes the density-1 conjecture. 0 sorries, 1 axiom (plus 1 imported from OQ-02).",
   "meta": {
     "author": "lean-genius researcher",
     "sourceUrl": "https://erdosproblems.com/1059",
@@ -60,20 +60,21 @@
       "decAllFact: Decidable instance for AllFactorialSubtractionsComposite via bounded quantifier over Finset.range n",
       "witness_461, witness_557, witness_673: three level-5 verified prime witnesses (p ∈ (120, 720))",
       "witness_769: first level-6 verified prime witness (p = 769 ∈ (720, 5040))",
-      "witness_5209, witness_5573: first level-7 verified prime witnesses (p ∈ (5040, 40320))",
-      "eight_prime_witnesses: summary theorem packaging eight verified witnesses (101, 211, 461, 557, 673, 769, 5209, 5573)",
-      "checkCount_*: verified factorial check counts (5 for p=101; 6 for p=211,461,557,673; 7 for p=769; 8 for p=5209,5573)",
+      "six_prime_witnesses: summary theorem packaging six verified witnesses (101, 211, 461, 557, 673, 769)",
+      "checkCount_*: verified factorial check counts (5 for p=101; 6 for p=211,461,557,673; 7 for p=769)",
       "factorialCheckCount_le_log: PROVED factorialCheckCount n ≤ ⌊log₂ n⌋ + 2 — formalizes the logarithmic check count bound",
       "factorialCheckCount_eq_of_interval: PROVED exact formula — factorialCheckCount n = l+1 when l! < n ≤ (l+1)!",
       "factorialCheckCount_const_on_interval: PROVED check count is constant within each factorial level",
       "qualifyingPrimeCount, primeCount: formal counting functions C(x) and π(x)",
       "qualifyingCount_le_primeCount: C(x) ≤ π(x) always",
-      "qualifyingPrimeCount_ge_eight: C(5573) ≥ 8 (eight verified witnesses)",
+      "qualifyingPrimeCount_ge_six: C(769) ≥ 6 (six verified witnesses)",
       "density_one_conjecture: density = 1 axiomatized (heuristic predicts all large primes qualify)",
       "three_not_qualifying: PROVED p = 3 is prime but fails AFSC (3 - 0! = 2 is prime)",
       "qualifyingPrimeCount_lt_primeCount: PROVED C(x) < π(x) for all x ≥ 3 — density < 1 at every finite stage",
       "qualifyingPrimeCount_pos: PROVED 0 < C(x) for all x ≥ 101 — density > 0 for large x",
-      "density_strictly_between: PROVED 0 < C(x) < π(x) for x ≥ 101 — density sandwich theorem"
+      "density_strictly_between: PROVED 0 < C(x) < π(x) for x ≥ 101 — density sandwich theorem",
+      "qualifyingPrimes_infinite: PROVED Set.Infinite {p | p.Prime ∧ AFSC(p)} via OQ-02's selberg_implies_erdos (definitional equality of AFSC)",
+      "qualifyingPrimeCount_ge: PROVED Selberg lower bound C((N+3)!) ≥ N — N qualifying primes from N disjoint primorial intervals via Classical.choose"
     ],
     "axiomCount": 1,
     "prerequisites": [
@@ -201,7 +202,9 @@
       "Mathlib.Data.Nat.Factorial.Basic",
       "Mathlib.Data.Nat.Log",
       "Mathlib.Data.Finset.Basic",
-      "Mathlib.Tactic"
+      "Mathlib.Data.Set.Basic",
+      "Mathlib.Tactic",
+      "Proofs.Erdos1059OQ02"
     ],
     "path": "Proofs/Erdos1059OQ01.lean",
     "sorries": 0,
@@ -223,8 +226,20 @@
     {
       "name": "factorialCheckCount_le_log",
       "type": "core",
-      "description": "PROVED: factorialCheckCount n ≤ ⌊log₂ n⌋ + 2 for n ≥ 2 — the formal logarithmic bound on check count",
-      "leanType": "∀ n ≥ 2, factorialCheckCount n ≤ Nat.log 2 n + 2"
+      "description": "PROVED: factorialCheckCount n ≤ ⌊log₂ n⌋ + 2 for all n — the formal logarithmic bound on check count (no n ≥ 2 hypothesis required)",
+      "leanType": "∀ n, factorialCheckCount n ≤ Nat.log 2 n + 2"
+    },
+    {
+      "name": "qualifyingPrimes_infinite",
+      "type": "derived",
+      "description": "PROVED (via OQ-02's Selberg framework): the set of primes satisfying AllFactorialSubtractionsComposite is infinite",
+      "leanType": "Set.Infinite {p : ℕ | p.Prime ∧ AllFactorialSubtractionsComposite p}"
+    },
+    {
+      "name": "qualifyingPrimeCount_ge",
+      "type": "derived",
+      "description": "PROVED (via OQ-02's Selberg axiom): the Selberg lower bound C((N+3)!) ≥ N for all N",
+      "leanType": "∀ N, qualifyingPrimeCount (Nat.factorial (N + 3)) ≥ N"
     },
     {
       "name": "density_one_conjecture",


### PR DESCRIPTION
## Summary

Documentation-integrity fix only — no Lean source changes.

The `meta.json` for erdos-1059-oq-01 had two categories of drift versus `proofs/Proofs/Erdos1059OQ01.lean`:

### Phantom claims (removed)
Items claimed in meta but NOT in the Lean file:
- `witness_5209`, `witness_5573` (level-7 witnesses) — file only has up to `witness_769`
- `eight_prime_witnesses` summary theorem — file has `six_prime_witnesses`
- `checkCount_5209`, `checkCount_5573` — file has `checkCount_769` as the largest
- `qualifyingPrimeCount_ge_eight: C(5573) ≥ 8` — file has `qualifyingPrimeCount_ge_six: C(769) ≥ 6`

### Missing claims (added)
The Lean file's header docstring lists items 14-15 that meta did not reflect:
- `qualifyingPrimes_infinite` — PROVED via OQ-02's `selberg_implies_erdos` (line 441)
- `qualifyingPrimeCount_ge` — PROVED Selberg lower bound `C((N+3)!) ≥ N` (line 487)

### Other fixes
- `leanFile.imports`: added `Mathlib.Data.Set.Basic` and `Proofs.Erdos1059OQ02` (file imports both at lines 46, 48; meta listed only 5 of the 7)
- `factorialCheckCount_le_log` `leanType`: removed spurious `n ≥ 2` hypothesis — actual theorem holds for all n
- `description`: replaced "six new witnesses ... 5209, 5573 at level 7" with "four new witnesses extending the 101, 211 from the main file"

## Verification

- `axiomCount=1`, `sorries=0` — both already accurate, unchanged
- Theorems re-verified by `grep -n '^theorem\|^axiom\|^def\|^private' Erdos1059OQ01.lean`
- JSON validates

## Test plan
- [x] `python3 -c "import json; json.load(open(...))"` validates
- [x] All claims in `originalContributions`, `mainTheorems`, `description` correspond to actual Lean declarations
- [ ] Gallery renders (will validate via deployer pipeline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)