### PR TITLE
audit(erdos-79): mark clean — phantom narrative fixed by #13801

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9153,9 +9153,9 @@
     },
     "erdos-79": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-29T04:04:34Z",
-      "result": "issues-found"
+      "auditCount": 4,
+      "lastAudited": "2026-04-29T04:29:43Z",
+      "result": "clean"
     },
     "erdos-790": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Re-audited erdos-79 after the phantom narrative fix in #13801 landed. Tracker updated from `issues-found` to `clean`.

## Verification

- Lean source: 4 axioms, 1 sorry, 238 lines — matches meta.json counts
- proofStrategy now correctly describes the single sorry (K4_unique_known type coercion); previously claimed three sorries including phantom ones for K4_edge_count (proved via native_decide) and minimal_form_antichain (fully proved)
- K4-structure section now correctly notes that K₃/paths Ramsey linearity appear in docstrings only — not axiomatized
- All section line ranges align with Lean source

## Test plan

- [x] No code changes; tracker JSON only
- [x] Closes audit cycle for erdos-79 (issue #13796 already closed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)