### PR TITLE
research: ballot-problem-oq-01-oq-04 — n=0 edge case + n=1 examples

### DIFF
--- a/proofs/Proofs/BallotProblemOQ01OQ04.lean
+++ b/proofs/Proofs/BallotProblemOQ01OQ04.lean
@@ -155,6 +155,11 @@ def upstepsAboveAxisC (l : List ℤ) : ℕ :=
 theorem upstepsAboveAxisC_eq (l : List ℤ) :
     upstepsAboveAxisC l = upstepsAboveAxis l := rfl
 
+/-- Computational verification of Chung-Feller for n=1:
+    Each of types 0 and 1 has exactly 1 = C₁ balanced path. -/
+example : upstepsAboveAxisC [1, -1] = 1 := by native_decide
+example : upstepsAboveAxisC [-1, 1] = 0 := by native_decide
+
 /-- Computational verification of Chung-Feller for n=2:
     Types 0, 1, 2 each have exactly 2 = C₂ balanced paths. -/
 example : upstepsAboveAxisC [1, 1, -1, -1] = 2 := by native_decide
@@ -163,6 +168,23 @@ example : upstepsAboveAxisC [1, -1, -1, 1] = 1 := by native_decide
 example : upstepsAboveAxisC [-1, 1, 1, -1] = 1 := by native_decide
 example : upstepsAboveAxisC [-1, 1, -1, 1] = 0 := by native_decide
 example : upstepsAboveAxisC [-1, -1, 1, 1] = 0 := by native_decide
+
+/-- The empty list is the unique balanced path with n = 0. -/
+theorem isBalancedPath_nil : IsBalancedPath ([] : List ℤ) 0 := by
+  refine ⟨?_, ?_, ?_⟩
+  · simp
+  · simp
+  · intro x hx
+    simp at hx
+
+/-- A balanced path with n = 0 is the empty list. -/
+theorem balanced_zero_eq_nil {l : List ℤ} (h : IsBalancedPath l 0) : l = [] := by
+  have hlen : l.length = 0 := by
+    have := balanced_length h
+    omega
+  rcases l with _ | ⟨x, rest⟩
+  · rfl
+  · simp at hlen
 
 /-- **Chung-Feller Theorem (uniform distribution)**:
 

--- a/src/data/proofs/ballot-problem-oq-01-oq-04/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-04/meta.json
@@ -37,7 +37,9 @@
       "prepend_one_good_rotation: applies the cycle lemma to show exactly 1 of 2n+1 cyclic rotations has all partial sums positive",
       "prepend_unique_good_rotation: the good rotation is unique (existential uniqueness from cardinality 1)",
       "balanced_path_total: C(2n,n) = Cₙ × (n+1), connecting the total path count to Catalan numbers",
-      "Proper definitions for upstepsAboveAxis and balancedPathsOfType, replacing placeholder stubs"
+      "Proper definitions for upstepsAboveAxis and balancedPathsOfType, replacing placeholder stubs",
+      "isBalancedPath_nil and balanced_zero_eq_nil: edge case n=0 (empty list is the unique balanced path)",
+      "n=1 native_decide examples: each of types 0 and 1 has exactly 1 = C₁ balanced path"
     ],
     "dateAdded": "2026-03-29",
     "prerequisites": [
@@ -61,7 +63,7 @@
       }
     ],
     "axiomCount": 1,
-    "lineCount": 187,
+    "lineCount": 209,
     "assumptions": "1 axiom: chung_feller_uniform (the uniform distribution of path types, requiring an explicit bijection between rotation indices and upstep-above-axis counts). All structural infrastructure is proved.",
     "mathlib_version": "4.26.0"
   },
@@ -178,10 +180,10 @@
       "LatticePathLGV"
     ],
     "namespace": "ChungFeller",
-    "lineCount": 187,
+    "lineCount": 209,
     "axiomCount": 1,
-    "theoremCount": 9,
-    "substantiveTheoremCount": 7,
+    "theoremCount": 11,
+    "substantiveTheoremCount": 9,
     "trivialPlaceholders": 0,
     "definitionCount": 4,
     "path": "Proofs/BallotProblemOQ01OQ04.lean",


### PR DESCRIPTION
## Summary

Small additive contribution to the Chung-Feller theorem formalization (`Proofs/BallotProblemOQ01OQ04.lean`):

- **Edge case n=0**: `isBalancedPath_nil` (the empty list is balanced) and `balanced_zero_eq_nil` (a balanced path with n=0 must be []).
- **n=1 native_decide examples** complementing the existing n=2 cases: each of types 0 and 1 has exactly 1 = C₁ balanced path.

## Status

- 0 sorries (unchanged)
- 1 axiom: `chung_feller_uniform` (unchanged — this is the open content of the theorem itself)
- lineCount 187 → 209, theoremCount 9 → 11

## Test plan

- [ ] Docker build (deferred — host disk is at ~1.1 GB free, below the safe Docker-build threshold per `feedback_disk_full_blocks_research.md`). The added theorems use only `simp`, `omega`, `rcases`, and `refine`, plus the existing `balanced_length` lemma. The native_decide examples are computational.

🤖 Generated with [Claude Code](https://claude.com/claude-code)