### PR TITLE
audit(erdos-842): correct section line drift

### DIFF
--- a/src/data/proofs/erdos-842/meta.json
+++ b/src/data/proofs/erdos-842/meta.json
@@ -79,48 +79,48 @@
       "id": "basic-definitions",
       "title": "Basic Definitions",
       "startLine": 46,
-      "endLine": 70,
+      "endLine": 67,
       "summary": "Triangle graph K₃ and its chromatic number"
     },
     {
       "id": "graph-construction",
       "title": "The Graph Construction",
-      "startLine": 71,
-      "endLine": 127,
+      "startLine": 68,
+      "endLine": 124,
       "summary": "Triangle-Hamiltonian Graph: vertices, triangle index, Hamiltonian edges"
     },
     {
       "id": "main-result",
       "title": "The Main Result",
-      "startLine": 128,
-      "endLine": 160,
+      "startLine": 125,
+      "endLine": 157,
       "summary": "Fleischner-Stiebitz theorem: χ(THG) = 3"
     },
     {
       "id": "coloring-structure",
       "title": "Coloring Structure",
-      "startLine": 161,
-      "endLine": 173,
+      "startLine": 158,
+      "endLine": 170,
       "summary": "Divisibility by 3 and cyclic coloring"
     },
     {
       "id": "graph-properties",
       "title": "Graph Properties",
-      "startLine": 174,
-      "endLine": 191,
+      "startLine": 171,
+      "endLine": 185,
       "summary": "Vertex count and degree bounds"
     },
     {
       "id": "special-cases",
       "title": "Special Cases",
-      "startLine": 192,
-      "endLine": 214,
+      "startLine": 186,
+      "endLine": 208,
       "summary": "Cases n=1 (K₃) and n=2 (6 vertices)"
     },
     {
       "id": "summary",
       "title": "Summary",
-      "startLine": 215,
+      "startLine": 209,
       "endLine": 227,
       "summary": "erdos_842 summary theorem: 3-colorable and χ = 3"
     }


### PR DESCRIPTION
## Summary

Section `startLine`/`endLine` values in `src/data/proofs/erdos-842/meta.json` were 3–6 lines past the actual `/- ## ... -/` headers in `proofs/Proofs/Erdos842Problem.lean`. Each of the 7 sections corrected to match the verified header line numbers in the Lean source.

## Audit Findings

All non-section fields verified correct:

- `axiomCount: 3` ✓ — `thg_3_colorable`, `thg_chromatic_number_le_3`, `thg_chromatic_number_ge_3` (lines 131, 138, 145)
- `sorries: 0` ✓ — no sorries in source
- `lineCount: 227` ✓
- `theoremCount: 7`, `definitionCount: 7` ✓
- `status: axiomatized`, `badge: axiom` ✓ — Fleischner-Stiebitz core result is honestly axiomatized
- No True stubs, no phantom-axiom narrative

## Section Corrections

| Section | Was | Now |
|---|---|---|
| basic-definitions | 46–70 | 46–67 |
| graph-construction | 71–127 | 68–124 |
| main-result | 128–160 | 125–157 |
| coloring-structure | 161–173 | 158–170 |
| graph-properties | 174–191 | 171–185 |
| special-cases | 192–214 | 186–208 |
| summary | 215–227 | 209–227 |

## Test plan

- [x] Verified actual header line numbers via direct file read of `proofs/Proofs/Erdos842Problem.lean`
- [x] Each `endLine` is the line immediately before the next section header

🤖 Generated with [Claude Code](https://claude.com/claude-code)