### PR TITLE
Fix: hurwitz-theorem-oq-04 stale lineCount/theoremCount after PR #13558

### DIFF
--- a/src/data/proofs/hurwitz-theorem-oq-04/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-04/meta.json
@@ -22,8 +22,8 @@
     "dateAdded": "2026-04-24",
     "axiomCount": 0,
     "assumptions": "1 sorry in G2_der_dimension proof chain: derEval14_injective — off-diagonal entries (j in {1,...,7}, i != 0, i != j) of the imaginary basis kernel claim. The j = 0 case is closed via submodule_der_unit_zero; the i = j diagonal case (Session 7, 2026-04-27) is closed via submodule_der_diagonal_kill (Leibniz at (e_j, e_j) using stdBasis_sq_neg_unit). Remaining 49-entry off-diagonal block requires antisymmetry ((f e_i)_j + (f e_j)_i = 0 from Leibniz at (e_i, e_j) + (e_j, e_i)) and Fano-line trilinear constraints. derBasis14_linearIndependent was proved in PR #13121. The Aut(O) is in O(7) — fully proved with 0 sorries.",
-    "lineCount": 1255,
-    "theoremCount": 60,
+    "lineCount": 1382,
+    "theoremCount": 65,
     "definitionCount": 19,
     "originalContributions": [
       "OctonionAlgHom / OctonionAut: structures for octonion algebra homomorphisms and automorphisms",
@@ -137,9 +137,9 @@
       "HurwitzTheorem"
     ],
     "namespace": "HurwitzTheoremOQ04",
-    "lineCount": 1255,
+    "lineCount": 1382,
     "axiomCount": 0,
-    "theoremCount": 60,
+    "theoremCount": 65,
     "definitionCount": 19,
     "sorries": 1,
     "path": "Proofs/HurwitzTheoremOQ04.lean"


### PR DESCRIPTION
## Fix

Update stale `lineCount` and `theoremCount` in `hurwitz-theorem-oq-04/meta.json` to match the current Lean source after PR #13558 added new helper lemmas.

## Evidence

**Root cause**: PR #13558 (`c770f8213c0`) added ~127 lines and 5 new theorems/lemmas (`eightMul_stdBasis_right_zero_imag`, `eightMul_stdBasis_left_zero_imag`, `submodule_der_real_part`, `derEval14_injective`, `derBasis14_linearIndependent`) to `HurwitzTheoremOQ04.lean` without updating `meta.json`.

**Before**:
- `meta.meta.lineCount`: 1255
- `meta.meta.theoremCount`: 60
- `leanFile.lineCount`: 1255
- `leanFile.theoremCount`: 60

**After**:
- `meta.meta.lineCount`: 1382 (actual: `wc -l` = 1382)
- `meta.meta.theoremCount`: 65 (actual: 65 `theorem`/`lemma` declarations)
- `leanFile.lineCount`: 1382
- `leanFile.theoremCount`: 65

**Validated**: `pnpm build` succeeded (exit 0, built in 2m 55s).

Note: PR #13330 (`audit/hurwitz-oq04-meta-sync`) is a pre-existing stale PR covering earlier state; this PR addresses the more recent drift from #13558.

---
Automated fix by lean-mechanic agent.