### PR TITLE
Research: hurwitz-oq-04 — 7 Fano residuals proved (derEval14_injective sorry-free pending build)

### DIFF
--- a/proofs/Proofs/HurwitzTheoremOQ04.lean
+++ b/proofs/Proofs/HurwitzTheoremOQ04.lean
@@ -1104,16 +1104,137 @@ private lemma derEval14_injective : Function.Injective derEval14 := by
             simpa [derEval14] using congr_fun hfg (12 : Fin 14)
           have e13 : f (stdBasis 7) 4 = g (stdBasis 7) 4 := by
             simpa [derEval14] using congr_fun hfg (13 : Fin 14)
-          -- 7 Fano upper-triangular residuals (j > i, both in {3,5,6,7} ∪ {(4,3)}).
-          -- These need Fano-line Leibniz analysis on the multiplication-table triples;
-          -- left as named sorries pending Fano-line lemmas.
-          have F43 : f (stdBasis 4) 3 = g (stdBasis 4) 3 := by sorry
-          have F53 : f (stdBasis 5) 3 = g (stdBasis 5) 3 := by sorry
-          have F63 : f (stdBasis 6) 3 = g (stdBasis 6) 3 := by sorry
-          have F73 : f (stdBasis 7) 3 = g (stdBasis 7) 3 := by sorry
-          have F65 : f (stdBasis 6) 5 = g (stdBasis 6) 5 := by sorry
-          have F75 : f (stdBasis 7) 5 = g (stdBasis 7) 5 := by sorry
-          have F76 : f (stdBasis 7) 6 = g (stdBasis 7) 6 := by sorry
+          -- 7 Fano upper-triangular residuals proved via Fano-line Leibniz.
+          -- For each F_{ji}, pick a multiplication-table pair (p,q) with
+          -- e_p · e_q = e_j and read off coord i of the Leibniz equation.
+          -- All RHS terms reduce to ev coords (e0..e13) or their antisymmetry
+          -- partners, after using submodule_der_real_part for the j=0 column.
+          have F43 : f (stdBasis 4) 3 = g (stdBasis 4) 3 := by
+            -- (5,1): e_5·e_1 = e_4. Comp 3: f(e_4)_3 = -f(e_5)_2 - f(e_1)_6.
+            -- f(e_5)_2 = g(e_5)_2 (e8); f(e_1)_6 = -f(e_6)_1 (antisym), e4.
+            have e51 : eightMul (stdBasis 5) (stdBasis 1) = (stdBasis 4 : Fin 8 → ℝ) := by
+              funext k; fin_cases k <;>
+                simp only [eightMul, stdBasis, Matrix.cons_val_zero, Matrix.cons_val_one,
+                  Matrix.head_cons, Matrix.cons_val_two, Matrix.cons_val_three] <;> norm_num
+            have hLf := hf (stdBasis 5) (stdBasis 1); rw [e51] at hLf
+            have hLg := hg (stdBasis 5) (stdBasis 1); rw [e51] at hLg
+            have hf3 := congr_fun hLf 3
+            have hg3 := congr_fun hLg 3
+            simp only [Pi.add_apply, eightMul, stdBasis,
+              Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+              Matrix.cons_val_two, Matrix.cons_val_three] at hf3 hg3
+            simp (config := { decide := true }) only [ite_true, ite_false] at hf3 hg3
+            have af := antisym f hf 1 6 (by decide) (by decide) (by decide)
+            have ag := antisym g hg 1 6 (by decide) (by decide) (by decide)
+            linarith
+          have F53 : f (stdBasis 5) 3 = g (stdBasis 5) 3 := by
+            -- (1,4): e_1·e_4 = e_5. Comp 3: f(e_5)_3 = -f(e_1)_7 + f(e_4)_2.
+            -- f(e_1)_7 = -f(e_7)_1 (antisym), e5; f(e_4)_2 = e7.
+            have e14 : eightMul (stdBasis 1) (stdBasis 4) = (stdBasis 5 : Fin 8 → ℝ) := by
+              funext k; fin_cases k <;>
+                simp only [eightMul, stdBasis, Matrix.cons_val_zero, Matrix.cons_val_one,
+                  Matrix.head_cons, Matrix.cons_val_two, Matrix.cons_val_three] <;> norm_num
+            have hLf := hf (stdBasis 1) (stdBasis 4); rw [e14] at hLf
+            have hLg := hg (stdBasis 1) (stdBasis 4); rw [e14] at hLg
+            have hf3 := congr_fun hLf 3
+            have hg3 := congr_fun hLg 3
+            simp only [Pi.add_apply, eightMul, stdBasis,
+              Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+              Matrix.cons_val_two, Matrix.cons_val_three] at hf3 hg3
+            simp (config := { decide := true }) only [ite_true, ite_false] at hf3 hg3
+            have af := antisym f hf 1 7 (by decide) (by decide) (by decide)
+            have ag := antisym g hg 1 7 (by decide) (by decide) (by decide)
+            linarith
+          have F63 : f (stdBasis 6) 3 = g (stdBasis 6) 3 := by
+            -- (2,4): e_2·e_4 = e_6. Comp 3: f(e_6)_3 = -f(e_2)_7 - f(e_4)_1.
+            -- f(e_2)_7 = -f(e_7)_2 (antisym), e10; f(e_4)_1 = e2.
+            have e24 : eightMul (stdBasis 2) (stdBasis 4) = (stdBasis 6 : Fin 8 → ℝ) := by
+              funext k; fin_cases k <;>
+                simp only [eightMul, stdBasis, Matrix.cons_val_zero, Matrix.cons_val_one,
+                  Matrix.head_cons, Matrix.cons_val_two, Matrix.cons_val_three] <;> norm_num
+            have hLf := hf (stdBasis 2) (stdBasis 4); rw [e24] at hLf
+            have hLg := hg (stdBasis 2) (stdBasis 4); rw [e24] at hLg
+            have hf3 := congr_fun hLf 3
+            have hg3 := congr_fun hLg 3
+            simp only [Pi.add_apply, eightMul, stdBasis,
+              Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+              Matrix.cons_val_two, Matrix.cons_val_three] at hf3 hg3
+            simp (config := { decide := true }) only [ite_true, ite_false] at hf3 hg3
+            have af := antisym f hf 2 7 (by decide) (by decide) (by decide)
+            have ag := antisym g hg 2 7 (by decide) (by decide) (by decide)
+            linarith
+          have F73 : f (stdBasis 7) 3 = g (stdBasis 7) 3 := by
+            -- (2,5): e_2·e_5 = e_7. Comp 3: f(e_7)_3 = +f(e_2)_6 - f(e_5)_1.
+            -- f(e_2)_6 = -f(e_6)_2 (antisym), e9; f(e_5)_1 = e3.
+            have e25 : eightMul (stdBasis 2) (stdBasis 5) = (stdBasis 7 : Fin 8 → ℝ) := by
+              funext k; fin_cases k <;>
+                simp only [eightMul, stdBasis, Matrix.cons_val_zero, Matrix.cons_val_one,
+                  Matrix.head_cons, Matrix.cons_val_two, Matrix.cons_val_three] <;> norm_num
+            have hLf := hf (stdBasis 2) (stdBasis 5); rw [e25] at hLf
+            have hLg := hg (stdBasis 2) (stdBasis 5); rw [e25] at hLg
+            have hf3 := congr_fun hLf 3
+            have hg3 := congr_fun hLg 3
+            simp only [Pi.add_apply, eightMul, stdBasis,
+              Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+              Matrix.cons_val_two, Matrix.cons_val_three] at hf3 hg3
+            simp (config := { decide := true }) only [ite_true, ite_false] at hf3 hg3
+            have af := antisym f hf 2 6 (by decide) (by decide) (by decide)
+            have ag := antisym g hg 2 6 (by decide) (by decide) (by decide)
+            linarith
+          have F65 : f (stdBasis 6) 5 = g (stdBasis 6) 5 := by
+            -- (2,4): e_2·e_4 = e_6. Comp 5: f(e_6)_5 = +f(e_2)_1 - f(e_4)_7.
+            -- f(e_2)_1 = e0; f(e_4)_7 = -f(e_7)_4 (antisym), e13.
+            have e24 : eightMul (stdBasis 2) (stdBasis 4) = (stdBasis 6 : Fin 8 → ℝ) := by
+              funext k; fin_cases k <;>
+                simp only [eightMul, stdBasis, Matrix.cons_val_zero, Matrix.cons_val_one,
+                  Matrix.head_cons, Matrix.cons_val_two, Matrix.cons_val_three] <;> norm_num
+            have hLf := hf (stdBasis 2) (stdBasis 4); rw [e24] at hLf
+            have hLg := hg (stdBasis 2) (stdBasis 4); rw [e24] at hLg
+            have hf5 := congr_fun hLf 5
+            have hg5 := congr_fun hLg 5
+            simp only [Pi.add_apply, eightMul, stdBasis,
+              Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+              Matrix.cons_val_two, Matrix.cons_val_three] at hf5 hg5
+            simp (config := { decide := true }) only [ite_true, ite_false] at hf5 hg5
+            have af := antisym f hf 4 7 (by decide) (by decide) (by decide)
+            have ag := antisym g hg 4 7 (by decide) (by decide) (by decide)
+            linarith
+          have F75 : f (stdBasis 7) 5 = g (stdBasis 7) 5 := by
+            -- (3,4): e_3·e_4 = e_7. Comp 5: f(e_7)_5 = +f(e_3)_1 + f(e_4)_6.
+            -- f(e_3)_1 = e1; f(e_4)_6 = -f(e_6)_4 (antisym), e12.
+            have e34 : eightMul (stdBasis 3) (stdBasis 4) = (stdBasis 7 : Fin 8 → ℝ) := by
+              funext k; fin_cases k <;>
+                simp only [eightMul, stdBasis, Matrix.cons_val_zero, Matrix.cons_val_one,
+                  Matrix.head_cons, Matrix.cons_val_two, Matrix.cons_val_three] <;> norm_num
+            have hLf := hf (stdBasis 3) (stdBasis 4); rw [e34] at hLf
+            have hLg := hg (stdBasis 3) (stdBasis 4); rw [e34] at hLg
+            have hf5 := congr_fun hLf 5
+            have hg5 := congr_fun hLg 5
+            simp only [Pi.add_apply, eightMul, stdBasis,
+              Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+              Matrix.cons_val_two, Matrix.cons_val_three] at hf5 hg5
+            simp (config := { decide := true }) only [ite_true, ite_false] at hf5 hg5
+            have af := antisym f hf 4 6 (by decide) (by decide) (by decide)
+            have ag := antisym g hg 4 6 (by decide) (by decide) (by decide)
+            linarith
+          have F76 : f (stdBasis 7) 6 = g (stdBasis 7) 6 := by
+            -- (3,4): e_3·e_4 = e_7. Comp 6: f(e_7)_6 = +f(e_3)_2 - f(e_4)_5.
+            -- f(e_3)_2 = e6; f(e_4)_5 = -f(e_5)_4 (antisym), e11.
+            have e34 : eightMul (stdBasis 3) (stdBasis 4) = (stdBasis 7 : Fin 8 → ℝ) := by
+              funext k; fin_cases k <;>
+                simp only [eightMul, stdBasis, Matrix.cons_val_zero, Matrix.cons_val_one,
+                  Matrix.head_cons, Matrix.cons_val_two, Matrix.cons_val_three] <;> norm_num
+            have hLf := hf (stdBasis 3) (stdBasis 4); rw [e34] at hLf
+            have hLg := hg (stdBasis 3) (stdBasis 4); rw [e34] at hLg
+            have hf6 := congr_fun hLf 6
+            have hg6 := congr_fun hLg 6
+            simp only [Pi.add_apply, eightMul, stdBasis,
+              Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+              Matrix.cons_val_two, Matrix.cons_val_three] at hf6 hg6
+            simp (config := { decide := true }) only [ite_true, ite_false] at hf6 hg6
+            have af := antisym f hf 4 5 (by decide) (by decide) (by decide)
+            have ag := antisym g hg 4 5 (by decide) (by decide) (by decide)
+            linarith
           -- Discharge each (j,i) pair.
           fin_cases j
           · exact absurd rfl hj

--- a/research/problems/hurwitz-theorem-oq-04/knowledge.md
+++ b/research/problems/hurwitz-theorem-oq-04/knowledge.md
@@ -6,7 +6,123 @@ Formalize the connection between Hurwitz's theorem (exactly 4 normed division al
 1. G₂ = Aut(𝕆)
 2. Freudenthal-Tits magic square: 𝔏(A,B) = Der(A)⊕(ImA⊗ImB)⊕Der(B)
 
-File: `proofs/Proofs/HurwitzTheoremOQ04.lean` (~1525 lines)
+File: `proofs/Proofs/HurwitzTheoremOQ04.lean` (~1646 lines)
+
+---
+
+## Session 2026-04-28 (Session 9) — 7 Fano residuals proved by Leibniz
+
+**Mode**: REVISIT (RICH knowledge tier — built directly on Session 8's 7-sorry decomposition)
+**Outcome**: PROGRESS — replaced all 7 named Fano sorries (`F43, F53, F63, F73, F65, F75, F76`)
+inside `derEval14_injective` with explicit Fano-line Leibniz proofs. The 64-entry
+kernel is now sorry-free *modulo build verification* (pending Docker capacity).
+
+### Strategy
+
+For each `F_{ji} : f (stdBasis j) i = g (stdBasis j) i`, choose a multiplication-table
+pair `(p, q)` with `eightMul (stdBasis p) (stdBasis q) = stdBasis j` and read off
+**coordinate i** of the Leibniz equation `f (e_p · e_q) = (f e_p)·e_q + e_p·(f e_q)`.
+
+The two RHS terms each become a **single coordinate** of `f` (or `g`) on a basis
+vector, because one factor is a stdBasis (concrete coordinate vector) and only
+one term in the comp-i formula contributes a non-zero `b_k` (resp. `a_k`).
+
+These two coords are *always* either:
+- in the **14 ev free coords** (e0..e13), giving `f = g` directly, OR
+- the **antisym partner** of an ev coord, giving `f = g` via `submodule_der_antisymm`.
+
+The choice of `(p, q)` for each `(j, i)`:
+
+| Sorry | (j, i) | (p, q) | comp | 1st RHS term | 2nd RHS term |
+|-------|--------|--------|------|--------------|--------------|
+| F43 | (4, 3) | (5, 1) | 3 | `−f(e₅)₂` (e8) | `−f(e₁)₆` (antisym e4) |
+| F53 | (5, 3) | (1, 4) | 3 | `−f(e₁)₇` (antisym e5) | `+f(e₄)₂` (e7) |
+| F63 | (6, 3) | (2, 4) | 3 | `−f(e₂)₇` (antisym e10) | `−f(e₄)₁` (e2) |
+| F73 | (7, 3) | (2, 5) | 3 | `+f(e₂)₆` (antisym e9) | `−f(e₅)₁` (e3) |
+| F65 | (6, 5) | (2, 4) | 5 | `+f(e₂)₁` (e0) | `−f(e₄)₇` (antisym e13) |
+| F75 | (7, 5) | (3, 4) | 5 | `+f(e₃)₁` (e1) | `+f(e₄)₆` (antisym e12) |
+| F76 | (7, 6) | (3, 4) | 6 | `+f(e₃)₂` (e6) | `−f(e₄)₅` (antisym e11) |
+
+Each proof is mechanical:
+
+```lean
+have F_ji : f (stdBasis j) i = g (stdBasis j) i := by
+  have e_pq : eightMul (stdBasis p) (stdBasis q) = stdBasis j := by
+    funext k; fin_cases k <;> simp [eightMul, stdBasis, …] <;> norm_num
+  have hLf := hf p q; rw [e_pq] at hLf
+  have hLg := hg p q; rw [e_pq] at hLg
+  have hf_i := congr_fun hLf i
+  have hg_i := congr_fun hLg i
+  simp only [Pi.add_apply, eightMul, stdBasis, Matrix.cons_val_*] at hf_i hg_i
+  simp (config := { decide := true }) only [ite_true, ite_false] at hf_i hg_i
+  have af := antisym f hf p' q' …
+  have ag := antisym g hg p' q' …
+  linarith
+```
+
+### Why This Works (mathematical content)
+
+The 14 ev coords form a *complete set of free generators* for the Lie subalgebra
+`Der(𝕆)`: any derivation is fully determined by its action at the 14 free pairs.
+The Fano-line Leibniz constraints close the remaining 7 pairs because each Fano
+triple `{a, b, c}` with `e_a · e_b = e_c` ties three coordinates together
+modulo `D(e_c)_? = (D(e_a) · e_b)_? + (e_a · D(e_b))_?`. Choosing the right
+component projects out two terms which are *exactly* the antisym partners or
+direct reads of the 14 free coords.
+
+This is the core mechanism by which `dim Der(𝕆) = 14` (not 21 = `dim 𝔰𝔬(7)`):
+the **7 extra Fano constraints** cut the 21-dimensional `𝔰𝔬(7)` down to G₂.
+
+### Files Modified
+
+- `proofs/Proofs/HurwitzTheoremOQ04.lean` — +131 lines, –10 lines
+  (replaced 7 sorries with 7 explicit Leibniz proofs).
+
+### Sorry Count: 0 (was 7)
+
+Modulo build verification, `derEval14_injective` is sorry-free. The remaining
+infrastructure for the dim-14 → G₂ identification (linear independence,
+spanning, Lie bracket structure) is in subsequent sections of the file.
+
+### Build Status
+
+NOT verified — Docker daemon was stuck/unresponsive (4 stale builds for
+HurwitzTheoremOQ04 dating to 5:05 AM, 9:37 AM, 15:27 PM); pushed unverified
+per `feedback_docker_build_io_errors.md` policy. Next session must build first.
+
+### Next Steps
+
+1. **Verify build** (Docker capacity permitting). Risk of failure:
+   - `linarith` may need `mul_zero, mul_one` cleanup before the simp set
+     leaves arithmetic noise (e.g. `0 * a₂ + (-1) * a₂ + 0 * a₃ + …`).
+     If so: add `ring_nf at hf_i hg_i` between the two `simp only` calls.
+   - The eightMul factorization equations (e51, e14, e24, e25, e34) might
+     not reduce cleanly with the chosen simp set. Test by inspecting the
+     existing `submodule_der_real_part` factorizations (which use the same
+     pattern and *do* compile).
+2. After build verification, advance phase to **COMPLETED** for this proof
+   (`derEval14_injective` is the central injectivity lemma).
+3. The remaining work in the file is:
+   - `derBasis14_linearIndependent` (linear independence of 14 explicit
+     derivations) — already partial.
+   - `OctonionDerSpace` dimension theorem (dim ≤ 14 from injectivity, ≥ 14
+     from independence, hence = 14).
+   - Connection to G₂ as `Aut(𝕆)`: the Lie algebra of G₂ is precisely Der(𝕆).
+
+### Tactical Notes
+
+- The seven `(p, q)` choices were selected to ensure **both** RHS coords are
+  either free or antisym partners of free, and **neither** is itself a Fano
+  residual. This avoids circularity (e.g. for F73, using `(3, 4)` at comp 3
+  gives a tautology because `(e_3·D(e_4))_3 = D(e_4)_0 = 0` and the other term
+  is the antisym partner of F73 itself).
+- The component-i formula for `(a · stdBasis q) i` (resp. `(stdBasis p · b) i`)
+  has exactly **one** non-zero term (since `b` has one non-zero entry). After
+  the simp + decide chain, this collapses to `±a_k` (resp. `±b_k`) for a
+  specific `k` determined by the Fano-line geometry.
+- `linarith` is given the Leibniz equations on f and g plus two antisym hypotheses
+  (one each for f, g). It must combine 4 hypotheses (`hf_i, hg_i, af, ag`) plus
+  the 14 ev hints (e0..e13) implicitly available in scope.
 
 ---
 

--- a/research/problems/hurwitz-theorem-oq-04/state.md
+++ b/research/problems/hurwitz-theorem-oq-04/state.md
@@ -1,9 +1,9 @@
 # Research State: hurwitz-theorem-oq-04
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ACT
 **Path**: full
-**Since**: 2026-04-23T04:27:17+02:00
+**Since**: 2026-04-28T15:10:38+02:00
 **Iteration**: 1
 
 ## Current Focus

--- a/research/registry.json
+++ b/research/registry.json
@@ -17152,11 +17152,11 @@
     },
     {
       "slug": "hurwitz-theorem-oq-04",
-      "phase": "OBSERVE",
+      "phase": "ACT",
       "path": "full",
       "started": "2026-04-22T13:25:38.667Z",
       "status": "active",
-      "lastUpdate": "2026-04-24T23:03:34.504Z"
+      "lastUpdate": "2026-04-28T15:10:38+02:00"
     },
     {
       "slug": "isoperimetric-theorem-oq-03",

--- a/src/data/research/problems/hurwitz-theorem-oq-04.json
+++ b/src/data/research/problems/hurwitz-theorem-oq-04.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 1 monolithic sorry → 7 concrete Fano-line sorries; 28 of 42 residual entries closed mechanically",
+    "progressSummary": "PROGRESS: 7 named Fano sorries → 0 (modulo Docker build verification); derEval14_injective complete pending build.",
     "builtItems": [
       "ExceptionalType inductive type (G2/F4/E6/E7/E8) with dim/rank — HurwitzTheoremOQ04.lean",
       "OctonionAlgHom structure + OctonionAut — HurwitzTheoremOQ04.lean",
@@ -54,7 +54,8 @@
       "submodule_der_antisymm: (f e_i)_j + (f e_j)_i = 0 for f in OctonionDerSubmodule (HurwitzTheoremOQ04.lean:864)",
       "i=0 sub-case in derEval14_injective via submodule_der_real_part (HurwitzTheoremOQ04.lean:1058-1063)",
       "derEval14_injective: 158-line case analysis covering all 42 entries of the (j ≠ 0, i ≠ 0, i ≠ j) residual; HurwitzTheoremOQ04.lean ~lines 1058-1230.",
-      "7 named hypotheses F43, F53, F63, F73, F65, F75, F76 inside derEval14_injective — concrete proof obligations replacing the prior monolithic sorry."
+      "7 named hypotheses F43, F53, F63, F73, F65, F75, F76 inside derEval14_injective — concrete proof obligations replacing the prior monolithic sorry.",
+      "F43, F53, F63, F73, F65, F75, F76: explicit proofs in HurwitzTheoremOQ04.lean L1107-1238 — replaces all 7 named sorries inside derEval14_injective."
     ],
     "insights": [
       "G₂ = Aut(𝕆): The exceptional Lie group G₂ (dim 14, rank 2) is the automorphism group of the octonions. The 14 dimensions come from SO(7) (dim 21) minus the 7 constraints from preserving the octonion cross product.",
@@ -79,7 +80,10 @@
       "Session 7 (2026-04-28): The 64-entry kernel claim in derEval14_injective decomposes structurally as 8 (j=0) + 7 (i=j) + 7 (i=0) + 42 (j≠0,i≠0,i≠j). The first three are closed by submodule_der_unit_zero, submodule_der_diagonal_kill, and submodule_der_real_part respectively. The residual 42 entries reduce to 21 upper-triangular by antisymmetry (submodule_der_antisymm), then 14 are the explicit ev=0 coords (from hfg directly), leaving 7 hard pairs requiring Fano-line Leibniz.",
       "Session 8 (2026-04-28): Replaced 1 monolithic residual sorry with 7 named upper-triangular Fano sorries; 28 mechanical closures via ev coords + antisymm.",
       "The 7 Fano residual pairs are exactly those (j,i) with both indices in {3,5,6,7} ∪ {(4,3)} — i.e. neither (j,i) nor (i,j) sits in the 14 ev coords.",
-      "Local antisym helper: D(stdBasis p) q = -D(stdBasis q) p reduces 14 antisymm-of-ev cases to single rw chains."
+      "Local antisym helper: D(stdBasis p) q = -D(stdBasis q) p reduces 14 antisymm-of-ev cases to single rw chains.",
+      "Session 9: Each Fano residual F_{ji} is dischargeable by Leibniz at a single (p,q) pair: comp-i RHS terms collapse to one antisym partner + one direct ev coord (or vice versa).",
+      "Session 9: The 7 residuals are *not* equivalent — F73 requires (2,5) (not (3,4) at comp 3) to avoid tautology (D(e₄)₀=0 makes one RHS term vanish trivially, leaving an identity in F73 itself).",
+      "Session 9: Mathematical reading — the 7 Fano constraints cut 𝔰𝔬(7) (dim 21) down to Der(𝕆) (dim 14) by tying the 7 upper-triangular Fano pairs to the 14 free coords + their antisym partners."
     ],
     "mathlibGaps": [
       "Lie groups not in Mathlib as of 2026-04 — blocks formal G₂ = Aut(𝕆) proof",
@@ -87,10 +91,11 @@
       "Derivation algebra of non-associative algebras not in Mathlib"
     ],
     "nextSteps": [
-      "Verify Docker build of the new derEval14_injective case analysis.",
-      "Prove the 7 Fano residuals via Fano-line Leibniz analysis on octonion multiplication-table triples.",
-      "Consider factoring the 7 Fano proofs into a uniform submodule_der_fano_line helper parameterized by the Fano triple.",
-      "After F-residuals close: derEval14_injective is sorry-free → completes the upper bound finrank ≤ 14 → G2_der_dimension is sorry-free."
+      "Verify Docker build of Proofs.HurwitzTheoremOQ04 once daemon frees up; if linarith fails, add ring_nf at hf_i hg_i between the two simp only calls.",
+      "After build green: advance phase to COMPLETED for derEval14_injective.",
+      "Tackle derBasis14_linearIndependent and the dimension theorem (OctonionDerSpace dim = 14).",
+      "Identify Der(𝕆) ≅ 𝔤₂ (Lie algebra of G₂) — connect to Mathlib LieAlgebra structure.",
+      "Wire dim-14 lemma into the gallery meta.json once verified."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Replaces all 7 named Fano sorries (`F43, F53, F63, F73, F65, F75, F76`) inside `derEval14_injective` (HurwitzTheoremOQ04.lean) with explicit Fano-line Leibniz proofs. The 64-entry kernel of the injectivity claim is now sorry-free **modulo build verification**.

## Strategy

For each `F_{ji} : f (stdBasis j) i = g (stdBasis j) i`, choose a multiplication-table pair `(p, q)` with `eightMul (stdBasis p) (stdBasis q) = stdBasis j` and read off coordinate `i` of the Leibniz equation. The two RHS terms each become a single coordinate of `f` (or `g`) on a basis vector — one of the 14 free ev coords or its antisym partner.

| Sorry | (j,i) | (p,q) | comp | Closing facts |
|-------|-------|-------|------|---------------|
| F43 | (4,3) | (5,1) | 3 | e8 + antisym e4 |
| F53 | (5,3) | (1,4) | 3 | antisym e5 + e7 |
| F63 | (6,3) | (2,4) | 3 | antisym e10 + e2 |
| F73 | (7,3) | (2,5) | 3 | antisym e9 + e3 |
| F65 | (6,5) | (2,4) | 5 | e0 + antisym e13 |
| F75 | (7,5) | (3,4) | 5 | e1 + antisym e12 |
| F76 | (7,6) | (3,4) | 6 | e6 + antisym e11 |

Mathematically: the **7 Fano constraints cut 𝔰𝔬(7) (dim 21) down to Der(𝕆) (dim 14)** = 𝔤₂.

## Build Status

NOT verified locally. Docker daemon was stuck/unresponsive (4 stale builds for HurwitzTheoremOQ04 dating to 5:05 AM, 9:37 AM, 15:27 PM); pushed unverified per `feedback_docker_build_io_errors.md` policy. Risks called out in `knowledge.md` Session 9 → Next Steps.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.HurwitzTheoremOQ04` succeeds
- [ ] If `linarith` fails to close any of the 7 Fano cases, add `ring_nf at hf_i hg_i` between the two `simp only` calls to clean up `0 * x` / `1 * x` arithmetic.
- [ ] After build green: advance pool entry phase to `COMPLETED` and update `meta.json` axiom/sorry counts for the gallery.