### PR TITLE
fix(auditor): stop false-positive axiom undercount on multi-file proofs

### DIFF
--- a/scripts/auditor/find-targets.ts
+++ b/scripts/auditor/find-targets.ts
@@ -297,12 +297,15 @@ function analyzeProof(id: string, galleryPath: string, tracker: Tracker): AuditT
       status: proofMeta.status || 'unknown',
       badge: proofMeta.badge || 'unknown',
       claimedSorries: proofMeta.sorries ?? -1,
-      // Use leanFile.axiomCount (raw declarations) for comparison when present.
-      // meta.axiomCount counts ALL assumptions including structure-encoded ones.
-      // leanFile.axiomCount counts only ^axiom declarations, matching what we detect.
-      claimedAxioms: (typeof meta.leanFile === 'object' && meta.leanFile !== null && meta.leanFile.axiomCount !== undefined)
-        ? meta.leanFile.axiomCount
-        : (proofMeta.axiomCount ?? -1),
+      // leanFile.axiomCount counts only the main file; meta.axiomCount counts the
+      // full import chain. When we aggregate detection across additionalFiles or
+      // followed imports, compare against meta.axiomCount to avoid false-positive
+      // undercounts (single-file claim vs multi-file actual).
+      claimedAxioms: (allLeanFiles.length > 1)
+        ? (proofMeta.axiomCount ?? -1)
+        : ((typeof meta.leanFile === 'object' && meta.leanFile !== null && meta.leanFile.axiomCount !== undefined)
+            ? meta.leanFile.axiomCount
+            : (proofMeta.axiomCount ?? -1)),
     },
     actual: {
       sorryCount,


### PR DESCRIPTION
## Summary

- erdos-2-oq-01 was perpetually flagged with `axiom undercount: claims 0, actual declarations 3`. The data is correct (the main file has 0 axiom declarations; 3 axioms come from the imported `Erdos2Problem.lean` listed in `additionalFiles`). The flag is a script bug.
- `find-targets.ts` aggregates axiom counts across `allLeanFiles` (main + additionalFiles + followed imports) but compared the multi-file actual against `leanFile.axiomCount`, which is by design a single-file count. That is apples-to-oranges.
- When `allLeanFiles.length > 1`, compare against `proofMeta.axiomCount` (full import-chain total per the Axiom Integrity Policy in CLAUDE.md). Single-file proofs continue to use `leanFile.axiomCount` as before.

## Test plan
- [x] `npx tsx scripts/auditor/find-targets.ts --issues` now returns 0 (was 1, erdos-2-oq-01)
- [x] `npx tsx scripts/auditor/find-targets.ts --stats` reports 0 with-issues across all 2179 proofs
- [x] No data files modified — script-only change

## Background

This is a recurrence of the class of bugs tracked in #9642 (false-positive overcounts) and #9050 / #9095 (false positives from sibling imports). The previous fix in #9642 silenced overcount false positives; this PR addresses the symmetric undercount false positive that arises whenever `additionalFiles` brings in axioms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)