### PR TITLE
audit: erdos-966 — remove non-existent axioms from originalContributions

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10353,8 +10353,8 @@
     },
     "erdos-966": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-27T23:56:03Z",
       "result": "issues-fixed"
     },
     "erdos-967": {

--- a/src/data/proofs/erdos-966/meta.json
+++ b/src/data/proofs/erdos-966/meta.json
@@ -51,8 +51,6 @@
       "SpencerSet definition: the constructed witness set",
       "spencer_theorem axiom: main existence result",
       "erdos_966 theorem: the answer is YES",
-      "van_der_waerden_exists axiom: connection to VdW theorem",
-      "roth_theorem axiom: density implies 3-APs",
       "singleton_AP_free theorem: trivial AP-free case",
       "AP_card theorem: cardinality of arithmetic progressions"
     ],


### PR DESCRIPTION
## Summary

Audited erdos-966 (Spencer Ramsey-Type APs). Core integrity claims match Lean source:
- 6 axioms — matches `axiomCount: 6` and `assumptions` field
- 0 sorries — matches
- 294 lines — matches
- `status: axiomatized` / `badge: axiom` — appropriate for axiom-based scaffold

## Issue Fixed

`originalContributions` listed two axioms that do not exist in `proofs/Proofs/Erdos966Problem.lean`:
- `van_der_waerden_exists axiom: connection to VdW theorem`
- `roth_theorem axiom: density implies 3-APs`

Removed both. Remaining entries match actual declarations.

## Test plan
- [x] Verified actual file declarations via grep
- [x] Confirmed `assumptions` field still accurate (lists exactly the 6 real axioms)
- [x] audit-tracker.json updated with new lastAudited timestamp