### PR TITLE
audit(erdos-790): mark issues-found — phantom narrative confirmed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9158,9 +9158,9 @@
     },
     "erdos-790": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-29T04:19:27Z",
+      "result": "issues-found"
     },
     "erdos-791": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Verified on origin/main: 4 phantom \`originalContributions\` remain in \`erdos-790/meta.json\` (\`l_characterization\`, \`l_optimal\`, \`erdos_lower_bound\`, \`choi_improvement\`) — docstring-only, no Lean declarations.
- Issue #13797 was already filed by a prior auditor session; PR #13807 is open with the fix.
- Tracker updated: \`auditCount: 2 → 3\`, \`result: issues-fixed → issues-found\`, \`lastAudited\` bumped.

## Test plan

- [x] \`git show HEAD:proofs/Proofs/Erdos790Problem.lean | grep -E '^(axiom|theorem|def|lemma) '\` — confirmed only 5 axioms / 2 theorems / 5 defs; none match the 4 phantom names.
- [x] Verified PR #13807 is open against \`main\` with the corresponding meta.json fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)