### PR TITLE
audit(erdos-855): correct phantom-axiom narrative + section line drift

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9602,9 +9602,9 @@
       "result": "issues-fixed"
     },
     "erdos-855": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
+      "agentId": "auditor-agent",
+      "auditCount": 3,
+      "lastAudited": "2026-04-28T20:00:00Z",
       "result": "issues-fixed"
     },
     "erdos-856": {

--- a/src/data/proofs/erdos-855/meta.json
+++ b/src/data/proofs/erdos-855/meta.json
@@ -44,15 +44,15 @@
     ],
     "originalContributions": [
       "primePi definition: prime counting function",
+      "primePi_monotone theorem: prime counting is monotone",
       "SecondHardyLittlewoodConjecture formulation",
       "IsAdmissibleTuple definition: admissible k-tuples",
       "PrimeKTuplesConjecture formulation",
       "hensley_richards_incompatibility axiom: key result",
-      "hensley_richards_quantitative: error term",
-      "dense_admissible_tuples_exist axiom",
-      "montgomery_vaughan_bound axiom",
+      "primePi_add_ge theorem: trivial lower bound \u03c0(x+y) \u2265 \u03c0(x)",
       "StrausConjecture and ErdosWeakerConjecture formulations",
-      "erdos_855_summary theorem"
+      "straus_also_incompatible axiom: extends Hensley-Richards to Straus's modification",
+      "erdos_855 theorem: combines both incompatibility axioms"
     ],
     "axiomCount": 2,
     "lineCount": 172,
@@ -79,43 +79,50 @@
     {
       "id": "prime-counting",
       "title": "The Prime Counting Function",
-      "summary": "primePi definition, primePi_monotone, prime number theorem",
+      "summary": "primePi definition and primePi_monotone theorem; prime number theorem mentioned in an orphan docstring (not formally stated).",
       "startLine": 33,
-      "endLine": 57
+      "endLine": 54
     },
     {
       "id": "second-hl",
       "title": "The Second Hardy-Littlewood Conjecture",
       "summary": "SecondHardyLittlewoodConjecture definition",
-      "startLine": 58,
-      "endLine": 72
+      "startLine": 55,
+      "endLine": 67
     },
     {
       "id": "k-tuples",
       "title": "The Prime k-Tuples Conjecture",
       "summary": "IsAdmissibleTuple, PrimeKTuplesConjecture definitions",
-      "startLine": 73,
-      "endLine": 94
+      "startLine": 68,
+      "endLine": 87
     },
     {
       "id": "hensley-richards",
       "title": "Hensley-Richards Incompatibility",
-      "summary": "hensley_richards_incompatibility, quantitative version, dense tuples",
-      "startLine": 95,
-      "endLine": 132
+      "summary": "hensley_richards_incompatibility axiom; the quantitative version and reason for incompatibility appear as orphan docstrings only (not separately axiomatized).",
+      "startLine": 88,
+      "endLine": 113
     },
     {
       "id": "unconditional",
       "title": "Unconditional Results",
-      "summary": "montgomery_vaughan_bound, primePi_add_ge theorem",
-      "startLine": 133,
-      "endLine": 154
+      "summary": "primePi_add_ge theorem (trivial lower bound \u03c0(x+y) \u2265 \u03c0(x)). The Montgomery-Vaughan bound is mentioned in an orphan docstring (not formalized).",
+      "startLine": 114,
+      "endLine": 130
     },
     {
       "id": "related",
       "title": "Related Conjectures",
-      "summary": "StrausConjecture, ErdosWeakerConjecture definitions",
-      "startLine": 155,
+      "summary": "StrausConjecture and ErdosWeakerConjecture definitions; straus_also_incompatible axiom (k-tuples \u2192 \u00acStrausConjecture).",
+      "startLine": 131,
+      "endLine": 155
+    },
+    {
+      "id": "main-results",
+      "title": "Main Results",
+      "summary": "erdos_855 theorem combining hensley_richards_incompatibility and straus_also_incompatible axioms.",
+      "startLine": 156,
       "endLine": 172
     }
   ],


### PR DESCRIPTION
## Summary

Gallery integrity audit of erdos-855 (Second Hardy-Littlewood Conjecture) found phantom-axiom narrative claims and section line drift consistent with the [erdos-9XX/8XX phantom-axiom pattern](https://github.com/rjwalters/lean-genius/issues?q=phantom-axiom). 24th confirmed instance.

### Phantom claims in `originalContributions`
- `hensley_richards_quantitative: error term` — orphan docstring at lines 102-106; no declaration
- `dense_admissible_tuples_exist axiom` — no such axiom; only docstring at 107-113 ("Reason for Incompatibility")
- `montgomery_vaughan_bound axiom` — orphan docstring at lines 116-122; no declaration
- `erdos_855_summary theorem` — name mismatch; real theorem is `erdos_855`

### Real declarations missing from narrative
- `straus_also_incompatible` axiom (line 143) — real, but not listed
- `primePi_monotone` theorem (line 46) — real, but not listed
- `primePi_add_ge` theorem (line 127) — real, but not listed

### Section line drift
The Lean file has 7 `Part I-VII` blocks but meta listed only 6 sections, with boundaries misaligned with the part comments:
- `primePi_add_ge` (line 127) fell inside `hensley-richards` (95-132) instead of `unconditional`
- Part VII (Main Results / `erdos_855` theorem at line 165) had no section

Realigned section ranges to Part I-VII comment boundaries and added a `main-results` section.

### Numerical fields verified clean
- axiomCount: 2 ✓ (`hensley_richards_incompatibility`, `straus_also_incompatible`)
- sorries: 0 ✓
- lineCount: 172 ✓
- theoremCount: 3 ✓ (`primePi_monotone`, `primePi_add_ge`, `erdos_855`)
- definitionCount: 6 ✓

## Test plan

- [x] `jq .` validates `meta.json`
- [x] All section line ranges form a non-overlapping partition of 33-172
- [x] Every name in `originalContributions` is verified to exist in `proofs/Proofs/Erdos855Problem.lean`
- [x] Audit tracker updated: `auditCount` 2 → 3, `result` issues-fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)