### PR TITLE
fix(erdos-822): correct properties section endLine to remove main-theorem overlap

### DIFF
--- a/src/data/proofs/erdos-822/meta.json
+++ b/src/data/proofs/erdos-822/meta.json
@@ -88,7 +88,7 @@
       "id": "properties",
       "title": "Basic Properties",
       "startLine": 66,
-      "endLine": 77,
+      "endLine": 75,
       "summary": "Lower bound n + φ(n) ≥ n and parity observation for large n."
     },
     {


### PR DESCRIPTION
## Summary
- After #13717 realigned `main-theorem` to startLine 76, the `properties` section retained `endLine: 77`, double-claiming lines 76-77 with `main-theorem`.
- Adjusted properties endLine from 77 to 75 (closing `-/` of the parity-observation docstring on line 75; line 76 begins the `## Main Theorem` section header).

## Verification
- Lean source `proofs/Proofs/Erdos822Problem.lean` lines 73–76:
  ```
  73: /-- For even n ≥ 2, ...
  74:     For odd primes p, ...
  75:     So odd values ... (and from n = 1, 2). -/
  76: /- ## Main Theorem
  ```
- `axiomCount: 1`, `sorries: 0`, `lineCount: 114` all match Lean source.
- Phantom-axiom narrative already cleaned by #13717.

## Test plan
- [x] JSON validates
- [x] No section overlap remains
- [ ] Visual confirmation in gallery render

🤖 Audit by lean auditor