### PR TITLE
fix(erdos-778): remove 2 phantom originalContributions + fix section drift

### DIFF
--- a/src/data/proofs/erdos-778/meta.json
+++ b/src/data/proofs/erdos-778/meta.json
@@ -51,10 +51,8 @@
       "AliceStrategy, BobStrategy, playGame axiomatization",
       "BobHasWinningStrategy_CliqueGame, AliceHasWinningStrategy_CliqueGame definitions",
       "ErdosConjecture: Bob wins for all n >= 3",
-      "malekshahian_spiro_density_clique: density >= 3/4",
       "malekshahian_spiro_alice_n_bob_n123: Alice at n implies Bob at n+1,n+2,n+3",
       "alice_no_four_consecutive: proved from Malekshahian-Spiro axiom",
-      "game_determined: Zermelo's theorem axiomatized",
       "erdos_778_periodicity summary theorem"
     ],
     "axiomCount": 3,
@@ -117,31 +115,31 @@
       "title": "Strategies",
       "summary": "AliceStrategy, BobStrategy, playGame, winning strategy definitions",
       "startLine": 125,
-      "endLine": 149,
+      "endLine": 160,
       "mathContext": "Formal definition: AliceStrategy, BobStrategy, playGame, winning strategy definitions"
     },
     {
       "id": "conjecture-and-results",
       "title": "Erd\u0151s's Conjecture and Known Results",
-      "summary": "ErdosConjecture, Malekshahian-Spiro density and periodicity axioms",
-      "startLine": 150,
+      "summary": "ErdosConjecture, Malekshahian-Spiro periodicity axioms",
+      "startLine": 161,
       "endLine": 181,
-      "mathContext": "Axiomatized: ErdosConjecture, Malekshahian-Spiro density and periodicity axioms"
+      "mathContext": "Axiomatized: ErdosConjecture, Malekshahian-Spiro periodicity axioms"
     },
     {
       "id": "consequences",
       "title": "Consequences of Known Results",
-      "summary": "alice_no_four_consecutive proved theorem, game_determined axiom",
+      "summary": "alice_no_four_consecutive proved theorem",
       "startLine": 182,
-      "endLine": 205,
-      "mathContext": "Verified: alice_no_four_consecutive proved theorem, game_determined axiom"
+      "endLine": 200,
+      "mathContext": "Verified: alice_no_four_consecutive proved theorem"
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "erdos_778_periodicity combining known results",
-      "startLine": 206,
-      "endLine": 219,
+      "startLine": 201,
+      "endLine": 225,
       "mathContext": "Mathematical content: erdos_778_periodicity combining known results"
     }
   ],
@@ -170,7 +168,7 @@
     "namespace": "Erdos778",
     "lineCount": 225,
     "axiomCount": 3,
-    "theoremCount": 3,
+    "theoremCount": 2,
     "definitionCount": 18,
     "path": "Proofs/Erdos778Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Remove phantom `malekshahian_spiro_density_clique` and `game_determined` entries from `meta.originalContributions`, and correct 4 section line-range drifts in `src/data/proofs/erdos-778/meta.json`.

## Evidence

**Phantom 1** — `malekshahian_spiro_density_clique: density >= 3/4` (originalContributions[9]):
No such declaration exists in `Erdos778Problem.lean`. The density claim lives only in a docstring of `malekshahian_spiro_alice_n_bob_n123`.

**Phantom 2** — `game_determined: Zermelo's theorem axiomatized` (originalContributions[12]):
No `game_determined` declaration exists in `Erdos778Problem.lean`.

**Section drift** — 4 sections had incorrect line ranges verified against Part header grep:
| Section | Before | After |
|---|---|---|
| `strategies` endLine | 149 | 160 |
| `conjecture-and-results` startLine | 150 | 161 |
| `consequences` endLine | 205 | 200 |
| `summary` startLine/endLine | 206–219 | 201–225 |

**Additional**: `leanFile.theoremCount` corrected 3→2 (file has `alice_no_four_consecutive` and `erdos_778_periodicity` only).

## Note

This supersedes PR #13821 (fix/mechanic-13817), which only addressed `game_determined`. This PR applies both the #13817 and #13825 fixes atomically to avoid a merge conflict. PR #13821 should be closed.

Closes #13825
Closes #13817

---
Automated fix by lean-mechanic agent.