### PR TITLE
research(erdos-105-oq-05): mark MATURE-VERIFIED — fix empty fields/stale state

### DIFF
--- a/src/data/research/problems/erdos-105-oq-05.json
+++ b/src/data/research/problems/erdos-105-oq-05.json
@@ -1,31 +1,48 @@
 {
   "slug": "erdos-105-oq-05",
   "title": "Does the analogous problem in $\\mathbb{R}^d$ for $d \\geq 3$ (rich 2-flats avo...",
-  "phase": "ACT",
-  "status": "in-progress",
+  "phase": "MATURE-VERIFIED",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {
     "formal": "\\text{(formal statement to be added)}",
     "plain": "Formal mathematical investigation: Does the analogous problem in $\\mathbb{R}^d$ for $d \\geq 3$ (rich 2-flats avo....",
-    "whyMatters": []
+    "whyMatters": [
+      "Generalizes the Erdos-Purdy R^2 rich-line / obstacle problem to higher dimensions",
+      "Tests whether the Beck-Szemeredi-Trotter style result (cn obstacles suffice) is fundamentally 2-dimensional",
+      "Counterexamples in low dimensions lift to higher dimensions by embedding, so the question is whether the threshold n-(d+1) is tight",
+      "Connects discrete geometry, incidence bounds, and affine subspace arrangements"
+    ]
   },
   "knownResults": {
-    "proven": [],
-    "open": [],
-    "goal": ""
+    "proven": [
+      "rich_line_exists_d: any 2+ points in R^d have a rich line (proved trivially)",
+      "higher_dim_d2_is_original: d=2 case matches the original Erdos-Purdy framing (proved)",
+      "unblocked_monotone_line: line obstacle-monotonicity in any dimension (proved)",
+      "unblocked_monotone_twoflat: 2-flat obstacle-monotonicity in any dimension (proved)"
+    ],
+    "open": [
+      "higherDimLineConjecture (stated as Prop): does the rich-unblocked line phenomenon generalize to R^d?",
+      "richTwoFlatConjecture (stated as Prop): does the rich-unblocked 2-flat version hold?",
+      "counterexample_lifts (stated as Prop): does a counterexample in R^d lift to R^{d+1}?"
+    ],
+    "goal": "Achieved: 0-axiom 0-sorry formalization of the higher-dimensional framework with conjectures stated as Prop. Future progress requires resolving the conjectures themselves."
   },
   "currentState": {
-    "phase": "ACT",
-    "since": "2026-03-30T01:04:30.788Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
-    "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "phase": "MATURE-VERIFIED",
+    "since": "2026-04-27T00:00:00Z",
+    "iteration": 2,
+    "focus": "Lean source proofs/Proofs/Erdos105OQ05.lean (206 lines, 4 theorems, 9 definitions, 0 axioms, 0 sorries) is complete: definitions of LineD/TwoFlat structures in R^d, two proved generalization theorems, two obstacle-monotonicity lemmas, and the open conjectures stated as Prop (higherDimLineConjecture, richTwoFlatConjecture, counterexample_lifts).",
+    "blockers": [
+      "Resolving the higherDimLineConjecture in R^d for d >= 3 is the main open mathematical question",
+      "The obstacle-threshold n-(d+1) is conjectural; a tight version would require Beck-Szemeredi-Trotter style incidence bounds in higher dimensions"
+    ],
+    "nextAction": "Hold at MATURE-VERIFIED status. Future enrichment ideas: (a) constructive counterexamples for d=3 to confirm the lifting conjecture; (b) connect to the erdos-105 main entry once that is at compatible maturity.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
@@ -84,12 +101,18 @@
     "erdos-1059-oq-05"
   ],
   "references": {
-    "papers": [],
-    "urls": [],
-    "mathlib": []
+    "papers": [
+      "Erdos, P. and Purdy, G. (1995): original lattice/incidence problem source for Erdos #105"
+    ],
+    "urls": [
+      "https://erdosproblems.com/105"
+    ],
+    "mathlib": [
+      "Mathlib.Analysis.InnerProductSpace.EuclideanDist (EuclideanSpace)"
+    ]
   },
   "started": "2026-03-30T01:04:30.788Z",
-  "lastUpdate": "2026-03-30T01:04:30.788Z",
+  "lastUpdate": "2026-04-27T00:00:00Z",
   "significance": 8,
   "tractability": 5,
   "leanFiles": [


### PR DESCRIPTION
## Summary

The Lean source `proofs/Proofs/Erdos105OQ05.lean` (206 lines, **4 theorems, 9 definitions, 0 axioms, 0 sorries**) is at the appropriate maturity for the open higher-dimensional Erdős-Purdy generalization: definitions of LineD/TwoFlat structures in R^d, two proved generalization theorems, two obstacle-monotonicity lemmas, and the open conjectures stated as `Prop` (higherDimLineConjecture, richTwoFlatConjecture, counterexample_lifts).

The metadata in `src/data/research/problems/erdos-105-oq-05.json` had multiple drifts:

| Field | Was | Now |
|---|---|---|
| top-level `phase` / `status` | `ACT` / `in-progress` | `MATURE-VERIFIED` / `completed` |
| `whyMatters` | `[]` | 4 substantive bullets |
| `knownResults.proven` | `[]` | 4 named theorems |
| `knownResults.open` | `[]` | 3 conjectures (stated as Prop) |
| `knownResults.goal` | `""` | "Achieved 0-axiom 0-sorry formalization..." |
| `currentState.focus` | "Initial exploration of the problem." | concrete summary of the verified content |
| `currentState.nextAction` | "Begin problem exploration." | "Hold at MATURE-VERIFIED status; future enrichment ideas" |
| `references.papers/urls/mathlib` | all `[]` | Erdos-Purdy 1995, erdosproblems.com/105, EuclideanSpace |
| `lastUpdate` | 2026-03-30 (stale) | 2026-04-27 |

These contradicted the file's own `knowledge.progressSummary`: "COMPLETED: Formalized higher-dimensional generalization (0A, 0S). 4 theorems proved..."

## What is NOT changed

The `leanFiles` array contains a long list of **unrelated** `Erdos1050..1059*` files due to an apparent slug-match bug (`erdos-105` matching `erdos-105*`). Fixing this properly requires changing the generator script, not just this entry, so it is left alone here. A separate PR / Mechanic pass should address the slug-prefix matcher.

No changes to the Lean source or gallery `meta.json`. The gallery `meta.json` itself shows `status: axiomatized` / `badge: axiom` despite the file having 0 axioms — that is a separate gallery audit issue, not in scope.

## Test plan

- [x] JSON validity verified with `node -e "JSON.parse(...)"`
- [x] No Lean source changed
- [x] Gallery `meta.json` not touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)