### PR TITLE
feat: Aristotle companion for erdos-338 (additive bases, Lagrange four-squares)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1135,6 +1135,7 @@ import Proofs.Erdos334Problem
 import Proofs.Erdos335Problem
 import Proofs.Erdos336Problem
 import Proofs.Erdos337Problem
+import Proofs.Erdos338Aristotle
 import Proofs.Erdos338Problem
 import Proofs.Erdos339Problem
 import Proofs.Erdos33Problem

--- a/proofs/Proofs/Erdos338Aristotle.lean
+++ b/proofs/Proofs/Erdos338Aristotle.lean
@@ -1,0 +1,32 @@
+/-
+  Aristotle targets for Erdős Problem #338 (Restricted Order of Additive Bases)
+  Routine supporting lemmas and known mathematical results for automated proof search.
+  See Erdos338Problem.lean for the main formalization.
+
+  Key targets:
+  1. mul_self_mem_squares: k*k ∈ squares (trivial by definition)
+  2. sq_mem_squares: k^2 ∈ squares (ring from definition)
+  3. squares_order_four_aristotle: Lagrange four-squares → IsBasisOfOrder squares 4
+     Proof route: Nat.sum_four_squares n gives a b c d with a^2+b^2+c^2+d^2=n.
+     Take N=0; witness s = {a^2, b^2, c^2, d^2} (Multiset), membership via sq_mem_squares,
+     card = 4 ≤ 4, Multiset.sum = a^2+b^2+c^2+d^2 = n.
+-/
+import Mathlib
+import Proofs.Erdos338Problem
+
+namespace Erdos338
+
+/-- k*k belongs to the squares set, directly by definition. -/
+theorem mul_self_mem_squares (k : ℕ) : k * k ∈ squares := ⟨k, rfl⟩
+
+/-- k^2 belongs to the squares set (since k^2 = k*k). -/
+theorem sq_mem_squares (k : ℕ) : k ^ 2 ∈ squares := by sorry
+
+/-- Lagrange's four-squares theorem recast as IsBasisOfOrder.
+    Every natural number n is a sum of four perfect squares (Nat.sum_four_squares).
+    Proof: take N = 0; for any n ≥ 0, Nat.sum_four_squares n gives a b c d with
+    a^2 + b^2 + c^2 + d^2 = n. Use multiset {a^2, b^2, c^2, d^2}:
+    each element is in squares, card = 4 ≤ 4, Multiset.sum = n. -/
+theorem squares_order_four_aristotle : IsBasisOfOrder squares 4 := by sorry
+
+end Erdos338


### PR DESCRIPTION
## Fix

Adds `Erdos338Aristotle.lean` — an Aristotle companion file for Erdős Problem #338 (Restricted Order of Additive Bases).

## Evidence

**Before**: `Erdos338Problem.lean` uses `axiom squares_order_four` (Lagrange four-squares) and related supporting facts as unproved axioms.

**After**: Companion file exposes three targets for Aristotle's automated proof search:
- `mul_self_mem_squares (k : ℕ) : k * k ∈ squares` — trivial membership lemma
- `sq_mem_squares (k : ℕ) : k ^ 2 ∈ squares` — definitional ring lemma
- `squares_order_four_aristotle : IsBasisOfOrder squares 4` — Lagrange's theorem in `IsBasisOfOrder` form, connecting Mathlib's `Nat.sum_four_squares` to the custom definition

Proof route hint for `squares_order_four_aristotle`: `Nat.sum_four_squares n` gives `a b c d` with `a^2 + b^2 + c^2 + d^2 = n`; take `N = 0`, witness multiset `{a^2, b^2, c^2, d^2}`.

Note: disk full prevents Docker build validation; Aristotle will validate on submission.

---
Automated fix by lean-mechanic agent.