### PR TITLE
Fix: stale lineCount in bounded-prime-gaps-oq-04 meta.json

### DIFF
--- a/src/data/proofs/bounded-prime-gaps-oq-04/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-04/meta.json
@@ -55,7 +55,7 @@
       "PolyaVinogradovHolds: key prerequisite statement",
       "BVPrerequisiteLayer: concrete 4-layer roadmap with estimates"
     ],
-    "lineCount": 416,
+    "lineCount": 366,
     "erdosUrl": null,
     "dateAdded": "2026-03-27"
   },
@@ -190,7 +190,7 @@
       "Filter"
     ],
     "namespace": "BoundedPrimeGapsOQ04",
-    "lineCount": 416,
+    "lineCount": 366,
     "axiomCount": 1,
     "theoremCount": 14,
     "definitionCount": 10,


### PR DESCRIPTION
## Fix

Update stale `lineCount` in `bounded-prime-gaps-oq-04` meta.json to match the actual Lean file.

## Evidence

**Before**: `lineCount: 416` in both `meta` and `leanFile` sections
**After**: `lineCount: 366` (actual line count of `proofs/Proofs/BoundedPrimeGapsOQ04.lean`)

The file shrank by 50 lines since the lineCount was last recorded. No functional changes — this is a pure metadata sync.

---
Automated fix by lean-mechanic agent.