### PR TITLE
Research: erdos-854 axioms restored + erdos-892 metadata reconciliation

### DIFF
--- a/proofs/Proofs/Erdos854Problem.lean
+++ b/proofs/Proofs/Erdos854Problem.lean
@@ -153,6 +153,9 @@ theorem distinctGapCount_def (n : ℕ) :
 /- ## Known Bounds -/
 
 /-- Maximal gap for primorial(k) grows like 2pₖ₋₁ (the Jacobsthal function bound) -/
+axiom maxGap_bound (k : ℕ) (hk : 2 ≤ k) :
+  maxGap (primorial k) ≤ 2 * nthPrime (k - 1)
+
 /-- The first missing gap: smallest positive even integer not in gapSet(n). -/
 noncomputable def firstMissingGap (n : ℕ) : ℕ :=
   2 * Nat.find (⟨(gapSet n).sup id + 1, fun h => by
@@ -171,10 +174,21 @@ theorem firstMissingGap_missing (n : ℕ) :
 
 /-- Lacampagne–Selfridge computation: for nₖ = 30030 (k=6),
     not all even integers up to the maximal gap appear -/
+axiom lacampagne_selfridge_counterexample :
+  ∃ d : ℕ, 2 ∣ d ∧ d < maxGap (primorial 6) ∧ d ∉ gapSet (primorial 6)
+
 /- ## The Erdős Conjectures -/
 
 /-- Erdős Problem 854, Part 1: Estimate the smallest even integer
     not representable as a consecutive gap in coprime residues of primorials -/
+axiom ErdosProblem854_missing_gap_growth :
+  ∀ C : ℕ, ∃ k : ℕ, C ≤ firstMissingGap (primorial k)
+
 /-- Erdős Problem 854, Part 2: The number of distinct even gaps
     is proportional to the maximal gap -/
+axiom ErdosProblem854_many_gaps :
+  ∃ c : ℚ, 0 < c ∧
+    ∀ k : ℕ, 2 ≤ k →
+      c * (maxGap (primorial k) : ℚ) ≤ (distinctGapCount (primorial k) : ℚ)
+
 end Erdos854

--- a/research/problems/erdos-892/state.md
+++ b/research/problems/erdos-892/state.md
@@ -1,27 +1,39 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-01-15T11:22:53.228Z
-**Iteration**: 1
+**Phase**: AXIOMATIZED (gallery formalization complete)
+**Since**: 2026-04-28
+**Iteration**: 2
 
 ## Current Focus
 
-Initial exploration of the problem.
+Metadata reconciliation: meta.json `conclusion.summary` was stale (claimed 6 theorems / 2 sorries / 1 axiom). Actual Lean file `Proofs/Erdos892Problem.lean` has 6 definitions, 7 theorems, 0 sorries, and 2 axioms. Updated conclusion.summary to match.
 
 ## Active Approach
 
-None yet.
+Gallery entry uses an "axiomatized" formalization:
+- 6 definitions: `IsPrimitive`, `IsStrictlyIncreasing`, `IsDominatedBy`, `ErdosProblem892`, `IsGCDFree`, `ErdosProblem892GCDFree`.
+- 7 proved theorems: `primitive_elements_ge_two`, `strict_inc_lower_bound`, `strict_inc_eventually_ge`, `product_log_comparison`, `reciprocal_log_comparison`, `erdos_1935_necessary`, `linear_growth_no_primitive_dominator`.
+- 2 axioms: `primitive_reciprocal_log_convergent` (Erdős 1935 deep result), `harmonic_log_plus2_diverges` (standard Cauchy condensation, not yet in Mathlib).
+
+The Erdős 1935 necessary condition is fully proved in Lean. The Erdős–Sárközy–Szemerédi 1968 problem itself remains open (no characterization of necessary AND sufficient conditions for primitive domination is known).
 
 ## Blockers
 
-None.
+- Problem is OPEN (1968): no known sufficient condition; characterization is conjectural.
+- Cannot run Docker builds in this session (host disk at 99% — 153Mi free).
 
 ## Next Action
 
-Begin problem exploration.
+When disk capacity returns and Mathlib gains a `Real.summable_one_div_n_log_n` analog,
+replace `harmonic_log_plus2_diverges` with a Mathlib-derived theorem.
+
+A second tractable refinement: instantiate `linear_growth_no_primitive_dominator` for
+specific `b_n` (e.g., `b_n = n^2`) where the necessary condition fails or is non-trivial
+to verify directly — this would not solve the open question but would strengthen the
+"tightness" of the necessary condition narrative.
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1 (metadata reconciliation; underlying problem remains open)

--- a/src/data/proofs/erdos-854/meta.json
+++ b/src/data/proofs/erdos-854/meta.json
@@ -22,9 +22,9 @@
     "erdosNumber": 854,
     "erdosUrl": "https://erdosproblems.com/854",
     "erdosProblemStatus": "open",
-    "axiomCount": 0,
-    "lineCount": 180,
-    "assumptions": "0 axioms. 0 sorries. All results formalized without axioms.",
+    "axiomCount": 4,
+    "lineCount": 194,
+    "assumptions": "4 axioms encoding the Erdős conjectures and known bounds: (1) maxGap_bound (Jacobsthal function bound), (2) lacampagne_selfridge_counterexample (computational disproof for n₆=30030), (3) ErdosProblem854_missing_gap_growth (Part 1, open), (4) ErdosProblem854_many_gaps (Part 2, open). 0 sorries. All supporting infrastructure (primorials, coprime residues, gap sets, gap evenness) formally proved without axioms.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -88,33 +88,33 @@
     {
       "id": "known-bounds",
       "title": "Jacobsthal Bound and First Missing Gap",
-      "startLine": 108,
-      "endLine": 128,
-      "summary": "Jacobsthal bound axiomatized. First missing gap defined with proved existence witness (sup+1 argument) and proved non-membership via Nat.find_spec.",
+      "startLine": 153,
+      "endLine": 173,
+      "summary": "Jacobsthal bound axiomatized (maxGap_bound: maxGap(primorial k) ≤ 2·pₖ₋₁). First missing gap defined with proved existence witness (sup+1 argument) and proved non-membership via Nat.find_spec.",
       "mathContext": "firstMissingGap existence and non-membership both proved; Jacobsthal bound axiomatized."
     },
     {
       "id": "counterexample",
       "title": "Lacampagne-Selfridge Counterexample",
-      "startLine": 130,
-      "endLine": 133,
-      "summary": "Records the computational disproof of Erdős's strong conjecture for n₆ = 30030.",
+      "startLine": 175,
+      "endLine": 178,
+      "summary": "Records the computational disproof of Erdős's strong conjecture for n₆ = 30030 (axiom lacampagne_selfridge_counterexample).",
       "mathContext": "Axiomatized: Computational fact about specific primorial."
     },
     {
       "id": "conjecture-part1",
       "title": "Conjecture Part 1: Missing Gap Growth",
-      "startLine": 137,
-      "endLine": 140,
-      "summary": "States that the smallest missing gap grows without bound.",
+      "startLine": 182,
+      "endLine": 185,
+      "summary": "States that the smallest missing gap grows without bound (axiom ErdosProblem854_missing_gap_growth).",
       "mathContext": "Open conjecture: axiomatized."
     },
     {
       "id": "conjecture-part2",
       "title": "Conjecture Part 2: Proportional Distinct Gaps",
-      "startLine": 143,
-      "endLine": 147,
-      "summary": "States that the number of distinct gap values is proportional to the maximal gap.",
+      "startLine": 187,
+      "endLine": 192,
+      "summary": "States that the number of distinct gap values is proportional to the maximal gap (axiom ErdosProblem854_many_gaps).",
       "mathContext": "Open conjecture: axiomatized."
     }
   ],
@@ -139,8 +139,8 @@
       "Nat"
     ],
     "namespace": "Erdos854",
-    "lineCount": 180,
-    "axiomCount": 0,
+    "lineCount": 194,
+    "axiomCount": 4,
     "theoremCount": 16,
     "definitionCount": 8,
     "path": "Proofs/Erdos854Problem.lean",

--- a/src/data/proofs/erdos-892/meta.json
+++ b/src/data/proofs/erdos-892/meta.json
@@ -132,7 +132,7 @@
     ]
   },
   "conclusion": {
-    "summary": "Erdős Problem 892 is formalized with 6 definitions, 6 theorems, and 2 sorries. The Erdős 1935 necessary condition ($\\sum 1/(b_n \\log b_n) < \\infty$) is partially proved: the main structure uses 1 axiom (primitive_reciprocal_log_convergent) and 2 remaining sorries for the divergence of the harmonic-log series and a cast arithmetic simplification.",
+    "summary": "Erdős Problem 892 is formalized with 6 definitions, 7 theorems, 0 sorries, and 2 axioms. The Erdős 1935 necessary condition ($\\sum 1/(b_n \\log b_n) < \\infty$) is fully proved: the main proof splits the sum at threshold $N_0$ where $a(n) \\geq C^2$, with the head bounded by a finite sum and the tail reduced via reciprocal_log_comparison to the convergent series captured by axiom primitive_reciprocal_log_convergent. The two axioms are primitive_reciprocal_log_convergent (Erdős 1935, deep number-theoretic result) and harmonic_log_plus2_diverges (standard Cauchy condensation result not yet in Mathlib).",
     "implications": "A full characterization would provide a fundamental understanding of how the 'thinness' of primitive sequences constrains their growth rates. This connects to Behrend's theorem, the distribution of primes (the densest primitive sequence), and the structure of the divisibility lattice on natural numbers.",
     "openQuestions": [
       "What are necessary and sufficient conditions for a sequence b to admit a primitive dominator?",


### PR DESCRIPTION
## Summary

This branch bundles two independent metadata-integrity fixes for Erdős gallery entries.

### Commit 1: erdos-854 — restore 4 axioms accidentally stripped (9d3f292)

The Erdős Problem 854 Lean file had its 4 axioms removed in commit `c34e89c6833` (titled "Research: 3D Feuerbach analogue for orthocentric tetrahedra (#8409)", which appears to have unintentionally stripped Erdős axioms). The gallery metadata and docstrings still referenced the removed axioms, leaving the file internally inconsistent.

#### Restored axioms

| Axiom | Role |
|-------|------|
| `maxGap_bound` | Jacobsthal bound: `maxGap (primorial k) ≤ 2 · nthPrime (k-1)` for `k ≥ 2` |
| `lacampagne_selfridge_counterexample` | Computational disproof of the strong form for n₆ = 30030 |
| `ErdosProblem854_missing_gap_growth` | Part 1 (open): smallest missing gap is unbounded |
| `ErdosProblem854_many_gaps` | Part 2 (open): distinct gap count proportional to maximal gap |

#### meta.json changes
- `axiomCount`: 0 → 4 (both `meta.axiomCount` and `leanFile.axiomCount`)
- `lineCount`: 180 → 194
- `assumptions`: now lists each axiom by name and role
- Sections (`known-bounds`, `counterexample`, `conjecture-part1`, `conjecture-part2`): `startLine`/`endLine` updated to match restored file

### Commit 2: erdos-892 — conclusion summary stale (46b7b20)

The `conclusion.summary` field in `src/data/proofs/erdos-892/meta.json` was outdated, claiming "6 theorems and 2 sorries... 1 axiom". The actual `Proofs/Erdos892Problem.lean` source contains 6 definitions, 7 theorems, 0 sorries, and 2 axioms (correctly enumerated in `assumptions`). Conclusion now matches the rest of the metadata.

State file `research/problems/erdos-892/state.md` updated from a NEW/iteration-1 placeholder to reflect the actual axiomatized formalization state and the open status of the underlying 1968 problem.

No Lean source changes; no rebuild required.

### Why

Per `CLAUDE.md` axiom integrity policy, Erdős open problems must be `"axiomatized"` and metadata must be internally consistent. Both fixes restore that consistency.

## Test plan

- [ ] Build verification (deferred — host disk at 99% capacity, Docker builds skipped)
- [x] erdos-854: Axiom signatures restored verbatim from prior version (`eab3db3d5b6`)
- [x] erdos-892: No Lean changes; only meta.json conclusion text and state.md
- [x] meta.json files validated as valid JSON
- [x] meta.json `lineCount` and section line ranges match Lean files

🤖 Generated with [Claude Code](https://claude.com/claude-code)