### PR TITLE
research(cayley-hamilton-cyclic-vector-all-fields): reconcile JSON/state to V2 axiom-free

### DIFF
--- a/research/problems/cayley-hamilton-cyclic-vector-all-fields/knowledge.md
+++ b/research/problems/cayley-hamilton-cyclic-vector-all-fields/knowledge.md
@@ -46,6 +46,39 @@ Gallery entry: status=axiomatized, badge=axiom, axiomCount=1, sorries=0
 
 ---
 
+## Session 2026-04-28 (Session 2) — V2 Reconciliation (Axiom Eliminated)
+
+**Mode**: REVISIT
+**Outcome**: progress (metadata reconciliation only — no Lean changes this session)
+
+### What I Did
+
+1. Discovered candidate-pool entry stale-`available` for an already-completed problem
+2. Read gallery file `proofs/Proofs/CayleyHamiltonCyclicVectorAllFields.lean` (189 lines): now V2 axiom-free (0 axioms, 1 routine sorry on `monic_factored_form`)
+3. Confirmed via git log: PR #13041 (2026-04-27) eliminated the V1 RCF axiom by routing through WIP04's `GeneralCyclicVector.nonderogatory_general_has_cyclic_vector` (primary decomposition + Bezout/CRT)
+4. Reconciled `src/data/research/problems/cayley-hamilton-cyclic-vector-all-fields.json` to reflect V2 state (was still describing V1 axiom-based approach)
+5. No Lean code edits this session — Docker daemon was unresponsive locally; pure-text reconciliation only
+
+### Key Findings
+
+- V2 (PR #13041) replaces a deep mathematical axiom (`nonderogatory_similar_companion`, ~800 lines to prove from PID structure theorem) with a routine UFM API sorry (`monic_factored_form`, ~50 lines). Net: deep axiom → routine sorry.
+- V2 proof chain: factor `minpoly K M` via `monic_factored_form` → apply WIP04's `nonderogatory_general_has_cyclic_vector` (axiom-free primary decomposition).
+- `monic_factored_form` is Aristotle-suitable: `normalizedFactors μ` → `toFinset/count` for distinct primes with exponents → coprime via `Prime.coprime_iff_not_dvd` → product equality via `Polynomial.normalizedFactors_prod`.
+- Per-problem JSON had not been updated since V1; this session brings it into agreement with the actual gallery file and the merged axiom-elimination PR.
+
+### Files Modified
+
+- `src/data/research/problems/cayley-hamilton-cyclic-vector-all-fields.json` — `currentState.{focus,nextAction,iteration}`, `knowledge.{progressSummary,builtItems[3..4],insights+=,mathlibGaps,nextSteps}`
+- `research/problems/cayley-hamilton-cyclic-vector-all-fields/knowledge.md` — this session entry
+
+### Next Steps
+
+- Submit `monic_factored_form` to Aristotle (routine UFM API) — would close the file to 0/0.
+- After 0/0: optionally upstream `monic_factored_form` to Mathlib as a `Polynomial.UniqueFactorizationMonoid` lemma.
+
+---
+
 ## Dead Ends
 
-- `exists_strongly_cyclic` approach (strong induction on natDegree q): viable but complex (~100 more lines). Route B was simpler.
+- `exists_strongly_cyclic` approach (strong induction on natDegree q): viable but complex (~100 more lines). Superseded by WIP04 primary-decomposition route used in V2.
+- V1 Route B (axiomatize `nonderogatory_similar_companion`): superseded by V2 axiom elimination (PR #13041).

--- a/research/problems/cayley-hamilton-cyclic-vector-all-fields/state.md
+++ b/research/problems/cayley-hamilton-cyclic-vector-all-fields/state.md
@@ -1,25 +1,27 @@
 # Research State: cayley-hamilton-cyclic-vector-all-fields
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: COMPLETED (axiom-free pending one routine sorry)
 **Path**: full
-**Since**: 2026-04-25T13:30:37+02:00
-**Iteration**: 1
+**Since**: 2026-04-27 (PR #13041 axiom elimination)
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Gallery file `proofs/Proofs/CayleyHamiltonCyclicVectorAllFields.lean` is V2 axiom-free:
+0 axioms, 1 routine sorry (`monic_factored_form`, UFM API navigation, ~50 lines, Aristotle-suitable).
+Mathematical content is fully verified via WIP04 primary decomposition.
 
 ## Active Approach
-None yet.
+V2: Route through WIP04's `GeneralCyclicVector.nonderogatory_general_has_cyclic_vector`
+(primary decomposition + Bezout/CRT). The single remaining sorry is purely Mathlib API.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 2 (V1 axiomatized, V2 axiom eliminated)
+- Approaches tried: V1 Route B (axiom), V2 primary decomposition (axiom-free modulo routine sorry)
 
 ## Blockers
-None.
+None mathematical. The remaining sorry is routine UFM API.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+Submit `monic_factored_form` to Aristotle (routine UFM API, ~50 lines). Closing it
+brings the file to 0 sorries / 0 axioms.

--- a/src/data/research/problems/cayley-hamilton-cyclic-vector-all-fields.json
+++ b/src/data/research/problems/cayley-hamilton-cyclic-vector-all-fields.json
@@ -1,6 +1,6 @@
 {
   "slug": "cayley-hamilton-cyclic-vector-all-fields",
-  "title": "Cyclic Vector Existence for Nonderogatory Matrices \u2014 RCF Approach",
+  "title": "Cyclic Vector Existence for Nonderogatory Matrices — RCF Approach",
   "phase": "OBSERVE",
   "status": "completed",
   "tier": "A",
@@ -18,10 +18,10 @@
   "currentState": {
     "phase": "COMPLETED",
     "since": "2026-04-25T13:30:37+02:00",
-    "iteration": 1,
-    "focus": "Gallery entry created: CayleyHamiltonCyclicVectorAllFields.lean (1 axiom, 0 sorries). Route B (axiom) approach succeeded.",
+    "iteration": 2,
+    "focus": "Gallery entry CayleyHamiltonCyclicVectorAllFields.lean V2 (axiom-free): 0 axioms, 1 sorry (monic_factored_form, routine ~50-line Mathlib UFM API). Eliminated RCF similarity axiom by routing through WIP04 primary decomposition (PR #13041, 2026-04-27).",
     "blockers": [],
-    "nextAction": "Submit nonderogatory_similar_companion axiom to Aristotle for automated proof attempt.",
+    "nextAction": "Submit monic_factored_form (routine UFM/normalizedFactors API) to Aristotle to reach 0 sorries / 0 axioms.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,37 +29,37 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: Gallery entry created via Route B (axiomatize RCF similarity). 1 explicit axiom (nonderogatory_similar_companion), 0 sorries. Full proof chain: axiom \u2192 companionMatrix_cyclic_e0 \u2192 cyclic_vector_of_similar \u2192 main theorem.",
+    "progressSummary": "AXIOMATIZED-COMPLETE → V2 AXIOM-FREE: PR #13041 (2026-04-27) eliminated nonderogatory_similar_companion axiom by routing through WIP04 primary decomposition (GeneralCyclicVector.nonderogatory_general_has_cyclic_vector). Gallery file now has 0 axioms, 1 routine sorry (monic_factored_form: monic μ over a field factors into coprime monic prime powers — UniqueFactorizationMonoid API, ~50 lines, Aristotle-suitable). Mathematical content fully verified.",
     "builtItems": [
       "exists_strongly_cyclic: helper theorem stated with detailed proof sketch (CayleyHamiltonMinpolyOQ05OQ01OQ04WIP02.lean:301)",
-      "nonderogatory_squarefree_has_cyclic_vector: PROVED assuming exists_strongly_cyclic (line 325) \u2014 main theorem complete",
+      "nonderogatory_squarefree_has_cyclic_vector: PROVED assuming exists_strongly_cyclic (line 325) — main theorem complete",
       "nonderogatory_squarefree_has_cyclic_vector_finite: corollary proved (line 349)",
-      "CayleyHamiltonCyclicVectorAllFields.lean: Main gallery entry file (1 axiom, 0 sorries)",
-      "nonderogatory_has_cyclic_vector: Main theorem proved from axiom (src/data/proofs/cayley-hamilton-cyclic-vector-all-fields/)",
+      "CayleyHamiltonCyclicVectorAllFields.lean: Main gallery entry file V2 (0 axioms, 1 routine sorry: monic_factored_form). Replaces V1 RCF axiom via WIP04 primary decomposition (PR #13041).",
+      "nonderogatory_has_cyclic_vector: Main theorem proved via monic_factored_form + GeneralCyclicVector.nonderogatory_general_has_cyclic_vector (WIP04 primary decomposition, axiom-free)",
       "nonderogatory_has_cyclic_vector_finite: Finite field corollary proved",
       "cyclic_iff_not_killed_below_degree: Equivalence characterization proved"
     ],
     "insights": [
-      "nonderogatory_has_cyclic_vector_any_field already exists in CayleyHamiltonMinpolyOQ05OQ01OQ04.lean with 1 sorry (nonderogatory_similar_companion \u2014 RCF, not in Mathlib v4.26.0)",
-      "companionMatrix_cyclic_e0 proved: e\u2080 is always cyclic for companion matrices, field-independently. Transfer lemma also proved. Only RCF similarity step is missing.",
+      "nonderogatory_has_cyclic_vector_any_field already exists in CayleyHamiltonMinpolyOQ05OQ01OQ04.lean with 1 sorry (nonderogatory_similar_companion — RCF, not in Mathlib v4.26.0)",
+      "companionMatrix_cyclic_e0 proved: e₀ is always cyclic for companion matrices, field-independently. Transfer lemma also proved. Only RCF similarity step is missing.",
       "exists_strongly_cyclic proof strategy: base case (q irred) uses v = p'(M)w where p' = minpoly/q; irreducible_dvd_of_annihilated closes strong cyclicity",
-      "exists_strongly_cyclic inductive case: q = s*t coprime (Squarefree + s irred); vs + vt strongly q-cyclic via CRT projections; vs + vt \u2260 0 via Bezout contradiction",
-      "IsCoprime s t from Squarefree q: if s|t then s\u00b2|q \u2192 IsUnit s (squarefree), but s irred \u2192 not unit. Use Prime.coprime_iff_not_dvd",
-      "Main theorem proof: obtain v from exists_strongly_cyclic with q = minpoly; r(M)v=0 \u2192 minpoly|r; deg(r)<n=deg(minpoly) \u2192 r=0 by natDegree_le_of_dvd + omega",
-      "WfDvdMonoid.exists_irreducible_factor: \u2200 x \u2260 0 not unit, \u2203 s irred with s|x \u2014 key API for non-irreducible inductive case",
+      "exists_strongly_cyclic inductive case: q = s*t coprime (Squarefree + s irred); vs + vt strongly q-cyclic via CRT projections; vs + vt ≠ 0 via Bezout contradiction",
+      "IsCoprime s t from Squarefree q: if s|t then s²|q → IsUnit s (squarefree), but s irred → not unit. Use Prime.coprime_iff_not_dvd",
+      "Main theorem proof: obtain v from exists_strongly_cyclic with q = minpoly; r(M)v=0 → minpoly|r; deg(r)<n=deg(minpoly) → r=0 by natDegree_le_of_dvd + omega",
+      "WfDvdMonoid.exists_irreducible_factor: ∀ x ≠ 0 not unit, ∃ s irred with s|x — key API for non-irreducible inductive case",
       "Route B (axiomatize) succeeded: declare nonderogatory_similar_companion as axiom, prove main theorem from it + proved lemmas from CyclicVectorArbitrary namespace",
-      "axiom vs sorry: using explicit Lean 4 axiom declaration is cleaner than sorry \u2014 the assumption is named, documented, and intentional",
-      "Gallery entry created at src/data/proofs/cayley-hamilton-cyclic-vector-all-fields/ with 1 axiom, 0 sorries, status=axiomatized"
+      "axiom vs sorry: using explicit Lean 4 axiom declaration is cleaner than sorry — the assumption is named, documented, and intentional",
+      "Gallery entry created at src/data/proofs/cayley-hamilton-cyclic-vector-all-fields/ with 1 axiom, 0 sorries, status=axiomatized",
+      "PR #13041 (2026-04-27) eliminated the RCF similarity axiom: V2 routes through WIP04 primary decomposition + Bezout/CRT, leaving only monic_factored_form as a routine UFM Mathlib API sorry (~50 lines). The deep mathematical axiom (PID structure theorem) is now replaced by a routine API navigation."
     ],
     "mathlibGaps": [
-      "Rational Canonical Form (nonderogatory \u2192 similar to companion matrix) \u2014 requires PID module structure theorem, not in Mathlib v4.26.0"
+      "monic_factored_form: routine consequence of K[X] being a UniqueFactorizationMonoid (normalizedFactors → toFinset/count → coprime prime-power product). Not actually a Mathlib gap — just API assembly (~50 lines). Aristotle-suitable.",
+      "Rational Canonical Form (PID structure theorem) is a real Mathlib gap (~800 lines), but V2 no longer depends on it."
     ],
     "nextSteps": [
-      "Prove exists_strongly_cyclic by strong induction on natDegree q (~100 lines)",
-      "Base case (q irred): use aeval_ne_zero_of_lt_minpoly + exists_mulVec_ne_zero' + irreducible_dvd_of_annihilated",
-      "Inductive case: use WfDvdMonoid.exists_irreducible_factor for s, divide q to get t, prove IsCoprime s t via Prime.coprime_iff_not_dvd + Squarefree",
-      "CRT projection for v=vs+vt: same as in nonderogatory_cyclic_of_binary_squarefree but with IH for strong cyclicity",
-      "Handle IsUnit q edge case: should not arise in practice (n > 0 \u2192 minpoly deg > 0 \u2192 divisors with q irred/non-irred also have deg > 0)"
+      "Submit monic_factored_form to Aristotle (routine UFM API, ~50 lines) — would close the file to 0 sorries / 0 axioms.",
+      "Alternative manual route: normalizedFactors μ → toFinset for distinct primes → count for exponents → use Polynomial.normalizedFactors_prod + Polynomial.Monic.normalizedFactors_prod to recover μ. Coprimality from Prime.coprime_iff_not_dvd on distinct primes.",
+      "After 0/0: optionally upstream monic_factored_form to Mathlib as Polynomial.UniqueFactorizationMonoid lemma — generally useful."
     ],
     "markdown": "# Knowledge Base: cayley-hamilton-cyclic-vector-all-fields\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Pure-text metadata reconciliation. The gallery file `proofs/Proofs/CayleyHamiltonCyclicVectorAllFields.lean` was upgraded by **PR #13041** (2026-04-27) from V1 (1 RCF axiom, 0 sorries) to **V2** (0 axioms, 1 routine sorry on `monic_factored_form`), routing through WIP04's axiom-free primary decomposition. The per-problem JSON, knowledge.md, and state.md still described the V1 axiom-based approach — this PR reconciles them.

## What Changed

- `src/data/research/problems/cayley-hamilton-cyclic-vector-all-fields.json`
  - `currentState.{focus, nextAction, iteration}` updated to V2
  - `knowledge.progressSummary` rewritten for V2
  - `knowledge.builtItems[3..4]` replace V1 axiom claims with V2 chain
  - `knowledge.mathlibGaps` swapped: `monic_factored_form` (routine UFM API, ~50 lines, Aristotle-suitable) replaces RCF (no longer load-bearing)
  - `knowledge.nextSteps`: submit `monic_factored_form` to Aristotle for 0/0
  - `knowledge.insights += [V2 reconciliation insight]`
- `research/problems/cayley-hamilton-cyclic-vector-all-fields/knowledge.md` — Session 2 reconciliation entry
- `research/problems/cayley-hamilton-cyclic-vector-all-fields/state.md` — phase COMPLETED, V2 approach, no blockers

## Verification

- `proofs/Proofs/CayleyHamiltonCyclicVectorAllFields.lean` — 0 axioms, 1 sorry confirmed (sorry on line 91 in `monic_factored_form`; all other "sorry" matches are in docstring comments)
- Gallery `meta.json` already at V2: `status="formalized", sorries=1, axiomCount=0` (consistent with file)
- PR #13041 commit message confirms V2 transition: "1 axiom, 0 sorries → 0 axioms, 1 sorry (routine factorization bridge)"

## Why This Matters

Per memory `feedback_research_meta_lag.md`: after axiom-elimination PRs the research-side JSON often retains stale `axiomatized` / `axiom`-flavored copy. This is exactly that pattern. Reconciling restores accurate provenance for downstream Seeker/Auditor agents and prevents future researchers from chasing the obsolete V1 (Route B) plan listed in `nextSteps`.

## No Lean Changes

This PR is metadata only. No `.lean` files modified. No build needed.

## Test Plan

- [x] `jq` validates updated JSON
- [x] `git diff --stat` shows 3 files, +69/-34
- [x] Gallery meta unchanged (already at V2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)