### PR TITLE
audit: tracker sync — mark erdos-9 issues-found

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9897,9 +9897,9 @@
     },
     "erdos-9": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-28T10:22:55Z",
+      "result": "issues-found"
     },
     "erdos-90": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Filed integrity issue #13600 against erdos-9: phantom Crocker, Pan, and `improvement_would_solve` axiom claims in meta.json narrative.

## Findings

- Lean source: 2 axioms (`schinzel_infinite`, `form_in_every_arithmetic_progression`), 7 theorems, 10 definitions, 0 sorries, 253 lines
- Numerical counts in meta.json are accurate
- But `originalContributions[2]`, `overview.proofStrategy`, `sections[4]` (known-results), and `sections[7]` (bounds) all describe Crocker's bound, Pan's bound, Pan's reformulation, and `improvement_would_solve` as axiomatized — they are only orphan docstrings (lines 129-147, 218-225)

Severity: HIGH (overclaims formalization). Same pattern as recently-fixed erdos-923, erdos-927, erdos-926, erdos-907, erdos-934, erdos-978.

## Test plan

- [x] Verified all 4 phantom-axiom claims in meta.json
- [x] Confirmed only 2 actual `axiom` declarations in Lean file
- [x] Issue #13600 filed for mechanic to fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)