### PR TITLE
feat: Aristotle companion for erdos-339 (additive bases, Lagrange four-squares)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1135,7 +1135,9 @@ import Proofs.Erdos334Problem
 import Proofs.Erdos335Problem
 import Proofs.Erdos336Problem
 import Proofs.Erdos337Problem
+import Proofs.Erdos338Aristotle
 import Proofs.Erdos338Problem
+import Proofs.Erdos339Aristotle
 import Proofs.Erdos339Problem
 import Proofs.Erdos33Problem
 import Proofs.Erdos340GreedySidon

--- a/proofs/Proofs/Erdos339Aristotle.lean
+++ b/proofs/Proofs/Erdos339Aristotle.lean
@@ -1,0 +1,34 @@
+/-
+  Aristotle targets for Erdős Problem #339 (Additive Bases and Distinct Element Sums)
+  Routine supporting lemma for automated proof search.
+  See Erdos339Problem.lean for the main formalization.
+
+  Key target:
+  1. squares_basis_of_order_4_aristotle: Lagrange's four-squares theorem recast as
+     IsBasisOfOrder {n | ∃ m, n = m^2} 4.
+     Proof route: Nat.sum_four_squares n gives a b c d with a^2+b^2+c^2+d^2=n.
+     Take N=0; witness f = ![a^2, b^2, c^2, d^2] : Fin 4 → ℕ,
+     membership via ⟨a, rfl⟩ etc., sum via Fin.sum_univ_four.
+
+  Note: hegyvari_hennecart_plagne_1 and _2 are deep theorems from combinatorics
+  (HHP 2003); Aristotle cannot prove them.
+-/
+import Mathlib
+import Proofs.Erdos339Problem
+
+namespace Erdos339
+
+/-- Lagrange's four-squares theorem gives IsBasisOfOrder for squares.
+    Proof: Nat.sum_four_squares gives a b c d with a^2+b^2+c^2+d^2=n;
+    use f = ![a^2, b^2, c^2, d^2], N = 0. -/
+theorem squares_basis_of_order_4_aristotle :
+    IsBasisOfOrder { n | ∃ m, n = m^2 } 4 := by
+  use 0
+  intro n _
+  obtain ⟨a, b, c, d, h⟩ := Nat.sum_four_squares n
+  refine ⟨![a^2, b^2, c^2, d^2], ?_, ?_⟩
+  · intro i
+    fin_cases i <;> simp [Set.mem_setOf_eq] <;> exact ⟨_, rfl⟩
+  · simp [Fin.sum_univ_four, ← h]
+
+end Erdos339


### PR DESCRIPTION
## Fix

Creates an Aristotle companion file for Erdős Problem #339 (Additive Bases and Distinct Element Sums).

## Evidence

**Before**: No companion file; `squares_basis_of_order_4` axiom in main file had no Aristotle target

**After**: `Erdos339Aristotle.lean` exposes `squares_basis_of_order_4_aristotle` — the Lagrange four-squares theorem cast as `IsBasisOfOrder {n | ∃ m, n = m^2} 4` — for automated proof search.

The proof strategy uses `Nat.sum_four_squares n` (Mathlib) to get `a b c d` with `a²+b²+c²+d²=n`, then constructs `f = ![a², b², c², d²] : Fin 4 → ℕ`.

The two deep results (`hegyvari_hennecart_plagne_1` and `_2`) are excluded — they are complex combinatorics theorems Aristotle cannot discover.

---
Automated fix by lean-mechanic agent.