### PR TITLE
fix(herald): verify Lean file via meta.json path

### DIFF
--- a/scripts/herald/post-mathstodon.sh
+++ b/scripts/herald/post-mathstodon.sh
@@ -304,18 +304,17 @@ if [[ ${#_proof_slugs[@]} -gt 0 ]]; then
             continue
         fi
 
-        # Check 4: Lean source file exists
-        # Convert slug to a case-insensitive search pattern (remove hyphens)
-        _lean_pattern=$(echo "$_slug" | tr -d '-')
-        _lean_found=false
-        # Search proofs/Proofs/ for a .lean file matching the slug (case-insensitive)
-        while IFS= read -r _match; do
-            _lean_found=true
-            break
-        done < <(find "$REPO_ROOT/proofs/Proofs" -maxdepth 1 -iname "${_lean_pattern}.lean" -type f 2>/dev/null)
-        if [[ "$_lean_found" != "true" ]]; then
+        # Check 4: Lean source file exists at the path declared in meta.json
+        _lean_path=$(jq -r '.leanFile.path // empty' "$_meta" 2>/dev/null)
+        if [[ -z "$_lean_path" ]]; then
             echo -e "${RED}Error: Proof page verification failed for '$_slug'${NC}" >&2
-            echo -e "${RED}  Lean source file not found in proofs/Proofs/ (searched for ${_lean_pattern}.lean)${NC}" >&2
+            echo -e "${RED}  meta.json leanFile.path is missing${NC}" >&2
+            _verify_failed=true
+            continue
+        fi
+        if [[ ! -f "$REPO_ROOT/proofs/$_lean_path" ]]; then
+            echo -e "${RED}Error: Proof page verification failed for '$_slug'${NC}" >&2
+            echo -e "${RED}  Lean source file not found: proofs/$_lean_path${NC}" >&2
             _verify_failed=true
             continue
         fi


### PR DESCRIPTION
## Summary

Fix Check 4 in `post-mathstodon.sh` to use the authoritative `leanFile.path` from meta.json instead of a slug-derived heuristic.

The previous check stripped hyphens from the slug and searched for `<slug>.lean`, which false-positive-rejected any proof whose Lean file has a descriptive suffix.

Concrete example that triggered this:
- Slug: `erdos-1178`
- Actual file: `proofs/Proofs/Erdos1178Problem.lean`
- Old check searched for `erdos1178.lean` → not found → post blocked

The herald is currently the only consumer of this verification, and it was unable to post about Erdős #1178 (Brown-Erdős-Sós) until the verification was patched in the working tree. This commit moves that fix to a permanent home.

## Test plan

- [x] Manually ran `--dry-run` against `erdos-1178`: previously failed Check 4, now passes via `leanFile.path` lookup
- [x] Posted live to verify end-to-end: https://mathstodon.xyz/@rjwalters/116479437438643871
- [ ] (No automated tests for this script in repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)