### PR TITLE
audit: tracker sync — mark erdos-903 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9927,9 +9927,9 @@
     },
     "erdos-903": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-28T10:41:52Z",
+      "result": "clean"
     },
     "erdos-904": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
Re-audit of erdos-903 (Block Designs and the de Bruijn-Erdős Gap) post-#13590 phantom-axiom fix. All gallery claims verified against `proofs/Proofs/Erdos903Problem.lean` at origin/main 2f5600bc.

## Verified
- **5 axioms** (de_bruijn_erdos, projective_plane_design, efsw_1985, gap_theorem, fisher_inequality) — matches `meta.axiomCount`
- **3 theorems**, **0 sorries**, **0 True stubs**
- **211 lines** — matches `meta.lineCount`
- Section line ranges align with Part 1–8 in source
- 1.148p stronger bound correctly described as **docstring-only** in `originalContributions` and `erdos-sos-theorem` section `mathContext`
- Status `axiomatized` / badge `axiom` consistent with axiom presence

## Result
clean (auditCount 2→3, lastAudited 2026-04-03 → 2026-04-28).

## Test plan
- [x] axiom/theorem/def counts confirmed via grep on Lean source
- [x] No sorries or True stubs
- [x] Section ranges sampled against file part headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)