### PR TITLE
audit(erdos-870): correct section startLine/endLine drift

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9705,9 +9705,9 @@
     },
     "erdos-870": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T14:23:14Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-04-28T14:43:50Z",
+      "result": "issues-fixed"
     },
     "erdos-871": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-870/meta.json
+++ b/src/data/proofs/erdos-870/meta.json
@@ -133,30 +133,30 @@
       "title": "Special Cases",
       "summary": "k = 2 case, weaker conjectures, classical bases",
       "startLine": 175,
-      "endLine": 217,
+      "endLine": 206,
       "mathContext": "Mathematical content: k = 2 case, weaker conjectures, classical bases"
     },
     {
       "id": "structural",
       "title": "Structural Properties",
       "summary": "Subset inheritance, finite removal, threshold phenomenon",
-      "startLine": 218,
-      "endLine": 250,
+      "startLine": 207,
+      "endLine": 233,
       "mathContext": "Mathematical content: Subset inheritance, finite removal, threshold phenomenon"
     },
     {
       "id": "connections",
       "title": "Connections",
       "summary": "Problem #868, Sidon sets",
-      "startLine": 251,
-      "endLine": 279,
+      "startLine": 234,
+      "endLine": 259,
       "mathContext": "Mathematical content: Problem #868, Sidon sets"
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "Main results and open status",
-      "startLine": 280,
+      "startLine": 260,
       "endLine": 303,
       "mathContext": "Mathematical content: Main results and open status"
     }


### PR DESCRIPTION
## Summary

- Section line numbers in `src/data/proofs/erdos-870/meta.json` had drifted from `proofs/Proofs/Erdos870Problem.lean`
- The lemma `basis_subset_reps` at line 215 was orphaned: `special-cases` ended at 217 (cutting into the lemma) while `structural` started at 218 (missing the lemma entirely)
- The `connections` and `summary` sections were similarly misaligned

## Fixes

| Section | Before | After | Reason |
|---------|--------|-------|--------|
| special-cases | 175-217 | 175-206 | Part V ends at `KthPowers` (line 205); blank line at 206 |
| structural | 218-250 | 207-233 | Part VI `/-` opener (207) through orphan threshold-phenomenon docstring; now includes `basis_subset_reps` at 215 |
| connections | 251-279 | 234-259 | Part VII `/-` opener (234) through orphan Sidon-controlled-reps docstring; now includes `RelatedProblem868` at 242 |
| summary | 280-303 | 260-303 | Part VIII `/-` opener at 260; the comment block 260-279 IS the summary text |

Numerical claims (`sorries=2`, `axiomCount=2`, `lineCount=303`, `theoremCount=4`, `definitionCount=17`) unchanged and verified.

## Test plan

- [x] `jq` validates updated `meta.json`
- [x] Section ranges form a contiguous partition of substantive content
- [x] All 19 substantive declarations (`abbrev`, `structure`, `def`, `theorem`, `lemma`, `axiom`) fall within exactly one section

🤖 Generated with [Claude Code](https://claude.com/claude-code)