### PR TITLE
fix(erdos-796): remove phantom contributions + realign section summaries

### DIFF
--- a/src/data/proofs/erdos-796/meta.json
+++ b/src/data/proofs/erdos-796/meta.json
@@ -50,7 +50,6 @@
       "E3: Second-order error term",
       "erdosConjecture796: Main conjecture (OPEN)",
       "IsNearOptimal3: Near-optimal sets",
-      "divisor_connection axiom: τ(m) bound",
       "erdos_796_summary theorem: Combines first-order and second-order bounds"
     ],
     "dateAdded": "2026-01-19",
@@ -62,7 +61,7 @@
     "historicalContext": "Erdős introduced the function $g_k(n)$ in his 1964 paper 'On the multiplicative representation of integers,' measuring the maximum size of a subset $A$ of $\\{1,\\ldots,n\\}$ such that every integer has fewer than $k$ multiplicative representations from $A$. This grew from his long-standing interest in the interplay between additive and multiplicative number theory, and specifically from questions about how the multiplicative structure of integers constrains extremal set sizes.\n\nThe key breakthrough was connecting $g_k(n)$ to the distribution of integers by their number of prime factors. Using the Sathe-Selberg formula (established independently by Sathe in 1953 and refined by Selberg in 1954), which gives the count of integers up to $n$ with exactly $r$ prime factors as $\\sim (\\log\\log n)^{r-1}/((r-1)!) \\cdot n/\\log n$, Erdős showed that $g_k(n)$ has the same asymptotic for the appropriate value of $r$ determined by $k$.\n\nFor the important case $k = 3$ (where $r = 2$), this gives $g_3(n) \\sim (\\log\\log n / \\log n) \\cdot n$. By 1969, Erdős had investigated the second-order behavior more deeply, establishing that the error $E_3(n) = g_3(n) - (\\log\\log n / \\log n) \\cdot n$ satisfies $c_1 \\cdot n/(\\log n)^2 \\le E_3(n) \\le c_2 \\cdot n/(\\log n)^2$ for positive constants $c_1 \\le c_2$, pinning the error to exact order $\\Theta(n/(\\log n)^2)$.\n\nThe central open question is whether $E_3(n)/(n/(\\log n)^2)$ converges to a constant $c$. This exemplifies a recurring theme in Erdős's work: once the leading asymptotic term is determined, the next-order correction often encodes much deeper structural information and is dramatically harder to pin down. The problem remains open and connects to subtle questions about the fine distribution of semiprimes (products of exactly two primes).",
     "problemStatement": "**Problem Statement (OPEN)**\n\nLet $g_k(n) = \\max\\{|A| : A \\subseteq \\{1,\\ldots,n\\},\\; \\forall m,\\; r_A(m) < k\\}$ where $r_A(m)$ counts representations $m = a_1 a_2$ with $a_1 < a_2 \\in A$.\n\n**Question:** Is $g_3(n) = \\frac{\\log\\log n}{\\log n} \\cdot n + (c + o(1)) \\cdot \\frac{n}{(\\log n)^2}$ for some constant $c > 0$?\n\n**Known:**\n- First-order: $g_3(n) \\sim \\frac{\\log\\log n}{\\log n} \\cdot n$ (Erdős 1964)\n- Bounds: $c_1 \\cdot \\frac{n}{(\\log n)^2} \\le E_3(n) \\le c_2 \\cdot \\frac{n}{(\\log n)^2}$ (Erdős 1969)\n\n**Open:** Existence and exact value of $c$",
     "text": "For g_k(n) = max |A| with A ⊆ {1,...,n} having < k representations per integer, is g₃(n) = (log log n / log n)n + (c+o(1))n/(log n)² for some c? First-order known, second-order OPEN.",
-    "proofStrategy": "The formalization proceeds in a layered approach. First, the core combinatorial definitions are established: product representations, representation counts, bounded-representation sets, and valid subsets. The optimization problem $g_k(n)$ is defined as a supremum over the finite powerset.\n\nThe first-order result from Erdős (1964) is axiomatized as `erdos_1964_main`, giving the general formula for all $k$. The $k = 3$ specialization `g3_first_order` is the sole fully-proved theorem, using `norm_num` to verify the arithmetic conditions $2 < 3 \\le 4$ and `simp` to simplify factorials and powers.\n\nThe second-order analysis introduces the error term $E_3(n)$, axiomatizes the known bounds, and formally states the open conjecture. Supporting results on optimal set structure and the divisor function connection are axiomatized to provide mathematical context. The summary theorem cleanly packages the two established results as a conjunction.",
+    "proofStrategy": "The formalization proceeds in a layered approach. First, the core combinatorial definitions are established: product representations, representation counts, bounded-representation sets, and valid subsets. The optimization problem $g_k(n)$ is defined as a supremum over the finite powerset.\n\nThe first-order result from Erdős (1964) is axiomatized as `erdos_1964_main`, giving the general formula for all $k$. The $k = 3$ specialization `g3_first_order` is the sole fully-proved theorem, using `norm_num` to verify the arithmetic conditions $2 < 3 \\le 4$ and `simp` to simplify factorials and powers.\n\nThe second-order analysis introduces the error term $E_3(n)$, axiomatizes the known bounds (E3_bounded), and formally states the open conjecture. Optimal set structure and the divisor function connection appear as definitions and docstrings only; they are not axiomatized. The summary theorem cleanly packages the two established results as a conjunction.",
     "keyInsights": [
       "**Multiplicative-to-additive bridge:** The function $g_k(n)$ transforms a multiplicative constraint (bounded factorization representations) into a counting problem that is governed by the additive prime factorization structure of integers, via the divisor function $\\tau(m) = \\prod(a_i + 1)$.",
       "**Threshold phenomenon at powers of 2:** The parameter $r$ in the asymptotic formula jumps at powers of 2 in $k$, because an integer with $r$ distinct prime factors has $\\tau(m) = 2^r$ divisors, giving exactly $2^{r-1}$ ordered factorizations. This creates a discrete staircase in the growth rate of $g_k(n)$.",
@@ -89,16 +88,16 @@
       "title": "The g_k(n) Function",
       "startLine": 71,
       "endLine": 88,
-      "summary": "Defines g_k(n) as the supremum of |A| over valid subsets A of {1,...,n}, and axiomatizes the trivial bound g_k(n) ≤ n.",
-      "mathContext": "Defines g_k(n) as the supremum of |A| over valid subsets A of {1,...,n}, and axiomatizes the trivial bound g_k(n) ≤ n."
+      "summary": "Defines g_k(n) as the supremum of |A| over valid subsets A of {1,...,n}.",
+      "mathContext": "Defines g_k(n) as the supremum of |A| over valid subsets A of {1,...,n}."
     },
     {
       "id": "first-order",
       "title": "First-Order Asymptotics",
       "startLine": 89,
       "endLine": 122,
-      "summary": "Defines omega_count (integers with r prime factors), axiomatizes the Sathe-Selberg formula, and axiomatizes Erdős's 1964 theorem connecting g_k(n) to the count of r-almost primes.",
-      "mathContext": "Defines omega_count (integers with r prime factors), axiomatizes the Sathe-Selberg formula, and axiomatizes Erdős's 1964 theorem connecting g_k(n) to the count of r-almost primes."
+      "summary": "Defines omega_count (integers with r prime factors) and axiomatizes Erdős's 1964 theorem (erdos_1964_main) connecting g_k(n) to the count of r-almost primes. The Sathe-Selberg formula appears only as a docstring, not an axiom.",
+      "mathContext": "Defines omega_count (integers with r prime factors) and axiomatizes Erdős's 1964 theorem (erdos_1964_main) connecting g_k(n) to the count of r-almost primes. The Sathe-Selberg formula appears only as a docstring, not an axiom."
     },
     {
       "id": "k3-case",
@@ -121,29 +120,29 @@
       "title": "The k = 2 Case (Problem #425)",
       "startLine": 172,
       "endLine": 184,
-      "summary": "Axiomatizes g₂(n) ~ n/log n (the PNT-like result) and notes the connection to the companion Problem #425.",
-      "mathContext": "Axiomatizes g₂(n) ~ n/log n (the PNT-like result) and notes the connection to the companion Problem #425."
+      "summary": "Contains a docstring connecting the k=2 case to the prime counting function and noting the companion Problem #425; no axiom is present in this section.",
+      "mathContext": "Contains a docstring connecting the k=2 case to the prime counting function and noting the companion Problem #425; no axiom is present in this section."
     },
     {
       "id": "optimal-sets",
       "title": "Optimal Sets and Semiprime Structure",
       "startLine": 185,
       "endLine": 205,
-      "summary": "Defines near-optimal sets and axiomatizes that they concentrate on semiprimes (integers with Ω(m) = 2).",
-      "mathContext": "Defines near-optimal sets and axiomatizes that they concentrate on semiprimes (integers with Ω(m) = 2)."
+      "summary": "Defines IsNearOptimal3 (sets achieving near-optimal size for g₃) and includes a docstring noting that optimal sets resemble integers with Ω(m)=2; no axiom is present.",
+      "mathContext": "Defines IsNearOptimal3 (sets achieving near-optimal size for g₃) and includes a docstring noting that optimal sets resemble integers with Ω(m)=2; no axiom is present."
     },
     {
       "id": "multiplicative",
       "title": "Divisor Function Connection",
       "startLine": 206,
-      "endLine": 218,
-      "summary": "Axiomatizes the key bound: τ(m) ≤ 2k-1 implies m is automatically safe (< k representations from any set).",
-      "mathContext": "Axiomatizes the key bound: τ(m) ≤ 2k-1 implies m is automatically safe (< k representations from any set)."
+      "endLine": 208,
+      "summary": "Docstring discussion of the divisor function connection: numbers with τ(m) ≤ 2k-1 are automatically safe for g_k; no axiom is present.",
+      "mathContext": "Docstring discussion of the divisor function connection: numbers with τ(m) ≤ 2k-1 are automatically safe for g_k; no axiom is present."
     },
     {
       "id": "summary",
       "title": "Summary Theorem",
-      "startLine": 219,
+      "startLine": 209,
       "endLine": 221,
       "summary": "Packages the first-order asymptotics and second-order bounds into a single conjunction, proved by pairing g3_first_order and E3_bounded.",
       "mathContext": "Packages the first-order asymptotics and second-order bounds into a single conjunction, proved by pairing g3_first_order and E3_bounded."


### PR DESCRIPTION
## Fix

Remove phantom `divisor_connection axiom` from originalContributions and correct five section summaries that falsely claimed axiomatizations not present in the Lean source.

## Evidence

**Lean source** (`proofs/Proofs/Erdos796Problem.lean`) has exactly 2 axioms: `erdos_1964_main` (line 111) and `E3_bounded` (line 151).

**Before**:
- `originalContributions` listed `"divisor_connection axiom: τ(m) bound"` — no such axiom exists
- `g-function` summary claimed "axiomatizes the trivial bound g_k(n) ≤ n" — section has only `def g`
- `first-order` summary claimed "axiomatizes the Sathe-Selberg formula" — Sathe-Selberg is a docstring only
- `k2-case` summary claimed "Axiomatizes g₂(n) ~ n/log n" — section has only a docstring
- `optimal-sets` summary claimed "axiomatizes that they concentrate on semiprimes" — section has only `def IsNearOptimal3` + docstring
- `multiplicative` summary claimed "Axiomatizes the key bound: τ(m) ≤ 2k-1" — section has only a docstring; endLine was 218 (overlapping summary theorem)
- `summary` section startLine was 219 (theorem starts at line 209)
- `proofStrategy` claimed "Supporting results...are axiomatized"

**After**:
- Removed phantom `divisor_connection axiom` from originalContributions
- All five section summaries describe actual content (defs + docstrings) without false axiom claims
- `multiplicative` endLine corrected to 208; `summary` startLine corrected to 209
- `proofStrategy` updated to remove false axiomatization claim

Closes #13767

---
Automated fix by lean-mechanic agent.