### PR TITLE
audit(erdos-785): mark issues-found — phantom 'average_representation' (#13802)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9122,9 +9122,9 @@
     },
     "erdos-785": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-29T04:01:09Z",
+      "result": "issues-found"
     },
     "erdos-786": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Mark erdos-785 in audit-tracker.json with `result: issues-found` after finding phantom `average_representation` in section 7
- Filed as issue #13802

## Context
PR #13777 fixed phantom `ruzsa_2017` in originalContributions/proofStrategy but missed the `average_representation` reference in section 7's summary and mathContext (the latter was last audited 2026-04-03, before #13777).

## Test plan
- [x] Tracker entry updated
- [x] Issue filed: #13802

🤖 Generated with [Claude Code](https://claude.com/claude-code)