### PR TITLE
research(ballot-problem-oq-03-oq-01-oq-02): reconcile leanFiles stats

### DIFF
--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
@@ -241,7 +241,6 @@
     "ballot-problem-oq-03-oq-01",
     "ballot-problem-oq-03-oq-01-oq-01",
     "ballot-problem-oq-03-oq-01-oq-01-oq-01",
-    "ballot-problem-oq-03-oq-01-oq-02",
     "ballot-problem-oq-03-oq-01-oq-04",
     "ballot-problem-oq-03-oq-02",
     "ballot-problem-oq-03-oq-03"
@@ -431,22 +430,22 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",
       "filename": "BallotProblemOQ03OQ01OQ02.lean",
-      "lineCount": 5506,
+      "lineCount": 14005,
       "theoremCount": 64,
       "axiomCount": 0,
       "defCount": 10,
-      "sorryCount": 11,
+      "sorryCount": 3,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean"
     },
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Aristotle.lean",
-      "lineCount": 114,
+      "lineCount": 113,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 4,
+      "sorryCount": 3,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ01OQ02Aristotle.lean"
     },


### PR DESCRIPTION
## Summary

Reconciles stale leanFiles entries in the research JSON for `ballot-problem-oq-03-oq-01-oq-02`. The main file has grown from 5506 to 14005 lines while sorries dropped from 11 to 3 — these values are already correct in `meta.json` but were never propagated to the research JSON.

Per CLAUDE.md memory: "Reconciling metadata is high-value pure-text work when disk is too low for builds." Disk currently at 99% (~221Mi free), so Docker builds are unavailable.

## Changes (no Lean code changes)

- `BallotProblemOQ03OQ01OQ02.lean`: `lineCount` 5506 → 14005, `sorryCount` 11 → 3
- `BallotProblemOQ03OQ01OQ02Aristotle.lean`: `lineCount` 114 → 113, `sorryCount` 4 → 3
- Removed self-reference `ballot-problem-oq-03-oq-01-oq-02` from `relatedProofs` (kept 14 sibling references)

## Verification

Counts verified by parsing the Lean files directly (stripping block/line comments and matching standalone `sorry` tokens). Values now match the authoritative `src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json`.

## Test plan

- [x] JSON validates with `python3 -m json.tool`
- [x] `lineCount` matches `wc -l` on actual files
- [x] `sorryCount` matches comment-stripped sorry count
- [x] No self-reference in `relatedProofs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)