### PR TITLE
audit: tracker sync — mark erdos-912 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9993,9 +9993,9 @@
     },
     "erdos-912": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-28T10:19:39Z",
+      "result": "clean"
     },
     "erdos-913": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Re-audit of erdos-912 confirms the phantom-axiom narrative correction from #13576 holds. All numerical claims in meta.json match the Lean source.

## Verification

- `proofs/Proofs/Erdos912Problem.lean`: 221 lines, 2 axioms (`erdos_selfridge_lower_bound`, `erdos_selfridge_upper_bound`), 3 theorems, 8 definitions, 0 sorries, 0 True stubs
- `meta.json` matches: `lineCount: 221`, `axiomCount: 2`, `theoremCount: 3`, `definitionCount: 8`, `sorries: 0`
- Section descriptions correctly note narrative-only docstrings in Parts IV/V/VI (no phantom axiom claims)
- Status `axiomatized` and badge `axiom` appropriate (Tier C — open conjecture)

## Test plan

- [x] Lean source counts verified
- [x] meta.json fields cross-checked
- [x] Section line ranges verified
- [x] No language overstatements detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)