### PR TITLE
audit(erdos-99): realign section line ranges + add Part VIII summary section

### DIFF
--- a/src/data/proofs/erdos-99/meta.json
+++ b/src/data/proofs/erdos-99/meta.json
@@ -105,32 +105,40 @@
       "title": "The Triangular Lattice",
       "summary": "triangularLatticePoint, TriangularLattice definitions; lattice properties described in docstrings only",
       "startLine": 98,
-      "endLine": 128,
+      "endLine": 116,
       "mathContext": "Mathematical content: triangularLatticePoint, TriangularLattice definitions; lattice properties described informally in docstrings only (no axiom declarations)"
     },
     {
       "id": "thue-theorem",
       "title": "Thue's Theorem and Lattice Structure",
       "summary": "Thue's diameter consequence described in docstring only; no Lean declaration",
-      "startLine": 129,
-      "endLine": 141,
+      "startLine": 117,
+      "endLine": 124,
       "mathContext": "Informal sketch only: Thue's diameter consequence described in docstring; no Lean declaration exists"
     },
     {
       "id": "small-cases",
       "title": "Small Cases",
       "summary": "case_n4_no_equilateral axiom (only); case_n3 is a docstring comment",
-      "startLine": 142,
-      "endLine": 157,
+      "startLine": 125,
+      "endLine": 136,
       "mathContext": "Axiomatized: case_n4_no_equilateral axiom only; case_n3 is a docstring comment with no corresponding Lean declaration"
     },
     {
       "id": "main-conjecture",
       "title": "The Main Conjecture (OPEN)",
       "summary": "Erdos99Conjecture, StrongerConjecture, triangularPackingDensity",
-      "startLine": 158,
-      "endLine": 179,
+      "startLine": 137,
+      "endLine": 164,
       "mathContext": "Mathematical content: Erdos99Conjecture, StrongerConjecture, triangularPackingDensity"
+    },
+    {
+      "id": "summary",
+      "title": "Summary Theorem",
+      "summary": "erdos_99_summary theorem assembling the n=4 counterexample as the concrete result",
+      "startLine": 165,
+      "endLine": 179,
+      "mathContext": "Theorem: erdos_99_summary derives the n=4 counterexample from case_n4_no_equilateral axiom; the main conjecture remains open"
     }
   ],
   "conclusion": {
@@ -161,7 +169,7 @@
     "lineCount": 179,
     "axiomCount": 1,
     "theoremCount": 1,
-    "definitionCount": 13,
+    "definitionCount": 14,
     "path": "Proofs/Erdos99Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary

- Section line ranges in erdos-99 meta.json drifted ~12 lines past their actual positions in `proofs/Proofs/Erdos99Problem.lean`
- The `case_n4_no_equilateral` axiom (line 133) was not contained in any named section
- The `erdos_99_summary` theorem (line 174) was not contained in any named section
- Part VIII (Summary) had no representation in the sections list

## Changes

| Section | Before | After | Notes |
|---------|--------|-------|-------|
| triangular-lattice | 98–128 | 98–116 | Part IV ends at 116 |
| thue-theorem | 129–141 | 117–124 | Part V (no Lean declaration) |
| small-cases | 142–157 | 125–136 | Part VI (axiom at 133) |
| main-conjecture | 158–179 | 137–164 | Part VII |
| summary (NEW) | — | 165–179 | Part VIII (erdos_99_summary theorem) |

Also corrected `leanFile.definitionCount` from 13 → 14 (actual count: 14 def/abbrev/noncomputable def declarations).

## Verification

- All section line ranges now match the corresponding `/- ## Part N: ... -/` headers in the Lean source
- meta.json validates as JSON
- `axiomCount: 1`, `sorries: 0`, `lineCount: 179` all unchanged (still accurate)

## Test plan
- [ ] Inspect /erdos-99 page on staging — verify each section navigation jumps to the correct lines
- [ ] Verify `pnpm build` succeeds with the updated meta.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)