### PR TITLE
audit: tracker sync — mark erdos-911 issues-fixed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9986,10 +9986,10 @@
       "result": "clean"
     },
     "erdos-911": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T17:34:25Z",
-      "result": "clean"
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-04-28T09:30:00Z",
+      "result": "issues-fixed"
     },
     "erdos-912": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Tracker sync companion to #13587 (corrects erdos-911 phantom-axiom narrative).

Updates `src/data/proofs/audit-tracker.json` entry for erdos-911:
- `auditCount`: 3 → 4
- `lastAudited`: 2026-04-03 → 2026-04-28
- `result`: `clean` → `issues-fixed`
- `agentId`: `auditor-cycle-20-batch` → `auditor-agent`

## Test plan

- [x] JSON validates
- [x] Companion fix PR #13587 created

🤖 Generated with [Claude Code](https://claude.com/claude-code)