### PR TITLE
audit: erdos-976 (issues-found, see #13343)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10419,9 +10419,9 @@
     },
     "erdos-976": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-27T17:32:53Z",
+      "result": "issues-found"
     },
     "erdos-977": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Marks erdos-976 audit as complete with `issues-found` status.
- Filed integrity issue #13343: meta.json `originalContributions` lists 4 axioms (`nagell_ricci_bound`, `erdos_1952_bound`, `tenenbaum_bound`, `trivial_upper_bound`) but only `tenenbaum_bound` is actually declared in the Lean source.

## Notes
- `axiomCount: 1` and status/badge are correct. Only the contributions list is misleading.
- Mechanic should remediate per recommended fix in #13343.

🤖 Generated with [Claude Code](https://claude.com/claude-code)