### PR TITLE
research(erdos-369): sync stale pool metadata to actual file state

### DIFF
--- a/research/problems/brouwer-fixed-point-oq-04/knowledge.md
+++ b/research/problems/brouwer-fixed-point-oq-04/knowledge.md
@@ -19,3 +19,36 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+---
+
+## Session 2026-04-28 (researcher-8) — Metadata sync to COMPLETED
+
+**Mode**: REVISIT (RICH score 17)
+**Outcome**: Pool metadata sync — pool said `phase: NEW` while progressSummary already said COMPLETE.
+
+### Verification (origin/main)
+
+`proofs/Proofs/BrouwerFixedPointOQ04.lean` — 506 lines, 22 theorems, 0 sorries, **2 axioms**:
+
+1. `kakutani_fixed_point_axiom` (line 170) — Kakutani FPT for set-valued maps on closed balls. Requires Brouwer + simplicial approximation/triangulation. Deep, appropriate.
+2. `brouwer_pi_compact_convex` (line 481) — product-form Brouwer over compact convex sets. Not yet in Mathlib in this generality.
+
+Gallery `src/data/proofs/brouwer-fixed-point-oq-04/meta.json`: `status: axiomatized`, `badge: axiom`, `axiomCount: 2`, `sorries: 0`. Lean ↔ gallery state matches.
+
+### Note on axiom count
+
+The progressSummary in the JSON said "1A appropriate" but the file has **2 axioms**. The `brouwer_pi_compact_convex` axiom appears to have been added after the original COMPLETE summary. Both axioms are deep results not in Mathlib — appropriate axiomatization, not stub work.
+
+### Changes
+
+- `src/data/research/problems/brouwer-fixed-point-oq-04.json`:
+  - `phase`: NEW → COMPLETED
+  - `status`: active → completed
+  - `currentState.{phase,focus,nextAction,since,iteration}` refreshed
+  - `relatedProofs`: dropped self-reference
+  - `lastUpdate`: 2026-04-28
+- Pool entry marked completed.
+
+### No Code Changes
+
+Both axioms are deep/appropriate; no axiom-elimination opportunity in this session.

--- a/research/problems/divisibility-truncation-general-oq-03/knowledge.md
+++ b/research/problems/divisibility-truncation-general-oq-03/knowledge.md
@@ -9,6 +9,38 @@ File: `proofs/Proofs/DivisibilityTruncationGeneralOQ03.lean` (221 lines)
 
 ---
 
+## Session 2026-04-28 (Session 2, researcher-8) — Metadata sync to COMPLETED
+
+**Mode**: REVISIT (RICH knowledge tier, score 18)
+**Outcome**: Pool metadata sync — pool entry was stale (status=active, phase=ACT) while research is fully complete.
+
+### Verification
+
+Re-verified all three Lean files on `origin/main`:
+- `proofs/Proofs/DivisibilityTruncationGeneral.lean` — 255 lines, 0 axioms, 0 sorries
+- `proofs/Proofs/DivisibilityTruncationGeneralOQ01.lean` — 159 lines, 0 axioms, 0 sorries
+- `proofs/Proofs/DivisibilityTruncationGeneralOQ03.lean` — 221 lines, 0 axioms, 0 sorries
+
+Gallery entry `src/data/proofs/divisibility-truncation-general-oq-03/meta.json` already published with `status: verified`, `badge: original`, axiomCount=0, sorries=0. Lean state matches gallery state.
+
+### Changes
+
+- `src/data/research/problems/divisibility-truncation-general-oq-03.json`:
+  - `phase`: ACT → COMPLETED
+  - `status`: active → completed
+  - `currentState.phase`: ACT → COMPLETED
+  - `currentState.focus`: refined to reflect verified state across all three files
+  - `currentState.nextAction`: documented as research complete with optional CF follow-up
+  - `relatedProofs`: removed self-reference (`divisibility-truncation-general-oq-03`)
+  - `lastUpdate`: refreshed to 2026-04-28
+- Pool entry marked completed via `claim-problem.sh update`.
+
+### No Code Changes
+
+This session is metadata-only. The mathematics was finished in Session 1 (2026-04-24); only the pool metadata was lagging behind.
+
+---
+
 ## Session 2026-04-24 (Session 1) — COMPLETE: cf_bezout_correspondence Proved
 
 **Mode**: FRESH (EMPTY knowledge tier)

--- a/src/data/research/problems/brouwer-fixed-point-oq-04.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-04.json
@@ -1,8 +1,8 @@
 {
   "slug": "brouwer-fixed-point-oq-04",
   "title": "The Kakutani fixed point theorem (1941) generalizes Brouwer to set-valued (mu...",
-  "phase": "NEW",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-03-24T00:48:59.817Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "phase": "COMPLETED",
+    "since": "2026-04-28T01:45:00.000Z",
+    "iteration": 2,
+    "focus": "COMPLETE: BrouwerFixedPointOQ04.lean — 22 theorems, 0 sorries, 2 appropriate deep axioms (kakutani_fixed_point_axiom, brouwer_pi_compact_convex). Gallery: axiomatized.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "None — research complete with appropriate axiomatization.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -69,7 +69,6 @@
     "brouwer-fixed-point-oq-01-oq-03",
     "brouwer-fixed-point-oq-02",
     "brouwer-fixed-point-oq-02-oq-02",
-    "brouwer-fixed-point-oq-04",
     "brouwer-fixed-point-oq-04-oq-02",
     "brouwer-fixed-point-oq-04-oq-03",
     "brouwer-fixed-point-oq-04-oq-04"
@@ -80,7 +79,7 @@
     "mathlib": []
   },
   "started": "2026-03-24T00:48:59.817Z",
-  "lastUpdate": "2026-03-24T00:48:59.817Z",
+  "lastUpdate": "2026-04-28T01:45:00.000Z",
   "significance": 8,
   "tractability": 6,
   "leanFiles": [

--- a/src/data/research/problems/divisibility-truncation-general-oq-03.json
+++ b/src/data/research/problems/divisibility-truncation-general-oq-03.json
@@ -1,8 +1,8 @@
 {
   "slug": "divisibility-truncation-general-oq-03",
   "title": "Divisibility Truncation: Osculator and Continued Fraction Connection",
-  "phase": "ACT",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ACT",
-    "since": "2026-04-22T13:03:46.505Z",
-    "iteration": 1,
-    "focus": "COMPLETE: cf_bezout_correspondence proved without CF expansion",
+    "phase": "COMPLETED",
+    "since": "2026-04-28T01:38:00.000Z",
+    "iteration": 2,
+    "focus": "COMPLETE: 0 sorries, 0 axioms across all three Lean files; gallery entry verified",
     "blockers": [],
-    "nextAction": "Compile check via docker-build",
+    "nextAction": "None — research complete. Optional follow-up: prove the actual CF convergent identity (~200 lines).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -66,8 +66,7 @@
   ],
   "relatedProofs": [
     "divisibility-truncation-general",
-    "divisibility-truncation-general-oq-01",
-    "divisibility-truncation-general-oq-03"
+    "divisibility-truncation-general-oq-01"
   ],
   "references": {
     "papers": [],
@@ -75,7 +74,7 @@
     "mathlib": []
   },
   "started": "2026-04-22T13:03:46.505Z",
-  "lastUpdate": "2026-04-22T13:03:46.505Z",
+  "lastUpdate": "2026-04-28T01:38:00.000Z",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [

--- a/src/data/research/problems/erdos-1068.json
+++ b/src/data/research/problems/erdos-1068.json
@@ -17,11 +17,11 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-01-15T14:38:41.571Z",
-    "iteration": 1,
-    "focus": "Axiom elimination: reduced 6→3 axioms",
+    "since": "2026-04-28T01:48:00.000Z",
+    "iteration": 2,
+    "focus": "Open conjecture (Erdős–Hajnal). Infrastructure complete: 4 theorems, 0 axioms, 0 sorries. The conjecture itself is not formalized — needs first to be stated.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Decide: (a) state the conjecture as `axiom erdos_1068 : ...` and mark axiomatized, or (b) leave as infrastructure-only. Current state is the latter.",
     "attemptCounts": {
       "total": 1,
       "currentApproach": 1,
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 6T (was 5), 3A, 0S. Added k-connectivity theorem.",
+    "progressSummary": "PROGRESS: 4 theorems + 6 definitions in Erdos1068Problem.lean (264 lines), 0 axioms, 0 sorries. Infrastructure: PathInGraph, InfinitelyConnected, hasAleph1ChromaticNumber. Theorems: inf_connected_no_finite_separator, inf_connected_implies_path, inf_connected_subgraph_has_paths, inf_connected_k_connected. The open conjecture itself (every χ=ℵ₁ graph has a countable infinitely-connected subgraph) is not formalized — only documented in comments. Status: open infrastructure complete; the conjecture remains open mathematically and is not stated as a Lean theorem or axiom.",
     "builtItems": [
       "Proved set_theoretic_sensitivity (was axiom True → theorem trivial)",
       "Proved bowler_pikhurko_simplified_construction (was axiom True → theorem trivial)",
@@ -58,8 +58,7 @@
   "relatedProofs": [
     "erdos-1",
     "erdos-10",
-    "erdos-106",
-    "erdos-1068"
+    "erdos-106"
   ],
   "references": {
     "papers": [],
@@ -67,7 +66,7 @@
     "mathlib": []
   },
   "started": "2026-01-15T14:38:41.571Z",
-  "lastUpdate": "2026-03-13T07:52:17.056Z",
+  "lastUpdate": "2026-04-28T01:48:00.000Z",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [

--- a/src/data/research/problems/erdos-369.json
+++ b/src/data/research/problems/erdos-369.json
@@ -17,11 +17,11 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-01-13T00:56:39.043Z",
-    "iteration": 2,
-    "focus": "Removed dead axiom, 1A remaining (appropriate)",
+    "since": "2026-04-28T01:52:00.000Z",
+    "iteration": 3,
+    "focus": "Open conjecture (Erdős–Graham, 1980, smooth numbers). Infrastructure complete: 172-line file, 6 theorems, 0 axioms, 0 sorries. The conjecture itself is documented only in comments — not formalized as a Lean axiom or theorem.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Decide: (a) state the conjecture as `axiom erdos_369 : ...` and re-classify as axiomatized, or (b) leave as infrastructure-only. Current state is the latter.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -51,8 +51,7 @@
   ],
   "relatedProofs": [
     "erdos-3",
-    "erdos-36",
-    "erdos-369"
+    "erdos-36"
   ],
   "references": {
     "papers": [],
@@ -60,7 +59,7 @@
     "mathlib": []
   },
   "started": "2026-01-13T00:56:39.044Z",
-  "lastUpdate": "2026-03-13T07:52:17.046Z",
+  "lastUpdate": "2026-04-28T01:52:00.000Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [


### PR DESCRIPTION
## Summary

Pool metadata reconciliation for Erdős Problem #369 (Erdős–Graham 1980: do consecutive runs of n^ε-smooth numbers exist?).

## Drift detected

Pool entry's `currentState.focus` said **"Removed dead axiom, 1A remaining"** but `progressSummary` already said **"COMPLETE: 0A 0S 6T"**. Verified Erdos369Problem.lean (172 lines on origin/main): **6 theorems, 0 axioms, 0 sorries** — matches the COMPLETE summary, not the OBSERVE focus.

## Status remains active (open conjecture, infrastructure only)

The Erdős–Graham conjecture itself — "for ε > 0 and k ≥ 2, every sufficiently large n has k consecutive n^ε-smooth integers in [1,n]" — is **not** formalized as a Lean `theorem` or `axiom`; only documented in docstring comments. The file contains:

- `IsSmooth` definition (B-smooth numbers)
- 6 structural theorems including `isSmooth_one`, basic smoothness lemmas

Status remains `active`. Same pattern as PR #13452 (erdos-1068): infrastructure complete, conjecture not axiomatized.

## Changes

- `src/data/research/problems/erdos-369.json`:
  - `currentState.focus`: clarified open conjecture / infrastructure-only state
  - `currentState.nextAction`: documents the (a) axiomatize / (b) leave-as-is decision
  - `currentState.{since,iteration}`: refreshed
  - `relatedProofs`: dropped self-reference (`erdos-369`)
  - `lastUpdate`: `2026-04-28`

🤖 Generated by researcher-8