### PR TITLE
feat: Aristotle companion for erdos-755 (equilateral triangles in R6)

### DIFF
--- a/proofs/Proofs/Erdos755Aristotle.lean
+++ b/proofs/Proofs/Erdos755Aristotle.lean
@@ -1,0 +1,52 @@
+/-
+  Aristotle targets for Erdős Problem #755 (Equilateral Triangles in ℝ⁶)
+  Routine supporting lemmas for automated proof search.
+  See Erdos755Problem.lean for the main formalization.
+
+  Key target:
+  T6_unit_le_T6_aristotle: T₆ᵘ(n) ≤ T₆(n).
+
+  Proof route:
+  1. unit_implies_equilateral: IsUnitEquilateralTriangle → IsEquilateralTriangle
+     (all sides = 1 implies sides equal and positive)
+  2. For any configuration P, the unit triangle vertex count ≤ general vertex count
+     (filter monotonicity via Finset.card_le_card + Finset.filter_subset_filter)
+  3. Hence sSup of unit counts ≤ sSup of general counts (csSup_le + le_csSup).
+-/
+import Mathlib
+import Proofs.Erdos755Problem
+
+namespace Erdos755
+
+variable {d : ℕ}
+
+/-- A unit equilateral triangle (all sides = 1) is an equilateral triangle
+    (all sides equal, positive length). -/
+theorem unit_implies_equilateral (p₁ p₂ p₃ : Fin d → ℝ)
+    (h : IsUnitEquilateralTriangle p₁ p₂ p₃) : IsEquilateralTriangle p₁ p₂ p₃ := by
+  sorry
+
+/-- For any point configuration P, the count of vertices in unit equilateral triangles
+    is ≤ the count of vertices in any equilateral triangles. -/
+theorem unit_count_le_eq_count (P : Finset (Fin 6 → ℝ)) :
+    (P.filter (fun p₁ =>
+      (P.filter (fun p₂ =>
+        (P.filter (fun p₃ =>
+          IsUnitEquilateralTriangle p₁ p₂ p₃ ∧ p₁ < p₂ ∧ p₂ < p₃
+        )).card > 0
+      )).card > 0
+    )).card ≤
+    (P.filter (fun p₁ =>
+      (P.filter (fun p₂ =>
+        (P.filter (fun p₃ =>
+          IsEquilateralTriangle p₁ p₂ p₃ ∧ p₁ < p₂ ∧ p₂ < p₃
+        )).card > 0
+      )).card > 0
+    )).card := by
+  sorry
+
+/-- T₆ᵘ(n) ≤ T₆(n): unit triangle vertex count ≤ equilateral triangle vertex count. -/
+theorem T6_unit_le_T6_aristotle (n : ℕ) : T6_unit n ≤ T6 n := by
+  sorry
+
+end Erdos755


### PR DESCRIPTION
## Fix

Add Aristotle companion file for Erdős Problem #755 (Equilateral Triangles in ℝ⁶).

## Evidence

**Problem**: `Erdos755Problem.lean` has one sorry: `T6_unit_le_T6 : T6_unit n ≤ T6 n`.

**Companion exposes**:
- `unit_implies_equilateral`: IsUnitEquilateralTriangle → IsEquilateralTriangle (trivial: all sides=1 implies equal+positive)
- `unit_count_le_eq_count`: For any configuration P, unit vertex count ≤ equilateral vertex count (filter monotonicity)
- `T6_unit_le_T6_aristotle`: sSup bound via the above (Aristotle target)

**Proof route**: unit → equilateral by definition; filter monotonicity gives count ≤; csSup_le + le_csSup gives sSup ≤.

**Checklist**:
- [x] No `def := sorry`
- [x] No `axiom` declarations
- [x] No `theorem : True`
- [x] No `/-!` docstrings
- [x] No open conjectures (T6_unit ≤ T6 is proved in the literature)
- [x] `pnpm build` passes

---
Automated fix by lean-mechanic agent.