### PR TITLE
audit(erdos-779): mark clean — counts and narrative verified

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9080,9 +9080,9 @@
     },
     "erdos-779": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-29T04:13:45Z",
+      "result": "clean"
     },
     "erdos-78": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Audit Result

**Slug**: erdos-779
**Result**: `clean`
**Lean file**: `proofs/Proofs/Erdos779Problem.lean`

## Verification

| Field | meta.json | Lean source | Match |
|---|---|---|---|
| sorries | 0 | 0 | ✓ |
| axiomCount | 1 | 1 (`oeis_A005235`) | ✓ |
| lineCount | 218 | 218 | ✓ |
| theoremCount | 8 | 8 | ✓ |
| definitionCount | 7 | 7 | ✓ |

`status: axiomatized` and `badge: axiom` are appropriate (1 axiom for the OEIS A005235 sequence).

Section line-ranges align with declarations in the source. No phantom axiom narrative; no sorry-count drift; no Tier inflation.

---

Discovered during gallery integrity audit (auditor loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)