### PR TITLE
fix(erdos-12): remove phantom Axiomatization claim from originalContributions

### DIFF
--- a/src/data/proofs/erdos-12/meta.json
+++ b/src/data/proofs/erdos-12/meta.json
@@ -57,9 +57,7 @@
       "Full proof of prime_3mod4_not_div_sum_squares (ZMod argument)",
       "Full proof of primeSquares3mod4_infinite (Dirichlet + injectivity)",
       "Statement of all three Erdős questions",
-      "Axiomatization of Erdős-Sárközy density-zero result",
-      "Elsholtz-Planitzer construction bound",
-      "Schoen-Baier coprime case bound"
+      "Documentation of Erdős-Sárközy density-zero result and bounds (Elsholtz-Planitzer, Schoen-Baier) in source comments"
     ],
     "relatedProblems": [
       {


### PR DESCRIPTION
Remove 'Axiomatization of Erdős-Sárközy density-zero result' — axiomCount=0, no axiom declarations in Erdos12Problem.lean. Known results are documented in source comments only.