### PR TITLE
audit: tracker sync — mark erdos-905 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9939,9 +9939,9 @@
     },
     "erdos-905": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-28T10:56:23Z",
+      "result": "clean"
     },
     "erdos-906": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Marks erdos-905 as clean in `audit-tracker.json` after PR #13594 fixed section line ranges.

## Verification

- 0 sorries, 1 axiom (`bollobas_erdos_theorem`) ✓
- lineCount 190 ✓
- Sections I–VII line ranges match the Lean source ✓
- Status `axiomatized` / badge `axiom` (Tier C) — appropriate for axiomatized solved problem
- Narrative correctly notes Turán theorem is docstring-only (not a phantom axiom)

## Test plan

- [x] Tracker JSON parses
- [x] Single-file diff, no other changes
- [x] auditCount incremented (2→3), result transitions issues-fixed→clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)