### PR TITLE
audit(erdos-861): correct section line drift

### DIFF
--- a/src/data/proofs/erdos-861/meta.json
+++ b/src/data/proofs/erdos-861/meta.json
@@ -86,64 +86,64 @@
       "id": "sidon-definitions",
       "title": "Sidon Set Definitions",
       "startLine": 45,
-      "endLine": 70,
-      "summary": "Definition of Sidon sets as sets with distinct pairwise sums",
-      "mathContext": "$\\text{IsSidon}(S) \\iff \\forall a \\le b,\\, c \\le d \\in S: a + b = c + d \\implies (a = c \\wedge b = d)$. All pairwise sums are distinct (B$_2$ sequence)."
+      "endLine": 90,
+      "summary": "Definition of Sidon sets as sets with distinct pairwise sums, plus equivalent formulation",
+      "mathContext": "$\\text{IsSidon}(S) \\iff \\forall a \\le b,\\, c \\le d \\in S: a + b = c + d \\implies (a = c \\wedge b = d)$. All pairwise sums are distinct (B$_2$ sequence). Includes `IsSidon'` (pair-set form) and `sidon_equiv` proving the two definitions agree."
     },
     {
       "id": "counting-functions",
       "title": "Functions f(N) and A(N)",
-      "startLine": 71,
-      "endLine": 90,
+      "startLine": 92,
+      "endLine": 110,
       "summary": "Maximum Sidon size and count of Sidon subsets",
       "mathContext": "$f(N) = \\max\\{|S| : S \\subseteq \\{1, \\ldots, N\\},\\, \\text{IsSidon}(S)\\}$. $A(N) = |\\{S : S \\subseteq \\{1, \\ldots, N\\},\\, \\text{IsSidon}(S)\\}|$."
     },
     {
       "id": "asymptotic",
       "title": "Known Asymptotic",
-      "startLine": 91,
-      "endLine": 113,
-      "summary": "Erdős-Turán result f(N) ~ √N",
-      "mathContext": "$f(N) \\sim \\sqrt{N}$ as $N \\to \\infty$ (Erdős-Turán). The maximum Sidon subset of $\\{1, \\ldots, N\\}$ has $\\sim \\sqrt{N}$ elements."
+      "startLine": 112,
+      "endLine": 128,
+      "summary": "Documents Erdős-Turán f(N) ~ √N (in docstring) and states `SidonSizeConjecture` for the refined bound",
+      "mathContext": "$f(N) \\sim \\sqrt{N}$ as $N \\to \\infty$ (Erdős-Turán, recorded only in docstring; not formally stated as a theorem). `SidonSizeConjecture` formalizes the refined statement $f(N) = \\sqrt{N} + O(N^\\varepsilon)$ for any $\\varepsilon > 0$."
     },
     {
       "id": "question1",
       "title": "Cameron-Erdős Question 1",
-      "startLine": 114,
-      "endLine": 134,
-      "summary": "Is A(N)/2^{f(N)} → ∞? (Answer: Yes)",
+      "startLine": 130,
+      "endLine": 149,
+      "summary": "Is A(N)/2^{f(N)} → ∞? (Answer: Yes; declared as axiom `cameron_erdos_q1_true`)",
       "mathContext": "Q1: Is $A(N) / 2^{f(N)} \\to \\infty$? *YES*. The Saxton-Thomason bound $A(N) \\ge 2^{1.16 f(N)}$ implies $A(N)/2^{f(N)} \\ge 2^{0.16 f(N)} \\to \\infty$."
     },
     {
       "id": "question2",
       "title": "Cameron-Erdős Question 2",
-      "startLine": 135,
-      "endLine": 156,
-      "summary": "Is A(N) = 2^{(1+o(1))f(N)}? (Answer: No)",
+      "startLine": 151,
+      "endLine": 171,
+      "summary": "Is A(N) = 2^{(1+o(1))f(N)}? (Answer: No; declared as axiom `cameron_erdos_q2_false`)",
       "mathContext": "Q2: Is $A(N) = 2^{(1+o(1))f(N)}$? *NO*. The bounds $2^{1.16 f(N)} \\le A(N) \\le 2^{6.442 f(N)}$ show the exponent is not $1 + o(1)$."
     },
     {
       "id": "bounds",
       "title": "Current Best Bounds",
-      "startLine": 157,
-      "endLine": 196,
-      "summary": "Saxton-Thomason lower and KLRS upper bounds",
+      "startLine": 173,
+      "endLine": 211,
+      "summary": "Saxton-Thomason lower and KLRS upper bound axioms, combined into `current_bounds` theorem",
       "mathContext": "$2^{1.16 f(N)} \\le A(N) \\le 2^{6.442 f(N)}$ for large $N$. Lower: Saxton-Thomason (2015, hypergraph containers). Upper: Kohayakawa-Lee-Rödl-Samotij (2015)."
     },
     {
       "id": "properties",
       "title": "Basic Properties",
-      "startLine": 197,
-      "endLine": 224,
-      "summary": "Elementary Sidon set properties",
-      "mathContext": "Empty set is Sidon. Singletons are Sidon. Sidon subset of a Sidon set is Sidon. If $S \\subseteq \\{1, \\ldots, N\\}$ is Sidon, then $|S| \\le f(N)$."
+      "startLine": 213,
+      "endLine": 234,
+      "summary": "Elementary Sidon set properties (empty set, singleton)",
+      "mathContext": "Empty set is Sidon. Singletons are Sidon. (A docstring fragment for an `addition preserves Sidon` lemma is present but the lemma itself is not stated.)"
     },
     {
       "id": "summary",
       "title": "Summary",
-      "startLine": 225,
-      "endLine": 255,
-      "summary": "Main results and current state of knowledge",
+      "startLine": 235,
+      "endLine": 263,
+      "summary": "Main results bundled: `erdos_861_summary` and `erdos_861` combine Q1-true and Q2-false axioms",
       "mathContext": "$A(N)/2^{f(N)} \\to \\infty$ (Q1: YES) and $\\exists c \\in [1.16, 6.442]: A(N) = 2^{(c+o(1))f(N)}$ (Q2: NO, exponent $\\neq 1$). The exact $c$ remains open."
     }
   ],


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-861 (Counting Sidon Sets / Cameron-Erdős)
**Problem**: Section startLine/endLine in `meta.json` are systematically off by ~20-30 lines from the actual Lean source. Some section summaries also misrepresent what is formally stated vs. what only appears in docstrings.

## Evidence

`proofs/Proofs/Erdos861Problem.lean` is 265 lines. Authoritative declaration positions (from grep):

| Section | meta claims | Actual file content | Correct range |
|---------|-------------|---------------------|---------------|
| sidon-definitions | 45-70 | Part I block + IsSidon + IsSidon' + `sidon_equiv` (66-90) | 45-90 |
| counting-functions | 71-90 | Part II (92-94) + `maxSidonSize` (100-102) + `countSidonSets` (108-110) | 92-110 |
| asymptotic | 91-113 | Part III (112-114) + Erdős-Turán *docstring only* (116-120) + `SidonSizeConjecture` (125-128) | 112-128 |
| question1 | 114-134 | Part IV (130-132) + `CameronErdosQuestion1` def + `cameron_erdos_q1_true` axiom (149) | 130-149 |
| question2 | 135-156 | Part V (151-153) + `CameronErdosQuestion2` def + `cameron_erdos_q2_false` axiom (171) | 151-171 |
| bounds | 157-196 | Part VI (173-175) + `saxton_thomason_lower_bound` + `klrs_upper_bound` + `current_bounds` (201-211) | 173-211 |
| properties | 197-224 | Part VII (213-215) + `empty_is_sidon` + `singleton_is_sidon` (ends 230) + orphan docstring 232-234 | 213-234 |
| summary | 225-255 | Part VIII (235-237) + `erdos_861_summary` + `erdos_861` (ends 263) | 235-263 |

The `header` section (1-44) was already correct.

## Fix

Realigned all 8 body sections to match actual source. Tightened summaries:
- `sidon-definitions` now mentions `IsSidon'` and `sidon_equiv` (which is why the section extends to line 90)
- `asymptotic` clarifies that `f(N) ~ √N` (Erdős-Turán) appears only in a docstring — no formal theorem statement; the formal content is `SidonSizeConjecture` for the refined ε-bound
- `properties` notes the orphan docstring at 232-234 (an "addition preserves Sidon" lemma is documented but not stated)
- `question1` / `question2` / `bounds` / `summary` name the relevant axioms/theorems

No counts changed: still 4 axioms, 0 sorries, status `axiomatized` / badge `axiom`. The four axioms (`cameron_erdos_q1_true`, `cameron_erdos_q2_false`, `saxton_thomason_lower_bound`, `klrs_upper_bound`) are correctly described in `assumptions` and `originalContributions`.

---
Discovered during gallery integrity audit.