### PR TITLE
fix(meta): erdos-868 section startLine/endLine drift

### DIFF
--- a/src/data/proofs/erdos-868/meta.json
+++ b/src/data/proofs/erdos-868/meta.json
@@ -118,31 +118,31 @@
       "id": "open-questions",
       "title": "The Main Open Questions",
       "startLine": 91,
-      "endLine": 122,
+      "endLine": 113,
       "summary": "Parts (i) and (ii) of Erdős Problem #868 - the unsolved cases.",
       "mathContext": "Mathematical content: Parts (i) and (ii) of Erdős Problem #868 - the unsolved cases."
     },
     {
       "id": "known-results",
       "title": "Known Results",
-      "startLine": 123,
-      "endLine": 187,
+      "startLine": 114,
+      "endLine": 167,
       "summary": "Erdős-Nathanson 1979 and 1989 axioms; Härtter-Nathanson result discussed in a commentary docstring only (not declared).",
       "mathContext": "Axiomatized: erdos_nathanson_1979 (line 126) and erdos_nathanson_1989 (line 149). Härtter-Nathanson result appears only in a docstring at line 135 with no declaration attached."
     },
     {
       "id": "examples",
       "title": "Examples and Structure",
-      "startLine": 188,
-      "endLine": 228,
+      "startLine": 168,
+      "endLine": 231,
       "summary": "Basic examples and the essential element theorem for minimal bases.",
       "mathContext": "Verified: Basic examples and the essential element theorem for minimal bases."
     },
     {
       "id": "summary",
       "title": "Summary",
-      "startLine": 229,
-      "endLine": 256,
+      "startLine": 232,
+      "endLine": 258,
       "summary": "Package of main results showing the gap between known conditions.",
       "mathContext": "Mathematical content: Package of main results showing the gap between known conditions."
     }


### PR DESCRIPTION
## Fix

Corrects 4 drifted section boundaries in `erdos-868/meta.json` to match the actual Lean source file structure (`Erdos868Problem.lean`, 258 lines).

## Evidence

| Section | Field | Was | Now | Why |
|---------|-------|-----|-----|-----|
| open-questions | endLine | 122 | 113 | Part ii docstring ends at line 113; lines 114–122 belong to Known Results |
| known-results | startLine | 123 | 114 | Known Results `/-` block opens at line 114 |
| known-results | endLine | 187 | 167 | "The Gap" section ends at line 167; lines 168–187 are Examples content |
| examples | startLine | 188 | 168 | Examples `/-` block opens at line 168 |
| examples | endLine | 228 | 231 | `minimal_basis_essential` body ends at line 230; line 231 is the trailing blank |
| summary | startLine | 229 | 232 | Summary `/-` opens at line 232; lines 229–231 are inside `minimal_basis_essential` |
| summary | endLine | 256 | 258 | File ends at line 258 (`end Erdos868`) |

Discovered during tracker review (auditor-cycle-20-batch flagged erdos-868 as `issues-found` on 2026-04-28 but did not file a GitHub issue).

---
Automated fix by lean-mechanic agent.