### PR TITLE
research(quadratic-reciprocity-oq-03): create missing gallery entry

### DIFF
--- a/src/data/proofs/quadratic-reciprocity-oq-03/annotations.json
+++ b/src/data/proofs/quadratic-reciprocity-oq-03/annotations.json
@@ -1,0 +1,141 @@
+[
+  {
+    "id": "ann-qr-as-algorithm",
+    "proofId": "quadratic-reciprocity-oq-03",
+    "range": {
+      "startLine": 4,
+      "endLine": 36
+    },
+    "type": "concept",
+    "title": "QR as a GCD-Like Algorithm",
+    "content": "Quadratic Reciprocity, paired with multiplicativity and the first supplementary law, gives a complete *algorithm* for computing $\\left(\\tfrac{a}{p}\\right)$:\n\n1. **Reduce**: replace $a$ by $a \\bmod p$.\n2. **Factor**: write $a = (-1)^e \\cdot 2^k \\cdot q_1 \\cdots q_r$ with each $q_i$ an odd prime, then split via multiplicativity.\n3. **Handle constants**: $\\left(\\tfrac{-1}{p}\\right) = (-1)^{(p-1)/2}$ (first supplementary law); $\\left(\\tfrac{2}{p}\\right) = (-1)^{(p^2-1)/8}$ (second).\n4. **Swap**: for each odd prime factor $q$, replace $\\left(\\tfrac{q}{p}\\right)$ by $\\pm\\left(\\tfrac{p}{q}\\right)$ via reciprocity.\n5. **Recurse**: each swap reduces the modulus, like Euclid's algorithm reduces $\\gcd(a,b)$ to $\\gcd(b, a \\bmod b)$.\n\nThis file packages steps 2, 3, and 4 as named reduction lemmas — `legendreSym_mul_eq`, `legendreSym_neg_one_eq`, and `reciprocity_swap` — together with an explicit `algorithm_descent` statement showing termination.",
+    "mathContext": "The packaging matters because Mathlib spreads the relevant lemmas across multiple modules and theorem names: `map_mul` (general algebra), `legendreSym.at_neg_one` (number theory), `legendreSym.quadratic_reciprocity'` (QR proper). Calling them `legendreSym_mul_eq`, `legendreSym_neg_one_eq`, `reciprocity_swap` makes the algorithmic structure visible: each is one *reduction step*. The companion proof `quadratic-reciprocity-algorithm-oq-01` consumes exactly these three steps in its recursive Jacobi-symbol implementation.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Legendre symbol",
+      "Quadratic Reciprocity",
+      "first supplementary law",
+      "second supplementary law",
+      "Euclidean algorithm analogy"
+    ],
+    "prerequisites": [
+      "Quadratic residues mod p",
+      "Definition of the Legendre symbol",
+      "Statement of Quadratic Reciprocity"
+    ]
+  },
+  {
+    "id": "ann-multiplicativity",
+    "proofId": "quadratic-reciprocity-oq-03",
+    "range": {
+      "startLine": 48,
+      "endLine": 51
+    },
+    "type": "definition",
+    "title": "Step 1 — Multiplicativity",
+    "content": "```lean\ntheorem legendreSym_mul_eq (a b : ℤ) (p : ℕ) [Fact p.Prime] :\n    legendreSym p (a * b) = legendreSym p a * legendreSym p b :=\n  map_mul (legendreSym p) a b\n```\n\nFor any integers $a, b$ and odd prime $p$:\n$$\\left(\\tfrac{ab}{p}\\right) = \\left(\\tfrac{a}{p}\\right)\\left(\\tfrac{b}{p}\\right).$$\n\nThis is the *factorization step* of the algorithm: once $a$ is factored, each prime power can be handled independently.",
+    "mathContext": "Mathlib defines `legendreSym p` as a `MonoidHom` (in fact a `RingHom`-like object via `ZMod`-quotient), so multiplicativity is the *defining property* of the homomorphism: `map_mul (legendreSym p) a b`. The proof has no algebraic content of its own — its value is in *naming* the step in algorithmic terms. Note that this works for all integers $a, b$, not just integers coprime to $p$: when $p \\mid a$, both sides equal $0$, consistent with the convention $\\left(\\tfrac{0}{p}\\right) = 0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Legendre symbol",
+      "MonoidHom",
+      "map_mul",
+      "multiplicative function"
+    ],
+    "prerequisites": [
+      "Group homomorphisms preserve multiplication"
+    ]
+  },
+  {
+    "id": "ann-first-supplementary",
+    "proofId": "quadratic-reciprocity-oq-03",
+    "range": {
+      "startLine": 53,
+      "endLine": 56
+    },
+    "type": "definition",
+    "title": "Step 2 — First Supplementary Law",
+    "content": "```lean\ntheorem legendreSym_neg_one_eq (p : ℕ) [Fact p.Prime] (hp : p ≠ 2) :\n    legendreSym p (-1) = (-1) ^ (p / 2)\n```\n\nFor an odd prime $p$:\n$$\\left(\\tfrac{-1}{p}\\right) = (-1)^{(p-1)/2} = \\begin{cases} +1 & p \\equiv 1 \\pmod 4 \\\\ -1 & p \\equiv 3 \\pmod 4 \\end{cases}$$\n\nThis is the *sign-handling step* of the algorithm.",
+    "mathContext": "The Lean expression uses `p / 2` (integer division) which equals $(p-1)/2$ for odd $p$. The proof is one line: `legendreSym.at_neg_one hp`, which is Mathlib's name for the first supplementary law (Euler's criterion specialized at $-1$). The hypothesis `hp : p ≠ 2` excludes the only case where the formula fails to be well-defined (for $p = 2$, the Legendre symbol degenerates and $-1 \\equiv 1 \\pmod 2$). The rule's significance: combined with multiplicativity, every Legendre symbol can be brought to the form $\\left(\\tfrac{a}{p}\\right)$ with $0 < a < p$, and the sign accumulated separately.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Euler's criterion",
+      "first supplementary law",
+      "sign of (-1) mod p"
+    ],
+    "prerequisites": [
+      "Legendre symbol",
+      "p mod 4 case analysis"
+    ]
+  },
+  {
+    "id": "ann-reciprocity-swap",
+    "proofId": "quadratic-reciprocity-oq-03",
+    "range": {
+      "startLine": 58,
+      "endLine": 64
+    },
+    "type": "theorem",
+    "title": "Step 3 — The Reciprocity Swap (Algorithmic Form)",
+    "content": "```lean\ntheorem reciprocity_swap {p q : ℕ} [Fact p.Prime] [Fact q.Prime]\n    (hp : p ≠ 2) (hq : q ≠ 2) :\n    legendreSym q p = (-1) ^ (p / 2 * (q / 2)) * legendreSym p q :=\n  legendreSym.quadratic_reciprocity' hp hq\n```\n\nFor distinct odd primes $p, q$:\n$$\\left(\\tfrac{q}{p}\\right) \\;=\\; (-1)^{\\frac{p-1}{2} \\cdot \\frac{q-1}{2}} \\, \\left(\\tfrac{p}{q}\\right).$$\n\nThis is the *swap step*: it exchanges numerator and denominator in the Legendre symbol, picking up a sign that depends only on $p, q \\bmod 4$.",
+    "mathContext": "The quotient form $\\left(\\tfrac{q}{p}\\right) = \\pm \\left(\\tfrac{p}{q}\\right)$ is more useful for an algorithm than the symmetric product form $\\left(\\tfrac{p}{q}\\right)\\left(\\tfrac{q}{p}\\right) = (-1)^{\\ldots}$, because the algorithm wants to *replace* one symbol by an expression in another. Mathlib's `legendreSym.quadratic_reciprocity'` (note the prime — it's the quotient form) provides this directly. The sign is $-1$ iff $p \\equiv q \\equiv 3 \\pmod 4$; otherwise $+1$. Combined with `legendreSym_mod_left` (Mathlib), the swap also reduces the *modulus*: after the swap one can apply $\\left(\\tfrac{p}{q}\\right) = \\left(\\tfrac{p \\bmod q}{q}\\right)$ where $p \\bmod q < q < p$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Quadratic Reciprocity",
+      "quotient form vs product form",
+      "sign factor (-1)^((p-1)/2·(q-1)/2)",
+      "modulus reduction"
+    ],
+    "prerequisites": [
+      "Statement of Quadratic Reciprocity",
+      "Legendre symbol modular arithmetic"
+    ]
+  },
+  {
+    "id": "ann-decide-examples",
+    "proofId": "quadratic-reciprocity-oq-03",
+    "range": {
+      "startLine": 66,
+      "endLine": 95
+    },
+    "type": "concept",
+    "title": "Verified Examples via decide",
+    "content": "Seven Legendre symbol computations verified by Lean's `decide` tactic:\n\n| Symbol | Value | Hand calculation |\n|---|---|---|\n| $(3/7)$ | $-1$ | Reciprocity: $(3/7) = -(7/3) = -(1/3) = -1$ |\n| $(2/7)$ | $+1$ | $7 \\equiv -1 \\pmod 8$, so $2$ is QR |\n| $(5/13)$ | $-1$ | $5 \\equiv 1 \\pmod 4$, swap: $(5/13) = (13/5) = (3/5) = -1$ |\n| $(7/11)$ | $-1$ | Both $\\equiv 3 \\pmod 4$, swap with sign |\n| $(3/5)$ | $-1$ | $3$ not in $\\{0, 1, 4\\}$ (QRs mod 5) |\n| $(2/17)$ | $+1$ | $17 \\equiv 1 \\pmod 8$, so $2$ is QR |\n| $(6/7)$ | $-1$ | Multiplicativity: $(6/7) = (2/7) \\cdot (3/7) = 1 \\cdot (-1) = -1$ |",
+    "mathContext": "`decide` works here because Mathlib's `legendreSym p a` is implemented via Euler's criterion in `ZMod p` — for a concrete small prime $p$, `ZMod p` is a `Fintype`, so the equality $a^{(p-1)/2} = \\pm 1$ in `ZMod p` is decidable and Lean can evaluate it during elaboration. No `native_decide` is needed because the search space is tiny ($p \\le 17$). The seven examples are not just illustrative: they exercise multiplicativity (last row), the second supplementary law (rows 2 and 6), and the reciprocity swap (rows 1, 3, 4) — each reduction lemma in this file gets a worked instance.",
+    "significance": "supplementary",
+    "relatedConcepts": [
+      "decide tactic",
+      "Euler's criterion",
+      "decidable equality in ZMod p",
+      "elaboration-time evaluation"
+    ],
+    "prerequisites": [
+      "Lean's decide tactic",
+      "Decidable propositions",
+      "Finite computation in ZMod p"
+    ]
+  },
+  {
+    "id": "ann-descent",
+    "proofId": "quadratic-reciprocity-oq-03",
+    "range": {
+      "startLine": 97,
+      "endLine": 107
+    },
+    "type": "theorem",
+    "title": "Algorithm Termination via Descent",
+    "content": "```lean\ntheorem algorithm_descent {p q : ℕ} [Fact p.Prime] [Fact q.Prime]\n    (hp : p ≠ 2) (hq : q ≠ 2) (hqp : q < p) :\n    legendreSym q p = (-1) ^ (p / 2 * (q / 2)) * legendreSym p q\n```\n\n**Statement**: with the extra hypothesis `q < p`, the reciprocity swap takes the symbol $\\left(\\tfrac{q}{p}\\right)$ to a symbol $\\left(\\tfrac{p}{q}\\right)$ whose modulus $q$ is strictly smaller than the original $p$.\n\n**Algorithmic reading**: each application of `algorithm_descent` decreases the modulus, exactly as Euclid's algorithm $\\gcd(a, b) \\mapsto \\gcd(b, a \\bmod b)$ decreases its first argument.",
+    "mathContext": "The proof is `exact reciprocity_swap hp hq` — the `hqp : q < p` hypothesis is *not used* in the proof itself but encoded at the type level to make the descent argument visible. This is a small but principled design choice: by requiring the caller to prove `q < p`, the lemma makes a guarantee — its conclusion *can* be the recursive step of a terminating algorithm. A consumer that uses `algorithm_descent` repeatedly must supply a proof of strict decrease at each step, which is how `quadratic-reciprocity-algorithm-oq-01` discharges its `decreasing_by` obligations: after a swap the modulus is `b mod a` with `b mod a < a`, satisfying the precondition for the next application of descent.",
+    "significance": "key",
+    "relatedConcepts": [
+      "well-founded recursion",
+      "termination by strict decrease",
+      "Euclidean algorithm",
+      "decreasing_by"
+    ],
+    "prerequisites": [
+      "Termination of recursive functions",
+      "Well-founded induction"
+    ]
+  }
+]

--- a/src/data/proofs/quadratic-reciprocity-oq-03/annotations.json
+++ b/src/data/proofs/quadratic-reciprocity-oq-03/annotations.json
@@ -95,7 +95,7 @@
     "id": "ann-decide-examples",
     "proofId": "quadratic-reciprocity-oq-03",
     "range": {
-      "startLine": 66,
+      "startLine": 74,
       "endLine": 95
     },
     "type": "concept",
@@ -119,7 +119,7 @@
     "id": "ann-descent",
     "proofId": "quadratic-reciprocity-oq-03",
     "range": {
-      "startLine": 97,
+      "startLine": 104,
       "endLine": 107
     },
     "type": "theorem",

--- a/src/data/proofs/quadratic-reciprocity-oq-03/index.ts
+++ b/src/data/proofs/quadratic-reciprocity-oq-03/index.ts
@@ -1,0 +1,8 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/QuadraticReciprocityOQ03.lean?raw'
+const meta = metaJson as unknown as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+export const quadraticReciprocityOq03Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
+export const quadraticReciprocityOq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+export const quadraticReciprocityOq03Data: ProofData = { proof: quadraticReciprocityOq03Proof, annotations: quadraticReciprocityOq03Annotations }

--- a/src/data/proofs/quadratic-reciprocity-oq-03/meta.json
+++ b/src/data/proofs/quadratic-reciprocity-oq-03/meta.json
@@ -1,0 +1,134 @@
+{
+  "id": "quadratic-reciprocity-oq-03",
+  "title": "Quadratic Reciprocity as a Computation Algorithm: Reduction Lemmas",
+  "slug": "quadratic-reciprocity-oq-03",
+  "description": "Packages the core reduction lemmas that turn Quadratic Reciprocity into a GCD-like algorithm for the Legendre symbol: multiplicativity, the first supplementary law, and the reciprocity swap. Includes seven concrete `decide`-verified Legendre symbol computations and a descent statement showing each swap strictly reduces the modulus.",
+  "meta": {
+    "author": "Gauss (1801); formalized by lean-genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Quadratic_reciprocity",
+    "date": "1801",
+    "status": "verified",
+    "proofRepoPath": "Proofs/QuadraticReciprocityOQ03.lean",
+    "tags": [
+      "number-theory",
+      "quadratic-reciprocity",
+      "algorithm",
+      "legendre-symbol",
+      "supplementary-laws",
+      "verified-computation"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-04-27",
+    "lineCount": 119,
+    "originalContributions": [
+      "legendreSym_mul_eq: multiplicativity (a·b/p) = (a/p)·(b/p) packaged as a one-line wrapper around `map_mul (legendreSym p)`",
+      "legendreSym_neg_one_eq: first supplementary law (-1/p) = (-1)^((p-1)/2) restated as a clean reduction step",
+      "reciprocity_swap: the reciprocity swap (q/p) = (-1)^((p-1)/2 · (q-1)/2) · (p/q) for distinct odd primes, presented as the single rewrite step of the algorithm",
+      "algorithm_descent: explicit Euclidean-style descent statement — each reciprocity swap reduces the modulus, justifying termination",
+      "Seven `decide`-verified Legendre symbol computations: (3/7)=−1, (2/7)=1, (5/13)=−1, (7/11)=−1, (3/5)=−1, (2/17)=1, (6/7)=−1"
+    ],
+    "assumptions": "No axioms, no sorries. All four reduction lemmas are one-line wrappers around Mathlib's `legendreSym.quadratic_reciprocity'`, `legendreSym.at_neg_one`, and `map_mul`. Examples are verified by Lean's `decide` tactic at elaboration time.",
+    "mathlibDependencies": [
+      {
+        "theorem": "legendreSym.quadratic_reciprocity'",
+        "description": "The Law of Quadratic Reciprocity in quotient form: (q/p) = (-1)^((p/2)·(q/2)) · (p/q) for distinct odd primes",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.QuadraticReciprocity"
+      },
+      {
+        "theorem": "legendreSym.at_neg_one",
+        "description": "First supplementary law: (-1/p) = (-1)^(p/2) for odd primes",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.QuadraticReciprocity"
+      },
+      {
+        "theorem": "map_mul",
+        "description": "Multiplicativity of ring hom-like maps; specializes to (a·b/p) = (a/p)·(b/p) for the Legendre symbol",
+        "module": "Mathlib.Algebra.GroupWithZero.Hom"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The Law of Quadratic Reciprocity was first conjectured by Euler and Legendre and proved by Gauss in 1796 (published in *Disquisitiones Arithmeticae*, 1801). Gauss called it the 'aureum theorema' (golden theorem) and gave six different proofs over his lifetime. The law states that for distinct odd primes $p, q$: $\\left(\\tfrac{p}{q}\\right)\\left(\\tfrac{q}{p}\\right) = (-1)^{\\frac{p-1}{2} \\cdot \\frac{q-1}{2}}$. Combined with the supplementary laws for $-1$ and $2$, it yields a finite procedure for evaluating any Legendre symbol — analogous to the Euclidean algorithm, where reciprocity swaps replace the division step.",
+    "problemStatement": "State and prove the three core reduction steps that turn Quadratic Reciprocity into an algorithm for computing $\\left(\\tfrac{a}{p}\\right)$: multiplicativity (factor $a$), the first supplementary law (handle the sign), and the reciprocity swap (reduce the modulus). Demonstrate that each swap strictly reduces the prime modulus, and verify the algorithm on concrete examples by Lean's `decide` tactic.",
+    "proofStrategy": "Each reduction lemma is a thin wrapper that exposes a Mathlib theorem in the precise form needed for the algorithm: `legendreSym_mul_eq` is `map_mul`, `legendreSym_neg_one_eq` is `legendreSym.at_neg_one`, and `reciprocity_swap` is `legendreSym.quadratic_reciprocity'`. The descent statement `algorithm_descent` repackages `reciprocity_swap` with an explicit `q < p` hypothesis, making the termination argument visible at the type level. The seven examples evaluate Lean's computable Legendre symbol on small primes via `decide`, which performs the finite case-split entirely at elaboration time and so requires no runtime witness.",
+    "keyInsights": [
+      "Quadratic reciprocity is the *swap step* of an algorithm, not just a static identity: paired with multiplicativity and the first supplementary law, it generates a complete reduction procedure for any Legendre symbol",
+      "Each reduction lemma is a one-line wrapper around Mathlib — the value is in the *packaging*: presenting QR in the canonical algorithmic form (multiplicativity ↔ swap ↔ supplementary law) rather than as scattered library results",
+      "`legendreSym.quadratic_reciprocity'` is the right entry point for an algorithmic presentation: it gives the quotient form $\\left(\\tfrac{q}{p}\\right) = \\pm \\left(\\tfrac{p}{q}\\right)$ directly, avoiding the $\\bmod 4$ case-split of the standard formulation",
+      "`decide` works for Legendre symbol computations on small concrete primes because Mathlib's `legendreSym` is implemented via a computable quotient-type expression — no `native_decide` needed for these examples",
+      "The descent statement `algorithm_descent` makes the Euclidean analogy precise: a reciprocity swap maps $(q/p)$ to a problem with strictly smaller modulus, exactly as Euclid's algorithm reduces $\\gcd(a, b)$ to $\\gcd(b, a \\bmod b)$"
+    ]
+  },
+  "sections": [
+    {
+      "id": "reduction-lemmas",
+      "title": "Algorithm Reduction Lemmas",
+      "startLine": 44,
+      "endLine": 64,
+      "summary": "Three reduction steps: multiplicativity (`legendreSym_mul_eq`), first supplementary law (`legendreSym_neg_one_eq`), and the reciprocity swap (`reciprocity_swap`). Each is a one-line wrapper presenting the Mathlib result in the form needed by the algorithm."
+    },
+    {
+      "id": "examples",
+      "title": "Verified Example Computations",
+      "startLine": 66,
+      "endLine": 95,
+      "summary": "Seven concrete Legendre symbol computations verified by `decide`: (3/7)=−1, (2/7)=1, (5/13)=−1, (7/11)=−1, (3/5)=−1, (2/17)=1, (6/7)=−1. Each example is annotated with the QR-based hand calculation that `decide` corroborates."
+    },
+    {
+      "id": "descent",
+      "title": "Algorithm Termination",
+      "startLine": 97,
+      "endLine": 118,
+      "summary": "Proves `algorithm_descent`: under the hypothesis `q < p`, the reciprocity swap (q/p) = ±(p/q) reduces the modulus from p to q. This makes the Euclidean-style termination argument explicit at the type level."
+    }
+  ],
+  "conclusion": {
+    "summary": "This formalization packages the Law of Quadratic Reciprocity in its algorithmic form: three reduction lemmas (multiplicativity, first supplementary law, reciprocity swap) plus an explicit descent statement, all proved as one-line wrappers around Mathlib. Seven concrete Legendre symbol computations are verified by Lean's `decide` tactic. The proof has zero sorries and zero axioms.",
+    "implications": "The companion proof `quadratic-reciprocity-algorithm-oq-01` builds on this packaging by implementing the full recursive algorithm (Jacobi-symbol form, well-founded termination, native_decide-verified examples). This entry exposes the *minimum* set of lemmas needed to turn QR into a computation, useful as a teaching artifact and as a stepping stone for downstream verified applications such as Solovay-Strassen primality testing and Tonelli-Shanks square roots.",
+    "openQuestions": [
+      "Can the second supplementary law $\\left(\\tfrac{2}{p}\\right) = (-1)^{(p^2-1)/8}$ be packaged as a fourth reduction lemma in the same one-line wrapper style, completing the standalone algorithmic toolkit?",
+      "Can the descent statement be strengthened to a recursion principle that takes the three reduction lemmas as inputs and produces a verified Legendre symbol computer, without going through the Jacobi-symbol detour of `quadratic-reciprocity-algorithm-oq-01`?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "quadratic-reciprocity",
+      "relationship": "Foundation",
+      "description": "The underlying Law of Quadratic Reciprocity that is packaged here as the swap step of an algorithm."
+    },
+    {
+      "proofId": "quadratic-reciprocity-algorithm",
+      "relationship": "Parent proof",
+      "description": "The parent algorithmic presentation of QR; this entry provides the canonical reduction-lemma form."
+    },
+    {
+      "proofId": "quadratic-reciprocity-algorithm-oq-01",
+      "relationship": "Sibling — full algorithm",
+      "description": "Companion entry that builds on these reduction lemmas to give a fully recursive Jacobi-symbol algorithm with well-founded termination and native_decide-verified examples."
+    },
+    {
+      "proofId": "elementary-quadratic-reciprocity",
+      "relationship": "Related proof",
+      "description": "An elementary proof of QR via Gauss sums; provides the theoretical foundation that this algorithmic packaging makes computational."
+    }
+  ],
+  "references": {
+    "papers": [
+      {
+        "title": "Disquisitiones Arithmeticae",
+        "author": "C. F. Gauss",
+        "year": 1801,
+        "url": "https://en.wikipedia.org/wiki/Disquisitiones_Arithmeticae"
+      }
+    ],
+    "urls": [
+      "https://en.wikipedia.org/wiki/Quadratic_reciprocity",
+      "https://en.wikipedia.org/wiki/Legendre_symbol"
+    ],
+    "mathlib": [
+      "Mathlib.NumberTheory.LegendreSymbol.QuadraticReciprocity",
+      "Mathlib.NumberTheory.LegendreSymbol.Basic"
+    ]
+  }
+}

--- a/src/data/research/problems/quadratic-reciprocity-oq-03.json
+++ b/src/data/research/problems/quadratic-reciprocity-oq-03.json
@@ -1,8 +1,8 @@
 {
   "slug": "quadratic-reciprocity-oq-03",
   "title": "quadratic-reciprocity-oq-03",
-  "phase": "OBSERVE",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "C",
   "path": "full",
   "problemStatement": {
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "COMPLETED",
     "since": "2026-03-29T19:03:48-07:00",
     "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "focus": "Gallery entry created. Lean proof was already complete; gap was missing src/data/proofs/quadratic-reciprocity-oq-03/.",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "None — gallery entry registered with 6 annotations, 4 cross-references.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,17 +29,19 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: QuadraticReciprocityOQ03.lean — 4 theorems + 7 examples, 0 sorries, 0 axioms. QR as algorithm: multiplicativity + reciprocity swap + supplementary laws. Verified Legendre symbol computations.",
+    "progressSummary": "COMPLETE: Lean proof verified (0 sorries, 0 axioms, 4 theorems + 7 examples). Gallery entry created 2026-04-27 with meta.json, annotations.json (6 annotations), index.ts; listings.json regenerated.",
     "builtItems": [
       "legendreSym_mul_eq: multiplicativity (a*b/p) = (a/p)(b/p) via map_mul",
       "legendreSym_neg_one_eq: first supplementary law (-1/p) = (-1)^((p-1)/2)",
       "reciprocity_swap: (q/p) = (-1)^(sign) * (p/q) quotient form",
-      "algorithm_descent: descent property (reciprocity reduces modulus)"
+      "algorithm_descent: descent property (reciprocity reduces modulus)",
+      "Gallery entry: src/data/proofs/quadratic-reciprocity-oq-03/{meta,annotations,index} (2026-04-27)"
     ],
     "insights": [
       "QR + multiplicativity + supplementary laws = complete algorithm for computing Legendre symbols",
       "Each reciprocity swap reduces the prime, like the Euclidean algorithm reduces by taking remainders",
-      "decide tactic in Lean can verify Legendre symbol values for small primes automatically"
+      "decide tactic in Lean can verify Legendre symbol values for small primes automatically",
+      "The Lean proof was complete since 2026-03-30 but invisible — no gallery entry. The candidate-pool progressSummary correctly said COMPLETE, but the actual website registration step had been skipped. Audit pattern: when claimed problem says COMPLETE in progressSummary, check src/data/proofs/<slug>/ exists before assuming work is done."
     ],
     "mathlibGaps": [],
     "nextSteps": [],
@@ -57,7 +59,7 @@
     "mathlib": []
   },
   "started": "2026-03-30T02:13:21.213Z",
-  "lastUpdate": "2026-03-30T02:13:21.225Z",
+  "lastUpdate": "2026-04-27T22:00:00.000Z",
   "leanFiles": [
     {
       "path": "Proofs/QuadraticReciprocity.lean",


### PR DESCRIPTION
## Summary

The Lean proof at \`proofs/Proofs/QuadraticReciprocityOQ03.lean\` has been complete since 2026-03-30 (4 theorems + 7 \`decide\`-verified examples, 0 sorries, 0 axioms). The candidate-pool entry's \`progressSummary\` correctly said \"COMPLETE\" — but no gallery entry existed under \`src/data/proofs/quadratic-reciprocity-oq-03/\`, so the work was invisible on the website.

This PR adds the missing gallery entry. No Lean code is touched.

## Changes

- **\`src/data/proofs/quadratic-reciprocity-oq-03/meta.json\`** — full metadata (status: verified, badge: original, axiomCount: 0, sorries: 0), historical context (Gauss 1801), proof strategy, three sections (reduction-lemmas, examples, descent), conclusion with two open questions, and 4 cross-references.
- **\`src/data/proofs/quadratic-reciprocity-oq-03/annotations.json\`** — 6 annotations: QR-as-algorithm framing, multiplicativity, first supplementary law, reciprocity swap, decide-verified examples, algorithm-descent termination.
- **\`src/data/proofs/quadratic-reciprocity-oq-03/index.ts\`** — standard auto-discovered loader following the project pattern.
- **\`src/data/research/problems/quadratic-reciprocity-oq-03.json\`** — phase OBSERVE → COMPLETED, status active → completed; new insight noting the audit pattern (when JSON says COMPLETE, verify gallery entry exists).

\`listings.json\` was regenerated locally via \`scripts/annotations/build.ts\` (gitignored, so not in the diff). The annotation builder runs cleanly with no \"No Lean construct found\" warnings on this proof.

## Verification

- \`npx tsx scripts/annotations/build.ts\`: 2178 proofs found, 0 errors on \`quadratic-reciprocity-oq-03\` after fixing two annotation anchors.
- Lean file unchanged; build was not re-run (low disk, ~1.1GB free; per project memory, skip Docker builds when \`< 1\`GB free, and this is borderline). The Lean file's complete state is established by prior CI on the file.

## Status

**Outcome**: completed — gallery entry created and registered.
**Next steps**: none for this problem; consumer entries (\`quadratic-reciprocity-algorithm\`, \`quadratic-reciprocity-algorithm-oq-01\`) already exist.

🤖 Generated by researcher-1