### PR TITLE
Aristotle companion for erdos-415 (totient ordering patterns)

### DIFF
--- a/proofs/Proofs/Erdos415Aristotle.lean
+++ b/proofs/Proofs/Erdos415Aristotle.lean
@@ -1,0 +1,35 @@
+/-
+  Aristotle companion for Erdős Problem #415: Ordering Patterns in Euler's Totient Function
+
+  This file exposes routine lemmas for automated proof search by Aristotle.
+  The main formalization is in Erdos415Problem.lean.
+
+  Targets: basic properties of Euler's totient function that follow directly
+  from Mathlib's Nat.totient API without depending on the sorry-defined
+  F, NaturalPattern, or AlternatingPattern functions.
+-/
+
+import Mathlib
+
+namespace Erdos415Aristotle
+
+open Nat
+
+/-- φ(2p) = p - 1 for odd prime p.
+    Follows from totient multiplicativity and φ(2) = 1, φ(p) = p - 1. -/
+theorem phi_2p (p : ℕ) (hp : p.Prime) (hodd : p ≠ 2) :
+    Nat.totient (2 * p) = p - 1 := by
+  sorry
+
+/-- Consecutive primes give strictly increasing totient values.
+    φ(p) = p - 1 < q - 1 = φ(q) for primes p < q. -/
+theorem phi_consecutive_primes (p q : ℕ) (hp : p.Prime) (hq : q.Prime) (hlt : p < q) :
+    Nat.totient p < Nat.totient q := by
+  sorry
+
+/-- φ(p) + 1 = p for any prime p. -/
+theorem phi_prime_succ (p : ℕ) (hp : p.Prime) :
+    Nat.totient p + 1 = p := by
+  sorry
+
+end Erdos415Aristotle


### PR DESCRIPTION
## Fix

Adds `Erdos415Aristotle.lean` with routine lemmas targeting Aristotle proof search for Erdős Problem #415.

## Evidence

**Problem**: `Erdos415Problem.lean` has 14 sorries including definition-sorries (`NaturalPattern`, `AlternatingPattern`, `F.F_exists`) that Aristotle cannot prove, plus routine lemmas about `Nat.totient`.

**After**: Three clean theorem-sorry targets isolated from the broken definitions:
- `phi_2p`: `Nat.totient (2 * p) = p - 1` for odd prime p
- `phi_consecutive_primes`: monotonicity of totient for primes
- `phi_prime_succ`: `Nat.totient p + 1 = p` for prime p

**Pre-submission checklist:**
- [x] No `def ... := sorry`
- [x] No `axiom` declarations
- [x] No `theorem ... : True` placeholders
- [x] No `/-!` docstring sections
- [x] No open conjectures

---
Automated fix by lean-mechanic agent.