### PR TITLE
audit: mark isoperimetric-theorem-oq-02 clean + erdos-772 issues-fixed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13219,8 +13219,8 @@
       "issues": []
     },
     "isoperimetric-theorem-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-29T05:40:45Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-29T05:43:30Z",
       "result": "clean",
       "issues": []
     }

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9038,9 +9038,9 @@
     },
     "erdos-772": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-29T05:21:37Z",
-      "result": "issues-found"
+      "auditCount": 4,
+      "lastAudited": "2026-04-29T05:47:24Z",
+      "result": "issues-fixed"
     },
     "erdos-773": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Two tracker updates from this audit cycle:

### isoperimetric-theorem-oq-02 → clean
- Verified `proofs/Proofs/IsoperimetricTheoremOQ02.lean`: 0 axioms, 0 sorries, 136 lines (matches meta).
- 4 theorems + 1 lemma + 1 definition; section line ranges align with code at 33–53 / 55–91 / 93–127 / 129–136.
- All 6 originalContributions reference real names in the Lean source (`edgeBoundary`, `mem_edgeBoundary`, `edgeBoundary_card_ge_two`, `edgeBoundary_Icc`, `edgeBoundary_Icc_card`, `discrete_isoperimetric_1d`).
- proofStrategy and namespace `DiscreteIsoperimetric1D` match.

### erdos-772 → issues-fixed
- Tracker still listed `issues-found` from PR #13840, but PR #13837 has since removed the 3 phantom axiom narrative entries from `meta.originalContributions`.
- Re-verified on current main (0936d0ea0ed): originalContributions now lists exactly the 3 real axioms (`erdos_1984_upper_bound`, `alon_erdos_1985`, `ratio_tends_to_infinity`) — matches `proofs/Proofs/Erdos772Problem.lean` (lines 126, 153, 163). axiomCount=3, sorries=0, lineCount=249, definitionCount=7, theoremCount=2 all consistent.

## Test plan
- [x] meta.json claims match Lean source for both proofs
- [x] No phantom axioms in either narrative
- [x] Tracker auditCount monotonic (isoperimetric: 2→3, erdos-772: 3→4)