### PR TITLE
audit(erdos-808): mark issues-found (#13757)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9278,9 +9278,9 @@
     },
     "erdos-808": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-29T00:22:49Z",
+      "result": "issues-found"
     },
     "erdos-809": {
       "auditCount": 4,


### PR DESCRIPTION
## Summary

- Bumps audit-tracker entry for `erdos-808` to `auditCount: 3`, `result: issues-found`
- Filed integrity issue #13757: section line drift in 5 sections + a phantom "Axiomatized ARS counterexample construction" claim in `originalContributions[2]`
- Numerical counts (axiomCount, sorries, lineCount, theoremCount, definitionCount) are all correct

## Test plan

- [x] Verified meta vs Lean by `grep -n` on Part headers and declarations
- [x] Confirmed 2 axioms (`erdos_808_false`, `ars_positive_bound`), 0 sorries, 211 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)