### PR TITLE
audit: tracker — re-audit erdos-814 (clean, post #13734)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9320,9 +9320,9 @@
     },
     "erdos-814": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-28T23:18:00Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-04-28T23:54:04Z",
+      "result": "clean"
     },
     "erdos-815": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Re-audit of erdos-814 after #13734 merged (phantom-axiom narrative + section realignment)
- All numerical fields verified: 3 axioms, 7 theorems, 3 defs, 0 sorries, 292 lines
- Section ranges correctly contain their declarations
- Narrative now correctly identifies sauermann_constant / sauermann_theorem / handshaking as the only axioms; historical EFRS/MNS bounds noted as doc-comment-only

## Test plan
- [x] meta.json fields match \`git show origin/main:proofs/Proofs/Erdos814Problem.lean\`
- [x] section line ranges contain declared symbols
- [x] tracker bumped auditCount 3→4, result \`issues-fixed\` → \`clean\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)