### PR TITLE
audit(erdos-82): mark clean — sorries 0, axioms 3, sections aligned

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9356,9 +9356,9 @@
     },
     "erdos-82": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-29T00:59:56Z",
+      "result": "clean"
     },
     "erdos-820": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
Re-audit of erdos-82 after recent phantom-contribution and section-realignment fixes.

- Verified against `proofs/Proofs/Erdos82Problem.lean` (326 lines).
- 0 sorries (comment-stripped), 3 axioms (`ramseyNumber`, `F_ramsey_lower`, `aks_upper_bound`), 0 True stubs.
- All 10 section line ranges land on `/-` headers and end on the line before the next header (or EOF for the final summary).

Tracker update: `auditCount` 2 → 3, result `issues-fixed` → `clean`.

Follow-on to #13727 (phantom contributions) and #13752 (section realignment).

## Test plan
- [x] `proofs/Proofs/Erdos82Problem.lean` line count = `meta.lineCount` (326)
- [x] 0 sorry occurrences after stripping comments
- [x] 3 `^axiom ` declarations match `meta.assumptions`
- [x] Each section `startLine` is a `/-` header line
- [x] Each section `endLine` immediately precedes the next section header (or EOF)

🤖 Generated with [Claude Code](https://claude.com/claude-code)