### PR TITLE
audit(erdos-760): mark issues-found — phantom-axiom narrative drift

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8960,9 +8960,9 @@
     },
     "erdos-760": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-29T06:28:24Z",
+      "result": "issues-found"
     },
     "erdos-761": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Audit of erdos-760 found phantom-axiom narrative drift: meta.json's `originalContributions` and `sections` name 7+ axioms that exist only in docstrings.
- Lean source declares 2 axioms (`cochromaticNumber`, `aks_theorem`) — numerical `axiomCount=2` is correct.
- Issue #13860 documents the recommended meta.json fix. This PR only updates the audit tracker.

## Test plan

- [x] Verified Lean source decls match #13860 evidence.
- [x] No code or content changes — tracker bookkeeping only.