### PR TITLE
fix(erdos-778): remove phantom game_determined + correct theoremCount

### DIFF
--- a/src/data/proofs/erdos-778/meta.json
+++ b/src/data/proofs/erdos-778/meta.json
@@ -54,7 +54,6 @@
       "malekshahian_spiro_density_clique: density >= 3/4",
       "malekshahian_spiro_alice_n_bob_n123: Alice at n implies Bob at n+1,n+2,n+3",
       "alice_no_four_consecutive: proved from Malekshahian-Spiro axiom",
-      "game_determined: Zermelo's theorem axiomatized",
       "erdos_778_periodicity summary theorem"
     ],
     "axiomCount": 3,
@@ -131,10 +130,10 @@
     {
       "id": "consequences",
       "title": "Consequences of Known Results",
-      "summary": "alice_no_four_consecutive proved theorem, game_determined axiom",
+      "summary": "alice_no_four_consecutive proved theorem",
       "startLine": 182,
       "endLine": 205,
-      "mathContext": "Verified: alice_no_four_consecutive proved theorem, game_determined axiom"
+      "mathContext": "Verified: alice_no_four_consecutive proved theorem"
     },
     {
       "id": "summary",
@@ -170,7 +169,7 @@
     "namespace": "Erdos778",
     "lineCount": 225,
     "axiomCount": 3,
-    "theoremCount": 3,
+    "theoremCount": 2,
     "definitionCount": 18,
     "path": "Proofs/Erdos778Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Remove phantom `game_determined` axiom references from erdos-778 meta.json and correct `theoremCount` from 3 to 2.

## Evidence

**Before**:
- `originalContributions` included `"game_determined: Zermelo's theorem axiomatized"` — no such axiom exists in `Erdos778Problem.lean`
- `sections[6].summary` and `mathContext` referenced `game_determined axiom`
- `leanFile.theoremCount`: 3 (actual: 2 theorems — `alice_no_four_consecutive`, `erdos_778_periodicity`)

**After**:
- `originalContributions` lists 13 real contributions (removed phantom)
- `sections[6]` describes only `alice_no_four_consecutive proved theorem`
- `leanFile.theoremCount`: 2

Closes #13817

---
Automated fix by lean-mechanic agent.