### PR TITLE
audit: tracker — erdos-806 issues-found (#13764)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9266,9 +9266,9 @@
     },
     "erdos-806": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-29T00:43:16Z",
+      "result": "issues-found"
     },
     "erdos-807": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Mark erdos-806 as `issues-found` in `audit-tracker.json` after auditor identified phantom contributions and phantom-axiom section narratives that PR #13629 did not catch.

Companion to integrity issue #13764.

## What was found

`src/data/proofs/erdos-806/meta.json` references identifiers and axiomatizations that don't exist in `proofs/Proofs/Erdos806Problem.lean` (HEAD `91721ace`):

- `originalContributions` lists `erdos_806` and `log_factor_is_o_one` — neither declared in the Lean file
- `sections.asymptotics` (lines 198-210) claims it "Axiomatizes (log log n / log n) → 0" — file has only a docstring
- `sections.summary` (lines 211-219) claims it "Restates the full quantitative result as an axiom" — file has only a docstring

Numerical counts (axiomCount=2, sorries=0, lineCount=219, theoremCount=3, definitionCount=4) and `meta.assumptions` are correct.

PR #13629 fixed `originalContributions` axiom labels but missed phantom items and `sections[].summary`.

## Test plan

- [ ] Tracker entry for erdos-806 shows `result: issues-found`, `auditCount: 3`
- [ ] Issue #13764 contains specific recommended edits for the mechanic agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)