### PR TITLE
audit: tracker sync — mark erdos-909 issues-fixed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9963,8 +9963,8 @@
     },
     "erdos-909": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-28T08:56:54Z",
       "result": "issues-fixed"
     },
     "erdos-909-oq-01": {


### PR DESCRIPTION
## Summary

Tracker sync after the erdos-909 phantom-axiom narrative fix in #13580.

- `auditCount`: 2 → 3
- `lastAudited`: refreshed to 2026-04-28T08:56:54Z
- `result`: already `issues-fixed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)