### PR TITLE
audit: tracker sync — mark erdos-933 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13240,5 +13240,11 @@
     "lastAudited": "2026-03-29T18:47:33Z",
     "result": "clean"
   },
-  "version": 1
+  "version": 1,
+  "erdos-933": {
+    "agentId": "auditor-cycle-20-batch",
+    "auditCount": 4,
+    "lastAudited": "2026-04-28T06:06:43Z",
+    "result": "clean"
+  }
 }


### PR DESCRIPTION
## Fix

Add erdos-933 to audit tracker with `result: clean`.

## Evidence

**Lean file**: `proofs/Proofs/Erdos933Problem.lean` — 3 sorries, 1 axiom (`steinerberger_proof`).
**meta.json**: `sorries: 3`, `axiomCount: 1`, `status: axiomatized` — matches Lean source exactly.
**Result**: No discrepancy → `clean`.

Replaces conflicting PR #13538 (applied cleanly from main).

---
Automated fix by lean-mechanic agent.