### PR TITLE
fix(erdos-816): remove phantom contributions + realign section lines

### DIFF
--- a/src/data/proofs/erdos-816/meta.json
+++ b/src/data/proofs/erdos-816/meta.json
@@ -62,10 +62,7 @@
       "satisfiesEH816: Erdős-Hajnal condition",
       "satisfiesWeakerEH816: Chen-Ma weaker condition",
       "isCompleteBipartite: K_{n,n+1} characterization",
-      "K_counterexample: threshold tightness",
-      "chen_ma_theorem: 2025 main result",
-      "erdos_816_for_large_n: corollary for n ≥ 600",
-      "erdos_816_full: complete answer"
+      "axiom erdos_816_full: full Chen-Ma (2025) result for all n (formalizing the answer YES to Erdős #816)"
     ],
     "axiomCount": 1,
     "lineCount": 206,
@@ -124,32 +121,32 @@
     {
       "id": "counterexample",
       "title": "The Counterexample",
-      "summary": "isCompleteBipartite, K_counterexample",
+      "summary": "isCompleteBipartite definition",
       "startLine": 124,
-      "endLine": 152,
-      "mathContext": "Mathematical content: isCompleteBipartite, K_counterexample"
+      "endLine": 145,
+      "mathContext": "Mathematical content: isCompleteBipartite definition"
     },
     {
       "id": "main-theorem",
       "title": "Chen-Ma Theorem (2025)",
-      "summary": "chen_ma_theorem, erdos_816_for_large_n, erdos_816_full",
-      "startLine": 153,
-      "endLine": 189,
-      "mathContext": "Verified: chen_ma_theorem, erdos_816_for_large_n, erdos_816_full"
+      "summary": "axiom erdos_816_full: full Chen-Ma (2025) result for all n",
+      "startLine": 146,
+      "endLine": 171,
+      "mathContext": "Axiomatized: erdos_816_full (complete Chen-Ma 2025 result)"
     },
     {
       "id": "pigeonhole",
       "title": "Pigeonhole for Degrees",
       "summary": "degree-pigeonhole reasoning (mathematical context in docstrings; not axiomatized in this file)",
-      "startLine": 190,
-      "endLine": 201,
+      "startLine": 172,
+      "endLine": 179,
       "mathContext": "degree-pigeonhole reasoning (mathematical context in docstrings; not axiomatized in this file)"
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "erdos_816_summary theorem",
-      "startLine": 202,
+      "startLine": 180,
       "endLine": 206,
       "mathContext": "Verified: erdos_816_summary theorem"
     }


### PR DESCRIPTION
## Fix

Remove three phantom `originalContributions` entries (`K_counterexample`, `chen_ma_theorem`, `erdos_816_for_large_n`) that do not exist as declarations in `Erdos816Problem.lean`, and realign the last four section line ranges to match actual `## Part` header positions.

## Evidence

**Issue 1 — Phantom contributions**: `originalContributions` listed `K_counterexample`, `chen_ma_theorem`, and `erdos_816_for_large_n` — none of these are declared in the Lean file. They appear only in `/-- ... -/` docstrings above `axiom erdos_816_full`. Replaced all three with a single accurate entry referencing the real axiom declaration.

**Issue 2 — Section line drift**: Last four sections were off by 7–22 lines. Realigned to actual `## Part` header positions:
- counterexample: endLine 152 → 145
- main-theorem: startLine 153 → 146, endLine 189 → 171
- pigeonhole: startLine 190 → 172, endLine 201 → 179
- summary: startLine 202 → 180

Closes #13741

---
Automated fix by lean-mechanic agent.