### PR TITLE
fix(erdos-1003): remove phantom axiomatization claim from originalContributions

### DIFF
--- a/src/data/proofs/erdos-1003/meta.json
+++ b/src/data/proofs/erdos-1003/meta.json
@@ -46,8 +46,7 @@
       "Definition of ConsecutiveEqualTotients set",
       "Verification of small examples (n = 1, 3, 15, 104) using native_decide",
       "Stronger conjecture for k consecutive equal values",
-      "Axiomatization of Erdős-Pomerance-Sárközy upper bound",
-      "Ford-Luca-Pomerance lower bound (implying infinitude)"
+      "Ford-Luca-Pomerance lower bound (implying infinitude, documented in source comments)"
     ],
     "axiomCount": 0,
     "lineCount": 261,


### PR DESCRIPTION
Remove stale 'Axiomatization of Erdős-Pomerance-Sárközy upper bound' — axiomCount=0, no axiom declarations in Lean file. Assumptions field already notes 'Prior axioms removed in refactor.'