### PR TITLE
audit(erdos-942): fix section line drift and wrong conjecture formula

### DIFF
--- a/src/data/proofs/erdos-942/meta.json
+++ b/src/data/proofs/erdos-942/meta.json
@@ -86,13 +86,13 @@
       "startLine": 1,
       "endLine": 24,
       "summary": "Problem statement, main question, known results, and references.",
-      "mathContext": "Problem #942: h(n) = count of powerful (squarefull) integers in [n^2, (n+1)^2). Is there c > 0 with h(n) >= c sqrt(n)?"
+      "mathContext": "Problem #942: h(n) = count of powerful (squarefull) integers in [n^2, (n+1)^2). Is there c > 0 with h(n) ~ (log n)^c?"
     },
     {
       "id": "background",
       "title": "Background: Powerful Numbers",
       "startLine": 35,
-      "endLine": 49,
+      "endLine": 48,
       "summary": "Definition, examples, non-examples, and density of powerful numbers.",
       "mathContext": "Powerful number: p | n implies p^2 | n. Equivalently n = a^2 b^3. Density ~ (zeta(3/2)/zeta(3)) sqrt(x)."
     },
@@ -100,41 +100,49 @@
       "id": "definitions",
       "title": "Core Definitions",
       "startLine": 50,
-      "endLine": 78,
+      "endLine": 68,
       "summary": "Powerful and PowerfulAlt definitions (the only Lean definitions in this file). h is an opaque axiom with no specification.",
       "mathContext": "Powerful(n): forall p | n, p^2 | n. PowerfulAlt(n): exists a b > 0, n = a^2 * b^3. h : ℕ → ℕ is an opaque axiom."
     },
     {
       "id": "examples",
       "title": "Examples of Powerful Numbers",
-      "startLine": 79,
-      "endLine": 104,
-      "summary": "Documentary docstring listing powerful and non-powerful examples. No Lean example declarations in this section.",
+      "startLine": 70,
+      "endLine": 72,
+      "summary": "Documentary docstring header. No Lean example declarations in this section.",
       "mathContext": "Examples documented as commentary: Powerful: 1, 4, 8, 9, 36, 72. Not powerful: 6, 12."
     },
     {
       "id": "conjecture",
       "title": "The Main Conjecture (OPEN)",
-      "startLine": 105,
-      "endLine": 119,
-      "summary": "erdos_942_conjecture (opaque Prop axiom) and erdos_942_open (axiom asserting neither true nor false) plus erdos_942_status theorem.",
-      "mathContext": "OPEN: exists c > 0 with h(n) >= c sqrt(n) for all large n."
+      "startLine": 74,
+      "endLine": 86,
+      "summary": "erdos_942_conjecture (opaque Prop axiom) and erdos_942_open (axiom asserting neither true nor false).",
+      "mathContext": "OPEN: exists c > 0 such that h(n) is bounded above by (log n)^{c+o(1)} and achieves (log n)^{c-o(1)} infinitely often."
     },
     {
       "id": "limsup",
       "title": "Known Result: limsup h(n) = infinity",
-      "startLine": 120,
-      "endLine": 132,
+      "startLine": 88,
+      "endLine": 92,
       "summary": "Documentary docstring on limsup h(n) = ∞ (van Doorn). No Lean axiom or theorem in this section — knowledge documented as commentary only.",
       "mathContext": "h(n) is unbounded: limsup h(n) = infinity. But uniform lower bound unknown."
     },
     {
       "id": "density",
       "title": "Known Result: Density of h(n) = l",
-      "startLine": 133,
-      "endLine": 144,
+      "startLine": 94,
+      "endLine": 101,
       "summary": "Documentary docstring on density theory (δ_l exists, Σδ_l = 1, δ_1 ≈ 0.275). No Lean axioms — density facts are commentary only.",
       "mathContext": "Density of {n : h(n) = k} exists for each k, and sum delta_k = 1."
+    },
+    {
+      "id": "summary",
+      "title": "Summary and Status Theorem",
+      "startLine": 102,
+      "endLine": 142,
+      "summary": "Documentary docstrings on De Koninck-Luca lower bound, properties, square intervals, small examples, and a final summary; concludes with erdos_942_status theorem (proved from erdos_942_open).",
+      "mathContext": "De Koninck-Luca: h(n) >= c (log n / log log n)^{1/3} infinitely often. Status theorem: ¬(erdos_942_conjecture ↔ True), proved from erdos_942_open."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

Two integrity issues found during gallery audit of erdos-942:

1. **Wrong formula in mathContext** (MEDIUM): `header` and `conjecture` sections claim the open question is whether `h(n) >= c sqrt(n)`. The actual conjecture (per the Lean file, meta description, problemStatement, and conclusion) is whether `h(n) ~ (log n)^c`. This contradicts every other place the formula appears.

2. **Section line ranges stale** (LOW): Six of seven section line ranges no longer match Lean source positions:

   | section | claimed | actual |
   |--|--|--|
   | background | 35-49 | 35-48 |
   | definitions | 50-78 | 50-68 |
   | examples | 79-104 | 70-72 |
   | conjecture | 105-119 | 74-86 |
   | limsup | 120-132 | 88-92 |
   | density | 133-144 | 94-101 |

   The `conjecture` section's range (105-119) does not contain the conjecture axioms — those are at lines 83 and 86. The status theorem at line 142 was claimed inside `density` but is well beyond its real range.

## Fix

- Update startLine/endLine for the six drifted sections to match the source.
- Fix `h(n) >= c sqrt(n)` → `h(n) ~ (log n)^c` in `header.mathContext` and `conjecture.mathContext`.
- Add new `summary` section covering lines 102-142 (De Koninck-Luca bound docstring + intermediate docstrings + summary + erdos_942_status theorem).
- Trim `conjecture.summary` to reflect that the status theorem now lives in the new `summary` section.

## Verification

- `axiomCount: 3` matches `^axiom ` declarations (h, erdos_942_conjecture, erdos_942_open) — already correct from #13471.
- `sorries: 0` matches.
- `theoremCount: 1` matches (erdos_942_status only).
- `definitionCount: 2` matches (Powerful, PowerfulAlt).
- JSON validates.

## Test plan

- [ ] Section line ranges resolve to the docstrings/declarations they describe.
- [ ] `pnpm build` passes.
- [ ] No remaining `sqrt(n)` references in mathContext for this proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)