### PR TITLE
fix(erdos-819): remove phantom originalContributions + realign sections

### DIFF
--- a/src/data/proofs/erdos-819/meta.json
+++ b/src/data/proofs/erdos-819/meta.json
@@ -53,7 +53,6 @@
       "erdos_freud_upper axiom: f(N) ≤ (1/2 + o(1))N",
       "erdos_freud_bounds theorem: combined bounds proved from axioms",
       "IsQuasiSidon: bounded representation count definition",
-      "problem_840_connection: quasi-Sidon sumset lower bound",
       "erdos_819_summary: combined main results"
     ],
     "axiomCount": 2,
@@ -81,71 +80,71 @@
     {
       "id": "sumsets",
       "title": "Sumsets",
-      "startLine": 41,
-      "endLine": 58,
+      "startLine": 42,
+      "endLine": 59,
       "summary": "Definitions of sumset A+A and restricted sumset (A+A) ∩ [1,N].",
       "mathContext": "Formal definition: Definitions of sumset A+A and restricted sumset (A+A) ∩ [1,N]."
     },
     {
       "id": "f-definition",
       "title": "The Function f(N)",
-      "startLine": 59,
-      "endLine": 98,
+      "startLine": 60,
+      "endLine": 96,
       "summary": "Definition of admissible sets (A ⊆ [1,N] with |A| = √N) and f(N) as the maximum restricted sumset size.",
       "mathContext": "Formal definition: Definition of admissible sets (A ⊆ [1,N] with |A| = √N) and f(N) as the maximum restricted sumset size."
     },
     {
       "id": "trivial-bounds",
       "title": "Trivial Bounds",
-      "startLine": 99,
-      "endLine": 116,
+      "startLine": 97,
+      "endLine": 110,
       "summary": "Basic bounds: f(N) ≤ N and f(N) ≥ √N.",
       "mathContext": "Basic bounds: f(N) $\\leq$ N and f(N) $\\geq$ √N."
     },
     {
       "id": "erdos-freud-bounds",
       "title": "Erdős-Freud Bounds",
-      "startLine": 117,
-      "endLine": 169,
+      "startLine": 111,
+      "endLine": 163,
       "summary": "The main result: (3/8 - o(1))N ≤ f(N) ≤ (1/2 + o(1))N from the 1991 paper.",
       "mathContext": "The main result: (3/8 - o(1))N $\\leq$ f(N) $\\leq$ (1/2 + o(1))N from the 1991 paper."
     },
     {
       "id": "construction-arguments",
       "title": "Lower Bound Construction",
-      "startLine": 170,
-      "endLine": 199,
+      "startLine": 164,
+      "endLine": 181,
       "summary": "Axiomatized construction achieving 3N/8 and counting argument for upper bound N/2.",
       "mathContext": "Axiomatized: Axiomatized construction achieving 3N/8 and counting argument for upper bound N/2."
     },
     {
       "id": "quasi-sidon",
       "title": "Connection to Quasi-Sidon Sets",
-      "startLine": 200,
-      "endLine": 224,
+      "startLine": 182,
+      "endLine": 201,
       "summary": "Link to Problem #840 on quasi-Sidon sets with axiomatized sumset lower bound.",
       "mathContext": "Axiomatized: Link to Problem #840 on quasi-Sidon sets with axiomatized sumset lower bound."
     },
     {
       "id": "extremal-examples",
       "title": "Extremal Examples",
-      "startLine": 225,
-      "endLine": 237,
+      "startLine": 202,
+      "endLine": 211,
       "summary": "Arithmetic progression sumset showing APs are suboptimal.",
       "mathContext": "Mathematical content: Arithmetic progression sumset showing APs are suboptimal."
     },
     {
       "id": "the-gap",
       "title": "The Gap",
-      "startLine": 238,
-      "endLine": 254,
+      "startLine": 212,
+      "endLine": 228,
       "summary": "The open question: the gap of N/8 between the known bounds.",
       "mathContext": "Bound: The open question: the gap of N/8 between the known bounds."
     },
     {
       "id": "summary",
       "title": "Summary",
-      "startLine": 255,
+      "startLine": 229,
       "endLine": 262,
       "summary": "Complete summary of the OPEN problem with combined bounds theorem.",
       "mathContext": "Verified: Complete summary of the OPEN problem with combined bounds theorem."


### PR DESCRIPTION
## Fix

Remove phantom `problem_840_connection` entry from erdos-819 `originalContributions` and realign 9 section line ranges.

## Evidence

**Before**: `originalContributions` listed `problem_840_connection: quasi-Sidon sumset lower bound` as if it were a declared theorem/def. It appears only in a docstring at lines 195–200 with no corresponding declaration. Section line ranges drifted 5–15 lines from actual `## Part` header positions.

**After**: `problem_840_connection` removed; remaining 9 entries all correspond to real declarations (`sumset`, `restrictedSumset`, `IsAdmissible`, `f`, `erdos_freud_lower`, `erdos_freud_upper`, `erdos_freud_bounds`, `IsQuasiSidon`, `erdos_819_summary`). All 9 sections realigned to actual header lines (42, 60, 97, 111, 164, 182, 202, 212, 229).

Closes #13723

---
Automated fix by lean-mechanic agent.