### PR TITLE
audit(erdos-86): clean re-audit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9635,10 +9635,10 @@
       "result": "issues-fixed"
     },
     "erdos-86": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-28T18:04:39Z",
+      "result": "clean"
     },
     "erdos-860": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Re-audited `erdos-86` (C₄-Free Subgraphs of Hypercubes — $100 open problem). Verified meta.json claims match Lean source.

## Verification

- **Axioms**: 2 (`bhn_lower_bound`, `baber_upper_bound`) ✓ matches `axiomCount: 2`
- **Sorries**: 0 ✓ matches `sorries: 0`
- **Theorems**: 4 (`hypercube_vertex_count`, `f_bounds_summary`, `erdos86_open`, `conjecture_implies_limit`) ✓
- **Definitions**: 9 ✓
- **Line count**: 186 ✓
- **No True stubs**, **no phantom-axiom narrative**
- **Status `axiomatized`** correctly applied (open problem with 2 explicit axioms)
- **Narrative honesty**: `proofStrategy` and `known-bounds` section explicitly distinguish axiomatized bounds (BHN lower, Baber upper) from docstring-only Erdős 1991 bound

## Test plan

- [x] `grep -c '^axiom '` returns 2
- [x] `grep -cE '(^| )sorry( |$)'` returns 0
- [x] meta.json `status: axiomatized`, `badge: axiom` consistent with axiom presence
- [x] No `originalContributions` overclaim

🤖 Generated with [Claude Code](https://claude.com/claude-code)