### PR TITLE
audit(erdos-775): mark issues-found — phantom axiom names in narrative

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9056,8 +9056,8 @@
     },
     "erdos-775": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-29T04:57:17Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-29T06:43:11Z",
       "result": "issues-found"
     },
     "erdos-776": {


### PR DESCRIPTION
## Summary

Re-audit at 488766ac3cd. The line-range drift fixed in #13832 has held up correctly, but a separate phantom-axiom narrative pattern remains in section `mathContext` strings and `proofStrategy`.

Filed issue #13865 with full evidence and recommended fixes.

## What this PR does

- `src/data/proofs/audit-tracker.json`: marks erdos-775 as `issues-found` (auditCount 3 → 4) so the auditor doesn't re-claim it before mechanic addresses #13865.

## Test plan
- [x] `jq empty src/data/proofs/audit-tracker.json` validates JSON
- [x] No code or other meta files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)