### PR TITLE
audit(erdos-404): fix stale '(3 sorries)' note in originalContributions

### DIFF
--- a/src/data/proofs/erdos-404/meta.json
+++ b/src/data/proofs/erdos-404/meta.json
@@ -52,7 +52,9 @@
       "lin_bound_meaning axiom: 2^255 never divides such sums",
       "legendreSum: Legendre's formula computation",
       "legendre_formula theorem: v_p(n!) = Σ⌊n/p^i⌋ (proved via Mathlib's padicValNat_factorial)",
-      "padic_val_factorial_asymp theorem (3 sorries): v_p(n!)/n → 1/(p-1) squeeze argument",
+      "padic_val_factorial_asymp theorem (sorry-free): v_p(n!)/n → 1/(p-1) via squeeze theorem",
+      "legendreSum_digitSum_identity theorem: legendreSum * (p-1) + baseDigitSum = n (telescoping proof)",
+      "padic_val_factorial_upper, padic_val_factorial_lower theorems: tight bounds for asymp argument",
       "factorial_sum_factored theorem: factorization a₁! + a₂! = a₁!(1 + a₂!/a₁!)",
       "Two proved examples by native_decide",
       "erdos_404_summary: proved conjunction of Lin's bounds"


### PR DESCRIPTION
## Summary

Fixes a stale annotation in `meta.json`'s `originalContributions` for erdos-404.

The text `\"padic_val_factorial_asymp theorem (3 sorries): ...\"` was inherited from an earlier draft. The theorem is now fully proved (0 sorries) via:
- `legendreSum_digitSum_identity` (telescoping proof)
- `padic_val_factorial_upper` and `padic_val_factorial_lower` (tight bounds)
- A squeeze argument using `Tendsto`

The Lean file (`Erdos404Problem.lean`) verifiably has 0 sorries; this PR just brings the metadata description in line.

Also surfaces three substantive theorems (`legendreSum_digitSum_identity`, `padic_val_factorial_upper`, `padic_val_factorial_lower`) in the contributions list — they were core to the asymptotic proof but went unmentioned.

## Test plan
- [ ] Lean file is unchanged (no rebuild needed, but CI will confirm)
- [ ] `pnpm build` succeeds with updated metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)