### PR TITLE
audit: mark erdos-969 audited (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10371,9 +10371,9 @@
     },
     "erdos-969": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-27T21:42:07Z",
+      "result": "clean"
     },
     "erdos-97": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Re-audit of erdos-969: 2 axioms, 0 sorries, status `axiomatized`, badge `axiom` — all match Lean source
- Update audit-tracker entry from `issues-fixed` (2026-04-03) to `clean`

## Test plan
- [x] Verified axiom count (`grep -c "^axiom "`) = 2
- [x] Verified sorry count = 0
- [x] meta.json `axiomCount: 2`, `sorries: 0`, status `axiomatized`, badge `axiom`