### PR TITLE
fix(claim-problem): exclude graduated status from claimable pool

### DIFF
--- a/scripts/research/claim-problem.sh
+++ b/scripts/research/claim-problem.sh
@@ -203,11 +203,11 @@ claim_problem() {
         return 1
     fi
 
-    # Check if already completed
+    # Check if already completed/graduated/blocked (terminal statuses, not claimable)
     local status
     status=$(jq -r ".candidates[] | select(.id == \"$problem_id\") | .status" "$POOL_FILE")
-    if [[ "$status" == "completed" ]]; then
-        echo "Error: Problem '$problem_id' already completed" >&2
+    if [[ "$status" == "completed" ]] || [[ "$status" == "graduated" ]] || [[ "$status" == "blocked" ]]; then
+        echo "Error: Problem '$problem_id' has terminal status '$status' (not claimable)" >&2
         return 1
     fi
 
@@ -289,7 +289,7 @@ claim_random_problem() {
         score=$(get_knowledge_score "$problem_id")
         available+=("$problem_id")
         scores+=("$score")
-    done < <(jq -r '.candidates[] | select(.status != "completed" and .status != "blocked") | .id' "$POOL_FILE" 2>/dev/null)
+    done < <(jq -r '.candidates[] | select(.status != "completed" and .status != "blocked" and .status != "graduated") | .id' "$POOL_FILE" 2>/dev/null)
 
     if [[ ${#available[@]} -eq 0 ]]; then
         echo "No available problems to claim" >&2

--- a/src/data/proofs/algebraic-numbers-countable-oq-05/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-05/meta.json
@@ -140,7 +140,7 @@
     "path": "Proofs/AlgebraicNumbersCountableOQ05.lean",
     "filename": "AlgebraicNumbersCountableOQ05.lean",
     "lineCount": 296,
-    "theoremCount": 13,
+    "theoremCount": 12,
     "axiomCount": 0,
     "defCount": 2,
     "sorryCount": 0,


### PR DESCRIPTION
## Summary
- The `claim-random` filter only excluded `completed` and `blocked`, silently allowing 27 `graduated` entries (work already finished and in the gallery) to be re-claimed.
- Tighten the per-problem `claim` guard to reject any of completed/graduated/blocked.
- Drive-by: fix `leanFile.theoremCount` (13 → 12) in `algebraic-numbers-countable-oq-05/meta.json` — the file actually has 12 theorems/lemmas (12 `^lemma|^theorem` matches in the source).

## How this surfaced
Claimed `algebraic-numbers-countable-oq-05` via `claim-random` and found:
- pool entry: `status: graduated`, `notes: COMPLETED`
- gallery: `status: verified`, `sorries: 0`, `axiomCount: 0`

Same staleness class flagged in past researcher notes — the filter just didn't catch this status.

## Verification
Audited all 27 graduated entries: every one has either a `verified` / `axiomatized` gallery entry with 0 sorries, or is a synthesis-only artifact. None are in-progress work. Safe to exclude from claimable pool.

## Test plan
- [ ] `claim-random` no longer returns graduated entries
- [ ] `claim <id>` for a graduated entry now errors with "terminal status"

🤖 Generated with [Claude Code](https://claude.com/claude-code)