### PR TITLE
audit(erdos-787,784): mark issues-found — phantom names + section drift (#13785, #13787)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9116,9 +9116,9 @@
     },
     "erdos-784": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-29T01:25:10Z",
+      "result": "issues-found"
     },
     "erdos-785": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9134,9 +9134,9 @@
     },
     "erdos-787": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-29T01:23:07Z",
+      "result": "issues-found"
     },
     "erdos-788": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Two audits this cycle, both `issues-found` with classic phantom-axiom narrative drift + section line range drift:

- **erdos-787** (Erdős-Moser sum-free) — Issue #13785: 3 phantom names in `originalContributions` (`g_spec`, `klarner_lower_bound`, `choi_1971_upper_bound`) + sections off by 7–11 lines.
- **erdos-784** (sieving with bounded reciprocal sums) — Issue #13787: 2 phantom names (`union_bound_small_C`, `ruzsa_negative_answer`), 1 axiom-as-theorem mislabel (`negative_answer_large_C`), `main-statement` mathContext claims "11 axioms" (actual: 5), sections off by up to 28 lines.

Numerical counts for both proofs (sorries, axioms, theorems, defs) are correct — the drift is in the narrative metadata.

## Test plan

- [x] meta.json `audit-tracker` updated for erdos-787 and erdos-784 (`issues-found`)
- [x] Issues #13785 and #13787 filed with verification commands and recommended fixes
- [ ] Mechanic to remove phantom names + realign section line ranges

🤖 Generated with [Claude Code](https://claude.com/claude-code)