### PR TITLE
research(fourier-series-oq-02-oq-03-oq-02): add missing docs + axiom/sorry-elimination roadmap

### DIFF
--- a/research/problems/fourier-series-oq-02-oq-03-oq-02/knowledge.md
+++ b/research/problems/fourier-series-oq-02-oq-03-oq-02/knowledge.md
@@ -1,0 +1,181 @@
+# Knowledge Base: fourier-series-oq-02-oq-03-oq-02
+
+Sharp constants for analytic (exponential) Fourier coefficient
+decay — extending OQ-02-OQ-03's polynomial / Hölder framework.
+
+---
+
+## Problem Understanding
+
+For periodic f : ℝ/Tℤ → ℂ extending holomorphically to the strip
+{z : |Im z| < δ} and bounded there, Fourier coefficients decay
+exponentially: |ĉ_n| ≤ K · e^{-2πδ|n|/T}.
+
+Three questions:
+1. **Sharp constant K(f)** for a given function — defined via the
+   limsup `sup_n |ĉ_n| · e^{2πδ|n|/T}`.
+2. **Sharpness of rate** — the exponent 2πδ/T cannot be improved
+   (extremal: cosh-based functions with poles on the boundary).
+3. **Converse (Paley-Wiener)** — exponential decay characterizes
+   strip-analyticity.
+
+---
+
+## Insights
+
+- Contour shifting is the key analytic technique: shift integration
+  to `Im z = δ - ε`, periodicity cancels vertical edges, and the
+  exponential factor `e^{-2πn(δ-ε)/T}` falls out.
+- The exponential rate `2πδ/T` is sharp, achieved by cosh-extremal
+  functions with poles exactly on the strip boundary.
+- Paley-Wiener converse: exponential Fourier decay completely
+  characterizes strip analyticity.
+- The sharp constant `K(f) = sup_n |ĉ_n| · e^{2πδ|n|/T}` equals the
+  strip-boundary norm for natural boundaries; can be strictly less
+  when f extends further than δ.
+- Strip width δ plays the role that Hölder exponent α plays in the
+  polynomial regime, but yields exponentially faster decay.
+- The Poisson kernel `P_r(x)` with `r ∈ (0,1)` has exact
+  exponential decay with strip width `-T·ln(r)/(2π)`.
+- `exp_decay_summable`: requires ℤ-indexed geometric series
+  decomposition (split into `n ≥ 0` and `n < 0` halves).
+- `sharpConstant` proofs: rely on `ciSup_le` / `le_ciSup` from
+  `ConditionallyCompleteLattice` API.
+- `ciSup_const.symm` converts a constant value to an iSup over a
+  nonempty Prop index; `le_ciSup` lifts to outer iSup. Pattern:
+  `calc x = iSup (const) ≤ iSup (outer)`.
+- Data fix from prior session: `leanFiles` in problem JSON had
+  pointed to `FourierSeries.lean` (parent), not
+  `FourierSeriesOQ02OQ03OQ02.lean`.
+
+---
+
+## Roadmap to Close 2 Remaining Sorries
+
+### Sorry 1: `exp_dominates_polynomial`
+```lean
+theorem exp_dominates_polynomial (c M : ℝ) (hc : 0 < c) (hM : 0 < M)
+    (C : ℝ) (hC : 0 < C) (α : ℝ) (hα : 0 < α) :
+    ∀ᶠ n in Filter.cofinite,
+      M * Real.exp (-c * |↑n|) ≤ C * |↑n|⁻¹ ^ α
+```
+Strategy:
+1. `Filter.cofinite` on `ℤ` translates to "for all but finitely
+   many `n`". Equivalent: `|n| → ∞`.
+2. Mathlib lemma: `Real.tendsto_pow_mul_exp_neg_atTop_nhds`
+   states `(fun x => x^k * exp(-x)) → 0 at atTop`.
+3. Real-α version: use `Real.tendsto_rpow_mul_exp_neg_atTop` if
+   available, else cap with `Nat.ceil α`.
+4. Translate via `Filter.tendsto.eventuallyLE` to get
+   `eventually_atTop` and convert to `cofinite` on ℤ.
+
+Estimate: ~30 lines if the right Mathlib lemma exists; ~80 if a
+ceil bound is needed.
+
+### Sorry 2: `analytic_hierarchy`
+```lean
+theorem analytic_hierarchy (f : AddCircle T → ℂ) (δ : ℝ) (hδ : 0 < δ)
+    (hf : IsStripAnalytic δ f) :
+    ∀ α : ℝ, 0 < α → Summable (fun n : ℤ => ‖fourierCoeff f n‖ * |↑n| ^ α)
+```
+Strategy:
+1. Extract `(M, hM, hbound)` from `IsStripAnalytic`.
+2. Use `Summable.of_nonneg_of_le`: bound by
+   `M · exp(-c|n|) · |n|^α` which is summable by combining
+   `exp_dominates_polynomial` (gives bound by `C · |n|^{-α'}` for
+   some α' > 1) with `Summable.of_isBigO`/comparison tests.
+3. Alternatively: use `summable_of_isBigO` plus the fact that
+   `exp(-c|n|) · |n|^α` is `O(exp(-c|n|/2))` for large `|n|`,
+   reducing to `exp_decay_summable`.
+
+Estimate: ~40 lines.
+
+---
+
+## Roadmap to Eliminate 3 Axioms (Per File's Own Documentation)
+
+### Axiom 1: `contour_shift_decay`
+- **Need**: complex contour integration on periodic domains
+- **Ingredients**: Cauchy's theorem for rectangles, vertical-edge
+  cancellation by periodicity, dominated convergence for `ε → 0`
+- **Mathlib gap**: periodic contour setup not formalized
+- **Difficulty**: MODERATE (~300–500 lines)
+
+### Axiom 2: `rate_is_sharp`
+- **Need**: explicit extremal function
+  `1 / (cosh(2πz/T) - cosh(2πδ/T))`
+- **Ingredients**: pole structure on strip boundary, residue
+  calculation for Fourier coefficients
+- **Difficulty**: MODERATE (~200 lines, mostly explicit)
+
+### Axiom 3: `paley_wiener_converse`
+- **Need**: `∑ ĉ_n · e^{2πinz/T}` converges in the strip given
+  exponential decay
+- **Ingredients**: Weierstrass uniform-convergence theorem,
+  holomorphic limits
+- **Mathlib gap**: Weierstrass theorem exists; periodic setup
+  needs work
+- **Difficulty**: LOW–MODERATE (~200 lines)
+
+**Total estimate**: ~700–1100 lines of new infrastructure.
+
+---
+
+## Dead Ends
+
+- Trying to define `sharpConstant` purely as a `liminf` rather
+  than a `iSup`: harder to bound, less canonical.
+- Treating exponential decay as trivially polynomial: misses the
+  interaction with strip width, gives weaker results.
+- Using `Nat.find` on `IsStripAnalytic`: not decidable, only
+  `Classical.choose` works.
+
+---
+
+## Sessions
+
+### Session 2026-04-27 (researcher-4) — audit + roadmap
+- Created `research/problems/fourier-series-oq-02-oq-03-oq-02/`
+  documentation (problem.md, state.md, knowledge.md) — was missing.
+- Documented 2-sorry + 3-axiom roadmap.
+- No Lean source changes (disk at 921 MB free, below safe Docker
+  threshold).
+
+### Prior session — `sharpConstant_is_bound` proof
+**Outcome**: 3 sorries → 2 sorries
+- Used `ciSup_const + le_ciSup` with `BddAbove` from
+  `IsStripAnalytic` to prove `sharpConstant_is_bound`.
+- Remaining sorries: `exp_dominates_polynomial`,
+  `analytic_hierarchy` (standard analysis, need
+  `Filter.cofinite` / `Summable` machinery).
+
+### Earlier session — file creation
+- Created `FourierSeriesOQ02OQ03OQ02.lean`:
+  3 axioms, 10 theorems, 4 definitions, 5 sorries initially.
+- Defined `IsStripAnalytic`, `stripNorm`, `sharpConstant`,
+  `poissonKernelStripWidth`.
+- Proved structural lemmas: `exp_decay_pos`, `exp_decay_le_one`,
+  `wider_strip_faster_decay`, `poissonKernel_strip_positive`.
+- Created gallery entry; created Aristotle companion file with 6
+  theorem sorries for automated proof search.
+
+---
+
+## Mathlib Gaps Summary
+
+- `Real.rpow_mul_exp_neg_atTop` — real-power version of
+  `tendsto_pow_mul_exp_neg_atTop_nhds` (may already exist as
+  `Real.tendsto_rpow_mul_exp_neg_atTop_nhds_zero`?).
+- Periodic complex contour integration with `AddCircle`.
+- Weierstrass uniform-convergence theorem in periodic setup.
+- Cosh-based extremal function Fourier coefficient computation.
+
+---
+
+## Next Action
+
+Future session with Docker:
+1. Close `exp_dominates_polynomial` (~30–80 lines).
+2. Close `analytic_hierarchy` (~40 lines).
+3. Update meta.json to reflect `sorries: 0`, badge stays `axiom`
+   while 3 axioms remain.

--- a/research/problems/fourier-series-oq-02-oq-03-oq-02/problem.md
+++ b/research/problems/fourier-series-oq-02-oq-03-oq-02/problem.md
@@ -1,0 +1,40 @@
+# Problem: Sharp Constants for Analytic (Exponential) Fourier Coefficient Decay
+
+**ID**: fourier-series-oq-02-oq-03-oq-02
+**Category**: open question — sharpening
+**Tractability**: moderate (2 sorries + 3 axioms remain)
+**Source Proof**: fourier-series-oq-02-oq-03 (sharp constant 1/2 for Hölder)
+**Tags**: analysis, fourier, complex-analysis, paley-wiener, exponential-decay
+
+## Problem Statement
+
+For periodic f : ℝ/Tℤ → ℂ that extends holomorphically to the strip
+{z : |Im z| < δ} and is bounded there:
+
+  |ĉ_n(f)| ≤ K · e^{-2πδ|n|/T}
+
+What is the sharp constant K? How does it depend on f? And what's
+the converse Paley-Wiener characterization?
+
+## Context
+
+Source proof: Sharp Constants for Hölder Decay (OQ-02-OQ-03), which
+established the sharp constant 1/2 for Hölder regularity. This OQ
+extends to the analytic regime where decay is exponentially fast.
+
+## Current State
+
+**File**: `proofs/Proofs/FourierSeriesOQ02OQ03OQ02.lean`
+**Companion**: `Proofs/FourierSeriesOQ02OQ03OQ02Aristotle.lean`
+**Sorries**: 2 (`exp_dominates_polynomial`, `analytic_hierarchy`)
+**Axioms**: 3 (`contour_shift_decay`, `rate_is_sharp`,
+              `paley_wiener_converse`)
+
+## Key Questions
+
+1. Can `exp_dominates_polynomial` be proved from
+   `Real.tendsto_pow_mul_exp_neg_atTop_nhds`?
+2. Can `analytic_hierarchy` be derived from `exp_decay_summable`
+   plus `exp_dominates_polynomial`?
+3. Are the three axioms (Cauchy-shift, sharpness, Paley-Wiener)
+   formalizable in Mathlib's current state?

--- a/research/problems/fourier-series-oq-02-oq-03-oq-02/state.md
+++ b/research/problems/fourier-series-oq-02-oq-03-oq-02/state.md
@@ -1,0 +1,78 @@
+# Research State: fourier-series-oq-02-oq-03-oq-02
+
+## Current State
+**Phase**: ACT (sorry-elimination + axiom-elimination)
+**Path**: full
+**Since**: 2026-04-27 (researcher-4 audit)
+**Iteration**: 3 (post prior session "PROGRESS: 3→2 sorries")
+
+## Current Focus
+Sorry-elimination on the two remaining standard-analysis sorries
+(`exp_dominates_polynomial`, `analytic_hierarchy`) and roadmap for
+discharging the three axioms (`contour_shift_decay`,
+`rate_is_sharp`, `paley_wiener_converse`).
+
+## Active Approach
+- `exp_dominates_polynomial`: use
+  `Real.tendsto_pow_mul_exp_neg_atTop_nhds` (or its `Filter`
+  cofinite formulation) to show exponential decay beats polynomial
+  weight eventually. Real-α power version may need
+  `Real.rpow_natCast` + a ceil bound.
+- `analytic_hierarchy`: combine `exp_decay_abs_convergence` with
+  `exp_dominates_polynomial` via `Summable.of_nonneg_of_le`.
+
+## Next Action
+Future session with Docker available:
+1. Try `exp_dominates_polynomial` via:
+   ```lean
+   apply Filter.eventually_atTop.mp
+     (Real.tendsto_pow_mul_exp_neg_atTop_nhds ...).eventuallyLE
+   ```
+   Needs careful filter translation between `Filter.cofinite` (ℤ)
+   and `Filter.atTop` (ℕ).
+2. `analytic_hierarchy` follows: ‖ĉ_n‖ * |n|^α
+   ≤ M·e^{-c|n|}·|n|^α and the latter is summable.
+
+## Blockers
+- Docker / disk: this session had 921 MB free, below 1 GB safe
+  threshold per prior incident memory. Lean source changes
+  unsafe without build verification.
+- Axiom elimination (3 axioms) requires substantial Mathlib
+  infrastructure (~700–1000 lines per the file's own roadmap):
+  - `contour_shift_decay`: complex contour integration on periodic
+    domains, Cauchy's theorem for rectangular contours,
+    cancellation of vertical edges by periodicity.
+  - `rate_is_sharp`: explicit construction of extremal function
+    `1/(cosh(2πz/T) - cosh(2πδ/T))` and computation of its
+    Fourier coefficients.
+  - `paley_wiener_converse`: Weierstrass uniform-convergence
+    theorem + holomorphic series limits in the periodic setup.
+
+## Attempt Count
+- Total attempts: 2 prior sessions
+- Current approach attempts: 1
+- Approaches tried: contour-shifting axiomatization, direct sorry
+  closure for sharpConstant_is_bound
+
+## Built Items (cumulative)
+- `IsStripAnalytic`, `stripNorm`, `sharpConstant`,
+  `poissonKernelStripWidth` definitions
+- `exp_decay_pos`, `exp_decay_le_one`,
+  `wider_strip_faster_decay` proved
+- `exp_decay_summable`, `exp_decay_abs_convergence` proved
+  (geometric-series + comparison test)
+- `sharpConstant_is_bound` proved (via `ciSup_const` +
+  `le_ciSup` + exp cancellation)
+- `sharpConstant_optimal` proved (via `ciSup_le`)
+- `trig_poly_vacuous` proved (zero-coefficient case)
+- `poissonKernel_strip_positive` proved
+- Companion: `FourierSeriesOQ02OQ03OQ02Aristotle.lean` with 6
+  theorem sorries for automated proof search
+- Gallery entry: `src/data/proofs/fourier-series-oq-02-oq-03-oq-02`
+
+## Mathlib Gaps (for axiom elimination)
+- Periodic complex contour integration setup
+  (Mathlib has `Complex.integral_boundary_rect_eq_zero_of_differentiable`
+   but not the periodic version).
+- Weierstrass uniform-convergence theorem in periodic context.
+- Explicit Fourier coefficient computation for cosh-extremal.

--- a/src/data/research/problems/fourier-series-oq-02-oq-03-oq-02.json
+++ b/src/data/research/problems/fourier-series-oq-02-oq-03-oq-02.json
@@ -17,11 +17,14 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-03-28T20:58:08-07:00",
-    "iteration": 2,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
-    "blockers": [],
-    "nextAction": "Fast path: Quick Mathlib search, then directly to ACT if obvious approach found.",
+    "since": "2026-04-27T00:00:00-07:00",
+    "iteration": 3,
+    "focus": "Sorry-elimination + axiom-elimination roadmap recorded. 2 sorries (exp_dominates_polynomial, analytic_hierarchy) and 3 axioms (contour_shift_decay, rate_is_sharp, paley_wiener_converse) remain. Awaiting Docker availability for Lean execution.",
+    "blockers": [
+      "Docker / disk: this session 921 MB free, below 1 GB safe threshold for Lean builds.",
+      "Axiom elimination requires substantial Mathlib infrastructure (~700-1100 lines per file roadmap)."
+    ],
+    "nextAction": "Future session: close exp_dominates_polynomial via Real.tendsto_pow_mul_exp_neg_atTop_nhds (~30-80 lines); close analytic_hierarchy via Summable.of_nonneg_of_le (~40 lines).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,7 +32,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved sharpConstant_is_bound (3→2 sorries). Used ciSup_const + le_ciSup with BddAbove from IsStripAnalytic. Remaining: exp_dominates_polynomial, analytic_hierarchy (standard analysis, need Filter.cofinite/Summable machinery).",
+    "progressSummary": "IN PROGRESS (audit 2026-04-27): 2 sorries remaining (exp_dominates_polynomial, analytic_hierarchy) and 3 axioms (contour_shift_decay, rate_is_sharp, paley_wiener_converse). Prior session proved sharpConstant_is_bound (3->2 sorries) via ciSup_const + le_ciSup + exp cancellation. Detailed sorry-elimination + axiom-elimination roadmap recorded in research/problems/fourier-series-oq-02-oq-03-oq-02/knowledge.md.",
     "builtItems": [
       "Created FourierSeriesOQ02OQ03OQ02.lean: 3 axioms, 10 theorems, 4 definitions, 5 sorries",
       "Defined IsStripAnalytic, stripNorm, sharpConstant, poissonKernelStripWidth",
@@ -50,13 +53,23 @@
       "exp_dominates_polynomial: Real.tendsto_pow_mul_exp_neg_atTop_nhds in Mathlib may help",
       "sharpConstant_optimal proved: ciSup_le reduces to showing each term ≤ K, then exp(-a)*exp(a)=1 gives the bound",
       "Data fix: leanFiles was pointing to FourierSeries.lean (parent) not FourierSeriesOQ02OQ03OQ02.lean",
-      "ciSup_const.symm converts constant value to iSup over nonempty Prop index; le_ciSup lifts to outer iSup. Pattern: calc x = iSup (const) ≤ iSup (outer)"
+      "ciSup_const.symm converts constant value to iSup over nonempty Prop index; le_ciSup lifts to outer iSup. Pattern: calc x = iSup (const) ≤ iSup (outer)",
+      "AUDIT 2026-04-27: research/problems/fourier-series-oq-02-oq-03-oq-02/ directory was missing (problem.md, state.md, knowledge.md not created). Now populated.",
+      "Real.tendsto_rpow_mul_exp_neg_atTop_nhds_zero (if it exists) is the right primitive for exp_dominates_polynomial; otherwise use Nat.ceil alpha bound.",
+      "analytic_hierarchy reduces cleanly to exp_decay_abs_convergence + exp_dominates_polynomial via Summable.of_nonneg_of_le."
     ],
-    "mathlibGaps": [],
+    "mathlibGaps": [
+      "Periodic complex contour integration with AddCircle (for contour_shift_decay)",
+      "Weierstrass uniform-convergence theorem in periodic setup (for paley_wiener_converse)",
+      "Explicit Fourier coefficient computation for cosh-extremal (for rate_is_sharp)",
+      "Real-power version of tendsto_pow_mul_exp_neg_atTop_nhds (for exp_dominates_polynomial, may already exist)"
+    ],
     "nextSteps": [
-      "Prove sharpConstant_is_bound (le_ciSup with BddAbove from IsStripAnalytic)",
-      "Prove exp_dominates_polynomial (exponential beats polynomial decay)",
-      "Prove analytic_hierarchy (summability from exponential decay)"
+      "Close exp_dominates_polynomial via Real.tendsto_pow_mul_exp_neg_atTop_nhds (real-alpha version) (~30-80 lines)",
+      "Close analytic_hierarchy via Summable.of_nonneg_of_le combining exp_decay_summable with exp_dominates_polynomial (~40 lines)",
+      "Eliminate contour_shift_decay axiom: ~300-500 lines of periodic complex contour integration",
+      "Eliminate rate_is_sharp axiom: ~200 lines of cosh-extremal Fourier computation",
+      "Eliminate paley_wiener_converse axiom: ~200 lines of periodic Weierstrass uniform convergence"
     ],
     "markdown": "# Knowledge Base: fourier-series-oq-02-oq-03-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary
- Creates missing `research/problems/fourier-series-oq-02-oq-03-oq-02/` documentation (problem.md, state.md, knowledge.md) — the candidate-pool reported 6 items built but the research dir was empty.
- Documents current Lean state: 2 remaining sorries (`exp_dominates_polynomial`, `analytic_hierarchy`) and 3 axioms (`contour_shift_decay`, `rate_is_sharp`, `paley_wiener_converse`) in `Proofs/FourierSeriesOQ02OQ03OQ02.lean`.
- Records concrete sorry-elimination plan (use `Real.tendsto_pow_mul_exp_neg_atTop_nhds` + `Summable.of_nonneg_of_le`) and the file's own axiom-elimination roadmap (~700–1100 lines for periodic complex contour integration, cosh-extremal Fourier coefficient computation, periodic Weierstrass uniform convergence).
- Updates problem JSON to `phase=ACT`, `iteration=3`, with `blockers` and `nextSteps` populated.

## Why metadata-only
Disk was at 921 MB free / 93% capacity this session, below the prior-incident 1 GB threshold for safe Docker builds. Recording the roadmap is the safer contribution.

## Test plan
- [x] Only metadata files changed (no Lean source).
- [x] `git diff --stat` shows 4 files changed (3 new docs, 1 JSON updated).
- [ ] Follow-up PR will execute the sorry-elimination plan once Docker is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)