### PR TITLE
audit(batch): correct phantom-axiom narratives in erdos-923 and erdos-927

### DIFF
--- a/src/data/proofs/erdos-923/meta.json
+++ b/src/data/proofs/erdos-923/meta.json
@@ -97,16 +97,16 @@
       "title": "Subgraphs",
       "startLine": 98,
       "endLine": 121,
-      "summary": "Defines `IsSpanningSubgraph` ($E(H) \\subseteq E(G)$, same vertices) and `inducedSubgraph` ($G[S]$ via `comap`). Axiomatizes $\\chi(H) \\leq \\chi(G)$ for spanning subgraphs $H \\subseteq G$.",
-      "mathContext": "Formal definition: Defines `IsSpanningSubgraph` ($E(H) \\subseteq E(G)$, same vertices) and `inducedSubgraph` ($G[S]$ via `comap`). Axiomatizes $\\chi(H) \\leq \\chi(G)$ for spanning subgraphs $H \\subseteq G$."
+      "summary": "Defines `IsSpanningSubgraph` ($E(H) \\subseteq E(G)$, same vertices). Subgraph monotonicity ($\\chi(H) \\leq \\chi(G)$) is described in a docstring only — no axiom or theorem is declared in this section, and there is no `inducedSubgraph` definition.",
+      "mathContext": "Formal definition: `IsSpanningSubgraph`. The subgraph-monotonicity property is described in docstring only; no `inducedSubgraph` definition or χ-monotonicity axiom exists in this file."
     },
     {
       "id": "mycielski",
       "title": "Mycielski's Construction",
       "startLine": 122,
       "endLine": 133,
-      "summary": "Axiomatizes Mycielski's 1955 theorem: $\\forall k,\\, \\exists G$ triangle-free with $\\chi(G) \\geq k$. The Mycielskian $\\mu(G)$ increments $\\chi$ by 1 while preserving triangle-freeness.",
-      "mathContext": "Verified: Axiomatizes Mycielski's 1955 theorem: $\\forall k,\\, \\exists G$ triangle-free with $\\chi(G) \\geq k$. The Mycielskian $\\mu(G)$ increments $\\chi$ by 1 while preserving triangle-freeness."
+      "summary": "Docstring section describing Mycielski's 1955 theorem ($\\forall k,\\, \\exists G$ triangle-free with $\\chi(G) \\geq k$) and the Mycielskian construction $\\mu(G)$. No `mycielski_*` axiom or theorem is declared in this file.",
+      "mathContext": "Docstring-only context: Mycielski's 1955 theorem and the Mycielskian construction $\\mu(G)$. Not formalized — no axiom or theorem declared in this section."
     },
     {
       "id": "main-theorem",
@@ -129,8 +129,8 @@
       "title": "Generalizations",
       "startLine": 200,
       "endLine": 227,
-      "summary": "Defines `HFreeSubgraphProblem` for arbitrary forbidden subgraph $H$. Axiomatizes Rödl's generalization: the $H$-free version holds when $H$ is bipartite ($\\exists$ 2-coloring of $H$). Connects to Erdős Problem #108.",
-      "mathContext": "Defines `HFreeSubgraphProblem` for arbitrary forbidden subgraph $H$. Axiomatizes Rödl's generalization: the $H$-free version holds when $H$ is bipartite ($\\exists$ 2-coloring of $H$)."
+      "summary": "Defines `HFreeSubgraphProblem` for arbitrary forbidden subgraph $H$. Rödl's generalization (the $H$-free version for bipartite $H$) is described in a docstring only — no axiom or theorem is declared. Connects to Erdős Problem #108.",
+      "mathContext": "Defines `HFreeSubgraphProblem` for arbitrary forbidden subgraph $H$. Rödl's bipartite-$H$ generalization appears in docstring only; not formalized as an axiom or theorem."
     },
     {
       "id": "summary",
@@ -148,7 +148,7 @@
       "What is the optimal constant $C$ in $f(k) \\leq \\text{tower}(Ck)$? Is $C = 1$ achievable?",
       "Can the result be extended to ALL graphs $H$ (not just bipartite)? For non-bipartite $H$ like $K_4$ or odd cycles $C_{2t+1}$, the problem connects to Erdős Problem #108.",
       "Is the tower-type growth of $f(k)$ necessary, or could $f(k)$ grow as a polynomial or exponential in $k$ for the triangle-free case?",
-      "Can the Lean axioms (`rodl_1977`, `mycielski_triangle_free_high_chromatic`) be replaced by fully verified proofs using Mathlib's graph coloring infrastructure?"
+      "Can the Lean axioms `rodl_1977` and `rodl_bound` be replaced by fully verified proofs using Mathlib's graph coloring infrastructure?"
     ]
   },
   "crossReferences": [
@@ -177,7 +177,7 @@
     "lineCount": 230,
     "axiomCount": 2,
     "theoremCount": 3,
-    "definitionCount": 9,
+    "definitionCount": 6,
     "path": "Proofs/Erdos923Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-927/meta.json
+++ b/src/data/proofs/erdos-927/meta.json
@@ -66,32 +66,32 @@
       "title": "The Function $g(n)$",
       "startLine": 65,
       "endLine": 94,
-      "summary": "Defines `g : \\mathbb{N} \\to \\mathbb{N}` as the maximum number of distinct clique sizes over all graphs on $n$ vertices (noncomputable). Axiomatizes $g(n) \\leq n$ and proves `singleton_is_clique`: every vertex forms a clique of size 1.",
-      "mathContext": "Defines `g : \\mathbb{N} \\to \\mathbb{N}` as the maximum number of distinct clique sizes over all graphs on $n$ vertices (noncomputable). Axiomatizes $g(n) \\leq n$ and proves `singleton_is_clique`: every vertex forms a clique of size 1."
+      "summary": "Defines `g : \\mathbb{N} \\to \\mathbb{N}` as the maximum number of distinct clique sizes over all graphs on $n$ vertices (currently a placeholder `g n := n`). Proves `singleton_is_clique`: every vertex forms a clique of size 1. The trivial $g(n) \\leq n$ bound is described in a docstring only — no axiom is declared.",
+      "mathContext": "Defines `g : \\mathbb{N} \\to \\mathbb{N}` (placeholder `g n := n`). Proves `singleton_is_clique`. The $g(n) \\leq n$ bound is described in docstring only; no axiom declared."
     },
     {
       "id": "moon-moser",
       "title": "Moon-Moser Bounds (1965)",
       "startLine": 95,
       "endLine": 112,
-      "summary": "Axiomatizes the Moon-Moser bounds: upper bound $g(n) \\leq n - \\lfloor \\log_2 n \\rfloor$ using `Nat.log 2 n`, and lower bound $g(n) > n - \\log_2 n - 2\\log\\log n / \\log 2$ using `Real.log`.",
-      "mathContext": "Axiomatizes the Moon-Moser bounds: upper bound $g(n) \\leq n - \\lfloor \\log_2 n \\rfloor$ using `Nat.log 2 n`, and lower bound $g(n) > n - \\log_2 n - 2\\log\\$\\log n$ / \\log 2$ using `Real.log`."
+      "summary": "Docstring section describing the Moon-Moser bounds: upper bound $g(n) \\leq n - \\lfloor \\log_2 n \\rfloor$ and lower bound $g(n) > n - \\log_2 n - 2\\log\\log n$. No axioms or theorems are declared in this section.",
+      "mathContext": "Docstring-only context: the Moon-Moser bounds are described but not axiomatized in this file."
     },
     {
       "id": "log-star",
       "title": "The Iterated Logarithm $\\log^*$",
       "startLine": 113,
       "endLine": 139,
-      "summary": "Defines `logStar : \\mathbb{N} \\to \\mathbb{N}` recursively: $\\log^*(0) = \\log^*(1) = 0$, otherwise $1 + \\log^*(\\lfloor \\log_2 n \\rfloor)$ if $\\lfloor \\log_2 n \\rfloor > 1$. Axiomatizes $\\log^*(2^{16}) \\leq 4$.",
-      "mathContext": "Defines `logStar : \\mathbb{N} \\to \\mathbb{N}` recursively: $\\log^*(0) = \\log^*(1) = 0$, otherwise $1 + \\log^*(\\lfloor \\log_2 n \\rfloor)$ if $\\lfloor \\log_2 n \\rfloor > 1$. Axiomatizes $\\log^*(2^{16}) \\leq 4$."
+      "summary": "Defines `logStar : \\mathbb{N} \\to \\mathbb{N}` recursively: $\\log^*(0) = \\log^*(1) = 0$, otherwise $1 + \\log^*(\\lfloor \\log_2 n \\rfloor)$ if $\\lfloor \\log_2 n \\rfloor > 1$. The $\\log^*(2^{16}) = 4$ value is mentioned in a docstring only — no axiom or theorem is declared.",
+      "mathContext": "Defines `logStar` recursively. $\\log^*(2^{16}) = 4$ is mentioned in docstring only; no axiom declared."
     },
     {
       "id": "erdos-conjecture",
       "title": "Erdős's Conjecture (1966)",
       "startLine": 140,
       "endLine": 162,
-      "summary": "Axiomatizes Erdős's improved lower bound $g(n) > n - \\log_2 n - \\log^*(n) - C$. Defines `ErdosConjecture` as $|g(n) - (n - \\log_2 n - \\log^*(n))| \\leq C$ for all $n \\geq 2$.",
-      "mathContext": "Formal definition: Axiomatizes Erdős's improved lower bound $g(n) > n - \\log_2 n - \\log^*(n) - C$. Defines `ErdosConjecture` as $|g(n) - (n - \\log_2 n - \\log^*(n))| \\leq C$ for all $n \\geq 2$."
+      "summary": "Defines `ErdosConjecture` as $|g(n) - (n - \\log_2 n - \\log^*(n))| \\leq C$ for all $n \\geq 2$. Erdős's improved lower bound $g(n) > n - \\log_2 n - \\log^*(n) - C$ is described in a docstring only — no axiom is declared (the conjecture is formalized as a `Prop` definition).",
+      "mathContext": "Defines `ErdosConjecture`. Erdős's improved lower bound is described in docstring only; no axiom declared in this section."
     },
     {
       "id": "spencer",


### PR DESCRIPTION
## Summary

Fixes phantom-axiom narratives in two more erdős-9XX gallery entries. As before, numerical `axiomCount` values were correct, but `sections[].summary` entries (and one `conclusion.openQuestions` reference and a `leanFile.definitionCount`) referenced declarations that exist only inside Lean docstring blocks.

### erdos-923 — 2 actual axioms
Source axioms: `rodl_1977`, `rodl_bound`.

Removed phantom claims for:
- \`inducedSubgraph\` definition and a χ-monotonicity axiom in section \"subgraphs\" (lines 87-97 are docstrings only)
- Mycielski's 1955 theorem axiom in section \"mycielski\" (lines 100-104 are docstrings only — no `mycielski_*` declaration)
- Rödl's bipartite-$H$ generalization axiom in section \"generalizations\" (lines 190-194 are docstring only)
- `mycielski_triangle_free_high_chromatic` reference in `conclusion.openQuestions`

Also corrected `leanFile.definitionCount`: 9 → 6 (actual: HasChromaticNumberAtLeast, HasTriangle, IsTriangleFree, IsSpanningSubgraph, towerFunction, HFreeSubgraphProblem).

### erdos-927 — 2 actual axioms
Source axioms: `spencer_theorem`, `conjecture_disproved`.

Removed phantom axiom claims for:
- \`g(n) ≤ n\` trivial upper bound (section \"g-function\", line 79 docstring only)
- Moon-Moser upper bound and lower bound (section \"moon-moser\", lines 97-104 are two docstrings)
- \`log*(2^16) ≤ 4\` (section \"log-star\", line 128 says the value is computed directly)
- Erdős's \"improved lower bound\" axiom (section \"erdos-conjecture\", lines 134-141 are docstrings; only the `ErdosConjecture` Prop is declared)

## Test plan
- [x] JSON validates
- [x] Cross-checked against `proofs/Proofs/Erdos923Problem.lean` and `proofs/Proofs/Erdos927Problem.lean`
- [x] No changes to badge/status/sorries/lineCount/axiomCount/theoremCount

Continues the erdős-9XX phantom-axiom audit cluster (cf. #13526 #13511 #13512 #13510 #13499 #13502 #13503 #13505 et al.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)