### PR TITLE
audit: tracker sync — mark hurwitz-theorem-oq-04 issues-found

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11350,10 +11350,10 @@
       "result": "clean"
     },
     "hurwitz-theorem-oq-04": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-28T13:20:59Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-28T13:42:21Z",
+      "result": "issues-found"
     },
     "inclusion-exclusion": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Tracker sync after auditing `hurwitz-theorem-oq-04`.

- Lean source on main (commit `cbbab24148e`, PR #13632 merged 2026-04-28 13:33) has **0 sorries**, **0 axioms**, **0 True stubs**.
- meta.json still claims `sorries: 7` (synced earlier today against pre-#13632 state).
- Filed #13635 documenting the mismatch with a Docker-build-verification gate before mechanic syncs meta.json (PR #13632 self-flagged as build-unverified).
- Commented on stale PR #13330 (proposed sorries 0→2, now contradicts both reality and current meta).

## Test plan

- [x] Audit complete via `claim-target.sh complete hurwitz-theorem-oq-04 issues-found`
- [x] Issue #13635 filed
- [ ] Mechanic verifies build then syncs meta.json (sorries 7→0, status formalized→verified, badge wip→original/mathlib per Tier classification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)