### PR TITLE
audit: tracker sync — mark erdos-904 issues-fixed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9933,8 +9933,8 @@
     },
     "erdos-904": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-28T09:52:46Z",
       "result": "issues-fixed"
     },
     "erdos-905": {


### PR DESCRIPTION
## Summary

Records the erdos-904 phantom-axiom narrative fix (#13592) in `audit-tracker.json`.

- `auditCount`: 2 → 3
- `lastAudited`: 2026-04-03 → 2026-04-28
- `result`: issues-fixed

## Test plan

- [x] Only `audit-tracker.json` modified
- [x] Two-line diff (auditCount + lastAudited)

🤖 Generated with [Claude Code](https://claude.com/claude-code)