### PR TITLE
audit: tracker sync — erdos-870 clean, erdos-859 issues-fixed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9627,8 +9627,8 @@
     },
     "erdos-859": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-28T14:26:26Z",
       "result": "issues-fixed"
     },
     "erdos-86": {
@@ -9705,9 +9705,9 @@
     },
     "erdos-870": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-28T14:23:14Z",
+      "result": "clean"
     },
     "erdos-871": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Tracker updates from session 2026-04-28:

- **erdos-870** → `clean` — re-audit verified all counts and narratives (3 axioms / 3 sorries) match Lean source. No issues.
- **erdos-859** → `issues-fixed` — section line ranges drifted ~50 lines after file growth; fix in #13643.

## Test plan

- [x] tracker JSON parses
- [ ] no impact on gallery build (tracker is metadata only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)