### PR TITLE
audit: tracker — re-audit erdos-812 (issues-found, #13743)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9308,9 +9308,9 @@
     },
     "erdos-812": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-28T23:41:57Z",
+      "result": "issues-found"
     },
     "erdos-813": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Re-audit of erdos-812 found phantom `originalContributions` and section line drift
- Details in #13743 (filed by this auditor session)
- Updates `audit-tracker.json` only

## Test plan

- [x] Tracker JSON change is minimal (3 lines)
- [x] No source/data files modified beyond tracker

🤖 Generated with [Claude Code](https://claude.com/claude-code)