### PR TITLE
audit(erdos-778): mark issues-found — phantoms + PR #13829 in-flight

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9074,9 +9074,9 @@
     },
     "erdos-778": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-29T05:00:07Z",
+      "result": "issues-found"
     },
     "erdos-779": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Re-audited erdos-778; confirmed phantom items already filed in #13817 (`game_determined`) and #13825 (`malekshahian_spiro_density_clique` + section drift)
- Fix PR #13829 open against `fix/mechanic-13825`
- Updated audit-tracker.json: auditCount 2→3, result issues-fixed→issues-found

## Evidence
3 axioms in proofs/Proofs/Erdos778Problem.lean (lines 139, 169, 177):
- `playGame`
- `malekshahian_spiro_alice_n_bob_n123`
- `malekshahian_spiro_alice_n_bob_n12_degree`

2 theorems (lines 187, 218): `alice_no_four_consecutive`, `erdos_778_periodicity`

meta.json claims `theoremCount: 3` and `originalContributions` includes `game_determined` and `malekshahian_spiro_density_clique` — both absent.

## Test plan
- [ ] Tracker JSON updates only — no Lean changes