### PR TITLE
fix(erdos-1041): remove phantom Axiomatization claim from originalContributions

### DIFF
--- a/src/data/proofs/erdos-1041/meta.json
+++ b/src/data/proofs/erdos-1041/meta.json
@@ -49,7 +49,6 @@
     "originalContributions": [
       "Formal definition of polynomial sublevel sets",
       "Definition of path length via 1-dimensional Hausdorff measure",
-      "Axiomatization of Erdős-Herzog-Piranian Component Lemma (1958)",
       "Statement of the OPEN path length conjecture",
       "Proved theorems about sublevel set properties",
       "Connection to polynomial lemniscates"


### PR DESCRIPTION
Remove 'Axiomatization of Erdős-Herzog-Piranian Component Lemma (1958)' — no axiom declarations (axiomCount=0). Assumptions already notes 'badge updated from axiom to wip'.