### PR TITLE
research(szemeredi-full-oq-02): reconcile stale top-level phase/status

### DIFF
--- a/src/data/research/problems/szemeredi-full-oq-02.json
+++ b/src/data/research/problems/szemeredi-full-oq-02.json
@@ -1,8 +1,8 @@
 {
   "slug": "szemeredi-full-oq-02",
   "title": "Szemerédi's Theorem: Uniform Sets Not Containing k-AP Are o(N) Dense",
-  "phase": "NEW",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {
@@ -19,9 +19,9 @@
     "phase": "COMPLETED",
     "since": "2026-04-22T13:03:46.383Z",
     "iteration": 1,
-    "focus": "Complete: SzemerediFullOQ02.lean built and PR created",
+    "focus": "Complete: SzemerediFullOQ02.lean has 0 sorries; gallery meta in sync (axiomatized, axiomCount=1).",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "None — work complete. Future work (Gowers U^2 infrastructure) tracked in mathlibGaps.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -69,7 +69,7 @@
     "mathlib": []
   },
   "started": "2026-04-22T13:03:46.383Z",
-  "lastUpdate": "2026-04-26T00:00:00.000Z",
+  "lastUpdate": "2026-04-27T23:36:00.000Z",
   "significance": 8,
   "tractability": 3
 }


### PR DESCRIPTION
## Summary
Pure metadata reconciliation. The candidate-pool entry for `szemeredi-full-oq-02` had a contradictory state: top-level `phase: NEW`, `status: active`, but inner `currentState.phase: COMPLETED` and `progressSummary` already declared "COMPLETE: SzemerediFullOQ02.lean built (118 lines, 0 sorries, 1 axiom inherited from szemeredi_k_ge_4)".

## Verification
- `grep -c "sorry" proofs/Proofs/SzemerediFullOQ02.lean` → 0
- `grep -c "^axiom " proofs/Proofs/SzemerediFullOQ02.lean` → 0 (the 1 axiom is inherited from `szemeredi_k_ge_4` in the parent file)
- Gallery meta `src/data/proofs/szemeredi-full-oq-02/meta.json` already in sync: `status: axiomatized`, `sorries: 0`, `axiomCount: 1`, `badge: axiom`

## Changes
- top-level `phase: NEW → COMPLETED`
- top-level `status: active → completed`
- `currentState.focus` / `nextAction`: reflect done state, point future Gowers U^2 work to `mathlibGaps`
- `lastUpdate`: bumped to `2026-04-27`

No Lean changes. No Docker build needed.

## Status
**Outcome**: completed (metadata reconciliation)
**Next Steps**: none — work is done; future Gowers U^k infrastructure tracked in `mathlibGaps`.

🤖 Generated by researcher-5