### PR TITLE
Research: erdos-938 — mark COMPLETED (stale-pool cleanup)

### DIFF
--- a/src/data/research/problems/erdos-938.json
+++ b/src/data/research/problems/erdos-938.json
@@ -1,8 +1,8 @@
 {
   "slug": "erdos-938",
-  "title": "Erdős #938",
-  "phase": "ACT",
-  "status": "active",
+  "title": "Erd\u0151s #938",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ACT",
-    "since": "2026-01-15T11:50:52.409Z",
+    "phase": "COMPLETED",
+    "since": "2026-04-27T16:50:00-07:00",
     "iteration": 3,
-    "focus": "Eliminated 4 enumeration axioms via Nat.nth (7→3 axioms)",
+    "focus": "Completed (researcher-7 stale-pool cleanup 2026-04-27). Erdos938Problem.lean is sorry-free with 0 axioms, 4 theorems. Gallery meta: status axiomatized, badge wip, axiomCount 0.",
     "blockers": [],
-    "nextAction": "Problem complete: only 3 irreducible axioms remain (open conjectures + deep analytic NT)",
+    "nextAction": "Closed.",
     "attemptCounts": {
       "total": 1,
       "currentApproach": 1,
@@ -41,19 +41,19 @@
     "insights": [
       "7 axioms total: 4 are enumeration axioms (nthPowerful + properties), 3 are deep/open results",
       "The 4 enumeration axioms CAN be eliminated: define nthPowerful using Nat.nth or Set.Nat.nth from Mathlib if available, or build from well-ordering",
-      "powerfulSet is provably infinite: contains all perfect squares k² (if p|k² then p|k so p²|k²)",
-      "Powerful is decidable for fixed n: check primes up to n for p²|n condition",
+      "powerfulSet is provably infinite: contains all perfect squares k\u00b2 (if p|k\u00b2 then p|k so p\u00b2|k\u00b2)",
+      "Powerful is decidable for fixed n: check primes up to n for p\u00b2|n condition",
       "erdos_938 (open conjecture), erdos_364_conjecture (open), powerful_count_asymptotic (deep analytic NT) cannot be proved from Mathlib",
       "The file has 0 sorries despite metadata claiming 1 - the open problem uses axiom, not sorry",
       "Nat.nth provides clean enumeration API: nth_strictMono, nth_mem_of_infinite, nth_count are the key lemmas",
       "pow_pos (not Nat.pos_pow_of_pos) is the correct Mathlib name for 0 < a^n given 0 < a",
       "interval_cases needs explicit upper bounds from Nat.le_of_dvd when dealing with prime/divisibility hypotheses",
-      "Sorry count in metadata is 1 but there are 0 actual sorries — the word appears in a docstring comment",
+      "Sorry count in metadata is 1 but there are 0 actual sorries \u2014 the word appears in a docstring comment",
       "All 3 axioms are appropriate: 2 open problems + 1 deep analytic number theory result"
     ],
     "mathlibGaps": [],
     "nextSteps": [],
-    "markdown": "# Erdős #938 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $A=\\{n_1<n_2<\\cdots\\}$ be the sequence of powerful numbers (if $p\\mid n$ then $p^2\\mid n$).\n\nAre there only finitely many three-term progressions of consecutive terms $n_k,n_{k+1},n_{k+2}$?\n\n\n\nErd\\H{o}s also conjectured (see [364]) that there are no triples of powerful numbers of the shape $n,n+1,n+2$.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #364\n- Problem #937\n- Problem #939\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er76d\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
+    "markdown": "# Erd\u0151s #938 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $A=\\{n_1<n_2<\\cdots\\}$ be the sequence of powerful numbers (if $p\\mid n$ then $p^2\\mid n$).\n\nAre there only finitely many three-term progressions of consecutive terms $n_k,n_{k+1},n_{k+2}$?\n\n\n\nErd\\H{o}s also conjectured (see [364]) that there are no triples of powerful numbers of the shape $n,n+1,n+2$.\n\n\nBack to the problem\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #364\n- Problem #937\n- Problem #939\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er76d\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
   "tags": [
     "erdos"
@@ -69,7 +69,7 @@
     "mathlib": []
   },
   "started": "2026-01-15T11:50:52.409Z",
-  "lastUpdate": "2026-03-13T07:52:17.055Z",
+  "lastUpdate": "2026-04-27T23:37:51.457077Z",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [
@@ -77,7 +77,7 @@
       "path": "Proofs/Erdos938Problem.lean",
       "filename": "Erdos938Problem.lean",
       "lineCount": 219,
-      "theoremCount": 6,
+      "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 13,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Stale-pool cleanup. `Erdos938Problem.lean` is sorry-free with 0 axioms and the gallery already has `status: axiomatized` — only the candidate-pool / problem JSON were stale.

## Verified state

- `proofs/Proofs/Erdos938Problem.lean`: 4 theorems, 0 axioms, 0 sorries.
- Gallery `meta.json`: `status: axiomatized`, `badge: wip`, `axiomCount: 0`.

JSON progressSummary already said "COMPLETE: 0 axioms, 0 sorries. All 3 former axioms converted to def Prop (2 open conjectures + 1 known result, none used by any theorem)" — the work was finished but the pool/state didn't reflect it.

## Changes (metadata only)

- candidate-pool: `active` → `completed`
- `src/data/research/problems/erdos-938.json`: `phase` ACT → COMPLETED, `status` → completed, `currentState` updated, `leanFile.theoremCount` synced (6 → 4).

## Test plan

- [x] No Lean code changed
- [x] Sorry/axiom counts verified by parsing comment-stripped source
- [x] Gallery `meta.json` already in agreement (`status: axiomatized`)

🤖 Generated by researcher-7