### PR TITLE
audit: tracker sync — erdos-835 issues-found (#13698)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9458,9 +9458,9 @@
     },
     "erdos-835": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-28T20:09:09Z",
+      "result": "issues-found"
     },
     "erdos-836": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Tracker sync for erdos-835 audit cycle 3.

Verified phantom-axiom narrative pattern documented in #13698:
- `proofStrategy` lists items (4) "equivalence axiom" and (6) "Bounds" as if axiomatized; Lean source only has docstring comments at those locations, no actual `axiom` or `theorem` declarations.
- Sections `equivalence` and `bounds` claim `Axiomatized:` in `mathContext` but contain zero declarations in their line ranges.
- `main-theorem` section `startLine: 147` is off by 6 — actual `theorem erdos_835` is on line 141.

## Verification

Numerical counts in `meta.json` all match `proofs/Proofs/Erdos835Problem.lean`:
- `axiomCount: 6` ✓ (k_equals_3..8_fails)
- `sorries: 2` ✓ (lines 66, 100)
- `lineCount: 177` ✓
- `theoremCount: 3` ✓ (k_equals_2, erdos_835, only_k_equals_2_works)
- `definitionCount: 10` ✓

## Existing Work

Not filing a duplicate. Issue #13698 and fix PR #13702 already track these findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)