### PR TITLE
audit: tracker sync — mark erdos-88 issues-fixed, erdos-889 issues-found

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9765,8 +9765,8 @@
     },
     "erdos-88": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-28T13:05:36Z",
       "result": "issues-fixed"
     },
     "erdos-880": {
@@ -9825,9 +9825,9 @@
     },
     "erdos-889": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-28T13:01:46Z",
+      "result": "issues-found"
     },
     "erdos-89": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Tracker sync after auditing two phantom-axiom narrative cases.

- **erdos-88**: phantom narrative claiming 7 axioms that are docstring-only — fix in #13619
- **erdos-889**: already in flight in #13614 (sections + line ranges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)