### PR TITLE
fix(erdos-811): remove phantom-axiom narrative + realign section lines

### DIFF
--- a/src/data/proofs/erdos-811/meta.json
+++ b/src/data/proofs/erdos-811/meta.json
@@ -61,7 +61,7 @@
     "historicalContext": "**Erdős Problem #811: Rainbow Graphs in Balanced Edge-Colorings**\n\nThis problem was posed by Erdős, Pyber, and Tuza in 1991, building on the anti-Ramsey theory initiated by Erdős, Simonovits, and Sós in 1975. While classical Ramsey theory asks for *monochromatic* subgraphs (all edges the same color), anti-Ramsey theory studies *rainbow* subgraphs (all edges different colors). Problem #811 introduces an elegant twist: rather than arbitrary colorings, it restricts attention to *balanced* colorings where each vertex sees exactly the same number of edges of each color.\n\n**The Balance Constraint:** A balanced $m$-coloring of $K_n$ requires $\\deg_c(v) = (n-1)/m$ for every vertex $v$ and color $c$. This is only possible when $m \\mid (n-1)$, i.e., $n \\equiv 1 \\pmod{m}$. The balance condition eliminates trivial counterexamples where one color class is deliberately arranged to avoid a particular subgraph.\n\n**Resolution Timeline:**\n- **1991**: Erdős, Pyber, and Tuza pose the problem, establish bounds for $C_4$ ($\\lfloor n/6 \\rfloor \\leq d_{C_4}(n) \\leq (1/4 - c)n$), and ask the specific challenge about $C_6$ and $K_4$ in 6-colorings.\n- **2023**: Clemen and Wagner prove that $K_4$ does NOT have the rainbow property — a major breakthrough resolving the simplest open case negatively.\n- **2024**: Axenovich and Clemen extend this, showing infinitely many complete graphs $K_m$ fail the rainbow property, and conjecture that ALL $K_m$ with $m \\geq 4$ fail.\n\n**The Emerging Picture:** Trees and stars have the rainbow property (folklore), but complete graphs appear not to (for $m \\geq 4$). The characterization of which graphs have the rainbow property remains wide open. The Axenovich-Clemen conjecture, if true, would draw a sharp line: acyclic graphs (trees) succeed, but highly connected graphs (complete graphs) fail.",
     "problemStatement": "For which graphs $G$ (with $m = e(G)$ edges) is it true that for all large $n \\equiv 1 \\pmod{m}$, every balanced $m$-coloring of $K_n$ contains a rainbow copy of $G$?\n\nKnown: $K_4$ does NOT have this property (Clemen-Wagner 2023). Infinitely many $K_m$ fail (Axenovich-Clemen 2024). Trees and stars DO have the property (folklore).\n\nSpecific challenge (Erdős): In any balanced 6-coloring of $K_{6n+1}$, must there exist a rainbow $C_6$ or rainbow $K_4$? (The $K_4$ part is now known to fail.)",
     "text": "Characterize graphs G such that every balanced edge-coloring of K_n contains a rainbow copy of G. K_4 fails (Clemen-Wagner 2023), but full characterization is open.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Coloring Infrastructure:** `EdgeColoring n m` with symmetry and irreflexivity; `colorDegree` counts edges per color per vertex; `IsBalanced` requires uniform color degrees.\n\n2. **Rainbow Framework:** `GraphEmbedding G n` for injective vertex maps; `IsRainbow` for edge-color injectivity; `ContainsRainbow` existentially quantifies.\n\n3. **The Central Definition:** `HasRainbowProperty G m` uses an `∃ N₀, ∀ n ≥ N₀` quantifier for the 'eventually for all large $n$' requirement.\n\n4. **Known Negative Results:** Two axioms capture Clemen-Wagner ($K_4$ fails) and Axenovich-Clemen (infinitely many $K_m$ fail). The conjecture `AxenovichClemenConjecture` strengthens to all $m ≥ 4$.\n\n5. **Known Positive Results:** Axioms for trees and stars having the rainbow property.\n\n6. **Main Theorem:** `erdos_811` packages both negative results as a clean conjunction.",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Coloring Infrastructure:** `EdgeColoring n m` with symmetry and irreflexivity; `colorDegree` counts edges per color per vertex; `IsBalanced` requires uniform color degrees.\n\n2. **Rainbow Framework:** `GraphEmbedding G n` for injective vertex maps; `IsRainbow` for edge-color injectivity; `ContainsRainbow` existentially quantifies.\n\n3. **The Central Definition:** `HasRainbowProperty G m` uses an `∃ N₀, ∀ n ≥ N₀` quantifier for the 'eventually for all large $n$' requirement.\n\n4. **Known Negative Results:** Two axioms capture Clemen-Wagner ($K_4$ fails) and Axenovich-Clemen (infinitely many $K_m$ fail). The conjecture `AxenovichClemenConjecture` strengthens to all $m ≥ 4$.\n\n5. **Known Positive Results:** Trees and stars are noted via docstrings as having the rainbow property (folklore); these are not formalized as axioms or theorems in this file.\n\n6. **Quantitative Version:** A `rainbowMinDegree` axiom introduces the rainbow minimum-degree function; the Erdős-Tuza bound for $C_4$ is referenced in a docstring but not formalized.\n\n7. **Main Theorem:** `erdos_811` packages both negative results as a clean conjunction.",
     "keyInsights": [
       "**Balance Eliminates Trivial Counterexamples:** Without the balance constraint, avoiding rainbow copies is easy: make one color class a large matching, isolating edges from forming rainbow subgraphs. The balance condition forces every color to appear uniformly, making avoidance much harder — but as Clemen-Wagner showed, not impossible.",
       "**The K₄ Failure is Surprising:** Before Clemen-Wagner (2023), it was widely expected that all 'reasonable' graphs would have the rainbow property. $K_4$ is the smallest complete graph where the question is non-trivial ($K_2$ and $K_3$ trivially have it), and its failure suggests a fundamental obstruction related to the interaction between balance and rainbow avoidance in clique structures.",
@@ -96,64 +96,64 @@
     {
       "id": "balanced",
       "title": "Balanced Colorings",
-      "summary": "IsBalanced predicate (uniform color degree) and balanced_existence axiom requiring n ≡ 1 (mod m)",
+      "summary": "IsBalanced predicate (uniform color degree); a docstring notes that balanced colorings exist only when n ≡ 1 (mod m), but no balanced-existence axiom is declared",
       "startLine": 53,
-      "endLine": 64,
-      "mathContext": "Axiomatized: IsBalanced predicate (uniform color degree) and balanced_existence axiom requiring n ≡ 1 (mod m)"
+      "endLine": 61,
+      "mathContext": "Formal definition: IsBalanced predicate (uniform color degree); a docstring notes that balanced colorings exist only when n ≡ 1 (mod m), but no balanced-existence axiom is declared"
     },
     {
       "id": "rainbow",
       "title": "Rainbow Subgraphs",
       "summary": "GraphEmbedding (injective vertex map), IsRainbow (edge-color injectivity), ContainsRainbow (existential rainbow copy)",
-      "startLine": 65,
-      "endLine": 84,
+      "startLine": 62,
+      "endLine": 80,
       "mathContext": "Mathematical content: GraphEmbedding (injective vertex map), IsRainbow (edge-color injectivity), ContainsRainbow (existential rainbow copy)"
     },
     {
       "id": "rainbow-property",
       "title": "The Rainbow Property",
       "summary": "HasRainbowProperty: for large n ≡ 1 (mod m), every balanced coloring contains a rainbow G",
-      "startLine": 85,
-      "endLine": 94,
+      "startLine": 82,
+      "endLine": 90,
       "mathContext": "Mathematical content: HasRainbowProperty: for large n ≡ 1 (mod m), every balanced coloring contains a rainbow G"
     },
     {
       "id": "known-results",
       "title": "Known Results: K₄ and Complete Graphs",
       "summary": "Clemen-Wagner axiom (K₄ fails), Axenovich-Clemen axiom (infinitely many K_m fail), and the AxenovichClemenConjecture (all K_m fail for m ≥ 4)",
-      "startLine": 95,
-      "endLine": 116,
+      "startLine": 92,
+      "endLine": 112,
       "mathContext": "Clemen-Wagner axiom (K₄ fails), Axenovich-Clemen axiom (infinitely many K_m fail), and the AxenovichClemenConjecture (all K_m fail for m $\\geq$ 4)"
     },
     {
       "id": "quantitative",
       "title": "Quantitative Version: Rainbow Minimum Degree",
-      "summary": "Axiomatized rainbowMinDegree function; Erdős-Tuza bounds for C₄: ⌊n/6⌋ ≤ d_{C₄}(n) ≤ (1/4 - c)n",
-      "startLine": 117,
-      "endLine": 134,
-      "mathContext": "Axiomatized rainbowMinDegree function; Erdős-Tuza bounds for C₄: ⌊n/6⌋ $\\leq$ d_{C₄}(n) $\\leq$ (1/4 - c)n"
+      "summary": "Axiomatized rainbowMinDegree function; the Erdős-Tuza bounds for C₄ (⌊n/6⌋ ≤ d_{C₄}(n) ≤ (1/4 − c)n) are referenced in a docstring but not formalized",
+      "startLine": 114,
+      "endLine": 123,
+      "mathContext": "Axiomatized rainbowMinDegree function; the Erdős-Tuza bounds for C₄ ($\\lfloor n/6 \\rfloor \\leq d_{C_4}(n) \\leq (1/4 - c)n$) are referenced in a docstring but not formalized"
     },
     {
       "id": "erdos-challenge",
       "title": "Erdős's Specific Challenge",
       "summary": "ErdosChallenge: rainbow C₆ or K₄ in balanced 6-colorings of K_{6n+1}; K₄ part resolved negatively",
-      "startLine": 135,
-      "endLine": 153,
+      "startLine": 124,
+      "endLine": 137,
       "mathContext": "Mathematical content: ErdosChallenge: rainbow C₆ or K₄ in balanced 6-colorings of K_{6n+1}; K₄ part resolved negatively"
     },
     {
       "id": "small-cases",
       "title": "Small Cases: Trees and Stars",
-      "summary": "Axioms: trees have the rainbow property (folklore); stars K_{1,m} have the rainbow property",
-      "startLine": 154,
-      "endLine": 167,
-      "mathContext": "Axiomatized: Axioms: trees have the rainbow property (folklore); stars K_{1,m} have the rainbow property"
+      "summary": "Docstrings note that trees and stars K_{1,m} have the rainbow property (folklore); no axioms or theorems are declared in this section",
+      "startLine": 138,
+      "endLine": 143,
+      "mathContext": "Documentation: Docstrings note that trees and stars K_{1,m} have the rainbow property (folklore); no axioms or theorems are declared in this section"
     },
     {
       "id": "summary",
       "title": "Main Theorem and Summary",
       "summary": "erdos_811 combines K₄ failure and infinitely-many-K_m failure as conjunction; proved by pairing axioms",
-      "startLine": 168,
+      "startLine": 144,
       "endLine": 169,
       "mathContext": "Axiomatized: erdos_811 combines K₄ failure and infinitely-many-K_m failure as conjunction; proved by pairing axioms"
     }


### PR DESCRIPTION
## Summary

Audit of `erdos-811` found the same phantom-axiom narrative + section line drift pattern as the recent erdos-8XX/9XX cluster (#13713, #13719).

**Phantom axioms (claimed in narrative, not in source):**
- Section `balanced` claimed a `balanced_existence` axiom — only a bare docstring exists at line 61 (no axiom declaration).
- Section `small-cases` claimed "Axioms: trees have the rainbow property; stars K_{1,m} have the rainbow property" — only dangling `/-- ... -/` docstrings at lines 142–143.
- `proofStrategy` point 5 echoed the phantom trees/stars axioms.

**Actual axioms** (matching `axiomCount: 3` and `assumptions`): `clemen_wagner_2023`, `axenovich_clemen_2024`, `rainbowMinDegree`.

**Section line drift:** every section's `endLine` had crept into the next `## Part N` comment header (typically +3 lines). The `quantitative` section drifted ~7 lines into Part 7's territory, cascading misalignment into `erdos-challenge`, `small-cases`, and `summary`. All section ranges realigned to the actual part structure of `proofs/Proofs/Erdos811Problem.lean`.

No changes to numerical fields (`axiomCount`, `lineCount`, `sorries`, `theoremCount`) — those were already correct.

## Test plan
- [x] `jq -e . meta.json` passes
- [x] Section ranges audited line-by-line against `Erdos811Problem.lean`
- [x] No phantom axioms remain in `proofStrategy`, section `summary` / `mathContext` fields
- [ ] CI build of gallery passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)