### PR TITLE
audit: tracker sync — erdos-84 clean re-audit (post #13684)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9494,9 +9494,9 @@
     },
     "erdos-84": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-28T19:31:10Z",
+      "result": "clean"
     },
     "erdos-840": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Tracker sync for erdos-84 after re-audit on main following PR #13684.

- `auditCount`: 2 → 3
- `lastAudited`: 2026-04-03 → 2026-04-28
- `result`: `issues-fixed` → `clean`

## Verification (current main)

| Field | meta.json | Lean source | Match |
|---|---|---|---|
| lineCount | 268 | 268 | ✓ |
| axiomCount | 7 | 7 | ✓ |
| sorries | 0 | 0 | ✓ |
| theoremCount | 4 | 4 | ✓ |
| definitionCount | 6 | 6 | ✓ |

Section ranges (47-268) all align with Part I-IX header lines.

Originality narrative properly hedges docstring-only items (e.g. `limit_bounds`, small-values, Verstraëte's quantitative bound) — no phantom-axiom claims.

## Test plan

- [x] tracker JSON validates
- [x] no other files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)