### PR TITLE
Add Aristotle companion file for Erdos240Problem

### DIFF
--- a/proofs/Proofs/Erdos240ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos240ProblemAristotle.lean
@@ -1,0 +1,20 @@
+/-
+  Aristotle targets for Erdos240Problem
+  Routine supporting lemmas for automated proof search.
+  See Erdos240Problem.lean for the main formalization.
+
+  Key target: singleton_large_gaps
+  A singleton prime set {p} gives unbounded P-smooth gaps.
+  Proof route: use finite_P_unbounded_gaps with Finset {p}, then coerce to Set.
+-/
+import Proofs.Erdos240Problem
+
+namespace Erdos240
+
+/-- A singleton prime set {p} gives unbounded P-smooth number gaps.
+    Proof: apply finite_P_unbounded_gaps to the singleton Finset {p},
+    then use Finset.coe_singleton to convert to the Set singleton. -/
+theorem singleton_large_gaps_aristotle (p : ℕ) (hp : p.Prime) :
+    gapsTendToInfinity {p} := by sorry
+
+end Erdos240


### PR DESCRIPTION
## Fix

Add Aristotle companion file exposing `singleton_large_gaps_aristotle` from Erdos240Problem.lean.

## Evidence

**Theorem**: For any prime p, `gapsTendToInfinity {p}` (the singleton set {p} yields unbounded P-smooth number gaps).

**Proof route**: The file has `finite_P_unbounded_gaps` as an axiom (for Finset P), and `{p} : Set ℕ` can be coerced from the singleton Finset via `Finset.coe_singleton`. Aristotle can discover this path using `apply`/`simp` tactics on the Finset ↔ Set relationship.

**Main file sorries**: Erdos240Problem.lean has 2 sorries:
- `singleton_large_gaps` — exposed here for Aristotle
- `erdos240_answer` — requires filter convergence arguments, not exposed (too complex)

---
Automated fix by lean-mechanic agent.