### PR TITLE
research: ballot-problem-oq-01-oq-04 — eliminate chung_feller_uniform axiom

### DIFF
--- a/proofs/Proofs/BallotProblemOQ01OQ04.lean
+++ b/proofs/Proofs/BallotProblemOQ01OQ04.lean
@@ -7,32 +7,38 @@ The Chung-Feller theorem states that the number of lattice paths from (0,0)
 to (2n,0) with steps +1 and -1, having exactly k upsteps above the x-axis,
 equals C(2n,n)/(n+1) = Cₙ (the nth Catalan number), independent of k.
 
+## Proof Architecture
+
+The full proof is composed of three files:
+
+- `BallotProblemOQ01OQ04Core.lean` — definitions and the cycle-lemma bridge
+  (`IsBalancedPath`, `prepend_one_good_rotation`, `balanced_path_total`,
+  `balancedPathsOfType`, etc.)
+- `BallotProblemOQ01OQ04OQ01.lean` — the explicit bijection
+  `chungFellerMap` from balanced paths to (Dyck paths) × (Fin (n+1)),
+  proving `chung_feller_bijection_exists` and `chung_feller_uniform'`
+  with 0 sorries and 0 axiom uses.
+- This file — the gallery face, re-exporting the uniform-distribution
+  theorem under its conventional name `chung_feller_uniform` and the
+  per-type Catalan-number count.
+
 ## Proof Strategy
 
 1. A lattice path from (0,0) to (2n,0) has n upsteps (+1) and n downsteps (-1).
 2. Prepend +1 to get a sequence of length 2n+1 with sum 1.
 3. By the cycle lemma (proved in BallotProblemOQ01.lean), exactly 1 of the
    2n+1 cyclic rotations has all partial sums positive.
-4. This creates a (2n+1)-to-1 map from rotation orbits to balanced paths,
-   uniformly distributed over n+1 types, yielding C(2n,n)/(n+1) per type.
+4. Mapping each balanced path l to (Dyck-tail of its good rotation,
+   upstepsAboveAxis l) is a bijection between balanced paths of length 2n
+   and (Dyck paths) × (Fin (n+1)). This forces uniform distribution across
+   types.
 
-## Infrastructure
+## Status
 
-- cycle_lemma: proved in BallotProblemOQ01.lean (Dvoretzky-Motzkin 1947)
-- Cn (Catalan number): defined in BallotProblemOQ03.lean
-- catalan_formula: Cn n * (n+1) = C(2n,n), proved in BallotProblemOQ03.lean
-
-## Proved in This File
-
-- balanced_length, balanced_sum_zero: basic properties of balanced paths
-- prepend_mem_kCountedSequence: key connection to the cycle lemma
-- prepend_one_good_rotation: exactly 1 good rotation (from cycle lemma)
-- prepend_unique_good_rotation: the good rotation is unique
-- balanced_path_total: C(2n,n) = Cₙ × (n+1)
-
-Axiom count: 1 (chung_feller_uniform — the bijection between rotation classes
-and path types, requiring explicit tracking of how rotations change upstep counts)
-Sorry count: 0
+- 0 axioms, 0 sorries.
+- The previously stated `axiom chung_feller_uniform` is now proved by
+  re-export of `ChungFellerBijection.chung_feller_uniform'`, which itself
+  was proved with no axiom uses.
 
 ## References
 
@@ -40,170 +46,28 @@ Sorry count: 0
 - Dvoretzky, A. and Motzkin, Th. (1947). A problem of arrangements.
 -/
 
-import Proofs.BallotProblemOQ01
-import Proofs.BallotProblemOQ03
+import Proofs.BallotProblemOQ01OQ04OQ01
 
 namespace ChungFeller
 
-open GeneralizedBallot LatticePathLGV
+open ChungFellerBijection
 
-/- ## Part I: Balanced Paths -/
+/-- **Chung-Feller Theorem (uniform distribution)**.
 
-/-- A balanced lattice path: a list of n ones and n negative-ones. -/
-def IsBalancedPath (l : List ℤ) (n : ℕ) : Prop :=
-  l.count 1 = n ∧ l.count (-1 : ℤ) = n ∧ (∀ x ∈ l, x = 1 ∨ x = (-1 : ℤ))
+    For each pair `j, k ∈ {0, 1, …, n}`, the number of balanced paths from
+    `(0,0)` to `(2n,0)` with exactly `j` upsteps above the x-axis equals
+    the number with exactly `k` upsteps above the x-axis — i.e. the
+    distribution is uniform across the `n+1` types.
 
-/-- A balanced path has length 2n. -/
-theorem balanced_length {l : List ℤ} {n : ℕ} (h : IsBalancedPath l n) :
-    l.length = 2 * n := by
-  obtain ⟨h1, h2, h3⟩ := h
-  have hlen := length_eq_count_add_count (k := 1) h3
-  simp only [h1, h2] at hlen
-  omega
+    Combined with `balanced_path_total` (`C(2n,n) = Cₙ × (n+1)`), this
+    implies each type has exactly `Cₙ` paths.
 
-/-- A balanced path has sum 0. -/
-theorem balanced_sum_zero {l : List ℤ} {n : ℕ} (h : IsBalancedPath l n) :
-    l.sum = 0 := by
-  obtain ⟨h1, h2, h3⟩ := h
-  have hsum := sum_eq_count_sub_mul_count (k := 1) h3
-  simp only [h1, h2] at hsum
-  omega
-
-/- ## Part II: Connection to the Cycle Lemma -/
-
-/-- Prepending +1 to a balanced path of length 2n gives a sequence in
-    kCountedSequence 1 (n+1) n: it has (n+1) ones and n negative-ones. -/
-theorem prepend_mem_kCountedSequence {l : List ℤ} {n : ℕ}
-    (h : IsBalancedPath l n) :
-    (1 :: l) ∈ kCountedSequence 1 (n + 1) n := by
-  obtain ⟨h1, h2, h3⟩ := h
-  refine ⟨?_, ?_, ?_⟩
-  · -- count of 1 in (1 :: l) = n + 1
-    simp [h1]
-  · -- count of -1 in (1 :: l) = n
-    simp [show (1 : ℤ) ≠ (-1 : ℤ) from by decide, h2]
-  · -- all elements are ±1
-    intro x hx
-    simp only [List.mem_cons] at hx
-    rcases hx with rfl | hx
-    · left; rfl
-    · exact h3 x hx
-
-/-- **Key result**: The cycle lemma gives exactly 1 good rotation for
-    the prepended sequence, since a - kb = (n+1) - 1·n = 1. -/
-theorem prepend_one_good_rotation {l : List ℤ} {n : ℕ}
-    (h : IsBalancedPath l n) :
-    (goodRotations (1 :: l)).card = 1 := by
-  have hmem := prepend_mem_kCountedSequence h
-  have hab : 1 * n < n + 1 := by omega
-  have hcl := cycle_lemma hmem hab
-  omega
-
-/-- The prepended sequence has length 2n+1. -/
-theorem prepend_length {l : List ℤ} {n : ℕ}
-    (h : IsBalancedPath l n) :
-    (1 :: l).length = 2 * n + 1 := by
-  simp [balanced_length h]
-
-/-- The prepended sequence has sum 1 (positive). -/
-theorem prepend_sum {l : List ℤ} {n : ℕ}
-    (h : IsBalancedPath l n) :
-    (1 :: l).sum = 1 := by
-  simp [List.sum_cons, balanced_sum_zero h]
-
-/-- The good rotation is unique: there is exactly one good rotation index. -/
-theorem prepend_unique_good_rotation {l : List ℤ} {n : ℕ}
-    (h : IsBalancedPath l n) :
-    ∃ i, goodRotations (1 :: l) = {i} :=
-  Finset.card_eq_one.mp (prepend_one_good_rotation h)
-
-/- ## Part III: Counting Identity -/
-
-/-- **Balanced path total**: C(2n,n) = Cₙ × (n+1).
-    This identity, combined with the Chung-Feller uniform distribution,
-    gives that each path type has exactly Cₙ members. -/
-theorem balanced_path_total (n : ℕ) :
-    Nat.choose (2 * n) n = Cn n * (n + 1) :=
-  (catalan_formula n).symm
-
-/-- Catalan number verification. -/
-example : Cn 0 = 1 := by native_decide
-example : Cn 1 = 1 := by native_decide
-example : Cn 2 = 2 := by native_decide
-example : Cn 3 = 5 := by native_decide
-
-/- ## Part IV: The Chung-Feller Theorem -/
-
-/-- Height of a lattice path at position i (the i-th prefix sum). -/
-def pathHeight (l : List ℤ) (i : ℕ) : ℤ := (l.take i).sum
-
-/-- Count of upsteps (+1 steps) that occur at non-negative height. -/
-noncomputable def upstepsAboveAxis (l : List ℤ) : ℕ :=
-  ((Finset.range l.length).filter (fun i =>
-    l.get? i = some 1 ∧ (0 : ℤ) ≤ (l.take i).sum)).card
-
-/-- The set of balanced paths of length 2n with exactly k upsteps above the axis. -/
-def balancedPathsOfType (n k : ℕ) : Set (List ℤ) :=
-  {l | IsBalancedPath l n ∧ upstepsAboveAxis l = k}
-
-/-- Computable version of `upstepsAboveAxis` for `native_decide` proofs. -/
-def upstepsAboveAxisC (l : List ℤ) : ℕ :=
-  ((Finset.range l.length).filter (fun i =>
-    l.get? i = some 1 ∧ (0 : ℤ) ≤ (l.take i).sum)).card
-
-/-- `upstepsAboveAxisC` agrees with `upstepsAboveAxis`. -/
-theorem upstepsAboveAxisC_eq (l : List ℤ) :
-    upstepsAboveAxisC l = upstepsAboveAxis l := rfl
-
-/-- Computational verification of Chung-Feller for n=1:
-    Each of types 0 and 1 has exactly 1 = C₁ balanced path. -/
-example : upstepsAboveAxisC [1, -1] = 1 := by native_decide
-example : upstepsAboveAxisC [-1, 1] = 0 := by native_decide
-
-/-- Computational verification of Chung-Feller for n=2:
-    Types 0, 1, 2 each have exactly 2 = C₂ balanced paths. -/
-example : upstepsAboveAxisC [1, 1, -1, -1] = 2 := by native_decide
-example : upstepsAboveAxisC [1, -1, 1, -1] = 2 := by native_decide
-example : upstepsAboveAxisC [1, -1, -1, 1] = 1 := by native_decide
-example : upstepsAboveAxisC [-1, 1, 1, -1] = 1 := by native_decide
-example : upstepsAboveAxisC [-1, 1, -1, 1] = 0 := by native_decide
-example : upstepsAboveAxisC [-1, -1, 1, 1] = 0 := by native_decide
-
-/-- The empty list is the unique balanced path with n = 0. -/
-theorem isBalancedPath_nil : IsBalancedPath ([] : List ℤ) 0 := by
-  refine ⟨?_, ?_, ?_⟩
-  · simp
-  · simp
-  · intro x hx
-    simp at hx
-
-/-- A balanced path with n = 0 is the empty list. -/
-theorem balanced_zero_eq_nil {l : List ℤ} (h : IsBalancedPath l 0) : l = [] := by
-  have hlen : l.length = 0 := by
-    have := balanced_length h
-    omega
-  rcases l with _ | ⟨x, rest⟩
-  · rfl
-  · simp at hlen
-
-/-- **Chung-Feller Theorem (uniform distribution)**:
-
-    For each k ∈ {0, 1, ..., n}, the number of balanced paths from (0,0) to (2n,0)
-    with exactly k upsteps above the x-axis equals the number with j upsteps above
-    the x-axis — the distribution is uniform across the n+1 types.
-
-    Combined with `balanced_path_total` (C(2n,n) = Cₙ × (n+1)), this implies
-    each type has exactly Cₙ paths.
-
-    **Proof idea** (from cycle lemma):
-    Each balanced path l gives a unique "good rotation" of (1 :: l). Conversely,
-    each good sequence (all prefix sums positive) of length 2n+1 comes from
-    prepending +1 to some balanced path. The cycle lemma guarantees each orbit
-    of cyclic rotations has exactly 1 good member, so the orbits partition
-    C(2n+1, n+1) sequences into groups of size 2n+1, with 1 good member each.
-    The remaining 2n non-good rotations correspond to 2n balanced paths that
-    collectively cover each type 0, 1, ..., n exactly once. -/
-axiom chung_feller_uniform (n : ℕ) (j k : ℕ) (hj : j ≤ n) (hk : k ≤ n) :
-    Set.ncard (balancedPathsOfType n j) = Set.ncard (balancedPathsOfType n k)
+    This was previously stated as an axiom in this file; the proof is
+    supplied by `ChungFellerBijection.chung_feller_uniform'`, which uses
+    the explicit bijection between balanced paths and Dyck paths × types
+    constructed via the cycle-lemma rotation. -/
+theorem chung_feller_uniform (n : ℕ) (j k : ℕ) (hj : j ≤ n) (hk : k ≤ n) :
+    Set.ncard (balancedPathsOfType n j) = Set.ncard (balancedPathsOfType n k) :=
+  ChungFellerBijection.chung_feller_uniform' n j k hj hk
 
 end ChungFeller

--- a/proofs/Proofs/BallotProblemOQ01OQ04Core.lean
+++ b/proofs/Proofs/BallotProblemOQ01OQ04Core.lean
@@ -1,0 +1,178 @@
+/-
+# Chung-Feller Setup: Definitions and Cycle-Lemma Bridge (Core)
+
+## Role in the proof family
+
+This Core file holds the structural definitions and supporting lemmas shared
+between the gallery face `BallotProblemOQ01OQ04.lean` and the bijection
+proof `BallotProblemOQ01OQ04OQ01.lean`.
+
+The split exists so that the bijection proof can supply the Chung-Feller
+uniform-distribution theorem (`chung_feller_uniform'`) that the gallery face
+re-exports as `chung_feller_uniform`, eliminating what was previously stated
+as an axiom.
+
+## Provided here
+
+- `IsBalancedPath`, `balanced_length`, `balanced_sum_zero`
+- `prepend_mem_kCountedSequence`, `prepend_one_good_rotation`,
+  `prepend_unique_good_rotation`, `prepend_length`, `prepend_sum`
+- `balanced_path_total`: C(2n,n) = Cₙ × (n+1)
+- `pathHeight`, `upstepsAboveAxis`, `upstepsAboveAxisC`,
+  `balancedPathsOfType`
+- `isBalancedPath_nil`, `balanced_zero_eq_nil`
+- Catalan-number sanity examples and small computational checks
+
+## References
+
+- Chung, K.L. and Feller, W. (1949). On fluctuations in coin-tossing.
+- Dvoretzky, A. and Motzkin, Th. (1947). A problem of arrangements.
+-/
+
+import Proofs.BallotProblemOQ01
+import Proofs.BallotProblemOQ03
+
+namespace ChungFeller
+
+open GeneralizedBallot LatticePathLGV
+
+/- ## Part I: Balanced Paths -/
+
+/-- A balanced lattice path: a list of n ones and n negative-ones. -/
+def IsBalancedPath (l : List ℤ) (n : ℕ) : Prop :=
+  l.count 1 = n ∧ l.count (-1 : ℤ) = n ∧ (∀ x ∈ l, x = 1 ∨ x = (-1 : ℤ))
+
+/-- A balanced path has length 2n. -/
+theorem balanced_length {l : List ℤ} {n : ℕ} (h : IsBalancedPath l n) :
+    l.length = 2 * n := by
+  obtain ⟨h1, h2, h3⟩ := h
+  have hlen := length_eq_count_add_count (k := 1) h3
+  simp only [h1, h2] at hlen
+  omega
+
+/-- A balanced path has sum 0. -/
+theorem balanced_sum_zero {l : List ℤ} {n : ℕ} (h : IsBalancedPath l n) :
+    l.sum = 0 := by
+  obtain ⟨h1, h2, h3⟩ := h
+  have hsum := sum_eq_count_sub_mul_count (k := 1) h3
+  simp only [h1, h2] at hsum
+  omega
+
+/- ## Part II: Connection to the Cycle Lemma -/
+
+/-- Prepending +1 to a balanced path of length 2n gives a sequence in
+    kCountedSequence 1 (n+1) n: it has (n+1) ones and n negative-ones. -/
+theorem prepend_mem_kCountedSequence {l : List ℤ} {n : ℕ}
+    (h : IsBalancedPath l n) :
+    (1 :: l) ∈ kCountedSequence 1 (n + 1) n := by
+  obtain ⟨h1, h2, h3⟩ := h
+  refine ⟨?_, ?_, ?_⟩
+  · -- count of 1 in (1 :: l) = n + 1
+    simp [h1]
+  · -- count of -1 in (1 :: l) = n
+    simp [show (1 : ℤ) ≠ (-1 : ℤ) from by decide, h2]
+  · -- all elements are ±1
+    intro x hx
+    simp only [List.mem_cons] at hx
+    rcases hx with rfl | hx
+    · left; rfl
+    · exact h3 x hx
+
+/-- **Key result**: The cycle lemma gives exactly 1 good rotation for
+    the prepended sequence, since a - kb = (n+1) - 1·n = 1. -/
+theorem prepend_one_good_rotation {l : List ℤ} {n : ℕ}
+    (h : IsBalancedPath l n) :
+    (goodRotations (1 :: l)).card = 1 := by
+  have hmem := prepend_mem_kCountedSequence h
+  have hab : 1 * n < n + 1 := by omega
+  have hcl := cycle_lemma hmem hab
+  omega
+
+/-- The prepended sequence has length 2n+1. -/
+theorem prepend_length {l : List ℤ} {n : ℕ}
+    (h : IsBalancedPath l n) :
+    (1 :: l).length = 2 * n + 1 := by
+  simp [balanced_length h]
+
+/-- The prepended sequence has sum 1 (positive). -/
+theorem prepend_sum {l : List ℤ} {n : ℕ}
+    (h : IsBalancedPath l n) :
+    (1 :: l).sum = 1 := by
+  simp [List.sum_cons, balanced_sum_zero h]
+
+/-- The good rotation is unique: there is exactly one good rotation index. -/
+theorem prepend_unique_good_rotation {l : List ℤ} {n : ℕ}
+    (h : IsBalancedPath l n) :
+    ∃ i, goodRotations (1 :: l) = {i} :=
+  Finset.card_eq_one.mp (prepend_one_good_rotation h)
+
+/- ## Part III: Counting Identity -/
+
+/-- **Balanced path total**: C(2n,n) = Cₙ × (n+1).
+    This identity, combined with the Chung-Feller uniform distribution,
+    gives that each path type has exactly Cₙ members. -/
+theorem balanced_path_total (n : ℕ) :
+    Nat.choose (2 * n) n = Cn n * (n + 1) :=
+  (catalan_formula n).symm
+
+/-- Catalan number verification. -/
+example : Cn 0 = 1 := by native_decide
+example : Cn 1 = 1 := by native_decide
+example : Cn 2 = 2 := by native_decide
+example : Cn 3 = 5 := by native_decide
+
+/- ## Part IV: Path Type Definitions -/
+
+/-- Height of a lattice path at position i (the i-th prefix sum). -/
+def pathHeight (l : List ℤ) (i : ℕ) : ℤ := (l.take i).sum
+
+/-- Count of upsteps (+1 steps) that occur at non-negative height. -/
+noncomputable def upstepsAboveAxis (l : List ℤ) : ℕ :=
+  ((Finset.range l.length).filter (fun i =>
+    l.get? i = some 1 ∧ (0 : ℤ) ≤ (l.take i).sum)).card
+
+/-- The set of balanced paths of length 2n with exactly k upsteps above the axis. -/
+def balancedPathsOfType (n k : ℕ) : Set (List ℤ) :=
+  {l | IsBalancedPath l n ∧ upstepsAboveAxis l = k}
+
+/-- Computable version of `upstepsAboveAxis` for `native_decide` proofs. -/
+def upstepsAboveAxisC (l : List ℤ) : ℕ :=
+  ((Finset.range l.length).filter (fun i =>
+    l.get? i = some 1 ∧ (0 : ℤ) ≤ (l.take i).sum)).card
+
+/-- `upstepsAboveAxisC` agrees with `upstepsAboveAxis`. -/
+theorem upstepsAboveAxisC_eq (l : List ℤ) :
+    upstepsAboveAxisC l = upstepsAboveAxis l := rfl
+
+/-- Computational verification of Chung-Feller for n=1:
+    Each of types 0 and 1 has exactly 1 = C₁ balanced path. -/
+example : upstepsAboveAxisC [1, -1] = 1 := by native_decide
+example : upstepsAboveAxisC [-1, 1] = 0 := by native_decide
+
+/-- Computational verification of Chung-Feller for n=2:
+    Types 0, 1, 2 each have exactly 2 = C₂ balanced paths. -/
+example : upstepsAboveAxisC [1, 1, -1, -1] = 2 := by native_decide
+example : upstepsAboveAxisC [1, -1, 1, -1] = 2 := by native_decide
+example : upstepsAboveAxisC [1, -1, -1, 1] = 1 := by native_decide
+example : upstepsAboveAxisC [-1, 1, 1, -1] = 1 := by native_decide
+example : upstepsAboveAxisC [-1, 1, -1, 1] = 0 := by native_decide
+example : upstepsAboveAxisC [-1, -1, 1, 1] = 0 := by native_decide
+
+/-- The empty list is the unique balanced path with n = 0. -/
+theorem isBalancedPath_nil : IsBalancedPath ([] : List ℤ) 0 := by
+  refine ⟨?_, ?_, ?_⟩
+  · simp
+  · simp
+  · intro x hx
+    simp at hx
+
+/-- A balanced path with n = 0 is the empty list. -/
+theorem balanced_zero_eq_nil {l : List ℤ} (h : IsBalancedPath l 0) : l = [] := by
+  have hlen : l.length = 0 := by
+    have := balanced_length h
+    omega
+  rcases l with _ | ⟨x, rest⟩
+  · rfl
+  · simp at hlen
+
+end ChungFeller

--- a/proofs/Proofs/BallotProblemOQ01OQ04OQ01.lean
+++ b/proofs/Proofs/BallotProblemOQ01OQ04OQ01.lean
@@ -29,7 +29,7 @@ paths of ALL DISTINCT types. This requires careful prefix sum tracking across
 the modular rotation — see the proof sketch in `chung_feller_uniform`.
 -/
 
-import Proofs.BallotProblemOQ01OQ04
+import Proofs.BallotProblemOQ01OQ04Core
 
 set_option maxHeartbeats 400000
 

--- a/research/problems/ballot-problem-oq-01-oq-04/knowledge.md
+++ b/research/problems/ballot-problem-oq-01-oq-04/knowledge.md
@@ -4,11 +4,64 @@
 
 **Problem**: Prove the Chung-Feller theorem — that among all $\binom{2n}{n}$ balanced lattice paths, exactly $C_n$ have each fixed number $k \in \{0,\ldots,n\}$ of upsteps above the $x$-axis — via an explicit bijection using the cycle lemma.
 
-**Status**: COMPLETED (Session 5, 2026-04-22)
+**Status**: COMPLETED with axiom eliminated (Session 7, 2026-04-28)
 
-**Key files**:
-- `proofs/Proofs/BallotProblemOQ01OQ04.lean` — structural infrastructure (1 axiom: `chung_feller_uniform`)
+**Key files (three-file architecture)**:
+- `proofs/Proofs/BallotProblemOQ01OQ04Core.lean` — definitions and cycle-lemma bridge (0 axioms, 0 sorries)
 - `proofs/Proofs/BallotProblemOQ01OQ04OQ01.lean` — explicit bijection proof (0 sorries, 0 axiom uses)
+- `proofs/Proofs/BallotProblemOQ01OQ04.lean` — gallery face: re-exports `chung_feller_uniform'` as `chung_feller_uniform` (0 axioms, 0 sorries)
+
+**Net effect**: gallery axiomCount 1 → 0; status `axiomatized` → `verified`.
+
+---
+
+## Session 2026-04-28 (Session 7) — Eliminate the chung_feller_uniform axiom
+
+**Mode**: FRESH (continuation; refactor only, no new math)
+**Outcome**: completed
+
+### What I Did
+
+Refactored the proof family into three files so that the gallery face can
+re-export the bijection-proved theorem instead of axiomatizing it:
+
+1. Created `BallotProblemOQ01OQ04Core.lean` containing all definitions and
+   cycle-lemma bridge lemmas previously in the parent: `IsBalancedPath`,
+   `balanced_length`, `balanced_sum_zero`, `prepend_mem_kCountedSequence`,
+   `prepend_one_good_rotation`, `prepend_unique_good_rotation`,
+   `prepend_length`, `prepend_sum`, `balanced_path_total`, `pathHeight`,
+   `upstepsAboveAxis`, `upstepsAboveAxisC`, `balancedPathsOfType`,
+   `isBalancedPath_nil`, `balanced_zero_eq_nil`, plus the Catalan and
+   `native_decide` examples. Same `ChungFeller` namespace.
+2. Switched `BallotProblemOQ01OQ04OQ01.lean`'s import from
+   `Proofs.BallotProblemOQ01OQ04` to `Proofs.BallotProblemOQ01OQ04Core`.
+   No changes to the bijection proof itself.
+3. Reduced `BallotProblemOQ01OQ04.lean` to a thin gallery face: imports the
+   companion (which transitively imports Core) and proves
+   `chung_feller_uniform := ChungFellerBijection.chung_feller_uniform'`.
+
+### Why This Was Needed
+
+The companion proved `chung_feller_uniform'` (with 0 sorries, 0 axiom uses)
+in Session 5, but the parent kept its own `axiom chung_feller_uniform`
+because the import direction was companion → parent. Reversing the
+direction required moving the parent's definitions out of its way (into a
+new Core file) so the companion could depend on Core instead, freeing the
+parent to consume the companion's proof.
+
+### Files Modified
+
+- `proofs/Proofs/BallotProblemOQ01OQ04Core.lean` (new, 178 lines)
+- `proofs/Proofs/BallotProblemOQ01OQ04OQ01.lean` (1-line import change)
+- `proofs/Proofs/BallotProblemOQ01OQ04.lean` (rewrote to 73-line re-export)
+
+### Result
+
+- `BallotProblemOQ01OQ04.lean`: 0 sorries, 0 axioms.
+- `BallotProblemOQ01OQ04OQ01.lean`: 0 sorries, 0 axiom uses (unchanged).
+- `BallotProblemOQ01OQ04Core.lean`: 0 sorries, 0 axioms.
+- Gallery `meta.json` updated: `status: axiomatized → verified`,
+  `badge: axiom → verified`, `axiomCount: 1 → 0`.
 
 ---
 
@@ -100,6 +153,6 @@ The Chung-Feller uniformity follows: `|type-j paths| = |type-k paths|` by swappi
 
 ## Next Steps (for future exploration)
 
-1. Can `BallotProblemOQ01OQ04.lean`'s axiom `chung_feller_uniform` be replaced by importing `chung_feller_uniform'` from OQ04OQ01? (Would make the parent file fully axiom-free)
+1. ~~Can `BallotProblemOQ01OQ04.lean`'s axiom `chung_feller_uniform` be replaced by importing `chung_feller_uniform'` from OQ04OQ01?~~ **Resolved in Session 7 (2026-04-28)** via the three-file refactor (Core / Bijection / GalleryFace).
 2. q-analog: can a q-Chung-Feller theorem be formalized, tracking path area?
 3. The bijection connects to RSK correspondence: does `chungFellerMap` have a nice description in terms of RSK?

--- a/research/problems/ballot-problem-oq-01-oq-04/state.md
+++ b/research/problems/ballot-problem-oq-01-oq-04/state.md
@@ -1,27 +1,59 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-03-26T20:00:24.431Z
-**Iteration**: 1
+**Phase**: COMPLETED
+**Since**: 2026-04-28T17:42:00Z (axiom elimination)
+**Iteration**: 7
 
 ## Current Focus
 
-Initial exploration of the problem.
+Axiom elimination via three-file refactor:
+`BallotProblemOQ01OQ04Core.lean` → `BallotProblemOQ01OQ04OQ01.lean` → `BallotProblemOQ01OQ04.lean`.
+
+The previously stated `axiom chung_feller_uniform` is now a `theorem` that
+re-exports `ChungFellerBijection.chung_feller_uniform'` (proved with 0 sorries
+and 0 axiom uses). Net axiomCount for this gallery proof: 1 → 0.
 
 ## Active Approach
 
-None yet.
+**Three-file architecture for the Chung-Feller proof family**:
+
+1. `BallotProblemOQ01OQ04Core.lean` — extracted definitions and cycle-lemma
+   bridge: `IsBalancedPath`, `prepend_one_good_rotation`, `balanced_path_total`,
+   `balancedPathsOfType`, `upstepsAboveAxis`, etc.
+2. `BallotProblemOQ01OQ04OQ01.lean` — companion (unchanged proof content);
+   import switched from the parent to `Core` so it no longer depends on the
+   axiom-bearing parent.
+3. `BallotProblemOQ01OQ04.lean` — gallery face: thin re-export of
+   `chung_feller_uniform'` as `chung_feller_uniform`.
+
+This flips the dependency direction: now Core ← Bijection ← GalleryFace,
+allowing the gallery face to consume the bijection-proved theorem.
 
 ## Blockers
 
-None.
+None. Build verification pending (Docker build in progress).
 
 ## Next Action
 
-Begin problem exploration.
+After build verification:
+1. Commit metadata + state updates to the same branch.
+2. Open PR consolidating the refactor.
+3. Mark candidate-pool entry `completed`.
+
+## Open Questions (downstream)
+
+- Can a q-Chung-Feller theorem be formalized, tracking path area?
+- Does `chungFellerMap` admit a description in terms of RSK?
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 7
+- Current approach attempts: 1
+- Approaches tried:
+  1. Establish IsBalancedPath, balanced_length, balanced_sum_zero (Session 1)
+  2. Cycle lemma application: prepend_one_good_rotation (Session 2)
+  3. Define chungFellerRot and prove tail-Dyck properties (Session 3)
+  4. Prove chung_feller_bijection_exists (Session 4)
+  5. Prove chung_feller_uniform' from the bijection (Session 5)
+  6. Fix BallotProblemOQ03 build failures (Session 6)
+  7. **Three-file refactor: eliminate the axiom (Session 7, this session)**

--- a/src/data/proofs/ballot-problem-oq-01-oq-04/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-04/meta.json
@@ -2,12 +2,12 @@
   "id": "ballot-problem-oq-01-oq-04",
   "title": "Chung-Feller Theorem via the Cycle Lemma",
   "slug": "ballot-problem-oq-01-oq-04",
-  "description": "Formalization of the Chung-Feller theorem connecting balanced lattice paths to the Dvoretzky-Motzkin cycle lemma. Proves that prepending +1 to any balanced ±1 path yields a sequence with exactly 1 good cyclic rotation, the structural foundation for showing the uniform distribution of upstep types.",
+  "description": "Formalization of the Chung-Feller theorem connecting balanced lattice paths to the Dvoretzky-Motzkin cycle lemma. Proves that prepending +1 to any balanced ±1 path yields a sequence with exactly 1 good cyclic rotation, and re-exports the resulting uniform distribution of upstep types — proved via an explicit bijection in the companion file BallotProblemOQ01OQ04OQ01.lean.",
   "meta": {
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Chung%E2%80%93Feller_theorem",
     "date": "2026",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/BallotProblemOQ01OQ04.lean",
     "tags": [
       "combinatorics",
@@ -18,7 +18,7 @@
       "lattice-paths",
       "research"
     ],
-    "badge": "axiom",
+    "badge": "verified",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -33,13 +33,14 @@
       }
     ],
     "originalContributions": [
-      "prepend_mem_kCountedSequence: proves that prepending +1 to a balanced ±1 path gives a kCountedSequence 1 (n+1) n element",
-      "prepend_one_good_rotation: applies the cycle lemma to show exactly 1 of 2n+1 cyclic rotations has all partial sums positive",
-      "prepend_unique_good_rotation: the good rotation is unique (existential uniqueness from cardinality 1)",
-      "balanced_path_total: C(2n,n) = Cₙ × (n+1), connecting the total path count to Catalan numbers",
-      "Proper definitions for upstepsAboveAxis and balancedPathsOfType, replacing placeholder stubs",
-      "isBalancedPath_nil and balanced_zero_eq_nil: edge case n=0 (empty list is the unique balanced path)",
-      "n=1 native_decide examples: each of types 0 and 1 has exactly 1 = C₁ balanced path"
+      "Eliminated the chung_feller_uniform axiom: re-exports ChungFellerBijection.chung_feller_uniform' (proved with 0 sorries / 0 axiom uses) by extracting shared definitions into BallotProblemOQ01OQ04Core.lean and flipping the import direction so the gallery face can consume the bijection proof",
+      "prepend_mem_kCountedSequence (Core): prepending +1 to a balanced ±1 path gives a kCountedSequence 1 (n+1) n element",
+      "prepend_one_good_rotation (Core): applies the cycle lemma to show exactly 1 of 2n+1 cyclic rotations has all partial sums positive",
+      "prepend_unique_good_rotation (Core): the good rotation is unique (existential uniqueness from cardinality 1)",
+      "balanced_path_total (Core): C(2n,n) = Cₙ × (n+1), connecting the total path count to Catalan numbers",
+      "Proper definitions for upstepsAboveAxis and balancedPathsOfType (Core), replacing placeholder stubs",
+      "isBalancedPath_nil and balanced_zero_eq_nil (Core): edge case n=0 (empty list is the unique balanced path)",
+      "n=1 native_decide examples (Core): each of types 0 and 1 has exactly 1 = C₁ balanced path"
     ],
     "dateAdded": "2026-03-29",
     "prerequisites": [
@@ -62,22 +63,23 @@
         "relationship": "Classical ballot problem, the foundational result in this family"
       }
     ],
-    "axiomCount": 1,
-    "lineCount": 209,
-    "assumptions": "1 axiom: chung_feller_uniform (the uniform distribution of path types, requiring an explicit bijection between rotation indices and upstep-above-axis counts). All structural infrastructure is proved.",
+    "axiomCount": 0,
+    "lineCount": 73,
+    "assumptions": "0 axioms, 0 sorries. The previously stated axiom chung_feller_uniform is now a theorem re-exporting ChungFellerBijection.chung_feller_uniform' from BallotProblemOQ01OQ04OQ01.lean. The full proof spans three files: BallotProblemOQ01OQ04Core.lean (definitions and cycle-lemma bridge), BallotProblemOQ01OQ04OQ01.lean (explicit bijection), and BallotProblemOQ01OQ04.lean (gallery face).",
     "mathlib_version": "4.26.0"
   },
   "overview": {
     "historicalContext": "**The Chung-Feller Theorem (1949)**\n\nChung and Feller proved that among the $\\binom{2n}{n}$ lattice paths from $(0,0)$ to $(2n,0)$ with steps $\\pm 1$, exactly $C_n = \\binom{2n}{n}/(n+1)$ paths have exactly $k$ upsteps above the $x$-axis, for each $k \\in \\{0, 1, \\ldots, n\\}$. The result is remarkable because the count is independent of $k$.\n\nThe most elegant proof uses the Dvoretzky-Motzkin cycle lemma (1947): prepend $+1$ to a balanced path to get a sequence of length $2n+1$ with sum $1$. The cycle lemma guarantees exactly $1$ of the $2n+1$ cyclic rotations has all partial sums positive. This creates a bijection that partitions paths uniformly across the $n+1$ types.",
-    "problemStatement": "**Theorem (Chung-Feller)**: For each $k \\in \\{0, 1, \\ldots, n\\}$, the number of lattice paths from $(0,0)$ to $(2n,0)$ with steps $\\pm 1$ having exactly $k$ upsteps above the $x$-axis is $C_n = \\binom{2n}{n}/(n+1)$, the $n$th Catalan number.\n\n**Key structural result** (proved here): For any balanced path $l$, the prepended sequence $(1 :: l)$ has exactly $1$ good cyclic rotation.",
-    "text": "This file formalizes the structural connection between balanced lattice paths and the cycle lemma that underpins the Chung-Feller theorem. The main results are: (1) prepending +1 to a balanced ±1 path of length 2n gives an element of kCountedSequence 1 (n+1) n; (2) by the cycle lemma (proved in BallotProblemOQ01.lean), this prepended sequence has exactly 1 good rotation out of 2n+1 total; (3) the counting identity C(2n,n) = Cₙ × (n+1) connects the total path count to Catalan numbers via OQ03's catalan_formula. The remaining step — showing that the cyclic rotation map creates a bijection between rotation indices and upstep-above-axis counts — is stated as an axiom.",
-    "proofStrategy": "**Cycle Lemma Bridge**:\n\n1. Define `IsBalancedPath l n`: the list $l$ has $n$ copies of $+1$ and $n$ copies of $-1$.\n2. Prove `prepend_mem_kCountedSequence`: $(1 :: l) \\in \\text{kCountedSequence}(1, n+1, n)$.\n3. Apply `cycle_lemma` with $k=1$, $a=n+1$, $b=n$: since $1 \\cdot n < n+1$, we get $|\\text{goodRotations}(1::l)| = (n+1) - 1 \\cdot n = 1$.\n4. The division identity $\\binom{2n}{n} = C_n \\cdot (n+1)$ follows from `catalan_formula` in OQ03.",
+    "problemStatement": "**Theorem (Chung-Feller)**: For each $k \\in \\{0, 1, \\ldots, n\\}$, the number of lattice paths from $(0,0)$ to $(2n,0)$ with steps $\\pm 1$ having exactly $k$ upsteps above the $x$-axis is $C_n = \\binom{2n}{n}/(n+1)$, the $n$th Catalan number.\n\n**Key structural result** (Core file): For any balanced path $l$, the prepended sequence $(1 :: l)$ has exactly $1$ good cyclic rotation.",
+    "text": "This proof family formalizes the Chung-Feller theorem in three files. (1) BallotProblemOQ01OQ04Core.lean introduces IsBalancedPath, prepends +1, applies the cycle lemma to obtain a unique good rotation, and proves the counting identity C(2n,n) = Cₙ × (n+1). (2) BallotProblemOQ01OQ04OQ01.lean constructs the explicit bijection chungFellerMap from balanced paths to (Dyck paths) × Fin(n+1) via the rightmost-minimum cyclic rotation and proves chung_feller_uniform' (uniform distribution of upstep types) with 0 sorries and 0 axiom uses. (3) This file is the gallery face: it imports the bijection proof and re-exports the theorem under its conventional name chung_feller_uniform — the previously stated axiom is now a proved theorem.",
+    "proofStrategy": "**Architecture (3-file proof)**:\n\n1. **Core**: Define `IsBalancedPath l n`. Prove `prepend_mem_kCountedSequence`: $(1 :: l) \\in \\text{kCountedSequence}(1, n+1, n)$. Apply `cycle_lemma` with $k=1$, $a=n+1$, $b=n$ to get $|\\text{goodRotations}(1::l)| = 1$. Prove the counting identity $\\binom{2n}{n} = C_n \\cdot (n+1)$.\n2. **Bijection (companion)**: Build `chungFellerMap : {l // IsBalancedPath l n} → {D // IsDyckPath D n} × Fin (n+1)` from the rightmost-minimum cyclic rotation. Prove `chung_feller_bijection_exists` (`chungFellerMap` is bijective). Conclude `chung_feller_uniform'`: type-j and type-k path sets have equal cardinality, by swapping the Fin component via the Equiv.\n3. **Gallery face (this file)**: Re-export `chung_feller_uniform'` under its conventional name `chung_feller_uniform`, eliminating the previously stated axiom.",
     "keyInsights": [
       "The cycle lemma with k=1, a=n+1, b=n gives exactly 1 good rotation — the key structural fact for Chung-Feller",
       "Prepending +1 converts a sum-0 balanced path into a sum-1 sequence, entering the domain of the cycle lemma",
       "The counting identity C(2n,n) = Cₙ × (n+1) means the n+1 path types must each have Cₙ members",
-      "The bijection between rotation index and type number requires tracking how cyclic shifts change the height profile — this is the remaining axiom",
-      "The Chung-Feller theorem has a surprising probabilistic interpretation: if you pick a random lattice path from (0,0) to (2n,0), the number of upsteps above the axis is uniformly distributed on {0,...,n}. This is non-obvious because different path shapes (e.g., mostly above vs mostly below the axis) seem geometrically distinct, yet the cycle lemma shows they are equinumerous — a discrete analog of the equipartition phenomenon in ergodic theory."
+      "The bijection between rotation index and type number is provided by the rightmost-minimum cyclic rotation: l ↦ (Dyck-tail of the good rotation, upstepsAboveAxis l). This is constructive and avoids any topological argument.",
+      "The Chung-Feller theorem has a surprising probabilistic interpretation: if you pick a random lattice path from (0,0) to (2n,0), the number of upsteps above the axis is uniformly distributed on {0,...,n}. This is non-obvious because different path shapes (e.g., mostly above vs mostly below the axis) seem geometrically distinct, yet the cycle lemma shows they are equinumerous — a discrete analog of the equipartition phenomenon in ergodic theory.",
+      "Architectural insight: a gallery proof can keep its 'face' file thin by extracting shared definitions to a Core file and re-exporting downstream theorems. This eliminates artificial axioms that arise only because the conventional naming sits in the file the bijection-proof depends on."
     ],
     "prerequisites": [
       "Dvoretzky-Motzkin Cycle Lemma",
@@ -89,43 +91,19 @@
   "sections": [
     {
       "id": "header",
-      "title": "Imports and Problem Overview",
+      "title": "Architecture and Imports",
       "startLine": 1,
-      "endLine": 38,
-      "summary": "Header documenting the Chung-Feller theorem, proof strategy via the cycle lemma, and infrastructure dependencies. Imports BallotProblemOQ01 (cycle lemma) and BallotProblemOQ03 (Catalan numbers).",
-      "mathContext": "The Chung-Feller theorem (1949): among $\\binom{2n}{n}$ balanced paths, exactly $C_n$ have $k$ upsteps above the axis, for each $k$."
+      "endLine": 49,
+      "summary": "Header documenting the three-file proof architecture (Core, OQ01 bijection, this gallery face), the cycle-lemma proof strategy, and the elimination of the previously stated axiom. Imports BallotProblemOQ01OQ04OQ01 (which transitively pulls in Core, OQ01, and OQ03).",
+      "mathContext": "The Chung-Feller theorem (1949): among $\\binom{2n}{n}$ balanced paths, exactly $C_n$ have $k$ upsteps above the axis, for each $k$. The proof uses Dvoretzky-Motzkin's cycle lemma to construct an explicit bijection between balanced paths and (Dyck paths) × (path types)."
     },
     {
-      "id": "balanced-paths",
-      "title": "Balanced Path Definitions and Properties",
-      "startLine": 39,
-      "endLine": 65,
-      "summary": "Defines `IsBalancedPath` (n ones and n negative-ones) and proves basic properties: `balanced_length` (length = 2n) and `balanced_sum_zero` (sum = 0). Both use the algebraic infrastructure from BallotProblemOQ01.",
-      "mathContext": "A balanced path has $n$ upsteps and $n$ downsteps, giving length $2n$ and total displacement $0$."
-    },
-    {
-      "id": "cycle-lemma-connection",
-      "title": "Connection to the Cycle Lemma",
-      "startLine": 67,
-      "endLine": 115,
-      "summary": "The core contribution: `prepend_mem_kCountedSequence` shows that (1 :: l) is a valid cycle lemma input. `prepend_one_good_rotation` applies the cycle lemma to get exactly 1 good rotation. Also proves prepend length (2n+1), prepend sum (1), and uniqueness.",
-      "mathContext": "For $l$ balanced: $(1::l)$ has $n+1$ ones and $n$ negative-ones with sum $1$. The cycle lemma gives $|\\text{goodRotations}(1::l)| = (n+1) - 1 \\cdot n = 1$."
-    },
-    {
-      "id": "counting-identity",
-      "title": "Counting Identity",
-      "startLine": 117,
-      "endLine": 130,
-      "summary": "`balanced_path_total`: C(2n,n) = Cₙ × (n+1), connecting the total balanced path count to Catalan numbers via `catalan_formula` from BallotProblemOQ03.",
-      "mathContext": "$\\binom{2n}{n} = C_n \\cdot (n+1)$ where $C_n$ is the $n$th Catalan number."
-    },
-    {
-      "id": "chung-feller-statement",
-      "title": "The Chung-Feller Theorem Statement",
-      "startLine": 132,
-      "endLine": 160,
-      "summary": "Defines `pathHeight`, `upstepsAboveAxis`, and `balancedPathsOfType`. States the Chung-Feller uniform distribution axiom: for all j, k ≤ n, the j-type and k-type path sets have the same cardinality.",
-      "mathContext": "The axiomatized statement: $|\\{\\text{paths with } j \\text{ upsteps above axis}\\}| = |\\{\\text{paths with } k \\text{ upsteps above axis}\\}|$ for all $j, k \\leq n$."
+      "id": "chung-feller-uniform",
+      "title": "Chung-Feller Theorem (Uniform Distribution)",
+      "startLine": 50,
+      "endLine": 73,
+      "summary": "Defines `chung_feller_uniform`: for j, k ≤ n, the j-type and k-type balanced-path sets have equal cardinality. Proof is by re-export of `ChungFellerBijection.chung_feller_uniform'` from the companion file, which constructs an explicit bijection. This was previously stated as an axiom.",
+      "mathContext": "$|\\{\\text{paths with } j \\text{ upsteps above axis}\\}| = |\\{\\text{paths with } k \\text{ upsteps above axis}\\}|$ for all $j, k \\leq n$ — proved via the explicit bijection $l \\mapsto (\\text{Dyck-tail of good rotation}, \\text{upstepsAboveAxis}\\, l)$."
     }
   ],
   "crossReferences": [
@@ -146,46 +124,49 @@
     }
   ],
   "conclusion": {
-    "summary": "This file establishes the structural foundation for the Chung-Feller theorem by proving the key connection between balanced paths and the cycle lemma. The main result — that prepending +1 to any balanced path creates a sequence with exactly 1 good cyclic rotation — reduces the Chung-Feller theorem to a bijection argument. The counting identity C(2n,n) = Cₙ × (n+1) is proved from existing infrastructure.",
-    "implications": "**Mathematical Significance**\n\n1. **Cycle Lemma Bridge**: The prepend-one-good-rotation theorem is the key structural fact: it shows that the 2n+1 cyclic rotations of a prepended balanced path contain exactly 1 good rotation, creating the foundation for the (n+1)-uniform partition.\n\n2. **Catalan Connection**: Via balanced_path_total, the total count C(2n,n) factors as Cₙ × (n+1), showing that any uniform (n+1)-partition of paths yields Cₙ members per type.\n\n3. **Remaining Gap**: The axiomatized chung_feller_uniform statement requires showing that cyclic rotations create a bijection between rotation index and upstep-type — this needs detailed analysis of how height profiles transform under cyclic shifts.",
+    "summary": "This proof family establishes the Chung-Feller theorem with 0 axioms and 0 sorries via an explicit bijection. The Core file proves the structural cycle-lemma bridge (prepending +1 to a balanced path yields exactly 1 good cyclic rotation) and the counting identity C(2n,n) = Cₙ × (n+1). The companion bijection file constructs chungFellerMap from balanced paths to (Dyck paths) × Fin(n+1) using the rightmost-minimum cyclic rotation. This gallery face re-exports the resulting chung_feller_uniform' as chung_feller_uniform, eliminating the axiom that was used as a placeholder while the bijection was being developed.",
+    "implications": "**Mathematical Significance**\n\n1. **Cycle Lemma Bridge**: The prepend-one-good-rotation theorem is the key structural fact: the 2n+1 cyclic rotations of a prepended balanced path contain exactly 1 good rotation, creating the foundation for the (n+1)-uniform partition.\n\n2. **Catalan Connection**: Via balanced_path_total, the total count C(2n,n) factors as Cₙ × (n+1), so the uniform (n+1)-partition yields Cₙ members per type.\n\n3. **Explicit Bijection**: The cycle-lemma route to Chung-Feller is constructive. The map l ↦ (Dyck-tail of good rotation, upstepsAboveAxis l) is bijective, with no appeal to algebraic topology or generating functions.\n\n4. **Architectural Note**: The previously stated axiom chung_feller_uniform was eliminated by extracting shared definitions to a Core file and flipping the import direction so the gallery face can re-export the bijection-proved theorem under its conventional name.",
     "openQuestions": [
-      "Can the chung_feller_uniform axiom be proved by explicitly constructing the bijection between rotation indices {0,...,2n} and path types {0,...,n}?",
-      "Can a q-analog of the Chung-Feller theorem be formalized, tracking the area under the path?"
+      "Can a q-analog of the Chung-Feller theorem be formalized, tracking the area under the path?",
+      "Does chungFellerMap admit a description in terms of the RSK correspondence, given that Dyck paths and Catalan structures are RSK-related?"
     ]
   },
   "mainTheorems": [
     {
-      "name": "prepend_one_good_rotation",
+      "name": "chung_feller_uniform",
       "type": "core",
-      "description": "Applying the cycle lemma to a prepended balanced path shows exactly 1 of the 2n+1 cyclic rotations has all partial sums positive — the key structural fact for the Chung-Feller theorem."
+      "description": "The Chung-Feller theorem: for j, k ≤ n, the number of balanced paths of length 2n with j upsteps above the x-axis equals the number with k upsteps above the x-axis. Re-exports ChungFellerBijection.chung_feller_uniform' (proved by explicit bijection in the companion file). Combined with balanced_path_total, this gives Cₙ paths per type."
+    },
+    {
+      "name": "prepend_one_good_rotation",
+      "type": "supporting",
+      "description": "Applying the cycle lemma to a prepended balanced path shows exactly 1 of the 2n+1 cyclic rotations has all partial sums positive — the key structural fact for the Chung-Feller theorem (lives in BallotProblemOQ01OQ04Core.lean)."
     },
     {
       "name": "prepend_mem_kCountedSequence",
-      "type": "core",
-      "description": "Prepending +1 to a balanced ±1 path of length 2n yields an element of kCountedSequence 1 (n+1) n, placing it within the cycle lemma's domain."
+      "type": "supporting",
+      "description": "Prepending +1 to a balanced ±1 path of length 2n yields an element of kCountedSequence 1 (n+1) n, placing it within the cycle lemma's domain (lives in BallotProblemOQ01OQ04Core.lean)."
     },
     {
       "name": "balanced_path_total",
       "type": "supporting",
-      "description": "The counting identity C(2n,n) = Cₙ × (n+1) connects total balanced path count to Catalan numbers, showing any uniform (n+1)-partition yields exactly Cₙ members per type."
+      "description": "The counting identity C(2n,n) = Cₙ × (n+1) connects total balanced path count to Catalan numbers, showing any uniform (n+1)-partition yields exactly Cₙ members per type (lives in BallotProblemOQ01OQ04Core.lean)."
     }
   ],
   "leanFile": {
     "imports": [
-      "Proofs.BallotProblemOQ01",
-      "Proofs.BallotProblemOQ03"
+      "Proofs.BallotProblemOQ01OQ04OQ01"
     ],
     "opens": [
-      "GeneralizedBallot",
-      "LatticePathLGV"
+      "ChungFellerBijection"
     ],
     "namespace": "ChungFeller",
-    "lineCount": 209,
-    "axiomCount": 1,
-    "theoremCount": 11,
-    "substantiveTheoremCount": 9,
+    "lineCount": 73,
+    "axiomCount": 0,
+    "theoremCount": 1,
+    "substantiveTheoremCount": 1,
     "trivialPlaceholders": 0,
-    "definitionCount": 4,
+    "definitionCount": 0,
     "path": "Proofs/BallotProblemOQ01OQ04.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary

Eliminates the `chung_feller_uniform` axiom from the ballot-problem-oq-01-oq-04 gallery proof via a three-file refactor:

- **`BallotProblemOQ01OQ04Core.lean`** (new) — extracted definitions and the cycle-lemma bridge: `IsBalancedPath`, `prepend_one_good_rotation`, `balanced_path_total`, `balancedPathsOfType`, `upstepsAboveAxis`, etc.
- **`BallotProblemOQ01OQ04OQ01.lean`** — companion proof; one-line import change so it depends on Core instead of the gallery face.
- **`BallotProblemOQ01OQ04.lean`** — gallery face, now a 73-line re-export of `ChungFellerBijection.chung_feller_uniform'` (proved with 0 sorries / 0 axiom uses) under its conventional name `chung_feller_uniform`.

The companion already proved `chung_feller_uniform'` in Session 5 (2026-04-22). The parent file kept its own `axiom chung_feller_uniform` only because the import direction was companion → parent, preventing re-export. This PR flips the dependency direction by extracting the parent's definitions to a new Core file.

## Impact

- Gallery: `axiomCount: 1 → 0`; `status: axiomatized → verified`; `badge: axiom → verified`.
- No mathematical content changed; no new sorries introduced. Pure refactor.
- `lakefile.toml` globs `Proofs/`, so no build-target changes needed.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.BallotProblemOQ01OQ04` succeeds (in progress locally)
- [ ] Transitive build of `Proofs.BallotProblemOQ01OQ04OQ01` succeeds
- [ ] `pnpm build` accepts the updated `meta.json`
- [ ] Gallery page renders with `verified` badge

## Notes for review

- Section line numbers in `meta.json` were rewritten to match the new 73-line gallery face.
- `originalContributions` retains the existing structural lemmas, now annotated with `(Core)` to reflect their new home.
- `keyInsights` adds an architectural note about how this kind of axiom-elimination refactor works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)