### PR TITLE
fix(erdos-1007-oq-01): correct phantom-axiom narrative (0 axioms, not 10)

### DIFF
--- a/src/data/proofs/erdos-1007-oq-01/meta.json
+++ b/src/data/proofs/erdos-1007-oq-01/meta.json
@@ -53,7 +53,7 @@
       }
     ],
     "originalContributions": [
-      "Axiomatization of the minEdges(d) function for graph dimension",
+      "Concrete definition of minEdges(d) for graph dimension: known values d=0..5 by literature, d for d≥6 as a valid placeholder satisfying the bounds",
       "Known values for d=0..5 including the d=4 surprise (K_{3,3} beats K₅)",
       "Small-dimension completeness: for d≤3, K_{d+1} is optimal",
       "Proof that d=4 is the first deviation from the complete graph pattern",
@@ -85,18 +85,18 @@
     {
       "id": "min-edge-function",
       "title": "Minimum Edge Function",
-      "summary": "Axiomatizes minEdges(d) as the minimum edge count among graphs of dimension d. Three axioms: the function, the lower bound property, and the achievability.",
-      "startLine": 62,
-      "endLine": 77,
-      "mathContext": "Axiomatized: Axiomatizes minEdges(d) as the minimum edge count among graphs of dimension d. Three axioms: the function, the lower bound property, and the achievability."
+      "summary": "Defines `minEdgesForDim` as a computable function with known values for d=0..5 and d as placeholder for d≥6. The lower bound `d ≤ minEdgesForDim d` and upper bound `minEdgesForDim d ≤ C(d+1,2)` are proved theorems (previously axioms, now proved by case analysis and arithmetic).",
+      "startLine": 172,
+      "endLine": 252,
+      "mathContext": "Defines `minEdgesForDim` concretely (was axiom in earlier versions). Lower and upper bound theorems proved by `decide` and `calc`; no `axiom` declarations remain."
     },
     {
       "id": "known-values",
       "title": "Known Values",
-      "summary": "Records $\\text{minEdges}(0..5) = (0, 1, 3, 6, 9, 15)$ as six axioms. For $d \\le 3$ and $d=5$, these match $\\binom{d+1}{2}$; the $d=4$ value of 9 (from $K_{3,3}$) is the sole exception.",
-      "startLine": 83,
-      "endLine": 99,
-      "mathContext": "Axiomatized: Records $\\text{minEdges}(0..5) = (0, 1, 3, 6, 9, 15)$ as six axioms. For $d \\le 3$ and $d=5$, these match $\\binom{d+1}{2}$; the $d=4$ value of 9 (from $K_{3,3}$) is the sole exception."
+      "summary": "Records $\\text{minEdges}(0..5) = (0, 1, 3, 6, 9, 15)$ as six definitional theorems proved by `rfl` (direct reduction from the `minEdgesForDim` definition). For $d \\le 3$ and $d=5$, these match $\\binom{d+1}{2}$; the $d=4$ value of 9 (from $K_{3,3}$) is the sole exception.",
+      "startLine": 188,
+      "endLine": 196,
+      "mathContext": "Known values proved by `rfl` from the `minEdgesForDim` definition — these are definitional equalities, not axioms."
     },
     {
       "id": "structural-results",
@@ -167,7 +167,7 @@
     "historicalContext": "**Graph Dimension and the minEdges Function**\n\nThe concept of graph dimension was introduced by Erdős, Harary, and Tutte in their seminal 1965 paper in Mathematika: the dimension of a graph $G$ is the minimum $n$ such that $G$ can be embedded in $\\mathbb{R}^n$ with all edges having unit length. This definition connects combinatorial graph theory to metric geometry and the classical theory of distance matrices developed by Schoenberg (1935) and Menger (1931).\n\nThe function $\\text{minEdges}(d)$ — the minimum number of edges in a graph of dimension exactly $d$ — captures a fundamental trade-off between combinatorial complexity and geometric freedom. For small $d$, the complete graph $K_{d+1}$ is optimal, embedding as a regular $d$-simplex with unit edges. Einhorn and Schoenberg (1966) studied two-distance sets in Euclidean space, laying groundwork for understanding which graphs require high dimension. Maehara (1991) established further bounds on embeddability.\n\n**The d=4 Anomaly**\n\nHouse (2013) discovered the first surprise: $K_{3,3}$ achieves dimension 4 with only 9 edges, beating $K_5$'s 10. Chaffee and Noble (2016) proved $\\text{minEdges}(5) = 15$, restoring the complete graph pattern. Whether $d=4$ is the unique anomaly remains a central open question, connecting to rigidity theory and the unit distance problem.",
     "problemStatement": "Given a graph G, its dimension dim(G) is the minimum n such that G embeds in ℝⁿ with all edges of unit length. The function minEdges(d) = min{|E(G)| : dim(G) = d} captures the minimum combinatorial complexity needed for geometric dimension d. What is minEdges(d) as a function of d? Is the complete graph K_{d+1} always optimal (except possibly at d=4)?",
     "text": "Studies the function minEdges(d) giving the minimum number of edges in a graph of dimension exactly d. Formalizes known values (d=0..5), proves structural results including a constructive simplex embedding of K_n in ℝⁿ, shows the complete graph optimality conjecture implies monotonicity, analyzes growth rates, and introduces the deficiency function.",
-    "proofStrategy": "The formalization proceeds in three layers: (1) **Axiomatization**: minEdges(d) is axiomatized with known values for d ≤ 5 and basic bounds (lower: d, upper: C(d+1,2)). (2) **Construction**: The simplex embedding (1/√2)·eᵢ gives a constructive proof that K_n embeds in ℝⁿ, establishing the upper bound. Irreflexive embedding existence is proved constructively. (3) **Conditional analysis**: The complete graph optimality conjecture is shown to imply monotonicity via case analysis on d=4, and the deficiency function δ(d) provides an equivalent reformulation.",
+    "proofStrategy": "The formalization proceeds in three layers: (1) **Concrete definition**: `minEdgesForDim` is a computable function with known values for d ≤ 5 and d as placeholder for d ≥ 6; basic bounds (lower: d, upper: C(d+1,2)) are proved theorems (previously axioms, now proved by case analysis). (2) **Construction**: The simplex embedding (1/√2)·eᵢ gives a constructive proof that K_n embeds in ℝⁿ, establishing the upper bound. Irreflexive embedding existence is proved constructively. (3) **Conditional analysis**: The complete graph optimality conjecture is shown to imply monotonicity via case analysis on d=4, and the deficiency function δ(d) provides an equivalent reformulation.",
     "keyInsights": [
       "The **d=4 anomaly**: $K_{3,3}$ achieves dimension 4 with 9 edges, beating $K_5$'s 10. Formally verified as the unique anomaly for $d \\le 5$.",
       "The **simplex embedding** $v_i = (1/\\sqrt{2})e_i$ is the simplest unit-distance embedding of $K_n$ in $\\mathbb{R}^n$. The factor $1/\\sqrt{2}$ is forced since $\\|e_i - e_j\\| = \\sqrt{2}$.",
@@ -183,7 +183,7 @@
     ]
   },
   "conclusion": {
-    "summary": "We significantly extend the minEdges formalization with a constructive simplex embedding (K_n in ℝⁿ), prove the complete graph optimality conjecture implies monotonicity, introduce and analyze the deficiency function, and verify d=4 is the unique anomaly for d≤5. All theorems are fully proved (no sorries), with 10 axioms for the minEdges function and known values.",
+    "summary": "We significantly extend the minEdges formalization with a constructive simplex embedding (K_n in ℝⁿ), prove the complete graph optimality conjecture implies monotonicity, introduce and analyze the deficiency function, and verify d=4 is the unique anomaly for d≤5. All theorems are fully proved (no sorries, 0 axioms): the minEdges function is a concrete computable definition, known values follow by `rfl`, and bounds are proved theorems.",
     "implications": "The simplex embedding construction provides a concrete geometric witness for the upper bound minEdges(d) ≤ C(d+1,2), useful as a starting point for dimension computations\nThe conditional monotonicity theorem demonstrates that resolving the complete graph optimality conjecture would simultaneously resolve the monotonicity question\nThe deficiency reformulation (δ(d) = 0 iff K_{d+1} optimal) reduces an infinite family of graph-theoretic questions to a numerical condition checkable dimension by dimension\nThe d=4 anomaly analysis suggests that bipartite structures may provide more efficient dimension-achieving graphs in higher dimensions",
     "openQuestions": [
       "Is minEdges monotone in d?",


### PR DESCRIPTION
## Fix

meta.json narrative falsely claimed 10 axioms for a proof with `leanFile.axiomCount: 0`.

## Evidence

**Lean source** (`Proofs/Erdos1007OQ01.lean`):
- `minEdgesForDim` is a computable `def`, not an axiom
- Known values (d=0..5) are proved by `rfl` — definitional equalities
- Lower bound `d ≤ minEdgesForDim d` is a proved theorem (comment says "Was axiom")
- Upper bound `minEdgesForDim d ≤ C(d+1,2)` is a proved theorem (comment says "Was axiom")
- 0 `axiom` declarations, 0 sorries, `status: verified`

**Before**:
- `sections['min-edge-function'].summary`: "Axiomatizes minEdges(d) as ... Three axioms: ..."
- `sections['known-values'].summary`: "Records ... as six axioms"
- `conclusion.summary`: "... with 10 axioms for the minEdges function and known values"
- `proofStrategy`: "(1) **Axiomatization**: minEdges(d) is axiomatized ..."
- `originalContributions[0]`: "Axiomatization of the minEdges(d) function ..."

**After**: All narrative updated to reflect that minEdgesForDim is a concrete computable definition and all results are proved theorems; no axiom declarations remain.

---
Automated fix by lean-mechanic agent.