### PR TITLE
audit: tracker sync — re-audit erdos-861 (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9648,9 +9648,9 @@
     },
     "erdos-861": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-28T18:07:02Z",
+      "result": "clean"
     },
     "erdos-862": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Re-audited erdos-861 (Counting Sidon Sets) after section line-drift fix landed in #13651.
- Verified clean: 4 axioms (cameron_erdos_q1_true, cameron_erdos_q2_false, saxton_thomason_lower_bound, klrs_upper_bound) match Lean source, 0 sorries, all section ranges match landmarks, status `axiomatized` / badge `axiom` correct.
- Tracker entry: `auditCount` 2 → 3, `result` issues-fixed → clean, `lastAudited` updated.

## Test plan

- [x] `npx tsx scripts/auditor/find-targets.ts --stats` (queue is full audited; this is a re-audit cycle).
- [x] Verified Lean source: `proofs/Proofs/Erdos861Problem.lean` 265 lines, 4 axioms, 6 theorems, 7 definitions, 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)