### PR TITLE
Enrich VC dim of thresholds: line-range fixes + witness-construction annotation

### DIFF
--- a/src/data/proofs/pac-learning-bounds-oq-01/annotations.json
+++ b/src/data/proofs/pac-learning-bounds-oq-01/annotations.json
@@ -3,7 +3,7 @@
     "id": "ann-shatters-def",
     "proofId": "pac-learning-bounds-oq-01",
     "range": {
-      "startLine": 22,
+      "startLine": 20,
       "endLine": 23
     },
     "type": "concept",
@@ -27,7 +27,7 @@
     "id": "ann-threshold-class",
     "proofId": "pac-learning-bounds-oq-01",
     "range": {
-      "startLine": 26,
+      "startLine": 25,
       "endLine": 27
     },
     "type": "concept",
@@ -47,8 +47,8 @@
     "id": "ann-singleton-shatters",
     "proofId": "pac-learning-bounds-oq-01",
     "range": {
-      "startLine": 31,
-      "endLine": 51
+      "startLine": 29,
+      "endLine": 49
     },
     "type": "theorem",
     "title": "Lower Bound: Singletons Are Shattered",
@@ -69,8 +69,8 @@
     "id": "ann-not-shatters-pair",
     "proofId": "pac-learning-bounds-oq-01",
     "range": {
-      "startLine": 54,
-      "endLine": 79
+      "startLine": 51,
+      "endLine": 77
     },
     "type": "theorem",
     "title": "Upper Bound: No Pair Is Shattered",
@@ -90,8 +90,8 @@
     "id": "ann-vcdim-bounds",
     "proofId": "pac-learning-bounds-oq-01",
     "range": {
-      "startLine": 81,
-      "endLine": 93
+      "startLine": 79,
+      "endLine": 92
     },
     "type": "concept",
     "title": "Combined Bound: VC dim = 1",
@@ -105,6 +105,32 @@
     "prerequisites": [
       "Lower bound theorem",
       "Upper bound theorem"
+    ]
+  },
+  {
+    "id": "ann-anonymous-constructor-witness",
+    "proofId": "pac-learning-bounds-oq-01",
+    "range": {
+      "startLine": 36,
+      "endLine": 43
+    },
+    "type": "technique",
+    "title": "Producing Hypothesis Witnesses via `⟨t, rfl⟩`",
+    "content": "Both branches of `threshold_shatters_singleton` use the same Lean idiom to produce a witness in $H_{thr}$:\n\n```lean\nrefine ⟨{x | x < a + 1}, ⟨a + 1, rfl⟩, ?_⟩\n```\n\nThis is a single anonymous constructor application that simultaneously:\n1. Provides the **set** $h = \\{x : x < a+1\\}$ — explicit set comprehension.\n2. Provides the **membership proof** $h \\in H_{thr}$ via the inner anonymous constructor $\\langle a+1, \\mathsf{rfl} \\rangle$, which exhibits $a + 1$ as the witnessing threshold and uses reflexivity (`rfl`) because $h$ was defined to *literally equal* $\\{x : x < a+1\\}$ — no unfolding required.\n3. Leaves the third component (the realization equation) as a metavariable `?_` to be filled by the subsequent tactic block.\n\n**Why `rfl` works here:** The definitional unfolding `thresholdClassifiers = { h | ∃ t, h = { x | x < t } }` reduces membership to an existential. Choosing $h$ already as $\\{x : x < a+1\\}$ makes the equation `{x | x < a + 1} = {x | x < (a+1)}` syntactically identical, so `rfl` discharges it. Had we chosen $h = \\{x : x ≤ a\\}$ instead — equivalent but not syntactically identical — `rfl` would fail and we'd need `Set.ext` plus arithmetic.\n\n**Mathlib idiom prevalence:** This `⟨witness, rfl⟩` pattern is ubiquitous in proofs about subobjects defined by existentials: `Submodule.span`, `Subgroup.closure`, `IsCompact.image`, etc. The `rfl` discharges any equation between syntactically identical normal forms, so the trick is to *choose your witnesses to make the equations definitional*. Failing that, the alternative `⟨witness, by simp [...]⟩` or `⟨witness, by rfl⟩` (which tries unfolding) is the next escalation.\n\n**Connection to constructive content:** Lean's `refine` keeps the proof term explicit. After this step the proof obligation is purely the realization equation $\\forall x \\in S, (x \\in h \\iff x \\in T)$ — entirely separated from the membership-in-$H$ obligation, which has been discharged by the witness data $(a+1)$. This separation is the hallmark of a well-structured constructive proof: *exhibit the witness, then verify its property*.",
+    "mathContext": "Anonymous-constructor pattern $\\langle h, \\langle t, \\mathsf{rfl} \\rangle, ?_\\rangle$ unifies (a) supplying the hypothesis $h \\in H_{thr}$, (b) supplying the threshold parameter $t$, (c) discharging the definitional equation $h = \\{x : x < t\\}$ via reflexivity, leaving only the realization condition.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "anonymous constructor",
+      "definitional equality",
+      "rfl tactic",
+      "existential elimination",
+      "subobject membership",
+      "Set.mem_setOf"
+    ],
+    "prerequisites": [
+      "Sigma/exists types",
+      "Lean tactic `refine`",
+      "Set comprehensions"
     ]
   },
   {

--- a/src/data/proofs/pac-learning-bounds-oq-01/meta.json
+++ b/src/data/proofs/pac-learning-bounds-oq-01/meta.json
@@ -49,7 +49,7 @@
       "Basic Finset operations in Mathlib"
     ],
     "mathlib_version": "4.26.0",
-    "lineCount": 86,
+    "lineCount": 94,
     "relatedProblems": [
       {
         "id": "pac-learning-bounds",
@@ -98,32 +98,32 @@
     {
       "id": "definitions",
       "title": "Definitions: Shatters and Threshold Classifiers",
-      "startLine": 17,
-      "endLine": 31,
+      "startLine": 16,
+      "endLine": 27,
       "summary": "Sets up the standard set-based shattering predicate and defines the threshold hypothesis class on ℕ as { x ↦ x < t : t ∈ ℕ }.",
       "mathContext": "$H$ shatters $S$ iff $\\forall T \\subseteq S, \\exists h \\in H : h \\cap S = T$."
     },
     {
       "id": "lower-bound",
       "title": "Singleton Shattering (VC dim ≥ 1)",
-      "startLine": 33,
-      "endLine": 51,
+      "startLine": 29,
+      "endLine": 49,
       "summary": "Every singleton {a} is shattered by thresholds: t = a+1 includes a, t = 0 excludes a.",
       "mathContext": "$\\forall a \\in \\mathbb{N}: H_{thr}$ shatters $\\{a\\}$."
     },
     {
       "id": "upper-bound",
       "title": "No Pair Shattered (VC dim ≤ 1)",
-      "startLine": 53,
-      "endLine": 76,
+      "startLine": 51,
+      "endLine": 77,
       "summary": "For a < b, labeling T = {b} is unrealizable: would need t ≤ a (exclude a) and t > b (include b), contradicting a < b.",
       "mathContext": "$\\forall a < b: \\neg H_{thr}$ shatters $\\{a, b\\}$."
     },
     {
       "id": "combined",
       "title": "Combined Bound (VC dim = 1)",
-      "startLine": 78,
-      "endLine": 86,
+      "startLine": 79,
+      "endLine": 92,
       "summary": "Together: every singleton is shattered, and no two-point set is. Symmetric pairs handled via Finset extensionality.",
       "mathContext": "$\\operatorname{VCdim}(H_{thr}) = 1$."
     }
@@ -232,7 +232,7 @@
       "Finset"
     ],
     "namespace": "LearningTheory.VCDimension",
-    "lineCount": 86,
+    "lineCount": 94,
     "axiomCount": 0,
     "theoremCount": 3,
     "definitionCount": 2,


### PR DESCRIPTION
Enrichment pass for **pac-learning-bounds-oq-01** (VC Dimension of Threshold Classifiers on ℕ).

## Quality improvements

**Line-range accuracy** (the entry was already content-rich at quality 98, but the line numbers had drifted):
- `leanFile.lineCount` and `meta.lineCount`: 86 → 94 (matches `wc -l` of the actual Lean file)
- All 4 sections in meta.json corrected to match real source ranges:
  - definitions: 17–31 → 16–27
  - lower-bound: 33–51 → 29–49
  - upper-bound: 53–76 → 51–77
  - combined: 78–86 → 79–92
- 5 annotation ranges corrected to match the theorems they annotate.

**New annotation** — `ann-anonymous-constructor-witness` (technique, supporting):
- Explains the `⟨h, ⟨t, rfl⟩, ?_⟩` Lean idiom used in both branches of `threshold_shatters_singleton`
- Covers: why `rfl` works definitionally (the witness was chosen syntactically equal to the existential normal form), prevalence in Mathlib subobject reasoning (`Submodule.span`, `Subgroup.closure`, etc.), and how this idiom *separates* witness-supply from property-verification — a hallmark of well-structured constructive proofs.
- Adds a missing layer of formalization-pedagogy that complements the existing mathematical depth.

## Verification

- JSON syntax validated (both files parse cleanly; 7 annotations total)
- `pnpm build` skipped due to disk-full condition (137Mi free); CI will validate on merge
- Axiom integrity preserved: still 0 axioms, 0 sorries, 0 structure-encoded assumptions

## Files

- `src/data/proofs/pac-learning-bounds-oq-01/meta.json`
- `src/data/proofs/pac-learning-bounds-oq-01/annotations.json`