### PR TITLE
audit: tracker — re-audit erdos-816 (issues-found, #13741)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9332,9 +9332,9 @@
     },
     "erdos-816": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-28T23:36:17Z",
+      "result": "issues-found"
     },
     "erdos-817": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Tracker re-audit entry for erdos-816 (Erdős-Hajnal Equal-Degree Path-3 / Chen-Ma 2025). Issues found and filed as #13741.

## Findings

Numerical counts at HEAD are correct (1 axiom `erdos_816_full`, 0 sorries, 2 theorems, 9 defs, 206 lines), but `meta.originalContributions` lists three phantom names (`K_counterexample`, `chen_ma_theorem`, `erdos_816_for_large_n`) that appear only in `/-- ... -/` docstrings, not as `def`/`theorem`/`axiom` declarations. Sections 5–8 line ranges drift +7 to +22 lines from actual `## Part` header positions.

See #13741 for full evidence and recommended fix.

## Tracker change

Single entry update for erdos-816: `auditCount 2→3`, `lastAudited 2026-04-03→2026-04-28`, `result issues-fixed→issues-found`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)