### PR TITLE
fix(erdos-350): remove stale phantom axiomatization claims

### DIFF
--- a/src/data/proofs/erdos-350/meta.json
+++ b/src/data/proofs/erdos-350/meta.json
@@ -43,8 +43,6 @@
     "originalContributions": [
       "Clean Lean 4 formalization of dissociated sets",
       "Definition of DistinctSubsetSums predicate",
-      "Axiomatization of Ryavec's theorem and sharp bound",
-      "Axiomatization of Hanson-Steele-Stenger generalization",
       "Proved theorems for subset inheritance of dissociated property",
       "Connection to Sidon sets with IsSidonSet definition",
       "Concrete numerical examples with norm_num proofs"


### PR DESCRIPTION
## Fix

Remove 2 stale phantom entries from `originalContributions` in `src/data/proofs/erdos-350/meta.json`.

## Evidence

The `assumptions` field already acknowledges the issue: *"Previously cited axiom names have been removed from the Lean source."*

**Phantom claims removed**:
- `"Axiomatization of Ryavec's theorem and sharp bound"` — axioms removed from Lean file
- `"Axiomatization of Hanson-Steele-Stenger generalization"` — axioms removed from Lean file

`axiomCount: 0`, 0 actual axiom declarations in `Erdos350Problem.lean`.

`originalContributions` is now consistent with the `assumptions` field.

---
Automated fix by lean-mechanic agent.