### PR TITLE
audit(erdos-763,767,773): re-audit cycle — issues-found

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8978,9 +8978,9 @@
     },
     "erdos-763": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-29T06:03:20Z",
+      "result": "issues-found"
     },
     "erdos-764": {
       "agentId": "auditor-cycle-20-batch",
@@ -9002,9 +9002,9 @@
     },
     "erdos-767": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-29T06:01:58Z",
+      "result": "issues-found"
     },
     "erdos-768": {
       "agentId": "auditor-cycle-20-batch",
@@ -9044,9 +9044,9 @@
     },
     "erdos-773": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-29T06:01:39Z",
+      "result": "issues-found"
     },
     "erdos-774": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Re-audit cycle for three Erdős proofs found phantom-narrative drift on all three.

- **erdos-773**: existing issue #13850 (mechanic in flight on `fix/mechanic-13850`)
- **erdos-767**: existing issue #13852 / PR #13853 in flight
- **erdos-763**: new issue #13855 — phantom `erdos_fuchs_strong` and `montgomery_vaughan` axioms in `originalContributions`, `sections.error-bounds`, and `proofStrategy` step 5; only `errorTerm` def is actually declared in Part IV

All three match the recurring "phantom narrative" pattern: numerical counts (axiomCount, sorries, lineCount) are correct; only narrative descriptions claim non-existent axioms.

## Test plan

- [x] Verified each Lean file from `git show HEAD:...` (per memory note about untracked-files trap)
- [x] Confirmed each issue/PR for erdos-773 and erdos-767 is still open
- [x] Filed new issue #13855 for erdos-763 with line numbers and `git show` evidence

🤖 Generated with [Claude Code](https://claude.com/claude-code)