### PR TITLE
audit: tracker sync — mark erdos-923 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10065,9 +10065,9 @@
     },
     "erdos-923": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-28T08:40:07Z",
+      "result": "clean"
     },
     "erdos-924": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Re-audited erdos-923 (Triangle-Free Subgraphs with High Chromatic Number). All integrity checks pass — tracker now reflects audit count 3 with result `clean`.

## Audit findings

- 2 axioms (`rodl_1977`, `rodl_bound`) — matches `meta.axiomCount`
- 0 sorries — matches
- 230 lines, 3 theorems, 6 definitions — matches
- No `True` stubs
- Section line ranges align with file (recently fixed in #13555)
- `chromaticNumber`/`IsKColorable` correctly noted as imported from `Proofs.GraphCore`
- Status `axiomatized` / badge `axiom` — appropriate

## Test plan

- [x] `npx tsx scripts/auditor/find-targets.ts --stats` confirms tracker integrity

🤖 Generated with [Claude Code](https://claude.com/claude-code)