### PR TITLE
fix(erdos-843): correct section startLine/endLine drift

### DIFF
--- a/src/data/proofs/erdos-843/meta.json
+++ b/src/data/proofs/erdos-843/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-843",
-  "title": "Erd\u0151s Problem #843: Are the Squares Ramsey 2-Complete?",
+  "title": "Erdős Problem #843: Are the Squares Ramsey 2-Complete?",
   "slug": "erdos-843",
   "description": "Are the squares Ramsey 2-complete? That is, in any 2-coloring of the squares, can every sufficiently large n be written as a monochromatic sum of distinct squares? Answer: YES (Conlon-Fox-Pham 2021).",
   "meta": {
-    "author": "Burr-Erd\u0151s (origin), Conlon-Fox-Pham (2021 published proof)",
+    "author": "Burr-Erdős (origin), Conlon-Fox-Pham (2021 published proof)",
     "sourceUrl": "https://erdosproblems.com/843",
     "date": "~1985",
     "status": "axiomatized",
@@ -29,15 +29,15 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "This problem was posed by Burr and Erd\u0151s around 1985. A set A \u2286 \u2115 is **Ramsey r-complete** if for every r-coloring of A, all sufficiently large integers can be written as a monochromatic sum of distinct elements from A.\n\nErd\u0151s reported in 1995 that Burr had proved k-th powers are Ramsey r-complete for all r,k \u2265 2, but this result was never published. The question remained officially open until Conlon, Fox, and Pham (2021) proved a stronger result: k-th powers contain a SPARSE Ramsey r-complete subsequence with counting function ~(log N)\u00b2, which is optimal.\n\nThe problem is part of a family of three Ramsey completeness problems for which Erd\u0151s offered a combined $350 prize.",
-    "problemStatement": "**Question:** Are the squares Ramsey 2-complete?\n\n**Equivalently:** In any 2-coloring of the perfect squares {1, 4, 9, 16, 25, ...}, can every sufficiently large natural number be written as a monochromatic sum of distinct squares?\n\n**Answer:** YES (Conlon-Fox-Pham 2021)\n\n**Stronger Result:** For all r, k \u2265 2, the k-th powers contain a sparse Ramsey r-complete subsequence. The optimal density is ~(log N)\u00b2.\n\n**Density Bounds:**\n- Upper: \u2203 r-Ramsey complete A with |A \u2229 [1,N]| \u226a r(log N)\u00b2 (CFP 2021)\n- Lower: Any r-Ramsey complete A has |A \u2229 [1,N]| \u226b (log N)\u00b2 (CFP 2021)\n- Previous best: |A \u2229 [1,N]| \u226a (log N)\u00b3 (Burr-Erd\u0151s 1985)",
+    "historicalContext": "This problem was posed by Burr and Erdős around 1985. A set A ⊆ ℕ is **Ramsey r-complete** if for every r-coloring of A, all sufficiently large integers can be written as a monochromatic sum of distinct elements from A.\n\nErdős reported in 1995 that Burr had proved k-th powers are Ramsey r-complete for all r,k ≥ 2, but this result was never published. The question remained officially open until Conlon, Fox, and Pham (2021) proved a stronger result: k-th powers contain a SPARSE Ramsey r-complete subsequence with counting function ~(log N)², which is optimal.\n\nThe problem is part of a family of three Ramsey completeness problems for which Erdős offered a combined $350 prize.",
+    "problemStatement": "**Question:** Are the squares Ramsey 2-complete?\n\n**Equivalently:** In any 2-coloring of the perfect squares {1, 4, 9, 16, 25, ...}, can every sufficiently large natural number be written as a monochromatic sum of distinct squares?\n\n**Answer:** YES (Conlon-Fox-Pham 2021)\n\n**Stronger Result:** For all r, k ≥ 2, the k-th powers contain a sparse Ramsey r-complete subsequence. The optimal density is ~(log N)².\n\n**Density Bounds:**\n- Upper: ∃ r-Ramsey complete A with |A ∩ [1,N]| ≪ r(log N)² (CFP 2021)\n- Lower: Any r-Ramsey complete A has |A ∩ [1,N]| ≫ (log N)² (CFP 2021)\n- Previous best: |A ∩ [1,N]| ≪ (log N)³ (Burr-Erdős 1985)",
     "text": "Are the squares Ramsey 2-complete? That is, in any 2-coloring of the squares, can every sufficiently large n be written as a monochromatic sum of distinct squares? Answer: YES (Conlon-Fox-Pham 2021).",
     "proofStrategy": "The formalization defines Ramsey r-completeness, the sets of squares and k-th powers, and the original question. Conlon-Fox-Pham's 2021 result is axiomatized: k-th powers contain sparse Ramsey r-complete subsequences. The main theorem follows: since a sparse subsequence of squares (= 2nd powers) is Ramsey 2-complete, the full set of squares is also Ramsey 2-complete. Related density bounds and Lagrange's four squares theorem provide context.",
     "keyInsights": [
       "A set is Ramsey r-complete if every r-coloring allows monochromatic sum representations of large integers",
       "Squares = 2nd powers, so the general k-th power result implies the squares result",
-      "The optimal density threshold for Ramsey completeness is (log N)\u00b2",
-      "Conlon-Fox-Pham improved Burr-Erd\u0151s's (log N)\u00b3 bound to the optimal (log N)\u00b2",
+      "The optimal density threshold for Ramsey completeness is (log N)²",
+      "Conlon-Fox-Pham improved Burr-Erdős's (log N)³ bound to the optimal (log N)²",
       "Lagrange's four squares theorem is related but doesn't directly imply Ramsey completeness"
     ],
     "prerequisites": [
@@ -51,74 +51,74 @@
     {
       "id": "basic-definitions",
       "title": "Part I: Basic Definitions",
-      "startLine": 43,
-      "endLine": 72,
+      "startLine": 45,
+      "endLine": 74,
       "summary": "Coloring, IsMonochromatic, HasDistinctSumRep definitions.",
       "mathContext": "Formal definition: Coloring, IsMonochromatic, HasDistinctSumRep definitions."
     },
     {
       "id": "ramsey-completeness",
       "title": "Part II: Ramsey r-Completeness",
-      "startLine": 73,
-      "endLine": 103,
+      "startLine": 75,
+      "endLine": 105,
       "summary": "IsRamseyComplete, Squares, KthPowers, SquaresRamsey2Complete definitions.",
       "mathContext": "Formal definition: IsRamseyComplete, Squares, KthPowers, SquaresRamsey2Complete definitions."
     },
     {
       "id": "original-conjecture",
       "title": "Part III: The Original Conjecture",
-      "startLine": 104,
-      "endLine": 123,
+      "startLine": 106,
+      "endLine": 125,
       "summary": "OriginalQuestion and GeneralizedQuestion definitions.",
       "mathContext": "Formal definition: OriginalQuestion and GeneralizedQuestion definitions."
     },
     {
       "id": "historical-results",
       "title": "Part IV: Historical Results",
-      "startLine": 124,
-      "endLine": 163,
+      "startLine": 126,
+      "endLine": 162,
       "summary": "Documents Burr's unpublished result (1985) as a docstring, then declares the `conlon_fox_pham_2021` and `subset_ramsey_complete` axioms, and proves `kth_powers_ramsey_complete` from them.",
       "mathContext": "`burr_unpublished` appears only as a docstring comment — no axiom declaration exists. Formal declarations: `conlon_fox_pham_2021` (axiom, L142), `subset_ramsey_complete` (axiom, L150), `kth_powers_ramsey_complete` (theorem proved from these axioms)."
     },
     {
       "id": "resolution",
       "title": "Part V: Resolution of Problem 843",
-      "startLine": 164,
-      "endLine": 185,
+      "startLine": 163,
+      "endLine": 184,
       "summary": "squares_ramsey_2_complete and erdos_843_resolved theorems.",
       "mathContext": "Verified: squares_ramsey_2_complete and erdos_843_resolved theorems."
     },
     {
       "id": "stronger-results",
       "title": "Part VI: Stronger Results",
-      "startLine": 186,
-      "endLine": 218,
+      "startLine": 185,
+      "endLine": 201,
       "summary": "Records the Conlon-Fox-Pham density bounds and the Burr-Erdős (1985) upper bound as documentation only — no formal `axiom` declarations are introduced.",
       "mathContext": "`cfp_density_bounds` and `burr_erdos_upper_bound` exist only as docstring comments — no formal axiom declarations in this section."
     },
     {
       "id": "related-context",
       "title": "Part VII: Related Results and Context",
-      "startLine": 219,
-      "endLine": 244,
+      "startLine": 202,
+      "endLine": 230,
       "summary": "Related problems, intuition, and Lagrange four squares theorem.",
       "mathContext": "Verified: Related problems, intuition, and Lagrange four squares theorem."
     },
     {
       "id": "summary",
       "title": "Part IX: Summary",
-      "startLine": 245,
+      "startLine": 231,
       "endLine": 256,
       "summary": "erdos_843_summary combining squares_ramsey_2_complete and kth_powers_ramsey_complete.",
       "mathContext": "Mathematical content: erdos_843_summary combining squares_ramsey_2_complete and kth_powers_ramsey_complete."
     }
   ],
   "conclusion": {
-    "summary": "Erd\u0151s Problem #843 asked whether the perfect squares are Ramsey 2-complete: in any 2-coloring, can every large integer be written as a monochromatic sum of distinct squares? The answer is YES, proved by Conlon, Fox, and Pham (2021) via a stronger result about sparse Ramsey complete subsequences of k-th powers.",
-    "implications": "**Theoretical Significance**: The resolution establishes that squares (and all k-th powers) have the strong Ramsey completeness property.\n\nThe (log N)\u00b2 density bound is optimal, answering questions about the sparsest possible Ramsey complete sequences. This connects number theory (sums of powers) with Ramsey theory (colorings).",
+    "summary": "Erdős Problem #843 asked whether the perfect squares are Ramsey 2-complete: in any 2-coloring, can every large integer be written as a monochromatic sum of distinct squares? The answer is YES, proved by Conlon, Fox, and Pham (2021) via a stronger result about sparse Ramsey complete subsequences of k-th powers.",
+    "implications": "**Theoretical Significance**: The resolution establishes that squares (and all k-th powers) have the strong Ramsey completeness property.\n\nThe (log N)² density bound is optimal, answering questions about the sparsest possible Ramsey complete sequences. This connects number theory (sums of powers) with Ramsey theory (colorings).",
     "openQuestions": [
       "Are there other natural sequences (beyond k-th powers) that are Ramsey r-complete?",
-      "What is the exact constant in the (log N)\u00b2 density bound?",
+      "What is the exact constant in the (log N)² density bound?",
       "How does the threshold N depend on r in practical terms?",
       "Can explicit constructions of sparse Ramsey complete sequences be given?"
     ]
@@ -146,17 +146,17 @@
     {
       "targetId": "erdos-45",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: combinatorics, number-theory, ramsey-theory, solved"
+      "description": "Related Erdős problem sharing themes: combinatorics, number-theory, ramsey-theory, solved"
     },
     {
       "targetId": "erdos-532",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: combinatorics, number-theory, ramsey-theory, solved"
+      "description": "Related Erdős problem sharing themes: combinatorics, number-theory, ramsey-theory, solved"
     },
     {
       "targetId": "erdos-1090",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: combinatorics, ramsey-theory, solved"
+      "description": "Related Erdős problem sharing themes: combinatorics, ramsey-theory, solved"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Fix

Corrected all 8 section `startLine`/`endLine` ranges in `src/data/proofs/erdos-843/meta.json` to match actual Part header positions in `Erdos843Problem.lean`.

## Evidence

**Before → After** (verified via `grep -n "Part" proofs/Proofs/Erdos843Problem.lean`):

| Section | Before | After |
|---|---|---|
| basic-definitions | 43–72 | 45–74 |
| ramsey-completeness | 73–103 | 75–105 |
| original-conjecture | 104–123 | 106–125 |
| historical-results | 124–163 | 126–162 |
| resolution | 164–185 | 163–184 |
| stronger-results | 186–218 | 185–201 |
| related-context | 219–244 | 202–230 |
| summary | 245–256 | 231–256 |

Note: Phantom-axiom narrative was already fixed in #13679; only line ranges remained stale.

Closes #13674

---
Automated fix by lean-mechanic agent.