### PR TITLE
audit(erdos-829): tracker sync — re-audit issues-found

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9416,9 +9416,9 @@
     },
     "erdos-829": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-28T20:45:16Z",
+      "result": "issues-found"
     },
     "erdos-83": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Re-audit of erdos-829 confirms findings already in flight via issue #13707 / PR #13710
- Updates `audit-tracker.json` (auditCount 2→3, result issues-fixed→issues-found, timestamp)

## What I found
- **Phantom declarations** in `originalContributions`: `mahler_1935` and `density_of_sums` are listed but absent from `proofs/Proofs/Erdos829Problem.lean`
- **Section line drift**: `lower-bounds`, `famous-examples`, `theory`, `the-gap`, `summary` ranges shifted vs actual `## Part` markers in source
- **Numerical counts correct**: sorries=0, axioms=2 (mordell_unbounded, stewart_2008), lineCount=196 — all match meta.json

## In flight
- Issue #13707 (loom:auditor)
- PR #13710 (fix/mechanic-13707) — addresses both findings

No new issue filed (per duplicate-prevention rule).

## Test plan
- [x] Verified Lean source counts via `git show HEAD:proofs/Proofs/Erdos829Problem.lean`
- [x] Confirmed `## Part` markers at lines 38, 72, 90, 121, 150, 161, 169
- [x] Tracker updated via `claim-target.sh complete`

🤖 Generated with [Claude Code](https://claude.com/claude-code)