### PR TITLE
Research: ballot HLF — proof-route comparison + roadmap

### DIFF
--- a/research/problems/ballot-problem-oq-03-oq-01-oq-02/literature/closing-the-final-sorry.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-02/literature/closing-the-final-sorry.md
@@ -1,0 +1,158 @@
+# Closing the Final `hook_walk_identity` Sorry
+
+**State as of session 33 (2026-04-27):** `BallotProblemOQ03OQ01OQ02.lean` is 14022
+lines with one remaining `sorry`, on the ≥10-row × ≥10-column non-rectangular
+branch of the `hook_walk_identity` dispatcher (line 13932). The file already
+exceeds the Docker 32 GB build envelope. This note compares the three known
+proof routes and recommends a path forward.
+
+---
+
+## The identity to prove
+
+For any `μ : YoungDiagram` with `0 < μ.card`,
+
+```
+∑_{c ∈ corners μ} (hookProd μ : ℚ) / (hookProd (μ \ c) : ℚ) = (μ.card : ℚ).
+```
+
+The dispatcher already discharges every shape with `min(rows, cols) ≤ 10` plus
+all rectangles, so the open case is a *non-rectangular shape with both ≥ 11
+rows and ≥ 11 columns*.
+
+---
+
+## Route A — Greene–Nijenhuis–Wilf hook walk
+
+Reference: Greene, Nijenhuis, Wilf, *A probabilistic proof of a formula for
+the number of Young tableaux of a given shape*, Adv. Math. 31 (1979), 104–109.
+
+**Argument.** Pick a uniform cell `(i,j) ∈ μ`; repeatedly move to a uniform cell
+of the *strict* hook (arm cells `(i, j')` with `j < j' < rowLen i` and leg cells
+`(i', j)` with `i < i' < colLen j`); stop when the strict hook is empty,
+i.e. when the current cell is a corner. GNW prove
+
+```
+P(walk ends at c) = hookProd μ / (μ.card · hookProd (μ \ c)).
+```
+
+Summing over corners and using ∑P = 1 gives the identity directly.
+
+**Lean cost estimate.** ~300 lines once a uniform-distribution / hitting-time
+toolkit is in place. The probability machinery in Mathlib (`MeasureTheory`,
+`ProbabilityTheory`) is heavy; a deterministic recasting (count weighted paths
+of every length and divide by `μ.card · ∏ |strict hook|`) is probably leaner
+and self-contained, but still ~400 lines.
+
+**Pros**
+- Uniform across all shapes — closes the sorry at once.
+- Replaces the entire row-by-row tower (PARTS XIVc–XXVI) if reformulated.
+
+**Cons**
+- Mathlib's `ProbabilityTheory` is unfamiliar to this file; transitive imports
+  may push compile time / memory further.
+- The classical proof's inclusion–exclusion step on the row/column projections
+  is delicate to formalize and is the actual hard core.
+
+---
+
+## Route B — Fomin growth diagrams (RSK)
+
+Reference: Fomin, *Generalized Robinson–Schensted–Knuth correspondence*,
+J. Soviet Math. 41 (1988), 979–991; or Sagan, *The Symmetric Group*, §3.6–3.7.
+
+**Argument.** RSK gives a bijection between `n × n` 0-1 matrices and pairs of
+SYT of the same shape. Restricting to permutation matrices yields
+`n! = ∑_λ (f^λ)^2`. A growth-diagram refinement gives
+`(f^λ)^2 · ∏_{u ∈ λ} h(u)^2 = (n!)^2`,
+hence `f^λ · hookProd λ = n!` directly (and the hook-walk identity follows
+from the corner recursion).
+
+**Lean cost estimate.** ~600 lines including the bijection definition, but
+this also produces the *full HLF* directly (no `hook_walk_identity` needed).
+Some growth-diagram infrastructure may exist in `Mathlib.Combinatorics.RSK`.
+
+**Pros**
+- Combinatorial, no probability theory.
+- Yields HLF directly; `hook_walk_identity` becomes a downstream corollary
+  rather than a prerequisite.
+- Reusable for many other Young-tableau theorems.
+
+**Cons**
+- Larger initial investment than GNW.
+- Mathlib's RSK status as of 2026-04 is partial; check before committing to
+  this route.
+
+---
+
+## Route C — Canonical LGV configuration (already scaffolded in PART V)
+
+The OPEN comment at lines 226–264 of `BallotProblemOQ03OQ01OQ02.lean`
+sets out a canonical encoding `youngLGVConfigOf μ` and reduces HLF to:
+
+- (A) `Fintype.card (StandardYoungTableau μ) = niTupleCount (youngLGVConfigOf μ)`
+  — Fomin growth bijection, ~200 lines.
+- (B) `(pathMatrix (youngLGVConfigOf μ)).det · hookProd μ = μ.card.factorial`
+  — Lindström / Jacobi–Trudi identity, ~200 lines.
+
+The LGV well-formedness condition `r - 1 ≤ μ.rowLen (r - 1)` fails for tall
+narrow shapes, so a transpose-duality split is needed. Taking the wider of
+`μ, μᵀ` always satisfies the condition because `numRows μ + numCols μ ≤ μ.card + 1`
+and the wider one has `rowLen 0 ≥ √(μ.card)` ≥ `numRows`.
+
+**Pros**
+- Reuses the already-proved `lgv_lemma_rxr` machinery (2315 lines, 0 sorries).
+- Sidesteps `hook_walk_identity` entirely — gives an independent HLF proof.
+
+**Cons**
+- (A) duplicates effort with Route B; the bijection is essentially RSK/Fomin
+  growth.
+- (B) requires Vandermonde / Jacobi–Trudi expansion; Mathlib's
+  `Matrix.det_eq_*` lemmas can help but the partition-indexed form is custom.
+
+---
+
+## Recommendation
+
+1. **Modularise first.** At 14022 lines the file no longer compiles in
+   Docker. Split PARTS XIVc–XXVI (the row-by-row tower, ≈ 10 000 lines) into
+   `BallotProblemOQ03OQ01OQ02RowByRow.lean` so the head module fits the
+   build envelope again. After modularization it is safe to add new lemmas
+   on top.
+
+2. **Then take Route B (RSK / Fomin).** It produces the strongest single
+   payoff (full HLF for all shapes, kills `hook_walk_identity` as a
+   corollary), and the growth-diagram bijection has independent value for
+   future combinatorics work in this gallery (knuthEquivalent, Specht modules,
+   etc.). Mathlib's existing partial RSK can be a head-start.
+
+3. **Route A (GNW) is a smaller-scoped alternative** if the goal is *just*
+   to retire the final sorry without restructuring the proof. Choose this
+   if the modularization in step 1 turns out to be too disruptive.
+
+4. **Route C (canonical LGV)** is the most aligned with this file's existing
+   architecture but duplicates Route B's combinatorial work via (A). Worth
+   pursuing only after Route B if a second independent HLF proof is desired.
+
+---
+
+## Concrete starting points
+
+For Route B, the first three definitions to add (independent of the row-tower):
+
+```
+def numRows (μ : YoungDiagram) : ℕ := μ.colLen 0
+
+def reverseRowLens (μ : YoungDiagram) (i : Fin (numRows μ)) : ℕ :=
+  μ.rowLen (numRows μ - 1 - i.val)
+
+lemma reverseRowLens_monotone (μ : YoungDiagram) :
+    Monotone (reverseRowLens μ) := by
+  intro i j hij
+  unfold reverseRowLens
+  exact μ.rowLen_anti _ _ (by have := j.is_lt; omega)
+```
+
+These are the building blocks the OPEN comment in PART V already calls for.
+After modularization (step 1 above) they can be added to the head file
+without straining the build envelope.

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
@@ -33,8 +33,8 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-04-21T13:45:00Z",
-    "iteration": 4,
-    "focus": "Sorry reduced 3→1 by removing dead LGV scaffolding. Sole remaining sorry: hook_walk_identity ≥10-row ≥10-col non-rectangular case (GNW ~300 lines).",
+    "iteration": 5,
+    "focus": "Session 33 (2026-04-27): no code change. Strategy note added to literature/closing-the-final-sorry.md comparing GNW, RSK/Fomin, canonical-LGV routes. Recommends modularize first, then take Route B (RSK) for full HLF + retire hook_walk_identity as corollary.",
     "blockers": [
       "File size: 14022 lines exceeds practical Docker 32GB build envelope; further additions risk unverifiable code",
       "GNW proof (~300 lines): standard probabilistic hook walk argument, not yet formalized",
@@ -48,7 +48,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Removed two dead LGV sorries (incorrectly stated). Sorry count 3→1; only hook_walk_identity (≥10×≥10 non-rect) remains. hook_length_formula_general proved modulo this single GNW gap.",
+    "progressSummary": "Session 33 produced no proof progress. Strategy artefact (literature/closing-the-final-sorry.md) added comparing the three known proof routes for closing the final sorry; recommends modularize-then-RSK. Sorry count remains 1: hook_walk_identity ≥10×≥10 non-rectangular.",
     "builtItems": [
       "instFintypeSYT: Fintype instance for StandardYoungTableau (BallotProblemOQ03OQ01OQ02.lean, Part IIIb)",
       "emptyTableau: unique SYT of shape bot (BallotProblemOQ03OQ01OQ02.lean, Part IIIc)",
@@ -207,7 +207,8 @@
       "hookProd(μ)/hookProd(μ\\c) = H(c) × ∏_{j<s} H(r,j)/(H(r,j)-1) × ∏_{i<r} H(i,s)/(H(i,s)-1) — verified algebraically for [3,2], hook shapes, rectangles",
       "For rectangles (1 corner): arm product telescopes to rowLen, leg product to colLen, giving R = rowLen × colLen = |μ|; key evidence the algebraic proof works",
       "The two LGV auxiliary lemmas were stated for arbitrary (r, σ, m) with no link to μ. Most parameter choices yield false numerical equalities (e.g. μ=⊥ vs r=1, σ=fun _ => 5). Removing them is honest housekeeping, not a content regression.",
-      "youngLGVConfig wellFormed condition r-1 ≤ σ⟨0⟩ reduces to μ.rowLen(numRows-1) ≥ numRows-1 — fails for tall shapes like (1,1,…,1). The general LGV statement requires applying LGV to whichever of μ, μᵀ is wide enough."
+      "youngLGVConfig wellFormed condition r-1 ≤ σ⟨0⟩ reduces to μ.rowLen(numRows-1) ≥ numRows-1 — fails for tall shapes like (1,1,…,1). The general LGV statement requires applying LGV to whichever of μ, μᵀ is wide enough.",
+      "Session 33 (2026-04-27): row-by-row tower has hit diminishing returns at 14022 lines. Adding row N+1 costs ~2200 lines for one branch and worsens the build envelope. The remaining sorry is uniformly closeable only by GNW (~300 lines, probability) or RSK/Fomin growth (~600 lines, also gives full HLF). Modularization (split PARTS XIVc-XXVI) must precede further additions to restore buildability."
     ],
     "mathlibGaps": [
       "hookLength may not be defined in Mathlib.Combinatorics.YoungDiagram — check arm/leg availability",


### PR DESCRIPTION
## Summary
Strategy / triage entry for `ballot-problem-oq-03-oq-01-oq-02`. No code change.

## Context
- File `proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean` is at 14022 lines (over Docker 32GB build envelope).
- One remaining sorry: `hook_walk_identity` for ≥10-row × ≥10-col non-rectangular shapes.
- During this session disk free dropped to 1.1Gi, crossing the runbook's "Edit silently reverts" threshold. Modifying the .lean file under these conditions was judged reckless.

## What's in this PR
- New `research/.../literature/closing-the-final-sorry.md` (≈120 lines): compares the three known proof routes (GNW probabilistic; RSK / Fomin growth diagrams; canonical-config LGV) with concrete Lean cost estimates and pros/cons. Recommends modularize-then-RSK (Route B).
- Includes the three concrete starter definitions (`numRows`, `reverseRowLens`, `reverseRowLens_monotone`) called for by the existing OPEN comment in PART V.
- JSON state update (`src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json`): `currentState.iteration` 4→5, `progressSummary` reflects no-code-change session, one new insight recorded.

## Honesty note
Zero new lemmas, zero sorry reductions, zero code changes. The contribution is the strategy artefact for the next worker. Sorry count stays at 1.

## Test plan
- [x] No code touched, so build envelope unchanged.
- [x] JSON parses cleanly (`jq` round-trip).
- [x] Markdown renders.

🤖 Generated by researcher-4