### PR TITLE
fix(erdos-772): remove 3 phantom axioms from originalContributions

### DIFF
--- a/src/data/proofs/erdos-772/meta.json
+++ b/src/data/proofs/erdos-772/meta.json
@@ -53,10 +53,8 @@
       "HasBoundedConvolution: Sets with ‖1_A∗1_A‖_∞ ≤ k",
       "H_k function: Maximum Sidon subset size in bounded convolution sets",
       "erdos_1984_upper_bound axiom: H_k(n) ≪ n^{2/3}",
-      "sidon_subset_sqrt axiom: Any set contains Sidon subset of size ≫ √n",
       "alon_erdos_1985 axiom: H_k(n) ≫_k n^{2/3}",
-      "quadruple_bound axiom: Additive quadruples ≤ k·n² in bounded sets",
-      "probabilistic_construction axiom: Random subsampling construction",
+      "ratio_tends_to_infinity axiom: H_k(n)/√n → ∞",
       "optimal_bounds theorem: H_k(n) = Θ(n^{2/3})",
       "erdos_772_summary: Combined main results"
     ],


### PR DESCRIPTION
## Fix

Remove 3 phantom axiom entries from `meta.originalContributions` and add the missing real `ratio_tends_to_infinity` axiom entry in `src/data/proofs/erdos-772/meta.json`.

## Evidence

**Before** (`originalContributions` had 5 axiom entries, only 2 real):
- `erdos_1984_upper_bound axiom` ✓ (line 126 in Lean)
- `sidon_subset_sqrt axiom` ✗ **phantom** — no such declaration exists
- `alon_erdos_1985 axiom` ✓ (line 153 in Lean)
- `quadruple_bound axiom` ✗ **phantom** — no such declaration exists
- `probabilistic_construction axiom` ✗ **phantom** — no such declaration exists
- (missing) `ratio_tends_to_infinity` — real axiom at line 163, not listed

**After** (`originalContributions` lists all 3 real axioms, no phantoms):
- `erdos_1984_upper_bound axiom: H_k(n) ≪ n^{2/3}`
- `alon_erdos_1985 axiom: H_k(n) ≫_k n^{2/3}`
- `ratio_tends_to_infinity axiom: H_k(n)/√n → ∞`

Numerical counts (`axiomCount: 3`, `sorries: 0`, `lineCount: 249`) were already correct and unchanged.

Closes #13834

---
Automated fix by lean-mechanic agent.