### PR TITLE
fix(erdos-976): correct sections array stale line numbers

### DIFF
--- a/src/data/proofs/erdos-976/meta.json
+++ b/src/data/proofs/erdos-976/meta.json
@@ -86,34 +86,34 @@
       "id": "section-2",
       "title": "Known Lower Bounds",
       "startLine": 69,
-      "endLine": 100,
+      "endLine": 91,
       "summary": "Documents three historical lower bounds as docstrings: Nagell-Ricci (n log n), Erdős 1952 (n(log n)^{log log log n}), and Tenenbaum 1990 (n exp((log n)^c)). Only Tenenbaum's bound is formalized as an axiom."
     },
     {
       "id": "section-3",
       "title": "Main Conjectures",
-      "startLine": 101,
-      "endLine": 122,
+      "startLine": 92,
+      "endLine": 113,
       "summary": "Formalizes the two open conjectures as Prop definitions: polynomial growth F_f(n) ≫ n^{1+c}, and the stronger degree growth F_f(n) ≫ n^d."
     },
     {
       "id": "section-4",
       "title": "Upper Bounds",
-      "startLine": 123,
-      "endLine": 134,
+      "startLine": 114,
+      "endLine": 121,
       "summary": "Documents the trivial upper bound F_f(n) ≤ C·n^d as a docstring only; no axiom declaration is present in this section."
     },
     {
       "id": "section-5",
       "title": "Computational Examples",
-      "startLine": 135,
-      "endLine": 162,
+      "startLine": 122,
+      "endLine": 149,
       "summary": "Defines P(n) alias, proves greatestPrimeDivisor examples via native_decide, and gives numerical bound comparisons at n=1000."
     },
     {
       "id": "section-6",
       "title": "Summary",
-      "startLine": 163,
+      "startLine": 150,
       "endLine": 175,
       "summary": "Proves erdos_976_status theorem establishing the current best bound by applying tenenbaum_bound."
     }


### PR DESCRIPTION
## Fix

Corrects the `sections` array in `src/data/proofs/erdos-976/meta.json` to match actual line numbers in `Erdos976Problem.lean` (175 lines).

## Evidence

**Before**: Parts II–VI had stale startLine/endLine values, off by 9–13 lines from the actual file structure.

| Section | Before (meta) | After (actual) |
|---------|--------------|----------------|
| Known Lower Bounds | 69–100 | 69–91 |
| Main Conjectures | 101–122 | 92–113 |
| Upper Bounds | 123–134 | 114–121 |
| Computational Examples | 135–162 | 122–149 |
| Summary | 163–175 | 150–175 |

**After**: All 6 sections have correct line numbers verified against `git show HEAD:proofs/Proofs/Erdos976Problem.lean`. Other metadata (axiomCount: 1, sorries: 0, lineCount: 175, status: axiomatized) remains correct.

Discovered via audit-tracker `issues-found` entry for erdos-976 (auditor-cycle-20-batch, 2026-04-27).

---
Automated fix by lean-mechanic agent.