### PR TITLE
research(erdos-332): reconcile metadata drift with current Lean state

### DIFF
--- a/src/data/proofs/erdos-332/meta.json
+++ b/src/data/proofs/erdos-332/meta.json
@@ -52,7 +52,7 @@
       "Proved diffSet_nonempty_of_infinite: D(A) is nonempty for infinite A (corollary of zero_mem_diffSet)",
       "Proved lower_density_implies_upper: positive lower density → positive upper density",
       "Proved positive_lower_density_bounded_gaps: lower density suffices for bounded gaps (combines density implication with Prikry's theorem)",
-      "Axiomatized Prikry's theorem, density inheritance, and harmonic thickness conjecture as the known landscape for Problem #332",
+      "Axiomatized Prikry's theorem (positive_density_bounded_gaps) as the single mathematical assumption; density inheritance and harmonic thickness divergence are stated only as related-question comments, not axioms",
       "Proved countingFn_le: counting function bounded by N (|A ∩ {1,...,N}| ≤ N)",
       "Proved positive_upper_density_infinite: positive upper density implies A is infinite, via Archimedean contradiction",
       "Proved positive_upper_density_diffSet_nonempty: density → D(A) nonempty (bridges density and difference set theory)",
@@ -70,7 +70,7 @@
   "overview": {
     "historicalContext": "Paul Erdős and Ronald Graham posed this problem in their 1980 monograph *Old and New Problems and Results in Combinatorial Number Theory* [ErGr80], building on the classical study of difference sets pioneered by Khintchine (1930s) and Følner (1954). The key known result is due to Karel Prikry, who proved that positive upper density of $A$ guarantees $D(A)$ has bounded gaps (syndeticity); related work by Robert Tijdeman and Cameron Stewart refined the quantitative bounds on the gap parameter $M$ in terms of the density $\\delta$. The problem connects deeply to Hillel Furstenberg's 1977 correspondence principle (*Journal d'Analyse Mathématique*), which translates combinatorial density questions into ergodic theory — Prikry's theorem follows from Poincaré recurrence in the associated measure-preserving system. The open question of finding the *weakest* sufficient condition sits within the broader program of understanding how density forces structure: Szemerédi's theorem (1975) shows positive density forces arithmetic progressions, and the Green–Tao theorem (2008) extends this to the primes. Problem #332 asks the analogous question for difference sets rather than progressions.",
     "problemStatement": "Let $A \\subseteq \\mathbb{N}$ and $D(A) = \\{d \\in \\mathbb{Z} : a_1 - a_2 = d \\text{ for infinitely many } (a_1, a_2) \\in A^2\\}$. What is the weakest condition on $A$ guaranteeing that $D(A)$ has bounded gaps (is syndetic)?",
-    "text": "A 154-line formalization of Erdős Problem #332 studying the difference set $D(A) = \\{d \\in \\mathbb{Z} : a_1 - a_2 = d \\text{ for infinitely many pairs}\\}$ and the conditions forcing it to be syndetic (have bounded gaps). Defines 6 predicates: `diffSet` (infinite-fibre differences), `HasBoundedGaps` (syndeticity), `countingFn` ($A(N) = |A \\cap [1,N]|$), `HasPositiveUpperDensity` and `HasPositiveLowerDensity` (density via $\\mathbb{Q}$ ratios), and `ErdosProblem332` (weakest sufficient condition). Axiomatizes Prikry's theorem ($\\overline{d}(A) > 0 \\Rightarrow D(A)$ syndetic), density inheritance, and the harmonic thickness conjecture. Proves 7 theorems including symmetry, zero membership, monotonicity, finite emptiness, nonemptiness for infinite sets, density hierarchy, and bounded gaps from lower density.",
+    "text": "A 254-line formalization of Erdős Problem #332 studying the difference set $D(A) = \\{d \\in \\mathbb{Z} : a_1 - a_2 = d \\text{ for infinitely many pairs}\\}$ and the conditions forcing it to be syndetic (have bounded gaps). Defines 6 predicates: `diffSet` (infinite-fibre differences), `HasBoundedGaps` (syndeticity), `countingFn` ($A(N) = |A \\cap [1,N]|$), `HasPositiveUpperDensity` and `HasPositiveLowerDensity` (density via $\\mathbb{Q}$ ratios), and `ErdosProblem332` (weakest sufficient condition). Axiomatizes Prikry's theorem ($\\overline{d}(A) > 0 \\Rightarrow D(A)$ syndetic) as the single assumption. Proves 20 theorems including symmetry, zero membership, monotonicity, finite emptiness, nonemptiness for infinite sets, density hierarchy, the iff characterizations $0 \\in D(A) \\iff A$ infinite $\\iff D(A) \\neq \\emptyset$, additional structural lemmas (union subset, syndeticity is upward closed), and the full density chain $\\overline{d}(A) > 0 \\Rightarrow A$ infinite $\\Rightarrow D(A)$ syndetic.",
     "proofStrategy": "We formalize $D(A)$ as the set of differences with infinite fibre, bounded gaps (syndeticity) via interval covering with parameter $M$, positive upper/lower density via counting functions over $\\mathbb{Q}$, and axiomatize Prikry's theorem and related structural results (density inheritance, symmetry, zero membership). The main problem is stated as a characterization question about optimal sufficient conditions.",
     "keyInsights": [
       "**$D(A)$ captures persistent differences**: Unlike the ordinary difference set $A - A$, $D(A)$ requires each difference to have infinitely many witness pairs — a much stronger structural property that filters out 'accidental' differences",
@@ -99,7 +99,7 @@
     {
       "id": "difference-set",
       "title": "Difference Set D(A)",
-      "startLine": 23,
+      "startLine": 24,
       "endLine": 30,
       "summary": "Defines $D(A) = \\{d \\in \\mathbb{Z} : |\\{(a_1,a_2) \\in A^2 : a_1 - a_2 = d\\}| = \\infty\\}$ using `Set.Infinite` on the fibre over each $d$. Stricter than $A - A$.",
       "mathContext": "$D(A) = \\{d \\in \\mathbb{Z} : |\\{(a_1,a_2) \\in A^2 : a_1 - a_2 = d\\}| = \\infty\\}$. Stricter than $A - A$."
@@ -107,58 +107,34 @@
     {
       "id": "bounded-gaps",
       "title": "Bounded Gaps (Syndeticity)",
-      "startLine": 31,
-      "endLine": 39,
-      "summary": "Defines `HasBoundedGaps`: $\\exists M > 0, \\forall z \\in \\mathbb{Z}, \\exists s \\in S: z \\leq s < z + M$. The dual of thick sets in topological dynamics.",
+      "startLine": 32,
+      "endLine": 43,
+      "summary": "Defines `HasBoundedGaps`: $\\exists M > 0, \\forall z \\in \\mathbb{Z}, \\exists s \\in S: z \\leq s < z + M$. The dual of thick sets in topological dynamics. Includes `diffSet_empty`: $D(\\emptyset) = \\emptyset$.",
       "mathContext": "$\\text{HasBoundedGaps}(S) \\iff \\exists M > 0,\\, \\forall z \\in \\mathbb{Z},\\, \\exists s \\in S: z \\leq s < z + M$."
     },
     {
       "id": "density-conditions",
       "title": "Density Conditions",
-      "startLine": 40,
-      "endLine": 57,
-      "summary": "Counting function $A(N) = |A \\cap [1,N]|$, positive upper density ($\\limsup A(N)/N > 0$), and positive lower density ($\\liminf A(N)/N > 0$), all formalized over $\\mathbb{Q}$.",
+      "startLine": 45,
+      "endLine": 72,
+      "summary": "Counting function $A(N) = |A \\cap [1,N]|$ with `countingFn_zero` and `countingFn_mono`, positive upper density ($\\limsup A(N)/N > 0$), and positive lower density ($\\liminf A(N)/N > 0$), all formalized over $\\mathbb{Q}$.",
       "mathContext": "$A(N) = |A \\cap [1,N]|$; $\\overline{d}(A) = \\limsup_{N \\to \\infty} A(N)/N$; $\\underline{d}(A) = \\liminf_{N \\to \\infty} A(N)/N$."
     },
     {
       "id": "known-results",
       "title": "Known Results",
-      "startLine": 59,
-      "endLine": 97,
-      "summary": "Two axioms (Prikry's theorem: $\\overline{d}(A) > 0 \\Rightarrow D(A)$ syndetic; density inheritance for $D(A)$) and two proved theorems (`diffSet_symm`: $D(A) = -D(A)$ via the swap bijection; `zero_mem_diffSet`: $0 \\in D(A)$ for infinite $A$ via diagonal pairs).",
-      "mathContext": "Axioms: Prikry's theorem $\\overline{d}(A) > 0 \\Rightarrow \\text{HasBoundedGaps}(D(A))$; density inheritance. Proved: $D(A) = -D(A)$, $0 \\in D(A)$ for infinite $A$."
+      "startLine": 74,
+      "endLine": 108,
+      "summary": "One axiom (Prikry–Tijdeman–Stewart theorem: $\\overline{d}(A) > 0 \\Rightarrow D(A)$ syndetic) and two proved theorems (`diffSet_symm`: $D(A) = -D(A)$ via the swap bijection; `zero_mem_diffSet`: $0 \\in D(A)$ for infinite $A$ via diagonal pairs).",
+      "mathContext": "Axiom: Prikry's theorem $\\overline{d}(A) > 0 \\Rightarrow \\text{HasBoundedGaps}(D(A))$. Proved: $D(A) = -D(A)$, $0 \\in D(A)$ for infinite $A$."
     },
     {
       "id": "structural-properties",
       "title": "Structural Properties",
-      "startLine": 99,
-      "endLine": 132,
-      "summary": "Five proved theorems: monotonicity ($A \\subseteq B \\Rightarrow D(A) \\subseteq D(B)$), empty difference set for finite sets, nonemptiness for infinite sets, positive lower density implies positive upper density, and bounded gaps from lower density (combining density implication with Prikry's theorem).",
-      "mathContext": "Proved: $D$ is monotone, $D(A) = \\emptyset$ for finite $A$, $D(A) \\neq \\emptyset$ for infinite $A$, $\\underline{d}(A) > 0 \\Rightarrow \\overline{d}(A) > 0$, $\\underline{d}(A) > 0 \\Rightarrow \\text{HasBoundedGaps}(D(A))$."
-    },
-    {
-      "id": "main-problem",
-      "title": "The Main Open Problem",
-      "startLine": 134,
-      "endLine": 144,
-      "summary": "Erdős Problem 332: characterize the weakest property $P$ such that $P(A) \\Rightarrow \\text{HasBoundedGaps}(D(A))$. Positive upper density is the best known sufficient condition.",
-      "mathContext": "Find weakest $P$: $P(A) \\Rightarrow \\text{HasBoundedGaps}(D(A))$. Known: $\\overline{d}(A) > 0$ suffices."
-    },
-    {
-      "id": "related-questions",
-      "title": "Related Questions",
-      "startLine": 146,
-      "endLine": 154,
-      "summary": "Does positive density imply $\\sum_{d \\in D(A)} 1/d = \\infty$? This would show $D(A)$ has 'harmonic thickness' beyond mere syndeticity.",
-      "mathContext": "Open: $\\overline{d}(A) > 0 \\Rightarrow \\sum_{d \\in D(A)} 1/|d| = \\infty$? (harmonic thickness conjecture)"
-    },
-    {
-      "id": "iff-characterizations",
-      "title": "If-and-Only-If Characterizations and Lower Density",
-      "startLine": 155,
+      "startLine": 110,
       "endLine": 163,
-      "summary": "Four theorems completing the structural picture: `zero_mem_diffSet_iff` ($0 \\in D(A) \\iff A$ is infinite), `diffSet_nonempty_iff` ($D(A) \\neq \\emptyset \\iff A$ is infinite), `lower_density_implies_upper` ($\\underline{d}(A) > 0 \\Rightarrow \\overline{d}(A) > 0$), and `positive_lower_density_bounded_gaps` (lower density suffices for syndeticity via Prikry composition).",
-      "mathContext": "$(0 \\in D(A)) \\iff (A \\text{ infinite}) \\iff (D(A) \\neq \\emptyset)$. Density hierarchy: $\\underline{d}(A) > 0 \\Rightarrow \\overline{d}(A) > 0 \\Rightarrow \\text{HasBoundedGaps}(D(A))$."
+      "summary": "Seven proved theorems: `diffSet_mono` (monotonicity $A \\subseteq B \\Rightarrow D(A) \\subseteq D(B)$), `diffSet_finite_eq_empty` (empty difference set for finite sets), `diffSet_nonempty_of_infinite` (nonemptiness for infinite sets), `zero_mem_diffSet_iff` and `diffSet_nonempty_iff` (iff characterizations: $0 \\in D(A) \\iff A$ infinite $\\iff D(A) \\neq \\emptyset$), `lower_density_implies_upper` (density hierarchy), and `positive_lower_density_bounded_gaps` (lower density suffices for syndeticity via Prikry composition).",
+      "mathContext": "Proved: $D$ is monotone, $D(A) = \\emptyset$ for finite $A$, $(0 \\in D(A)) \\iff (A \\text{ infinite}) \\iff (D(A) \\neq \\emptyset)$, $\\underline{d}(A) > 0 \\Rightarrow \\overline{d}(A) > 0 \\Rightarrow \\text{HasBoundedGaps}(D(A))$."
     },
     {
       "id": "additional-structural",

--- a/src/data/research/problems/erdos-332.json
+++ b/src/data/research/problems/erdos-332.json
@@ -8,20 +8,32 @@
   "problemStatement": {
     "formal": "Let $A\\subseteq \\mathbb{N}$ and $D(A)$ be the set of those numbers which occur infinitely often as $a_1-a_2$ with $a_1,a_2\\in A$. What conditions on $A$ are sufficient to ensure $D(A)$ has bounded gaps?\n\n\n\nPrikry, Tijdeman, Stewart, and others (see the survey articles \\cite{St78} and \\cite{Ti79}) have shown that a sufficient condition is that $A$ has positive density.\n\nOne can also ask what conditions are sufficient for $D(A)$ to have positive density, or for $\\sum_{d\\in D(A)}\\frac{1}{d}=\\infty$, or even just $D(A)\\neq\\emptyset$.",
     "plain": "Let $A\\subseteq \\mathbb{N}$ and $D(A)$ be the set of those numbers which occur infinitely often as $a_1-a_2$ with $a_1,a_2\\in A$. What conditions on $A$ are sufficient to ensure $D(A)$ has bounded gaps?",
-    "whyMatters": []
+    "whyMatters": [
+      "Connects to the Furstenberg correspondence: positive density sets correspond to sets of positive measure in a measure-preserving system, and syndeticity of D(A) follows from Poincaré recurrence in the associated dynamics.",
+      "Sibling of Szemerédi's theorem in the density-forces-structure paradigm: where Szemerédi forces arithmetic progressions, Prikry forces syndetic difference sets — both instances of the same ergodic principle.",
+      "The 'weakest sufficient condition' question is open: zero-density sets (e.g., the primes) sometimes have syndetic D(A), so positive density is not necessary, only sufficient. Determining the optimal condition would clarify how density forces additive structure."
+    ]
   },
   "knownResults": {
-    "proven": [],
-    "open": [],
-    "goal": ""
+    "proven": [
+      "Prikry–Tijdeman–Stewart (1977–78): positive upper density of A implies D(A) has bounded gaps (i.e., is syndetic). Survey references St78 (Stewart, Séminaire Delange-Pisot-Poitou) and Ti79 (Tijdeman, Bicentennial Congress).",
+      "Furstenberg correspondence (1977): positive density sets correspond to positive measure in a measure-preserving system; Prikry's result follows from Poincaré recurrence.",
+      "Bergelson (1985): generalized Prikry's theorem to ℤᵐ-actions, connecting difference set syndeticity to recurrence in ergodic theory."
+    ],
+    "open": [
+      "What is the WEAKEST condition on A guaranteeing D(A) has bounded gaps? Specifically: does $\\sum_{a \\in A} 1/a = \\infty$ alone (without positive density) suffice?",
+      "Does $\\overline{d}(A) > 0$ imply $\\sum_{d \\in D(A)} 1/d = \\infty$ (the harmonic thickness conjecture for difference sets)?",
+      "What conditions on A are sufficient just for D(A) ≠ ∅ (weakest possible structural result)?"
+    ],
+    "goal": "Identify the weakest sufficient condition on A ⊆ ℕ guaranteeing that D(A) has bounded gaps (is syndetic). Positive upper density is the best known sufficient condition, but the optimal threshold is unknown."
   },
   "currentState": {
     "phase": "COMPLETED",
     "since": "2026-03-28T09:00:00Z",
     "iteration": 4,
-    "focus": "Graduated: formalization complete (0 sorries, 3 deep axioms)",
+    "focus": "Graduated: formalization complete (0 sorries, 1 deep axiom: Prikry's theorem)",
     "blockers": [],
-    "nextAction": "None — all provable structural results formalized. Remaining 3 axioms are deep published results.",
+    "nextAction": "None — all provable structural results formalized. The single remaining axiom (positive_density_bounded_gaps) is the deep Prikry–Tijdeman–Stewart theorem; full proof would require Furstenberg correspondence and ergodic-theoretic recurrence machinery not yet available in Mathlib.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,7 +41,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: 20 theorems, 3 deep axioms, 0 sorries. Complete D(A) characterization: empty↔finite, nonempty↔infinite, syndetic↔positive density. Full implication chain proved. Axioms: positive_density_bounded_gaps (Prikry), positive_density_diffset_dense, diffSet_harmonic_diverges — all deep additive combinatorics results.",
+    "progressSummary": "COMPLETED: 20 theorems, 1 deep axiom (Prikry's theorem), 0 sorries. Complete D(A) characterization: empty↔finite, nonempty↔infinite, syndetic⟸positive density. Full implication chain density → infinite → D(A) nonempty → D(A) syndetic. The single axiom is positive_density_bounded_gaps (Prikry–Tijdeman–Stewart, 1977–78), a deep additive-combinatorics result.",
     "builtItems": [
       "Assessment: all 3A appropriate and deep",
       "Proved diffSet_mono in Erdos332Problem.lean:102",
@@ -53,8 +65,8 @@
       "Graduated problem to completed status (iteration 4)"
     ],
     "insights": [
-      "3 axioms all deep: positive_density_bounded_gaps (Furstenberg), positive_density_diffset_dense (additive combinatorics), diffSet_harmonic_diverges. None provable from Mathlib.",
-      "2 theorems proved, 0 sorries. File is clean but minimal.",
+      "Single axiom is deep: positive_density_bounded_gaps (Prikry–Tijdeman–Stewart, follows from Furstenberg correspondence + Poincaré recurrence). Not currently provable from Mathlib.",
+      "20 theorems proved, 0 sorries. File is clean and structurally complete.",
       "Proved diffSet_mono: monotonicity A ⊆ B → D(A) ⊆ D(B) via subset transfer on infinite fibres",
       "Proved diffSet_finite_eq_empty: D(A) = ∅ for finite A using Set.Finite.prod bound",
       "Proved lower_density_implies_upper: liminf > 0 → limsup > 0, connects density definitions",
@@ -64,7 +76,7 @@
       "Proved positive_upper_density_infinite: positive upper density → A infinite via Archimedean contradiction on bounded countingFn",
       "Completed full implication chain: density → infinite → D(A) nonempty → D(A) syndetic",
       "Added countingFn_le: elementary bound countingFn A N ≤ N",
-      "Graduation review: 3 axioms verified as deep results (Prikry-Furstenberg for bounded gaps, density transfer for D(A), harmonic divergence). All structural/combinatorial results that follow from definitions alone are proved."
+      "Graduation review: single axiom verified as the deep Prikry–Tijdeman–Stewart result (positive density → bounded gaps via Furstenberg correspondence and Poincaré recurrence). All structural/combinatorial results that follow from definitions alone are proved."
     ],
     "mathlibGaps": [],
     "nextSteps": [],
@@ -75,8 +87,7 @@
   ],
   "relatedProofs": [
     "erdos-3",
-    "erdos-33",
-    "erdos-332"
+    "erdos-33"
   ],
   "references": {
     "papers": [],
@@ -91,7 +102,7 @@
     {
       "path": "Proofs/Erdos332Problem.lean",
       "filename": "Erdos332Problem.lean",
-      "lineCount": 255,
+      "lineCount": 254,
       "theoremCount": 20,
       "axiomCount": 1,
       "defCount": 6,


### PR DESCRIPTION
## Summary

Reconciles metadata drift in `src/data/proofs/erdos-332/meta.json` and `src/data/research/problems/erdos-332.json` against the current `Erdos332Problem.lean` (254 lines, 20 theorems, 1 axiom, 0 sorries).

The metadata referred to an earlier 154-line / 3-axiom version. Per CLAUDE.md memory, "Reconciling metadata is high-value pure-text work when disk is too low for builds" — disk is currently at 97% capacity (498Mi free), so Docker builds are unavailable.

## Changes (no Lean code changes)

**`meta.json`**:
- `overview.text`: "A 154-line formalization" → "A 254-line formalization", with updated theorem inventory
- `originalContributions`: clarified that only Prikry's theorem is axiomatized (the "density inheritance" and "harmonic thickness" mentions referred to comments, not axioms)
- `sections[].startLine/endLine`: fixed stale ranges for difference-set, bounded-gaps, density-conditions, known-results, structural-properties to match current file structure
- Removed duplicate sections `main-problem` (134-144) and `related-questions` (146-154) which overlapped with `main-problem-definition` (240-254)
- Merged content from `iff-characterizations` into `structural-properties` to match actual file organization
- known-results section: "Two axioms" → "One axiom (Prikry–Tijdeman–Stewart)"

**`research/problems/erdos-332.json`**:
- Populated empty `problemStatement.whyMatters` with Furstenberg-correspondence framing (3 entries)
- Populated empty `knownResults`: 3 proven (Prikry-Tijdeman-Stewart, Furstenberg, Bergelson), 3 open (weakest condition, harmonic thickness, D(A)≠∅ threshold), and a goal statement
- Updated `currentState.focus` and `nextAction` from "3 deep axioms" to "1 deep axiom: Prikry's theorem"
- Updated `knowledge.progressSummary` and `knowledge.insights` to reflect actual single-axiom state
- Removed self-reference `erdos-332` from `relatedProofs` (kept `erdos-3`, `erdos-33`)
- Fixed `leanFiles[0].lineCount` 255 → 254 (off by one)

## Test plan

- [x] Both JSON files validate with `python3 -m json.tool`
- [x] meta.json `axiomCount` (1) matches actual `grep -c "^axiom " Erdos332Problem.lean`
- [x] meta.json `lineCount` (254) matches `wc -l Erdos332Problem.lean`
- [x] meta.json `theoremCount` (20) matches `grep -c "^theorem \|^lemma "` actual count
- [x] meta.json `definitionCount` (6) matches `grep -c "^def \|^noncomputable def "` actual count
- [x] meta.json `sorries` (0) matches actual code (no `sorry` keywords)
- [x] All section line numbers point to existing content in current file
- [ ] Gallery page renders correctly (cannot verify locally due to disk constraints; relies on CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)