### PR TITLE
audit: tracker sync — mark erdos-878 issues-fixed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9753,8 +9753,8 @@
     },
     "erdos-878": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-28T12:57:05Z",
       "result": "issues-fixed"
     },
     "erdos-879": {


### PR DESCRIPTION
## Summary

Tracker sync for erdos-878 audit completed in cycle 3. Phantom-section narrative fix in #13617.

- **Audit result**: issues-fixed
- **Fix PR**: #13617 (meta.json `sections[f-definition]` removed phantom `f_prime`; `sections[erdos-1984]` removed entirely; `proofStrategy` no longer claims a partial-asymptotic axiom that doesn't exist)
- **No Lean changes**: numerical counts (5 axioms, 0 sorries, 4 theorems, 12 defs, 1 structure, 219 lines) all match `proofs/Proofs/Erdos878Problem.lean`

🤖 Generated by auditor-agent