### PR TITLE
fix(batch): correct phantom-axiom narratives in erdos-905, erdos-908, erdos-920

### DIFF
--- a/src/data/proofs/erdos-905/meta.json
+++ b/src/data/proofs/erdos-905/meta.json
@@ -35,8 +35,8 @@
   "overview": {
     "historicalContext": "Bollobás and Erdős conjectured this result about edge-triangle multiplicity. It was independently proved by Edwards (unpublished) and Hadziivanov-Nikiforov in 1979. The problem connects to Turán's classical theorem on triangle-free graphs. Turán's theorem (1941) established that the complete bipartite graph K_{⌊n/2⌋,⌈n/2⌉} is the unique triangle-free graph on n vertices maximizing the number of edges, at exactly ⌊n²/4⌋. The question posed by Bollobás and Erdős pushed beyond mere existence of triangles to ask about their concentration: once the Turán bound is exceeded, must some edge bear a disproportionate share of the triangle count? The answer n/6 is tight, achieved by graphs close to the balanced complete bipartite graph with a small clique added. Nikiforov subsequently extended these ideas into a broader program on the distribution of cliques above Turán thresholds.",
     "problemStatement": "Every graph with n vertices and more than n²/4 edges contains an edge which is in at least n/6 triangles.",
-    "text": "A 215-line formalization of Erdős Problem #905 (SOLVED) with 1 proved theorem, 9 definitions, and 7 axioms. Defines a custom `Graph` structure with symmetric irreflexive edge sets, `IsTriangle` (three pairwise adjacent vertices), `triangleCountEdge` (number of triangles containing a given edge), and `maxTriangleMultiplicity` (maximum over all edges). The Turán threshold `turanNumber n = n^2/4` and `AboveTuran` predicate are defined. The main result `bollobas_erdos_theorem` is axiomatized: any graph with $> n^2/4$ edges has an edge in $\\geq n/6$ triangles. Tightness of $n/6$, Turán graph properties, and a triangle count lower bound are included.",
-    "proofStrategy": "**Part I**: Custom `Graph` structure with `adj : Fin n → Fin n → Prop`, symmetric and irreflexive. `edgeCount` counts unordered pairs.\n\n**Part II**: `IsTriangle G a b c` requires all three edges. `triangleCountEdge G u v` counts vertices $w$ forming a triangle with $(u,v)$. `maxTriangleMultiplicity G` is the maximum over all edges.\n\n**Part III**: `turanNumber n = n^2/4` defines the Turán threshold. `AboveTuran G` means `edgeCount G > turanNumber n`. `turan_theorem` is axiomatized: triangle-free $\\Rightarrow$ `edgeCount G \\leq turanNumber n`.\n\n**Part IV**: `BollobasErdosConjecture` states the main result. `bollobas_erdos_theorem` axiomatizes it as proved.\n\n**Part V-VII**: Tightness, Turán graph properties, and the triangle count lemma $T(G) \\geq (e(G) - n^2/4) \\cdot n/6$.",
+    "text": "A 190-line formalization of Erdős Problem #905 (SOLVED) with 1 proved theorem, 9 definitions, and 1 axiom. Defines a custom `Graph` structure with symmetric irreflexive edge sets, `IsTriangle` (three pairwise adjacent vertices), `triangleCountEdge` (number of triangles containing a given edge), and `maxTriangleMultiplicity` (maximum over all edges). The Turán threshold `turanNumber n = n^2/4` and `AboveTuran` predicate are defined. The main result `bollobas_erdos_theorem` is axiomatized: any graph with $> n^2/4$ edges has an edge in $\\geq n/6$ triangles. Turán graph properties and a triangle count lower bound are documented in comments.",
+    "proofStrategy": "**Part I**: Custom `Graph` structure with `adj : Fin n → Fin n → Prop`, symmetric and irreflexive. `edgeCount` counts unordered pairs.\n\n**Part II**: `IsTriangle G a b c` requires all three edges. `triangleCountEdge G u v` counts vertices $w$ forming a triangle with $(u,v)$. `maxTriangleMultiplicity G` is the maximum over all edges.\n\n**Part III**: `turanNumber n = n^2/4` defines the Turán threshold. `AboveTuran G` means `edgeCount G > turanNumber n`. Turán's theorem (triangle-free $\\Rightarrow e(G) \\leq n^2/4$) is stated only in a docstring comment; the file's sole axiom is `bollobas_erdos_theorem`.\n\n**Part IV**: `BollobasErdosConjecture` states the main result. `bollobas_erdos_theorem` axiomatizes it as proved.\n\n**Part V-VII**: `IsTuranGraph` defined as the balanced bipartite structure. Tightness of n/6 and the triangle count lemma $T(G) \\geq (e(G) - n^2/4) \\cdot n/6$ are stated in docstring comments only; no additional axioms.",
     "keyInsights": [
       "n²/4 is the Turán threshold for triangle-free graphs",
       "Exceeding this threshold forces high triangle multiplicity on some edge",
@@ -74,7 +74,7 @@
       "title": "Part III: Turán's Threshold",
       "startLine": 95,
       "endLine": 118,
-      "summary": "`turanNumber n = n^2/4` and `AboveTuran G` ($e(G) > n^2/4$). `turan_theorem` axiomatized: triangle-free $\\Rightarrow e(G) \\leq n^2/4$.",
+      "summary": "`turanNumber n = n^2/4` and `AboveTuran G` ($e(G) > n^2/4$). Turán's theorem (triangle-free $\\Rightarrow e(G) \\leq n^2/4$) is stated in a docstring comment only; no `turan_theorem` axiom declaration exists in the file.",
       "mathContext": "Turán's theorem (1941): $\\text{ex}(n, K_3) = \\lfloor n^2/4 \\rfloor$, the maximum number of edges in a triangle-free graph on $n$ vertices, achieved uniquely by $K_{\\lfloor n/2 \\rfloor, \\lceil n/2 \\rceil}$."
     },
     {
@@ -89,7 +89,7 @@
       "title": "Part V: Tightness and Turán Theory",
       "startLine": 146,
       "endLine": 187,
-      "summary": "Axiomatizes tightness of n/6 constant. Defines IsTuranGraph and axiomatizes triangle-free property and that adding any edge creates triangles."
+      "summary": "Defines `IsTuranGraph` as the balanced bipartite structure. Tightness of n/6, triangle-free property, and edge-addition lemma are stated in docstring comments only; no formal axioms or theorems declared in this section."
     },
     {
       "id": "key-lemma",

--- a/src/data/proofs/erdos-908/meta.json
+++ b/src/data/proofs/erdos-908/meta.json
@@ -53,14 +53,7 @@
       "IsRigid definition (a.e. constant on translates)",
       "additive_zero theorem (h(0) = 0)",
       "additive_neg theorem (h(-x) = -h(x))",
-      "additive_linear_over_rationals axiom",
-      "discontinuous_additive_exists axiom (via Hamel bases)",
-      "continuous_additive_characterization axiom",
-      "rigid_continuous_is_constant axiom",
-      "rigid_has_measurable_differences axiom",
-      "laczkovich_decomposition axiom (main theorem)",
-      "decomposition_uniqueness axiom",
-      "measurable_decomposition axiom (special case)",
+      "laczkovich_decomposition axiom (main theorem, the file's only axiom)",
       "continuous_has_measurable_differences theorem",
       "additive_has_measurable_differences theorem",
       "erdos_907_related definition and connection",
@@ -76,7 +69,7 @@
     "historicalContext": "**Erdős Problem #908: Functions with Measurable Differences**\n\nThis problem originated from **Nicolaas Govert de Bruijn's** 1951 study of functions whose differences belong to given classes. In his paper \"Functions whose differences belong to a given class\" (*Nieuw Archief voor Wiskunde*), de Bruijn asked: if the difference operator $\\Delta_h f(x) = f(x+h) - f(x)$ maps $f$ into a \"nice\" class of functions for every $h$, what can we say about $f$ itself?\n\nThe specific conjecture, formulated by de Bruijn and Erdős, concerned the class of **Lebesgue measurable** functions: if $\\Delta_h f$ is measurable for all $h > 0$, is $f$ a sum of a continuous function, an additive function, and a \"rigid\" function? The motivation came from the observation that **discontinuous additive functions** (solutions of Cauchy's equation $h(x+y) = h(x) + h(y)$ constructed via Hamel bases and the Axiom of Choice) have the property that $\\Delta_t h = h(t)$ is constant — hence measurable — despite $h$ itself being non-measurable.\n\n**Miklós Laczkovich** resolved the conjecture affirmatively in 1980 in his paper \"Functions with measurable differences\" (*Acta Mathematica Academiae Scientiarum Hungaricae 35*, 217-235). His proof used deep measure-theoretic techniques, including **Steinhaus's theorem** (if $A$ has positive measure, then $A - A$ contains an interval) and properties of measurable sets under translation.\n\nThe result fits into a broader program in real analysis: understanding the interplay between algebraic structure (additivity), topological structure (continuity), and measure-theoretic structure (measurability). The three components — continuous, additive, rigid — represent three fundamentally different \"modes\" of behavior for functions on $\\mathbb{R}$.",
     "problemStatement": "**Problem Statement (Solved)**\n\nLet $f : \\mathbb{R} \\to \\mathbb{R}$ be such that $f(x+h) - f(x)$ is Lebesgue measurable for every $h > 0$.\n\nIs it true that $f = g + h + r$ where:\n- $g$ is continuous\n- $h$ is additive: $h(x+y) = h(x) + h(y)$\n- $r$ is rigid: $r(x+h) = r(x)$ for $\\lambda$-a.e. $x$ (the null set may depend on $h$)\n\n**Answer:** YES (Laczkovich, 1980). The decomposition exists and is essentially unique.",
     "text": "If f : ℝ → ℝ has measurable differences (f(x+h) - f(x) is measurable for all h > 0), can f be decomposed as f = g + h + r where g is continuous, h is additive, and r is rigid? SOLVED: YES (Laczkovich, 1980).",
-    "proofStrategy": "**Formalization Approach**\n\nThe formalization defines the three predicates and builds to the main theorem:\n\n1. **Core Definitions (Lines 52–64):** `HasMeasurableDifferences f` ($\\Delta_h f$ measurable $\\forall h > 0$), `IsAdditive h` ($h(x+y) = h(x)+h(y)$), `IsRigid r` ($r(x+h) = r(x)$ $\\lambda$-a.e.).\n\n2. **Additive Properties (Lines 69–93):** Verified proofs of $h(0) = 0$ and $h(-x) = -h(x)$. Axioms for $\\mathbb{Q}$-linearity, existence of discontinuous additive functions, and characterization of continuous additive functions as $h(x) = cx$.\n\n3. **Rigid Properties (Lines 98–106):** Axioms that rigid + continuous $\\Rightarrow$ constant, and rigid $\\Rightarrow$ measurable differences.\n\n4. **Main Theorem (Lines 117–138):** `laczkovich_decomposition` axiomatizes $f = g + h + r$. `decomposition_uniqueness` axiomatizes essential uniqueness ($g_1 - g_2$ linear, $r_1 = r_2$ a.e.).\n\n5. **Special Cases (Lines 143–175):** Measurable $f \\Rightarrow h = 0$. Verified proofs that continuous and additive functions have measurable differences.\n\n6. **de Bruijn Formulation (Lines 200–207):** `DifferenceClosed C` and proof that measurable functions are difference closed.\n\n7. **Summary (Lines 232–256):** `erdos_908_summary` combines decomposition with verification theorems.",
+    "proofStrategy": "**Formalization Approach**\n\nThe formalization defines the three predicates and builds to the main theorem:\n\n1. **Core Definitions (Lines 52–64):** `HasMeasurableDifferences f` ($\\Delta_h f$ measurable $\\forall h > 0$), `IsAdditive h` ($h(x+y) = h(x)+h(y)$), `IsRigid r` ($r(x+h) = r(x)$ $\\lambda$-a.e.).\n\n2. **Additive Properties (Lines 69–93):** Proved: $h(0) = 0$ (`additive_zero`) and $h(-x) = -h(x)$ (`additive_neg`). Q-linearity, existence of discontinuous additive functions, and characterization of continuous additive as $h(x) = cx$ are stated in docstring comments only; no formal axiom declarations in this section.\n\n3. **Rigid Properties (Lines 98–106):** Rigid function properties (rigid + continuous $\\Rightarrow$ constant, rigid $\\Rightarrow$ measurable differences) are stated in docstring comments only; no formal declarations in this section.\n\n4. **Main Theorem (Lines 117–138):** `laczkovich_decomposition` axiomatizes $f = g + h + r$ (the file's only axiom). Essential uniqueness ($g_1 - g_2$ linear, $r_1 = r_2$ a.e.) is described in the axiom's docstring but not separately formalized.\n\n5. **Special Cases (Lines 143–175):** Verified proofs that continuous and additive functions have measurable differences (`continuous_has_measurable_differences`, `additive_has_measurable_differences`).\n\n6. **de Bruijn Formulation (Lines 200–207):** `DifferenceClosed C` and proof that measurable functions are difference closed.\n\n7. **Summary (Lines 232–256):** `erdos_908_summary` combines decomposition with verification theorems.",
     "keyInsights": [
       "**The Three-Way Decomposition:** Every $f$ with measurable differences splits uniquely (up to a linear function) as $f = g + h + r$: continuous ($g$), additive ($h$), rigid ($r$). Each component captures a fundamentally different \"mode\" of non-measurability: $g$ contributes smoothness, $h$ contributes algebraic structure, and $r$ contributes translation-invariant noise.",
       "**Hamel Functions as Non-Measurability Source:** Discontinuous additive functions, constructed via Hamel bases for $\\mathbb{R}/\\mathbb{Q}$, are the only source of non-measurability in functions with measurable differences. If $f$ itself is measurable, the additive part vanishes ($h = 0$). This explains the precise mechanism by which measurable differences can coexist with non-measurability.",
@@ -109,18 +102,18 @@
     {
       "id": "additive-properties",
       "title": "Properties of Additive Functions",
-      "summary": "Verified: $h(0) = 0$ and $h(-x) = -h(x)$. Axioms: $h(qx) = qh(x)$ for $q \\in \\mathbb{Q}$, $\\exists$ discontinuous additive (via Hamel bases), continuous additive $\\Rightarrow h(x) = cx$.",
+      "summary": "Proved: $h(0) = 0$ (`additive_zero`) and $h(-x) = -h(x)$ (`additive_neg`). Q-linearity ($h(qx) = qh(x)$), existence of discontinuous additive functions (via Hamel bases), and continuous-additive characterization ($h(x) = cx$) are stated in docstring comments only; no formal axiom declarations in this section.",
       "startLine": 67,
       "endLine": 96,
-      "mathContext": "Axiomatized: Verified: $h(0) = 0$ and $h(-x) = -h(x)$. Axioms: $h(qx) = qh(x)$ for $q \\in \\mathbb{Q}$, $\\exists$ discontinuous additive (via Hamel bases), continuous additive $\\Rightarrow h(x) = cx$."
+      "mathContext": "Proved: $h(0) = 0$ and $h(-x) = -h(x)$. Q-linearity and Cauchy equation properties are documented in comments."
     },
     {
       "id": "rigid-properties",
       "title": "Properties of Rigid Functions",
-      "summary": "Axioms: rigid + continuous $\\Rightarrow$ constant (periodic with every period). Rigid $\\Rightarrow$ measurable differences ($\\Delta_h r = 0$ $\\lambda$-a.e.).",
+      "summary": "Rigid function properties (rigid + continuous $\\Rightarrow$ constant, rigid $\\Rightarrow$ measurable differences) are stated in docstring comments only; no formal axiom or theorem declarations exist in this section. The file's sole axiom is `laczkovich_decomposition`.",
       "startLine": 97,
       "endLine": 109,
-      "mathContext": "Axiomatized: Axioms: rigid + continuous $\\Rightarrow$ constant (periodic with every period). Rigid $\\Rightarrow$ measurable differences ($\\Delta_h r = 0$ $\\lambda$-a.e.)."
+      "mathContext": "Rigid properties documented in docstring comments; no formal declarations in this section."
     },
     {
       "id": "decomposition-theorem",
@@ -141,10 +134,10 @@
     {
       "id": "related-problems",
       "title": "Connection to Erdős #907",
-      "summary": "Formalizes Problem #907: additive + bounded on $(a,b) \\Rightarrow$ continuous. Axiom `erdos_907_connection` asserts this. Connects to #908 via the additive component's (dis)continuity.",
+      "summary": "Erdős Problem #907 (additive + bounded on $(a,b) \\Rightarrow$ continuous) is captured by `def erdos_907_related : Prop :=...` — a `def`, not an axiom. No `erdos_907_connection` axiom exists in the file. Connects to #908 via the additive component's (dis)continuity.",
       "startLine": 183,
       "endLine": 195,
-      "mathContext": "Axiomatized: Formalizes Problem #907: additive + bounded on $(a,b) \\Rightarrow$ continuous. Axiom `erdos_907_connection` asserts this. Connects to #908 via the additive component's (dis)continuity."
+      "mathContext": "Problem #907 captured as `def erdos_907_related`; related to #908 via additive component's continuity properties."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-920/meta.json
+++ b/src/data/proofs/erdos-920/meta.json
@@ -31,7 +31,7 @@
     "historicalContext": "The study of chromatic numbers of $K_k$-free graphs has a rich history intertwining graph coloring and Ramsey theory. Erdős initiated this line in 1959 when he used the probabilistic method to show $R(3,m) \\gg (m/\\log m)^2$, which implies $g_3(n) \\gg n^{1/2}/\\log n$. Graver and Yackel established the upper bound $g_k(n) \\ll (n \\log\\log n / \\log n)^{1-1/(k-1)}$ in 1968, published in the Journal of Combinatorial Theory. Shearer later improved the $k=3$ lower bound to $g_3(n) \\gg (n/\\log n)^{1/2}$, essentially resolving that case. For decades the general case $k \\geq 4$ remained open, with the best known lower bound exponent $1 - 2/(k+1)$ falling short of the conjectured $1 - 1/(k-1)$. The landscape changed dramatically in 2023 when Sam Mattheus and Jacques Verstraete proved $R(4,t) \\gg t^3/(\\log t)^4$ using algebraic geometry over finite fields, resolving the $k=4$ case with the optimal exponent $2/3$. Their work appeared in Annals of Mathematics and represents one of the major combinatorial breakthroughs of the decade. The problem for $k \\geq 5$ remains one of the central open questions in extremal combinatorics.",
     "problemStatement": "Let $g_k(n)$ denote the largest chromatic number of a graph with $n$ vertices containing no complete graph $K_k$. Is it true that for $k \\geq 4$, $g_k(n) \\gg n^{1-1/(k-1)} / (\\log n)^c$ for some constant $c > 0$?",
     "text": "Let g_k(n) denote the largest chromatic number of a K_k-free graph on n vertices. Is g_k(n) ≫ n^{1-1/(k-1)} / (log n)^c for k ≥ 4? This connects chromatic numbers to Ramsey theory.",
-    "proofStrategy": "The formalization axiomatizes the key results and connections in this area. The central structural insight is the **Ramsey-chromatic bridge**: if $R(k,m) \\geq c \\cdot m^\\alpha / (\\log m)^\\beta$, then $g_k(n) \\geq c' \\cdot n^{1-1/\\alpha} / (\\log n)^{\\beta/\\alpha}$. This reduces the chromatic number problem to bounding Ramsey numbers. The file axiomatizes the Graver-Yackel upper bound, the Erdős $k=3$ bound, Shearer's improvement, the Mattheus-Verstraete $k=4$ breakthrough, and the general lower bound, then uses the Ramsey-chromatic connection to unify these results in a summary theorem.",
+    "proofStrategy": "The formalization axiomatizes the key results and connections in this area. The central structural insight is the **Ramsey-chromatic bridge**: if $R(k,m) \\geq c \\cdot m^\\alpha / (\\log m)^\\beta$, then $g_k(n) \\geq c' \\cdot n^{1-1/\\alpha} / (\\log n)^{\\beta/\\alpha}$. This reduces the chromatic number problem to bounding Ramsey numbers. The file declares 4 axioms: `maxChromaticKFree` (extremal function), `mattheus_verstraete_2023` (k=4 breakthrough), `general_lower_bound` (general bound with exponent 1−2/(k+1)), and `RamseyNumber`. The Graver-Yackel upper bound, Erdős k=3 bound, Shearer's improvement, and Ramsey-chromatic connection are stated in docstring comments only; no formal axiom declarations for those results.",
     "keyInsights": [
       "**Extremal function** $g_k(n)$: measures the worst-case chromatic complexity among $K_k$-free graphs on $n$ vertices, capturing the tension between local structure (no large cliques) and global complexity (high chromatic number)",
       "**Graver-Yackel upper bound** (1968): $g_k(n) \\ll (n \\log\\log n / \\log n)^{1-1/(k-1)}$ provides the conjectured target exponent $1 - 1/(k-1)$ as the 'correct' answer",
@@ -64,28 +64,28 @@
     {
       "id": "upper-bounds",
       "title": "Known Upper Bounds",
-      "summary": "Axiomatizes the Graver-Yackel (1968) upper bound $g_k(n) \\leq C(n \\log\\log n / \\log n)^{1-1/(k-1)}$ and the trivial bound $g_k(n) \\leq n$. The Graver-Yackel bound provides the target exponent that Erdős conjectures also holds for the lower bound.",
+      "summary": "Contains docstring comments for the Graver-Yackel (1968) upper bound $g_k(n) \\leq C(n \\log\\log n / \\log n)^{1-1/(k-1)}$ and the trivial bound $g_k(n) \\leq n$. No formal axiom declarations for these bounds; they are stated as background context only. The Graver-Yackel exponent $1-1/(k-1)$ is the target for the Erdős conjecture.",
       "startLine": 73,
       "endLine": 94
     },
     {
       "id": "lower-bounds",
       "title": "Known Lower Bounds",
-      "summary": "Axiomatizes four progressively stronger lower bounds: Erdős (1959) $g_3(n) \\gg n^{1/2}/\\log n$ via the probabilistic method, Shearer's improvement $g_3(n) \\gg (n/\\log n)^{1/2}$, the Mattheus-Verstraete (2023) breakthrough $g_4(n) \\gg n^{2/3}/(\\log n)^{4/3}$, and the general bound $g_k(n) \\gg n^{1-2/(k+1)}/(\\log n)^{c_k}$.",
+      "summary": "Axiomatizes two lower bounds as formal declarations: `mattheus_verstraete_2023` ($g_4(n) \\gg n^{2/3}/(\\log n)^{4/3}$, the 2023 breakthrough) and `general_lower_bound` ($g_k(n) \\gg n^{1-2/(k+1)}/(\\log n)^{c_k}$). The Erdős (1959) bound $g_3(n) \\gg n^{1/2}/\\log n$ and Shearer's improvement $g_3(n) \\gg (n/\\log n)^{1/2}$ are stated in docstring comments only; no `^axiom` declarations for those.",
       "startLine": 95,
       "endLine": 139
     },
     {
       "id": "erdos-conjecture",
       "title": "The Erdős Conjecture",
-      "summary": "Formalizes the conjecture as `ErdosConjecture k`: for $k \\geq 4$, $g_k(n) \\geq C \\cdot n^{1-1/(k-1)}/(\\log n)^c$. Also axiomatizes `the_gap` showing the strict inequality $1 - 2/(k+1) < 1 - 1/(k-1)$ for $k \\geq 4$, quantifying how far current bounds fall short.",
+      "summary": "Defines the conjecture as `def ErdosConjecture k : Prop :=...` (a `def`, not an axiom). The gap $1 - 2/(k+1) < 1 - 1/(k-1)$ for $k \\geq 4$ is stated in a docstring comment only; no `the_gap` axiom declaration exists in the file.",
       "startLine": 140,
       "endLine": 165
     },
     {
       "id": "ramsey-connection",
       "title": "Connection to Ramsey Numbers",
-      "summary": "Axiomatizes the Ramsey number $R(k,m)$, the Ramsey-chromatic connection (the key bridge: $R(k,m) \\geq c \\cdot m^\\alpha/(\\log m)^\\beta \\implies g_k(n) \\geq c' \\cdot n^{1-1/\\alpha}/(\\log n)^{\\beta/\\alpha}$), and the specific Ramsey bounds of Erdős ($R(3,m) \\gg (m/\\log m)^2$) and Mattheus-Verstraete ($R(4,m) \\gg m^3/(\\log m)^4$).",
+      "summary": "Axiomatizes the Ramsey number as `axiom RamseyNumber (k m : ℕ) : ℕ`. The Ramsey-chromatic connection ($R(k,m) \\geq c \\cdot m^\\alpha/(\\log m)^\\beta \\implies g_k(n) \\geq c' \\cdot n^{1-1/\\alpha}/(\\log n)^{\\beta/\\alpha}$) and specific Ramsey bounds of Erdős ($R(3,m) \\gg (m/\\log m)^2$) and Mattheus-Verstraete ($R(4,m) \\gg m^3/(\\log m)^4$) are stated in docstring comments only; no formal axiom declarations for those results.",
       "startLine": 166,
       "endLine": 203
     }


### PR DESCRIPTION
## Fix

Three meta.json files had section summaries claiming axiom declarations that exist only as docstring comments in the Lean source files.

## Evidence

**erdos-905**: Only axiom is `bollobas_erdos_theorem`.
- **Before**: `overview.text` claimed "7 axioms" and "215-line"; `proofStrategy` said "`turan_theorem` is axiomatized"; sections had phantom axiom references
- **After**: Corrected to "1 axiom" and "190-line"; Turán's theorem and tightness noted as docstring comments only

**erdos-908**: Only axiom is `laczkovich_decomposition`.
- **Before**: `originalContributions` listed 7 phantom axioms; sections claimed "Axioms" for additive/rigid properties; claimed `erdos_907_connection` axiom
- **After**: Single axiom in originalContributions; properties noted as docstring-only; `erdos_907_related` is a `def`, not an axiom

**erdos-920**: 4 real axioms: `maxChromaticKFree`, `mattheus_verstraete_2023`, `general_lower_bound`, `RamseyNumber`.
- **Before**: upper-bounds claimed "Axiomatizes Graver-Yackel"; lower-bounds claimed "four" axiomatized bounds; `the_gap` claimed as axiom; full Ramsey-chromatic claimed as axiom
- **After**: Docstring-only bounds noted; 2 real axioms in lower-bounds; `ErdosConjecture` is a `def`; `RamseyNumber` axiom noted

Rescues fix from conflicting PR #13534 by applying only the targeted changes from a clean master base.

---
Automated fix by lean-mechanic agent.