### PR TITLE
research: binary-gcd-oq-03-oq-02 — HGCD scope survey (NEW → ORIENT)

### DIFF
--- a/research/problems/binary-gcd-oq-03-oq-02/knowledge.md
+++ b/research/problems/binary-gcd-oq-03-oq-02/knowledge.md
@@ -1,0 +1,136 @@
+# Knowledge: Schönhage's Recursive HGCD (binary-gcd-oq-03-oq-02)
+
+## Summary
+
+Open question: can we formalize Schönhage's recursive half-GCD (HGCD) algorithm
+in Lean 4, achieving the O(M(n)·log n) bit complexity bound, where M(n) is the
+cost of multiplying n-bit integers?
+
+## Mathematical content
+
+Lehmer's algorithm (formalized in `BinaryGcdOQ03.lean`, 491 lines, 0 sorries)
+extracts the top w bits of the inputs, computes a 2×2 cofactor matrix on those
+small approximations, then applies the matrix to the full-precision inputs.
+Each Lehmer step performs O(w) Euclidean iterations on small numbers.
+Total cost: O(n²/w) bit operations vs O(n²) for plain Euclidean.
+
+Schönhage's HGCD adds **recursion**:
+
+1. Take inputs (a, b) of n bits.
+2. **Recursively** compute the cofactor matrix M₁ that transforms the top half
+   (n/2 bits) of (a, b) — solving the subproblem on n/2-bit inputs.
+3. Apply M₁ to the full (a, b), reducing them to ~n/2 bits.
+4. Recursively compute M₂ on the reduced pair.
+5. Compose: total matrix M = M₂ · M₁.
+
+The recursion depth is O(log n). Each level does O(M(n)) work for matrix
+application (using fast multiplication). Total: O(M(n)·log n).
+
+## Survey of existing infrastructure (2026-04-28)
+
+### Already in this gallery (0 axioms, 0 sorries):
+
+- `BinaryGcdOQ03.lean` (491 lines) — Lehmer hybrid: cofactor matrices,
+  GCD invariance under det ±1, top-bit extraction, lehmerCofactors,
+  cofactor_apply_gcd. **All the matrix machinery for HGCD is here.**
+- `BinaryGcdOQ03OQ01.lean` (240 lines) — Lehmer step progress/correctness.
+- `BinaryGcdOQ01.lean`, `BinaryGcdOQ01OQ03.lean`, `BinaryGcdOQ01OQ04.lean`
+  — Binary GCD step bounds (Lamé-Fibonacci).
+
+### Mathlib gaps (verified 2026-04-28):
+
+| Need | Status |
+|---|---|
+| `Nat.gcd`, `Int.gcd`, basic divisibility | ✅ Mathlib |
+| Bit operations (`Nat.shiftRight`, `Nat.log2`) | ✅ Mathlib |
+| 2×2 integer cofactor matrices | ✅ in BinaryGcdOQ03 |
+| GCD invariance under det ±1 matrices | ✅ in BinaryGcdOQ03 (`gcd_cofactor_eq`) |
+| Half-GCD / HGCD definition | ❌ **gap** — neither Mathlib nor gallery |
+| Karatsuba / Toom-Cook / FFT multiplication | ❌ **gap** — Mathlib has no fast multiplication |
+| Bit-complexity model (M(n) = cost to multiply n-bit ints) | ❌ **gap** |
+| Big-integer / arbitrary-precision arithmetic abstraction | ❌ **gap** — Mathlib uses `Nat`/`Int` opaquely |
+
+`grep -ri "halfgcd\|hgcd\|schönhage\|karatsuba"` against Mathlib returned no
+relevant matches.
+
+## Research strategy (recommended)
+
+The question as stated couples two distinct claims:
+
+- **(A) Algorithmic formalization**: define `hgcdMatrix : ℕ → ℕ → CofactorMatrix`
+  recursively, prove `cofactor_apply_gcd` for it (using the existing det ±1
+  invariance), prove that applying it reduces input size by ~½.
+- **(B) Complexity bound**: prove the bit operations are O(M(n)·log n).
+
+(A) is **tractable**: ~300–500 lines extending `BinaryGcdOQ03.lean`.
+The recursion structure is well-established and the matrix invariants are
+already proved. The hard parts are (i) establishing termination of the
+recursion and (ii) proving the size-reduction lemma `applying hgcdMatrix(a,b)
+yields (a',b') with bitsize(max a' b') ≤ bitsize(max a b)/2 + O(1)`.
+
+(B) is **blocked** on three foundational gaps in Mathlib (fast multiplication,
+bit-complexity model, big-integer abstraction). Filling these gaps is a
+multi-thousand-line project that should not be attempted as part of an HGCD
+formalization. Cost would dwarf the actual algorithm.
+
+**Recommendation**: split the question. Pursue (A) as a self-contained
+verification: HGCD correctness + size-reduction. State the complexity bound
+in a comment/docstring, deferring (B) until a complexity model lands in
+Mathlib (or as a separate, much larger gallery initiative).
+
+## Sessions
+
+## Session 2026-04-28 (Session 1) — Initial Survey
+
+**Mode**: FRESH
+**Outcome**: surveyed — phase NEW → ORIENT, decision: SURVEY-then-defer-complexity
+
+### What I Did
+
+- Read parent `BinaryGcdOQ03.lean` (Lehmer-Schönhage hybrid, 491 lines, 0 sorries)
+  to understand existing cofactor-matrix machinery.
+- Surveyed siblings `BinaryGcdOQ01*` and `BinaryGcdOQ03OQ01.lean`.
+- Searched Mathlib for HGCD, Schönhage, Karatsuba, fast-multiplication —
+  no relevant infrastructure exists.
+- Searched Mathlib `Computability/` directory — has Turing-machine/primrec
+  infrastructure but no bit-complexity model for arithmetic operations.
+- Identified the (correctness, complexity) split.
+
+### Key Findings
+
+- **All matrix-level invariants needed for HGCD correctness already exist**
+  (`gcd_cofactor_eq`, `lehmerCofactors_det_unit`, `cofactor_apply_gcd`).
+  The HGCD formalization is "just" wiring these into a recursion.
+- **The complexity claim is currently unfalsifiable in Lean**: there is no
+  Mathlib model in which to state "M(n) bit operations". Stating
+  O(M(n)·log n) requires inventing/upstreaming substantial infrastructure
+  first.
+- **Termination of HGCD recursion** is the single hardest piece for the
+  correctness side: need `bitsize(max a' b') < bitsize(max a b)` after
+  one application of the recursively-computed matrix, which requires
+  showing the matrix actually accumulated ≥ 1 Euclidean step.
+
+### Files Modified
+
+- `src/data/research/problems/binary-gcd-oq-03-oq-02.json` — populated
+  knowledge fields, advanced phase NEW → ORIENT.
+- `research/problems/binary-gcd-oq-03-oq-02/knowledge.md` — this file.
+- `research/problems/binary-gcd-oq-03-oq-02/state.md` — synced to ORIENT.
+
+### Next Steps
+
+1. Decide explicitly whether to scope this problem to correctness-only
+   (recommended) or keep the complexity claim in scope.
+2. If correctness-only: draft `hgcdMatrix : ℕ → ℕ → CofactorMatrix`
+   signature and termination measure (probably `bitsize a + bitsize b`).
+3. If complexity-in-scope: spin off a separate gallery initiative for
+   "Mathlib bit-complexity model + fast multiplication" — likely 2–4
+   sessions of architectural work before HGCD complexity becomes
+   provable.
+
+### Honest Assessment
+
+This survey produces a structural insight (the correctness/complexity split)
+and identifies infrastructure gaps. It does **not** prove anything. The next
+session can act on the recommendation in ~1–2 sessions of pure correctness
+work, or escalate the complexity gap to a separate initiative.

--- a/research/problems/binary-gcd-oq-03-oq-02/state.md
+++ b/research/problems/binary-gcd-oq-03-oq-02/state.md
@@ -1,24 +1,28 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-04-26T08:56:57.650Z
-**Iteration**: 1
+**Phase**: ORIENT
+**Since**: 2026-04-28
+**Iteration**: 2
 
 ## Current Focus
 
-Initial exploration of the problem.
+Decide scope of formalization: correctness-only (recommended) vs correctness-plus-complexity (deferred). See knowledge.md "Research strategy (recommended)" for the split.
 
 ## Active Approach
 
-None yet.
+Session 1 survey recommendation: pursue **correctness-only** formalization of `hgcdMatrix : ℕ → ℕ → CofactorMatrix` in a new `BinaryGcdOQ03OQ02.lean`, reusing the cofactor-matrix machinery already verified in `BinaryGcdOQ03.lean`. Defer the O(M(n)·log n) complexity claim until Mathlib has a bit-complexity model and fast multiplication.
 
 ## Blockers
 
-None.
+- **Complexity claim only**: O(M(n)·log n) is currently unfalsifiable in Lean. Mathlib has no bit-complexity model for arithmetic operations and no fast multiplication (Karatsuba / Toom-Cook / FFT). Filling these gaps is a multi-thousand-line foundational project that should not be attempted as part of an HGCD formalization.
+
+No blocker on the correctness side; all needed cofactor-matrix machinery exists.
 
 ## Next Action
 
-Begin problem exploration.
+1. Confirm scope decision (correctness-only).
+2. Draft `hgcdMatrix` definition + termination measure (`bitsize a + bitsize b`).
+3. State and prove the size-reduction lemma: applying `hgcdMatrix(a,b)` to `(a,b)` yields `(a',b')` with `bitsize(max a' b') ≤ bitsize(max a b)/2 + O(1)`. This is the only genuinely new mathematical content vs. the existing Lehmer formalization.
 
 ## Attempt Counts
 

--- a/src/data/research/problems/binary-gcd-oq-03-oq-02.json
+++ b/src/data/research/problems/binary-gcd-oq-03-oq-02.json
@@ -1,7 +1,7 @@
 {
   "slug": "binary-gcd-oq-03-oq-02",
   "title": "Can Schönhage's recursive HGCD (half-GCD) be formalized, achieving O(M(n) log...",
-  "phase": "NEW",
+  "phase": "ORIENT",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -16,12 +16,14 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ORIENT",
     "since": "2026-04-26T08:56:57.650Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
-    "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "iteration": 2,
+    "focus": "Decide scope: correctness-only HGCD formalization, or include complexity claim (deferred).",
+    "blockers": [
+      "Complexity bound O(M(n) log n) is unfalsifiable in current Mathlib: no bit-complexity model for arithmetic, no fast multiplication."
+    ],
+    "nextAction": "Confirm scope decision. If correctness-only: draft hgcdMatrix definition and termination measure in BinaryGcdOQ03OQ02.lean.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,11 +31,29 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
+    "progressSummary": "SURVEYED (Session 1, 2026-04-28): identified that the question splits into (A) HGCD correctness (tractable, all needed matrix machinery exists in BinaryGcdOQ03.lean) and (B) O(M(n) log n) complexity (blocked on Mathlib gaps: no fast multiplication, no bit-complexity model). Recommendation: pursue (A) only; defer (B) to a separate Mathlib-contribution initiative.",
     "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": []
+    "insights": [
+      "All 2x2 cofactor matrix invariants needed for HGCD correctness already exist in BinaryGcdOQ03.lean (gcd_cofactor_eq, lehmerCofactors_det_unit, cofactor_apply_gcd). The HGCD formalization is the recursive wiring of these.",
+      "The original question conflates two distinct claims: (A) HGCD algorithmic correctness (tractable, ~300-500 lines) and (B) O(M(n) log n) bit complexity (blocked on multiple Mathlib gaps).",
+      "Mathlib has no half-GCD, Schoenhage, Karatsuba, or any fast multiplication; grep against Mathlib confirmed (2026-04-28). Mathlib Computability has Turing/primrec but no bit-complexity model for arithmetic.",
+      "The complexity bound O(M(n) log n) is currently unfalsifiable in Lean: no model in which to state \"M(n) bit operations\". Proving (B) requires upstreaming a bit-complexity framework + fast multiplication first (multi-thousand-line project).",
+      "The single hardest piece on the correctness side is termination of the HGCD recursion: need bitsize(max a b) strict decrease after applying the recursively-computed matrix, which requires showing the matrix accumulated >=1 Euclidean step.",
+      "Recommendation: split the question. Pursue (A) HGCD correctness as a self-contained verification; defer (B) until a complexity model lands in Mathlib or as a separate gallery initiative."
+    ],
+    "mathlibGaps": [
+      "Half-GCD / HGCD: no formalization in Mathlib or this gallery (verified by grep 2026-04-28).",
+      "Fast multiplication algorithms: Mathlib has no Karatsuba, Toom-Cook, or Schoenhage-Strassen FFT-based multiplication (verified 2026-04-28).",
+      "Bit-complexity model for arithmetic operations: Mathlib has Turing/primrec/partrec but nothing that lets you state \"M(n) bit operations to multiply n-bit integers\". Required to formulate the O(M(n) log n) complexity claim.",
+      "Big-integer abstraction: Mathlib operates on Nat/Int as opaque algebraic structures; there is no big-integer-as-array-of-words representation that would let bit-complexity reasoning attach to actual arithmetic primitives."
+    ],
+    "nextSteps": [
+      "Decide scope: correctness-only (recommended, ~300-500 lines) vs correctness-plus-complexity (deferred, multi-thousand lines of foundational work).",
+      "If correctness-only: define hgcdMatrix : Nat -> Nat -> CofactorMatrix recursively in a new BinaryGcdOQ03OQ02.lean, with termination measure bitsize a + bitsize b; reuse cofactor_apply_gcd for the GCD invariance.",
+      "Prove the size-reduction lemma: applying hgcdMatrix(a,b) yields (a',b') with bitsize(max a' b') roughly bitsize(max a b)/2. This is the only genuinely new mathematical content vs the existing Lehmer formalization.",
+      "If complexity-in-scope: escalate to Architect or Hermit role - this becomes a separate Mathlib-contribution-class initiative (bit-complexity model + Karatsuba upstream).",
+      "Update problem statement: replace placeholder formal-statement-to-be-added with a concrete Lean-style spec, e.g. correctness: hgcdMatrix a b applied to (a,b) preserves Nat.gcd a b."
+    ]
   },
   "tags": [
     "challenging",
@@ -52,7 +72,7 @@
     "mathlib": []
   },
   "started": "2026-04-26T08:56:57.650Z",
-  "lastUpdate": "2026-04-26T08:56:57.650Z",
+  "lastUpdate": "2026-04-28T00:00:00.000Z",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [


### PR DESCRIPTION
## Summary

Session-1 survey on `binary-gcd-oq-03-oq-02` ("Schönhage's recursive HGCD"). Identifies that the question conflates two claims with very different tractability:

- **(A) HGCD correctness** — tractable, ~300–500 lines of Lean. All cofactor-matrix machinery (`gcd_cofactor_eq`, `lehmerCofactors_det_unit`, `cofactor_apply_gcd`) already exists in `BinaryGcdOQ03.lean`. The only new content is the size-reduction lemma.
- **(B) O(M(n)·log n) complexity** — currently unfalsifiable in Lean. Mathlib has no bit-complexity model for arithmetic, no fast multiplication, no big-integer abstraction. Verified by grep 2026-04-28.

**Recommendation**: pursue (A) as a self-contained verification; defer (B) to a separate gallery initiative.

## Changes

- `src/data/research/problems/binary-gcd-oq-03-oq-02.json`: phase NEW → ORIENT; populated 6 insights, 4 mathlibGaps, 5 nextSteps, progressSummary.
- `research/problems/binary-gcd-oq-03-oq-02/knowledge.md`: new — Session-1 survey + recommended research strategy.
- `research/problems/binary-gcd-oq-03-oq-02/state.md`: synced to ORIENT.

No code changes, no proof attempts. Pure orient-phase scoping.

## Test plan

- [x] JSON schema check — `jq` passes; required `knowledge.*` fields populated.
- [x] No Lean files modified — no Docker build needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)