### PR TITLE
Research: erdos-827 audit + erdos-913 completion

### DIFF
--- a/research/problems/erdos-827/knowledge.md
+++ b/research/problems/erdos-827/knowledge.md
@@ -2,75 +2,152 @@
 
 ## Problem Statement
 
-Forum
-Favourites
-Tags
-More
- Go
- Go
-Dual View
-Random Solved
-Random Open
+Let $n_k$ be minimal such that any $n_k$ points in $\mathbb{R}^2$ in general
+position contain a $k$-subset where all $\binom{k}{3}$ triples determine
+circles of distinct radii. **Determine $n_k$.**
 
-Let $n_k$ be minimal such that if $n_k$ points in $\mathbb{R}^2$ are in general position then there exists a subset of $k$ points such that all $\binom{k}{3}$ triples determine circles of different radii.
+- Erdős (1975) asked whether $n_k$ exists.
+- Erdős (1978) gave $n_k \leq k + 2\binom{k-1}{2}\binom{k-1}{3}$ — argument
+  later shown incorrect by Martinez & Roldán-Pensado.
+- Martinez & Roldán-Pensado (2015) proved $n_k \ll k^9$.
 
-Determine $n_k$.
-
-
-
-In \cite{Er75h} Erd\H{o}s asks whether $n_k$ exists. In \cite{Er78c} he gave a simple argument which proves that it does, and in fact\[n_k \leq k+2\binom{k-1}{2}\binom{k-1}{3},\]but this argument is incorrect, as explained by Martinez and Rold\'{a}n-Pensado \cite{MaRo15}.
-
-Martinez and Rold\'{a}n-Pensado give a corrected argument that proves $n_k\ll k^9$.
-
-
-
-
-References
-
-
-[Er75h] Erd\H{o}s, P., Some problems on elementary geometry. Austral. Math. Soc. Gaz. (1975), 2-3.
-
-[Er78c] Erd\H{o}s, P., Some more problems on elementary geometry. Austral. Math. Soc. Gaz. (1978), 52-54.
-
-[MaRo15] Mart\'{I}nez, L. and Rold\'an-Pensado, E., Points defining triangles with distinct circumradii. Acta Math. Hungar. (2015), 136--141.
-
-
-Back to the problem
+The exact value of $n_k$ remains **open** for $k \geq 4$.
 
 ## Status
 
-**Erdős Database Status**: OPEN
+- **Erdős database**: OPEN
+- **Lean formalization**: 4 axioms, 14 theorems, 0 sorries
+- **Tractability**: 4/10 (full solution requires the published MRP proof)
+- **Aristotle suitable**: No (the open conjecture is the value of n_k itself)
 
-**Tractability Score**: 4/10
-**Aristotle Suitable**: No
+## Lean Formalization Architecture
+
+**Geometry primitives:**
+- `Point := ℝ × ℝ`
+- `distSq p q : ℝ` — squared Euclidean distance
+- `GeneralPosition S` — no three collinear, via cross-product determinant
+- `circumRadiusSq p q r` — formula `a²·b²·c² / (4·Area²)`
+- `AllDistinctCircumradii T` — every two distinct triples in T have ≠ radii
+
+**Threshold function:**
+- `NkExists k : Prop` — ∃ n forces a good k-subset in any GP set of size ≥ n
+- `minimalNk : ℕ → ℕ` — axiomatized as the minimal such threshold
+- `ErdosProblem827 : Prop := ∀ k ≥ 3, NkExists k`
+- `MartinezBound : Prop` — ∃ C > 0, ∀ k ≥ 3, minimalNk k ≤ C·k⁹
+
+**Construction:**
+- `parabolaPoint i := (i, i²)` — parabolic embedding
+- `parabolaSet n` — the first n parabola points
+- `parabolaSet_gp` — parabola points are in GP (collinearity determinant
+  factors as $(a-c)(b-c)(b-a) \neq 0$)
+
+## Insights
+
+### 1. Opaque function design forces axiom triple
+
+`minimalNk` is declared as `axiom minimalNk : ℕ → ℕ`. This *forces*
+`minimalNk_valid` (validity) and `minimalNk_sharp` (sharpness) to also be
+axioms — Lean has no way to derive properties of an opaque function.
+
+### 2. `Nat.find` refactor consolidates axioms
+
+A `noncomputable def` using `Nat.find` over a witness existence axiom
+collapses three axioms (function + valid + sharp) into one (witness
+existence) plus zero (def is a definition, not an axiom).
+
+```lean
+def NkProperty (k n : ℕ) : Prop :=
+  ∀ S : Finset Point, GeneralPosition S → n ≤ S.card →
+    ∃ T : Finset Point, T ⊆ S ∧ T.card = k ∧ AllDistinctCircumradii T
+
+axiom nk_property_witness (k : ℕ) (hk : 3 ≤ k) : ∃ n, NkProperty k n
+
+noncomputable def minimalNk (k : ℕ) : ℕ :=
+  if h : ∃ n, NkProperty k n then Nat.find h else 0
+```
+
+Then `minimalNk_valid` follows from `Nat.find_spec`, and `minimalNk_sharp`
+follows from `Nat.find_min`. This reduces 4 → 2 axioms.
+
+### 3. Parabola GP via determinant factoring
+
+The collinearity test for $(a,a^2), (b,b^2), (c,c^2)$ reduces to:
+$$
+(a-c)(b^2-c^2) - (b-c)(a^2-c^2) = (a-c)(b-c)(b-a)
+$$
+which is non-zero iff a, b, c are pairwise distinct.
+
+### 4. n_3 = 3 via vacuous AllDistinctCircumradii
+
+For 3-element sets, there is only one unordered triple, so the "every two
+*distinct* triples have different radii" hypothesis has empty conclusion
+domain. This forces `nk_three` even though `minimalNk` is opaque.
+
+### 5. Monotonicity is automatic from validity + sharpness
+
+`nk_monotone` follows by contradiction: if $n_{k_2} < n_{k_1}$, then the
+sharp witness for $k_1$ is a GP set of size $\geq n_{k_2}$, hence has a
+good $k_2$-subset $T$. Subset $T' \subseteq T$ of size $k_1$ inherits
+`AllDistinctCircumradii` (the property is hereditary), contradicting
+sharpness.
+
+### 6. Vacuous-ness is geometry-blind
+
+`nk_three = 3` is a *combinatorial* truth, not a geometric one — it follows
+from the structure of "all distinct triples" being empty for 3-sets. This is
+why it can be proved without touching circumRadiusSq computations.
+
+### 7. Further axiom reduction needs published proof formalization
+
+The deepest remaining axiom is `martinez_roldan_pensado` (the polynomial
+bound). Eliminating it would require formalizing the Martinez & Roldán-Pensado
+2015 paper (Acta Math. Hungar.) — a multi-month effort involving incidence
+geometry and polynomial method techniques.
+
+## Mathlib Gaps
+
+(None identified during this audit. The proofs use only `Real`, `Finset`,
+`Tactic` — basic Mathlib infrastructure.)
+
+## Sessions
+
+### Session 1 (pre-2026-04, recorded retroactively)
+- Reduced axiom count 6 → 5 → 4
+- Proved nk_ge_k, nk_three, nk_monotone (all promoted from axioms)
+- Built parabola GP infrastructure
+- Added structural lemmas (distSq, hereditary properties)
+- See git log: PRs #7696, #7239, #7324, #8301
+
+### Session 2 (2026-04-27, this session — researcher-7)
+- Audit: confirmed file state matches metadata (4 axioms, 14 theorems, 0 sorries)
+- Identified Nat.find refactor as concrete next step (4 → 2 axioms)
+- Refactor deferred to next session: disk at 89%, Docker build unsafe;
+  per CLAUDE.md never run lake build directly
+- No Lean code changes this session; pure metadata + planning
+
+## References
+
+- [Er75h] Erdős, P. *Some problems on elementary geometry.* Austral. Math.
+  Soc. Gaz. (1975), 2-3.
+- [Er78c] Erdős, P. *Some more problems on elementary geometry.* Austral.
+  Math. Soc. Gaz. (1978), 52-54.
+- [MaRo15] Martínez, L. and Roldán-Pensado, E. *Points defining triangles
+  with distinct circumradii.* Acta Math. Hungar. (2015), 136–141.
 
 ## Tags
 
 - erdos
+- geometry
+- discrete-geometry
+- circumradii
+- ramsey-type
 
 ## Related Problems
 
-- Problem #2000
-- Problem #83
-- Problem #888
-- Problem #1998
-- Problem #826
-- Problem #828
-- Problem #2
-- Problem #39
-- Problem #1
-
-## References
-
-- Er75h
-- Er78c
-- Er92e
-- MaRo15
-
-## Sessions
-
-(No research sessions yet)
+- #826, #828 (neighbors in Erdős's geometry sequence)
+- #2000, #1998 (other Ramsey-type combinatorial geometry)
+- #83, #888 (related distinct-distance / distinct-radius problems)
 
 ---
 
-*Generated from erdosproblems.com on 2026-01-15*
+*Last updated: 2026-04-27 by researcher-7 (audit/refactor-planning session)*

--- a/research/problems/erdos-827/state.md
+++ b/research/problems/erdos-827/state.md
@@ -1,27 +1,85 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-01-15T09:39:18.200Z
-**Iteration**: 1
+**Phase**: AUDIT
+**Since**: 2026-04-27
+**Iteration**: 2
+**Last Updated**: 2026-04-27
 
 ## Current Focus
 
-Initial exploration of the problem.
+Metadata sync + axiom-elimination refactor planning. Lean file
+`proofs/Proofs/Erdos827Problem.lean` has 4 axioms, 14 theorems, 0 sorries —
+significantly more proved than the original metadata claimed (state.md and
+src/data JSON were stuck at iteration 1 / NEW phase despite multiple
+axiom-elimination PRs).
+
+## Axiom Inventory (4)
+
+1. `minimalNk : ℕ → ℕ` — opaque function (the threshold itself)
+2. `minimalNk_valid` — universal property of the threshold
+3. `minimalNk_sharp` — minimality property
+4. `martinez_roldan_pensado` — published bound: ∃ C > 0, ∀ k ≥ 3, minimalNk k ≤ C·k⁹
+
+## Theorem Inventory (14)
+
+Structural:
+- `parabolaPoint_injective`, `parabolaSet_card`, `parabolaSet_gp`
+- `distSq_comm`, `distSq_self`, `distSq_nonneg`, `distSq_eq_zero_iff`
+- `generalPosition_subset`, `allDistinctCircumradii_subset`
+
+Existence & combinatorial:
+- `nk_ge_k`: k ≤ minimalNk k via parabola GP construction
+- `allDistinctCircumradii_of_card_three`: vacuous case for |T|=3
+- `nk_three`: minimalNk 3 = 3
+- `nk_monotone`: k₁ ≤ k₂ → minimalNk k₁ ≤ minimalNk k₂
+- `nkExists_of_axioms`: NkExists k for k ≥ 3
 
 ## Active Approach
 
-None yet.
+**Refactor opportunity** (not yet attempted; requires Docker to verify):
+
+The triple {minimalNk, minimalNk_valid, minimalNk_sharp} can be collapsed
+to **one** axiom plus a noncomputable definition:
+
+```lean
+def NkProperty (k n : ℕ) : Prop :=
+  ∀ S : Finset Point, GeneralPosition S → n ≤ S.card →
+    ∃ T : Finset Point, T ⊆ S ∧ T.card = k ∧ AllDistinctCircumradii T
+
+axiom nk_property_witness (k : ℕ) (hk : 3 ≤ k) : ∃ n, NkProperty k n
+
+noncomputable def minimalNk (k : ℕ) : ℕ :=
+  if h : ∃ n, NkProperty k n then Nat.find h else 0
+```
+
+Then `minimalNk_valid` follows from `Nat.find_spec`, and `minimalNk_sharp`
+follows from `Nat.find_min`. This reduces 4 → 2 axioms.
+
+Further: properly stating Martinez-Roldán-Pensado as a free-standing
+existence theorem with explicit polynomial witness *implies*
+`nk_property_witness`, so in principle the axiom count could drop to 1
+(the published MRP theorem itself).
 
 ## Blockers
 
-None.
+- **Disk pressure**: 89% capacity, 1.6GB free. Cannot run Docker build to
+  verify a refactor PR (per memory, disk-full sessions corrupt containerd).
+- **Refactor scope**: switching to `Nat.find` requires updating proofs of
+  `nk_ge_k`, `nk_three`, `nk_monotone` (each consumes
+  `minimalNk_valid`/`_sharp`). Mechanical but needs build verification in
+  one PR.
 
 ## Next Action
 
-Begin problem exploration.
+1. Wait for disk pressure to clear (other agents complete or cleanup runs).
+2. Prototype Nat.find refactor in fresh worktree; verify with Docker.
+3. Submit refactor as separate PR (axiom count 4 → 2).
+
+For now: this audit + insight documentation lands the structural
+understanding so the next session can proceed directly to implementation.
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 2 (initial axiom-elimination wave + this audit)
+- Current approach attempts: 1 (audit/refactor planning)
+- Approaches tried: parabola GP construction (success), audit (in progress)

--- a/src/data/research/problems/erdos-827.json
+++ b/src/data/research/problems/erdos-827.json
@@ -16,37 +16,49 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "COMPLETED",
-    "since": "2026-01-15T09:39:18.200Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
-    "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "phase": "AUDIT",
+    "since": "2026-04-27T21:05:00.000Z",
+    "iteration": 2,
+    "focus": "Metadata sync + Nat.find refactor planning. 4 axioms / 14 theorems / 0 sorries; further reduction (4 → 2) requires Nat.find refactor of minimalNk, deferred until Docker build is safe.",
+    "blockers": ["Disk at 89% (1.6GB free) — Docker build unsafe; refactor PR deferred"],
+    "nextAction": "When disk pressure clears: prototype Nat.find refactor of minimalNk + valid + sharp into 1 axiom (witness existence) + 1 noncomputable def. Update nk_ge_k, nk_three, nk_monotone proofs. Verify with Docker.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 2,
+      "currentApproach": 1,
+      "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: 6→5 axioms. Proved nk_ge_k via parabola GP construction. Added parabolaPoint, parabolaSet, parabolaSet_gp infrastructure.",
+    "progressSummary": "STABLE at 4 axioms / 14 theorems / 0 sorries. Prior PRs eliminated nk_ge_k, nk_three, nk_monotone (axiom → theorem). Audit (2026-04-27) identifies Nat.find refactor as concrete path 4 → 2 axioms; deferred until Docker build is safe.",
     "builtItems": [
       "Assessment: all axioms appropriate for opaque function design",
       "PROVED nk_ge_k: k ≤ minimalNk k via parabola contradiction (axiom→theorem)",
+      "PROVED nk_three: minimalNk 3 = 3 via vacuous AllDistinctCircumradii for 3-sets",
+      "PROVED nk_monotone: monotonicity via sharp witness + hereditary AllDistinctCircumradii",
+      "PROVED structural lemmas: distSq_comm/self/nonneg/eq_zero_iff, generalPosition_subset, allDistinctCircumradii_subset",
       "parabolaPoint/parabolaSet: reusable GP set construction for any size n",
-      "parabolaSet_gp: collinearity determinant factoring proof (ring + cast injection)"
+      "parabolaSet_gp: collinearity determinant factoring proof (ring + cast injection)",
+      "parabolaSet_card: |parabolaSet n| = n via injectivity",
+      "allDistinctCircumradii_of_card_three: vacuous case for |T|=3 (Finset cardinality)"
     ],
     "insights": [
-      "minimalNk is an axiom (opaque function), forcing all properties to be axioms too",
-      "nk_ge_k and nk_monotone could be proved if minimalNk were a def with minimality built in",
+      "minimalNk is an axiom (opaque function), forcing valid + sharp to also be axioms; the triple is structurally coupled",
+      "Nat.find refactor: replace {minimalNk, valid, sharp} with {nk_property_witness, noncomputable def using Nat.find}; reduces axiom count 4 → 2",
+      "Refactor sketch: NkProperty k n : Prop; axiom nk_property_witness; minimalNk k := if h then Nat.find h else 0; valid follows from Nat.find_spec, sharp from Nat.find_min",
       "Definitions (GeneralPosition, circumRadiusSq, AllDistinctCircumradii) are mathematically correct",
-      "nk_ge_k proof strategy: construct GP set of size minimalNk k, apply minimalNk_valid, cardinality contradiction",
       "Parabola y=x² points are in GP: collinearity determinant is (a-c)(b-c)(b-a)!=0 for distinct a,b,c",
-      "Remaining 5 axioms are all deep: minimalNk (opaque function), valid/sharp (properties of opaque fn), martinez_roldan_pensado (published result), nk_three (specific value of opaque fn)",
-      "Further axiom reduction requires restructuring minimalNk as Nat.find (major refactor) or formalizing Martinez-Roldán-Pensado (paper-length proof)"
+      "n_3 = 3 is combinatorial (vacuous distinct-triples), not geometric — proved without circumRadiusSq facts",
+      "nk_monotone: hereditary AllDistinctCircumradii on subsets allows shrinking k₂-witness to k₁-witness",
+      "Properly stated MRP (free of minimalNk reference) implies nk_property_witness via threshold n = ⌈C·k⁹⌉; in principle axiom count could drop to 1",
+      "Deepest residual axiom: martinez_roldan_pensado — formalizing it requires the 2015 Acta Math. Hungar. paper (incidence geometry, polynomial method, multi-month effort)"
     ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Wait for disk pressure to clear (currently 89%, Docker unsafe)",
+      "Prototype Nat.find refactor in fresh worktree with Docker verification",
+      "Update nk_ge_k, nk_three, nk_monotone to use Nat.find_spec / Nat.find_min instead of valid/sharp",
+      "Submit refactor PR (axiom count 4 → 2) with explicit verification log"
+    ],
     "markdown": "# Erdős #827 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $n_k$ be minimal such that if $n_k$ points in $\\mathbb{R}^2$ are in general position then there exists a subset of $k$ points such that all $\\binom{k}{3}$ triples determine circles of different radii.\n\nDetermine $n_k$.\n\n\n\nIn \\cite{Er75h} Erd\\H{o}s asks whether $n_k$ exists. In \\cite{Er78c} he gave a simple argument which proves that it does, and in fact\\[n_k \\leq k+2\\binom{k-1}{2}\\binom{k-1}{3},\\]but this argument is incorrect, as explained by Martinez and Rold\\'{a}n-Pensado \\cite{MaRo15}.\n\nMartinez and Rold\\'{a}n-Pensado give a corrected argument that proves $n_k\\ll k^9$.\n\n\n\n\nReferences\n\n\n[Er75h] Erd\\H{o}s, P., Some problems on elementary geometry. Austral. Math. Soc. Gaz. (1975), 2-3.\n\n[Er78c] Erd\\H{o}s, P., Some more problems on elementary geometry. Austral. Math. Soc. Gaz. (1978), 52-54.\n\n[MaRo15] Mart\\'{I}nez, L. and Rold\\'an-Pensado, E., Points defining triangles with distinct circumradii. Acta Math. Hungar. (2015), 136--141.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #826\n- Problem #828\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er75h\n- Er78c\n- Er92e\n- MaRo15\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
   "tags": [
@@ -63,7 +75,7 @@
     "mathlib": []
   },
   "started": "2026-01-15T09:39:18.200Z",
-  "lastUpdate": "2026-03-13T07:52:17.053Z",
+  "lastUpdate": "2026-04-27T21:10:00.000Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [

--- a/src/data/research/problems/erdos-913.json
+++ b/src/data/research/problems/erdos-913.json
@@ -16,16 +16,16 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ACT",
-    "since": "2026-01-15T11:36:40.862Z",
-    "iteration": 2,
-    "focus": "Initial exploration of the problem.",
-    "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "phase": "COMPLETED",
+    "since": "2026-04-27T21:15:00.000Z",
+    "iteration": 3,
+    "focus": "Two independent conditional proofs (8p²-1 path and Mersenne path); 1 axiom remaining is the Bunyakovsky-type conjecture (genuinely open). 0 sorries.",
+    "blockers": ["Remaining axiom is an unsolved open conjecture; no further reduction possible without proving Bunyakovsky-type statement"],
+    "nextAction": "No further work — file is complete given current mathematical knowledge. Marking problem as completed in pool.",
     "attemptCounts": {
-      "total": 0,
+      "total": 3,
       "currentApproach": 0,
-      "approachesTried": 0
+      "approachesTried": 2
     }
   },
   "knowledge": {
@@ -79,7 +79,7 @@
     "mathlib": []
   },
   "started": "2026-01-15T11:36:40.863Z",
-  "lastUpdate": "2026-03-13T07:52:17.054Z",
+  "lastUpdate": "2026-04-27T21:15:00.000Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [


### PR DESCRIPTION
## Summary

Two metadata-sync research sessions in one PR.

### Erdős #827 (Distinct Circumradii)
Sync stale metadata (state.md was iter 1 / NEW phase despite multiple axiom-elimination PRs). Lean file state: 4 axioms / 14 theorems / 0 sorries.

Document **Nat.find refactor opportunity**: collapse {`minimalNk`, `minimalNk_valid`, `minimalNk_sharp`} into 1 axiom (witness existence) + 1 noncomputable def using `Nat.find`. Reduces axiom count 4 → 2; valid/sharp recovered via `Nat.find_spec`/`Nat.find_min`. Refactor itself deferred — disk at 89%, Docker build unsafe per CLAUDE.md guidance.

### Erdős #913 (Distinct Exponents in n(n+1))
Mark as **completed** in pool: file has 1 axiom (genuinely open Bunyakovsky-type conjecture) and 0 sorries. The progressSummary already said COMPLETED but `currentState` was stuck at iteration 2 / phase "ACT" / focus "Initial exploration." Two independent conditional proofs are in place (8p²-1 path and Mersenne path); no further reduction possible without solving the open conjecture.

## Files changed

- `research/problems/erdos-827/state.md` — NEW → AUDIT, iter 1 → 2; full inventory; refactor sketch.
- `research/problems/erdos-827/knowledge.md` — replaced auto-generated template with proper knowledge base.
- `src/data/research/problems/erdos-827.json` — synced `currentState`, `progressSummary`, `builtItems`, `insights`, `nextSteps`.
- `src/data/research/problems/erdos-913.json` — synced `currentState` to COMPLETED.

Pool entry for erdos-913 updated to status `completed` via `claim-problem.sh`.

## Why metadata-only

Disk at 89-91% during this session; Docker build unsafe per project memory (overlay filesystem corruption risk on heavy multi-agent activity). Editing Lean code without verification is unsafe. This PR lands the structural understanding so the next session can proceed directly to the erdos-827 refactor.

## Test plan

- [ ] No Lean code changed; existing build remains valid.
- [ ] JSON schema fields preserved (verified `currentState.iteration`, `knowledge.progressSummary` parse with `jq`).
- [ ] `state.md` and `knowledge.md` are valid Markdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)