### PR TITLE
audit(isoperimetric-theorem-oq-02): mark clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13217,6 +13217,12 @@
       "lastAudited": "2026-04-27T16:24:40Z",
       "result": "clean",
       "issues": []
+    },
+    "isoperimetric-theorem-oq-02": {
+      "auditCount": 2,
+      "lastAudited": "2026-04-29T05:40:45Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {


### PR DESCRIPTION
## Summary

- Audited `isoperimetric-theorem-oq-02` against `meta.json` claims and the `IsoperimetricTheoremOQ02.lean` source
- All counts match: 0 sorries, 0 axioms, 136 lines, 4 theorems, 1 definition
- Section line ranges (33-53 / 55-91 / 93-127 / 129-136) match the actual file structure
- Status `verified` and badge `verified` are justified — Tier A formalization

## Audit details

- The proof obtains its lower bound `|∂S| ≥ 2` constructively via `Finset.min'`/`Finset.max'` and `Finset.min'_lt_max'_of_card`, not by wrapping a Mathlib isoperimetric theorem
- `mathlibDependencies` lists only basic Finset primitives (`min'`, `max'`, `Icc`), correctly scoped
- `originalContributions` accurately describe what is independently proved
- No True stubs, no `sorry`, no `axiom` declarations, no structure-encoded assumptions

## Test plan

- [x] `meta.json` sorries field matches Lean source
- [x] `meta.json` axiomCount matches actual axiom declarations
- [x] Section ranges align with actual line numbers
- [x] No Tier B/C overclaiming as Tier A

🤖 Generated with [Claude Code](https://claude.com/claude-code)