### PR TITLE
audit(erdos-811): mark clean (re-audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9302,9 +9302,9 @@
     },
     "erdos-811": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-29T00:09:58Z",
+      "result": "clean"
     },
     "erdos-812": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Re-audit of erdos-811 (Rainbow Graphs in Balanced Edge-Colorings)
- All meta.json claims verified against proofs/Proofs/Erdos811Problem.lean
- No issues found; tracker updated to result=clean

## Audit Detail
- 3 explicit axioms in source (clemen_wagner_2023, axenovich_clemen_2024, rainbowMinDegree) match meta.axiomCount=3 and the assumptions string
- 1 theorem erdos_811 derives its conjunction by pairing the two citation axioms; 0 sorries
- All 11 originalContributions exist in source at expected lines
- 10 sections; line ranges align with file structure (1-35, 36-52, 53-61, 62-80, 82-90, 92-112, 114-123, 124-137, 138-143, 144-169)
- Narrative honestly labels axiomatized definitions vs documentation-only references; no phantom-axiom narrative or overclaiming
- Title/description correctly mark the problem as open

## Test plan
- [x] meta.json field-by-field comparison with Lean source
- [x] Section line range overlay vs git show HEAD:proofs/Proofs/Erdos811Problem.lean
- [x] tracker entry updated via claim-target.sh complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)