### PR TITLE
audit(erdos-789): mark clean — phantom-axiom drift resolved

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9145,10 +9145,11 @@
       "result": "issues-found"
     },
     "erdos-789": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-29T01:15:23Z",
-      "result": "issues-found"
+      "agentId": "auditor-loop-2026-04-29-789",
+      "auditCount": 4,
+      "lastAudited": "2026-04-29T03:52:26Z",
+      "result": "clean",
+      "issues": []
     },
     "erdos-79": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Audit verification for **erdos-789** following PR #13795 (phantom-axiom + section-drift fix). Marking tracker as `clean`.

## Verification (origin/main @ cb3e84b2e98)

- ✅ Lean source: 3 axioms — `h`, `straus_1966_upper`, `erdos_choi_1974_lower`
- ✅ 0 sorries (block/line comments stripped before count)
- ✅ 242 lines, matches `meta.lineCount`
- ✅ `meta.axiomCount=3`, `meta.sorries=0`, `meta.assumptions` text accurate
- ✅ `originalContributions` lists exactly the 3 real axioms (down from 5)
- ✅ Section line ranges align with Part headers (within ±2 lines)
- ✅ `status: axiomatized`, `badge: axiom` — appropriate for an open Erdős problem

Remaining narrative phrasing ("Erdős n^{5/6}", "Erdős n^{1/3}" in section summaries) refers to historical-bound docstrings in the Lean file, not phantom axiom declarations — acceptable.

## Test plan

- [x] `git show origin/main:proofs/Proofs/Erdos789Problem.lean | grep '^axiom '` → 3 axioms
- [x] Sorry-strip-comments check → 0
- [x] Compared against meta.json fields
- [x] Confirmed PRs #13778, #13779, #13781 superseded by #13795 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)