### PR TITLE
fix(erdos-251): remove phantom Axiomatization claim from originalContributions

### DIFF
--- a/src/data/proofs/erdos-251/meta.json
+++ b/src/data/proofs/erdos-251/meta.json
@@ -43,7 +43,6 @@
     "originalContributions": [
       "Formal definition of the Erdős sum Σ pₙ/2^(n+1)",
       "Statement of the main conjecture as Irrational erdosSum",
-      "Axiomatization of Erdős's factorial irrationality result",
       "Statement of the generalized conjecture for all powers k ≥ 1",
       "Verified partial sums: first 5 terms = 101/32"
     ],


### PR DESCRIPTION
Remove 'Axiomatization of Erdős's factorial irrationality result' — axiomCount=0, assumptions confirms 'Prior axioms removed from Lean source'.