### PR TITLE
Add Aristotle companion file for Erdos589Problem

### DIFF
--- a/proofs/Proofs/Erdos589Aristotle.lean
+++ b/proofs/Proofs/Erdos589Aristotle.lean
@@ -1,0 +1,24 @@
+/-
+  Aristotle targets for Erdős Problem #589 (Points in General Position)
+  Routine supporting lemmas for automated proof search.
+  See Erdos589Problem.lean for the main formalization.
+
+  Target:
+  - erdos_belief_false: ¬ErdosBelief — follows from furedi_upper_bound.
+    Strategy: assume ∃ c > 0, ∀ n ≥ 1, g(n) ≥ c*n; apply furedi_upper_bound
+    with ε = c/2 to get N where ∀ n ≥ N, g(n) < (c/2)*n; pick n = max N 1;
+    both bounds hold, giving c*n ≤ g(n) < (c/2)*n, so c < c/2, contradiction.
+-/
+import Mathlib
+import Proofs.Erdos589Problem
+
+namespace Erdos589Aristotle
+
+open Erdos589
+
+/-- Erdős's linear belief was wrong: g(n) ≠ Ω(n).
+    Proof: furedi_upper_bound gives g(n) = o(n); this contradicts any linear lower bound. -/
+theorem erdos_belief_false : ¬ErdosBelief := by
+  sorry
+
+end Erdos589Aristotle


### PR DESCRIPTION
## Fix

Add Aristotle companion file targeting `erdos_belief_false` in `Erdos589Problem.lean`.

## Evidence

**Before**: `Erdos589Problem.lean` has a sorry in `erdos_belief_false` with no companion file for automated proof search.

**After**: `Erdos589Aristotle.lean` exposes the theorem for Aristotle:
- `erdos_belief_false : ¬ErdosBelief` — should follow from `furedi_upper_bound` (axiom in parent file). Strategy: assume `∃ c > 0, ∀ n ≥ 1, g(n) ≥ c*n`; apply `furedi_upper_bound` with `ε = c/2` to get `N` where `∀ n ≥ N, g(n) < (c/2)*n`; pick `n = max N 1`; contradiction via `c ≤ c/2`.

The other 2 sorries in the parent file are excluded:
- `trivial_lower_bound`: gap between `Nat.sqrt` and `Real.rpow` is mathematically incorrect as stated (axiom is too weak)
- `g_kl` def sorry: Aristotle skips definition sorries

---
Automated fix by lean-mechanic agent.