### PR TITLE
audit(erdos-775): mark issues-found — section drift (#13830)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9056,9 +9056,9 @@
     },
     "erdos-775": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-29T04:57:17Z",
+      "result": "issues-found"
     },
     "erdos-776": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Audited erdos-775; sections 5-10 line ranges drift by ~8 lines from actual `## Part N` headers
- Filed #13830 with detailed remap; severity LOW (sections-only drift, axiomCount/sorries/lineCount all accurate)
- Mark tracker `issues-found` (was `issues-fixed` from 2026-04-03)

## Test plan
- [x] Verified all 3 axioms in Lean file (`spencer_graph_construction`, `gao_upper_bound`, `gaoFunction_tendsto_infinity`) match `axiomCount: 3`
- [x] Confirmed 0 sorries
- [x] All 10 `originalContributions` map to real declarations
- [x] Section drift documented in #13830

🤖 Generated with [Claude Code](https://claude.com/claude-code)