### PR TITLE
audit: tracker sync — erdos-835 clean re-audit (post #13702)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9458,9 +9458,9 @@
     },
     "erdos-835": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T20:09:09Z",
-      "result": "issues-found"
+      "auditCount": 4,
+      "lastAudited": "2026-04-28T20:14:53Z",
+      "result": "clean"
     },
     "erdos-836": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Re-audited erdos-835 after PR #13702 corrected the phantom proofStrategy claims and section line drift originally filed in #13698. All issues are now resolved.

Verified against `proofs/Proofs/Erdos835Problem.lean` (177 lines):
- 6 axioms (k_equals_3_fails through k_equals_8_fails) — matches `axiomCount: 6`
- 2 sorries (line 66 in `chromaticNumber`, line 100 in `k_equals_2`) — matches `sorries: 2`
- 3 theorems, 10 definitions, 3 imports, namespace `Erdos835`, opens `Finset` — all match
- Section ranges 82-90 (equivalence), 91-120 (known-results), 121-127 (bounds), 128-177 (main-theorem) align with the `## Part IV..VII` block structure
- Phantom narrative removed: `equivalence` and `bounds` sections now correctly describe their content as docstring-only (no axioms exist for them)

Tracker: `issues-found` → `clean`.

## Test plan
- [x] `find-targets.ts --next` returned erdos-835 with stale `issues-found`
- [x] Verified meta.json matches Lean source post-#13702
- [x] No outstanding gallery integrity issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)