### PR TITLE
audit: tracker sync — erdos-842 issues-fixed (#13672)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9513,8 +9513,8 @@
     },
     "erdos-842": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-28T18:45:51Z",
       "result": "issues-fixed"
     },
     "erdos-843": {


### PR DESCRIPTION
## Summary

Tracker sync for erdos-842 re-audit. Section line drift fix is in #13672.

- `auditCount`: 2 → 3
- `lastAudited`: 2026-04-03 → 2026-04-28
- `result`: `issues-fixed`

## Test plan

- [x] Single-line tracker update only

🤖 Generated with [Claude Code](https://claude.com/claude-code)