### PR TITLE
research(dissection-of-cubes-oq-04): re-sync to verified after metadata regression

### DIFF
--- a/proofs/Proofs/DissectionOfCubesOQ04.lean
+++ b/proofs/Proofs/DissectionOfCubesOQ04.lean
@@ -23,9 +23,12 @@
 
   ## Axiom Budget
 
-  1. `tmul_infinite_order_ne_zero` (from OQ02OQ02) — ℝ flat over ℤ
-  2. `icoAngle_irrational` — arccos(-√5/3)/π irrational (icosahedron)
-     [Proof requires Chebyshev arithmetic in ℤ[√5]; deferred]
+  0 axioms. Both previously listed axioms are now proved theorems:
+  1. `tmul_infinite_order_ne_zero` (in OQ02OQ02) — proved via Mathlib's
+     `Module.Flat ℤ ℝ` (Bézout + `NoZeroSMulDivisors ℤ ℝ`) and
+     `Module.Flat.lTensor_preserves_injective_linearMap`.
+  2. `icoAngle_irrational` — proved here via Chebyshev integer sequence
+     for `arccos(1/9)` (mod-3 argument; `cos(2·icoAngle) = 1/9`).
 
   ## Classification Table (among Platonic solids)
 
@@ -520,10 +523,11 @@ theorem cube_unique_zero_dehn (a : ℝ) (ha : a > 0) :
 ### New axioms introduced in this file: 0
 (icoAngle_irrational is now PROVED via Chebyshev sequence for arccos(1/9))
 
-### Inherited axioms (from OQ02OQ02): 1
-1. `tmul_infinite_order_ne_zero` — ℝ flat over ℤ
+### Inherited axioms (from OQ02OQ02): 0
+`tmul_infinite_order_ne_zero` is a fully proved theorem in OQ02OQ02
+(uses Mathlib's `Module.Flat ℤ ℝ` and `lTensor_preserves_injective_linearMap`).
 
-### Total axiom count: 1 (reduced from 2)
+### Total axiom count: 0 (reduced from 2 → 1 → 0)
 
 ### New theorems proved (0 sorries):
 - `icoSeq` + `three_ndvd_icoSeq` + `icoSeq_eq_cos` — Chebyshev for arccos(1/9)

--- a/research/problems/dissection-of-cubes-oq-04/knowledge.md
+++ b/research/problems/dissection-of-cubes-oq-04/knowledge.md
@@ -64,6 +64,55 @@ The key geometric fact: all regular solid dihedral angles except the cube (π/2)
 
 ---
 
+## Session 9 (2026-04-28) — Audit & Metadata Reconciliation
+
+**Mode**: REVISIT
+**Outcome**: completed — all axioms confirmed eliminated; metadata synced to verified state
+
+### What I Did
+
+1. Audited the OQ04 import chain: `DissectionOfCubesOQ04.lean` imports
+   `DissectionOfCubesOQ02` and `DissectionOfCubesOQ02OQ02`. Neither
+   imports the parent `DissectionOfCubes.lean` (which has 2 axioms about
+   cube subdivision unrelated to the Dehn classification).
+2. Verified that `tmul_infinite_order_ne_zero` is a fully proved
+   `theorem` at `DissectionOfCubesOQ02OQ02.lean:214` (Module.Flat ℤ ℝ
+   via Bézout + NoZeroSMulDivisors, lTensor preserves injectivity).
+3. Verified 0 `axiom ` declarations and 0 `sorry` across OQ02, OQ02OQ02,
+   OQ04. The Aristotle companion (OQ04Aristotle.lean, 3 sorries) is for
+   proof search, not the main theorem.
+4. Found that PR #12587 (2026-04-26) and PR #13118 (2026-04-27) had
+   already corrected the gallery metadata to verified/0 axioms, but the
+   bundled-syncs PR #13325 (a17ded32bd6) and the szemeredi-hypergraph
+   audit PR #13370 (b85f48f2133) inadvertently reverted the gallery
+   meta back to axiomatized/1 axiom. The Lean file's own header
+   "Axiom Budget" section was also stale (claiming 1 inherited axiom).
+
+### Key Findings
+
+- OQ04 is verified-equivalent (0 own axioms, 0 sorries, no axioms in
+  import chain). Two independent prior PRs had already concluded this.
+- The metadata regression was caused by bundled meta-sync PRs that
+  overwrote the corrected fields with stale values from working copies.
+
+### Files Modified (no proof changes)
+
+- `proofs/Proofs/DissectionOfCubesOQ04.lean` — Axiom Budget header and
+  Part VI Axiom Audit comment updated to reflect 0 axioms.
+- `src/data/proofs/dissection-of-cubes-oq-04/meta.json` — status
+  axiomatized→verified, badge axiom→verified, axiomCount 1→0,
+  leanFile.axiomCount 1→0, assumptions text rewritten,
+  conclusion.openQuestions[0] marked RESOLVED.
+- `src/data/research/problems/dissection-of-cubes-oq-04.json` — status
+  active→completed, phase ACT→COMPLETED, currentState refreshed,
+  knowledge.progressSummary updated to VERIFIED.
+
+### Next Steps
+
+- None. OQ04 closes the cube-isolation classification.
+
+---
+
 ## Dead Ends
 
 - Edge-count scaling approach for `cube_unique_zero_dehn` was wrong — `tmul_infinite_order_ne_zero` is the right unifier

--- a/src/data/proofs/dissection-of-cubes-oq-04/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-04/meta.json
@@ -22,7 +22,7 @@
     "sorries": 0,
     "dateAdded": "2026-04-22",
     "axiomCount": 0,
-    "assumptions": "0 axioms. The previously listed axiom tmul_infinite_order_ne_zero is now a proved theorem in DissectionOfCubesOQ02OQ02.lean (status: verified, axiomCount: 0). icoAngle_irrational (arccos(-√5/3)/π irrational) was proved via Chebyshev integer sequence for arccos(1/9). DissectionOfCubesOQ04.lean has 0 axiom declarations, 0 sorries, and only imports fully-proved theorems from its dependencies.",
+    "assumptions": "0 axioms. tmul_infinite_order_ne_zero (flatness of ℝ over ℤ) is proved in DissectionOfCubesOQ02OQ02.lean via Mathlib Module.Flat ℤ ℝ (Bézout + NoZeroSMulDivisors) and lTensor_preserves_injective_linearMap. icoAngle_irrational (arccos(-√5/3)/π irrational) is proved here via Chebyshev integer sequence for arccos(1/9). DissectionOfCubesOQ04.lean has 0 axiom declarations and 0 sorries; OQ02OQ02 import chain is also axiom-free.",
     "lineCount": 557,
     "theoremCount": 25,
     "definitionCount": 4,
@@ -148,7 +148,7 @@
     "summary": "Among the five Platonic solids, the cube is uniquely characterized by having zero Dehn invariant. This extends Hilbert's Third Problem from the single pair (cube, tetrahedron) to the complete classification of all Platonic solids under scissors congruence.",
     "implications": "The complete classification shows that the cube is the unique Platonic solid that can potentially be scissors congruent to a non-Platonic polyhedron of equal volume. All other four Platonic solids have D ≠ 0 and so cannot be dissected and reassembled into any shape with D = 0 (in particular, not into a cube). The new irrationality result arccos(1/√5)/π ∉ ℚ is itself a contribution to the theory of irrational angles, extending the Niven-style Chebyshev technique to a new cosine value.",
     "openQuestions": [
-      "Can the remaining axiom (tmul_infinite_order_ne_zero — flatness of ℝ over ℤ) be proved using Mathlib Module.Flat infrastructure?",
+      "RESOLVED: tmul_infinite_order_ne_zero (flatness of ℝ over ℤ) was proved in DissectionOfCubesOQ02OQ02.lean using Mathlib Module.Flat infrastructure (#12587).",
       "Can this technique be applied to prove irrationality results for other dihedral angles arising in higher-dimensional polytopes?"
     ]
   },

--- a/src/data/research/problems/dissection-of-cubes-oq-04.json
+++ b/src/data/research/problems/dissection-of-cubes-oq-04.json
@@ -1,8 +1,8 @@
 {
   "slug": "dissection-of-cubes-oq-04",
   "title": "Dissection of Cubes: Connection to Dehn Invariant Impossibility",
-  "phase": "ACT",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "COMPLETED",
     "since": "2026-04-22T13:03:46.505Z",
     "iteration": 1,
-    "focus": "Fix 3 sorries in cube_unique_zero_dehn via tmul_infinite_order_ne_zero",
+    "focus": "Verified — no further work needed; OQ04 closes the cube-isolation classification.",
     "blockers": [],
-    "nextAction": "Compile check via docker-build",
+    "nextAction": "None — gallery entry verified, axiom-free.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: icoAngle_irrational proved (115 lines, Chebyshev sequence). Axiom count 2->1. Only tmul_infinite_order_ne_zero remains.",
+    "progressSummary": "VERIFIED (axiom-free, 0 sorries): tmul_infinite_order_ne_zero proved in OQ02OQ02 via Module.Flat ℤ ℝ (#12587, 2026-04-26); icoAngle_irrational proved here via Chebyshev seq for arccos(1/9). cube_unique_zero_dehn closes the Platonic-solid Dehn classification.",
     "builtItems": [
       "cube_unique_zero_dehn (PROVED, 0 sorries) — DissectionOfCubesOQ04.lean",
       "cube_isolated_dehn_invariant (PROVED) — cube D=0, all others D≠0",
@@ -53,15 +53,11 @@
       "2 axioms remain: tmul_infinite_order_ne_zero (ℝ flat over ℤ) + icoAngle_irrational (Chebyshev ℤ[√5])",
       "icoAngle_irrational proved via Chebyshev sequence for arccos(1/9)",
       "Key: cos(2*icoAngle)=1/9, so arccos(1/9)=2pi-2*icoAngle — reduces to integer sequence",
-      "Sequence d_n=9^n*2cos(n*arccos(1/9)) satisfies d_{n+2}=2d_{n+1}-81d_n; 3 ndvd d_n for all n"
+      "Sequence d_n=9^n*2cos(n*arccos(1/9)) satisfies d_{n+2}=2d_{n+1}-81d_n; 3 ndvd d_n for all n",
+      "RESOLVED 2026-04-28: tmul_infinite_order_ne_zero is a fully proved theorem in DissectionOfCubesOQ02OQ02.lean (line 214) via Module.Flat ℤ ℝ. The OQ04 import chain is axiom-free. Metadata had been reverted by bundled-sync PRs #13325 and #13370; this audit re-syncs gallery and research JSON to verified."
     ],
-    "mathlibGaps": [
-      "tmul_infinite_order_ne_zero (R flat over Z) — axiomatized, only remaining axiom"
-    ],
-    "nextSteps": [
-      "Verify DissectionOfCubesOQ04.lean compiles via docker-build.sh",
-      "Attempt tmul_infinite_order_ne_zero proof (flatness of R over Z)"
-    ]
+    "mathlibGaps": [],
+    "nextSteps": []
   },
   "tags": [
     "geometry",
@@ -85,7 +81,7 @@
     "mathlib": []
   },
   "started": "2026-04-22T13:03:46.504Z",
-  "lastUpdate": "2026-04-22T13:03:46.504Z",
+  "lastUpdate": "2026-04-28T00:00:00.000Z",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [


### PR DESCRIPTION
## Summary

- Re-sync `dissection-of-cubes-oq-04` gallery + research metadata to **verified / 0 axioms / 0 sorries** (matching its actual proof state since PR #12587 on 2026-04-26).
- The Lean file header "Axiom Budget" and Part-VI "Axiom Audit" comments are also updated to remove stale "1 inherited axiom" claims.

## Why this PR

PR #12587 proved `tmul_infinite_order_ne_zero` via `Module.Flat ℤ ℝ`, eliminating the last axiom and leaving OQ04 axiom-free. PR #13118 corrected the gallery `meta.json` accordingly. But the bundled-sync PRs #13325 and #13370 inadvertently reverted those fields, leaving a stale "axiomatized / 1 axiom" badge on a file that has **zero** axiom declarations and **zero** sorries across its entire import chain (OQ02, OQ02OQ02, OQ04).

I verified by:
- `grep ^axiom proofs/Proofs/DissectionOfCubesOQ02.lean proofs/Proofs/DissectionOfCubesOQ02OQ02.lean proofs/Proofs/DissectionOfCubesOQ04.lean` → 0 matches in each.
- Confirming `tmul_infinite_order_ne_zero` is a `theorem` (not `axiom`) at `DissectionOfCubesOQ02OQ02.lean:214`, with a complete proof using Mathlib's `Module.Flat`, `NoZeroSMulDivisors`, and `lTensor_preserves_injective_linearMap`.
- Confirming `icoAngle_irrational` is a `theorem` at `DissectionOfCubesOQ04.lean:396`, proved via Chebyshev seq for `arccos(1/9)`.
- Tracing the regression to `b85f48f2133` (#13370) which reverted `axiomCount: 0 → 1`, `status: verified → axiomatized`, `badge: verified → axiom`.

No proof code changes — only comments and JSON metadata.

## Test plan

- [x] `grep -c '^axiom ' proofs/Proofs/DissectionOfCubesOQ02*.lean proofs/Proofs/DissectionOfCubesOQ04.lean` returns 0 for each file.
- [x] `tmul_infinite_order_ne_zero` is `theorem`, not `axiom`.
- [x] `jq '.meta.status, .meta.badge, .meta.axiomCount, .leanFile.axiomCount' src/data/proofs/dissection-of-cubes-oq-04/meta.json` returns `"verified" "verified" 0 0`.
- [x] `jq '.status, .phase' src/data/research/problems/dissection-of-cubes-oq-04.json` returns `"completed" "COMPLETED"`.
- [ ] Optional: `./proofs/scripts/docker-build.sh Proofs.DissectionOfCubesOQ04` (no proof changes — should be a no-op for compilation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)