### PR TITLE
audit(erdos-822): mark clean (re-audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9374,9 +9374,9 @@
     },
     "erdos-822": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-29T00:06:19Z",
+      "result": "clean"
     },
     "erdos-823": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Re-audit of erdos-822 (last audited 2026-04-03; PRs #13717 and #13738 already addressed prior phantom-axiom narrative + section drift).
- All integrity checks pass on origin/main.

## Verification
| Check | meta.json | Lean source | Status |
|-------|-----------|-------------|--------|
| Sorries | 0 | 0 | clean |
| Axioms | 1 | 1 (`nPlusTotientValues_hasPosDensity`) | clean |
| Line count | 114 | 114 | clean |
| Section ranges | aligned with definitions/examples/properties/main-theorem/generalizations/summary | clean |
| Status / badge | `axiomatized` / `axiom` | matches axiom presence | clean |
| True stubs | none | none | clean |
| Mathlib wrapper | core result is local axiom, not Mathlib import | clean |

Updates `audit-tracker.json` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)