### PR TITLE
audit(erdos-788): mark issues-found in tracker (#13782)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9140,9 +9140,9 @@
     },
     "erdos-788": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-29T01:18:52Z",
+      "result": "issues-found"
     },
     "erdos-789": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Audited erdos-788 (Sum-Free Subsets in Intervals) — found phantom-axiom narrative drift.
- Filed issue #13782 for the meta.json fixes.
- This PR only updates `audit-tracker.json` to reflect the audit result.

Counts (axiomCount=3, sorries=0, theoremCount=3, definitionCount=8, lineCount=155) are all correct. Drift is in `originalContributions`, `proofStrategy`, and `sections` summaries (3 phantom names + 1 theorem mislabeled as axiom).

## Test plan

- [x] No production code or gallery meta.json changes here — tracker bookkeeping only.