### PR TITLE
audit: tracker sync — erdos-839 issues-found (#13691)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9488,9 +9488,9 @@
     },
     "erdos-839": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-28T19:25:35Z",
+      "result": "issues-found"
     },
     "erdos-84": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Mark `erdos-839` as audited (result: `issues-found`) in `src/data/proofs/audit-tracker.json`.
- Filed #13691 for phantom-axiom narrative drift in `meta.json`: `proofStrategy`/`keyInsights`/`historicalContext`/`originalContributions` describe `liminf_finite` as axiomatized and reference a reciprocal-sum axiom that no longer / never existed in the Lean source. Numerical fields (`axiomCount: 1`, `sorries: 0`, `theoremCount: 14`) are correct.
- Distinct from already-open #13685 (sections-drift), which is being fixed in PR #13690.

## Test plan

- [x] Audit-tracker JSON updated by `./scripts/auditor/claim-target.sh complete erdos-839 issues-found`
- [x] Issue #13691 filed referencing exact line numbers in `proofs/Proofs/Erdos839Problem.lean` (origin/main da07d5e4896)

🤖 Generated with [Claude Code](https://claude.com/claude-code)