### PR TITLE
audit: tracker sync — erdos-832 clean re-audit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9440,9 +9440,9 @@
     },
     "erdos-832": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-28T20:48:57Z",
+      "result": "clean"
     },
     "erdos-833": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
Re-audited erdos-832 after PR #13700 (phantom-axiom + section-drift fix). Verified the fix landed correctly and the gallery entry now matches the Lean source.

## Verification
- 3 axioms in `proofs/Proofs/Erdos832Problem.lean`: `alon_disproof`, `m`, `cherkashin_petrov_limit`
- 0 sorries, 140 lines, 1 theorem (`erdos_832`)
- Section line ranges align with Lean source (Parts I–VIII)
- `originalContributions`, `proofStrategy`, `assumptions` accurately describe the axiomatization
- `find-targets.ts --next` reports no detected issues

Tracker entry: `auditCount=3`, `lastAudited=2026-04-28T20:48:57Z`, `result=clean`.

## Test plan
- [x] `npx tsx scripts/auditor/find-targets.ts --json --next` reports `detectedIssues: []` for erdos-832
- [x] `git diff HEAD~1` shows only `src/data/proofs/audit-tracker.json` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)