### PR TITLE
audit: tracker sync — mark erdos-925 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10077,9 +10077,9 @@
     },
     "erdos-925": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-28T08:28:53Z",
+      "result": "clean"
     },
     "erdos-926": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Audit tracker update only: marks erdos-925 as clean after re-audit
- Audit count 2 → 3, lastAudited 2026-04-03 → 2026-04-28, result issues-fixed → clean

## Audit findings (verified clean)
- meta.json claims match Lean source exactly:
  - 0 sorries, 4 axioms (`independenceNumber`, `R_3_3`, `erdos_925_disproved`, `easy_lower_bound`)
  - 2 theorems (`erdos_925`, `erdos_925_summary`), 4 definitions
  - Section line ranges align with file structure (44–166)
- Narrative correctly notes the sharp Alon-Rödl bounds and Sudakov improvement live only in section docstrings — no phantom-axiom claims
- Status `axiomatized` / badge `axiom` appropriate; main result is axiomatic, not Mathlib-derived

## Test plan
- [x] `npx tsx scripts/auditor/find-targets.ts --stats` after merge will show erdos-925 audit-count incremented