### PR TITLE
research(shannon-source-coding-oq-04): audit — achievability statement is trivially true

### DIFF
--- a/research/problems/shannon-source-coding-oq-04/knowledge.md
+++ b/research/problems/shannon-source-coding-oq-04/knowledge.md
@@ -137,6 +137,117 @@ cannot be used in `dominant_type_lower_bound` (Section 2). Fix: inline the proof
 
 ---
 
+## Session 2026-04-27 (Session 4) — Statement Audit: `source_coding_achievability_mot` is Trivially True
+
+**Mode**: REVISIT (MODERATE knowledge tier, score 13)
+**Outcome**: AUDIT — identified a soundness issue with the remaining `sorry`'s theorem statement.
+Disk pressure (1.5 GiB free) blocks Docker verification, so this session contributes a
+specification audit only. No Lean source modifications.
+
+### The Issue
+
+The remaining sorry in `ShannonSourceCodingOQ04.lean:386` is in:
+
+```lean
+theorem source_coding_achievability_mot
+    (p : Fin k → ℝ) (hp_pos : ∀ i, 0 < p i) (hp_sum : ∑ i : Fin k, p i = 1)
+    (ε : ℝ) (hε : 0 < ε) :
+    ∀ δ > 0, ∃ N : ℕ, ∀ n ≥ N,
+    ∃ (code_length : ℕ),
+    (code_length : ℝ) ≤ n * (shannonEntropy p) + n * ε ∧
+    ∃ f : Fin k → ℕ, ∃ hf : ∑ i, f i = n,
+    (typeClass n f hf).card ≤ 2 ^ code_length := by
+  sorry
+```
+
+**This statement is trivially true**, because:
+
+1. The variable `δ` does not appear in the conclusion — `∀ δ > 0` can be eliminated.
+2. `code_length : ℕ` and the bound `(code_length : ℝ) ≤ n * H + n * ε`. Since `H ≥ 0` (it's
+   the Shannon entropy of a probability distribution; per the local definition at line 42, it
+   sums `-p_i log p_i` and for `0 < p_i ≤ 1` we have `log p_i ≤ 0`, so each term is non-negative),
+   and `ε > 0`, the right-hand side is `≥ 0`. So we can pick **`code_length = 0`**.
+3. With `code_length = 0`, we need `∃ f, hf, |typeClass n f hf| ≤ 2^0 = 1`. The **degenerate
+   type** `f i = if i = 0 then n else 0` (using `[NeZero k]` to know `0 : Fin k` exists)
+   satisfies `∑ i, f i = n`, and its type class is exactly `{const 0}` — a singleton.
+
+So a Lean proof of the trivial form is:
+
+```lean
+intro δ _
+refine ⟨0, fun n _ => ⟨0, ?_, fun i => if i = 0 then n else 0, ?_, ?_⟩⟩
+· -- 0 ≤ n * H + n * ε
+  have hH : 0 ≤ shannonEntropy p := shannonEntropy_nonneg p hp_pos hp_sum  -- needs lemma
+  positivity
+· -- ∑ i, (if i = 0 then n else 0) = n
+  rw [Finset.sum_ite_eq']; simp
+· -- |typeClass n (fun i => if i = 0 then n else 0) _| ≤ 1
+  have hSing : typeClass n (fun i => if i = 0 then n else 0) _ = {fun _ => 0} := by
+    ext x; simp [typeClass, empDist, Finset.mem_filter]
+    -- A sequence is in the class iff every position equals 0; that's the singleton {const 0}
+    sorry  -- ~10 lines of empDist analysis
+  rw [hSing]; simp
+```
+
+### Why This Matters
+
+- **The current sorry is provable in ~30 lines**, eliminating the badge `wip` and bringing the
+  proof to 0 sorries.
+- **However**, the resulting theorem does NOT capture Shannon's source coding achievability,
+  because:
+  - The "code" represented by `code_length = 0` covers **only one sequence** (the all-zero one),
+    not most sequences
+  - The actual achievability claim is: for any δ > 0, there exists a code of length
+    ≤ n(H(p) + ε) that **covers all but probability δ** of sequences (under the source
+    distribution p)
+  - The current statement makes no probability claim — it just exhibits one type's size
+
+### Recommended Strengthening
+
+The intended source coding theorem should look more like:
+
+```lean
+theorem source_coding_achievability_mot_strong
+    (p : Fin k → ℝ) (hp_pos : ∀ i, 0 < p i) (hp_sum : ∑ i, p i = 1)
+    (ε : ℝ) (hε : 0 < ε) :
+    ∀ δ > 0, ∃ N : ℕ, ∀ n ≥ N,
+    ∃ (S : Finset (Fin n → Fin k)),                          -- the code
+    (S.card : ℝ) ≤ Real.exp ((n : ℝ) * (shannonEntropy p + ε)) ∧
+    -- "Most" sequences are covered: under product measure ⊗p,
+    --   ∑_{x ∈ S} ∏ j, p (x j) ≥ 1 - δ
+    ∑ x ∈ S, ∏ j, p (x j) ≥ 1 - δ := by
+  sorry
+```
+
+This requires:
+1. Sum over `n`-fold product probability: `∑ x, ∏ j, p (x j)`
+2. Concentration around the dominant type via `type_class_size_le_entropy_pow` + LLN/AEP
+3. ~300-500 lines of additional infrastructure
+
+### Two-Track Recommendation
+
+**Track A (Quick Win, ~30 lines)**: Prove the trivial form to eliminate the sorry. Update
+meta.json to flag in description/conclusion that "achievability is stated weakly"; add a
+companion `axiom source_coding_achievability_mot_strong` for the real claim. Status changes
+to `axiomatized`.
+
+**Track B (Real Theorem, ~300-500 lines)**: Strengthen the statement and prove via the type-class
+infrastructure. This gives a genuinely new Lean proof of source coding via method of types,
+fulfilling the original goal of the OQ-04 problem.
+
+### Files NOT Modified This Session
+
+Disk pressure (1.5 GiB) prevented compile verification. All contributions are in `knowledge.md`
+and (in the next session) `state.md`.
+
+### Sorry Count: 1 (unchanged), but now flagged as low-content
+
+The sorry's statement is trivially true — eliminating it gives no real mathematical content.
+The next session should choose Track A (quick zero-sorry victory with weakening note) or
+Track B (real theorem, multi-session investment).
+
+---
+
 ## Session 2026-04-26 (Session 3) — Integrated Aristotle Proof of type_class_size_eq_multinomial
 
 **Mode**: REVISIT

--- a/research/problems/shannon-source-coding-oq-04/state.md
+++ b/research/problems/shannon-source-coding-oq-04/state.md
@@ -1,18 +1,20 @@
 # Research State: shannon-source-coding-oq-04
 
 ## Current State
-**Phase**: SCOPED — sorry isolated, proof outline in hand
+**Phase**: ACT (statement audit; awaiting decision between Track A vs Track B)
 **Since**: 2026-04-27T17:55:00Z
-**Iteration**: 2
+**Iteration**: 4
 
 ## Current Focus
 
-`proofs/Proofs/ShannonSourceCodingOQ04.lean` (429 lines, 0 axioms, 1 sorry).
-The single sorry is at line 386 in `source_coding_achievability_mot` — the main
-achievability theorem of the Shannon source coding theorem via the method of types.
+`ShannonSourceCodingOQ04.lean` has 1 remaining sorry at line 386, in
+`source_coding_achievability_mot`. Session 4 audit (2026-04-27) found that the **statement
+of this theorem is trivially true** — it does not actually capture Shannon's achievability
+claim because:
 
-**Definition of the local `shannonEntropy`** in this file is `H(p) = -∑ pᵢ log₂ pᵢ` and is
-used inside the conclusion.
+- `δ` does not appear in the conclusion
+- `code_length = 0` always works (since `n * H(p) + n * ε ≥ 0`)
+- The witness type `f = (n, 0, ..., 0)` has type class `{const 0}` (singleton, ≤ 2^0 = 1)
 
 The supporting infrastructure is already proved:
 
@@ -24,19 +26,51 @@ The supporting infrastructure is already proved:
 | `dominant_type_lower_bound` | Largest type class has ≥ k^n / (n+1)^k sequences |
 | `type_class_size_le_entropy_pow` | |T_f| ≤ 2^{n H(Q)} (entropy upper bound) |
 
-What remains for the sorry:
+## Active Approach
 
-The conclusion `(typeClass n f hf).card ≤ 2 ^ code_length` with
-`code_length ≤ n·H(p) + nε` must be exhibited together with the existence of
-the type vector `f`. The intended construction is:
-1. Choose `f` to be the dominant type (closest to `n·p` componentwise) — by
-   `dominant_type_lower_bound`, the dominant type class has size ≥ k^n / (n+1)^k.
-2. Bound that class size from above using `type_class_size_le_entropy_pow` for
-   the dominant type's empirical distribution Q (which is ε-close to p for
-   sufficiently large n by the standard Bernstein/Chernoff concentration).
-3. Set `code_length = ⌈n·H(p) + nε⌉` so 2^{code_length} ≥ 2^{n·H(p)+nε} ≥ |T_f|
-   for all sufficiently large n (by 2^{nε/2} eventually dominating the
-   entropy-continuity error |H(Q) - H(p)| ≤ ε/2).
+Two tracks identified:
+
+- **Track A** (Quick Win, ~30 lines): Prove the trivial form to eliminate the sorry.
+  Mark statement as weak in description; status → `axiomatized` (with companion axiom for the
+  real claim).
+- **Track B** (Real Theorem, ~300-500 lines): Strengthen the statement to capture
+  probability-mass coverage; prove via type-class size bounds + AEP / concentration.
+
+## Attempt Count
+- Total attempts: 4 (sessions 1-4)
+- Current approach attempts: 4
+- Approaches tried: 1 (combinatorial method-of-types infrastructure)
+
+## Blockers
+
+- **Disk pressure** (1.5 GiB free as of 2026-04-27) blocks Docker build verification.
+- Track B requires AEP-like concentration: `∑_x ∏_j p(x j) → 1 - O(ε)` for sequences in the
+  dominant type class. This needs LLN/concentration infrastructure (~300+ lines).
+
+## Next Action
+
+Decide between Track A and Track B (a human-level decision about formalization standards).
+
+If Track A:
+1. Prove the trivial form (~30 lines, see knowledge.md Session 4 for sketch)
+2. Add `shannonEntropy_nonneg` lemma if not in scope
+3. Add a clear note in the docstring/description that the statement is weak
+4. Add `axiom source_coding_achievability_mot_strong` for the real claim
+5. Update meta.json: status → `axiomatized`, badge → `axiom`
+
+If Track B:
+1. Replace the statement with the strong version (see knowledge.md)
+2. Build product-measure-on-`Fin n → Fin k` infrastructure (~50 lines)
+3. Prove dominant-type concentration via Chernoff or Hoeffding (~150 lines)
+4. Assemble achievability (~100 lines)
+5. Total: 1 sorry → 0 sorries with REAL achievability content
+
+## Key Mathlib Lemmas (Session 4 reference)
+
+- `shannonEntropy` (local, line 42): non-negative for probability distributions
+- `Finset.sum_ite_eq'`: gives `∑ i, (if i = a then x else 0) = x` for the degenerate type
+- `Real.exp_nonneg`: needed for the H + ε bound positivity
+- (Track B only) `Mathlib.Analysis.SpecificLimits.Basic`, `Mathlib.Probability.IdentDistrib`
 
 ## Mathlib API Survey (Mathlib 4.26.0)
 
@@ -53,46 +87,7 @@ file's `shannonEntropy` is locally defined). It does have KL divergence, from wh
 H(p) = log(k) - D(p ‖ uniform) for finite alphabets — could be used as a bridge if
 needed.
 
-## Active Approach
+## Remaining Work
 
-**Direction: close the sorry directly using the lemmas already in the file.**
-
-The proof is mostly bookkeeping: choose `code_length := Nat.ceil (n * shannonEntropy p + n * ε)`,
-exhibit the dominant type vector, and chain `dominant_type_lower_bound` with
-`type_class_size_le_entropy_pow`. The hardest sub-step is the **continuity-of-entropy**
-argument: for any δ > 0, there is N such that |H(Q) - H(p)| ≤ δ whenever ‖Q - p‖_∞ ≤ 1/N.
-This needs continuity of `shannonEntropy` (which is `x log x` integrable), but for the
-discrete finite-alphabet case it is just continuity of a polynomial-in-rpow expression.
-
-Estimated proof length: 50–80 lines of Lean.
-
-## Blockers
-
-**Disk space tight (2026-04-27): 90% capacity, ~1.4 GB free.** Closing the sorry
-requires several Docker iteration cycles to debug log/rpow manipulation (Lean's
-`Real.logb` lemmas are notoriously fiddly in proofs). Not safe this session per
-researcher feedback memory.
-
-## Next Action
-
-For a future researcher session (disk > 5 GB free):
-
-1. Read the file's `shannonEntropy` definition (around the imports) to confirm exact
-   form (logb base 2 vs. nats).
-2. Add a helper lemma `entropy_continuity_at_p`: for any δ > 0, ∃ N, ∀ Q with
-   ‖Q - p‖_∞ ≤ 1/N, |H(Q) - H(p)| ≤ δ. ~20 lines using `Continuous.tendsto`.
-3. Replace the sorry on line 386 by chaining `dominant_type_lower_bound` (existence
-   of the dominant type) with `type_class_size_le_entropy_pow` (size bound), then
-   bridge via the continuity lemma. ~40 lines.
-4. Build with `./proofs/scripts/docker-build.sh Proofs.ShannonSourceCodingOQ04`.
-5. Update `meta.json`: `sorries` 1 → 0, `status` `formalized` → `verified`,
-   `badge` `wip` → `verified`.
-
-This problem is **tractable in a single session** with disk headroom — the sorry is
-isolated and all supporting lemmas are already proved.
-
-## Attempt Counts
-- Total attempts: 1 (sorry isolation + Mathlib survey, no code changes)
-- Current approach attempts: 1
-- Approaches tried: 1 (proof-outline scoping — concluded single-session feasible
-  given Docker availability)
+- 1 sorry: `source_coding_achievability_mot` (line 386) — trivially provable per audit
+- For genuine achievability content: need product measure + AEP/concentration (Track B)


### PR DESCRIPTION
## Summary

Session 4 specification audit for `shannon-source-coding-oq-04`. Disk pressure (1.5 GiB free)
blocked Docker verification, so this PR contains **no Lean source changes** — only knowledge
and state documentation.

## Finding

The remaining sorry in `ShannonSourceCodingOQ04.lean:386` (in `source_coding_achievability_mot`)
is in a theorem whose statement is **trivially provable**:

1. The variable `δ` does not appear in the conclusion (vacuous quantifier)
2. `shannonEntropy p ≥ 0` for probability distributions ⇒ `n * H + n * ε ≥ 0`, so
   `code_length = 0` always satisfies the bound
3. The degenerate type `f = (n, 0, ..., 0)` (via `[NeZero k]`) yields type class `{const 0}`,
   a singleton ≤ 2^0 = 1

So a Lean proof of the *current* form is ~30 lines, but it has **no real mathematical content**.

## Two Tracks Documented

- **Track A** (~30 lines, quick): prove the trivial form, downgrade to `axiomatized`, add a
  companion axiom for the real claim
- **Track B** (~300-500 lines, substantive): strengthen the statement to require probability-mass
  coverage `∑ x ∈ S, ∏ j, p (x j) ≥ 1 - δ` and prove via type-class size bounds plus
  concentration / AEP

## Why This Matters

The current 1-sorry status is misleading. Eliminating it via the trivial proof gives a
"verified" theorem with no source-coding content. This audit lets the next session make an
informed decision before committing to a code change.

## Sorry Count

Unchanged: 1 sorry remains in `ShannonSourceCodingOQ04.lean:386`.

## Test plan

- [ ] No Lean code changed; existing build status unaffected
- [ ] Markdown renders correctly on GitHub
- [ ] Next-session pickup: state.md iteration 4 has explicit Track A/B decision criteria

🤖 Generated with [Claude Code](https://claude.com/claude-code)