### PR TITLE
Fix: sync stale lineCount in 4 gallery meta.json files

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-03/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-03/meta.json
@@ -18,7 +18,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 165,
+    "lineCount": 242,
     "assumptions": "1 axiom: solvableGal_implies_solvableByRad (reverse direction, requires Kummer theory for cyclic extensions not yet in Mathlib).",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-03-27",
@@ -63,7 +63,7 @@
       "Polynomial"
     ],
     "namespace": "GaloisCriterion",
-    "lineCount": 165,
+    "lineCount": 242,
     "axiomCount": 1,
     "theoremCount": 6,
     "definitionCount": 0,

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -23,7 +23,7 @@
     "dateAdded": "2026-04-23",
     "axiomCount": 0,
     "assumptions": "2 sorries remain: (1) jdt_weight_sum — weight-preserving JDT bijection {non-col-strict (a,b)} ≃ {all (a+1,b-1)} (~80 lines); (2) jacobi_trudi_ssyt_eq k≥3 — algebraic LGV + RSK (~300 lines). ssytFin_two_row_eq_sum_colstrict proved (row-decomp bijection, no sorry). ssytSchurFin_two_row main theorem proved. k=0,1,2 proved.",
-    "lineCount": 633,
+    "lineCount": 666,
     "theoremCount": 14,
     "definitionCount": 8,
     "originalContributions": [
@@ -78,7 +78,7 @@
       "Finset"
     ],
     "namespace": "JacobiTrudi",
-    "lineCount": 633,
+    "lineCount": 666,
     "axiomCount": 0,
     "theoremCount": 16,
     "definitionCount": 9,

--- a/src/data/proofs/erdos-1000/meta.json
+++ b/src/data/proofs/erdos-1000/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/1000",
     "erdosProblemStatus": "solved",
     "axiomCount": 2,
-    "lineCount": 1124,
+    "lineCount": 1149,
     "assumptions": "Two deep axioms: erdos_dichotomy (liminf=0 implies limsup=1, via Euler product for φ(n)/n), haight_resolution (vanishing Cesàro average exists, via highly composite construction). erdos_no_zero_limit is now PROVED from erdos_dichotomy (convergence to 0 contradicts dichotomy via frequently-vs-eventually). cassels_liminf_zero is PROVED from haight_resolution. Infrastructure: complement formula, growth bounds, multiplicity bounds, double-counting vocabulary, growth constraints from low density, deficit counting bounds.",
     "mathlib_version": "4.26.0"
   },
@@ -202,7 +202,7 @@
       "Topology"
     ],
     "namespace": "Erdos1000",
-    "lineCount": 1124,
+    "lineCount": 1149,
     "axiomCount": 2,
     "theoremCount": 60,
     "definitionCount": 8,

--- a/src/data/proofs/erdos-1009-oq-02/meta.json
+++ b/src/data/proofs/erdos-1009-oq-02/meta.json
@@ -26,7 +26,7 @@
     "erdosProblemStatus": "open",
     "dateAdded": "2026-04-02",
     "mathlib_version": "4.26.0",
-    "lineCount": 240,
+    "lineCount": 267,
     "axiomCount": 0,
     "assumptions": "Main open question stated as Prop (not asserted true). All supporting theorems fully proved: 0 sorries, 0 axioms. Core Tur\u00e1n bound (turanK4_extremal) uses Mathlib's CliqueFree.card_edgeFinset_le. Open conjecture; supporting lemmas fully verified.",
     "mathlibDependencies": [
@@ -154,7 +154,7 @@
   ],
   "leanFile": {
     "path": "Proofs/Erdos1009OQ02Problem.lean",
-    "lineCount": 240,
+    "lineCount": 267,
     "axiomCount": 0,
     "sorries": 0,
     "theoremCount": 15,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` fields in 4 gallery proof meta.json files to match actual Lean file line counts.

## Evidence

| Proof | meta.lineCount | actual | diff |
|-------|---------------|--------|------|
| `abel-ruffini-oq-04-oq-03` | 165 | 242 | +77 |
| `ballot-problem-oq-03-oq-01-oq-01-oq-01` | 633 | 666 | +33 |
| `erdos-1009-oq-02` | 240 | 267 | +27 |
| `erdos-1000` | 1124 | 1149 | +25 |

Both `meta.lineCount` and `leanFile.lineCount` updated in each file. No changes to Lean proof files, sorry counts, axiom counts, or proof status.

---
Automated fix by lean-mechanic agent.