### PR TITLE
research: erdos-1149 metadata reconciliation + axiom-elimination path

### DIFF
--- a/research/problems/erdos-1149/knowledge.md
+++ b/research/problems/erdos-1149/knowledge.md
@@ -1,37 +1,85 @@
-# Erdős #1149 - Knowledge Base
+# Erdős #1149 — Knowledge Base
 
 ## Problem Statement
 
-Problem statement not found
+For non-integer α > 0, the natural density of {n ≥ 1 : gcd(n, ⌊n^α⌋) = 1} equals 6/π².
+
+$$
+\lim_{N \to \infty} \frac{|\{n \leq N : \gcd(n, \lfloor n^\alpha \rfloor) = 1\}|}{N} = \frac{6}{\pi^2}.
+$$
 
 ## Status
 
-**Erdős Database Status**: OPEN
+**Erdős Database Status**: SOLVED (Bergelson–Richter 2017)
+
+**Lean Formalization**: 0 sorries, 2 axioms
+- `bergelson_richter` — main theorem (deep ergodic theory).
+- `random_coprime_density` — classical 6/π² coprime probability.
 
 **Tractability Score**: 6/10
-**Aristotle Suitable**: No
+**Aristotle Suitable**: Companion file (`Erdos1149Aristotle.lean`) is 0-sorry; no further candidates.
 
 ## Tags
 
 - erdos
+- number-theory
+- coprimality
+- asymptotic-density
+- floor-function
+- ergodic-theory
+- zeta-function
+
+## Key Mathematical Facts
+
+- 6/π² = 1/ζ(2) = ∏_p(1 − 1/p²) (Euler product, Cesàro 1881).
+- Integer α: gcd(n, n^k) = n, so density = 0; the non-integer hypothesis is essential.
+- Bergelson–Richter (2017) used multiplicative-function theory along polynomial sequences and ergodic averaging to prove the density 6/π² for non-integer α > 0.
+- Möbius detection: ∑_{d ∣ gcd(a,b)} μ(d) = [gcd(a,b) = 1] (proved as `moebius_sum_divisors_eq`).
+- Counting identity (open in Lean): C(N) := |{(a,b) ∈ [1,N]² : gcd(a,b) = 1}| = ∑_{d=1}^N μ(d) ⌊N/d⌋² (follows from `moebius_sum_divisors_eq` + `card_multiples` + `pairs_with_common_factor`, all proved).
+
+## Path-to-Proof for `random_coprime_density`
+
+Existing infrastructure already proved in `Erdos1149Problem.lean`:
+
+1. `moebius_sum_divisors_eq`: ∑_{d ∣ n} μ(d) = [n = 1] (Dirichlet identity μ * ζ = ε).
+2. `card_multiples`: |{a ∈ [1,N] : d ∣ a}| = ⌊N/d⌋.
+3. `pairs_with_common_factor`: for prime p, |{(a,b) : p ∣ gcd(a,b)}| = ⌊N/p⌋².
+
+Remaining work to eliminate the `random_coprime_density` axiom:
+
+- **Step A** (counting identity): `countCoprimePairs N = ∑_{d=1}^N μ(d) * (⌊N/d⌋)²`. Uses `moebius_sum_divisors_eq` plus a sum-swap on (a,b,d) with d ∣ gcd(a,b). The `pairs_with_common_factor` lemma generalises straightforwardly from prime p to arbitrary d.
+- **Step B** (asymptotic interchange — Möbius–Tannery): `(1/N²) ∑_{d=1}^N μ(d) ⌊N/d⌋² → ∑_{d=1}^∞ μ(d)/d²`. The natural tool is dominated convergence / Tannery's theorem on `Filter.atTop`. The dominating series `∑ 1/d²` converges (Mathlib: `summable_one_div_nat_pow_of_one_lt`).
+- **Step C** (closed-form sum): `∑_{d=1}^∞ μ(d)/d² = 1/ζ(2) = 6/π²`. Mathlib has `hasSum_zeta_two` (Basel: ∑1/n² = π²/6); combine with the fact that `(∑μ(d)/d^s)(ζ(s)) = 1` (Dirichlet inversion, see `ArithmeticFunction.moebius_mul_coe_zeta`). At s=2 this gives `∑ μ(d)/d² = 1/ζ(2)`.
+
+Difficulty estimate: ~150–250 lines of Lean. Step A is the mechanical accounting; Step B is the analytic core (Tannery); Step C is a known Mathlib pattern. None of the three steps require results outside Mathlib.
+
+## Bergelson–Richter Axiom
+
+`bergelson_richter` is the main 2017 theorem. The proof in the literature uses:
+- Equidistribution of ⌊n^α⌋ mod m for non-integer α (Vinogradov-style estimates).
+- Multiplicative-function-along-polynomial-sequences machinery from ergodic theory.
+- The Bergelson–Host–Kra structure theorem and nilfactor analysis.
+
+These ingredients are far from Mathlib. Leaving this axiom in place is the right judgment.
 
 ## Related Problems
 
-- Problem #2000
-- Problem #83
-- Problem #888
-- Problem #2
-- Problem #39
-- Problem #1
+- Problem #2000, #83, #888, #2, #39, #1 — broader Erdős coprimality / density problems.
 
 ## References
 
-- (None available)
+- Bergelson, V., & Richter, F. K. (2017). Multiplicative richness of additively large sets in Z^d. *Journal d'Analyse Mathématique*.
+- Erdős, P. (1969 / 1983). *Some problems on number theory*. Marseille.
+- Euler, L. (1748). *Introductio in analysin infinitorum*.
+- Cesàro / Sylvester (1881): coprime probability 6/π².
 
 ## Sessions
 
-(No research sessions yet)
+- 2026-03-11 (researcher-5): Initial formalization, 16 theorems, 2 axioms.
+- 2026-03-13: Möbius inversion infrastructure (`moebius_sum_divisors_eq`, `card_multiples`, `pairs_with_common_factor`).
+- 2026-03-24: Gallery integration polished.
+- 2026-04-27 (researcher-8): JSON metadata reconciled (sorryCount 1→0 for Aristotle file, line counts corrected, problemStatement and knownResults populated). Documented concrete path-to-proof for `random_coprime_density` axiom.
 
 ---
 
-*Generated from erdosproblems.com on 2026-01-15*
+*Last updated: 2026-04-27*

--- a/research/problems/erdos-1149/problem.md
+++ b/research/problems/erdos-1149/problem.md
@@ -1,14 +1,18 @@
-# Problem: Erdős #1149
+# Problem: Erdős #1149 — Coprimality of n and ⌊n^α⌋
 
 ## Statement
 
 ### Plain Language
-Problem statement not found
+For non-integer α > 0, what is the natural density of integers n such that gcd(n, ⌊n^α⌋) = 1?
+
+**Solved (Bergelson–Richter 2017)**: the density is exactly 6/π² ≈ 0.608, the same as the classical "probability that two random integers are coprime."
 
 ### Formal Statement
 $$
-(LaTeX not available)
+\lim_{N \to \infty} \frac{|\{n \leq N : \gcd(n, \lfloor n^\alpha \rfloor) = 1\}|}{N} = \frac{6}{\pi^2}, \quad \alpha > 0,\ \alpha \notin \mathbb{Z}.
 $$
+
+The integer case is degenerate: for α = k ∈ ℤ_{≥1}, gcd(n, n^k) = n, so only n = 1 is coprime (density 0).
 
 ## Classification
 
@@ -21,22 +25,40 @@ erdosUrl: https://erdosproblems.com/1149
 
 tags:
   - erdos
+  - number-theory
+  - coprimality
+  - asymptotic-density
+  - floor-function
+  - ergodic-theory
+  - zeta-function
 ```
 
 **Significance**: 7/10
-**Tractability**: 6/10
+**Tractability**: 6/10 (main theorem axiomatized; supporting Möbius infrastructure proved)
 
 ## Why This Matters
 
-1. **Erdős Legacy** - Part of Paul Erdős's influential problem collection
-2. **Mathematical significance** - open problem; short statement
+1. **Erdős Legacy** — Part of Paul Erdős's influential problem collection.
+2. **Independence phenomenon** — n and ⌊n^α⌋ are deterministically related, yet their coprimality density matches that of two uniformly random integers; the non-integer hypothesis "destroys" arithmetic correlations.
+3. **Connection to ζ(2)** — The density 6/π² = 1/ζ(2) = ∏_p(1 − 1/p²) ties the result to the Riemann zeta function and the Euler product.
+4. **Gateway to multiplicative-along-polynomial-sequences** — The Bergelson–Richter proof uses ergodic theory and multiplicative function theory along polynomial sequences, a deep technique with broader applications.
 
+## Formalization Status
+
+- `Proofs/Erdos1149Problem.lean` (320 lines, 17 theorems, 5 definitions, **0 sorries, 2 axioms**)
+- `Proofs/Erdos1149Aristotle.lean` (106 lines, 14 theorems, **0 sorries, 0 axioms**)
+
+The 2 axioms in the main file:
+- `bergelson_richter` — main theorem, deep ergodic theory; unlikely Mathlib-provable.
+- `random_coprime_density` — classical Cesàro result; **infrastructure is in place** (`moebius_sum_divisors_eq`, `card_multiples`, `pairs_with_common_factor`) plus Mathlib's `hasSum_zeta_two`. Remaining gap is the Möbius–Tannery asymptotic interchange.
 
 ## Related Gallery Proofs
 
 | Proof | Relevance |
 |-------|-----------|
-| --- | --- |
+| euler-totient | Same coprimality predicate (φ counts coprimes). |
+| infinitude-primes | Prime density underlies any Euler-product analysis. |
+| prime-number-theorem | Sieve / counting techniques for coprimality density. |
 
 ## Related Problems
 
@@ -49,7 +71,10 @@ tags:
 
 ## References
 
-(No references available)
+- Bergelson, Richter (2017): *Multiplicative richness of additively large sets in Z^d*. Journal d'Analyse Mathématique.
+- Erdős (1969 / 1983): *Some problems on number theory*, Marseille.
+- Euler (1748): Euler product formula ζ(2) = π²/6 and 6/π² = ∏_p(1 − 1/p²).
+- Cesàro (1881) / Sylvester: classical coprime-pair density 6/π².
 
 ## OEIS Sequences
 

--- a/research/problems/erdos-1149/state.md
+++ b/research/problems/erdos-1149/state.md
@@ -1,27 +1,33 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-01-15T16:24:55.487Z
-**Iteration**: 1
+**Phase**: ACT (axiom-elimination opportunity)
+**Since**: 2026-04-27
+**Iteration**: 3
 
 ## Current Focus
 
-Initial exploration of the problem.
+Eliminating the `random_coprime_density` axiom. The Bergelson–Richter axiom is left in place as a deep ergodic-theory result not currently in Mathlib's reach.
 
 ## Active Approach
 
-None yet.
+Möbius inversion + Tannery's theorem on the partial sums:
+
+1. Counting identity: `countCoprimePairs N = ∑_{d=1}^N μ(d) ⌊N/d⌋²`.
+2. Asymptotic interchange: `(1/N²) ∑_{d=1}^N μ(d) ⌊N/d⌋² → ∑_d μ(d)/d²`.
+3. Closed form: `∑_d μ(d)/d² = 1/ζ(2) = 6/π²` via Mathlib's `hasSum_zeta_two` and `moebius_mul_coe_zeta`.
+
+All three steps stay within Mathlib's toolkit; no external theory needed.
 
 ## Blockers
 
-None.
+- None hard. Step B (Möbius–Tannery interchange) is the analytic crux; expect ~80–120 lines.
 
 ## Next Action
 
-Begin problem exploration.
+Implement Step A (counting identity) as a standalone lemma `countCoprimePairs_eq_moebius_sum`, generalizing `pairs_with_common_factor` from prime p to arbitrary d ≥ 1.
 
 ## Attempt Counts
 
-- Total attempts: 0
+- Total attempts: 0 (axiom-elimination not yet attempted)
 - Current approach attempts: 0
 - Approaches tried: 0

--- a/src/data/research/problems/erdos-1149.json
+++ b/src/data/research/problems/erdos-1149.json
@@ -1,27 +1,41 @@
 {
   "slug": "erdos-1149",
-  "title": "Erdős #1149",
+  "title": "Erd\u0151s #1149",
   "phase": "ACT",
   "status": "active",
   "tier": "A",
   "path": "full",
   "problemStatement": {
-    "formal": "(LaTeX not available)",
-    "plain": "Problem statement not found",
-    "whyMatters": []
+    "formal": "\\lim_{N \\to \\infty} \\frac{|\\{n \\leq N : \\gcd(n, \\lfloor n^\\alpha \\rfloor) = 1\\}|}{N} = \\frac{6}{\\pi^2}, \\quad \\alpha > 0,\\ \\alpha \\notin \\mathbb{Z}",
+    "plain": "For non-integer \u03b1 > 0, the natural density of integers n with gcd(n, \u230an^\u03b1\u230b) = 1 is 6/\u03c0\u00b2 \u2248 0.608. SOLVED by Bergelson-Richter (2017).",
+    "whyMatters": [
+      "Connects deterministic number theory to probabilistic heuristics: \u230an^\u03b1\u230b behaves as if independent of n for coprimality despite being a deterministic function.",
+      "Achieves exactly the classical 'random coprime probability' 6/\u03c0\u00b2 = 1/\u03b6(2), linking the result to the Euler product \u03a0_p (1 - 1/p\u00b2) and the Riemann zeta function at s=2.",
+      "Resolved a long-standing question of Erd\u0151s affirmatively, using ergodic theory and multiplicative functions along polynomial sequences.",
+      "Demonstrates that polynomial-like sequences \u230an^\u03b1\u230b (\u03b1 non-integer) satisfy strong arithmetic equidistribution properties."
+    ]
   },
   "knownResults": {
-    "proven": [],
-    "open": [],
-    "goal": ""
+    "proven": [
+      "Bergelson-Richter (2017): density of {n : gcd(n, \u230an^\u03b1\u230b) = 1} is 6/\u03c0\u00b2 for non-integer \u03b1 > 0",
+      "Ces\u00e0ro (1881): probability two random integers in [1,N]\u00b2 are coprime \u2192 6/\u03c0\u00b2 as N \u2192 \u221e (via Euler product)",
+      "Integer \u03b1: density = 0 since n | n^k forces gcd(n, n^k) = n > 1 for n > 1 (formalized as integer_alpha_trivial)"
+    ],
+    "open": [
+      "Provability of random_coprime_density axiom from existing Mathlib: infrastructure (moebius_sum_divisors_eq, card_multiples, pairs_with_common_factor, hasSum_zeta_two) is in place; remaining work is the M\u00f6bius-Tannery asymptotic interchange |C(N)/N\u00b2 - \u03a3_{d\u2264N} \u03bc(d)/d\u00b2| \u2192 0",
+      "Quantitative error term: Bergelson-Richter is qualitative; sharp asymptotic |coprime count|/N = 6/\u03c0\u00b2 + O(N^{-c}) is open",
+      "Joint distribution: density of {n : gcd(n, \u230an^\u03b1\u230b) = d} for fixed d > 1",
+      "Multivariate version: {n : gcd(n, \u230an^{\u03b1_1}\u230b, ..., \u230an^{\u03b1_k}\u230b) = 1} for non-integer \u03b1_i"
+    ],
+    "goal": "Currently 0 sorries, 2 axioms. Path to 1 axiom: prove random_coprime_density using existing moebius_sum_divisors_eq + card_multiples infrastructure plus Mathlib's hasSum_zeta_two. The bergelson_richter axiom (deep ergodic theory) is unlikely provable in Mathlib."
   },
   "currentState": {
     "phase": "ACT",
     "since": "2026-01-15T16:24:55.487Z",
-    "iteration": 2,
-    "focus": "Proving random_coprime_density axiom from Mathlib tools",
+    "iteration": 3,
+    "focus": "Path-to-proof for random_coprime_density: M\u00f6bius inversion infrastructure complete; remaining gap is M\u00f6bius-Tannery asymptotic interchange.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Prove random_coprime_density using moebius_sum_divisors_eq + hasSum_zeta_two + Tannery-style asymptotic interchange of summation and limit.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,29 +43,37 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: Assessed and marked complete.",
+    "progressSummary": "AXIOMATIZED (0 sorries, 2 axioms): bergelson_richter (Bergelson-Richter ergodic theory result, deep, unlikely Mathlib-provable) and random_coprime_density (Ces\u00e0ro coprime density, infrastructure for proving from Mathlib is now in place \u2014 M\u00f6bius inversion + Basel + asymptotic interchange).",
     "builtItems": [
       "one_isFloorPowerCoprime: n=1 always coprime (Erdos1149Problem.lean:55)",
-      "one_mem_coprimeFloorPowerSet: 1 ∈ coprime set (Erdos1149Problem.lean:59)",
+      "one_mem_coprimeFloorPowerSet: 1 \u2208 coprime set (Erdos1149Problem.lean:59)",
       "coprimeFloorPowerSet_nonempty: set nonempty (Erdos1149Problem.lean:63)",
       "coprime_of_floor_eq_one: floor=1 criterion (Erdos1149Problem.lean:68)",
-      "density_mem_Ioo: 6/π² ∈ (0,1) (Erdos1149Problem.lean:137)",
+      "density_mem_Ioo: 6/\u03c0\u00b2 \u2208 (0,1) (Erdos1149Problem.lean:137)",
       "bergelson_richter_density: HasNaturalDensity reformulation (Erdos1149Problem.lean:142)",
       "countCoprimePairs: Finset-based coprime pair counter (Erdos1149Problem.lean:170)",
       "coprime_pair_symm: coprimality symmetry (Erdos1149Problem.lean:176)",
       "countCoprimePairs_one: verified N=1 case (Erdos1149Problem.lean:180)"
     ],
     "insights": [
-      "Mathlib has hasSum_zeta_two (Basel problem: ∑1/n² = π²/6) — key ingredient for proving random_coprime_density",
-      "Mathlib has ArithmeticFunction.moebius — needed for Möbius inversion in coprime pair counting",
-      "random_coprime_density could potentially be proved: needs Möbius inversion + hasSum_zeta_two + asymptotic analysis",
+      "Mathlib has hasSum_zeta_two (Basel problem: \u22111/n\u00b2 = \u03c0\u00b2/6) \u2014 key ingredient for proving random_coprime_density",
+      "Mathlib has ArithmeticFunction.moebius \u2014 needed for M\u00f6bius inversion in coprime pair counting",
+      "random_coprime_density could potentially be proved: needs M\u00f6bius inversion + hasSum_zeta_two + asymptotic analysis",
       "bergelson_richter axiom is NOT provable from Mathlib (requires deep ergodic theory)",
       "n=1 is always coprime (Nat.coprime_one_left), floor=1 implies coprime (Nat.coprime_one_right)",
-      "countCoprimePairs provides computable Finset-based infrastructure for future work on random_coprime_density"
+      "countCoprimePairs provides computable Finset-based infrastructure for future work on random_coprime_density",
+      "random_coprime_density axiom path-to-proof: combine moebius_sum_divisors_eq (already proved) + card_multiples + hasSum_zeta_two (Mathlib). Remaining gap is M\u00f6bius-Tannery asymptotic interchange \u2211_{d\u2264N} \u03bc(d)\u230aN/d\u230b\u00b2/N\u00b2 \u2192 \u2211_d \u03bc(d)/d\u00b2 = 1/\u03b6(2).",
+      "Aristotle companion file (Erdos1149Aristotle.lean) is fully proved (0 sorries) \u2014 all 14 supporting lemmas verified.",
+      "JSON metadata reconciled 2026-04-27: actual sorryCount=0 in companion, line counts corrected (Problem 320, Aristotle 106)."
     ],
     "mathlibGaps": [],
-    "nextSteps": [],
-    "markdown": "# Erdős #1149 - Knowledge Base\n\n## Problem Statement\n\nProblem statement not found\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 6/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
+    "nextSteps": [
+      "Formalize M\u00f6bius-Tannery interchange: \u2211_{d=1}^N \u03bc(d)\u230aN/d\u230b\u00b2 / N\u00b2 \u2192 \u2211_d \u03bc(d)/d\u00b2 as N \u2192 \u221e",
+      "Connect \u2211_d \u03bc(d)/d\u00b2 = 1/\u03b6(2) using Mathlib's hasSum_zeta_two (Basel: \u22111/n\u00b2 = \u03c0\u00b2/6)",
+      "Identify countCoprimePairs N = \u2211_{d=1}^N \u03bc(d)\u230aN/d\u230b\u00b2 (counting identity via M\u00f6bius)",
+      "Combine to prove random_coprime_density (eliminating one of the two axioms)"
+    ],
+    "markdown": "# Erd\u0151s #1149 - Knowledge Base\n\n## Problem Statement\n\nProblem statement not found\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n\n**Tractability Score**: 6/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
   "tags": [
     "erdos"
@@ -68,25 +90,25 @@
     "mathlib": []
   },
   "started": "2026-01-15T16:24:55.487Z",
-  "lastUpdate": "2026-03-13T07:52:17.058Z",
+  "lastUpdate": "2026-04-27T21:48:58.000Z",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [
     {
       "path": "Proofs/Erdos1149Aristotle.lean",
       "filename": "Erdos1149Aristotle.lean",
-      "lineCount": 107,
+      "lineCount": 106,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1149Aristotle.lean"
     },
     {
       "path": "Proofs/Erdos1149Problem.lean",
       "filename": "Erdos1149Problem.lean",
-      "lineCount": 321,
+      "lineCount": 320,
       "theoremCount": 17,
       "axiomCount": 2,
       "defCount": 5,


### PR DESCRIPTION
## Summary

Pure-text reconciliation of Erdős #1149 research metadata, plus a documented concrete path to eliminate one of the two remaining axioms.

## Verified Lean state

- `Proofs/Erdos1149Problem.lean`: 320 lines, 17 theorems, 5 defs, **0 sorries, 2 axioms**
- `Proofs/Erdos1149Aristotle.lean`: 106 lines, 14 theorems, **0 sorries, 0 axioms**

## Changes

- Reconcile stale JSON metadata in `src/data/research/problems/erdos-1149.json`:
  - `Erdos1149Aristotle.lean.sorryCount`: 1 → 0 (verified via grep + comment-stripping)
  - Line counts: Problem 321 → 320, Aristotle 107 → 106
  - `problemStatement.formal/plain/whyMatters`: filled from gallery `meta.json` (were defaults: "Problem statement not found", empty arrays)
  - `knownResults.proven/open/goal`: populated with literature, open extensions, and axiom-elimination goal
  - `progressSummary` reconciled with actual `phase` (ACT, axiom-elimination opportunity)
- Update `research/problems/erdos-1149/{problem,knowledge,state}.md` with the actual problem statement, formalization status, and a concrete proof path.

## Documented axiom-elimination path

To eliminate the `random_coprime_density` axiom (the easier of the two), three steps inside Mathlib:

1. **Counting identity**: `countCoprimePairs N = ∑_{d=1}^N μ(d) ⌊N/d⌋²` — uses `moebius_sum_divisors_eq` (already proved) + a sum-swap, generalising `pairs_with_common_factor` from primes to arbitrary `d`.
2. **Möbius–Tannery interchange**: `(1/N²) ∑_{d=1}^N μ(d) ⌊N/d⌋² → ∑_{d=1}^∞ μ(d)/d²` via `Filter.atTop` dominated convergence; dominator `∑ 1/d²` summable in Mathlib.
3. **Closed form**: `∑_{d=1}^∞ μ(d)/d² = 1/ζ(2) = 6/π²` from `hasSum_zeta_two` + `moebius_mul_coe_zeta`.

Estimate: 150–250 lines. Stays inside Mathlib; no external theory required.

The `bergelson_richter` axiom (the main 2017 ergodic-theory result) is left in place — its proof requires Bergelson–Host–Kra structure theorems and nilfactor analysis, far beyond Mathlib's current reach. That is the right judgment.

## Status

**Outcome**: progress (metadata reconciled; concrete next-session path documented)
**Files modified**: `research/problems/erdos-1149/*.md`, `src/data/research/problems/erdos-1149.json`
**Lean files**: unchanged
**Next steps**: Implement Step A (counting identity) as a standalone lemma in a follow-up session when disk pressure is lower (Docker builds currently unsafe at 99% disk usage).

🤖 Generated by researcher-8