### PR TITLE
fix(erdos-925): realign section line ranges to actual file structure

### DIFF
--- a/src/data/proofs/erdos-925/meta.json
+++ b/src/data/proofs/erdos-925/meta.json
@@ -88,41 +88,41 @@
       "title": "Ramsey Numbers",
       "summary": "R(3,3,m) definition and trivial bound",
       "startLine": 66,
-      "endLine": 83
+      "endLine": 75
     },
     {
       "id": "conjecture",
       "title": "The Conjecture",
       "summary": "Erdős's original question and Ramsey formulation",
-      "startLine": 84,
-      "endLine": 103
+      "startLine": 76,
+      "endLine": 95
     },
     {
       "id": "disproof",
       "title": "Alon-Rödl Disproof (2005)",
       "summary": "Single axiom erdos_925_disproved : ¬erdos_925_conjecture. The sharp Alon-Rödl bounds and Sudakov improvement appear in section docstrings only.",
-      "startLine": 104,
-      "endLine": 132
+      "startLine": 96,
+      "endLine": 107
     },
     {
       "id": "optimality",
       "title": "Optimality of n^(1/3)",
       "summary": "Docstring section noting the trivial bound is essentially tight; no axioms or theorems declared here.",
-      "startLine": 133,
-      "endLine": 145
+      "startLine": 108,
+      "endLine": 112
     },
     {
       "id": "easy-bound",
       "title": "The Easy Lower Bound",
       "summary": "easy_lower_bound axiom: every non-Ramsey graph has α ≥ cn^(1/3).",
-      "startLine": 146,
-      "endLine": 160
+      "startLine": 113,
+      "endLine": 126
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "Main result theorems: erdos_925 and erdos_925_summary",
-      "startLine": 161,
+      "startLine": 128,
       "endLine": 166
     }
   ],


### PR DESCRIPTION
## Fix

Realign all `sections[]` `startLine`/`endLine` values in `src/data/proofs/erdos-925/meta.json` to match the actual `## Part X` structural boundaries in `Erdos925Problem.lean`.

## Evidence

**Before** (drifted — gallery viewers saw wrong code per section):

| Section | Old range | Actual content at old range |
|---------|-----------|----------------------------|
| `ramsey` | 66–83 | Extended past Part II into `def erdos_925_conjecture` |
| `conjecture` | 84–103 | Mid-def body through Part IV header |
| `disproof` | 104–132 | Axiom + all of Part V (optimality) |
| `optimality` | 133–145 | Inside Part VII summary docstring |
| `easy-bound` | 146–160 | Lines of `theorem erdos_925`, not the axiom |
| `summary` | 161–166 | Last 6 lines, missing Part VII docstring |

**After** (aligned to actual `## Part` boundaries):

| Section | New range | Content |
|---------|-----------|---------|
| `ramsey` | 66–75 | Part II only |
| `conjecture` | 76–95 | Part III only |
| `disproof` | 96–107 | Part IV only |
| `optimality` | 108–112 | Part V only |
| `easy-bound` | 113–126 | Part VI: `easy_lower_bound` axiom |
| `summary` | 128–166 | Part VII: summary docstring + theorems |

`definitions` (44–65) was already correct; unchanged.

Closes #13537

---
Automated fix by lean-mechanic agent.