### PR TITLE
fix(erdos-773): residual phantom-axiom drift in 3 section mathContext fields

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9044,9 +9044,9 @@
     },
     "erdos-773": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-29T06:01:39Z",
-      "result": "issues-found"
+      "auditCount": 4,
+      "lastAudited": "2026-04-29T06:35:02Z",
+      "result": "issues-fixed"
     },
     "erdos-774": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-773/meta.json
+++ b/src/data/proofs/erdos-773/meta.json
@@ -76,8 +76,8 @@
       "title": "Perfect Squares and the Extremal Function",
       "startLine": 54,
       "endLine": 96,
-      "summary": "Defines `squaresUpTo N` as the set $\\{1^2, \\ldots, N^2\\}$, the cardinality theorem (sorry), and the extremal function $f(N) = \\max\\{|A| : A \\subseteq \\text{squaresUpTo}(N), A \\text{ Sidon}\\}$. States the main question: is $f(N) = N^{1-o(1)}$?",
-      "mathContext": "Defines `squaresUpTo N` as the set $\\{1^2, \\ldots, N^2\\}$, the cardinality theorem (sorry), and the extremal function $f(N) = \\max\\{|A| : A \\subseteq \\text{squaresUpTo}(N), A \\text{ Sidon}\\}$. States the main question: is $f(N) = N^{1-o(1)}$?"
+      "summary": "Defines `squaresUpTo N` as the set $\\{1^2, \\ldots, N^2\\}$, proves the cardinality theorem `squaresUpTo_card`, and defines the extremal function $f(N) = \\max\\{|A| : A \\subseteq \\text{squaresUpTo}(N), A \\text{ Sidon}\\}$. States the main question: is $f(N) = N^{1-o(1)}$?",
+      "mathContext": "Defines `squaresUpTo N` as the set $\\{1^2, \\ldots, N^2\\}$, proves the cardinality theorem `squaresUpTo_card`, and defines the extremal function $f(N) = \\max\\{|A| : A \\subseteq \\text{squaresUpTo}(N), A \\text{ Sidon}\\}$. States the main question: is $f(N) = N^{1-o(1)}$?"
     },
     {
       "id": "bounds",
@@ -92,16 +92,16 @@
       "title": "Landau's Theorem on Sums of Two Squares",
       "startLine": 121,
       "endLine": 161,
-      "summary": "Defines the representation function $r_2(n)$ and the counting function $S(N)$. Axiomatizes Landau's 1908 asymptotic $S(N) \\sim c \\cdot N/\\sqrt{\\log N}$ and its implication for Sidon sets of squares.",
-      "mathContext": "Formal definition: Defines the representation function $r_2(n)$ and the counting function $S(N)$. Axiomatizes Landau's 1908 asymptotic $S(N) \\sim c \\cdot N/\\sqrt{\\log N}$ and its implication for Sidon sets of squares."
+      "summary": "Defines the representation function $r_2(n)$ and the counting function $S(N)$. Discusses Landau's 1908 asymptotic $S(N) \\sim c \\cdot N/\\sqrt{\\log N}$ and its implication for Sidon sets of squares in docstrings (no formal axiom or theorem statement).",
+      "mathContext": "Defines the representation function $r_2(n)$ and the counting function $S(N)$. Discusses Landau's 1908 asymptotic $S(N) \\sim c \\cdot N/\\sqrt{\\log N}$ and its implication for Sidon sets of squares in docstrings (no formal axiom or theorem statement)."
     },
     {
       "id": "probabilistic",
       "title": "Probabilistic Method and Upper Bound Sketch",
       "startLine": 162,
       "endLine": 201,
-      "summary": "Axiomatizes the random construction giving the $N^{2/3}$ lower bound (random subset with density $N^{-1/3}$) and the upper bound proof sketch (Sidon + Landau forces $m^2 \\le N^2/(\\log N)^{1/2}$).",
-      "mathContext": "Verified: Axiomatizes the random construction giving the $N^{2/3}$ lower bound (random subset with density $N^{-1/3}$) and the upper bound proof sketch (Sidon + Landau forces $m^2 \\le N^2/(\\log N)^{1/2}$)."
+      "summary": "Sketches in docstrings the random construction for the $N^{2/3}$ lower bound (random subset with density $N^{-1/3}$) and the upper bound argument (Sidon + Landau forces $m^2 \\le N^2/(\\log N)^{1/2}$). No formal axioms or theorems in this section — the bounds themselves are axiomatized in the `bounds` section.",
+      "mathContext": "Sketches in docstrings the random construction for the $N^{2/3}$ lower bound (random subset with density $N^{-1/3}$) and the upper bound argument (Sidon + Landau forces $m^2 \\le N^2/(\\log N)^{1/2}$). No formal axioms or theorems in this section — the bounds themselves are axiomatized in the `bounds` section."
     },
     {
       "id": "open-questions",


### PR DESCRIPTION
## Summary

Follow-up to #13854 which fixed `originalContributions` and section line ranges, but missed three `sections[].summary` / `mathContext` pairs that still claim phantom axiomatization or a non-existent sorry.

| Section | Old (false) | New |
|---|---|---|
| `squares-and-f` | "the cardinality theorem (sorry)" | "proves the cardinality theorem `squaresUpTo_card`" |
| `landau` | "Axiomatizes Landau's 1908 asymptotic ... and its implication" | "Discusses Landau's 1908 asymptotic ... in docstrings (no formal axiom or theorem statement)" |
| `probabilistic` | "Axiomatizes the random construction ... and the upper bound proof sketch" | "Sketches in docstrings the random construction ... No formal axioms or theorems in this section — the bounds themselves are axiomatized in the `bounds` section" |

Numerical fields (`axiomCount: 2`, `sorries: 0`, `theoremCount: 3`, `definitionCount: 8`) were already correct and remain unchanged.

## Why

Verified against `proofs/Proofs/Erdos773Problem.lean` @ `488766ac3cd`:
- Only two `axiom ` declarations exist: `lower_bound` (line 106) and `upper_bound` (line 114), both inside the `bounds` section.
- Part V (`landau`) contains `def r2`, `def sumOfTwoSquaresCount`, and three docstrings — no axiom declarations.
- Parts VI–VII (`probabilistic`) contain only docstrings — no declarations at all.
- `squaresUpTo_card` (lines 69–77) is fully proved using `pow_lt_pow_left` and `Finset.card_image_of_injective`.

## Test plan
- [x] `jq empty src/data/proofs/erdos-773/meta.json` — JSON validates
- [x] No declarations or numerical fields modified
- [x] Section line ranges (already corrected in #13854) untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)