### PR TITLE
fix(erdos-785): remove phantom average_representation + realign section line ranges

### DIFF
--- a/src/data/proofs/erdos-785/meta.json
+++ b/src/data/proofs/erdos-785/meta.json
@@ -119,21 +119,21 @@
       "title": "Ruzsa's Refinement",
       "summary": "Documents (in a docstring) Ruzsa's (2017) tight characterization of growth rates. Not formalized in this file.",
       "startLine": 139,
-      "endLine": 154
+      "endLine": 148
     },
     {
       "id": "related-concepts",
       "title": "Related Concepts",
-      "summary": "representationFunction, average_representation",
-      "startLine": 155,
-      "endLine": 175,
-      "mathContext": "Mathematical content: representationFunction, average_representation"
+      "summary": "representationFunction",
+      "startLine": 149,
+      "endLine": 163,
+      "mathContext": "Mathematical content: representationFunction"
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "erdos_785_summary, erdos_785",
-      "startLine": 176,
+      "startLine": 164,
       "endLine": 199,
       "mathContext": "Mathematical content: erdos_785_summary, erdos_785"
     }


### PR DESCRIPTION
## Fix

Remove phantom `average_representation` from `sections[6]` (related-concepts) summary and mathContext, and realign line ranges for `ruzsa-refinement`, `related-concepts`, and `summary` sections to match the actual Lean file structure.

## Evidence

**Before** (`related-concepts` section):
- summary: `"representationFunction, average_representation"` ← `average_representation` does not exist as any declaration; it is only a docstring heading at lines 160-163 with no following `def`/`theorem`/`axiom`
- startLine: 155, endLine: 175 ← off (Part VII header is at line 149)

**After** (`related-concepts` section):
- summary: `"representationFunction"` (only actual `noncomputable def` at line 157)
- startLine: 149, endLine: 163 ← aligned to actual Part VII block

**Also fixed** section line ranges:
- `ruzsa-refinement`: endLine 154 → 148 (block ends at the docstring close)
- `summary`: startLine 176 → 164 (Part IX header starts at line 164)

Verified against `proofs/Proofs/Erdos785Problem.lean` @ `cb3e84b2e98`. Numerical counts (`axiomCount: 2`, `sorries: 0`, `definitionCount: 9`) are correct and unchanged.

Closes #13802

---
Automated fix by lean-mechanic agent.