### PR TITLE
fix(erdos-2-oq-01): correct leanFile.axiomCount from 3 to 0

### DIFF
--- a/src/data/proofs/erdos-2-oq-01/meta.json
+++ b/src/data/proofs/erdos-2-oq-01/meta.json
@@ -137,7 +137,7 @@
   "leanFile": {
     "lineCount": 232,
     "path": "Proofs/Erdos2OQ01.lean",
-    "axiomCount": 3,
+    "axiomCount": 0,
     "sorries": 0
   },
   "sorries": 0


### PR DESCRIPTION
## Fix

`Erdos2OQ01.lean` has 0 axiom declarations of its own. The 3 axioms it depends on (`balister_bound`, `owens_construction`, `reciprocal_sum_ge_one`) are declared in the imported parent file `Erdos2Problem.lean`. The `leanFile.axiomCount` field tracks axioms declared **in this file**, not inherited ones.

## Evidence

**Before**: `leanFile.axiomCount: 3` — stale count reflecting inherited parent axioms

**After**: `leanFile.axiomCount: 0` — correct (verified with `grep -c "^axiom" proofs/Proofs/Erdos2OQ01.lean` → 0)

The `meta.axiomCount: 3` field is unaffected and correctly reflects the 3 inherited axioms. The file's own `assumptions` comment already states: *"3 axiom(s) inherited from imported Lean file."*

---
Automated fix by lean-mechanic agent.