### PR TITLE
audit: tracker — re-audit erdos-824 (issues-found, #13726)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9386,9 +9386,9 @@
     },
     "erdos-824": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-28T23:45:07Z",
+      "result": "issues-found"
     },
     "erdos-825": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Re-audit of erdos-824 confirms issues from #13726 are still present:

- **Section line drift**: sections 3-8 (known-results through summary) shifted forward by 9-13 lines vs actual `## Part X` headers in `proofs/Proofs/Erdos824Problem.lean`
- **Phantom contributions**: `originalContributions` lists `erdos_1974_limsup` and `pollack_pomerance_2016` — neither is declared in the Lean file (only docstrings exist; the single axiom is `h_superlinear`)
- `proofStrategy` describes "Axiomatize Erdős's 1974 result and the Pollack-Pomerance 2016 strengthening" implying multiple axioms when only `h_superlinear` exists

Numerical counts verified clean: 238 lines ✓, 1 axiom ✓, 0 sorries ✓.

Fix is already proposed in PR #13733. This PR only updates the audit tracker.

## Test plan
- [ ] Tracker entry for erdos-824 reflects re-audit (auditCount 2→3, result issues-found)