### PR TITLE
fix(erdos-985): correct sections array stale line numbers

### DIFF
--- a/src/data/proofs/erdos-985/meta.json
+++ b/src/data/proofs/erdos-985/meta.json
@@ -114,38 +114,38 @@
       "title": "Artin's Conjecture and Heath-Brown",
       "summary": "heath_brown_theorem axiom: at least one of {2, 3, 5} is a primitive root for infinitely many primes",
       "startLine": 113,
-      "endLine": 130,
+      "endLine": 127,
       "mathContext": "Axiomatized: heath_brown_theorem (Heath-Brown 1986 unconditional result)"
     },
     {
       "id": "main-conjecture",
       "title": "Main Conjecture",
       "summary": "erdos_985_conjecture axiom, erdos_985_iff_all_odd_primes equivalence",
-      "startLine": 131,
-      "endLine": 173,
+      "startLine": 128,
+      "endLine": 170,
       "mathContext": "Axiomatized: erdos_985_conjecture axiom, erdos_985_iff_all_odd_primes equivalence"
     },
     {
       "id": "density",
       "title": "Density Considerations",
       "summary": "Heuristic argument based on prime number theorem",
-      "startLine": 174,
-      "endLine": 184,
+      "startLine": 171,
+      "endLine": 178,
       "mathContext": "Verified: Heuristic argument based on prime number theorem"
     },
     {
       "id": "connections",
       "title": "Connections to Other Problems",
       "summary": "artin_implies_erdos_985 theorem",
-      "startLine": 185,
-      "endLine": 199,
+      "startLine": 179,
+      "endLine": 193,
       "mathContext": "Placeholder: artin_implies_erdos_985 bypasses its hypothesis and calls erdos_985_conjecture axiom directly"
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "erdos_985_summary combining verified cases and Heath-Brown",
-      "startLine": 200,
+      "startLine": 194,
       "endLine": 223,
       "mathContext": "Mathematical content: erdos_985_summary combining verified cases and Heath-Brown"
     }


### PR DESCRIPTION
## Fix

Corrects the `sections` array in `src/data/proofs/erdos-985/meta.json` to match actual line numbers in `Erdos985Problem.lean` (223 lines total).

## Evidence

**Before**: The last 5 sections (artin-heathbrown through summary) had startLine/endLine values off by 3–6 lines.

| Section | Before (meta) | After (actual) |
|---------|--------------|----------------|
| Artin's Conjecture and Heath-Brown | 113–130 | 113–127 |
| Main Conjecture | 131–173 | 128–170 |
| Density Considerations | 174–184 | 171–178 |
| Connections to Other Problems | 185–199 | 179–193 |
| Summary | 200–223 | 194–223 |

**After**: All 9 sections have correct line numbers verified against `git show HEAD:proofs/Proofs/Erdos985Problem.lean`. First 4 sections (definitions, basic-properties, small-examples, erdos-verification) were already correct. Other metadata (axiomCount: 2, sorries: 0, lineCount: 223, status: axiomatized) remains correct.

Discovered via audit-tracker `issues-found` entry for erdos-985 (auditor-cycle-20-batch, 2026-04-27).

---
Automated fix by lean-mechanic agent.