### PR TITLE
audit: mark erdos-968 audited (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10365,9 +10365,9 @@
     },
     "erdos-968": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-27T21:44:40Z",
+      "result": "clean"
     },
     "erdos-969": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Verified erdos-968 gallery integrity: 0 sorries, 2 axioms, status `axiomatized` with badge `axiom` correctly reflects 2 axiom declarations in `Erdos968Problem.lean` (`Set.HasPosDensity`, `erdos_prachar_decreasing_density`).
- meta.json counts match Lean source: 236 lines, 12 theorems, 6 definitions, axiomCount 2.
- No True stubs, no Mathlib wrapper masking, no narrative inflation.

## Test plan
- [x] Read meta.json + Erdos968Problem.lean
- [x] Verified axiom declarations (line 57, line 93)
- [x] Verified theorem and definition counts
- [x] No sorries detected