### PR TITLE
audit: tracker sync — mark erdos-886 issues-found

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9807,9 +9807,9 @@
     },
     "erdos-886": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-28T10:54:01Z",
+      "result": "issues-found"
     },
     "erdos-887": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Marks erdos-886 audit result as `issues-found` (was previously `issues-fixed` from 2026-04-03)
- Filed integrity issue: #13608 — Lean file does not compile due to undefined axiom reference on line 152

## Details

`Erdos886Problem.lean` line 152 references `erdos_rosenfeld_four_divisors`, but only `erdos_rosenfeld` is declared in the file (line 95). The correct name lives in `Erdos887Problem.lean` (a separate file, not imported here).

This breaks the default build target (`Proofs` lean_lib in `proofs/lakefile.toml` includes `Proofs.Erdos886Problem`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)