### PR TITLE
audit(erdos-903): correct phantom-axiom narrative + realign sections

### DIFF
--- a/src/data/proofs/erdos-903/meta.json
+++ b/src/data/proofs/erdos-903/meta.json
@@ -52,7 +52,7 @@
       "Stated Erd\u0151s-Fowler-S\u00f3s-Wilson theorem (1985): t > n implies t \u2265 n + p",
       "Defined achievableBlocks set and gap_theorem",
       "Connected to Fisher's inequality for 2-designs",
-      "Stated stronger bound: t \u2265 n + 1.148p unless broken projective plane"
+      "Noted (in docstring only, not axiomatized) the stronger bound t \u2265 n + 1.148p for non-broken-projective-plane designs"
     ],
     "axiomCount": 5,
     "lineCount": 211,
@@ -87,58 +87,58 @@
     {
       "id": "de-bruijn-erdos",
       "title": "The de Bruijn-Erd\u0151s Theorem",
-      "summary": "de_bruijn_erdos axiom (t \u2265 n), IsMinimalDesign, minimal_design_uniform",
+      "summary": "de_bruijn_erdos axiom (t \u2265 n) and IsMinimalDesign predicate",
       "startLine": 57,
-      "endLine": 74,
-      "mathContext": "de_bruijn_erdos axiom (t $\\geq$ n), IsMinimalDesign, minimal_design_uniform"
+      "endLine": 71,
+      "mathContext": "Axiomatized: de_bruijn_erdos (t $\\geq$ n). Defined: IsMinimalDesign."
     },
     {
       "id": "projective-planes",
       "title": "Projective Plane Constructions",
-      "summary": "ProjectivePlane structure, projective_plane_exists, projective_plane_design axioms",
-      "startLine": 75,
-      "endLine": 99,
-      "mathContext": "Formal definition: ProjectivePlane structure, projective_plane_exists, projective_plane_design axioms"
+      "summary": "ProjectivePlane structure and projective_plane_design axiom",
+      "startLine": 72,
+      "endLine": 93,
+      "mathContext": "Defined: ProjectivePlane structure. Axiomatized: projective_plane_design (a projective plane gives a block design with t = n)."
     },
     {
       "id": "erdos-sos-theorem",
       "title": "The Erd\u0151s-S\u00f3s Conjecture (Now Theorem)",
-      "summary": "efsw_1985 axiom (gap theorem), efsw_strong axiom with broken-plane condition",
-      "startLine": 100,
-      "endLine": 120,
-      "mathContext": "Verified: efsw_1985 axiom (gap theorem), efsw_strong axiom with broken-plane condition"
+      "summary": "efsw_1985 axiom (gap theorem); 1.148p stronger bound noted in docstring only (not axiomatized)",
+      "startLine": 94,
+      "endLine": 106,
+      "mathContext": "Axiomatized: efsw_1985 (t > n implies t \u2265 n + p). The 1.148p stronger bound under non-broken-projective-plane condition appears only in a docstring comment, not as an axiom or theorem."
     },
     {
       "id": "gap-structure",
       "title": "The Gap Structure",
-      "summary": "achievableBlocks set, n_achievable, gap_theorem, first_above_n (proved by contradiction)",
-      "startLine": 121,
-      "endLine": 147,
-      "mathContext": "Verified: achievableBlocks set, n_achievable, gap_theorem, first_above_n (proved by contradiction)"
+      "summary": "achievableBlocks set, gap_theorem axiom, first_above_n (proved by contradiction)",
+      "startLine": 107,
+      "endLine": 130,
+      "mathContext": "Defined: achievableBlocks. Axiomatized: gap_theorem. Proved: first_above_n (by contradiction from gap_theorem)."
     },
     {
       "id": "examples",
       "title": "Examples",
       "summary": "Concrete gap computations for p = 2, 3, 4, 5 via norm_num",
-      "startLine": 148,
-      "endLine": 163,
+      "startLine": 131,
+      "endLine": 146,
       "mathContext": "Mathematical content: Concrete gap computations for p = 2, 3, 4, 5 via norm_num"
     },
     {
       "id": "2-designs",
       "title": "Connection to Combinatorial Designs",
       "summary": "Is2Design predicate, fisher_inequality axiom, de_bruijn_erdos_from_fisher (proved)",
-      "startLine": 164,
-      "endLine": 183,
-      "mathContext": "Axiomatized: Is2Design predicate, fisher_inequality axiom, de_bruijn_erdos_from_fisher (proved)"
+      "startLine": 147,
+      "endLine": 165,
+      "mathContext": "Defined: Is2Design. Axiomatized: fisher_inequality. Proved: de_bruijn_erdos_from_fisher (direct application of fisher_inequality)."
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "erdos_903_summary (proved): three-part conjunction combining de Bruijn-Erd\u0151s, projective plane existence, and EFSW gap theorem",
-      "startLine": 184,
+      "startLine": 166,
       "endLine": 211,
-      "mathContext": "Verified: erdos_903_summary (proved): three-part conjunction combining de Bruijn-Erd\u0151s, projective plane existence, and EFSW gap theorem"
+      "mathContext": "Proved: erdos_903_summary, a three-part conjunction combining the de Bruijn-Erd\u0151s, projective_plane_design, and efsw_1985 axioms into a single statement."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

Gallery integrity audit of `erdos-903` (Block Designs and the de Bruijn-Erdős Gap) found one phantom-axiom claim and section line-range drift.

## Issues Found

1. **Phantom contribution**: `originalContributions` listed "Stated stronger bound: t ≥ n + 1.148p unless broken projective plane", but no `efsw_strong` axiom or theorem exists in `Erdos903Problem.lean`. The 1.148p bound appears only in a docstring comment (lines 105–106) that is attached to no declaration.

2. **Phantom axiom in section[3]**: The "erdos-sos-theorem" section's `summary` and `mathContext` referenced `efsw_strong axiom with broken-plane condition` — also nonexistent.

3. **Section line drift**: All section ranges from `de-bruijn-erdos` onward were 1–17 lines off (e.g. `gap-structure` started at 121, but Part 5 comment block actually starts at line 107).

## Fix

- Reworded the phantom contribution to acknowledge the bound is noted in a docstring only, not axiomatized.
- Replaced phantom-axiom references in section[3] with accurate descriptions of the single `efsw_1985` axiom.
- Realigned section line ranges (29–56, 57–71, 72–93, 94–106, 107–130, 131–146, 147–165, 166–211).

## Counts (unchanged)

5 axioms, 0 sorries, 211 lines, status `axiomatized`.

## Test plan

- [x] JSON validates
- [ ] Gallery preview renders sections at correct line ranges
- [ ] No regression in audit-tracker

---

Continues the documented erdos-9XX phantom-axiom narrative pattern (latest precedents: erdos-984 #13544, erdos-921/922/925 #13526, erdos-905/908/920 #13550).

🤖 Generated with [Claude Code](https://claude.com/claude-code)