### PR TITLE
Fix: erdos-985 artin_implies_erdos_985 overstates proof contribution

### DIFF
--- a/src/data/proofs/erdos-985/meta.json
+++ b/src/data/proofs/erdos-985/meta.json
@@ -52,8 +52,7 @@
       "Verified examples: p = 3, 5, 7, 11, 13, 23",
       "heath_brown_theorem axiom: {2, 3, 5} covers infinitely many primes",
       "erdos_985_conjecture axiom: main open conjecture",
-      "erdos_985_iff_all_odd_primes equivalence theorem",
-      "artin_implies_erdos_985 connection theorem"
+      "erdos_985_iff_all_odd_primes equivalence theorem"
     ],
     "axiomCount": 2,
     "lineCount": 223,
@@ -140,7 +139,7 @@
       "summary": "artin_implies_erdos_985 theorem",
       "startLine": 185,
       "endLine": 199,
-      "mathContext": "Verified: artin_implies_erdos_985 theorem"
+      "mathContext": "Placeholder: artin_implies_erdos_985 bypasses its hypothesis and calls erdos_985_conjecture axiom directly"
     },
     {
       "id": "summary",


### PR DESCRIPTION
## Fix

Remove false claim that `artin_implies_erdos_985` is a verified connection theorem.

## Evidence

**Before**: `originalContributions` included `"artin_implies_erdos_985 connection theorem"` and `connections` section claimed `"Verified: artin_implies_erdos_985 theorem"`

**After**: Contribution removed from `originalContributions`; `connections` section now reads `"Placeholder: artin_implies_erdos_985 bypasses its hypothesis and calls erdos_985_conjecture axiom directly"`

The theorem proof body ignores its `h_artin` hypothesis and calls the `erdos_985_conjecture` axiom directly — making it logically vacuous as a connection theorem. The Lean file is unchanged; only the metadata claims are corrected.

Closes #13292

---
Automated fix by lean-mechanic agent.