### PR TITLE
research: bundled state syncs (5 problems with stale 'active' status)

### DIFF
--- a/src/data/research/problems/dirichlets-theorem-oq-02.json
+++ b/src/data/research/problems/dirichlets-theorem-oq-02.json
@@ -2,7 +2,7 @@
   "slug": "dirichlets-theorem-oq-02",
   "title": "Generalized Riemann Hypothesis for Dirichlet L-functions: All non-trivial zer...",
   "phase": "ACT",
-  "status": "active",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: Assessed and marked complete.",
+    "progressSummary": "COMPLETE: GRH formalization (DirichletsTheoremOQ02OQ01.lean, axiomatized) and elementary primes≡3 mod 4 (DirichletsTheoremOQ02.lean, verified) both stable on main. 0 sorries across all 6 Dirichlet files. Top-level status synced from 'active' to 'completed' to match currentState.phase.",
     "builtItems": [
       "Created DirichletsTheoremOQ02OQ01.lean: GRH formalization (445 lines, 0 sorry)",
       "15 theorems proved: GRH_iff_right_half, GRH_zero_free_region, GRH_no_siegel_zeros, GRH_L_nonzero_right_of_half, GRH_consequence_chain, GRH_error_sublinear, etc.",
@@ -74,7 +74,7 @@
     "mathlib": []
   },
   "started": "2026-03-24T00:48:59.817Z",
-  "lastUpdate": "2026-03-25T00:00:00Z",
+  "lastUpdate": "2026-04-28T00:00:00Z",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [
@@ -118,7 +118,7 @@
       "theoremCount": 16,
       "axiomCount": 4,
       "defCount": 9,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DirichletsTheoremOQ02OQ01.lean"
     },

--- a/src/data/research/problems/erdos-1146.json
+++ b/src/data/research/problems/erdos-1146.json
@@ -2,7 +2,7 @@
   "slug": "erdos-1146",
   "title": "Erdős #1146",
   "phase": "OBSERVE",
-  "status": "active",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {
@@ -21,7 +21,7 @@
     "iteration": 1,
     "focus": "Initial exploration of the problem.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "None — axiomatized formalization stable; 2 axioms appropriate (deep).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -63,7 +63,7 @@
     "mathlib": []
   },
   "started": "2026-01-15T16:41:04.200Z",
-  "lastUpdate": "2026-03-13T07:52:17.058Z",
+  "lastUpdate": "2026-04-28T00:00:00Z",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [

--- a/src/data/research/problems/erdos-530.json
+++ b/src/data/research/problems/erdos-530.json
@@ -1,8 +1,8 @@
 {
   "slug": "erdos-530",
   "title": "Erdős #530",
-  "phase": "ACT",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "COMPLETED",
     "since": "2026-01-13T04:39:49.623Z",
     "iteration": 2,
-    "focus": "Axiom elimination — proved sidon_upper_bound, partially proved sidon_sum_count",
+    "focus": "Axiomatized stable: 0 sorries, 2 foundational axioms — komlos_sulyok_szemeredi (deep theorem, not in Mathlib) and alon_erdos_partition_conjecture (genuinely open). sidon_sum_count is fully proved despite stale focus saying 'partially'.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "None — axiomatized formalization stable. Both axioms are appropriate: KSS is a deep 1975 result not yet in Mathlib, Alon–Erdős is the open conjecture itself.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Fixed incorrect universal upper bound in ErdosProblem530 (counterexample: powers of 2 are Sidon). Proved interval upper bound: Sidon subsets of {1,...,N} have |S|^2 <= 4N. Proved corrected problem statement from KSS axiom + interval bound. 4 new theorems, 0 new sorries.",
+    "progressSummary": "COMPLETED (axiomatized): Erdos530Problem.lean has 0 sorry, 2 axiom, 15 theorems on main. Gallery entry erdos-530 is status=axiomatized, badge=axiom. Both remaining axioms are non-Mathlib foundational results (KSS lower bound, Alon–Erdős partition conjecture).",
     "builtItems": [
       "maxSidonSize_le_card: proved maxSidonSize A ≤ A.card (Erdos530Problem.lean:87)",
       "sidon_upper_bound: PROVED (was axiom) — trivial bound from subset property (Erdos530Problem.lean:95)",
@@ -84,7 +84,7 @@
     "mathlib": []
   },
   "started": "2026-01-13T04:39:49.623Z",
-  "lastUpdate": "2026-03-24T09:00:00.000Z",
+  "lastUpdate": "2026-04-28T00:00:00Z",
   "significance": 5,
   "tractability": 3,
   "leanFiles": [

--- a/src/data/research/problems/erdos-668.json
+++ b/src/data/research/problems/erdos-668.json
@@ -2,7 +2,7 @@
   "slug": "erdos-668",
   "title": "Erdős #668",
   "phase": "OBSERVE",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "COMPLETED",
     "since": "2026-01-13T18:22:04.305Z",
     "iteration": 1,
     "focus": "Proved congruent_unitDistanceCount, assessed all axioms",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "None — assessed complete; 3 axioms appropriate.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -66,7 +66,7 @@
     "mathlib": []
   },
   "started": "2026-01-13T18:22:04.305Z",
-  "lastUpdate": "2026-03-29T01:17:49.437187+00:00",
+  "lastUpdate": "2026-04-28T00:00:00Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [

--- a/src/data/research/problems/erdos-706.json
+++ b/src/data/research/problems/erdos-706.json
@@ -2,7 +2,7 @@
   "slug": "erdos-706",
   "title": "Erdős #706",
   "phase": "OBSERVE",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "COMPLETED",
     "since": "2026-01-14T21:11:01.533Z",
     "iteration": 2,
     "focus": "5A assessed, all appropriate",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "None — axiomatized formalization stable; 3 axioms appropriate for open problem.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -60,7 +60,7 @@
     "mathlib": []
   },
   "started": "2026-01-14T21:11:01.534Z",
-  "lastUpdate": "2026-03-13T07:52:17.052Z",
+  "lastUpdate": "2026-04-28T00:00:00Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [

--- a/src/data/research/problems/erdos-913.json
+++ b/src/data/research/problems/erdos-913.json
@@ -2,7 +2,7 @@
   "slug": "erdos-913",
   "title": "Erdős #913",
   "phase": "OBSERVE",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -79,7 +79,7 @@
     "mathlib": []
   },
   "started": "2026-01-15T11:36:40.863Z",
-  "lastUpdate": "2026-03-13T07:52:17.054Z",
+  "lastUpdate": "2026-04-28T00:00:00Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [


### PR DESCRIPTION
## Summary
Bundle of metadata reconciliations for problems whose top-level `status` field stayed at `"active"` despite the work having reached a stable state. Pattern follows precedent from #13325. Pure metadata — no Lean files touched.

Per saved feedback: "Many RICH/MODERATE problems are already-solved with status: active. Audit JSON's phase/progressSummary against gallery verified before researching." Each entry was claimed via `claim-random` and released because the work is already done — sync the metadata so seekers stop surfacing them.

This session: **6 claims, 5 stale-completed reconciles, 1 deferred** (claim/no-change rate matches saved memory; the pool desperately needs this sync).

## Problems Reconciled

### 1. `dirichlets-theorem-oq-02` (RICH)
- JSON had `currentState.phase = "COMPLETED"` since 2026-03-25 with `nextAction: "None — formalization complete"`
- `DirichletsTheoremOQ02.lean` (0 sorry, 0 axiom, verified, primes ≡ 3 mod 4) + `DirichletsTheoremOQ02OQ01.lean` (0 sorry, 4 axiom, axiomatized GRH)
- Gallery: verified + axiomatized
- Also fixed stale `leanFiles[OQ02OQ01].sorryCount: 1 → 0`

### 2. `erdos-913` (RICH)
- JSON had `nextAction: "Marking problem as completed in pool."` but top status stayed active
- `Erdos913Problem.lean`: 0 sorry, 1 axiom (Bunyakovsky-type, genuinely open), 11 theorems
- Gallery: axiomatized

### 3. `erdos-530` (RICH)
- JSON had stale focus claiming "partially proved sidon_sum_count" — but `sidon_sum_count` is fully proved on main
- `Erdos530Problem.lean`: 0 sorry, 2 axiom, 15 theorems
  - `komlos_sulyok_szemeredi` (1975 deep theorem, not in Mathlib)
  - `alon_erdos_partition_conjecture` (the open conjecture itself)
- Gallery: axiomatized

### 4. `erdos-706` (MODERATE)
- JSON had `progressSummary = "COMPLETE: Assessed and marked complete."` but `status: "active"`
- `Erdos706Problem.lean`: 0 sorry, 3 axiom (Hadwiger–Nelson generalization)
  - `multiDistChromatic` opaque def (needs ℝ² chromatic theory)
  - `erdos_706_base_case` (de Grey 2018: 5 ≤ L(1) ≤ 7)
  - `erdos_706_monotone` (chromatic monotonicity)

### 5. `erdos-1146` (MODERATE)
- JSON had `cs.phase = "COMPLETED"` with `progressSummary = "COMPLETE: 2A appropriate (deep), 13T proved, 0S"` but `status: "active"`
- `Erdos1146Problem.lean`: 0 sorry, 2 axiom (deep, appropriate), 13 theorems

### 6. `erdos-668` (MODERATE)
- JSON had `progressSummary = "COMPLETE: Assessed and marked complete."` but `status: "active"`
- `Erdos668Problem.lean`: 0 sorry, 3 axiom (appropriate), 10 theorems

## Verification
All sorry/axiom counts verified via `git show HEAD:proofs/Proofs/<file>.lean` with comment-stripped grep, per `feedback_lean_sorry_counting` and `feedback_auditor_untracked_files` saved guidance.

## Out of scope (claimed but released without changes)
- `erdos-152-oq-01` — focus says "Needs Docker build verification" with 3 nextSteps still listed. Not safely reconcilable without a Docker build (disk at 99% blocks Docker per saved guidance). Released for next researcher with Docker access.

## Test plan
- [ ] Seeker should no longer surface these 6 slugs as research candidates
- [ ] Gallery rendering unchanged (no proof files touched, only metadata)

🤖 Generated by researcher-10 (disk at 99% — text-only metadata reconciliation session)