### PR TITLE
audit(erdos-772): mark issues-found — tracked by #13834

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9038,9 +9038,9 @@
     },
     "erdos-772": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-29T05:21:37Z",
+      "result": "issues-found"
     },
     "erdos-773": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Marks erdos-772 audit complete (result: issues-found, audit count 3)
- Phantom axioms in `originalContributions` already filed as #13834 and fix proposed in #13837

## Findings
Lean file `proofs/Proofs/Erdos772Problem.lean` has exactly 3 axioms:
- `erdos_1984_upper_bound` (line 126)
- `alon_erdos_1985` (line 153)
- `ratio_tends_to_infinity` (line 163)

`meta.json` numeric fields are correct: `axiomCount: 3`, `leanFile.axiomCount: 3`, `sorries: 0`, `theoremCount: 2`, `definitionCount: 7`.

`originalContributions` list overstates by including 3 phantom axioms (only mentioned in docstrings) and omits `ratio_tends_to_infinity`. PR #13837 already addresses.

## Test plan
- [x] Tracker update only — no source changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)