### PR TITLE
audit: tracker sync — mark erdos-930 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10113,9 +10113,9 @@
     },
     "erdos-930": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-28T06:09:35Z",
+      "result": "clean"
     },
     "erdos-931": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Re-audited erdos-930 (3rd cycle); confirmed clean against current Lean source.
- meta.json matches `Erdos930Problem.lean`: 1 axiom (`six_not_isPower`), 0 sorries, 5 theorems, 4 definitions, lineCount 149.
- Phantom-axiom narrative correction from #13533 remains accurate.

## Test plan
- [x] `grep -c "^axiom " proofs/Proofs/Erdos930Problem.lean` → 1
- [x] `grep -c "sorry" proofs/Proofs/Erdos930Problem.lean` → 0
- [x] meta.json fields (axiomCount, sorries, theoremCount, definitionCount, lineCount) verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)