### PR TITLE
fix(erdos-835): remove phantom proofStrategy claims + realign section line ranges

### DIFF
--- a/src/data/proofs/erdos-835/meta.json
+++ b/src/data/proofs/erdos-835/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-835",
-  "title": "Erd\u0151s Problem #835: Chromatic Number of Johnson Graphs",
+  "title": "Erdős Problem #835: Chromatic Number of Johnson Graphs",
   "slug": "erdos-835",
-  "description": "Does there exist k > 2 such that J(2k,k) has chromatic number k+1? SOLVED: NO for 3 \u2264 k \u2264 8. The chromatic number exceeds k+1 in all verified cases.",
+  "description": "Does there exist k > 2 such that J(2k,k) has chromatic number k+1? SOLVED: NO for 3 ≤ k ≤ 8. The chromatic number exceeds k+1 in all verified cases.",
   "meta": {
-    "author": "Erd\u0151s, Rosenfeld",
+    "author": "Erdős, Rosenfeld",
     "sourceUrl": "https://erdosproblems.com/835",
     "date": "",
     "status": "axiomatized",
@@ -48,15 +48,15 @@
     "assumptions": "6 axioms: k_equals_3_fails, k_equals_4_fails, k_equals_5_fails, k_equals_6_fails, k_equals_7_fails, k_equals_8_fails. 2 sorries."
   },
   "overview": {
-    "historicalContext": "This problem was posed by Paul Erd\u0151s and Moshe Rosenfeld. It connects to the broader theory of Johnson graphs $J(n,k)$, named after Selmer M. Johnson who studied them in the context of error-correcting codes in the 1960s. Johnson graphs are a fundamental family in algebraic graph theory \u2014 they are distance-transitive and their eigenvalues are given by Eberlein polynomials (dual Hahn polynomials). The chromatic number question for Johnson graphs relates to the Kneser graph framework: the Kneser graph $K(n,k)$ has the same vertex set but connects disjoint (rather than nearly-equal) subsets. Lov\u00e1sz's celebrated 1978 proof that $\\chi(K(n,k)) = n - 2k + 2$ using algebraic topology was a landmark of topological combinatorics, but the Johnson graph chromatic problem is structurally different and resists similar techniques. Erd\u0151s and Rosenfeld specifically asked whether the $k$-subsets of $\\{1,\\ldots,2k\\}$ can be $(k+1)$-colored so that every $(k+1)$-subset sees all colors \u2014 a 'rainbow' condition equivalent to $\\chi(J(2k,k)) = k + 1$. Computational verification (for $3 \\leq k \\leq 8$) shows the answer is NO: the chromatic number always exceeds $k+1$ except for the trivial case $k = 2$.",
+    "historicalContext": "This problem was posed by Paul Erdős and Moshe Rosenfeld. It connects to the broader theory of Johnson graphs $J(n,k)$, named after Selmer M. Johnson who studied them in the context of error-correcting codes in the 1960s. Johnson graphs are a fundamental family in algebraic graph theory — they are distance-transitive and their eigenvalues are given by Eberlein polynomials (dual Hahn polynomials). The chromatic number question for Johnson graphs relates to the Kneser graph framework: the Kneser graph $K(n,k)$ has the same vertex set but connects disjoint (rather than nearly-equal) subsets. Lovász's celebrated 1978 proof that $\\chi(K(n,k)) = n - 2k + 2$ using algebraic topology was a landmark of topological combinatorics, but the Johnson graph chromatic problem is structurally different and resists similar techniques. Erdős and Rosenfeld specifically asked whether the $k$-subsets of $\\{1,\\ldots,2k\\}$ can be $(k+1)$-colored so that every $(k+1)$-subset sees all colors — a 'rainbow' condition equivalent to $\\chi(J(2k,k)) = k + 1$. Computational verification (for $3 \\leq k \\leq 8$) shows the answer is NO: the chromatic number always exceeds $k+1$ except for the trivial case $k = 2$.",
     "problemStatement": "Does there exist $k > 2$ such that $\\chi(J(2k,k)) = k+1$? Equivalently, can the $k$-subsets of $\\{1,\\ldots,2k\\}$ be colored with $k+1$ colors so that every $(k+1)$-subset contains $k$-subsets of all $k+1$ colors?",
-    "text": "Does there exist k > 2 such that J(2k,k) has chromatic number k+1? SOLVED: NO for 3 \u2264 k \u2264 8. The chromatic number exceeds k+1 in all verified cases.",
-    "proofStrategy": "The formalization captures the full problem landscape: (1) Johnson graph $J(n,k)$ defined with $k$-subsets as vertices and adjacency via $|S \\cap T| = k-1$. (2) Proper colorings and chromatic number via `Nat.find`. (3) The Erd\u0151s-Rosenfeld rainbow property as a predicate on colorings. (4) An equivalence axiom linking the rainbow property to $\\chi(J(2k,k)) = k+1$. (5) Computational results axiomatized for $k = 3$ through $k = 8$, each showing $\\chi > k+1$. (6) Bounds $k+1 \\leq \\chi(J(2k,k)) \\leq 2k$. (7) The main theorem `erdos_835` proving failure for $3 \\leq k \\leq 8$ via `interval_cases`.",
+    "text": "Does there exist k > 2 such that J(2k,k) has chromatic number k+1? SOLVED: NO for 3 ≤ k ≤ 8. The chromatic number exceeds k+1 in all verified cases.",
+    "proofStrategy": "The formalization captures the full problem landscape: (1) Johnson graph $J(n,k)$ defined with $k$-subsets as vertices and adjacency via $|S \\cap T| = k-1$. (2) Proper colorings and chromatic number via `Nat.find`. (3) The Erdős-Rosenfeld rainbow property as a predicate on colorings. (4) A docstring outlining the (un-formalized) equivalence between the rainbow property and $\\chi(J(2k,k)) = k+1$. (5) Computational results axiomatized for $k = 3$ through $k = 8$, each showing $\\chi > k+1$. (6) Docstrings sketching bounds $k+1 \\leq \\chi(J(2k,k)) \\leq 2k$ (not formally axiomatized). (7) The main theorem `erdos_835` proving failure for $3 \\leq k \\leq 8$ via `interval_cases`.",
     "keyInsights": [
-      "**Johnson graph structure**: $J(n,k)$ has $\\binom{n}{k}$ vertices and each vertex has degree $k(n-k)$. For $J(2k,k)$, this gives $k^2$-regular graphs on $\\binom{2k}{k}$ vertices \u2014 large, highly symmetric graphs whose chromatic numbers are hard to determine exactly.",
-      "**Rainbow coloring equivalence**: The Erd\u0151s-Rosenfeld property \u2014 every $(k+1)$-subset sees all colors \u2014 is equivalent to achieving the chromatic number lower bound $\\chi = k+1$. This connects a combinatorial coloring constraint to a graph-theoretic invariant.",
+      "**Johnson graph structure**: $J(n,k)$ has $\\binom{n}{k}$ vertices and each vertex has degree $k(n-k)$. For $J(2k,k)$, this gives $k^2$-regular graphs on $\\binom{2k}{k}$ vertices — large, highly symmetric graphs whose chromatic numbers are hard to determine exactly.",
+      "**Rainbow coloring equivalence**: The Erdős-Rosenfeld property — every $(k+1)$-subset sees all colors — is equivalent to achieving the chromatic number lower bound $\\chi = k+1$. This connects a combinatorial coloring constraint to a graph-theoretic invariant.",
       "**Chromatic gap grows**: The known values $\\chi(J(2k,k))$ for $k = 2,\\ldots,8$ are $3, 4, 7, 8, 11, 13, 15$, while $k+1 = 3, 4, 5, 6, 7, 8, 9$. The gap $\\chi - (k+1)$ is $0, 0, 2, 2, 4, 5, 6$, growing with $k$.",
-      "**Connection to Kneser graphs**: The Kneser graph $K(n,k)$ connects disjoint $k$-subsets, while $J(n,k)$ connects nearly-equal ones. Lov\u00e1sz proved $\\chi(K(n,k)) = n - 2k + 2$ using the Borsuk-Ulam theorem, but Johnson graph chromatic numbers lack such clean formulas.",
+      "**Connection to Kneser graphs**: The Kneser graph $K(n,k)$ connects disjoint $k$-subsets, while $J(n,k)$ connects nearly-equal ones. Lovász proved $\\chi(K(n,k)) = n - 2k + 2$ using the Borsuk-Ulam theorem, but Johnson graph chromatic numbers lack such clean formulas.",
       "**Only $k = 2$ works**: $J(4,2)$ is isomorphic to $K_3 \\square K_2$ (the octahedron graph) with $\\chi = 3 = 2 + 1$. For all $k \\geq 3$, the additional structure forces higher chromatic numbers."
     ],
     "prerequisites": [
@@ -71,8 +71,8 @@
       "title": "Problem Statement and Background",
       "startLine": 1,
       "endLine": 35,
-      "summary": "Header documenting Erd\u0151s Problem #835: the Erd\u0151s-Rosenfeld question on coloring $k$-subsets with a rainbow property, equivalent to $\\chi(J(2k,k)) = k+1$. Imports Mathlib graph coloring and Finset modules.",
-      "mathContext": "Header documenting Erd\u0151s Problem #835: the Erd\u0151s-Rosenfeld question on coloring $k$-subsets with a rainbow property, equivalent to $\\chi(J(2k,k)) = k+1$."
+      "summary": "Header documenting Erdős Problem #835: the Erdős-Rosenfeld question on coloring $k$-subsets with a rainbow property, equivalent to $\\chi(J(2k,k)) = k+1$. Imports Mathlib graph coloring and Finset modules.",
+      "mathContext": "Header documenting Erdős Problem #835: the Erdős-Rosenfeld question on coloring $k$-subsets with a rainbow property, equivalent to $\\chi(J(2k,k)) = k+1$."
     },
     {
       "id": "johnson-graphs",
@@ -92,7 +92,7 @@
     },
     {
       "id": "erdos-rosenfeld",
-      "title": "The Erd\u0151s-Rosenfeld Rainbow Property",
+      "title": "The Erdős-Rosenfeld Rainbow Property",
       "startLine": 68,
       "endLine": 81,
       "summary": "Defines `hasErdosRosenfeldProperty`: a $(k+1)$-coloring where $\\forall A \\subseteq \\{1,\\ldots,2k\\}$ with $|A| = k+1$, every color $c \\in \\text{Fin}(k+1)$ appears among the $k$-subsets of $A$.",
@@ -102,42 +102,42 @@
       "id": "equivalence",
       "title": "Equivalence to Chromatic Number",
       "startLine": 82,
-      "endLine": 94,
-      "summary": "Axiomatizes the key equivalence: $\\text{ErdosRosenfeldQuestion}(k) \\iff \\chi(J(2k,k)) = k + 1$. This transforms the combinatorial rainbow condition into a pure graph coloring question.",
-      "mathContext": "Axiomatized: Axiomatizes the key equivalence: $\\text{ErdosRosenfeldQuestion}(k) \\iff \\chi(J(2k,k)) = k + 1$. This transforms the combinatorial rainbow condition into a pure graph coloring question."
+      "endLine": 90,
+      "summary": "Documents (as a docstring only) the key equivalence: $\\text{ErdosRosenfeldQuestion}(k) \\iff \\chi(J(2k,k)) = k + 1$. No axiom or theorem is declared — the connection to $\\chi(J(2k,k)) = k+1$ is noted in a comment only.",
+      "mathContext": "The equivalence between the Erdős-Rosenfeld rainbow property and $\\chi(J(2k,k)) = k + 1$ is stated in a docstring comment but is not formally declared as an axiom or theorem. The connection is well-known but lies outside the scope of the current formalization."
     },
     {
       "id": "known-results",
       "title": "Known Results: $k = 2$ through $k = 8$",
-      "startLine": 95,
-      "endLine": 124,
+      "startLine": 91,
+      "endLine": 120,
       "summary": "Base case $k = 2$ proved constructively. Failure for $k = 3,\\ldots,8$ axiomatized from computational results: $\\chi(J(6,3)) = 4$, $\\chi(J(8,4)) = 7$, $\\chi(J(10,5)) = 8$, $\\chi(J(12,6)) = 11$, $\\chi(J(14,7)) = 13$, $\\chi(J(16,8)) = 15$.",
       "mathContext": "Base case $k = 2$ proved constructively. Failure for $k = 3,\\ldots,8$ axiomatized from computational results: $\\chi(J(6,3)) = 4$, $\\chi(J(8,4)) = 7$, $\\chi(J(10,5)) = 8$, $\\chi(J(12,6)) = 11$, $\\chi(J(14,7)) = 13$, $\\chi(J(16,8)) = 15$."
     },
     {
       "id": "bounds",
       "title": "Chromatic Number Bounds",
-      "startLine": 125,
-      "endLine": 146,
-      "summary": "Axiomatizes $k + 1 \\leq \\chi(J(2k,k)) \\leq 2k$ and the table of known chromatic numbers. Only $k = 2$ achieves the lower bound.",
-      "mathContext": "Axiomatized: Axiomatizes $k + 1 \\leq \\chi(J(2k,k)) \\leq 2k$ and the table of known chromatic numbers. Only $k = 2$ achieves the lower bound."
+      "startLine": 121,
+      "endLine": 127,
+      "summary": "Documents (as dangling docstrings only) the lower bound $k + 1 \\leq \\chi(J(2k,k))$, upper bound $\\chi(J(2k,k)) \\leq 2k$, and the table of computed values. No axiom or theorem is declared for these bounds.",
+      "mathContext": "The bounds $k+1 \\leq \\chi(J(2k,k)) \\leq 2k$ are described in three dangling docstrings (\\`Lower bound\\`, \\`Upper bound\\`, \\`Computed values\\`) at lines 125-127 with no following declarations. The known chromatic values for $k = 3,\\ldots,8$ are given only in the docstring text."
     },
     {
       "id": "main-theorem",
       "title": "Main Theorem and Answer",
-      "startLine": 147,
+      "startLine": 128,
       "endLine": 177,
       "summary": "The main theorem `erdos_835` proves $\\forall k,\\, 3 \\leq k \\leq 8 \\Rightarrow \\neg\\text{ErdosRosenfeldQuestion}(k)$ via `interval_cases`. Also proves $k = 2$ is the unique solution in range $[2, 8]$.",
       "mathContext": "Verified: The main theorem `erdos_835` proves $\\forall k,\\, 3 \\leq k \\leq 8 \\Rightarrow \\neg\\text{ErdosRosenfeldQuestion}(k)$ via `interval_cases`. Also proves $k = 2$ is the unique solution in range $[2, 8]$."
     }
   ],
   "conclusion": {
-    "summary": "Erd\u0151s Problem #835 is solved: for $3 \\leq k \\leq 8$, the Erd\u0151s-Rosenfeld property fails because $\\chi(J(2k,k)) > k + 1$. Only $k = 2$ works, where $J(4,2)$ achieves $\\chi = 3 = k + 1$. The formalization axiomatizes the computational chromatic number values and derives the negative answer via case analysis.",
-    "implications": "**Theoretical Significance**: The failure of the rainbow property reveals that Johnson graphs have richer chromatic structure than the naive lower bound suggests.\n\nThe growing gap between $\\chi(J(2k,k))$ and $k+1$ connects to broader questions about the fractional chromatic number and Shannon capacity of Johnson schemes. The relationship between Johnson and Kneser graph colorings \u2014 where Lov\u00e1sz's topological method gives exact answers for Kneser graphs but fails for Johnson graphs \u2014 highlights the different complexity of 'nearly equal' vs 'disjoint' adjacency conditions.",
+    "summary": "Erdős Problem #835 is solved: for $3 \\leq k \\leq 8$, the Erdős-Rosenfeld property fails because $\\chi(J(2k,k)) > k + 1$. Only $k = 2$ works, where $J(4,2)$ achieves $\\chi = 3 = k + 1$. The formalization axiomatizes the computational chromatic number values and derives the negative answer via case analysis.",
+    "implications": "**Theoretical Significance**: The failure of the rainbow property reveals that Johnson graphs have richer chromatic structure than the naive lower bound suggests.\n\nThe growing gap between $\\chi(J(2k,k))$ and $k+1$ connects to broader questions about the fractional chromatic number and Shannon capacity of Johnson schemes. The relationship between Johnson and Kneser graph colorings — where Lovász's topological method gives exact answers for Kneser graphs but fails for Johnson graphs — highlights the different complexity of 'nearly equal' vs 'disjoint' adjacency conditions.",
     "openQuestions": [
-      "Does $\\chi(J(2k,k)) > k + 1$ hold for ALL $k \\geq 3$? A general proof would fully resolve the Erd\u0151s-Rosenfeld question.",
+      "Does $\\chi(J(2k,k)) > k + 1$ hold for ALL $k \\geq 3$? A general proof would fully resolve the Erdős-Rosenfeld question.",
       "What is the asymptotic growth of $\\chi(J(2k,k))$? The known values suggest roughly linear growth, possibly $\\chi(J(2k,k)) \\sim 2k - o(k)$.",
-      "Is there a closed-form or topological proof, analogous to Lov\u00e1sz's Kneser graph theorem, for the Johnson graph chromatic numbers?",
+      "Is there a closed-form or topological proof, analogous to Lovász's Kneser graph theorem, for the Johnson graph chromatic numbers?",
       "What is the fractional chromatic number $\\chi_f(J(2k,k))$? For Kneser graphs, $\\chi_f(K(n,k)) = n/k$, but the Johnson analogue is open."
     ]
   },
@@ -169,17 +169,17 @@
     {
       "targetId": "erdos-57",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: chromatic-number, combinatorics, graph-theory, solved"
+      "description": "Related Erdős problem sharing themes: chromatic-number, combinatorics, graph-theory, solved"
     },
     {
       "targetId": "erdos-58",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: chromatic-number, combinatorics, graph-theory, solved"
+      "description": "Related Erdős problem sharing themes: chromatic-number, combinatorics, graph-theory, solved"
     },
     {
       "targetId": "erdos-19",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: chromatic-number, combinatorics, graph-theory"
+      "description": "Related Erdős problem sharing themes: chromatic-number, combinatorics, graph-theory"
     }
   ],
   "sorries": 2


### PR DESCRIPTION
## Fix

Remove phantom-axiom narrative from `meta.proofStrategy` and realign section `startLine`/`endLine` to match actual Lean file structure.

## Evidence

**Before**:
- `proofStrategy` step (4): *"An equivalence axiom linking the rainbow property to χ(J(2k,k)) = k+1"* — no such axiom/theorem exists; lines 86–90 are a docstring only
- `proofStrategy` step (6): *"Bounds k+1 ≤ χ(J(2k,k)) ≤ 2k"* — no such theorems; lines 125–127 are three dangling docstrings
- `sections[equivalence].endLine`: 94 (absorbs Part V header at line 91)
- `sections[known-results].startLine`: 95 (misses Part V header at line 91)
- `sections[bounds].startLine`: 125 / `endLine`: 146 (off by 4/+19 — splits `theorem erdos_835` mid-proof)
- `sections[main-theorem].startLine`: 147 (`· exact k_equals_5_fails` mid-interval_cases)

**After**:
- `proofStrategy` steps (4) and (6) rephrased to accurately describe docstrings
- `equivalence`: 82–90
- `known-results`: 91–120
- `bounds`: 121–127
- `main-theorem`: 128–177

No Lean source change. No change to numerical fields (`axiomCount`, `sorries`, `lineCount`).

Closes #13698

---
Automated fix by lean-mechanic agent.