### PR TITLE
research(laws-of-large-numbers-oq-02): refresh stale axiom count

### DIFF
--- a/src/data/research/problems/laws-of-large-numbers-oq-02.json
+++ b/src/data/research/problems/laws-of-large-numbers-oq-02.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Eliminated 1 axiom (integral_sampleMean→theorem) and 2 sorries (chebyshev_convergence_rate, chebyshev_rate_implies_convergence). File now: 13 axioms, 0 sorries.",
+    "progressSummary": "PROGRESS: LawsOfLargeNumbersOQ02.lean is at 330 lines, 4 axioms (sampleMean_memLp, variance_sampleMean, standardNormalCDF, berryEsseenConstant), 0 sorries. Down from 13 axioms after sustained elimination work. Remaining axioms split: two L²-bookkeeping (sampleMean_memLp, variance_sampleMean) likely provable from Mathlib, two CLT-domain (standardNormalCDF, berryEsseenConstant) blocked by absence of CLT in Mathlib v4.26.",
     "builtItems": [
       "integral_sampleMean: axiom → theorem (proved via integral linearity)",
       "chebyshev_convergence_rate: sorry → proved (Chebyshev + axiom substitution)",
@@ -70,7 +70,7 @@
     "mathlib": []
   },
   "started": "2026-03-29T04:28:18.978Z",
-  "lastUpdate": "2026-03-29T04:28:18.988Z",
+  "lastUpdate": "2026-04-27T23:45:00.000Z",
   "leanFiles": [
     {
       "path": "Proofs/LawsOfLargeNumbers.lean",


### PR DESCRIPTION
## Summary
Pure metadata reconciliation. The candidate-pool entry's `knowledge.progressSummary` claimed "File now: 13 axioms, 0 sorries", but `LawsOfLargeNumbersOQ02.lean` actually has 4 axioms (and the `leanFiles` array already has `axiomCount: 4` — only the human-readable summary drifted).

## Verification
- `grep -c "^axiom " proofs/Proofs/LawsOfLargeNumbersOQ02.lean` → 4
- The four axioms: `sampleMean_memLp`, `variance_sampleMean`, `standardNormalCDF`, `berryEsseenConstant`
- 0 sorries

## Changes
- `knowledge.progressSummary`: "13 axioms" → "4 axioms", with the four named and classified:
  - **L²-bookkeeping** (`sampleMean_memLp`, `variance_sampleMean`) — likely provable from Mathlib
  - **CLT-domain** (`standardNormalCDF`, `berryEsseenConstant`) — blocked by absence of CLT in Mathlib v4.26
- `lastUpdate`: 2026-03-29 → 2026-04-27

No Lean changes. No Docker build needed.

## Status
**Outcome**: progress (metadata reconciliation; clarifies the surviving Mathlib gap)
**Next Steps**: prove `sampleMean_memLp` and `variance_sampleMean` from Mathlib's `Memℒp.const_smul` / `IndepFun.variance_sum` (already noted in `nextSteps`).

🤖 Generated by researcher-5