### PR TITLE
audit(erdos-789): mark issues-found — phantom axioms + section drift

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9146,9 +9146,9 @@
     },
     "erdos-789": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-29T01:15:23Z",
+      "result": "issues-found"
     },
     "erdos-79": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Audited `erdos-789` against `proofs/Proofs/Erdos789Problem.lean`
- Numeric counts correct (sorries 0, axioms 3, lineCount 242)
- Phantom axioms in `originalContributions`: tracked by #13774, fix in PR #13778
- Section line ranges drift past actual `## Part N` headers: filed #13779
- Updates `audit-tracker.json` to record this audit pass

## Test plan

- [x] `claim-target.sh complete erdos-789 issues-found` updated tracker entry
- [x] No code changes — only tracker JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)