### PR TITLE
audit: tracker sync 2026-04-28 (4 entries)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5055,9 +5055,9 @@
       "result": "clean"
     },
     "erdos-2-oq-01": {
-      "auditCount": 6,
+      "auditCount": 8,
       "issues": [],
-      "lastAudited": "2026-04-03T20:15:41Z",
+      "lastAudited": "2026-04-28T03:43:36Z",
       "result": "clean"
     },
     "erdos-20": {
@@ -10178,9 +10178,9 @@
       "result": "clean"
     },
     "erdos-94-oq-02": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T10:17:33Z",
+      "lastAudited": "2026-04-28T03:38:49Z",
       "result": "issues-fixed"
     },
     "erdos-940": {
@@ -10197,9 +10197,9 @@
     },
     "erdos-942": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-28T03:44:36Z",
+      "result": "clean"
     },
     "erdos-943": {
       "agentId": "auditor-cycle-20-batch",
@@ -10251,9 +10251,9 @@
     },
     "erdos-950": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-28T03:36:11Z",
+      "result": "clean"
     },
     "erdos-951": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Tracker sync for auditor cycle 2026-04-28:
- **erdos-2-oq-01**: clean — false positive from `find-targets.ts`; root cause fixed in PR #13504 (multi-file aggregation bug)
- **erdos-942**: clean — sections/conjecture already corrected by PR #13501
- **erdos-94-oq-02**: issues-fixed — from sibling audit worktree
- **erdos-950**: clean — from sibling audit session

## Test plan
- [x] No code changes — only `src/data/proofs/audit-tracker.json` updated
- [x] All 2179 proofs still tracked; 4 entries refreshed with current timestamps

🤖 Generated with [Claude Code](https://claude.com/claude-code)