### PR TITLE
research(erdos-105): replace axiom thresholdFunction with real def (3→2)

### DIFF
--- a/proofs/Proofs/Erdos105Problem.lean
+++ b/proofs/Proofs/Erdos105Problem.lean
@@ -164,10 +164,24 @@ theorem many_rich_lines_exist (A : Finset Point) (hncoll : NonCollinear (A : Set
 
 /- ## Part VI: Threshold Function -/
 
-/-- f(n) = largest number such that for all A with |A| = n non-collinear,
-    and all B with |B| ≤ f(n), some rich line of A avoids B.
-    Known: c·n ≤ f(n) ≤ n - 4. Axiomatized since exact determination is open. -/
-axiom thresholdFunction (n : ℕ) : ℕ
+/-- f(n) = largest m such that for all A with |A| = n non-collinear, and all
+    disjoint B with |B| ≤ m, some rich line of A avoids B. Defined as the
+    supremum of obstacle counts that can always be avoided.
+
+    Known: c·n ≤ f(n) ≤ n - 4 (exact value is the open question this gallery
+    studies). Replaces a previous `axiom thresholdFunction : ℕ → ℕ`, which
+    declared the function abstractly without tying it to its mathematical
+    meaning — making conjectures about an opaque symbol rather than a real
+    threshold.
+
+    Note: For n ≤ 1 (or any n where no rich line exists), the set is unbounded
+    above (the implication is vacuous), so by Mathlib convention `sSup = 0`
+    in that range. The interesting regime is n ≥ 4. -/
+noncomputable def thresholdFunction (n : ℕ) : ℕ :=
+  sSup {m : ℕ | ∀ (A B : Finset Point),
+    A.card = n → B.card ≤ m → Disjoint A B →
+    NonCollinear (A : Set Point) →
+    ∃ L : Line, L.richAndUnblocked (A : Set Point) (B : Set Point)}
 
 /-- **Lower bound:** f(n) ≥ c·n for some c > 0. -/
 /-- **Upper bound:** f(n) ≤ n - 4 (from Xichuan's counterexample). -/

--- a/src/data/proofs/erdos-105-oq-05/meta.json
+++ b/src/data/proofs/erdos-105-oq-05/meta.json
@@ -51,9 +51,9 @@
         "relationship": "Parent problem: rich lines avoiding obstacles in R^2"
       }
     ],
-    "axiomCount": 3,
+    "axiomCount": 2,
     "lineCount": 206,
-    "assumptions": "3 axioms inherited from Erdos105Problem.lean: xichuan_counterexample (Xichuan's counterexample), beck_szemeredi_trotter_positive (positive result via Szemerédi-Trotter), thresholdFunction (threshold function axiom). 0 own axioms. 0 sorries."
+    "assumptions": "2 axioms inherited from Erdos105Problem.lean: xichuan_counterexample (Xichuan's counterexample), beck_szemeredi_trotter_positive (positive result via Szemerédi-Trotter). 0 own axioms. 0 sorries. The previous transitive `axiom thresholdFunction` was replaced with a real `noncomputable def` in the parent Erdos105Problem.lean."
   },
   "overview": {
     "historicalContext": "Erdős Problem #105 asks about rich lines avoiding obstacle points in R². A line through at least 2 points of a configuration A is 'rich'; a set B of obstacle points 'blocks' all rich lines if every rich line contains at least one obstacle. The conjecture that n−4 obstacles suffice was disproved by Xichuan (2024), showing that the threshold function f(n) (minimum obstacles needed to block all rich lines) satisfies cn ≤ f(n) ≤ n−4, but its exact asymptotics remain unknown.\n\nThe Szemerédi-Trotter theorem (1983) bounds the number of incidences between n points and m lines in R² to O(n^{2/3}m^{2/3} + n + m), implying that any point configuration has many 'ordinary' lines (through exactly 2 points). This structural result is the backdrop for #105: obstacles need to cover enough of the rich-line structure. The natural higher-dimensional question — do rich k-flats in R^d exhibit similar blocking behavior? — requires understanding how incidence bounds change when lines and planes replace each other.",

--- a/src/data/proofs/erdos-105/meta.json
+++ b/src/data/proofs/erdos-105/meta.json
@@ -59,9 +59,9 @@
         "relationship": "Beck and Szemerédi-Trotter results on point-line incidences"
       }
     ],
-    "axiomCount": 3,
-    "lineCount": 291,
-    "assumptions": "3 axioms: xichuan_counterexample (Xichuan: explicit counterexamples to the naive conjecture), beck_szemeredi_trotter_positive (Beck-Szemerédi-Trotter: with cn obstacles a rich line always exists), thresholdFunction (threshold f(n) — axiomatized, known c·n ≤ f(n) ≤ n-4). 0 sorries."
+    "axiomCount": 2,
+    "lineCount": 305,
+    "assumptions": "2 axioms: xichuan_counterexample (Xichuan: explicit counterexamples to the naive conjecture), beck_szemeredi_trotter_positive (Beck-Szemerédi-Trotter: with cn obstacles a rich line always exists). 0 sorries. The previous `axiom thresholdFunction : ℕ → ℕ` was replaced with a real `noncomputable def thresholdFunction (n : ℕ) : ℕ := sSup {m | …}` — defining f(n) concretely as the supremum of obstacle counts that can always be avoided. The conjectures about its asymptotic behaviour (cn ≤ f(n) ≤ n-4) remain open and are stated in `openProblem_exact_threshold`."
   },
   "overview": {
     "historicalContext": "**Point-Line Incidences and Blocking Sets**\n\nErdős Problem #105 sits at the intersection of incidence geometry and extremal combinatorics. A *rich line* for a point set $A \\subset \\mathbb{R}^2$ is one containing $\\geq 2$ points of $A$; the question is how many *obstacle* points are needed to *block* every rich line — i.e., place a point of $B$ on each.\n\n**Szemerédi-Trotter Foundation (1983)**: The Szemerédi-Trotter theorem $I(P, L) = O(|P|^{2/3}|L|^{2/3} + |P| + |L|)$ implies that $n$ non-collinear points determine $\\Omega(n^2)$ rich lines (most through exactly 2 points). Beck (1983) independently proved that for any $c > 0$ sufficiently small, $cn$ obstacle points cannot block all rich lines — by a double-counting argument, $cn$ obstacles can lie on at most $O(cn \\cdot n) = O(cn^2)$ rich lines, which for small $c$ is fewer than the total.\n\n**The Erdős-Purdy Conjecture (1995)**: Erdős and Purdy conjectured that even $n - 3$ obstacles cannot block all rich lines of $n$ non-collinear points. They offered a \\$50 prize for proof or disproof. The number $n - 3$ was motivated by Hickerson's construction showing $n - 2$ obstacles *can* block all rich lines, making $n - 3$ the natural boundary case.\n\n**Hickerson's $n - 2$ Construction**: Hickerson exhibited, for each $n$, a configuration of $n$ non-collinear points $A$ and $n - 2$ obstacles $B$ such that every rich line of $A$ passes through a point of $B$. This established $f(n) \\leq n - 3$ for the threshold function.\n\n**Xichuan's Disproof (2024)**: Xichuan constructed three explicit counterexamples showing that $n - 3$ obstacles also suffice to block all rich lines. The constructions exploit point configurations where $A$ has unusually few rich lines relative to its size — specifically, configurations where the rich lines can be covered by $n - 3$ points. This disproved the Erdős-Purdy conjecture and earned the \\$50 prize, establishing $f(n) \\leq n - 4$.\n\n**Current State**: The threshold function $f(n)$ satisfies $cn \\leq f(n) \\leq n - 4$ for some constant $c > 0$. The enormous gap between linear and near-linear bounds is the central open problem.",
@@ -252,10 +252,10 @@
       "Finset"
     ],
     "namespace": "Erdos105",
-    "lineCount": 291,
-    "axiomCount": 3,
+    "lineCount": 305,
+    "axiomCount": 2,
     "theoremCount": 3,
-    "definitionCount": 9,
+    "definitionCount": 10,
     "path": "Proofs/Erdos105Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary

Replace `axiom thresholdFunction (n : ℕ) : ℕ` in `Erdos105Problem.lean` with a real `noncomputable def`. The function `f(n)` is now defined concretely as the supremum of obstacle counts that can always be avoided:

```lean
noncomputable def thresholdFunction (n : ℕ) : ℕ :=
  sSup {m : ℕ | ∀ A B : Finset Point, A.card = n → B.card ≤ m →
    Disjoint A B → NonCollinear (A : Set Point) →
    ∃ L : Line, L.richAndUnblocked (A : Set Point) (B : Set Point)}
```

## Why this matters

The previous axiom declared `thresholdFunction` as an opaque symbol with no mathematical content. `openProblem_exact_threshold` (the conjecture `∃ c₁ c₂, c₁n ≤ thresholdFunction n ≤ c₂n`) was stated about this opaque function — making claims about a meaningless symbol rather than the actual mathematical threshold. Defining the function concretely turns those conjectures into real, well-formed statements.

The bounds `cn ≤ f(n) ≤ n − 4` (Beck / Szemerédi-Trotter 1983; Xichuan 2024) remain open *in the formalization*. They are still stated in `openProblem_exact_threshold` — but now about a definite function rather than an opaque axiom.

## Axiom Counts

- `Erdos105Problem.lean`: 3 → 2 (`xichuan_counterexample` and `beck_szemeredi_trotter_positive` remain — these encode published existence results that need substantial formalization).
- `erdos-105/meta.json`: axiomCount 3 → 2, lineCount 291 → 305, definitionCount 9 → 10, assumptions updated.
- `erdos-105-oq-05/meta.json`: transitive axiomCount 3 → 2 (file imports `Erdos105Problem`).
- `erdos-105-oq-02/meta.json`: unchanged. Its 3 axioms (`threshold_lower_bound`, `threshold_upper_bound`, `threshold_gap_axiom`) are local theorems about the threshold's bounds — distinct from the parent's.

## Definition Soundness

For `n ≥ 4` (the regime studied), the set is bounded above by `n − 4` (Xichuan), so `sSup` gives the actual maximum. For `n ≤ 1` (or any `n` where `NonCollinear` is unsatisfiable), the predicate is vacuous and `sSup = 0` by Mathlib convention — harmless edge behaviour.

## Files Modified

- `proofs/Proofs/Erdos105Problem.lean`: axiom → noncomputable def
- `src/data/proofs/erdos-105/meta.json`: counts and assumptions
- `src/data/proofs/erdos-105-oq-05/meta.json`: counts and assumptions

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.Erdos105Problem` (skipped this session — disk space tight; please verify in CI)
- [ ] `./proofs/scripts/docker-build.sh Proofs.Erdos105OQ05` (regression check)
- [ ] `pnpm build` (gallery build)

🤖 Generated by researcher-9