### PR TITLE
Research: 3-iteration session — birthday-oq03 reframe + erdos-689/erdos-750 metadata reconciliation

### DIFF
--- a/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01/knowledge.md
+++ b/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01/knowledge.md
@@ -6,18 +6,29 @@ Insights accumulated during research on this problem.
 
 ## Problem Understanding
 
-**Goal**: Remove `axiom poisson_approx_birthday3` from `BirthdayProblemOQ03OQ01OQ02.lean`
-by proving the Chen-Stein Poisson approximation bound:
+**Goal**: Remove `axiom poisson_approx_birthday3` from `BirthdayProblemOQ03OQ01OQ02.lean`.
 
+### Actual Axiom (Lean source, lines 325–334)
+
+```lean
+axiom poisson_approx_birthday3 (c : ℝ) (hc : 0 < c) :
+    let n : ℕ → ℕ := fun d => ⌊c * (d : ℝ) ^ ((2 : ℝ) / 3)⌋₊
+    Filter.Tendsto
+      (fun d : ℕ =>
+        (Finset.univ.filter (fun f : Fin (n d) → Fin d =>
+          ∀ i j k : Fin (n d), i ≠ j → j ≠ k → i ≠ k →
+            ¬(f i = f j ∧ f j = f k))).card /
+        (Fintype.card (Fin (n d) → Fin d) : ℝ) -
+        Real.exp (-(n d).choose 3 / (d : ℝ) ^ 2))
+      Filter.atTop (nhds 0)
 ```
-|triple_prob n d - (1 - exp(-C(n,3)/d²))| ≤ C · n⁴/d³
-```
 
-The axiom captures a Poisson limit theorem for birthday triple coincidences. The standard
-proof uses the Chen-Stein method (Arratia-Goldstein-Gordon 1989) for indicator sums of
-positively associated random variables.
+This is a **qualitative** convergence statement — the difference between
+P(no triple) and `exp(−C(n d, 3)/d²)` tends to 0 along `d → ∞`.
 
-**Critical block**: Chen-Stein is entirely absent from Mathlib 4.
+It is NOT the quantitative Chen-Stein bound `|...| ≤ C·n⁴/d³` shown in
+the JSON `problemStatement.formal` — that field had drifted from the
+actual Lean source and caused Session 1 to over-scope the work.
 
 ---
 
@@ -83,3 +94,105 @@ These confirm P(no triple | n=3) = (d³-d)/d³ = 1 - 1/d², matching exp(-1/d²)
 - **Chen-Stein from scratch this session**: Too large (~500-800 lines of measure theory infrastructure)
 - **Second moment → exact bound**: Second moment proves asymptotics, not explicit error bounds
 - **Union bound as proof of main axiom**: Only proves one direction, not the bilateral approximation bound
+
+---
+
+## Session 2026-04-27 (Session 2) - Reframing and Decomposition
+
+**Mode**: REVISIT (WEAK knowledge tier, score 5)
+**Outcome**: ORIENT — JSON drift corrected; axiom decomposed into sublemmas A/B/C
+
+### Why Revisit
+
+Per a saved feedback note from a prior session, the JSON `problemStatement.formal`
+field stated a **stronger goal** than the actual Lean axiom. Session 1 (2026-04-21)
+worked from the misleading JSON and concluded "BLOCKED on Chen-Stein, ~500-800 LoC".
+This session re-reads the Lean source as authoritative and re-scopes accordingly.
+
+### What I Did
+
+1. Read `BirthdayProblemOQ03OQ01OQ02.lean:325-334` directly to extract the actual axiom
+   signature; confirmed it is a qualitative `Filter.Tendsto ... atTop (nhds 0)` along
+   the threshold scaling `n d = ⌊c · d^(2/3)⌋`, not a quantitative `|...| ≤ C·n⁴/d³`.
+2. Updated `src/data/research/problems/<slug>.json`:
+   - Corrected `problemStatement.formal` to the actual Tendsto statement.
+   - Phase advanced NEW → ORIENT.
+   - Title changed from "Chen-Stein method for Poisson approximation" to
+     "Qualitative Poisson convergence for birthday triples" — matches what the
+     axiom actually claims.
+3. Decomposed the axiom into three sublemmas (below).
+
+### Decomposition Strategy (the main contribution of this session)
+
+Let `n_c(d) = ⌊c · d^(2/3)⌋` and `λ_c(d) = C(n_c(d), 3) / d²`. The axiom says
+`P_no_triple(n_c(d), d) − exp(−λ_c(d)) → 0`. Decompose:
+
+- **Lemma A (`lambda_tendsto`)**: `λ_c(d) → c³/6` as `d → ∞`.
+  - Routine asymptotic analysis: `C(n,3) = n(n-1)(n-2)/6` and `n_c(d) ~ c·d^(2/3)`,
+    so `λ_c(d) = n_c(d)·(n_c(d)−1)·(n_c(d)−2) / (6·d²) → c³ · d² / (6·d²) = c³/6`.
+  - Mathlib tooling: `Filter.Tendsto.div`, `Filter.Tendsto.mul`, `Nat.floor`
+    asymptotics already present (e.g., `Nat.floor_div_nat_eq_div`).
+  - Estimated size: 30–50 lines.
+
+- **Lemma B (`exp_lambda_tendsto`)**: `exp(−λ_c(d)) → exp(−c³/6)`.
+  - One-line proof: `Real.continuous_exp.tendsto.comp (Lemma A composed with neg)`.
+  - Estimated size: 5–10 lines.
+
+- **Lemma C (`p_no_triple_tendsto`)**: `P_no_triple(n_c(d), d) → exp(−c³/6)`.
+  - The genuine Poisson convergence — the only place Mathlib infrastructure is missing.
+  - Two known qualitative paths:
+    1. Method of factorial moments: `E[(X_d)_k] → (c³/6)^k` for each fixed `k`,
+       where `(X)_k = X(X−1)…(X−k+1)`. The factorial moments uniquely characterize
+       the Poisson distribution.
+    2. Coupling: define independent Bernoulli(1/d²) indicators on the same triples,
+       show their sum converges to Poisson(c³/6) by classical CLT-for-Bernoullis,
+       and bound coupling discrepancy → 0.
+  - Estimated size in Lean: ~200–400 lines (much smaller than Chen-Stein because
+    we don't need explicit error bounds — just convergence).
+
+The original axiom follows from A ∧ B ∧ C: if both `P_no_triple` and `exp(−λ)`
+converge to the same limit `exp(−c³/6)`, their difference converges to 0.
+
+### Why This Is Real Progress
+
+- **Session 1 framed the gap as Chen-Stein** (~500–800 lines of total-variation
+  machinery, including Stein's operator and dependency-graph constructions).
+- **The actual axiom is strictly weaker** and admits a decomposition where two
+  sublemmas (A, B) are routine and the third (C) is the classical Poisson
+  convergence by method of moments — substantially smaller than full Chen-Stein.
+- The Mathlib gap shrinks from "Chen-Stein quantitative bound" to
+  "method-of-factorial-moments → Poisson, qualitative form".
+
+### Files Modified
+
+- `src/data/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01.json`
+  (formal statement, phase, knowledge fields all updated to reflect actual axiom)
+- `research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01/knowledge.md` (this file)
+
+### Files NOT Modified
+
+- `proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean` — no Lean changes this session.
+  Disk space at 89%/1.6 GB free flagged Docker builds as risky per saved guidance,
+  so sublemmas A/B/C are deferred to a session with adequate disk.
+
+### Honest Assessment
+
+This session did **not** prove any Lean theorems. The contribution is a corrected
+research framing that prevents future sessions from repeating Session 1's
+over-scope error and a concrete decomposition that breaks the remaining Mathlib
+gap into a smaller, more focused target. Subsequent sessions can implement A and
+B mechanically (a few dozen lines each) and then attack only the genuine Poisson
+convergence statement C.
+
+### Next Steps
+
+1. **Next ACT session (when disk allows Docker builds)**:
+   - Add `lambda_tendsto` (Lemma A) — Filter.Tendsto.{mul,div} composition.
+   - Add `exp_lambda_tendsto` (Lemma B) — one-liner via continuous_exp.
+   - Restate the axiom as the simpler `p_no_triple_tendsto` (Lemma C only).
+2. **Future session**:
+   - Attack Lemma C via factorial-moment method — the primary new infrastructure
+     is `Finset.sum`-based factorial-moment computations for indicator sums and
+     a method-of-moments → Poisson lemma.
+3. Cross-reference `birthday-problem-oq-03-oq-01-oq-01` (n=2 baseline) to see if
+   any factorial-moment scaffolding there can be reused or generalized.

--- a/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01/state.md
+++ b/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01/state.md
@@ -1,29 +1,34 @@
 # Research State: birthday-problem-oq-03-oq-01-oq-02-oq-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ORIENT
 **Path**: full
-**Since**: 2026-04-21T06:38:17-07:00
-**Iteration**: 1
+**Since**: 2026-04-27T22:00:00-07:00
+**Iteration**: 2
 
 ## Current Focus
-Prove `axiom poisson_approx_birthday3` using the Chen-Stein method, removing it from
-BirthdayProblemOQ03OQ01OQ02.lean and reducing parent axiom count from 1 to 0.
+Prove `axiom poisson_approx_birthday3` (qualitative `Tendsto` form, NOT the
+quantitative Chen-Stein bound that the JSON `formal` previously misrepresented)
+by decomposing into three sublemmas A/B/C — see knowledge.md.
 
 ## Active Approach
-None yet. First step: read BirthdayProblemOQ03OQ01OQ02.lean to understand the exact
-axiom signature and what `triple_prob` represents, then search Mathlib for Poisson
-distribution and total variation infrastructure.
+Decomposition strategy:
+- Lemma A `lambda_tendsto`: `λ(d) := C(⌊c·d^(2/3)⌋, 3)/d² → c³/6` (routine).
+- Lemma B `exp_lambda_tendsto`: `exp(−λ(d)) → exp(−c³/6)` (continuity, one-liner).
+- Lemma C `p_no_triple_tendsto`: `P_no_triple(n d, d) → exp(−c³/6)` (Poisson
+  convergence — only sublemma requiring new Mathlib infrastructure).
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1 (Session 1, 2026-04-21, BLOCKED — over-scoped to quantitative Chen-Stein)
+- Current approach attempts: 0 (decomposition strategy not yet executed in Lean)
+- Approaches tried: 1
 
 ## Blockers
-None.
+None for Lemmas A and B (routine Mathlib composition).
+Lemma C still requires method-of-factorial-moments → Poisson convergence, which is
+not in Mathlib but is substantially smaller than full Chen-Stein.
 
 ## Next Action
-OBSERVE: Read `proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean` to find the axiom
-statement and understand what `triple_prob n d` computes. Then search Mathlib for
-`PoissonDistribution`, `totalVariation`, and any indicator sum approximation lemmas.
+ACT (next session with adequate disk for Docker builds): add Lemmas A and B to
+`proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean` and restate the axiom as the
+simpler Lemma C alone, halving the conceptual scope of the remaining gap.

--- a/research/problems/erdos-689/knowledge.md
+++ b/research/problems/erdos-689/knowledge.md
@@ -55,8 +55,82 @@ Back to the problem
 
 ## Sessions
 
-(No research sessions yet)
+### Session 2026-04-27 (Session 2) — Metadata reconciliation
+
+**Mode**: REVISIT (RICH knowledge tier, score 16)
+**Outcome**: stable — formalization at minimal axiom count, JSON metadata reconciled.
+
+#### Why Revisit
+
+Prior session(s) had reduced the Lean file `Erdos689Problem.lean` to 1 axiom (the
+open conjecture itself) and proved 13 supporting theorems including
+`mertens_sum_divergence`. However, the JSON `src/data/research/problems/erdos-689.json`
+still had `whyMatters: []`, `knownResults.proven: []`, `knownResults.open: []`,
+`knownResults.goal: ""`, phase `OBSERVE`, and `relatedProofs` containing a
+self-reference (`erdos-689` listed as related to itself). The metadata did not
+reflect the actual state of the formalization.
+
+#### What I Did
+
+1. Read `proofs/Proofs/Erdos689Problem.lean` (180 lines, 1 axiom, 13 theorems, 0 sorries).
+2. Confirmed the only remaining axiom `erdos_689_r_fold` IS the open Erdős
+   conjecture (and Ben Green's open problem 45 in the r=10 case).
+3. Updated `src/data/research/problems/erdos-689.json`:
+   - Filled in `whyMatters` (4 entries) describing the significance.
+   - Populated `knownResults.proven` with the 9 proved structural lemmas and the
+     3 derived consequences (`erdos_689_double_cover`, `green_variant_r10`,
+     `jacobsthal_connection`).
+   - Populated `knownResults.open` with the single remaining axiom.
+   - Set `knownResults.goal` to honestly describe the stable endpoint.
+   - Advanced `phase` from `OBSERVE` to `ACT` (the file IS in stable post-action
+     state — formalization is complete modulo the open conjecture).
+   - Cleaned `relatedProofs` (removed self-reference; added 687/688/690 siblings).
+   - Expanded `tags` to include `covering-systems`, `primes`, `open-conjecture`,
+     `mertens-theorem`.
+   - Added an explicit `blockers` entry recording that the remaining axiom is
+     the open question itself.
+
+#### Key Finding (already established by prior sessions, re-asserted here)
+
+**The file is at minimal axiom count.** The single remaining axiom
+`erdos_689_r_fold (r : ℕ) (hr : r ≥ 1) : ∃ N₀, ∀ n ≥ N₀, ∃ a, IsRFoldCover n r a`
+captures *all* of:
+- Erdős #689 (the original r=2 problem),
+- Ben Green's open problem 45 (the r=10 variant),
+- The Jacobsthal-style 1-fold covering (the r=1 case).
+
+Consolidating these into a single r-fold axiom is itself a small contribution:
+we now have one open conjecture rather than three.
+
+The `mertens_sum_divergence` lemma — Σ_{p ≤ n} 1/p → ∞ — was extracted from
+Mathlib's `not_summable_one_div_on_primes`. This provides heuristic intuition
+for why r-fold covering should be possible (random assignments give expected
+coverage equal to a divergent sum), but does NOT prove the conjecture.
+
+#### Files Modified
+
+- `src/data/research/problems/erdos-689.json` (metadata reconciled)
+- `research/problems/erdos-689/knowledge.md` (this file — session record)
+- `research/problems/erdos-689/state.md` (phase, iteration, focus updated)
+
+#### Files NOT Modified
+
+- `proofs/Proofs/Erdos689Problem.lean` — already at minimal axiom count;
+  no Lean changes possible without solving the open conjecture or adding
+  non-axiom-reducing structural depth (deferred — disk at 91%/1.3 GB free
+  flagged Docker builds as risky).
+
+#### Next Steps
+
+1. **MAINTAIN** — this slug should be deprioritized for axiom-removal sessions.
+2. **Optional structural enrichment** (does NOT reduce axiom count):
+   - Prove `expectedCoverage`: for uniform random a_p, expected coverage of any
+     m ∈ [1,n] equals Σ_{p≤n} 1/p (which → ∞ by `mertens_sum_divergence`). This
+     turns the heuristic into a formal probability statement.
+   - Compute exact small-r=2 cases (e.g., explicit 2-fold covers for n ≤ 30).
+3. **Cross-reference siblings** — `erdos-687` (Jacobsthal upper-bound problem)
+   and `erdos-688` (covering with restricted prime ranges).
 
 ---
 
-*Generated from erdosproblems.com on 2026-01-14*
+*Generated from erdosproblems.com on 2026-01-14; updated by researcher-10 on 2026-04-27.*

--- a/research/problems/erdos-689/state.md
+++ b/research/problems/erdos-689/state.md
@@ -1,27 +1,35 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-01-14T19:46:33.202Z
-**Iteration**: 1
+**Phase**: ACT (stable — formalization at minimal axiom count)
+**Since**: 2026-04-27T22:10:00-07:00
+**Iteration**: 2
 
 ## Current Focus
 
-Initial exploration of the problem.
+The Lean file `Erdos689Problem.lean` is at its natural endpoint. It contains
+1 axiom and 13 proved theorems, with 0 sorries. The remaining axiom
+`erdos_689_r_fold` IS the open Erdős conjecture (and Ben Green's open
+problem 45 for r=10).
 
 ## Active Approach
 
-None yet.
+None — the file is stable. Future sessions should EITHER add structural
+depth that does NOT reduce axiom count (expected-coverage formula,
+exact small-n cases) OR deprioritize this slug since axiom-reduction
+work is finished modulo the open conjecture.
 
 ## Blockers
 
-None.
+The single remaining axiom is the open Erdős conjecture itself.
+Eliminating it requires genuine mathematical progress on the open question.
 
 ## Next Action
 
-Begin problem exploration.
+MAINTAIN: Deprioritize this slug for axiom-removal sessions. Optional
+structural enrichment is documented in knowledge.md.
 
 ## Attempt Counts
 
-- Total attempts: 0
+- Total attempts: 2 (prior axiom-reduction session + this metadata session)
 - Current approach attempts: 0
-- Approaches tried: 0
+- Approaches tried: 2

--- a/research/problems/erdos-750/knowledge.md
+++ b/research/problems/erdos-750/knowledge.md
@@ -74,8 +74,112 @@ Back to the problem
 
 ## Sessions
 
-(No research sessions yet)
+### Session 2026-04-27 (Session 2) — Identify formalization gap
+
+**Mode**: REVISIT (MODERATE knowledge tier, score 6)
+**Outcome**: progress — identified that the open conjecture is described in
+docstrings but NOT actually formalized as a Lean proposition.
+
+#### What I Found
+
+The Lean file `proofs/Proofs/Erdos750Problem.lean` (111 lines) currently contains:
+
+- 3 definitions: `HasInfiniteChromatic`, `maxIndSetSize`, `AlmostBipartite`
+- 1 private theorem: `fin2_ne_zero_eq_one` (utility for Fin 2)
+- 1 main theorem: `bipartite_benchmark` (bipartite graphs achieve `m/2` for the
+  independence requirement — this is the **trivial** baseline, not the open conjecture)
+- 0 axioms, 0 sorries
+
+**The open Erdős conjecture is NOT formalized as a proposition.** Lines 49–67 of
+the Lean file have a sequence of `/-- ... -/` docstrings describing:
+
+- The main conjecture (line 51–52)
+- Erdős–Hajnal 1967 result (line 55–56)
+- Erdős–Hajnal–Szemerédi 1982 result (line 57–58)
+- Open square-root case (line 61–62)
+- Open logarithmic case (line 63)
+- Problem #75 connection (line 66–67)
+
+But these docstrings are **orphaned** — none of them is followed by an `axiom`,
+`theorem`, or `def` declaration. They are prose embedded as docstring syntax,
+attached either to nothing (a Lean error if strict) or eventually absorbed by the
+next declaration `fin2_ne_zero_eq_one`, where the description doesn't apply.
+
+#### Why The Existing JSON Was Misleading
+
+The JSON `progressSummary` reads `"COMPLETE: Assessed and marked complete."` and
+the file has 0 axioms and 0 sorries. By naive metrics this looks finished. But
+**the open conjecture has no Lean expression at all**. Compare:
+
+- Erdős #689 (similar OPEN problem, similar tractability) explicitly writes
+  `axiom erdos_689_r_fold (r : ℕ) (hr : r ≥ 1) : ∃ N₀, ∀ n ≥ N₀, ∃ a, IsRFoldCover n r a`
+  and then derives `erdos_689_double_cover := erdos_689_r_fold 2`. This is a
+  proper formalization: the open conjecture is a named Lean proposition.
+- Erdős #750 has the analogous `AlmostBipartite` definition and a docstring
+  describing the conjecture, but no corresponding `axiom erdos_750 : ...`.
+
+A future session should add the missing axiom (and possibly derived consequences
+for the Erdős–Hajnal cases proved in 1967/1982).
+
+#### Recommended Formalization (for next ACT session)
+
+```lean
+/-- **Erdős Problem #750 (OPEN)**: For any f : ℕ → ℕ with f → ∞, there exists
+    an infinite-chromatic graph that is f-almost-bipartite eventually. -/
+axiom erdos_750
+    (f : ℕ → ℕ) (hf : Filter.Tendsto f Filter.atTop Filter.atTop) :
+    ∃ (V : Type) (_ : DecidableEq V) (G : SimpleGraph V) (m₀ : ℕ),
+      HasInfiniteChromatic G ∧ AlmostBipartite G f m₀
+
+/-- **Erdős–Hajnal 1967** (proved in literature, axiomatized here pending
+    Mathlib chromatic-graph machinery): Resolves Problem #750 for f(m) = c·m
+    with c > 1/4. -/
+axiom erdos_hajnal_1967 (c : ℝ) (hc : c > 1/4) : ...
+
+/-- **Erdős–Hajnal–Szemerédi 1982**: Resolves Problem #750 for f(m) = ε·m
+    with any ε > 0. -/
+axiom ehs_1982 (ε : ℝ) (hε : ε > 0) : ...
+
+/-- The open square-root case follows from `erdos_750` applied to f(m) = ⌊√m⌋. -/
+theorem erdos_750_sqrt : ... := erdos_750 (fun m => Nat.sqrt m) sqrt_tendsto_atTop
+```
+
+This would raise the file's axiom count from 0 to 3 (or so), but it accurately
+reflects what is actually formalized vs. what remains conjectural. Per the
+project's axiom integrity policy (CLAUDE.md), an open conjecture should be
+expressed as an `axiom`, not as a docstring with no proposition behind it.
+
+#### What I Did This Session
+
+1. Read `proofs/Proofs/Erdos750Problem.lean` and confirmed the orphan-docstring
+   pattern.
+2. Updated `src/data/research/problems/erdos-750.json`:
+   - Filled in `whyMatters`.
+   - Documented the formalization gap in `knownResults.open`.
+   - Set `phase` to `ORIENT` (was `OBSERVE` at top level / `NEW` in nested state).
+   - Cleaned `relatedProofs` (removed self-reference).
+3. Wrote this session record.
+
+#### Files Modified
+
+- `src/data/research/problems/erdos-750.json`
+- `research/problems/erdos-750/knowledge.md` (this file)
+- `research/problems/erdos-750/state.md`
+
+#### Files NOT Modified
+
+- `proofs/Proofs/Erdos750Problem.lean` — disk at 91%/1.2 GB free flagged
+  Docker builds as risky; the recommended axiom additions are deferred to a
+  session with adequate disk to verify they typecheck.
+
+#### Next Steps
+
+1. ACT (next session with disk): add `axiom erdos_750` and possibly the
+   `axiom erdos_hajnal_1967` / `axiom ehs_1982` derived statements; convert the
+   orphan docstrings into actual declarations.
+2. Build verify with Docker, then the file's `axiomCount` correctly becomes ≥1
+   (matching its actual mathematical status as an open-conjecture formalization).
 
 ---
 
-*Generated from erdosproblems.com on 2026-01-15*
+*Generated from erdosproblems.com on 2026-01-15; updated by researcher-10 on 2026-04-27.*

--- a/research/problems/erdos-750/state.md
+++ b/research/problems/erdos-750/state.md
@@ -1,27 +1,37 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-01-15T08:18:33.645Z
-**Iteration**: 1
+**Phase**: ORIENT
+**Since**: 2026-04-27T22:20:00-07:00
+**Iteration**: 2
 
 ## Current Focus
 
-Initial exploration of the problem.
+Identified that the open Erdős conjecture is described in orphan docstrings
+at lines 49–67 of `Erdos750Problem.lean` but is NOT formalized as a Lean
+proposition. The 0-axiom count is misleading — it reflects formalization
+absence, not completeness.
 
 ## Active Approach
 
-None yet.
+Document the formalization gap and recommend axiomatization. Defer the
+actual Lean changes (`axiom erdos_750`, etc.) to a session with adequate
+disk for Docker builds.
 
 ## Blockers
 
-None.
+None for the metadata-reconciliation step. The recommended Lean axiom
+additions require Docker builds to verify, deferred to a session with
+adequate disk.
 
 ## Next Action
 
-Begin problem exploration.
+ACT: convert the orphan docstrings into proper Lean declarations:
+- `axiom erdos_750 (f : ℕ → ℕ) (hf : Tendsto f atTop atTop) : ∃ V G m₀, HasInfiniteChromatic G ∧ AlmostBipartite G f m₀`
+- Optional: `axiom erdos_hajnal_1967` (proves the c > 1/4 case)
+- Optional: `axiom ehs_1982` (proves the linear ε > 0 case)
 
 ## Attempt Counts
 
-- Total attempts: 0
+- Total attempts: 2 (initial structural-lemmas session + this metadata session)
 - Current approach attempts: 0
-- Approaches tried: 0
+- Approaches tried: 2

--- a/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01.json
@@ -1,55 +1,69 @@
 {
   "slug": "birthday-problem-oq-03-oq-01-oq-02-oq-01",
-  "title": "Chen-Stein method for Poisson approximation",
-  "phase": "NEW",
+  "title": "Qualitative Poisson convergence for birthday triples",
+  "phase": "ORIENT",
   "status": "active",
   "tier": "B",
   "path": "full",
   "problemStatement": {
-    "formal": "axiom poisson_approx_birthday3 (n d : ℕ) (hn : 0 < n) (hd : 0 < d) : |triple_prob n d - (1 - Real.exp (-(n.choose 3 : ℝ) / d ^ 2))| ≤ C * (n ^ 4 : ℝ) / d ^ 3",
-    "plain": "Prove the total variation bound between the k=3 birthday triple-coincidence probability and its Poisson approximation using the Chen-Stein method, removing the axiom from BirthdayProblemOQ03OQ01OQ02.lean.",
+    "formal": "axiom poisson_approx_birthday3 (c : ℝ) (hc : 0 < c) : let n d := ⌊c · d^(2/3)⌋ in Filter.Tendsto (fun d => P_no_triple(n d, d) − Real.exp(−C(n d, 3)/d²)) atTop (nhds 0)",
+    "plain": "Prove the qualitative Poisson convergence axiom poisson_approx_birthday3 in BirthdayProblemOQ03OQ01OQ02.lean: along the threshold scaling n ≈ c·d^(2/3), the probability of no triple coincidence and exp(−C(n,3)/d²) have the same limit, so their difference tends to 0.",
     "whyMatters": [
       "Removes axiom poisson_approx_birthday3 from existing gallery proof, reducing axiom count from 1 to 0",
-      "Demonstrates Chen-Stein method in Lean 4 — not yet in Mathlib, broadly applicable to birthday-type problems",
-      "Connects topological threshold results to probabilistic approximation theory"
+      "Qualitative Tendsto form is much more tractable than the originally framed quantitative Chen-Stein bound",
+      "Decomposes cleanly into routine asymptotic analysis + classical Poisson convergence"
     ]
   },
   "knownResults": {
     "proven": [
       "asympThreshold d = (6 * d^2 * Real.log 2)^{1/3} (in BirthdayProblemOQ03OQ01OQ02.lean, 0 sorries)",
       "birthday3_threshold_asymptotics: n*(d) ~ (6d² ln 2)^{1/3}",
-      "general_threshold_exponent: For general k, threshold scales as (k! d^{k-1} ln 2)^{1/k}"
+      "general_threshold_exponent: For general k, threshold scales as (k! d^{k-1} ln 2)^{1/k}",
+      "bad_count_n3 / good_count_n3: exact triple-free counts at n=3 (Session 1, 2026-04-21)"
     ],
     "open": [
-      "poisson_approx_birthday3: |triple_prob n d - (1 - exp(-λ))| ≤ C·n⁴/d³ where λ = C(n,3)/d²"
+      "poisson_approx_birthday3 (qualitative form): Tendsto (P_no_triple(n d, d) − exp(−C(n d, 3)/d²)) atTop (nhds 0), where n d := ⌊c·d^(2/3)⌋"
     ],
-    "goal": "Prove poisson_approx_birthday3 via Chen-Stein method for positively associated indicator random variables"
+    "goal": "Prove the qualitative Tendsto form via decomposition: (A) λ(d) → c³/6 (asymptotic analysis), (B) exp(−λ(d)) → exp(−c³/6) (continuity), (C) P_no_triple(n d, d) → exp(−c³/6) (Poisson convergence)"
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-04-21T00:00:00Z",
-    "iteration": 1,
-    "focus": "Prove axiom poisson_approx_birthday3 using Chen-Stein method",
+    "phase": "ORIENT",
+    "since": "2026-04-27T00:00:00Z",
+    "iteration": 2,
+    "focus": "Decompose qualitative Tendsto axiom into A/B/C sublemmas and prove A+B (routine asymptotics), isolating C as the only remaining hard step",
     "blockers": [],
-    "nextAction": "OBSERVE: Read BirthdayProblemOQ03OQ01OQ02.lean for axiom signature, then search Mathlib for PoissonDistribution and totalVariation",
+    "nextAction": "ACT: In a session with adequate disk, formalize sublemmas A (lambda_tendsto: λ(d) → c³/6) and B (exp_lambda_tendsto: exp(−λ(d)) → exp(−c³/6)). The original axiom then reduces to sublemma C alone.",
     "attemptCounts": {
-      "total": 0,
+      "total": 1,
       "currentApproach": 0,
-      "approachesTried": 0
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "Session 2 (2026-04-27): Reframed the axiom from quantitative Chen-Stein bound to its actual qualitative Tendsto form (drift between JSON `formal` and Lean source identified and corrected). Decomposed the axiom into three sublemmas: (A) λ(d) := C(n d, 3)/d² → c³/6 by routine ratio-of-polynomials analysis with floor-correction control; (B) exp(−λ(d)) → exp(−c³/6) by continuity of Real.exp; (C) P_no_triple(n d, d) → exp(−c³/6) — the genuine Poisson convergence. Sublemmas A and B are formalizable from existing Mathlib without new infrastructure; only C requires the Poisson convergence machinery (method of factorial moments or coupling). This isolates the actual Mathlib gap to its narrowest possible form. Session 1 over-scoped to a Chen-Stein quantitative bound that the axiom does not actually demand.",
+    "builtItems": [
+      "Corrected JSON `problemStatement.formal` to match actual Lean axiom signature (qualitative Tendsto, not |...| ≤ C·n⁴/d³)",
+      "Decomposed axiom strategy in research/problems/<slug>/knowledge.md into sublemmas A/B/C"
+    ],
+    "insights": [
+      "JSON `formal` field drifted from actual Lean axiom: JSON claimed quantitative |triple_prob − (1−exp(−λ))| ≤ C·n⁴/d³, but the Lean axiom is qualitative Tendsto along the threshold scaling — discrepancy was the cause of Session 1's BLOCKED conclusion",
+      "Qualitative Tendsto axiom decomposes into three independent steps; only one (the Poisson convergence) actually requires probability-theoretic machinery absent from Mathlib",
+      "λ(d) := C(⌊c·d^(2/3)⌋, 3)/d² → c³/6 — formalizable using ratio-of-polynomials limits + floor-correction estimates already present in Mathlib",
+      "exp(−λ(d)) → exp(−c³/6) is one application of Real.continuous_exp.tendsto composed with Lemma A",
+      "The original axiom equals (A ∧ B) plus a strictly weaker Poisson convergence statement: P_no_triple(n d, d) → exp(−c³/6). Restating the axiom as the latter halves the conceptual gap.",
+      "Method of factorial moments is the cleanest qualitative path: factorial moments of indicator-sum X converge to factorial moments of Poisson(c³/6), which uniquely determines the Poisson distribution — no quantitative error bounds needed",
+      "Coupling-to-independent-Bernoullis is an alternative qualitative path: bound TV distance between dependent and independent triple-indicator vectors, both giving the same Poisson limit"
+    ],
     "mathlibGaps": [
-      "Chen-Stein lemma for indicator sums not in Mathlib",
-      "Total variation bounds for Poisson approximation not in Mathlib"
+      "Method of factorial moments → Poisson convergence (qualitative form) — not in Mathlib but smaller than Chen-Stein",
+      "Coupling distance / total variation between dependent and independent indicator sums",
+      "(Quantitative) Chen-Stein bound — NOT NEEDED for the actual qualitative axiom; was only needed for the misframed quantitative bound"
     ],
     "nextSteps": [
-      "Read proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean for axiom context",
-      "Search Mathlib for PoissonDistribution, totalVariation, BernoulliDistribution",
-      "Assess whether Chen-Stein or direct moment approach is more feasible in Lean"
+      "ACT: formalize Lemma A (lambda_tendsto) and Lemma B (exp_lambda_tendsto) — both ~30-50 lines using Mathlib asymptotic and continuity tooling",
+      "After A+B: restate the original axiom as the simpler P_no_triple(n d, d) → exp(−c³/6), reducing conceptual scope to one Poisson convergence statement",
+      "ACT (later): for sublemma C, decide between method-of-factorial-moments and coupling — the former has cleaner Mathlib alignment via Finset.sum and Nat.descFactorial",
+      "Verify the decomposition in Docker before pushing (skip if disk <1GB free)"
     ]
   },
   "tags": [
@@ -82,7 +96,7 @@
     ]
   },
   "started": "2026-04-21T06:38:17Z",
-  "lastUpdate": "2026-04-21T06:38:17Z",
+  "lastUpdate": "2026-04-27T22:00:00Z",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [

--- a/src/data/research/problems/erdos-689.json
+++ b/src/data/research/problems/erdos-689.json
@@ -1,68 +1,93 @@
 {
   "slug": "erdos-689",
-  "title": "Erdős #689",
-  "phase": "OBSERVE",
+  "title": "Erdős #689 — r-fold prime covering of [1,n]",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
   "problemStatement": {
-    "formal": "Let $n$ be sufficiently large. Is there some choice of congruence class $a_p$ for all primes $2\\leq p\\leq n$ such that every integer in $[1,n]$ satisfies at least two of the congruences $\\equiv a_p\\pmod{p}$?\n\n\n\nOne can ask a similar question replacing $2$ by any fixed integer $r$ (provided $n$ is sufficiently large depending on $r$).\n\nSee also [687] and [688].\n\nThis problem (with $2$ replaced by $10$) is Problem 45 on Green's open problems list.",
-    "plain": "Let $n$ be sufficiently large. Is there some choice of congruence class $a_p$ for all primes $2\\leq p\\leq n$ such that every integer in $[1,n]$ satisfies at least two of the congruences $\\equiv a_p\\pmod{p}$?",
-    "whyMatters": []
+    "formal": "axiom erdos_689_r_fold (r : ℕ) (hr : r ≥ 1) : ∃ N₀ : ℕ, ∀ n ≥ N₀, ∃ a : ℕ → ℕ, IsRFoldCover n r a — i.e., for every fixed r ≥ 1 there exists N₀ such that for all n ≥ N₀, some choice of congruence classes a_p (one per prime p ≤ n) makes every integer in [1, n] satisfy at least r of the congruences ≡ a_p (mod p). Source: Erdős 1979d.",
+    "plain": "For sufficiently large n, can the primes p ≤ n cover [1, n] r-fold via chosen residues? The original Erdős problem is r=2. Ben Green's open problem 45 is the same with r=10. The r=1 case is the Jacobsthal-style 1-fold covering question.",
+    "whyMatters": [
+      "Open Erdős problem #689 with active interest from Ben Green (Problem 45 on his open list)",
+      "Connects to gaps between primes (Jacobsthal function, problem #687) and to covering systems",
+      "Mertens' second theorem (Σ_{p≤n} 1/p ~ log log n → ∞) suggests enough covering 'power' exists; turning this heuristic into a proof is the hard part",
+      "Formalizing the conjecture and provable structural lemmas in Lean creates a foundation for any future progress on the open question"
+    ]
   },
   "knownResults": {
-    "proven": [],
-    "open": [],
-    "goal": ""
+    "proven": [
+      "primesUpTo n is monotone in n",
+      "coveringCount n m a is monotone in n",
+      "isRFoldCover n r a is monotone in r (smaller r is easier)",
+      "isRFoldCover n 0 a holds trivially",
+      "primesUpTo 1 = ∅, hence coveringCount 1 m a = 0",
+      "mertens_sum_divergence: ∀ C > 0, Σ_{p ≤ n} 1/p > C eventually (proved from Mathlib's not_summable_one_div_on_primes)",
+      "erdos_689_double_cover := erdos_689_r_fold 2 (the r=2 case derived from the r-fold axiom)",
+      "green_variant_r10 := erdos_689_r_fold 10 (Ben Green's variant)",
+      "jacobsthal_connection := r=1 case via Filter.eventually_atTop"
+    ],
+    "open": [
+      "erdos_689_r_fold (r : ℕ) (hr : r ≥ 1) — the only remaining axiom; this IS the open Erdős conjecture"
+    ],
+    "goal": "The Lean file is at its natural endpoint: 1 axiom remains, and it IS the open conjecture itself. Further reduction requires actually solving the conjecture, which is open. Future sessions can add structural lemmas (e.g., Mertens-based heuristic bounds, exact small-n cases for r=2) but cannot eliminate the remaining axiom without genuine mathematical progress."
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-01-14T19:46:33.202Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
-    "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "phase": "ACT",
+    "since": "2026-04-27T22:10:00Z",
+    "iteration": 2,
+    "focus": "Stable formalization at minimal axiom count. The remaining axiom is the open Erdős conjecture itself.",
+    "blockers": [
+      "The remaining axiom erdos_689_r_fold IS the open Erdős conjecture #689 (and Ben Green's open problem 45 for r=10) — not eliminable without genuine mathematical progress on the open question."
+    ],
+    "nextAction": "MAINTAIN: The Lean file is complete modulo the open conjecture. Future sessions can add structural depth (e.g., quantitative bounds on coveringCount for random a, or exact analysis of small r=2 cases for n ≤ 100), but axiom-removal sessions should deprioritize this slug and focus on problems with provable axioms.",
     "attemptCounts": {
-      "total": 0,
+      "total": 2,
       "currentApproach": 0,
-      "approachesTried": 0
+      "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Eliminated jacobsthal_connection axiom (2->1). Only remaining axiom is erdos_689_r_fold (the open conjecture itself).",
+    "progressSummary": "STABLE — formalization at minimal axiom count. Only remaining axiom is erdos_689_r_fold, which IS the open Erdős conjecture (and equivalently Ben Green's open problem 45 for r=10). 13 supporting theorems all proved. Further axiom reduction is impossible without solving the open question. Session 2 (2026-04-27) reconciled JSON metadata with the actual stable state — previous JSON had whyMatters/knownResults all empty despite the file being substantively complete.",
     "builtItems": [
-      "Surveyed Erdos689Problem.lean (141 lines)",
+      "Surveyed Erdos689Problem.lean (180 lines)",
       "Proved theorem mertens_sum_divergence in Erdos689Problem.lean (was axiom)",
       "erdos_689_double_cover: converted from axiom to theorem (= erdos_689_r_fold 2)",
       "green_variant_r10: converted from axiom to theorem (= erdos_689_r_fold 10)",
-      "jacobsthal_connection: converted from axiom to theorem (r=1 case of erdos_689_r_fold via Filter.eventually_atTop)"
+      "jacobsthal_connection: converted from axiom to theorem (r=1 case of erdos_689_r_fold via Filter.eventually_atTop)",
+      "Reconciled JSON metadata to reflect 13 proved theorems and the single remaining open-conjecture axiom (Session 2, 2026-04-27)"
     ],
     "insights": [
-      "5 axioms: erdos_689_double_cover (OPEN), erdos_689_r_fold (OPEN generalization), mertens_sum_divergence (KNOWN but not in Mathlib), jacobsthal_connection (KNOWN), green_variant_r10 (OPEN variant)",
-      "mertens_sum_divergence is most promising for elimination: Σ_{p≤n} 1/p → ∞ is Mertens' second theorem",
+      "Only remaining axiom is erdos_689_r_fold which IS the open conjecture; further reduction requires genuine mathematical progress on the open question",
       "9 proved theorems: covering monotonicity, bounds, small cases — all clean",
       "Problem relates to #687 (Jacobsthal), #688 (covering), Ben Green problem 45",
       "Proved mertens_sum_divergence from Mathlib: not_summable_one_div_on_primes → partial sums → ∞ → exceeds any bound C over primesUpTo n",
-      "Both the main r=2 conjecture and Greens r=10 variant are special cases of the r-fold axiom"
+      "Both the main r=2 conjecture and Green's r=10 variant are special cases of the r-fold axiom; consolidating into a single axiom reduces 3 separate open-conjecture axioms to 1",
+      "Mertens' divergence (Σ_{p≤n} 1/p → ∞) is heuristic evidence for r-fold covering: random a_p assignment gives expected coverage of any m equal to Σ 1/p, which exceeds any constant — but turning the heuristic into a proof remains open"
     ],
     "mathlibGaps": [
-      "No Mertens' second theorem (Σ 1/p ~ log log n) in Mathlib",
+      "No Mertens' second theorem (Σ 1/p ~ log log n) in Mathlib (mertens_sum_divergence proves only divergence, not the asymptotic rate)",
       "No Jacobsthal function bounds in Mathlib"
     ],
     "nextSteps": [
       "Only remaining axiom is erdos_689_r_fold (OPEN conjecture, cannot eliminate)",
       "File is at minimal axiom count — formalization is complete modulo the open conjecture",
-      "Could add more structural lemmas but axiom reduction is done"
+      "Optional structural enrichment (not axiom-reducing): random-assignment expected-coverage formula, exact computation for small r=2 cases (e.g., r=2 explicit covers for n ≤ 30)",
+      "Cross-reference recommendations: erdos-687 (Jacobsthal Y(x)), erdos-688 (one-fold covering with prime range restricted)"
     ],
     "markdown": "# Erdős #689 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $n$ be sufficiently large. Is there some choice of congruence class $a_p$ for all primes $2\\leq p\\leq n$ such that every integer in $[1,n]$ satisfies at least two of the congruences $\\equiv a_p\\pmod{p}$?\n\n\n\nOne can ask a similar question replacing $2$ by any fixed integer $r$ (provided $n$ is sufficiently large depending on $r$).\n\nSee also [687] and [688].\n\nThis problem (with $2$ replaced by $10$) is Problem 45 on Green's open problems list.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #687\n- Problem #688\n- Problem #690\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er79d\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-14*\n"
   },
   "tags": [
-    "erdos"
+    "erdos",
+    "covering-systems",
+    "primes",
+    "open-conjecture",
+    "mertens-theorem"
   ],
   "relatedProofs": [
-    "erdos-6",
-    "erdos-68",
-    "erdos-689"
+    "erdos-687",
+    "erdos-688",
+    "erdos-690"
   ],
   "references": {
     "papers": [],
@@ -70,7 +95,7 @@
     "mathlib": []
   },
   "started": "2026-01-14T19:46:33.202Z",
-  "lastUpdate": "2026-03-13T07:52:17.051Z",
+  "lastUpdate": "2026-04-27T22:10:00Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [

--- a/src/data/research/problems/erdos-750.json
+++ b/src/data/research/problems/erdos-750.json
@@ -1,56 +1,87 @@
 {
   "slug": "erdos-750",
-  "title": "Erdős #750",
-  "phase": "OBSERVE",
+  "title": "Erdős #750 — Almost-bipartite graphs of infinite chromatic number",
+  "phase": "ORIENT",
   "status": "active",
   "tier": "B",
   "path": "full",
   "problemStatement": {
-    "formal": "Let $f(m)$ be some function such that $f(m)\\to \\infty$ as $m\\to \\infty$. Does there exist a graph $G$ of infinite chromatic number such that every subgraph on $m$ vertices contains an independent set of size at least $\\frac{m}{2}-f(m)$?\n\n\n\nIn \\cite{Er69b} Erd\\H{o}s conjectures this for $f(m)=\\epsilon m$ for any fixed $\\epsilon>0$. This follows from a result of Erd\\H{o}s, Hajnal, and Szemer\\'{e}di \\cite{EHS82}, as described by msellke in the comments.\n\nIn \\cite{ErHa67b} Erd\\H{o}s and Hajnal prove this for $f(m)\\geq cm$ for all $c>1/4$.\n\nSee also [75].",
-    "plain": "Let $f(m)$ be some function such that $f(m)\\to \\infty$ as $m\\to \\infty$. Does there exist a graph $G$ of infinite chromatic number such that every subgraph on $m$ vertices contains an independent set of size at least $\\frac{m}{2}-f(m)$?",
-    "whyMatters": []
+    "formal": "Open Erdős conjecture: For any f : ℕ → ℕ with f(m) → ∞, does there exist a graph G with infinite chromatic number such that every m-vertex induced subgraph contains an independent set of size ≥ m/2 − f(m)? Erdős–Hajnal (1967) prove this for f(m) ≥ cm with c > 1/4; Erdős–Hajnal–Szemerédi (1982) extend to f(m) = εm for any ε > 0. The sublinear case (f(m) → ∞ but f(m) = o(m)) — including f(m) = √m and f(m) = log m — remains open.",
+    "plain": "Let f(m) → ∞. Is there an infinite-chromatic graph G such that every m-vertex subgraph has an independent set of size ≥ m/2 − f(m)? Erdős–Hajnal (1967) and Erdős–Hajnal–Szemerédi (1982) resolve the linear case; sublinear deviations (f(m) = √m, log m, etc.) are open.",
+    "whyMatters": [
+      "Open Erdős conjecture connecting global graph property (infinite chromatic number) with local sparsity (large independent sets in every subgraph)",
+      "Erdős–Hajnal–Szemerédi 1982 resolves the linear case via 'almost bipartite large chromatic graphs' — a deep construction",
+      "Sublinear case f(m) = o(m) remains open and would refine the local-vs-global gap",
+      "Connected to Erdős #75 (independent sets of size n^{1−ε} with χ = ℵ₁) — a stronger local condition"
+    ]
   },
   "knownResults": {
-    "proven": [],
-    "open": [],
-    "goal": ""
+    "proven": [
+      "bipartite_benchmark in Erdos750Problem.lean: bipartite graphs satisfy maxIndSetSize G S ≥ S.card / 2 (the trivial baseline — proves only the m/2 component, not the deviation)",
+      "fin2_ne_zero_eq_one (utility): ∀ (i : Fin 2), i ≠ 0 → i = 1",
+      "Erdős–Hajnal (1967, NOT in Lean): the conjecture holds for f(m) ≥ cm with c > 1/4",
+      "Erdős–Hajnal–Szemerédi (1982, NOT in Lean): extends to f(m) = εm for any ε > 0"
+    ],
+    "open": [
+      "Sublinear case: f(m) = o(m) with f(m) → ∞ — Erdős' original conjecture (Er69b)",
+      "Specific sublinear cases: f(m) = √m, f(m) = log m",
+      "FORMALIZATION GAP: The open conjecture is described in orphan docstrings (lines 49–67 of Erdos750Problem.lean) but NOT formalized as a Lean proposition. There is no `axiom erdos_750` or analogous declaration. A future session should add `axiom erdos_750 (f : ℕ → ℕ) (hf : Tendsto f atTop atTop) : ∃ V G m₀, HasInfiniteChromatic G ∧ AlmostBipartite G f m₀`."
+    ],
+    "goal": "Add `axiom erdos_750` (and possibly axiomatized Erdős–Hajnal 1967 / EHS 1982 statements) so the file properly formalizes the open conjecture. The current 0-axiom state is misleading — it reflects formalization absence, not formalization completeness."
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-01-15T08:18:33.645Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "phase": "ORIENT",
+    "since": "2026-04-27T22:20:00Z",
+    "iteration": 2,
+    "focus": "Identified that the open conjecture is described only in orphan docstrings; recommended axiomatization to make it a proper Lean proposition.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "ACT (next session with disk for Docker builds): convert the orphan docstrings at lines 49–67 of Erdos750Problem.lean into proper Lean declarations — `axiom erdos_750`, `axiom erdos_hajnal_1967`, `axiom ehs_1982` — so the file's axiom count accurately reflects the conjectural assumptions it depends on.",
     "attemptCounts": {
-      "total": 0,
+      "total": 2,
       "currentApproach": 0,
-      "approachesTried": 0
+      "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: Assessed and marked complete.",
+    "progressSummary": "PARTIAL: bipartite_benchmark and fin2_ne_zero_eq_one proved, but the open conjecture is NOT formalized as a Lean proposition. Lines 49–67 of Erdos750Problem.lean contain orphan docstrings describing the conjecture and known results, with no corresponding axiom or theorem declarations. The 0-axiom count is misleading — it reflects absence of formalization, not completeness. Session 2 (2026-04-27) identified this gap and recommended adding `axiom erdos_750` plus axiomatized statements of the known Erdős–Hajnal 1967 and EHS 1982 results.",
     "builtItems": [
       "Proved fin2_ne_zero_eq_one: ∀ (i : Fin 2), i ≠ 0 → i = 1 (by decide)",
-      "Proved bipartite_benchmark: bipartite graphs have independent sets ≥ m/2, via complement-filter pigeonhole on 2-coloring classes"
+      "Proved bipartite_benchmark: bipartite graphs have independent sets ≥ m/2, via complement-filter pigeonhole on 2-coloring classes",
+      "(Session 2) Documented formalization gap: open conjecture described only in orphan docstrings, no Lean proposition exists for it"
     ],
     "insights": [
       "IsBipartite = Colorable 2 in Mathlib; coloring is a Hom to completeGraph (Fin 2)",
       "completeGraph.Adj is definitionally Ne, so c.map_rel gives c v ≠ c w directly",
       "Finset.filter_card_add_filter_neg_card_eq_card gives the partition identity for complement filters",
-      "Finset.le_sup provides the bridge from independent-set membership to maxIndSetSize bound"
+      "Finset.le_sup provides the bridge from independent-set membership to maxIndSetSize bound",
+      "The bipartite_benchmark theorem proves only the trivial m/2 baseline — bipartite graphs achieve f(m) = 0 deviation but have χ = 2, so they are not counterexamples to or witnesses of the conjecture",
+      "Erdős–Hajnal–Szemerédi 1982 ('On almost bipartite large chromatic graphs') resolves the linear case f(m) = εm via probabilistic construction; the sublinear case is what remains genuinely open",
+      "The current Lean file's 0-axiom 1-theorem state is misleading: it would benefit from explicit axiomatization of (a) the open conjecture itself, and (b) the proved-in-literature Erdős–Hajnal 1967/EHS 1982 results, so that the axiom count honestly tracks the conjectural assumptions"
     ],
-    "mathlibGaps": [],
-    "nextSteps": [],
+    "mathlibGaps": [
+      "Mathlib lacks chromatic-number machinery sufficient to prove EHS 1982 directly; axiomatizing it is the appropriate intermediate step",
+      "No probabilistic-construction lemmas for almost-bipartite graphs in Mathlib"
+    ],
+    "nextSteps": [
+      "ACT (next session with disk): add axiom erdos_750 (f : ℕ → ℕ) (hf : Tendsto f atTop atTop) : ∃ V G m₀, HasInfiniteChromatic G ∧ AlmostBipartite G f m₀",
+      "Optional: add axiom erdos_hajnal_1967 (proves the c > 1/4 case) and axiom ehs_1982 (proves the linear ε > 0 case) — these are KNOWN results not currently in Mathlib",
+      "Convert orphan docstrings at lines 49–67 into proper Lean declarations or move them into a single block-comment section so they don't masquerade as docstrings",
+      "Build verify the axiomatized file and update axiomCount in JSON metadata (will become ≥1)"
+    ],
     "markdown": "# Erdős #750 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $f(m)$ be some function such that $f(m)\\to \\infty$ as $m\\to \\infty$. Does there exist a graph $G$ of infinite chromatic number such that every subgraph on $m$ vertices contains an independent set of size at least $\\frac{m}{2}-f(m)$?\n\n\n\nIn \\cite{Er69b} Erd\\H{o}s conjectures this for $f(m)=\\epsilon m$ for any fixed $\\epsilon>0$. This follows from a result of Erd\\H{o}s, Hajnal, and Szemer\\'{e}di \\cite{EHS82}, as described by msellke in the comments.\n\nIn \\cite{ErHa67b} Erd\\H{o}s and Hajnal prove this for $f(m)\\geq cm$ for all $c>1/4$.\n\nSee also [75].\n\n\n\n\nReferences\n\n\n[EHS82] Erd\\H{o}s, P. and Hajnal, A. and Szemer\\'{e}di, E., On almost bipartite large chromatic graphs. Theory and practice of combinatorics (1982), 117-123.\n\n[Er69b] Erd\\H{o}s, P., Problems and results in chromatic graph theory. Proof Techniques in Graph Theory (Proc. Second Ann\nArbor Graph Theory Conf., Ann Arbor, Mich.,\n1968) (1969), 27-35.\n\n[ErHa67b] Erd\\H{o}s, P. and Hajnal, Andr\\'as, On chromatic graphs. Mat. Lapok (1967), 1--4.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #4\n- Problem #75\n- Problem #749\n- Problem #751\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er94b\n- Er95d\n- Er69b\n- EHS82\n- ErHa67b\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
   "tags": [
-    "erdos"
+    "erdos",
+    "graph-theory",
+    "chromatic-number",
+    "independent-sets",
+    "open-conjecture",
+    "formalization-gap"
   ],
   "relatedProofs": [
-    "erdos-7",
     "erdos-75",
-    "erdos-750"
+    "erdos-749",
+    "erdos-751"
   ],
   "references": {
     "papers": [],
@@ -58,7 +89,7 @@
     "mathlib": []
   },
   "started": "2026-01-15T08:18:33.645Z",
-  "lastUpdate": "2026-03-13T07:52:17.052Z",
+  "lastUpdate": "2026-04-27T22:20:00Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [


### PR DESCRIPTION
## Summary

Three research iterations from researcher-10 on 2026-04-27. Each contributes corrected metadata + research-strategy documentation; no Lean source changes (disk at 93% / 930 MB free below the 1 GB threshold for Docker builds, per saved guidance).

## Iteration 1: birthday-problem-oq-03-oq-01-oq-02-oq-01 — reframe to qualitative Tendsto

### Background

Session 1 (2026-04-21) read the JSON `problemStatement.formal` field, which claimed a quantitative Chen-Stein bound `|triple_prob n d − (1 − exp(−C(n,3)/d²))| ≤ C·n⁴/d³` and concluded BLOCKED on a 500-800 LoC Mathlib gap.

The actual axiom in `BirthdayProblemOQ03OQ01OQ02.lean:325` is qualitative:

```lean
axiom poisson_approx_birthday3 (c : ℝ) (hc : 0 < c) :
    let n d := ⌊c · d^(2/3)⌋
    Filter.Tendsto
      (fun d => P_no_triple(n d, d) − exp(−C(n d, 3)/d²))
      atTop (nhds 0)
```

i.e., a `Tendsto` to 0, not a `|...| ≤ C·n⁴/d³` bound. The drift in `problemStatement.formal` caused the over-scope.

### Progress

1. Confirmed JSON-vs-Lean drift; corrected `problemStatement.formal`.
2. Decomposed the axiom into three sublemmas:
   - **A. `lambda_tendsto`** — `λ(d) := C(⌊c·d^(2/3)⌋, 3)/d² → c³/6` (routine asymptotics, ~30–50 LoC).
   - **B. `exp_lambda_tendsto`** — `exp(−λ(d)) → exp(−c³/6)` (one-liner via `Real.continuous_exp`).
   - **C. `p_no_triple_tendsto`** — `P_no_triple(n d, d) → exp(−c³/6)` (the only sublemma actually requiring new Mathlib infrastructure).

The original axiom follows from A ∧ B ∧ C. The Mathlib gap reduces from full Chen-Stein to method-of-factorial-moments → Poisson convergence (qualitative), substantially smaller because no explicit error bounds are required.

### Files

- `src/data/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01.json`
- `research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01/{knowledge,state}.md`

## Iteration 2: erdos-689 — reconcile JSON metadata with stable formalization state

### Background

`Erdos689Problem.lean` is at minimal axiom count (1 axiom, 13 theorems, 0 sorries). The remaining axiom `erdos_689_r_fold` IS the open Erdős conjecture itself, encompassing the original r=2 problem, Ben Green's open problem 45 for r=10, and the Jacobsthal-style 1-fold case.

Prior sessions had reached this stable state but left research metadata stale: `whyMatters: []`, `knownResults.proven: []`, `knownResults.open: []`, `knownResults.goal: ""`, phase `OBSERVE`, `relatedProofs` containing a self-reference.

### Progress

- Filled in `whyMatters` (4 entries describing significance).
- Populated `knownResults.proven` with 9 structural lemmas + 3 derived consequences.
- Populated `knownResults.open` with the single remaining axiom; set `knownResults.goal` to the stable endpoint description.
- Advanced phase OBSERVE → ACT.
- Cleaned `relatedProofs` (removed self-reference; added 687/688/690).
- Added explicit `blockers` entry: the remaining axiom is the open conjecture.

### Files

- `src/data/research/problems/erdos-689.json`
- `research/problems/erdos-689/{knowledge,state}.md`

## Iteration 3: erdos-750 — identify and document formalization gap

### Background

`Erdos750Problem.lean` (111 lines) appeared "complete" by axiom-count metrics (0 axioms, 1 theorem, 0 sorries). But on inspection, the **open Erdős conjecture is NOT formalized as a Lean proposition**. Lines 49–67 contain a sequence of orphan `/-- ... -/` docstrings describing the conjecture, the proved-in-literature Erdős–Hajnal 1967 / EHS 1982 results, and open sublinear cases — with no corresponding `axiom`, `theorem`, or `def` declarations.

The result is that the 0-axiom count reflects **formalization absence**, not formalization completeness. Per the project's axiom integrity policy (CLAUDE.md), an open conjecture should be expressed as an `axiom`, not as prose.

### Progress

- Identified the orphan-docstring pattern at lines 49–67.
- Recommended the axiomatization template for the next ACT session:
  - `axiom erdos_750 (f : ℕ → ℕ) (hf : Tendsto f atTop atTop) : ∃ V G m₀, HasInfiniteChromatic G ∧ AlmostBipartite G f m₀`
  - Optional: `axiom erdos_hajnal_1967` (proves the c > 1/4 case from literature)
  - Optional: `axiom ehs_1982` (proves the linear ε > 0 case from literature)
- Rewrote `progressSummary` from `"COMPLETE: Assessed and marked complete."` to `"PARTIAL: ..."` honestly describing the gap.
- Filled in `whyMatters`, `knownResults.{proven,open,goal}`; advanced phase OBSERVE → ORIENT.
- Cleaned `relatedProofs` (removed self-reference; added 75/749/751).
- Expanded `tags` (graph-theory, chromatic-number, independent-sets, open-conjecture, formalization-gap).

### Files

- `src/data/research/problems/erdos-750.json`
- `research/problems/erdos-750/{knowledge,state}.md`

## Status

**Outcome**: progress (three reframings/reconciliations; no Lean theorems proved this session)

**Next Steps** (each by future researcher session with adequate disk):

1. **birthday**: ACT — implement Lemmas A and B in `BirthdayProblemOQ03OQ01OQ02.lean`, restate the axiom as Lemma C alone.
2. **erdos-689**: MAINTAIN — file is stable; deprioritize for axiom-removal sessions.
3. **erdos-750**: ACT — convert orphan docstrings into proper Lean declarations; the file's `axiomCount` should rise from 0 to ≥1, accurately reflecting that an open conjecture is being formalized.

🤖 Generated by researcher-10