### PR TITLE
Research: erdos-662 — mark COMPLETED in pool metadata

### DIFF
--- a/src/data/research/problems/erdos-662.json
+++ b/src/data/research/problems/erdos-662.json
@@ -1,8 +1,8 @@
 {
   "slug": "erdos-662",
   "title": "Erdős #662",
-  "phase": "ORIENT",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -16,10 +16,10 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ORIENT",
+    "phase": "COMPLETED",
     "since": "2026-01-13T18:22:04.304Z",
     "iteration": 3,
-    "focus": "All supporting theorems proved. kissing_number_2d fully proved via angular sector pigeonhole. 0 sorries, 1 axiom (open conjecture). Gallery metadata updated.",
+    "focus": "Gallery already at max potential: 0 sorries, 1 axiom (erdos_662_lattice_optimal — main open conjecture, unprovable). All supporting work (kissing_number_2d, contact_number_3n, etc.) is fully proved. Pool entry marked completed 2026-04-27 by researcher-4.",
     "blockers": [],
     "nextAction": "Problem at maximum formalization potential — only axiom is the open conjecture.",
     "attemptCounts": {


### PR DESCRIPTION
## Summary
Pool-metadata-only update for `erdos-662`. The gallery has been at max formalization potential since session 3 (2026-03-27): 0 sorries, 1 axiom (the open Erdős conjecture itself), with all supporting infrastructure (kissing_number_2d, unit_neighbor_bound, contact_number_3n) fully proved.

The candidate-pool entry still had `phase: "ORIENT"` / `status: "active"`, which makes the depth-first claim heuristic keep re-selecting it. Updated `phase`/`status`/`currentState.phase` to `"COMPLETED"` and ran `claim-problem.sh update erdos-662 completed` to update the pool tracker.

This matches the pattern in researcher memory about stale "completed" candidate-pool entries.

## Changes
- `src/data/research/problems/erdos-662.json`: phase / status / currentState.phase → COMPLETED, focus rewritten.

No Lean changes.

## Test plan
- [x] JSON parses (`jq`).
- [x] Pool tracker updated (`claim-problem.sh status` no longer lists erdos-662 as available).

🤖 Generated by researcher-4