### PR TITLE
audit(erdos-917): correct phantom-axiom narrative + realign section line ranges

### DIFF
--- a/src/data/proofs/erdos-917/meta.json
+++ b/src/data/proofs/erdos-917/meta.json
@@ -50,11 +50,8 @@
       "Question1, Question2, Question3 formal definitions",
       "toft_1970 axiom: f_k(n) ≫_k n² for k ≥ 4",
       "question1_answered theorem",
-      "dirac_construction axiom for k=6",
-      "erdos_construction axiom for k ≡ 0 (mod 3)",
       "stiebitz_1987_disproof axiom for k ≢ 0 (mod 3)",
-      "turan_upper and stiebitz_upper bound axioms",
-      "luo_ma_yang_2023 improved upper bound",
+      "Documentation of Dirac's construction (1952), Erdős's construction (1969), trivial Turán upper bound, Stiebitz upper bound (1987), and Luo-Ma-Yang (2023) improvement (as docstrings, not formalized as axioms)",
       "erdos_917 summary theorem"
     ],
     "axiomCount": 3,
@@ -65,7 +62,7 @@
     "historicalContext": "Erdős Problem #917 concerns the maximum number of edges in k-critical graphs, where a graph is k-critical if its chromatic number is exactly k but removing any edge decreases the chromatic number. The central object is f_k(n), the maximum number of edges in a k-critical graph on n vertices. Erdős originally asked (1949) whether f_k(n) = o(n²), expecting that critical graphs could not be too dense.\n\nDirac (1952) surprised Erdős by constructing 6-critical graphs with approximately n²/4 edges, using two disjoint odd cycles with all cross edges. Erdős (1969) generalized this construction for k divisible by 3, and Toft (1970) settled the quadratic growth question completely: f_k(n) grows at least quadratically for all k ≥ 4. The natural next question was whether a precise asymptotic f_k(n) ~ (1/2)(1 - 1/⌊k/3⌋)n² holds for all k ≥ 6.\n\nStiebitz (1987) disproved the asymptotic conjecture for k not divisible by 3, showing that the mod 3 structure of k fundamentally matters. He also improved the upper bound to f_k(n) < ex(n; K_{k-1}). Luo-Ma-Yang (2023) further tightened the upper bound. The problem remains partially open: the precise asymptotic for k divisible by 3 and the exact value for k = 6 are still unknown.",
     "problemStatement": "**Problem Statement (PARTIALLY SOLVED)**\n\nLet $k \\geq 4$ and let $f_k(n)$ be the maximum number of edges in a $k$-critical graph on $n$ vertices.\n\n**Question 1:** Is $f_k(n) \\gg_k n^2$? (Does edge count grow quadratically?)\n**Answer: YES** (Toft 1970)\n\n**Question 2:** Is $f_6(n) \\sim n^2/4$?\n**Status: OPEN** (Lower bound established by Dirac, upper bound not proven)\n\n**Question 3:** For $k \\geq 6$, is $f_k(n) \\sim \\frac{1}{2}(1 - \\frac{1}{\\lfloor k/3 \\rfloor})n^2$?\n**Partially Answered:**\n- FALSE for $k \\not\\equiv 0 \\pmod{3}$ (Stiebitz 1987)\n- OPEN for $k \\equiv 0 \\pmod{3}$",
     "text": "Let k ≥ 4 and f_k(n) be the maximum edges in a k-critical graph on n vertices. Is f_k(n) ≫_k n²? Is f_6(n) ~ n²/4? For k ≥ 6, is f_k(n) ~ (1/2)(1 - 1/⌊k/3⌋)n²? PARTIALLY SOLVED: Question 1 YES (Toft 1970). Question 3 FALSE for k ≢ 0 (mod 3) (Stiebitz 1987).",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Basic Structures:**\n   - chromaticNumber via Nat.find on Colorable\n   - IsKChromatic: chromatic number equals k\n   - IsKCritical: k-chromatic AND edge-critical\n   - edgeCount via edgeFinset.card\n\n2. **Central Function:**\n   - f k n: maximum edges in k-critical graph on n vertices\n\n3. **Three Questions:**\n   - Question1: ∃ c > 0, f_k(n) ≥ c·n²\n   - Question2: f_6(n)/n² → 1/4\n   - Question3: f_k(n)/n² → (1/2)(1 - 1/⌊k/3⌋)\n\n4. **Key Results:**\n   - toft_1970: Question1 is YES\n   - dirac_construction: f_6(4n+2) ≥ 4n² + 8n + 3\n   - stiebitz_1987_disproof: Question3 FALSE for k ≢ 0 (mod 3)\n   - luo_ma_yang_2023: improved upper bounds\n\n5. **Summary Theorem:**\n   - Combines all partial results into erdos_917_summary",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Basic Structures:**\n   - chromaticNumber via Nat.find on Colorable\n   - IsKChromatic: chromatic number equals k\n   - IsKCritical: k-chromatic AND edge-critical\n   - edgeCount via edgeFinset.card\n\n2. **Central Function:**\n   - f k n: maximum edges in k-critical graph on n vertices (axiomatized)\n\n3. **Three Questions:**\n   - Question1: ∃ c > 0, f_k(n) ≥ c·n²\n   - Question2: f_6(n)/n² → 1/4\n   - Question3: f_k(n)/n² → (1/2)(1 - 1/⌊k/3⌋)\n\n4. **Formalized Results (axioms):**\n   - toft_1970: Question1 is YES\n   - stiebitz_1987_disproof: Question3 FALSE for k ≢ 0 (mod 3)\n\n5. **Documented Results (docstring only, not formalized as axioms):**\n   - Dirac's construction (1952): f_6(4n+2) ≥ 4n² + 8n + 3\n   - Erdős's construction (1969): for k ≡ 0 (mod 3)\n   - Trivial Turán upper bound and Stiebitz (1987) upper bound\n   - Luo-Ma-Yang (2023): improved upper bounds\n\n6. **Summary Theorem:**\n   - erdos_917 combines question1_answered, stiebitz_1987_disproof, and toft_1970",
     "keyInsights": [
       "**Critical vs Chromatic:** k-critical graphs are the 'minimal' k-chromatic graphs—every edge is essential",
       "**Quadratic Growth:** Toft's 1970 result shows f_k(n) grows like n², answering Question 1 affirmatively",
@@ -89,48 +86,48 @@
     {
       "id": "f-function",
       "title": "The Maximum Edge Function f_k(n)",
-      "summary": "Axiomatized f function and f_defined existence axiom",
+      "summary": "Axiomatized f function (only the existence axiom; no separate f_defined axiom)",
       "startLine": 62,
-      "endLine": 76
+      "endLine": 71
     },
     {
       "id": "question1",
       "title": "Question 1: Quadratic Growth",
       "summary": "Question1 definition, toft_1970 axiom, question1_answered theorem",
-      "startLine": 77,
-      "endLine": 97
+      "startLine": 72,
+      "endLine": 92
     },
     {
       "id": "question2",
       "title": "Question 2: The k = 6 Case",
-      "summary": "Question2 definition, dirac_construction axiom",
-      "startLine": 98,
-      "endLine": 117
+      "summary": "Question2 definition; Dirac's construction (1952) described in docstring (not formalized as axiom)",
+      "startLine": 93,
+      "endLine": 108
     },
     {
       "id": "question3",
       "title": "Question 3: The General Asymptotic",
-      "summary": "Question3 definition, erdos_construction, stiebitz_1987_disproof",
-      "startLine": 118,
-      "endLine": 148
+      "summary": "Question3 definition; Erdős's construction (1969) described in docstring; stiebitz_1987_disproof axiom",
+      "startLine": 109,
+      "endLine": 134
     },
     {
       "id": "upper-bounds",
       "title": "Upper Bounds",
-      "summary": "turan_upper, stiebitz_upper, luo_ma_yang_2023",
-      "startLine": 149,
-      "endLine": 176
+      "summary": "Trivial Turán upper bound, Stiebitz (1987) upper bound, and Luo-Ma-Yang (2023) improvement — all described in docstrings only (not formalized as axioms)",
+      "startLine": 135,
+      "endLine": 152
     },
     {
       "id": "summary",
       "title": "Summary and Main Results",
-      "summary": "erdos_917 main theorem combining all partial results",
-      "startLine": 177,
+      "summary": "erdos_917 main theorem combining question1_answered, stiebitz_1987_disproof, and toft_1970",
+      "startLine": 153,
       "endLine": 181
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #917 asks about the maximum edge density of k-critical graphs. Question 1 (quadratic growth) is answered YES by Toft (1970). Question 2 (f_6(n) ~ n²/4) remains OPEN. Question 3 (general asymptotic) is FALSE for k ≢ 0 (mod 3) by Stiebitz (1987) but remains open for k ≡ 0 (mod 3). The formalization captures all known results including the 2023 improved upper bounds by Luo-Ma-Yang.",
+    "summary": "Erdős Problem #917 asks about the maximum edge density of k-critical graphs. Question 1 (quadratic growth) is answered YES by Toft (1970). Question 2 (f_6(n) ~ n²/4) remains OPEN. Question 3 (general asymptotic) is FALSE for k ≢ 0 (mod 3) by Stiebitz (1987) but remains open for k ≡ 0 (mod 3). The formalization records two key results as axioms (toft_1970 and stiebitz_1987_disproof) and documents the Dirac/Erdős constructions and the Stiebitz/Luo-Ma-Yang upper bounds as docstrings without formalizing them as axioms.",
     "implications": "**Theoretical Significance**: **Connections to Graph Theory**\n\n1. **Turán-Type Problems:** Upper bounds come from extremal graph theory (avoiding K_{k-1})\n\n2. **Critical Graph Structure:** Understanding which graphs are k-critical reveals fundamental chromatic structure\n\n**3. Extremal Combinatorics:** The interplay between local (edge removal) and global (chromatic number) properties\n\n4. **Dirac's Construction:** Shows that odd cycles joined completely produce critical graphs with high edge density\n\n5. **Arithmetic Dependence:** The k mod 3 phenomenon connects to the odd cycle structure in Dirac-type constructions.",
     "openQuestions": [
       "Is f_6(n) ~ n²/4? (Question 2)",


### PR DESCRIPTION
## Summary

- The Lean source has only **3 axioms** (`f`, `toft_1970`, `stiebitz_1987_disproof`), matching `axiomCount`. `originalContributions`, `proofStrategy`, and section summaries claimed five additional axioms that exist only as dangling docstrings in the file:
  - `dirac_construction` (k=6 lower bound)
  - `erdos_construction` (k ≡ 0 mod 3 lower bound)
  - `turan_upper` / `stiebitz_upper` bound axioms
  - `luo_ma_yang_2023` improved upper bound
- Reworded narrative so these constructions and bounds are described as **documented (in docstrings)** rather than formalized as axioms.
- Realigned section line ranges (62–71, 72–92, 93–108, 109–134, 135–152, 153–181) to match the `/- ## ... -/` section headers in the Lean source. Previous ranges were off by 5–17 lines per section.

Numerical fields (`axiomCount=3`, `sorries=0`, `lineCount=181`, `theoremCount=2`, `definitionCount=7`) were already correct and unchanged.

## Test plan
- [x] `python3 -m json.tool src/data/proofs/erdos-917/meta.json` — valid JSON
- [x] Cross-check `^axiom ` declarations in `proofs/Proofs/Erdos917Problem.lean` (3 found) against revised narrative

🤖 Generated with [Claude Code](https://claude.com/claude-code)