### PR TITLE
research(erdos-1178): formalize Solymosi-Solymosi d_3(10) ≤ 14 bound

### DIFF
--- a/proofs/Proofs/Erdos1178Problem.lean
+++ b/proofs/Proofs/Erdos1178Problem.lean
@@ -188,9 +188,27 @@ theorem d3_4_conjectured : conjecturedValue 3 4 = 7 := by norm_num
 /-- d_4(3) should be 9 according to the conjecture. -/
 theorem d4_3_conjectured : conjecturedValue 4 3 = 9 := by norm_num
 
-/- d_3(10): Solymosi-Solymosi (2017) proved d_3(10) ≤ 14.
-    The conjecture predicts d_3(10) = 13.
-    Formally: dr 3 10 ≤ 14. -/
+/-- **Solymosi-Solymosi (2017):** d_3(10) ≤ 14.
+    The conjecture predicts d_3(10) = 13. Axiomatized as a deep published result.
+    Reference: Solymosi-Solymosi, "On a hypergraph Turán problem of Frankl",
+    Combinatorica 37 (2017). -/
+axiom solymosi_d3_10 : dr 3 10 ≤ 14
+
+/-- The Solymosi-Solymosi bound differs from the conjectured value by at most 1. -/
+theorem solymosi_d3_10_gap : dr 3 10 ≤ conjecturedValue 3 10 + 1 := by
+  unfold conjecturedValue
+  have h := solymosi_d3_10
+  omega
+
+/-- Lower bound on d_3(10) from BES: d_3(10) ≥ 13. -/
+theorem bes_d3_10_lower : dr 3 10 ≥ 13 := by
+  have h := bes_lower_bound 3 10 (by omega) (by omega)
+  unfold conjecturedValue at h
+  omega
+
+/-- Combined bounds: 13 ≤ d_3(10) ≤ 14 (the conjecture says equality at 13). -/
+theorem d3_10_bounds : 13 ≤ dr 3 10 ∧ dr 3 10 ≤ 14 :=
+  ⟨bes_d3_10_lower, solymosi_d3_10⟩
 
 /- ## Part IX: The Main Conjecture -/
 

--- a/src/data/proofs/erdos-1178/meta.json
+++ b/src/data/proofs/erdos-1178/meta.json
@@ -50,11 +50,12 @@
       "efr_e3: d_r(3) = (r-2)·3+3 for all r ≥ 3 (Erdős-Frankl-Rödl 1986)",
       "BrownErdosSosGeneralConjecture: formal statement of the open conjecture",
       "conjecture_implies_dense_free, conjecture_implies_subquadratic: implications",
-      "Connection theorems linking to Problems #716 and #1076"
+      "Connection theorems linking to Problems #716 and #1076",
+      "solymosi_d3_10 axiom + d3_10_bounds: 13 ≤ d_3(10) ≤ 14 (gap of 1 from conjectured 13)"
     ],
-    "axiomCount": 2,
-    "lineCount": 260,
-    "assumptions": "2 axioms: sarkozy_selkow_result (Sárközy-Selkow 2005 upper bound construction) and bes_lower_bound (Brown-Erdős-Sós 1973 lower bound via Steiner systems). Both are deep published results not available in Mathlib. All derived theorems (dr_spec, dr_minimal, sarkozy_selkow_upper, ruzsa_szemeredi_d3_3, efr_e3) are fully proved from these axioms. 0 sorries."
+    "axiomCount": 3,
+    "lineCount": 278,
+    "assumptions": "3 axioms: sarkozy_selkow_result (Sárközy-Selkow 2005 upper bound construction), bes_lower_bound (Brown-Erdős-Sós 1973 lower bound via Steiner systems), and solymosi_d3_10 (Solymosi-Solymosi 2017 specific bound dr 3 10 ≤ 14). All three are deep published results not available in Mathlib. All derived theorems (dr_spec, dr_minimal, sarkozy_selkow_upper, ruzsa_szemeredi_d3_3, efr_e3, solymosi_d3_10_gap, bes_d3_10_lower, d3_10_bounds) are fully proved from these axioms. 0 sorries."
   },
   "overview": {
     "historicalContext": "Brown, Erdős, and Sós (1973) initiated the study of extremal numbers for r-uniform hypergraphs avoiding configurations with few vertices relative to edges. They introduced the function d_r(e) — the threshold number of vertices above which the extremal number becomes subquadratic — and conjectured d_r(e) = (r-2)e + 3. They proved the lower bound. Ruzsa and Szemerédi (1978) resolved the case r=3, e=3 (the famous (6,3)-problem), connecting it to the Triangle Removal Lemma and Szemerédi's regularity lemma. Erdős-Frankl-Rödl (1986) proved the full e=3 case. Recent work by Conlon, Gishboliner, Levanzov, and Shapira (2023) brought the r=3 upper bound close to the conjectured value.",
@@ -258,9 +259,9 @@
       "Filter"
     ],
     "namespace": "Erdos1178",
-    "lineCount": 260,
-    "axiomCount": 2,
-    "theoremCount": 13,
+    "lineCount": 278,
+    "axiomCount": 3,
+    "theoremCount": 16,
     "definitionCount": 10,
     "path": "Proofs/Erdos1178Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Adds the Solymosi-Solymosi (2017) result $d_3(10) \leq 14$ as an axiom and derives the bound $13 \leq d_3(10) \leq 14$ using the existing Brown-Erdős-Sós (BES) lower bound.

The conjecture predicts $d_3(10) = 13$, so this exhibits the gap of 1 between the best known upper bound and the BES conjecture for this concrete value.

## What's new in `Erdos1178Problem.lean`

- `solymosi_d3_10` axiom: `dr 3 10 ≤ 14` (Solymosi-Solymosi, Combinatorica 37, 2017)
- `solymosi_d3_10_gap` theorem: `dr 3 10 ≤ conjecturedValue 3 10 + 1`
- `bes_d3_10_lower` theorem: `dr 3 10 ≥ 13` (from existing `bes_lower_bound`)
- `d3_10_bounds` theorem: `13 ≤ dr 3 10 ∧ dr 3 10 ≤ 14`

## Metadata reconciliation

- `axiomCount`: 2 → 3 (still 0 sorries; all three axioms are deep published results)
- `theoremCount`: 13 → 16
- `lineCount`: 260 → 278
- Added Solymosi entry to `originalContributions` and updated the `assumptions` field

The conjecture itself remains OPEN (status: axiomatized, badge: axiom). The new axiom is a published deep result, consistent with the existing approach.

## Test plan
- [ ] CI Lean build passes
- [ ] Gallery `pnpm build` succeeds
- [ ] meta.json axiomCount/theoremCount/lineCount match the Lean file

🤖 Generated with [Claude Code](https://claude.com/claude-code)