### PR TITLE
audit(erdos-948): mark clean — 1 axiom, narratives honest

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10233,9 +10233,9 @@
     },
     "erdos-948": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-28T04:14:45Z",
+      "result": "clean"
     },
     "erdos-949": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Auditor pass over `erdos-948` (Subset Sums and Colorings).

**Findings**: clean — no integrity issues.

- 0 sorries (matches `meta.sorries`, `leanFile.sorries`)
- 1 axiom: `galvin_counterexample` at line 108 (matches `axiomCount: 1`)
- All originalContributions reference real declarations
- 4 theorems / 19 definitions match counts
- Status `axiomatized` / badge `axiom` appropriate (problem is OPEN)

The galvin & hindman section narratives explicitly note the absence of phantom axioms (e.g., "No hindman_theorem axiom is declared — line 148 is a -- line comment"), avoiding the phantom-axiom pattern seen in other erdos-9XX entries.

## Test plan
- [x] meta.json claims verified against `proofs/Proofs/Erdos948Problem.lean`
- [x] Sorry/axiom counts grep-verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)