### PR TITLE
audit(erdos-778): mark clean — narrative matches Lean source

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9074,9 +9074,9 @@
     },
     "erdos-778": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-29T05:00:07Z",
-      "result": "issues-found"
+      "auditCount": 4,
+      "lastAudited": "2026-04-29T05:19:10Z",
+      "result": "clean"
     },
     "erdos-779": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Re-audit of Erdős Problem #778 (Clique-Building Games on Complete Graphs).
- Verified `src/data/proofs/erdos-778/meta.json` against `proofs/Proofs/Erdos778Problem.lean` at `origin/main`.

## Verification
- **Sorries**: 0 actual / 0 claimed ✓
- **Axioms**: 3 actual / 3 claimed ✓ (names match: `playGame`, `malekshahian_spiro_alice_n_bob_n123`, `malekshahian_spiro_alice_n_bob_n12_degree`)
- **Status / badge**: `axiomatized` / `axiom` — correct (axiom-bearing file)
- **Original contributions**: every identifier listed (`EdgeColor`, `GameState`, `Kn`, `redSubgraph`, `blueSubgraph`, `hasClique`, `AliceStrategy`, `BobStrategy`, `ErdosConjecture`, `alice_no_four_consecutive`, `erdos_778_periodicity`, etc.) exists in the source.
- No phantom-axiom narrative drift detected.

## Test plan
- [x] meta.json claims numerically match Lean source
- [x] Narrative identifiers all exist in source
- [x] Tracker entry updated to `auditCount: 3, result: clean, lastAudited: 2026-04-29`