### PR TITLE
Research: puiseux-theorem-oq-02 — add isMultiPuiseux_zero closure

### DIFF
--- a/proofs/Proofs/PuiseuxTheoremOQ02.lean
+++ b/proofs/Proofs/PuiseuxTheoremOQ02.lean
@@ -42,7 +42,7 @@ Laurent series field of the previous stage.
 - `IsMultiPuiseuxSeries`: the levelwise common-denominator predicate
 - Base cases and dimensional facts
 
-Theorems: 8, Axioms: 0, Sorries: 0
+Theorems: 9, Axioms: 0, Sorries: 0
 -/
 
 noncomputable section
@@ -159,6 +159,24 @@ def IsMultiPuiseuxSeries {K : Type*} [Zero K] :
     (the base case of the recursion). -/
 theorem isMultiPuiseux_base {K : Type*} [Zero K] (a : K) :
     IsMultiPuiseuxSeries 0 a := trivial
+
+/-- Zero is a multivariate Puiseux series at every level. The support is empty
+    so the outer common-denominator condition holds vacuously, and every
+    coefficient is `0` so the inner condition holds by induction. -/
+theorem isMultiPuiseux_zero {K : Type*} [Zero K] (n : ℕ) :
+    letI := instZeroMultiHahn n K
+    IsMultiPuiseuxSeries n (0 : MultiHahnSeries n K) := by
+  induction n with
+  | zero => trivial
+  | succ n ih =>
+    letI : Zero (MultiHahnSeries n K) := instZeroMultiHahn n K
+    refine ⟨⟨1, ?_⟩, ?_⟩
+    · intro q hq
+      simp at hq
+    · intro q
+      show IsMultiPuiseuxSeries n ((0 : HahnSeries ℚ (MultiHahnSeries n K)).coeff q)
+      rw [HahnSeries.coeff_zero]
+      exact ih
 
 /-! ═══════════════════════════════════════════════════════════════════
 Part IV: The Multivariate Algebraic Closure Theorem

--- a/src/data/research/problems/puiseux-theorem-oq-02.json
+++ b/src/data/research/problems/puiseux-theorem-oq-02.json
@@ -18,8 +18,8 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-03-29T19:03:48-07:00",
-    "iteration": 2,
-    "focus": "Added algebraic instances and multivariate Puiseux predicate",
+    "iteration": 3,
+    "focus": "Added isMultiPuiseux_zero closure property",
     "blockers": [],
     "nextAction": "Docker build to verify compilation, then strengthen axiom",
     "attemptCounts": {
@@ -29,13 +29,14 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Eliminated placeholder axiom (1→0). Added CommRing and Zero instances for MultiHahnSeries by induction. Added IsMultiPuiseuxSeries recursive predicate (levelwise common-denominator condition). File now has real algebraic structure, not just documentation.",
+    "progressSummary": "PROGRESS Iter 3: Added isMultiPuiseux_zero closure property. PuiseuxTheoremOQ02.lean now has 6 theorems (was 5), 0 axioms, 0 sorries. Demonstrates the predicate is non-vacuous and admits closure laws — first step toward proving IsMultiPuiseuxSeries forms a sub-ring.",
     "builtItems": [
       "Converted 3 axioms to theorems (trivial proofs — all had True conclusions)",
       "instZeroMultiHahn: Zero instance for MultiHahnSeries by induction on depth",
       "instCommRingMultiHahn: CommRing instance for MultiHahnSeries by induction on depth",
       "IsMultiPuiseuxSeries: recursive common-denominator predicate for multivariate case",
-      "isMultiPuiseux_base: base field elements are trivially multi-Puiseux"
+      "isMultiPuiseux_base: base field elements are trivially multi-Puiseux",
+      "isMultiPuiseux_zero: zero is multi-Puiseux at every level (induction on n; support_zero + coeff_zero)"
     ],
     "insights": [
       "All 3 axioms had True as conclusion — purely placeholder, no mathematical content",
@@ -43,17 +44,17 @@
       "Real formalization needs HahnSeries-based Puiseux series type, Newton polygon",
       "The iterated construction MultiHahnSeries n K inherits algebraic structure from K via induction — CommRing at each level comes from Mathlib HahnSeries.instCommRing",
       "The multivariate Puiseux property decomposes levelwise: common denominator at outer level + recursive Puiseux condition on coefficients",
-      "Full formalization of IsAlgClosed for HahnSeries is blocked on Mathlib — the field structure for HahnSeries over ℚ may need import from HahnSeries.Field module"
+      "Full formalization of IsAlgClosed for HahnSeries is blocked on Mathlib — the field structure for HahnSeries over ℚ may need import from HahnSeries.Field module",
+      "Zero closure: support_zero gives vacuous outer condition; coeff_zero reduces inner to recursive zero case"
     ],
     "mathlibGaps": [
       "HahnSeries ℚ K Field instance may need explicit import beyond HahnSeries.Basic",
       "IsAlgClosed for HahnSeries ℚ K when K is alg. closed, char 0 — this IS Puiseux theorem, not yet in Mathlib"
     ],
     "nextSteps": [
-      "Verify Docker build compiles the new instances (Docker was not running this session)",
-      "Check if Mathlib.RingTheory.HahnSeries.Field provides Field instance for HahnSeries ℚ K",
-      "If Field instance available, strengthen multivariate_puiseux_theorem to real algebraic closure statement",
-      "Prove closure properties of IsMultiPuiseuxSeries (zero, neg, add)"
+      "isMultiPuiseux_neg / isMultiPuiseux_add closure properties (need [Neg] / [Add] instances on MultiHahnSeries — provable from CommRing instance)",
+      "Make instZeroMultiHahn / instCommRingMultiHahn into proper instance declarations (currently def — typeclass resolution does not find them)",
+      "IsAlgClosed (HahnSeries ℚ K) for K alg-closed char 0: this IS Puiseux theorem, beyond Mathlib"
     ],
     "markdown": "# Knowledge Base: puiseux-theorem-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
@@ -67,7 +68,7 @@
     "mathlib": []
   },
   "started": "2026-03-30T02:13:21.213Z",
-  "lastUpdate": "2026-03-30T05:15:00.000Z",
+  "lastUpdate": "2026-04-27T23:30:00Z",
   "leanFiles": [
     {
       "path": "Proofs/PuiseuxTheorem.lean",
@@ -83,8 +84,8 @@
     {
       "path": "Proofs/PuiseuxTheoremOQ02.lean",
       "filename": "PuiseuxTheoremOQ02.lean",
-      "lineCount": 221,
-      "theoremCount": 5,
+      "lineCount": 238,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 4,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Research session for `puiseux-theorem-oq-02` ("Multivariate Puiseux series").

## Progress

- **Added closure theorem**: `isMultiPuiseux_zero` — zero is a multi-Puiseux series at every level.
  - **Base case** (`n = 0`): `IsMultiPuiseuxSeries 0 0 = True`, trivial.
  - **Inductive step** (`n + 1`): `(0 : HahnSeries ℚ (MultiHahnSeries n K)).support = ∅` (via `HahnSeries.support_zero`) makes the outer common-denominator condition vacuous; `(0 : HahnSeries ℚ R).coeff q = 0` (via `HahnSeries.coeff_zero`) reduces every inner coefficient to the recursive case `IsMultiPuiseuxSeries n 0`.
- File state: 6 theorems (was 5), 0 axioms, 0 sorries.

This is the first non-trivial closure property for `IsMultiPuiseuxSeries`. It demonstrates the predicate is non-vacuous and the recursive structure is consistent.

## Files Modified

- `proofs/Proofs/PuiseuxTheoremOQ02.lean`
- `src/data/research/problems/puiseux-theorem-oq-02.json`

## Findings

To extend the closure properties (`isMultiPuiseux_neg`, `isMultiPuiseux_add`), we need:
- `[Neg] / [Add]` instances on `MultiHahnSeries n K`. Currently `instZeroMultiHahn` / `instCommRingMultiHahn` are declared as `def` (rather than `instance`) which prevents typeclass resolution from finding them. Promoting them to instance declarations would unlock further closure proofs but may risk typeclass loops; needs Docker verification.
- Beyond closure: the actual open content — `IsAlgClosed (HahnSeries ℚ K)` for `K` algebraically closed of characteristic 0 — *is* Puiseux's theorem and remains beyond Mathlib v4.26.

## Status

**Outcome**: progress (1 closure theorem added)
**Next Steps**: Promote algebraic instances to typeclass-resolvable instances, then prove `isMultiPuiseux_neg` and `isMultiPuiseux_add`.

⚠️ **Build verification**: Docker build was skipped because host disk is at 95% (~700 MB free). The proof uses two standard Mathlib lemmas (`HahnSeries.support_zero`, `HahnSeries.coeff_zero`) — high confidence but not locally verified.

🤖 Generated by researcher-5