### PR TITLE
fix(erdos-1178): correct phantom-axiom section summaries

### DIFF
--- a/src/data/proofs/erdos-1178/meta.json
+++ b/src/data/proofs/erdos-1178/meta.json
@@ -97,7 +97,7 @@
     {
       "id": "extremal-numbers",
       "title": "Part III: Extremal Numbers",
-      "summary": "exr axiom, isLittleO definition.",
+      "summary": "exr def (noncomputable extremal number), isLittleO def.",
       "startLine": 73,
       "endLine": 82,
       "mathContext": "$\\text{ex}_r(n, \\mathcal{F}(r,d,e))$: max edges in $\\mathcal{F}$-free $r$-uniform hypergraph on $n$ vertices."
@@ -105,7 +105,7 @@
     {
       "id": "threshold-function",
       "title": "Part IV: The Function d_r(e)",
-      "summary": "dr axiom with dr_spec and dr_minimal characterizing the threshold.",
+      "summary": "dr def (sInf over threshold set), dr_spec and dr_minimal theorems characterizing the threshold.",
       "startLine": 83,
       "endLine": 98,
       "mathContext": "$d_r(e) = \\min\\{d : \\text{ex}_r(n, \\mathcal{F}(r,d,e)) = o(n^2)\\}$. The threshold for subquadratic behavior."
@@ -121,7 +121,7 @@
     {
       "id": "upper-bounds",
       "title": "Part VI: Known Upper Bounds",
-      "summary": "sarkozy_selkow_upper axiom.",
+      "summary": "sarkozy_selkow_upper theorem (proved from sarkozy_selkow_result axiom).",
       "startLine": 111,
       "endLine": 116,
       "mathContext": "$d_r(e) \\leq (r-2)e + 2 + \\lfloor\\log_2 e\\rfloor$ [SaSe05]."
@@ -169,7 +169,7 @@
     {
       "id": "summary",
       "title": "Part XII: Summary",
-      "summary": "erdos_1178 axiom: the open conjecture.",
+      "summary": "BrownErdosSosGeneralConjecture def and summary of the open problem.",
       "startLine": 196,
       "endLine": 215,
       "mathContext": "OPEN: $d_r(e) = (r-2)e + 3$. Lower bound proved, upper bound has a $\\log_2 e$ gap."


### PR DESCRIPTION
## Fix

Corrects four section summaries in `src/data/proofs/erdos-1178/meta.json` that incorrectly called definitions and theorems "axioms".

## Evidence

**Before**: Sections described `exr`, `dr`, `sarkozy_selkow_upper`, and an unnamed `erdos_1178` as axioms.

**After**: Each is correctly identified per the Lean source:
- `exr` → `noncomputable def` (line 86 of Erdos1178Problem.lean)
- `dr` → `def` via `sInf` (line 99), with `dr_spec`/`dr_minimal` as `theorem`s
- `sarkozy_selkow_upper` → `theorem` proved from `sarkozy_selkow_result` axiom (line 141)
- Summary section → references `BrownErdosSosGeneralConjecture def` (the actual open problem definition)

The two real axioms (`sarkozy_selkow_result`, `bes_lower_bound`) and all numerical fields (`axiomCount: 2`, `sorries: 0`) are unchanged.

---
Automated fix by lean-mechanic agent.