### PR TITLE
audit: tracker sync — mark erdos-868 issues-found

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9687,9 +9687,9 @@
     },
     "erdos-868": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-28T13:14:29Z",
+      "result": "issues-found"
     },
     "erdos-869": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Tracker sync: mark `erdos-868` as `issues-found` per phantom-axiom narrative discovered during gallery integrity audit.

## Companion PR

- #13624 — `audit(erdos-868): correct phantom-axiom narrative` (the actual meta.json fix)

## Changes

- `src/data/proofs/audit-tracker.json`: `erdos-868.auditCount: 2 → 3`, `lastAudited` → `2026-04-28T13:14:29Z`, `result: issues-fixed → issues-found`.