### PR TITLE
audit(erdos-930): correct phantom-axiom narrative

### DIFF
--- a/src/data/proofs/erdos-930/meta.json
+++ b/src/data/proofs/erdos-930/meta.json
@@ -42,11 +42,11 @@
       }
     ],
     "originalContributions": [
-      "Formal statement of the OPEN Erd\u0151s problem in Lean 4",
-      "Definition of perfect power predicate IsPower",
-      "Axiomatization of the Erd\u0151s-Selfridge theorem (r=1 case)",
-      "Statement of the technical prime multiplicity lemma",
-      "Verified properties of perfect powers and small examples"
+      "Definition of perfect power predicate IsPower in Lean 4",
+      "Definitions of intervalProduct and intervalLength",
+      "Verified theorems that 0, 1, n^2, and n^3 are perfect powers",
+      "Verified example: the product 2\u00b73 = 6 is not a perfect power (axiomatizing six_not_isPower)",
+      "Documentation of the OPEN main conjecture and the Erd\u0151s-Selfridge theorem (no formal declarations for these)"
     ],
     "axiomCount": 1,
     "lineCount": 149,
@@ -56,11 +56,11 @@
     "historicalContext": "This problem asks about products of integers from multiple disjoint intervals. Erd\u0151s and Selfridge famously proved in 1975 that the product of two or more consecutive positive integers is NEVER a perfect power. This resolved the r=1 case of Problem #930.\n\nThe general case asks: for r disjoint intervals of consecutive integers, all sufficiently long, is their combined product never a perfect power? The condition that intervals be 'sufficiently long' (length at least k, where k depends on r) is necessary\u2014without it, counterexamples exist for r=2.\n\nThe Erd\u0151s-Selfridge proof uses sophisticated arguments about prime multiplicities. The key insight is that for any product of consecutive integers, there exists a prime whose multiplicity is not divisible by any given l > 1, preventing the product from being a perfect l-th power.",
     "problemStatement": "Is it true that, for every $r$, there is a $k$ such that if $I_1,\\ldots,I_r$ are disjoint intervals of consecutive integers, all of length at least $k$, then\n$$\\prod_{1\\leq i\\leq r}\\prod_{m\\in I_i}m$$\nis not a perfect power?\n\n**Status**:\n- **OPEN** for general $r > 1$\n- **SOLVED** for $r = 1$ (Erd\u0151s-Selfridge, 1975)\n\n**Known**: The product of $k \\geq 2$ consecutive positive integers $(n+1)(n+2)\\cdots(n+k)$ is never a perfect power.",
     "text": "Is it true that, for every r, there is a k such that if I\u2081,...,I\u1d63 are disjoint intervals of consecutive integers, all of length at least k, then their combined product is not a perfect power?",
-    "proofStrategy": "We formalize this problem by:\n\n1. **Defining perfect powers**: `IsPower n` holds if n = m^l for some l > 1\n\n2. **Stating the main conjecture**: For every r > 0, there exists k such that r disjoint intervals of length \u2265 k have a non-power product\n\n3. **Axiomatizing the Erd\u0151s-Selfridge theorem**: The r=1 case is stated as an axiom\n\n4. **Technical lemma**: The prime multiplicity result that drives the proof\n\n5. **Verified examples**: Basic properties of perfect powers and small cases",
+    "proofStrategy": "We provide a partial Lean 4 scaffold for this problem:\n\n1. **Defining perfect powers**: `IsPower n` holds if n = m^l for some l > 1\n\n2. **Interval primitives**: `intervalProduct` and `intervalLength` over `Finset.Icc`\n\n3. **Documented (not formalized)**: The main conjecture for r > 1, the r=1 Erd\u0151s-Selfridge theorem, and the prime-multiplicity technical lemma appear only as docstrings; no `axiom` or `theorem` declarations are produced for them\n\n4. **Verified properties**: 0, 1, n^2, and n^3 are perfect powers (proved)\n\n5. **Single concrete axiom**: `six_not_isPower` (\u00ac IsPower 6) is asserted by axiom and used to prove the example `product_2_3_not_power`",
     "keyInsights": [
       "**Perfect power definition**: n is a perfect power if n = m^l with l > 1. Examples: 4, 8, 9, 16, 25, 27, 32, ...",
-      "**Why consecutive products aren't powers**: In any product (n+1)(n+2)...(n+k), there's always some prime p whose multiplicity isn't divisible by any l > 1.",
-      "**The key technical lemma**: For k \u2265 3 and sufficiently large n, there exists a prime p \u2265 k such that l \u2224 ord_p((n+1)...(n+k)).",
+      "**Why consecutive products aren't powers (mathematical, not formalized here)**: In any product (n+1)(n+2)...(n+k), there's always some prime p whose multiplicity isn't divisible by any l > 1.",
+      "**The key technical lemma (documented in comments, not formalized)**: For k \u2265 3 and sufficiently large n, there exists a prime p \u2265 k such that l \u2224 ord_p((n+1)...(n+k)).",
       "**Why intervals must be long**: For r=2 with short intervals, counterexamples exist\u2014the length constraint prevents pathological cases.",
       "**Connection to factorials**: This problem relates to the structure of prime factorizations in factorial-like products."
     ],
@@ -88,24 +88,24 @@
     },
     {
       "id": "main-conjecture",
-      "title": "Main Conjecture (OPEN)",
+      "title": "Main Conjecture (documentation only)",
       "startLine": 48,
       "endLine": 71,
-      "summary": "The general statement of Problem #930 for arbitrary r disjoint intervals."
+      "summary": "Comment-only description of Problem #930 for arbitrary r disjoint intervals; no axiom or theorem declaration."
     },
     {
       "id": "erdos-selfridge",
-      "title": "Erd\u0151s-Selfridge Theorem (r=1)",
+      "title": "Erd\u0151s-Selfridge Theorem r=1 (documentation only)",
       "startLine": 72,
       "endLine": 90,
-      "summary": "The solved case: products of consecutive integers are never perfect powers."
+      "summary": "Comment-only description of the solved r=1 case (1975); no axiom or theorem declaration."
     },
     {
       "id": "technical-lemma",
-      "title": "Prime Multiplicity Lemma",
+      "title": "Prime Multiplicity Lemma (nextPrime def + documentation)",
       "startLine": 91,
       "endLine": 113,
-      "summary": "The technical result about prime multiplicities that drives the proof."
+      "summary": "Defines `nextPrime` (least prime \u2265 k) and describes the technical Erd\u0151s-Selfridge lemma in a docstring; the lemma itself is not formalized."
     },
     {
       "id": "properties",
@@ -123,7 +123,7 @@
     }
   ],
   "conclusion": {
-    "summary": "We formalize Erd\u0151s Problem #930 about products of integers from disjoint intervals and perfect powers. The case r=1 was famously solved by Erd\u0151s and Selfridge in 1975, showing that no product of consecutive integers is a perfect power. The general case for r > 1 intervals remains OPEN.",
+    "summary": "We provide a partial Lean 4 scaffold for Erd\u0151s Problem #930. Concretely we formalize the perfect power predicate, basic verified properties (0, 1, squares, cubes), and a single axiomatized counterexample (`six_not_isPower`) used to prove that 2\u00b73 is not a power. The main conjecture (r > 1) and the Erd\u0151s-Selfridge r=1 theorem (1975) are documented in comments but not declared as Lean axioms or theorems. The general case for r > 1 intervals remains OPEN.",
     "implications": "**Theoretical Significance**: This problem connects prime factorization structure with the arithmetic of interval products.\n\nUnderstanding why consecutive products avoid being powers reveals deep facts about how primes distribute in these products. Progress here would illuminate the multiplicative structure of factorial-like numbers.",
     "openQuestions": [
       "Does the conjecture hold for r = 2 disjoint intervals?",


### PR DESCRIPTION
## Summary

Corrects the meta.json narrative for `erdos-930` (Products of Disjoint Intervals and Perfect Powers). Numerical counts were correct, but `originalContributions`, `proofStrategy`, section summaries, and conclusion claimed formal statements (the main conjecture, the Erdős-Selfridge theorem, and the prime-multiplicity technical lemma) that exist only as docstrings in the Lean source.

## Evidence

`proofs/Proofs/Erdos930Problem.lean` actually declares:

- 4 defs: `IsPower`, `intervalProduct`, `intervalLength`, `nextPrime`
- 5 theorems: `zero_isPower`, `one_isPower`, `sq_isPower`, `cube_isPower`, `product_2_3_not_power`
- 3 examples: `IsPower 4`, `IsPower 8`, `IsPower 27`
- 1 axiom: `six_not_isPower : ¬ IsPower 6`

The "Main Conjecture (OPEN)", "Erdős-Selfridge Theorem (1975)", and "Erdős-Selfridge Technical Lemma" sections contain only `/-- ... -/` comments — no Lean declarations.

## Changes

- `originalContributions`: replaced phantom items with the actual contents of the file (definitions, the 0/1/n²/n³ theorems, the single concrete axiom `six_not_isPower`, and the documentation-only conjectures)
- `proofStrategy`: rewritten to describe what is actually formalized vs documented
- `keyInsights`: tagged the two insights about the open conjecture as "mathematical, not formalized here" / "documented in comments, not formalized"
- Section titles for `main-conjecture`, `erdos-selfridge`, `technical-lemma`: annotated as "documentation only"; summaries clarified that no axiom/theorem is declared
- `conclusion.summary`: updated to describe the partial scaffold accurately

`axiomCount`, `sorries`, `theoremCount`, `definitionCount`, `lineCount` are unchanged — they were already correct.

## Test plan

- [x] `python3 -m json.tool` validates the JSON
- [ ] Site renders the section titles and conclusion correctly
- [ ] `make build` passes

Part of the gallery audit phantom-axiom narrative cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)