### PR TITLE
Fix: erdos-985 artin_implies_erdos_985 bypasses its hypothesis

### DIFF
--- a/proofs/Proofs/Erdos985Problem.lean
+++ b/proofs/Proofs/Erdos985Problem.lean
@@ -186,10 +186,12 @@ theorem artin_implies_erdos_985 :
     (∀ q, q.Prime → Set.Infinite {p : ℕ | p.Prime ∧ orderOf (q : ZMod p) = p - 1}) →
     ∀ p, p.Prime → p ≠ 2 → ∃ q, q.Prime ∧ q < p ∧ orderOf (q : ZMod p) = p - 1 := by
   intro h_artin p hp hp2
-  -- This requires showing that among the infinitely many primes for which
-  -- each small prime is a primitive root, there must be one ≤ p.
-  -- The actual proof is more subtle and requires quantitative bounds.
-  exact erdos_985_conjecture p hp hp2
+  -- Deriving Erdős 985 from Artin's conjecture requires a quantitative step:
+  -- the Artin hypothesis gives infinitely many p' for which each prime q is a
+  -- primitive root, but we need to find such a prime q < p specifically for p.
+  -- This gap requires a Linnik-type upper bound (smallest p' ≤ f(q)) and is
+  -- not yet formalized here.
+  sorry
 
 /- ## Summary -/
 


### PR DESCRIPTION
## Fix

Replace the vacuous `exact erdos_985_conjecture` proof in `artin_implies_erdos_985` with `sorry`, documenting the missing quantitative connection. Update meta.json to accurately reflect 1 sorry.

## Evidence

**Before**: `artin_implies_erdos_985` took Artin's conjecture as a hypothesis but ignored it, calling `erdos_985_conjecture` (an axiom) directly. The theorem was logically equivalent to the axiom — providing no mathematical content beyond it. meta.json claimed `sorries: 0` and `sections[connections].mathContext: "Verified"`.

**After**: The proof body is replaced with `sorry` and a comment explaining the missing quantitative step (Linnik-type upper bound needed to go from Artin's infinite density to a specific prime q < p). meta.json updated: `sorries: 0 → 1` in all three fields; `assumptions`, `originalContributions`, and `sections[connections].mathContext` updated to reflect the sorry.

The theorem statement is mathematically meaningful and kept.

Closes #13292

---
Automated fix by lean-mechanic agent.