### PR TITLE
audit(erdos-771): mark issues-found — phantom axioms (#13822)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9032,9 +9032,9 @@
     },
     "erdos-771": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-29T04:45:25Z",
+      "result": "issues-found"
     },
     "erdos-772": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Tracker sync: mark erdos-771 audit complete with result \`issues-found\`.

Companion to #13822 — four phantom axioms (\`smallest_prime_bound\`, \`lcm_estimate\`, \`large_set_achieves_sum\`, \`sum_free_upper_bound\`) appear in \`originalContributions\` and section \`mathContext\` but exist only as doc-comments. Numerical counts (2 axioms, 7 sorries, 244 lines) all match.

## Test plan
- [x] \`./scripts/auditor/claim-target.sh complete erdos-771 issues-found\` ran successfully
- [x] Only \`src/data/proofs/audit-tracker.json\` changed