### PR TITLE
audit(erdos-913): remove duplicate section + sync axiom line range

### DIFF
--- a/src/data/proofs/erdos-913/meta.json
+++ b/src/data/proofs/erdos-913/meta.json
@@ -71,22 +71,14 @@
       "id": "sec-913-hypothesis",
       "title": "The 8p²-1 Prime Hypothesis",
       "startLine": 57,
-      "endLine": 68,
-      "summary": "Defines PrimePairs8 = {p : p prime ∧ 8p²-1 prime} and axiomatizes its infinitude as a Bunyakovsky-type hypothesis.",
+      "endLine": 69,
+      "summary": "Defines PrimePairs8 = {p : p prime ∧ 8p²-1 prime} and axiomatizes its infinitude as a Bunyakovsky-type hypothesis (the sole axiom: infinite_8p_sq_minus_1_primes at line 69).",
       "mathContext": "Formal definition: Defines PrimePairs8 = {p : p prime ∧ 8p²-1 prime} and axiomatizes its infinitude as a Bunyakovsky-type hypothesis."
-    },
-    {
-      "id": "sec-913-conditional",
-      "title": "Conditional Proof",
-      "startLine": 69,
-      "endLine": 84,
-      "summary": "The key reduction: PrimePairs8.Infinite implies DistinctExponentSet.Infinite. For p in PrimePairs8, n = 8p²-1 gives exponents {1, 2, 3} on primes {8p²-1, p, 2}.",
-      "mathContext": "Mathematical content: The key reduction: PrimePairs8.Infinite implies DistinctExponentSet.Infinite. For p in PrimePairs8, n = 8p²-1 gives exponents {1, 2, 3} on primes {8p²-1, p, 2}."
     },
     {
       "id": "sec-913-conditional-proof",
       "title": "8p²-1 Conditional Proof",
-      "startLine": 69,
+      "startLine": 70,
       "endLine": 199,
       "summary": "Fully proved conditional: PrimePairs8.Infinite ⟹ DistinctExponentSet.Infinite. Includes the proved exponent_structure theorem (prime factor set is {8p²-1, p, 2}), factorization value computations (exponents 1, 2, 3), and the Set.Infinite.image argument via injectivity of p ↦ 8p²-1.",
       "mathContext": "Core proof: For each prime p ∈ PrimePairs8 \\ {2}, n = 8p²-1 gives n(n+1) = (8p²-1)¹·p²·2³ with all exponents distinct. The exponent_structure theorem proves the prime factors are exactly {8p²-1, p, 2}, using coprimality of consecutive integers and Mathlib's factorization API."


### PR DESCRIPTION
## Summary

Section-array cleanup for `erdos-913` discovered via routine auditor pass.

### Issue 1: Axiom outside its section

`sec-913-hypothesis` (\"The 8p²-1 Prime Hypothesis\") claimed lines 57-68. But the axiom it describes — `axiom infinite_8p_sq_minus_1_primes` — is at line 69, outside the range:

```
68: /-- Hypothesis: there are infinitely many primes p with 8p² - 1 prime. -/
69: axiom infinite_8p_sq_minus_1_primes : PrimePairs8.Infinite
```

Extended endLine 68 → 69.

### Issue 2: Duplicate section

The sections array contained two overlapping entries for the same content:

| id | range | summary |
|---|---|---|
| `sec-913-conditional` | 69-84 | \"key reduction: PrimePairs8.Infinite implies DistinctExponentSet.Infinite\" |
| `sec-913-conditional-proof` | 69-199 | \"Fully proved conditional: PrimePairs8.Infinite ⟹ DistinctExponentSet.Infinite\" |

Removed the smaller duplicate; bumped `sec-913-conditional-proof`'s startLine 69 → 70 so it begins after the axiom.

### Result

8 contiguous sections covering lines 17-342 with no overlaps:

```
 17- 26: Problem Overview and Imports
 27- 46: Distinct Exponent Property
 47- 56: The Main Conjecture
 57- 69: The 8p²-1 Prime Hypothesis      ← axiom now inside
 70-199: 8p²-1 Conditional Proof          ← was 69, duplicate removed
200-258: Known Examples
259-272: Connection to Bunyakovsky Conjecture
273-342: Mersenne Prime Conditional
```

## Numerical fields verified correct, no changes needed

- `axiomCount`: 1 ✓ (`axiom infinite_8p_sq_minus_1_primes` only)
- `sorries`: 0 ✓
- `lineCount`: 344 ✓
- `assumptions` text: correctly names the single axiom

## Test plan

- [x] JSON parses (`python3 -m json.tool`)
- [ ] After merge: `pnpm build` passes
- [ ] After merge: `npx tsx scripts/auditor/find-targets.ts --issues` does not report erdos-913

🤖 Generated with [Claude Code](https://claude.com/claude-code)