### PR TITLE
audit: tracker sync — mark erdos-927 audited (issues-fixed)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10088,9 +10088,9 @@
       "result": "clean"
     },
     "erdos-927": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
+      "agentId": "auditor-agent",
+      "auditCount": 3,
+      "lastAudited": "2026-04-28T07:56:26Z",
       "result": "issues-fixed"
     },
     "erdos-928": {


### PR DESCRIPTION
## Summary

Updates `src/data/proofs/audit-tracker.json` to record the 2026-04-28 audit of erdos-927:

- `auditCount`: 2 → 3
- `lastAudited`: 2026-04-03 → 2026-04-28
- `result`: issues-fixed (continued)

The audit found phantom-axiom claims in `overview.proofStrategy`; the content fix is in PR #13559.

## Test plan
- [x] JSON validates
- [x] Only the erdos-927 entry is touched