### PR TITLE
fix(erdos-760): correct section line ranges to match Part I-VII boundaries

### DIFF
--- a/src/data/proofs/erdos-760/meta.json
+++ b/src/data/proofs/erdos-760/meta.json
@@ -102,41 +102,41 @@
       "title": "Basic Properties",
       "summary": "Commentary on ζ(G) ≤ χ(G) relationship and complete graph cochromatic bounds (docstring only; no declarations in this section)",
       "startLine": 105,
-      "endLine": 138
+      "endLine": 123
     },
     {
       "id": "erdos-gimbel",
       "title": "Erdős-Gimbel Partial Result",
       "summary": "aks_theorem (axiom, AKS bound ζ(H) ≥ cm/log m), erdos_760_solved (theorem reducing to aks_theorem)",
-      "startLine": 139,
-      "endLine": 164
+      "startLine": 124,
+      "endLine": 138
     },
     {
       "id": "aks-theorem",
       "title": "Alon-Krivelevich-Sudakov Theorem",
       "summary": "Body of erdos_760_solved and proof technique commentary (no new declarations)",
-      "startLine": 165,
-      "endLine": 197
+      "startLine": 139,
+      "endLine": 171
     },
     {
       "id": "proof-technique",
       "title": "Proof Technique",
       "summary": "Ramsey-type argument commentary (docstring only; no declarations)",
-      "startLine": 198,
-      "endLine": 216
+      "startLine": 172,
+      "endLine": 184
     },
     {
       "id": "related",
       "title": "Related Results",
       "summary": "erdos_760 summary theorem (lines 224–230, reduces to aks_theorem)",
-      "startLine": 217,
-      "endLine": 231
+      "startLine": 185,
+      "endLine": 193
     },
     {
       "id": "summary",
       "title": "Main Results Summary",
       "summary": "Closing namespace (end Erdos760)",
-      "startLine": 232,
+      "startLine": 194,
       "endLine": 232
     }
   ],


### PR DESCRIPTION
## Fix

Corrects 6 of 7 section `startLine`/`endLine` values in `src/data/proofs/erdos-760/meta.json` to match the actual `/- ## Part N: -/` headers in `Erdos760Problem.lean`.

## Evidence

**Before** (drifted after phantom-axiom fix in #13860):

| Section | Meta range |
|---|---|
| basic-properties | 105-138 |
| erdos-gimbel | 139-164 |
| aks-theorem | 165-197 |
| proof-technique | 198-216 |
| related | 217-231 |
| summary | 232-232 |

**After** (matches actual Part boundaries):

| Section | Meta range |
|---|---|
| basic-properties | 105-123 |
| erdos-gimbel | 124-138 |
| aks-theorem | 139-171 |
| proof-technique | 172-184 |
| related | 185-193 |
| summary | 194-232 |

No changes to Lean source, `axiomCount`, `sorries`, `lineCount`, or other numerical fields.

Closes #13873

---
Automated fix by lean-mechanic agent.