### PR TITLE
audit(erdos-777): mark issues-found — phantom narrative (#13812)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9068,9 +9068,9 @@
     },
     "erdos-777": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-29T04:26:21Z",
+      "result": "issues-found"
     },
     "erdos-778": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Re-audit of `erdos-777` found 3 phantom names in `originalContributions` plus narrative drift, all referencing doc-comment-only entities in `Erdos777Problem.lean`.

- Phantom names: `extremal_construction`, `sperner_bound`, `daykinFrankl` — none declared in source
- `proofStrategy` references Sperner bound and Daykin-Frankl as supporting results (docstring-only)
- `sections[].summary` references `alonFrankl_quantitative` (also docstring-only); ranges drift from real declarations

Numerical counts verified correct: 3 axioms, 8 theorems, 9 defs, 0 sorries, 336 lines.

Issue: #13812

## Test plan

- [ ] Tracker entry for `erdos-777` flips from `issues-fixed` → `issues-found`
- [ ] Mechanic picks up #13812 to remove phantom narrative

🤖 Generated with [Claude Code](https://claude.com/claude-code)