### PR TITLE
audit: tracker sync — mark hurwitz-theorem-oq-04 issues-fixed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11350,9 +11350,9 @@
       "result": "clean"
     },
     "hurwitz-theorem-oq-04": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-27T11:16:51Z",
+      "lastAudited": "2026-04-28T13:20:59Z",
       "result": "issues-fixed"
     },
     "inclusion-exclusion": {


### PR DESCRIPTION
## Summary

Tracker sync for hurwitz-theorem-oq-04 (auditCount 3→4, lastAudited 2026-04-27→2026-04-28, result issues-fixed). The integrity fix is in PR #13626.

🤖 Generated with [Claude Code](https://claude.com/claude-code)