### PR TITLE
audit: tracker — erdos-806 issues-found (#13789)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9266,8 +9266,8 @@
     },
     "erdos-806": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-29T00:43:16Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-29T01:32:13Z",
       "result": "issues-found"
     },
     "erdos-807": {


### PR DESCRIPTION
## Summary

Re-audit of erdos-806 found residual section line-range drift. PR #13771 corrected phantom identifiers and three section summaries, but did not realign `sections[].startLine`/`endLine`. Six sections drift 5–9 lines from actual Lean positions.

Numerical counts remain clean: axiomCount=2, theoremCount=3, definitionCount=4, sorries=0, lineCount=219.

Filed #13789 with the drift table and expected ranges.

## Test plan
- [ ] mechanic addresses #13789 with a meta.json edit (no Lean changes)