### PR TITLE
Fix: erdos-886 undefined axiom reference breaks compilation

### DIFF
--- a/proofs/Proofs/Erdos886Problem.lean
+++ b/proofs/Proofs/Erdos886Problem.lean
@@ -91,10 +91,9 @@ def ruzsaConjecture : Prop :=
 /-- **Erdős-Rosenfeld Theorem (1997):**
     There are infinitely many n with four divisors in (√n, √n + n^{1/4}).
     Note: This uses ε = 1/4, which gives a wider interval than the conjecture. -/
-/-- The Erdős-Rosenfeld result for the specific interval (√n, √n + n^{1/4}). -/
-axiom erdos_rosenfeld :
-    ∀ k : ℕ, k ≥ 1 → ∃ n : ℕ, n ≥ k ∧
-      (divisorsInInterval n (Real.sqrt n) (Real.sqrt n + (n : ℝ)^(1/4 : ℝ))).card ≥ 4
+/-- The Erdős-Rosenfeld result: infinitely many n have ≥ 4 divisors in (√n, √n + n^{1/4}). -/
+axiom erdos_rosenfeld_four_divisors :
+    ∃ S : Set ℕ, S.Infinite ∧ ∀ n ∈ S, divisorsNearSqrt n (1/4 : ℝ) ≥ 4
 
 /- ## Part VI: The Factor-Difference Set
 -/

--- a/src/data/proofs/erdos-886/meta.json
+++ b/src/data/proofs/erdos-886/meta.json
@@ -53,7 +53,7 @@
       "divisorsInInterval definition: divisors in (a, b)",
       "divisorsNearSqrt definition: count of divisors near √n",
       "ruzsaConjecture definition: formal statement",
-      "erdos_rosenfeld_four_divisors axiom: Erdős-Rosenfeld result",
+      "erdos_rosenfeld_four_divisors axiom: infinitely many n with ≥ 4 divisors in (√n, √n + n^{1/4})",
       "factorDifferenceSet definition: differences between divisors",
       "localDivisorDensity definition: density measure",
       "ruzsaConjectureAlt definition: equivalent formulation",
@@ -68,7 +68,7 @@
     ],
     "axiomCount": 1,
     "lineCount": 154,
-    "assumptions": "1 axiom: erdos_rosenfeld. 0 sorries."
+    "assumptions": "1 axiom: erdos_rosenfeld_four_divisors. 0 sorries."
   },
   "overview": {
     "historicalContext": "**Ruzsa's Conjecture**\n\nThis problem is attributed by Erdős to Imre Z. Ruzsa, a Hungarian mathematician known for work in additive combinatorics and number theory.\n\n**The Question:** Given ε > 0, is there a constant C_ε such that for all sufficiently large n, the number of divisors of n lying in the narrow interval (√n, √n + n^{1/2-ε}) is at most C_ε?\n\n**Why It's Hard:** The interval shrinks relative to √n as n grows (since n^{1/2-ε} / √n = n^{-ε} → 0). Can divisors 'pile up' in this shrinking window?\n\n**Known Result:** Erdős and Rosenfeld (1997) showed there are infinitely many n with four divisors in (√n, √n + n^{1/4}). This uses ε = 1/4, giving a wider interval.\n\n**Current Status:** OPEN. The problem is considered tractable by some researchers.",
@@ -124,10 +124,10 @@
     {
       "id": "erdos-rosenfeld",
       "title": "Erdős-Rosenfeld Result",
-      "summary": "erdos_rosenfeld_four_divisors, erdos_rosenfeld axioms",
+      "summary": "erdos_rosenfeld_four_divisors axiom",
       "startLine": 95,
-      "endLine": 110,
-      "mathContext": "Axiomatized: erdos_rosenfeld_four_divisors, erdos_rosenfeld axioms"
+      "endLine": 98,
+      "mathContext": "Axiomatized: erdos_rosenfeld_four_divisors (1 axiom)"
     },
     {
       "id": "factor-difference",


### PR DESCRIPTION
## Fix

Replace the misnamed `erdos_rosenfeld` axiom with `erdos_rosenfeld_four_divisors` having the correct type required by the summary theorem.

## Evidence

**Before**: `Erdos886Problem.lean` declared `axiom erdos_rosenfeld` but `erdos_886_summary` referenced `erdos_rosenfeld_four_divisors` (undefined → compile failure).

**After**: Single axiom `erdos_rosenfeld_four_divisors : ∃ S : Set ℕ, S.Infinite ∧ ∀ n ∈ S, divisorsNearSqrt n (1/4 : ℝ) ≥ 4` — name and type both match the summary theorem. `pnpm build` passes.

Also updated `meta.json`:
- `assumptions` field: corrected axiom name from `erdos_rosenfeld` → `erdos_rosenfeld_four_divisors`
- Section `erdos-rosenfeld` summary/mathContext: removed phantom second axiom name

Closes #13608

---
Automated fix by lean-mechanic agent.