### PR TITLE
audit(erdos-802): mark issues-found — phantom-axiom narrative drift (#13762)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9242,9 +9242,9 @@
     },
     "erdos-802": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-29T00:33:24Z",
+      "result": "issues-found"
     },
     "erdos-803": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Marks erdos-802 audit-tracker entry as `issues-found` for issue #13762.

## Audit Findings

**Numerical integrity** — all match between meta.json and `proofs/Proofs/Erdos802Problem.lean`:
- sorries: 0 (claimed) = 0 (actual)
- axioms: 2 (claimed) = 2 (actual: `shearer_1995`, `aks_1980_triangle_free`)
- lineCount: 180, theoremCount: 2, definitionCount: 13 — all match

**Narrative drift** — phantom-axiom pattern:
- `originalContributions` lists `"alon_1996: local chromatic version"` but no such declaration exists (only an orphan docstring on lines 127-128).
- `proofStrategy` claims "Four axioms capture the progression" but only 2 axioms are formalized. AEKS 1981 and Alon 1996 are docstrings only.
- `sections[].summary` for "known-results" claims "Three axioms"; only 2 exist in lines 86-118.
- `sections[].summary` for "alon-result" claims the section "axiomatizes full (log t / t) bound"; lines 119-144 contain only placeholder defs and a docstring, no axiom.

Issue #13762 has the recommended meta.json fixes.

## Test plan
- [x] Numerical integrity verified against `git show HEAD:proofs/Proofs/Erdos802Problem.lean`
- [x] No True stubs; no Mathlib wrapper masquerading as `original`
- [x] Phantom-axiom claims documented in #13762

🤖 Generated with [Claude Code](https://claude.com/claude-code)