### PR TITLE
audit: tracker sync — mark erdos-918 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10029,9 +10029,9 @@
     },
     "erdos-918": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-28T10:09:40Z",
+      "result": "clean"
     },
     "erdos-919": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Audited erdos-918 (Chromatic Numbers of Infinite Graphs) and verified clean.

- 3 axioms (Question1, Question2, erdos_hajnal_finite) match meta.json
- 0 sorries, 146 lineCount confirmed
- status `axiomatized` / badge `axiom` correct
- Phantom-axiom narrative already corrected by #13572 — `originalContributions[1]` and the `erdos-hajnal` section explicitly disclose that `erdos_hajnal_finite` is a placeholder encoding only the cardinality condition (`Cardinal.mk V = aleph k`), not the chromatic number conditions
- All 7 section line ranges verified against the file

## Test plan
- [x] axiomCount, sorries, lineCount match HEAD source
- [x] section line ranges match `git show HEAD:proofs/Proofs/Erdos918Problem.lean`
- [x] narrative does not overstate (Tier C — axiomatized, badge `axiom`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)