### PR TITLE
Add Aristotle companion file for SumOfKthPowersOQ04

### DIFF
--- a/proofs/Proofs/SumOfKthPowersOQ04Aristotle.lean
+++ b/proofs/Proofs/SumOfKthPowersOQ04Aristotle.lean
@@ -1,0 +1,31 @@
+/-
+  Aristotle targets for SumOfKthPowersOQ04
+
+  Routine supporting lemmas for automated proof search.
+  See SumOfKthPowersOQ04.lean for the main formalization.
+
+  Targets:
+  1. low_degree_poly_ratio_tendsto_zero: for q with deg(q) < d, q(n)/n^d → 0
+  2. monic_sub_pow_natDegree_lt: if p has deg d and leading coeff 1,
+     then deg(p - X^d) < d
+-/
+import Mathlib
+
+open Filter Polynomial
+
+namespace SumOfKthPowersAsymptotic
+
+/-- For a polynomial q over ℚ with degree < d, q(n)/n^d → 0 as n → ∞. -/
+lemma low_degree_poly_ratio_tendsto_zero (q : Polynomial ℚ) (d : ℕ)
+    (hd : 0 < d) (hdeg : q.natDegree < d) :
+    Tendsto (fun n : ℕ => q.eval (↑n : ℚ) / (↑n : ℚ) ^ d) atTop (nhds 0) := by
+  sorry
+
+/-- If p : Polynomial ℚ has natDegree = d and leadingCoeff = 1 and d > 0,
+    then (p - X^d).natDegree < d. -/
+lemma monic_sub_pow_natDegree_lt (p : Polynomial ℚ) (d : ℕ)
+    (hd_deg : p.natDegree = d) (hlc : p.leadingCoeff = 1) (hd : 0 < d) :
+    (p - Polynomial.X ^ d).natDegree < d := by
+  sorry
+
+end SumOfKthPowersAsymptotic


### PR DESCRIPTION
## Fix

Add Aristotle companion file targeting 2 routine sorries in `SumOfKthPowersOQ04.lean`.

## Evidence

**Before**: `SumOfKthPowersOQ04.lean` has 2 sorries explicitly marked "Routine" in comments but no companion file for automated proof search.

**After**: `SumOfKthPowersOQ04Aristotle.lean` exposes both lemmas with sorries for Aristotle:
- `low_degree_poly_ratio_tendsto_zero`: q(n)/n^d → 0 as n → ∞ when deg(q) < d
- `monic_sub_pow_natDegree_lt`: deg(p − X^d) < d when p has degree d and leading coeff 1

Both lemmas are routine algebra/analysis with no open conjectures — good Aristotle candidates.

---
Automated fix by lean-mechanic agent.