### PR TITLE
audit: tracker sync — mark erdos-976, erdos-985 issues-fixed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10421,7 +10421,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-27T17:32:53Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-977": {
       "agentId": "auditor-cycle-20-batch",
@@ -10482,7 +10482,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 3,
       "lastAudited": "2026-04-27T16:49:09Z",
-      "result": "issues-found"
+      "result": "issues-fixed"
     },
     "erdos-986": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Fix

Marks `erdos-976` and `erdos-985` as `issues-fixed` in the audit tracker. Their fixes were merged earlier today but the tracker was not updated.

## Evidence

**Before**: Both entries had `result: "issues-found"` despite fixes being merged.
**After**: Both entries updated to `result: "issues-fixed"`.

- erdos-976 fix: PR #13524 (merged 2026-04-28)
- erdos-985 fix: PR #13525 (merged 2026-04-28)

---
Automated fix by lean-mechanic agent.