### PR TITLE
audit: tracker sync — mark erdos-92 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10041,9 +10041,9 @@
     },
     "erdos-92": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-28T08:37:22Z",
+      "result": "clean"
     },
     "erdos-920": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Re-audit of erdos-92 verified clean post-#13543 (phantom-axiom narrative fix). Bumps `auditCount: 2 → 3`, updates `lastAudited`, and changes result to `clean`.

## Verification

- **Axioms**: 3 in source (lines 116, 134, 192) match `axiomCount: 3` ✓
- **Sorries**: 0 in source match `sorries: 0` ✓
- **Definitions**: 7 (`dist'`, `maxEquidistantPoints`, `hasEquidistantProperty`, `achievableValues`, `f`, `WeakConjecture`, `StrongConjecture`) ✓
- **Theorems/lemmas**: 4 (`hasEquidistantProperty_le`, `f_le_n_minus_one`, `rpow_le_rpow_of_exponent_le'`, `strong_implies_weak`) ✓
- **Section line ranges**: accurate against current source ✓
- **Narrative**: Pach-Sharir n^{2/5}, JJMT n^{4/11}, lattice n^{c/log log n}, Fishburn small-values correctly noted as docstring-only — not formalized ✓

## Test plan

- [x] Tracker entry updated by `claim-target.sh complete erdos-92 clean`
- [x] No drift between meta.json claims and Lean source

🤖 Generated with [Claude Code](https://claude.com/claude-code)