### PR TITLE
fix(erdos-82): realign section line ranges for Parts 4-10

### DIFF
--- a/src/data/proofs/erdos-82/meta.json
+++ b/src/data/proofs/erdos-82/meta.json
@@ -109,54 +109,54 @@
       "id": "trivial-lower",
       "title": "Part 4: Trivial Lower Bound",
       "startLine": 115,
-      "endLine": 142,
+      "endLine": 134,
       "summary": "F(n) ≥ 1 for n ≥ 1, and cliques/independent sets are regular.",
       "mathContext": "F(n) $\\geq$ 1 for n $\\geq$ 1, and cliques/independent sets are regular."
     },
     {
       "id": "ramsey-lower",
       "title": "Part 5: Ramsey-Theoretic Lower Bound",
-      "startLine": 143,
-      "endLine": 184,
+      "startLine": 135,
+      "endLine": 170,
       "summary": "Ramsey numbers, the classical R(k,k) ≤ 4^k bound, and the key consequence F(n) ≥ (1/2)log₂(n).",
       "mathContext": "Ramsey numbers, the classical R(k,k) $\\leq$ $4^{k}$ bound, and the key consequence F(n) $\\geq$ (1/2)log₂(n)."
     },
     {
       "id": "aks-upper",
       "title": "Part 6: Alon-Krivelevich-Sudakov Upper Bound",
-      "startLine": 185,
-      "endLine": 206,
+      "startLine": 171,
+      "endLine": 192,
       "summary": "The 2007 upper bound F(n) ≤ C·√n·(log n)^{O(1)} from probabilistic constructions.",
       "mathContext": "The 2007 upper bound F(n) $\\leq$ C·√n·($\\log n$)^{$O(1)$} from probabilistic constructions."
     },
     {
       "id": "small-values",
       "title": "Part 7: Small Values and Computations",
-      "startLine": 207,
-      "endLine": 243,
+      "startLine": 193,
+      "endLine": 225,
       "summary": "The inverse function G(k), exact values of F(n) for small n, and OEIS references.",
       "mathContext": "Mathematical content: The inverse function G(k), exact values of F(n) for small n, and OEIS references."
     },
     {
       "id": "conjecture",
       "title": "Part 8: The Erdős Conjecture",
-      "startLine": 244,
-      "endLine": 275,
+      "startLine": 226,
+      "endLine": 257,
       "summary": "The formal conjecture F(n)/log(n) → ∞ in both Filter.Tendsto and explicit ε-N forms.",
       "mathContext": "The formal conjecture F(n)/log(n) $\\to$ ∞ in both Filter.Tendsto and explicit ε-N forms."
     },
     {
       "id": "connections",
       "title": "Part 9: Related Results and Connections",
-      "startLine": 276,
-      "endLine": 319,
+      "startLine": 258,
+      "endLine": 293,
       "summary": "Connections to Ramsey diagonal improvements, Erdős-Sauer problem, and random graph theory.",
       "mathContext": "Mathematical content: Connections to Ramsey diagonal improvements, Erdős-Sauer problem, and random graph theory."
     },
     {
       "id": "summary",
       "title": "Part 10: Problem Status and Summary",
-      "startLine": 320,
+      "startLine": 294,
       "endLine": 326,
       "summary": "Bounds summary theorem combining lower and upper bounds.",
       "mathContext": "Verified: Bounds summary theorem combining lower and upper bounds."


### PR DESCRIPTION
## Fix

Corrects drifted `sections[*]` startLine/endLine values in `src/data/proofs/erdos-82/meta.json` for Parts 4–10.

## Evidence

**Before**: Parts 4–10 line ranges were off by 8–18 lines (Parts 1–3 were correct).
**After**: All 10 sections aligned to actual Lean source `/-` part-header positions.

| Section | Before | After |
|---|---|---|
| trivial-lower (4) | 115–142 | 115–134 |
| ramsey-lower (5) | 143–184 | 135–170 |
| aks-upper (6) | 185–206 | 171–192 |
| small-values (7) | 207–243 | 193–225 |
| conjecture (8) | 244–275 | 226–257 |
| connections (9) | 276–319 | 258–293 |
| summary (10) | 320–326 | 294–326 |

Closes #13752

---
Automated fix by lean-mechanic agent.