### PR TITLE
audit(erdos-877): correct section startLine/endLine drift

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9747,8 +9747,8 @@
     },
     "erdos-877": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-28T13:36:35Z",
       "result": "issues-fixed"
     },
     "erdos-878": {

--- a/src/data/proofs/erdos-877/meta.json
+++ b/src/data/proofs/erdos-877/meta.json
@@ -84,7 +84,7 @@
       "id": "counting-functions",
       "title": "Counting Functions f(n) and f_m(n)",
       "startLine": 117,
-      "endLine": 132,
+      "endLine": 136,
       "summary": "Defines $f(n)$ (all sum-free subsets) and $f_m(n)$ (maximal sum-free subsets) via `Finset.powerset.filter`. Proves $f_m(n) \\leq f(n)$.",
       "mathContext": "Formal definition: Defines $f(n)$ (all sum-free subsets) and $f_m(n)$ (maximal sum-free subsets) via `Finset.powerset.filter`. Proves $f_m(n) \\leq f(n)$."
     },
@@ -92,7 +92,7 @@
       "id": "cameron-erdos-bound",
       "title": "Cameron-Erdős Lower Bound",
       "startLine": 143,
-      "endLine": 156,
+      "endLine": 160,
       "summary": "$f_m(n) > 2^{n/4}$ for $n \\geq 4$, via constructing exponentially many maximal sum-free sets from subsets of odd numbers.",
       "mathContext": "$f_m(n) > $$2^{{n/4}$}$$ for $n \\geq 4$, via constructing exponentially many maximal sum-free sets from subsets of odd numbers."
     },
@@ -100,38 +100,38 @@
       "id": "luczak-schoen",
       "title": "Łuczak-Schoen (2001): Main Question Resolved",
       "startLine": 167,
-      "endLine": 184,
+      "endLine": 180,
       "summary": "$\\exists c < 1/2,\\ f_m(n) < 2^{cn}$. Resolves the main question: $f_m(n) = o(2^{n/2})$ is **YES**.",
       "mathContext": "$\\exists c < 1/2,\\ f_m(n) < $$2^{{cn}$}$$. Resolves the main question: $f_m(n) = o($$2^{{n/2}$}$)$ is **YES**."
     },
     {
       "id": "blst-sharp",
       "title": "BLST Sharp Asymptotics (2015, 2018)",
-      "startLine": 194,
-      "endLine": 219,
+      "startLine": 193,
+      "endLine": 207,
       "summary": "BLST 2015: $f_m(n) = 2^{(1/4+o(1))n}$ via the container method. BLST 2018: $f_m(n) = (C_n + o(1)) \\cdot 2^{n/4}$ with $C_n$ depending on $n \\bmod 4$.",
       "mathContext": "BLST 2015: $f_m(n) = $$2^{{(1/4+o(1))n}$}$$ via the container method. BLST 2018: $f_m(n) = (C_n + o(1)) \\cdot $$2^{{n/4}$}$$ with $C_n$ depending on $n \\bmod 4$."
     },
     {
       "id": "structure",
       "title": "Structure and the Container Method",
-      "startLine": 234,
-      "endLine": 248,
+      "startLine": 209,
+      "endLine": 232,
       "summary": "Explains the $1/4$ exponent (only $n/4$ free choices in typical maximal sets) and the hypergraph container method underlying the BLST proof.",
       "mathContext": "Verified: Explains the $1/4$ exponent (only $n/4$ free choices in typical maximal sets) and the hypergraph container method underlying the BLST proof."
     },
     {
       "id": "erdos-748",
       "title": "Comparison with Erdős #748",
-      "startLine": 254,
-      "endLine": 270,
+      "startLine": 234,
+      "endLine": 253,
       "summary": "$f(n) = \\Theta(2^{n/2})$ vs $f_m(n) = \\Theta(2^{n/4})$: maximality reduces the count exponentially. The ratio $f_m(n)/f(n) = \\Theta(2^{-n/4}) \\to 0$.",
       "mathContext": "$f(n) = \\Theta($$2^{{n/2}$}$)$ vs $f_m(n) = \\Theta($$2^{{n/4}$}$)$: maximality reduces the count exponentially. The ratio $f_m(n)/f(n) = \\Theta($$2^{{-n/4}$}$) \\to 0$."
     },
     {
       "id": "summary",
       "title": "Summary and Resolution",
-      "startLine": 286,
+      "startLine": 256,
       "endLine": 291,
       "summary": "Combined `erdos_877_solved`: Łuczak-Schoen resolves the question, Cameron-Erdős gives the tight lower bound. Final `erdos_877` states $f_m(n) = \\Theta(2^{n/4})$.",
       "mathContext": "Combined `erdos_877_solved`: Łuczak-Schoen resolves the question, Cameron-Erdős gives the tight lower bound. Final `erdos_877` states $f_m(n) = \\Theta($$2^{{n/4}$}$)$."


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-877
**Problem**: Section line numbers in meta.json drifted from the Lean source

## Evidence

Verified against `proofs/Proofs/Erdos877Problem.lean` (291 lines, unchanged since #12921):

| Section | Claimed | Actual |
|---------|---------|--------|
| counting-functions | 117-132 | 117-136 (proof body extends to 136) |
| cameron-erdos-bound | 143-156 | 143-160 (odds_construction sorry at 160) |
| luczak-schoen | 167-184 | 167-180 (main_question_resolved ends at 180) |
| blst-sharp | 194-219 | 193-207 (only Part VI docstrings) |
| structure | 234-248 | 209-232 (Part VII; was off by 25 lines) |
| erdos-748 | 254-270 | 234-253 (Part VIII; was off by 20 lines) |
| summary | 286-291 | 256-291 (Part IX includes erdos_877_solved at 274-279) |

## Fix

10 line-number corrections in `src/data/proofs/erdos-877/meta.json`. Numerical claims (sorries=4, axiomCount=2, lineCount=291) were already correct after #13615 and are unchanged.

---
Discovered during gallery integrity audit.