### PR TITLE
research(erdos-118-oq-01): document axiom-elimination roadmap (4 → 2)

### DIFF
--- a/research/problems/erdos-118-oq-01/knowledge.md
+++ b/research/problems/erdos-118-oq-01/knowledge.md
@@ -1,40 +1,169 @@
 # Erdős #118 OQ-01: Partition Threshold of ω^{ω²}
 
 **Problem**: Is the partition threshold of ω^{ω²} exactly 3 or 4?
-**Status**: IN-PROGRESS (4 axioms, 0 sorries)
+**Status**: IN-PROGRESS (4 axioms, 0 sorries) — bracketed in [3, 4],
+exact value remains open mathematics.
 
 ## Current State
 
-- **File**: `proofs/Proofs/Erdos118Problem.lean` (~144 lines)
-- **Axioms**: 4 (counter_partition_3, counter_not_partition_5, partitionThreshold, threshold_exact)
-- **Proved**: ordPartition (was axiom, now def), partition_monotone_down (was axiom, now theorem)
-- **Key theorem**: omega_omega2_threshold bounds threshold to {3, 4}
+- **File**: `proofs/Proofs/Erdos118Problem.lean` (143 lines)
+- **Axioms**: 4 — see classification below
+- **Theorems proved**: `erdos_118_disproved`,
+  `partition_monotone_down`, `omega_omega2_threshold`,
+  `relation_to_592`
+- **Definitions**: `ordPartition`, `IsPartitionOrd`,
+  `ErdosHajnalConjecture`, `counterexampleOrd = ω^(ω²)`
 
-## Session 2026-03-28 (Session 1) - Define ordPartition, prove partition_monotone_down
+## Axiom Classification
+
+| Axiom | Source / Role | Eliminable? |
+| --- | --- | --- |
+| `counter_partition_3` | Schipperus (1999/2010), positive partition for K_3 | NO — deep result |
+| `counter_not_partition_5` | Larson, blocker for K_5 | NO — deep result |
+| `partitionThreshold : Ordinal → ℕ` | Definitional | YES — replace with classical definition |
+| `threshold_exact` | Definitional (universal) | YES (conditionally) — provable when transition exists |
+
+The two "counter" axioms encode genuinely deep mathematics not
+formalizable in Mathlib without substantial ordinal Ramsey theory
+infrastructure.
+
+## Roadmap to Reduce Structural Axioms (4 → 2)
+
+### Step 1: Add `partition_monotone_up_neg`
+```lean
+theorem partition_monotone_up_neg (α : Ordinal.{0}) (j k : ℕ)
+    (hjk : j ≤ k) (hj : ¬ IsPartitionOrd α j) :
+    ¬ IsPartitionOrd α k :=
+  fun hk => hj (partition_monotone_down α k j hjk hk)
+```
+Trivial; safe.
+
+### Step 2: Prove transition existence on a finite gap
+```lean
+theorem partition_transition_exists (α : Ordinal.{0}) (k m : ℕ)
+    (hk  : IsPartitionOrd α k)
+    (hm  : ¬ IsPartitionOrd α m)
+    (hkm : k < m) :
+    ∃ t, k ≤ t ∧ t < m ∧ IsPartitionOrd α t ∧
+         ¬ IsPartitionOrd α (t + 1) := by
+  -- strong induction on `m`; split on Classical.em
+  -- (IsPartitionOrd α (m-1))
+  ...
+```
+~20 lines.
+
+### Step 3: Replace `partitionThreshold` axiom with definition
+```lean
+noncomputable def partitionThreshold (α : Ordinal.{0}) : ℕ :=
+  if h : ∃ t, IsPartitionOrd α t ∧ ¬ IsPartitionOrd α (t + 1)
+  then Classical.choose h
+  else 0
+```
+
+### Step 4: Replace `threshold_exact` axiom with conditional theorem
+```lean
+theorem threshold_exact_of_exists (α : Ordinal.{0})
+    (h : ∃ t, IsPartitionOrd α t ∧ ¬ IsPartitionOrd α (t + 1)) :
+    IsPartitionOrd α (partitionThreshold α) ∧
+    ¬ IsPartitionOrd α (partitionThreshold α + 1) := by
+  unfold partitionThreshold; rw [dif_pos h]
+  exact Classical.choose_spec h
+```
+
+### Step 5: Discharge the existence hypothesis for ω^{ω²}
+Combine Steps 1–2 with `counter_partition_3` and
+`counter_not_partition_5`:
+```lean
+theorem omega_omega2_transition_exists :
+    ∃ t, IsPartitionOrd counterexampleOrd t ∧
+         ¬ IsPartitionOrd counterexampleOrd (t + 1) := by
+  obtain ⟨t, _, _, ht, ht'⟩ :=
+    partition_transition_exists counterexampleOrd 3 5
+      counter_partition_3 counter_not_partition_5 (by norm_num)
+  exact ⟨t, ht, ht'⟩
+```
+
+After this refactor the file has **2 axioms** (the deep
+mathematical results), down from 4.
+
+## Why Not Done This Session
+
+Disk was 783 MB free / 94 % capacity at session start, below the
+prior-incident 1 GB threshold for safe Docker builds. The proof
+strategy above is sound but I cannot verify Lean syntax without a
+build, and broken proofs propagating to master would corrupt the
+gallery. Recording the roadmap is the safer contribution.
+
+## What "3 vs 4" Reduces To
+
+The threshold is bracketed in [3, 4]. Resolving the open question
+amounts to deciding:
+
+> Does ω^{ω²} → (ω^{ω²}, 4)² hold?
+
+If yes, threshold = 4. If no, threshold = 3. Both are consistent
+with the current formalization; the answer requires new mathematics
+(a positive K_4 partition argument, or a K_4 blocker), not better
+Lean tooling.
+
+## Insights
+
+- The partition relation on ordinals is monotone *down* in the
+  clique size: blue k-clique → blue j-clique for j ≤ k. Core fact
+  making the threshold well-defined.
+- The "exact threshold" property holds whenever a finite transition
+  point exists; for `counterexampleOrd` such a point lies in {3, 4}.
+- `IsPartitionOrd α k` is not obviously decidable (universal
+  quantification over `Ordinal → Ordinal → Bool`), so the threshold
+  must be defined classically.
+- Dropping the `(threshold + 1 > 2)` guard from the original
+  `threshold_exact` axiom was load-bearing for proving
+  `omega_omega2_threshold` (recorded by prior session).
+
+## Dead Ends
+
+- Proving `omega_omega2_threshold = 4` (or = 3) inside Lean alone:
+  not possible without new mathematics.
+- Making `partitionThreshold` computable: blocked by the
+  undecidability of `IsPartitionOrd`.
+
+## Sessions
+
+### Session 2026-04-27 (researcher-4) — roadmap + audit
+- Audited current state; documented axiom classification.
+- Wrote 5-step roadmap to reduce structural axioms 4 → 2.
+- Reconciled stale problem JSON (had progressSummary text from
+  Erdos1182, not this problem).
+- No Lean changes (disk pressure precluded build verification).
+
+### Session 2026-03-28 — Define ordPartition,
+prove partition_monotone_down (prior session)
 
 **Mode**: FRESH (MODERATE knowledge, score 11)
 **Outcome**: progress (6A→4A, 2 axioms eliminated)
 
-### What I Did
-- Converted `ordPartition` from axiom to concrete definition:
-  - Red condition: ∃ φ : Ordinal → Ordinal, StrictMono φ ∧ maps [0,α) into itself ∧ all pairs red
-  - Blue condition: ∃ ψ : Fin k → Ordinal, StrictMono ψ ∧ all < α ∧ all pairs blue
-- Proved `partition_monotone_down`: given blue k-clique, restrict to j-element initial segment via Fin.castLE
+#### What was done
+- Converted `ordPartition` from axiom to concrete definition.
+- Proved `partition_monotone_down` from the definition by
+  restricting a blue k-clique to a j-element initial segment via
+  `Fin.castLE`.
 
-### Key Findings
-- `ordPartition` was an opaque axiom making everything downstream unprovable. Now it's a concrete Prop.
-- `partition_monotone_down` follows cleanly: compose with `embed : Fin j → Fin k` that preserves `.val`
-- `StrictMono embed` holds because Fin comparison is by `.val`, and embed preserves `.val`
-- `partitionThreshold` and `threshold_exact` remain axioms (would need bounded set theory for proper definition)
-- Counter-partition axioms (Schipperus, Larson) remain axioms (deep results, not in Mathlib)
-- Docker not available — build verification needed
+#### Key Findings
+- `ordPartition` was an opaque axiom blocking everything
+  downstream — making it concrete unlocked further proofs.
+- `partition_monotone_down` follows cleanly from the embedding
+  `Fin j → Fin k`.
+- `StrictMono` of the embedding holds because Fin comparison is by
+  `.val`, and the embedding preserves `.val`.
+- Counter-partition axioms (Schipperus, Larson) are deep; not in
+  Mathlib.
 
-### Files Modified
-- `proofs/Proofs/Erdos118Problem.lean` (121→144 lines, -2 axioms, +1 def, +1 theorem)
-- `src/data/proofs/erdos-118/meta.json` (axiomCount: 6→4, lineCount: 120→144)
-- `src/data/research/problems/erdos-118-oq-01.json` (knowledge updated)
+#### Files Modified
+- `proofs/Proofs/Erdos118Problem.lean` (121→144 lines, −2 axioms,
+  +1 def, +1 theorem)
+- `src/data/proofs/erdos-118/meta.json` (axiomCount: 6→4)
 
-### Next Steps
-- Verify build when Docker available
-- Consider defining partitionThreshold as noncomputable def with Nat.find
-- The exact threshold value (3 vs 4) requires deep ordinal combinatorics beyond current scope
+## Next Action
+
+When Docker is available and disk has ≥ 5 GB free, execute
+Steps 1–5 above to drop the axiom count from 4 to 2.

--- a/src/data/research/problems/erdos-118-oq-01.json
+++ b/src/data/research/problems/erdos-118-oq-01.json
@@ -17,11 +17,13 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-03-24T00:48:59.907Z",
-    "iteration": 4,
-    "focus": "Initial exploration of the problem.",
-    "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "since": "2026-04-27T00:00:00-07:00",
+    "iteration": 5,
+    "focus": "Roadmap recorded for axiom-elimination 4 -> 2 (eliminate partitionThreshold + threshold_exact via classical definition + transition-existence theorem). Awaiting Docker availability and disk headroom for Lean execution.",
+    "blockers": [
+      "Docker / disk headroom: prior session noted disk-full conditions corrupting builds; this session had only 783 MB free."
+    ],
+    "nextAction": "Execute knowledge.md Steps 1-5: partition_monotone_up_neg, partition_transition_exists, redefine partitionThreshold, prove threshold_exact_of_exists, discharge existence for omega^(omega^2).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: 3S→0S in Erdos1182. Fixed bigF_threshold connectivity bug, proved bigF_lower_bound_tree, f_val_2, bigF_val_2. Added Graph.Connected, connected_min_edges axiom.",
+    "progressSummary": "4 axioms (Schipperus, Larson, partitionThreshold, threshold_exact), 0 sorries, 4 theorems including omega_omega2_threshold (bracket in [3,4]). Roadmap to reduce structural axioms 4 -> 2 documented in knowledge.md (Steps 1-5). The exact threshold value (3 vs 4) is open mathematics, not a Lean tooling gap.",
     "builtItems": [
       "Proved relation_to_592 as theorem (trivially follows from counterexample axioms)",
       "Fixed build: Ordinal universe annotations (.{0}), Ordinal.omega->omega0, added Exponential import",
@@ -61,11 +63,17 @@
       "connected_min_edges (connected→≥n-1 edges) is key link: with ≤n-1 edges, connected forces exactly n-1 edges (tree), enabling chvatal_tree_ramsey",
       "Fin 2 graphs have ≤1 edge: proved by Finset.card_le_one + fin2_lt_unique showing (0,1) is the only ordered pair"
     ],
-    "mathlibGaps": [],
+    "mathlibGaps": [
+      "No formalization of Schipperus 1999/2010 (positive K_3 partition for omega^(omega^2))",
+      "No formalization of Larson K_5 blocker",
+      "Decidability of IsPartitionOrd (universal quantification over Ordinal -> Ordinal -> Bool) — only achievable classically"
+    ],
     "nextSteps": [
-      "Verify Erdos1182Problem.lean builds (Docker was unavailable during session)",
-      "If build fails, fix Lean proof syntax issues (Finset.card_le_one API, Classical decidability interaction)",
-      "Consider proving connected_min_edges as theorem instead of axiom (by induction on n, needs graph vertex removal infrastructure)"
+      "Add partition_monotone_up_neg (trivial)",
+      "Prove partition_transition_exists by strong induction (~20 lines)",
+      "Replace partitionThreshold axiom with noncomputable def using Classical.choose",
+      "Replace threshold_exact axiom with conditional theorem threshold_exact_of_exists",
+      "Discharge the existence hypothesis for counterexampleOrd via Schipperus + Larson + transition-existence"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary
- Reconciles stale problem JSON for `erdos-118-oq-01` (Partition threshold of ω^(ω²)) — its `progressSummary` had been overwritten with text from a different problem (Erdos1182).
- Records a concrete 5-step roadmap to reduce the structural axioms in `Proofs/Erdos118Problem.lean` from 4 to 2 by replacing `partitionThreshold` and `threshold_exact` with a `Classical.choose`-based definition plus a `partition_transition_exists` theorem.
- The remaining 2 axioms (Schipperus K_3, Larson K_5 blocker) are genuine deep mathematics outside current Mathlib coverage.
- The exact-threshold question (3 vs 4) is open mathematics, not a Lean tooling gap.

## Why metadata-only
Disk was at 783 MB free / 94% capacity this session, below the prior-incident 1 GB Docker-build threshold. Recording the roadmap is the safer contribution; the next session with disk headroom can execute Steps 1–5 verbatim.

## Test plan
- [x] Only 2 metadata files changed (knowledge.md, problem JSON).
- [x] No Lean source touched.
- [ ] Follow-up PR will execute Steps 1–5 once Docker is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)