### PR TITLE
audit: tracker — re-audit erdos-847 (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9543,9 +9543,9 @@
     },
     "erdos-847": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-28T19:04:46Z",
+      "result": "clean"
     },
     "erdos-848": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Re-audited erdos-847 (AP-Free Subsets and Finite Unions, DISPROVED)
- Counts verified: 0 sorries, 1 axiom (`enr_conjecture_false`), 290 lines
- Status `axiomatized` + badge `axiom` correctly reflect the single axiom
- Section line ranges (1–9) all match Lean source
- Sections 5/6/8 explicitly distinguish docstring-only content (`szemeredi_theorem`, `key_insight`, `roth_theorem`, `kelley_meka_bound`) from formal declarations — no phantom-axiom narrative
- `originalContributions` correctly identifies the real axiom and the proven theorem `finite_union_implies_enr`

## Test plan
- [x] sorry/axiom/line counts verified against `proofs/Proofs/Erdos847Problem.lean`
- [x] Section line ranges spot-checked
- [x] No True stubs

🤖 Generated with [Claude Code](https://claude.com/claude-code)