### PR TITLE
fix(erdos-1108): remove phantom axiomatization claims from originalContributions

### DIFF
--- a/src/data/proofs/erdos-1108/meta.json
+++ b/src/data/proofs/erdos-1108/meta.json
@@ -42,12 +42,10 @@
       }
     ],
     "originalContributions": [
-      "Clean Lean 4 formalization of factorial sums set",
+      "Clean Lean 4 formalization of factorial sums set (FactorialSums)",
       "Definition of IsPowerful predicate for powerful numbers",
-      "Axiomatization of both open questions as Props",
-      "Axiomatization of Brindza-Erdős 1991 bound",
       "Connection to Mahler's related problem on power sums",
-      "Proved membership examples for factorial sums",
+      "Proved membership examples for factorial sums (0, 1, 2, 6, 24)",
       "Proved 1 is both a square factorial sum and powerful"
     ],
     "axiomCount": 0,


### PR DESCRIPTION
## Fix

Remove 2 phantom entries from `originalContributions` in `src/data/proofs/erdos-1108/meta.json`.

## Evidence

**Lean file** (`proofs/Proofs/Erdos1108Problem.lean`) contains 0 axiom declarations, only defs and proven theorems.

**Phantom claims removed**:
- `"Axiomatization of both open questions as Props"` — no such Props declared
- `"Axiomatization of Brindza-Erdős 1991 bound"` — no such axiom in file

The `assumptions` field already correctly states: "0 axioms. 0 sorries. All results formalized without axioms."

---
Automated fix by lean-mechanic agent.