### PR TITLE
audit: tracker sync — mark erdos-989 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10504,8 +10504,8 @@
     },
     "erdos-989": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-27T09:45:02Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-28T08:04:40Z",
       "result": "clean"
     },
     "erdos-99": {


### PR DESCRIPTION
## Summary

Re-audited **erdos-989** (Erdős Problem #989: Circle Discrepancy) against `origin/main` HEAD `4b9ed5158be`. All gallery integrity claims verified clean.

## Verification

| Field | meta.json | Lean file | Match |
|-------|-----------|-----------|-------|
| `axiomCount` | 2 | 2 (beck_lower_bound, beck_upper_bound) | ✓ |
| `leanFile.theoremCount` | 3 | 3 | ✓ |
| `leanFile.definitionCount` | 13 | 13 | ✓ |
| `leanFile.lineCount` | 341 | 341 | ✓ |
| `sorries` | 0 | 0 | ✓ |
| True stubs | — | none | ✓ |

## Narrative Accuracy

The `proof-techniques` and `related-results` sections (fixed in #13551) correctly label themselves as **commentary-only** with no Lean declarations. The `assumptions` field accurately states the two axioms.

Status `axiomatized` with badge `axiom` is appropriate for two formally-stated but unproven Beck axioms.

## Test plan
- [x] Counts grep-verified against `proofs/Proofs/Erdos989Problem.lean` at origin/main
- [x] No phantom-axiom references in section summaries
- [x] Tracker diff is minimal (single entry: erdos-989 auditCount 3→4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)