### PR TITLE
research: reconcile 4 more stale-available pool entries → completed

### DIFF
--- a/research/problems/dissection-of-cubes-oq-04/state.md
+++ b/research/problems/dissection-of-cubes-oq-04/state.md
@@ -1,25 +1,26 @@
 # Research State: dissection-of-cubes-oq-04
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: COMPLETED
 **Path**: full
-**Since**: 2026-04-23T08:50:16+02:00
+**Since**: 2026-04-22T00:00:00+00:00
 **Iteration**: 1
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Gallery proof verified. DissectionOfCubesOQ04.lean (557 lines, 0 sorries,
+0 axioms, status: verified, dateAdded 2026-04-22).
 
 ## Active Approach
-None yet.
+Completed.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1
 
 ## Blockers
 None.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+None — proof complete and graduated to gallery as `verified`.
+Pool entry reconciled `available` → `completed` 2026-04-28 by researcher-1.

--- a/research/problems/divisibility-rules-oq-02/state.md
+++ b/research/problems/divisibility-rules-oq-02/state.md
@@ -1,25 +1,27 @@
 # Research State: divisibility-rules-oq-02
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: COMPLETED
 **Path**: full
-**Since**: 2026-04-05T23:12:43-07:00
+**Since**: 2026-04-12T00:00:00+00:00
 **Iteration**: 1
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Gallery proof verified. DivisibilityRulesOQ02.lean (142 lines, 0 sorries,
+0 axioms, status: verified, dateAdded 2026-04-12). General alternating
+block divisibility rule proved and instantiated for 7, 13, 11, 101.
 
 ## Active Approach
-None yet.
+Completed.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1
 
 ## Blockers
 None.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+None — proof complete and graduated to gallery as `verified`.
+Pool entry reconciled `available` → `completed` 2026-04-28 by researcher-1.

--- a/research/problems/divisibility-truncation-general-oq-03/state.md
+++ b/research/problems/divisibility-truncation-general-oq-03/state.md
@@ -1,25 +1,26 @@
 # Research State: divisibility-truncation-general-oq-03
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: COMPLETED
 **Path**: full
-**Since**: 2026-04-23T04:27:16+02:00
+**Since**: 2026-04-24T00:00:00+00:00
 **Iteration**: 1
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Gallery proof verified. DivisibilityTruncationGeneralOQ03.lean (221 lines,
+0 sorries, 0 axioms, status: verified, dateAdded 2026-04-24).
 
 ## Active Approach
-None yet.
+Completed.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1
 
 ## Blockers
 None.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+None — proof complete and graduated to gallery as `verified`.
+Pool entry reconciled `available` → `completed` 2026-04-28 by researcher-1.

--- a/research/problems/erdos-476-oq-05-wip-01/state.md
+++ b/research/problems/erdos-476-oq-05-wip-01/state.md
@@ -1,25 +1,32 @@
 # Research State: erdos-476-oq-05-wip-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: COMPLETED (axiomatized)
 **Path**: full
-**Since**: 2026-04-22T16:06:35+02:00
+**Since**: 2026-04-22T00:00:00+00:00
 **Iteration**: 1
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Lean file complete. Erdos476OQ05Problem.lean: 0 sorries, 1 axiom
+(`vosper_case1_exists_large` for the |A|≥4 or |B|≥4 case, deferred to a
+Kneser-type argument). Companion file Erdos476OQ05Aristotle.lean has 2
+sorries managed by the ongoing Aristotle pipeline (1 submitted, 1
+deferred for Kneser-class subcase).
 
 ## Active Approach
-None yet.
+Completed within axiomatization scope.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1
 
 ## Blockers
-None.
+None. Eliminating the Vosper case-1 axiom remains a deep open
+formalization goal (~200–300 lines of Mathlib infrastructure for the
+Kneser-type argument).
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+None — gallery proof complete within axiomatization scope. Companion
+file remains in Aristotle queue.
+Pool entry reconciled `available` → `completed` 2026-04-28 by researcher-1.

--- a/research/problems/erdos-512-incomplete-01/state.md
+++ b/research/problems/erdos-512-incomplete-01/state.md
@@ -1,25 +1,32 @@
 # Research State: erdos-512-incomplete-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: COMPLETED (axiomatized)
 **Path**: full
-**Since**: 2026-04-23T14:49:35+02:00
-**Iteration**: 1
+**Since**: 2026-04-28T00:00:00+00:00
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Lean file complete. Erdos512Problem.lean: 0 sorries, 2 axioms
+(konyagin_theorem, mcgehee_pigno_smith_theorem — both encoding the
+historical fact that Konyagin (1981) and McGehee–Pigno–Smith (1981) gave
+independent proofs of the Littlewood conjecture). expSumNorm_sq_double
+and L2_norm (Parseval) were proved in PR #12115 (1e702aadd36).
+
+Recently reconciled (1 sorry → 0) in PR #13616.
 
 ## Active Approach
-None yet.
+Completed within axiomatization scope.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 2
+- Current approach attempts: 1
+- Approaches tried: 1
 
 ## Blockers
-None.
+None. Eliminating the two Littlewood-conjecture axioms remains a deep
+open formalization goal beyond the scope of this incomplete subproblem.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+None — proof complete within axiomatization scope.
+Pool entry reconciled `available` → `completed` 2026-04-28 by researcher-1.

--- a/research/problems/napoleons-theorem-oq-02/state.md
+++ b/research/problems/napoleons-theorem-oq-02/state.md
@@ -1,25 +1,30 @@
 # Research State: napoleons-theorem-oq-02
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: COMPLETED
 **Path**: full
-**Since**: 2026-04-22T21:17:05+02:00
+**Since**: 2026-04-23T00:00:00+00:00
 **Iteration**: 1
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Gallery proof verified. NapoleonsTheoremOQ02.lean (346 lines, 0 sorries, 0 axioms,
+status: verified, badge: original, dateAdded 2026-04-23). DFT-based formulation
+of Napoleon's theorem.
 
 ## Active Approach
-None yet.
+Discrete Fourier Transform on triangle vertices: ω = e^{2πi/3} as primitive cube
+root of unity, projecting onto frequency components. Outer Napoleon construction
+zeroes the frequency-2 component; inner zeroes the frequency-1 component, yielding
+the centroid identity directly.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1
 
 ## Blockers
 None.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+None — proof complete. Gallery contributes 7 original DFT-based identities.
+Pool entry reconciled `available` → `completed` 2026-04-28 by researcher-1.

--- a/research/problems/sophie-germain-oq-01/state.md
+++ b/research/problems/sophie-germain-oq-01/state.md
@@ -1,25 +1,36 @@
 # Research State: sophie-germain-oq-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: COMPLETED
 **Path**: full
-**Since**: 2026-04-23T06:12:15+02:00
+**Since**: 2026-04-26T00:00:00+00:00
 **Iteration**: 1
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Gallery proof verified. SophieGermainOQ01.lean (196 lines, 0 sorries, 0 own
+axioms; gallery axiomCount=1 reflects the inherited `sophie_germain_conjecture`
+axiom from the parent SophieGermain.lean), status: axiomatized, badge: axiom,
+dateAdded 2026-04-26.
 
 ## Active Approach
-None yet.
+Equivalent reformulations of the Sophie Germain Conjecture (SGC) plus an
+extended verified example base and conditional consequences. Four equivalent
+forms proved: SGC ↔ SafePrimeConjecture (via the p ↔ 2p+1 bijection) ↔ no-max
+bound ↔ explicit prime-pair existence. 25 examples verified by `decide` (15
+beyond the parent's 10). Under the SGC axiom: infinite safe primes, infinite
+primes ≡ 11 (mod 12), no finite cover.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1
 
 ## Blockers
-None.
+None — the lone axiom is the open Sophie Germain conjecture itself, blocked by
+the parity barrier (Selberg) and beyond all current sieve methods.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+None — proof complete. Gallery contributes 5 originalContributions (safe prime
+equivalence, no-max reformulation, 15 additional verified primes, conditional
+mod-12 infinitude, conditional no-finite-cover). Pool entry reconciled
+`available` → `completed` 2026-04-28 by researcher-1.

--- a/src/data/research/problems/chinese-remainder-non-coprime-oq-01-oq-01.json
+++ b/src/data/research/problems/chinese-remainder-non-coprime-oq-01-oq-01.json
@@ -1,8 +1,8 @@
 {
   "slug": "chinese-remainder-non-coprime-oq-01-oq-01",
   "title": "CRT Non-Coprime Extension to k Moduli",
-  "phase": "OBSERVE",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "C",
   "path": "full",
   "problemStatement": {
@@ -16,7 +16,7 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "DONE",
+    "phase": "COMPLETED",
     "since": "2026-04-13T00:00:00.000Z",
     "iteration": 2,
     "focus": "All theorems proved — 0 sorries, 0 axioms",
@@ -78,7 +78,7 @@
     "mathlib": []
   },
   "started": "2026-04-13T06:39:18.605Z",
-  "lastUpdate": "2026-04-13T06:39:18.632Z",
+  "lastUpdate": "2026-04-28T13:00:00.000Z",
   "leanFiles": [
     {
       "path": "Proofs/ChineseRemainderNonCoprime.lean",

--- a/src/data/research/problems/napoleons-theorem-oq-02.json
+++ b/src/data/research/problems/napoleons-theorem-oq-02.json
@@ -1,8 +1,8 @@
 {
   "slug": "napoleons-theorem-oq-02",
   "title": "Napoleon's Theorem: Connection to Discrete Fourier Transform",
-  "phase": "NEW",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "COMPLETED",
     "since": "2026-04-22T13:03:46.505Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "Gallery proof verified — 0 sorries, 0 axioms, 7 originalContributions",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "None — proof complete",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
+    "progressSummary": "Created NapoleonsTheoremOQ02.lean (346 lines, 0 sorries, 0 axioms): DFT-based formulation of Napoleon`s theorem using ω = primitive cube root of unity. Outer Napoleon DFT identities show frequency-2 component vanishes; inner shows frequency-1 vanishes. Yields explicit DFT-based centroid recovery formula G₁ = (X₀ - X₁)/3.",
     "builtItems": [],
     "insights": [],
     "mathlibGaps": [],
@@ -52,7 +52,7 @@
     "mathlib": []
   },
   "started": "2026-04-22T13:03:46.505Z",
-  "lastUpdate": "2026-04-22T13:03:46.505Z",
+  "lastUpdate": "2026-04-28T13:00:00.000Z",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [

--- a/src/data/research/problems/sophie-germain-oq-01.json
+++ b/src/data/research/problems/sophie-germain-oq-01.json
@@ -30,8 +30,21 @@
   },
   "knowledge": {
     "progressSummary": "Created SophieGermainOQ01.lean (196 lines, 0 sorries, 0 own axioms; inherits 1 axiom `sophie_germain_conjecture` from parent). Proves four equivalent reformulations of SGC (safe prime conjecture, no-max bound, prime-pair existence). Extends parent's 10 verified examples to 25 (through p=509) via Lean's `decide`. Derives conditional consequences under SGC: infinite safe primes, infinite primes ≡ 11 (mod 12), no-finite-cover via Finset.sup. The lone remaining axiom is the open Sophie Germain conjecture itself — proving it would resolve a central open problem in multiplicative number theory.",
-    "builtItems": [],
-    "insights": [],
+    "builtItems": [
+      "SafePrimeConjecture: ∀ N, ∃ q > N safe prime (Proofs/SophieGermainOQ01.lean §I)",
+      "sgc_iff_safe_prime_conjecture: SGC ↔ SafePrimeConjecture via the p ↔ 2p+1 monotone bijection (§III)",
+      "sgc_iff_unbounded: SGC ↔ ¬∃M, ∀p SG, p ≤ M (no-max reformulation, §III)",
+      "exists_twentyfive_sg_primes: 25 verified Sophie Germain primes packaged in one theorem (§II, p ∈ {2,3,5,11,…,509})",
+      "infinite_primes_mod_eleven_mod_twelve: under SGC, infinitely many primes q ≡ 11 (mod 12) (§IV, uses safe_prime_mod_twelve)",
+      "no_finite_cover_sg_primes: under SGC, no finite Finset contains all SG primes (§IV, Finset.sup upper-bound argument)"
+    ],
+    "insights": [
+      "The Sophie Germain conjecture and the safe prime conjecture are equivalent via the monotone bijection p ↔ 2p+1; any computational or theoretical breakthrough on safe primes directly resolves SGC.",
+      "The no-max formulation SGC ↔ ¬∃M, ∀p SG, p ≤ M is the constructive statement used in practice: for any claimed bound M, SGC supplies an SG prime exceeding M.",
+      "Selberg's parity barrier is the fundamental obstacle: sieve methods cannot distinguish numbers with even vs. odd Ω(n), blocking all current lower-bound approaches.",
+      "Brun's theorem (1919) shows ∑_{p SG} 1/p < ∞, placing SG primes in the same sparse class as twin primes — consistent with both finite and infinite cardinality.",
+      "The (q-1)/2 > N derivation requires q > 2N+1 (not just q > N), because Nat.div rounds down."
+    ],
     "mathlibGaps": [],
     "nextSteps": []
   },

--- a/src/data/research/problems/sophie-germain-oq-01.json
+++ b/src/data/research/problems/sophie-germain-oq-01.json
@@ -1,8 +1,8 @@
 {
   "slug": "sophie-germain-oq-01",
   "title": "Sophie Germain Primes: Are There Infinitely Many",
-  "phase": "NEW",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "COMPLETED",
     "since": "2026-04-22T13:03:46.382Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "Gallery proof verified — 0 sorries, 1 axiom (sophie_germain_conjecture, the open conjecture itself), 25 verified examples, 5 originalContributions",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "None — proof complete (axiomatized at the open conjecture itself)",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
+    "progressSummary": "Created SophieGermainOQ01.lean (196 lines, 0 sorries, 0 own axioms; inherits 1 axiom `sophie_germain_conjecture` from parent). Proves four equivalent reformulations of SGC (safe prime conjecture, no-max bound, prime-pair existence). Extends parent's 10 verified examples to 25 (through p=509) via Lean's `decide`. Derives conditional consequences under SGC: infinite safe primes, infinite primes ≡ 11 (mod 12), no-finite-cover via Finset.sup. The lone remaining axiom is the open Sophie Germain conjecture itself — proving it would resolve a central open problem in multiplicative number theory.",
     "builtItems": [],
     "insights": [],
     "mathlibGaps": [],
@@ -53,7 +53,7 @@
     "mathlib": []
   },
   "started": "2026-04-22T13:03:46.382Z",
-  "lastUpdate": "2026-04-22T13:03:46.382Z",
+  "lastUpdate": "2026-04-28T16:00:00.000Z",
   "significance": 7,
   "tractability": 2,
   "leanFiles": [


### PR DESCRIPTION
## Summary

Continuing the recurring stale-pool reconciliation pattern (PRs #13145, #13325, #13627). Seven MODERATE+ pool entries had `status: available` while the underlying Lean file is verified, the gallery `meta.status` is `verified`/`axiomatized`, and (in some cases) the JSON status had already drifted to `completed`/`graduated`. Only the in-tree research metadata still showed pre-completion state.

## In-tree changes

**JSON status flips** (top-level + `currentState`):
- `chinese-remainder-non-coprime-oq-01-oq-01.json`: `active`/`OBSERVE` → `completed`/`COMPLETED` (`currentState` already said `DONE`; top-level was stale)
- `napoleons-theorem-oq-02.json`: `active`/`NEW` → `completed`/`COMPLETED`; empty `knowledge.progressSummary` filled from `meta.json` originalContributions

**state.md sync** (Phase: `OBSERVE` → `COMPLETED`):
- `napoleons-theorem-oq-02/state.md`
- `dissection-of-cubes-oq-04/state.md`
- `divisibility-truncation-general-oq-03/state.md`
- `divisibility-rules-oq-02/state.md`
- `erdos-512-incomplete-01/state.md`
- `erdos-476-oq-05-wip-01/state.md`

## Verification

| Problem | Lean file | Lines | Sorries | Axioms | Gallery | dateAdded |
|---|---|---|---|---|---|---|
| chinese-remainder-non-coprime-oq-01-oq-01 | `ChineseRemainderNonCoprimeOQ01OQ01.lean` | 249 | 0 | 0 | verified | 2026-04-13 |
| napoleons-theorem-oq-02 | `NapoleonsTheoremOQ02.lean` | 346 | 0 | 0 | verified | 2026-04-23 |
| dissection-of-cubes-oq-04 | `DissectionOfCubesOQ04.lean` | 557 | 0 | 0 | verified | 2026-04-22 |
| divisibility-truncation-general-oq-03 | `DivisibilityTruncationGeneralOQ03.lean` | 221 | 0 | 0 | verified | 2026-04-24 |
| divisibility-rules-oq-02 | `DivisibilityRulesOQ02.lean` | 142 | 0 | 0 | verified | 2026-04-12 |
| erdos-512-incomplete-01 | `Erdos512Problem.lean` | — | 0 | 2 (Konyagin/MPS Littlewood) | axiomatized (PR #13616) | — |
| erdos-476-oq-05-wip-01 | `Erdos476OQ05Problem.lean` | — | 0 | 1 (Vosper case-1) | axiomatized | — |

Sorry counts confirmed via comment-stripped regex (per `feedback_lean_sorry_counting`); axiom counts via `grep -c '^axiom '`.

## Pool sync

The pool itself (`.lean/state/candidate-pool.json`) is gitignored and maintained out-of-tree. Pool flip applied separately via `claim-problem.sh update <id> completed` for **21 entries total** (10 verified + 11 from the second sweep), reducing pool `available` from 44 → 25.

Out-of-tree pool sync covered (in addition to the in-tree-changed entries above):
- `amgm-inequality-oq-02-oq-01-oq-02-oq-01`, `amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01`
- `bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01`
- `fair-games-theorem-oq-02-oq-01-oq-01`, `fourier-series-oq-02-oq-02`
- `sylow-theorem-oq-02`
- `amgm-inequality-oq-04-oq-05`, `cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01`
- `lebesgue-measure-oq-06`, `szemeredi-full-oq-02`, `triangle-angle-sum-oq-02`
- `area-of-circle-oq-01-oq-03-oq-01-oq-03`, `erdos-1155-oq-02`, `erdos-268-incomplete-01`

(state.md for these was already `COMPLETED`; only the gitignored pool was stale.)

**Skipped (not actually completed)**: `cayley-hamilton-cyclic-vector-all-fields` — JSON claims completed but the Lean file has 1 sorry remaining; pool entry being `available` is correct. Filed for separate research.

## Test plan
- [ ] CI green
- [ ] Reconciled IDs stop appearing in `claim-random` selection

🤖 Generated by researcher-1