### PR TITLE
audit(erdos-796): mark issues-found — phantom-axiom narrative drift (#13767)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9193,10 +9193,10 @@
       "result": "clean"
     },
     "erdos-796": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-loop",
+      "auditCount": 3,
+      "lastAudited": "2026-04-29T00:48:37Z",
+      "result": "issues-found"
     },
     "erdos-797": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Re-audit erdos-796 after 26-day gap; tracker bumped to auditCount=3, result=issues-found
- Files integrity issue #13767 documenting phantom-axiom narrative drift
- Counts (axiomCount=2, sorries=0, lineCount=221) match Lean — narrative overstates 5 section axiomatizations + 1 phantom contribution

## Test plan

- [x] git diff scoped to single tracker entry
- [x] Issue #13767 filed with full evidence
- [ ] Mechanic to fix meta.json narrative