### PR TITLE
audit(erdos-803): tracker → issues-found (phantom contribs + section drift)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9247,10 +9247,10 @@
       "result": "issues-fixed"
     },
     "erdos-803": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-loop-2026-04-29",
+      "auditCount": 3,
+      "lastAudited": "2026-04-29T00:52:12Z",
+      "result": "issues-found"
     },
     "erdos-804": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Re-audit of erdos-803 confirms the integrity issues already filed in #13756 are still present on origin/main. Tracker is reset to `issues-found` so the audit queue surfaces it again.

## Findings (from current `proofs/Proofs/Erdos803Problem.lean` on origin/main)

- **originalContributions** lists `alon_2008_counterexample` and `janzer_sudakov_2023` — neither identifier exists in the Lean file. The actual axioms are `erdos_803_disproved` and `erdos_simonovits_polynomial`.
- **proofStrategy** says "Janzer-Sudakov" is axiomatized; the file only contains a docstring at line 133, no axiom or theorem.
- **sections** line ranges have all drifted by ≥1 line:
  - balanced: 32-72 → 31-71
  - density: 73-87 → 72-86
  - conjecture: 88-106 → 87-105
  - alon: 107-129 → 106-113
  - positive: 130-159 → 114-135
- meta is missing the **Summary** section (file lines 136-159).
- Numerical counts (sorries 0, axiomCount 2, lineCount 159) are correct.

PR #13759 (mechanic) appears to address these; this tracker update just keeps the audit queue honest until that PR lands.

## Test plan

- [x] minimal diff (only erdos-803 entry changed)
- [x] re-verified counts via `git show HEAD:proofs/Proofs/Erdos803Problem.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)