### PR TITLE
fix(brouwer-fixed-point-oq-04-oq-02): correct phantom-axiom references

### DIFF
--- a/src/data/proofs/brouwer-fixed-point-oq-04-oq-02/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-04-oq-02/meta.json
@@ -105,7 +105,7 @@
       "title": "Fixed Point Is Nash + Main Existence Theorem",
       "startLine": 201,
       "endLine": 280,
-      "summary": "fixed_point_is_nash: algebraic proof that any fixed point σ* of Nash's map is a Nash equilibrium (Cᵢ = 0 for all i). nash_existence: apply brouwer_product_simplex axiom to nashMap, then fixed_point_is_nash.",
+      "summary": "fixed_point_is_nash: algebraic proof that any fixed point σ* of Nash's map is a Nash equilibrium (Cᵢ = 0 for all i). nash_existence: apply brouwer_product_simplex theorem to nashMap, then fixed_point_is_nash.",
       "mathContext": "At fixed point: eᵢₖ = σ*ᵢ(k)·Cᵢ for all i,k. If Cᵢ > 0: EU_i(σ*ᵢ, σ*₋ᵢ) > EU_i(σ*ᵢ, σ*₋ᵢ) — contradiction. So Cᵢ = 0, meaning σ* is a Nash equilibrium."
     }
   ],
@@ -118,7 +118,7 @@
     {
       "targetId": "brouwer-fixed-point-oq-04",
       "relationship": "depends-on",
-      "description": "Provides the brouwer_product_simplex axiom (Brouwer FPT for product simplex) and the kakutani_fixed_point_axiom used in OQ-01."
+      "description": "Provides the brouwer_pi_compact_convex axiom (general Brouwer FPT) from which brouwer_product_simplex is proved, and the kakutani_fixed_point_axiom used in OQ-01."
     }
   ],
   "references": [


### PR DESCRIPTION
## Fix

Corrects two phantom-axiom references in `src/data/proofs/brouwer-fixed-point-oq-04-oq-02/meta.json`.

`brouwer_product_simplex` is declared as `theorem brouwer_product_simplex` (line 457 of `BrouwerFixedPointOQ04OQ02.lean`), proved from the `brouwer_pi_compact_convex` axiom in the parent file. It is **not** an axiom in this file.

## Evidence

**Section fixed-point-and-nash summary**:
- Before: "apply `brouwer_product_simplex` axiom to nashMap"
- After: "apply `brouwer_product_simplex` theorem to nashMap"

**Cross-reference description (parent file)**:
- Before: "Provides the `brouwer_product_simplex` axiom"
- After: "Provides the `brouwer_pi_compact_convex` axiom (from which `brouwer_product_simplex` is proved)"

All numerical fields unchanged (`axiomCount: 1`, `sorries: 0`). The 1 axiom is `brouwer_pi_compact_convex` in the parent file, correctly described in `assumptions`.

---
Automated fix by lean-mechanic agent.