### PR TITLE
fix(erdos-200): correct phantom-axiom narratives in section summaries

### DIFF
--- a/src/data/proofs/erdos-200/meta.json
+++ b/src/data/proofs/erdos-200/meta.json
@@ -58,13 +58,11 @@
     "originalContributions": [
       "IsAPSequence, IsPrimeAP: Definitions of arithmetic progressions and prime APs in {1,...,N}",
       "longestPrimeAP: Central function via sSup over prime AP lengths",
-      "prime_ap_upper_pnt: Axiom encoding PNT upper bound (1+ε)·log N",
       "green_tao: Axiom encoding the Green-Tao theorem (arbitrarily long prime APs exist)",
-      "longest_prime_ap_unbounded: Proved unboundedness from Green-Tao axiom",
-      "erdos_200_conjecture: Formal statement of the o(log N) open problem",
-      "green_tao_quantitative: Axiom encoding triple-exponential effective bounds",
+      "longest_prime_ap_unbounded: PROVED from green_tao axiom — unboundedness of longestPrimeAP",
       "exists_dvd_in_ap: Helper lemma — ZMod witness for divisibility in APs",
-      "ap_difference_primorial: PROVED (was false axiom) — primorial divisibility with corrected hypothesis"
+      "ap_difference_primorial: PROVED (was false axiom) — primorial divisibility with corrected hypothesis",
+      "prime_ap_3, prime_ap_5, prime_ap_6: PROVED via native_decide — concrete prime AP examples"
     ],
     "dateAdded": "2026-01-19",
     "axiomCount": 1,
@@ -104,35 +102,35 @@
       "title": "Upper Bound from PNT",
       "startLine": 45,
       "endLine": 58,
-      "summary": "Axiomatizes `prime_ap_upper_pnt`: $\\forall \\varepsilon > 0,\\, \\exists N_0:\\, \\forall N > N_0,\\, \\text{longestPrimeAP}(N) \\leq (1+\\varepsilon)\\log N$. The bound follows from prime density $\\pi(N) \\sim N/\\log N$."
+      "summary": "Docstring comment about PNT upper bound (lines 46–56) — no `axiom prime_ap_upper_pnt` or theorem declaration exists in this section. The upper bound $\\text{longestPrimeAP}(N) \\leq (1+\\varepsilon)\\log N$ is described mathematically but not formalized as a Lean declaration."
     },
     {
       "id": "green-tao",
       "title": "Green-Tao Theorem",
       "startLine": 59,
       "endLine": 69,
-      "summary": "Axiomatizes `green_tao` ($\\forall k,\\, \\exists N:\\, \\text{IsPrimeAP}(k, N)$) and `longest_prime_ap_unbounded` ($\\forall M,\\, \\exists N:\\, \\text{longestPrimeAP}(N) \\geq M$). The 2008 landmark result using transference from Szemerédi's theorem."
+      "summary": "`green_tao` (axiom, line 60): $\\forall k,\\, \\exists N:\\, \\text{IsPrimeAP}(k, N)$. `longest_prime_ap_unbounded` (theorem, line 66): PROVED from `green_tao` — $\\forall M,\\, \\exists N:\\, \\text{longestPrimeAP}(N) \\geq M$. The Green-Tao 2008 landmark result is axiomatized; its consequence is proved."
     },
     {
       "id": "main-conjecture",
       "title": "Main Conjecture: $o(\\log N)$",
       "startLine": 70,
       "endLine": 80,
-      "summary": "Axiomatizes `erdos_200_conjecture`: $\\forall \\varepsilon > 0,\\, \\exists N_0:\\, \\text{longestPrimeAP}(N) < \\varepsilon \\log N$ for $N > N_0$. This is the formal $o(\\log N)$ statement, the central open problem."
+      "summary": "Docstring comment (lines 77–81) stating the $o(\\log N)$ open problem — no `axiom erdos_200_conjecture` or theorem is declared in this section. The conjecture $\\text{longestPrimeAP}(N) = o(\\log N)$ is described but not formalized as a Lean declaration."
     },
     {
       "id": "known-examples",
       "title": "Concrete Prime APs and Quantitative Bounds",
       "startLine": 81,
       "endLine": 96,
-      "summary": "Axiomatizes $\\{3,5,7\\}$ ($k=3$) and $\\{5,11,17,23,29\\}$ ($k=5$) as prime APs. States the Green-Tao-Maynard quantitative bound $N(k) \\leq e^{e^{e^{ck}}}$, reflecting tower-type inefficiency."
+      "summary": "`prime_ap_3` (theorem, line 85): PROVED via `native_decide` — $\\{3,5,7\\}$ is a prime AP. `prime_ap_5` (theorem, line 90): PROVED. `prime_ap_6` (theorem, line 96): PROVED — $\\{7,37,67,97,127,157\\}$. The Green-Tao-Maynard quantitative bound $N(k) \\leq e^{e^{e^{ck}}}$ is mentioned in a docstring (lines 100–102) — no `axiom green_tao_quantitative` is declared."
     },
     {
       "id": "other-conjectures",
       "title": "Hardy-Littlewood Heuristics",
       "startLine": 97,
       "endLine": 111,
-      "summary": "Notes the Hardy-Littlewood $k$-tuple prediction: $\\text{longestPrimeAP}(N) \\sim c \\cdot \\log N$ with $c < 1$. If correct, this contradicts the $o(\\log N)$ conjecture, making the problem delicate. Both axiomatized as `True` placeholders."
+      "summary": "Docstring comment (lines 103–110) discussing the Hardy-Littlewood $k$-tuple prediction: $\\text{longestPrimeAP}(N) \\sim c \\cdot \\log N$ with $c < 1$. This section is commentary only — no Lean declarations or `True` placeholders are present. The heuristic tension with the $o(\\log N)$ conjecture is described mathematically but not formalized."
     },
     {
       "id": "structural",


### PR DESCRIPTION
## Fix

Correct phantom-axiom narratives in `erdos-200/meta.json` section summaries and `originalContributions`.

## Evidence

The Lean file `Erdos200Problem.lean` has exactly **1 axiom**: `green_tao` (line 60). The following were docstring comments or proved theorems, not axioms:

**Before** (phantom claims):
- `originalContributions` listed `prime_ap_upper_pnt`, `erdos_200_conjecture`, `green_tao_quantitative` as axioms
- `sections[upper-bound]`: "Axiomatizes `prime_ap_upper_pnt`..." — no such axiom exists
- `sections[green-tao]`: claimed `longest_prime_ap_unbounded` was axiomatized — it's a PROVED theorem (line 66)
- `sections[main-conjecture]`: "Axiomatizes `erdos_200_conjecture`..." — no such axiom exists  
- `sections[known-examples]`: "Axiomatizes {3,5,7}..." — `prime_ap_3/5/6` are PROVED via `native_decide`
- `sections[other-conjectures]`: "Both axiomatized as `True` placeholders" — the section is a docstring block comment with no declarations

**After**: Sections accurately reflect what's in the Lean source. Only `green_tao` is listed as an axiom.

## Notes

Re-applies fix from stale PR #13552 (based on diverged `origin/main` branch, not mergeable to `master`). Closes #13552.

---
Automated fix by lean-mechanic agent.