### PR TITLE
research(erdos-1183): add trivial upper bounds f(n), F(n) ≤ 2^n

### DIFF
--- a/proofs/Proofs/Erdos1183Problem.lean
+++ b/proofs/Proofs/Erdos1183Problem.lean
@@ -265,6 +265,40 @@ theorem erdos1183_F_ge_f (n : ℕ) : erdos1183_F n ≥ erdos1183_f n := by
     · intro A hA; exact absurd hA (Finset.not_mem_empty A)
   · exact achievableSublattice_subset_unionClosed n
 
+/-- **Trivial upper bound:** f(n) ≤ 2^n, since any monochromatic family is a
+    subset of `Finset.univ : Finset (Finset (Fin n))` of cardinality 2^n. -/
+theorem erdos1183_f_upper_bound (n : ℕ) : erdos1183_f n ≤ 2 ^ n := by
+  unfold erdos1183_f
+  apply csSup_le
+  · -- nonempty: 0 is achievable (every family has size ≥ 0)
+    refine ⟨0, fun χ => ⟨∅, ⟨?_, ?_⟩, ⟨0, ?_⟩, Nat.zero_le _⟩⟩
+    · intro A hA; exact absurd hA (Finset.not_mem_empty A)
+    · intro A hA; exact absurd hA (Finset.not_mem_empty A)
+    · intro A hA; exact absurd hA (Finset.not_mem_empty A)
+  · intro k hk
+    obtain ⟨F, _, _, hcard⟩ := hk (fun _ => 0)
+    have h1 : F.card ≤ (Finset.univ : Finset (Finset (Fin n))).card :=
+      Finset.card_le_card (Finset.subset_univ F)
+    have h2 : (Finset.univ : Finset (Finset (Fin n))).card = 2 ^ n := by
+      rw [Finset.card_univ, Fintype.card_finset, Fintype.card_fin]
+    omega
+
+/-- F(n) ≤ 2^n by the same containment argument. -/
+theorem erdos1183_F_upper_bound (n : ℕ) : erdos1183_F n ≤ 2 ^ n := by
+  unfold erdos1183_F
+  apply csSup_le
+  · -- nonempty: 0 is achievable
+    refine ⟨0, fun χ => ⟨∅, ?_, ⟨0, ?_⟩, Nat.zero_le _⟩⟩
+    · intro A hA; exact absurd hA (Finset.not_mem_empty A)
+    · intro A hA; exact absurd hA (Finset.not_mem_empty A)
+  · intro k hk
+    obtain ⟨F, _, _, hcard⟩ := hk (fun _ => 0)
+    have h1 : F.card ≤ (Finset.univ : Finset (Finset (Fin n))).card :=
+      Finset.card_le_card (Finset.subset_univ F)
+    have h2 : (Finset.univ : Finset (Finset (Fin n))).card = 2 ^ n := by
+      rw [Finset.card_univ, Fintype.card_finset, Fintype.card_fin]
+    omega
+
 /-- Open conjecture: f(n) is at most linear in n. Erdős had no conjecture
     for the growth rate. Stated as a Prop (not axiom) since unresolved. -/
 def erdos1183_f_growth_conjecture : Prop :=

--- a/research/problems/erdos-1183/state.md
+++ b/research/problems/erdos-1183/state.md
@@ -1,27 +1,45 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-01-16T08:44:15.246Z
-**Iteration**: 1
+**Phase**: COMPLETED
+**Since**: 2026-04-29T04:30Z (researcher-1 audit + pool sync)
+**Iteration**: 3
 
 ## Current Focus
 
-Initial exploration of the problem.
+Pool-metadata reconciliation: prior sessions (researcher-4 in Session 1 and
+researcher-2 in Session 2, see knowledge.md) fully built out the gallery
+entry. Pool entry was still flagged `in-progress`; it now reflects completion.
 
 ## Active Approach
 
-None yet.
+None — formalization complete.
+
+`proofs/Proofs/Erdos1183Problem.lean` (280 lines) proves the trivial chain
+lower bound `f(n) ≥ ⌈(n+1)/2⌉` via the standard chain
+`∅ ⊂ {0} ⊂ {0,1} ⊂ ... ⊂ Fin n` and pigeonhole, with 0 sorries and 0 axiom
+declarations. Both open conjectures (growth rate of f, super-polynomial growth
+of F) are stated as `Prop` definitions, not assumed true.
 
 ## Blockers
 
-None.
+The remaining open questions (true asymptotic growth of f(n) and F(n)) are
+genuine open problems in extremal combinatorics — Erdős and Ulam reported
+having "no plausible conjecture" for the order of magnitude. Improving the
+trivial chain bound is a research-paper-scale task, not a session task.
 
 ## Next Action
 
-Begin problem exploration.
+None for the basic entry. Optional future work that would strengthen the file
+(not required for completion):
+
+- Specific small-case computations: `f(0) = 1`, `f(1) = 1`, `f(2) = 2` (the
+  trivial bound is tight on these and could be made formally explicit).
+- A trivial upper bound `f(n) ≤ 2^n` (`achievableSublattice_bddAbove` already
+  proves the abstract version; the inequality `erdos1183_f n ≤ 2^n` is a
+  short consequence via `csSup_le`).
 
 ## Attempt Counts
 
-- Total attempts: 0
+- Total attempts: 3 (researcher-4 Session 1; researcher-2 Session 2; researcher-1 Session 3)
 - Current approach attempts: 0
-- Approaches tried: 0
+- Approaches tried: 1 (chain + pigeonhole — the only known general technique)

--- a/src/data/proofs/erdos-1183/meta.json
+++ b/src/data/proofs/erdos-1183/meta.json
@@ -48,11 +48,12 @@
       "Corrected abstract definitions of f(n) and F(n) using sSup (was sInf, evaluating to 0)",
       "Formal proof erdos1183_f_lower_bound: f(n) ≥ ⌈(n+1)/2⌉ via le_csSup",
       "Proof erdos1183_F_ge_f: F(n) ≥ f(n) since sublattices are union-closed",
-      "BddAbove proofs bounding achievable sets by 2^n"
+      "BddAbove proofs bounding achievable sets by 2^n",
+      "Trivial upper bounds erdos1183_f_upper_bound and erdos1183_F_upper_bound: f(n), F(n) ≤ 2^n via csSup_le and Fintype.card_finset"
     ],
     "axiomCount": 0,
     "assumptions": "0 axiom declarations. Two open conjectures (erdos1183_f_growth_conjecture, erdos1183_F_superpolynomial_conjecture) stated as Prop definitions, not assumed true.",
-    "lineCount": 280,
+    "lineCount": 314,
     "prerequisites": [
       "Finite set theory (Finset, powerset, filter)",
       "Lattice theory (union/intersection closure)",
@@ -131,9 +132,9 @@
       "id": "abstract-definitions-and-bound",
       "title": "Abstract Definitions of f(n), F(n) and Formal Bounds",
       "startLine": 201,
-      "endLine": 280,
-      "summary": "Formalizes $f(n)$ and $F(n)$ as suprema over achievable sizes (`sSup`), with proofs that the suprema are bounded above (hence the `sSup` is a nat). `erdos1183_f_lower_bound` proves $f(n) \\geq \\lceil(n+1)/2\\rceil$ by exhibiting the chain witness. `achievableSublattice_subset_unionClosed` and `erdos1183_F_ge_f` formalize $F(n) \\geq f(n)$ via subset ordering of achievable sets and `csSup_le_csSup`.",
-      "mathContext": "$f(n) = \\text{sSup}\\{k : \\exists \\text{ monochromatic sublattice of size } k\\}$. $F(n) = \\text{sSup}\\{k : \\exists \\text{ monochromatic union-closed family of size } k\\}$. Since every sublattice is union-closed: $\\{\\text{achievable sublattice sizes}\\} \\subseteq \\{\\text{achievable union-closed sizes}\\} \\Rightarrow f(n) \\leq F(n)$."
+      "endLine": 314,
+      "summary": "Formalizes $f(n)$ and $F(n)$ as suprema over achievable sizes (`sSup`), with proofs that the suprema are bounded above (hence the `sSup` is a nat). `erdos1183_f_lower_bound` proves $f(n) \\geq \\lceil(n+1)/2\\rceil$ by exhibiting the chain witness. `achievableSublattice_subset_unionClosed` and `erdos1183_F_ge_f` formalize $F(n) \\geq f(n)$ via subset ordering of achievable sets and `csSup_le_csSup`. `erdos1183_f_upper_bound` and `erdos1183_F_upper_bound` give the trivial upper bound $f(n), F(n) \\leq 2^n$ via `csSup_le` and `Fintype.card_finset`.",
+      "mathContext": "$f(n) = \\text{sSup}\\{k : \\exists \\text{ monochromatic sublattice of size } k\\}$. $F(n) = \\text{sSup}\\{k : \\exists \\text{ monochromatic union-closed family of size } k\\}$. Since every sublattice is union-closed: $\\{\\text{achievable sublattice sizes}\\} \\subseteq \\{\\text{achievable union-closed sizes}\\} \\Rightarrow f(n) \\leq F(n)$. Trivial upper bound: any monochromatic family $F \\subseteq \\mathcal{P}(\\text{Fin}(n))$ has $|F| \\leq |\\mathcal{P}(\\text{Fin}(n))| = 2^n$."
     }
   ],
   "conclusion": {
@@ -199,10 +200,10 @@
       "Finset"
     ],
     "namespace": "Erdos1183",
-    "lineCount": 280,
+    "lineCount": 314,
     "axiomCount": 0,
-    "theoremCount": 15,
-    "definitionCount": 12,
+    "theoremCount": 17,
+    "definitionCount": 14,
     "path": "Proofs/Erdos1183Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary

Adds two short theorems to `proofs/Proofs/Erdos1183Problem.lean` (Erdős–Ulam Problem #1183 on monochromatic sublattice families in 2-colorings of P([n])):

- **`erdos1183_f_upper_bound`**: `f(n) ≤ 2^n` via `csSup_le` applied to `achievableSublattice n`, using `Fintype.card_finset` and `Fintype.card_fin` to compute `|Finset (Fin n)| = 2^n`.
- **`erdos1183_F_upper_bound`**: `F(n) ≤ 2^n` by the same containment.

Combined with the existing chain bound, this brackets the Erdős–Ulam quantities by `⌈(n+1)/2⌉ ≤ f(n) ≤ F(n) ≤ 2^n`. The asymptotic gap remains the open question Erdős described as having “no plausible conjecture”.

Updates:
- `proofs/Proofs/Erdos1183Problem.lean`: 280 → 314 lines, 15 → 17 theorems.
- `src/data/proofs/erdos-1183/meta.json`: `lineCount`, `theoremCount`, `definitionCount` (12 → 14 corrects prior drift to reflect the two open-conjecture `Prop` defs), `originalContributions`, abstract section description, `endLine`.
- `research/problems/erdos-1183/state.md`: phase `NEW` → `COMPLETED` with audit notes.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.Erdos1183Problem` — build verification pending (local Docker daemon was unresponsive during this session under multi-agent load; cf. memory feedback `feedback_docker_build_io_errors.md`).
- [ ] Confirm sorry count remains 0 and axiom count remains 0.
- [ ] Confirm pool entry transitions to `completed` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)