### PR TITLE
audit: tracker sync — mark erdos-924 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10071,9 +10071,9 @@
     },
     "erdos-924": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-28T08:11:22Z",
+      "result": "clean"
     },
     "erdos-925": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Re-audited erdos-924 (Folkman-Nešetřil-Rödl Theorem); gallery is clean.
- Numerical claims match Lean source: 2 axioms (folkman_1970, nesetril_rodl_1976), 0 sorries, 14 defs, 3 theorems, 303 lines.
- Status `axiomatized` / badge `axiom` correctly reflect Tier C (axiomatized result).
- Narrative honest about RamseyNumber non-typechecking placeholder and docstring-only f(3;2) bounds.

## Test plan
- [x] meta.json axiomCount=2 matches `grep -c "^axiom " proofs/Proofs/Erdos924Problem.lean`
- [x] Lean file 303 lines matches lineCount
- [x] No phantom-axiom narrative pattern detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)