### PR TITLE
audit(erdos-786): mark issues-found — phantom Ruzsa axiom in narrative

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9128,9 +9128,9 @@
     },
     "erdos-786": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-29T04:07:17Z",
+      "result": "issues-found"
     },
     "erdos-787": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Audit of `erdos-786` (Erdős Problem #786: Multiplicative Cardinality Sets) found a phantom-axiom narrative drift.
- `originalContributions` lists "Ruzsa's unpublished upper bound axiom" and `proofStrategy`/sections describe a log 2 lower bound, but neither is declared in the Lean source — they only appear in docstrings.
- Numerical counts (`axiomCount: 2`, `sorries: 0`) are correct; only the prose narrative is wrong.
- Filed integrity issue #13805 for content fix.

## Test plan

- [x] Read `proofs/Proofs/Erdos786Problem.lean` — only 2 actual `axiom` declarations: `mod4_example`, `selfridge_construction`
- [x] Read `src/data/proofs/erdos-786/meta.json` — confirmed `originalContributions[4]` claims "Ruzsa's unpublished upper bound axiom" with no corresponding declaration
- [x] Confirmed no existing PR/issue/worktree for erdos-786 phantom-axiom fix
- [x] Audit tracker updated: `erdos-786` marked `issues-found`

🤖 Generated with [Claude Code](https://claude.com/claude-code)