### PR TITLE
audit(erdos-1078): fix section line range drift in meta.json

### DIFF
--- a/src/data/proofs/erdos-1078/meta.json
+++ b/src/data/proofs/erdos-1078/meta.json
@@ -117,22 +117,22 @@
       "id": "comparison",
       "title": "Part VI: Comparison with BES Threshold",
       "startLine": 165,
-      "endLine": 176,
+      "endLine": 172,
       "summary": "asymptotic_agreement: sharp threshold ≈ (r-3/2)n.",
       "mathContext": "Mathematical content: asymptotic_agreement: sharp threshold ≈ (r-3/2)n."
     },
     {
       "id": "transversals",
       "title": "Part VII: Connection to Transversals",
-      "startLine": 177,
-      "endLine": 197,
+      "startLine": 173,
+      "endLine": 188,
       "summary": "IsIndependentTransversal definition and extremal_construction.",
       "mathContext": "Formal definition: IsIndependentTransversal definition and extremal_construction."
     },
     {
       "id": "summary",
       "title": "Part VIII: Summary",
-      "startLine": 198,
+      "startLine": 189,
       "endLine": 205,
       "summary": "erdos_1078_summary combining haxell_theorem, threshold_tight, haxell_szabo_theorem, threshold_sharp.",
       "mathContext": "Verified: erdos_1078_summary combining haxell_theorem, threshold_tight, haxell_szabo_theorem, threshold_sharp."


### PR DESCRIPTION
## Summary

- Fixes 3 drifted section line ranges in `src/data/proofs/erdos-1078/meta.json`
- Verified by comparing against `/- ## Part X -/` headers in `proofs/Proofs/Erdos1078Problem.lean` (205 lines, on origin/main)

## Drift detected

| Section | Was | Now | Note |
|---|---|---|---|
| comparison | 165-176 | 165-172 | endLine off by +4 (header at 173 belongs to next section) |
| transversals | 177-197 | 173-188 | startLine -4, endLine -9 (header is at 173; ends before Part VIII at 189) |
| summary | 198-205 | 189-205 | startLine -9 (Part VIII header is at 189; theorem at 195) |

## Other integrity fields (all verified clean on origin/main)

- `sorries: 0` matches actual count
- `axiomCount: 4` matches the four `axiom` declarations: `threshold_tight` (78), `haxell_theorem` (93), `haxell_szabo_theorem` (125), `threshold_sharp` (133)
- `lineCount: 205` matches
- `status: axiomatized` and `badge: axiom` are correct (4 axiom declarations make this Tier C)
- No True stubs

## Test plan

- [ ] `pnpm build` succeeds (gallery JSON parses)
- [ ] Proof page renders sections in correct line ranges

🤖 Generated with [Claude Code](https://claude.com/claude-code)