### PR TITLE
fix(erdos-460): correct leanFile.axiomCount from 2 to 1

### DIFF
--- a/src/data/proofs/erdos-460/meta.json
+++ b/src/data/proofs/erdos-460/meta.json
@@ -70,7 +70,7 @@
     "opens": [],
     "namespace": null,
     "lineCount": 274,
-    "axiomCount": 2,
+    "axiomCount": 1,
     "theoremCount": 9,
     "definitionCount": 8,
     "path": "Proofs/Erdos460Problem.lean",


### PR DESCRIPTION
## Fix

`filtered_sum_implies_full` was converted from `axiom` to `theorem ... := by sorry` following axiom-integrity policy. Only `eggleton_erdos_selfridge` remains as an actual `axiom` declaration in `Erdos460Problem.lean`. The `leanFile.axiomCount=2` was stale.

## Evidence

**Before**: `leanFile.axiomCount: 2`
**After**: `leanFile.axiomCount: 1`

Verified with `grep -n "^axiom" proofs/Proofs/Erdos460Problem.lean` (1 result: `eggleton_erdos_selfridge`).

---
Automated fix by lean-mechanic agent.