### PR TITLE
audit: tracker sync — erdos-841 issues-fixed (#13687)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9507,8 +9507,8 @@
     },
     "erdos-841": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-28T19:19:44Z",
       "result": "issues-fixed"
     },
     "erdos-842": {


### PR DESCRIPTION
## Summary

Tracker sync for erdos-841 audit. Section line drift fix is in #13687.

- `auditCount`: 2 → 3
- `lastAudited`: 2026-04-03 → 2026-04-28
- `result`: `issues-fixed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)