### PR TITLE
fix(erdos-30): remove phantom Axiomatization claim from originalContributions

### DIFF
--- a/src/data/proofs/erdos-30/meta.json
+++ b/src/data/proofs/erdos-30/meta.json
@@ -44,7 +44,7 @@
       "Formalization of Sidon set definition",
       "Equivalence of two Sidon characterizations",
       "Definition of Sidon number h(N)",
-      "Axiomatization of historical bounds (Erdős-Turán to Carter-Hunter-O'Bryant)",
+      "Documentation of historical bounds (Erdős-Turán to Carter-Hunter-O'Bryant) in source comments",
       "Perfect difference set connection"
     ],
     "axiomCount": 0,


### PR DESCRIPTION
Remove 'Axiomatization of historical bounds (Erdős-Turán to Carter-Hunter-O'Bryant)' — axiomCount=0. Historical bounds are documented in source comments, not formally axiomatized.