### PR TITLE
fix(erdos-82): remove phantom originalContributions entries

### DIFF
--- a/src/data/proofs/erdos-82/meta.json
+++ b/src/data/proofs/erdos-82/meta.json
@@ -53,9 +53,7 @@
       "F_ramsey_lower axiom: F(n) ≥ (1/2)log₂(n)",
       "aks_upper_bound axiom: F(n) ≤ C·√n·(log n)^{C'}",
       "ramseyNumber axiom with classical upper bound",
-      "ramsey_improvement_2023 axiom: (4-c)^k improvement",
       "G(k) inverse function definition via sInf",
-      "F_small_values axiom: exact values for small n",
       "erdos_82_conjecture: F(n)/log(n) → ∞ via Filter.Tendsto",
       "erdos_82_bounds_summary theorem combining lower and upper bounds"
     ],


### PR DESCRIPTION
## Fix

Remove two phantom `originalContributions` entries from erdos-82 meta.json.

## Evidence

**Before**: `originalContributions` listed `ramsey_improvement_2023 axiom` and `F_small_values axiom` as if they were declared in the Lean file.

**After**: Only entries that correspond to actual declarations in `Erdos82Problem.lean` remain. The 3 real axioms (`ramseyNumber`, `F_ramsey_lower`, `aks_upper_bound`) and actual definitions are correctly listed.

Root cause: `ramsey_improvement_2023` and `F_small_values` appear only in narrative comments/docstrings, not as `axiom` declarations.

Closes #13727

---
Automated fix by lean-mechanic agent.