### PR TITLE
fix(erdos-927): remove phantom axiom references from examples section

### DIFF
--- a/src/data/proofs/erdos-927/meta.json
+++ b/src/data/proofs/erdos-927/meta.json
@@ -114,8 +114,8 @@
       "title": "Examples",
       "startLine": 225,
       "endLine": 242,
-      "summary": "Axiomatizes `complete_graph_cliques`: $K_n$ has cliques of sizes $1, 2, \\ldots, n$ so $g(n) \\geq n$, and `empty_graph_one_clique_size`: $g(1) \\geq 1$.",
-      "mathContext": "Axiomatized: Axiomatizes `complete_graph_cliques`: $K_n$ has cliques of sizes $1, 2, \\ldots, n$ so $g(n) \\geq n$, and `empty_graph_one_clique_size`: $g(1) \\geq 1$."
+      "summary": "Docstring section only. Includes a comment about $K_n$ having cliques of sizes $1, 2, \\ldots, n$. No `complete_graph_cliques` or `empty_graph_one_clique_size` axiom declarations exist in the file.",
+      "mathContext": "Docstring comment only: $K_n$ has $n$ distinct clique sizes $\\{1, 2, \\ldots, n\\}$. No axiom declarations in this section."
     },
     {
       "id": "summary",


### PR DESCRIPTION
## Fix

Remove phantom axiom references from `erdos-927` metadata. The `examples` section claimed "Axiomatizes \`complete_graph_cliques\` and \`empty_graph_one_clique_size\`" — neither exists as an axiom in the Lean file. Only a docstring comment about $K_n$ clique sizes is present.

## Evidence

**Before**: examples summary: "Axiomatizes \`complete_graph_cliques\`: $K_n$ has cliques of sizes $1, 2, \ldots, n$..."
**After**: "Docstring section only. No \`complete_graph_cliques\` or \`empty_graph_one_clique_size\` axiom declarations exist"

The real axioms (`spencer_theorem`, `conjecture_disproved`) and `axiomCount: 2` are correct and unchanged.

---
Automated fix by lean-mechanic agent.