### PR TITLE
audit(erdos-985): correct sorry count 0→1 + lineCount drift

### DIFF
--- a/src/data/proofs/erdos-985/meta.json
+++ b/src/data/proofs/erdos-985/meta.json
@@ -18,7 +18,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 985,
     "erdosUrl": "https://erdosproblems.com/985",
     "erdosProblemStatus": "open",
@@ -55,8 +55,8 @@
       "erdos_985_iff_all_odd_primes equivalence theorem"
     ],
     "axiomCount": 2,
-    "lineCount": 223,
-    "assumptions": "2 axioms: heath_brown_theorem, erdos_985_conjecture. 0 sorries."
+    "lineCount": 225,
+    "assumptions": "2 axioms: heath_brown_theorem, erdos_985_conjecture. 1 sorry (in artin_implies_erdos_985, awaiting Linnik-type quantitative step)."
   },
   "overview": {
     "historicalContext": "**Erd\u0151s Problem #985: Prime Primitive Roots**\n\nThis problem asks whether every odd prime p admits a prime primitive root less than itself.\n\n**Key History:**\n- Artin (1927): Conjectured that any non-square integer is a primitive root for infinitely many primes\n- Hooley (1967): Proved Artin's conjecture assuming the Generalized Riemann Hypothesis\n- Heath-Brown (1986): Proved unconditionally that at least one of 2, 3, or 5 is a primitive root for infinitely many primes\n\n**Mathematical Setting:**\nA primitive root modulo p is an integer g whose multiplicative order equals p - 1. This means g generates the entire multiplicative group (\u2124/p\u2124)\u00d7. Erd\u0151s's question asks specifically for PRIME primitive roots, a natural but difficult restriction.",
@@ -139,7 +139,7 @@
       "summary": "artin_implies_erdos_985 theorem",
       "startLine": 179,
       "endLine": 193,
-      "mathContext": "Placeholder: artin_implies_erdos_985 bypasses its hypothesis and calls erdos_985_conjecture axiom directly"
+      "mathContext": "artin_implies_erdos_985 theorem with sorry: deriving Erdős 985 from Artin's conjecture requires a Linnik-type quantitative step (smallest p' ≤ f(q)) not yet formalized"
     },
     {
       "id": "summary",
@@ -171,12 +171,12 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 223,
+    "lineCount": 225,
     "axiomCount": 2,
     "theoremCount": 18,
     "definitionCount": 3,
     "path": "Proofs/Erdos985Problem.lean",
-    "sorries": 0
+    "sorries": 1
   },
   "crossReferences": [
     {
@@ -195,5 +195,5 @@
       "description": "Related Erd\u0151s problem sharing themes: number-theory, open, primes"
     }
   ],
-  "sorries": 0
+  "sorries": 1
 }


### PR DESCRIPTION
## Summary

Audit-tracker flagged `erdos-985`: `❌ sorry mismatch: claims 0, actual 1`.

The Lean source has 1 `sorry` on line 194 in `artin_implies_erdos_985`,
introduced by PR #13292 to fix the prior hypothesis-bypass bug, but the
`meta.json` was not updated to reflect the new state.

## Fixes

- `meta.sorries`, `leanFile.sorries`, top-level `sorries`: 0 → 1
- `meta.lineCount`, `leanFile.lineCount`: 223 → 225 (file is 225 lines)
- `meta.assumptions`: now records the 1 sorry and its location
- `connections` section `mathContext`: replaced stale "bypasses its
  hypothesis" wording with current "sorry / Linnik-type step" description

Status `axiomatized` / badge `axiom` are preserved (open conjecture stays
axiomatized; the sorry is in a derived corollary theorem awaiting a
Linnik-type quantitative step that is not yet formalized).

## Test plan

- [x] `python3 -m json.tool` validates JSON
- [x] Checked actual file: `wc -l` = 225, `grep -n sorry` finds line 194
- [x] Verified no other phantom claims

🤖 Generated with [Claude Code](https://claude.com/claude-code)