### PR TITLE
Research: bertrands-postulate-oq-03-oq-04 metadata reconcile (completed)

### DIFF
--- a/research/problems/bertrands-postulate-oq-03-oq-04/knowledge.md
+++ b/research/problems/bertrands-postulate-oq-03-oq-04/knowledge.md
@@ -41,3 +41,28 @@ The PNT prediction: π(x+h) - π(x) ~ h/ln(x) when h is not too small.
 
 #### Next Steps
 None — all sorries resolved. Problem correctly axiomatized.
+
+### Session 2026-04-28 (Session 2) - Metadata Reconciliation
+
+**Mode**: REVISIT
+**Outcome**: completed
+
+#### What I Did
+- Verified actual Lean state via `git show HEAD:`:
+  - BertrandsPostulateOQ03OQ04.lean: 0 sorries, 1 axiom
+  - BertrandsPostulateOQ03OQ04Aristotle.lean: 0 sorries, 0 axioms
+  - BertrandsPostulateOQ03OQ04OQ03.lean: 0 sorries (JSON had stale 1)
+  - Gallery meta.json: status `axiomatized`, badge `axiom`, sorries 0 — correct
+- Reconciled JSON: phase NEW→COMPLETED, status active→completed, sorryCount 1→0 for OQ03 sub-file
+- Updated progressSummary, lastUpdate, nextSteps cleared
+- No code changes — pool entry was simply stale (`active` despite work done in 2026-04-22 session)
+
+#### Key Findings
+- The single remaining axiom `shortIntervalPNT_rh_conditional` encodes RH + von-Koch error term;
+  this is a deep result, NOT provable from current Mathlib — keeping as axiom is correct
+- Pool sweep value: this is exactly the kind of stale `status: active` flagged in researcher feedback
+  memory — high-knowledge problems with completed work but uncleaned pool metadata
+
+#### Files Modified
+- src/data/research/problems/bertrands-postulate-oq-03-oq-04.json (phase, status, sorryCount fix)
+- research/problems/bertrands-postulate-oq-03-oq-04/knowledge.md (this entry)

--- a/src/data/research/problems/bertrands-postulate-oq-03-oq-04.json
+++ b/src/data/research/problems/bertrands-postulate-oq-03-oq-04.json
@@ -1,8 +1,8 @@
 {
   "slug": "bertrands-postulate-oq-03-oq-04",
   "title": "PNT-based asymptotic for prime gaps in short intervals",
-  "phase": "NEW",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {
@@ -16,20 +16,20 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-04-05T05:54:09.851Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "phase": "COMPLETED",
+    "since": "2026-04-28T00:00:00.000Z",
+    "iteration": 3,
+    "focus": "Problem axiomatized; metadata reconciled.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "None — gallery entry verified axiomatized with 1 deep RH-conditional axiom.",
     "attemptCounts": {
-      "total": 0,
+      "total": 3,
       "currentApproach": 0,
       "approachesTried": 0
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Created BertrandsPostulateOQ03OQ04.lean (323 lines). Builds with 2 sorries + 1 axiom. Proves ShortIntervalPNT density implies PrimeGapConjecture existence; log ratio lemma proved; RH-conditional density axiomatized.",
+    "progressSummary": "COMPLETED: BertrandsPostulateOQ03OQ04.lean (358 lines, 0 sorries, 1 RH-conditional axiom). Companion Aristotle file 0 sorries. Sub-file OQ03OQ04OQ03.lean has 0 sorries. Gallery status: axiomatized (1 deep axiom shortIntervalPNT_rh_conditional encoding the RH+von-Koch density bound).",
     "builtItems": [
       "BertrandsPostulateOQ03OQ04.lean: ShortIntervalPNT def + 7 proved/partial theorems",
       "Gallery entry: src/data/proofs/bertrands-postulate-oq-03-oq-04/meta.json"
@@ -42,10 +42,7 @@
       "Filter limit algebra for combining PNT limits is the hard part — 2 sorries remain"
     ],
     "mathlibGaps": [],
-    "nextSteps": [
-      "Prove long_interval_density_from_pnt: need pnt_1c.mul hlog_ratio filter algebra",
-      "Submit sorries to Aristotle for automated search"
-    ]
+    "nextSteps": []
   },
   "tags": [
     "seeker-selected"
@@ -62,7 +59,7 @@
     "mathlib": []
   },
   "started": "2026-04-05T05:54:09.851Z",
-  "lastUpdate": "2026-04-05T05:54:09.851Z",
+  "lastUpdate": "2026-04-28T00:00:00.000Z",
   "significance": 7,
   "tractability": 4,
   "leanFiles": [
@@ -117,7 +114,7 @@
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BertrandsPostulateOQ03OQ04OQ03.lean"
     }


### PR DESCRIPTION
## Summary
Pool sweep: `bertrands-postulate-oq-03-oq-04` was stale (status: `active`) despite work having been completed in the prior 2026-04-22 session. Reconciles the JSON metadata to reflect actual gallery state.

## Verification (against `git show HEAD:`)
- `BertrandsPostulateOQ03OQ04.lean`: 0 sorries, 1 axiom (`shortIntervalPNT_rh_conditional`)
- `BertrandsPostulateOQ03OQ04Aristotle.lean`: 0 sorries, 0 axioms
- `BertrandsPostulateOQ03OQ04OQ03.lean`: **0 sorries** (JSON had stale `sorryCount: 1`)
- Gallery `meta.json`: status `axiomatized`, badge `axiom`, sorries `0` — already correct

## Changes
- `src/data/research/problems/bertrands-postulate-oq-03-oq-04.json`
  - `phase`: `NEW` → `COMPLETED`
  - `status`: `active` → `completed`
  - `currentState.phase`/`focus`/`nextAction` updated
  - `progressSummary` rewritten to reflect actual state
  - `nextSteps` cleared
  - `leanFiles[OQ03OQ04OQ03].sorryCount`: `1` → `0` (matches actual file)
  - `lastUpdate` bumped
- `research/problems/bertrands-postulate-oq-03-oq-04/knowledge.md` — Session 2 entry appended

## Why the axiom remains
`shortIntervalPNT_rh_conditional` encodes RH + von-Koch error term giving primes density in `[x, x + x^(1/2+ε)]`. Deep result, not provable from current Mathlib — keeping as axiom is correct per axiom integrity policy.

## Status
**Outcome**: completed (metadata reconciliation only, no Lean changes)
**Next Steps**: None for this problem family.

🤖 Generated by researcher-7