### PR TITLE
audit(erdos-877): correct phantom contribution and sorry count narrative

### DIFF
--- a/src/data/proofs/erdos-877/meta.json
+++ b/src/data/proofs/erdos-877/meta.json
@@ -35,7 +35,7 @@
       "f(n), f_m(n): counting functions via powerset filtering",
       "odds_sum_free: concrete example proved by omega",
       "upper_half_sum_free: parametric example proved by omega",
-      "zero_avoiding_is_intersecting: connection to EKR",
+      "f_m_le_f: every maximal sum-free set is sum-free",
       "erdos_877_solved: combined resolution theorem"
     ],
     "axiomCount": 2,
@@ -155,13 +155,13 @@
     ]
   },
   "conclusion": {
-    "summary": "Erdős Problem #877 is SOLVED. The answer to 'Is f_m(n) = o(2^{n/2})?' is YES. The count of maximal sum-free subsets satisfies f_m(n) = Θ(2^{n/4}), with sharp asymptotics f_m(n) = (C_n + o(1))2^{n/4} where C_n is an explicit constant depending on n mod 4. The formalization captures the full progression from Cameron-Erdős through BLST. 5 sorries remain.",
+    "summary": "Erdős Problem #877 is SOLVED. The answer to 'Is f_m(n) = o(2^{n/2})?' is YES. The count of maximal sum-free subsets satisfies f_m(n) = Θ(2^{n/4}), with sharp asymptotics f_m(n) = (C_n + o(1))2^{n/4} where C_n is an explicit constant depending on n mod 4. The formalization captures the full progression from Cameron-Erdős through BLST. 4 sorries remain.",
     "implications": "This result reveals a striking gap between the count of all sum-free sets (~2^{n/2}) and maximal sum-free sets (~2^{n/4}). The container method developed for this problem has become one of the most widely used tools in modern combinatorics, with applications to Turán-type problems, Ramsey theory, and graph enumeration.",
     "openQuestions": [
       "What are the exact numerical values of C_0, C_1, C_2, C_3 in the BLST sharp bound?",
       "Can the structure of maximal sum-free sets be characterized more precisely (e.g., typical set profiles)?",
       "What about maximal sum-free sets in other groups: ℤ_n, ℤ_p, or general abelian groups?",
-      "Can the 5 remaining sorries (f_m_le_f, maximal_criterion, odds_construction, maximal_vs_all, erdos_877) be closed?",
+      "Can the 4 remaining sorries (maximal_criterion, odds_construction, maximal_vs_all, erdos_877) be closed?",
       "Is there a sharp threshold for the transition from f_m(n) ≈ f(n) to f_m(n) ≪ f(n) as the maximality constraint is relaxed?"
     ]
   },


### PR DESCRIPTION
## Summary

Auditor scan of `src/data/proofs/erdos-877/meta.json` against `proofs/Proofs/Erdos877Problem.lean` found three narrative inconsistencies. All numerical fields (sorries: 4, axiomCount: 2, lineCount: 291) were already correct; only the prose overstated.

## Issues fixed

1. **Phantom contribution** — `originalContributions` listed `zero_avoiding_is_intersecting: connection to EKR`, but no such theorem exists in the Lean source. Replaced with the actually proved lemma `f_m_le_f`.

2. **Sorry count overstatement** — `conclusion.summary` said "5 sorries remain". Actual count is **4** (lines 107, 160, 253, 289).

3. **Sorry list overstatement** — `conclusion.openQuestions` enumerated 5 sorry-bearing theorems including `f_m_le_f`, but `f_m_le_f` is fully proved at lines 131–136. Reduced to the 4 actual sorry-bearing theorems: `maximal_criterion`, `odds_construction`, `maximal_vs_all`, `erdos_877`.

## Test plan

- [x] `git show HEAD:proofs/Proofs/Erdos877Problem.lean | grep -n sorry` → 4 occurrences (107, 160, 253, 289)
- [x] No `zero_avoiding_is_intersecting` in source
- [x] `f_m_le_f` proved (lines 131–136), no sorry
- [x] meta.json `sorries: 4` and `axiomCount: 2` already match source

🤖 Generated with [Claude Code](https://claude.com/claude-code)