### PR TITLE
audit(erdos-869): correct section startLine/endLine drift

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9693,8 +9693,8 @@
     },
     "erdos-869": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-28T13:49:45Z",
       "result": "issues-fixed"
     },
     "erdos-87": {

--- a/src/data/proofs/erdos-869/meta.json
+++ b/src/data/proofs/erdos-869/meta.json
@@ -118,38 +118,38 @@
       "title": "Known Negative Results",
       "summary": "Härtter-Nathanson theorem and union of bases theorem",
       "startLine": 141,
-      "endLine": 174,
+      "endLine": 173,
       "mathContext": "Verified: Härtter-Nathanson theorem and union of bases theorem"
     },
     {
       "id": "structural-properties",
       "title": "Structural Properties",
       "summary": "Basis monotonicity, minimal bases are thin, essential elements",
-      "startLine": 175,
-      "endLine": 205,
+      "startLine": 174,
+      "endLine": 201,
       "mathContext": "Mathematical content: Basis monotonicity, minimal bases are thin, essential elements"
     },
     {
       "id": "examples",
       "title": "Examples",
       "summary": "Powers of 2, dense sets, existence of disjoint bases",
-      "startLine": 206,
-      "endLine": 234,
+      "startLine": 202,
+      "endLine": 225,
       "mathContext": "Mathematical content: Powers of 2, dense sets, existence of disjoint bases"
     },
     {
       "id": "challenges",
       "title": "Why the Problem is Hard",
       "summary": "Challenges from Härtter-Nathanson and cross-sums",
-      "startLine": 235,
-      "endLine": 257,
+      "startLine": 226,
+      "endLine": 240,
       "mathContext": "Mathematical content: Challenges from Härtter-Nathanson and cross-sums"
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "Summary theorem and open question statement",
-      "startLine": 258,
+      "startLine": 241,
       "endLine": 283,
       "mathContext": "Verified: Summary theorem and open question statement"
     }


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-869
**Problem**: Section line numbers in meta.json drifted from the Lean source

## Evidence

Verified against `proofs/Proofs/Erdos869Problem.lean` (283 lines, axiomCount=2, sorries=0):

| Section | Claimed | Actual |
|---------|---------|--------|
| negative-results | 141-174 | 141-173 (Part V; ends at blank before Part VI `/-`) |
| structural-properties | 175-205 | 174-201 (Part VI `/-` opener at L174) |
| examples | 206-234 | 202-225 (Part VII `/-` opener at L202) |
| challenges | 235-257 | 226-240 (Part VIII; ends at `-/` before Part IX) |
| summary | 258-283 | 241-283 (Part IX `/-` opener at L241) |

Five sections drifted; the largest drift (`summary`) was off by 17 lines. Pattern matches sections 1-5 (which align with `/-` openers) but not 6-9.

## Fix

8 line-number corrections in `src/data/proofs/erdos-869/meta.json`. Numerical claims (sorries=0, axiomCount=2, lineCount=283) were already correct and are unchanged.

Tracker also marked `issues-fixed`.

---
Discovered during gallery integrity audit.