### PR TITLE
audit(erdos-79): mark issues-found — phantom narrative tracked in #13796

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9152,9 +9152,9 @@
     },
     "erdos-79": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-29T04:04:34Z",
+      "result": "issues-found"
     },
     "erdos-790": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Re-audit of erdos-79 confirms the phantom-axiom/sorry narrative drift already captured in #13796 with active fix PR #13801. No new issue filed.

## Findings

- **proofStrategy** says \"the three \`sorry\`s correspond to: a type coercion issue for K₄, the edge count computation, and the antichain theorem\" — but the file has only 1 \`sorry\` (line 179, in K4_unique_known).
- **Section \"K4-structure\"** summary describes \`K4_edge_count\` as \`(sorry)\`; the actual proof is \`native_decide\`.
- **Section \"K4-structure\"** also claims it axiomatizes the Chvátal–Rödl–Szemerédi–Trotter (1983) result and Lee (2017); no such axioms or theorems exist in the file (just docstring placeholders at lines 197–198).
- Numerical fields (axiomCount=4, sorries=1, lineCount=238, status/badge) are correct.

## Audit-tracker

Marks \`erdos-79\` as \`issues-found\` (already in flight via #13796 / #13801).

## Test plan

- [x] \`./scripts/auditor/claim-target.sh complete erdos-79 issues-found\`
- [x] verified existing issue #13796 + fix PR #13801 cover the same drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)