### PR TITLE
Enrich Abel-Ruffini Theorem: deepen Cardinal-bridge annotation

### DIFF
--- a/src/data/proofs/abel-ruffini/annotations.json
+++ b/src/data/proofs/abel-ruffini/annotations.json
@@ -176,19 +176,25 @@
     },
     "type": "tactic",
     "title": "The Cardinal Bridge: From ℕ to Lean's Type Universe",
-    "content": "The proof of symmetric_group_not_solvable bridges between ℕ (where 5 ≤ n lives) and Cardinal (where Mathlib's Equiv.Perm.not_solvable expects 5 ≤ Cardinal.mk α). Step 1: simp rewrites Cardinal.mk (Fin n) as ↑n. Step 2: exact_mod_cast strips the cast and applies hn. The ℕ → Cardinal coercion is an order embedding, so inequalities transfer automatically. This 3-line pattern recurs in AbelRuffiniOQ04.lean.",
-    "mathContext": "$5 \\leq n$ in $\\mathbb{N}$ $\\xrightarrow{\\text{cast}}$ $\\uparrow 5 \\leq \\uparrow n$ in Cardinal $\\xleftarrow{\\text{simp}}$ $5 \\leq |\\text{Fin}\\,n|$. The cast $\\mathbb{N} \\hookrightarrow \\text{Cardinal}$ is an order embedding.",
+    "content": "The proof of `symmetric_group_not_solvable` bridges between $\\mathbb{N}$ (where `5 ≤ n` lives) and `Cardinal` (where Mathlib's `Equiv.Perm.not_solvable` expects `5 ≤ Cardinal.mk α`). The two-line tactic block performs the bridge: `simp only [Cardinal.mk_fintype, Fintype.card_fin]` rewrites `Cardinal.mk (Fin n)` as the canonically lifted `↑n`, and `exact_mod_cast hn` strips the resulting `ℕ → Cardinal` cast and applies the natural-number hypothesis directly. The `ℕ → Cardinal` coercion is an order embedding, so the inequality `5 ≤ n` transfers without effort.\n\n**Why does Mathlib state `Equiv.Perm.not_solvable` in terms of `Cardinal` rather than `ℕ`?** The theorem is genuinely more general: $S_X$ is non-solvable for *any* type $X$ with $|X| \\geq 5$, not only finite types of the form `Fin n`. Examples include $S_\\omega$ (the symmetric group on a countable infinite set), $S_X$ for $X$ uncountable, and exotic finite types like products and sums where the cardinality bound is more naturally expressed via `Cardinal.mk` than `Fintype.card`. Stating the result over `Cardinal` lets Mathlib avoid duplicating the proof for finite and infinite cases — a single statement covers both. Concrete callers like the present file pay a 2-line cardinal cast as the cost of this generality. The same pattern recurs verbatim in `AbelRuffiniOQ04.lean` and similar downstream files; it has become an idiomatic Lean pattern for invoking cardinal-stated Mathlib lemmas with concrete `Fin n` arguments.\n\n**The deeper design lesson.** This is a small instance of a broader Mathlib design principle: whenever a result holds in greater generality without complicating the proof, state it in the more general form, even at the cost of slightly more friction at instantiation sites. The friction is local (a 2-line cast), the benefit is global (one proof serves all callers). Compare with the alternative — a separate `Fintype`-based statement — which would require Mathlib to maintain duplicate proofs and force every caller to choose the right variant. The cardinal bridge is the user-visible manifestation of this trade-off.",
+    "mathContext": "$5 \\leq n$ in $\\mathbb{N}$ $\\xrightarrow{\\text{cast}}$ $\\uparrow 5 \\leq \\uparrow n$ in Cardinal $\\xleftarrow{\\text{simp}}$ $5 \\leq |\\text{Fin}\\,n|$. The cast $\\mathbb{N} \\hookrightarrow \\text{Cardinal}$ is an order embedding (preserving and reflecting $\\leq$).\n\nThe Mathlib statement: `Equiv.Perm.not_solvable : ∀ (X : Type u), 5 ≤ Cardinal.mk X → ¬ IsSolvable (Equiv.Perm X)`. The cardinal hypothesis covers the finite case (via `Cardinal.mk_fintype : Cardinal.mk α = (Fintype.card α : Cardinal)` for any `Fintype α`) and the infinite case uniformly. The non-solvability proof inducts on a 5-element subtype $\\{x_1, \\ldots, x_5\\} \\hookrightarrow X$ (extracted using the cardinality bound), realizes $S_5 \\hookrightarrow S_X$ as a subgroup, and applies the closure of solvability under subgroups (`IsSolvable.subgroupOf`) — the structure of $A_5$ as a perfect simple group inside $S_5$ then propagates the non-solvability obstruction.",
     "significance": "supporting",
     "prerequisites": [
       "Cardinal.mk_fintype",
       "Fintype.card_fin",
-      "exact_mod_cast"
+      "exact_mod_cast",
+      "Equiv.Perm",
+      "IsSolvable.subgroupOf"
     ],
     "relatedConcepts": [
       "cardinal arithmetic",
       "exact_mod_cast tactic",
       "type coercion",
-      "order embedding"
+      "order embedding",
+      "Mathlib generality principle",
+      "Fintype.card vs Cardinal.mk",
+      "infinite symmetric group",
+      "subgroup closure of solvability"
     ]
   },
   {

--- a/src/data/proofs/abel-ruffini/annotations.source.json
+++ b/src/data/proofs/abel-ruffini/annotations.source.json
@@ -179,19 +179,25 @@
     },
     "type": "tactic",
     "title": "The Cardinal Bridge: From ℕ to Lean's Type Universe",
-    "content": "The proof of symmetric_group_not_solvable bridges between ℕ (where 5 ≤ n lives) and Cardinal (where Mathlib's Equiv.Perm.not_solvable expects 5 ≤ Cardinal.mk α). Step 1: simp rewrites Cardinal.mk (Fin n) as ↑n. Step 2: exact_mod_cast strips the cast and applies hn. The ℕ → Cardinal coercion is an order embedding, so inequalities transfer automatically. This 3-line pattern recurs in AbelRuffiniOQ04.lean.",
-    "mathContext": "$5 \\leq n$ in $\\mathbb{N}$ $\\xrightarrow{\\text{cast}}$ $\\uparrow 5 \\leq \\uparrow n$ in Cardinal $\\xleftarrow{\\text{simp}}$ $5 \\leq |\\text{Fin}\\,n|$. The cast $\\mathbb{N} \\hookrightarrow \\text{Cardinal}$ is an order embedding.",
+    "content": "The proof of `symmetric_group_not_solvable` bridges between $\\mathbb{N}$ (where `5 ≤ n` lives) and `Cardinal` (where Mathlib's `Equiv.Perm.not_solvable` expects `5 ≤ Cardinal.mk α`). The two-line tactic block performs the bridge: `simp only [Cardinal.mk_fintype, Fintype.card_fin]` rewrites `Cardinal.mk (Fin n)` as the canonically lifted `↑n`, and `exact_mod_cast hn` strips the resulting `ℕ → Cardinal` cast and applies the natural-number hypothesis directly. The `ℕ → Cardinal` coercion is an order embedding, so the inequality `5 ≤ n` transfers without effort.\n\n**Why does Mathlib state `Equiv.Perm.not_solvable` in terms of `Cardinal` rather than `ℕ`?** The theorem is genuinely more general: $S_X$ is non-solvable for *any* type $X$ with $|X| \\geq 5$, not only finite types of the form `Fin n`. Examples include $S_\\omega$ (the symmetric group on a countable infinite set), $S_X$ for $X$ uncountable, and exotic finite types like products and sums where the cardinality bound is more naturally expressed via `Cardinal.mk` than `Fintype.card`. Stating the result over `Cardinal` lets Mathlib avoid duplicating the proof for finite and infinite cases — a single statement covers both. Concrete callers like the present file pay a 2-line cardinal cast as the cost of this generality. The same pattern recurs verbatim in `AbelRuffiniOQ04.lean` and similar downstream files; it has become an idiomatic Lean pattern for invoking cardinal-stated Mathlib lemmas with concrete `Fin n` arguments.\n\n**The deeper design lesson.** This is a small instance of a broader Mathlib design principle: whenever a result holds in greater generality without complicating the proof, state it in the more general form, even at the cost of slightly more friction at instantiation sites. The friction is local (a 2-line cast), the benefit is global (one proof serves all callers). Compare with the alternative — a separate `Fintype`-based statement — which would require Mathlib to maintain duplicate proofs and force every caller to choose the right variant. The cardinal bridge is the user-visible manifestation of this trade-off.",
+    "mathContext": "$5 \\leq n$ in $\\mathbb{N}$ $\\xrightarrow{\\text{cast}}$ $\\uparrow 5 \\leq \\uparrow n$ in Cardinal $\\xleftarrow{\\text{simp}}$ $5 \\leq |\\text{Fin}\\,n|$. The cast $\\mathbb{N} \\hookrightarrow \\text{Cardinal}$ is an order embedding (preserving and reflecting $\\leq$).\n\nThe Mathlib statement: `Equiv.Perm.not_solvable : ∀ (X : Type u), 5 ≤ Cardinal.mk X → ¬ IsSolvable (Equiv.Perm X)`. The cardinal hypothesis covers the finite case (via `Cardinal.mk_fintype : Cardinal.mk α = (Fintype.card α : Cardinal)` for any `Fintype α`) and the infinite case uniformly. The non-solvability proof inducts on a 5-element subtype $\\{x_1, \\ldots, x_5\\} \\hookrightarrow X$ (extracted using the cardinality bound), realizes $S_5 \\hookrightarrow S_X$ as a subgroup, and applies the closure of solvability under subgroups (`IsSolvable.subgroupOf`) — the structure of $A_5$ as a perfect simple group inside $S_5$ then propagates the non-solvability obstruction.",
     "significance": "supporting",
     "relatedConcepts": [
       "cardinal arithmetic",
       "exact_mod_cast tactic",
       "type coercion",
-      "order embedding"
+      "order embedding",
+      "Mathlib generality principle",
+      "Fintype.card vs Cardinal.mk",
+      "infinite symmetric group",
+      "subgroup closure of solvability"
     ],
     "prerequisites": [
       "Cardinal.mk_fintype",
       "Fintype.card_fin",
-      "exact_mod_cast"
+      "exact_mod_cast",
+      "Equiv.Perm",
+      "IsSolvable.subgroupOf"
     ]
   },
   {


### PR DESCRIPTION
## Summary

Expands the previously thin `ann-cardinal-bridge` annotation (Lean lines 77–84) from a 4-sentence mechanical description into a 3-paragraph explanation that teaches a transferable Mathlib design principle.

**What's new in the annotation:**

1. **Tactic mechanics** (preserved + sharpened) — the 2-line `simp` + `exact_mod_cast` pattern that bridges `5 ≤ n` (in ℕ) with `5 ≤ Cardinal.mk (Fin n)` (the form Mathlib's `Equiv.Perm.not_solvable` expects).
2. **Why `Cardinal` not `ℕ`?** — Mathlib's `Equiv.Perm.not_solvable` is genuinely more general: $S_X$ is non-solvable for *any* type $X$ with $|X| \geq 5$, including $S_\omega$ (countable infinite) and uncountable cases. Stating the result over `Cardinal` lets Mathlib avoid duplicating the proof for finite and infinite cases. Concrete callers like this file pay a 2-line cardinal cast for that generality.
3. **Mathlib design principle** — when a result holds in greater generality without complicating the proof, state it in the more general form even at the cost of small per-caller friction. The friction is local (2-line cast); the benefit is global (one proof serves all callers).

**Also added:**
- The full Mathlib statement signature for `Equiv.Perm.not_solvable`.
- The proof outline (subtype embedding $S_5 \hookrightarrow S_X$ + `IsSolvable.subgroupOf`).
- Refreshed `prerequisites` and `relatedConcepts` arrays with the new vocabulary.

This is part of an ongoing pass on the `abel-ruffini` entry (5 prior enrichment passes, quality 100). The Cardinal-bridge annotation was the only `supporting` annotation with content materially shorter than its peers — the only place a sustained explanation could meaningfully add depth without bloating already-rich content.

## Test plan

- [x] Edited `annotations.source.json` (the source-of-truth file) and re-ran `pnpm build` so `annotations.json` regenerates correctly.
- [x] `pnpm build` passes (vite build clean, 16.23s).
- [x] Only `src/data/proofs/abel-ruffini/annotations.{json,source.json}` staged; no unrelated research-problem files included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)