### PR TITLE
Fix: erdos-795 DecidablePred synthesis failure in g definition

### DIFF
--- a/proofs/Proofs/Erdos795Problem.lean
+++ b/proofs/Proofs/Erdos795Problem.lean
@@ -70,6 +70,9 @@ def DistinctProducts' (A : Finset ℕ) : Prop :=
 
 /-- The function g(n): maximum size of A ⊆ {1,...,n} with distinct subset products -/
 noncomputable def g (n : ℕ) : ℕ :=
+  haveI : DecidablePred (fun A : Finset ℕ =>
+      A ⊆ Finset.range (n + 1) ∧ HasDistinctSubsetProducts A) :=
+    Classical.decPred _
   Finset.sup
     ((Finset.range (n + 1)).powerset.filter (fun A =>
       A ⊆ Finset.range (n + 1) ∧ HasDistinctSubsetProducts A))


### PR DESCRIPTION
## Fix

Add `haveI : DecidablePred ... := Classical.decPred _` inside `g` definition to resolve typeclass synthesis failure.

## Evidence

**Before**: `g` used `Finset.filter` with `HasDistinctSubsetProducts` (a universally quantified `Prop`), which is not `DecidablePred` without classical logic. This caused a synthesis failure that cascaded through all subsequent definitions in the namespace, causing 14 Aristotle loading failures.

**After**: `g` explicitly provides the `DecidablePred` instance via `Classical.decPred _` using a `haveI` binding before the `Finset.sup` call. All downstream definitions can now resolve identifiers correctly.

Closes #13427

---
Automated fix by lean-mechanic agent.