### PR TITLE
fix(erdos-789): realign sections[] startLine/endLine to actual Part headers

### DIFF
--- a/src/data/proofs/erdos-789/meta.json
+++ b/src/data/proofs/erdos-789/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-789",
-  "title": "Erd\u0151s Problem #789: Sum-Length-Free Subsets",
+  "title": "Erdős Problem #789: Sum-Length-Free Subsets",
   "slug": "erdos-789",
-  "description": "Estimate h(n) where h(n) is the max |B| such that equal sums in B have equal length. Known: (n log n)^{1/3} \u226a h(n) \u226a \u221an. Status: OPEN.",
+  "description": "Estimate h(n) where h(n) is the max |B| such that equal sums in B have equal length. Known: (n log n)^{1/3} ≪ h(n) ≪ √n. Status: OPEN.",
   "meta": {
-    "author": "Erd\u0151s, Straus, Choi",
+    "author": "Erdős, Straus, Choi",
     "sourceUrl": "https://erdosproblems.com/789",
     "date": "1962-1974",
     "status": "axiomatized",
@@ -48,7 +48,7 @@
       "h function axiom (maximal sum-length-free subset)",
       "h_achievable axiom (existence)",
       "erdos_1962_upper axiom (n^{5/6})",
-      "straus_1966_upper axiom (\u221an, best upper)",
+      "straus_1966_upper axiom (√n, best upper)",
       "erdos_1962_lower axiom (n^{1/3})",
       "erdos_choi_1974_lower axiom ((n log n)^{1/3}, best lower)",
       "combined_bounds theorem",
@@ -60,7 +60,7 @@
     "relatedProblems": [
       {
         "id": "erdos-1109",
-        "relationship": "Related Erd\u0151s problem on additive combinatorics and sumset constraints"
+        "relationship": "Related Erdős problem on additive combinatorics and sumset constraints"
       }
     ],
     "erdosNumber": 789,
@@ -71,16 +71,16 @@
     "assumptions": "3 axioms: h, straus_1966_upper, erdos_choi_1974_lower. 0 sorries."
   },
   "overview": {
-    "historicalContext": "**The Sum-Length-Free Property**\\n\\nA set B is sum-length-free if whenever two sums of elements from B are equal, they must involve the same number of terms. This is weaker than the Sidon property (which requires the actual terms to be equal).\\n\\n**Erd\u0151s's Original Work (1962)**\\n\\nErd\u0151s proved h(n) \u226a n^{5/6} and h(n) \u226b n^{1/3}. The lower bound used a beautiful probabilistic construction: for random \u03b1, the set of elements whose fractional parts {\u03b1a} lie in a small interval tends to be sum-length-free.\\n\\n**Straus's Improvement (1966)**\\n\\nStraus dramatically improved the upper bound to h(n) \u226a \u221an using a clever counting argument on sum representations.\\n\\n**Erd\u0151s-Choi (1974)**\\n\\nChoi improved the lower bound to h(n) \u226b (n log n)^{1/3} by refining Erd\u0151s's probabilistic argument.\\n\\n**The Gap**\\n\\nThe gap between (n log n)^{1/3} and \u221an is substantial. For n = 10^6, this is roughly 239 vs 1000. Closing this gap is the main open problem.",
-    "problemStatement": "Let h(n) be maximal such that if A \u2286 \u2124 with |A| = n then there is B \u2286 A with |B| \u2265 h(n) such that if a\u2081+\u22ef+a\u1d63 = b\u2081+\u22ef+b\u209b with a\u1d62,b\u1d62 \u2208 B then r = s. Estimate h(n).",
-    "text": "Estimate h(n) where h(n) is the max |B| such that equal sums in B have equal length. Known: (n log n)^{1/3} \u226a h(n) \u226a \u221an. Status: OPEN.",
-    "proofStrategy": "We formalize the sum-length-free property via SumRep structures and the SumLengthFree predicate. The function h(n) is axiomatized with bounds from Straus (upper) and Erd\u0151s-Choi (lower). We connect to Sidon sets and show computational examples. The main theorem combines all known bounds.",
+    "historicalContext": "**The Sum-Length-Free Property**\\n\\nA set B is sum-length-free if whenever two sums of elements from B are equal, they must involve the same number of terms. This is weaker than the Sidon property (which requires the actual terms to be equal).\\n\\n**Erdős's Original Work (1962)**\\n\\nErdős proved h(n) ≪ n^{5/6} and h(n) ≫ n^{1/3}. The lower bound used a beautiful probabilistic construction: for random α, the set of elements whose fractional parts {αa} lie in a small interval tends to be sum-length-free.\\n\\n**Straus's Improvement (1966)**\\n\\nStraus dramatically improved the upper bound to h(n) ≪ √n using a clever counting argument on sum representations.\\n\\n**Erdős-Choi (1974)**\\n\\nChoi improved the lower bound to h(n) ≫ (n log n)^{1/3} by refining Erdős's probabilistic argument.\\n\\n**The Gap**\\n\\nThe gap between (n log n)^{1/3} and √n is substantial. For n = 10^6, this is roughly 239 vs 1000. Closing this gap is the main open problem.",
+    "problemStatement": "Let h(n) be maximal such that if A ⊆ ℤ with |A| = n then there is B ⊆ A with |B| ≥ h(n) such that if a₁+⋯+aᵣ = b₁+⋯+bₛ with aᵢ,bᵢ ∈ B then r = s. Estimate h(n).",
+    "text": "Estimate h(n) where h(n) is the max |B| such that equal sums in B have equal length. Known: (n log n)^{1/3} ≪ h(n) ≪ √n. Status: OPEN.",
+    "proofStrategy": "We formalize the sum-length-free property via SumRep structures and the SumLengthFree predicate. The function h(n) is axiomatized with bounds from Straus (upper) and Erdős-Choi (lower). We connect to Sidon sets and show computational examples. The main theorem combines all known bounds.",
     "keyInsights": [
       "Sum-length-free is weaker than Sidon: only length must match",
-      "Upper bound h(n) \u226a \u221an (Straus 1966) matches Sidon bound",
-      "Lower bound h(n) \u226b (n log n)^{1/3} (Erd\u0151s-Choi 1974)",
+      "Upper bound h(n) ≪ √n (Straus 1966) matches Sidon bound",
+      "Lower bound h(n) ≫ (n log n)^{1/3} (Erdős-Choi 1974)",
       "Gap between exponents 1/3 and 1/2 is significant",
-      "Probabilistic construction uses fractional parts {\u03b1a}",
+      "Probabilistic construction uses fractional parts {αa}",
       "Sidon sets are automatically sum-length-free",
       "Related to Problems 186 (sum-free) and 874"
     ],
@@ -94,74 +94,74 @@
       "id": "basic-definitions",
       "title": "Basic Definitions",
       "summary": "SumRep structure, SumLengthFree property",
-      "startLine": 39,
-      "endLine": 59,
+      "startLine": 41,
+      "endLine": 60,
       "mathContext": "SumRep structure, SumLengthFree property"
     },
     {
       "id": "h-function",
       "title": "The Function h(n)",
       "summary": "Definition and existence axioms for h(n)",
-      "startLine": 60,
-      "endLine": 78,
+      "startLine": 62,
+      "endLine": 75,
       "mathContext": "Definition and existence axioms for h(n)"
     },
     {
       "id": "upper-bounds",
       "title": "Upper Bounds",
-      "summary": "Erd\u0151s n^{5/6}, Straus \u221an (best known)",
-      "startLine": 79,
-      "endLine": 98,
-      "mathContext": "Erd\u0151s n^{5/6}, Straus \u221an (best known)"
+      "summary": "Erdős n^{5/6}, Straus √n (best known)",
+      "startLine": 76,
+      "endLine": 89,
+      "mathContext": "Erdős n^{5/6}, Straus √n (best known)"
     },
     {
       "id": "lower-bounds",
       "title": "Lower Bounds",
-      "summary": "Erd\u0151s n^{1/3}, Choi (n log n)^{1/3} (best known)",
-      "startLine": 99,
-      "endLine": 121,
-      "mathContext": "Erd\u0151s n^{1/3}, Choi (n log n)^{1/3} (best known)"
+      "summary": "Erdős n^{1/3}, Choi (n log n)^{1/3} (best known)",
+      "startLine": 91,
+      "endLine": 104,
+      "mathContext": "Erdős n^{1/3}, Choi (n log n)^{1/3} (best known)"
     },
     {
       "id": "gap",
       "title": "The Gap and Combined Bounds",
-      "summary": "Combined bounds theorem: (n log n)^{1/3} \u226a h(n) \u226a \u221an",
-      "startLine": 122,
-      "endLine": 133,
-      "mathContext": "Combined bounds theorem: (n log n)^{1/3} \u226a h(n) \u226a \u221an"
+      "summary": "Combined bounds theorem: (n log n)^{1/3} ≪ h(n) ≪ √n",
+      "startLine": 106,
+      "endLine": 119,
+      "mathContext": "Combined bounds theorem: (n log n)^{1/3} ≪ h(n) ≪ √n"
     },
     {
       "id": "sidon",
       "title": "Connection to Sidon Sets",
       "summary": "IsSidonSet definition, Sidon implies sum-length-free",
-      "startLine": 134,
-      "endLine": 154,
+      "startLine": 131,
+      "endLine": 141,
       "mathContext": "IsSidonSet definition, Sidon implies sum-length-free"
     },
     {
       "id": "examples",
       "title": "Computational Examples",
-      "summary": "\u221a1000 and \u221a10^6 via native_decide",
-      "startLine": 155,
-      "endLine": 169,
-      "mathContext": "\u221a1000 and \u221a10^6 via native_decide"
+      "summary": "√1000 and √10^6 via native_decide",
+      "startLine": 157,
+      "endLine": 177,
+      "mathContext": "√1000 and √10^6 via native_decide"
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "Main theorem combining bounds, problem OPEN",
-      "startLine": 170,
+      "startLine": 207,
       "endLine": 242,
       "mathContext": "Main theorem combining bounds, problem OPEN"
     }
   ],
   "conclusion": {
-    "summary": "Erd\u0151s Problem #789 asks for the growth rate of h(n), the maximum size of a sum-length-free subset. Straus proved h(n) \u226a \u221an (1966) and Erd\u0151s-Choi proved h(n) \u226b (n log n)^{1/3} (1974). The gap between these bounds remains open.",
+    "summary": "Erdős Problem #789 asks for the growth rate of h(n), the maximum size of a sum-length-free subset. Straus proved h(n) ≪ √n (1966) and Erdős-Choi proved h(n) ≫ (n log n)^{1/3} (1974). The gap between these bounds remains open.",
     "implications": "Understanding h(n) would illuminate the structure of additive combinatorics. The sum-length-free property sits between arbitrary sets and Sidon sets in terms of constraint strength.",
     "openQuestions": [
       "What is the true growth rate of h(n)?",
-      "Is h(n) ~ \u221an (Straus bound tight)?",
-      "Is h(n) ~ n^\u03b1 for some 1/3 < \u03b1 < 1/2?",
+      "Is h(n) ~ √n (Straus bound tight)?",
+      "Is h(n) ~ n^α for some 1/3 < α < 1/2?",
       "Can the probabilistic construction be improved?",
       "What is the connection to other sum problems?"
     ]
@@ -190,7 +190,7 @@
     {
       "targetId": "erdos-1109",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem on additive combinatorics and sumset constraints"
+      "description": "Related Erdős problem on additive combinatorics and sumset constraints"
     },
     {
       "targetId": "erdos-332",


### PR DESCRIPTION
## Fix

Realign `sections[].startLine`/`endLine` in `src/data/proofs/erdos-789/meta.json` to match the actual `## Part N` header positions in the Lean source file.

## Evidence

**Before**: Section ranges drifted 15–40 lines past actual Part headers (e.g., `gap` pointed to Part VI instead of Part V; `summary` started 38 lines early inside Part XII).

**After**: All 8 sections aligned to verified Part header positions:

| section.id | old range | new range | actual Part header |
|------------|-----------|-----------|-------------------|
| basic-definitions | 39–59 | 41–60 | Part I @ 42 |
| h-function | 60–78 | 62–75 | Part II @ 63 |
| upper-bounds | 79–98 | 76–89 | Part III @ 77 |
| lower-bounds | 99–121 | 91–104 | Part IV @ 92 |
| gap | 122–133 | 106–119 | Part V @ 107 |
| sidon | 134–154 | 131–141 | Part VII @ 132 |
| examples | 155–169 | 157–177 | Part X @ 158 |
| summary | 170–242 | 207–242 | Part XIII @ 208 |

Closes #13779

---
Automated fix by lean-mechanic agent.