### PR TITLE
audit: tracker — re-audit erdos-813 (issues-found, #13747)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9314,9 +9314,9 @@
     },
     "erdos-813": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-28T23:50:32Z",
+      "result": "issues-found"
     },
     "erdos-814": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Re-audits erdos-813; bumps auditCount 2→3, sets result `issues-found`.
- Backs filed integrity issue #13747 (phantom `h_spec` / `bucic_sudakov_lower_bound` contributions + section line drift).

## Test plan

- [x] `audit-tracker.json` updated for `erdos-813` only
- [x] No other gallery files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)