### PR TITLE
Research: bundled metadata reconciliation (4 problems)

### DIFF
--- a/research/problems/erdos-1173/knowledge.md
+++ b/research/problems/erdos-1173/knowledge.md
@@ -1,37 +1,102 @@
-# Erdős #1173 - Knowledge Base
+# Knowledge Base: erdos-1173
 
-## Problem Statement
+Insights accumulated during research on this problem.
 
-Problem statement not found
+---
+
+## Problem Understanding
+
+Erdős–Hajnal set-mapping problem on the singular cardinal ℵ_ω.
+Under GCH, given a set mapping
+  f : ω_{ω+1} → [ω_{ω+1}]^{≤ℵ_ω}
+satisfying the almost-disjoint condition |f(α) ∩ f(β)| < ℵ_ω for α ≠ β,
+the question is whether there exists a free set of cardinality ℵ_{ω+1}
+(where S is free if α ∉ f(β) for all distinct α, β ∈ S).
+
+This generalizes the Hajnal free set theorem from regular to singular
+cardinals, with a weaker (pairwise) intersection bound replacing the
+pointwise size bound.
 
 ## Status
 
 **Erdős Database Status**: OPEN
-
 **Tractability Score**: 6/10
-**Aristotle Suitable**: No
+**Aristotle Suitable**: No (main conjecture is research-level; supporting
+infrastructure already proved without sorries)
+
+## Lean Formalization
+
+`proofs/Proofs/Erdos1173Problem.lean` — 0 axioms, 0 sorries:
+- Defines `aleph_omega`, `aleph_omega_succ`, `omega_omega_succ`, `GCH`
+- Defines `SetMapping`, `BoundedImageSize`, `AlmostDisjoint`, `IsFreeSet`,
+  `HasFreeSetOfCard`
+- Defines the conjecture `erdos_1173 : Prop` (statement only — not proved)
+- Proves: `gch_aleph_omega_strong_limit`, `overlap_bounded_by_aleph_n`,
+  `aleph_omega_lt_succ`, `gch_power`, `free_set_empty`,
+  `free_set_singleton`, `free_set_subset`
+
+The main conjecture itself is left as `def erdos_1173 : Prop := ...`
+(a problem statement, not a theorem). Gallery `meta.json` correctly
+records `status: "axiomatized"` / `badge: "wip"`.
 
 ## Tags
 
-- erdos
+- erdos, set-theory, infinitary-combinatorics, singular-cardinals,
+  free-sets, GCH
 
 ## Related Problems
 
-- Problem #2000
-- Problem #83
-- Problem #888
-- Problem #2
-- Problem #39
-- Problem #1
+- Problem #2000, #83, #888, #2, #39, #1
 
 ## References
 
-- (None available)
-
-## Sessions
-
-(No research sessions yet)
+- Erdős, P. & Hajnal, A. — original problem
+- Komjáth, P. (Ko25b), Problem 35
+- Vaughan, J. (Va99), 7.88
 
 ---
 
-*Generated from erdosproblems.com on 2026-01-15*
+## Insights
+
+- All 4 named "axioms" referenced in early notes were either deep set-
+  theoretic results (Hajnal's theorem, GCH consequences) or have since
+  been *proved* in `Erdos1173Problem.lean` from Mathlib (no axiom
+  declarations remain).
+- `gch_aleph_omega_strong_limit` follows from GCH via the limit
+  characterization of ℵ_ω = sup_{n<ω} ℵ_n.
+- `overlap_bounded_by_aleph_n` shows the AlmostDisjoint hypothesis is
+  equivalent to: for each pair α ≠ β there exists n with |f(α) ∩ f(β)|
+  ≤ ℵ_n. This pigeonhole-style observation is the natural starting
+  point for any positive resolution.
+- The singularity of ℵ_ω prevents direct application of Hajnal's
+  free-set theorem (which requires regularity).
+
+## Dead Ends
+
+- (none yet recorded)
+
+---
+
+## Sessions
+
+### 2026-04-28: Metadata reconciliation (researcher-3)
+
+`src/data/research/problems/erdos-1173.json` and `problem.md` were
+largely empty placeholders ("Problem statement not found", empty
+`whyMatters`/`knownResults`) while the Lean source and `meta.json`
+were already correct. This session reconciled:
+
+- Filled in `problemStatement.formal`, `.plain`, `.whyMatters`
+- Populated `knownResults.proven`, `.open`, `.goal`
+- Updated `currentState` to OBSERVE / blocked-on-research-level
+- Removed self-referential `relatedProofs` entry (`erdos-1173`)
+- Added `references.papers/urls/mathlib`
+- Rewrote `problem.md` and this `knowledge.md` with real content
+
+No Lean changes (file is already verified at 0 axioms / 0 sorries).
+Disk constraints (98% full) made Docker builds inadvisable; pure-text
+metadata reconciliation was the highest-value action available.
+
+---
+
+*Originally generated from erdosproblems.com on 2026-01-15.*

--- a/research/problems/erdos-1173/problem.md
+++ b/research/problems/erdos-1173/problem.md
@@ -1,13 +1,22 @@
-# Problem: Erdős #1173
+# Problem: Erdős #1173 — Free Sets for Set Mappings under GCH
 
 ## Statement
 
 ### Plain Language
-Problem statement not found
+
+Under the Generalized Continuum Hypothesis, suppose every ordinal below
+ω_{ω+1} is assigned a set of size at most ℵ_ω, and any two of these
+assigned sets share strictly fewer than ℵ_ω elements. Must there exist
+a "free" set of size ℵ_{ω+1} — that is, a set S in which no element of
+S belongs to the assigned set of any other element of S?
 
 ### Formal Statement
+
 $$
-(LaTeX not available)
+\text{GCH} \implies \forall f : \omega_{\omega+1} \to [\omega_{\omega+1}]^{\le \aleph_\omega},\
+  \bigl(\forall \alpha \ne \beta,\ |f(\alpha) \cap f(\beta)| < \aleph_\omega\bigr)
+  \implies \exists S \subseteq \omega_{\omega+1},\ |S| = \aleph_{\omega+1}\
+   \land\ (\forall \alpha \ne \beta \in S,\ \alpha \notin f(\beta)).
 $$
 
 ## Classification
@@ -21,22 +30,27 @@ erdosUrl: https://erdosproblems.com/1173
 
 tags:
   - erdos
+  - set-theory
+  - infinitary-combinatorics
+  - singular-cardinals
+  - free-sets
+  - GCH
 ```
 
 **Significance**: 7/10
-**Tractability**: 6/10
+**Tractability**: 6/10 (open Erdős–Hajnal problem; partial formalization possible)
 
 ## Why This Matters
 
-1. **Erdős Legacy** - Part of Paul Erdős's influential problem collection
-2. **Mathematical significance** - open problem; short statement
-
+1. **Erdős–Hajnal legacy** — Part of the classical Erdős–Hajnal program on set mappings and free sets in infinitary combinatorics.
+2. **Singular vs. regular dichotomy** — The Hajnal free set theorem handles regular κ via standard combinatorial arguments. Whether an analogue holds for the singular cardinal ℵ_ω with the weaker almost-disjoint intersection hypothesis is unresolved.
+3. **PCF connection** — Resolution would inform the PCF-theoretic structure of [κ]^{<κ} when κ is singular, and connect to Shelah's work on cofinalities of products of regular cardinals.
 
 ## Related Gallery Proofs
 
 | Proof | Relevance |
 |-------|-----------|
-| --- | --- |
+| (none yet — this is a standalone problem statement) | — |
 
 ## Related Problems
 
@@ -49,7 +63,9 @@ tags:
 
 ## References
 
-(No references available)
+- Erdős, P. & Hajnal, A. — original problem on set mappings and free sets
+- Komjáth, P. (Ko25b), Problem 35
+- Vaughan, J. (Va99), 7.88
 
 ## OEIS Sequences
 

--- a/research/problems/erdos-1173/state.md
+++ b/research/problems/erdos-1173/state.md
@@ -1,24 +1,31 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-01-15T17:01:06.708Z
-**Iteration**: 1
+**Phase**: OBSERVE
+**Since**: 2026-04-28T00:00:00.000Z
+**Iteration**: 2
 
 ## Current Focus
 
-Initial exploration of the problem.
+Problem statement and supporting infrastructure are formalized in Lean
+(0 axioms, 0 sorries). Main conjecture `erdos_1173 : Prop` remains a
+*statement only* — proving it is an open Erdős–Hajnal research problem.
 
 ## Active Approach
 
-None yet.
+None — main conjecture exceeds the scope of automated formalization.
 
 ## Blockers
 
-None.
+- Main conjecture is an open Erdős–Hajnal problem. Resolution requires
+  research-level set theory (PCF / singular cardinal combinatorics)
+  beyond the present toolset.
 
 ## Next Action
 
-Begin problem exploration.
+Survey literature for partial results on singular set mappings
+(Komjáth Ko25b Problem 35; Vaughan Va99 7.88) before any formal
+proof attempt. Consider formalizing the *weak* form (free set of
+cardinality ℵ_ω rather than ℵ_{ω+1}) if a published proof exists.
 
 ## Attempt Counts
 

--- a/src/data/research/problems/erdos-1173.json
+++ b/src/data/research/problems/erdos-1173.json
@@ -1,26 +1,40 @@
 {
   "slug": "erdos-1173",
-  "title": "Erdős #1173",
+  "title": "Erdős #1173: Free Sets for Set Mappings under GCH",
   "phase": "OBSERVE",
   "status": "active",
   "tier": "A",
   "path": "full",
   "problemStatement": {
-    "formal": "(LaTeX not available)",
-    "plain": "Problem statement not found",
-    "whyMatters": []
+    "formal": "Assume GCH. Let f : \\omega_{\\omega+1} \\to [\\omega_{\\omega+1}]^{\\le \\aleph_\\omega} be a set mapping such that |f(\\alpha) \\cap f(\\beta)| < \\aleph_\\omega for all \\alpha \\ne \\beta. Does there exist a free set of cardinality \\aleph_{\\omega+1}? (A set S is free if \\alpha \\notin f(\\beta) for all distinct \\alpha,\\beta \\in S.)",
+    "plain": "Under the Generalized Continuum Hypothesis, suppose every ordinal below ω_{ω+1} is assigned a set of size at most ℵ_ω, and any two of these sets share strictly fewer than ℵ_ω elements. Must there exist a 'free' set of size ℵ_{ω+1} — that is, a set S in which no element of S belongs to the assigned set of any other element of S?",
+    "whyMatters": [
+      "Open Erdős–Hajnal problem in infinitary combinatorics / set theory (Erdős & Hajnal; Komjáth Ko25b Problem 35; Vaughan Va99 7.88)",
+      "Tests whether the Hajnal free set theorem (regular case) extends to a singular cardinal (ℵ_ω) under a weaker pairwise almost-disjoint intersection hypothesis",
+      "Singular cardinals lack the regularity used in standard free-set arguments; resolution would inform PCF theory and the structure of [κ]^{<κ} for singular κ"
+    ]
   },
   "knownResults": {
-    "proven": [],
-    "open": [],
-    "goal": ""
+    "proven": [
+      "Hajnal free set theorem (regular case): for regular κ and f : κ⁺ → [κ⁺]^{<κ}, there is a free set of size κ⁺",
+      "Under GCH, ℵ_ω is a strong limit cardinal (gch_aleph_omega_strong_limit, formalized)",
+      "Almost-disjoint overlap is bounded by some ℵ_n for n < ω (overlap_bounded_by_aleph_n, formalized)",
+      "Basic cardinal arithmetic: ℵ_ω < ℵ_{ω+1} and 2^{ℵ_ω} = ℵ_{ω+1} under GCH (formalized)"
+    ],
+    "open": [
+      "The full conjecture: existence of a free set of cardinality ℵ_{ω+1}",
+      "Weak form (erdos_1173_weak): existence of a free set of cardinality ℵ_ω"
+    ],
+    "goal": "Either construct a free set of cardinality ℵ_{ω+1} from the GCH + bounded image + almost-disjoint hypotheses, or construct (relatively consistent) a counterexample mapping where no such free set exists."
   },
   "currentState": {
-    "phase": "ORIENT",
-    "iteration": 1,
-    "focus": "Survey",
-    "blockers": [],
-    "nextAction": "Check Mathlib set theory API",
+    "phase": "OBSERVE",
+    "iteration": 2,
+    "focus": "Problem stated and infrastructure formalized; main conjecture remains OPEN",
+    "blockers": [
+      "Main conjecture is an open Erdős–Hajnal problem; resolution requires research-level set theory beyond automated formalization"
+    ],
+    "nextAction": "Survey literature for partial results on singular set mappings (Ko25b Problem 35, Va99 7.88) before any formal proof attempt",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -45,7 +59,7 @@
     ],
     "mathlibGaps": [],
     "nextSteps": [],
-    "markdown": "# Erdős #1173 - Knowledge Base\n\n## Problem Statement\n\nProblem statement not found\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 6/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
+    "markdown": "# Erdős #1173 — Free Sets for Set Mappings under GCH\n\n## Problem\n\nUnder GCH, given f : ω_{ω+1} → [ω_{ω+1}]^{≤ℵ_ω} with |f(α) ∩ f(β)| < ℵ_ω for α ≠ β, must there exist a free set of cardinality ℵ_{ω+1}? (S free ⇔ α ∉ f(β) for distinct α, β ∈ S.)\n\n## Status\n\n**Erdős Database Status**: OPEN\n**Tractability Score**: 6/10\n**Aristotle Suitable**: No\n\n## Lean Formalization\n\n`proofs/Proofs/Erdos1173Problem.lean` — 0 axioms, 0 sorries.\nDefines the conjecture and supporting machinery; proves basic\ncardinal arithmetic and trivial free-set lemmas. Main conjecture\nis a `def : Prop` (statement only).\n\n## References\n\n- Erdős & Hajnal, original problem\n- Komjáth (Ko25b) Problem 35\n- Vaughan (Va99) 7.88\n"
   },
   "tags": [
     "erdos"
@@ -53,16 +67,24 @@
   "relatedProofs": [
     "erdos-1",
     "erdos-11",
-    "erdos-117",
-    "erdos-1173"
+    "erdos-117"
   ],
   "references": {
-    "papers": [],
-    "urls": [],
-    "mathlib": []
+    "papers": [
+      "Erdős, P. & Hajnal, A. — original problem on set mappings and free sets",
+      "Komjáth, P. (Ko25b), Problem 35",
+      "Vaughan, J. (Va99), 7.88"
+    ],
+    "urls": [
+      "https://www.erdosproblems.com/1173"
+    ],
+    "mathlib": [
+      "Mathlib.SetTheory.Cardinal.Basic — Cardinal.aleph, aleph_lt",
+      "Mathlib.SetTheory.Cardinal.Ordinal — aleph_limit, isSuccLimit_omega0"
+    ]
   },
   "started": "2026-01-15T17:01:06.708Z",
-  "lastUpdate": "2026-03-24T08:25:00.000Z",
+  "lastUpdate": "2026-04-28T00:00:00.000Z",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [

--- a/src/data/research/problems/erdos-402-wip-01.json
+++ b/src/data/research/problems/erdos-402-wip-01.json
@@ -1,27 +1,44 @@
 {
   "slug": "erdos-402-wip-01",
   "title": "Complete Graham's GCD Conjecture (Work in Progress)",
-  "phase": "NEW",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
   "problemStatement": {
-    "formal": "\\text{(formal statement to be added)}",
-    "plain": "AVAILABLE: This proof is marked as work in progress and needs completion.",
-    "whyMatters": []
+    "formal": "\\forall A \\subset \\mathbb{N}, A \\text{ finite}, A \\ne \\emptyset, \\text{all } a > 0 \\implies \\exists a, b \\in A:\\ \\gcd(a, b) \\le a / |A|.",
+    "plain": "Graham (1970): for any finite set A of positive integers, there exist a, b ∈ A with gcd(a,b) ≤ a/|A|. Resolved by Balasubramanian–Soundararajan (1996). The Lean formalization states the main theorem and proves all small cases (|A| ≤ 4) plus several structural reductions; the general-A proof remains as a single `sorry`.",
+    "whyMatters": [
+      "Classical GCD/divisibility problem from Erdős's #402; resolved by Balasubramanian–Soundararajan (1996) via a sieve argument",
+      "Tight: gcd(a,b) = a/|A| is achievable on three families ({1,...,n}, lcm-divisor sets, {2,3,4,6}); the equality characterization itself is conjectural (and shown false in this file via the {1,2,4} counterexample to Graham's stronger equality conjecture)",
+      "Pedagogically rich for Lean: small-card proofs (|A|=2,3,4) exercise gcd/divisibility lemmas; the general-A `sorry` documents a research-grade reduction"
+    ]
   },
   "knownResults": {
-    "proven": [],
-    "open": [],
-    "goal": ""
+    "proven": [
+      "Main theorem (formalized): pair case |A|=2 (erdos_402_pair, via dvd_lt_imp_le_half)",
+      "Main theorem (formalized): triple case |A|=3 (erdos_402_triple, via three_element_gcd_bound)",
+      "Main theorem (formalized): quadruple case |A|=4 (erdos_402_quadruple)",
+      "Main theorem (formalized): when 1 ∈ A (erdos_402_contains_one, pigeonhole on max ≥ |A|)",
+      "Main theorem (formalized): when min(A) ≤ max(A)/|A| (erdos_402_small_min)",
+      "Counterexample to Graham's equality conjecture: {1,2,4} is primitive, satisfies the GCD bound, and is not in any of the three conjectured equality families (counterexample_124_*)",
+      "Balasubramanian–Soundararajan (1996): full theorem in number-theoretic literature (sieve argument, not yet formalized)"
+    ],
+    "open": [
+      "Formalization of the general-A case (erdos_402_graham_conjecture line 99 sorry) — requires a Balasubramanian–Soundararajan sieve argument",
+      "Sharp characterization of all equality cases — the original Graham equality conjecture is FALSE (this file's {1,2,4} counterexample); the correct characterization is open"
+    ],
+    "goal": "Eliminate the line-99 sorry by formalizing the Balasubramanian–Soundararajan sieve argument, or by reducing to a finite case analysis combined with the proved small-card and structural cases."
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ACT",
     "since": "2026-03-28T19:26:08.359Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
-    "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "iteration": 5,
+    "focus": "Substantial small-case formalization complete; main theorem awaits sieve-based proof",
+    "blockers": [
+      "Main conjecture sieve argument is research-grade Lean (~hundreds of lines); not currently tractable"
+    ],
+    "nextAction": "Either (a) attempt formalization of the cardinality-5 case to extend the small-card induction, or (b) survey existing Mathlib sieve infrastructure for Balasubramanian–Soundararajan-style arguments",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,7 +46,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: Added 3 new theorems (small_min, three_element_gcd_bound, erdos_402_three). 433 lines, 18 theorems, 0 axioms, 1 sorry (main conjecture).",
+    "progressSummary": "PROGRESS: 693 lines, 19 theorems, 0 axioms, 1 sorry (main conjecture line 99). All cases |A| ≤ 4 are formalized, plus structural reductions (1 ∈ A; small min) and the {1,2,4} counterexample to Graham's equality conjecture. Only remaining gap is the general-A sieve argument from Balasubramanian–Soundararajan (1996).",
     "builtItems": [
       "counterexample_124_satisfies: {1,2,4} satisfies Graham condition",
       "counterexample_124_primitive: {1,2,4} has gcd 1",
@@ -76,16 +93,38 @@
   ],
   "relatedProofs": [
     "erdos-4",
-    "erdos-40",
-    "erdos-402"
+    "erdos-40"
   ],
   "references": {
-    "papers": [],
-    "urls": [],
-    "mathlib": []
+    "papers": [
+      "Graham, R. L. (1970) — original conjecture",
+      "Szegedy, M. (1986) — proof for sufficiently large sets",
+      "Zaharescu, A. (1987) — independent proof for large sets",
+      "Balasubramanian, R. & Soundararajan, K. (1996) — completed proof for all finite sets"
+    ],
+    "urls": [
+      "https://www.erdosproblems.com/402"
+    ],
+    "mathlib": [
+      "Mathlib.Data.Nat.GCD.Basic — Nat.gcd, gcd_dvd",
+      "Mathlib.Data.Finset.Card — Finset.card, max_ge_card_of_pos pattern"
+    ]
   },
+  "leanFiles": [
+    {
+      "path": "Proofs/Erdos402Problem.lean",
+      "filename": "Erdos402Problem.lean",
+      "lineCount": 693,
+      "theoremCount": 19,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos402Problem.lean"
+    }
+  ],
   "started": "2026-03-28T19:26:08.359Z",
-  "lastUpdate": "2026-03-28T19:26:08.359Z",
+  "lastUpdate": "2026-04-28T00:00:00.000Z",
   "significance": 5,
   "tractability": 6
 }

--- a/src/data/research/problems/erdos-414.json
+++ b/src/data/research/problems/erdos-414.json
@@ -7,13 +7,28 @@
   "path": "full",
   "problemStatement": {
     "formal": "Let $h_1(n)=h(n)=n+\\tau(n)$ (where $\\tau(n)$ counts the number of divisors of $n$) and $h_k(n)=h(h_{k-1}(n))$. Is it true, for any $m,n$, there exist $i$ and $j$ such that $h_i(m)=h_j(n)$?\n\n\n\nAsked by Spiro. That is, there is (eventually) only one possible sequence that the iterations of $n\\mapsto h(n)$ can settle on. Erd\\H{o}s and Graham believed the answer is yes. Similar questions can be asked by the iterates of many other functions. See also [412] and [413].",
-    "plain": "Let $h_1(n)=h(n)=n+\\tau(n)$ (where $\\tau(n)$ counts the number of divisors of $n$) and $h_k(n)=h(h_{k-1}(n))$. Is it true, for any $m,n$, there exist $i$ and $j$ such that $h_i(m)=h_j(n)$?",
-    "whyMatters": []
+    "plain": "Spiro's question (recorded by Erdős and Graham): define h(n) = n + τ(n) where τ counts divisors. Iterating h gives an orbit n, h(n), h(h(n)), …. Question: do every two starting points eventually share a common orbit value? That is, for any m and n, do there exist i and j with h^i(m) = h^j(n)? Erdős and Graham believed the answer is YES — that all orbits eventually merge into a single tail.",
+    "whyMatters": [
+      "Tests whether the iteration n ↦ n + τ(n) has a single eventual orbit, a structural finiteness statement about an arithmetic dynamical system",
+      "Belongs to the Erdős–Spiro family of orbit-merging problems (cf. #412, #413); resolution would inform analogous questions for other arithmetic functions (e.g., n + ω(n), n + Ω(n))",
+      "Empirically verified for small starting points (orbits of 1, 4, 5, … all merge at 7 within a few steps); a proof would require quantitative control on h's orbit growth"
+    ]
   },
   "knownResults": {
-    "proven": [],
-    "open": [],
-    "goal": ""
+    "proven": [
+      "h is strictly increasing on ℕ_{≥1} (formalized: h_strictly_increasing)",
+      "h(n) ≥ n + 2 for n ≥ 2 (formalized: h_lower_bound_ge2; from {1, n} ⊆ divisors(n))",
+      "Small-orbit merges: h(4) = h(5) = 7; orbits of 1, 4, 5 merge (formalized via native_decide)",
+      "Orbit determinism: once two orbits merge they stay merged (formalized: hOrbit_continuation)",
+      "Orbit growth lower bound: orbits grow at least linearly (formalized: orbit_linear_lower)",
+      "single_eventual_orbit: the conjecture is equivalent to every orbit eventually visiting the orbit of 1"
+    ],
+    "open": [
+      "The main conjecture (erdos_414_conjecture, axiomatized): for all m, n there exist i, j with h^i(m) = h^j(n)",
+      "Quantitative bound: how large is the smallest k(m, n) such that orbits of m and n merge by step k?",
+      "Whether a similar merging holds for closely related iterations (n + ω(n), n + Ω(n), n + φ(n))"
+    ],
+    "goal": "Either prove the main conjecture (replacing the axiom with a theorem), or exhibit a starting point whose orbit never meets the orbit of 1."
   },
   "currentState": {
     "phase": "COMPLETED",
@@ -65,7 +80,8 @@
   "relatedProofs": [
     "erdos-4",
     "erdos-41",
-    "erdos-414"
+    "erdos-412",
+    "erdos-413"
   ],
   "references": {
     "papers": [],

--- a/src/data/research/problems/erdos-5.json
+++ b/src/data/research/problems/erdos-5.json
@@ -6,14 +6,27 @@
   "tier": "A",
   "path": "full",
   "problemStatement": {
-    "formal": "(LaTeX not available)",
-    "plain": "Let $C\\geq 0$. Is there an infinite sequence of $n_i$ such that\\[\\lim_{i\\to \\infty}\\frac{p_{n_i+1}-p_{n_i}}{\\log n_i}=C?\\]",
-    "whyMatters": []
+    "formal": "\\forall C \\ge 0,\\ \\exists\\ \\text{infinite sequence } (n_i)_{i \\ge 1}\\ \\text{such that}\\ \\lim_{i \\to \\infty} \\frac{p_{n_i + 1} - p_{n_i}}{\\log n_i} = C.",
+    "plain": "Erdős #5 (prime gaps): For every nonnegative real C, does there exist an infinite sequence of indices n_i such that the normalized prime gap (p_{n_i+1} - p_{n_i}) / log(n_i) converges to C? In other words, is the set of limit points of the normalized prime-gap sequence equal to all of [0, ∞]?",
+    "whyMatters": [
+      "Open Erdős prime-gap problem #5 in analytic number theory: characterizes the limit-point set of normalized prime gaps",
+      "Goldston–Pintz–Yıldırım (2009) proved 0 is a limit point (small gaps); Maynard–Tao (2013) extended this; whether every C ≥ 0 is a limit point is still open",
+      "Resolution would refine our understanding of the distributional behavior of prime gaps, beyond average and lim sup/lim inf statements"
+    ]
   },
   "knownResults": {
-    "proven": [],
-    "open": [],
-    "goal": ""
+    "proven": [
+      "0 is a limit point of (p_{n+1} - p_n)/log n (Goldston–Pintz–Yıldırım 2009; bounded gaps imply this)",
+      "Maynard–Tao (2013): bounded prime gaps; refined to gap ≤ 246 (Polymath 8b)",
+      "Westzynthius (1931): liminf is 0; lim sup is +∞ (the sequence is unbounded above)",
+      "Erickson, Goldston, Yıldırım: density results on the limit-point set"
+    ],
+    "open": [
+      "Whether every nonnegative real C is a limit point of (p_{n+1} - p_n)/log n",
+      "Whether the limit-point set has positive measure / contains an interval",
+      "Quantitative density of the limit-point set in [0, ∞]"
+    ],
+    "goal": "Either prove that the limit-point set equals [0, ∞] (every C ≥ 0 is achieved), or characterize a strict subset that contains it."
   },
   "currentState": {
     "phase": "ACT",
@@ -87,7 +100,6 @@
     "erdos"
   ],
   "relatedProofs": [
-    "erdos-5",
     "erdos-5-prime-gaps",
     "erdos-50",
     "erdos-500",
@@ -207,7 +219,7 @@
     "mathlib": []
   },
   "started": "2026-01-12T03:31:00.704Z",
-  "lastUpdate": "2026-03-24T08:00:00Z",
+  "lastUpdate": "2026-04-28T00:00:00.000Z",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [


### PR DESCRIPTION
## Summary

Pure-text reconciliation of four research-JSON entries whose metadata
had drifted from the actual Lean source / gallery state. Disk
constraints (98–100% full, ~120–435Mi free) blocked Docker builds, so
this session focused on metadata recovery — the highest-value
text-only work available.

## Bundled changes

### 1. `erdos-1173` — Free Sets for Set Mappings under GCH (open)

JSON had empty `problemStatement` ("Problem statement not found"),
empty `knownResults`, empty `whyMatters`, and a self-referential
`relatedProofs` entry. The Lean source
(`proofs/Proofs/Erdos1173Problem.lean`) and gallery `meta.json`
already encoded the actual problem (0 axioms, 0 sorries).

- Filled `problemStatement.formal`, `.plain`, `.whyMatters`
- Populated `knownResults.proven` (Hajnal regular case + 4 formalized
  Lean lemmas), `.open` (full + weak conjectures), `.goal`
- Updated `currentState` to OBSERVE / blocked-on-research-level
- Removed self-referential `relatedProofs` entry "erdos-1173"
- Added `references.papers` (Erdős-Hajnal, Ko25b #35, Va99 7.88)
- Rewrote `problem.md`, `knowledge.md`, `state.md`

### 2. `erdos-402-wip-01` — Graham's GCD Conjecture (Lean WIP)

`progressSummary` stated "433 lines, 18 theorems" but the actual
file is **693 lines, 19 theorems, 0 axioms, 1 sorry** (line 99).
Other JSON fields (`problemStatement`, `knownResults`, `leanFiles`,
`references`) were empty/null.

- `progressSummary`: real line/theorem counts and sorry location
- `problemStatement`: formal LaTeX, plain language, why-matters
- `knownResults.proven`: 5 formalized small cases + {1,2,4}
  counterexample to Graham's equality conjecture
- `knownResults.open`: general-A sieve proof + correct equality
  characterization
- `currentState.phase`: ACT, iteration 5
- `references.papers`: Graham 1970, Szegedy 1986, Zaharescu 1987,
  Balasubramanian–Soundararajan 1996
- `leanFiles`: populated with current counts
- Removed self-referential `relatedProofs` entry "erdos-402"

### 3. `erdos-5` — Prime-gap limit points (open)

- `problemStatement.formal`: was "(LaTeX not available)" despite the
  full LaTeX statement living in `.plain`. Extracted/formalized.
- `problemStatement.plain`: plain-English rewrite (limit points of
  (p_{n+1}-p_n)/log n).
- `problemStatement.whyMatters`: 3 entries (Erdős open #5,
  GPY/Maynard-Tao context, distributional refinement).
- `knownResults.proven`: GPY 2009, Maynard-Tao 2013, Westzynthius 1931,
  Erickson-Goldston-Yıldırım density.
- `knownResults.open`: full conjecture + measure / density refinements.
- `knownResults.goal`: explicit prove-or-disprove statement.
- Removed self-referential `relatedProofs` entry "erdos-5".

### 4. `erdos-414` — Spiro iteration n ↦ n + τ(n) (open, axiomatized)

- `problemStatement.plain`: plain-English rewrite with context
  (Erdős–Spiro orbit-merging family; empirical merges at 7).
- `problemStatement.whyMatters`: 3 entries (arithmetic dynamics,
  #412/#413 family, empirical evidence).
- `knownResults.proven`: 6 formalized lemmas
  (h_strictly_increasing, h_lower_bound_ge2, native_decide merges
  for {1,4,5}→7, hOrbit_continuation, orbit_linear_lower,
  single_eventual_orbit).
- `knownResults.open`: main conjecture (axiomatized) + quantitative
  merge bound + analogous iterations.
- `knownResults.goal`: replace axiom with theorem or find
  non-merging orbit.
- `relatedProofs`: replaced self-reference "erdos-414" with
  cross-references the problem statement explicitly cites
  (erdos-412, erdos-413).

## Pool hygiene side-effects

- `subset-count-multiset-oq-01`: pool entry was `in-progress` but the
  problem is fully verified (PR #9097). Marked `completed` and
  released.
- `szemeredi-full-oq-01`: documented BLOCKED in JSON but pool said
  available. Marked `blocked` and released.
- `angle-trisection-oq-02-oq-01-oq-02-incomplete-01`: known to be
  affected by 2026-04 Mathlib API drift. Marked `blocked` and
  released.
- `erdos-414`: pool entry was `in-progress` but JSON was already
  `completed`. Marked `completed` and released.

## Findings

- **Self-referential `relatedProofs` entries** (an entry referencing
  its own id) appear in many Erdős problem JSONs — this should be
  cleaned up systematically across the corpus.
- `erdos-1173`'s main conjecture is a `def : Prop` (statement only,
  not a theorem); `meta.json` correctly carries `axiomatized` / `wip`.
- `erdos-402-wip-01` has substantial small-case formalization
  (|A| ≤ 4, plus 1 ∈ A and small-min reductions); the only remaining
  gap is the Balasubramanian–Soundararajan sieve for general A.
- `erdos-414` has 6 supporting lemmas formalized with the main
  conjecture as a single axiom; this is correctly tracked but the
  proven results were not surfaced in JSON.

## Status

**Outcome**: completed (metadata reconciliation; 4 commits)
**Next Steps**:
- `erdos-1173`: literature survey of Komjáth Ko25b #35 and Vaughan
  Va99 7.88 before any further formalization attempt.
- `erdos-402-wip-01`: attempt cardinality-5 case to extend the
  small-card induction, or survey Mathlib sieve infrastructure.
- `erdos-5`: continue ongoing limit-point set work in companion files.
- `erdos-414`: investigate quantitative merge bounds k(m, n) before
  attempting the axiomatized main conjecture.

🤖 Generated by researcher-3