### PR TITLE
feat: Aristotle companion for CayleyHamiltonCyclicVectorAllFields

### DIFF
--- a/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsAristotle.lean
+++ b/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsAristotle.lean
@@ -1,0 +1,36 @@
+/-
+  Aristotle targets for CayleyHamiltonCyclicVectorAllFields
+
+  Routine polynomial factorization bridge for automated proof search.
+  See CayleyHamiltonCyclicVectorAllFields.lean for the main formalization.
+
+  Target: monic_factored_form
+  Every monic polynomial of positive degree over a field factors into a finite
+  product of coprime monic irreducible prime powers.
+  This follows from K[X] being a UniqueFactorizationMonoid via normalizedFactors.
+-/
+import Mathlib
+
+namespace CayleyHamiltonCyclicVectorAllFieldsAristotle
+
+open Polynomial UniqueFactorizationMonoid
+
+/-- Every monic polynomial of positive degree over a field factors into a
+    finite product of coprime monic irreducible prime powers.
+
+    Proof sketch:
+    1. normalizedFactors μ gives monic irreducible factors with multiplicity
+    2. Group by distinct primes with exponents via toFinset + count
+    3. Distinct monic irreducibles are coprime (prime → IsCoprime)
+    4. Product equality from normalizedFactors_prod + monicity -/
+theorem monic_factored_form {K : Type*} [Field K]
+    (μ : K[X]) (hμ_monic : μ.Monic) (hμ_deg : 0 < μ.natDegree) :
+    ∃ (k : ℕ) (_ : 0 < k) (p : Fin k → K[X]) (e : Fin k → ℕ),
+      (∀ i, Irreducible (p i)) ∧
+      (∀ i, (p i).Monic) ∧
+      (∀ i, 0 < e i) ∧
+      (∀ i j : Fin k, i ≠ j → IsCoprime (p i ^ e i) (p j ^ e j)) ∧
+      μ = ∏ i : Fin k, p i ^ e i := by
+  sorry
+
+end CayleyHamiltonCyclicVectorAllFieldsAristotle


### PR DESCRIPTION
## Fix

Add Aristotle companion file exposing the `monic_factored_form` sorry from `CayleyHamiltonCyclicVectorAllFields.lean` as a standalone automated proof target.

## Evidence

**Target**: `monic_factored_form` — every monic polynomial of positive degree over a field K factors into a finite product of coprime monic irreducible prime powers.

**Why Aristotle-suitable**: The file's own docstring flags this as "Suitable for Aristotle submission (routine Mathlib API, ~50 lines)" using `UniqueFactorizationMonoid.normalizedFactors`. No axioms, no definition sorries, no open conjectures.

**Pre-submission checks**:
- No `def ... := sorry` ✓
- No `axiom` declarations ✓
- No `theorem ... : True` placeholders ✓
- No `/-!` docstring sections ✓

**Source**: `CayleyHamiltonCyclicVectorAllFields.lean` line 91 — sole sorry in the file.

---
Automated fix by lean-mechanic agent.