### PR TITLE
audit: tracker sync — mark erdos-985 issues-fixed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10480,8 +10480,8 @@
     },
     "erdos-985": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-27T16:49:09Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-28T09:12:11Z",
       "result": "issues-fixed"
     },
     "erdos-986": {


### PR DESCRIPTION
## Summary

Tracker sync companion to #13583 (corrects erdos-985 sorry count 0 → 1 and lineCount 223 → 225).

Updates `src/data/proofs/audit-tracker.json` entry for erdos-985:
- `auditCount`: 3 → 4
- `lastAudited`: 2026-04-27 → 2026-04-28
- `result`: stays `issues-fixed` (the new issue was found and is fixed by #13583)

## Test plan

- [x] JSON validates
- [x] Companion fix PR #13583 created