### PR TITLE
audit(batch): correct phantom-axiom narratives in erdos-921, erdos-922, erdos-925

### DIFF
--- a/src/data/proofs/erdos-921/meta.json
+++ b/src/data/proofs/erdos-921/meta.json
@@ -43,15 +43,12 @@
     ],
     "originalContributions": [
       "Graph structure definition with adjacency, symmetry, and looplessness",
-      "chromaticNumber axiom: minimum k for proper k-coloring",
-      "oddGirth axiom: length of shortest odd cycle",
       "f(k,n) axiom: maximum odd girth in k-chromatic n-vertex graphs",
       "erdos_gallai_conjecture formalization: f_k(n) ≍ n^{1/(k-2)}",
       "kierstead_szemeredi_trotter axiom: complete resolution for all k ≥ 4",
       "gallai_lower_bound axiom: f_4(n) ≥ c√n (1963)",
       "erdos_upper_bound axiom: f_4(n) ≤ C√n (unpublished)",
       "k4_case theorem: f_4(n) ≍ √n (constructive proof from bounds)",
-      "general_lower_bound and general_upper_bound axioms for k ≥ 4",
       "erdos_921_status theorem: main result combining all components"
     ],
     "axiomCount": 4,
@@ -62,7 +59,7 @@
     "historicalContext": "**Erdős Problem #921**\n\nThis problem, posed jointly by Erdős and Gallai, explores the fundamental tension between a graph's chromatic number and its odd cycle structure.\n\n**Key History:**\n- **Gallai (1963):** Initiated the study by proving f_4(n) ≫ n^{1/2}, constructing explicit 4-chromatic graphs with large odd girth\n- **Erdős (unpublished):** Proved the matching upper bound f_4(n) ≪ n^{1/2}, showing the k=4 case is completely characterized\n- **Kierstead-Szemerédi-Trotter (1984):** Resolved the full conjecture for all k ≥ 4, proving f_k(n) ≍ n^{1/(k-2)}\n\n**Mathematical Significance:**\nThe result quantifies a deep principle: high chromatic number forces short odd cycles. A bipartite graph (χ = 2) has no odd cycles at all. As chromatic number increases, some odd cycles must appear, and this problem determines exactly how short they must be.",
     "problemStatement": "**Problem Statement (Proved)**\n\nLet k ≥ 4 and let f_k(n) be the largest m such that there exists a graph on n vertices with chromatic number k in which every odd cycle has length > m.\n\n**Conjecture:** f_k(n) ≍ n^{1/(k-2)}\n\n**Answer: YES**\n\nKierstead, Szemerédi, and Trotter (1984) proved that for all k ≥ 4:\n- Lower bound: f_k(n) ≥ c_k · n^{1/(k-2)} for some c_k > 0\n- Upper bound: f_k(n) ≤ C_k · n^{1/(k-2)} for some C_k > 0",
     "text": "For k ≥ 4, let f_k(n) be the largest m such that there exists an n-vertex graph with χ = k where all odd cycles have length > m. SOLVED: f_k(n) ≍ n^{1/(k-2)} by Kierstead-Szemerédi-Trotter (1984).",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Graph Definitions:** Define graph structure with adjacency, symmetry, and looplessness\n\n2. **Key Concepts:**\n   - Chromatic number χ(G): minimum k for proper k-coloring (axiomatized)\n   - Odd girth: length of shortest odd cycle (axiomatized)\n   - f(k,n): maximum odd girth - 1 among k-chromatic n-vertex graphs\n\n3. **Conjecture Formalization:** The Erdős-Gallai conjecture expressed as existence of constants c₁, c₂\n\n4. **Main Results:**\n   - Kierstead-Szemerédi-Trotter theorem (axiom): conjecture holds for all k ≥ 4\n   - Constructive k=4 case from Gallai and Erdős bounds\n\n5. **Why Axioms:** The proof requires deep results in extremal graph theory and regularity methods beyond current Mathlib scope",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Graph Definitions:** Define graph structure with adjacency, symmetry, and looplessness\n\n2. **Key Concepts (described in docstrings):**\n   - Chromatic number χ(G): minimum k for proper k-coloring\n   - Odd girth: length of shortest odd cycle\n   - f(k,n): maximum odd girth - 1 among k-chromatic n-vertex graphs (axiomatized)\n\n3. **Conjecture Formalization:** The Erdős-Gallai conjecture expressed as existence of constants c₁, c₂\n\n4. **Main Results:**\n   - Kierstead-Szemerédi-Trotter theorem (axiom): conjecture holds for all k ≥ 4\n   - Constructive k=4 case from Gallai and Erdős bounds (axioms)\n\n5. **Why Axioms:** The proof requires deep results in extremal graph theory and regularity methods beyond current Mathlib scope",
     "keyInsights": [
       "**Bipartite = No Odd Cycles:** A graph is 2-colorable iff it has no odd cycles, so χ ≥ 3 forces odd cycles",
       "**Exponent Formula:** For chromatic number k, the critical exponent is 1/(k-2): k=4 gives 1/2, k=5 gives 1/3, k=6 gives 1/4",
@@ -83,7 +80,7 @@
       "title": "Basic Definitions",
       "startLine": 33,
       "endLine": 76,
-      "summary": "Defines graph structure, chromatic number (axiom), odd girth (axiom), and the key function f_k(n) measuring maximum odd girth in k-chromatic graphs."
+      "summary": "Defines graph structure and the key function f_k(n) (axiom) measuring maximum odd girth in k-chromatic graphs. Chromatic number and odd girth are described in docstrings only."
     },
     {
       "id": "section-2",
@@ -104,7 +101,7 @@
       "title": "General k Case",
       "startLine": 134,
       "endLine": 153,
-      "summary": "The general lower and upper bounds for arbitrary k ≥ 4, establishing f_k(n) ≍ n^{1/(k-2)}."
+      "summary": "Docstrings describing the general lower and upper bounds for arbitrary k ≥ 4. The full f_k(n) ≍ n^{1/(k-2)} result is captured as the kierstead_szemeredi_trotter axiom in section 2; this section contains no axioms or theorems."
     },
     {
       "id": "section-5",

--- a/src/data/proofs/erdos-922/meta.json
+++ b/src/data/proofs/erdos-922/meta.json
@@ -119,10 +119,10 @@
     {
       "id": "summary",
       "title": "Summary",
-      "summary": "erdos_922_summary and erdos_922_answer",
+      "summary": "erdos_922_summary theorem combining all main results",
       "startLine": 218,
       "endLine": 220,
-      "mathContext": "Mathematical content: erdos_922_summary and erdos_922_answer"
+      "mathContext": "Mathematical content: erdos_922_summary theorem combining all main results"
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-925/meta.json
+++ b/src/data/proofs/erdos-925/meta.json
@@ -44,14 +44,14 @@
     "originalContributions": [
       "isNotRamseyForTriangle G: triangle-free 2-coloring exists",
       "hasIndependentSetOfSize G k: independent set existence",
-      "independenceNumber G: α(G) definition",
-      "R_3_3 m: multicolor Ramsey number R(3,3,m)",
+      "independenceNumber G axiom: α(G) definition",
+      "R_3_3 m axiom: multicolor Ramsey number R(3,3,m)",
       "erdos_925_conjecture: the disproved conjecture",
       "erdos_925_ramsey_form: equivalent Ramsey formulation",
-      "alon_rodl_lower_bound axiom: R(3,3,m) ≥ m³/(log m)^(4+o(1))",
-      "alon_rodl_upper_bound axiom: R(3,3,m) ≤ m³(log log m)/(log m)²",
-      "sudakov_improvement axiom: removes log log factor",
-      "erdos_925_disproved axiom: conjecture is false"
+      "erdos_925_disproved axiom: conjecture is false (Alon-Rödl 2005, with sharp R(3,3,m) bounds described in docstrings)",
+      "easy_lower_bound axiom: every non-Ramsey graph has α ≥ cn^(1/3)",
+      "erdos_925 theorem: the conjecture is false",
+      "erdos_925_summary theorem: combines disproof with the easy lower bound"
     ],
     "axiomCount": 4,
     "lineCount": 166,
@@ -61,7 +61,7 @@
     "historicalContext": "**Erdős Problem #925**\n\nThis problem connects Ramsey theory to independent set sizes.\n\n**History:**\n- Erdős posed this problem, probably in the 1960s-70s\n- The \"easy\" result: non-Ramsey graphs have independent sets of size Ω(n^(1/3))\n- The question: can we improve this to n^(1/3+δ) for some δ > 0?\n- Equivalently: is R(3,3,m) ≪ m^(3-c) for some c > 0?\n\n**Resolution (Alon-Rödl 2005):**\nThe answer is NO. They proved:\n- Lower bound: R(3,3,m) ≥ m³/(log m)^(4+o(1))\n- Upper bound: R(3,3,m) ≤ m³(log log m)/(log m)²\n\nSudakov later improved the upper bound by removing the log log factor.",
     "problemStatement": "**Problem Statement (Disproved)**\n\nIs there a constant δ > 0 such that, for all large n, if G is a graph on n vertices which is not Ramsey for K₃ (i.e., there exists a 2-coloring of the edges with no monochromatic triangle), then G contains an independent set of size ≫ n^(1/3+δ)?\n\n**Known:** Independent sets of size ≫ n^(1/3) always exist (easy).\n\n**Equivalent Question:** Is R(3,3,m) ≪ m^(3-c) for some c > 0?\n\n**Answer:** NO (Alon-Rödl 2005)\n\nThe n^(1/3) bound cannot be improved to n^(1/3+δ).",
     "text": "Is there δ > 0 such that non-Ramsey graphs for K₃ on n vertices have independent sets of size ≫ n^(1/3+δ)? NO (Alon-Rödl 2005).",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Graph Basics:** Use SimpleGraph from Mathlib\n\n2. **Key Definitions:**\n   - isNotRamseyForTriangle: 2-coloring with no monochromatic K₃\n   - hasIndependentSetOfSize: independent set existence\n   - R_3_3: multicolor Ramsey number R(3,3,m)\n\n3. **The Conjecture:**\n   - erdos_925_conjecture: the original (false) conjecture\n   - erdos_925_ramsey_form: equivalent Ramsey formulation\n\n4. **Main Results:**\n   - alon_rodl_lower_bound: R(3,3,m) ≥ m³/(log m)^(4+o(1))\n   - alon_rodl_upper_bound: R(3,3,m) ≤ m³(log log m)/(log m)²\n   - sudakov_improvement: removes log log factor\n   - erdos_925_disproved: the conjecture is FALSE\n\n**Why Axioms:** The proofs involve probabilistic and algebraic methods beyond Mathlib.",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Graph Basics:** Use SimpleGraph from Mathlib\n\n2. **Key Definitions:**\n   - isNotRamseyForTriangle: 2-coloring with no monochromatic K₃\n   - hasIndependentSetOfSize: independent set existence\n   - independenceNumber (axiom): α(G)\n   - R_3_3 (axiom): multicolor Ramsey number R(3,3,m)\n\n3. **The Conjecture:**\n   - erdos_925_conjecture: the original (false) conjecture\n   - erdos_925_ramsey_form: equivalent Ramsey formulation\n\n4. **Main Results:**\n   - erdos_925_disproved (axiom): the conjecture is FALSE (the sharp Alon-Rödl bounds R(3,3,m) ≥ m³/(log m)^(4+o(1)) and ≤ m³(log log m)/(log m)², plus Sudakov's improvement removing the log log factor, are described in docstrings only)\n   - easy_lower_bound (axiom): every non-Ramsey graph has α ≥ cn^(1/3)\n   - erdos_925 / erdos_925_summary (theorems): combine the disproof with the easy bound\n\n**Why Axioms:** The proofs involve probabilistic and algebraic methods beyond Mathlib.",
     "keyInsights": [
       "**Polynomial vs Polylog:** The question asks about polynomial improvement (n^δ), but the truth involves only polylogarithmic factors.",
       "**Tight Bounds:** R(3,3,m) ~ m³/(log m)^Θ(1), neither m^(3-c) nor m³.",
@@ -100,21 +100,21 @@
     {
       "id": "disproof",
       "title": "Alon-Rödl Disproof (2005)",
-      "summary": "Sharp bounds on R(3,3,m) and disproof axioms",
+      "summary": "Single axiom erdos_925_disproved : ¬erdos_925_conjecture. The sharp Alon-Rödl bounds and Sudakov improvement appear in section docstrings only.",
       "startLine": 104,
       "endLine": 132
     },
     {
       "id": "optimality",
       "title": "Optimality of n^(1/3)",
-      "summary": "The trivial bound is essentially tight",
+      "summary": "Docstring section noting the trivial bound is essentially tight; no axioms or theorems declared here.",
       "startLine": 133,
       "endLine": 145
     },
     {
       "id": "easy-bound",
       "title": "The Easy Lower Bound",
-      "summary": "Every non-Ramsey graph has α ≥ cn^(1/3)",
+      "summary": "easy_lower_bound axiom: every non-Ramsey graph has α ≥ cn^(1/3).",
       "startLine": 146,
       "endLine": 160
     },


### PR DESCRIPTION
## Summary

Fixes phantom-axiom narratives in two erdős-9XX gallery entries. In each case the numerical `axiomCount` was correct, but `originalContributions` / `proofStrategy` / `sections` referenced named axioms that exist only inside Lean docstring blocks, never declared as `axiom` in the source.

### erdos-921 — 4 actual axioms
Source axioms: `f`, `kierstead_szemeredi_trotter`, `gallai_lower_bound`, `erdos_upper_bound`.

Removed phantom references to:
- \`chromaticNumber axiom\` — only the docstring at lines 47-51
- \`oddGirth axiom\` — only the docstring at lines 53-55
- \`general_lower_bound\` / \`general_upper_bound axioms\` — only docstrings at lines 131-138; section-4 declares nothing

### erdos-925 — 4 actual axioms
Source axioms: `independenceNumber`, `R_3_3`, `erdos_925_disproved`, `easy_lower_bound`.

Removed phantom references to:
- \`alon_rodl_lower_bound axiom\` — only the docstring at lines 98-99
- \`alon_rodl_upper_bound axiom\` — only the docstring at lines 100-101
- \`sudakov_improvement axiom\` — only the docstring at line 102

Also added the previously-omitted `easy_lower_bound` axiom and the `erdos_925` / `erdos_925_summary` theorems to `originalContributions` for accuracy.

## Test plan
- [x] JSON validates
- [x] Cross-checked against `proofs/Proofs/Erdos921Problem.lean` and `proofs/Proofs/Erdos925Problem.lean`
- [x] No changes to numerical fields (`axiomCount`, `sorries`, `lineCount`)
- [x] No changes to badge/status

Continues the erdős-9XX phantom-axiom audit cluster (cf. #13464 #13465 #13466 #13499 #13502 #13503 #13505 #13510 #13511 #13512 #13514).

🤖 Generated with [Claude Code](https://claude.com/claude-code)