### PR TITLE
Research: ballot-problem-oq-03-oq-01-oq-01-oq-01 — refine b=1 inverse recipe (session 13)

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean
@@ -406,11 +406,38 @@ private lemma jdt_weight_sum (n a b : ℕ) (hba : b ≤ a) :
     --     = (P.1.map X).prod * X q
     --     = ((q ::ₘ P.1).map X).prod          -- by Multiset.prod_cons + map_cons
     --     = wt(q ::ₛ P)
-    -- KEY LEMMAS:
-    --   * Multiset.sort_cons (∀ b ∈ s, r a b) : sort(a ::ₘ s) = a :: sort(s)
-    --     applied with: q ≤ P.sort[0] implies q ≤ all elements of P (sortedness)
-    --   * Sym.cons_erase : a ::ₛ s.erase a h = s  (closes left_inv)
-    --   * Sym.erase_cons_head : (a ::ₛ s).erase a _ = s  (closes right_inv direction)
+    -- KEY LEMMAS (verified Mathlib v4.26.0, paths confirmed 2026-04-27 session 13):
+    --   * Multiset.sort_cons (Data/Multiset/Sort.lean:69):
+    --       (∀ b ∈ s, r a b) → sort(a ::ₘ s) r = a :: sort s r
+    --     Applied with: q ≤ P.sort[0] + sortedness ⇒ q ≤ all of P
+    --   * Sym.cons (Data/Sym/Basic.lean:106), coe_cons:123 (rfl):
+    --       (a ::ₛ s : Multiset α) = a ::ₘ s.1
+    --   * Sym.cons_erase (Data/Sym/Basic.lean:219, simp):
+    --       a ::ₛ s.erase a h = s   — closes left_inv
+    --   * Sym.erase_cons_head (Data/Sym/Basic.lean:223, simp):
+    --       (a ::ₛ s).erase a _ = s — closes right_inv direction
+    --   * Sym.oneEquiv (Data/Sym/Basic.lean:477, @[simps apply]):
+    --       α ≃ Sym α 1; oneEquiv_apply rewrites oneEquiv a to ⟨{a}, _⟩
+    --
+    -- INVERSE DIRECTION MECHANISM (the trickiest piece, fleshed out session 13):
+    --   Given P' : Sym (Fin n) (a+1):
+    --     L := (P'.1 : Multiset).sort (· ≤ ·) : List (Fin n), length = a+1, sorted
+    --     L_pos : 0 < L.length := by simp [Multiset.length_sort, P'.2]
+    --     q' := L.head L_pos.ne' : Fin n
+    --   Show q' ∈ P'.1 (need this to apply Sym.erase):
+    --     have : q' ∈ L := List.head_mem L_pos.ne'
+    --     have : q' ∈ (L : Multiset) := Multiset.mem_coe.mpr this
+    --     rw [Multiset.sort_eq] at this
+    --     exact this -- q' ∈ P'.1
+    --   Show q' ≤ (P'.1.erase q').sort[0] (the bijection's domain constraint):
+    --     L = q' :: L.tail (by List.head_cons_tail)
+    --     P'.1 = (q' ::ₘ (L.tail : Multiset)) by Multiset.sort_eq + List congruence
+    --     (P'.1.erase q' : Multiset) = (L.tail : Multiset)
+    --       by Multiset.erase_cons_head (Data/Multiset/AddSub.lean:156):
+    --         (a ::ₘ s).erase a = s
+    --     (P'.1.erase q').sort[0] = L.tail[0] = L[1] (when a ≥ 1)
+    --     Sortedness of L gives L[0] ≤ L[1], so q' ≤ L.tail[0]. ✓
+    --     For a = 0 case: tail is empty, so erased multiset is 0; ColStrictSym is vacuous.
     -- ESTIMATE: ~80-100 lines for jdt_weight_sum_b_one as a separate helper.
     -- ============================================================================
     --

--- a/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/knowledge.md
+++ b/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/knowledge.md
@@ -625,3 +625,67 @@ Did not produce code changes this iteration. Both remaining sorries are large, w
 ### Suggested Next Owner
 
 A session targeting **only `jdt_weight_sum`**: define the forward map (`P + {Q.sort[c]}, Q − {Q.sort[c]}`), the inverse (find seam in P'), then prove `Equiv.weight_preserved` via `Multiset.prod_cons` + `Multiset.prod_erase`. Estimated ~120 lines focused work.
+
+---
+
+## Session 2026-04-27 (Session 13) — b=1 Inverse Mechanism Refined
+
+**Mode**: REVISIT (RICH, score 75)
+**Outcome**: SURVEY+ — refined inverse direction recipe with verified Mathlib paths; no proof code change
+
+### Constraints
+
+Disk at 89% (1.6GB free). Per project memory and prior sessions 10-12, attempting a
+fresh ~80-100 line bijection proof without Docker iteration risks committing broken Lean.
+Adopted SURVEY+ approach: refine the recipe so the next session's implementation
+is more mechanical.
+
+### What I Verified
+
+Cross-checked Mathlib v4.26.0 source at `/private/tmp/mathlib4`:
+
+- `Multiset.erase_cons_head (a : α) (s : Multiset α) : (a ::ₘ s).erase a = s`
+  — `Mathlib/Data/Multiset/AddSub.lean:156` (NEW reference, not surfaced in prior sessions)
+- `Multiset.cons_erase {s : Multiset α} {a : α} : a ∈ s → a ::ₘ s.erase a = s`
+  — `Mathlib/Data/Multiset/AddSub.lean:175`
+- `Multiset.length_sort : (sort s r).length = card s` — `Sort.lean:88`
+- All Sym.cons / erase / oneEquiv references from session 12 still valid
+
+### What I Refined
+
+Updated the recipe in `BallotProblemOQ03OQ01OQ01OQ01.lean` (jdt_weight_sum b≥1 branch
+comment) to spell out the inverse direction's mechanism step-by-step:
+
+```text
+Given P' : Sym (Fin n) (a+1):
+  L := P'.1.sort (· ≤ ·) : List, length a+1, sorted
+  q' := L.head L_pos.ne'
+  q' ∈ P'.1: List.head_mem + Multiset.mem_coe + Multiset.sort_eq
+  Erase well-defined: P'.1 = q' ::ₘ (L.tail : Multiset) → erase q' = L.tail
+    (via Multiset.erase_cons_head, AddSub.lean:156)
+  Domain constraint q' ≤ (P'.erase q').sort[0]:
+    L = q' :: L.tail (List.head_cons_tail), so L[0] ≤ L[1] = L.tail[0]
+```
+
+This is more concrete than session 11/12's recipe — the inverse direction was the
+trickiest piece, and the precise lemma chain (Multiset.erase_cons_head was missing
+from the prior recipe) is now spelled out.
+
+### Sorry Count: 2 (unchanged)
+
+Both remaining sorries are stable, correctly stated:
+1. `jdt_weight_sum (hba : b ≤ a)` b≥1 case — JDT bijection (~80-100 lines for b=1; ~150 for b≥2)
+2. `jacobi_trudi_ssyt_eq` k≥3 — algebraic LGV + RSK (~300 lines)
+
+### Files Modified
+
+- `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean` — recipe comment refined (~25 line addition, comment-only, no code/proof change)
+- `src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json` — knowledge updated
+- `research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/knowledge.md` — this entry
+
+### Next Session Owner
+
+The b=1 helper is now mechanical to implement given Docker access. Estimated 80-100
+lines using the documented recipe. The b≥2 JDT seam construction remains the genuine
+frontier (~150 lines). For k≥3, a separate file `BallotProblemOQ03AlgebraicLGV.lean`
+with ~150 lines of ring-valued LGV would complete the framework.


### PR DESCRIPTION
## Summary

Session 13 SURVEY+ for ballot-problem-oq-03-oq-01-oq-01-oq-01 (Jacobi-Trudi via SSYT).

Refines the b=1 case recipe in the JDT bijection sorry, with verified Mathlib v4.26.0 paths. Comment-only change to the .lean file; no proof code modified.

## Progress

- Verified `Multiset.erase_cons_head` (`AddSub.lean:156`) — closes a gap in the inverse direction's well-definedness chain (was missing from prior recipe).
- Spelled out the inverse mechanism step-by-step in the file's recipe comment: head extraction, erase via cons-head, sortedness gives the domain constraint.
- Both sorries unchanged; b=1 helper is now mechanical to implement (~80-100 lines) given Docker access.

## Files Modified

- `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean` — recipe comment refined (~25 lines added; comment-only)
- `src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json` — knowledge updated
- `research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01/knowledge.md` — session 13 entry

## Status

**Outcome**: progress (recipe refinement; SURVEY+ pattern from sessions 10–12)
**Sorry count**: 2 (unchanged)
**Next steps**: implement `jdt_weight_sum_b_one` per the documented recipe with Docker access; tackle b≥2 JDT seam construction; build algebraic LGV for k≥3.

🤖 Generated by researcher-5