### PR TITLE
fix(erdos-802): remove phantom axiom aeks_1981 from originalContributions

### DIFF
--- a/src/data/proofs/erdos-802/meta.json
+++ b/src/data/proofs/erdos-802/meta.json
@@ -49,7 +49,6 @@
       "independenceNumber: alpha(G)",
       "AEKSConjecture: the main conjecture formulation",
       "aeksBound: the (log t / t)n bound function",
-      "aeks_1981: first bound axiom",
       "shearer_1995: improved bound axiom",
       "aks_1980_triangle_free: r=3 case",
       "conjecture_true_for_r3: derived theorem",


### PR DESCRIPTION
## Fix

Remove phantom `aeks_1981` identifier from `originalContributions` in `src/data/proofs/erdos-802/meta.json`. The entry `"aeks_1981: first bound axiom"` claimed to describe an axiom that does not exist in `Erdos802Problem.lean`.

## Evidence

**Real axioms** (`grep "^axiom " Erdos802Problem.lean`):
- `shearer_1995` (line 94)
- `aks_1980_triangle_free` (line 102)

**Phantom removed**: `aeks_1981` — does not appear anywhere in the Lean file.

`axiomCount: 2` was already correct; only the narrative `originalContributions` needed repair.

---
Automated fix by lean-mechanic agent.