### PR TITLE
audit(erdos-790): mark clean — phantom narrative fixed by #13807

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9159,9 +9159,9 @@
     },
     "erdos-790": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-29T04:19:27Z",
-      "result": "issues-found"
+      "auditCount": 4,
+      "lastAudited": "2026-04-29T04:40:07Z",
+      "result": "clean"
     },
     "erdos-791": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Re-audit Result: clean

Re-audit of erdos-790 after PR #13807 merged. The 4 phantom originalContributions and section drift flagged in #13797 are now correctly fixed on `main`.

## Verified on origin/main

**Lean source** (`proofs/Proofs/Erdos790Problem.lean`):
- 5 `axiom` declarations: `l`, `cks_lower_bound`, `cks_upper_bound`, `question1_affirmative`, `question2_answered`
- 0 sorries, 2 theorems (`cks_bounds`, `erdos_790_summary`), 5 definitions

**meta.json**:
- `axiomCount: 5`, `sorries: 0` — match source
- `originalContributions` lists only real declarations
- `sections.extremal-function.summary`: "l(n) axiom; characterization and optimality discussed in docstrings only"
- `sections.lower-bounds.summary`: "CKS lower bound axiomatized; Erdős and Choi bounds discussed in docstrings only"
- `proofStrategy`: notes Erdős's and Choi's earlier lower bounds are "discussed in docstrings only"

## Tracker update

`audit-tracker.json`: erdos-790 → `auditCount: 4`, `result: clean` (was `issues-found` from prior cycle).