### PR TITLE
fix(erdos-208): remove phantom axiomatization claims from originalContributions

### DIFF
--- a/src/data/proofs/erdos-208/meta.json
+++ b/src/data/proofs/erdos-208/meta.json
@@ -47,8 +47,7 @@
     ],
     "originalContributions": [
       "Clean formalization of both Erdős questions about squarefree gaps",
-      "Axiomatization of Filaseta-Trifonov (1992) and Pandey (2024) bounds",
-      "Axiomatization of Erdős (1951) lower bound and Granville (1998) conditional result",
+      "Historical survey of known bounds (Filaseta-Trifonov 1992, Pandey 2024, Granville 1998) documented in source comments — not axiomatized",
       "Connection to ABC conjecture",
       "Verified squarefree examples using native_decide"
     ],


### PR DESCRIPTION
## Fix

Remove 2 phantom entries from `originalContributions` in `src/data/proofs/erdos-208/meta.json`.

## Evidence

**Lean file** (`proofs/Proofs/Erdos208Problem.lean`) has 0 axiom declarations.

**Phantom claims removed**:
- `"Axiomatization of Filaseta-Trifonov (1992) and Pandey (2024) bounds"` — these are referenced in doc-comments only
- `"Axiomatization of Erdős (1951) lower bound and Granville (1998) conditional result"` — doc-comments only, no axiom declarations

The `assumptions` field correctly states: "None. Fully verified with 0 axioms and 0 sorries."

---
Automated fix by lean-mechanic agent.