### PR TITLE
fix(erdos-803): remove phantom contributions + realign section lines

### DIFF
--- a/src/data/proofs/erdos-803/meta.json
+++ b/src/data/proofs/erdos-803/meta.json
@@ -51,10 +51,8 @@
       "balanced_monotone theorem (proved)",
       "HasLogDensity definition: ≥ n log n edges",
       "Erdos803Conjecture definition: formal statement of the disproved conjecture",
-      "alon_2008_counterexample: D-balanced subgraphs bounded by m√(log m)",
       "erdos_803_disproved axiom: negation of the conjecture",
       "erdos_simonovits_polynomial axiom: positive result for polynomial density",
-      "janzer_sudakov_2023: best logarithmic density bound",
       "erdos_803_summary theorem combining disproof with positive result"
     ],
     "axiomCount": 2,
@@ -83,36 +81,43 @@
       "id": "balanced",
       "title": "D-Balanced Graphs",
       "startLine": 32,
-      "endLine": 72,
+      "endLine": 71,
       "summary": "Definitions of maxDegree, minDegree, IsDBalanced; proofs that regular graphs are 1-balanced and the balanced property is monotone in D."
     },
     {
       "id": "density",
       "title": "Edge Density",
       "startLine": 73,
-      "endLine": 87,
+      "endLine": 86,
       "summary": "Definitions of edgeCount, vertexCount, and HasLogDensity (n log n edge threshold)."
     },
     {
       "id": "conjecture",
       "title": "The Conjecture (Disproved)",
       "startLine": 88,
-      "endLine": 106,
+      "endLine": 105,
       "summary": "Formal statement of the original (false) conjecture: O(1)-balanced subgraphs with m log m edges."
     },
     {
       "id": "alon",
       "title": "Alon's Counterexample (2008)",
       "startLine": 107,
-      "endLine": 129,
+      "endLine": 113,
       "summary": "Alon's 2008 counterexample axiom and the disproof of the conjecture."
     },
     {
       "id": "positive",
       "title": "Positive Results",
-      "startLine": 130,
-      "endLine": 159,
+      "startLine": 115,
+      "endLine": 135,
       "summary": "Erdős-Simonovits for polynomial density and Janzer-Sudakov 2023 for best logarithmic bound."
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 136,
+      "endLine": 159,
+      "summary": "erdos_803_summary theorem combining the disproof (erdos_803_disproved) with the polynomial-density positive result (erdos_simonovits_polynomial)."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Fix

Remove two phantom `originalContributions` entries and realign all section line ranges for `erdos-803` (`Erdos803Problem.lean`, 159 lines).

## Evidence

**Issue 1 — Phantom `alon_2008_counterexample`**: Listed in `originalContributions` but no such declaration exists. Lines 108–112 contain only docstrings followed by the actual axiom `erdos_803_disproved`.

**Issue 2 — Phantom `janzer_sudakov_2023`**: Listed in `originalContributions` but no corresponding axiom or theorem is declared. Lines 133–135 are an orphan docstring with no following declaration.

**Issue 3 — Section line drift**: Five sections had wrong endLine values; `positive` started 15 lines too late; `summary` section was missing entirely.

| Section    | Before         | After          |
|------------|----------------|----------------|
| balanced   | 32–72          | 32–71          |
| density    | 73–87          | 73–86          |
| conjecture | 88–106         | 88–105         |
| alon       | 107–**129**    | 107–**113**    |
| positive   | **130**–159    | **115**–135    |
| summary    | *(missing)*    | 136–159        |

Closes #13756

---
Automated fix by lean-mechanic agent.