### PR TITLE
audit(szemeredi-hypergraph-core-oq-01-incomplete-01): sync meta.json with sorry-free Lean state

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12853,10 +12853,10 @@
       "result": "clean"
     },
     "szemeredi-hypergraph-core-oq-01-incomplete-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-23T18:43:36Z",
-      "result": "clean"
+      "lastAudited": "2026-04-27T21:13:24Z",
+      "result": "issues-fixed"
     },
     "szemeredi-regularity": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/szemeredi-hypergraph-core-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/szemeredi-hypergraph-core-oq-01-incomplete-01/meta.json
@@ -19,7 +19,7 @@
     ],
     "proofRepoPath": "Proofs/SzemerediHypergraphGowers.lean",
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Finset.inter_eq_left",
@@ -35,12 +35,16 @@
       "relativeKDensity: d(H | C) = |H.edges ∩ topCliques(C)| / |topCliques(C)|",
       "IsGowersRegular: density stable under dense sub-complexes",
       "relativeKDensity_completeComplex: relative density w.r.t. complete complex equals global density",
-      "mono_eps, mono_delta: monotonicity of Gowers regularity in ε and δ"
+      "mono_eps, mono_delta: monotonicity of Gowers regularity in ε and δ",
+      "relativeKDensity_eq_of_topCliques_eq: relative density depends only on the topCliques set",
+      "isGowersRegular_self: every k-graph is (0,1)-Gowers-regular w.r.t. any complex",
+      "isGowersRegular_empty: the empty hypergraph is (0,δ)-Gowers-regular for every δ",
+      "Documented obstruction: naive (transversal) regularity does NOT imply Gowers (sub-complex) regularity in general; sub-complex topCliques are not generally expressible as transversals of vertex sub-parts"
     ],
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
-    "lineCount": 244,
-    "assumptions": "1 sorry (naive_implies_gowers). All definitions and 12 out of 13 theorems fully machine-verified.",
+    "lineCount": 322,
+    "assumptions": "0 sorries, 0 axioms. The previously conjectured naive_implies_gowers was eliminated in #13176; the converse is FALSE as stated (transversal density and sub-complex density are orthogonal notions). Replaced with 3 verified structural lemmas (relativeKDensity_eq_of_topCliques_eq, isGowersRegular_self, isGowersRegular_empty). All definitions and theorems fully machine-verified.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -105,7 +109,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Full Gowers hypergraph regularity infrastructure: 2 definitions (SimplicialComplex, IsGowersRegular), 3 noncomputable definitions (completeComplex, topCliques, relativeKDensity), 12 proved theorems, 1 sorry (naive_implies_gowers). The key result relativeKDensity_completeComplex shows the stratified approach is self-consistent: relative density w.r.t. completeComplex equals global density.",
+    "summary": "Full Gowers hypergraph regularity infrastructure: 2 definitions (SimplicialComplex, IsGowersRegular), 3 noncomputable definitions (completeComplex, topCliques, relativeKDensity), 14 proved theorems/lemmas, 0 sorries. The key result relativeKDensity_completeComplex shows the stratified approach is self-consistent: relative density w.r.t. completeComplex equals global density. The previously conjectured naive_implies_gowers was eliminated and shown to be false as stated; replaced with three verified structural lemmas (relativeKDensity_eq_of_topCliques_eq, isGowersRegular_self, isGowersRegular_empty) that document the obstruction.",
     "implications": "**Theoretical**: This infrastructure is the foundation for formalizing the hypergraph counting lemma (Nagle-Rödl-Schacht 2006) and the multidimensional Szemerédi theorem (Gowers 2007). The stratified SimplicialComplex design makes dimension-level conditions explicit, which is essential for the inductive structure of the counting lemma proof.\n\n**For the gallery**: The Gowers regularity infrastructure completes the theoretical framework started in SzemerediHypergraphCore.lean (naive regularity) and SzemerediHypergraphCoreOQ01.lean (flat simplicial complex). Together, these files provide a comprehensive formalization of hypergraph regularity foundations.",
     "openQuestions": [
       "Can naive_implies_gowers be proved by constructing an explicit correspondence between dense sub-complexes and vertex sub-parts?",
@@ -132,12 +136,12 @@
       "Classical"
     ],
     "namespace": "Szemeredi.Hypergraph",
-    "lineCount": 244,
+    "lineCount": 322,
     "axiomCount": 0,
-    "theoremCount": 12,
+    "theoremCount": 14,
     "definitionCount": 5,
     "path": "Proofs/SzemerediHypergraphGowers.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "references": [
     {


### PR DESCRIPTION
## Gallery integrity issue

**Detected by**: `npx tsx scripts/auditor/find-targets.ts`
**Mismatch**: `sorries` field claims **1**, Lean file has **0**.

## Root cause

PR #13176 eliminated the `naive_implies_gowers` sorry by replacing it with three verified structural lemmas (`relativeKDensity_eq_of_topCliques_eq`, `isGowersRegular_self`, `isGowersRegular_empty`) and grew the file from 244 → 322 lines and 12 → 14 theorems. The Lean source was updated; the gallery `meta.json` was not.

## Changes (meta.json only — Lean source already correct)

| Field | Was | Now |
|-------|-----|-----|
| `meta.sorries` | 1 | 0 |
| `meta.lineCount` | 244 | 322 |
| `leanFile.sorries` | 1 | 0 |
| `leanFile.lineCount` | 244 | 322 |
| `leanFile.theoremCount` | 12 | 14 |
| `meta.assumptions` | "1 sorry…" | rewritten — 0 sorries, documents naive→Gowers obstruction |
| `conclusion.summary` | "12 proved theorems, 1 sorry" | "14 proved theorems/lemmas, 0 sorries" + obstruction note |
| `originalContributions` | 8 entries | + 3 new theorems + obstruction note |

## Why badge/status unchanged

`badge: "wip"` and `status: "formalized"` are kept because the slug carries an `-incomplete-01` suffix and the file is infrastructure for the broader Gowers hypergraph regularity theorem, which is not yet formalized end-to-end. The infrastructure file itself is now sorry-free; promoting the badge would require a separate decision.

## Test plan
- [x] `jq empty meta.json` validates
- [x] `meta.sorries` matches actual sorry count in Lean source
- [x] `meta.lineCount` and `leanFile.lineCount` match `wc -l` of the Lean file
- [x] `leanFile.theoremCount` matches `grep -c "^theorem " <file>`

🤖 Discovered during gallery integrity audit.