### PR TITLE
research: erdos-1155-oq-02 — reconcile stale pool/JSON/meta state

### DIFF
--- a/research/problems/erdos-1155-oq-02/knowledge.md
+++ b/research/problems/erdos-1155-oq-02/knowledge.md
@@ -2,7 +2,7 @@
 
 Triangle Removal Process: Turán Extremality Gap (Erdős #1155 OQ-02)
 
-**Status**: COMPLETED — 0 sorries, 2 axioms (inherited from parent)
+**Status**: COMPLETED — 0 sorries, 7 axioms total (6 inherited from `Erdos1155Problem.lean` + 1 own: `triangleRemovalEdges_le_turan_exact`)
 
 ---
 
@@ -74,3 +74,42 @@ OQ-02 asks: Quantify the gap. Does f(n)/(n²/4) → 0? What is the rate?
 ## Dead Ends
 
 None — clean proof on first attempt.
+
+---
+
+## Session 2026-04-28 (Session 2) — Metadata Reconciliation
+
+**Mode**: REVISIT (pool said `available`, gallery already promoted)
+**Outcome**: completed — pool/JSON/meta synced to actual on-disk state
+
+### What I Did
+
+1. **Verified Lean source** at `proofs/Proofs/Erdos1155OQ02.lean`: 314 lines, 9 theorems, 1 def, 1 own axiom, 0 sorries.
+2. **Confirmed import-chain axiom total = 7**: `Erdos1155Problem.lean` declares 6 (`triangleRemovalEdges`, `_nonneg`, `_le_complete`, `bfl_upper_bound`, `bfl_lower_bound`, `triangleRemoval_mantel_bound`) and this file adds `triangleRemovalEdges_le_turan_exact`. Gallery `meta.axiomCount = 7` was already correct.
+3. **Updated `src/data/research/problems/erdos-1155-oq-02.json`**:
+   - `phase` `ACT` → `COMPLETED`
+   - `currentState.focus` and `nextAction` rewritten to reflect 7-axiom completion (was misstated as "2 axioms inherited from parent")
+   - `progressSummary` rewritten with full axiom inventory
+   - `builtItems` line numbers corrected to current source positions
+   - `nextSteps` reduced to genuine future work (eliminate `triangleRemovalEdges_le_turan_exact` axiom; track sibling oq-01-oq-01 limiting-distribution OQ)
+   - `leanFiles` lineCount 315 → 314
+   - `lastUpdate` bumped to 2026-04-28
+4. **Updated `src/data/proofs/erdos-1155-oq-02/meta.json`**: `theoremCount` 10 → 9 (matches actual count).
+5. **Updated candidate-pool** (both `.lean/state/` and `research/`): status `available` → `completed`, name/notes corrected to reflect that the slug formalizes Turán-extremality (not the originally-pooled "limiting distribution" OQ — sibling slug `erdos-1155-oq-01-oq-01` already tracks the limiting-distribution question).
+
+### Key Findings
+
+- Slug repurposing: the candidate-pool `name` field referred to the *originally seeded* OQ-2 ("Limiting Distribution"), but the gallery file under this slug formalizes a *different* OQ-2 ("Turán Extremality Gap"). Pool name now matches the formalized content.
+- "2 axioms inherited from parent" narrative had been propagating across `progressSummary` / `currentState.focus` / earlier knowledge.md header — actual inheritance is 6 axioms from `Erdos1155Problem.lean`, plus 1 own axiom in this file.
+
+### Files Modified
+
+- `src/data/research/problems/erdos-1155-oq-02.json`
+- `src/data/proofs/erdos-1155-oq-02/meta.json`
+- `research/problems/erdos-1155-oq-02/knowledge.md` (this file)
+- `.lean/state/candidate-pool.json` and `research/candidate-pool.json` (untracked state)
+
+### Next Steps
+
+- Future axiom-elimination: `triangleRemovalEdges_le_turan_exact` requires connecting abstract `f : ℕ → ℝ` to a concrete `CliqueFree` `SimpleGraph` (≈100 lines).
+- Sibling slug `erdos-1155-oq-01-oq-01` (status `in-progress`) tracks whether `f(n)/n^{3/2}` converges; that is the original Erdős OQ-2 question and remains genuinely open.

--- a/src/data/proofs/erdos-1155-oq-02/meta.json
+++ b/src/data/proofs/erdos-1155-oq-02/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 7,
     "assumptions": "7 axioms: triangleRemovalEdges (f(n) exists), triangleRemovalEdges_nonneg (f(n) ≥ 0), triangleRemovalEdges_le_complete (f(n) ≤ C(n,2)), bfl_upper_bound (f(n) ≤ n^{3/2+ε}), bfl_lower_bound (f(n) ≥ n^{3/2−ε}), triangleRemoval_mantel_bound (Mantel variant), triangleRemovalEdges_le_turan_exact (f(n) ≤ n²/4 via Turán).",
     "lineCount": 314,
-    "theoremCount": 10,
+    "theoremCount": 9,
     "definitionCount": 1,
     "originalContributions": [
       "turanDensity_tendsto_zero: δ(n) = f(n)/(n²/4) → 0, combining BFL with Turán bound via squeeze",

--- a/src/data/research/problems/erdos-1155-oq-02.json
+++ b/src/data/research/problems/erdos-1155-oq-02.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-1155-oq-02",
   "title": "Triangle Removal Process: Turán Extremality Gap",
-  "phase": "ACT",
+  "phase": "COMPLETED",
   "status": "completed",
   "tier": "B",
   "path": "full",
@@ -19,9 +19,9 @@
     "phase": "COMPLETED",
     "since": "2026-04-24T00:00:00.000Z",
     "iteration": 1,
-    "focus": "All sorries eliminated. 0 sorries, 2 axioms (inherited from parent).",
+    "focus": "All sorries eliminated. 0 sorries, 7 axioms total (6 inherited from Erdos1155Problem.lean + 1 own: triangleRemovalEdges_le_turan_exact).",
     "blockers": [],
-    "nextAction": "Prove turan_bfl_exponent_gap: needs BFL lower bound n^{3/2-ε} ≤ f(n) (axiomatized in parent).",
+    "nextAction": "None — formalization complete within axiomatization scope.",
     "attemptCounts": {
       "total": 1,
       "currentApproach": 1,
@@ -29,17 +29,17 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: 0 sorries remain. 2 axioms inherited from parent. triangleRemovalEdges_le_turan proved via axiom. turan_bfl_exponent_gap proved via BFL squeeze.",
+    "progressSummary": "COMPLETE: 0 sorries remain. 7 axioms total: 6 inherited from Erdos1155Problem.lean (triangleRemovalEdges, _nonneg, _le_complete, bfl_upper_bound, bfl_lower_bound, triangleRemoval_mantel_bound) + 1 own (triangleRemovalEdges_le_turan_exact). All theorems proved via BFL squeeze + Turán bound.",
     "builtItems": [
-      "turan_triangle_free_bound in Erdos1155OQ02.lean:53 — CliqueFree 3 graph has ≤ n²/4 edges (1 sorry)",
-      "turanDensity def in Erdos1155OQ02.lean:112 — f(n)/(n²/4), noncomputable",
-      "turanDensity_eq in Erdos1155OQ02.lean:116 — turanDensity n = 4·f(n)/n²",
-      "turanDensity_mem_Icc in Erdos1155OQ02.lean:123 — turanDensity n ∈ [0,1]",
-      "turanDensity_tendsto_zero in Erdos1155OQ02.lean:140 — PROVED via squeeze: 0 ≤ δ(n) ≤ 4/n^{1/4} → 0",
-      "process_not_turan_extremal in Erdos1155OQ02.lean:183 — eventually f(n) < n²/8 (proved)",
-      "turan_gap_diverges in Erdos1155OQ02.lean:218 — PROVED via (1/8)n^{1/4} ≤ n²/4/(f(n)+1) using BFL",
-      "turan_graph_r2_is_maximal in Erdos1155OQ02.lean:271 — turanGraph n 2 is triangle-free",
-      "turan_bfl_exponent_gap in Erdos1155OQ02.lean:277 — PROVED (was sorry): n²/4/f(n) > n^{1/2-ε} eventually via BFL upper at ε/2 + n^{ε/2}>4 squeeze"
+      "turan_triangle_free_bound in Erdos1155OQ02.lean:53 — CliqueFree 3 graph has ≤ n²/4 edges (proved via Mathlib CliqueFree.card_edgeFinset_le)",
+      "turanDensity def in Erdos1155OQ02.lean:104 — f(n)/(n²/4), noncomputable",
+      "turanDensity_eq in Erdos1155OQ02.lean:108 — turanDensity n = 4·f(n)/n²",
+      "turanDensity_mem_Icc in Erdos1155OQ02.lean:116 — turanDensity n ∈ [0,1]",
+      "turanDensity_tendsto_zero in Erdos1155OQ02.lean:132 — PROVED via squeeze: 0 ≤ δ(n) ≤ 4/n^{1/4} → 0",
+      "process_not_turan_extremal in Erdos1155OQ02.lean:175 — eventually f(n) < n²/8 (proved)",
+      "turan_gap_diverges in Erdos1155OQ02.lean:210 — PROVED via (1/8)n^{1/4} ≤ n²/4/(f(n)+1) using BFL",
+      "turan_graph_r2_is_maximal in Erdos1155OQ02.lean:263 — turanGraph n 2 is triangle-free",
+      "turan_bfl_exponent_gap in Erdos1155OQ02.lean:269 — PROVED: n²/4/f(n) > n^{1/2-ε} eventually via BFL upper at ε/2 + n^{ε/2}>4 squeeze"
     ],
     "insights": [
       "turanDensity_tendsto_zero: squeeze proof — 0 ≤ turanDensity n ≤ 4/n^{1/4} → 0. Key: f(n)*n^{1/4} ≤ n^{7/4}*n^{1/4} = n² via Real.rpow_add + Real.rpow_natCast",
@@ -54,9 +54,8 @@
       "No direct way to connect abstract triangleRemovalEdges function to a concrete CliqueFree SimpleGraph — requires axiom"
     ],
     "nextSteps": [
-      "turan_bfl_exponent_gap (line 277): n²/4/f(n) > n^{1/2-ε} — needs BFL lower bound n^{3/2-ε} ≤ f(n) which is axiomatized in parent",
-      "turan_triangle_free_bound sorry: ~100 lines to connect f(n) to concrete triangle-free graph via construction",
-      "Consider graduating to gallery after resolving the turan_triangle_free_bound sorry"
+      "Future axiom-elimination: triangleRemovalEdges_le_turan_exact (~100 lines) requires connecting abstract f(n) to a concrete CliqueFree SimpleGraph construction",
+      "Possible follow-up OQ: bound the rate of convergence to the limiting distribution of f(n)/n^{3/2} (sibling slug erdos-1155-oq-01-oq-01 tracks the existence of a limit)"
     ]
   },
   "tags": [
@@ -83,7 +82,7 @@
     "mathlib": []
   },
   "started": "2026-04-24T00:00:00.000Z",
-  "lastUpdate": "2026-04-24T12:00:00.000Z",
+  "lastUpdate": "2026-04-28T16:00:00.000Z",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [
@@ -134,7 +133,7 @@
     {
       "path": "Proofs/Erdos1155OQ02.lean",
       "filename": "Erdos1155OQ02.lean",
-      "lineCount": 315,
+      "lineCount": 314,
       "theoremCount": 9,
       "axiomCount": 1,
       "defCount": 1,


### PR DESCRIPTION
## Summary

The gallery proof at `src/data/proofs/erdos-1155-oq-02` was promoted on 2026-04-24 (axiomatized: 0 sorries, 7 axioms) but several caches remained stale. This PR reconciles the metadata to the actual on-disk Lean state.

- `candidate-pool.json` (untracked, both `.lean/state/` and `research/`): status `available` → `completed`; `name` corrected to "Triangle Removal Process — Turán Extremality Gap" (the slug formalizes that variant; sibling slug `erdos-1155-oq-01-oq-01` already covers the originally-pooled "Limiting Distribution" OQ).
- `src/data/research/problems/erdos-1155-oq-02.json`: `phase` `ACT` → `COMPLETED`; `progressSummary` / `currentState.focus` / `nextAction` rewritten — earlier text claimed "2 axioms inherited from parent" but the import chain has 6 inherited axioms from `Erdos1155Problem.lean` + 1 own = 7. Fixed `builtItems` line numbers to current source positions, pruned obsolete `nextSteps`, bumped `leanFiles[..].lineCount` 315 → 314.
- `src/data/proofs/erdos-1155-oq-02/meta.json`: `theoremCount` 10 → 9 (file actually has 9 theorems / 1 def / 1 axiom / 0 sorries).
- `research/problems/erdos-1155-oq-02/knowledge.md`: corrected header axiom narrative; appended Session 2 reconciliation entry.

No Lean source changes — `Erdos1155OQ02.lean` was already complete.

## Test plan

- [x] `grep -cE '^(theorem|lemma) ' proofs/Proofs/Erdos1155OQ02.lean` → 9
- [x] `grep -c '^axiom ' proofs/Proofs/Erdos1155OQ02.lean` → 1 own (`triangleRemovalEdges_le_turan_exact`)
- [x] `grep -c '^axiom ' proofs/Proofs/Erdos1155Problem.lean` → 6 inherited
- [x] `wc -l proofs/Proofs/Erdos1155OQ02.lean` → 314
- [x] No edits to Lean source; no Docker build needed
- [ ] Auditor / Mechanic agents will pick up the synced metadata on next pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)