### PR TITLE
audit(erdos-764): mark issues-found — phantom-axiom narrative drift

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8984,9 +8984,9 @@
     },
     "erdos-764": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-29T09:09:14Z",
+      "result": "issues-found"
     },
     "erdos-765": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Re-audited erdos-764 (2-fold→3-fold convolution linear error, Vaughan 1972).
- Numerical counts correct: 4 actual axiom declarations match `axiomCount: 4`.
- 5 phantom axioms exist in narrative fields (`originalContributions`, section `mathContext`, `proofStrategy`): `erdos_fuchs_theorem`, `erdos_fuchs_corollary`, `error_oscillation`, `montgomery_vaughan_refinement`, `quarter_exponent_tight`. These names only appear in docstrings — no `axiom` declarations exist.
- Existing issue #13868 and PR #13871 (fix/mechanic-13868) already address the drift; this PR only updates the audit tracker, not meta.json.

## Test plan
- [x] Verify Lean source axioms via grep `^axiom ` (4: `convH`, `vaughan_3fold_theorem`, `vaughan_corollary`, `vaughan_hfold_theorem`)
- [x] Verify phantom names absent from Lean source
- [x] Tracker bumped: `auditCount` 2→3, `result` issues-fixed→issues-found, `lastAudited` 2026-04-03→2026-04-29

🤖 Generated with [Claude Code](https://claude.com/claude-code)