### PR TITLE
fix(erdos-784): remove phantom contributions + fix axiom/theorem mislabel + realign sections

### DIFF
--- a/src/data/proofs/erdos-784/meta.json
+++ b/src/data/proofs/erdos-784/meta.json
@@ -35,11 +35,10 @@
       "ruzsa_1982_lower_bound axiom: H₁(x) ≥ K·x/log x",
       "saias_1998_upper_bound axiom: H₁(x) ≤ K·x/log x",
       "H_one_asymptotic theorem: combining bounds for H₁(x) ≍ x/log x",
-      "union_bound_small_C theorem: trivial case for C < 1",
+      "positive_answer_small_C axiom: YES for 0 < C < 1",
       "alpha_lt_one theorem: proves e^{1-C} < 1 for C > 1",
-      "ruzsa_negative_answer axiom: sublinear growth for C > 1",
       "weingartner_2025 axiom: precise asymptotics with log factor",
-      "negative_answer_large_C theorem: NO for C > 1",
+      "negative_answer_large_C axiom: NO for C > 1",
       "erdos_784_complete_answer theorem: YES iff C ≤ 1",
       "one_in_A_trivial theorem: excluding 1 from A"
     ],
@@ -79,82 +78,82 @@
     {
       "id": "basic-definitions",
       "title": "Basic Definitions",
-      "startLine": 37,
-      "endLine": 63,
+      "startLine": 38,
+      "endLine": 64,
       "summary": "Defines reciprocal sum Σ 1/n for a set A, the sieved set of elements not divisible by any a ∈ A, and the sieving function H_C(x).",
       "mathContext": "$\\text{reciprocalSum}(A) = \\sum_{n \\in A} 1/n$; $\\text{sievedSet}(A, x) = \\{m \\leq x : a \\nmid m \\text{ for all } a \\in A\\}$; $H_C(x) = \\min\\{|\\text{sievedSet}(A,x)| : \\sum_{A} 1/n \\leq C\\}$."
     },
     {
       "id": "the-question",
       "title": "The Question",
-      "startLine": 64,
-      "endLine": 74,
+      "startLine": 65,
+      "endLine": 75,
       "summary": "Formalizes the main question: Does H_C(x) ≫ x/(log x)^c for some c depending on C?",
       "mathContext": "$\\text{HasPolynomialLogBound}(C) :\\iff \\exists c > 0, \\exists K > 0, \\forall x \\geq 2: H_C(x) \\geq K \\cdot x/(\\log x)^c$."
     },
     {
       "id": "case-c-equals-1",
       "title": "The Case C = 1",
-      "startLine": 75,
-      "endLine": 106,
+      "startLine": 76,
+      "endLine": 101,
       "summary": "States Ruzsa's lower bound and Saias's upper bound giving H₁(x) ≍ x/log x. Includes Weingartner's precise asymptotic constant c ≈ 0.878.",
       "mathContext": "Ruzsa (1982): $H_1(x) \\geq K_1 \\cdot x/\\log x$. Saias (1998): $H_1(x) \\leq K_2 \\cdot x/\\log x$. Combined: $H_1(x) \\asymp x/\\log x$ with $c = 1$."
     },
     {
       "id": "case-small-c",
       "title": "The Case 0 < C < 1",
-      "startLine": 107,
-      "endLine": 125,
+      "startLine": 102,
+      "endLine": 115,
       "summary": "The trivial case: union bound gives (1-C)x, which beats any polynomial-log bound. Answer is YES for all c.",
       "mathContext": "For $C < 1$: at most $\\sum_{a \\in A} \\lfloor x/a \\rfloor \\leq Cx$ elements are sieved, so $\\geq (1-C)x$ survive — linear growth trivially dominates $x/(\\log x)^c$."
     },
     {
       "id": "case-large-c",
       "title": "The Case C > 1",
-      "startLine": 126,
-      "endLine": 157,
+      "startLine": 116,
+      "endLine": 142,
       "summary": "Ruzsa's negative answer: H_C(x) ≍ x^{e^{1-C}}/log x. Since e^{1-C} < 1 for C > 1, this is sublinear—no polynomial-log bound exists.",
       "mathContext": "For $C > 1$: $\\alpha = e^{1-C} < 1$, so $H_C(x) \\asymp x^\\alpha/\\log x = o(x/(\\log x)^c)$ for any $c > 0$. The sublinear exponent kills any polynomial-log bound."
     },
     {
       "id": "schinzel-szekeres",
       "title": "Schinzel-Szekeres Example",
-      "startLine": 158,
-      "endLine": 173,
+      "startLine": 143,
+      "endLine": 152,
       "summary": "The 1959 construction showing the x/(log x)^c bound is best possible (up to the value of c).",
       "mathContext": "Schinzel-Szekeres: $\\forall c > 0, \\exists A$ with $\\sum 1/n \\leq 1$ and $|\\text{sievedSet}(A,x)| \\leq 2x/(\\log x)^c$. This shows the log-polynomial form is tight."
     },
     {
       "id": "trivial-cases",
       "title": "The Trivial Cases",
-      "startLine": 174,
-      "endLine": 192,
+      "startLine": 153,
+      "endLine": 171,
       "summary": "If 1 ∈ A, all elements are divisible. Hence we assume 1 ∉ A (validSet requires a ≥ 2).",
       "mathContext": "Since $1 \\mid m$ for all $m$, including 1 in $A$ trivially sieves everything. The `validSet` predicate requires $a \\geq 2$ to avoid this degeneracy."
     },
     {
       "id": "connections",
       "title": "Connection to Dense Divisors",
-      "startLine": 193,
-      "endLine": 211,
+      "startLine": 172,
+      "endLine": 183,
       "summary": "Connection to Problem #542 and the phase transition principle for reciprocal sum control of sieving.",
       "mathContext": "Dense divisor problems study the distribution of integers with many small divisors — the dual perspective to sieving. The phase transition at $C = 1$ mirrors phenomena in probabilistic number theory."
     },
     {
       "id": "complete-answer",
       "title": "Complete Answer",
-      "startLine": 212,
-      "endLine": 235,
+      "startLine": 184,
+      "endLine": 207,
       "summary": "Combines all cases: YES for C ≤ 1, NO for C > 1. The transition at C = 1 is sharp.",
       "mathContext": "$(C \\leq 1 \\implies \\text{HasPolynomialLogBound}(C)) \\wedge (C > 1 \\implies \\neg\\text{HasPolynomialLogBound}(C))$. The dichotomy is exhaustive."
     },
     {
       "id": "main-statement",
       "title": "Main Problem Statement",
-      "startLine": 236,
+      "startLine": 208,
       "endLine": 251,
       "summary": "Complete formalization with both asymptotic formulas and the dichotomous answer to the original question.",
-      "mathContext": "Packages all results: $H_1(x) \\asymp x/\\log x$, $H_C(x) \\asymp x^{e^{1-C}}/\\log x$ for $C > 1$, and the YES/NO dichotomy at $C = 1$. 11 axioms encode results spanning 1959-2025."
+      "mathContext": "Packages all results: $H_1(x) \\asymp x/\\log x$, $H_C(x) \\asymp x^{e^{1-C}}/\\log x$ for $C > 1$, and the YES/NO dichotomy at $C = 1$. 5 axioms encode results spanning 1982-2025."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Fix

Remove 2 phantom names and fix 1 axiom/theorem mislabel in `originalContributions`, correct a phantom axiom count in `mathContext`, and realign all 10 section line ranges in `src/data/proofs/erdos-784/meta.json`.

## Evidence

**Phantom contributions removed/corrected:**
- `"union_bound_small_C theorem: trivial case for C < 1"` → no such theorem. The matching declaration is `axiom positive_answer_small_C` at L112. Renamed to `"positive_answer_small_C axiom: YES for 0 < C < 1"`
- `"ruzsa_negative_answer axiom: sublinear growth for C > 1"` → phantom name; `negative_answer_large_C` already listed in entry 14. Removed.
- `"negative_answer_large_C theorem: NO for C > 1"` → declared as `axiom` at L139, not a theorem. Corrected to `"negative_answer_large_C axiom: NO for C > 1"`

**Phantom axiom count in mathContext corrected:**
- `main-statement.mathContext`: "11 axioms encode results spanning 1959-2025" → "5 axioms encode results spanning 1982-2025" (file has 5 axioms, oldest is Ruzsa 1982)

**Section startLines corrected** to match actual `grep -nE "^## Part"` output:

| Section | Before | After |
|---|---|---|
| basic-definitions | 37–63 | 38–64 |
| the-question | 64–74 | 65–75 |
| case-c-equals-1 | 75–106 | 76–101 |
| case-small-c | 107–125 | 102–115 |
| case-large-c | 126–157 | 116–142 |
| schinzel-szekeres | 158–173 | 143–152 |
| trivial-cases | 174–192 | 153–171 |
| connections | 193–211 | 172–183 |
| complete-answer | 212–235 | 184–207 |
| main-statement | 236–251 | 208–251 |

Closes #13787

---
Automated fix by lean-mechanic agent.