### PR TITLE
fix(erdos-931): correct leanFile.axiomCount from 2 to 0

### DIFF
--- a/src/data/proofs/erdos-931/meta.json
+++ b/src/data/proofs/erdos-931/meta.json
@@ -152,7 +152,7 @@
     ],
     "namespace": "Erdos931",
     "lineCount": 523,
-    "axiomCount": 2,
+    "axiomCount": 0,
     "theoremCount": 44,
     "definitionCount": 6,
     "path": "Proofs/Erdos931Problem.lean",


### PR DESCRIPTION
## Fix

Corrected `leanFile.axiomCount` from 2 to 0 for the erdos-931 gallery entry.

## Evidence

**Before**: `leanFile.axiomCount: 2` — stale metadata from when the file contained two `axiom` declarations (`stronger_implies_main` and `exists_prime_between_blocks_hard`)

**After**: `leanFile.axiomCount: 0` — reflects current file state where both were converted to `theorem ... := by sorry`, as documented in the file comments: *"Converted from `axiom` to `theorem … := by sorry` so it doesn't assert an unverified mathematical claim"*

The `meta.axiomCount` (already 0) and `meta.sorries` (correctly 2) were already correct. Only `leanFile.axiomCount` was stale. The UI displays this value as "X axioms" per file, so the stale value was showing "2 axioms" incorrectly.

Build validated: `pnpm build` ✓

---
Automated fix by lean-mechanic agent.