### PR TITLE
Fix: hurwitz-theorem-oq-04 stale axiom language and lineCount

### DIFF
--- a/proofs/Proofs/HurwitzTheoremOQ04.lean
+++ b/proofs/Proofs/HurwitzTheoremOQ04.lean
@@ -31,7 +31,7 @@ These four algebras are deeply connected to the exceptional Lie groups through:
 
 ## Contents
 
-- **Proved** (0 sorries, 1 axiom):
+- **Proved** (1 sorry, 0 axioms):
   - `normSq_octUnit`: the unit e₀ has norm 1
   - `OctonionAlgHom` forms a monoid (identity, composition)
   - `alg_hom_preserves_norm_product`: φ preserves products of norms

--- a/src/data/proofs/hurwitz-theorem-oq-04/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-04/meta.json
@@ -2,7 +2,7 @@
   "id": "hurwitz-theorem-oq-04",
   "title": "Hurwitz's Theorem: Connection to Exceptional Lie Groups",
   "slug": "hurwitz-theorem-oq-04",
-  "description": "Formalizes the deep connection between the four normed division algebras (ℝ, ℂ, ℍ, 𝕆) and the five exceptional Lie algebras (G₂, F₄, E₆, E₇, E₈) via the Freudenthal-Tits magic square. Proves that Aut(𝕆) ⊆ O(7) (automorphisms preserve the imaginary subspace and inner product), and axiomatizes G₂ = Aut(𝕆) and the four exceptional types F₄, E₆, E₇, E₈ arising from the magic square construction.",
+  "description": "Formalizes the deep connection between the four normed division algebras (ℝ, ℂ, ℍ, 𝕆) and the five exceptional Lie algebras (G₂, F₄, E₆, E₇, E₈) via the Freudenthal-Tits magic square. Proves that Aut(𝕆) ⊆ O(7) (automorphisms preserve the imaginary subspace and inner product), and introduces an inductive ExceptionalType labeling G₂, F₄, E₆, E₇, E₈ with their dimensions and ranks; the deeper identification G₂ ≅ Aut(𝕆) is reduced to G2_der_dimension (1 sorry remaining) pending future Lie-group infrastructure.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-24",
@@ -22,7 +22,7 @@
     "dateAdded": "2026-04-24",
     "axiomCount": 0,
     "assumptions": "1 sorry in G2_der_dimension proof chain: derEval14_injective — off-diagonal entries (j in {1,...,7}, i != 0, i != j) of the imaginary basis kernel claim. The j = 0 case is closed via submodule_der_unit_zero; the i = j diagonal case (Session 7, 2026-04-27) is closed via submodule_der_diagonal_kill (Leibniz at (e_j, e_j) using stdBasis_sq_neg_unit). Remaining 49-entry off-diagonal block requires antisymmetry ((f e_i)_j + (f e_j)_i = 0 from Leibniz at (e_i, e_j) + (e_j, e_i)) and Fano-line trilinear constraints. derBasis14_linearIndependent was proved in PR #13121. The Aut(O) is in O(7) — fully proved with 0 sorries.",
-    "lineCount": 1180,
+    "lineCount": 1255,
     "theoremCount": 60,
     "definitionCount": 19,
     "originalContributions": [
@@ -137,7 +137,7 @@
       "HurwitzTheorem"
     ],
     "namespace": "HurwitzTheoremOQ04",
-    "lineCount": 1180,
+    "lineCount": 1255,
     "axiomCount": 0,
     "theoremCount": 60,
     "definitionCount": 19,


### PR DESCRIPTION
## Fix

Remove stale "axiomatizes" language from description and fix internal Lean docstring that misstates the sorry/axiom counts.

## Evidence

**Before**:
- `description` says "axiomatizes G₂ = Aut(𝕆) and the four exceptional types F₄, E₆, E₇, E₈" (file has 0 axiom declarations)
- Lean docstring line 34: `**Proved** (0 sorries, 1 axiom):`
- `lineCount`: 1180

**After**:
- `description` accurately states ExceptionalType is an inductive labeling with 1 sorry remaining in G2_der_dimension
- Lean docstring line 34: `**Proved** (1 sorry, 0 axioms):`
- `lineCount`: 1255 (actual wc -l count)

Closes #13383

---
Automated fix by lean-mechanic agent.