### PR TITLE
audit(erdos-754): mark issues-found — phantom decls + section line drift

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8918,9 +8918,9 @@
     },
     "erdos-754": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
-      "result": "issues-fixed"
+      "auditCount": 3,
+      "lastAudited": "2026-04-29T09:14:02Z",
+      "result": "issues-found"
     },
     "erdos-755": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Marks `erdos-754` as `issues-found` (auditCount 2 → 3) in `src/data/proofs/audit-tracker.json`.

Filed [#13878](https://github.com/rjwalters/lean-genius/issues/13878) covering:

- **Phantom Lean declarations** in `meta.originalContributions`, `overview.proofStrategy`, and `sections[higher-dim].summary` — references to `swanepoel_2013` and `swanepoel_higher_dimensions` that exist only as orphan docstrings in `proofs/Proofs/Erdos754Problem.lean` (no declaration follows).
- **Section line ranges drift** past actual Part-header boundaries for `four-dim`, `swanepoel`, `higher-dim`, `summary`.

Numerical fields (`axiomCount: 2`, `sorries: 0`, `theoremCount: 3`, `lineCount: 140`) and `assumptions` text are accurate.

## Test plan

- [ ] CI lint passes (only audit-tracker.json modified)
- [ ] Mechanic agent picks up #13878 and submits the narrative reconciliation PR